### PR TITLE
fix(net): deliberate logout skips linkdead grace

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -2464,6 +2464,13 @@ export class GameServer {
     const msg = rawMsg as ClientMessage;
     const sim = this.sim;
     const pid = session.pid;
+    // Deliberate logout: the client wants a clean leave, not a linkdead grace.
+    // Calling leave() immediately sets session.left = true, so the subsequent
+    // WebSocket close event (from the page reload) is a no-op in socketClosed().
+    if (msg.t === 'logout') {
+      void this.leave(session, 'logout');
+      return;
+    }
     if (msg.t === 'input') {
       if (session.spectating) return;
       const meta = sim.meta(pid);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1545,7 +1545,12 @@ async function startGame(
   // the options menu drives logout + key-capture + settings, all of which need
   // refs that only exist now (input/renderer) or are page-level (reload)
   hud.attachOptions({
-    logout: () => location.reload(),
+    logout: () => {
+      // Signal the server to leave immediately, skipping the linkdead grace, so
+      // the character is not held in-world after a deliberate logout.
+      online?.sendLogout();
+      location.reload();
+    },
     captureKey: (cb) => input.captureNextKey(cb),
     settings,
     onSettingChange: (key, value) => applySetting(key, value),

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -1141,6 +1141,19 @@ export class ClientWorld implements IWorld {
     this.ws.close();
   }
 
+  // Signal a deliberate logout to the server so it skips linkdead grace and
+  // calls leave() immediately. Must be called before a page reload so the
+  // character is properly removed from the world instead of being held
+  // in-world for the 5-minute linkdead window.
+  sendLogout(): void {
+    this.sessionEnded = true;
+    clearInterval(this.sendTimer);
+    if (this.reconnectTimer !== undefined) clearTimeout(this.reconnectTimer);
+    if (this.ws.readyState === 1) {
+      this.ws.send(JSON.stringify({ t: 'logout' }));
+    }
+  }
+
   get player(): Entity {
     return this.entities.get(this.playerId) ?? blankEntity(-1);
   }

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -1133,10 +1133,14 @@ export class ClientWorld implements IWorld {
     this.reconnectTimer = window.setTimeout(() => this.openSocket(), delayMs);
   }
 
-  close(): void {
+  private endSession(): void {
     this.sessionEnded = true;
     clearInterval(this.sendTimer);
     if (this.reconnectTimer !== undefined) clearTimeout(this.reconnectTimer);
+  }
+
+  close(): void {
+    this.endSession();
     this.ws.onclose = null;
     this.ws.close();
   }
@@ -1146,10 +1150,8 @@ export class ClientWorld implements IWorld {
   // character is properly removed from the world instead of being held
   // in-world for the 5-minute linkdead window.
   sendLogout(): void {
-    this.sessionEnded = true;
-    clearInterval(this.sendTimer);
-    if (this.reconnectTimer !== undefined) clearTimeout(this.reconnectTimer);
-    if (this.ws.readyState === 1) {
+    this.endSession();
+    if (this.ws.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify({ t: 'logout' }));
     }
   }
@@ -1355,9 +1357,7 @@ export class ClientWorld implements IWorld {
       }
       // any other server rejection (kick, moderation, takeover, failed auth)
       // ends the session for good: no auto-reconnect
-      this.sessionEnded = true;
-      clearInterval(this.sendTimer);
-      if (this.reconnectTimer !== undefined) clearTimeout(this.reconnectTimer);
+      this.endSession();
       this.onDisconnect?.(msg.error ?? 'rejected by server');
       return;
     }

--- a/tests/linkdead.test.ts
+++ b/tests/linkdead.test.ts
@@ -390,3 +390,45 @@ describe('reconnect policy (client-side conflict tolerance)', () => {
     expect(plan).toEqual({ action: 'reject', error: RECONNECT_CONFLICT_ERROR });
   });
 });
+
+describe('deliberate logout skips linkdead grace', () => {
+  it("a t:'logout' message leaves the session immediately, not linkdead", async () => {
+    const server = new GameServer();
+    const ws = fakeWs();
+    const session = expectJoined(server.join(ws, 11, 101, 'Quitter', 'warrior', null));
+
+    server.handleMessage(session, JSON.stringify({ t: 'logout' }));
+
+    // session.left is set synchronously so socketClosed (page-unload close)
+    // cannot enter linkdead grace
+    expect(session.left).toBe(true);
+    expect(session.linkdead).toBe(false);
+
+    // the subsequent WebSocket close from the page reload is now a no-op
+    expect(server.socketClosed(session, ws)).toBe(false);
+    expect(session.linkdead).toBe(false);
+
+    // character is gone, not held in-world
+    await vi.waitFor(() => {
+      expect((server as any).sessionByCharacterId(101)).toBeNull();
+    });
+    expect(server.clients.size).toBe(0);
+    expect(server.sim.entities.has(session.pid)).toBe(false);
+  });
+
+  it('allows a fresh join on the same character after a t:logout', async () => {
+    const server = new GameServer();
+    const ws = fakeWs();
+    const session = expectJoined(server.join(ws, 11, 101, 'Loggedout', 'warrior', null));
+    server.handleMessage(session, JSON.stringify({ t: 'logout' }));
+
+    await vi.waitFor(() => {
+      expect((server as any).sessionByCharacterId(101)).toBeNull();
+    });
+
+    // no "character already in world" after a deliberate logout
+    const fresh = expectJoined(server.join(fakeWs(), 11, 101, 'Loggedout', 'warrior', null));
+    expect(fresh.characterId).toBe(101);
+    expect(fresh.left).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Since v0.22.0 the in-game **Log Out** button left the character held in-world
for 5 minutes instead of removing it cleanly. On re-login, the character
appeared as **online** in the character list, showing a "Take Over" prompt and
the hint *"Already in world. Log out elsewhere, or take over."* instead of the
normal **Enter World** button.

**Root cause:** The linkdead grace feature (v0.22.0) was designed for accidental
disconnects. A deliberate logout was not handled: `logout: () =>
location.reload()` just reloaded the page without signalling the server, so the
server treated the resulting socket close as an accidental drop and entered the
5-minute grace.

**Fix:** Before the reload, the client sends `{ t: 'logout' }` over the
WebSocket. The server handles this in `dispatchMessage()` by calling `leave()`
immediately, setting `session.left = true` synchronously, so the subsequent
page-unload socket close is a no-op in `socketClosed()` and linkdead grace is
never entered. `ClientWorld.sendLogout()` also sets `sessionEnded = true` to
prevent the auto-reconnect from firing.

## Related issues

Closes #<!-- issue number -->

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/linkdead.test.ts` (27 tests pass, including 2
  new regression tests covering the deliberate-logout path)
- Manual steps:
  1. Start server + client (`npm run server` / `npm run dev`)
  2. Log in, pick a character, enter the world
  3. Open Options → Log Out
  4. Log back in and open the character list
  5. **Before fix:** character shows "Already in world" hint + Take Over button
  6. **After fix:** character shows the normal Enter World button; enters
     immediately with no confirmation dialog

---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green. Added 2 regression tests in
      `tests/linkdead.test.ts` covering the `t:'logout'` message path.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [ ] **Builds succeed.**

### Cross-platform

- ~Tested on desktop and mobile.~ Not a UI layout change.
- ~Accessible.~ Not a UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed.
- [x] No generated files hand-edited.