### PR TITLE
fix(sim): give the fishing-dock plank deck collision

### DIFF
--- a/src/sim/colliders.ts
+++ b/src/sim/colliders.ts
@@ -76,6 +76,15 @@ function rotY(lx: number, lz: number, rot: number): { x: number; z: number } {
   return { x: lx * c + lz * s, z: -lx * s + lz * c };
 }
 
+// Fishing-dock plank-deck collider footprint, in the dock's local frame (the
+// deck runs from the shore toward the water along local -z; see props.ts). The
+// deck sections sit at local z -1.05/-3.18/-5.31 and the on-deck props span x
+// -0.6..1.45, so one OBB centered mid-run covers the walkable planks + props.
+const DECK_LOCAL_X = 0.1;
+const DECK_LOCAL_Z = -3.2;
+const DECK_HALF_WIDTH = 1.4;
+const DECK_HALF_DEPTH = 3.3;
+
 // ---------------------------------------------------------------------------
 // Collider sets
 // ---------------------------------------------------------------------------
@@ -128,7 +137,7 @@ function staticWorldColliders(seed: number): Collider[] {
     out.push({ type: 'circle', x, z, r: 5, cameraTopY: topY(seed, x, z, 5.2), camGhost: true });
   }
 
-  // dock huts
+  // dock huts + the plank deck they sit on
   for (const d of PROPS.docks) {
     const hut = rotY(d.hutLocal.x, d.hutLocal.z, d.rot);
     const x = d.x + hut.x,
@@ -141,6 +150,26 @@ function staticWorldColliders(seed: number): Collider[] {
       hd: d.hutLocal.hd,
       rot: d.rot,
       cameraTopY: topY(seed, x, z, 2.9),
+      camGhost: true,
+    });
+    // The plank deck (props.ts draws three dockPlatform sections stepping toward
+    // the water along local -z, plus the barrels/crates on top) had no collider,
+    // so the player walked straight through the pier and its props (issue 1500).
+    // Emit one OBB spanning the deck run in the dock's local frame, so the deck is
+    // solid like every other structure. Both docks (zone1 + zone2) share this
+    // geometry, so this fixes both. Footprint tracks the rendered plank + prop
+    // extents (sections at local z -1.05/-3.18/-5.31, props at x -0.6..1.45).
+    const deck = rotY(DECK_LOCAL_X, DECK_LOCAL_Z, d.rot);
+    const dx = d.x + deck.x,
+      dz = d.z + deck.z;
+    out.push({
+      type: 'obb',
+      x: dx,
+      z: dz,
+      hw: DECK_HALF_WIDTH,
+      hd: DECK_HALF_DEPTH,
+      rot: d.rot,
+      cameraTopY: topY(seed, dx, dz, 1.2),
       camGhost: true,
     });
   }

