### PR TITLE
feat(ui): school-tinted debuff borders and a clear buff/debuff corner split

### DIFF
--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -879,11 +879,13 @@
     max-width: 320px;
     pointer-events: auto;
   }
-  /* Debuffs sit in their own row beneath the buff row (classic layout). */
+  /* Debuffs sit in their own row well beneath the buff row (classic layout),
+     level with the minimap's lower edge (the mail badge), so a wrapping wall of
+     raid buffs and their duration labels never crowds the debuff row. */
   #debuff-bar {
     position: absolute;
     right: 196px;
-    top: 50px;
+    top: 172px;
     display: flex;
     flex-direction: row-reverse;
     flex-wrap: wrap;
@@ -951,22 +953,22 @@
     border-color: var(--color-debuff);
     border-width: 2px;
   }
-  .buff.debuff[data-school='fire'] {
+  .buff.debuff[data-school="fire"] {
     border-color: var(--color-debuff-fire);
   }
-  .buff.debuff[data-school='frost'] {
+  .buff.debuff[data-school="frost"] {
     border-color: var(--color-debuff-frost);
   }
-  .buff.debuff[data-school='arcane'] {
+  .buff.debuff[data-school="arcane"] {
     border-color: var(--color-debuff-arcane);
   }
-  .buff.debuff[data-school='shadow'] {
+  .buff.debuff[data-school="shadow"] {
     border-color: var(--color-debuff-shadow);
   }
-  .buff.debuff[data-school='nature'] {
+  .buff.debuff[data-school="nature"] {
     border-color: var(--color-debuff-nature);
   }
-  .buff.debuff[data-school='holy'] {
+  .buff.debuff[data-school="holy"] {
     border-color: var(--color-debuff-holy);
   }
   /* The player's own cancelable buffs: right-click to drop, with a hover cue. */

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -945,8 +945,29 @@
     background-position: center;
     background-repeat: no-repeat;
   }
+  /* A debuff reads as harmful at a glance: a thicker border (border-box, so no
+     layout shift) tinted by magic school, WoW-style (physical keeps the base red). */
   .buff.debuff {
     border-color: var(--color-debuff);
+    border-width: 2px;
+  }
+  .buff.debuff[data-school='fire'] {
+    border-color: var(--color-debuff-fire);
+  }
+  .buff.debuff[data-school='frost'] {
+    border-color: var(--color-debuff-frost);
+  }
+  .buff.debuff[data-school='arcane'] {
+    border-color: var(--color-debuff-arcane);
+  }
+  .buff.debuff[data-school='shadow'] {
+    border-color: var(--color-debuff-shadow);
+  }
+  .buff.debuff[data-school='nature'] {
+    border-color: var(--color-debuff-nature);
+  }
+  .buff.debuff[data-school='holy'] {
+    border-color: var(--color-debuff-holy);
   }
   /* The player's own cancelable buffs: right-click to drop, with a hover cue. */
   .buff.cancelable {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -48,6 +48,14 @@
     --color-friendly: #9fdc7f;
     --color-buff: #3a6ea8;
     --color-debuff: #c0392b;
+    /* Per-school debuff border tints (WoW-style poison/magic/curse reads); physical
+       keeps the base --color-debuff red. Driven by the aura node's data-school. */
+    --color-debuff-fire: #e8722a;
+    --color-debuff-frost: #4aa3df;
+    --color-debuff-arcane: #3f8cff;
+    --color-debuff-shadow: #9b59d0;
+    --color-debuff-nature: #35a835;
+    --color-debuff-holy: #d8b56b;
 
     --color-bg-dark: #08080d;
     --color-bg-input: #0a0a0f;

--- a/src/ui/auras_painter.ts
+++ b/src/ui/auras_painter.ts
@@ -38,6 +38,9 @@ const DEBUFF_CLASS = 'debuff';
 // stylesheet draws the affordance (context-menu cursor + hover border); the class is
 // toggled per frame so a recycled node never keeps a stale affordance.
 const CANCELABLE_CLASS = 'cancelable';
+// Carries the debuff's magic school so the stylesheet tints the border per school
+// (WoW-style poison/magic/curse reads); '' on a buff, so no school selector matches.
+const SCHOOL_ATTR = 'data-school';
 const DUR_CLASS = 'dur';
 const STACKS_CLASS = 'stacks';
 const BACKGROUND_IMAGE_PROP = 'background-image';
@@ -204,6 +207,7 @@ export class AurasPainter {
       // The buff/debuff distinction is a structural class (not an inline color); the
       // stylesheet renders it as a border the icon meaning does not depend on.
       this.writers.toggleClass(rec.el, DEBUFF_CLASS, s.isDebuff);
+      this.writers.setAttr(rec.el, SCHOOL_ATTR, s.school);
       this.writers.toggleClass(rec.el, CANCELABLE_CLASS, rec.cancelable);
       this.writers.setText(rec.dur, s.durationText);
       const hasStacks = s.stacksText !== '';

--- a/src/ui/auras_view.ts
+++ b/src/ui/auras_view.ts
@@ -171,6 +171,12 @@ export interface AuraSlotState {
   iconKey: string;
   /** Whether this aura reads as a debuff (drives the `debuff` class, not a color). */
   isDebuff: boolean;
+  /** The debuff's magic school ('' for a buff), driving the WoW-style per-school
+   *  border tint (data-school on the node; the stylesheet maps it to a token).
+   *  PARITY: the wire sends `school` sparsely (server/game.ts omits 'physical');
+   *  the decode default and this fallback are both 'physical', so a debuff tints
+   *  identically under a Sim-shaped and a ClientWorld-mirror aura. */
+  school: string;
   /** The remaining-duration label, or '' when effectively permanent. */
   durationText: string;
   /** The stack-count label, or '' when the aura does not stack past 1. */
@@ -223,6 +229,7 @@ function makeSlotState(): AuraSlotState {
     key: '',
     iconKey: '',
     isDebuff: false,
+    school: '',
     durationText: '',
     stacksText: '',
     name: '',
@@ -259,6 +266,7 @@ export function createAurasView(mode: AuraMode, deps: AurasDeps): AurasView {
         slot.key = a.id;
         slot.iconKey = deps.iconId(a);
         slot.isDebuff = debuff;
+        slot.school = debuff ? (a.school ?? 'physical') : '';
         slot.durationText =
           TOGGLE_KINDS.has(a.kind) || TOGGLE_IDS.has(a.id)
             ? ''

--- a/tests/auras_painter.test.ts
+++ b/tests/auras_painter.test.ts
@@ -148,6 +148,7 @@ function slot(over: Partial<AuraSlotState> & { key: string }): AuraSlotState {
   return {
     iconKey: over.key,
     isDebuff: false,
+    school: '',
     durationText: '',
     stacksText: '',
     name: over.key,
@@ -312,7 +313,14 @@ describe('AurasPainter: keyed pool over the elided writers', () => {
   it('routes EVERY per-frame write through the elided writers', () => {
     painter.paint(
       state([
-        slot({ key: 'a', iconKey: 'ic', isDebuff: true, durationText: '5s', stacksText: '3' }),
+        slot({
+          key: 'a',
+          iconKey: 'ic',
+          isDebuff: true,
+          school: 'nature',
+          durationText: '5s',
+          stacksText: '3',
+        }),
       ]),
     );
     const has = (m: Call['m'], pred: (c: Call) => boolean) =>
@@ -323,6 +331,9 @@ describe('AurasPainter: keyed pool over the elided writers', () => {
     ).toBe(true);
     // debuff via toggleClass (a structural class, not a color).
     expect(has('toggleClass', (c) => c.args[0] === 'debuff' && c.args[1] === true)).toBe(true);
+    // the school border tint via setAttr(data-school), a structural attribute the
+    // stylesheet maps to a --color-debuff-* token.
+    expect(has('setAttr', (c) => c.args[0] === 'data-school' && c.args[1] === 'nature')).toBe(true);
     // duration + stacks via setText.
     expect(has('setText', (c) => c.args[0] === '5s')).toBe(true);
     expect(has('setText', (c) => c.args[0] === '3')).toBe(true);

--- a/tests/auras_view.test.ts
+++ b/tests/auras_view.test.ts
@@ -135,6 +135,19 @@ describe('createAurasView: derivation per mode', () => {
     expect(s.remaining).toBe(4.2);
   });
 
+  it('derives the debuff school for the border tint (physical fallback; buffs carry none)', () => {
+    const state = createAurasView('all', deps()).tick(
+      entity([
+        aura({ id: 'venom', kind: 'dot', school: 'nature' }),
+        // No school on the aura (the wire omits 'physical') -> the physical fallback.
+        aura({ id: 'rend', kind: 'dot' }),
+        // A buff never tints: school stays '' even when the aura carries one.
+        aura({ id: 'might', kind: 'buff_ap', value: 50, school: 'holy' }),
+      ]),
+    );
+    expect(state.slots.slice(0, 3).map((s) => s.school)).toEqual(['nature', 'physical', '']);
+  });
+
   it('appends the INJECTED duration units (so an in-game language switch lands next tick)', () => {
     // The units are a fired dep, not hardcoded letters: a localized host swaps them per language.
     const localized: AurasDeps = {


### PR DESCRIPTION
## What

Two readability changes to the player aura corner (the rows left of the minimap), from playtesting with a full group where stacked buffs made incoming debuffs hard to pick out.

**Debuffs read as harmful at a glance.** A debuff icon border thickens to 2px (border-box, so no layout shift) and tints by the aura magic school, WoW-style: nature green for poisons, shadow purple for curses, fire orange, frost and arcane blues, holy gold; physical (bleeds, stuns) keeps the base debuff red. The pure view core derives the school with a physical fallback that matches the sparse wire encoding (server/game.ts omits physical, online.ts decodes the same default), so a debuff tints identically offline and online. The painter writes it as a data-school attribute through the elided setAttr writer, and the stylesheet maps it to new --color-debuff-* tokens; no hex lands in TS.

**The debuff row drops clear of the buff wall.** It sat at 50px, close enough that buff duration labels brushed its icons once a group stacked a full row of buffs. It now sits at 172px, level with the minimap lower edge (where the mail badge lives), so even a wrapping wall of raid buffs never crowds it. The auras-on-frame variant and the mobile layout keep their own placements, untouched.

## Notes for review

- No behavior or fairness change: debuff visibility and the low-tier debuff-priority cap are untouched; this is purely how the icons read.
- Verified in a real browser (headless, offline priest with a poison, a shadow curse, and a 9-buff wall): borders tint per school at 2px and the debuff row lands level with the mail badge with clear separation.
- New tests: school derivation in the view core (physical fallback, buffs carry none) and the data-school write through the elided writers in the painter suite.

## Testing

tsc, auras view/painter suites, the CSS guards (value validity, corpus, extraction), the HUD perf budget, and the architecture purity scan are green; the pre-push floor (typecheck, guard tests, biome ci on changed files, copy scan) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)