### PR TITLE
fix(sim): death left channeling armed, turning the next cast into a per-tick bolt hose

### DIFF
--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -482,8 +482,16 @@ export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): 
   // it, so mobs still clear fully.
   e.auras = aurasSurvivingDeath(e.auras);
   e.ccDr.clear();
+  // Death clears the WHOLE cast/channel state (the same fields cancelCast resets,
+  // without its castStop emit). Nulling only castingAbility left `channeling`
+  // armed through death, so the victim's next timed cast after a resurrection ran
+  // updateCasting's channel branch and re-fired the spell's effects on every
+  // leftover channel-tick boundary (the Pyrelance "hundreds of fireballs" bug).
   e.castingAbility = null;
   e.castTargetId = null;
+  e.channeling = false;
+  e.castRemaining = 0;
+  e.castAim = null;
   ctx.emit({ type: 'death', entityId: e.id, killerId: killer?.id ?? -1 });
 
   // a dead mob keeps no raid marker — respawnMob reuses the same entity id,

--- a/tests/combat_casting_lifecycle.test.ts
+++ b/tests/combat_casting_lifecycle.test.ts
@@ -284,6 +284,57 @@ describe('casting_lifecycle: determinism', () => {
   });
 });
 
+describe('casting_lifecycle: death mid-channel fully clears the channel state', () => {
+  it('handleDeath on a channeling caster clears channeling, not just castingAbility', () => {
+    const { sim, p } = makeSim('warlock', 12);
+    const mob = spawnTarget(sim, p);
+    castAbility(sim.ctx, 'drain_life', p.id);
+    expect(p.channeling).toBe(true);
+    expect(p.castRemaining).toBeGreaterThan(0);
+    handleDeath(sim.ctx, p, mob); // the CASTER dies mid-channel
+    expect(p.castingAbility).toBeNull();
+    expect(p.castTargetId).toBeNull();
+    expect(p.channeling).toBe(false); // stale true turned the next timed cast into a channel
+    expect(p.castRemaining).toBe(0);
+    expect(p.castAim).toBeNull();
+  });
+
+  it('a timed cast after a mid-channel death resolves ONCE at completion, not per channel tick', () => {
+    // The live repro (the Pyrelance "hundreds of fireballs" raid bug): a mage dies
+    // while channeling, gets back up, and casts a timed nuke. The stale
+    // channeling flag sent updateCasting down the channel branch, re-firing the
+    // nuke's effects on every leftover channel-tick boundary DURING the cast.
+    const { sim, p, meta } = makeSim('mage', 20);
+    const mob = spawnTarget(sim, p, 20, 6);
+    castAbility(sim.ctx, 'arcane_missiles', p.id);
+    expect(p.channeling).toBe(true);
+    handleDeath(sim.ctx, p, mob); // dies mid-channel
+    p.dead = false; // revived on the spot (test-suite revive idiom)
+    p.hp = p.maxHp;
+    p.resource = p.maxResource;
+    p.gcdRemaining = 0;
+    sim.drainEvents();
+
+    castAbility(sim.ctx, 'pyroblast', p.id);
+    expect(p.castingAbility).toBe('pyroblast');
+    let n = 0;
+    while (p.castingAbility && n++ < 1000) {
+      updateCasting(sim.ctx, p, meta);
+      // No bolt may launch while the cast is still in progress: a mid-cast
+      // projectile means the channel branch fired the nuke early.
+      if (p.castingAbility) expect(sim.ctx.pendingProjectiles).toHaveLength(0);
+    }
+    expect(p.castingAbility).toBeNull();
+    expect(sim.ctx.pendingProjectiles).toHaveLength(1); // exactly one bolt, at completion
+    for (let i = 0; i < 200 && sim.ctx.pendingProjectiles.length > 0; i++)
+      advancePendingProjectiles(sim.ctx);
+    const resolutions = sim
+      .drainEvents()
+      .filter((e: any) => e.type === 'damage' && e.ability === 'Pyrelance');
+    expect(resolutions).toHaveLength(1); // one cast = one resolution (hit or resist)
+  });
+});
+
 describe('casting_lifecycle: physical ranged shots resolve on projectile impact (Long Draw)', () => {
   it('deals no damage at cast completion; damage lands when the arrow arrives', () => {
     const { sim, p, meta } = makeSim('hunter', 20);

--- a/tests/nythraxis_raid.test.ts
+++ b/tests/nythraxis_raid.test.ts
@@ -2278,6 +2278,62 @@ describe('Nythraxis raid encounter', () => {
     expect(tank.hp).toBeLessThan(tank.maxHp);
   });
 
+  it('fully clears the ward-channel cast state when the channeler dies mid-channel', () => {
+    // Regression: handleDeath nulled castingAbility but left `channeling` armed,
+    // and clearNythraxisWardChannelCast no-ops once castingAbility is null, so a
+    // player killed mid-ward-channel kept channeling=true through resurrection.
+    // Their next timed cast (Pyrelance) then ran the channel branch and re-fired
+    // its damage every leftover channel tick: the "hundreds of fireballs" bug.
+    const sim = makeWorld();
+    const tankPid = sim.addPlayer('warrior', 'Tank');
+    const origin = enterRaid(sim, tankPid);
+    const tank = sim.entities.get(tankPid)!;
+    tank.maxHp = 1e7;
+    tank.hp = tank.maxHp;
+    const boss = mob(sim, 'nythraxis_scourge_of_thornpeak');
+    engage(boss, tank);
+    boss.nythraxis = {
+      phase: 2,
+      introSpoken: true,
+      transitionStarted: true,
+      transitionTimer: 0,
+      transitionCues: [],
+      transitionReleased: true,
+      gravebreakerTimer: 99,
+      raiseFallenTimer: 99,
+      soulRendTimer: 99,
+      soulRendMarks: [],
+      soulRendLockout: 0,
+      deathlessTimer: 0,
+      deathlessCastRemaining: 0,
+      deathlessStunRemaining: 0,
+      wardChannels: [],
+      finalStand: false,
+      deathSpoken: false,
+    };
+    sim.tick();
+
+    const ward = objects(sim, 'bastion_ward_stone', origin)[0];
+    const pid = sim.addPlayer('mage', 'DoomedMage');
+    teleport(sim, pid, ward.pos.x, ward.pos.z);
+    sim.targetEntity(ward.id, pid);
+    sim.interact(pid);
+    sim.tick();
+    const mage = sim.entities.get(pid)!;
+    expect(mage.castingAbility).toBe('nythraxis_ward_channel');
+    expect(mage.channeling).toBe(true);
+
+    (sim as any).dealDamage(boss, mage, mage.maxHp * 10, false, 'shadow', null, 'hit', true);
+    expect(mage.dead).toBe(true);
+    expect(mage.castingAbility).toBeNull();
+    expect(mage.channeling).toBe(false); // death must clear the WHOLE cast state
+    expect(mage.castRemaining).toBe(0);
+
+    sim.tick();
+    const channel = boss.nythraxis!.wardChannels.find((c) => c.objectId === ward.id)!;
+    expect(channel.playerId).toBeNull(); // the slot frees for another raider
+  });
+
   it('starts wardstone channels through the object click pickup path', () => {
     const sim = makeWorld();
     const tankPid = sim.addPlayer('warrior', 'Tank');


### PR DESCRIPTION
## Summary

Fixes the live raid report: mages casting Pyrelance (pyroblast) at Nythraxis firing "hundreds of fireballs" (one player at ~1393 dps on the damage meter, roughly 40x expected).

### Root cause

`handleDeath` (src/sim/combat/damage.ts) cleared `castingAbility`/`castTargetId` on death but left `channeling` armed, along with `castRemaining`/`castAim`. The failure chain:

1. A player dies mid-channel. In the Nythraxis raid this is easy: the wardstone channel (`tryStartNythraxisWardChannel`) sets `channeling = true` with the fake cast id `nythraxis_ward_channel`, and dying mid-ward-channel also defeats the encounter's own cleanup, because `clearNythraxisWardChannelCast` guards on `castingAbility === 'nythraxis_ward_channel'`, which `handleDeath` has already nulled. A real channel (Aether Darts, Drain Life) hits the same gap.
2. No resurrection path resets `channeling`, so the player carries `channeling = true` back into the fight.
3. Their next timed cast passes `castAbility`'s busy check (`castingAbility` is null), sets `castingAbility='pyroblast'` with a ~6s `castRemaining` and the boss as `castTargetId`, and never touches `channeling`.
4. `updateCasting` now takes the CHANNEL branch for a timed cast. The ward channel never sets `channelTickEvery`, so for a player who never real-channeled it is still 0 from entity init, and `channelTickTimer += 0` stays at or below zero: `applyChannelTick` fires EVERY 20 Hz tick, each emitting a fire projectile visual and scheduling a homing bolt of full Pyrelance direct damage (`rng.range(170, 225)`), about 120 fireballs per 6s cast, per press.

Healers self-heal out of the poisoned state (their friendly cast target fails the hostile check in `applyChannelTick`, which calls `cancelCast`), which is why only offensive casters report it.

### Fix

`handleDeath` now clears the whole cast/channel state, mirroring `cancelCast`'s field set without its `castStop` emit: `channeling = false`, `castRemaining = 0`, `castAim = null`. State-only: no new events, no rng draws, no tick-phase change; the parity gate's golden traces and draw-order log are unchanged.

## Test plan

- [x] `tests/combat_casting_lifecycle.test.ts`: two new tests, RED before the fix, GREEN after. One pins that `handleDeath` on a channeling caster clears `channeling`/`castRemaining`/`castAim`; one replays the full repro (die mid-channel, revive, cast pyroblast) and asserts zero projectiles launch mid-cast and exactly one Pyrelance resolution total.
- [x] `tests/nythraxis_raid.test.ts`: new regression test for the reported chain: a mage killed mid-wardstone-channel must come out with the whole cast state cleared (was `channeling=true` before the fix) and the ward slot freed.
- [x] `tests/parity` (162 passed): rng draw order and golden traces unchanged.
- [x] `tests/architecture.test.ts` (24 passed): sim purity.
- [x] Adjacent suites green (146 tests): sim, casting_command, cast_bar, ability_damage, ground_target_cast, haste_set_bonus.
- [x] `tsc --noEmit` clean; `biome ci` clean on the three changed files.
- [x] qa-checklist agent pass: zero blocking findings. One informational note: if a caster dies synchronously inside their own position-mode channel tick (lethal spell-reflect ward), the channel branch now emits one extra harmless `castStop(success: true)` for the already-dead caster; the client cast bar is hidden by its `e.dead` guard either way.