### PR TITLE
fix(offline): center the eyebrow label on the offline page

### DIFF
--- a/public/server-unavailable.html
+++ b/public/server-unavailable.html
@@ -75,6 +75,7 @@
       font-size: 12px;
       font-weight: 700;
       letter-spacing: 0.16em;
+      text-indent: 0.16em;
       text-transform: uppercase;
     }
 


### PR DESCRIPTION
## Summary

- The "Realm maintenance" eyebrow label on the offline page (`public/server-unavailable.html`) rendered visibly left of center relative to the logo, heading, description, and status pill.
- Root cause: `.eyebrow` carries `letter-spacing: 0.16em`, which adds tracking after the last character only. That trailing space is included when the browser centers the text, so the visible glyphs sit left of the panel's true center line.
- Fix: add a matching `text-indent: 0.16em` to `.eyebrow`, which shifts the text right by the same amount the trailing letter-spacing pulls it left, without touching the `text-align: center` inherited from `main` or any other element's layout.

## How

```mermaid
flowchart LR
    A[".eyebrow text node"] --> B["letter-spacing 0.16em adds trailing tracking after last glyph"]
    B --> C["text-align center centers box INCLUDING the trailing tracking"]
    C --> D["visible glyphs sit left of true center"]
    D -.fix.-> E["text-indent 0.16em shifts first line right to compensate"]
    E --> F["glyphs now visually centered"]
```

Single line CSS change, scoped to `public/server-unavailable.html`, per the issue's suggested fix in the Notes section.

## Screenshots

Desktop (900px):

![desktop](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-1233/pr-assets/offline-desktop-1233.png?v=2)

Mobile (390px, under the 560px breakpoint):

![mobile](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-1233/pr-assets/offline-mobile-1233.png?v=2)

The eyebrow label now reads centered under the logo at both widths, matching the heading/description/status-pill centering. Verified with the English locale; the fix is a layout-level compensation (not per-locale text), so it holds for every locale in the inline `copy` map since `letter-spacing`/`text-indent` apply identically regardless of string content.

## Test plan

- [x] Rendered `public/server-unavailable.html` in headless Chromium at 900px and 390px widths, confirmed the eyebrow is now centered under the logo/heading (see screenshots).
- [x] Confirmed the heading, description, logo, and status pill layout are unchanged (single property addition, no other rules touched).
- [x] `public/` is plain static HTML with no build step affecting this file; no test suite covers this page's CSS layout.
- [x] `git diff --stat` shows exactly 1 line changed in 1 file.

Fixes #1233

🤖 Generated with [Claude Code](https://claude.com/claude-code)
