### PR TITLE
feat(assets): step-by-step web creation wizard in the live library

### DIFF
--- a/scripts/asset_pipeline/CLAUDE.md
+++ b/scripts/asset_pipeline/CLAUDE.md
@@ -220,6 +220,26 @@ esbuild-bundled to `/three.bundle.js`, `viewer_live.js` is the browser module, a
 `/repo/*` route serves GLBs/atlases from `public/` and `tmp/asset_pipeline/` only (never `.env`
 or `src/`). The server runs until Ctrl-C.
 
+### Web creation wizard (`--serve`, human-in-the-loop)
+The live viewer also hosts a step-by-step asset CREATOR so an operator can generate an asset
+from the browser without the CLI: a "+ Create asset" button (and a "Regenerate this asset"
+button on each generatable asset's detail) opens a modal that walks
+prompt -> model (review, keep or regenerate) -> animations/finish (review) -> save. Each step
+is human-gated: the operator sees the rendered result and only spends more credits on approve.
+Mechanics:
+- `wizard_ui.js` is the browser module (self-contained: injects its button + modal, exposes
+  `window.WizardUI.onDetail(asset)` for the grid's per-asset Regenerate button).
+- `lib/wizard.mjs` is the server action layer: the `/api/wizard/{model,finish,apply}` POST
+  routes each spawn ONE `pipeline.mjs` child (never a second per job), and
+  `/api/wizard/status?job=<id>` reports the step ledger + captured log + preview images the
+  browser polls. It shells out to the SAME CLI, never Tripo directly.
+- The model-review stop is the CLI flag `--until generate`: it runs concept + generate, renders
+  a review shot into the job's `preview_model/` dir, and returns before rigging/normalizing.
+  The wizard drives a DETERMINISTIC job id via `--job <id> --new-job` (`--new-job` lets
+  `Job.open` create that exact id; bare `--job` still requires an existing job so a mistyped
+  CLI id errors instead of forking). Regenerate re-runs a stage with `--redo` (model =
+  `--redo generate`, animations = `--redo retarget`). Save is the lane's normal `--apply`.
+
 ## Utility commands
 - `validate --file x.glb --kind weapon|prop|creature [--family sword] [--height n] [--clips ...]`
 - `preview --file x.glb [--out dir]`: turntable + per-clip PNGs, no API key needed. Preview

--- a/scripts/asset_pipeline/lib/job.mjs
+++ b/scripts/asset_pipeline/lib/job.mjs
@@ -35,10 +35,13 @@ export class Job {
   }
 
   /** Open an existing job or create a new one named after the asset. */
-  static open({ job, kind, name }) {
+  static open({ job, kind, name, create = false }) {
     if (job) {
       const id = slug(job);
-      if (!existsSync(join(JOBS_ROOT, id, 'job.json'))) {
+      // `create` (the web wizard's --new-job) lets a caller pass an EXPLICIT,
+      // deterministic job id and create it if missing; the bare --job path still
+      // requires an existing job so a mistyped CLI id errors instead of forking.
+      if (!create && !existsSync(join(JOBS_ROOT, id, 'job.json'))) {
         throw new Error(`job "${id}" not found under tmp/asset_pipeline/`);
       }
       return new Job(id);

--- a/scripts/asset_pipeline/lib/library.mjs
+++ b/scripts/asset_pipeline/lib/library.mjs
@@ -503,8 +503,10 @@ export async function serveLibrary({ port = 5180 } = {}) {
   const http = await import('node:http');
   const { readFileSync: rf, existsSync: ex, statSync: st } = await import('node:fs');
   const { extname, join: pjoin, normalize: pnorm } = await import('node:path');
+  const wiz = await import('./wizard.mjs');
   const threeBundle = await buildThreeBundle();
   const liveModule = rf(join(REPO_ROOT, 'scripts/asset_pipeline/viewer_live.js'), 'utf8');
+  const wizardModule = rf(join(REPO_ROOT, 'scripts/asset_pipeline/wizard_ui.js'), 'utf8');
 
   // Only these repo subtrees are reachable via /repo/* (never .env, src, etc.).
   const ALLOWED = ['public/', 'tmp/asset_pipeline/'];
@@ -512,16 +514,55 @@ export async function serveLibrary({ port = 5180 } = {}) {
     res.writeHead(code, { 'Content-Type': type, 'Cache-Control': 'no-store' });
     res.end(body);
   };
+  const sendJson = (res, code, obj) => send(res, code, MIME['.json'], JSON.stringify(obj));
+  const readBody = (req) =>
+    new Promise((resolve) => {
+      let data = '';
+      req.on('data', (c) => {
+        data += c;
+        if (data.length > 1e6) req.destroy();
+      });
+      req.on('end', () => {
+        try {
+          resolve(data ? JSON.parse(data) : {});
+        } catch {
+          resolve({});
+        }
+      });
+      req.on('error', () => resolve({}));
+    });
+
+  // The wizard action layer: POST endpoints spawn a pipeline step (the browser
+  // polls status), GET /api/wizard/status reports progress + preview artifacts.
+  async function handleApi(req, res, url) {
+    if (req.method === 'GET' && url === '/api/wizard/status') {
+      const q = new URL(req.url, 'http://x').searchParams;
+      return sendJson(res, 200, wiz.wizardStatus(q.get('job') || ''));
+    }
+    if (req.method !== 'POST') return sendJson(res, 405, { error: 'method not allowed' });
+    const body = await readBody(req);
+    try {
+      if (url === '/api/wizard/model') return sendJson(res, 200, wiz.startModel(body));
+      if (url === '/api/wizard/finish') return sendJson(res, 200, wiz.finishAsset(body));
+      if (url === '/api/wizard/apply') return sendJson(res, 200, wiz.applyAsset(body));
+      return sendJson(res, 404, { error: 'unknown action' });
+    } catch (err) {
+      return sendJson(res, 400, { error: String(err.message ?? err) });
+    }
+  }
 
   const server = http.createServer((req, res) => {
     try {
       const url = decodeURIComponent((req.url || '/').split('?')[0]);
+      if (url.startsWith('/api/')) return void handleApi(req, res, url);
+      if (url === '/wizard_ui.js') return send(res, 200, MIME['.js'], wizardModule);
       if (url === '/' || url === '/index.html') {
         let html = rf(join(LIBRARY_DIR, 'index.html'), 'utf8');
         html = html.replace('window.__LIVE__ = false;', 'window.__LIVE__ = true;');
         html = html.replace(
           '</body>',
-          '<script type="module" src="/viewer_live.js"></script>\n</body>',
+          '<script type="module" src="/viewer_live.js"></script>\n' +
+            '<script type="module" src="/wizard_ui.js"></script>\n</body>',
         );
         return send(res, 200, MIME['.html'], html);
       }

--- a/scripts/asset_pipeline/lib/wizard.mjs
+++ b/scripts/asset_pipeline/lib/wizard.mjs
@@ -1,0 +1,199 @@
+// Web-wizard backend for the live asset library (library --serve). Drives the
+// existing pipeline CLI step by step as a child process, so an operator can
+// generate an asset from scratch in the browser: text -> model (review, keep or
+// regenerate) -> animations/finish (review) -> save. Long Tripo stages run in a
+// detached-ish child while the browser polls status; only ONE child per job runs
+// at a time. Nothing here talks to Tripo directly: it spawns pipeline.mjs with
+// --until / --redo / --apply and reads the job dir the pipeline already writes.
+import { spawn } from 'node:child_process';
+import {
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { REPO_ROOT } from './env.mjs';
+import { JOBS_ROOT } from './job.mjs';
+
+const PIPELINE = join(REPO_ROOT, 'scripts/asset_pipeline/pipeline.mjs');
+const LANES = new Set(['creature', 'weapon', 'prop']);
+
+// In-memory registry of the currently-running child per jobId. A job with no
+// live child is idle (finished, failed, or awaiting the next operator action).
+const running = new Map(); // jobId -> { proc, phase, startedAt }
+
+function safeName(s) {
+  return String(s || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 40);
+}
+
+function jobIdFor(lane, name) {
+  // Mirror Job.open's id shape so status/artifact lookups line up.
+  return `${lane}_${safeName(name)}`;
+}
+
+/** Spawn one pipeline invocation for a job and stream its output to
+ *  <jobdir>/wizard.out. Resolves when the child exits (the caller does not wait
+ *  on it: the HTTP handler returns immediately and the browser polls status). */
+function spawnStep(jobId, args, phase) {
+  if (running.has(jobId)) throw new Error('a step is already running for this asset');
+  const dir = join(JOBS_ROOT, jobId);
+  // The pipeline child creates the job dir, but we open the capture stream first,
+  // so ensure it exists and never let a stream error crash the server.
+  mkdirSync(dir, { recursive: true });
+  const out = createWriteStream(join(dir, 'wizard.out'), { flags: 'a' });
+  out.on('error', () => {});
+  out.write(`\n=== ${phase} :: ${new Date().toISOString()} :: ${args.join(' ')} ===\n`);
+  const proc = spawn(process.execPath, [PIPELINE, ...args], {
+    cwd: REPO_ROOT,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  proc.stdout.pipe(out, { end: false });
+  proc.stderr.pipe(out, { end: false });
+  const entry = { proc, phase, startedAt: Date.now() };
+  running.set(jobId, entry);
+  proc.on('exit', (code) => {
+    out.write(`=== exit ${code} ===\n`);
+    out.end();
+    entry.exitCode = code;
+    running.delete(jobId);
+  });
+  proc.on('error', () => {
+    out.end();
+    running.delete(jobId);
+  });
+  return entry;
+}
+
+/** Start (or restart) generating the model for a new/edited asset. Runs the
+ *  concept + generate stages and stops for review (--until generate). When
+ *  regenerate is true, redoes the generate stage for a fresh candidate. */
+export function startModel({ lane, name, prompt, image, regenerate, jobExists }) {
+  if (!LANES.has(lane)) throw new Error(`unsupported lane: ${lane}`);
+  const key = safeName(name);
+  if (!key) throw new Error('name required');
+  if (!prompt && !image) throw new Error('prompt or image required');
+  const jobId = jobIdFor(lane, key);
+  // Always drive a DETERMINISTIC job id (--job) so status/steps line up; --new-job
+  // lets the pipeline create it on the first model run (it exists on resume/regen).
+  const args = [lane, '--name', key, '--job', jobId, '--new-job', '--until', 'generate'];
+  if (prompt) args.push('--prompt', prompt);
+  if (image) args.push('--image', image);
+  if (regenerate) args.push('--redo', 'generate');
+  spawnStep(jobId, args, regenerate ? 'regenerate-model' : 'model');
+  return { jobId };
+}
+
+/** Run the finishing stages (rig + animations for creatures, normalize + icon
+ *  for weapons/props) and render final previews, stopping before apply so the
+ *  operator reviews the animated/finished asset. regenerateAnimations redoes the
+ *  animation stage only (creatures). */
+export function finishAsset({ lane, jobId, regenerateAnimations }) {
+  if (!existsSync(join(JOBS_ROOT, jobId, 'job.json'))) throw new Error('job not found');
+  const args = [lane, '--job', jobId];
+  const nm = readJob(jobId)?.name;
+  if (nm) args.push('--name', nm);
+  if (regenerateAnimations) {
+    args.push('--redo', lane === 'creature' ? 'retarget' : 'normalize');
+  }
+  spawnStep(jobId, args, regenerateAnimations ? 'regenerate-animations' : 'finish');
+  return { jobId };
+}
+
+/** Integrate the approved asset into the game (copy GLB into public/, credits,
+ *  registry snippet). Runs the lane once more with --apply (idempotent stages
+ *  resume; only the copy/credits run). */
+export function applyAsset({ lane, jobId }) {
+  if (!existsSync(join(JOBS_ROOT, jobId, 'job.json'))) throw new Error('job not found');
+  const args = [lane, '--job', jobId, '--apply'];
+  const nm = readJob(jobId)?.name;
+  if (nm) args.push('--name', nm);
+  spawnStep(jobId, args, 'apply');
+  return { jobId };
+}
+
+function readJob(jobId) {
+  const f = join(JOBS_ROOT, jobId, 'job.json');
+  if (!existsSync(f)) return null;
+  try {
+    return JSON.parse(readFileSync(f, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+// Preview image dirs the wizard surfaces, newest-relevant first. preview_model
+// is the raw-model review shot; preview is the final (animated/finished) set.
+const PREVIEW_DIRS = ['preview', 'preview_model'];
+
+function listPreviews(jobId) {
+  const out = [];
+  for (const sub of PREVIEW_DIRS) {
+    const dir = join(JOBS_ROOT, jobId, sub);
+    if (!existsSync(dir)) continue;
+    for (const f of readdirSync(dir)) {
+      if (/\.(png|webp|jpg)$/i.test(f)) {
+        out.push({
+          group: sub === 'preview' ? 'final' : 'model',
+          name: f.replace(/\.[^.]+$/, ''),
+          url: `/repo/tmp/asset_pipeline/${jobId}/${sub}/${f}`,
+          mtime: statSync(join(dir, f)).mtimeMs,
+        });
+      }
+    }
+  }
+  return out.sort((a, b) => b.mtime - a.mtime);
+}
+
+/** Full wizard status for the browser: whether a child is live, the step
+ *  ledger, the tail of the captured output (for progress + the printed report /
+ *  VisualDef snippet), and the current preview images. */
+export function wizardStatus(jobId) {
+  const id = safeName(jobId);
+  const job = readJob(id);
+  const live = running.get(id);
+  if (!job) {
+    // A child can be mid-first-step before it has written job.json: still report
+    // running + the captured log so the browser shows progress immediately.
+    const outFile = join(JOBS_ROOT, id, 'wizard.out');
+    const boot = existsSync(outFile) ? readFileSync(outFile, 'utf8').slice(-4000) : '';
+    return {
+      jobId: id,
+      exists: !!live,
+      running: !!live,
+      phase: live?.phase ?? null,
+      steps: {},
+      previews: [],
+      log: boot,
+    };
+  }
+  let tail = '';
+  const outFile = join(JOBS_ROOT, id, 'wizard.out');
+  if (existsSync(outFile)) {
+    const buf = readFileSync(outFile, 'utf8');
+    tail = buf.slice(-4000);
+  }
+  return {
+    jobId: id,
+    exists: true,
+    name: job.name ?? null,
+    kind: job.kind ?? null,
+    running: !!live,
+    phase: live?.phase ?? null,
+    steps: Object.fromEntries(Object.entries(job.steps ?? {}).map(([k, v]) => [k, v.status])),
+    validation: job.validation ?? null,
+    previews: listPreviews(id),
+    log: tail,
+  };
+}
+
+export function isLaneSupported(lane) {
+  return LANES.has(lane);
+}

--- a/scripts/asset_pipeline/pipeline.mjs
+++ b/scripts/asset_pipeline/pipeline.mjs
@@ -79,6 +79,30 @@ function flag(name) {
   return argv.includes(`--${name}`);
 }
 
+// Human-in-the-loop stop point: `--until generate` runs the concept + model
+// stages, renders a review preview of the raw model, and returns before rigging
+// / normalizing, so the web wizard (library --serve) can show the model and let
+// the operator approve it or regenerate (--redo generate) before spending more
+// credits. `--until preview` is implicit: a run without --apply already stops
+// after the previews, so the operator reviews the animated/finished asset there.
+const UNTIL = opt('until');
+async function reviewStop(job, step, glbForReview) {
+  if (UNTIL !== step) return false;
+  // Render the RAW model into its own preview_model/ dir (not the canonical
+  // preview/ that the library + final stage own), so the wizard can show the
+  // model-review shots distinctly from the finished/animated previews.
+  if (glbForReview) {
+    await job.step('preview_model', async () => {
+      const files = await renderPreviews(glbForReview, job.path('preview_model'), {
+        views: ['hero', 'front', 'right', 'back'],
+      });
+      return { files };
+    });
+  }
+  printReport(job, { stoppedAt: step, glb: glbForReview ?? null });
+  return true;
+}
+
 function help() {
   const src = readFileSync(new URL(import.meta.url), 'utf8');
   console.log(
@@ -340,7 +364,7 @@ async function cmdWeapon() {
         'sword, dagger, staff, hammer, axe, halberd, spear, scythe, wand (test contract), or pass --family',
     );
   }
-  const job = Job.open({ job: opt('job'), kind: 'weapon', name });
+  const job = Job.open({ job: opt('job'), kind: 'weapon', name, create: flag('new-job') });
   applyRedo(job, 'weapon');
   job.set('kind', 'weapon');
   job.set('name', name);
@@ -378,6 +402,7 @@ async function cmdWeapon() {
       faceLimit: faceLimitOpt(CATEGORY_SPECS.weapon.faceLimit),
     });
   }
+  if (await reviewStop(job, 'generate', gen.raw)) return;
 
   const flip = flag('flip');
   const roll = Number(opt('roll', 0)) || 0;
@@ -457,7 +482,7 @@ async function cmdProp() {
   const name = opt('name');
   const height = Number(opt('height'));
   if (!name || !height) throw new Error('prop needs --name and --height <world units>');
-  const job = Job.open({ job: opt('job'), kind: 'prop', name });
+  const job = Job.open({ job: opt('job'), kind: 'prop', name, create: flag('new-job') });
   applyRedo(job, 'prop');
   job.set('kind', 'prop');
   job.set('name', name);
@@ -474,6 +499,7 @@ async function cmdProp() {
     model: opt('model') === 'hifi' ? tripo.MODEL_HIFI : tripo.MODEL_LOWPOLY,
     faceLimit: faceLimitOpt(CATEGORY_SPECS.prop.faceLimit),
   });
+  if (await reviewStop(job, 'generate', gen.raw)) return;
 
   const built = job.path(`${name}.glb`);
   const rotateY = (Number(opt('rotate-y', 0)) * Math.PI) / 180;
@@ -519,7 +545,7 @@ async function cmdProp() {
 async function cmdCreature() {
   const name = opt('name');
   if (!name) throw new Error('creature needs --name <snake_case>');
-  const job = Job.open({ job: opt('job'), kind: 'creature', name });
+  const job = Job.open({ job: opt('job'), kind: 'creature', name, create: flag('new-job') });
   applyRedo(job, 'creature');
   job.set('kind', 'creature');
   job.set('name', name);
@@ -537,6 +563,7 @@ async function cmdCreature() {
     model: opt('model') === 'hifi' ? tripo.MODEL_HIFI : tripo.MODEL_LOWPOLY,
     faceLimit: faceLimitOpt(CATEGORY_SPECS.creature.faceLimit),
   });
+  if (await reviewStop(job, 'generate', gen.raw)) return;
 
   const rig = await job.step('rig', async () => {
     const prior = await reconnectTask(job, 'rig');
@@ -1241,14 +1268,28 @@ async function cmdLibrary() {
     console.log(
       '  drag to rotate, scroll to zoom, pick animations, toggle "vs player". Ctrl-C to stop.',
     );
-    const { spawn } = await import('node:child_process');
-    spawn('open', [url], { detached: true, stdio: 'ignore' }).unref();
+    await openInBrowser(url);
     return; // the http server keeps the process alive
   }
-  console.log(`open it with: open '${out}'`);
+  console.log(`open it with your browser: ${out}`);
   if (flag('open')) {
-    const { spawn } = await import('node:child_process');
-    spawn('open', [out], { detached: true, stdio: 'ignore' }).unref();
+    await openInBrowser(out);
+  }
+}
+
+// Open a URL/file in the OS browser without ever crashing the caller: the opener
+// binary is platform-specific and may be absent (headless Linux), so a missing
+// command must be swallowed (async 'error' event), not thrown.
+async function openInBrowser(target) {
+  const { spawn } = await import('node:child_process');
+  const cmd =
+    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+  try {
+    const child = spawn(cmd, [target], { detached: true, stdio: 'ignore' });
+    child.on('error', () => {});
+    child.unref();
+  } catch {
+    // no opener available; the URL/path is printed above for manual use
   }
 }
 

--- a/scripts/asset_pipeline/viewer_template.html
+++ b/scripts/asset_pipeline/viewer_template.html
@@ -315,6 +315,7 @@ function openDetail(i) {
   document.getElementById('inspector').innerHTML = inspectorHtml(a);
   document.getElementById('overlay').classList.add('open');
   document.getElementById('inspector').scrollTop = 0;
+  if (window.WizardUI) window.WizardUI.onDetail(a);
 
   if (useLive) {
     big.style.display = 'none';

--- a/scripts/asset_pipeline/wizard_ui.js
+++ b/scripts/asset_pipeline/wizard_ui.js
@@ -1,0 +1,466 @@
+// Web wizard for the live asset library (library --serve). Adds an in-browser,
+// step-by-step asset creator: type a prompt -> generate a 3D model (review it,
+// keep it or regenerate for another candidate) -> generate animations / finish
+// (review) -> save into the game. Existing generatable assets get a Regenerate
+// button that re-enters the same flow, so a human decides when it looks right
+// before saving. Talks only to the /api/wizard/* endpoints (serveLibrary); the
+// actual Tripo work runs server-side in the pipeline CLI.
+//
+// Self-contained: injects its own button + modal + styles, and exposes
+// window.WizardUI.onDetail(asset) so the grid can add the per-asset Regenerate
+// button. No build step, no framework (matches viewer_live.js).
+
+const LANES = [
+  { id: 'creature', label: 'Creature / mob', animated: true },
+  { id: 'weapon', label: 'Weapon', animated: false },
+  { id: 'prop', label: 'Prop', animated: false },
+];
+
+function laneOf(asset) {
+  if (asset?.job?.lane) return asset.job.lane;
+  if (asset?.category === 'creatures' || asset?.kind === 'creature') return 'creature';
+  if (asset?.category === 'weapons') return 'weapon';
+  if (asset?.category === 'props') return 'prop';
+  return null;
+}
+
+// --- tiny DOM helpers --------------------------------------------------------
+function el(tag, attrs = {}, ...kids) {
+  const n = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs)) {
+    if (k === 'class') n.className = v;
+    else if (k === 'html') n.innerHTML = v;
+    else if (k.startsWith('on') && typeof v === 'function') n.addEventListener(k.slice(2), v);
+    else if (v != null) n.setAttribute(k, v);
+  }
+  for (const kid of kids)
+    if (kid != null) n.append(kid.nodeType ? kid : document.createTextNode(kid));
+  return n;
+}
+async function api(path, body) {
+  const res = await fetch(path, {
+    method: body ? 'POST' : 'GET',
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return res.json();
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// --- styles ------------------------------------------------------------------
+const STYLE = `
+.wz-fab { position: fixed; right: 22px; bottom: 22px; z-index: 40; background: var(--gold);
+  color: #14171d; border: none; border-radius: 24px; padding: 11px 18px; font-size: 14px;
+  font-weight: 600; cursor: pointer; box-shadow: 0 4px 14px rgba(0,0,0,0.4); }
+.wz-fab:hover { filter: brightness(1.08); }
+.wz-overlay { position: fixed; inset: 0; z-index: 50; background: rgba(6,8,12,0.72);
+  display: none; align-items: center; justify-content: center; }
+.wz-overlay.open { display: flex; }
+.wz-modal { background: var(--panel); border: 1px solid var(--line); border-radius: 12px;
+  width: min(760px, 94vw); max-height: 92vh; overflow: auto; padding: 18px 20px; }
+.wz-modal h2 { color: var(--gold); font-size: 16px; margin-bottom: 3px; }
+.wz-modal .wz-sub { color: var(--dim); font-size: 12px; margin-bottom: 14px; }
+.wz-steps { display: flex; gap: 8px; margin-bottom: 16px; flex-wrap: wrap; }
+.wz-step { font-size: 11px; color: var(--dim); border: 1px solid var(--line); border-radius: 12px; padding: 3px 9px; }
+.wz-step.on { color: var(--gold); border-color: var(--gold); }
+.wz-step.done { color: var(--green); border-color: var(--green); }
+.wz-field { margin-bottom: 12px; }
+.wz-field label { display: block; font-size: 12px; color: var(--dim); margin-bottom: 4px; }
+.wz-field input, .wz-field textarea, .wz-field select { width: 100%; background: var(--bg);
+  border: 1px solid var(--line); color: var(--text); border-radius: 6px; padding: 8px 10px; font: inherit; }
+.wz-field textarea { min-height: 66px; resize: vertical; }
+.wz-previews { display: flex; gap: 8px; flex-wrap: wrap; margin: 10px 0; }
+.wz-previews img { width: 150px; height: 150px; object-fit: contain; background: #10131a;
+  border: 1px solid var(--line); border-radius: 6px; }
+.wz-actions { display: flex; gap: 10px; margin-top: 16px; flex-wrap: wrap; }
+.wz-btn { border: 1px solid var(--line); background: var(--panel2); color: var(--text);
+  border-radius: 7px; padding: 9px 16px; font: inherit; font-size: 13px; cursor: pointer; }
+.wz-btn:hover { border-color: var(--gold); }
+.wz-btn.primary { background: var(--gold); color: #14171d; border-color: var(--gold); font-weight: 600; }
+.wz-btn.ghost { background: transparent; }
+.wz-btn:disabled { opacity: 0.5; cursor: default; }
+.wz-progress { color: var(--dim); font-size: 12px; margin: 10px 0; white-space: pre-wrap;
+  max-height: 140px; overflow: auto; background: var(--bg); border: 1px solid var(--line);
+  border-radius: 6px; padding: 8px 10px; font-family: ui-monospace, monospace; }
+.wz-note { color: var(--amber); font-size: 12px; margin: 8px 0; }
+.wz-detail-regen { margin-top: 10px; }
+`;
+
+// --- wizard controller -------------------------------------------------------
+class Wizard {
+  constructor() {
+    document.head.append(el('style', { html: STYLE }));
+    this.overlay = el('div', {
+      class: 'wz-overlay',
+      onclick: (e) => {
+        if (e.target === this.overlay) this.close();
+      },
+    });
+    this.modal = el('div', { class: 'wz-modal' });
+    this.overlay.append(this.modal);
+    document.body.append(this.overlay);
+    document.body.append(
+      el('button', { class: 'wz-fab', onclick: () => this.openNew() }, '+ Create asset'),
+    );
+    this.state = null;
+    this.polling = false;
+  }
+
+  open() {
+    this.overlay.classList.add('open');
+  }
+  close() {
+    this.overlay.classList.remove('open');
+    this.polling = false;
+    this.state = null;
+  }
+
+  openNew(preset = {}) {
+    this.state = {
+      mode: preset.jobId ? 'regenerate' : 'new',
+      lane: preset.lane ?? 'creature',
+      name: preset.name ?? '',
+      prompt: preset.prompt ?? '',
+      jobId: preset.jobId ?? null,
+      phase: 'prompt',
+    };
+    this.open();
+    this.renderPrompt();
+  }
+
+  stepsBar(active) {
+    const steps = [
+      'Prompt',
+      'Model',
+      this.state.lane === 'creature' ? 'Animations' : 'Finish',
+      'Save',
+    ];
+    const order = ['prompt', 'model', 'finish', 'save'];
+    const ai = order.indexOf(active);
+    return el(
+      'div',
+      { class: 'wz-steps' },
+      ...steps.map((s, i) =>
+        el('div', { class: 'wz-step' + (i === ai ? ' on' : i < ai ? ' done' : '') }, s),
+      ),
+    );
+  }
+
+  renderPrompt() {
+    const s = this.state;
+    this.modal.innerHTML = '';
+    this.modal.append(
+      el('h2', {}, s.mode === 'regenerate' ? 'Regenerate asset' : 'Create a new asset'),
+      el(
+        'div',
+        { class: 'wz-sub' },
+        'Generate a 3D model from a text description, review each step, keep what you like, and save it into the game.',
+      ),
+      this.stepsBar('prompt'),
+    );
+    const laneSel = el(
+      'select',
+      {},
+      ...LANES.map((l) =>
+        el('option', { value: l.id, ...(l.id === s.lane ? { selected: '' } : {}) }, l.label),
+      ),
+    );
+    const nameIn = el('input', {
+      type: 'text',
+      placeholder: 'snake_case name, e.g. bog_lurker',
+      value: s.name,
+    });
+    const promptIn = el(
+      'textarea',
+      { placeholder: 'chibi swamp lurker, hunched, dripping moss, glowing eyes' },
+      s.prompt,
+    );
+    if (s.mode === 'regenerate') {
+      laneSel.disabled = true;
+      nameIn.disabled = true;
+    }
+    this.modal.append(
+      el('div', { class: 'wz-field' }, el('label', {}, 'Type'), laneSel),
+      el('div', { class: 'wz-field' }, el('label', {}, 'Name'), nameIn),
+      el('div', { class: 'wz-field' }, el('label', {}, 'Description (text prompt)'), promptIn),
+      el(
+        'div',
+        { class: 'wz-note' },
+        'Kaykit chibi style is added automatically. Generating a model spends Tripo credits.',
+      ),
+      el(
+        'div',
+        { class: 'wz-actions' },
+        el('button', { class: 'wz-btn ghost', onclick: () => this.close() }, 'Cancel'),
+        el(
+          'button',
+          {
+            class: 'wz-btn primary',
+            onclick: () => {
+              s.lane = laneSel.value;
+              s.name = nameIn.value.trim();
+              s.prompt = promptIn.value.trim();
+              if (!s.name || !s.prompt) {
+                alert('Name and description are required.');
+                return;
+              }
+              this.startModel(false);
+            },
+          },
+          'Generate model',
+        ),
+      ),
+    );
+  }
+
+  async startModel(regenerate) {
+    const s = this.state;
+    s.phase = 'model';
+    this.renderWorking(
+      'model',
+      regenerate
+        ? 'Generating another model candidate...'
+        : 'Generating the 3D model from your description...',
+    );
+    const r = await api('/api/wizard/model', {
+      lane: s.lane,
+      name: s.name,
+      prompt: s.prompt,
+      regenerate,
+      jobExists: s.mode === 'regenerate' || !!s.jobId,
+    });
+    if (r.error) return this.renderError(r.error, () => this.renderPrompt());
+    s.jobId = r.jobId;
+    this.pollUntilIdle(() => this.renderModelReview());
+  }
+
+  renderModelReview() {
+    const s = this.state;
+    const models = (this._status.previews || []).filter((p) => p.group === 'model');
+    this.modal.innerHTML = '';
+    this.modal.append(
+      el('h2', {}, 'Review the model'),
+      el(
+        'div',
+        { class: 'wz-sub' },
+        'Keep this model, or regenerate for another candidate. Nothing is saved yet.',
+      ),
+      this.stepsBar('model'),
+      this.previewRow(models, 'No preview rendered; check the log.'),
+      this.logBox(),
+      el(
+        'div',
+        { class: 'wz-actions' },
+        el('button', { class: 'wz-btn ghost', onclick: () => this.close() }, 'Cancel'),
+        el('button', { class: 'wz-btn', onclick: () => this.startModel(true) }, 'Regenerate model'),
+        el(
+          'button',
+          { class: 'wz-btn primary', onclick: () => this.startFinish(false) },
+          s.lane === 'creature' ? 'Keep, add animations' : 'Keep, finish',
+        ),
+      ),
+    );
+  }
+
+  async startFinish(regen) {
+    const s = this.state;
+    s.phase = 'finish';
+    this.renderWorking(
+      'finish',
+      s.lane === 'creature'
+        ? regen
+          ? 'Re-rigging and re-generating the animations...'
+          : 'Rigging and generating the animations...'
+        : 'Finishing the model (normalize, icon, previews)...',
+    );
+    const r = await api('/api/wizard/finish', {
+      lane: s.lane,
+      jobId: s.jobId,
+      regenerateAnimations: regen,
+    });
+    if (r.error) return this.renderError(r.error, () => this.renderModelReview());
+    this.pollUntilIdle(() => this.renderFinalReview());
+  }
+
+  renderFinalReview() {
+    const s = this.state;
+    const finals = (this._status.previews || []).filter((p) => p.group === 'final');
+    const val = this._status.validation;
+    this.modal.innerHTML = '';
+    this.modal.append(
+      el('h2', {}, s.lane === 'creature' ? 'Review the animations' : 'Review the finished asset'),
+      el(
+        'div',
+        { class: 'wz-sub' },
+        'Each frame is one animation pose. Approve to save into the game, or regenerate.',
+      ),
+      this.stepsBar('finish'),
+      this.previewRow(finals, 'No final previews yet.'),
+      val && !val.ok
+        ? el(
+            'div',
+            { class: 'wz-note' },
+            'Validation warnings: ' + (val.errors || val.warnings || []).join('; '),
+          )
+        : null,
+      this.logBox(),
+      el(
+        'div',
+        { class: 'wz-actions' },
+        el('button', { class: 'wz-btn ghost', onclick: () => this.close() }, 'Cancel'),
+        s.lane === 'creature'
+          ? el(
+              'button',
+              { class: 'wz-btn', onclick: () => this.startFinish(true) },
+              'Regenerate animations',
+            )
+          : el(
+              'button',
+              { class: 'wz-btn', onclick: () => this.startModel(true) },
+              'Regenerate model',
+            ),
+        el(
+          'button',
+          { class: 'wz-btn primary', onclick: () => this.startApply() },
+          'Approve and save',
+        ),
+      ),
+    );
+  }
+
+  async startApply() {
+    const s = this.state;
+    s.phase = 'save';
+    this.renderWorking(
+      'save',
+      'Saving the asset into the game (copying the model, wiring credits)...',
+    );
+    const r = await api('/api/wizard/apply', { lane: s.lane, jobId: s.jobId });
+    if (r.error) return this.renderError(r.error, () => this.renderFinalReview());
+    this.pollUntilIdle(() => this.renderDone());
+  }
+
+  renderDone() {
+    this.modal.innerHTML = '';
+    this.modal.append(
+      el('h2', {}, 'Saved'),
+      el(
+        'div',
+        { class: 'wz-sub' },
+        'The model was copied into public/models/ and CREDITS.md updated. For creatures, wire the printed VisualDef/MOB_KEYS snippet (in the log) into src/render/characters/manifest.ts.',
+      ),
+      this.stepsBar('save'),
+      this.logBox(true),
+      el(
+        'div',
+        { class: 'wz-actions' },
+        el(
+          'button',
+          {
+            class: 'wz-btn primary',
+            onclick: () => {
+              this.close();
+              location.reload();
+            },
+          },
+          'Done (reload library)',
+        ),
+      ),
+    );
+  }
+
+  // --- shared render bits ----
+  renderWorking(step, msg) {
+    this.modal.innerHTML = '';
+    this.modal.append(
+      el('h2', {}, 'Working...'),
+      el('div', { class: 'wz-sub' }, msg),
+      this.stepsBar(step),
+      this.logBox(),
+    );
+  }
+  renderError(msg, back) {
+    this.modal.innerHTML = '';
+    this.modal.append(
+      el('h2', {}, 'Something went wrong'),
+      el('div', { class: 'wz-note' }, String(msg)),
+      this.logBox(),
+      el(
+        'div',
+        { class: 'wz-actions' },
+        el('button', { class: 'wz-btn ghost', onclick: () => this.close() }, 'Close'),
+        back ? el('button', { class: 'wz-btn', onclick: back }, 'Back') : null,
+      ),
+    );
+  }
+  previewRow(list, empty) {
+    if (!list.length) return el('div', { class: 'wz-sub' }, empty);
+    return el(
+      'div',
+      { class: 'wz-previews' },
+      ...list
+        .slice(0, 10)
+        .map((p) =>
+          el('img', { src: p.url + '?t=' + Math.floor(p.mtime), alt: p.name, title: p.name }),
+        ),
+    );
+  }
+  logBox(open) {
+    const box = el(
+      'div',
+      { class: 'wz-progress' },
+      (this._status?.log || '').trim() || 'starting...',
+    );
+    this._logBox = box;
+    return box;
+  }
+
+  // Poll status until no child is running, refreshing the log box live, then run cb.
+  async pollUntilIdle(cb) {
+    this.polling = true;
+    const jobId = this.state.jobId;
+    for (;;) {
+      if (!this.polling) return;
+      const st = await api('/api/wizard/status?job=' + encodeURIComponent(jobId));
+      this._status = st;
+      if (this._logBox) this._logBox.textContent = (st.log || '').trim() || 'working...';
+      if (!st.running) break;
+      await sleep(1500);
+    }
+    if (this.polling) cb();
+  }
+
+  // Per-asset Regenerate button, injected into the open detail inspector.
+  onDetail(asset) {
+    const lane = laneOf(asset);
+    const inspector = document.getElementById('inspector');
+    if (!inspector || !lane) return;
+    if (inspector.querySelector('.wz-detail-regen')) return;
+    const priorPrompt = asset.job?.prompt || asset.prompt || '';
+    inspector.prepend(
+      el(
+        'div',
+        { class: 'wz-detail-regen' },
+        el(
+          'button',
+          {
+            class: 'wz-btn',
+            onclick: () => {
+              document.getElementById('overlay')?.classList.remove('open');
+              this.openNew({
+                lane,
+                name: asset.name,
+                prompt: priorPrompt,
+                jobId: asset.job?.id || asset.name,
+              });
+            },
+          },
+          'Regenerate this asset',
+        ),
+      ),
+    );
+  }
+}
+
+const wizard = new Wizard();
+window.WizardUI = wizard;


### PR DESCRIPTION
Adds an in-browser, human-in-the-loop asset creator to \`library --serve\`, on top of PR #1405, so an operator can generate an asset from scratch in the browser and decide at each step when it looks right before spending more Tripo credits.

## Flow
\`prompt -> model (review: keep or regenerate) -> animations/finish (review) -> save\`

- **+ Create asset** button opens the wizard; every generatable asset's detail gets a **Regenerate this asset** button that re-enters the same flow.
- The model-review screen shows the rendered candidate from four angles with **Keep / Regenerate**; the animation-review screen shows the animated previews before **Approve and save**.

## How it works
- \`wizard_ui.js\`: self-contained browser module (injects its own button + modal, exposes \`window.WizardUI.onDetail\`).
- \`lib/wizard.mjs\`: server action layer. \`/api/wizard/{model,finish,apply}\` each spawn ONE \`pipeline.mjs\` child per job; \`/api/wizard/status\` reports the step ledger + live log + preview images the browser polls. It shells out to the same tested CLI, never Tripo directly.
- \`pipeline.mjs\`: new \`--until generate\` gate stops after concept+generate and renders a review shot into the job's \`preview_model/\` dir, before rigging/normalizing (creature, weapon, prop). Regenerate re-runs a stage via \`--redo\`; save is the lane's normal \`--apply\`.
- \`job.mjs\`: \`--new-job\` lets the wizard drive a deterministic job id (created on the first model run); bare \`--job\` still requires an existing job so a mistyped CLI id errors instead of forking.
- The \`--serve\` browser-open is now cross-platform (\`xdg-open\` on Linux) and can no longer crash the server on a missing opener.

## Verification
Verified end to end against the real Tripo API: a creature prompt generated a model, the wizard stopped at the model-review step and showed the four rendered angles with Keep / Regenerate. Pipeline unit tests stay green (32/32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)