### PR TITLE
Fix mobile minimap HUD controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,9 +264,9 @@
              accessible #map-window as the alternative, per the zone-label decision. -->
         <canvas id="minimap" width="162" height="162" aria-hidden="true"></canvas>
         <button id="raid-lockout" type="button" hidden data-i18n-title="hudChrome.raidLockout.title" data-i18n-aria="hudChrome.raidLockout.title" title="Raid Lockouts" aria-label="Raid Lockouts"></button>
-        <!-- Ravenpost envelope: visible while unread letters wait (role=status so
-             arrivals are announced; reading them still requires a mailbox). -->
-        <div id="mail-indicator" role="status" hidden data-icon="mail"><span class="mail-indicator-count">0</span></div>
+        <!-- Ravenpost envelope: visible while unread letters wait; opens the mailbox
+             window, which explains when the player is too far from a mailbox. -->
+        <button id="mail-indicator" type="button" hidden data-icon="mail" aria-live="polite"><span class="mail-indicator-count">0</span></button>
       </div>
       <div id="minimap-clock" data-i18n-title="hudChrome.widgets.clockTitle" title="Local time — click to toggle 12/24-hour">--:--</div>
       <div id="minimap-coords" role="status" data-i18n-title="hudChrome.widgets.worldCoordinates" data-i18n-aria="hudChrome.widgets.coordinates" title="Your current world coordinates" aria-label="Coordinates">0, 0</div>

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -4206,6 +4206,9 @@
     border: 1px solid #cc9a3c88;
     border-radius: 12px;
     color: var(--gold);
+    appearance: none;
+    cursor: pointer;
+    font: inherit;
     pointer-events: auto;
   }
   #mail-indicator[hidden] {

--- a/src/styles/hud.mobile.css
+++ b/src/styles/hud.mobile.css
@@ -1839,8 +1839,82 @@
   body.mobile-touch #minimap-wrap {
     right: max(20px, calc(env(safe-area-inset-right) + 10px));
     top: max(8px, env(safe-area-inset-top));
-    transform: scale(calc(0.72 * var(--mobile-chrome-scale, 1)));
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    transform: scale(calc(0.94 * var(--mobile-chrome-scale, 1)));
     transform-origin: right top;
+  }
+  body.mobile-touch #zone-label {
+    order: 0;
+  }
+  body.mobile-touch #minimap-disc {
+    order: 1;
+  }
+  body.mobile-touch #minimap-coords {
+    order: 2;
+  }
+  body.mobile-touch #compass {
+    order: 3;
+  }
+  body.mobile-touch #minimap-clock {
+    position: static;
+    order: 4;
+    transform: none;
+    margin: 5px auto 0;
+  }
+  /* The minimap wrapper is scaled down on touch, so counter-scale the disc
+     controls and place them in a row below the aura strip, left of the map. */
+  body.mobile-touch #raid-lockout {
+    left: auto;
+    right: calc(100% + 10px);
+    top: 156px;
+    bottom: auto;
+    width: 44px;
+    height: 44px;
+    border-width: 2px;
+    transform: scale(1.25);
+    transform-origin: right top;
+  }
+  body.mobile-touch #raid-lockout svg {
+    width: 24px;
+    height: 24px;
+  }
+  body.mobile-touch #mail-indicator {
+    right: calc(100% + 74px);
+    top: 156px;
+    bottom: auto;
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0;
+    justify-content: center;
+    border-radius: 999px;
+    border-width: 2px;
+    transform: scale(1.25);
+    transform-origin: right top;
+  }
+  body.mobile-touch #mail-indicator .ui-icon {
+    width: 22px;
+    height: 22px;
+  }
+  body.mobile-touch #mail-indicator .mail-indicator-count {
+    position: absolute;
+    right: 3px;
+    top: 2px;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 3px;
+    border-radius: 999px;
+    font-size: 11px;
+    line-height: 16px;
+  }
+  body.mobile-touch #minimap-zoom {
+    display: none;
+  }
+  body.mobile-touch #compass-heading {
+    display: none;
   }
   body.mobile-touch #right-tracker-stack {
     right: max(10px, env(safe-area-inset-right));
@@ -3668,7 +3742,12 @@
     body.mobile-touch #minimap-wrap {
       right: max(6px, env(safe-area-inset-right));
       top: max(6px, env(safe-area-inset-top));
-      transform: scale(calc(0.46 * var(--mobile-chrome-scale, 1)));
+      transform: scale(calc(0.6 * var(--mobile-chrome-scale, 1)));
+    }
+    body.mobile-touch #raid-lockout,
+    body.mobile-touch #mail-indicator {
+      top: 94px;
+      transform: scale(1.27);
     }
     body.mobile-touch #quest-tracker {
       display: none;
