### PR TITLE
feat(daily-rewards): award delve clear and chest points

### DIFF
--- a/server/daily_rewards.ts
+++ b/server/daily_rewards.ts
@@ -1,5 +1,7 @@
 import { timingSafeEqual } from 'node:crypto';
 import type * as http from 'node:http';
+import { DELVES } from '../src/sim/data';
+import type { LootTier } from '../src/sim/types';
 import type {
   DailyRewardHistory,
   DailyRewardLeaderboardEntry,
@@ -467,6 +469,83 @@ function onlineMultiplierPoints(
   return { points: Math.max(0, Math.floor(basePoints * multiplier)), multiplier };
 }
 
+function delveClearPoints(
+  task: { points: number; basePoints: number; config: Record<string, unknown> },
+  delveId: string,
+  tierId: string,
+  onlineMinutes: number,
+): {
+  points: number;
+  multiplier: number;
+  baseClearPoints: number;
+  levelBonus: number;
+  tierMultiplier: number;
+  preOnlinePoints: number;
+} | null {
+  const delve = DELVES[delveId];
+  if (!delve?.tiers.some((tier) => tier.id === tierId)) return null;
+  const taskConfig = task.config ?? {};
+  const baseClearPoints = numberConfig(
+    taskConfig,
+    'baseClearPoints',
+    task.basePoints ?? task.points,
+  );
+  const levelBaseline = numberConfig(taskConfig, 'levelBaseline', 7);
+  const pointsPerLevel = numberConfig(taskConfig, 'pointsPerLevel', 1);
+  const normalTierMultiplier = numberConfig(taskConfig, 'normalTierMultiplier', 1);
+  const heroicTierMultiplier = numberConfig(taskConfig, 'heroicTierMultiplier', 1.5);
+  const tierMultiplier = tierId === 'heroic' ? heroicTierMultiplier : normalTierMultiplier;
+  const levelBonus = Math.max(0, delve.minLevel - levelBaseline) * pointsPerLevel;
+  const preOnlinePoints = Math.max(0, Math.floor((baseClearPoints + levelBonus) * tierMultiplier));
+  const { points, multiplier } = onlineMultiplierPoints(preOnlinePoints, taskConfig, onlineMinutes);
+  return {
+    points,
+    multiplier,
+    baseClearPoints,
+    levelBonus,
+    tierMultiplier,
+    preOnlinePoints,
+  };
+}
+
+function delveChestOpenPoints(
+  task: { config: Record<string, unknown> },
+  chestTier: LootTier,
+  bountiful: boolean,
+  onlineMinutes: number,
+): {
+  points: number;
+  multiplier: number;
+  chestBasePoints: number;
+  chestTier: LootTier;
+  bountifulMultiplier: number;
+  preOnlinePoints: number;
+} | null {
+  const taskConfig = task.config ?? {};
+  const chestBasePoints =
+    chestTier === 'premium'
+      ? numberConfig(taskConfig, 'premiumChestPoints', 20)
+      : chestTier === 'medium'
+        ? numberConfig(taskConfig, 'mediumChestPoints', 10)
+        : chestTier === 'low'
+          ? numberConfig(taskConfig, 'lowChestPoints', 5)
+          : null;
+  if (chestBasePoints === null) return null;
+  const bountifulMultiplier = bountiful
+    ? numberConfig(taskConfig, 'bountifulChestMultiplier', 1.5)
+    : 1;
+  const preOnlinePoints = Math.max(0, Math.floor(chestBasePoints * bountifulMultiplier));
+  const { points, multiplier } = onlineMultiplierPoints(preOnlinePoints, taskConfig, onlineMinutes);
+  return {
+    points,
+    multiplier,
+    chestBasePoints,
+    chestTier,
+    bountifulMultiplier,
+    preOnlinePoints,
+  };
+}
+
 function currentTaskMultiplier(
   task: { type: string; points: number; basePoints: number; config: Record<string, unknown> },
   onlineMinutes: number,
@@ -474,6 +553,9 @@ function currentTaskMultiplier(
   if (task.type === 'quest_completion')
     return questCompletionPoints(task, onlineMinutes).multiplier;
   if (task.type === 'arena_result')
+    return onlineMultiplierPoints(task.basePoints ?? task.points, task.config ?? {}, onlineMinutes)
+      .multiplier;
+  if (task.type === 'delve_clear')
     return onlineMultiplierPoints(task.basePoints ?? task.points, task.config ?? {}, onlineMinutes)
       .multiplier;
   return null;
@@ -683,6 +765,100 @@ export class DailyRewardService {
         },
       );
       if (recorded) awardedPoints += points;
+    }
+    return awardedPoints;
+  }
+
+  async recordDelveClear(
+    accountId: number,
+    characterId: number | null,
+    delveId: string,
+    tierId: string,
+    completedAt: Date = new Date(),
+  ): Promise<number> {
+    if (!DELVES[delveId]) return 0;
+    const { day, config } = await dailyRewardClock(completedAt);
+    await this.db.ensureDay(day, config.prizePoolUsd, config.wocUsdPrice);
+    await this.db.seedTasks(day, config.tasks);
+    const eligibility = await dailyRewardEligibility(accountId, config);
+    if (!eligibility.eligible) return 0;
+    const tasks = await this.db.tasksForType(day, 'delve_clear');
+    if (tasks.length === 0) return 0;
+    const onlineMinutes = await this.db.onlineMinutesForAccount(day, accountId);
+    let awardedPoints = 0;
+    for (const task of tasks) {
+      const clearPoints = delveClearPoints(task, delveId, tierId, onlineMinutes);
+      if (!clearPoints || clearPoints.points <= 0) continue;
+      const recorded = await this.db.addPoints(
+        day,
+        accountId,
+        'task',
+        clearPoints.points,
+        `task:${task.taskId}:delve:${delveId}:${tierId}:character:${characterId ?? 'account'}:${completedAt.toISOString()}`,
+        {
+          taskId: task.taskId,
+          taskType: task.type,
+          delveId,
+          tierId,
+          characterId,
+          onlineMinutes,
+          multiplier: clearPoints.multiplier,
+          baseClearPoints: clearPoints.baseClearPoints,
+          levelBonus: clearPoints.levelBonus,
+          tierMultiplier: clearPoints.tierMultiplier,
+          preOnlinePoints: clearPoints.preOnlinePoints,
+        },
+      );
+      if (recorded) awardedPoints += clearPoints.points;
+    }
+    return awardedPoints;
+  }
+
+  async recordDelveChestOpen(
+    accountId: number,
+    characterId: number | null,
+    delveId: string,
+    tierId: string,
+    chestTier: LootTier,
+    bountiful: boolean,
+    openedAt: Date = new Date(),
+  ): Promise<number> {
+    if (!DELVES[delveId]) return 0;
+    const { day, config } = await dailyRewardClock(openedAt);
+    await this.db.ensureDay(day, config.prizePoolUsd, config.wocUsdPrice);
+    await this.db.seedTasks(day, config.tasks);
+    const eligibility = await dailyRewardEligibility(accountId, config);
+    if (!eligibility.eligible) return 0;
+    const tasks = await this.db.tasksForType(day, 'delve_clear');
+    if (tasks.length === 0) return 0;
+    const onlineMinutes = await this.db.onlineMinutesForAccount(day, accountId);
+    let awardedPoints = 0;
+    for (const task of tasks) {
+      const chestPoints = delveChestOpenPoints(task, chestTier, bountiful, onlineMinutes);
+      if (!chestPoints || chestPoints.points <= 0) continue;
+      const recorded = await this.db.addPoints(
+        day,
+        accountId,
+        'task',
+        chestPoints.points,
+        `task:${task.taskId}:delve_chest:${delveId}:${tierId}:${chestTier}:${bountiful ? 'bountiful' : 'standard'}:character:${characterId ?? 'account'}:${openedAt.toISOString()}`,
+        {
+          taskId: task.taskId,
+          taskType: task.type,
+          bonusType: 'delve_chest',
+          delveId,
+          tierId,
+          characterId,
+          chestTier: chestPoints.chestTier,
+          bountiful,
+          onlineMinutes,
+          multiplier: chestPoints.multiplier,
+          chestBasePoints: chestPoints.chestBasePoints,
+          bountifulMultiplier: chestPoints.bountifulMultiplier,
+          preOnlinePoints: chestPoints.preOnlinePoints,
+        },
+      );
+      if (recorded) awardedPoints += chestPoints.points;
     }
     return awardedPoints;
   }

