### PR TITLE
fix(hud): guard entry HUD-ctor id parity (catches a live #tf-discord gap on /play)

### DIFF
--- a/play.html
+++ b/play.html
@@ -186,6 +186,7 @@
         <div class="uf-name" id="tf-name"></div>
         <div class="bar hp"><div class="bar-fill" id="tf-hp"></div><div class="bar-absorb" id="tf-absorb"></div><div class="bar-text" id="tf-hp-text"></div></div>
         <div class="bar" id="tf-resource"><div class="bar-fill" id="tf-res"></div><div class="bar-text" id="tf-res-text"></div></div>
+        <div class="uf-discord" id="tf-discord"></div>
         <div id="tf-castbar" role="progressbar" aria-valuemin="0" aria-valuemax="100" data-i18n-aria="hudChrome.castBar.targetAria" aria-label="Unit Cast Bar"><div class="fill"></div><div class="label"></div><div class="timer"></div></div>
       </div>
       <div class="uf-buffs" id="tf-debuffs"></div>

--- a/tests/entry_hud_ctor_parity.test.ts
+++ b/tests/entry_hud_ctor_parity.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// Both build entries (index.html at / and play.html at /play) hand-carry the HUD
+// chrome. The Hud class resolves many elements as CONSTRUCTOR-TIME field initializers
+// via `$('#id')` (= document.querySelector, cast to a non-null type). If an entry is
+// missing one of those ids, the field is silently null and the first thing that touches
+// it — `new QuestProgressBanner($('#quest-banner'))`, `el.addEventListener(...)` — throws
+// during `new Hud()`, taking the whole renderer down on that entry.
+//
+// entry_window_parity.test.ts guards `.window panel` ids, but the crash class is broader:
+// banners, bars, and indicators the ctor resolves are not window panels. This guard scrapes
+// the ctor field-initializer `$('#id')` literals from hud.ts and asserts every one exists in
+// BOTH entries, so a HUD element added to one entry but not the other fails CI instead of
+// the browser.
+const read = (p: string) => readFileSync(new URL(`../${p}`, import.meta.url), 'utf8');
+
+// The Hud class field-initializer region: from the first `$('#...')` field initializer up to
+// the constructor. Only ids resolved HERE run at `new Hud()` and can crash construction.
+// Ids resolved inside method bodies are excluded — those elements are often injected on
+// demand (modals, dynamic previews) and are not part of the static entry chrome.
+function ctorFieldIds(hudSrc: string): Set<string> {
+  const start = hudSrc.search(/^\s*(?:private|readonly|public)\b[^\n]*\$\('#/m);
+  const ctor = hudSrc.search(/^\s{2}(?:private\s+)?constructor\s*\(/m);
+  const region = start >= 0 && ctor > start ? hudSrc.slice(start, ctor) : '';
+  const ids = new Set<string>();
+  for (const m of region.matchAll(/\$\('#([a-zA-Z0-9_-]+)'\)/g)) ids.add(m[1]);
+  return ids;
+}
+
+function htmlIds(html: string): Set<string> {
+  const ids = new Set<string>();
+  for (const m of html.matchAll(/id="([^"]+)"/g)) ids.add(m[1]);
+  return ids;
+}
+
+describe('entry HUD-constructor parity', () => {
+  it('every Hud ctor-resolved #id exists in both index.html and play.html', () => {
+    const ctorIds = ctorFieldIds(read('src/ui/hud.ts'));
+    // Sanity: the scrape found the field region, not an empty set from a refactor.
+    expect(ctorIds.size).toBeGreaterThan(20);
+
+    const index = htmlIds(read('index.html'));
+    const play = htmlIds(read('play.html'));
+
+    const missingInIndex = [...ctorIds].filter((id) => !index.has(id)).sort();
+    const missingInPlay = [...ctorIds].filter((id) => !play.has(id)).sort();
+    expect({ missingInIndex, missingInPlay }).toEqual({ missingInIndex: [], missingInPlay: [] });
+  });
+});


### PR DESCRIPTION
## Problem

The `Hud` class resolves many elements as **constructor-time field initializers** via `$('#id')` (which is `document.querySelector` cast to a non-null type). If an entry HTML is missing one of those ids, the field is silently `null`, and the first code that touches it — `new QuestProgressBanner($('#quest-banner'))`, `el.addEventListener(...)` — throws during `new Hud()`, taking the renderer down on that entry.

`entry_window_parity.test.ts` guards `.window panel` ids, but the crash class is broader: banners, bars, and indicators the ctor resolves are **not** window panels, so that whole surface was unguarded.

## What this catches (a real one, today)

The new guard immediately found a live gap on `main`: **`#tf-discord`** (the target-frame `targetDiscordEl` field) is in `index.html` but **missing from `play.html``** — so on `/play` that field resolves to `null`. This PR restores the identical `<div class="uf-discord" id="tf-discord">` to `play.html` in the same position.

## The guard

`tests/entry_hud_ctor_parity.test.ts` scrapes the ctor field-initializer `$('#id')` literals from `hud.ts` (only the field region, before the constructor — method-body lookups are excluded since those elements are often injected on demand) and asserts every id exists in **both** `index.html` and `play.html`. Adding a HUD element to one entry but not the other now fails CI instead of the browser.

## Verification

- New test **fails** with `missingInPlay: ["tf-discord"]` before the fix, **passes** after (red→green).
- Existing `entry_window_parity.test.ts` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)