### PR TITLE
ci(pr-ai): split the /review command so anyone can use it safely

### DIFF
--- a/.github/workflows/pr-ai.yml
+++ b/.github/workflows/pr-ai.yml
@@ -1,9 +1,8 @@
 name: PR AI assist
 
-# Two INFORMATIONAL, NON-BLOCKING jobs that help review a pull request, plus an on-demand
-# comment trigger for the second one. None of this is a required check; it assists
-# review, it does not gate merge. Lives in its own workflow so it never interferes with
-# the CI gate in ci.yml.
+# INFORMATIONAL, NON-BLOCKING jobs that help review a pull request, plus an on-demand
+# comment trigger. None of this is a required check; it assists review, it does not gate
+# merge. Lives in its own workflow so it never interferes with the CI gate in ci.yml.
 #
 #   screenshots        boots the Vite dev client headless and, ONLY when the diff has a
 #                       visual change, renders the sections it touches (a mapped window, or
@@ -14,16 +13,18 @@ name: PR AI assist
 #                       auth.json), and posts the review as a sticky PR comment. The
 #                       agent gets the PR HEAD checked out with dependencies installed
 #                       and is required to VERIFY before writing: read the tree, run
-#                       npx tsc --noEmit, run the vitest files covering the change.
-#                       No-ops without the secret (for example on a fork PR), so it
-#                       never blocks.
-#   ai-review-comment   on demand: ANYONE comments `/review` or `/suggest <focus>` on
-#                       the PR. Same verifying setup as ai-review (PR-head checkout +
-#                       deps), posting a fresh reply comment keyed to the triggering
-#                       comment rather than the sticky review above. Open to any
-#                       commenter by deliberate choice, including a fork PR's own author;
-#                       this runs that PR's code in a secret-holding job, so read the
-#                       security note on the job before relying on it.
+#                       npx tsc --noEmit, run the vitest files covering the change. Runs
+#                       only on the pull_request trigger, where a fork PR gets no secret
+#                       and the script no-ops, so it never runs fork code under the token.
+#   ai-review-comment-* on demand: ANYONE comments `/review` or `/suggest <focus>` on the
+#                       PR, including a fork PR's own author (no author_association gate).
+#                       Split in two so it can be open to everyone without running fork
+#                       code under the secret: the -verify job runs the PR's checks with
+#                       NO secret and emits only sanitized text; the -post job holds the
+#                       secret but never checks out or runs the PR's code, feeding Codex
+#                       only that text under a read-only, no-execute sandbox. It posts a
+#                       fresh reply comment keyed to the triggering comment, separate from
+#                       the sticky ai-review above. See the note on the jobs.
 #
 # Setup (one time): run `codex login` locally and store ~/.codex/auth.json in the
 # CODEX_AUTH_JSON repo secret to enable ai-review. Optionally set a CODEX_MODEL repo
@@ -39,9 +40,9 @@ on:
 # Needed to post the sticky review/screenshot comments and read the PR diff via the API.
 # Fork PRs get a read-only token on the pull_request trigger, so the comment steps
 # degrade to a no-op there (handled in the scripts). issue_comment always runs with the
-# base repo's token and secrets regardless of whose PR it is; ai-review-comment is
-# intentionally open to any commenter, so the security note on that job is the only thing
-# standing between a fork PR's code and the secret it runs under.
+# base repo's token and secrets regardless of whose PR it is; the on-demand command is
+# open to any commenter but split into a secret-less -verify job and a -post job that
+# never runs the PR's code, so no fork code executes under CODEX_AUTH_JSON.
 permissions:
   contents: read
   pull-requests: write
@@ -193,67 +194,60 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node scripts/ai_review.mjs
 
-  ai-review-comment:
-    name: AI review (comment command)
+  # The on-demand /review command is split into TWO jobs so it can be open to ANY
+  # commenter (no author_association gate) without ever running a fork's code in the
+  # job that holds CODEX_AUTH_JSON. See docs/ai-pr-bot.md.
+  #
+  #   ai-review-comment-verify  runs the PR's OWN code (i18n:gen, tsc, the covering
+  #                             tests) but has NO secret, so a fork author executing
+  #                             code here can steal nothing. It emits only sanitized
+  #                             TEXT (the diff plus the check output) as an artifact.
+  #   ai-review-comment-post    holds CODEX_AUTH_JSON but never checks out or runs the
+  #                             PR's code: it feeds Codex ONLY that text artifact, from
+  #                             an empty working dir under a read-only sandbox with an
+  #                             explicit "do not run anything" instruction. The only
+  #                             attacker-controlled input is text-as-data, so the
+  #                             residual surface is prompt injection, contained by the
+  #                             read-only sandbox, the minimal child env, and the
+  #                             output secret-redaction in ai_review.mjs.
+  ai-review-comment-verify:
+    name: AI review (verify, no secret)
     runs-on: ubuntu-latest
     # Any PR conversation comment (not a plain issue) starting with /review or /suggest,
