### PR TITLE
fix(mobile): disable Appflow OTA updates

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -4,12 +4,11 @@ const config: CapacitorConfig = {
   appId: 'com.worldofclaudecraft',
   appName: 'World of ClaudeCraft',
   webDir: 'dist',
-  bundledWebRuntime: false,
   plugins: {
     LiveUpdates: {
       appId: '9fa1b0c1',
       channel: 'Production',
-      autoUpdateMethod: 'background',
+      autoUpdateMethod: 'none',
       maxVersions: 2,
     },
   },


### PR DESCRIPTION
## Summary
- Disable Appflow Live Updates by setting `autoUpdateMethod` to `none`
- Remove the legacy `bundledWebRuntime` Capacitor config field that no longer exists in Capacitor 8

## Verification
- npx tsc --noEmit --pretty false