### PR TITLE
fix(ui): open bags on the first press after loading in

### DIFF
--- a/src/ui/bags_view.ts
+++ b/src/ui/bags_view.ts
@@ -94,6 +94,18 @@ export function bagShiftLinks(mode: BagMode): boolean {
   return !mode.vendorOpen;
 }
 
+/** Whether the #bags window is currently shown, from its inline display value.
+ *  Shown = any non-hidden value (today 'flex'; the close() guard also allows a
+ *  'block' pet-feed path), NOT hidden ('none') and NOT the cold-load empty ''.
+ *  The '' case is the bug (issue #1538): the .window stylesheet rule hides the
+ *  window, so a fresh page load leaves the inline display '' (never 'none'). It
+ *  must read as NOT shown so the first toggle OPENS instead of taking the close
+ *  branch (and playing the close sound) against an already-hidden window. Guards
+ *  on the hidden values rather than a specific shown value, mirroring close(). */
+export function bagsWindowShown(display: string): boolean {
+  return display !== 'none' && display !== '';
+}
+
 /** The tooltip hint sub-line for a bag item, matching the original tooltip's
  *  mode-then-kind branch. Returns '' when no hint applies (e.g. a material). */
 export function bagTooltipHintKey(item: BagItemInfo, mode: BagMode): BagTooltipHintKey {

--- a/src/ui/bags_view.ts
+++ b/src/ui/bags_view.ts
@@ -95,13 +95,14 @@ export function bagShiftLinks(mode: BagMode): boolean {
 }
 
 /** Whether the #bags window is currently shown, from its inline display value.
- *  Shown = any non-hidden value (today 'flex'; the close() guard also allows a
- *  'block' pet-feed path), NOT hidden ('none') and NOT the cold-load empty ''.
- *  The '' case is the bug (issue #1538): the .window stylesheet rule hides the
- *  window, so a fresh page load leaves the inline display '' (never 'none'). It
- *  must read as NOT shown so the first toggle OPENS instead of taking the close
- *  branch (and playing the close sound) against an already-hidden window. Guards
- *  on the hidden values rather than a specific shown value, mirroring close(). */
+ *  Shown = any non-hidden value (#bags is only ever assigned 'flex' today), NOT
+ *  hidden ('none') and NOT the cold-load empty ''. The '' case is the bug (issue
+ *  #1538): the .window stylesheet rule hides the window, so a fresh page load
+ *  leaves the inline display '' (never 'none'). It must read as NOT shown so the
+ *  first toggle OPENS instead of taking the close branch (and playing the close
+ *  sound) against an already-hidden window. Guards on the hidden values rather
+ *  than pinning to a specific shown value (mirroring close() and the closeAll
+ *  precedent), so it stays correct if the shown value ever changes. */
 export function bagsWindowShown(display: string): boolean {
   return display !== 'none' && display !== '';
 }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -126,6 +126,7 @@ import { type AuraEffectInput, auraEffectDescriptor } from './aura_effect';
 import { AurasPainter, type AurasPainterDeps } from './auras_painter';
 import { type AurasDeps, createAurasView } from './auras_view';
 import { attachAvatarFallback } from './avatar_fallback';
+import { bagsWindowShown } from './bags_view';
 import { BagsWindow } from './bags_window';
 import { CalendarWindow } from './calendar_window';
 import { CastBarPainter } from './cast_bar_painter';
@@ -9763,9 +9764,12 @@ export class Hud {
 
   toggleBags(): void {
     const el = $('#bags');
-    if (el.style.display !== 'none') {
+    if (bagsWindowShown(el.style.display)) {
       // Close through the painter so focus returns to the opener (WCAG 2.4.3); close()
       // owns the hide + tooltip + pet-feed teardown, so keep only the audio cue here.
+      // Only a genuinely shown window closes here: on a cold load the inline display
+      // is '' (hidden by the .window CSS rule), which must open on the first press,
+      // not take this close branch and play the close sound (issue #1538).
       audio.bagClose();
       this.bagsWindow.close();
       return;

--- a/tests/bags_view.test.ts
+++ b/tests/bags_view.test.ts
@@ -6,6 +6,7 @@ import {
   bagItemAction,
   bagQualityKey,
   bagShiftLinks,
+  bagsWindowShown,
   bagTooltipHintKey,
   buildBagGrid,
 } from '../src/ui/bags_view';
@@ -41,6 +42,24 @@ describe('bagShiftLinks', () => {
     expect(bagShiftLinks({ ...NO_MODE, marketSell: true })).toBe(true);
     expect(bagShiftLinks({ ...NO_MODE, petFeed: true })).toBe(true);
     expect(bagShiftLinks({ ...NO_MODE, vendorOpen: true })).toBe(false);
+  });
+});
+
+describe('bagsWindowShown', () => {
+  it('reads the cold-load empty display as NOT shown so the first toggle opens (issue #1538)', () => {
+    // The regression: the window is hidden by the .window CSS rule, so on a fresh
+    // page load the inline display is '' (never 'none'). The old `!== 'none'` check
+    // treated '' as shown and ran the close branch on the first press.
+    expect(bagsWindowShown('')).toBe(false);
+  });
+  it('reads an explicitly hidden window as NOT shown', () => {
+    expect(bagsWindowShown('none')).toBe(false);
+  });
+  it('reads a shown window as shown, for either shown value (flex, or the block pet-feed path)', () => {
+    expect(bagsWindowShown('flex')).toBe(true);
+    // The close() guard documents a 'block' pet-feed path; treat any non-hidden
+    // value as shown so a block-shown bags still closes on toggle.
+    expect(bagsWindowShown('block')).toBe(true);
   });
 });
 

--- a/tests/bags_view.test.ts
+++ b/tests/bags_view.test.ts
@@ -55,10 +55,11 @@ describe('bagsWindowShown', () => {
   it('reads an explicitly hidden window as NOT shown', () => {
     expect(bagsWindowShown('none')).toBe(false);
   });
-  it('reads a shown window as shown, for either shown value (flex, or the block pet-feed path)', () => {
+  it('reads any non-hidden value as shown (not pinned to the current shown value)', () => {
+    // #bags is only ever assigned 'flex' today, but the guard checks the hidden
+    // values (none / '') rather than pinning to 'flex', so it stays correct if the
+    // shown value ever changes. Assert a non-'flex' non-hidden value still closes.
     expect(bagsWindowShown('flex')).toBe(true);
-    // The close() guard documents a 'block' pet-feed path; treat any non-hidden
-    // value as shown so a block-shown bags still closes on toggle.
     expect(bagsWindowShown('block')).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

Opening the bags for the first time after loading into the world takes two activations: the first press of B (or the first click of the minimap bag button, or the mobile bags button) does nothing visible and plays the bag-close sound, and only the second press opens the window. All three open paths funnel through `toggleBags`, so all three show it. After the first phantom toggle it behaves normally until the next page load.

Fixes #1538.

## Root cause

`toggleBags` (`src/ui/hud.ts`) decided open-vs-close from the inline `style.display`:

```ts
if (el.style.display !== 'none') { audio.bagClose(); this.bagsWindow.close(); return; }
```

But `#bags` carries no inline style; `.window` is hidden purely by a stylesheet rule (`src/styles/layout.css`). So on a fresh load the inline `display` is the empty string `''`, not `'none'`. The `!== 'none'` check treats `''` as shown, so the first press runs the close branch: nothing opens and `audio.bagClose()` plays. `close()` also guards on `=== 'none'`, so it does not early-return either; it sets the inline `display` to `'none'`, and only then does the second press open.

## Fix

Read visibility through a small pure `bagsWindowShown()` core in `bags_view.ts` that treats only genuinely shown values as open (guarding on the hidden values `'none'`/`''` rather than a specific shown value, mirroring `close()`'s own guard and the existing `closeAll` empty-string precedent). A cold-load `''` now reads as not-shown, so the first activation opens and the close cue plays only when a genuinely open window closes.

## Test

`tests/bags_view.test.ts` pins the regression: `bagsWindowShown('')` is `false` (the cold-load state that must open), `'none'` is `false`, and `'flex'`/`'block'` are `true`.

## Scope

- `src/ui/bags_view.ts` (new pure `bagsWindowShown`), `src/ui/hud.ts` (`toggleBags` consumes it), `tests/bags_view.test.ts`.
- Client HUD chrome only; no `IWorld`/parity/determinism/i18n surface touched.
