### PR TITLE
fix(delves): reset Sister Nhalia's encounter state when she evades

### DIFF
--- a/src/sim/delves/drowned_litany_boss.ts
+++ b/src/sim/delves/drowned_litany_boss.ts
@@ -77,6 +77,24 @@ export function clearDrownedLitanyBossState(run: DelveRun): void {
   run.nhaliaBoss = undefined;
 }
 
+// Evade/leash reset: when Sister Nhalia goes home (kited past the leash or a
+// party wipe), her encounter re-arms to the exact fresh-pull state, so the
+// re-pull fires the Cantor phases and the Final Bell again. The generic
+// resetEvadingMob already full-heals her, clears her auras (the Cantor shield),
+// and despawns her summonedIds (Cantor and thrall adds); bells are deliberately
+// NOT summoned adds, so drop the in-flight ones here before re-initializing.
+export function resetDrownedLitanyBossEncounter(ctx: SimContext, boss: Entity): void {
+  const run = ctx.delveRunForMob(boss.id);
+  if (!run || run.delveId !== 'drowned_litany') return;
+  const st = run.nhaliaBoss;
+  if (!st) return;
+  for (const bell of st.bells) {
+    const be = ctx.entities.get(bell.entityId);
+    if (be && !be.dead) ctx.dropEntity(bell.entityId);
+  }
+  initDrownedLitanyBossState(run);
+}
+
 function findNhaliaBoss(ctx: SimContext, run: DelveRun): Entity | null {
   for (const id of run.mobIds) {
     const e = ctx.entities.get(id);

--- a/src/sim/mob/locomotion.ts
+++ b/src/sim/mob/locomotion.ts
@@ -24,6 +24,7 @@
 // touches not-yet-extracted Sim state routes through the seam.
 
 import { DUNGEON_X_THRESHOLD, MOBS } from '../data';
+import { resetDrownedLitanyBossEncounter } from '../delves/drowned_litany_boss';
 import { PLAYER_BODY_RADIUS, PLAYER_SWIM_DEPTH } from '../pathfind';
 import type { SimContext } from '../sim_context';
 import { clearThreat, stealthDetectionRadius } from '../threat';
@@ -38,6 +39,7 @@ import {
   MELEE_RANGE,
   NYTHRAXIS_ADD_ID,
   NYTHRAXIS_BOSS_ID,
+  SISTER_NHALIA_BOSS_ID,
   TOLLING_BELL_TEMPLATE_ID,
   type Vec3,
 } from '../types';
@@ -605,6 +607,7 @@ export function resetEvadingMob(ctx: SimContext, mob: Entity): void {
   mob.yelledEngage = false;
   mob.wanderTimer = ctx.rng.range(2, 8);
   if (mob.templateId === NYTHRAXIS_BOSS_ID) ctx.resetNythraxisEncounter(mob);
+  if (mob.templateId === SISTER_NHALIA_BOSS_ID) resetDrownedLitanyBossEncounter(ctx, mob);
 }
 
 // Cowardly mobs panic once per pull at low HP, then recover their nerve and turn to

--- a/tests/delves.test.ts
+++ b/tests/delves.test.ts
@@ -2548,6 +2548,72 @@ describe('The Drowned Litany (Phase 6 boss mechanics)', () => {
     };
     expect(runMark(42)).toEqual(runMark(42));
   });
+
+  it('an evade re-arms the encounter to fresh-pull state and despawns bells and adds', () => {
+    const sim = makeSim();
+    const run = enterLitanyApse(sim);
+    const boss = nhalia(sim);
+    boss.inCombat = true;
+
+    // First pull: below 70% fires the first Cantor phase; force a bell volley too.
+    boss.hp = Math.ceil(boss.maxHp * 0.69);
+    run.nhaliaBoss!.bellVolleyTimer = 0.001;
+    (sim as any).updateDelveRuns();
+    expect(run.nhaliaBoss?.firedCantorPhases).toBe(1);
+    const bellIds = run.nhaliaBoss!.bells.map((b) => b.entityId);
+    expect(bellIds.length).toBeGreaterThan(0);
+    const cantorIds = [...sim.entities.values()]
+      .filter((e) => e.templateId === 'drowned_cantor')
+      .map((e) => e.id);
+    expect(cantorIds.length).toBe(2);
+
+    // Kited past the leash: the evade arrival reset (same entry the wipe path uses).
+    (sim as any).resetEvadingMob(boss);
+
+    expect(boss.hp).toBe(boss.maxHp);
+    expect(boss.auras.some((a) => a.id === 'nhalia_cantor_shield')).toBe(false);
+    expect(run.nhaliaBoss?.firedCantorPhases).toBe(0);
+    expect(run.nhaliaBoss?.finalBellFired).toBe(false);
+    expect(run.nhaliaBoss?.marks).toEqual([]);
+    expect(run.nhaliaBoss?.bells).toEqual([]);
+    expect(run.nhaliaBoss?.cantorShieldAdds).toEqual([]);
+    for (const id of bellIds) expect(sim.entities.has(id)).toBe(false);
+    for (const id of cantorIds) expect(sim.entities.has(id)).toBe(false);
+  });
+
+  it('a re-pull after an evade fires the 70% phase and the Final Bell again', () => {
+    const sim = makeSim();
+    const run = enterLitanyApse(sim);
+    const boss = nhalia(sim);
+    boss.inCombat = true;
+    boss.hp = Math.ceil(boss.maxHp * 0.69);
+    (sim as any).updateDelveRuns();
+    expect(run.nhaliaBoss?.firedCantorPhases).toBe(1);
+
+    (sim as any).resetEvadingMob(boss);
+    expect(run.nhaliaBoss?.firedCantorPhases).toBe(0);
+
+    // Re-pull: the 70% Cantor phase fires again, shield and all.
+    boss.inCombat = true;
+    boss.hp = Math.ceil(boss.maxHp * 0.69);
+    (sim as any).updateDelveRuns();
+    expect(run.nhaliaBoss?.firedCantorPhases).toBe(1);
+    const cantors = [...sim.entities.values()].filter(
+      (e) => e.templateId === 'drowned_cantor' && !e.dead,
+    );
+    expect(cantors.length).toBe(2);
+    expect(boss.auras.some((a) => a.id === 'nhalia_cantor_shield')).toBe(true);
+
+    // And the Final Bell still fires at 10% on the re-pull.
+    run.nhaliaBoss!.firedCantorPhases = 2;
+    boss.hp = Math.max(1, Math.round(boss.maxHp * 0.08));
+    (sim as any).updateDelveRuns();
+    expect(run.nhaliaBoss?.finalBellFired).toBe(true);
+    const thralls = [...sim.entities.values()].filter(
+      (e) => e.templateId === 'choir_thrall' && !e.dead,
+    );
+    expect(thralls.length).toBeGreaterThanOrEqual(4);
+  });
 });
 
 describe('The Drowned Litany (Phase 7 Drowned Reliquary Rite)', () => {


### PR DESCRIPTION
## Problem

In the Drowned Litany delve (#1327), Sister Nhalia's custom encounter state lives on the run as `run.nhaliaBoss` (`firedCantorPhases` for the 70%/35% Cantor shield phases, `finalBellFired` for the 10% Final Bell). The generic `resetEvadingMob` full-heals her, clears her auras, and despawns her summoned adds when she evades/leashes, but never touches `run.nhaliaBoss`. So kiting her past the leash distance (or a party wipe) sends her home at full HP with her phase flags still set, and the re-pull is a mechanics-free boss: no Cantor shields, no Final Bell. A deliberate Heroic-clear exploit, and an accidental difficulty loss after any unintended reset.

## Fix

New `resetDrownedLitanyBossEncounter(ctx, boss)` in `src/sim/delves/drowned_litany_boss.ts` resolves the run via the existing `ctx.delveRunForMob` seam, drops in-flight Tolling Bell entities (they are deliberately not in `boss.summonedIds`, so the generic reset misses them), and reuses the existing fresh-pull initializer `initDrownedLitanyBossState` (no duplicated literal). It is hooked in `resetEvadingMob` with a `templateId`-gated one-liner, exactly the way the codebase already hooks `resetNythraxisEncounter`, keeping the delve logic in the delve module. Verified the generic reset already covers the Cantor/thrall adds and the Cantor shield aura, so only the bells plus the per-run state needed the boss-specific reset. The party-wipe path reaches the same `resetEvadingMob` entry.

## Tests

Two tests added to `tests/delves.test.ts` (RED confirmed before the fix):
- an evade re-arms the encounter to fresh-pull state and despawns bells and adds
- a re-pull after an evade fires the 70% phase and the Final Bell again

## Verification

- `tsc --noEmit`: clean
- `vitest`: delves (133), tolling_bells, sloomtooth_drowned, architecture, parity (96) all green (269 tests in the targeted run)
- No parity re-mint needed (fix draws no rng, fires only for the Nhalia template, and no golden trace kites the delve boss)

## Manual test plan

- Heroic Drowned Litany: pull Nhalia below 70% (Cantor adds + shield appear), kite her from the altar to the apse entrance until she evades and full-heals, re-pull: the 70%/35% Cantor phases and the 10% Final Bell must fire again, and no bells/adds survive the evade.
