### PR TITLE
feat(market): add Legendary to World Market rarity filter

### DIFF
--- a/src/sim/market_query.ts
+++ b/src/sim/market_query.ts
@@ -37,7 +37,7 @@ export const MARKET_WEAPON_TYPE_FILTERS = [
   'axe',
   'other',
 ] as const;
-export const MARKET_RARITY_FILTERS = ['all', 'poor', 'common', 'uncommon', 'rare', 'epic'] as const;
+export const MARKET_RARITY_FILTERS = ['all', 'poor', 'common', 'uncommon', 'rare', 'epic', 'legendary'] as const;
 
 // Listings per browse page (the count of OTHER sellers' listings shown at a time;
 // the player's own listings are always wired on top for quick reclaim).

--- a/src/ui/i18n.catalog/items.ts
+++ b/src/ui/i18n.catalog/items.ts
@@ -149,6 +149,7 @@ const itemStringsEn = {
       rarityUncommon: 'Uncommon',
       rarityRare: 'Rare',
       rarityEpic: 'Epic',
+      rarityLegendary: 'Legendary',
       merchantStock: 'Merchant stock',
       stackCount: 'x{count}',
       each: '{money} each',

--- a/src/ui/market_window.ts
+++ b/src/ui/market_window.ts
@@ -698,6 +698,7 @@ export class MarketWindow {
     if (filter === 'uncommon') return t('itemUi.market.rarityUncommon');
     if (filter === 'rare') return t('itemUi.market.rarityRare');
     if (filter === 'epic') return t('itemUi.market.rarityEpic');
+    if (filter === 'legendary') return t('itemUi.market.rarityLegendary');
     return t('itemUi.market.filterRarityAll');
   }
 

--- a/tests/market_filters.test.ts
+++ b/tests/market_filters.test.ts
@@ -58,7 +58,7 @@ describe('World Market filters', () => {
       'axe',
       'other',
     ]);
-    expect(MARKET_RARITY_FILTERS).toEqual(['all', 'poor', 'common', 'uncommon', 'rare', 'epic']);
+    expect(MARKET_RARITY_FILTERS).toEqual(['all', 'poor', 'common', 'uncommon', 'rare', 'epic', 'legendary']);
   });
 
   it('groups wearable armor separately from weapons and consumables', () => {


### PR DESCRIPTION
## Summary

Adds `'legendary'` to the World Market rarity filter dropdown. Legendary-tier items existed in the game but were not selectable in the browse filter, making them impossible to filter for. This extends `MARKET_RARITY_FILTERS` in the authoritative `market_query.ts` (used by both server-side filtering and the client UI), adds the `rarityLegendary` i18n key to the English catalog, and wires up the label in `marketRarityLabel()`.

## Related issues

N/A

## Type of change

- [x] Feature: new functionality

## How was this tested?

- Commands: `npx vitest run tests/market_filters.test.ts` — all 8 tests pass including the updated filter snapshot
- Manual steps: Opened the World Market browse tab, confirmed "Legendary" appears as a rarity filter option and correctly filters legendary items

## Screenshots / recordings

I added 2 dummy items for testing purposes. Not included in the commit

<img width="572" height="653" alt="image" src="https://github.com/user-attachments/assets/e3fb10ba-ee3b-4453-bfc6-cbc52616d336" />
<img width="572" height="653" alt="image" src="https://github.com/user-attachments/assets/7064c8dd-39b2-4556-b156-8508faf2ee56" />

---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green. Updated the `MARKET_RARITY_FILTERS` snapshot test in `tests/market_filters.test.ts`.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.**

### Cross-platform

- ~Tested on desktop and mobile.~ No layout change; filter menu already handles variable option counts.
- ~Accessible.~ No new interactive elements; the existing filter menu pattern is already keyboard-operable.

### Localization (i18n)

- [x] **New player-visible strings are translated into every supported locale.** Added `rarityLegendary: 'Legendary'` to the English catalog (`src/ui/i18n.catalog/items.ts`) and rendered via `t('itemUi.market.rarityLegendary')`. Per contributor convention, English only — maintainer fills other locales at release.
- [x] N/A for sim/server player-facing text (change is UI-only).

### Hygiene

- [x] No secrets, credentials, or `.env` committed.
- [x] No generated files hand-edited.