### PR TITLE
fix(shell): account bar no longer covers the roster on character select

### DIFF
--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -2542,9 +2542,19 @@
     }
     /* The online panels' card layout is a grid, and grid-placement on an
        absolutely-positioned child would anchor it to its grid AREA rather
-       than the full-screen panel: flatten to a block. */
-    body:not(.mobile-touch) :is(#charselect-panel, #charcreate-panel).cs-wow {
+       than the full-screen panel: flatten. The create panel stays a block
+       (everything in it docks against the panel). The roster panel is a
+       column flexbox instead: the account bar sits IN FLOW at the top and
+       the stage (.cs-body) takes the rest, so when the wallet / developer
+       cards wrap the bar onto extra lines the docked columns shift down
+       with it. (The bar used to be absolute over hardcoded 150px column
+       offsets, which let a wrapped bar cover the top of the roster.) */
+    body:not(.mobile-touch) #charcreate-panel.cs-wow {
       display: block;
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow {
+      display: flex;
+      flex-direction: column;
     }
     #offline-select.cs-wow .charselect-layout,
     #offline-select.cs-wow .charselect-col-left,
@@ -2562,8 +2572,18 @@
         .skin-picker,
         .cs-form-actions
       ),
-    body:not(.mobile-touch) #charselect-panel.cs-wow :is(.cs-body, .cs-detail-col) {
+    body:not(.mobile-touch) #charselect-panel.cs-wow .cs-detail-col {
       display: contents;
+    }
+    /* The roster's stage region below the account bar: the 3D preview and
+       the two docked columns anchor to THIS box rather than the viewport,
+       so none of them can slide under the bar whatever height it wraps to.
+       Overrides the card layout's display: contents. */
+    body:not(.mobile-touch) #charselect-panel.cs-wow .cs-body {
+      display: block;
+      position: relative;
+      flex: 1 1 auto;
+      min-height: 0;
     }
     #offline-select.cs-wow .auth-title,
     body:not(.mobile-touch) #charcreate-panel.cs-wow .auth-title {
@@ -2805,16 +2825,15 @@
       border-top: 58px solid transparent;
     }
 
-    /* The roster: the account chrome (realm / sort / wallet) stays a top bar,
-       the character list docks right (WoW style) with its actions at its
-       foot, and the selected character's summary docks left. display:flex is
-       restated because the card layout below unwraps .cs-head / .cs-head-row
-       with display:contents. */
+    /* The roster: the account chrome (realm / sort / wallet) is an in-flow
+       top bar (first flex row of the panel column; it grows when its cards
+       wrap and pushes the stage down), the character list docks right (WoW
+       style) with its actions at its foot, and the selected character's
+       summary docks left. display:flex is restated because the card layout
+       below unwraps .cs-head / .cs-head-row with display:contents. The
+       z-index keeps the bar's dropdown menus over the stage columns. */
     body:not(.mobile-touch) #charselect-panel.cs-wow .cs-head {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
+      flex: 0 0 auto;
       z-index: 3;
       display: flex;
       flex-direction: row;
@@ -2872,11 +2891,12 @@
       max-width: 300px;
       font-size: 10px;
     }
-    /* Between 900px and 1400px the two cards plus the realm/sort controls
-       would wrap the account bar to a second line and collide with the
-       docked columns below: drop the captions (every action keeps its
-       title/aria text) so the bar stays one line. */
-    @media (max-width: 1399px) {
+    /* Below 1800px the two cards (verified wallet + linked developer) plus
+       the realm/sort controls no longer fit the account bar on one line
+       with their helper captions, so the bar wraps tall and eats stage
+       height: drop the captions (every action keeps its title/aria text)
+       so the wrapped cards stay short. */
+    @media (max-width: 1799px) {
       body:not(.mobile-touch) #charselect-panel.cs-wow .cs-wallet-help {
         display: none;
       }
@@ -2884,7 +2904,7 @@
     body:not(.mobile-touch) #charselect-panel.cs-wow .cs-list-col {
       position: absolute;
       right: 26px;
-      top: 150px;
+      top: 18px;
       bottom: 96px;
       width: 340px;
       /* The card layout gives the column height:100%; the dock stretches via
@@ -2911,7 +2931,7 @@
     body:not(.mobile-touch) #charselect-panel.cs-wow .class-details-panel {
       position: absolute;
       left: 26px;
-      top: 150px;
+      top: 18px;
       bottom: 96px;
       width: 340px;
       overflow-y: auto;


### PR DESCRIPTION
## Summary

On the new full-screen character select screen the account bar (realm and sort controls plus the $WOC Wallet and Developer cards) was absolutely positioned over the stage, while the roster and class-summary columns were docked at a hardcoded 150px offset. With a verified wallet and a linked GitHub the two cards wrap the bar onto extra lines even at MacBook Pro widths (1512px), and the bar covered the top of the character list (reported: the top profile row hidden behind the Developer card).

## Fix

- The roster panel is now a column flexbox: the account bar sits in normal flow at the top and the stage (.cs-body) becomes a positioned box that takes the remaining height.
- The docked roster and class-summary columns (and the 3D preview) anchor to the stage box instead of the viewport, so however tall the bar wraps, the columns shift down instead of sliding underneath it.
- The wallet and developer helper captions now drop below 1800px instead of 1400px: with both cards present the bar cannot hold them on one line below that width, and dropping them keeps the wrapped cards short (every action keeps its title and aria text).
- The create screen keeps its block layout, and the sub-900px and mobile-touch card layouts are untouched (every changed selector is gated to min-width 900 plus body:not(.mobile-touch) and #charselect-panel).

## Test plan

- [x] Playwright sweep against the real server (logged in as a test account, account bar forced to the reported worst case: verified wallet with full controls plus linked-GitHub developer card, 10 roster rows): 1512x982, 1728x1117, 1440x900, 1280x800, 1024x700, 905x650, 1920x1080, 2560x1440 all pass; asserted roster top and class-summary top sit below the bar and the first roster row is hit-testable (not covered).
- [x] 899x800 (below the 900px breakpoint): classic card layout intact.
- [x] Mobile self-test: iPhone 13 and iPad Pro 11 landscape emulation (mobile-touch body), first roster row reachable; only overlay is the pre-existing dismissible Discord banner.
- [x] Create screen at 1512x982: unchanged, name input reachable.
- [x] World dropdown on the in-flow bar still paints above the docked roster (z-index via flex-item stacking).
- [x] Guard tests: css_corpus, css_value_validity, styles_extraction, per_entry_css_wiring, client_shell (100 tests pass); biome clean on the changed file.