### PR TITLE
fix(sim): lock cast and channel targets at cast start

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -774,6 +774,7 @@ function blankEntity(id: number): Entity {
     castingAbility: null,
     castRemaining: 0,
     castTotal: 0,
+    castTargetId: null,
     castAim: null,
     channeling: false,
     channelTickTimer: 0,

--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -132,6 +132,7 @@ export function updateCasting(ctx: SimContext, p: Entity, meta: PlayerMeta): voi
       // completed ground-targeted channels drop their aim like every other
       // resolve path: castAim is always cleared on resolve
       p.castAim = null;
+      p.castTargetId = null;
       ctx.emit({ type: 'castStop', entityId: p.id, success: true });
     }
     return;
@@ -151,6 +152,7 @@ export function updateCasting(ctx: SimContext, p: Entity, meta: PlayerMeta): voi
     // the aim point is consumed by the resolved area effects; drop it so a later
     // non-aimed cast can't inherit a stale target point.
     p.castAim = null;
+    p.castTargetId = null;
   }
 }
 
@@ -159,6 +161,7 @@ export function cancelCast(ctx: SimContext, p: Entity): void {
   p.castRemaining = 0;
   p.channeling = false;
   p.castAim = null;
+  p.castTargetId = null;
   ctx.emit({ type: 'castStop', entityId: p.id, success: false });
 }
 
@@ -413,6 +416,7 @@ export function castAbility(
     if (!p.autoAttack && target) ctx.startAutoAttack(p.id);
     return;
   }
+  p.castTargetId = target?.id ?? null;
 
   const gcd = ctx.playerGcdFor(meta.cls);
   // A channel keeps its duration, so it must not eat a next_cast_instant charge.
@@ -465,6 +469,7 @@ export function castAbility(
   applyAbility(ctx, p, meta, res);
   // instant ground-targeted cast: its effects have consumed the aim point.
   p.castAim = null;
+  p.castTargetId = null;
 }
 
 export function spendResource(p: Entity, cost: number): void {
@@ -540,7 +545,7 @@ function applyChannelTick(ctx: SimContext, p: Entity, res: ResolvedAbility): voi
     return;
   }
 
