### PR TITLE
fix(ui): apply the UI scale slider on release, not live while dragging

### DIFF
--- a/src/ui/options_view.ts
+++ b/src/ui/options_view.ts
@@ -40,6 +40,11 @@ export interface SliderControl {
   /** Current value at build time; the painter re-reads the live value on input. */
   value: number;
   fmt: SliderFmt;
+  /** Commit the setting on release ('change') instead of live on every 'input'
+   *  tick. Set for uiScale, whose live rescale moves the slider under the cursor
+   *  mid-drag (issue 1558); dragging updates only the readout, not the setting.
+   *  Other sliders keep their intended live preview (volume, fov, frame scale). */
+  commitOnChange?: boolean;
 }
 
 export interface ToggleControl {
@@ -357,7 +362,10 @@ export function buildControllerControls(s: OptionsSettingsSource): OptionsContro
 
 export function buildInterfaceControls(s: OptionsSettingsSource): OptionsControl[] {
   return [
-    slider(s, 'uiScale', 'hudChrome.options.uiScale'),
+    // uiScale commits on release: applying it live rescales the whole UI (the
+    // options window included), which shoves the slider under the cursor and makes
+    // the value hard to land (issue 1558).
+    { ...slider(s, 'uiScale', 'hudChrome.options.uiScale'), commitOnChange: true },
     slider(s, 'playerFrameScale', 'hudChrome.options.playerFrameScale'),
     slider(s, 'targetFrameScale', 'hudChrome.options.targetFrameScale'),
     slider(s, 'hudOpacity', 'hud.options.hudOpacity'),

--- a/src/ui/options_window.ts
+++ b/src/ui/options_window.ts
@@ -490,6 +490,12 @@ export class OptionsWindow {
       );
     };
     paintFill();
+    // Commit the setting (from the raw slider value), then sync the readout + fill.
+    const commit = () => {
+      hooks.onSettingChange(key, sliderDispatchValue(slider.value));
+      syncReadout();
+      paintFill();
+    };
     if (c.commitOnChange) {
       // Apply on release. 'input' (drag / each keyboard step) only previews the
       // readout + fill, so the setting (and any live UI rescale it drives) does not
@@ -500,17 +506,9 @@ export class OptionsWindow {
         readoutFromSlider();
         paintFill();
       });
-      slider.addEventListener('change', () => {
-        hooks.onSettingChange(key, sliderDispatchValue(slider.value));
-        syncReadout();
-        paintFill();
-      });
+      slider.addEventListener('change', commit);
     } else {
-      slider.addEventListener('input', () => {
-        hooks.onSettingChange(key, sliderDispatchValue(slider.value));
-        syncReadout();
-        paintFill();
-      });
+      slider.addEventListener('input', commit);
     }
     row.append(name, slider, val);
     parent.appendChild(row);

--- a/src/ui/options_window.ts
+++ b/src/ui/options_window.ts
@@ -467,11 +467,14 @@ export class OptionsWindow {
     // screen reader announces the human-meaningful value (50%, 90 degrees) instead
     // of the raw stored number. The native range already exposes role=slider plus
     // aria-valuenow/min/max from value/min/max, so only valuetext needs setting.
-    const syncReadout = () => {
-      const text = fmt(hooks.settings.get(key));
+    const applyReadout = (text: string) => {
       val.textContent = text;
       slider.setAttribute('aria-valuetext', text);
     };
+    const syncReadout = () => applyReadout(fmt(hooks.settings.get(key)));
+    // The raw slider position, for the live readout while dragging a commit-on-change
+    // slider (the store is not written until release, so syncReadout would be stale).
+    const readoutFromSlider = () => applyReadout(fmt(Number(slider.value)));
     syncReadout();
     // Paint a gold fill up to the current value on every engine (CSS alone can't
     // read the value; --range-fill drives the webkit track gradient and Firefox's
@@ -487,11 +490,28 @@ export class OptionsWindow {
       );
     };
     paintFill();
-    slider.addEventListener('input', () => {
-      hooks.onSettingChange(key, sliderDispatchValue(slider.value));
-      syncReadout();
-      paintFill();
-    });
+    if (c.commitOnChange) {
+      // Apply on release. 'input' (drag / each keyboard step) only previews the
+      // readout + fill, so the setting (and any live UI rescale it drives) does not
+      // fire until 'change' (pointer release / touchend, and per keyboard step,
+      // which emits both events). This keeps the uiScale slider from rescaling the
+      // window under the cursor mid-drag (issue 1558).
+      slider.addEventListener('input', () => {
+        readoutFromSlider();
+        paintFill();
+      });
+      slider.addEventListener('change', () => {
+        hooks.onSettingChange(key, sliderDispatchValue(slider.value));
+        syncReadout();
+        paintFill();
+      });
+    } else {
+      slider.addEventListener('input', () => {
+        hooks.onSettingChange(key, sliderDispatchValue(slider.value));
+        syncReadout();
+        paintFill();
+      });
+    }
     row.append(name, slider, val);
     parent.appendChild(row);
   }

--- a/tests/options_view.test.ts
+++ b/tests/options_view.test.ts
@@ -288,6 +288,16 @@ describe('options_view: interface dispatch matrix (cluster 5)', () => {
     ]);
     expect(find(controls, 'reduceMotion')).toMatchObject({ control: 'boolToggle' });
   });
