### PR TITLE
fix(ui): center the maintenance eyebrow label on the offline page

### DIFF
--- a/public/server-unavailable.html
+++ b/public/server-unavailable.html
@@ -70,7 +70,9 @@
     }
 
     .eyebrow {
-      margin: 0 0 10px;
+      /* keep the horizontal auto margins from the p rule: its 470px max-width
+         box would otherwise hug the panel's left padding edge off-center */
+      margin: 0 auto 10px;
       color: var(--gold);
       font-size: 12px;
       font-weight: 700;


### PR DESCRIPTION
## Summary

The "Realm maintenance" eyebrow label on the offline page (`public/server-unavailable.html`) rendered about 38px left of the panel's center on desktop, out of alignment with the centered logo, heading, description, and status pill.

Root cause (confirmed by measurement, see below): the page's generic `p` rule gives paragraphs a 470px `max-width` box centered with horizontal `auto` margins, and the `.eyebrow` margin shorthand (`0 0 10px`) clobbered those `auto` margins. On desktop the panel's content box is ~548px wide, so the eyebrow's 470px block hugged the left padding edge and its centered text sat ~38px left of the panel center. Mobile was unaffected because the panel content there is narrower than 470px. The issue's own hypothesis (trailing `letter-spacing: 0.16em` tracking) measures at under 1px and is not the cause, so the letter-spacing and centering rules are untouched.

The fix restores the `auto` horizontal margins in the `.eyebrow` shorthand: `margin: 0 auto 10px`. One rule changed, plus a short comment; no copy, markup, or locale entries touched.

## Related issues

Closes #1233

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - A headless-Chrome (puppeteer-core) measurement script that loads the page and compares the eyebrow text's glyph-box center against the panel's content-box center, for every one of the 14 locales in the page's inline `copy` map, at desktop 1440x900 and mobile 414x896. Before: offset -38px on desktop for every locale. After: offset within 0.02px everywhere (28/28 checks pass), and the logo, heading, description, and status pill boxes are unchanged.
  - `npm test` (728 files, 7851 tests, green)
  - `npx tsc --noEmit` (clean)
  - `npm run build` (green)
  - `npm run security:gate` (PASS)
- Manual steps: opened the page served locally and visually confirmed the label centers under the logo on desktop and mobile viewports (screenshots below).

## Screenshots / recordings

Desktop 1440x900 (`?lang=en_CA`), before / after:

<img src="https://raw.githubusercontent.com/MarchalMaxim/world-of-claudecraft/assets/issue-1233-eyebrow/eyebrow_before_desktop.png" width="49%"> <img src="https://raw.githubusercontent.com/MarchalMaxim/world-of-claudecraft/assets/issue-1233-eyebrow/eyebrow_after_desktop.png" width="49%">

Mobile 414x896 (unaffected by the bug and unchanged by the fix), before / after:

<img src="https://raw.githubusercontent.com/MarchalMaxim/world-of-claudecraft/assets/issue-1233-eyebrow/eyebrow_before_mobile.png" width="33%"> <img src="https://raw.githubusercontent.com/MarchalMaxim/world-of-claudecraft/assets/issue-1233-eyebrow/eyebrow_after_mobile.png" width="33%">

---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green. No `sim/` or `server/` behavior changed (static `public/` page, CSS only), so no unit test applies; verification is the headless measurement above.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build` is green. ~`build:server` / `build:env`~ N/A, not touched.

### Cross-platform

- [x] **Tested on desktop and mobile.** Measured and screenshotted at 1440x900 and 414x896; the fix only restores auto horizontal margins, no touch targets or input sizes involved.
- [x] **Accessible.** No markup, focus, ARIA, or motion changes; layout-only CSS fix.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The page's inline `copy` map is untouched; centering was verified across all 14 inline locales.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)