### PR TITLE
feat(ui): WoW-style quest progress flash at the top-center

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,6 +413,7 @@
     <div id="tooltip" class="panel"></div>
 
     <div id="error-msg"></div>
+    <div id="quest-banner" aria-hidden="true"></div>
     <div id="banner"></div>
     <div id="low-health-vignette"></div>
     <div id="subzone-banner"></div>

--- a/play.html
+++ b/play.html
@@ -361,6 +361,7 @@
     <div id="tooltip" class="panel"></div>
 
     <div id="error-msg"></div>
+    <div id="quest-banner" aria-hidden="true"></div>
     <div id="banner"></div>
     <div id="low-health-vignette"></div>
     <div id="subzone-banner"></div>

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -3480,6 +3480,36 @@
     letter-spacing: 1px;
     white-space: nowrap;
   }
+  /* The quest-progress flash (quest_progress_banner.ts): small yellow lines
+     stacked at the top-center, above the zone banner's slot, the classic
+     "Forest Wolf slain: 3/8" cue. Lines are appended by the banner module and
+     fade out on their own timers. */
+  #quest-banner {
+    position: absolute;
+    left: 50%;
+    top: 15%;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    pointer-events: none;
+    z-index: 7;
+  }
+  .quest-banner-line {
+    color: #ffd100;
+    font-size: 20px;
+    font-weight: bold;
+    text-shadow:
+      0 0 10px #00000088,
+      1px 1px 3px #000;
+    white-space: nowrap;
+    opacity: 1;
+    transition: opacity 0.4s ease;
+  }
+  .quest-banner-line.fade {
+    opacity: 0;
+  }
   #subzone-banner {
     position: absolute;
     left: 50%;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -292,6 +292,7 @@ import { chatPlayerContextActions } from './player_context_menu';
 import { hydratePortraits, portraitChipHtml } from './portrait_chip';
 import { maskProfanity } from './profanity';
 import { encodeItemLink, encodeQuestLink, parseChatSegments } from './quest_link';
+import { QuestProgressBanner } from './quest_progress_banner';
 import { type QuestTrackerView, questTrackerView, type TrackedQuest } from './quest_tracker';
 import { QuestLogWindow } from './questlog_window';
 import { lockoutParts, lockoutShape } from './raid_lockout';