-    # from ANY commenter. There is no author_association gate: a fork PR's own author,
-    # or any drive-by GitHub account, can trigger this on their own comment. This is a
-    # deliberate choice to let every contributor self-serve a review.
-    #
-    # SECURITY TRADEOFF, deliberate and now UNGATED: this job checks out and exercises
-    # the PR's own code (i18n:gen, and the tests the agent runs) in a job that holds
-    # CODEX_AUTH_JSON, so anyone who can open a PR can cause that PR's code to run here.
-    # Mitigations: the REVIEWER SCRIPTS run from a trusted default-branch checkout while
-    # the PR head sits in a separate pr/ tree (so a fork cannot swap ai_review.mjs itself
-    # and read the secret), npm ci --ignore-scripts (no third-party install hooks), the
-    # raw secret is scrubbed from the agent's child environment (ai_review.mjs), and
-    # GITHUB_TOKEN carries only contents:read + pull-requests:write. Residual risk, larger
-    # now that anyone can trigger: code the agent chooses to execute (the PR's tests) runs
-    # inside the job. If the CODEX_AUTH_JSON token is ever suspected leaked, refresh it
-    # (docs/ai-pr-bot.md) and consider restoring an author_association gate here.
+    # from ANY commenter, including a fork PR's own author. Safe to leave ungated because
+    # this job holds no secret; the secret-bearing post job below consumes only its text.
     if: >
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
       (startsWith(github.event.comment.body, '/review') || startsWith(github.event.comment.body, '/suggest'))
-    timeout-minutes: 35
+    timeout-minutes: 25
     steps:
-      # Trusted copy of the reviewer tooling: the default branch of the base repo. The
-      # secret-holding step below runs scripts from HERE, never from the PR's tree.
-      - name: Check out trusted reviewer code
-        uses: actions/checkout@v6
-
-      # The PR head, in its own subdirectory: the tree the agent verifies (and whose
-      # tests it may run), kept apart from the code that handles the secret.
+      # The PR head is the ONLY thing this job checks out, and this job has no secret,
+      # so running its code (i18n:gen, tsc, tests) exposes nothing. persist-credentials:
+      # false keeps even the ephemeral GITHUB_TOKEN out of .git/config so fork code cannot
+      # read it back; the base branch is fetched anonymously below (public repo).
       - name: Check out the PR head
         uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
           fetch-depth: 0
-          path: pr
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: pr/package-lock.json
-
-      - name: Install the Codex CLI
-        run: npm install -g @openai/codex
 
       - name: Install PR dependencies
-        working-directory: pr
         run: npm ci --ignore-scripts
 
       - name: Generate i18n artifacts
-        working-directory: pr
         run: npm run i18n:gen
 
-      # The issue_comment payload has no base/head SHAs; resolve them so the agent can
-      # read the full diff via git.
+      # The issue_comment payload has no base/head SHAs; resolve them from the API. This
+      # is the only step that gets the (read-only) token, and it runs no PR code.
       - name: Resolve the PR base and head
-        working-directory: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -262,14 +256,96 @@ jobs:
           echo "BASE_SHA=$(git merge-base "origin/$BASE_REF" HEAD)" >> "$GITHUB_ENV"
           echo "HEAD_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
 
