### PR TITLE
fix(ui): mailbox coin inputs select on focus; repaint bags on send/collect

### DIFF
--- a/src/ui/mailbox_window.ts
+++ b/src/ui/mailbox_window.ts
@@ -139,9 +139,16 @@ export class MailboxWindow {
         if (coin) coin.value = '0';
       }
       this.renderParcels();
+      // Escrow left the purse and bags the moment the send resolved: repaint the
+      // bags window now (it rides alongside the Send tab), not on mailbox close.
+      this.deps.syncBags(this.isSendTab);
     }
     if (code === 'collected' || code === 'letterGone' || code === 'takeParcelsFirst') {
       this.lastSig = '';
+    }
+    if (code === 'collected') {
+      // Coin and parcels just landed in the purse and bags: repaint if open.
+      this.deps.syncBags(false);
     }
   }
 
@@ -375,6 +382,17 @@ export class MailboxWindow {
     this.renderParcels();
     // Bags ride alongside so parcels can be clicked straight onto the letter.
     this.deps.syncBags(true);
+    // The coin inputs seed "0": select it on focus so typing replaces the value
+    // (clicking into gold and typing 1 must mean 1g, not the 10 you get by
+    // appending). The once-only mouseup swallow keeps the click-to-focus gesture
+    // from collapsing the selection again; a second click still places the caret.
+    for (const id of ['mail-g', 'mail-s', 'mail-c']) {
+      const coin = body.querySelector<HTMLInputElement>(`#${id}`);
+      coin?.addEventListener('focus', () => {
+        coin.select();
+        coin.addEventListener('mouseup', (e) => e.preventDefault(), { once: true });
+      });
+    }
     body.querySelector('#mail-send-btn')?.addEventListener('click', () => {
       const root = this.deps.root();
       const read = (id: string) =>

--- a/tests/mailbox_window.test.ts
+++ b/tests/mailbox_window.test.ts
@@ -1,0 +1,49 @@
+// Source-level guards for the Ravenpost mailbox painter (the bags_window.test.ts
+// shape): the pure inbox/send decisions are unit-tested in mailbox_view.test.ts; here
+// we pin the two send-tab contracts that live in painter glue and broke in play:
+// the coin inputs select their contents on focus (typing "1" must mean 1g, not the
+// "10" you get by appending to the seeded 0), and a send/collect outcome repaints
+// the bags window immediately (the inventory cluster must not show stale gold or
+// items while the mailbox stays open).
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const painter = readFileSync(new URL('../src/ui/mailbox_window.ts', import.meta.url), 'utf8');
+const onMailResult = painter.slice(
+  painter.indexOf('onMailResult('),
+  painter.indexOf('refreshIfChanged('),
+);
+
+describe('mailbox_window: coin inputs select their value on focus', () => {
+  it('wires a focus listener that selects the whole input', () => {
+    expect(painter).toMatch(/addEventListener\('focus',[\s\S]{0,160}\.select\(\)/);
+  });
+
+  it('swallows the mouseup that follows a click-to-focus (once), so the selection survives', () => {
+    expect(painter).toMatch(/'mouseup',[\s\S]{0,120}preventDefault\(\)[\s\S]{0,120}once: true/);
+  });
+});
+
+describe('mailbox_window: mail outcomes repaint the inventory cluster', () => {
+  it('slices a real onMailResult body to guard against renames', () => {
+    expect(onMailResult.length).toBeGreaterThan(0);
+  });
+
+  it('repaints the bags window when a send lands (escrow left the purse and bags)', () => {
+    const sent = onMailResult.slice(0, onMailResult.indexOf("'collected'"));
+    expect(sent).toContain('syncBags(');
+  });
+
+  it('repaints the bags window when parcels or coin are collected from a letter', () => {
+    const collected = onMailResult.slice(onMailResult.indexOf("'collected'"));
+    expect(collected).toContain('syncBags(');
+  });
+});
+
+describe('mailbox_window: house style', () => {
+  it('uses no em or en dashes (ASCII separators only)', () => {
+    expect(painter.includes('—'), 'em dash found').toBe(false);
+    expect(painter.includes('–'), 'en dash found').toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Two Ravenpost send-tab issues:

1. The g/s/c coin inputs seed `value="0"`, so clicking into the gold field and typing `1` produces `10` (the digit appends to the seeded 0). Easy to send 10g when you meant 1g.
2. After sending (or collecting) mail, the bags window that rides alongside the mailbox keeps showing the pre-send gold and items until the mailbox closes. The server escrow is authoritative and immediate (`mailSendResolved` re-validates fungible stock and copper before deducting, so this was display-only, not a duplication vector), but the stale display looks exactly like a dupe angle and misleads the player.

## Fix

- The three coin inputs select their contents on focus, with a once-only `mouseup` swallow so the click-to-focus gesture does not collapse the selection (a second click still places the caret normally).
- `onMailResult` now repaints the bags window through the existing `syncBags` dep on `sent` and `collected`, matching how the `vendor` / `tradeDone` / `item` event cases already repaint the inventory cluster.

## Test plan

- [x] New `tests/mailbox_window.test.ts` (the `bags_window.test.ts` source-guard shape): focus-select wiring, the mouseup swallow, and the sent/collected repaints. Written first, RED against the unpatched painter, GREEN after.
- [x] `tests/mailbox_view.test.ts`, `tests/mail.test.ts`, `tests/bags_window.test.ts` pass.
- [x] Biome clean on changed files; `tsc --noEmit` clean.