### PR TITLE
feat(ui): auto-close quest dialog and fade NPC voice when you walk away

### DIFF
--- a/src/game/voice.ts
+++ b/src/game/voice.ts
@@ -13,15 +13,51 @@ import { VOICE_LINES } from './voice_manifest.generated';
 // the SFX/ambience mix.
 const VOICE_BASE_GAIN = 0.9;
 
+// Distance-attenuation curve for a talking NPC (world yards). At or within
+// VOICE_FULL_DIST the line plays at full volume; past it the volume ramps down
+// linearly to silence at VOICE_SILENT_DIST, so a dialogue you walk away from
+// trails off as if heard from farther away. You open a dialog within
+// INTERACT_RANGE (5), so FULL sits just past it and never dips the line on open.
+export const VOICE_FULL_DIST = 6;
+export const VOICE_SILENT_DIST = 22;
+
+export function voiceDistanceGain(
+  dist: number,
+  full = VOICE_FULL_DIST,
+  silent = VOICE_SILENT_DIST,
+): number {
+  if (!(dist > full)) return 1; // also catches NaN / negative: play at full
+  if (dist >= silent) return 0;
+  return (silent - dist) / (silent - full);
+}
+
 class GameVoice {
   private el: HTMLAudioElement | null = null;
   private vol = 0.9; // 0..1, from the settings slider
   private enabled = true;
+  private playGain = 1; // per-line gain passed to play()
+  private distanceGain = 1; // live distance attenuation (1 = at the NPC)
+
+  private applyVolume(): void {
+    if (this.el)
+      this.el.volume = Math.min(1, this.vol * VOICE_BASE_GAIN * this.playGain * this.distanceGain);
+  }
 
   /** Set voice volume (0..1). Safe any time. */
   setVolume(v: number): void {
     this.vol = Math.min(1, Math.max(0, v));
-    if (this.el) this.el.volume = this.vol * VOICE_BASE_GAIN;
+    this.applyVolume();
+  }
+
+  /** Live distance attenuation (0 = out of earshot, 1 = at the NPC) for the current line. */
+  setDistanceGain(g: number): void {
+    this.distanceGain = Math.min(1, Math.max(0, g));
+    this.applyVolume();
+  }
+
+  /** True while a line is actively sounding (used to stop driving the fade once it ends). */
+  isPlaying(): boolean {
+    return !!this.el && !this.el.paused && !this.el.ended;
   }
 
   /** Enable/disable voice-over. Disabling also stops any line in progress. */
@@ -46,10 +82,14 @@ class GameVoice {
     this.stop();
     if (!this.el) this.el = new Audio();
     this.el.src = src;
-    this.el.volume = Math.min(1, this.vol * VOICE_BASE_GAIN * (opts?.gain ?? 1));
+    this.playGain = opts?.gain ?? 1;
+    this.distanceGain = 1; // a fresh line starts at full: you just clicked the NPC, you are close
+    this.applyVolume();
     // Autoplay restrictions / a missing file reject the promise — ignore, the
     // dialogue text is the source of truth and audio is an enhancement.
-    void this.el.play().catch(() => { /* no-op */ });
+    void this.el.play().catch(() => {
+      /* no-op */
+    });
   }
 }
 

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -12,7 +12,7 @@ import {
   nonSelfRepaintDue,
   targetFrameNonSelfIntervalMs,
 } from '../game/ui_tier_knobs';
-import { voice } from '../game/voice';
+import { voice, voiceDistanceGain } from '../game/voice';
 import { castBarState, consumeBarState } from '../render/cast_bar';
 import { CharacterPreview } from '../render/characters';
 import { preloadMechAssets } from '../render/characters/assets';