-      - name: Review with Codex
+      # Everything below runs the PR's code but has NO token/secret in its env (secrets
+      # are only injected where referenced, and these steps reference none), so fork code
+      # cannot exfiltrate anything. Failures are captured as text, never fail the job:
+      # a red tsc or a failing test is a finding for the reviewer, not a reason to abort.
+      - name: Compute the diff and run the project checks
+        env:
+          BASE_SHA: ${{ env.BASE_SHA }}
+          HEAD_SHA: ${{ env.HEAD_SHA }}
+        run: |
+          mkdir -p review-input
+          git diff --no-color "$BASE_SHA" "$HEAD_SHA" > review-input/pr.diff || true
+          echo "diff bytes: $(wc -c < review-input/pr.diff)"
+
+          VERIFY=review-input/verify.txt
+          : > "$VERIFY"
+
+          echo "== tsc --noEmit ==" >> "$VERIFY"
+          npx tsc --noEmit >> "$VERIFY" 2>&1 && echo "(tsc: clean)" >> "$VERIFY" || echo "(tsc: reported errors above)" >> "$VERIFY"
+          echo "" >> "$VERIFY"
+
+          # Targeted tests: the test files the diff touches, plus the sim guard when the
+          # diff touches src/sim/. Keeps this fast and mirrors the old agent's scope; CI
+          # (ci.yml) still runs the full suite on the PR regardless.
+          CHANGED="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          TESTS="$(echo "$CHANGED" | grep -E '^tests/.*\.test\.ts$' || true)"
+          if echo "$CHANGED" | grep -q '^src/sim/'; then
+            TESTS="$(printf '%s\ntests/architecture.test.ts\n' "$TESTS")"
+          fi
+          TESTS="$(echo "$TESTS" | sort -u | grep -E '\.test\.ts$' || true)"
+          echo "== vitest (targeted) ==" >> "$VERIFY"
+          if [ -n "$TESTS" ]; then
+            echo "files: $(echo "$TESTS" | tr '\n' ' ')" >> "$VERIFY"
+            # shellcheck disable=SC2086
+            npx vitest run --reporter=dot $TESTS >> "$VERIFY" 2>&1 || echo "(vitest: failures reported above)" >> "$VERIFY"
+          else
+            echo "(no covering test files changed; the full suite runs in CI)" >> "$VERIFY"
+          fi
+
+      - name: Upload the sanitized review input
+        uses: actions/upload-artifact@v4
+        with:
+          name: ai-review-input
+          path: review-input/
+          retention-days: 1
+
+  ai-review-comment-post:
+    name: AI review (post, secret)
+    runs-on: ubuntu-latest
+    needs: ai-review-comment-verify
+    timeout-minutes: 20
+    steps:
+      # ONLY the trusted base-repo tooling is checked out. The PR's code is never present
+      # in this job; the secret-bearing Codex step reads solely the text artifact below.
+      - name: Check out trusted reviewer code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install the Codex CLI
+        run: npm install -g @openai/codex
+
+      - name: Download the sanitized review input
+        uses: actions/download-artifact@v4
+        with:
+          name: ai-review-input
+          path: review-input
+
+      # An EMPTY scratch dir is the agent's workspace: there is no code tree to read and
+      # no PR file to execute. Combined with the read-only sandbox and the no-execute
+      # prompt (REVIEW_NO_EXECUTE), the agent only reasons over the provided text.
+      - name: Prepare an empty agent workspace
+        run: |
+          EMPTY="$(mktemp -d)"
+          echo "AGENT_CWD=$EMPTY" >> "$GITHUB_ENV"
+
+      - name: Review with Codex (no execution)
         env:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           CODEX_MODEL: ${{ vars.CODEX_MODEL }}
-          # Same rationale as the automatic job: the runner VM is the isolation boundary.
-          CODEX_SANDBOX: danger-full-access
-          # The agent works inside the PR tree; the script itself is the trusted copy.
-          REVIEW_CWD: ${{ github.workspace }}/pr
+          # Read-only: the agent must not run the PR's (absent) code; if it tries a
+          # command it is blocked. It only needs to emit text, so this fails closed safely.
+          CODEX_SANDBOX: read-only
+          # Static review: do not read a tree, do not run commands, reason over the text.
+          REVIEW_NO_EXECUTE: '1'
+          REVIEW_CWD: ${{ env.AGENT_CWD }}
+          DIFF_FILE: ${{ github.workspace }}/review-input/pr.diff
+          VERIFY_FILE: ${{ github.workspace }}/review-input/verify.txt
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/pr-ai.yml
+++ b/.github/workflows/pr-ai.yml
@@ -17,12 +17,13 @@ name: PR AI assist
 #                       npx tsc --noEmit, run the vitest files covering the change.
 #                       No-ops without the secret (for example on a fork PR), so it
 #                       never blocks.
-#   ai-review-comment   on demand: an OWNER/MEMBER/COLLABORATOR comments `/review` or
-#                       `/suggest <focus>` on the PR. Same verifying setup as ai-review
-#                       (PR-head checkout + deps), posting a fresh reply comment keyed
-#                       to the triggering comment rather than the sticky review above.
-#                       Running a fork PR's code here is a deliberate maintainer opt-in;
-#                       see the security note on the job.
+#   ai-review-comment   on demand: ANYONE comments `/review` or `/suggest <focus>` on
+#                       the PR. Same verifying setup as ai-review (PR-head checkout +
+#                       deps), posting a fresh reply comment keyed to the triggering
+#                       comment rather than the sticky review above. Open to any
+#                       commenter by deliberate choice, including a fork PR's own author;
+#                       this runs that PR's code in a secret-holding job, so read the
+#                       security note on the job before relying on it.
 #
 # Setup (one time): run `codex login` locally and store ~/.codex/auth.json in the
 # CODEX_AUTH_JSON repo secret to enable ai-review. Optionally set a CODEX_MODEL repo
@@ -38,8 +39,9 @@ on:
 # Needed to post the sticky review/screenshot comments and read the PR diff via the API.
 # Fork PRs get a read-only token on the pull_request trigger, so the comment steps
 # degrade to a no-op there (handled in the scripts). issue_comment always runs with the
-# base repo's token and secrets regardless of whose PR it is, which is why
-# ai-review-comment additionally gates on the commenter's author_association.
+# base repo's token and secrets regardless of whose PR it is; ai-review-comment is
+# intentionally open to any commenter, so the security note on that job is the only thing
+# standing between a fork PR's code and the secret it runs under.
 permissions:
   contents: read
   pull-requests: write
@@ -194,25 +196,25 @@ jobs:
   ai-review-comment:
     name: AI review (comment command)
     runs-on: ubuntu-latest
