### PR TITLE
fix(ui): apply UI scale after slider release

### DIFF
--- a/src/ui/options_view.ts
+++ b/src/ui/options_view.ts
@@ -40,6 +40,8 @@ export interface SliderControl {
   /** Current value at build time; the painter re-reads the live value on input. */
   value: number;
   fmt: SliderFmt;
+  /** When true, preview input updates locally and the setting writes on change/blur. */
+  commitOnChange?: boolean;
 }
 
 export interface ToggleControl {
@@ -144,9 +146,20 @@ const slider = (
   labelKey: TranslationKey,
   fmt: SliderFmt = 'percent',
   step = 0.05,
+  commitOnChange?: boolean,
 ): SliderControl => {
   const r = s.range(key);
-  return { control: 'slider', key, labelKey, min: r.min, max: r.max, step, value: s.num(key), fmt };
+  return {
+    control: 'slider',
+    key,
+    labelKey,
+    min: r.min,
+    max: r.max,
+    step,
+    value: s.num(key),
+    fmt,
+    commitOnChange,
+  };
 };
 
 const toggle = (
@@ -351,7 +364,7 @@ export function buildControllerControls(s: OptionsSettingsSource): OptionsContro
 
 export function buildInterfaceControls(s: OptionsSettingsSource): OptionsControl[] {
   return [
-    slider(s, 'uiScale', 'hudChrome.options.uiScale'),
+    slider(s, 'uiScale', 'hudChrome.options.uiScale', 'percent', 0.05, true),
     slider(s, 'playerFrameScale', 'hudChrome.options.playerFrameScale'),
     slider(s, 'targetFrameScale', 'hudChrome.options.targetFrameScale'),
     slider(s, 'hudOpacity', 'hud.options.hudOpacity'),

--- a/src/ui/options_window.ts
+++ b/src/ui/options_window.ts
@@ -416,7 +416,8 @@ export class OptionsWindow {
     }
   }
 
-  // A labelled slider bound to a numeric setting; live-applies via the hook.
+  // A labelled slider bound to a numeric setting; most live-apply via the hook.
+  // Sliders marked commitOnChange preview locally, then write on release/blur.
   private settingSlider(parent: HTMLElement, c: SliderControl, hooks: OptionsHooks): void {
     const key = c.key as NumericSettingKey;
     const label = t(c.labelKey);
@@ -440,8 +441,9 @@ export class OptionsWindow {
     // screen reader announces the human-meaningful value (50%, 90 degrees) instead
     // of the raw stored number. The native range already exposes role=slider plus
     // aria-valuenow/min/max from value/min/max, so only valuetext needs setting.
+    const currentSliderValue = () => sliderDispatchValue(slider.value);
     const syncReadout = () => {
-      const text = fmt(hooks.settings.get(key));
+      const text = fmt(currentSliderValue());
       val.textContent = text;
       slider.setAttribute('aria-valuetext', text);
     };
@@ -460,11 +462,30 @@ export class OptionsWindow {
       );
     };
     paintFill();
+    let lastCommittedValue = hooks.settings.get(key);
+    const commitValue = () => {
+      const next = currentSliderValue();
+      if (next === lastCommittedValue) return;
+      lastCommittedValue = next;
+      hooks.onSettingChange(key, next);
+      syncReadout();
+      paintFill();
+    };
     slider.addEventListener('input', () => {
-      hooks.onSettingChange(key, sliderDispatchValue(slider.value));
+      if (c.commitOnChange) {
+        syncReadout();
+        paintFill();
+        return;
+      }
+      hooks.onSettingChange(key, currentSliderValue());
+      lastCommittedValue = currentSliderValue();
       syncReadout();
       paintFill();
     });
+    if (c.commitOnChange) {
+      slider.addEventListener('change', commitValue);
+      slider.addEventListener('blur', commitValue);
+    }
     row.append(name, slider, val);
     parent.appendChild(row);
   }

--- a/tests/browser/a11y.browser.test.ts
+++ b/tests/browser/a11y.browser.test.ts
@@ -12,6 +12,13 @@
 // by this painter-mount harness; their pixels get no faked per-marker aria.
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  BOOL_SETTINGS,
+  type BoolSettingKey,
+  type GameSettings,
+  type NumericSettingKey,
+  SETTING_RANGES,
+} from '../../src/game/settings';
 import type { TalentAllocation } from '../../src/sim/content/talents';
 import { ITEMS, QUESTS } from '../../src/sim/data';
 import { ArenaWindow } from '../../src/ui/arena_window';
@@ -267,6 +274,76 @@ describe('axe: options menu', () => {
     return { root, win };
   }
 
+  function sliderHarness(): {
+    calls: { key: keyof GameSettings; value: GameSettings[keyof GameSettings] }[];
+    root: HTMLElement;
+    win: OptionsWindow;
+    hooks: {
+      settings: {
+        get: (key: NumericSettingKey | BoolSettingKey) => number | boolean;
+        set: (key: NumericSettingKey, value: number) => number;
+        all: () => Partial<GameSettings>;
+        reset: () => void;
+      };
+      onSettingChange: (key: keyof GameSettings, value: GameSettings[keyof GameSettings]) => void;
+    };
+  } {
+    const root = host('options-menu');
+    root.style.display = 'none';
+    const values = new Map<NumericSettingKey, number>();
+    const calls: { key: keyof GameSettings; value: GameSettings[keyof GameSettings] }[] = [];
+    const hooks = {
+      settings: {
+        get: (key: NumericSettingKey | BoolSettingKey) => {
+          if (key in BOOL_SETTINGS) return BOOL_SETTINGS[key as BoolSettingKey].def;
+          return (
+            values.get(key as NumericSettingKey) ?? SETTING_RANGES[key as NumericSettingKey].def
+          );
+        },
+        set: (key: NumericSettingKey, value: number) => {
+          values.set(key, value);
+          return value;
+        },
+        all: () => ({}),
+        reset: () => undefined,
+      },
+      onSettingChange: (key: keyof GameSettings, value: GameSettings[keyof GameSettings]) => {
+        calls.push({ key, value });
+        if (typeof value === 'number') values.set(key as NumericSettingKey, value);
+      },
+    };
+    const win = new OptionsWindow(
+      stubDeps({
+        root: () => root,
+        world: () =>
+          ({
+            realm: 'Claudemoon',
+            player: { name: 'Aurelia', pos: { x: 0, y: 0, z: 0 } },
+          }) as never,
+        options: () =>
+          ({
+            logout: () => undefined,
+            captureKey: () => undefined,
+            ...hooks,
+            perfOverlay: { setPlacement: () => undefined },
+            theme: {
+              get: () => ({ preset: 'classic', custom: {} }),
+              setPreset: () => undefined,
+              setCustom: () => undefined,
+              resetCustom: () => undefined,
+            },
+            changeLanguage: async () => true,
+          }) as never,
+        bugReport: () => null,
+        captureFocus: () => null,
+        buildDropdown: () => document.createElement('button'),
+        setDropdownValue: () => undefined,
+        focusFirstInteractive: () => undefined,
+      }),
+    );
+    return { calls, hooks, root, win };
+  }
+
   it('main menu is clean (dialog role, labelled title that resolves)', async () => {
     const { root, win } = optionsWindow();
     win.toggle();
@@ -292,6 +369,73 @@ describe('axe: options menu', () => {
     expect(root.getAttribute('aria-label')).toBe(t('hudChrome.perf.title'));
     expect(root.getAttribute('aria-labelledby')).toBeNull();
     await expectClean(root);
+  });
+
+  it('defers only UI Scale writes until release while keeping slider preview live', () => {
+    const { calls, hooks, root, win } = sliderHarness();
+    const settingSlider = (
+      win as unknown as {
+        settingSlider(parent: HTMLElement, c: unknown, hooks: unknown): void;
+      }
+    ).settingSlider.bind(win);
+    settingSlider(
+      root,
+      {
+        control: 'slider',
+        key: 'uiScale',
+        labelKey: 'hudChrome.options.uiScale',
+        min: SETTING_RANGES.uiScale.min,
+        max: SETTING_RANGES.uiScale.max,
+        step: 0.05,
+        value: SETTING_RANGES.uiScale.def,
+        fmt: 'percent',
+        commitOnChange: true,
+      },
+      hooks,
+    );
+    settingSlider(
+      root,
+      {
+        control: 'slider',
+        key: 'hudOpacity',
+        labelKey: 'hud.options.hudOpacity',
+        min: SETTING_RANGES.hudOpacity.min,
+        max: SETTING_RANGES.hudOpacity.max,
+        step: 0.05,
+        value: SETTING_RANGES.hudOpacity.def,
+        fmt: 'percent',
+      },
+      hooks,
+    );
+
+    const sliders = Array.from(root.querySelectorAll<HTMLInputElement>('input[type="range"]'));
+    const uiScale = sliders.find(
+      (input) => input.getAttribute('aria-label') === t('hudChrome.options.uiScale'),
+    );
+    const hudOpacity = sliders.find(
+      (input) => input.getAttribute('aria-label') === t('hud.options.hudOpacity'),
+    );
+    expect(uiScale, 'ui scale slider present').toBeTruthy();
+    expect(hudOpacity, 'hud opacity slider present').toBeTruthy();
+    if (!uiScale || !hudOpacity) throw new Error('expected test sliders to render');
+
+    uiScale.value = '1.25';
+    uiScale.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(calls).toEqual([]);
+    expect(uiScale.nextElementSibling?.textContent).toBe('125%');
+    expect(uiScale.style.getPropertyValue('--range-fill')).toBe('72.72727272727273%');
+
+    uiScale.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(calls).toEqual([{ key: 'uiScale', value: 1.25 }]);
+
+    uiScale.value = '1.3';
+    uiScale.dispatchEvent(new Event('input', { bubbles: true }));
+    uiScale.dispatchEvent(new FocusEvent('blur', { bubbles: false }));
+    expect(calls.at(-1)).toEqual({ key: 'uiScale', value: 1.3 });
+
+    hudOpacity.value = '0.75';
+    hudOpacity.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(calls.at(-1)).toEqual({ key: 'hudOpacity', value: 0.75 });
   });
 });
 

--- a/tests/options_view.test.ts
+++ b/tests/options_view.test.ts
@@ -256,6 +256,18 @@ describe('options_view: interface dispatch matrix (cluster 5)', () => {
     ]);
     expect(find(controls, 'reduceMotion')).toMatchObject({ control: 'boolToggle' });
   });
+
+  it('defers only the global UI scale slider until commit', () => {
+    const controls = buildInterfaceControls(makeSource());
+    const uiScale = find(controls, 'uiScale');
+    const hudOpacity = find(controls, 'hudOpacity');
+    const tooltipScale = find(controls, 'tooltipScale');
+    expect(uiScale).toMatchObject({ control: 'slider', commitOnChange: true });
+    expect(hudOpacity).toMatchObject({ control: 'slider' });
+    expect(tooltipScale).toMatchObject({ control: 'slider' });
+    if (hudOpacity?.control === 'slider') expect(hudOpacity.commitOnChange).toBeUndefined();
+    if (tooltipScale?.control === 'slider') expect(tooltipScale.commitOnChange).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/options_window.test.ts
+++ b/tests/options_window.test.ts
@@ -91,8 +91,13 @@ describe('options_window: control-primitive dispatch wiring', () => {
   });
 
   it('fires the exact same setting write per control kind as the inline original', () => {
-    // slider: the raw input value coerced via the pure dispatch fn
-    expect(painter).toContain('hooks.onSettingChange(key, sliderDispatchValue(slider.value))');
+    // slider: the raw input value is still coerced via the pure dispatch fn
+    expect(painter).toContain('const currentSliderValue = () => sliderDispatchValue(slider.value)');
+    // normal sliders live-apply on input
+    expect(painter).toContain('hooks.onSettingChange(key, currentSliderValue())');
+    // deferred sliders commit on release/blur
+    expect(painter).toContain("slider.addEventListener('change', commitValue)");
+    expect(painter).toContain("slider.addEventListener('blur', commitValue)");
     // numeric toggle: flip off the stored value, no pre-set
     expect(painter).toContain(
       'hooks.onSettingChange(key, toggleNextValue(hooks.settings.get(key)))',


### PR DESCRIPTION
Closes #1558

## Summary
- Added a `commitOnChange` slider option and enabled it only for UI Scale.
- Kept slider readout/fill previewing during drag.
- Deferred UI Scale application until `change` or `blur`.
- Preserved live-apply behavior for other sliders such as HUD opacity.

## Testing
Passed:
- `npx vitest run tests/options_view.test.ts tests/options_window.test.ts`
- `npx vitest run --config vitest.browser.config.ts tests/browser/a11y.browser.test.ts -t "defers only UI Scale"`
- `npx tsc --noEmit`
- `npm run security:gate`
- `npm run build`

Manual verification:
- `--ui-scale` stayed `1` during slider `input`.
- UI Scale readout and fill updated while dragging.
- `change` applied `1.25`.
- `blur` applied `1.3`.
- HUD opacity still live-applied to `0.75`.

Known unrelated failure:
- `npm test` failed with 33 unrelated failures, mostly timeout-heavy sim/parity/security tests plus i18n failures around an unrelated `lockActionBars` change.
