### PR TITLE
feat(sim): add achievement core

### DIFF
--- a/src/sim/achievements.ts
+++ b/src/sim/achievements.ts
@@ -1,0 +1,132 @@
+type AchievementCounterKey = 'kills' | 'deaths' | 'xpGained' | 'questsCompleted' | 'levelUps';
+
+export type AchievementCriterion =
+  | { kind: 'level'; value: number }
+  | { kind: 'lifetimeXp'; value: number }
+  | { kind: 'counter'; counter: AchievementCounterKey; value: number };
+
+export interface AchievementDef {
+  id: string;
+  nameKey: `achievements.${string}.name`;
+  descriptionKey: `achievements.${string}.description`;
+  points: number;
+  criterion: AchievementCriterion;
+}
+
+export interface AchievementState {
+  unlocked: string[];
+  points: number;
+}
+
+export interface AchievementEvaluationInput {
+  level: number;
+  lifetimeXp: number;
+  counters: Record<AchievementCounterKey, number>;
+}
+
+export const ACHIEVEMENTS = [
+  {
+    id: 'level_10',
+    nameKey: 'achievements.level_10.name',
+    descriptionKey: 'achievements.level_10.description',
+    points: 10,
+    criterion: { kind: 'level', value: 10 },
+  },
+  {
+    id: 'level_20',
+    nameKey: 'achievements.level_20.name',
+    descriptionKey: 'achievements.level_20.description',
+    points: 20,
+    criterion: { kind: 'level', value: 20 },
+  },
+  {
+    id: 'lifetime_xp_1000',
+    nameKey: 'achievements.lifetime_xp_1000.name',
+    descriptionKey: 'achievements.lifetime_xp_1000.description',
+    points: 5,
+    criterion: { kind: 'lifetimeXp', value: 1_000 },
+  },
+  {
+    id: 'kills_10',
+    nameKey: 'achievements.kills_10.name',
+    descriptionKey: 'achievements.kills_10.description',
+    points: 10,
+    criterion: { kind: 'counter', counter: 'kills', value: 10 },
+  },
+] as const satisfies readonly AchievementDef[];
+
+const ACHIEVEMENT_BY_ID: ReadonlyMap<string, AchievementDef> = new Map(
+  ACHIEVEMENTS.map<[string, AchievementDef]>((achievement) => [achievement.id, achievement]),
+);
+const ACHIEVEMENT_ORDER: ReadonlyMap<string, number> = new Map(
+  ACHIEVEMENTS.map<[string, number]>((achievement, i) => [achievement.id, i]),
+);
+
+export function emptyAchievementState(): AchievementState {
+  return { unlocked: [], points: 0 };
+}
+
+export function cloneAchievementState(state: AchievementState): AchievementState {
+  return { unlocked: [...state.unlocked], points: state.points };
+}
+
+export function normalizeAchievementState(
+  state?: Partial<AchievementState> | null,
+): AchievementState {
+  const seen = new Set<string>();
+  const unlocked: string[] = [];
+  for (const id of state?.unlocked ?? []) {
+    if (!ACHIEVEMENT_BY_ID.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    unlocked.push(id);
+  }
+  unlocked.sort(compareAchievementIds);
+  return { unlocked, points: pointsFor(unlocked) };
+}
+
+export function unlockAchievement(state: AchievementState, achievementId: string): boolean {
+  if (!ACHIEVEMENT_BY_ID.has(achievementId) || state.unlocked.includes(achievementId)) return false;
+  state.unlocked.push(achievementId);
+  state.unlocked.sort(compareAchievementIds);
+  state.points = pointsFor(state.unlocked);
+  return true;
+}
+
+export function evaluateAchievements(input: AchievementEvaluationInput): string[] {
+  return ACHIEVEMENTS.filter((achievement) => criterionMet(achievement.criterion, input)).map(
+    (achievement) => achievement.id,
+  );
+}
+
+export function applyAchievementEvaluation(
+  state: AchievementState,
+  input: AchievementEvaluationInput,
+): string[] {
+  const newlyUnlocked: string[] = [];
+  for (const achievementId of evaluateAchievements(input)) {
+    if (unlockAchievement(state, achievementId)) newlyUnlocked.push(achievementId);
+  }
+  return newlyUnlocked;
+}
+
+function criterionMet(criterion: AchievementCriterion, input: AchievementEvaluationInput): boolean {
+  switch (criterion.kind) {
+    case 'level':
+      return input.level >= criterion.value;
+    case 'lifetimeXp':
+      return input.lifetimeXp >= criterion.value;
+    case 'counter':
+      return input.counters[criterion.counter] >= criterion.value;
+  }
+}
+
+function compareAchievementIds(a: string, b: string): number {
+  return (
+    (ACHIEVEMENT_ORDER.get(a) ?? Number.MAX_SAFE_INTEGER) -
+    (ACHIEVEMENT_ORDER.get(b) ?? Number.MAX_SAFE_INTEGER)
+  );
+}
+
+function pointsFor(unlocked: readonly string[]): number {
+  return unlocked.reduce((sum, id) => sum + (ACHIEVEMENT_BY_ID.get(id)?.points ?? 0), 0);
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4,6 +4,14 @@ import type {
   DelveRunInfo,
   LockpickView,
 } from '../world_api';
+import {
+  applyAchievementEvaluation,
+  cloneAchievementState,
+  emptyAchievementState,
+  type AchievementState,
+  normalizeAchievementState,
+  unlockAchievement as unlockAchievementState,
+} from './achievements';
 import { lineOfSightClear, resolveMovement, resolvePosition } from './colliders';
 import { auraAffectsStats, removeCancelableAura } from './combat/aura_cancel';
 import {
@@ -640,6 +648,7 @@ export interface PlayerMeta {
   lifetimeXp: number;
   prestigeRank: number;
   unlockedMilestones: Set<string>;
+  achievements: AchievementState;
   // Classic Rested XP pool (copper-less XP units). Accrues while resting in an
   // inn, spent to double kill XP. Persisted in CharacterState.
   restedXp: number;
@@ -728,6 +737,7 @@ export interface CharacterState {
   lifetimeXp?: number;
   prestigeRank?: number;
   unlockedMilestones?: string[];
+  achievements?: AchievementState;
   // Rested XP pool. Optional so pre-rested-XP saves load cleanly (defaults to 0).
   restedXp?: number;
   copper: number;
@@ -1167,6 +1177,7 @@ export class Sim {
       lifetimeXp: 0,
       prestigeRank: 0,
       unlockedMilestones: new Set(),
+      achievements: emptyAchievementState(),
       restedXp: 0,
       known: [],
       questLog: new Map(),
@@ -1217,6 +1228,7 @@ export class Sim {
       meta.restedXp = Math.max(0, s.restedXp ?? 0);
       if (s.unlockedMilestones)
         for (const id of s.unlockedMilestones) meta.unlockedMilestones.add(id);
+      meta.achievements = normalizeAchievementState(s.achievements);
       meta.copper = s.copper;
       meta.equipment = { ...s.equipment };
       meta.inventory = s.inventory.map((i) => ({ ...i }));
@@ -1385,6 +1397,7 @@ export class Sim {
       lifetimeXp: meta.lifetimeXp,
       prestigeRank: meta.prestigeRank,
       unlockedMilestones: [...meta.unlockedMilestones],
+      achievements: cloneAchievementState(meta.achievements),
       restedXp: meta.restedXp,
       copper: meta.copper,
       hp: e.hp,
@@ -1622,6 +1635,9 @@ export class Sim {
   get unlockedMilestones(): string[] {
     return [...this.primary.unlockedMilestones];
   }
+  get achievements(): AchievementState {
+    return cloneAchievementState(this.primary.achievements);
+  }
   // Offline leaderboard: rank the players the local sim knows about by lifetime
   // XP. Online play overrides this with the cached, realm-scoped server query.
   // Paged through the same helper the server uses so both worlds behave alike.
@@ -1701,6 +1717,26 @@ export class Sim {
 
   meta(pid: number): PlayerMeta | null {
     return this.players.get(pid) ?? null;
+  }
+
+  achievementsFor(pid?: number): AchievementState {
+    const r = this.resolve(pid);
+    return r ? cloneAchievementState(r.meta.achievements) : emptyAchievementState();
+  }
+
+  unlockAchievement(achievementId: string, pid?: number): boolean {
+    const r = this.resolve(pid);
+    return r ? unlockAchievementState(r.meta.achievements, achievementId) : false;
+  }
+
+  evaluateAchievements(pid?: number): string[] {
+    const r = this.resolve(pid);
+    if (!r) return [];
+    return applyAchievementEvaluation(r.meta.achievements, {
+      level: r.e.level,
+      lifetimeXp: r.meta.lifetimeXp,
+      counters: r.meta.counters,
+    });
   }
 
   private resolve(pid?: number): { meta: PlayerMeta; e: Entity } | null {
@@ -2248,6 +2284,7 @@ export class Sim {
     if (r.e.resourceType === 'mana') r.e.resource = r.e.maxResource;
     this.refreshKnownAbilities(r.meta, false);
     this.syncPetLevel(r.e);
+    this.evaluateAchievements(pid);
   }
 
   // -------------------------------------------------------------------------
@@ -3447,6 +3484,7 @@ export class Sim {
 
   grantXp(amount: number, meta: PlayerMeta = this.primary, opts?: { fromKill?: boolean }): void {
     grantXpImpl(this.ctx, amount, meta, opts);
+    this.evaluateAchievements(meta.entityId);
   }
 
   // Opt-in cosmetic prestige: only at the cap. Resets the level XP

--- a/tests/achievements.test.ts
+++ b/tests/achievements.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ACHIEVEMENTS,
+  applyAchievementEvaluation,
+  emptyAchievementState,
+  normalizeAchievementState,
+  unlockAchievement,
+} from '../src/sim/achievements';
+import { Sim } from '../src/sim/sim';
+import { MAX_LEVEL } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 11, playerClass: 'warrior', autoEquip: true });
+}
+
+function serializePrimary(sim: Sim) {
+  const state = sim.serializeCharacter(sim.playerId);
+  if (!state) throw new Error('expected primary character to serialize');
+  return state;
+}
+
+describe('achievement state', () => {
+  it('normalizes persisted unlocks and recomputes points from current defs', () => {
+    const state = normalizeAchievementState({
+      unlocked: ['unknown', 'level_20', 'level_10', 'level_10'],
+      points: 999,
+    });
+
+    const expectedPoints = ACHIEVEMENTS.filter((achievement) =>
+      ['level_10', 'level_20'].includes(achievement.id),
+    ).reduce((sum, achievement) => sum + achievement.points, 0);
+
+    expect(state.unlocked).toEqual(['level_10', 'level_20']);
+    expect(state.points).toBe(expectedPoints);
+  });
+
+  it('unlocks known ids once', () => {
+    const state = emptyAchievementState();
+
+    expect(unlockAchievement(state, 'level_10')).toBe(true);
+    expect(unlockAchievement(state, 'level_10')).toBe(false);
+    expect(unlockAchievement(state, 'not_real')).toBe(false);
+    expect(state.unlocked).toEqual(['level_10']);
+  });
+
+  it('applies all criteria met by the current sim snapshot', () => {
+    const state = emptyAchievementState();
+
+    const unlocked = applyAchievementEvaluation(state, {
+      level: MAX_LEVEL,
+      lifetimeXp: 1_000,
+      counters: { kills: 10, deaths: 0, xpGained: 1_000, questsCompleted: 0, levelUps: 19 },
+    });
+
+    expect(unlocked).toEqual(['level_10', 'level_20', 'lifetime_xp_1000', 'kills_10']);
+    expect(
+      applyAchievementEvaluation(state, {
+        level: MAX_LEVEL,
+        lifetimeXp: 1_000,
+        counters: { kills: 10, deaths: 0, xpGained: 1_000, questsCompleted: 0, levelUps: 19 },
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe('Sim achievement integration', () => {
+  it('unlocks level achievements when player level changes', () => {
+    const sim = makeSim();
+
+    sim.setPlayerLevel(10);
+
+    expect(sim.achievements.unlocked).toEqual(['level_10', 'lifetime_xp_1000']);
+    sim.setPlayerLevel(MAX_LEVEL);
+    expect(sim.achievements.unlocked).toContain('level_20');
+  });
+
+  it('unlocks lifetime-XP achievements after XP awards', () => {
+    const sim = makeSim();
+
+    sim.grantXp(1_000);
+
+    expect(sim.achievements.unlocked).toContain('lifetime_xp_1000');
+  });
+
+  it('keeps returned achievement state detached from PlayerMeta', () => {
+    const sim = makeSim();
+    sim.unlockAchievement('level_10');
+
+    const state = sim.achievementsFor();
+    state.unlocked.push('level_20');
+    state.points = 999;
+
+    expect(sim.achievements).toEqual({ unlocked: ['level_10'], points: 10 });
+  });
+
+  it('round-trips achievement unlocks through character persistence', () => {
+    const sim = makeSim();
+    sim.unlockAchievement('level_10');
+    const state = serializePrimary(sim);
+
+    const restored = new Sim({ seed: 11, playerClass: 'warrior', noPlayer: true });
+    const pid = restored.addPlayer('warrior', 'Restored', { state });
+
+    expect(restored.achievementsFor(pid)).toEqual({ unlocked: ['level_10'], points: 10 });
+  });
+
+  it('loads legacy characters with an empty achievement state', () => {
+    const sim = makeSim();
+    const state = serializePrimary(sim);
+    delete state.achievements;
+
+    const restored = new Sim({ seed: 11, playerClass: 'warrior', noPlayer: true });
+    const pid = restored.addPlayer('warrior', 'Legacy', { state });
+
+    expect(restored.achievementsFor(pid)).toEqual({ unlocked: [], points: 0 });
+  });
+});

--- a/tests/persistence_round_trip.test.ts
+++ b/tests/persistence_round_trip.test.ts
@@ -30,6 +30,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     meta.arena2v2Losses = 4;
     meta.prestigeRank = 2;
     meta.unlockedMilestones = new Set(['m_first', 'm_second']);
+    sim.unlockAchievement('level_10', pid);
     meta.restedXp = 321;
     meta.skin = 3;
     meta.skinCatalog = 'mech';
@@ -52,6 +53,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     expect(s2.delveMarks).toBe(17);
     expect(s2.loadouts?.length).toBe(1);
     expect(s2.skinCatalog).toBe('mech');
+    expect(s2.achievements).toEqual({ unlocked: ['level_10', 'lifetime_xp_1000'], points: 15 });
   });
 
   it('a legacy state missing the post-launch fields loads with sane defaults', () => {
@@ -84,6 +86,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
       'delveDaily',
       'prestigeRank',
       'unlockedMilestones',
+      'achievements',
       'lifetimeXp',
       'restedXp',
     ]) {
@@ -104,6 +107,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     expect(m.skinCatalog).toBe('class');
     expect(m.loadouts).toEqual([]);
     expect(m.prestigeRank).toBe(0);
+    expect(m.achievements).toEqual({ unlocked: [], points: 0 });
     expect(m.restedXp).toBe(0);
     // re-serializing a defaulted character does not throw and fills the new fields.
     expect(() => sim2.serializeCharacter(pid)).not.toThrow();


### PR DESCRIPTION
## Summary

Adds the first core slice of the achievements system: stable achievement definitions, normalized per-character unlock state with points, deterministic evaluation helpers, and persistence through `CharacterState`.

This wires level and XP changes to evaluate achievements in the sim while keeping UI, toasts, and the achievements panel out of this focused PR.

## Related issues

Part of #559

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src\sim\achievements.ts src\sim\sim.ts tests\achievements.test.ts tests\persistence_round_trip.test.ts`
  - `npx biome lint src\sim\achievements.ts src\sim\sim.ts tests\achievements.test.ts tests\persistence_round_trip.test.ts` (exits 0; existing warnings remain in `src/sim/sim.ts` and `tests/persistence_round_trip.test.ts`)
  - `npm run check:ts`
  - wrapped `.browserslistrc` comments, then `npx vitest run tests/achievements.test.ts tests/persistence_round_trip.test.ts tests/xp.test.ts`
  - wrapped `.browserslistrc` comments, then `npm run build`
  - wrapped `.browserslistrc` comments, then `npx vitest run tests/architecture.test.ts` (known unrelated failure: `src/world_api/chat.ts` value-imports `OVERHEAD_EMOTE_IDS` from `../sim/types`)
- Manual steps: N/A, sim/persistence core only.

## Screenshots / recordings

N/A. This PR does not change player-visible UI.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.