### PR TITLE
fix(content): move Gravewyrm Sanctum entrance off the mountain to (0, 858)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -16,7 +16,7 @@ android {
         applicationId "com.worldofclaudecraft"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10
+        versionCode 11
         versionName "0.20.0"
         buildConfigField "long", "PLAY_INTEGRITY_CLOUD_PROJECT_NUMBER", "${playIntegrityCloudProjectNumber}L"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -308,7 +308,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 9RT4S4TGA3;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -316,7 +316,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.19.0;
+				MARKETING_VERSION = 0.20.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.worldofclaudecraft;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -335,7 +335,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 9RT4S4TGA3;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -343,7 +343,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.19.0;
+				MARKETING_VERSION = 0.20.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.worldofclaudecraft;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "world-of-claudecraft",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "world-of-claudecraft",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/live-updates": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "world-of-claudecraft",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "private": true,
   "license": "MIT",
   "author": "levy-street",

--- a/src/sim/content/dungeons.ts
+++ b/src/sim/content/dungeons.ts
@@ -605,7 +605,7 @@ export const DUNGEON_DEFS: Record<string, DungeonDef> = {
     id: 'gravewyrm_sanctum',
     name: 'Gravewyrm Sanctum',
     index: 2,
-    doorPos: { x: 0, z: 880 }, // sealed gate at the head of the Sanctum Approach
+    doorPos: { x: 0, z: 858 }, // sealed gate in the graveyard, off the Sanctum Approach slope
     entry: { x: 0, z: 4 },
     exitOffset: { x: 0, z: -6 },
     spawns: SANCTUM_SPAWN_LIST,

--- a/tests/social.test.ts
+++ b/tests/social.test.ts
@@ -1174,7 +1174,7 @@ describe('the new dungeons', () => {
     sim.leaveDungeon(a);
     expect(dist2d(ea.pos, { x: 45, y: 0, z: 515 })).toBeLessThan(10);
 
-    teleport(sim, a, 0, 876);
+    teleport(sim, a, 0, 858);
     sim.enterDungeon('gravewyrm_sanctum', a);
     expect(ea.pos.x).toBeGreaterThan(2000); // index-2 band
     const slot2 = sim.instanceSlotAt(ea.pos)!;
@@ -1183,7 +1183,7 @@ describe('the new dungeons', () => {
     expect(korzul).toBeTruthy();
     expect(korzul.level).toBe(20);
     sim.leaveDungeon(a);
-    expect(dist2d(ea.pos, { x: 0, y: 0, z: 880 })).toBeLessThan(10);
+    expect(dist2d(ea.pos, { x: 0, y: 0, z: 858 })).toBeLessThan(10);
   });
 
   it('Velkhar summons add waves at hp thresholds and Korgath enrages below 30%', () => {


### PR DESCRIPTION
## What

The Gravewyrm Sanctum entrance door was at `(0, 880)`, high on the Sanctum Approach slope, so the portal renders floating on the mountainside above the graveyard where players actually stand (see screenshot). This moves the door down into the graveyard at `(0, 858)`.

## How

Single data change: `DUNGEON_DEFS.gravewyrm_sanctum.doorPos` `{ x: 0, z: 880 }` to `{ x: 0, z: 858 }`.

Because the door entity is placed via `groundPos(doorPos)` and `leaveDungeon` returns the player to `groundPos(doorPos.x, doorPos.z - 4)`, this one change fixes both requested behaviors:

- **Entrance**: the portal now sits on the graveyard terrain at `(0, 858)` instead of floating on the mountain.
- **On exit**: leaving the instance now teleports you to `(0, 854)`, just in front of the graveyard portal, instead of back up the mountain. The existing `-4` offset is kept so you don't immediately re-trigger the door's 2.0-unit entry radius on the way out.

The map POI (`map_dungeon_portals.ts`) and the logout-inside-dungeon return path (`sim.ts`) both read `doorPos` directly, so they follow automatically. No renderer or i18n changes needed (no player strings touched). No parity scenario enters or captures this door.

## Test

Updated the exit assertion in `tests/social.test.ts` ("the Sunken Bastion and Gravewyrm Sanctum are enterable with full spawn sets") to expect the new position. Full `social.test.ts` passes (50/50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)