### PR TITLE
tooling(ci): embed PR screenshots inline, and only for visual changes

### DIFF
--- a/.github/workflows/pr-ai.yml
+++ b/.github/workflows/pr-ai.yml
@@ -5,9 +5,10 @@ name: PR AI assist
 # review, it does not gate merge. Lives in its own workflow so it never interferes with
 # the CI gate in ci.yml.
 #
-#   screenshots        boots the Vite dev client headless, runs a fixed offline tour
-#                       (character select, desktop HUD, mobile HUD), uploads the PNGs as
-#                       an artifact, and links them in a sticky PR comment.
+#   screenshots        boots the Vite dev client headless and, ONLY when the diff has a
+#                       visual change, renders the sections it touches (a mapped window, or
+#                       the in-world HUD for a generic visual change), then embeds the PNGs
+#                       inline in a sticky PR comment. A non-visual diff captures nothing.
 #   ai-review           reviews the PR diff with the OpenAI Codex CLI, authenticated via
 #                       ChatGPT OAuth (the CODEX_AUTH_JSON secret holds a `codex login`
 #                       auth.json), and posts the review as a sticky PR comment. The
@@ -48,6 +49,12 @@ jobs:
   screenshots:
     name: Screenshots of changes
     runs-on: ubuntu-latest
+    # contents:write so the embedded screenshots can be uploaded to the bot-owned asset
+    # branch; pull-requests:write to post the comment. A fork PR still gets a read-only
+    # token, so both degrade to a no-op (the scripts handle it) and never block.
+    permissions:
+      contents: write
+      pull-requests: write
     # issue_comment fires this workflow on every comment on any issue or PR; without this
     # guard the full checkout + npm ci + Vite boot + puppeteer run would fire on every
     # comment too, even though nothing in this job reads the comment.
@@ -92,9 +99,9 @@ jobs:
             sleep 2
           done
 
-      # Change-aware capture: map the diff to the screens it implies (inventory, world
-      # map, ...). Only on pull_request; otherwise pr_screenshots falls back to the fixed
-      # tour. pr.diff is gitignored.
+      # Change-aware capture: map the diff to the sections it touches (inventory, world map,
+      # or the in-world HUD for a generic visual change) and shoot only those. A diff with no
+      # visual change captures nothing. pr.diff is gitignored.
       - name: Compute PR diff (for change-aware capture)
         if: github.event_name == 'pull_request'
         env:
@@ -113,23 +120,13 @@ jobs:
         if: always()
         run: kill "$(cat .devpid)" 2>/dev/null || true
 
-      - name: Upload screenshots
-        id: upload
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr-screenshots
-          path: pr-shots/
-          if-no-files-found: warn
-
-      - name: Comment with screenshot link
+      # Host the PNGs on the bot asset branch and embed them inline in a sticky comment.
+      - name: Embed screenshots in a comment
         if: always() && github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SHOTS_DIR: pr-shots
         run: node scripts/pr_comment_shots.mjs
 

--- a/docs/ai-pr-bot.md
+++ b/docs/ai-pr-bot.md
@@ -7,17 +7,26 @@ them is a required check.
 ## What it does
 
 1. **Screenshots of changes** (`screenshots` job). Boots the Vite dev client headless on
-   a runner (software GL via SwiftShader, no GPU needed) and captures PNGs of the relevant
-   screens. The frames are uploaded as the `pr-screenshots` artifact and linked from a
-   sticky PR comment. Two modes (`scripts/pr_screenshots.mjs`):
-   - **Change-aware** (when a diff is available): it maps the changed paths to the screens
-     they imply and shoots exactly those, cropped to the relevant region. A change under
-     `src/ui/bags*` captures the inventory window; a change under `src/sim/content/zones*`
-     (or the map/terrain renderer) teleports to a landmark and captures the world map. The
-     target registry (which paths imply which screen, and how to bring it up + clip it)
-     lives in `scripts/pr_shot_targets.mjs`; add coverage with one entry there.
-   - **Fixed tour** (no diff or no matched target): a consistent baseline, character
-     select, desktop HUD, mobile HUD. Keep all recipes offline and quick.
+   a runner (software GL via SwiftShader, no GPU needed) and, only when the diff has a
+   visual change, captures PNGs of the sections it touches, then **embeds them inline** in a
+   sticky PR comment (no artifact to download). The capture plan comes from the diff alone
+   (`scripts/pr_screenshots.mjs` + the classifier in `scripts/pr_shot_targets.mjs`):
+   - **Specific windows**: a change under `src/ui/bags*` captures the inventory window; a
+     change under `src/sim/content/zones*` (or the map/terrain renderer) teleports to a
+     landmark and captures the world map, each cropped to that window. The target registry
+     (which paths imply which screen, and how to bring it up + clip it) lives in
+     `scripts/pr_shot_targets.mjs`; add coverage with one entry there.
+   - **Generic HUD**: a visual change that maps to no specific window (renderer, HUD chrome,
+     CSS) captures the in-world desktop HUD, plus the mobile HUD when the change touches the
+     mobile/responsive surface (`hud.mobile`, `play.html`, touch controls).
+   - **Nothing**: a backend/data/i18n-only diff is not visual, so it captures no frames and
+     posts no screenshots. There is no fixed tour of unrelated screens.
+
+   Inline embedding needs a URL GitHub can fetch (artifacts are not embeddable and markdown
+   does not render `data:` URIs), so `scripts/gh_image_host.mjs` uploads each PNG to a
+   bot-owned orphan branch (`bot-pr-screenshots`) via the REST API and references its raw
+   URL. This needs the job's `contents: write` permission; on a fork PR the token is
+   read-only, so it degrades to a note instead of broken image links.
 2. **AI review** (`ai-review` job). Reviews the PR diff with the OpenAI Codex CLI,
    authenticated with a ChatGPT account via OAuth (no API key), and posts a short review
    as a sticky PR comment, grouped into Correctness / Invariants / Tests / Nits with
