### PR TITLE
feat(daily-rewards): halve repeated quest task rewards

### DIFF
--- a/server/daily_rewards.ts
+++ b/server/daily_rewards.ts
@@ -425,6 +425,11 @@ function questCompletionPoints(
   return { points: Math.max(0, Math.floor(basePoints * multiplier)), multiplier };
 }
 
+function repeatQuestPoints(points: number, priorCompletions: number): number {
+  if (points <= 0) return 0;
+  return Math.max(1, Math.floor(points / 2 ** Math.max(0, priorCompletions)));
+}
+
 function onlineMultiplierPoints(
   basePoints: number,
   config: Record<string, unknown>,
@@ -566,6 +571,7 @@ export class DailyRewardService {
 
   async recordQuestCompletion(
     accountId: number,
+    characterId: number | null,
     questId: string,
     completedAt: Date = new Date(),
   ): Promise<number> {
@@ -582,22 +588,32 @@ export class DailyRewardService {
     for (const task of tasks) {
       const { points, multiplier } = questCompletionPoints(task, onlineMinutes);
       if (points <= 0) continue;
+      const priorCompletions = await this.db.questTaskCompletionCount(
+        day,
+        accountId,
+        task.taskId,
+        questId,
+      );
+      const awarded = repeatQuestPoints(points, priorCompletions);
       const recorded = await this.db.addPoints(
         day,
         accountId,
         'task',
-        points,
-        `task:${task.taskId}:quest:${questId}`,
+        awarded,
+        `task:${task.taskId}:quest:${questId}:character:${characterId ?? 'account'}`,
         {
           taskId: task.taskId,
           taskType: task.type,
           questId,
+          characterId,
           onlineMinutes,
           multiplier,
           basePoints: task.basePoints,
+          undiscountedPoints: points,
+          repeatIndex: priorCompletions,
         },
       );
-      if (recorded) awardedPoints += points;
+      if (recorded) awardedPoints += awarded;
     }
     return awardedPoints;
   }

--- a/server/daily_rewards_db.ts
+++ b/server/daily_rewards_db.ts
@@ -66,6 +66,12 @@ export interface DailyRewardDb {
   tasksForType(day: string, type: string): Promise<DailyRewardTaskRow[]>;
   scoreForAccount(day: string, accountId: number): Promise<number>;
   onlineMinutesForAccount(day: string, accountId: number): Promise<number>;
+  questTaskCompletionCount(
+    day: string,
+    accountId: number,
+    taskId: string,
+    questId: string,
+  ): Promise<number>;
   rankForAccount(day: string, accountId: number): Promise<number | null>;
   leaderboard(day: string, accountId: number, limit: number): Promise<DailyRewardScoreRow[]>;
   leaderboardRowForAccount(day: string, accountId: number): Promise<DailyRewardScoreRow | null>;
@@ -283,6 +289,26 @@ export class PgDailyRewardDb implements DailyRewardDb {
       [day, REALM, accountId],
     );
     return Number(res.rows[0]?.minutes ?? 0);
+  }
+
+  async questTaskCompletionCount(
+    day: string,
+    accountId: number,
+    taskId: string,
+    questId: string,
+  ): Promise<number> {
+    const res = await pool.query(
+      `SELECT COUNT(*) AS completions
+         FROM daily_reward_events
+        WHERE day = $1
+          AND realm = $2
+          AND account_id = $3
+          AND kind = 'task'
+          AND meta->>'taskId' = $4
+          AND meta->>'questId' = $5`,
+      [day, REALM, accountId, taskId, questId],
+    );
+    return Number(res.rows[0]?.completions ?? 0);
   }
 
   async rankForAccount(day: string, accountId: number): Promise<number | null> {

--- a/server/game.ts
+++ b/server/game.ts
@@ -2380,7 +2380,7 @@ export class GameServer {
           const afterDone = sim.meta(pid)?.questsDone.has(msg.quest) ?? false;
           if (!beforeDone && afterDone) {
             void dailyRewardService
-              .recordQuestCompletion(session.accountId, msg.quest)
+              .recordQuestCompletion(session.accountId, session.characterId, msg.quest)
               .then((points) => {
                 if (points > 0) this.sendDailyRewardPointsGained(session, points);
               })

--- a/tests/daily_rewards.test.ts
+++ b/tests/daily_rewards.test.ts
@@ -76,6 +76,17 @@ class FakeDailyRewardDb implements DailyRewardDb {
   async onlineMinutesForAccount(): Promise<number> {
     return this.events.filter((event) => event.kind === 'online').length;
   }
+  async questTaskCompletionCount(
+    _day: string,
+    _accountId: number,
+    taskId: string,
+    questId: string,
+  ): Promise<number> {
+    return this.events.filter(
+      (event) =>
+        event.kind === 'task' && event.meta.taskId === taskId && event.meta.questId === questId,
+    ).length;
+  }
   async rankForAccount(): Promise<number | null> {
     return this.score > 0 ? 1 : null;
   }
@@ -323,16 +334,53 @@ describe('daily rewards', () => {
         new Date(`2026-06-30T12:${String(minute).padStart(2, '0')}:00.000Z`),
       );
     }
-    await service.recordQuestCompletion(1, 'wolf_hunt', new Date('2026-06-30T13:00:00.000Z'));
-    await service.recordQuestCompletion(1, 'wolf_hunt', new Date('2026-06-30T13:01:00.000Z'));
+    await service.recordQuestCompletion(1, 101, 'wolf_hunt', new Date('2026-06-30T13:00:00.000Z'));
+    await service.recordQuestCompletion(1, 102, 'wolf_hunt', new Date('2026-06-30T13:01:00.000Z'));
     const taskEvents = db.events.filter((event) => event.kind === 'task');
-    expect(taskEvents).toHaveLength(1);
+    expect(taskEvents).toHaveLength(2);
     expect(taskEvents[0]).toMatchObject({
       points: 30,
-      key: 'task:quest_completion:quest:wolf_hunt',
-      meta: { questId: 'wolf_hunt', onlineMinutes: 60, multiplier: 3, basePoints: 10 },
+      key: 'task:quest_completion:quest:wolf_hunt:character:101',
+      meta: {
+        questId: 'wolf_hunt',
+        characterId: 101,
+        onlineMinutes: 60,
+        multiplier: 3,
+        basePoints: 10,
+        undiscountedPoints: 30,
+        repeatIndex: 0,
+      },
     });
-    expect(db.score).toBe(30);
+    expect(taskEvents[1]).toMatchObject({
+      points: 15,
+      key: 'task:quest_completion:quest:wolf_hunt:character:102',
+      meta: {
+        questId: 'wolf_hunt',
+        characterId: 102,
+        onlineMinutes: 60,
+        multiplier: 3,
+        basePoints: 10,
+        undiscountedPoints: 30,
+        repeatIndex: 1,
+      },
+    });
+    expect(db.score).toBe(45);
+  });
+
+  it('halves repeated quest task points per account down to one point', async () => {
+    const db = new FakeDailyRewardDb();
+    const service = new DailyRewardService(db);
+    await service.ensureActiveDay('2026-06-30');
+
+    await service.recordQuestCompletion(1, 101, 'wolf_hunt', new Date('2026-06-30T13:00:00.000Z'));
+    await service.recordQuestCompletion(1, 102, 'wolf_hunt', new Date('2026-06-30T13:01:00.000Z'));
+    await service.recordQuestCompletion(1, 103, 'wolf_hunt', new Date('2026-06-30T13:02:00.000Z'));
+    await service.recordQuestCompletion(1, 104, 'wolf_hunt', new Date('2026-06-30T13:03:00.000Z'));
+    await service.recordQuestCompletion(1, 105, 'wolf_hunt', new Date('2026-06-30T13:04:00.000Z'));
+
+    const points = db.events.filter((event) => event.kind === 'task').map((event) => event.points);
+    expect(points).toEqual([10, 5, 2, 1, 1]);
+    expect(db.score).toBe(19);
   });
 
   it('awards arena task points using win/loss base points and the online-time multiplier', async () => {


### PR DESCRIPTION
## Summary
- allow repeated quest daily reward completions per account by making quest task idempotency character-scoped
- halve repeated rewards for the same account/task/quest, flooring whole points down to a minimum of 1
- track repeat metadata on task events and add DB-backed repeat counting
- update daily rewards tests for repeated quest rewards

## Tests
- npx @biomejs/biome check --write server/daily_rewards.ts server/daily_rewards_db.ts server/game.ts tests/daily_rewards.test.ts
- npx vitest run tests/daily_rewards.test.ts
- npm run check:ts