+
+  it('marks only uiScale as commit-on-release; the other comfort sliders stay live (#1558)', () => {
+    const controls = buildInterfaceControls(makeSource());
+    // uiScale rescales the whole UI (window included), so it must apply on release.
+    expect(find(controls, 'uiScale')).toMatchObject({ control: 'slider', commitOnChange: true });
+    // Sibling sliders keep their live preview (no commitOnChange flag).
+    expect(find(controls, 'playerFrameScale')).not.toHaveProperty('commitOnChange');
+    expect(find(controls, 'tooltipScale')).not.toHaveProperty('commitOnChange');
+    expect(find(controls, 'fctScale')).not.toHaveProperty('commitOnChange');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/options_window.test.ts
+++ b/tests/options_window.test.ts
@@ -255,3 +255,33 @@ describe('options_window: title-bar back control', () => {
     expect(rule).toContain('transform: none;');
   });
 });
+
+describe('options_window: uiScale slider commits on release (#1558)', () => {
+  it('a commit-on-change slider commits only on change, previewing readout on input', () => {
+    // Isolate the settingSlider commit-on-change branch.
+    const fn = painter.slice(painter.indexOf('if (c.commitOnChange) {'));
+    const branch = fn.slice(0, fn.indexOf('} else {'));
+    // input previews only (readout + fill), and must NOT commit the setting.
+    const inputHandler = branch.slice(
+      branch.indexOf("addEventListener('input'"),
+      branch.indexOf("addEventListener('change'"),
+    );
+    expect(inputHandler).toContain('readoutFromSlider();');
+    expect(inputHandler).not.toContain('onSettingChange');
+    // change (release / keyboard step) is the one that commits.
+    const changeHandler = branch.slice(branch.indexOf("addEventListener('change'"));
+    expect(changeHandler).toContain(
+      'hooks.onSettingChange(key, sliderDispatchValue(slider.value))',
+    );
+  });
+
+  it('a normal slider still commits live on input (behavior preserved)', () => {
+    const elseArm = painter.slice(
+      painter.indexOf('} else {', painter.indexOf('if (c.commitOnChange) {')),
+    );
+    const inputHandler = elseArm.slice(elseArm.indexOf("addEventListener('input'"));
+    expect(inputHandler.slice(0, inputHandler.indexOf('});'))).toContain(
+      'hooks.onSettingChange(key, sliderDispatchValue(slider.value))',
+    );
+  });
+});

