### PR TITLE
fix(sim): prevent pets inheriting evade immunity

### DIFF
--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -75,11 +75,12 @@ export function dealDamage(
 ): void {
   if (target.dead) return;
   if (target.gm) return; // GM characters are invulnerable — every damage path funnels here
-  // A mob that broke leash (or a pet freed to the wild) is in 'evade': it has
-  // dropped its hate table and walks home without fighting back, healing to
-  // full only on arrival. Classic mechanics make it immune while it retreats,
-  // so it can't be chipped down — or killed outright — for a risk-free kill.
-  if (target.kind === 'mob' && target.aiState === 'evade') return;
+  // A wild mob that broke leash is in 'evade': it has dropped its hate table
+  // and walks home without fighting back, healing to full only on arrival.
+  // Classic mechanics make it immune while it retreats, so it can't be chipped
+  // down or killed outright for a risk-free kill. Owned pets use pet AI, not
+  // wild-mob leash recovery, and must not inherit this immunity from stale state.
+  if (target.kind === 'mob' && target.aiState === 'evade' && target.ownerId === null) return;
   amount = Math.max(0, amount);
 
   // Defensive Stance, classic: deal 10% less, take 10% less (and +30% threat below)

--- a/src/sim/mob/targeting.ts
+++ b/src/sim/mob/targeting.ts
@@ -34,6 +34,13 @@ const TRIVIAL_LEVEL_GAP = 10;
 // attacker. With no living threat left, it evades home instead of grabbing a
 // nearby bystander who never acted on the mob.
 export function retargetMob(ctx: SimContext, mob: Entity): void {
+  if (mob.ownerId !== null) {
+    mob.aggroTargetId = null;
+    mob.aiState = 'idle';
+    mob.inCombat = false;
+    mob.despawnTimer = undefined;
+    return;
+  }
   const next = highestThreatTarget(ctx, mob);
   if (next) {
     mob.aggroTargetId = next.id;

--- a/tests/combat_damage.test.ts
+++ b/tests/combat_damage.test.ts
@@ -200,8 +200,9 @@ describe('combat/damage handleDeath', () => {
     handleDeath(sim.ctx, victim, owner);
 
     expect(pet.dead).toBe(false);
-    expect(pet.aiState).toBe('attack');
-    expect(pet.aggroTargetId).toBe(victim.id);
+    expect(pet.aiState).toBe('idle');
+    expect(pet.aggroTargetId).toBeNull();
+    expect(pet.inCombat).toBe(false);
     const hpBefore = pet.hp;
     dealDamage(sim.ctx, victim, pet, 5, false, 'physical', 'Test Strike', 'hit');
     expect(pet.hp).toBe(hpBefore - 5);

--- a/tests/combat_damage.test.ts
+++ b/tests/combat_damage.test.ts
@@ -175,4 +175,35 @@ describe('combat/damage handleDeath', () => {
     expect(mob.auras.length).toBe(0); // auras cleared on death
     expect(meta.counters.kills).toBe(kills + 1); // kill credit went to the tapper
   });
+
+  it('does not put an enemy-owned pet into evade when its player target dies', () => {
+    const sim = new Sim({ seed: 909, playerClass: 'hunter', noPlayer: true, autoEquip: true });
+    const ownerId = sim.addPlayer('hunter', 'Hunter');
+    const victimId = sim.addPlayer('warrior', 'Victim');
+    sim.setPlayerLevel(10, ownerId);
+    sim.setPlayerLevel(10, victimId);
+    const owner = sim.entities.get(ownerId) as AnyEntity;
+    const victim = sim.entities.get(victimId) as AnyEntity;
+    const pet = createMob(sim.nextId++, MOBS.forest_wolf, owner.level, {
+      x: owner.pos.x + 2,
+      y: owner.pos.y,
+      z: owner.pos.z,
+    }) as AnyEntity;
+    pet.ownerId = owner.id;
+    pet.hostile = false;
+    pet.aiState = 'attack';
+    pet.aggroTargetId = victim.id;
+    pet.inCombat = true;
+    pet.threat.clear();
+    sim.addEntity(pet);
+
+    handleDeath(sim.ctx, victim, owner);
+
+    expect(pet.dead).toBe(false);
+    expect(pet.aiState).toBe('attack');
+    expect(pet.aggroTargetId).toBe(victim.id);
+    const hpBefore = pet.hp;
+    dealDamage(sim.ctx, victim, pet, 5, false, 'physical', 'Test Strike', 'hit');
+    expect(pet.hp).toBe(hpBefore - 5);
+  });
 });

--- a/tests/evade_immunity.test.ts
+++ b/tests/evade_immunity.test.ts
@@ -4,8 +4,8 @@
 // risk-free kill, which also breaks the classic reset contract.
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
-import { dist2d } from '../src/sim/types';
 import type { Entity } from '../src/sim/types';
+import { dist2d } from '../src/sim/types';
 
 function makeSim() {
   return new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
@@ -17,7 +17,10 @@ function nearestMob(sim: Sim): Entity {
   for (const e of sim.entities.values()) {
     if (e.kind !== 'mob' || e.dead || e.ownerId !== null) continue;
     const d = dist2d(sim.player.pos, e.pos);
-    if (d < bestD) { bestD = d; best = e; }
+    if (d < bestD) {
+      bestD = d;
+      best = e;
+    }
   }
   return best!;
 }
@@ -68,6 +71,25 @@ describe('evading mobs are immune while resetting', () => {
     expect(wolf.hp).toBe(4900);
     expect(wolf.threat.get(sim.playerId)).toBeCloseTo(100, 5);
   });
+
+  it('does not make an owned pet immune if stale evade state leaks onto it', () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true, autoEquip: true });
+    const attackerId = sim.addPlayer('warrior', 'Attacker');
+    const ownerId = sim.addPlayer('hunter', 'Owner');
+    const attacker = sim.entities.get(attackerId);
+    if (!attacker) throw new Error('missing attacker');
+    const pet = nearestMob(sim);
+    pet.ownerId = ownerId;
+    pet.hostile = false;
+    pet.aiState = 'evade';
+    pet.maxHp = 5000;
+    pet.hp = 5000;
+
+    hit(sim, attacker, pet, 1000);
+
+    expect(pet.hp).toBe(4000);
+    expect(pet.dead).toBe(false);
+  });
 });
 
 // An evading mob walks a STRAIGHT line home with no pathfinding, and resolvePosition
