### PR TITLE
fix(sim): key solo dungeon instances to the durable character id (#1600)

### DIFF
--- a/src/sim/instances/dungeons.ts
+++ b/src/sim/instances/dungeons.ts
@@ -41,7 +41,18 @@ const RAID_REQUIRED_DUNGEON_IDS = new Set(['nythraxis_boss_arena']);
 
 export function instanceKeyFor(ctx: SimContext, pid: number): string {
   const party = ctx.partyOf(pid);
-  return party ? `party:${party.id}` : `solo:${pid}`;
+  if (party) return `party:${party.id}`;
+  // Key a solo instance to the DURABLE character id, not the transient entity
+  // id. A logout/relog or a character-select Take-Over mints a NEW entity id,
+  // which under an entity-id key spawned a fresh instance with the boss alive
+  // again, bypassing the empty-instance reset timer (the Gravewyrm Sanctum
+  // zero-downtime farm, issue 1600). Re-deriving the same key across relog makes
+  // re-entry rejoin the cleared instance instead. Keep the `solo:` prefix (the
+  // delve auto-companion gates on startsWith('solo:')) and mark the
+  // character-keyed form so it can never collide with the entity-id fallback,
+  // which offline / headless / tests (no character id) still use.
+  const cid = ctx.players.get(pid)?.characterId;
+  return cid != null ? `solo:char:${cid}` : `solo:${pid}`;
 }
 
 export function instanceOriginOf(inst: InstanceSlot): { x: number; z: number } {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -397,8 +397,8 @@ import {
   type SkinCatalog,
   type SkinRank,
   type SportRole,
-  steadyAngleTo,
   SUNDER_ARMOR_PCT_PER_STACK,
+  steadyAngleTo,
   swingMissChance,
   type VcBracket,
   type VcNationId,
@@ -700,7 +700,7 @@ export interface InstanceSlot {
   dungeonId: string;
   difficulty: DungeonDifficulty;
   slot: number;
-  partyKey: string | null; // party id or 'solo:<pid>'
+  partyKey: string | null; // 'party:<id>', 'solo:char:<characterId>', or the 'solo:<pid>' entity-id fallback
   mobIds: number[];
   objectIds: number[];
   exitId: number | null;

--- a/tests/dungeons.test.ts
+++ b/tests/dungeons.test.ts
@@ -980,6 +980,48 @@ describe('dungeons: pure helpers', () => {
     expect(instanceKeyFor(sim.ctx, b)).toBe(`party:${party.id}`);
   });
 
+  it('keys a solo instance to the durable character id when present (issue 1600)', () => {
+    const sim = makeSim();
+    // Online players carry a durable character id; the solo key is derived from
+    // it, not the transient entity id, so a relog (new entity id) rejoins the
+    // same instance. The `solo:` prefix is preserved (the delve auto-companion
+    // checks startsWith('solo:')) and the `char:` marker keeps it from ever
+    // colliding with the entity-id fallback used offline / in tests.
+    const withCid = sim.addPlayer('warrior', 'Durable', { characterId: 77 });
+    expect(instanceKeyFor(sim.ctx, withCid)).toBe('solo:char:77');
+    // No character id (offline / headless / most tests): fall back to entity id.
+    const noCid = sim.addPlayer('mage', 'Legacy');
+    expect(instanceKeyFor(sim.ctx, noCid)).toBe(`solo:${noCid}`);
+  });
+
+  it('a relog rejoins the cleared solo instance instead of respawning the boss (issue 1600)', () => {
+    const sim = makeSim();
+    const cid = 4242;
+    const pid1 = sim.addPlayer('rogue', 'Exploiter', { characterId: cid });
+    enterDungeon(sim.ctx, 'gravewyrm_sanctum', pid1);
+    const inst1 = claimedDungeon(sim, 'gravewyrm_sanctum');
+    expect(inst1, 'gravewyrm_sanctum did not claim a solo instance').toBeTruthy();
+    const slot1 = inst1.slot;
+    const bossId1 = mobInInstance(sim, inst1, 'korzul_the_gravewyrm').id;
+
+    // Simulate the Take-Over relog exploit: drop the player (the instance
+    // lingers, its 300s empty reset not yet elapsed) and re-add the SAME
+    // character, which assigns a NEW entity id.
+    sim.removePlayer(pid1);
+    const pid2 = sim.addPlayer('rogue', 'Exploiter', { characterId: cid });
+    expect(pid2).not.toBe(pid1);
+    enterDungeon(sim.ctx, 'gravewyrm_sanctum', pid2);
+
+    // The relog must rejoin the cleared instance, not mint a fresh one with the
+    // boss respawned: exactly ONE claimed instance, same slot, same boss entity.
+    const claimed = (sim.instances as any[]).filter(
+      (i) => i.dungeonId === 'gravewyrm_sanctum' && i.partyKey !== null,
+    );
+    expect(claimed.length).toBe(1);
+    expect(claimed[0].slot).toBe(slot1);
+    expect(mobInInstance(sim, claimed[0], 'korzul_the_gravewyrm').id).toBe(bossId1);
+  });
+
   it('instanceOriginOf matches the data instanceOrigin for the slot', () => {
     const sim = makeSim();
     const pid = sim.addPlayer('warrior', 'Solo');


### PR DESCRIPTION
## Problem (critical farm exploit)

Gravewyrm Sanctum, and any standard solo dungeon, could be farmed with zero downtime (issue #1600). Solo instances were keyed by the **transient entity id** (`solo:<entityId>`), and a logout/relog or a character-select **Take-Over** mints a new entity id. That changed the instance key, so re-entering claimed a **fresh instance with every mob (including the finale boss Korzul) respawned**, bypassing the 300s empty-instance reset that is meant to throttle a re-farm. Standard dungeons have no per-character lockout (only the Nythraxis raid does), so nothing else stopped it. Korzul drops a guaranteed uncommon plus a high chance at a rare/epic, re-rolled every kill, so this is a real economy exploit.

## Fix

Derive the solo key from the **durable character id** instead: `solo:char:<cid>`, falling back to the entity id (`solo:<pid>`) when there is none (offline / headless / tests). Re-deriving the same key across a relog makes re-entry **rejoin the still-live cleared instance** instead of minting a fresh one, so the boss stays dead until the intended empty-instance reset, exactly like an honest player who waited.

- Normal play is unchanged: a legitimate mid-run relog now rejoins its instance (a correctness improvement), and party runs are untouched.
- The `solo:` prefix is preserved so the delve auto-companion gate (`startsWith('solo:')`) still fires for solo players, and the `char:` marker keeps the durable key from ever colliding with the entity-id fallback.
- `instanceKeyFor` is opaque to its consumers (`partyMembersForKey` re-derives and compares whole keys; nothing parses the id out of the string), and instances are runtime-only state (never serialized), so there is no wire-parity or persisted-state impact. The derivation is a pure read (no rng, no tick-phase change), so determinism and draw order are unaffected.

## Tests

`tests/dungeons.test.ts` pins the durable key and the entity-id fallback, and reproduces the exploit: a relog with the same character id but a new entity id rejoins the same instance slot with the same boss entity, instead of claiming a second instance with the boss respawned (which failed before the fix). The parity golden-trace gate and `tests/architecture.test.ts` (sim purity) stay green; the delve suites confirm the solo auto-companion still spawns.

## Scope note

This closes the reported boss-respawn farm at its root. The issue also lists two related-but-separate concerns from the same investigation that I deliberately kept out of this PR to keep it one cohesive change: the arena free-heal-on-return (a fighter can leave a bout topped off) and a matchmaking position filter for queueing while inside an instance. Happy to follow up on those as their own PR if you would like.

Fixes #1600