-  const target = p.targetId !== null ? ctx.entities.get(p.targetId) : null;
+  const target = p.castTargetId !== null ? ctx.entities.get(p.castTargetId) : null;
   if (!target || target.dead || !ctx.isHostileTo(p, target)) {
     cancelCast(ctx, p);
     return;
@@ -649,7 +654,7 @@ function applyAbility(ctx: SimContext, p: Entity, meta: PlayerMeta, res: Resolve
 
   let target: Entity | null = null;
   if (ability.requiresTarget && ability.targetType === 'friendly') {
-    const cur = p.targetId !== null ? (ctx.entities.get(p.targetId) ?? null) : null;
+    const cur = p.castTargetId !== null ? (ctx.entities.get(p.castTargetId) ?? null) : null;
     target = cur && !cur.dead && ctx.isFriendlyTo(p, cur) ? cur : p;
     if (dist2d(p.pos, target.pos) > Math.max(ability.range, 5) + 2) {
       ctx.error(p.id, 'Out of range.');
@@ -660,7 +665,7 @@ function applyAbility(ctx: SimContext, p: Entity, meta: PlayerMeta, res: Resolve
       return;
     }
   } else if (ability.requiresTarget) {
-    target = p.targetId !== null ? (ctx.entities.get(p.targetId) ?? null) : null;
+    target = p.castTargetId !== null ? (ctx.entities.get(p.castTargetId) ?? null) : null;
     if (!target || target.dead || !ctx.isHostileTo(p, target)) {
       ctx.error(p.id, 'You have no target.');
       return;

--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -483,6 +483,7 @@ export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): 
   e.auras = aurasSurvivingDeath(e.auras);
   e.ccDr.clear();
   e.castingAbility = null;
+  e.castTargetId = null;
   ctx.emit({ type: 'death', entityId: e.id, killerId: killer?.id ?? -1 });
 
   // a dead mob keeps no raid marker — respawnMob reuses the same entity id,

--- a/src/sim/encounters/nythraxis.ts
+++ b/src/sim/encounters/nythraxis.ts
@@ -209,6 +209,7 @@ export function resetNythraxisEncounter(ctx: SimContext, boss: Entity): void {
   boss.castingAbility = null;
   boss.castRemaining = 0;
   boss.castTotal = 0;
+  boss.castTargetId = null;
   boss.channeling = false;
 }
 
@@ -583,6 +584,7 @@ export function startNythraxisTransition(
   boss.castingAbility = null;
   boss.castRemaining = 0;
   boss.castTotal = 0;
+  boss.castTargetId = null;
   const transitionLines = [
     { speaker: 'nythraxis' as const, text: 'Another priest...', delay: 0 },
     { speaker: 'aldric' as const, text: 'Your kingdom is gone, Nythraxis', delay: 3.0 },
@@ -790,6 +792,7 @@ export function startNythraxisDeathlessRage(
   boss.castingAbility = 'nythraxis_deathless_rage';
   boss.castTotal = NYTHRAXIS_DEATHLESS_CAST;
   boss.castRemaining = NYTHRAXIS_DEATHLESS_CAST;
+  boss.castTargetId = null;
   boss.channeling = false;
   nythraxisSay(ctx, boss, 'nythraxis', 'Witness true eternity!', true);
   ctx.emit({
@@ -810,12 +813,14 @@ export function updateNythraxisDeathlessRage(
   boss.castingAbility = 'nythraxis_deathless_rage';
   boss.castTotal = NYTHRAXIS_DEATHLESS_CAST;
   boss.castRemaining = st.deathlessCastRemaining;
+  boss.castTargetId = null;
   updateNythraxisWardChannels(ctx, boss, st);
   if (nythraxisWardstoneInterruptReady(st)) {
     st.deathlessCastRemaining = 0;
     boss.castingAbility = null;
     boss.castRemaining = 0;
     boss.castTotal = 0;
+    boss.castTargetId = null;
     st.deathlessStunRemaining = NYTHRAXIS_DEATHLESS_STUN;
     ctx.applyAura(boss, {
       id: 'nythraxis_deathless_stun',
@@ -840,6 +845,7 @@ export function updateNythraxisDeathlessRage(
   boss.castingAbility = null;
   boss.castRemaining = 0;
   boss.castTotal = 0;
+  boss.castTargetId = null;
   nythraxisSay(ctx, boss, 'nythraxis', 'You cannot stop what was promised..', true);
   ctx.emit({
     type: 'spellfx',
@@ -891,6 +897,7 @@ export function updateNythraxisWardChannels(
     p.channeling = true;
     p.castTotal = NYTHRAXIS_DEATHLESS_CHANNEL;
     p.castRemaining = channel.remaining;
+    p.castTargetId = null;
     ctx.emit({
       type: 'spellfx',
       sourceId: ward.id,
@@ -918,6 +925,7 @@ export function clearNythraxisWardChannelCast(p: Entity): void {
   p.channeling = false;
   p.castRemaining = 0;
   p.castTotal = 0;
+  p.castTargetId = null;
 }
 
 export function nythraxisWardstones(ctx: SimContext, boss: Entity): Entity[] {
@@ -963,6 +971,7 @@ export function tryStartNythraxisWardChannel(
   player.channeling = true;
   player.castTotal = NYTHRAXIS_DEATHLESS_CHANNEL;
   player.castRemaining = NYTHRAXIS_DEATHLESS_CHANNEL;
+  player.castTargetId = null;
   ctx.emit({
     type: 'spellfx',
     sourceId: ward.id,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -51,6 +51,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     castingAbility: null,
     castRemaining: 0,
     castTotal: 0,
+    castTargetId: null,
     castAim: null,
     channeling: false,
     channelTickTimer: 0,

--- a/src/sim/mob/lifecycle.ts
+++ b/src/sim/mob/lifecycle.ts
@@ -86,6 +86,7 @@ export function respawnMob(ctx: SimContext, mob: Entity): void {
     mob.castingAbility = null;
     mob.castTotal = 0;
     mob.castRemaining = 0;
+    mob.castTargetId = null;
   }
   mob.yelledEngage = false;
   mob.wanderTimer = ctx.rng.range(2, 8);

--- a/src/sim/mob/locomotion.ts
+++ b/src/sim/mob/locomotion.ts
@@ -398,6 +398,7 @@ export function updateMob(ctx: SimContext, mob: Entity): void {
             mob.castingAbility = null;
             mob.castTotal = 0;
             mob.castRemaining = 0;
+            mob.castTargetId = null;
             const school = (bigCast.school ?? 'nature') as Aura['school'];
             ctx.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
             ctx.emit({
@@ -421,6 +422,7 @@ export function updateMob(ctx: SimContext, mob: Entity): void {
             mob.castingAbility = bigCast.castId;
             mob.castTotal = bigCast.castTime;
             mob.castRemaining = bigCast.castTime;
+            mob.castTargetId = null;
             mob.channeling = false;
             if (bigCast.yell) emitMobYell(ctx, mob, bigCast.yell);
           }
@@ -598,6 +600,7 @@ export function resetEvadingMob(ctx: SimContext, mob: Entity): void {
     mob.castingAbility = null;
     mob.castTotal = 0;
     mob.castRemaining = 0;
+    mob.castTargetId = null;
   }
   mob.yelledEngage = false;
   mob.wanderTimer = ctx.rng.range(2, 8);

--- a/src/sim/pet/pet_commands.ts
+++ b/src/sim/pet/pet_commands.ts
@@ -656,6 +656,7 @@ export function healPet(ctx: SimContext, pid?: number): void {
   r.e.castingAbility = DEMON_HEAL_CAST_ID;
   r.e.castTotal = DEMON_HEAL_DURATION;
   r.e.castRemaining = DEMON_HEAL_DURATION;
+  r.e.castTargetId = null;
   r.e.channeling = true;
   r.e.channelTickEvery = DEMON_HEAL_TICK;
   r.e.channelTickTimer = DEMON_HEAL_TICK;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4883,6 +4883,7 @@ export class Sim {
     p.castingAbility = FISHING_CAST_ID;
     p.castTotal = FISHING_CAST_TIME;
     p.castRemaining = FISHING_CAST_TIME;
+    p.castTargetId = null;
     p.channeling = false;
     this.emit({
       type: 'castStart',

--- a/src/sim/social/arena.ts
+++ b/src/sim/social/arena.ts
@@ -734,6 +734,7 @@ export function readyArenaFighter(ctx: SimContext, e: Entity, opts: { clearPrep:
   delete e.queuedOnSwingFree;
   e.castingAbility = null;
   e.castRemaining = 0;
+  e.castTargetId = null;
   e.channeling = false;
   e.comboPoints = 0;
   e.comboUntil = -1;

--- a/src/sim/social/fiesta.ts
+++ b/src/sim/social/fiesta.ts
@@ -290,6 +290,7 @@ export function fiestaDownEntity(ctx: SimContext, e: Entity, killer: Entity | nu
   e.ccDr.clear();
   e.castingAbility = null;
   e.castRemaining = 0;
+  e.castTargetId = null;
   e.channeling = false;
   e.autoAttack = false;
   e.queuedOnSwing = null;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1469,6 +1469,12 @@ export interface Entity {
   castingAbility: string | null;
   castRemaining: number;
   castTotal: number;
+  // Entity-targeted casting: the target captured at cast start for entity-targeted
+  // casts (hostile and friendly) and channels. Timed casts and channel ticks resolve
+  // against this id, so retargeting mid-cast/mid-channel cannot redirect the spell,
+  // and clearing your target no longer cancels a channel. The channel still cancels
+  // if the locked target dies or turns non-hostile.
+  castTargetId: number | null;
   // Ground-targeted casting: the world point a `targetMode: 'position'` ability is
   // aimed at, captured (server-clamped to range) when the cast begins and read by
   // its area effects when it resolves. null for normal entity/self casts.

--- a/tests/combat_casting_lifecycle.test.ts
+++ b/tests/combat_casting_lifecycle.test.ts
@@ -13,8 +13,10 @@ import {
   pushbackCast,
   updateCasting,
 } from '../src/sim/combat/casting_lifecycle';
+import { handleDeath } from '../src/sim/combat/damage';
 import { MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
+import { advancePendingProjectiles } from '../src/sim/projectile_travel';
 import { Sim } from '../src/sim/sim';
 import type { Entity, PlayerClass } from '../src/sim/types';
 import { CAST_PUSHBACK_SEC, CHANNEL_PUSHBACK_FRACTION } from '../src/sim/types';
@@ -70,6 +72,53 @@ describe('casting_lifecycle: timed cast start -> progress -> finish', () => {
     expect(ticks).toBeGreaterThan(1); // actually progressed over multiple ticks
     expect(p.hp).toBeGreaterThan(hp0); // applyAbility ran the heal effect
   });
+
+  it('resolves a completed hostile cast against the target selected at cast start', () => {
+    const { sim, p, meta } = makeSim('mage', 12);
+    const firstTarget = spawnTarget(sim, p, 12, 6);
+    const firstHp0 = firstTarget.hp;
+    castAbility(sim.ctx, 'fireball', p.id);
+    expect(p.castingAbility).toBe('fireball');
+    expect(p.castTargetId).toBe(firstTarget.id);
+
+    const secondTarget = spawnTarget(sim, p, 12, 8);
+    const secondHp0 = secondTarget.hp;
+    expect(p.targetId).toBe(secondTarget.id);
+    sim.rng.chance = () => true;
+    drainCast(sim, p, meta);
+
+    expect(p.castingAbility).toBeNull();
+    expect(p.castTargetId).toBeNull();
+    expect(sim.ctx.pendingProjectiles[0]?.targetId).toBe(firstTarget.id);
+    for (let i = 0; i < 200 && sim.ctx.pendingProjectiles.length > 0; i++)
+      advancePendingProjectiles(sim.ctx);
+    expect(firstTarget.hp).toBeLessThan(firstHp0);
+    expect(secondTarget.hp).toBe(secondHp0);
+  });
+
+  it('resolves a completed friendly heal against the target locked at cast start', () => {
+    const { sim, p, meta } = makeSim('priest', 12);
+    const ally = sim.entities.get(sim.addPlayer('warrior', 'Ally')) as AnyEntity;
+    const bystander = sim.entities.get(sim.addPlayer('rogue', 'Bystander')) as AnyEntity;
+    ally.hp = Math.max(1, ally.maxHp - 500);
+    bystander.hp = Math.max(1, bystander.maxHp - 500);
+    const allyHp0 = ally.hp;
+    const bystanderHp0 = bystander.hp;
+
+    sim.targetEntity(ally.id, p.id);
+    castAbility(sim.ctx, 'lesser_heal', p.id);
+    expect(p.castingAbility).toBe('lesser_heal');
+    expect(p.castTargetId).toBe(ally.id);
+
+    sim.targetEntity(bystander.id, p.id); // retarget mid-cast
+    expect(p.targetId).toBe(bystander.id);
+    drainCast(sim, p, meta);
+
+    expect(p.castingAbility).toBeNull();
+    expect(p.castTargetId).toBeNull();
+    expect(ally.hp).toBeGreaterThan(allyHp0); // the heal landed on the locked target
+    expect(bystander.hp).toBe(bystanderHp0); // the current target got nothing
+  });
 });
 
 describe('casting_lifecycle: channel start -> tick -> finish', () => {
@@ -91,6 +140,81 @@ describe('casting_lifecycle: channel start -> tick -> finish', () => {
     for (let i = 0; i < 20 && mob.hp >= mobHp0; i++) sim.tick();
     expect(mob.hp).toBeLessThan(mobHp0); // applyChannelTick dealt drain damage
   });
+
+  it('keeps channel ticks on the target locked at channel start after retargeting', () => {
+    const { sim, p, meta } = makeSim('warlock', 12);
+    const first = spawnTarget(sim, p, 12, 6);
+    const firstHp0 = first.hp;
+    sim.drainEvents();
+    castAbility(sim.ctx, 'drain_life', p.id);
+    expect(p.channeling).toBe(true);
+    expect(p.castTargetId).toBe(first.id);
+
+    const second = spawnTarget(sim, p, 12, 8); // spawnTarget also retargets p to it
+    const secondHp0 = second.hp;
+    expect(p.targetId).toBe(second.id);
+    drainCast(sim, p, meta);
+
+    const stops = sim
+      .drainEvents()
+      .filter((e: any) => e.type === 'castStop' && e.entityId === p.id);
+    expect(stops.some((e: any) => e.success === false)).toBe(false); // never cancelled
+    for (let i = 0; i < 200 && sim.ctx.pendingProjectiles.length > 0; i++)
+      advancePendingProjectiles(sim.ctx);
+    expect(first.hp).toBeLessThan(firstHp0); // ticks kept hitting the locked target
+    expect(second.hp).toBe(secondHp0); // the new current target was never drained
+  });
+
+  it('keeps a channel ticking when the current target is cleared mid-channel', () => {
+    const { sim, p, meta } = makeSim('warlock', 12);
+    const mob = spawnTarget(sim, p, 12, 6);
+    const mobHp0 = mob.hp;
+    sim.drainEvents();
+    castAbility(sim.ctx, 'drain_life', p.id);
+    expect(p.castTargetId).toBe(mob.id);
+
+    for (let i = 0; i < 25; i++) updateCasting(sim.ctx, p, meta); // past the 1s tick
+    sim.targetEntity(null, p.id); // clear the current target mid-channel
+    expect(p.targetId).toBeNull();
+    for (let i = 0; i < 25; i++) updateCasting(sim.ctx, p, meta); // crosses the 2s tick
+    expect(p.castingAbility).toBe('drain_life'); // NOT cancelled by the cleared target
+    expect(p.channeling).toBe(true);
+
+    drainCast(sim, p, meta);
+    const stops = sim
+      .drainEvents()
+      .filter((e: any) => e.type === 'castStop' && e.entityId === p.id);
+    expect(stops.some((e: any) => e.success === false)).toBe(false); // never cancelled
+    expect((stops.at(-1) as any)?.success).toBe(true); // ran to completion
+    for (let i = 0; i < 200 && sim.ctx.pendingProjectiles.length > 0; i++)
+      advancePendingProjectiles(sim.ctx);
+    expect(mob.hp).toBeLessThan(mobHp0); // the locked target kept taking ticks
+  });
+
+  it('cancels the channel when the locked target dies mid-channel', () => {
+    const { sim, p, meta } = makeSim('warlock', 12);
+    const mob = spawnTarget(sim, p, 12, 6);
+    sim.drainEvents();
+    castAbility(sim.ctx, 'drain_life', p.id);
+    expect(p.castTargetId).toBe(mob.id);
+
+    for (let i = 0; i < 22; i++) updateCasting(sim.ctx, p, meta); // the 1s tick fired
+    expect(p.castingAbility).toBe('drain_life');
+    handleDeath(sim.ctx, mob, p); // the locked target dies mid-channel
+    for (let i = 0; i < 25 && p.castingAbility; i++) updateCasting(sim.ctx, p, meta);
+
+    expect(p.castingAbility).toBeNull(); // the 2s tick found a dead locked target
+    expect(p.channeling).toBe(false);
+    expect(p.castTargetId).toBeNull();
+    expect(p.castRemaining).toBe(0);
+    // cancelCast emitted castStop(success:false). (updateCasting's channel branch also
+    // emits a trailing success:true because the cancel zeroed castRemaining — a
+    // pre-existing quirk of mid-tick cancellation, so assert on the cancel event.)
+    const stops = sim
+      .drainEvents()
+      .filter((e: any) => e.type === 'castStop' && e.entityId === p.id);
+    expect(stops.some((e: any) => e.success === false)).toBe(true);
+  });
 });
 
 describe('casting_lifecycle: interrupt (cancelCast)', () => {
@@ -107,6 +231,15 @@ describe('casting_lifecycle: interrupt (cancelCast)', () => {
     const stop = sim.drainEvents().find((e: any) => e.type === 'castStop' && e.entityId === p.id);
     expect(stop).toBeTruthy();
     expect((stop as any).success).toBe(false);
+  });
+
+  it('clears the locked cast target on interrupt', () => {
+    const { sim, p } = makeSim('mage', 12);
+    const mob = spawnTarget(sim, p);
+    castAbility(sim.ctx, 'fireball', p.id);
+    expect(p.castTargetId).toBe(mob.id);
+    cancelCast(sim.ctx, p);
+    expect(p.castTargetId).toBeNull();
   });
 });
 

--- a/tests/parity/golden/c4a_casting_lifecycle.json
+++ b/tests/parity/golden/c4a_casting_lifecycle.json
@@ -35,7 +35,7 @@
       "tick": 1,
       "time": 0.05,
       "nextId": 404,
-      "state": "841da602",
+      "state": "a08a8986",
       "events": "ca1afded",
       "rng": {
         "draws": 2,
@@ -141,6 +141,7 @@
           "aiState": "idle",
           "attackPower": 10,
           "castRemaining": 2.95,
+          "castTargetId": 403,
           "castTotal": 3,
           "castingAbility": "fireball",
           "comboUntil": -1,
@@ -357,7 +358,7 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 404,
-      "state": "0bd83248",
+      "state": "e5264418",
       "events": "5afd3f86",
       "rng": {
         "draws": 5,
@@ -368,7 +369,7 @@
       "tick": 10,
       "time": 0.5,
       "nextId": 404,
-      "state": "06fb9488",
+      "state": "31b4515a",
       "events": "741638a5",
       "rng": {
         "draws": 5,
@@ -379,7 +380,7 @@
       "tick": 15,
       "time": 0.75,
       "nextId": 404,
-      "state": "4858c1f1",
+      "state": "5e364441",
       "events": "741638a5",
       "rng": {
         "draws": 5,
@@ -390,7 +391,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 404,
-      "state": "bc51d519",
+      "state": "61e3882b",
       "events": "b4dcc512",
       "rng": {
         "draws": 5,
@@ -401,7 +402,7 @@
       "tick": 25,
       "time": 1.25,
       "nextId": 404,
-      "state": "35852adb",
+      "state": "9e006ed1",
       "events": "741638a5",
       "rng": {
         "draws": 5,
@@ -412,7 +413,7 @@
       "tick": 30,
       "time": 1.5,
       "nextId": 404,
-      "state": "a9d27810",
+      "state": "21d92008",
       "events": "741638a5",
       "rng": {
         "draws": 5,
@@ -423,7 +424,7 @@
       "tick": 35,
       "time": 1.75,
       "nextId": 404,
-      "state": "9f01e82e",
+      "state": "246e9164",
       "events": "741638a5",
       "rng": {
         "draws": 5,
@@ -434,7 +435,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 404,
-      "state": "9fafe227",
+      "state": "9bb4bf77",
       "events": "741638a5",
       "rng": {
         "draws": 5,
@@ -445,7 +446,7 @@
       "tick": 45,
       "time": 2.25,
       "nextId": 404,
-      "state": "e06f32dd",
+      "state": "4275b331",
       "events": "a3408790",
       "rng": {
         "draws": 24,
@@ -456,7 +457,7 @@
       "tick": 50,
       "time": 2.5,
       "nextId": 404,
-      "state": "d737de4b",
+      "state": "4d1d7cbd",
       "events": "741638a5",
       "rng": {
         "draws": 48,
@@ -467,7 +468,7 @@
       "tick": 55,
       "time": 2.75,
       "nextId": 404,
-      "state": "c147f9fd",
+      "state": "77456531",
       "events": "741638a5",
       "rng": {
         "draws": 66,
@@ -478,7 +479,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 404,
-      "state": "b822f728",
+      "state": "37973ece",
       "events": "741638a5",
       "rng": {
         "draws": 82,
@@ -489,7 +490,7 @@
       "tick": 65,
       "time": 3.25,
       "nextId": 404,
-      "state": "ad4312a8",
+      "state": "0da5d8a2",
       "events": "741638a5",
       "rng": {
         "draws": 103,
@@ -972,7 +973,7 @@
       "tick": 125,
       "time": 6.25,
       "nextId": 404,
-      "state": "9b105c4c",
+      "state": "7c5c39e4",
       "events": "a539bc12",
       "rng": {
         "draws": 421,
@@ -983,7 +984,7 @@
       "tick": 130,
       "time": 6.5,
       "nextId": 404,
-      "state": "6abb73fb",
+      "state": "62e18d23",
       "events": "741638a5",
       "rng": {
         "draws": 457,
@@ -994,7 +995,7 @@
       "tick": 135,
       "time": 6.75,
       "nextId": 404,
-      "state": "b87f8852",
+      "state": "7971ab02",
       "events": "741638a5",
       "rng": {
         "draws": 488,
@@ -1005,7 +1006,7 @@
       "tick": 140,
       "time": 7,
       "nextId": 404,
-      "state": "f19bff09",
+      "state": "8c7b17cf",
       "events": "741638a5",
       "rng": {
         "draws": 513,
@@ -1016,7 +1017,7 @@
       "tick": 145,
       "time": 7.25,
       "nextId": 404,
-      "state": "de184b40",
+      "state": "b0991ec2",
       "events": "497d6b07",
       "rng": {
         "draws": 538,
@@ -1027,7 +1028,7 @@
       "tick": 145,
       "time": 7.25,
       "nextId": 404,
-      "state": "e37f260e",
+      "state": "7f62141a",
       "events": "69ec1e23",
       "rng": {
         "draws": 538,
@@ -1252,6 +1253,7 @@
           "aiState": "idle",
           "attackPower": 11,
           "castRemaining": 2.65,
+          "castTargetId": 403,
           "castTotal": 5,
           "castingAbility": "drain_life",
           "channelTickEvery": 1,
@@ -1388,7 +1390,7 @@
       "tick": 150,
       "time": 7.5,
       "nextId": 404,
-      "state": "171525cf",
+      "state": "9f0f0c6d",
       "events": "df1aefac",
       "rng": {
         "draws": 574,

--- a/tests/parity/golden/c4b_effect_dispatch.json
+++ b/tests/parity/golden/c4b_effect_dispatch.json
@@ -35,7 +35,7 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 407,
-      "state": "94e4c59b",
+      "state": "41d690e8",
       "events": "2b7f294a",
       "rng": {
         "draws": 2,
@@ -46,7 +46,7 @@
       "tick": 10,
       "time": 0.5,
       "nextId": 407,
-      "state": "cd37f8d9",
+      "state": "8a3441a4",
       "events": "741638a5",
       "rng": {
         "draws": 2,
@@ -57,7 +57,7 @@
       "tick": 15,
       "time": 0.75,
       "nextId": 407,
-      "state": "f5a7063f",
+      "state": "2ce79d6e",
       "events": "741638a5",
       "rng": {
         "draws": 2,
@@ -68,7 +68,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 407,
-      "state": "998838d7",
+      "state": "d1df04f0",
       "events": "48df308c",
       "rng": {
         "draws": 2,
@@ -79,7 +79,7 @@
       "tick": 25,
       "time": 1.25,
       "nextId": 407,
-      "state": "a05b614c",
+      "state": "3b727a85",
       "events": "741638a5",
       "rng": {
         "draws": 2,

--- a/tests/parity/golden/solo_mage.json
+++ b/tests/parity/golden/solo_mage.json
@@ -111,7 +111,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 402,
-      "state": "f9275a1b",
+      "state": "96811767",
       "events": "9bba49b4",
       "rng": {
         "draws": 3,


### PR DESCRIPTION
## Summary

Entity-targeted casts and channels now resolve against the target captured when the cast began. Retargeting (or clearing your target) mid-cast no longer redirects a fireball, redirects a heal, or cancels a drain channel; channels still cancel when the locked target dies or becomes invalid.

Player-facing behavior:
- Timed hostile casts land on the cast-start target (approved Discord bug `1522314621778661598`).
- Timed friendly heals lock to the cast-start target.
- Channel ticks stay on the cast-start target; clearing your current target mid-channel no longer cancels the channel.

The broader heal/channel locking (beyond the reported hostile-cast bug) is an intentional game-feel change, product-approved by @reuben.

Supersedes the cast-lock portion of #1370 and all of #1366 — credit to the OSSBrain agent for the original implementation; this is #1370's semantics rebuilt clean on the current tip (no i18n churn, no test-harness changes, goldens re-minted rather than hand-carried).

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- 6 regression tests in `tests/combat_casting_lifecycle.test.ts` (hostile cast lock, friendly heal lock, channel retarget lock, channel survives target-clear, channel cancels on locked-target death, interrupt clears the lock). Each proven RED on the un-fixed base and GREEN with the fix.
- Parity goldens (`c4a_casting_lifecycle`, `c4b_effect_dispatch`, `solo_mage`) re-minted with `UPDATE_PARITY=1`; churn verified to be state-digest-only (events digests and rng draw counts byte-identical), and re-minting reproduces the committed goldens byte-identically. Parity suite 96/96.
- Full suite: 697 files / 7,563 tests passing. `tsc --noEmit` clean. Biome clean (new test code matches the file's existing patterns).

## Checklist

- [x] Tests pass, typecheck passes, builds succeed
- [x] N/A This PR adds no player-visible strings (sim-only; no UI changes)
- [x] No secrets/credentials; no hand-edited generated files (goldens minted via UPDATE_PARITY, no i18n files touched)