### PR TITLE
feat(worldboss): Thunzharr tuning + loot fixes

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -866,6 +866,7 @@ function blankEntity(id: number): Entity {
     enraged: false,
     healedThisPull: false,
     threat: new Map(),
+    bossDamagers: new Set(),
     forcedTargetId: null,
     forcedTargetTimer: 0,
     ownerId: null,

--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -45,7 +45,7 @@ import {
   virtualLevel,
   xpForLevel,
 } from '../types';
-import { WORLD_BOSS_CORPSE_SECONDS, worldBossContributors } from '../world_boss';
+import { WORLD_BOSS_CORPSE_SECONDS, worldBossLootContributors } from '../world_boss';
 
 // How long a slain mob's corpse persists (seconds) before it is cleared. Sole user
 // is handleDeath, so the constant lives here with the death-domain code.
@@ -340,6 +340,16 @@ export function dealDamage(
     else if (source.ownerId !== null) target.tappedById = source.ownerId;
   }
 
+  // World-boss loot roster: every player (or pet owner) who lands a hit on a world
+  // boss becomes a permanent loot contributor. Unlike the hate table above, this set
+  // is NEVER pruned when they die, release their spirit, or drop off threat, so a
+  // raider who died to the boss still gets their personal drop. Read at death by
+  // worldBossLootContributors. Only world-boss templates ever populate it.
+  if (source && amount > 0 && MOBS[target.templateId]?.worldBoss) {
+    const contributorId = source.kind === 'player' ? source.id : source.ownerId;
+    if (contributorId !== null) target.bossDamagers.add(contributorId);
+  }
+
   if (source && source.kind === 'player' && source.id !== target.id) {
     const meta = ctx.players.get(source.id);
     if (meta) meta.counters.damageDealt += amount;
@@ -578,7 +588,7 @@ export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): 
     // collapse with the boss: leaving them alive would harass looters for the
     // whole window, and a slain add's in-place respawn timer would revive it
     // mid-window (only fires for worldBoss templates, so no parity rng change).
-    const worldBossContribs = template?.worldBoss ? worldBossContributors(ctx, e) : null;
+    const worldBossContribs = template?.worldBoss ? worldBossLootContributors(ctx, e) : null;
     if (template?.worldBoss) {
       e.corpseTimer = WORLD_BOSS_CORPSE_SECONDS;
       e.respawnTimer = Infinity;

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -852,7 +852,10 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     stomp: {
       radius: 11,
       every: 24,
-      duration: 3,
+      // A short pin, not a shutdown: at 11.6 vs a base run of 7 the boss closes
+      // about 7yd in 1.5s, enough to be on top of anyone caught mid-flight
+      // without benching the raid for whole GCDs.
+      duration: 1.5,
       min: 18,
       max: 28,
       name: 'Seismic Stomp',
@@ -897,10 +900,10 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     },
     // Loud: a mountain-sized voice. Every yell (engage/summon/enrage + these battle
     // cries) carries 350yd, far past the 100yd default, and he bellows one of these
-    // lines every 30s in combat so the whole of Thornpeak knows he is awake without
-    // the barks drowning out the raid's chat.
+    // lines once a minute in combat: the whole of Thornpeak still knows he is awake,
+    // but the barks never drown out the raid's chat.
     battleYells: {
-      every: 30,
+      every: 60,
       range: 350,
       lines: [
         'THUNDER ANSWERS! The peak has teeth again!',

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -836,20 +836,22 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     dmgPerLevel: 10.3,
     attackSpeed: 2.4,
     armorPerLevel: 46,
-    moveSpeed: 5.8,
+    // Faster than a player's base run speed (7, entity.ts): Thunzharr cannot be
+    // outrun on foot, so there is no kite even before the Howling Gale snare lands.
+    moveSpeed: 11.6,
     aggroRadius: 18,
     aoePulse: {
       min: 36,
       max: 50,
       radius: 12,
-      every: 8,
+      every: 12,
       name: 'Thunderclap',
       school: 'nature',
       fx: 'nova',
     },
     stomp: {
       radius: 11,
-      every: 16,
+      every: 24,
       duration: 3,
       min: 18,
       max: 28,
@@ -859,11 +861,10 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     // Howling Gale: the anti-kite snare. Gale-force winds pin every player within 40yd
     // to 70% move speed for 6s, re-slammed every 5s (so uptime is permanent while you
     // stand in the storm, and the snare lingers if you flee the radius). Unlike the
-    // other pulses this one also fires while Thunzharr is CHASING, so a hunter whose
-    // run speed (7) outpaces the boss (5.8) can no longer kite it forever: once snared
-    // to 4.9yd/s the boss (5.8) still closes and the melee, Thunderclap, and Stomp come
-    // online. A gentle 30% snare, not a hard 80% one: it denies a permanent kite without
-    // rooting the raid in place.
+    // other pulses this one also fires while Thunzharr is CHASING. With the boss now
+    // outrunning base run speed (11.6 vs 7) the snare is a second layer: it keeps a
+    // sprint-cooldown or speed-buffed runner from opening a gap. A gentle 30% snare,
+    // not a hard 80% one: it denies a permanent kite without rooting the raid in place.
     aoeSlow: {
       radius: 40,
       mult: 0.7,
@@ -874,7 +875,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     },
     summonAdds: { mobId: 'thunzharr_stormling', count: 2, atHpPct: [0.66, 0.33] },
     knockback: { chance: 0.3, distance: 7, name: 'Tectonic Heave' },
-    stoneskin: { amount: 500, every: 18, duration: 9, name: 'Mountainhide', school: 'nature' },
+    stoneskin: { amount: 500, every: 27, duration: 9, name: 'Mountainhide', school: 'nature' },
     // Stormcall: the telegraphed hardcast. A 3.5s cast bar the whole raid can see
     // (and the yell announces), then a heavy nature nova on everyone within 30yd,
     // roughly double a Thunderclap pulse on a much longer cadence.
@@ -882,7 +883,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
       castId: 'thunzharr_stormcall',
       name: 'Stormcall',
       castTime: 3.5,
-      every: 25,
+      every: 40,
       radius: 30,
       min: 70,
       max: 90,
@@ -896,9 +897,10 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     },
     // Loud: a mountain-sized voice. Every yell (engage/summon/enrage + these battle
     // cries) carries 350yd, far past the 100yd default, and he bellows one of these
-    // lines every 9s in combat so the whole of Thornpeak knows he is awake.
+    // lines every 30s in combat so the whole of Thornpeak knows he is awake without
+    // the barks drowning out the raid's chat.
     battleYells: {
-      every: 9,
+      every: 30,
       range: 350,
       lines: [
         'THUNDER ANSWERS! The peak has teeth again!',
@@ -925,7 +927,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
       { itemId: 'soulflame_cord', chance: 0.08, rollGroup: 'thunzharr_t2_belt' },
       { itemId: 'stormcallers_waistguard', chance: 0.08, rollGroup: 'thunzharr_t2_belt' },
     ],
-    scale: 8, // a large, imposing world boss that reads on the skyline without being mountain-sized. Visual scale is DECOUPLED from combat reach: his melee is pinned to a ~17yd (scale-5) body in combatProfileForMob (mob_combat.ts), so the Howling Gale snare, not a giant swing, is what keeps him unkitable.
+    scale: 8, // a large, imposing world boss that reads on the skyline without being mountain-sized. Visual scale is DECOUPLED from combat reach: his melee is pinned to a ~17yd (scale-5) body in combatProfileForMob (mob_combat.ts), so his move speed and the Howling Gale snare, not a giant swing, are what keep him unkitable.
     color: 0x7d8a99,
   },
   // Stormlings: lesser storm elementals Thunzharr tears loose from itself at the

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -819,6 +819,10 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     boss: true,
     elite: true,
     canSwim: false,
+    // The mountain does not path around camp furniture: every chase step walks
+    // the straight line through fences, buildings, and the waterline, so he can
+    // always go directly at his target and never wedges on a collider.
+    phasesThroughObstacles: true,
     ccImmune: true,
     // A raid boss cannot be perma-snared by a wall of Frostbolts / Hamstrings: slows do
     // not stick to him (ccImmune already blocks stun/root/etc; slow is separate).

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -106,6 +106,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     enraged: false,
     healedThisPull: false,
     threat: new Map(),
+    bossDamagers: new Set(),
     forcedTargetId: null,
     forcedTargetTimer: 0,
     ownerId: null,

--- a/src/sim/mob/lifecycle.ts
+++ b/src/sim/mob/lifecycle.ts
@@ -68,6 +68,9 @@ export function respawnMob(ctx: SimContext, mob: Entity): void {
   mob.fleeReturnTimer = 0;
   mob.hasFled = false;
   clearThreat(mob);
+  // A respawn is a brand-new pull: the world-boss damager roster clears with
+  // the hate table so loot rights never carry across lives.
+  mob.bossDamagers.clear();
   despawnSummonedAdds(ctx, mob);
   mob.firedSummons = 0;
   mob.enraged = false;

--- a/src/sim/mob/locomotion.ts
+++ b/src/sim/mob/locomotion.ts
@@ -588,6 +588,10 @@ export function resetEvadingMob(ctx: SimContext, mob: Entity): void {
   mob.fleeReturnTimer = 0;
   mob.hasFled = false;
   clearThreat(mob);
+  // A full evade-home reset ends the pull: loot rights die with it, so the
+  // world-boss damager roster clears alongside the hate table (a raider from
+  // a wiped pull must not receive a personal slot from a later kill).
+  mob.bossDamagers.clear();
   ctx.despawnSummonedAdds(mob);
   mob.firedSummons = 0;
   mob.enraged = false;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4446,9 +4446,11 @@ export class Sim {
   }
 
   // Step `e` one tick toward `dest`. With `ignoreObstacles`, the mover phases
-  // straight through props — used to free a stuck evader, never for normal
-  // locomotion. Returns true on arrival.
+  // straight through props — used to free a stuck evader, and forced on for
+  // templates flagged `phasesThroughObstacles` (mountain-sized world bosses
+  // that must never wedge on a collider mid-chase). Returns true on arrival.
   private moveToward(e: Entity, dest: Vec3, speed: number, ignoreObstacles = false): boolean {
+    if (!ignoreObstacles && MOBS[e.templateId]?.phasesThroughObstacles) ignoreObstacles = true;
     const d = dist2d(e.pos, dest);
     if (d < 0.3) return true;
     const desired = angleTo(e.pos, dest);

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1722,6 +1722,12 @@ export interface Entity {
    *  Wiped on evade/respawn/death; drives target selection with the 110%
    *  melee / 130% ranged pull-over rules. */
   threat: Map<number, number>;
+  /** World-boss loot roster: every player id (pet threat credited to the owner) that
+   *  has damaged this world boss since it was pulled. Unlike `threat`, it is NEVER
+   *  pruned when a contributor dies, releases their spirit, leaves range, or drops off
+   *  the hate table, so a raider who died to the boss keeps their personal loot rights.
+   *  Only ever written for `worldBoss` templates; empty on every other entity. */
+  bossDamagers: Set<number>;
   forcedTargetId: number | null; // taunt/growl: attack this target while the timer runs
   forcedTargetTimer: number; // seconds left on the forced-attack window
   ownerId: number | null; // controlled pets: owning player's entity id (null = wild)

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -679,6 +679,11 @@ export interface MobTemplate {
   xpMult?: number;
   // Rare/miniboss controls.
   canSwim?: boolean;
+  // Every movement step (chase, flee, wander, leash return) uses Sim.moveToward's
+  // phasing mode: a straight line that ignores prop colliders, the waterline, and
+  // the steep-wall gate. For mountain-sized movers (world bosses) that must never
+  // wedge on camp furniture while closing on a target.
+  phasesThroughObstacles?: boolean;
   ccImmune?: boolean;
   // Immune to movement-speed slow auras (kind 'slow'). Distinct from ccImmune, which
   // blocks the hard control auras (stun/root/incapacitate/polymorph) but intentionally

--- a/src/sim/world_boss.ts
+++ b/src/sim/world_boss.ts
@@ -29,9 +29,12 @@ import type { Entity, LootSlot } from './types';
 export const WORLD_BOSS_INTERVAL_SECONDS = 1 * 3600;
 
 // How long a slain world boss's lootable corpse lingers before it is removed. Much
-// longer than a normal corpse so every contributor has time to walk over and loot
-// their personal drops; the scheduler drops the entity once this elapses.
-export const WORLD_BOSS_CORPSE_SECONDS = 300;
+// longer than a normal corpse (and than the raid needs to clear trash) so every
+// contributor has time to walk over and loot their personal drops, INCLUDING those
+// who died to the boss and have to run back from the graveyard and resurrect first
+// (a ghost cannot loot). Well inside the spawn cadence, so corpse windows never
+// overlap. The scheduler drops the entity once this elapses.
+export const WORLD_BOSS_CORPSE_SECONDS = 900;
 
 export interface WorldBossDef {
   // MobTemplate id (must have `worldBoss: true`).
@@ -123,6 +126,34 @@ export function worldBossContributors(ctx: SimContext, mob: Entity): PlayerMeta[
   return out.sort((a, b) => a.entityId - b.entityId);
 }
 
+// The LOOT roster for a slain world boss: everyone eligible for a personal drop. This
+// is the permanent damager set (`mob.bossDamagers`, every player who hit the boss since
+// it was pulled, never pruned) UNIONED with whoever still remains on the live hate table
+// at death (a healer who threat-built but never dealt damage; pet threat credited to the
+// owner). Deduped, resolved to live PlayerMeta, sorted by entityId so downstream rng
+// draws stay in a fixed order. Unlike worldBossContributors (the hate-table-only view the
+// HP scaler uses), this SURVIVES a contributor dying or dropping off threat: the whole
+// point is that a raider who died to the boss still gets their loot. Read BEFORE
+// handleDeath clears the boss's threat (the damager set survives that clear regardless).
+export function worldBossLootContributors(ctx: SimContext, mob: Entity): PlayerMeta[] {
+  const seen = new Set<number>();
+  const out: PlayerMeta[] = [];
+  const add = (pid: number) => {
+    if (seen.has(pid)) return;
+    seen.add(pid);
+    const meta = ctx.players.get(pid);
+    if (meta) out.push(meta);
+  };
+  // Permanent damagers (already owner-resolved player ids), then anyone still on the
+  // hate table (pets credit their owner, exactly as worldBossContributors resolves).
+  for (const pid of mob.bossDamagers) add(pid);
+  for (const attackerId of mob.threat.keys()) {
+    const attacker = ctx.entities.get(attackerId);
+    add(attacker && attacker.ownerId !== null ? attacker.ownerId : attackerId);
+  }
+  return out.sort((a, b) => a.entityId - b.entityId);
+}
+
 // Retail-style participant HP scaling, driven each tick by the scheduler while the
 // boss is alive. The target pool is `base + perPlayer * (participants - 1)` clamped
 // to `max`, where participants is the deduped player count on the hate table. It only
@@ -166,13 +197,13 @@ export function rollWorldBossLoot(ctx: SimContext, mob: Entity, contributors: Pl
   if (!template) return;
   const items: LootSlot[] = mob.loot?.items ?? [];
   const copper = mob.loot?.copper ?? 0;
-  // contributors arrive sorted by entityId (worldBossContributors); iterate in that
-  // fixed order so the rng draw order is deterministic for the parity gate.
-  // Eligibility is checked here, but the daily lockout is consumed only when the
-  // player actually LOOTS a personal slot (lootCorpse in interaction.ts): a
-  // contributor who dies or never reaches the corpse inside the loot window keeps
-  // their daily and can try again at the next spawn. Corpse windows (300s) never
-  // overlap the 3h cadence, so at most one corpse is ever lootable at a time.
+  // contributors arrive sorted by entityId (worldBossLootContributors); iterate in
+  // that fixed order so the rng draw order is deterministic for the parity gate.
+  // Eligibility is checked here, but the lockout is consumed only when the player
+  // actually LOOTS a personal slot (lootCorpse in interaction.ts): a contributor who
+  // dies or never reaches the corpse inside the loot window keeps their lockout and
+  // can try again at the next spawn. The corpse window (WORLD_BOSS_CORPSE_SECONDS)
+  // never overlaps the spawn cadence, so at most one corpse is ever lootable at a time.
   for (const meta of contributors) {
     if (!isWorldBossLootEligible(meta, mob.templateId, ctx.lockoutNowMs())) continue;
     const rolledGroups = new Set<string>();

--- a/tests/world_boss.test.ts
+++ b/tests/world_boss.test.ts
@@ -5,6 +5,7 @@ import type { Entity, SimEvent } from '../src/sim/types';
 import {
   isWorldBossLootEligible,
   markWorldBossLooted,
+  WORLD_BOSS_CORPSE_SECONDS,
   WORLD_BOSS_INTERVAL_SECONDS,
   WORLD_BOSSES,
   worldBossLockoutId,
@@ -424,6 +425,80 @@ describe('world boss personal loot', () => {
       return JSON.stringify(boss.loot?.items ?? []);
     };
     expect(run()).toBe(run());
+  });
+});
+
+describe('world boss loot roster survives contributor death and grouping', () => {
+  it('keeps a contributor who DIED to the boss on the loot roster (not just the hate table)', () => {
+    const sim = makeSim();
+    sim.utcDay = DAY;
+    const p1 = sim.addPlayer('warrior', 'Ada');
+    const p2 = sim.addPlayer('mage', 'Bru');
+    const { boss } = spawnBossNow(sim);
+    const e1 = (sim as any).entities.get(p1) as Entity;
+    const e2 = (sim as any).entities.get(p2) as Entity;
+    // Both land a hit: both go on the hate table AND the permanent damager roster.
+    (sim as any).dealDamage(e1, boss, 10, false, 'physical', 'Chip', 'hit', true);
+    (sim as any).dealDamage(e2, boss, 10, false, 'physical', 'Chip', 'hit', true);
+    expect(boss.threat.has(p2)).toBe(true);
+
+    // p2 dies to the boss: handleDeath drops them from EVERY hate table (the classic
+    // "the dead fall off threat" prune) so the boss re-targets. This is exactly what
+    // used to strip a fallen raider's loot rights.
+    (sim as any).dealDamage(boss, e2, 999_999, false, 'physical', 'Boss', 'hit', true);
+    expect(e2.dead).toBe(true);
+    expect(boss.threat.has(p2)).toBe(false); // pruned off the live hate table...
+    expect(boss.bossDamagers.has(p2)).toBe(true); // ...but kept on the permanent roster
+
+    // p1 lands the killing blow.
+    (sim as any).dealDamage(e1, boss, 999_999, false, 'physical', 'Finisher', 'hit', true);
+    expect(boss.dead).toBe(true);
+
+    // Both contributors get their own personal drop, including the one who died.
+    const owners = (boss.loot?.items ?? []).flatMap((s) => s.personalFor ?? []);
+    expect(owners).toContain(p1);
+    expect(owners).toContain(p2);
+  });
+
+  it('lets a slain world boss corpse linger far longer than a normal corpse', () => {
+    const sim = makeSim();
+    const p1 = sim.addPlayer('warrior', 'Ada');
+    const { boss } = spawnBossNow(sim);
+    const e1 = (sim as any).entities.get(p1) as Entity;
+    (sim as any).dealDamage(e1, boss, 999_999, false, 'physical', 'Finisher', 'hit', true);
+    expect(boss.dead).toBe(true);
+    expect(boss.corpseTimer).toBe(WORLD_BOSS_CORPSE_SECONDS);
+    // Generous enough that a corpse-runner can resurrect and walk back before it drops.
+    expect(WORLD_BOSS_CORPSE_SECONDS).toBeGreaterThanOrEqual(900);
+  });
+
+  it('never routes a world-boss epic through a party need/greed roll (personal loot only)', () => {
+    const sim = makeSim();
+    sim.utcDay = DAY;
+    const p1 = sim.addPlayer('warrior', 'Ada');
+    const p2 = sim.addPlayer('mage', 'Bru');
+    // Party them up: the default party loot strategy rolls premium (epic) items as
+    // need/greed. If a boss epic ever reached the shared path, this is where it would.
+    sim.partyInvite(p1, p2);
+    sim.partyAccept(p2);
+    const { boss } = spawnBossNow(sim);
+    const e1 = (sim as any).entities.get(p1) as Entity;
+    const e2 = (sim as any).entities.get(p2) as Entity;
+    (sim as any).dealDamage(e1, boss, 10, false, 'physical', 'Chip', 'hit', true);
+    (sim as any).dealDamage(e2, boss, 10, false, 'physical', 'Chip', 'hit', true);
+    (sim as any).dealDamage(e1, boss, 999_999, false, 'physical', 'Finisher', 'hit', true);
+    expect(boss.dead).toBe(true);
+
+    // Every slot is a single-owner personal drop even for a grouped raid: an epic can
+    // never enter a shared (need/greed) roll the party would have to fight over.
+    for (const slot of boss.loot?.items ?? []) {
+      expect(slot.personalFor && slot.personalFor.length === 1).toBe(true);
+      expect(slot.openToAll).toBeFalsy();
+    }
+    // Looting the personal drops opens NO group roll: they go straight to the bags.
+    e1.pos = { ...boss.pos };
+    sim.lootCorpse(boss.id, p1);
+    expect((sim as any).pendingLootRolls.size).toBe(0);
   });
 });
 

--- a/tests/world_boss.test.ts
+++ b/tests/world_boss.test.ts
@@ -206,8 +206,8 @@ describe('world boss raid-tier combat (melee, Stormcall hardcast, yells)', () =>
     let sawCastBar = false;
     let castYell = false;
     let unleashed = false;
-    // 25s cadence + 3.5s cast, with slack for chase/knockback interruptions.
-    for (let t = 0; t < 20 * 45 && !unleashed; t++) {
+    // 40s cadence + 3.5s cast, with slack for chase/knockback interruptions.
+    for (let t = 0; t < 20 * 60 && !unleashed; t++) {
       // Step back into melee after every Tectonic Heave shove, and keep chipping
       // so the threat table never empties.
       p.pos.x = boss.pos.x + 2;
@@ -452,6 +452,14 @@ describe('world boss anti-kite snare (Howling Gale)', () => {
     sim.tick();
   }
 
+  it('outruns a player on foot: boss move speed exceeds base run speed', () => {
+    const sim = makeSim();
+    const pid = sim.addPlayer('hunter', 'Runner');
+    const { boss } = spawnBossNow(sim);
+    const p = (sim as any).entities.get(pid) as Entity;
+    expect(boss.moveSpeed).toBeGreaterThan(p.moveSpeed);
+  });
+
   it('snares a ranged kiter it is chasing, cutting move speed to 70% (not kiteable)', () => {
     const sim = makeSim();
     const kiter = sim.addPlayer('hunter', 'Kiter');
@@ -464,8 +472,8 @@ describe('world boss anti-kite snare (Howling Gale)', () => {
     const slow = p.auras.find((a) => a.kind === 'slow' && a.name === 'Howling Gale');
     expect(slow).toBeTruthy();
     expect(slow?.value).toBe(0.7);
-    // Run speed (7) beats the boss's 5.8, but a 30% snare (4.9yd/s) still lets the boss,
-    // at 5.8, slowly close the gap: the gentler snare denies a perma-kite without rooting.
+    // The boss (11.6) already outruns base run speed (7); the 30% snare (4.9yd/s) is
+    // the second layer that keeps a speed-buffed runner from opening a gap.
     expect((sim as any).moveSpeedMult(p)).toBeCloseTo(0.7, 5);
   });
 
@@ -592,7 +600,8 @@ describe('world boss is imposing and loud', () => {
     // A large, imposing world boss, but no longer mountain-sized.
     expect(boss.scale).toBe(8);
     // His melee reach is PINNED to a ~17yd (scale-5) body, not the wider reach a scale-8
-    // body would give: the Howling Gale snare, not a giant swing, is what makes him unkitable.
+    // body would give: his move speed and the Howling Gale snare, not a giant swing,
+    // are what make him unkitable.
     const reach = combatProfileForMob(boss.templateId, boss.scale).meleeRange;
     expect(reach).toBe(scaledDefaultMobMeleeRange(5));
     expect(reach).toBeLessThan(scaledDefaultMobMeleeRange(boss.scale));

--- a/tests/world_boss.test.ts
+++ b/tests/world_boss.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { MOBS } from '../src/sim/data';
+import { respawnMob } from '../src/sim/mob/lifecycle';
+import { resetEvadingMob } from '../src/sim/mob/locomotion';
 import { combatProfileForMob, scaledDefaultMobMeleeRange } from '../src/sim/mob_combat';
 import { Sim } from '../src/sim/sim';
 import type { Entity, SimEvent } from '../src/sim/types';
@@ -459,6 +461,50 @@ describe('world boss loot roster survives contributor death and grouping', () =>
     const owners = (boss.loot?.items ?? []).flatMap((s) => s.personalFor ?? []);
     expect(owners).toContain(p1);
     expect(owners).toContain(p2);
+  });
+
+  it('clears the damager roster on a full evade-home reset: a wiped pull ends loot rights', () => {
+    const sim = makeSim();
+    sim.utcDay = DAY;
+    const p1 = sim.addPlayer('warrior', 'WipedRaiderA');
+    const p2 = sim.addPlayer('mage', 'FreshRaiderB');
+    const { boss } = spawnBossNow(sim);
+    const e1 = (sim as any).entities.get(p1) as Entity;
+    const e2 = (sim as any).entities.get(p2) as Entity;
+
+    // Pull A: p1 lands a hit and goes on the roster, then the raid wipes and the
+    // boss evades home to full (the same entity survives: only the scheduler
+    // makes a new one, and only after a real kill).
+    (sim as any).dealDamage(e1, boss, 10, false, 'physical', 'Chip', 'hit', true);
+    expect(boss.bossDamagers.has(p1)).toBe(true);
+    resetEvadingMob((sim as any).ctx, boss);
+    expect(boss.hp).toBe(boss.maxHp);
+    expect(boss.bossDamagers.size).toBe(0);
+
+    // Pull B: only p2 fights. The pull-A raider must NOT land on the kill roster.
+    (sim as any).dealDamage(e2, boss, 10, false, 'physical', 'Chip', 'hit', true);
+    (sim as any).dealDamage(e2, boss, 999_999, false, 'physical', 'Finisher', 'hit', true);
+    expect(boss.dead).toBe(true);
+    const owners = (boss.loot?.items ?? []).flatMap((s) => s.personalFor ?? []);
+    expect(owners).toContain(p2);
+    expect(owners).not.toContain(p1);
+  });
+
+  it('clears the damager roster on respawn: loot rights never carry across lives', () => {
+    const sim = makeSim();
+    sim.utcDay = DAY;
+    const p1 = sim.addPlayer('warrior', 'Ada');
+    const { boss } = spawnBossNow(sim);
+    const e1 = (sim as any).entities.get(p1) as Entity;
+    (sim as any).dealDamage(e1, boss, 999_999, false, 'physical', 'Finisher', 'hit', true);
+    expect(boss.dead).toBe(true);
+    expect(boss.bossDamagers.has(p1)).toBe(true); // the kill snapshot already rolled loot
+    respawnMob((sim as any).ctx, boss);
+    expect(boss.bossDamagers.size).toBe(0);
+  });
+
+  it('the lootable corpse window always fits inside the spawn cadence (never overlaps)', () => {
+    expect(WORLD_BOSS_CORPSE_SECONDS).toBeLessThan(WORLD_BOSS_INTERVAL_SECONDS);
   });
 
   it('lets a slain world boss corpse linger far longer than a normal corpse', () => {

--- a/tests/world_boss.test.ts
+++ b/tests/world_boss.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { MOBS } from '../src/sim/data';
 import { combatProfileForMob, scaledDefaultMobMeleeRange } from '../src/sim/mob_combat';
 import { Sim } from '../src/sim/sim';
 import type { Entity, SimEvent } from '../src/sim/types';
@@ -730,6 +731,42 @@ describe('world boss is imposing and loud', () => {
     expect(yellTextTo(far).some((t) => /THUNDER ANSWERS/.test(t))).toBe(true);
     // ...but nothing reaches a player 400yd away, past the loud range.
     expect(yellTextTo(tooFar)).toHaveLength(0);
+  });
+});
+
+describe('world boss pathing (phases through obstacles)', () => {
+  it('walks a dead-straight chase line through a building collider', () => {
+    const sim = makeSim();
+    const { boss } = spawnBossNow(sim);
+    // The zone1 house at (10, 12) is a 7x6 OBB collider. Park the boss south of
+    // it and march him due north straight through: with phasesThroughObstacles
+    // his x never deviates and he arrives on the straight-line tick budget. A
+    // sliding mover would have to fan around the OBB (x deviates) or stall.
+    boss.pos = { x: 10, z: 2, y: 0 };
+    const dest = { x: 10, z: 22, y: 0 };
+    let arrived = false;
+    const straightTicks = Math.ceil(20 / (boss.moveSpeed * (1 / 20))) + 2;
+    for (let t = 0; t < straightTicks && !arrived; t++) {
+      arrived = (sim as any).moveToward(boss, dest, boss.moveSpeed);
+      expect(Math.abs(boss.pos.x - 10)).toBeLessThan(1e-6);
+    }
+    expect(arrived).toBe(true);
+  });
+
+  it('an ordinary mob still collides: the same straight line is deflected', () => {
+    const sim = makeSim();
+    const { boss } = spawnBossNow(sim);
+    // Reuse the boss entity but masquerade as an unflagged template: the gate
+    // reads MOBS[templateId], so a plain wolf template must NOT phase.
+    boss.templateId = 'forest_wolf';
+    boss.pos = { x: 10, z: 8, y: 0 };
+    (sim as any).moveToward(boss, { x: 10, z: 22, y: 0 }, 7);
+    const deflected = Math.abs(boss.pos.x - 10) > 1e-6 || Math.abs(boss.pos.z - 8) < 0.3;
+    expect(deflected).toBe(true);
+  });
+
+  it('the template opts in via phasesThroughObstacles', () => {
+    expect(MOBS[BOSS_ID]?.phasesThroughObstacles).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

A world-boss tuning and fixes pass for Thunzharr, the Waking Peak, aimed at the v0.24.0 PTR window. Two halves:

### Tuning (src/sim/content/zone3.ts, data only)

- **No more kiting on foot.** Move speed doubles from 5.8 to 11.6, past a player's base run speed of 7. The Howling Gale snare stays as the second layer against sprint cooldowns and speed buffs; the comments describing the old 5.8-vs-7 chase math are updated to match.
- **Less spell spam.** Mechanic cadences stretch by roughly 1.5x: Thunderclap 8s to 12s, Seismic Stomp 16s to 24s, Mountainhide 18s to 27s, Stormcall 25s to 40s. Damage, radii, and durations are otherwise unchanged.
- **Shorter stun.** The Seismic Stomp stun drops from 3s to 1.5s: at 11.6 move speed the boss only needs a moment to close on anyone caught mid-flight, and the raid is not benched for whole GCDs.
- **No more wedging on colliders.** Live reports showed him getting caught on props while pathfinding, unable to go directly at an enemy. A new `phasesThroughObstacles` template flag forces `Sim.moveToward`'s existing phasing mode (straight line through props, the waterline, and the steep-wall gate) for every step he takes; ordinary mobs still collide. Tests pin the straight line through a building collider, the ordinary-mob control, and the template opt-in.
- **Quieter.** His zone-wide battle cries slow from every 9s to once a minute (the 350yd loud range and the one-time engage/summon/enrage barks and Stormcall telegraph yell are kept).

### Loot fixes (folds in #1513)

Fixes the cluster of Thunzharr loot problems reported from the live realm. The contributor roster used to be derived from the boss's live hate table, and `handleDeath` prunes the dead off threat, so a raider who died to the boss lost their personal drop; the corpse also despawned after 300s, sometimes before dead players could run back.

- A persistent `bossDamagers` set on `Entity` records every player (pet damage credits the owner) who lands a hit on a world boss; it is never pruned on death, spirit release, or threat drop.
- World-boss loot rolls from `worldBossLootContributors()` (the damager set unioned with the remaining hate table, e.g. a healer), sorted by `entityId` so the rng draw order stays deterministic.
- The lootable-corpse window extends 300s to 900s (`WORLD_BOSS_CORPSE_SECONDS`), still well inside the spawn cadence.
- A test pins that world-boss loot is personal (`personalFor` slots), never routed through a party need/greed roll.

The damager set is sim-internal and never wired to clients; loot resolves server-side. It is initialized in both the offline `Sim` (`baseEntity`) and the online `ClientWorld` (`blankEntity`).

Note on the base: release/v0.24.0 is not cut yet, so this targets the release/v0.23.0 tip; happy to retarget once the v0.24.0 branch exists.

## Related issues

Supersedes #1513 (folded in unchanged as its own commit). Addresses the reported Thunzharr issues: corpse despawning before everyone loots, loot rights lost on death, and the request that anyone who hit the boss can loot.

## Type of change

- [x] Feature: new functionality (balance retune)
- [x] Bug fix (loot roster and corpse window)

## How was this tested?

- Commands:
  - npx vitest run tests/world_boss.test.ts tests/world_boss_cc.test.ts tests/dead_party_loot.test.ts tests/loot_roll.test.ts (54 passed)
  - npx vitest run tests/parity tests/architecture.test.ts (188 passed, 1 skipped: rng draw-order digest unchanged)
  - The pre-push floor (tsc, guard tests, changed-files biome, copy scan) ran clean on push.
- New/updated tests:
  - A new pin that the boss's move speed exceeds a player's base run speed.
  - The Stormcall test's tick budget widened to cover the longer 40s cadence.
  - From #1513: a contributor who died to the boss still lands on the loot roster and receives their personal slot; the corpse lingers for `WORLD_BOSS_CORPSE_SECONDS`; a party's world-boss slots never enter a group roll.

Generated with [Claude Code](https://claude.com/claude-code)
