### PR TITLE
fix(sim): ranged aggro timing and physical-shot projectiles

### DIFF
--- a/src/sim/combat/auto_attack.ts
+++ b/src/sim/combat/auto_attack.ts
@@ -62,13 +62,15 @@ export function startAutoAttack(ctx: SimContext, pid?: number): void {
   if (p.sitting) ctx.standUp(p);
   p.autoAttack = true;
   r.meta.lastActiveTick = ctx.tickCount; // starting auto-attack is a deliberate action
+  // Engaging MELEE auto-attack seeds aggro at once, because the swing lands almost
+  // immediately. Ranged auto-attack (wand / auto shot, up to 30-35yd) must NOT pre-aggro
+  // at engage: its threat comes from the shot LANDING (rangedSwing schedules a projectile
+  // whose impact aggros, like the spell it accompanies). Otherwise the "Attack on Ability
+  // Use" QoL, which engages auto-attack when you cast a damaging spell, pulls a distant
+  // mob the instant the cast starts, before anything lands.
   const d = dist2d(p.pos, t.pos);
-  const ranged = CLASSES[r.meta.cls].ranged;
-  const inAutoAttackRange = ranged
-    ? d <= ranged.maxRange && d >= (ranged.wand ? 0 : ranged.minRange) && ctx.hasLineOfSight(p, t)
-    : d <= MELEE_RANGE;
   if (
-    inAutoAttackRange &&
+    d <= MELEE_RANGE &&
     t.kind === 'mob' &&
     t.hostile &&
     t.ownerId === null &&

--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -677,7 +677,15 @@ function applyAbility(ctx: SimContext, p: Entity, meta: PlayerMeta, res: Resolve
     return;
   }
 
-  if (target && ability.school !== 'physical') {
+  // A ranged attack travels as a projectile, so its damage/effects resolve when the
+  // bolt LANDS, not at cast completion. Every non-physical spell is a bolt by
+  // convention (school proxy); a physical ranged shot (hunter Aimed / Concussive Shot)
+  // opts in with projectile:true. Without this a physical shot deals its damage
+  // instantly while the arrow is still visibly in flight (health drops, or the mob
+  // dies, before it arrives).
+  const firesProjectile = ability.school !== 'physical' || ability.projectile === true;
+  if (target && firesProjectile) {
+    const isSpell = ability.school !== 'physical';
     spendAbilityCost(p, res);
     armAbilityCooldown(p, ability.id, res.cooldown, togglingOff);
     ctx.emit({
@@ -689,11 +697,12 @@ function applyAbility(ctx: SimContext, p: Entity, meta: PlayerMeta, res: Resolve
     });
     // The bolt is now in flight: its hit roll and effects resolve when it reaches the
     // target (projectile_travel), not this tick. A target that dies before impact
-    // takes nothing (the drain fizzles the projectile). Spells never "miss" like a
-    // physical attack; a target can only fully RESIST them (classic-era semantics),
-    // so the on-impact roll uses isSpellResisted and emits a 'resist', not a 'miss'.
+    // takes nothing (the fizzle is handled by scheduleProjectile). Spells never "miss"
+    // like a physical attack; a target can only fully RESIST them (classic-era
+    // semantics), so a spell's on-impact roll uses isSpellResisted and emits a 'resist'.
+    // A physical shot has no resist roll; its hit/crit resolve inside runEffects.
     scheduleProjectile(ctx, p, target, (src, tgt) => {
-      if (isSpellResisted(ctx.rng, src.level, tgt.level)) {
+      if (isSpell && isSpellResisted(ctx.rng, src.level, tgt.level)) {
         ctx.emit({
           type: 'damage',
           sourceId: src.id,

--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -1920,6 +1920,7 @@ export const ABILITIES: Record<string, AbilityDef> = {
     range: 35,
     minRange: 8,
     school: 'physical',
+    projectile: true, // a fired shot: damage/slow resolve when the bolt lands
     // A fired shot: its flat damage scales off Ranged AP like the other shots,
     // not melee AP, even though it is physical.
     scalesWith: 'ranged',
@@ -2012,6 +2013,7 @@ export const ABILITIES: Record<string, AbilityDef> = {
     range: 35,
     minRange: 8,
     school: 'physical',
+    projectile: true, // a fired shot: damage resolves when the arrow lands
     scalesWith: 'ranged',
     requiresTarget: true,
     effects: [{ type: 'directDamage', min: 50, max: 62 }],

--- a/src/sim/pet/pet_ai.ts
+++ b/src/sim/pet/pet_ai.ts
@@ -32,6 +32,7 @@
 
 import { lineOfSightClear } from '../colliders';
 import { MOBS } from '../data';
+import { isTrivialTo } from '../mob/targeting';
 import { findPlayerPath, PLAYER_BODY_RADIUS } from '../pathfind';
 import { scheduleProjectile } from '../projectile_travel';
 import type { SimContext } from '../sim_context';
@@ -56,6 +57,11 @@ const PET_PATH_STALE_DISTANCE = 4; // path end this far from the (now-moved) own
 const PET_WAYPOINT_REACHED = 1; // pet within this of the next waypoint: pop it and home on the next leg
 const PET_ASSIST_RANGE = 50; // how far the pet scans for enemies engaging the pair
 const PET_AGGRESSIVE_RANGE = 18; // aggressive pets look for idle enemies this close
+// A pet pulls idle wild mobs by proximity just like its owner. The max mob detection
+// radius is 20 (see the clamp below), so any mob that could notice the pet is within
+// 20yd of it; scanning from the pet (there are at most a handful) keeps this off every
+// idle mob's per-tick path, so work scales with pet count, not mob count.
+const PET_PULL_SCAN = 20;
 // Anti-AFK: an aggressive pet only proactively pulls fresh targets while its
 // owner has acted (moved, cast, or commanded the pet) within this many ticks.
 // 1200 ticks = 60s at 20Hz. Stops hunters/warlocks parking an aggressive pet to
@@ -74,6 +80,8 @@ export function updatePet(ctx: SimContext, pet: Entity): void {
   if (!pet.inCombat && ctx.tickCount % 40 === 0 && pet.hp < pet.maxHp) {
     pet.hp = Math.min(pet.maxHp, pet.hp + Math.max(1, Math.round(pet.maxHp * 0.02)));
   }
+
+  pullNearbyMobs(ctx, pet);
 
   let target = pet.aggroTargetId !== null ? (ctx.entities.get(pet.aggroTargetId) ?? null) : null;
   if (target && (target.dead || !ctx.isHostileTo(pet, target))) target = null;
@@ -123,6 +131,24 @@ export function updatePet(ctx: SimContext, pet: Entity): void {
   // heel
   pet.swingTimer = Math.max(0, pet.swingTimer - DT);
   petFollow(ctx, pet, owner);
+}
+
+// A pet standing inside an idle wild mob's detection radius pulls it, exactly as its
+// owner would: the mob notices the pet sent in ahead instead of waiting for the pet's
+// first strike. This mirrors the player proximity-aggro pass (mob/locomotion) but runs
+// from the pet side so a pet-free region costs nothing.
+function pullNearbyMobs(ctx: SimContext, pet: Entity): void {
+  ctx.grid.forEachInRadius(pet.pos.x, pet.pos.z, PET_PULL_SCAN, (m, d2) => {
+    // wild, live, idle mobs only (skip pets/adds, corpses, already-engaged, visions)
+    if (m.ownerId !== null || m.kind !== 'mob' || m.dead) return;
+    if (m.aiState !== 'idle' || !m.hostile || m.templateId.startsWith('vision_')) return;
+    if (isTrivialTo(m, pet)) return;
+    const radius = Math.max(
+      4,
+      Math.min(20, (MOBS[m.templateId]?.aggroRadius ?? 0) + (m.level - pet.level) * 1.5),
+    );
+    if (Math.sqrt(d2) < radius) ctx.aggroMob(m, pet, true);
+  });
 }
 
 // Heel locomotion: route the pet to its owner AROUND obstacles instead of

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1110,6 +1110,13 @@ export interface AbilityDef {
   cooldown: number; // seconds, 0 = none (GCD only)
   range: number; // yards; 0 = melee range
   minRange?: number;
+  // The attack travels to its target as a projectile, so its damage and effects
+  // resolve when the bolt LANDS (projectile_travel), not at cast completion. Every
+  // non-physical spell is a projectile by convention (keyed off school in
+  // casting_lifecycle); a PHYSICAL ranged shot (hunter Aimed / Concussive Shot) must
+  // set this explicitly, or it would deal its damage instantly while the arrow is
+  // still visibly in flight. Melee physical attacks leave it unset.
+  projectile?: boolean;
   school: 'physical' | 'fire' | 'frost' | 'arcane' | 'shadow' | 'holy' | 'nature';
   // Damage scaling source for the flat directDamage / DoT / AoE riders. Default:
   // non-physical damage scales with Spell Power; physical damage scales with melee

--- a/tests/combat_auto_attack.test.ts
+++ b/tests/combat_auto_attack.test.ts
@@ -235,6 +235,40 @@ describe('auto_attack start/stopAutoAttack', () => {
   });
 });
 
+describe('auto_attack startAutoAttack: ranged engage must not pre-aggro (issue #1)', () => {
+  // Casting a damaging spell engages the wand / auto-shot via the "Attack on Ability
+  // Use" QoL (default on). That must NOT aggro a distant mob the instant the cast
+  // starts: ranged threat comes from the shot LANDING (rangedSwing schedules a
+  // projectile), exactly like the spell it accompanies. Only melee, where a swing
+  // lands at once, seeds aggro on engage.
+  it('a wand caster engaging at ranged distance does NOT aggro an idle mob', () => {
+    const { sim, p } = makeSim('mage', 12);
+    const mob = spawnDummy(sim, p, 12, 25); // 25yd: inside the 30yd wand range, beyond melee
+    startAutoAttack(sim.ctx, p.id);
+    expect(p.autoAttack).toBe(true); // auto-attack still engages
+    expect(mob.aiState).toBe('idle'); // but the mob is NOT pulled at engage time
+    expect(mob.aggroTargetId).toBe(null);
+  });
+
+  it('melee engage still seeds aggro immediately (unchanged behavior)', () => {
+    const { sim, p } = makeSim('warrior', 12);
+    const mob = spawnDummy(sim, p, 12, 2); // 2yd: melee range, a swing lands at once
+    startAutoAttack(sim.ctx, p.id);
+    expect(p.autoAttack).toBe(true);
+    expect(mob.aggroTargetId).toBe(p.id);
+  });
+
+  it('a wand caster still aggros the mob when the shot actually lands', () => {
+    const { sim, p } = makeSim('mage', 12);
+    const mob = spawnDummy(sim, p, 12, 25);
+    const events = capture(sim);
+    startAutoAttack(sim.ctx, p.id);
+    expect(mob.aggroTargetId).toBe(null); // not at engage
+    landProjectiles(sim, events, (e) => e.type === 'damage' && e.sourceId === p.id, 60);
+    expect(mob.aggroTargetId).toBe(p.id); // aggroed on impact, the classic-correct moment
+  });
+});
+
 describe('auto_attack determinism', () => {
   it('identical seeds produce an identical swing-damage sequence (seeded replay)', () => {
     const run = (): number[] => {

--- a/tests/combat_casting_lifecycle.test.ts
+++ b/tests/combat_casting_lifecycle.test.ts
@@ -150,3 +150,28 @@ describe('casting_lifecycle: determinism', () => {
     expect(run()).toEqual(run());
   });
 });
+
+describe('casting_lifecycle: physical ranged shots resolve on projectile impact (Aimed Shot)', () => {
+  it('deals no damage at cast completion; damage lands when the arrow arrives', () => {
+    const { sim, p, meta } = makeSim('hunter', 20);
+    p.resource = p.maxResource = 500;
+    const mob = spawnTarget(sim, p, 20, 20); // 20yd: within 35yd range, beyond the 8yd deadzone
+    const events: Array<Record<string, any>> = [];
+    const orig = (sim as any).emit.bind(sim);
+    (sim as any).emit = (e: Record<string, any>) => {
+      events.push(e);
+      orig(e);
+    };
+    const hp0 = mob.hp;
+    castAbility(sim.ctx, 'aimed_shot', p.id);
+    expect(p.castingAbility).toBe('aimed_shot');
+    drainCast(sim, p, meta); // run the 3s cast to completion (updateCasting only, no projectile step)
+    // The shot is LAUNCHED at cast completion, not landed: no damage yet, a bolt is in flight.
+    expect(mob.hp).toBe(hp0);
+    expect(events.some((e) => e.type === 'spellfx' && e.fx === 'projectile')).toBe(true);
+    // Advance ticks so the arrow travels and connects.
+    for (let i = 0; i < 60 && mob.hp === hp0; i++) sim.tick();
+    expect(mob.hp).toBeLessThan(hp0);
+    expect(events.some((e) => e.type === 'damage' && e.ability === 'Aimed Shot')).toBe(true);
+  });
+});

--- a/tests/parity/golden/c5_auto_attack.json
+++ b/tests/parity/golden/c5_auto_attack.json
@@ -35,172 +35,172 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 399,
-      "state": "6e2ac63d",
+      "state": "0ae8f876",
       "events": "4a6c7105",
       "rng": {
-        "draws": 16,
-        "digest": "76cf2232"
+        "draws": 20,
+        "digest": "55f37111"
       }
     },
     {
       "tick": 10,
       "time": 0.5,
       "nextId": 399,
-      "state": "2efd78fb",
-      "events": "7220b02d",
+      "state": "f5751c90",
+      "events": "741638a5",
       "rng": {
-        "draws": 19,
-        "digest": "106b80d2"
+        "draws": 20,
+        "digest": "55f37111"
       }
     },
     {
       "tick": 15,
       "time": 0.75,
       "nextId": 399,
-      "state": "b2df0a60",
-      "events": "41ae2539",
+      "state": "39022c33",
+      "events": "9bbd02df",
       "rng": {
-        "draws": 19,
-        "digest": "106b80d2"
+        "draws": 23,
+        "digest": "b39278ba"
       }
     },
     {
       "tick": 20,
       "time": 1,
       "nextId": 399,
-      "state": "01fffae8",
-      "events": "32515182",
+      "state": "38d209c5",
+      "events": "f9d3fc28",
       "rng": {
-        "draws": 22,
-        "digest": "c0f15e96"
+        "draws": 26,
+        "digest": "708cc4a7"
       }
     },
     {
       "tick": 25,
       "time": 1.25,
       "nextId": 399,
-      "state": "91b6f9d4",
+      "state": "94ac188e",
       "events": "41ae2539",
       "rng": {
-        "draws": 22,
-        "digest": "c0f15e96"
+        "draws": 26,
+        "digest": "708cc4a7"
       }
     },
     {
       "tick": 30,
       "time": 1.5,
       "nextId": 399,
-      "state": "a3dce6d7",
+      "state": "77c8aec3",
       "events": "741638a5",
       "rng": {
-        "draws": 22,
-        "digest": "c0f15e96"
+        "draws": 26,
+        "digest": "708cc4a7"
       }
     },
     {
       "tick": 35,
       "time": 1.75,
       "nextId": 399,
-      "state": "72899831",
+      "state": "acb07593",
       "events": "41ae2539",
       "rng": {
-        "draws": 22,
-        "digest": "c0f15e96"
+        "draws": 26,
+        "digest": "708cc4a7"
       }
     },
     {
       "tick": 40,
       "time": 2,
       "nextId": 399,
-      "state": "2c4958c3",
-      "events": "170a76c8",
+      "state": "92b330b1",
+      "events": "72ccd44f",
       "rng": {
-        "draws": 25,
-        "digest": "34f63655"
+        "draws": 27,
+        "digest": "b7df48f2"
       }
     },
     {
       "tick": 45,
       "time": 2.25,
       "nextId": 399,
-      "state": "9d71f004",
-      "events": "e6b04fda",
+      "state": "5e2c2b16",
+      "events": "4fc51e8d",
       "rng": {
-        "draws": 66,
-        "digest": "b6949540"
+        "draws": 68,
+        "digest": "4e54af34"
       }
     },
     {
       "tick": 50,
       "time": 2.5,
       "nextId": 399,
-      "state": "412ac573",
-      "events": "12ab4695",
+      "state": "ab59c198",
+      "events": "842619cc",
       "rng": {
-        "draws": 91,
-        "digest": "1c05f7c3"
+        "draws": 93,
+        "digest": "e53395e6"
       }
     },
     {
       "tick": 55,
       "time": 2.75,
       "nextId": 399,
-      "state": "9492818e",
+      "state": "6455d45c",
       "events": "41ae2539",
       "rng": {
-        "draws": 103,
-        "digest": "563e4e07"
+        "draws": 105,
+        "digest": "bee63e22"
       }
     },
     {
       "tick": 60,
       "time": 3,
       "nextId": 399,
-      "state": "7b0233a9",
-      "events": "a087532a",
+      "state": "17945273",
+      "events": "5e1fd76f",
       "rng": {
-        "draws": 128,
-        "digest": "55009736"
+        "draws": 129,
+        "digest": "ae076555"
       }
     },
     {
       "tick": 65,
       "time": 3.25,
       "nextId": 399,
-      "state": "86e67409",
+      "state": "8b49a7bb",
       "events": "41ae2539",
       "rng": {
-        "draws": 148,
-        "digest": "1ed7f5ef"
+        "draws": 151,
+        "digest": "208fe418"
       }
     },
     {
       "tick": 70,
       "time": 3.5,
       "nextId": 399,
-      "state": "04443a2d",
+      "state": "e26db8ed",
       "events": "741638a5",
       "rng": {
-        "draws": 169,
-        "digest": "e71cefca"
+        "draws": 173,
+        "digest": "e2550f48"
       }
     },
     {
       "tick": 75,
       "time": 3.75,
       "nextId": 399,
-      "state": "73370ffc",
-      "events": "90bf4ba7",
+      "state": "d8aa33eb",
+      "events": "bdbe797e",
       "rng": {
-        "draws": 193,
-        "digest": "d945fccc"
+        "draws": 198,
+        "digest": "c4eec8b8"
       }
     },
     {
       "tick": 80,
       "time": 4,
       "nextId": 399,
-      "state": "b7f7b0ad",
+      "state": "935afa86",
       "events": "741638a5",
       "rng": {
         "draws": 216,
@@ -211,29 +211,29 @@
       "tick": 85,
       "time": 4.25,
       "nextId": 399,
-      "state": "fed4ad36",
-      "events": "eb982a74",
+      "state": "897c136a",
+      "events": "010e6dcb",
       "rng": {
-        "draws": 258,
-        "digest": "25c55ffa"
+        "draws": 256,
+        "digest": "caa0beb3"
       }
     },
     {
       "tick": 90,
       "time": 4.5,
       "nextId": 399,
-      "state": "b03b9bfd",
-      "events": "6219ea4c",
+      "state": "3fae6f53",
+      "events": "9345f7d4",
       "rng": {
-        "draws": 289,
-        "digest": "329800bc"
+        "draws": 285,
+        "digest": "eb174aa4"
       }
     },
     {
       "tick": 95,
       "time": 4.75,
       "nextId": 399,
-      "state": "91275a4d",
+      "state": "767d4acb",
       "events": "78c777a2",
       "rng": {
         "draws": 315,
@@ -244,66 +244,66 @@
       "tick": 100,
       "time": 5,
       "nextId": 399,
-      "state": "26c62e13",
+      "state": "85bee3ab",
       "events": "741638a5",
       "rng": {
-        "draws": 342,
-        "digest": "a17e533e"
+        "draws": 341,
+        "digest": "daa80465"
       }
     },
     {
       "tick": 105,
       "time": 5.25,
       "nextId": 399,
-      "state": "31dfa8f9",
+      "state": "c712e65d",
       "events": "41ae2539",
       "rng": {
-        "draws": 372,
-        "digest": "c50d6ea5"
+        "draws": 374,
+        "digest": "1ef810ee"
       }
     },
     {
       "tick": 110,
       "time": 5.5,
       "nextId": 399,
-      "state": "1bfb5bd5",
-      "events": "40452fa8",
+      "state": "ffff32ca",
+      "events": "2e963b99",
       "rng": {
-        "draws": 396,
-        "digest": "346ccc0d"
+        "draws": 399,
+        "digest": "d3aca4ad"
       }
     },
     {
       "tick": 115,
       "time": 5.75,
       "nextId": 399,
-      "state": "34f13cbb",
+      "state": "a0a46db0",
       "events": "41ae2539",
       "rng": {
-        "draws": 418,
-        "digest": "43a127ed"
+        "draws": 419,
+        "digest": "193892c1"
       }
     },
     {
       "tick": 120,
       "time": 6,
       "nextId": 399,
-      "state": "e57b8b4b",
-      "events": "7bcf0e70",
+      "state": "1a58fabf",
+      "events": "c13a5186",
       "rng": {
-        "draws": 473,
-        "digest": "d9ceee98"
+        "draws": 478,
+        "digest": "852cf2d5"
       }
     },
     {
       "tick": 120,
       "time": 6,
       "nextId": 399,
-      "state": "e57b8b4b",
+      "state": "1a58fabf",
       "events": "741638a5",
       "rng": {
-        "draws": 473,
-        "digest": "d9ceee98"
+        "draws": 478,
+        "digest": "852cf2d5"
       },
       "label": "swings",
       "players": [
@@ -314,8 +314,8 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 147,
-            "damageTaken": 22
+            "damageDealt": 149,
+            "damageTaken": 17
           },
           "delveClears": {},
           "delveDaily": {},
@@ -337,8 +337,8 @@
           "cls": "rogue",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 75,
-            "damageTaken": 7
+            "damageDealt": 59,
+            "damageTaken": 14
           },
           "delveClears": {},
           "delveDaily": {},
@@ -360,7 +360,7 @@
           "cls": "hunter",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 72,
+            "damageDealt": 54,
             "damageTaken": 27
           },
           "delveClears": {},
@@ -383,7 +383,7 @@
           "cls": "hunter",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 84
+            "damageDealt": 86
           },
           "delveClears": {},
           "delveDaily": {},
@@ -405,7 +405,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 15
+            "damageDealt": 21
           },
           "delveClears": {},
           "delveDaily": {},
@@ -426,13 +426,13 @@
           "aiState": "idle",
           "attackPower": 102,
           "autoAttack": true,
-          "combatTimer": 1.55,
+          "combatTimer": 2,
           "critChance": 0.067,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.067,
           "fallStartY": -1.553351,
           "fiveSecondRule": 105,
-          "hp": 79978,
+          "hp": 79983,
           "id": 389,
           "inCombat": true,
           "kind": "player",
@@ -486,7 +486,7 @@
           "dodgeChance": 0.0835,
           "fallStartY": -3.203049,
           "fiveSecondRule": 105,
-          "hp": 79993,
+          "hp": 79986,
           "id": 390,
           "inCombat": true,
           "kind": "player",
@@ -496,7 +496,7 @@
           "maxResource": 100,
           "moveSpeed": 7,
           "onGround": true,
-          "overpowerUntil": -1,
+          "overpowerUntil": 6.85,
           "petMode": "defensive",
           "pos": {
             "x": -30,
@@ -556,7 +556,7 @@
           "maxResource": 457,
           "moveSpeed": 7,
           "onGround": true,
-          "overpowerUntil": -1,
+          "overpowerUntil": 7.25,
           "petMode": "defensive",
           "pos": {
             "y": -3.063027,
@@ -699,7 +699,7 @@
         {
           "aggroTargetId": 389,
           "aiState": "attack",
-          "combatTimer": 1.55,
+          "combatTimer": 2,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
@@ -707,7 +707,7 @@
           "fallStartY": -1.689975,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499853,
+          "hp": 499851,
           "id": 394,
           "inCombat": true,
           "kind": "mob",
@@ -743,7 +743,7 @@
           "threat": [
             [
               389,
-              326
+              328
             ]
           ],
           "weapon": {
@@ -763,7 +763,7 @@
           "fallStartY": -3.216598,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499925,
+          "hp": 499941,
           "id": 395,
           "inCombat": true,
           "kind": "mob",
@@ -799,7 +799,7 @@
           "threat": [
             [
               390,
-              77
+              61
             ]
           ],
           "weapon": {
@@ -819,7 +819,7 @@
           "fallStartY": -3.078543,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499928,
+          "hp": 499946,
           "id": 396,
           "inCombat": true,
           "kind": "mob",
@@ -852,7 +852,7 @@
           "threat": [
             [
               391,
-              73
+              56
             ]
           ],
           "weapon": {
@@ -872,7 +872,7 @@
           "fallStartY": 2.785314,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499916,
+          "hp": 499914,
           "id": 397,
           "inCombat": true,
           "kind": "mob",
@@ -907,9 +907,15 @@
           "threat": [
             [
               392,
-              86
+              87
             ]
           ],
+          "wanderTarget": {
+            "x": 26.013586,
+            "y": 2.800258,
+            "z": -23.944155
+          },
+          "wanderTimer": 29.25,
           "weapon": {
             "max": 18,
             "min": 11,
@@ -927,7 +933,7 @@
           "fallStartY": 2.551396,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499985,
+          "hp": 499979,
           "id": 398,
           "inCombat": true,
           "kind": "mob",
@@ -962,9 +968,15 @@
           "threat": [
             [
               393,
-              17
+              22
             ]
           ],
+          "wanderTarget": {
+            "x": 57.452186,
+            "y": 1.950071,
+            "z": -26.835242
+          },
+          "wanderTimer": 29.45,
           "weapon": {
             "max": 18,
             "min": 11,
@@ -977,18 +989,18 @@
       "tick": 125,
       "time": 6.25,
       "nextId": 399,
-      "state": "3f12b97d",
-      "events": "04b7ed59",
+      "state": "541cd6eb",
+      "events": "e0a8606c",
       "rng": {
-        "draws": 518,
-        "digest": "43746d41"
+        "draws": 516,
+        "digest": "e781610a"
       }
     },
     {
       "tick": 126,
       "time": 6.3,
       "nextId": 399,
-      "state": "84d85861",
+      "state": "592a6e85",
       "events": "741638a5",
       "rng": {
         "draws": 524,
@@ -1003,8 +1015,8 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 196,
-            "damageTaken": 24
+            "damageDealt": 200,
+            "damageTaken": 19
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1026,8 +1038,8 @@
           "cls": "rogue",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 75,
-            "damageTaken": 17
+            "damageDealt": 59,
+            "damageTaken": 14
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1049,7 +1061,7 @@
           "cls": "hunter",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 72,
+            "damageDealt": 54,
             "damageTaken": 34
           },
           "delveClears": {},
@@ -1072,7 +1084,7 @@
           "cls": "hunter",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 84
+            "damageDealt": 86
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1094,7 +1106,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 15
+            "damageDealt": 21
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1121,7 +1133,7 @@
           "dodgeChance": 0.067,
           "fallStartY": -1.553351,
           "fiveSecondRule": 105.3,
-          "hp": 79976,
+          "hp": 79981,
           "id": 389,
           "inCombat": true,
           "kind": "player",
@@ -1167,13 +1179,13 @@
         {
           "aiState": "idle",
           "attackPower": 98,
-          "combatTimer": 0.25,
+          "combatTimer": 0.9,
           "critChance": 0.0835,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.0835,
           "fallStartY": -3.203049,
           "fiveSecondRule": 105.3,
-          "hp": 79983,
+          "hp": 79986,
           "id": 390,
           "inCombat": true,
           "kind": "player",
@@ -1183,7 +1195,7 @@
           "maxResource": 100,
           "moveSpeed": 7,
           "onGround": true,
-          "overpowerUntil": -1,
+          "overpowerUntil": 6.85,
           "petMode": "defensive",
           "pos": {
             "x": -30,
@@ -1237,7 +1249,7 @@
           "maxResource": 457,
           "moveSpeed": 7,
           "onGround": true,
-          "overpowerUntil": -1,
+          "overpowerUntil": 7.25,
           "petMode": "defensive",
           "pos": {
             "y": -3.063027,
@@ -1388,7 +1400,7 @@
           "fallStartY": -1.689975,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499804,
+          "hp": 499800,
           "id": 394,
           "inCombat": true,
           "kind": "mob",
@@ -1424,7 +1436,7 @@
           "threat": [
             [
               389,
-              434
+              438
             ]
           ],
           "weapon": {
@@ -1436,7 +1448,7 @@
         {
           "aggroTargetId": 390,
           "aiState": "attack",
-          "combatTimer": 0.25,
+          "combatTimer": 0.9,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
@@ -1444,7 +1456,7 @@
           "fallStartY": -3.216598,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499925,
+          "hp": 499941,
           "id": 395,
           "inCombat": true,
           "kind": "mob",
@@ -1480,7 +1492,7 @@
           "threat": [
             [
               390,
-              77
+              61
             ]
           ],
           "weapon": {
@@ -1500,7 +1512,7 @@
           "fallStartY": -3.078543,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499928,
+          "hp": 499946,
           "id": 396,
           "inCombat": true,
           "kind": "mob",
@@ -1533,7 +1545,7 @@
           "threat": [
             [
               391,
-              73
+              56
             ]
           ],
           "weapon": {
@@ -1553,7 +1565,7 @@
           "fallStartY": 2.785314,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499916,
+          "hp": 499914,
           "id": 397,
           "inCombat": true,
           "kind": "mob",
@@ -1588,9 +1600,15 @@
           "threat": [
             [
               392,
-              86
+              87
             ]
           ],
+          "wanderTarget": {
+            "x": 26.013586,
+            "y": 2.800258,
+            "z": -23.944155
+          },
+          "wanderTimer": 29.25,
           "weapon": {
             "max": 18,
             "min": 11,
@@ -1608,7 +1626,7 @@
           "fallStartY": 2.551396,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499985,
+          "hp": 499979,
           "id": 398,
           "inCombat": true,
           "kind": "mob",
@@ -1643,9 +1661,15 @@
           "threat": [
             [
               393,
-              17
+              22
             ]
           ],
+          "wanderTarget": {
+            "x": 57.452186,
+            "y": 1.950071,
+            "z": -26.835242
+          },
+          "wanderTimer": 29.45,
           "weapon": {
             "max": 18,
             "min": 11,
@@ -1658,7 +1682,7 @@
       "tick": 126,
       "time": 6.3,
       "nextId": 399,
-      "state": "84d85861",
+      "state": "592a6e85",
       "events": "741638a5",
       "rng": {
         "draws": 524,
@@ -1673,8 +1697,8 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 196,
-            "damageTaken": 24
+            "damageDealt": 200,
+            "damageTaken": 19
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1696,8 +1720,8 @@
           "cls": "rogue",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 75,
-            "damageTaken": 17
+            "damageDealt": 59,
+            "damageTaken": 14
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1719,7 +1743,7 @@
           "cls": "hunter",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 72,
+            "damageDealt": 54,
             "damageTaken": 34
           },
           "delveClears": {},
@@ -1742,7 +1766,7 @@
           "cls": "hunter",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 84
+            "damageDealt": 86
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1764,7 +1788,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 15
+            "damageDealt": 21
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1791,7 +1815,7 @@
           "dodgeChance": 0.067,
           "fallStartY": -1.553351,
           "fiveSecondRule": 105.3,
-          "hp": 79976,
+          "hp": 79981,
           "id": 389,
           "inCombat": true,
           "kind": "player",
@@ -1837,13 +1861,13 @@
         {
           "aiState": "idle",
           "attackPower": 98,
-          "combatTimer": 0.25,
+          "combatTimer": 0.9,
           "critChance": 0.0835,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.0835,
           "fallStartY": -3.203049,
           "fiveSecondRule": 105.3,
-          "hp": 79983,
+          "hp": 79986,
           "id": 390,
           "inCombat": true,
           "kind": "player",
@@ -1853,7 +1877,7 @@
           "maxResource": 100,
           "moveSpeed": 7,
           "onGround": true,
-          "overpowerUntil": -1,
+          "overpowerUntil": 6.85,
           "petMode": "defensive",
           "pos": {
             "x": -30,
@@ -1907,7 +1931,7 @@
           "maxResource": 457,
           "moveSpeed": 7,
           "onGround": true,
-          "overpowerUntil": -1,
+          "overpowerUntil": 7.25,
           "petMode": "defensive",
           "pos": {
             "y": -3.063027,
@@ -2058,7 +2082,7 @@
           "fallStartY": -1.689975,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499804,
+          "hp": 499800,
           "id": 394,
           "inCombat": true,
           "kind": "mob",
@@ -2094,7 +2118,7 @@
           "threat": [
             [
               389,
-              434
+              438
             ]
           ],
           "weapon": {
@@ -2106,7 +2130,7 @@
         {
           "aggroTargetId": 390,
           "aiState": "attack",
-          "combatTimer": 0.25,
+          "combatTimer": 0.9,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
@@ -2114,7 +2138,7 @@
           "fallStartY": -3.216598,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499925,
+          "hp": 499941,
           "id": 395,
           "inCombat": true,
           "kind": "mob",
@@ -2150,7 +2174,7 @@
           "threat": [
             [
               390,
-              77
+              61
             ]
           ],
           "weapon": {
@@ -2170,7 +2194,7 @@
           "fallStartY": -3.078543,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499928,
+          "hp": 499946,
           "id": 396,
           "inCombat": true,
           "kind": "mob",
@@ -2203,7 +2227,7 @@
           "threat": [
             [
               391,
-              73
+              56
             ]
           ],
           "weapon": {
@@ -2223,7 +2247,7 @@
           "fallStartY": 2.785314,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499916,
+          "hp": 499914,
           "id": 397,
           "inCombat": true,
           "kind": "mob",
@@ -2258,9 +2282,15 @@
           "threat": [
             [
               392,
-              86
+              87
             ]
           ],
+          "wanderTarget": {
+            "x": 26.013586,
+            "y": 2.800258,
+            "z": -23.944155
+          },
+          "wanderTimer": 29.25,
           "weapon": {
             "max": 18,
             "min": 11,
@@ -2278,7 +2308,7 @@
           "fallStartY": 2.551396,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499985,
+          "hp": 499979,
           "id": 398,
           "inCombat": true,
           "kind": "mob",
@@ -2313,9 +2343,15 @@
           "threat": [
             [
               393,
-              17
+              22
             ]
           ],
+          "wanderTarget": {
+            "x": 57.452186,
+            "y": 1.950071,
+            "z": -26.835242
+          },
+          "wanderTimer": 29.45,
           "weapon": {
             "max": 18,
             "min": 11,

--- a/tests/parity/golden/multi_class_heal.json
+++ b/tests/parity/golden/multi_class_heal.json
@@ -1244,7 +1244,7 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 398,
-      "state": "91ab1392",
+      "state": "fce5c6e4",
       "events": "e7cecad5",
       "rng": {
         "draws": 10,
@@ -1255,7 +1255,7 @@
       "tick": 8,
       "time": 0.4,
       "nextId": 398,
-      "state": "7e99b18f",
+      "state": "7090d4a8",
       "events": "e7cecad5",
       "rng": {
         "draws": 10,
@@ -1648,6 +1648,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
+          "facing": 1.394614,
           "fallStartY": -1.48336,
           "fiveSecondRule": 99,
           "hp": 84,
@@ -1661,7 +1662,7 @@
           "overpowerUntil": -1,
           "ownerId": 393,
           "petMode": "defensive",
-          "petPathCooldown": 0.15,
+          "petPathCooldown": 0.2,
           "pos": {
             "x": 30,
             "y": -1.48336,
@@ -1749,7 +1750,7 @@
             ],
             [
               391,
-              393.5
+              268.5
             ],
             [
               393,
@@ -1809,7 +1810,7 @@
             ],
             [
               391,
-              287.5
+              162.5
             ],
             [
               393,
@@ -1875,7 +1876,7 @@
             ],
             [
               391,
-              287.5
+              162.5
             ],
             [
               394,

--- a/tests/parity/golden/pet_ai.json
+++ b/tests/parity/golden/pet_ai.json
@@ -103,7 +103,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 394,
-      "state": "987cf043",
+      "state": "4fad860d",
       "events": "11a8de12",
       "rng": {
         "draws": 14,
@@ -114,7 +114,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 394,
-      "state": "5423739a",
+      "state": "8ede7750",
       "events": "741638a5",
       "rng": {
         "draws": 14,
@@ -125,7 +125,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 394,
-      "state": "2415fc54",
+      "state": "5e88f7e6",
       "events": "78032d7d",
       "rng": {
         "draws": 107,
@@ -136,7 +136,7 @@
       "tick": 80,
       "time": 4,
       "nextId": 394,
-      "state": "549e1346",
+      "state": "e6fc7140",
       "events": "741638a5",
       "rng": {
         "draws": 186,
@@ -147,7 +147,7 @@
       "tick": 100,
       "time": 5,
       "nextId": 394,
-      "state": "b6cf6270",
+      "state": "aad168ea",
       "events": "7ffe1025",
       "rng": {
         "draws": 307,
@@ -158,7 +158,7 @@
       "tick": 120,
       "time": 6,
       "nextId": 394,
-      "state": "162be455",
+      "state": "80a673bb",
       "events": "741638a5",
       "rng": {
         "draws": 418,
@@ -169,7 +169,7 @@
       "tick": 120,
       "time": 6,
       "nextId": 394,
-      "state": "c0794cb1",
+      "state": "20f33d77",
       "events": "741638a5",
       "rng": {
         "draws": 418,
@@ -453,11 +453,11 @@
           "threat": [
             [
               389,
-              27
+              26
             ],
             [
               392,
-              61
+              60
             ]
           ],
           "weapon": {

--- a/tests/pet_ai.test.ts
+++ b/tests/pet_ai.test.ts
@@ -137,3 +137,29 @@ describe('pet_ai module (P1a) — direct unit tests', () => {
     expect(pet.petPath).toEqual([]);
   });
 });
+
+describe('pet proximity pull: a pet drags idle wild mobs like its owner', () => {
+  it('an idle wild mob inside the pet reach aggros the pet, not only when struck', () => {
+    const { sim, pid, owner } = world();
+    const pet = adopt(sim, pid);
+    const mob = wildHostile(sim, [pet.id]);
+    // even level: not trivial-con, and the mob placed inside the radius floor (>=4yd)
+    mob.level = 10;
+    pet.level = 10;
+    mob.aiState = 'idle';
+    mob.aggroTargetId = null;
+    mob.inCombat = false;
+    place(owner, 500, 500); // owner far away: the mob cannot proximity-aggro the PLAYER
+    place(pet, 100, 100);
+    place(mob, 103, 100); // 3yd from the pet, well within the mob's detection radius
+    sim.rebucket(pet);
+    sim.rebucket(mob);
+    sim.rebucket(owner);
+    expect(pet.ownerId).toBe(pid); // a player-owned pet
+    expect(mob.aiState).toBe('idle');
+    // The pet's own tick pulls nearby idle wild mobs (no reliance on being hit first).
+    updatePet(sim.ctx, pet);
+    expect(mob.aggroTargetId).toBe(pet.id);
+    expect(mob.aiState).not.toBe('idle');
+  });
+});

--- a/tests/pet_command.test.ts
+++ b/tests/pet_command.test.ts
@@ -86,6 +86,17 @@ describe('/pet command', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('hunter', 'Aleph');
     const pet = givePet(sim, a);
+    // The pet is adopted straight out of a spawn camp; move owner + pet onto empty
+    // ground so its former campmates do not proximity-aggro and chip its HP before the
+    // readout (a full-health pet is the point of this case).
+    const owner = sim.entities.get(a)!;
+    owner.pos = { x: 5000, y: owner.pos.y, z: 5000 };
+    owner.prevPos = { ...owner.pos };
+    pet.pos = { x: 5001, y: pet.pos.y, z: 5000 };
+    pet.prevPos = { ...pet.pos };
+    pet.hp = pet.maxHp;
+    (sim as unknown as { rebucket(e: Entity): void }).rebucket(owner);
+    (sim as unknown as { rebucket(e: Entity): void }).rebucket(pet);
     sim.tick();
 
     sim.chat('/pet', a);


### PR DESCRIPTION
Three related ranged-combat correctness fixes, found while testing offline.

## 1. Ranged auto-attack no longer pre-aggros on engage

`startAutoAttack` seeded aggro whenever the target was inside auto-attack range, which for a caster wand or hunter auto shot is 30 to 35 yd. Combined with the default "Attack on Ability Use" QoL (which engages auto-attack when you cast a damaging spell), this meant a mob would aggro and charge the instant you *started* a cast, before anything landed. The engage-time aggro seed is now gated to `MELEE_RANGE`; ranged threat comes from the shot actually landing (`rangedSwing` already schedules a projectile whose impact aggros). Affects mage, priest, warlock (wands) and hunter (auto shot); melee classes are unchanged.

## 2. Pets pull idle wild mobs by proximity, like their owner

A mob only aggroed a player's pet once the pet struck it (`enterCombat`), never by proximity, so a pet sent in ahead was ignored until its first hit. Now each pet scans the small radius around itself and pulls idle wild mobs whose detection range it has entered, mirroring the player proximity-aggro pass. Scanning from the pet side (there are at most a handful) keeps this off every idle mob's per-tick path, so the work scales with pet count, not mob count, and a region with no pet pays nothing. Delve companions (a separate update path) are intentionally not affected.

## 3. Physical ranged shots travel as projectiles

Aimed Shot and Concussive Shot are `school: 'physical'`, and the cast-resolution projectile branch only fired for non-physical schools, so they applied their damage instantly at cast completion while a projectile visual travelled separately (health dropped, or the mob died, before the arrow arrived). Added an explicit `projectile` flag to `AbilityDef` (keying this off the existing `scalesWith: 'ranged'` scaling marker would have conflated two unrelated concepts) and set it on both shots, so their damage now resolves on impact like every other bolt.

## Tests

- New unit tests for each fix (`combat_auto_attack`, `combat_casting_lifecycle`, `pet_ai`).
- Regenerated 3 parity goldens (`c5_auto_attack`, `pet_ai`, `multi_class_heal`): only combat / aggro / movement timing shifted.
- `pet_command` readout test isolated (its pet is adopted out of a spawn camp and now correctly gets pulled).
- Full suite green.