### PR TITLE
fix(character-select): improve responsive layout and readability

### DIFF
--- a/src/game/app_viewport.ts
+++ b/src/game/app_viewport.ts
@@ -9,18 +9,16 @@ export function syncAppViewport(win: Window = window): void {
   const doc = win.document;
   const useStableGameViewport =
     doc.body.classList.contains('game-active') && useTouchInterface(win);
-  const width = Math.max(
-    1,
-    Math.round(
-      useStableGameViewport ? win.innerWidth : (win.visualViewport?.width ?? win.innerWidth),
-    ),
-  );
-  const height = Math.max(
-    1,
-    Math.round(
-      useStableGameViewport ? win.innerHeight : (win.visualViewport?.height ?? win.innerHeight),
-    ),
-  );
+  const visualScale = win.visualViewport?.scale ?? 1;
+  // visualViewport dimensions are expressed inside the current page scale.
+  // Normalize them back to layout CSS pixels before writing html/body's fixed
+  // dimensions. Without this, a landscape-to-portrait rotation can feed the
+  // landscape width back into --app-vw while the browser zooms the page down,
+  // permanently trapping the portrait layout at the landscape scale.
+  const visualWidth = (win.visualViewport?.width ?? win.innerWidth) * visualScale;
+  const visualHeight = (win.visualViewport?.height ?? win.innerHeight) * visualScale;
+  const width = Math.max(1, Math.round(useStableGameViewport ? win.innerWidth : visualWidth));
+  const height = Math.max(1, Math.round(useStableGameViewport ? win.innerHeight : visualHeight));
   doc.documentElement.style.setProperty('--app-vw', `${width}px`);
   doc.documentElement.style.setProperty('--app-vh', `${height}px`);
 }

--- a/src/render/characters/preview.ts
+++ b/src/render/characters/preview.ts
@@ -16,6 +16,8 @@ const PREVIEW_ANIM_STATE = {
   sitting: false,
 };
 
