### PR TITLE
fix(ui): combo pips vanished, a merge resurrected the old target-frame combo row

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,7 +238,6 @@
         <div class="bar" id="tf-resource"><div class="bar-fill" id="tf-res"></div><div class="bar-text" id="tf-res-text"></div></div>
         <div class="uf-discord" id="tf-discord"></div>
         <div id="tf-castbar" role="progressbar" aria-valuemin="0" aria-valuemax="100" data-i18n-aria="hudChrome.castBar.targetAria" aria-label="Unit Cast Bar"><div class="fill"></div><div class="label"></div><div class="timer"></div></div>
-        <div class="combo-row" id="combo-row"></div>
       </div>
       <div class="uf-buffs" id="tf-debuffs"></div>
     </div>

--- a/play.html
+++ b/play.html
@@ -187,7 +187,6 @@
         <div class="bar hp"><div class="bar-fill" id="tf-hp"></div><div class="bar-absorb" id="tf-absorb"></div><div class="bar-text" id="tf-hp-text"></div></div>
         <div class="bar" id="tf-resource"><div class="bar-fill" id="tf-res"></div><div class="bar-text" id="tf-res-text"></div></div>
         <div id="tf-castbar" role="progressbar" aria-valuemin="0" aria-valuemax="100" data-i18n-aria="hudChrome.castBar.targetAria" aria-label="Unit Cast Bar"><div class="fill"></div><div class="label"></div><div class="timer"></div></div>
-        <div class="combo-row" id="combo-row"></div>
       </div>
       <div class="uf-buffs" id="tf-debuffs"></div>
     </div>


### PR DESCRIPTION
## What

Combo points no longer show on the player frame: the pips silently paint into an invisible stale row instead.

## Why

The character-bound combo rework (#1367) moved #combo-row from the target frame to the player frame. A later merge reintroduced the OLD target-frame row in index.html and play.html, so the id now appears twice. The HUD painter resolves #combo-row to the FIRST match in document order (the stale target-frame one), so the pips paint there while the visible player-frame row stays empty.

## Fix

Drop the stale target-frame row from both entries; the player-frame row is the only #combo-row again.

## Testing

- Real-browser check with a rogue: exactly one #combo-row in the DOM, inside #player-frame, driven by the painter.
- client_shell and combo_points suites green (70 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)