### PR TITLE
perf(net): drop the duplicate stats/weapon self-wire emit

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -3335,8 +3335,6 @@ export class GameServer {
     // draws the corpse marker and gates the resurrect-at-corpse button on it.
     maybe('corpse', p.corpsePos);
     maybe('cds', Object.fromEntries([...p.cooldowns.entries()].map(([k, v]) => [k, round2(v)])));
-    maybe('stats', p.stats);
-    maybe('weapon', p.weapon);
     maybe('party', this.partyWire(anchorSession.pid));
     maybe('marks', this.markersWire(anchorSession.pid));
     maybe('trade', this.tradeWire(anchorSession.pid));


### PR DESCRIPTION
## Problem

`selfWireJson` (server/game.ts) emitted `maybe('stats', p.stats)` and `maybe('weapon', p.weapon)` **twice**, in the same straight-line code path (once near the top of the dynamic-field block, once again ~35 lines down with the explanatory comment). `maybe()` `JSON.stringify`s its value on every call before the delta-cache check, so the redundant pair re-stringified `stats` and `weapon` for every player every tick, in the hot broadcast path, only for the delta cache to no-op the write. The code's own comment calls stringifying these per tick "the dominant avoidable broadcast cost".

## Fix

Remove the undocumented duplicate emit, keeping the single documented one. The wire output is byte-unchanged (same keys, same values, same delta gating), just built once.

## Verification

- `stats`/`weapon` still emitted exactly once each.
- `tests/snapshots.test.ts` (wire round-trip + the `ALL_DELTA_KEYS` registry) and `tests/bandwidth.test.ts`: 83 tests green.
- `tsc --noEmit` clean.

## Notes

From our read-only repo audit (item N05, "dead maybe()"). No wire-protocol change, so `src/net/online.ts` is untouched; the delta-key registry is unchanged.
