### PR TITLE
fix(terrain): close LOD seams, smooth mountain relief and ground cliff scatter

### DIFF
--- a/src/render/self_motion.ts
+++ b/src/render/self_motion.ts
@@ -26,7 +26,12 @@
 // against a real lagging Sim.
 
 import { resolveMovement } from '../sim/colliders';
-import { moveSpeedMult, type PlayerMotionDeps, stepPlayerMotion } from '../sim/player_motion';
+import {
+  BACKPEDAL_MULT,
+  moveSpeedMult,
+  type PlayerMotionDeps,
+  stepPlayerMotion,
+} from '../sim/player_motion';
 import { DT, type Entity, type MoveInput, RUN_SPEED } from '../sim/types';
 
 // Latency cap on the extrapolation window: at least one snapshot-ish interval
@@ -66,6 +71,8 @@ export const SELF_MOTION_DEADBAND_YD = 0.05;
 export const SELF_MOTION_SNAP_DIST_SQ = 6 * 6;
 const MAX_FRAME_DT = 0.25; // matches the main-loop frame clamp
 const LEASH_SLACK_YD = 0.05;
+const BLOCKED_INTENT_PROGRESS_FRACTION = 0.45;
+const BLOCKED_INTENT_MOVE_FRACTION = 0.75;
 // Pose-history ring: enough to look SELF_MOTION_CAP_MAX_MS into the past with
 // headroom even on high-refresh displays (128 entries covers 267 ms at 480 fps
 // and over 2 s at 60 fps).
@@ -92,6 +99,29 @@ interface Vec3Like {
 }
 
 const clamp = (n: number, min: number, max: number): number => Math.max(min, Math.min(max, n));
