### PR TITLE
feat(render): realistic jagged mountains and distinct biome palettes

### DIFF
--- a/scripts/mountain_realism_shot.mjs
+++ b/scripts/mountain_realism_shot.mjs
@@ -1,0 +1,79 @@
+// Screenshot harness for the mountain-realism / draw-distance-haze pass.
+// Boots an offline warrior, god-mode teleports to each zone hub (~"zone
+// centre") plus a couple of up-close mountain vantage points, hides the HUD,
+// and captures a frame at each. Needs `npm run dev` on :5173 (override with
+// GAME_URL). Writes to tmp/, filenames prefixed by the LABEL env var (default
+// "after") so before/after pairs don't collide.
+
+import fs from 'node:fs';
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const LABEL = process.env.LABEL ?? 'after';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// zone hubs (data.ts / content/zone*.ts), "standing at the centre of the
+// zone" vantage points, plus two up-close mountain details.
+const VANTAGE_POINTS = [
+  { name: 'vale-hub', x: 0, z: 0, yaw: 0 },
+  { name: 'marsh-hub', x: 0, z: 300, yaw: Math.PI / 2 },
+  { name: 'peaks-hub', x: 0, z: 660, yaw: Math.PI },
+  { name: 'ridge-closeup', x: 0, z: 160, yaw: 0 },
+  { name: 'rim-closeup', x: 0, z: -140, yaw: 0 },
+];
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+page.on('console', (m) => {
+  if (m.type() === 'error') console.log('CONSOLE:', m.text());
+});
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await sleep(200);
+await page.type('#char-name', 'Aldwyn');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await page.waitForFunction(() => Boolean(window.__game?.sim), { timeout: 20000 });
+await sleep(1000);
+
+// god mode so the settle-fall from teleporting never kills the camera
+await page.evaluate(() => {
+  const p = window.__game.sim.player;
+  p.maxHp = 99999;
+  p.hp = 99999;
+});
+
+// hide every HUD chrome element so the screenshot is pure world/terrain
+await page.evaluate(() => {
+  const style = document.createElement('style');
+  style.textContent = `
+    #hud, #minimap, #chat, #bags, #action-bars, #nameplates, #cast-bar,
+    #player-frame, #target-frame, #party-frame { display: none !important; }
+  `;
+  document.head.appendChild(style);
+});
+
+for (const v of VANTAGE_POINTS) {
+  await page.evaluate((vp) => {
+    const g = window.__game;
+    const p = g.sim.player;
+    p.pos.x = vp.x;
+    p.pos.z = vp.z;
+    p.facing = vp.yaw;
+    for (let i = 0; i < 10; i++) g.sim.tick();
+  }, v);
+  await sleep(1200); // let terrain chunks + fog settle after the teleport
+  await page.screenshot({ path: `tmp/mountains-${LABEL}-${v.name}.png` });
+  console.log('captured', v.name);
+}
+
+await browser.close();

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -3610,14 +3610,18 @@ export class Renderer {
 
   // Outdoor fog presets per biome (high tier eases between them as the
   // player crosses zone bands; low keeps the legacy vale fog everywhere).
+  // far/near trimmed from the original release so a zone's own mountains (the
+  // rim wall, the inter-zone ridges) fade into haze instead of standing out
+  // crisp when viewed from the zone's hub/centre; ratio near:far kept roughly
+  // constant per biome so the fog gradient itself doesn't change shape.
   private static BIOME_FOG: Record<BiomeId, { color: number; near: number; far: number }> = {
-    vale: { color: 0xa6c6e0, near: 130, far: 470 },
-    marsh: { color: 0xa3b294, near: 80, far: 330 },
-    peaks: { color: 0xbdd3ec, near: 160, far: 560 },
-    beach: { color: 0xbcd6e6, near: 150, far: 520 },
-    desert: { color: 0xd8c9a8, near: 140, far: 500 },
-    volcano: { color: 0x8a7468, near: 70, far: 300 },
-    cave: { color: 0x76807c, near: 60, far: 260 },
+    vale: { color: 0xa6c6e0, near: 95, far: 340 },
+    marsh: { color: 0xa3b294, near: 60, far: 240 },
+    peaks: { color: 0xbdd3ec, near: 110, far: 390 },
+    beach: { color: 0xbcd6e6, near: 105, far: 370 },
+    desert: { color: 0xd8c9a8, near: 100, far: 360 },
+    volcano: { color: 0x8a7468, near: 50, far: 220 },
+    cave: { color: 0x76807c, near: 45, far: 190 },
   };
   private static LOW_FOG = { color: 0xa6c6e0, near: 70, far: 260 };
 

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_Z, ZONES } from '../sim/data';
+import { fbm2 } from '../sim/rng';
 import type { BiomeId } from '../sim/types';
 import { biomeAt, roadDistance, terrainHeight, waterLevel, zoneBiomeAt } from '../sim/world';
 import { loadTexture } from './assets/loader';
@@ -90,8 +91,8 @@ const ROUGH_SNOW = 0.72;
 const LOD_BANDS = {
   high: [
     { maxHubDist: 95, spacing: 1.2 },
-    { maxHubDist: 185, spacing: 2.0 },
-    { maxHubDist: Infinity, spacing: 3.5 },
+    { maxHubDist: 185, spacing: 1.6 },
+    { maxHubDist: Infinity, spacing: 2.6 },
   ],
   low: [
     { maxHubDist: 95, spacing: 3.0 },
@@ -119,48 +120,56 @@ const BIOME_PALETTE: Record<
     dirt: 0x8a6f47,
     sand: 0xc2b283,
   },
+  // Darker, murkier and more desaturated than the vale so the swamp reads as
+  // gloomy lowland rather than "vale but slightly duller".
   marsh: {
-    grass: 0x596d36,
-    grassDark: 0x41522b,
-    grassYellow: 0x71764a,
-    dirt: 0x6e5a3e,
-    sand: 0x8f7f5c,
+    grass: 0x4a5a2e,
+    grassDark: 0x384527,
+    grassYellow: 0x5e6a3e,
+    dirt: 0x5c4a34,
+    sand: 0x746650,
   },
+  // Cooler and greyer than the vale/marsh's warm greens, pushing toward sage
+  // and stone since altitude thins out the lush growth.
   peaks: {
-    grass: 0x687a55,
-    grassDark: 0x4d5c45,
-    grassYellow: 0x8d9168,
-    dirt: 0x7d6a50,
-    sand: 0xb0a486,
+    grass: 0x6d7a68,
+    grassDark: 0x525c50,
+    grassYellow: 0x8f9484,
+    dirt: 0x7a6f5c,
+    sand: 0xafa892,
   },
   // Paint-only biomes (editor brush): flat palettes, no zone-band blend.
+  // Coastal green-blue, brighter sand than the desert's.
   beach: {
-    grass: 0x9aa55e,
-    grassDark: 0x7a8a4e,
-    grassYellow: 0xb5b06a,
+    grass: 0x8fa860,
+    grassDark: 0x6f8850,
+    grassYellow: 0xa8b56c,
     dirt: 0xb59a6b,
-    sand: 0xe2d3a4,
+    sand: 0xe8dcb0,
   },
+  // Warmer and browner than the beach, less green.
   desert: {
-    grass: 0xb0a060,
-    grassDark: 0x8f8350,
-    grassYellow: 0xc4b070,
-    dirt: 0xa87f4f,
-    sand: 0xd8b581,
+    grass: 0xbfa668,
+    grassDark: 0x9c8752,
+    grassYellow: 0xd4b978,
+    dirt: 0xb08653,
+    sand: 0xe0bc86,
   },
+  // Dark, red-tinted ash rather than the cave's neutral grey.
   volcano: {
-    grass: 0x5a4a42,
-    grassDark: 0x40332e,
-    grassYellow: 0x6e5a4a,
-    dirt: 0x4a3a32,
-    sand: 0x6a5548,
+    grass: 0x4a3a34,
+    grassDark: 0x332622,
+    grassYellow: 0x5e483e,
+    dirt: 0x3a2c26,
+    sand: 0x5c463c,
   },
+  // Neutral blue-grey stone, distinct from volcano's warm ash.
   cave: {
-    grass: 0x6a6a62,
-    grassDark: 0x50504a,
-    grassYellow: 0x7a7a6e,
-    dirt: 0x5a5248,
-    sand: 0x8a8274,
+    grass: 0x62666a,
+    grassDark: 0x484c50,
+    grassYellow: 0x74787a,
+    dirt: 0x565a5e,
+    sand: 0x84888a,
   },
 };
 
@@ -195,6 +204,7 @@ const dirtC = new THREE.Color(),
   sandC = new THREE.Color();
 const dirtDarkC = new THREE.Color(0x73592f);
 const rockC = new THREE.Color(0x7a7a72);
