### PR TITLE
fix(tests): run npm .bin shims via shell on Windows in the endpoint golden

### DIFF
--- a/tests/server/new_endpoint.test.ts
+++ b/tests/server/new_endpoint.test.ts
@@ -57,6 +57,9 @@ const REPO = fileURLToPath(new URL('../../', import.meta.url));
 const SCRIPT = join(REPO, 'scripts', 'new_endpoint.mjs');
 const TSC = join(REPO, 'node_modules', '.bin', 'tsc');
 const VITEST = join(REPO, 'node_modules', '.bin', 'vitest');
+// The .bin shims are .cmd files on Windows, which spawnSync only launches via a
+// shell (the same workaround scripts/gate.mjs uses for npm/npx).
+const SHELL = process.platform === 'win32';
 
 // Every file the generator appends to, seeded as a copy into each temp root.
 const APPEND_TARGETS = [
@@ -105,13 +108,17 @@ function gitPorcelain(): string {
  */
 function runChildVitest(root: string, testPaths: string[]): { status: number; out: string } {
   const config = join(root, 'vitest.golden.config.mjs');
+  // include entries are globs: keep them forward-slashed so a Windows path's
+  // backslashes are not eaten as glob escapes.
+  const include = testPaths.map((p) => p.replaceAll('\\', '/'));
   writeFileSync(
     config,
-    `export default { test: { include: ${JSON.stringify(testPaths)}, exclude: [] } };\n`,
+    `export default { test: { include: ${JSON.stringify(include)}, exclude: [] } };\n`,
   );
   const result = spawnSync(VITEST, ['run', '--config', config], {
     cwd: REPO,
     encoding: 'utf8',
+    shell: SHELL,
     // CI runners color the piped child output (ANSI then sits between "Tests" and the
     // count in the summary line, defeating the plain-text assertions below), so ask the
     // child for no color and strip whatever arrives anyway.
@@ -468,7 +475,11 @@ describe('golden: all three rungs emit, type-check, and pass (one temp root)', (
         files,
       }),
     );
-    const tsc = spawnSync(TSC, ['-p', tsconfig, '--noEmit'], { cwd: REPO, encoding: 'utf8' });
+    const tsc = spawnSync(TSC, ['-p', tsconfig, '--noEmit'], {
+      cwd: REPO,
+      encoding: 'utf8',
+      shell: SHELL,
+    });
     expect(tsc.status, `tsc failed:\n${tsc.stdout}\n${tsc.stderr}`).toBe(0);
 
     // All three emitted tests PASS, plus the code-catalog snapshot stays green against the


### PR DESCRIPTION
## Summary

Makes tests/server/new_endpoint.test.ts pass on Windows checkouts. It spawned
node_modules/.bin/tsc and .bin/vitest directly, but on Windows those are .cmd
shims that spawnSync can only launch through a shell (the same workaround
scripts/gate.mjs already applies to npm/npx), so the spawn returned status
null and the golden failed on every Windows machine. The child vitest include
paths are also forward-slashed: they are globs, and a backslashed Windows
path is consumed as glob escapes and matches no test files.

No production code changes; CI (Linux) is unaffected, this fixes the local
gate for Windows contributors.

## Related issues

Part of #1531 (targets `release/v0.23.0`).

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [x] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands: `npx vitest run tests/server/new_endpoint.test.ts` (23/23 green on
  Windows 11, previously 1 failing); full `npm run gate` green on Windows with
  this fix applied; `npx tsc --noEmit` clean.
- Manual steps: none needed; test-infrastructure-only change.

---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** Unaffected (test-only change); verified via the
      full gate regardless.

### Cross-platform

- [ ] ~Tested on desktop and mobile.~ N/A, no player-facing surface.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed; no generated files
      touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)