### PR TITLE
fix(input): clear stale held-key state when menu suspends movement

### DIFF
--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -354,6 +354,22 @@ export class Input {
     this.updateCursor();
   }
 
+  setSuspendMovement(on: boolean): void {
+    if (this.suspendMovement === on) return;
+    this.suspendMovement = on;
+    if (on) {
+      const hadEmoteWheel = this.emoteWheelHeldCodes.size > 0;
+      const hadHeldInput = this.keys.size > 0 || hadEmoteWheel || this.keyJumpUntil > 0;
+      this.keys.clear();
+      this.keyJumpUntil = 0;
+      if (hadEmoteWheel) {
+        this.emoteWheelHeldCodes.clear();
+        this.cb.onEmoteWheel(false);
+      }
+      if (hadHeldInput) this.noteIntent('move');
+    }
+  }
+
   captureNextKey(cb: (code: string | null) => void): void {
     this.captureCb = cb;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2315,7 +2315,7 @@ async function startGame(
     // freeze movement while the game menu is up so WASD doesn't walk the
     // character behind it (other windows stay non-modal, as before); the
     // first-spawn intro cinematic holds movement the same way until it lands
-    input.suspendMovement = !gameInputReady || hud.isModalOpen() || intro !== null;
+    input.setSuspendMovement(!gameInputReady || hud.isModalOpen() || intro !== null);
     perf.trace('input.updateTouchLook', () => input.updateTouchLook(frameDt), {
       frameDtMs: frameDt * 1000,
     });
@@ -2613,7 +2613,7 @@ async function startGame(
     window.addEventListener('keydown', skipIntro, true);
     window.addEventListener('pointerdown', skipIntro, true);
   }
-  input.suspendMovement = true;
+  input.setSuspendMovement(true);
   await nextPaint();
   try {
     await renderer.prewarmInitialScene();

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -120,11 +120,11 @@ describe('Input autorun', () => {
     input.toggleAutorun();
     expect(input.readMoveInput().forward).toBe(true);
 
-    input.suspendMovement = true; // mirrors main.ts setting it while the game menu is open
+    input.setSuspendMovement(true); // mirrors main.ts setting it while the game menu is open
     expect(input.autorun).toBe(true); // latch untouched by the menu
     expect(input.readMoveInput().forward).toBe(true); // keeps running while suspended
 
-    input.suspendMovement = false; // menu closed
+    input.setSuspendMovement(false); // menu closed
     expect(input.autorun).toBe(true);
     expect(input.readMoveInput().forward).toBe(true); // still running
   });
@@ -137,9 +137,41 @@ describe('Input autorun', () => {
     windowListeners.get('keydown')!({ code: 'KeyW', repeat: false }); // hold forward
     expect(input.readMoveInput().forward).toBe(true);
 
-    input.suspendMovement = true; // game menu / chat open
+    input.setSuspendMovement(true); // game menu / chat open
     expect(input.autorun).toBe(false);
     expect(input.readMoveInput().forward).toBe(false); // held key is suppressed
+  });
+
+  it('drops stale held forward and jump state when movement suspension begins', () => {
+    const { input, windowListeners } = makeInput();
+    let now = 1000;
+    vi.spyOn(performance, 'now').mockImplementation(() => now);
+
+    windowListeners.get('keydown')!({ code: 'KeyW', repeat: false });
+    windowListeners.get('keydown')!({ code: 'Space', repeat: false, preventDefault: vi.fn() });
+    expect(input.readMoveInput().forward).toBe(true);
+    expect(input.readMoveInput().jump).toBe(true);
+
+    input.setSuspendMovement(true);
+    input.setSuspendMovement(false);
+    now += 1;
+
+    expect(input.debugState().keys).toEqual([]);
+    expect(input.readMoveInput().forward).toBe(false);
+    expect(input.readMoveInput().jump).toBe(false);
+  });
+
+  it('keeps autorun latched when suspension clears stale held key state', () => {
+    const { input, windowListeners } = makeInput();
+    input.toggleAutorun();
+    windowListeners.get('keydown')!({ code: 'Space', repeat: false, preventDefault: vi.fn() });
+
+    input.setSuspendMovement(true);
+    input.setSuspendMovement(false);
+
+    expect(input.autorun).toBe(true);
+    expect(input.readMoveInput().forward).toBe(true);
+    expect(input.debugState().keys).toEqual([]);
   });
 });
 
@@ -533,6 +565,16 @@ describe('Input Escape handling', () => {
 
     windowListeners.get('keydown')!({ code: 'Escape', repeat: false });
     windowListeners.get('keydown')!({ code: 'KeyB', repeat: false });
+
+    expect(cb.onUiKey).toHaveBeenCalledTimes(1);
+    expect(cb.onUiKey).toHaveBeenCalledWith('escape');
+  });
+
+  it('ignores repeated Escape keydown events so holding the menu key cannot retoggle', () => {
+    const { cb, windowListeners } = makeInput();
+
+    windowListeners.get('keydown')!({ code: 'Escape', repeat: false });
+    windowListeners.get('keydown')!({ code: 'Escape', repeat: true });
 
     expect(cb.onUiKey).toHaveBeenCalledTimes(1);
     expect(cb.onUiKey).toHaveBeenCalledWith('escape');


### PR DESCRIPTION
## Summary

Opening the game menu with movement/jump keys held left stale input state (held WASD codes, pending key-jump, emote wheel) that kept acting after the menu closed. `Input.setSuspendMovement(on)` now clears held-key state on the suspend transition; the autorun latch is deliberately preserved. `main.ts` switches both call sites to the setter — **keeping the base's `|| intro !== null` clause** so the spawn-intro movement freeze is unaffected.

Extracted from #1370 (commit `041dbeb6`, credit to the OSSBrain agent) for approved Discord bug `1522537933071056957` — taken alone, without that PR's unrelated `vite.config.ts` test-harness change and i18n churn.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- 3 new tests in `tests/input.test.ts` (stale held forward/jump dropped on suspend; autorun latch survives; repeated-Escape guard pinned); 54/54 input tests green.
- Full suite: 697 files passing. `tsc --noEmit` clean.
- Diff verified to touch exactly `src/game/input.ts`, `src/main.ts`, `tests/input.test.ts`.
- **Pending: desktop self-test of the live repro** (hold W/Space, open menu with O, close, confirm no residual movement/jump and menu does not reopen) per contribution standards — keyboard-only surface, mobile/touch paths untouched.

## Checklist

- [x] Tests pass, typecheck passes, builds succeed
- [ ] Tested on desktop (pending quick manual repro above)
- [x] N/A This PR adds no player-visible strings
- [x] No secrets/credentials; no generated files touched