### PR TITLE
fix(market): include legendary in world market rarity filter

### DIFF
--- a/src/sim/market_query.ts
+++ b/src/sim/market_query.ts
@@ -37,7 +37,15 @@ export const MARKET_WEAPON_TYPE_FILTERS = [
   'axe',
   'other',
 ] as const;
-export const MARKET_RARITY_FILTERS = ['all', 'poor', 'common', 'uncommon', 'rare', 'epic'] as const;
+export const MARKET_RARITY_FILTERS = [
+  'all',
+  'poor',
+  'common',
+  'uncommon',
+  'rare',
+  'epic',
+  'legendary',
+] as const;
 
 // Listings per browse page (the count of OTHER sellers' listings shown at a time;
 // the player's own listings are always wired on top for quick reclaim).

--- a/src/ui/market_window.ts
+++ b/src/ui/market_window.ts
@@ -698,6 +698,7 @@ export class MarketWindow {
     if (filter === 'uncommon') return t('itemUi.market.rarityUncommon');
     if (filter === 'rare') return t('itemUi.market.rarityRare');
     if (filter === 'epic') return t('itemUi.market.rarityEpic');
+    if (filter === 'legendary') return t('itemUi.quality.legendary');
     return t('itemUi.market.filterRarityAll');
   }
 

--- a/tests/market_filters.test.ts
+++ b/tests/market_filters.test.ts
@@ -58,7 +58,15 @@ describe('World Market filters', () => {
       'axe',
       'other',
     ]);
-    expect(MARKET_RARITY_FILTERS).toEqual(['all', 'poor', 'common', 'uncommon', 'rare', 'epic']);
+    expect(MARKET_RARITY_FILTERS).toEqual([
+      'all',
+      'poor',
+      'common',
+      'uncommon',
+      'rare',
+      'epic',
+      'legendary',
+    ]);
   });
 
   it('groups wearable armor separately from weapons and consumables', () => {
@@ -98,6 +106,13 @@ describe('World Market filters', () => {
       'keen_dirk',
       'greyjaw_pelt_cloak',
       'elixir_of_the_bear',
+    ]);
+  });
+
+  it('includes legendary items in the shared rarity filter vocabulary', () => {
+    expect(filterIds(['deathless_heartwood', 'kingsbane_last_oath'], { rarity: 'legendary' })).toEqual([
+      'deathless_heartwood',
+      'kingsbane_last_oath',
     ]);
   });
 


### PR DESCRIPTION
## Summary

This PR fixes the World Market rarity filter so it includes the `legendary` tier.

Previously, the filter options stopped at `epic`, which prevented players from explicitly filtering Legendary listings in the Browse tab.

Changes included:
- Added `legendary` to the shared rarity filter vocabulary used by market queries.
- Updated the market rarity label mapping in the UI so the new filter option renders correctly.
- Added test coverage to lock the filter option list and verify legendary-item matching behavior.

## Type of change

- ~~[ ] Feature: new functionality~~
- [x] Bug fix
- ~~[ ] Refactor or performance (no behavior change)~~
- ~~[ ] Documentation~~
- [x] Tests
- ~~[ ] Build, CI, or tooling~~
- ~~[ ] Breaking change (please call it out in the summary)~~

## How was this tested?

- Commands:
  - `npx vitest run tests/market_filters.test.ts`
- Manual steps:
      - Started the game and opened the World Market from the Merchant dialog.
      - Navigated to `Browse` and opened the `Rarity` dropdown.
      - Verified `Legendary` appears as a selectable option.
      - Selected `Legendary` and confirmed filter behavior works in-game.

## Screenshots / recordings
I added 2 dummy items for testing purposes. Not included in the commit

<img width="572" height="653" alt="image" src="https://github.com/user-attachments/assets/e3fb10ba-ee3b-4453-bfc6-cbc52616d336" />
<img width="572" height="653" alt="image" src="https://github.com/user-attachments/assets/7064c8dd-39b2-4556-b156-8508faf2ee56" />


---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [x] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [x] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [x] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- ~~[ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.~~
- ~~[ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).~~
- ~~[ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.~~
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
