### PR TITLE
fix(sim): stop rest channels when full

### DIFF
--- a/src/sim/combat/auras.ts
+++ b/src/sim/combat/auras.ts
@@ -90,8 +90,11 @@ export function updateRegen(ctx: SimContext, p: Entity, _meta: PlayerMeta): void
       p.resource = Math.min(p.maxResource, p.resource + c.manaPer2s);
     }
     c.remaining -= 2;
-    if (c.remaining <= 0) p[slot] = null;
+    const fullHealth = c.hpPer2s > 0 && p.hp >= p.maxHp;
+    const fullMana = c.manaPer2s > 0 && (p.resourceType !== 'mana' || p.resource >= p.maxResource);
+    if (c.remaining <= 0 || fullHealth || fullMana) p[slot] = null;
   }
+  if (!p.eating && !p.drinking) p.sitting = false;
 }
 
 export function updateTimers(p: Entity): void {

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -828,6 +828,40 @@ describe('food, drink, vendor', () => {
     expect(sim.player.drinking).toBe(null);
   });
 
+  it('stops eating and stands once food tops off health', () => {
+    const sim = makeSim('warrior');
+    sim.addItem('baked_bread', 1);
+    sim.player.hp = sim.player.maxHp - 1;
+    sim.player.combatTimer = 99;
+    sim.player.inCombat = false;
+
+    sim.useItem('baked_bread');
+    for (let i = 0; i < 40; i++) sim.tick();
+
+    expect(sim.player.hp).toBe(sim.player.maxHp);
+    expect(sim.player.eating).toBe(null);
+    expect(sim.player.sitting).toBe(false);
+  });
+
+  it('stops drinking at full mana while food keeps restoring health', () => {
+    const sim = makeSim('mage');
+    sim.addItem('baked_bread', 1);
+    sim.addItem('spring_water', 1);
+    sim.player.hp = 20;
+    sim.player.resource = sim.player.maxResource - 1;
+    sim.player.combatTimer = 99;
+    sim.player.inCombat = false;
+
+    sim.useItem('baked_bread');
+    sim.useItem('spring_water');
+    for (let i = 0; i < 40; i++) sim.tick();
+
+    expect(sim.player.resource).toBe(sim.player.maxResource);
+    expect(sim.player.drinking).toBe(null);
+    expect(sim.player.eating).not.toBe(null);
+    expect(sim.player.sitting).toBe(true);
+  });
+
   it('combat potions restore instantly, work in combat, and share a cooldown (#103)', () => {
     const sim = makeSim('mage');
     sim.addItem('minor_mana_potion', 2);


### PR DESCRIPTION
## Summary

Stops food/drink rest channels as soon as their restorative target is full:

- eating clears once food tops health to max
- drinking clears once mana reaches max
- the player stands automatically when no eating or drinking channel remains

This addresses the `#15` QoL subitem where heal/rest sounds should stop once health and mana are full. Keeping the sim channel state accurate also gives downstream audio/UI state a clear stop condition.

## Related issues

Part of #15

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src\sim\combat\auras.ts tests\sim.test.ts`
  - `npx biome lint src\sim\combat\auras.ts tests\sim.test.ts` (exits 0; existing warning noise remains in `tests/sim.test.ts`)
  - `npm run check:ts`
  - wrapped `.browserslistrc` comments, then `npx vitest run tests/sim.test.ts tests/items.test.ts`
  - wrapped `.browserslistrc` comments, then `npm run build`
  - wrapped `.browserslistrc` comments, then `npx vitest run tests/architecture.test.ts` (known unrelated failure: `src/world_api/chat.ts` value-imports `OVERHEAD_EMOTE_IDS` from `../sim/types`)
- Manual steps: N/A, sim state behavior only.

## Screenshots / recordings

N/A. This PR changes sim state behavior only and does not alter UI layout.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.