### PR TITLE
fix(shell): keep the site menu bar on the character screens; card layout for wallet and developer sections

### DIFF
--- a/scripts/charselect_desktop_shots.mjs
+++ b/scripts/charselect_desktop_shots.mjs
@@ -1,0 +1,133 @@
+// Desktop character-select chrome shots: registers a throwaway account, creates
+// three characters, lands on the roster, and captures the screen at a wide and
+// a narrow desktop width. Verifies the site menu bar stays visible above the
+// full-screen stage and the $WOC Wallet / Developer cards lay out sanely.
+// Needs the dev server (GAME_URL, default :5173) and the game server on :8787.
+import fs from 'node:fs';
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+fs.mkdirSync('tmp', { recursive: true });
+
+const uniq = Date.now().toString(36).slice(-6);
+const alpha = uniq.replace(/[0-9]/g, (d) => 'abcdefghij'[Number(d)]);
+const USER = `uishot_${uniq}`;
+const CHARS = [
+  { name: `Ashot${alpha}`, cls: 'warrior' },
+  { name: `Bshot${alpha}`, cls: 'mage' },
+  { name: `Cshot${alpha}`, cls: 'druid' },
+];
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  protocolTimeout: 60000,
+  args: ['--window-size=2000,1150', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 2000, height: 1150 },
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 2000, height: 1150 });
+page.on('pageerror', (e) => console.log('PAGEERR', e.message.slice(0, 200)));
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+await sleep(900);
+await page.evaluate(() => document.querySelector('#btn-online')?.click());
+await sleep(500);
+await page.evaluate(
+  (u, p) => {
+    // Register mode: the login form toggles via the Create Account link and
+    // submits through the same #btn-login submit button.
+    document.querySelector('#btn-auth-toggle')?.click();
+    const set = (id, v) => {
+      const el = document.querySelector(id);
+      el.value = v;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    };
+    set('#login-user', u);
+    set('#login-pass', p);
+    set('#login-email', `${u}@example.com`);
+    document.querySelector('#btn-login').click();
+  },
+  USER,
+  'hunter22',
+);
+// Fresh accounts land on the World List first: click through whichever
+// screen shows up until a character screen is visible.
+const deadline = Date.now() + 25000;
+for (;;) {
+  const state = await page.evaluate(() => {
+    const vis = (sel) => {
+      const el = document.querySelector(sel);
+      return !!el && !el.hidden && getComputedStyle(el).display !== 'none';
+    };
+    if (vis('#charselect-panel') || vis('#charcreate-panel')) return 'chars';
+    const row = document.querySelector('#realm-list .realm-row');
+    if (row && vis('#realm-panel')) {
+      row.click();
+      return 'realm-clicked';
+    }
+    return 'waiting';
+  });
+  if (state === 'chars') break;
+  if (state !== 'waiting') console.log(state);
+  if (Date.now() > deadline) throw new Error(`stuck before character screen (${state})`);
+  await sleep(400);
+}
+console.log('registered, on character screen');
+
+for (const c of CHARS) {
+  // Fresh accounts can land on either the roster or the create screen.
+  const onCreate = await page.evaluate(() => {
+    const el = document.querySelector('#charcreate-panel');
+    return !!el && !el.hidden && getComputedStyle(el).display !== 'none';
+  });
+  if (!onCreate) {
+    await page.evaluate(() => document.querySelector('#btn-new-character')?.click());
+    await sleep(400);
+  }
+  await page.evaluate(
+    (name, cls) => {
+      const input = document.querySelector('#new-char-name');
+      input.value = name;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      document.querySelector(`#charcreate-panel .mini-class[data-class="${cls}"]`)?.click();
+      document.querySelector('#btn-create-char')?.click();
+    },
+    c.name,
+    c.cls,
+  );
+  await sleep(900);
+  console.log('created', c.name);
+}
+
+await page.waitForFunction(
+  () => {
+    const el = document.querySelector('#charselect-panel');
+    return !!el && !el.hidden && getComputedStyle(el).display !== 'none';
+  },
+  { timeout: 8000, polling: 200 },
+);
+await sleep(1600); // let the 3D preview settle
+
+const chrome = await page.evaluate(() => {
+  const header = document.querySelector('.homepage-header');
+  const r = header?.getBoundingClientRect();
+  return {
+    headerVisible: !!header && getComputedStyle(header).visibility !== 'hidden',
+    headerRect: r ? { top: r.top, height: r.height } : null,
+    headerZ: header ? getComputedStyle(header).zIndex : null,
+  };
+});
+console.log('site header:', JSON.stringify(chrome));
+
+await page.screenshot({ path: 'tmp/charselect_desktop_wide.png' });
+await page.setViewport({ width: 1100, height: 800 });
+await sleep(700);
+await page.screenshot({ path: 'tmp/charselect_desktop_narrow.png' });
+await page.setViewport({ width: 1500, height: 950 });
+await sleep(700);
+await page.screenshot({ path: 'tmp/charselect_desktop_mid.png' });
+console.log('wrote tmp/charselect_desktop_{wide,narrow,mid}.png');
+await browser.close();

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -2767,19 +2767,42 @@
       text-align: center;
     }
 
