### PR TITLE
fix(deploy): control the two build-drift inputs behind the v0.22 CPU incident

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
 # World of Claudecraft game server — serves the built client, REST API and WebSocket
 # world on one port. Pair with a postgres service (see docker-compose.yml).
 
-FROM node:22-alpine AS build
+# Base image for BOTH stages, overridable at build time. An unpinned floating
+# tag means two builds of the same source can ship different node runtimes
+# (build drift, see the v0.22 CPU incident). Deploys should pin an exact
+# version or digest, for example:
+#   BASE_IMAGE=node:22.17.0-alpine
+#   BASE_IMAGE=node:22-alpine@sha256:<digest>
+ARG BASE_IMAGE=node:22-alpine
+FROM ${BASE_IMAGE} AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --no-audit --no-fund
@@ -23,7 +30,7 @@ ARG VITE_TURNSTILE_SITEKEY=""
 RUN VITE_TURNSTILE_SITEKEY="$VITE_TURNSTILE_SITEKEY" \
     npm run build && cp -a dist/media ./media-build && rm -rf dist/media && npm run build:server && npm run build:bot
 
-FROM node:22-alpine
+FROM ${BASE_IMAGE}
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=build /app/dist ./dist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       args:
         # Build-time public client config inlined into the bundle (see .env.example).
         VITE_TURNSTILE_SITEKEY: ${VITE_TURNSTILE_SITEKEY:-}
+        # Pin the node base image for reproducible builds (see Dockerfile).
+        BASE_IMAGE: ${EASTBROOK_BASE_IMAGE:-node:22-alpine}
     container_name: eastbrook-game
     restart: unless-stopped
     depends_on:
@@ -35,6 +37,13 @@ services:
     environment:
       DATABASE_URL: postgres://eastbrook:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env. See .env.example.}@postgres:5432/eastbrook
       PORT: "8787"
+      # Runtime: the one-flag API dispatch rollback (legacy|new; empty means the
+      # default) and the 20 Hz tick perf trace (1 to enable). Compose passes only
+      # the vars listed in this block, so a value set in the host .env is silently
+      # dropped unless it appears here (this masked the API_DISPATCH=legacy test
+      # during the v0.22 CPU incident).
+      API_DISPATCH: ${API_DISPATCH:-}
+      PERF_TICK_LOG: ${PERF_TICK_LOG:-}
       # Target the game server 302-redirects /wiki to when hit directly (not via the
       # reverse proxy). Public origin in prod; localhost fallback for local dev.
       WIKI_URL: ${WIKI_URL:-http://localhost:8080/wiki/index.php/Main_Page}


### PR DESCRIPTION
## Problem

During the v0.22 CPU P0 every in-repo suspect was ruled out (legacy dispatch verified live via the boot log, linkdead reverted, pg idle), yet rolling back to the v0.21 IMAGE fixed it. Investigation found the prod image bakes two inputs that are not pinned by this repo, so image rebuilds drift invisibly to git ranges:

1. Both Dockerfile stages use the floating node:22-alpine tag (runtime can change between builds).
2. The private bot detector is cloned at unpinned main at build time (pinned separately in woc-deploy).

It also found the compose game environment block silently drops host .env vars that are not allowlisted, which turned the first API_DISPATCH=legacy rollback test into a no-op and blocks PERF_TICK_LOG tick tracing.

## Changes

- Dockerfile: BASE_IMAGE build arg for both stages, defaulting to the current tag; deploys pin an exact version or digest.
- docker-compose.yml: pass the EASTBROOK_BASE_IMAGE build arg through, and allowlist API_DISPATCH and PERF_TICK_LOG (empty values keep server defaults, verified against server/http/config.ts parseDispatch and game.ts maybeLogTickPerf).

## Test plan

- [x] docker compose config validates; new keys interpolate ('' defaults)
- [x] parseDispatch treats '' as unset (DEFAULT_DISPATCH); PERF_TICK_LOG '' stays off
- [ ] Rebuild v0.22.1 image with EASTBROOK_BASE_IMAGE pinned to the v0.21 node version and redeploy (the confirming experiment for the remaining drift hypothesis)