### PR TITLE
fix(server): REALM_NAME set only in .env was silently ignored

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -30,20 +30,9 @@ import { USER_ASSETS_SCHEMA } from './user_assets_db';
 // consumers (the market tests) keep importing it from ./db unchanged.
 export { marketStateKey } from './market_backfill';
 
-try {
-  process.loadEnvFile?.();
-} catch {
-  // .env is optional; production usually injects DATABASE_URL directly.
-}
-try {
-  // Local-dev convenience: also load .env.local so the server can reuse the
-  // client's VITE_* values (e.g. the Solana RPC + $WOC mint) for the in-world
-  // holder-tier reads. Existing keys from .env are not overwritten. In
-  // production these come from real env vars (SOLANA_RPC_URL / WOC_MINT).
-  process.loadEnvFile?.('.env.local');
-} catch {
-  // .env.local is optional.
-}
+// The actual load lives in server/env.ts so import-time readers other than
+// db.ts (realm.ts via main.ts's first import) share one bootstrap.
+import './env';
 
 export const DATABASE_URL =
   process.env.DATABASE_URL ??

--- a/server/env.ts
+++ b/server/env.ts
@@ -1,0 +1,26 @@
+// Server env bootstrap: loads .env (and .env.local) into process.env.
+//
+// Several modules read configuration at IMPORT time (server/realm.ts pins
+// REALM_NAME into an exported const, server/db.ts derives DATABASE_URL), so
+// the file load must happen before any of them evaluates. Node evaluates a
+// module once, in import order, depth-first: the entry point (server/main.ts)
+// imports this module FIRST, and db.ts imports it too so non-main entry
+// points that only pull the db keep working. Never add an import-time
+// process.env read to a module without importing './env' above it.
+export function loadServerEnv(): void {
+  try {
+    process.loadEnvFile?.();
+  } catch {
+    // .env is optional; production usually injects real env vars directly.
+  }
+  try {
+    // Local-dev convenience: also load .env.local so the server can reuse the
+    // client's VITE_* values (e.g. the Solana RPC + $WOC mint) for the
+    // in-world holder-tier reads. Existing keys from .env are not overwritten.
+    process.loadEnvFile?.('.env.local');
+  } catch {
+    // .env.local is optional.
+  }
+}
+
+loadServerEnv();

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,3 +1,6 @@
+// FIRST import on purpose: loads .env before realm.ts (or any other module
+// with an import-time process.env read) evaluates. See server/env.ts.
+import './env';
 import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as path from 'node:path';

--- a/tests/server/env_bootstrap.test.ts
+++ b/tests/server/env_bootstrap.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { loadServerEnv } from '../../server/env';
+
+// REALM_NAME (and any other import-time config read) silently fell back to its
+// default when set only in .env: server/realm.ts evaluated process.env before
+// server/db.ts's module body had loaded the file. The fix is server/env.ts, a
+// bootstrap module the entry point imports FIRST. These tests pin both halves:
+// the loader itself, and the import order that makes it run early enough.
+
+describe('loadServerEnv', () => {
+  const cleanupKeys: string[] = [];
+  let savedCwd: string | null = null;
+  let tempDir: string | null = null;
+
+  afterEach(() => {
+    for (const k of cleanupKeys.splice(0)) delete process.env[k];
+    if (savedCwd !== null) {
+      process.chdir(savedCwd);
+      savedCwd = null;
+    }
+    if (tempDir !== null) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  it('loads .env from the working directory into process.env', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'env-bootstrap-'));
+    writeFileSync(
+      join(tempDir, '.env'),
+      'ENV_BOOTSTRAP_TEST_REALM=TestRealm\nENV_BOOTSTRAP_TEST_FLAG=1\n',
+    );
+    cleanupKeys.push('ENV_BOOTSTRAP_TEST_REALM', 'ENV_BOOTSTRAP_TEST_FLAG');
+    savedCwd = process.cwd();
+    process.chdir(tempDir);
+
+    loadServerEnv();
+
+    expect(process.env.ENV_BOOTSTRAP_TEST_REALM).toBe('TestRealm');
+    expect(process.env.ENV_BOOTSTRAP_TEST_FLAG).toBe('1');
+  });
+
+  it('is a no-op without a .env file (production injects real env vars)', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'env-bootstrap-'));
+    savedCwd = process.cwd();
+    process.chdir(tempDir);
+
+    expect(() => loadServerEnv()).not.toThrow();
+  });
+});
+
+describe('entry-point import order (the actual bug)', () => {
+  it('server/main.ts imports ./env before any other server-local module', () => {
+    const src = readFileSync(resolve(process.cwd(), 'server/main.ts'), 'utf8');
+    const imports = [...src.matchAll(/^import\s+(?:[^;]*?from\s+)?'([^']+)'/gms)].map((m) => m[1]);
+    const localImports = imports.filter((s) => s.startsWith('./') || s.startsWith('../'));
+    expect(
+      localImports[0],
+      'server/main.ts must import ./env FIRST: realm.ts (and any module reading ' +
+        'process.env at import time) evaluates before db.ts loads .env otherwise',
+    ).toBe('./env');
+  });
+
+  it('server/db.ts delegates its .env load to the shared bootstrap', () => {
+    const src = readFileSync(resolve(process.cwd(), 'server/db.ts'), 'utf8');
+    expect(src).toMatch(/import '\.\/env';/);
+    expect(src, 'db.ts must not keep its own inline loadEnvFile calls').not.toMatch(
+      /process\.loadEnvFile/,
+    );
+  });
+});

