### PR TITLE
fix(talents): stop percent mods from rounding away ratio-valued aura buffs

### DIFF
--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -1,4 +1,4 @@
-import type { AbilityDef, AbilityEffect, PlayerClass, Stats, WeaponInfo } from '../types';
+import type { AbilityDef, AbilityEffect, AuraKind, PlayerClass, Stats, WeaponInfo } from '../types';
 import type { TalentModifiers } from './talents';
 
 // ---------------------------------------------------------------------------
@@ -3621,6 +3621,38 @@ export interface KnownAbility {
   castWhileMoving?: boolean; // talent-granted mobility (def.castWhileMoving covers baseline)
 }
 
+// Aura kinds whose `value` is a multiplier or a 0..1 fraction, not a flat
+// magnitude (the per-kind semantics live on the sim apply sites; see the table in
+// src/ui/aura_effect.ts). Talent damage/heal percentages must never scale these,
+// and the integer rounding the flat kinds use would destroy them outright: a
+// restoration mastery's +14% healing turned Fleet Form's 1.4 speed multiplier
+// into Math.round(1.4) = 1 (no speed bonus), and a melee mastery turned
+// Ghostfoot's 0.5 dodge fraction into Math.round(0.55) = 1 (100% dodge).
+const RATIO_VALUED_AURA_KINDS: ReadonlySet<AuraKind> = new Set<AuraKind>([
+  'slow',
+  'attackspeed',
+  'buff_dodge',
+  'buff_speed',
+  'buff_haste',
+  'buff_allstats_pct',
+  'form_bear',
+  'form_cat',
+  'form_travel',
+  'stealth',
+  'defensive_stance',
+  'righteous_fury',
+  'mortal_wound',
+  'expose',
+  'spellvuln',
+  'vulnerability',
+  'hex',
+  'tongues',
+  'cost_tax',
+  'critvuln',
+  'buff_scale',
+  'buff_jump',
+]);
+
 // Scale one effect's damage/heal magnitudes, returning a NEW effect object — the
 // base content arrays are shared module data and must never be mutated. `flat`
 // is added once to the effect's primary magnitude.
