### PR TITLE
chore(deploy): pass METRICS_TOKEN through to the game container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,12 @@ WIKI_URL=http://localhost:8080/wiki/index.php/Main_Page
 # so production logs stay quiet.
 #PERF_TICK_LOG=
 
+# Bearer token that gates GET /metrics (the Prometheus RED + process exposition).
+# Unset (the default) leaves /metrics feature-off (404); a non-empty value turns
+# it on behind Authorization: Bearer <token>. Set to a long random value and
+# mirror it in the monitoring scrape secret. Leave unset for local dev.
+#METRICS_TOKEN=
+
 # Discord integration. OAuth in the game server is enabled when
 # DISCORD_CLIENT_ID and DISCORD_CLIENT_SECRET are set. The separate bot service
 # is opt-in so local/self-hosted compose stacks keep working without Discord

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,11 @@ services:
       # heartbeat log line (tickHz, per-phase p95/max) plus over-budget stutter
       # traces. Off by default so production logs stay quiet.
       PERF_TICK_LOG: ${PERF_TICK_LOG:-}
+      # Runtime: bearer token that gates GET /metrics (server/http/health.ts).
+      # Empty (unset) leaves the endpoint feature-off (404); a non-empty value
+      # turns it on behind Authorization: Bearer <token>. Set on the host .env by
+      # the monitoring deploy so Prometheus can scrape the RED + process metrics.
+      METRICS_TOKEN: ${METRICS_TOKEN:-}
       # Runtime: protects the loopback-only deploy countdown endpoint.
       RESTART_COUNTDOWN_SECRET: ${RESTART_COUNTDOWN_SECRET:-}
       # Runtime: Discord OAuth + the secret-gated game <-> Discord bot channel.

--- a/tests/deploy_metrics_endpoint.test.ts
+++ b/tests/deploy_metrics_endpoint.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const compose = readFileSync('docker-compose.yml', 'utf8');
+const envExample = readFileSync('.env.example', 'utf8');
+const composeEnv = (name: string) => `$${`{${name}:-}`}`;
+
+describe('Prometheus /metrics deploy contract', () => {
+  // The game service passes an explicit environment allowlist (no env_file), so a
+  // secret only reaches the container if it is listed here. METRICS_TOKEN gates
+  // GET /metrics (server/http/health.ts): without this line, setting it in the
+  // host .env would populate compose interpolation but never reach the process,
+  // leaving the endpoint stuck at 404.
+  it('passes METRICS_TOKEN through to the game server container', () => {
+    expect(compose).toContain(`METRICS_TOKEN: ${composeEnv('METRICS_TOKEN')}`);
+  });
+
+  it('documents METRICS_TOKEN in .env.example, commented out (off by default)', () => {
+    expect(envExample).toContain('#METRICS_TOKEN=');
+  });
+});


### PR DESCRIPTION
## What

Add `METRICS_TOKEN: ${METRICS_TOKEN:-}` to the game service's `environment:` block in `docker-compose.yml`, and document the variable in `.env.example`.

## Why

The game already ships a bearer-gated Prometheus `/metrics` endpoint (`server/http/health.ts`): 404 when `METRICS_TOKEN` is unset, 401 on a wrong bearer, and the RED + Node process exposition on a match. Enabling it is the first phase of the app-metrics monitoring rollout.

The game service passes an explicit `environment:` allowlist (there is no `env_file:`), and `METRICS_TOKEN` was not in it. So setting `METRICS_TOKEN` in the host `.env` only populates compose interpolation, it never reaches the container, and the endpoint stays 404. This one-line passthrough (identical in shape to every other runtime secret here, for example `RESTART_COUNTDOWN_SECRET` and `PERF_TICK_LOG`) is what actually lets the deploy turn the endpoint on. Unset stays the default, so the endpoint is off (404) unless a token is provided: no behavior change for local dev or any host without the token.

## Testing

- `tests/deploy_metrics_endpoint.test.ts` asserts the game service passes `METRICS_TOKEN` through and that `.env.example` documents it (commented out, off by default), mirroring the existing `tests/deploy_discord_bot.test.ts` compose-contract pattern.
- The monitoring side (host `.env` token via idempotent lineinfile, the internal nginx metrics listener, the SG rule, and the Prometheus scrape job) lives in the `woc-deploy` and `resources` repos.

No game source, sim, wire, or render change.
