### PR TITLE
docs(prd): Badges of Valor + heroic/mythic+ dungeons (endgame retention)

### DIFF
--- a/docs/prd/badges.md
+++ b/docs/prd/badges.md
@@ -1,0 +1,269 @@
+# PRD: Badges of Valor (Endgame Currency and Quartermaster Vendor)
+
+Status: draft v2 (tuning pass applied: no badges from normal dungeons,
+heroic pays 1, raid pays 3; vendor stock fully specified)
+Owner: design
+Companion doc: `docs/prd/heroic-mythic-dungeons.md` (the primary badge
+earner and the forged-drop system)
+
+## 1. Summary
+
+A deterministic endgame currency, the **Badge of Valor**, awarded for
+clearing max-level group content: heroic and mythic+ dungeons, the
+Nythraxis raid, the world boss, and delve clears. Badges are spent at a new
+**Badge Quartermaster** NPC selling level-20 gear and cosmetics. The point
+is retention math the player can see: a bad-luck run still pays, and "N
+more runs until the epic chest" is always a concrete, plannable number.
+
+Design reference: the classic-era "Badge of Justice" model, where the end
+boss of cap-level content pays a predictable token and the vendor stock
+sits slightly below raid drops so raiding stays aspirational.
+
+Design pillars (definitive):
+1. **Badges come only from max-level content.** Normal leveling dungeons
+   pay zero; nobody should farm a level 8 instance at the cap.
+2. **No friction between completion and payout.** The award is on the kill
+   or the clear, never behind a chest, lockbox, minigame, or timer.
+3. **Deterministic on top of RNG, never instead of it.** Loot tables are
+   untouched; badges are the pity layer.
+
+## 2. Background and motivation
+
+### 2.1 The gap
+At the level cap (20, which stays the cap) the reward loop is pure RNG:
+dungeon and raid loot tables, the daily world boss roll, delve marks
+(delve-only sink). A player whose slots are mostly filled has no reason to
+run anything again; a player on a bad-luck streak has nothing to show for a
+week of runs. Lifetime XP / prestige
+(`docs/prd/max-level-xp-overflow.md`) gives cosmetic cadence but no gear
+agency.
+
+### 2.2 The fix
+Deterministic progress layered on top of existing RNG loot. Every piece of
+**max-level** content pays badges on completion, and heroic/mythic+
+(companion PRD) turns all three existing dungeons into max-level content,
+so the badge faucet and the difficulty system launch as one loop.
+
+## 3. Current state in the codebase (what this reuses)
+
+- **Currency-as-counter precedent:** `delveMarks` on `CharacterState`
+  (`src/sim/sim.ts`), spent in the delve shop
+  (`src/sim/content/delves/shop.ts`). Badges follow the same shape: a
+  counter, not a bag item.
+- **Daily-gate precedent:** `worldBossDaily` (`src/sim/world_boss.ts`):
+  UTC-day window keyed off the host-provided `utcDay`, no-op when the day
+  is unknown (headless/replay stays reproducible). `delveDaily` is the
+  multi-counter variant.
+- **Weekly-gate precedent:** `raidLockouts` (per-dungeon expiry ms).
+- **Contributor derivation:** `worldBossContributors()` (hate-table
+  contributors, pets credit owners, sorted by entityId for fixed rng
+  order). Badge awards reuse it verbatim.
+- **Vendor precedent:** NPC vendors with buy/sell and `vendorBuyback`; the
+  delve shop shows a non-copper purchase path.
+- **Cosmetic sink with zero new item i18n:** `event_skin_token`
+  ("Mysterious Cosmetic Cache", `src/sim/content/items.ts`) already rolls a
+  skin rarity server-side and opens the skin-select overlay; it is
+  currently dev-grant only. Selling it for badges gives the vendor an
+  evergreen, repeatable sink on day one.
+- **Stat-budget convention:** no formal budget table exists; items balance
+  to peers (see the empirical convention comment in
+  `src/sim/content/items.ts`: armor slot-weighted off the chest/legs
+  baseline at roughly head 1.0, shoulder 0.75, gloves 0.65, waist 0.55).
+  Level-20 anchors in `src/sim/content/zone3.ts`: class-group rare feet at
+  14 stat points (armor 68, int 9, spi 5); raid epic chests at 18 to 22
+  points (Deathlord Warplate armor 270, str 8, sta 10; Necromancer's
+  Starshroud armor 92, int 14, spi 8).
+
+## 4. Goals and non-goals
+
+### Goals
+1. Every max-level group activity pays a predictable badge amount on
+   completion, server-authoritatively.
+2. The vendor turns badges into gear (slightly below raid quality) and
+   cosmetics, so both the unlucky and the fully-geared keep running.
+3. Daily and weekly gates reuse the existing `utcDay` / lockout patterns;
+   determinism and replay reproducibility untouched.
+4. The v1 gear stock is a fully specified, self-contained authoring slice
+   (section 5.3) suitable for delegation to codex.
+
+### Non-goals
+- No level-cap raise; 20 stays the cap.
+- No badges from normal (leveling) dungeon runs, ever. They stay the
+  leveling path.
+- No badge trading, mailing, or market listing (a counter cannot leak into
+  the economy).
+- No second currency tier in v1 (add a second counter later if the economy
+  wants one).
+- Delve marks stay as they are: marks buy delve-local upgrades, badges buy
+  character gear.
+- No open-world biome level scaling (separate PRD if pursued).
+
+## 5. Functional requirements
+
+### 5.1 Earning (definitive table, v1)
+
+| Source | Badges | Gate |
+|---|---|---|
+| Normal dungeon, any boss | 0 | by design (pillar 1) |
+| Heroic dungeon final boss | 1 | 1 paid kill per dungeon per UTC day |
+| Mythic+ clear | 2 (keys 2 to 4), 3 (keys 5 to 9), 4 (key 10+) | shares the heroic daily slot per dungeon (one paid dungeon-kill per day, the higher rate applies) |
+| Nythraxis raid boss | 3 | rides the existing raid lockout (weekly) |
+| World boss (Thunzharr) | 2 | rides the existing `worldBossDaily` loot gate |
+| Delve clear (normal or heroic) | 1 | shares the existing `delveDaily` mark-clear cap |
+
+Rules:
+- Awarded to every eligible **contributor** via the
+  `worldBossContributors` semantics.
+- The award lands on kill/clear, never on a chest or bonus objective
+  (pillar 2). The mythic+ end-of-run chest is a separate gear reward
+  (companion PRD); badges do not route through it.
+- When `utcDay` is unknown (offline browser world, headless RL env), gates
+  are not enforced, mirroring `isWorldBossLootEligible`. Offline play is
+  non-authoritative, so nothing leaks into the online economy.
+- Faucet model: a daily player clearing 3 heroic/mythic+ dungeons, the
+  world boss, and 2 delves earns roughly 8 to 10 per day, plus 3 per week
+  from the raid: call it 60 to 70 per week hardcore, about 20 to 25 per
+  week for a casual third of that.
+
+### 5.2 Pricing (tuned to the 5.1 faucet)
+
+| Stock class | Price | Cadence check |
+|---|---|---|
+| Rare gear piece | 10 | casual: one every 3 to 4 days |
+| Epic gear piece | 45 | casual: one every ~2 weeks; daily player: ~5 days |
+| Mysterious Cosmetic Cache | 30 | evergreen repeatable sink |
+
+Purchases resolve server-side through the vendor buy path with a
+`costBadges` field on the stock entry instead of copper; insufficient
+badges is a normal vendor rejection.
+
+### 5.3 The Badge Quartermaster stock (full v1 authoring spec)
+
+A new NPC vendor in the zone 3 settlement near the Gravewyrm Sanctum
+entrance (exact placement at implementation). Ten gear items plus the
+cache. **This table is the implementation spec for the gear slice, which
+is delegated to codex** (see phasing): ids, slots, class groups, and stat
+points are fixed here; armor values follow the slot-weight convention off
+the zone3 class-group baselines; `sellValue` matches zone3 peers (rare
+3200, epic 9000); all pieces `noMarketList` (badge gear must not become a
+gold printer).
+
+Naming theme: "Valewarden" (plate group), "Mistrunner" (leather group),
+"Thornweave" (cloth group), after the Vale / Thornpeak lore already in
+zone 3.
+
+| id | Name | Slot | Quality | Classes | Stats (points) | Price |
+|---|---|---|---|---|---|---|
+| valewarden_girdle | Valewarden Girdle | waist | rare | warrior, paladin, shaman | str 6, sta 5 (11) | 10 |
+| valewarden_stompers | Valewarden Stompers | feet | rare | warrior, paladin, shaman | str 7, sta 5 (12) | 10 |
+| mistrunner_cord | Mistrunner Cord | waist | rare | rogue, hunter | agi 6, sta 5 (11) | 10 |
+| mistrunner_treads | Mistrunner Treads | feet | rare | rogue, hunter | agi 7, sta 5 (12) | 10 |
+| thornweave_sash | Thornweave Sash | waist | rare | mage, priest, warlock, druid | int 6, spi 5 (11) | 10 |
+| thornweave_slippers | Thornweave Slippers | feet | rare | mage, priest, warlock, druid | int 7, spi 5 (12) | 10 |
+| valewarden_breastplate | Valewarden Breastplate | chest | epic | warrior, paladin, shaman | str 8, sta 8 (16) | 45 |
+| mistrunner_tunic | Mistrunner Tunic | chest | epic | rogue, hunter | agi 9, sta 8 (17) | 45 |
+| thornweave_robe | Thornweave Robe | chest | epic | mage, priest, warlock, druid | int 10, spi 8 (18) | 45 |
+| valewarden_crown | Valewarden Crown | helmet | epic | warrior, paladin, shaman | str 7, sta 8 (15) | 45 |
+| event_skin_token | Mysterious Cosmetic Cache | (use item) | epic | all | rolls a skin rarity on use (existing behavior) | 30 |
+
+Budget rationale: epic chests sit 2 to 4 stat points below their Nythraxis
+equivalents (Deathlord 18, Necromancer's 22, Wyrmshadow 20), so raid drops
+stay best-in-slot; rares sit at or just below the zone3 rare anchors,
+slot-weighted. Armor values: compute from the class-group zone3 chest
+baseline times the slot weight, rounded to the nearest 2.
+
+### 5.4 Persistence and data model
+
+`CharacterState` (JSONB) additions, following the established
+serialize / `addPlayer` backfill pattern:
+
+- `badges: number` (init and backfill 0)
+- `badgeDaily: { date: string, dungeonPaid: Record<string, boolean> }`:
+  one paid heroic-or-mythic+ kill per dungeon per UTC day, rolls over on
+  `utcDay` change (the `delveDaily` shape).
+
+Raid and world boss sources need no new gate state (they ride existing
+lockouts). Wire: `badges` ships in the owning player's snapshot only
+(private, like copper).
+
+### 5.5 Determinism and architecture invariants
+
+- No new randomness: awards are fixed amounts; the cosmetic cache keeps
+  its existing server-side `Rng` roll.
+- No `Date.now` in sim logic: the UTC day arrives from the host exactly as
+  it does for `worldBossDaily`.
+- New logic is a small module (`src/sim/progression/badges.ts`); the
+  quartermaster stock is a declarative record in `src/sim/content/` merged
+  by `data.ts`; nothing lands inline in `sim.ts`. Guarded by
+  `tests/architecture.test.ts`.
+- `IWorld` gains read surface for the badge count and the quartermaster
+  stock; implemented in both `Sim` and `ClientWorld` before any UI
+  consumes it.
+
+## 6. Localization (budget for it, it is the hidden cost)
+
+- **The 10 new gear items need names in every locale in the same change**;
+  experience says English-only item names fail the localization coverage
+  test (this is why v1 stock is exactly 10 pieces and why the cosmetic
+  sink reuses `event_skin_token` instead of minting a new item). The codex
+  gear slice includes drafting all locale overlay entries for maintainer
+  review.
+- The currency name ("Badge of Valor"), quartermaster NPC name, and any
+  server-emitted award line ("You receive 2 Badges of Valor.") follow the
+  sim/server rule: sim stays language-agnostic; emit a stable key plus
+  values re-localized via `src/ui/sim_i18n.ts` and `server_i18n.ts` in the
+  same change (S3 guard: `tests/localization_fixes.test.ts`).
+- New HUD strings (currency row, vendor badge pricing label) are `t()`
+  keys in the English catalog modules; the i18n completeness gate has
+  blocked new catalog keys before, so keep new UI chrome minimal and
+  coordinate the locale fill with the release pass.
+- Wiki: run `npm run wiki:content` and add `guide.*` prose keys for the
+  badge system page (`tests/guide.test.ts` gates freshness).
+
+## 7. Testing and acceptance
+
+Vitest, new `tests/badges.test.ts`:
+- normal dungeon bosses award 0 in all difficulties' absence (regression
+  pin for pillar 1);
+- heroic kill pays 1 once per dungeon per day, 0 after; a mythic+ clear
+  consumes the same slot at its higher rate; second dungeon same day still
+  pays;
+- raid pays 3 on lockout grant only; world boss pays 2 alongside the
+  existing loot-gate check; delve clear pays 1 under the mark-clear cap;
+- gates roll over on `utcDay` change and are inert when `utcDay` is `''`;
+- contributor derivation matches world boss semantics (pets credit owner);
+- vendor purchase deducts badges, grants the item, rejects on insufficient
+  badges or full bags; badge gear is not market-listable;
+- persistence roundtrip: serialize then `addPlayer` restores `badges` and
+  `badgeDaily`; pre-badge saves backfill to 0.
+
+Plus: golden-test any new SimEvent; a `cross-platform-sync` agent pass for
+IWorld / wire drift; `tests/architecture.test.ts`,
+`tests/localization_fixes.test.ts`, and `tests/guide.test.ts` stay green.
+
+## 8. Phasing (with delegation)
+
+1. **P1, sim core (fable/opus):** counter, `badgeDaily`, award hooks on
+   the heroic/mythic+/raid/world-boss/delve paths, persistence, wire,
+   tests. Depends on companion PRD P1 (heroic exists first).
+2. **P2, vendor gear (codex / gpt-5.5 slice):** the 10 items from the 5.3
+   table plus all-locale names, quartermaster NPC + stock record, badge
+   purchase path, purchase tests. The 5.3 table is the complete spec;
+   review by fable before merge.
+3. **P3, UI (taste-critical, stays on fable/opus):** currency display in
+   the character sheet and vendor window badge pricing, award floating
+   combat text, wiki page.
+4. **P4, follow-ons:** arena win badges (daily-capped, pending PvP
+   population), a second currency tier if needed, badge-priced vanity pet
+   or mount when those systems exist.
+
+## 9. Open questions
+
+1. Vendor placement: zone 3 settlement (proposed) vs a quartermaster in
+   each zone hub.
+2. Should epic vendor pieces require one Nythraxis kill as an attunement
+   nod, or stay purely badge-priced? (Leaning purely badge-priced:
+   friction pillar.)
+3. World boss at 2 vs 3: revisit once real faucet telemetry exists.
+4. Cache at 30: too cheap once players are epic-capped? Could rise to 40
+   with a weekly first-purchase discount instead.

