### PR TITLE
refactor(equipment): make weapon requiredClass list every class that can equip

### DIFF
--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -2173,7 +2173,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 18, max: 29, speed: 2.3 },
     stats: { str: 6, sta: 2 },
     sellValue: 900,
-    requiredClass: ['warrior', 'paladin', 'shaman'],
+    requiredClass: ['warrior', 'rogue', 'hunter', 'shaman', 'paladin'],
   },
   emberwood_staff: {
     id: 'emberwood_staff',
@@ -2184,7 +2184,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 20, max: 33, speed: 3.0 },
     stats: { int: 6, spi: 2 },
     sellValue: 900,
-    requiredClass: ['mage', 'priest', 'warlock', 'druid'],
+    requiredClass: ['mage', 'priest', 'warlock', 'shaman', 'paladin', 'druid'],
   },
   cultist_flayer: {
     id: 'cultist_flayer',
@@ -2228,7 +2228,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 19, max: 31, speed: 3.0 },
     stats: { int: 7, spi: 3 },
     sellValue: 950,
-    requiredClass: ['mage', 'priest', 'warlock', 'druid'],
+    requiredClass: ['mage', 'priest', 'warlock', 'shaman', 'paladin', 'druid'],
   },
   marrowlord_boneboots: {
     id: 'marrowlord_boneboots',
@@ -2280,7 +2280,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 26, max: 41, speed: 2.5 },
     stats: { str: 8, sta: 3 },
     sellValue: 2400,
-    requiredClass: ['warrior', 'paladin', 'shaman'],
+    requiredClass: ['warrior', 'rogue', 'hunter', 'shaman', 'paladin'],
   },
   // --- quest & dungeon blues (rare) ---
   // Brutok Skullsmasher chase weapons (mutually exclusive: brutok_chase)
@@ -2293,7 +2293,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 24, max: 37, speed: 2.7 },
     stats: { str: 8, sta: 3 },
     sellValue: 2000,
-    requiredClass: ['warrior', 'paladin', 'shaman'],
+    requiredClass: ['warrior', 'rogue', 'hunter', 'shaman', 'paladin'],
   },
   crag_warden_cudgel: {
     id: 'crag_warden_cudgel',
@@ -2304,7 +2304,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 23, max: 36, speed: 3.0 },
     stats: { int: 8, spi: 4 },
     sellValue: 2000,
-    requiredClass: ['mage', 'priest', 'warlock', 'druid'],
+    requiredClass: ['mage', 'priest', 'warlock', 'shaman', 'paladin', 'druid'],
   },
   skullsplitter_dirk: {
     id: 'skullsplitter_dirk',
@@ -2326,7 +2326,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 22, max: 35, speed: 2.6 },
     stats: { str: 7, sta: 4 },
     sellValue: 2000,
-    requiredClass: ['warrior', 'paladin', 'shaman'],
+    requiredClass: ['warrior', 'rogue', 'hunter', 'shaman', 'paladin'],
   },
   ogre_bonecharm_staff: {
     id: 'ogre_bonecharm_staff',
@@ -2337,7 +2337,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 24, max: 38, speed: 3.0 },
     stats: { int: 9, spi: 4 },
     sellValue: 2000,
-    requiredClass: ['mage', 'priest', 'warlock', 'druid'],
+    requiredClass: ['mage', 'priest', 'warlock', 'shaman', 'paladin', 'druid'],
   },
   gutripper_shiv: {
     id: 'gutripper_shiv',
@@ -2390,7 +2390,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 27, max: 43, speed: 3.0 },
     stats: { int: 9, spi: 4 },
     sellValue: 2500,
-    requiredClass: ['mage', 'priest', 'warlock', 'druid'],
+    requiredClass: ['mage', 'priest', 'warlock', 'shaman', 'paladin', 'druid'],
   },
   shadowmeld_tunic: {
     id: 'shadowmeld_tunic',
@@ -2587,7 +2587,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 30, max: 48, speed: 2.6 },
     stats: { str: 11, sta: 7 },
     sellValue: 8000,