@@ -3796,12 +3875,9 @@
     font-size: 10px;
   }
   body.mobile-touch.hud-mobile-compact #minimap-wrap {
-    /* 0.44, tighter than the 0.46 landscape baseline (never larger): the wrap
-       (map circle + compass/coords band, ~170x258 unscaled) must clear the
-       combat arc's top button on a 360px-tall phone, where the vertical budget
-       is wrap bottom (~120px) + arc run (bottom inset + attack/2 + radius +
-       action/2, ~239px) against the full viewport height. */
-    transform: scale(calc(0.44 * var(--mobile-chrome-scale, 1)));
+    /* Keep compact phones slightly tighter than the landscape baseline while
+       still making the minimap materially larger than the old 0.44 scale. */
+    transform: scale(calc(0.57 * var(--mobile-chrome-scale, 1)));
   }
   /* A short landscape phone (the compact tier's primary trigger) has too little
      vertical room for a full chat log AND the action ring at once; drop the log

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1343,6 +1343,7 @@ export class Hud {
     this.emoteWheelSlots = this.loadEmoteWheelSlots();
     this.loadSlotMap();
     this.buildActionBar();
+    this.initMailIndicator();
     this.refreshKeybindLabels();
     this.buildXpTicks();
     document.addEventListener('woc:languagechange', () => this.refreshLocalizedDynamicUi());
@@ -1449,13 +1450,20 @@ export class Hud {
     this.clockEl = $('#minimap-clock');
     // raid-lockout badge on the minimap rim: a lock icon whose hover/tap panel
     // lists the player's raid lockouts (the unlock countdown). Always visible;
-    // it lights up (.locked) while any raid is on cooldown. attachTooltip already
-    // handles desktop hover, mobile tap, and keyboard focus uniformly.
+    // it lights up (.locked) while any raid is on cooldown. attachTooltip handles
+    // desktop hover, mobile long-press, and keyboard focus; mobile tap below opens
+    // the same panel immediately because the badge has no primary action.
     this.raidLockoutEl = document.getElementById('raid-lockout');
     if (this.raidLockoutEl) {
       this.raidLockoutEl.innerHTML = svgIcon('lock');
       this.raidLockoutEl.hidden = false;
       this.attachTooltip(this.raidLockoutEl, () => this.raidLockoutPanelView());
+      this.raidLockoutEl.addEventListener('click', (ev) => {
+        if (!document.body.classList.contains('mobile-touch')) return;
+        ev.preventDefault();
+        ev.stopPropagation();
+        this.showRaidLockoutTooltip();
+      });
     }
     const dailyRewardsButton = document.getElementById(
       'daily-rewards-button',
@@ -3965,6 +3973,13 @@ export class Hud {
   hideTooltip(): void {
     this.tooltipEl.style.display = 'none';
     this.tooltipEl.classList.remove('mob-tooltip');
+  }
+
+  private showRaidLockoutTooltip(): void {
+    const el = this.raidLockoutEl;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    this.paintTooltipAt(this.raidLockoutPanelView(), rect.right, rect.top + rect.height / 2);
   }
 
   // Paints the shared #tooltip box at a screen point, used by attachTooltip's
@@ -6868,6 +6883,22 @@ export class Hud {
     if (slowHud && this.bankWindow.isOpen) this.bankWindow.refreshIfChanged();
     if (slowHud && this.calendarWindow.isOpen) this.calendarWindow.refreshIfChanged();
     if (slowHud) this.updateMailIndicator();
+  }
+
+  private initMailIndicator(): void {
+    const el = $('#mail-indicator') as HTMLButtonElement;
+    this.mailIndicatorEl = el;
+    el.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      this.openMailbox();
+    });
+    el.addEventListener('keydown', (ev) => {
+      if (ev.key !== 'Enter' && ev.key !== ' ') return;
+      ev.preventDefault();
+      ev.stopPropagation();
+      this.openMailbox();
+    });
   }
 
   // The envelope indicator by the minimap: visible while unread letters wait.


### PR DESCRIPTION
## Summary
- enlarge the mobile minimap and remove mobile minimap zoom controls
- move mail and raid-lockout buttons into a row below mobile buff/debuffs, left of the minimap
- make the mail indicator open the mailbox window and make raid lockouts show on mobile tap
- hide the extra mobile compass heading and place the clock below the compass row

## Tests
- npx tsc --noEmit --pretty false
- npx vitest run tests/mailbox_view.test.ts tests/css_value_validity.test.ts tests/minimap_rim_badges.test.ts
- npx vitest run tests/raid_lockout.test.ts tests/css_value_validity.test.ts tests/minimap_rim_badges.test.ts