### PR TITLE
fix(server): cap in-flight pre-auth WebSocket sockets per IP

### DIFF
--- a/server/ip_block.ts
+++ b/server/ip_block.ts
@@ -61,3 +61,42 @@ export function isConnectionRefused(input: {
   if (input.isAdmin) return false;
   return input.blocked || input.ipSessions >= input.hardLimit;
 }
+
+// Per-IP cap on IN-FLIGHT pre-auth WebSocket sockets (upgraded but not yet joined
+// a game session). The existing session cap (isConnectionRefused / countIpSessions)
+// only counts ESTABLISHED sessions and is checked AFTER several DB lookups in the
+// auth handshake, so without this an IP could open many sockets and force those
+// lookups unbounded. A socket is acquired at the upgrade event and released when it
+// authenticates (becoming a counted session) or its socket closes/errors/times out.
+// Pure + unit-testable: no timers, no socket refs, just the per-IP tally.
+export class PreAuthConnections {
+  private counts = new Map<string, number>();
+  constructor(private readonly cap: number) {}
+
+  // Reserve a slot for `ip`. Returns false (and reserves nothing) when the IP is
+  // already at the cap, so the caller destroys the socket before the handshake.
+  tryAcquire(ip: string): boolean {
+    const n = this.counts.get(ip) ?? 0;
+    if (n >= this.cap) return false;
+    this.counts.set(ip, n + 1);
+    return true;
+  }
+
+  // Free a slot. Safe to call more than once for the same socket and when the IP
+  // has no reservation (never drives the tally negative); the caller guards
+  // once-per-socket, this guards the map.
+  release(ip: string): void {
+    const n = this.counts.get(ip);
+    if (n === undefined) return;
+    if (n <= 1) this.counts.delete(ip);
+    else this.counts.set(ip, n - 1);
+  }
+
+  countFor(ip: string): number {
+    return this.counts.get(ip) ?? 0;
+  }
+
+  get size(): number {
+    return this.counts.size;
+  }
+}

--- a/server/main.ts
+++ b/server/main.ts
@@ -124,7 +124,7 @@ import {
   readBody,
 } from './http_util';
 import { handleInternalApi } from './internal';
-import { isConnectionRefused } from './ip_block';
+import { isConnectionRefused, PreAuthConnections } from './ip_block';
 import { pruneExpiredBlockedIps } from './ip_block_db';
 import {
   MAX_MAP_SAVE_BYTES,
@@ -227,6 +227,11 @@ const ADMIN_ONLINE_SAMPLE_MS = 60_000;
 const TURNSTILE_SECRET = process.env.TURNSTILE_SECRET ?? '';
 // Hard WS connection limit per IP. Soft threshold (adds bot evidence) is in game.ts.
 const MAX_WS_PER_IP_HARD = Number(process.env.MAX_WS_PER_IP_HARD ?? '20');
+// Cap on concurrent in-flight PRE-AUTH sockets from one IP (upgraded but not yet
+// joined). Bounds the auth-handshake DB lookups an unauthenticated client can
+// force before the session cap applies. Set above MAX_WS_PER_IP_HARD so a legit
+// client reconnecting several characters is never caught by it.
+const MAX_WS_PREAUTH_PER_IP = Number(process.env.MAX_WS_PREAUTH_PER_IP ?? '30');
 // Each realm re-reads the blocklist on this interval so edits on another realm
 // process propagate and expired blocks fall out.
 const BLOCKED_IP_REFRESH_MS = 60_000;
@@ -1858,14 +1863,32 @@ async function main(): Promise<void> {
   // command; without this the ws default (~100 MiB) lets one socket force a
   // huge allocation + parse before any field-level validation runs
   const wss = new WebSocketServer({ noServer: true, maxPayload: 16 * 1024 });
+  const preAuth = new PreAuthConnections(MAX_WS_PREAUTH_PER_IP);
   server.on('upgrade', (req, socket, head) => {
     const url = new URL(req.url ?? '/', 'http://localhost');
     if (url.pathname !== '/ws') {
       socket.destroy();
       return;
     }
+    // Reserve a pre-auth slot for this IP BEFORE the handshake (and its DB
+    // lookups). Over the cap: drop the socket immediately. The slot is freed once,
+    // whichever comes first: the socket closes/errors, or it authenticates and
+    // becomes a counted session (release passed into onConnection).
+    const ip = requestMetadata(req).ip;
+    if (!preAuth.tryAcquire(ip)) {
+      socket.destroy();
+      return;
+    }
+    let released = false;
+    const release = () => {
+      if (released) return;
+      released = true;
+      preAuth.release(ip);
+    };
+    socket.on('close', release);
+    socket.on('error', release);
     wss.handleUpgrade(req, socket, head, (ws) => {
-      void onConnection(ws, req);
+      void onConnection(ws, req, release);
     });
   });
 
@@ -1873,6 +1896,7 @@ async function main(): Promise<void> {
     ws: WebSocket,
     raw: string,
     req: http.IncomingMessage,
+    onAuthenticated: () => void = () => {},
   ): Promise<void> {
     let msg: any;
     try {
@@ -1961,6 +1985,9 @@ async function main(): Promise<void> {
       return;
     }
     const session = result;
+    // Joined: this socket is now a counted session (countIpSessions), so free its
+    // pre-auth slot. The socket-close release is a no-op after this (idempotent).
+    onAuthenticated();
     console.log(`+ ${character.name} (${character.class}) joined — ${game.clients.size} online`);
     ws.on('message', (data) => {
       game.handleMessage(session, String(data));
@@ -1974,7 +2001,11 @@ async function main(): Promise<void> {
     });
   }
 
-  async function onConnection(ws: WebSocket, req: http.IncomingMessage): Promise<void> {
+  async function onConnection(
+    ws: WebSocket,
+    req: http.IncomingMessage,
+    onAuthenticated: () => void = () => {},
+  ): Promise<void> {
     const authTimer = setTimeout(() => {
       ws.send(JSON.stringify({ t: 'error', error: 'authentication timed out' }));
       ws.close();
@@ -2000,7 +2031,7 @@ async function main(): Promise<void> {
       // attached the permanent message handler. Without this the frames are
       // silently dropped (see ws_buffer.ts).
       const flush = bufferHandshakeMessages(ws);
-      void authenticateWebSocket(ws, String(data), req).finally(flush);
+      void authenticateWebSocket(ws, String(data), req, onAuthenticated).finally(flush);
     });
   }
 

--- a/tests/ip_block.test.ts
+++ b/tests/ip_block.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { IpBlockList, cleanIp, parseBlockExpiry, isConnectionRefused } from '../server/ip_block';
+import {
+  cleanIp,
+  IpBlockList,
+  isConnectionRefused,
+  PreAuthConnections,
+  parseBlockExpiry,
+} from '../server/ip_block';
 import { normalizeIp } from '../server/ratelimit';
 
 const NOW = 1_000_000;
@@ -38,7 +44,10 @@ describe('IpBlockList', () => {
 
   it('ignores empty IPs', () => {
     const list = new IpBlockList();
-    list.setEntries([{ ip: '', expiresAtMs: null }, { ip: '9.9.9.9', expiresAtMs: null }]);
+    list.setEntries([
+      { ip: '', expiresAtMs: null },
+      { ip: '9.9.9.9', expiresAtMs: null },
+    ]);
     expect(list.isBlocked('', NOW)).toBe(false);
     expect(list.size).toBe(1);
   });
@@ -104,17 +113,66 @@ describe('parseBlockExpiry', () => {
 
 describe('isConnectionRefused', () => {
   it('refuses a blocked non-admin', () => {
-    expect(isConnectionRefused({ blocked: true, isAdmin: false, ipSessions: 0, hardLimit: 20 })).toBe(true);
+    expect(
+      isConnectionRefused({ blocked: true, isAdmin: false, ipSessions: 0, hardLimit: 20 }),
+    ).toBe(true);
   });
 
   it('lets a blocked admin through (full bypass)', () => {
-    expect(isConnectionRefused({ blocked: true, isAdmin: true, ipSessions: 0, hardLimit: 20 })).toBe(false);
-    expect(isConnectionRefused({ blocked: true, isAdmin: true, ipSessions: 999, hardLimit: 20 })).toBe(false);
+    expect(
+      isConnectionRefused({ blocked: true, isAdmin: true, ipSessions: 0, hardLimit: 20 }),
+    ).toBe(false);
+    expect(
+      isConnectionRefused({ blocked: true, isAdmin: true, ipSessions: 999, hardLimit: 20 }),
+    ).toBe(false);
   });
 
   it('enforces the hard per-IP cap on non-admins', () => {
-    expect(isConnectionRefused({ blocked: false, isAdmin: false, ipSessions: 20, hardLimit: 20 })).toBe(true);
-    expect(isConnectionRefused({ blocked: false, isAdmin: false, ipSessions: 19, hardLimit: 20 })).toBe(false);
+    expect(
+      isConnectionRefused({ blocked: false, isAdmin: false, ipSessions: 20, hardLimit: 20 }),
+    ).toBe(true);
+    expect(
+      isConnectionRefused({ blocked: false, isAdmin: false, ipSessions: 19, hardLimit: 20 }),
+    ).toBe(false);
+  });
+});
+
+describe('PreAuthConnections', () => {
+  it('acquires up to the cap per IP, then refuses without reserving', () => {
+    const p = new PreAuthConnections(2);
+    expect(p.tryAcquire('1.1.1.1')).toBe(true);
+    expect(p.tryAcquire('1.1.1.1')).toBe(true);
+    expect(p.countFor('1.1.1.1')).toBe(2);
+    // Over the cap: refused, and the tally does not grow.
+    expect(p.tryAcquire('1.1.1.1')).toBe(false);
+    expect(p.countFor('1.1.1.1')).toBe(2);
+  });
+
+  it('caps each IP independently', () => {
+    const p = new PreAuthConnections(1);
+    expect(p.tryAcquire('1.1.1.1')).toBe(true);
+    expect(p.tryAcquire('2.2.2.2')).toBe(true); // different IP unaffected
+    expect(p.tryAcquire('1.1.1.1')).toBe(false);
+    expect(p.size).toBe(2);
+  });
+
+  it('release frees a slot and lets a new acquire through', () => {
+    const p = new PreAuthConnections(1);
+    expect(p.tryAcquire('1.1.1.1')).toBe(true);
+    expect(p.tryAcquire('1.1.1.1')).toBe(false);
+    p.release('1.1.1.1');
+    expect(p.countFor('1.1.1.1')).toBe(0);
+    expect(p.tryAcquire('1.1.1.1')).toBe(true);
+  });
+
+  it('never drives the tally negative and drops the IP key at zero', () => {
+    const p = new PreAuthConnections(3);
+    p.tryAcquire('1.1.1.1');
+    p.release('1.1.1.1');
+    p.release('1.1.1.1'); // extra release (idempotent caller double-fire) is a no-op
+    p.release('9.9.9.9'); // releasing an unknown IP is a no-op
+    expect(p.countFor('1.1.1.1')).toBe(0);
+    expect(p.size).toBe(0); // key removed at zero, no leak
   });
 });
 


### PR DESCRIPTION
## Summary

Security/DoS hardening from an audit. The `/ws` auth handshake performs several DB lookups (`accountForToken`, `moderationStatusForAccount`, `getCharacter`, `chatMuteStatusForAccount`) **before** the existing per-IP limit is reached, and that limit (`isConnectionRefused` / `countIpSessions`) only counts **established** sessions. So an unauthenticated client could open many `/ws` upgrades and force those lookups unbounded, with no pre-auth cap.

## Fix
Add a per-IP cap on concurrent **in-flight pre-auth** sockets:
- Reserved at the `upgrade` event, **before** `handleUpgrade` and the handshake. Over the cap → the socket is destroyed immediately.
- Released exactly once, whichever comes first: the socket closes/errors/times out (10s auth timeout), or it authenticates and becomes a counted session (so the pre-auth tally tracks only unauthenticated sockets; established sessions are covered by the existing session cap).
- The tally is a small, pure, unit-tested `PreAuthConnections` helper in `server/ip_block.ts` (never goes negative, drops the IP key at zero — no leak), mirroring the existing pure `isConnectionRefused` there.
- Cap is `MAX_WS_PREAUTH_PER_IP` (default 30), set above `MAX_WS_PER_IP_HARD` (20) so a legitimate client reconnecting several characters is never caught by it.

## Type of change
- [x] Bug fix (security / DoS hardening)

## How was this tested?
- New unit tests for `PreAuthConnections` in `tests/ip_block.test.ts`: acquire up to the cap then refuse without reserving, per-IP independence, release frees a slot, and release never goes negative / drops the key at zero (24 tests in the file pass).
- `npx tsc --noEmit` clean; `npm run build:server` clean (the `main.ts` wiring bundles).

## Notes for reviewers
- The release is idempotent and attached to the raw `socket` `close`/`error` (so it fires even if `handleUpgrade` fails before a `ws` exists) plus the auth-success path. I couldn't add a full upgrade-path integration test (no WS-upgrade harness in the suite), so the coverage is on the pure counter + the lifecycle is wired to fire on every terminal path; a manual review of the release points is worthwhile.
