### PR TITLE
test(i18n): collapse the registry expect-storms into single asserts

### DIFF
--- a/tests/i18n_status_registry.test.ts
+++ b/tests/i18n_status_registry.test.ts
@@ -98,12 +98,19 @@ describe('i18n status registry: universe coverage', () => {
 
 describe('i18n status registry: enHash re-derivation (independent)', () => {
   it('each enHash == contentHash(englishText, sortedPlaceholders) recomputed from source', () => {
+    // Accumulate violations and assert ONCE: a per-row expect() over the ~5k-key
+    // universe costs seconds of matcher overhead and trips the default per-test
+    // timeout on a loaded runner, for identical semantics.
     const expected = expectedUniverse();
+    const violations: string[] = [];
     for (const [ck, enVal] of expected) {
       const row = registry.keys[ck];
-      expect(row.enHash, `${ck} enHash mismatch`).toBe(contentHash(enVal, placeholdersOf(enVal)));
-      expect(row.placeholders, `${ck} placeholders`).toEqual(placeholdersOf(enVal));
+      if (row.enHash !== contentHash(enVal, placeholdersOf(enVal)))
+        violations.push(`${ck} enHash mismatch`);
+      if (JSON.stringify(row.placeholders) !== JSON.stringify(placeholdersOf(enVal)))
+        violations.push(`${ck} placeholders`);
     }
+    expect(violations).toEqual([]);
   });
 });
 
@@ -169,12 +176,18 @@ describe('i18n status registry: states', () => {
   });
 
   it('every translated row is fresh (srcHash === enHash) and attributed (by human|agent)', () => {
-    for (const [, entry] of keyEntries())
-      for (const row of Object.values<any>(entry.locales)) {
+    // Accumulate violations and assert ONCE: this walks ~100k locale rows, and a
+    // per-row expect() pair (~200k matcher calls) took ~6s, past the default 5s
+    // per-test budget on a loaded runner (the flake seen in full-suite runs).
+    // Plain JS checks keep it in milliseconds with identical semantics.
+    const violations: string[] = [];
+    for (const [ck, entry] of keyEntries())
+      for (const [loc, row] of Object.entries<any>(entry.locales)) {
         if (row.state !== 'translated') continue;
-        expect(row.srcHash).toBe(entry.enHash);
-        expect(['human', 'agent']).toContain(row.by);
+        if (row.srcHash !== entry.enHash) violations.push(`${ck} ${loc} stale srcHash`);
+        if (row.by !== 'human' && row.by !== 'agent') violations.push(`${ck} ${loc} unattributed`);
       }
+    expect(violations).toEqual([]);
   });
 });
 
@@ -205,12 +218,16 @@ describe('i18n status registry: blocked rows are load-bearing (no over-allow)', 
   });
 
   it('only server/admin scopes carry blocked rows (main/sim carry none)', () => {
+    // Same accumulate-then-assert-once shape as the freshness walk above.
+    const violations: string[] = [];
     for (const [ck, entry] of keyEntries()) {
       const scope = ck.slice(0, ck.indexOf(':'));
       if (scope === 'server' || scope === 'admin') continue;
       for (const row of Object.values<any>(entry.locales))
-        expect(row.state, `${ck} unexpected blocked row in scope ${scope}`).not.toBe('blocked');
+        if (row.state === 'blocked')
+          violations.push(`${ck} unexpected blocked row in scope ${scope}`);
     }
+    expect(violations).toEqual([]);
   });
 
   it('every blockedSource entry is a unique sim-channel string with a reason', () => {


### PR DESCRIPTION
## Summary

Timing pass over the release suite after #1354 (comparison against v0.18.0 and v0.17.0 in throwaway worktrees):

| Release | Tests | Wall | ms per test |
|---|---|---|---|
| v0.17.0 | 5742 | 84.6s | 14.7 |
| v0.18.0 | 6344 | 81.4s | 12.8 |
| v0.20.0 tip | 7269 | 89.4s | 12.3 |

No systemic regression (per-test cost is flat to improving), but the per-file ranking surfaced one real defect: `tests/i18n_status_registry.test.ts` issued a pair of `expect()` calls per locale row across the ~100k-row registry (about 200k matcher invocations). That single case took ~6s, past the default 5s per-test budget on a loaded runner, which is the recurring "every translated row is fresh" flake seen in parallel full-suite runs.

The freshness walk, the enHash re-derivation, and the blocked-scope sweep now accumulate violations in plain JS and assert once against an empty list: identical semantics, per-key failure messages preserved, milliseconds instead of seconds. File time drops from ~23.5s to ~8.8s; the remainder is the deliberate cold scanner subprocess spawns, untouched.

## Tests

`npx vitest run tests/i18n_status_registry.test.ts`: 17 passed, 1 skipped, and the previously flaky case now completes in under 100ms.

Generated with [Claude Code](https://claude.com/claude-code)
