### PR TITLE
fix(sim): make steep mountains and the world rim genuinely unclimbable

### DIFF
--- a/src/render/critters.ts
+++ b/src/render/critters.ts
@@ -7,10 +7,8 @@
 
 import * as THREE from 'three';
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
-import {
-  DUNGEON_X_THRESHOLD, WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_Z,
-} from '../sim/data';
-import { terrainHeight, WATER_LEVEL } from '../sim/world';
+import { DUNGEON_X_THRESHOLD, WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_Z } from '../sim/data';
+import { terrainHeight, terrainSteepnessAt, WATER_LEVEL } from '../sim/world';
 import { GFX } from './gfx';
 
 export interface CritterField {
@@ -23,6 +21,9 @@ const SPAWN_MIN = 16; // relocate ring around the player (min..max yd)
 const SPAWN_MAX = 30;
 const FLEE_DIST = 6; // critters bolt when the player gets this close
 const EDGE = 8; // keep clear of the world edges
+// Same rise/run limit the sim's movement uses (MAX_CLIMB_SLOPE): wildlife stays
+// off the unclimbable mountain walls and the world rim, like everything else.
+const MAX_WALK_SLOPE = 1.5;
 
 // The Eastbrook Vale / Mirefen Marsh boundary runs along the causeway at z=180.
 // Cheerful overworld critters (rabbits/squirrels/songbirds) thin out as the dry
@@ -44,7 +45,8 @@ export function causewayPopScale(pz: number): number {
 function mulberry32(seed: number): () => number {
   let a = seed >>> 0;
   return () => {
-    a |= 0; a = (a + 0x6d2b79f5) | 0;
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
     let t = Math.imul(a ^ (a >>> 15), 1 | a);
     t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
     return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
@@ -56,41 +58,58 @@ type Species = 'rabbit' | 'squirrel' | 'bird';
 // Build one merged body per species out of primitives, feet resting at y=0.
 function buildSpeciesGeo(species: Species): THREE.BufferGeometry {
   const parts: THREE.BufferGeometry[] = [];
-  const sphere = (r: number, sx: number, sy: number, sz: number, x: number, y: number, z: number) => {
+  const sphere = (
+    r: number,
+    sx: number,
+    sy: number,
+    sz: number,
+    x: number,
+    y: number,
+    z: number,
+  ) => {
     const g = new THREE.SphereGeometry(r, 8, 6);
-    g.scale(sx, sy, sz); g.translate(x, y, z); parts.push(g);
+    g.scale(sx, sy, sz);
+    g.translate(x, y, z);
+    parts.push(g);
   };
   if (species === 'bird') {
-    sphere(0.10, 1, 0.9, 1.4, 0, 0.12, 0); // body
-    sphere(0.07, 1, 1, 1, 0, 0.20, 0.10); // head
+    sphere(0.1, 1, 0.9, 1.4, 0, 0.12, 0); // body
+    sphere(0.07, 1, 1, 1, 0, 0.2, 0.1); // head
     const beak = new THREE.ConeGeometry(0.03, 0.08, 5);
-    beak.rotateX(Math.PI / 2); beak.translate(0, 0.20, 0.18); parts.push(beak);
+    beak.rotateX(Math.PI / 2);
+    beak.translate(0, 0.2, 0.18);
+    parts.push(beak);
     for (const s of [-1, 1]) sphere(0.07, 1.4, 0.25, 0.8, s * 0.09, 0.13, 0); // wings
   } else {
     const big = species === 'rabbit';
     sphere(0.18, 1, 0.9, 1.3, 0, 0.16, 0); // body
     sphere(0.12, 1, 1, 1, 0, 0.26, 0.18); // head
     if (big) {
-      for (const s of [-1, 1]) { // upright ears
+      for (const s of [-1, 1]) {
+        // upright ears
         const ear = new THREE.BoxGeometry(0.04, 0.18, 0.03);
-        ear.translate(s * 0.05, 0.40, 0.18); parts.push(ear);
+        ear.translate(s * 0.05, 0.4, 0.18);
+        parts.push(ear);
       }
       sphere(0.06, 1, 1, 1, 0, 0.16, -0.18); // cottontail
     } else {
-      sphere(0.13, 0.7, 1.5, 0.6, 0, 0.30, -0.20); // bushy squirrel tail
+      sphere(0.13, 0.7, 1.5, 0.6, 0, 0.3, -0.2); // bushy squirrel tail
     }
   }
   return mergeGeometries(parts.map((p) => p.toNonIndexed())) ?? parts[0];
 }
 
 const TINT: Record<Species, number> = {
-  rabbit: 0x9a8166, squirrel: 0xa05a30, bird: 0x6b8fb5,
+  rabbit: 0x9a8166,
+  squirrel: 0xa05a30,
+  bird: 0x6b8fb5,
 };
 
 interface Critter {
   mesh: THREE.Mesh;
   species: Species;
-  x: number; z: number;
+  x: number;
+  z: number;
   heading: number; // radians
   moving: boolean;
   speed: number;
@@ -111,7 +130,9 @@ export function buildCritters(seed: number): CritterField {
     bird: buildSpeciesGeo('bird'),
   };
   const mats: Record<Species, THREE.Material> = {
-    rabbit: matFor('rabbit'), squirrel: matFor('squirrel'), bird: matFor('bird'),
+    rabbit: matFor('rabbit'),
+    squirrel: matFor('squirrel'),
+    bird: matFor('bird'),
   };
   function matFor(s: Species): THREE.Material {
     const opts = { color: TINT[s], roughness: 0.85, metalness: 0 };
@@ -133,8 +154,15 @@ export function buildCritters(seed: number): CritterField {
     mesh.visible = false;
     group.add(mesh);
     critters.push({
-      mesh, species, x: 0, z: 0, heading: rng() * Math.PI * 2,
-      moving: false, speed: 0, hopPhase: 0, turnT: 0,
+      mesh,
+      species,
+      x: 0,
+      z: 0,
+      heading: rng() * Math.PI * 2,
+      moving: false,
+      speed: 0,
+      hopPhase: 0,
+      turnT: 0,
       baseY: species === 'bird' ? 0.25 + rng() * 0.4 : 0,
     });
   }
@@ -143,6 +171,7 @@ export function buildCritters(seed: number): CritterField {
     if (Math.abs(x) > WORLD_MAX_X - EDGE) return false;
     if (z < WORLD_MIN_Z + EDGE || z > WORLD_MAX_Z - EDGE) return false;
     if (x > DUNGEON_X_THRESHOLD - 24) return false;
+    if (terrainSteepnessAt(x, z, seed) > MAX_WALK_SLOPE) return false;
     return terrainHeight(x, z, seed) > WATER_LEVEL + 0.8;
   };
 
@@ -153,13 +182,18 @@ export function buildCritters(seed: number): CritterField {
       const x = px + Math.cos(ang) * d;
       const z = pz + Math.sin(ang) * d;
       if (validGround(x, z)) {
-        c.x = x; c.z = z; c.heading = rng() * Math.PI * 2;
-        c.turnT = 0.5 + rng() * 2; c.moving = false;
+        c.x = x;
+        c.z = z;
+        c.heading = rng() * Math.PI * 2;
+        c.turnT = 0.5 + rng() * 2;
+        c.moving = false;
         return;
       }
     }
     // no valid spot this frame — hide and retry next tick
-    c.x = px; c.z = pz; c.mesh.visible = false;
+    c.x = px;
+    c.z = pz;
+    c.mesh.visible = false;
   };
 
   return {
@@ -183,7 +217,8 @@ export function buildCritters(seed: number): CritterField {
           if (c.mesh.visible) c.mesh.visible = false;
           continue;
         }
-        const dx = c.x - px, dz = c.z - pz;
+        const dx = c.x - px,
+          dz = c.z - pz;
         const dist = Math.hypot(dx, dz);
         if (dist > CULL_RADIUS || !validGround(c.x, c.z)) {
           relocate(c, px, pz);
@@ -208,16 +243,28 @@ export function buildCritters(seed: number): CritterField {
         const baseSpeed = c.species === 'bird' ? 2.4 : 1.5;
         c.speed = c.moving ? (fleeing ? baseSpeed * 2.4 : baseSpeed) : 0;
         if (c.speed > 0) {
-          c.x += Math.cos(c.heading) * c.speed * dt;
-          c.z += Math.sin(c.heading) * c.speed * dt;
-          c.hopPhase += dt * (c.species === 'bird' ? 18 : 9);
+          const nx = c.x + Math.cos(c.heading) * c.speed * dt;
+          const nz = c.z + Math.sin(c.heading) * c.speed * dt;
+          if (validGround(nx, nz)) {
+            c.x = nx;
+            c.z = nz;
+            c.hopPhase += dt * (c.species === 'bird' ? 18 : 9);
+          } else {
+            // wall, water, or the world edge ahead: turn back instead of
+            // hopping up a face nothing can walk
+            c.heading += Math.PI + (rng() - 0.5);
+            c.turnT = 0.4 + rng();
+          }
         }
 
         const groundY = terrainHeight(c.x, c.z, seed);
         // rabbits/squirrels hop (sin arc while moving); birds bob in place
-        const motion = c.species === 'bird'
-          ? Math.sin(c.hopPhase) * 0.06
-          : (c.speed > 0 ? Math.abs(Math.sin(c.hopPhase)) * 0.16 : 0);
+        const motion =
+          c.species === 'bird'
+            ? Math.sin(c.hopPhase) * 0.06
+            : c.speed > 0
+              ? Math.abs(Math.sin(c.hopPhase)) * 0.16
+              : 0;
         c.mesh.position.set(c.x, groundY + c.baseY + motion, c.z);
         c.mesh.rotation.y = -c.heading + Math.PI / 2;
         c.mesh.visible = true;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -310,7 +310,13 @@ import {
   virtualLevel,
   xpToReachLevel,
 } from './types';
-import { groundHeight, WATER_LEVEL } from './world';
+import {
+  groundHeight,
+  nearSteepWalls,
+  terrainDownhill,
+  terrainSteepnessAt,
+  WATER_LEVEL,
+} from './world';
 
 // TRIVIAL_LEVEL_GAP moved to mob/targeting.ts (used only by isTrivialTo).
 // CORPSE_DURATION moved to combat/damage.ts (C1; used only by the death path).
@@ -411,7 +417,15 @@ const DELVE_COMPANION_LEVEL_PCT = [0, 0.5, 0.75, 1.0]; // index = rank
 // re-exported from there so external importers (src/ui/sim_i18n.ts, tests) are unchanged.
 export { DELVE_IMPLEMENTED_AFFIXES, DELVE_MODULE_NAMES } from './delves/runs';
 
-const MAX_CLIMB_SLOPE = PLAYER_MAX_CLIMB_SLOPE; // rise/run above which a ground move is blocked (cliffs, world rim)
+// Rise/run above which ground is unwalkable (cliffs, mountain walls, the world
+// rim). Uphill steps are blocked both along the step direction AND by the true
+// terrain steepness at the destination (terrainSteepness), so a diagonal
+// switchback cannot beat the limit; airborne movement is gated the same way so
+// jump-spam cannot climb a face; and a player standing on ground steeper than
+// this slides downhill (STEEP_SLIDE_SPEED) and cannot jump until footing is
+// walkable again.
+const MAX_CLIMB_SLOPE = PLAYER_MAX_CLIMB_SLOPE;
+const STEEP_SLIDE_SPEED = RUN_SPEED; // yd/s a player skids downhill off unwalkable ground
 
 // How far a mob pulls same-family neighbours into a fight ("social aggro").
 // Murlocs (the clustered water mobs players call "frogs") used to pull too much,
@@ -2714,7 +2728,13 @@ export class Sim {
     const h0 = groundHeight(p.pos.x, p.pos.z, this.cfg.seed);
     const h1 = groundHeight(nx, nz, this.cfg.seed);
     if (h1 < WATER_LEVEL - SWIM_DEPTH) return done(false);
-    if (h1 > h0 && (h1 - h0) / step > MAX_CLIMB_SLOPE) return done(false);
+    if (
+      h1 > h0 &&
+      ((h1 - h0) / step > MAX_CLIMB_SLOPE ||
+        terrainSteepnessAt(nx, nz, this.cfg.seed) > MAX_CLIMB_SLOPE)
+    ) {
+      return done(false);
+    }
     const resolved = this.resolveMove(p.pos.x, p.pos.z, nx, nz, BODY_RADIUS, p);
     p.pos.x = resolved.x;
     p.pos.z = resolved.z;
@@ -2776,7 +2796,14 @@ export class Sim {
     const h0 = groundHeight(p.pos.x, p.pos.z, this.cfg.seed);
     const h1 = groundHeight(nx, nz, this.cfg.seed);
     if (h1 < WATER_LEVEL - SWIM_DEPTH) return true; // don't trail into deep water
-    if (h1 > h0 && step > 1e-5 && (h1 - h0) / step > MAX_CLIMB_SLOPE) return true; // wall/cliff
+    if (
+      h1 > h0 &&
+      step > 1e-5 &&
+      ((h1 - h0) / step > MAX_CLIMB_SLOPE ||
+        terrainSteepnessAt(nx, nz, this.cfg.seed) > MAX_CLIMB_SLOPE)
+    ) {
+      return true; // wall/cliff
+    }
     const resolved = this.resolveMove(p.pos.x, p.pos.z, nx, nz, BODY_RADIUS, p);
     p.pos.x = resolved.x;
     p.pos.z = resolved.z;
@@ -2824,8 +2851,13 @@ export class Sim {
     if (wantsMove && p.sitting) this.standUp(p);
 
     const hasMoveInput = mx !== 0 || mz !== 0;
-    const moving = hasMoveInput && !isRooted(p);
     const swimming = this.isSwimming(p);
+    // Standing on unwalkably steep ground: no control, no jump, slide downhill.
+    const steepGround =
+      p.onGround &&
+      !swimming &&
+      terrainSteepnessAt(p.pos.x, p.pos.z, this.cfg.seed) > MAX_CLIMB_SLOPE;
+    const moving = hasMoveInput && !isRooted(p) && !steepGround;
     let wishX = 0,
       wishZ = 0,
       wishSpeed = 0;
@@ -2854,20 +2886,46 @@ export class Sim {
     }
 
     const movingOnGround = moving && (p.onGround || swimming);
-    if (movingOnGround || (!p.onGround && (p.vx !== 0 || p.vz !== 0))) {
-      const stepX = movingOnGround ? wishX * wishSpeed : p.vx;
-      const stepZ = movingOnGround ? wishZ * wishSpeed : p.vz;
+    const slide = steepGround ? terrainDownhill(p.pos.x, p.pos.z, this.cfg.seed) : null;
+    if (slide || movingOnGround || (!p.onGround && (p.vx !== 0 || p.vz !== 0))) {
+      if (slide && p.castingAbility) this.cancelCast(p);
+      const stepX = slide ? slide.x * STEEP_SLIDE_SPEED : movingOnGround ? wishX * wishSpeed : p.vx;
+      const stepZ = slide ? slide.z * STEEP_SLIDE_SPEED : movingOnGround ? wishZ * wishSpeed : p.vz;
       let nx = p.pos.x + stepX * DT;
       let nz = p.pos.z + stepZ * DT;
-      // cliffs and the world rim are walls, not ramps
+      // cliffs, steep mountainsides, and the world rim are walls, not ramps:
+      // an uphill step is blocked when the step itself is too steep OR when it
+      // lands on ground whose true gradient is unwalkable (so approaching at an
+      // angle cannot cheat the limit)
       if (p.onGround && !swimming) {
         const h0 = groundHeight(p.pos.x, p.pos.z, this.cfg.seed);
         const h1 = groundHeight(nx, nz, this.cfg.seed);
         const run = Math.hypot(nx - p.pos.x, nz - p.pos.z);
-        if (h1 > h0 && run > 1e-5 && (h1 - h0) / run > MAX_CLIMB_SLOPE) {
+        if (
+          h1 > h0 &&
+          run > 1e-5 &&
+          ((h1 - h0) / run > MAX_CLIMB_SLOPE ||
+            terrainSteepnessAt(nx, nz, this.cfg.seed) > MAX_CLIMB_SLOPE)
+        ) {
           nx = p.pos.x;
           nz = p.pos.z;
-          if (!p.onGround) {
+        }
+      } else if (!p.onGround) {
+        // Airborne, the same wall rule applies: terrain rising above the body
+        // that could not be walked up cannot be jumped into either. The player
+        // drops at the base of the face instead of beaching partway up it.
+        const h1 = groundHeight(nx, nz, this.cfg.seed);
+        if (h1 > p.pos.y) {
+          const h0 = groundHeight(p.pos.x, p.pos.z, this.cfg.seed);
+          const run = Math.hypot(nx - p.pos.x, nz - p.pos.z);
+          if (
+            h1 > h0 &&
+            run > 1e-5 &&
+            ((h1 - h0) / run > MAX_CLIMB_SLOPE ||
+              terrainSteepnessAt(nx, nz, this.cfg.seed) > MAX_CLIMB_SLOPE)
+          ) {
+            nx = p.pos.x;
+            nz = p.pos.z;
             p.vx = 0;
             p.vz = 0;
           }
@@ -2909,7 +2967,7 @@ export class Sim {
       }
       return;
     }
-    if (inp.jump && p.onGround && !isRooted(p)) {
+    if (inp.jump && p.onGround && !isRooted(p) && !steepGround) {
       p.vy = JUMP_VELOCITY * this.jumpMult(p);
       p.vx = wishX * wishSpeed;
       p.vz = wishZ * wishSpeed;
@@ -3224,7 +3282,13 @@ export class Sim {
       const h0 = groundHeight(cx, cz, this.cfg.seed);
       const h1 = groundHeight(nx, nz, this.cfg.seed);
       if (h1 < WATER_LEVEL - SWIM_DEPTH) break; // would land in deep water
-      if (h1 > h0 && (h1 - h0) / adv > MAX_CLIMB_SLOPE) break; // would slam into a cliff
+      if (
+        h1 > h0 &&
+        ((h1 - h0) / adv > MAX_CLIMB_SLOPE ||
+          terrainSteepnessAt(nx, nz, this.cfg.seed) > MAX_CLIMB_SLOPE)
+      ) {
+        break; // would slam into a cliff
+      }
       cx = nx;
       cz = nz;
       moved += adv;
@@ -3921,12 +3985,26 @@ export class Sim {
     let bestX = e.pos.x,
       bestZ = e.pos.z,
       bestProgress = 1e-3;
+    // Swimmers ride the water surface, so slope checks clamp submerged ground
+    // to the waterline (a sloped lake bed is not a wall; see pathfind rideHeight).
+    const ride = (h: number): number => (canSwim && h < WATER_LEVEL ? WATER_LEVEL : h);
+    let h0 = Number.NaN; // lazily sampled: only steep cells pay for heights
     for (const off of MOVE_SLIDE_FAN) {
       const a = desired + off;
       const nx = e.pos.x + Math.sin(a) * step;
       const nz = e.pos.z + Math.cos(a) * step;
       // landlocked creatures stop at the waterline instead of walking under it
       if (!canSwim && groundHeight(nx, nz, this.cfg.seed) < WATER_LEVEL - SWIM_DEPTH) continue;
+      // Mobs, pets, and feared players obey the wall rule too: no uphill step
+      // onto unwalkably steep ground. Screened to the wall bands so the hot
+      // open-world fan pays nothing; inside a band the memoized cell steepness
+      // screens next, and only actual wall cells pay for exact heights. This
+      // is a NEW gate for these movers, so the finer per-step cliff check
+      // players get is not replicated here.
+      if (nearSteepWalls(nx, nz) && terrainSteepnessAt(nx, nz, this.cfg.seed) > MAX_CLIMB_SLOPE) {
+        if (Number.isNaN(h0)) h0 = ride(groundHeight(e.pos.x, e.pos.z, this.cfg.seed));
+        if (ride(groundHeight(nx, nz, this.cfg.seed)) > h0) continue;
+      }
       const r = this.resolveMovePoint(nx, nz, BODY_RADIUS, e);
       const progress = d - Math.hypot(r.x - dest.x, r.z - dest.z);
       if (progress > bestProgress) {

--- a/src/sim/world.ts
+++ b/src/sim/world.ts
@@ -1,8 +1,15 @@
-import { fbm2, hash2 } from './rng';
 import {
-  CAMPS, DUNGEON_FLOOR_Y, DUNGEON_X_THRESHOLD, ROADS, WORLD_MAX_X, WORLD_MAX_Z,
-  WORLD_MIN_X, WORLD_MIN_Z, ZONES,
+  CAMPS,
+  DUNGEON_FLOOR_Y,
+  DUNGEON_X_THRESHOLD,
+  ROADS,
+  WORLD_MAX_X,
+  WORLD_MAX_Z,
+  WORLD_MIN_X,
+  WORLD_MIN_Z,
+  ZONES,
 } from './data';
+import { fbm2, hash2 } from './rng';
 import type { BiomeId } from './types';
 
 // Terrain is a pure function of (x, z, seed): both the sim (ground clamping)
@@ -30,8 +37,12 @@ const ZONE_RIDGES: { z: number; passX: number }[] = [];
 for (let i = 0; i + 1 < ZONES.length; i++) {
   ZONE_RIDGES.push({ z: ZONES[i].zMax, passX: 0 });
 }
-const RIDGE_HEIGHT = 22;
-const RIDGE_SIGMA = 18; // gaussian width of the wall
+// Tall and narrow on purpose: every crossing outside the road pass must be
+// steeper than the movement climb limit (rise/run 1.5, see sim.ts
+// MAX_CLIMB_SLOPE) so the walls are genuinely impassable, not scenery.
+// tests/terrain_walls.test.ts guards this.
+const RIDGE_HEIGHT = 40;
+const RIDGE_SIGMA = 10; // gaussian width of the wall
 const PASS_HALF_WIDTH = 10; // flat opening around the road
 const PASS_SHOULDER = 34; // ...rising to full wall by this far from the pass
 
@@ -60,16 +71,16 @@ export function mirefenImpactCraterOffset(x: number, z: number): number {
   if (d >= MIREFEN_IMPACT_CRATER.radius) return 0;
 
   const bowlT = d / MIREFEN_IMPACT_CRATER.bowlRadius;
-  const bowl = d < MIREFEN_IMPACT_CRATER.bowlRadius
-    ? -MIREFEN_IMPACT_CRATER.depth * (1 - smoothstep(0, 1, bowlT))
-    : 0;
+  const bowl =
+    d < MIREFEN_IMPACT_CRATER.bowlRadius
+      ? -MIREFEN_IMPACT_CRATER.depth * (1 - smoothstep(0, 1, bowlT))
+      : 0;
 
   const rimStart = MIREFEN_IMPACT_CRATER.bowlRadius * 0.82;
   if (d <= rimStart) return bowl;
   const rimT = (d - rimStart) / (MIREFEN_IMPACT_CRATER.radius - rimStart);
-  const rim = MIREFEN_IMPACT_CRATER.rimHeight
-    * smoothstep(0, 0.35, rimT)
-    * (1 - smoothstep(0.72, 1, rimT));
+  const rim =
+    MIREFEN_IMPACT_CRATER.rimHeight * smoothstep(0, 0.35, rimT) * (1 - smoothstep(0.72, 1, rimT));
   return bowl + rim;
 }
 
@@ -90,11 +101,13 @@ function shapeAt(z: number): { hill: number; base: number } {
 
 function baseHeight(x: number, z: number, seed: number): number {
   const shape = shapeAt(z);
-  let h = (fbm2(x * HILL_SCALE + 100, z * HILL_SCALE + 100, seed, 4) - 0.5) * shape.hill + shape.base;
+  let h =
+    (fbm2(x * HILL_SCALE + 100, z * HILL_SCALE + 100, seed, 4) - 0.5) * shape.hill + shape.base;
   h += (fbm2(x * DETAIL_SCALE, z * DETAIL_SCALE, seed + 7, 2) - 0.5) * 2.2;
   // Flatten each zone's hub settlement into a plateau
   for (const zone of ZONES) {
-    const dx = x - zone.hub.x, dz = z - zone.hub.z;
+    const dx = x - zone.hub.x,
+      dz = z - zone.hub.z;
     const dHub = Math.sqrt(dx * dx + dz * dz);
     if (dHub < zone.hub.radius * 1.6) {
       const blend = smoothstep(zone.hub.radius * 0.7, zone.hub.radius * 1.6, dHub);
@@ -128,7 +141,8 @@ export function terrainHeight(x: number, z: number, seed: number): number {
 
   // Flatten each camp a little so mobs don't stand on cliffs
   for (const camp of CAMPS) {
-    const dx = x - camp.center.x, dz = z - camp.center.z;
+    const dx = x - camp.center.x,
+      dz = z - camp.center.z;
     const d = Math.sqrt(dx * dx + dz * dz);
     if (d < camp.radius * 1.8) {
       const ch = baseHeight(camp.center.x, camp.center.z, seed);
@@ -143,20 +157,98 @@ export function terrainHeight(x: number, z: number, seed: number): number {
     if (dz < RIDGE_SIGMA * 3) {
       const profile = Math.exp(-(dz * dz) / (2 * RIDGE_SIGMA * RIDGE_SIGMA));
       const pass = smoothstep(PASS_HALF_WIDTH, PASS_SHOULDER, Math.abs(x - ridge.passX));
-      // jagged crest so the wall reads as mountains, not a berm
-      const crest = 1 + (fbm2(x * 0.03, ridge.z * 0.03, seed + 19, 2) - 0.5) * 0.7;
+      // jagged crest so the wall reads as mountains, not a berm (variance kept
+      // tight so the lowest saddle still beats the climb limit)
+      const crest = 1 + (fbm2(x * 0.03, ridge.z * 0.03, seed + 19, 2) - 0.5) * 0.4;
       h += RIDGE_HEIGHT * crest * profile * pass;
     }
   }
 
-  // Raise the world rim so the player naturally stays in bounds
-  const rimX = smoothstep(WORLD_MAX_X - 30, WORLD_MAX_X, Math.abs(x));
-  const rimS = smoothstep(WORLD_MIN_Z + 30, WORLD_MIN_Z, z);
-  const rimN = smoothstep(WORLD_MAX_Z - 30, WORLD_MAX_Z, z);
+  // Raise the world rim so the player naturally stays in bounds. Like the zone
+  // ridges, the rise is steeper than the climb limit everywhere (guarded by
+  // tests/terrain_walls.test.ts); it starts where it always did (30yd inside,
+  // the Mirefen impact site leans on that wall base) but peaks before the
+  // boundary so the whole climb happens in-world.
+  const rimX = smoothstep(WORLD_MAX_X - 30, WORLD_MAX_X - 6, Math.abs(x));
+  const rimS = smoothstep(WORLD_MIN_Z + 30, WORLD_MIN_Z + 6, z);
+  const rimN = smoothstep(WORLD_MAX_Z - 30, WORLD_MAX_Z - 6, z);
   const rim = Math.max(rimX, rimS, rimN);
-  h += rim * 40;
+  h += rim * 55;
   h += mirefenImpactCraterOffset(x, z);
   return h;
+}
+
+// Steepest local rise/run of the walkable heightfield at (x, z), independent of
+// travel direction. Movement gates on this (not just the slope along the step)
+// so a diagonal switchback approach cannot beat the straight-line climb limit.
+const STEEPNESS_SAMPLE = 0.35; // yards; about one movement tick of run
+export function terrainSteepness(x: number, z: number, seed: number): number {
+  const e = STEEPNESS_SAMPLE;
+  const hx = (groundHeight(x + e, z, seed) - groundHeight(x - e, z, seed)) / (2 * e);
+  const hz = (groundHeight(x, z + e, seed) - groundHeight(x, z - e, seed)) / (2 * e);
+  return Math.hypot(hx, hz);
+}
+
+// Memoized 1-yard-cell view of terrainSteepness for the per-tick movement
+// gates (every moving mob evaluates its step fan every tick; the exact helper
+// costs four heightfield samples). A cache over a pure function of
+// (cell, seed) stays fully deterministic; the cap just bounds memory on
+// long-running hosts. Cell granularity only shifts a gate line by under a
+// yard, far inside the walls' steepness margin (tests/terrain_walls.test.ts).
+const steepnessCache = new Map<number, Map<number, number>>(); // seed -> cell -> steepness
+const STEEPNESS_CACHE_MAX = 400_000; // cells per seed; ~the whole overworld
+const STEEPNESS_CACHE_MAX_SEEDS = 4; // hosts run one seed; only test runs see more
+const STEEPNESS_CELL_SPAN = 16384; // cells per axis in the packed key
+export function terrainSteepnessAt(x: number, z: number, seed: number): number {
+  // Instanced interiors (dungeons/arena/delves) are flat floors; skip the cache
+  // entirely so their far-off coordinates never enter (or overflow) the packed
+  // key space, which is sized for the overworld.
+  if (x > DUNGEON_X_THRESHOLD) return 0;
+  const cx = Math.round(x);
+  const cz = Math.round(z);
+  let bySeed = steepnessCache.get(seed);
+  if (!bySeed) {
+    if (steepnessCache.size >= STEEPNESS_CACHE_MAX_SEEDS) steepnessCache.clear();
+    bySeed = new Map();
+    steepnessCache.set(seed, bySeed);
+  }
+  const key = (cx + STEEPNESS_CELL_SPAN / 2) * STEEPNESS_CELL_SPAN + (cz + STEEPNESS_CELL_SPAN / 2);
+  let v = bySeed.get(key);
+  if (v === undefined) {
+    if (bySeed.size >= STEEPNESS_CACHE_MAX) bySeed.clear();
+    v = terrainSteepness(cx, cz, seed);
+    bySeed.set(key, v);
+  }
+  return v;
+}
+
+// True inside the terrain bands that hold the deliberate unwalkable walls: the
+// zone-ridge walls and the world rim (with margin). The per-tick mob movement
+// gate screens with this so the steepness memo never runs over the open world;
+// rare interior steep spots stay mob-walkable, exactly as they always were
+// (players get the full gate everywhere in sim.ts).
+export function nearSteepWalls(x: number, z: number): boolean {
+  if (x > DUNGEON_X_THRESHOLD) return false; // instanced interiors: flat floors
+  if (Math.abs(x) > WORLD_MAX_X - 40 || z < WORLD_MIN_Z + 40 || z > WORLD_MAX_Z - 40) return true;
+  for (const ridge of ZONE_RIDGES) {
+    if (Math.abs(z - ridge.z) < RIDGE_SIGMA * 4) return true;
+  }
+  return false;
+}
+
+// Unit downhill direction at (x, z), or null on (near-)flat ground. Drives the
+// slide that carries a player off ground steeper than the climb limit.
+export function terrainDownhill(
+  x: number,
+  z: number,
+  seed: number,
+): { x: number; z: number } | null {
+  const e = STEEPNESS_SAMPLE;
+  const hx = (groundHeight(x + e, z, seed) - groundHeight(x - e, z, seed)) / (2 * e);
+  const hz = (groundHeight(x, z + e, seed) - groundHeight(x, z - e, seed)) / (2 * e);
+  const mag = Math.hypot(hx, hz);
+  if (mag < 1e-6) return null;
+  return { x: -hx / mag, z: -hz / mag };
 }
 
 // Distance from (x,z) to the nearest road polyline segment.
@@ -164,12 +256,16 @@ export function roadDistance(x: number, z: number): number {
   let best = Infinity;
   for (const road of ROADS) {
     for (let i = 0; i < road.length - 1; i++) {
-      const a = road[i], b = road[i + 1];
-      const abx = b.x - a.x, abz = b.z - a.z;
-      const apx = x - a.x, apz = z - a.z;
+      const a = road[i],
+        b = road[i + 1];
+      const abx = b.x - a.x,
+        abz = b.z - a.z;
+      const apx = x - a.x,
+        apz = z - a.z;
       const len2 = abx * abx + abz * abz;
       const t = len2 > 0 ? Math.max(0, Math.min(1, (apx * abx + apz * abz) / len2)) : 0;
-      const dx = apx - abx * t, dz = apz - abz * t;
+      const dx = apx - abx * t,
+        dz = apz - abz * t;
       const d = Math.sqrt(dx * dx + dz * dz);
       if (d < best) best = d;
     }
@@ -191,12 +287,12 @@ export interface Decoration {
 }
 
 const DECORATION_EXCLUSION_RADIUS = 1.2;
-const DECORATION_EXCLUSIONS = [
-  { x: 2.456450840458274, z: 211.33819991815835 },
-];
+const DECORATION_EXCLUSIONS = [{ x: 2.456450840458274, z: 211.33819991815835 }];
 
 function isExcludedDecoration(x: number, z: number): boolean {
-  return DECORATION_EXCLUSIONS.some((p) => Math.hypot(x - p.x, z - p.z) < DECORATION_EXCLUSION_RADIUS);
+  return DECORATION_EXCLUSIONS.some(
+    (p) => Math.hypot(x - p.x, z - p.z) < DECORATION_EXCLUSION_RADIUS,
+  );
 }
 
 export function zoneBiomeAt(z: number): BiomeId {
@@ -218,35 +314,45 @@ export function generateDecorations(seed: number): Decoration[] {
       let kind: Decoration['kind'] | null = null;
       if (biome === 'vale') {
         if (r > 0.48) continue;
-        kind = r < 0.30 ? 'tree' : r < 0.40 ? 'tree2' : 'rock';
+        kind = r < 0.3 ? 'tree' : r < 0.4 ? 'tree2' : 'rock';
       } else if (biome === 'marsh') {
         if (r > 0.34) continue;
         kind = r < 0.08 ? 'tree' : r < 0.26 ? 'tree2' : 'rock';
       } else {
         if (r > 0.44) continue;
-        kind = r < 0.20 ? 'tree' : r < 0.24 ? 'tree2' : 'rock';
+        kind = r < 0.2 ? 'tree' : r < 0.24 ? 'tree2' : 'rock';
       }
       const ox = (hash2(Math.round(gx), Math.round(gz), seed + 57) - 0.5) * step;
       const oz = (hash2(Math.round(gx), Math.round(gz), seed + 91) - 0.5) * step;
-      const x = gx + ox, z = gz + oz;
+      const x = gx + ox,
+        z = gz + oz;
       if (isExcludedDecoration(x, z)) continue;
       let inHub = false;
       for (const zone of ZONES) {
-        const dx = x - zone.hub.x, dz = z - zone.hub.z;
-        if (Math.sqrt(dx * dx + dz * dz) < zone.hub.radius + 4) { inHub = true; break; }
+        const dx = x - zone.hub.x,
+          dz = z - zone.hub.z;
+        if (Math.sqrt(dx * dx + dz * dz) < zone.hub.radius + 4) {
+          inHub = true;
+          break;
+        }
       }
       if (inHub) continue;
       if (terrainHeight(x, z, seed) < WATER_LEVEL + 1) continue;
       if (roadDistance(x, z) < 5) continue;
       let inCamp = false;
       for (const c of CAMPS) {
-        const dx = x - c.center.x, dz = z - c.center.z;
-        if (Math.sqrt(dx * dx + dz * dz) < c.radius + 3) { inCamp = true; break; }
+        const dx = x - c.center.x,
+          dz = z - c.center.z;
+        if (Math.sqrt(dx * dx + dz * dz) < c.radius + 3) {
+          inCamp = true;
+          break;
+        }
       }
       if (inCamp) continue;
       out.push({
         kind,
-        x, z,
+        x,
+        z,
         scale: 0.7 + hash2(Math.round(gx), Math.round(gz), seed + 13) * 0.9,
         variant: Math.floor(hash2(Math.round(gx), Math.round(gz), seed + 77) * 3),
         biome,

--- a/tests/climb_slope.test.ts
+++ b/tests/climb_slope.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import { isBlocked } from '../src/sim/colliders';
+import { CAMPS } from '../src/sim/data';
+import { Sim } from '../src/sim/sim';
+import { terrainDownhill, terrainHeight, terrainSteepness, WATER_LEVEL } from '../src/sim/world';
+
+// Movement gates for unwalkable slopes (the report: players climbing the
+// mountains and the world rim by strafing diagonally or spamming jump).
+// Contract, mirroring classic MMO rules:
+//  - an uphill step onto ground steeper than MAX_CLIMB_SLOPE is blocked no
+//    matter the approach angle (a switchback cannot beat the limit),
+//  - airborne movement cannot carry you into a face you could not walk up,
+//  - you cannot jump while standing on unwalkably steep ground, and
+//  - standing on such ground slides you downhill until footing is walkable.
+// tests/terrain_walls.test.ts pins that the walls themselves are steep enough.
+
+const SEED = 42;
+const CLIMB_LIMIT = 1.5;
+
+function makeSim(): Sim {
+  const sim = new Sim({ seed: SEED, playerClass: 'warrior', autoEquip: true });
+  sim.setPlayerLevel(60); // rim mobs must not decide these tests
+  return sim;
+}
+
+function teleport(sim: Sim, x: number, z: number): void {
+  const p = sim.player;
+  p.pos.x = x;
+  p.pos.z = z;
+  p.pos.y = terrainHeight(x, z, sim.cfg.seed);
+  p.prevPos = { ...p.pos };
+  p.fallStartY = p.pos.y;
+  p.onGround = true;
+  p.vx = 0;
+  p.vz = 0;
+  p.vy = 0;
+}
+
+// A z where the run-up to the west rim wall is dry, collider-free, and far from
+// mob camps, plus where the wall's steep band begins and where its crest tops out.
+let rimApproach: { z: number; xStart: number; xCrest: number } | null = null;
+function findWestRimApproach(seed: number): { z: number; xStart: number; xCrest: number } {
+  if (rimApproach) return rimApproach;
+  rimApproach = scanWestRimApproach(seed);
+  return rimApproach;
+}
+
+function scanWestRimApproach(seed: number): { z: number; xStart: number; xCrest: number } {
+  outer: for (let z = -60; z <= 820; z += 7) {
+    for (const camp of CAMPS) {
+      if (Math.hypot(camp.center.x + 160, camp.center.z - z) < camp.radius + 80) continue outer;
+    }
+    let xSteep = Number.NaN;
+    for (let x = -130; x >= -178; x -= 0.5) {
+      if (terrainHeight(x, z, seed) < WATER_LEVEL + 0.5) continue outer;
+      if (Number.isNaN(xSteep) && isBlocked(seed, x, z, 0.6)) continue outer;
+      if (Number.isNaN(xSteep) && terrainSteepness(x, z, seed) > CLIMB_LIMIT + 0.2) {
+        xSteep = x;
+      }
+    }
+    if (Number.isNaN(xSteep)) continue;
+    let xCrest = xSteep;
+    let hCrest = -Infinity;
+    for (let x = xSteep; x >= -184; x -= 0.5) {
+      const h = terrainHeight(x, z, seed);
+      if (h > hCrest) {
+        hCrest = h;
+        xCrest = x;
+      }
+    }
+    return { z, xStart: xSteep + 6, xCrest };
+  }
+  throw new Error('no clean west-rim approach found for this seed');
+}
+
+// A steep on-wall footing reachable for the slide tests: the first point past
+// the steep band start with real steepness.
+function findSteepFooting(seed: number): { x: number; z: number } {
+  const { z, xStart } = findWestRimApproach(seed);
+  for (let x = xStart; x >= -184; x -= 0.25) {
+    if (terrainSteepness(x, z, seed) > CLIMB_LIMIT + 0.4 && !isBlocked(seed, x, z, 0.6)) {
+      return { x, z };
+    }
+  }
+  throw new Error('no steep footing found');
+}
+
+const WEST = -Math.PI / 2; // facing f moves along (sin f, cos f); west = -x
+
+describe('unwalkable slope movement gates', () => {
+  it('cannot climb the rim wall by strafing diagonally (switchback)', { timeout: 30000 }, () => {
+    const sim = makeSim();
+    const { z, xStart, xCrest } = findWestRimApproach(SEED);
+    teleport(sim, xStart, z);
+    const meta = sim.players.get(sim.player.id);
+    if (!meta) throw new Error('missing player meta');
+    meta.moveInput.forward = true;
+    for (let i = 0; i < 20 * 60; i++) {
+      // hug the live gradient at ~65 degrees off uphill, alternating sides:
+      // the classic switchback that beats a direction-only slope check
+      const down = terrainDownhill(sim.player.pos.x, sim.player.pos.z, SEED);
+      const uphill = down ? Math.atan2(-down.x, -down.z) : WEST;
+      sim.player.facing = uphill + (Math.floor(i / 15) % 2 === 0 ? 1.15 : -1.15);
+      sim.tick();
+      expect(sim.player.pos.x, `tick ${i}: crossed the rim crest`).toBeGreaterThan(xCrest);
+    }
+  });
+
+  it('cannot climb the rim wall by spamming jump into it', { timeout: 30000 }, () => {
+    const sim = makeSim();
+    const { z, xStart, xCrest } = findWestRimApproach(SEED);
+    teleport(sim, xStart, z);
+    const meta = sim.players.get(sim.player.id);
+    if (!meta) throw new Error('missing player meta');
+    meta.moveInput.forward = true;
+    meta.moveInput.jump = true;
+    sim.player.facing = WEST;
+    for (let i = 0; i < 20 * 60; i++) {
+      sim.tick();
+      expect(sim.player.pos.x, `tick ${i}: crossed the rim crest`).toBeGreaterThan(xCrest);
+    }
+  });
+
+  it('slides downhill off unwalkably steep ground', () => {
+    const sim = makeSim();
+    const spot = findSteepFooting(SEED);
+    teleport(sim, spot.x, spot.z);
+    const startY = sim.player.pos.y;
+    for (let i = 0; i < 20 * 20; i++) sim.tick();
+    const p = sim.player.pos;
+    expect(terrainSteepness(p.x, p.z, SEED)).toBeLessThanOrEqual(CLIMB_LIMIT);
+    expect(p.y).toBeLessThan(startY);
+  });
+
+  it('cannot jump while standing on unwalkably steep ground', () => {
+    const sim = makeSim();
+    const spot = findSteepFooting(SEED);
+    teleport(sim, spot.x, spot.z);
+    const meta = sim.players.get(sim.player.id);
+    if (!meta) throw new Error('missing player meta');
+    meta.moveInput.jump = true;
+    for (let i = 0; i < 20 * 5; i++) {
+      sim.tick();
+      const p = sim.player;
+      if (terrainSteepness(p.pos.x, p.pos.z, SEED) > CLIMB_LIMIT) {
+        expect(p.vy, `tick ${i}: jumped off steep ground`).toBeLessThanOrEqual(0);
+      }
+    }
+  });
+
+  it('still crosses the zone ridge through the road pass', () => {
+    const sim = makeSim();
+    teleport(sim, 0, 160);
+    const meta = sim.players.get(sim.player.id);
+    if (!meta) throw new Error('missing player meta');
+    meta.moveInput.forward = true;
+    sim.player.facing = 0; // north, straight up the pass
+    for (let i = 0; i < 20 * 30 && sim.player.pos.z < 210; i++) sim.tick();
+    expect(sim.player.pos.z).toBeGreaterThan(210);
+  });
+
+  it('normal jumping on walkable ground still works', () => {
+    const sim = makeSim();
+    teleport(sim, 0, -40); // flat vale ground near the hub
+    const meta = sim.players.get(sim.player.id);
+    if (!meta) throw new Error('missing player meta');
+    const startY = sim.player.pos.y;
+    meta.moveInput.jump = true;
+    sim.tick();
+    meta.moveInput.jump = false;
+    expect(sim.player.onGround).toBe(false);
+    let apex = startY;
+    for (let i = 0; i < 20 * 2 && !sim.player.onGround; i++) {
+      sim.tick();
+      apex = Math.max(apex, sim.player.pos.y);
+    }
+    expect(sim.player.onGround).toBe(true);
+    expect(apex - startY).toBeGreaterThan(0.7);
+  });
+});

--- a/tests/climb_slope.test.ts
+++ b/tests/climb_slope.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { isBlocked } from '../src/sim/colliders';
 import { CAMPS } from '../src/sim/data';
+import { PLAYER_MAX_CLIMB_SLOPE } from '../src/sim/pathfind';
 import { Sim } from '../src/sim/sim';
 import { terrainDownhill, terrainHeight, terrainSteepness, WATER_LEVEL } from '../src/sim/world';
 
@@ -14,6 +15,9 @@ import { terrainDownhill, terrainHeight, terrainSteepness, WATER_LEVEL } from '.
 //  - standing on such ground slides you downhill until footing is walkable.
 // tests/terrain_walls.test.ts pins that the walls themselves are steep enough.
 
+// Seed 42, not the production seed: the movement gates are seed-agnostic (any
+// steep-enough wall exercises them) and the terrain contract at the production
+// seed is pinned separately in tests/terrain_walls.test.ts.
 const SEED = 42;
 const CLIMB_LIMIT = 1.5;
 
@@ -88,6 +92,12 @@ function findSteepFooting(seed: number): { x: number; z: number } {
 const WEST = -Math.PI / 2; // facing f moves along (sin f, cos f); west = -x
 
 describe('unwalkable slope movement gates', () => {
+  // CLIMB_LIMIT is deliberately a literal (an independent pin, not a
+  // self-comparison); this keeps it from silently desyncing from the source.
+  it('the pinned climb limit matches the movement constant', () => {
+    expect(PLAYER_MAX_CLIMB_SLOPE).toBe(CLIMB_LIMIT);
+  });
+
   it('cannot climb the rim wall by strafing diagonally (switchback)', { timeout: 30000 }, () => {
     const sim = makeSim();
     const { z, xStart, xCrest } = findWestRimApproach(SEED);

--- a/tests/parity/golden/arena_1v1.json
+++ b/tests/parity/golden/arena_1v1.json
@@ -8,8 +8,8 @@
     "multi-player PlayerMeta sampling",
     "classes:warrior,mage"
   ],
-  "draws": 479,
-  "drawDigest": "808d7f7b",
+  "draws": 482,
+  "drawDigest": "b4688c48",
   "frames": [
     {
       "tick": 0,
@@ -65,8 +65,8 @@
       "state": "863d9757",
       "events": "a6010c17",
       "rng": {
-        "draws": 256,
-        "digest": "3d77ef20"
+        "draws": 254,
+        "digest": "07655741"
       }
     },
     {
@@ -76,8 +76,8 @@
       "state": "19de32dc",
       "events": "55bc7862",
       "rng": {
-        "draws": 379,
-        "digest": "8d90ccd7"
+        "draws": 384,
+        "digest": "9a9a7293"
       }
     },
     {
@@ -87,8 +87,8 @@
       "state": "d497439c",
       "events": "741638a5",
       "rng": {
-        "draws": 479,
-        "digest": "808d7f7b"
+        "draws": 482,
+        "digest": "b4688c48"
       },
       "label": "final",
       "players": [

--- a/tests/parity/golden/delve_companion.json
+++ b/tests/parity/golden/delve_companion.json
@@ -355,7 +355,7 @@
       "tick": 41,
       "time": 2.05,
       "nextId": 399,
-      "state": "061c2057",
+      "state": "6972f46f",
       "events": "b98b9587",
       "rng": {
         "draws": 8,
@@ -395,7 +395,7 @@
           "critChance": 0.063,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.063,
-          "fallStartY": 40.657208,
+          "fallStartY": 55.657208,
           "fiveSecondRule": 101.05,
           "hp": 29000,
           "id": 389,
@@ -410,7 +410,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 4811.246093,
-            "y": 40.657208,
+            "y": 55.657208,
             "z": -1170.162032
           },
           "potionCooldownUntil": -1,
@@ -536,7 +536,7 @@
       "tick": 45,
       "time": 2.25,
       "nextId": 399,
-      "state": "b29968f3",
+      "state": "d8d8b713",
       "events": "741638a5",
       "rng": {
         "draws": 8,
@@ -547,7 +547,7 @@
       "tick": 49,
       "time": 2.45,
       "nextId": 399,
-      "state": "16e766b8",
+      "state": "d6a02731",
       "events": "741638a5",
       "rng": {
         "draws": 8,
@@ -587,7 +587,7 @@
           "critChance": 0.063,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.063,
-          "fallStartY": 40.323103,
+          "fallStartY": 55.323103,
           "fiveSecondRule": 101.45,
           "hp": 29000,
           "id": 389,
@@ -601,7 +601,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 4820.246093,
-            "y": 39.203103,
+            "y": 54.203103,
             "z": -1170.162032
           },
           "potionCooldownUntil": -1,
@@ -673,7 +673,7 @@
       "tick": 50,
       "time": 2.5,
       "nextId": 399,
-      "state": "08c140c7",
+      "state": "93cb66f4",
       "events": "741638a5",
       "rng": {
         "draws": 8,
@@ -684,7 +684,7 @@
       "tick": 51,
       "time": 2.55,
       "nextId": 399,
-      "state": "655eed96",
+      "state": "acb3f485",
       "events": "741638a5",
       "rng": {
         "draws": 8,
@@ -724,7 +724,7 @@
           "critChance": 0.063,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.063,
-          "fallStartY": 45.246749,
+          "fallStartY": 60.246749,
           "fiveSecondRule": 101.55,
           "hp": 29000,
           "id": 389,
@@ -738,7 +738,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 4891.046093,
-            "y": 45.206749,
+            "y": 60.206749,
             "z": -1170.162032
           },
           "potionCooldownUntil": -1,
@@ -785,7 +785,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 4891.046093,
-            "y": 45.246749,
+            "y": 60.246749,
             "z": -1170.162032
           },
           "potionCooldownUntil": -1,
@@ -811,7 +811,7 @@
       "tick": 51,
       "time": 2.55,
       "nextId": 399,
-      "state": "655eed96",
+      "state": "acb3f485",
       "events": "741638a5",
       "rng": {
         "draws": 8,
@@ -851,7 +851,7 @@
           "critChance": 0.063,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.063,
-          "fallStartY": 45.246749,
+          "fallStartY": 60.246749,
           "fiveSecondRule": 101.55,
           "hp": 29000,
           "id": 389,
@@ -865,7 +865,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 4891.046093,
-            "y": 45.206749,
+            "y": 60.206749,
             "z": -1170.162032
           },
           "potionCooldownUntil": -1,
@@ -912,7 +912,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 4891.046093,
-            "y": 45.246749,
+            "y": 60.246749,
             "z": -1170.162032
           },
           "potionCooldownUntil": -1,

--- a/tests/parity/golden/dungeon_instances.json
+++ b/tests/parity/golden/dungeon_instances.json
@@ -789,8 +789,8 @@
       "tick": 4,
       "time": 0.2,
       "nextId": 405,
-      "state": "d017bf0f",
-      "events": "1ebf3fdc",
+      "state": "9e5c6aae",
+      "events": "35839585",
       "rng": {
         "draws": 49,
         "digest": "1d1c5dad"
@@ -804,7 +804,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 110624,
+            "damageTaken": 163124,
             "deaths": 1
           },
           "delveClears": {},
@@ -895,7 +895,7 @@
           "critChance": 0.056,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.056,
-          "fallStartY": 42.122741,
+          "fallStartY": 57.122741,
           "fiveSecondRule": 99.2,
           "hp": 50000,
           "id": 390,
@@ -1529,8 +1529,8 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 405,
-      "state": "b7d091f1",
-      "events": "73ee09ee",
+      "state": "c0a5f54f",
+      "events": "eda0c419",
       "rng": {
         "draws": 49,
         "digest": "1d1c5dad"
@@ -1540,7 +1540,7 @@
       "tick": 10,
       "time": 0.5,
       "nextId": 405,
-      "state": "c84e8ad3",
+      "state": "1128e2f1",
       "events": "741638a5",
       "rng": {
         "draws": 49,
@@ -1551,7 +1551,7 @@
       "tick": 15,
       "time": 0.75,
       "nextId": 405,
-      "state": "f4a57241",
+      "state": "072c6bdf",
       "events": "741638a5",
       "rng": {
         "draws": 49,
@@ -1562,7 +1562,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 405,
-      "state": "9c493d5c",
+      "state": "4c6a4afa",
       "events": "741638a5",
       "rng": {
         "draws": 49,
@@ -1573,7 +1573,7 @@
       "tick": 24,
       "time": 1.2,
       "nextId": 405,
-      "state": "50d2c03c",
+      "state": "9a69c45a",
       "events": "741638a5",
       "rng": {
         "draws": 49,
@@ -1588,7 +1588,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 110624,
+            "damageTaken": 163124,
             "deaths": 1
           },
           "delveClears": {},
@@ -1610,7 +1610,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 110624,
+            "damageTaken": 163124,
             "deaths": 1
           },
           "delveClears": {},
@@ -1730,7 +1730,7 @@
       "tick": 24,
       "time": 1.2,
       "nextId": 405,
-      "state": "50d2c03c",
+      "state": "9a69c45a",
       "events": "741638a5",
       "rng": {
         "draws": 49,
@@ -1745,7 +1745,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 110624,
+            "damageTaken": 163124,
             "deaths": 1
           },
           "delveClears": {},
@@ -1767,7 +1767,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 110624,
+            "damageTaken": 163124,
             "deaths": 1
           },
           "delveClears": {},

--- a/tests/parity/golden/fiesta_midcast_kill.json
+++ b/tests/parity/golden/fiesta_midcast_kill.json
@@ -10,8 +10,8 @@
     "fiesta lifesteal augment arm (~5499)",
     "multi-player fiesta meta"
   ],
-  "draws": 524,
-  "drawDigest": "1731ce7a",
+  "draws": 523,
+  "drawDigest": "1bff173c",
   "frames": [
     {
       "tick": 0,
@@ -1128,8 +1128,8 @@
       "state": "2f59c65c",
       "events": "741638a5",
       "rng": {
-        "draws": 524,
-        "digest": "1731ce7a"
+        "draws": 523,
+        "digest": "1bff173c"
       },
       "label": "final",
       "players": [

--- a/tests/parity/golden/fiesta_powerups.json
+++ b/tests/parity/golden/fiesta_powerups.json
@@ -513,7 +513,7 @@
       "tick": 450,
       "time": 22.5,
       "nextId": 393,
-      "state": "0ab68d9e",
+      "state": "57450894",
       "events": "fc956308",
       "rng": {
         "draws": 2073,
@@ -524,7 +524,7 @@
       "tick": 460,
       "time": 23,
       "nextId": 393,
-      "state": "f2421d08",
+      "state": "6e80390f",
       "events": "6290a585",
       "rng": {
         "draws": 2113,
@@ -535,7 +535,7 @@
       "tick": 470,
       "time": 23.5,
       "nextId": 393,
-      "state": "8fc33398",
+      "state": "5b09d7a2",
       "events": "f01f657f",
       "rng": {
         "draws": 2165,
@@ -546,7 +546,7 @@
       "tick": 480,
       "time": 24,
       "nextId": 393,
-      "state": "5a0239b8",
+      "state": "5a998711",
       "events": "8764f0a2",
       "rng": {
         "draws": 2216,
@@ -557,7 +557,7 @@
       "tick": 490,
       "time": 24.5,
       "nextId": 393,
-      "state": "7bbc17fc",
+      "state": "48b9a1c4",
       "events": "8764f0a2",
       "rng": {
         "draws": 2251,
@@ -568,8 +568,8 @@
       "tick": 500,
       "time": 25,
       "nextId": 393,
-      "state": "54cd765a",
-      "events": "3ddd30aa",
+      "state": "8a0c5f01",
+      "events": "1aa59991",
       "rng": {
         "draws": 2301,
         "digest": "2e012f5a"
@@ -579,7 +579,7 @@
       "tick": 510,
       "time": 25.5,
       "nextId": 393,
-      "state": "8ecfa556",
+      "state": "c0be6105",
       "events": "c5088c04",
       "rng": {
         "draws": 2357,
@@ -590,7 +590,7 @@
       "tick": 520,
       "time": 26,
       "nextId": 393,
-      "state": "b170da16",
+      "state": "1bda2bc5",
       "events": "c5088c04",
       "rng": {
         "draws": 2394,
@@ -601,7 +601,7 @@
       "tick": 530,
       "time": 26.5,
       "nextId": 393,
-      "state": "5afd2e02",
+      "state": "3d219c49",
       "events": "cc51ff62",
       "rng": {
         "draws": 2452,
@@ -612,7 +612,7 @@
       "tick": 540,
       "time": 27,
       "nextId": 393,
-      "state": "8e8c76a2",
+      "state": "9775e8e9",
       "events": "e56e199b",
       "rng": {
         "draws": 2493,
@@ -623,7 +623,7 @@
       "tick": 550,
       "time": 27.5,
       "nextId": 393,
-      "state": "d965168e",
+      "state": "f8d605fd",
       "events": "e56e199b",
       "rng": {
         "draws": 2551,
@@ -634,7 +634,7 @@
       "tick": 560,
       "time": 28,
       "nextId": 393,
-      "state": "07a3f942",
+      "state": "23da1ab7",
       "events": "6d27c92c",
       "rng": {
         "draws": 2601,
@@ -645,7 +645,7 @@
       "tick": 570,
       "time": 28.5,
       "nextId": 393,
-      "state": "a2e918dc",
+      "state": "d9ef116d",
       "events": "6290a585",
       "rng": {
         "draws": 2652,
@@ -656,7 +656,7 @@
       "tick": 573,
       "time": 28.65,
       "nextId": 393,
-      "state": "5ac79064",
+      "state": "5931f511",
       "events": "741638a5",
       "rng": {
         "draws": 2662,
@@ -671,7 +671,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 1825,
+            "damageTaken": 2678,
             "deaths": 1,
             "kills": 1
           },
@@ -807,7 +807,7 @@
         {
           "aiState": "idle",
           "attackPower": 122,
-          "combatTimer": 100.1,
+          "combatTimer": 99.75,
           "critChance": 0.0995,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.0795,

--- a/tests/parity/golden/mob_lifecycle.json
+++ b/tests/parity/golden/mob_lifecycle.json
@@ -1091,7 +1091,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 397,
-      "state": "f4958315",
+      "state": "d2cc9402",
       "events": "a2b8439c",
       "rng": {
         "draws": 13,
@@ -1465,7 +1465,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 39.410541,
+          "fallStartY": 54.410541,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 84,
@@ -1480,14 +1480,14 @@
           "petMode": "defensive",
           "pos": {
             "x": 300,
-            "y": 39.410541,
+            "y": 54.410541,
             "z": 300
           },
           "potionCooldownUntil": -1,
           "respawnTimer": -0.05,
           "spawnPos": {
             "x": 300,
-            "y": 39.410541,
+            "y": 54.410541,
             "z": 300
           },
           "stats": {
@@ -1507,7 +1507,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 398,
-      "state": "cb529d8c",
+      "state": "2d13f2eb",
       "events": "d877e3e8",
       "rng": {
         "draws": 17,
@@ -1881,7 +1881,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 39.410541,
+          "fallStartY": 54.410541,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 84,
@@ -1896,14 +1896,14 @@
           "petMode": "defensive",
           "pos": {
             "x": 300,
-            "y": 39.410541,
+            "y": 54.410541,
             "z": 300
           },
           "potionCooldownUntil": -1,
           "respawnTimer": -0.05,
           "spawnPos": {
             "x": 300,
-            "y": 39.410541,
+            "y": 54.410541,
             "z": 300
           },
           "stats": {
@@ -1924,7 +1924,7 @@
           "dead": true,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 41.399945,
+          "fallStartY": 56.399945,
           "fiveSecondRule": 99,
           "hostile": true,
           "id": 397,
@@ -1932,7 +1932,7 @@
           "kind": "mob",
           "leashAnchor": {
             "x": 700,
-            "y": 41.399945,
+            "y": 56.399945,
             "z": 300
           },
           "level": 5,
@@ -1950,14 +1950,14 @@
           "petMode": "defensive",
           "pos": {
             "x": 700,
-            "y": 41.399945,
+            "y": 56.399945,
             "z": 300
           },
           "potionCooldownUntil": -1,
           "respawnTimer": -0.05,
           "spawnPos": {
             "x": 700,
-            "y": 41.399945,
+            "y": 56.399945,
             "z": 300
           },
           "stats": {
@@ -1977,7 +1977,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 398,
-      "state": "cb529d8c",
+      "state": "2d13f2eb",
       "events": "741638a5",
       "rng": {
         "draws": 17,
@@ -2351,7 +2351,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 39.410541,
+          "fallStartY": 54.410541,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 84,
@@ -2366,14 +2366,14 @@
           "petMode": "defensive",
           "pos": {
             "x": 300,
-            "y": 39.410541,
+            "y": 54.410541,
             "z": 300
           },
           "potionCooldownUntil": -1,
           "respawnTimer": -0.05,
           "spawnPos": {
             "x": 300,
-            "y": 39.410541,
+            "y": 54.410541,
             "z": 300
           },
           "stats": {
@@ -2394,7 +2394,7 @@
           "dead": true,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 41.399945,
+          "fallStartY": 56.399945,
           "fiveSecondRule": 99,
           "hostile": true,
           "id": 397,
@@ -2402,7 +2402,7 @@
           "kind": "mob",
           "leashAnchor": {
             "x": 700,
-            "y": 41.399945,
+            "y": 56.399945,
             "z": 300
           },
           "level": 5,
@@ -2420,14 +2420,14 @@
           "petMode": "defensive",
           "pos": {
             "x": 700,
-            "y": 41.399945,
+            "y": 56.399945,
             "z": 300
           },
           "potionCooldownUntil": -1,
           "respawnTimer": -0.05,
           "spawnPos": {
             "x": 700,
-            "y": 41.399945,
+            "y": 56.399945,
             "z": 300
           },
           "stats": {

--- a/tests/parity/golden/mob_locomotion.json
+++ b/tests/parity/golden/mob_locomotion.json
@@ -585,7 +585,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 394,
-      "state": "75fb820e",
+      "state": "1ad9d9f0",
       "events": "741638a5",
       "rng": {
         "draws": 15,
@@ -825,7 +825,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -0.226092,
-          "fallStartY": 43.188532,
+          "fallStartY": 58.188532,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 84,
@@ -840,13 +840,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 299.968616,
-            "y": 43.180156,
+            "y": 58.180156,
             "z": 300.136437
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 300,
-            "y": 43.188532,
+            "y": 58.188532,
             "z": 300
           },
           "stats": {
@@ -855,7 +855,7 @@
           "templateId": "forest_wolf",
           "wanderTarget": {
             "x": 298.918529,
-            "y": 42.734603,
+            "y": 57.734603,
             "z": 304.70153
           },
           "wanderTimer": 30,
@@ -871,7 +871,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 395,
-      "state": "d0537866",
+      "state": "4be62baa",
       "events": "741638a5",
       "rng": {
         "draws": 16,
@@ -1111,7 +1111,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -0.226092,
-          "fallStartY": 43.188532,
+          "fallStartY": 58.188532,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 84,
@@ -1126,13 +1126,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 299.968616,
-            "y": 43.180156,
+            "y": 58.180156,
             "z": 300.136437
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 300,
-            "y": 43.188532,
+            "y": 58.188532,
             "z": 300
           },
           "stats": {
@@ -1141,7 +1141,7 @@
           "templateId": "forest_wolf",
           "wanderTarget": {
             "x": 298.918529,
-            "y": 42.734603,
+            "y": 57.734603,
             "z": 304.70153
           },
           "wanderTimer": 30,
@@ -1157,7 +1157,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 42.211832,
+          "fallStartY": 57.211832,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 84,
@@ -1172,13 +1172,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 320,
-            "y": 42.211832,
+            "y": 57.211832,
             "z": 320
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 320,
-            "y": 42.211832,
+            "y": 57.211832,
             "z": 320
           },
           "stats": {
@@ -1198,7 +1198,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 396,
-      "state": "d5d2f3f9",
+      "state": "fb489e59",
       "events": "514349f0",
       "rng": {
         "draws": 16,
@@ -1438,7 +1438,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -0.226092,
-          "fallStartY": 43.188532,
+          "fallStartY": 58.188532,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 84,
@@ -1453,13 +1453,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 299.968616,
-            "y": 43.180156,
+            "y": 58.180156,
             "z": 300.136437
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 300,
-            "y": 43.188532,
+            "y": 58.188532,
             "z": 300
           },
           "stats": {
@@ -1468,7 +1468,7 @@
           "templateId": "forest_wolf",
           "wanderTarget": {
             "x": 298.918529,
-            "y": 42.734603,
+            "y": 57.734603,
             "z": 304.70153
           },
           "wanderTimer": 30,
@@ -1484,7 +1484,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 42.211832,
+          "fallStartY": 57.211832,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 84,
@@ -1499,13 +1499,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 320,
-            "y": 42.211832,
+            "y": 57.211832,
             "z": 320
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 320,
-            "y": 42.211832,
+            "y": 57.211832,
             "z": 320
           },
           "stats": {
@@ -1569,7 +1569,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 396,
-      "state": "135c12a0",
+      "state": "454cb700",
       "events": "741638a5",
       "rng": {
         "draws": 16,
@@ -1809,7 +1809,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -0.226092,
-          "fallStartY": 43.188532,
+          "fallStartY": 58.188532,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 84,
@@ -1824,13 +1824,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 299.968616,
-            "y": 43.180156,
+            "y": 58.180156,
             "z": 300.136437
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 300,
-            "y": 43.188532,
+            "y": 58.188532,
             "z": 300
           },
           "stats": {
@@ -1839,7 +1839,7 @@
           "templateId": "forest_wolf",
           "wanderTarget": {
             "x": 298.918529,
-            "y": 42.734603,
+            "y": 57.734603,
             "z": 304.70153
           },
           "wanderTimer": 30,
@@ -1855,7 +1855,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 42.211832,
+          "fallStartY": 57.211832,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 84,
@@ -1870,13 +1870,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 320,
-            "y": 42.211832,
+            "y": 57.211832,
             "z": 320
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 320,
-            "y": 42.211832,
+            "y": 57.211832,
             "z": 320
           },
           "stats": {
@@ -1941,7 +1941,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 396,
-      "state": "135c12a0",
+      "state": "454cb700",
       "events": "741638a5",
       "rng": {
         "draws": 16,
@@ -2181,7 +2181,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -0.226092,
-          "fallStartY": 43.188532,
+          "fallStartY": 58.188532,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 84,
@@ -2196,13 +2196,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 299.968616,
-            "y": 43.180156,
+            "y": 58.180156,
             "z": 300.136437
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 300,
-            "y": 43.188532,
+            "y": 58.188532,
             "z": 300
           },
           "stats": {
@@ -2211,7 +2211,7 @@
           "templateId": "forest_wolf",
           "wanderTarget": {
             "x": 298.918529,
-            "y": 42.734603,
+            "y": 57.734603,
             "z": 304.70153
           },
           "wanderTimer": 30,
@@ -2227,7 +2227,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 42.211832,
+          "fallStartY": 57.211832,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 84,
@@ -2242,13 +2242,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 320,
-            "y": 42.211832,
+            "y": 57.211832,
             "z": 320
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 320,
-            "y": 42.211832,
+            "y": 57.211832,
             "z": 320
           },
           "stats": {

--- a/tests/parity/golden/nythraxis_full_pull.json
+++ b/tests/parity/golden/nythraxis_full_pull.json
@@ -13,8 +13,8 @@
     "Final Stand enrage at 5% + grantNythraxisLockout (raidLockouts) + onBossDeath death dialogue",
     "class:warrior"
   ],
-  "draws": 3299,
-  "drawDigest": "195346eb",
+  "draws": 3302,
+  "drawDigest": "126a6770",
   "frames": [
     {
       "tick": 0,
@@ -5430,8 +5430,8 @@
       "state": "e906566e",
       "events": "741638a5",
       "rng": {
-        "draws": 2906,
-        "digest": "30df916f"
+        "draws": 2905,
+        "digest": "dbe79aae"
       }
     },
     {
@@ -5441,8 +5441,8 @@
       "state": "54291850",
       "events": "741638a5",
       "rng": {
-        "draws": 2957,
-        "digest": "2e220812"
+        "draws": 2956,
+        "digest": "6196f6b9"
       }
     },
     {
@@ -5452,8 +5452,8 @@
       "state": "72e4519a",
       "events": "e77e7089",
       "rng": {
-        "draws": 2991,
-        "digest": "dfc1b570"
+        "draws": 2990,
+        "digest": "d3e2c3a7"
       },
       "label": "finalstand",
       "players": [
@@ -6206,11 +6206,11 @@
       "tick": 628,
       "time": 31.4,
       "nextId": 402,
-      "state": "52976032",
+      "state": "0ed815cb",
       "events": "da1da39a",
       "rng": {
-        "draws": 3002,
-        "digest": "1aed0b18"
+        "draws": 3001,
+        "digest": "e7e41486"
       },
       "label": "death",
       "players": [
@@ -6624,7 +6624,7 @@
           },
           "level": 20,
           "loot": {
-            "copper": 148474,
+            "copper": 183782,
             "items": [
               {
                 "count": 1,
@@ -6632,15 +6632,15 @@
               },
               {
                 "count": 1,
-                "itemId": "crownforged_warspaulders"
-              },
-              {
-                "count": 1,
                 "itemId": "soulflame_mantle"
               },
               {
                 "count": 1,
-                "itemId": "nighttalon_shoulderguards"
+                "itemId": "crownforged_dreadhelm"
+              },
+              {
+                "count": 1,
+                "itemId": "nighttalon_crown"
               }
             ]
           },
@@ -7010,7 +7010,7 @@
       "tick": 630,
       "time": 31.5,
       "nextId": 402,
-      "state": "51bc6507",
+      "state": "407d66da",
       "events": "741638a5",
       "rng": {
         "draws": 3009,
@@ -7021,7 +7021,7 @@
       "tick": 640,
       "time": 32,
       "nextId": 402,
-      "state": "5806f500",
+      "state": "04815fc9",
       "events": "741638a5",
       "rng": {
         "draws": 3055,
@@ -7032,7 +7032,7 @@
       "tick": 650,
       "time": 32.5,
       "nextId": 402,
-      "state": "64ef4900",
+      "state": "13f535a5",
       "events": "741638a5",
       "rng": {
         "draws": 3091,
@@ -7043,29 +7043,29 @@
       "tick": 660,
       "time": 33,
       "nextId": 402,
-      "state": "11c3d39f",
+      "state": "25a0e4c6",
       "events": "741638a5",
       "rng": {
-        "draws": 3146,
-        "digest": "849d5a24"
+        "draws": 3144,
+        "digest": "cf538127"
       }
     },
     {
       "tick": 670,
       "time": 33.5,
       "nextId": 402,
-      "state": "cfb838a5",
+      "state": "ec4bd1c8",
       "events": "741638a5",
       "rng": {
-        "draws": 3209,
-        "digest": "5ab8b2ef"
+        "draws": 3207,
+        "digest": "0ff03005"
       }
     },
     {
       "tick": 680,
       "time": 34,
       "nextId": 402,
-      "state": "0d2bffbe",
+      "state": "e66999cf",
       "events": "741638a5",
       "rng": {
         "draws": 3263,
@@ -7076,11 +7076,11 @@
       "tick": 688,
       "time": 34.4,
       "nextId": 402,
-      "state": "dccf58b9",
+      "state": "b008a8ec",
       "events": "17666c9a",
       "rng": {
-        "draws": 3299,
-        "digest": "195346eb"
+        "draws": 3302,
+        "digest": "126a6770"
       },
       "label": "final",
       "players": [
@@ -7494,7 +7494,7 @@
           },
           "level": 20,
           "loot": {
-            "copper": 148474,
+            "copper": 183782,
             "items": [
               {
                 "count": 1,
@@ -7502,15 +7502,15 @@
               },
               {
                 "count": 1,
-                "itemId": "crownforged_warspaulders"
-              },
-              {
-                "count": 1,
                 "itemId": "soulflame_mantle"
               },
               {
                 "count": 1,
-                "itemId": "nighttalon_shoulderguards"
+                "itemId": "crownforged_dreadhelm"
+              },
+              {
+                "count": 1,
+                "itemId": "nighttalon_crown"
               }
             ]
           },

--- a/tests/parity/golden/pet_ai.json
+++ b/tests/parity/golden/pet_ai.json
@@ -169,7 +169,7 @@
       "tick": 120,
       "time": 6,
       "nextId": 394,
-      "state": "c0794cb1",
+      "state": "cd049fc7",
       "events": "741638a5",
       "rng": {
         "draws": 418,
@@ -306,7 +306,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -1.713587,
-          "fallStartY": 37.026485,
+          "fallStartY": 52.026485,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 49946,
@@ -327,7 +327,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 202,
-            "y": 37.026485,
+            "y": 52.026485,
             "z": -2
           },
           "potionCooldownUntil": -1,
@@ -412,7 +412,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": 1.570796,
-          "fallStartY": 39.397438,
+          "fallStartY": 54.397438,
           "fiveSecondRule": 99,
           "forcedTargetTimer": -0.05,
           "hostile": true,
@@ -434,7 +434,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 202,
-            "y": 39.397438,
+            "y": 54.397438,
             "z": 18
           },
           "potionCooldownUntil": -1,
@@ -472,7 +472,7 @@
       "tick": 140,
       "time": 7,
       "nextId": 394,
-      "state": "6fde9258",
+      "state": "e8c904b8",
       "events": "741638a5",
       "rng": {
         "draws": 518,
@@ -483,7 +483,7 @@
       "tick": 160,
       "time": 8,
       "nextId": 394,
-      "state": "1c414dfc",
+      "state": "1f65b13a",
       "events": "741638a5",
       "rng": {
         "draws": 637,
@@ -494,7 +494,7 @@
       "tick": 180,
       "time": 9,
       "nextId": 394,
-      "state": "520e6cf6",
+      "state": "43a389c1",
       "events": "741638a5",
       "rng": {
         "draws": 777,
@@ -505,7 +505,7 @@
       "tick": 180,
       "time": 9,
       "nextId": 394,
-      "state": "520e6cf6",
+      "state": "43a389c1",
       "events": "741638a5",
       "rng": {
         "draws": 777,
@@ -638,7 +638,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -1.570796,
-          "fallStartY": 37.026485,
+          "fallStartY": 52.026485,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 49946,
@@ -654,7 +654,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 164.88,
-            "y": 22.296471,
+            "y": 39.746386,
             "z": -2
           },
           "potionCooldownUntil": -1,
@@ -736,7 +736,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -1.665748,
-          "fallStartY": 39.397438,
+          "fallStartY": 54.397438,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 49940,
@@ -752,7 +752,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 165.047208,
-            "y": 22.379664,
+            "y": 40.034879,
             "z": 14.480686
           },
           "potionCooldownUntil": -1,

--- a/tests/pet_follow.test.ts
+++ b/tests/pet_follow.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { Sim } from '../src/sim/sim';
-import { Entity, Vec3 } from '../src/sim/types';
 import { isBlocked } from '../src/sim/colliders';
+import { Sim } from '../src/sim/sim';
+import type { Entity, Vec3 } from '../src/sim/types';
 import { terrainHeight } from '../src/sim/world';
 
 // Pets heel by pathfinding around obstacles (like a warrior charge route) rather
@@ -25,7 +25,10 @@ function setup(petAt: Vec3, ownerAt: Vec3): { sim: Sim; pet: Entity; owner: Enti
   const owner = sim.entities.get(pid)!;
   let pet: Entity | null = null;
   for (const e of sim.entities.values()) {
-    if (e.kind === 'mob' && !e.dead && e.ownerId === null) { pet = e; break; }
+    if (e.kind === 'mob' && !e.dead && e.ownerId === null) {
+      pet = e;
+      break;
+    }
   }
   if (!pet) throw new Error('no wild mob to adopt');
   pet.ownerId = pid;
@@ -69,7 +72,10 @@ describe('pet heel pathfinding', () => {
     const trace = () => {
       const { sim, pet } = setup(PET, OWNER);
       const path: Vec3[] = [];
-      for (let i = 0; i < 20 * 6; i++) { sim.tick(); path.push({ ...pet.pos }); }
+      for (let i = 0; i < 20 * 6; i++) {
+        sim.tick();
+        path.push({ ...pet.pos });
+      }
       return path;
     };
     expect(trace()).toEqual(trace());
@@ -90,10 +96,12 @@ describe('pet heel pathfinding', () => {
 
   it('does not snap on a stale unreachable path when a route actually exists', () => {
     // Regression: the teleport must be confirmed by a FRESH A* attempt, not by a
-    // leftover single-waypoint cache. Owner is 62yd away with the line of sight
-    // blocked but a real route around exists, and the pet carries a stale "no
-    // route" cache with the throttle still active — it must path, never warp.
-    const { sim, pet, owner } = setup({ x: -138, y: 0, z: -160 }, { x: -200, y: 0, z: -160 });
+    // leftover single-waypoint cache. Owner is 62yd away on the far side of the
+    // spawn building (straight line blocked, real route around exists), and the
+    // pet carries a stale "no route" cache with the throttle still active: it
+    // must path, never warp. (This used to stage across the west rim mountains,
+    // which are now correctly unclimbable, so the route there no longer exists.)
+    const { sim, pet, owner } = setup({ x: 0, y: 0, z: -25 }, { x: 0, y: 0, z: 37 });
     expect(dist(pet.pos, owner.pos)).toBeGreaterThan(60);
     pet.petPath = [{ ...owner.pos }]; // stale single-waypoint (looks "unreachable")
     pet.petPathCooldown = 0.4; // throttle active: would skip recompute without the fresh-attempt guard

--- a/tests/terrain_walls.test.ts
+++ b/tests/terrain_walls.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { CAMPS, NPCS, ROADS, WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_Z, ZONES } from '../src/sim/data';
+import { terrainSteepness } from '../src/sim/world';
+
+// The mountain walls of the world (the inter-zone ridges and the outer rim) are
+// meant to be impassable: every crossing outside the road pass must somewhere be
+// steeper than the movement climb limit (MAX_CLIMB_SLOPE = 1.5 rise/run) so the
+// slope gates in sim.ts actually stop the player. This file pins that terrain
+// contract; tests/climb_slope.test.ts pins the movement gates themselves.
+
+const WORLD_SEED = 20061; // the fixed production seed (src/main.ts, server/game.ts)
+const CLIMB_LIMIT = 1.5;
+const WALL_MARGIN = 1.7; // walls must beat the limit with headroom, not by a hair
+const PASS_HALF_WIDTH = 10;
+
+// Max steepness met along a straight crossing path.
+function pathMaxSteepness(
+  seed: number,
+  from: { x: number; z: number },
+  to: { x: number; z: number },
+): number {
+  const steps = Math.ceil(Math.hypot(to.x - from.x, to.z - from.z) / 0.5);
+  let max = 0;
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    const s = terrainSteepness(from.x + (to.x - from.x) * t, from.z + (to.z - from.z) * t, seed);
+    if (s > max) max = s;
+  }
+  return max;
+}
+
+const RIDGE_ZS = ZONES.slice(0, -1).map((zone) => zone.zMax);
+
+describe('impassable terrain walls', () => {
+  it('every non-pass crossing of each zone ridge is steeper than the climb limit', () => {
+    for (const rz of RIDGE_ZS) {
+      for (let x = -172; x <= 172; x += 4) {
+        if (Math.abs(x) < PASS_HALF_WIDTH + 26) continue; // the road pass corridor
+        const max = pathMaxSteepness(WORLD_SEED, { x, z: rz - 50 }, { x, z: rz + 50 });
+        expect(max, `ridge z=${rz} crossing at x=${x}`).toBeGreaterThan(WALL_MARGIN);
+      }
+    }
+  });
+
+  it('every crossing of the world rim is steeper than the climb limit', () => {
+    for (let z = WORLD_MIN_Z + 40; z <= WORLD_MAX_Z - 40; z += 4) {
+      for (const side of [-1, 1]) {
+        const max = pathMaxSteepness(
+          WORLD_SEED,
+          { x: side * (WORLD_MAX_X - 36), z },
+          { x: side * (WORLD_MAX_X + 4), z },
+        );
+        expect(max, `x-rim side=${side} at z=${z}`).toBeGreaterThan(WALL_MARGIN);
+      }
+    }
+    for (let x = -144; x <= 144; x += 4) {
+      const south = pathMaxSteepness(
+        WORLD_SEED,
+        { x, z: WORLD_MIN_Z + 36 },
+        { x, z: WORLD_MIN_Z - 4 },
+      );
+      expect(south, `south rim at x=${x}`).toBeGreaterThan(WALL_MARGIN);
+      const north = pathMaxSteepness(
+        WORLD_SEED,
+        { x, z: WORLD_MAX_Z - 36 },
+        { x, z: WORLD_MAX_Z + 4 },
+      );
+      expect(north, `north rim at x=${x}`).toBeGreaterThan(WALL_MARGIN);
+    }
+  });
+
+  it('the road pass through each ridge stays gently walkable', () => {
+    for (const rz of RIDGE_ZS) {
+      for (let x = -8; x <= 8; x += 2) {
+        const max = pathMaxSteepness(WORLD_SEED, { x, z: rz - 50 }, { x, z: rz + 50 });
+        expect(max, `pass across ridge z=${rz} at x=${x}`).toBeLessThan(1.0);
+      }
+    }
+  });
+
+  it('camps, npcs, hubs, and road vertices all sit on walkable ground', () => {
+    for (const camp of CAMPS) {
+      expect(
+        terrainSteepness(camp.center.x, camp.center.z, WORLD_SEED),
+        `camp at (${camp.center.x},${camp.center.z})`,
+      ).toBeLessThanOrEqual(CLIMB_LIMIT);
+    }
+    for (const [id, npc] of Object.entries(NPCS)) {
+      const pos = (npc as { pos?: { x: number; z: number } }).pos;
+      if (!pos) continue;
+      expect(
+        terrainSteepness(pos.x, pos.z, WORLD_SEED),
+        `npc ${id} at (${pos.x},${pos.z})`,
+      ).toBeLessThanOrEqual(CLIMB_LIMIT);
+    }
+    for (const zone of ZONES) {
+      expect(
+        terrainSteepness(zone.hub.x, zone.hub.z, WORLD_SEED),
+        `hub of ${zone.name}`,
+      ).toBeLessThanOrEqual(CLIMB_LIMIT);
+    }
+    for (const road of ROADS) {
+      for (const p of road) {
+        expect(
+          terrainSteepness(p.x, p.z, WORLD_SEED),
+          `road vertex (${p.x},${p.z})`,
+        ).toBeLessThanOrEqual(CLIMB_LIMIT);
+      }
+    }
+  });
+});

--- a/tests/terrain_walls.test.ts
+++ b/tests/terrain_walls.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { CAMPS, NPCS, ROADS, WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_Z, ZONES } from '../src/sim/data';
+import { PLAYER_MAX_CLIMB_SLOPE } from '../src/sim/pathfind';
 import { terrainSteepness } from '../src/sim/world';
 
 // The mountain walls of the world (the inter-zone ridges and the outer rim) are
@@ -32,12 +33,38 @@ function pathMaxSteepness(
 const RIDGE_ZS = ZONES.slice(0, -1).map((zone) => zone.zMax);
 
 describe('impassable terrain walls', () => {
+  // CLIMB_LIMIT is deliberately a literal (an independent pin, not a
+  // self-comparison); this keeps it from silently desyncing from the source.
+  it('the pinned climb limit matches the movement constant', () => {
+    expect(PLAYER_MAX_CLIMB_SLOPE).toBe(CLIMB_LIMIT);
+  });
+
   it('every non-pass crossing of each zone ridge is steeper than the climb limit', () => {
     for (const rz of RIDGE_ZS) {
       for (let x = -172; x <= 172; x += 4) {
         if (Math.abs(x) < PASS_HALF_WIDTH + 26) continue; // the road pass corridor
         const max = pathMaxSteepness(WORLD_SEED, { x, z: rz - 50 }, { x, z: rz + 50 });
         expect(max, `ridge z=${rz} crossing at x=${x}`).toBeGreaterThan(WALL_MARGIN);
+      }
+    }
+  });
+
+  it('the pass shoulder band is already a real wall', () => {
+    // The wall ramps from the flat pass opening (|x| < 10) to full height by
+    // |x| = 34 (PASS_SHOULDER in src/sim/world.ts). The crossable zone must
+    // stay contiguous with the road pass: by |x| = 16 every crossing already
+    // beats the margin, so a terrain tweak cannot quietly widen the gap into
+    // a cross-beside-the-pass hole.
+    for (const rz of RIDGE_ZS) {
+      for (let x = 16; x <= 34; x += 2) {
+        for (const side of [-1, 1]) {
+          const max = pathMaxSteepness(
+            WORLD_SEED,
+            { x: side * x, z: rz - 50 },
+            { x: side * x, z: rz + 50 },
+          );
+          expect(max, `ridge z=${rz} shoulder at x=${side * x}`).toBeGreaterThan(WALL_MARGIN);
+        }
       }
     }
   });


### PR DESCRIPTION
## Problem

Players can climb the mountains that are supposed to fence the world: the ridge walls between zones and the outer rim. From the report screenshots, a player walked over Thornpeak's rim mountains and ended up standing outside the map at x = -248 (the world ends at x = -180), floating over the boundary water plane.

Three holes combined to allow this:

1. The walls were not actually steep. The easiest crossing of the inter-zone ridges had a gradient of 0.63 to 0.79, far below the movement climb limit of 1.5, so players could simply walk over them and skip the road pass. The rim's easiest crossings sat at 1.54 to 1.90, barely above the limit.
2. The climb gate only measured rise/run along the step direction, so strafing diagonally (a switchback) reduced the effective slope below 1.5 and beat the gate on any wall.
3. Airborne movement skipped the gate entirely: holding jump plus forward walked up any face about a yard per hop, and landing snapped the player onto the higher ground.

## Fix

Terrain (`src/sim/world.ts`):
- Zone ridge walls are taller and narrower (height 22 to 40, sigma 18 to 10, crest variance tightened). Every non-pass crossing now peaks above gradient 2.19 at the production seed.
- The world rim rises 55 over 24yd (was 40 over 30) and peaks 6yd inside the boundary; every crossing now exceeds gradient 2.93. Its base stays at the same 30yd offset so the Mirefen impact site still leans on the wall.
- The road passes stay gentle (worst gradient 0.35) and all camps, NPCs, hubs, and road vertices remain on walkable ground; narrowing the ridges actually freed the camps that used to sit inside the old wide bands.
- New pure helpers: `terrainSteepness` (true gradient magnitude), `terrainSteepnessAt` (1yd-cell memo for hot gates), `terrainDownhill`, `nearSteepWalls`.

Movement (`src/sim/sim.ts`):
- Uphill ground steps are blocked when the step slope OR the true terrain steepness at the destination exceeds `MAX_CLIMB_SLOPE`, so approach angle no longer matters.
- Airborne horizontal movement cannot enter terrain rising above the body that could not be walked up; a jump into a steep face drops the player at its base.
- Jumping is blocked while standing on unwalkably steep ground, and standing on such ground slides the player downhill (classic-style) until footing is walkable, so no input pattern can rest partway up a wall.
- The same wall rule applies to charge, follow, knockback, and (screened to the wall bands for hot-path cost) the shared `moveToward` used by mobs, pets, and feared players.

## Verification

- New `tests/climb_slope.test.ts`: switchback and jump-spam cannot cross the rim (both reproduced the exploit and failed before the fix), slide off steep ground, no jumping on steep ground, the road pass still crosses, and normal jumping is unaffected.
- New `tests/terrain_walls.test.ts`: pins the terrain contract at the production seed: every non-pass ridge/rim crossing beats the climb limit with margin, passes stay gentle, and all content sits on walkable ground. The pass shoulder band (|x| 16-34) is now pinned to prevent quiet widenings.
- Parity goldens re-recorded (`UPDATE_PARITY=1`): terrain heights and mob movement legitimately changed. Rng draw order and counts shift downstream: taller terrain plus wall-blocked mobs change proximity-gated aggro/wander/target draws (arena_1v1 479 to 482, nythraxis_full_pull 3299 to 3302, mob_locomotion 15 to 16, and others). The new helpers use stateless `hash2`/`fbm2` with no draw sites added, so the shifts are position-driven conditional draws. Digests were re-recorded and parity is green.
- One `pet_follow` test restaged: its old coordinates relied on a route across the (then climbable) west rim, which correctly no longer exists.
- Tick benchmark at parity with main after memoizing steepness per cell and band-screening the mob gate; `tsc`, build, and the full suite are green modulo the pre-existing flaky set on main.
- A player already stranded outside the rim (like the reporter) can still walk back down into the world without fall damage.
- Reviewed by the repo's architecture-reviewer and qa-checklist agents; their findings (an em dash, packed-key hardening for instance coordinates, an instance short-circuit for the band screen) are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)