+const LIVE_PREVIEW_X = 0;
+
 export class CharacterPreview {
   private container: HTMLElement;
   private canvas: HTMLCanvasElement;
@@ -62,8 +64,8 @@ export class CharacterPreview {
         ? this.container.clientWidth / this.container.clientHeight
         : 1;
     this.camera = new THREE.PerspectiveCamera(45, aspect, 0.1, 100);
-    this.camera.position.set(-0.15, 1.45, 5.1);
-    this.camera.lookAt(new THREE.Vector3(-0.15, 1.3, 0));
+    this.camera.position.set(LIVE_PREVIEW_X, 1.45, 5.1);
+    this.camera.lookAt(new THREE.Vector3(LIVE_PREVIEW_X, 1.3, 0));
 
     // 4. Initialize Character Group
     this.characterGroup = new THREE.Group();
@@ -312,7 +314,7 @@ export class CharacterPreview {
     this.renderer.setSize(prevSize.x, prevSize.y, false);
     this.camera.aspect = prevAspect;
     this.camera.position.copy(prevPos);
-    this.camera.lookAt(new THREE.Vector3(-0.15, 1.3, 0));
+    this.camera.lookAt(new THREE.Vector3(LIVE_PREVIEW_X, 1.3, 0));
     this.camera.updateProjectionMatrix();
     this.characterGroup.rotation.y = prevRotY;
     this.renderer.render(this.scene, this.camera);

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -2552,7 +2552,11 @@
      name floats top-center, and the actions sit in the corners. On the
      roster (#charselect-panel) the character list docks right instead, WoW
      style, and the summary docks left. All the ids / buttons / rows stay
-     untouched, so the main.ts wiring is unchanged. */
+     untouched, so the main.ts wiring is unchanged.
+     Intentionally starts before the shared 900px card foundation: this
+     takeover restates the sizing and inner grids required throughout the
+     861px to 899px range.
+     */
   @media (min-width: 861px) {
     #offline-select.cs-wow,
     body:not(.mobile-touch) :is(#charselect-panel, #charcreate-panel).cs-wow {

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -2540,7 +2540,7 @@
   }
 
   /* WoW-style full-screen character screens (the offline panel plus the two
-     online panels carry the cs-wow class). Desktop only: below 900px the
+     online panels carry the cs-wow class). Desktop only: below 861px the
      classic card layout above stays, and the ONLINE panels additionally keep
      their card layout on touch bodies (the body.mobile-touch blocks below own
      that styling), hence the body:not(.mobile-touch) prefix on their arms.
@@ -2553,7 +2553,7 @@
      roster (#charselect-panel) the character list docks right instead, WoW
      style, and the summary docks left. All the ids / buttons / rows stay
      untouched, so the main.ts wiring is unchanged. */
-  @media (min-width: 900px) {
+  @media (min-width: 861px) {
     #offline-select.cs-wow,
     body:not(.mobile-touch) :is(#charselect-panel, #charcreate-panel).cs-wow {
       position: fixed;
@@ -2587,6 +2587,10 @@
       display: block;
     }
     body:not(.mobile-touch) #charselect-panel.cs-wow {
+      --cs-stage-gutter: max(26px, calc((100vw - 1780px) / 2));
+      --cs-roster-width: clamp(340px, 28vw, 440px);
+      --cs-details-width: var(--cs-roster-width);
+      --cs-dock-bottom: clamp(18px, 6.5vh, 96px);
       display: flex;
       flex-direction: column;
     }
@@ -2937,10 +2941,10 @@
     }
     body:not(.mobile-touch) #charselect-panel.cs-wow .cs-list-col {
       position: absolute;
-      right: 26px;
+      right: var(--cs-stage-gutter);
       top: 18px;
-      bottom: 96px;
-      width: 340px;
+      bottom: var(--cs-dock-bottom);
+      width: var(--cs-roster-width);
       /* The card layout gives the column height:100%; the dock stretches via
          top/bottom instead. */
       height: auto;
@@ -2964,16 +2968,86 @@
     }
     body:not(.mobile-touch) #charselect-panel.cs-wow .class-details-panel {
       position: absolute;
-      left: 26px;
+      left: var(--cs-stage-gutter);
       top: 18px;
-      bottom: 96px;
-      width: 340px;
+      bottom: var(--cs-dock-bottom);
+      width: var(--cs-details-width);
       overflow-y: auto;
+      scrollbar-width: thin;
+      scrollbar-color: color-mix(in srgb, var(--scrollbar-thumb) 42%, transparent) transparent;
       background: #0d0d16d9;
       border: 1px solid var(--color-border-default);
       border-radius: var(--radius-md);
       padding: 14px;
       z-index: 2;
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow .class-details-panel::-webkit-scrollbar {
+      width: 6px;
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow .class-details-panel::-webkit-scrollbar-track {
+      background: transparent;
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow .class-details-panel::-webkit-scrollbar-thumb {
+      background: color-mix(in srgb, var(--scrollbar-thumb) 42%, transparent);
+      border: 0;
+      border-radius: 999px;
+    }
+    body:not(.mobile-touch)
+      #charselect-panel.cs-wow
+      .class-details-panel::-webkit-scrollbar-thumb:hover {
+      background: color-mix(in srgb, var(--scrollbar-thumb) 68%, transparent);
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow #char-list .char-row {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      column-gap: 12px;
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow #char-list .char-name {
+      overflow-wrap: anywhere;
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow #char-list .char-actions {
+      display: grid;
+      grid-template-columns: minmax(112px, 1fr);
+      gap: 6px;
+      align-items: stretch;
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow #char-list .char-actions .btn {
+      width: 100%;
+      white-space: nowrap;
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow .class-details-grid {
+      grid-template-columns: minmax(0, 1fr);
+      gap: clamp(18px, 2vh, 28px);
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow .details-spells-section {
+      grid-column: 1;
+      padding-top: clamp(6px, 1vh, 12px);
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow .details-gear-row {
+      display: grid;
+      grid-template-columns: clamp(76px, 5vw, 92px) minmax(0, 1fr);
+      align-items: baseline;
+      gap: 12px;
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow .details-gear-row .badge {
+      padding: 0;
+      border: 0;
+      border-radius: 0;
+      background: none;
+      text-transform: none;
+      line-height: 1.45;
+      white-space: normal;
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow .details-gear-row .badge-resource::before {
+      content: "";
+      display: inline-block;
+      width: 7px;
+      height: 7px;
+      margin-right: 7px;
+      border-radius: 50%;
+      background: currentColor;
+      box-shadow: 0 0 7px currentColor;
+      vertical-align: 1px;
     }
 
     /* The class summary's base type is sized for the small pre-game card
@@ -2981,35 +3055,35 @@
        whole details sheet up one step in every cs-wow panel. */
     #offline-select.cs-wow .class-details-panel,
     body:not(.mobile-touch) :is(#charselect-panel, #charcreate-panel).cs-wow .class-details-panel {
-      font-size: 13px;
+      font-size: clamp(13px, 0.72vw, 15px);
     }
     #offline-select.cs-wow .class-details-name,
     body:not(.mobile-touch) :is(#charselect-panel, #charcreate-panel).cs-wow .class-details-name {
-      font-size: 24px;
+      font-size: clamp(24px, 1.35vw, 30px);
     }
     #offline-select.cs-wow .class-details-role,
     body:not(.mobile-touch) :is(#charselect-panel, #charcreate-panel).cs-wow .class-details-role {
-      font-size: 13px;
+      font-size: clamp(13px, 0.7vw, 15px);
     }
     #offline-select.cs-wow .class-details-lore,
     body:not(.mobile-touch) :is(#charselect-panel, #charcreate-panel).cs-wow .class-details-lore {
-      font-size: 14px;
+      font-size: clamp(14px, 0.78vw, 16px);
       line-height: 1.55;
     }
     #offline-select.cs-wow .details-section-title,
     body:not(.mobile-touch)
       :is(#charselect-panel, #charcreate-panel).cs-wow
       .details-section-title {
-      font-size: 14px;
+      font-size: clamp(14px, 0.75vw, 16px);
     }
     #offline-select.cs-wow .details-stat-bar-row,
     body:not(.mobile-touch) :is(#charselect-panel, #charcreate-panel).cs-wow .details-stat-bar-row {
-      font-size: 13px;
+      font-size: clamp(13px, 0.7vw, 15px);
       margin-bottom: 8px;
     }
     #offline-select.cs-wow .details-stat-label,
     body:not(.mobile-touch) :is(#charselect-panel, #charcreate-panel).cs-wow .details-stat-label {
-      width: 76px;
+      width: clamp(76px, 5vw, 92px);
     }
     #offline-select.cs-wow .details-stat-val,
     body:not(.mobile-touch) :is(#charselect-panel, #charcreate-panel).cs-wow .details-stat-val {
@@ -3017,7 +3091,7 @@
     }
     #offline-select.cs-wow .details-gear-row,
     body:not(.mobile-touch) :is(#charselect-panel, #charcreate-panel).cs-wow .details-gear-row {
-      font-size: 13px;
+      font-size: clamp(13px, 0.7vw, 15px);
     }
     #offline-select.cs-wow .badge,
     body:not(.mobile-touch) :is(#charselect-panel, #charcreate-panel).cs-wow .badge {
@@ -3025,14 +3099,14 @@
     }
     #offline-select.cs-wow .details-spell-item,
     body:not(.mobile-touch) :is(#charselect-panel, #charcreate-panel).cs-wow .details-spell-item {
-      font-size: 13px;
+      font-size: clamp(13px, 0.68vw, 15px);
     }
     #offline-select.cs-wow .details-spell-text strong,
     body:not(.mobile-touch)
       :is(#charselect-panel, #charcreate-panel).cs-wow
       .details-spell-text
       strong {
-      font-size: 13px;
+      font-size: clamp(13px, 0.68vw, 15px);
     }
     #offline-select.cs-wow .details-spell-icon-img,
     body:not(.mobile-touch)

--- a/tests/app_viewport.test.ts
+++ b/tests/app_viewport.test.ts
@@ -4,7 +4,7 @@ import { syncAppViewport } from '../src/game/app_viewport';
 interface FakeWin {
   innerWidth: number;
   innerHeight: number;
-  visualViewport: { width: number; height: number } | undefined;
+  visualViewport: { width: number; height: number; scale?: number } | undefined;
   matchMedia: (query: string) => { matches: boolean };
   document: {
     body: { classList: { contains: (c: string) => boolean } };
@@ -15,7 +15,7 @@ interface FakeWin {
 function fakeWin(opts: {
   innerWidth: number;
   innerHeight: number;
-  visualViewport?: { width: number; height: number };
+  visualViewport?: { width: number; height: number; scale?: number };
   gameActive?: boolean;
   touch?: boolean;
 }): { win: FakeWin; props: Record<string, string> } {
@@ -71,6 +71,18 @@ describe('syncAppViewport', () => {
     syncAppViewport(win as unknown as Window);
     expect(props['--app-vw']).toBe('1194px');
     expect(props['--app-vh']).toBe('905px');
+  });
+
+  it('normalizes a stale scaled visual viewport after a landscape-to-portrait rotation', () => {
+    const { win, props } = fakeWin({
+      innerWidth: 844,
+      innerHeight: 1827,
+      visualViewport: { width: 844, height: 1827, scale: 390 / 844 },
+      touch: true,
+    });
+    syncAppViewport(win as unknown as Window);
+    expect(props['--app-vw']).toBe('390px');
+    expect(props['--app-vh']).toBe('844px');
   });
 
   it('rounds fractional visualViewport dimensions and floors at 1px', () => {

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -676,6 +676,42 @@ describe('client HTML shell', () => {
     expect(characterPreviewTs).toContain('this.renderer.dispose();');
   });
 
+  it('keeps the desktop character roster readable inside a centered cinematic stage', () => {
+    expect(shellCss).toContain('--cs-stage-gutter: max(26px, calc((100vw - 1780px) / 2));');
+    expect(shellCss).toContain('--cs-roster-width: clamp(340px, 28vw, 440px);');
+    expect(shellCss).toContain('--cs-details-width: var(--cs-roster-width);');
+    expect(shellCss).toContain(
+      '@media (min-width: 861px) {\n    #offline-select.cs-wow,\n    body:not(.mobile-touch) :is(#charselect-panel, #charcreate-panel).cs-wow {',
+    );
+    expect(shellCss).toContain(
+      'body:not(.mobile-touch) #charselect-panel.cs-wow #char-list .char-row {\n      display: grid;\n      grid-template-columns: auto minmax(0, 1fr) auto;',
+    );
+    expect(shellCss).toContain(
+      'body:not(.mobile-touch) #charselect-panel.cs-wow #char-list .char-actions {\n      display: grid;\n      grid-template-columns: minmax(112px, 1fr);',
+    );
+    expect(shellCss).toContain(
+      'body:not(.mobile-touch) #charselect-panel.cs-wow #char-list .char-name {\n      overflow-wrap: anywhere;',
+    );
+    expect(shellCss).toContain(
+      'body:not(.mobile-touch) #charselect-panel.cs-wow .class-details-grid {\n      grid-template-columns: minmax(0, 1fr);',
+    );
+    expect(shellCss).toContain(
+      'overflow-y: auto;\n      scrollbar-width: thin;\n      scrollbar-color: color-mix(in srgb, var(--scrollbar-thumb) 42%, transparent) transparent;',
+    );
+    expect(shellCss).toContain(
+      'body:not(.mobile-touch) #charselect-panel.cs-wow .class-details-panel::-webkit-scrollbar {\n      width: 6px;',
+    );
+    expect(shellCss).toContain(
+      'body:not(.mobile-touch) #charselect-panel.cs-wow .details-gear-row .badge {\n      padding: 0;\n      border: 0;\n      border-radius: 0;\n      background: none;\n      text-transform: none;',
+    );
+    expect(shellCss).toContain('font-size: clamp(13px, 0.72vw, 15px);');
+    expect(characterPreviewTs).toContain('const LIVE_PREVIEW_X = 0;');
+    expect(characterPreviewTs).toContain('this.camera.position.set(LIVE_PREVIEW_X, 1.45, 5.1);');
+    expect(characterPreviewTs).toContain(
+      'this.camera.lookAt(new THREE.Vector3(LIVE_PREVIEW_X, 1.3, 0));',
+    );
+  });
+
   it('offers the quest log in the mobile controls drawer', () => {
     expect(html).toContain('id="mobile-extra-controls"');
     expect(html).toContain('id="mobile-quest"');


### PR DESCRIPTION
## Summary

The character selection screen did not scale cleanly across desktop and mobile viewports. Wide displays left excessive empty space around the character, long names were squeezed by the action buttons, and the class details panel was difficult to read. On phones, rotating from portrait to landscape and back could also leave the page zoomed to the stale landscape width.

This PR:

- centers the character preview and balances both side panels;
- scales panel widths, spacing, and typography across desktop resolutions;
- gives character names more room and stacks row actions vertically;
- reorganizes starting stats and equipment into readable full-width sections;
- replaces equipment badges with a simpler typographic presentation;
- adds a subtle scrollbar for overflowing class details;
- extends the cinematic desktop layout down to 861px while preserving the touch layout;
- normalizes `visualViewport` dimensions by its scale so portrait layout is restored after rotating a phone back from landscape;
- adds regression coverage for the responsive shell and stale mobile viewport scale.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run check:types && npm run check:admin && npm test && npm run ci:changed && npm run build`

- Manual steps:
  - Verified the character selection screen at 768×700, 899×700, 900×700, 1024×768, 1366×768, 1440×900, 1920×1080, and 2560×1440.
  - Verified Retina layouts for MacBook Air 13/15 and MacBook Pro 14/16 using DPR 2 viewports.
  - Verified long character names, centered preview framing, class-detail scrolling, and responsive typography.
  - Reproduced a phone rotation sequence at 390×844 → 844×390 → 390×844 without reloading.
  - Confirmed the restored portrait viewport returns to 390×844 at scale 1 instead of retaining the landscape width.

## Screenshots / recordings

**desktop 2560x1440**

<img width="2560" height="1440" alt="desktop-2560x1440" src="https://github.com/user-attachments/assets/7210d3f7-6a52-48cd-92db-1dae5bd67479" />

**desktop 1920x1080**

<img width="1920" height="1080" alt="desktop-1920x1080" src="https://github.com/user-attachments/assets/591613df-b270-456e-b13b-a08efe775de0" />

**desktop 1440x900**

<img width="1440" height="900" alt="desktop-1440x900" src="https://github.com/user-attachments/assets/f77ddabc-b339-49a9-8c42-3b9d1560c6a8" />


**desktop 1366x768**

<img width="1366" height="768" alt="desktop-1366x768" src="https://github.com/user-attachments/assets/28e44f68-bedd-4c08-aa4d-06845a51a7d8" />

**compact**

<img width="768" height="700" alt="desktop-compact-768x700" src="https://github.com/user-attachments/assets/201beebe-2d73-46e1-97b3-4e0352972672" />


---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [x] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [x] **Accessible.** No interactive semantics were changed. Existing keyboard
      operation, focus styles, ARIA, and reduced-motion behavior are preserved.

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.