### PR TITLE
db: preload pg_stat_statements for query monitoring

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,16 @@ services:
     image: postgres:16-alpine
     container_name: eastbrook-db
     restart: unless-stopped
+    # Preload pg_stat_statements so monitoring can track per-query stats
+    # (slowest/most-frequent queries) via postgres_exporter. Takes effect on the
+    # next DB restart. One-time `CREATE EXTENSION pg_stat_statements;` is needed
+    # afterwards, handled idempotently by the monitoring deploy (woc-deploy).
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_preload_libraries=pg_stat_statements"
+      - "-c"
+      - "pg_stat_statements.track=all"
     environment:
       POSTGRES_USER: eastbrook
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env. See .env.example.}


### PR DESCRIPTION
## What

Preloads `pg_stat_statements` on the `eastbrook-db` postgres service (adds `shared_preload_libraries=pg_stat_statements`, `pg_stat_statements.track=all`).

## Why

Monitoring needs it to surface **slowest / most-frequent queries** (via `postgres_exporter`). `pg_stat_statements` is the standard Postgres way to aggregate per-query stats over time; there is no reliable no-restart alternative for that.

## Impact / what you need to do

- **Requires a DB restart** to take effect (that is why this is your call, not the monitoring repo's). The game itself is unaffected: no schema, query, or app-behaviour change; it just starts recording query stats.
- After it is deployed, a one-time `CREATE EXTENSION pg_stat_statements;` (+ read grant to the monitoring role) is needed. That is handled idempotently by the monitoring deploy in `woc-deploy`, run after this lands.
- Low risk: `pg_stat_statements` has negligible overhead and is safe to run on prod.

## Sequence

1. You review / merge / deploy this (the restart).
2. We run the monitoring side (`woc-deploy`) which creates the extension and starts scraping the query stats.

No urgency; monitoring works fine without it (host + DB health metrics are already live). This just unlocks query-level visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