--- a/server/daily_rewards.ts
+++ b/server/daily_rewards.ts
@@ -1,7 +1,7 @@
 import { timingSafeEqual } from 'node:crypto';
 import type * as http from 'node:http';
 import { DELVES } from '../src/sim/data';
-import type { LootTier } from '../src/sim/types';
+import type { LootTier } from '../src/sim/lockpick';
 import type {
   DailyRewardHistory,
   DailyRewardLeaderboardEntry,

--- a/server/game.ts
+++ b/server/game.ts
@@ -3869,6 +3869,31 @@ export class GameServer {
           `arena:${s.accountId}:${ev.ratingAfter}`,
           now,
         );
+      } else if (ev.type === 'delveObjectiveComplete' && ev.pid !== undefined) {
+        const s = this.clients.get(ev.pid);
+        if (!s) continue;
+        void dailyRewardService
+          .recordDelveClear(s.accountId, s.characterId, ev.delveId, ev.tierId)
+          .then((points) => {
+            if (points > 0) this.sendDailyRewardPointsGained(s, points);
+          })
+          .catch((err) => console.error('daily reward delve task failed:', err));
+      } else if (ev.type === 'delveChestLoot' && ev.pid !== undefined) {
+        const s = this.clients.get(ev.pid);
+        if (!s) continue;
+        void dailyRewardService
+          .recordDelveChestOpen(
+            s.accountId,
+            s.characterId,
+            ev.delveId,
+            ev.tierId,
+            ev.lootTier,
+            ev.bountiful,
+          )
+          .then((points) => {
+            if (points > 0) this.sendDailyRewardPointsGained(s, points);
+          })
+          .catch((err) => console.error('daily reward delve chest task failed:', err));
       }
     }
   }

