### PR TITLE
fix(ui): anchor mail indicator to bottom-right minimap rim so it never stacks on the raid-lockout badge

### DIFF
--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -4133,10 +4133,13 @@
 
   /* ---------- Ravenpost envelope indicator ---------- */
   /* Sits on the minimap disc rim (the raid-lockout button pattern): an envelope
-     glyph with an unread count, visible only while letters wait. */
+     glyph with an unread count, visible only while letters wait. Anchored to the
+     bottom-RIGHT corner because the raid-lockout badge owns bottom-left; each rim
+     satellite must claim its own corner or they stack (guarded by
+     tests/minimap_rim_badges.test.ts). */
   #mail-indicator {
     position: absolute;
-    left: 4px;
+    right: 4px;
     bottom: 4px;
     z-index: 3;
     display: inline-flex;

--- a/tests/minimap_rim_badges.test.ts
+++ b/tests/minimap_rim_badges.test.ts
@@ -1,0 +1,46 @@
+// Regression guard for the minimap rim satellites (src/styles/hud.css). The
+// raid-lockout badge and the Ravenpost mail indicator are both absolutely
+// positioned children of #minimap-disc. Both originally anchored to the same
+// corner (left + bottom), so whenever unread mail and the lockout badge were
+// visible at once they stacked on top of each other. Each rim badge must claim
+// exactly one horizontal and one vertical inset, and no two badges may share a
+// corner.
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(new URL('../src/styles/hud.css', import.meta.url), 'utf8').replace(
+  /\r\n/g,
+  '\n',
+);
+
+const RIM_BADGE_SELECTORS = ['#raid-lockout', '#mail-indicator'];
+
+// The base rule for each badge is the bare selector followed by "{" (the
+// pseudo-class, descendant, and [hidden] rules never match that shape), and
+// none of these blocks nest braces.
+function declarationBlock(selector: string): string {
+  const match = css.match(new RegExp(`${selector}\\s*\\{([^}]*)\\}`));
+  if (!match) throw new Error(`missing ${selector} rule in src/styles/hud.css`);
+  return match[1];
+}
+
+function anchoredCorner(selector: string): string {
+  const block = declarationBlock(selector);
+  const anchoredSides = (sides: string[]) =>
+    sides.filter((side) => new RegExp(`(?:^|[\\s;])${side}\\s*:`).test(block));
+  const horizontal = anchoredSides(['left', 'right']);
+  const vertical = anchoredSides(['top', 'bottom']);
+  expect(horizontal, `${selector} must anchor exactly one of left/right`).toHaveLength(1);
+  expect(vertical, `${selector} must anchor exactly one of top/bottom`).toHaveLength(1);
+  return `${horizontal[0]}+${vertical[0]}`;
+}
+
+describe('minimap rim badges', () => {
+  it('anchors each rim badge to a distinct corner of the minimap disc', () => {
+    const corners = RIM_BADGE_SELECTORS.map(anchoredCorner);
+    expect(
+      new Set(corners).size,
+      `rim badges share a corner: ${RIM_BADGE_SELECTORS.map((s, i) => `${s} at ${corners[i]}`).join(', ')}`,
+    ).toBe(corners.length);
+  });
+});


### PR DESCRIPTION
## Summary
- The Ravenpost mail indicator (#mail-indicator) and the raid-lockout badge (#raid-lockout) were both absolutely positioned at the bottom-left corner of #minimap-disc, so whenever unread mail was waiting the two minimap rim satellites rendered stacked on top of each other.
- The mail indicator now anchors to the bottom-right rim corner (right: 4px, bottom: 4px, the mirrored inset), opposite the raid-lockout badge which keeps its classic tracking-button spot at bottom-left. The bottom-center of the ring stays clear for #minimap-clock (min-width 52px spans roughly x 55 to 107 of the 162px disc; the mail pill sits at roughly x 117 to 158).
- Adds tests/minimap_rim_badges.test.ts, a source-scan guard (written first, red on the old CSS): each rim badge must anchor exactly one horizontal and one vertical inset, and no two badges may share a corner.

## Test plan
- [x] npx vitest run tests/minimap_rim_badges.test.ts (red before the CSS change, green after)
- [x] npx vitest run tests/css_corpus.test.ts tests/css_value_validity.test.ts tests/styles_extraction.test.ts
- [x] biome check on the two changed files
- [ ] Desktop self-test: with unread mail and a raid lockout active, both badges visible on opposite rim corners
- [ ] Mobile self-test: same check under the touch layout (no hud.mobile.css overrides exist for either badge, so behavior should match desktop)