### PR TITLE
fix(ui): keep map canvas aligned with UI scale

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -3446,6 +3446,17 @@
   /* map */
   #map-window {
     --window-pad: 14px;
+    --map-canvas-border: 2px;
+    --map-canvas-frame: calc(
+      var(--window-pad) + var(--window-pad) + var(--map-canvas-border) + var(--map-canvas-border)
+    );
+    --map-canvas-max: min(
+      560px,
+      calc(var(--app-vw, 100vw) / var(--window-scale, 1) - 16px - var(--map-canvas-frame)),
+      calc(var(--app-vh, 100vh) * 0.85 / var(--window-scale, 1) - 24px - var(--map-canvas-frame))
+    );
+    box-sizing: border-box;
+    overflow: hidden;
   }
   /* zoom controls, matching the micro-menu button look */
   #map-zoom {
@@ -4150,7 +4161,10 @@
     align-items: center;
   }
   #map-canvas {
-    border: 2px solid var(--border);
+    display: block;
+    width: var(--map-canvas-max);
+    height: var(--map-canvas-max);
+    border: var(--map-canvas-border) solid var(--border);
     outline: 1px solid #000;
     border-radius: 4px;
     touch-action: none;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -249,6 +249,11 @@ import {
   parseUntrackedQuests,
   serializeUntrackedQuests,
 } from './map_quest_list_view';
