### PR TITLE
docs(claude): codify the default task workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,33 @@ Most directories above have their own `CLAUDE.md` with local conventions; read i
 
 See `README.md` for the full host/develop/play guide and the classic-fidelity checklist; `DEPLOY.md` for production.
 
+## Default task workflow
+Unless the request says otherwise, the default for any task is to accomplish the stated
+objective, and to deliver it this way. This is the baseline for every contribution.
+
+Before making changes:
+- **Base your work off the latest release branch** (and its tracking issue), not `main`. The
+  release branch is the active integration base; `main` trails it.
+- **Create and use a separate git worktree for the task**, so unrelated working-tree WIP never
+  contaminates the branch and parallel tasks stay isolated.
+- **Review the existing implementation before modifying anything.** Read the code paths, tests,
+  and the local `CLAUDE.md` for the area you are touching first.
+- **Preserve existing behavior unless the goal explicitly requires changing it.**
+
+Implementation requirements:
+- Make **all** the changes the objective needs: code, data, validation, UI, and tests.
+- **Avoid unrelated refactors.** Keep the diff scoped to the task.
+- **Add or update automated tests** covering the new behavior (`sim/` and `server/` changes
+  always get a test).
+- Keep the solution maintainable and extensible: follow the module-first seams above, do not grow
+  a monolith.
+- **If the change is visual, add before/after screenshots to the PR** (desktop and mobile where
+  relevant), committed under `docs/screenshots` and referenced from the PR body.
+
+Deliverable: a PR based off the latest release branch, following
+`.github/PULL_REQUEST_TEMPLATE.md`, that is **fully mergeable and passes CI**. Gate it locally
+with `npm run gate` (above) before calling it done.
+
 ## Architecture (the load-bearing ideas)
 - **One sim, three hosts.** The exact same `src/sim/` code runs the offline
   browser world, the online server, and the RL env. Behavior must be identical


### PR DESCRIPTION
## Summary

Adds a **Default task workflow** section to the root `CLAUDE.md` so the team's standing working agreement is written down, not tacit. It states that, unless a request says otherwise, every task by default:

- bases off the latest release branch (and its tracking issue), not `main`;
- runs in its own git worktree;
- reviews the existing implementation before changing anything, and preserves behavior unless the goal requires a change;
- ships all the code/data/validation/UI/test changes it needs, with no unrelated refactors;
- adds or updates automated tests for the new behavior;
- includes before/after screenshots in the PR for visual changes;
- lands as a PR (following the PR template) that is fully mergeable and passes CI, gated locally with `npm run gate`.

It reuses the seams and conventions already documented elsewhere in the file (worktree isolation, module-first, the gate command, the PR template).

## Type of change

- [x] Documentation

## How was this tested?

- Docs-only change. No code, tests, or build affected. Verified the new section renders and contains no em/en dashes or emoji per the repo copy rules.

N/A: no player-visible or UI change, so no screenshots.