### PR TITLE
fix(ui): show empty mana warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,6 +302,7 @@
 
     <div id="quest-tracker"></div>
     <div id="delve-tracker"></div>
+    <div id="empty-mana-warning" class="empty-mana-warning" role="status" aria-live="polite" hidden></div>
 
     <div id="bottom-bar">
       <div id="actionbar-row">

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -681,7 +681,7 @@
     line-height: 15px;
     font-size: 9px;
     font-weight: bold;
-    letter-spacing: 0.5px;
+    letter-spacing: 0;
     color: #eaf4ff;
     text-shadow:
       0 0 3px #000,
@@ -689,6 +689,39 @@
     text-transform: uppercase;
     pointer-events: none;
     animation: low-resource-pulse var(--lr-pulse, 1s) ease-in-out infinite;
+  }
+  .bar.low.critical .bar-fill {
+    box-shadow:
+      0 0 9px 2px rgba(120, 210, 255, var(--lr-opacity)),
+      0 0 18px rgba(45, 135, 255, 0.65),
+      inset 0 0 6px rgba(235, 250, 255, 0.95);
+  }
+  .empty-mana-warning {
+    position: fixed;
+    top: 42%;
+    left: 50%;
+    z-index: 75;
+    transform: translate(-50%, -50%);
+    min-width: 210px;
+    padding: 8px 14px;
+    border: 1px solid rgba(150, 220, 255, 0.72);
+    border-radius: 4px;
+    background: rgba(6, 16, 30, 0.78);
+    box-shadow:
+      0 0 16px rgba(80, 185, 255, 0.55),
+      inset 0 0 10px rgba(150, 220, 255, 0.18);
+    color: #f2fbff;
+    font-size: 18px;
+    font-weight: bold;
+    line-height: 1;
+    letter-spacing: 0;
+    text-align: center;
+    text-shadow:
+      0 0 3px #000,
+      1px 1px 1px #000;
+    text-transform: uppercase;
+    pointer-events: none;
+    animation: low-resource-pulse var(--lr-pulse, 0.42s) ease-in-out infinite;
   }
   .bar.energy.low .low-resource-label {
     color: #fff3c2;
@@ -706,10 +739,12 @@
   }
   @media (prefers-reduced-motion: reduce) {
     .bar.low .bar-fill,
-    .low-resource-label {
+    .low-resource-label,
+    .empty-mana-warning {
       animation: none;
     }
-    .low-resource-label {
+    .low-resource-label,
+    .empty-mana-warning {
       opacity: 1;
     }
   }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -747,6 +747,7 @@ export class Hud {
   private pfResEl = $('#pf-res');
   private pfResTextEl = $('#pf-res-text');
   private pfResourceEl = $('#pf-resource');
+  private emptyManaWarningEl = $('#empty-mana-warning');
   private pfAbsorbEl = $('#pf-absorb');
   private buffBarEl = $('#buff-bar');
   private debuffBarEl = $('#debuff-bar');
@@ -5064,17 +5065,26 @@ export class Hud {
     // is cheap and idempotent. Only the expensive style / label writes below are
     // diffed against the cached signature.
     bar.classList.toggle('low', v.active);
-    const sig = v.active ? `${v.opacity.toFixed(2)}|${v.pulseSeconds.toFixed(2)}|${v.label}` : '';
+    bar.classList.toggle('critical', v.active && v.critical);
+    const sig = v.active
+      ? `${v.critical ? 'critical' : 'low'}|${v.opacity.toFixed(2)}|${v.pulseSeconds.toFixed(2)}|${v.label}`
+      : '';
     if (sig === this.lastLowResourceSig) return;
     this.lastLowResourceSig = sig;
     const label = $('#pf-low-resource') as HTMLElement;
+    const center = this.emptyManaWarningEl as HTMLElement;
     if (v.active) {
       bar.style.setProperty('--lr-opacity', String(v.opacity));
       bar.style.setProperty('--lr-pulse', `${v.pulseSeconds}s`);
       label.textContent = v.label;
       label.style.display = 'block';
+      center.textContent = v.critical ? v.label : '';
+      center.hidden = !v.critical;
+      center.style.setProperty('--lr-pulse', `${v.pulseSeconds}s`);
     } else {
       label.style.display = 'none';
+      center.hidden = true;
+      center.textContent = '';
     }
   }
 

--- a/src/ui/low_resource.ts
+++ b/src/ui/low_resource.ts
@@ -17,6 +17,7 @@ export interface LowResourceInput {
 
 export interface LowResourceView {
   active: boolean; // warning visible
+  critical: boolean; // empty mana state; rendered stronger than low-resource
   opacity: number; // 0..1 glow strength, intensifies toward empty
   pulseSeconds: number; // breathe period; shorter = more urgent
   label: string; // "Low Mana" / "Low Energy" ('' when inactive)
@@ -27,7 +28,13 @@ export const LOW_RESOURCE_THRESHOLD = 0.25;
 
 export function lowResourceView(input: LowResourceInput): LowResourceView {
   const { resource, maxResource, resourceType } = input;
-  const inactive: LowResourceView = { active: false, opacity: 0, pulseSeconds: 0, label: '' };
+  const inactive: LowResourceView = {
+    active: false,
+    critical: false,
+    opacity: 0,
+    pulseSeconds: 0,
+    label: '',
+  };
 
   // Only mana/energy warn; rage and resource-less/degenerate frames are silent.
   if (maxResource <= 0) return inactive;
@@ -35,17 +42,26 @@ export function lowResourceView(input: LowResourceInput): LowResourceView {
 
   const frac = clamp01(resource / maxResource);
   if (frac >= LOW_RESOURCE_THRESHOLD) return inactive;
+  if (resourceType === 'mana' && resource <= 0) {
+    return {
+      active: true,
+      critical: true,
+      opacity: 1,
+      pulseSeconds: 0.42,
+      label: t('hud.errors.notEnoughMana'),
+    };
+  }
 
   // t: 0 at the threshold, 1 at empty.
   const tt = clamp01((LOW_RESOURCE_THRESHOLD - frac) / LOW_RESOURCE_THRESHOLD);
   // Ease the glow in (matches the low-health vignette feel) and keep a floor so
   // it's visible the instant it crosses the threshold.
-  const opacity = 0.4 + Math.pow(tt, 0.8) * 0.55;
+  const opacity = 0.4 + tt ** 0.8 * 0.55;
   // Breathe slowly when just-low (~1.4s), urgently when near-empty (~0.5s).
   const pulseSeconds = 1.4 - tt * 0.9;
   const label = resourceType === 'mana' ? t('game.hud.lowMana') : t('game.hud.lowEnergy');
 
-  return { active: true, opacity, pulseSeconds, label };
+  return { active: true, critical: false, opacity, pulseSeconds, label };
 }
 
 function clamp01(v: number): number {

--- a/tests/low_resource.test.ts
+++ b/tests/low_resource.test.ts
@@ -3,12 +3,18 @@ import { lowResourceView, LOW_RESOURCE_THRESHOLD } from '../src/ui/low_resource'
 
 describe('lowResourceView', () => {
   it('is inactive for rage (rage builds in combat — low is normal)', () => {
-    expect(lowResourceView({ resource: 0, maxResource: 100, resourceType: 'rage' }).active).toBe(false);
+    expect(lowResourceView({ resource: 0, maxResource: 100, resourceType: 'rage' }).active).toBe(
+      false,
+    );
   });
 
   it('is inactive with no resource type or a degenerate max', () => {
-    expect(lowResourceView({ resource: 0, maxResource: 0, resourceType: 'mana' }).active).toBe(false);
-    expect(lowResourceView({ resource: 5, maxResource: 100, resourceType: null }).active).toBe(false);
+    expect(lowResourceView({ resource: 0, maxResource: 0, resourceType: 'mana' }).active).toBe(
+      false,
+    );
+    expect(lowResourceView({ resource: 5, maxResource: 100, resourceType: null }).active).toBe(
+      false,
+    );
   });
 
   it('is inactive when above the threshold', () => {
@@ -18,9 +24,14 @@ describe('lowResourceView', () => {
   });
 
   it('activates just below the threshold for mana', () => {
-    const v = lowResourceView({ resource: LOW_RESOURCE_THRESHOLD * 100 - 1, maxResource: 100, resourceType: 'mana' });
+    const v = lowResourceView({
+      resource: LOW_RESOURCE_THRESHOLD * 100 - 1,
+      maxResource: 100,
+      resourceType: 'mana',
+    });
     expect(v.active).toBe(true);
     expect(v.label).toBe('Low Mana');
+    expect(v.critical).toBe(false);
     expect(v.opacity).toBeGreaterThan(0);
   });
 
@@ -28,6 +39,16 @@ describe('lowResourceView', () => {
     const v = lowResourceView({ resource: 10, maxResource: 100, resourceType: 'energy' });
     expect(v.active).toBe(true);
     expect(v.label).toBe('Low Energy');
+    expect(v.critical).toBe(false);
+  });
+
+  it('promotes empty mana to a critical center-screen warning', () => {
+    const v = lowResourceView({ resource: 0, maxResource: 100, resourceType: 'mana' });
+    expect(v.active).toBe(true);
+    expect(v.critical).toBe(true);
+    expect(v.label).toBe('Not enough mana!');
+    expect(v.opacity).toBe(1);
+    expect(v.pulseSeconds).toBeLessThan(0.5);
   });
 
   it('intensifies (more opaque, faster pulse) toward empty', () => {


### PR DESCRIPTION
﻿## Summary

This PR makes the empty-mana state much harder to miss for mana users.

- Promotes exactly-empty mana from the ordinary low-resource warning to a critical warning state.
- Shows a centered `Not enough mana!` HUD alert while mana is empty, while keeping the existing resource-bar label/pulse for continuity.
- Strengthens the resource bar glow in the critical state and respects reduced-motion preferences.
- Reuses the existing localized `hud.errors.notEnoughMana` string, so no new i18n/generated-string churn is needed.

## Related issues

Part of #15

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write index.html src\ui\low_resource.ts src\ui\hud.ts src\styles\hud.css tests\low_resource.test.ts`
  - `npx vitest run tests\low_resource.test.ts tests\client_shell.test.ts` -> 2 files passed, 74 tests passed
  - `npm run check:ts`
  - `npx biome lint index.html src\ui\low_resource.ts src\ui\hud.ts src\styles\hud.css tests\low_resource.test.ts` -> exits 0; reports existing unrelated `src/ui/hud.ts` non-null assertion warnings in the loot modal code
- Visual validation:
  - Started local Vite dev server at `http://127.0.0.1:5173/` with the existing temporary `.browserslistrc` comment-strip workaround, then restored `.browserslistrc`.
  - Booted an offline Mage, forced mana to `0 / 195` via the repo's local `window.__game` visual-script hook, and verified:
    - center alert text: `Not enough mana!`
    - resource bar class: `bar mana low critical`
    - center alert visible at viewport center area
  - Screenshot captured: `C:\tmp\woc-empty-mana-warning-center.png`

## Screenshots / recordings

![Empty mana warning](C:/tmp/woc-empty-mana-warning-center.png)

---

## Checklist

### Quality

- [x] **Tests pass.** Focused low-resource and client-shell tests are green.
- [x] **Typecheck passes.** `npm run check:ts` is clean.
- [ ] **Builds succeed.** Not run for this narrow HUD patch.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Desktop viewport visual validation was performed; mobile was not covered for this narrow HUD patch.
- [x] **Accessible.** The center alert is a `role="status"` live region and respects reduced-motion preferences.

### Localization (i18n)

- [x] N/A. This PR reuses the existing localized `hud.errors.notEnoughMana` string and adds no new player-visible copy.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