-    # Only a PR conversation comment (not a plain issue), starting with /review or
-    # /suggest, from someone with write access to THIS repo. author_association is
-    # evaluated against the base repo regardless of whether the PR itself is from a
-    # fork, so a fork PR's own author cannot self-trigger this on their own comment.
+    # Any PR conversation comment (not a plain issue) starting with /review or /suggest,
+    # from ANY commenter. There is no author_association gate: a fork PR's own author,
+    # or any drive-by GitHub account, can trigger this on their own comment. This is a
+    # deliberate choice to let every contributor self-serve a review.
     #
-    # SECURITY TRADEOFF, deliberate: this job checks out and exercises the PR's own code
-    # (i18n:gen, and the tests the agent runs) in a job that holds CODEX_AUTH_JSON, so a
-    # maintainer typing /review on a fork PR is explicitly opting in to running that
-    # fork's code. Mitigations: the REVIEWER SCRIPTS run from a trusted default-branch
-    # checkout while the PR head sits in a separate pr/ tree (so a fork cannot swap
-    # ai_review.mjs itself and read the secret), npm ci --ignore-scripts (no third-party
-    # install hooks), the raw secret is scrubbed from the agent's child environment
-    # (ai_review.mjs), and GITHUB_TOKEN carries only contents:read + pull-requests:write.
-    # Residual risk: code the agent chooses to execute (the PR's tests) runs inside the
-    # job; skim a fork PR's diff before requesting a review on it.
+    # SECURITY TRADEOFF, deliberate and now UNGATED: this job checks out and exercises
+    # the PR's own code (i18n:gen, and the tests the agent runs) in a job that holds
+    # CODEX_AUTH_JSON, so anyone who can open a PR can cause that PR's code to run here.
+    # Mitigations: the REVIEWER SCRIPTS run from a trusted default-branch checkout while
+    # the PR head sits in a separate pr/ tree (so a fork cannot swap ai_review.mjs itself
+    # and read the secret), npm ci --ignore-scripts (no third-party install hooks), the
+    # raw secret is scrubbed from the agent's child environment (ai_review.mjs), and
+    # GITHUB_TOKEN carries only contents:read + pull-requests:write. Residual risk, larger
+    # now that anyone can trigger: code the agent chooses to execute (the PR's tests) runs
+    # inside the job. If the CODEX_AUTH_JSON token is ever suspected leaked, refresh it
+    # (docs/ai-pr-bot.md) and consider restoring an author_association gate here.
     if: >
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
       (startsWith(github.event.comment.body, '/review') || startsWith(github.event.comment.body, '/suggest'))
     timeout-minutes: 35
     steps:

--- a/docs/ai-pr-bot.md
+++ b/docs/ai-pr-bot.md
@@ -44,8 +44,8 @@ them is a required check.
    `scripts/gh_sticky_comment.mjs`. No new npm dependencies in the repo: the workflow
    installs `@openai/codex` globally on the runner, and the GitHub side is Node's
    built-in `fetch` against the REST API.
-3. **AI review on demand** (`ai-review-comment` job). An OWNER, MEMBER, or COLLABORATOR
-   of this repo can comment `/review` or `/suggest <focus>` on a PR (for example
+3. **AI review on demand** (`ai-review-comment` job). Anyone can comment `/review` or
+   `/suggest <focus>` on a PR (for example
    `/suggest check the null handling around the new cache`) to re-run the same reviewer
    whenever they want, optionally pointed at a specific concern. It runs the same
    `scripts/ai_review.mjs` with the same PR-head checkout and verification setup, and
@@ -84,21 +84,24 @@ opt-in and authenticates with a ChatGPT account through OAuth, not an API key:
 Comment `/review` on a PR to re-run the reviewer over the current state of the PR, or
 `/suggest <focus>` to ask it to prioritize something specific (the rest of the comment
 after the command is passed to the model as the thing to focus on; it still mentions
-other high-confidence findings). Only comments from an OWNER, MEMBER, or COLLABORATOR of
-this repo trigger it, checked against this repo regardless of whose PR it is, so a first-
-time contributor cannot self-trigger it on their own fork PR by commenting on it.
+other high-confidence findings). There is no author_association gate: any commenter can
+trigger it, including a first-time contributor on their own fork PR. This is a deliberate
+choice so every contributor can self-serve a review without waiting on a maintainer.
 
