### PR TITLE
Add Vale Cup ranked win daily reward task

### DIFF
--- a/server/daily_rewards.ts
+++ b/server/daily_rewards.ts
@@ -863,11 +863,11 @@ export class DailyRewardService {
     return awardedPoints;
   }
 
-  // Vale Cup sibling of recordArenaResult: arena-style win/loss points with the
-  // same online-time multiplier. Only DECIDED matches reach this (the game loop
-  // skips draws) and only RATED ones (the sim marks bot-backfilled and practice
-  // matches unrated; the loop gates on match.rated). The match id keys the
-  // dedupe row, so one match yields at most one grant per account.
+  // Vale Cup daily task: ranked wins only. The game loop gates this to rated
+  // matches (the sim marks bot-backfilled and practice matches unrated); this
+  // method also no-ops losses so the task cannot award participation points.
+  // The match id keys the dedupe row, so one match yields at most one grant per
+  // account.
   async recordValeCupResult(
     accountId: number,
     result: {
@@ -877,6 +877,7 @@ export class DailyRewardService {
       completedAt?: Date;
     },
   ): Promise<number> {
+    if (!result.won) return 0;
     const completedAt = result.completedAt ?? new Date();
     const { day, config } = await dailyRewardClock(completedAt);
     await this.db.ensureDay(day, config.prizePoolUsd, config.wocUsdPrice);
@@ -889,9 +890,7 @@ export class DailyRewardService {
     let awardedPoints = 0;
     for (const task of tasks) {
       const taskConfig = task.config ?? {};
-      const basePoints = result.won
-        ? numberConfig(taskConfig, 'winBasePoints', task.basePoints ?? task.points)
-        : numberConfig(taskConfig, 'lossBasePoints', 10);
+      const basePoints = numberConfig(taskConfig, 'winBasePoints', task.basePoints ?? task.points);
       const { points, multiplier } = onlineMultiplierPoints(basePoints, taskConfig, onlineMinutes);
       if (points <= 0) continue;
       const recorded = await this.db.addPoints(
@@ -899,13 +898,13 @@ export class DailyRewardService {
         accountId,
         'task',
         points,
-        `task:${task.taskId}:vale_cup:${result.matchId}:${result.won ? 'win' : 'loss'}`,
+        `task:${task.taskId}:vale_cup:${result.matchId}:win`,
         {
           taskId: task.taskId,
           taskType: task.type,
           bracket: result.bracket,
           matchId: result.matchId,
-          won: result.won,
+          won: true,
           onlineMinutes,
           multiplier,
           basePoints,

--- a/server/game.ts
+++ b/server/game.ts
@@ -4235,9 +4235,10 @@ export class GameServer {
         if (!s) continue;
         const match = this.sim.vcupMatchOf(ev.pid);
         if (!match || !match.rated) continue;
+        if (!ev.won) continue;
         void dailyRewardService
           .recordValeCupResult(s.accountId, {
-            won: ev.won,
+            won: true,
             bracket: match.bracket,
             matchId: match.id,
           })
@@ -4245,7 +4246,6 @@ export class GameServer {
             if (points > 0) this.sendDailyRewardPointsGained(s, points);
           })
           .catch((err) => console.error('daily reward vale cup task failed:', err));
-        if (!ev.won) continue;
         // One card per decided match: every winner's vcupResult lands on the
         // same tick and the match-id dedupe key collapses them, so the first
         // one enumerates the whole winning side (linked teammates get tagged

--- a/tests/daily_rewards.test.ts
+++ b/tests/daily_rewards.test.ts
@@ -441,6 +441,73 @@ describe('daily rewards', () => {
     expect(db.score).toBe(90);
   });
 
+  it('awards Vale Cup task points for ranked wins only', async () => {
+    const db = new FakeDailyRewardDb();
+    const service = new DailyRewardService(db);
+    resetDailyRewardPriceCacheForTests();
+    stubRewardConfig({
+      tasks: [
+        {
+          id: 'vale_cup_ranked_wins',
+          type: 'vale_cup_result',
+          title: 'Win ranked Vale Cup matches',
+          description: 'Win ranked football matches today.',
+          points: 25,
+          basePoints: 25,
+          sortOrder: 1,
+          active: true,
+          config: {
+            winBasePoints: 25,
+            lossBasePoints: 10,
+            minMultiplier: 1,
+            maxMultiplier: 3,
+            minutesPerMultiplier: 30,
+          },
+        },
+      ],
+    });
+    for (let minute = 0; minute < 60; minute += 1) {
+      await service.recordOnlineMinute(
+        1,
+        new Date(`2026-06-30T12:${String(minute).padStart(2, '0')}:00.000Z`),
+      );
+    }
+
+    await service.recordValeCupResult(1, {
+      won: false,
+      bracket: 1,
+      matchId: 41,
+      completedAt: new Date('2026-06-30T13:00:00.000Z'),
+    });
+    expect(db.events.filter((event) => event.kind === 'task')).toHaveLength(0);
+    expect(db.score).toBe(0);
+
+    await service.recordValeCupResult(1, {
+      won: true,
+      bracket: 1,
+      matchId: 42,
+      completedAt: new Date('2026-06-30T13:01:00.000Z'),
+    });
+
+    const taskEvents = db.events.filter((event) => event.kind === 'task');
+    expect(taskEvents).toHaveLength(1);
+    expect(taskEvents[0]).toMatchObject({
+      points: 75,
+      key: 'task:vale_cup_ranked_wins:vale_cup:42:win',
+      meta: {
+        taskId: 'vale_cup_ranked_wins',
+        taskType: 'vale_cup_result',
+        bracket: 1,
+        matchId: 42,
+        won: true,
+        onlineMinutes: 60,
+        multiplier: 3,
+        basePoints: 25,
+      },
+    });
+    expect(db.score).toBe(75);
+  });
+
   it('awards delve clear task points with level, tier, and online-time scaling', async () => {
     const db = new FakeDailyRewardDb();
     const service = new DailyRewardService(db);

--- a/tests/vale_cup_online.test.ts
+++ b/tests/vale_cup_online.test.ts
@@ -360,8 +360,13 @@ describe('vale cup: online integration (GameServer)', () => {
     expect(rewardSpy).not.toHaveBeenCalled();
     expect(drainActivity().filter((c) => c.kind === 'vale_cup')).toHaveLength(0);
 
-    // flipping the same match rated proves the gate was the rated flag
+    // A rated loss is still not a daily-reward task: the variant is ranked wins only.
     fakeMatch.rated = true;
+    detect({ type: 'vcupResult', won: false, draw: false, pid: session.pid });
+    expect(rewardSpy).not.toHaveBeenCalled();
+    expect(drainActivity().filter((c) => c.kind === 'vale_cup')).toHaveLength(0);
+
+    // flipping the same match to a rated win proves the gate is ranked wins.
     detect({ type: 'vcupResult', won: true, draw: false, pid: session.pid });
     expect(rewardSpy).toHaveBeenCalledTimes(1);
     expect(drainActivity().filter((c) => c.kind === 'vale_cup')).toHaveLength(1);


### PR DESCRIPTION
## Summary
- award Vale Cup daily reward task points for ranked wins only
- skip unrated practice or bot-backfilled matches, losses, and draws
- add focused coverage for reward scoring and game-server integration gates

## Tests
- npx vitest run tests/daily_rewards.test.ts tests/vale_cup_online.test.ts
- npx tsc --noEmit
- git diff --check -- server/daily_rewards.ts server/game.ts tests/daily_rewards.test.ts tests/vale_cup_online.test.ts