### PR TITLE
tooling(ci): move the AI PR reviewer to the Codex CLI with ChatGPT OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,9 +197,9 @@ WIKI_URL=http://localhost:8080/wiki/index.php/Main_Page
 #WOC_DAILY_REWARD_SERVICE_SECRET=local-dev-secret
 #WOC_DAILY_REWARD_CONFIG_TTL_MS=300000
 
-# AI PR reviewer (scripts/ai_review.mjs, docs/ai-pr-bot.md). In CI these come from
-# the OPENROUTER_API_KEY repo secret and the OPENROUTER_MODEL repo variable; a local
-# run of the script reads them from this file instead (ambient env always wins).
-# Free OpenRouter models commonly log prompts; see the privacy note in the doc.
-#OPENROUTER_API_KEY=
-#OPENROUTER_MODEL=nvidia/nemotron-3-ultra-550b-a55b:free
+# AI PR reviewer (scripts/ai_review.mjs, docs/ai-pr-bot.md). Auth is ChatGPT OAuth via
+# the Codex CLI: locally `codex login` is enough (no key here); in CI the CODEX_AUTH_JSON
+# repo secret carries the auth.json. The model override comes from the CODEX_MODEL repo
+# variable in CI, or from this file for a local run (ambient env always wins). Leave it
+# unset to use the Codex CLI's default model.
+#CODEX_MODEL=gpt-5-codex

--- a/.env.example
+++ b/.env.example
@@ -196,3 +196,10 @@ WIKI_URL=http://localhost:8080/wiki/index.php/Main_Page
 #WOC_DAILY_REWARD_SERVICE_URL=http://127.0.0.1:8797
 #WOC_DAILY_REWARD_SERVICE_SECRET=local-dev-secret
 #WOC_DAILY_REWARD_CONFIG_TTL_MS=300000
+
+# AI PR reviewer (scripts/ai_review.mjs, docs/ai-pr-bot.md). In CI these come from
+# the OPENROUTER_API_KEY repo secret and the OPENROUTER_MODEL repo variable; a local
+# run of the script reads them from this file instead (ambient env always wins).
+# Free OpenRouter models commonly log prompts; see the privacy note in the doc.
+#OPENROUTER_API_KEY=
+#OPENROUTER_MODEL=nvidia/nemotron-3-ultra-550b-a55b:free

--- a/.github/workflows/pr-ai.yml
+++ b/.github/workflows/pr-ai.yml
@@ -8,11 +8,11 @@ name: PR AI assist
 #   screenshots        boots the Vite dev client headless, runs a fixed offline tour
 #                       (character select, desktop HUD, mobile HUD), uploads the PNGs as
 #                       an artifact, and links them in a sticky PR comment.
-#   ai-review           sends the PR diff to an OpenRouter model (free
-#                       nvidia/nemotron-3-ultra-550b-a55b:free by default) and posts the
-#                       review as a sticky PR comment. No-ops without the
-#                       OPENROUTER_API_KEY secret (for example on a fork PR), so it never
-#                       blocks.
+#   ai-review           reviews the PR diff with the OpenAI Codex CLI, authenticated via
+#                       ChatGPT OAuth (the CODEX_AUTH_JSON secret holds a `codex login`
+#                       auth.json), and posts the review as a sticky PR comment. The
+#                       agent runs sandboxed read-only. No-ops without the secret (for
+#                       example on a fork PR), so it never blocks.
 #   ai-review-comment   on demand: an OWNER/MEMBER/COLLABORATOR comments `/review` or
 #                       `/suggest <focus>` on the PR. Fetches the diff itself via the
 #                       GitHub API (no checkout of the PR head, so this stays safe to run
@@ -20,10 +20,10 @@ name: PR AI assist
 #                       comment, keyed to the triggering comment rather than the sticky
 #                       review above.
 #
-# Setup (one time): add an OPENROUTER_API_KEY repo secret to enable ai-review. Optionally
-# set an OPENROUTER_MODEL repo variable to swap the model (free models can change or
-# disappear at any time). See docs/ai-pr-bot.md, including the privacy note on free
-# OpenRouter models logging prompts.
+# Setup (one time): run `codex login` locally and store ~/.codex/auth.json in the
+# CODEX_AUTH_JSON repo secret to enable ai-review. Optionally set a CODEX_MODEL repo
+# variable to override the Codex CLI's default model. See docs/ai-pr-bot.md, including
+# the data-handling note and how to refresh an expired OAuth session.
 
 on:
   pull_request:
@@ -134,9 +134,10 @@ jobs:
         run: node scripts/pr_comment_shots.mjs
 
   ai-review:
-    name: AI review (OpenRouter)
+    name: AI review (Codex)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    timeout-minutes: 20
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -148,6 +149,9 @@ jobs:
         with:
           node-version: 22
 
+      - name: Install the Codex CLI
+        run: npm install -g @openai/codex
+
       - name: Compute PR diff
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -156,10 +160,10 @@ jobs:
           git diff --no-color "$BASE_SHA" "$HEAD_SHA" > pr.diff || true
           echo "diff bytes: $(wc -c < pr.diff)"
 
-      - name: Review with OpenRouter
+      - name: Review with Codex
         env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL || 'nvidia/nemotron-3-ultra-550b-a55b:free' }}
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+          CODEX_MODEL: ${{ vars.CODEX_MODEL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -178,6 +182,7 @@ jobs:
       github.event.issue.pull_request != null &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
       (startsWith(github.event.comment.body, '/review') || startsWith(github.event.comment.body, '/suggest'))
+    timeout-minutes: 20
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -187,10 +192,13 @@ jobs:
         with:
           node-version: 22
 
-      - name: Review with OpenRouter
+      - name: Install the Codex CLI
+        run: npm install -g @openai/codex
+
+      - name: Review with Codex
         env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL || 'nvidia/nemotron-3-ultra-550b-a55b:free' }}
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+          CODEX_MODEL: ${{ vars.CODEX_MODEL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}

--- a/docs/ai-pr-bot.md
+++ b/docs/ai-pr-bot.md
@@ -18,11 +18,15 @@ them is a required check.
      lives in `scripts/pr_shot_targets.mjs`; add coverage with one entry there.
    - **Fixed tour** (no diff or no matched target): a consistent baseline, character
      select, desktop HUD, mobile HUD. Keep all recipes offline and quick.
-2. **AI review** (`ai-review` job). Sends the PR diff to an OpenRouter model and posts a
-   short review as a sticky PR comment, grouped into Correctness / Invariants / Tests /
-   Nits with severity tags. The reviewer is `scripts/ai_review.mjs`; the GitHub comment
-   helper is `scripts/gh_sticky_comment.mjs`. No new npm dependencies: it uses Node's
-   built-in `fetch` and the GitHub REST API.
+2. **AI review** (`ai-review` job). Reviews the PR diff with the OpenAI Codex CLI,
+   authenticated with a ChatGPT account via OAuth (no API key), and posts a short review
+   as a sticky PR comment, grouped into Correctness / Invariants / Tests / Nits with
+   severity tags. Codex runs as an agent with READ-ONLY access to the checkout (sandboxed,
+   no network for the agent itself), so it can verify imports and helpers against the real
+   tree instead of guessing from the diff. The reviewer is `scripts/ai_review.mjs`; the
+   GitHub comment helper is `scripts/gh_sticky_comment.mjs`. No new npm dependencies in
+   the repo: the workflow installs `@openai/codex` globally on the runner, and the GitHub
+   side is Node's built-in `fetch` against the REST API.
 3. **AI review on demand** (`ai-review-comment` job). An OWNER, MEMBER, or COLLABORATOR
    of this repo can comment `/review` or `/suggest <focus>` on a PR (for example
    `/suggest check the null handling around the new cache`) to re-run the same reviewer
@@ -34,22 +38,29 @@ them is a required check.
 ## Enabling the AI review
 
 The screenshots job needs no configuration. The AI review (automatic and on-demand) is
-opt-in:
+opt-in and authenticates with a ChatGPT account through OAuth, not an API key:
 
-- Add a repository **secret** `OPENROUTER_API_KEY` (Settings -> Secrets and variables ->
-  Actions). Get a key at https://openrouter.ai. Without it the `ai-review` and
+- On any machine, install the Codex CLI (`npm install -g @openai/codex`) and run
+  `codex login`. Complete the browser OAuth flow with the ChatGPT account whose plan
+  should pay for the reviews. This writes `~/.codex/auth.json` (OAuth access + refresh
+  tokens).
+- Add a repository **secret** `CODEX_AUTH_JSON` (Settings -> Secrets and variables ->
+  Actions) containing that file's exact contents. The workflow materializes it into a
+  throwaway `CODEX_HOME` for each run. Without the secret the `ai-review` and
   `ai-review-comment` jobs run but no-op and exit green, so the workflow is safe to merge
-  before the key exists.
-- Optional repository **variable** `OPENROUTER_MODEL` to override the model. The default is
-  `nvidia/nemotron-3-ultra-550b-a55b:free` (NVIDIA Nemotron 3 Ultra). It is free **for
-  now**: OpenRouter free tiers can change pricing, rate limits, or be pulled at any time
-  (the previous default, `openrouter/owl-alpha`, was pulled), so treat this as a
-  prototype default and switch the variable when it goes away. Swapping the model is a
-  one-line change with no workflow edit.
-- For a **local run** of `node scripts/ai_review.mjs`, both `OPENROUTER_API_KEY` and
-  `OPENROUTER_MODEL` can live in the repo-root `.env` (see `.env.example`); the script
-  loads it best-effort. Variables already set in the environment always take precedence,
-  so the CI values are never overridden.
+  before the secret exists. Treat the secret like a password: it is a login to the
+  ChatGPT account.
+- If reviews start failing with an auth error in the workflow logs, the OAuth session
+  has expired or been revoked: re-run `codex login` and refresh the secret.
+- Optional repository **variable** `CODEX_MODEL` to override the model; when unset, the
+  Codex CLI's own default model is used. Swapping the model is a one-line change with no
+  workflow edit.
+- For a **local run** of `node scripts/ai_review.mjs`, your normal `codex login` session
+  is used directly (no secret needed), and `CODEX_MODEL` can live in the repo-root
+  `.env` (see `.env.example`); the script loads it best-effort. Variables already set in
+  the environment always take precedence, so the CI values are never overridden.
+- Reviews consume the ChatGPT plan's Codex usage quota; a burst of PR pushes can hit the
+  plan's rate limits, in which case the job posts the non-blocking fallback note instead.
 
 ## Requesting a review on demand
 
@@ -62,19 +73,17 @@ time contributor cannot self-trigger it on their own fork PR by commenting on it
 gate exists because, unlike the automatic `pull_request`-triggered job, a comment trigger
 always runs with this repo's secrets available, even against a fork PR: the job never
 checks out or executes the PR's own code, it only reads the diff as text through the
-GitHub API, but the trust gate keeps it from being invoked, and the OpenRouter budget
-spent, by an untrusted commenter.
+GitHub API, but the trust gate keeps it from being invoked, and the ChatGPT plan's Codex
+quota spent, by an untrusted commenter. Codex itself additionally runs in a read-only
+sandbox with network access disabled, so even a malicious diff crafted as a prompt
+injection cannot make the agent modify the checkout or call out anywhere.
 
 ## Privacy: read before enabling on private code
 
-Free OpenRouter models commonly **log prompts to improve the model**, which means the PR
-diff you send may be retained by a third party; check the model's Data Policy tab on
-openrouter.ai. Do not enable the AI review on code you cannot disclose while it points at
-a free model. Safer options:
-
-- Point `OPENROUTER_MODEL` at a paid / non-logging OpenRouter model.
-- Run a local model (the same script pattern works against any OpenAI-compatible endpoint;
-  change `ENDPOINT` in `scripts/ai_review.mjs`).
+The PR diff (and whatever the agent reads from the checkout) is sent to OpenAI under the
+ChatGPT account that ran `codex login`. Whether that data can be used for training
+follows the account's plan and data-control settings, so review those settings on the
+account behind `CODEX_AUTH_JSON` before enabling this on code you cannot disclose.
 
 The screenshots job sends nothing to a third party; it only renders your own client.
 
@@ -82,7 +91,7 @@ The screenshots job sends nothing to a third party; it only renders your own cli
 
 Pull requests from forks get a read-only `GITHUB_TOKEN` and cannot read repo secrets on
 the `pull_request` trigger. Both comment steps and the automatic AI review degrade to a
-no-op there (the scripts detect the missing write access / key and skip), so the workflow
+no-op there (the scripts detect the missing write access / auth and skip), so the workflow
 never errors on a fork PR. Screenshots are still captured and uploaded as an artifact.
 
 The on-demand `/review` and `/suggest` comment trigger is different: `issue_comment`

--- a/docs/ai-pr-bot.md
+++ b/docs/ai-pr-bot.md
@@ -46,6 +46,10 @@ opt-in:
   (the previous default, `openrouter/owl-alpha`, was pulled), so treat this as a
   prototype default and switch the variable when it goes away. Swapping the model is a
   one-line change with no workflow edit.
+- For a **local run** of `node scripts/ai_review.mjs`, both `OPENROUTER_API_KEY` and
+  `OPENROUTER_MODEL` can live in the repo-root `.env` (see `.env.example`); the script
+  loads it best-effort. Variables already set in the environment always take precedence,
+  so the CI values are never overridden.
 
 ## Requesting a review on demand
 

--- a/scripts/ai_review.mjs
+++ b/scripts/ai_review.mjs
@@ -1,7 +1,8 @@
-// Minimal AI pull-request reviewer. Sends the PR diff to an OpenRouter model (default:
-// the free nvidia/nemotron-3-ultra-550b-a55b:free model) and posts the review as a
-// sticky comment on the PR. No new npm deps: Node 18+ global fetch + the GitHub REST
-// API.
+// Minimal AI pull-request reviewer, driven by the OpenAI Codex CLI authenticated with a
+// ChatGPT account (OAuth), not an API key. Runs `codex exec` non-interactively over the
+// PR diff (read-only sandbox, no network for the agent) and posts the review as a sticky
+// comment on the PR. No new npm deps: the Codex CLI is installed by the workflow, and
+// the GitHub side is plain REST via global fetch.
 //
 // Two ways to trigger it (both wired in .github/workflows/pr-ai.yml):
 //   - automatically on every push to the PR: DIFF_FILE points at a precomputed diff.
@@ -11,18 +12,22 @@
 //     head) and posts a fresh reply comment keyed to the triggering comment, separate
 //     from the sticky automatic review.
 //
-// It is best-effort and NON-BLOCKING: if OPENROUTER_API_KEY is absent (for example a
-// fork PR that cannot read repo secrets) it prints a notice and exits 0, so it never
-// gates a merge. The model is swappable via OPENROUTER_MODEL with zero workflow edits,
-// which matters because free OpenRouter models can disappear or change at any time.
+// AUTH (ChatGPT OAuth): run `codex login` once locally, which stores OAuth tokens in
+// ~/.codex/auth.json. In CI, put that file's contents in the CODEX_AUTH_JSON repo
+// secret; this script materializes it into a private CODEX_HOME for the run. Locally,
+// an existing `codex login` session is used as-is. If neither is present (for example a
+// fork PR that cannot read repo secrets), it prints a notice and exits 0: it is
+// best-effort and NON-BLOCKING, it never gates a merge.
 //
-// PRIVACY: free OpenRouter models commonly log prompts to improve the model, so the
-// diff you send may be retained by a third party. Check the model's Data Policy on
-// openrouter.ai, or point OPENROUTER_MODEL at a non-logging / paid model (or a
-// self-hosted one), before using this on code you cannot disclose.
+// PRIVACY: the diff is sent to OpenAI under the ChatGPT account that logged in. Whether
+// it is used for training follows that account's plan and data settings (check the
+// workspace's data controls); the agent itself runs sandboxed read-only with network
+// disabled, so it cannot exfiltrate beyond the model request itself.
 //
 // Env (set by the workflow):
-//   OPENROUTER_API_KEY  OpenRouter key (repo secret); absent -> skip, exit 0
+//   CODEX_AUTH_JSON     contents of a `codex login` auth.json (repo secret); when
+//                       absent, falls back to the ambient CODEX_HOME/~/.codex login,
+//                       and if there is none, skips with exit 0
 //   GITHUB_TOKEN        token with pull-requests:write (default Actions token)
 //   GITHUB_REPOSITORY   owner/repo
 //   PR_NUMBER           the pull request number
@@ -31,15 +36,17 @@
 //   COMMENT_BODY        the triggering comment's body (comment run only)
 //   COMMENT_ID          the triggering comment's id; keys its reply comment
 //   COMMENT_AUTHOR      the triggering comment's author; credited in the reply
-//   OPENROUTER_MODEL    model id (default nvidia/nemotron-3-ultra-550b-a55b:free)
+//   CODEX_MODEL         model id override; when absent the Codex CLI default is used
+//   CODEX_BIN           path to the codex binary (default: `codex` on PATH)
 //   MAX_DIFF_CHARS      cap on diff chars sent to the model (default 60000)
 //
 // A local .env is loaded best-effort (same pattern as the other scripts/ utilities), so
-// a local run can keep OPENROUTER_API_KEY / OPENROUTER_MODEL there. Ambient environment
-// variables (the ones the workflow sets) always win: loadEnvFile never overwrites an
-// existing process.env entry.
+// a local run can keep CODEX_MODEL there. Ambient environment variables (the ones the
+// workflow sets) always win: loadEnvFile never overwrites an existing process.env entry.
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { upsertStickyComment } from './gh_sticky_comment.mjs';
 
 try {
@@ -48,20 +55,30 @@ try {
   /* no .env: rely on the ambient env */
 }
 
-const MODEL = process.env.OPENROUTER_MODEL || 'nvidia/nemotron-3-ultra-550b-a55b:free';
+const MODEL = process.env.CODEX_MODEL || '';
+const CODEX_BIN = process.env.CODEX_BIN || 'codex';
 const MAX_DIFF_CHARS = Number(process.env.MAX_DIFF_CHARS || 60000);
-const ENDPOINT = 'https://openrouter.ai/api/v1/chat/completions';
 const GITHUB_API = process.env.GITHUB_API_URL ?? 'https://api.github.com';
 
-const key = process.env.OPENROUTER_API_KEY;
 const prNumber = process.env.PR_NUMBER;
 const diffFile = process.env.DIFF_FILE;
 const commentBody = process.env.COMMENT_BODY;
 const commentId = process.env.COMMENT_ID;
 const commentAuthor = process.env.COMMENT_AUTHOR;
 
-if (!key) {
-  console.log('[ai_review] OPENROUTER_API_KEY not set; skipping AI review (non-blocking).');
+// Resolve auth: a CI secret becomes a throwaway CODEX_HOME (also keeps the run's
+// session logs out of the real home dir); otherwise reuse the ambient `codex login`.
+const ambientHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+let codexHome = ambientHome;
+if (process.env.CODEX_AUTH_JSON) {
+  codexHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-home-'));
+  fs.writeFileSync(path.join(codexHome, 'auth.json'), process.env.CODEX_AUTH_JSON, {
+    mode: 0o600,
+  });
+} else if (!fs.existsSync(path.join(ambientHome, 'auth.json'))) {
+  console.log(
+    '[ai_review] no CODEX_AUTH_JSON and no `codex login` session; skipping AI review (non-blocking).',
+  );
   process.exit(0);
 }
 
@@ -121,66 +138,21 @@ if (diff.length > MAX_DIFF_CHARS) {
   truncated = true;
 }
 
-// Give the model the file list of the directories this diff touches, so it stops
-// hallucinating that existing imports/helpers are "missing" (its top false positive).
-// Best-effort: empty string when not in a git checkout. On a comment-triggered run the
-// checkout is the base branch (no PR-head checkout, intentionally, see the module
-// comment), so a file the PR itself newly adds will not appear here; that is a known
-// false-positive risk specific to the /review and /suggest path.
-function listTouchedDirs(d) {
-  const files = [...d.matchAll(/^\+\+\+ b\/(.+)$/gm)]
-    .map((m) => m[1])
-    .filter((p) => p !== '/dev/null');
-  // Map each changed file to its parent dir; drop the repo root so a root-level file
-  // (e.g. .gitignore) does not expand `git ls-files` to the whole tree.
-  const dirs = [
-    ...new Set(
-      files
-        .map((f) => (f.includes('/') ? f.slice(0, f.lastIndexOf('/')) : '.'))
-        .filter((d) => d !== '.'),
-    ),
-  ];
-  if (!dirs.length) return '';
-  try {
-    const out = execFileSync('git', ['ls-files', '--', ...dirs], {
-      encoding: 'utf8',
-      maxBuffer: 8 * 1024 * 1024,
-    }).trim();
-    // Safety cap so a large touched directory cannot blow up the prompt.
-    const lines = out.split('\n');
-    return lines.length > 500
-      ? `${lines.slice(0, 500).join('\n')}\n... (${lines.length - 500} more)`
-      : out;
-  } catch {
-    return '';
-  }
-}
-const repoFiles = listTouchedDirs(diff);
-
-// Declared dependency names, so the model does not flag an imported package as "missing
-// from package.json" (a false positive it cannot otherwise verify from the diff).
-function declaredDeps() {
-  try {
-    const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-    return [...Object.keys(pkg.dependencies ?? {}), ...Object.keys(pkg.devDependencies ?? {})]
-      .sort()
-      .join(', ');
-  } catch {
-    return '';
-  }
-}
-const deps = declaredDeps();
-
-const system = `You are a precise, skeptical senior code reviewer for World of ClaudeCraft, a TypeScript
+// Unlike the old single-shot HTTP reviewer, Codex runs as an agent with READ-ONLY access
+// to the checkout, so instead of shipping it file lists to stop hallucinated "missing
+// import" findings, we tell it to verify against the working tree itself. One caveat is
+// preserved from the old design: on a comment-triggered run the checkout is the BASE
+// branch (no PR-head checkout, intentionally, see .github/workflows/pr-ai.yml), so a
+// file the PR itself adds exists only inside the diff text.
+const prompt = `You are a precise, skeptical senior code reviewer for World of ClaudeCraft, a TypeScript
 micro-MMO and reinforcement-learning environment built on one deterministic 20 Hz simulation core.
 
-You see ONLY a unified diff plus a list of files that ALREADY EXIST in the repository. Everything
-not shown in the diff already exists and works. Do NOT flag an imported module, helper, or
-referenced file as "missing" or "not in the diff": that is expected. If an import resolves to a path
-in the existing-files list, it is fine. You are also given the list of declared package.json
-dependencies; an import of any listed package is available, so NEVER say a dependency is missing
-from package.json. When you cannot verify something from what you were given, ask a one-line
-question at LOW severity instead of asserting a problem.
+Review the unified diff below. You have READ-ONLY access to a checkout of the repository; before
+flagging that an import, helper, or referenced file is missing or wrong, verify it against the
+working tree (and package.json for dependencies). Note: the checkout may be the PR's BASE branch,
+so a file the diff itself adds may exist only in the diff text; that is expected, never a finding.
+When you cannot verify something, ask a one-line question at LOW severity instead of asserting a
+problem. Do not modify anything; produce a review only.
 
 Invariant scope, apply LITERALLY and do not generalize beyond it: these rules constrain application
 code under src/ ONLY.
@@ -195,75 +167,70 @@ or emojis" rule applies everywhere.
 
 Severity rubric, use it strictly:
 - high: a real bug, security issue, or src/ invariant violation that WILL break behavior or fail CI
-  AND that you can confirm from the diff alone.
+  AND that you confirmed from the diff plus the working tree.
 - medium: likely incorrect or risky, but not certain.
 - low: style, naming, maintainability, or a question.
-If you CANNOT verify a finding from the diff and the provided context, it is AT MOST low and MUST be
-phrased as a one-line question, never high or medium. Do not guess at repository state you were not
-given (CI pins, other files' contents): if you did not see it, do not assert it.
+If you CANNOT verify a finding, it is AT MOST low and MUST be phrased as a one-line question, never
+high or medium.
 
-Output rules: prefer FEW high-confidence findings over many. If you are not confident a finding is
-real, OMIT it. Do not pad with generic advice. Only mention missing tests when the diff changes src/
-or server logic that the repo actually tests. Do NOT add your own title or top-level heading (no
-"# ..." or "## AI review"); start directly with the first group. Group findings under Correctness,
-Invariants, Tests, Nits and tag each with its severity. If the change looks fine, say so in one line.
-Do not restate the diff. Output GitHub-flavored Markdown.`;
+Output rules: your FINAL message is posted verbatim as the PR review comment, so it must contain
+ONLY the review in GitHub-flavored Markdown, no preamble or meta commentary. Prefer FEW
+high-confidence findings over many; if you are not confident a finding is real, OMIT it. Do not pad
+with generic advice. Only mention missing tests when the diff changes src/ or server logic that the
+repo actually tests. Do NOT add your own title or top-level heading (no "# ..." or "## AI review");
+start directly with the first group. Group findings under Correctness, Invariants, Tests, Nits and
+tag each with its severity. If the change looks fine, say so in one line. Do not restate the diff.
 
-const user = [
-  truncated ? `Note: the diff was truncated to the first ${MAX_DIFF_CHARS} characters.\n` : '',
+${truncated ? `Note: the diff was truncated to the first ${MAX_DIFF_CHARS} characters.\n\n` : ''}${
   command?.focus
-    ? `The reviewer specifically asked (via a PR comment) to focus on:\n\n${command.focus}\n\nStill mention any other high-confidence finding, but prioritize this.\n`
-    : '',
-  repoFiles
-    ? `Files that already exist in the directories this diff touches (so you can resolve imports and must NOT flag these as missing):\n\n\`\`\`\n${repoFiles}\n\`\`\`\n`
-    : '',
-  deps
-    ? `Declared package.json dependencies (names only); any import of these is available, do NOT flag it as missing:\n\n${deps}\n`
-    : '',
-  `Unified diff to review:\n\n\`\`\`diff\n${diff}\n\`\`\``,
-]
-  .filter(Boolean)
-  .join('\n');
+    ? `The reviewer specifically asked (via a PR comment) to focus on:\n\n${command.focus}\n\nStill mention any other high-confidence finding, but prioritize this.\n\n`
+    : ''
+}Unified diff to review:
 
-async function review() {
-  const res = await fetch(ENDPOINT, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${key}`,
-      'Content-Type': 'application/json',
-      'X-Title': 'WoCC PR review',
-    },
-    body: JSON.stringify({
-      model: MODEL,
-      temperature: 0.2,
-      messages: [
-        { role: 'system', content: system },
-        { role: 'user', content: user },
-      ],
-    }),
+\`\`\`diff
+${diff}
+\`\`\``;
+
+function review() {
+  const outFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'codex-review-')), 'last.md');
+  const args = [
+    'exec',
+    '--sandbox',
+    'read-only',
+    '--skip-git-repo-check',
+    '--output-last-message',
+    outFile,
+    ...(MODEL ? ['--model', MODEL] : []),
+    '-',
+  ];
+  // Progress goes to the workflow log (stderr/stdout inherited); the review itself is
+  // read back from --output-last-message so log noise can never leak into the comment.
+  execFileSync(CODEX_BIN, args, {
+    input: prompt,
+    stdio: ['pipe', 'inherit', 'inherit'],
+    env: { ...process.env, CODEX_HOME: codexHome },
+    timeout: 12 * 60 * 1000,
   });
-  if (!res.ok) {
-    throw new Error(`OpenRouter HTTP ${res.status}: ${(await res.text()).slice(0, 500)}`);
-  }
-  const data = await res.json();
-  const content = data?.choices?.[0]?.message?.content?.trim();
-  if (!content)
-    throw new Error(`OpenRouter returned no content: ${JSON.stringify(data).slice(0, 500)}`);
+  const content = fs.readFileSync(outFile, 'utf8').trim();
+  if (!content) throw new Error('Codex produced no final message');
   return content;
 }
 
+const modelLabel = MODEL ? `Codex, \`${MODEL}\`` : 'Codex';
 let reviewText;
 try {
-  reviewText = await review();
+  reviewText = review();
 } catch (e) {
-  // Non-blocking: a model/API failure leaves a short note rather than failing the job.
+  // Non-blocking: a CLI/auth/model failure leaves a short note rather than failing the
+  // job. Common cause: the CODEX_AUTH_JSON secret's OAuth session expired; re-run
+  // `codex login` locally and refresh the secret.
   console.log(`[ai_review] review failed (non-blocking): ${e.message}`);
-  reviewText = `_The automated review could not run this time (\`${MODEL}\`). See the workflow logs._`;
+  reviewText = `_The automated review could not run this time (${modelLabel}). See the workflow logs._`;
 }
 
 const heading = command
-  ? `## AI review (\`${MODEL}\`, requested by @${commentAuthor ?? 'a maintainer'} via \`/${command.command}\`)`
-  : `## AI review (\`${MODEL}\`)`;
+  ? `## AI review (${modelLabel}, requested by @${commentAuthor ?? 'a maintainer'} via \`/${command.command}\`)`
+  : `## AI review (${modelLabel})`;
 
 const body = [
   heading,
@@ -271,7 +238,7 @@ const body = [
   reviewText,
   truncated ? `\n<sub>Diff truncated to the first ${MAX_DIFF_CHARS} characters.</sub>` : '',
   '',
-  '<sub>Automated and non-blocking. May be wrong; a human review still decides. Free OpenRouter models commonly log prompts, so the diff may be retained by a third party.</sub>',
+  '<sub>Automated and non-blocking. May be wrong; a human review still decides. Generated by the OpenAI Codex CLI under the maintainer ChatGPT account; data handling follows that account plan and settings.</sub>',
 ].join('\n');
 
 // A comment-triggered run gets its own marker keyed to the triggering comment, so a

--- a/scripts/ai_review.mjs
+++ b/scripts/ai_review.mjs
@@ -33,9 +33,20 @@
 //   COMMENT_AUTHOR      the triggering comment's author; credited in the reply
 //   OPENROUTER_MODEL    model id (default nvidia/nemotron-3-ultra-550b-a55b:free)
 //   MAX_DIFF_CHARS      cap on diff chars sent to the model (default 60000)
+//
+// A local .env is loaded best-effort (same pattern as the other scripts/ utilities), so
+// a local run can keep OPENROUTER_API_KEY / OPENROUTER_MODEL there. Ambient environment
+// variables (the ones the workflow sets) always win: loadEnvFile never overwrites an
+// existing process.env entry.
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import { upsertStickyComment } from './gh_sticky_comment.mjs';
+
+try {
+  process.loadEnvFile();
+} catch {
+  /* no .env: rely on the ambient env */
+}
 
 const MODEL = process.env.OPENROUTER_MODEL || 'nvidia/nemotron-3-ultra-550b-a55b:free';
 const MAX_DIFF_CHARS = Number(process.env.MAX_DIFF_CHARS || 60000);

--- a/scripts/ai_review.mjs
+++ b/scripts/ai_review.mjs
@@ -149,10 +149,12 @@ micro-MMO and reinforcement-learning environment built on one deterministic 20 H
 
 Review the unified diff below. You have READ-ONLY access to a checkout of the repository; before
 flagging that an import, helper, or referenced file is missing or wrong, verify it against the
-working tree (and package.json for dependencies). Note: the checkout may be the PR's BASE branch,
-so a file the diff itself adds may exist only in the diff text; that is expected, never a finding.
-When you cannot verify something, ask a one-line question at LOW severity instead of asserting a
-problem. Do not modify anything; produce a review only.
+working tree (and package.json for dependencies). Use lightweight inspection only: file reads,
+focused searches, and short static checks. Do not install packages, run network commands, run full
+builds, run full test suites, or run long typecheck commands. Note: the checkout may be the PR's
+BASE branch, so a file the diff itself adds may exist only in the diff text; that is expected,
+never a finding. When you cannot verify something, ask a one-line question at LOW severity instead
+of asserting a problem. Do not modify anything; produce a review only.
 
 Invariant scope, apply LITERALLY and do not generalize beyond it: these rules constrain application
 code under src/ ONLY.
@@ -198,6 +200,8 @@ function review() {
     '--sandbox',
     'read-only',
     '--skip-git-repo-check',
+    '--ignore-user-config',
+    '--ignore-rules',
     '--output-last-message',
     outFile,
     ...(MODEL ? ['--model', MODEL] : []),


### PR DESCRIPTION
## What

Replaces the OpenRouter-based AI PR reviewer with the OpenAI Codex CLI authenticated via ChatGPT OAuth (no API key), and makes the model override configurable per environment.

- `scripts/ai_review.mjs` now runs `codex exec` non-interactively: read-only sandbox, prompt on stdin, review read back via `--output-last-message` so log noise can never leak into the PR comment.
- Auth: in CI, the new `CODEX_AUTH_JSON` secret carries the contents of a `codex login` auth.json and is materialized into a throwaway `CODEX_HOME` per run; locally an existing `codex login` session is reused directly.
- Model: `CODEX_MODEL` repo variable in CI, or the repo-root `.env` for a local run (ambient env always wins); unset means the Codex CLI's own default model, so no model id is pinned that could go stale.
- Since Codex is an agent with read access to the checkout, the file-list and package.json crutches against hallucinated "missing import" findings are dropped in favor of instructing it to verify against the working tree.
- Workflow installs `@openai/codex` on the runner and both AI jobs get `timeout-minutes: 20`.
- `docs/ai-pr-bot.md` and `.env.example` rewritten for the new setup, including the data-handling note (diff goes to OpenAI under the logged-in account's plan and data controls) and how to refresh an expired OAuth session.

## What is preserved

- Non-blocking skip without auth: fork PRs stay green with a log notice, never a red check.
- The `/review` and `/suggest <focus>` comment path, its OWNER/MEMBER/COLLABORATOR gate, and the no-PR-head-checkout design.
- Sticky comment markers (the automatic review updates in place; each comment-triggered reply is keyed to its comment).
- The 60k-char diff cap.

## Setup after merge (maintainer, one time)

1. `codex login` with the ChatGPT account that should pay for reviews, then store `~/.codex/auth.json` in the `CODEX_AUTH_JSON` repo secret.
2. Optional: set a `CODEX_MODEL` repo variable. Remove the old `OPENROUTER_API_KEY` secret and `OPENROUTER_MODEL` variable.

Note: reviews consume the ChatGPT plan's Codex quota; on rate limit the job posts the non-blocking fallback note.

## Verification

- No-auth path exits 0 with the skip notice.
- Full wiring exercised with a stub codex binary (`CODEX_BIN`): correct args, throwaway `CODEX_HOME` with the auth.json, prompt piped on stdin, final message read back, sticky-comment helper degrades gracefully without a token.
- Workflow YAML parses; Biome clean on the changed script; no `openrouter` reference left in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)