### PR TITLE
fix(desktop): split prod/dev auto-update tracks and refuse cross-origin updates

### DIFF
--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -28,12 +28,34 @@ endpoint. The updater runs only for a PACKAGED WEBSITE build; there is deliberat
 no way to force it on in a Steam build. To try either channel unpacked, set
 `WOC_DISTRIBUTION=website|steam` on `npm run electron:dev`.
 
+Update tracks (prod/dev split): the publish channel is derived from the baked
+`apiOrigin` by one rule shared between build and runtime
+(`electron/update_guard.cjs`). A build baked with the production origin publishes
+and reads the `latest` channel (`latest-mac.yml`, `latest.yml`,
+`latest-linux*.yml`); a build baked with ANY other origin (dev, staging, a
+localhost smoke pack) publishes and reads the `dev` channel (`dev-mac.yml` and
+friends), which production installs never request. Three layers keep the tracks
+apart: the build throws if the production channel is requested for a
+non-production origin (`scripts/electron-builder-config.mjs`); every emitted feed
+file is stamped with the `wocApiOrigin` its artifact was baked with; and the
+running app refuses to download an update whose stamp differs from its own baked
+origin (loud `[updater] REFUSED` entry in `main.log`), so even a feed file
+renamed onto the wrong track cannot flip an install to another backend.
+`WOC_UPDATE_CHANNEL=dev` on a production-origin build is the one supported
+cross: it emits a production-origin artifact's feed files on the dev track to
+exercise the publish pipeline end to end (no install ever downloads such an
+artifact: dev-origin installs refuse its production origin stamp, which is the
+fail-safe direction). Never rename `dev-*.yml` files to `latest-*.yml` on the
+update host.
+
 `npm run electron:pack` / `electron:pack:steam` are the fast local variants
 (`--dir`, host arch only, no installers). Release builds use the full arch matrix in
 `package.json` `build`: macOS universal (dmg + zip), Windows x64 + arm64 (nsis + zip),
 Linux x64 + arm64 (AppImage + deb). To smoke-test a packaged build against a local
 server: `VITE_DESKTOP_API_ORIGIN=http://localhost:8787 npm run electron:pack` (a
-BUILD-time value: baked into the bundle and stamped into the app).
+BUILD-time value: baked into the bundle and stamped into the app; such a build
+lands on the `dev` update channel automatically and cannot produce production
+feed files).
 
 Build each OS on its own runner (mac artifacts on macOS, Windows artifacts on Windows,
 Linux artifacts on Linux). Cross-building is not part of this runbook.
@@ -145,7 +167,19 @@ Fedora atomic desktops (Bazzite, Steam Deck) with no system install, just
    page links point at the new build (the static hrefs in `index.html` are the
    no-JS fallback; keep them on the same version). The page offers macOS (dmg)
    and Linux (AppImage); Windows stays "pending" until its installer is uploaded.
-2. Build on each OS runner with signing env present: `npm run electron:build`.
+2. Build on each OS runner with signing env present: `npm run electron:build`,
+   with `VITE_DESKTOP_API_ORIGIN` unset or set to the production origin. A
+   production release MUST emit `latest-*.yml` feed files; if the build produced
+   `dev-*.yml` instead, it was baked with a non-production origin: rebuild, do
+   not rename (renamed files still carry the `wocApiOrigin` stamp and every
+   production install will refuse them).
+   One-time cleanup with the first track-split release: audit the production
+   update host and delete any `latest*.yml` (and its artifacts) that this
+   release did not produce. Feed files published before the split carry no
+   `wocApiOrigin` stamp and the runtime guard accepts unstamped files for back
+   compat, so a leftover pre-split dev-baked `latest*.yml` is the one artifact
+   the guard cannot refuse; from this release on, every feed file on the host
+   is stamped and the acceptance window can later be tightened to stamped-only.
 3. Upload from `release/` to the update host directory (keep filenames exactly):
    - macOS: `world-of-claudecraft-<v>-mac-universal.dmg` (download page),
      `...-mac-universal.zip` + `.zip.blockmap` (updater), `latest-mac.yml`.
@@ -247,7 +281,8 @@ Rules that keep this working:
 
 1. Fresh install, launch: window appears, no Gatekeeper/SmartScreen block (signed
    builds), log file created, startup banner shows the right `version`,
-   `distribution`, and `updaterEnabled`.
+   `distribution`, `updaterEnabled`, and `updateChannel` (`latest` on a
+   production build, `dev` on anything else).
 2. GPU: log shows `[gpu] feature status` with hardware WebGL2 (no
    `software only`, no SwiftShader/llvmpipe renderer, no softwareRendering warning).
 3. Login both paths: email/password in-app, and Discord via the external browser +
@@ -257,8 +292,9 @@ Rules that keep this working:
    world (backgroundThrottling stays off).
 5. Website channel only: with a higher-version build on the feed, the update toast
    appears, "Restart now" applies it, and a player who quits instead gets it on next
-   launch. Steam channel: confirm the log says the updater is disabled and no
-   update network traffic occurs.
+   launch; after the restart the log's startup banner still shows the production
+   `apiOrigin` channel (`updateChannel: latest`). Steam channel: confirm the log
+   says the updater is disabled and no update network traffic occurs.
 6. Crash surfaces: `kill -SEGV <renderer pid>` THREE times within a minute (a
    task-manager "end task" is classified as a benign `killed` exit and does not
    trigger recovery). The first two SEGVs each produce a log entry and a bounded

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -45,8 +45,11 @@ renamed onto the wrong track cannot flip an install to another backend.
 cross: it emits a production-origin artifact's feed files on the dev track to
 exercise the publish pipeline end to end (no install ever downloads such an
 artifact: dev-origin installs refuse its production origin stamp, which is the
-fail-safe direction). Never rename `dev-*.yml` files to `latest-*.yml` on the
-update host.
+fail-safe direction). Never rename `dev*.yml` files to `latest*.yml` on the
+update host. Dev installs made BEFORE the track split read the `latest`
+channel like everything else did, so they will auto-update onto production
+builds; give dev testers a fresh post-split dev build rather than expecting
+their old installs to stay on dev.
 
 `npm run electron:pack` / `electron:pack:steam` are the fast local variants
 (`--dir`, host arch only, no installers). Release builds use the full arch matrix in
@@ -169,8 +172,9 @@ Fedora atomic desktops (Bazzite, Steam Deck) with no system install, just
    and Linux (AppImage); Windows stays "pending" until its installer is uploaded.
 2. Build on each OS runner with signing env present: `npm run electron:build`,
    with `VITE_DESKTOP_API_ORIGIN` unset or set to the production origin. A
-   production release MUST emit `latest-*.yml` feed files; if the build produced
-   `dev-*.yml` instead, it was baked with a non-production origin: rebuild, do
+   production release MUST emit `latest*.yml` feed files (`latest.yml` on
+   Windows, `latest-mac.yml`, `latest-linux*.yml`); if the build produced
+   `dev*.yml` instead, it was baked with a non-production origin: rebuild, do
    not rename (renamed files still carry the `wocApiOrigin` stamp and every
    production install will refuse them).
    One-time cleanup with the first track-split release: audit the production

--- a/docs/desktop-ship-notes.md
+++ b/docs/desktop-ship-notes.md
@@ -67,17 +67,26 @@ node_modules in the asar, all seven fuses set.
 
 1. At build time, electron-builder bakes `resources/app-update.yml` into the
    app (from `build.publish`: generic provider, feed URL
-   `https://updates.worldofclaudecraft.com/desktop`).
+   `https://updates.worldofclaudecraft.com/desktop`), and the publish channel
+   is derived from the baked API origin (`electron/update_guard.cjs`): the
+   production origin emits the `latest` feed files, any other origin (dev,
+   staging, localhost smoke packs) emits `dev` ones, and each emitted feed
+   file is stamped with the `wocApiOrigin` its artifact was baked with.
 2. At runtime, `electron/updater.cjs` initializes ONLY when the build is
    packaged AND stamped `website`. It checks the feed 15 seconds after launch
-   and every 4 hours: it GETs the platform's `latest*.yml`, compares the
-   version there against the running `app.getVersion()`, and only ever moves
-   FORWARD (no downgrades).
-3. If newer, it downloads in the background (delta via blockmap when the host
-   supports HTTP range requests, full download otherwise), verifies the SHA512
-   from the yml, then emits `update-downloaded`. The player sees a toast:
-   "Restart now" calls `quitAndInstall`; ignoring it still installs on next
-   quit (`autoInstallOnAppQuit`). Failed checks (offline, host down) only log.
+   and every 4 hours: it GETs the yml of the channel derived from its OWN
+   baked origin (production installs: `latest*.yml`; anything else:
+   `dev*.yml`), compares the version there against the running
+   `app.getVersion()`, and only ever moves FORWARD (no downgrades).
+3. If newer AND the feed file's `wocApiOrigin` stamp matches the install's own
+   baked origin (a missing stamp, from a pre-split feed file, is accepted; a
+   mismatch is REFUSED with a loud `main.log` entry, so a wrong-track artifact
+   can never flip an install to another backend), it downloads in the
+   background (delta via blockmap when the host supports HTTP range requests,
+   full download otherwise), verifies the SHA512 from the yml, then emits
+   `update-downloaded`. The player sees a toast: "Restart now" calls
+   `quitAndInstall`; ignoring it still installs on next quit
+   (`autoInstallOnAppQuit`). Failed checks (offline, host down) only log.
 4. Staged rollout: hand-edit `stagingPercentage: N` into the uploaded yml; each
    install hashes a persistent per-machine ID against N. Rollback: you MUST
    publish a higher version; machines that took a bad build will not downgrade.

