### PR TITLE
perf(sim): skip rim-crest noise where the rim factor is zero (#1620)

### DIFF
--- a/src/sim/world.ts
+++ b/src/sim/world.ts
@@ -516,11 +516,20 @@ export function terrainHeight(x: number, z: number, seed: number): number {
   // crest as the inter-zone ridges: a coarse peak/saddle layer plus a finer
   // crag layer, same conservative combined variance so the climb-limit
   // invariant still holds along the whole rim.
-  const rimCrest =
-    1 +
-    (fbm2(x * 0.025, z * 0.025, seed + 29, 3) - 0.5) * 0.35 * mountainDetail +
-    (fbm2(x * 0.09, z * 0.09, seed + 37, 2) - 0.5) * 0.15 * mountainDetail;
-  mountainAdd += rim * 55 * rimCrest;
+  // rimCrest is only ever consumed as `rim * 55 * rimCrest`, so where rim is 0
+  // (the entire open world, everything more than 30yd inside the boundary) it
+  // adds exactly 0. Skip its two fbm2 layers there: groundHeight is the hottest
+  // sim function (player/mob/pet movement, gravity, deep-water and charge checks)
+  // and this was paying 5 noise2 evaluations per ground sample for nothing. This
+  // is a pure early-out, never an approximation: any positive rim still pays the
+  // full crest, so returned heights stay bit-identical (tests/terrain_walls.test.ts).
+  if (rim > 0) {
+    const rimCrest =
+      1 +
+      (fbm2(x * 0.025, z * 0.025, seed + 29, 3) - 0.5) * 0.35 * mountainDetail +
+      (fbm2(x * 0.09, z * 0.09, seed + 37, 2) - 0.5) * 0.15 * mountainDetail;
+    mountainAdd += rim * 55 * rimCrest;
+  }
   // Terrace the combined mountain rise into stair-stepped bands (flat treads
   // + steep risers) instead of one smooth ramp, so slopes read as a stacked
   // rocky mountainside rather than a uniform incline. This does not reduce

--- a/tests/terrain_walls.test.ts
+++ b/tests/terrain_walls.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { CAMPS, NPCS, ROADS, WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_Z, ZONES } from '../src/sim/data';
 import { PLAYER_MAX_CLIMB_SLOPE } from '../src/sim/pathfind';
+import * as rng from '../src/sim/rng';
 import {
   PITCH,
   PITCH_CENTER,
@@ -224,6 +225,55 @@ describe('impassable terrain walls', () => {
           CLIMB_LIMIT,
         );
       }
+    }
+  });
+});
+
+// The rim-crest noise (two fbm2 layers) is only ever consumed as rim * 55 * crest,
+// so where rim is 0 (the entire open world) it contributes exactly nothing. The
+// height function early-outs that work when rim === 0. This must stay a PURE
+// early-out (bit-identical), not an approximation, since groundHeight is shared by
+// the sim, the server, and the renderer and any drift would fork the world.
+describe('rim-crest early-out (issue 1620)', () => {
+  // Interior samples with rim === 0 (open world), and boundary samples where the
+  // rim wall rises (rim > 0): +X edge, south edge (minZ), north edge (maxZ). Both
+  // sets are pinned to their pre-change outputs; the early-out must not move them.
+  const RIM_ZERO: [number, number, number][] = [
+    [0, 100, 0.44542967472922235],
+    [0, 0, 1.5],
+    [120, 200, 3.757897204555065],
+    [-140, 300, -6.453833730142541],
+  ];
+  const RIM_POSITIVE: [number, number, number][] = [
+    [165, 100, 40.836764683877306],
+    [0, -165, 38.295170748071776],
+    [0, 885, 37.198901254787515],
+    [160, -40, 16.37517884232531],
+    [178, 100, 58.015307256852566],
+    [0, -178, 46.49842115412116],
+  ];
+
+  it('returns bit-identical heights for rim === 0 and rim > 0 samples', () => {
+    for (const [x, z, h] of [...RIM_ZERO, ...RIM_POSITIVE]) {
+      expect(groundHeight(x, z, WORLD_SEED), `groundHeight(${x}, ${z})`).toBe(h);
+    }
+  });
+
+  it('skips the two rim-crest fbm2 evaluations only where rim === 0', () => {
+    // (0, 300) and (165, 300) share the same z (identical ridge / crater / plateau
+    // cost) so the ONLY fbm2 difference between them is the rim-crest pair, which
+    // runs at the +X-edge sample (rim > 0) but not the interior one (rim === 0).
+    const spy = vi.spyOn(rng, 'fbm2');
+    try {
+      spy.mockClear();
+      groundHeight(0, 300, WORLD_SEED); // interior, rim === 0
+      const interior = spy.mock.calls.length;
+      spy.mockClear();
+      groundHeight(165, 300, WORLD_SEED); // +X edge, rim > 0
+      const boundary = spy.mock.calls.length;
+      expect(boundary - interior).toBe(2);
+    } finally {
+      spy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## What

`terrainHeight`/`groundHeight` is the hottest function in the sim: player and mob movement, gravity, deep-water and charge/fishing checks all sample it many times per tick. Since the jagged-mountains work, every call unconditionally evaluated the rim-crest noise, two `fbm2` layers (a 3-octave plus a 2-octave, five `noise2` = 20 `hash2` evaluations), even where the rim factor is 0.

That contribution is only ever consumed as `rim * 55 * rimCrest`, and `rim` is exactly 0 across the entire open world (nonzero only within 30yd of the boundary). So the two `fbm2` evaluations were pure waste on the hottest path everywhere a player actually is.

## Fix

Guard the rim-crest block behind `if (rim > 0)`. This is a **pure early-out, never an approximation**: any positive rim still pays the full crest, so returned heights are **bit-identical for every input**. Determinism across the three hosts (offline `Sim`, server, headless RL env) and agreement with the renderer (which samples the same function) are preserved. The inter-zone ridge crest is already gated by its own proximity check, and `terraceStep(0) === 0`, so the rim block was the sole remaining per-sample waste.

## Tests

`tests/terrain_walls.test.ts`:
- Pins bit-identical `groundHeight` outputs at `rim === 0` interior samples and `rim > 0` boundary samples (+X edge, south, north): the early-out must not move any value.
- Asserts the two rim-crest `fbm2` evaluations run **only** where `rim > 0`: a same-`z` interior vs edge sample whose `fbm2` call counts differ by exactly two (test-first: failed before the guard).

The parity golden-trace gate (`tests/parity`) and `tests/architecture.test.ts` (sim purity) stay green.

## Notes

Found during the v0.22 production CPU investigation; filed as hot-path hygiene (not the P0 cause). Measured impact is small (order 0.1% of a core at typical scale) but it is free to reclaim on the sim's busiest path.

Fixes #1620