@@ -92,7 +101,8 @@ The screenshots job sends nothing to a third party; it only renders your own cli
 Pull requests from forks get a read-only `GITHUB_TOKEN` and cannot read repo secrets on
 the `pull_request` trigger. Both comment steps and the automatic AI review degrade to a
 no-op there (the scripts detect the missing write access / auth and skip), so the workflow
-never errors on a fork PR. Screenshots are still captured and uploaded as an artifact.
+never errors on a fork PR. Screenshots are still captured, but with a read-only token they
+cannot be hosted for inline embedding, so the comment shows a short note instead.
 
 The on-demand `/review` and `/suggest` comment trigger is different: `issue_comment`
 always runs with full repo secrets, regardless of whether the PR is from a fork. It is
@@ -100,13 +110,15 @@ still safe against a fork PR because the job never checks out or runs the PR's o
 and because it is gated on the commenter's `author_association` with this repo, not with
 the PR's origin (see "Requesting a review on demand" above).
 
-## Running the screenshot tour locally
+## Running the screenshot capture locally
 
 ```sh
 npm run dev                       # serves the client on :5173
-BROWSER_PATH=/path/to/chrome \
-  node scripts/pr_screenshots.mjs # writes PNGs into pr-shots/
+git diff --no-color origin/main > pr.diff   # the change to classify
+BROWSER_PATH=/path/to/chrome DIFF_FILE=pr.diff \
+  node scripts/pr_screenshots.mjs # writes PNGs into pr-shots/ (none if not visual)
 ```
 
-`BROWSER_PATH` is only needed if no Chrome/Edge/Chromium is on a standard path
-(see `scripts/browser_path.mjs`).
+The capture is diff-driven: with no `DIFF_FILE` (or a diff that changes nothing visual)
+it captures nothing. `BROWSER_PATH` is only needed if no Chrome/Edge/Chromium is on a
+standard path (see `scripts/browser_path.mjs`), and only when there is something to shoot.

