### PR TITLE
fix(shell): keep character-select "Level N Class" on one line at narrow widths

### DIFF
--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -5133,6 +5133,13 @@
     display: flex;
     align-items: center;
     gap: 14px;
+    /* Reflow on a narrow row (a small desktop window, not just mobile-touch):
+       when the info column would be crushed below its min-width beside the
+       fixed-width action buttons, the buttons wrap to their own line below
+       instead, so the name + "Level N Class" line keeps the full width. Reacts
+       to the actual row width, so it holds at every screen size. */
+    flex-wrap: wrap;
+    row-gap: 8px;
     padding: 10px 12px;
     border: 1px solid rgba(78, 61, 29, 0.3);
     border-radius: var(--radius-sm);
@@ -5153,7 +5160,11 @@
   /* name stacked over level/class, vertically centered with the portrait */
   #char-list .char-row .char-id {
     flex: 1 1 auto;
-    min-width: 0;
+    /* A real minimum (not 0) so the column cannot be squeezed narrower than the
+       name + level line: once it would go below this, the action buttons wrap
+       below (flex-wrap on the row) rather than crushing the text into
+       "Level" / "20" / "Shaman". */
+    min-width: 150px;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -5164,9 +5175,15 @@
   }
   #char-list .char-row .char-sub {
     flex: 0 0 auto;
+    /* Keep "Level 20 Shaman" on ONE line; the row reflow above guarantees the
+       column is wide enough to hold it. */
+    white-space: nowrap;
   }
   #char-list .char-row .char-actions {
     flex: 0 0 auto;
+    /* Right-align the buttons whether they sit inline (wide row) or wrap to
+       their own line below (narrow row). */
+    margin-left: auto;
   }
   .char-list-message {
     list-style: none;


### PR DESCRIPTION
## Problem

On a narrow character-select column (a small desktop window, the single-column state), the fixed-width Delete / Enter World buttons squeeze the info column so tight that the "Level 20 Shaman" subtitle wraps word by word into three stacked lines ("Level" / "20" / "Shaman"). It reads as broken.

The desktop `.char-row` keeps portrait, info, and buttons on one flex row with no reflow at narrow widths, so the info column collapses. The mobile-touch layout already stacks the buttons below (grid), but a narrow non-touch window does not get that treatment.

## Fix

CSS only (`src/styles/shell.css`, `#char-list .char-row`):

- The row reflows to its actual width (`flex-wrap: wrap`): when the info column would drop below its minimum beside the fixed-width buttons, the buttons wrap to their own line below (right-aligned via `margin-left: auto`), the same shape the mobile-touch layout already uses. It reacts to the real row width, so it holds at every screen size, not just at a viewport breakpoint.
- The info column keeps a real `min-width` (was 0) so it cannot be crushed.
- The level/class subtitle is pinned to a single line (`white-space: nowrap`).

## Testing

- Rendered the real character-select list at wide (560px), medium (400px), and narrow (320px, the reported case) column widths:
  - Wide: buttons inline, subtitle on one line (unchanged desktop look, no regression).
  - Medium and narrow: buttons wrap below cleanly, subtitle stays on one line (subtitle height stays one line at all three widths).
- Mobile-touch layout (its own grid) is unaffected; it already stacked the buttons and had room for the subtitle.
- CSS guard suites green (css_corpus, css_value_validity, styles_extraction); biome clean on the file.