### PR TITLE
feat(items): add gear enhancement core

### DIFF
--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -1,5 +1,6 @@
 import type { TalentModifiers } from './content/talents';
 import { aggregateSetBonuses, CLASSES, ITEMS, MOBS, type NpcDef } from './data';
+import { aggregateItemEnhancements } from './item_enhancements';
 import { meetsLevelRequirement } from './item_level_req';
 import type { Entity, EquipSlot, MobTemplate, PlayerClass, Stats, Vec3 } from './types';
 import { EQUIP_SLOTS, SPELL_POWER_PER_INT } from './types';
@@ -172,6 +173,8 @@ export function recalcPlayerStats(
     armor: def.baseStats.armor + def.statsPerLevel.armor * (lvl - 1),
   };
   const setCounts = new Map<string, number>();
+  let enhancementAp = 0;
+  let enhancementCrit = 0;
   let bonusSp = 0; // flat Spell Power from gear affixes + buff_spellpower auras
   for (const slot of EQUIP_SLOTS) {
     const itemId = equipment[slot];
@@ -186,13 +189,16 @@ export function recalcPlayerStats(
     if (!meetsLevelRequirement(lvl, item)) continue;
     if (item.set) setCounts.set(item.set, (setCounts.get(item.set) ?? 0) + 1);
     bonusSp += item.spellPower ?? 0;
-    if (!item.stats) continue;
-    s.str += item.stats.str ?? 0;
-    s.agi += item.stats.agi ?? 0;
-    s.sta += item.stats.sta ?? 0;
-    s.int += item.stats.int ?? 0;
-    s.spi += item.stats.spi ?? 0;
-    s.armor += item.stats.armor ?? 0;
+    const enhancements = aggregateItemEnhancements(item);
+    enhancementAp += enhancements.attackPower;
+    enhancementCrit += enhancements.crit;
+    bonusSp += enhancements.spellPower;
+    s.str += (item.stats?.str ?? 0) + enhancements.stats.str;
+    s.agi += (item.stats?.agi ?? 0) + enhancements.stats.agi;
+    s.sta += (item.stats?.sta ?? 0) + enhancements.stats.sta;
+    s.int += (item.stats?.int ?? 0) + enhancements.stats.int;
+    s.spi += (item.stats?.spi ?? 0) + enhancements.stats.spi;
+    s.armor += (item.stats?.armor ?? 0) + enhancements.stats.armor;
   }
   // Item-set bonuses from equipped pieces. Flat primary stats join the gear
   // totals so they feed every derivation below; AP/crit/pushback fold in at
@@ -204,7 +210,7 @@ export function recalcPlayerStats(
   s.int += setEff.int;
   s.spi += setEff.spi;
   // Buff auras
-  let bonusAp = setEff.ap;
+  let bonusAp = setEff.ap + enhancementAp;
   let bonusDodge = 0;
   let bearForm = false;
   let catForm = false;
@@ -310,7 +316,7 @@ export function recalcPlayerStats(
   // from gear/buffs. Floored at 0 so an Intellect-draining debuff can't go negative.
   e.spellPower = Math.max(0, Math.round(s.int * SPELL_POWER_PER_INT + bonusSp));
   // Crit: ~1% per 20 agi at low level
-  e.critChance = 0.05 + s.agi * 0.0005 + (mods?.stats.crit ?? 0) + setEff.crit;
+  e.critChance = 0.05 + s.agi * 0.0005 + (mods?.stats.crit ?? 0) + setEff.crit + enhancementCrit;
   e.castPushbackReduction = setEff.castPushbackReduction;
   // Floored at 0: an off-balance debuff (negative buff_dodge) can drive dodge to nothing.
   e.dodgeChance = Math.max(0, 0.05 + s.agi * 0.0005 + bonusDodge);

--- a/src/sim/item_enhancements.ts
+++ b/src/sim/item_enhancements.ts
@@ -1,0 +1,32 @@
+import type { ItemDef, Stats } from './types';
+
+export interface AggregatedItemEnhancements {
+  stats: Stats;
+  attackPower: number;
+  spellPower: number;
+  crit: number;
+}
+
+export function aggregateItemEnhancements(
+  item: Pick<ItemDef, 'enhancements'> | undefined,
+): AggregatedItemEnhancements {
+  const out: AggregatedItemEnhancements = {
+    stats: { str: 0, agi: 0, sta: 0, int: 0, spi: 0, armor: 0 },
+    attackPower: 0,
+    spellPower: 0,
+    crit: 0,
+  };
+  for (const enhancement of item?.enhancements ?? []) {
+    const effect = enhancement.effect;
+    out.stats.str += effect.stats?.str ?? 0;
+    out.stats.agi += effect.stats?.agi ?? 0;
+    out.stats.sta += effect.stats?.sta ?? 0;
+    out.stats.int += effect.stats?.int ?? 0;
+    out.stats.spi += effect.stats?.spi ?? 0;
+    out.stats.armor += effect.stats?.armor ?? 0;
+    out.attackPower += effect.attackPower ?? 0;
+    out.spellPower += effect.spellPower ?? 0;
+    out.crit += effect.crit ?? 0;
+  }
+  return out;
+}

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -225,6 +225,22 @@ export interface Stats {
   armor: number;
 }
 
+export type ItemEnhancementKind = 'enchant' | 'gem';
+
+export interface ItemEnhancementEffect {
+  stats?: Partial<Stats>;
+  attackPower?: number;
+  spellPower?: number;
+  crit?: number;
+}
+
+export interface ItemEnhancement {
+  id: string;
+  name: string;
+  kind: ItemEnhancementKind;
+  effect: ItemEnhancementEffect;
+}
+
 export interface WeaponInfo {
   min: number;
   max: number;
@@ -287,6 +303,7 @@ interface BaseItemDef {
   slot?: EquipSlot;
   weapon?: WeaponInfo;
   stats?: Partial<Stats>;
+  enhancements?: ItemEnhancement[];
   // Spell Power affix (caster gear): flat Spell Power, summed in recalcPlayerStats.
   // Kept off `Stats` because Spell Power is a derived combat rating (like attackPower),
   // not one of the six primary attributes.

--- a/src/ui/item_compare.ts
+++ b/src/ui/item_compare.ts
@@ -1,6 +1,7 @@
 // Pure item-comparison helper (no DOM), so the stat-delta math can be unit
 // tested directly the way xp_bar.ts / player_context_menu.ts are. The HUD turns
 // these deltas into coloured tooltip lines; see Hud.itemCompareBlock.
+import { aggregateItemEnhancements } from '../sim/item_enhancements';
 import type { ItemDef, Stats } from '../sim/types';
 
 // Stable stat identifier; the HUD maps it to a localized label via t().
@@ -24,9 +25,14 @@ export function itemStatDeltas(item: ItemDef, equipped: ItemDef): StatDelta[] {
   const dpsDelta = weaponDps(item.weapon) - weaponDps(equipped.weapon);
   if (Math.abs(dpsDelta) >= 0.05) out.push({ stat: 'dps', delta: dpsDelta, decimals: 1 });
 
+  const itemEnhancements = aggregateItemEnhancements(item);
+  const equippedEnhancements = aggregateItemEnhancements(equipped);
   const stats: Array<keyof Stats & CompareStat> = ['armor', 'str', 'agi', 'sta', 'int', 'spi'];
   for (const k of stats) {
-    const delta = (item.stats?.[k] ?? 0) - (equipped.stats?.[k] ?? 0);
+    const delta =
+      (item.stats?.[k] ?? 0) +
+      itemEnhancements.stats[k] -
+      ((equipped.stats?.[k] ?? 0) + equippedEnhancements.stats[k]);
     if (Math.abs(delta) >= 0.5) out.push({ stat: k, delta, decimals: 0 });
   }
   return out;

--- a/tests/item_compare.test.ts
+++ b/tests/item_compare.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { ItemDef, Stats } from '../src/sim/types';
 import { itemStatDeltas } from '../src/ui/item_compare';
 
-function armor(id: string, stats: Partial<Stats>): ItemDef {
+function armor(id: string, stats: Partial<Stats>, extra: Partial<ItemDef> = {}): ItemDef {
   return {
     id,
     name: id,
@@ -11,7 +11,8 @@ function armor(id: string, stats: Partial<Stats>): ItemDef {
     slot: 'chest',
     sellValue: 1,
     stats,
-  };
+    ...extra,
+  } as ItemDef;
 }
 function weapon(id: string, min: number, max: number, speed: number): ItemDef {
   return {
@@ -59,6 +60,44 @@ describe('itemStatDeltas', () => {
       itemStatDeltas(candidate, equipped).map((d) => [d.stat, d.delta]),
     );
     expect(byStat.int).toBe(12);
+    expect(byStat.armor).toBeUndefined();
+  });
+
+  it('includes item enhancement primary stats in deltas', () => {
+    const candidate = armor(
+      'enchanted',
+      { armor: 30 },
+      {
+        enhancements: [
+          {
+            id: 'minor_agility',
+            name: 'Minor Agility',
+            kind: 'enchant',
+            effect: { stats: { agi: 5 } },
+          },
+        ],
+      },
+    );
+    const equipped = armor(
+      'socketed',
+      { armor: 30 },
+      {
+        enhancements: [
+          {
+            id: 'small_ruby',
+            name: 'Small Ruby',
+            kind: 'gem',
+            effect: { stats: { sta: 2 } },
+          },
+        ],
+      },
+    );
+
+    const byStat = Object.fromEntries(
+      itemStatDeltas(candidate, equipped).map((d) => [d.stat, d.delta]),
+    );
+    expect(byStat.agi).toBe(5);
+    expect(byStat.sta).toBe(-2);
     expect(byStat.armor).toBeUndefined();
   });
 });

--- a/tests/item_enhancements.test.ts
+++ b/tests/item_enhancements.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ITEMS } from '../src/sim/data';
+import {
+  characterDerivedStats,
+  createPlayer,
+  recalcPlayerStats,
+  type PlayerEquipment,
+} from '../src/sim/entity';
+import { aggregateItemEnhancements } from '../src/sim/item_enhancements';
+import type { ItemDef } from '../src/sim/types';
+
+const ENHANCED_CHEST = 'test_enhanced_chest';
+const OVER_LEVEL_CHEST = 'test_over_level_enhanced_chest';
+
+afterEach(() => {
+  delete ITEMS[ENHANCED_CHEST];
+  delete ITEMS[OVER_LEVEL_CHEST];
+});
+
+function register(id: string, item: ItemDef): void {
+  ITEMS[id] = item;
+}
+
+function chest(id: string, extra: Partial<ItemDef> = {}): ItemDef {
+  return {
+    id,
+    name: id,
+    kind: 'armor',
+    armorType: 'mail',
+    slot: 'chest',
+    sellValue: 1,
+    ...extra,
+  } as ItemDef;
+}
+
+function warrior(level: number, equipment: PlayerEquipment) {
+  const e = createPlayer(0, 'warrior', { x: 0, y: 0, z: 0 }, 'Tester');
+  e.level = level;
+  recalcPlayerStats(e, 'warrior', equipment);
+  return e;
+}
+
+describe('aggregateItemEnhancements', () => {
+  it('sums enchant and gem effects into one deterministic stat block', () => {
+    const item = chest('stacked', {
+      enhancements: [
+        {
+          id: 'minor_might',
+          name: 'Minor Might',
+          kind: 'enchant',
+          effect: { stats: { str: 3, armor: 7 }, attackPower: 10 },
+        },
+        {
+          id: 'glowing_ruby',
+          name: 'Glowing Ruby',
+          kind: 'gem',
+          effect: { stats: { sta: 4 }, spellPower: 5, crit: 0.02 },
+        },
+      ],
+    });
+
+    expect(aggregateItemEnhancements(item)).toEqual({
+      stats: { str: 3, agi: 0, sta: 4, int: 0, spi: 0, armor: 7 },
+      attackPower: 10,
+      spellPower: 5,
+      crit: 0.02,
+    });
+  });
+
+  it('returns a zero block for plain items', () => {
+    expect(aggregateItemEnhancements(chest('plain'))).toEqual({
+      stats: { str: 0, agi: 0, sta: 0, int: 0, spi: 0, armor: 0 },
+      attackPower: 0,
+      spellPower: 0,
+      crit: 0,
+    });
+  });
+});
+
+describe('recalcPlayerStats applies item enhancements', () => {
+  it('folds enhanced gear into primary stats, AP, crit, spell power, and vitals', () => {
+    register(
+      ENHANCED_CHEST,
+      chest(ENHANCED_CHEST, {
+        stats: { armor: 10, str: 2 },
+        enhancements: [
+          {
+            id: 'greater_might',
+            name: 'Greater Might',
+            kind: 'enchant',
+            effect: {
+              stats: { armor: 7, str: 3, sta: 4 },
+              attackPower: 10,
+              spellPower: 5,
+              crit: 0.02,
+            },
+          },
+        ],
+      }),
+    );
+
+    const bare = warrior(20, {});
+    const enhanced = warrior(20, { chest: ENHANCED_CHEST });
+
+    expect(enhanced.stats.str).toBe(bare.stats.str + 5);
+    expect(enhanced.stats.sta).toBe(bare.stats.sta + 4);
+    expect(enhanced.stats.armor).toBe(bare.stats.armor + 17);
+    expect(enhanced.attackPower).toBe(bare.attackPower + 20);
+    expect(enhanced.critChance).toBeCloseTo(bare.critChance + 0.02);
+    expect(enhanced.spellPower).toBe(bare.spellPower + 5);
+    expect(enhanced.maxHp).toBeGreaterThan(bare.maxHp);
+  });
+
+  it('keeps enhancements inert while the underlying gear is over-level', () => {
+    register(
+      OVER_LEVEL_CHEST,
+      chest(OVER_LEVEL_CHEST, {
+        requiredLevel: 20,
+        stats: { armor: 10, sta: 2 },
+        enhancements: [
+          {
+            id: 'too_soon',
+            name: 'Too Soon',
+            kind: 'enchant',
+            effect: {
+              stats: { str: 99, sta: 99, armor: 99 },
+              attackPower: 99,
+              spellPower: 99,
+              crit: 0.5,
+            },
+          },
+        ],
+      }),
+    );
+
+    const bare = characterDerivedStats('warrior', 19, {});
+    const inert = characterDerivedStats('warrior', 19, { chest: OVER_LEVEL_CHEST });
+    expect(inert).toEqual(bare);
+  });
+});


### PR DESCRIPTION
## Summary

- Add typed `enchant` / `gem` enhancement effects on `ItemDef` for primary stats, attack power, spell power, and crit.
- Add a pure enhancement aggregator and fold equipped item enhancements through `recalcPlayerStats` alongside base gear and set bonuses.
- Keep over-level enhanced gear inert until the item itself meets its level requirement.
- Include enhancement primary stats in pure item comparison deltas so static enhanced gear compares correctly.

This is the deterministic item/stat core for gear enhancements. It does not add the player application flow, item-instance persistence, sockets UI, or tooltip enhancement name lines yet.

## Related issues

Part of #452

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src/sim/types.ts src/sim/item_enhancements.ts src/sim/entity.ts src/ui/item_compare.ts tests/item_enhancements.test.ts tests/item_compare.test.ts`
  - `npx biome lint src/sim/types.ts src/sim/item_enhancements.ts src/sim/entity.ts src/ui/item_compare.ts tests/item_enhancements.test.ts tests/item_compare.test.ts`
  - `npx vitest run tests/item_enhancements.test.ts tests/item_compare.test.ts tests/item_sets.test.ts tests/over_level_gear_inert.test.ts tests/stat_tooltip.test.ts`
  - `npm run check:ts`
  - `npm run build`
- Manual steps: N/A; no UI flow or authored player-facing content was added.

## Screenshots / recordings

N/A; this PR adds deterministic item/stat core support and no visible UI layout changes.

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

> **Tip:** commit messages and PR titles use [Conventional Commits](https://www.conventionalcommits.org/)
> with a scope where it fits (`feat(talents): ...`, `fix(net): ...`). It's a
> convention we like, not a requirement. Clear, descriptive messages are what
> matter most.
