### PR TITLE
fix(input): keep the held emote wheel open when its own suspension begins

### DIFF
--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -357,17 +357,22 @@ export class Input {
   setSuspendMovement(on: boolean): void {
     if (this.suspendMovement === on) return;
     this.suspendMovement = on;
-    if (on) {
-      const hadEmoteWheel = this.emoteWheelHeldCodes.size > 0;
-      const hadHeldInput = this.keys.size > 0 || hadEmoteWheel || this.keyJumpUntil > 0;
-      this.keys.clear();
-      this.keyJumpUntil = 0;
-      if (hadEmoteWheel) {
-        this.emoteWheelHeldCodes.clear();
-        this.cb.onEmoteWheel(false);
-      }
-      if (hadHeldInput) this.noteIntent('move');
-    }
+    if (!on) return;
+    // The held-open emote wheel itself counts as a modal (hud.isModalOpen()),
+    // so when its keys are down this suspension almost always IS the wheel. The
+    // stale-input clear below must not run then: it would close the wheel one
+    // frame after the bound key opened it, and drop still-held movement keys
+    // mid-emote. Nothing held is actually stale in that state, because onKeyUp
+    // is never modal-gated and releaseCapture handles focus loss. (Rare corner:
+    // the hud can close the wheel while the key is still physically down, e.g.
+    // Escape or clicking a slice mid-hold; a menu suspension inside that window
+    // also skips the clear, which just restores the pre-clear behavior of held
+    // movement resuming when the menu closes.)
+    if (this.emoteWheelHeldCodes.size > 0) return;
+    const hadHeldInput = this.keys.size > 0 || this.keyJumpUntil > 0;
+    this.keys.clear();
+    this.keyJumpUntil = 0;
+    if (hadHeldInput) this.noteIntent('move');
   }
 
   captureNextKey(cb: (code: string | null) => void): void {

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -748,6 +748,40 @@ describe('Input emote wheel hold', () => {
 
     expect(cb.onEmoteWheel).toHaveBeenLastCalledWith(false);
   });
+
+  it('stays open when its own modal state suspends movement', () => {
+    // Regression (v0.20.0): the open emote wheel counts toward hud.isModalOpen(),
+    // which main.ts feeds into setSuspendMovement every frame. The stale-input
+    // clear then closed the wheel one frame after the bound key opened it, so
+    // the X hotkey wheel flashed and vanished. Held wheel keys are never stale:
+    // onKeyUp is not modal-gated and releaseCapture covers focus loss.
+    const { cb, input, windowListeners } = makeInput();
+
+    windowListeners.get('keydown')!({ code: 'KeyX', repeat: false, preventDefault: vi.fn() });
+    expect(cb.onEmoteWheel).toHaveBeenCalledWith(true);
+
+    input.setSuspendMovement(true); // mirrors the frame loop reacting to the open wheel
+    expect(cb.onEmoteWheel).not.toHaveBeenCalledWith(false); // wheel stays open
+
+    windowListeners.get('keyup')!({ code: 'KeyX', preventDefault: vi.fn() });
+    expect(cb.onEmoteWheel).toHaveBeenCalledWith(false); // release still closes it
+  });
+
+  it('resumes held movement after the wheel closes instead of going stale', () => {
+    // Classic flow: run with W held, flick X to emote, keep running. The
+    // wheel-caused suspension must not clear the still-held movement keys.
+    const { input, windowListeners } = makeInput();
+
+    windowListeners.get('keydown')!({ code: 'KeyW', repeat: false });
+    windowListeners.get('keydown')!({ code: 'KeyX', repeat: false, preventDefault: vi.fn() });
+    input.setSuspendMovement(true); // the open wheel is the modal that suspends
+    expect(input.readMoveInput().forward).toBe(false); // movement frozen while the wheel is up
+
+    windowListeners.get('keyup')!({ code: 'KeyX', preventDefault: vi.fn() });
+    input.setSuspendMovement(false); // wheel closed, modal gone
+
+    expect(input.readMoveInput().forward).toBe(true); // W never went stale
+  });
 });
 
 describe('Input modifier combos', () => {


### PR DESCRIPTION
## Summary

The emote wheel opened by holding the X hotkey stopped appearing after the release/v0.20.0 deploy: it rendered for one frame and vanished.

Root cause: the open emote wheel counts toward hud.isModalOpen() (it always has, so the wheel intentionally freezes movement while held). PR #1396 changed the frame loop from plainly assigning input.suspendMovement to calling setSuspendMovement(), whose false-to-true transition clears stale held input, including emoteWheelHeldCodes plus a forced onEmoteWheel(false). That created a feedback loop: hold X, wheel opens, the wheel itself makes isModalOpen() true, the next frame begins suspension, and the suspension force-closes the wheel the player just opened. The pinned wheel (menu-bar and mobile Emotes button) never populates emoteWheelHeldCodes, which is why only the hotkey path broke.

The fix: skip the stale-input clear when the emote wheel keys are what is holding the modal open. Nothing held is stale in that state: onKeyUp is never modal-gated, and releaseCapture already clears the wheel on focus loss. Menu and intro suspensions still clear stale held keys exactly as #1396 intended (its tests still pass unchanged). This also restores the classic run-W, flick-X-to-emote, keep-running flow, which the clear was silently breaking too.

Known corner (reviewed, accepted): the hud can close the wheel while the key is still physically down (Escape, or clicking a slice mid-hold). A menu suspension inside that brief window also skips the clear, which just restores the pre-#1396 behavior of held movement resuming when the menu closes. Noted in the code comment.

## Test plan

- [x] Two regression tests added to tests/input.test.ts (Input emote wheel hold): both RED on current main, GREEN with the fix (npx vitest run tests/input.test.ts: 56 passed)
- [x] The four PR #1396 stale-input tests pass unchanged (menu suspension still clears held W/Space, autorun latch preserved)
- [x] tests/keybinds.test.ts: 45 passed; npx tsc --noEmit clean; biome ci on changed files clean
- [x] Desktop self-test (real browser, offline flow, headless Chromium via puppeteer): hold X, wheel visible at 700ms and 1.2s into the hold, hidden on release; W+X flow keeps W alive after the wheel closes; rapid X taps end hidden; Escape menu still suspends movement and still drops stale held W (#1396 behavior intact)
- [x] Differential run: same browser harness against pre-fix input.ts fails exactly on the regression (wheel gone mid-hold, W stale after wheel close), passes with the fix
- [x] Mobile self-test (844x390 touch viewport): pinned wheel opens from the More tray Emotes button, survives later frames, closes on second tap

Fixes the v0.20.0 emote wheel hotkey regression introduced by #1396.