### PR TITLE
feat(ui): add mailbox recipient autocomplete

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -5245,6 +5245,10 @@
     overflow-y: auto;
     box-shadow: 0 6px 18px #000a;
   }
+  .mail-to-suggest.up {
+    top: auto;
+    bottom: calc(100% + 3px);
+  }
   .mail-coin-row {
     flex-direction: row;
     align-items: center;

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -5225,6 +5225,26 @@
     outline-offset: 1px;
     border-color: var(--color-border-focus);
   }
+  /* Recipient field autocomplete: relative wrapper anchors the listbox below the
+     input. Reuses .soc-sugg-item / .soc-suggest visual tokens from the social panel
+     so no new design-system surface is introduced. */
+  .mail-to-wrap {
+    position: relative;
+  }
+  .mail-to-suggest {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: calc(100% + 3px);
+    display: none;
+    z-index: 30;
+    background: #14110d;
+    border: 1px solid #6f5a2a;
+    border-radius: 5px;
+    max-height: 210px;
+    overflow-y: auto;
+    box-shadow: 0 6px 18px #000a;
+  }
   .mail-coin-row {
     flex-direction: row;
     align-items: center;

--- a/src/ui/mailbox_view.ts
+++ b/src/ui/mailbox_view.ts
@@ -122,3 +122,26 @@ export function mailIndicatorView(unread: number): MailIndicatorView {
   const count = Number.isFinite(unread) ? Math.max(0, Math.floor(unread)) : 0;
   return { visible: count > 0, count };
 }
+
+export interface RecipientSuggestion {
+  name: string;
+  cls: string;
+  level: number;
+}
+
+export function recipientSuggestions(
+  results: RecipientSuggestion[],
+  selfName: string,
+  max: number,
+): RecipientSuggestion[] {
+  const self = selfName.trim();
+  const limit = Math.max(0, Math.floor(max));
+  if (limit === 0) return [];
+  return results.filter((r) => r.name !== self).slice(0, limit);
+}
+
+export function wrappedSuggestionIndex(current: number, delta: number, total: number): number {
+  if (total <= 0) return -1;
+  if (current < 0) return delta > 0 ? 0 : total - 1;
+  return (current + delta + total) % total;
+}

--- a/src/ui/mailbox_window.ts
+++ b/src/ui/mailbox_window.ts
@@ -27,6 +27,8 @@ import {
   type MailSendBody,
   type MailTab,
   mailSendBlocked,
+  recipientSuggestions,
+  wrappedSuggestionIndex,
 } from './mailbox_view';
 import type { PainterHostPresentation } from './painter_host';
 import { svgIcon } from './ui_icons';
@@ -102,6 +104,8 @@ export class MailboxWindow {
 
   close(): void {
     if (!this.opened) return;
+    window.clearTimeout(this.recipientSuggestTimer);
+    this.recipientSuggest = { items: [], index: -1 };
     this.opened = false;
     this.openedId = null;
     this.attachments = [];
@@ -369,6 +373,8 @@ export class MailboxWindow {
   }
 
   private renderSend(body: HTMLElement, view: MailSendBody): void {
+    window.clearTimeout(this.recipientSuggestTimer);
+    this.recipientSuggest = { items: [], index: -1 };
     body.innerHTML =
       `<div class="mail-send-form">` +
       `<div class="mail-field"><label for="mail-to">${esc(t('hudChrome.mailbox.toLabel'))}</label>` +
@@ -452,10 +458,11 @@ export class MailboxWindow {
       }
       this.recipientSuggestTimer = window.setTimeout(async () => {
         const results = await this.deps.world().searchCharacters(q);
-        // Exclude current player; limit to max suggestions.
-        const filtered = results
-          .filter((r) => r.name !== this.deps.world().player.name)
-          .slice(0, RECIPIENT_SUGGEST_MAX);
+        const filtered = recipientSuggestions(
+          results,
+          this.deps.world().player.name,
+          RECIPIENT_SUGGEST_MAX,
+        );
         this.renderRecipientSuggest(body, filtered);
       }, RECIPIENT_SUGGEST_DEBOUNCE_MS);
     });
@@ -517,6 +524,7 @@ export class MailboxWindow {
           `<div id="mail-to-sugg-${i}" class="soc-sugg-item" data-i="${i}" data-name="${esc(r.name)}" role="option" aria-selected="false"><span class="soc-name">${esc(r.name)}</span></div>`,
       )
       .join('');
+    this.placeRecipientSuggest(body, box);
     box.style.display = 'block';
     input?.setAttribute('aria-expanded', 'true');
     input?.removeAttribute('aria-activedescendant');
@@ -536,13 +544,25 @@ export class MailboxWindow {
   private moveRecipientSuggest(body: HTMLElement, delta: number): void {
     const n = this.recipientSuggest.items.length;
     if (n === 0) return;
-    this.recipientSuggest.index =
-      this.recipientSuggest.index < 0
-        ? delta > 0
-          ? 0
-          : n - 1
-        : (this.recipientSuggest.index + delta + n) % n;
+    this.recipientSuggest.index = wrappedSuggestionIndex(this.recipientSuggest.index, delta, n);
     this.highlightRecipientSuggest(body);
+  }
+
+  private placeRecipientSuggest(body: HTMLElement, box: HTMLElement): void {
+    const wrap = body.querySelector<HTMLElement>('.mail-to-wrap');
+    if (!wrap) return;
+    box.classList.remove('up');
+    box.style.maxHeight = '';
+    const bodyRect = body.getBoundingClientRect();
+    const wrapRect = wrap.getBoundingClientRect();
+    const gap = 3;
+    const spaceBelow = Math.floor(bodyRect.bottom - wrapRect.bottom - gap);
+    const spaceAbove = Math.floor(wrapRect.top - bodyRect.top - gap);
+    const openUp = spaceBelow < 110 && spaceAbove > spaceBelow;
+    if (openUp) box.classList.add('up');
+    const available = openUp ? spaceAbove : spaceBelow;
+    const maxHeight = Math.min(210, Math.max(80, available));
+    box.style.maxHeight = `${maxHeight}px`;
   }
 
   private highlightRecipientSuggest(body: HTMLElement): void {

--- a/src/ui/mailbox_window.ts
+++ b/src/ui/mailbox_window.ts
@@ -38,6 +38,12 @@ const COPPER_PER_SILVER = 100;
 // Grace before "no mailInfo" closes the window: online, the mail mirror rides
 // the staggered heavy self refresh, so it can lag the open by up to ~2s.
 const MAIL_INFO_GRACE_MS = 3_000;
+// Recipient autocomplete timings: debounce before querying, delay clear after
+// blur so a pending mousedown on a suggestion can still fire first.
+const RECIPIENT_SUGGEST_DEBOUNCE_MS = 160;
+const RECIPIENT_SUGGEST_BLUR_CLEAR_MS = 150;
+// Maximum number of autocomplete suggestions shown.
+const RECIPIENT_SUGGEST_MAX = 8;
 
 export interface MailboxWindowDeps extends PainterHostPresentation {
   root(): HTMLElement;
@@ -59,6 +65,12 @@ export class MailboxWindow {
   private lastSig = '';
   private openerFocus: HTMLElement | null = null;
   private openedAt = 0;
+  // Recipient autocomplete state (Send tab only).
+  private recipientSuggestTimer: number | undefined;
+  private recipientSuggest: {
+    items: { name: string; cls: string; level: number }[];
+    index: number;
+  } = { items: [], index: -1 };
 
   constructor(private readonly deps: MailboxWindowDeps) {}
 
@@ -360,7 +372,9 @@ export class MailboxWindow {
     body.innerHTML =
       `<div class="mail-send-form">` +
       `<div class="mail-field"><label for="mail-to">${esc(t('hudChrome.mailbox.toLabel'))}</label>` +
-      `<input id="mail-to" type="text" maxlength="32" autocomplete="off" placeholder="${esc(t('hudChrome.mailbox.toPlaceholder'))}"></div>` +
+      `<div class="mail-to-wrap">` +
+      `<div class="mail-to-suggest" id="mail-to-suggest" role="listbox"></div>` +
+      `<input id="mail-to" type="text" maxlength="32" autocomplete="off" placeholder="${esc(t('hudChrome.mailbox.toPlaceholder'))}" role="combobox" aria-autocomplete="list" aria-controls="mail-to-suggest" aria-expanded="false"></div></div>` +
       `<div class="mail-field"><label for="mail-subject">${esc(t('hudChrome.mailbox.subjectLabel'))}</label>` +
       `<input id="mail-subject" type="text" maxlength="64" autocomplete="off"></div>` +
       `<div class="mail-field"><label for="mail-body">${esc(t('hudChrome.mailbox.bodyLabel'))}</label>` +
@@ -393,6 +407,7 @@ export class MailboxWindow {
         coin.addEventListener('mouseup', (e) => e.preventDefault(), { once: true });
       });
     }
+    this.wireRecipientSuggest(body);
     body.querySelector('#mail-send-btn')?.addEventListener('click', () => {
       const root = this.deps.root();
       const read = (id: string) =>
@@ -419,6 +434,132 @@ export class MailboxWindow {
       this.deps.world().mailSend(to, subject, letter, copper, this.attachments);
       audio.click();
     });
+  }
+
+  // Wire the recipient field combobox: debounced searchCharacters, keyboard
+  // navigation (ArrowDown/Up/Enter/Escape), hover highlight, click-to-select,
+  // and blur-with-delay so mousedown on a suggestion fires before the list clears.
+  private wireRecipientSuggest(body: HTMLElement): void {
+    const input = body.querySelector<HTMLInputElement>('#mail-to');
+    if (!input) return;
+
+    input.addEventListener('input', () => {
+      const q = input.value.trim();
+      window.clearTimeout(this.recipientSuggestTimer);
+      if (!q) {
+        this.renderRecipientSuggest(body, []);
+        return;
+      }
+      this.recipientSuggestTimer = window.setTimeout(async () => {
+        const results = await this.deps.world().searchCharacters(q);
+        // Exclude current player; limit to max suggestions.
+        const filtered = results
+          .filter((r) => r.name !== this.deps.world().player.name)
+          .slice(0, RECIPIENT_SUGGEST_MAX);
+        this.renderRecipientSuggest(body, filtered);
+      }, RECIPIENT_SUGGEST_DEBOUNCE_MS);
+    });
+
+    input.addEventListener('keydown', (e) => {
+      const ke = e as KeyboardEvent;
+      const open = this.recipientSuggest.items.length > 0;
+      if (ke.key === 'ArrowDown' && open) {
+        ke.preventDefault();
+        this.moveRecipientSuggest(body, 1);
+      } else if (ke.key === 'ArrowUp' && open) {
+        ke.preventDefault();
+        this.moveRecipientSuggest(body, -1);
+      } else if (ke.key === 'Escape' && open) {
+        ke.preventDefault();
+        this.renderRecipientSuggest(body, []);
+      } else if (ke.key === 'Enter' && open && this.recipientSuggest.index >= 0) {
+        ke.preventDefault();
+        const picked = this.recipientSuggest.items[this.recipientSuggest.index]?.name;
+        if (picked) this.selectRecipient(body, input, picked);
+      }
+    });
+
+    input.addEventListener('blur', () => {
+      window.setTimeout(
+        () => this.renderRecipientSuggest(body, []),
+        RECIPIENT_SUGGEST_BLUR_CLEAR_MS,
+      );
+    });
+  }
+
+  private selectRecipient(
+    body: HTMLElement,
+    input: HTMLInputElement,
+    name: string,
+  ): void {
+    input.value = name;
+    this.renderRecipientSuggest(body, []);
+  }
+
+  private renderRecipientSuggest(
+    body: HTMLElement,
+    results: { name: string; cls: string; level: number }[],
+  ): void {
+    const box = body.querySelector<HTMLElement>('#mail-to-suggest');
+    const input = body.querySelector<HTMLInputElement>('#mail-to');
+    if (!box) return;
+    this.recipientSuggest = { items: results, index: -1 };
+    if (results.length === 0) {
+      box.style.display = 'none';
+      box.innerHTML = '';
+      input?.setAttribute('aria-expanded', 'false');
+      input?.removeAttribute('aria-activedescendant');
+      return;
+    }
+    box.innerHTML = results
+      .map(
+        (r, i) =>
+          `<div id="mail-to-sugg-${i}" class="soc-sugg-item" data-i="${i}" data-name="${esc(r.name)}" role="option" aria-selected="false"><span class="soc-name">${esc(r.name)}</span></div>`,
+      )
+      .join('');
+    box.style.display = 'block';
+    input?.setAttribute('aria-expanded', 'true');
+    input?.removeAttribute('aria-activedescendant');
+    box.querySelectorAll('.soc-sugg-item').forEach((it) => {
+      it.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        const name = (it as HTMLElement).dataset.name ?? '';
+        if (name && input) this.selectRecipient(body, input, name);
+      });
+      it.addEventListener('mousemove', () => {
+        this.recipientSuggest.index = Number((it as HTMLElement).dataset.i);
+        this.highlightRecipientSuggest(body);
+      });
+    });
+  }
+
+  private moveRecipientSuggest(body: HTMLElement, delta: number): void {
+    const n = this.recipientSuggest.items.length;
+    if (n === 0) return;
+    this.recipientSuggest.index =
+      this.recipientSuggest.index < 0
+        ? delta > 0
+          ? 0
+          : n - 1
+        : (this.recipientSuggest.index + delta + n) % n;
+    this.highlightRecipientSuggest(body);
+  }
+
+  private highlightRecipientSuggest(body: HTMLElement): void {
+    const box = body.querySelector<HTMLElement>('#mail-to-suggest');
+    const input = body.querySelector<HTMLInputElement>('#mail-to');
+    if (!box) return;
+    box.querySelectorAll('.soc-sugg-item').forEach((it) => {
+      const on = Number((it as HTMLElement).dataset.i) === this.recipientSuggest.index;
+      it.classList.toggle('active', on);
+      it.setAttribute('aria-selected', on ? 'true' : 'false');
+      if (on) (it as HTMLElement).scrollIntoView({ block: 'nearest' });
+    });
+    if (this.recipientSuggest.index >= 0) {
+      input?.setAttribute('aria-activedescendant', `mail-to-sugg-${this.recipientSuggest.index}`);
+    } else {
+      input?.removeAttribute('aria-activedescendant');
+    }
   }
 
   private renderParcels(): void {

--- a/tests/mailbox_view.test.ts
+++ b/tests/mailbox_view.test.ts
@@ -10,6 +10,8 @@ import {
   mailIndicatorView,
   mailSendBlocked,
   mailSendCost,
+  recipientSuggestions,
+  wrappedSuggestionIndex,
 } from '../src/ui/mailbox_view';
 import type { MailInfo } from '../src/world_api';
 
@@ -141,5 +143,39 @@ describe('mailIndicatorView', () => {
     expect(mailIndicatorView(0)).toEqual({ visible: false, count: 0 });
     expect(mailIndicatorView(3)).toEqual({ visible: true, count: 3 });
     expect(mailIndicatorView(Number.NaN)).toEqual({ visible: false, count: 0 });
+  });
+});
+
+describe('recipientSuggestions', () => {
+  const results = [
+    { name: 'Player', cls: 'warrior', level: 20 },
+    { name: 'Alice', cls: 'mage', level: 18 },
+    { name: 'Bob', cls: 'priest', level: 12 },
+    { name: 'Cara', cls: 'rogue', level: 16 },
+  ];
+
+  it('excludes the current player name and caps results', () => {
+    expect(recipientSuggestions(results, 'Player', 2).map((r) => r.name)).toEqual(['Alice', 'Bob']);
+  });
+
+  it('returns no suggestions when max is zero or negative', () => {
+    expect(recipientSuggestions(results, 'Player', 0)).toEqual([]);
+    expect(recipientSuggestions(results, 'Player', -3)).toEqual([]);
+  });
+});
+
+describe('wrappedSuggestionIndex', () => {
+  it('starts at the first item on down and last item on up from no selection', () => {
+    expect(wrappedSuggestionIndex(-1, 1, 4)).toBe(0);
+    expect(wrappedSuggestionIndex(-1, -1, 4)).toBe(3);
+  });
+
+  it('wraps around in both directions', () => {
+    expect(wrappedSuggestionIndex(3, 1, 4)).toBe(0);
+    expect(wrappedSuggestionIndex(0, -1, 4)).toBe(3);
+  });
+
+  it('returns -1 for an empty list', () => {
+    expect(wrappedSuggestionIndex(0, 1, 0)).toBe(-1);
   });
 });

--- a/tests/mailbox_window.test.ts
+++ b/tests/mailbox_window.test.ts
@@ -62,13 +62,8 @@ describe('mailbox_window: recipient autocomplete wiring', () => {
     expect(painter).toContain('searchCharacters(');
   });
 
-  it('excludes the current player name from suggestions', () => {
-    // The filter uses player.name to exclude self (matches social_window behavior).
-    expect(painter).toMatch(/filter[\s\S]{0,80}player\.name/);
-  });
-
-  it('limits suggestions to RECIPIENT_SUGGEST_MAX results', () => {
-    expect(painter).toContain('RECIPIENT_SUGGEST_MAX');
+  it('routes filtering/limit logic through recipientSuggestions view helper', () => {
+    expect(painter).toContain('recipientSuggestions(');
   });
 
   it('selecting a suggestion writes the name into the recipient input', () => {
@@ -93,13 +88,24 @@ describe('mailbox_window: recipient autocomplete wiring', () => {
     expect(painter).toContain('RECIPIENT_SUGGEST_BLUR_CLEAR_MS');
   });
 
-  it('aria-expanded toggles when suggestions appear or disappear', () => {
-    expect(painter).toContain("'aria-expanded', 'true'");
-    expect(painter).toContain("'aria-expanded', 'false'");
+  it('sets aria-expanded false in the empty-results branch and true in the non-empty branch', () => {
+    expect(painter).toMatch(/results\.length === 0[\s\S]{0,240}'aria-expanded', 'false'/);
+    expect(painter).toMatch(/results\.length === 0[\s\S]{0,900}'aria-expanded', 'true'/);
   });
 
   it('aria-activedescendant is set on the highlighted option', () => {
     expect(painter).toContain('aria-activedescendant');
+  });
+
+  it('resets suggestion model and debounce timer when the send form is rebuilt and on close', () => {
+    expect(painter).toMatch(/renderSend\([\s\S]{0,220}clearTimeout\(this\.recipientSuggestTimer\)/);
+    expect(painter).toMatch(/renderSend\([\s\S]{0,320}this\.recipientSuggest = \{ items: \[], index: -1 \}/);
+    expect(painter).toMatch(/close\([\s\S]{0,220}clearTimeout\(this\.recipientSuggestTimer\)/);
+    expect(painter).toMatch(/close\([\s\S]{0,320}this\.recipientSuggest = \{ items: \[], index: -1 \}/);
+  });
+
+  it('routes keyboard wrap-around through wrappedSuggestionIndex view helper', () => {
+    expect(painter).toContain('wrappedSuggestionIndex(');
   });
 });
 

--- a/tests/mailbox_window.test.ts
+++ b/tests/mailbox_window.test.ts
@@ -41,6 +41,68 @@ describe('mailbox_window: mail outcomes repaint the inventory cluster', () => {
   });
 });
 
+describe('mailbox_window: recipient autocomplete wiring', () => {
+  it('recipient input has role="combobox"', () => {
+    expect(painter).toContain('role="combobox"');
+  });
+
+  it('recipient input has aria-autocomplete="list"', () => {
+    expect(painter).toContain('aria-autocomplete="list"');
+  });
+
+  it('recipient listbox has role="listbox"', () => {
+    expect(painter).toContain('role="listbox"');
+  });
+
+  it('recipient input is wired with aria-controls pointing to the listbox', () => {
+    expect(painter).toContain('aria-controls="mail-to-suggest"');
+  });
+
+  it('calls searchCharacters when building recipient suggestions', () => {
+    expect(painter).toContain('searchCharacters(');
+  });
+
+  it('excludes the current player name from suggestions', () => {
+    // The filter uses player.name to exclude self (matches social_window behavior).
+    expect(painter).toMatch(/filter[\s\S]{0,80}player\.name/);
+  });
+
+  it('limits suggestions to RECIPIENT_SUGGEST_MAX results', () => {
+    expect(painter).toContain('RECIPIENT_SUGGEST_MAX');
+  });
+
+  it('selecting a suggestion writes the name into the recipient input', () => {
+    // selectRecipient sets input.value = name and then clears the list.
+    expect(painter).toMatch(/input\.value\s*=\s*name/);
+  });
+
+  it('ArrowDown moves the suggestion highlight', () => {
+    expect(painter).toContain("'ArrowDown'");
+    expect(painter).toContain('moveRecipientSuggest');
+  });
+
+  it('ArrowUp moves the suggestion highlight', () => {
+    expect(painter).toContain("'ArrowUp'");
+  });
+
+  it('Escape closes the suggestion list', () => {
+    expect(painter).toMatch(/'Escape'[\s\S]{0,120}renderRecipientSuggest/);
+  });
+
+  it('blur clears suggestions after a delay so mousedown can fire first', () => {
+    expect(painter).toContain('RECIPIENT_SUGGEST_BLUR_CLEAR_MS');
+  });
+
+  it('aria-expanded toggles when suggestions appear or disappear', () => {
+    expect(painter).toContain("'aria-expanded', 'true'");
+    expect(painter).toContain("'aria-expanded', 'false'");
+  });
+
+  it('aria-activedescendant is set on the highlighted option', () => {
+    expect(painter).toContain('aria-activedescendant');
+  });
+});
+
 describe('mailbox_window: house style', () => {
   it('uses no em or en dashes (ASCII separators only)', () => {
     expect(painter.includes('\u2014'), 'em dash found').toBe(false);


### PR DESCRIPTION
## Summary

Add recipient name autocomplete to the Ravenpost mailbox

This change adds live character suggestions while typing in the recipient field, with debounce, self-filtering, keyboard and mouse selection, and ARIA combobox/listbox wiring.

Updated areas:
- src/ui/mailbox_window.ts: Send-tab recipient autocomplete logic and interactions
- src/styles/components.css: minimal mailbox-specific suggestion list positioning, reusing social suggestion item style
- tests/mailbox_window.test.ts: source-shape regression coverage for autocomplete wiring and selection behavior

## Type of change

- [x] Feature: new functionality
~~- [ ] Bug fix~~
~~- [ ] Refactor or performance (no behavior change)~~
~~- [ ] Documentation~~
- [x] Tests
~~- [ ] Build, CI, or tooling~~
~~- [ ] Breaking change (please call it out in the summary)~~

## How was this tested?

- Commands:
  - npx vitest run --config vite.config.ts tests/mailbox_window.test.ts
- Manual steps:
  - Started server and client locally.
  - Opened mailbox, switched to Send tab.
  - Typed recipient prefixes and verified live suggestions appear.
  - Verified ArrowDown and ArrowUp move highlight.
  - Verified Enter selects highlighted suggestion and writes name into recipient field.
  - Verified Escape closes suggestions.
  - Verified mouse hover updates highlight and click selects.
  - Verified blur closes suggestions with a short delay, allowing click selection first.
  - Verified existing send flow, coin fields, and parcel staging behavior still work.

## Screenshots / recordings
<img width="462" height="561" alt="charactername-autocomplete" src="https://github.com/user-attachments/assets/b33d47fd-fbff-4eb0-bbb4-bd98e80836e5" />

---

## Checklist

### Quality

- [x] Tests pass. npm test is green. I added or updated tests for any
      sim/ or server/ behavior I changed.
- [x] Typecheck passes. npx tsc --noEmit is clean (the project is
      TypeScript strict).
~~- [ ] Builds succeed. npm run build, plus npm run build:server and
      npm run build:env if I touched those.~~

### Cross-platform

- [x] Tested on desktop and mobile. Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see src/ui/CLAUDE.md).
- [x] Accessible. Keyboard-operable, with visible focus, sensible ARIA, and
      respect for prefers-reduced-motion (only if this change adds or edits UI).

### Localization (i18n)

~~- [ ] New player-visible strings are translated into every supported locale.
      Every user-facing string is a t() key, added to en first, then given a
      real translation in every locale in supportedLanguages
      (src/ui/i18n.ts). No English placeholders or TODO in other locales.~~
~~- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (formatNumber, formatMoney, formatDateTime, Intl).~~
~~- [ ] Player-facing text emitted from src/sim/ or server/ is re-localized at
      the client boundary in this same change, and
      npx vitest run tests/localization_fixes.test.ts passes.~~
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      src/render/assets/manifest.generated.ts. They're regenerated by the build.
