### PR TITLE
fix(render): flatten the corpse pick capsule so it stops phantom clicks

### DIFF
--- a/src/render/characters/anim_state.ts
+++ b/src/render/characters/anim_state.ts
@@ -52,3 +52,14 @@ export function locomotionTimeScale(
 function clamp(v: number, lo: number, hi: number): number {
   return Math.min(hi, Math.max(lo, v));
 }
+
+/** The vertical extent (scale.y) for an entity's click/pick proxy. The proxy is a
+ *  unit cylinder scaled to (radius*2, standHeight, radius*2) and rooted at the feet.
+ *  A living entity uses its full standing height; a dead (lying) one collapses to a
+ *  low, ground-hugging profile (roughly its own body width tall) so a near-eye click
+ *  behind or above the flat corpse no longer intersects an invisible upright column
+ *  (issue 1486), while the ground-level footprint stays clickable for looting. */
+export function pickProxyHeight(standHeight: number, radius: number, dead: boolean): number {
+  if (!dead) return standHeight;
+  return Math.min(standHeight, radius * 2);
+}

--- a/src/render/characters/visual.ts
+++ b/src/render/characters/visual.ts
@@ -11,6 +11,7 @@ import {
   type BaseState,
   desiredBaseState,
   locomotionTimeScale,
+  pickProxyHeight,
 } from './anim_state';
 import {
   applyMaterials,
@@ -69,6 +70,9 @@ export class CharacterVisual {
   readonly height: number;
   /** invisible capsule for picking (userData.entityId set by the renderer) */
   readonly clickProxy: THREE.Mesh;
+  /** click-capsule radius (measured body extent); the pick proxy's standing scale.y
+   *  is `height`, collapsed to a flat profile while dead (see enterDeath/revive). */
+  private readonly clickRadius: number;
 
   private def: VisualDef;
   private key: string;
@@ -181,6 +185,7 @@ export class CharacterVisual {
     // capsule from measured body extents — long/wide creatures (wolves,
     // dragons) were nearly unclickable with a height-derived sliver
     const r = prep.clickRadius;
+    this.clickRadius = r;
     this.clickProxy = new THREE.Mesh(clickGeo(), clickMat());
     this.clickProxy.scale.set(r * 2, this.height, r * 2);
     this.clickProxy.visible = false;
@@ -649,6 +654,13 @@ export class CharacterVisual {
     this.deadLock = true;
     this.currentIsOneShot = false;
     this.currentOneShotIsEmote = false;
+    // Collapse the upright pick capsule to a flat, ground-hugging profile so a
+    // near-eye click behind or above the now-lying corpse no longer intersects an
+    // invisible standing column (issue 1486). The ground-level footprint stays, so
+    // a lootable corpse remains clickable. Restored in revive(). Set here (not the
+    // per-frame update) since it only changes on the death/revive edge, and this
+    // runs on every enterDeath path including the created-already-dead snapshot.
+    this.clickProxy.scale.y = pickProxyHeight(this.height, this.clickRadius, true);
     const death = this.action(this.def.clips.death);
     if (!death) return;
     const prev = this.current;
@@ -674,6 +686,8 @@ export class CharacterVisual {
     this.deadLock = false;
     this.baseState = 'idle';
     this.currentOneShotIsEmote = false;
+    // Restore the upright pick capsule (the corpse-flatten from enterDeath).
+    this.clickProxy.scale.y = pickProxyHeight(this.height, this.clickRadius, false);
     const death = this.action(this.def.clips.death);
     if (death) death.stop();
     const flourish = this.action(this.def.clips.flourish);

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -5123,7 +5123,10 @@ export class Renderer {
       if (!e || (e.dead && !e.lootable)) continue;
       // A lying corpse (dead + lootable) has no upright body: collapse its sloppy
       // column to a ground-level point so a near-eye click above/behind the flat
-      // body no longer snaps to it (issue 1486), matching the flattened pick proxy.
+      // body no longer snaps to it (issue 1486). Like the flattened pick proxy, this
+      // sheds the upright column; the exact drop is approximate (a ground-level
+      // anchor inside the 26px assist radius is all this path needs), not a parity
+      // match of the proxy's min(standHeight, radius*2) height.
       const dead = !!e.dead;
       // body midpoint anchor (also the in-front-of-camera cull); ground-hug if dead
       this.tmpV.copy(v.group.position);

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -5121,9 +5121,13 @@ export class Renderer {
       if (id === this.sim.playerId || !v.visual || !v.group.visible) continue;
       const e = this.sim.entities.get(id);
       if (!e || (e.dead && !e.lootable)) continue;
-      // body midpoint anchor (also the in-front-of-camera cull)
+      // A lying corpse (dead + lootable) has no upright body: collapse its sloppy
+      // column to a ground-level point so a near-eye click above/behind the flat
+      // body no longer snaps to it (issue 1486), matching the flattened pick proxy.
+      const dead = !!e.dead;
+      // body midpoint anchor (also the in-front-of-camera cull); ground-hug if dead
       this.tmpV.copy(v.group.position);
-      this.tmpV.y += v.height * e.scale * 0.5;
+      this.tmpV.y += v.height * e.scale * (dead ? 0.15 : 0.5);
       this.tmpV.project(this.camera);
       if (this.tmpV.z > 1) continue;
       const midX = (this.tmpV.x * 0.5 + 0.5) * this.viewport.width;
@@ -5133,16 +5137,19 @@ export class Renderer {
       // front of the camera: a point behind the near plane projects to bogus
       // screen coords that could steal an unrelated click (close / first-person
       // camera puts the head behind the near plane). Same guard the real
-      // nameplate path uses before trusting its projection.
-      this.tmpV2.copy(v.group.position);
-      this.tmpV2.y += v.height * e.scale + 1.0;
+      // nameplate path uses before trusting its projection. A dead corpse has no
+      // overhead column at all, so keep top == mid (the ground point).
       let topX = midX;
       let topY = midY;
-      if (isProjectedNameplateAnchorVisible(this.camera, this.tmpV2, this.tmpV3)) {
-        this.tmpV2.project(this.camera);
-        if (this.tmpV2.z <= 1) {
-          topX = (this.tmpV2.x * 0.5 + 0.5) * this.viewport.width;
-          topY = (-this.tmpV2.y * 0.5 + 0.5) * this.viewport.height;
+      if (!dead) {
+        this.tmpV2.copy(v.group.position);
+        this.tmpV2.y += v.height * e.scale + 1.0;
+        if (isProjectedNameplateAnchorVisible(this.camera, this.tmpV2, this.tmpV3)) {
+          this.tmpV2.project(this.camera);
+          if (this.tmpV2.z <= 1) {
+            topX = (this.tmpV2.x * 0.5 + 0.5) * this.viewport.width;
+            topY = (-this.tmpV2.y * 0.5 + 0.5) * this.viewport.height;
+          }
         }
       }
       candidates.push({ id, midX, midY, topX, topY });

--- a/tests/locomotion.test.ts
+++ b/tests/locomotion.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
-  MOVE_HOLD_TIME, newLocoTrack, updateLocomotion,
-} from '../src/render/locomotion';
-import { desiredBaseState, locomotionTimeScale, type AnimState } from '../src/render/characters/anim_state';
+  type AnimState,
+  desiredBaseState,
+  locomotionTimeScale,
+  pickProxyHeight,
+} from '../src/render/characters/anim_state';
+import { MOVE_HOLD_TIME, newLocoTrack, updateLocomotion } from '../src/render/locomotion';
 
 const FPS = 1 / 60;
 const BASE_ANIM_STATE: AnimState = {
@@ -98,8 +101,41 @@ describe('locomotion animation state', () => {
   });
 
   it('reverses forward locomotion for Ghost Wolf-style backpedal', () => {
-    const state = { ...BASE_ANIM_STATE, moving: true, backwards: true, reverseBackpedal: true, speed: 7 };
+    const state = {
+      ...BASE_ANIM_STATE,
+      moving: true,
+      backwards: true,
+      reverseBackpedal: true,
+      speed: 7,
+    };
     expect(desiredBaseState(state, true)).toBe('run');
     expect(locomotionTimeScale('run', state)).toBeLessThan(0);
+  });
+});
+
+describe('pickProxyHeight (corpse pick-capsule flatten, issue 1486)', () => {
+  it('uses the full standing height while alive', () => {
+    expect(pickProxyHeight(1.8, 0.4, false)).toBe(1.8);
+    expect(pickProxyHeight(3.0, 1.2, false)).toBe(3.0);
+  });
+
+  it('collapses a dead entity to a low, ground-hugging profile well under standing height', () => {
+    // A humanoid: standing 1.8, radius 0.4 -> flat ~0.8, far below the upright column
+    // that caused the phantom hitbox.
+    const flat = pickProxyHeight(1.8, 0.4, true);
+    expect(flat).toBeLessThan(1.8);
+    expect(flat).toBe(0.8);
+  });
+
+  it('never exceeds the standing height for a wide, short creature', () => {
+    // radius*2 would be 2.4 but standing height is only 1.0: clamp to the height so
+    // the dead proxy is never TALLER than the living one.
+    expect(pickProxyHeight(1.0, 1.2, true)).toBe(1.0);
+  });
+
+  it('scales the flat profile with body radius (long/wide creatures stay clickable)', () => {
+    // A larger creature keeps a proportionally larger (but still sub-standing) flat
+    // footprint so its corpse is not an unclickable sliver.
+    expect(pickProxyHeight(3.0, 1.0, true)).toBe(2.0);
   });
 });


### PR DESCRIPTION
## Problem

In a near-eye/perspective camera, clicking the ground behind or "above" a downed NPC still triggered interactions with the corpse. The model correctly lies flat on death, but its invisible pick volume stayed a full-height standing cylinder, so a ray anywhere in that upright column selected the corpse. Most visible zoomed in, where the standing column is spatially distinct from the flat body.

Closes #1486.

## Layer

This is a render/interaction-layer issue, not sim. The sim has no per-entity movement collision (`src/sim/colliders.ts` is static-world only), so `handleDeath` has no collision volume to change and is correct as-is. The renderer's pick geometry is what stays upright. No determinism/parity surface is touched.

## Fix

Two pick paths select an entity; both treated a corpse as full standing height:

1. **Direct raycast proxy** (`clickProxy` in `visual.ts`): collapse its vertical extent to a low, ground-hugging profile on the death edge (`enterDeath`) and restore it on `revive`, via a new pure `pickProxyHeight()` in the three-free `characters/anim_state.ts` core. Set on the edge (not per-frame) and covers the created-already-dead snapshot path.
2. **Sloppy-pick assist** (`renderer.pick()`): the 26px screen-space fallback built a body-midpoint-to-overhead column for lootable corpses. For a dead entity it now hugs the ground and drops the overhead column, so a near-eye click above/behind the flat body no longer snaps to it.

The ground-level footprint is unchanged in both paths, so a lootable corpse stays clickable to loot; only the phantom upright column is removed.

## Test

`tests/locomotion.test.ts`: `pickProxyHeight` returns full standing height while alive, collapses well below it when dead, never exceeds standing height (wide/short creature), and scales the flat profile with body radius so large corpses stay clickable. (The `renderer.pick()` candidate build is WebGL-bound and follows the same dead-height rule; not unit-tested, consistent with the renderer's other pick code.)

## Scope

- `src/render/characters/anim_state.ts` (pure `pickProxyHeight`), `src/render/characters/visual.ts` (consume on death/revive), `src/render/renderer.ts` (sloppy-pick corpse column), `tests/locomotion.test.ts`.
