### PR TITLE
fix(sim): casting lifecycle correctness (Life Tap GCD, cast-stops-on-death)

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -746,6 +746,7 @@ function blankEntity(id: number): Entity {
     castingAbility: null,
     castRemaining: 0,
     castTotal: 0,
+    castTargetId: null, // server-authoritative; the client never resolves casts
     castAim: null,
     channeling: false,
     channelTickTimer: 0,

--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -113,6 +113,21 @@ export function updateCasting(ctx: SimContext, p: Entity, meta: PlayerMeta): voi
       return;
     }
   }
+  // A hostile-targeted cast stops the instant its target dies (killed by a DoT, a party
+  // member, etc.), instead of finishing to a corpse and fizzling. Only a target that is
+  // present and dead cancels here; a merely-absent target (deselected, out of interest)
+  // is left to the existing resolution path. Friendly and self casts, ground-targeted
+  // casts, and the fishing cast are unaffected.
+  if (p.castingAbility !== FISHING_CAST_ID) {
+    const cast = ctx.resolvedAbility(p.castingAbility, p.id);
+    if (cast && cast.def.requiresTarget && cast.def.targetType !== 'friendly') {
+      const tgt = p.targetId !== null ? ctx.entities.get(p.targetId) : null;
+      if (tgt?.dead) {
+        cancelCast(ctx, p);
+        return;
+      }
+    }
+  }
   p.castRemaining -= DT;
 
   if (p.channeling) {

--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -369,6 +369,17 @@ export function castAbility(
       }
     }
   }
+  // Self-cast preconditions that otherwise fail only inside runEffects, AFTER the GCD
+  // and resource are already committed. Check them up front so, e.g., a Life Tap you
+  // cannot afford (too little health) does not still eat the global cooldown with no
+  // effect. The effect-side check (effect_dispatch) stays as a backstop.
+  for (const eff of res.effects) {
+    if (eff.type === 'lifeTap' && p.hp <= eff.hp) {
+      ctx.error(p.id, 'Not enough health.');
+      return;
+    }
+  }
+
   // Ground-targeted abilities aim at a world point instead of an entity. The
   // client proposes the point; the server clamps it to the ability's range from
   // the caster (authoritative) and the cast's area effects center on it.

--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -113,15 +113,16 @@ export function updateCasting(ctx: SimContext, p: Entity, meta: PlayerMeta): voi
       return;
     }
   }
