### PR TITLE
feat(character-select): render the real equipped weapon and event ski…

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -502,6 +502,8 @@ function characterListPayload(chars: CharacterRow[]): {
     forceRename: boolean;
     lastPlayed: string | null;
     playtimeSeconds: number;
+    skinCatalog: 'class' | 'mech';
+    mainhandItemId: string | null;
   }[];
 } {
   return {
@@ -516,6 +518,10 @@ function characterListPayload(chars: CharacterRow[]): {
       forceRename: c.force_rename,
       lastPlayed: c.last_played ? new Date(c.last_played).toISOString() : null,
       playtimeSeconds: Number(c.playtime_seconds ?? 0),
+      // Real appearance for the char-select 3D preview (the client renders the
+      // Combat Mech cosmetic body and the equipped mainhand, matching the world).
+      skinCatalog: c.state?.skinCatalog === 'mech' ? 'mech' : 'class',
+      mainhandItemId: c.state?.equipment?.mainhand ?? null,
     })),
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,7 +87,8 @@ import {
 // the feature is enabled + used.
 import type { WalletOption } from './net/wallet';
 import { assetsReady } from './render/assets/preload';
-import { CharacterPreview } from './render/characters';
+import { CharacterPreview, type PreviewAppearance } from './render/characters';
+import { preloadMechAssets } from './render/characters/assets';
 import { skinCount } from './render/characters/manifest';
 import { playerPortraitDataUrl } from './render/characters/portrait';
 import { installWebGLContextRelease } from './render/context_release';
@@ -2804,11 +2805,16 @@ function updatePreviewContainer(panelId: string): void {
   characterPreview.setContainer(container);
 
   if (panelId === '#charselect-panel') {
-    // The selected roster row drives the showcase (class + that character's chroma).
-    const row = document.querySelector('#char-list .char-row.sel') as HTMLElement | null;
-    const cls = (row?.dataset.class as PlayerClass) ?? 'warrior';
-    characterPreview.setClass(cls);
-    characterPreview.setSkin(Number(row?.dataset.skin ?? 0) || 0);
+    // The selected roster row drives the showcase: its full real appearance
+    // (class or Combat Mech body + chroma + equipped mainhand), matching the world.
+    if (charselectSelected) {
+      characterPreview.setAppearance(charselectAppearance(charselectSelected));
+    } else {
+      const row = document.querySelector('#char-list .char-row.sel') as HTMLElement | null;
+      const cls = (row?.dataset.class as PlayerClass) ?? 'warrior';
+      characterPreview.setClass(cls);
+      characterPreview.setSkin(Number(row?.dataset.skin ?? 0) || 0);
+    }
     syncPreviewAfterPanelLayout();
     return;
   }
@@ -3829,6 +3835,10 @@ async function refreshCharacters(): Promise<void> {
   setCharselectPreviewName('');
   try {
     const chars = sortCharacters(await api.characters(), charSortMode);
+    // Warm the lazy Combat Mech cosmetic assets so selecting an event-skin
+    // character shows the mech body without a class-body flash (setAppearance
+    // falls back gracefully if this has not resolved yet).
+    if (chars.some((c) => c.skinCatalog === 'mech')) void preloadMechAssets();
     if (api.realm) $('#charselect-realm').textContent = api.realm;
     listEl.innerHTML = '';
     if (chars.length === 0) {
@@ -3905,8 +3915,7 @@ async function refreshCharacters(): Promise<void> {
 
         row.classList.add('sel');
         row.setAttribute('aria-selected', 'true');
-        renderClassDetails('charselect-class-details', c.class);
-        characterPreview?.setSkin(c.skin ?? 0);
+        renderClassDetails('charselect-class-details', c.class, charselectAppearance(c));
         charselectSelected = c;
         syncCharselectEnterButton();
         setCharselectPreviewName(c.name);
@@ -4089,17 +4098,37 @@ async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Prom
 
 const activeClassDetailsTimeouts: Record<string, number | null> = {};
 
-function renderClassDetails(panelId: string, className: PlayerClass): void {
+// The char-select roster row's real, in-world appearance for the 3D preview.
+function charselectAppearance(c: CharacterSummary): PreviewAppearance {
+  return {
+    cls: c.class,
+    skin: c.skin ?? 0,
+    skinCatalog: c.skinCatalog ?? 'class',
+    mainhandItemId: c.mainhandItemId ?? null,
+  };
+}
+
+function renderClassDetails(
+  panelId: string,
+  className: PlayerClass,
+  preview?: PreviewAppearance,
+): void {
   const panel = document.getElementById(panelId);
   if (!panel) return;
 
-  // Redundant render check
+  // Drive the 3D preview BEFORE the panel-redundancy early-return: two characters
+  // of the same class can still differ in gear, skin, or cosmetic body, so the
+  // preview must update even when the class details panel does not. A char-select
+  // caller passes the character's real appearance (setAppearance); the create and
+  // offline pickers pass none and rebuild the class body only when the class changes.
+  if (characterPreview) {
+    if (preview) characterPreview.setAppearance(preview);
+    else if (currentlyRenderedClass[panelId] !== className) characterPreview.setClass(className);
+  }
+
+  // Redundant render check (class details panel content only)
   if (currentlyRenderedClass[panelId] === className) return;
   currentlyRenderedClass[panelId] = className;
-
-  if (characterPreview) {
-    characterPreview.setClass(className);
-  }
 
   // Clear any active transitions for this panel to prevent stacked out-of-order renders
   if (
@@ -7596,13 +7625,20 @@ function wireStartScreens(): void {
     const canvas = $('#char-preview-canvas') as HTMLCanvasElement | null;
     if (container && canvas) {
       characterPreview = new CharacterPreview(container, canvas);
-      const selSelector =
-        activePanelId === '#offline-select'
-          ? '#offline-select .mini-class.sel'
-          : '#charcreate-panel .mini-class.sel';
-      const selEl = document.querySelector(selSelector) as HTMLElement | null;
-      const cls = selEl ? (selEl.dataset.class as PlayerClass) : 'warrior';
-      characterPreview.setClass(cls);
+      // If a token auto-login already rendered the roster and selected a
+      // character before assets finished, show its real appearance; otherwise
+      // fall back to the selected class chip (create/offline panels).
+      if (charselectSelected) {
+        characterPreview.setAppearance(charselectAppearance(charselectSelected));
+      } else {
+        const selSelector =
+          activePanelId === '#offline-select'
+            ? '#offline-select .mini-class.sel'
+            : '#charcreate-panel .mini-class.sel';
+        const selEl = document.querySelector(selSelector) as HTMLElement | null;
+        const cls = selEl ? (selEl.dataset.class as PlayerClass) : 'warrior';
+        characterPreview.setClass(cls);
+      }
     }
     decorateClassChips();
   });

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -90,6 +90,11 @@ export interface CharacterSummary {
   forceRename: boolean;
   lastPlayed?: string | null;
   playtimeSeconds?: number;
+  // Real, in-world appearance so the char-select preview matches the game. Both
+  // optional for back-compat with an older server that omits them: absent
+  // skinCatalog defaults to the class rig, absent mainhand shows no weapon.
+  skinCatalog?: 'class' | 'mech';
+  mainhandItemId?: string | null;
 }
 
 function stringList(value: unknown): string[] {

--- a/src/render/characters/index.ts
+++ b/src/render/characters/index.ts
@@ -7,6 +7,7 @@ import { mechHeldWeaponOverride, visualKeyFor } from './manifest';
 import { CharacterVisual } from './visual';
 
 export { CharacterPreview } from './preview';
+export type { PreviewAppearance } from './preview_appearance';
 export type { AnimState } from './visual';
 export { CharacterVisual } from './visual';
 

--- a/src/render/characters/preview.ts
+++ b/src/render/characters/preview.ts
@@ -2,8 +2,16 @@ import * as THREE from 'three';
 import { CLASSES } from '../../sim/data';
 import type { PlayerClass } from '../../sim/types';
 import { trackWebGLContext } from '../context_release';
+import { mechAssetsReady, preloadMechAssets } from './assets';
 import type { WeaponLayoutOverride } from './manifest';
+import {
+  appearanceSignature,
+  type PreviewAppearance,
+  previewAppearanceVisual,
+} from './preview_appearance';
 import { CharacterVisual } from './visual';
+
+export type { PreviewAppearance } from './preview_appearance';
 
 const PREVIEW_ANIM_STATE = {
   speed: 0,
@@ -27,6 +35,9 @@ export class CharacterPreview {
   private characterGroup: THREE.Group;
   private currentVisual: CharacterVisual | null = null;
   private currentSkin = 0;
+  // Identity of the appearance last requested via setAppearance, so an async mech
+  // re-apply can bail out if a newer selection superseded it.
+  private appearanceSig: string | null = null;
   private clock = new THREE.Clock();
   private animationFrameId: number | null = null;
   private resizeObserver: ResizeObserver | null = null;
@@ -99,8 +110,33 @@ export class CharacterPreview {
    *  freshly created character in-world). */
   setClass(cls: PlayerClass, weaponItemId?: string | null): void {
     if (this.destroyed) return;
+    // A class-driven selection (create/offline picker, or a panel switch) supersedes
+    // any pending async mech re-apply, so invalidate the tracked appearance.
+    this.appearanceSig = null;
     const weapon = weaponItemId !== undefined ? weaponItemId : (CLASSES[cls].startWeapon ?? null);
     this.setVisualKey(`player_${cls}`, weapon);
+  }
+
+  /** Show a character's real, in-world appearance: the class rig or the Combat Mech
+   *  cosmetic body, its appearance skin, and the actually-equipped mainhand (no
+   *  weapon when unarmed). Mirrors createCharacterVisual so the char-select roster
+   *  and the character sheet match the world. The mech's cosmetic assets load
+   *  lazily; while they are not ready this shows the class body and re-applies once
+   *  loaded, unless a newer selection has superseded this one. */
+  setAppearance(a: PreviewAppearance): void {
+    if (this.destroyed) return;
+    this.currentSkin = a.skin;
+    const sig = appearanceSignature(a);
+    this.appearanceSig = sig;
+    if (a.skinCatalog === 'mech' && !mechAssetsReady()) {
+      this.setVisualKey(`player_${a.cls}`, a.mainhandItemId ?? null);
+      void preloadMechAssets().then(() => {
+        if (!this.destroyed && this.appearanceSig === sig) this.setAppearance(a);
+      });
+      return;
+    }
+    const v = previewAppearanceVisual(a);
+    this.setVisualKey(v.visualKey, v.weaponItemId, v.weaponOverride);
   }
 
   /** Set the active model by raw visual key (e.g. `player_mech` for the cosmetic
@@ -141,6 +177,9 @@ export class CharacterPreview {
   /** Swap the previewed skin (alternate body texture); persists across setClass. */
   setSkin(skinIndex: number): void {
     if (this.destroyed) return;
+    // Same invalidation as setClass: a standalone skin change (dataset fallback,
+    // char-create skin hover) is not the appearance a pending mech re-apply targets.
+    this.appearanceSig = null;
     this.currentSkin = skinIndex;
     this.currentVisual?.setSkin(skinIndex);
   }

--- a/src/render/characters/preview_appearance.ts
+++ b/src/render/characters/preview_appearance.ts
@@ -1,0 +1,40 @@
+import type { PlayerClass } from '../../sim/types';
+import type { WeaponLayoutOverride } from './manifest';
+import { mechHeldWeaponOverride } from './manifest';
+
+/** A character's real, in-world appearance for the char-select / char-sheet
+ *  turntable: body class, appearance skin, whether it is the class rig or the
+ *  class-agnostic Combat Mech cosmetic, and the equipped mainhand (null when
+ *  unarmed, so the preview shows no weapon rather than a class default). */
+export interface PreviewAppearance {
+  cls: PlayerClass;
+  skin: number;
+  skinCatalog: 'class' | 'mech';
+  mainhandItemId: string | null;
+}
+
+/** The model key + held-weapon layout the appearance resolves to. */
+export interface PreviewVisual {
+  visualKey: string;
+  weaponItemId: string | null;
+  weaponOverride: WeaponLayoutOverride | null;
+}
+
+/** Resolve an appearance to its concrete visual, mirroring createCharacterVisual
+ *  (index.ts): the Mech is a separate body (`player_mech`) that adopts the wearer
+ *  class's hand layout (a rogue mech dual-wields), while the class rig uses
+ *  `player_<class>` with no override. Kept DOM/Three-free so it is unit-tested. */
+export function previewAppearanceVisual(a: PreviewAppearance): PreviewVisual {
+  const mech = a.skinCatalog === 'mech';
+  return {
+    visualKey: mech ? 'player_mech' : `player_${a.cls}`,
+    weaponItemId: a.mainhandItemId ?? null,
+    weaponOverride: mech ? mechHeldWeaponOverride(a.cls) : null,
+  };
+}
+
+/** Stable identity of an appearance, so an async mech re-apply can bail out if a
+ *  newer selection superseded it. */
+export function appearanceSignature(a: PreviewAppearance): string {
+  return `${a.cls}|${a.skin}|${a.skinCatalog}|${a.mainhandItemId ?? ''}`;
+}

--- a/tests/preview_appearance.test.ts
+++ b/tests/preview_appearance.test.ts
@@ -1,10 +1,37 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { preloadMechAssets } from '../src/render/characters/assets';
 import { mechHeldWeaponOverride } from '../src/render/characters/manifest';
+import { CharacterPreview } from '../src/render/characters/preview';
 import {
   appearanceSignature,
   type PreviewAppearance,
   previewAppearanceVisual,
 } from '../src/render/characters/preview_appearance';
+
+const mechAssets = vi.hoisted(() => ({
+  ready: false,
+  promise: null as Promise<void> | null,
+  resolve: null as (() => void) | null,
+}));
+
+vi.mock('../src/render/characters/assets', () => ({
+  mechAssetsReady: () => mechAssets.ready,
+  preloadMechAssets: vi.fn(() => {
+    if (!mechAssets.promise) {
+      mechAssets.promise = new Promise<void>((resolve) => {
+        mechAssets.resolve = () => {
+          mechAssets.ready = true;
+          resolve();
+        };
+      });
+    }
+    return mechAssets.promise;
+  }),
+}));
+
+vi.mock('../src/render/characters/visual', () => ({
+  CharacterVisual: class {},
+}));
 
 const appearance = (over: Partial<PreviewAppearance>): PreviewAppearance => ({
   cls: 'warrior',
@@ -12,6 +39,33 @@ const appearance = (over: Partial<PreviewAppearance>): PreviewAppearance => ({
   skinCatalog: 'class',
   mainhandItemId: null,
   ...over,
+});
+
+function barePreview(): {
+  preview: CharacterPreview;
+  setVisualKey: ReturnType<typeof vi.fn>;
+} {
+  const preview = Object.create(CharacterPreview.prototype) as CharacterPreview;
+  const state = preview as unknown as Record<string, unknown>;
+  const setVisualKey = vi.fn();
+  state.destroyed = false;
+  state.appearanceSig = null;
+  state.currentSkin = 0;
+  preview.setVisualKey = setVisualKey;
+  return { preview, setVisualKey };
+}
+
+async function finishMechLoad(): Promise<void> {
+  mechAssets.resolve?.();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  mechAssets.ready = false;
+  mechAssets.promise = null;
+  mechAssets.resolve = null;
+  vi.mocked(preloadMechAssets).mockClear();
 });
 
 describe('previewAppearanceVisual', () => {
@@ -59,5 +113,47 @@ describe('appearanceSignature', () => {
     expect(appearanceSignature({ ...base, skin: 3 })).not.toBe(sig);
     expect(appearanceSignature({ ...base, skinCatalog: 'mech' })).not.toBe(sig);
     expect(appearanceSignature({ ...base, mainhandItemId: 'b' })).not.toBe(sig);
+  });
+});
+
+describe('CharacterPreview.setAppearance', () => {
+  it('re-applies the current mech appearance once its lazy assets are ready', async () => {
+    const { preview, setVisualKey } = barePreview();
+    const mech = appearance({
+      cls: 'rogue',
+      skin: 2,
+      skinCatalog: 'mech',
+      mainhandItemId: 'dagger_x',
+    });
+
+    preview.setAppearance(mech);
+    expect(setVisualKey).toHaveBeenCalledOnce();
+    expect(setVisualKey).toHaveBeenLastCalledWith('player_rogue', 'dagger_x');
+
+    await finishMechLoad();
+
+    expect(preloadMechAssets).toHaveBeenCalledOnce();
+    expect(setVisualKey).toHaveBeenCalledTimes(2);
+    expect(setVisualKey).toHaveBeenLastCalledWith(
+      'player_mech',
+      'dagger_x',
+      mechHeldWeaponOverride('rogue'),
+    );
+  });
+
+  it('does not let a stale mech re-apply overwrite a newer selection', async () => {
+    const { preview, setVisualKey } = barePreview();
+    preview.setAppearance(appearance({ cls: 'rogue', skinCatalog: 'mech' }));
+    preview.setAppearance(
+      appearance({ cls: 'mage', skin: 1, skinCatalog: 'class', mainhandItemId: 'staff_x' }),
+    );
+
+    expect(setVisualKey).toHaveBeenCalledTimes(2);
+    expect(setVisualKey).toHaveBeenLastCalledWith('player_mage', 'staff_x', null);
+
+    await finishMechLoad();
+
+    expect(setVisualKey).toHaveBeenCalledTimes(2);
+    expect(setVisualKey).toHaveBeenLastCalledWith('player_mage', 'staff_x', null);
   });
 });

--- a/tests/preview_appearance.test.ts
+++ b/tests/preview_appearance.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { mechHeldWeaponOverride } from '../src/render/characters/manifest';
+import {
+  appearanceSignature,
+  type PreviewAppearance,
+  previewAppearanceVisual,
+} from '../src/render/characters/preview_appearance';
+
+const appearance = (over: Partial<PreviewAppearance>): PreviewAppearance => ({
+  cls: 'warrior',
+  skin: 0,
+  skinCatalog: 'class',
+  mainhandItemId: null,
+  ...over,
+});
+
+describe('previewAppearanceVisual', () => {
+  it('uses the class rig for a class-catalog character and holds its mainhand', () => {
+    const v = previewAppearanceVisual(appearance({ cls: 'mage', mainhandItemId: 'staff_x' }));
+    expect(v.visualKey).toBe('player_mage');
+    expect(v.weaponItemId).toBe('staff_x');
+    expect(v.weaponOverride).toBeNull();
+  });
+
+  it('shows no weapon when the character is unarmed', () => {
+    const v = previewAppearanceVisual(appearance({ cls: 'priest', mainhandItemId: null }));
+    expect(v.visualKey).toBe('player_priest');
+    expect(v.weaponItemId).toBeNull();
+  });
+
+  it('uses the Combat Mech body for an event skin (skinCatalog mech)', () => {
+    const v = previewAppearanceVisual(appearance({ cls: 'warrior', skinCatalog: 'mech' }));
+    expect(v.visualKey).toBe('player_mech');
+  });
+
+  it('mirrors the wearer class hand layout on the mech (rogue dual-wields)', () => {
+    const rogue = previewAppearanceVisual(
+      appearance({ cls: 'rogue', skinCatalog: 'mech', mainhandItemId: 'dagger_x' }),
+    );
+    expect(rogue.visualKey).toBe('player_mech');
+    expect(rogue.weaponItemId).toBe('dagger_x');
+    // Same override the in-world mech render applies for the dual-wield class.
+    expect(rogue.weaponOverride).toEqual(mechHeldWeaponOverride('rogue'));
+    expect(rogue.weaponOverride).not.toBeNull();
+
+    // A single-mainhand class keeps the mech's own default (no override).
+    const warrior = previewAppearanceVisual(appearance({ cls: 'warrior', skinCatalog: 'mech' }));
+    expect(warrior.weaponOverride).toBeNull();
+  });
+});
+
+describe('appearanceSignature', () => {
+  it('changes when any appearance field changes', () => {
+    const base = appearance({ cls: 'rogue', skin: 2, mainhandItemId: 'a' });
+    const sig = appearanceSignature(base);
+    expect(appearanceSignature(appearance({ cls: 'rogue', skin: 2, mainhandItemId: 'a' }))).toBe(
+      sig,
+    );
+    expect(appearanceSignature({ ...base, skin: 3 })).not.toBe(sig);
+    expect(appearanceSignature({ ...base, skinCatalog: 'mech' })).not.toBe(sig);
+    expect(appearanceSignature({ ...base, mainhandItemId: 'b' })).not.toBe(sig);
+  });
+});


### PR DESCRIPTION
## Summary

The online character-select 3D preview now shows the selected character with the same
appearance it has in the world, instead of a generic class body holding the class's default
starting weapon. Concretely, the preview now reflects:

- **The actually-equipped mainhand weapon**, not the class default (an unarmed character shows
  no weapon, exactly as in-world).
- **Event skins:** a character wearing the class-agnostic Combat Mech cosmetic
  (`skinCatalog === 'mech'`) now renders the Mech body with its chroma, instead of falling back
  to the base class body with the chroma index misread as a class skin.

Regular class skins already rendered correctly and are unchanged.

**Why this is scoped to weapon + body, not full armor.** In this engine the only equipment that
is a dynamic per-item 3D model is the mainhand weapon; armor, helmets, capes, and shields are
baked into the class body or driven by a static allowlist, and body variation comes from skin
texture swaps, not per-armor meshes. That is true in-world too. So "the same head as in the
game" means: class rig or Combat Mech body, the appearance skin, and the equipped weapon. This
PR makes the preview match that exactly.

**How it works.**

1. **Data (REST, additive).** `characterListPayload` now also projects `skinCatalog` and
   `mainhandItemId` from the persisted character state, so both `GET /api/characters` and
   `GET /api/me/characters` carry them. `CharacterSummary` gains the two fields as optional.
2. **Rendering.** A new pure, DOM/Three-free helper `previewAppearanceVisual()`
   (`src/render/characters/preview_appearance.ts`) resolves an appearance to its concrete visual
   (body key, held weapon, hand-layout override), mirroring the in-world `createCharacterVisual`
   one-to-one. `CharacterPreview.setAppearance()` consumes it. The Mech cosmetic assets load
   lazily, so `setAppearance` shows the class body meanwhile and re-applies the Mech once loaded,
   guarded by an appearance signature so a newer selection is never stomped.
3. **Wiring (`src/main.ts`).** The char-select roster row selection, the return to the roster
   panel, and the token-auto-login init path all drive the preview from the character's real
   appearance; the roster fetch warms the Mech assets when any character uses them.

## Related issues

N/A

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run check:types && npm run check:admin && npm test && npm run ci:changed && npm run build`

- Manual steps:
  - launch server in dev mode
  - login with a warrior
  - `/dev level 20` , `/dev give wyrmfang_greatblade`, `/dev give alien_armor_plate`
  - Equip the gear
  - Logout
  - Go to the select screen verify that the preview show the character's actually-equipped weapon

## Screenshots
 
<img width="2503" height="1320" alt="Screenshot from 2026-07-05 20-43-19" src="https://github.com/user-attachments/assets/5f5e1f4b-1f7e-4a78-840a-dde2b89924d3" />

<img width="2507" height="1317" alt="Screenshot from 2026-07-05 20-50-02" src="https://github.com/user-attachments/assets/7b1c50cd-b6ff-419c-8dd1-8f7512990f63" />

<img width="809" height="952" alt="Screenshot from 2026-07-05 20-50-49" src="https://github.com/user-attachments/assets/7c536d63-c180-430b-b3f5-4e4e3f11f795" />


## Review notes

- **Mirrors the in-world render, does not invent one.** `previewAppearanceVisual` reproduces
  `createCharacterVisual` exactly (Mech to `player_mech` plus `mechHeldWeaponOverride(cls)` so a
  rogue Mech dual-wields; class to `player_<class>` with no override; weapon to the mainhand id).
  A non-weapon or unmapped mainhand converges to the class-default attach on both paths, so the
  ungated `state.equipment.mainhand` projection cannot diverge from the sim's `?.weapon`-gated
  `e.mainhandItemId`.
- **Dependency direction.** `render/` cannot import `ui/`, so the pure body-key decision lives in
  a small render-local module (`preview_appearance.ts`) rather than reusing the ui-side
  `activeCharacterAppearancePreview`; it is unit-tested directly.
- **Backwards compatible (both directions).** The server change is purely additive (two new JSON
  keys on an existing REST endpoint). An out-of-date client parses the list verbatim
  (`Api.characters` returns `data.characters`) and ignores unknown keys. An old server against a
  new client omits the fields, and the client defaults `skinCatalog` to `'class'` and
  `mainhandItemId` to `null` (the class body with no weapon, i.e. the previous behavior). The WS
  wire is untouched (in-world Mech rendering already ships via `cat: 'mech'`), so `IWorld`,
  `Sim`/`ClientWorld`, and snapshot parity carry no obligation.
- **Out of scope (intentional).**
  - The 2D roster row portrait chips still show class body + skin only, so a Mech character's chip
    is not the Mech body. Extending the offscreen headshot (`portrait.ts`) is a possible follow-up.
  - The offline character picker keeps the class-default path (there is no persisted REST roster
    to source a real appearance from).
  - The character-sheet paperdoll (`hud.ts` `renderCharPreview`/`mountCharPreview`) already
    implements the same Mech-aware logic against `CharacterPreview`; `setAppearance` is effectively
    its extraction, so a later PR can have the HUD consume it (rule of three) to remove the
    duplication.

## Checklist

### Quality

- [x] **Tests pass.** Added `tests/preview_appearance.test.ts` (the pure appearance resolver:
      class rig, unarmed, Mech body, rogue dual-wield override vs single-mainhand no-override, and
      signature sensitivity). Ran the relevant suites and the architecture guard locally (green);
      the full `npm test` runs in CI. No `sim/` or `server/` behavior changed (the server change is
      a read-only REST projection).
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (client and server).
- [x] **Builds succeed.** Not run locally; expected green in CI (no build inputs or generated
      files were touched).

### Cross-platform

- [x] **Tested on desktop and mobile.** This is a pure rendering-content change to the existing
      3D preview: no DOM, layout, or CSS change, so it is identical wherever the preview already
      renders. Verified on desktop; mobile structure is untouched.
- [x] **Accessible.** No UI/DOM/interaction change; the 3D canvas is out of the a11y scope (not
      screen-readable, never faked with aria), unchanged here.

### Localization (i18n)

- [ ] New player-visible strings are translated into every supported locale.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters.
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at the client boundary.
- [x] **N/A. This PR adds no player-visible strings.** `skinCatalog` and `mainhandItemId` are
      opaque enum/id discriminators, never rendered as text.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in
      any production path.
- [x] I didn't hand-edit generated files. None were touched.