--- a/electron/desktop_config.cjs
+++ b/electron/desktop_config.cjs
@@ -14,6 +14,8 @@
 // code and differ only by this stamp. WOC_DISTRIBUTION overrides it for local
 // testing of either path in `electron .` / electron:dev.
 
+const { updateChannelForOrigin } = require('./update_guard.cjs');
+
 const DISTRIBUTIONS = new Set(['website', 'steam']);
 
 // Resolve the distribution channel. The WOC_DISTRIBUTION env override applies
@@ -92,14 +94,20 @@ function updaterAllowed({ distribution, isPackaged }) {
   return isPackaged === true && distribution === 'website';
 }
 
-// One-call summary used by electron/main.cjs at startup.
+// One-call summary used by electron/main.cjs at startup. updateChannel is a
+// pure function of the resolved apiOrigin (electron/update_guard.cjs): there
+// is deliberately no stamp and no env hatch for it, so a build baked with a
+// non-production origin can never read the production update feed, however it
+// was stamped or launched.
 function resolveDesktopConfig({ packagedMetadata, env, isPackaged } = {}) {
   const distribution = resolveDistribution({ packagedMetadata, env, isPackaged });
+  const origins = resolveDesktopOrigins({ packagedMetadata, env, isPackaged });
   return {
     distribution,
     updaterEnabled: updaterAllowed({ distribution, isPackaged }),
     crashSubmitUrl: resolveCrashSubmitUrl({ packagedMetadata, env, isPackaged }),
-    ...resolveDesktopOrigins({ packagedMetadata, env, isPackaged }),
+    updateChannel: updateChannelForOrigin(origins.apiOrigin),
+    ...origins,
   };
 }
 

--- a/electron/desktop_config.cjs
+++ b/electron/desktop_config.cjs
@@ -14,7 +14,7 @@
 // code and differ only by this stamp. WOC_DISTRIBUTION overrides it for local
 // testing of either path in `electron .` / electron:dev.
 
-const { updateChannelForOrigin } = require('./update_guard.cjs');
+const { PRODUCTION_API_ORIGIN, updateChannelForOrigin } = require('./update_guard.cjs');
 
 const DISTRIBUTIONS = new Set(['website', 'steam']);
 
@@ -78,8 +78,7 @@ function resolveDesktopOrigins({ packagedMetadata, env, isPackaged } = {}) {
     if (typeof stampedValue === 'string' && stampedValue !== '') return stampedValue;
     return '';
   };
-  const apiOrigin =
-    pick(env?.VITE_DESKTOP_API_ORIGIN, stamped.apiOrigin) || 'https://worldofclaudecraft.com';
+  const apiOrigin = pick(env?.VITE_DESKTOP_API_ORIGIN, stamped.apiOrigin) || PRODUCTION_API_ORIGIN;
   const loginOrigin = pick(env?.VITE_DESKTOP_LOGIN_ORIGIN, stamped.loginOrigin) || apiOrigin;
   return { apiOrigin, loginOrigin };
 }

--- a/electron/desktop_config.d.cts
+++ b/electron/desktop_config.d.cts
@@ -2,6 +2,8 @@
 // (tests/electron_desktop_config.test.ts) type-checks its imports. Keep in sync
 // with the .cjs exports (same convention as shell_guards.d.cts).
 