-    /* While a full-screen cs-wow panel is up, the landing chrome (sticky nav,
-       footer, SEO hero copy) would bleed through the translucent stage: park
-       it. The online arms keep the touch gate, matching their layout arms. */
+    /* While a full-screen cs-wow panel is up, the landing chrome that has no
+       business on a character screen (footer, SEO hero copy) would bleed
+       through the translucent stage: park it. The ONLINE panels deliberately
+       KEEP the site menu bar (pinned below); only the offline quick-play
+       panel still parks the whole chrome. The online arms keep the touch
+       gate, matching their layout arms. */
     body[data-start-panel="offline-select"] :is(
         .homepage-header,
         .homepage-footer,
         .official-site-copy
       ),
     body:not(.mobile-touch)[data-start-panel="charselect-panel"]
-      :is(.homepage-header, .homepage-footer, .official-site-copy),
+      :is(.homepage-footer, .official-site-copy),
     body:not(.mobile-touch)[data-start-panel="charcreate-panel"]
-      :is(.homepage-header, .homepage-footer, .official-site-copy) {
+      :is(.homepage-footer, .official-site-copy) {
       visibility: hidden;
+    }
+
+    /* The online character screens keep the site menu bar: pin it over the
+       full-screen stage (the panel is fixed at z-index 60) so Play / Wiki /
+       News / Account stay reachable, and reserve its height on the panel
+       with a transparent top border. Absolutely-positioned children anchor
+       to the padding box (inside the border), so the border shifts the
+       cs-head bar, the docked columns, and the corner actions down
+       uniformly without touching any of their offsets. */
+    body:not(.mobile-touch)[data-start-panel="charselect-panel"] .homepage-header,
+    body:not(.mobile-touch)[data-start-panel="charcreate-panel"] .homepage-header {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 70;
+    }
+    body:not(.mobile-touch) :is(#charselect-panel, #charcreate-panel).cs-wow {
+      /* Matches the one-line desktop header height (logo row + its padding). */
+      border-top: 58px solid transparent;
     }
 
     /* The roster: the account chrome (realm / sort / wallet) stays a top bar,
@@ -2816,9 +2839,47 @@
       justify-content: flex-end;
       margin: 0;
     }
+    /* $WOC Wallet and Developer become two matching stacked cards on the
+       account bar: the service name reads as the card's own header, the
+       action row sits under it, and the helper caption anchors the foot,
+       instead of a label floating beside a button row with its caption
+       dangling underneath. Overrides the base .cs-wallet row layout (label
+       beside actions, separator border-top), which the card/mobile layouts
+       keep. */
+    body:not(.mobile-touch) #charselect-panel.cs-wow :is(.cs-wallet-group, .cs-github-group) {
+      flex-direction: column;
+      align-items: stretch;
+      justify-content: flex-start;
+      gap: 7px;
+      margin: 0;
+      padding: 9px 12px 8px;
+      border: 1px solid var(--color-border-default);
+      border-radius: var(--radius-sm);
+      background: rgba(255, 255, 255, 0.03);
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow .cs-wallet-label {
+      font-size: 11px;
+      letter-spacing: 0.8px;
+      text-transform: uppercase;
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow .cs-wallet-main {
+      align-items: flex-start;
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow .cs-wallet-actions {
+      justify-content: flex-start;
+    }
     body:not(.mobile-touch) #charselect-panel.cs-wow .cs-wallet-help {
       max-width: 300px;
       font-size: 10px;
+    }
+    /* Between 900px and 1400px the two cards plus the realm/sort controls
+       would wrap the account bar to a second line and collide with the
+       docked columns below: drop the captions (every action keeps its
+       title/aria text) so the bar stays one line. */
+    @media (max-width: 1399px) {
+      body:not(.mobile-touch) #charselect-panel.cs-wow .cs-wallet-help {
+        display: none;
+      }
     }
     body:not(.mobile-touch) #charselect-panel.cs-wow .cs-list-col {
       position: absolute;


### PR DESCRIPTION
## What

Two desktop character-screen changes (both scoped to the min-width-900 cs-wow block on non-touch bodies; mobile and the card layouts are untouched):

1. **The site menu bar stays visible on the online character screens.** The full-screen roster/create panels previously parked the whole landing chrome, losing Play / High Scores / Wiki / News / Account. They now hide only the footer and SEO copy: the header pins fixed above the stage (z-index 70 over the panel's 60) and the panel reserves its height with a transparent top border, which shifts the account bar, docked columns, and corner actions down uniformly (absolute children anchor to the padding box), so none of their offsets change.

2. **The $WOC Wallet and Developer sections become two matching stacked cards** on the roster's account bar: service name as the card header, the action row under it, the helper caption at the foot, instead of a label floating beside a button row with its caption dangling underneath. Between 900px and 1400px the captions drop (every action keeps its title/aria text) so the bar stays one line and clear of the docked columns.

## Test plan

- [x] New `scripts/charselect_desktop_shots.mjs` (kept for reuse): registers a throwaway account, creates three characters, lands on the roster, asserts the site header is visible (measured 58px at top:0, z-index 70, matching the reserved border), and screenshots 2000/1500/1100 widths. Also verified the two-card layout with the Developer card forced visible (local dev has no GitHub OAuth).
- [x] Full Vitest suite: one unrelated file-scan test timed out under load (three servers running alongside), green in isolation; everything else passed.
- [x] Biome clean on changed files.