--- a/scripts/gh_image_host.mjs
+++ b/scripts/gh_image_host.mjs
@@ -1,0 +1,130 @@
+// Host PR screenshots so they can be embedded inline in a comment. GitHub Actions
+// artifacts are not embeddable as images, and markdown does not render data: URIs, so the
+// only way to show a picture in the comment is a URL GitHub can fetch. This uploads each
+// PNG to a dedicated orphan branch via the REST API and returns its raw.githubusercontent
+// URL, which renders in markdown on a public repo.
+//
+// Best-effort and non-blocking: on a fork PR the Actions token is read-only, so the branch
+// create / file upload 403s; callers get an empty list back and simply post no images.
+//
+// Needs a token with contents:write (set the screenshots job's permissions accordingly).
+// No npm deps: Node 18+ global fetch only.
+
+const DEFAULT_BRANCH = 'bot-pr-screenshots';
+
+function ghHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+  };
+}
+
+// Create the assets branch as an orphan (no repo files, just a README) if it does not
+// exist yet. Returns true when the branch is present and writable, false otherwise.
+async function ensureBranch({ api, repo, branch, headers }) {
+  const refRes = await fetch(`${api}/repos/${repo}/git/ref/heads/${branch}`, { headers });
+  if (refRes.ok) return true;
+  if (refRes.status !== 404) {
+    console.log(`[gh_image_host] cannot read branch ${branch} (HTTP ${refRes.status}); skipping.`);
+    return false;
+  }
+
+  const readme = Buffer.from(
+    'Bot-managed branch holding rendered PR screenshots for inline comment embedding.\n' +
+      'Files live under pr-<number>/<run-id>/. Safe to prune; regenerated on the next PR run.\n',
+    'utf8',
+  ).toString('base64');
+
+  const blob = await fetch(`${api}/repos/${repo}/git/blobs`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ content: readme, encoding: 'base64' }),
+  });
+  if (!blob.ok) {
+    console.log(`[gh_image_host] blob create failed (HTTP ${blob.status}); skipping embedding.`);
+    return false;
+  }
+  const blobSha = (await blob.json()).sha;
+
+  const tree = await fetch(`${api}/repos/${repo}/git/trees`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      tree: [{ path: 'README.md', mode: '100644', type: 'blob', sha: blobSha }],
+    }),
+  });
+  if (!tree.ok) return false;
+  const treeSha = (await tree.json()).sha;
+
+  const commit = await fetch(`${api}/repos/${repo}/git/commits`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      message: 'init pr-screenshots asset branch',
+      tree: treeSha,
+      parents: [],
+    }),
+  });
+  if (!commit.ok) return false;
+  const commitSha = (await commit.json()).sha;
+
+  const ref = await fetch(`${api}/repos/${repo}/git/refs`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: commitSha }),
+  });
+  // A concurrent run may have created it first (422); treat that as success.
+  if (!ref.ok && ref.status !== 422) {
+    console.log(`[gh_image_host] branch create failed (HTTP ${ref.status}); skipping embedding.`);
+    return false;
+  }
+  return true;
+}
+
+// Upload the given PNG files and return [{ name, url }] with a raw URL per uploaded image.
+// files is a list of basenames present in `dir`. Paths are keyed by PR number and run id so
+// each run gets fresh, immutable URLs (no CDN-cache staleness between pushes).
+export async function uploadScreenshots({
+  files,
+  readFile,
+  prNumber,
+  runId,
+  token = process.env.GITHUB_TOKEN,
+  repo = process.env.GITHUB_REPOSITORY,
+  api = process.env.GITHUB_API_URL ?? 'https://api.github.com',
+  rawBase = process.env.GITHUB_RAW_BASE ?? 'https://raw.githubusercontent.com',
+  branch = DEFAULT_BRANCH,
+}) {
+  if (!token || !repo || !prNumber || !files?.length) return [];
+  const headers = ghHeaders(token);
+
+  if (!(await ensureBranch({ api, repo, branch, headers }))) return [];
+
+  const uploaded = [];
+  for (const name of files) {
+    try {
+      const content = readFile(name).toString('base64');
+      const path = `pr-${prNumber}/${runId ?? 'latest'}/${name}`;
+      const put = await fetch(`${api}/repos/${repo}/contents/${path}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({
+          message: `pr-${prNumber}: ${name}`,
+          content,
+          branch,
+        }),
+      });
+      if (!put.ok) {
+        console.log(`[gh_image_host] upload ${name} failed (HTTP ${put.status}); skipping it.`);
+        continue;
+      }
+      const encodedPath = path.split('/').map(encodeURIComponent).join('/');
+      uploaded.push({ name, url: `${rawBase}/${repo}/${branch}/${encodedPath}` });
+    } catch (e) {
+      console.log(`[gh_image_host] upload ${name} errored (${e.message}); skipping it.`);
+    }
+  }
+  return uploaded;
+}

--- a/scripts/gh_sticky_comment.mjs
+++ b/scripts/gh_sticky_comment.mjs
@@ -23,7 +23,9 @@ function ghHeaders(token) {
 // Upsert a sticky comment. Returns 'created' | 'updated', or null when it could not
 // post (no token, no PR number, or a non-write token, e.g. a fork PR). Never throws on
 // a missing token so callers can stay non-blocking; real API errors do throw.
-export async function upsertStickyComment({ marker, body, prNumber, token, repo }) {
+// updateOnly: when true, edit an existing sticky but never create a new one (used to flip
+// a prior screenshot comment to a "no visual changes" note without spamming plain PRs).
+export async function upsertStickyComment({ marker, body, prNumber, token, repo, updateOnly }) {
   token = token ?? process.env.GITHUB_TOKEN;
   repo = repo ?? process.env.GITHUB_REPOSITORY;
   if (!token || !repo || !prNumber) {
@@ -52,6 +54,11 @@ export async function upsertStickyComment({ marker, body, prNumber, token, repo 
     });
     if (!res.ok) throw new Error(`PATCH comment failed: HTTP ${res.status} ${await res.text()}`);
     return 'updated';
+  }
+
+  if (updateOnly) {
+    // Nothing to edit and we were told not to create: stay silent.
+    return null;
   }
 
   const res = await fetch(`${API}/repos/${repo}/issues/${prNumber}/comments`, {

--- a/scripts/pr_comment_shots.mjs
+++ b/scripts/pr_comment_shots.mjs
@@ -1,57 +1,97 @@
-// Posts (or updates) a sticky PR comment pointing at the screenshot artifact produced
-// by pr_screenshots.mjs. GitHub Actions artifacts are not directly embeddable as images
-// in a comment, so this links the downloadable artifact and lists which frames it holds.
-// Best-effort and non-blocking: it never fails the job.
+// Posts (or updates) a sticky PR comment that EMBEDS the screenshots pr_screenshots.mjs
+// captured, inline, so a reviewer sees them without downloading anything. The PNGs are
+// uploaded to a bot-owned orphan branch (gh_image_host.mjs) and referenced by their raw
+// URL. Best-effort and non-blocking: it never fails the job.
+//
+// When the capture step found no visual change (nothing captured), it posts nothing on a
+// fresh PR, and flips an existing screenshot comment to a short "no visual changes" note
+// so a stale gallery never lingers after a later non-visual push.
 //
 // Env (set by the workflow):
-//   GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER   standard Actions context
-//   ARTIFACT_URL   download URL of the uploaded screenshots artifact (optional)
-//   RUN_URL        link to the workflow run (fallback when ARTIFACT_URL is absent)
-//   SHOTS_DIR      directory holding manifest.json (default pr-shots)
+//   GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER   standard Actions context (token needs
+//                                                contents:write to host the images)
+//   GITHUB_RUN_ID   run id, used to key the uploaded image paths (optional)
+//   SHOTS_DIR       directory holding manifest.json + the PNGs (default pr-shots)
 import fs from 'node:fs';
+import { uploadScreenshots } from './gh_image_host.mjs';
 import { upsertStickyComment } from './gh_sticky_comment.mjs';
 
 const MARKER = '<!-- pr-ai-screenshots -->';
 const OUT = process.env.SHOTS_DIR ?? 'pr-shots';
 const prNumber = process.env.PR_NUMBER;
+const runId = process.env.GITHUB_RUN_ID;
 
-let manifest = { captured: [], errors: [] };
+let manifest = { mode: 'no-visual', captured: [], errors: [] };
 try {
   manifest = JSON.parse(fs.readFileSync(`${OUT}/manifest.json`, 'utf8'));
 } catch {
   // No manifest means the capture step did not run or produced nothing.
 }
 
-const artifact = process.env.ARTIFACT_URL || process.env.RUN_URL || '';
-const list = manifest.captured.length
-  ? manifest.captured.map((f) => `- \`${f}\``).join('\n')
-  : '_No screenshots were captured for this run._';
+// Turn a captured file name into a readable caption ("01-hud-desktop.png" -> "hud desktop").
+function caption(file) {
+  return file
+    .replace(/\.png$/i, '')
+    .replace(/^\d+-/, '')
+    .replace(/[-_]/g, ' ');
+}
 
-const body = [
-  '## Screenshots of this change',
-  '',
-  artifact
-    ? `Download the rendered client screenshots: [**pr-screenshots** artifact](${artifact})`
-    : 'Screenshots were captured but no artifact link was available.',
-  '',
-  '<details><summary>Captured frames</summary>',
-  '',
-  list,
-  '',
-  '</details>',
-  '',
-  manifest.errors?.length
-    ? `<details><summary>Capture notes (${manifest.errors.length})</summary>\n\n\`\`\`\n${manifest.errors.join('\n')}\n\`\`\`\n\n</details>`
-    : '',
-  '',
-  '<sub>Automated, non-blocking. Offline client tour (character select, desktop HUD, mobile HUD).</sub>',
-]
-  .filter((l) => l !== null)
-  .join('\n');
+const notes = manifest.errors?.length
+  ? `<details><summary>Capture notes (${manifest.errors.length})</summary>\n\n\`\`\`\n${manifest.errors.join('\n')}\n\`\`\`\n\n</details>`
+  : '';
 
-try {
+async function run() {
+  // No frames: do not spam a plain PR, but correct a prior gallery if one exists.
+  if (!manifest.captured?.length) {
+    const body = [
+      '## Screenshots of this change',
+      '',
+      'No visual changes detected in the latest commit, so no screenshots were captured.',
+      '',
+      '<sub>Automated, non-blocking. Shots are taken only for changes to the renderer, HUD/UI, styles, or client controls.</sub>',
+    ].join('\n');
+    const result = await upsertStickyComment({ marker: MARKER, body, prNumber, updateOnly: true });
+    console.log(`screenshot comment: ${result ?? 'skipped (no visual change, no prior comment)'}`);
+    return;
+  }
+
+  // Host the images, then embed whatever uploaded successfully.
+  const uploaded = await uploadScreenshots({
+    files: manifest.captured,
+    readFile: (name) => fs.readFileSync(`${OUT}/${name}`),
+    prNumber,
+    runId,
+  });
+
+  let gallery;
+  if (uploaded.length) {
+    gallery = uploaded
+      .map((u) => `**${caption(u.name)}**\n\n![${caption(u.name)}](${u.url})`)
+      .join('\n\n');
+  } else {
+    // Upload path unavailable (for example a fork PR's read-only token): degrade to a note
+    // rather than posting broken image links.
+    gallery = '_Screenshots were captured but could not be hosted for inline embedding._';
+  }
+
+  const body = [
+    '## Screenshots of this change',
+    '',
+    gallery,
+    '',
+    notes,
+    '',
+    '<sub>Automated, non-blocking. Offline client render of the sections this diff touches.</sub>',
+  ]
+    .filter((l) => l !== '')
+    .join('\n');
+
   const result = await upsertStickyComment({ marker: MARKER, body, prNumber });
   console.log(`screenshot comment: ${result ?? 'skipped'}`);
+}
+
+try {
+  await run();
 } catch (e) {
   // Non-blocking: a comment failure must not fail the screenshots job.
   console.log(`screenshot comment failed (non-blocking): ${e.message}`);

--- a/scripts/pr_screenshots.mjs
+++ b/scripts/pr_screenshots.mjs
@@ -2,47 +2,69 @@
 // the change looks like. Offline only: it drives the local Vite dev client (no server, no
 // dev commands) through the shared offline entry flow and writes PNGs into SHOTS_DIR.
 //
-// Two modes:
-//   change-aware  When DIFF_FILE points at a unified diff, it maps the changed paths to the
-//                 screens they imply (see pr_shot_targets.mjs) and shoots exactly those:
-//                 a bag change -> the inventory window, a zone/map change -> the world map.
-//   fixed tour    With no diff (or no matched targets), it falls back to a consistent
-//                 baseline: character select, desktop HUD, mobile HUD.
+// Change-aware and visual-only. From the PR diff (DIFF_FILE) it decides WHAT to shoot:
+//   specific targets  a bag change -> the inventory window, a zone/map change -> the world
+//                      map (see pr_shot_targets.mjs), clipped to that window.
+//   generic HUD       a visual change with no specific window (renderer, HUD chrome, CSS)
+//                      -> the in-world desktop HUD, plus the mobile HUD when the change
+//                      touches the mobile/responsive surface.
+//   nothing           a backend/data/i18n-only diff is not visual, so it captures no frames
+//                      at all (the comment step then posts no screenshots).
+// There is no fixed tour: it never shoots unrelated parts of the game just to have something.
 //
 // Run locally:  npm run dev   (in another terminal, serves :5173)
 //               BROWSER_PATH=/path/to/chrome DIFF_FILE=pr.diff node scripts/pr_screenshots.mjs
 // Env:
 //   GAME_URL    client URL (default http://localhost:5173)
 //   SHOTS_DIR   output directory for PNGs (default pr-shots)
-//   DIFF_FILE   optional unified diff; enables change-aware capture
+//   DIFF_FILE   unified diff; required for capture (no diff -> nothing is visual -> skip)
 //   BROWSER_PATH  Chrome/Edge/Chromium binary (see browser_path.mjs)
 import fs from 'node:fs';
 import puppeteer from 'puppeteer-core';
-import { BROWSER_PATH } from './browser_path.mjs';
 import { enterOfflineGame } from './enter_offline_game.mjs';
-import { resolveTargets } from './pr_shot_targets.mjs';
+import { classifyDiff } from './pr_shot_targets.mjs';
 
 const URL = process.env.GAME_URL ?? 'http://localhost:5173';
 const OUT = process.env.SHOTS_DIR ?? 'pr-shots';
 const DIFF_FILE = process.env.DIFF_FILE;
 fs.mkdirSync(OUT, { recursive: true });
 
-// Resolve change-aware targets from the diff, when one is provided.
-let targets = [];
+// Classify the diff into a capture plan. With no diff, nothing is treated as visual.
+let plan = { specific: [], generic: [], isVisual: false };
 if (DIFF_FILE) {
   try {
     const diff = fs.readFileSync(DIFF_FILE, 'utf8');
     const files = [...diff.matchAll(/^\+\+\+ b\/(.+)$/gm)]
       .map((m) => m[1])
       .filter((p) => p !== '/dev/null');
-    targets = resolveTargets(files);
-    console.log(
-      `diff: ${files.length} changed file(s) -> targets: ${targets.map((t) => t.key).join(', ') || '(none, using fixed tour)'}`,
-    );
+    plan = classifyDiff(files);
+    const shooting = plan.specific.length
+      ? plan.specific.map((t) => t.key).join(', ')
+      : plan.generic.join(', ') || '(none, no visual change)';
+    console.log(`diff: ${files.length} changed file(s) -> shooting: ${shooting}`);
   } catch (e) {
     console.log(`could not read DIFF_FILE=${DIFF_FILE}: ${e.message}`);
   }
+} else {
+  console.log('no DIFF_FILE: nothing to classify, capturing nothing.');
 }
+
+const errors = [];
+const captured = [];
+
+// Nothing visual changed: write an empty manifest and exit clean. No browser launch.
+if (!plan.isVisual) {
+  fs.writeFileSync(
+    `${OUT}/manifest.json`,
+    JSON.stringify({ mode: 'no-visual', captured, errors }, null, 2),
+  );
+  console.log('no visual changes in this diff; captured 0 screenshots.');
+  process.exit(0);
+}
+
+// Resolve the browser lazily: the no-visual path above never needs one, and browser_path
+// throws at import when no binary is present.
+const { BROWSER_PATH } = await import('./browser_path.mjs');
 
 const browser = await puppeteer.launch({
   executablePath: BROWSER_PATH,
@@ -52,11 +74,8 @@ const browser = await puppeteer.launch({
   defaultViewport: { width: 1600, height: 900 },
 });
 
-const errors = [];
-const captured = [];
-
 // One guarded shot: a failure in one frame must not lose the others, so the run always
-// uploads whatever it managed to capture. `clip` is an optional CSS selector; when given
+// keeps whatever it managed to capture. `clip` is an optional CSS selector; when given
 // and found, the shot is cropped to that element (plus a small margin) instead of full frame.
 async function shoot(page, name, clip) {
   try {
@@ -100,7 +119,8 @@ function watch(page, tag) {
   });
 }
 
-async function changeAwareTour() {
+// Specific window targets: bring each one up in one desktop world and clip to it.
+async function shootSpecific(targets) {
   const page = await browser.newPage();
   watch(page, 'desktop');
   await page.goto(URL, { waitUntil: 'networkidle0', timeout: 60000 });
@@ -119,55 +139,54 @@ async function changeAwareTour() {
   await page.close();
 }
 
-async function fixedTour() {
-  // 1) Character-select landing (desktop): open the offline select so the class cards show.
-  const page = await browser.newPage();
-  watch(page, 'desktop');
-  await page.goto(URL, { waitUntil: 'networkidle0', timeout: 60000 });
-  await page.evaluate(() => document.querySelector('#btn-offline')?.click());
-  await page
-    .waitForSelector('#offline-select .mini-class', { visible: true, timeout: 15000 })
-    .catch(() => {});
-  await shoot(page, '01-character-select');
+// Generic HUD frames for a visual change that maps to no specific window: the in-world
+// desktop view, and the mobile view when the change touches the mobile/responsive surface.
+async function shootGenericHud(frames) {
+  let i = 1;
+  const next = () => String(i++).padStart(2, '0');
 
-  // 2) Desktop HUD in-world.
-  await enterOfflineGame(page, { charClass: 'warrior', charName: 'Thorgar', settleMs: 3000 });
-  await shoot(page, '02-hud-desktop');
-  await page.close();
+  if (frames.includes('hud-desktop')) {
+    const page = await browser.newPage();
+    watch(page, 'desktop');
+    await page.goto(URL, { waitUntil: 'networkidle0', timeout: 60000 });
+    await enterOfflineGame(page, { charClass: 'warrior', charName: 'Thorgar', settleMs: 3000 });
+    await shoot(page, `${next()}-hud-desktop`);
+    await page.close();
+  }
 
-  // 3) Mobile-viewport HUD (iPhone-class touch viewport).
-  try {
-    const mobile = await browser.newPage();
-    watch(mobile, 'mobile');
-    await mobile.emulate({
-      viewport: { width: 390, height: 844, isMobile: true, hasTouch: true, deviceScaleFactor: 2 },
-      userAgent:
-        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
-    });
-    await mobile.goto(URL, { waitUntil: 'networkidle0', timeout: 60000 });
-    await mobile.evaluate(() => document.body.classList.add('mobile-touch'));
-    await enterOfflineGame(mobile, { charClass: 'mage', charName: 'Aldwin', settleMs: 3000 });
-    await shoot(mobile, '03-hud-mobile');
-    await mobile.close();
-  } catch (e) {
-    errors.push(`MOBILE: ${e.message}`);
+  if (frames.includes('hud-mobile')) {
+    try {
+      const mobile = await browser.newPage();
+      watch(mobile, 'mobile');
+      await mobile.emulate({
+        viewport: { width: 390, height: 844, isMobile: true, hasTouch: true, deviceScaleFactor: 2 },
+        userAgent:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      });
+      await mobile.goto(URL, { waitUntil: 'networkidle0', timeout: 60000 });
+      await mobile.evaluate(() => document.body.classList.add('mobile-touch'));
+      await enterOfflineGame(mobile, { charClass: 'mage', charName: 'Aldwin', settleMs: 3000 });
+      await shoot(mobile, `${next()}-hud-mobile`);
+      await mobile.close();
+    } catch (e) {
+      errors.push(`MOBILE: ${e.message}`);
+    }
   }
 }
 
 try {
-  if (targets.length) await changeAwareTour();
-  else await fixedTour();
+  if (plan.specific.length) await shootSpecific(plan.specific);
+  else await shootGenericHud(plan.generic);
 } finally {
   await browser.close();
 }
 
 // Record the manifest so the comment step can list what was captured without re-reading.
-fs.writeFileSync(
-  `${OUT}/manifest.json`,
-  JSON.stringify({ mode: targets.length ? 'change-aware' : 'fixed', captured, errors }, null, 2),
-);
+const mode = plan.specific.length ? 'change-aware' : 'generic-hud';
+fs.writeFileSync(`${OUT}/manifest.json`, JSON.stringify({ mode, captured, errors }, null, 2));
 
 if (errors.length) console.log(`notes during capture:\n${errors.join('\n')}`);
 console.log(`captured ${captured.length} screenshot(s) into ${OUT}/`);
-// Non-zero only if we got nothing at all, so a partial run still uploads its frames.
+// Non-zero only if a visual change captured nothing at all, so a partial run still keeps
+// its frames while a total capture failure surfaces in the job log.
 process.exit(captured.length > 0 ? 0 : 1);

--- a/scripts/pr_shot_targets.mjs
+++ b/scripts/pr_shot_targets.mjs
@@ -80,3 +80,54 @@ export const TARGETS = [
 export function resolveTargets(changedFiles) {
   return TARGETS.filter((t) => changedFiles.some((f) => t.when.some((w) => f.includes(w))));
 }
+
+// Path prefixes/names that make a change "visual": the renderer, the HUD/UI, the extracted
+// CSS, local input/camera/mobile controls, and the two HTML shells. A change here can alter
+// what the client looks like even when it does not map to a specific window target above.
+const VISUAL_PREFIXES = ['src/render/', 'src/ui/', 'src/styles/', 'src/game/'];
+const VISUAL_FILES = ['index.html', 'play.html'];
+
+// Not visual even under those prefixes: the i18n text tables (labels are text, not layout),
+// and the test/doc files that sit alongside the code.
+function isTextOrTest(path) {
+  return (
+    path.includes('i18n') ||
+    path.includes('.test.') ||
+    path.startsWith('tests/') ||
+    path.endsWith('.md')
+  );
+}
+
+function isVisualPath(path) {
+  if (isTextOrTest(path)) return false;
+  if (VISUAL_FILES.includes(path)) return true;
+  return VISUAL_PREFIXES.some((p) => path.startsWith(p));
+}
+
+// A change touches the mobile/responsive surface: the mobile HUD CSS, the touch controls,
+// or the /play shell (which carries its own chrome and mobile layout).
+function isMobilePath(path) {
+  return path.includes('hud.mobile') || path.includes('mobile') || path.includes('play.html');
+}
+
+// Decide, from the changed files alone, WHAT to shoot:
+//   specific  the window targets the diff maps to (bags, world map, ...). Shot when non-empty.
+//   generic   fallback HUD frames ('hud-desktop', optionally 'hud-mobile') used only when the
+//             change is visual but maps to no specific window, so the reviewer still sees the
+//             in-world view the change lives in.
+//   isVisual  true when anything visual changed at all. When false, capture nothing: a
+//             backend/data/i18n-only diff gets no screenshots.
+// This is the whole "only shoot visual changes, and only the relevant sections" policy, kept
+// pure so it is unit-tested without a browser.
+export function classifyDiff(changedFiles) {
+  const specific = resolveTargets(changedFiles);
+  const visualFiles = changedFiles.filter(isVisualPath);
+  const isVisual = specific.length > 0 || visualFiles.length > 0;
+
+  let generic = [];
+  if (specific.length === 0 && visualFiles.length > 0) {
+    generic = ['hud-desktop'];
+    if (visualFiles.some(isMobilePath)) generic.push('hud-mobile');
+  }
+  return { specific, generic, isVisual };
+}

--- a/tests/pr_shot_targets.test.ts
+++ b/tests/pr_shot_targets.test.ts
@@ -1,0 +1,65 @@
+// Unit test for the PR-screenshot diff classifier. classifyDiff is the whole "shoot only
+// visual changes, and only the sections they touch" policy, kept pure so it needs no
+// browser. The .mjs script has no TS/browser imports at module load, so vitest can import
+// it directly.
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error - plain Node ESM script, no types
+import { classifyDiff, resolveTargets } from '../scripts/pr_shot_targets.mjs';
+
+describe('classifyDiff', () => {
+  it('treats a backend/data-only diff as non-visual (captures nothing)', () => {
+    const plan = classifyDiff(['server/game.ts', 'src/sim/spirit.ts', 'server/db.ts']);
+    expect(plan.isVisual).toBe(false);
+    expect(plan.specific).toHaveLength(0);
+    expect(plan.generic).toHaveLength(0);
+  });
+
+  it('maps a bags change to the inventory window target', () => {
+    const plan = classifyDiff(['src/ui/bags.ts']);
+    expect(plan.isVisual).toBe(true);
+    expect(plan.specific.map((t: { key: string }) => t.key)).toContain('inventory');
+    // A specific window was found, so no generic HUD fallback.
+    expect(plan.generic).toHaveLength(0);
+  });
+
+  it('maps a zone/terrain change to the world-map target', () => {
+    const plan = classifyDiff(['src/render/terrain.ts']);
+    expect(plan.specific.map((t: { key: string }) => t.key)).toContain('world-map');
+  });
+
+  it('falls back to the desktop HUD for a generic visual change', () => {
+    const plan = classifyDiff(['src/render/renderer.ts']);
+    expect(plan.isVisual).toBe(true);
+    expect(plan.specific).toHaveLength(0);
+    expect(plan.generic).toEqual(['hud-desktop']);
+  });
+
+  it('adds the mobile HUD when the visual change touches the mobile surface', () => {
+    const plan = classifyDiff(['src/styles/hud.mobile.css']);
+    expect(plan.generic).toEqual(['hud-desktop', 'hud-mobile']);
+  });
+
+  it('does not treat an i18n text-table change as visual', () => {
+    const plan = classifyDiff(['src/ui/i18n.catalog/hud_chrome.ts']);
+    expect(plan.isVisual).toBe(false);
+    expect(plan.generic).toHaveLength(0);
+  });
+
+  it('does not treat a UI test file as visual', () => {
+    const plan = classifyDiff(['tests/social_view.test.ts', 'src/ui/social_view.test.ts']);
+    expect(plan.isVisual).toBe(false);
+  });
+
+  it('prefers specific targets even when other generic-visual files also changed', () => {
+    const plan = classifyDiff(['src/ui/bags.ts', 'src/render/renderer.ts']);
+    expect(plan.specific.map((t: { key: string }) => t.key)).toContain('inventory');
+    expect(plan.generic).toHaveLength(0);
+  });
+
+  it('resolveTargets stays available and returns registry-ordered matches', () => {
+    const keys = resolveTargets(['src/ui/map_window.ts', 'src/ui/bags.ts']).map(
+      (t: { key: string }) => t.key,
+    );
+    expect(keys).toEqual(['inventory', 'world-map']);
+  });
+});


### PR DESCRIPTION
## Summary

Rework the PR screenshot bot so it (1) captures only when a change is actually visual and
only the sections it touches, and (2) embeds the frames inline in the sticky comment
instead of linking a downloadable artifact.

## Behavior

- **Visual-only, relevant-section capture.** A pure classifier (`classifyDiff` in
  `scripts/pr_shot_targets.mjs`) maps the changed-file list to:
  - specific windows (a bags change to the inventory window, a zone/terrain change to the
    world map), cropped to that window; or
  - a generic in-world HUD (desktop, plus mobile when the change touches the
    mobile/responsive surface) when the change is visual but maps to no specific window; or
  - nothing at all, for a backend/data/i18n-only diff.
  There is no fixed tour of unrelated screens anymore.
- **Inline embedding.** Artifacts are not embeddable and markdown does not render `data:`
  URIs, so `scripts/gh_image_host.mjs` uploads each PNG to a bot-owned orphan branch
  (`bot-pr-screenshots`) via the REST API and the comment references the raw URLs. The
  artifact upload is gone.
- Non-visual PRs post no screenshot comment; a prior gallery is flipped to a short "no
  visual changes" note via a new `updateOnly` option on the sticky-comment helper.

## Permissions and forks

The screenshots job gains `contents: write` (to host the images). On a fork PR the token
is read-only, so hosting and commenting degrade to a no-op / note, exactly as before.

## Tests and verification

- New unit test `tests/pr_shot_targets.test.ts` covers the classifier (backend-only,
  bags, zone, generic renderer, mobile CSS, i18n text, test files, precedence): 9 pass.
- Smoke-ran `pr_screenshots.mjs` locally on a non-visual diff: classifies as non-visual,
  captures nothing, exits 0, needs no browser (the browser import is now lazy).
- Smoke-ran `pr_comment_shots.mjs` with an empty manifest and no token: degrades cleanly.
- Biome clean on changed files; pre-push floor green.

The browser-driven capture mechanics (offline entry, clip, mobile emulation) are unchanged
from the previous script, so they keep their existing CI coverage; the new logic is the
pure classifier and the image host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
