### PR TITLE
fix(loot): shorten corpse owner lock

### DIFF
--- a/src/sim/loot/loot_ffa.ts
+++ b/src/sim/loot/loot_ffa.ts
@@ -12,8 +12,9 @@
 // deterministic and unit-testable (reference: format_money.ts, threat.ts).
 
 // Seconds a tapped corpse stays owner-locked after it becomes lootable. After
-// this, any player may loot it. One minute, matching classic-era behavior.
-export const LOOT_FFA_DELAY = 60;
+// this, any player may loot it, so stray corpses no longer sit around as
+// confusing "permission denied" targets for other players.
+export const LOOT_FFA_DELAY = 10;
 
 /**
  * Has a lootable corpse's owner-lock lapsed? Drives the FFA flag from the

--- a/tests/loot_ffa.test.ts
+++ b/tests/loot_ffa.test.ts
@@ -5,8 +5,8 @@ import { hasSharedLootRights, LOOT_FFA_DELAY, lootHasGoneFfa } from '../src/sim/
 // owner has not cleared within LOOT_FFA_DELAY seconds opens to everyone.
 
 describe('loot FFA timeout', () => {
-  it('locks to classic one minute', () => {
-    expect(LOOT_FFA_DELAY).toBe(60);
+  it('opens tapped corpse loot to everyone after ten seconds', () => {
+    expect(LOOT_FFA_DELAY).toBe(10);
   });
 
   it('lootHasGoneFfa flips only once the countdown reaches zero', () => {

--- a/tests/loot_ffa_sim.test.ts
+++ b/tests/loot_ffa_sim.test.ts
@@ -23,7 +23,9 @@ function setup() {
 
   // Both standing on the corpse so the interact-range gate is satisfied.
   for (const pid of [tapper, stranger]) {
-    const e = internals.entities.get(pid)!;
+    const e = internals.entities.get(pid);
+    expect(e).toBeDefined();
+    if (!e) throw new Error(`missing player entity ${pid}`);
     e.pos = { x: 0, y: 0, z: 0 };
     e.prevPos = { x: 0, y: 0, z: 0 };
   }
@@ -48,7 +50,7 @@ function setup() {
 
 const copperOf = (meta: PlayerMeta | undefined) => meta?.copper ?? 0;
 
-describe('loot goes FFA one minute after a corpse becomes lootable', () => {
+describe('loot goes FFA ten seconds after a corpse becomes lootable', () => {
   it('blocks a stranger while the corpse is still owner-locked', () => {
     const { sim, internals, stranger, mob } = setup();
     expect(mob.lootFfaTimer).toBeGreaterThan(0);
@@ -65,9 +67,23 @@ describe('loot goes FFA one minute after a corpse becomes lootable', () => {
     expect(copperOf(internals.players.get(tapper))).toBeGreaterThan(before);
   });
 
+  it('keeps the owner lock only for the ten-second cleanup window', () => {
+    const { sim, internals, stranger, mob } = setup();
+    const before = copperOf(internals.players.get(stranger));
+
+    for (let i = 0; i < 20 * (LOOT_FFA_DELAY - 1) && mob.lootFfaTimer > 1; i++) sim.tick();
+    expect(mob.lootFfaTimer).toBeGreaterThan(0);
+    sim.lootCorpse(mob.id, stranger);
+    expect(copperOf(internals.players.get(stranger))).toBe(before);
+
+    for (let i = 0; i < 20 * 2 && mob.lootFfaTimer > 0; i++) sim.tick();
+    expect(mob.lootFfaTimer).toBeLessThanOrEqual(0);
+    sim.lootCorpse(mob.id, stranger);
+    expect(copperOf(internals.players.get(stranger))).toBeGreaterThan(before);
+  });
   it('lets a stranger loot once the owner-lock has lapsed', () => {
     const { sim, internals, stranger, mob } = setup();
-    // Drive the dead-mob tick until the owner-lock lapses (just over one minute).
+    // Drive the dead-mob tick until the owner-lock lapses (just over ten seconds).
     for (let i = 0; i < 20 * (LOOT_FFA_DELAY + 1) && mob.lootFfaTimer > 0; i++) sim.tick();
     expect(mob.lootFfaTimer).toBeLessThanOrEqual(0);
     expect(mob.lootable).toBe(true); // corpse still present to be looted


### PR DESCRIPTION
﻿## Summary

This PR addresses the corpse-cleanup QoL bullet from #15 by shortening the tapped-corpse owner-lock window.

- Tapped corpse loot now opens to free-for-all after 10 seconds instead of 60 seconds.
- This keeps the original tapper/party protection briefly, but prevents corpses from sitting around as long-lived "permission denied" targets for nearby players.
- The existing deterministic FFA countdown path is reused; no loot drops, roll outcomes, or entitlement rules change besides the timeout duration.

## Related issues

Part of #15

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src\sim\loot\loot_ffa.ts tests\loot_ffa.test.ts tests\loot_ffa_sim.test.ts`
  - `npx vitest run tests\loot_ffa.test.ts tests\loot_ffa_sim.test.ts tests\interaction.test.ts` -> 3 files passed, 26 tests passed
  - `npm run check:ts`
  - `npx biome lint src\sim\loot\loot_ffa.ts tests\loot_ffa.test.ts tests\loot_ffa_sim.test.ts`
- Notes:
  - Vitest was run with `.browserslistrc` comment lines temporarily stripped/restored due an existing Vite config parser limitation.

## Screenshots / recordings

N/A. This is a simulation loot-timer change with no static UI layout change.

---

## Checklist

### Quality

- [x] **Tests pass.** Focused loot FFA and interaction coverage is green.
- [x] **Typecheck passes.** `npm run check:ts` is clean.
- [ ] **Builds succeed.** Not run for this narrow sim-timer patch.

### Cross-platform

- [ ] **Tested on desktop and mobile.**
- [x] **Accessible.** N/A; this PR changes loot timing, not UI controls or text.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
