### PR TITLE
fix(gamepad): take no pad input while the window is unfocused

### DIFF
--- a/src/game/gamepad.ts
+++ b/src/game/gamepad.ts
@@ -112,6 +112,14 @@ export class GamepadManager {
     }
   }
 
+  private windowFocused(): boolean {
+    try {
+      return typeof document === 'undefined' || document.hasFocus();
+    } catch {
+      return true;
+    }
+  }
+
   private activePad(): Gamepad | null {
     if (this.index === null || typeof navigator === 'undefined') return null;
     const pad = navigator.getGamepads()[this.index];
@@ -132,6 +140,17 @@ export class GamepadManager {
     };
     const cur: boolean[] = [];
     for (let i = 0; i < STANDARD_BUTTON_COUNT; i++) cur[i] = pressed(i);
+
+    // Match keyboard and mouse, which the browser only delivers to a focused
+    // window: an unfocused window takes no pad input. Consume the button state
+    // without dispatching so a button held across a refocus does not fire a
+    // stale edge on return.
+    if (!this.windowFocused()) {
+      this.input.clearGamepadMove();
+      this.hideCursor();
+      this.prevPressed = cur;
+      return;
+    }
 
     this.checkRumble();
 

--- a/tests/gamepad.test.ts
+++ b/tests/gamepad.test.ts
@@ -65,3 +65,88 @@ describe('GamepadManager', () => {
     expect(onInputEdge).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('GamepadManager window focus', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function setup() {
+    let pad = gamepadWithPressed();
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: { getGamepads: () => [pad] },
+    });
+    const onInputEdge = vi.fn();
+    const onAction = vi.fn();
+    const setGamepadMove = vi.fn();
+    const clearGamepadMove = vi.fn();
+    const input = {
+      applyGamepadLook: vi.fn(),
+      setGamepadMove,
+      clearGamepadMove,
+      triggerGamepadJump: vi.fn(),
+    } as unknown as Input;
+    const callbacks = {
+      onAction,
+      onInputEdge,
+      isPointerMode: () => false,
+    } satisfies GamepadCallbacks;
+    const manager = new GamepadManager(input, new GamepadBindings(), callbacks);
+    (manager as unknown as { index: number | null }).index = 0;
+    return {
+      manager,
+      onInputEdge,
+      onAction,
+      setGamepadMove,
+      clearGamepadMove,
+      setPad: (p: Gamepad) => {
+        pad = p;
+      },
+    };
+  }
+
+  it('takes no pad input while the window is unfocused', () => {
+    const { manager, onInputEdge, onAction, setGamepadMove, clearGamepadMove, setPad } = setup();
+    vi.stubGlobal('document', { hasFocus: () => false });
+
+    manager.poll(1 / 60);
+    setPad(gamepadWithPressed(GP.A));
+    manager.poll(1 / 60);
+
+    expect(onInputEdge).not.toHaveBeenCalled();
+    expect(onAction).not.toHaveBeenCalled();
+    expect(setGamepadMove).not.toHaveBeenCalled();
+    expect(clearGamepadMove).toHaveBeenCalled();
+  });
+
+  it('does not fire a stale edge for a button held across a refocus', () => {
+    const { manager, onInputEdge, setPad } = setup();
+    let focused = false;
+    vi.stubGlobal('document', { hasFocus: () => focused });
+
+    setPad(gamepadWithPressed(GP.A));
+    manager.poll(1 / 60); // pressed while unfocused: consumed, never dispatched
+    focused = true;
+    manager.poll(1 / 60); // still held on refocus: no rising edge
+    expect(onInputEdge).not.toHaveBeenCalled();
+
+    setPad(gamepadWithPressed());
+    manager.poll(1 / 60);
+    setPad(gamepadWithPressed(GP.A));
+    manager.poll(1 / 60); // a fresh press after the refocus dispatches normally
+    expect(onInputEdge).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes movement and edges once the window regains focus', () => {
+    const { manager, onInputEdge, setGamepadMove, setPad } = setup();
+    let focused = false;
+    vi.stubGlobal('document', { hasFocus: () => focused });
+
+    manager.poll(1 / 60);
+    focused = true;
+    setPad(gamepadWithPressed(GP.A));
+    manager.poll(1 / 60);
+
+    expect(onInputEdge).toHaveBeenCalledTimes(1);
+    expect(setGamepadMove).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

The browser only delivers keyboard and mouse input to a focused window, but it keeps reporting gamepad state to a visible, unfocused one (confirmed on Linux+Chrome: with the game side by side with another focused window, the pad kept driving the character). This makes the focus rule uniform across every input method: an unfocused window takes no pad input.

`GamepadManager.poll()` now checks `document.hasFocus()`. While the window is unfocused it clears held stick movement (no more character running off on a held stick), consumes the button state without dispatching (a button held across a refocus does not fire a stale edge on return), and skips camera, edge actions, and rumble. The check is fail-open (no DOM or an exception reads as focused), so a quirky environment can never brick controller input.

Note for reviewers, one deliberate behavior change: playing with the pad while another window has focus no longer works; click the game window to resume, exactly like keyboard and mouse. Rumble is not tracked while unfocused, so on refocus a single vibration fires for any health lost meanwhile.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm test`
  - `npx tsc --noEmit`
  - `npm run build` 

- Manual steps: game and another window side by side (game visible, not
  covered), focus the other window, use the pad: the character no longer moves
  or casts; click back into the game and input resumes immediately, with no
  phantom action from buttons held during the switch.

---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [x] Tested on desktop with an xbox controller

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
