### PR TITLE
feat(input): brand-aware gamepad button glyphs

### DIFF
--- a/src/game/gamepad.ts
+++ b/src/game/gamepad.ts
@@ -8,7 +8,9 @@
 import type { GamepadBindings } from './gamepad_bindings';
 import {
   AXIS,
+  detectGamepadKind,
   GAMEPAD_NONE,
+  type GamepadKind,
   GP,
   risingEdges,
   STANDARD_BUTTON_COUNT,
@@ -30,12 +32,16 @@ export interface GamepadCallbacks {
   isPointerMode(): boolean;
   // Current local-player health, for rumble-on-damage. Optional.
   getPlayerHealth?(): number;
+  // A pad connected or disconnected, so the detected brand (and thus the button
+  // glyphs shown in the Controller options panel) may have changed. Optional.
+  onConnectionChange?(): void;
 }
 
 const CURSOR_SPEED = 900; // px/sec at full stick deflection in UI cursor mode
 
 export class GamepadManager {
   private index: number | null = null;
+  private kind: GamepadKind = 'generic';
   private prevPressed: boolean[] = new Array(STANDARD_BUTTON_COUNT).fill(false);
   private deadzone = 0.18;
   private camSpeed = 2.4;
@@ -59,10 +65,13 @@ export class GamepadManager {
     if (typeof navigator === 'undefined' || typeof navigator.getGamepads !== 'function') return;
     window.addEventListener('gamepadconnected', this.boundConnect);
     window.addEventListener('gamepaddisconnected', this.boundDisconnect);
-    // Pick up a pad that was already connected before we started listening.
+    // Pick up a pad that was already connected before we started listening (e.g.
+    // the Controller setting toggled on while a pad is plugged in). Notify so an
+    // open Controller panel re-labels to the detected brand; a no-op otherwise.
     for (const pad of navigator.getGamepads()) {
       if (pad?.connected) {
-        this.index = pad.index;
+        this.acquire(pad);
+        this.cb.onConnectionChange?.();
         break;
       }
     }
@@ -77,6 +86,7 @@ export class GamepadManager {
     // camera, and edge buttons after the Controller setting is turned off. start()
     // re-acquires an already-connected pad on re-enable.
     this.index = null;
+    this.kind = 'generic';
     this.prevPressed.fill(false);
     this.input.clearGamepadMove();
     this.hideCursor();
@@ -99,16 +109,33 @@ export class GamepadManager {
     return this.index !== null;
   }
 
+  /** Detected brand of the connected pad, for glyph labeling; 'generic' when
+   *  none is connected or the pad's id is unrecognized. */
+  getKind(): GamepadKind {
+    return this.index === null ? 'generic' : this.kind;
+  }
+
+  // Latch a pad as the active one and classify its brand from the id string.
+  private acquire(pad: Gamepad): void {
+    this.index = pad.index;
+    this.kind = detectGamepadKind(pad.id);
+  }
+
   private onConnect(e: GamepadEvent): void {
-    if (this.index === null) this.index = e.gamepad.index;
+    if (this.index === null) {
+      this.acquire(e.gamepad);
+      this.cb.onConnectionChange?.();
+    }
   }
 
   private onDisconnect(e: GamepadEvent): void {
     if (this.index === e.gamepad.index) {
       this.index = null;
+      this.kind = 'generic';
       this.prevPressed.fill(false);
       this.input.clearGamepadMove();
       this.hideCursor();
+      this.cb.onConnectionChange?.();
     }
   }
 

--- a/src/game/gamepad_map.ts
+++ b/src/game/gamepad_map.ts
@@ -23,10 +23,22 @@ export interface LookDelta {
 // pads that report mapping === 'standard'.
 export const STANDARD_BUTTON_COUNT = 17;
 export const GP = {
-  A: 0, B: 1, X: 2, Y: 3,
-  LB: 4, RB: 5, LT: 6, RT: 7,
-  BACK: 8, START: 9, L3: 10, R3: 11,
-  DPAD_UP: 12, DPAD_DOWN: 13, DPAD_LEFT: 14, DPAD_RIGHT: 15,
+  A: 0,
+  B: 1,
+  X: 2,
+  Y: 3,
+  LB: 4,
+  RB: 5,
+  LT: 6,
+  RT: 7,
+  BACK: 8,
+  START: 9,
+  L3: 10,
+  R3: 11,
+  DPAD_UP: 12,
+  DPAD_DOWN: 13,
+  DPAD_LEFT: 14,
+  DPAD_RIGHT: 15,
   GUIDE: 16,
 } as const;
 export const AXIS = { LEFT_X: 0, LEFT_Y: 1, RIGHT_X: 2, RIGHT_Y: 3 } as const;
@@ -34,11 +46,23 @@ export const AXIS = { LEFT_X: 0, LEFT_Y: 1, RIGHT_X: 2, RIGHT_Y: 3 } as const;
 // Analog triggers report a 0..1 value; treat them as pressed past this point.
 export const TRIGGER_THRESHOLD = 0.5;
 
+// D-pad arrows are identical across every brand; defined once here and spread into
+// the generic combined set below and each per-brand set, so the four glyphs have a
+// single source of truth and cannot drift between the label tables.
+const DPAD_LABELS: Record<number, string> = {
+  [GP.DPAD_UP]: 'D-pad ↑',
+  [GP.DPAD_DOWN]: 'D-pad ↓',
+  [GP.DPAD_LEFT]: 'D-pad ←',
+  [GP.DPAD_RIGHT]: 'D-pad →',
+};
+
 // Hardware glyphs for the bindable buttons, shown in the Controller options panel.
 // These are physical button names (silk-screened on the pad) and d-pad arrows,
 // language-neutral by convention, so they render as-is and are deliberately not
-// t() keys (see the hud_chrome.ts controller note). Order is the panel's display
-// order. Guide/home (16) is intentionally omitted, the OS usually swallows it.
+// t() keys (see the hud_chrome.ts controller note). This brand-neutral combined
+// set is the fallback when the connected pad's brand is unknown. Order is the
+// panel's display order. Guide/home (16) is intentionally omitted, the OS usually
+// swallows it.
 export const GAMEPAD_BUTTON_LABELS: Record<number, string> = {
   [GP.A]: 'A / Cross',
   [GP.B]: 'B / Circle',
@@ -52,15 +76,113 @@ export const GAMEPAD_BUTTON_LABELS: Record<number, string> = {
   [GP.START]: 'Start / Options',
   [GP.L3]: 'L3',
   [GP.R3]: 'R3',
-  [GP.DPAD_UP]: 'D-pad ↑',
-  [GP.DPAD_DOWN]: 'D-pad ↓',
-  [GP.DPAD_LEFT]: 'D-pad ←',
-  [GP.DPAD_RIGHT]: 'D-pad →',
+  ...DPAD_LABELS,
 };
 
 export const BINDABLE_BUTTONS: number[] = Object.keys(GAMEPAD_BUTTON_LABELS)
   .map(Number)
   .sort((a, b) => a - b);
+
+// --- Per-brand button glyphs ---------------------------------------------
+// The W3C standard mapping keys buttons by physical POSITION, not silk-screen:
+// index 0 is always the bottom face button, 1 the right, 2 the left, 3 the top.
+// That position is stable across pads, but the letter printed on it is not, so a
+// single "A / Cross" label misleads a player looking at their actual controller,
+// most sharply on Nintendo pads, whose A/B and X/Y are mirror-swapped versus an
+// Xbox pad (the bottom button reads "B" on a Switch pad, "A" on an Xbox pad).
+// We detect the brand from Gamepad.id and label each button with the glyph that
+// player sees. Bindings stay position-indexed, so the DEFAULT layout is
+// unchanged: "bottom face button = jump" holds on every pad; only the shown text
+// differs. Like GAMEPAD_BUTTON_LABELS these are hardware names, not t() keys.
+export type GamepadKind = 'xbox' | 'playstation' | 'nintendo' | 'generic';
+
+export const GAMEPAD_BUTTON_LABELS_BY_KIND: Record<GamepadKind, Record<number, string>> = {
+  generic: GAMEPAD_BUTTON_LABELS,
+  xbox: {
+    [GP.A]: 'A',
+    [GP.B]: 'B',
+    [GP.X]: 'X',
+    [GP.Y]: 'Y',
+    [GP.LB]: 'LB',
+    [GP.RB]: 'RB',
+    [GP.LT]: 'LT',
+    [GP.RT]: 'RT',
+    [GP.BACK]: 'View',
+    [GP.START]: 'Menu',
+    [GP.L3]: 'L3',
+    [GP.R3]: 'R3',
+    ...DPAD_LABELS,
+  },
+  playstation: {
+    [GP.A]: 'Cross',
+    [GP.B]: 'Circle',
+    [GP.X]: 'Square',
+    [GP.Y]: 'Triangle',
+    [GP.LB]: 'L1',
+    [GP.RB]: 'R1',
+    [GP.LT]: 'L2',
+    [GP.RT]: 'R2',
+    // DualShock 4 silk-screens "Share"; DualSense renamed it "Create". Both report
+    // as this one 'playstation' kind, so show both to cover either generation.
+    [GP.BACK]: 'Share / Create',
+    [GP.START]: 'Options',
+    [GP.L3]: 'L3',
+    [GP.R3]: 'R3',
+    ...DPAD_LABELS,
+  },
+  // Face buttons carry the Nintendo silk-screen for each POSITION: the bottom
+  // button (index 0) reads B, the right (1) A, the left (2) Y, the top (3) X.
+  nintendo: {
+    [GP.A]: 'B',
+    [GP.B]: 'A',
+    [GP.X]: 'Y',
+    [GP.Y]: 'X',
+    [GP.LB]: 'L',
+    [GP.RB]: 'R',
+    [GP.LT]: 'ZL',
+    [GP.RT]: 'ZR',
+    [GP.BACK]: 'Minus',
+    [GP.START]: 'Plus',
+    [GP.L3]: 'L Stick',
+    [GP.R3]: 'R Stick',
+    ...DPAD_LABELS,
+  },
+};
+
+// USB vendor ids for the three console brands.
+const VENDOR_ID: Record<string, GamepadKind> = {
+  '054c': 'playstation', // Sony
+  '045e': 'xbox', // Microsoft
+  '057e': 'nintendo', // Nintendo
+};
+
+// Classify a controller from its Gamepad.id string. Product-NAME keywords are the
+// primary signal: they are unambiguous and appear in both the Chrome format
+// ("DualSense Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 0ce6)")
+// and the Firefox format ("054c-0ce6-DualSense Wireless Controller"). Only if no
+// name matches do we fall back to the USB VENDOR id, read from its specific field
+// so a matching PRODUCT id cannot be mistaken for a vendor (Chrome's "Vendor: XXXX"
+// or Firefox's leading "XXXX-YYYY-" pair). Anything unrecognized returns 'generic'
+// so the brand-neutral combined labels are shown.
+export function detectGamepadKind(id: string): GamepadKind {
+  const s = id.toLowerCase();
+  if (/dualsense|dualshock|playstation/.test(s)) return 'playstation';
+  if (/xbox|x-box|xinput/.test(s)) return 'xbox';
+  if (/switch|joy-?con|pro controller/.test(s)) return 'nintendo';
+  const vendor =
+    /vendor:\s*([0-9a-f]{4})/.exec(s)?.[1] ?? /^([0-9a-f]{4})-[0-9a-f]{4}-/.exec(s)?.[1];
+  return (vendor && VENDOR_ID[vendor]) || 'generic';
+}
+
+// Label for a button on a given brand, falling back to the generic combined
+// label and finally to a raw index so every bindable button always renders.
+export function gamepadButtonLabel(button: number, kind: GamepadKind): string {
+  return (
+    GAMEPAD_BUTTON_LABELS_BY_KIND[kind][button] ??
+    GAMEPAD_BUTTON_LABELS_BY_KIND.generic[button] ??
+    `#${button}`
+  );
+}
 
 // Action ids reuse the keyboard Keybinds registry ids (so the gamepad dispatches
 // through the same InputCallbacks) plus two specials Keybinds doesn't model:

--- a/src/main.ts
+++ b/src/main.ts
@@ -1306,6 +1306,7 @@ async function startGame(
     onInputEdge: () => inputMeter.record(performance.now()),
     isPointerMode: () => hud.isWindowOpen(),
     getPlayerHealth: () => (world.player.dead ? 0 : world.player.hp),
+    onConnectionChange: () => hud.refreshControllerLabels(),
   });
   // The startup apply-all loop (below) calls applySetting('gamepadEnabled', ...)
   // which starts/stops the manager and pushes the saved deadzone/speed/vibration.
@@ -1655,7 +1656,14 @@ async function startGame(
       },
       setPlacement: (on) => perfOverlay.setPlacementMode(on),
     },
-    gamepad: gamepadBindings,
+    gamepad: {
+      entries: () => gamepadBindings.entries(),
+      bind: (button, action) => gamepadBindings.bind(button, action),
+      reset: () => gamepadBindings.reset(),
+      // The connected pad's brand lives on the manager, not the (hardware-agnostic)
+      // bindings, so surface it here for the Controller panel's glyph labels.
+      kind: () => gamepad.getKind(),
+    },
   });
   if (online) {
     hud.attachReporting({

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1,4 +1,5 @@
 import { audio } from '../game/audio';
+import type { GamepadKind } from '../game/gamepad_map';
 import type { Keybinds } from '../game/keybinds';
 import { music, musicZoneForLocation, shouldResetMusicForDungeonEntry } from '../game/music';
 import type { GameSettings, Settings } from '../game/settings';
@@ -378,6 +379,9 @@ export interface GamepadBindingsHooks {
   entries(): { button: number; action: string }[];
   bind(button: number, action: string): void;
   reset(): void;
+  // Detected brand of the connected pad, so the panel labels each button with the
+  // glyph printed on that controller ('generic' combined labels when none/unknown).
+  kind(): GamepadKind;
 }
 
 export interface ReportHooks {
@@ -11772,6 +11776,12 @@ export class Hud {
    *  dropped normalized position to the options window's open performance panel. */
   onPerfOverlayMoved(x: number, y: number): void {
     this.optionsWindow.onPerfOverlayMoved(x, y);
+  }
+
+  /** Called by main.ts when a pad connects/disconnects: re-label the Controller
+   *  panel with the newly detected brand's glyphs if that panel is open. */
+  refreshControllerLabels(): void {
+    this.optionsWindow.refreshControllerLabels();
   }
 
   // -------------------------------------------------------------------------

--- a/src/ui/options_window.ts
+++ b/src/ui/options_window.ts
@@ -21,7 +21,7 @@
 
 import { syncAppViewport } from '../game/app_viewport';
 import { audio } from '../game/audio';
-import { GAMEPAD_BUTTON_LABELS, GAMEPAD_NONE } from '../game/gamepad_map';
+import { GAMEPAD_NONE, gamepadButtonLabel } from '../game/gamepad_map';
 import {
   BIND_ACTIONS,
   BIND_CATEGORIES,
@@ -271,6 +271,13 @@ export class OptionsWindow {
    *  normalized position into the open panel's sliders so they do not lag the drag. */
   onPerfOverlayMoved(x: number, y: number): void {
     this.perfSettings?.syncPosition(x, y);
+  }
+
+  /** Called by main.ts when a pad connects/disconnects: re-render the Controller
+   *  sub-view in place if it is open, so the button glyphs switch to the newly
+   *  detected brand without the player reopening the panel. A no-op otherwise. */
+  refreshControllerLabels(): void {
+    if (this.isOpen && this.view === 'controller') this.renderController();
   }
 
   // -------------------------------------------------------------------------
@@ -1190,12 +1197,13 @@ export class OptionsWindow {
 
     if (hooks) {
       const opts = this.gamepadActionOptions();
+      const kind = hooks.gamepad.kind();
       for (const { button, action } of hooks.gamepad.entries()) {
         const row = document.createElement('div');
         row.className = 'set-row';
         const name = document.createElement('span');
         name.className = 'set-name';
-        const buttonLabel = GAMEPAD_BUTTON_LABELS[button] ?? `#${button}`;
+        const buttonLabel = gamepadButtonLabel(button, kind);
         name.textContent = buttonLabel;
         // Name the remap listbox after the physical button it rebinds (WCAG 4.1.2):
         // the visible set-name span is not programmatically linked, so the dropdown

--- a/tests/gamepad.test.ts
+++ b/tests/gamepad.test.ts
@@ -150,3 +150,156 @@ describe('GamepadManager window focus', () => {
     expect(setGamepadMove).toHaveBeenCalled();
   });
 });
+
+function padWithId(id: string): Gamepad {
+  return { ...gamepadWithPressed(), id } as unknown as Gamepad;
+}
+
+function stubInput(): Input {
+  return {
+    applyGamepadLook: vi.fn(),
+    setGamepadMove: vi.fn(),
+    triggerGamepadJump: vi.fn(),
+    clearGamepadMove: vi.fn(),
+    toggleAutorun: vi.fn(),
+  } as unknown as Input;
+}
+
+describe('GamepadManager brand detection', () => {
+  it('reports generic when no pad is connected', () => {
+    const manager = new GamepadManager(stubInput(), new GamepadBindings(), {
+      onAction: vi.fn(),
+      onInputEdge: vi.fn(),
+      isPointerMode: () => false,
+    });
+    expect(manager.getKind()).toBe('generic');
+  });
+
+  it('detects the brand of an already-connected pad on start() and notifies', () => {
+    const pad = padWithId('DualSense Wireless Controller (Vendor: 054c Product: 0ce6)');
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: { getGamepads: () => [pad] },
+    });
+    // start() attaches window listeners; stub them so the Node env has no DOM.
+    const originalWindow = (globalThis as { window?: unknown }).window;
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { addEventListener: vi.fn(), removeEventListener: vi.fn() },
+    });
+
+    const onConnectionChange = vi.fn();
+    const manager = new GamepadManager(stubInput(), new GamepadBindings(), {
+      onAction: vi.fn(),
+      onInputEdge: vi.fn(),
+      isPointerMode: () => false,
+      onConnectionChange,
+    });
+    manager.start();
+
+    expect(manager.getKind()).toBe('playstation');
+    expect(onConnectionChange).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: originalWindow });
+  });
+
+  it('sets the kind on connect and resets it to generic on disconnect (both notify)', () => {
+    const onConnectionChange = vi.fn();
+    const manager = new GamepadManager(stubInput(), new GamepadBindings(), {
+      onAction: vi.fn(),
+      onInputEdge: vi.fn(),
+      isPointerMode: () => false,
+      onConnectionChange,
+    });
+    const pad = padWithId('Pro Controller (Vendor: 057e Product: 2009)');
+
+    (manager as unknown as { onConnect(e: { gamepad: Gamepad }): void }).onConnect({
+      gamepad: pad,
+    });
+    expect(manager.getKind()).toBe('nintendo');
+    expect(manager.isConnected()).toBe(true);
+
+    (manager as unknown as { onDisconnect(e: { gamepad: Gamepad }): void }).onDisconnect({
+      gamepad: pad,
+    });
+    expect(manager.getKind()).toBe('generic');
+    expect(manager.isConnected()).toBe(false);
+    expect(onConnectionChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores a second pad connecting while one is already active (no hijack, no notify)', () => {
+    const onConnectionChange = vi.fn();
+    const manager = new GamepadManager(stubInput(), new GamepadBindings(), {
+      onAction: vi.fn(),
+      onInputEdge: vi.fn(),
+      isPointerMode: () => false,
+      onConnectionChange,
+    });
+    const mgr = manager as unknown as { onConnect(e: { gamepad: Gamepad }): void };
+    const first = {
+      ...padWithId('Xbox Wireless Controller (Vendor: 045e Product: 02fd)'),
+      index: 0,
+    };
+    const second = {
+      ...padWithId('DualSense Wireless Controller (Vendor: 054c Product: 0ce6)'),
+      index: 1,
+    };
+    mgr.onConnect({ gamepad: first as Gamepad });
+    expect(manager.getKind()).toBe('xbox');
+    onConnectionChange.mockClear();
+    mgr.onConnect({ gamepad: second as Gamepad });
+    // The active pad and its brand are unchanged, and no re-label fires.
+    expect(manager.getKind()).toBe('xbox');
+    expect(onConnectionChange).not.toHaveBeenCalled();
+  });
+
+  it('ignores a non-active pad disconnecting (kind + notify untouched)', () => {
+    const onConnectionChange = vi.fn();
+    const manager = new GamepadManager(stubInput(), new GamepadBindings(), {
+      onAction: vi.fn(),
+      onInputEdge: vi.fn(),
+      isPointerMode: () => false,
+      onConnectionChange,
+    });
+    const mgr = manager as unknown as {
+      onConnect(e: { gamepad: Gamepad }): void;
+      onDisconnect(e: { gamepad: Gamepad }): void;
+    };
+    const active = {
+      ...padWithId('Xbox Wireless Controller (Vendor: 045e Product: 02fd)'),
+      index: 0,
+    };
+    mgr.onConnect({ gamepad: active as Gamepad });
+    onConnectionChange.mockClear();
+    const other = { ...padWithId('DualSense Wireless Controller'), index: 3 };
+    mgr.onDisconnect({ gamepad: other as Gamepad });
+    expect(manager.getKind()).toBe('xbox');
+    expect(manager.isConnected()).toBe(true);
+    expect(onConnectionChange).not.toHaveBeenCalled();
+  });
+
+  it('resets the detected kind to generic on stop()', () => {
+    const pad = padWithId('Xbox Wireless Controller (Vendor: 045e Product: 02fd)');
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: { getGamepads: () => [pad] },
+    });
+    const originalWindow = (globalThis as { window?: unknown }).window;
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { addEventListener: vi.fn(), removeEventListener: vi.fn() },
+    });
+
+    const manager = new GamepadManager(stubInput(), new GamepadBindings(), {
+      onAction: vi.fn(),
+      onInputEdge: vi.fn(),
+      isPointerMode: () => false,
+    });
+    manager.start();
+    expect(manager.getKind()).toBe('xbox');
+    manager.stop();
+    expect(manager.getKind()).toBe('generic');
+
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: originalWindow });
+  });
+});

