### PR TITLE
fix(delves): recover stranded Drowned Reliquary loot on interact

### DIFF
--- a/src/sim/delves/drowned_litany_rite.ts
+++ b/src/sim/delves/drowned_litany_rite.ts
@@ -17,7 +17,7 @@ import {
   type RiteShrineKind,
 } from '../types';
 import { RITE_INTENSITY } from './rite_tuning';
-import { grantDelveRewards, openDelveSurfaceExit } from './runs';
+import { collectDelveChestLoot, grantDelveRewards, openDelveSurfaceExit } from './runs';
 
 const RITE_PLAYBACK_STEP = 0.6; // seconds between sequence lights
 const RITE_REPEAT_GAP = 1.2; // longer dark beat between repeat playbacks
@@ -290,7 +290,12 @@ export function interactDrownedLitanyRite(
 
   if (state.kind === 'drowned_reliquary') {
     if (state.looted && state.partyLoot?.[pid]?.length) {
-      return false; // let collectDelveChestLoot handle
+      // The rite completes at a shrine 8yd out, beyond both the loot window's
+      // auto-close radius and the collect gate, so the take-all can never fire
+      // from there. Interacting with the reliquary is the recovery path: collect
+      // this player's own slice directly (it re-checks kind and proximity).
+      collectDelveChestLoot(ctx, objectId, pid);
+      return true;
     }
     if (state.open) {
       ctx.emit({ type: 'log', text: 'The reliquary is empty.', color: '#aaa', pid });

--- a/tests/delves.test.ts
+++ b/tests/delves.test.ts
@@ -2901,6 +2901,45 @@ describe('The Drowned Litany (Phase 7 Drowned Reliquary Rite)', () => {
     expect(state.partyLoot![sim.playerId]!.length).toBe(0);
   });
 
+  it('F-interact at the reliquary collects loot stranded by the distance-gated window', () => {
+    const sim = makeSim('warrior');
+    const run = enterLitanyApse(sim);
+    killNhalia(sim);
+    // Hard flawless guarantees a premium (non-empty) roll, so this isn't seed-flaky.
+    chooseRite(sim, 'hard');
+    waitForRitePlayback(sim, run);
+    // replaySequence completes the rite standing at the FINAL SHRINE, 8yd from the
+    // reliquary: outside both the HUD loot window's 7yd auto-close radius and the
+    // collect gate (DELVE_PLATE_RADIUS + 2). The real player is stuck exactly here.
+    replaySequence(sim, run);
+    const chestId = run.rewardChestId!;
+    const state = run.objectState[chestId];
+    expect(state.partyLoot![sim.playerId]!.length).toBeGreaterThan(0);
+    // The loot window's take-all fires from the shrine and is rejected as too far.
+    sim.drainEvents();
+    sim.collectDelveChestLoot(chestId);
+    const farRefusals = sim.drainEvents().filter((e) => e.type === 'error');
+    expect(farRefusals.some((e) => /move closer/i.test(e.text ?? ''))).toBe(true);
+    expect(state.partyLoot![sim.playerId]!.length).toBeGreaterThan(0); // not granted
+    // Recovery: walk onto the reliquary and press F. Pre-fix this fell through to
+    // "Nothing happens." and the items were stranded in partyLoot forever.
+    const chest = sim.entities.get(chestId)!;
+    sim.player.pos = { ...chest.pos };
+    sim.player.prevPos = { ...chest.pos };
+    sim.delveInteract(chestId);
+    const events = sim.drainEvents();
+    expect(events.some((e) => e.type === 'error' && /nothing happens/i.test(e.text ?? ''))).toBe(
+      false,
+    );
+    expect(events.some((e) => e.type === 'loot' && /you receive/i.test(e.text ?? ''))).toBe(true);
+    expect(state.partyLoot![sim.playerId]!.length).toBe(0);
+    // A second interact reads as an emptied reliquary, not a dead object.
+    sim.delveInteract(chestId);
+    expect(
+      sim.drainEvents().some((e) => e.type === 'log' && /reliquary is empty/i.test(e.text ?? '')),
+    ).toBe(true);
+  });
+
   it('Easy caps loot at low even with a flawless replay', () => {
     const sim = makeSim('warrior');
     const run = enterLitanyApse(sim);


### PR DESCRIPTION
## Summary

Fixes the report that The Drowned Litany (second delve) drops no loot. The item loot was always rolled correctly; it just could never reach the player.

Root cause, three interacting pieces:

1. The rite completes while the player stands at the final shrine, which sits exactly 8yd from the reliquary (riteSiteLocalOffsets places the shrines in a diamond at 8yd).
2. The loot window that opens on the delveChestLoot event auto-closes beyond 7yd (src/ui/hud.ts), and the sim's collect gate is DELVE_PLATE_RADIUS + 2 = 4.5yd, so the take-all either never renders or is refused with Move closer to the chest.
3. Walking to the reliquary and pressing F hit a dead branch in interactDrownedLitanyRite that returned false with the comment let collectDelveChestLoot handle, but nothing on the interact path ever called it: the dispatcher fell through to Nothing happens and the items stayed stranded in state.partyLoot until the run was freed.

Players still received XP, copper, and Delve Marks (granted directly in openDrownedReliquary), which is exactly why the delve read as dropping no loot at all. The Collapsed Reliquary is unaffected because its lockpick flow keeps the player within 4.5yd of the chest when its loot event fires.

## The fix

Interacting with a looted reliquary while you have a pending partyLoot slice now collects that slice directly via the existing collectDelveChestLoot, which re-checks object kind and proximity and grants only the interacting player's own share (no party front-running). One behavior line plus an import; no new player-facing strings, no rng draws, no tick-phase, wire, or IWorld changes, so no parity golden or i18n matcher updates are needed.

## Test plan

- [x] New regression test in tests/delves.test.ts reproducing the full stranded sequence: collect from the final shrine refused as too far, loot still pending, then F at the reliquary collects (no Nothing happens, a You receive loot event, slice cleared), and a second F reads The reliquary is empty
- [x] Full delve suite green (135 tests)
- [x] tests/architecture.test.ts + tests/localization_fixes.test.ts green (sim purity, S3 i18n guard)
- [x] tests/parity golden-trace gate green, rng draw-order digest unchanged
- [x] npx tsc --noEmit clean; biome ci clean on both changed files
- [x] qa-checklist and architecture-reviewer agents: zero blocking findings