+const wetRockC = new THREE.Color(0x3f4442); // dark wet-rock shoreline (peaks/volcano/cave)
 const impactAshC = new THREE.Color(0x18110d);
 const impactScorchC = new THREE.Color(0x2a160c);
 const hazyPeakC = new THREE.Color(0xa8bdd4); // world-rim mountains, atmospheric
@@ -236,7 +246,7 @@ function makeBiomePalette(b: BiomeId): (typeof zonePalettes)[number] {
 // Palette at a point. A painted cell (biome differs from its zone band) uses that
 // biome's flat palette; otherwise the smooth zone-band blend. With no paint layer
 // `biome === zoneBiomeAt(z)` always, so this is the original z-blend exactly.
-function paletteAt(x: number, z: number, biome: BiomeId): void {
+function paletteAt(_x: number, z: number, biome: BiomeId): void {
   if (biome !== zoneBiomeAt(z)) {
     const p = biomePalettes[biome];
     grassC.copy(p.grass);
@@ -317,20 +327,33 @@ function sampleVertex(x: number, z: number, seed: number): VertexSample {
   }
   const impact = impactCraterTerrainBlend(x, z);
 
-  // base grass with patchy variation
-  const v = (Math.sin(x * 0.21) * Math.cos(z * 0.17) + 1) / 2;
+  // base grass with patchy variation: a coarse fbm layer for dry/lush
+  // patches plus a fine one for grain, replacing the old pure-sine tint
+  // (sine repeats on a visible grid at a distance; noise reads as natural
+  // ground cover instead).
+  const v = fbm2(x * 0.045, z * 0.045, seed + 53, 3);
   cTmp.copy(grassC).lerp(grassDarkC, v);
-  const v2 = (Math.sin(x * 0.043 + 5) * Math.cos(z * 0.05 + 2) + 1) / 2;
+  const v2 = fbm2(x * 0.16, z * 0.16, seed + 59, 2);
   cTmp.lerp(grassYellowC, v2 * 0.35);
   // the marsh reads muddier: patches of wet dirt across the lowland
   if (biome === 'marsh') lerpSplat(w, 1, 0.3 * v2 * clamp01((4 - h) / 6));
-  // shoreline sand — color and splat weight share one feathered falloff so
-  // the beach blends out instead of cutting a razor-hard grass/sand line.
+  // shoreline blend, biome-specific: marsh has no sandy beach (wet mud
+  // instead), rocky/ashen biomes get a darker wet-rock tint, everywhere else
+  // keeps the classic sandy bank. Color and splat weight share one feathered
+  // falloff so the shore blends out instead of cutting a razor-hard edge.
   // waterLevel() (not the const) so the beach tracks a custom map's water.
   const wl = waterLevel();
   const shore = clamp01((wl + 1.6 - h) / 1.6);
-  cTmp.lerp(sandC, shore);
-  lerpSplat(w, 3, shore);
+  if (biome === 'marsh') {
+    cTmp.lerp(dirtDarkC, shore);
+    lerpSplat(w, 1, shore);
+  } else if (biome === 'peaks' || biome === 'volcano' || biome === 'cave') {
+    cTmp.lerp(wetRockC, shore);
+    lerpSplat(w, 2, shore);
+  } else {
+    cTmp.lerp(sandC, shore);
+    lerpSplat(w, 3, shore);
+  }
   // packed dirt at each hub settlement (same feather as the splat weight —
   // a constant lerp stamped a clean-edged brown disc on the grass)
   for (const zn of ZONES) {
@@ -351,17 +374,23 @@ function sampleVertex(x: number, z: number, seed: number): VertexSample {
     cTmp.lerp(dirtC, t);
     lerpSplat(w, 1, t);
   }
+  // Break up the rock/snow blend so cliffs read as striated stone and snow
+  // reads as patchy drifts instead of a single flat tone / a clean cutoff.
+  const rockStreak = fbm2(x * 0.09, z * 0.09, seed + 41, 3);
+  const snowPatch = fbm2(x * 0.06, z * 0.06, seed + 47, 3);
   const rockStart = ROCK_SLOPE_START[biome];
   if (slope > rockStart) {
     const t = Math.min(1, (slope - rockStart) * 2);
     cTmp.lerp(rockC, t);
+    cTmp.lerp(dirtDarkC, t * (rockStreak - 0.5) * 0.35);
     lerpSplat(w, 2, t);
   }
   // high ground (ridges, peaks) goes rocky then snowy
   let snow = 0;
   if (h > 22) {
-    cTmp.lerp(rockC, clamp01((h - 22) / 10) * 0.7);
-    snow = clamp01((h - 34) / 14) * 0.85;
+    const rockT = clamp01((h - 22) / 10) * (0.6 + rockStreak * 0.25);
+    cTmp.lerp(rockC, rockT);
+    snow = clamp01((h - 34 + (snowPatch - 0.5) * 8) / 14) * 0.85;
     cTmp.lerp(snowCapC, snow);
     lerpSplat(w, 2, clamp01((h - 22) / 10) * 0.8);
   }
@@ -371,15 +400,18 @@ function sampleVertex(x: number, z: number, seed: number): VertexSample {
     lerpSplat(w, 1, impact.dirt);
     lerpSplat(w, 2, impact.rock);
   }
-  // the rim wall reads as distant sunlit peaks, not a black cliff
+  // the rim wall reads as distant sunlit peaks, not a black cliff. The haze
+  // kicks in well before the wall itself (edge starts negative deep inland)
+  // so from a zone's centre the rim reads as atmospheric haze rather than a
+  // crisp silhouette, reinforcing the reduced BIOME_FOG draw distance.
   const edge = Math.max(
-    Math.abs(x) - (WORLD_MAX_X - 32),
-    WORLD_MIN_Z + 32 - z,
-    z - (WORLD_MAX_Z - 32),
+    Math.abs(x) - (WORLD_MAX_X - 70),
+    WORLD_MIN_Z + 70 - z,
+    z - (WORLD_MAX_Z - 70),
   );
-  const rim = clamp01(edge / 26);
+  const rim = clamp01(edge / 64);
   if (rim > 0) {
-    cTmp.lerp(hazyPeakC, rim * 0.9);
+    cTmp.lerp(hazyPeakC, rim * 0.95);
     const rimSnow = clamp01((h - 26) / 16) * rim * 0.8;
     cTmp.lerp(snowCapC, rimSnow);
     snow = Math.max(snow, rimSnow);

--- a/src/render/textures.ts
+++ b/src/render/textures.ts
@@ -2,7 +2,10 @@ import * as THREE from 'three';
 
 // Procedurally generated canvas textures — no external assets.
 
-function makeCanvas(size: number, draw: (ctx: CanvasRenderingContext2D, size: number) => void): THREE.CanvasTexture {
+function makeCanvas(
+  size: number,
+  draw: (ctx: CanvasRenderingContext2D, size: number) => void,
+): THREE.CanvasTexture {
   const c = document.createElement('canvas');
   c.width = size;
   c.height = size;
@@ -29,7 +32,8 @@ export function groundDetailTexture(): THREE.CanvasTexture {
     for (let i = 0; i < 5000; i++) {
       const v = 150 + Math.floor(rnd() * 105);
       ctx.fillStyle = `rgba(${v},${v},${v},0.35)`;
-      const x = rnd() * s, y = rnd() * s;
+      const x = rnd() * s,
+        y = rnd() * s;
       const r = 1 + rnd() * 2.5;
       ctx.fillRect(x, y, r, r);
     }
@@ -37,7 +41,8 @@ export function groundDetailTexture(): THREE.CanvasTexture {
     for (let i = 0; i < 1400; i++) {
       const v = 120 + Math.floor(rnd() * 100);
       ctx.strokeStyle = `rgba(${v},${v},${v},0.30)`;
-      const x = rnd() * s, y = rnd() * s;
+      const x = rnd() * s,
+        y = rnd() * s;
       ctx.beginPath();
       ctx.moveTo(x, y);
       ctx.lineTo(x + (rnd() - 0.5) * 3, y - 2 - rnd() * 4);
@@ -72,7 +77,9 @@ export function foliageTexture(detail = false): THREE.CanvasTexture {
       // shadowed cavities first so leaves overlap them; kept small so the
       // canopy UVs can't smear them into long diagonal streaks
       for (let i = 0; i < 110; i++) {
-        const x = rnd() * s, y = rnd() * s, r = 3 + rnd() * 7;
+        const x = rnd() * s,
+          y = rnd() * s,
+          r = 3 + rnd() * 7;
         ctx.fillStyle = `rgba(${10 + rnd() * 12},${28 + rnd() * 16},${14 + rnd() * 10},0.5)`;
         ctx.beginPath();
         ctx.ellipse(x, y, r, r * 0.75, rnd() * Math.PI, 0, Math.PI * 2);
@@ -83,7 +90,8 @@ export function foliageTexture(detail = false): THREE.CanvasTexture {
     for (let i = 0; i < leaves; i++) {
       const g = detail ? 60 + Math.floor(rnd() * 75) : 70 + Math.floor(rnd() * 60);
       ctx.fillStyle = `rgba(${30 + rnd() * 30},${g},${30 + rnd() * 18},${detail ? 0.6 : 0.5})`;
-      const x = rnd() * s, y = rnd() * s;
+      const x = rnd() * s,
+        y = rnd() * s;
       ctx.beginPath();
       ctx.ellipse(x, y, 1 + rnd() * 3, 3 + rnd() * 5, rnd() * Math.PI, 0, Math.PI * 2);
       ctx.fill();
@@ -91,7 +99,8 @@ export function foliageTexture(detail = false): THREE.CanvasTexture {
     if (detail) {
       // sun-catching highlight leaves — warm olive, not lime
       for (let i = 0; i < 200; i++) {
-        const x = rnd() * s, y = rnd() * s;
+        const x = rnd() * s,
+          y = rnd() * s;
         ctx.fillStyle = `rgba(${95 + rnd() * 40},${145 + rnd() * 40},${70 + rnd() * 28},0.45)`;
         ctx.beginPath();
         ctx.ellipse(x, y, 1 + rnd() * 2, 2.5 + rnd() * 4, rnd() * Math.PI, 0, Math.PI * 2);
@@ -177,7 +186,10 @@ export function stoneTexture(): THREE.CanvasTexture {
     ctx.fillStyle = '#8d8d85';
     ctx.fillRect(0, 0, s, s);
     for (let i = 0; i < 28; i++) {
-      const x = rnd() * s, y = rnd() * s, w = 14 + rnd() * 26, h = 10 + rnd() * 16;
+      const x = rnd() * s,
+        y = rnd() * s,
+        w = 14 + rnd() * 26,
+        h = 10 + rnd() * 16;
       const v = 115 + Math.floor(rnd() * 50);
       ctx.fillStyle = `rgb(${v},${v},${v - 6})`;
       ctx.fillRect(x, y, w, h);
@@ -192,7 +204,9 @@ export function waterNormalish(): THREE.CanvasTexture {
     ctx.fillStyle = '#7f7fff';
     ctx.fillRect(0, 0, s, s);
     for (let i = 0; i < 300; i++) {
-      const x = rnd() * s, y = rnd() * s, r = 6 + rnd() * 22;
+      const x = rnd() * s,
+        y = rnd() * s,
+        r = 6 + rnd() * 22;
       const g = ctx.createRadialGradient(x, y, 0, x, y, r);
       g.addColorStop(0, `rgba(${100 + rnd() * 80},${100 + rnd() * 80},255,0.25)`);
       g.addColorStop(1, 'rgba(127,127,255,0)');
@@ -213,7 +227,7 @@ export function cloudTexture(puffs = 14, spread = 0.5): THREE.CanvasTexture {
     for (let i = 0; i < puffs; i++) {
       const x = s * (0.5 - spread / 2) + rnd() * s * spread;
       const y = s * 0.35 + rnd() * s * 0.3;
-      const r = s * 0.10 + rnd() * s * 0.14;
+      const r = s * 0.1 + rnd() * s * 0.14;
       const g = ctx.createRadialGradient(x, y, 0, x, y, r);
       g.addColorStop(0, 'rgba(255,255,255,0.55)');
       g.addColorStop(1, 'rgba(255,255,255,0)');
@@ -232,7 +246,9 @@ export function macroNoiseTexture(): THREE.CanvasTexture {
     ctx.fillStyle = '#808080';
     ctx.fillRect(0, 0, s, s);
     for (let i = 0; i < 160; i++) {
-      const x = rnd() * s, y = rnd() * s, r = 18 + rnd() * 46;
+      const x = rnd() * s,
+        y = rnd() * s,
+        r = 18 + rnd() * 46;
       const v = 40 + rnd() * 175;
       drawWrapped(ctx, s, (ox, oy) => {
         const g = ctx.createRadialGradient(x + ox, y + oy, 0, x + ox, y + oy, r);
@@ -314,7 +330,10 @@ export interface GroundSplat {
   sand: SurfaceMaps;
 }
 
-function makeRawCanvas(size: number, draw: (ctx: CanvasRenderingContext2D, size: number) => void): HTMLCanvasElement {
+function makeRawCanvas(
+  size: number,
+  draw: (ctx: CanvasRenderingContext2D, size: number) => void,
+): HTMLCanvasElement {
   const c = document.createElement('canvas');
   c.width = size;
   c.height = size;
@@ -324,14 +343,21 @@ function makeRawCanvas(size: number, draw: (ctx: CanvasRenderingContext2D, size:
 }
 
 // Draws fn at the 9 wrap offsets so blobs crossing an edge tile seamlessly.
-function drawWrapped(ctx: CanvasRenderingContext2D, size: number, fn: (ox: number, oy: number) => void): void {
+function drawWrapped(
+  ctx: CanvasRenderingContext2D,
+  size: number,
+  fn: (ox: number, oy: number) => void,
+): void {
   for (const ox of [-size, 0, size]) {
     for (const oy of [-size, 0, size]) fn(ox, oy);
   }
 }
 
 // Sobel-ish height->tangent-space normal conversion with wrap sampling.
-export function heightToNormal(heightCanvas: HTMLCanvasElement, strength = 2.0): THREE.CanvasTexture {
+export function heightToNormal(
+  heightCanvas: HTMLCanvasElement,
+  strength = 2.0,
+): THREE.CanvasTexture {
   const s = heightCanvas.width;
   const src = heightCanvas.getContext('2d')!.getImageData(0, 0, s, s).data;
   const out = document.createElement('canvas');
@@ -397,7 +423,14 @@ export function barkMaps(): SurfaceMaps {
 // crypt walls don't read as a uniform wallpaper grid.
 export function stoneMaps(): SurfaceMaps {
   const S = 256;
-  interface Block { x: number; y: number; w: number; h: number; v: number; warm: number }
+  interface Block {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    v: number;
+    warm: number;
+  }
   const blocks: Block[] = [];
   let y = 0;
   let row = 0;
@@ -418,7 +451,8 @@ export function stoneMaps(): SurfaceMaps {
     ctx.fillStyle = '#6f6f67';
     ctx.fillRect(0, 0, s, s);
     for (const b of blocks) {
-      for (const ox of [0, s]) { // blocks only overhang in x; rows tile exactly
+      for (const ox of [0, s]) {
+        // blocks only overhang in x; rows tile exactly
         const v = b.v;
         ctx.fillStyle = `rgb(${v + b.warm},${v},${v - 8})`;
         ctx.fillRect(b.x + ox, b.y + 1, b.w - 2, b.h - 2);
@@ -444,8 +478,14 @@ export function stoneMaps(): SurfaceMaps {
       for (const ox of [0, s]) {
         const v = 130 + (b.v - 100) * 1.5;
         const g = ctx.createLinearGradient(0, b.y, 0, b.y + b.h);
-        g.addColorStop(0, `rgb(${Math.min(255, v + 24)},${Math.min(255, v + 24)},${Math.min(255, v + 24)})`);
-        g.addColorStop(1, `rgb(${Math.max(0, v - 22)},${Math.max(0, v - 22)},${Math.max(0, v - 22)})`);
+        g.addColorStop(
+          0,
+          `rgb(${Math.min(255, v + 24)},${Math.min(255, v + 24)},${Math.min(255, v + 24)})`,
+        );
+        g.addColorStop(
+          1,
+          `rgb(${Math.max(0, v - 22)},${Math.max(0, v - 22)},${Math.max(0, v - 22)})`,
+        );
         ctx.fillStyle = g;
         ctx.fillRect(b.x + ox + 2, b.y + 2, b.w - 5, b.h - 4);
       }
@@ -495,7 +535,9 @@ export function wallMaps(): SurfaceMaps {
     ctx.fillStyle = '#6e6e6e';
     ctx.fillRect(0, 0, s, s);
     for (let i = 0; i < 320; i++) {
-      const x = rnd() * s, y = rnd() * s, r = 3 + rnd() * 9;
+      const x = rnd() * s,
+        y = rnd() * s,
+        r = 3 + rnd() * 9;
       const v = 85 + rnd() * 70;
       const g = ctx.createRadialGradient(x, y, 0, x, y, r);
       g.addColorStop(0, `rgba(${v},${v},${v},0.5)`);
@@ -555,7 +597,9 @@ export function groundSplatMaps(): GroundSplat {
     ctx.fillStyle = '#7e8a64';
     ctx.fillRect(0, 0, s, s);
     for (let i = 0; i < 900; i++) {
-      const x = rnd() * s, y = rnd() * s, r = 4 + rnd() * 9;
+      const x = rnd() * s,
+        y = rnd() * s,
+        r = 4 + rnd() * 9;
       const v = 90 + rnd() * 105;
       drawWrapped(ctx, s, (ox, oy) => {
         ctx.fillStyle = `rgba(${v - 18},${v},${v - 40},0.30)`;
@@ -566,7 +610,8 @@ export function groundSplatMaps(): GroundSplat {
     }
     // blades
     for (let i = 0; i < 3200; i++) {
-      const x = rnd() * s, y = rnd() * s;
+      const x = rnd() * s,
+        y = rnd() * s;
       const v = 75 + rnd() * 125;
       ctx.strokeStyle = `rgba(${v - 25},${v},${v - 45},0.55)`;
       ctx.lineWidth = 1 + rnd() * 0.8;
@@ -580,7 +625,9 @@ export function groundSplatMaps(): GroundSplat {
     ctx.fillStyle = '#787878';
     ctx.fillRect(0, 0, s, s);
     for (let i = 0; i < 700; i++) {
-      const x = rnd() * s, y = rnd() * s, r = 4 + rnd() * 10;
+      const x = rnd() * s,
+        y = rnd() * s,
+        r = 4 + rnd() * 10;
       const v = 80 + rnd() * 110;
       drawWrapped(ctx, s, (ox, oy) => {
         const g = ctx.createRadialGradient(x + ox, y + oy, 0, x + ox, y + oy, r);
@@ -598,7 +645,9 @@ export function groundSplatMaps(): GroundSplat {
     ctx.fillStyle = '#8a7a60';
     ctx.fillRect(0, 0, s, s);
     for (let i = 0; i < 800; i++) {
-      const x = rnd() * s, y = rnd() * s, r = 1.5 + rnd() * 4;
+      const x = rnd() * s,
+        y = rnd() * s,
+        r = 1.5 + rnd() * 4;
       const v = 95 + rnd() * 85;
       drawWrapped(ctx, s, (ox, oy) => {
         ctx.fillStyle = `rgba(${v},${v - 12},${v - 32},0.5)`;
@@ -609,7 +658,8 @@ export function groundSplatMaps(): GroundSplat {
     }
     for (let i = 0; i < 40; i++) {
       // dry cracks
-      let x = rnd() * s, y = rnd() * s;
+      let x = rnd() * s,
+        y = rnd() * s;
       ctx.strokeStyle = 'rgba(50,40,28,0.45)';
       ctx.lineWidth = 1;
       ctx.beginPath();
@@ -626,7 +676,9 @@ export function groundSplatMaps(): GroundSplat {
     ctx.fillStyle = '#6e6e6e';
     ctx.fillRect(0, 0, s, s);
     for (let i = 0; i < 600; i++) {
-      const x = rnd() * s, y = rnd() * s, r = 1.5 + rnd() * 4.5;
+      const x = rnd() * s,
+        y = rnd() * s,
+        r = 1.5 + rnd() * 4.5;
       const v = 110 + rnd() * 120;
       drawWrapped(ctx, s, (ox, oy) => {
         const g = ctx.createRadialGradient(x + ox, y + oy, 0, x + ox, y + oy, r);
@@ -645,7 +697,9 @@ export function groundSplatMaps(): GroundSplat {
     ctx.fillRect(0, 0, s, s);
     for (let i = 0; i < 90; i++) {
       // fractured plates
-      const x = rnd() * s, y = rnd() * s, r = 10 + rnd() * 24;
+      const x = rnd() * s,
+        y = rnd() * s,
+        r = 10 + rnd() * 24;
       const v = 105 + rnd() * 55;
       drawWrapped(ctx, s, (ox, oy) => {
         ctx.fillStyle = `rgba(${v},${v},${v - 5},0.55)`;
@@ -654,7 +708,8 @@ export function groundSplatMaps(): GroundSplat {
         for (let k = 0; k <= n; k++) {
           const a = (k / n) * Math.PI * 2;
           const rr = r * (0.7 + rnd() * 0.5);
-          const px = x + ox + Math.cos(a) * rr, py = y + oy + Math.sin(a) * rr;
+          const px = x + ox + Math.cos(a) * rr,
+            py = y + oy + Math.sin(a) * rr;
           if (k === 0) ctx.moveTo(px, py);
           else ctx.lineTo(px, py);
         }
@@ -664,12 +719,28 @@ export function groundSplatMaps(): GroundSplat {
         ctx.stroke();
       });
     }
+    // finer secondary fracture pass: smaller, higher-contrast cracks layered
+    // on top so the rock reads as striated stone rather than one flat tone.
+    for (let i = 0; i < 140; i++) {
+      const x = rnd() * s,
+        y = rnd() * s,
+        r = 3 + rnd() * 8;
+      const v = 90 + rnd() * 70;
+      drawWrapped(ctx, s, (ox, oy) => {
+        ctx.fillStyle = `rgba(${v},${v},${v - 8},0.4)`;
+        ctx.beginPath();
+        ctx.arc(x + ox, y + oy, r, 0, Math.PI * 2);
+        ctx.fill();
+      });
+    }
   });
   const rockHeight = makeRawCanvas(256, (ctx, s) => {
     ctx.fillStyle = '#505050';
     ctx.fillRect(0, 0, s, s);
     for (let i = 0; i < 90; i++) {
-      const x = rnd() * s, y = rnd() * s, r = 10 + rnd() * 24;
+      const x = rnd() * s,
+        y = rnd() * s,
+        r = 10 + rnd() * 24;
       const v = 120 + rnd() * 110;
       drawWrapped(ctx, s, (ox, oy) => {
         ctx.fillStyle = `rgba(${v},${v},${v},0.8)`;
@@ -678,7 +749,8 @@ export function groundSplatMaps(): GroundSplat {
         for (let k = 0; k <= n; k++) {
           const a = (k / n) * Math.PI * 2;
           const rr = r * (0.7 + rnd() * 0.5);
-          const px = x + ox + Math.cos(a) * rr, py = y + oy + Math.sin(a) * rr;
+          const px = x + ox + Math.cos(a) * rr,
+            py = y + oy + Math.sin(a) * rr;
           if (k === 0) ctx.moveTo(px, py);
           else ctx.lineTo(px, py);
         }
@@ -744,7 +816,9 @@ export function canvasMaps(): SurfaceMaps {
     }
     // weather stains
     for (let i = 0; i < 26; i++) {
-      const x = rnd() * s, y = rnd() * s, r = 6 + rnd() * 16;
+      const x = rnd() * s,
+        y = rnd() * s,
+        r = 6 + rnd() * 16;
       drawWrapped(ctx, s, (ox, oy) => {
         const g = ctx.createRadialGradient(x + ox, y + oy, 0, x + ox, y + oy, r);
         g.addColorStop(0, 'rgba(120,100,64,0.16)');
@@ -827,7 +901,9 @@ export function waterNormalMaps(): [THREE.CanvasTexture, THREE.CanvasTexture] {
       ctx.fillStyle = '#808080';
       ctx.fillRect(0, 0, s, s);
       for (let i = 0; i < count; i++) {
-        const x = rnd() * s, y = rnd() * s, r = rMin + rnd() * (rMax - rMin);
+        const x = rnd() * s,
+          y = rnd() * s,
+          r = rMin + rnd() * (rMax - rMin);
         const v = 70 + rnd() * 140;
         drawWrapped(ctx, s, (ox, oy) => {
           const g = ctx.createRadialGradient(x + ox, y + oy, 0, x + ox, y + oy, r);
@@ -851,12 +927,14 @@ export function foliageCardTexture(): THREE.CanvasTexture {
   c.width = c.height = 128;
   const ctx = c.getContext('2d')!;
   ctx.clearRect(0, 0, 128, 128);
-  const cx = 64, cy = 64;
+  const cx = 64,
+    cy = 64;
   for (let i = 0; i < 240; i++) {
     // leaves cluster densely at the centre, thin toward the rim
     const a = rnd() * Math.PI * 2;
-    const d = Math.pow(rnd(), 0.6) * 56;
-    const x = cx + Math.cos(a) * d, y = cy + Math.sin(a) * d;
+    const d = rnd() ** 0.6 * 56;
+    const x = cx + Math.cos(a) * d,
+      y = cy + Math.sin(a) * d;
     const fade = 1 - d / 64;
     const g = 80 + rnd() * 80;
     ctx.fillStyle = `rgba(${30 + rnd() * 35},${g},${28 + rnd() * 25},${(0.5 + rnd() * 0.5) * fade})`;
@@ -887,7 +965,9 @@ function drawPlaster(ctx: CanvasRenderingContext2D, s: number): void {
   // soft daub patches — uneven hand-finished render, strong enough contrast
   // to survive mips at 10-15m
   for (let i = 0; i < 80; i++) {
-    const x = rnd() * s, y = rnd() * s, r = 5 + rnd() * 15;
+    const x = rnd() * s,
+      y = rnd() * s,
+      r = 5 + rnd() * 15;
     const v = 168 + rnd() * 70;
     drawWrapped(ctx, s, (ox, oy) => {
       const g = ctx.createRadialGradient(x + ox, y + oy, 0, x + ox, y + oy, r);
@@ -908,7 +988,8 @@ function drawPlaster(ctx: CanvasRenderingContext2D, s: number): void {
   ctx.strokeStyle = 'rgba(110,94,66,0.5)';
   ctx.lineWidth = 1;
   for (let i = 0; i < 4; i++) {
-    let cx = rnd() * s, cy = rnd() * s;
+    let cx = rnd() * s,
+      cy = rnd() * s;
     ctx.beginPath();
     ctx.moveTo(cx, cy);
     for (let kk = 0; kk < 5; kk++) {
@@ -932,7 +1013,9 @@ export function plasterMaps(): SurfaceMaps {
     ctx.fillStyle = '#787878';
     ctx.fillRect(0, 0, s, s);
     for (let i = 0; i < 320; i++) {
-      const x = rnd() * s, y = rnd() * s, r = 3 + rnd() * 11;
+      const x = rnd() * s,
+        y = rnd() * s,
+        r = 3 + rnd() * 11;
       const v = 70 + rnd() * 100;
       drawWrapped(ctx, s, (ox, oy) => {
         const g = ctx.createRadialGradient(x + ox, y + oy, 0, x + ox, y + oy, r);
@@ -1022,7 +1105,9 @@ function drawThatch(ctx: CanvasRenderingContext2D, s: number): void {
     ctx.fillRect(0, y + 13, s, 3);
   }
   for (let i = 0; i < 900; i++) {
-    const x = rnd() * s, y = rnd() * s, len = 6 + rnd() * 12;
+    const x = rnd() * s,
+      y = rnd() * s,
+      len = 6 + rnd() * 12;
     const v = 140 + rnd() * 80;
     ctx.strokeStyle = `rgba(${v},${Math.floor(v * 0.78)},${Math.floor(v * 0.36)},0.5)`;
     ctx.lineWidth = 1 + rnd() * 0.6;
@@ -1070,7 +1155,9 @@ function drawAwningStripes(ctx: CanvasRenderingContext2D, s: number): void {
     ctx.fillRect(0, yy, s, 1.5);
   }
   for (let i = 0; i < 18; i++) {
-    const x = rnd() * s, y = rnd() * s, r = 5 + rnd() * 12;
+    const x = rnd() * s,
+      y = rnd() * s,
+      r = 5 + rnd() * 12;
     drawWrapped(ctx, s, (ox, oy) => {
       const g = ctx.createRadialGradient(x + ox, y + oy, 0, x + ox, y + oy, r);
       g.addColorStop(0, 'rgba(110,92,58,0.14)');
@@ -1123,8 +1210,10 @@ export function sparkleTexture(): THREE.CanvasTexture {
   ctx.strokeStyle = 'rgba(255,255,220,0.9)';
   ctx.lineWidth = 2;
   ctx.beginPath();
-  ctx.moveTo(32, 6); ctx.lineTo(32, 58);
-  ctx.moveTo(6, 32); ctx.lineTo(58, 32);
+  ctx.moveTo(32, 6);
+  ctx.lineTo(32, 58);
+  ctx.moveTo(6, 32);
+  ctx.lineTo(58, 32);
   ctx.stroke();
   const tex = new THREE.CanvasTexture(c);
   tex.colorSpace = THREE.SRGBColorSpace;

--- a/src/sim/world.ts
+++ b/src/sim/world.ts
@@ -345,9 +345,14 @@ export function terrainHeight(x: number, z: number, seed: number): number {
     if (dz < RIDGE_SIGMA * 3) {
       const profile = Math.exp(-(dz * dz) / (2 * RIDGE_SIGMA * RIDGE_SIGMA));
       const pass = smoothstep(PASS_HALF_WIDTH, PASS_SHOULDER, Math.abs(x - ridge.passX));
-      // jagged crest so the wall reads as mountains, not a berm (variance kept
-      // tight so the lowest saddle still beats the climb limit)
-      const crest = 1 + (fbm2(x * 0.03, ridge.z * 0.03, seed + 19, 2) - 0.5) * 0.4;
+      // jagged crest so the wall reads as mountains, not a berm: a coarse layer
+      // for peak/saddle shape plus a finer layer for crag/shoulder detail.
+      // Combined variance kept tight so the lowest saddle still beats the
+      // climb limit (tests/terrain_walls.test.ts).
+      const crest =
+        1 +
+        (fbm2(x * 0.03, ridge.z * 0.03, seed + 19, 2) - 0.5) * 0.4 +
+        (fbm2(x * 0.11, ridge.z * 0.11, seed + 23, 2) - 0.5) * 0.14;
       h += RIDGE_HEIGHT * crest * profile * pass;
     }
   }
@@ -361,7 +366,16 @@ export function terrainHeight(x: number, z: number, seed: number): number {
   const rimS = smoothstep(w.minZ + 30, w.minZ + 6, z);
   const rimN = smoothstep(w.maxZ - 30, w.maxZ - 6, z);
   const rim = Math.max(rimX, rimS, rimN);
-  h += rim * 55;
+  // The rim wall used to be a perfectly smooth berm (no noise at all), which
+  // read as artificial from a distance. Give it the same two-layer jagged
+  // crest as the inter-zone ridges: a coarse peak/saddle layer plus a finer
+  // crag layer, same conservative combined variance so the climb-limit
+  // invariant still holds along the whole rim.
+  const rimCrest =
+    1 +
+    (fbm2(x * 0.025, z * 0.025, seed + 29, 3) - 0.5) * 0.35 +
+    (fbm2(x * 0.09, z * 0.09, seed + 37, 2) - 0.5) * 0.15;
+  h += rim * 55 * rimCrest;
   h += mirefenImpactCraterOffset(x, z);
   h = applyEditLayer(x, z, h);
   return h;

--- a/tests/parity/golden/delve_companion.json
+++ b/tests/parity/golden/delve_companion.json
@@ -391,7 +391,7 @@
       "tick": 41,
       "time": 2.05,
       "nextId": 410,
-      "state": "589a73cf",
+      "state": "e18e8a55",
       "events": "1aaa30ce",
       "rng": {
         "draws": 8,
@@ -448,7 +448,7 @@
           "critChance": 0.063,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.063,
-          "fallStartY": 55.657208,
+          "fallStartY": 55.987386,
           "fiveSecondRule": 101.05,
           "hp": 29000,
           "id": 400,
@@ -463,7 +463,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 4811.246093,
-            "y": 55.657208,
+            "y": 55.987386,
             "z": -1170.162032
           },
           "potionCooldownUntil": -1,
@@ -591,7 +591,7 @@
       "tick": 45,
       "time": 2.25,
       "nextId": 410,
-      "state": "fdeaa087",
+      "state": "ee73b7f6",
       "events": "741638a5",
       "rng": {
         "draws": 8,
@@ -602,7 +602,7 @@
       "tick": 49,
       "time": 2.45,
       "nextId": 410,
-      "state": "bc513da9",
+      "state": "d233cd69",
       "events": "741638a5",
       "rng": {
         "draws": 8,
@@ -659,7 +659,7 @@
           "critChance": 0.063,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.063,
-          "fallStartY": 55.323103,
+          "fallStartY": 56.279414,
           "fiveSecondRule": 101.45,
           "hp": 29000,
           "id": 400,
@@ -673,7 +673,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 4820.246093,
-            "y": 54.203103,
+            "y": 55.159414,
             "z": -1170.162032
           },
           "potionCooldownUntil": -1,
@@ -746,7 +746,7 @@
       "tick": 50,
       "time": 2.5,
       "nextId": 410,
-      "state": "7278fdb4",
+      "state": "93a73649",
       "events": "741638a5",
       "rng": {
         "draws": 8,
@@ -757,7 +757,7 @@
       "tick": 51,
       "time": 2.55,
       "nextId": 410,
-      "state": "60cd37b1",
+      "state": "d312001c",
       "events": "741638a5",
       "rng": {
         "draws": 8,
@@ -814,7 +814,7 @@
           "critChance": 0.063,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.063,
-          "fallStartY": 60.246749,
+          "fallStartY": 60.693294,
           "fiveSecondRule": 101.55,
           "hp": 29000,
           "id": 400,
@@ -828,7 +828,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 4891.046093,
-            "y": 60.206749,
+            "y": 60.653294,
             "z": -1170.162032
           },
           "potionCooldownUntil": -1,
@@ -876,7 +876,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 4891.046093,
-            "y": 60.246749,
+            "y": 60.693294,
             "z": -1170.162032
           },
           "potionCooldownUntil": -1,
@@ -902,7 +902,7 @@
       "tick": 51,
       "time": 2.55,
       "nextId": 410,
-      "state": "60cd37b1",
+      "state": "d312001c",
       "events": "741638a5",
       "rng": {
         "draws": 8,
@@ -959,7 +959,7 @@
           "critChance": 0.063,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.063,
-          "fallStartY": 60.246749,
+          "fallStartY": 60.693294,
           "fiveSecondRule": 101.55,
           "hp": 29000,
           "id": 400,
@@ -973,7 +973,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 4891.046093,
-            "y": 60.206749,
+            "y": 60.653294,
             "z": -1170.162032
           },
           "potionCooldownUntil": -1,
@@ -1021,7 +1021,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 4891.046093,
-            "y": 60.246749,
+            "y": 60.693294,
             "z": -1170.162032
           },
           "potionCooldownUntil": -1,

--- a/tests/parity/golden/dungeon_instances.json
+++ b/tests/parity/golden/dungeon_instances.json
@@ -841,8 +841,8 @@
       "tick": 4,
       "time": 0.2,
       "nextId": 416,
-      "state": "edb1a041",
-      "events": "8ca70f8e",
+      "state": "ae416258",
+      "events": "b0c301f0",
       "rng": {
         "draws": 49,
         "digest": "1d1c5dad"
@@ -862,7 +862,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 163124,
+            "damageTaken": 175396,
             "deaths": 1
           },
           "craftSkills": {},
@@ -985,7 +985,7 @@
           "critChance": 0.056,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.056,
-          "fallStartY": 57.122741,
+          "fallStartY": 60.62914,
           "fiveSecondRule": 99.2,
           "hp": 50000,
           "id": 401,
@@ -1633,8 +1633,8 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 416,
-      "state": "cd1a9f14",
-      "events": "5d7113da",
+      "state": "9d91fc10",
+      "events": "2dd4b9a0",
       "rng": {
         "draws": 49,
         "digest": "1d1c5dad"
@@ -1644,7 +1644,7 @@
       "tick": 10,
       "time": 0.5,
       "nextId": 416,
-      "state": "8a1df92c",
+      "state": "a1b6a2c8",
       "events": "741638a5",
       "rng": {
         "draws": 49,
@@ -1655,7 +1655,7 @@
       "tick": 15,
       "time": 0.75,
       "nextId": 416,
-      "state": "f92b727a",
+      "state": "c4198506",
       "events": "741638a5",
       "rng": {
         "draws": 49,
@@ -1666,7 +1666,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 416,
-      "state": "05459bf7",
+      "state": "98937093",
       "events": "14a3ffd8",
       "rng": {
         "draws": 49,
@@ -1677,7 +1677,7 @@
       "tick": 24,
       "time": 1.2,
       "nextId": 416,
-      "state": "e32c4147",
+      "state": "084ca8e3",
       "events": "741638a5",
       "rng": {
         "draws": 49,
@@ -1698,7 +1698,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 163124,
+            "damageTaken": 175396,
             "deaths": 1
           },
           "craftSkills": {},
@@ -1736,7 +1736,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 163124,
+            "damageTaken": 175396,
             "deaths": 1
           },
           "craftSkills": {},
@@ -1872,7 +1872,7 @@
       "tick": 24,
       "time": 1.2,
       "nextId": 416,
-      "state": "e32c4147",
+      "state": "084ca8e3",
       "events": "741638a5",
       "rng": {
         "draws": 49,
@@ -1893,7 +1893,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 163124,
+            "damageTaken": 175396,
             "deaths": 1
           },
           "craftSkills": {},
@@ -1931,7 +1931,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 163124,
+            "damageTaken": 175396,
             "deaths": 1
           },
           "craftSkills": {},

--- a/tests/parity/golden/fiesta_powerups.json
+++ b/tests/parity/golden/fiesta_powerups.json
@@ -513,7 +513,7 @@
       "tick": 450,
       "time": 22.5,
       "nextId": 404,
-      "state": "9e9c0e16",
+      "state": "52edb60f",
       "events": "a781f735",
       "rng": {
         "draws": 2073,
@@ -524,7 +524,7 @@
       "tick": 460,
       "time": 23,
       "nextId": 404,
-      "state": "0407a76d",
+      "state": "9a252b85",
       "events": "c549fdfe",
       "rng": {
         "draws": 2113,
@@ -535,7 +535,7 @@
       "tick": 470,
       "time": 23.5,
       "nextId": 404,
-      "state": "6a187c7a",
+      "state": "835d1ec9",
       "events": "6505e636",
       "rng": {
         "draws": 2165,
@@ -546,7 +546,7 @@
       "tick": 480,
       "time": 24,
       "nextId": 404,
-      "state": "b575b95d",
+      "state": "1054aa89",
       "events": "5cffe15c",
       "rng": {
         "draws": 2216,
@@ -557,7 +557,7 @@
       "tick": 490,
       "time": 24.5,
       "nextId": 404,
-      "state": "7ca14b88",
+      "state": "b7dac15c",
       "events": "5cffe15c",
       "rng": {
         "draws": 2251,
@@ -568,8 +568,8 @@
       "tick": 500,
       "time": 25,
       "nextId": 404,
-      "state": "806ebf0f",
-      "events": "fe086691",
+      "state": "3440d738",
+      "events": "ab9eb854",
       "rng": {
         "draws": 2301,
         "digest": "2e012f5a"
@@ -579,7 +579,7 @@
       "tick": 510,
       "time": 25.5,
       "nextId": 404,
-      "state": "2a8f8437",
+      "state": "5ddc57e0",
       "events": "c393471c",
       "rng": {
         "draws": 2357,
@@ -590,7 +590,7 @@
       "tick": 520,
       "time": 26,
       "nextId": 404,
-      "state": "60a9726b",
+      "state": "7904bbc4",
       "events": "c393471c",
       "rng": {
         "draws": 2394,
@@ -601,7 +601,7 @@
       "tick": 530,
       "time": 26.5,
       "nextId": 404,
-      "state": "bbfdcced",
+      "state": "a203678a",
       "events": "c68a3c57",
       "rng": {
         "draws": 2452,
@@ -612,7 +612,7 @@
       "tick": 540,
       "time": 27,
       "nextId": 404,
-      "state": "b2654f21",
+      "state": "b6559cbe",
       "events": "f243e63e",
       "rng": {
         "draws": 2493,
@@ -623,7 +623,7 @@
       "tick": 550,
       "time": 27.5,
       "nextId": 404,
-      "state": "26a06c77",
+      "state": "8c11ba20",
       "events": "f243e63e",
       "rng": {
         "draws": 2551,
@@ -634,7 +634,7 @@
       "tick": 560,
       "time": 28,
       "nextId": 404,
-      "state": "984d25d1",
+      "state": "7f74d56e",
       "events": "b810548b",
       "rng": {
         "draws": 2601,
@@ -645,7 +645,7 @@
       "tick": 570,
       "time": 28.5,
       "nextId": 404,
-      "state": "af3afa33",
+      "state": "9dba9cec",
       "events": "c549fdfe",
       "rng": {
         "draws": 2652,
@@ -656,7 +656,7 @@
       "tick": 573,
       "time": 28.65,
       "nextId": 404,
-      "state": "485afaf7",
+      "state": "adcc48a0",
       "events": "741638a5",
       "rng": {
         "draws": 2662,
@@ -677,7 +677,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageTaken": 2678,
+            "damageTaken": 2659,
             "deaths": 1,
             "kills": 1
           },

--- a/tests/parity/golden/mob_lifecycle.json
+++ b/tests/parity/golden/mob_lifecycle.json
@@ -1144,7 +1144,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 408,
-      "state": "e5bfcde6",
+      "state": "83f9f08e",
       "events": "70ed87d1",
       "rng": {
         "draws": 15,
@@ -1535,7 +1535,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 54.410541,
+          "fallStartY": 56.398681,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 96,
@@ -1550,14 +1550,14 @@
           "petMode": "defensive",
           "pos": {
             "x": 300,
-            "y": 54.410541,
+            "y": 56.398681,
             "z": 300
           },
           "potionCooldownUntil": -1,
           "respawnTimer": -0.05,
           "spawnPos": {
             "x": 300,
-            "y": 54.410541,
+            "y": 56.398681,
             "z": 300
           },
           "stats": {
@@ -1577,7 +1577,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 409,
-      "state": "64bf5ed5",
+      "state": "727f293d",
       "events": "d9e22721",
       "rng": {
         "draws": 20,
@@ -1968,7 +1968,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 54.410541,
+          "fallStartY": 56.398681,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 96,
@@ -1983,14 +1983,14 @@
           "petMode": "defensive",
           "pos": {
             "x": 300,
-            "y": 54.410541,
+            "y": 56.398681,
             "z": 300
           },
           "potionCooldownUntil": -1,
           "respawnTimer": -0.05,
           "spawnPos": {
             "x": 300,
-            "y": 54.410541,
+            "y": 56.398681,
             "z": 300
           },
           "stats": {
@@ -2012,7 +2012,7 @@
           "dead": true,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 56.399945,
+          "fallStartY": 50.723014,
           "fiveSecondRule": 99,
           "hostile": true,
           "id": 408,
@@ -2020,7 +2020,7 @@
           "kind": "mob",
           "leashAnchor": {
             "x": 700,
-            "y": 56.399945,
+            "y": 50.723014,
             "z": 300
           },
           "level": 5,
@@ -2044,14 +2044,14 @@
           "petMode": "defensive",
           "pos": {
             "x": 700,
-            "y": 56.399945,
+            "y": 50.723014,
             "z": 300
           },
           "potionCooldownUntil": -1,
           "respawnTimer": -0.05,
           "spawnPos": {
             "x": 700,
-            "y": 56.399945,
+            "y": 50.723014,
             "z": 300
           },
           "stats": {
@@ -2071,7 +2071,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 409,
-      "state": "64bf5ed5",
+      "state": "727f293d",
       "events": "741638a5",
       "rng": {
         "draws": 20,
@@ -2462,7 +2462,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 54.410541,
+          "fallStartY": 56.398681,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 96,
@@ -2477,14 +2477,14 @@
           "petMode": "defensive",
           "pos": {
             "x": 300,
-            "y": 54.410541,
+            "y": 56.398681,
             "z": 300
           },
           "potionCooldownUntil": -1,
           "respawnTimer": -0.05,
           "spawnPos": {
             "x": 300,
-            "y": 54.410541,
+            "y": 56.398681,
             "z": 300
           },
           "stats": {
@@ -2506,7 +2506,7 @@
           "dead": true,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 56.399945,
+          "fallStartY": 50.723014,
           "fiveSecondRule": 99,
           "hostile": true,
           "id": 408,
@@ -2514,7 +2514,7 @@
           "kind": "mob",
           "leashAnchor": {
             "x": 700,
-            "y": 56.399945,
+            "y": 50.723014,
             "z": 300
           },
           "level": 5,
@@ -2538,14 +2538,14 @@
           "petMode": "defensive",
           "pos": {
             "x": 700,
-            "y": 56.399945,
+            "y": 50.723014,
             "z": 300
           },
           "potionCooldownUntil": -1,
           "respawnTimer": -0.05,
           "spawnPos": {
             "x": 700,
-            "y": 56.399945,
+            "y": 50.723014,
             "z": 300
           },
           "stats": {

--- a/tests/parity/golden/mob_locomotion.json
+++ b/tests/parity/golden/mob_locomotion.json
@@ -642,7 +642,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 405,
-      "state": "094615e5",
+      "state": "779aeeac",
       "events": "741638a5",
       "rng": {
         "draws": 15,
@@ -903,7 +903,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -0.226092,
-          "fallStartY": 58.188532,
+          "fallStartY": 56.243337,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 96,
@@ -918,13 +918,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 299.968616,
-            "y": 58.180156,
+            "y": 56.237153,
             "z": 300.136437
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 300,
-            "y": 58.188532,
+            "y": 56.243337,
             "z": 300
           },
           "stats": {
@@ -933,7 +933,7 @@
           "templateId": "forest_wolf",
           "wanderTarget": {
             "x": 298.918529,
-            "y": 57.734603,
+            "y": 54.992634,
             "z": 304.70153
           },
           "wanderTimer": 30,
@@ -949,7 +949,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 406,
-      "state": "583c8992",
+      "state": "5c093e22",
       "events": "741638a5",
       "rng": {
         "draws": 16,
@@ -1210,7 +1210,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -0.226092,
-          "fallStartY": 58.188532,
+          "fallStartY": 56.243337,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 96,
@@ -1225,13 +1225,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 299.968616,
-            "y": 58.180156,
+            "y": 56.237153,
             "z": 300.136437
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 300,
-            "y": 58.188532,
+            "y": 56.243337,
             "z": 300
           },
           "stats": {
@@ -1240,7 +1240,7 @@
           "templateId": "forest_wolf",
           "wanderTarget": {
             "x": 298.918529,
-            "y": 57.734603,
+            "y": 54.992634,
             "z": 304.70153
           },
           "wanderTimer": 30,
@@ -1257,7 +1257,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 57.211832,
+          "fallStartY": 58.140895,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 96,
@@ -1272,13 +1272,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 320,
-            "y": 57.211832,
+            "y": 58.140895,
             "z": 320
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 320,
-            "y": 57.211832,
+            "y": 58.140895,
             "z": 320
           },
           "stats": {
@@ -1298,7 +1298,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 407,
-      "state": "e9a426a0",
+      "state": "51cec820",
       "events": "89e78911",
       "rng": {
         "draws": 16,
@@ -1559,7 +1559,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -0.226092,
-          "fallStartY": 58.188532,
+          "fallStartY": 56.243337,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 96,
@@ -1574,13 +1574,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 299.968616,
-            "y": 58.180156,
+            "y": 56.237153,
             "z": 300.136437
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 300,
-            "y": 58.188532,
+            "y": 56.243337,
             "z": 300
           },
           "stats": {
@@ -1589,7 +1589,7 @@
           "templateId": "forest_wolf",
           "wanderTarget": {
             "x": 298.918529,
-            "y": 57.734603,
+            "y": 54.992634,
             "z": 304.70153
           },
           "wanderTimer": 30,
@@ -1606,7 +1606,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 57.211832,
+          "fallStartY": 58.140895,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 96,
@@ -1621,13 +1621,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 320,
-            "y": 57.211832,
+            "y": 58.140895,
             "z": 320
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 320,
-            "y": 57.211832,
+            "y": 58.140895,
             "z": 320
           },
           "stats": {
@@ -1692,7 +1692,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 407,
-      "state": "fd5bb20f",
+      "state": "cf3baf8f",
       "events": "741638a5",
       "rng": {
         "draws": 16,
@@ -1953,7 +1953,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -0.226092,
-          "fallStartY": 58.188532,
+          "fallStartY": 56.243337,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 96,
@@ -1968,13 +1968,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 299.968616,
-            "y": 58.180156,
+            "y": 56.237153,
             "z": 300.136437
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 300,
-            "y": 58.188532,
+            "y": 56.243337,
             "z": 300
           },
           "stats": {
@@ -1983,7 +1983,7 @@
           "templateId": "forest_wolf",
           "wanderTarget": {
             "x": 298.918529,
-            "y": 57.734603,
+            "y": 54.992634,
             "z": 304.70153
           },
           "wanderTimer": 30,
@@ -2000,7 +2000,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 57.211832,
+          "fallStartY": 58.140895,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 96,
@@ -2015,13 +2015,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 320,
-            "y": 57.211832,
+            "y": 58.140895,
             "z": 320
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 320,
-            "y": 57.211832,
+            "y": 58.140895,
             "z": 320
           },
           "stats": {
@@ -2087,7 +2087,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 407,
-      "state": "fd5bb20f",
+      "state": "cf3baf8f",
       "events": "741638a5",
       "rng": {
         "draws": 16,
@@ -2348,7 +2348,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -0.226092,
-          "fallStartY": 58.188532,
+          "fallStartY": 56.243337,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 96,
@@ -2363,13 +2363,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 299.968616,
-            "y": 58.180156,
+            "y": 56.237153,
             "z": 300.136437
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 300,
-            "y": 58.188532,
+            "y": 56.243337,
             "z": 300
           },
           "stats": {
@@ -2378,7 +2378,7 @@
           "templateId": "forest_wolf",
           "wanderTarget": {
             "x": 298.918529,
-            "y": 57.734603,
+            "y": 54.992634,
             "z": 304.70153
           },
           "wanderTimer": 30,
@@ -2395,7 +2395,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
-          "fallStartY": 57.211832,
+          "fallStartY": 58.140895,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 96,
@@ -2410,13 +2410,13 @@
           "petMode": "defensive",
           "pos": {
             "x": 320,
-            "y": 57.211832,
+            "y": 58.140895,
             "z": 320
           },
           "potionCooldownUntil": -1,
           "spawnPos": {
             "x": 320,
-            "y": 57.211832,
+            "y": 58.140895,
             "z": 320
           },
           "stats": {

--- a/tests/parity/golden/pet_ai.json
+++ b/tests/parity/golden/pet_ai.json
@@ -190,7 +190,7 @@
       "tick": 120,
       "time": 6,
       "nextId": 405,
-      "state": "b6d13ad8",
+      "state": "a487e3aa",
       "events": "741638a5",
       "rng": {
         "draws": 418,
@@ -350,7 +350,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -1.713587,
-          "fallStartY": 52.026485,
+          "fallStartY": 54.870727,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 49946,
@@ -371,7 +371,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 202,
-            "y": 52.026485,
+            "y": 54.870727,
             "z": -2
           },
           "potionCooldownUntil": -1,
@@ -458,7 +458,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": 1.570796,
-          "fallStartY": 54.397438,
+          "fallStartY": 52.748011,
           "fiveSecondRule": 99,
           "forcedTargetTimer": -0.05,
           "hostile": true,
@@ -480,7 +480,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 202,
-            "y": 54.397438,
+            "y": 52.748011,
             "z": 18
           },
           "potionCooldownUntil": -1,
@@ -518,7 +518,7 @@
       "tick": 140,
       "time": 7,
       "nextId": 405,
-      "state": "07e5a5c1",
+      "state": "bd56bc16",
       "events": "741638a5",
       "rng": {
         "draws": 518,
@@ -529,7 +529,7 @@
       "tick": 160,
       "time": 8,
       "nextId": 405,
-      "state": "647a28bd",
+      "state": "95aedcf7",
       "events": "741638a5",
       "rng": {
         "draws": 637,
@@ -540,7 +540,7 @@
       "tick": 180,
       "time": 9,
       "nextId": 405,
-      "state": "00495b18",
+      "state": "1e261a1a",
       "events": "741638a5",
       "rng": {
         "draws": 777,
@@ -551,7 +551,7 @@
       "tick": 180,
       "time": 9,
       "nextId": 405,
-      "state": "00495b18",
+      "state": "1e261a1a",
       "events": "741638a5",
       "rng": {
         "draws": 777,
@@ -707,7 +707,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -1.570796,
-          "fallStartY": 52.026485,
+          "fallStartY": 54.870727,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 49946,
@@ -723,7 +723,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 164.88,
-            "y": 39.746386,
+            "y": 42.627935,
             "z": -2
           },
           "potionCooldownUntil": -1,
@@ -807,7 +807,7 @@
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": -1.665748,
-          "fallStartY": 54.397438,
+          "fallStartY": 52.748011,
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 49940,
@@ -823,7 +823,7 @@
           "petMode": "defensive",
           "pos": {
             "x": 165.047208,
-            "y": 40.034879,
+            "y": 39.484433,
             "z": 14.480686
           },
           "potionCooldownUntil": -1,


### PR DESCRIPTION
## Summary

More realistic mountains and more distinct biome ground palettes, purely in the
render layer (no gameplay/collision change beyond the heightfield's own noise,
which is still deterministic and covered by the existing terrain tests).

- **Jagged ridges and rim wall.** The inter-zone ridge walls and the world-rim
  wall (`src/sim/world.ts`) get a two-layer jagged crest (coarse peak/saddle +
  fine crag) instead of a perfectly smooth berm, so mountains read as real
  terrain instead of a rounded wall. Combined noise variance is kept small so
  the climb-limit invariant (`tests/terrain_walls.test.ts`) still holds.
- **Tighter wilderness LOD** (`src/render/terrain.ts`) so the extra height
  detail actually resolves into visible geometry instead of getting smoothed
  away by coarse vertex spacing.
- **Striated rock and patchy snow**: noise breaks up what was previously a flat
  rock/snow color blend, plus a finer fracture pass on the procedural rock
  texture (`src/render/textures.ts`).
- **Atmospheric rim haze**: `BIOME_FOG` near/far trimmed and the rim haze blend
  strengthened, so a zone's own mountains fade into haze before they can be
  seen crisply from the zone's hub (`src/render/renderer.ts`).
- **More distinct biome palettes**: widened the ground-color contrast between
  vale/marsh/peaks and the paint-only beach/desert/volcano/cave biomes (marsh
  darker and murkier, peaks cooler and greyer, desert warmer than beach,
  volcano red-ash vs cave neutral grey) so each biome reads as visually
  distinct rather than variations on the same green.
- **Organic ground noise**: replaced the old pure-sine grass patchiness (which
  repeats on a visible grid at a distance) with fbm noise.
- **Per-biome shoreline blend**: previously every biome faded to the same sand
  color at the waterline. Marsh now blends to mud (no sandy beach), and
  peaks/volcano/cave blend to a dark wet-rock tint instead of sand.

Parity goldens regenerated: entity fall height/position near the world rim
shifts by a few units from the jagged rim crest and the tighter LOD spacing;
no other sim behavior changes.

```mermaid
flowchart TD
    A["sim/world.ts terrainHeight()"] -->|"jagged ridge + rim crest (fbm2 noise)"| B["heightfield (shared by sim + render)"]
    B --> C["render/terrain.ts sampleVertex()"]
    D["BIOME_PALETTE per-biome colors"] --> C
    E["fbm2 grass/rock/snow noise"] --> C
    F["per-biome shoreline blend\n(marsh->mud, peaks/volcano/cave->wet-rock)"] --> C
    C --> G["vertex color + splat weights"]
    G --> H["render/textures.ts splat maps\n(+ finer rock fracture pass)"]
    H --> I["render/renderer.ts BIOME_FOG\n(trimmed draw distance + rim haze)"]
    I --> J["final frame: jagged, hazy mountains\ndistinct biome ground colors"]
```

## Before / after

| | Before | After |
|---|---|---|
| Ridge close-up (Eastbrook Vale pass) | ![before](https://cdn.jsdelivr.net/gh/jgyy/world-of-claudecraft@pr-assets-realistic-mountains/mountains-before-ridge-closeup.png) | ![after](https://cdn.jsdelivr.net/gh/jgyy/world-of-claudecraft@pr-assets-realistic-mountains/mountains-after-ridge-closeup.png) |
| Vale hub | ![before](https://cdn.jsdelivr.net/gh/jgyy/world-of-claudecraft@pr-assets-realistic-mountains/mountains-before-vale-hub.png) | ![after](https://cdn.jsdelivr.net/gh/jgyy/world-of-claudecraft@pr-assets-realistic-mountains/mountains-after-vale-hub.png) |
| Marsh hub | ![before](https://cdn.jsdelivr.net/gh/jgyy/world-of-claudecraft@pr-assets-realistic-mountains/mountains-before-marsh-hub.png) | ![after](https://cdn.jsdelivr.net/gh/jgyy/world-of-claudecraft@pr-assets-realistic-mountains/mountains-after-marsh-hub.png) |
| Peaks hub | ![before](https://cdn.jsdelivr.net/gh/jgyy/world-of-claudecraft@pr-assets-realistic-mountains/mountains-before-peaks-hub.png) | ![after](https://cdn.jsdelivr.net/gh/jgyy/world-of-claudecraft@pr-assets-realistic-mountains/mountains-after-peaks-hub.png) |
| Rim close-up | ![before](https://cdn.jsdelivr.net/gh/jgyy/world-of-claudecraft@pr-assets-realistic-mountains/mountains-before-rim-closeup.png) | ![after](https://cdn.jsdelivr.net/gh/jgyy/world-of-claudecraft@pr-assets-realistic-mountains/mountains-after-rim-closeup.png) |

Captured with the new `scripts/mountain_realism_shot.mjs` tour script (teleports
to each zone hub plus two mountain vantage points, hides HUD chrome, screenshots).

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx @biomejs/biome check` on every changed file (0 errors; pre-existing
      `noNonNullAssertion` warnings only, which do not fail CI)
- [x] `npx vitest run tests/terrain_walls.test.ts tests/architecture.test.ts tests/parity` (all green)
- [x] `npm run build` (clean)
- [x] Branch is based on `upstream/release/v0.22.0` HEAD (latest release), so no
      merge conflicts expected
- [x] Visual verification via before/after screenshot tour (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
