### PR TITLE
fix(tests): architecture seam gate fails on Windows (path separator in sanction lookup)

### DIFF
--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
@@ -363,7 +363,9 @@ describe('src/world_api IWorld seam purity invariants', () => {
   it('pulls only TYPES from src/sim (a value sim import would drag the engine into the seam)', () => {
     const violations: string[] = [];
     for (const file of worldApiFiles) {
-      const rel = relative(repoRoot, file);
+      // Windows: path.relative yields backslash-separated paths; the allowlist
+      // keys use '/', so normalize before the lookup or the sanction never matches.
+      const rel = relative(repoRoot, file).split(sep).join('/');
       const allowed = SANCTIONED_VALUE_SIM_IMPORTS[rel] ?? new Set<string>();
       const src = stripComments(readFileSync(file, 'utf8'));
       for (const m of src.matchAll(SEAM_IMPORT_RE)) {


### PR DESCRIPTION
## Problem
On Windows, `path.relative()` yields backslash-separated paths, but `SANCTIONED_VALUE_SIM_IMPORTS` in `tests/architecture.test.ts` is keyed with forward slashes (`src/world_api/chat.ts`). The sanctioned `OVERHEAD_EMOTE_IDS` import therefore never matches, and the **"pulls only TYPES from src/sim"** gate is red for every Windows contributor out of the box:

```
src\world_api\chat.ts value-imports 'OVERHEAD_EMOTE_IDS' from '../sim/types' (sim imports must be type-only)
```

## Fix
Normalize the relative path with `path.sep` before the allowlist lookup (one line + import). No behavior change on POSIX runners.

## Verification
- `npx vitest run tests/architecture.test.ts` on Windows 11: 24 passed (was 1 failed).
- POSIX unaffected: `split(sep).join('/')` is an identity when `sep === '/'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)