### PR TITLE
fix(admin): require a full-scope token for the admin API

### DIFF
--- a/server/admin.ts
+++ b/server/admin.ts
@@ -47,6 +47,7 @@ import {
   type WordTier,
 } from './chat_filter_db';
 import {
+  accountAndScopeForToken,
   accountById,
   accountForToken,
   accountMailTarget,
@@ -55,6 +56,7 @@ import {
   pool,
   revokeTokensExcept,
   saveToken,
+  scopeAllowsMutation,
   setAccountDeactivated,
   touchLogin,
   updatePasswordHash,
@@ -225,12 +227,17 @@ interface AdminIdentity {
 async function adminIdentity(req: http.IncomingMessage): Promise<AdminIdentity | null> {
   const m = /^Bearer ([a-f0-9]{64})$/.exec(req.headers.authorization ?? '');
   if (!m) return null;
-  const accountId = await accountForToken(m[1]);
-  if (accountId === null) return null;
-  const staff = await adminRolesForAccount(accountId);
+  const info = await accountAndScopeForToken(m[1]);
+  if (!info) return null;
+  // The whole admin API is privileged reads + mutations, so a read-scoped token
+  // (an OAuth / companion-app token) must never reach it, even on a staff account.
+  // Require a full-session token, matching scopeAllowsMutation elsewhere, before the
+  // role lookup.
+  if (!scopeAllowsMutation(info.scope)) return null;
+  const staff = await adminRolesForAccount(info.accountId);
   if (staff === null) return null;
   return {
-    accountId,
+    accountId: info.accountId,
     username: staff.username,
     roles: staff.roles,
     permissions: permissionsForRoles(staff.roles),
@@ -1037,6 +1044,9 @@ function makeRealAdminDb() {
     moderationReportsForAccount,
     muteAccountChat,
     accountForToken,
+    // The pipeline admin gate (createRequireAdmin) reads token scope so a read-scoped
+    // companion token of a staff account is rejected, matching the legacy adminIdentity fix.
+    accountAndScopeForToken,
     accountMailTarget,
     findAccount,
     // Target-account staff check (the "admin accounts cannot be suspended / banned /

--- a/server/http/middleware/require_admin.ts
+++ b/server/http/middleware/require_admin.ts
@@ -3,8 +3,10 @@
 // mirroring the account-owner seam (require_owned.ts) but for the OPERATOR scope:
 //
 //  - createRequireAdmin(getDb): the admin-auth gate. It mirrors the legacy
-//    adminIdentity(req) resolver EXACTLY (server/admin.ts): resolve the 64-hex
-//    bearer, look up the account, require at least one staff role
+//    adminIdentity(req) resolver (server/admin.ts): resolve the 64-hex bearer,
+//    require a full-session token scope (a read-scoped companion/OAuth token of a
+//    staff account is rejected, since the admin API is all privileged mutations),
+//    then require at least one staff role
 //    (staff_db.adminRolesForAccount, fail closed; roles are re-read on every
 //    request so a dashboard revocation applies to the next call). On ANY failure
 //    (absent/bad token, unknown account, non-staff account) it writes the legacy
@@ -53,6 +55,7 @@
 
 import { type AdminPermission, permissionsForRoles } from '../../admin_permissions';
 import { adminPathKnown, permissionForAdminRoute } from '../../admin_routes';
+import { scopeAllowsMutation, type TokenScope } from '../../db';
 import { json } from '../../http_util';
 import { num } from '../schema';
 import type { Ctx, Middleware, Next, RouteMeta } from '../types';
@@ -88,11 +91,18 @@ export interface AdminIdentity {
 /**
  * The two db reads the admin gate needs, bundled so a unit test can inject a fake
  * with no Postgres. The shape mirrors the real server exports the legacy
- * adminIdentity(req) resolver calls (db.accountForToken, staff_db.adminRolesForAccount).
+ * adminIdentity(req) resolver calls (db.accountAndScopeForToken, staff_db.adminRolesForAccount).
  */
 export interface AdminAuthDb {
-  /** Account id for a live bearer token, or null (mirrors db.accountForToken). */
-  accountForToken(token: string): Promise<number | null>;
+  /**
+   * Account id + token scope for a live bearer token, or null (mirrors
+   * db.accountAndScopeForToken). A read-scoped companion / OAuth token of a staff
+   * account resolves here but the gate rejects it: the whole admin API is
+   * privileged mutations, so only a full-session token may pass.
+   */
+  accountAndScopeForToken(
+    token: string,
+  ): Promise<{ accountId: number; scope: TokenScope } | null>;
   /** Staff username + roles, or null when not staff (mirrors staff_db.adminRolesForAccount). */
   adminRolesForAccount(accountId: number): Promise<{ username: string; roles: string[] } | null>;
 }
@@ -109,9 +119,18 @@ export function createRequireAdmin(getDb: () => AdminAuthDb): Middleware {
   return async (ctx: Ctx, next: Next) => {
     const token = bearerToken(ctx.req);
     const db = getDb();
-    const accountId = token === null ? null : await db.accountForToken(token);
-    const staff = accountId === null ? null : await db.adminRolesForAccount(accountId);
-    if (accountId === null || staff === null) {
+    const info = token === null ? null : await db.accountAndScopeForToken(token);
+    // A read-scoped companion / OAuth token of a staff account must never reach the
+    // admin API (all privileged mutations). Reject on scope BEFORE the role lookup,
+    // matching scopeAllowsMutation elsewhere and the legacy adminIdentity resolver.
+    // This is prod-critical: API_DISPATCH=new (the default) runs this pipeline arm.
+    if (info === null || !scopeAllowsMutation(info.scope)) {
+      json(ctx.res, 401, ADMIN_AUTH_REQUIRED);
+      return;
+    }
+    const accountId = info.accountId;
+    const staff = await db.adminRolesForAccount(accountId);
+    if (staff === null) {
       json(ctx.res, 401, ADMIN_AUTH_REQUIRED);
       return;
     }
@@ -151,11 +170,9 @@ export function createRequireAdmin(getDb: () => AdminAuthDb): Middleware {
       return;
     }
 
-    // NOMINAL stamp, not the token's real scope: the legacy gate never scope-checks
-    // an admin bearer (accountForToken ignores the scope column, so a read-scope
-    // companion token of a staff account passes too, parity-first). Today's admin
-    // handlers read only ctxAccountId; do NOT trust ctx.account.scope downstream of
-    // requireAdmin for a scope decision without resolving the token's actual scope.
+    // Truthful now: the gate rejected any non-full token above, so only a full-session
+    // staff token reaches here. (Previously a nominal parity-first stamp that a
+    // read-scope companion token could sail through; that hole is now closed.)
     ctx.account = { accountId, scope: 'full' };
     ctx.state.set(ADMIN_IDENTITY, identity);
     await next();

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -4,18 +4,25 @@ import { isIP } from 'node:net';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the db layers so no Postgres is needed; the router logic is under test.
-vi.mock('../server/db', () => ({
-  pool: { query: vi.fn(async () => ({ rows: [] })) },
-  findAccount: vi.fn(),
-  touchLogin: vi.fn(),
-  saveToken: vi.fn(),
-  accountForToken: vi.fn(),
-  isAdminAccount: vi.fn(),
-  accountMailTarget: vi.fn(async () => null),
-  accountById: vi.fn(),
-  updatePasswordHash: vi.fn(),
-  revokeTokensExcept: vi.fn(),
-}));
+vi.mock('../server/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../server/db')>();
+  return {
+    pool: { query: vi.fn(async () => ({ rows: [] })) },
+    findAccount: vi.fn(),
+    touchLogin: vi.fn(),
+    saveToken: vi.fn(),
+    accountAndScopeForToken: vi.fn(),
+    accountForToken: vi.fn(),
+    // Pure policy: use the REAL implementation so the scope gate cannot drift from
+    // server/db.ts (the mock stays true if the policy ever changes).
+    scopeAllowsMutation: actual.scopeAllowsMutation,
+    isAdminAccount: vi.fn(),
+    accountMailTarget: vi.fn(async () => null),
+    accountById: vi.fn(),
+    updatePasswordHash: vi.fn(),
+    revokeTokensExcept: vi.fn(),
+  };
+});
 vi.mock('../server/admin_db', async () => {
   const actual = await vi.importActual<typeof import('../server/admin_db')>('../server/admin_db');
   return {
@@ -110,6 +117,7 @@ import {
   updateFilterConfig,
 } from '../server/chat_filter_db';
 import {
+  accountAndScopeForToken,
   accountById,
   accountForToken,
   accountMailTarget,
@@ -249,7 +257,7 @@ describe('admin api auth', () => {
   });
 
   it('rejects a valid token whose account is not an admin', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(false);
     const res = fakeRes();
 
@@ -259,8 +267,21 @@ describe('admin api auth', () => {
     expect(isAdminAccount).toHaveBeenCalledWith(7);
   });
 
+  it('rejects a read-scoped token even on an admin account', async () => {
+    // A read-scoped token (OAuth / companion app) on an admin's account must not
+    // reach the admin API. It is rejected on scope before any admin check runs.
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'read' });
+    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    const res = fakeRes();
+
+    await handleAdminApi(fakeReq({ token: VALID_TOKEN }), res, fakeGame);
+
+    expect(res.statusCode).toBe(401);
+    expect(isAdminAccount).not.toHaveBeenCalled();
+  });
+
   it('serves the overview to an admin token and includes live server stats', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(overviewCounts).mockResolvedValue({
       accounts: 10,
@@ -295,7 +316,7 @@ describe('admin api auth', () => {
   });
 
   it('serves persistent online history with cleaned range parameters', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(onlineHistory).mockResolvedValue({
       range: '7d',
@@ -328,7 +349,7 @@ describe('admin api auth', () => {
   });
 
   it('serves live suspicious players to an authenticated admin', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     fakeGame.suspiciousPlayers.mockReturnValue([
       {
@@ -365,7 +386,7 @@ describe('admin api auth', () => {
   });
 
   it('serves detection calibration histograms to an authenticated admin', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     fakeGame.detectionCalibration.mockReturnValue({
       schemaVersion: 1,
@@ -431,7 +452,7 @@ describe('admin api auth', () => {
   });
 
   it('rejects non-GET methods on data endpoints', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     const res = fakeRes();
     await handleAdminApi(
@@ -444,7 +465,7 @@ describe('admin api auth', () => {
   });
 
   it('returns 404 for unknown admin endpoints', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     const res = fakeRes();
 
@@ -454,7 +475,7 @@ describe('admin api auth', () => {
   });
 
   it('passes pagination and search through to the accounts query', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(listAccounts).mockResolvedValue({ rows: [], total: 0, page: 2, limit: 50 });
     const res = fakeRes();
@@ -470,7 +491,7 @@ describe('admin api auth', () => {
   });
 
   it('passes pagination, search, and sorting through to the characters query', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(listCharacters).mockResolvedValue({ rows: [], total: 0, page: 3, limit: 50 });
     const res = fakeRes();
@@ -489,7 +510,7 @@ describe('admin api auth', () => {
   });
 
   it('serves shared IPs with their current block state', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(listSharedIps).mockResolvedValue({
       rows: [
@@ -523,7 +544,7 @@ describe('admin api auth', () => {
   });
 
   it('serves online shared IPs from memory without querying session history', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     fakeGame.liveSharedIps.mockReturnValue([
       {
@@ -566,7 +587,7 @@ describe('admin api auth', () => {
   });
 
   it('serves grouped IP associations with normalized pagination', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(associationsForIp).mockResolvedValue({
       ip: '203.0.113.7',
@@ -608,7 +629,7 @@ describe('admin api auth', () => {
   });
 
   it('rejects an invalid IP association lookup', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     const res = fakeRes();
 
@@ -623,7 +644,7 @@ describe('admin api auth', () => {
   });
 
   it('serves the moderation queue to admins with online account context', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(moderationQueue).mockResolvedValue([
       {
@@ -653,7 +674,7 @@ describe('admin api auth', () => {
   });
 
   it('serves perf summaries and raw rows through existing admin auth', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(clientPerfSummary).mockResolvedValue({
       hours: 24,
@@ -703,7 +724,7 @@ describe('admin api auth', () => {
   });
 
   it('loads moderation account detail with open reports', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(accountDetail).mockResolvedValue({
       id: 9,
@@ -738,7 +759,7 @@ describe('admin api auth', () => {
   });
 
   it('includes the in-memory online state in account detail without another query', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(accountDetail).mockResolvedValue({
       id: 9,
@@ -772,7 +793,7 @@ describe('admin api auth', () => {
   });
 
   it('ignores an open report', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(ignoreReport).mockResolvedValue(true);
     const res = fakeRes();
@@ -793,7 +814,7 @@ describe('admin api auth', () => {
   });
 
   it('suspends and disconnects an account', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     vi.mocked(moderateAccount).mockResolvedValue();
     const res = fakeRes();
@@ -822,7 +843,7 @@ describe('admin api auth', () => {
   });
 
   it('bans and disconnects an account', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     vi.mocked(moderateAccount).mockResolvedValue();
     const res = fakeRes();
@@ -850,7 +871,7 @@ describe('admin api auth', () => {
   });
 
   it('mutes account chat and sends a live warning without disconnecting', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     vi.mocked(muteAccountChat).mockResolvedValue();
     const res = fakeRes();
@@ -879,7 +900,7 @@ describe('admin api auth', () => {
   });
 
   it('unbans without disconnecting the account', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(moderateAccount).mockResolvedValue();
     const res = fakeRes();
@@ -907,7 +928,7 @@ describe('admin api auth', () => {
   });
 
   it('unsuspends without disconnecting the account', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(moderateAccount).mockResolvedValue();
     const res = fakeRes();
@@ -936,7 +957,7 @@ describe('admin api auth', () => {
   });
 
   it('rejects suspending or banning admin accounts', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValueOnce(true).mockResolvedValueOnce(true);
     const res = fakeRes();
 
@@ -958,7 +979,7 @@ describe('admin api auth', () => {
   });
 
   it('forces a character rename and disconnects that account', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(forceCharacterRename).mockResolvedValue({ accountId: 9 });
     const res = fakeRes();
@@ -989,7 +1010,7 @@ describe('admin api auth', () => {
 
 describe('admin api chat filter', () => {
   beforeEach(() => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
   });
 
@@ -1116,7 +1137,7 @@ describe('admin api chat filter', () => {
   });
 
   it('lifts a mute and syncs the live session', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(liftAccountChatMute).mockResolvedValue();
     const res = fakeRes();
 
@@ -1238,7 +1259,7 @@ describe('escapeLike', () => {
 
 describe('blocked-ips admin route', () => {
   beforeEach(() => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(isAdminAccount).mockResolvedValue(true);
   });
 
@@ -1465,7 +1486,7 @@ describe('admin api password reset', () => {
 
 describe('admin api permissions', () => {
   const actAs = (roles: string[], accountId = 7) => {
-    vi.mocked(accountForToken).mockResolvedValue(accountId);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId, scope: 'full' });
     vi.mocked(adminRolesForAccount).mockResolvedValue({ username: 'operator', roles });
   };
 
@@ -1608,7 +1629,7 @@ describe('admin api permissions', () => {
     expect(res.body.error).toBe('you cannot change your own roles');
 
     // Superadmin target: refused even for another superadmin actor.
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(adminRolesForAccount).mockImplementation(async (id: number) =>
       id === 7
         ? { username: 'operator', roles: ['superadmin'] }
@@ -1623,7 +1644,7 @@ describe('admin api permissions', () => {
   });
 
   it('applies a valid role change through the audited writer', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(adminRolesForAccount).mockImplementation(async (id: number) =>
       id === 7 ? { username: 'operator', roles: ['superadmin'] } : null,
     );
@@ -1736,7 +1757,7 @@ describe('staff role change live effects', () => {
     fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/staff/roles', body });
 
   const actorAndTarget = () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
     vi.mocked(adminRolesForAccount).mockImplementation(async (id: number) =>
       id === 7
         ? { username: 'operator', roles: ['superadmin'] }

--- a/tests/server/admin.test.ts
+++ b/tests/server/admin.test.ts
@@ -86,7 +86,7 @@ const allowedRateLimit = (): ReturnType<NonNullable<AdminDbBundle['rateLimited']
 // target reads as a normal account). Extra reads are layered per test.
 function authedAdminDb(overrides: DbOverrides = {}): void {
   setDb({
-    accountForToken: async () => ADMIN_ACCOUNT_ID,
+    accountAndScopeForToken: async () => ({ accountId: ADMIN_ACCOUNT_ID, scope: 'full' as const }),
     adminRolesForAccount: async (id: number) =>
       id === ADMIN_ACCOUNT_ID ? { username: 'op', roles: ['superadmin'] } : null,
     isAdminAccount: async (id: number) => id === ADMIN_ACCOUNT_ID,
@@ -271,28 +271,44 @@ describe('admin envelope contract (frozen)', () => {
 
 describe('requireAdmin gate', () => {
   it('401s a missing bearer DB-free with the legacy admin body', async () => {
-    const accountForToken = vi.fn(async () => ADMIN_ACCOUNT_ID);
+    const accountAndScopeForToken = vi.fn(async () => ({ accountId: ADMIN_ACCOUNT_ID, scope: 'full' as const }));
     const adminRolesForAccount = vi.fn(async () => ({ username: 'op', roles: ['superadmin'] }));
-    setDb({ accountForToken, adminRolesForAccount });
+    setDb({ accountAndScopeForToken, adminRolesForAccount });
     installAdminRuntime();
     const r = await runRoute('GET', '/admin/api/overview');
     expect(r.status).toBe(401);
     expect(r.body).toEqual({ success: false, data: null, error: 'admin authentication required' });
     // A missing bearer never reaches the token lookup.
-    expect(accountForToken).not.toHaveBeenCalled();
+    expect(accountAndScopeForToken).not.toHaveBeenCalled();
   });
 
   it('401s a valid bearer whose account is NOT staff (no roles)', async () => {
-    setDb({ accountForToken: async () => 42, adminRolesForAccount: async () => null });
+    setDb({ accountAndScopeForToken: async () => ({ accountId: 42, scope: 'full' as const }), adminRolesForAccount: async () => null });
     installAdminRuntime();
     const r = await runRoute('GET', '/admin/api/overview', { headers: { authorization: BEARER } });
     expect(r.status).toBe(401);
     expect(r.body).toEqual({ success: false, data: null, error: 'admin authentication required' });
   });
 
+  it('401s a read-scoped token even on a staff account, before the role lookup (#1385)', async () => {
+    // A read-scoped companion / OAuth token of a staff account must never reach the
+    // admin API (all privileged mutations). The gate rejects on scope BEFORE the
+    // adminRolesForAccount lookup, so a read token never even resolves staff roles.
+    const adminRolesForAccount = vi.fn(async () => ({ username: 'op', roles: ['superadmin'] }));
+    setDb({
+      accountAndScopeForToken: async () => ({ accountId: ADMIN_ACCOUNT_ID, scope: 'read' as const }),
+      adminRolesForAccount,
+    });
+    installAdminRuntime();
+    const r = await runRoute('GET', '/admin/api/overview', { headers: { authorization: BEARER } });
+    expect(r.status).toBe(401);
+    expect(r.body).toEqual({ success: false, data: null, error: 'admin authentication required' });
+    expect(adminRolesForAccount).not.toHaveBeenCalled();
+  });
+
   it('401s a bearer that resolves to no account', async () => {
     setDb({
-      accountForToken: async () => null,
+      accountAndScopeForToken: async () => null,
       adminRolesForAccount: async () => ({ username: 'op', roles: ['superadmin'] }),
     });
     installAdminRuntime();
@@ -1987,7 +2003,7 @@ describe('reset-password RouteDef handler (accounts.password)', () => {
     // The actor holds accounts.password via the plain admin role, but the target
     // reads as staff (isAdminAccount true), so the reset is refused.
     setDb({
-      accountForToken: async () => ADMIN_ACCOUNT_ID,
+      accountAndScopeForToken: async () => ({ accountId: ADMIN_ACCOUNT_ID, scope: 'full' as const }),
       adminRolesForAccount: async (id: number) =>
         id === ADMIN_ACCOUNT_ID ? { username: 'op', roles: ['admin'] } : null,
       isAdminAccount: async () => true,
@@ -2012,7 +2028,7 @@ describe('reset-password RouteDef handler (accounts.password)', () => {
   it('is denied 403 by the central gate for a moderator (accounts.password not held)', async () => {
     const deps = resetDeps();
     setDb({
-      accountForToken: async () => ADMIN_ACCOUNT_ID,
+      accountAndScopeForToken: async () => ({ accountId: ADMIN_ACCOUNT_ID, scope: 'full' as const }),
       adminRolesForAccount: async () => ({ username: 'op', roles: ['moderator'] }),
       ...deps,
     });

--- a/tests/server/http/ownership_coverage.test.ts
+++ b/tests/server/http/ownership_coverage.test.ts
@@ -319,7 +319,7 @@ const ADMIN_VALIDATION_FAILED = { success: false, data: null, error: 'validation
 // so the gate's fail-closed staff check is the one that must refuse it.
 function installNonAdminDb(): void {
   setAdminDbForTests({
-    accountForToken: async () => NON_ADMIN_ACCOUNT_ID,
+    accountAndScopeForToken: async () => ({ accountId: NON_ADMIN_ACCOUNT_ID, scope: 'full' as const }),
     adminRolesForAccount: async () => null,
   });
 }
@@ -329,7 +329,7 @@ function installNonAdminDb(): void {
 // operator identity.
 function installAdminDb(): void {
   setAdminDbForTests({
-    accountForToken: async () => CALLER_ACCOUNT_ID,
+    accountAndScopeForToken: async () => ({ accountId: CALLER_ACCOUNT_ID, scope: 'full' as const }),
     adminRolesForAccount: async () => ({ username: 'op', roles: ['superadmin'] }),
   });
 }


### PR DESCRIPTION
## Summary

Security fix from an audit: the admin API ignored token **scope**. `adminAccountId` resolved the bearer token with `accountForToken` and gated only on `isAdminAccount`, so a **read-scoped** token (an OAuth / companion-app token minted for an admin's own account) could drive every admin mutation, bans, suspensions, chat-filter and config changes, account notes.

## Fix
Resolve the token with `accountAndScopeForToken` and reject anything that is not mutation-capable via the existing named policy `scopeAllowsMutation` (i.e. require a `full` session token) **before** the `isAdminAccount` check. Admin logins already issue `full` tokens, so legitimate admin use is unaffected; a `read` token now never reaches the admin API.

## Type of change
- [x] Bug fix (security)

## How was this tested?
- New test in `tests/admin.test.ts`: a read-scoped token on an admin account is rejected (401) and `isAdminAccount` is never called (scope is checked first).
- Existing admin-API suite updated to the scope-aware token mock; all 46 tests pass. `npx tsc --noEmit` clean.

## Notes for reviewers
- `scopeAllowsMutation` / `accountAndScopeForToken` are the same helpers `oauth.ts` already uses to gate mutation vs read; this brings the admin API in line with that single policy.
- The whole admin API is privileged, so requiring full scope for the entire surface (not per-route) is intentional; there is no admin route a read/companion token should reach.
