### PR TITLE
fix(ui): clear the stale bag tooltip after a drag-drop (#1626)

### DIFF
--- a/src/ui/bags_window.ts
+++ b/src/ui/bags_window.ts
@@ -575,6 +575,13 @@ export class BagsWindow {
         row.addEventListener('dragend', () => {
           this.deps.setDragAction(null);
           this.deps.clearActionDropTargets();
+          // A drag that ends over another bag item is rejected (bag rows are not
+          // drop targets), so no drop handler clears the tooltip and no fresh
+          // mouseenter fires on the item under the now-stationary cursor: the
+          // dragged item's tooltip is left pinned (mousemove only repositions it).
+          // Clear it so the next hover resolves the item actually under the cursor
+          // (issue 1626, the bags twin of the hotbar fix 1485).
+          this.deps.hideTooltip();
         });
       }
       this.deps.attachTooltip(row, () => {

--- a/tests/bags_drop_tooltip.test.ts
+++ b/tests/bags_drop_tooltip.test.ts
@@ -1,0 +1,28 @@
+// Regression for a reported bug (#1626): dragging a bag item on top of another
+// left the tooltip stale. A drag that ends over another bag item is rejected (bag
+// rows are not drop targets), so no drop handler clears the tooltip and no fresh
+// mouseenter fires on the item under the now-stationary cursor; the dragged item's
+// tooltip stayed pinned (mousemove only repositions it). This is the bags twin of
+// the hotbar fix (#1485), which added hideTooltip() to the drop-completion paths.
+// Guard that the bag row's dragend handler now clears the tooltip after teardown.
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const src = readFileSync(new URL('../src/ui/bags_window.ts', import.meta.url), 'utf8');
+// Strip comments so the explanatory comment near the fix cannot satisfy the scan.
+const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+describe('bag drag-drop clears the stale tooltip (#1626)', () => {
+  it('the bag row dragend handler calls hideTooltip after clearing the drag state', () => {
+    // There is exactly one dragend handler on a bag row; isolate it up to the
+    // attachTooltip wiring that immediately follows the draggable block.
+    const start = code.indexOf("addEventListener('dragend'");
+    expect(start).toBeGreaterThan(-1);
+    const handler = code.slice(start, code.indexOf('attachTooltip', start));
+    const clearIdx = handler.indexOf('this.deps.clearActionDropTargets();');
+    const hideIdx = handler.indexOf('this.deps.hideTooltip();');
+    expect(clearIdx).toBeGreaterThan(-1);
+    expect(hideIdx).toBeGreaterThan(clearIdx);
+  });
+});


### PR DESCRIPTION
## Problem

In the bag, dragging one item on top of another leaves the wrong tooltip showing: the dragged item's description stays pinned over the item the cursor landed on, even as the cursor moves within that item's icon bounds (issue #1626). The reporter noted it's "similar to #1485".

## Root cause

This is the bags twin of the hotbar bug we fixed in #1485/#1564. A drag that ends over another bag item is rejected (bag rows are drag *sources*, not drop targets), so no drop handler clears the tooltip. Because the cursor is already stationary inside the target row, no fresh `mouseenter` fires to re-resolve the tooltip; the browser re-shows the drag source's tooltip at `dragend`, and `mousemove` only repositions the box, so the dragged item's tooltip is left pinned.

## Fix

Add `hideTooltip()` to the bag row's `dragend` handler (the single drag-completion path for bag items, which use HTML5 `draggable` only, no touch-drag path). This matches the drop-completion `hideTooltip()` the hotbar fix added and every sibling slot mutation already does. The next hover then resolves the item actually under the cursor.

## Tests

`tests/bags_drop_tooltip.test.ts` source-scans the `dragend` handler and asserts it calls `hideTooltip()` after clearing the drag state, mirroring the #1485 guard (`tests/hotbar_drop_tooltip.test.ts`).

## Note on screenshots

No static visual change: the fix removes a transient stale tooltip, so a before/after screenshot can't capture it (the bug is a pinned tooltip that shouldn't be there). The regression is guarded by the source-scan test.

Fixes #1626