### PR TITLE
fix(chat): tab strip stays one row, add-channel picker dismisses

### DIFF
--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -1522,14 +1522,26 @@
   }
   #chatlog-tabs {
     display: flex;
-    flex-wrap: wrap;
+    /* Stay a single clean row as tabs are added: never wrap the "+" to its own
+       line. When the tabs outgrow the strip they scroll horizontally instead
+       (the scrollbar is hidden for the classic look; wheel-to-horizontal is
+       wired in renderChatTabs, and the "+" stays pinned via position: sticky). */
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
     gap: 2px;
     margin-left: 6px;
     margin-bottom: -1px;
     position: relative;
     z-index: 2;
   }
+  #chatlog-tabs::-webkit-scrollbar {
+    display: none;
+  }
   .chat-tab {
+    /* keep each tab its natural width and let the strip scroll, never squish */
+    flex: 0 0 auto;
     height: 22px;
     padding: 0 12px;
     border: 1px solid #3a321d;
@@ -1547,8 +1559,12 @@
     border-color: #6f5a2a;
     background: linear-gradient(#2a2436, #161220);
   }
-  /* "add channel" (+) tab: square, icon-only, slightly de-emphasised */
+  /* "add channel" (+) tab: square, icon-only, slightly de-emphasised. Sticks to
+     the right edge so it stays inline and reachable even when the tabs scroll. */
   .chat-tab-add {
+    flex: 0 0 auto;
+    position: sticky;
+    right: 0;
     padding: 0;
     width: 26px;
     font-size: 15px;

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -1530,6 +1530,10 @@
     overflow-x: auto;
     overflow-y: hidden;
     scrollbar-width: none;
+    /* Desktop: the empty strip is a chat-box move handle (a touch-drag moves the
+       box), so suppress the browser's own touch gesture here. Mobile has no move
+       gesture and overrides this to pan-x so overflowed tabs stay swipeable. */
+    touch-action: none;
     gap: 2px;
     margin-left: 6px;
     margin-bottom: -1px;

--- a/src/styles/hud.mobile.css
+++ b/src/styles/hud.mobile.css
@@ -729,6 +729,11 @@
   body.mobile-touch #chatlog-tabs {
     transform: scale(0.92);
     transform-origin: left bottom;
+    /* The chat-box move gesture is desktop-only (onChatBoxMoveStart bails on mobile),
+       so allow a horizontal touch-pan here to reach tabs that overflow the strip
+       (its scrollbar is hidden for the classic look). */
+    touch-action: pan-x;
+    -webkit-overflow-scrolling: touch;
   }
   body.mobile-touch #chat-input {
     left: max(10px, env(safe-area-inset-left));

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -815,6 +815,9 @@ export class Hud {
   // shown, and drives both the log filter and the send channel.
   private chatTabs: ChatOpenTab[] = [];
   private activeChatTab: ChatTabId = 'all';
+  // Bind the tab-strip wheel-to-horizontal-scroll listener exactly once (renderChatTabs
+  // rebuilds the strip's children but the bar element itself persists).
+  private chatTabsWheelBound = false;
   private errorEl = $('#error-msg');
   private bannerEl = $('#banner');
   // The WoW-style quest-progress flash (quest_progress_banner.ts): yellow
@@ -2310,6 +2313,22 @@ export class Hud {
 
   private renderChatTabs(): void {
     const bar = $('#chatlog-tabs');
+    // Overflowed tabs scroll horizontally (see #chatlog-tabs in hud.css); translate
+    // a vertical wheel into that scroll (bound once, the bar element persists across
+    // these innerHTML rebuilds) so a mouse without a horizontal wheel can still reach
+    // them. A no-op until the strip actually overflows.
+    if (!this.chatTabsWheelBound) {
+      this.chatTabsWheelBound = true;
+      bar.addEventListener(
+        'wheel',
+        (ev) => {
+          if (ev.deltaY === 0 || bar.scrollWidth <= bar.clientWidth) return;
+          ev.preventDefault();
+          bar.scrollLeft += ev.deltaY;
+        },
+        { passive: false },
+      );
+    }
     bar.innerHTML = '';
     bar.setAttribute('role', 'tablist');
     const makeTab = (id: ChatTabId, label: string): HTMLButtonElement => {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -818,6 +818,10 @@ export class Hud {
   // Bind the tab-strip wheel-to-horizontal-scroll listener exactly once (renderChatTabs
   // rebuilds the strip's children but the bar element itself persists).
   private chatTabsWheelBound = false;
+  // The control that opened the shared #ctx-menu (the chat "+" button), so the
+  // outside-click closer can defer to that opener's own toggle click. Cleared on
+  // every close path (closeContextMenu + item activation).
+  private ctxMenuOpener: HTMLElement | null = null;
   private errorEl = $('#error-msg');
   private bannerEl = $('#banner');
   // The WoW-style quest-progress flash (quest_progress_banner.ts): yellow
@@ -1265,6 +1269,20 @@ export class Hud {
       document.body.classList.remove('mobile-more-open');
       document.getElementById('mobile-controls')?.classList.remove('expanded');
       document.getElementById('mobile-more')?.classList.remove('active');
+    });
+    // Dismiss the shared #ctx-menu (right-click menus and the chat "+" channel
+    // picker) on any pointerdown outside it. A pointerdown inside the menu is left
+    // to the item's own click; a pointerdown on the opener is left to that opener's
+    // toggle (so a second click on + closes rather than reopens). Escape still
+    // closes it through the unified closeAll dispatcher.
+    document.addEventListener('pointerdown', (ev) => {
+      const menu = $('#ctx-menu');
+      if (menu.style.display !== 'block') return;
+      const target = ev.target as Node | null;
+      if (!target) return;
+      if (menu.contains(target)) return;
+      if (this.ctxMenuOpener?.contains(target)) return;
+      this.closeContextMenu();
     });
     // classic-style minimap clock: real local time under the minimap; click it to
     // flip between 12-hour (AM/PM) and 24-hour display. Real-time clocks are a
@@ -2363,8 +2381,14 @@ export class Hud {
     add.setAttribute('aria-label', t('hud.core.chatChannels.add'));
     add.title = t('hud.core.chatChannels.add');
     add.addEventListener('click', () => {
+      // Toggle: a second click on + closes the picker it opened.
+      const menu = $('#ctx-menu');
+      if (menu.style.display === 'block' && this.ctxMenuOpener === add) {
+        this.closeContextMenu();
+        return;
+      }
       const r = add.getBoundingClientRect();
-      this.openChatChannelMenu(r.left, r.bottom);
+      this.openChatChannelMenu(r.left, r.bottom, add);
     });
     bar.append(add);
     this.updateActiveTabStyles();
@@ -2439,8 +2463,9 @@ export class Hud {
   // toggle off; the rest add a tab. Whisper is offered alongside the channels as
   // a filter-only tab that gathers every whisper in one place. Reuses the shared
   // #ctx-menu, so it inherits its outside-click / Escape close behaviour.
-  private openChatChannelMenu(x: number, y: number): void {
+  private openChatChannelMenu(x: number, y: number, opener: HTMLElement | null = null): void {
     const el = $('#ctx-menu');
+    this.ctxMenuOpener = opener;
     let html = `<div class="ctx-title">${esc(t('hud.core.chatChannels.addTitle'))}</div>`;
     // A trailing check mark flags already-open tabs, exactly as the channel list
     // did before this whisper tab was added. Built from its char code so no literal
@@ -11665,7 +11690,7 @@ export class Hud {
       const activate = () => {
         const act = item.dataset.act;
         if (!act) return;
-        el.style.display = 'none';
+        this.closeContextMenu();
         onActivate(act);
       };
       item.addEventListener('click', activate);
@@ -11810,6 +11835,7 @@ export class Hud {
 
   closeContextMenu(): void {
     $('#ctx-menu').style.display = 'none';
+    this.ctxMenuOpener = null;
   }
 
   // -------------------------------------------------------------------------

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -2057,7 +2057,10 @@ export class Hud {
     grip.setAttribute('aria-hidden', 'true');
     frame.appendChild(grip);
 
-    tabs.style.touchAction = 'none';
+    // touch-action lives in CSS now: `none` on desktop so a touch-drag on the empty
+    // strip moves the chat box (the move gesture is desktop-only, see
+    // onChatBoxMoveStart), and `pan-x` on mobile so overflowed tabs can be swiped
+    // (hud.mobile.css). An inline style here would override those rules.
     tabs.setAttribute('aria-label', t('hudChrome.chatWindow.move'));
     tabs.addEventListener('pointerdown', (ev) => this.onChatBoxMoveStart(ev, wrap, tabs));
     grip.addEventListener('pointerdown', (ev) => this.onChatBoxResizeStart(ev, wrap, frame));

--- a/tests/chat_tab_strip.test.ts
+++ b/tests/chat_tab_strip.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// Source guards for the #1365 chat tab-strip fix. The behavior is otherwise only
+// reachable in a live browser, so these pin the load-bearing declarations: a future
+// edit that reintroduces the wrap, unpins the add button, or drops the mobile
+// touch-pan (the exact regressions this PR fixes) fails here instead of silently.
+const hud = readFileSync(new URL('../src/styles/hud.css', import.meta.url), 'utf8');
+const mobile = readFileSync(new URL('../src/styles/hud.mobile.css', import.meta.url), 'utf8');
+
+// First declaration block for an exact `selector {` (not a descendant/pseudo rule).
+function block(css: string, selector: string): string {
+  const at = css.indexOf(`${selector} {`);
+  if (at < 0) throw new Error(`selector not found: ${selector}`);
+  const open = css.indexOf('{', at);
+  const close = css.indexOf('}', open);
+  return css.slice(open + 1, close);
+}
+
+describe('chat tab strip layout (issue #1365)', () => {
+  it('#chatlog-tabs stays a single nowrap row that scrolls horizontally on overflow', () => {
+    const b = block(hud, '#chatlog-tabs');
+    expect(b).toMatch(/flex-wrap:\s*nowrap/);
+    expect(b).toMatch(/overflow-x:\s*auto/);
+  });
+
+  it('the add-channel button stays pinned inline (never drops to its own row)', () => {
+    expect(block(hud, '.chat-tab-add')).toMatch(/position:\s*sticky/);
+  });
+
+  it('desktop suppresses the browser touch gesture on the move-handle strip', () => {
+    expect(block(hud, '#chatlog-tabs')).toMatch(/touch-action:\s*none/);
+  });
+
+  it('mobile keeps the strip horizontally swipeable so overflowed tabs stay reachable', () => {
+    expect(block(mobile, 'body.mobile-touch #chatlog-tabs')).toMatch(/touch-action:\s*pan-x/);
+  });
+});


### PR DESCRIPTION
## Problem

Part of #1365. Two of the chat window's problems are layout/interaction bugs on the tab strip and the add-channel picker:

1. The tab strip used `flex-wrap: wrap`, so once more than the default channels were open the tabs wrapped to a second row and the "+" button dropped onto its own line. The window looked broken as tabs were added.
2. The "+" channel picker could not be dismissed: clicking "+" again did not close it, and clicking anywhere else (on or outside the window) did not either. Only Escape or selecting an item closed it.

## What this changes

- **Tab strip stays a single clean row (`fix(chat)` commit 1).** `#chatlog-tabs` is now `flex-wrap: nowrap` and scrolls horizontally when the tabs overflow (scrollbar hidden for the classic look), the tabs never squish (`flex: 0 0 auto`), and the "+" stays inline and reachable via `position: sticky; right: 0`. A vertical wheel over the strip is translated to horizontal scroll (bound once) so a plain mouse can reach overflowed tabs, and it no-ops until the strip actually overflows.
- **Picker toggles and dismisses (`fix(chat)` commit 2).** A document `pointerdown` closes the shared `#ctx-menu` on any click outside it, "+" is now a proper toggle (a second click closes the picker it opened), and the tracked opener is cleared on every close path so the outside-click defers to the opener's own toggle. This also gives every right-click context menu the same click-away dismissal. Escape still closes via the existing `closeAll` dispatcher.

## Scope

Focused on the tab strip and the picker. The other two items in #1365 are intentionally out of scope here to avoid duplicated work:

- The message-input sizing/centering is already handled by #1234 (`fix(ui): size chat input for placeholder text`).
- Drag-to-reorder tabs with persisted order is a separable feature and will land as a follow-up PR.

## Verification

Driven in the real offline game (`npm run dev`), warrior in Eastbrook Vale, with 8 open tabs (all, combat, world, lfg, yell, general, whisper, +):

- Tab strip: `barHeight = 22px` (one row, not wrapped), all tab tops on a single row, strip overflows (`scrollWidth 528 > clientWidth 364`) and scrolls, `flex-wrap: nowrap`, `overflow-x: auto`, "+" on the first row with `position: sticky`.
- Picker: click "+" opens, second "+" click closes (toggle), click outside closes, Escape/`closeAll` closes. All seven state transitions asserted.
- `tsc --noEmit` clean; `css_corpus` / `css_value_validity` / `styles_extraction` guard suites green; biome clean on the changed files; no new i18n keys (the picker reuses existing `t()` keys).

Screenshots (offline game): the tab strip staying one row with the "+" pinned, and the add-channel picker open, attached below.

## Checklist

- [x] Targets `release/v0.20.0`
- [x] `tsc` + guard suites + biome (changed files) green
- [x] No em/en dashes, emoji, or attribution lines
- [x] UI change verified in the offline game (desktop); mobile chat tab strip unaffected (the mobile block only sets the strip cursor)
- [x] No new player-visible strings (existing `t()` keys reused)