@@ -878,6 +878,10 @@ export class Hud {
   private pendingChatLinks = new Map<string, string>(); // display "[Name]" -> [[q:id]]/[[i:id]] token
   private questDialogTrap: FocusTrapHandle | null = null;
   private questDialogOpenedAtMs = 0;
+  // The NPC whose voice line is currently sounding, so update() can fade it by
+  // distance as the player walks away. Outlives the dialog window (which closes at
+  // 8) and is cleared once the clip ends. null when no dialogue voice is playing.
+  private voiceNpcId: number | null = null;
   // swing timer: the period is captured from the reset edge (swingTimer jumping
   // up), so the bar tracks real swing speed including haste / ranged weapons.
   private swingPeriod = 0;
@@ -4445,6 +4449,18 @@ export class Hud {
     // chat burst on the fast tier once chat goes quiet.
     if (fastHud) this.chatAnnouncer.flush(now);
 
+    // Fade a talking NPC's voice line by distance as the player walks away, so a
+    // dialogue trails off naturally instead of holding full volume. Per-frame for a
+    // smooth ramp; independent of the dialog window (which closes at 8), so the
+    // voice keeps fading until the clip ends or the player is out of earshot.
+    if (this.voiceNpcId !== null) {
+      if (!voice.isPlaying()) {
+        this.voiceNpcId = null;
+      } else {
+        const vnpc = sim.entities.get(this.voiceNpcId);
+        voice.setDistanceGain(vnpc ? voiceDistanceGain(dist2d(p.pos, vnpc.pos)) : 0);
+      }
+    }
     this.meters.update();
     this.lockpickWindow.repaintIfChanged();
     this.tutorial.update(sim, this.renderer, this.keybinds);
@@ -4813,6 +4829,13 @@ export class Hud {
       if (this.openVendorNpcId !== null) {
         const npc = sim.entities.get(this.openVendorNpcId);
         if (!npc || dist2d(p.pos, npc.pos) > 8) this.closeVendor();
+      }
+      // Close the quest/gossip dialog once the player walks out of talking range
+      // (or the NPC is gone), the same way the vendor window auto-closes above. You
+      // open within INTERACT_RANGE (5), so the wider 8 threshold never fires on open.
+      if (this.openGossipNpcId !== null) {
+        const npc = sim.entities.get(this.openGossipNpcId);
+        if (!npc || dist2d(p.pos, npc.pos) > 8) this.closeQuestDialog();
       }
     }
 
@@ -6427,7 +6450,12 @@ export class Hud {
               performance.now(),
             );
             this.lastVoicedYell = voiced.state;
-            if (voiced.play) voice.play(voiced.state.key, { gain: voicedYellGain(ev.from) });
+            if (voiced.play) {
+              voice.play(voiced.state.key, { gain: voicedYellGain(ev.from) });
+              // A distinct overheard yell, not a dialogue: do not let the per-frame
+              // distance fade attenuate it by a talked-to NPC's position.
+              this.voiceNpcId = null;
+            }
           }
           break;
         }
@@ -7731,6 +7759,7 @@ export class Hud {
     // navigating back from a quest detail or after accept/turn-in, where a
     // re-greeting would be noise.
     voice.play(`greeting__${npc.templateId}`);
+    this.voiceNpcId = npc.id;
     this.renderGossip(npc);
   }
 
@@ -7833,6 +7862,7 @@ export class Hud {
       this.sim.player.name,
     );
     voice.play(state === 'ready' ? `quest__${questId}__complete` : `quest__${questId}__offer`);
