### PR TITLE
docs(contributing): add missing .env setup step before npm run db:up

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,8 @@ That's enough to play the offline world and work on most things. To run the full
 online stack:
 
 ```bash
+cp .env.example .env
+# edit .env and set POSTGRES_PASSWORD (DATABASE_URL should use the same password)
 npm run db:up        # start Postgres 16 in Docker (dev DB on port 5433)
 npm run server       # build and run the authoritative game server on :8787
 npm run dev          # in another terminal; the client proxies to the server


### PR DESCRIPTION
## Summary

CONTRIBUTING.md's "Getting started" guide walks through `npm run db:up` to
start Postgres, but never has the reader create a `.env` file first. Running
the steps verbatim fails with:

```
error while interpolating services.postgres.environment.POSTGRES_PASSWORD:
required variable POSTGRES_PASSWORD is missing a value: Set POSTGRES_PASSWORD in .env.
```

README.md's equivalent "Develop online with hot reload" section already has
this step; this PR brings CONTRIBUTING.md in line with it so new contributors
following the guide don't get stuck on step one of the online stack.

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [ ] Bug fix
- [x] Refactor or performance (no behavior change)
- [x] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands: `npm ci`, `npm run dev`, `npm run db:up`, `npm run server`, `npm test`, `npx tsc --noEmit`, `npm run security:gate`, `npm run build`
- Manual steps: followed CONTRIBUTING.md's getting-started steps verbatim on a clean checkout. Hit the `POSTGRES_PASSWORD` failure on `npm run db:up` before this fix; with `cp .env.example .env` added, `db:up` and `npm run server` both succeeded and I registered an account and logged in through the browser client to confirm the full online stack works end to end.

## Screenshots / recordings

N/A, docs-only change with no player or operator facing UI.

---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build` succeeds.

### Cross-platform

- [x] N/A. Docs-only change, no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
