### PR TITLE
feat(character-select): UX improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -869,6 +869,7 @@
             <!-- Right: selected character showcase -->
             <div class="cs-detail-col">
               <div class="char-preview-container cs-preview" id="online-preview-container">
+                <div class="cs-preview-name" id="charselect-preview-name" aria-live="polite"></div>
                 <canvas id="char-preview-canvas"></canvas>
               </div>
               <div id="charselect-class-details" class="class-details-panel" aria-live="polite"></div>

--- a/index.html
+++ b/index.html
@@ -861,6 +861,7 @@
             <div class="cs-list-col">
               <ul id="char-list"></ul>
               <div class="cs-list-actions">
+                <button type="button" class="btn btn-primary" id="btn-charselect-enter" data-i18n="auth.enterWorld">Enter World</button>
                 <button type="button" class="btn btn-secondary" id="btn-charselect-back" data-i18n="auth.back">Back</button>
                 <button type="button" class="btn btn-primary cs-new-btn" id="btn-new-character" data-i18n="auth.newCharacter">New Character</button>
               </div>

--- a/play.html
+++ b/play.html
@@ -707,6 +707,7 @@
             <!-- Right: selected character showcase -->
             <div class="cs-detail-col">
               <div class="char-preview-container cs-preview" id="online-preview-container">
+                <div class="cs-preview-name" id="charselect-preview-name" aria-live="polite"></div>
                 <canvas id="char-preview-canvas"></canvas>
               </div>
               <div id="charselect-class-details" class="class-details-panel" aria-live="polite"></div>

--- a/play.html
+++ b/play.html
@@ -699,6 +699,7 @@
             <div class="cs-list-col">
               <ul id="char-list" role="list"></ul>
               <div class="cs-list-actions">
+                <button type="button" class="btn btn-primary" id="btn-charselect-enter" data-i18n="auth.enterWorld">Enter World</button>
                 <button type="button" class="btn btn-secondary" id="btn-charselect-back" data-i18n="auth.back">Back</button>
                 <button type="button" class="btn btn-primary cs-new-btn" id="btn-new-character" data-i18n="auth.newCharacter">New Character</button>
               </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -3923,9 +3923,10 @@ async function refreshCharacters(): Promise<void> {
   const listEl = $('#char-list');
   listEl.innerHTML = `<li class="char-list-message">${escapeHtml(t('character.loading'))}</li>`;
   // Drop any stale selection from a previous realm; the default first-row
-  // selection below re-arms the shared Enter World button.
+  // selection below re-arms the shared Enter World button and the preview name.
   charselectSelected = null;
   syncCharselectEnterButton();
+  setCharselectPreviewName('');
   try {
     const chars = sortCharacters(await api.characters(), charSortMode);
     if (api.realm) $('#charselect-realm').textContent = api.realm;
@@ -4008,6 +4009,7 @@ async function refreshCharacters(): Promise<void> {
         characterPreview?.setSkin(c.skin ?? 0);
         charselectSelected = c;
         syncCharselectEnterButton();
+        setCharselectPreviewName(c.name);
       };
 
       row.addEventListener('click', selectRow);
@@ -4089,6 +4091,15 @@ async function takeOverAndEnter(c: CharacterSummary, btn: HTMLButtonElement): Pr
     // Reflect any state change (e.g. a lost race) back into the list.
     void refreshCharacters();
   }
+}
+
+// The selected character's name, shown above the 3D preview on the desktop
+// stage so it is obvious which character you are about to play. textContent (not
+// innerHTML): names are player-supplied. Only the desktop docked layout reveals
+// the element (CSS), but setting it is a harmless no-op elsewhere.
+function setCharselectPreviewName(name: string): void {
+  const el = document.getElementById('charselect-preview-name');
+  if (el) el.textContent = name;
 }
 
 // Reflect the selected character's primary action on the desktop shared Enter