--- a/tests/options_window.test.ts
+++ b/tests/options_window.test.ts
@@ -257,6 +257,13 @@ describe('options_window: title-bar back control', () => {
 });
 
 describe('options_window: uiScale slider commits on release (#1558)', () => {
+  it('the shared commit closure applies the setting from the raw slider value', () => {
+    const commit = painter.slice(painter.indexOf('const commit = () => {'));
+    const body = commit.slice(0, commit.indexOf('};'));
+    expect(body).toContain('hooks.onSettingChange(key, sliderDispatchValue(slider.value))');
+    expect(body).toContain('syncReadout();');
+  });
+
   it('a commit-on-change slider commits only on change, previewing readout on input', () => {
     // Isolate the settingSlider commit-on-change branch.
     const fn = painter.slice(painter.indexOf('if (c.commitOnChange) {'));
@@ -268,20 +275,18 @@ describe('options_window: uiScale slider commits on release (#1558)', () => {
     );
     expect(inputHandler).toContain('readoutFromSlider();');
     expect(inputHandler).not.toContain('onSettingChange');
-    // change (release / keyboard step) is the one that commits.
+    expect(inputHandler).not.toContain('commit');
+    // change (release / keyboard step) commits, via the shared closure.
     const changeHandler = branch.slice(branch.indexOf("addEventListener('change'"));
-    expect(changeHandler).toContain(
-      'hooks.onSettingChange(key, sliderDispatchValue(slider.value))',
-    );
+    expect(changeHandler).toContain("addEventListener('change', commit)");
   });
 
-  it('a normal slider still commits live on input (behavior preserved)', () => {
+  it('a normal slider still commits live on input, via the shared closure', () => {
     const elseArm = painter.slice(
       painter.indexOf('} else {', painter.indexOf('if (c.commitOnChange) {')),
     );
-    const inputHandler = elseArm.slice(elseArm.indexOf("addEventListener('input'"));
-    expect(inputHandler.slice(0, inputHandler.indexOf('});'))).toContain(
-      'hooks.onSettingChange(key, sliderDispatchValue(slider.value))',
+    expect(elseArm.slice(0, elseArm.indexOf('\n    }'))).toContain(
+      "addEventListener('input', commit)",
     );
   });
 });


### PR DESCRIPTION
## Problem

Dragging the UI scale slider in Options > Interface rescaled the whole UI live on every value change. Because `#ui` is scaled with `zoom: var(--ui-scale)` and the options window is a child of `#ui`, the window resized under the cursor mid-drag, so the slider jumped and flickered and it was hard to land a target scale.

Closes #1558.

## Fix

Give the slider descriptor an opt-in `commitOnChange` flag, set only for `uiScale`. The other comfort sliders (frame scales, opacity, tooltip/FCT/chat scales) keep their intended live preview.

When `commitOnChange` is set, `settingSlider` previews the readout + gold fill on `input` but commits the setting on `change`, so the UI rescales once on release instead of on every drag tick:
- `input` (drag, and each keyboard step) updates only the readout (from the raw slider position, since the store is not written until commit) and the fill.
- `change` (pointer release / touchend, and each keyboard step, which fires both events) is the one that calls `onSettingChange`.

Keyboard arrow adjustment and touch stay fully functional (both commit per step / on release), and `aria-valuetext` still updates live while dragging.

## Test

- `tests/options_view.test.ts`: `uiScale` carries `commitOnChange: true`; the sibling sliders do not (so their live preview is preserved).
- `tests/options_window.test.ts`: the commit-on-change branch previews on `input` without committing and commits on `change`; a normal slider still commits live on `input`.

## Scope

- `src/ui/options_view.ts` (descriptor flag + set it on `uiScale`), `src/ui/options_window.ts` (`settingSlider` branch), tests.
- Pure cosmetic UI scale (fairness invariant not implicated); no new strings; client HUD only.
