### PR TITLE
ci: cap vitest fork parallelism + raise testTimeout to de-flake gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,11 @@ jobs:
         run: npm run security:gate
 
       - name: Run tests (PR tier)
-        run: npm test
+        # Cap fork parallelism to half the cores, mirroring scripts/gate.mjs's local
+        # worker cap. A bare `npm test` lets vitest spawn one fork per core; on shared
+        # CI runners that starves CPU-bound sim tick-loop tests (fiesta/social/threat),
+        # which then intermittently trip the per-test timeout. See vite.config.ts.
+        run: npm test -- --maxWorkers=50%
 
       - name: Typecheck
         run: npx tsc --noEmit
@@ -197,7 +201,8 @@ jobs:
         run: npm run security:gate
 
       - name: Run tests (release tier - 14-locale + empty-pending)
-        run: npm test
+        # Cap fork parallelism to half the cores (see the PR-tier step / scripts/gate.mjs).
+        run: npm test -- --maxWorkers=50%
 
       - name: Typecheck
         run: npx tsc --noEmit

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -349,6 +349,11 @@ export default defineConfig({
     },
   },
   test: {
+    // Sim tick-loop tests (fiesta/social/threat) run 1200-1600 full-world ticks and sit
+    // right against vitest's stock 5000ms per-test default; under parallel CPU contention
+    // on CI they intermittently trip it. Give them headroom (the ci.yml worker cap is the
+    // primary mitigation; this removes the reliance on the borderline default).
+    testTimeout: 15_000,
     // server/db.ts (and every module importing it) requires DATABASE_URL at module
     // load. Locally db.ts fills it from .env; a CI checkout has no .env, so default
     // a dummy here to keep the suite runnable in plain Node. Unit tests never open


### PR DESCRIPTION
## Summary

De-flakes the CI test gates. Sim-heavy tick-loop tests — `fiesta` (offline practice vs bots), `social` (lightning shield), `threat` (tame beast) — run 1,200–1,600 full-world ticks and sit right against vitest's stock **5000 ms** per-test default. On shared CI runners, a bare `npm test` lets vitest spawn **one fork per core**, which starves these CPU-bound tests until they intermittently trip the timeout (`Test timed out in 5000ms`). The failing set varies run-to-run (6 → 2 timeouts across re-runs of the same commit) — the signature of contention flake, not a real regression.

This is **pre-existing and content-agnostic**: the same tests time out on unrelated branches (e.g. `fix/terrain-aware-water-1518`, a rendering PR) at the same line numbers, and bounce red→green→red across near-identical commits.

## Change
- **`.github/workflows/ci.yml`** — cap fork parallelism to half the cores on both the PR-tier and release-tier test steps: `npm test -- --maxWorkers=50%`. This ports the mitigation `scripts/gate.mjs` **already applies locally** (`--maxWorkers=${halfCores}`) to CI, where it was never applied.
- **`vite.config.ts`** — add `testTimeout: 15_000` so borderline tick-loops have headroom instead of relying on the stock 5000 ms default.

## Why separate from the content PR
Surfaced while getting the Mirror World PR (#1514) green, but it's shared CI infrastructure that affects every branch — kept out of the content PR so its review stays focused on gameplay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)