--- a/tests/dock_collision.test.ts
+++ b/tests/dock_collision.test.ts
@@ -1,0 +1,59 @@
+// Regression for issue 1500: the fishing-dock plank deck had no collision, so the
+// player walked straight through the pier and the barrels/crates on it while every
+// other structure blocks. colliders.ts emitted only the dock hut OBB, never a deck
+// collider. Both docks (zone1 + zone2) share the deck geometry, so one derived
+// collider fixes both. This pins that the deck run is now solid, and that the
+// footprint is bounded (open water a couple yards past the far end stays walkable).
+import { afterEach, describe, expect, it } from 'vitest';
+import { isBlocked } from '../src/sim/colliders';
+import { BUILTIN_WORLD, setActiveWorldContent } from '../src/sim/data';
+
+const SEED = 20061;
+
+// Mirror colliders.ts rotY: rotate a local (lx,lz) offset by a rotation.y angle.
+function rotY(lx: number, lz: number, rot: number): { x: number; z: number } {
+  const c = Math.cos(rot);
+  const s = Math.sin(rot);
+  return { x: lx * c + lz * s, z: -lx * s + lz * c };
+}
+// World point for a dock-local offset.
+function dockLocal(
+  dock: { x: number; z: number; rot: number },
+  lx: number,
+  lz: number,
+): { x: number; z: number } {
+  const o = rotY(lx, lz, dock.rot);
+  return { x: dock.x + o.x, z: dock.z + o.z };
+}
+
+// The two docks from content (zone1.ts / zone2.ts); the deck-local mid-run point
+// matches DECK_LOCAL_X/Z in colliders.ts.
+const DOCKS = [
+  { x: -64, z: 60, rot: -2.2 }, // zone 1
+  { x: -66, z: 305, rot: 1.68 }, // zone 2 (Deepfen)
+];
+const DECK_LX = 0.1;
+const DECK_LZ = -3.2;
+
+describe('fishing dock deck collision (issue 1500)', () => {
+  afterEach(() => setActiveWorldContent(null));
+
+  it('blocks the plank deck at both docks (previously walk-through)', () => {
+    setActiveWorldContent(BUILTIN_WORLD);
+    for (const dock of DOCKS) {
+      const p = dockLocal(dock, DECK_LX, DECK_LZ);
+      expect(isBlocked(SEED, p.x, p.z), `deck of dock at ${dock.x},${dock.z}`).toBe(true);
+    }
+  });
+
+  it('does not block open water a couple yards past the deck far end (footprint bounded)', () => {
+    setActiveWorldContent(BUILTIN_WORLD);
+    for (const dock of DOCKS) {
+      // ~2.4u beyond the far deck-collider edge (DECK_LZ - halfDepth 3.3 = -6.5).
+      const past = dockLocal(dock, DECK_LX, -8.9);
+      expect(isBlocked(SEED, past.x, past.z), `past-deck of dock at ${dock.x},${dock.z}`).toBe(
+        false,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The pier at Deepfen shallows (with barrels/crates on top) had no collision: the character walks straight through it, while every other structure blocks. Expected: the pier is solid so the player can stand on it.

Closes #1500.

## Root cause

The dock is `src/sim/content` data rendered by `src/render/props.ts` (three `dockPlatform` deck sections stepping toward the water, plus a stone hut and barrels/crates). But `src/sim/colliders.ts` derived only the **hut** OBB from `PROPS.docks` in its docks loop; the plank deck and its props got no collider, so the deck was walk-through. The same asset is the zone-1 dock too.

## Fix

Emit one deck OBB per dock in the docks loop, in the dock's local frame, spanning the plank run (footprint tracks the rendered deck sections at local z -1.05/-3.18/-5.31 and the on-deck props at x -0.6..1.45). The deck is now solid like every other structure. Both docks share the geometry, so the single derived collider fixes both. The collision model is pure XZ push-out (there is no walkable-top surface anywhere in the engine), so "stand on it" resolves, as for every other structure, to a solid footprint you no longer clip through.

## Determinism / parity

Static geometry only: no rng draw, no tick-phase change. Colliders are rebuilt per (content, seed) and cached, so determinism and the three-host parity are unaffected. The renderer already samples the same `PROPS.docks`, so no `IWorld` change is needed; this closes the render/collision drift on the deck.

## Test

`tests/dock_collision.test.ts`: the deck mid-run point is now blocked at both docks (was walk-through), and open water a couple yards past the far deck edge stays walkable (the footprint is bounded, not an over-water lip).

## Note

The exact footprint (`DECK_HALF_WIDTH`/`DECK_HALF_DEPTH`, the local center) is derived from the rendered plank + prop extents; a quick in-game walk onto the Deepfen dock to confirm the collider matches the visible planks (no phantom lip over the water, no gap) is worth a look before merge. Happy to nudge the numbers with a screenshot if useful.

## Scope

- `src/sim/colliders.ts` (deck OBB in the docks loop + named footprint constants), `tests/dock_collision.test.ts`. Sim-side data; no render/UI/server change.
