### PR TITLE
feat(sim): add player mail core

### DIFF
--- a/src/sim/mail.ts
+++ b/src/sim/mail.ts
@@ -1,0 +1,144 @@
+import type { InvSlot } from './types';
+
+export const MAIL_ATTACHMENT_LIMIT = 6;
+export const MAIL_SUBJECT_MAX = 80;
+export const MAIL_BODY_MAX = 500;
+
+export interface PlayerMail {
+  id: number;
+  fromName: string;
+  fromCharacterId?: number;
+  subject: string;
+  body: string;
+  copper: number;
+  items: InvSlot[];
+  sentAt: number;
+  read: boolean;
+  attachmentsTaken: boolean;
+}
+
+export interface MailboxState {
+  nextId: number;
+  inbox: PlayerMail[];
+}
+
+export interface MailDraft {
+  fromName: string;
+  fromCharacterId?: number;
+  subject?: string;
+  body?: string;
+  copper?: number;
+  items?: InvSlot[];
+  sentAt?: number;
+}
+
+export interface MailAttachmentPayload {
+  copper: number;
+  items: InvSlot[];
+}
+
+export function emptyMailbox(): MailboxState {
+  return { nextId: 1, inbox: [] };
+}
+
+export function cloneMailbox(mailbox: MailboxState): MailboxState {
+  return {
+    nextId: Math.max(1, Math.floor(mailbox.nextId)),
+    inbox: mailbox.inbox.map(cloneMail),
+  };
+}
+
+export function normalizeMailbox(value: MailboxState | undefined): MailboxState {
+  if (!value) return emptyMailbox();
+  const inbox = Array.isArray(value.inbox)
+    ? value.inbox.map(normalizeMail).filter((mail): mail is PlayerMail => mail !== null)
+    : [];
+  const maxId = inbox.reduce((max, mail) => Math.max(max, mail.id), 0);
+  const nextId = Number.isFinite(value.nextId)
+    ? Math.max(maxId + 1, Math.floor(value.nextId))
+    : maxId + 1;
+  return { nextId, inbox };
+}
+
+export function normalizeMailItems(items: InvSlot[] | undefined): InvSlot[] {
+  const merged = new Map<string, number>();
+  for (const slot of (items ?? []).slice(0, MAIL_ATTACHMENT_LIMIT)) {
+    if (!slot || typeof slot.itemId !== 'string' || !Number.isFinite(slot.count)) continue;
+    const count = Math.max(1, Math.floor(slot.count));
+    merged.set(slot.itemId, (merged.get(slot.itemId) ?? 0) + count);
+  }
+  return [...merged].map(([itemId, count]) => ({ itemId, count }));
+}
+
+export function enqueueMail(mailbox: MailboxState, draft: MailDraft): PlayerMail {
+  const mail: PlayerMail = {
+    id: mailbox.nextId++,
+    fromName: clampText(draft.fromName, MAIL_SUBJECT_MAX) || 'Unknown',
+    fromCharacterId: draft.fromCharacterId,
+    subject: clampText(draft.subject ?? '', MAIL_SUBJECT_MAX),
+    body: clampText(draft.body ?? '', MAIL_BODY_MAX),
+    copper: normalizeCopper(draft.copper),
+    items: normalizeMailItems(draft.items),
+    sentAt: normalizeSentAt(draft.sentAt),
+    read: false,
+    attachmentsTaken: false,
+  };
+  mailbox.inbox.push(mail);
+  return cloneMail(mail);
+}
+
+export function markMailRead(mailbox: MailboxState, mailId: number): boolean {
+  const mail = mailbox.inbox.find((m) => m.id === mailId);
+  if (!mail) return false;
+  mail.read = true;
+  return true;
+}
+
+export function takeMailAttachments(
+  mailbox: MailboxState,
+  mailId: number,
+): MailAttachmentPayload | null {
+  const mail = mailbox.inbox.find((m) => m.id === mailId);
+  if (!mail || mail.attachmentsTaken) return null;
+  const payload = { copper: mail.copper, items: mail.items.map((item) => ({ ...item })) };
+  mail.copper = 0;
+  mail.items = [];
+  mail.attachmentsTaken = true;
+  mail.read = true;
+  return payload;
+}
+
+function normalizeMail(value: PlayerMail): PlayerMail | null {
+  if (!value || !Number.isFinite(value.id)) return null;
+  return {
+    id: Math.max(1, Math.floor(value.id)),
+    fromName: clampText(value.fromName, MAIL_SUBJECT_MAX) || 'Unknown',
+    fromCharacterId: value.fromCharacterId,
+    subject: clampText(value.subject, MAIL_SUBJECT_MAX),
+    body: clampText(value.body, MAIL_BODY_MAX),
+    copper: normalizeCopper(value.copper),
+    items: normalizeMailItems(value.items),
+    sentAt: normalizeSentAt(value.sentAt),
+    read: !!value.read,
+    attachmentsTaken: !!value.attachmentsTaken,
+  };
+}
+
+function cloneMail(mail: PlayerMail): PlayerMail {
+  return {
+    ...mail,
+    items: mail.items.map((item) => ({ ...item })),
+  };
+}
+
+function normalizeCopper(value: number | undefined): number {
+  return value === undefined || !Number.isFinite(value) ? 0 : Math.max(0, Math.floor(value));
+}
+
+function normalizeSentAt(value: number | undefined): number {
+  return value === undefined || !Number.isFinite(value) ? 0 : Math.max(0, Math.floor(value));
+}
+
+function clampText(value: string, max: number): string {
+  return typeof value === 'string' ? value.slice(0, max) : '';
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -156,6 +156,19 @@ import {
   setPartyLootMaster as setPartyLootMasterImpl,
   submitLootRoll as submitLootRollImpl,
 } from './loot/loot_roll';
+import {
+  cloneMailbox,
+  emptyMailbox,
+  enqueueMail,
+  type MailAttachmentPayload,
+  type MailboxState,
+  type MailDraft,
+  markMailRead as markMailReadImpl,
+  normalizeMailbox,
+  normalizeMailItems,
+  type PlayerMail,
+  takeMailAttachments,
+} from './mail';
 import { Market, type MarketListing, type MarketSave } from './market';
 import { defaultMarketQuery, type MarketQuery } from './market_query';
 import * as lifecycle from './mob/lifecycle';
@@ -630,6 +643,7 @@ export interface PlayerMeta {
   wireRev: number;
   inventory: InvSlot[];
   vendorBuyback: InvSlot[];
+  mailbox: MailboxState;
   copper: number;
   equipment: PlayerEquipment;
   xp: number;
@@ -738,6 +752,7 @@ export interface CharacterState {
   equipment: PlayerEquipment;
   inventory: InvSlot[];
   vendorBuyback?: InvSlot[];
+  mailbox?: MailboxState;
   questLog: { questId: string; counts: number[]; state: 'active' | 'ready' | 'done' }[];
   questsDone: string[];
   // Legacy arenaRating/Wins/Losses are treated as 1v1 data. The explicit
@@ -1161,6 +1176,7 @@ export class Sim {
       wireRev: 0,
       inventory: [],
       vendorBuyback: [],
+      mailbox: emptyMailbox(),
       copper: 0,
       equipment: { mainhand: classDef.startWeapon, chest: classDef.startChest },
       xp: 0,
@@ -1221,6 +1237,7 @@ export class Sim {
       meta.equipment = { ...s.equipment };
       meta.inventory = s.inventory.map((i) => ({ ...i }));
       meta.vendorBuyback = (s.vendorBuyback ?? []).map((i) => ({ ...i }));
+      meta.mailbox = normalizeMailbox(s.mailbox);
       for (const q of s.questLog) {
         if (q.state !== 'done')
           meta.questLog.set(q.questId, {
@@ -1402,6 +1419,7 @@ export class Sim {
       equipment: { ...meta.equipment },
       inventory: meta.inventory.map((i) => ({ ...i })),
       vendorBuyback: meta.vendorBuyback.map((i) => ({ ...i })),
+      mailbox: cloneMailbox(meta.mailbox),
       questLog: [...meta.questLog.values()].map((q) => ({
         questId: q.questId,
         counts: [...q.counts],
@@ -1595,6 +1613,9 @@ export class Sim {
   get vendorBuyback(): InvSlot[] {
     return this.primary.vendorBuyback;
   }
+  get mailbox(): MailboxState {
+    return cloneMailbox(this.primary.mailbox);
+  }
   get equipment(): PlayerEquipment {
     return this.primary.equipment;
   }
@@ -1701,6 +1722,61 @@ export class Sim {
 
   meta(pid: number): PlayerMeta | null {
     return this.players.get(pid) ?? null;
+  }
+
+  mailboxFor(pid: number = this.primaryId): MailboxState {
+    const meta = this.players.get(pid);
+    return meta ? cloneMailbox(meta.mailbox) : emptyMailbox();
+  }
+
+  sendMail(
+    fromPid: number,
+    toPid: number,
+    draft: Omit<MailDraft, 'fromName' | 'fromCharacterId' | 'sentAt'>,
+  ): PlayerMail | null {
+    const from = this.players.get(fromPid);
+    const to = this.players.get(toPid);
+    if (!from || !to) return null;
+    const copper = Math.max(0, Math.floor(draft.copper ?? 0));
+    if (from.copper < copper) return null;
+    const items = this.cleanMailAttachments(fromPid, draft.items);
+    if (!items) return null;
+
+    from.copper -= copper;
+    for (const item of items) this.removeItem(item.itemId, item.count, fromPid);
+    return enqueueMail(to.mailbox, {
+      ...draft,
+      copper,
+      items,
+      fromName: from.name,
+      fromCharacterId: from.characterId,
+      sentAt: this.tickCount,
+    });
+  }
+
+  markMailRead(pid: number, mailId: number): boolean {
+    const meta = this.players.get(pid);
+    return meta ? markMailReadImpl(meta.mailbox, mailId) : false;
+  }
+
+  collectMailAttachments(pid: number, mailId: number): MailAttachmentPayload | null {
+    const meta = this.players.get(pid);
+    if (!meta) return null;
+    const payload = takeMailAttachments(meta.mailbox, mailId);
+    if (!payload) return null;
+    meta.copper += payload.copper;
+    for (const item of payload.items) this.addItem(item.itemId, item.count, pid);
+    return payload;
+  }
+
+  private cleanMailAttachments(pid: number, items: InvSlot[] | undefined): InvSlot[] | null {
+    const normalized = normalizeMailItems(items);
+    for (const item of normalized) {
+      const def = ITEMS[item.itemId];
+      if (!def || def.kind === 'quest') return null;
+      if (this.countItem(item.itemId, pid) < item.count) return null;
+    }
+    return normalized;
   }
 
   private resolve(pid?: number): { meta: PlayerMeta; e: Entity } | null {

--- a/tests/persistence_round_trip.test.ts
+++ b/tests/persistence_round_trip.test.ts
@@ -41,6 +41,12 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     meta.companionUpgrades = { tessa: 2 };
     meta.delveLoreUnlocked = new Set(['lore_1']);
     meta.delveDaily = { date: '2026-06-26', firstClearXp: new Set(['crypt']), markClears: 2 };
+    const mailer = sim.addPlayer('mage', 'Mailer');
+    const mailerMeta = sim.meta(mailer);
+    expect(mailerMeta).toBeTruthy();
+    if (!mailerMeta) throw new Error('missing mailer meta');
+    mailerMeta.copper = 99;
+    sim.sendMail(mailer, pid, { subject: 'Stored', body: 'Persist me', copper: 42 });
 
     const s1 = sim.serializeCharacter(pid)!;
     const sim2 = makeWorld();
@@ -52,6 +58,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     expect(s2.delveMarks).toBe(17);
     expect(s2.loadouts?.length).toBe(1);
     expect(s2.skinCatalog).toBe('mech');
+    expect(s2.mailbox?.inbox[0]?.subject).toBe('Stored');
   });
 
   it('a legacy state missing the post-launch fields loads with sane defaults', () => {
@@ -86,6 +93,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
       'unlockedMilestones',
       'lifetimeXp',
       'restedXp',
+      'mailbox',
     ]) {
       delete legacy[key];
     }
@@ -105,6 +113,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     expect(m.loadouts).toEqual([]);
     expect(m.prestigeRank).toBe(0);
     expect(m.restedXp).toBe(0);
+    expect(m.mailbox).toEqual({ nextId: 1, inbox: [] });
     // re-serializing a defaulted character does not throw and fills the new fields.
     expect(() => sim2.serializeCharacter(pid)).not.toThrow();
     expect(sim2.serializeCharacter(pid)!.delveMarks).toBe(0);

--- a/tests/player_mail.test.ts
+++ b/tests/player_mail.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import { emptyMailbox, enqueueMail, normalizeMailbox, normalizeMailItems } from '../src/sim/mail';
+import { Sim, type PlayerMeta } from '../src/sim/sim';
+
+function makeWorld() {
+  return new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+}
+
+function requireMeta(sim: Sim, pid: number): PlayerMeta {
+  const meta = sim.meta(pid);
+  expect(meta).toBeTruthy();
+  return meta as PlayerMeta;
+}
+
+describe('player mail core', () => {
+  it('normalizes mailbox state and mail item stacks deterministically', () => {
+    expect(
+      normalizeMailItems([
+        { itemId: 'baked_bread', count: 1.9 },
+        { itemId: 'baked_bread', count: 2 },
+        { itemId: 'wolf_fang', count: 0 },
+      ]),
+    ).toEqual([
+      { itemId: 'baked_bread', count: 3 },
+      { itemId: 'wolf_fang', count: 1 },
+    ]);
+
+    const mailbox = emptyMailbox();
+    enqueueMail(mailbox, {
+      fromName: '',
+      subject: 'A'.repeat(100),
+      body: 'B'.repeat(600),
+      copper: 12.7,
+      sentAt: 3.5,
+    });
+    const normalized = normalizeMailbox(mailbox);
+    expect(normalized.nextId).toBe(2);
+    expect(normalized.inbox[0]).toMatchObject({
+      id: 1,
+      fromName: 'Unknown',
+      subject: 'A'.repeat(80),
+      body: 'B'.repeat(500),
+      copper: 12,
+      sentAt: 3,
+      read: false,
+      attachmentsTaken: false,
+    });
+  });
+
+  it('sends copper and item attachments, then collects them once', () => {
+    const sim = makeWorld();
+    const sender = sim.addPlayer('warrior', 'Sender');
+    const recipient = sim.addPlayer('mage', 'Recipient');
+    requireMeta(sim, sender).copper = 100;
+    sim.addItem('baked_bread', 3, sender);
+
+    const mail = sim.sendMail(sender, recipient, {
+      subject: 'Supplies',
+      body: 'For you',
+      copper: 35,
+      items: [{ itemId: 'baked_bread', count: 2 }],
+    });
+    expect(mail).toBeTruthy();
+    const mailId = mail?.id ?? 0;
+
+    expect(requireMeta(sim, sender).copper).toBe(65);
+    expect(sim.countItem('baked_bread', sender)).toBe(1);
+    expect(sim.mailboxFor(recipient).inbox[0]).toMatchObject({
+      id: mailId,
+      fromName: 'Sender',
+      subject: 'Supplies',
+      copper: 35,
+      items: [{ itemId: 'baked_bread', count: 2 }],
+      read: false,
+      attachmentsTaken: false,
+    });
+
+    const payload = sim.collectMailAttachments(recipient, mailId);
+    expect(payload).toEqual({
+      copper: 35,
+      items: [{ itemId: 'baked_bread', count: 2 }],
+    });
+    expect(requireMeta(sim, recipient).copper).toBe(35);
+    expect(sim.countItem('baked_bread', recipient)).toBe(2);
+    expect(sim.collectMailAttachments(recipient, mailId)).toBeNull();
+    expect(sim.mailboxFor(recipient).inbox[0]).toMatchObject({
+      copper: 0,
+      items: [],
+      read: true,
+      attachmentsTaken: true,
+    });
+  });
+
+  it('rejects unaffordable mail and invalid item attachments atomically', () => {
+    const sim = makeWorld();
+    const sender = sim.addPlayer('warrior', 'Sender');
+    const recipient = sim.addPlayer('mage', 'Recipient');
+    requireMeta(sim, sender).copper = 5;
+    sim.addItem('boar_hide', 1, sender);
+
+    expect(sim.sendMail(sender, recipient, { copper: 10 })).toBeNull();
+    expect(requireMeta(sim, sender).copper).toBe(5);
+    expect(sim.mailboxFor(recipient).inbox).toEqual([]);
+
+    expect(
+      sim.sendMail(sender, recipient, {
+        items: [{ itemId: 'boar_hide', count: 1 }],
+      }),
+    ).toBeNull();
+    expect(sim.countItem('boar_hide', sender)).toBe(1);
+    expect(sim.mailboxFor(recipient).inbox).toEqual([]);
+  });
+
+  it('returns cloned mailbox state for callers', () => {
+    const sim = makeWorld();
+    const sender = sim.addPlayer('warrior', 'Sender');
+    const recipient = sim.addPlayer('mage', 'Recipient');
+    const mail = sim.sendMail(sender, recipient, { subject: 'Original' });
+    expect(mail).toBeTruthy();
+
+    const external = sim.mailboxFor(recipient);
+    external.inbox[0].subject = 'Changed';
+    expect(sim.mailboxFor(recipient).inbox[0].subject).toBe('Original');
+  });
+
+  it('round-trips through character persistence and defaults legacy saves', () => {
+    const sim = makeWorld();
+    const sender = sim.addPlayer('warrior', 'Sender');
+    const recipient = sim.addPlayer('mage', 'Recipient');
+    requireMeta(sim, sender).copper = 50;
+    sim.sendMail(sender, recipient, {
+      subject: 'Saved',
+      copper: 25,
+      items: [],
+    });
+
+    const saved = sim.serializeCharacter(recipient);
+    expect(saved?.mailbox?.inbox[0]).toMatchObject({ subject: 'Saved', copper: 25 });
+
+    const restored = makeWorld();
+    const restoredPid = restored.addPlayer('mage', 'Recipient', { state: saved ?? undefined });
+    expect(restored.serializeCharacter(restoredPid)?.mailbox).toEqual(saved?.mailbox);
+
+    const legacy = { ...(saved as unknown as Record<string, unknown>) };
+    delete legacy.mailbox;
+    const legacyWorld = makeWorld();
+    const legacyPid = legacyWorld.addPlayer('mage', 'Legacy', { state: legacy as never });
+    expect(legacyWorld.mailboxFor(legacyPid)).toEqual(emptyMailbox());
+  });
+});


### PR DESCRIPTION
## Summary

Adds the first deterministic Sim slice for player mail:

- stores a per-character mailbox in `PlayerMeta` / `CharacterState`
- adds mailbox normalization/cloning plus send/read/collect helpers
- supports copper and stackable item attachments with atomic sender-side validation
- rejects quest/unknown/missing item attachments and unaffordable copper sends
- leaves UI, chat commands, server/offline lookup, and delivery surfaces for later PRs

## Related issues

Part of #438.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src\sim\mail.ts src\sim\sim.ts tests\player_mail.test.ts tests\persistence_round_trip.test.ts`
  - `npx biome lint src\sim\mail.ts src\sim\sim.ts tests\player_mail.test.ts tests\persistence_round_trip.test.ts` (exits 0; reports existing warning noise in broad files)
  - `npm run check:ts`
  - `npx vitest run tests/player_mail.test.ts tests/persistence_round_trip.test.ts tests/trade.test.ts` with `.browserslistrc` comments temporarily removed and restored afterward
  - `npm run build` with `.browserslistrc` comments temporarily removed and restored afterward
- Manual steps: N/A; this is backend Sim state/API only.

## Screenshots / recordings

N/A; no UI/UX changes.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
