### PR TITLE
fix(ui): bind death-screen respawn buttons via touch-tap (#1484)

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1354,12 +1354,17 @@ export class Hud {
     });
     this.initCompass();
     this.initMinimapZoom(mm);
-    this.releaseSpiritBtnEl.addEventListener('click', () => {
+    // bindTouchTap, not 'click': the browser only synthesizes click for the
+    // PRIMARY pointer, so on a phone these death-screen buttons went dead the
+    // moment another finger was down (a held movement joystick when the player
+    // died mid-run), stranding them on the death overlay (issue 1484). Matches
+    // every other touch-facing HUD button; desktop mouse/keyboard is preserved.
+    bindTouchTap(this.releaseSpiritBtnEl, () => {
       if (this.sim.arenaInfo?.match) return;
       this.sim.releaseSpirit();
     });
-    this.resurrectCorpseBtnEl.addEventListener('click', () => this.sim.resurrectAtCorpse());
-    this.resurrectHealerBtnEl.addEventListener('click', () => this.sim.resurrectAtSpiritHealer());
+    bindTouchTap(this.resurrectCorpseBtnEl, () => this.sim.resurrectAtCorpse());
+    bindTouchTap(this.resurrectHealerBtnEl, () => this.sim.resurrectAtSpiritHealer());
     document.addEventListener('pointerdown', (ev) => {
       const target = ev.target as Node | null;
       if (!target) return;

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -942,6 +942,23 @@ describe('client HTML shell', () => {
     expect(hudTs).toContain('bindTouchTap(moreClose, () => {');
   });
 
+  it('binds the death-screen respawn buttons via touch-tap, not bare click', () => {
+    // On a phone the browser only synthesizes 'click' for the primary pointer,
+    // so a bare click binding goes dead while another finger is down (a held
+    // movement joystick when the player dies mid-run), stranding them on the
+    // death overlay (issue 1484). All three buttons must use bindTouchTap.
+    expect(hudTs).toContain('bindTouchTap(this.releaseSpiritBtnEl, () => {');
+    expect(hudTs).toContain(
+      'bindTouchTap(this.resurrectCorpseBtnEl, () => this.sim.resurrectAtCorpse());',
+    );
+    expect(hudTs).toContain(
+      'bindTouchTap(this.resurrectHealerBtnEl, () => this.sim.resurrectAtSpiritHealer());',
+    );
+    expect(hudTs).not.toMatch(
+      /(?:releaseSpiritBtnEl|resurrectCorpseBtnEl|resurrectHealerBtnEl)\.addEventListener\('click'/,
+    );
+  });
+
   it('keeps desktop community links open after HUD clicks', () => {
     expect(mainTs).toContain('communityMenu.open = !(NATIVE_APP || useTouchInterface());');
     expect(hudTs).toMatch(


### PR DESCRIPTION
## Problem

On mobile, a player can get stuck on the death screen: tapping **Release Spirit** does nothing and the overlay never clears (issue #1484).

## Root cause

The three death-screen buttons (Release Spirit, Resurrect at Corpse, Resurrect at Spirit Healer) were wired with a bare `addEventListener('click', ...)`. As `src/ui/touch_tap.ts` documents, the browser only synthesizes a compatibility `click` for the **primary** pointer, so a bare `click` binding goes dead the moment a second finger is already down.

The concrete case: the player dies mid-run with the movement joystick still held. That joystick finger owns the primary pointer (implicit pointer capture), and `#mobile-controls` (z-index 60) sits above the death overlay (z-index 30) and is never hidden on death. A tap on Release Spirit with the other thumb never synthesizes a `click`, so `sim.releaseSpirit()` never fires, no release command reaches the server, the ghost flag never flips, and the overlay (keyed off `dead && !ghost`) never clears. This is why it is mobile-only and intermittent (it needs a second finger down).

Every other touch-facing HUD control (the mobile action ring, the more-menu close X, page toggles) was already migrated to `bindTouchTap` for exactly this reason; these three were missed.

## Fix

Swap the three bindings to `bindTouchTap`, matching every sibling button. `bindTouchTap` preserves the desktop mouse and keyboard (Enter/Space) `click` path, so this is purely additive touch handling with no desktop regression. No server, wire, or sim change: the online release path was already correct, the tap just never reached it.

## Tests

`tests/client_shell.test.ts` asserts all three buttons use `bindTouchTap` and none is left on a bare `click` binding, extending the same source-scan guard that already covers the more-menu close X.

## Note on screenshots

There is no visual change: the death overlay renders identically. The defect is a dead tap under multi-touch, so the fix is behavioral (which event binding is used), not visual.

Fixes #1484