### PR TITLE
feat(delves): telegraph the Reedbound Acolyte's vial so the throw animation leads the release

### DIFF
--- a/src/render/characters/visual.ts
+++ b/src/render/characters/visual.ts
@@ -270,6 +270,13 @@ export class CharacterVisual {
   // One-shot triggers (sim events)
   // -------------------------------------------------------------------------
 
+  /** A one-shot (attack/hit/emote) is still playing. The renderer's spellfx
+   *  handler reads this to avoid restarting a windup-started throw animation
+   *  when the projectile releases mid-clip. */
+  get isMidOneShot(): boolean {
+    return this.currentIsOneShot;
+  }
+
   playAttack(): void {
     if (this.deadLock) return;
     const clips = this.def.clips.attack;

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -2808,20 +2808,33 @@ export class Renderer {
   handleEvent(ev: SimEvent): void {
     switch (ev.type) {
       case 'spellfx':
+        if (ev.fx === 'windup') {
+          // A petSpell windup telegraph: start the throw animation NOW; the
+          // projectile for this throw follows petSpell.windup later, timed to
+          // the clip's release pose (the acolyte def's attackTimeScale is
+          // tuned so both meet).
+          this.triggerAttack(ev.sourceId);
+          break;
+        }
         if (ev.fx === 'projectile') this.vfx.projectile(ev.sourceId, ev.targetId, ev.school);
         else if (ev.fx === 'beam') this.vfx.beam(ev.sourceId, ev.targetId, ev.school);
         else if (ev.fx === 'tick') this.vfx.tick(ev.targetId, ev.school);
         else this.vfx.nova(ev.targetId, ev.school);
-        // A mob that hurls an instant bolt (the hostile petSpell path: the
-        // Reedbound Acolyte's Rotwater Vial, the warlock demon's bolt) has no
-        // cast state for the looping cast channel, and the damage event that
-        // animates melee fires on ARRIVAL and only for the physical school:
-        // play the shooter's attack one-shot at launch so the throw reads.
-        // Real casts (castingAbility set) already animate via the cast
+        // A mob that hurls an instant bolt with NO windup (the warlock
+        // demon's bolt) has no cast state for the looping cast channel, and
+        // the damage event that animates melee fires on ARRIVAL and only for
+        // the physical school: play the shooter's attack one-shot at launch
+        // so the throw reads. A windup-telegraphed throw already started its
+        // one-shot above (still mid-flight at the release: skip the
+        // retrigger). Real casts (castingAbility set) animate via the cast
         // channel; players animate through their own cast/swing paths.
         if (ev.fx === 'projectile' || ev.fx === 'beam') {
           const src = this.sim.entities.get(ev.sourceId);
-          if (src && src.kind === 'mob' && !src.castingAbility) this.triggerAttack(ev.sourceId);
+          if (src && src.kind === 'mob' && !src.castingAbility) {
+            const view = this.views.get(ev.sourceId);
+            const vis = view ? this.activeVisual(view) : null;
+            if (!vis?.isMidOneShot) this.triggerAttack(ev.sourceId);
+          }
         }
         break;
       case 'spellfxAt': {

--- a/src/sim/content/delves/mobs.ts
+++ b/src/sim/content/delves/mobs.ts
@@ -186,7 +186,18 @@ export const DELVE_MOBS: Record<string, MobTemplate> = {
     // Ranged attacker: hurls single-target Rotwater Vials from the back of the pack
     // (the hostile-caster petSpell path; updateRangedPetAttack draws a projectile).
     // Matches the PRD MVP "rotwater_vial: ranged damage at target".
-    petSpell: { name: 'Rotwater Vial', school: 'nature', min: 5, max: 8, range: 22, every: 2.6 },
+    // windup 0.85s (17 ticks): the telegraph before the vial leaves the hand,
+    // tuned so the Stone Cantor Cast clip's release pose (1.45s authored, at the
+    // visual def's 1.7x attackTimeScale) lands exactly on the release.
+    petSpell: {
+      name: 'Rotwater Vial',
+      school: 'nature',
+      min: 5,
+      max: 8,
+      range: 22,
+      every: 2.6,
+      windup: 0.85,
+    },
     loot: [{ copper: 9, chance: 1 }],
     scale: 0.95,
     color: 0x5b6b4a,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4293,6 +4293,7 @@ export class Sim {
       max: number;
       range: number;
       every: number;
+      windup?: number;
     },
   ): void {
     const d = dist2d(pet.pos, target.pos);
@@ -4303,33 +4304,63 @@ export class Sim {
     }
     pet.facing = angleTo(pet.pos, target.pos);
     pet.swingTimer -= DT;
-    if (pet.swingTimer > 0) return;
-    this.emit({
-      type: 'spellfx',
-      sourceId: pet.id,
-      targetId: target.id,
-      school: spell.school,
-      fx: 'projectile',
-    });
-    // Pet spells are resisted, not missed (same semantics as player casts).
-    if (isSpellResisted(this.rng, pet.level, target.level)) {
+    // Emit the projectile + resolve the hit (resisted, not missed: the same
+    // semantics as player casts). Shared by the instant path and the windup
+    // release below; the caller owns the swing-timer bookkeeping.
+    const fire = () => {
       this.emit({
-        type: 'damage',
+        type: 'spellfx',
         sourceId: pet.id,
         targetId: target.id,
-        amount: 0,
-        crit: false,
         school: spell.school,
-        ability: spell.name,
-        kind: 'resist',
+        fx: 'projectile',
       });
-      this.enterCombat(pet, target);
-    } else {
-      const dmg = Math.round(
-        this.rng.range(spell.min + pet.level * 0.8, spell.max + pet.level * 1.1),
-      );
-      this.dealDamage(pet, target, Math.max(1, dmg), false, spell.school, spell.name, 'hit');
+      if (isSpellResisted(this.rng, pet.level, target.level)) {
+        this.emit({
+          type: 'damage',
+          sourceId: pet.id,
+          targetId: target.id,
+          amount: 0,
+          crit: false,
+          school: spell.school,
+          ability: spell.name,
+          kind: 'resist',
+        });
+        this.enterCombat(pet, target);
+      } else {
+        const dmg = Math.round(
+          this.rng.range(spell.min + pet.level * 0.8, spell.max + pet.level * 1.1),
+        );
+        this.dealDamage(pet, target, Math.max(1, dmg), false, spell.school, spell.name, 'hit');
+      }
+    };
+    // A committed windup releases when its tick arrives, regardless of the
+    // swing timer (which is already counting the NEXT cycle: the windup eats
+    // into the cadence rather than extending it).
+    if (pet.rangedWindupReleaseTick != null) {
+      if (this.tickCount < pet.rangedWindupReleaseTick) return;
+      pet.rangedWindupReleaseTick = null;
+      fire();
+      return;
     }
+    if (pet.swingTimer > 0) return;
+    const windupTicks = Math.round((spell.windup ?? 0) / DT);
+    if (windupTicks > 0) {
+      // Telegraph first: the renderer starts the throw animation on 'windup'
+      // and the projectile leaves the hand at the release tick, lined up with
+      // the animation's release pose.
+      this.emit({
+        type: 'spellfx',
+        sourceId: pet.id,
+        targetId: target.id,
+        school: spell.school,
+        fx: 'windup',
+      });
+      pet.rangedWindupReleaseTick = this.tickCount + windupTicks;
+      pet.swingTimer = spell.every;
+      return;
+    }
+    fire();
     pet.swingTimer = spell.every;
   }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -987,6 +987,12 @@ export interface MobTemplate {
     max: number;
     range: number;
     every: number;
+    /** Telegraph seconds between the windup spellfx (the renderer starts the
+     *  throw animation on it) and the actual release (projectile + damage).
+     *  Eats into `every`, so the fire-to-fire cadence is unchanged; the
+     *  release is committed once the windup starts. Omitted = release at the
+     *  timer with no telegraph, the original behavior (warlock demon bolts). */
+    windup?: number;
   };
   // On-hit mechanic: chance to silence the victim, locking out spell (non-physical) casts for a duration.
   silence?: { chance: number; duration: number; name: string; school?: string };
@@ -1467,6 +1473,9 @@ export interface Entity {
   targetId: number | null;
   autoAttack: boolean;
   swingTimer: number;
+  /** petSpell windup in flight: sim tick the committed release fires on
+   *  (transient combat state like swingTimer; never persisted or wired). */
+  rangedWindupReleaseTick?: number | null;
   inCombat: boolean;
   combatTimer: number; // time since last combat event
   auras: Aura[];
@@ -1852,13 +1861,16 @@ export type SimEvent = { pid?: number } & (
       crit: boolean;
       ability: string;
     }
-  // visual-only cue for the renderer: spell projectiles, channel beams, dot ticks, aoe novas
+  // visual-only cue for the renderer: spell projectiles, channel beams, dot
+  // ticks, aoe novas, and the ranged-mob windup telegraph ('windup' fires at
+  // the START of a petSpell windup so the throw animation leads the release;
+  // the 'projectile' for the same throw follows petSpell.windup later).
   | {
       type: 'spellfx';
       sourceId: number;
       targetId: number;
       school: string;
-      fx: 'projectile' | 'beam' | 'tick' | 'nova';
+      fx: 'projectile' | 'beam' | 'tick' | 'nova' | 'windup';
     }
   // visual-only cue anchored to a WORLD POINT rather than an entity: a
   // ground-targeted spell's impact (the burst/nova lands where it was aimed, not

--- a/tests/delves.test.ts
+++ b/tests/delves.test.ts
@@ -33,6 +33,7 @@ import { solveLockActions } from '../src/sim/lockpick';
 import { PLAYER_BODY_RADIUS } from '../src/sim/pathfind';
 import { Rng } from '../src/sim/rng';
 import { DELVE_IMPLEMENTED_AFFIXES, Sim } from '../src/sim/sim';
+import { DT } from '../src/sim/types';
 import { terrainHeight } from '../src/sim/world';
 
 function makeSim(cls: 'warrior' | 'warlock' = 'warrior', seed = 42) {
@@ -1646,6 +1647,58 @@ describe('The Drowned Litany (Phase 4 enemy kits)', () => {
     }
     expect(p.hp, 'acolyte should land ranged Rotwater Vials').toBeLessThan(hp0);
     expect(minDist, 'acolyte should hold at range, never melee').toBeGreaterThan(8);
+  });
+
+  it('the Reedbound Acolyte telegraphs its vial: windup event, release exactly windup ticks later, cadence preserved', () => {
+    const sim = makeSim('warrior');
+    enterLitany(sim);
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    const p = sim.player;
+    const acolyte = createMob(990302, MOBS.reedbound_acolyte, 13, {
+      x: p.pos.x,
+      y: 0,
+      z: p.pos.z + 14,
+    });
+    (sim as any).addEntity(acolyte);
+    run.mobIds.push(acolyte.id);
+
+    const spell = MOBS.reedbound_acolyte.petSpell!;
+    expect(spell.windup, 'the vial throw carries a windup for the cast animation').toBeCloseTo(
+      0.85,
+    );
+    const windupTicks = Math.round((spell.windup ?? 0) / DT);
+    const cadenceTicks = Math.round(spell.every / DT);
+
+    // Record the tick of every windup / projectile spellfx the acolyte emits and
+    // every damage event it lands on the player.
+    const windups: number[] = [];
+    const projectiles: number[] = [];
+    const damages: number[] = [];
+    for (let i = 0; i < 20 * 10 && projectiles.length < 2; i++) {
+      // tick() drains and returns this tick's events (sim.events is reset).
+      const evs = sim.tick() as any[];
+      for (const ev of evs) {
+        if (ev.type === 'spellfx' && ev.sourceId === acolyte.id) {
+          if (ev.fx === 'windup') windups.push(i);
+          if (ev.fx === 'projectile') projectiles.push(i);
+        }
+        if (ev.type === 'damage' && ev.sourceId === acolyte.id && ev.targetId === p.id) {
+          damages.push(i);
+        }
+      }
+    }
+
+    expect(windups.length, 'a windup telegraph precedes each vial').toBeGreaterThanOrEqual(2);
+    expect(projectiles.length).toBe(2);
+    // The release (projectile + its damage) lands exactly the windup after the telegraph.
+    expect(projectiles[0] - windups[0]).toBe(windupTicks);
+    expect(projectiles[1] - windups[1]).toBe(windupTicks);
+    expect(damages[0]).toBe(projectiles[0]);
+    // Fire-to-fire cadence stays spell.every (one tick of float wobble on the
+    // swing timer, same as the pre-windup path): the windup eats into the
+    // cycle, it does not extend it to every + windup.
+    expect(projectiles[1] - projectiles[0]).toBeGreaterThanOrEqual(cadenceTicks);
+    expect(projectiles[1] - projectiles[0]).toBeLessThanOrEqual(cadenceTicks + 1);
   });
 });
 


### PR DESCRIPTION
## What

The acolyte's Cast animation used to START at the projectile launch, so the wind-up played while the bolt was already flying. The Cast clip's release pose sits at **1.45s authored time** (frame-stepped in a model viewer), which is **0.85s of real time** at the def's 1.7x attackTimeScale — so the sim now telegraphs the throw and releases at the animation's release pose.

## How

- `petSpell` gains an optional `windup` (seconds). At the attack timer, the sim emits a new `spellfx fx:'windup'` event and commits the release; the projectile + damage fire exactly `windup` later (17 ticks at 0.85s). The windup eats into the cadence: fire-to-fire stays `spell.every`, so sustained damage is unchanged — the first hit of each engagement arrives one windup later, which is now a readable telegraph.
- Omitting `windup` keeps the original instant release: warlock demon bolts are untouched.
- The renderer starts the throw one-shot on 'windup' and skips the launch-time retrigger while that one-shot is still mid-flight (new `isMidOneShot` getter on CharacterVisual). The bolt-launch sound stays on the actual release (the HUD's spellfx audio matches fx variants explicitly).
- The new event variant relays through the existing generic event path with interest scoping: no wire or server change.

## Test plan

- [x] Test-first in `tests/delves.test.ts`: a windup telegraph precedes each vial, the release lands exactly windup ticks after it, damage rides the release tick, and cadence holds at `spell.every` (one tick of float wobble, same as before).
- [x] Live-client instrumentation of `renderer.handleEvent`: windup/projectile alternate cleanly and the release arrives with the SAME Cast one-shot at ~1.2-1.6s clip time (frame-pacing jitter), bracketing the 1.45s release pose; no double-trigger.
- [x] Full Vitest suite green (700 files / 7604 tests) including the parity goldens (untouched: no trace exercises this timing).
- [x] `tsc --noEmit` and Biome clean on changed files.