### PR TITLE
fix(ui): clear the stale hotbar tooltip after a drag-drop

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -4636,6 +4636,11 @@ export class Hud {
             this.hotbarActions = placeItemOnSlot(this.hotbarActions, action.id, slot - 1);
           }
           this.saveSlotMap();
+          // The drop rearranged this slot's contents, but a drop that ends with the
+          // cursor already inside the slot fires no mouseenter, so the tooltip would
+          // keep the pre-drop text (stale "empty slot" / wrong ability). Clear it so
+          // it no longer shows the old slot; the next hover resolves it live (#1485).
+          this.hideTooltip();
         });
         btn.addEventListener('dragend', () => {
           this.dragAction = null;
@@ -4813,6 +4818,9 @@ export class Hud {
         if (targetIndex !== null && targetIndex !== drag.sourceIndex) {
           this.hotbarActions = swapHotbarSlots(this.hotbarActions, drag.sourceIndex, targetIndex);
           this.saveSlotMap();
+          // Match the desktop drop: clear the now-stale tooltip for the rearranged
+          // slot so a long-press peek resolves the new content (#1485).
+          this.hideTooltip();
         }
       }
       this.clearMobileHotbarDrag();

--- a/tests/hotbar_drop_tooltip.test.ts
+++ b/tests/hotbar_drop_tooltip.test.ts
@@ -1,0 +1,42 @@
+// Regression for a reported bug (#1485): dragging a hotbar ability onto another
+// slot left the tooltip stale. A drop that ends with the cursor already inside the
+// target slot fires no mouseenter, so the tooltip kept its pre-drop text (the
+// "empty slot" hint, or the previous ability's name after a swap). Every sibling
+// slot mutation (clearSlot, the context-menu clear, char/bags window drops) already
+// calls hideTooltip() on mutate; the two hotbar drop-completion paths did not.
+// Guard that both now clear the tooltip after the slot is rearranged.
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const src = readFileSync(new URL('../src/ui/hud.ts', import.meta.url), 'utf8');
+// Strip comments so the explanatory comment near the fix cannot satisfy the scan.
+const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+describe('hotbar drag-drop clears the stale tooltip (#1485)', () => {
+  it('desktop drop calls hideTooltip after saving the rearranged slot map', () => {
+    // The action-bar desktop drop handler is the block that places an item onto a
+    // hotbar slot; isolate it up to the following dragend handler.
+    const start = code.indexOf('placeItemOnSlot(this.hotbarActions');
+    expect(start).toBeGreaterThan(-1);
+    const handler = code.slice(start, code.indexOf("addEventListener('dragend'", start));
+    const saveIdx = handler.indexOf('this.saveSlotMap();');
+    const hideIdx = handler.indexOf('this.hideTooltip();');
+    expect(saveIdx).toBeGreaterThan(-1);
+    expect(hideIdx).toBeGreaterThan(saveIdx);
+  });
+
+  it('mobile drag finish calls hideTooltip after swapping slots', () => {
+    // The mobile finish handler swaps by pointer target; isolate from its swap call
+    // to the clearMobileHotbarDrag teardown.
+    const start = code.indexOf(
+      'swapHotbarSlots(this.hotbarActions, drag.sourceIndex, targetIndex)',
+    );
+    expect(start).toBeGreaterThan(-1);
+    const handler = code.slice(start, code.indexOf('this.clearMobileHotbarDrag();', start));
+    const saveIdx = handler.indexOf('this.saveSlotMap();');
+    const hideIdx = handler.indexOf('this.hideTooltip();');
+    expect(saveIdx).toBeGreaterThan(-1);
+    expect(hideIdx).toBeGreaterThan(saveIdx);
+  });
+});


### PR DESCRIPTION
## Problem

Dragging a hotbar ability onto another slot on the same bar left the tooltip stale. Dropped on an empty slot it kept showing "empty slot" even though the cursor now sits on the moved ability; after swapping two abilities it showed the wrong ability's name. The tooltip did not reflect what is now under the cursor.

Fixes #1485.

## Root cause

The tooltip content is a live closure that recomputes the slot's ability/item on each run, so it is correct; the defect is refresh *timing*. `attachTooltip` re-runs that closure only on `mouseenter`/`focusin` (or a touch long-press); `mousemove` merely repositions the box. Native HTML5 drag-and-drop suppresses synthetic mouse events during a drag, and a drop that ends with the cursor already inside the target slot crosses no element boundary, so no `mouseenter` fires and the closure is never re-run for the new slot content.

The two hotbar drop-completion paths (`src/ui/hud.ts`: the desktop `drop` handler and the mobile `finish` handler) rearranged the slot but never touched the tooltip. Every sibling slot mutation (`clearSlot`, the shift-right-click clear, the char-window and bags-window drops) already calls `hideTooltip()` on mutate; these two diverged.

## Fix

Add `this.hideTooltip()` after the slot map is saved on both drop paths, matching the established convention. The stale text is dismissed on drop, and the next hover resolves the slot's tooltip live.

## Test

`tests/hotbar_drop_tooltip.test.ts` guards that both drop-completion handlers call `hideTooltip()` after the slot mutation (source scan, matching the repo's existing hud.ts behavior-guard style, e.g. `daily_rewards_window_chest_toggle.test.ts`).

## Scope

- `src/ui/hud.ts` (two one-line additions), `tests/hotbar_drop_tooltip.test.ts`.
- Client HUD only; no new strings, no per-frame/render-loop code (the change is in the `drop`/`finish` event handlers), no determinism/parity surface.
