### PR TITLE
feat(server): one online character per account

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -135,7 +135,10 @@ const CHAT_RATE_ERROR_COOLDOWN_SECONDS = 4;
 const CHAT_COOLDOWN_SECONDS = 20;
 const CHAT_RATE_VIOLATIONS_FOR_COOLDOWN = 3;
 const WHO_RESULT_LIMIT = 50;
-const MAX_ACTIVE_SESSIONS_PER_ACCOUNT = 2;
+// One live session per account: Ravenpost mail (v0.20.0) moves coin and goods
+// between an account's characters, so the old allowance of a second online
+// character (self-trade by dual-boxing) is no longer needed. GMs are exempt.
+const MAX_ACTIVE_SESSIONS_PER_ACCOUNT = 1;
 const RESTART_COUNTDOWN_TOTAL_SECONDS = 600;
 const RESTART_COUNTDOWN_STEPS = [
   { atSeconds: 0, text: 'Server restart in 10 minutes.' },

--- a/tests/game_sessions.test.ts
+++ b/tests/game_sessions.test.ts
@@ -199,8 +199,11 @@ describe('GameServer sessions', () => {
         accountCosmetics: cosmetics,
       }),
     );
+    // The second live character rides the GM exemption: the session cap allows
+    // one non-GM character per account, and the account-wide sweep under test
+    // is the same either way.
     const second = expectJoined(
-      server.join(fakeWs(), 11, 102, 'Mechtwo', 'mage', null, false, {
+      server.join(fakeWs(), 11, 102, 'Mechtwo', 'mage', null, true, {
         accountCosmetics: cosmetics,
       }),
     );
@@ -371,15 +374,15 @@ describe('GameServer sessions', () => {
     expect(closePlaySession).toHaveBeenCalledWith(99);
   });
 
-  it('allows two ONLINE characters per account, and lets the account back in once one leaves', async () => {
+  it('allows one ONLINE character per account, and lets the account back in once it leaves', async () => {
     const server = new GameServer();
     const a = expectJoined(server.join(fakeWs(), 20, 201, 'Aone', 'warrior', null));
-    const a2 = expectJoined(server.join(fakeWs(), 20, 202, 'Atwo', 'mage', null));
 
-    expect((server as any).sessionByCharacterId(202)).toBe(a2);
+    expect((server as any).sessionByCharacterId(201)).toBe(a);
 
-    // same account, a third character is rejected while two are online
-    expect(server.join(fakeWs(), 20, 204, 'Athree', 'rogue', null)).toEqual({
+    // same account, a second character is rejected while one is online (Ravenpost
+    // mail moves goods between an account's characters, so dual-boxing is gone)
+    expect(server.join(fakeWs(), 20, 202, 'Atwo', 'mage', null)).toEqual({
       error: 'too many characters on this account are already in the world',
     });
 
@@ -387,19 +390,22 @@ describe('GameServer sessions', () => {
     const b = expectJoined(server.join(fakeWs(), 21, 203, 'Bone', 'priest', null));
     expect((server as any).sessionByCharacterId(203)).toBe(b);
 
-    // once one of the account's online characters leaves, another of its characters may join
+    // once the account's online character leaves, another of its characters may join
     await server.leave(a, 'test');
-    const a3 = expectJoined(server.join(fakeWs(), 20, 204, 'Athree', 'rogue', null));
-    expect((server as any).sessionByCharacterId(204)).toBe(a3);
+    const a2 = expectJoined(server.join(fakeWs(), 20, 202, 'Atwo', 'mage', null));
+    expect((server as any).sessionByCharacterId(202)).toBe(a2);
   });
 
   it('exempts GM characters from the per-account session cap (for supervision)', () => {
     const server = new GameServer();
     expectJoined(server.join(fakeWs(), 30, 301, 'Gmaa', 'warrior', null));
-    expectJoined(server.join(fakeWs(), 30, 302, 'Gmbb', 'warrior', null));
-    // a third character on the same account joins because it is flagged GM
+    // a second character on the same account joins because it is flagged GM
     expectJoined(server.join(fakeWs(), 30, 303, 'Gmcc', 'warrior', null, true));
     expect((server as any).sessionByCharacterId(303)).not.toBeNull();
+    // and the cap still applies to a non-GM sibling
+    expect(server.join(fakeWs(), 30, 302, 'Gmbb', 'warrior', null)).toEqual({
+      error: 'too many characters on this account are already in the world',
+    });
   });
 
   // The per-IP session count backs the hard connection cap (countIpSessions in


### PR DESCRIPTION
## What

Drops `MAX_ACTIVE_SESSIONS_PER_ACCOUNT` from 2 to 1.

## Why

The two-session allowance existed so an account could hand items and coin between its own characters by logging both in at once. With Ravenpost mail shipping in v0.20.0, that transfer has a proper in-game path, so the remaining uses of a second live session are multiboxing and bots. GMs stay exempt for supervision, and accounts still own up to 10 characters; this only limits live sessions.

## Notes

- The join refusal message is unchanged (`too many characters on this account are already in the world`), so no i18n changes.
- The mech-chroma account-sweep test now joins its second live character through the GM exemption; the account-wide sweep it tests is the same either way.

## Test plan

- [x] `tests/game_sessions.test.ts` updated first (RED against limit 2, GREEN after): second same-account character rejected, different account unaffected, account re-admitted after leave, GM exemption still works and the cap still applies to a non-GM sibling.
- [x] Full Vitest suite green (698 files, 7584 tests): nothing else depended on the two-session allowance.
- [x] Biome clean on changed files.