--- a/tests/gamepad_map.test.ts
+++ b/tests/gamepad_map.test.ts
@@ -1,12 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   applyRadialDeadzone,
-  stickToMoveFlags,
-  stickToLook,
-  risingEdges,
-  DEFAULT_GAMEPAD_BINDINGS,
   BINDABLE_BUTTONS,
+  DEFAULT_GAMEPAD_BINDINGS,
+  detectGamepadKind,
   GP,
+  gamepadButtonLabel,
+  risingEdges,
+  stickToLook,
+  stickToMoveFlags,
 } from '../src/game/gamepad_map';
 
 describe('applyRadialDeadzone', () => {
@@ -36,7 +38,10 @@ describe('applyRadialDeadzone', () => {
 describe('stickToMoveFlags', () => {
   it('produces nothing inside the deadzone', () => {
     expect(stickToMoveFlags(0.1, 0.1, 0.25)).toEqual({
-      forward: false, back: false, strafeLeft: false, strafeRight: false,
+      forward: false,
+      back: false,
+      strafeLeft: false,
+      strafeRight: false,
     });
   });
 
@@ -110,7 +115,9 @@ describe('default layout', () => {
   });
 
   it('assigns a default to every bindable button (catches a dropped binding)', () => {
-    const bound = Object.keys(DEFAULT_GAMEPAD_BINDINGS).map(Number).sort((a, b) => a - b);
+    const bound = Object.keys(DEFAULT_GAMEPAD_BINDINGS)
+      .map(Number)
+      .sort((a, b) => a - b);
     expect(bound).toEqual(BINDABLE_BUTTONS);
   });
 
@@ -120,6 +127,116 @@ describe('default layout', () => {
       // Exactly once: count 0 = a dropped slot, count >= 2 = a duplicated slot
       // (additive or displacing). The default layout binds each slot to one button.
       expect(values.filter((v) => v === `slot${slot}`).length, `slot${slot}`).toBe(1);
+    }
+  });
+});
+
+describe('detectGamepadKind', () => {
+  it('classifies a PlayStation pad by name and by Sony vendor id', () => {
+    expect(
+      detectGamepadKind(
+        'DualSense Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 0ce6)',
+      ),
+    ).toBe('playstation');
+    // DualShock 4 often reports the generic name "Wireless Controller"; the 054c
+    // vendor id is what still identifies it.
+    expect(
+      detectGamepadKind('Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 09cc)'),
+    ).toBe('playstation');
+  });
+
+  it('classifies an Xbox pad by name and by Microsoft vendor id', () => {
+    expect(
+      detectGamepadKind('Xbox Wireless Controller (STANDARD GAMEPAD Vendor: 045e Product: 02fd)'),
+    ).toBe('xbox');
+  });
+
+  it('classifies Nintendo pads (Switch Pro, Joy-Con) by name and vendor id', () => {
+    expect(detectGamepadKind('Pro Controller (STANDARD GAMEPAD Vendor: 057e Product: 2009)')).toBe(
+      'nintendo',
+    );
+    expect(detectGamepadKind('Joy-Con (L/R)')).toBe('nintendo');
+  });
+
+  it('classifies Xbox pads reported with hyphenated or XInput-only names', () => {
+    expect(detectGamepadKind('Xbox 360 Controller (XInput STANDARD GAMEPAD)')).toBe('xbox');
+    expect(detectGamepadKind('Microsoft X-Box 360 pad')).toBe('xbox');
+  });
+
+  it('reads the vendor id from the Firefox "vendor-product-name" id format', () => {
+    expect(detectGamepadKind('054c-0ce6-DualSense Wireless Controller')).toBe('playstation');
+    // Vendor-only Firefox id with no recognizable product name still resolves.
+    expect(detectGamepadKind('045e-02fd-')).toBe('xbox');
+  });
+
+  it('prefers the product NAME over a colliding product-id hex (no misclassification)', () => {
+    // The product id here is 054c (Sony's vendor code), but the pad is an Xbox pad.
+    // Name must win, and the vendor must be read from its field, not the product.
+    expect(detectGamepadKind('Xbox Wireless Controller (Vendor: 045e Product: 054c)')).toBe('xbox');
+  });
+
+  it('reads the vendor from its field, not a colliding product id, when no name matches', () => {
+    // No name keyword; vendor 045e (Xbox) but product 054c (Sony's vendor code). A
+    // naive whole-string scan for "054c" would wrongly return 'playstation'; reading
+    // the vendor field returns 'xbox'. This is the case that actually pins the parse.
+    expect(detectGamepadKind('Wireless Controller (Vendor: 045e Product: 054c)')).toBe('xbox');
+  });
+
+  it('pins the PlayStation name arm alone (no vendor id present)', () => {
+    expect(detectGamepadKind('DualSense Wireless Controller')).toBe('playstation');
+  });
+
+  it('pins the Nintendo vendor arm alone (no name keyword present)', () => {
+    expect(detectGamepadKind('Wireless Controller (Vendor: 057e Product: 2009)')).toBe('nintendo');
+  });
+
+  it('falls back to generic for an unknown or empty id', () => {
+    expect(detectGamepadKind('Some Random Pad (Vendor: 1234 Product: 5678)')).toBe('generic');
+    expect(detectGamepadKind('')).toBe('generic');
+  });
+});
+
+describe('gamepadButtonLabel', () => {
+  it('mirrors the Nintendo A/B and X/Y face-button swap (labels follow the silk-screen)', () => {
+    // Position index 0 is the bottom face button: "B" on a Switch pad, "A" on Xbox.
+    expect(gamepadButtonLabel(GP.A, 'nintendo')).toBe('B');
+    expect(gamepadButtonLabel(GP.B, 'nintendo')).toBe('A');
+    expect(gamepadButtonLabel(GP.X, 'nintendo')).toBe('Y');
+    expect(gamepadButtonLabel(GP.Y, 'nintendo')).toBe('X');
+    // Xbox is unswapped: the same positions read A/B/X/Y.
+    expect(gamepadButtonLabel(GP.A, 'xbox')).toBe('A');
+    expect(gamepadButtonLabel(GP.Y, 'xbox')).toBe('Y');
+  });
+
+  it("uses each brand's shoulder/face names", () => {
+    expect(gamepadButtonLabel(GP.A, 'playstation')).toBe('Cross');
+    expect(gamepadButtonLabel(GP.X, 'playstation')).toBe('Square');
+    expect(gamepadButtonLabel(GP.LT, 'playstation')).toBe('L2');
+    expect(gamepadButtonLabel(GP.LT, 'nintendo')).toBe('ZL');
+    expect(gamepadButtonLabel(GP.LT, 'xbox')).toBe('LT');
+  });
+
+  it('shares identical d-pad arrows across brands', () => {
+    for (const kind of ['generic', 'xbox', 'playstation', 'nintendo'] as const) {
+      expect(gamepadButtonLabel(GP.DPAD_UP, kind)).toBe('D-pad ↑');
+    }
+  });
+
+  it('keeps the brand-neutral combined labels for the generic kind', () => {
+    expect(gamepadButtonLabel(GP.A, 'generic')).toBe('A / Cross');
+  });
+
+  it('falls back to a raw index for an out-of-range button', () => {
+    expect(gamepadButtonLabel(99, 'xbox')).toBe('#99');
+  });
+
+  it('labels every bindable button for every brand (no undefined glyphs)', () => {
+    for (const kind of ['generic', 'xbox', 'playstation', 'nintendo'] as const) {
+      for (const button of BINDABLE_BUTTONS) {
+        const label = gamepadButtonLabel(button, kind);
+        expect(label, `${kind} #${button}`).toBeTruthy();
+        expect(label.startsWith('#'), `${kind} #${button} unlabeled`).toBe(false);
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary

The Controller options panel currently labels every button with a single brand-neutral string ("A / Cross", "X / Square", ...). That is fine for Xbox and PlayStation, but it misleads Nintendo players: a Switch pad's face buttons are mirror-swapped versus an Xbox pad (the bottom button reads "B" on Switch, "A" on Xbox), so "A / Cross" points a Nintendo player at the wrong button.

This PR detects the connected controller's brand from `Gamepad.id` (PlayStation / Xbox / Nintendo, else generic) and labels each button with the glyph printed on that player's actual pad, including the Nintendo A/B and X/Y swap.

Bindings stay position-indexed, so `DEFAULT_GAMEPAD_BINDINGS` is unchanged and "bottom face button = jump" holds on every pad. Only the displayed text changes; there is no gameplay effect.

### How it works
- New pure core in `src/game/gamepad_map.ts`: `GamepadKind`, `detectGamepadKind(id)`, `GAMEPAD_BUTTON_LABELS_BY_KIND`, and `gamepadButtonLabel(button, kind)`. Detection checks product-name keywords first (present in both the Chrome and Firefox `id` formats), then reads the USB vendor id from its own field so a matching product-id hex cannot be mistaken for a vendor.
- `GamepadManager` (`gamepad.ts`) stores the detected brand on connect, exposes `getKind()`, and fires an `onConnectionChange` callback.
- The Controller panel (`options_window.ts`) labels each button via the detected brand and re-labels live on connect/disconnect (`OptionsWindow.refreshControllerLabels` -> `Hud` passthrough -> `main.ts` wiring; `GamepadBindingsHooks` gained `kind()`).
- Glyphs stay non-`t()`, consistent with the existing controller-panel convention that hardware button names are language-neutral.

## Type of change

- [x] Feature: new functionality

## How was this tested?

- Commands: `npx vitest run tests/gamepad_map.test.ts tests/gamepad.test.ts` (34 pass), `npx tsc --noEmit` (clean), `npx @biomejs/biome ci <changed files>` (clean), `npm run build` (clean).
- Added unit tests: brand detection (name + Chrome/Firefox vendor formats, the product-id-collision case, xinput/x-box names, generic/empty fallback), the Nintendo A/B/X/Y swap, per-brand shoulder/face names, shared d-pad, full per-brand button coverage, and `GamepadManager` kind lifecycle (connect/disconnect/stop/getKind + the connection-change callback).
- Not yet verified on physical hardware: real PS5/Xbox/Switch brand detection and the live re-label are the one item that needs an actual controller.

## Checklist

### Quality
- [x] Tests pass; added tests for the new behavior.
- [x] Typecheck passes (`npx tsc --noEmit`).
- [x] Builds succeed (`npm run build`).

### Localization (i18n)
- [x] N/A. The button glyphs are hardware names, kept non-localized per the existing controller-panel convention (`hud_chrome.ts` note + `gamepad_map.ts`). No new `t()` keys.

### Hygiene
- [x] No secrets or generated files touched.

## Notes for reviewers

- Out of scope (pre-existing, noted for a possible follow-up): when the active pad is unplugged while a second pad stays connected, the manager goes idle instead of re-scanning for the remaining pad. This PR does not change that behavior.