+import {
+  mapCanvasPointFromEvent,
+  readMapCanvasRenderedBox,
+  syncMapCanvasSize,
+} from './map_canvas_size';
 import { type MapRegion, mapCanvasHeight, paintTerrainRows } from './map_terrain';
 import { MapWindowPainter } from './map_window_painter';
 import {
@@ -1463,13 +1468,13 @@ export class Hud {
     });
     mapCanvas.addEventListener('pointermove', (ev) => {
       if (!this.mapDrag || !this.mapView) return;
-      const rect = mapCanvas.getBoundingClientRect();
+      const box = readMapCanvasRenderedBox(mapCanvas);
       // "grab the paper" pan: the world point under the cursor stays under it.
       // toMap draws +X to the left and +Z up (mx = (maxX-x)/span, my = (maxZ-z)/
       // span), so a cursor delta of (dx, dy) px shifts the centre by (+dx, +dy)
       // world units on each axis.
-      const wppx = this.mapView.spanX / rect.width;
-      const wppy = this.mapView.spanZ / rect.height;
+      const wppx = this.mapView.spanX / box.contentWidth;
+      const wppy = this.mapView.spanZ / box.contentHeight;
       this.mapCenter = {
         x: this.mapDrag.cx + (ev.clientX - this.mapDrag.px) * wppx,
         z: this.mapDrag.cz + (ev.clientY - this.mapDrag.py) * wppy,
@@ -1503,13 +1508,11 @@ export class Hud {
         hideMapAreaTip();
         return;
       }
-      const rect = mapCanvas.getBoundingClientRect();
-      const cx = ((ev.clientX - rect.left) * mapCanvas.width) / rect.width;
-      const cy = ((ev.clientY - rect.top) * mapCanvas.height) / rect.height;
-      const glyph = npcMarkerAt(this.mapNpcMarkers, cx, cy);
+      const point = mapCanvasPointFromEvent(mapCanvas, ev);
+      const glyph = npcMarkerAt(this.mapNpcMarkers, point.x, point.y);
       const html = glyph
         ? this.questGiverTooltipHtml(glyph)
-        : this.questAreaTooltipHtml(questAreaObjectivesAt(this.mapQuestAreas, cx, cy));
+        : this.questAreaTooltipHtml(questAreaObjectivesAt(this.mapQuestAreas, point.x, point.y));
       if (!html) {
         hideMapAreaTip();
         return;
@@ -6771,8 +6774,8 @@ export class Hud {
   // map_window_painter; the pure geometry lives in map_window_view.ts.
   private updateMapWindow(): void {
     const canvas = $('#map-canvas') as unknown as HTMLCanvasElement;
+    const S = syncMapCanvasSize(canvas);
     const ctx = require2dContext(canvas);
-    const S = canvas.width;
     const p = this.sim.player;
     const summaryEl = $('#map-summary');
 

--- a/src/ui/map_canvas_size.ts
+++ b/src/ui/map_canvas_size.ts
@@ -1,0 +1,115 @@
+export interface MapCanvasRenderedSize {
+  width: number;
+  height: number;
+}
+
+export interface MapCanvasRenderedBox {
+  left?: number;
+  top?: number;
+  width: number;
+  height: number;
+  borderLeft?: number;
+  borderRight?: number;
+  borderTop?: number;
+  borderBottom?: number;
+  contentWidth?: number;
+  contentHeight?: number;
+}
+
+export interface MapCanvasPoint {
+  x: number;
+  y: number;
+}
+
+function finitePx(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number.parseFloat(String(value ?? ''));
+  return Number.isFinite(n) ? n : 0;
+}
+
+function positiveSquareFallback(canvas: HTMLCanvasElement): number {
+  const size = Math.min(canvas.width, canvas.height);
+  if (Number.isFinite(size) && size > 0) return size;
+  const attrSize = Math.min(
+    finitePx(canvas.getAttribute?.('width')),
+    finitePx(canvas.getAttribute?.('height')),
+  );
+  return attrSize > 0 ? attrSize : 1;
+}
+
+export function mapCanvasRenderedContentSize(box: MapCanvasRenderedBox): MapCanvasRenderedSize {
+  const borderLeft = finitePx(box.borderLeft);
+  const borderRight = finitePx(box.borderRight);
+  const borderTop = finitePx(box.borderTop);
+  const borderBottom = finitePx(box.borderBottom);
+  return {
+    width: Math.max(0, finitePx(box.contentWidth ?? box.width - borderLeft - borderRight)),
+    height: Math.max(0, finitePx(box.contentHeight ?? box.height - borderTop - borderBottom)),
+  };
+}
+
+export function readMapCanvasRenderedBox(canvas: HTMLCanvasElement): Required<MapCanvasRenderedBox> {
+  const rect = canvas.getBoundingClientRect();
+  const style = getComputedStyle(canvas);
+  const borderLeft = finitePx(style.borderLeftWidth);
+  const borderRight = finitePx(style.borderRightWidth);
+  const borderTop = finitePx(style.borderTopWidth);
+  const borderBottom = finitePx(style.borderBottomWidth);
+  const content = mapCanvasRenderedContentSize({
+    width: rect.width,
+    height: rect.height,
+    borderLeft,
+    borderRight,
+    borderTop,
+    borderBottom,
+  });
+  return {
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+    height: rect.height,
+    borderLeft,
+    borderRight,
+    borderTop,
+    borderBottom,
+    contentWidth: content.width,
+    contentHeight: content.height,
+  };
+}
+
+export function syncMapCanvasSize(
+  canvas: HTMLCanvasElement,
+  rendered = mapCanvasRenderedContentSize(readMapCanvasRenderedBox(canvas)),
+): number {
+  const rawSize = Math.min(finitePx(rendered.width), finitePx(rendered.height));
+  const size = rawSize > 0 ? Math.max(1, Math.round(rawSize)) : positiveSquareFallback(canvas);
+  if (canvas.width !== size) canvas.width = size;
+  if (canvas.height !== size) canvas.height = size;
+  return size;
+}
+
+export function mapCanvasPointFromClient(
+  box: MapCanvasRenderedBox,
+  clientX: number,
+  clientY: number,
+  canvasSize: number,
+): MapCanvasPoint {
+  const content = mapCanvasRenderedContentSize(box);
+  const contentWidth = content.width > 0 ? content.width : canvasSize;
+  const contentHeight = content.height > 0 ? content.height : canvasSize;
+  const x = ((clientX - finitePx(box.left) - finitePx(box.borderLeft)) * canvasSize) / contentWidth;
+  const y = ((clientY - finitePx(box.top) - finitePx(box.borderTop)) * canvasSize) / contentHeight;
+  return { x, y };
+}
+
+export function mapCanvasPointFromEvent(
+  canvas: HTMLCanvasElement,
+  event: Pick<PointerEvent, 'clientX' | 'clientY'>,
+  canvasSize = canvas.width,
+): MapCanvasPoint {
+  return mapCanvasPointFromClient(
+    readMapCanvasRenderedBox(canvas),
+    event.clientX,
+    event.clientY,
+    canvasSize,
+  );
+}

--- a/tests/map_canvas_size.test.ts
+++ b/tests/map_canvas_size.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mapCanvasPointFromClient,
+  mapCanvasRenderedContentSize,
+  syncMapCanvasSize,
+} from '../src/ui/map_canvas_size';
+
+function canvas(attrs: { width?: number; height?: number } = {}): HTMLCanvasElement {
+  return {
+    width: attrs.width ?? 560,
+    height: attrs.height ?? 560,
+  } as HTMLCanvasElement;
+}
+
+describe('map_canvas_size', () => {
+  it('keeps the default 560px square backing store when the rendered content is 560px', () => {
+    const c = canvas();
+    const size = syncMapCanvasSize(c, { width: 560, height: 560 });
+    expect(size).toBe(560);
+    expect(c.width).toBe(560);
+    expect(c.height).toBe(560);
+  });
+
+  it('shrinks the backing store to a smaller rendered square', () => {
+    const c = canvas();
+    const size = syncMapCanvasSize(c, { width: 438, height: 438 });
+    expect(size).toBe(438);
+    expect(c.width).toBe(438);
+    expect(c.height).toBe(438);
+  });
+
+  it('uses the smaller rendered side so the map coordinate space stays square', () => {
+    const c = canvas();
+    const size = syncMapCanvasSize(c, { width: 520, height: 440 });
+    expect(size).toBe(440);
+    expect(c.width).toBe(440);
+    expect(c.height).toBe(440);
+  });
+
+  it('falls back to the existing backing store when the rendered size is hidden or zero', () => {
+    const c = canvas({ width: 512, height: 512 });
+    const size = syncMapCanvasSize(c, { width: 0, height: 0 });
+    expect(size).toBe(512);
+    expect(c.width).toBe(512);
+    expect(c.height).toBe(512);
+  });
+
+  it('maps client coordinates into the border-aware canvas content coordinate space', () => {
+    const point = mapCanvasPointFromClient(
+      {
+        left: 100,
+        top: 50,
+        width: 444,
+        height: 444,
+        borderLeft: 2,
+        borderTop: 2,
+        contentWidth: 440,
+        contentHeight: 440,
+      },
+      322,
+      272,
+      440,
+    );
+    expect(point).toEqual({ x: 220, y: 220 });
+  });
+
+  it('reads rendered content size by subtracting border from the border-box rect', () => {
+    const size = mapCanvasRenderedContentSize({
+      width: 444,
+      height: 442,
+      borderLeft: 2,
+      borderRight: 2,
+      borderTop: 1,
+      borderBottom: 1,
+    });
+    expect(size).toEqual({ width: 440, height: 440 });
+  });
+});

--- a/tests/map_window_painter.test.ts
+++ b/tests/map_window_painter.test.ts
@@ -87,4 +87,22 @@ describe('map_window_painter: cadence + cached background preserved', () => {
     // Hud keeps the bg cache + prewarm and passes the cached canvas in each redraw.
     expect(hud).toContain('bg: this.mapZoneBg(zone)');
   });
+
+  it('syncs the canvas backing store before either world-map branch paints', () => {
+    expect(hud).toContain("from './map_canvas_size'");
+    expect(hud).toContain('const S = syncMapCanvasSize(canvas);');
+    expect(hud.indexOf('const S = syncMapCanvasSize(canvas);')).toBeLessThan(
+      hud.indexOf("if (mapWindowMode(this.sim) === 'delve')"),
+    );
+    expect(hud.indexOf('const S = syncMapCanvasSize(canvas);')).toBeLessThan(
+      hud.indexOf('this.mapPainter.paintOverworld(ctx, this.sim, {'),
+    );
+  });
+
+  it('routes map hover and drag through shared rendered-canvas coordinate helpers', () => {
+    expect(hud).toContain('mapCanvasPointFromEvent(mapCanvas, ev)');
+    expect(hud).toContain('const box = readMapCanvasRenderedBox(mapCanvas);');
+    expect(hud).toContain('const wppx = this.mapView.spanX / box.contentWidth;');
+    expect(hud).not.toContain('const rect = mapCanvas.getBoundingClientRect();');
+  });
 });


### PR DESCRIPTION
Closes #1559

## Summary
- Added a shared map canvas sizing helper to sync the canvas backing store with rendered CSS-pixel size.
- Updated map drag, hover hit testing, NPC hover, quest hover, delve paint, and overworld paint to use the synced coordinate space.
- Updated map canvas CSS so it stays square and fits inside the UI-scaled viewport.
- Added focused coverage for canvas sizing and painter source guards.

## Testing
Passed:
- `npx vitest run tests/map_canvas_size.test.ts tests/map_window_painter.test.ts tests/map_window_view.test.ts tests/delve_map.test.ts tests/delve_map_painter.test.ts`
- `npx tsc --noEmit`
- `npm run security:gate`
- `npm run build`

Known unrelated failure:
- `npm test` failed in the current dirty tree with 48 failures, mainly unrelated timeout/i18n freshness/localization issues such as `hudChrome.options.lockActionBars` and generated i18n hash mismatch.

Manual verification:
- Local Playwright verification against `npm run dev` passed at UI Scale 100%, 85%, and 140%.
- Confirmed the map remains square, stays fully inside the map window, and keeps the canvas backing store aligned with rendered content.
- Exercised map zoom in, zoomed drag/pan, pointer hover movement, close, and reopen.
- Screenshots for 100%, 85%, and 140% will be attached in the PR conversation.
