### PR TITLE
feat(game): first-spawn intro cinematic for new characters

### DIFF
--- a/src/game/spawn_cinematic.ts
+++ b/src/game/spawn_cinematic.ts
@@ -1,0 +1,58 @@
+// First-spawn camera cinematic, pure math (no DOM): the camera opens high and
+// far, one full turn behind the gameplay yaw, circles the spawn while it
+// descends, and lands exactly on the normal gameplay pose. main.ts feeds
+// elapsed seconds in and applies the returned pose to the input camera each
+// frame; tests/spawn_cinematic.test.ts locks the start/landing/continuity
+// contract.
+
+export interface CameraPose {
+  yaw: number;
+  pitch: number;
+  dist: number;
+}
+
+export interface SpawnCinematic {
+  durationSec: number;
+  turns: number; // full camera turns around the spawn
+  startDist: number; // the orbit opens far ...
+  startPitch: number; // ... and high, looking down at the spawn
+  end: CameraPose; // gameplay pose the cinematic lands on exactly
+}
+
+// startDist stays inside the wheel-zoom range input.ts allows (3..22) so the
+// whole path uses camera poses the player could reach themselves.
+export function spawnCinematicFor(end: CameraPose): SpawnCinematic {
+  return { durationSec: 9, turns: 1, startDist: 22, startPitch: 0.55, end };
+}
+
+// The yaw eases over the whole run (gentle start, slow landing) while the
+// descent (dist + pitch) holds the high wide shot for the opening stretch and
+// only settles onto the character in the back stretch.
+const DESCENT_START = 0.45;
+
+export function spawnCinematicPose(
+  elapsedSec: number,
+  c: SpawnCinematic,
+): CameraPose & { done: boolean } {
+  const p = clamp01(elapsedSec / c.durationSec);
+  const orbit = easeInOutSine(p);
+  const descent = easeInOutCubic(clamp01((p - DESCENT_START) / (1 - DESCENT_START)));
+  return {
+    yaw: c.end.yaw - (1 - orbit) * c.turns * Math.PI * 2,
+    pitch: c.startPitch + (c.end.pitch - c.startPitch) * descent,
+    dist: c.startDist + (c.end.dist - c.startDist) * descent,
+    done: elapsedSec >= c.durationSec,
+  };
+}
+
+function clamp01(x: number): number {
+  return Math.min(1, Math.max(0, x));
+}
+
+function easeInOutSine(x: number): number {
+  return 0.5 - Math.cos(Math.PI * x) / 2;
+}
+
+function easeInOutCubic(x: number): number {
+  return x < 0.5 ? 4 * x * x * x : 1 - (-2 * x + 2) ** 3 / 2;
+}

