### PR TITLE
feat(mobile): collapsible consumables quick bar on the touch HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -1291,6 +1291,21 @@
       <button type="button" id="mobile-jump" data-i18n-title="hud.keybinds.actions.jump" data-i18n-aria="hud.keybinds.actions.jump" title="Jump" aria-label="Jump" data-icon="jump"><span class="mobile-label" data-i18n="hudChrome.mobile.jump">Jump</span></button>
       <button type="button" id="mobile-action-page-toggle" data-i18n-aria="hudChrome.mobile.actionPageToggle" aria-label="Switch action page" data-icon="swap"><span class="mobile-action-page-indicator"></span></button>
     </div>
+    <!-- Consumables quick bar: a slim chevron chip right of the Chat/Social/More
+         trio; tapping it expands a row of the carried potions/elixirs/food/drink
+         (auto-populated, no setup) so touch players can quaff mid-fight without
+         the More > Bags full-screen detour. Collapsed by default, session-only. -->
+    <div id="mobile-consumables" role="group" data-i18n-aria="hudChrome.bags.filterConsumable" aria-label="Consumables">
+      <button type="button" id="mobile-consumables-toggle" data-i18n-title="hudChrome.bags.filterConsumable" data-i18n-aria="hudChrome.bags.filterConsumable" title="Consumables" aria-label="Consumables" aria-expanded="false" data-icon="next"></button>
+      <div id="mobile-consumables-row">
+        <button class="mobile-consumable-slot" type="button" data-consumable-index="0"></button>
+        <button class="mobile-consumable-slot" type="button" data-consumable-index="1"></button>
+        <button class="mobile-consumable-slot" type="button" data-consumable-index="2"></button>
+        <button class="mobile-consumable-slot" type="button" data-consumable-index="3"></button>
+        <button class="mobile-consumable-slot" type="button" data-consumable-index="4"></button>
+        <button class="mobile-consumable-slot" type="button" data-consumable-index="5"></button>
+      </div>
+    </div>
       <div id="mobile-extra-controls" class="window panel" role="dialog" aria-modal="true" aria-labelledby="mobile-more-title">
         <div class="panel-title">
           <span id="mobile-more-title" data-i18n="hud.core.mobileMore">More</span>

--- a/play.html
+++ b/play.html
@@ -970,6 +970,21 @@
       <button type="button" id="mobile-jump" data-i18n-title="hud.keybinds.actions.jump" data-i18n-aria="hud.keybinds.actions.jump" title="Jump" aria-label="Jump" data-icon="jump"><span class="mobile-label" data-i18n="hudChrome.mobile.jump">Jump</span></button>
       <button type="button" id="mobile-action-page-toggle" data-i18n-aria="hudChrome.mobile.actionPageToggle" aria-label="Switch action page" data-icon="swap"><span class="mobile-action-page-indicator"></span></button>
     </div>
+    <!-- Consumables quick bar: a slim chevron chip right of the Chat/Social/More
+         trio; tapping it expands a row of the carried potions/elixirs/food/drink
+         (auto-populated, no setup) so touch players can quaff mid-fight without
+         the More > Bags full-screen detour. Collapsed by default, session-only. -->
+    <div id="mobile-consumables" role="group" data-i18n-aria="hudChrome.bags.filterConsumable" aria-label="Consumables">
+      <button type="button" id="mobile-consumables-toggle" data-i18n-title="hudChrome.bags.filterConsumable" data-i18n-aria="hudChrome.bags.filterConsumable" title="Consumables" aria-label="Consumables" aria-expanded="false" data-icon="next"></button>
+      <div id="mobile-consumables-row">
+        <button class="mobile-consumable-slot" type="button" data-consumable-index="0"></button>
+        <button class="mobile-consumable-slot" type="button" data-consumable-index="1"></button>
+        <button class="mobile-consumable-slot" type="button" data-consumable-index="2"></button>
+        <button class="mobile-consumable-slot" type="button" data-consumable-index="3"></button>
+        <button class="mobile-consumable-slot" type="button" data-consumable-index="4"></button>
+        <button class="mobile-consumable-slot" type="button" data-consumable-index="5"></button>
+      </div>
+    </div>
       <div id="mobile-extra-controls" class="window panel" role="dialog" aria-modal="true" aria-labelledby="mobile-more-title">
         <div class="panel-title">
           <span id="mobile-more-title" data-i18n="hud.core.mobileMore">More</span>

--- a/scripts/mobile_cluster_layout_check.mjs
+++ b/scripts/mobile_cluster_layout_check.mjs
@@ -39,6 +39,9 @@ const CONTROL_IDS = [
   'mobile-chat',
   'mobile-social',
   'mobile-more',
+  // The consumables quick bar's always-visible chevron chip; the row it
+  // expands is display:none by default, so its slots are not measurable here.
+  'mobile-consumables-toggle',
 ];
 const NEIGHBOR_IDS = ['minimap-wrap', 'side-buttons'];
 const TOUCH_FLOOR = 40;
