### PR TITLE
Shorten mobile Autorun label

### DIFF
--- a/index.html
+++ b/index.html
@@ -1293,7 +1293,7 @@
       <div class="mobile-joy-label" data-i18n="hud.core.mobileCamera">Camera</div>
     </div>
     <div id="mobile-utility-cluster">
-      <button class="mobile-btn" type="button" id="mobile-autorun" data-i18n-title="hud.keybinds.actions.autorun" data-i18n-aria="hud.keybinds.actions.autorun" title="Toggle autorun" aria-label="Toggle autorun" data-icon="autorun"><span class="mobile-label" data-i18n="hudChrome.mobile.autorun">Autorun</span></button>
+      <button class="mobile-btn" type="button" id="mobile-autorun" data-i18n-title="hud.keybinds.actions.autorun" data-i18n-aria="hud.keybinds.actions.autorun" title="Toggle autorun" aria-label="Toggle autorun" data-icon="autorun"><span class="mobile-label" data-i18n="hudChrome.mobile.autorun">Auto</span></button>
     </div>
     <div id="mobile-combat-controls">
       <button class="mobile-btn" type="button" id="mobile-chat" data-i18n-title="hud.keybinds.actions.chat" data-i18n-aria="hud.keybinds.actions.chat" title="Open Chat" aria-label="Open Chat" data-icon="chat"><span class="mobile-label" data-i18n="hud.core.mobileChat">Chat</span></button>

--- a/play.html
+++ b/play.html
@@ -977,7 +977,7 @@
       <div class="mobile-joy-label" data-i18n="hud.core.mobileCamera">Camera</div>
     </div>
     <div id="mobile-utility-cluster">
-      <button class="mobile-btn" type="button" id="mobile-autorun" data-i18n-title="hud.keybinds.actions.autorun" data-i18n-aria="hud.keybinds.actions.autorun" title="Toggle autorun" aria-label="Toggle autorun" data-icon="autorun"><span class="mobile-label" data-i18n="hudChrome.mobile.autorun">Autorun</span></button>
+      <button class="mobile-btn" type="button" id="mobile-autorun" data-i18n-title="hud.keybinds.actions.autorun" data-i18n-aria="hud.keybinds.actions.autorun" title="Toggle autorun" aria-label="Toggle autorun" data-icon="autorun"><span class="mobile-label" data-i18n="hudChrome.mobile.autorun">Auto</span></button>
     </div>
     <div id="mobile-combat-controls">
       <button class="mobile-btn" type="button" id="mobile-chat" data-i18n-title="hud.keybinds.actions.chat" data-i18n-aria="hud.keybinds.actions.chat" title="Open Chat" aria-label="Open Chat" data-icon="chat"><span class="mobile-label" data-i18n="hud.core.mobileChat">Chat</span></button>

--- a/src/ui/i18n.catalog/hud_chrome.ts
+++ b/src/ui/i18n.catalog/hud_chrome.ts
@@ -231,7 +231,7 @@ export const hudChromeStrings = {
   // On-screen / mobile control labels and their accessible names. char/bags/music
   // reuse existing keys (hud.keybinds.actions.*, hud.options.music) at the call site.
   mobile: {
-    autorun: 'Autorun',
+    autorun: 'Auto',
     jump: 'Jump',
     leaderboard: 'Ranks',
     dailyRewards: 'Rewards',

--- a/src/ui/i18n.resolved.generated/en.ts
+++ b/src/ui/i18n.resolved.generated/en.ts
@@ -306,7 +306,7 @@ export const en: EnTranslations = {
       "chat": "Skip to Chat"
     },
     "mobile": {
-      "autorun": "Autorun",
+      "autorun": "Auto",
       "jump": "Jump",
       "leaderboard": "Ranks",
       "dailyRewards": "Rewards",

--- a/src/ui/i18n.resolved.generated/en_CA.ts
+++ b/src/ui/i18n.resolved.generated/en_CA.ts
@@ -306,7 +306,7 @@ export const en_CA: EnTranslations = {
       "chat": "Skip to Chat"
     },
     "mobile": {
-      "autorun": "Autorun",
+      "autorun": "Auto",
       "jump": "Jump",
       "leaderboard": "Ranks",
       "dailyRewards": "Rewards",

--- a/src/ui/i18n.resolved.generated/en_XA.ts
+++ b/src/ui/i18n.resolved.generated/en_XA.ts
@@ -306,7 +306,7 @@ export const en_XA: EnTranslations = {
       "chat": "[Šķíþ ţó Çĥáţ]"
     },
     "mobile": {
-      "autorun": "[Áúţóŕúñ]",
+      "autorun": "[Áúţó]",
       "jump": "[Ĵúɱþ]",
       "leaderboard": "[Ŕáñķš]",
       "dailyRewards": "[Ŕéŵáŕðš]",


### PR DESCRIPTION
## Summary
- rename the visible mobile Autorun button label to Auto
- keep the existing Toggle Autorun title and aria text unchanged
- update both HTML entries and English generated locale outputs

## Test
- npx vitest run tests/client_shell.test.ts tests/per_entry_css_wiring.test.ts
- npx tsc --noEmit --pretty false