### PR TITLE
tooling(ci): rework the PR AI bot: verifying Codex reviewer + inline visual-only screenshots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -203,3 +203,9 @@ WIKI_URL=http://localhost:8080/wiki/index.php/Main_Page
 # variable in CI, or from this file for a local run (ambient env always wins). Leave it
 # unset to use the Codex CLI's default model.
 #CODEX_MODEL=gpt-5-codex
+# Sandbox mode for the reviewer agent: workspace-write locally (it runs tsc/vitest, which
+# write caches); CI overrides to danger-full-access because the hosted runner VM is the
+# isolation boundary and the kernel sandbox is unreliable there.
+#CODEX_SANDBOX=workspace-write
+# Model reasoning effort for the review (default high).
+#CODEX_EFFORT=high

--- a/.github/workflows/pr-ai.yml
+++ b/.github/workflows/pr-ai.yml
@@ -5,9 +5,10 @@ name: PR AI assist
 # review, it does not gate merge. Lives in its own workflow so it never interferes with
 # the CI gate in ci.yml.
 #
-#   screenshots        boots the Vite dev client headless, runs a fixed offline tour
-#                       (character select, desktop HUD, mobile HUD), uploads the PNGs as
-#                       an artifact, and links them in a sticky PR comment.
+#   screenshots        boots the Vite dev client headless and, ONLY when the diff has a
+#                       visual change, renders the sections it touches (a mapped window, or
+#                       the in-world HUD for a generic visual change), then embeds the PNGs
+#                       inline in a sticky PR comment. A non-visual diff captures nothing.
 #   ai-review           reviews the PR diff with the OpenAI Codex CLI, authenticated via
 #                       ChatGPT OAuth (the CODEX_AUTH_JSON secret holds a `codex login`
 #                       auth.json), and posts the review as a sticky PR comment. The
@@ -48,6 +49,12 @@ jobs:
   screenshots:
     name: Screenshots of changes
     runs-on: ubuntu-latest
+    # contents:write so the embedded screenshots can be uploaded to the bot-owned asset
+    # branch; pull-requests:write to post the comment. A fork PR still gets a read-only
+    # token, so both degrade to a no-op (the scripts handle it) and never block.
+    permissions:
+      contents: write
+      pull-requests: write
     # issue_comment fires this workflow on every comment on any issue or PR; without this
     # guard the full checkout + npm ci + Vite boot + puppeteer run would fire on every
     # comment too, even though nothing in this job reads the comment.
@@ -92,9 +99,9 @@ jobs:
             sleep 2
           done
 
-      # Change-aware capture: map the diff to the screens it implies (inventory, world
-      # map, ...). Only on pull_request; otherwise pr_screenshots falls back to the fixed
-      # tour. pr.diff is gitignored.
+      # Change-aware capture: map the diff to the sections it touches (inventory, world map,
+      # or the in-world HUD for a generic visual change) and shoot only those. A diff with no
+      # visual change captures nothing. pr.diff is gitignored.
       - name: Compute PR diff (for change-aware capture)
         if: github.event_name == 'pull_request'
         env:
@@ -113,23 +120,13 @@ jobs:
         if: always()
         run: kill "$(cat .devpid)" 2>/dev/null || true
 
-      - name: Upload screenshots
-        id: upload
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr-screenshots
-          path: pr-shots/
-          if-no-files-found: warn
-
-      - name: Comment with screenshot link
+      # Host the PNGs on the bot asset branch and embed them inline in a sticky comment.
+      - name: Embed screenshots in a comment
         if: always() && github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SHOTS_DIR: pr-shots
         run: node scripts/pr_comment_shots.mjs
 

--- a/.github/workflows/pr-ai.yml
+++ b/.github/workflows/pr-ai.yml
@@ -205,10 +205,13 @@ jobs:
     # SECURITY TRADEOFF, deliberate: this job checks out and exercises the PR's own code
     # (i18n:gen, and the tests the agent runs) in a job that holds CODEX_AUTH_JSON, so a
     # maintainer typing /review on a fork PR is explicitly opting in to running that
-    # fork's code. Mitigations: npm ci --ignore-scripts (no third-party install hooks),
-    # the raw secret is scrubbed from the agent's child environment (ai_review.mjs), and
-    # GITHUB_TOKEN carries only contents:read + pull-requests:write. Skim a fork PR's
-    # diff before requesting a review on it.
+    # fork's code. Mitigations: the REVIEWER SCRIPTS run from a trusted default-branch
+    # checkout while the PR head sits in a separate pr/ tree (so a fork cannot swap
+    # ai_review.mjs itself and read the secret), npm ci --ignore-scripts (no third-party
+    # install hooks), the raw secret is scrubbed from the agent's child environment
+    # (ai_review.mjs), and GITHUB_TOKEN carries only contents:read + pull-requests:write.
+    # Residual risk: code the agent chooses to execute (the PR's tests) runs inside the
+    # job; skim a fork PR's diff before requesting a review on it.
     if: >
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
@@ -216,32 +219,42 @@ jobs:
       (startsWith(github.event.comment.body, '/review') || startsWith(github.event.comment.body, '/suggest'))
     timeout-minutes: 35
     steps:
-      # The PR head, so the agent verifies the change against the real tree (the same
-      # reason the automatic job does).
+      # Trusted copy of the reviewer tooling: the default branch of the base repo. The
+      # secret-holding step below runs scripts from HERE, never from the PR's tree.
+      - name: Check out trusted reviewer code
+        uses: actions/checkout@v6
+
+      # The PR head, in its own subdirectory: the tree the agent verifies (and whose
+      # tests it may run), kept apart from the code that handles the secret.
       - name: Check out the PR head
         uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
           fetch-depth: 0
+          path: pr
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
+          cache-dependency-path: pr/package-lock.json
 
       - name: Install the Codex CLI
         run: npm install -g @openai/codex
 
-      - name: Install dependencies
+      - name: Install PR dependencies
+        working-directory: pr
         run: npm ci --ignore-scripts
 
       - name: Generate i18n artifacts
+        working-directory: pr
         run: npm run i18n:gen
 
       # The issue_comment payload has no base/head SHAs; resolve them so the agent can
       # read the full diff via git.
       - name: Resolve the PR base and head
+        working-directory: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -256,6 +269,8 @@ jobs:
           CODEX_MODEL: ${{ vars.CODEX_MODEL }}
           # Same rationale as the automatic job: the runner VM is the isolation boundary.
           CODEX_SANDBOX: danger-full-access
+          # The agent works inside the PR tree; the script itself is the trusted copy.
+          REVIEW_CWD: ${{ github.workspace }}/pr
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/pr-ai.yml
+++ b/.github/workflows/pr-ai.yml
@@ -8,17 +8,20 @@ name: PR AI assist
 #   screenshots        boots the Vite dev client headless, runs a fixed offline tour
 #                       (character select, desktop HUD, mobile HUD), uploads the PNGs as
 #                       an artifact, and links them in a sticky PR comment.
-#   ai-review           reviews the PR diff with the OpenAI Codex CLI, authenticated via
+#   ai-review           reviews the PR with the OpenAI Codex CLI, authenticated via
 #                       ChatGPT OAuth (the CODEX_AUTH_JSON secret holds a `codex login`
 #                       auth.json), and posts the review as a sticky PR comment. The
-#                       agent runs sandboxed read-only. No-ops without the secret (for
-#                       example on a fork PR), so it never blocks.
+#                       agent gets the PR HEAD checked out with dependencies installed
+#                       and is required to VERIFY before writing: read the tree, run
+#                       npx tsc --noEmit, run the vitest files covering the change.
+#                       No-ops without the secret (for example on a fork PR), so it
+#                       never blocks.
 #   ai-review-comment   on demand: an OWNER/MEMBER/COLLABORATOR comments `/review` or
-#                       `/suggest <focus>` on the PR. Fetches the diff itself via the
-#                       GitHub API (no checkout of the PR head, so this stays safe to run
-#                       with repo secrets even against a fork PR) and posts a fresh reply
-#                       comment, keyed to the triggering comment rather than the sticky
-#                       review above.
+#                       `/suggest <focus>` on the PR. Same verifying setup as ai-review
+#                       (PR-head checkout + deps), posting a fresh reply comment keyed
+#                       to the triggering comment rather than the sticky review above.
+#                       Running a fork PR's code here is a deliberate maintainer opt-in;
+#                       see the security note on the job.
 #
 # Setup (one time): run `codex login` locally and store ~/.codex/auth.json in the
 # CODEX_AUTH_JSON repo secret to enable ai-review. Optionally set a CODEX_MODEL repo
@@ -137,20 +140,35 @@ jobs:
     name: AI review (Codex)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    timeout-minutes: 20
+    timeout-minutes: 35
     steps:
-      - name: Check out repository
+      # The PR HEAD itself (not the merge ref): the agent reviews and runs exactly what
+      # the contributor wrote, and BASE_SHA/HEAD_SHA below match this tree.
+      - name: Check out the PR head
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: npm
 
       - name: Install the Codex CLI
         run: npm install -g @openai/codex
+
+      # Mount the project for real verification: the agent runs tsc and targeted vitest
+      # against the PR's own tree. --ignore-scripts skips third-party install hooks (the
+      # only dep with one, esbuild, works via its optionalDependencies binary), so no
+      # lifecycle script from a dependency bump ever runs in this job.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # The client and several tests import committed-but-derived i18n tables.
+      - name: Generate i18n artifacts
+        run: npm run i18n:gen
 
       - name: Compute PR diff
         env:
@@ -164,10 +182,16 @@ jobs:
         env:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           CODEX_MODEL: ${{ vars.CODEX_MODEL }}
+          # The GitHub-hosted runner VM is the isolation boundary; the kernel sandbox
+          # (Landlock) is not reliably available there and used to abort every
+          # inspection command before it ran.
+          CODEX_SANDBOX: danger-full-access
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           DIFF_FILE: pr.diff
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node scripts/ai_review.mjs
 
   ai-review-comment:
@@ -177,28 +201,61 @@ jobs:
     # /suggest, from someone with write access to THIS repo. author_association is
     # evaluated against the base repo regardless of whether the PR itself is from a
     # fork, so a fork PR's own author cannot self-trigger this on their own comment.
+    #
+    # SECURITY TRADEOFF, deliberate: this job checks out and exercises the PR's own code
+    # (i18n:gen, and the tests the agent runs) in a job that holds CODEX_AUTH_JSON, so a
+    # maintainer typing /review on a fork PR is explicitly opting in to running that
+    # fork's code. Mitigations: npm ci --ignore-scripts (no third-party install hooks),
+    # the raw secret is scrubbed from the agent's child environment (ai_review.mjs), and
+    # GITHUB_TOKEN carries only contents:read + pull-requests:write. Skim a fork PR's
+    # diff before requesting a review on it.
     if: >
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
       (startsWith(github.event.comment.body, '/review') || startsWith(github.event.comment.body, '/suggest'))
-    timeout-minutes: 20
+    timeout-minutes: 35
     steps:
-      - name: Check out repository
+      # The PR head, so the agent verifies the change against the real tree (the same
+      # reason the automatic job does).
+      - name: Check out the PR head
         uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: npm
 
       - name: Install the Codex CLI
         run: npm install -g @openai/codex
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Generate i18n artifacts
+        run: npm run i18n:gen
+
+      # The issue_comment payload has no base/head SHAs; resolve them so the agent can
+      # read the full diff via git.
+      - name: Resolve the PR base and head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BASE_REF="$(gh pr view "${{ github.event.issue.number }}" --json baseRefName --jq .baseRefName)"
+          git fetch origin "$BASE_REF"
+          echo "BASE_SHA=$(git merge-base "origin/$BASE_REF" HEAD)" >> "$GITHUB_ENV"
+          echo "HEAD_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
 
       - name: Review with Codex
         env:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           CODEX_MODEL: ${{ vars.CODEX_MODEL }}
+          # Same rationale as the automatic job: the runner VM is the isolation boundary.
+          CODEX_SANDBOX: danger-full-access
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}

--- a/docs/ai-pr-bot.md
+++ b/docs/ai-pr-bot.md
@@ -7,17 +7,26 @@ them is a required check.
 ## What it does
 
 1. **Screenshots of changes** (`screenshots` job). Boots the Vite dev client headless on
-   a runner (software GL via SwiftShader, no GPU needed) and captures PNGs of the relevant
-   screens. The frames are uploaded as the `pr-screenshots` artifact and linked from a
-   sticky PR comment. Two modes (`scripts/pr_screenshots.mjs`):
-   - **Change-aware** (when a diff is available): it maps the changed paths to the screens
-     they imply and shoots exactly those, cropped to the relevant region. A change under
-     `src/ui/bags*` captures the inventory window; a change under `src/sim/content/zones*`
-     (or the map/terrain renderer) teleports to a landmark and captures the world map. The
-     target registry (which paths imply which screen, and how to bring it up + clip it)
-     lives in `scripts/pr_shot_targets.mjs`; add coverage with one entry there.
-   - **Fixed tour** (no diff or no matched target): a consistent baseline, character
-     select, desktop HUD, mobile HUD. Keep all recipes offline and quick.
+   a runner (software GL via SwiftShader, no GPU needed) and, only when the diff has a
+   visual change, captures PNGs of the sections it touches, then **embeds them inline** in a
+   sticky PR comment (no artifact to download). The capture plan comes from the diff alone
+   (`scripts/pr_screenshots.mjs` + the classifier in `scripts/pr_shot_targets.mjs`):
+   - **Specific windows**: a change under `src/ui/bags*` captures the inventory window; a
+     change under `src/sim/content/zones*` (or the map/terrain renderer) teleports to a
+     landmark and captures the world map, each cropped to that window. The target registry
+     (which paths imply which screen, and how to bring it up + clip it) lives in
+     `scripts/pr_shot_targets.mjs`; add coverage with one entry there.
+   - **Generic HUD**: a visual change that maps to no specific window (renderer, HUD chrome,
+     CSS) captures the in-world desktop HUD, plus the mobile HUD when the change touches the
+     mobile/responsive surface (`hud.mobile`, `play.html`, touch controls).
+   - **Nothing**: a backend/data/i18n-only diff is not visual, so it captures no frames and
+     posts no screenshots. There is no fixed tour of unrelated screens.
+
+   Inline embedding needs a URL GitHub can fetch (artifacts are not embeddable and markdown
+   does not render `data:` URIs), so `scripts/gh_image_host.mjs` uploads each PNG to a
+   bot-owned orphan branch (`bot-pr-screenshots`) via the REST API and references its raw
+   URL. This needs the job's `contents: write` permission; on a fork PR the token is
+   read-only, so it degrades to a note instead of broken image links.
 2. **AI review** (`ai-review` job). Reviews the PR diff with the OpenAI Codex CLI,
    authenticated with a ChatGPT account via OAuth (no API key), and posts a short review
    as a sticky PR comment, grouped into Correctness / Invariants / Tests / Nits with
@@ -92,7 +101,8 @@ The screenshots job sends nothing to a third party; it only renders your own cli
 Pull requests from forks get a read-only `GITHUB_TOKEN` and cannot read repo secrets on
 the `pull_request` trigger. Both comment steps and the automatic AI review degrade to a
 no-op there (the scripts detect the missing write access / auth and skip), so the workflow
-never errors on a fork PR. Screenshots are still captured and uploaded as an artifact.
+never errors on a fork PR. Screenshots are still captured, but with a read-only token they
+cannot be hosted for inline embedding, so the comment shows a short note instead.
 
 The on-demand `/review` and `/suggest` comment trigger is different: `issue_comment`
 always runs with full repo secrets, regardless of whether the PR is from a fork. It is
@@ -100,13 +110,15 @@ still safe against a fork PR because the job never checks out or runs the PR's o
 and because it is gated on the commenter's `author_association` with this repo, not with
 the PR's origin (see "Requesting a review on demand" above).
 
-## Running the screenshot tour locally
+## Running the screenshot capture locally
 
 ```sh
 npm run dev                       # serves the client on :5173
-BROWSER_PATH=/path/to/chrome \
-  node scripts/pr_screenshots.mjs # writes PNGs into pr-shots/
+git diff --no-color origin/main > pr.diff   # the change to classify
+BROWSER_PATH=/path/to/chrome DIFF_FILE=pr.diff \
+  node scripts/pr_screenshots.mjs # writes PNGs into pr-shots/ (none if not visual)
 ```
 
-`BROWSER_PATH` is only needed if no Chrome/Edge/Chromium is on a standard path
-(see `scripts/browser_path.mjs`).
+The capture is diff-driven: with no `DIFF_FILE` (or a diff that changes nothing visual)
+it captures nothing. `BROWSER_PATH` is only needed if no Chrome/Edge/Chromium is on a
+standard path (see `scripts/browser_path.mjs`), and only when there is something to shoot.

--- a/docs/ai-pr-bot.md
+++ b/docs/ai-pr-bot.md
@@ -18,22 +18,29 @@ them is a required check.
      lives in `scripts/pr_shot_targets.mjs`; add coverage with one entry there.
    - **Fixed tour** (no diff or no matched target): a consistent baseline, character
      select, desktop HUD, mobile HUD. Keep all recipes offline and quick.
-2. **AI review** (`ai-review` job). Reviews the PR diff with the OpenAI Codex CLI,
-   authenticated with a ChatGPT account via OAuth (no API key), and posts a short review
-   as a sticky PR comment, grouped into Correctness / Invariants / Tests / Nits with
-   severity tags. Codex runs as an agent with READ-ONLY access to the checkout (sandboxed,
-   no network for the agent itself), so it can verify imports and helpers against the real
-   tree instead of guessing from the diff. The reviewer is `scripts/ai_review.mjs`; the
-   GitHub comment helper is `scripts/gh_sticky_comment.mjs`. No new npm dependencies in
-   the repo: the workflow installs `@openai/codex` globally on the runner, and the GitHub
-   side is Node's built-in `fetch` against the REST API.
+2. **AI review** (`ai-review` job). Reviews the PR with the OpenAI Codex CLI,
+   authenticated with a ChatGPT account via OAuth (no API key), and posts the review as a
+   sticky PR comment: a short overall assessment, a "Verified" list of the commands it
+   ran with their outcomes, then findings grouped into Correctness / Invariants / Tests /
+   Nits with severity tags. The job checks out the PR HEAD, installs dependencies
+   (`npm ci --ignore-scripts`) and generates the i18n artifacts, so Codex runs as a
+   VERIFYING agent: it is required to read the changed files in the tree, run
+   `npx tsc --noEmit`, and run the vitest files covering the change before writing, and
+   to only report findings it confirmed (anything unverifiable is at most a low-severity
+   question). The inlined prompt diff is pre-filtered (`scripts/ai_review_diff.mjs`
+   drops generated i18n tables, parity goldens, lockfiles, and binary assets) and capped
+   on a file boundary; the agent reads the full diff itself via `git diff BASE HEAD`.
+   The reviewer is `scripts/ai_review.mjs`; the GitHub comment helper is
+   `scripts/gh_sticky_comment.mjs`. No new npm dependencies in the repo: the workflow
+   installs `@openai/codex` globally on the runner, and the GitHub side is Node's
+   built-in `fetch` against the REST API.
 3. **AI review on demand** (`ai-review-comment` job). An OWNER, MEMBER, or COLLABORATOR
    of this repo can comment `/review` or `/suggest <focus>` on a PR (for example
    `/suggest check the null handling around the new cache`) to re-run the same reviewer
    whenever they want, optionally pointed at a specific concern. It runs the same
-   `scripts/ai_review.mjs`, fetching the diff itself from the GitHub API instead of a
-   precomputed file, and posts its answer as a fresh reply comment rather than editing
-   the standing sticky review, so a one-off question does not overwrite it.
+   `scripts/ai_review.mjs` with the same PR-head checkout and verification setup, and
+   posts its answer as a fresh reply comment rather than editing the standing sticky
+   review, so a one-off question does not overwrite it.
 
 ## Enabling the AI review
 
@@ -64,19 +71,22 @@ opt-in and authenticates with a ChatGPT account through OAuth, not an API key:
 
 ## Requesting a review on demand
 
-Comment `/review` on a PR to re-run the reviewer over the current diff, or
+Comment `/review` on a PR to re-run the reviewer over the current state of the PR, or
 `/suggest <focus>` to ask it to prioritize something specific (the rest of the comment
 after the command is passed to the model as the thing to focus on; it still mentions
 other high-confidence findings). Only comments from an OWNER, MEMBER, or COLLABORATOR of
 this repo trigger it, checked against this repo regardless of whose PR it is, so a first-
-time contributor cannot self-trigger it on their own fork PR by commenting on it. This
-gate exists because, unlike the automatic `pull_request`-triggered job, a comment trigger
-always runs with this repo's secrets available, even against a fork PR: the job never
-checks out or executes the PR's own code, it only reads the diff as text through the
-GitHub API, but the trust gate keeps it from being invoked, and the ChatGPT plan's Codex
-quota spent, by an untrusted commenter. Codex itself additionally runs in a read-only
-sandbox with network access disabled, so even a malicious diff crafted as a prompt
-injection cannot make the agent modify the checkout or call out anywhere.
+time contributor cannot self-trigger it on their own fork PR by commenting on it.
+
+Know what you are opting into on a FORK PR: unlike the old diff-only reviewer, this job
+checks out the fork's code and exercises it (the i18n generation step, and whatever tests
+the agent runs), in a job that holds the `CODEX_AUTH_JSON` secret. The mitigations are
+real but not absolute: `npm ci --ignore-scripts` keeps third-party install hooks from
+running, the raw secret is scrubbed from the agent's child environment (only the
+materialized `CODEX_HOME/auth.json` exists, in a throwaway temp dir), and the
+`GITHUB_TOKEN` carries only `contents: read` plus `pull-requests: write`. Skim a fork
+PR's diff for anything that reads credentials or phones home before typing `/review` on
+it; for same-repo PRs there is no new exposure.
 
 ## Privacy: read before enabling on private code
 