+    this.voiceNpcId = npc.id;
     markDialogRoot(el, { labelledBy: 'quest-dialog-title' });
     let html = `<div class="panel-title"><span id="quest-dialog-title">${esc(questTitle(questId))}${this.questSuggestedPlayersHtml(quest.suggestedPlayers)}</span><button type="button" class="x-btn" data-close aria-label="${esc(t('questUi.dialog.close'))}">${svgIcon('close')}</button></div>`;
     if (state === 'available' && quest.minLevel) {

--- a/src/world_api/chat.ts
+++ b/src/world_api/chat.ts
@@ -1,4 +1,4 @@
-import { OVERHEAD_EMOTE_IDS, type OverheadEmoteId } from '../sim/types';
+import type { OverheadEmoteId } from '../sim/types';
 
 export const OVERHEAD_EMOTES = [
   { id: 'wave', label: 'Wave' },
@@ -16,8 +16,13 @@ export const OVERHEAD_EMOTES = [
   { id: 'kneel', label: 'Kneel' },
 ] as const satisfies readonly { id: OverheadEmoteId; label: string }[];
 
+// Sourced from the local OVERHEAD_EMOTES (not sim/types' OVERHEAD_EMOTE_IDS): the
+// IWorld seam imports sim/ for TYPES only, so the runtime id set is derived here
+// instead of value-importing the sim's array.
+const OVERHEAD_EMOTE_ID_SET: ReadonlySet<string> = new Set(OVERHEAD_EMOTES.map((e) => e.id));
+
 export function isOverheadEmoteId(value: unknown): value is OverheadEmoteId {
-  return typeof value === 'string' && (OVERHEAD_EMOTE_IDS as readonly string[]).includes(value);
+  return typeof value === 'string' && OVERHEAD_EMOTE_ID_SET.has(value);
 }
 
 export interface IWorldChat {

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -276,11 +276,13 @@ describe('src/sim architecture invariants', () => {
 // sim import would drag the deterministic engine into the seam), and run no
 // i18n/UI logic (no t()/tSim()/tServer()). Without this scan the facet files'
 // purity is convention-only; a later W6-W10 re-home could add a net/ui import or a
-// t() call to a facet and no gate would redden. This closes that gap. The two
-// blessed value sites are COMMAND_NAMES (world_api.ts) and OVERHEAD_EMOTES +
-// isOverheadEmoteId (chat.ts); string literals are NOT banned (only imports + DOM
-// + i18n calls are), and the one sanctioned runtime sim import is chat.ts pulling
-// OVERHEAD_EMOTE_IDS to back its isOverheadEmoteId guard.
+// t() call to a facet and no gate would redden. This closes that gap. The one
+// blessed value site is COMMAND_NAMES (world_api.ts); string literals are NOT
+// banned (only imports + DOM + i18n calls are). chat.ts's OVERHEAD_EMOTES +
+// isOverheadEmoteId derive their runtime id set from OVERHEAD_EMOTES itself
+// (not sim/types' OVERHEAD_EMOTE_IDS), so there is currently no sanctioned
+// runtime sim import; SANCTIONED_VALUE_SIM_IMPORTS below stays as the escape
+// valve for a future one.
 
 const worldApiEntry = join(repoRoot, 'src', 'world_api.ts');
 const worldApiRoot = join(repoRoot, 'src', 'world_api');
@@ -329,13 +331,20 @@ function runtimeBindings(clause: string): string[] {
     .map((n) => n.split(/\s+as\s+/)[0].trim());
 }
 
-// The ONLY sanctioned runtime sim import on the seam, keyed by repo-relative file:
-// chat.ts pulls OVERHEAD_EMOTE_IDS to back its isOverheadEmoteId guard. Any OTHER
-// value sim import, in chat.ts or any other facet, still reddens the gate, so this
-// is a per-site allowlist, not a blanket file-level exemption.
-const SANCTIONED_VALUE_SIM_IMPORTS: Record<string, ReadonlySet<string>> = {
-  'src/world_api/chat.ts': new Set(['OVERHEAD_EMOTE_IDS']),
-};
+// Any sanctioned runtime sim import on the seam, keyed by repo-relative file
+// (forward-slash form: see posixRel below, since `relative()` yields backslashes
+// on Windows). Currently empty (chat.ts derives its runtime id set from its own
+// OVERHEAD_EMOTES instead of value-importing sim/types' OVERHEAD_EMOTE_IDS); kept
+// as the escape valve for a future legitimate case. Any value sim import not
+// listed here, in any facet, reddens the gate: this is a per-site allowlist, not
+// a blanket file-level exemption.
+const SANCTIONED_VALUE_SIM_IMPORTS: Record<string, ReadonlySet<string>> = {};
+
+// Normalizes a relative() path to forward slashes so the allowlist above (and
+// its keys, always written posix-style) matches on Windows too.
+function posixRel(rel: string): string {
+  return rel.split('\\').join('/');
+}
 
 describe('src/world_api IWorld seam purity invariants', () => {
   it('finds the IWorld seam (world_api.ts + every facet file)', () => {
@@ -366,7 +375,7 @@ describe('src/world_api IWorld seam purity invariants', () => {
     const violations: string[] = [];
     for (const file of worldApiFiles) {
       const rel = relative(repoRoot, file);
-      const allowed = SANCTIONED_VALUE_SIM_IMPORTS[rel] ?? new Set<string>();
+      const allowed = SANCTIONED_VALUE_SIM_IMPORTS[posixRel(rel)] ?? new Set<string>();
       const src = stripComments(readFileSync(file, 'utf8'));
       for (const m of src.matchAll(SEAM_IMPORT_RE)) {
         const [, clause, spec] = m;

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -337,7 +337,9 @@ function runtimeBindings(clause: string): string[] {
 // OVERHEAD_EMOTES instead of value-importing sim/types' OVERHEAD_EMOTE_IDS); kept
 // as the escape valve for a future legitimate case. Any value sim import not
 // listed here, in any facet, reddens the gate: this is a per-site allowlist, not
-// a blanket file-level exemption.
+// a blanket file-level exemption. (The flip side, that chat.ts's local
+// OVERHEAD_EMOTES stays complete against sim/types' OVERHEAD_EMOTE_IDS so the
+// decoupled id set cannot silently drift, is guarded in overhead_emote_parity.test.ts.)
 const SANCTIONED_VALUE_SIM_IMPORTS: Record<string, ReadonlySet<string>> = {};
 
 // Normalizes a relative() path to forward slashes so the allowlist above (and

--- a/tests/overhead_emote_parity.test.ts
+++ b/tests/overhead_emote_parity.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { OVERHEAD_EMOTE_IDS, type OverheadEmoteId } from '../src/sim/types';
+import { isOverheadEmoteId, OVERHEAD_EMOTES } from '../src/world_api/chat';
+
+// The IWorld seam file src/world_api/chat.ts imports sim/ for TYPES only, so its
+// runtime overhead-emote id set is derived from its own OVERHEAD_EMOTES array, not
+// value-imported from sim/types' canonical OVERHEAD_EMOTE_IDS (the seam-purity scan
+// in architecture.test.ts enforces the type-only import). That decoupling is only
+// safe while the two lists stay in lockstep: an id added to OVERHEAD_EMOTE_IDS alone
+// would silently drop out of isOverheadEmoteId and the emote wheel with no failure.
+// These guards lock the two together at compile time and at run time.
+
+// Compile-time: the local array's id union must EQUAL the canonical OverheadEmoteId
+// union. The `satisfies` clause in chat.ts already proves every local id is valid (no
+// extras); this proves the reverse (no missing), so tsc reddens the moment sim/types
+// gains an id that OVERHEAD_EMOTES does not list. Type-only, so it adds no runtime
+// sim import to the seam.
+type Expect<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type LocalOverheadEmoteId = (typeof OVERHEAD_EMOTES)[number]['id'];
+type _OverheadEmoteIdsAreComplete = Expect<Equal<LocalOverheadEmoteId, OverheadEmoteId>>;
+
+describe('overhead emote id parity (world_api/chat.ts vs sim/types)', () => {
+  it('OVERHEAD_EMOTES lists exactly the canonical OVERHEAD_EMOTE_IDS, no drift either way', () => {
+    const local = new Set<string>(OVERHEAD_EMOTES.map((e) => e.id));
+    const canonical = new Set<string>(OVERHEAD_EMOTE_IDS);
+    expect(local).toEqual(canonical);
+  });
+
+  it('isOverheadEmoteId accepts every canonical id and rejects a non-member or non-string', () => {
+    for (const id of OVERHEAD_EMOTE_IDS) expect(isOverheadEmoteId(id)).toBe(true);
+    expect(isOverheadEmoteId('not-an-emote')).toBe(false);
+    expect(isOverheadEmoteId(123)).toBe(false);
+    expect(isOverheadEmoteId(undefined)).toBe(false);
+    expect(isOverheadEmoteId(null)).toBe(false);
+  });
+});

--- a/tests/voice.test.ts
+++ b/tests/voice.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { VOICE_FULL_DIST, VOICE_SILENT_DIST, voiceDistanceGain } from '../src/game/voice';
+
+describe('voiceDistanceGain', () => {
+  it('plays at full volume at or within the full distance', () => {
+    expect(voiceDistanceGain(0)).toBe(1);
+    expect(voiceDistanceGain(VOICE_FULL_DIST - 1)).toBe(1);
+    expect(voiceDistanceGain(VOICE_FULL_DIST)).toBe(1);
+  });
+
+  it('is silent at or beyond the silent distance', () => {
+    expect(voiceDistanceGain(VOICE_SILENT_DIST)).toBe(0);
+    expect(voiceDistanceGain(VOICE_SILENT_DIST + 5)).toBe(0);
+  });
+
+  it('ramps down monotonically between full and silent, reaching ~0.5 at the midpoint', () => {
+    const mid = (VOICE_FULL_DIST + VOICE_SILENT_DIST) / 2;
+    expect(voiceDistanceGain(mid)).toBeCloseTo(0.5, 5);
+    let prev = 1;
+    for (let d = VOICE_FULL_DIST; d <= VOICE_SILENT_DIST; d++) {
+      const g = voiceDistanceGain(d);
+      expect(g).toBeLessThanOrEqual(prev);
+      expect(g).toBeGreaterThanOrEqual(0);
+      prev = g;
+    }
+  });
+
+  it('never dips a line the moment a dialog opens (opened within INTERACT_RANGE 5)', () => {
+    expect(voiceDistanceGain(5)).toBe(1);
+  });
+
+  it('treats NaN or negative distance as full, never a negative volume', () => {
+    expect(voiceDistanceGain(Number.NaN)).toBe(1);
+    expect(voiceDistanceGain(-3)).toBe(1);
+  });
+
+  it('honors custom full/silent bounds', () => {
+    expect(voiceDistanceGain(10, 10, 20)).toBe(1);
+    expect(voiceDistanceGain(20, 10, 20)).toBe(0);
+    expect(voiceDistanceGain(15, 10, 20)).toBeCloseTo(0.5, 5);
+  });
+});


### PR DESCRIPTION
## What

Two small polish touches for leaving an NPC mid-conversation.

- **Quest dialog auto-close.** The quest/gossip dialog now closes once you step
  out of talking range (dist > 8 from the NPC), matching how the vendor and loot
  windows already auto-close, instead of lingering until you click the X. The
  check lives in the per-frame update() right next to the existing vendor/loot
  ones (an earlier attempt sat in a language-change-only path and never fired).
- **Distance-faded NPC voice.** An NPC's voice line now fades by distance while
  it plays: full volume within about 6 yards, ramping to silence by about 22, so
  a dialogue you walk away from trails off naturally. It runs per-frame for a
  smooth ramp and is independent of the dialog window, so the voice keeps fading
  after the window closes until the clip ends. Overheard yells keep their own
  gain and are excluded from the fade.

## Notes

- Adds the pure `voiceDistanceGain()` curve (unit-tested in tests/voice.test.ts)
  plus a distance-gain layer on the voice player that leaves the settings volume
  and per-line gain intact. Purely cosmetic (voice-over is an enhancement; the
  dialogue text stays the source of truth), so it is gameplay-neutral.
- Includes one small pre-existing fix cherry-picked from the target-frame branch
  (c1ae201d): world_api/chat.ts becomes a real type-only sim import, and the
  architecture guard's allowlist lookup is made cross-platform (it silently never
  matched on Windows). Keeps the guard test green on all platforms.

## Testing

- tsc --noEmit clean; biome (changed files) clean.
- New Vitest: voice.test.ts (voiceDistanceGain curve, clamps, monotonicity, and
  the never-dip-on-open behavior).
- Guard tests green: architecture.test.ts, localization_fixes.test.ts.

Generated with Claude Code: https://claude.com/claude-code
