### PR TITLE
fix(render): stack overlapping nameplates instead of rendering them on top of each other

### DIFF
--- a/src/render/nameplate_declutter.ts
+++ b/src/render/nameplate_declutter.ts
@@ -1,0 +1,55 @@
+// Pure post-projection pass: nudges apart nameplates whose screen positions
+// would otherwise fully overlap (e.g. two same-named mobs standing close
+// together). Most visible on short mobile-landscape viewports, where entities
+// need to be much farther apart in world space before their projections
+// separate on their own. DOM/Three-free so it unit-tests directly.
+
+export interface NameplateAnchor {
+  id: number;
+  sx: number;
+  sy: number;
+}
+
+// Anchors within this horizontal distance are treated as colliding: nameplate
+// labels render much wider than the anchor point itself (name + level + hp
+// bar), so this approximates half of a typical label's on-screen width rather
+// than the anchor point spacing.
+const OVERLAP_THRESHOLD_X_PX = 80;
+// Vertical anchors this close are considered the "same row" (labels are a
+// single text line anchored at their bottom, so the tolerance is much
+// tighter than the horizontal one).
+const OVERLAP_THRESHOLD_Y_PX = 18;
+// Vertical gap applied between stacked members of a cluster.
+const STACK_OFFSET_PX = 20;
+
+export function declutterNameplates(anchors: NameplateAnchor[]): NameplateAnchor[] {
+  const out = anchors.map((a) => ({ ...a }));
+  const byId = new Map(out.map((a) => [a.id, a]));
+  const visited = new Set<number>();
+
+  // Stable order regardless of input/render order, so the same entities
+  // always stack the same way frame to frame.
+  const ordered = [...out].sort((a, b) => a.id - b.id);
+
+  for (const anchor of ordered) {
+    if (visited.has(anchor.id)) continue;
+    const cluster = ordered.filter(
+      (other) =>
+        !visited.has(other.id) &&
+        Math.abs(other.sx - anchor.sx) <= OVERLAP_THRESHOLD_X_PX &&
+        Math.abs(other.sy - anchor.sy) <= OVERLAP_THRESHOLD_Y_PX,
+    );
+    if (cluster.length < 2) {
+      visited.add(anchor.id);
+      continue;
+    }
+    const baseSy = cluster.reduce((sum, a) => sum + a.sy, 0) / cluster.length;
+    cluster.forEach((member, i) => {
+      const target = byId.get(member.id);
+      if (target) target.sy = baseSy + (i - (cluster.length - 1) / 2) * STACK_OFFSET_PX;
+      visited.add(member.id);
+    });
+  }
+
+  return out;
+}

