### PR TITLE
Fix(ui): decouple UI scale slider dragging from immediate window resizing

### DIFF
--- a/src/ui/options_view.ts
+++ b/src/ui/options_view.ts
@@ -106,6 +106,13 @@ export type OptionsControl =
 /** A slider input dispatches the raw input value coerced to a Number. */
 export const sliderDispatchValue = (rawValue: string): number => Number(rawValue);
 
+/**
+ * Sliders that resize the coordinate space they live in must buffer drag input
+ * and commit on release/change, otherwise the moving pointer shifts under the
+ * thumb as the HUD resizes. Other sliders keep the existing live-input dispatch.
+ */
+export const sliderCommitsOnRelease = (key: string): boolean => key === 'uiScale';
+
 /** A numeric toggle flips between 0 and 1 off the current stored value. */
 export const toggleNextValue = (current: number): number => (current >= 0.5 ? 0 : 1);
 

--- a/src/ui/options_window.ts
+++ b/src/ui/options_window.ts
@@ -67,6 +67,7 @@ import {
   type OptionsSettingsSource,
   type SliderControl,
   type SliderFmt,
+  sliderCommitsOnRelease,
   sliderDispatchValue,
   type ToggleControl,
   toggleIsOn,
@@ -440,8 +441,8 @@ export class OptionsWindow {
     // screen reader announces the human-meaningful value (50%, 90 degrees) instead
     // of the raw stored number. The native range already exposes role=slider plus
     // aria-valuenow/min/max from value/min/max, so only valuetext needs setting.
-    const syncReadout = () => {
-      const text = fmt(hooks.settings.get(key));
+    const syncReadout = (displayValue = hooks.settings.get(key)) => {
+      const text = fmt(displayValue);
       val.textContent = text;
       slider.setAttribute('aria-valuetext', text);
     };
@@ -460,11 +461,33 @@ export class OptionsWindow {
       );
     };
     paintFill();
-    slider.addEventListener('input', () => {
-      hooks.onSettingChange(key, sliderDispatchValue(slider.value));
-      syncReadout();
-      paintFill();
-    });
+    if (sliderCommitsOnRelease(key)) {
+      // Buffered update pattern for uiScale: slider.value is the transient
+      // pending_scale that keeps the thumb/readout/fill moving during a drag,
+      // while hooks.settings remains the committed_scale that drives #ui zoom.
+      // Commit exactly when the interaction settles (pointerup) with a change
+      // fallback for keyboard/browser paths, avoiding resize feedback mid-drag.
+      let committedValue = slider.value;
+      const commitBufferedValue = () => {
+        if (slider.value === committedValue) return;
+        committedValue = slider.value;
+        hooks.onSettingChange(key, sliderDispatchValue(slider.value));
+        syncReadout();
+        paintFill();
+      };
+      slider.addEventListener('input', () => {
+        syncReadout(sliderDispatchValue(slider.value));
+        paintFill();
+      });
+      slider.addEventListener('pointerup', commitBufferedValue);
+      slider.addEventListener('change', commitBufferedValue);
+    } else {
+      slider.addEventListener('input', () => {
+        hooks.onSettingChange(key, sliderDispatchValue(slider.value));
+        syncReadout();
+        paintFill();
+      });
+    }
     row.append(name, slider, val);
     parent.appendChild(row);
   }

--- a/tests/options_view.test.ts
+++ b/tests/options_view.test.ts
@@ -10,6 +10,7 @@ import {
   buildOptionsMenu,
   type OptionsControl,
   type OptionsSettingsSource,
+  sliderCommitsOnRelease,
   sliderDispatchValue,
   toggleIsOn,
   toggleNextValue,
@@ -55,6 +56,12 @@ describe('options_view: control primitive dispatch (cluster 1)', () => {
     expect(sliderDispatchValue('60')).toBe(60);
     // identical coercion regardless of formatting kind
     expect(sliderDispatchValue('1')).toBe(1);
+  });
+
+  it('only the global uiScale slider buffers drag input until release/change', () => {
+    expect(sliderCommitsOnRelease('uiScale')).toBe(true);
+    expect(sliderCommitsOnRelease('playerFrameScale')).toBe(false);
+    expect(sliderCommitsOnRelease('renderScale')).toBe(false);
   });
 
   it('settingToggle flips 0<->1 off the stored value and reads on at >=0.5', () => {

--- a/tests/options_window.test.ts
+++ b/tests/options_window.test.ts
@@ -104,6 +104,18 @@ describe('options_window: control-primitive dispatch wiring', () => {
     // enumerated choice: the chosen option value verbatim
     expect(painter).toContain('hooks.onSettingChange(key, option.value)');
   });
+  it('buffers the UI scale slider until pointer release/change', () => {
+    const slider = painter.slice(
+      painter.indexOf('private settingSlider'),
+      painter.indexOf('private settingToggle'),
+    );
+    expect(slider).toContain('sliderCommitsOnRelease(key)');
+    expect(slider).toContain('pending_scale');
+    expect(slider).toContain('committed_scale');
+    expect(slider).toContain("slider.addEventListener('pointerup', commitBufferedValue)");
+    expect(slider).toContain("slider.addEventListener('change', commitBufferedValue)");
+    expect(slider).toContain('syncReadout(sliderDispatchValue(slider.value))');
+  });
 });
 
 describe('options_window: changeLanguage hardening (PR #730)', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to World of ClaudeCraft!

New here? The contributing guide is available in your language:
https://github.com/levy-street/world-of-claudecraft/blob/main/CONTRIBUTING.md

Filling this out helps reviewers understand and merge your work faster. Anything
that doesn't apply to your change, feel free to delete or mark as N/A.
-->

## Summary
This PR fixes an issue where dragging the UI scale slider caused a feedback loop of window resizing, leading to flickering and erratic slider behavior. 

I have implemented a **Buffered Update Pattern**:
- The slider now updates a transient state during the drag sequence (`pointermove`), allowing smooth thumb movement without triggering global layout changes.
- The authoritative `committed_scale` and final window resize are only triggered upon the `pointerup` event.

## Related issues
Fixes #1558

## Type of change
- [x] Bug fix

## How was this tested?

- **Commands:**
    - `npm test` (Verified that Vitest suite passes)
    - `npx tsc --noEmit` (Verified TypeScript typecheck is clean)
    - `npm run build` (Verified production client build succeeds)
- **Manual steps:**
    - Opened the options menu and interface menu.
    - Clicked and held the UI scale slider and moved it across various ranges.
    - Observed that the window remains stable during dragging and only resizes once the mouse is released.

## Screenshots / recordings

N/A

---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green. I added or updated tests for any `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and `npm run build:env` if I touched those.

### Cross-platform

- [x] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [x] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