@@ -95,10 +105,11 @@ no-op there (the scripts detect the missing write access / auth and skip), so th
 never errors on a fork PR. Screenshots are still captured and uploaded as an artifact.
 
 The on-demand `/review` and `/suggest` comment trigger is different: `issue_comment`
-always runs with full repo secrets, regardless of whether the PR is from a fork. It is
-still safe against a fork PR because the job never checks out or runs the PR's own code,
-and because it is gated on the commenter's `author_association` with this repo, not with
-the PR's origin (see "Requesting a review on demand" above).
+always runs with full repo secrets, regardless of whether the PR is from a fork, and it
+checks out and exercises the PR's own code so the agent can verify it. That combination
+is gated on the commenter's `author_association` with this repo, not the PR's origin,
+and is a deliberate maintainer opt-in with documented mitigations (see "Requesting a
+review on demand" above).
 
 ## Running the screenshot tour locally
 

--- a/docs/ai-pr-bot.md
+++ b/docs/ai-pr-bot.md
@@ -81,12 +81,14 @@ time contributor cannot self-trigger it on their own fork PR by commenting on it
 Know what you are opting into on a FORK PR: unlike the old diff-only reviewer, this job
 checks out the fork's code and exercises it (the i18n generation step, and whatever tests
 the agent runs), in a job that holds the `CODEX_AUTH_JSON` secret. The mitigations are
-real but not absolute: `npm ci --ignore-scripts` keeps third-party install hooks from
-running, the raw secret is scrubbed from the agent's child environment (only the
-materialized `CODEX_HOME/auth.json` exists, in a throwaway temp dir), and the
-`GITHUB_TOKEN` carries only `contents: read` plus `pull-requests: write`. Skim a fork
-PR's diff for anything that reads credentials or phones home before typing `/review` on
-it; for same-repo PRs there is no new exposure.
+real but not absolute: the reviewer scripts themselves run from a TRUSTED default-branch
+checkout while the PR head sits in a separate `pr/` tree (so a fork cannot replace
+`ai_review.mjs` and read the secret from inside the secret-holding step),
+`npm ci --ignore-scripts` keeps third-party install hooks from running, the raw secret is
+scrubbed from the agent's child environment (only the materialized `CODEX_HOME/auth.json`
+exists, in a throwaway temp dir), and the `GITHUB_TOKEN` carries only `contents: read`
+plus `pull-requests: write`. Skim a fork PR's diff for anything that reads credentials or
+phones home before typing `/review` on it; for same-repo PRs there is no new exposure.
 
 ## Privacy: read before enabling on private code
 

--- a/docs/ai-pr-bot.md
+++ b/docs/ai-pr-bot.md
@@ -25,8 +25,9 @@ them is a required check.
    Inline embedding needs a URL GitHub can fetch (artifacts are not embeddable and markdown
    does not render `data:` URIs), so `scripts/gh_image_host.mjs` uploads each PNG to a
    bot-owned orphan branch (`bot-pr-screenshots`) via the REST API and references its raw
-   URL. This needs the job's `contents: write` permission; on a fork PR the token is
-   read-only, so it degrades to a note instead of broken image links.
+   URL. This needs the job's `contents: write` permission. If hosting fails while
+   commenting still works, the comment degrades to a note instead of broken image links;
+   on a fork PR the read-only token can do neither, so the comment is skipped entirely.
 2. **AI review** (`ai-review` job). Reviews the PR with the OpenAI Codex CLI,
    authenticated with a ChatGPT account via OAuth (no API key), and posts the review as a
    sticky PR comment: a short overall assessment, a "Verified" list of the commands it
@@ -113,8 +114,9 @@ The screenshots job sends nothing to a third party; it only renders your own cli
 Pull requests from forks get a read-only `GITHUB_TOKEN` and cannot read repo secrets on
 the `pull_request` trigger. Both comment steps and the automatic AI review degrade to a
 no-op there (the scripts detect the missing write access / auth and skip), so the workflow