--- a/src/main.ts
+++ b/src/main.ts
@@ -4023,11 +4023,12 @@ async function refreshCharacters(): Promise<void> {
       // muscle memory). It routes through the shared desktop Enter World button
       // so entry owns its loading state; the button only exists in the docked
       // desktop layout, so this is a no-op on mobile (where the per-row button
-      // is a single tap away). A double-click that lands on a per-row control is
-      // safe because every such control either opens a full-screen modal on the
-      // first click (Delete: the two clicks then have different targets, so the
-      // browser synthesises no dblclick) or is itself disabled; keep that true
-      // for any per-row action added later.
+      // is a single tap away). Entry is gated on that shared button being visible
+      // AND enabled: for a forced-rename selection it is disabled (so the rename
+      // input/button on such a row cannot trigger entry), and Delete opens a
+      // full-screen modal on the first click, so the second click retargets and
+      // the browser synthesises no dblclick. Keep entry gated on the shared
+      // button's enabled state for any per-row action added later.
       row.addEventListener('dblclick', () => {
         selectRow();
         const enterBtn = document.getElementById(
@@ -4111,9 +4112,19 @@ function syncCharselectEnterButton(): void {
   if (!btn) return;
   const action = charselectPrimaryAction(charselectSelected);
   btn.disabled = action.kind === 'disabled';
+  // Drive BOTH the i18n key and the rendered text/title, so a later language
+  // switch (translatePage re-applies every [data-i18n]/[data-i18n-title]) rerenders
+  // the current dynamic state instead of clobbering it back to the static "Enter
+  // World". Same approach as applyServerMode.
+  btn.setAttribute('data-i18n', action.labelKey);
   btn.textContent = t(action.labelKey);
-  if (action.titleKey) btn.title = t(action.titleKey);
-  else btn.removeAttribute('title');
+  if (action.titleKey) {
+    btn.setAttribute('data-i18n-title', action.titleKey);
+    btn.title = t(action.titleKey);
+  } else {
+    btn.removeAttribute('data-i18n-title');
+    btn.removeAttribute('title');
+  }
 }
 
 async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,6 +71,7 @@ import {
   normalizeCharSortMode,
   sortCharacters,
 } from './net/char_sort';
+import { charselectPrimaryAction } from './net/charselect_action';
 import { createNativeAttestationProof } from './net/native_attestation';
 import {
   Api,
@@ -233,6 +234,10 @@ if (DESKTOP_APP) initDesktopShellIntegration();
 // context pool and break the next renderer with "Error creating WebGL context".
 installWebGLContextRelease();
 let pendingDeleteCharacter: CharacterSummary | null = null;
+// The desktop roster shows one shared "Enter World" button (in .cs-list-actions)
+// instead of a per-row one; it acts on whichever character is selected. Mobile
+// and narrow layouts keep the per-row buttons and never read this.
+let charselectSelected: CharacterSummary | null = null;
 let homepageMusic: HTMLAudioElement | null = null;
 let homepageMusicStarted = false;
 let homepageMusicMuted = readHomepageMusicMuted();
@@ -3917,6 +3922,10 @@ async function refreshCharacters(): Promise<void> {
   updateSortButtonLabel();
   const listEl = $('#char-list');
   listEl.innerHTML = `<li class="char-list-message">${escapeHtml(t('character.loading'))}</li>`;
+  // Drop any stale selection from a previous realm; the default first-row
+  // selection below re-arms the shared Enter World button.
+  charselectSelected = null;
+  syncCharselectEnterButton();
   try {
     const chars = sortCharacters(await api.characters(), charSortMode);
     if (api.realm) $('#charselect-realm').textContent = api.realm;
@@ -3975,29 +3984,9 @@ async function refreshCharacters(): Promise<void> {
           }
         });
       } else if (c.online) {
-        row.querySelector('.take-over-btn')?.addEventListener('click', async (e) => {
+        row.querySelector('.take-over-btn')?.addEventListener('click', (e) => {
           e.stopPropagation();
-          const btn = e.currentTarget as HTMLButtonElement;
-          // Taking over disconnects the other live session with no undo, so guard a
-          // stray click (e.g. you are genuinely playing on another device) behind a
-          // confirm. The prompt text is the existing t() key, keeping it localized.
-          if (!window.confirm(t('character.takeOverConfirm'))) return;
-          $('#charselect-error').textContent = '';
-          btn.disabled = true;
-          try {
-            // Free the stale/other session, then enter on this character.
-            // takeOverCharacter awaits the old session's leave() server-side, so
-            // the slot is free by the time enterWorld connects. Pass btn so
-            // enterWorld owns its loading/disabled state and restores it if entry
-            // is aborted before it begins; surface any failure via the catch.
-            await api.takeoverCharacter(c.id);
-            await enterWorld({ ...c, online: false }, btn);
-          } catch (err) {
-            btn.disabled = false;
-            $('#charselect-error').textContent = userFacingApiError(err);
-            // Reflect any state change (e.g. a lost race) back into the list.
-            void refreshCharacters();
-          }
+          void takeOverAndEnter(c, e.currentTarget as HTMLButtonElement);
         });
       } else {
         row.querySelector('.enter-world-btn')?.addEventListener('click', (e) => {
@@ -4017,6 +4006,8 @@ async function refreshCharacters(): Promise<void> {
         row.setAttribute('aria-selected', 'true');
         renderClassDetails('charselect-class-details', c.class);
         characterPreview?.setSkin(c.skin ?? 0);
+        charselectSelected = c;
+        syncCharselectEnterButton();
       };
 
       row.addEventListener('click', selectRow);
@@ -4025,6 +4016,22 @@ async function refreshCharacters(): Promise<void> {
           e.preventDefault();
           selectRow();
         }
+      });
+      // Double-click a row to jump straight into the world (classic-select
+      // muscle memory). It routes through the shared desktop Enter World button
+      // so entry owns its loading state; the button only exists in the docked
+      // desktop layout, so this is a no-op on mobile (where the per-row button
+      // is a single tap away). A double-click that lands on a per-row control is
+      // safe because every such control either opens a full-screen modal on the
+      // first click (Delete: the two clicks then have different targets, so the
+      // browser synthesises no dblclick) or is itself disabled; keep that true
+      // for any per-row action added later.
+      row.addEventListener('dblclick', () => {
+        selectRow();
+        const enterBtn = document.getElementById(
+          'btn-charselect-enter',
+        ) as HTMLButtonElement | null;
+        if (enterBtn && enterBtn.offsetParent !== null && !enterBtn.disabled) enterBtn.click();
       });
 
       listEl.appendChild(row);
@@ -4059,6 +4066,43 @@ function fatalOverlay(message: string): void {
   btn.addEventListener('click', () => location.reload());
   el.appendChild(btn);
   document.body.appendChild(el);
+}
+
+// Take over a character that is still online in another session, then enter on
+// it. Shared by the per-row Take Over button (mobile/narrow) and the desktop
+// shared Enter World button, which relabels itself Take Over for an online
+// selection. Taking over disconnects the other live session with no undo, so it
+// is guarded by a confirm. takeoverCharacter awaits the old session's leave()
+// server-side, so the slot is free by the time enterWorld connects; btn is
+// passed so enterWorld owns its loading/disabled state and restores it if entry
+// is aborted before it begins.
+async function takeOverAndEnter(c: CharacterSummary, btn: HTMLButtonElement): Promise<void> {
+  if (!window.confirm(t('character.takeOverConfirm'))) return;
+  $('#charselect-error').textContent = '';
+  btn.disabled = true;
+  try {
+    await api.takeoverCharacter(c.id);
+    await enterWorld({ ...c, online: false }, btn);
+  } catch (err) {
+    btn.disabled = false;
+    $('#charselect-error').textContent = userFacingApiError(err);
+    // Reflect any state change (e.g. a lost race) back into the list.
+    void refreshCharacters();
+  }
+}
+
+// Reflect the selected character's primary action on the desktop shared Enter
+// World button: Enter World for a ready character, Take Over for one online
+// elsewhere, and disabled (with a hint) while a forced rename is pending. A
+// no-op when the button is absent (mobile/narrow layouts use per-row buttons).
+function syncCharselectEnterButton(): void {
+  const btn = document.getElementById('btn-charselect-enter') as HTMLButtonElement | null;
+  if (!btn) return;
+  const action = charselectPrimaryAction(charselectSelected);
+  btn.disabled = action.kind === 'disabled';
+  btn.textContent = t(action.labelKey);
+  if (action.titleKey) btn.title = t(action.titleKey);
+  else btn.removeAttribute('title');
 }
 
 async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Promise<void> {
@@ -6887,6 +6931,17 @@ function wireStartScreens(): void {
   $('#btn-change-realm').addEventListener('click', (e) => {
     e.stopPropagation();
     toggleRealmDropdown();
+  });
+  // Desktop roster: one shared Enter World button acts on the selected
+  // character (Take Over when it is online elsewhere). Hidden on mobile/narrow
+  // layouts, which keep the per-row buttons.
+  $('#btn-charselect-enter').addEventListener('click', (e) => {
+    const btn = e.currentTarget as HTMLButtonElement;
+    const c = charselectSelected;
+    if (!c || btn.disabled) return;
+    // Same classifier that set the label, so routing and label never disagree.
+    if (charselectPrimaryAction(c).kind === 'takeover') void takeOverAndEnter(c, btn);
+    else void enterWorld(c, btn);
   });
   // New Character opens the dedicated create screen; create's Back returns here.
   $('#btn-new-character').addEventListener('click', () => show('#charcreate-panel'));

--- a/src/net/charselect_action.ts
+++ b/src/net/charselect_action.ts
@@ -1,0 +1,26 @@
+import type { CharacterSummary } from './online';
+
+// The primary action a character-select entry offers, as i18n keys (not rendered
+// text) so this stays DOM/i18n-free and unit-testable. Single source of truth for
+// BOTH the shared desktop Enter World button's label/enabled/title AND the branch
+// that routes its click to enter vs take over, so the two can never drift.
+export type CharselectActionKind = 'enter' | 'takeover' | 'disabled';
+
+export interface CharselectPrimaryAction {
+  kind: CharselectActionKind;
+  labelKey: 'auth.enterWorld' | 'character.takeOver';
+  titleKey: 'character.renameRequired' | null;
+}
+
+export function charselectPrimaryAction(
+  c: Pick<CharacterSummary, 'online' | 'forceRename'> | null,
+): CharselectPrimaryAction {
+  // No selection: a disabled Enter World placeholder (roster loading or empty).
+  if (!c) return { kind: 'disabled', labelKey: 'auth.enterWorld', titleKey: null };
+  // A forced rename must happen first: entry is blocked until the name is fixed.
+  if (c.forceRename)
+    return { kind: 'disabled', labelKey: 'auth.enterWorld', titleKey: 'character.renameRequired' };
+  // Online in another session: entry means taking that session over.
+  if (c.online) return { kind: 'takeover', labelKey: 'character.takeOver', titleKey: null };
+  return { kind: 'enter', labelKey: 'auth.enterWorld', titleKey: null };
+}

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -2654,6 +2654,31 @@
       border-radius: 0;
       z-index: 1;
     }
+    /* The selected character's name, centred over the top of the 3D stage so it
+       is unmistakable which character you are about to play. Truncates rather
+       than wrapping; non-interactive so it never blocks the turntable. */
+    body:not(.mobile-touch) #charselect-panel.cs-wow #charselect-preview-name {
+      display: block;
+      position: absolute;
+      top: 22px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 3;
+      max-width: min(56%, 420px);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      text-align: center;
+      font-family: var(--title-font);
+      font-weight: 700;
+      font-size: 26px;
+      letter-spacing: 2px;
+      color: var(--gold);
+      text-shadow:
+        0 2px 8px #000,
+        0 0 14px rgba(0, 0, 0, 0.55);
+      pointer-events: none;
+    }
     /* Name entry floats just under the title. */
     #offline-select.cs-wow .auth-label {
       position: absolute;
@@ -4543,6 +4568,14 @@
     display: block;
     width: 100% !important;
     height: 100% !important;
+  }
+
+  /* The selected-character name plate over the 3D stage. Belongs to the desktop
+     docked layout (the only one with a full 3D turntable); mobile shows the name
+     on each roster card already, so it stays hidden by default and the docked
+     layout reveals it. */
+  .cs-preview-name {
+    display: none;
   }
 
   .char-input-group {

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -2969,6 +2969,44 @@
     body:not(.mobile-touch) #charselect-panel.cs-wow .cs-list-actions {
       margin-top: auto;
       flex-shrink: 0;
+      /* Enter World is a full-width hero row; Back + New Character wrap below. */
+      flex-wrap: wrap;
+    }
+    /* The docked roster carries a single Enter World button acting on the
+       selected character, so the per-row Enter World / Take Over buttons drop
+       out here (Delete stays per-row: it targets one specific character). */
+    body:not(.mobile-touch) #charselect-panel.cs-wow #char-list .enter-world-btn,
+    body:not(.mobile-touch) #charselect-panel.cs-wow #char-list .take-over-btn {
+      display: none;
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow #btn-charselect-enter {
+      display: block;
+      flex: 1 1 100%;
+      min-height: 44px;
+      font-family: var(--title-font);
+      font-size: 17px;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+      /* Filled-gold CTA, matching the Donate button (.donate-cta): this is the
+         hero action of the screen, so it reads as a primary call to action
+         rather than the darker .btn-primary gradient. */
+      background: #f0c34d;
+      color: #2a1c05;
+      border: 1px solid var(--gold-dim);
+      outline: none;
+      text-shadow: none;
+      box-shadow:
+        0 2px 10px rgba(255, 209, 0, 0.25),
+        inset 0 1px 0 rgba(255, 255, 255, 0.35);
+    }
+    body:not(.mobile-touch) #charselect-panel.cs-wow #btn-charselect-enter:hover:not(:disabled),
+    body:not(.mobile-touch) #charselect-panel.cs-wow #btn-charselect-enter:focus-visible {
+      filter: brightness(1.08);
+      background: #ffd86b;
+      box-shadow:
+        0 0 14px rgba(255, 209, 0, 0.5),
+        inset 0 1px 0 rgba(255, 255, 255, 0.45);
+      transform: translateY(-1px);
     }
     body:not(.mobile-touch) #charselect-panel.cs-wow .class-details-panel {
       position: absolute;
@@ -4088,6 +4126,13 @@
     overflow-y: auto;
     list-style: none;
     padding: 0;
+  }
+
+  /* The shared Enter World CTA belongs only to the desktop docked roster; every
+     other layout (mobile, narrow non-touch) drives entry from the per-row
+     buttons, so hide it by default and let the docked layout reveal it. */
+  #btn-charselect-enter {
+    display: none;
   }
 
   .fatal-overlay {

--- a/tests/charselect_action.test.ts
+++ b/tests/charselect_action.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { charselectPrimaryAction } from '../src/net/charselect_action';
+
+describe('charselectPrimaryAction', () => {
+  it('offers a disabled Enter World placeholder when nothing is selected', () => {
+    expect(charselectPrimaryAction(null)).toEqual({
+      kind: 'disabled',
+      labelKey: 'auth.enterWorld',
+      titleKey: null,
+    });
+  });
+
+  it('blocks entry with a rename-required hint while a forced rename is pending', () => {
+    expect(charselectPrimaryAction({ online: false, forceRename: true })).toEqual({
+      kind: 'disabled',
+      labelKey: 'auth.enterWorld',
+      titleKey: 'character.renameRequired',
+    });
+  });
+
+  it('offers Take Over for a character online in another session', () => {
+    expect(charselectPrimaryAction({ online: true, forceRename: false })).toEqual({
+      kind: 'takeover',
+      labelKey: 'character.takeOver',
+      titleKey: null,
+    });
+  });
+
+  it('offers Enter World for a ready offline character', () => {
+    expect(charselectPrimaryAction({ online: false, forceRename: false })).toEqual({
+      kind: 'enter',
+      labelKey: 'auth.enterWorld',
+      titleKey: null,
+    });
+  });
+
+  it('prioritises the rename block over the online take-over state', () => {
+    // forceRename wins: a character that is both online and force-rename must be
+    // renamed first, so entry stays disabled rather than offering Take Over.
+    expect(charselectPrimaryAction({ online: true, forceRename: true }).kind).toBe('disabled');
+  });
+});

--- a/tests/charselect_sort_parity.test.ts
+++ b/tests/charselect_sort_parity.test.ts
@@ -64,3 +64,21 @@ describe('character-select sort control parity', () => {
     });
   }
 });
