### PR TITLE
fix(desktop): disable Linux launcher download

### DIFF
--- a/index.html
+++ b/index.html
@@ -1004,9 +1004,9 @@
               data-i18n="download.macCta"
             >Download for macOS</a>
             <a
-              class="btn btn-primary desktop-download-link"
+              class="btn btn-primary desktop-download-link is-unavailable"
               data-platform="linux"
-              href="https://updates.worldofclaudecraft.com/desktop/world-of-claudecraft-0.21.0-linux-x86_64.AppImage"
+              aria-disabled="true"
               data-i18n="download.linuxCta"
             >Download for Linux</a>
           </div>

--- a/src/game/desktop_download.ts
+++ b/src/game/desktop_download.ts
@@ -14,12 +14,10 @@ export const DESKTOP_VERSION = '0.21.0';
 const DESKTOP_HOST = 'https://updates.worldofclaudecraft.com/desktop';
 
 // electron-builder website-channel artifact names (docs/desktop-release.md):
-// mac ships one universal dmg; the x64 Linux AppImage is named x86_64 (that is
-// electron-builder's arch token for AppImage, not "x64"). Windows is not
-// published yet, so it has no entry here.
+// mac ships one universal dmg. Linux and Windows are not published yet, so they
+// have no entries here.
 const ARTIFACT: Partial<Record<DesktopPlatform, string>> = {
   mac: `world-of-claudecraft-${DESKTOP_VERSION}-mac-universal.dmg`,
-  linux: `world-of-claudecraft-${DESKTOP_VERSION}-linux-x86_64.AppImage`,
 };
 
 // Full download URL for a platform, or null when no artifact is published for it.
@@ -52,17 +50,25 @@ export function initDesktopDownload(doc: Document = document): void {
   for (const link of links) {
     const platform = link.dataset.platform as DesktopPlatform | undefined;
     const url = platform ? desktopDownloadUrl(platform) : null;
-    if (url) link.href = url;
+    link.classList.toggle('is-unavailable', !url);
+    link.setAttribute('aria-disabled', url ? 'false' : 'true');
+    if (url) {
+      link.href = url;
+    } else {
+      link.removeAttribute('href');
+    }
   }
   const detected = detectDesktopPlatform(navigator.userAgent);
   const actions = section.querySelector('.desktop-download-actions');
   for (const link of links) {
-    const isSelf = link.dataset.platform === detected;
+    const platform = link.dataset.platform as DesktopPlatform | undefined;
+    const isSelf = !!platform && !!desktopDownloadUrl(platform) && platform === detected;
     link.classList.toggle('is-detected', isSelf);
     if (isSelf && actions && link !== actions.firstElementChild) actions.prepend(link);
   }
   const hints = section.querySelectorAll<HTMLElement>('[data-platform-hint]');
   for (const hint of hints) {
-    hint.hidden = hint.dataset.platformHint !== detected;
+    const platform = hint.dataset.platformHint as DesktopPlatform | undefined;
+    hint.hidden = platform !== detected || !desktopDownloadUrl(platform);
   }
 }

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -1281,6 +1281,17 @@
     box-shadow: 0 0 0 2px rgba(255, 209, 0, 0.55);
   }
 
+  .desktop-download-link.btn-primary.is-unavailable,
+  .desktop-download-link.btn-primary.is-unavailable:hover,
+  .desktop-download-link.btn-primary.is-unavailable:focus-visible {
+    background: linear-gradient(180deg, #3a3a3a 0%, #1b1b1b 100%);
+    border-color: rgba(180, 180, 180, 0.32);
+    box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.55);
+    color: #9f9f9f;
+    cursor: not-allowed;
+    opacity: 0.68;
+  }
+
   .desktop-download-hint {
     max-width: 420px;
     margin: var(--spacing-xs) auto 0;

--- a/tests/desktop_download.test.ts
+++ b/tests/desktop_download.test.ts
@@ -50,10 +50,8 @@ describe('desktopDownloadUrl', () => {
     );
   });
 
-  it('builds the Linux x86_64 AppImage URL (electron-builder x64 arch token)', () => {
-    expect(desktopDownloadUrl('linux')).toBe(
-      `https://updates.worldofclaudecraft.com/desktop/world-of-claudecraft-${DESKTOP_VERSION}-linux-x86_64.AppImage`,
-    );
+  it('returns null for Linux while the AppImage is held back', () => {
+    expect(desktopDownloadUrl('linux')).toBeNull();
   });
 
   it('returns null for platforms with no published artifact', () => {

--- a/tests/desktop_download_dom.test.ts
+++ b/tests/desktop_download_dom.test.ts
@@ -20,24 +20,27 @@ function setUserAgent(ua: string): void {
 describe('initDesktopDownload', () => {
   beforeEach(buildView);
 
-  it('syncs each button href to the versioned artifact URL', () => {
+  it('syncs published buttons and disables unavailable buttons', () => {
     setUserAgent('Mozilla/5.0 (X11; Linux x86_64)');
     initDesktopDownload(document);
     const mac = document.querySelector('[data-platform="mac"]') as HTMLAnchorElement;
     const linux = document.querySelector('[data-platform="linux"]') as HTMLAnchorElement;
     expect(mac.href).toBe(desktopDownloadUrl('mac'));
-    expect(linux.href).toBe(desktopDownloadUrl('linux'));
+    expect(linux.hasAttribute('href')).toBe(false);
+    expect(linux.getAttribute('aria-disabled')).toBe('true');
+    expect(linux.classList.contains('is-unavailable')).toBe(true);
   });
 
-  it('highlights and floats the visitor OS button first, and reveals its hint', () => {
+  it('does not highlight or float Linux while its download is unavailable', () => {
     setUserAgent('Mozilla/5.0 (X11; Linux x86_64) Chrome/125');
     initDesktopDownload(document);
     const actions = document.querySelector('.desktop-download-actions') as HTMLElement;
     const first = actions.firstElementChild as HTMLElement;
-    expect(first.dataset.platform).toBe('linux');
-    expect(first.classList.contains('is-detected')).toBe(true);
+    expect(first.dataset.platform).toBe('mac');
+    const linux = document.querySelector('[data-platform="linux"]') as HTMLElement;
+    expect(linux.classList.contains('is-detected')).toBe(false);
     const hint = document.querySelector('.desktop-download-hint') as HTMLElement;
-    expect(hint.hidden).toBe(false);
+    expect(hint.hidden).toBe(true);
   });
 
   it('keeps the Linux hint hidden for non-Linux visitors and highlights their OS', () => {


### PR DESCRIPTION
## Summary
- grey out and disable the Linux desktop launcher CTA while the Linux app is held back
- remove Linux download URL generation so client initialization cannot re-enable it
- keep Linux platform detection from floating/highlighting the disabled button or showing the AppImage hint

## Validation
- npm test -- tests/desktop_download.test.ts tests/desktop_download_dom.test.ts
- npm run ci:changed
- npm run gate