### PR TITLE
refactor(render): extract dungeon door/portal into its own module

### DIFF
--- a/src/render/CLAUDE.md
+++ b/src/render/CLAUDE.md
@@ -25,8 +25,9 @@ renderer:
 | `water.ts` · `sky.ts` | per-zone water planes · HDRI sky dome + clouds |
 | `vfx.ts` | pooled `THREE.Points` spell/impact particles (Kenney atlas) |
 | `dungeon.ts` | instanced KayKit interiors from `sim/dungeon_layout.ts` |
+| `door_portal.ts` | dungeon-door / exit-portal bodies (stone arch + additive portal swirl) |
 | `post.ts` | post chain (see below) |
-| `gfx.ts`, `textures.ts`, `render_budget.ts`, `locomotion.ts`, `stealth.ts` | shared helpers (below) |
+| `gfx.ts`, `textures.ts`, `render_budget.ts`, `locomotion.ts`, `stealth.ts`, `shared_resource.ts` | shared helpers (below) |
 
 ## gfx.ts: the shared core (read this before touching any subsystem)
 - **`GFX` quality tiers** (`low`/`medium`/`high`/`ultra`). Every tier-dependent knob lives

--- a/src/render/door_portal.ts
+++ b/src/render/door_portal.ts
@@ -1,0 +1,151 @@
+import * as THREE from 'three';
+import { markSharedGeometry, markSharedMaterial } from './shared_resource';
+
+// The dungeon door / exit-portal visual system, lifted out of renderer.ts so the
+// orchestrator only calls buildDoorBody() (the same shape as buildProps /
+// buildMailboxPillar / buildDelveInteractable). Geometry and materials are
+// shared, process-lifetime resources tagged via shared_resource so the renderer's
+// per-view disposal guard never frees them (see the note there).
+
+// Additive boost applied to the portal shimmer on non-low tiers so it blooms on
+// the composer.
+const PORTAL_BOOST = 2;
+
+let stoneMat: THREE.Material | null = null;
+let archGeo: THREE.BufferGeometry | null = null;
+let keystoneGeo: THREE.BufferGeometry | null = null;
+let plinthGeo: THREE.BufferGeometry | null = null;
+let portalGeo: THREE.BufferGeometry | null = null;
+let nythraxisClickGeo: THREE.BufferGeometry | null = null;
+let nythraxisClickMat: THREE.MeshBasicMaterial | null = null;
+// Keyed by `${entering}:${lowGfx}`. In production lowGfx is fixed for the
+// renderer's lifetime, so only two entries are ever created (identical to the
+// previous per-entering caching that captured lowGfx at first build); keying it
+// on both inputs just keeps the builder correct for any caller and unit-testable.
+const portalMats = new Map<string, THREE.MeshBasicMaterial>();
+
+function doorStoneMaterial(): THREE.Material {
+  stoneMat ??= markSharedMaterial(new THREE.MeshLambertMaterial({ color: 0x6a6a72 }));
+  return stoneMat;
+}
+
+function doorArchGeometry(): THREE.BufferGeometry {
+  if (!archGeo) {
+    const outer = new THREE.Shape();
+    outer.moveTo(-2.1, 0);
+    outer.lineTo(-2.1, 3.1);
+    outer.quadraticCurveTo(-2.1, 4.85, 0, 5.05);
+    outer.quadraticCurveTo(2.1, 4.85, 2.1, 3.1);
+    outer.lineTo(2.1, 0);
+    outer.closePath();
+    const inner = new THREE.Path();
+    inner.moveTo(-1.3, -0.5);
+    inner.lineTo(-1.3, 2.9);
+    inner.quadraticCurveTo(-1.3, 4.05, 0, 4.22);
+    inner.quadraticCurveTo(1.3, 4.05, 1.3, 2.9);
+    inner.lineTo(1.3, -0.5);
+    inner.closePath();
+    outer.holes.push(inner);
+    const geo = new THREE.ExtrudeGeometry(outer, {
+      depth: 0.7,
+      bevelEnabled: true,
+      bevelThickness: 0.07,
+      bevelSize: 0.07,
+      bevelSegments: 1,
+    });
+    geo.translate(0, 0, -0.35);
+    archGeo = markSharedGeometry(geo);
+  }
+  return archGeo;
+}
+
+function doorKeystoneGeometry(): THREE.BufferGeometry {
+  keystoneGeo ??= markSharedGeometry(new THREE.BoxGeometry(0.7, 1.0, 0.95));
+  return keystoneGeo;
+}
+
+function doorPlinthGeometry(): THREE.BufferGeometry {
+  plinthGeo ??= markSharedGeometry(new THREE.BoxGeometry(1.15, 0.7, 1.15));
+  return plinthGeo;
+}
+
+function doorPortalGeometry(): THREE.BufferGeometry {
+  portalGeo ??= markSharedGeometry(new THREE.CircleGeometry(1.55, 24));
+  return portalGeo;
+}
+
+function doorNythraxisClickGeometry(): THREE.BufferGeometry {
+  nythraxisClickGeo ??= markSharedGeometry(new THREE.BoxGeometry(4.6, 4.2, 2.4));
+  return nythraxisClickGeo;
+}
+
+function doorNythraxisClickMaterial(): THREE.MeshBasicMaterial {
+  nythraxisClickMat ??= markSharedMaterial(
+    new THREE.MeshBasicMaterial({
+      color: 0x000000,
+      transparent: true,
+      opacity: 0.001,
+      depthWrite: false,
+    }),
+  );
+  return nythraxisClickMat;
+}
+
+function doorPortalMaterial(entering: boolean, lowGfx: boolean): THREE.MeshBasicMaterial {
+  const key = `${entering}:${lowGfx}`;
+  const existing = portalMats.get(key);
+  if (existing) return existing;
+  const tint = entering ? 0x9a5df0 : 0x6ab8ff;
+  const material = markSharedMaterial(
+    new THREE.MeshBasicMaterial({
+      color: tint,
+      transparent: true,
+      opacity: 0.55,
+      side: THREE.DoubleSide,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    }),
+  );
+  if (!lowGfx) material.color.multiplyScalar(PORTAL_BOOST);
+  portalMats.set(key, material);
+  return material;
+}
+
+// Build a dungeon-door (entering) or dungeon-exit (leaving) body: a stone arch +
+// keystone + plinths framing an additive portal swirl. The Nythraxis crypt door
+// is a bespoke invisible click-box instead (the visible arch is baked into that
+// dungeon's geometry). Returns the portal mesh separately so the renderer can
+// animate its swirl per frame.
+export function buildDoorBody(
+  entering: boolean,
+  dungeonId: string | null | undefined,
+  lowGfx: boolean,
+): { body: THREE.Group; portal?: THREE.Mesh } {
+  const body = new THREE.Group();
+  if (entering && dungeonId === 'nythraxis_crypt') {
+    const clickBox = new THREE.Mesh(doorNythraxisClickGeometry(), doorNythraxisClickMaterial());
+    clickBox.position.y = 2.1;
+    body.add(clickBox);
+    return { body };
+  }
+
+  const stone = doorStoneMaterial();
+  const arch = new THREE.Mesh(doorArchGeometry(), stone);
+  arch.castShadow = true;
+  body.add(arch);
+  const keystone = new THREE.Mesh(doorKeystoneGeometry(), stone);
+  keystone.position.set(0, 4.75, 0);
+  keystone.castShadow = true;
+  body.add(keystone);
+  for (const sx of [-1.7, 1.7]) {
+    const plinth = new THREE.Mesh(doorPlinthGeometry(), stone);
+    plinth.position.set(sx, 0.35, 0);
+    plinth.castShadow = true;
+    body.add(plinth);
+  }
+  const portal = new THREE.Mesh(doorPortalGeometry(), doorPortalMaterial(entering, lowGfx));
+  portal.position.y = 2.15;
+  portal.scale.set(1, 1.35, 1);
+  body.add(portal);
+  return { body, portal };
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -47,6 +47,7 @@ import { trackWebGLContext } from './context_release';
 import { buildCritters, type CritterField } from './critters';
 import { buildDelveModule } from './delve_interiors';
 import { buildDelveInteractable } from './delve_props';
+import { buildDoorBody } from './door_portal';
 import { DungeonInteriors, ensureDungeonAssets } from './dungeon';
 import { objectDisplayName } from './entity_labels';
 import { releaseSelfFacing, stepSelfFacing } from './facing_smooth';
@@ -88,6 +89,7 @@ import { isOwnedPetHostile } from './reaction';
 import { RenderBudgetGovernor, type RenderBudgetState } from './render_budget';
 import { downscaleDims } from './screenshot';
 import { drapeRingLocalY } from './selection_ring';
+import { isSharedGeometry, isSharedMaterial } from './shared_resource';
 import { buildClouds, buildSky, type SkyView } from './sky';
 import { nearestSloppyPickId, type SloppyPickCandidate } from './sloppy_pick';
 import { freezeStaticMatrices } from './static_matrix';
@@ -187,7 +189,6 @@ const SELECTION_RING_SPIN = 0.6; // rad/s — slow classic target-reticle rotati
 const CLICK_MARKER_POOL = 4; // concurrent click-feedback markers before reuse
 const GROUND_AIM_RETICLE_PULSE_HZ = 2;
 const SPARKLE_BOOST = 1.5;
-const PORTAL_BOOST = 2;
 // Third-person camera collision (see updateCamera). Prop colliders marked
 // camGhost are hidden by props.ts/foliage.ts instead; this path is for
 // non-hideable blockers such as large rocks and interior walls.
@@ -672,24 +673,6 @@ function isPersistentPortalObject(e: Entity): boolean {
   return (
     e.kind === 'object' && (e.templateId === 'dungeon_door' || e.templateId === 'dungeon_exit')
   );
-}
-
-function markSharedGeometry<T extends THREE.BufferGeometry>(geometry: T): T {
-  geometry.userData.sharedRendererResource = true;
-  return geometry;
-}
-
-function markSharedMaterial<T extends THREE.Material>(material: T): T {
-  material.userData.sharedRendererResource = true;
-  return material;
-}
-
-function isSharedGeometry(geometry: THREE.BufferGeometry): boolean {
-  return geometry.userData.sharedRendererResource === true;
-}
-
-function isSharedMaterial(material: THREE.Material): boolean {
-  return material.userData.sharedRendererResource === true;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -3029,147 +3012,16 @@ export class Renderer {
   // -------------------------------------------------------------------------
 
   // Shared object-view resources: views must not own materials/textures, or
-  // interest churn leaks them (removeView only disposes per-view geometry).
-  private doorStoneMat: THREE.Material | null = null;
-  private doorArchGeo: THREE.BufferGeometry | null = null;
-  private doorKeystoneGeo: THREE.BufferGeometry | null = null;
-  private doorPlinthGeo: THREE.BufferGeometry | null = null;
-  private doorPortalGeo: THREE.BufferGeometry | null = null;
-  private doorNythraxisClickGeo: THREE.BufferGeometry | null = null;
-  private doorNythraxisClickMat: THREE.MeshBasicMaterial | null = null;
-  private doorEntrancePortalMat: THREE.MeshBasicMaterial | null = null;
-  private doorExitPortalMat: THREE.MeshBasicMaterial | null = null;
+  // interest churn leaks them (removeView only disposes per-view geometry). The
+  // dungeon door/portal resources moved to door_portal.ts (same shared tagging).
   private sparkleMat: THREE.SpriteMaterial | null = null;
-
-  private doorStoneMaterial(): THREE.Material {
-    this.doorStoneMat ??= markSharedMaterial(new THREE.MeshLambertMaterial({ color: 0x6a6a72 }));
-    return this.doorStoneMat;
-  }
-
-  private doorArchGeometry(): THREE.BufferGeometry {
-    if (!this.doorArchGeo) {
-      const outer = new THREE.Shape();
-      outer.moveTo(-2.1, 0);
-      outer.lineTo(-2.1, 3.1);
-      outer.quadraticCurveTo(-2.1, 4.85, 0, 5.05);
-      outer.quadraticCurveTo(2.1, 4.85, 2.1, 3.1);
-      outer.lineTo(2.1, 0);
-      outer.closePath();
-      const inner = new THREE.Path();
-      inner.moveTo(-1.3, -0.5);
-      inner.lineTo(-1.3, 2.9);
-      inner.quadraticCurveTo(-1.3, 4.05, 0, 4.22);
-      inner.quadraticCurveTo(1.3, 4.05, 1.3, 2.9);
-      inner.lineTo(1.3, -0.5);
-      inner.closePath();
-      outer.holes.push(inner);
-      const archGeo = new THREE.ExtrudeGeometry(outer, {
-        depth: 0.7,
-        bevelEnabled: true,
-        bevelThickness: 0.07,
-        bevelSize: 0.07,
-        bevelSegments: 1,
-      });
-      archGeo.translate(0, 0, -0.35);
-      this.doorArchGeo = markSharedGeometry(archGeo);
-    }
-    return this.doorArchGeo;
-  }
-
-  private doorKeystoneGeometry(): THREE.BufferGeometry {
-    this.doorKeystoneGeo ??= markSharedGeometry(new THREE.BoxGeometry(0.7, 1.0, 0.95));
-    return this.doorKeystoneGeo;
-  }
-
-  private doorPlinthGeometry(): THREE.BufferGeometry {
-    this.doorPlinthGeo ??= markSharedGeometry(new THREE.BoxGeometry(1.15, 0.7, 1.15));
-    return this.doorPlinthGeo;
-  }
-
-  private doorPortalGeometry(): THREE.BufferGeometry {
-    this.doorPortalGeo ??= markSharedGeometry(new THREE.CircleGeometry(1.55, 24));
-    return this.doorPortalGeo;
-  }
-
-  private doorNythraxisClickGeometry(): THREE.BufferGeometry {
-    this.doorNythraxisClickGeo ??= markSharedGeometry(new THREE.BoxGeometry(4.6, 4.2, 2.4));
-    return this.doorNythraxisClickGeo;
-  }
-
-  private doorNythraxisClickMaterial(): THREE.MeshBasicMaterial {
-    this.doorNythraxisClickMat ??= markSharedMaterial(
-      new THREE.MeshBasicMaterial({
-        color: 0x000000,
-        transparent: true,
-        opacity: 0.001,
-        depthWrite: false,
-      }),
-    );
-    return this.doorNythraxisClickMat;
-  }
-
-  private doorPortalMaterial(entering: boolean): THREE.MeshBasicMaterial {
-    const tint = entering ? 0x9a5df0 : 0x6ab8ff;
-    const existing = entering ? this.doorEntrancePortalMat : this.doorExitPortalMat;
-    if (existing) return existing;
-    const material = markSharedMaterial(
-      new THREE.MeshBasicMaterial({
-        color: tint,
-        transparent: true,
-        opacity: 0.55,
-        side: THREE.DoubleSide,
-        blending: THREE.AdditiveBlending,
-        depthWrite: false,
-      }),
-    );
-    if (!this.lowGfx) material.color.multiplyScalar(PORTAL_BOOST);
-    if (entering) this.doorEntrancePortalMat = material;
-    else this.doorExitPortalMat = material;
-    return material;
-  }
-
-  private buildDoorBody(
-    entering: boolean,
-    dungeonId?: string | null,
-  ): { body: THREE.Group; portal?: THREE.Mesh } {
-    const body = new THREE.Group();
-    if (entering && dungeonId === 'nythraxis_crypt') {
-      const clickBox = new THREE.Mesh(
-        this.doorNythraxisClickGeometry(),
-        this.doorNythraxisClickMaterial(),
-      );
-      clickBox.position.y = 2.1;
-      body.add(clickBox);
-      return { body };
-    }
-
-    const stone = this.doorStoneMaterial();
-    const arch = new THREE.Mesh(this.doorArchGeometry(), stone);
-    arch.castShadow = true;
-    body.add(arch);
-    const keystone = new THREE.Mesh(this.doorKeystoneGeometry(), stone);
-    keystone.position.set(0, 4.75, 0);
-    keystone.castShadow = true;
-    body.add(keystone);
-    for (const sx of [-1.7, 1.7]) {
-      const plinth = new THREE.Mesh(this.doorPlinthGeometry(), stone);
-      plinth.position.set(sx, 0.35, 0);
-      plinth.castShadow = true;
-      body.add(plinth);
-    }
-    const portal = new THREE.Mesh(this.doorPortalGeometry(), this.doorPortalMaterial(entering));
-    portal.position.y = 2.15;
-    portal.scale.set(1, 1.35, 1);
-    body.add(portal);
-    return { body, portal };
-  }
 
   private buildDoorPrewarmGroup(): THREE.Group {
     const group = new THREE.Group();
-    const entrance = this.buildDoorBody(true).body;
+    const entrance = buildDoorBody(true, null, this.lowGfx).body;
     entrance.position.x = -3;
     group.add(entrance);
-    const exit = this.buildDoorBody(false).body;
+    const exit = buildDoorBody(false, null, this.lowGfx).body;
     exit.position.x = 3;
     group.add(exit);
     const p = this.sim.player;
@@ -3196,7 +3048,7 @@ export class Renderer {
       (e.templateId === 'dungeon_door' || e.templateId === 'dungeon_exit')
     ) {
       const entering = e.templateId === 'dungeon_door';
-      const built = this.buildDoorBody(entering, e.dungeonId);
+      const built = buildDoorBody(entering, e.dungeonId, this.lowGfx);
       body = built.body;
       portal = built.portal;
       height = 4.6;

--- a/src/render/shared_resource.ts
+++ b/src/render/shared_resource.ts
@@ -1,0 +1,26 @@
+import type * as THREE from 'three';
+
+// Shared object-view resources: views must not own the materials/geometries they
+// draw with, or interest churn leaks them (removeView only disposes per-view,
+// non-shared geometry). Tagging a resource here marks it as renderer-owned and
+// process-lifetime, so the per-view disposal guard skips it. The flag lives on
+// `userData` so any subsystem that builds a shared resource (e.g. door_portal.ts)
+// marks it the same way the renderer's disposal path reads it back.
+
+export function markSharedGeometry<T extends THREE.BufferGeometry>(geometry: T): T {
+  geometry.userData.sharedRendererResource = true;
+  return geometry;
+}
+
+export function markSharedMaterial<T extends THREE.Material>(material: T): T {
+  material.userData.sharedRendererResource = true;
+  return material;
+}
+
+export function isSharedGeometry(geometry: THREE.BufferGeometry): boolean {
+  return geometry.userData.sharedRendererResource === true;
+}
+
+export function isSharedMaterial(material: THREE.Material): boolean {
+  return material.userData.sharedRendererResource === true;
+}

--- a/tests/door_portal.test.ts
+++ b/tests/door_portal.test.ts
@@ -1,0 +1,101 @@
+// The dungeon door / exit-portal visual system extracted from renderer.ts.
+// Geometry/material shape, shared-resource tagging, and the Nythraxis click-box
+// special case. Three.js runs headless in Node (no WebGL needed for geometry).
+import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
+import { buildDoorBody } from '../src/render/door_portal';
+import { isSharedGeometry, isSharedMaterial } from '../src/render/shared_resource';
+
+const meshes = (body: THREE.Group): THREE.Mesh[] =>
+  body.children.filter((c): c is THREE.Mesh => (c as THREE.Mesh).isMesh);
+
+describe('buildDoorBody: standard arch door', () => {
+  it('builds arch + keystone + two plinths + portal, and returns the portal mesh', () => {
+    const { body, portal } = buildDoorBody(true, null, false);
+    const ms = meshes(body);
+    // arch, keystone, plinth x2, portal
+    expect(ms.length).toBe(5);
+    expect(portal).toBeDefined();
+    expect(body.children).toContain(portal);
+  });
+
+  it('positions the portal at y=2.15 with the classic 1x1.35x1 oval scale', () => {
+    const { portal } = buildDoorBody(false, null, false);
+    expect(portal?.position.y).toBeCloseTo(2.15);
+    expect(portal?.scale.x).toBeCloseTo(1);
+    expect(portal?.scale.y).toBeCloseTo(1.35);
+    expect(portal?.scale.z).toBeCloseTo(1);
+  });
+
+  it('the stone frame meshes cast shadows', () => {
+    const { body } = buildDoorBody(true, null, false);
+    // every non-portal mesh (arch/keystone/plinths) casts a shadow
+    const frame = meshes(body).filter((m) => m.geometry.type !== 'CircleGeometry');
+    expect(frame.length).toBe(4);
+    expect(frame.every((m) => m.castShadow)).toBe(true);
+  });
+});
+
+describe('buildDoorBody: Nythraxis crypt click-box', () => {
+  it('an entering nythraxis_crypt door is a single invisible click-box with no portal', () => {
+    const { body, portal } = buildDoorBody(true, 'nythraxis_crypt', false);
+    const ms = meshes(body);
+    expect(ms.length).toBe(1);
+    expect(portal).toBeUndefined();
+    expect(ms[0].position.y).toBeCloseTo(2.1);
+  });
+
+  it('the special-case only applies when entering (an exit uses the normal arch)', () => {
+    const { body, portal } = buildDoorBody(false, 'nythraxis_crypt', false);
+    expect(meshes(body).length).toBe(5);
+    expect(portal).toBeDefined();
+  });
+});
+
+describe('shared-resource tagging (disposal guard contract)', () => {
+  it('door geometries and materials are marked shared so per-view disposal skips them', () => {
+    const { body, portal } = buildDoorBody(true, null, false);
+    for (const m of meshes(body)) {
+      expect(isSharedGeometry(m.geometry)).toBe(true);
+      expect(isSharedMaterial(m.material as THREE.Material)).toBe(true);
+    }
+    if (!portal) throw new Error('expected a portal mesh');
+    expect(isSharedMaterial(portal.material as THREE.Material)).toBe(true);
+  });
+
+  it('reuses the same cached geometry instances across builds', () => {
+    const a = buildDoorBody(true, null, false);
+    const b = buildDoorBody(true, null, false);
+    const archA = meshes(a.body)[0];
+    const archB = meshes(b.body)[0];
+    // same shared geometry object, not a fresh allocation per door
+    expect(archA.geometry).toBe(archB.geometry);
+  });
+});
+
+describe('portal material: tint per direction and HDR boost per tier', () => {
+  const portalMat = (entering: boolean, lowGfx: boolean): THREE.MeshBasicMaterial => {
+    const { portal } = buildDoorBody(entering, null, lowGfx);
+    if (!portal) throw new Error('expected a portal mesh');
+    return portal.material as THREE.MeshBasicMaterial;
+  };
+
+  it('entering vs exit use distinct base tints', () => {
+    // low tier: no boost, so the color is the raw tint
+    const enter = portalMat(true, true);
+    const exit = portalMat(false, true);
+    expect(enter.color.getHex()).toBe(0x9a5df0);
+    expect(exit.color.getHex()).toBe(0x6ab8ff);
+    expect(enter.transparent).toBe(true);
+    expect(enter.blending).toBe(THREE.AdditiveBlending);
+    expect(enter.depthWrite).toBe(false);
+  });
+
+  it('non-low tier multiplies the tint by the bloom boost (2x), low tier does not', () => {
+    const enterHigh = portalMat(true, false);
+    const enterLow = portalMat(true, true);
+    // The boost multiplies the working color channels by 2 (no clamp at this tint).
+    expect(enterHigh.color.r).toBeCloseTo(enterLow.color.r * 2);
+    expect(enterHigh.color.r).toBeGreaterThan(enterLow.color.r);
+  });
+});


### PR DESCRIPTION
## What

Extracts the dungeon-door / exit-portal visual system out of the `renderer.ts` monolith into a dedicated `src/render/door_portal.ts`, following the render module rule (`src/render/CLAUDE.md`: a visual system is its own `render/<thing>.ts` the renderer calls, not a method bank on `renderer.ts`). It now sits alongside `buildProps` / `buildMailboxPillar` / `buildDelveInteractable`, which the renderer already calls the same way.

Also lifts the four tiny shared-resource tagging helpers (`markSharedGeometry` / `markSharedMaterial` / `isSharedGeometry` / `isSharedMaterial`) into `src/render/shared_resource.ts`, so the new module and the renderer's per-view disposal guard read the same `userData.sharedRendererResource` flag instead of duplicating the magic string.

## Why

`renderer.ts` is one of the four named logic monoliths. The door cluster (9 cached fields + 10 builder methods) was a self-contained visual system inlined on the orchestrator, the clearest remaining example of the rule this repo already documents. This is a move-not-rewrite.

## Change shape

- `renderer.ts` shrinks by ~150 lines. The door branch in `createView` and the prewarm group now call `buildDoorBody(entering, dungeonId, lowGfx)`.
- The portal-material cache is now keyed by `(entering, lowGfx)`. In production `lowGfx` is fixed for the renderer's lifetime, so only two materials are ever created, identical to the previous per-entering cache that captured `lowGfx` at first build. Keying on both inputs just makes the builder correct for any caller and unit-testable.
- Disposal behavior is unchanged: door resources stay tagged shared, so the per-view disposal guard skips them exactly as before.

## Tests

New `tests/door_portal.test.ts` (Three.js runs headless in Node, same as the existing render tests) covers:
- body structure (arch + keystone + 2 plinths + portal; portal returned separately),
- the Nythraxis crypt invisible click-box special case (entering only),
- shared-resource tagging (the disposal-guard contract),
- geometry cache reuse across builds,
- portal tint per direction and the HDR bloom boost per tier.

## Verification

- `tsc --noEmit`: clean.
- `tests/architecture.test.ts` (determinism + purity guard), `tests/door_portal.test.ts`, and the render suites (`delve_render`, `render_asset_fallback`, `gfx`, `nameplate_projection`): green (77 tests).
- `biome ci` on changed files: no errors, no new warnings (the new files are warning-clean).
- No behavior change intended; visuals are preserved by construction (byte-identical geometry/material construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)