@@ -336,7 +339,9 @@ try {
   // 1.3 max, what applySetting writes for joystickScale / actionButtonScale):
   // at max the grown joystick must not slide under the cluster; at min the
   // cluster's floored offset must keep every button clear of the FIXED
-  // #mobile-move-zone capture area, or a movement thumb would trigger Jump.
+  // #mobile-move-zone capture area, or a movement thumb would trigger Autorun
+  // (Jump moved to the ring's bottom-right, so Autorun is the one satellite
+  // still seated by the joystick).
   for (const joyScale of ['0.7', '1.3']) {
     await page.evaluate((v) => {
       const c = document.getElementById('mobile-controls');
@@ -346,7 +351,7 @@ try {
     await sleep(300);
     const ext = await collectRects(page);
     if (ext.moveZone) {
-      for (const id of ['mobile-jump', 'mobile-autorun']) {
+      for (const id of ['mobile-autorun']) {
         const r = ext.controls[id];
         if (r && edgeGap(r, ext.moveZone) < 0) {
           fail(`joy-scale ${joyScale}: #${id} overlaps the move capture zone`);
@@ -368,7 +373,7 @@ try {
     // corner-to-corner with the pad, so bounding boxes overlap by design
     // while the circles keep a positive gap (same rationale as CIRCLE_IDS).
     const joyCircle = circleOf({ ...joy, w: joy.right - joy.left, h: joy.bottom - joy.top });
-    for (const id of ['mobile-jump', 'mobile-autorun']) {
+    for (const id of ['mobile-autorun']) {
       const r = sc.controls[id];
       if (!r) continue;
       const c = circleOf(r);

--- a/src/game/touch_router.ts
+++ b/src/game/touch_router.ts
@@ -92,6 +92,7 @@ const INTERACTIVE_HUD_SELECTORS = [
   '.action-btn',
   '.mobile-action-slot',
   '#mobile-action-ring',
+  '#mobile-consumables',
   '.window',
   '.panel',
   '#minimap-wrap',

--- a/src/styles/hud.mobile.css
+++ b/src/styles/hud.mobile.css
@@ -843,6 +843,162 @@
       transition: opacity 0.12s ease;
     }
   }
+  /* Consumables quick bar: a quiet chevron chip docked right of the top-left
+     trio that expands a row of the carried potions/elixirs/food/drink
+     (auto-populated by consumable_bar_view.ts, painted by the shared action
+     bar painter, so the cd-overlay/count/state classes below mirror the
+     ring's). Collapsed by default and session-only: the row shows only under
+     body.mobile-consumables-open, and empty slots collapse away so the open
+     row is exactly as wide as what the player carries. The left anchor adds
+     the trio's SCALED width (3 columns + 2 gaps) to the trio's own safe-area
+     anchor so a grown --btn-scale never slides the trio under the chip. */
+  body.mobile-touch #mobile-consumables {
+    position: absolute;
+    left: calc(max(12px, env(safe-area-inset-left)) + 198px * var(--btn-scale, 1) + 10px);
+    top: max(8px, env(safe-area-inset-top));
+    /* Right reservation sized for the WORST-CASE visual overhang: flex-wrap
+       decides on the untransformed layout width, but the container then scales
+       by --btn-scale (max 1.3) from left top, so the painted row extends past
+       its layout edge by (scale - 1) x row width. 260px keeps the scaled row
+       clear of everything in #ui above it (buff column at right 98px+, the
+       daily-chest rail, the minimap corner): on an 844px landscape phone,
+       (844 - 260 - left(1.3)) x 1.3 + left(1.3) = 684 = the buff column edge. */
+    right: calc(260px + env(safe-area-inset-right));
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    /* The container spans the top band; only its BUTTONS take touches, so an
+       empty stretch stays camera-draggable (touch_router matches the target's
+       closest #mobile-consumables, which pointer-events: none prevents). */
+    pointer-events: none;
+    transform: scale(var(--btn-scale, 1));
+    transform-origin: left top;
+    z-index: 30;
+  }
+  body.mobile-touch #mobile-consumables-toggle {
+    width: 40px;
+    height: 54px;
+    padding: 0;
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+    pointer-events: auto;
+    border: 1px solid var(--mobile-glass-border, #cba43d8c);
+    border-radius: 12px;
+    background: var(--mobile-glass-bg, linear-gradient(160deg, #23212de3, #0e0d10eb));
+    -webkit-backdrop-filter: blur(var(--mobile-glass-blur, 8px));
+    backdrop-filter: blur(var(--mobile-glass-blur, 8px));
+    color: #d8b98a;
+    cursor: var(--cursor-point);
+    opacity: 0.85;
+    box-shadow:
+      inset 0 1px 0 #ffffff14,
+      0 2px 8px #0009;
+  }
+  body.mobile-touch #mobile-consumables-toggle .ui-icon {
+    width: 14px;
+    height: 14px;
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    body.mobile-touch #mobile-consumables-toggle .ui-icon {
+      transition: transform 0.12s ease;
+    }
+  }
+  body.mobile-touch.mobile-consumables-open #mobile-consumables-toggle {
+    opacity: 1;
+    border-color: var(--gold-dim);
+    color: #ffdf9c;
+  }
+  body.mobile-touch.mobile-consumables-open #mobile-consumables-toggle .ui-icon {
+    transform: rotate(90deg);
+  }
+  /* The open row drops BELOW the chip line rather than extending along the top
+     band: the top-centre band belongs to the pet bar (pet classes) and #ui
+     (z 80) paints ABOVE #mobile-controls (z 60), so a row up there would sit
+     UNDER the pet command buttons, which would steal its taps. Below the
+     chrome line the band is open world; a crowded row wraps further down. */
+  body.mobile-touch #mobile-consumables-row {
+    display: none;
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    right: 0;
+    gap: 8px;
+  }
+  body.mobile-touch.mobile-consumables-open #mobile-consumables-row {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  body.mobile-touch .mobile-consumable-slot {
+    position: relative;
+    width: 48px;
+    height: 48px;
+    padding: 0;
+    flex: none;
+    pointer-events: auto;
+    border: 1px solid var(--mobile-glass-border, #cba43d8c);
+    border-radius: 50%;
+    background: var(--mobile-glass-bg, linear-gradient(160deg, #23212de3, #0e0d10eb));
+    -webkit-backdrop-filter: blur(var(--mobile-glass-blur, 8px));
+    backdrop-filter: blur(var(--mobile-glass-blur, 8px));
+    color: #eee8ff;
+    cursor: var(--cursor-point);
+    overflow: hidden;
+    box-shadow:
+      inset 0 1px 0 #ffffff14,
+      0 2px 8px #0009;
+  }
+  body.mobile-touch .mobile-consumable-slot:active {
+    border-color: var(--gold);
+  }
+  /* Same cd-overlay/count/state structure as the ring buttons (shared painter). */
+  body.mobile-touch .mobile-consumable-slot .icon-label {
+    position: absolute;
+    inset: 3px;
+    border-radius: 50%;
+    background-size: cover;
+    background-position: center;
+  }
+  body.mobile-touch .mobile-consumable-slot .cd-overlay {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 0;
+    border-radius: 0 0 50% 50%;
+    background: #000a;
+    pointer-events: none;
+  }
+  body.mobile-touch .mobile-consumable-slot .cdtext {
+    position: relative;
+    font-size: 13px;
+    font-weight: bold;
+    text-shadow: 1px 1px 2px #000;
+    pointer-events: none;
+  }
+  body.mobile-touch .mobile-consumable-slot .item-count {
+    position: absolute;
+    right: 4px;
+    bottom: 2px;
+    font-size: 11px;
+    font-weight: bold;
+    text-shadow: 1px 1px 2px #000;
+    pointer-events: none;
+  }
+  body.mobile-touch .mobile-consumable-slot .keybind {
+    display: none;
+  }
+  body.mobile-touch .mobile-consumable-slot.empty {
+    display: none;
+  }
+  body.mobile-touch .mobile-consumable-slot.unusable {
+    filter: grayscale(0.6);
+    opacity: 0.6;
+  }
+  body.mobile-touch .mobile-consumable-slot.used {
+    border-color: var(--gold);
+  }
   body.mobile-touch #mobile-extra-controls {
     position: fixed;
     left: 50%;
@@ -862,8 +1018,8 @@
     box-shadow:
       0 8px 28px #000d,
       inset 0 1px 0 #ffffff12;
-    /* Centre-screen modal (the More button lives at top-centre now, so the
-       menu opens under the middle of the screen instead of stacking on the
+    /* Centre-screen modal (the More button lives in the top-left trio now, so
+       the menu opens under the middle of the screen instead of stacking on the
        trigger): cap to the safe viewport so short landscape phones can
        scroll the full menu without hiding rows behind controls or browser chrome.
        No --ui-scale division: this drawer is a <body>-level window OUTSIDE the
@@ -1025,7 +1181,7 @@
     left: 50%;
     /* Centred just above the bottom-centre #player-frame (14px inset + its
        scaled ~48px height + a gap), the classic seat: with Chat/More moved to
-       top-centre the band over the player frame is free again, and the old
+       the top-left trio the band over the player frame is free again, and the old
        left-strip seat now belongs to Jump's hollow seat around the joystick
        (a cast bar rendered behind a button, z 19 vs 30, was unreadable). */
     bottom: calc(68px + env(safe-area-inset-bottom));
@@ -1114,6 +1270,7 @@
      cast bars aren't in this selector list). */
   body.mobile-touch.mobile-chrome-idle #mobile-combat-controls .mobile-btn,
   body.mobile-touch.mobile-chrome-idle #mobile-utility-cluster .mobile-btn,
+  body.mobile-touch.mobile-chrome-idle #mobile-consumables-toggle,
   body.mobile-touch.mobile-chrome-idle #side-buttons {
     opacity: 0.5;
   }
@@ -2333,6 +2490,15 @@
       height: 44px;
       font-size: 16px;
     }
+    /* Portrait trio is 3x42px + 2x6px gaps = 138px wide (native app: web
+       gameplay is landscape-locked); shrink the chip to the 44px button
+       height and re-dock it past the narrower trio. */
+    body.mobile-touch #mobile-consumables {
+      left: calc(max(12px, env(safe-area-inset-left)) + 138px * var(--btn-scale, 1) + 8px);
+    }
+    body.mobile-touch #mobile-consumables-toggle {
+      height: 44px;
+    }
   }
 
   @media (orientation: landscape) {
@@ -2454,6 +2620,12 @@
       top: max(6px, env(safe-area-inset-top));
       grid-template-columns: repeat(3, 54px);
       gap: 10px;
+    }
+    /* Landscape trio is 3x54px + 2x10px gaps = 182px wide; keep the chip docked
+       just past it on the same compressed top line. */
+    body.mobile-touch #mobile-consumables {
+      left: calc(max(12px, env(safe-area-inset-left)) + 182px * var(--btn-scale, 1) + 10px);
+      top: max(6px, env(safe-area-inset-top));
     }
     /* Landscape joystick is 128px and re-anchored (above), so the satellite
        seats follow via the cluster's anchor/radius hooks; the hollow math and

--- a/src/ui/consumable_bar_view.ts
+++ b/src/ui/consumable_bar_view.ts
@@ -1,0 +1,61 @@
+// Pure, DOM-free core for the mobile consumables quick bar: turns the raw
+// inventory into the ordered, capped list of consumable item ids whose slots
+// the bar paints (through the shared action_bar_view core, which derives the
+// per-slot count / potion-cooldown / usable state itself). Touch has no way to
+// drag an item onto the hotbar, so unlike the desktop bar this list is
+// AUTO-POPULATED from what the player is carrying: zero setup, the bag's
+// "Consumables" category made castable. Host-agnostic (a Vitest drives it
+// directly); registered in tests/architecture.test.ts UI_PURE_CORES.
+
+import type { InvSlot, ItemDef } from '../sim/types';
+
+/** Slot buttons the quick bar renders; both game shells ship this many. */
+export const CONSUMABLE_BAR_SLOTS = 6;
+
+// Combat-priority order: what a player reaches for mid-fight comes first, so
+// the capped row never buries a potion behind a stack of picnic food.
+export const CONSUMABLE_KIND_ORDER = ['potion', 'elixir', 'food', 'drink'] as const;
+
+export type ConsumableLookup = (itemId: string) => ItemDef | undefined;
+
+/**
+ * Fill `out` with the item ids the quick bar shows, in render order:
+ * potions, then elixirs, then food, then drink; id-sorted within a kind so the
+ * row stays visually stable while stacks merge, split, or shuffle bag order.
+ * Multiple stacks of one item collapse to a single slot (the shared bar core
+ * sums the count across stacks). Mutates and returns `out` (allocation-light:
+ * per-frame callers reuse one array, matching the action_bar_view contract).
+ */
+export function consumableBarItems(
+  inventory: readonly Pick<InvSlot, 'itemId'>[],
+  lookup: ConsumableLookup,
+  out: string[],
+  cap = CONSUMABLE_BAR_SLOTS,
+): string[] {
+  out.length = 0;
+  for (const kind of CONSUMABLE_KIND_ORDER) {
+    const segStart = out.length;
+    for (const slot of inventory) {
+      const def = lookup(slot.itemId);
+      if (!def || def.kind !== kind) continue;
+      let seen = false;
+      for (let i = segStart; i < out.length; i++) {
+        if (out[i] === slot.itemId) {
+          seen = true;
+          break;
+        }
+      }
+      if (seen) continue;
+      // Insertion-sort the new id into its kind segment (no splice: splice
+      // allocates its removed-elements array even when removing nothing).
+      out.push(slot.itemId);
+      for (let i = out.length - 1; i > segStart && out[i - 1] > out[i]; i--) {
+        const tmp = out[i - 1];
+        out[i - 1] = out[i];
+        out[i] = tmp;
+      }
+    }
+  }
+  if (out.length > cap) out.length = cap;
+  return out;
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -163,6 +163,7 @@ import {
   shouldPlayMobVoiceSfxForEntity,
 } from './combat_sfx';
 import { type CardinalId, compassView } from './compass';
+import { CONSUMABLE_BAR_SLOTS, consumableBarItems } from './consumable_bar_view';
 import { formatMinimapCoords } from './coords';
 import { corpseHarvestView } from './corpse_harvest_view';
 import { renderCorpseHarvestPicker } from './corpse_harvest_window';
@@ -772,6 +773,17 @@ export class Hud {
   private mobileActionPage = 0;
   private mobileActionRingView: ActionBarView | undefined;
   private mobileActionRingPainter: MobileActionRingPainter | undefined;
+  // Consumables quick bar (touch): the auto-populated potion/elixir/food/drink
+  // row behind the chevron chip next to the top-left trio. consumableBarIds is
+  // the ONE reused array the pure core fills WHEN THE ROW OPENS and that stays
+  // FROZEN while it is open: slots must not shift under the player's thumb the
+  // frame a stack depletes (a depleted item stays in place, greyed at count 0,
+  // exactly like a desktop bar item shortcut). Reopening refreshes the list.
+  private consumableBarView: ActionBarView | undefined;
+  private consumableBarPainter: ActionBarPainter | undefined;
+  private consumableBarSlotBtns: HTMLButtonElement[] = [];
+  private readonly consumableBarIds: string[] = [];
+  private consumablesOpen = false;
   /** Ring button refs so castSlot's used-flash can hit the ring too (the
    *  desktop bar is display:none under body.mobile-touch). */
   private mobileRingAttackBtn: HTMLButtonElement | null = null;
@@ -4772,6 +4784,7 @@ export class Hud {
     );
 
     this.buildMobileActionRing();
+    this.buildMobileConsumableBar();
   }
 
   // Build the mobile action ring: a SECOND createActionBarView instance over a
@@ -4943,6 +4956,129 @@ export class Hud {
       (iconKey) => (iconKey === ATTACK_ICON_KEY ? '' : this.actionBarIconBg(iconKey)),
       t,
     );
+  }
+
+  // Consumables quick bar: the chevron chip next to the top-left trio expands a
+  // row auto-populated from the carried consumables (consumable_bar_view.ts),
+  // painted by another instance of the shared bar family. Touch has no way to
+  // drag an item onto the hotbar, so unlike the ring's paged slots this bar
+  // needs no setup: tap the chip, tap the potion. Collapsed by default and
+  // session-only (no persisted state, no settings entry). Defensive against
+  // missing markup like the ring (an older cached template leaves it unbuilt).
+  private buildMobileConsumableBar(): void {
+    const toggle = document.getElementById('mobile-consumables-toggle');
+    const row = document.getElementById('mobile-consumables-row');
+    const slotBtns = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('.mobile-consumable-slot'),
+    ).sort(
+      (a, b) => Number(a.dataset.consumableIndex ?? 0) - Number(b.dataset.consumableIndex ?? 0),
+    );
+    if (!toggle || !row || slotBtns.length !== CONSUMABLE_BAR_SLOTS) return;
+    this.consumableBarSlotBtns = slotBtns;
+
+    const slotEls: ActionBarSlotElements[] = slotBtns.map((btn) => {
+      const label = document.createElement('span');
+      label.className = 'icon-label';
+      const countEl = document.createElement('span');
+      countEl.className = 'item-count';
+      const keybindEl = document.createElement('span');
+      keybindEl.className = 'keybind';
+      const cdOverlay = document.createElement('div');
+      cdOverlay.className = 'cd-overlay';
+      const cdText = document.createElement('div');
+      cdText.className = 'cdtext';
+      btn.append(label, countEl, keybindEl, cdOverlay, cdText);
+      return { btn, label, countEl, keybindEl, cdOverlay, cdText };
+    });
+
+    // bindTouchTap, not 'click', for the same reason as the ring: the browser
+    // only synthesizes click for the PRIMARY pointer, so a click-bound button
+    // goes dead while the other thumb holds the joystick.
+    bindTouchTap(toggle, () => {
+      audio.click();
+      this.consumablesOpen = !this.consumablesOpen;
+      // Snapshot the consumable list at OPEN time; it stays frozen while open
+      // so slot positions are tap-stable (see the field comment). Counts and
+      // the potion-cooldown sweep still update live off the sim each frame.
+      if (this.consumablesOpen) {
+        consumableBarItems(this.sim.inventory, (id) => ITEMS[id], this.consumableBarIds);
+      }
+      document.body.classList.toggle('mobile-consumables-open', this.consumablesOpen);
+      toggle.setAttribute('aria-expanded', this.consumablesOpen ? 'true' : 'false');
+      (toggle as HTMLElement).blur();
+    });
+    slotBtns.forEach((btn, i) => {
+      bindTouchTap(btn, () => {
+        if (this.peekGuard.consume()) {
+          this.hideTooltip();
+          btn.blur();
+          return;
+        }
+        audio.click();
+        this.useConsumableSlot(i);
+        btn.blur();
+      });
+      // Long-press-to-inspect, arming the peek guard the tap handler consumes
+      // (same contract as the ring: a long press must never quaff).
+      this.attachTooltip(btn, () => {
+        const id = this.consumableBarIds[i];
+        const item = id ? (ITEMS[id] ?? null) : null;
+        if (!item) return `<div class="tt-sub">${esc(t('abilityUi.actionBar.emptySlot'))}</div>`;
+        const count = this.inventoryCount(item.id);
+        return (
+          this.itemTooltip(item) +
+          `<div class="tt-sub">${esc(
+            count > 0
+              ? t('abilityUi.actionBar.itemInBags', {
+                  count: formatNumber(count, { maximumFractionDigits: 0 }),
+                })
+              : t('abilityUi.actionBar.itemNoneInBags'),
+          )}</div>`
+        );
+      });
+    });
+
+    this.consumableBarView = createActionBarView(
+      {
+        slots: Array.from({ length: CONSUMABLE_BAR_SLOTS }, (_, i) => ({
+          slotIndex: i,
+          isAttack: false,
+          hasAction: () => this.consumableBarIds[i] !== undefined,
+          ability: () => null,
+          item: () => {
+            const id = this.consumableBarIds[i];
+            return id ? (ITEMS[id] ?? null) : null;
+          },
+          keybindLabel: () => '',
+        })),
+      },
+      {
+        t,
+        abilityName: abilityDisplayName,
+        itemName: itemDisplayName,
+        slotLabel: (i) => formatAbilityNumber(i + 1),
+        formatCount: (n) => formatNumber(n, { maximumFractionDigits: 0 }),
+      },
+    );
+    this.consumableBarPainter = new ActionBarPainter(
+      this.writerFacet,
+      { container: row, slots: slotEls },
+      (iconKey) => this.actionBarIconBg(iconKey),
+    );
+  }
+
+  // Tap dispatch for a consumables-bar slot: the same seam as castSlot's item
+  // arm (IWorld.useItem, so offline runs the sim directly and online sends the
+  // authoritative 'use' command), minus the hotbar-eligibility gate: the bar's
+  // ids come pre-filtered from consumable_bar_view, which deliberately INCLUDES
+  // elixirs (usable from bags, just never hotbar-placeable).
+  private useConsumableSlot(i: number): void {
+    const id = this.consumableBarIds[i];
+    if (!id || this.tradeOpen) return;
+    this.sim.useItem(id);
+    if ($('#bags').style.display !== 'none') this.renderBags();
+    const btn = this.consumableBarSlotBtns[i];
+    if (btn) this.flashActionButton(btn);
   }
 
   // Resolve a core icon key to the slot label's background-image value. Kept on the
@@ -5762,6 +5898,28 @@ export class Hud {
         }),
         this.mobileActionPage,
         mobilePageCount(),
+      );
+    }
+
+    // consumables quick bar: tick+paint ONLY while the row is expanded on touch.
+    // The id list is NOT recomputed here: it was snapshotted when the row opened
+    // and stays frozen so slots never shift under the player's thumb; counts,
+    // usability, and the shared potion-cooldown sweep still derive live from the
+    // sim/inventory every tick. Skipping the closed bar entirely is safe for the
+    // same reason ring paging is: all of that state lives on the sim, not the
+    // view, so the row is correct the frame it opens.
+    if (
+      this.isMobileLayout() &&
+      this.consumablesOpen &&
+      this.consumableBarView &&
+      this.consumableBarPainter
+    ) {
+      this.consumableBarPainter.paint(
+        this.consumableBarView.tick({
+          player: p,
+          target: target ?? null,
+          inventory: sim.inventory,
+        }),
       );
     }
 

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -160,6 +160,7 @@ const UI_PURE_CORES = [
   'src/ui/unit_frame.ts',
   'src/ui/action_bar_view.ts',
   'src/ui/mobile_action_page_view.ts',
+  'src/ui/consumable_bar_view.ts',
   'src/ui/mobile_hud_layout.ts',
   'src/ui/auras_view.ts',
   'src/ui/minimap_markers.ts',

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -759,6 +759,53 @@ describe('client HTML shell', () => {
     );
   });
 
