### PR TITLE
feat(content): make T1 epic legs/boots grindable in Thornpeak Heights

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -16,7 +16,7 @@ android {
         applicationId "com.worldofclaudecraft"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10
+        versionCode 11
         versionName "0.20.0"
         buildConfigField "long", "PLAY_INTEGRITY_CLOUD_PROJECT_NUMBER", "${playIntegrityCloudProjectNumber}L"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -308,7 +308,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 9RT4S4TGA3;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -316,7 +316,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.19.0;
+				MARKETING_VERSION = 0.20.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.worldofclaudecraft;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -335,7 +335,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 9RT4S4TGA3;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -343,7 +343,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.19.0;
+				MARKETING_VERSION = 0.20.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.worldofclaudecraft;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "world-of-claudecraft",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "world-of-claudecraft",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/live-updates": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "world-of-claudecraft",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "private": true,
   "license": "MIT",
   "author": "levy-street",

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -155,6 +155,10 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
       { itemId: 'glowing_wax', chance: 0.5, questId: 'q_glowing_wax' },
       { itemId: 'tallow_candle', chance: 0.4 },
       { itemId: 'healing_potion', chance: 0.08 },
+      // A grindable long-shot at the epic T1 mail boots that also drop from the
+      // Ironvein Foreman: a rare per-kill chance so the Deeprock Burrows are a
+      // farmable path to the sabatons, not just the Foreman rare.
+      { itemId: 'deathlord_sabatons', chance: 0.001 },
     ],
     scale: 0.85,
     color: 0x9c7a3c,
@@ -172,7 +176,9 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     elite: true,
     canSwim: true,
     ccImmune: true,
-    respawnMult: 864,
+    // 144 * 25s base = 1 hour, so the epic-mail-boot rare is farmable on a
+    // predictable hourly cadence rather than the old 6-hour wait.
+    respawnMult: 144,
     hpBase: 420,
     hpPerLevel: 70,
     dmgBase: 19,
@@ -483,6 +489,10 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
       { copper: 100, chance: 1 },
       { itemId: 'bone_fragments', chance: 0.6 },
       { itemId: 'runed_bone_shard', chance: 0.7, questId: 'q_nythraxis_restless_dead' },
+      // A grindable long-shot at the epic T1 cloth legs that also drop from
+      // Marrowlord Varkas: a rare per-kill chance so the bonefields are a
+      // farmable path to the legwraps, not just the once-per-respawn rare.
+      { itemId: 'necromancers_legwraps', chance: 0.001 },
     ],
     scale: 1.05,
     color: 0xcacfd2,
@@ -696,7 +706,9 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     elite: true,
     canSwim: true,
     ccImmune: true,
-    respawnMult: 864,
+    // 144 * 25s base = 1 hour, so the epic-cloth-leg rare is farmable on a
+    // predictable hourly cadence rather than the old 6-hour wait.
+    respawnMult: 144,
     hpBase: 480,
     hpPerLevel: 80,
     dmgBase: 22,

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -296,7 +296,9 @@ describe('rare spawn rules', () => {
       });
       if (id === 'mirejaw_the_ravenous' || id === 'sister_nhalia')
         expect(MOBS[id].respawnMult).toBe(648);
-      else expect(MOBS[id].respawnMult).toBe(864);
+      // Ironvein Foreman + Marrowlord Varkas rise hourly (144 * 25s base) so
+      // their epic T1 boots/legs are farmable on a predictable cadence.
+      else expect(MOBS[id].respawnMult).toBe(144);
     }
     expect(MOBS.mogger).toMatchObject({
       rare: true,


### PR DESCRIPTION
## Summary

Makes the two epic Tier-1 pieces in Thornpeak Heights (zone 3) realistically obtainable by more players, without touching item budgets or adding new items.

- **Necromancer's Legwraps** (epic cloth legs): added a 0.1% per-kill drop to **Boneclad Revenant**, the bonefield trash beside Marrowlord Varkas. Varkas still drops them at his existing higher chase rate.
- **Deathlord Sabatons** (epic mail boots): added a 0.1% per-kill drop to **Deeprock Tunneler**, the Deeprock Burrows trash beside the Ironvein Foreman.
- **Marrowlord Varkas** and **Ironvein Foreman** respawn shortened: `respawnMult` 864 to 144 (144 * 25s base = 1 hour), a predictable hourly cadence instead of the old 6-hour wait.

The new drops are plain independent per-entry rolls (no `rollGroup`), so they do not compete with the mobs' existing drops. `chance` is a 0 to 1 fraction, so 0.1% is `0.001`. No new items, so item-budget gates are unaffected; no parity golden trace references these mobs, so the added loot draws do not perturb any recorded rng stream.

## Related issues

N/A (raised in Discord: players want a farmable path to the T1 epics).

## Type of change

- [x] Feature: new functionality (content/balance)
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands: `npx vitest run tests/fixes.test.ts tests/mob_enervate.test.ts tests/mob_stagger.test.ts tests/mob_rally.test.ts tests/mob_stoneskin.test.ts tests/mob_knockback.test.ts` (112 passing).
- Manual steps: updated the rare-respawn assertion in `tests/fixes.test.ts` to the new 1-hour multiplier for the two rares; confirmed no `tests/parity` golden trace references these four mobs (so no rng draw-order change).

## Screenshots / recordings

N/A (no player-visible UI change; data-only balance tuning).

---

## Checklist

### Quality

- [x] Tests pass. Updated `tests/fixes.test.ts` for the changed respawn multipliers.
- [x] Typecheck passes.
- [x] Builds succeed (content data only).

### Cross-platform

- [x] N/A. Sim-core content data; runs identically offline, on the server, and headless.

### Localization (i18n)

- [x] N/A. Reuses existing items (`necromancers_legwraps`, `deathlord_sabatons`) by id; no new player-visible strings.

### Hygiene

- [x] No secrets or `.env`; `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated files hand-edited. Balance numbers live in the content data (`src/sim/content/zone3.ts`), per the "no inline balance numbers" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