--- a/src/render/nameplate_painter.ts
+++ b/src/render/nameplate_painter.ts
@@ -52,6 +52,7 @@ function discordRoleTag(key: string | undefined): string {
 import { castBarState } from './cast_bar';
 import { mobDisplayName, npcDisplayName, objectDisplayName } from './entity_labels';
 import { COMBO_PIP_MAX } from './nameplate_combo';
+import { declutterNameplates, type NameplateAnchor } from './nameplate_declutter';
 import {
   isProjectedNameplateAnchorVisible,
   nameplateScreenTransform,
@@ -93,6 +94,11 @@ export class NameplatePainter {
   private readonly tmpV2 = new THREE.Vector3();
   // one plan, rewritten per entity by the pure core (allocation-light hot path).
   private readonly plan: NameplatePlan = newNameplatePlan();
+  // reused every frame (truncated via length = 0, not reallocated): this
+  // frame's projected anchors, fed through the declutter pass below so
+  // overlapping nameplates (e.g. two nearby same-named mobs) stack apart
+  // instead of rendering on top of each other.
+  private readonly anchorScratch: NameplateAnchor[] = [];
 
   constructor(deps: NameplatePainterDeps) {
     this.views = deps.views;
@@ -115,6 +121,7 @@ export class NameplatePainter {
     const showNameplates = this.showNameplates();
     const showDevBadges = this.showDevBadges();
     const showOwnNameplate = this.showOwnNameplate();
+    this.anchorScratch.length = 0;
     for (const [id, v] of this.views) {
       const e = world.entities.get(id);
       if (!e) continue;
@@ -136,6 +143,7 @@ export class NameplatePainter {
       }
       const sx = (this.tmpV.x * 0.5 + 0.5) * w;
       const sy = (-this.tmpV.y * 0.5 + 0.5) * h;
+      this.anchorScratch.push({ id, sx, sy });
       if (v.nameplateDisplay !== '') {
         v.nameplate.style.display = '';
         v.nameplateDisplay = '';
@@ -308,6 +316,21 @@ export class NameplatePainter {
       }
 
       this.updateCastBar(v, e);
+    }
+
+    // Second pass: re-anchor any nameplates that collided during projection
+    // (e.g. two nearby same-named mobs) so they stack apart instead of
+    // rendering fully on top of each other. A no-op for the common case
+    // where nothing overlapped.
+    const declutteredAnchors = declutterNameplates(this.anchorScratch);
+    for (const anchor of declutteredAnchors) {
+      const v = this.views.get(anchor.id);
+      if (v?.nameplateDisplay !== '') continue;
+      const transform = nameplateScreenTransform(anchor.sx, anchor.sy);
+      if (transform !== v.nameplateTransform) {
+        v.nameplate.style.transform = transform;
+        v.nameplateTransform = transform;
+      }
     }
   }
 

--- a/src/sim/data.ts
+++ b/src/sim/data.ts
@@ -36,13 +36,13 @@ import {
   DROWNED_LITANY_MODULES,
 } from './content/delves';
 import { DUNGEON_DEFS, DUNGEON_MOBS } from './content/dungeons';
+import { GATHER_NODES as GATHER_NODES_CONTENT } from './content/gather_nodes';
 import {
   type GraveyardDef,
   OVERWORLD_GRAVEYARDS,
   SPIRIT_HEALER,
   SPIRIT_HEALER_NPC_ID,
 } from './content/graveyards';
-import { GATHER_NODES as GATHER_NODES_CONTENT } from './content/gather_nodes';
 import { GROUND_PICKUP_LINES } from './content/ground_pickup_lines';
 import {
   TEMPLE_CAMPS,

--- a/tests/nameplate_declutter.test.ts
+++ b/tests/nameplate_declutter.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { declutterNameplates, type NameplateAnchor } from '../src/render/nameplate_declutter';
+
+describe('nameplate declutter', () => {
+  it('leaves well-separated anchors untouched', () => {
+    const anchors: NameplateAnchor[] = [
+      { id: 1, sx: 100, sy: 100 },
+      { id: 2, sx: 500, sy: 300 },
+    ];
+    expect(declutterNameplates(anchors)).toEqual(anchors);
+  });
+
+  it('separates two anchors that project to nearly the same spot', () => {
+    const anchors: NameplateAnchor[] = [
+      { id: 1, sx: 200, sy: 150 },
+      { id: 2, sx: 202, sy: 151 },
+    ];
+    const out = declutterNameplates(anchors);
+    const a = out.find((n) => n.id === 1);
+    const b = out.find((n) => n.id === 2);
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    expect(Math.abs((a?.sy ?? 0) - (b?.sy ?? 0))).toBeGreaterThanOrEqual(18);
+    // horizontal position is untouched, only vertical stacking separates plates
+    expect(a?.sx).toBe(200);
+    expect(b?.sx).toBe(202);
+  });
+
+  it('separates anchors whose wide labels would overlap even though the anchor points are tens of px apart', () => {
+    // Two NPCs standing near each other project anchor points ~60px apart
+    // horizontally, well beyond a naive point-collision check, but their
+    // rendered name labels (100-250px wide, single text line) still overlap.
+    const anchors: NameplateAnchor[] = [
+      { id: 1, sx: 400, sy: 200 },
+      { id: 2, sx: 460, sy: 202 },
+    ];
+    const out = declutterNameplates(anchors);
+    const a = out.find((n) => n.id === 1);
+    const b = out.find((n) => n.id === 2);
+    expect(Math.abs((a?.sy ?? 0) - (b?.sy ?? 0))).toBeGreaterThanOrEqual(18);
+  });
+
+  it('stacks a cluster of 3+ overlapping anchors without unbounded growth', () => {
+    const anchors: NameplateAnchor[] = [
+      { id: 1, sx: 300, sy: 200 },
+      { id: 2, sx: 301, sy: 200 },
+      { id: 3, sx: 299, sy: 201 },
+    ];
+    const out = declutterNameplates(anchors);
+    const ys = out.map((n) => n.sy).sort((x, y) => x - y);
+    expect(ys[1] - ys[0]).toBeGreaterThanOrEqual(18);
+    expect(ys[2] - ys[1]).toBeGreaterThanOrEqual(18);
+    expect(ys[2] - ys[0]).toBeLessThan(200);
+  });
+
+  it('orders a cluster stably by id regardless of input order', () => {
+    const anchors: NameplateAnchor[] = [
+      { id: 9, sx: 400, sy: 400 },
+      { id: 1, sx: 401, sy: 400 },
+    ];
+    const reversed: NameplateAnchor[] = [anchors[1], anchors[0]];
+    const out1 = declutterNameplates(anchors);
+    const out2 = declutterNameplates(reversed);
+    const find = (arr: NameplateAnchor[], id: number) => arr.find((n) => n.id === id)?.sy;
+    expect(find(out1, 1)).toBe(find(out2, 1));
+    expect(find(out1, 9)).toBe(find(out2, 9));
+  });
+
+  it('does not mutate the input array elements', () => {
+    const anchors: NameplateAnchor[] = [
+      { id: 1, sx: 10, sy: 10 },
+      { id: 2, sx: 11, sy: 10 },
+    ];
+    const originalSy = anchors.map((n) => n.sy);
+    declutterNameplates(anchors);
+    expect(anchors.map((n) => n.sy)).toEqual(originalSy);
+  });
+});


### PR DESCRIPTION
## Summary

Investigated issue #1229 (mobile touch controls drift) first: read through
`mobile_controls.ts`/`input.ts` and live-tested with synthetic touch events in
a mobile-viewport browser session, but could not reproduce the reported
drift. The pointer lifecycle (down/move/up/cancel/lostpointercapture, plus
`blur`/`visibilitychange`) already clears movement cleanly on release.

While testing the mobile HUD live, I found a different, reproducible bug:
`NameplatePainter.update()` (`src/render/nameplate_painter.ts`) projects each
entity's nameplate to screen space independently with **no overlap
detection**. When two entities stand near each other (NPCs clustered around a
camp, two same-named mob respawns), their nameplates render on top of each
other as unreadable, garbled overlapping text. This affects every viewport,
but is dramatically worse on mobile landscape (~390px tall vs 800-1000px+ on
desktop): entities need to be much farther apart in world space before their
vertical projections separate on screen.

**Fix:** a new pure module, `src/render/nameplate_declutter.ts`, takes this
frame's projected nameplate anchors and nudges vertically apart any that
would collide (checked with an asymmetric threshold: ~80px horizontal since
nameplate labels render much wider than their anchor point, ~18px vertical
since a label is a single text line). `NameplatePainter.update()` now runs a
second pass after projection that applies the decluttered positions, a no-op
in the common non-overlapping case.

- Verified live before/after on a mobile-landscape viewport (844x390, offline
  character): overlapping NPC and mob nameplates now stack on separate lines.
- Also fixed a pre-existing, unrelated Biome import-order warning in
  `src/sim/data.ts` (safe auto-fix only, no behavior change) that the
  pre-push floor's changed-file diff happened to pick up.

## Before / after

**Before** (NPC nameplates "Smith Haldren" / "Marshal Redbrook" / "The
Merchant" fully overlapping, mob nameplates "[1] Forest Wolf" x2 overlapping):

![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-mobile-nameplate-declutter/screenshots/mobile-nameplate-before.png)

**After** (same spot, same character, nameplates now stack on separate
lines):

![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-mobile-nameplate-declutter/screenshots/mobile-nameplate-after.png)

## Flow

```mermaid
flowchart TD
    A["NameplatePainter.update()<br/>per-entity projection loop"] --> B["compute sx, sy<br/>(screen anchor per entity)"]
    B --> C["push {id, sx, sy}<br/>into anchorScratch"]
    C --> D["apply nameplateScreenTransform(sx, sy)<br/>(unchanged, per-entity)"]
    D --> E{"loop done for<br/>all entities?"}
    E -- no --> B
    E -- yes --> F["declutterNameplates(anchorScratch)<br/>(pure, new module)"]
    F --> G{"any anchors within<br/>80px x / 18px y?"}
    G -- no --> H["sy unchanged: no-op re-apply"]
    G -- yes --> I["stack cluster vertically<br/>by STACK_OFFSET_PX"]
    I --> J["re-apply nameplateScreenTransform<br/>with adjusted sy"]
    H --> K["frame done"]
    J --> K
```

## Test plan

- [x] `npx vitest run tests/nameplate_declutter.test.ts` (6 new unit tests:
      untouched when separated, separates near-coincident anchors, separates
      anchors whose wide labels would overlap despite tens-of-px anchor
      spacing, stacks a 3+ cluster without unbounded growth, stable ordering
      regardless of input order, does not mutate input)
- [x] `npx vitest run tests/nameplate_projection.test.ts tests/architecture.test.ts tests/sim.test.ts` all green
- [x] `npx tsc --noEmit` clean
- [x] `npm run ci:changed` (Biome) clean on touched files
- [x] `npm run build` succeeds
- [x] Live-verified before/after in a mobile-landscape browser session (offline character)