### PR TITLE
fix(delves): Drowned Litany death loop, companion respawn, and Blackwater walkway fixes

### DIFF
--- a/scripts/delve_death_e2e.mjs
+++ b/scripts/delve_death_e2e.mjs
@@ -1,0 +1,641 @@
+// REAL end-to-end for the death-related Drowned Litany (Heroic) fixes. Offline
+// only; needs `npm run dev` (:5173). Drives the actual offline sim through
+// window.__game.sim, exercising the real death/respawn seams (dealDamage ->
+// handleDeath, releaseSpirit -> releaseSpiritInDelve), the real boss driver
+// (updateDelveRuns -> tickDrownedLitanyBoss), and the real static Blackwater
+// hazard tick (tickDelveBlackwater). It asserts three fixes:
+//
+//   (a) COMPANION RESPAWN: the auto-companion (Edda Reedhand) respawns after the
+//       owner dies and releases in-delve, and a spent once-per-run rank-3 revive
+//       (run.companionReviveUsed) survives the respawn un-reset.
+//   (b) BELL DEATH LOOP: a Tolling Bells volley in flight (plus a Blackwater
+//       Mark puddle) is cleared on player death, so an in-delve respawn is not
+//       killed again by pending lethal effects. Negative control: a volley in
+//       flight DOES damage a live player, so the clear check is decisive.
+//   (c) HAZARD WALKWAY SAFETY: an authored WALKABLE point clear of every hazard
+//       zone in the apse takes zero Blackwater damage over ~4s of ticks, while a
+//       point authored INSIDE a hazard zone does take ticks. Both points are
+//       derived from the litany layout data itself, not hardcoded coordinates,
+//       so the test survives retuning of the pool placement.
+//
+// The layout is imported in-page through the vite dev server (dynamic import of
+// the TS source), never into Node. Everything else drives real sim methods.
+
+import fs from 'node:fs';
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+fs.mkdirSync('tmp', { recursive: true });
+
+let pass = 0,
+  fail = 0;
+const check = (name, cond, extra = '') => {
+  cond
+    ? (pass++, console.log(`  PASS ${name}${extra ? `: ${extra}` : ''}`))
+    : (fail++, console.log(`  FAIL ${name}${extra ? `: ${extra}` : ''}`));
+};
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  protocolTimeout: 60000,
+  userDataDir: `C:/Users/Sud0S/AppData/Local/Temp/woc-delve-death-e2e-${Date.now()}`,
+  args: [
+    '--window-size=1280,800',
+    '--use-angle=swiftshader',
+    '--enable-unsafe-swiftshader',
+    '--no-first-run',
+    '--no-default-browser-check',
+    // __game is published behind a setTimeout(LOADING_FADE_MS) after the loading
+    // fade; an occluded headless page freezes timers, so keep the page active.
+    '--disable-background-timer-throttling',
+    '--disable-backgrounding-occluded-windows',
+    '--disable-renderer-backgrounding',
+  ],
+  defaultViewport: { width: 1280, height: 800 },
+});
+const page = await browser.newPage();
+const errors = [];
+// Offline `npm run dev` has no server, so the homepage's /api project-stats fetch
+// 502s, unrelated to these fixes. Ignore that one known-benign noise.
+const benign = (t) => /502|Bad Gateway|project stats/i.test(t);
+page.on('pageerror', (e) => errors.push(`PAGEERROR: ${e.message}`));
+page.on('console', (m) => {
+  if (m.type() === 'error' && !benign(m.text())) errors.push(`CONSOLE: ${m.text()}`);
+});
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+// Settle before clicking so the boot handlers are attached (clicking the moment
+// the node exists in the DOM is a no-op and stalls the boot).
+await sleep(2500);
+await page.evaluate(() => {
+  document.querySelector('.server-select-option[data-mode="offline"]')?.click();
+  document.querySelector('#btn-play')?.click();
+});
+await sleep(1200);
+await page.evaluate(() => {
+  const name = document.querySelector('#char-name');
+  if (name) name.value = 'Deathcheck';
+  document.querySelector('#offline-select .mini-class[data-class="warrior"]')?.click();
+  document.querySelector('#btn-start-offline')?.click();
+});
+await page.waitForFunction(() => window.__game?.sim?.player?.pos, { timeout: 30000, polling: 200 });
+await sleep(1500);
+
+// Publish the litany layout helpers into the page from the TS source (through the
+// vite dev server). We only need pure data/geometry accessors here.
+await page.evaluate(async () => {
+  const lay = await import('/src/sim/delve_litany_layout.ts');
+  const data = await import('/src/sim/data.ts');
+  const geo2d = await import('/src/sim/geometry2d.ts');
+  window.__litanyGeometry = lay.litanyModuleGeometry;
+  window.__delveModuleZOffset = data.delveModuleZOffset;
+  window.__polygonXAtZ = geo2d.polygonXAtZ;
+});
+
+// -------------------------------------------------------------------------
+// (a) COMPANION RESPAWN after an in-delve player death + release.
+// -------------------------------------------------------------------------
+const companion = await page.evaluate(() => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  // Clean any prior run so the enter claims a fresh solo instance.
+  const prev = sim.delveRunForPlayer(p.id);
+  if (prev) {
+    sim.leaveDelve();
+    sim.freeDelveRun(prev);
+  }
+  // Heroic gate is level 9+; use a comfortable level.
+  sim.setPlayerLevel(14);
+  sim.enterDelve('drowned_litany', 'heroic');
+  const run = sim.delveRunForPlayer(p.id);
+  if (!run) return { err: 'no delve run after enterDelve' };
+
+  const solo = !!run.partyKey && run.partyKey.startsWith('solo:');
+  const spawnedCompanion = run.companion ? run.companion.entityId : null;
+  const companionAliveOnSpawn =
+    spawnedCompanion != null &&
+    !!sim.entities.get(spawnedCompanion) &&
+    !sim.entities.get(spawnedCompanion).dead;
+
+  // Mark the once-per-run rank-3 revive as already spent, to prove the respawn
+  // does not recharge it (the fix must preserve companionReviveUsed).
+  run.companionReviveUsed = true;
+
+  // Kill the player through the real death path (dealDamage -> handleDeath),
+  // not a raw hp write, so p.dead is set exactly as combat sets it.
+  sim.dealDamage(null, p, p.maxHp + 1000, false, 'physical', null, 'hit', true);
+  const diedProperly = p.dead === true && p.ghost !== true;
+
+  // Advance a couple of real ticks so the mob-AI pass runs the owner-dead arm of
+  // updateDelveCompanion, which despawns the companion while the owner is dead
+  // (this mirrors the live sequence the fix must recover from).
+  sim.tick();
+  sim.tick();
+  const companionGoneWhileDead = spawnedCompanion != null && !sim.entities.has(spawnedCompanion);
+
+  // Perform the normal in-delve respawn the game offers (the client calls
+  // releaseSpirit; it routes to releaseSpiritInDelve for delve positions).
+  sim.releaseSpirit();
+  const aliveAfterRespawn = p.dead === false;
+
+  const respawnedCompanion = run.companion ? run.companion.entityId : null;
+  const companionEntity = respawnedCompanion != null ? sim.entities.get(respawnedCompanion) : null;
+
+  return {
+    solo,
+    spawnedCompanion,
+    companionAliveOnSpawn,
+    diedProperly,
+    companionGoneWhileDead,
+    aliveAfterRespawn,
+    respawnedCompanion,
+    respawnedCompanionAlive: !!companionEntity && companionEntity.dead === false,
+    respawnedCompanionIsNew: respawnedCompanion != null && respawnedCompanion !== spawnedCompanion,
+    companionStateNotNull: sim.companionState != null,
+    reviveStillUsed: run.companionReviveUsed === true,
+  };
+});
+console.log('(a) companion:', JSON.stringify(companion));
+check('(a) entered drowned_litany solo (heroic)', companion.solo === true);
+check('(a) auto-companion spawned + alive on entry', companion.companionAliveOnSpawn === true);
+check('(a) player died through the real death path', companion.diedProperly === true);
+check('(a) companion despawned while owner dead', companion.companionGoneWhileDead === true);
+check('(a) player alive after in-delve respawn', companion.aliveAfterRespawn === true);
+check(
+  '(a) companion respawned (new entity) and alive',
+  companion.respawnedCompanion != null &&
+    companion.respawnedCompanionAlive === true &&
+    companion.respawnedCompanionIsNew === true,
+  `id ${companion.spawnedCompanion}->${companion.respawnedCompanion}`,
+);
+check('(a) companionState is populated after respawn', companion.companionStateNotNull === true);
+check(
+  '(a) spent rank-3 revive (companionReviveUsed) survives the respawn un-reset',
+  companion.reviveStillUsed === true,
+);
+
+// -------------------------------------------------------------------------
+// (b) BELL DEATH LOOP: a volley in flight kills the player once, then is cleared
+//     on death so the respawn is not killed again. Negative control included.
+// -------------------------------------------------------------------------
+const bells = await page.evaluate(() => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+
+  // Advance only the delve-run systems (boss driver + Blackwater hazard) one
+  // tick and return the emitted events, without a full sim.tick() moving the
+  // player. updateDelveRuns() emits into sim.events; drainEvents() returns +
+  // clears that buffer (both are on the real sim, mirroring the unit tests that
+  // drive (sim as any).updateDelveRuns() directly).
+  const stepDelve = () => {
+    sim.updateDelveRuns();
+    return sim.drainEvents();
+  };
+
+  // Fresh run: free the prior instance (check (a) already spent a death on it;
+  // a second death on the same run would trip the two-strike failDelveRun rule
+  // and eject the player, tearing down run.nhaliaBoss). A fresh solo enter resets
+  // deathsThisRun so this scenario's single death takes the normal in-delve
+  // respawn path we want to test.
+  const prev = sim.delveRunForPlayer(p.id);
+  if (prev) {
+    sim.leaveDelve();
+    sim.freeDelveRun(prev);
+  }
+  sim.setPlayerLevel(14);
+  sim.enterDelve('drowned_litany', 'heroic');
+  const run = sim.delveRunForPlayer(p.id);
+  if (!run) return { err: 'no delve run after enterDelve' };
+
+  // Jump straight to the finale module (litany_apse) and spawn it, the same way
+  // the unit-test enterLitanyApse helper does. spawnDelveModule spawns the boss.
+  const finaleId = 'litany_apse';
+  run.modules = [finaleId];
+  run.moduleIndex = 0;
+  sim.spawnDelveModule(run);
+  const onFinale = run.modules[run.moduleIndex] === finaleId;
+
+  // Find Sister Nhalia and put her in combat so the boss driver ticks mechanics.
+  const boss = [...sim.entities.values()].find(
+    (e) => e.templateId === 'sister_nhalia_drowned_canticle' && !e.dead,
+  );
+  if (!boss) return { err: 'no Sister Nhalia in apse', onFinale };
+  boss.inCombat = true;
+
+  // Move the player onto the altar center so an outbound volley is guaranteed to
+  // pass through the player's hit radius on its way out (bells spawn at the altar
+  // and fly radially outward). The altar is at room-local (0, 72).
+  const zBase = window.__delveModuleZOffset(run.modules, run.moduleIndex);
+  const placeAtAltar = () => {
+    p.pos.x = run.origin.x + 0;
+    p.pos.z = run.origin.z + zBase + 72;
+    p.prevPos = { ...p.pos };
+  };
+
+  // Ensure boss state exists (inits on the first finale tick).
+  sim.updateDelveRuns();
+  if (!run.nhaliaBoss) return { err: 'nhaliaBoss state did not init', onFinale };
+
+  // NEGATIVE CONTROL: a volley in flight DOES hurt a live player. Full-heal, put
+  // the player on the altar, fire a volley, and tick until a bell contacts.
+  p.dead = false;
+  p.hp = p.maxHp;
+  placeAtAltar();
+  run.nhaliaBoss.bellVolleyTimer = 0.001;
+  sim.updateDelveRuns(); // fires the volley (bells now in flight)
+  const volleyBellCount = run.nhaliaBoss.bells.length;
+  const hpBeforeControl = p.hp;
+  let controlBellHit = false;
+  for (let i = 0; i < 20 * 3; i++) {
+    placeAtAltar(); // hold the player in the bell path
+    for (const ev of stepDelve()) {
+      if (
+        ev.type === 'damage' &&
+        ev.targetId === p.id &&
+        (ev.ability === 'Tolling Bell' || ev.ability === 'Blackwater Mark')
+      )
+        controlBellHit = true;
+    }
+    if (controlBellHit) break;
+  }
+  const controlHpDrop = hpBeforeControl - p.hp;
+
+  // MAIN SCENARIO: fire a fresh volley AND a Blackwater mark, both now in flight.
+  // Then kill the player and respawn; the fix clears pending bell/mark lethal
+  // effects on death, so the freshly respawned player takes no further damage.
+  p.dead = false;
+  p.hp = p.maxHp;
+  placeAtAltar();
+  run.nhaliaBoss.bellVolleyTimer = 0.001;
+  sim.updateDelveRuns(); // volley in flight
+  run.nhaliaBoss.markTimer = 0.001;
+  sim.updateDelveRuns(); // a Blackwater Mark puddle now persisted
+  const bellsInFlight = run.nhaliaBoss.bells.length;
+  const marksInFlight = run.nhaliaBoss.marks.length;
+  const bellIds = run.nhaliaBoss.bells.map((b) => b.entityId);
+  const volleyTimerBeforeDeath = run.nhaliaBoss.bellVolleyTimer;
+  const firedCantorBeforeDeath = run.nhaliaBoss.firedCantorPhases;
+
+  // Kill the player through the real death path, then respawn in-delve.
+  sim.dealDamage(null, p, p.maxHp + 1000, false, 'physical', null, 'hit', true);
+  const diedProperly = p.dead === true && p.ghost !== true;
+  sim.releaseSpirit();
+  const aliveAfterRespawn = p.dead === false;
+
+  const bellsClearedOnDeath = run.nhaliaBoss.bells.length === 0;
+  const marksClearedOnDeath = run.nhaliaBoss.marks.length === 0;
+  const bellEntitiesDropped = bellIds.every((id) => !sim.entities.has(id));
+
+  // Isolate the fix under test: the PRE-DEATH volley/mark must not damage the
+  // respawned player. The boss keeps fighting for a live party, so a brand-new
+  // volley fired after respawn IS correct behavior and would be a false failure
+  // here; push the volley/mark timers out past the observation window so ONLY
+  // an effect that survived the death (the bug) could land a hit.
+  run.nhaliaBoss.bellVolleyTimer = 999;
+  run.nhaliaBoss.markTimer = 999;
+
+  // Discard every event emitted before this point (the setup volleys/marks and
+  // the kill blow pushed Tolling Bell / Blackwater damage into sim.events but
+  // were never drained). Otherwise the first post-respawn stepDelve() would drain
+  // that stale backlog and miscount a pre-death hit as a post-respawn one.
+  sim.drainEvents();
+
+  // Over the next several real seconds, the respawned player takes NO bell/mark
+  // damage: the death loop is broken. Hold the player where they respawned.
+  const hpAfterRespawn = p.hp;
+  let postRespawnBellHits = 0;
+  const postHitDetail = [];
+  for (let i = 0; i < 20 * 5; i++) {
+    for (const ev of stepDelve()) {
+      if (
+        ev.type === 'damage' &&
+        ev.targetId === p.id &&
+        (ev.ability === 'Tolling Bell' || ev.ability === 'Blackwater Mark')
+      ) {
+        postRespawnBellHits++;
+        if (postHitDetail.length < 4)
+          postHitDetail.push({ i, ability: ev.ability, amount: ev.amount ?? ev.value ?? null });
+      }
+    }
+  }
+  const hpUnchangedAfterRespawn = p.hp >= hpAfterRespawn; // may regen up, never bell-damaged down
+
+  // The death must NOT re-arm the encounter (unlike an evade reset): the volley
+  // timer and Cantor-phase progress are untouched by the clear.
+  const encounterNotRearmed =
+    run.nhaliaBoss.firedCantorPhases === firedCantorBeforeDeath &&
+    run.nhaliaBoss.bellVolleyTimer > 0;
+  void volleyTimerBeforeDeath;
+
+  return {
+    onFinale,
+    volleyBellCount,
+    controlBellHit,
+    controlHpDrop,
+    bellsInFlight,
+    marksInFlight,
+    diedProperly,
+    aliveAfterRespawn,
+    bellsClearedOnDeath,
+    marksClearedOnDeath,
+    bellEntitiesDropped,
+    postRespawnBellHits,
+    postHitDetail,
+    hpUnchangedAfterRespawn,
+    encounterNotRearmed,
+  };
+});
+console.log('(b) bells:', JSON.stringify(bells));
+if (bells.err) {
+  check('(b) bell scenario reached the apse finale', false, bells.err);
+} else {
+  check('(b) reached the litany_apse finale via advanceDelveModule', bells.onFinale === true);
+  check('(b) a volley fires bells into flight', bells.volleyBellCount > 0);
+  check(
+    '(b) NEGATIVE CONTROL: a volley in flight damages a live player',
+    bells.controlBellHit === true && bells.controlHpDrop > 0,
+    `hp drop ${bells.controlHpDrop}`,
+  );
+  check(
+    '(b) bells + a Blackwater mark are in flight before death',
+    bells.bellsInFlight > 0 && bells.marksInFlight > 0,
+  );
+  check('(b) player died through the real death path', bells.diedProperly === true);
+  check('(b) player alive after in-delve respawn', bells.aliveAfterRespawn === true);
+  check('(b) in-flight bells cleared on death', bells.bellsClearedOnDeath === true);
+  check('(b) in-flight Blackwater marks cleared on death', bells.marksClearedOnDeath === true);
+  check('(b) bell projectile entities dropped on death', bells.bellEntitiesDropped === true);
+  check(
+    '(b) respawned player takes NO further bell/mark damage over ~5s',
+    bells.postRespawnBellHits === 0 && bells.hpUnchangedAfterRespawn === true,
+    `postRespawnBellHits=${bells.postRespawnBellHits}`,
+  );
+  check('(b) player death does not re-arm the encounter', bells.encounterNotRearmed === true);
+}
+
+// -------------------------------------------------------------------------
+// (c) HAZARD WALKWAY SAFETY: an authored walkable point clear of every hazard is
+//     dry over ~4s; a point inside a hazard zone takes ticks. Points derived
+//     from the layout data itself.
+// -------------------------------------------------------------------------
+const hazard = await page.evaluate(() => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+
+  // Advance only the delve-run systems one tick and return the emitted events
+  // (see the bell scenario for why we avoid a full sim.tick() here).
+  const stepDelve = () => {
+    sim.updateDelveRuns();
+    return sim.drainEvents();
+  };
+
+  // Fresh run so this check is independent of the death count the bell scenario
+  // spent (keeps the whole script green on a back-to-back re-run).
+  const prev = sim.delveRunForPlayer(p.id);
+  if (prev) {
+    sim.leaveDelve();
+    sim.freeDelveRun(prev);
+  }
+  sim.setPlayerLevel(14);
+  sim.enterDelve('drowned_litany', 'heroic');
+  const run = sim.delveRunForPlayer(p.id);
+  if (!run) return { err: 'no delve run after enterDelve' };
+
+  const moduleId = 'litany_apse';
+  run.modules = [moduleId];
+  run.moduleIndex = 0;
+  sim.spawnDelveModule(run);
+  // Clear the room so ONLY the static hazard could deal Blackwater damage, and
+  // make sure the boss is not tossing marks/bells during this window.
+  for (const id of [...run.mobIds]) sim.dropEntity(id);
+  if (run.nhaliaBoss) {
+    run.nhaliaBoss.bells = [];
+    run.nhaliaBoss.marks = [];
+  }
+
+  const geo = window.__litanyGeometry(moduleId);
+  if (!geo) return { err: 'no apse geometry' };
+  const poly = geo.walkable[0].points;
+  const hazards = geo.hazards;
+
+  // Point-in-polygon (even-odd), matching src/sim/geometry2d.polygonContainsPoint.
+  const inPoly = (pts, x, z) => {
+    let inside = false;
+    for (let i = 0, j = pts.length - 1; i < pts.length; j = i++) {
+      const pi = pts[i];
+      const pj = pts[j];
+      const hit = pi.z > z !== pj.z > z && x < ((pj.x - pi.x) * (z - pi.z)) / (pj.z - pi.z) + pi.x;
+      if (hit) inside = !inside;
+    }
+    return inside;
+  };
+  // Inside-any-hazard uses the SAME ellipse test tickDelveBlackwater uses
+  // (rx/rz per-axis, r/r fallback). A small dry-margin buffer keeps the derived
+  // walkable probe clear of the very hazard edge so it is unambiguously dry.
+  const hazardScore = (x, z, buffer) => {
+    let worst = 0; // 0 = clear, 1 = inside some ellipse (with buffer)
+    for (const h of hazards) {
+      const rx = (h.rx ?? h.r) + buffer;
+      const rz = (h.rz ?? h.r) + buffer;
+      const dx = x - h.x;
+      const dz = z - h.z;
+      if ((dx * dx) / (rx * rx) + (dz * dz) / (rz * rz) <= 1) worst = 1;
+    }
+    return worst;
+  };
+
+  // Dais and islands are authored dry ground (tickDelveBlackwater exempts them);
+  // skip a candidate that lands on one so the "walkable and dry" point is a real
+  // Blackwater-tick candidate that only the hazard geometry keeps dry.
+  const onDryGround = (x, z) => {
+    if (Math.hypot(x - geo.dais.x, z - geo.dais.z) <= geo.dais.r) return true;
+    for (const isl of geo.islands) {
+      if (Math.abs(x - isl.x) <= isl.hw && Math.abs(z - isl.z) <= isl.hd) return true;
+    }
+    return false;
+  };
+
+  // Derive a WALKABLE + hazard-clear point by scanning the polygon bounding box
+  // on a grid and picking the interior point farthest from every hazard edge (a
+  // robust "middle of the dry walkway"), requiring a >=2yd dry buffer.
+  let xMin = Infinity,
+    xMax = -Infinity,
+    zMin = Infinity,
+    zMax = -Infinity;
+  for (const pt of poly) {
+    xMin = Math.min(xMin, pt.x);
+    xMax = Math.max(xMax, pt.x);
+    zMin = Math.min(zMin, pt.z);
+    zMax = Math.max(zMax, pt.z);
+  }
+  const clearMargin = (x, z) => {
+    let m = Infinity;
+    for (const h of hazards) {
+      const rx = h.rx ?? h.r;
+      const rz = h.rz ?? h.r;
+      const dx = x - h.x;
+      const dz = z - h.z;
+      // Signed distance-ish to the ellipse boundary in normalized space, mapped
+      // back to yards using the smaller radius as the scale.
+      const nd = Math.sqrt((dx * dx) / (rx * rx) + (dz * dz) / (rz * rz));
+      const yards = (nd - 1) * Math.min(rx, rz);
+      m = Math.min(m, yards);
+    }
+    return m; // positive = outside every hazard by this many yards
+  };
+  let best = null;
+  for (let x = Math.ceil(xMin); x <= Math.floor(xMax); x++) {
+    for (let z = Math.ceil(zMin); z <= Math.floor(zMax); z++) {
+      if (!inPoly(poly, x, z)) continue;
+      if (onDryGround(x, z)) continue; // must be a real hazard-tick candidate
+      const m = clearMargin(x, z);
+      if (m < 2) continue; // require a comfortable dry buffer
+      if (best === null || m > best.m) best = { x, z, m };
+    }
+  }
+  if (!best) return { err: 'no walkable hazard-clear point found in apse polygon' };
+
+  // Derive a point INSIDE a hazard zone that the Blackwater tick will actually
+  // damage: it must be inside a hazard ellipse AND on the walkable polygon AND
+  // NOT on a dry island/dais (tickDelveBlackwater exempts island/dais ground, so
+  // a hazard centre that happens to sit under the altar island reads as dry).
+  // Scan the grid for the point deepest inside a hazard that clears dry ground,
+  // preferring a deep-tier zone (2.0x, unambiguously lethal) when one qualifies.
+  const insideHazardTier = (x, z) => {
+    let tier = null; // 'deep' beats 'shallow'
+    for (const h of hazards) {
+      const rx = h.rx ?? h.r;
+      const rz = h.rz ?? h.r;
+      const dx = x - h.x;
+      const dz = z - h.z;
+      if ((dx * dx) / (rx * rx) + (dz * dz) / (rz * rz) <= 1) {
+        const t = h.tier ?? 'deep';
+        if (t === 'deep') return 'deep';
+        if (tier === null) tier = 'shallow';
+      }
+    }
+    return tier;
+  };
+  let wetBest = null;
+  for (let x = Math.ceil(xMin); x <= Math.floor(xMax); x++) {
+    for (let z = Math.ceil(zMin); z <= Math.floor(zMax); z++) {
+      if (!inPoly(poly, x, z)) continue;
+      if (onDryGround(x, z)) continue; // exempted by the tick: not a real wet probe
+      const tier = insideHazardTier(x, z);
+      if (!tier) continue;
+      // Prefer the most-inside deep point; -clearMargin is how deep we are.
+      const depth = -clearMargin(x, z);
+      const rank = (tier === 'deep' ? 1000 : 0) + depth;
+      if (wetBest === null || rank > wetBest.rank) wetBest = { x, z, tier, rank };
+    }
+  }
+  if (!wetBest) return { err: 'no wet hazard point clear of dry ground found', dry: best };
+  const wet = { x: wetBest.x, z: wetBest.z, tier: wetBest.tier };
+  const wetInsidePoly = inPoly(poly, wet.x, wet.z);
+  const wetScore = hazardScore(wet.x, wet.z, 0);
+  const dryScore = hazardScore(best.x, best.z, 2); // still clear with a 2yd buffer
+
+  const zBase = window.__delveModuleZOffset(run.modules, run.moduleIndex);
+  const toWorld = (lx, lz) => ({
+    x: run.origin.x + lx,
+    z: run.origin.z + zBase + lz,
+  });
+
+  const countBlackwater = (localX, localZ, ticks) => {
+    const w = toWorld(localX, localZ);
+    p.dead = false;
+    p.hp = p.maxHp;
+    p.jumping = false;
+    p.pos.x = w.x;
+    p.pos.z = w.z;
+    p.prevPos = { ...p.pos };
+    let hits = 0;
+    for (let i = 0; i < ticks; i++) {
+      // Re-plant every tick so nothing can nudge the player off the probe point.
+      p.pos.x = w.x;
+      p.pos.z = w.z;
+      p.prevPos = { ...p.pos };
+      for (const ev of stepDelve()) {
+        if (ev.type === 'damage' && ev.targetId === p.id && ev.ability === 'Blackwater') hits++;
+      }
+    }
+    return hits;
+  };
+
+  // ~4 real seconds of ticks (80 ticks at 20 Hz) covers multiple hazard pulses.
+  const dryHits = countBlackwater(best.x, best.z, 80);
+  const wetHits = countBlackwater(wet.x, wet.z, 80);
+
+  // Decisive walkway-ring probe: the specific bug this fix addresses is the moat
+  // rim reaching the OUTER walkway ring and drowning the authored safe flank at
+  // the moat's z-center. Derive that flank straight from the polygon boundary
+  // (polygonXAtZ) 1yd inside the wall on each side, at the moat centre z. Post-
+  // fix these are dry; if the moat rx regressed to reach the wall they would take
+  // ticks. The apse hazard[0] is the moat; use its z-center.
+  const moatZ = hazards[0].z;
+  const westWallX = window.__polygonXAtZ(poly, moatZ, -1);
+  const eastWallX = window.__polygonXAtZ(poly, moatZ, 1);
+  const ringProbes =
+    westWallX != null && eastWallX != null ? { west: westWallX + 1, east: eastWallX - 1 } : null;
+  const ringWestHits = ringProbes ? countBlackwater(ringProbes.west, moatZ, 80) : -1;
+  const ringEastHits = ringProbes ? countBlackwater(ringProbes.east, moatZ, 80) : -1;
+
+  return {
+    dry: { x: best.x, z: best.z, margin: Number(best.m.toFixed(2)) },
+    wet,
+    wetInsidePoly,
+    wetScore,
+    dryScore,
+    dryHits,
+    wetHits,
+    ringProbes: ringProbes
+      ? {
+          west: Number(ringProbes.west.toFixed(1)),
+          east: Number(ringProbes.east.toFixed(1)),
+          z: moatZ,
+        }
+      : null,
+    ringWestHits,
+    ringEastHits,
+  };
+});
+console.log('(c) hazard:', JSON.stringify(hazard));
+if (hazard.err) {
+  check('(c) hazard scenario derived probe points from layout', false, hazard.err);
+} else {
+  check(
+    '(c) derived a walkable point clear of every hazard (from layout data)',
+    hazard.dryScore === 0,
+    `dry local (${hazard.dry.x},${hazard.dry.z}) margin ${hazard.dry.margin}yd`,
+  );
+  check(
+    '(c) derived a point inside an authored hazard zone (from layout data)',
+    hazard.wetScore === 1,
+    `wet local (${hazard.wet.x},${hazard.wet.z})`,
+  );
+  check(
+    '(c) walkable dry point takes ZERO Blackwater damage over ~4s',
+    hazard.dryHits === 0,
+    `hits=${hazard.dryHits}`,
+  );
+  check(
+    '(c) hazard-zone point DOES take Blackwater ticks within the interval',
+    hazard.wetHits > 0,
+    `hits=${hazard.wetHits}`,
+  );
+  check(
+    '(c) authored outer walkway ring flanks stay dry at the moat z-center',
+    hazard.ringProbes != null && hazard.ringWestHits === 0 && hazard.ringEastHits === 0,
+    hazard.ringProbes
+      ? `ring z${hazard.ringProbes.z} west x${hazard.ringProbes.west} (${hazard.ringWestHits}) east x${hazard.ringProbes.east} (${hazard.ringEastHits})`
+      : 'polygon has no boundary at moat z',
+  );
+}
+
+console.log(`\nerrors: ${errors.length ? errors.slice(0, 6).join(' | ') : 'none'}`);
+console.log(`\n=== ${pass} passed, ${fail} failed ===`);
+await browser.close();
+process.exit(fail > 0 || errors.length > 0 ? 1 : 0);