--- a/src/game/spawn_cinematic.ts
+++ b/src/game/spawn_cinematic.ts
@@ -1,8 +1,9 @@
-// First-spawn camera cinematic, pure math (no DOM): the camera opens high and
-// far, one full turn behind the gameplay yaw, circles the spawn while it
-// descends, and lands exactly on the normal gameplay pose. main.ts feeds
-// elapsed seconds in and applies the returned pose to the input camera each
-// frame; tests/spawn_cinematic.test.ts locks the start/landing/continuity
+// First-spawn camera cinematic, pure math (no DOM): the camera opens far out
+// across the field, high above the world, and glides in one long continuous
+// approach toward the character, sweeping gently around (a fraction of a turn,
+// not an orbit) until it lands exactly on the normal gameplay pose. main.ts
+// feeds elapsed seconds in and applies the returned pose to the input camera
+// each frame; tests/spawn_cinematic.test.ts locks the start/landing/continuity
 // contract.
 
 export interface CameraPose {
@@ -13,36 +14,46 @@ export interface CameraPose {
 
 export interface SpawnCinematic {
   durationSec: number;
-  turns: number; // full camera turns around the spawn
-  startDist: number; // the orbit opens far ...
-  startPitch: number; // ... and high, looking down at the spawn
+  turns: number; // fraction of a turn swept during the approach
+  startDist: number; // the approach opens far out across the field ...
+  startPitch: number; // ... and high, looking down over the world
   end: CameraPose; // gameplay pose the cinematic lands on exactly
 }
 
-// startDist stays inside the wheel-zoom range input.ts allows (3..22) so the
-// whole path uses camera poses the player could reach themselves.
+// startDist is deliberately beyond the wheel-zoom range (3..22): the opening
+// is an establishing shot of the world around the spawn. The renderer clamps
+// the camera above terrain, so the long path can never dip underground.
 export function spawnCinematicFor(end: CameraPose): SpawnCinematic {
-  return { durationSec: 9, turns: 1, startDist: 22, startPitch: 0.55, end };
+  return { durationSec: 9, turns: 0.3, startDist: 55, startPitch: 1.0, end };
 }
-
-// The yaw eases over the whole run (gentle start, slow landing) while the
-// descent (dist + pitch) holds the high wide shot for the opening stretch and
-// only settles onto the character in the back stretch.
-const DESCENT_START = 0.45;
 
 export function spawnCinematicPose(
   elapsedSec: number,
   c: SpawnCinematic,
 ): CameraPose & { done: boolean } {
   const p = clamp01(elapsedSec / c.durationSec);
-  const orbit = easeInOutSine(p);
-  const descent = easeInOutCubic(clamp01((p - DESCENT_START) / (1 - DESCENT_START)));
+  // One shared ease for the whole approach: gentle start, long glide, slow
+  // landing, with yaw/pitch/dist arriving together so there is no snap.
+  const glide = easeInOutSine(p);
   return {
-    yaw: c.end.yaw - (1 - orbit) * c.turns * Math.PI * 2,
-    pitch: c.startPitch + (c.end.pitch - c.startPitch) * descent,
-    dist: c.startDist + (c.end.dist - c.startDist) * descent,
+    yaw: c.end.yaw - (1 - glide) * c.turns * Math.PI * 2,
+    pitch: c.startPitch + (c.end.pitch - c.startPitch) * glide,
+    dist: c.startDist + (c.end.dist - c.startDist) * glide,
     done: elapsedSec >= c.durationSec,
   };
+}
+
+// Skipping: desktop presses Escape; touch players have no Escape key, so a
+// rapid burst of taps skips instead (a lone stray tap must not).
+export const SKIP_TAP_COUNT = 4;
+export const SKIP_TAP_WINDOW_SEC = 1.5;
+
+// Records one tap at nowSec into `taps` (pruned in place to the sliding
+// window) and reports whether the burst threshold was reached.
+export function recordSkipTap(taps: number[], nowSec: number): boolean {
+  taps.push(nowSec);
+  while (taps.length > 0 && nowSec - taps[0] > SKIP_TAP_WINDOW_SEC) taps.shift();
+  return taps.length >= SKIP_TAP_COUNT;
 }
 
 function clamp01(x: number): number {
@@ -51,8 +62,4 @@ function clamp01(x: number): number {
 
 function easeInOutSine(x: number): number {
   return 0.5 - Math.cos(Math.PI * x) / 2;
-}
-
-function easeInOutCubic(x: number): number {
-  return x < 0.5 ? 4 * x * x * x : 1 - (-2 * x + 2) ** 3 / 2;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2640,8 +2640,7 @@ async function startOffline(playerClass: PlayerClass, name: string, skin = 0): P
   }
   // Offline characters are not persisted (a fresh name is typed each session),
   // so the only stable handle is class + name. Keybinds scope to that pair.
-  // Editor play-tests (a custom `world`) skip the first-spawn intro cinematic.
-  void startGame(sim, sim, null, `offline:${playerClass}:${name}`, !world);
+  void startGame(sim, sim, null, `offline:${playerClass}:${name}`, true);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,7 @@ import {
   Settings,
 } from './game/settings';
 import { sfx } from './game/sfx';
+import { type SpawnCinematic, spawnCinematicFor, spawnCinematicPose } from './game/spawn_cinematic';
 import { resolveUiEffectsProfile } from './game/ui_effects_profile';
 import { currentUtcDay } from './game/utc_day';
 import { voice } from './game/voice';
@@ -844,6 +845,7 @@ async function startGame(
   offlineSim: Sim | null,
   online: ClientWorld | null,
   keybindScope: string,
+  playIntro = false,
 ): Promise<void> {
   // Model/texture/HDRI fetches were kicked off at module import; the renderer
   // builds its scene synchronously, so everything must be resolved first.
@@ -2235,8 +2237,9 @@ async function startGame(
     syncPerfOverlay(frameDt, now);
 
     // freeze movement while the game menu is up so WASD doesn't walk the
-    // character behind it (other windows stay non-modal, as before)
-    input.suspendMovement = !gameInputReady || hud.isModalOpen();
+    // character behind it (other windows stay non-modal, as before); the
+    // first-spawn intro cinematic holds movement the same way until it lands
+    input.suspendMovement = !gameInputReady || hud.isModalOpen() || intro !== null;
     perf.trace('input.updateTouchLook', () => input.updateTouchLook(frameDt), {
       frameDtMs: frameDt * 1000,
     });
@@ -2244,7 +2247,7 @@ async function startGame(
     perf.trace('input.hoverCursor', () => updateHoverCursor(), { active: input.hoverActive });
     perf.markInputFrame(performance.now());
 
-    const mouselook = input.isMouselookActive() && !world.player.dead;
+    const mouselook = intro === null && input.isMouselookActive() && !world.player.dead;
     const controllerFacing = input.controllerFacingOverride();
     const renderFacing = renderFacingOverride();
     // On the frame mouselook is released, latch the final camera yaw so the player
@@ -2302,6 +2305,7 @@ async function startGame(
           frameDtMs: frameDt * 1000,
         },
       );
+      introCameraTick(now);
       renderer.camYaw = input.camYaw;
       renderer.camPitch = input.camPitch;
       renderer.camDist = input.camDist;
@@ -2396,6 +2400,7 @@ async function startGame(
         lastSnapAge: net.lastSnapAt > 0 ? performance.now() - net.lastSnapAt : -1,
       },
     );
+    introCameraTick(now);
     renderer.camYaw = input.camYaw;
     renderer.camPitch = input.camPitch;
     renderer.camDist = input.camDist;
@@ -2436,6 +2441,73 @@ async function startGame(
       input.clearControllerMoveInput();
     },
   };
+  // First-spawn intro cinematic: a newly created character's first entry opens
+  // with the camera high over the spawn, circling it once before settling into
+  // the gameplay pose; the HUD stays hidden until the camera lands, and any key
+  // or click skips straight to the end. Seen-state persists per character so it
+  // plays exactly once; reduce-motion players go straight to gameplay.
+  const INTRO_SEEN_KEY = `woc_spawn_intro_seen:${keybindScope}`;
+  let introSeen = true;
+  try {
+    introSeen = localStorage.getItem(INTRO_SEEN_KEY) === '1';
+  } catch {
+    // storage unavailable: the seen marker can't persist, so treat the intro as
+    // seen rather than replaying it on every boot
+  }
+  let intro: { cinematic: SpawnCinematic; startedAt: number | null } | null = null;
+  const setIntroUiHidden = (hidden: boolean): void => {
+    const display = hidden ? 'none' : '';
+    const ui = document.getElementById('ui');
+    if (ui) ui.style.display = display;
+    nameplates.style.display = display;
+  };
+  const finishIntro = (skipToEnd: boolean): void => {
+    if (!intro) return;
+    const end = intro.cinematic.end;
+    intro = null;
+    if (skipToEnd) {
+      input.camYaw = end.yaw;
+      input.camPitch = end.pitch;
+      input.camDist = end.dist;
+    }
+    setIntroUiHidden(false);
+    window.removeEventListener('keydown', skipIntro, true);
+    window.removeEventListener('pointerdown', skipIntro, true);
+    try {
+      localStorage.setItem(INTRO_SEEN_KEY, '1');
+    } catch {
+      // storage unavailable: worst case the intro replays next session
+    }
+  };
+  const skipIntro = (e: Event): void => {
+    e.stopPropagation();
+    if (e.type === 'keydown') e.preventDefault();
+    finishIntro(true);
+  };
+  // Applied each frame between the follow-camera update and the renderer read,
+  // so the cinematic pose wins over mouse/follow input while it runs.
+  const introCameraTick = (now: number): void => {
+    if (!intro) return;
+    const elapsed = intro.startedAt === null ? 0 : (now - intro.startedAt) / 1000;
+    const pose = spawnCinematicPose(elapsed, intro.cinematic);
+    input.camYaw = pose.yaw;
+    input.camPitch = pose.pitch;
+    input.camDist = pose.dist;
+    if (pose.done) finishIntro(false);
+  };
+  if (playIntro && !introSeen && world.player.level <= 1 && !settings.get('reduceMotion')) {
+    intro = {
+      cinematic: spawnCinematicFor({
+        yaw: input.camYaw,
+        pitch: input.camPitch,
+        dist: input.camDist,
+      }),
+      startedAt: null,
+    };
+    setIntroUiHidden(true);
+    window.addEventListener('keydown', skipIntro, true);
+    window.addEventListener('pointerdown', skipIntro, true);
+  }
   input.suspendMovement = true;
   await nextPaint();
   try {
@@ -2450,6 +2522,9 @@ async function startGame(
   requestAnimationFrame(() =>
     requestAnimationFrame(() => {
       hideLoadingScreen();
+      // Start the intro clock as the loading screen begins to fade: the camera
+      // holds the opening pose until now, so the fade doubles as the cut in.
+      if (intro) intro.startedAt = performance.now();
       window.setTimeout(() => {
         gameInputReady = true;
         perf.reset();
@@ -2552,7 +2627,8 @@ async function startOffline(playerClass: PlayerClass, name: string, skin = 0): P
   }
   // Offline characters are not persisted (a fresh name is typed each session),
   // so the only stable handle is class + name. Keybinds scope to that pair.
-  void startGame(sim, sim, null, `offline:${playerClass}:${name}`);
+  // Editor play-tests (a custom `world`) skip the first-spawn intro cinematic.
+  void startGame(sim, sim, null, `offline:${playerClass}:${name}`, !world);
 }
 
 // ---------------------------------------------------------------------------
@@ -3905,7 +3981,7 @@ async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Prom
   const poll = setInterval(() => {
     if (world.connected && world.entities.has(world.playerId)) {
       clearInterval(poll);
-      void startGame(world, null, world, `char:${c.id}`);
+      void startGame(world, null, world, `char:${c.id}`, true);
     } else if (Date.now() - waitStart > 10000) {
       clearInterval(poll);
       world.close();

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,12 @@ import {
   Settings,
 } from './game/settings';
 import { sfx } from './game/sfx';
-import { type SpawnCinematic, spawnCinematicFor, spawnCinematicPose } from './game/spawn_cinematic';
+import {
+  recordSkipTap,
+  type SpawnCinematic,
+  spawnCinematicFor,
+  spawnCinematicPose,
+} from './game/spawn_cinematic';
 import { resolveUiEffectsProfile } from './game/ui_effects_profile';
 import { currentUtcDay } from './game/utc_day';
 import { voice } from './game/voice';
@@ -2442,10 +2447,11 @@ async function startGame(
     },
   };
   // First-spawn intro cinematic: a newly created character's first entry opens
-  // with the camera high over the spawn, circling it once before settling into
-  // the gameplay pose; the HUD stays hidden until the camera lands, and any key
-  // or click skips straight to the end. Seen-state persists per character so it
-  // plays exactly once; reduce-motion players go straight to gameplay.
+  // far out across the field and glides in toward the character; the HUD stays
+  // hidden until the camera lands. Escape (or a rapid tap burst on touch, which
+  // has no Escape key) skips straight to the end; other input is swallowed
+  // while it runs. Seen-state persists per character so it plays exactly once;
+  // reduce-motion players go straight to gameplay.
   const INTRO_SEEN_KEY = `woc_spawn_intro_seen:${keybindScope}`;
   let introSeen = true;
   try {
@@ -2479,10 +2485,17 @@ async function startGame(
       // storage unavailable: worst case the intro replays next session
     }
   };
+  const introTaps: number[] = [];
   const skipIntro = (e: Event): void => {
+    // Swallow gameplay input while the intro runs; only the skip gestures act.
     e.stopPropagation();
-    if (e.type === 'keydown') e.preventDefault();
-    finishIntro(true);
+    if (e.type === 'keydown') {
+      if ((e as KeyboardEvent).key !== 'Escape') return;
+      e.preventDefault(); // skip only: the eaten Escape must not open the menu
+      finishIntro(true);
+      return;
+    }
+    if (recordSkipTap(introTaps, performance.now() / 1000)) finishIntro(true);
   };
   // Applied each frame between the follow-camera update and the renderer read,
   // so the cinematic pose wins over mouse/follow input while it runs.

--- a/src/main.ts
+++ b/src/main.ts
@@ -2465,6 +2465,12 @@ async function startGame(
     const display = hidden ? 'none' : '';
     const ui = document.getElementById('ui');
     if (ui) ui.style.display = display;
+    // The touch controls are a top-level layer OUTSIDE #ui, so they need their
+    // own toggle or the joysticks and combat buttons stay up during the intro
+    // on mobile. Clearing to '' hands display back to the stylesheet
+    // (body.mobile-touch.game-active shows it, desktop keeps it hidden).
+    const mobileControls = document.getElementById('mobile-controls');
+    if (mobileControls) mobileControls.style.display = display;
     nameplates.style.display = display;
   };
   const finishIntro = (skipToEnd: boolean): void => {

--- a/tests/spawn_cinematic.test.ts
+++ b/tests/spawn_cinematic.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type CameraPose,
+  spawnCinematicFor,
+  spawnCinematicPose,
+} from '../src/game/spawn_cinematic';
+
+// The gameplay pose the cinematic must land on (input.ts camera defaults).
+const END: CameraPose = { yaw: Math.PI, pitch: 0.32, dist: 12 };
+
+describe('spawn cinematic camera path', () => {
+  const cin = spawnCinematicFor(END);
+
+  it('opens far and high, one full turn behind the landing yaw', () => {
+    const p0 = spawnCinematicPose(0, cin);
+    expect(p0.done).toBe(false);
+    expect(p0.dist).toBe(cin.startDist);
+    expect(p0.pitch).toBe(cin.startPitch);
+    expect(p0.yaw).toBeCloseTo(END.yaw - cin.turns * Math.PI * 2, 10);
+  });
+
+  it('clamps negative time to the opening pose', () => {
+    expect(spawnCinematicPose(-5, cin)).toEqual(spawnCinematicPose(0, cin));
+  });
+
+  it('lands exactly on the gameplay pose and reports done', () => {
+    for (const t of [cin.durationSec, cin.durationSec + 3]) {
+      const p = spawnCinematicPose(t, cin);
+      expect(p.done).toBe(true);
+      expect(p.yaw).toBeCloseTo(END.yaw, 10);
+      expect(p.pitch).toBeCloseTo(END.pitch, 10);
+      expect(p.dist).toBeCloseTo(END.dist, 10);
+    }
+  });
+
+  it('moves monotonically: yaw forward, camera never pulls back out', () => {
+    let prev = spawnCinematicPose(0, cin);
+    for (let t = 0.05; t <= cin.durationSec; t += 0.05) {
+      const p = spawnCinematicPose(t, cin);
+      expect(p.yaw).toBeGreaterThanOrEqual(prev.yaw);
+      expect(p.dist).toBeLessThanOrEqual(prev.dist + 1e-9);
+      expect(p.pitch).toBeLessThanOrEqual(prev.pitch + 1e-9);
+      prev = p;
+    }
+  });
+
+  it('is continuous: no per-frame jumps anywhere on the path', () => {
+    const step = 1 / 60;
+    let prev = spawnCinematicPose(0, cin);
+    for (let t = step; t <= cin.durationSec + step; t += step) {
+      const p = spawnCinematicPose(t, cin);
+      expect(Math.abs(p.yaw - prev.yaw)).toBeLessThan(0.05);
+      expect(Math.abs(p.dist - prev.dist)).toBeLessThan(0.15);
+      expect(Math.abs(p.pitch - prev.pitch)).toBeLessThan(0.02);
+      prev = p;
+    }
+  });
+});

--- a/tests/spawn_cinematic.test.ts
+++ b/tests/spawn_cinematic.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   type CameraPose,
+  recordSkipTap,
+  SKIP_TAP_COUNT,
+  SKIP_TAP_WINDOW_SEC,
   spawnCinematicFor,
   spawnCinematicPose,
 } from '../src/game/spawn_cinematic';
@@ -11,12 +14,16 @@ const END: CameraPose = { yaw: Math.PI, pitch: 0.32, dist: 12 };
 describe('spawn cinematic camera path', () => {
   const cin = spawnCinematicFor(END);
 
-  it('opens far and high, one full turn behind the landing yaw', () => {
+  it('opens far out and high, a fraction of a turn behind the landing yaw', () => {
     const p0 = spawnCinematicPose(0, cin);
     expect(p0.done).toBe(false);
     expect(p0.dist).toBe(cin.startDist);
     expect(p0.pitch).toBe(cin.startPitch);
     expect(p0.yaw).toBeCloseTo(END.yaw - cin.turns * Math.PI * 2, 10);
+    // An approach, not an orbit: well under half a turn of total sweep.
+    expect(cin.turns).toBeLessThan(0.5);
+    // An establishing shot: it starts far beyond the gameplay camera.
+    expect(cin.startDist).toBeGreaterThan(2 * END.dist);
   });
 
   it('clamps negative time to the opening pose', () => {
@@ -33,7 +40,7 @@ describe('spawn cinematic camera path', () => {
     }
   });
 
-  it('moves monotonically: yaw forward, camera never pulls back out', () => {
+  it('moves monotonically: yaw forward, camera always closing in and settling', () => {
     let prev = spawnCinematicPose(0, cin);
     for (let t = 0.05; t <= cin.durationSec; t += 0.05) {
       const p = spawnCinematicPose(t, cin);
@@ -54,5 +61,30 @@ describe('spawn cinematic camera path', () => {
       expect(Math.abs(p.pitch - prev.pitch)).toBeLessThan(0.02);
       prev = p;
     }
+  });
+});
+
+describe('skip tap burst', () => {
+  it('a lone tap or slow taps never skip', () => {
+    const taps: number[] = [];
+    expect(recordSkipTap(taps, 1)).toBe(false);
+    // One tap every 2 s: the window keeps pruning, never reaches the count.
+    for (let t = 3; t < 20; t += 2) expect(recordSkipTap(taps, t)).toBe(false);
+  });
+
+  it('a rapid burst skips', () => {
+    const taps: number[] = [];
+    let skipped = false;
+    for (let i = 0; i < SKIP_TAP_COUNT; i++) {
+      skipped = recordSkipTap(taps, 1 + i * 0.15);
+    }
+    expect(skipped).toBe(true);
+  });
+
+  it('taps outside the window do not count toward the burst', () => {
+    const taps: number[] = [];
+    for (let i = 0; i < SKIP_TAP_COUNT - 1; i++) recordSkipTap(taps, i * 0.1);
+    // The next tap lands past the window: everything before it is pruned.
+    expect(recordSkipTap(taps, SKIP_TAP_WINDOW_SEC + 1)).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

A newly created character is dropped straight into gameplay with no sense of place: the camera snaps to the gameplay pose and the HUD is already up. Classic MMOs open a new character with a short establishing shot of the world around the spawn before handing over control.

## Feature

On a character's first world entry, the camera opens 55 yd out across the field, high over the world, and glides in one continuous eased approach toward the character (a 0.3-turn sweep, not an orbit), landing exactly on the normal gameplay camera pose. The HUD and nameplates stay hidden until the camera lands, and the loading-screen fade doubles as the cut in, so there is no extra overlay.

- Plays exactly once per character: a localStorage seen marker keyed by the keybind scope (per online character id, per offline class + name).
- Only for new characters (level 1) and never for reduce-motion players, who go straight to gameplay.
- Deliberate skip only: Escape on desktop (eaten so it does not also open the game menu), or a rapid 4-tap burst inside 1.5 s on touch, where there is no Escape key. All other input is swallowed while it runs; a stray click or keypress does not cancel it.
- Works for both the online and offline entry paths. The camera path is pure math in src/game/spawn_cinematic.ts (no DOM), applied per frame between the follow-camera update and the renderer read, so it wins over mouse and follow input and hands off with zero snap. The renderer's existing terrain clamp keeps the long approach above ground.

## Verification

- tests/spawn_cinematic.test.ts pins the path contract (opening pose, exact landing on the gameplay pose, monotonic approach, per-frame continuity) and the tap-burst skip tracker (lone or slow taps never skip, a rapid burst does, the sliding window prunes).
- Browser end to end against the real dev client (offline quick start, headless Chrome): intro opens far out with the HUD hidden, a single click and a movement key do not skip, Escape skips without opening the menu, a 4-tap burst skips, an untouched run glides in and lands on the exact gameplay pose with the HUD restored, and a second entry with the same character does not replay it.
- tsc and the architecture guard are green on this base.

Note for the queue: the map-editor PR #1312 adds a custom-world parameter to startOffline; if both land, editor play-test entries should pass the intro flag as false so play-testing a map never triggers the cinematic (the map-editor branch already carries that form of the call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)