### PR TITLE
fix(i18n): auto-select native device language

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -176,6 +176,7 @@ import {
 } from './ui/i18n';
 import { defaultIconPrewarmEntries, prewarmIconCache } from './ui/icon_prewarm';
 import { iconDataUrl } from './ui/icons';
+import { applyNativeDeviceLanguage } from './ui/native_language';
 import { scheduleNativeUpdateCheck } from './ui/native_update_prompt';
 import { createMetricsSampler } from './ui/perf_metrics_sampler';
 import { PerfOverlay } from './ui/perf_overlay';
@@ -261,6 +262,22 @@ function isNativeRuntime(): boolean {
   const cap = (window as unknown as { Capacitor?: { isNativePlatform?: () => boolean } }).Capacitor;
   return cap?.isNativePlatform?.() === true;
 }
+
+function localStorageOrNull(): Storage | null {
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+applyNativeDeviceLanguage({
+  native: isNativeRuntime(),
+  locationSearch: window.location.search,
+  storage: localStorageOrNull(),
+  languages: navigator.languages,
+  language: navigator.language,
+});
 
 const SITE_URL = 'https://worldofclaudecraft.com/';
 

--- a/src/ui/native_language.ts
+++ b/src/ui/native_language.ts
@@ -1,0 +1,138 @@
+import { isSupportedLanguage, type SupportedLanguage, setLanguage } from './i18n';
+
+type LocaleStorageLike = Pick<Storage, 'getItem' | 'setItem'>;
+
+export interface NativeLanguageEnv {
+  native: boolean;
+  locationSearch?: string;
+  storage?: LocaleStorageLike | null;
+  languages?: readonly string[] | null;
+  language?: string | null;
+}
+
+const LOCALE_KEY = 'locale';
+const NATIVE_AUTO_LOCALE_KEY = 'woc_native_auto_locale';
+
+const DEFAULT_REGION_BY_LANGUAGE: Readonly<Record<string, SupportedLanguage>> = {
+  cs: 'cs_CZ',
+  da: 'da_DK',
+  de: 'de_DE',
+  fr: 'fr_FR',
+  id: 'id_ID',
+  it: 'it_IT',
+  ja: 'ja_JP',
+  ko: 'ko_KR',
+  nl: 'nl_NL',
+  pl: 'pl_PL',
+  pt: 'pt_BR',
+  ru: 'ru_RU',
+  sv: 'sv_SE',
+  tr: 'tr_TR',
+  vi: 'vi_VN',
+  zh: 'zh_CN',
+};
+
+function normalizedLocaleCandidates(locale: string): string[] {
+  const cleaned = locale.trim().split('.')[0]?.split('@')[0] ?? '';
+  if (!cleaned) return [];
+
+  const parts = cleaned
+    .replace(/-/g, '_')
+    .split('_')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const language = parts[0]?.toLowerCase();
+  if (!language) return [];
+
+  const region = parts.find((part, index) => index > 0 && /^[A-Za-z]{2}$|\d{3}$/.test(part));
+  const out: string[] = [];
+  if (region) out.push(`${language}_${region.toUpperCase()}`);
+  out.push(language);
+
+  const defaultRegion = DEFAULT_REGION_BY_LANGUAGE[language];
+  if (defaultRegion) out.push(defaultRegion);
+
+  return out;
+}
+
+export function resolveSupportedDeviceLanguage(
+  locales: readonly string[],
+): SupportedLanguage | null {
+  for (const locale of locales) {
+    for (const candidate of normalizedLocaleCandidates(locale)) {
+      if (isSupportedLanguage(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+function explicitLanguageSelection(env: NativeLanguageEnv): boolean {
+  if (env.locationSearch) {
+    const params = new URLSearchParams(env.locationSearch);
+    const langParam = params.get('lang');
+    if (langParam && isSupportedLanguage(langParam)) return true;
+  }
+
+  const saved = storedSupportedLanguage(env.storage, LOCALE_KEY);
+  if (!saved) return false;
+  return storedSupportedLanguage(env.storage, NATIVE_AUTO_LOCALE_KEY) !== saved;
+}
+
+function storedSupportedLanguage(
+  storage: LocaleStorageLike | null | undefined,
+  key: string,
+): SupportedLanguage | null {
+  if (!storage || typeof storage.getItem !== 'function') return null;
+  try {
+    const saved = storage.getItem(key);
+    return saved && isSupportedLanguage(saved) ? saved : null;
+  } catch {
+    return null;
+  }
+}
+
+function rememberNativeAutoLanguage(
+  storage: LocaleStorageLike | null | undefined,
+  lang: SupportedLanguage,
+): void {
+  if (!storage || typeof storage.setItem !== 'function') return;
+  try {
+    storage.setItem(LOCALE_KEY, lang);
+    storage.setItem(NATIVE_AUTO_LOCALE_KEY, lang);
+  } catch {
+    // Storage may be unavailable in privacy modes; the in-memory language still applies.
+  }
+}
+
+export function nativeDeviceLocaleList(
+  env: Pick<NativeLanguageEnv, 'languages' | 'language'>,
+): string[] {
+  const out: string[] = [];
+  if (Array.isArray(env.languages)) {
+    for (const locale of env.languages) {
+      if (typeof locale === 'string' && locale.trim()) out.push(locale);
+    }
+  }
+  if (typeof env.language === 'string' && env.language.trim() && !out.includes(env.language)) {
+    out.push(env.language);
+  }
+  return out;
+}
+
+export function applyNativeDeviceLanguage(env: NativeLanguageEnv): SupportedLanguage | null {
+  if (!env.native || explicitLanguageSelection(env)) return null;
+  const selected = resolveSupportedDeviceLanguage(nativeDeviceLocaleList(env));
+  if (selected) {
+    setLanguage(selected);
+    rememberNativeAutoLanguage(env.storage, selected);
+    return selected;
+  }
+
+  if (storedSupportedLanguage(env.storage, NATIVE_AUTO_LOCALE_KEY)) {
+    setLanguage('en');
+    rememberNativeAutoLanguage(env.storage, 'en');
+    return 'en';
+  }
+
+  return null;
+}

--- a/tests/native_language.test.ts
+++ b/tests/native_language.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getLanguage, setLanguage } from '../src/ui/i18n';
+import {
+  applyNativeDeviceLanguage,
+  nativeDeviceLocaleList,
+  resolveSupportedDeviceLanguage,
+} from '../src/ui/native_language';
+
+function storageWithLocale(
+  locale: string | null,
+  nativeAutoLocale: string | null = null,
+): Pick<Storage, 'getItem' | 'setItem'> & { values: Map<string, string> } {
+  const values = new Map<string, string>();
+  if (locale) values.set('locale', locale);
+  if (nativeAutoLocale) values.set('woc_native_auto_locale', nativeAutoLocale);
+  return {
+    values,
+    getItem(key: string): string | null {
+      return values.get(key) ?? null;
+    },
+    setItem(key: string, value: string): void {
+      values.set(key, value);
+    },
+  };
+}
+
+describe('native device language selection', () => {
+  afterEach(() => setLanguage('en'));
+
+  it('uses an exact supported device dialect when available', () => {
+    expect(resolveSupportedDeviceLanguage(['fr-CA'])).toBe('fr_CA');
+    expect(resolveSupportedDeviceLanguage(['zh-Hant-TW'])).toBe('zh_TW');
+    expect(resolveSupportedDeviceLanguage(['en-CA'])).toBe('en_CA');
+  });
+
+  it('falls back from device language subtags to an available game locale', () => {
+    expect(resolveSupportedDeviceLanguage(['fr-BE'])).toBe('fr_FR');
+    expect(resolveSupportedDeviceLanguage(['de'])).toBe('de_DE');
+    expect(resolveSupportedDeviceLanguage(['es-MX'])).toBe('es');
+    expect(resolveSupportedDeviceLanguage(['en-US'])).toBe('en');
+  });
+
+  it('returns null for unsupported device languages so English remains the default', () => {
+    setLanguage('en');
+    expect(resolveSupportedDeviceLanguage(['ar-SA', 'hi-IN'])).toBeNull();
+    expect(
+      applyNativeDeviceLanguage({
+        native: true,
+        storage: storageWithLocale(null),
+        languages: ['ar-SA'],
+      }),
+    ).toBeNull();
+    expect(getLanguage()).toBe('en');
+  });
+
+  it('does not override an explicit saved language or URL language', () => {
+    setLanguage('en');
+    expect(
+      applyNativeDeviceLanguage({
+        native: true,
+        storage: storageWithLocale('ja_JP'),
+        languages: ['de-DE'],
+      }),
+    ).toBeNull();
+    expect(getLanguage()).toBe('en');
+
+    expect(
+      applyNativeDeviceLanguage({
+        native: true,
+        locationSearch: '?lang=pt_BR',
+        storage: storageWithLocale(null),
+        languages: ['de-DE'],
+      }),
+    ).toBeNull();
+    expect(getLanguage()).toBe('en');
+  });
+
+  it('keeps native auto-selected languages device-driven across launches', () => {
+    setLanguage('de_DE');
+    const storage = storageWithLocale('de_DE', 'de_DE');
+    expect(
+      applyNativeDeviceLanguage({
+        native: true,
+        storage,
+        languages: ['vi-VN'],
+      }),
+    ).toBe('vi_VN');
+    expect(getLanguage()).toBe('vi_VN');
+    expect(storage.values.get('woc_native_auto_locale')).toBe('vi_VN');
+  });
+
+  it('resets an auto-managed saved locale to English when the device language is unavailable', () => {
+    setLanguage('de_DE');
+    expect(
+      applyNativeDeviceLanguage({
+        native: true,
+        storage: storageWithLocale('de_DE', 'de_DE'),
+        languages: ['ar-SA'],
+      }),
+    ).toBe('en');
+    expect(getLanguage()).toBe('en');
+  });
+
+  it('applies a supported native device language only in native mode', () => {
+    setLanguage('en');
+    expect(
+      applyNativeDeviceLanguage({
+        native: false,
+        storage: storageWithLocale(null),
+        languages: ['it-IT'],
+      }),
+    ).toBeNull();
+    expect(getLanguage()).toBe('en');
+
+    expect(
+      applyNativeDeviceLanguage({
+        native: true,
+        storage: storageWithLocale(null),
+        languages: ['it-IT'],
+      }),
+    ).toBe('it_IT');
+    expect(getLanguage()).toBe('it_IT');
+  });
+
+  it('deduplicates navigator.languages with navigator.language preserving priority', () => {
+    expect(nativeDeviceLocaleList({ languages: ['pl-PL'], language: 'pl-PL' })).toEqual(['pl-PL']);
+    expect(nativeDeviceLocaleList({ languages: ['ar-SA'], language: 'vi-VN' })).toEqual([
+      'ar-SA',
+      'vi-VN',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- auto-select the game language from the native mobile WebView device locale when supported
- preserve explicit saved or URL language choices
- keep English selected when the device language is unavailable

## Tests
- npx vitest run tests/native_language.test.ts
- npx tsc --noEmit
- npx @biomejs/biome check --write src/main.ts src/ui/native_language.ts tests/native_language.test.ts