### PR TITLE
fix(lint): clear noArguments and unused-param warnings on the delve rite / input seam

### DIFF
--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -522,7 +522,7 @@ export class Input {
 
   setControllerMoveInput(input: unknown, facing?: unknown): void {
     this.controllerMoveInput = sanitizeMoveInput(input);
-    if (arguments.length > 1) this.controllerFacing = sanitizeMoveFacing(facing);
+    if (facing !== undefined) this.controllerFacing = sanitizeMoveFacing(facing);
   }
 
   setControllerFacing(facing: unknown): void {

--- a/src/sim/delves/drowned_litany_rite.ts
+++ b/src/sim/delves/drowned_litany_rite.ts
@@ -170,12 +170,12 @@ export function spawnDrownedLitanyRite(
 /** Lock in the chosen difficulty: generate the seeded sequence and start playback.
  * Shared per run (the first chooser commits it); returns false if not awaiting. */
 export function chooseDrownedLitanyRiteIntensity(
-  ctx: SimContext,
+  _ctx: SimContext,
   run: DelveRun,
   intensity: RiteIntensity,
 ): boolean {
   const st = run.drownedLitanyRite;
-  if (!st || !st.awaitingChoice) return false;
+  if (!st?.awaitingChoice) return false;
   // Reject unknown intensities outright (riteCeiling would crash on a raw
   // string later); every caller validates, this is the shared backstop.
   // Object.hasOwn so Object.prototype keys ('toString', 'constructor') cannot


### PR DESCRIPTION
## Summary
- `Input.setControllerMoveInput` used `arguments.length` to detect an omitted `facing` arg; every call site either omits it or passes a defined value, so `facing !== undefined` is equivalent and drops the legacy `arguments` object (`lint/complexity/noArguments`).
- `chooseDrownedLitanyRiteIntensity` never used its `ctx` param; keeps the `SimContext`-seam signature (for consistency with sibling `tickDrownedLitanyRite`) but marks it unused, and simplifies the guard to an optional chain (`lint/correctness/noUnusedFunctionParameters`, `lint/complexity/useOptionalChain`).

Both are pre-existing biome warnings (not errors) surfaced on these files by the pre-push floor; no behavior change.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run tests/delves.test.ts tests/input.test.ts tests/architecture.test.ts tests/localization_fixes.test.ts` (244 passed, 3 skipped)
- [x] `npx @biomejs/biome check --changed --since=release/v0.21.0` clean on the two touched files