### PR TITLE
fix(ui): drop inherited text shadow on quest tracker number badges

### DIFF
--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -1916,6 +1916,9 @@
     font-size: 11px;
     font-family: var(--ui-font);
     vertical-align: text-bottom;
+    /* dark digit on a gold fill: the tracker's inherited black text-shadow
+       only blurs it, so drop it inside the badge */
+    text-shadow: none;
   }
   #quest-tracker .qt-obj {
     color: var(--color-text-overlay);


### PR DESCRIPTION
## Problem

The order-number badges in the quest tracker (the gold circles numbered 1, 2, 3, ...) were hard to read: the digits looked smudged against the gold fill.

## Cause

`#quest-tracker` sets `text-shadow: 1px 1px 2px #000` so the light quest text stays legible over the game world. The `.qt-num` badges inherited that shadow, but they render a dark digit on a solid opaque gold fill, so the black shadow only blurred the digit into itself.

## Fix

CSS only: reset the inherited shadow (`text-shadow: none`) on `#quest-tracker .qt-num`. Quest titles and objective rows keep their overlay shadow. Verified the world map quest badges do not need the same fix: they are painted on canvas (`map_window_painter.ts`) and never set a canvas shadow, so nothing is inherited there. Badge size, colors, and layout are unchanged.

Fixes #1536

Generated with [Claude Code](https://claude.com/claude-code)