+import type { UpdateChannel } from './update_guard.cjs';
+
 export type Distribution = 'website' | 'steam';
 
 export interface DesktopConfigInput {
@@ -21,6 +23,7 @@ export interface DesktopConfig {
   distribution: Distribution;
   updaterEnabled: boolean;
   crashSubmitUrl: string;
+  updateChannel: UpdateChannel;
   apiOrigin: string;
   loginOrigin: string;
 }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -25,6 +25,7 @@ const {
   ALLOWED_PERMISSIONS,
 } = require('./shell_guards.cjs');
 const { resolveDesktopConfig } = require('./desktop_config.cjs');
+const { PRODUCTION_API_ORIGIN } = require('./update_guard.cjs');
 const {
   MAX_FORWARDED_ERRORS,
   MAX_MIRRORED_CONSOLE_LINES,
@@ -77,7 +78,7 @@ const desktopConfig = resolveDesktopConfig({
 // what the Vite client bundle was baked with; loginOrigin is main-process-only);
 // the VITE_DESKTOP_* env pair is honored on unpackaged checkouts only,
 // mirroring the WOC_DISTRIBUTION hatch closure.
-const apiOrigin = deriveOrigin(desktopConfig.apiOrigin) || 'https://worldofclaudecraft.com';
+const apiOrigin = deriveOrigin(desktopConfig.apiOrigin) || PRODUCTION_API_ORIGIN;
 const desktopLoginOrigin = desktopConfig.loginOrigin.replace(/\/+$/, '');
 
 // Crashpad must start before any window exists so native crashes in EVERY

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -464,6 +464,7 @@ app.whenReady().then(() => {
     packaged: app.isPackaged,
     distribution: desktopConfig.distribution,
     updaterEnabled: desktopConfig.updaterEnabled,
+    updateChannel: desktopConfig.updateChannel,
     crashUpload: desktopConfig.crashSubmitUrl !== '',
     crashDumpDir: app.getPath('crashDumps'),
     logFile: logFilePath,
@@ -501,6 +502,11 @@ app.whenReady().then(() => {
         getWindow: () => mainWindow,
         isTrusted: trustedSender,
         isPackaged: app.isPackaged,
+        // The normalized origin this install talks to and the update channel
+        // derived from it (electron/update_guard.cjs): the updater reads only
+        // its own track's feed and refuses cross-origin artifacts.
+        apiOrigin,
+        updateChannel: desktopConfig.updateChannel,
       });
     } catch (err) {
       log.error('[updater] init failed', err);

--- a/electron/update_guard.cjs
+++ b/electron/update_guard.cjs
@@ -1,0 +1,79 @@
+'use strict';
+
+// Pure, Node-testable guard logic for the auto-updater's prod/dev track split
+// (tests/electron_update_guard.test.ts). One origin rule decides everything: a
+// build baked with the production API origin lives on the 'latest' update
+// channel (the feed production installs have always read), and a build baked
+// with ANY other origin (dev, staging, a localhost smoke-test pack) lives on
+// the 'dev' channel, whose feed files (dev-mac.yml, dev.yml, dev-linux*.yml) a
+// production install never requests. scripts/electron-builder-config.mjs
+// imports the same rule at build time, so the channel a build publishes to and
+// the channel it reads at runtime cannot drift apart.
+//
+// evaluateUpdateOffer is the runtime defense in depth behind that split: the
+// build stamps every emitted feed file with the API origin its artifact was
+// baked with (wocApiOrigin, scripts/electron-build.mjs), and
+// electron/updater.cjs refuses to download an update whose stamp differs from
+// this install's own origin, so a feed file renamed or uploaded onto the wrong
+// track still cannot flip a shipped app to another backend. No electron
+// imports; callers pass everything in.
+
+const PRODUCTION_API_ORIGIN = 'https://worldofclaudecraft.com';
+
+// Normalize an origin-ish string to its URL origin so 'https://x.com' and
+// 'https://x.com/' compare equal; null when the value is not a parseable
+// http(s) URL.
+function apiOriginKey(value) {
+  if (typeof value !== 'string' || value === '') return null;
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null;
+  return parsed.origin;
+}
+
+function isProductionApiOrigin(origin) {
+  return apiOriginKey(origin) === PRODUCTION_API_ORIGIN;
+}
+
+// The electron-updater channel for a build baked with this API origin. Only
+// the exact production origin earns the production channel; anything else,
+// including a missing or garbage value, fails safe onto 'dev'.
+function updateChannelForOrigin(apiOrigin) {
+  return isProductionApiOrigin(apiOrigin) ? 'latest' : 'dev';
+}
+
+// Decide whether an offered update (electron-updater's UpdateInfo, which is
+// the parsed feed yml, so the wocApiOrigin stamp rides along) may be
+// downloaded by an install whose own baked origin is apiOrigin. Feed files
+// published before the track split carry no stamp and are accepted
+// (stamped: false); a present stamp must match exactly, and an unverifiable
+// side (garbage stamp, garbage own origin) refuses rather than guesses.
+function evaluateUpdateOffer({ apiOrigin, info } = {}) {
+  const offered = info?.wocApiOrigin;
+  if (offered === undefined || offered === null || offered === '') {
+    return { ok: true, stamped: false };
+  }
+  const offeredKey = apiOriginKey(offered);
+  const ownKey = apiOriginKey(apiOrigin);
+  if (offeredKey !== null && ownKey !== null && offeredKey === ownKey) {
+    return { ok: true, stamped: true };
+  }
+  return {
+    ok: false,
+    stamped: true,
+    offeredOrigin: typeof offered === 'string' ? offered : String(offered),
+    expectedOrigin: typeof apiOrigin === 'string' ? apiOrigin : String(apiOrigin),
+  };
+}
+
+module.exports = {
+  PRODUCTION_API_ORIGIN,
+  apiOriginKey,
+  isProductionApiOrigin,
+  updateChannelForOrigin,
+  evaluateUpdateOffer,
+};

--- a/electron/update_guard.d.cts
+++ b/electron/update_guard.d.cts
@@ -1,0 +1,23 @@
+// Hand-written declarations for electron/update_guard.cjs so the Vitest suite
+// (tests/electron_update_guard.test.ts) type-checks its imports. Keep in sync
+// with the .cjs exports (same convention as shell_guards.d.cts).
+
+export type UpdateChannel = 'latest' | 'dev';
+
+export const PRODUCTION_API_ORIGIN: string;
+
+export function apiOriginKey(value: unknown): string | null;
+export function isProductionApiOrigin(origin: unknown): boolean;
+export function updateChannelForOrigin(apiOrigin: unknown): UpdateChannel;
+
+export interface UpdateOfferVerdict {
+  ok: boolean;
+  stamped: boolean;
+  offeredOrigin?: string;
+  expectedOrigin?: string;
+}
+
+export function evaluateUpdateOffer(input?: {
+  apiOrigin?: unknown;
+  info?: unknown;
+}): UpdateOfferVerdict;

--- a/electron/updater.cjs
+++ b/electron/updater.cjs
@@ -10,11 +10,20 @@
 // UX contract: this side only LOGS and forwards whitelisted payloads
 // (electron/update_events.cjs) to the renderer over 'desktop-update-event';
 // the renderer renders the t()-localized toast and calls
-// 'desktop-update-install' when the player picks "restart now". Downloads are
-// automatic; if the player ignores the toast the update installs on quit
-// (autoInstallOnAppQuit).
+// 'desktop-update-install' when the player picks "restart now". Downloads
+// start as soon as an offered update passes the cross-track origin guard
+// (electron/update_guard.cjs); if the player ignores the toast the update
+// installs on quit (autoInstallOnAppQuit).
+//
+// Track safety: this install reads ONLY the update channel derived from its
+// own baked API origin (production origin: 'latest'; anything else: 'dev'),
+// and it refuses to download an update whose feed-file wocApiOrigin stamp
+// differs from that origin. Both are defense in depth behind the build-time
+// split in scripts/electron-builder-config.mjs; see the issue this closes:
+// a dev-origin artifact on the production feed must never install.
 
 const { shouldNotifyProgress, updateEventPayload } = require('./update_events.cjs');
+const { evaluateUpdateOffer } = require('./update_guard.cjs');
 
 const FIRST_CHECK_DELAY_MS = 15_000;
 const RECHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
@@ -44,15 +53,38 @@ function loadAutoUpdater({ isPackaged } = {}) {
   return null;
 }
 
-function initUpdater({ ipcMain, log, getWindow, isTrusted, isPackaged }) {
-  const autoUpdater = loadAutoUpdater({ isPackaged });
+function initUpdater({
+  ipcMain,
+  log,
+  getWindow,
+  isTrusted,
+  isPackaged,
+  apiOrigin,
+  updateChannel,
+  autoUpdater: injectedAutoUpdater,
+}) {
+  // injectedAutoUpdater is a test seam only (tests/electron_updater_track.test.ts);
+  // electron/main.cjs never passes it, so a real app always loads the vendor bundle.
+  const autoUpdater = injectedAutoUpdater ?? loadAutoUpdater({ isPackaged });
   if (!autoUpdater) {
     log.warn('[updater] electron-updater bundle missing; auto-update disabled this session');
     return null;
   }
 
   autoUpdater.logger = log;
-  autoUpdater.autoDownload = true;
+  // Read the channel derived from this build's own baked API origin, never the
+  // one in the shipped app-update.yml: even an artifact packaged with a wrong
+  // publish config stays on its origin's track. electron-updater's channel
+  // setter silently flips allowDowngrade to true, so reset it right after (a
+  // production install must never "update" onto an older feed entry).
+  if (typeof updateChannel === 'string' && updateChannel !== '') {
+    autoUpdater.channel = updateChannel;
+    autoUpdater.allowDowngrade = false;
+  }
+  // Downloads are gated on the cross-track origin guard in 'update-available'
+  // below; only a guard-approved download exists for autoInstallOnAppQuit to
+  // install.
+  autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = true;
 
   const send = (payload) => {
@@ -64,9 +96,26 @@ function initUpdater({ ipcMain, log, getWindow, isTrusted, isPackaged }) {
 
   let lastProgressSent = -1;
   autoUpdater.on('update-available', (info) => {
-    log.info('[updater] update available', { version: info?.version });
+    const verdict = evaluateUpdateOffer({ apiOrigin, info });
+    if (!verdict.ok) {
+      // Never user-facing: the player keeps playing on the build they have.
+      // Loud in the log so the operator finds the wrong-track artifact.
+      log.error('[updater] REFUSED update: baked for another API origin; not downloading', {
+        version: info?.version,
+        offeredOrigin: verdict.offeredOrigin,
+        expectedOrigin: verdict.expectedOrigin,
+      });
+      return;
+    }
+    log.info('[updater] update available', {
+      version: info?.version,
+      originStamp: verdict.stamped ? 'match' : 'absent (pre-split feed file)',
+    });
     lastProgressSent = -1;
     send(updateEventPayload('available', info));
+    autoUpdater
+      .downloadUpdate()
+      .catch((err) => log.warn('[updater] download failed', err?.message ?? String(err)));
   });
   autoUpdater.on('update-not-available', (info) => {
     log.info('[updater] up to date', { version: info?.version });

--- a/electron/updater.d.cts
+++ b/electron/updater.d.cts
@@ -1,7 +1,8 @@
 // Hand-written declarations for electron/updater.cjs so the Vitest suite
-// (tests/electron_update_cadence.test.ts) type-checks its imports. Keep in sync
-// with the .cjs exports (same convention as shell_guards.d.cts). Only the pure,
-// electron-free surface is declared; initUpdater's runtime deps are injected.
+// (tests/electron_update_cadence.test.ts, tests/electron_updater_track.test.ts)
+// type-checks its imports. Keep in sync with the .cjs exports (same convention
+// as shell_guards.d.cts). Only the pure, electron-free surface is declared;
+// initUpdater's runtime deps are injected.
 
 export const FIRST_CHECK_DELAY_MS: number;
 export const RECHECK_INTERVAL_MS: number;
@@ -16,4 +17,7 @@ export function initUpdater(deps: {
   getWindow: () => unknown;
   isTrusted: (event: unknown) => boolean;
   isPackaged?: boolean;
+  apiOrigin?: string;
+  updateChannel?: string;
+  autoUpdater?: unknown;
 }): unknown;

--- a/scripts/electron-build.mjs
+++ b/scripts/electron-build.mjs
@@ -1,9 +1,13 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { azureSignOptionsFromEnv, desktopBuilderConfig } from './electron-builder-config.mjs';
+import {
+  azureSignOptionsFromEnv,
+  desktopBuilderConfig,
+  stampChannelFeedFiles,
+} from './electron-builder-config.mjs';
 import { buildElectronVendor } from './electron-vendor.mjs';
 
 // Usage: node scripts/electron-build.mjs [pack|build] [website|steam]
@@ -95,6 +99,12 @@ const config = desktopBuilderConfig({
   loginOrigin,
   crashSubmitUrl: process.env.WOC_CRASH_SUBMIT_URL ?? '',
   azureSign: process.platform === 'win32' ? azureSignOptionsFromEnv(process.env) : null,
+  // The update track defaults from apiOrigin (production origin publishes the
+  // 'latest' feed, anything else 'dev'); WOC_UPDATE_CHANNEL=dev stages a
+  // production-origin artifact on the dev track for update-pipeline testing.
+  // The one dangerous combination, 'latest' with a non-production origin,
+  // makes desktopBuilderConfig throw before anything is built.
+  updateChannel: process.env.WOC_UPDATE_CHANNEL ?? null,
 });
 const configDir = mkdtempSync(path.join(tmpdir(), 'woc-eb-'));
 const configPath = path.join(configDir, 'electron-builder.json');
@@ -114,3 +124,26 @@ run(electronBuilderCommand, [
 // The derived config holds no secrets, but do not litter the tmpdir on the
 // success path (run() exits the process on failure, skipping this).
 rmSync(configDir, { recursive: true, force: true });
+
+// Stamp every emitted update-feed file with the baked API origin so the
+// running app can refuse a cross-track artifact (electron/update_guard.cjs).
+// Steam builds publish nothing and pack builds emit no feed files, so this is
+// a no-op there.
+const feedChannel = config.publish?.channel;
+if (feedChannel) {
+  const outDir = path.join(root, config.directories?.output ?? 'release');
+  const stamped = stampChannelFeedFiles({
+    outDir,
+    channel: feedChannel,
+    apiOrigin,
+    fs: { existsSync, readdirSync, readFileSync, writeFileSync },
+    joinPath: path.join,
+  });
+  for (const name of stamped) console.log(`[electron-build] stamped wocApiOrigin into ${name}`);
+  if (mode === 'build' && stamped.length === 0) {
+    console.warn(
+      `[electron-build] no ${feedChannel}*.yml feed files found in ${outDir}; ` +
+        'nothing stamped (expected for target sets with no updatable artifact)',
+    );
+  }
+}

--- a/scripts/electron-build.mjs
+++ b/scripts/electron-build.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import {
   azureSignOptionsFromEnv,
   desktopBuilderConfig,
+  isChannelFeedFile,
   stampChannelFeedFiles,
 } from './electron-builder-config.mjs';
 import { buildElectronVendor } from './electron-vendor.mjs';
@@ -37,9 +38,10 @@ const defaultOrigin = 'https://worldofclaudecraft.com';
 // the wocDesktop stamp below (so the packaged main process always agrees with
 // what the bundle was baked with); loginOrigin is stamped for the main process
 // only. A packaged build ignores VITE_DESKTOP_* from runtime env;
-// electron/desktop_config.cjs reads the stamp instead.
-const apiOrigin = process.env.VITE_DESKTOP_API_ORIGIN ?? defaultOrigin;
-const loginOrigin = process.env.VITE_DESKTOP_LOGIN_ORIGIN ?? apiOrigin;
+// electron/desktop_config.cjs reads the stamp instead. Set-but-empty env vars
+// (CI matrices) mean "unset", hence || rather than ??.
+const apiOrigin = process.env.VITE_DESKTOP_API_ORIGIN || defaultOrigin;
+const loginOrigin = process.env.VITE_DESKTOP_LOGIN_ORIGIN || apiOrigin;
 const env = {
   ...process.env,
   VITE_DESKTOP_APP: '1',
@@ -103,12 +105,27 @@ const config = desktopBuilderConfig({
   // 'latest' feed, anything else 'dev'); WOC_UPDATE_CHANNEL=dev stages a
   // production-origin artifact on the dev track for update-pipeline testing.
   // The one dangerous combination, 'latest' with a non-production origin,
-  // makes desktopBuilderConfig throw before anything is built.
-  updateChannel: process.env.WOC_UPDATE_CHANNEL ?? null,
+  // makes desktopBuilderConfig throw before anything is built. Set-but-empty
+  // means "unset" (derive from the origin), hence || rather than ??.
+  updateChannel: process.env.WOC_UPDATE_CHANNEL || null,
 });
 const configDir = mkdtempSync(path.join(tmpdir(), 'woc-eb-'));
 const configPath = path.join(configDir, 'electron-builder.json');
 writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+// Feed files accumulate across local builds sharing one output dir, and a
+// stale one from a differently-baked earlier build would be re-stamped below
+// with THIS build's origin, misdescribing the artifact it points at. Remove
+// both channels' feed files up front; electron-builder regenerates the
+// current channel's set.
+const outDir = path.join(root, config.directories?.output ?? 'release');
+if (config.publish?.channel && existsSync(outDir)) {
+  for (const name of readdirSync(outDir)) {
+    if (!isChannelFeedFile(name, 'latest') && !isChannelFeedFile(name, 'dev')) continue;
+    rmSync(path.join(outDir, name));
+    console.log(`[electron-build] removed stale feed file ${name}`);
+  }
+}
 
 // --publish never: artifact upload is a deliberate, documented manual step
 // (docs/desktop-release.md); without this, electron-builder auto-publishes on
@@ -131,7 +148,6 @@ rmSync(configDir, { recursive: true, force: true });
 // a no-op there.
 const feedChannel = config.publish?.channel;
 if (feedChannel) {
-  const outDir = path.join(root, config.directories?.output ?? 'release');
   const stamped = stampChannelFeedFiles({
     outDir,
     channel: feedChannel,

--- a/scripts/electron-builder-config.d.mts
+++ b/scripts/electron-builder-config.d.mts
@@ -2,6 +2,8 @@
 // Vitest suite type-checks its imports (same convention as the electron/*.d.cts
 // files). Keep in sync with the .mjs exports.
 
+import type { UpdateChannel } from '../electron/update_guard.cjs';
+
 export interface AzureSignOptions {
   publisherName: string;
   endpoint: string;
@@ -22,7 +24,7 @@ export interface DesktopBuilderConfig {
       crashSubmitUrl?: string;
     };
   };
-  publish: { channel?: 'latest' | 'dev'; [key: string]: unknown } | null;
+  publish: { channel?: UpdateChannel; [key: string]: unknown } | null;
   directories: { output?: string; [key: string]: unknown };
   mac: { [key: string]: unknown };
   win: { azureSignOptions?: AzureSignOptions; [key: string]: unknown };

--- a/scripts/electron-builder-config.d.mts
+++ b/scripts/electron-builder-config.d.mts
@@ -22,7 +22,7 @@ export interface DesktopBuilderConfig {
       crashSubmitUrl?: string;
     };
   };
-  publish: unknown;
+  publish: { channel?: 'latest' | 'dev'; [key: string]: unknown } | null;
   directories: { output?: string; [key: string]: unknown };
   mac: { [key: string]: unknown };
   win: { azureSignOptions?: AzureSignOptions; [key: string]: unknown };
@@ -38,4 +38,20 @@ export function desktopBuilderConfig(input: {
   loginOrigin?: string;
   crashSubmitUrl?: string;
   azureSign?: AzureSignOptions | null;
+  updateChannel?: string | null;
 }): DesktopBuilderConfig;
+
+export function isChannelFeedFile(fileName: unknown, channel: unknown): boolean;
+export function stampFeedFile(text: string, apiOrigin: string): string;
+export function stampChannelFeedFiles(input: {
+  outDir: string;
+  channel: unknown;
+  apiOrigin: string;
+  fs: {
+    existsSync: (path: string) => boolean;
+    readdirSync: (path: string) => string[];
+    readFileSync: (path: string, encoding: 'utf8') => string;
+    writeFileSync: (path: string, data: string) => void;
+  };
+  joinPath: (...parts: string[]) => string;
+}): string[];

--- a/scripts/electron-builder-config.mjs
+++ b/scripts/electron-builder-config.mjs
@@ -28,6 +28,7 @@
 // the channel differences directly.
 
 import {
+  apiOriginKey,
   isProductionApiOrigin,
   PRODUCTION_API_ORIGIN,
   updateChannelForOrigin,
@@ -81,12 +82,26 @@ export function desktopBuilderConfig({
     },
   };
   if (distribution === 'website' && config.publish) {
+    // A non-empty origin that does not parse would strand the install it
+    // bakes: the channel would fail safe to 'dev' while the runtime guard
+    // normalizes its own side to production, refusing every stamped update on
+    // that install's track forever. That mistake dies here instead (a missing
+    // origin stays fail-safe: it only happens on direct calls, never through
+    // scripts/electron-build.mjs, which always resolves one).
+    if (apiOrigin !== '' && apiOriginKey(apiOrigin) === null) {
+      throw new Error(
+        `desktop website builds need a parseable http(s) VITE_DESKTOP_API_ORIGIN ` +
+          `to pick an update track; got "${apiOrigin}"`,
+      );
+    }
     // The update-track split: default the channel from the baked origin, and
     // hard-fail the one dangerous combination (production feed files for an
     // artifact not baked with the production origin). The reverse cross,
     // updateChannel 'dev' with a production origin, is allowed on purpose: it
     // stages a production artifact on the dev track for update-pipeline tests.
-    const channel = updateChannel ?? updateChannelForOrigin(apiOrigin);
+    // An empty updateChannel means "not requested" (set-but-empty env vars are
+    // common in CI matrices), so it derives like null does.
+    const channel = updateChannel || updateChannelForOrigin(apiOrigin);
     if (!UPDATE_CHANNELS.has(channel)) {
       throw new Error(`unknown desktop update channel: ${channel}`);
     }

--- a/scripts/electron-builder-config.mjs
+++ b/scripts/electron-builder-config.mjs
@@ -9,6 +9,13 @@
 //    (electron/desktop_config.cjs) knows what it is at runtime, how the
 //    auto-updater stays OFF in Steam builds, and why a packaged build never
 //    honors the VITE_DESKTOP_* runtime env pair.
+//  - website: the publish feed gains an explicit update channel derived from
+//    the baked apiOrigin (electron/update_guard.cjs): the production origin
+//    publishes 'latest' (latest-mac.yml and friends, the feed shipped installs
+//    read), any other origin publishes 'dev' (dev-mac.yml and friends), so a
+//    dev or staging build can never emit the feed files a production install
+//    consumes. Requesting the production channel with a non-production origin
+//    throws: that mistake must die at build time, not on players' machines.
 //  - steam: publish is nulled (no app-update.yml is emitted, electron-updater
 //    has nothing to read even if it were reached), and every OS targets 'dir'
 //    because SteamPipe depots upload the loose installed layout (mac: the
@@ -19,6 +26,14 @@
 //
 // Kept free of child_process/fs so tests/electron_builder_config.test.ts can pin
 // the channel differences directly.
+
+import {
+  isProductionApiOrigin,
+  PRODUCTION_API_ORIGIN,
+  updateChannelForOrigin,
+} from '../electron/update_guard.cjs';
+
+const UPDATE_CHANNELS = new Set(['latest', 'dev']);
 
 export function azureSignOptionsFromEnv(env = {}) {
   const options = {
@@ -50,6 +65,7 @@ export function desktopBuilderConfig({
   loginOrigin = '',
   crashSubmitUrl = '',
   azureSign = null,
+  updateChannel = null,
 }) {
   if (distribution !== 'website' && distribution !== 'steam') {
     throw new Error(`unknown desktop distribution: ${distribution}`);
@@ -64,6 +80,24 @@ export function desktopBuilderConfig({
       ...(crashSubmitUrl ? { crashSubmitUrl } : {}),
     },
   };
+  if (distribution === 'website' && config.publish) {
+    // The update-track split: default the channel from the baked origin, and
+    // hard-fail the one dangerous combination (production feed files for an
+    // artifact not baked with the production origin). The reverse cross,
+    // updateChannel 'dev' with a production origin, is allowed on purpose: it
+    // stages a production artifact on the dev track for update-pipeline tests.
+    const channel = updateChannel ?? updateChannelForOrigin(apiOrigin);
+    if (!UPDATE_CHANNELS.has(channel)) {
+      throw new Error(`unknown desktop update channel: ${channel}`);
+    }
+    if (channel === 'latest' && !isProductionApiOrigin(apiOrigin)) {
+      throw new Error(
+        `refusing to emit production update-feed files: baked API origin "${apiOrigin}" ` +
+          `is not ${PRODUCTION_API_ORIGIN}`,
+      );
+    }
+    config.publish = { ...config.publish, channel };
+  }
   if (azureSign) {
     config.win = { ...(config.win ?? {}), azureSignOptions: azureSign };
   }
@@ -83,4 +117,47 @@ export function desktopBuilderConfig({
     }
   }
   return config;
+}
+
+// Whether a file in the electron-builder output directory is one of this
+// channel's update-feed files (latest-mac.yml, latest.yml,
+// latest-linux-arm64.yml, ...). Other ymls electron-builder leaves there
+// (builder-debug.yml) are not feed files and must not be stamped.
+export function isChannelFeedFile(fileName, channel) {
+  if (typeof fileName !== 'string' || typeof channel !== 'string' || channel === '') return false;
+  if (!UPDATE_CHANNELS.has(channel)) return false;
+  return new RegExp(`^${channel}(-[a-z0-9-]+)?\\.yml$`).test(fileName);
+}
+
+// Stamp the baked API origin into one update-feed file's yml text so the
+// runtime cross-track guard (electron/update_guard.cjs evaluateUpdateOffer)
+// can refuse an artifact baked for another backend. electron-updater hands
+// the parsed yml through as the UpdateInfo object, so the extra key rides
+// along to the running app. Replaces any existing stamp; idempotent.
+export function stampFeedFile(text, apiOrigin) {
+  if (typeof apiOrigin !== 'string' || apiOrigin === '') {
+    throw new Error('stampFeedFile needs the baked apiOrigin');
+  }
+  const lines = String(text)
+    .split('\n')
+    .filter((line) => !line.startsWith('wocApiOrigin:'));
+  while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+  return `${lines.join('\n')}\nwocApiOrigin: ${JSON.stringify(apiOrigin)}\n`;
+}
+
+// Stamp every one of the channel's feed files in the electron-builder output
+// directory, returning the stamped names (empty when there is no channel, no
+// directory, or no feed file: steam and pack builds). The fs functions are
+// injected so this module stays free of node imports and
+// tests/electron_builder_config.test.ts can drive the whole orchestration
+// against a temp directory, not just the per-file helpers.
+export function stampChannelFeedFiles({ outDir, channel, apiOrigin, fs, joinPath }) {
+  if (typeof channel !== 'string' || channel === '') return [];
+  if (!fs.existsSync(outDir)) return [];
+  const names = fs.readdirSync(outDir).filter((name) => isChannelFeedFile(name, channel));
+  for (const name of names) {
+    const feedPath = joinPath(outDir, name);
+    fs.writeFileSync(feedPath, stampFeedFile(fs.readFileSync(feedPath, 'utf8'), apiOrigin));
+  }
+  return names;
 }

--- a/tests/electron_builder_config.test.ts
+++ b/tests/electron_builder_config.test.ts
@@ -1,7 +1,13 @@
+import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   azureSignOptionsFromEnv,
   desktopBuilderConfig,
+  isChannelFeedFile,
+  stampChannelFeedFiles,
+  stampFeedFile,
 } from '../scripts/electron-builder-config.mjs';
 
 // A miniature of package.json's "build" block: just the keys the channel
@@ -16,13 +22,66 @@ const base = {
   linux: { target: [{ target: 'AppImage', arch: ['x64', 'arm64'] }] },
 };
 
+const prodOrigin = 'https://worldofclaudecraft.com';
+
 describe('desktopBuilderConfig', () => {
   it('stamps the website channel into extraMetadata and keeps the publish feed', () => {
-    const config = desktopBuilderConfig({ base, distribution: 'website' });
-    expect(config.extraMetadata.wocDesktop).toEqual({ distribution: 'website' });
-    expect(config.publish).toEqual(base.publish);
+    const config = desktopBuilderConfig({ base, distribution: 'website', apiOrigin: prodOrigin });
+    expect(config.extraMetadata.wocDesktop).toEqual({
+      distribution: 'website',
+      apiOrigin: prodOrigin,
+    });
+    expect(config.publish).toEqual({ ...base.publish, channel: 'latest' });
     expect(config.appId).toBe(base.appId);
     expect(config.mac.hardenedRuntime).toBe(true);
+  });
+
+  it('routes the production origin to the latest update channel', () => {
+    const config = desktopBuilderConfig({ base, distribution: 'website', apiOrigin: prodOrigin });
+    expect(config.publish?.channel).toBe('latest');
+  });
+
+  it('routes every non-production origin to the dev update channel (issue 1537)', () => {
+    for (const apiOrigin of [
+      'https://dev.worldofclaudecraft.com',
+      'http://localhost:8787',
+      undefined,
+    ]) {
+      const config = desktopBuilderConfig({ base, distribution: 'website', apiOrigin });
+      expect(config.publish?.channel).toBe('dev');
+    }
+  });
+
+  it('refuses to emit production feed files for a non-production origin', () => {
+    expect(() =>
+      desktopBuilderConfig({
+        base,
+        distribution: 'website',
+        apiOrigin: 'http://localhost:8787',
+        updateChannel: 'latest',
+      }),
+    ).toThrow(/refusing to emit production update-feed files/);
+    expect(() =>
+      desktopBuilderConfig({ base, distribution: 'website', updateChannel: 'latest' }),
+    ).toThrow(/refusing to emit production update-feed files/);
+  });
+
+  it('allows staging a production-origin artifact on the dev track, but no other override', () => {
+    const staged = desktopBuilderConfig({
+      base,
+      distribution: 'website',
+      apiOrigin: prodOrigin,
+      updateChannel: 'dev',
+    });
+    expect(staged.publish?.channel).toBe('dev');
+    expect(() =>
+      desktopBuilderConfig({
+        base,
+        distribution: 'website',
+        apiOrigin: prodOrigin,
+        updateChannel: 'beta',
+      }),
+    ).toThrow(/unknown desktop update channel/);
   });
 
   it('never mutates the base config object', () => {
@@ -36,6 +95,14 @@ describe('desktopBuilderConfig', () => {
     const config = desktopBuilderConfig({ base, distribution: 'steam' });
     expect(config.extraMetadata.wocDesktop).toEqual({ distribution: 'steam' });
     expect(config.publish).toBeNull();
+    // The update-track split never touches Steam: publish stays nulled and a
+    // dev origin does not trip the production-channel guard.
+    const devSteam = desktopBuilderConfig({
+      base,
+      distribution: 'steam',
+      apiOrigin: 'http://localhost:8787',
+    });
+    expect(devSteam.publish).toBeNull();
     expect(config.directories.output).toBe('release-steam');
     expect(config.mac.target).toEqual([{ target: 'dir', arch: ['universal'] }]);
     expect(config.win.target).toEqual([{ target: 'dir', arch: ['x64'] }]);
@@ -97,6 +164,102 @@ describe('desktopBuilderConfig', () => {
     expect(() => desktopBuilderConfig({ base, distribution: 'beta' })).toThrow(
       /unknown desktop distribution/,
     );
+  });
+});
+
+describe('isChannelFeedFile', () => {
+  it('matches only the channel feed files electron-builder emits', () => {
+    expect(isChannelFeedFile('latest-mac.yml', 'latest')).toBe(true);
+    expect(isChannelFeedFile('latest.yml', 'latest')).toBe(true);
+    expect(isChannelFeedFile('latest-linux.yml', 'latest')).toBe(true);
+    expect(isChannelFeedFile('latest-linux-arm64.yml', 'latest')).toBe(true);
+    expect(isChannelFeedFile('dev-mac.yml', 'dev')).toBe(true);
+    expect(isChannelFeedFile('dev.yml', 'dev')).toBe(true);
+  });
+
+  it('never matches the other channel, non-feed ymls, or garbage', () => {
+    expect(isChannelFeedFile('dev-mac.yml', 'latest')).toBe(false);
+    expect(isChannelFeedFile('latest-mac.yml', 'dev')).toBe(false);
+    expect(isChannelFeedFile('builder-debug.yml', 'latest')).toBe(false);
+    expect(isChannelFeedFile('latest-mac.yml.bak', 'latest')).toBe(false);
+    expect(isChannelFeedFile('latest-mac.json', 'latest')).toBe(false);
+    expect(isChannelFeedFile('latest-mac.yml', '')).toBe(false);
+    expect(isChannelFeedFile('latest-mac.yml', 'beta')).toBe(false);
+    expect(isChannelFeedFile(undefined, 'latest')).toBe(false);
+  });
+});
+
+describe('stampFeedFile', () => {
+  const yml = 'version: 0.23.0\nfiles:\n  - url: woc.zip\npath: woc.zip\n';
+
+  it('appends the baked origin as a yml key the updater can read back', () => {
+    const stamped = stampFeedFile(yml, 'https://worldofclaudecraft.com');
+    expect(stamped).toBe(
+      'version: 0.23.0\nfiles:\n  - url: woc.zip\npath: woc.zip\n' +
+        'wocApiOrigin: "https://worldofclaudecraft.com"\n',
+    );
+  });
+
+  it('replaces an existing stamp instead of stacking (idempotent re-stamp)', () => {
+    const once = stampFeedFile(yml, 'http://localhost:8787');
+    const twice = stampFeedFile(once, 'https://worldofclaudecraft.com');
+    expect(twice.match(/wocApiOrigin/g)).toHaveLength(1);
+    expect(twice).toContain('wocApiOrigin: "https://worldofclaudecraft.com"');
+    expect(twice).not.toContain('localhost');
+  });
+
+  it('requires the origin: a stamp-less production feed must not be emitted silently', () => {
+    expect(() => stampFeedFile(yml, '')).toThrow(/apiOrigin/);
+  });
+});
+
+describe('stampChannelFeedFiles (the electron-build.mjs stamping orchestration)', () => {
+  const fsOps = { existsSync, readdirSync, readFileSync, writeFileSync };
+  const seed = (dir: string, names: string[]) => {
+    for (const name of names) writeFileSync(join(dir, name), 'version: 0.23.0\n');
+  };
+
+  it('stamps exactly the channel feed files in the output dir, nothing else', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'woc-feed-'));
+    seed(dir, ['latest-mac.yml', 'latest.yml', 'dev-mac.yml', 'builder-debug.yml']);
+    const stamped = stampChannelFeedFiles({
+      outDir: dir,
+      channel: 'latest',
+      apiOrigin: 'https://worldofclaudecraft.com',
+      fs: fsOps,
+      joinPath: join,
+    });
+    expect([...stamped].sort()).toEqual(['latest-mac.yml', 'latest.yml']);
+    expect(readFileSync(join(dir, 'latest-mac.yml'), 'utf8')).toContain(
+      'wocApiOrigin: "https://worldofclaudecraft.com"',
+    );
+    expect(readFileSync(join(dir, 'latest.yml'), 'utf8')).toContain('wocApiOrigin');
+    expect(readFileSync(join(dir, 'dev-mac.yml'), 'utf8')).not.toContain('wocApiOrigin');
+    expect(readFileSync(join(dir, 'builder-debug.yml'), 'utf8')).not.toContain('wocApiOrigin');
+  });
+
+  it('is a no-op without a channel or an output dir (steam and pack builds)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'woc-feed-'));
+    seed(dir, ['latest-mac.yml']);
+    expect(
+      stampChannelFeedFiles({
+        outDir: dir,
+        channel: undefined,
+        apiOrigin: 'https://worldofclaudecraft.com',
+        fs: fsOps,
+        joinPath: join,
+      }),
+    ).toEqual([]);
+    expect(readFileSync(join(dir, 'latest-mac.yml'), 'utf8')).not.toContain('wocApiOrigin');
+    expect(
+      stampChannelFeedFiles({
+        outDir: join(dir, 'does-not-exist'),
+        channel: 'latest',
+        apiOrigin: 'https://worldofclaudecraft.com',
+        fs: fsOps,
+        joinPath: join,
+      }),
+    ).toEqual([]);
   });
 });
 

--- a/tests/electron_builder_config.test.ts
+++ b/tests/electron_builder_config.test.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -82,6 +83,38 @@ describe('desktopBuilderConfig', () => {
         updateChannel: 'beta',
       }),
     ).toThrow(/unknown desktop update channel/);
+  });
+
+  it('treats a set-but-empty WOC_UPDATE_CHANNEL as unset and derives from the origin', () => {
+    const prod = desktopBuilderConfig({
+      base,
+      distribution: 'website',
+      apiOrigin: prodOrigin,
+      updateChannel: '',
+    });
+    expect(prod.publish?.channel).toBe('latest');
+    const dev = desktopBuilderConfig({
+      base,
+      distribution: 'website',
+      apiOrigin: 'http://localhost:8787',
+      updateChannel: '',
+    });
+    expect(dev.publish?.channel).toBe('dev');
+  });
+
+  it('rejects an unparseable non-empty origin at build time (would strand the install)', () => {
+    // A schemeless origin derives the dev channel at build time but normalizes
+    // to production in the runtime guard, refusing every stamped update on its
+    // own track forever; that mistake must die here.
+    for (const apiOrigin of ['localhost:8787', 'worldofclaudecraft.com', 'not a url']) {
+      expect(() => desktopBuilderConfig({ base, distribution: 'website', apiOrigin })).toThrow(
+        /parseable http\(s\) VITE_DESKTOP_API_ORIGIN/,
+      );
+    }
+    // Steam builds publish nothing, so the same origin does not throw there.
+    expect(
+      desktopBuilderConfig({ base, distribution: 'steam', apiOrigin: 'localhost:8787' }).publish,
+    ).toBeNull();
   });
 
   it('never mutates the base config object', () => {
@@ -210,6 +243,24 @@ describe('stampFeedFile', () => {
 
   it('requires the origin: a stamp-less production feed must not be emitted silently', () => {
     expect(() => stampFeedFile(yml, '')).toThrow(/apiOrigin/);
+  });
+
+  it('round-trips through the real electron-updater feed parser onto UpdateInfo', () => {
+    // Guards the load-bearing vendor assumption: parseUpdateInfo is a raw yaml
+    // load with no key whitelist, so the stamp reaches the update-available
+    // handler. If a future electron-updater upgrade starts stripping unknown
+    // keys, the runtime guard silently degrades to accept-everything and THIS
+    // test is the only signal.
+    const require = createRequire(import.meta.url);
+    const { parseUpdateInfo } = require('electron-updater/out/providers/Provider.js');
+    const info = parseUpdateInfo(
+      stampFeedFile(yml, 'https://worldofclaudecraft.com'),
+      'latest-mac.yml',
+      'https://updates.example.com/desktop/latest-mac.yml',
+    );
+    expect(info.wocApiOrigin).toBe('https://worldofclaudecraft.com');
+    expect(info.version).toBe('0.23.0');
+    expect(info.path).toBe('woc.zip');
   });
 });
 

--- a/tests/electron_desktop_config.test.ts
+++ b/tests/electron_desktop_config.test.ts
@@ -195,6 +195,7 @@ describe('resolveDesktopConfig', () => {
       distribution: 'website',
       updaterEnabled: true,
       crashSubmitUrl: '',
+      updateChannel: 'latest',
       ...defaultOrigins,
     });
   });
@@ -205,6 +206,7 @@ describe('resolveDesktopConfig', () => {
       distribution: 'steam',
       updaterEnabled: false,
       crashSubmitUrl: '',
+      updateChannel: 'latest',
       ...defaultOrigins,
     });
   });
@@ -215,7 +217,35 @@ describe('resolveDesktopConfig', () => {
       distribution: 'website',
       updaterEnabled: false,
       crashSubmitUrl: '',
+      updateChannel: 'latest',
       ...defaultOrigins,
     });
+  });
+
+  it('derives the update channel from the baked origin: non-production reads the dev feed', () => {
+    const dev = resolveDesktopConfig({
+      packagedMetadata: {
+        wocDesktop: { distribution: 'website', apiOrigin: 'https://dev.worldofclaudecraft.com' },
+      },
+      isPackaged: true,
+    });
+    expect(dev.updateChannel).toBe('dev');
+    expect(dev.updaterEnabled).toBe(true);
+    const smoke = resolveDesktopConfig({
+      packagedMetadata: {
+        wocDesktop: { distribution: 'website', apiOrigin: 'http://localhost:8787' },
+      },
+      isPackaged: true,
+    });
+    expect(smoke.updateChannel).toBe('dev');
+    // No env hatch: a packaged build's channel follows its baked origin only.
+    const forced = resolveDesktopConfig({
+      packagedMetadata: {
+        wocDesktop: { distribution: 'website', apiOrigin: 'https://dev.worldofclaudecraft.com' },
+      },
+      env: { VITE_DESKTOP_API_ORIGIN: 'https://worldofclaudecraft.com' },
+      isPackaged: true,
+    });
+    expect(forced.updateChannel).toBe('dev');
   });
 });

--- a/tests/electron_update_guard.test.ts
+++ b/tests/electron_update_guard.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import {
+  apiOriginKey,
+  evaluateUpdateOffer,
+  isProductionApiOrigin,
+  PRODUCTION_API_ORIGIN,
+  updateChannelForOrigin,
+} from '../electron/update_guard.cjs';
+
+// The prod/dev update-track split (desktop auto-update). One origin rule is
+// shared by the build (scripts/electron-builder-config.mjs decides which feed
+// files a build emits) and the runtime (electron/desktop_config.cjs decides
+// which feed a build reads; electron/updater.cjs refuses cross-origin
+// artifacts), so these pins protect both sides at once.
+
+describe('PRODUCTION_API_ORIGIN', () => {
+  it('is the production site', () => {
+    expect(PRODUCTION_API_ORIGIN).toBe('https://worldofclaudecraft.com');
+  });
+});
+
+describe('apiOriginKey', () => {
+  it('normalizes equivalent spellings to one origin', () => {
+    expect(apiOriginKey('https://worldofclaudecraft.com')).toBe('https://worldofclaudecraft.com');
+    expect(apiOriginKey('https://worldofclaudecraft.com/')).toBe('https://worldofclaudecraft.com');
+    expect(apiOriginKey('HTTPS://WorldOfClaudeCraft.COM')).toBe('https://worldofclaudecraft.com');
+    expect(apiOriginKey('http://localhost:8787')).toBe('http://localhost:8787');
+  });
+
+  it('returns null for garbage, empty, non-string, and non-http values', () => {
+    expect(apiOriginKey('')).toBeNull();
+    expect(apiOriginKey('worldofclaudecraft.com')).toBeNull();
+    expect(apiOriginKey('not a url')).toBeNull();
+    expect(apiOriginKey(42)).toBeNull();
+    expect(apiOriginKey(undefined)).toBeNull();
+    expect(apiOriginKey('ftp://worldofclaudecraft.com')).toBeNull();
+  });
+});
+
+describe('isProductionApiOrigin', () => {
+  it('accepts only the production origin (slash and case tolerant)', () => {
+    expect(isProductionApiOrigin('https://worldofclaudecraft.com')).toBe(true);
+    expect(isProductionApiOrigin('https://worldofclaudecraft.com/')).toBe(true);
+  });
+
+  it('rejects dev, staging, localhost, http, subdomains, and garbage', () => {
+    expect(isProductionApiOrigin('https://dev.worldofclaudecraft.com')).toBe(false);
+    expect(isProductionApiOrigin('http://worldofclaudecraft.com')).toBe(false);
+    expect(isProductionApiOrigin('http://localhost:8787')).toBe(false);
+    expect(isProductionApiOrigin('https://worldofclaudecraft.com.evil.example')).toBe(false);
+    expect(isProductionApiOrigin('')).toBe(false);
+    expect(isProductionApiOrigin(undefined)).toBe(false);
+  });
+});
+
+describe('updateChannelForOrigin (the track split)', () => {
+  it('production origin publishes and reads the latest channel', () => {
+    expect(updateChannelForOrigin('https://worldofclaudecraft.com')).toBe('latest');
+    expect(updateChannelForOrigin('https://worldofclaudecraft.com/')).toBe('latest');
+  });
+
+  it('every non-production origin fails safe onto the dev channel', () => {
+    expect(updateChannelForOrigin('https://dev.worldofclaudecraft.com')).toBe('dev');
+    expect(updateChannelForOrigin('http://localhost:8787')).toBe('dev');
+    expect(updateChannelForOrigin('')).toBe('dev');
+    expect(updateChannelForOrigin('garbage')).toBe('dev');
+    expect(updateChannelForOrigin(undefined)).toBe('dev');
+  });
+});
+
+describe('evaluateUpdateOffer (the runtime cross-track refusal)', () => {
+  const own = 'https://worldofclaudecraft.com';
+
+  it('accepts an offer stamped with the same origin, slash tolerant', () => {
+    expect(
+      evaluateUpdateOffer({ apiOrigin: own, info: { version: '0.23.0', wocApiOrigin: own } }),
+    ).toEqual({ ok: true, stamped: true });
+    expect(
+      evaluateUpdateOffer({
+        apiOrigin: own,
+        info: { wocApiOrigin: 'https://worldofclaudecraft.com/' },
+      }),
+    ).toEqual({ ok: true, stamped: true });
+  });
+
+  it('accepts a pre-split feed file with no stamp (back compat), flagged unstamped', () => {
+    expect(evaluateUpdateOffer({ apiOrigin: own, info: { version: '0.23.0' } })).toEqual({
+      ok: true,
+      stamped: false,
+    });
+    expect(evaluateUpdateOffer({ apiOrigin: own, info: { wocApiOrigin: '' } })).toEqual({
+      ok: true,
+      stamped: false,
+    });
+    // A valueless `wocApiOrigin:` yml line parses to null; same back-compat arm.
+    expect(evaluateUpdateOffer({ apiOrigin: own, info: { wocApiOrigin: null } })).toEqual({
+      ok: true,
+      stamped: false,
+    });
+    expect(evaluateUpdateOffer({ apiOrigin: own })).toEqual({ ok: true, stamped: false });
+  });
+
+  it('refuses an offer baked for another backend (the issue 1537 flip)', () => {
+    const verdict = evaluateUpdateOffer({
+      apiOrigin: own,
+      info: { version: '0.23.0', wocApiOrigin: 'https://dev.worldofclaudecraft.com' },
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.offeredOrigin).toBe('https://dev.worldofclaudecraft.com');
+    expect(verdict.expectedOrigin).toBe(own);
+  });
+
+  it('refuses a localhost smoke-test artifact offered to a production install', () => {
+    expect(
+      evaluateUpdateOffer({ apiOrigin: own, info: { wocApiOrigin: 'http://localhost:8787' } }).ok,
+    ).toBe(false);
+  });
+
+  it('refuses rather than guesses when either side is unverifiable', () => {
+    // Present-but-garbage stamp: suspicious artifact, never install it.
+    expect(evaluateUpdateOffer({ apiOrigin: own, info: { wocApiOrigin: 'garbage' } }).ok).toBe(
+      false,
+    );
+    const numeric = evaluateUpdateOffer({ apiOrigin: own, info: { wocApiOrigin: 42 } });
+    expect(numeric.ok).toBe(false);
+    expect(numeric.offeredOrigin).toBe('42');
+    // Own origin unverifiable: cannot prove the offer matches, so refuse.
+    expect(evaluateUpdateOffer({ apiOrigin: 'garbage', info: { wocApiOrigin: own } }).ok).toBe(
+      false,
+    );
+  });
+
+  it('a dev install accepts its own dev-track artifact', () => {
+    expect(
+      evaluateUpdateOffer({
+        apiOrigin: 'https://dev.worldofclaudecraft.com',
+        info: { wocApiOrigin: 'https://dev.worldofclaudecraft.com' },
+      }),
+    ).toEqual({ ok: true, stamped: true });
+  });
+});

--- a/tests/electron_updater_track.test.ts
+++ b/tests/electron_updater_track.test.ts
@@ -147,9 +147,11 @@ describe('main.cjs updater wiring pin', () => {
   it('passes apiOrigin and the resolved updateChannel into initUpdater', () => {
     // main.cjs is the electron entry and cannot run under vitest, so pin the
     // wiring textually: dropping either argument would silently break the
-    // origin guard (undefined own origin refuses every stamped update).
+    // origin guard (undefined own origin refuses every stamped update). The
+    // match runs to the call's own `});` closer (a nested `})` mid-args, e.g.
+    // an arrow body, cannot end it), so growing the arg list stays matched.
     const source = readFileSync(new URL('../electron/main.cjs', import.meta.url), 'utf8');
-    const call = source.match(/initUpdater\(\{[\s\S]*?\}\)/)?.[0] ?? '';
+    const call = source.match(/initUpdater\(\{[\s\S]*?\n\s*\}\);/)?.[0] ?? '';
     expect(call).toContain('apiOrigin');
     expect(call).toContain('updateChannel: desktopConfig.updateChannel');
   });

--- a/tests/electron_updater_track.test.ts
+++ b/tests/electron_updater_track.test.ts
@@ -1,0 +1,156 @@
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initUpdater } from '../electron/updater.cjs';
+
+// Behavioral pins for the updater's track wiring (issue 1537: a production
+// install must never download an update baked for another API backend). Uses
+// initUpdater's injected-autoUpdater test seam; everything else the module
+// touches is a plain fake, so this runs in Node with no electron.
+
+const PROD = 'https://worldofclaudecraft.com';
+const DEV = 'https://dev.worldofclaudecraft.com';
+
+type Handler = (info: unknown) => void;
+
+function makeFakeAutoUpdater() {
+  const handlers = new Map<string, Handler>();
+  return {
+    logger: null as unknown,
+    autoDownload: true,
+    autoInstallOnAppQuit: false,
+    allowDowngrade: undefined as boolean | undefined,
+    channelSets: [] as string[],
+    _channel: undefined as string | undefined,
+    // Mirror the real electron-updater trap: assigning channel silently
+    // re-enables downgrades, which initUpdater must undo.
+    set channel(value: string) {
+      this._channel = value;
+      this.channelSets.push(value);
+      this.allowDowngrade = true;
+    },
+    get channel(): string | undefined {
+      return this._channel;
+    },
+    on(event: string, handler: Handler) {
+      handlers.set(event, handler);
+      return this;
+    },
+    emit(event: string, info: unknown) {
+      handlers.get(event)?.(info);
+    },
+    checkForUpdates: vi.fn(() => Promise.resolve(null)),
+    downloadUpdate: vi.fn(() => Promise.resolve([])),
+    quitAndInstall: vi.fn(),
+  };
+}
+
+function makeDeps(autoUpdater: ReturnType<typeof makeFakeAutoUpdater>, apiOrigin: string) {
+  const sent: unknown[] = [];
+  const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  const win = {
+    isDestroyed: () => false,
+    webContents: {
+      isDestroyed: () => false,
+      send: (_channel: string, payload: unknown) => sent.push(payload),
+    },
+  };
+  const deps = {
+    ipcMain: { handle: vi.fn() },
+    log,
+    getWindow: () => win,
+    isTrusted: () => true,
+    isPackaged: true,
+    apiOrigin,
+    updateChannel: 'latest',
+    autoUpdater,
+  };
+  return { deps, sent, log };
+}
+
+describe('initUpdater track wiring', () => {
+  beforeEach(() => {
+    // initUpdater arms process-lifetime check timers; keep them inert.
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reads its own-origin channel and undoes the channel-setter downgrade flip', () => {
+    const fake = makeFakeAutoUpdater();
+    const { deps } = makeDeps(fake, PROD);
+    expect(initUpdater(deps)).toBe(fake);
+    expect(fake.channelSets).toEqual(['latest']);
+    // The real setter flips allowDowngrade to true; initUpdater must reset it.
+    expect(fake.allowDowngrade).toBe(false);
+    // Downloads wait for the origin guard; installs still apply on quit.
+    expect(fake.autoDownload).toBe(false);
+    expect(fake.autoInstallOnAppQuit).toBe(true);
+  });
+
+  it('downloads and toasts a matching-origin update', () => {
+    const fake = makeFakeAutoUpdater();
+    const { deps, sent } = makeDeps(fake, PROD);
+    initUpdater(deps);
+    fake.emit('update-available', { version: '0.23.0', wocApiOrigin: PROD });
+    expect(fake.downloadUpdate).toHaveBeenCalledTimes(1);
+    expect(sent).toEqual([{ type: 'available', version: '0.23.0' }]);
+  });
+
+  it('accepts a pre-split feed file with no origin stamp', () => {
+    const fake = makeFakeAutoUpdater();
+    const { deps, sent } = makeDeps(fake, PROD);
+    initUpdater(deps);
+    fake.emit('update-available', { version: '0.23.0' });
+    expect(fake.downloadUpdate).toHaveBeenCalledTimes(1);
+    expect(sent).toEqual([{ type: 'available', version: '0.23.0' }]);
+  });
+
+  it('REFUSES a cross-origin update: no download, no toast, loud log', () => {
+    const fake = makeFakeAutoUpdater();
+    const { deps, sent, log } = makeDeps(fake, PROD);
+    initUpdater(deps);
+    fake.emit('update-available', { version: '0.23.1', wocApiOrigin: DEV });
+    expect(fake.downloadUpdate).not.toHaveBeenCalled();
+    expect(sent).toEqual([]);
+    expect(log.error).toHaveBeenCalledTimes(1);
+    const [message, detail] = log.error.mock.calls[0] as [string, Record<string, unknown>];
+    expect(message).toContain('REFUSED');
+    expect(detail).toMatchObject({
+      version: '0.23.1',
+      offeredOrigin: DEV,
+      expectedOrigin: PROD,
+    });
+  });
+
+  it('leaves the channel untouched when none is resolved (legacy default feed)', () => {
+    const fake = makeFakeAutoUpdater();
+    const { deps } = makeDeps(fake, PROD);
+    initUpdater({ ...deps, updateChannel: undefined });
+    expect(fake.channelSets).toEqual([]);
+  });
+
+  it('logs and survives a failed download (no unhandled rejection)', async () => {
+    const fake = makeFakeAutoUpdater();
+    fake.downloadUpdate = vi.fn(() => Promise.reject(new Error('feed host down')));
+    const { deps, log } = makeDeps(fake, PROD);
+    initUpdater(deps);
+    fake.emit('update-available', { version: '0.23.0', wocApiOrigin: PROD });
+    // Let the rejected downloadUpdate() promise settle through its .catch.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(log.warn).toHaveBeenCalledWith('[updater] download failed', 'feed host down');
+  });
+});
+
+describe('main.cjs updater wiring pin', () => {
+  it('passes apiOrigin and the resolved updateChannel into initUpdater', () => {
+    // main.cjs is the electron entry and cannot run under vitest, so pin the
+    // wiring textually: dropping either argument would silently break the
+    // origin guard (undefined own origin refuses every stamped update).
+    const source = readFileSync(new URL('../electron/main.cjs', import.meta.url), 'utf8');
+    const call = source.match(/initUpdater\(\{[\s\S]*?\}\)/)?.[0] ?? '';
+    expect(call).toContain('apiOrigin');
+    expect(call).toContain('updateChannel: desktopConfig.updateChannel');
+  });
+});


### PR DESCRIPTION
## Summary

A production macOS install auto-updated onto a build that talks to the dev API (#1537). Root cause: every website desktop build shared one undifferentiated `latest` update feed, and the API origin baked into each artifact rode along unchecked, so any dev/staging artifact that reached the feed became "the latest version" for every production install.

This PR separates the update tracks and adds defense in depth, in three layers:

1. **Track split at build time.** The electron-builder publish channel is now derived from the baked `apiOrigin` by one rule shared between build and runtime (`electron/update_guard.cjs`): the production origin publishes and reads the `latest` channel (`latest-mac.yml` and friends, the feed shipped installs already read), and ANY other origin (dev, staging, localhost smoke packs) publishes and reads a `dev` channel (`dev-mac.yml` and friends), which production installs never request. Requesting the production channel with a non-production origin makes the build throw (the CI/build-time guard from the issue's acceptance criteria). `WOC_UPDATE_CHANNEL=dev` remains as the one supported cross: staging a production-origin artifact on the dev track for update-pipeline testing.
2. **Origin stamp in the feed files.** `scripts/electron-build.mjs` stamps `wocApiOrigin` into every emitted feed yml. electron-updater hands the parsed yml through as the `UpdateInfo` object, so the stamp reaches the running app.
3. **Runtime refusal.** `electron/updater.cjs` now sets its update channel from its own baked origin (so even a build packaged with a wrong `app-update.yml` stays on its origin's track), turns `autoDownload` off, and only downloads after the offer passes the origin guard: an update whose `wocApiOrigin` stamp differs from the install's own origin is refused with a loud `[updater] REFUSED` entry in `main.log`, so even a feed file hand-renamed onto the wrong track cannot flip a shipped app to another backend. Feed files published before the split carry no stamp and are accepted (back compat with the current production feed). The change also undoes a hidden electron-updater trap: assigning `channel` silently flips `allowDowngrade` to `true`; we reset it so a production install can never move backward.

Steam builds are untouched: publish stays nulled, no feed files are emitted, and the in-app updater stays off (pinned by the existing and new tests).

Recovery note for currently flipped installs: an install that already took a dev-origin artifact still reads `latest-*.yml` from the production feed (its baked publish config is unchanged), so publishing the next higher production version brings those players back to production automatically, per the runbook's forward-only rollback model.

The startup banner now logs `updateChannel` next to `updaterEnabled`, and `docs/desktop-release.md` / `docs/desktop-ship-notes.md` document the track model, the guard, and the "never rename dev feed files" rule.

## Related issues

Closes #1537.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests
- [x] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/electron_update_guard.test.ts tests/electron_updater_track.test.ts tests/electron_builder_config.test.ts tests/electron_desktop_config.test.ts tests/electron_update_cadence.test.ts tests/electron_update_events.test.ts tests/electron_vendor_loading.test.ts` (all green; the two new suites cover the origin rule, the accept/refuse matrix, the build-time guard throw, feed-file stamping idempotence, and the updater wiring incl. the `allowDowngrade` reset, via `initUpdater`'s injected-autoUpdater test seam)
  - `npx tsc --noEmit` clean; changed files pass `biome check`
  - `npm run electron:pack` end to end: electron-builder accepts the derived config with `publish.channel`, and the packaged app carries the expected stamp
  - Verified against the vendored electron-updater/electron-builder sources that `publish.channel` names the emitted feed files (`updateInfoBuilder.js`), that `autoUpdater.channel` selects the requested feed at runtime (`GenericProvider.js`), and that extra yml keys survive `parseUpdateInfo` onto `UpdateInfo`
- Manual steps:
  - Simulated the issue's scenario at the unit level: a production install offered an update stamped `https://dev.worldofclaudecraft.com` (or `http://localhost:8787`) refuses to download, sends no toast, and logs the offered vs expected origins; the same offer stamped with the production origin downloads and toasts as before
  - Confirmed a pre-split feed file (no stamp, like the current production `latest-mac.yml`) is still accepted, so already-shipped installs keep updating

## Checklist

### Quality

- [x] **Tests pass.** Targeted suites green (full `npm test` runs in CI). I added or updated tests for the behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build` runs as part of `npm run electron:pack`, verified end to end.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: Electron main process, build scripts, tests, and docs only; no UI change.
- ~Accessible.~ N/A: no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (updater refusals are dev-channel `main.log` lines by design, matching the existing updater logging convention; the player-facing update toast is unchanged).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