@@ -3679,8 +3711,10 @@ function scaleEffect(
     case 'absorb':
       return { ...eff, amount: Math.round(eff.amount * healMult + flat) };
     case 'buffTarget':
+      if (RATIO_VALUED_AURA_KINDS.has(eff.kind)) return eff;
       return { ...eff, value: Math.round(eff.value * dmgMult + flat) };
     case 'selfBuff':
+      if (RATIO_VALUED_AURA_KINDS.has(eff.kind)) return eff;
       return { ...eff, value: Math.round(eff.value * dmgMult + flat) };
     case 'lifeTap':
       return { ...eff, mana: Math.round(eff.mana * dmgMult + flat) };
@@ -3715,11 +3749,12 @@ function applyTalentMods(entry: KnownAbility, mods: TalentModifiers): void {
     if (am.cooldownPct) entry.cooldown = Math.max(0, entry.cooldown * (1 + am.cooldownPct));
     if (am.castWhileMoving) entry.castWhileMoving = true;
     // buffPct strengthens the value of a (self/target) buff, e.g. Improved Devotion Aura
-    // giving more armor. Only the buff effects scale; damage on the same ability does not.
+    // giving more armor. Only the buff effects scale; damage on the same ability does not,
+    // and ratio-valued kinds (speed/stealth/dodge multipliers) pass through untouched.
     if (am.buffPct) {
       const mul = 1 + am.buffPct;
       entry.effects = entry.effects.map((e) =>
-        e.type === 'selfBuff' || e.type === 'buffTarget'
+        (e.type === 'selfBuff' || e.type === 'buffTarget') && !RATIO_VALUED_AURA_KINDS.has(e.kind)
           ? { ...e, value: Math.round(e.value * mul) }
           : e,
       );

--- a/tests/talent_aura_multiplier_scaling.test.ts
+++ b/tests/talent_aura_multiplier_scaling.test.ts
@@ -1,0 +1,104 @@
+// Reproduces the live "Fleet Form runs at normal speed" reports (druids, plus a
+// restoration shaman with Shadewolf): any talent damage/heal percent triggers the
+// effect-scaling pass in abilitiesKnownAt, whose selfBuff/buffTarget arm applied
+// Math.round(value * dmgMult + flat) to EVERY aura kind. Kinds whose value is a
+// multiplier or a 0..1 fraction are not magnitudes: a restoration mastery's +14%
+// healing rounded Fleet Form's 1.4 speed multiplier down to 1 (no speed bonus,
+// gone only when the healing mods are respecced away), a balance/elemental
+// mastery's spell damage rounded 1.4 up to 2 (double speed), and a combat rogue's
+// melee mastery rounded Ghostfoot's 0.5 dodge fraction up to 1 (100% dodge).
+// Ratio-valued kinds must pass through talent scaling untouched; flat-magnitude
+// buffs (armor, stats) keep scaling as before.
+import { describe, expect, it } from 'vitest';
+import { abilitiesKnownAt } from '../src/sim/content/classes';
+import {
+  computeTalentModifiers,
+  emptyAllocation,
+  type TalentAllocation,
+} from '../src/sim/content/talents';
+import { Sim } from '../src/sim/sim';
+import type { PlayerClass } from '../src/sim/types';
+
+const alloc = (over: Partial<TalentAllocation> = {}): TalentAllocation => ({
+  ...emptyAllocation(),
+  ...over,
+});
+
+// Resolve one ability for a class/level/build and return its first buff effect value.
+function resolvedBuffValue(
+  cls: PlayerClass,
+  level: number,
+  allocation: TalentAllocation,
+  abilityId: string,
+): number {
+  const known = abilitiesKnownAt(cls, level, computeTalentModifiers(cls, allocation));
+  const entry = known.find((k) => k.def.id === abilityId);
+  if (!entry) throw new Error(`${abilityId} not known for ${cls} at level ${level}`);
+  for (const eff of entry.effects) {
+    if (eff.type === 'selfBuff' || eff.type === 'buffTarget') return eff.value;
+  }
+  throw new Error(`${abilityId} has no selfBuff/buffTarget effect`);
+}
+
+describe('talent percent mods leave ratio-valued aura effects untouched', () => {
+  it('restoration druid keeps Fleet Form at the 1.4 speed multiplier', () => {
+    expect(resolvedBuffValue('druid', 20, alloc({ spec: 'restoration' }), 'travel_form')).toBe(1.4);
+  });
+
+  it('restoration shaman keeps Shadewolf at the 1.4 speed multiplier', () => {
+    expect(resolvedBuffValue('shaman', 20, alloc({ spec: 'restoration' }), 'ghost_wolf')).toBe(1.4);
+  });
+
+  it('balance druid spell damage does not inflate Fleet Form to double speed', () => {
+    expect(resolvedBuffValue('druid', 20, alloc({ spec: 'balance' }), 'travel_form')).toBe(1.4);
+  });
+
+  it('combat rogue melee damage leaves Swift Heels, Ghostfoot, and stealth untouched', () => {
+    const combat = alloc({ spec: 'combat' });
+    expect(resolvedBuffValue('rogue', 20, combat, 'sprint')).toBe(1.7);
+    expect(resolvedBuffValue('rogue', 20, combat, 'evasion')).toBe(0.5);
+    expect(resolvedBuffValue('rogue', 20, combat, 'stealth')).toBe(0.5);
+  });
+
+  it('flat-magnitude self-buffs still scale with damage percents (Oakhide armor)', () => {
+    const base = resolvedBuffValue('druid', 20, alloc(), 'barkskin');
+    expect(resolvedBuffValue('druid', 20, alloc({ spec: 'balance' }), 'barkskin')).toBe(
+      Math.round(base * 1.1),
+    );
+  });
+
+  it('buffPct still strengthens flat buff values (Improved Steadfast Aura)', () => {
+    const base = resolvedBuffValue('paladin', 20, alloc(), 'devotion_aura');
+    expect(
+      resolvedBuffValue(
+        'paladin',
+        20,
+        alloc({ ranks: { pal_imp_devotion_aura: 1 } }),
+        'devotion_aura',
+      ),
+    ).toBe(Math.round(base * 1.2));
+  });
+});
+
+describe('Sim integration: healing-spec travel forms', () => {
+  it('a restoration druid in Fleet Form moves at 1.4x run speed', () => {
+    const sim = new Sim({ seed: 11, playerClass: 'druid' });
+    sim.setPlayerLevel(20);
+    expect(sim.applyTalents(alloc({ spec: 'restoration' }))).toBe(true);
+    sim.castAbility('travel_form');
+    sim.tick();
+    expect(sim.player.auras.some((a) => a.kind === 'form_travel')).toBe(true);
+    expect(sim.moveSpeedMult(sim.player)).toBeCloseTo(1.4);
+  });
+
+  it('a restoration shaman in Shadewolf moves at 1.4x run speed', () => {
+    const sim = new Sim({ seed: 11, playerClass: 'shaman' });
+    sim.setPlayerLevel(20);
+    expect(sim.applyTalents(alloc({ spec: 'restoration' }))).toBe(true);
+    sim.castAbility('ghost_wolf');
+    // Shadewolf has a 2s cast: advance through it.
+    for (let i = 0; i < 60; i++) sim.tick();
+    expect(sim.player.auras.some((a) => a.kind === 'buff_speed')).toBe(true);
+    expect(sim.moveSpeedMult(sim.player)).toBeCloseTo(1.4);
+  });
+});


### PR DESCRIPTION
## Problem
Many players reported druids shifting into Fleet Form and moving at plain run speed, and a restoration shaman recently reported the same with Shadewolf. Respeccing appeared to clear it in some cases. The healing-spec correlation in the reports is real and is the key to the bug.

## Root cause
`abilitiesKnownAt` folds talent modifiers into each resolved ability via `scaleEffect`, whose `selfBuff`/`buffTarget` arm applied `Math.round(value * dmgMult + flat)` to every aura kind. That is correct for flat magnitudes (armor, attack power, stamina) but destroys kinds whose value is a multiplier or a 0..1 fraction:

- A restoration mastery (druid or shaman, +14% healing) makes `healMult !== 1`, which triggers the scaling pass. Speed buffs scale by `dmgMult`, which is still 1, so Fleet Form / Shadewolf's 1.4 becomes `Math.round(1.4) = 1`: the form applies, the visual shows, and the player runs at exactly normal speed.
- A balance/elemental mastery (+10% spell damage) rounds the same 1.4 up to `Math.round(1.54) = 2`: double speed.
- A combat rogue mastery (+10% melee damage) rounds Ghostfoot's 0.5 dodge fraction up to 1 (100% dodge for the duration) and deletes stealth's 0.5 movement penalty.

This also explains the respec observation: wiping talent points removes class-tree percent mods, so the next shift resolves the unscaled 1.4 again. A character whose percent comes from the spec mastery itself needs to leave the spec, which is why respec only sometimes cleared it.

## Fix
Add `RATIO_VALUED_AURA_KINDS`, the set of aura kinds whose value is a multiplier or fraction rather than a flat magnitude (speed, forms, stealth, dodge, haste, attack speed, vulnerability fractions, and the rest of the documented ratio kinds), and pass those effects through untouched in both `scaleEffect` and the `buffPct` arm of `applyTalentMods`. Flat magnitude buffs keep scaling exactly as before (pinned by tests). No live `buffPct` talent targets a ratio kind, so that guard changes nothing today.

Notes:
- Auras are not persisted (`serializeCharacter` saves no aura array), so no migration is needed and no stale broken values survive a deploy; the next shift after the deploy is correct.
- The change is in the shared sim core, so offline, server, and headless RL hosts all pick it up identically. Parity golden-trace gate is green.

## Test plan
- [x] New `tests/talent_aura_multiplier_scaling.test.ts`: RED before the fix (6 failures reproducing the reported symptoms, including `moveSpeedMult === 1` for a resto druid in Fleet Form and a resto shaman in Shadewolf), GREEN after
- [x] Pins that flat-magnitude scaling is unchanged (Oakhide armor under spell damage, Steadfast Aura under `buffPct`)
- [x] Full local suite green (860 files / 10256 tests), including the parity golden-trace gate
- [x] `tsc --noEmit` clean, changed files `biome ci` clean