### PR TITLE
fix(ui): scale the world map with the UI scale setting

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -4157,7 +4157,12 @@
        past it above 100% (issue 1559). A px length zoom-scales exactly like the
        frame, so the map fills its window at every UI scale; the 100% look is
        unchanged. The mobile rule below overrides this with width 100% to fill the
-       responsive window. */
+       responsive window.
+       box-sizing: content-box so the 2px border sits OUTSIDE the 560 content box:
+       under the global border-box reset, a plain width:560px would make the content
+       box 556 and downscale the 560 backing (~0.7%). content-box keeps the content
+       box exactly 560, so the map stays a crisp 1:1 at 100%. */
+    box-sizing: content-box;
     width: 560px;
     height: 560px;
     border: 2px solid var(--border);

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -4150,6 +4150,16 @@
     align-items: center;
   }
   #map-canvas {
+    /* Authored display size matching the 560x560 backing store (index.html /
+       play.html). Without a CSS length the canvas box is a replaced intrinsic size,
+       which does NOT scale in lockstep with the window frame under the #ui
+       zoom var(--ui-scale): the map underfilled the frame below 100% and clipped
+       past it above 100% (issue 1559). A px length zoom-scales exactly like the
+       frame, so the map fills its window at every UI scale; the 100% look is
+       unchanged. The mobile rule below overrides this with width 100% to fill the
+       responsive window. */
+    width: 560px;
+    height: 560px;
     border: 2px solid var(--border);
     outline: 1px solid #000;
     border-radius: 4px;

--- a/tests/map_canvas_scale.test.ts
+++ b/tests/map_canvas_scale.test.ts
@@ -16,13 +16,17 @@ const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const componentsCss = readFileSync(join(root, 'src/styles/components.css'), 'utf8');
 const mobileCss = readFileSync(join(root, 'src/styles/hud.mobile.css'), 'utf8');
 const indexHtml = readFileSync(join(root, 'index.html'), 'utf8');
+const playHtml = readFileSync(join(root, 'play.html'), 'utf8');
 
 // The desktop #map-canvas rule block (components.css), up to its closing brace.
 const rule = componentsCss.slice(componentsCss.indexOf('#map-canvas {'));
 const desktopRule = rule.slice(0, rule.indexOf('}'));
 // The canvas backing store width from the markup (the pixel resolution the map
