### PR TITLE
feat(settings): add home graphics selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -1170,6 +1170,17 @@
           </select>
           <span id="lang-select-status" class="visually-hidden" role="status" aria-live="polite"></span>
         </div>
+        <label class="landing-graphics-control" for="landing-graphics-select">
+          <span data-i18n="hud.options.graphics">Graphics</span>
+          <select id="landing-graphics-select" class="landing-graphics-select">
+            <option value="auto" data-i18n="hud.options.graphicsPresetAuto">Auto</option>
+            <option value="1" data-i18n="hud.options.graphicsPresetLow">Low</option>
+            <option value="2" data-i18n="hud.options.graphicsPresetMedium">Medium</option>
+            <option value="3" data-i18n="hud.options.graphicsPresetHigh">High</option>
+            <option value="4" data-i18n="hud.options.graphicsPresetUltra">Ultra</option>
+            <option value="5" data-i18n="hud.options.graphicsPresetAdvanced">Advanced</option>
+          </select>
+        </label>
         <button type="button" id="landing-contrast-toggle" class="landing-contrast-toggle" aria-pressed="false" data-i18n="hudChrome.landing.highContrast" data-i18n-aria="hudChrome.landing.highContrastAria" aria-label="Toggle high-contrast background">High Contrast</button>
       </div>
       </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ import { startPerfReporter } from './game/perf_reporter';
 import {
   type GameSettings,
   normalizeClickMoveButton,
-  type SETTING_RANGES,
+  SETTING_RANGES,
   Settings,
 } from './game/settings';
 import { sfx } from './game/sfx';
@@ -195,6 +195,7 @@ const HOMEPAGE_MUSIC_MUTED_KEY = 'woc_homepage_music_muted';
 const HOMEPAGE_MUSIC_VOLUME = 0.225;
 const GRAPHICS_PRESET_HIGH = 3;
 const GRAPHICS_PRESET_ULTRA = 4;
+const LANDING_GRAPHICS_AUTO = 'auto';
 
 const $ = <T extends HTMLElement = HTMLElement>(sel: string): T => document.querySelector(sel) as T;
 document.body.classList.toggle('native-app', NATIVE_APP);
@@ -7049,9 +7050,40 @@ function wireStartScreens(): void {
   const contrastToggle = document.getElementById(
     'landing-contrast-toggle',
   ) as HTMLButtonElement | null;
+  const graphicsSelect = document.getElementById(
+    'landing-graphics-select',
+  ) as HTMLSelectElement | null;
+  const normalizedLandingGraphicsChoice = (raw: string | null): string => {
+    if (raw === LANDING_GRAPHICS_AUTO) return raw;
+    const preset = Number(raw);
+    if (
+      Number.isInteger(preset) &&
+      preset >= SETTING_RANGES.graphicsPreset.min &&
+      preset <= SETTING_RANGES.graphicsPreset.max
+    ) {
+      return String(preset);
+    }
+    return LANDING_GRAPHICS_AUTO;
+  };
+  const applyLandingGraphicsChoice = (choice: string): void => {
+    if (choice === LANDING_GRAPHICS_AUTO) {
+      landingSettings.set('graphicsPreset', SETTING_RANGES.graphicsPreset.def);
+      landingSettings.set('graphicsDefaultApplied', false);
+      return;
+    }
+    landingSettings.set('graphicsPreset', Number(choice));
+    landingSettings.set('graphicsDefaultApplied', true);
+  };
+  const syncLandingGraphicsSelect = (): void => {
+    if (!graphicsSelect) return;
+    graphicsSelect.value = landingSettings.get('graphicsDefaultApplied')
+      ? String(landingSettings.get('graphicsPreset'))
+      : LANDING_GRAPHICS_AUTO;
+  };
   const syncContrastToggle = (on: boolean): void => {
     if (contrastToggle) contrastToggle.setAttribute('aria-pressed', String(on));
   };
+  syncLandingGraphicsSelect();
   syncContrastToggle(landingSettings.get('landingHighContrast'));
   applyLandingBackdrop(landingSettings.get('landingHighContrast'));
 
@@ -7080,6 +7112,11 @@ function wireStartScreens(): void {
     landingSettings.set('landingHighContrast', next);
     syncContrastToggle(next);
     applyLandingBackdrop(next);
+  });
+  graphicsSelect?.addEventListener('change', () => {
+    const choice = normalizedLandingGraphicsChoice(graphicsSelect.value);
+    applyLandingGraphicsChoice(choice);
+    syncLandingGraphicsSelect();
   });
 
   // Initialize 3D character preview once assets are ready

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -696,6 +696,36 @@
     gap: 12px;
     flex-wrap: wrap;
   }
+  .landing-graphics-control {
+    min-height: 40px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 10px;
+    font-family: var(--font-ui);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--color-text-light, #e8dcc0);
+    background: rgba(21, 21, 31, 0.7);
+    border: 1px solid var(--color-border-default, #4e3d1d);
+    border-radius: var(--radius-sm, 6px);
+  }
+  .landing-graphics-select {
+    min-height: 32px;
+    padding: 0 26px 0 10px;
+    font-family: var(--font-ui);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--color-text-light, #e8dcc0);
+    background: rgba(9, 10, 16, 0.9);
+    border: 1px solid rgba(255, 209, 0, 0.28);
+    border-radius: var(--radius-sm, 6px);
+    cursor: var(--cursor-point, pointer);
+  }
+  .landing-graphics-control:focus-within,
+  .landing-graphics-control:hover {
+    border-color: var(--color-primary, #ffd100);
+  }
   /* Landing accessibility toggle: cinematic trailer vs static high-contrast
      backdrop. Sits beside the language picker (the page's preferences area).
      ≥40px tall tap target, aria-pressed reflects state. */


### PR DESCRIPTION
## Summary
- Add a graphics preset selector to the home screen preferences row
- Persist Auto versus explicit graphics preset choices through existing settings
- Style the selector to match the landing controls

## Verification
- npx vitest run tests/css_value_validity.test.ts tests/styles_extraction.test.ts
- npm run build