--- a/src/sim/delves/drowned_litany_rite.ts
+++ b/src/sim/delves/drowned_litany_rite.ts
@@ -239,7 +239,16 @@ function openDrownedReliquary(
   grantRiteBonus(ctx, run, tier);
   openDelveSurfaceExit(ctx, run);
   for (const pid of members) {
-    ctx.emit({ type: 'delveChestLoot', chestId: st.reliquaryId, items: partyLoot[pid], pid });
+    ctx.emit({
+      type: 'delveChestLoot',
+      chestId: st.reliquaryId,
+      delveId: run.delveId,
+      tierId: run.tierId,
+      lootTier: tier,
+      bountiful: isCoffer,
+      items: partyLoot[pid],
+      pid,
+    });
   }
   emitPartyLog(ctx, run, 'The Drowned Reliquary opens.', '#8cf');
 }

--- a/src/sim/delves/lockpick_controller.ts
+++ b/src/sim/delves/lockpick_controller.ts
@@ -368,7 +368,16 @@ function lockpickSucceed(ctx: SimContext, run: DelveRun, session: LockSession): 
   grantDelveRewards(ctx, run);
   grantLockpickBonus(ctx, run, session.lootTier);
   openDelveSurfaceExit(ctx, run);
-  ctx.emit({ type: 'delveChestLoot', chestId: session.chestId, items, pid: session.ownerId });
+  ctx.emit({
+    type: 'delveChestLoot',
+    chestId: session.chestId,
+    delveId: run.delveId,
+    tierId: run.tierId,
+    lootTier: session.lootTier,
+    bountiful: isCoffer,
+    items,
+    pid: session.ownerId,
+  });
   ctx.emit({
     type: 'lockpickEnd',
     sessionId: session.sessionId,

--- a/src/sim/delves/runs.ts
+++ b/src/sim/delves/runs.ts
@@ -662,6 +662,10 @@ export function onDelveBossDefeated(ctx: SimContext, run: DelveRun): void {
   const layout = DELVE_MODULE_LAYOUTS[moduleId];
   const zBase = delveModuleZOffset(run);
   const dais = layout?.dais ?? { x: 0, z: 52 };
+  const members = run.partyKey ? ctx.partyMembersForKey(run.partyKey) : [];
+  for (const pid of members) {
+    ctx.emit({ type: 'delveObjectiveComplete', delveId: run.delveId, tierId: run.tierId, pid });
+  }
   // Drop any stale module_exit (same z as dais / north passage) before placing rewards.
   for (const id of [...run.objectIds]) {
     if (run.objectState[id]?.kind !== 'module_exit') continue;
@@ -685,7 +689,7 @@ export function onDelveBossDefeated(ctx: SimContext, run: DelveRun): void {
   run.rewardChestId = chest.id;
   run.objectState[chest.id].attemptAvailable = true;
   if (!run.partyKey) return;
-  for (const pid of ctx.partyMembersForKey(run.partyKey)) {
+  for (const pid of members) {
     ctx.emit({
       type: 'log',
       text: 'The boss falls. A warded reliquary chest rises on the dais. Pick its lock to claim your spoils.',

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1941,6 +1941,7 @@ export type SimEvent = { pid?: number } & (
   // delivers it to nearby players; anchorless logs broadcast server-wide
   | { type: 'log'; text: string; color?: string; entityId?: number }
   | { type: 'delveEntered'; delveId: string; tierId: string }
+  | { type: 'delveObjectiveComplete'; delveId: string; tierId: string }
   | { type: 'delveComplete'; delveId: string; tierId: string }
   | { type: 'delveFailed'; delveId: string; tierId: string }
   | { type: 'delveLoreUnlock'; loreId: string }
@@ -1986,7 +1987,15 @@ export type SimEvent = { pid?: number } & (
       lootTier?: LootTier;
     }
   | { type: 'lockpickBonus'; tier: LootTier; marks: number; copper: number }
-  | { type: 'delveChestLoot'; chestId: number; items: { itemId: string; count: number }[] }
+  | {
+      type: 'delveChestLoot';
+      chestId: number;
+      delveId: string;
+      tierId: string;
+      lootTier: LootTier;
+      bountiful: boolean;
+      items: { itemId: string; count: number }[];
+    }
   // Carries the shrine as `entityId` so the server's eventAnchor interest-scopes
   // the pulse to players near the apse instead of broadcasting it realm-wide
   // (the HUD closes the rite popup on the first pulse).

--- a/tests/daily_rewards.test.ts
+++ b/tests/daily_rewards.test.ts
@@ -441,6 +441,263 @@ describe('daily rewards', () => {
     expect(db.score).toBe(90);
   });
 
+  it('awards delve clear task points with level, tier, and online-time scaling', async () => {
+    const db = new FakeDailyRewardDb();
+    const service = new DailyRewardService(db);
+    resetDailyRewardPriceCacheForTests();
+    stubRewardConfig({
+      tasks: [
+        {
+          id: 'delve_clears',
+          type: 'delve_clear',
+          title: 'Clear delves',
+          description: 'Complete delves today.',
+          points: 15,
+          basePoints: 15,
+          sortOrder: 1,
+          active: true,
+          config: {
+            baseClearPoints: 15,
+            levelBaseline: 7,
+            pointsPerLevel: 1,
+            normalTierMultiplier: 1,
+            heroicTierMultiplier: 1.5,
+            lowChestPoints: 5,
+            mediumChestPoints: 10,
+            premiumChestPoints: 20,
+            bountifulChestMultiplier: 1.5,
+            minMultiplier: 1,
+            maxMultiplier: 3,
+            minutesPerMultiplier: 30,
+          },
+        },
+      ],
+    });
+    for (let minute = 0; minute < 60; minute += 1) {
+      await service.recordOnlineMinute(
+        1,
+        new Date(`2026-06-30T12:${String(minute).padStart(2, '0')}:00.000Z`),
+      );
+    }
+
+    await service.recordDelveClear(
+      1,
+      101,
+      'collapsed_reliquary',
+      'normal',
+      new Date('2026-06-30T13:00:00.000Z'),
+    );
+    await service.recordDelveClear(
+      1,
+      101,
+      'collapsed_reliquary',
+      'heroic',
+      new Date('2026-06-30T13:01:00.000Z'),
+    );
+    await service.recordDelveClear(
+      1,
+      101,
+      'drowned_litany',
+      'normal',
+      new Date('2026-06-30T13:02:00.000Z'),
+    );
+    await service.recordDelveClear(
+      1,
+      101,
+      'drowned_litany',
+      'heroic',
+      new Date('2026-06-30T13:03:00.000Z'),
+    );
+
+    const taskEvents = db.events.filter((event) => event.kind === 'task');
+    expect(taskEvents).toHaveLength(4);
+    expect(taskEvents[0]).toMatchObject({
+      points: 45,
+      key: 'task:delve_clears:delve:collapsed_reliquary:normal:character:101:2026-06-30T13:00:00.000Z',
+      meta: {
+        delveId: 'collapsed_reliquary',
+        tierId: 'normal',
+        onlineMinutes: 60,
+        multiplier: 3,
+        baseClearPoints: 15,
+        levelBonus: 0,
+        tierMultiplier: 1,
+        preOnlinePoints: 15,
+      },
+    });
+    expect(taskEvents[1]).toMatchObject({
+      points: 66,
+      meta: {
+        delveId: 'collapsed_reliquary',
+        tierId: 'heroic',
+        tierMultiplier: 1.5,
+        preOnlinePoints: 22,
+      },
+    });
+    expect(taskEvents[2]).toMatchObject({
+      points: 60,
+      meta: {
+        delveId: 'drowned_litany',
+        tierId: 'normal',
+        levelBonus: 5,
+        preOnlinePoints: 20,
+      },
+    });
+    expect(taskEvents[3]).toMatchObject({
+      points: 90,
+      meta: {
+        delveId: 'drowned_litany',
+        tierId: 'heroic',
+        tierMultiplier: 1.5,
+        preOnlinePoints: 30,
+      },
+    });
+    expect(db.score).toBe(261);
+  });
+
+  it('awards delve chest bonus points by chest tier with online-time scaling', async () => {
+    const db = new FakeDailyRewardDb();
+    const service = new DailyRewardService(db);
+    resetDailyRewardPriceCacheForTests();
+    stubRewardConfig({
+      tasks: [
+        {
+          id: 'delve_clears',
+          type: 'delve_clear',
+          title: 'Clear delves',
+          description: 'Complete delves today.',
+          points: 15,
+          basePoints: 15,
+          sortOrder: 1,
+          active: true,
+          config: {
+            lowChestPoints: 5,
+            mediumChestPoints: 10,
+            premiumChestPoints: 20,
+            bountifulChestMultiplier: 1.5,
+            minMultiplier: 1,
+            maxMultiplier: 3,
+            minutesPerMultiplier: 30,
+          },
+        },
+      ],
+    });
+    for (let minute = 0; minute < 30; minute += 1) {
+      await service.recordOnlineMinute(
+        1,
+        new Date(`2026-06-30T12:${String(minute).padStart(2, '0')}:00.000Z`),
+      );
+    }
+
+    await service.recordDelveChestOpen(
+      1,
+      101,
+      'collapsed_reliquary',
+      'normal',
+      'low',
+      false,
+      new Date('2026-06-30T13:00:00.000Z'),
+    );
+    await service.recordDelveChestOpen(
+      1,
+      101,
+      'collapsed_reliquary',
+      'normal',
+      'medium',
+      false,
+      new Date('2026-06-30T13:01:00.000Z'),
+    );
+    await service.recordDelveChestOpen(
+      1,
+      101,
+      'collapsed_reliquary',
+      'normal',
+      'premium',
+      true,
+      new Date('2026-06-30T13:02:00.000Z'),
+    );
+
+    const taskEvents = db.events.filter((event) => event.kind === 'task');
+    expect(taskEvents).toHaveLength(3);
+    expect(taskEvents[0]).toMatchObject({
+      points: 10,
+      meta: {
+        bonusType: 'delve_chest',
+        delveId: 'collapsed_reliquary',
+        tierId: 'normal',
+        chestTier: 'low',
+        bountiful: false,
+        onlineMinutes: 30,
+        multiplier: 2,
+        chestBasePoints: 5,
+        bountifulMultiplier: 1,
+        preOnlinePoints: 5,
+      },
+    });
+    expect(taskEvents[1]).toMatchObject({
+      points: 20,
+      meta: {
+        chestTier: 'medium',
+        chestBasePoints: 10,
+        preOnlinePoints: 10,
+      },
+    });
+    expect(taskEvents[2]).toMatchObject({
+      points: 60,
+      meta: {
+        chestTier: 'premium',
+        bountiful: true,
+        chestBasePoints: 20,
+        bountifulMultiplier: 1.5,
+        preOnlinePoints: 30,
+      },
+    });
+    expect(db.score).toBe(90);
+  });
+
+  it('does not award delve clear task points when locked or unconfigured', async () => {
+    const db = new FakeDailyRewardDb();
+    const service = new DailyRewardService(db);
+    resetDailyRewardPriceCacheForTests();
+    stubRewardConfig({
+      tasks: [
+        {
+          id: 'delve_clears',
+          type: 'delve_clear',
+          title: 'Clear delves',
+          description: 'Complete delves today.',
+          points: 15,
+          basePoints: 15,
+          sortOrder: 1,
+          active: true,
+          config: {},
+        },
+      ],
+    });
+
+    balanceMock.value = 0;
+    await service.recordDelveClear(
+      1,
+      101,
+      'collapsed_reliquary',
+      'normal',
+      new Date('2026-06-30T13:00:00.000Z'),
+    );
+    expect(db.events.filter((event) => event.kind === 'task')).toHaveLength(0);
+
+    balanceMock.value = 50;
+    resetDailyRewardPriceCacheForTests();
+    stubRewardConfig({ tasks: [] });
+    await service.recordDelveClear(
+      1,
+      101,
+      'collapsed_reliquary',
+      'normal',
+      new Date('2026-06-30T13:01:00.000Z'),
+    );
+    expect(db.events.filter((event) => event.kind === 'task')).toHaveLength(0);
+  });
+
   it('uses a non-linear top-heavy payout split that sums to all prizes', () => {
     const splits = dailyRewardPayoutSplits();
     expect(splits).toEqual([0.2, 0.15, 0.12, 0.1, 0.09, 0.08, 0.075, 0.07, 0.065, 0.05]);

--- a/tests/delves.test.ts
+++ b/tests/delves.test.ts
@@ -776,8 +776,8 @@ describe('delve reward chest + surface exit flow', () => {
   function killBoss(sim: ReturnType<typeof makeSim>, _run: ReturnType<typeof enterFinale>) {
     const boss = [...sim.entities.values()].find((e) => e.templateId === 'deacon_varric')!;
     (sim as any).dealDamage(sim.player, boss, boss.maxHp + 1, false, 'physical', null, 'hit', true);
-    sim.tick();
-    return boss;
+    const events = sim.tick();
+    return { boss, events };
   }
 
   // Drive the lockpicking minigame to a flawless solve. Returns the chest id.
@@ -805,7 +805,7 @@ describe('delve reward chest + surface exit flow', () => {
     sim.setPlayerLevel(DELVES.collapsed_reliquary.minLevel);
     const run = enterFinale(sim);
     const playerPosBefore = { ...sim.player.pos };
-    killBoss(sim, run);
+    const { events } = killBoss(sim, run);
 
     // run.completed still false, chest not yet opened
     expect(run.completed).toBe(false);
@@ -818,6 +818,12 @@ describe('delve reward chest + surface exit flow', () => {
     const chestId = run.objectIds.find((id) => run.objectState[id]?.kind === 'locked_chest');
     expect(chestId).toBeDefined();
     expect(run.rewardChestId).not.toBeNull();
+    expect(events).toContainEqual({
+      type: 'delveObjectiveComplete',
+      delveId: 'collapsed_reliquary',
+      tierId: 'normal',
+      pid: sim.playerId,
+    });
     expect(run.objectState[chestId!].attemptAvailable).toBe(true);
     expect(run.objectState[chestId!].open).toBe(false);
   });
@@ -885,6 +891,7 @@ describe('delve reward chest + surface exit flow', () => {
 
     const marksBefore = sim.delveMarksFor(sim.playerId);
     const chestId = pickLockFlawless(sim, run, 1);
+    const events = sim.drainEvents();
 
     expect(run.completed).toBe(true);
     // base clear (+1 mark) + premium ante bonus (+2 marks)
@@ -892,6 +899,16 @@ describe('delve reward chest + surface exit flow', () => {
     expect(run.objectState[chestId].looted).toBe(true);
     expect(run.objectState[chestId].open).toBe(true);
     expect(run.objectState[chestId].lootedTier).toBe('premium');
+    expect(events).toContainEqual({
+      type: 'delveChestLoot',
+      chestId,
+      delveId: 'collapsed_reliquary',
+      tierId: 'normal',
+      lootTier: 'premium',
+      bountiful: false,
+      items: run.objectState[chestId].pendingLoot,
+      pid: sim.playerId,
+    });
     expect(run.lockpick).toBeNull();
     // surface exit spawned
     expect(run.surfaceExitId).not.toBeNull();

--- a/tests/parity/golden/delve_lockpick.json
+++ b/tests/parity/golden/delve_lockpick.json
@@ -153,7 +153,7 @@
       "time": 1.9,
       "nextId": 416,
       "state": "ed3ce5e6",
-      "events": "0a56b75f",
+      "events": "6c6bd0f2",
       "rng": {
         "draws": 8,
         "digest": "20464699"

--- a/tests/parity/golden/delve_lockpick_fail.json
+++ b/tests/parity/golden/delve_lockpick_fail.json
@@ -120,7 +120,7 @@
       "time": 0.5,
       "nextId": 412,
       "state": "249bb1be",
-      "events": "32297f59",
+      "events": "b2a5ec1f",
       "rng": {
         "draws": 3,
         "digest": "ad960248"

--- a/tests/parity/golden/drowned_litany.json
+++ b/tests/parity/golden/drowned_litany.json
@@ -661,7 +661,7 @@
       "time": 20.5,
       "nextId": 434,
       "state": "404978c8",
-      "events": "2599ed97",
+      "events": "09142b93",
       "rng": {
         "draws": 2032,
         "digest": "41807424"

--- a/tests/server/daily_rewards_routes.test.ts
+++ b/tests/server/daily_rewards_routes.test.ts
@@ -752,5 +752,7 @@ describe('dailyRewardService singleton', () => {
     expect(typeof dailyRewardService.recordOnlineMinute).toBe('function');
     expect(typeof dailyRewardService.recordQuestCompletion).toBe('function');
     expect(typeof dailyRewardService.recordArenaResult).toBe('function');
+    expect(typeof dailyRewardService.recordDelveClear).toBe('function');
+    expect(typeof dailyRewardService.recordDelveChestOpen).toBe('function');
   });
 });


### PR DESCRIPTION
## Summary
- add delve daily reward scoring for final boss/objective completion
- add chest-open bonus scoring based on lockpick loot tier, with bountiful multiplier support
- emit structured delve chest metadata from the sim and wire server-side reward hooks
- add daily reward service and delve coverage for clear and chest point calculations

## Validation
- npx vitest run tests/delves.test.ts tests/lockpick_session.test.ts tests/daily_rewards.test.ts tests/server/daily_rewards_routes.test.ts
- git diff --cached --check

## Notes
- Branch is based on origin/release/v0.22.0.
- package-lock.json is intentionally left uncommitted because it was an unrelated local diff.