### PR TITLE
feat(server): the world boss rises at realm boot

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -795,6 +795,9 @@ export class GameServer {
       playerClass: 'warrior',
       noPlayer: true,
       devCommands: process.env.ALLOW_DEV_COMMANDS === '1',
+      // Thunzharr is up as soon as the realm boots; subsequent rises keep the
+      // normal interval cadence (see src/sim/world_boss.ts).
+      worldBossAtBoot: true,
       lockoutNowMs: () => Date.now(),
       // Raid lockouts end at the next 3 AM (the classic daily reset) in this realm's civil
       // time zone, so the whole realm shares one predictable reset (via REALM_RESET_TZ).

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1053,6 +1053,7 @@ export class Sim {
       autoEquip: cfg.autoEquip ?? false,
       playerName: cfg.playerName ?? 'Adventurer',
       devCommands: this.devCommands,
+      worldBossAtBoot: cfg.worldBossAtBoot ?? false,
       lockoutNowMs: cfg.lockoutNowMs ?? (() => Math.floor(this.time * 1000)),
       raidResetMs: cfg.raidResetMs ?? ((nowMs: number) => nowMs + DEFAULT_RAID_LOCKOUT_MS),
       // Carried through so the renderer (which reaches the Sim as IWorld) can read
@@ -1060,6 +1061,11 @@ export class Sim {
       world: cfg.world,
     };
     this.rng = new Rng(cfg.seed);
+    // Live server opt-in (worldBossAtBoot): the first world-boss rise is due
+    // immediately instead of one interval out, so a freshly (re)started realm
+    // has its boss up. Draws no rng here; the spawn itself fires on the first
+    // tick through the normal updateWorldBosses path.
+    if (cfg.worldBossAtBoot) this.worldBossNextAt = WORLD_BOSSES.map(() => 0);
     // S0b seam: the shared SimContext every extracted slice routes through. Built
     // once here (the rng now exists); a live view + bound callbacks, it draws no rng
     // and mutates nothing, so it cannot perturb the construction draws below.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -2059,6 +2059,11 @@ export interface SimConfig {
   noPlayer?: boolean; // multiplayer server: start with an empty world and addPlayer() later
   devCommands?: boolean; // local dev: /dev level|tp|give chat cheats
   lockoutNowMs?: () => number; // host wall-clock for persisted raid lockouts
+  // Live server: schedule the first world-boss rise at boot instead of one
+  // interval out, so a freshly (re)started realm has Thunzharr up immediately.
+  // Offline worlds and parity traces keep the default (first rise after one
+  // interval), so this never fires inside a short deterministic scenario.
+  worldBossAtBoot?: boolean;
   // Host-computed next raid-reset instant for a given lockout "now" (epoch ms). The
   // authoritative server uses its realm-local 3 AM daily reset; offline/headless omit
   // this and fall back to a flat 24h day. Keeps the time zone out of the sim core.

--- a/tests/world_boss.test.ts
+++ b/tests/world_boss.test.ts
@@ -78,6 +78,25 @@ describe('world boss scheduler', () => {
     expect((announce as any).entityId).toBeUndefined();
   });
 
+  it('worldBossAtBoot spawns the boss on the first tick (the live server), default waits the interval', () => {
+    // The live server opts in: Thunzharr is up as soon as the realm boots.
+    const atBoot = new Sim({
+      seed: 7,
+      playerClass: 'warrior',
+      autoEquip: true,
+      noPlayer: true,
+      worldBossAtBoot: true,
+    });
+    atBoot.tick();
+    expect(findBoss(atBoot)).toBeDefined();
+    // After the boot spawn, the next rise is still one interval out.
+    expect((atBoot as any).worldBossNextAt[0]).toBeCloseTo(WORLD_BOSS_INTERVAL_SECONDS, 0);
+    // Default (offline worlds, parity traces): nothing spawns at boot.
+    const plain = makeSim();
+    plain.tick();
+    expect(findBoss(plain)).toBeUndefined();
+  });
+
   it('does not spawn a second boss while one is alive', () => {
     const sim = makeSim();
     spawnBossNow(sim);


### PR DESCRIPTION
## What

Thunzharr spawns as soon as the realm boots instead of 3 hours after; the 3-hour cadence between rises is unchanged.

## How

New `SimConfig.worldBossAtBoot` (default false) schedules the first rise at t=0; only the live server (`server/game.ts`) opts in. Offline worlds and parity traces keep the default, so the goldens are byte-identical and no deterministic scenario changes. No rng is drawn at construction; the boot spawn fires through the normal `updateWorldBosses` path on the first tick and advances the schedule exactly like an interval spawn (next rise at boot + 3h).

## Test plan

- [x] Test-first in `tests/world_boss.test.ts` (RED then GREEN): the opt-in sim has the boss up after one tick with the next rise one interval out; the default sim spawns nothing at boot.
- [x] Full suite green locally (703 files / 7,630 tests) including the parity goldens.
- [x] `tsc --noEmit` and Biome clean.