### PR TITLE
fix(sim): keep every world-boss damager on the loot roster, even after death

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -860,6 +860,7 @@ function blankEntity(id: number): Entity {
     enraged: false,
     healedThisPull: false,
     threat: new Map(),
+    bossDamagers: new Set(),
     forcedTargetId: null,
     forcedTargetTimer: 0,
     ownerId: null,

--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -44,7 +44,7 @@ import {
   virtualLevel,
   xpForLevel,
 } from '../types';
-import { WORLD_BOSS_CORPSE_SECONDS, worldBossContributors } from '../world_boss';
+import { WORLD_BOSS_CORPSE_SECONDS, worldBossLootContributors } from '../world_boss';
 
 // How long a slain mob's corpse persists (seconds) before it is cleared. Sole user
 // is handleDeath, so the constant lives here with the death-domain code.
@@ -330,6 +330,16 @@ export function dealDamage(
     else if (source.ownerId !== null) target.tappedById = source.ownerId;
   }
 
+  // World-boss loot roster: every player (or pet owner) who lands a hit on a world
+  // boss becomes a permanent loot contributor. Unlike the hate table above, this set
+  // is NEVER pruned when they die, release their spirit, or drop off threat, so a
+  // raider who died to the boss still gets their personal drop. Read at death by
+  // worldBossLootContributors. Only world-boss templates ever populate it.
+  if (source && amount > 0 && MOBS[target.templateId]?.worldBoss) {
+    const contributorId = source.kind === 'player' ? source.id : source.ownerId;
+    if (contributorId !== null) target.bossDamagers.add(contributorId);
+  }
+
   if (source && source.kind === 'player' && source.id !== target.id) {
     const meta = ctx.players.get(source.id);
     if (meta) meta.counters.damageDealt += amount;
@@ -568,7 +578,7 @@ export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): 
     // collapse with the boss: leaving them alive would harass looters for the
     // whole window, and a slain add's in-place respawn timer would revive it
     // mid-window (only fires for worldBoss templates, so no parity rng change).
-    const worldBossContribs = template?.worldBoss ? worldBossContributors(ctx, e) : null;
+    const worldBossContribs = template?.worldBoss ? worldBossLootContributors(ctx, e) : null;
     if (template?.worldBoss) {
       e.corpseTimer = WORLD_BOSS_CORPSE_SECONDS;
       e.respawnTimer = Infinity;

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -97,6 +97,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     enraged: false,
     healedThisPull: false,
     threat: new Map(),
+    bossDamagers: new Set(),
     forcedTargetId: null,
     forcedTargetTimer: 0,
     ownerId: null,

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1571,6 +1571,12 @@ export interface Entity {
    *  Wiped on evade/respawn/death; drives target selection with the 110%
    *  melee / 130% ranged pull-over rules. */
   threat: Map<number, number>;
+  /** World-boss loot roster: every player id (pet threat credited to the owner) that
+   *  has damaged this world boss since it was pulled. Unlike `threat`, it is NEVER
+   *  pruned when a contributor dies, releases their spirit, leaves range, or drops off
+   *  the hate table, so a raider who died to the boss keeps their personal loot rights.
+   *  Only ever written for `worldBoss` templates; empty on every other entity. */
+  bossDamagers: Set<number>;
   forcedTargetId: number | null; // taunt/growl: attack this target while the timer runs
   forcedTargetTimer: number; // seconds left on the forced-attack window
   ownerId: number | null; // controlled pets: owning player's entity id (null = wild)

--- a/src/sim/world_boss.ts
+++ b/src/sim/world_boss.ts
@@ -29,9 +29,12 @@ import type { Entity, LootSlot } from './types';
 export const WORLD_BOSS_INTERVAL_SECONDS = 1 * 3600;
 
 // How long a slain world boss's lootable corpse lingers before it is removed. Much
-// longer than a normal corpse so every contributor has time to walk over and loot
-// their personal drops; the scheduler drops the entity once this elapses.
-export const WORLD_BOSS_CORPSE_SECONDS = 300;
+// longer than a normal corpse (and than the raid needs to clear trash) so every
+// contributor has time to walk over and loot their personal drops, INCLUDING those
+// who died to the boss and have to run back from the graveyard and resurrect first
+// (a ghost cannot loot). Well inside the spawn cadence, so corpse windows never
+// overlap. The scheduler drops the entity once this elapses.
+export const WORLD_BOSS_CORPSE_SECONDS = 900;
 
 export interface WorldBossDef {
   // MobTemplate id (must have `worldBoss: true`).
@@ -121,6 +124,34 @@ export function worldBossContributors(ctx: SimContext, mob: Entity): PlayerMeta[
   return out.sort((a, b) => a.entityId - b.entityId);
 }
 
+// The LOOT roster for a slain world boss: everyone eligible for a personal drop. This
+// is the permanent damager set (`mob.bossDamagers`, every player who hit the boss since
+// it was pulled, never pruned) UNIONED with whoever still remains on the live hate table
+// at death (a healer who threat-built but never dealt damage; pet threat credited to the
+// owner). Deduped, resolved to live PlayerMeta, sorted by entityId so downstream rng
+// draws stay in a fixed order. Unlike worldBossContributors (the hate-table-only view the
+// HP scaler uses), this SURVIVES a contributor dying or dropping off threat: the whole
+// point is that a raider who died to the boss still gets their loot. Read BEFORE
+// handleDeath clears the boss's threat (the damager set survives that clear regardless).
+export function worldBossLootContributors(ctx: SimContext, mob: Entity): PlayerMeta[] {
+  const seen = new Set<number>();
+  const out: PlayerMeta[] = [];
+  const add = (pid: number) => {
+    if (seen.has(pid)) return;
+    seen.add(pid);
+    const meta = ctx.players.get(pid);
+    if (meta) out.push(meta);
+  };
+  // Permanent damagers (already owner-resolved player ids), then anyone still on the
+  // hate table (pets credit their owner, exactly as worldBossContributors resolves).
+  for (const pid of mob.bossDamagers) add(pid);
+  for (const attackerId of mob.threat.keys()) {
+    const attacker = ctx.entities.get(attackerId);
+    add(attacker && attacker.ownerId !== null ? attacker.ownerId : attackerId);
+  }
+  return out.sort((a, b) => a.entityId - b.entityId);
+}
+
 // Retail-style participant HP scaling, driven each tick by the scheduler while the
 // boss is alive. The target pool is `base + perPlayer * (participants - 1)` clamped
 // to `max`, where participants is the deduped player count on the hate table. It only
@@ -164,13 +195,13 @@ export function rollWorldBossLoot(ctx: SimContext, mob: Entity, contributors: Pl
   if (!template) return;
   const items: LootSlot[] = mob.loot?.items ?? [];
   const copper = mob.loot?.copper ?? 0;
-  // contributors arrive sorted by entityId (worldBossContributors); iterate in that
-  // fixed order so the rng draw order is deterministic for the parity gate.
-  // Eligibility is checked here, but the daily lockout is consumed only when the
-  // player actually LOOTS a personal slot (lootCorpse in interaction.ts): a
-  // contributor who dies or never reaches the corpse inside the loot window keeps
-  // their daily and can try again at the next spawn. Corpse windows (300s) never
-  // overlap the 3h cadence, so at most one corpse is ever lootable at a time.
+  // contributors arrive sorted by entityId (worldBossLootContributors); iterate in
+  // that fixed order so the rng draw order is deterministic for the parity gate.
+  // Eligibility is checked here, but the lockout is consumed only when the player
+  // actually LOOTS a personal slot (lootCorpse in interaction.ts): a contributor who
+  // dies or never reaches the corpse inside the loot window keeps their lockout and
+  // can try again at the next spawn. The corpse window (WORLD_BOSS_CORPSE_SECONDS)
+  // never overlaps the spawn cadence, so at most one corpse is ever lootable at a time.
   for (const meta of contributors) {
     if (!isWorldBossLootEligible(meta, mob.templateId, ctx.lockoutNowMs())) continue;
     const rolledGroups = new Set<string>();

--- a/tests/world_boss.test.ts
+++ b/tests/world_boss.test.ts
@@ -5,6 +5,7 @@ import type { Entity, SimEvent } from '../src/sim/types';
 import {
   isWorldBossLootEligible,
   markWorldBossLooted,
+  WORLD_BOSS_CORPSE_SECONDS,
   WORLD_BOSS_INTERVAL_SECONDS,
   WORLD_BOSSES,
   worldBossLockoutId,
@@ -424,6 +425,80 @@ describe('world boss personal loot', () => {
       return JSON.stringify(boss.loot?.items ?? []);
     };
     expect(run()).toBe(run());
+  });
+});
+
+describe('world boss loot roster survives contributor death and grouping', () => {
+  it('keeps a contributor who DIED to the boss on the loot roster (not just the hate table)', () => {
+    const sim = makeSim();
+    sim.utcDay = DAY;
+    const p1 = sim.addPlayer('warrior', 'Ada');
+    const p2 = sim.addPlayer('mage', 'Bru');
+    const { boss } = spawnBossNow(sim);
+    const e1 = (sim as any).entities.get(p1) as Entity;
+    const e2 = (sim as any).entities.get(p2) as Entity;
+    // Both land a hit: both go on the hate table AND the permanent damager roster.
+    (sim as any).dealDamage(e1, boss, 10, false, 'physical', 'Chip', 'hit', true);
+    (sim as any).dealDamage(e2, boss, 10, false, 'physical', 'Chip', 'hit', true);
+    expect(boss.threat.has(p2)).toBe(true);
+
+    // p2 dies to the boss: handleDeath drops them from EVERY hate table (the classic
+    // "the dead fall off threat" prune) so the boss re-targets. This is exactly what
+    // used to strip a fallen raider's loot rights.
+    (sim as any).dealDamage(boss, e2, 999_999, false, 'physical', 'Boss', 'hit', true);
+    expect(e2.dead).toBe(true);
+    expect(boss.threat.has(p2)).toBe(false); // pruned off the live hate table...
+    expect(boss.bossDamagers.has(p2)).toBe(true); // ...but kept on the permanent roster
+
+    // p1 lands the killing blow.
+    (sim as any).dealDamage(e1, boss, 999_999, false, 'physical', 'Finisher', 'hit', true);
+    expect(boss.dead).toBe(true);
+
+    // Both contributors get their own personal drop, including the one who died.
+    const owners = (boss.loot?.items ?? []).flatMap((s) => s.personalFor ?? []);
+    expect(owners).toContain(p1);
+    expect(owners).toContain(p2);
+  });
+
+  it('lets a slain world boss corpse linger far longer than a normal corpse', () => {
+    const sim = makeSim();
+    const p1 = sim.addPlayer('warrior', 'Ada');
+    const { boss } = spawnBossNow(sim);
+    const e1 = (sim as any).entities.get(p1) as Entity;
+    (sim as any).dealDamage(e1, boss, 999_999, false, 'physical', 'Finisher', 'hit', true);
+    expect(boss.dead).toBe(true);
+    expect(boss.corpseTimer).toBe(WORLD_BOSS_CORPSE_SECONDS);
+    // Generous enough that a corpse-runner can resurrect and walk back before it drops.
+    expect(WORLD_BOSS_CORPSE_SECONDS).toBeGreaterThanOrEqual(900);
+  });
+
+  it('never routes a world-boss epic through a party need/greed roll (personal loot only)', () => {
+    const sim = makeSim();
+    sim.utcDay = DAY;
+    const p1 = sim.addPlayer('warrior', 'Ada');
+    const p2 = sim.addPlayer('mage', 'Bru');
+    // Party them up: the default party loot strategy rolls premium (epic) items as
+    // need/greed. If a boss epic ever reached the shared path, this is where it would.
+    sim.partyInvite(p1, p2);
+    sim.partyAccept(p2);
+    const { boss } = spawnBossNow(sim);
+    const e1 = (sim as any).entities.get(p1) as Entity;
+    const e2 = (sim as any).entities.get(p2) as Entity;
+    (sim as any).dealDamage(e1, boss, 10, false, 'physical', 'Chip', 'hit', true);
+    (sim as any).dealDamage(e2, boss, 10, false, 'physical', 'Chip', 'hit', true);
+    (sim as any).dealDamage(e1, boss, 999_999, false, 'physical', 'Finisher', 'hit', true);
+    expect(boss.dead).toBe(true);
+
+    // Every slot is a single-owner personal drop even for a grouped raid: an epic can
+    // never enter a shared (need/greed) roll the party would have to fight over.
+    for (const slot of boss.loot?.items ?? []) {
+      expect(slot.personalFor && slot.personalFor.length === 1).toBe(true);
+      expect(slot.openToAll).toBeFalsy();
+    }
+    // Looting the personal drops opens NO group roll: they go straight to the bags.
+    e1.pos = { ...boss.pos };
+    sim.lootCorpse(boss.id, p1);
+    expect((sim as any).pendingLootRolls.size).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes a cluster of Thunzharr (world boss) loot problems reported from the live realm.

The world boss awards **personal** loot to every contributor, but the contributor roster was derived from the boss's **live hate table**. The sim prunes the hate table the instant a player dies (the classic "the dead fall off threat" rule in `handleDeath`), so a raider who died to the boss was stripped from the roster and got **no personal drop**. On top of that, the lootable corpse only lingered 300s, which could expire before players who died had resurrected and run back.

This PR:

- Adds a persistent `bossDamagers: Set<number>` on `Entity` that records every player (pet threat credited to the owner) who lands a hit on a world boss. Unlike the hate table, it is **never pruned** when a contributor dies, releases their spirit, leaves range, or drops off threat. So anyone who has hit the boss since it was pulled keeps their loot rights.
- Rolls world-boss loot from a new `worldBossLootContributors()` (the persistent damager set unioned with whoever still remains on the hate table, e.g. a healer who is still alive), sorted by `entityId` so the rng draw order stays deterministic.
- Extends the lootable-corpse window `300s -> 900s` (`WORLD_BOSS_CORPSE_SECONDS`) so a slain contributor has time to resurrect and run back before the corpse is removed. Still well inside the spawn cadence, so corpse windows never overlap.

On the group-loot concern: world-boss loot was **already** personal (`personalFor` slots looted straight to the player, never routed through a party need/greed roll), so a grouped raider's epic is never shared for the party to roll on. A new test pins that guarantee explicitly, including a party with the default need/greed premium-item strategy.

The damager set is server-sim-internal and is **never wired** to clients (it mirrors the existing `threat` map); loot resolves server-side. It is initialized in both the offline `Sim` (`baseEntity`) and the online `ClientWorld` (`blankEntity`) entity constructors.

## Related issues

Addresses the reported Thunzharr issues: corpse despawning before everyone loots, loot rights lost on death, and the request that anyone who hit the boss can loot.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/world_boss.test.ts tests/dead_party_loot.test.ts` (37 passed, incl. 3 new roster tests)
  - `npx vitest run tests/parity` (162 passed, 1 skipped: rng draw-order digest unchanged)
  - `npx vitest run tests/architecture.test.ts tests/entity_roster.test.ts tests/sim_context.test.ts tests/loot_roll.test.ts tests/autoloot.test.ts tests/raid_lockout_world.test.ts tests/loot_ffa_sim.test.ts tests/loot_drops.test.ts tests/loot_roll_wire.test.ts tests/world_api_parity.test.ts tests/loot_master_sim.test.ts` (all green)
  - `npx tsc --noEmit` clean (one pre-existing unrelated `prom-client` missing-dep error on the base branch, not from this change)
  - `npx @biomejs/biome check` on changed files: no format diffs
- New tests:
  - A contributor who **died** to the boss (pruned off the hate table) still lands on the loot roster and receives their `personalFor` slot.
  - A slain world-boss corpse lingers for `WORLD_BOSS_CORPSE_SECONDS` (>= 900s).
  - In a party, every world-boss slot is single-owner `personalFor`, and looting opens zero `pendingLootRolls` (an epic never enters a group roll).

## Notes for reviewers

- Determinism: the new recording draws no rng and is guarded by `MOBS[target.templateId]?.worldBoss`, so it cannot perturb the draw stream for ordinary mobs; the loot list is sorted by `entityId` before any per-contributor roll.
- The roster intentionally accumulates across a mid-fight evade rather than clearing with `clearThreat`: a knockback mechanic that briefly evades the boss must not wipe eligibility mid-fight (that would re-introduce the bug). Bounded by the per-boss loot lockout.