-    requiredClass: ['warrior', 'paladin', 'shaman'],
+    requiredClass: ['warrior', 'rogue', 'hunter', 'shaman', 'paladin'],
   },
   staff_of_the_gravewyrm: {
     id: 'staff_of_the_gravewyrm',
@@ -2598,7 +2598,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 32, max: 52, speed: 3.0 },
     stats: { int: 12, spi: 6 },
     sellValue: 8000,
-    requiredClass: ['mage', 'priest', 'warlock', 'druid'],
+    requiredClass: ['mage', 'priest', 'warlock', 'shaman', 'paladin', 'druid'],
   },
   fang_of_korzul: {
     id: 'fang_of_korzul',
@@ -2766,7 +2766,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     // mainhand budget.
     stats: { spi: 17, sta: 13, int: 14 },
     sellValue: 25000,
-    requiredClass: ['druid'],
+    requiredClass: ['mage', 'priest', 'warlock', 'shaman', 'paladin', 'druid'],
     // Life and decay: a damaging spell may fester a nature DoT (Deathbloom); a heal
     // may bloom a nature heal-over-time on its target (Lifebloom).
     weaponProcs: [
@@ -2807,7 +2807,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     // crit) while it stays usable by its warrior/paladin owners.
     stats: { str: 15, agi: 15, sta: 14 },
     sellValue: 25000,
-    requiredClass: ['warrior', 'paladin'],
+    requiredClass: ['warrior', 'rogue', 'hunter', 'shaman', 'paladin'],
     // Thunderfury-style on-hit: a nature arc that blasts the target and chains to
     // nearby foes, and slows the primary target's attack speed.
     weaponProcs: [

--- a/src/sim/equipment_rules.ts
+++ b/src/sim/equipment_rules.ts
@@ -20,8 +20,6 @@ const CASTER_WEAPON_CLASSES = new Set<PlayerClass>([
   'druid',
 ]);
 const ROGUE_WEAPON_CLASSES = new Set<PlayerClass>(['rogue', 'hunter']);
-const OLD_WARRIOR_WEAPON_ARCHETYPE = new Set<PlayerClass>(['warrior', 'paladin', 'shaman']);
-const OLD_CASTER_WEAPON_ARCHETYPE = new Set<PlayerClass>(['mage', 'priest', 'warlock', 'druid']);
 
 const ARMOR_RANK: Record<ArmorType, number> = {
   cloth: 0,
@@ -29,8 +27,9 @@ const ARMOR_RANK: Record<ArmorType, number> = {
   mail: 2,
 };
 
-function subsetOf(classes: readonly PlayerClass[], allowed: ReadonlySet<PlayerClass>): boolean {
-  return classes.length > 0 && classes.every((cls) => allowed.has(cls));
+// True when `classes` names exactly the members of `allowed` (order-independent).
+function sameClassSet(classes: readonly PlayerClass[], allowed: ReadonlySet<PlayerClass>): boolean {
+  return classes.length === allowed.size && classes.every((cls) => allowed.has(cls));
 }
 
 export function armorTypeForItem(item: ItemDef): ArmorType | null {
@@ -60,11 +59,17 @@ export function maxArmorTypeForClass(cls: PlayerClass): ArmorType {
   return 'cloth';
 }
 
+// A weapon's `requiredClass` lists exactly the classes that can equip it, i.e. the
+// full weapon-proficiency group (weapons are proficiency-based, not class-locked).
+// Recover the archetype by matching that list against each group. A weapon with a
+// narrower, bespoke class lock (not one of the three groups) has no archetype and
+// falls through to the literal `requiredClass` check in canEquipItem, and shows its
+// class line on the tooltip.
 export function weaponArchetypeForItem(item: ItemDef): WeaponArchetype | null {
   if (item.kind !== 'weapon' || !item.requiredClass) return null;
-  if (subsetOf(item.requiredClass, OLD_WARRIOR_WEAPON_ARCHETYPE)) return 'warrior';
-  if (subsetOf(item.requiredClass, OLD_CASTER_WEAPON_ARCHETYPE)) return 'caster';
-  if (subsetOf(item.requiredClass, ROGUE_WEAPON_CLASSES)) return 'rogue';
+  if (sameClassSet(item.requiredClass, WARRIOR_WEAPON_CLASSES)) return 'warrior';
+  if (sameClassSet(item.requiredClass, CASTER_WEAPON_CLASSES)) return 'caster';
+  if (sameClassSet(item.requiredClass, ROGUE_WEAPON_CLASSES)) return 'rogue';
   return null;
 }
 

--- a/tests/equipment_proficiency.test.ts
+++ b/tests/equipment_proficiency.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import { CLASSES, ITEMS } from '../src/sim/data';
+import { canEquipItem } from '../src/sim/equipment_rules';
 import { Sim } from '../src/sim/sim';
+import type { PlayerClass } from '../src/sim/types';
+
+const ALL_CLASSES = Object.keys(CLASSES) as PlayerClass[];
 
 function equip(cls: Parameters<Sim['addPlayer']>[0], itemId: string) {
   const sim = new Sim({ seed: 42, playerClass: cls, noPlayer: true, autoEquip: false });
@@ -62,5 +67,22 @@ describe('armor proficiencies', () => {
     expect(equip('warrior', 'staff_of_the_gravewyrm').equipment.mainhand).not.toBe(
       'staff_of_the_gravewyrm',
     );
+  });
+});
+
+describe('weapon requiredClass is representative of who can equip', () => {
+  // The whole point of the field: a weapon's requiredClass must list exactly the
+  // classes that can actually equip it, not an archetype-signature subset. Guards
+  // every weapon at once, so a future archetype weapon authored with the short
+  // form (e.g. ['warrior','paladin']) fails here until it lists the full group.
+  it('lists exactly the classes canEquipItem allows, for every weapon with a class list', () => {
+    for (const item of Object.values(ITEMS)) {
+      if (item.kind !== 'weapon' || !item.requiredClass) continue;
+      const equippable = ALL_CLASSES.filter((c) => canEquipItem(c, item)).sort();
+      const listed = [...item.requiredClass].sort();
+      expect(listed, `${item.id}: requiredClass must match its equippable classes`).toEqual(
+        equippable,
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

A weapon's `requiredClass` was an archetype **signature**, not the real list. Thronebane was `['warrior','paladin']`, yet `canEquipItem` (via `weaponArchetypeForItem`) opened it to the whole warrior-weapon group, so a rogue or hunter could equip it. The field read like a hard class lock while the game let five classes wear it. Weapons here are proficiency-based, not class-locked, but the data did not say so.

This makes the data representative. Every archetype weapon's `requiredClass` now lists exactly the classes that can equip it:
- warrior group -> `warrior, rogue, hunter, shaman, paladin`
- caster group -> `mage, priest, warlock, shaman, paladin, druid`
- rogue group was already its full set (`rogue, hunter`), unchanged

`weaponArchetypeForItem` now recovers the archetype by matching the full list against each group set (order-independent equality) instead of a subset of the legacy signature sets. Equip results and the item tooltip (which still suppresses the redundant class line for group weapons) are byte-identical to before. A future weapon with a genuine bespoke lock has no archetype and correctly shows its class line.

13 weapons expanded (all in `zone3.ts`, including both legendaries). No gameplay behavior change.

## Type of change

- [x] Refactor or performance (no behavior change)

## How was this tested?

- `npx vitest run tests/equipment_proficiency.test.ts tests/item_armor_type.test.ts tests/items.test.ts tests/item_level.test.ts tests/progression.test.ts tests/inspect_equipment.test.ts tests/item_compare.test.ts tests/unequip_item.test.ts tests/equip_jewelry.test.ts tests/equip_level_requirement.test.ts tests/guide.test.ts tests/architecture.test.ts` (all pass). `npx tsc --noEmit` clean (the only local error is a pre-existing missing `prom-client` dep, untouched here).
- New guard in `equipment_proficiency.test.ts`: for every weapon with a `requiredClass`, the field must equal exactly the set of classes `canEquipItem` allows. It fails on the old short-form data, so it pins the fix and blocks future drift.

N/A: no player-visible copy or UI change (group-weapon tooltips still hide the class line), so no screenshots.