### PR TITLE
fix(sim): dead players cannot interact with the world; logout preserves the death loop

### DIFF
--- a/src/game/interactions.ts
+++ b/src/game/interactions.ts
@@ -1,5 +1,6 @@
 import { dist2d, type Entity, INTERACT_RANGE } from '../sim/types';
 import { t } from '../ui/i18n';
+import { tSim } from '../ui/sim_i18n';
 import type { IWorld } from '../world_api';
 import type { HoverCursorKind } from './cursors';
 
@@ -126,8 +127,12 @@ export function handlePickedEntity(
       }
       if (e.templateId === 'dungeon_door' && e.dungeonId) world.enterDungeon(e.dungeonId);
       else if (e.templateId === 'dungeon_exit') world.leaveDungeon();
-      else if (e.templateId === 'mailbox') hud.openMailbox();
-      else world.pickUpObject(id);
+      else if (e.templateId === 'mailbox') {
+        // Dead players (ghosts included) cannot use the mail; the server-side
+        // interact path refuses too, this just keeps the window from opening.
+        if (world.player.dead) hud.showError(tSim('error.cantWhileDead'));
+        else hud.openMailbox();
+      } else world.pickUpObject(id);
     } else if (e.kind === 'mob' && e.dead && e.lootable) {
       if (d <= INTERACT_RANGE + 1) hud.openLoot(id, screenX, screenY);
       else hud.showError(t('questUi.errors.tooFar'));
@@ -138,6 +143,10 @@ export function handlePickedEntity(
           // Sickness). To the living it offers only watchful flavor.
           if (world.player.ghost) world.resurrectAtSpiritHealer();
           else hud.showError(t('hudChrome.death.spiritHealerAlive'));
+        } else if (world.player.dead) {
+          // Dead players and ghosts cannot talk to NPCs (the server refuses the
+          // command too); do not open the quest dialog client-side.
+          hud.showError(tSim('error.cantWhileDead'));
         } else if (e.templateId === 'brother_halven' || e.templateId === 'brother_halven_marsh')
           hud.openDelveBoard(id);
         else hud.openQuestDialog(id);
@@ -156,8 +165,10 @@ export function handlePickedEntity(
       if (d > INTERACT_RANGE + 1) return;
       if (e.templateId === 'dungeon_door' && e.dungeonId) world.enterDungeon(e.dungeonId);
       else if (e.templateId === 'dungeon_exit') world.leaveDungeon();
-      else if (e.templateId === 'mailbox') hud.openMailbox();
-      else world.pickUpObject(id);
+      else if (e.templateId === 'mailbox') {
+        if (world.player.dead) hud.showError(tSim('error.cantWhileDead'));
+        else hud.openMailbox();
+      } else world.pickUpObject(id);
     } else if (e.kind === 'mob' && e.dead && e.lootable) {
       const d = dist2d(world.player.pos, e.pos);
       if (d <= INTERACT_RANGE + 1) hud.openLoot(id, screenX, screenY);
@@ -165,7 +176,9 @@ export function handlePickedEntity(
       // left-click talks too — Mac trackpads make right-click a chore;
       // out of range it just targets (no error spam while exploring)
       const d = dist2d(world.player.pos, e.pos);
-      if (d <= INTERACT_RANGE + 2) {
+      // No quest dialog while dead (the server refuses quest talk too); a ghost
+      // takes the Spirit Healer res via right-click or the death panel button.
+      if (d <= INTERACT_RANGE + 2 && !world.player.dead) {
         if (e.templateId === 'brother_halven' || e.templateId === 'brother_halven_marsh')
           hud.openDelveBoard(id);
         else hud.openQuestDialog(id);

--- a/src/sim/interaction.ts
+++ b/src/sim/interaction.ts
@@ -23,7 +23,7 @@
 // `src/sim`-pure: no DOM/Three/render-ui-game-net imports, no Math.random/Date.now
 // (enforced by tests/architecture.test.ts).
 
-import { ITEMS, MOBS, QUESTS } from './data';
+import { ITEMS, MOBS, QUESTS, SPIRIT_HEALER_NPC_ID } from './data';
 import {
   activateNythraxisRelic,
   interactObjectForQuests,
@@ -79,6 +79,13 @@ export function lootCorpse(
   const r = ctx.resolve(pid);
   if (!r) return;
   const { meta, e: p } = r;
+  // Dead players (released ghosts included) cannot loot; the same rejection the
+  // item family uses (src/sim/items.ts). The walk-by autoLootForParty path never
+  // reaches this: it silently drops a dead trigger before delegating here.
+  if (p.dead) {
+    ctx.error(meta.entityId, "You can't do that while dead.");
+    return;
+  }
   const mob = ctx.entities.get(mobId);
   if (!mob?.lootable || !mob.loot) return;
   // owner-lock lapses LOOT_FFA_DELAY after the corpse became lootable: then anyone may loot.
@@ -172,6 +179,11 @@ export function pickUpObject(ctx: SimContext, objId: number, pid?: number): void
   const r = ctx.resolve(pid);
   if (!r) return;
   const { meta, e: p } = r;
+  // Dead players (released ghosts included) cannot pick up world objects.
+  if (p.dead) {
+    ctx.error(meta.entityId, "You can't do that while dead.");
+    return;
+  }
   const obj = ctx.entities.get(objId);
   if (obj?.kind !== 'object' || !obj.lootable || !obj.objectItemId) return;
   if (dist2d(p.pos, obj.pos) > INTERACT_RANGE) {
@@ -217,6 +229,30 @@ export function interact(ctx: SimContext, pid?: number): void {
   const r = ctx.resolve(pid);
   if (!r) return;
   const p = r.e;
+  if (p.dead) {
+    // A dead player or released spirit cannot interact with the world: no
+    // looting, object pickup, mailbox, or quest talk. The one exception is the
+    // Spirit Healer (talking to the angel is how a ghost reaches the healer
+    // resurrection), so route a nearby angel through the normal quest-NPC talk
+    // and refuse everything else. A ghost still re-enters its instance via the
+    // proximity door trigger (updateDoorTriggers), which never comes through here.
+    let bestHealer: Entity | null = null;
+    let bestHealerD2 = INTERACT_RANGE * INTERACT_RANGE;
+    ctx.grid.forEachInRadius(p.pos.x, p.pos.z, INTERACT_RANGE, (e, d2) => {
+      if (e.kind === 'npc' && e.templateId === SPIRIT_HEALER_NPC_ID && d2 < bestHealerD2) {
+        bestHealer = e;
+        bestHealerD2 = d2;
+      }
+    });
+    // re-read through a wider type: TS cannot see the closure assignment above
+    const healer = bestHealer as Entity | null;
+    if (healer) {
+      ctx.talkToNpc(healer.id, p.id);
+      return;
+    }
+    ctx.error(r.meta.entityId, "You can't do that while dead.");
+    return;
+  }
   if (p.targetId !== null) {
     const target = ctx.entities.get(p.targetId);
     if (target && dist2d(p.pos, target.pos) <= INTERACT_RANGE + 2) {

--- a/src/sim/items.ts
+++ b/src/sim/items.ts
@@ -239,6 +239,12 @@ export function buyItem(ctx: SimContext, npcId: number, itemId: string, pid?: nu
     ctx.error(meta.entityId, 'That item is not for sale.');
     return;
   }
+  // Dead players (released ghosts included) cannot buy, matching the rest of
+  // the vendor family (sellItem / sellAllJunk / buyBackItem below).
+  if (p.dead) {
+    ctx.error(meta.entityId, "You can't do that while dead.");
+    return;
+  }
   if (dist2d(p.pos, npc.pos) > INTERACT_RANGE + 2) {
     ctx.error(meta.entityId, 'Too far away.');
     return;

--- a/src/sim/mail/post_office.ts
+++ b/src/sim/mail/post_office.ts
@@ -286,6 +286,7 @@ export class PostOffice {
     const r = this.ctx.resolve(pid);
     if (!r) return;
     const { meta, e: p } = r;
+    if (p.dead) return; // same silent dead-gate as mailSendResolved above
     if (!this.nearMailbox(p)) {
       this.result(meta.entityId, 'tooFar');
       return;
@@ -311,6 +312,7 @@ export class PostOffice {
     const r = this.ctx.resolve(pid);
     if (!r) return;
     const { meta, e: p } = r;
+    if (p.dead) return; // same silent dead-gate as mailSendResolved above
     if (!this.nearMailbox(p)) {
       this.result(meta.entityId, 'tooFar');
       return;

--- a/src/sim/quests/quest_commands.ts
+++ b/src/sim/quests/quest_commands.ts
@@ -113,6 +113,11 @@ export function acceptQuest(ctx: SimContext, questId: string, pid?: number): voi
   if (!r) return;
   const quest = QUESTS[questId];
   const { meta, e: p } = r;
+  // Dead players (released ghosts included) cannot deal with quest givers.
+  if (p.dead) {
+    ctx.error(meta.entityId, "You can't do that while dead.");
+    return;
+  }
   if (!quest) {
     ctx.error(meta.entityId, 'That quest is not available.');
     return;
@@ -177,6 +182,11 @@ export function turnInQuest(ctx: SimContext, questId: string, pid?: number): voi
   const r = ctx.resolve(pid);
   if (!r) return;
   const { meta, e: p } = r;
+  // Dead players (released ghosts included) cannot turn in quests.
+  if (p.dead) {
+    ctx.error(meta.entityId, "You can't do that while dead.");
+    return;
+  }
   const quest = QUESTS[questId];
   if (!quest) {
     ctx.error(meta.entityId, 'That quest is not available.');

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -105,6 +105,7 @@ import {
   isDelvePos,
   MOBS,
   QUESTS,
+  SPIRIT_HEALER_NPC_ID,
   zoneAt,
 } from './data';
 import * as companionMod from './delves/companion';
@@ -873,6 +874,11 @@ export interface CharacterState {
   // still marked, rather than free-resurrecting on relog. See src/sim/spirit.ts.
   ghost?: boolean;
   corpsePos?: { x: number; z: number } | null;
+  // True when the character was saved dead (JSONB; optional so older saves load
+  // alive exactly as before). A dead-but-UNRELEASED logout resumes as a released
+  // ghost on relog (auto-release-on-logout), so logging out cannot bypass the
+  // death loop. See the addPlayer ghost block + src/sim/spirit.ts.
+  dead?: boolean;
   // The Keeper's Toll (Resurrection Sickness) remaining seconds (JSONB; optional/null when
   // none). Persisted so the penalty cannot be shed by logging out and back in.
   resSickness?: number | null;
@@ -1579,6 +1585,20 @@ export class Sim {
         ? this.groundPos(savedState.corpsePos.x, savedState.corpsePos.z)
         : null;
       player.hp = player.maxHp;
+    } else if (savedState?.dead && !isArenaPos(savedState.pos.x) && !isDelvePos(savedState.pos.x)) {
+      // Auto-release-on-logout: a character saved dead but UNRELEASED resumes as
+      // a released ghost rather than reviving in place at 1 hp (logging out must
+      // not bypass the death loop). Put the body back at the death spot, then run
+      // the normal release path so the corpse marker and graveyard choice
+      // (including the instance rule: a dungeon corpse releases to the outdoor
+      // graveyard nearest the door) cannot drift from spirit.ts. Delve, arena,
+      // and fiesta deaths keep their own bounded respawn rules and never enter
+      // the ghost loop, so those positions load exactly as before.
+      player.pos = this.groundPos(savedState.pos.x, savedState.pos.z);
+      player.prevPos = { ...player.pos };
+      this.rebucket(player);
+      player.dead = true;
+      releasePlayerSpirit(this.ctx, player.id);
     }
     if (savedState?.pet) this.restorePet(player, savedState.pet);
     // One-time Ravenpost welcome (doubles as the service announcement for
@@ -1711,7 +1731,9 @@ export class Sim {
       ),
       pos: { x: e.pos.x, z: e.pos.z },
       facing: e.facing,
-      // Ghost state, so a logged-out spirit resumes its corpse run on relog.
+      // Death state: a released spirit resumes its corpse run on relog, and a
+      // dead-but-unreleased corpse auto-releases on load (see addPlayer).
+      dead: e.dead,
       ghost: e.ghost,
       corpsePos: e.corpsePos ? { x: e.corpsePos.x, z: e.corpsePos.z } : null,
       // The Keeper's Toll persists across logout (it cannot be shed by relogging).
@@ -5015,9 +5037,16 @@ export class Sim {
   talkToNpc(npcId: number, pid?: number): void {
     const r = this.resolve(pid);
     if (!r) return;
-    const { meta } = r;
+    const { meta, e: p } = r;
     const npc = this.entities.get(npcId);
     if (!npc || !this.isQuestInteractionEntity(npc)) return;
+    // Dead players (released ghosts included) cannot talk to quest NPCs. The
+    // Spirit Healer is the one exception: talking to the angel is how a ghost
+    // reaches its resurrection offer (the res itself is resurrectAtSpiritHealer).
+    if (p.dead && npc.templateId !== SPIRIT_HEALER_NPC_ID) {
+      this.error(meta.entityId, "You can't do that while dead.");
+      return;
+    }
     if (this.interactNpcForQuests(npc, meta)) return;
     for (const qid of npc.questIds) {
       const quest = QUESTS[qid];

--- a/tests/ghost_dead_gate.test.ts
+++ b/tests/ghost_dead_gate.test.ts
@@ -1,0 +1,384 @@
+// Dead players cannot interact with the world, and logging out preserves the
+// death loop (follow-up to the ghost/death loop of src/sim/spirit.ts).
+//
+// Part A: the interaction/quest command family (interact / lootCorpse /
+// pickUpObject / talkToNpc / acceptQuest / turnInQuest, plus the mailbox-open
+// path inside interact) refuses a dead player, released ghost or not, with the
+// same "You can't do that while dead." error the item family already emits.
+// The Spirit Healer stays reachable for a ghost (that is how it takes the
+// healer resurrection).
+//
+// Part B: a character saved dead but UNRELEASED resumes as a released ghost
+// (auto-release-on-logout) with the corpse at the death spot and the spirit at
+// the graveyard the normal release path picks; old saves without the field and
+// alive/released-ghost saves load exactly as before.
+
+import { describe, expect, it } from 'vitest';
+import { DUNGEON_X_THRESHOLD, QUESTS, SPIRIT_HEALER_NPC_ID } from '../src/sim/data';
+import { Sim } from '../src/sim/sim';
+import { SPIRIT_HEALER_RANGE } from '../src/sim/spirit';
+import { dist2d, type Entity, INTERACT_RANGE, type SimEvent } from '../src/sim/types';
+import { terrainHeight } from '../src/sim/world';
+
+type AnyEntity = Entity & Record<string, any>;
+type AnySim = Sim & Record<string, any>;
+
+const DEAD_ERROR = "You can't do that while dead.";
+
+const makeSim = (seed = 42): AnySim =>
+  new Sim({ seed, playerClass: 'warrior', autoEquip: true }) as AnySim;
+
+function deadErrors(events: SimEvent[]): number {
+  return events.filter((ev) => ev.type === 'error' && ev.text === DEAD_ERROR).length;
+}
+
+function teleport(sim: AnySim, p: AnyEntity, x: number, z: number): void {
+  p.pos = { x, y: terrainHeight(x, z, sim.cfg.seed), z };
+  p.prevPos = { ...p.pos };
+  sim.rebucket(p);
+}
+
+// A Spirit Healer NPC within reach of a position (2D).
+function healerInRange(sim: AnySim, pos: { x: number; z: number }, range: number): boolean {
+  for (const e of sim.entities.values() as IterableIterator<AnyEntity>) {
+    if (e.kind !== 'npc' || e.templateId !== SPIRIT_HEALER_NPC_ID) continue;
+    if (dist2d(e.pos, { x: pos.x, y: 0, z: pos.z }) <= range) return true;
+  }
+  return false;
+}
+
+// Put the primary player into one of the two dead modes AT ITS CURRENT SPOT:
+// an unreleased corpse (dead, not ghost), or a released ghost teleported back
+// to the spot (a ghost roams freely, which is what made these paths reachable).
+function makeDead(sim: AnySim, mode: 'unreleased' | 'ghost'): AnyEntity {
+  const p = sim.player as AnyEntity;
+  const spot = { x: p.pos.x, z: p.pos.z };
+  p.hp = 0;
+  p.dead = true;
+  if (mode === 'ghost') {
+    sim.releaseSpirit();
+    teleport(sim, p, spot.x, spot.z);
+  }
+  return p;
+}
+
+for (const mode of ['unreleased', 'ghost'] as const) {
+  describe(`dead-gate: interaction commands refused for a ${mode} dead player`, () => {
+    it('interact is refused with the while-dead error', () => {
+      const sim = makeSim();
+      const p = sim.player as AnyEntity;
+      teleport(sim, p, 0, -120); // open ground, no Spirit Healer in reach
+      makeDead(sim, mode);
+      expect(healerInRange(sim, p.pos, INTERACT_RANGE)).toBe(false);
+      sim.drainEvents();
+      sim.interact();
+      expect(deadErrors(sim.drainEvents())).toBe(1);
+    });
+
+    it('interact near a mailbox is refused (the mailbox-open path)', () => {
+      const sim = makeSim();
+      const p = sim.player as AnyEntity;
+      const mailbox = [...sim.entities.values()].find(
+        (e: AnyEntity) => e.templateId === 'mailbox',
+      ) as AnyEntity;
+      expect(mailbox).toBeTruthy();
+      teleport(sim, p, mailbox.pos.x + 1, mailbox.pos.z);
+      makeDead(sim, mode);
+      sim.drainEvents();
+      sim.interact();
+      const events = sim.drainEvents();
+      expect(deadErrors(events)).toBe(1);
+      expect(events.some((ev: any) => ev.type === 'mailbox')).toBe(false);
+    });
+
+    it('lootCorpse is refused and the loot stays on the corpse', () => {
+      const sim = makeSim();
+      const p = sim.player as AnyEntity;
+      const wolf = [...sim.entities.values()].find((e: AnyEntity) => e.kind === 'mob') as AnyEntity;
+      wolf.hp = 0;
+      wolf.dead = true;
+      wolf.lootable = true;
+      wolf.tappedById = sim.playerId;
+      wolf.loot = { copper: 0, items: [{ itemId: 'wolf_fang', count: 1 }] };
+      teleport(sim, p, wolf.pos.x, wolf.pos.z);
+      makeDead(sim, mode);
+      sim.drainEvents();
+      sim.lootCorpse(wolf.id);
+      expect(deadErrors(sim.drainEvents())).toBe(1);
+      expect(wolf.loot!.items[0].count).toBe(1); // untouched, still on the corpse
+      expect(sim.countItem('wolf_fang')).toBe(0);
+    });
+
+    it('pickUpObject is refused and the object stays in the world', () => {
+      const sim = makeSim();
+      const p = sim.player as AnyEntity;
+      const obj = [...sim.entities.values()].find(
+        (e: AnyEntity) => e.kind === 'object' && e.lootable && e.objectItemId,
+      ) as AnyEntity;
+      expect(obj).toBeTruthy();
+      teleport(sim, p, obj.pos.x + 1, obj.pos.z);
+      makeDead(sim, mode);
+      sim.drainEvents();
+      sim.pickUpObject(obj.id);
+      expect(deadErrors(sim.drainEvents())).toBe(1);
+      expect(obj.lootable).toBe(true);
+      expect(sim.countItem(obj.objectItemId as string)).toBe(0);
+    });
+
+    it('talkToNpc on a quest NPC is refused', () => {
+      const sim = makeSim();
+      const p = sim.player as AnyEntity;
+      const npc = [...sim.entities.values()].find(
+        (e: AnyEntity) =>
+          e.kind === 'npc' && e.questIds.length > 0 && e.templateId !== SPIRIT_HEALER_NPC_ID,
+      ) as AnyEntity;
+      expect(npc).toBeTruthy();
+      teleport(sim, p, npc.pos.x + 1, npc.pos.z);
+      makeDead(sim, mode);
+      sim.drainEvents();
+      sim.talkToNpc(npc.id);
+      const events = sim.drainEvents();
+      expect(deadErrors(events)).toBe(1);
+      expect(events.some((ev: any) => ev.type === 'questAccepted')).toBe(false);
+    });
+
+    it('acceptQuest is refused and nothing lands in the log', () => {
+      const sim = makeSim();
+      makeDead(sim, mode);
+      const questId = Object.keys(QUESTS)[0];
+      sim.drainEvents();
+      sim.acceptQuest(questId);
+      expect(deadErrors(sim.drainEvents())).toBe(1);
+      expect(sim.questLog.size).toBe(0);
+    });
+
+    it('buyItem is refused like the rest of the vendor family', () => {
+      const sim = makeSim();
+      const p = sim.player as AnyEntity;
+      const vendor = [...sim.entities.values()].find(
+        (e: AnyEntity) => e.kind === 'npc' && e.vendorItems.length > 0,
+      ) as AnyEntity;
+      expect(vendor).toBeTruthy();
+      const itemId = vendor.vendorItems[0] as string;
+      teleport(sim, p, vendor.pos.x + 1, vendor.pos.z);
+      makeDead(sim, mode);
+      sim.drainEvents();
+      sim.buyItem(vendor.id, itemId);
+      expect(deadErrors(sim.drainEvents())).toBe(1);
+      expect(sim.countItem(itemId)).toBe(0);
+    });
+
+    it('turnInQuest is refused and the quest stays ready in the log', () => {
+      const sim = makeSim();
+      const questId = Object.keys(QUESTS)[0];
+      const quest = QUESTS[questId];
+      sim.questLog.set(questId, {
+        questId,
+        counts: quest.objectives.map((o: any) => o.count),
+        state: 'ready',
+      });
+      makeDead(sim, mode);
+      sim.drainEvents();
+      sim.turnInQuest(questId);
+      const events = sim.drainEvents();
+      expect(deadErrors(events)).toBe(1);
+      expect(events.some((ev: any) => ev.type === 'questDone')).toBe(false);
+      expect(sim.questLog.get(questId)?.state).toBe('ready');
+    });
+  });
+}
+
+describe('dead-gate: Spirit Healer exceptions for a ghost', () => {
+  it('interact at the graveyard (angel in reach) emits no while-dead error', () => {
+    const sim = makeSim();
+    const p = sim.player as AnyEntity;
+    p.hp = 0;
+    p.dead = true;
+    sim.releaseSpirit(); // ghost rises at a graveyard, an angel hovering there
+    expect(healerInRange(sim, p.pos, INTERACT_RANGE)).toBe(true);
+    sim.drainEvents();
+    sim.interact();
+    expect(deadErrors(sim.drainEvents())).toBe(0);
+  });
+
+  it('talkToNpc on the Spirit Healer emits no while-dead error', () => {
+    const sim = makeSim();
+    const p = sim.player as AnyEntity;
+    p.hp = 0;
+    p.dead = true;
+    sim.releaseSpirit();
+    const healer = [...sim.entities.values()].find(
+      (e: AnyEntity) =>
+        e.kind === 'npc' &&
+        e.templateId === SPIRIT_HEALER_NPC_ID &&
+        dist2d(e.pos, p.pos) <= INTERACT_RANGE + 2,
+    ) as AnyEntity;
+    expect(healer).toBeTruthy();
+    sim.drainEvents();
+    sim.talkToNpc(healer.id);
+    expect(deadErrors(sim.drainEvents())).toBe(0);
+  });
+
+  it('the healer resurrection itself still works for a ghost', () => {
+    const sim = makeSim();
+    const p = sim.player as AnyEntity;
+    sim.setPlayerLevel(10);
+    p.hp = 0;
+    p.dead = true;
+    sim.releaseSpirit();
+    expect(healerInRange(sim, p.pos, SPIRIT_HEALER_RANGE)).toBe(true);
+    sim.resurrectAtSpiritHealer();
+    expect(p.dead).toBe(false);
+    expect(p.ghost).toBe(false);
+  });
+
+  it('mailTake is silently refused while dead (no parcels into a corpse)', () => {
+    const sim = makeSim();
+    const p = sim.player as AnyEntity;
+    const meta = sim.players.get(sim.playerId)!;
+    const mailbox = [...sim.entities.values()].find(
+      (e: AnyEntity) => e.templateId === 'mailbox',
+    ) as AnyEntity;
+    sim.postOffice.mail.push({
+      id: 4242,
+      recipientKey: meta.name,
+      recipientName: meta.name,
+      senderName: 'Postmaster',
+      kind: 'system',
+      subject: 'Coin',
+      body: '',
+      copper: 50,
+      items: [],
+      deliverAt: 0,
+      expiresAt: Infinity,
+      read: false,
+      announced: false,
+    });
+    teleport(sim, p, mailbox.pos.x + 1, mailbox.pos.z);
+    makeDead(sim, 'ghost');
+    const before = meta.copper;
+    sim.mailTake(4242);
+    expect(meta.copper).toBe(before);
+    const letter = sim.postOffice.mail.find((m: any) => m.id === 4242)!;
+    expect(letter.copper).toBe(50); // still attached
+  });
+});
+
+describe('auto-release-on-logout: save/load of a dead-unreleased character', () => {
+  it('an overworld dead-unreleased save resumes as a released ghost at the graveyard', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(10);
+    const p = sim.player as AnyEntity;
+    teleport(sim, p, 0, -120); // a known overworld death spot
+    p.hp = 0;
+    p.dead = true; // died, logged out WITHOUT releasing
+    const state = sim.serializeCharacter(sim.playerId)!;
+    expect(state.dead).toBe(true);
+    expect(state.ghost).toBe(false);
+
+    // what the normal release path would produce from the same death spot
+    sim.releaseSpirit();
+    const releasedPos = { x: p.pos.x, z: p.pos.z };
+
+    const sim2 = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true }) as AnySim;
+    const pid2 = sim2.addPlayer('warrior', 'Reloger', { state });
+    const e2 = sim2.entities.get(pid2) as AnyEntity;
+    expect(e2.dead).toBe(true);
+    expect(e2.ghost).toBe(true);
+    // the corpse lies at the death spot
+    expect(e2.corpsePos).toBeTruthy();
+    expect(dist2d(e2.corpsePos!, { x: 0, y: 0, z: -120 })).toBeLessThan(1);
+    // the spirit stands exactly where the normal release path puts it
+    expect(Math.abs(e2.pos.x - releasedPos.x)).toBeLessThan(1);
+    expect(Math.abs(e2.pos.z - releasedPos.z)).toBeLessThan(1);
+    expect(healerInRange(sim2, e2.pos, SPIRIT_HEALER_RANGE)).toBe(true);
+    // ghost display pools: full greyed bar
+    expect(e2.hp).toBe(e2.maxHp);
+  });
+
+  it('a dungeon dead-unreleased save keeps the corpse inside and rises at an outdoor graveyard', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(10);
+    const p = sim.player as AnyEntity;
+    sim.enterDungeon('hollow_crypt');
+    expect(p.pos.x).toBeGreaterThan(DUNGEON_X_THRESHOLD);
+    // die deeper inside the instance
+    p.pos = { x: p.pos.x, y: p.pos.y, z: p.pos.z + 30 };
+    p.prevPos = { ...p.pos };
+    sim.rebucket(p);
+    const deathSpot = { x: p.pos.x, z: p.pos.z };
+    p.hp = 0;
+    p.dead = true;
+    const state = sim.serializeCharacter(sim.playerId)!;
+    expect(state.dead).toBe(true);
+
+    const sim2 = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true }) as AnySim;
+    const pid2 = sim2.addPlayer('warrior', 'Reloger', { state });
+    const e2 = sim2.entities.get(pid2) as AnyEntity;
+    expect(e2.dead).toBe(true);
+    expect(e2.ghost).toBe(true);
+    // corpse marked at the death spot inside the instance band
+    expect(e2.corpsePos!.x).toBeGreaterThan(DUNGEON_X_THRESHOLD);
+    expect(dist2d(e2.corpsePos!, { x: deathSpot.x, y: 0, z: deathSpot.z })).toBeLessThan(1);
+    // the spirit rises OUTSIDE, at an overworld graveyard with an angel
+    expect(e2.pos.x).toBeLessThan(DUNGEON_X_THRESHOLD);
+    expect(healerInRange(sim2, e2.pos, SPIRIT_HEALER_RANGE)).toBe(true);
+  });
+
+  it('an alive save still loads alive and unchanged', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(10);
+    const p = sim.player as AnyEntity;
+    p.hp = 37;
+    const state = sim.serializeCharacter(sim.playerId)!;
+    expect(state.dead).toBe(false);
+
+    const sim2 = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true }) as AnySim;
+    const pid2 = sim2.addPlayer('warrior', 'Reloger', { state });
+    const e2 = sim2.entities.get(pid2) as AnyEntity;
+    expect(e2.dead).toBe(false);
+    expect(e2.ghost).toBe(false);
+    expect(e2.hp).toBe(37);
+  });
+
+  it('a released-ghost save still resumes exactly as today (no double release)', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(10);
+    const p = sim.player as AnyEntity;
+    teleport(sim, p, 0, -120);
+    p.hp = 0;
+    p.dead = true;
+    sim.releaseSpirit();
+    const savedGhostPos = { x: p.pos.x, z: p.pos.z };
+    const savedCorpse = { ...(p.corpsePos as { x: number; y: number; z: number }) };
+    const state = sim.serializeCharacter(sim.playerId)!;
+    expect(state.ghost).toBe(true);
+
+    const sim2 = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true }) as AnySim;
+    const pid2 = sim2.addPlayer('warrior', 'Reloger', { state });
+    const e2 = sim2.entities.get(pid2) as AnyEntity;
+    expect(e2.dead).toBe(true);
+    expect(e2.ghost).toBe(true);
+    expect(Math.abs(e2.pos.x - savedGhostPos.x)).toBeLessThan(1);
+    expect(Math.abs(e2.pos.z - savedGhostPos.z)).toBeLessThan(1);
+    expect(dist2d(e2.corpsePos!, savedCorpse)).toBeLessThan(1);
+  });
+
+  it('an old save without the dead field loads alive at 1 hp, exactly as before', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(10);
+    const p = sim.player as AnyEntity;
+    teleport(sim, p, 0, -120);
+    p.hp = 0;
+    p.dead = true;
+    const state = sim.serializeCharacter(sim.playerId)! as any;
+    delete state.dead; // simulate a pre-fix save
+
+    const sim2 = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true }) as AnySim;
+    const pid2 = sim2.addPlayer('warrior', 'Reloger', { state });
+    const e2 = sim2.entities.get(pid2) as AnyEntity;
+    expect(e2.dead).toBe(false);
+    expect(e2.ghost).toBe(false);
+    expect(e2.hp).toBe(1);
+  });
+});

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -279,6 +279,97 @@ describe('handlePickedEntity', () => {
   });
 });
 
+describe('handlePickedEntity while dead (the ghost/death loop)', () => {
+  // Shared rig: a player stub, a nearby entity, and call-recording world + hud.
+  function rig(playerPartial: Partial<Entity>, target: Entity) {
+    const player = stubEntity({ id: 1, kind: 'player', ...playerPartial });
+    const calls: string[] = [];
+    const world: any = {
+      playerId: 1,
+      player,
+      entities: new Map([
+        [1, player],
+        [target.id, target],
+      ]),
+      duelInfo: null,
+      arenaInfo: null,
+      targetEntity: () => {},
+      enterDungeon: () => calls.push('enterDungeon'),
+      leaveDungeon: () => {},
+      pickUpObject: () => calls.push('pickUpObject'),
+      startAutoAttack: () => {},
+      resurrectAtSpiritHealer: () => calls.push('resurrectAtSpiritHealer'),
+    };
+    const hud = {
+      openLoot: () => calls.push('openLoot'),
+      openQuestDialog: () => calls.push('openQuestDialog'),
+      openDelveBoard: () => calls.push('openDelveBoard'),
+      openMailbox: () => calls.push('openMailbox'),
+      showError: () => calls.push('showError'),
+      closeContextMenu: () => {},
+    };
+    return { world, hud, calls };
+  }
+
+  const questNpc = () =>
+    stubEntity({ id: 2, kind: 'npc', templateId: 'elder_maren', pos: { x: 3, y: 0, z: 0 } });
+
+  it('a ghost right-clicking a quest NPC does not open the quest dialog', () => {
+    const { world, hud, calls } = rig({ dead: true, ghost: true }, questNpc());
+    handlePickedEntity(world, hud, 2, 2, 10, 20);
+    expect(calls).not.toContain('openQuestDialog');
+    expect(calls).not.toContain('openDelveBoard');
+    expect(calls).toContain('showError');
+  });
+
+  it('a ghost left-clicking a quest NPC does not open the quest dialog', () => {
+    const { world, hud, calls } = rig({ dead: true, ghost: true }, questNpc());
+    handlePickedEntity(world, hud, 2, 0, 10, 20);
+    expect(calls).not.toContain('openQuestDialog');
+    expect(calls).not.toContain('openDelveBoard');
+  });
+
+  it('a dead-unreleased player clicking a quest NPC does not open the quest dialog', () => {
+    const { world, hud, calls } = rig({ dead: true, ghost: false }, questNpc());
+    handlePickedEntity(world, hud, 2, 2, 10, 20);
+    expect(calls).not.toContain('openQuestDialog');
+  });
+
+  it('a ghost right-clicking the Spirit Healer still takes the healer res', () => {
+    const healer = stubEntity({
+      id: 2,
+      kind: 'npc',
+      templateId: 'spirit_healer',
+      pos: { x: 3, y: 0, z: 0 },
+    });
+    const { world, hud, calls } = rig({ dead: true, ghost: true }, healer);
+    handlePickedEntity(world, hud, 2, 2, 10, 20);
+    expect(calls).toContain('resurrectAtSpiritHealer');
+    expect(calls).not.toContain('openQuestDialog');
+  });
+
+  it('a ghost clicking a mailbox does not open it', () => {
+    const mailbox = stubEntity({
+      id: 2,
+      kind: 'object',
+      templateId: 'mailbox',
+      lootable: true,
+      pos: { x: 3, y: 0, z: 0 },
+    });
+    const { world, hud, calls } = rig({ dead: true, ghost: true }, mailbox);
+    handlePickedEntity(world, hud, 2, 2, 10, 20);
+    expect(calls).not.toContain('openMailbox');
+    handlePickedEntity(world, hud, 2, 0, 10, 20);
+    expect(calls).not.toContain('openMailbox');
+  });
+
+  it('an alive player clicking a quest NPC still opens the quest dialog', () => {
+    const { world, hud, calls } = rig({}, questNpc());
+    handlePickedEntity(world, hud, 2, 2, 10, 20);
+    expect(calls).toContain('openQuestDialog');
+  });
+});
+
 describe('HoverPickGate', () => {
   it('picks on first call and then throttles a stationary pointer', () => {
     const gate = new HoverPickGate();


### PR DESCRIPTION
## Problem

PR #1384 (ghost/death loop) let a released ghost roam the world while invulnerable and faster than the living. But the interaction and quest command family was never dead-gated, because before ghost mode a dead player could not move, so those paths were unreachable. As a result a ghost could loot corpses, pick up ground quest objectives inside lethal camps, talk to NPCs, and accept/turn in quests, all server-side and reachable from the stock client. Separately, dying and logging out **without** releasing revived the character in place at 1 hp on relog, bypassing the whole death loop (no corpse run, no sickness).

## Fix

**Part A, dead-gate the world-interaction family.** Every entry point now refuses a dead player (released ghosts included) with the item family's existing `"You can't do that while dead."` string (already covered by the `error.cantWhileDead` matcher, so no new i18n key):
- `lootCorpse`, `pickUpObject`, `interact` (`src/sim/interaction.ts`)
- `talkToNpc` (`src/sim/sim.ts`)
- `acceptQuest`, `turnInQuest` (`src/sim/quests/quest_commands.ts`)
- `buyItem` (`src/sim/items.ts`, the one ungated vendor entry point)
- `mailTake` / `mailDelete` (`src/sim/mail/post_office.ts`, matching the silent gate `mailSend` already had)

Exceptions preserved: `interact` routes a nearby Spirit Healer (Pale Keeper) through `talkToNpc`, `talkToNpc` exempts `SPIRIT_HEALER_NPC_ID`, and the release / resurrect flows in `spirit.ts` are untouched. Client UX (`src/game/interactions.ts`): a ghost no longer opens the quest dialog, delve board, or mailbox; a ghost right-clicking the Pale Keeper still takes the healer res.

**Part B, logout preserves the death loop.** `CharacterState` gains an optional `dead` field; `serializeCharacter` persists it; `addPlayer` auto-releases a dead-but-unreleased save by placing the body at the death spot and reusing `releasePlayerSpirit` (so the corpse marker and graveyard choice, including the instance rule, cannot drift from `spirit.ts`). Old saves without the field load alive exactly as before; released-ghost saves resume unchanged; delve/arena/fiesta positions are excluded so those flows are untouched.

## Tests

- `tests/ghost_dead_gate.test.ts` (new, 25 tests): each gated action refused for a dead-unreleased player AND a released ghost; Spirit Healer exceptions still work; auto-release-on-logout save/load (overworld + dungeon-instance cases; alive and released-ghost saves unchanged; legacy save without the field loads alive).
- `tests/interactions.test.ts` (extended): client picked-entity behavior while dead.

## Verification

- `tsc --noEmit`: clean
- `vitest`: ghost_dead_gate (25), interactions (21), spirit (15), architecture, parity (96) all green (181 tests in the targeted run)
- No parity re-mint needed (gates fire only on dead-player commands; `releasePlayerSpirit` draws no rng)
- No new i18n key (reused `error.cantWhileDead`)

## Manual test plan

- As a ghost: try to loot a party kill, pick up a ground quest object in a hostile camp, turn in a ready quest, open a mailbox. All must be refused.
- As a ghost at a graveyard: right-click the Pale Keeper still resurrects (with sickness).
- Die and log out **without** releasing, relog: you resume as a released ghost with the corpse marker, not alive at 1 hp. Die inside a dungeon, log out unreleased, relog: spirit at the outdoor graveyard nearest the door.
- Delve/arena/fiesta deaths behave exactly as before.