-Know what you are opting into on a FORK PR: unlike the old diff-only reviewer, this job
-checks out the fork's code and exercises it (the i18n generation step, and whatever tests
-the agent runs), in a job that holds the `CODEX_AUTH_JSON` secret. The mitigations are
+Know what that opens up on a FORK PR: unlike the old diff-only reviewer, this job checks
+out the fork's code and exercises it (the i18n generation step, and whatever tests the
+agent runs), in a job that holds the `CODEX_AUTH_JSON` secret. Because the trigger is
+ungated, anyone who can open a PR can cause that code to run here. The mitigations are
 real but not absolute: the reviewer scripts themselves run from a TRUSTED default-branch
 checkout while the PR head sits in a separate `pr/` tree (so a fork cannot replace
 `ai_review.mjs` and read the secret from inside the secret-holding step),
 `npm ci --ignore-scripts` keeps third-party install hooks from running, the raw secret is
 scrubbed from the agent's child environment (only the materialized `CODEX_HOME/auth.json`
 exists, in a throwaway temp dir), and the `GITHUB_TOKEN` carries only `contents: read`
-plus `pull-requests: write`. Skim a fork PR's diff for anything that reads credentials or
-phones home before typing `/review` on it; for same-repo PRs there is no new exposure.
+plus `pull-requests: write`. Residual risk is that the code the agent chooses to run (the
+PR's tests) executes inside the secret-holding job. If the `CODEX_AUTH_JSON` token is ever
+suspected leaked, refresh it (see the setup note) and consider restoring the
+author_association gate on the `ai-review-comment` job.
 
 ## Privacy: read before enabling on private code
 
@@ -121,9 +124,9 @@ is skipped entirely (the frames exist only in the job log's capture output).
 The on-demand `/review` and `/suggest` comment trigger is different: `issue_comment`
 always runs with full repo secrets, regardless of whether the PR is from a fork, and it
 checks out and exercises the PR's own code so the agent can verify it. That combination
-is gated on the commenter's `author_association` with this repo, not the PR's origin,
-and is a deliberate maintainer opt-in with documented mitigations (see "Requesting a
-review on demand" above).
+is intentionally ungated: any commenter can trigger it on any PR, including a fork PR's
+own author. The documented mitigations (see "Requesting a review on demand" above) are
+what contain the residual risk of running fork code under the secret.
 
 ## Running the screenshot capture locally
 

--- a/docs/ai-pr-bot.md
+++ b/docs/ai-pr-bot.md
@@ -44,13 +44,15 @@ them is a required check.
    `scripts/gh_sticky_comment.mjs`. No new npm dependencies in the repo: the workflow
    installs `@openai/codex` globally on the runner, and the GitHub side is Node's
    built-in `fetch` against the REST API.
-3. **AI review on demand** (`ai-review-comment` job). Anyone can comment `/review` or
-   `/suggest <focus>` on a PR (for example
-   `/suggest check the null handling around the new cache`) to re-run the same reviewer
-   whenever they want, optionally pointed at a specific concern. It runs the same
-   `scripts/ai_review.mjs` with the same PR-head checkout and verification setup, and
-   posts its answer as a fresh reply comment rather than editing the standing sticky
-   review, so a one-off question does not overwrite it.
+3. **AI review on demand** (`ai-review-comment-verify` + `ai-review-comment-post` jobs).
+   Anyone can comment `/review` or `/suggest <focus>` on a PR (for example
+   `/suggest check the null handling around the new cache`) to re-run the reviewer
+   whenever they want, optionally pointed at a specific concern. It is split into two
+   jobs so it can be open to every commenter without ever running a fork's code under the
+   secret (see "Requesting a review on demand" below): a secret-less verify job runs the
+   PR's checks and emits only sanitized text, and a post job feeds that text to
+   `scripts/ai_review.mjs` in no-execute mode and posts a fresh reply comment rather than
+   editing the standing sticky review, so a one-off question does not overwrite it.
 
 ## Enabling the AI review
 
@@ -88,20 +90,31 @@ other high-confidence findings). There is no author_association gate: any commen
 trigger it, including a first-time contributor on their own fork PR. This is a deliberate
 choice so every contributor can self-serve a review without waiting on a maintainer.
 
-Know what that opens up on a FORK PR: unlike the old diff-only reviewer, this job checks
-out the fork's code and exercises it (the i18n generation step, and whatever tests the
-agent runs), in a job that holds the `CODEX_AUTH_JSON` secret. Because the trigger is
-ungated, anyone who can open a PR can cause that code to run here. The mitigations are
-real but not absolute: the reviewer scripts themselves run from a TRUSTED default-branch
-checkout while the PR head sits in a separate `pr/` tree (so a fork cannot replace
-`ai_review.mjs` and read the secret from inside the secret-holding step),
-`npm ci --ignore-scripts` keeps third-party install hooks from running, the raw secret is
-scrubbed from the agent's child environment (only the materialized `CODEX_HOME/auth.json`
-exists, in a throwaway temp dir), and the `GITHUB_TOKEN` carries only `contents: read`
-plus `pull-requests: write`. Residual risk is that the code the agent chooses to run (the
-PR's tests) executes inside the secret-holding job. If the `CODEX_AUTH_JSON` token is ever
-suspected leaked, refresh it (see the setup note) and consider restoring the
-author_association gate on the `ai-review-comment` job.
+That is safe to leave open to everyone because the command is split into two jobs so a
+fork's code never runs in the job that holds the secret:
+
+- **`ai-review-comment-verify`** has NO secret. It checks out the PR head, installs deps
+  with `npm ci --ignore-scripts`, generates i18n artifacts, computes the diff, and runs
+  the project's own checks (`tsc --noEmit`, plus the vitest files the diff touches and the
+  sim guard when `src/sim/` changed). This is the only place the PR's code executes, and
+  because the job holds no token there is nothing for that code to steal (secrets are
+  injected only into steps that reference them, and the check steps reference none). It
+  uploads only sanitized TEXT (the diff and the check output) as a workflow artifact.
+- **`ai-review-comment-post`** holds `CODEX_AUTH_JSON` but never checks out or runs the
+  PR's code. It checks out only the trusted base-repo tooling, downloads the text
+  artifact, and runs `scripts/ai_review.mjs` in no-execute mode (`REVIEW_NO_EXECUTE=1`)
+  from an empty working directory under a `read-only` sandbox, with a prompt that forbids
+  running commands or reading files. Codex reviews the diff and the pre-computed check
+  output as text-as-data and posts the reply.
+
+The only attacker-controlled input reaching the secret-bearing job is that text, so the
+remaining surface is prompt injection (a diff that tries to talk the model into leaking
+the token), contained by the read-only sandbox, the minimal child environment that never
+exposes `GITHUB_TOKEN` or the raw `CODEX_AUTH_JSON` (`codexChildEnv`), and the output
+secret-redaction (`redactSecrets`) before anything is posted. Defense in depth worth
+adding: point `CODEX_AUTH_JSON` at a dedicated throwaway ChatGPT account rather than a
+personal one, so a leak is contained. If the token is ever suspected leaked, refresh it
+(see the setup note).
 
 ## Privacy: read before enabling on private code
 
