### PR TITLE
fix(render): boot prewarm must skip lazyPreload visuals (renderer crash)

### DIFF
--- a/src/render/characters/manifest.ts
+++ b/src/render/characters/manifest.ts
@@ -1048,6 +1048,14 @@ const NPC_KEYS: Record<string, string> = {
   spirit_healer: 'npc_villager_robed',
 };
 
+/** True if a visual model is excluded from the boot preload sweep (lazyPreload).
+ *  The boot prewarm must SKIP these — their GLB isn't loaded yet, so building one
+ *  would throw "character asset not preloaded". They load on demand when first
+ *  needed (e.g. the first time such a mob spawns in-world). */
+export function isVisualLazy(visualKey: string): boolean {
+  return !!VISUALS[visualKey]?.lazyPreload;
+}
+
 export function visualKeyFor(e: Entity): string {
   if (e.kind === 'player') {
     if (e.skinCatalog === 'mech') return 'player_mech';

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -41,7 +41,7 @@ import { type CameraOcclusionState, stepCameraOcclusion } from './camera_collisi
 import { characterSoulRendActive } from './character_effects';
 import { type AnimState, type CharacterVisual, createCharacterVisual } from './characters';
 import { mechAssetsReady, preloadMechAssets } from './characters/assets';
-import { skinCount, visualKeyFor } from './characters/manifest';
+import { isVisualLazy, skinCount, visualKeyFor } from './characters/manifest';
 import { CLICK_MARKER_LIFETIME, clickMarkerAnim, clickMarkerColor } from './click_marker';
 import { trackWebGLContext } from './context_release';
 import { buildCritters, type CritterField } from './critters';
@@ -2216,7 +2216,16 @@ export class Renderer {
       if (!template) return;
       for (let i = 0; i < copies; i++) {
         const entity = this.prewarmEntity('mob', template.id, template.color, template.scale);
-        builtModels.add(visualKeyFor(entity));
+        const vkey = visualKeyFor(entity);
+        // Skip lazy-preloaded models: their GLB isn't in the boot preload sweep, so
+        // building one here throws "character asset not preloaded" and crashes the
+        // renderer at boot. They warm up on demand the first time such a mob spawns.
+        // Still mark it built so the tail loop below doesn't retry it.
+        if (isVisualLazy(vkey)) {
+          builtModels.add(vkey);
+          continue;
+        }
+        builtModels.add(vkey);
         const visual = createCharacterVisual(entity);
         const poolKey = this.visualPoolKeyFor(entity);
         if (poolKey) this.storePooledVisual(poolKey, visual);

--- a/tests/prewarm_lazy_visual.test.ts
+++ b/tests/prewarm_lazy_visual.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { isVisualLazy } from '../src/render/characters/manifest';
+
+// Guards the boot-prewarm crash fix: a lazyPreload visual must be reported as lazy
+// so the renderer's prewarm sweep skips building it (its GLB isn't loaded at boot,
+// and building one throws "character asset not preloaded"). player_mech is the
+// upstream visual flagged lazyPreload: true.
+describe('isVisualLazy', () => {
+  it('is true for a lazyPreload visual (player_mech)', () => {
+    expect(isVisualLazy('player_mech')).toBe(true);
+  });
+
+  it('is false for an eagerly-preloaded visual (player_warrior)', () => {
+    expect(isVisualLazy('player_warrior')).toBe(false);
+  });
+
+  it('is false for an unknown visual key', () => {
+    expect(isVisualLazy('definitely_not_a_real_visual_key')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The boot prewarm sweep (`buildEntityPrewarmGroup` in `renderer.ts`) builds one copy of every distinct mob visual up front to compile its shader. But a visual flagged `lazyPreload: true` is deliberately excluded from the boot preload sweep — its GLB is fetched on demand the first time such a mob spawns. Building one at boot throws `character asset not preloaded` and takes down the renderer (the client sees "the server closed the connection").

This is latent on `main` today: `player_mech` is flagged `lazyPreload: true`, so any code path that makes prewarm iterate it will crash the boot.

## Fix

The **preload** sweep already guards this — `manifest.ts` has `if (def.lazyPreload) continue;`. The **prewarm** sweep did not. This adds an `isVisualLazy()` helper next to `visualKeyFor()` and skips lazy visuals in prewarm the same way, still marking the key built so the tail loop doesn't retry it. Lazy models warm up correctly on their real first spawn; eagerly-preloaded visuals are unaffected.

## Test

`tests/prewarm_lazy_visual.test.ts` covers `isVisualLazy()` over a lazy visual (`player_mech`), an eager one (`player_warrior`), and an unknown key.

- `npx tsc --noEmit` clean
- `npx vitest run tests/prewarm_lazy_visual.test.ts tests/architecture.test.ts` green
- `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)