### PR TITLE
fix(sim): low props (campfires, crates) no longer block spell line of sight

### DIFF
--- a/src/sim/colliders.ts
+++ b/src/sim/colliders.ts
@@ -712,6 +712,51 @@ export function cameraOcclusion(
   return best;
 }
 
+// Eye height (yards above the ground) for the spell line-of-sight ray. An
+// open-world obstacle whose visual top (`cameraTopY`, the same precomputed top
+// the camera occlusion uses) sits at or below the sight line no longer blocks a
+// cast: a campfire (top 1.45), a crate (1.35), or a small rock is something you
+// see and cast OVER, while buildings, trees, tents, and fences still block.
+// Colliders without a known top (the interior wall layouts) always block, the
+// conservative default, and MOVEMENT collision is untouched everywhere.
+export const SIGHT_HEIGHT = 1.6;
+
+// Does any collider at (x,z) rise above `sightY` (absolute world Y of the
+// sight line at that sample)? Mirrors resolvePosition's zone routing so
+// interiors, delves and the arena keep their wall sets, but tests pure overlap
+// (no push-out) and applies the low-obstacle skip only where tops are known.
+function sightBlockedAt(seed: number, x: number, z: number, r: number, sightY: number): boolean {
+  const overlapsAny = (list: Collider[], lx: number, lz: number, skipLow: boolean): boolean => {
+    for (const c of list) {
+      if (skipLow && c.cameraTopY !== undefined && c.cameraTopY <= sightY) continue;
+      if (pushOut(c, lx, lz, r) !== null) return true;
+    }
+    return false;
+  };
+  if (isDelvePos(x)) {
+    const delve = delveAt(x);
+    const mods = delve ? defaultDelveModules(delve.id) : [];
+    const loc = delveModuleLocal(x, z, mods);
+    return overlapsAny(
+      delveModuleColliders(loc.moduleId as DelveModuleId),
+      loc.localX,
+      loc.localZ,
+      false,
+    );
+  }
+  if (isArenaPos(x)) {
+    const o = arenaOriginAt(z);
+    return overlapsAny(ARENA_COLLIDERS, x - o.x, z - o.z, false);
+  }
+  if (x > DUNGEON_X_THRESHOLD) {
+    const { ox, oz, interior } = instanceLocal(x, z);
+    return overlapsAny(INTERIOR_COLLIDERS[interior] ?? CRYPT_COLLIDERS, x - ox, z - oz, false);
+  }
+  const grid = gridFor(seed);
+  const list = grid.cells.get(`${Math.floor(x / GRID_CELL)},${Math.floor(z / GRID_CELL)}`);
+  return list ? overlapsAny(list, x, z, true) : false;
+}
+
 export function lineOfSightClear(
   seed: number,
   from: { x: number; z: number },
@@ -722,12 +767,16 @@ export function lineOfSightClear(
   const dz = to.z - from.z;
   const d = Math.hypot(dx, dz);
   if (d < 1e-6) return true;
+  // The sight line runs eye-to-eye: lerp the endpoint eye heights per sample so
+  // a low prop only blocks when its top actually crosses the line.
+  const eyeFrom = groundHeight(from.x, from.z, seed) + SIGHT_HEIGHT;
+  const eyeTo = groundHeight(to.x, to.z, seed) + SIGHT_HEIGHT;
   const steps = Math.max(2, Math.ceil(d / 0.5));
   for (let i = 1; i < steps; i++) {
     const t = i / steps;
     const x = from.x + dx * t;
     const z = from.z + dz * t;
-    if (isBlocked(seed, x, z, r)) return false;
+    if (sightBlockedAt(seed, x, z, r, eyeFrom + (eyeTo - eyeFrom) * t)) return false;
   }
   return true;
 }

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -16,6 +16,7 @@ import {
   LAKE,
   MOBS,
   NPCS,
+  PROPS,
   QUESTS,
   zoneAt,
   zoneWelcomeText,
@@ -1840,6 +1841,23 @@ describe('spell visuals', () => {
 
     expect(p.castingAbility).toBe('fireball');
     expect(events.some((e) => e.type === 'castStart' && e.ability === 'fireball')).toBe(true);
+  });
+
+  it('a LOW prop (campfire) no longer blocks spell line of sight, buildings still do', () => {
+    const sim = makeSim('mage');
+    const seed = sim.cfg.seed;
+    // Straddle a world campfire: its collider sits on the ray (it still blocks
+    // MOVEMENT below), but its visual top (1.45) is under the eye line (1.6),
+    // so the cast sees straight over it.
+    const [cx, cz] = PROPS.campfires[0];
+    expect(isBlocked(seed, cx, cz, 0.5)).toBe(true); // movement still collides
+    expect(lineOfSightClear(seed, { x: cx - 3, z: cz }, { x: cx + 3, z: cz })).toBe(true);
+    // A building straddled through its center still blocks (top far above eyes).
+    const b = PROPS.buildings[0];
+    const span = b.w + b.d;
+    expect(lineOfSightClear(seed, { x: b.x - span, z: b.z }, { x: b.x + span, z: b.z })).toBe(
+      false,
+    );
   });
 
   it('ranged auto shot does not fire through dungeon walls', () => {


### PR DESCRIPTION
## Problem

Standing behind the spawn campfire and healing an ally in front of it fails with 'no line of sight': the LoS ray is pure 2D, so ANY movement collider blocks a cast regardless of how low it is. A knee-high fire pit blocks a heal exactly like a chapel wall.

## Fix

The ray now runs eye-to-eye: SIGHT_HEIGHT (1.6) above each endpoint's ground, lerped per sample along the segment. An open-world obstacle blocks only when its visual top rises above the sight line, reusing the SAME precomputed cameraTopY the chase-camera occlusion has always used (no new data, no drift between what you see and what blocks).

- Casts over: campfires (top 1.45), crates (1.35), small rocks (1.25 x scale).
- Still blocks: buildings, trees, tents, fences, mud huts, ruin columns, wells, editor-placed assets, and every interior/delve/arena wall set plus editor blocker walls (no known top = the conservative always-block default).
- MOVEMENT collision is untouched everywhere: the fire still stops you walking through it, it just stops eating your heals.
- Symmetric by construction: mobs, pets, and players all resolve LoS through this one function, on all three hosts.

## Testing

- New cases in tests/fixes.test.ts against the real world data: a straddled campfire keeps blocking movement but clears sight; a straddled building still blocks sight. The existing dungeon-wall LoS pair (blocked through the wall, clear through the passage) stays green, pinning that walls still deny casts.
- The parity gate passes untouched (no golden drift: no existing scenario's combat crossed a low prop), plus architecture and the delve collider suites; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)