### PR TITLE
fix(combat): no aggro before damage from auto-attack (option and manual toggle)

### DIFF
--- a/src/sim/combat/auto_attack.ts
+++ b/src/sim/combat/auto_attack.ts
@@ -67,8 +67,15 @@ export function startAutoAttack(ctx: SimContext, pid?: number): void {
   const inAutoAttackRange = ranged
     ? d <= ranged.maxRange && d >= (ranged.wand ? 0 : ranged.minRange) && ctx.hasLineOfSight(p, t)
     : d <= MELEE_RANGE;
+  // Engaging pulls the idle target into combat, but ONLY when a swing can
+  // actually happen now: while a cast is in progress the swing loop is paused
+  // (updatePlayerAutoAttack bails on castingAbility), so a mid-cast Attack
+  // press must not aggro an untouched mob (the aggro-before-damage bug). The
+  // toggle still arms autoAttack above; once the cast resolves, the first
+  // landed swing (or the spell's own damage) aggros the target legitimately.
   if (
     inAutoAttackRange &&
+    !p.castingAbility &&
     t.kind === 'mob' &&
     t.hostile &&
     t.ownerId === null &&

--- a/src/ui/attack_on_ability.ts
+++ b/src/ui/attack_on_ability.ts
@@ -92,3 +92,17 @@ export function abilityStartsAutoAttack(effects: AbilityEffect[]): boolean {
 export function hasAutoAttackTarget(target: Entity | null | undefined): boolean {
   return !!target && !target.dead && target.hostile;
 }
+
+/**
+ * Whether the auto-attack engage must WAIT for the cast to finish instead of
+ * firing at cast start. Starting auto-attack aggros the target immediately
+ * (sim startAutoAttack: aggroMob + threat + combat), so engaging at the START
+ * of a timed cast (Smite, Fireball, ...) pulled the mob before any damage
+ * existed, an aggro-before-damage bug. A timed cast therefore defers the
+ * engage to its successful castStop (the moment its damage lands, when aggro
+ * is legitimate); an instant ability keeps engaging at once, since its damage
+ * applies in the same tick anyway.
+ */
+export function deferAutoAttackUntilCastEnd(castTime: number): boolean {
+  return castTime > 0;
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -110,7 +110,11 @@ import {
   ITEM_ICON_PREFIX,
 } from './action_bar_view';
 import { ArenaWindow } from './arena_window';
-import { abilityStartsAutoAttack, hasAutoAttackTarget } from './attack_on_ability';
+import {
+  abilityStartsAutoAttack,
+  deferAutoAttackUntilCastEnd,
+  hasAutoAttackTarget,
+} from './attack_on_ability';
 import { type AuraEffectInput, auraEffectDescriptor } from './aura_effect';
 import { AurasPainter, type AurasPainterDeps } from './auras_painter';
 import { type AurasDeps, createAurasView } from './auras_view';
@@ -2572,6 +2576,11 @@ export class Hud {
       repaintPortrait: () => this.drawTargetPortrait(),
     },
   );
+  // Deferred "Auto-Attack on Ability Use" for TIMED casts: set by castSlot when
+  // the QoL would engage but the ability has a cast time, consumed by the
+  // castStop event (engage on success, drop on interrupt), so starting a Smite
+  // never aggros the target before its damage lands.
+  private pendingAutoAttackOnCastEnd = false;
   // The party frames are N further instances of the unit_frame family, one per
   // member, behind a keyed node pool that replaces the old per-rebuild innerHTML wipe
   // + click/contextmenu re-attach. The pool owns #party-frames; updatePartyFrames
@@ -3832,7 +3841,16 @@ export class Hud {
             abilityStartsAutoAttack(resolved.effects) &&
             hasAutoAttackTarget(target)
           ) {
-            this.sim.startAutoAttack();
+            // A TIMED cast must not engage yet: startAutoAttack aggros the target
+            // immediately, so engaging at cast start pulled the mob before any
+            // damage existed (the aggro-before-damage bug). Defer to the
+            // successful castStop (handled in the events switch); instants keep
+            // engaging at once since their damage lands this same tick.
+            if (deferAutoAttackUntilCastEnd(resolved.castTime)) {
+              this.pendingAutoAttackOnCastEnd = true;
+            } else {
+              this.sim.startAutoAttack();
+            }
           }
         }
         this.flashActionSlot(barSlot);
@@ -6971,6 +6989,19 @@ export class Hud {
         case 'castStart':
           break; // cast-loop SFX is spatial now (see playEventSfx)
         case 'castStop':
+          // Deferred "Auto-Attack on Ability Use" (timed casts): engage only when
+          // the player's own cast COMPLETES, so the aggro happens as the damage
+          // lands, never at cast start (the aggro-before-damage bug). An
+          // interrupted/canceled cast just drops the pending engage; the target
+          // is re-validated since the cast itself may have killed or cleared it.
+          if (ev.entityId === sim.playerId && this.pendingAutoAttackOnCastEnd) {
+            this.pendingAutoAttackOnCastEnd = false;
+            if (ev.success) {
+              const castTid = sim.player.targetId;
+              const castTarget = castTid !== null ? (sim.entities.get(castTid) ?? null) : null;
+              if (hasAutoAttackTarget(castTarget)) this.sim.startAutoAttack();
+            }
+          }
           break;
         case 'aura': {
           const tgt = sim.entities.get(ev.targetId);

--- a/tests/attack_on_ability.test.ts
+++ b/tests/attack_on_ability.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { ABILITIES } from '../src/sim/data';
 import type { AbilityEffect, Entity } from '../src/sim/types';
-import { abilityStartsAutoAttack, hasAutoAttackTarget } from '../src/ui/attack_on_ability';
+import {
+  abilityStartsAutoAttack,
+  deferAutoAttackUntilCastEnd,
+  hasAutoAttackTarget,
+} from '../src/ui/attack_on_ability';
 
 // Resolve a real ability's rank-1 effects by id, so the test pins behavior against
 // the actual content tables (not hand-mocked shapes that could drift).
@@ -85,5 +89,20 @@ describe('hasAutoAttackTarget', () => {
 
   it('is false for a non-hostile target (friendly NPC / player)', () => {
     expect(hasAutoAttackTarget(target({ hostile: false }))).toBe(false);
+  });
+});
+
+describe('deferAutoAttackUntilCastEnd (the aggro-before-damage bug)', () => {
+  it('defers for a timed cast so starting a Smite cannot pull the mob early', () => {
+    // any positive cast time waits for the successful castStop
+    expect(deferAutoAttackUntilCastEnd(2.5)).toBe(true);
+    expect(deferAutoAttackUntilCastEnd(0.1)).toBe(true);
+    // a real timed spell from content: the priest's smite carries a cast time
+    const smite = ABILITIES.smite;
+    if (smite) expect(deferAutoAttackUntilCastEnd(smite.castTime)).toBe(true);
+  });
+
+  it('engages immediately for instants (their damage lands the same tick)', () => {
+    expect(deferAutoAttackUntilCastEnd(0)).toBe(false);
   });
 });

--- a/tests/combat_auto_attack.test.ts
+++ b/tests/combat_auto_attack.test.ts
@@ -260,3 +260,26 @@ describe('auto_attack determinism', () => {
     expect(a).toEqual(b); // byte-identical across the replay
   });
 });
+
+describe('startAutoAttack while casting (the aggro-before-damage bug)', () => {
+  it('a mid-cast Attack press queues the swing but does NOT aggro the untouched target', () => {
+    const { sim, p } = makeSim('priest', 10);
+    const mob = spawnDummy(sim, p, 5, 2);
+    sim.castAbility('smite', p.id); // timed cast in progress
+    expect(p.castingAbility).toBe('smite');
+    startAutoAttack(sim.ctx, p.id);
+    // the toggle still arms white swings for after the cast...
+    expect(p.autoAttack).toBe(true);
+    // ...but no damage has landed, so the idle mob must not come running
+    expect(mob.aiState).toBe('idle');
+    expect(mob.aggroTargetId).toBe(null);
+  });
+
+  it('outside a cast the toggle still pulls the idle target at once (unchanged)', () => {
+    const { sim, p } = makeSim('warrior', 10);
+    const mob = spawnDummy(sim, p, 5, 2);
+    startAutoAttack(sim.ctx, p.id);
+    expect(mob.aiState).not.toBe('idle');
+    expect(p.inCombat).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Two companion fixes for the same player-reported bug: with a TIMED spell
(Smite, Fireball, ...), the target mob charged the caster BEFORE any damage
existed. Aggro should come from the first thing that actually lands, the
spell's own damage or the first white swing, exactly like classic.

- **"Auto-Attack on Ability Use" engaged at cast start.** With the QoL option
  on, pressing a timed offensive spell called startAutoAttack immediately,
  and startAutoAttack aggros the target at once (aggroMob + threat + combat).
  The engage is now DEFERRED for any ability with a cast time: castSlot arms
  a pending flag instead, and the player's own castStop event consumes it,
  engaging on success (the moment the damage lands, re-validating the target
  since the cast may have killed it) and dropping it on interrupt/cancel.
  Instants keep engaging at once, since their damage applies the same tick.
- **A manual mid-cast Attack press did the same.** Pressing the Attack toggle
  while casting also aggroed the untouched target, even though the swing loop
  is paused during a cast (updatePlayerAutoAttack bails on castingAbility),
  so no damage could exist yet. startAutoAttack's pull-idle-target block now
  also requires no cast in progress; the toggle still arms autoAttack, and
  white swings resume after the cast.

## How

- HUD fix: pure deferAutoAttackUntilCastEnd(castTime) in attack_on_ability.ts
  plus the pending-flag wiring in Hud.castSlot / the castStop event arm. No
  sim change on this half.
- Sim fix: one added condition (!p.castingAbility) on startAutoAttack's
  aggro block in combat/auto_attack.ts, with the rationale commented.

## Testing

- Test-first on both halves: deferAutoAttackUntilCastEnd cases (timed defers,
  including the real smite cast time from content; instant engages) in
  tests/attack_on_ability.test.ts, and the red-then-green mid-cast case plus
  an unchanged-behavior pin (a non-casting Attack press still pulls at once)
  in tests/combat_auto_attack.test.ts.
- Parity gate green: no recorded scenario starts auto-attack mid-cast, so the
  shared rng draw order is untouched. Full sweep on this branch: 245 tests
  across parity / architecture / casting / auto-attack / i18n guards.

Generated with Claude Code: https://claude.com/claude-code
