### PR TITLE
fix(docker): copy editor.html and svelte.config.js into the image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:22-alpine AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --no-audit --no-fund
-COPY .browserslistrc tsconfig.json vite.config.ts index.html admin.html play.html guide.html ./
+COPY .browserslistrc tsconfig.json vite.config.ts svelte.config.js index.html admin.html play.html guide.html editor.html ./
 COPY src ./src
 COPY server ./server
 COPY bot ./bot


### PR DESCRIPTION
## Problem

The v0.20.0 Docker image does not build. The map editor (#1306) added a fifth Vite entry, `editor.html`, but the Dockerfile COPY line still lists only the four older HTML entries, so `npm run build` inside the container fails to resolve the editor input and the build dies at the client build step (the `dist/.vite/manifest.json` ENOENT in the log is a downstream symptom from the i18n modulepreload plugin). Host builds pass because they run from a full checkout; only the Docker context is missing the file.

## Fix

One line: add `editor.html` to the build-stage COPY. Also adds `svelte.config.js` to the same line: a pre-existing gap (the container's admin bundle built with the vite-plugin-svelte default config instead of the repo's). Harmless today because the default matches `vitePreprocess()`, but this keeps the container build identical to the host build.

## Test plan

- [x] `docker build` on release/v0.20.0 head without this fix: fails at `npm run build` (reproduced)
- [x] `docker build` with this fix: green end to end (client build with all five entries, `build:server`, `build:bot`)
- [x] Smoke test of the built image against a blank Postgres 16: server boots, schema applies (including the new `maps`/`guild_events`/`user_assets` tables), `/`, `/api/status`, `/editor`, `/wiki`, `/admin`, `/play.html` all serve 200, unauthenticated map save is rejected with 401