+
+function horizontalIntent(
+  facing: number,
+  input: MoveInput,
+): { x: number; z: number; step: number } | null {
+  let mx = 0;
+  let mz = 0;
+  if (input.forward) mz += 1;
+  if (input.back) mz -= 1;
+  if (input.strafeLeft) mx -= 1;
+  if (input.strafeRight) mx += 1;
+  const len = Math.hypot(mx, mz);
+  if (len === 0) return null;
+  mx /= len;
+  mz /= len;
+  const sin = Math.sin(facing);
+  const cos = Math.cos(facing);
+  return {
+    x: mz * sin - mx * cos,
+    z: mz * cos + mx * sin,
+    step: RUN_SPEED * (mz < 0 ? BACKPEDAL_MULT : 1) * DT,
+  };
+}
 
 export class SelfMotionPredictor {
   /**
@@ -273,13 +303,30 @@ export class SelfMotionPredictor {
     inp.strafeLeft = frame.moveInput.strafeLeft;
     inp.strafeRight = frame.moveInput.strafeRight;
     inp.jump = frame.moveInput.jump;
+    const intent = horizontalIntent(frame.displayFacing, inp);
+    let blockedHorizontalIntent = false;
     this.acc = Math.min(this.acc + dt, MAX_FRAME_DT);
     while (this.acc >= DT) {
+      const beforeX = actor.pos.x;
+      const beforeZ = actor.pos.z;
       actor.prevPos.x = actor.pos.x;
       actor.prevPos.y = actor.pos.y;
       actor.prevPos.z = actor.pos.z;
       actor.facing = frame.displayFacing;
       stepPlayerMotion(this.deps, actor, inp);
+      if (intent) {
+        const stepX = actor.pos.x - beforeX;
+        const stepZ = actor.pos.z - beforeZ;
+        const progress = stepX * intent.x + stepZ * intent.z;
+        const moved = Math.hypot(stepX, stepZ);
+        const expectedStep = intent.step * moveSpeedMult(actor, 0);
+        if (
+          progress < expectedStep * BLOCKED_INTENT_PROGRESS_FRACTION &&
+          moved < expectedStep * BLOCKED_INTENT_MOVE_FRACTION
+        ) {
+          blockedHorizontalIntent = true;
+        }
+      }
       this.acc -= DT;
     }
     const frac = this.acc / DT;
@@ -339,6 +386,16 @@ export class SelfMotionPredictor {
       // turned each 20Hz kernel step into a visible forward/back sawtooth.
       actor.pos.x = ax + (ex * budget) / elen;
       actor.pos.z = az + (ez * budget) / elen;
+    }
+
+    if (blockedHorizontalIntent && intent) {
+      const lead = (actor.pos.x - ax) * intent.x + (actor.pos.z - az) * intent.z;
+      if (lead > 0) {
+        actor.pos.x -= intent.x * lead;
+        actor.pos.z -= intent.z * lead;
+        actor.prevPos.x -= intent.x * lead;
+        actor.prevPos.z -= intent.z * lead;
+      }
     }
 
     this.out.x = actor.prevPos.x + (actor.pos.x - actor.prevPos.x) * frac;

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -16,7 +16,14 @@ import { groundDetailTexture, groundSplatMaps, macroNoiseTexture } from './textu
 //   works (the old single-plane-per-zone terrain was always fully submitted).
 // - LOD by distance from the nearest hub at build time: settlements (where
 //   the camera lingers) get dense vertices, the wilderness gets coarse ones.
-// - 0.3u skirts hang from every chunk edge to hide LOD cracks.
+//   Chunks carrying the impassable mountain walls (inter-zone ridges, world
+//   rim) are promoted to the densest band regardless: the terraced walls hold
+//   the heightfield's highest frequencies and the far band smears them into
+//   ragged shards.
+// - Skirts hang from every chunk edge to hide LOD cracks: a 0.3u base drop
+//   plus the vertex slope times the coarsest band spacing, since a T-junction
+//   hole grows with both the neighbor's chord span and the local gradient
+//   (terraced cliffs open multi-yard holes that a flat drop cannot cover).
 // - High tier: MeshStandardMaterial + splat shading (grass/dirt/rock/sand
 //   weights precomputed per vertex from slope/height/roadDistance into a vec4
 //   attribute) over the biome vertex-color tint, plus a world-space macro
@@ -100,6 +107,13 @@ const LOD_BANDS = {
     { maxHubDist: Infinity, spacing: 6.5 },
   ],
 } as const;
+
+// Mountain-wall chunks are promoted to the densest LOD band. Half-widths
+// mirror sim/world.ts: the ridge contribution lives within RIDGE_SIGMA*3
+// (30yd) of each inter-zone ridge line, and the rim rise starts 30yd inside
+// the world edge (plus crest-noise margin).
+const WALL_LOD_RIDGE_HALF = 30;
+const WALL_LOD_RIM_MARGIN = 40;
 
 // terrain normal map resolution (~0.56u per texel over 360x1080)
 const NORMAL_TEX_W = 640;
@@ -391,12 +405,16 @@ function sampleVertex(x: number, z: number, seed: number): VertexSample {
     cTmp.lerp(dirtDarkC, t * (rockStreak - 0.5) * 0.35);
     lerpSplat(w, 2, t);
   }
-  // high ground (ridges, peaks) goes rocky then snowy
+  // high ground (ridges, peaks) goes rocky then snowy. The snow ramp is wide
+  // (26u, over four terrace bands) with a strong patch-noise term: the terraced
+  // heightfield steps 6u at a time, and a ramp comparable to the step paints
+  // alternate treads fully white / fully bare, which reads as a repetitive
+  // checkerboard from a distance.
   let snow = 0;
   if (h > 22) {
     const rockT = clamp01((h - 22) / 10) * (0.6 + rockStreak * 0.25);
     cTmp.lerp(rockC, rockT);
-    snow = clamp01((h - 34 + (snowPatch - 0.5) * 8) / 14) * 0.85;
+    snow = clamp01((h - 28 + (snowPatch - 0.5) * 14) / 26) * 0.85;
     cTmp.lerp(snowCapC, snow);
     lerpSplat(w, 2, clamp01((h - 22) / 10) * 0.8);
   }
@@ -418,7 +436,10 @@ function sampleVertex(x: number, z: number, seed: number): VertexSample {
   const rim = clamp01(edge / 64);
   if (rim > 0) {
     cTmp.lerp(hazyPeakC, rim * 0.95);
-    const rimSnow = clamp01((h - 26) / 16) * rim * 0.8;
+    // same wide, noise-broken ramp as the interior snow above: a pure
+    // height threshold snowed every terrace tread above the line uniformly,
+    // turning the rim's 2D terrace lattice into a white/grey checkerboard
+    const rimSnow = clamp01((h - 21 + (snowPatch - 0.5) * 12) / 26) * rim * 0.8;
     cTmp.lerp(snowCapC, rimSnow);
     snow = Math.max(snow, rimSnow);
     lerpSplat(w, 2, rim * 0.85);
@@ -457,6 +478,7 @@ function buildChunkGeometry(
   spacing: number,
   seed: number,
   withSplat: boolean,
+  skirtSpan: number,
 ): THREE.BufferGeometry {
   const nx = Math.max(4, Math.round(size / spacing));
   const nz = nx;
@@ -493,7 +515,11 @@ function buildChunkGeometry(
       }
       const vi = gj * gw + gi;
       positions[vi * 3] = x;
-      positions[vi * 3 + 1] = s.height - (isSkirt ? SKIRT_DROP : 0);
+      // Slope-aware drop: a T-junction hole under a coarse neighbor's chord is
+      // bounded by the local gradient times that neighbor's vertex spacing, so
+      // a flat cliff-side skirt must deepen with the slope or the hole shows
+      // sky (skirtSpan is the coarsest spacing any neighbor can have).
+      positions[vi * 3 + 1] = s.height - (isSkirt ? SKIRT_DROP + s.slope * skirtSpan : 0);
       positions[vi * 3 + 2] = z;
       normals[vi * 3] = s.normal[0];
       normals[vi * 3 + 1] = s.normal[1];
@@ -528,12 +554,29 @@ function buildChunkGeometry(
       const b = a + 1;
       const c = a + gw;
       const d = c + 1;
-      indices[k++] = a;
-      indices[k++] = c;
-      indices[k++] = b;
-      indices[k++] = b;
-      indices[k++] = c;
-      indices[k++] = d;
+      // Split each quad along the diagonal whose endpoints are closest in
+      // height, so the fold line follows a ridge/terrace edge instead of
+      // cutting across it (a fixed diagonal saws terraced cliffs into
+      // alternating shards). Both windings keep the +y face up.
+      const ha = positions[a * 3 + 1];
+      const hb = positions[b * 3 + 1];
+      const hc = positions[c * 3 + 1];
+      const hd = positions[d * 3 + 1];
+      if (Math.abs(hb - hc) <= Math.abs(ha - hd)) {
+        indices[k++] = a;
+        indices[k++] = c;
+        indices[k++] = b;
+        indices[k++] = b;
+        indices[k++] = c;
+        indices[k++] = d;
+      } else {
+        indices[k++] = a;
+        indices[k++] = c;
+        indices[k++] = d;
+        indices[k++] = a;
+        indices[k++] = d;
+        indices[k++] = b;
+      }
     }
   }
 
@@ -620,7 +663,15 @@ function terrainNormalTexture(seed: number): THREE.DataTexture {
   tex.colorSpace = THREE.NoColorSpace;
   tex.wrapS = tex.wrapT = THREE.ClampToEdgeWrapping;
   tex.magFilter = THREE.LinearFilter;
-  tex.minFilter = THREE.LinearFilter;
+  // Mipmapped minification (DataTexture defaults it off): the bake packs the
+  // terraces' near-vertical risers next to flat treads at 0.56u/texel, and
+  // sampling that unfiltered from a distant camera aliases the lighting into
+  // shimmering checker patterns. Mips average the relief away smoothly with
+  // distance instead. WebGL2 handles the NPOT mip chain; the editor's
+  // rebakeNormalRegion re-upload regenerates it automatically.
+  tex.minFilter = THREE.LinearMipmapLinearFilter;
+  tex.generateMipmaps = true;
+  tex.anisotropy = NORMAL_ANISOTROPY;
   tex.needsUpdate = true;
   return tex;
 }
@@ -914,9 +965,32 @@ export function buildTerrain(seed: number): TerrainView {
     spacing: number;
   }[] = [];
 
+  // True when the chunk cell overlaps a mountain-wall band: an inter-zone
+  // ridge line (ZONES[i].zMax) or the world rim. Those chunks always take the
+  // densest band; the walls sit far from every hub, so hub-distance LOD alone
+  // hands the steepest, most looked-at cliffs the coarsest grid.
+  const wallChunkAt = (x0: number, z0: number, size: number): boolean => {
+    if (x0 < -WORLD_MAX_X + WALL_LOD_RIM_MARGIN || x0 + size > WORLD_MAX_X - WALL_LOD_RIM_MARGIN) {
+      return true;
+    }
+    if (z0 < WORLD_MIN_Z + WALL_LOD_RIM_MARGIN || z0 + size > WORLD_MAX_Z - WALL_LOD_RIM_MARGIN) {
+      return true;
+    }
+    for (let i = 0; i + 1 < ZONES.length; i++) {
+      const ridgeZ = ZONES[i].zMax;
+      if (z0 - WALL_LOD_RIDGE_HALF < ridgeZ && z0 + size + WALL_LOD_RIDGE_HALF > ridgeZ) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   const bandIndexAt = (cx: number, cz: number): number => {
-    const centerX = -WORLD_MAX_X + cx * CHUNK_SIZE + CHUNK_SIZE / 2;
-    const centerZ = WORLD_MIN_Z + cz * CHUNK_SIZE + CHUNK_SIZE / 2;
+    const x0 = -WORLD_MAX_X + cx * CHUNK_SIZE;
+    const z0 = WORLD_MIN_Z + cz * CHUNK_SIZE;
+    if (wallChunkAt(x0, z0, CHUNK_SIZE)) return 0;
+    const centerX = x0 + CHUNK_SIZE / 2;
+    const centerZ = z0 + CHUNK_SIZE / 2;
     let hubDist = Infinity;
     for (const zn of ZONES) {
       hubDist = Math.min(hubDist, Math.hypot(centerX - zn.hub.x, centerZ - zn.hub.z));
@@ -925,8 +999,13 @@ export function buildTerrain(seed: number): TerrainView {
     return idx === -1 ? bands.length - 1 : idx;
   };
 
+  // the coarsest spacing any neighbor chunk can have; sizes the slope-aware
+  // skirt drop so a fine chunk's skirt always reaches past the coarsest
+  // neighbor's chord (and vice versa)
+  const skirtSpan = bands[bands.length - 1].spacing;
+
   const addChunk = (x0: number, z0: number, size: number, spacing: number): void => {
-    const geo = buildChunkGeometry(x0, z0, size, spacing, seed, !lowGfx);
+    const geo = buildChunkGeometry(x0, z0, size, spacing, seed, !lowGfx, skirtSpan);
     const mesh = new THREE.Mesh(geo, mat);
     mesh.receiveShadow = true;
     group.add(mesh);
@@ -1009,6 +1088,7 @@ export function buildTerrain(seed: number): TerrainView {
           chunk.spacing,
           seed,
           !lowGfx,
+          skirtSpan,
         );
         chunk.mesh.geometry.dispose();
         chunk.mesh.geometry = geo; // bounding box/sphere already computed by the build

--- a/src/sim/player_motion.ts
+++ b/src/sim/player_motion.ts
@@ -115,6 +115,8 @@ export interface PlayerMotionDeps {
 }
 
 export function stepPlayerMotion(deps: PlayerMotionDeps, p: Entity, inp: MoveInput): void {
+  const stepStartX = p.pos.x;
+  const stepStartZ = p.pos.z;
   // Convention: facing f points along (sin f, cos f); the camera sits behind
   // the player, so screen-right is the world vector (-cos f, sin f).
   // Turning right therefore DECREASES facing.
@@ -320,10 +322,41 @@ export function stepPlayerMotion(deps: PlayerMotionDeps, p: Entity, inp: MoveInp
     const s = terrainWallStandoff(p.pos.x, p.pos.z, deps.seed, BODY_RADIUS, MAX_CLIMB_SLOPE);
     if (s.x !== p.pos.x || s.z !== p.pos.z) {
       const resolved = deps.resolveMove(p.pos.x, p.pos.z, s.x, s.z, BODY_RADIUS, p, false);
-      if (terrainSteepnessAt(resolved.x, resolved.z, deps.seed) <= MAX_CLIMB_SLOPE) {
-        p.pos.x = resolved.x;
-        p.pos.z = resolved.z;
-        p.pos.y = groundHeight(resolved.x, resolved.z, deps.seed);
+      let standX = resolved.x;
+      let standZ = resolved.z;
+      if (movingOnGround && wishSpeed > 0) {
+        const startStand = terrainWallStandoff(
+          stepStartX,
+          stepStartZ,
+          deps.seed,
+          BODY_RADIUS,
+          MAX_CLIMB_SLOPE,
+        );
+        const alreadyClear =
+          Math.hypot(startStand.x - stepStartX, startStand.z - stepStartZ) < 1e-4;
+        const netX = standX - stepStartX;
+        const netZ = standZ - stepStartZ;
+        const progress = netX * wishX + netZ * wishZ;
+        if (alreadyClear && progress < -1e-6) {
+          const slideX = standX - wishX * progress;
+          const slideZ = standZ - wishZ * progress;
+          const slide = deps.resolveMove(
+            stepStartX,
+            stepStartZ,
+            slideX,
+            slideZ,
+            BODY_RADIUS,
+            p,
+            false,
+          );
+          standX = slide.x;
+          standZ = slide.z;
+        }
+      }
+      if (terrainSteepnessAt(standX, standZ, deps.seed) <= MAX_CLIMB_SLOPE) {
+        p.pos.x = standX;
+        p.pos.z = standZ;
+        p.pos.y = groundHeight(standX, standZ, deps.seed);
       }
     }
   }

--- a/src/sim/player_motion.ts
+++ b/src/sim/player_motion.ts
@@ -318,13 +318,13 @@ export function stepPlayerMotion(deps: PlayerMotionDeps, p: Entity, inp: MoveInp
   // ground and on flat instanced floors.
   if (p.onGround && !isSwimming(p, deps.seed)) {
     const s = terrainWallStandoff(p.pos.x, p.pos.z, deps.seed, BODY_RADIUS, MAX_CLIMB_SLOPE);
-    if (
-      (s.x !== p.pos.x || s.z !== p.pos.z) &&
-      terrainSteepnessAt(s.x, s.z, deps.seed) <= MAX_CLIMB_SLOPE
-    ) {
-      p.pos.x = s.x;
-      p.pos.z = s.z;
-      p.pos.y = groundHeight(s.x, s.z, deps.seed);
+    if (s.x !== p.pos.x || s.z !== p.pos.z) {
+      const resolved = deps.resolveMove(p.pos.x, p.pos.z, s.x, s.z, BODY_RADIUS, p, false);
+      if (terrainSteepnessAt(resolved.x, resolved.z, deps.seed) <= MAX_CLIMB_SLOPE) {
+        p.pos.x = resolved.x;
+        p.pos.z = resolved.z;
+        p.pos.y = groundHeight(resolved.x, resolved.z, deps.seed);
+      }
     }
   }
 }

--- a/src/sim/player_motion.ts
+++ b/src/sim/player_motion.ts
@@ -21,7 +21,13 @@ import { isRooted, isStunned } from './combat/cc';
 import { PLAYER_BODY_RADIUS, PLAYER_MAX_CLIMB_SLOPE, PLAYER_SWIM_DEPTH } from './pathfind';
 import { GHOST_RUN_MULT } from './spirit';
 import { DT, type Entity, type MoveInput, normAngle, RUN_SPEED, TURN_SPEED } from './types';
-import { groundHeight, terrainDownhill, terrainSteepnessAt, waterLevelAt } from './world';
+import {
+  groundHeight,
+  terrainDownhill,
+  terrainSteepnessAt,
+  terrainWallStandoff,
+  waterLevelAt,
+} from './world';
 
 export const BACKPEDAL_MULT = 0.65;
 export const GRAVITY = 16;
@@ -299,6 +305,26 @@ export function stepPlayerMotion(deps: PlayerMotionDeps, p: Entity, inp: MoveInp
     } else {
       p.pos.y = ground;
       p.fallStartY = ground;
+    }
+  }
+
+  // Ease the body off any terrain wall it now overlaps. The slope gates above
+  // block the CENTER from climbing a wall, but nothing keeps the body's WIDTH
+  // clear of one, so standing at (or strafing along) a wall foot buries the near
+  // side of the model. Only on settled ground (a fall/ledge is resolved above),
+  // and never onto ground steeper than the climb limit (a rare terrace corner:
+  // a tick's clip beats being shoved onto a wall). Lives in the kernel so the
+  // server Sim and the client self-predictor apply it identically; no-op on open
+  // ground and on flat instanced floors.
+  if (p.onGround && !isSwimming(p, deps.seed)) {
+    const s = terrainWallStandoff(p.pos.x, p.pos.z, deps.seed, BODY_RADIUS, MAX_CLIMB_SLOPE);
+    if (
+      (s.x !== p.pos.x || s.z !== p.pos.z) &&
+      terrainSteepnessAt(s.x, s.z, deps.seed) <= MAX_CLIMB_SLOPE
+    ) {
+      p.pos.x = s.x;
+      p.pos.z = s.z;
+      p.pos.y = groundHeight(s.x, s.z, deps.seed);
     }
   }
 }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3493,9 +3493,10 @@ export class Sim {
     if (this.updateFearMovement(p)) return;
     // The rest of the step (turn integration, wish vector, slope gates, swept
     // static collision, the vertical pass with fall damage) moved VERBATIM to
-    // player_motion.ts (MV1); playerMotionDeps binds the live Sim callbacks
-    // (fiesta-aware moveSpeedMult, delve-aware resolveMove, cancelCast/standUp/
-    // dealDamage) so behavior and the rng draw order are unchanged.
+    // player_motion.ts (MV1), which also eases the body off terrain walls at the
+    // end (the standoff); playerMotionDeps binds the live Sim callbacks (fiesta-
+    // aware moveSpeedMult, delve-aware resolveMove, cancelCast/standUp/dealDamage)
+    // so behavior and the rng draw order are unchanged.
     stepPlayerMotion(this.playerMotionDeps, p, meta.moveInput);
   }
 

--- a/src/sim/world.ts
+++ b/src/sim/world.ts
@@ -667,6 +667,17 @@ export function zoneBiomeAt(z: number): BiomeId {
   return zones[zones.length - 1].biome;
 }
 
+// Scatter props (trees, boulders) are anchored to terrainHeight at their exact
+// (x, z). On a near-vertical rim/ridge wall a prop juts out of the face and
+// reads as floating, and (via colliders.ts) a large rock or trunk there is also
+// an invisible collider on the cliff. Reject any candidate whose local terrain
+// is steeper than this: it matches PLAYER_MAX_CLIMB_SLOPE (the impassable-wall
+// gate), so only genuine walls are cleared and rolling interior hills keep
+// their props. Grass and ground dressing already refuse cliffs the same way
+// (foliage.ts tooSteep / GRASS_MAX_SLOPE); this brings the big props in line.
+// Pinned as a literal by tests/fixes.test.ts.
+export const DECORATION_MAX_SLOPE = 1.5;
+
 export function generateDecorations(seed: number): Decoration[] {
   const w = world();
   const out: Decoration[] = [];
@@ -732,6 +743,11 @@ export function generateDecorations(seed: number): Decoration[] {
         }
       }
       if (inCamp) continue;
+      // no scatter on cliff faces: a prop anchored to the surface here floats
+      // off the wall (and large ones would be phantom colliders). Checked last,
+      // after the cheaper gates, so the four-sample steepness only runs for
+      // candidates that survive everything else.
+      if (terrainSteepness(x, z, seed) > DECORATION_MAX_SLOPE) continue;
       out.push({
         kind,
         x,

--- a/src/sim/world.ts
+++ b/src/sim/world.ts
@@ -615,6 +615,52 @@ export function terrainDownhill(
   return { x: -hx / mag, z: -hz / mag };
 }
 
+// Ring samples for the wall standoff below. 8 covers the body circle evenly
+// without being a hot-loop cost (the caller only runs it for grounded overworld
+// players).
+const WALL_STANDOFF_SAMPLES = 8;
+
+// Push a body of `radius` out of terrain steeper than `maxSlope` so the
+// character model does not sink into a cliff face. Movement collision samples
+// only the center point (the climb gate blocks the center from CLIMBING a wall,
+// but nothing keeps the body's WIDTH clear of one), so standing at or strafing
+// along the foot of a near-vertical wall buries the model's near side. This
+// samples the heightfield on a ring at the body radius; any direction rising
+// faster than a climbable slope is a wall within reach, and the center is nudged
+// directly away from it, toward the lower walkable side. Pure and deterministic;
+// returns the input unchanged on open or merely-sloped ground (no ring sample
+// exceeds a climbable rise there), so it is a near-no-op away from the walls.
+export function terrainWallStandoff(
+  x: number,
+  z: number,
+  seed: number,
+  radius: number,
+  maxSlope: number,
+): { x: number; z: number } {
+  const h0 = groundHeight(x, z, seed);
+  const wallRise = radius * maxSlope; // the most a climbable slope rises over `radius`
+  let pushX = 0;
+  let pushZ = 0;
+  for (let k = 0; k < WALL_STANDOFF_SAMPLES; k++) {
+    const a = (k / WALL_STANDOFF_SAMPLES) * Math.PI * 2;
+    const sx = Math.sin(a);
+    const sz = Math.cos(a);
+    const rise = groundHeight(x + sx * radius, z + sz * radius, seed) - h0;
+    if (rise > wallRise) {
+      // horizontal setback that would make this direction merely climbable,
+      // capped at the body radius (a face closer than `radius` reads as a huge
+      // rise; one exactly at `radius` contributes nothing)
+      const setback = Math.min((rise - wallRise) / maxSlope, radius);
+      pushX -= sx * setback;
+      pushZ -= sz * setback;
+    }
+  }
+  if (pushX === 0 && pushZ === 0) return { x, z };
+  const mag = Math.hypot(pushX, pushZ);
+  const scale = Math.min(mag, radius) / mag; // total nudge never exceeds one body radius
+  return { x: x + pushX * scale, z: z + pushZ * scale };
+}
+
 // Distance from (x,z) to the nearest road polyline segment.
 export function roadDistance(x: number, z: number): number {
   let best = Infinity;

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -25,7 +25,13 @@ import { createMob } from '../src/sim/entity';
 import { ACTIONS, encodeObs } from '../src/sim/obs';
 import { Sim } from '../src/sim/sim';
 import { dist2d, type Entity, type SimEvent } from '../src/sim/types';
-import { generateDecorations, groundHeight, WATER_LEVEL } from '../src/sim/world';
+import {
+  DECORATION_MAX_SLOPE,
+  generateDecorations,
+  groundHeight,
+  terrainSteepness,
+  WATER_LEVEL,
+} from '../src/sim/world';
 
 const SEED = 20061;
 
@@ -231,6 +237,15 @@ describe('collision & terrain', () => {
 
     const blocked = resolvePosition(SEED, tree.x, tree.z, 0.5);
     expect(Math.abs(blocked.x - tree.x) + Math.abs(blocked.z - tree.z)).toBeGreaterThan(0.5);
+  });
+
+  it('does not scatter trees or rocks onto cliff faces', () => {
+    // A prop on a wall steeper than the climb limit floats off the face and
+    // (for large rocks / trunks) plants an invisible collider there.
+    const onCliffs = generateDecorations(SEED)
+      .filter((d) => terrainSteepness(d.x, d.z, SEED) > DECORATION_MAX_SLOPE)
+      .map((d) => `${d.kind}@${d.x.toFixed(0)},${d.z.toFixed(0)}`);
+    expect(onCliffs).toEqual([]);
   });
 });
 

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -320,6 +320,43 @@ describe('terrain wall standoff', () => {
       SLOPE + 1e-6,
     );
   });
+
+  it('does not sawtooth when holding forward into the western wall', () => {
+    const sim = makeSim();
+    teleportTo(sim, -90, -154);
+    sim.player.facing = Math.PI;
+    const meta = sim.players.get(sim.playerId);
+    if (!meta) throw new Error('missing player meta');
+    meta.moveInput.forward = true;
+
+    sim.tick(); // allow the body-width standoff to clear the initial wall overlap
+    let totalJitter = 0;
+    let largestStep = 0;
+    for (let i = 0; i < 60; i++) {
+      const beforeZ = sim.player.pos.z;
+      sim.tick();
+      const dz = Math.abs(sim.player.pos.z - beforeZ);
+      totalJitter += dz;
+      largestStep = Math.max(largestStep, dz);
+    }
+
+    expect(largestStep).toBeLessThan(0.02);
+    expect(totalJitter).toBeLessThan(0.05);
+  });
+
+  it('still preserves tangential wall slide when pushing into the western wall at an angle', () => {
+    const sim = makeSim();
+    teleportTo(sim, -90, -154);
+    sim.player.facing = Math.PI - 0.2;
+    const meta = sim.players.get(sim.playerId);
+    if (!meta) throw new Error('missing player meta');
+    meta.moveInput.forward = true;
+
+    for (let i = 0; i < 20; i++) sim.tick();
+
+    expect(sim.player.pos.x).toBeGreaterThan(-88.5);
+    expect(Math.abs(sim.player.pos.z + 153.65)).toBeLessThan(0.25);
+  });
 });
 
 describe('swimming', () => {

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -245,6 +245,7 @@ describe('collision & terrain', () => {
   it('does not scatter trees or rocks onto cliff faces', () => {
     // A prop on a wall steeper than the climb limit floats off the face and
     // (for large rocks / trunks) plants an invisible collider there.
+    expect(DECORATION_MAX_SLOPE).toBe(1.5);
     const onCliffs = generateDecorations(SEED)
       .filter((d) => terrainSteepness(d.x, d.z, SEED) > DECORATION_MAX_SLOPE)
       .map((d) => `${d.kind}@${d.x.toFixed(0)},${d.z.toFixed(0)}`);

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -23,6 +23,7 @@ import {
 } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
 import { ACTIONS, encodeObs } from '../src/sim/obs';
+import { PLAYER_BODY_RADIUS, PLAYER_MAX_CLIMB_SLOPE } from '../src/sim/pathfind';
 import { Sim } from '../src/sim/sim';
 import { dist2d, type Entity, type SimEvent } from '../src/sim/types';
 import {
@@ -30,6 +31,8 @@ import {
   generateDecorations,
   groundHeight,
   terrainSteepness,
+  terrainSteepnessAt,
+  terrainWallStandoff,
   WATER_LEVEL,
 } from '../src/sim/world';
 
@@ -246,6 +249,75 @@ describe('collision & terrain', () => {
       .filter((d) => terrainSteepness(d.x, d.z, SEED) > DECORATION_MAX_SLOPE)
       .map((d) => `${d.kind}@${d.x.toFixed(0)},${d.z.toFixed(0)}`);
     expect(onCliffs).toEqual([]);
+  });
+});
+
+describe('terrain wall standoff', () => {
+  const R = PLAYER_BODY_RADIUS;
+  const SLOPE = PLAYER_MAX_CLIMB_SLOPE;
+
+  it('leaves open ground untouched', () => {
+    // the Eastbrook hub plateau: flat, no wall within a body radius
+    const s = terrainWallStandoff(0, 0, SEED, R, SLOPE);
+    expect(s).toEqual({ x: 0, z: 0 });
+  });
+
+  it('eases a body off the rim wall, bounded by one body radius', () => {
+    let pushed = 0;
+    let maxMove = 0;
+    for (let x = -175; x <= -148; x += 0.5) {
+      for (let z = 555; z <= 645; z += 0.5) {
+        // only positions a player could actually stand on
+        if (terrainSteepness(x, z, SEED) > SLOPE) continue;
+        const s = terrainWallStandoff(x, z, SEED, R, SLOPE);
+        const moved = Math.hypot(s.x - x, s.z - z);
+        if (moved === 0) continue;
+        pushed++;
+        maxMove = Math.max(maxMove, moved);
+      }
+    }
+    expect(pushed).toBeGreaterThan(0); // the standoff actually engages along the wall
+    expect(maxMove).toBeLessThanOrEqual(R + 1e-9); // never more than a body radius
+  });
+
+  it('keeps the Abandoned Crypt door reachable (door trigger 2.0yd)', () => {
+    // the crypt door sits in the west rim at (-152, 610); the standoff must not
+    // fence the player out of its 2.0yd trigger.
+    const door = { x: -152, z: 610 };
+    let closest = Infinity;
+    for (let x = -156; x <= -148; x += 0.5) {
+      for (let z = 606; z <= 614; z += 0.5) {
+        if (terrainSteepness(x, z, SEED) > SLOPE) continue;
+        const s = terrainWallStandoff(x, z, SEED, R, SLOPE);
+        if (terrainSteepness(s.x, s.z, SEED) > SLOPE) continue;
+        closest = Math.min(closest, Math.hypot(s.x - door.x, s.z - door.z));
+      }
+    }
+    expect(closest).toBeLessThan(2.0);
+  });
+
+  it('eases a player parked at a rim wall foot off it, end to end through the Sim', () => {
+    // A cell the Sim itself treats as FLAT footing (terrainSteepnessAt well under
+    // the limit, so no downhill slide and no move gate fires) that still has a
+    // wall within a body radius. A no-input grounded tick therefore moves the
+    // player ONLY via the standoff in the shared movement kernel, isolating it
+    // from the slide: without the standoff the player would not move at all.
+    const cell = { x: -150, z: 546.75 };
+    expect(terrainSteepnessAt(cell.x, cell.z, SEED)).toBeLessThan(1.0); // flat footing: no slide
+    const sim = makeSim();
+    teleportTo(sim, cell.x, cell.z);
+    sim.player.onGround = true;
+    sim.player.vx = 0;
+    sim.player.vz = 0;
+    sim.player.vy = 0;
+    sim.tick();
+    const moved = Math.hypot(sim.player.pos.x - cell.x, sim.player.pos.z - cell.z);
+    expect(moved).toBeGreaterThan(0.1); // the standoff engaged in the live Sim
+    expect(moved).toBeLessThanOrEqual(R + 1e-6); // and never more than a body radius
+    // and it did not shove the player onto a wall to slide back off
+    expect(terrainSteepnessAt(sim.player.pos.x, sim.player.pos.z, SEED)).toBeLessThanOrEqual(
+      SLOPE + 1e-6,
+    );
   });
 });
 

--- a/tests/player_motion.test.ts
+++ b/tests/player_motion.test.ts
@@ -3,7 +3,7 @@ import { isBlocked, resolveMovement } from '../src/sim/colliders';
 import { moveSpeedMult, type PlayerMotionDeps, stepPlayerMotion } from '../src/sim/player_motion';
 import { Sim } from '../src/sim/sim';
 import type { Entity, MoveInput } from '../src/sim/types';
-import { terrainHeight, terrainSteepness, WATER_LEVEL } from '../src/sim/world';
+import { terrainHeight, terrainSteepness, terrainSteepnessAt, WATER_LEVEL } from '../src/sim/world';
 
 // The parity gate for the movement-kernel extraction (MV1) and the foundation
 // of the online self extrapolator: stepPlayerMotion driven with CLIENT-shaped
@@ -191,6 +191,34 @@ describe('player motion kernel parity with the live Sim', () => {
     const actor2pos = { ...sim.player.pos };
     runParity(sim, mi({ forward: true, jump: true }), 20 * 5, 'uphill push');
     expect(sim.player.pos.x).toBeGreaterThan(actor2pos.x - 40); // never crested the rim
+  });
+
+  it('routes terrain wall standoff through the collision sweep', () => {
+    const standoffSeed = 20061;
+    const sim = new Sim({ seed: standoffSeed, playerClass: 'warrior', autoEquip: true });
+    const start = { x: -150, z: 546.75 };
+    teleport(sim, start.x, start.z);
+    expect(terrainSteepnessAt(start.x, start.z, standoffSeed)).toBeLessThan(1.0);
+
+    const actor = mirrorActor(sim);
+    let swept = false;
+    const deps: PlayerMotionDeps = {
+      ...clientDeps(standoffSeed),
+      resolveMove: (fromX, fromZ, nx, nz, _r, _e, ignoreFences) => {
+        swept = true;
+        expect(fromX).toBe(start.x);
+        expect(fromZ).toBe(start.z);
+        expect(Math.hypot(nx - fromX, nz - fromZ)).toBeGreaterThan(0.1);
+        expect(ignoreFences).toBe(false);
+        return { x: fromX, z: fromZ };
+      },
+    };
+
+    stepPlayerMotion(deps, actor, mi());
+
+    expect(swept).toBe(true);
+    expect(actor.pos.x).toBe(start.x);
+    expect(actor.pos.z).toBe(start.z);
   });
 
   it('enters deep water, treads the surface, and shore-hops identically', () => {

--- a/tests/self_motion.test.ts
+++ b/tests/self_motion.test.ts
@@ -62,15 +62,20 @@ class Lab {
   constructor(
     readonly lagMs: number,
     readonly frameMs = FRAME_MS,
+    opts: { start?: { x: number; z: number }; facing?: number } = {},
   ) {
     this.srv = new Sim({ seed: SEED, playerClass: 'warrior', autoEquip: true });
     this.srv.setPlayerLevel(60);
-    teleport(this.srv, 0, -40);
-    this.srv.player.facing = 0; // run straight north (+z)
+    const start = opts.start ?? { x: 0, z: -40 };
+    teleport(this.srv, start.x, start.z);
+    this.facing = opts.facing ?? 0;
+    this.srv.player.facing = this.facing; // run straight north (+z) by default
     const p = this.srv.player;
     this.self = { ...p, pos: { ...p.pos }, prevPos: { ...p.prevPos } };
     this.inputLog.push({ atMs: 0, input: mi() });
   }
+
+  readonly facing: number;
 
   setInput(input: MoveInput): void {
     this.localInput = input;
@@ -106,7 +111,7 @@ class Lab {
     const frame: SelfMotionFrame = {
       enabled: this.enabled,
       moveInput: this.localInput,
-      displayFacing: 0,
+      displayFacing: this.facing,
       echoMs: this.lagMs,
       jitterMs: 0,
       alpha,
@@ -141,6 +146,23 @@ describe('SelfMotionPredictor', () => {
     expect(moved).toBeGreaterThan(0.2); // ~4 frames of RUN_SPEED
     // the server has not even received the input yet (120ms lag > 4 frames)
     expect(lab.srv.player.pos.z).toBeCloseTo(-40, 3);
+  });
+
+  it('does not lead into a blocker and then reconcile back while forward is held', () => {
+    const lab = new Lab(120, FRAME_MS, { start: { x: 0, z: -0.15 }, facing: 0 });
+    lab.frame();
+    const before = lab.frame();
+    if (!before.pose) throw new Error('no initial pose');
+
+    lab.setInput(mi({ forward: true }));
+    let farthestLead = 0;
+    for (let i = 0; i < 6; i++) {
+      const r = lab.frame();
+      if (!r.pose) throw new Error('predictor disabled unexpectedly');
+      farthestLead = Math.max(farthestLead, r.pose.z - before.pose.z);
+    }
+
+    expect(farthestLead).toBeLessThan(0.03);
   });
 
   it('keeps the horizontal error inside the latency leash for the whole run', () => {


### PR DESCRIPTION
## Summary

A pass over how the zone-rim and inter-zone mountain walls look and feel, from
issues spotted while playing around Thornpeak Heights and Mirefen Marsh. Five
problems, one common cause: the steep walls are far from every hub and hold the
heightfield's highest frequencies, so they were the worst-served part of the
world. Two commits:

1. `fix(terrain): close LOD seams, smooth mountain relief and ground cliff scatter`
2. `fix(sim): ease the player body off cliff faces (wall standoff)`

**What was wrong, and the fix:**

1. **See-through seams.** At LOD-band borders the coarse side (a chord) and the
   fine side diverged; measured holes reached 3.3yd against a flat 0.3yd skirt, so
   you saw sky through the wall. Skirts now drop by `0.3 + slope * spacing`, and
   every wall chunk is promoted to the densest LOD band regardless of hub distance.
   Re-measured: 44 differing-spacing borders, 0 uncovered gaps.
2. **Sharp, faceted relief.** The wall-chunk LOD promotion resolves the terraced
   risers, and each quad now splits along the diagonal whose endpoints are closest
   in height, so the fold follows a ridge edge instead of sawing across it.
3. **Repetitive checkerboard on distant peaks.** The snow ramp was narrow relative
   to the 6yd terrace step (alternate treads went fully white / fully bare) and the
   macro normal map was sampled unfiltered (distant shimmer). The snow ramp was
   widened and noise-broken; the normal map now uses mipmaps + anisotropy (magFilter
   stays linear, so no loss up close).
4. **Floating rocks and trees.** `generateDecorations` had no slope gate, so scatter
   landed on near-vertical faces and jutted into the air (and large rocks / trunks
   planted invisible colliders there). It now rejects any candidate on terrain
   steeper than the climb limit. On the built-in seed this drops 141 props, all on
   rim/ridge walls, none in the rolling interior.
5. **The player sinking into cliff faces.** Heightfield collision samples only the
   player's center: the climb gate blocks the center from climbing a wall, but
   nothing keeps the body's width clear of one. A body-radius "wall standoff" now
   eases the center off any wall within reach.

**Design notes (the seams touched):**

- **Terrain is render-only; the heightfield is untouched.** Problems 1 to 3 live in
  `src/render/terrain.ts`. Sim and renderer share the same `terrainHeight`, so
  collision, movement, and parity are unaffected: pure presentation.
- **Decorations are one deterministic source, consumed by three systems.**
  `generateDecorations` (`src/sim/world.ts`) feeds the renderer, the minimap, AND
  collision (`colliders.ts`: large rocks and trunks are solid). So the cliff filter
  had to live at the source, not the renderer: a render-only filter would hide the
  visual but leave a phantom collider on the wall and a stray minimap dot.
- **The movement kernel is shared by the server and the client predictor.** The wall
  standoff lives in `stepPlayerMotion` (`src/sim/player_motion.ts`), the kernel both
  the authoritative server Sim and the client self extrapolator
  (`src/render/self_motion.ts`) run. Putting it there (not on `sim.ts`) keeps client
  prediction in lockstep with the server; a Sim-only standoff would rubber-band the
  player near walls. The standoff is a pure ring sample of the shared heightfield
  (`terrainWallStandoff` in `world.ts`), bounded to one body radius, never nudging
  onto steeper ground, a no-op on open ground and flat instanced floors. It draws no
  rng, so the tick draw order and the MV1 kernel parity gate are unchanged.

**Scope / known limits:** the standoff covers the normal WASD + gravity path; charge,
follow, and fear resolve separately (rare, brief, server-authoritative). A
sub-body-radius cosmetic clip can remain when hugging a cliff at a low camera angle
(the model is slightly wider than the collision radius); left as is, within
classic-MMO norms.

## Related issues

N/A (reported in-play, no filed issue).

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run` (full suite, 10,860 passed) and `npx vitest run tests/fixes.test.ts`
    for the new terrain/decoration/standoff tests.
  - `npx tsc --noEmit` clean; Biome on changed files clean.
  - `npm run build`, `npm run build:server`, `npm run build:env` all succeed.
- Manual / numeric steps:
  - Measured LOD-seam holes vs skirt coverage before/after (44 borders, 0 uncovered).
  - Measured the decoration slope distribution (141 props removed, all on walls).
  - Before/after screenshots at the reported vantages (seams, relief, distant
    checkerboard, floating props) on the high graphics tier. The geometry changes
    (skirts, LOD promotion, triangulation, scatter filter, standoff) apply to both
    tiers by construction; the snow/mipmap change is high-tier only (the Lambert
    tier has no normal map or splat snow).
  - The wall-clip case is verified by an end-to-end Sim test rather than a
    screenshot: near walls the climb gate and downhill slide dominate the exact
    resting frame, so the test is the decisive evidence (it fails without the fix).

## Screenshots / recordings


**Seam before:**

<img width="1402" height="1094" alt="seam-before" src="https://github.com/user-attachments/assets/e0317ebd-3cc7-4ba1-8d8b-aebfd3ceec73" />

**Seam after:**

<img width="1738" height="1086" alt="seam-after" src="https://github.com/user-attachments/assets/6d9ce5c7-95a3-44be-9688-8055900fe372" />


**Relief before:**

<img width="1402" height="1094" alt="relief-before" src="https://github.com/user-attachments/assets/6f672371-68b5-4f13-814d-556604516ed2" />

**Relief after:**

<img width="1738" height="1086" alt="relief-after" src="https://github.com/user-attachments/assets/e1fea30a-4301-4b0d-9bc8-b7b3b74489ce" />


---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` green; added tests for the `sim/` changes
      (decoration slope filter and the wall standoff) in `tests/fixes.test.ts`.
- [x] **Typecheck passes.** `npx tsc --noEmit` clean.
- [x] **Builds succeed.** `npm run build`, `npm run build:server`, `npm run build:env`.

### Cross-platform

- [x] ~Tested on desktop and mobile / touch targets.~ N/A: no HUD/UI or touch
      surface. Terrain rendering + sim only; geometry changes are graphics-tier
      independent, snow/mipmap is high-tier only.
- [ ] ~Accessible.~ N/A: no UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed; `ALLOW_DEV_COMMANDS` not
      enabled anywhere.
- [x] No hand-edited generated files (`manifest.generated.ts` etc.).
