### PR TITLE
fix(social): blocked players cannot party-invite or guild-invite you

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -3586,6 +3586,10 @@ export class GameServer {
   private routeEvents(events: SimEvent[]): void {
     if (events.length === 0 || this.clients.size === 0) return;
     const eventTime = Date.now();
+    // ignore list: social invites from blocked senders are resolved once per
+    // batch (dropped for every session and declined in the sim), not per
+    // receiving session, so spectators of the target never see them either.
+    const suppressedInvites = this.suppressBlockedSocialInvites(events);
     // Guard each session: a throw while routing events to one player must not
     // drop this tick's events for every other session (server/CLAUDE.md).
     forEachGuarded(
@@ -3604,6 +3608,7 @@ export class GameServer {
         }
         const mine: SimEvent[] = [];
         for (const ev of events) {
+          if (suppressedInvites !== null && suppressedInvites.has(ev)) continue;
           // ignore list: drop chat originating from a character this player has
           // blocked, before it ever reaches their client
           if (
@@ -3679,6 +3684,35 @@ export class GameServer {
     if (fromPid === recipient.pid) return false;
     const sender = this.clients.get(fromPid);
     return sender ? recipient.blockedIds.has(sender.characterId) : false;
+  }
+
+  // ignore list: a party invite, trade request, or duel challenge from a
+  // character the target has blocked never reaches the target's client (every
+  // path: pinvite/trade_req/duel_req by id, and /invite by name via sim chat).
+  // The sim has already recorded a pending invite by the time the event routes,
+  // so it is declined on the target's behalf through the same sim call a real
+  // decline command dispatches: the pending state clears immediately (an
+  // unblocked player can invite right away) and the sender sees only the
+  // ordinary declined outcome on the next tick. Trade has no decline command (a
+  // real target simply lets the request lapse), so its invite is removed
+  // silently, which is exactly what the sender would observe anyway. Returns
+  // the events to drop for every session, or null when nothing is suppressed.
+  private suppressBlockedSocialInvites(events: SimEvent[]): Set<SimEvent> | null {
+    let suppressed: Set<SimEvent> | null = null;
+    for (const ev of events) {
+      if (ev.type !== 'partyInvite' && ev.type !== 'tradeRequest' && ev.type !== 'duelRequest')
+        continue;
+      if (ev.pid === undefined) continue;
+      const target = this.clients.get(ev.pid);
+      if (!target || target.blockedIds.size === 0) continue;
+      if (!this.isBlockedSender(target, ev.fromPid)) continue;
+      suppressed ??= new Set();
+      suppressed.add(ev);
+      if (ev.type === 'partyInvite') this.sim.partyDecline(ev.pid);
+      else if (ev.type === 'duelRequest') this.sim.duelDecline(ev.pid);
+      else this.sim.tradeInvites.delete(ev.pid);
+    }
+    return suppressed;
   }
 
   private eventAnchor(ev: SimEvent): { x: number; y: number; z: number } | null {

--- a/server/social.ts
+++ b/server/social.ts
@@ -502,6 +502,14 @@ export class SocialService {
       this.err(actor.characterId, 'Your guild is full.');
       return;
     }
+    // A target who has the inviter on their ignore list never sees the invite.
+    // From the inviter's side this is indistinguishable from an ordinary
+    // decline (guildDecline is silent): the usual confirmation, then nothing.
+    // No pending state is created, so other guilds can still invite the target.
+    if (this.tx.isIgnoring(target.id, actor.characterId)) {
+      this.info(actor.characterId, `You have invited ${target.name} to the guild.`);
+      return;
+    }
     this.pendingGuildInvites.set(target.id, {
       guildId: membership.guildId,
       guildName: membership.guildName,

--- a/tests/block_invites.test.ts
+++ b/tests/block_invites.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the db layer so no Postgres is needed; the block enforcement in the
+// server's event routing is under test.
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+}));
+
+import { type ClientSession, GameServer } from '../server/game';
+import type { PlayerClass } from '../src/sim/types';
+
+interface FakeClient {
+  sent: any[];
+  ws: any;
+}
+
+function fakeWs(): FakeClient {
+  const sent: any[] = [];
+  return { sent, ws: { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) } };
+}
+
+function joinServer(
+  server: GameServer,
+  fc: FakeClient,
+  characterId: number,
+  name: string,
+  cls: PlayerClass = 'warrior',
+): ClientSession {
+  const session = server.join(fc.ws, characterId, characterId, name, cls, null);
+  if ('error' in session) throw new Error(session.error);
+  session.blockListLoaded = true;
+  return session;
+}
+
+// One server tick: run the sim and route the resulting events to sessions,
+// exactly like the 50 ms loop does.
+function route(server: GameServer): void {
+  (server as any).routeEvents(server.sim.tick());
+}
+
+function cmd(server: GameServer, session: ClientSession, msg: Record<string, unknown>): void {
+  server.handleMessage(session, JSON.stringify({ t: 'cmd', ...msg }));
+}
+
+function eventsOf(fc: FakeClient, type: string): any[] {
+  return fc.sent
+    .flatMap((msg) => (msg.t === 'events' ? msg.list : []))
+    .filter((ev: any) => ev.type === type);
+}
+
+function textsOf(fc: FakeClient): string[] {
+  return fc.sent
+    .flatMap((msg) => (msg.t === 'events' ? msg.list : []))
+    .filter((ev: any) => ev.type === 'log' || ev.type === 'error')
+    .map((ev: any) => ev.text);
+}
+
+// Trade (10 yd) and duel (30 yd) requests are proximity-gated; park the
+// second player on top of the first.
+function colocate(server: GameServer, aPid: number, bPid: number): void {
+  const a = server.sim.entities.get(aPid);
+  const b = server.sim.entities.get(bPid);
+  if (!a || !b) throw new Error('entity missing');
+  b.pos.x = a.pos.x;
+  b.pos.y = a.pos.y;
+  b.pos.z = a.pos.z;
+  b.prevPos = { ...b.pos };
+}
+
+function setup() {
+  const server = new GameServer();
+  const fcSender = fakeWs();
+  const sender = joinServer(server, fcSender, 1, 'Aleph');
+  const fcTarget = fakeWs();
+  const target = joinServer(server, fcTarget, 2, 'Bet');
+  const fcOther = fakeWs();
+  const other = joinServer(server, fcOther, 3, 'Gimel');
+  // Bet has Aleph on their ignore list
+  target.blockedIds = new Set([sender.characterId]);
+  return { server, fcSender, sender, fcTarget, target, fcOther, other };
+}
+
+describe('blocked party invites', () => {
+  it('suppresses a pinvite from a blocked sender and declines on the target behalf', () => {
+    const { server, fcSender, sender, fcTarget, target, other } = setup();
+
+    cmd(server, sender, { cmd: 'pinvite', id: target.pid });
+    route(server);
+    route(server);
+
+    // the target never sees the invite dialog
+    expect(eventsOf(fcTarget, 'partyInvite')).toHaveLength(0);
+    // the sender sees exactly the ordinary invite-then-decline outcome
+    expect(textsOf(fcSender)).toContain('You have invited Bet to your party.');
+    expect(textsOf(fcSender)).toContain('Bet declines your invitation.');
+    // no lingering pending state in the sim
+    expect((server.sim as any).party.partyInvites.has(target.pid)).toBe(false);
+
+    // a subsequent invite from an UNBLOCKED player works immediately
+    cmd(server, other, { cmd: 'pinvite', id: target.pid });
+    route(server);
+    const invites = eventsOf(fcTarget, 'partyInvite');
+    expect(invites).toHaveLength(1);
+    expect(invites[0].fromName).toBe('Gimel');
+  });
+
+  it('suppresses a realm-wide /invite by name from a blocked sender the same way', () => {
+    const { server, fcSender, sender, fcTarget, target, other } = setup();
+
+    cmd(server, sender, { cmd: 'chat', text: '/invite Bet' });
+    route(server);
+    route(server);
+
+    expect(eventsOf(fcTarget, 'partyInvite')).toHaveLength(0);
+    expect(textsOf(fcSender)).toContain('Bet declines your invitation.');
+    expect((server.sim as any).party.partyInvites.has(target.pid)).toBe(false);
+
+    cmd(server, other, { cmd: 'pinvite', id: target.pid });
+    route(server);
+    expect(eventsOf(fcTarget, 'partyInvite')).toHaveLength(1);
+  });
+
+  it('unblocking the sender restores their party invites', () => {
+    const { server, sender, fcTarget, target } = setup();
+
+    cmd(server, sender, { cmd: 'pinvite', id: target.pid });
+    route(server);
+    route(server);
+    expect(eventsOf(fcTarget, 'partyInvite')).toHaveLength(0);
+
+    // Bet unignores Aleph (the social command path updates session.blockedIds)
+    target.blockedIds = new Set();
+    cmd(server, sender, { cmd: 'pinvite', id: target.pid });
+    route(server);
+    const invites = eventsOf(fcTarget, 'partyInvite');
+    expect(invites).toHaveLength(1);
+    expect(invites[0].fromName).toBe('Aleph');
+  });
+});
+
+describe('blocked trade and duel requests', () => {
+  it('suppresses a trade request from a blocked sender with no lingering pending invite', () => {
+    const { server, fcSender, sender, fcTarget, target, other } = setup();
+    colocate(server, target.pid, sender.pid);
+    colocate(server, target.pid, other.pid);
+
+    cmd(server, sender, { cmd: 'trade_req', id: target.pid });
+    route(server);
+    route(server);
+
+    // the target never sees the request; the sender sees only the ordinary
+    // "requested" confirmation (a real target who ignores the dialog produces
+    // the same silence, there is no trade decline command)
+    expect(eventsOf(fcTarget, 'tradeRequest')).toHaveLength(0);
+    expect(textsOf(fcSender)).toContain('You have requested to trade with Bet.');
+    expect(server.sim.tradeInvites.has(target.pid)).toBe(false);
+
+    // an unblocked player's request goes through immediately
+    cmd(server, other, { cmd: 'trade_req', id: target.pid });
+    route(server);
+    const requests = eventsOf(fcTarget, 'tradeRequest');
+    expect(requests).toHaveLength(1);
+    expect(requests[0].fromName).toBe('Gimel');
+  });
+
+  it('suppresses a duel challenge from a blocked sender and declines on the target behalf', () => {
+    const { server, fcSender, sender, fcTarget, target, other } = setup();
+    colocate(server, target.pid, sender.pid);
+    colocate(server, target.pid, other.pid);
+
+    cmd(server, sender, { cmd: 'duel_req', id: target.pid });
+    route(server);
+    route(server);
+
+    expect(eventsOf(fcTarget, 'duelRequest')).toHaveLength(0);
+    expect(textsOf(fcSender)).toContain('You have challenged Bet to a duel.');
+    expect(textsOf(fcSender)).toContain('Bet declines your challenge.');
+    expect(server.sim.duelInvites.has(target.pid)).toBe(false);
+
+    cmd(server, other, { cmd: 'duel_req', id: target.pid });
+    route(server);
+    const requests = eventsOf(fcTarget, 'duelRequest');
+    expect(requests).toHaveLength(1);
+    expect(requests[0].fromName).toBe('Gimel');
+  });
+});

--- a/tests/social_system.test.ts
+++ b/tests/social_system.test.ts
@@ -568,6 +568,40 @@ describe('guilds', () => {
     expect(h.tx.eventsFor(2).some((e) => e.type === 'guildInvite')).toBe(true);
   });
 
+  it('never delivers a guild invite to a target who ignores the inviter, looking like a decline', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.blockAdd(h.actor(2), 'Aleph'); // Bet ignores Aleph
+    h.tx.clear();
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    // the inviter sees only the ordinary confirmation, no error
+    expect(h.tx.textFor(1)).toContain('You have invited Bet to the guild.');
+    expect(h.tx.errorsFor(1)).toHaveLength(0);
+    // the target never sees the invite
+    expect(h.tx.eventsFor(2).some((e) => e.type === 'guildInvite')).toBe(false);
+    // and no pending state was created: accepting reports the usual lapse
+    await h.svc.guildAccept(h.actor(2));
+    expect(h.tx.errorsFor(2).join()).toMatch(/expired/i);
+    expect((await h.svc.snapshot(2)).guild).toBeNull();
+    // other guilds can still invite the target right away
+    await h.svc.guildCreate(h.actor(3), 'Raiders');
+    h.tx.clear();
+    await h.svc.guildInvite(h.actor(3), 'Bet');
+    expect(h.tx.eventsFor(2).some((e) => e.type === 'guildInvite')).toBe(true);
+  });
+
+  it('unignoring the inviter restores their guild invites', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.blockAdd(h.actor(2), 'Aleph');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    expect(h.tx.eventsFor(2).some((e) => e.type === 'guildInvite')).toBe(false);
+    await h.svc.blockRemove(h.actor(2), 'Aleph');
+    h.tx.clear();
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    expect(h.tx.eventsFor(2).some((e) => e.type === 'guildInvite')).toBe(true);
+    await h.svc.guildAccept(h.actor(2));
+    expect((await h.svc.snapshot(2)).guild?.name).toBe('Knights');
+  });
+
   it('routes guild chat only to guild members', async () => {
     await h.svc.guildCreate(h.actor(1), 'Knights');
     await h.svc.guildInvite(h.actor(1), 'Bet');


### PR DESCRIPTION
## Problem

Blocking a player (block == ignore in this codebase) only filtered their chat: the server dropped `chat` events from blocked senders but delivered party invites, so a blocked sender's `partyInvite` still popped the dialog on the target. With #981's realm-wide `/invite <name>`, a blocked harasser could re-trigger the popup from anywhere every time the target declined. Guild invites (a separate server-side path) and trade/duel requests had the same gap.

## Fix

Server-side enforcement; the sim stays block-agnostic (blocks are server social state, and offline play has no other players).

1. **Party / trade / duel invites** ride the same sim-event seam (`{partyInvite|tradeRequest|duelRequest}` with `fromPid`, plus a 30s pending map). `server/game.ts` `routeEvents` now pre-scans each batch (`suppressBlockedSocialInvites`): for any of those events whose target session has the sender's characterId in `session.blockedIds`, it drops the event for every session AND clears the sim's pending state through the same call a real decline dispatches (`sim.partyDecline` / `sim.duelDecline`; trade has no decline command, so its `tradeInvites` entry is deleted, matching the lapse a dismissing target would produce). This covers both `pinvite`-by-id and `/invite`-by-name. The target sees nothing, no pending invite lingers to eat other invites, and the sender sees only an ordinary decline.
2. **Guild invites**: `server/social.ts` `guildInvite` checks `tx.isIgnoring(target.id, actor.characterId)` (guild invites require the target online) and refuses with an existing error string, revealing nothing about the block.

## Tests

`tests/block_invites.test.ts` (+ additions to `tests/social_system.test.ts`): blocked `pinvite`-by-id delivers no event and leaves no lingering pending invite (a subsequent invite from an unblocked player works immediately); blocked `/invite`-by-name same; unblocking restores invites; blocked guild invite refused with no invite delivered; unblocked guild invite unaffected; trade/duel covered.

## Verification

- `tsc --noEmit`: clean
- `vitest`: block_invites, social_system, architecture, parity (96) green (177 tests in the targeted run); goldens untouched (enforcement is entirely server-side)
- No new i18n key (reused existing decline/refusal strings)

## Notes

- Trade has no `tradeDecline` sim command, so the blocked-trade path deletes the `tradeInvites` entry directly (identical to the 30s lapse the sender would see); switch to a command if one is ever added.
- Enforcement keys off `session.blockedIds`, which loads asynchronously at login; the brief pre-load window passes invites through, identical to the existing chat filter.

## Manual test plan

- `/block` a player, then have them `/invite <you>` from another zone: no popup arrives, they see a normal decline. Confirm a different (unblocked) player can still invite you immediately (no stuck pending state).
- Blocked player sends a guild invite: refused. Unblock and retry: works.
- Repeat with trade and duel requests from a blocked player.
