### PR TITLE
fix(itemization): fire legendary weapon procs on a hunter's Auto Shot

### DIFF
--- a/src/sim/combat/auto_attack.ts
+++ b/src/sim/combat/auto_attack.ts
@@ -223,6 +223,11 @@ export function rangedSwing(
     // 4-piece set procs keyed to weapon crits (ranged arm). Gated on setProcs
     // inside applySetProcs, so proc-less players draw no rng.
     if (crit && atk.kind === 'player') ctx.applySetProcs(atk, tgt, 'weaponCrit');
+    // Legendary on-hit weapon procs (e.g. Thronebane's Chain Arc) fire on a hunter's
+    // Auto Shot too, since it strikes with the equipped mainhand. Wand bolts do not
+    // swing the mainhand, so casters never roll it. No-op (no rng draw) unless the
+    // shooter wields a proc weapon with a weaponHit proc.
+    if (!ranged.wand) runWeaponProcs(ctx, atk, tgt, 'weaponHit');
   });
 }
 
@@ -334,7 +339,7 @@ export function meleeSwing(
     }
   }
   // Legendary on-hit weapon procs (e.g. Thronebane's Chain Arc). No-op (no rng
-  // draw) unless the attacker wields a proc weapon with a meleeHit proc.
-  runWeaponProcs(ctx, attacker, target, 'meleeHit');
+  // draw) unless the attacker wields a proc weapon with a weaponHit proc.
+  runWeaponProcs(ctx, attacker, target, 'weaponHit');
   return true;
 }

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -2814,7 +2814,9 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
       {
         id: 'thronebane_arc',
         name: 'Chain Arc',
-        trigger: 'meleeHit',
+        // Fires on any weapon strike: a melee swing for its warrior/paladin owners,
+        // or a hunter's Auto Shot (which shoots this same weapon).
+        trigger: 'weaponHit',
         chance: 0.1,
         effects: [
           { kind: 'chainArc', school: 'nature', damage: 42, jumps: 3, falloff: 0.6, radius: 8 },

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -479,12 +479,15 @@ export interface WeaponItemDef extends BaseItemDef {
 }
 
 // A legendary weapon proc: a "chance on action" effect that rolls when the wielder
-// performs the trigger action (lands a melee swing, lands a damaging spell, or lands
+// performs the trigger action (lands a weapon strike, lands a damaging spell, or lands
 // a heal) and, on success, fires its effects. Handled by
 // src/sim/combat/equip_procs.ts. The proc's rng roll is gated on the wielder actually
 // carrying a proc weapon, so ordinary gear draws no extra rng and the deterministic
 // draw order (and every parity golden that equips no legendary) is unchanged.
-export type WeaponProcTrigger = 'meleeHit' | 'spellDamage' | 'heal';
+// `weaponHit` covers ANY weapon strike with the equipped mainhand: a melee swing OR a
+// hunter's Auto Shot (which fires with that same weapon). Caster wand bolts, which do
+// not swing the mainhand, never roll it.
+export type WeaponProcTrigger = 'weaponHit' | 'spellDamage' | 'heal';
 
 export type WeaponProcEffect =
   // Thunderfury-style arc: a bolt that strikes the primary target and then jumps to

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -4058,7 +4058,9 @@ export class Hud {
     for (const line of lines) {
       const effect = line.effects.map((e) => this.procEffectText(e)).join(' ');
       const triggerKey =
-        line.trigger === 'meleeHit'
+        // onMeleeHit is the legacy key id; its English reads the generic "Chance on
+        // hit", correct for a weaponHit proc that fires on melee AND hunter ranged.
+        line.trigger === 'weaponHit'
           ? 'hudChrome.itemProc.onMeleeHit'
           : line.trigger === 'spellDamage'
             ? 'hudChrome.itemProc.onSpellDamage'

--- a/tests/combat_auto_attack.test.ts
+++ b/tests/combat_auto_attack.test.ts
@@ -412,3 +412,39 @@ describe('rangedSwing damage: the 0.6 weapon coefficient is Auto Shot only', () 
     for (const h of hits) expect(h.amount).toBe(h.crit ? 240 : 120);
   });
 });
+
+// A hunter's Auto Shot strikes with the equipped mainhand, so an on-hit weapon proc
+// (Thronebane's Chain Arc, trigger 'weaponHit') must fire from a ranged shot too, not
+// just a melee swing. A caster's wand bolt does NOT swing the mainhand, so it never
+// rolls the mainhand's proc.
+describe('rangedSwing fires weaponHit procs (Thronebane on a hunter Auto Shot)', () => {
+  const chainArcs = (events: Ev[]) =>
+    events.filter((e) => e.type === 'damage' && e.ability === 'Chain Arc' && e.school === 'nature');
+
+  it('a hunter wielding Thronebane procs Chain Arc off Auto Shot', () => {
+    const { sim, p } = makeSim('hunter', 20);
+    const mob = spawnDummy(sim, p, 1, 20); // far below level -> floored miss chance
+    mob.stats = { ...mob.stats, armor: 0 };
+    p.mainhandItemId = 'kingsbane_last_oath'; // Thronebane: 10% weaponHit Chain Arc
+    p.critChance = 0;
+    const events = capture(sim);
+    for (let i = 0; i < 200; i++) rangedSwing(sim.ctx, p, mob, { min: 50, max: 50, speed: 2.8 });
+    for (let i = 0; i < 800 && sim.ctx.pendingProjectiles.length > 0; i++)
+      advancePendingProjectiles(sim.ctx);
+    // over ~200 landed shots at a 10% proc, the seeded run lands multiple arcs
+    expect(chainArcs(events).length).toBeGreaterThan(0);
+    expect(chainArcs(events)[0].amount).toBe(42); // Chain Arc primary damage
+  });
+
+  it('a wand caster wielding Thronebane never rolls the mainhand proc off a bolt', () => {
+    const { sim, p } = makeSim('mage', 20);
+    const mob = spawnDummy(sim, p, 1, 15);
+    p.mainhandItemId = 'kingsbane_last_oath';
+    const events = capture(sim);
+    for (let i = 0; i < 200; i++)
+      rangedSwing(sim.ctx, p, mob, { min: 50, max: 50, speed: 1.8, wand: true, school: 'arcane' });
+    for (let i = 0; i < 800 && sim.ctx.pendingProjectiles.length > 0; i++)
+      advancePendingProjectiles(sim.ctx);
+    expect(chainArcs(events).length).toBe(0);
+  });
+});

--- a/tests/equip_procs.test.ts
+++ b/tests/equip_procs.test.ts
@@ -38,13 +38,13 @@ describe('runWeaponProcs: determinism / parity safety', () => {
   it('draws NO rng for a wielder holding a weapon with no procs', () => {
     const { ctx, rolls } = fakeCtx(true);
     // rusty_hatchet is a plain weapon with no weaponProcs
-    fire(ctx, ent(1, 'rusty_hatchet'), ent(2, null), 'meleeHit');
+    fire(ctx, ent(1, 'rusty_hatchet'), ent(2, null), 'weaponHit');
     expect(rolls()).toBe(0);
   });
 
   it('draws NO rng for a wielder with an empty mainhand', () => {
     const { ctx, rolls } = fakeCtx(true);
-    fire(ctx, ent(1, null), ent(2, null), 'meleeHit');
+    fire(ctx, ent(1, null), ent(2, null), 'weaponHit');
     expect(rolls()).toBe(0);
   });
 
@@ -52,12 +52,12 @@ describe('runWeaponProcs: determinism / parity safety', () => {
     const { ctx, rolls } = fakeCtx(true);
     const target = ent(2, null);
     target.dead = true;
-    fire(ctx, ent(1, 'kingsbane_last_oath'), target, 'meleeHit');
+    fire(ctx, ent(1, 'kingsbane_last_oath'), target, 'weaponHit');
     expect(rolls()).toBe(0);
   });
 
   it('does NOT roll a proc whose trigger does not match the action', () => {
-    // Thronebane only has a meleeHit proc; a heal action must not roll it.
+    // Thronebane only has a weaponHit proc; a heal action must not roll it.
     const { ctx, rolls } = fakeCtx(true);
     fire(ctx, ent(1, 'kingsbane_last_oath'), ent(2, null), 'heal');
     expect(rolls()).toBe(0);
@@ -67,18 +67,18 @@ describe('runWeaponProcs: determinism / parity safety', () => {
     // recalcPlayerStats keeps an over-level mainhand worn but inert; its procs
     // must be inert too, and the gate short-circuits before any rng draw.
     const { ctx, rolls, calls } = fakeCtx(true);
-    fire(ctx, ent(1, 'kingsbane_last_oath', 10), ent(2, null), 'meleeHit');
+    fire(ctx, ent(1, 'kingsbane_last_oath', 10), ent(2, null), 'weaponHit');
     expect(rolls()).toBe(0);
     expect(calls.length).toBe(0);
   });
 });
 
-describe('Thronebane Chain Arc (meleeHit)', () => {
+describe('Thronebane Chain Arc (weaponHit)', () => {
   it('on proc: arcs the primary target, chains to nearby foes, and slows the primary', () => {
     const nearby = [ent(2, null), ent(3, null), ent(4, null)];
     const target = nearby[0];
     const { ctx, calls } = fakeCtx(true, nearby);
-    fire(ctx, ent(1, 'kingsbane_last_oath'), target, 'meleeHit');
+    fire(ctx, ent(1, 'kingsbane_last_oath'), target, 'weaponHit');
 
     const dmg = calls.filter((c) => c.fn === 'dealDamage');
     // primary + up to `jumps` (3) other foes; here 2 others (id 3 and 4)
@@ -100,14 +100,14 @@ describe('Thronebane Chain Arc (meleeHit)', () => {
 
   it('on no proc: nothing fires', () => {
     const { ctx, calls } = fakeCtx(false, [ent(2, null)]);
-    fire(ctx, ent(1, 'kingsbane_last_oath'), ent(2, null), 'meleeHit');
+    fire(ctx, ent(1, 'kingsbane_last_oath'), ent(2, null), 'weaponHit');
     expect(calls.length).toBe(0);
   });
 
   it('caps the number of chain jumps', () => {
     const nearby = [ent(2, null), ent(3, null), ent(4, null), ent(5, null), ent(6, null)];
     const { ctx, calls } = fakeCtx(true, nearby);
-    fire(ctx, ent(1, 'kingsbane_last_oath'), nearby[0], 'meleeHit');
+    fire(ctx, ent(1, 'kingsbane_last_oath'), nearby[0], 'weaponHit');
     // primary + 3 jumps max = 4 dealDamage, not 5
     expect(calls.filter((c) => c.fn === 'dealDamage').length).toBe(4);
   });

--- a/tests/weapon_proc_view.test.ts
+++ b/tests/weapon_proc_view.test.ts
@@ -6,7 +6,7 @@ import { weaponProcLines } from '../src/ui/weapon_proc_view';
 const THRONEBANE: WeaponProc = {
   id: 'thronebane_arc',
   name: 'Chain Arc',
-  trigger: 'meleeHit',
+  trigger: 'weaponHit',
   chance: 0.1,
   effects: [
     { kind: 'chainArc', school: 'nature', damage: 42, jumps: 3, falloff: 0.6, radius: 8 },
@@ -40,7 +40,7 @@ describe('weaponProcLines', () => {
 
   it('describes the chain-arc + attack-slow on-hit proc', () => {
     const [line] = weaponProcLines([THRONEBANE]);
-    expect(line.trigger).toBe('meleeHit');
+    expect(line.trigger).toBe('weaponHit');
     expect(line.chancePct).toBe(10);
     expect(line.effects[0]).toEqual({
       kind: 'chainArc',


### PR DESCRIPTION
## Summary

On `release/v0.23.0` a hunter's Auto Shot already fires with the equipped mainhand (the ranged-weapon-scaling change), but on-hit weapon procs still only rolled on a melee swing. So Thronebane's Chain Arc never fired for a hunter attacking at range, which is where hunters spend their whole rotation.

This renames the `WeaponProcTrigger` `meleeHit` -> `weaponHit` (it always meant "on a weapon strike") and rolls it from `rangedSwing` too, gated to non-wand shooters so caster wand bolts (which do not swing the mainhand) never roll the mainhand's proc.

Determinism is preserved: the proc still draws no rng unless the shooter carries a matching proc weapon, so the shared draw order and every parity golden that equips no legendary are unchanged (parity gate green).

The tooltip label key (`onMeleeHit`) already reads the generic "Chance on hit", so no i18n copy change is needed and no new key is added; it is reused as-is.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/equip_procs.test.ts tests/weapon_proc_view.test.ts tests/combat_auto_attack.test.ts tests/ranged_shot.test.ts tests/architecture.test.ts tests/parity/` (233 passing, 1 skipped). `npx tsc --noEmit` clean on the changed files (the only local error is a pre-existing missing `prom-client` dep in `server/http/metrics.ts`, untouched here).
- Added an integration test: a Thronebane hunter procs Chain Arc off Auto Shot, and a wand caster with the same mainhand does not.

N/A: no UI/player-visible copy change (label reused), so no screenshots.