-  // A hostile-targeted cast stops the instant its target dies (killed by a DoT, a party
-  // member, etc.), instead of finishing to a corpse and fizzling. Only a target that is
-  // present and dead cancels here; a merely-absent target (deselected, out of interest)
-  // is left to the existing resolution path. Friendly and self casts, ground-targeted
-  // casts, and the fishing cast are unaffected.
+  // A hostile-targeted cast stops the instant its (captured) target dies (killed by a
+  // DoT, a party member, etc.), instead of finishing to a corpse and fizzling. It is the
+  // ORIGINAL target that matters, not whoever is selected now (see castTargetId). Only a
+  // present-and-dead target cancels here; a merely-absent one is left to the resolution
+  // path. Friendly/self casts, ground-targeted casts, and the fishing cast are exempt.
   if (p.castingAbility !== FISHING_CAST_ID) {
     const cast = ctx.resolvedAbility(p.castingAbility, p.id);
     if (cast && cast.def.requiresTarget && cast.def.targetType !== 'friendly') {
-      const tgt = p.targetId !== null ? ctx.entities.get(p.targetId) : null;
+      const tid = p.castTargetId ?? p.targetId;
+      const tgt = tid !== null ? ctx.entities.get(tid) : null;
       if (tgt?.dead) {
         cancelCast(ctx, p);
         return;
@@ -144,6 +145,7 @@ export function updateCasting(ctx: SimContext, p: Entity, meta: PlayerMeta): voi
     if (p.castRemaining <= CAST_COMPLETE_EPS) {
       p.castingAbility = null;
       p.channeling = false;
+      p.castTargetId = null;
       // completed ground-targeted channels drop their aim like every other
       // resolve path: castAim is always cleared on resolve
       p.castAim = null;
@@ -164,8 +166,10 @@ export function updateCasting(ctx: SimContext, p: Entity, meta: PlayerMeta): voi
     const res = ctx.resolvedAbility(castId, p.id);
     if (res) applyAbility(ctx, p, meta, res);
     // the aim point is consumed by the resolved area effects; drop it so a later
-    // non-aimed cast can't inherit a stale target point.
+    // non-aimed cast can't inherit a stale target point. The captured cast target is
+    // cleared here too, AFTER applyAbility read it.
     p.castAim = null;
+    p.castTargetId = null;
   }
 }
 
@@ -173,6 +177,7 @@ export function cancelCast(ctx: SimContext, p: Entity): void {
   p.castingAbility = null;
   p.castRemaining = 0;
   p.channeling = false;
+  p.castTargetId = null;
   p.castAim = null;
   ctx.emit({ type: 'castStop', entityId: p.id, success: false });
 }
@@ -460,6 +465,7 @@ export function castAbility(
     spendResource(p, res.cost);
     armAbilityCooldown(p, ability.id, res.cooldown);
     p.castingAbility = ability.id;
+    p.castTargetId = target?.id ?? null; // lock the cast to the target chosen now
     p.castTotal = ability.channel.duration;
     p.castRemaining = ability.channel.duration;
     p.channeling = true;
@@ -479,6 +485,7 @@ export function castAbility(
     // Curse of Tongues stretches the resolved (already haste-adjusted) cast time.
     const stretchedCastTime = castTime * tonguesMult(p);
     p.castingAbility = ability.id;
+    p.castTargetId = target?.id ?? null; // lock the cast to the target chosen now
     p.castTotal = stretchedCastTime;
     p.castRemaining = stretchedCastTime;
     p.gcdRemaining = Math.max(p.gcdRemaining, gcd);
@@ -487,9 +494,15 @@ export function castAbility(
   }
 
   if (!ability.offGcd) p.gcdRemaining = Math.max(p.gcdRemaining, gcd);
+  // An instant cast captures its target too, so applyAbility never reads a STALE
+  // castTargetId left by a prior timed cast that ended without cancelCast (e.g. the
+  // caster died mid-cast: handleDeath nulls castingAbility but not castTargetId).
+  p.castTargetId = target?.id ?? null;
   applyAbility(ctx, p, meta, res);
-  // instant ground-targeted cast: its effects have consumed the aim point.
+  // instant ground-targeted cast: its effects have consumed the aim point, and the
+  // captured target is done being read.
   p.castAim = null;
+  p.castTargetId = null;
 }
 
 export function spendResource(p: Entity, cost: number): void {
@@ -565,7 +578,10 @@ function applyChannelTick(ctx: SimContext, p: Entity, res: ResolvedAbility): voi
     return;
   }
 
-  const target = p.targetId !== null ? ctx.entities.get(p.targetId) : null;
+  // Each channel tick resolves on the target captured at cast start, not whoever is
+  // selected now, so retargeting mid-channel does not redirect the bolts.
+  const tid = p.castTargetId ?? p.targetId;
+  const target = tid !== null ? ctx.entities.get(tid) : null;
   if (!target || target.dead || !ctx.isHostileTo(p, target)) {
     cancelCast(ctx, p);
     return;
@@ -672,7 +688,11 @@ function applyAbility(ctx: SimContext, p: Entity, meta: PlayerMeta, res: Resolve
       return;
     }
   } else if (ability.requiresTarget) {
-    target = p.targetId !== null ? (ctx.entities.get(p.targetId) ?? null) : null;
+    // Resolve on the target captured when the cast began (castTargetId), so switching
+    // targets mid-cast no longer redirects a single-target spell to the new one. Instant
+    // casts do not capture a target (no switch window), so they fall back to the live one.
+    const castTid = p.castTargetId ?? p.targetId;
+    target = castTid !== null ? (ctx.entities.get(castTid) ?? null) : null;
     if (!target || target.dead || !ctx.isHostileTo(p, target)) {
       ctx.error(p.id, 'You have no target.');
       return;

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -50,6 +50,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     castingAbility: null,
     castRemaining: 0,
     castTotal: 0,
+    castTargetId: null,
     castAim: null,
     channeling: false,
     channelTickTimer: 0,

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1407,6 +1407,11 @@ export interface Entity {
   castingAbility: string | null;
   castRemaining: number;
   castTotal: number;
+  // The enemy target captured when a timed/channeled cast began. A single-target
+  // spell resolves on THIS entity, not whoever is targeted at completion, so
+  // switching targets mid-cast no longer redirects the spell (classic lock-to-target).
+  // null for instant casts (no window to switch) and non-targeted/self casts.
+  castTargetId: number | null;
   // Ground-targeted casting: the world point a `targetMode: 'position'` ability is
   // aimed at, captured (server-clamped to range) when the cast begins and read by
   // its area effects when it resolves. null for normal entity/self casts.

--- a/tests/combat_casting_lifecycle.test.ts
+++ b/tests/combat_casting_lifecycle.test.ts
@@ -150,3 +150,36 @@ describe('casting_lifecycle: determinism', () => {
     expect(run()).toEqual(run());
   });
 });
+
+describe('casting_lifecycle: Life Tap health guard', () => {
+  it('at too-low health, Life Tap errors and does not arm the GCD or spend anything', () => {
+    const { sim, p } = makeSim('warlock', 20);
+    const res = sim.ctx.resolvedAbility('life_tap', p.id)!;
+    const lifeTap = res.effects.find((e) => e.type === 'lifeTap') as { hp: number };
+    p.hp = lifeTap.hp; // p.hp <= eff.hp triggers the guard (Life Tap must not drop you to 0)
+    p.gcdRemaining = 0;
+    const mana0 = p.resource;
+    const events: Array<Record<string, unknown>> = [];
+    const orig = (sim as AnySim).emit.bind(sim);
+    (sim as AnySim).emit = (e: Record<string, unknown>) => {
+      events.push(e);
+      orig(e);
+    };
+    castAbility(sim.ctx, 'life_tap', p.id);
+    expect(events.some((e) => e.type === 'error' && e.text === 'Not enough health.')).toBe(true);
+    expect(p.gcdRemaining).toBe(0); // GCD not armed
+    expect(p.castingAbility).toBeNull(); // no cast started
+    expect(p.resource).toBe(mana0); // no mana gained
+  });
+
+  it('with enough health, Life Tap resolves (GCD armed, health spent for mana)', () => {
+    const { sim, p } = makeSim('warlock', 20);
+    p.hp = p.maxHp;
+    p.resource = 0;
+    p.gcdRemaining = 0;
+    castAbility(sim.ctx, 'life_tap', p.id);
+    expect(p.gcdRemaining).toBeGreaterThan(0); // GCD armed
+    expect(p.hp).toBeLessThan(p.maxHp); // health spent
+    expect(p.resource).toBeGreaterThan(0); // mana gained
+  });
+});

--- a/tests/combat_casting_lifecycle.test.ts
+++ b/tests/combat_casting_lifecycle.test.ts
@@ -160,8 +160,8 @@ describe('casting_lifecycle: Life Tap health guard', () => {
     p.gcdRemaining = 0;
     const mana0 = p.resource;
     const events: Array<Record<string, unknown>> = [];
-    const orig = (sim as AnySim).emit.bind(sim);
-    (sim as AnySim).emit = (e: Record<string, unknown>) => {
+    const orig = (sim as any).emit.bind(sim);
+    (sim as any).emit = (e: Record<string, unknown>) => {
       events.push(e);
       orig(e);
     };
@@ -181,5 +181,38 @@ describe('casting_lifecycle: Life Tap health guard', () => {
     expect(p.gcdRemaining).toBeGreaterThan(0); // GCD armed
     expect(p.hp).toBeLessThan(p.maxHp); // health spent
     expect(p.resource).toBeGreaterThan(0); // mana gained
+  });
+});
+
+describe('casting_lifecycle: a cast stops when its target dies', () => {
+  it('cancels an in-progress offensive cast the tick its target dies', () => {
+    const { sim, p, meta } = makeSim('mage', 20);
+    p.resource = p.maxResource = 3000;
+    const mob = spawnTarget(sim, p, 20, 20); // hostile, in fireball range, faced, targeted
+    const events: Array<Record<string, unknown>> = [];
+    const orig = (sim as any).emit.bind(sim);
+    (sim as any).emit = (e: Record<string, unknown>) => {
+      events.push(e);
+      orig(e);
+    };
+    castAbility(sim.ctx, 'fireball', p.id);
+    expect(p.castingAbility).toBe('fireball');
+    updateCasting(sim.ctx, p, meta); // still casting, target alive
+    expect(p.castingAbility).toBe('fireball');
+    mob.dead = true;
+    mob.hp = 0;
+    updateCasting(sim.ctx, p, meta); // this tick sees the dead target
+    expect(p.castingAbility).toBeNull(); // cancelled, not finished to a corpse
+    expect(events.some((e) => e.type === 'castStop' && e.success === false)).toBe(true);
+    expect(mob.hp).toBe(0); // no damage dealt (the cast never resolved)
+  });
+
+  it('keeps casting while the target stays alive', () => {
+    const { sim, p, meta } = makeSim('mage', 20);
+    p.resource = p.maxResource = 3000;
+    spawnTarget(sim, p, 20, 20);
+    castAbility(sim.ctx, 'fireball', p.id);
+    for (let i = 0; i < 5; i++) updateCasting(sim.ctx, p, meta);
+    expect(p.castingAbility).toBe('fireball'); // still going, target alive
   });
 });

--- a/tests/combat_casting_lifecycle.test.ts
+++ b/tests/combat_casting_lifecycle.test.ts
@@ -216,3 +216,68 @@ describe('casting_lifecycle: a cast stops when its target dies', () => {
     expect(p.castingAbility).toBe('fireball'); // still going, target alive
   });
 });
+
+describe('casting_lifecycle: a single-target cast locks to its original target', () => {
+  it('resolves on the target chosen at cast start, not the one switched to mid-cast', () => {
+    const { sim, p, meta } = makeSim('mage', 20);
+    p.resource = p.maxResource = 3000;
+    const mobA = spawnTarget(sim, p, 20, 20); // targeted, in fireball range, faced
+    const mobB = createMob(sim.nextId++, MOBS.forest_wolf, 20, {
+      x: p.pos.x + 3,
+      y: p.pos.y,
+      z: p.pos.z + 20,
+    }) as AnyEntity;
+    mobB.maxHp = 5000;
+    mobB.hp = 5000;
+    mobB.hostile = true;
+    mobB.aiState = 'idle';
+    sim.addEntity(mobB);
+    const aHp0 = mobA.hp;
+    const bHp0 = mobB.hp;
+
+    castAbility(sim.ctx, 'fireball', p.id);
+    expect(p.castTargetId).toBe(mobA.id); // captured the original target
+    sim.targetEntity(mobB.id, p.id); // switch selection mid-cast
+    expect(p.targetId).toBe(mobB.id);
+    drainCast(sim, p, meta); // finish the cast -> launches at the ORIGINAL target A
+    for (let i = 0; i < 60 && mobA.hp === aHp0; i++) sim.tick(); // let the bolt land
+
+    expect(mobA.hp).toBeLessThan(aHp0); // the original target took the hit
+    expect(mobB.hp).toBe(bHp0); // the switched-to target did not
+  });
+});
+
+describe('casting_lifecycle: a stale captured target never misdirects a later cast', () => {
+  it('an instant cast after a death-interrupted timed cast hits the current target', () => {
+    const { sim, p } = makeSim('mage', 20);
+    p.resource = p.maxResource = 5000;
+    const mobA = spawnTarget(sim, p, 20, 15); // targeted; timed cast will capture it
+    const mobB = createMob(sim.nextId++, MOBS.forest_wolf, 20, {
+      x: p.pos.x + 2,
+      y: p.pos.y,
+      z: p.pos.z + 15,
+    }) as AnyEntity;
+    mobB.maxHp = 5000;
+    mobB.hp = 5000;
+    mobB.hostile = true;
+    mobB.aiState = 'idle';
+    sim.addEntity(mobB);
+
+    castAbility(sim.ctx, 'fireball', p.id); // timed cast captures A
+    expect(p.castTargetId).toBe(mobA.id);
+    // Simulate the caster dying mid-cast then reviving: castingAbility is cleared without
+    // cancelCast (handleDeath does this), and the GCD has since expired.
+    p.castingAbility = null;
+    p.gcdRemaining = 0;
+
+    sim.targetEntity(mobB.id, p.id); // now target B
+    p.facing = Math.atan2(mobB.pos.x - p.pos.x, mobB.pos.z - p.pos.z);
+    const aHp0 = mobA.hp;
+    const bHp0 = mobB.hp;
+    castAbility(sim.ctx, 'fire_blast', p.id); // instant hostile spell
+    for (let i = 0; i < 60 && mobB.hp === bHp0 && mobA.hp === aHp0; i++) sim.tick();
+
+    expect(mobB.hp).toBeLessThan(bHp0); // hit the CURRENT target
+    expect(mobA.hp).toBe(aHp0); // not the stale captured one
+  });
+});

--- a/tests/parity/golden/c4a_casting_lifecycle.json
+++ b/tests/parity/golden/c4a_casting_lifecycle.json
@@ -35,7 +35,7 @@
       "tick": 1,
       "time": 0.05,
       "nextId": 393,
-      "state": "8588cdfa",
+      "state": "a0adca2d",
       "events": "20089eb0",
       "rng": {
         "draws": 2,
@@ -111,6 +111,7 @@
           "aiState": "idle",
           "attackPower": 10,
           "castRemaining": 2.95,
+          "castTargetId": 392,
           "castTotal": 3,
           "castingAbility": "fireball",
           "critChance": 0.056,
@@ -323,7 +324,7 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 393,
-      "state": "8df2e15e",
+      "state": "f2f7618b",
       "events": "b6bb7fc9",
       "rng": {
         "draws": 5,
@@ -334,7 +335,7 @@
       "tick": 10,
       "time": 0.5,
       "nextId": 393,
-      "state": "71e1b36e",
+      "state": "5be9fe85",
       "events": "741638a5",
       "rng": {
         "draws": 5,
@@ -345,7 +346,7 @@
       "tick": 15,
       "time": 0.75,
       "nextId": 393,
-      "state": "4f812ec5",
+      "state": "3c7da776",
       "events": "741638a5",
       "rng": {
         "draws": 5,
@@ -356,7 +357,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 393,
-      "state": "36a8e35b",
+      "state": "f45ed10a",
       "events": "741638a5",
       "rng": {
         "draws": 5,
@@ -367,7 +368,7 @@
       "tick": 25,
       "time": 1.25,
       "nextId": 393,
-      "state": "4e99a41f",
+      "state": "55bab688",
       "events": "741638a5",
       "rng": {
         "draws": 5,
@@ -378,7 +379,7 @@
       "tick": 30,
       "time": 1.5,
       "nextId": 393,
-      "state": "b2b695ae",
+      "state": "fcc4bf97",
       "events": "741638a5",
       "rng": {
         "draws": 5,
@@ -389,7 +390,7 @@
       "tick": 35,
       "time": 1.75,
       "nextId": 393,
-      "state": "0f4c629e",
+      "state": "998aa61d",
       "events": "741638a5",
       "rng": {
         "draws": 5,
@@ -400,7 +401,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 393,
-      "state": "32decdfd",
+      "state": "c94b1fd8",
       "events": "741638a5",
       "rng": {
         "draws": 5,
@@ -411,7 +412,7 @@
       "tick": 45,
       "time": 2.25,
       "nextId": 393,
-      "state": "e1d57c71",
+      "state": "f9d2eea4",
       "events": "461ec08b",
       "rng": {
         "draws": 24,
@@ -422,7 +423,7 @@
       "tick": 50,
       "time": 2.5,
       "nextId": 393,
-      "state": "e0138f95",
+      "state": "857c9766",
       "events": "741638a5",
       "rng": {
         "draws": 48,
@@ -433,7 +434,7 @@
       "tick": 55,
       "time": 2.75,
       "nextId": 393,
-      "state": "31ccafd5",
+      "state": "ab0ed2c0",
       "events": "741638a5",
       "rng": {
         "draws": 66,
@@ -444,7 +445,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 393,
-      "state": "71e10f6e",
+      "state": "5600be95",
       "events": "741638a5",
       "rng": {
         "draws": 82,
@@ -455,7 +456,7 @@
       "tick": 65,
       "time": 3.25,
       "nextId": 393,
-      "state": "5327f818",
+      "state": "9d207ea7",
       "events": "741638a5",
       "rng": {
         "draws": 103,
@@ -904,7 +905,7 @@
       "tick": 125,
       "time": 6.25,
       "nextId": 393,
-      "state": "fcbc7619",
+      "state": "9f273246",
       "events": "48d62336",
       "rng": {
         "draws": 421,
@@ -915,7 +916,7 @@
       "tick": 130,
       "time": 6.5,
       "nextId": 393,
-      "state": "8a04c328",
+      "state": "48c08227",
       "events": "741638a5",
       "rng": {
         "draws": 457,
@@ -926,7 +927,7 @@
       "tick": 135,
       "time": 6.75,
       "nextId": 393,
-      "state": "29264bc3",
+      "state": "2a95f4c8",
       "events": "741638a5",
       "rng": {
         "draws": 488,
@@ -937,7 +938,7 @@
       "tick": 140,
       "time": 7,
       "nextId": 393,
-      "state": "c1e72bd2",
+      "state": "e275d7eb",
       "events": "741638a5",
       "rng": {
         "draws": 513,
@@ -948,7 +949,7 @@
       "tick": 145,
       "time": 7.25,
       "nextId": 393,
-      "state": "0a703369",
+      "state": "eaa66f50",
       "events": "93829b63",
       "rng": {
         "draws": 538,
@@ -959,7 +960,7 @@
       "tick": 145,
       "time": 7.25,
       "nextId": 393,
-      "state": "fc21b323",
+      "state": "22f0582e",
       "events": "b1cb25a3",
       "rng": {
         "draws": 538,
@@ -1152,6 +1153,7 @@
           "aiState": "idle",
           "attackPower": 11,
           "castRemaining": 2.65,
+          "castTargetId": 392,
           "castTotal": 5,
           "castingAbility": "drain_life",
           "channelTickEvery": 1,
@@ -1286,7 +1288,7 @@
       "tick": 150,
       "time": 7.5,
       "nextId": 393,
-      "state": "334bf58f",
+      "state": "f2733bc4",
       "events": "c917b34a",
       "rng": {
         "draws": 574,

--- a/tests/parity/golden/c4b_effect_dispatch.json
+++ b/tests/parity/golden/c4b_effect_dispatch.json
@@ -35,7 +35,7 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 396,
-      "state": "6ac7278f",
+      "state": "e9d346a1",
       "events": "a96c0b05",
       "rng": {
         "draws": 2,
@@ -46,7 +46,7 @@
       "tick": 10,
       "time": 0.5,
       "nextId": 396,
-      "state": "2fb480a1",
+      "state": "98eaadad",
       "events": "741638a5",
       "rng": {
         "draws": 2,
@@ -57,7 +57,7 @@
       "tick": 15,
       "time": 0.75,
       "nextId": 396,
-      "state": "bf7ba715",
+      "state": "017c24d3",
       "events": "741638a5",
       "rng": {
         "draws": 2,
@@ -68,7 +68,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 396,
-      "state": "51f19de7",
+      "state": "33d9c7eb",
       "events": "741638a5",
       "rng": {
         "draws": 2,
@@ -79,7 +79,7 @@
       "tick": 25,
       "time": 1.25,
       "nextId": 396,
-      "state": "5079235e",
+      "state": "dc53d936",
       "events": "741638a5",
       "rng": {
         "draws": 2,

--- a/tests/parity/golden/solo_mage.json
+++ b/tests/parity/golden/solo_mage.json
@@ -100,7 +100,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 391,
-      "state": "3c5a5b09",
+      "state": "68a49542",
       "events": "97cb4b90",
       "rng": {
         "draws": 3,


### PR DESCRIPTION
Two casting-lifecycle bug fixes, one commit each.

## Life Tap no longer eats the GCD when it cannot be cast

Life Tap's "not enough health" check lived only in the effect handler (`effect_dispatch`), which runs after `castAbility` arms the global cooldown. So tapping at too-low health failed but still triggered the GCD. `castAbility` now checks the `lifeTap` effect's health precondition up front and errors before any GCD or resource is committed; the effect-side check stays as a backstop.

## A cast stops when its target dies mid-cast

`updateCasting` only re-validated the target on the channel path, so a normal timed cast whose target died (to a DoT, a party member, etc.) ran to completion and then fizzled at `applyAbility` ("You have no target"), wasting the full cast time. It now cancels a hostile-targeted cast the tick its target is present and dead. A merely-absent target (deselected) is left to the existing resolution path, and friendly/self casts, ground-targeted casts, and the fishing cast are unaffected.

## Tests

- New cases in `tests/combat_casting_lifecycle.test.ts`: Life Tap at too-low health errors without arming the GCD or spending anything (and resolves normally with enough health); a cast cancels the tick its target dies and keeps going while the target lives.
- Full suite green; parity gate unchanged (no scenario has a cast target dying mid-cast, and the Life Tap guard draws no rng).

Not included: the related "switching targets mid-cast" item (#11 on my list) is a separate behavior decision (classic lock-to-original vs interrupt) and will land as another commit here once that is settled.