@@ -98,7 +120,8 @@ describe('an evading mob that cannot path home recovers instead of getting stuck
     const home = { ...mob.spawnPos };
     // place it on the far side of the tent from its spawn, so the straight line home
     // runs through the tent collider — exactly how a kited summoner ends up stuck.
-    const dx = CAMP_TENT.x - home.x, dz = CAMP_TENT.z - home.z;
+    const dx = CAMP_TENT.x - home.x,
+      dz = CAMP_TENT.z - home.z;
     const len = Math.hypot(dx, dz) || 1;
     mob.maxHp = 200;
     mob.hp = 50;
@@ -120,9 +143,13 @@ describe('an evading mob that cannot path home recovers instead of getting stuck
 
     // it must free itself (phase past the tent, walk home) and reset to a clean idle
     let reset = false;
-    for (let i = 0; i < 300; i++) { // 15s, comfortably past the stall timeout + walk
+    for (let i = 0; i < 300; i++) {
+      // 15s, comfortably past the stall timeout + walk
       sim.tick();
-      if (sim.entities.get(mob.id)!.aiState === 'idle') { reset = true; break; }
+      if (sim.entities.get(mob.id)!.aiState === 'idle') {
+        reset = true;
+        break;
+      }
     }
     expect(reset).toBe(true);
     expect(dist2d(mob.pos, home)).toBeLessThan(0.5); // back at its spawn
@@ -135,12 +162,17 @@ describe('an evading mob that cannot path home recovers instead of getting stuck
     sim.player.pos = { x: 9999, z: 9999, y: 0 };
 
     const home = { ...mob.spawnPos };
-    const dx = CAMP_TENT.x - home.x, dz = CAMP_TENT.z - home.z;
+    const dx = CAMP_TENT.x - home.x,
+      dz = CAMP_TENT.z - home.z;
     const len = Math.hypot(dx, dz) || 1;
-    mob.maxHp = 200; mob.hp = 50; mob.auras = [];
+    mob.maxHp = 200;
+    mob.hp = 50;
+    mob.auras = [];
     mob.pos = { x: CAMP_TENT.x + (dx / len) * 2.5, z: CAMP_TENT.z + (dz / len) * 2.5, y: 0 };
     mob.prevPos = { ...mob.pos };
-    mob.evadeStall = 0; mob.aiState = 'evade'; mob.threat.clear();
+    mob.evadeStall = 0;
+    mob.aiState = 'evade';
+    mob.threat.clear();
 
     // tick until it has left the tent's collision radius (proof it moved, not jumped)
     let maxStepSeen = 0;
@@ -171,7 +203,10 @@ describe('an evading mob that cannot path home recovers instead of getting stuck
     let reset = false;
     for (let i = 0; i < 200; i++) {
       sim.tick();
-      if (sim.entities.get(mob.id)!.aiState === 'idle') { reset = true; break; }
+      if (sim.entities.get(mob.id)!.aiState === 'idle') {
+        reset = true;
+        break;
+      }
     }
     expect(reset).toBe(true);
     // it walked home under its own power (no snap needed): well within ~20yd of spawn

--- a/tests/mob_targeting.test.ts
+++ b/tests/mob_targeting.test.ts
@@ -28,6 +28,7 @@ function ent(id: number, over: Partial<Entity> = {}): Entity {
     pos: { x: 0, y: 0, z: 0 },
     level: 1,
     templateId: 'forest_wolf',
+    ownerId: null,
     scale: 1, // updateMobTarget reads scale for the size-scaled melee reach
     aiState: 'idle',
     inCombat: false,
@@ -355,6 +356,23 @@ describe('mob/targeting: retargetMob', () => {
     expect(mob.aggroTargetId).toBe(null);
     expect(mob.aiState).toBe('evade');
     expect(mob.threat.size).toBe(0); // the missing entry was pruned
+  });
+
+  it('clears an owned pet target without using evade', () => {
+    const ctx = fakeCtx(new Map(), { fallback: null, despawn: false });
+    const pet = ent(10, {
+      ownerId: 1,
+      aiState: 'attack',
+      aggroTargetId: 9,
+      inCombat: true,
+      despawnTimer: 3,
+      threat: new Map(),
+    });
+    retargetMob(ctx, pet);
+    expect(pet.aggroTargetId).toBeNull();
+    expect(pet.aiState).toBe('idle');
+    expect(pet.inCombat).toBe(false);
+    expect(pet.despawnTimer).toBeUndefined();
   });
 
   it('takes the Nythraxis fallback target when present and seeds its threat', () => {


### PR DESCRIPTION
## Summary
- prevent owned pets from entering wild-mob evade recovery when their player target dies
- keep evade damage immunity scoped to ownerless wild mobs
- add regression coverage for player-death pet retargeting, owned-pet retargeting, and stale pet evade state

## Root cause
When a player died, `handleDeath` retargeted every mob whose `aggroTargetId` was that player. Owned hunter and warlock pets were not excluded, so an empty threat table sent the pet through `retargetMob()` into `aiState = 'evade'`. Pet AI then ignored that state and kept fighting, while `dealDamage()` treated all evading mobs as immune.

## Validation
- RED reproduced before fix: `npx vitest run tests/combat_damage.test.ts` failed with the pet in `evade`
- `npx vitest run tests/combat_damage.test.ts tests/mob_targeting.test.ts tests/evade_immunity.test.ts`
- `npm run check:ts`
- `npm run ci:changed` exits 0 with warning-only existing test-file lint