+
+// The shared desktop Enter World button is wired the same way: wireStartScreens()
+// runs $('#btn-charselect-enter').addEventListener(...) unconditionally, so the id
+// missing from either entry would throw and abort the rest of the wiring. Pin it
+// to parity, like the sort controls above.
+describe('character-select Enter World button parity', () => {
+  it('wireStartScreens reads #btn-charselect-enter (the dependency this guards)', () => {
+    expect(mainTs).toContain("$('#btn-charselect-enter').addEventListener");
+  });
+
+  it('index.html character select contains #btn-charselect-enter', () => {
+    expect(indexHtml).toContain('id="btn-charselect-enter"');
+  });
+
+  it('play.html character select contains #btn-charselect-enter (mirrors index.html)', () => {
+    expect(playHtml).toContain('id="btn-charselect-enter"');
+  });
+});


### PR DESCRIPTION
## Summary

Two focused UX improvements to the online character-select screen, both scoped to the
desktop docked layout. Mobile and tablet are left exactly as they are.

**1. One prominent "Enter World" CTA**
Desktop used to show a separate "Enter World" button on every roster row, right next to that
row's "Delete", which made the primary action easy to misclick and visually noisy. This PR
replaces them with a single gold "Enter World" button pinned to the foot of the roster,
acting on the currently selected character:

- The button reflects the selected character's state: "Enter World" for a ready character,
  "Take Over" when the character is online in another session, and disabled (with a rename
  hint) while a forced rename is pending.
- Double-click a roster row to jump straight in (classic character-select muscle memory).
- Rows keep only "Delete", so the Delete/Enter adjacency misclick is gone.
- Styled to match the existing Donate / Verify Wallet gold CTA, so it reads as the screen's
  primary call to action.
- The button is pinned in the roster's action bar while the list scrolls inside its own area,
  so it stays visible no matter how many characters you have (you never scroll to play).

The classification that drives the label and the click routing is a single pure function
(`src/net/charselect_action.ts`, following the existing `char_sort.ts` pattern), so the label
and the action can never disagree. It is unit-tested.

**2. Character name over the 3D model**
The selected character's name now appears centered above the 3D preview, so it is
unmistakable which character you are about to play.

Both features are gated to the desktop docked stage. On mobile the roster is a vertical list
of cards that already show each character's name and its own per-row "Enter World" button, so
nothing there changes.

## Related issues

N/A

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run check:types && npm run check:admin && npm test && npm run ci:changed && npm run build`

- Manual steps:
  - Desktop at a wide (2000px) and a narrow (1100px) width: the single "Enter World" CTA sits at
    the foot of the roster with Back / New Character below, and per-row rows show only Delete.
  - Confirmed the CTA stays pinned and visible with the roster list scrolling internally, so
    entering the world never requires scrolling regardless of character count.
  - Confirmed the selected character's name renders centered above the 3D model and updates as
    you pick a different character; it truncates with an ellipsis so a long name cannot break
    the layout.
  - Verified the mobile fallback via computed-style checks (the reveal is `body:not(.mobile-touch)`
    gated): on `mobile-touch` the single CTA and the name plate stay hidden and the per-row
    buttons remain visible. A real phone pass in portrait and landscape is still worth a look.

## Screenshots / recordings

<img width="2560" height="1440" alt="Screenshot from 2026-07-05 18-58-56" src="https://github.com/user-attachments/assets/9a8a86bf-1b38-45ef-b10c-bebb3158b3ed" />


<img width="1304" height="670" alt="Screenshot from 2026-07-05 18-59-39" src="https://github.com/user-attachments/assets/8de4908f-8723-4d86-a66c-5b5fa159f7bb" />


<img width="545" height="896" alt="Screenshot from 2026-07-05 18-59-56" src="https://github.com/user-attachments/assets/192ed4ef-467d-4cac-8fa1-da97f1446658" />


---

## Checklist

### Quality

- [x] **Tests pass.** 
- [x] **Typecheck passes.** 
- [x] **Builds succeed.** 

### Cross-platform

- [x] **Tested on desktop and mobile.** Desktop verified at wide and narrow widths. Mobile
      per-row fallback confirmed via computed-style checks (the new UI is `body:not(.mobile-touch)`
      gated and untouched on mobile); a real-device portrait/landscape pass is recommended.
- [x] **Accessible.** The CTA is keyboard-operable with a visible focus ring, has a proper
      disabled state, and the name plate uses `aria-live`. No motion added. Note: the shell has no
      `forced-colors` rules today (pre-existing, not introduced here).

### Localization (i18n)

- [ ] New player-visible strings are translated into every supported locale.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters.
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at the client boundary.
- [x] **N/A. This PR adds no player-visible strings.** The button reuses existing keys
      (`auth.enterWorld`, `character.takeOver`, `character.renameRequired`) via `t()`, and the name
      plate renders the player's own character name (not a translatable string).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in
      any production path.
- [x] I didn't hand-edit generated files. None were touched.