--- a/tests/server/http/characterization.test.ts
+++ b/tests/server/http/characterization.test.ts
@@ -66,6 +66,7 @@ async function loadDispatch(): Promise<Dispatch> {
 let dispatch: Dispatch;
 let main: typeof import('../../../server/main');
 let savedDiscordEnv: Partial<Record<(typeof DISCORD_ENV_KEYS)[number], string | undefined>>;
+let savedRealmName: string | undefined;
 
 beforeAll(async () => {
   savedDiscordEnv = {};
@@ -73,6 +74,12 @@ beforeAll(async () => {
     savedDiscordEnv[key] = process.env[key];
   }
   clearDiscordConfigEnv();
+  // Pin the realm BEFORE importing main: server/env.ts (main's first import)
+  // loads the developer's .env, and realm.ts freezes REALM into a const at
+  // import time, so a machine-local REALM_NAME would otherwise leak into the
+  // goldens below (which pin the default realm's literal name).
+  savedRealmName = process.env.REALM_NAME;
+  process.env.REALM_NAME = 'Claudemoon';
   main = await import('../../../server/main');
   // server/db.ts loads .env during the main import, so clear again after import.
   clearDiscordConfigEnv();
@@ -92,6 +99,8 @@ afterAll(() => {
     if (value === undefined) delete process.env[key];
     else process.env[key] = value;
   }
+  if (savedRealmName === undefined) delete process.env.REALM_NAME;
+  else process.env.REALM_NAME = savedRealmName;
 });
 
 // One golden per case: 'written' on the first ever run (fixture absent -> written),


### PR DESCRIPTION
## What

A realm named via `REALM_NAME` in `.env` always booted as the default realm. `server/realm.ts` resolves `REALM` into an exported const at import time, but the `.env` load lived inside `server/db.ts`'s module body, which evaluates after `realm.ts` in `main.ts`'s import graph, so the variable was not set yet when it was read.

## Fix

- New `server/env.ts`: the one `.env` / `.env.local` bootstrap (`loadServerEnv()`, runs once on import), with a comment warning that any module reading `process.env` at import time needs it imported above.
- `server/main.ts` imports it FIRST, before anything that can pull `realm.ts`.
- `server/db.ts` replaces its inline `process.loadEnvFile` calls with the same bootstrap, so entry points that only import the db keep their existing behavior.

## Tests

- `tests/server/env_bootstrap.test.ts`: pins the loader behavior (loads `.env` from cwd, no-op without one) and the import order in both `main.ts` and `db.ts` (the order test is the one that reproduces the bug: it fails on the old tree).
- `tests/server/http/characterization.test.ts`: pins `REALM_NAME` before importing main. With the bootstrap actually working, a developer's machine-local `.env` realm would otherwise leak into the goldens; this mirrors how the file already handles the Discord env keys.

Found while standing up a LAN realm: `REALM_NAME=Lan-mode` in `.env` kept booting as Claudemoon. Verified end to end on Windows: with only `.env` set, `/api/status` now reports the configured realm.

Generated with [Claude Code](https://claude.com/claude-code)