### PR TITLE
fix(server): decode request bodies once to preserve split UTF-8

### DIFF
--- a/server/http_util.ts
+++ b/server/http_util.ts
@@ -59,17 +59,24 @@ export function readBody(
   maxBytes = DEFAULT_JSON_BODY_MAX_BYTES,
 ): Promise<any> {
   return new Promise((resolve, reject) => {
-    let data = '';
+    // Collect raw bytes and decode ONCE at the end. Concatenating each chunk onto
+    // a string (`data += c`) decodes every chunk independently, which mangles a
+    // multi-byte UTF-8 character split across a chunk boundary into replacement
+    // characters. Same buffer-then-decode-once strategy as readBinaryBody; the cap
+    // ordering here matches the old readBody (push the chunk, then check the cap),
+    // not readBinaryBody (which rejects before pushing an over-cap chunk).
+    const chunks: Buffer[] = [];
     let bytes = 0;
     let aborted = false;
     req.on('data', (c: Buffer | string) => {
       if (aborted) return;
-      bytes += typeof c === 'string' ? Buffer.byteLength(c) : c.byteLength;
-      data += c;
+      const chunk = typeof c === 'string' ? Buffer.from(c) : c;
+      bytes += chunk.byteLength;
+      chunks.push(chunk);
       if (bytes > maxBytes) {
         // Rejecting the promise does not pause the socket, so without
         // destroying the request a client could keep streaming unbounded
-        // data into `data`. Stop reading and ignore any further chunks.
+        // data into memory. Stop reading and ignore any further chunks.
         aborted = true;
         req.destroy();
         reject(new Error('body too large'));
@@ -77,6 +84,7 @@ export function readBody(
     });
     req.on('end', () => {
       if (aborted) return;
+      const data = Buffer.concat(chunks).toString('utf8');
       try {
         // Every route reads properties off the body, so only a JSON object is
         // a valid request body: a literal null, an array, or a primitive is

--- a/tests/http_util.test.ts
+++ b/tests/http_util.test.ts
@@ -38,6 +38,25 @@ describe('readBody', () => {
     await expect(promise).rejects.toThrow('bad json');
   });
 
+  it('decodes a multi-byte UTF-8 character split across two chunks', async () => {
+    // A 4-byte emoji plus CJK/accented text inside a JSON string. TCP/HTTP can
+    // split a chunk mid-character; decoding each chunk to a string independently
+    // corrupts the boundary character into replacement chars. The body must be
+    // buffered and decoded once.
+    const obj = { name: 'Ünïcödé \u{1F409} 名前' };
+    const buf = Buffer.from(JSON.stringify(obj), 'utf8');
+    const dragon = buf.indexOf(0xf0); // first byte of the 4-byte emoji
+    expect(dragon).toBeGreaterThan(-1); // pin the mid-character split (guard vs a future ASCII-only payload)
+    const first = buf.subarray(0, dragon + 2); // split INSIDE the emoji
+    const second = buf.subarray(dragon + 2);
+    const req = fakeReq();
+    const promise = readBody(req);
+    req.emit('data', first);
+    req.emit('data', second);
+    req.emit('end');
+    await expect(promise).resolves.toEqual(obj);
+  });
+
   it('rejects non-object JSON bodies (null, arrays, primitives) as bad json', async () => {
     // A literal `null` body used to resolve, then crash route handlers on
     // property access (500); every route reads properties, so only an object


### PR DESCRIPTION
## Summary

Fixes a request-body corruption bug found in an audit. `readBody` accumulated each incoming chunk onto a JS string with `data += c`. When `c` is a `Buffer`, that calls `Buffer.toString()` (UTF-8) on **each chunk independently**, so a multi-byte UTF-8 character split across a chunk boundary (which routinely happens over TCP/HTTP) is decoded as two invalid halves and mangled into replacement characters (`U+FFFD`).

Any request body containing non-ASCII text — character/guild names, chat, emoji — could be corrupted when the bytes happened to split mid-character.

## Fix
Buffer the chunks and decode once at `end` with `Buffer.concat(chunks).toString('utf8')`, exactly mirroring the already-correct `readBinaryBody` in the same file. The byte cap, socket-destroy-on-overflow, and string-chunk tolerance are preserved.

## Type of change
- [x] Bug fix

## How was this tested?
- New regression test in `tests/http_util.test.ts`: emits a JSON body containing a 4-byte emoji + CJK/accented text as two chunks split **inside** the emoji, and asserts `readBody` resolves to the exact object. Fails before the fix (replacement chars), passes after.
- `npx tsc --noEmit` clean; `tests/http_util.test.ts` (17) and `tests/account_server.test.ts` (38, a heavy `readBody` consumer) green.
