### PR TITLE
fix(gamepad): include controller button presses in APM

### DIFF
--- a/src/game/gamepad.ts
+++ b/src/game/gamepad.ts
@@ -4,20 +4,23 @@
 // Input instance (movement / camera / jump), dispatching edge-button actions via
 // the host's onAction callback, the virtual-cursor UI-navigation mode, and
 // haptic rumble. Modeled structurally on MobileControls.
-import type { Input } from './input';
+
 import type { GamepadBindings } from './gamepad_bindings';
 import {
-  STANDARD_BUTTON_COUNT,
   AXIS,
-  GP,
-  TRIGGER_THRESHOLD,
   GAMEPAD_NONE,
-  stickToMoveFlags,
-  stickToLook,
+  GP,
   risingEdges,
+  STANDARD_BUTTON_COUNT,
+  stickToLook,
+  stickToMoveFlags,
+  TRIGGER_THRESHOLD,
 } from './gamepad_map';
+import type { Input } from './input';
 
 export interface GamepadCallbacks {
+  // Record one physical button rising edge for the HUD's APM readout.
+  onInputEdge(): void;
   // Dispatch a bound action id (slotN / target / interact / bags / escape / ...).
   // Reuses the host's existing keybind/UI dispatch; jump & autorun are handled
   // here against Input directly and never reach this.
@@ -46,7 +49,11 @@ export class GamepadManager {
   private boundConnect = (e: GamepadEvent) => this.onConnect(e);
   private boundDisconnect = (e: GamepadEvent) => this.onDisconnect(e);
 
-  constructor(private input: Input, private bindings: GamepadBindings, private cb: GamepadCallbacks) {}
+  constructor(
+    private input: Input,
+    private bindings: GamepadBindings,
+    private cb: GamepadCallbacks,
+  ) {}
 
   start(): void {
     if (typeof navigator === 'undefined' || typeof navigator.getGamepads !== 'function') return;
@@ -54,7 +61,10 @@ export class GamepadManager {
     window.addEventListener('gamepaddisconnected', this.boundDisconnect);
     // Pick up a pad that was already connected before we started listening.
     for (const pad of navigator.getGamepads()) {
-      if (pad?.connected) { this.index = pad.index; break; }
+      if (pad?.connected) {
+        this.index = pad.index;
+        break;
+      }
     }
   }
 
@@ -72,12 +82,22 @@ export class GamepadManager {
     this.hideCursor();
   }
 
-  setDeadzone(v: number): void { this.deadzone = Math.min(0.4, Math.max(0.05, v)); }
-  setCameraSpeed(v: number): void { this.camSpeed = Math.max(0.1, v); }
-  setInvertY(on: boolean): void { this.invertY = on; }
-  setVibration(v: number): void { this.vibration = Math.min(1, Math.max(0, v)); }
+  setDeadzone(v: number): void {
+    this.deadzone = Math.min(0.4, Math.max(0.05, v));
+  }
+  setCameraSpeed(v: number): void {
+    this.camSpeed = Math.max(0.1, v);
+  }
+  setInvertY(on: boolean): void {
+    this.invertY = on;
+  }
+  setVibration(v: number): void {
+    this.vibration = Math.min(1, Math.max(0, v));
+  }
 
-  isConnected(): boolean { return this.index !== null; }
+  isConnected(): boolean {
+    return this.index !== null;
+  }
 
   private onConnect(e: GamepadEvent): void {
     if (this.index === null) this.index = e.gamepad.index;
@@ -138,7 +158,10 @@ export class GamepadManager {
     this.input.applyGamepadLook(look.yaw, look.pitch);
 
     // Edge actions: one-shot on each button's rising edge.
-    for (const idx of risingEdges(this.prevPressed, cur)) this.dispatch(idx);
+    for (const idx of risingEdges(this.prevPressed, cur)) {
+      this.cb.onInputEdge();
+      this.dispatch(idx);
+    }
 
     this.prevPressed = cur;
   }
@@ -146,14 +169,23 @@ export class GamepadManager {
   private dispatch(buttonIndex: number): void {
     const action = this.bindings.actionFor(buttonIndex);
     if (action === GAMEPAD_NONE) return;
-    if (action === 'jump') { this.input.triggerGamepadJump(); return; }
-    if (action === 'autorun') { this.input.toggleAutorun(); return; }
+    if (action === 'jump') {
+      this.input.triggerGamepadJump();
+      return;
+    }
+    if (action === 'autorun') {
+      this.input.toggleAutorun();
+      return;
+    }
     this.cb.onAction(action);
   }
 
   // --- Haptics -------------------------------------------------------------
   private checkRumble(): void {
-    if (this.vibration <= 0 || !this.cb.getPlayerHealth) { this.lastHealth = null; return; }
+    if (this.vibration <= 0 || !this.cb.getPlayerHealth) {
+      this.lastHealth = null;
+      return;
+    }
     const hp = this.cb.getPlayerHealth();
     if (this.lastHealth !== null && hp < this.lastHealth) {
       const dmgFrac = Math.min(1, (this.lastHealth - hp) / Math.max(1, this.lastHealth));
@@ -165,7 +197,11 @@ export class GamepadManager {
   /** Fire a dual-rumble effect scaled by the vibration setting (best-effort). */
   rumble(strength: number, durationMs: number): void {
     const pad = this.activePad();
-    const actuator = (pad as unknown as { vibrationActuator?: { playEffect(type: string, opts: object): Promise<unknown> } })?.vibrationActuator;
+    const actuator = (
+      pad as unknown as {
+        vibrationActuator?: { playEffect(type: string, opts: object): Promise<unknown> };
+      }
+    )?.vibrationActuator;
     if (!actuator?.playEffect) return;
     const mag = Math.min(1, Math.max(0, strength)) * this.vibration;
     try {
@@ -174,7 +210,9 @@ export class GamepadManager {
         strongMagnitude: mag,
         weakMagnitude: mag * 0.6,
       });
-    } catch { /* unsupported actuator type */ }
+    } catch {
+      /* unsupported actuator type */
+    }
   }
 
   // --- UI-navigation virtual cursor ---------------------------------------
@@ -200,7 +238,10 @@ export class GamepadManager {
     // Left stick (or d-pad) moves the pointer.
     let mx = pad.axes[AXIS.LEFT_X] ?? 0;
     let my = pad.axes[AXIS.LEFT_Y] ?? 0;
-    if (Math.hypot(mx, my) < this.deadzone) { mx = 0; my = 0; }
+    if (Math.hypot(mx, my) < this.deadzone) {
+      mx = 0;
+      my = 0;
+    }
     if (cur[GP.DPAD_LEFT]) mx = -1;
     if (cur[GP.DPAD_RIGHT]) mx = 1;
     if (cur[GP.DPAD_UP]) my = -1;
@@ -211,6 +252,7 @@ export class GamepadManager {
     el.style.top = `${this.cursorY}px`;
 
     for (const idx of risingEdges(this.prevPressed, cur)) {
+      this.cb.onInputEdge();
       if (idx === GP.A) this.clickAtCursor();
       else if (idx === GP.B || idx === GP.START) this.cb.onAction('escape');
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1196,6 +1196,12 @@ async function startGame(
   // Gamepad: a separate remappable button profile drives the same dispatch the
   // keyboard/touch paths use. Edge-button actions route through this dispatcher;
   // movement/camera/jump are applied to Input directly by the manager.
+  const inputMeter = new InputActivityMeter();
+  installInputActivityTracking(inputMeter, window, () => performance.now());
+  const APM_BEAT_MS = 10_000;
+  window.setInterval(() => {
+    world.reportTelemetry('apm', { count: inputMeter.drainCount(), periodMs: APM_BEAT_MS });
+  }, APM_BEAT_MS);
   const gamepadBindings = new GamepadBindings();
   const canUseGameKeysNow = () => !hud.isModalOpen() && chatInput.style.display !== 'block';
   function dispatchGamepadAction(id: string): void {
@@ -1264,6 +1270,7 @@ async function startGame(
   }
   const gamepad = new GamepadManager(input, gamepadBindings, {
     onAction: (id) => dispatchGamepadAction(id),
+    onInputEdge: () => inputMeter.record(performance.now()),
     isPointerMode: () => hud.isWindowOpen(),
     getPlayerHealth: () => (world.player.dead ? 0 : world.player.hp),
   });
@@ -2156,14 +2163,6 @@ async function startGame(
   // online-only and null offline; Chromium-only sources (heap, connection) report
   // null elsewhere so their rows simply hide. The pure assembly lives in
   // perf_metrics_sampler.ts; here we inject the live sources.
-  // Input-activity meter for the overlay APM readout
-  const inputMeter = new InputActivityMeter();
-  installInputActivityTracking(inputMeter, window, () => performance.now());
-  const APM_BEAT_MS = 10_000;
-  window.setInterval(() => {
-    world.reportTelemetry('apm', { count: inputMeter.drainCount(), periodMs: APM_BEAT_MS });
-  }, APM_BEAT_MS);
-
   const sampleMetrics = createMetricsSampler({
     renderer,
     meter: perfMeter,

--- a/tests/gamepad.test.ts
+++ b/tests/gamepad.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { type GamepadCallbacks, GamepadManager } from '../src/game/gamepad';
+import { GamepadBindings } from '../src/game/gamepad_bindings';
+import { GP, STANDARD_BUTTON_COUNT } from '../src/game/gamepad_map';
+import type { Input } from '../src/game/input';
+
+const originalNavigator = globalThis.navigator;
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: originalNavigator,
+  });
+});
+
+function gamepadWithPressed(...pressed: number[]): Gamepad {
+  const pressedSet = new Set(pressed);
+  return {
+    axes: [0, 0, 0, 0],
+    buttons: Array.from({ length: STANDARD_BUTTON_COUNT }, (_, index) => ({
+      pressed: pressedSet.has(index),
+      touched: pressedSet.has(index),
+      value: pressedSet.has(index) ? 1 : 0,
+    })),
+    connected: true,
+    id: 'test gamepad',
+    index: 0,
+    mapping: 'standard',
+    timestamp: 0,
+    vibrationActuator: null,
+  } as unknown as Gamepad;
+}
+
+describe('GamepadManager', () => {
+  it('reports each button rising edge once for the APM meter', () => {
+    let pad = gamepadWithPressed();
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: { getGamepads: () => [pad] },
+    });
+
+    const onInputEdge = vi.fn();
+    const input = {
+      applyGamepadLook: vi.fn(),
+      setGamepadMove: vi.fn(),
+      triggerGamepadJump: vi.fn(),
+    } as unknown as Input;
+    const callbacks = {
+      onAction: vi.fn(),
+      onInputEdge,
+      isPointerMode: () => false,
+    } satisfies GamepadCallbacks;
+    const manager = new GamepadManager(input, new GamepadBindings(), callbacks);
+    (manager as unknown as { index: number | null }).index = 0;
+
+    manager.poll(1 / 60);
+    pad = gamepadWithPressed(GP.A);
+    manager.poll(1 / 60);
+    manager.poll(1 / 60);
+    pad = gamepadWithPressed();
+    manager.poll(1 / 60);
+    pad = gamepadWithPressed(GP.A);
+    manager.poll(1 / 60);
+
+    expect(onInputEdge).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Controller button presses were missing from the APM value displayed in the HUD because controller input is polled instead of producing keyboard or pointer events.

This change records each controller button rising edge once, including buttons handled directly by the controller manager and buttons used while navigating HUD windows. Held buttons do not produce repeated APM entries.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run check:types && npm test && npm run ci:changed && npm run build && npm run build:server`

- Manual steps: Tested on desktop with an xbox controller

## Screenshots / recordings

<img width="401" height="67" alt="image" src="https://github.com/user-attachments/assets/9ca4f4c7-2a65-4e37-ae48-9f1dd3996f52" />


---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [x] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters.
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.