@@ -122,11 +135,12 @@ neither host the images nor post a comment at all, so on a fork PR the screensho
 is skipped entirely (the frames exist only in the job log's capture output).
 
 The on-demand `/review` and `/suggest` comment trigger is different: `issue_comment`
-always runs with full repo secrets, regardless of whether the PR is from a fork, and it
-checks out and exercises the PR's own code so the agent can verify it. That combination
-is intentionally ungated: any commenter can trigger it on any PR, including a fork PR's
-own author. The documented mitigations (see "Requesting a review on demand" above) are
-what contain the residual risk of running fork code under the secret.
+always runs with full repo secrets, regardless of whether the PR is from a fork. It is
+intentionally ungated (any commenter, any PR, including a fork PR's own author), and it is
+split so the secret never meets the fork's code: the `-verify` job runs that code with no
+secret, and the `-post` job that holds the secret only reviews the resulting text and
+never runs the PR's code. See "Requesting a review on demand" above for the full split and
+its remaining prompt-injection surface.
 
 ## Running the screenshot capture locally
 

--- a/scripts/ai_review.mjs
+++ b/scripts/ai_review.mjs
@@ -7,11 +7,16 @@
 // installed by the workflow, and the GitHub side is plain REST via global fetch.
 //
 // Two ways to trigger it (both wired in .github/workflows/pr-ai.yml):
-//   - automatically on every push to the PR: DIFF_FILE points at a precomputed diff.
-//   - on demand: an OWNER/MEMBER/COLLABORATOR comments `/review` or `/suggest <focus>`
-//     on the PR. The workflow gates on the commenter's author_association, checks out
-//     the PR head the same way, and posts a fresh reply comment keyed to the triggering
-//     comment, separate from the sticky automatic review.
+//   - automatically on every push to the PR (ai-review job): DIFF_FILE points at a
+//     precomputed diff and the agent VERIFIES against a full PR-HEAD checkout (executing
+//     mode). Runs only on the pull_request trigger, so a fork PR gets no secret and this
+//     script no-ops instead of running fork code under the token.
+//   - on demand, open to ANY commenter (`/review` or `/suggest <focus>`): split across
+//     two jobs so no fork code runs under the secret. A secret-less -verify job runs the
+//     PR's tsc/vitest and writes the results to VERIFY_FILE; this script then runs in the
+//     secret-bearing -post job with REVIEW_NO_EXECUTE=1, which FORBIDS running anything
+//     and reviews only the inlined diff plus that VERIFY_FILE text. It posts a fresh
+//     reply comment keyed to the triggering comment, separate from the sticky review.
 //
 // AUTH (ChatGPT OAuth): run `codex login` once locally, which stores OAuth tokens in
 // ~/.codex/auth.json. In CI, put that file's contents in the CODEX_AUTH_JSON repo
@@ -33,6 +38,12 @@
 //   PR_NUMBER           the pull request number
 //   DIFF_FILE           path to a precomputed unified diff (automatic run); when absent,
 //                       the diff is fetched from the GitHub API instead (comment run)
+//   REVIEW_NO_EXECUTE   when '1', static mode: no code tree, no commands, review the diff
+//                       plus VERIFY_FILE only. Set by the /review comment's -post job so
+//                       the PR's code never runs in the secret-bearing job.
+//   VERIFY_FILE         path to the pre-computed check output (tsc + covering vitest) that
+//                       the secret-less -verify job produced; embedded in the prompt in
+//                       no-execute mode
 //   COMMENT_BODY        the triggering comment's body (comment run only)
 //   COMMENT_ID          the triggering comment's id; keys its reply comment
 //   COMMENT_AUTHOR      the triggering comment's author; credited in the reply
@@ -82,6 +93,13 @@ const GITHUB_API = process.env.GITHUB_API_URL ?? 'https://api.github.com';
 const BASE_SHA = process.env.BASE_SHA || '';
 const HEAD_SHA = process.env.HEAD_SHA || '';
 const REVIEW_CWD = process.env.REVIEW_CWD || process.cwd();
+// No-execute (static) mode: the comment-command flow runs the PR's checks in a separate,
+// secret-less job and hands this step ONLY the resulting text (the diff plus VERIFY_FILE).
+// Here the agent has no code tree and must not run anything; it reasons over that text.
+// This is what lets the /review command be open to any commenter without a fork's code
+// ever executing in the job that holds CODEX_AUTH_JSON.
+const NO_EXECUTE = process.env.REVIEW_NO_EXECUTE === '1';
+const VERIFY_FILE = process.env.VERIFY_FILE || '';
 
 const prNumber = process.env.PR_NUMBER;
 const diffFile = process.env.DIFF_FILE;
@@ -173,13 +191,24 @@ if (!diff.trim()) {
   process.exit(0);
 }
 
-// Codex runs as a verifying agent over a full checkout of the PR HEAD with dependencies
-// installed (the workflow runs npm ci + i18n:gen first), so the prompt demands evidence:
-// read the tree, run the typecheck, run the tests that cover the change, and only then
-// write the review. The inlined diff below is filtered (no generated/binary churn) and
-// capped; the agent reads the full diff itself via git when it needs more.
-const gitDiffHint =
-  BASE_SHA && HEAD_SHA
+// The reviewer runs in one of two modes. Executing mode (default: the automatic ai-review
+// job and local runs) gets a full PR-HEAD checkout and is told to VERIFY by reading the
+// tree and running tsc/vitest. No-execute mode (the /review comment command) has no tree:
+// a separate secret-less job already ran those checks, so the agent is FORBIDDEN to run
+// anything and reasons only over the inlined diff and the provided check output.
+let verifyText = '';
+if (NO_EXECUTE && VERIFY_FILE) {
+  try {
+    verifyText = fs.readFileSync(VERIFY_FILE, 'utf8').trim();
+  } catch {
+    console.log(`[ai_review] could not read VERIFY_FILE=${VERIFY_FILE}; proceeding without it.`);
+  }
+}
+
+const gitDiffHint = NO_EXECUTE
+  ? `You do NOT have a code tree and cannot run git; the inlined diff below (filtered of
+generated/binary files, possibly capped) plus the pre-computed check output are your only sources.`
+  : BASE_SHA && HEAD_SHA
     ? `The checkout is the PR HEAD (${HEAD_SHA.slice(0, 10)}). The full, unfiltered diff is available
 locally: \`git diff --no-color ${BASE_SHA} ${HEAD_SHA}\` (also \`git log ${BASE_SHA}..${HEAD_SHA}\`
 for the commits). The inlined diff below omits generated/binary files and may be capped; consult
@@ -187,7 +216,21 @@ git whenever you need the complete picture.`
     : `The checkout may be the PR's BASE branch, so a file the diff itself adds may exist only in the
 diff text; that is expected, never a finding.`;
 
-const prompt = `You are a thorough, constructive senior code reviewer for World of ClaudeCraft, a TypeScript
+// In no-execute mode there is no tree and no commands: the "verify" step is replaced by
+// the pre-computed check output, and the agent is told not to run anything.
+const preamble = NO_EXECUTE
+  ? `You are reviewing a pull request from its diff and the output of the project's own checks that
+were ALREADY RUN for you (in a separate, isolated job). ${gitDiffHint}
+
+DO NOT RUN ANYTHING. You have no repository checkout, no network, and no shell to trust: do not run
+commands, do not read files, do not fetch anything. Ground the review ONLY in the inlined diff and
+the check output provided below. If the diff plus that output is not enough to be sure of a finding,
+downgrade it to a one-line question rather than guessing.
+
+Pre-computed check output (tsc, and the vitest files covering the change; a separate job ran these
+against the PR's own code):
+${verifyText ? `\n\`\`\`\n${verifyText}\n\`\`\`\n` : '\n(no check output was provided this run)\n'}`
+  : `You are a thorough, constructive senior code reviewer for World of ClaudeCraft, a TypeScript
 micro-MMO and reinforcement-learning environment built on one deterministic 20 Hz simulation core
 (see CLAUDE.md at the repo root for the architecture and the invariants; read it first).
 
@@ -210,7 +253,15 @@ plainly cannot affect it:
 Budget your time: about 10 minutes of commands. Do not install packages, do not run npm ci, do not
 run browser/E2E scripts (scripts/*.mjs need a live dev server), do not push, and do not modify any
 tracked file; scratch output under /tmp is fine. If a command fails for environmental reasons,
-say so in the verification section rather than guessing.
+say so in the verification section rather than guessing.`;
+
+const prompt = `${
+  NO_EXECUTE
+    ? `You are a thorough, constructive senior code reviewer for World of ClaudeCraft, a TypeScript
+micro-MMO and reinforcement-learning environment built on one deterministic 20 Hz simulation core.
+`
+    : ''
+}${preamble}
 
 Invariant scope, apply LITERALLY and do not generalize beyond it: these rules constrain application
 code under src/ ONLY.
@@ -242,9 +293,11 @@ Output rules: your FINAL message is posted verbatim as the PR review comment, so
 ONLY the review in GitHub-flavored Markdown, no preamble or meta commentary. Do NOT add your own
 title or top-level heading (no "# ..." or "## AI review"). Structure it as:
 1. A one-or-two-line overall assessment (what the change does and whether it is sound).
-2. "**Verified:**" followed by a short list of the commands you ran and their outcomes (for
-   example: tsc clean; vitest tests/spirit.test.ts 34 passed). If something could not run,
-   say so here honestly.
+2. "**Verified:**" followed by a short list of ${
+  NO_EXECUTE
+    ? 'the pre-computed check results you were given and what they show (for example: tsc clean; vitest tests/spirit.test.ts 34 passed). Do not claim to have run anything yourself; if no check output was provided, say the review is diff-only'
+    : 'the commands you ran and their outcomes (for example: tsc clean; vitest tests/spirit.test.ts 34 passed). If something could not run, say so'
+} here honestly.
 3. Findings grouped under Correctness, Invariants, Tests, Nits, each tagged with its severity.
    Omit an empty group. If there are no findings, say the change looks correct in one line and
    name the strongest piece of evidence.


### PR DESCRIPTION
## What

Makes the on-demand `/review` (and `/suggest`) comment command usable by **anyone**, including a fork PR's own author, **without** exposing the `CODEX_AUTH_JSON` secret to fork code. Supersedes the earlier "just remove the gate" approach in this PR, which a review flagged as a high-severity token-exfiltration risk (running fork code in a secret-holding job).

## Why

Contributors like the author of #1533 (a fork PR) commented `/review` and got no response: the job was gated to `OWNER`/`MEMBER`/`COLLABORATOR`. We want everyone to self-serve a review, but the command needs the secret and used to run the PR's own code (`i18n:gen` + the tests the agent ran) in the same job. Removing the gate alone would let a malicious fork PR steal the maintainer OAuth token.

## How (two-job split)

- **`ai-review-comment-verify`** (no secret): checks out the PR head, `npm ci --ignore-scripts`, `i18n:gen`, computes the diff, runs `tsc --noEmit` and the vitest files the diff touches (plus the sim guard when `src/sim/` changed). This is the only place the PR's code runs, and the job holds no secret, so that code can steal nothing. `persist-credentials: false` keeps even the ephemeral `GITHUB_TOKEN` out of `.git/config`. It uploads only the diff + check output as text.
- **`ai-review-comment-post`** (secret): checks out only trusted base-repo tooling, never the PR's code. Runs `scripts/ai_review.mjs` in a new **no-execute** mode (`REVIEW_NO_EXECUTE=1`) from an empty working dir under a `read-only` sandbox, reviewing the diff + pre-computed check text as data, then posts the reply.

`scripts/ai_review.mjs` gains the no-execute mode: embeds `VERIFY_FILE`, forbids running commands, drops the "read the tree / run tsc" instructions. **Executing mode (the automatic `ai-review` job and local runs) is unchanged.**

## Residual risk (documented)

The only attacker-controlled input reaching the secret-bearing job is text (the diff and the check output), so the remaining surface is **prompt injection**, contained by the read-only sandbox, the minimal Codex child env (`codexChildEnv`, never `GITHUB_TOKEN`/raw `CODEX_AUTH_JSON`), and output `redactSecrets`. Recommended defense in depth: point `CODEX_AUTH_JSON` at a dedicated throwaway ChatGPT account.

## Verification

- `node --check scripts/ai_review.mjs` and YAML parse: clean.
- Dry-ran `ai_review.mjs` in both modes with a stub `codex` binary: no-execute mode embeds the diff + `VERIFY_FILE` and the "DO NOT RUN ANYTHING" instruction and omits the executing "VERIFY BEFORE YOU WRITE / run tsc" block; executing mode keeps them. Posting no-ops without a token (non-blocking), exit 0.
- biome clean on the changed script; pre-push QA floor green.

Files: `.github/workflows/pr-ai.yml`, `scripts/ai_review.mjs`, `docs/ai-pr-bot.md`. No product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)