+  it('ships the consumables quick bar in BOTH entries, collapsed by default', () => {
+    for (const [name, entry] of [
+      ['index.html', html],
+      ['play.html', playHtml],
+    ] as const) {
+      expect(entry, name).toContain('id="mobile-consumables"');
+      // aria-label on a role-less div is prohibited ARIA (ignored by screen
+      // readers); the container carries role="group" so the name is exposed.
+      expect(entry, name).toMatch(/id="mobile-consumables" role="group"/);
+      // The chevron chip starts collapsed (aria-expanded false; hud.ts flips it)
+      // and reuses the existing bags-filter key, so the bar adds no i18n keys.
+      expect(entry, name).toMatch(/id="mobile-consumables-toggle"[^>]*aria-expanded="false"/);
+      expect(entry, name).toMatch(/id="mobile-consumables-toggle"[^>]*data-icon="next"/);
+      expect(entry, name).toMatch(
+        /id="mobile-consumables-toggle"[^>]*data-i18n-aria="hudChrome\.bags\.filterConsumable"/,
+      );
+      const slots = [
+        ...entry.matchAll(/class="mobile-consumable-slot"[^>]*data-consumable-index="(\d+)"/g),
+      ];
+      expect(slots, name).toHaveLength(6);
+      expect(slots.map((m) => m[1]).sort(), name).toEqual(['0', '1', '2', '3', '4', '5']);
+    }
+    // The row shows only via the session-only body toggle, and empty slots
+    // collapse away so the open row is as wide as what the player carries.
+    expect(hudMobileCss).toContain(
+      'body.mobile-touch.mobile-consumables-open #mobile-consumables-row {',
+    );
+    expect(hudMobileCss).toContain('body.mobile-touch .mobile-consumable-slot.empty {');
+    // A touch starting on the bar must never double as a camera drag.
+    expect(readFileSync(new URL('../src/game/touch_router.ts', import.meta.url), 'utf8')).toContain(
+      "'#mobile-consumables',",
+    );
+    // The open row drops BELOW the chip line: the top-centre band belongs to
+    // the pet bar, and #ui (z 80) paints above #mobile-controls (z 60), so a
+    // row along the top band would sit UNDER the pet buttons and lose taps.
+    expect(hudMobileCss).toMatch(
+      /#mobile-consumables-row \{\n {4}display: none;\n {4}position: absolute;\n {4}top: calc\(100% \+ 6px\);/,
+    );
+    // The id list is snapshotted at OPEN time and stays frozen while open, so
+    // slots never shift under the thumb the frame a stack depletes: exactly one
+    // consumableBarItems CALL (the toggle handler's snapshot), none per-frame.
+    expect(hudTs.match(/consumableBarItems\(/g) ?? []).toHaveLength(1);
+    expect(hudTs).toContain(
+      'consumableBarItems(this.sim.inventory, (id) => ITEMS[id], this.consumableBarIds);',
+    );
+  });
+
   it('carries identical mobile-action-ring markup in BOTH entries', () => {
     for (const entry of [html, playHtml]) {
       expect(entry).toContain('id="mobile-action-ring"');
@@ -1344,7 +1391,7 @@ describe('client HTML shell', () => {
     expect(marketWindowTs).not.toContain('<select data-market-filter=');
   });
 
-  it('keeps Chat, Social and More alone at top-centre, away from both thumb clusters', () => {
+  it('keeps Chat, Social and More alone at top-left, away from both thumb clusters', () => {
     for (const [name, entry] of [
       ['index.html', html],
       ['play.html', playHtml],
@@ -1357,7 +1404,7 @@ describe('client HTML shell', () => {
       const chat = combatControls.indexOf('id="mobile-chat"');
       const social = combatControls.indexOf('id="mobile-social"');
       const more = combatControls.indexOf('id="mobile-more"');
-      // Chat/Social/More are deliberately the ONLY top-centre buttons:
+      // Chat/Social/More are deliberately the ONLY top-left buttons:
       // everything a thumb needs mid-fight lives in the two bottom corner
       // clusters, so the trio is hard to fat-finger but still one reach away.
       expect(primaryButtons, name).toHaveLength(3);

--- a/tests/consumable_bar_view.test.ts
+++ b/tests/consumable_bar_view.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import type { ItemDef } from '../src/sim/types';
+import {
+  CONSUMABLE_BAR_SLOTS,
+  CONSUMABLE_KIND_ORDER,
+  consumableBarItems,
+} from '../src/ui/consumable_bar_view';
+
+// Minimal synthetic item table: the core reads only `kind` off the def, so a
+// cast keeps the fixture small (same trick as tests/bag_filter.test.ts).
+const DEFS: Record<string, ItemDef> = Object.fromEntries(
+  (
+    [
+      ['healing_potion', 'potion'],
+      ['mana_potion', 'potion'],
+      ['bear_elixir', 'elixir'],
+      ['bread', 'food'],
+      ['boar_meat', 'food'],
+      ['water', 'drink'],
+      ['sword', 'weapon'],
+      ['pelt', 'junk'],
+      ['fishing_rod', 'tool'],
+    ] as const
+  ).map(([id, kind]) => [id, { id, kind } as unknown as ItemDef]),
+);
+const lookup = (id: string) => DEFS[id];
+const inv = (...ids: string[]) => ids.map((itemId) => ({ itemId, count: 1 }));
+
+describe('consumableBarItems', () => {
+  it('keeps only the four consumable kinds and drops gear/junk/tools/unknowns', () => {
+    const got = consumableBarItems(
+      inv('sword', 'bread', 'pelt', 'healing_potion', 'fishing_rod', 'no_such_item'),
+      lookup,
+      [],
+    );
+    expect(got).toEqual(['healing_potion', 'bread']);
+  });
+
+  it('orders by combat priority (potion, elixir, food, drink), id-sorted within a kind', () => {
+    // deliberately scrambled bag order; the row must not follow it
+    const got = consumableBarItems(
+      inv('water', 'boar_meat', 'mana_potion', 'bear_elixir', 'bread', 'healing_potion'),
+      lookup,
+      [],
+    );
+    expect(got).toEqual([
+      'healing_potion',
+      'mana_potion',
+      'bear_elixir',
+      'boar_meat',
+      'bread',
+      'water',
+    ]);
+    // the priority table itself is the load-bearing order; pin it
+    expect(CONSUMABLE_KIND_ORDER).toEqual(['potion', 'elixir', 'food', 'drink']);
+  });
+
+  it('collapses multiple stacks of one item into a single slot', () => {
+    const got = consumableBarItems(
+      inv('bread', 'healing_potion', 'bread', 'bread', 'healing_potion'),
+      lookup,
+      [],
+    );
+    expect(got).toEqual(['healing_potion', 'bread']);
+  });
+
+  it('caps at the slot count, shedding the lowest-priority tail (never a potion)', () => {
+    const got = consumableBarItems(
+      inv('water', 'bread', 'boar_meat', 'bear_elixir', 'healing_potion', 'mana_potion', 'water'),
+      lookup,
+      [],
+    );
+    expect(got).toHaveLength(CONSUMABLE_BAR_SLOTS);
+    // 6 distinct consumables fit exactly; a 7th distinct food would push out
+    // the drink, never the potions at the head
+    expect(got[0]).toBe('healing_potion');
+    expect(got[1]).toBe('mana_potion');
+    const capped = consumableBarItems(
+      inv('water', 'bread', 'boar_meat', 'bear_elixir', 'healing_potion', 'mana_potion'),
+      lookup,
+      [],
+      2,
+    );
+    expect(capped).toEqual(['healing_potion', 'mana_potion']);
+  });
+
+  it('reuses the caller array across calls (allocation-light per-frame contract)', () => {
+    const out: string[] = [];
+    const first = consumableBarItems(inv('bread'), lookup, out);
+    expect(first).toBe(out);
+    const second = consumableBarItems(inv('healing_potion', 'water'), lookup, out);
+    expect(second).toBe(out);
+    expect(out).toEqual(['healing_potion', 'water']);
+  });
+
+  it('accepts both hosts inventory shapes (InvSlot needs only itemId)', () => {
+    // Sim-side slots can carry an instance payload; ClientWorld mirrors plain
+    // {itemId, count} rows. The core reads itemId only, so both satisfy it.
+    const simShaped = [
+      { itemId: 'healing_potion', count: 3, instance: { crafterName: 'Bob' } },
+      { itemId: 'bread', count: 5 },
+    ];
+    expect(consumableBarItems(simShaped, lookup, [])).toEqual(['healing_potion', 'bread']);
+  });
+
+  it('returns empty for an empty or consumable-free inventory', () => {
+    expect(consumableBarItems([], lookup, ['stale'])).toEqual([]);
+    expect(consumableBarItems(inv('sword', 'pelt'), lookup, [])).toEqual([]);
+  });
+});


### PR DESCRIPTION
Follow-up to #1533 (merged while this was in review fan-out, so it arrives as its own PR).

## What

Using a potion on a phone meant More, then Bags, then tapping the item inside a full-screen sheet that covers the fight; there was also no touch path to place an item on the hotbar at all. This adds a quiet chevron chip docked right of the Chat/Social/More trio that expands a row of the carried consumables, auto-populated with zero setup: tap the chip, tap the potion. Collapsed by default, session-only, no settings entry.

## How

- New pure core `src/ui/consumable_bar_view.ts` (registered in UI_PURE_CORES, unit tested): filters the inventory to potion/elixir/food/drink, one slot per item id, combat-priority ordered (potions first), capped at the 6 static slots both shells ship. Elixirs are included; they were only ever excluded from hotbar placement, not from use.
- Another instance of the shared bar family (`createActionBarView` + `ActionBarPainter`), so item icons, stack counts, dimming, and the shared 2 minute potion-cooldown sweep behave exactly like the desktop bar. Taps dispatch through `IWorld.useItem`, so online stays server-authoritative with no optimistic mutation.
- The id list is snapshotted when the row opens and stays frozen while open, so slots never shift under the player's thumb when a stack depletes (the item stays in place, greyed at count 0, like a desktop item shortcut). Reopening refreshes it.
- The open row drops below the chip line: the top-centre band belongs to the pet bar, and #ui (z 80) paints above #mobile-controls (z 60), so a row along the top band would lose taps to the pet command buttons. The right reservation is sized for the worst-case --btn-scale 1.3 visual overhang so the scaled row never slides under the buff column, chest rail, or minimap. Both hazards were caught by an adversarial review fan-out before commit.
- `touch_router` treats the bar as interactive chrome (a touch starting on it never doubles as a camera drag); the container carries role="group"; every label reuses existing i18n keys (no new keys); the chip joins the idle chrome fade; both game shells carry identical markup.

Also included, from the earlier review feedback on this branch: the two stale "top-centre" comments in hud.mobile.css (the trio is anchored top-left) plus the matching client_shell test name, and the always-pass mobile-jump arms dropped from the layout script's joystick-overlap loops.

## Verification

Unit + guard suites green (architecture purity/completeness, hud_perf_budget, client_shell both-entries pins, css corpus/validity, i18n completeness, mobile_controls, the new consumable_bar_view suite); tsc clean; scripts/mobile_cluster_layout_check.mjs passes across all 7 device profiles with the chip added to CONTROL_IDS. Verified live in an offline world in forced-touch mode: collapsed default, open/close cycle, priority-ordered slots with counts and localized aria, empty-slot collapse, potion tap healing and arming the shared 120s cooldown sweep on both potion slots, food tap starting eat plus sit, row rendering below the pet-bar seat, and the depleted-last-potion slot staying put greyed at count 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)