### PR TITLE
fix(sim): clear held movement intent on arena respawn and delve-companion revive (#1651 follow-up to #1723)

### DIFF
--- a/src/sim/delves/companion.ts
+++ b/src/sim/delves/companion.ts
@@ -21,6 +21,7 @@ import {
   DT,
   dist2d,
   type Entity,
+  emptyMoveInput,
   MELEE_RANGE,
   PET_TELEPORT_DISTANCE,
   steadyAngleTo,
@@ -68,6 +69,11 @@ export function updateDelveCompanion(ctx: SimContext, companion: Entity): void {
       // re-entering mid-run cannot recharge the boon.
       run.companionReviveUsed = true;
       fallen.dead = false;
+      // Clear any movement intent held at death so the revived ally does not walk
+      // off on its own with no key held (issue 1651, companion-revive path). fallen
+      // is always a player (owner or a partyMembersForKey ally), so it has a meta.
+      const fallenMeta = ctx.players.get(fallen.id);
+      if (fallenMeta) Object.assign(fallenMeta.moveInput, emptyMoveInput());
       fallen.hp = Math.max(1, Math.round(fallen.maxHp * 0.5));
       if (fallen.resourceType === 'mana')
         fallen.resource = Math.max(fallen.resource, Math.round(fallen.maxResource * 0.5));

--- a/src/sim/social/arena.ts
+++ b/src/sim/social/arena.ts
@@ -33,6 +33,7 @@ import {
   type ArenaStanding,
   DT,
   type Entity,
+  emptyMoveInput,
 } from '../types';
 
 // Ashen Coliseum 1v1 arena tuning consts (moved with the slice). FIESTA_COUNTDOWN
@@ -852,6 +853,10 @@ export function readyArenaFighter(ctx: SimContext, e: Entity, opts: { clearPrep:
   e.resource = e.resourceType === 'mana' ? e.maxResource : e.resourceType === 'energy' ? 100 : 0;
   e.targetId = null;
   e.autoAttack = false;
+  // Drop any held movement intent so a fighter placed/respawned into the arena does
+  // not drift from a stale forward/back flag with no key held (issue 1651); bots
+  // already reset theirs on spawn.
+  if (meta) Object.assign(meta.moveInput, emptyMoveInput());
   e.queuedOnSwing = null;
   delete e.queuedOnSwingFree;
   e.queuedCastAbility = null;

--- a/tests/arena_respawn_intent.test.ts
+++ b/tests/arena_respawn_intent.test.ts
@@ -1,0 +1,68 @@
+// Regression for issue 1651 (arena arm): a fighter's last-held movement key
+// survived on PlayerMeta.moveInput through the arena respawn. readyArenaFighter
+// (the one place a benched Fiesta/ranked fighter is placed back into the bout)
+// reset hp/resource/target/auto-attack but never cleared moveInput, so the
+// revived fighter drifted in the last-held direction with no key pressed. The
+// graveyard/delve respawn paths are covered elsewhere (spirit.ts / entity_roster
+// / runs.ts); this pins the arena path readyArenaFighter owns.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import type { PlayerClass } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function teleport(sim: Sim, pid: number, x: number, z: number) {
+  const e = sim.entities.get(pid)!;
+  e.pos.x = x;
+  e.pos.z = z;
+  e.pos.y = groundHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+  (sim as any).rebucket(e);
+}
+
+// Seat a 2v2 Fiesta with four solo-queued players and run the countdown out so
+// the bout is live. Fiesta respawns route through readyArenaFighter, so it is
+// the clean vehicle for exercising the arena revive path.
+function startFiesta(classes: PlayerClass[] = ['warrior', 'mage', 'rogue', 'priest']) {
+  const sim = makeWorld();
+  const pids = classes.map((c, i) => sim.addPlayer(c, `P${i}`));
+  pids.forEach((p, i) => {
+    teleport(sim, p, i * 4, -40);
+  });
+  pids.forEach((p) => {
+    sim.arenaQueueJoin(p, 'fiesta');
+  });
+  sim.tick(); // matchmake
+  for (let i = 0; i < 20 * 8; i++) {
+    sim.tick();
+    const m = sim.arenaMatchFor(pids[0]);
+    if (m && m.state === 'active') break;
+  }
+  const match = sim.arenaMatchFor(pids[0])!;
+  return { sim, match };
+}
+
+describe('arena respawn clears stale movement intent (issue 1651)', () => {
+  it('a benched fiesta fighter does not auto-walk from a held intent after revive', () => {
+    const { sim, match } = startFiesta();
+    const killerPid = match.teamA[0];
+    const victimPid = match.teamB[0];
+    const victim = sim.entities.get(victimPid)!;
+    const killer = sim.entities.get(killerPid)!;
+    const victimMeta = (sim as any).players.get(victimPid);
+    // Down the victim while it holds a forward intent, and keep the flag set while it
+    // is benched so readyArenaFighter is the only thing that could clear it on revive.
+    victimMeta.moveInput.forward = true;
+    (sim as any).dealDamage(killer, victim, victim.maxHp + 50, false, 'physical', null);
+    expect(victim.dead).toBe(true);
+    victimMeta.moveInput.forward = true;
+    const downedFor = match.fiesta!.respawn.get(victimPid)!;
+    for (let i = 0; i < Math.ceil(downedFor * 20) + 5; i++) sim.tick();
+    expect(sim.entities.get(victimPid)!.dead).toBe(false);
+    // The revived fighter must not auto-walk from the stale intent.
+    expect(victimMeta.moveInput.forward).toBe(false);
+  });
+});

--- a/tests/delve_companion.test.ts
+++ b/tests/delve_companion.test.ts
@@ -177,6 +177,28 @@ describe('delve companions', () => {
     expect(sim.entities.has(companion.id)).toBe(false);
   });
 
+  it('rank 3 revive clears a movement intent held at death (issue 1651)', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(20);
+    const meta = (sim as any).players.get(sim.playerId);
+    meta.companionUpgrades.companion_tessa = 3;
+    teleport(sim, 0, 0);
+    sim.enterDelve('collapsed_reliquary', 'normal');
+    const run = sim.delveRunForPlayer(sim.playerId)!;
+    const companion = sim.entities.get(run.companion!.entityId)!;
+    const p = sim.player;
+    // Hold forward, then die: handleDeath does not zero moveInput, so the flag
+    // survives the dead interval and would re-activate the tick after the revive.
+    meta.moveInput.forward = true;
+    p.dead = true;
+    p.hp = 0;
+    updateDelveCompanion((sim as any).ctx, companion);
+    expect(p.dead).toBe(false);
+    expect(run.companionReviveUsed).toBe(true);
+    // The revived owner must not auto-walk from the stale intent.
+    expect(meta.moveInput.forward).toBe(false);
+  });
+
   it('below rank 3 a dead owner still despawns the companion (no revive)', () => {
     const sim = makeSim();
     sim.setPlayerLevel(20);


### PR DESCRIPTION
## Update: rescoped as a follow-up to #1723

#1723 has since merged and fixes issue #1651 for the graveyard release, healer revive, and delve first-death / eject paths. I have rebased this PR onto the current release and **dropped everything #1723 now covers**, so it no longer overlaps. What remains are the two respawn sites that route around #1723's fixes and were left uncovered:

- **`readyArenaFighter` (`src/sim/social/arena.ts`)** - the arena's own placement path (Fiesta and ranked) resets hp/resource/target/auto-attack but never `moveInput`, so a fighter revived into a live bout drifted from a stale forward/back flag with no key held.
- **`updateDelveCompanion` (`src/sim/delves/companion.ts`)** - the rank-3 companion boon that revives a downed ally mid-run never cleared that ally's `moveInput`.

Both now clear `PlayerMeta.moveInput` in place, exactly matching #1723's approach at the sites it covered.

## Tests
- `tests/arena_respawn_intent.test.ts` (new) - a benched Fiesta fighter does not auto-walk from a held intent after revive.
- `tests/delve_companion.test.ts` - added the rank-3 companion-revive intent-clear case.
- Both were verified to **fail without** the code change and pass with it (decisive, not vacuous). Determinism confirmed: the `fiesta_powerups` parity golden trace still matches.

## Type of change
- [x] Bug fix

If you would rather fold these two paths into #1723's follow-up work or handle them differently, happy to adjust or close - just wanted the two uncovered revive sites not to slip through.