--- a/docs/prd/dungeon-mechanic-primitives.md
+++ b/docs/prd/dungeon-mechanic-primitives.md
@@ -1,0 +1,386 @@
+# Design: Dungeon Mechanic Primitives, Difficulty Modes, and the Encounter UI
+
+Status: draft v3 (design only, nothing here is implemented)
+Owner: design
+Companion docs: `docs/prd/heroic-mythic-dungeons.md` (difficulty plumbing,
+forge, chest, ladder), `docs/prd/badges.md` (the reward loop),
+`docs/prd/talents-2.0.md` (owns the player interrupt, see the P8 dependency)
+
+Dependency: the player kick is NOT built here. The interrupt ENGINE
+(`interrupt` AbilityEffect: cancels a non-physical cast, applies the school
+lockout with DR, `uninterruptible` AbilityDef flag, works against non-player
+casters) already merged in Talents 2.0 foundation **PR #1305**. Player ACCESS
+to it (Pummel / Counterspell / Kick and the other per-class L8 choice-row
+options) ships with the open Talents 2.0 epic **PR #1348**. P8 below and every
+"once the kick exists" line in sections 5 and 6 block on #1348 landing.
+
+## 1. Summary
+
+The heroic/mythic+ PRD ships the difficulty LADDER: instancing, scaling,
+affixes, forged drops. It deliberately reuses the existing boss mechanics
+wholesale. This doc designs the missing half: the MECHANICS that make climbing
+that ladder fun.
+
+Three claims, each grounded in the codebase:
+
+1. **The current dungeon mechanic vocabulary is passive.** Every dungeon boss
+   is some mix of `aoePulse`, `summonAdds`, `enrage`, `stomp`, `cleave`, and
+   on-hit debuffs. Nothing asks a player to move, face, kick, swap, or spread.
+   The healer sweats; everyone else executes a rotation.
+2. **The Nythraxis raid already hand-rolls the missing vocabulary.** The
+   encounter script (`src/sim/encounters/nythraxis.ts`) contains a working
+   frontal cone (Gravebreaker: facing + half-arc check), a stack-to-split bomb
+   (Soul Rend: lethal damage divided by marked players within 5 yd), a
+   telegraphed 10 s boss cast on the entity cast-bar fields (Deathless Rage),
+   counter-play objects (wardstone channels), timed add waves, and a 5 percent
+   soft enrage. The engine can do all of this today; it just cannot do it
+   **declaratively**, on more than one boss.
+3. **Therefore the work is extraction, not invention.** Each primitive below
+   is a `MobTemplate` field in the exact style of `aoePulse`/`stomp`,
+   generalizing something Nythraxis (or an existing system) already proved.
+   Heroic dungeons are the test bed for the primitives one at a time; mythic
+   turns on the full kit; mythic+ scales it and layers affixes on the same
+   hooks.
+
+## 2. Grounding: what the sim already has
+
+From a capability audit of `src/sim/`:
+
+| Capability | Status | Where |
+|---|---|---|
+| Persistent ticking ground zones | EXISTS | `GroundAoE` (`entity_roster.ts:37`), `pulseGroundAoE` shared entry, `groundAoE` effect |
+| Threat table, taunt, forced target | EXISTS | `threat.ts`; `mob.threat`; `applyTaunt` sets `forcedTargetId`/`forcedTargetTimer` |
+| Frontal cone geometry | EXISTS (hand-rolled) | Gravebreaker: `angleTo` vs `boss.facing` within `HALF_ARC` (`encounters/nythraxis.ts:505`) |
+| Stack-to-split bomb | EXISTS (hand-rolled) | Soul Rend: `maxHp / marked within STACK_RANGE` (`encounters/nythraxis.ts:743`) |
+| Boss cast bar | EXISTS (fields; current casts are scripted, uninterruptible) | Deathless Rage drives `boss.castingAbility`/`castRemaining`/`castTotal`; `castStart` SimEvent |
+| Counter-play objects | EXISTS (hand-rolled) | Wardstone channels during Deathless Rage |
+| Stacking auras, heal reduction | EXISTS | aura system; `mortalStrike` is a working healing-reduction debuff |
+| On-death payload | EXISTS | `deathThroes` + corpse detonate (`mob/lifecycle.ts:157`) |
+| Knockback | EXISTS (on-hit only) | `knockback` on-hit affix |
+| Line of sight | EXISTS | `hasLineOfSight` (`sim.ts:3012`), gates ranged + AoE |
+| Telegraph render hooks | EXISTS | `castStart` + `spellfx` (`nova`/`beam`/`projectile`) SimEvents |
+| Interrupt engine (cast-break + school lockout + DR + `uninterruptible` flag) | MERGED (PR #1305) | `interrupt` AbilityEffect; resolves against non-player casters too |
+| Player access to an interrupt (Pummel/Counterspell/Kick per class) | BLOCKED on Talents 2.0 (PR #1348, open) | L8 choice-row grants; one interrupt-family OPTION per class, not baseline |
+| Location-anchored telegraph decal | MISSING | `spellfx` flashes at entities; no "this circle on the ground, in 2 s" event |
+
+The genuine engineering gap left for THIS doc is the **ground telegraph
+event** (a SimEvent carrying position + shape + arm time so the renderer can
+draw the decal before the hit). The interrupt, which draft v2 called the one
+real system build, turned out to be Talents 2.0's P1 primitive: the engine is
+already merged (#1305) and the player-facing kicks ship with the open epic
+(#1348). What remains here is the mob-side half only: declarative boss-cast
+records that route through that same interruptible pipeline. Everything else
+is generalizing code that exists.
+
+## 3. The primitive catalog
+
+Each primitive is a declarative, optional `MobTemplate` field (data-as-code in
+`src/sim/content/`, types in `types.ts`), implemented once in the mob update
+path, reused by any boss via tuning. All randomness through `Rng`, fixed draw
+order. Names below are working names; per-boss flavor names ride the record
+(`name:` field) like `aoePulse` does today.
+
+### Tier 1: extract and prove in heroic
+
+**P1 `tankBuster`** (new). Every Nth melee (or on a cadence) applies a
+stacking debuff to the current threat leader: damage taken up, or healing
+taken down. Past the tuned comfort point the tank must taunt-swap or the boss
+must be turned by cooldowns. Reuses threat + taunt + stacking auras wholesale;
+the cheapest primitive on the board and the one that gives tanks a job.
+Fields: `{ everyNthSwing | every, aura: { dmgTakenPct | healTakenPct, duration }, maxStacks, name }`.
+
+**P2 `groundHazard`** (generalize `GroundAoE`). On a cadence, place a
+telegraphed zone at a placement-policy position (under a random player, under
+the tank, at range, fixed point). Telegraph for `armTime`, then tick damage
+for `duration`. "Do not stand in the fire," the atomic movement mechanic.
+Needs the new telegraph SimEvent; the zone itself is the existing `GroundAoE`.
+Fields: `{ every, radius, armTime, duration, tickDamage, placement, count, name }`.
+
+**P3 `frontalBreath`** (extract Gravebreaker). Telegraphed cone from the
+boss's facing: windup on the cast bar, facing snapshot at cast start, then
+heavy damage in `angle`/`range`. The tank faces the boss away; melee step
+out of the front. Gravebreaker keeps its identity as the Nythraxis tuning of
+this record (its current untelegraphed form becomes `armTime: 0`).
+Fields: `{ every, angle, range, armTime, damage, offTankMult, name }`.
+
+**P4 `soulMark`** (extract Soul Rend). Mark K random non-tanks; after
+`fuse` seconds each mark detonates for damage divided by the number of marked
+players within `shareRange` (stack to survive), or, with `mode: 'spread'`,
+full damage to everyone within `splashRadius` of the carrier (spread to
+survive). One record, sign-flipped, covers both classic shapes and creates
+tension against P2/P3 positioning.
+Fields: `{ every, targets, fuse, damage, mode: 'stack' | 'spread', shareRange | splashRadius, name }`.
+
+**P5 `fixate`** (reuse `forcedTargetId`). On a cadence the mob locks onto a
+random non-tank for `duration`, ignoring threat, moving at `speedMult`;
+contact hits hard or applies a stack. The taunt machinery already forces
+targets; fixate is the same field with a different selection policy and a
+"taunt does not break it" flag. The fixated player kites, ideally through
+ground the P2 hazards have not claimed.
+Fields: `{ every, duration, speedMult, target: 'random' | 'farthest', contactDamage, name }`.
+
+**P6 `berserk`** (the Patchwerk lever). A hard enrage on a fight-length
+timer: at `after` seconds the boss gains `dmgMult`/`hasteMult` (effectively
+unhealable), with emote warnings at 60/30/10 s. This is THE clean DPS check
+for an untimed mode: the RUN has no clock, but a boss can. Distinct from the
+existing `enrage` (an HP threshold); this is a wall-clock-of-the-fight
+threshold on sim time. Also doubles as the anti-turtling guard the untimed
+PRD needs.
+Fields: `{ after, dmgMult, hasteMult, warnAt: number[], name }`.
+
+**P7 `shockwave`** (knockback, area form). Telegraphed radial wave on a
+cadence: everyone within `radius` is knocked `distance` from the boss and
+takes damage. Positioning turns it from a nuisance into a threat: knocked
+into a P2 pool, out of `shareRange` during a P4 stack, or off the healer's
+range. Reuses the on-hit `knockback` displacement math on an area trigger,
+with the P2 telegraph.
+Fields: `{ every, radius, armTime, distance, damage, name }`.
+
+### Tier 2: the interactive layer (mythic and up)
+
+**P8 `bossCast`** (mob-side only; the kick is Talents 2.0's). A first-class
+interruptible mob cast: visible bar (`castStart` and the entity cast fields
+already exist), `payload` on completion (nuke, heal, summon, CC), broken by a
+player interrupt through the `interrupt` effect that PR #1305 merged (it
+already resolves against non-player casters). The player-side kick is
+explicitly NOT this doc's work: Talents 2.0 grants one interrupt-family
+option per class at the L8 choice row (PR #1348, open), and its own PRD plans
+to give mobs an interrupt cast so players feel the counterplay, which is
+exactly this record. **Hard dependency: P8 content cannot ship before #1348.**
+And because the kick is a build CHOICE, not baseline, a legal party can have
+zero interrupts: every P8 cast must be survivable uninterrupted at heroic
+(expensive, not lethal), and only mythic tuning may assume at least one kick
+in the group. Deathless Rage stays a scripted special (its counter is
+wardstones, not kicks) but moves onto the same cast plumbing. This primitive
+is what makes trash packs interesting, not just bosses, and it is what
+finally makes `mendAlly`/`desperateHeal` casters into kill-or-kick decisions.
+Fields: `{ every, castTime, payload, interruptible, lockout, name }`.
+
+**P9 `priorityAdd`** (compose, not build). `summonAdds` output tagged with a
+role: an add that channels healing into the boss, empowers it, or detonates
+if alive at `softEnrage`. Composition of `summonAdds` + P8 (or `deathThroes`).
+Creates the "what do I hit right now" decision.
+Fields on the summoned template: `{ role: 'healer' | 'empowerer' | 'bomber', payload, softEnrage }`.
+
+### Tier 3: deferred (map-coupled or moving geometry)
+
+Rotating beams (P2 with a time-varying transform), pillar/LOS gaze (LOS
+exists, but arenas would need authored occluders), knock-off-ledge (needs
+kill volumes in arena data), tethers (pair-distance constraint; delve
+`linkIds` is precedent but nothing combat-side consumes it). All good, none
+worth their infra until Tier 1 and 2 are proven and the arenas carry region
+data.
+
+### Affixes are these primitives, broadcast
+
+Every mythic+ affix in the companion PRD is one of these records applied
+dungeon-wide instead of per-boss. Build once, expose twice:
+
+| Affix (working name) | Primitive reused |
+|---|---|
+| Ichor Pool (Sanguine-like: on-death heal pool) | `deathThroes` payload spawning a P2 zone that heals mobs |
+| Eruption (Volcanic-like: plumes under players) | P2 with `placement: randomPlayer`, short arm |
+| Cornered (Raging-like: sub-30 percent damage enrage) | existing `enrage`, applied to all non-boss mobs |
+| Festering (Grievous-like: ramping DoT below 90 percent HP) | stacking aura, HP-gated |
+| Corrosion (Necrotic-like: melee stacks reduce healing taken) | P1 pointed at whoever is hit |
+| Volatile (Explosive-like: destructible orbs) | P9 with `role: bomber`, retuned to pulse rather than one-shot (untimed mode) |
+
+Seeded weekly rotation and level thresholds per the PRD (5.3), plus a
+conflict rule: never draw two same-lesson affixes (two on-death punishers,
+two movement hazards) in one week.
+
+## 4. The difficulty ladder (amended)
+
+The PRD defines heroic as a pure numbers rebase. This doc amends that into a
+three-step mechanics ladder, because the primitives need a place to be
+learned before they can be stacked:
+
+- **Normal**: unchanged. The leveling experience, current mechanics only.
+- **Heroic (L20 rebase + ONE new mechanic per boss)**: the numbers transform
+  from the PRD, plus each boss gains exactly one Tier 1 primitive, chosen to
+  teach it in the friendliest possible room. Heroic is the tutorial tier for
+  the vocabulary. Daily badge cadence per badges.md.
+- **Mythic (fixed, the full kit)**: one difficulty, no keystone, sitting
+  between heroic and mythic+ 2. Every boss runs its complete mechanic kit
+  (the heroic mechanic plus one or two more, incl. P6 berserk DPS checks on
+  the meters bosses) at fixed tuning. Mythic is where the dungeon's "real"
+  encounter design lives; mythic+ then scales exactly this. Weekly loot
+  lockout on bosses (badges still daily-slotted), so mythic is the weekly
+  "learn the dance" tier, not a farm tier.
+- **Mythic+ (keystones 2 and up)**: mythic mechanics + compounding
+  health/damage + affixes at 4/7/10, untimed, per the PRD. The mechanics do
+  not change with key level; the margin for failing them does, and P6 berserk
+  timers become the de facto gear gate at high keys (you cannot out-turtle a
+  boss whose berserk you cannot beat).
+
+Instance keying, entry gating, chest, forge, and ladder all per the PRD; the
+difficulty enum just gains the `mythic` value between `heroic` and keyed
+levels.
+
+## 5. Heroic Nythraxis (10-player raid)
+
+The PRD scopes mythic+ away from the raid; a single heroic raid difficulty is
+the right-sized raid analogue. Same room, same phases, same wardstones; each
+existing mechanic gets its screws turned using the primitives, and the fight
+gains the raid's only true DPS check.
+
+- **Gravebreaker** becomes the P3 record it inspired: a 1.5 s telegraphed
+  windup (it is instant today), the arc widened from 120 to 150 degrees, and
+  anyone hit who is not the current tank is also knocked back (P7 math).
+  The dance: melee step out on the windup, tank alone eats it.
+- **Soul Rend** marks 4 players instead of 3, and each detonation leaves an
+  Ichor Pool (P2 zone) at the point of impact for 20 s. The room fills with
+  consequences; stacking spots must rotate.
+- **Raise Fallen** guards become P9 priority adds (`role: healer`): a Royal
+  Guard that reaches the boss channels Deathless Vigor, healing him 1 percent
+  per second until killed or (once P8 lands) kicked. Ignoring adds stops
+  being an option.
+- **Deathless Rage** is unchanged in shape (it is already the best mechanic
+  in the game) but heroic requires the three wardstones to be channeled by
+  three DIFFERENT players, and taking damage interrupts a channel. The raid
+  must pre-assign runners.
+- **Final Stand** (5 percent) is replaced by a true P6 berserk: at 8 minutes
+  Nythraxis gains 25 percent damage, again every 30 s thereafter, until the
+  raid dies or he does. Patchwerk pressure without a run timer: the raid can
+  wipe and re-pull forever, but every pull must beat the 8-minute check.
+- **Loot**: the existing epic table at a heroic bonus rate, plus forge rolls
+  (PRD 5.5) at raid-tier chances. Shared 24 h lockout with normal (one
+  Nythraxis kill per day per character, either difficulty): open question 4.
+
+## 6. Per-dungeon difficulty sketches
+
+Heroic teaches one primitive per boss; mythic completes the kit. Numbers are
+placeholders for the playtest pass; per the PRD they live in per-dungeon
+scaling records, never inline. Flavor names are working copy.
+
+### 6.1 The Hollow Crypt (heroic teaches: P2 ground, P1 stacks)
+
+The friendliest room, so it teaches the two most fundamental habits: watch
+the ground, watch the tank debuff.
+
+| Boss | Today | Heroic (+1) | Mythic (full kit) |
+|---|---|---|---|
+| Sexton Marrow (miniboss) | plain stats | **P1 Gravedigger's Blow**: every 3rd melee stacks +15 percent damage taken, 12 s | P1 + widow adds join at 50 percent (existing `summonAdds` reuse) |
+| Morthen the Gravecaller | `aoePulse` (Shadow Pulse) | **P2 Graven Miasma**: every 12 s, a 5 yd pool under a random player, 2 s arm, 15 s lifetime | P2 + **P9 Bone Servitors** (healer role, channel to Morthen) + Shadow Pulse magnitudes up |
+
+Trash: Hollow Acolytes gain a P8 interruptible Dark Mending on mythic once
+the interrupt exists; until then they keep `desperateHeal`.
+
+### 6.2 The Sunken Bastion (heroic teaches: P3 facing, P4 stack/spread)
+
+The positioning dungeon.
+
+| Boss | Today | Heroic (+1) | Mythic (full kit) |
+|---|---|---|---|
+| Knight-Commander Olen (miniboss) | `cleave` | **P3 Sweeping Blade**: cleave becomes a telegraphed 90 degree, 10 yd frontal every 10 s | P3 + **P1 Sunder** (tank stacks) + **P7 Tide Slam**: radial knockback off the dais toward the water line |
+| Vael the Mistcaller | `aoePulse`, `summonAdds` | **P4 Mist Rend** (stack mode): 3 marks, 6 s fuse, split within 6 yd | P4 + thralls become **P9 bombers** (`deathThroes` if alive 20 s) + **P6 Rising Tide** berserk at 4 min (the flood takes the room) |
+
+### 6.3 Gravewyrm Sanctum (heroic teaches: P1 swaps, P5 kiting; mythic is the meters check)
+
+The endgame calibration anchor stays the hardest, and Korzul becomes the
+game's Patchwerk.
+
+| Boss | Today | Heroic (+1) | Mythic (full kit) |
+|---|---|---|---|
+| Korgath the Bound | `enrage`, `stomp` | **P1 Bonecrusher**: every 4th melee, +20 percent damage taken, 15 s (the tank-swap teacher; solo-tank groups burn cooldowns) | P1 + **P5 Chained Fury**: snaps his bindings and fixates a random player for 6 s at 1.3x speed |
+| Grand Necromancer Velkhar | `summonAdds` | **P9 kill-order**: bonewalkers that reach Velkhar empower him +10 percent damage each (stacking) | P9 + **P2 Desecration** pools + **P8 Dark Ritual** (3 s interruptible raid nuke) once the kick exists |
+| Korzul the Gravewyrm | `aoePulse`, `enrage` | **P3 Necrotic Breath**: 2 s windup, 60 degree, 16 yd cone; tank turns him from the group | P3 + **P7 Wing Buffet** (radial knockback into his own breath line) + **P6 Consume the Dead** berserk at 6 min: the pure gear-and-execution check that anchors mythic+ scaling |
+
+Mythic+ (all three dungeons): exactly the mythic kits, health/damage
+compounding per the PRD, affixes from section 3 at 4/7/10. No per-key
+mechanic changes; the design intent is that key 10 Korzul is the same dance
+as mythic Korzul with no room left for error, and his berserk is what gear
+progression is measured against.
+
+## 7. UI elements
+
+Everything here consumes `IWorld` (extended first, implemented in both `Sim`
+and `ClientWorld`) or new SimEvents; render/ui never touch a concrete world.
+Every label is a `t()` key; sim-emitted lines get `sim_i18n.ts` matchers in
+the same change; mechanic auras register `AURA_NAME_KEY`.
+
+**Difficulty selection and status**
+- Dungeon door / meeting-stone dialog: leader-only difficulty picker
+  (Normal / Heroic / Mythic / Mythic+ N), with the keystone stepper capped at
+  `bestCleared + 1` and the party-minimum rule surfaced inline ("Aldra has
+  not cleared 6: cap 7 -> 5"). Non-leaders see the selection read-only.
+- In-instance banner: the zone-in text and the persistent HUD tag under the
+  minimap ("Gravewyrm Sanctum, Mythic+ 7"), plus active affix icons with
+  tooltips. Week's affixes also shown on the dungeon selector before entry.
+
+**Telegraphs (the load-bearing new render surface)**
+- A new `telegraph` SimEvent (position or source entity, shape circle/cone,
+  radius or angle+range, arm time) drives ground decals: an outlined ring or
+  wedge that fills as the arm timer elapses, then flashes on resolve.
+  P2/P3/P7 all ride this one event; this is the single most important UI
+  investment in the doc, because an undodgeable-looking dodge mechanic reads
+  as unfair.
+- Boss cast bar on the target frame, reusing the existing `castStart` event
+  and entity cast fields (Deathless Rage already populates them).
+  Interruptible casts (P8) render with a bright border; uninterruptible with
+  the standard shield motif; a successful kick flashes the bar.
+
+**Personal warnings**
+- P4 marks: a debuff icon with a fuse countdown on the player frame, a decal
+  ring around the carrier sized to `shareRange`/`splashRadius`, and a
+  center-screen line ("Soul Rend: stack!" / "spread!") through the existing
+  FCT/raid-warning channel.
+- P5 fixate: a marker over the fixated player, a center-screen "Korgath
+  fixates on you!", and a glow on the boss nameplate for everyone else.
+- P1 stacks: the debuff already renders in the aura row; add a stack-count
+  emphasis at `maxStacks - 1` on the party/tank frames so the swap call is
+  visible to the other tank, not just the victim.
+- P6 berserk: no timer bar (classic fidelity: the pressure is felt, not
+  displayed); boss emotes at the `warnAt` marks through the existing yell
+  channel, red tint on the model at berserk.
+
+**Ladder and rewards**
+- Leaderboard window: per-dungeon best-key ladder (PRD 5.7), a new sort key
+  on the existing paginated `leaderboard_page.ts` surface.
+- End-of-run chest panel: reuse the personal-loot window; forge outcomes get
+  the tier label and bonus lines in the item tooltip from wire data
+  (Valeforged/Swiftforged rendering per PRD 6, client-side `t()` keys).
+- Character sheet: `bestCleared` per dungeon on a small progress pane in the
+  dungeon selector, so the "your key" state is always discoverable.
+
+**Wiki**
+- `npm run wiki:content` regen plus `guide.*` prose pages for difficulty
+  modes and (spoiler-safely) the affix roster. Boss mechanic kits stay out of
+  the guide per the existing spoiler policy.
+
+## 8. Invariants that bind every section above
+
+- All primitive state lives on `Entity`/`MobTemplate` types in `types.ts`;
+  behavior in the mob modules behind `SimContext`; content records in
+  `src/sim/content/` merged by `data.ts`. No balance numbers inline.
+- Every roll (placement, target picks, marks, affix rotation) through `Rng`
+  in fixed draw order; zone/cone membership evaluated in stable entity-id
+  order so float boundaries reproduce across the three hosts. New mechanics
+  with rng draws get `tests/parity` scenarios; the heroic Hollow Crypt golden
+  run from the PRD (7) extends to cover each primitive as it lands.
+- Difficulty transform stays a pure function (PRD 5.9); primitives read their
+  tuning through it so heroic/mythic/key-level magnitudes are data.
+- Gates: `tests/architecture.test.ts`, `tests/localization_fixes.test.ts`,
+  `tests/guide.test.ts`, and golden parity, per the PRD.
+
+## 9. Open questions
+
+1. RESOLVED: the player kick is Talents 2.0's, not this doc's. The engine
+   merged in PR #1305; the per-class L8 choice-row kicks ship with PR #1348,
+   which P8 and the P9 healer role block on. The residual question is tuning
+   policy: interrupts are optional build choices, so how punishing may an
+   uninterrupted P8 cast be at each tier? Proposed: survivable at heroic and
+   mythic with cooldowns, lethal-if-ignored only at high keys where a kick
+   (or a stun, which also breaks casts through the same #1305 machinery) can
+   be assumed.
+2. Mythic lockout shape: weekly loot lockout (proposed) vs daily like heroic.
+   Interacts with badges.md paid-kill slots.
+3. P6 berserk timers on 5-player bosses: 4 to 6 minutes proposed; needs the
+   wind-tunnel pass against actual group DPS at honest gear levels.
+4. Heroic Nythraxis lockout: shared daily lockout with normal (proposed) or
+   separate, which doubles raid loot per day.
+5. Telegraph density: how many simultaneous decals before the floor is noise?
+   Proposed cap of 3 active P2 zones per boss and one affix hazard batch, to
+   be playtested.
+6. Does `fixate` need pathing work, or does existing chase locomotion feel
+   right at 1.3x speed? Prototype before committing P5 to two bosses.

--- a/docs/prd/heroic-mythic-dungeons.md
+++ b/docs/prd/heroic-mythic-dungeons.md
@@ -1,0 +1,353 @@
+# PRD: Heroic and Mythic+ Dungeons with Forged Drops
+
+Status: draft v2 (badge amounts synced to badges.md v2; forged-drop
+system fully specified)
+Owner: design
+Companion doc: `docs/prd/badges.md` (heroic/mythic+ is the badge system's
+primary earner)
+
+## 1. Summary
+
+Two difficulty layers on top of the **existing** dungeons, reusing their
+layouts, mob rosters, and mechanics wholesale, plus a forged-drop system
+that gives every heroic and mythic+ loot roll a chance to come back
+better than its base item:
+
+- **Heroic:** every dungeon re-tuned to level 20. The Hollow Crypt (a
+  level 7 to 10 leveling dungeon) becomes max-level endgame content again.
+  One toggle, no new maps.
+- **Mythic+:** an infinitely scaling ladder above heroic. Each keystone
+  level multiplies enemy health and damage; affixes unlock at level
+  thresholds; rewards scale with the level you clear. **Untimed**: the
+  pressure is surviving, not racing a clock or a minigame.
+- **Forged drops (the titanforging analogue):** heroic and mythic+ gear
+  drops can roll **Valeforged** (the item comes back 2 item levels higher,
+  with the budget scaled to match) or **Swiftforged** (a 3% to 5%
+  movement-speed bonus, a property no base item has, never stackable).
+  The same boss on the same day can still surprise you, so farmed content
+  never fully dries up.
+
+This is the highest content-per-effort move available: three finished
+dungeons become an infinite ladder with chase variance, with zero new
+geometry, zero new mobs, and near-zero new i18n.
+
+Design references: classic-era heroic dungeons (same dungeon, cap-level
+tuning, daily lockout, badge on the end boss), the mythic+ keystone model
+(compounding scaling, affix thresholds, best-level ladder) minus the
+timer, and titanforging (drop-time upgrade rolls) minus the infinite
+ilvl creep: forge bonuses are small, capped, and never beat raid drops by
+more than the forge margin.
+
+## 2. Background and motivation
+
+### 2.1 The gap
+Only Gravewyrm Sanctum and the Nythraxis raid are relevant at the cap.
+The Hollow Crypt and The Sunken Bastion, the two most polished instances
+in the game, are outleveled and abandoned. Capped players have no
+difficulty knob at all: content is either on farm or not.
+
+### 2.2 Player direction this encodes (definitive)
+- Keep 20 as the cap; difficulty and reward scale instead of levels.
+- Rewards scale with challenge, not a linear level treadmill.
+- No punishing minigames between the player and the loot (the delve
+  lockpick complaint): mythic+ is untimed, and every reward is granted on
+  the kill or the clear.
+- Normal leveling dungeons pay no endgame currency; heroic is where the
+  endgame loop starts (badges.md pillar 1).
+
+## 3. Current state in the codebase (what this reuses and what must change)
+
+Reused as-is:
+- **Instancing:** `src/sim/instances/dungeons.ts` keys instance slots per
+  party and handles enter/leave/reset lifecycle. Difficulty joins the key.
+- **Mob definitions:** `src/sim/content/dungeons.ts` records carry levels,
+  stats, and mechanics (aoePulse, cleave, stomp, mortalStrike, adds).
+  Heroic is a deterministic transform of these records, not a copy.
+- **Affix content model:** delve affixes
+  (`src/sim/content/delves/affixes.ts`) already express "modify enemy
+  stats and mechanics by tier"; mythic+ affixes are a sibling record set,
+  not a delve dependency.
+- **Loot plumbing:** loot tables, personal loot (world boss), need/greed,
+  rarity tiers (`src/sim/loot/`).
+- **Move-speed hook:** `Sim.moveSpeedMult()` (`src/sim/sim.ts`) already
+  aggregates speed modifiers (fiesta augments contribute `moveSpeedPct`,
+  `buff_speed` auras exist). Swiftforged folds in here; no new movement
+  code path.
+- **Daily gates:** the `worldBossDaily` / `delveDaily` UTC-day pattern.
+- **Ladder:** `src/sim/leaderboard_page.ts` is host-agnostic and
+  paginated; best-keystone-level is a new sort key, not a new system.
+
+Must change (the honest engineering cost):
+- **Item instances exist in inventory but not on the paperdoll.** As of
+  release/v0.20.0 (professions, #1165/#1174), `InvSlot` carries an
+  optional `instance?: ItemInstancePayload` with `rolled` stat values,
+  `boundTo` binding, per-copy `charges`, and `cloneInvSlot` deep-clone
+  discipline at save/load boundaries; the World Market already blocks
+  instanced items at list time (real handling deferred to #1146). Forge
+  builds on that payload (section 5.6) instead of inventing a parallel
+  one. The remaining gap: `PlayerEquipment` still maps slot to a bare
+  item-id string and `recalcPlayerStats()` reads `ITEMS[itemId].stats`,
+  so equipping currently drops the payload. Equipment must learn to
+  carry the instance; that is the largest single work item in this PRD,
+  and everything else is data and transforms.
+
+## 4. Goals and non-goals
+
+### Goals
+1. Every existing dungeon is playable at the cap via a heroic toggle.
+2. Mythic+ gives the most engaged players an uncapped difficulty ladder
+   with a visible leaderboard.
+3. Reward quality scales with difficulty: better tables, daily-gated
+   chests with slot variety, and forge chances that rise with keystone
+   level.
+4. 100% reuse of existing dungeon geometry and mobs; new content records
+   are scaling tables, affix definitions, and forge rules only.
+
+### Non-goals
+- No run timer, no depleting keystones, no key items in bags (v1 tracks
+  the unlocked level per character).
+- No new dungeons in this PRD; no mythic+ for the raid.
+- No forged drops outside heroic/mythic+ in v1 (no forged world-boss,
+  delve, or normal-dungeon loot; no forged badge-vendor gear).
+- No open-world difficulty scaling.
+- Forge bonuses never introduce a new best-in-slot over raid gear beyond
+  the forge margin itself (a Valeforged heroic rare stays below a raid
+  epic).
+
+## 5. Functional requirements
+
+### 5.1 Difficulty selection and instancing
+- The party leader sets the difficulty (normal / heroic / mythic+ level N)
+  before entering; the instance slot is keyed `(dungeonId, difficulty)`.
+- Mythic+ level N is selectable up to `bestCleared + 1` for that dungeon;
+  the party may enter at `min(bestCleared across members) + 1`, so you can
+  pull a friend up one level but not skip the ladder.
+- Difficulty is fixed for the life of the instance (reset-on-empty rules
+  unchanged).
+
+### 5.2 Heroic tuning (the deterministic transform)
+Applied to existing mob records at spawn, driven by a per-dungeon scaling
+record in `src/sim/content/` (data, not code):
+- Every mob becomes level 20 (elites stay elite).
+- Health and damage rebase to the dungeon's level-20 peer (Gravewyrm
+  Sanctum trash and bosses are the calibration anchor).
+- Mechanics keep their identity; magnitudes rebase with damage.
+- Loot: the normal table still rolls, plus a heroic bonus table on the
+  final boss (rare gear from the L20 pool, small epic chance), the forge
+  roll (5.5), and 1 Badge of Valor (once per dungeon per UTC day, per
+  badges.md).
+
+### 5.3 Mythic+ scaling
+- Starts at keystone level 2 (heroic is effectively level 1).
+- Enemy health and damage multiply by a compounding factor per level
+  (start at 1.10; data-driven, tune in playtesting; 1.10 is 2.6x at key
+  10).
+- Affixes activate at thresholds: level 4 one affix, level 7 a second,
+  level 10 a third. Declarative records in the delve-affix style
+  (examples: enemies enrage below 30% health; non-boss deaths pulse AoE;
+  bosses summon adds at 50%). Rotation is seeded per UTC week through
+  `Rng` so all hosts agree and replays reproduce.
+- **Untimed.** The failure condition is wiping; wipes do not lower the
+  unlocked level and the run can be re-pulled. Clearing level N sets
+  `bestCleared = max(bestCleared, N)` per character per dungeon.
+- Badges: 2 (keys 2 to 4), 3 (keys 5 to 9), 4 (key 10+), consuming the
+  same one-paid-kill-per-dungeon-per-day slot as heroic (badges.md 5.1).
+
+### 5.4 Mythic+ chest (the "few times a day, different slots" reward)
+- End-of-run chest, personal loot per eligible contributor
+  (`worldBossContributors` semantics).
+- Grants one gear piece from the level-20 pool for a **rotating slot
+  band**: a seeded weekly rotation cycles which slots the chest favors per
+  dungeon (Hollow Crypt week A: waist/feet; week B: helmet/shoulder; and
+  so on), so repeat days target different slots.
+- Quality scales with keystone level: rare at low keys, epic chance
+  rising with level, capped below raid ubiquity.
+- Paid chests: first 2 mythic+ clears per character per UTC day (across
+  dungeons). Further clears still pay badges and advance `bestCleared`,
+  so ladder pushing is never pointless.
+- Chest contents get a forge roll (5.5) at the run's keystone level.
+
+### 5.5 Forged drops (Valeforged / Swiftforged), definitive spec
+
+Every **gear** item (kind weapon or armor with a slot) that drops from a
+heroic final boss, a heroic bonus table, or a mythic+ chest rolls once on
+the forge table at drop time, through `Rng`, server-authoritatively:
+
+| Tier | Effect | Heroic chance | Mythic+ chance (key N) | Cap |
+|---|---|---|---|---|
+| Valeforged | the item is upgraded by **+2 item levels**: every stat (armor included) scales by the item-level budget curve, section 5.5.1 | 12% | 12% + 2% per key level | 40% |
+| Swiftforged | `moveSpeedPct` rolled from 3%, 4%, or 5% (no stat bonus; speed is the whole prize) | 4% | 4% + 1% per key level | 15% |
+
+#### 5.5.1 What "+2 item levels" computes to
+The game has no explicit item-level field; budgets are the empirical
+peer convention (`src/sim/content/items.ts`). Valeforged formalizes the
+minimum needed: an item's **implicit level** is the level of the content
+that drops it (20 for everything in scope here), and its stats already
+embody that level's budget. Upgrading by 2 levels scales every stat and
+armor value by `(L + 2) / L`, rounded to nearest, with a guard that the
+total non-armor stat gain is at least 2 points. At L20 that is +10%: a
+14-point rare boot becomes roughly 15 to 16 points, an 18-point epic
+chest becomes 20, armor rises 10%. The scaled deltas are frozen into the
+forge payload at drop time (5.6); the formula generalizes unchanged if
+content above L20 ever exists.
+
+#### 5.5.2 Roll and stacking rules
+- Tiers are exclusive per drop; roll Swiftforged first, else Valeforged,
+  else base. Fixed `Rng` draw order (determinism). Whether one item can
+  ever be both is open question 6.
+- The Swiftforged magnitude (3/4/5) is a second `Rng` draw, uniform at
+  heroic; mythic+ weights shift toward 5% as the key level rises
+  (weights data-driven in the forge record).
+- **Speed does not stack:** `moveSpeedMult()` applies only the single
+  highest equipped Swiftforged bonus (the classic minor-speed-enchant
+  rule). Two Swiftforged pieces are a re-gear choice, not an additive
+  win; this keeps 8 slots from compounding into +40% and keeps PvP sane.
+- Valeforged stat gains stack normally across slots (they are just
+  stats).
+- Forged drops are **bind-on-pickup**: the drop sets
+  `instance.boundTo` to the looter (the field #1165 already provides),
+  and the market's existing block on instanced items keeps them
+  unlistable with zero new market code (open question 4 revisits
+  trading).
+- Forge bonuses apply on top of the item's base def at stat-recalc time;
+  the base `ItemDef` is never mutated (content stays static data).
+- Why a speed stat: no base item grants movement speed, so Swiftforged is
+  a genuinely new chase axis that does not raise the combat power ceiling.
+  It is the "do even more runs" hook.
+
+### 5.6 Data model: forge rides the professions item-instance payload
+
+Forge is expressed through `ItemInstancePayload` (#1165), not a parallel
+mechanism:
+
+- `ItemInstancePayload` gains
+  `forge?: { tier: 'valeforged' | 'swiftforged', moveSpeedPct?: number }`.
+  Valeforged bakes its scaled stat values from the 5.5.1 formula into the
+  existing `rolled.stats` (matching the professions semantics for rolled
+  copies, aligned at implementation) and records the tier in `forge` for
+  display; Swiftforged carries only the rolled `moveSpeedPct`. The
+  concrete numbers are frozen at drop time, so later tuning never mutates
+  already-dropped items.
+- Forged slots never stack (`count` stays 1), which #1165 instanced
+  slots already guarantee; `cloneInvSlot` deep-clone discipline applies
+  unchanged at every save/load boundary.
+- **Equipment carries the instance (the enabling change):** a parallel
+  map `equipmentInstance: Partial<Record<EquipSlot, ItemInstancePayload>>`
+  beside `PlayerEquipment`, so every existing itemId code path (vendor,
+  tooltips by id, wire) keeps working untouched; equip/unequip moves the
+  payload with the item. This also future-proofs equipping signed or
+  charged professions items.
+- `recalcPlayerStats()` folds the equipped `rolled.stats` after the
+  base-item loop; `moveSpeedMult()` reads the highest equipped
+  `forge.moveSpeedPct`.
+- Persistence: `equipmentInstance` rides the JSONB `CharacterState`
+  (serialize / `addPlayer` backfill to empty); `InvSlot.instance` already
+  persists via #1165. Old saves load unchanged.
+- Wire: instance payloads ship with inventory and equipment snapshots for
+  the owning player; other players' paperdolls do not need forge data in
+  v1.
+- Loot wire: `LootSlot extends InvSlot`, so the pre-rolled `instance`
+  rides existing loot slots and the client tooltip can show the bonus
+  before pickup (the roll happened at drop, not at loot).
+
+### 5.7 Ladder
+- Leaderboard per dungeon: best cleared keystone level, ties broken by
+  earliest clear (tick time from the host clock event, never `Date.now`
+  in sim). Reuses `leaderboard_page.ts` pagination.
+
+### 5.8 Persistence summary
+`CharacterState` (JSONB) additions, standard serialize/backfill pattern:
+- `mythicBest: Record<string, number>` (dungeonId to best cleared level)
+- `mythicDaily: { date: string, paidChests: number }`
+- `equipmentInstance` (5.6); forged bag items ride the existing
+  `InvSlot.instance` persistence from #1165
+- heroic/mythic+ paid-kill state lives in `badgeDaily` (badges.md)
+
+### 5.9 Determinism and architecture invariants
+- All scaling multipliers, affix definitions, slot rotations, and forge
+  tables are declarative records in `src/sim/content/` merged by
+  `data.ts`.
+- Every roll (chest contents, affix rotation, forge) goes through `Rng`
+  in a fixed draw order; weekly rotation seeds derive from the UTC week
+  string, not wall clock.
+- The difficulty transform is a pure function of (mob record, scaling
+  record, keystone level) in a new module
+  `src/sim/instances/difficulty.ts`; the forge roll is a pure function of
+  (item def, difficulty, rng) in `src/sim/loot/forge.ts`. Both
+  unit-testable without a world.
+- `IWorld` gains the difficulty read surface (current instance
+  difficulty, best levels, chest gate state) implemented in both `Sim`
+  and `ClientWorld` before UI consumes it.
+
+## 6. Localization
+
+Deliberately small:
+- Dungeon, mob, and mechanic names are unchanged and already localized.
+- Chest gear reuses existing L20 items: no new item-name translations.
+- Affix names and difficulty labels ("Heroic", "Mythic+ 7") are
+  sim-emitted player text: stable keys re-localized via
+  `src/ui/sim_i18n.ts` / `server_i18n.ts` in the same change (S3 guard);
+  affix effects surfaced as auras also need the `AURA_NAME_KEY` path.
+- Forge presentation is **client-side only in v1**: the tier label
+  ("Valeforged", "Swiftforged") and the bonus lines ("+1 Strength",
+  "+3% Movement Speed") render in the item tooltip from wire data via
+  `t()` keys; chat/loot messages keep the base item name, so no sim
+  matcher work for forge. The tier could later become a name suffix; that
+  is an i18n cost deferred deliberately.
+- Wiki: `npm run wiki:content` plus `guide.*` prose for the difficulty
+  and forging pages.
+
+## 7. Testing and acceptance
+
+- Difficulty transform as a pure function: levels, health, damage,
+  mechanic magnitudes against the scaling record.
+- Keystone gating: `bestCleared + 1`, the party-minimum entry rule.
+- Forge roll: distribution sanity at fixed seeds, draw-order stability
+  (two sims, same seed, identical forges), tier exclusivity, chance caps,
+  the Swiftforged 3/4/5 magnitude weighting.
+- The 5.5.1 scaling formula as a pure function: +10% at L20, rounding,
+  the minimum +2 total stat-point guard, armor scaling.
+- Forge application: recalc folds Valeforged deltas; only the highest
+  Swiftforged speed applies; unequip removes it; forged items reject
+  market listing.
+- Persistence: roundtrip of `mythicBest`, `mythicDaily`,
+  `equipmentInstance`, and forged `InvSlot.instance` payloads;
+  pre-feature saves backfill clean.
+- Chest: slot-rotation determinism across hosts; daily gate rollover;
+  `utcDay === ''` inertness.
+- Golden/parity: a scripted heroic Hollow Crypt clear in the existing
+  golden-test style to lock rng draw order; new SimEvents golden-tested;
+  `cross-platform-sync` pass for IWorld and wire drift.
+- Gates: `tests/architecture.test.ts`,
+  `tests/localization_fixes.test.ts`, `tests/guide.test.ts`.
+
+## 8. Phasing
+
+1. **P1, heroic:** difficulty key on instances, the transform module,
+   Hollow Crypt heroic tuning record, badge hook (1/day), tests. Ships
+   value with one dungeon and unblocks badges.md P1.
+2. **P2, heroic everywhere + forge foundation:** Sunken Bastion and
+   Gravewyrm records, heroic bonus tables, the equipment-instance change
+   plus the `forge` payload field (5.6), forge rolls on heroic drops.
+   The data-model change is taste-and-risk critical (save-format
+   surface): fable/opus, not codex.
+3. **P3, mythic+:** keystone levels, scaling, `mythicBest`, chest with
+   slot rotation and daily gate, forge scaling by key level.
+4. **P4, affixes + ladder:** affix records (authoring slice suitable for
+   codex against this spec), weekly rotation, leaderboard sort key, UI
+   polish (tooltip forge display, difficulty banner).
+
+## 9. Open questions
+
+1. Compounding factor 1.08 vs 1.10 per level (playtest).
+2. Party-minimum entry: +1 (proposed) or +2 carry allowance.
+3. Chest slot rotation per dungeon per week (proposed) vs per character.
+4. Forged item trading: locked in v1; if unlocked later, the market wire
+   and listing UI must learn to show forge data (deferred cost, noted).
+5. Swiftforged in arena/fiesta: does +5% move speed need a PvP dampener,
+   or is the no-stacking rule enough?
+6. Double-forging: can one item roll Valeforged and Swiftforged together?
+   Locked to exclusive in v1; if opened later it should be mythic+-only
+   and very rare.
+7. Forge chance caps (40% / 15%): generous enough to feel, rare enough to
+   chase? Revisit with drop telemetry.


### PR DESCRIPTION
## Summary

Two interlocking endgame-retention PRDs, docs only, no code changes. Based on release/v0.20.0.

**docs/prd/badges.md: Badge of Valor currency + Quartermaster vendor**
- Deterministic badge income from max-level content only: heroic final boss 1/day per dungeon, mythic+ 2/3/4 by key bracket (shares the heroic daily slot), raid 3 weekly, world boss 2 daily, delve clear 1. Normal leveling dungeons pay zero by design.
- Rewards land on the kill or clear, never behind a chest, lockbox, minigame, or timer.
- Vendor: 10 fully specified gear items (Valewarden / Mistrunner / Thornweave, rare 10 badges, epic 45, budgeted 2-4 stat points below the Nythraxis equivalents) plus the existing Mysterious Cosmetic Cache at 30. The gear table is the complete authoring spec for a codex implementation slice.
- Reuses the delveMarks counter pattern, worldBossDaily/delveDaily UTC-day gates, and worldBossContributors semantics; one new JSONB field plus a daily record.

**docs/prd/heroic-mythic-dungeons.md: difficulty reuse + forged drops**
- Heroic: existing dungeons re-tuned to level 20 via a pure data transform of the mob records (zero new geometry, mobs, or i18n).
- Mythic+: untimed keystone scaling (compounding ~1.10/level), affixes at keys 4/7/10 reusing the delve affix content model, best-key leaderboard, and a daily-gated end-of-run chest with a seeded weekly slot rotation.
- Forged drops: Valeforged upgrades an item by +2 item levels (stats scaled by (L+2)/L, deltas frozen at drop time); Swiftforged rolls 3-5% movement speed, non-stacking (highest equipped applies). Builds on the professions item-instance payload from #1174 (rolled stats, boundTo binding, market block); the remaining enabling change is equipment carrying the instance payload.

## Status
Draft for design review; numbers marked tunable are flagged in each doc. Implementation entry point is heroic P1 (difficulty transform + heroic Hollow Crypt + badge hook).

Generated with [Claude Code](https://claude.com/claude-code)