--- a/scripts/delve_panel_visual_e2e.mjs
+++ b/scripts/delve_panel_visual_e2e.mjs
@@ -1,0 +1,712 @@
+// VISUAL / scene-graph end-to-end for the visibility-related Drowned Litany
+// (Heroic) fixes. Offline only; needs `npm run dev` (:5173). Like
+// scripts/drowned_litany_shots.mjs it walks all 7 Drowned Litany modules and
+// screenshots each, but instead of only eyeballing it ASSERTS against the live
+// three.js scene graph (window.__game.renderer). It pins three regressions:
+//
+//   (a) NO GIANT UNTEXTURED QUADS floating in a room interior. Scans the scene
+//       for a large flat plane / near-degenerate box that uses an untextured
+//       plain-color material and floats off the floor inside the active
+//       module's world footprint. The authored Blackwater pool overlays sit
+//       flush at the floor (y ~0.1 to 0.16) and are excluded; a regression that
+//       re-introduces a big unanchored fallback quad flips this red.
+//   (b) FLOOR PANEL FINDABILITY. For every module that gates progression on a
+//       walk-on / pull interactable (sluice valves, grave tablets, corpse
+//       candles, bell ropes) the corresponding render view must exist, sit at
+//       the interior floor height at its x,z, land inside the module bounds,
+//       and carry a real material (not the missing-asset fallback crate). A
+//       per-module screenshot lands in tmp/ for the maintainer to eyeball.
+//   (c) HAZARD TELEGRAPHS MATCH THE SIM. Every authored Blackwater hazard zone
+//       for the active module (read from the layout data in-page) must have a
+//       visible pool telegraph in the scene whose world position lands inside
+//       the hazard radius, AND no telegraph pool may float where no hazard
+//       exists. This pins the exact bug from the report: a lethal sim zone with
+//       no visual (and its inverse, a visual with no zone).
+//
+// Discipline: scene-graph positions/materials/visibility are the source of
+// truth; screenshots are human evidence only, never asserted on by pixel color.
+// The camera is placed with wide offsets and clear sightlines before each shot.
+//
+// NOTE (concurrent repair): the floor-panel fix (b) is being repaired in the
+// tree as this runs. The (b) assertions are written against the INTENDED
+// behavior. If (b) is red on the current tree the orchestrator re-runs after
+// the repair lands; (a) and (c) are expected green now.
+
+import fs from 'node:fs';
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+fs.mkdirSync('tmp', { recursive: true });
+
+const ALL_MODULES = [
+  'litany_sluice',
+  'litany_ledger',
+  'litany_ring',
+  'litany_baptistry',
+  'litany_choir_loft',
+  'litany_causeway',
+  'litany_apse',
+];
+
+let pass = 0,
+  fail = 0;
+const check = (name, cond, extra = '') => {
+  cond
+    ? (pass++, console.log(`  PASS ${name}${extra ? `: ${extra}` : ''}`))
+    : (fail++, console.log(`  FAIL ${name}${extra ? `: ${extra}` : ''}`));
+};
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  protocolTimeout: 60000,
+  userDataDir: `C:/Users/Sud0S/AppData/Local/Temp/woc-litany-visual-e2e-${Date.now()}`,
+  args: [
+    '--window-size=1280,820',
+    '--use-angle=swiftshader',
+    '--enable-unsafe-swiftshader',
+    '--no-first-run',
+    '--no-default-browser-check',
+    // __game is published behind a setTimeout(LOADING_FADE_MS) after the loading
+    // fade; an occluded headless page freezes timers, so keep the page active.
+    '--disable-background-timer-throttling',
+    '--disable-backgrounding-occluded-windows',
+    '--disable-renderer-backgrounding',
+  ],
+  defaultViewport: { width: 1280, height: 820 },
+});
+const page = await browser.newPage();
+const errors = [];
+// Offline `npm run dev` has no server, so the homepage's /api project-stats fetch
+// 502s, unrelated to these fixes. Ignore that one known-benign noise.
+const benign = (t) => /502|Bad Gateway|project stats/i.test(t);
+page.on('pageerror', (e) => errors.push(`PAGEERROR: ${e.message}`));
+page.on('console', (m) => {
+  if (m.type() === 'error' && !benign(m.text())) errors.push(`CONSOLE: ${m.text()}`);
+});
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+// Settle before clicking so the boot handlers are attached (clicking the moment
+// the node exists in the DOM is a no-op and stalls the boot).
+await sleep(2500);
+await page.evaluate(() => {
+  document.querySelector('.server-select-option[data-mode="offline"]')?.click();
+  document.querySelector('#btn-play')?.click();
+});
+await sleep(1200);
+await page.evaluate(() => {
+  const name = document.querySelector('#char-name');
+  if (name) name.value = 'Visualcheck';
+  document.querySelector('#offline-select .mini-class[data-class="warrior"]')?.click();
+  document.querySelector('#btn-start-offline')?.click();
+});
+await page.waitForFunction(() => window.__game?.sim?.player?.pos, { timeout: 30000, polling: 200 });
+await sleep(1500);
+
+// Publish the litany layout helpers into the page from the TS source (through the
+// vite dev server). Pure data/geometry accessors only.
+await page.evaluate(async () => {
+  const lay = await import('/src/sim/delve_litany_layout.ts');
+  const data = await import('/src/sim/data.ts');
+  const world = await import('/src/sim/world.ts');
+  window.__litanyGeometry = lay.litanyModuleGeometry;
+  window.__litanyBounds = lay.litanyModuleBounds;
+  window.__delveModuleZOffset = data.delveModuleZOffset;
+  window.__groundHeight = world.groundHeight;
+});
+
+// Enter the delve and force the full ordered module list so we can walk all 7.
+await page.evaluate((mods) => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  const prev = sim.delveRunForPlayer(p.id);
+  if (prev) {
+    sim.leaveDelve();
+    sim.freeDelveRun(prev);
+  }
+  sim.setPlayerLevel(14);
+  sim.enterDelve('drowned_litany', 'heroic');
+  const run = sim.delveRunForPlayer(sim.playerId);
+  if (!run) throw new Error('no delve run after enterDelve');
+  run.modules = mods.slice();
+}, ALL_MODULES);
+await sleep(2200);
+
+// Puzzle interactable slots per module (mirrors DROWNED_LITANY_MODULES
+// interactableSlots so the (b) check can name which modules gate progression on
+// a floor panel). templateIds map: sluice_valve -> delve_sluice_valve, etc.; a
+// pulled/lit/open suffix appears once triggered, all handled by prefix match.
+const PUZZLE_TEMPLATE_PREFIXES = [
+  'delve_pressure_plate',
+  'delve_sluice_valve',
+  'delve_grave_tablet',
+  'delve_corpse_candle',
+  'delve_bell_rope',
+];
+
+// Deterministically pin the run to module index `target`, (re)spawn that
+// module's contents, CLOSE the exit portal, and park the player at the entry end
+// well clear of both the exit portal and the puzzle plates. This is the crux of
+// making the probe reproducible: the live game loop keeps ticking updateDelveRuns
+// between our evaluate calls, and with an OPEN exit portal + the player near it,
+// tickDelveModuleExit auto-advances the module out from under the probe (which
+// is what made an early version read the next room's objects under this room's
+// header). Forcing moduleIndex + respawn + exitPortalOpen=false + an entry park
+// removes every auto-advance and puzzle-trigger path during the wait.
+//
+// Camera / sightline discipline: parking at the entry end facing +z gives the
+// chase cam a clear look up the room over the water for the screenshot.
+async function pinAndParkModule(target) {
+  await page.evaluate((t) => {
+    const sim = window.__game.sim;
+    const run = sim.delveRunForPlayer(sim.playerId);
+    run.moduleIndex = t;
+    // Respawn the target module's mobs + interactables so run.objectIds is this
+    // module's set (spawnDelveModule clears the prior module's objects first).
+    sim.spawnDelveModule(run);
+    run.exitPortalOpen = false;
+    const b = window.__litanyBounds(run.modules[t]);
+    const zBase = window.__delveModuleZOffset(run.modules, t);
+    const p = sim.player;
+    p.pos.x = run.origin.x;
+    p.pos.z = run.origin.z + zBase + b.zMin + 8;
+    p.pos.y = 0;
+    p.prevPos = { ...p.pos };
+    p.facing = 0; // look up-room (+z)
+  }, target);
+  // The renderer schedules interior builds off the player position / run state;
+  // give it real time to build the KayKit kit, dressing, and pool overlays, and
+  // to build the entity views for the parked module's interactables.
+  await sleep(2600);
+  // Re-park + hold the exit closed once more: any tick during the sleep may have
+  // nudged the player or re-opened the portal (a fully-cleared puzzle set opens
+  // it). Freeze the state we probe against.
+  await page.evaluate((t) => {
+    const sim = window.__game.sim;
+    const run = sim.delveRunForPlayer(sim.playerId);
+    if (run.moduleIndex !== t) {
+      run.moduleIndex = t;
+      sim.spawnDelveModule(run);
+    }
+    run.exitPortalOpen = false;
+    const b = window.__litanyBounds(run.modules[t]);
+    const zBase = window.__delveModuleZOffset(run.modules, t);
+    const p = sim.player;
+    p.pos.x = run.origin.x;
+    p.pos.z = run.origin.z + zBase + b.zMin + 8;
+    p.pos.y = 0;
+    p.prevPos = { ...p.pos };
+    p.facing = 0;
+  }, target);
+  // Let the renderer build the (re)spawned interior and swing the cam for the
+  // screenshot the caller takes right after this returns.
+  await sleep(1600);
+}
+
+// Move the player to the module CENTRE so every interactable lands inside the
+// renderer's ENTITY_DRAW_RANGE (80yd) view-create band, then wait until each
+// puzzle view is built. The entry-end park used for the screenshot leaves the
+// far-end panels (e.g. the ledger tablet at local z=76, ~87yd from the entry)
+// OUTSIDE the create range, so their views never build and (b) would falsely
+// fail on interest culling rather than a real hidden-panel bug. From the centre
+// the room half-diagonal (~47yd for a 110x50 room) is comfortably in range.
+// Bounded poll so a GENUINELY missing/mis-placed view (the (b) bug class) still
+// surfaces as a failure instead of hanging.
+async function centerForProbe(target) {
+  await page.evaluate((t) => {
+    const sim = window.__game.sim;
+    const run = sim.delveRunForPlayer(sim.playerId);
+    run.moduleIndex = t;
+    run.exitPortalOpen = false;
+    const b = window.__litanyBounds(run.modules[t]);
+    const zBase = window.__delveModuleZOffset(run.modules, t);
+    const p = sim.player;
+    p.pos.x = run.origin.x;
+    p.pos.z = run.origin.z + zBase + (b.zMin + b.zMax) / 2;
+    p.pos.y = 0;
+    p.prevPos = { ...p.pos };
+    p.facing = 0;
+  }, target);
+  await sleep(1200);
+  await page
+    .waitForFunction(
+      (prefixes) => {
+        const sim = window.__game.sim;
+        const run = sim.delveRunForPlayer(sim.playerId);
+        const views = window.__game.renderer.views;
+        const puzzleIds = run.objectIds.filter((id) => {
+          const e = sim.entities.get(id);
+          return e && prefixes.some((pre) => (e.templateId || '').startsWith(pre));
+        });
+        if (puzzleIds.length === 0) return true; // no panels in this module
+        return puzzleIds.every((id) => views.has(id));
+      },
+      { timeout: 6000, polling: 300 },
+      PUZZLE_TEMPLATE_PREFIXES,
+    )
+    .catch(() => {
+      // Timed out: leave it to the (b) assertions to report the missing view.
+    });
+}
+
+// The scene-graph probe for one module. Returns everything the checks assert on.
+// All geometry math runs in-page against window.__game.renderer's live scene.
+async function probeModule(moduleId) {
+  return page.evaluate(
+    ({ moduleId, prefixes }) => {
+      const sim = window.__game.sim;
+      const renderer = window.__game.renderer;
+      const run = sim.delveRunForPlayer(sim.playerId);
+      const scene = renderer.scene;
+      const views = renderer.views;
+
+      const geo = window.__litanyGeometry(moduleId);
+      const bounds = window.__litanyBounds(moduleId);
+      const zBase = window.__delveModuleZOffset(run.modules, run.moduleIndex);
+      const ox = run.origin.x;
+      const oz = run.origin.z + zBase;
+
+      // Module world footprint (with a small margin so a mesh straddling the
+      // wall still counts as "in the room interior").
+      const worldBounds = {
+        xMin: ox + bounds.minX - 2,
+        xMax: ox + bounds.maxX + 2,
+        zMin: oz + bounds.zMin - 2,
+        zMax: oz + bounds.zMax + 2,
+      };
+      const inModuleXZ = (x, z) =>
+        x >= worldBounds.xMin &&
+        x <= worldBounds.xMax &&
+        z >= worldBounds.zMin &&
+        z <= worldBounds.zMax;
+
+      // Floor height the interior renders at (flat delve floor). Sample it from
+      // the SAME groundHeight the sim/render share, at the module centre.
+      const floorY = window.__groundHeight(ox, oz + (bounds.zMin + bounds.zMax) / 2, sim.cfg.seed);
+
+      // ---- gather scene meshes with world geometry -------------------------
+      // We walk the whole scene once, capturing per-mesh: world-space center,
+      // an approximate largest planar face area, whether the material is a
+      // plain untextured color, and whether it is (roughly) axis-flat. The
+      // meshes already expose real THREE geometry.boundingBox / boundingSphere
+      // (Box3 / Sphere with .clone()/.applyMatrix4()) and mesh.matrixWorld
+      // (Matrix4), so no `three` import is needed in-page.
+      const worldCenter = (mesh) => {
+        const g = mesh.geometry;
+        if (!g) return null;
+        if (!g.boundingSphere) g.computeBoundingSphere();
+        const c = g.boundingSphere.center.clone();
+        mesh.updateWorldMatrix(true, false);
+        c.applyMatrix4(mesh.matrixWorld);
+        return { x: c.x, y: c.y, z: c.z };
+      };
+
+      // World-space AABB size for a mesh (accounts for the group offset + any
+      // baked geometry translate).
+      const worldSize = (mesh) => {
+        const g = mesh.geometry;
+        if (!g) return null;
+        if (!g.boundingBox) g.computeBoundingBox();
+        mesh.updateWorldMatrix(true, false);
+        const bb = g.boundingBox.clone().applyMatrix4(mesh.matrixWorld);
+        return {
+          x: bb.max.x - bb.min.x,
+          y: bb.max.y - bb.min.y,
+          z: bb.max.z - bb.min.z,
+          min: { x: bb.min.x, y: bb.min.y, z: bb.min.z },
+          max: { x: bb.max.x, y: bb.max.y, z: bb.max.z },
+        };
+      };
+
+      // Is the material a plain, untextured single-color material (no map of any
+      // kind)? A fallback quad uses exactly this; a real floor/prop is textured.
+      const isUntexturedPlain = (mat) => {
+        if (!mat) return false;
+        const m = Array.isArray(mat) ? mat[0] : mat;
+        if (!m) return false;
+        const mapKeys = [
+          'map',
+          'normalMap',
+          'roughnessMap',
+          'metalnessMap',
+          'aoMap',
+          'emissiveMap',
+          'alphaMap',
+          'bumpMap',
+          'displacementMap',
+        ];
+        for (const k of mapKeys) if (m[k]) return false;
+        return true;
+      };
+
+      // ---- (a) giant untextured floating quads -----------------------------
+      // Threshold: a flat mesh whose largest planar face is bigger than a sane
+      // room-prop cap AND that floats clearly off the floor AND is inside the
+      // room. The Blackwater pool overlays are flush at the floor (y<=~0.2) so
+      // they never qualify; a re-introduced fallback panel would.
+      const GIANT_FACE_AREA = 220; // yd^2: bigger than any legit floor-flush pool overlay face at this scale
+      const FLAT_THICKNESS = 0.6; // a "quad" is near-flat on one axis
+      const FLOOR_EPS = 0.9; // meshes within this of the floor count as anchored
+      const giantQuads = [];
+      let meshCount = 0;
+      scene.traverse((obj) => {
+        if (!obj.isMesh) return;
+        const size = worldSize(obj);
+        if (!size) return;
+        const c = worldCenter(obj);
+        if (!c) return;
+        if (!inModuleXZ(c.x, c.z)) return;
+        meshCount++;
+        // Which axis is flat? Compute the two largest extents (the face).
+        const ext = [size.x, size.y, size.z];
+        const flatAxis = ext.indexOf(Math.min(...ext));
+        if (ext[flatAxis] > FLAT_THICKNESS) return; // not flat enough to be a quad
+        const face = ext.filter((_, i) => i !== flatAxis);
+        const faceArea = face[0] * face[1];
+        if (faceArea < GIANT_FACE_AREA) return;
+        if (!isUntexturedPlain(obj.material)) return; // textured big surfaces are legit (floor, water)
+        // Floating? Its lowest point sits clearly above the floor.
+        const floats = size.min.y > floorY + FLOOR_EPS;
+        if (!floats) return;
+        giantQuads.push({
+          faceArea: Math.round(faceArea),
+          y: Number(c.y.toFixed(2)),
+          minY: Number(size.min.y.toFixed(2)),
+          size: {
+            x: Number(size.x.toFixed(1)),
+            y: Number(size.y.toFixed(1)),
+            z: Number(size.z.toFixed(1)),
+          },
+          matType: (Array.isArray(obj.material) ? obj.material[0] : obj.material)?.type,
+        });
+      });
+
+      // ---- (c) hazard telegraphs -------------------------------------------
+      // Collect the floor-flush, untextured, single-color pool overlay meshes
+      // (CircleGeometry / RingGeometry) inside the room. These are the telegraph
+      // visuals placeMarshBlackwaterPools builds. Group them into clusters by
+      // world x,z so a pool (fill + rim + edge, several meshes at one centre)
+      // reads as ONE telegraph.
+      const poolMeshes = [];
+      scene.traverse((obj) => {
+        if (!obj.isMesh) return;
+        const g = obj.geometry;
+        if (!g) return;
+        const type = g.type || '';
+        if (type !== 'CircleGeometry' && type !== 'RingGeometry') return;
+        const mat = Array.isArray(obj.material) ? obj.material[0] : obj.material;
+        if (!mat || mat.type !== 'MeshBasicMaterial') return;
+        if (mat.map) return; // the additive glow decal is textured; exclude it
+        const c = worldCenter(obj);
+        if (!c) return;
+        if (!inModuleXZ(c.x, c.z)) return;
+        // Pool overlays sit flush at the floor (y ~0.1 to 0.16). Exclude any
+        // stray elevated ring (e.g. a triggered-plate glow inset).
+        if (c.y > floorY + 0.5) return;
+        poolMeshes.push({ x: c.x, z: c.z });
+      });
+      // Cluster the pool meshes into telegraph centres (2yd link radius).
+      const clusters = [];
+      for (const m of poolMeshes) {
+        let hit = null;
+        for (const cl of clusters) {
+          if (Math.hypot(cl.x - m.x, cl.z - m.z) <= 3) {
+            hit = cl;
+            break;
+          }
+        }
+        if (hit) {
+          hit.x = (hit.x * hit.n + m.x) / (hit.n + 1);
+          hit.z = (hit.z * hit.n + m.z) / (hit.n + 1);
+          hit.n++;
+        } else {
+          clusters.push({ x: m.x, z: m.z, n: 1 });
+        }
+      }
+
+      // For each authored hazard, is there a telegraph cluster whose centre
+      // lands within that hazard's radius (world coords)? Deep + shallow of a
+      // concentric pair share a centre, so one cluster can cover both.
+      const hazards = geo ? geo.hazards : [];
+      const hazardWorld = hazards.map((h) => ({
+        x: ox + h.x,
+        z: oz + h.z,
+        rx: h.rx ?? h.r,
+        rz: h.rz ?? h.r,
+        tier: h.tier ?? 'deep',
+      }));
+      const hazardCovered = hazardWorld.map((h) => {
+        // Point-in-ellipse (with a small tolerance) for any cluster centre.
+        return clusters.some((cl) => {
+          const dx = cl.x - h.x;
+          const dz = cl.z - h.z;
+          const tolx = h.rx + 1.5;
+          const tolz = h.rz + 1.5;
+          return (dx * dx) / (tolx * tolx) + (dz * dz) / (tolz * tolz) <= 1;
+        });
+      });
+      const uncoveredHazards = hazardWorld.filter((_, i) => !hazardCovered[i]);
+
+      // Phantom telegraph: a cluster centre that lands inside NO authored hazard
+      // (allowing the same radius tolerance). Concentric pairs make many
+      // clusters legitimately land inside a hazard; a phantom is one that does
+      // not match any zone at all.
+      const phantomClusters = clusters.filter((cl) => {
+        return !hazardWorld.some((h) => {
+          const dx = cl.x - h.x;
+          const dz = cl.z - h.z;
+          const tolx = h.rx + 2.5;
+          const tolz = h.rz + 2.5;
+          return (dx * dx) / (tolx * tolx) + (dz * dz) / (tolz * tolz) <= 1;
+        });
+      });
+
+      // ---- (b) floor panel findability -------------------------------------
+      // The progression interactables for this module: their sim entities, then
+      // their render views.
+      const puzzleEntities = [];
+      for (const id of run.objectIds) {
+        const e = sim.entities.get(id);
+        if (!e) continue;
+        if (!prefixes.some((pre) => (e.templateId || '').startsWith(pre))) continue;
+        puzzleEntities.push(e);
+      }
+      const panels = puzzleEntities.map((e) => {
+        const v = views.get(e.id);
+        let viewY = null;
+        let hasRealMaterial = false;
+        let isFallbackCrate = false;
+        const matTypes = [];
+        if (v && v.group) {
+          v.group.updateWorldMatrix(true, false);
+          viewY = v.group.position.y;
+          // Walk the view's meshes: a real prop uses surfaceMat (Standard /
+          // Lambert / Basic with intended color) or emissive runes; the missing
+          // -asset fallback is a 1x0.9x1 wood BoxGeometry crate with iron bands.
+          let boxCount = 0;
+          let crateSizedBox = false;
+          v.group.traverse((o) => {
+            if (!o.isMesh) return;
+            const mat = Array.isArray(o.material) ? o.material[0] : o.material;
+            if (mat) {
+              matTypes.push(mat.type);
+              if (
+                mat.type === 'MeshStandardMaterial' ||
+                mat.type === 'MeshLambertMaterial' ||
+                mat.type === 'MeshBasicMaterial' ||
+                mat.type === 'MeshPhongMaterial'
+              )
+                hasRealMaterial = true;
+            }
+            const g = o.geometry;
+            if (g && g.type === 'BoxGeometry') {
+              boxCount++;
+              const params = g.parameters || {};
+              // buildFallbackCrate body is exactly 1.0 x 0.9 x 1.0.
+              if (
+                Math.abs((params.width ?? 0) - 1.0) < 0.01 &&
+                Math.abs((params.height ?? 0) - 0.9) < 0.01 &&
+                Math.abs((params.depth ?? 0) - 1.0) < 0.01
+              )
+                crateSizedBox = true;
+            }
+          });
+          // The fallback crate is a body box + 2 iron band boxes and nothing
+          // else; require both the tell-tale body size AND the low box count.
+          isFallbackCrate = crateSizedBox && boxCount <= 3 && matTypes.length <= 4;
+        }
+        const localX = e.pos.x - ox;
+        const localZ = e.pos.z - oz;
+        return {
+          id: e.id,
+          templateId: e.templateId,
+          hasView: !!v,
+          viewY: viewY == null ? null : Number(viewY.toFixed(3)),
+          floorY: Number(floorY.toFixed(3)),
+          atFloor: viewY != null && Math.abs(viewY - floorY) <= 0.25,
+          inBounds: inModuleXZ(e.pos.x, e.pos.z),
+          localX: Number(localX.toFixed(1)),
+          localZ: Number(localZ.toFixed(1)),
+          hasRealMaterial,
+          isFallbackCrate,
+          matTypes,
+        };
+      });
+
+      return {
+        moduleId,
+        activeModuleId: run.modules[run.moduleIndex],
+        meshCount,
+        floorY: Number(floorY.toFixed(3)),
+        worldBounds,
+        // (a)
+        giantQuads,
+        // (c)
+        hazardCount: hazards.length,
+        clusterCount: clusters.length,
+        clusters: clusters.map((c) => ({
+          x: Number(c.x.toFixed(1)),
+          z: Number(c.z.toFixed(1)),
+          n: c.n,
+        })),
+        uncoveredHazards: uncoveredHazards.map((h) => ({
+          x: Number(h.x.toFixed(1)),
+          z: Number(h.z.toFixed(1)),
+          tier: h.tier,
+        })),
+        phantomClusters: phantomClusters.map((c) => ({
+          x: Number(c.x.toFixed(1)),
+          z: Number(c.z.toFixed(1)),
+        })),
+        // (b)
+        panelCount: panels.length,
+        panels,
+      };
+    },
+    { moduleId, prefixes: PUZZLE_TEMPLATE_PREFIXES },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Walk every module: advance, place camera, screenshot, probe, assert.
+// ---------------------------------------------------------------------------
+const summaries = [];
+for (let mi = 0; mi < ALL_MODULES.length; mi++) {
+  const moduleId = ALL_MODULES[mi];
+  const label = moduleId.replace('litany_', '');
+  await pinAndParkModule(mi);
+  // Screenshot from the entry vantage (clear up-room sightline over the water).
+  await page.screenshot({ path: `tmp/litany_visual_${mi}_${label}.png` });
+  // Then move to the module centre so every interactable is inside the renderer's
+  // view-create range before the (b) findability probe reads the scene views.
+  await centerForProbe(mi);
+
+  const probe = await probeModule(moduleId);
+  summaries.push(probe);
+  console.log(
+    `\n[${mi}] ${moduleId} (active=${probe.activeModuleId}) meshes=${probe.meshCount} floorY=${probe.floorY}`,
+  );
+  console.log(
+    `    hazards=${probe.hazardCount} telegraphClusters=${probe.clusterCount} panels=${probe.panelCount} giantQuads=${probe.giantQuads.length}`,
+  );
+
+  // Guard: the renderer must actually have built the module this iteration.
+  check(
+    `[${label}] renderer positioned on the active module`,
+    probe.activeModuleId === moduleId && probe.meshCount > 0,
+    `active=${probe.activeModuleId} meshes=${probe.meshCount}`,
+  );
+
+  // ---- (a) no giant untextured floating quads ----
+  check(
+    `[${label}] (a) no giant untextured quad floating in the interior`,
+    probe.giantQuads.length === 0,
+    probe.giantQuads.length ? JSON.stringify(probe.giantQuads) : 'none',
+  );
+
+  // ---- (c) telegraphs match the sim hazards ----
+  if (probe.hazardCount > 0) {
+    check(
+      `[${label}] (c) a telegraph pool exists at every authored hazard`,
+      probe.uncoveredHazards.length === 0,
+      probe.uncoveredHazards.length
+        ? `uncovered ${JSON.stringify(probe.uncoveredHazards)} (clusters ${JSON.stringify(probe.clusters)})`
+        : `${probe.hazardCount} hazards covered by ${probe.clusterCount} clusters`,
+    );
+    check(
+      `[${label}] (c) no phantom telegraph where no hazard exists`,
+      probe.phantomClusters.length === 0,
+      probe.phantomClusters.length ? JSON.stringify(probe.phantomClusters) : 'none',
+    );
+  } else {
+    // Modules with no authored hazard should show no floor-flush pool telegraph
+    // either (a phantom would be a bug just the same).
+    check(
+      `[${label}] (c) no telegraph pool in a hazard-free module`,
+      probe.phantomClusters.length === 0,
+      probe.phantomClusters.length ? JSON.stringify(probe.phantomClusters) : 'none',
+    );
+  }
+
+  // ---- (b) floor panel findability (only modules that gate on a panel) ----
+  if (probe.panelCount > 0) {
+    const allFound = probe.panels.every((p) => p.hasView);
+    const allAtFloor = probe.panels.every((p) => p.atFloor);
+    const allInBounds = probe.panels.every((p) => p.inBounds);
+    const allRealMat = probe.panels.every((p) => p.hasRealMaterial && !p.isFallbackCrate);
+    check(
+      `[${label}] (b) every progression panel has a render view`,
+      allFound,
+      allFound
+        ? `${probe.panelCount} panels`
+        : JSON.stringify(probe.panels.map((p) => ({ id: p.id, hasView: p.hasView }))),
+    );
+    check(
+      `[${label}] (b) every panel sits at interior floor height`,
+      allAtFloor,
+      allAtFloor
+        ? `floorY=${probe.floorY}`
+        : JSON.stringify(
+            probe.panels.map((p) => ({
+              id: p.id,
+              viewY: p.viewY,
+              floorY: p.floorY,
+              atFloor: p.atFloor,
+            })),
+          ),
+    );
+    check(
+      `[${label}] (b) every panel is inside the module bounds`,
+      allInBounds,
+      allInBounds
+        ? 'ok'
+        : JSON.stringify(
+            probe.panels.map((p) => ({
+              id: p.id,
+              localX: p.localX,
+              localZ: p.localZ,
+              inBounds: p.inBounds,
+            })),
+          ),
+    );
+    check(
+      `[${label}] (b) every panel has a real material (not a missing-asset fallback crate)`,
+      allRealMat,
+      allRealMat
+        ? 'ok'
+        : JSON.stringify(
+            probe.panels.map((p) => ({
+              id: p.id,
+              hasRealMaterial: p.hasRealMaterial,
+              isFallbackCrate: p.isFallbackCrate,
+              matTypes: p.matTypes,
+            })),
+          ),
+    );
+  } else {
+    console.log(`    (b) no progression panel authored in ${label}; skipped`);
+  }
+}
+
+// A cross-module sanity floor: check (b) must have actually exercised at least
+// the four panel-gated modules, or the whole (b) arm silently passed on nothing.
+const panelModules = summaries.filter((s) => s.panelCount > 0).map((s) => s.moduleId);
+check(
+  '(b) exercised the panel-gated modules (sluice/ledger/ring/choir_loft)',
+  panelModules.length >= 4,
+  `panel modules: ${panelModules.join(', ') || 'none'}`,
+);
+// And check (c) must have exercised real hazards in the marsh modules.
+const hazardModules = summaries.filter((s) => s.hazardCount > 0).map((s) => s.moduleId);
+check(
+  '(c) exercised authored hazards in the marsh modules',
+  hazardModules.length >= 5,
+  `hazard modules: ${hazardModules.join(', ') || 'none'}`,
+);
+
+console.log(`\nerrors: ${errors.length ? errors.slice(0, 6).join(' | ') : 'none'}`);
+console.log(`\n=== ${pass} passed, ${fail} failed ===`);
+await browser.close();
+process.exit(fail > 0 || errors.length > 0 ? 1 : 0);

--- a/scripts/gen_sfx.mjs
+++ b/scripts/gen_sfx.mjs
@@ -26,7 +26,7 @@ const force = process.argv.includes('--force');
 try {
   process.loadEnvFile();
 } catch {
-  /* no .env — rely on the ambient env */
+  /* no .env, rely on the ambient env */
 }
 const KEY = process.env.ELEVENLABS_API_KEY;
 if (!KEY) {
@@ -88,7 +88,7 @@ for (const entry of SFX) {
     console.log('ok');
     await sleep(200);
   } catch (err) {
-    // One bad clip shouldn't abort the whole run — record it and continue.
+    // One bad clip shouldn't abort the whole run: record it and continue.
     console.log('FAILED');
     console.error(`  ${err.message}`);
     failed.push(entry.key);

--- a/src/render/delve_marsh_dressing.ts
+++ b/src/render/delve_marsh_dressing.ts
@@ -430,16 +430,18 @@ export function placeMarshBlackwaterPools(
     const sxr = (h.rx ?? h.r) / h.r;
     const szr = (h.rz ?? h.r) / h.r;
     if (isShallow) {
-      // Shallow: lighter teal, more translucent - reads as wading depth.
+      // Shallow: teal, but opaque enough to read as a damaging pool, not clear
+      // floor. Shallow Blackwater still hurts, so the fill and the warning rim
+      // carry real contrast (a faint teal wash was read as safe wading water).
       const pool = new THREE.Mesh(
         new THREE.CircleGeometry(r, 36)
           .scale(sxr, szr, 1)
           .rotateX(-Math.PI / 2)
           .translate(h.x, 0.1, h.z),
         new THREE.MeshBasicMaterial({
-          color: 0x1a5a6a,
+          color: 0x123f4c,
           transparent: true,
-          opacity: 0.52,
+          opacity: 0.72,
           depthWrite: false,
         }),
       );
@@ -453,7 +455,7 @@ export function placeMarshBlackwaterPools(
         new THREE.MeshBasicMaterial({
           color: 0x4adaaa,
           transparent: true,
-          opacity: 0.38,
+          opacity: 0.6,
           side: THREE.DoubleSide,
           depthWrite: false,
           blending: THREE.AdditiveBlending,
@@ -461,6 +463,24 @@ export function placeMarshBlackwaterPools(
       );
       rim.renderOrder = 2;
       group.add(rim);
+      // A defined outer boundary ring so the pool edge (where the damage starts)
+      // reads at a glance, the same telegraph the deep pool gets.
+      const edge = new THREE.Mesh(
+        new THREE.RingGeometry(r * 0.98, r * 1.06, 40)
+          .scale(sxr, szr, 1)
+          .rotateX(-Math.PI / 2)
+          .translate(h.x, 0.15, h.z),
+        new THREE.MeshBasicMaterial({
+          color: 0x6fe8c4,
+          transparent: true,
+          opacity: 0.5,
+          side: THREE.DoubleSide,
+          depthWrite: false,
+          blending: THREE.AdditiveBlending,
+        }),
+      );
+      edge.renderOrder = 3;
+      group.add(edge);
       addGlow(h.x, h.z, 0x3abcaa, 0.06, r * 0.8);
     } else {
       // Deep (default): dark near-opaque navy/black - reads as drowning danger.

--- a/src/sim/delve_litany_layout.ts
+++ b/src/sim/delve_litany_layout.ts
@@ -279,14 +279,17 @@ const LITANY_SLUICE = litanyRoom({
     },
   ],
   // Wall-hugging pool chain: west, east, west. The dry lane snakes between the
-  // pools instead of skirting one central blob.
+  // pools instead of skirting one central blob. Each shallow/deep pair stays
+  // concentric; the east z33 and west z47 pairs are pulled a touch inward (x 7->5,
+  // -7->-6) so the shallow rim keeps a ~2yd dry margin off the side wall (at the
+  // authored x it reached the wall edge and drowned the outer walkway ring).
   hazards: [
     { x: -8, z: 18, r: 8, tier: 'shallow' },
     { x: -8, z: 18, r: 5, tier: 'deep' },
-    { x: 7, z: 33, r: 8, tier: 'shallow' },
-    { x: 7, z: 33, r: 5, tier: 'deep' },
-    { x: -7, z: 47, r: 7, tier: 'shallow' },
-    { x: -7, z: 47, r: 4, tier: 'deep' },
+    { x: 5, z: 33, r: 8, tier: 'shallow' },
+    { x: 5, z: 33, r: 5, tier: 'deep' },
+    { x: -6, z: 47, r: 7, tier: 'shallow' },
+    { x: -6, z: 47, r: 4, tier: 'deep' },
   ],
   islands: [
     { x: 0, z: -9, hw: 5, hd: 3 },
@@ -368,15 +371,18 @@ const LITANY_LEDGER = litanyRoom({
     },
   ],
   // Staggered pool chain east, center, west, east: the island line threads the
-  // center pool as stepping stones while the dry bank alternates sides.
+  // center pool as stepping stones while the dry bank alternates sides. The three
+  // wall-side pairs are pulled inward (x 14->9, -13->-9, 13->10), keeping each
+  // shallow/deep pair concentric, so the shallow rim clears the side wall by ~2yd:
+  // at the authored x these rims crossed the wall edge and drowned the walkway ring.
   hazards: [
-    { x: 14, z: 24, r: 9, tier: 'shallow' },
-    { x: 14, z: 24, r: 6, tier: 'deep' },
+    { x: 9, z: 24, r: 9, tier: 'shallow' },
+    { x: 9, z: 24, r: 6, tier: 'deep' },
     { x: 0, z: 40, r: 7, tier: 'shallow' },
-    { x: -13, z: 42, r: 9, tier: 'shallow' },
-    { x: -13, z: 42, r: 6, tier: 'deep' },
-    { x: 13, z: 60, r: 8, tier: 'shallow' },
-    { x: 13, z: 60, r: 5, tier: 'deep' },
+    { x: -9, z: 42, r: 9, tier: 'shallow' },
+    { x: -9, z: 42, r: 6, tier: 'deep' },
+    { x: 10, z: 60, r: 8, tier: 'shallow' },
+    { x: 10, z: 60, r: 5, tier: 'deep' },
   ],
   islands: [
     { x: 0, z: -11, hw: 5, hd: 3 },
@@ -547,12 +553,15 @@ const LITANY_BAPTISTRY = litanyRoom({
     },
   ],
   // Sinkhole font with a diagonal feed: inlet channel from the northeast,
-  // outlet to the southwest, so the rim walk spirals rather than circles.
+  // outlet to the southwest, so the rim walk spirals rather than circles. The
+  // two feeder pools are pulled in (x 14->12, -14->-12) so their rims keep a
+  // ~2yd dry margin off the side wall: at the authored x they touched the wall
+  // edge and drowned the outer walkway ring.
   hazards: [
     { x: 0, z: 38, r: 14, tier: 'shallow' },
     { x: 0, z: 38, r: 10, tier: 'deep' },
-    { x: 14, z: 24, r: 7, tier: 'shallow' },
-    { x: -14, z: 50, r: 7, tier: 'shallow' },
+    { x: 12, z: 24, r: 7, tier: 'shallow' },
+    { x: -12, z: 50, r: 7, tier: 'shallow' },
   ],
   islands: [
     { x: 0, z: -9, hw: 5, hd: 3 },
@@ -632,16 +641,19 @@ const LITANY_CHOIR_LOFT = litanyRoom({
     },
   ],
   // Two slanted seepage channels drifting inward toward the dais: the fan's
-  // dry aisles zigzag between them instead of running three straight lanes.
+  // dry aisles zigzag between them instead of running three straight lanes. The
+  // two wall-side pairs are pulled inward (x -16->-12, 16->15), staying
+  // concentric, so their shallow rims keep a ~2yd dry margin off the side wall:
+  // at the authored x they overshot the wall and drowned the outer walkway ring.
   hazards: [
-    { x: -16, z: 22, r: 7, tier: 'shallow' },
-    { x: -16, z: 22, r: 4, tier: 'deep' },
+    { x: -12, z: 22, r: 7, tier: 'shallow' },
+    { x: -12, z: 22, r: 4, tier: 'deep' },
     { x: -11, z: 36, r: 7, tier: 'shallow' },
     { x: 2, z: 30, r: 7, tier: 'shallow' },
     { x: -3, z: 46, r: 7, tier: 'shallow' },
     { x: -3, z: 46, r: 4, tier: 'deep' },
-    { x: 16, z: 28, r: 8, tier: 'shallow' },
-    { x: 16, z: 28, r: 5, tier: 'deep' },
+    { x: 15, z: 28, r: 8, tier: 'shallow' },
+    { x: 15, z: 28, r: 5, tier: 'deep' },
     { x: 9, z: 46, r: 7, tier: 'shallow' },
   ],
   islands: [
@@ -818,7 +830,10 @@ const LITANY_APSE = litanyRoom({
     },
   ],
   hazards: [
-    { x: 0, z: 56, rx: 24, rz: 17, r: 24, tier: 'shallow' },
+    // Shallow moat rx pulls in to 22 (from 24) so the outer walkway ring
+    // (|x| ~= 23.8 at z 48 to 91) keeps a dry flank margin: at rx 24 the moat
+    // edge reached x=24 at z=56 and drowned the authored safe path.
+    { x: 0, z: 56, rx: 22, rz: 17, r: 22, tier: 'shallow' },
     { x: 0, z: 56, rx: 21, rz: 14, r: 21, tier: 'deep' },
     { x: -12, z: 22, r: 6, tier: 'deep' },
     { x: 12, z: 26, r: 6, tier: 'deep' },

--- a/src/sim/delves/companion.ts
+++ b/src/sim/delves/companion.ts
@@ -83,7 +83,7 @@ export function updateDelveCompanion(ctx: SimContext, companion: Entity): void {
     }
   }
   if (owner.dead) {
-    ctx.dropEntity(companion.id);
+    ctx.despawnDelveCompanion(run);
     return;
   }
   if (owner.inCombat) ctx.maybeCompanionBark(run, owner.id, 'combat_start');

--- a/src/sim/delves/drowned_litany_boss.ts
+++ b/src/sim/delves/drowned_litany_boss.ts
@@ -95,6 +95,25 @@ export function resetDrownedLitanyBossEncounter(ctx: SimContext, boss: Entity): 
   initDrownedLitanyBossState(run);
 }
 
+// Player death: the Tolling Bells volley and Blackwater Mark puddles must not
+// outlive the death, or an in-delve respawn at the module entry can be hit (or
+// insta-killed) by an effect that was already in flight before they died. Drop
+// every in-flight bell entity and empty both collections. Unlike the evade/leash
+// reset above, this does NOT re-init the encounter: firedCantorPhases,
+// finalBellFired, cantorShieldAdds, and bellVolleyTimer stay untouched so the
+// fight keeps progressing for any party members still alive.
+export function clearDrownedLitanyBellsAndMarks(ctx: SimContext, run: DelveRun): void {
+  if (run.delveId !== 'drowned_litany') return;
+  const st = run.nhaliaBoss;
+  if (!st) return;
+  for (const bell of st.bells) {
+    const be = ctx.entities.get(bell.entityId);
+    if (be && !be.dead) ctx.dropEntity(bell.entityId);
+  }
+  st.bells = [];
+  st.marks = [];
+}
+
 function findNhaliaBoss(ctx: SimContext, run: DelveRun): Entity | null {
   for (const id of run.mobIds) {
     const e = ctx.entities.get(id);

--- a/src/sim/entity_roster.ts
+++ b/src/sim/entity_roster.ts
@@ -20,7 +20,8 @@
 // `src/sim`-pure: no DOM/Three/render/ui/game/net imports, no Math.random/Date.now
 // (enforced by tests/architecture.test.ts).
 
-import { dungeonAt, zoneAt } from './data';
+import { DELVES, dungeonAt, zoneAt } from './data';
+import { clearDrownedLitanyBellsAndMarks } from './delves/drowned_litany_boss';
 import { recalcPlayerStats } from './entity';
 import { aurasSurvivingDeath } from './resurrection';
 import type { SimContext } from './sim_context';
@@ -178,6 +179,10 @@ export function releaseSpiritInDelve(ctx: SimContext, pid: number): void {
   p.pos = entry;
   p.prevPos = { ...entry };
   rebucketEntity(ctx, p);
+  // The Drowned Litany finale: in-flight Tolling Bells and Blackwater Mark
+  // puddles must not outlive the death, or the respawned player can be hit
+  // (or insta-killed) by an effect that was already active before they died.
+  clearDrownedLitanyBellsAndMarks(ctx, run);
   p.facing = 0;
   // The Keeper's Toll persists through a delve death too (see resurrection.ts); every
   // other aura clears on respawn.
@@ -194,6 +199,19 @@ export function releaseSpiritInDelve(ctx: SimContext, pid: number): void {
   p.targetId = null;
   p.combatTimer = 99;
   p.inCombat = false;
+  // The owner-dead arm of updateDelveCompanion despawns the auto-companion (and
+  // clears run.companion) while the player is dead. Re-spawn her here so she is
+  // back at the player's side promptly on release, same as a fresh delve entry.
+  // Despawn any stale reference first (belt and suspenders: a caller that
+  // releases without an intervening tick, e.g. a direct test/parity drive,
+  // still has a live run.companion at this point) so the guard on
+  // spawnDelveCompanion never no-ops. This draws no rng and does not touch
+  // run.companionReviveUsed, so the once-per-run revive boon is unaffected.
+  const delve = DELVES[run.delveId];
+  if (run.partyKey?.startsWith('solo:') && delve?.autoCompanionId) {
+    if (run.companion) ctx.despawnDelveCompanion(run);
+    ctx.spawnDelveCompanion(run, pid, delve.autoCompanionId);
+  }
   ctx.emit({ type: 'respawn', pid });
 }
 

--- a/tests/delve_companion.test.ts
+++ b/tests/delve_companion.test.ts
@@ -224,6 +224,84 @@ describe('delve companions', () => {
     expect(p.dead).toBe(true); // no second revive in the same run
   });
 
+  it('companion respawns after an in-delve player death and release', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(10);
+    teleport(sim, 0, 0);
+    sim.enterDelve('collapsed_reliquary', 'normal');
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    expect(run.companion).toBeDefined();
+    const oldId = run.companion!.entityId;
+
+    // Kill the owner and advance a couple of ticks so the mob-AI pass runs the
+    // owner-dead arm of updateDelveCompanion, which drops the companion entity
+    // before the player's spirit is released (mirrors the live sequence).
+    sim.player.dead = true;
+    sim.player.hp = 0;
+    sim.tick();
+    sim.tick();
+    expect(sim.entities.has(oldId)).toBe(false);
+
+    sim.releaseSpirit();
+
+    expect(run.companion).toBeDefined();
+    expect(run.companion!.entityId).not.toBe(oldId);
+    expect(sim.entities.has(run.companion!.entityId)).toBe(true);
+    expect(sim.companionState).not.toBeNull();
+  });
+
+  it('companion respawns after death in the Drowned Litany (Edda Reedhand)', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(14);
+    teleport(sim, 0, 0);
+    sim.enterDelve('drowned_litany', 'normal');
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    expect(run.companion?.companionId).toBe('companion_edda');
+    const oldId = run.companion!.entityId;
+
+    sim.player.dead = true;
+    sim.player.hp = 0;
+    sim.tick();
+    sim.tick();
+    expect(sim.entities.has(oldId)).toBe(false);
+
+    sim.releaseSpirit();
+
+    expect(run.companion?.companionId).toBe('companion_edda');
+    expect(run.companion!.entityId).not.toBe(oldId);
+    expect(sim.entities.has(run.companion!.entityId)).toBe(true);
+  });
+
+  it('respawning the companion after death does not recharge the rank 3 revive boon', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(20);
+    const meta = (sim as any).players.get(sim.playerId);
+    meta.companionUpgrades.companion_tessa = 3;
+    teleport(sim, 0, 0);
+    sim.enterDelve('collapsed_reliquary', 'normal');
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    const companion = sim.entities.get(run.companion!.entityId)!;
+
+    // Spend the once-per-run revive first.
+    sim.player.dead = true;
+    sim.player.hp = 0;
+    updateDelveCompanion((sim as any).ctx, companion);
+    expect(sim.player.dead).toBe(false);
+    expect(run.companionReviveUsed).toBe(true);
+
+    // A real death now (revive already spent) drops the companion; release
+    // should respawn her but must not reset the spent flag.
+    sim.player.dead = true;
+    sim.player.hp = 0;
+    sim.tick();
+    sim.tick();
+    sim.releaseSpirit();
+
+    expect(run.companionReviveUsed).toBe(true);
+    expect(run.companion).toBeDefined();
+    expect(sim.entities.has(run.companion!.entityId)).toBe(true);
+  });
+
   it('companion upgrade rank 2 costs 3 marks (Marks only, no copper)', () => {
     const sim = makeSim();
     const meta = (sim as any).players.get(sim.playerId);

--- a/tests/delves.test.ts
+++ b/tests/delves.test.ts
@@ -27,8 +27,8 @@ import {
 } from '../src/sim/delve_litany_layout';
 import { isLitanyPuzzleKind, LITANY_PUZZLE_KINDS } from '../src/sim/delves/drowned_litany_rooms';
 import { rollDelveAffixes } from '../src/sim/delves/runs';
-
 import { createMob } from '../src/sim/entity';
+import { polygonContainsPoint } from '../src/sim/geometry2d';
 import { solveLockActions } from '../src/sim/lockpick';
 import { PLAYER_BODY_RADIUS } from '../src/sim/pathfind';
 import { Rng } from '../src/sim/rng';
@@ -1777,7 +1777,7 @@ describe('The Drowned Litany (Phase 3 static Blackwater hazard)', () => {
     const sim = makeSim('warrior');
     enterLitany(sim);
     enterModule(sim, 'litany_apse');
-    const hz = hazardWorld(sim, 'litany_apse', 0); // shallow: rx 24, rz 17, r 24
+    const hz = hazardWorld(sim, 'litany_apse', 0); // shallow: rx 22, rz 17, r 22
     const p = sim.player;
     const hitsAt = (dx: number, dz: number) => {
       p.pos.x = hz.x + dx;
@@ -1925,6 +1925,65 @@ describe('The Drowned Litany (Phase 3 static Blackwater hazard)', () => {
     expect(countBlackwaterHits(sim, 25)).toBeGreaterThan(0);
   });
 
+  it('the apse outer walkway ring has a dry flank path (no Blackwater on the ring)', () => {
+    const sim = makeSim('warrior');
+    enterLitany(sim, 'heroic');
+    enterModule(sim, 'litany_apse');
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    const zBase = delveModuleZOffset(run.modules, run.moduleIndex);
+    // Clear the room so only the hazard could deal damage during the window.
+    for (const id of [...run.mobIds]) (sim as any).dropEntity(id);
+    const p = sim.player;
+    const ringHits = (localX: number, localZ: number) => {
+      p.pos.x = run.origin.x + localX;
+      p.pos.z = run.origin.z + zBase + localZ;
+      p.prevPos = { ...p.pos };
+      return countBlackwaterHits(sim, 45);
+    };
+    // The outer walkway ring reaches |x| ~= 23.8 at z 48 to 91 (the authored
+    // safe path). One yard in from the wall on the east and west flanks at
+    // z=56 must be dry: the shallow moat must not pinch the ring.
+    expect(ringHits(22.8, 56)).toBe(0);
+    expect(ringHits(-22.8, 56)).toBe(0);
+    // Control: the central moat is still lethal (the fix must not neuter it).
+    expect(ringHits(18, 56)).toBeGreaterThan(0);
+  });
+
+  it('the trash modules keep a dry wall-hugging walkway (shallow pools do not drown the ring)', () => {
+    // The same class of bug as the apse moat: a shallow Blackwater pool authored
+    // so its rim reaches the outer walkable-ring wall band drowns ground that
+    // reads as clean walkway, dealing invisible damage. Each probe below is a
+    // point ~1-2yd inside the side wall on the flank the pool overshot; it must
+    // be dry. A same-module control confirms the pool still damages further in.
+    const cases: Array<{
+      moduleId: string;
+      dry: [number, number];
+      wet: [number, number];
+    }> = [
+      { moduleId: 'litany_sluice', dry: [13, 29], wet: [7, 33] },
+      { moduleId: 'litany_baptistry', dry: [17, 18], wet: [12, 24] },
+      { moduleId: 'litany_ledger', dry: [19, 18], wet: [9, 24] },
+      { moduleId: 'litany_choir_loft', dry: [-18, 17], wet: [-12, 22] },
+    ];
+    for (const c of cases) {
+      const sim = makeSim('warrior');
+      enterLitany(sim, 'heroic');
+      enterModule(sim, c.moduleId);
+      const run = sim.delveRunForPlayer(sim.playerId)!;
+      const zBase = delveModuleZOffset(run.modules, run.moduleIndex);
+      for (const id of [...run.mobIds]) (sim as any).dropEntity(id);
+      const p = sim.player;
+      const hitsAt = (localX: number, localZ: number) => {
+        p.pos.x = run.origin.x + localX;
+        p.pos.z = run.origin.z + zBase + localZ;
+        p.prevPos = { ...p.pos };
+        return countBlackwaterHits(sim, 45);
+      };
+      expect(hitsAt(...c.dry), `${c.moduleId} wall-hug walkway must be dry`).toBe(0);
+      expect(hitsAt(...c.wet), `${c.moduleId} interior pool must still damage`).toBeGreaterThan(0);
+    }
+  });
+
   it('pins the deep (2.0x) and shallow (0.35x) tier multipliers on the 4% Normal base', () => {
     const pulse = (localX: number, localZ: number) => {
       const sim = makeSim('warrior');
@@ -2064,6 +2123,56 @@ describe('The Drowned Litany (Phase 5 room puzzles)', () => {
       expect(run.exitPortalOpen, `after puzzle ${i + 1}/${puzzles.length}`).toBe(
         i === puzzles.length - 1,
       );
+    }
+  });
+
+  it('the north-passage exit spawns on findable, walkable, hazard-clear ground in every trash module', () => {
+    // Findability guard for the progression object (the module_exit "Sealed
+    // Passage" the player walks into to advance): in every non-finale Drowned
+    // Litany module it must be spawned, sit on the walkable polygon, be clear of
+    // the shell/interior colliders (reachable, not walled off), and not sit under
+    // a Blackwater hazard (a submerged or blocked exit reads as "no way forward").
+    for (const moduleId of DELVES.drowned_litany.modules) {
+      const sim = makeSim('warrior');
+      enterLitany(sim);
+      const run = sim.delveRunForPlayer(sim.playerId)!;
+      // Two-module run so this module is NOT the finale (the finale has a boss,
+      // not a north-passage exit).
+      run.modules = [moduleId, 'litany_apse'];
+      run.moduleIndex = 0;
+      (sim as any).spawnDelveModule(run);
+      const zBase = delveModuleZOffset(run.modules, 0);
+      const exitId = run.objectIds.find((id) => run.objectState[id]?.kind === 'module_exit');
+      expect(exitId, `${moduleId} spawns a module_exit`).toBeDefined();
+      const exit = sim.entities.get(exitId!)!;
+      const localX = exit.pos.x - run.origin.x;
+      const localZ = exit.pos.z - run.origin.z - zBase;
+      // On the authored walkable polygon (not off the mapped floor).
+      const poly = litanyModuleGeometry(moduleId as any)!.walkable[0].points;
+      expect(
+        polygonContainsPoint(poly, localX, localZ),
+        `${moduleId} exit (${localX.toFixed(1)},${localZ.toFixed(1)}) is inside the walkable polygon`,
+      ).toBe(true);
+      // Reachable: the exit body is not inside a movement collider (wall/pillar/
+      // island). The exit portal radius is generous, so require the centre clear.
+      expect(
+        plateBlocked(moduleId, localX, localZ),
+        `${moduleId} exit is walled off by a collider`,
+      ).toBe(false);
+      // Not under a Blackwater pool: a player standing on the exit takes no damage.
+      const p = sim.player;
+      for (const id of [...run.mobIds]) (sim as any).dropEntity(id);
+      p.pos.x = exit.pos.x;
+      p.pos.z = exit.pos.z;
+      p.prevPos = { ...p.pos };
+      let blackwaterHits = 0;
+      for (let i = 0; i < 45; i++) {
+        for (const ev of sim.tick()) {
+          if (ev.type === 'damage' && ev.targetId === p.id && ev.ability === 'Blackwater')
+            blackwaterHits++;
+        }
+      }
+      expect(blackwaterHits, `${moduleId} exit sits under a Blackwater hazard`).toBe(0);
     }
   });
 
@@ -2683,6 +2792,68 @@ describe('The Drowned Litany (Phase 6 boss mechanics)', () => {
       (e) => e.templateId === 'choir_thrall' && !e.dead,
     );
     expect(thralls.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('a player death clears in-flight bells and Blackwater marks so an in-delve respawn is not insta-killed', () => {
+    const sim = makeSim();
+    const run = enterLitanyApse(sim);
+    const boss = nhalia(sim);
+    boss.inCombat = true;
+
+    // Force a bell volley: bells are now in flight.
+    run.nhaliaBoss!.bellVolleyTimer = 0.001;
+    (sim as any).updateDelveRuns();
+    expect(run.nhaliaBoss!.bells.length).toBeGreaterThan(0);
+    const bellIds = run.nhaliaBoss!.bells.map((b) => b.entityId);
+
+    // Force a Blackwater mark: a puddle is now persisted at the player's position.
+    run.nhaliaBoss!.markTimer = 0.001;
+    (sim as any).updateDelveRuns();
+    expect(run.nhaliaBoss!.marks.length).toBeGreaterThanOrEqual(1);
+
+    // Kill the player and respawn in-delve (first death: 50% HP at the module entry).
+    killPlayer(sim);
+    expect(sim.player.dead).toBe(true);
+    sim.releaseSpirit();
+    expect(sim.player.dead).toBe(false);
+
+    // The bell/mark lethal effects must not outlive the death: they are cleared
+    // at respawn, so the entity ids are gone and the collections are empty.
+    expect(run.nhaliaBoss!.bells).toEqual([]);
+    expect(run.nhaliaBoss!.marks).toEqual([]);
+    for (const id of bellIds) expect(sim.entities.has(id)).toBe(false);
+
+    // The respawned player takes no further bell/mark damage: the loop is broken.
+    const hpAfterRespawn = sim.player.hp;
+    for (let i = 0; i < 20; i++) (sim as any).updateDelveRuns();
+    expect(sim.player.hp).toBe(hpAfterRespawn);
+
+    // The encounter itself is not re-armed by the death (unlike an evade reset):
+    // Cantor phases / Final Bell progress and the volley timer are untouched.
+    expect(run.nhaliaBoss!.bellVolleyTimer).toBeGreaterThan(0);
+  });
+
+  it('a player death clearing bells does not perturb the shared rng draw order', () => {
+    const runOnce = (seed: number) => {
+      const sim = makeSim('warrior', seed);
+      const run = enterLitanyApse(sim);
+      const boss = nhalia(sim);
+      boss.inCombat = true;
+      run.nhaliaBoss!.bellVolleyTimer = 0.001;
+      (sim as any).updateDelveRuns();
+      killPlayer(sim);
+      sim.releaseSpirit();
+      // A few more volleys/marks after the respawn to exercise further rng draws.
+      for (let i = 0; i < 20 * 15; i++) (sim as any).updateDelveRuns();
+      return {
+        firedCantorPhases: run.nhaliaBoss!.firedCantorPhases,
+        finalBellFired: run.nhaliaBoss!.finalBellFired,
+        bells: run.nhaliaBoss!.bells.length,
+        marks: run.nhaliaBoss!.marks.length,
+        bellVolleyTimer: Math.round(run.nhaliaBoss!.bellVolleyTimer * 1000),
+      };
+    };
+    expect(runOnce(42)).toEqual(runOnce(42));
   });
 });
 

--- a/tests/parity/golden/delve_death.json
+++ b/tests/parity/golden/delve_death.json
@@ -118,7 +118,7 @@
     {
       "tick": 0,
       "time": 0,
-      "nextId": 410,
+      "nextId": 411,
       "state": "943d2821",
       "events": "23be8555",
       "rng": {
@@ -222,7 +222,7 @@
     {
       "tick": 2,
       "time": 0.1,
-      "nextId": 410,
+      "nextId": 411,
       "state": "7f243ad0",
       "events": "c2d0b576",
       "rng": {
@@ -327,7 +327,7 @@
     {
       "tick": 2,
       "time": 0.1,
-      "nextId": 410,
+      "nextId": 411,
       "state": "7f243ad0",
       "events": "741638a5",
       "rng": {


### PR DESCRIPTION
## Problem

Live Heroic runs of The Drowned Litany hit four bug clusters:

- Blackwater hazard damage landing on ground that reads as safe walkway, with no clear telegraph (about 200 damage per second on the module 4 apse walkway ring, and similar wall-hugging spots in four trash modules).
- The progression floor panel appearing unfindable (module 3, The Crescent Sluice).
- Sister Nhalia's Tolling Bells volley one-shotting a player, then killing them again immediately after the in-delve respawn (a respawn death loop).
- The delve auto-companion never respawning after the owner dies, for the rest of the run. This is a shared-path bug affecting every delve (Edda Reedhand and Acolyte Tessa alike).

## What changed

- **Blackwater walkway safety** (`src/sim/delve_litany_layout.ts`): the apse shallow moat narrows (rx 24 to 22) and the wall-side pools in sluice, baptistry, ledger, and choir loft nudge inward so every authored walkway keeps a dry margin. Fine-grid scans show zero submerged walkway rows across those modules. The causeway is deliberately untouched: its pools reach the walls by design and the dry path is the island spine. Balance neutral: the pools remain lethal, the authored dry paths are simply dry again.
- **Telegraph readability** (`src/render/delve_marsh_dressing.ts`): shallow Blackwater renders with higher fill opacity and a brighter rim so wadeable-but-damaging water no longer reads as harmless. Presentation only, gameplay neutral.
- **Bell death loop** (`src/sim/delves/drowned_litany_boss.ts`, `src/sim/entity_roster.ts`): a new `clearDrownedLitanyBellsAndMarks` drops every in-flight bell and Blackwater Mark when a player dies and releases in-delve, so a respawn can never be hit by a volley that outlived the death. Boss phases and timers stay untouched, so the fight keeps progressing for a surviving duo partner. One reviewable semantic: bells are not player-targeted, so a duo death clears the current volley for both players; the next volley re-fires seconds later. Flag if you would rather gate the clear to solo runs.
- **Companion respawn** (`src/sim/delves/companion.ts`, `src/sim/entity_roster.ts`): the owner-dead arm of `updateDelveCompanion` now despawns through `despawnDelveCompanion` (clearing `run.companion` instead of leaving a dangling entity id), and `releaseSpiritInDelve` re-spawns the auto-companion for a solo run. The once-per-run rank 3 revive stays spent across the respawn.
- **Floor panels**: root-caused as NOT a sim placement bug. A new test proves the north-passage exit spawns on findable, walkable, hazard-clear ground in every non-finale module. The reported symptom is attributed to the (out of scope, see below) render occlusion artifact plus the previously untelegraphed hazards.

## Verification

- Every fix landed test-first (the failing test was confirmed to fail for the right reason before the fix). `tests/delves.test.ts` and `tests/delve_companion.test.ts` gained 8 tests, covering both delves and the duo path.
- On this exact branch: 380 delve-suite and guard tests green, the full parity gate green, `tsc --noEmit` clean, changed-file biome clean.
- `tests/parity/golden/delve_death.json` regenerated deliberately in its own commit: the companion respawn allocates one entity id (`nextId` 410 to 411 in three snapshots), no event-digest or rng draw-order change.
- Two new real-browser E2E suites (headless Chrome driving the offline sim through `window.__game`, dev server on :5173): `scripts/delve_death_e2e.mjs` (24 checks: companion respawn, bell clear with a live-player negative control, layout-derived dry and wet hazard probes) and `scripts/delve_panel_visual_e2e.mjs` (46 checks across all seven modules: no giant untextured quad in any interior, every progression interactable floor-anchored with a real material in bounds, every sim hazard zone covered by a visible telegraph and no phantom telegraphs). Both deterministic across consecutive runs and verified to flip red under injected regressions.

## Known issue, deliberately out of scope

The giant untextured tan rectangle visible in the original report screenshots did not reproduce in the offline client in any of the seven modules under the new visual scan. The delve render pipeline was traced (no fallback-box path, shared kit atlas, pools and islands accounted for); the suspect is an online-only or asset-variant artifact needing live-client mesh inspection. The new E2E quad scan now guards it permanently in CI-adjacent tooling, and it is tracked as a follow-up.

## Note on the last commit

`chore(scripts): remove em dashes from gen_sfx comments` fixes two comment-only copy-rule violations that arrived with the quest-sfx merge; they block the repo's pre-push QA floor for any branch based on `release/v0.23.0`, so the fix rides along here.

Generated with [Claude Code](https://claude.com/claude-code)