### PR TITLE
feat(pvp): add honor core

### DIFF
--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -25,6 +25,7 @@
 import { DELVES, GROUP_XP_BONUS, MOBS } from '../data';
 import { recalcPlayerStats } from '../entity';
 import { DAMAGE_IDLE_DESPAWN_MOB_IDS, DAMAGE_IDLE_DESPAWN_SECONDS } from '../entity_roster';
+import { grantPvpHonorForKill } from '../honor';
 import type { PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
 import { addThreat, clearThreat } from '../threat';
@@ -241,6 +242,7 @@ export function dealDamage(
     if (target.hp - amount <= 0) {
       amount = Math.max(0, target.hp);
       target.hp = 0;
+      grantPvpHonorForKill(ctx, source, target);
       match.defeated.add(target.id);
       ctx.emit({
         type: 'damage',
@@ -496,6 +498,7 @@ export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): 
   if (e.kind === 'player') {
     const meta = ctx.players.get(e.id);
     if (meta) meta.counters.deaths++;
+    grantPvpHonorForKill(ctx, killer, e);
     e.autoAttack = false;
     e.queuedOnSwing = null;
     e.comboPoints = 0;

--- a/src/sim/honor.ts
+++ b/src/sim/honor.ts
@@ -1,0 +1,60 @@
+import type { PlayerMeta } from './sim';
+import type { SimContext } from './sim_context';
+import type { Entity } from './types';
+
+export const HONOR_PER_PLAYER_KILL = 20;
+
+export interface HonorRank {
+  id: string;
+  title: string;
+  minHonor: number;
+}
+
+const UNRANKED_HONOR_RANK: HonorRank = { id: 'unranked', title: 'Unranked', minHonor: 0 };
+
+export const HONOR_RANKS: readonly HonorRank[] = [
+  UNRANKED_HONOR_RANK,
+  { id: 'skirmisher', title: 'Skirmisher', minHonor: 100 },
+  { id: 'vanguard', title: 'Vanguard', minHonor: 250 },
+  { id: 'champion', title: 'Champion', minHonor: 500 },
+  { id: 'marshal', title: 'Marshal', minHonor: 1000 },
+  { id: 'high_marshal', title: 'High Marshal', minHonor: 2000 },
+] as const;
+
+export function normalizeHonor(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+
+export function honorRankFor(lifetimeHonor: number): HonorRank {
+  const honor = normalizeHonor(lifetimeHonor);
+  let rank = UNRANKED_HONOR_RANK;
+  for (const candidate of HONOR_RANKS) {
+    if (honor < candidate.minHonor) break;
+    rank = candidate;
+  }
+  return rank;
+}
+
+export function grantPvpHonor(meta: PlayerMeta, amount = HONOR_PER_PLAYER_KILL): number {
+  const gain = normalizeHonor(amount);
+  if (gain === 0) return 0;
+  meta.pvpHonor += gain;
+  meta.lifetimePvpHonor += gain;
+  meta.lifetimeHonorableKills += 1;
+  return gain;
+}
+
+export function grantPvpHonorForKill(
+  ctx: SimContext,
+  killer: Entity | null,
+  victim: Entity,
+): number {
+  if (victim.kind !== 'player') return 0;
+  const killerPlayer = ctx.pvpController(killer);
+  if (!killerPlayer || killerPlayer.id === victim.id || !ctx.isHostileTo(killerPlayer, victim)) {
+    return 0;
+  }
+  const killerMeta = ctx.players.get(killerPlayer.id);
+  return killerMeta ? grantPvpHonor(killerMeta) : 0;
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -130,6 +130,7 @@ import {
 import { canEquipItem } from './equipment_rules';
 import { fleeSpeed } from './flee_speed';
 import { formatMoney } from './format_money';
+import { normalizeHonor } from './honor';
 import * as interaction from './interaction';
 import { meetsLevelRequirement } from './item_level_req';
 import * as items from './items';
@@ -664,6 +665,10 @@ export interface PlayerMeta {
   arena2v2Rating: number;
   arena2v2Wins: number;
   arena2v2Losses: number;
+  // PvP honor is a persistent currency; lifetime honor drives the rank ladder.
+  pvpHonor: number;
+  lifetimePvpHonor: number;
+  lifetimeHonorableKills: number;
   // Talents & Specializations. `talents` is the active allocation; `talentMods`
   // is its precomputed flat struct — resolved only on allocation/respec/loadout
   // change (recomputeTalents), never walked on the combat or stat hot path.
@@ -751,6 +756,9 @@ export interface CharacterState {
   arena2v2Rating?: number;
   arena2v2Wins?: number;
   arena2v2Losses?: number;
+  pvpHonor?: number;
+  lifetimePvpHonor?: number;
+  lifetimeHonorableKills?: number;
   // Talents & Specializations (JSONB; no schema migration). All optional so
   // characters saved before talents existed load cleanly (default: no points spent).
   talents?: TalentAllocation;
@@ -1181,6 +1189,9 @@ export class Sim {
       arena2v2Rating: savedArena2v2.rating,
       arena2v2Wins: savedArena2v2.wins,
       arena2v2Losses: savedArena2v2.losses,
+      pvpHonor: 0,
+      lifetimePvpHonor: 0,
+      lifetimeHonorableKills: 0,
       talents: emptyAllocation(),
       talentMods: emptyModifiers(),
       fiestaAugments: [],
@@ -1215,6 +1226,9 @@ export class Sim {
       meta.lifetimeXp = s.lifetimeXp ?? xpToReachLevel(player.level) + Math.max(0, s.xp);
       meta.prestigeRank = s.prestigeRank ?? 0;
       meta.restedXp = Math.max(0, s.restedXp ?? 0);
+      meta.pvpHonor = normalizeHonor(s.pvpHonor);
+      meta.lifetimePvpHonor = normalizeHonor(s.lifetimePvpHonor ?? s.pvpHonor);
+      meta.lifetimeHonorableKills = normalizeHonor(s.lifetimeHonorableKills);
       if (s.unlockedMilestones)
         for (const id of s.unlockedMilestones) meta.unlockedMilestones.add(id);
       meta.copper = s.copper;
@@ -1417,6 +1431,9 @@ export class Sim {
       arena2v2Rating: meta.arena2v2Rating,
       arena2v2Wins: meta.arena2v2Wins,
       arena2v2Losses: meta.arena2v2Losses,
+      pvpHonor: meta.pvpHonor,
+      lifetimePvpHonor: meta.lifetimePvpHonor,
+      lifetimeHonorableKills: meta.lifetimeHonorableKills,
       talents: cloneAllocation(restore ? restore.talents : meta.talents),
       loadouts: meta.loadouts.map((l) => ({
         name: l.name,

--- a/tests/honor.test.ts
+++ b/tests/honor.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  HONOR_PER_PLAYER_KILL,
+  grantPvpHonor,
+  honorRankFor,
+  normalizeHonor,
+} from '../src/sim/honor';
+import { Sim, type CharacterState, type PlayerMeta } from '../src/sim/sim';
+import type { Entity, PlayerClass } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function entity(sim: Sim, pid: number): Entity {
+  const e = sim.entities.get(pid);
+  expect(e).toBeDefined();
+  return e as Entity;
+}
+
+function meta(sim: Sim, pid: number): PlayerMeta {
+  const m = sim.meta(pid);
+  expect(m).not.toBeNull();
+  return m as PlayerMeta;
+}
+
+function state(sim: Sim, pid: number): CharacterState {
+  const saved = sim.serializeCharacter(pid);
+  expect(saved).not.toBeNull();
+  return saved as CharacterState;
+}
+
+function teleport(sim: Sim, pid: number, x: number, z: number) {
+  const e = entity(sim, pid);
+  e.pos.x = x;
+  e.pos.z = z;
+  e.pos.y = groundHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+  (sim as unknown as { rebucket(e: Entity): void }).rebucket(e);
+}
+
+function queueDuo(
+  aClass: PlayerClass = 'warrior',
+  bClass: PlayerClass = 'mage',
+): { sim: Sim; a: number; b: number } {
+  const sim = makeWorld();
+  const a = sim.addPlayer(aClass, 'Aleph');
+  const b = sim.addPlayer(bClass, 'Bet');
+  teleport(sim, a, 0, -40);
+  teleport(sim, b, 6, -40);
+  sim.arenaQueueJoin(a);
+  sim.arenaQueueJoin(b);
+  sim.tick();
+  return { sim, a, b };
+}
+
+function startBout(sim: Sim) {
+  for (let i = 0; i < 20 * 6; i++) {
+    sim.tick();
+    const match = sim.arenaMatchFor([...sim.arenaMatches.keys()][0] ?? -1);
+    if (match?.state === 'active') return;
+  }
+}
+
+describe('PvP honor', () => {
+  it('normalizes honor counters and resolves the rank ladder', () => {
+    expect(normalizeHonor(undefined)).toBe(0);
+    expect(normalizeHonor(-4)).toBe(0);
+    expect(normalizeHonor(12.9)).toBe(12);
+    expect(honorRankFor(0).id).toBe('unranked');
+    expect(honorRankFor(99).id).toBe('unranked');
+    expect(honorRankFor(100).id).toBe('skirmisher');
+    expect(honorRankFor(500).id).toBe('champion');
+    expect(honorRankFor(99999).id).toBe('high_marshal');
+  });
+
+  it('grants spendable and lifetime honor from honorable kills', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Honored');
+    const playerMeta = meta(sim, pid);
+
+    expect(grantPvpHonor(playerMeta, 125.9)).toBe(125);
+    expect(playerMeta.pvpHonor).toBe(125);
+    expect(playerMeta.lifetimePvpHonor).toBe(125);
+    expect(playerMeta.lifetimeHonorableKills).toBe(1);
+    expect(honorRankFor(playerMeta.lifetimePvpHonor).id).toBe('skirmisher');
+  });
+
+  it('awards honor when an active arena player kills a hostile player', () => {
+    const { sim, a, b } = queueDuo();
+    startBout(sim);
+    const attacker = entity(sim, a);
+    const victim = entity(sim, b);
+
+    sim.dealDamage(attacker, victim, 99999, false, 'physical', null, 'hit');
+
+    expect(meta(sim, a).pvpHonor).toBe(HONOR_PER_PLAYER_KILL);
+    expect(meta(sim, a).lifetimePvpHonor).toBe(HONOR_PER_PLAYER_KILL);
+    expect(meta(sim, a).lifetimeHonorableKills).toBe(1);
+    expect(meta(sim, b).pvpHonor).toBe(0);
+    expect(meta(sim, b).lifetimeHonorableKills).toBe(0);
+  });
+
+  it('does not award honor for non-player-caused deaths', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Faller');
+    const player = entity(sim, pid);
+
+    sim.dealDamage(null, player, 99999, false, 'physical', null, 'hit');
+
+    expect(meta(sim, pid).pvpHonor).toBe(0);
+    expect(meta(sim, pid).lifetimePvpHonor).toBe(0);
+    expect(meta(sim, pid).lifetimeHonorableKills).toBe(0);
+  });
+
+  it('round-trips honor counters and backfills legacy saves', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('rogue', 'Saver');
+    grantPvpHonor(meta(sim, pid), 250);
+    const saved = state(sim, pid);
+
+    const sim2 = makeWorld();
+    const loaded = sim2.addPlayer('rogue', 'Saver', { state: saved });
+    expect(meta(sim2, loaded).pvpHonor).toBe(250);
+    expect(meta(sim2, loaded).lifetimePvpHonor).toBe(250);
+    expect(meta(sim2, loaded).lifetimeHonorableKills).toBe(1);
+
+    const legacy = { ...saved };
+    delete legacy.pvpHonor;
+    delete legacy.lifetimePvpHonor;
+    delete legacy.lifetimeHonorableKills;
+    const sim3 = makeWorld();
+    const legacyPid = sim3.addPlayer('rogue', 'Legacy', { state: legacy });
+    expect(meta(sim3, legacyPid).pvpHonor).toBe(0);
+    expect(meta(sim3, legacyPid).lifetimePvpHonor).toBe(0);
+    expect(meta(sim3, legacyPid).lifetimeHonorableKills).toBe(0);
+  });
+});


### PR DESCRIPTION
﻿## Summary

Adds the first backend slice of PvP honor progression:

- Adds persistent `pvpHonor`, `lifetimePvpHonor`, and `lifetimeHonorableKills` counters to character state.
- Adds a deterministic honor rank ladder/helper in `src/sim/honor.ts`.
- Grants honor for hostile player kills in ranked arena eliminations, with the player-death path also wired for future hostile PvP death flows.
- Adds focused tests for rank resolution, kill awards, non-player deaths, and save/load back-compat.

This intentionally does not add HUD display, vendors, spending, decay, diminishing returns, or title presentation yet.

## Related issues

Part of #667

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src\sim\honor.ts src\sim\sim.ts src\sim\combat\damage.ts tests\honor.test.ts`
  - `npx biome lint src\sim\honor.ts src\sim\sim.ts src\sim\combat\damage.ts tests\honor.test.ts` (exits 0; reports existing warnings in `src/sim/sim.ts`)
  - `npm run check:ts`
  - `$b = [System.IO.File]::ReadAllBytes('.browserslistrc'); try { $lines = Get-Content .browserslistrc | Where-Object { $_ -notmatch '^\s*#' }; Set-Content .browserslistrc $lines; npx vitest run tests/honor.test.ts tests/arena.test.ts tests/persistence_round_trip.test.ts } finally { [System.IO.File]::WriteAllBytes('.browserslistrc', $b) }`
  - `$b = [System.IO.File]::ReadAllBytes('.browserslistrc'); try { $lines = Get-Content .browserslistrc | Where-Object { $_ -notmatch '^\s*#' }; Set-Content .browserslistrc $lines; npm run build } finally { [System.IO.File]::WriteAllBytes('.browserslistrc', $b) }`
- Manual steps: N/A, sim-core behavior only.

## Screenshots / recordings

N/A. This PR adds no UI or UX changes.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
