### PR TITLE
feat(world-boss): respawn every hour

### DIFF
--- a/src/sim/world_boss.ts
+++ b/src/sim/world_boss.ts
@@ -22,8 +22,8 @@ import type { Entity, LootSlot } from './types';
 
 // Sim-time cadence: a fresh boss rises this many seconds after the previous one
 // was scheduled. On the live server the sim runs at wall-clock speed (20 Hz), so
-// this is "every 3 hours". Lives here with the system that uses it.
-export const WORLD_BOSS_INTERVAL_SECONDS = 3 * 3600;
+// this is "every hour". Lives here with the system that uses it.
+export const WORLD_BOSS_INTERVAL_SECONDS = 1 * 3600;
 
 // How long a slain world boss's lootable corpse lingers before it is removed. Much
 // longer than a normal corpse so every contributor has time to walk over and loot


### PR DESCRIPTION
## What

Change the world-boss respawn cadence from every 3 hours to **every hour** (`WORLD_BOSS_INTERVAL_SECONDS`), so Thunzharr rises more frequently.

## How

One-line constant change in `src/sim/world_boss.ts` (`3 * 3600` to `1 * 3600`), plus the comment. The scheduler and the reschedule test both read the constant, so nothing else needs to change; `tests/world_boss.test.ts` passes (17).

## Note

This is an alternative to PR #1446, which set the same cadence to 90 minutes. Both edit the same line, so whichever merges second will need a trivial rebase (or just pick this one for a 1-hour respawn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)