@@ -798,6 +799,10 @@ export class Hud {
   private activeChatTab: ChatTabId = 'all';
   private errorEl = $('#error-msg');
   private bannerEl = $('#banner');
+  // The WoW-style quest-progress flash (quest_progress_banner.ts): yellow
+  // top-center lines fed by the questProgress event, aria-hidden decoration
+  // (the chat log + live region carry the announced copy).
+  private readonly questBanner = new QuestProgressBanner($('#quest-banner'));
   private subzoneEl = $('#subzone-banner');
   private tooltipEl = $('#tooltip');
   // Distinguishes a touch long-press "peek" (inspect, no action) from a tap.
@@ -7080,10 +7085,15 @@ export class Hud {
           audio.questAccept();
           this.refreshGossip();
           break;
-        case 'questProgress':
-          this.log(this.localizeQuestProgressText(ev.questId, ev.text), '#dcd29f');
+        case 'questProgress': {
+          const progressText = this.localizeQuestProgressText(ev.questId, ev.text);
+          this.log(progressText, '#dcd29f');
+          // The classic yellow top-center flash ("Forest Wolf slain: 3/8"); the
+          // log line above stays the durable, announced copy.
+          this.questBanner.show(progressText);
           this.refreshGossip();
           break;
+        }
         case 'questReady': {
           this.showBanner(
             t('questUi.logs.ready', {

--- a/src/ui/quest_progress_banner.ts
+++ b/src/ui/quest_progress_banner.ts
@@ -1,0 +1,40 @@
+// The WoW-style quest-progress banner: short yellow lines at the top-center
+// ("Forest Wolf slain: 3/8") whenever a quest mob dies or a quest item lands in
+// the bags. Event-driven (the sim's questProgress SimEvent, already localized
+// by the Hud before it reaches here), never a per-frame path, so plain DOM
+// construction is fine. Up to maxLines stack (a multi-objective loot burst
+// shows every line); each line fades on its own timer and the oldest drops
+// when the stack overflows. The chat log keeps the durable copy and the live
+// region announces it, so the banner container is aria-hidden decoration.
+
+// How long a line stays fully visible before its fade starts, and how long the
+// CSS opacity fade runs (matches .quest-banner-line's transition duration).
+export const QUEST_BANNER_LINE_MS = 3000;
+export const QUEST_BANNER_FADE_MS = 400;
+export const QUEST_BANNER_MAX_LINES = 3;
+const LINE_CLASS = 'quest-banner-line';
+const FADE_CLASS = 'fade';
+
+export class QuestProgressBanner {
+  constructor(
+    private readonly el: HTMLElement,
+    private readonly maxLines: number = QUEST_BANNER_MAX_LINES,
+    private readonly lineMs: number = QUEST_BANNER_LINE_MS,
+    private readonly fadeMs: number = QUEST_BANNER_FADE_MS,
+  ) {}
+
+  /** Push one already-localized progress line onto the stack. */
+  show(text: string): void {
+    const line = this.el.ownerDocument.createElement('div');
+    line.className = LINE_CLASS;
+    line.textContent = text;
+    this.el.appendChild(line);
+    // Overflow: the OLDEST line yields immediately (classic behavior: the
+    // newest kill is the one you are reading).
+    while (this.el.children.length > this.maxLines) this.el.firstElementChild?.remove();
+    setTimeout(() => {
+      line.classList.add(FADE_CLASS);
+      setTimeout(() => line.remove(), this.fadeMs);
+    }, this.lineMs);
+  }
+}

--- a/tests/quest_progress_banner.test.ts
+++ b/tests/quest_progress_banner.test.ts
@@ -1,0 +1,107 @@
+// QuestProgressBanner (src/ui/quest_progress_banner.ts): the WoW-style yellow
+// top-center quest flash. Pins the stack contract: lines append in order, the
+// oldest drops past maxLines, and each line fades then removes on its own
+// timers. Driven over a tiny hand-rolled fake DOM (no jsdom) + fake timers.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  QUEST_BANNER_FADE_MS,
+  QUEST_BANNER_LINE_MS,
+  QUEST_BANNER_MAX_LINES,
+  QuestProgressBanner,
+} from '../src/ui/quest_progress_banner';
+
+interface FakeEl {
+  className: string;
+  textContent: string;
+  children: FakeEl[];
+  parentEl: FakeEl | null;
+  firstElementChild: FakeEl | null;
+  ownerDocument: { createElement(tag: string): FakeEl };
+  classList: { add(c: string): void; contains(c: string): boolean };
+  appendChild(kid: FakeEl): void;
+  remove(): void;
+}
+
+function fakeEl(): FakeEl {
+  const classes = new Set<string>();
+  const el: FakeEl = {
+    className: '',
+    textContent: '',
+    children: [],
+    parentEl: null,
+    get firstElementChild() {
+      return el.children[0] ?? null;
+    },
+    ownerDocument: { createElement: () => fakeEl() },
+    classList: {
+      add: (c) => classes.add(c),
+      contains: (c) => classes.has(c),
+    },
+    appendChild(kid) {
+      kid.parentEl = el;
+      el.children.push(kid);
+    },
+    remove() {
+      const p = el.parentEl;
+      if (!p) return;
+      const i = p.children.indexOf(el);
+      if (i >= 0) p.children.splice(i, 1);
+      el.parentEl = null;
+    },
+  };
+  return el;
+}
+
+describe('QuestProgressBanner', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('appends a yellow line per progress event, newest last', () => {
+    const host = fakeEl();
+    const banner = new QuestProgressBanner(host as unknown as HTMLElement);
+    banner.show('Forest Wolf slain: 1/8');
+    banner.show('Forest Wolf slain: 2/8');
+    expect(host.children.map((c) => c.textContent)).toEqual([
+      'Forest Wolf slain: 1/8',
+      'Forest Wolf slain: 2/8',
+    ]);
+    expect(host.children[0].className).toBe('quest-banner-line');
+  });
+
+  it('drops the OLDEST line when the stack overflows maxLines', () => {
+    const host = fakeEl();
+    const banner = new QuestProgressBanner(host as unknown as HTMLElement);
+    for (let i = 1; i <= QUEST_BANNER_MAX_LINES + 2; i++) banner.show(`line ${i}`);
+    expect(host.children).toHaveLength(QUEST_BANNER_MAX_LINES);
+    expect(host.children[0].textContent).toBe('line 3'); // 1 and 2 yielded
+    expect(host.children.at(-1)?.textContent).toBe(`line ${QUEST_BANNER_MAX_LINES + 2}`);
+  });
+
+  it('fades a line after its visible window, then removes it after the fade', () => {
+    const host = fakeEl();
+    const banner = new QuestProgressBanner(host as unknown as HTMLElement);
+    banner.show('Forest Wolf slain: 3/8');
+    const line = host.children[0];
+    // fully visible through the window
+    vi.advanceTimersByTime(QUEST_BANNER_LINE_MS - 1);
+    expect(line.classList.contains('fade')).toBe(false);
+    // fade class lands at the window's end; the node survives the transition
+    vi.advanceTimersByTime(1);
+    expect(line.classList.contains('fade')).toBe(true);
+    expect(host.children).toHaveLength(1);
+    // and is removed once the CSS fade duration elapses
+    vi.advanceTimersByTime(QUEST_BANNER_FADE_MS);
+    expect(host.children).toHaveLength(0);
+  });
+
+  it('a line already dropped by overflow does not throw when its fade timer fires', () => {
+    const host = fakeEl();
+    const banner = new QuestProgressBanner(host as unknown as HTMLElement, 1);
+    banner.show('first');
+    banner.show('second'); // evicts 'first' immediately
+    expect(host.children.map((c) => c.textContent)).toEqual(['second']);
+    // both timers fire; the evicted line's remove() is a no-op, never a throw
+    vi.advanceTimersByTime(QUEST_BANNER_LINE_MS + QUEST_BANNER_FADE_MS);
+    expect(host.children).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

Killing a quest mob or picking up a quest item flashes the classic yellow progress line at the top-center of the screen ('Forest Wolf slain: 3/8'), the vanilla objective-progress cue. Both kill and collect objectives fire it.

## How

- Fed by the SAME localized questProgress SimEvent the chat line already uses, so no new sim surface, wire field, or i18n key: the Hud localizes once and hands the string to both sinks.
- A small event-driven module (src/ui/quest_progress_banner.ts) owns the flash: up to three lines stack (a multi-objective loot burst shows every line), the oldest drops on overflow, and each line fades on its own timer. Event-driven, never a per-frame path.
- The container is aria-hidden decoration: the chat log keeps the durable copy and the existing live region announces it, so screen readers hear it exactly once.
- Sits above the zone-banner slot (top 15%), yellow with the classic dark text-shadow.

## Testing

- New tests/quest_progress_banner.test.ts (4 cases, fake DOM + fake timers): append order, oldest-drops overflow, the fade-then-remove timer chain, and the evicted-line no-throw edge.
- client_shell, css corpus/validity, architecture, hud_perf_budget, localization_coverage green; tsc clean.
- Verified in a real browser: accepted Wolves at the Door at Marshal Redbrook, killed a wolf, and the yellow 'Forest Wolf slain: 1/8' flashed top-center (screenshot-confirmed against the classic reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)