-never errors on a fork PR. Screenshots are still captured, but with a read-only token they
-cannot be hosted for inline embedding, so the comment shows a short note instead.
+never errors on a fork PR. Screenshots are still captured, but a read-only token can
+neither host the images nor post a comment at all, so on a fork PR the screenshot comment
+is skipped entirely (the frames exist only in the job log's capture output).
 
 The on-demand `/review` and `/suggest` comment trigger is different: `issue_comment`
 always runs with full repo secrets, regardless of whether the PR is from a fork, and it

--- a/scripts/ai_review.mjs
+++ b/scripts/ai_review.mjs
@@ -47,6 +47,11 @@
 //   BASE_SHA, HEAD_SHA  the PR's base/head commits when the workflow checked out the PR
 //                       head with history: lets the agent read the FULL diff itself via
 //                       git instead of relying only on the inlined (filtered, capped) one
+//   REVIEW_CWD          working directory for the Codex agent (default: this script's
+//                       cwd). The comment-command job sets it to a separate PR-head
+//                       checkout so this script always runs from TRUSTED base-repo code
+//                       while the agent inspects the (possibly fork) PR tree; a fork can
+//                       then never swap this script out to read the raw secret.
 //   MAX_DIFF_CHARS      cap on inlined diff chars in the prompt (default 150000);
 //                       generated/vendored/binary sections are filtered out first
 //                       (ai_review_diff.mjs) so the cap is spent on hand-written code
@@ -75,6 +80,7 @@ const MAX_DIFF_CHARS = Number(process.env.MAX_DIFF_CHARS || 150000);
 const GITHUB_API = process.env.GITHUB_API_URL ?? 'https://api.github.com';
 const BASE_SHA = process.env.BASE_SHA || '';
 const HEAD_SHA = process.env.HEAD_SHA || '';
+const REVIEW_CWD = process.env.REVIEW_CWD || process.cwd();
 
 const prNumber = process.env.PR_NUMBER;
 const diffFile = process.env.DIFF_FILE;
@@ -282,6 +288,9 @@ function review() {
   execFileSync(CODEX_BIN, args, {
     input: prompt,
     stdio: ['pipe', 'inherit', 'inherit'],
+    // The agent's workspace: REVIEW_CWD when the workflow separates the (trusted) script
+    // checkout from the (untrusted) PR tree; otherwise wherever this script runs.
+    cwd: REVIEW_CWD,
     // Scrub the raw secret from the child environment: the agent (and any test process it
     // spawns, which on a fork PR is that PR's code) only needs the materialized
     // CODEX_HOME/auth.json, never the CODEX_AUTH_JSON env var itself.

--- a/scripts/ai_review.mjs
+++ b/scripts/ai_review.mjs
@@ -1,16 +1,17 @@
-// Minimal AI pull-request reviewer, driven by the OpenAI Codex CLI authenticated with a
-// ChatGPT account (OAuth), not an API key. Runs `codex exec` non-interactively over the
-// PR diff (read-only sandbox, no network for the agent) and posts the review as a sticky
-// comment on the PR. No new npm deps: the Codex CLI is installed by the workflow, and
-// the GitHub side is plain REST via global fetch.
+// AI pull-request reviewer, driven by the OpenAI Codex CLI authenticated with a ChatGPT
+// account (OAuth), not an API key. Runs `codex exec` non-interactively as a VERIFYING
+// agent: the workflow checks out the PR head with dependencies installed (npm ci +
+// i18n:gen), and the prompt requires it to confirm findings against the real tree by
+// reading files and running the project's own checks (tsc, targeted vitest) before
+// posting the review as a sticky comment on the PR. No new npm deps: the Codex CLI is
+// installed by the workflow, and the GitHub side is plain REST via global fetch.
 //
 // Two ways to trigger it (both wired in .github/workflows/pr-ai.yml):
 //   - automatically on every push to the PR: DIFF_FILE points at a precomputed diff.
 //   - on demand: an OWNER/MEMBER/COLLABORATOR comments `/review` or `/suggest <focus>`
-//     on the PR. The workflow gates on the commenter's author_association; this script
-//     fetches the diff itself via the GitHub API (no DIFF_FILE, no checkout of the PR
-//     head) and posts a fresh reply comment keyed to the triggering comment, separate
-//     from the sticky automatic review.
+//     on the PR. The workflow gates on the commenter's author_association, checks out
+//     the PR head the same way, and posts a fresh reply comment keyed to the triggering
+//     comment, separate from the sticky automatic review.
 //
 // AUTH (ChatGPT OAuth): run `codex login` once locally, which stores OAuth tokens in
 // ~/.codex/auth.json. In CI, put that file's contents in the CODEX_AUTH_JSON repo
@@ -19,10 +20,9 @@
 // fork PR that cannot read repo secrets), it prints a notice and exits 0: it is
 // best-effort and NON-BLOCKING, it never gates a merge.
 //
-// PRIVACY: the diff is sent to OpenAI under the ChatGPT account that logged in. Whether
-// it is used for training follows that account's plan and data settings (check the
-// workspace's data controls); the agent itself runs sandboxed read-only with network
-// disabled, so it cannot exfiltrate beyond the model request itself.
+// PRIVACY: the diff and whatever the agent reads from the checkout are sent to OpenAI
+// under the ChatGPT account that logged in. Whether it is used for training follows that
+// account's plan and data settings (check the workspace's data controls).
 //
 // Env (set by the workflow):
 //   CODEX_AUTH_JSON     contents of a `codex login` auth.json (repo secret); when
@@ -38,7 +38,18 @@
 //   COMMENT_AUTHOR      the triggering comment's author; credited in the reply
 //   CODEX_MODEL         model id override; when absent the Codex CLI default is used
 //   CODEX_BIN           path to the codex binary (default: `codex` on PATH)
-//   MAX_DIFF_CHARS      cap on diff chars sent to the model (default 60000)
+//   CODEX_SANDBOX       codex --sandbox mode (default workspace-write). CI sets
+//                       danger-full-access: the hosted runner is an ephemeral VM, and the
+//                       kernel sandbox (Landlock) is not reliably available there, which
+//                       used to abort every inspection command before it ran.
+//   CODEX_EFFORT        model reasoning effort (default high), passed as
+//                       -c model_reasoning_effort=<value>
+//   BASE_SHA, HEAD_SHA  the PR's base/head commits when the workflow checked out the PR
+//                       head with history: lets the agent read the FULL diff itself via
+//                       git instead of relying only on the inlined (filtered, capped) one
+//   MAX_DIFF_CHARS      cap on inlined diff chars in the prompt (default 150000);
+//                       generated/vendored/binary sections are filtered out first
+//                       (ai_review_diff.mjs) so the cap is spent on hand-written code
 //
 // A local .env is loaded best-effort (same pattern as the other scripts/ utilities), so
 // a local run can keep CODEX_MODEL there. Ambient environment variables (the ones the
@@ -47,6 +58,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { capDiff, filterReviewDiff } from './ai_review_diff.mjs';
 import { upsertStickyComment } from './gh_sticky_comment.mjs';
 
 try {
@@ -57,8 +69,12 @@ try {
 
 const MODEL = process.env.CODEX_MODEL || '';
 const CODEX_BIN = process.env.CODEX_BIN || 'codex';
-const MAX_DIFF_CHARS = Number(process.env.MAX_DIFF_CHARS || 60000);
+const SANDBOX = process.env.CODEX_SANDBOX || 'workspace-write';
+const EFFORT = process.env.CODEX_EFFORT || 'high';
+const MAX_DIFF_CHARS = Number(process.env.MAX_DIFF_CHARS || 150000);
 const GITHUB_API = process.env.GITHUB_API_URL ?? 'https://api.github.com';
+const BASE_SHA = process.env.BASE_SHA || '';
+const HEAD_SHA = process.env.HEAD_SHA || '';
 
 const prNumber = process.env.PR_NUMBER;
 const diffFile = process.env.DIFF_FILE;
@@ -132,36 +148,70 @@ if (!diff.trim()) {
   process.exit(0);
 }
 
-let truncated = false;
-if (diff.length > MAX_DIFF_CHARS) {
-  diff = diff.slice(0, MAX_DIFF_CHARS);
-  truncated = true;
+// Spend the prompt budget on the hand-written change: drop generated/vendored/binary
+// sections first, then cap on a file-section boundary. The agent can always read the
+// full diff itself via git (BASE_SHA/HEAD_SHA below).
+const filtered = filterReviewDiff(diff);
+const dropped = filtered.dropped;
+if (dropped.length) {
+  console.log(
+    `[ai_review] filtered ${dropped.length} generated/binary file section(s) from the inlined diff.`,
+  );
+}
+const capped = capDiff(filtered.diff, MAX_DIFF_CHARS);
+diff = capped.diff;
+const truncated = capped.truncated;
+if (!diff.trim()) {
+  console.log('[ai_review] diff is all generated/binary churn; skipping the AI review.');
+  process.exit(0);
 }
 
-// Unlike the old single-shot HTTP reviewer, Codex runs as an agent with READ-ONLY access
-// to the checkout, so instead of shipping it file lists to stop hallucinated "missing
-// import" findings, we tell it to verify against the working tree itself. One caveat is
-// preserved from the old design: on a comment-triggered run the checkout is the BASE
-// branch (no PR-head checkout, intentionally, see .github/workflows/pr-ai.yml), so a
-// file the PR itself adds exists only inside the diff text.
-const prompt = `You are a precise, skeptical senior code reviewer for World of ClaudeCraft, a TypeScript
-micro-MMO and reinforcement-learning environment built on one deterministic 20 Hz simulation core.
+// Codex runs as a verifying agent over a full checkout of the PR HEAD with dependencies
+// installed (the workflow runs npm ci + i18n:gen first), so the prompt demands evidence:
+// read the tree, run the typecheck, run the tests that cover the change, and only then
+// write the review. The inlined diff below is filtered (no generated/binary churn) and
+// capped; the agent reads the full diff itself via git when it needs more.
+const gitDiffHint =
+  BASE_SHA && HEAD_SHA
+    ? `The checkout is the PR HEAD (${HEAD_SHA.slice(0, 10)}). The full, unfiltered diff is available
+locally: \`git diff --no-color ${BASE_SHA} ${HEAD_SHA}\` (also \`git log ${BASE_SHA}..${HEAD_SHA}\`
+for the commits). The inlined diff below omits generated/binary files and may be capped; consult
+git whenever you need the complete picture.`
+    : `The checkout may be the PR's BASE branch, so a file the diff itself adds may exist only in the
+diff text; that is expected, never a finding.`;
 
-Review the unified diff below. You have READ-ONLY access to a checkout of the repository; before
-flagging that an import, helper, or referenced file is missing or wrong, verify it against the
-working tree (and package.json for dependencies). Use lightweight inspection only: file reads,
-focused searches, and short static checks. Do not install packages, run network commands, run full
-builds, run full test suites, or run long typecheck commands. Note: the checkout may be the PR's
-BASE branch, so a file the diff itself adds may exist only in the diff text; that is expected,
-never a finding. When you cannot verify something, ask a one-line question at LOW severity instead
-of asserting a problem. Do not modify anything; produce a review only.
+const prompt = `You are a thorough, constructive senior code reviewer for World of ClaudeCraft, a TypeScript
+micro-MMO and reinforcement-learning environment built on one deterministic 20 Hz simulation core
+(see CLAUDE.md at the repo root for the architecture and the invariants; read it first).
+
+You have a full checkout of the repository with npm dependencies already installed and generated
+i18n artifacts in place. ${gitDiffHint}
+
+VERIFY BEFORE YOU WRITE. This review must be grounded in what you actually ran and read, not in
+what the diff looks like. Do all of the following that apply, and skip a step only when the diff
+plainly cannot affect it:
+1. Read the changed files IN THE TREE (not just the hunks) so you see each change in context.
+2. Run the typecheck: \`npx tsc --noEmit\`. A new type error introduced by the diff is a finding.
+3. Run the tests that cover the change: the test files the diff touches, plus the suites for the
+   changed area (for example \`npx vitest run tests/<area>.test.ts\`). When the diff touches
+   src/sim/, also run the guard \`npx vitest run tests/architecture.test.ts\`. Prefer several
+   targeted files over the full suite; run broader slices only when the change is genuinely broad.
+4. For a bug fix, check the fix has a test that would fail without it (read the test, do not
+   assume). For new behavior, check the new code paths are exercised by some test.
+5. Confirm imports, helpers, wire fields, and referenced files exist where the code says they do
+   (grep the tree; check package.json for dependencies).
+Budget your time: about 10 minutes of commands. Do not install packages, do not run npm ci, do not
+run browser/E2E scripts (scripts/*.mjs need a live dev server), do not push, and do not modify any
+tracked file; scratch output under /tmp is fine. If a command fails for environmental reasons,
+say so in the verification section rather than guessing.
 
 Invariant scope, apply LITERALLY and do not generalize beyond it: these rules constrain application
 code under src/ ONLY.
 - src/sim/ stays pure: no DOM/Three/render/ui/net imports; all randomness via the Rng helper, never
   Math.random / Date.now / performance.now.
 - The server is authoritative; clients never decide outcomes.
-- Every player-visible string rendered by the app is a t() key.
+- Every player-visible string rendered by the app is a t() key. Contributors add ENGLISH only;
+  never ask for translations, they are release-time maintainer work.
 Code under scripts/, tests/, headless/, and CI YAML under .github/ is Node TOOLING: it is
 English-only, exempt from t(), and may use Math.random / Date.now / child_process freely. NEVER
 raise a t(), Rng, or sim-purity finding against a file outside src/. The "no em dashes, en dashes,
@@ -169,21 +219,34 @@ or emojis" rule applies everywhere.
 
 Severity rubric, use it strictly:
 - high: a real bug, security issue, or src/ invariant violation that WILL break behavior or fail CI
-  AND that you confirmed from the diff plus the working tree.
+  AND that you confirmed against the tree (and, where relevant, by running the check).
 - medium: likely incorrect or risky, but not certain.
 - low: style, naming, maintainability, or a question.
 If you CANNOT verify a finding, it is AT MOST low and MUST be phrased as a one-line question, never
 high or medium.
 
-Output rules: your FINAL message is posted verbatim as the PR review comment, so it must contain
-ONLY the review in GitHub-flavored Markdown, no preamble or meta commentary. Prefer FEW
-high-confidence findings over many; if you are not confident a finding is real, OMIT it. Do not pad
-with generic advice. Only mention missing tests when the diff changes src/ or server logic that the
-repo actually tests. Do NOT add your own title or top-level heading (no "# ..." or "## AI review");
-start directly with the first group. Group findings under Correctness, Invariants, Tests, Nits and
-tag each with its severity. If the change looks fine, say so in one line. Do not restate the diff.
+Be constructive: when the change is solid, open with one or two specific lines on what is good
+(design choice, test coverage, a subtle case handled), never generic praise. Every finding names
+the file and line, explains WHY it matters in one or two sentences, and proposes a concrete fix or
+next step. Prefer FEW verified findings over many speculative ones; if you are not confident a
+finding is real, OMIT it. Do not pad with generic advice, and do not restate the diff.
 
-${truncated ? `Note: the diff was truncated to the first ${MAX_DIFF_CHARS} characters.\n\n` : ''}${
+Output rules: your FINAL message is posted verbatim as the PR review comment, so it must contain
+ONLY the review in GitHub-flavored Markdown, no preamble or meta commentary. Do NOT add your own
+title or top-level heading (no "# ..." or "## AI review"). Structure it as:
+1. A one-or-two-line overall assessment (what the change does and whether it is sound).
+2. "**Verified:**" followed by a short list of the commands you ran and their outcomes (for
+   example: tsc clean; vitest tests/spirit.test.ts 34 passed). If something could not run,
+   say so here honestly.
+3. Findings grouped under Correctness, Invariants, Tests, Nits, each tagged with its severity.
+   Omit an empty group. If there are no findings, say the change looks correct in one line and
+   name the strongest piece of evidence.
+
+${truncated ? `Note: the inlined diff below was capped at ${MAX_DIFF_CHARS} characters; use git for the rest.\n\n` : ''}${
+  dropped.length
+    ? `Note: ${dropped.length} generated/binary file section(s) were omitted from the inlined diff (${dropped.slice(0, 8).join(', ')}${dropped.length > 8 ? ', ...' : ''}); they are derived from the real change and gated elsewhere.\n\n`
+    : ''
+}${
   command?.focus
     ? `The reviewer specifically asked (via a PR comment) to focus on:\n\n${command.focus}\n\nStill mention any other high-confidence finding, but prioritize this.\n\n`
     : ''
@@ -197,11 +260,16 @@ function review() {
   const outFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'codex-review-')), 'last.md');
   const args = [
     'exec',
+    // Sandbox mode comes from the environment: workspace-write for a local run (the agent
+    // needs to execute tsc/vitest, which write caches), danger-full-access in CI where the
+    // kernel sandbox is unavailable and the runner VM is the isolation boundary.
     '--sandbox',
-    'read-only',
+    SANDBOX,
     '--skip-git-repo-check',
     '--ignore-user-config',
     '--ignore-rules',
+    '-c',
+    `model_reasoning_effort=${JSON.stringify(EFFORT)}`,
     '--output-last-message',
     outFile,
     ...(MODEL ? ['--model', MODEL] : []),
@@ -209,11 +277,16 @@ function review() {
   ];
   // Progress goes to the workflow log (stderr/stdout inherited); the review itself is
   // read back from --output-last-message so log noise can never leak into the comment.
+  // The budget is generous because the agent runs the project's own checks (tsc, targeted
+  // vitest) before writing; the workflow job timeout is the hard backstop.
   execFileSync(CODEX_BIN, args, {
     input: prompt,
     stdio: ['pipe', 'inherit', 'inherit'],
-    env: { ...process.env, CODEX_HOME: codexHome },
-    timeout: 12 * 60 * 1000,
+    // Scrub the raw secret from the child environment: the agent (and any test process it
+    // spawns, which on a fork PR is that PR's code) only needs the materialized
+    // CODEX_HOME/auth.json, never the CODEX_AUTH_JSON env var itself.
+    env: { ...process.env, CODEX_AUTH_JSON: undefined, CODEX_HOME: codexHome },
+    timeout: 25 * 60 * 1000,
   });
   const content = fs.readFileSync(outFile, 'utf8').trim();
   if (!content) throw new Error('Codex produced no final message');
@@ -240,7 +313,9 @@ const body = [
   heading,
   '',
   reviewText,
-  truncated ? `\n<sub>Diff truncated to the first ${MAX_DIFF_CHARS} characters.</sub>` : '',
+  truncated
+    ? `\n<sub>The inlined diff was capped at ${MAX_DIFF_CHARS} characters; the agent had the full diff via git.</sub>`
+    : '',
   '',
   '<sub>Automated and non-blocking. May be wrong; a human review still decides. Generated by the OpenAI Codex CLI under the maintainer ChatGPT account; data handling follows that account plan and settings.</sub>',
 ].join('\n');

--- a/scripts/ai_review_diff.mjs
+++ b/scripts/ai_review_diff.mjs
@@ -1,0 +1,92 @@
+// Pure helpers for the AI reviewer's diff handling, split out so they unit-test without
+// the CLI, the network, or the top-level side effects of ai_review.mjs.
+//
+// A raw PR diff is mostly noise for a reviewer: regenerated i18n tables, parity golden
+// snapshots, lockfiles, and binary assets can dwarf the actual code change and burn the
+// character budget (which then truncates the real code). filterReviewDiff drops those
+// per-file sections so the model sees the hand-written change, and reports what it dropped
+// so the prompt can say so.
+
+// Path fragments whose per-file diff is generated, vendored, or binary: reviewing the diff
+// text of these adds nothing (they are derived from the real change, gated elsewhere).
+const NOISE = [
+  'i18n.resolved.generated/',
+  'i18n.status.json',
+  'i18n.status.summary.json',
+  'i18n.resolved.sha256',
+  '.generated.ts',
+  'tests/parity/golden/',
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'yarn.lock',
+];
+
+// Extensions that are binary/asset blobs (a diff shows them as "Binary files differ" or a
+// huge base64-ish blob); never useful to a code reviewer.
+const BINARY_EXT = [
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.ico',
+  '.glb',
+  '.gltf',
+  '.hdr',
+  '.mp3',
+  '.wav',
+  '.ogg',
+  '.woff',
+  '.woff2',
+  '.pdf',
+];
+
+// The b-side path of a "diff --git a/<x> b/<y>" section header.
+function sectionPath(section) {
+  const header = section.match(/^diff --git a\/(?:.+?) b\/(.+)$/m);
+  if (header) return header[1].trim();
+  const plus = section.match(/^\+\+\+ b\/(.+)$/m);
+  return plus ? plus[1].trim() : '';
+}
+
+function isNoise(path) {
+  if (!path) return false;
+  if (NOISE.some((n) => path.includes(n))) return true;
+  return BINARY_EXT.some((ext) => path.toLowerCase().endsWith(ext));
+}
+
+// Split a unified diff into per-file sections. Each section starts at a "diff --git" line.
+function splitSections(diff) {
+  const parts = diff.split(/(?=^diff --git )/m);
+  // A leading chunk before the first "diff --git" (rare) is kept as-is if non-empty.
+  return parts.filter((p) => p.length > 0);
+}
+
+// Drop the generated/vendored/binary file sections from a unified diff. Returns the kept
+// diff plus the list of dropped paths (for a one-line note in the prompt).
+export function filterReviewDiff(diff) {
+  if (!diff) return { diff: '', dropped: [] };
+  const kept = [];
+  const dropped = [];
+  for (const section of splitSections(diff)) {
+    if (!section.startsWith('diff --git ')) {
+      kept.push(section);
+      continue;
+    }
+    const path = sectionPath(section);
+    if (isNoise(path)) dropped.push(path);
+    else kept.push(section);
+  }
+  return { diff: kept.join(''), dropped };
+}
+
+// Apply the character cap after filtering, cutting on a section boundary when possible so
+// the model never sees a half-truncated hunk. Returns { diff, truncated }.
+export function capDiff(diff, maxChars) {
+  if (!maxChars || diff.length <= maxChars) return { diff, truncated: false };
+  const head = diff.slice(0, maxChars);
+  // Prefer to end at the last complete file section within the cap.
+  const lastBoundary = head.lastIndexOf('\ndiff --git ');
+  const cut = lastBoundary > 0 ? head.slice(0, lastBoundary + 1) : head;
+  return { diff: cut, truncated: true };
+}

--- a/scripts/gh_image_host.mjs
+++ b/scripts/gh_image_host.mjs
@@ -1,0 +1,130 @@
+// Host PR screenshots so they can be embedded inline in a comment. GitHub Actions
+// artifacts are not embeddable as images, and markdown does not render data: URIs, so the
+// only way to show a picture in the comment is a URL GitHub can fetch. This uploads each
+// PNG to a dedicated orphan branch via the REST API and returns its raw.githubusercontent
+// URL, which renders in markdown on a public repo.
+//
+// Best-effort and non-blocking: on a fork PR the Actions token is read-only, so the branch
+// create / file upload 403s; callers get an empty list back and simply post no images.
+//
+// Needs a token with contents:write (set the screenshots job's permissions accordingly).
+// No npm deps: Node 18+ global fetch only.
+
+const DEFAULT_BRANCH = 'bot-pr-screenshots';
+
+function ghHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+  };
+}
+
+// Create the assets branch as an orphan (no repo files, just a README) if it does not
+// exist yet. Returns true when the branch is present and writable, false otherwise.
+async function ensureBranch({ api, repo, branch, headers }) {
+  const refRes = await fetch(`${api}/repos/${repo}/git/ref/heads/${branch}`, { headers });
+  if (refRes.ok) return true;
+  if (refRes.status !== 404) {
+    console.log(`[gh_image_host] cannot read branch ${branch} (HTTP ${refRes.status}); skipping.`);
+    return false;
+  }
+
+  const readme = Buffer.from(
+    'Bot-managed branch holding rendered PR screenshots for inline comment embedding.\n' +
+      'Files live under pr-<number>/<run-id>/. Safe to prune; regenerated on the next PR run.\n',
+    'utf8',
+  ).toString('base64');
+
+  const blob = await fetch(`${api}/repos/${repo}/git/blobs`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ content: readme, encoding: 'base64' }),
+  });
+  if (!blob.ok) {
+    console.log(`[gh_image_host] blob create failed (HTTP ${blob.status}); skipping embedding.`);
+    return false;
+  }
+  const blobSha = (await blob.json()).sha;
+
+  const tree = await fetch(`${api}/repos/${repo}/git/trees`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      tree: [{ path: 'README.md', mode: '100644', type: 'blob', sha: blobSha }],
+    }),
+  });
+  if (!tree.ok) return false;
+  const treeSha = (await tree.json()).sha;
+
+  const commit = await fetch(`${api}/repos/${repo}/git/commits`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      message: 'init pr-screenshots asset branch',
+      tree: treeSha,
+      parents: [],
+    }),
+  });
+  if (!commit.ok) return false;
+  const commitSha = (await commit.json()).sha;
+
+  const ref = await fetch(`${api}/repos/${repo}/git/refs`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: commitSha }),
+  });
+  // A concurrent run may have created it first (422); treat that as success.
+  if (!ref.ok && ref.status !== 422) {
+    console.log(`[gh_image_host] branch create failed (HTTP ${ref.status}); skipping embedding.`);
+    return false;
+  }
+  return true;
+}
+
+// Upload the given PNG files and return [{ name, url }] with a raw URL per uploaded image.
+// files is a list of basenames present in `dir`. Paths are keyed by PR number and run id so
+// each run gets fresh, immutable URLs (no CDN-cache staleness between pushes).
+export async function uploadScreenshots({
+  files,
+  readFile,
+  prNumber,
+  runId,
+  token = process.env.GITHUB_TOKEN,
+  repo = process.env.GITHUB_REPOSITORY,
+  api = process.env.GITHUB_API_URL ?? 'https://api.github.com',
+  rawBase = process.env.GITHUB_RAW_BASE ?? 'https://raw.githubusercontent.com',
+  branch = DEFAULT_BRANCH,
+}) {
+  if (!token || !repo || !prNumber || !files?.length) return [];
+  const headers = ghHeaders(token);
+
+  if (!(await ensureBranch({ api, repo, branch, headers }))) return [];
+
+  const uploaded = [];
+  for (const name of files) {
+    try {
+      const content = readFile(name).toString('base64');
+      const path = `pr-${prNumber}/${runId ?? 'latest'}/${name}`;
+      const put = await fetch(`${api}/repos/${repo}/contents/${path}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({
+          message: `pr-${prNumber}: ${name}`,
+          content,
+          branch,
+        }),
+      });
+      if (!put.ok) {
+        console.log(`[gh_image_host] upload ${name} failed (HTTP ${put.status}); skipping it.`);
+        continue;
+      }
+      const encodedPath = path.split('/').map(encodeURIComponent).join('/');
+      uploaded.push({ name, url: `${rawBase}/${repo}/${branch}/${encodedPath}` });
+    } catch (e) {
+      console.log(`[gh_image_host] upload ${name} errored (${e.message}); skipping it.`);
+    }
+  }
+  return uploaded;
+}

--- a/scripts/gh_sticky_comment.mjs
+++ b/scripts/gh_sticky_comment.mjs
@@ -23,7 +23,9 @@ function ghHeaders(token) {
 // Upsert a sticky comment. Returns 'created' | 'updated', or null when it could not
 // post (no token, no PR number, or a non-write token, e.g. a fork PR). Never throws on
 // a missing token so callers can stay non-blocking; real API errors do throw.
-export async function upsertStickyComment({ marker, body, prNumber, token, repo }) {
+// updateOnly: when true, edit an existing sticky but never create a new one (used to flip
+// a prior screenshot comment to a "no visual changes" note without spamming plain PRs).
+export async function upsertStickyComment({ marker, body, prNumber, token, repo, updateOnly }) {
   token = token ?? process.env.GITHUB_TOKEN;
   repo = repo ?? process.env.GITHUB_REPOSITORY;
   if (!token || !repo || !prNumber) {
@@ -52,6 +54,11 @@ export async function upsertStickyComment({ marker, body, prNumber, token, repo 
     });
     if (!res.ok) throw new Error(`PATCH comment failed: HTTP ${res.status} ${await res.text()}`);
     return 'updated';
+  }
+
+  if (updateOnly) {
+    // Nothing to edit and we were told not to create: stay silent.
+    return null;
   }
 
   const res = await fetch(`${API}/repos/${repo}/issues/${prNumber}/comments`, {

--- a/scripts/pr_comment_shots.mjs
+++ b/scripts/pr_comment_shots.mjs
@@ -19,7 +19,14 @@ import { upsertStickyComment } from './gh_sticky_comment.mjs';
 const MARKER = '<!-- pr-ai-screenshots -->';
 const OUT = process.env.SHOTS_DIR ?? 'pr-shots';
 const prNumber = process.env.PR_NUMBER;
-const runId = process.env.GITHUB_RUN_ID;
+// Key hosted image paths by run id AND attempt: GITHUB_RUN_ID is stable across re-runs,
+// and a Contents-API PUT to an existing path without its sha fails with 422, which would
+// silently drop every image on a re-run. The attempt suffix keeps each upload path fresh.
+// (Both are default Actions env vars; no workflow wiring needed.)
+const runAttempt = process.env.GITHUB_RUN_ATTEMPT;
+const runId = process.env.GITHUB_RUN_ID
+  ? `${process.env.GITHUB_RUN_ID}${runAttempt ? `-${runAttempt}` : ''}`
+  : undefined;
 
 let manifest = { mode: 'no-visual', captured: [], errors: [] };
 try {

--- a/scripts/pr_comment_shots.mjs
+++ b/scripts/pr_comment_shots.mjs
@@ -1,57 +1,97 @@
-// Posts (or updates) a sticky PR comment pointing at the screenshot artifact produced
-// by pr_screenshots.mjs. GitHub Actions artifacts are not directly embeddable as images
-// in a comment, so this links the downloadable artifact and lists which frames it holds.
-// Best-effort and non-blocking: it never fails the job.
+// Posts (or updates) a sticky PR comment that EMBEDS the screenshots pr_screenshots.mjs
+// captured, inline, so a reviewer sees them without downloading anything. The PNGs are
+// uploaded to a bot-owned orphan branch (gh_image_host.mjs) and referenced by their raw
+// URL. Best-effort and non-blocking: it never fails the job.
+//
+// When the capture step found no visual change (nothing captured), it posts nothing on a
+// fresh PR, and flips an existing screenshot comment to a short "no visual changes" note
+// so a stale gallery never lingers after a later non-visual push.
 //
 // Env (set by the workflow):
-//   GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER   standard Actions context
-//   ARTIFACT_URL   download URL of the uploaded screenshots artifact (optional)
-//   RUN_URL        link to the workflow run (fallback when ARTIFACT_URL is absent)
-//   SHOTS_DIR      directory holding manifest.json (default pr-shots)
+//   GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER   standard Actions context (token needs
+//                                                contents:write to host the images)
+//   GITHUB_RUN_ID   run id, used to key the uploaded image paths (optional)
+//   SHOTS_DIR       directory holding manifest.json + the PNGs (default pr-shots)
 import fs from 'node:fs';
+import { uploadScreenshots } from './gh_image_host.mjs';
 import { upsertStickyComment } from './gh_sticky_comment.mjs';
 
 const MARKER = '<!-- pr-ai-screenshots -->';
 const OUT = process.env.SHOTS_DIR ?? 'pr-shots';
 const prNumber = process.env.PR_NUMBER;
+const runId = process.env.GITHUB_RUN_ID;
 
-let manifest = { captured: [], errors: [] };
+let manifest = { mode: 'no-visual', captured: [], errors: [] };
 try {
   manifest = JSON.parse(fs.readFileSync(`${OUT}/manifest.json`, 'utf8'));
 } catch {
   // No manifest means the capture step did not run or produced nothing.
 }
 
-const artifact = process.env.ARTIFACT_URL || process.env.RUN_URL || '';
-const list = manifest.captured.length
-  ? manifest.captured.map((f) => `- \`${f}\``).join('\n')
-  : '_No screenshots were captured for this run._';
+// Turn a captured file name into a readable caption ("01-hud-desktop.png" -> "hud desktop").
+function caption(file) {
+  return file
+    .replace(/\.png$/i, '')
+    .replace(/^\d+-/, '')
+    .replace(/[-_]/g, ' ');
+}
 
-const body = [
-  '## Screenshots of this change',
-  '',
-  artifact
-    ? `Download the rendered client screenshots: [**pr-screenshots** artifact](${artifact})`
-    : 'Screenshots were captured but no artifact link was available.',
-  '',
-  '<details><summary>Captured frames</summary>',
-  '',
-  list,
-  '',
-  '</details>',
-  '',
-  manifest.errors?.length
-    ? `<details><summary>Capture notes (${manifest.errors.length})</summary>\n\n\`\`\`\n${manifest.errors.join('\n')}\n\`\`\`\n\n</details>`
-    : '',
-  '',
-  '<sub>Automated, non-blocking. Offline client tour (character select, desktop HUD, mobile HUD).</sub>',
-]
-  .filter((l) => l !== null)
-  .join('\n');
+const notes = manifest.errors?.length
+  ? `<details><summary>Capture notes (${manifest.errors.length})</summary>\n\n\`\`\`\n${manifest.errors.join('\n')}\n\`\`\`\n\n</details>`
+  : '';
 
-try {
+async function run() {
+  // No frames: do not spam a plain PR, but correct a prior gallery if one exists.
+  if (!manifest.captured?.length) {
+    const body = [
+      '## Screenshots of this change',
+      '',
+      'No visual changes detected in the latest commit, so no screenshots were captured.',
+      '',
+      '<sub>Automated, non-blocking. Shots are taken only for changes to the renderer, HUD/UI, styles, or client controls.</sub>',
+    ].join('\n');
+    const result = await upsertStickyComment({ marker: MARKER, body, prNumber, updateOnly: true });
+    console.log(`screenshot comment: ${result ?? 'skipped (no visual change, no prior comment)'}`);
+    return;
+  }
+
+  // Host the images, then embed whatever uploaded successfully.
+  const uploaded = await uploadScreenshots({
+    files: manifest.captured,
+    readFile: (name) => fs.readFileSync(`${OUT}/${name}`),
+    prNumber,
+    runId,
+  });
+
+  let gallery;
+  if (uploaded.length) {
+    gallery = uploaded
+      .map((u) => `**${caption(u.name)}**\n\n![${caption(u.name)}](${u.url})`)
+      .join('\n\n');
+  } else {
+    // Upload path unavailable (for example a fork PR's read-only token): degrade to a note
+    // rather than posting broken image links.
+    gallery = '_Screenshots were captured but could not be hosted for inline embedding._';
+  }
+
+  const body = [
+    '## Screenshots of this change',
+    '',
+    gallery,
+    '',
+    notes,
+    '',
+    '<sub>Automated, non-blocking. Offline client render of the sections this diff touches.</sub>',
+  ]
+    .filter((l) => l !== '')
+    .join('\n');
+
   const result = await upsertStickyComment({ marker: MARKER, body, prNumber });
   console.log(`screenshot comment: ${result ?? 'skipped'}`);
+}
+
+try {
+  await run();
 } catch (e) {
   // Non-blocking: a comment failure must not fail the screenshots job.
   console.log(`screenshot comment failed (non-blocking): ${e.message}`);

--- a/scripts/pr_screenshots.mjs
+++ b/scripts/pr_screenshots.mjs
@@ -22,7 +22,7 @@
 import fs from 'node:fs';
 import puppeteer from 'puppeteer-core';
 import { enterOfflineGame } from './enter_offline_game.mjs';
-import { classifyDiff } from './pr_shot_targets.mjs';
+import { classifyDiff, diffChangedPaths } from './pr_shot_targets.mjs';
 
 const URL = process.env.GAME_URL ?? 'http://localhost:5173';
 const OUT = process.env.SHOTS_DIR ?? 'pr-shots';
@@ -34,9 +34,8 @@ let plan = { specific: [], generic: [], isVisual: false };
 if (DIFF_FILE) {
   try {
     const diff = fs.readFileSync(DIFF_FILE, 'utf8');
-    const files = [...diff.matchAll(/^\+\+\+ b\/(.+)$/gm)]
-      .map((m) => m[1])
-      .filter((p) => p !== '/dev/null');
+    // Both diff sides, so a DELETED visual file (whose "+++" side is /dev/null) still counts.
+    const files = diffChangedPaths(diff);
     plan = classifyDiff(files);
     const shooting = plan.specific.length
       ? plan.specific.map((t) => t.key).join(', ')

--- a/scripts/pr_screenshots.mjs
+++ b/scripts/pr_screenshots.mjs
@@ -2,47 +2,69 @@
 // the change looks like. Offline only: it drives the local Vite dev client (no server, no
 // dev commands) through the shared offline entry flow and writes PNGs into SHOTS_DIR.
 //
-// Two modes:
-//   change-aware  When DIFF_FILE points at a unified diff, it maps the changed paths to the
-//                 screens they imply (see pr_shot_targets.mjs) and shoots exactly those:
-//                 a bag change -> the inventory window, a zone/map change -> the world map.
-//   fixed tour    With no diff (or no matched targets), it falls back to a consistent
-//                 baseline: character select, desktop HUD, mobile HUD.
+// Change-aware and visual-only. From the PR diff (DIFF_FILE) it decides WHAT to shoot:
+//   specific targets  a bag change -> the inventory window, a zone/map change -> the world
+//                      map (see pr_shot_targets.mjs), clipped to that window.
+//   generic HUD       a visual change with no specific window (renderer, HUD chrome, CSS)
+//                      -> the in-world desktop HUD, plus the mobile HUD when the change
+//                      touches the mobile/responsive surface.
+//   nothing           a backend/data/i18n-only diff is not visual, so it captures no frames
+//                      at all (the comment step then posts no screenshots).
+// There is no fixed tour: it never shoots unrelated parts of the game just to have something.
 //
 // Run locally:  npm run dev   (in another terminal, serves :5173)
 //               BROWSER_PATH=/path/to/chrome DIFF_FILE=pr.diff node scripts/pr_screenshots.mjs
 // Env:
 //   GAME_URL    client URL (default http://localhost:5173)
 //   SHOTS_DIR   output directory for PNGs (default pr-shots)
-//   DIFF_FILE   optional unified diff; enables change-aware capture
+//   DIFF_FILE   unified diff; required for capture (no diff -> nothing is visual -> skip)
 //   BROWSER_PATH  Chrome/Edge/Chromium binary (see browser_path.mjs)
 import fs from 'node:fs';
 import puppeteer from 'puppeteer-core';
-import { BROWSER_PATH } from './browser_path.mjs';
 import { enterOfflineGame } from './enter_offline_game.mjs';
-import { resolveTargets } from './pr_shot_targets.mjs';
+import { classifyDiff } from './pr_shot_targets.mjs';
 
 const URL = process.env.GAME_URL ?? 'http://localhost:5173';
 const OUT = process.env.SHOTS_DIR ?? 'pr-shots';
 const DIFF_FILE = process.env.DIFF_FILE;
 fs.mkdirSync(OUT, { recursive: true });
 
-// Resolve change-aware targets from the diff, when one is provided.
-let targets = [];
+// Classify the diff into a capture plan. With no diff, nothing is treated as visual.
+let plan = { specific: [], generic: [], isVisual: false };
 if (DIFF_FILE) {
   try {
     const diff = fs.readFileSync(DIFF_FILE, 'utf8');
     const files = [...diff.matchAll(/^\+\+\+ b\/(.+)$/gm)]
       .map((m) => m[1])
       .filter((p) => p !== '/dev/null');
-    targets = resolveTargets(files);
-    console.log(
-      `diff: ${files.length} changed file(s) -> targets: ${targets.map((t) => t.key).join(', ') || '(none, using fixed tour)'}`,
-    );
+    plan = classifyDiff(files);
+    const shooting = plan.specific.length
+      ? plan.specific.map((t) => t.key).join(', ')
+      : plan.generic.join(', ') || '(none, no visual change)';
+    console.log(`diff: ${files.length} changed file(s) -> shooting: ${shooting}`);
   } catch (e) {
     console.log(`could not read DIFF_FILE=${DIFF_FILE}: ${e.message}`);
   }
+} else {
+  console.log('no DIFF_FILE: nothing to classify, capturing nothing.');
 }
+
+const errors = [];
+const captured = [];
+
+// Nothing visual changed: write an empty manifest and exit clean. No browser launch.
+if (!plan.isVisual) {
+  fs.writeFileSync(
+    `${OUT}/manifest.json`,
+    JSON.stringify({ mode: 'no-visual', captured, errors }, null, 2),
+  );
+  console.log('no visual changes in this diff; captured 0 screenshots.');
+  process.exit(0);
+}
+
+// Resolve the browser lazily: the no-visual path above never needs one, and browser_path
+// throws at import when no binary is present.
+const { BROWSER_PATH } = await import('./browser_path.mjs');
 
 const browser = await puppeteer.launch({
   executablePath: BROWSER_PATH,
@@ -52,11 +74,8 @@ const browser = await puppeteer.launch({
   defaultViewport: { width: 1600, height: 900 },
 });
 
-const errors = [];
-const captured = [];
-
 // One guarded shot: a failure in one frame must not lose the others, so the run always
-// uploads whatever it managed to capture. `clip` is an optional CSS selector; when given
+// keeps whatever it managed to capture. `clip` is an optional CSS selector; when given
 // and found, the shot is cropped to that element (plus a small margin) instead of full frame.
 async function shoot(page, name, clip) {
   try {
@@ -100,7 +119,8 @@ function watch(page, tag) {
   });
 }
 
-async function changeAwareTour() {
+// Specific window targets: bring each one up in one desktop world and clip to it.
+async function shootSpecific(targets) {
   const page = await browser.newPage();
   watch(page, 'desktop');
   await page.goto(URL, { waitUntil: 'networkidle0', timeout: 60000 });
@@ -119,55 +139,54 @@ async function changeAwareTour() {
   await page.close();
 }
 
-async function fixedTour() {
-  // 1) Character-select landing (desktop): open the offline select so the class cards show.
-  const page = await browser.newPage();
-  watch(page, 'desktop');
-  await page.goto(URL, { waitUntil: 'networkidle0', timeout: 60000 });
-  await page.evaluate(() => document.querySelector('#btn-offline')?.click());
-  await page
-    .waitForSelector('#offline-select .mini-class', { visible: true, timeout: 15000 })
-    .catch(() => {});
-  await shoot(page, '01-character-select');
+// Generic HUD frames for a visual change that maps to no specific window: the in-world
+// desktop view, and the mobile view when the change touches the mobile/responsive surface.
+async function shootGenericHud(frames) {
+  let i = 1;
+  const next = () => String(i++).padStart(2, '0');
 
-  // 2) Desktop HUD in-world.
-  await enterOfflineGame(page, { charClass: 'warrior', charName: 'Thorgar', settleMs: 3000 });
-  await shoot(page, '02-hud-desktop');
-  await page.close();
+  if (frames.includes('hud-desktop')) {
+    const page = await browser.newPage();
+    watch(page, 'desktop');
+    await page.goto(URL, { waitUntil: 'networkidle0', timeout: 60000 });
+    await enterOfflineGame(page, { charClass: 'warrior', charName: 'Thorgar', settleMs: 3000 });
+    await shoot(page, `${next()}-hud-desktop`);
+    await page.close();
+  }
 
-  // 3) Mobile-viewport HUD (iPhone-class touch viewport).
-  try {
-    const mobile = await browser.newPage();
-    watch(mobile, 'mobile');
-    await mobile.emulate({
-      viewport: { width: 390, height: 844, isMobile: true, hasTouch: true, deviceScaleFactor: 2 },
-      userAgent:
-        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
-    });
-    await mobile.goto(URL, { waitUntil: 'networkidle0', timeout: 60000 });
-    await mobile.evaluate(() => document.body.classList.add('mobile-touch'));
-    await enterOfflineGame(mobile, { charClass: 'mage', charName: 'Aldwin', settleMs: 3000 });
-    await shoot(mobile, '03-hud-mobile');
-    await mobile.close();
-  } catch (e) {
-    errors.push(`MOBILE: ${e.message}`);
+  if (frames.includes('hud-mobile')) {
+    try {
+      const mobile = await browser.newPage();
+      watch(mobile, 'mobile');
+      await mobile.emulate({
+        viewport: { width: 390, height: 844, isMobile: true, hasTouch: true, deviceScaleFactor: 2 },
+        userAgent:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      });
+      await mobile.goto(URL, { waitUntil: 'networkidle0', timeout: 60000 });
+      await mobile.evaluate(() => document.body.classList.add('mobile-touch'));
+      await enterOfflineGame(mobile, { charClass: 'mage', charName: 'Aldwin', settleMs: 3000 });
+      await shoot(mobile, `${next()}-hud-mobile`);
+      await mobile.close();
+    } catch (e) {
+      errors.push(`MOBILE: ${e.message}`);
+    }
   }
 }
 
 try {
-  if (targets.length) await changeAwareTour();
-  else await fixedTour();
+  if (plan.specific.length) await shootSpecific(plan.specific);
+  else await shootGenericHud(plan.generic);
 } finally {
   await browser.close();
 }
 
 // Record the manifest so the comment step can list what was captured without re-reading.
-fs.writeFileSync(
-  `${OUT}/manifest.json`,
-  JSON.stringify({ mode: targets.length ? 'change-aware' : 'fixed', captured, errors }, null, 2),
-);
+const mode = plan.specific.length ? 'change-aware' : 'generic-hud';
+fs.writeFileSync(`${OUT}/manifest.json`, JSON.stringify({ mode, captured, errors }, null, 2));
 
 if (errors.length) console.log(`notes during capture:\n${errors.join('\n')}`);
 console.log(`captured ${captured.length} screenshot(s) into ${OUT}/`);
-// Non-zero only if we got nothing at all, so a partial run still uploads its frames.
+// Non-zero only if a visual change captured nothing at all, so a partial run still keeps
+// its frames while a total capture failure surfaces in the job log.
 process.exit(captured.length > 0 ? 0 : 1);

--- a/scripts/pr_shot_targets.mjs
+++ b/scripts/pr_shot_targets.mjs
@@ -80,3 +80,54 @@ export const TARGETS = [
 export function resolveTargets(changedFiles) {
   return TARGETS.filter((t) => changedFiles.some((f) => t.when.some((w) => f.includes(w))));
 }
+
+// Path prefixes/names that make a change "visual": the renderer, the HUD/UI, the extracted
+// CSS, local input/camera/mobile controls, and the two HTML shells. A change here can alter
+// what the client looks like even when it does not map to a specific window target above.
+const VISUAL_PREFIXES = ['src/render/', 'src/ui/', 'src/styles/', 'src/game/'];
+const VISUAL_FILES = ['index.html', 'play.html'];
+
+// Not visual even under those prefixes: the i18n text tables (labels are text, not layout),
+// and the test/doc files that sit alongside the code.
+function isTextOrTest(path) {
+  return (
+    path.includes('i18n') ||
+    path.includes('.test.') ||
+    path.startsWith('tests/') ||
+    path.endsWith('.md')
+  );
+}
+
+function isVisualPath(path) {
+  if (isTextOrTest(path)) return false;
+  if (VISUAL_FILES.includes(path)) return true;
+  return VISUAL_PREFIXES.some((p) => path.startsWith(p));
+}
+
+// A change touches the mobile/responsive surface: the mobile HUD CSS, the touch controls,
+// or the /play shell (which carries its own chrome and mobile layout).
+function isMobilePath(path) {
+  return path.includes('hud.mobile') || path.includes('mobile') || path.includes('play.html');
+}
+
+// Decide, from the changed files alone, WHAT to shoot:
+//   specific  the window targets the diff maps to (bags, world map, ...). Shot when non-empty.
+//   generic   fallback HUD frames ('hud-desktop', optionally 'hud-mobile') used only when the
+//             change is visual but maps to no specific window, so the reviewer still sees the
+//             in-world view the change lives in.
+//   isVisual  true when anything visual changed at all. When false, capture nothing: a
+//             backend/data/i18n-only diff gets no screenshots.
+// This is the whole "only shoot visual changes, and only the relevant sections" policy, kept
+// pure so it is unit-tested without a browser.
+export function classifyDiff(changedFiles) {
+  const specific = resolveTargets(changedFiles);
+  const visualFiles = changedFiles.filter(isVisualPath);
+  const isVisual = specific.length > 0 || visualFiles.length > 0;
+
+  let generic = [];
+  if (specific.length === 0 && visualFiles.length > 0) {
+    generic = ['hud-desktop'];
+    if (visualFiles.some(isMobilePath)) generic.push('hud-mobile');
+  }
+  return { specific, generic, isVisual };
+}

--- a/scripts/pr_shot_targets.mjs
+++ b/scripts/pr_shot_targets.mjs
@@ -81,6 +81,15 @@ export function resolveTargets(changedFiles) {
   return TARGETS.filter((t) => changedFiles.some((f) => t.when.some((w) => f.includes(w))));
 }
 
+// Every path a unified diff touches. Reads BOTH sides of each file header: an addition has
+// only a real "+++ b/" path, a deletion only a real "--- a/" path (its "+++" side is
+// /dev/null, which must still count as a visual change when a renderer/CSS file is removed).
+export function diffChangedPaths(diff) {
+  const paths = new Set();
+  for (const m of diff.matchAll(/^(?:---|\+\+\+) [ab]\/(.+)$/gm)) paths.add(m[1]);
+  return [...paths];
+}
+
 // Path prefixes/names that make a change "visual": the renderer, the HUD/UI, the extracted
 // CSS, local input/camera/mobile controls, and the two HTML shells. A change here can alter
 // what the client looks like even when it does not map to a specific window target above.

--- a/tests/ai_review_diff.test.ts
+++ b/tests/ai_review_diff.test.ts
@@ -1,0 +1,70 @@
+// Unit tests for the AI reviewer's diff filtering/capping helpers. Pure Node module, no
+// CLI or network.
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error - plain Node ESM script, no types
+import { capDiff, filterReviewDiff } from '../scripts/ai_review_diff.mjs';
+
+function section(path: string, body = '+x\n') {
+  return `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n@@ -1 +1 @@\n${body}`;
+}
+
+describe('filterReviewDiff', () => {
+  it('keeps hand-written code sections untouched', () => {
+    const diff = section('src/sim/spirit.ts') + section('server/game.ts');
+    const out = filterReviewDiff(diff);
+    expect(out.diff).toBe(diff);
+    expect(out.dropped).toEqual([]);
+  });
+
+  it('drops generated i18n tables, goldens, and lockfiles, reporting what it dropped', () => {
+    const keep = section('src/ui/hud.ts');
+    const diff =
+      keep +
+      section('src/ui/i18n.resolved.generated/es.ts') +
+      section('tests/parity/golden/solo_warrior.json') +
+      section('package-lock.json') +
+      section('src/ui/i18n.status.summary.json');
+    const out = filterReviewDiff(diff);
+    expect(out.diff).toBe(keep);
+    expect(out.dropped).toEqual([
+      'src/ui/i18n.resolved.generated/es.ts',
+      'tests/parity/golden/solo_warrior.json',
+      'package-lock.json',
+      'src/ui/i18n.status.summary.json',
+    ]);
+  });
+
+  it('drops binary asset sections', () => {
+    const keep = section('src/render/renderer.ts');
+    const out = filterReviewDiff(keep + section('public/icons/sword.png'));
+    expect(out.diff).toBe(keep);
+    expect(out.dropped).toEqual(['public/icons/sword.png']);
+  });
+
+  it('handles an empty diff', () => {
+    expect(filterReviewDiff('')).toEqual({ diff: '', dropped: [] });
+  });
+});
+
+describe('capDiff', () => {
+  it('returns the diff unchanged when under the cap', () => {
+    const diff = section('src/a.ts');
+    expect(capDiff(diff, 10000)).toEqual({ diff, truncated: false });
+  });
+
+  it('cuts on a file-section boundary when over the cap', () => {
+    const a = section('src/a.ts', '+aaaa\n'.repeat(50));
+    const b = section('src/b.ts', '+bbbb\n'.repeat(50));
+    const out = capDiff(a + b, a.length + 40);
+    expect(out.truncated).toBe(true);
+    // The partial second section is dropped entirely, never half a hunk.
+    expect(out.diff).toBe(a);
+  });
+
+  it('falls back to a hard cut when there is no boundary inside the cap', () => {
+    const a = section('src/a.ts', '+aaaa\n'.repeat(200));
+    const out = capDiff(a, 100);
+    expect(out.truncated).toBe(true);
+    expect(out.diff.length).toBe(100);
+  });
+});

--- a/tests/pr_shot_targets.test.ts
+++ b/tests/pr_shot_targets.test.ts
@@ -1,0 +1,65 @@
+// Unit test for the PR-screenshot diff classifier. classifyDiff is the whole "shoot only
+// visual changes, and only the sections they touch" policy, kept pure so it needs no
+// browser. The .mjs script has no TS/browser imports at module load, so vitest can import
+// it directly.
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error - plain Node ESM script, no types
+import { classifyDiff, resolveTargets } from '../scripts/pr_shot_targets.mjs';
+
+describe('classifyDiff', () => {
+  it('treats a backend/data-only diff as non-visual (captures nothing)', () => {
+    const plan = classifyDiff(['server/game.ts', 'src/sim/spirit.ts', 'server/db.ts']);
+    expect(plan.isVisual).toBe(false);
+    expect(plan.specific).toHaveLength(0);
+    expect(plan.generic).toHaveLength(0);
+  });
+
+  it('maps a bags change to the inventory window target', () => {
+    const plan = classifyDiff(['src/ui/bags.ts']);
+    expect(plan.isVisual).toBe(true);
+    expect(plan.specific.map((t: { key: string }) => t.key)).toContain('inventory');
+    // A specific window was found, so no generic HUD fallback.
+    expect(plan.generic).toHaveLength(0);
+  });
+
+  it('maps a zone/terrain change to the world-map target', () => {
+    const plan = classifyDiff(['src/render/terrain.ts']);
+    expect(plan.specific.map((t: { key: string }) => t.key)).toContain('world-map');
+  });
+
+  it('falls back to the desktop HUD for a generic visual change', () => {
+    const plan = classifyDiff(['src/render/renderer.ts']);
+    expect(plan.isVisual).toBe(true);
+    expect(plan.specific).toHaveLength(0);
+    expect(plan.generic).toEqual(['hud-desktop']);
+  });
+
+  it('adds the mobile HUD when the visual change touches the mobile surface', () => {
+    const plan = classifyDiff(['src/styles/hud.mobile.css']);
+    expect(plan.generic).toEqual(['hud-desktop', 'hud-mobile']);
+  });
+
+  it('does not treat an i18n text-table change as visual', () => {
+    const plan = classifyDiff(['src/ui/i18n.catalog/hud_chrome.ts']);
+    expect(plan.isVisual).toBe(false);
+    expect(plan.generic).toHaveLength(0);
+  });
+
+  it('does not treat a UI test file as visual', () => {
+    const plan = classifyDiff(['tests/social_view.test.ts', 'src/ui/social_view.test.ts']);
+    expect(plan.isVisual).toBe(false);
+  });
+
+  it('prefers specific targets even when other generic-visual files also changed', () => {
+    const plan = classifyDiff(['src/ui/bags.ts', 'src/render/renderer.ts']);
+    expect(plan.specific.map((t: { key: string }) => t.key)).toContain('inventory');
+    expect(plan.generic).toHaveLength(0);
+  });
+
+  it('resolveTargets stays available and returns registry-ordered matches', () => {
+    const keys = resolveTargets(['src/ui/map_window.ts', 'src/ui/bags.ts']).map(
+      (t: { key: string }) => t.key,
+    );
+    expect(keys).toEqual(['inventory', 'world-map']);
+  });
+});

--- a/tests/pr_shot_targets.test.ts
+++ b/tests/pr_shot_targets.test.ts
@@ -4,7 +4,7 @@
 // it directly.
 import { describe, expect, it } from 'vitest';
 // @ts-expect-error - plain Node ESM script, no types
-import { classifyDiff, resolveTargets } from '../scripts/pr_shot_targets.mjs';
+import { classifyDiff, diffChangedPaths, resolveTargets } from '../scripts/pr_shot_targets.mjs';
 
 describe('classifyDiff', () => {
   it('treats a backend/data-only diff as non-visual (captures nothing)', () => {
@@ -61,5 +61,38 @@ describe('classifyDiff', () => {
       (t: { key: string }) => t.key,
     );
     expect(keys).toEqual(['inventory', 'world-map']);
+  });
+});
+
+describe('diffChangedPaths', () => {
+  function section(header: string, minus: string, plus: string) {
+    return `diff --git ${header}\n--- ${minus}\n+++ ${plus}\n@@ -1 +1 @@\n-x\n+y\n`;
+  }
+
+  it('collects modified, added, and deleted paths (both diff sides, no /dev/null)', () => {
+    const diff =
+      section('a/src/ui/hud.ts b/src/ui/hud.ts', 'a/src/ui/hud.ts', 'b/src/ui/hud.ts') +
+      section('a/src/render/new.ts b/src/render/new.ts', '/dev/null', 'b/src/render/new.ts') +
+      section(
+        'a/src/styles/hud.mobile.css b/src/styles/hud.mobile.css',
+        'a/src/styles/hud.mobile.css',
+        '/dev/null',
+      );
+    expect(diffChangedPaths(diff).sort()).toEqual([
+      'src/render/new.ts',
+      'src/styles/hud.mobile.css',
+      'src/ui/hud.ts',
+    ]);
+  });
+
+  it('a DELETED visual file still classifies as a visual change', () => {
+    const diff = section(
+      'a/src/styles/hud.mobile.css b/src/styles/hud.mobile.css',
+      'a/src/styles/hud.mobile.css',
+      '/dev/null',
+    );
+    const plan = classifyDiff(diffChangedPaths(diff));
+    expect(plan.isVisual).toBe(true);
+    expect(plan.generic).toEqual(['hud-desktop', 'hud-mobile']);
   });
 });


### PR DESCRIPTION
## Summary

Unified rework of the PR AI assist bot (supersedes #1391, which is folded in here). Two
halves, one goal: the bot's output should be worth reading.

### 1. The Codex reviewer mounts the project and verifies for real

A live review had come back as "Looks fine from the visible diff. I could not verify
working-tree details because the read-only command sandbox failed before any inspection
commands ran", with the diff truncated at 60k chars. Fixes:

- **Sandbox**: `--sandbox read-only` needs the kernel sandbox (Landlock), unreliable on
  hosted runners. CI now passes `CODEX_SANDBOX=danger-full-access` (the ephemeral runner
  VM is the isolation boundary); local runs default to `workspace-write`.
- **Project mounted**: both review jobs (automatic and `/review` / `/suggest`) check out
  the PR HEAD with history, `npm ci --ignore-scripts`, and `npm run i18n:gen`.
- **Verification required**: the prompt demands evidence: read the changed files in the
  tree, run `npx tsc --noEmit`, run the vitest files covering the change (plus the
  architecture guard for `src/sim/` diffs), confirm a bug fix has a test that would fail
  without it. The review opens with an assessment plus a "Verified:" list of commands run
  and their outcomes, then constructive findings (file:line, why, proposed fix).
  Reasoning effort defaults to high; 25 min CLI budget; 35 min job timeouts.
- **Diff budget**: `scripts/ai_review_diff.mjs` (unit-tested) filters generated i18n
  tables, parity goldens, lockfiles, and binary assets from the inlined diff and caps it
  on a file boundary (60k -> 150k). The agent also gets `BASE_SHA`/`HEAD_SHA` to read the
  full diff via git. An all-churn diff skips the review entirely.
- **Trusted-code split on `/review`** (found by this PR's own automatic Codex review, as
  a high finding, and fixed here): the comment job keeps the reviewer scripts in a
  default-branch checkout at the workspace root while the PR head sits in `pr/`
  (`REVIEW_CWD`), so a fork PR can never swap `ai_review.mjs` itself to read the raw
  secret. Remaining fork-PR tradeoffs are documented on the job and in
  `docs/ai-pr-bot.md` (maintainer opt-in via the author-association gate, no third-party
  install hooks, raw secret scrubbed from the agent's child env, minimal token).

### 2. Screenshots: inline, and only for visual changes

- A pure classifier (`classifyDiff` in `scripts/pr_shot_targets.mjs`, unit-tested) maps
  the changed files to: specific windows (bags -> inventory, zones/terrain -> world map,
  cropped), a generic in-world HUD (desktop, plus mobile when the mobile/responsive
  surface is touched), or nothing at all for a backend/data/i18n-only diff. The fixed
  tour of unrelated screens is gone.
- The PNGs are embedded inline in the sticky comment: `scripts/gh_image_host.mjs`
  uploads them to a bot-owned orphan branch (`bot-pr-screenshots`) and the comment
  references the raw URLs. The artifact upload is removed. Non-visual PRs post no
  screenshot comment; a stale gallery is flipped to a short note (new `updateOnly`
  option on the sticky-comment helper). The screenshots job gains `contents: write`;
  fork PRs degrade to a note as before.

## Verification

- `tests/ai_review_diff.test.ts` (7) + `tests/pr_shot_targets.test.ts` (9): 16 pass.
- Smoke-ran locally: non-visual diff captures nothing and needs no browser (lazy browser
  import); all-churn diff skips the review before invoking the CLI; CLI failure degrades
  to the non-blocking note; comment step with empty manifest and no token degrades clean.
- Workflow YAML parses; Biome clean on changed files; pre-push floor green.
- The automatic review on this PR already exercised the new reviewer end to end (it
  produced the verified, structured review that caught the trusted-code finding above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