-// paints into): <canvas id="map-canvas" width="560" ...>.
-const backing = indexHtml.match(/id="map-canvas"[^>]*\bwidth="(\d+)"/);
+// paints into): <canvas id="map-canvas" width="560" ...>. Both game entries carry
+// their own canvas, so pin both so a drift in only one entry cannot slip through.
+const backingRe = /id="map-canvas"[^>]*\bwidth="(\d+)"/;
+const backing = indexHtml.match(backingRe);
+const playBacking = playHtml.match(backingRe);
 
 describe('map canvas scales with the UI scale (issue 1559)', () => {
   it('the desktop #map-canvas declares an explicit display size (not a replaced intrinsic size)', () => {
@@ -30,13 +34,22 @@ describe('map canvas scales with the UI scale (issue 1559)', () => {
     expect(desktopRule).toMatch(/\bheight:\s*\d+px/);
   });
 
-  it('the desktop display size is pinned to the canvas backing resolution', () => {
+  it('the desktop display size is pinned to the canvas backing resolution (both entries)', () => {
     expect(backing, 'could not read the #map-canvas backing width from index.html').toBeTruthy();
+    expect(playBacking, 'could not read the #map-canvas backing width from play.html').toBeTruthy();
     const backingPx = backing![1];
-    // CSS display size must equal the backing store, so the map stays 1:1 (no
-    // stretch) and a future change to one cannot silently diverge from the other.
+    // Both game entries must declare the same backing, and the CSS display size must
+    // equal it, so the map stays 1:1 (no stretch) and a future change to any one
+    // cannot silently diverge from the others.
+    expect(playBacking![1]).toBe(backingPx);
     expect(desktopRule).toContain(`width: ${backingPx}px`);
     expect(desktopRule).toContain(`height: ${backingPx}px`);
+  });
+
+  it('keeps the content box exactly the backing size (content-box, not the border-box reset)', () => {
+    // The global reset is border-box; a plain width:560px would shrink the content
+    // box by the 2px border and downscale the backing. content-box keeps it 1:1.
+    expect(desktopRule).toMatch(/\bbox-sizing:\s*content-box/);
   });
 
   it('mobile still overrides the canvas to fill its responsive window', () => {

--- a/tests/map_canvas_scale.test.ts
+++ b/tests/map_canvas_scale.test.ts
@@ -1,0 +1,46 @@
+// Regression for issue 1559: the world map did not scale with the UI-scale
+// setting. #ui is magnified by `zoom: var(--ui-scale)`, but the desktop
+// #map-canvas rule declared no display size, so its box was a replaced intrinsic
+// size (the 560x560 backing store) that did not scale in lockstep with the window
+// frame: the map underfilled the frame below 100% and clipped past it above 100%.
+// The fix gives the desktop canvas an authored px display size matching the
+// backing store, so it zoom-scales exactly like the frame. Guard that the desktop
+// canvas keeps an explicit size pinned to the backing attribute, and that mobile
+// keeps its fill-the-window override.
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const componentsCss = readFileSync(join(root, 'src/styles/components.css'), 'utf8');
+const mobileCss = readFileSync(join(root, 'src/styles/hud.mobile.css'), 'utf8');
+const indexHtml = readFileSync(join(root, 'index.html'), 'utf8');
+
+// The desktop #map-canvas rule block (components.css), up to its closing brace.
+const rule = componentsCss.slice(componentsCss.indexOf('#map-canvas {'));
+const desktopRule = rule.slice(0, rule.indexOf('}'));
+// The canvas backing store width from the markup (the pixel resolution the map
+// paints into): <canvas id="map-canvas" width="560" ...>.
+const backing = indexHtml.match(/id="map-canvas"[^>]*\bwidth="(\d+)"/);
+
+describe('map canvas scales with the UI scale (issue 1559)', () => {
+  it('the desktop #map-canvas declares an explicit display size (not a replaced intrinsic size)', () => {
+    expect(desktopRule).toMatch(/\bwidth:\s*\d+px/);
+    expect(desktopRule).toMatch(/\bheight:\s*\d+px/);
+  });
+
+  it('the desktop display size is pinned to the canvas backing resolution', () => {
+    expect(backing, 'could not read the #map-canvas backing width from index.html').toBeTruthy();
+    const backingPx = backing![1];
+    // CSS display size must equal the backing store, so the map stays 1:1 (no
+    // stretch) and a future change to one cannot silently diverge from the other.
+    expect(desktopRule).toContain(`width: ${backingPx}px`);
+    expect(desktopRule).toContain(`height: ${backingPx}px`);
+  });
+
+  it('mobile still overrides the canvas to fill its responsive window', () => {
+    const mobileRule = mobileCss.slice(mobileCss.indexOf('body.mobile-touch #map-canvas {'));
+    expect(mobileRule.slice(0, mobileRule.indexOf('}'))).toMatch(/\bwidth:\s*100%/);
+  });
+});


### PR DESCRIPTION
## Problem

The world map does not scale with the UI-scale setting. At 85% the map underfills its window (empty space on the right); at 140% nearly half the map is hidden behind the window border. At 100% it looks correct.

Closes #1559.

## Root cause

`#ui` is magnified by `zoom: var(--ui-scale)` (`src/styles/hud.css`), so everything under it, including the map window, scales with the setting. But the desktop `#map-canvas` rule (`src/styles/components.css`) declared no CSS display size, so the canvas box was a replaced *intrinsic* size (the `560x560` backing store from `index.html`/`play.html`). A replaced intrinsic size does not scale in lockstep with the window frame's shrink-to-fit box under `zoom`, so the content and frame diverge: smaller than the frame below 100%, larger (and clipped by the window's `overflow`) above 100%. Mobile already handles this (`body.mobile-touch #map-canvas { width: 100% }`); desktop was the outlier.

## Fix

Give the desktop canvas an authored px display size matching the backing store (`width: 560px; height: 560px`). A CSS px length is zoom-scaled by every engine exactly like the window frame's padding/border, so the map fills its window at all UI scales. The `100%` look is byte-identical (560px display == the intrinsic 560), and the map stays 1:1 (no DPR/backing change, per the canvas contract). The mobile `width: 100%` override is untouched.

## Test

`tests/map_canvas_scale.test.ts`: the desktop `#map-canvas` declares an explicit display size, that size is pinned to the canvas backing resolution (so CSS and backing cannot silently diverge), and mobile keeps its fill-the-window override.

## Verification note

This is a CSS-only layout fix reasoned from the source (the desktop rule missing the size that mobile has, and the reporter's screenshot dimensions showing frame height tracking the scale while width stayed constant). A quick Firefox pass at 85/100/140% to confirm the map fills the frame is still worth doing before merge; happy to attach screenshots if useful.

## Scope

- `src/styles/components.css` (desktop `#map-canvas` size), `tests/map_canvas_scale.test.ts`. No painter/render-loop change (the map core is already scale-agnostic); no per-frame budget impact.
