### PR TITLE
feat(server): expose game-state metrics on /metrics (app-metrics phase 2)

### DIFF
--- a/server/characters.ts
+++ b/server/characters.ts
@@ -62,6 +62,7 @@ import {
   scopeAllowsMutation,
 } from './db';
 import { ctxAccountId } from './http/context';
+import { gameMetricsCounters } from './http/game_signals';
 import { withBody } from './http/middleware/body';
 import {
   CHARACTER_CREATE_POLICY,
@@ -376,6 +377,7 @@ async function createCharacterHandler(ctx: Ctx): Promise<void> {
       rt.initialCharacterState(cls, name, skin),
     );
   const respondCreated = (c: CharacterRow): void => {
+    gameMetricsCounters().characterCreated();
     json(ctx.res, 200, {
       id: c.id,
       name: c.name,

--- a/server/game.ts
+++ b/server/game.ts
@@ -85,6 +85,7 @@ import { formatDuration } from './duration';
 import { mergedPrsForLogin } from './github_contributors';
 import { githubForAccount } from './github_db';
 import { forEachGuarded, runGuarded } from './guarded_iter';
+import { gameMetricsCounters } from './http/game_signals';
 import { IpBlockList } from './ip_block';
 import { loadActiveBlockedIps } from './ip_block_db';
 import { LINKDEAD_GRACE_MS, planJoin } from './linkdead';
@@ -2303,6 +2304,24 @@ export class GameServer {
     };
   }
 
+  // Achieved sim Hz for the /metrics exporter (server/http/game_metrics.ts), or
+  // null while the rate meter is still warming up (its first second of uptime).
+  simTickHz(): number | null {
+    return this.tickHz == null ? null : round2(this.tickHz);
+  }
+
+  // Per-phase loop timing (p95 + max, in MILLISECONDS) for the /metrics exporter,
+  // keyed by phase name. The exporter converts to seconds and surfaces only its
+  // fixed WOC_TICK_PHASES subset, so the exported label set stays bounded.
+  tickPhaseMillis(): Record<string, { p95: number; max: number }> {
+    const { phases } = this.tickProfiler.profile();
+    const out: Record<string, { p95: number; max: number }> = {};
+    for (const [name, stats] of Object.entries(phases)) {
+      out[name] = { p95: stats.p95, max: stats.max };
+    }
+    return out;
+  }
+
   // Start an on-demand detailed capture (admin-triggered). Clears the profiler so the
   // window is clean, flips the detailed sub-phase timing on, and schedules the close
   // `durationMs` (clamped) out in sim ticks. A second call while one is running just
@@ -2697,6 +2716,7 @@ export class GameServer {
   // -------------------------------------------------------------------------
 
   handleMessage(session: ClientSession, raw: string): void {
+    gameMetricsCounters().wsMessage('in');
     const receivedAtMs = Date.now();
     const verdict = consumeMsgToken(session.msgRate, receivedAtMs / 1000);
     if (verdict === 'kick') {
@@ -3075,6 +3095,7 @@ export class GameServer {
           void route
             .then((sent) => {
               if (sent) {
+                gameMetricsCounters().chatMessage();
                 this.chatLog.log({
                   accountId: session.accountId,
                   characterId: session.characterId,
@@ -4565,6 +4586,7 @@ export class GameServer {
           void route
             .then((sent) => {
               if (sent) {
+                gameMetricsCounters().chatMessage();
                 this.chatLog.log({
                   accountId: session.accountId,
                   characterId: session.characterId,
@@ -4607,6 +4629,7 @@ export class GameServer {
 
   private logChat(session: ClientSession, sent: import('../src/sim/sim').SentChat | null): void {
     if (!sent) return;
+    gameMetricsCounters().chatMessage();
     this.chatLog.log({
       accountId: session.accountId,
       characterId: session.characterId,
@@ -4899,6 +4922,7 @@ export class GameServer {
       }
       return;
     }
+    gameMetricsCounters().wsMessage('out');
     session.ws.send(payload);
   }
 }

--- a/server/http/game_metrics.ts
+++ b/server/http/game_metrics.ts
@@ -1,0 +1,226 @@
+// The game-state half of the /metrics exporter: the live game signals that are
+// already measured in-memory by GameServer (players/accounts/ws connections online,
+// sim entity count, achieved sim Hz, per-phase loop timing) plus the three
+// throughput counters (ws frames, chat messages, characters created), all
+// registered on the SAME prom-client registry the RED exporter builds
+// (server/http/metrics.ts). Prometheus attaches env / service=game / server_name at
+// scrape time, so nothing here emits those.
+//
+// GAUGES ARE READ AT SCRAPE TIME, NO DRIFT. Each gauge carries a collect() that
+// pulls the current value from the injected GameStateSource the moment
+// registry.metrics() runs, so a scrape always reflects live state and the game loop
+// never has to push a sample. COUNTERS are pushed from their emission sites through
+// the process-wide slot in server/http/game_signals.ts (installed by main.ts at
+// boot with the sink this function returns), exactly like the attack-signal counters.
+//
+// CARDINALITY IS BOUNDED BY DESIGN, same contract as server/http/metrics.ts: the
+// only label values are the fixed tick-phase names, the two per-phase stats
+// (p95, max), and the two ws directions (in, out). Nothing per-player (account id,
+// character id, name, ip) is ever a label. The tick-phase series count is fixed at
+// WOC_TICK_PHASES.length * 2, independent of the profiler's internal phase set.
+
+import { Counter, Gauge, type Registry } from 'prom-client';
+import type { GameMetricsCounters, WsMessageDirection } from './game_signals';
+
+/** Live characters online (joined sessions). */
+export const WOC_PLAYERS_ONLINE = 'woc_players_online';
+
+/** Distinct accounts online (a single account may hold several sessions). */
+export const WOC_ACCOUNTS_ONLINE = 'woc_accounts_online';
+
+/** Open WebSocket connections, including sockets connected but not yet joined. */
+export const WOC_WS_CONNECTIONS = 'woc_ws_connections';
+
+/** Active entities in the authoritative sim (players, mobs, projectiles, ...). */
+export const WOC_SIM_ENTITIES = 'woc_sim_entities';
+
+/** Achieved sim ticks per wall-clock second (target is 20 Hz). */
+export const WOC_SIM_TICK_HZ = 'woc_sim_tick_hz';
+
+/** Per-phase authoritative-loop timing in SECONDS, labeled by phase and stat (p95/max). */
+export const WOC_SIM_TICK_PHASE_SECONDS = 'woc_sim_tick_phase_seconds';
+
+/** Total ws frames handled, labeled by direction (in/out). */
+export const WOC_WS_MESSAGES_TOTAL = 'woc_ws_messages_total';
+
+/** Total player chat messages routed to other players (any channel). */
+export const WOC_CHAT_MESSAGES_TOTAL = 'woc_chat_messages_total';
+
+/** Total characters successfully created. */
+export const WOC_CHARACTERS_CREATED_TOTAL = 'woc_characters_created_total';
+
+/**
+ * The FIXED set of loop phases surfaced on woc_sim_tick_phase_seconds. These are
+ * GameServer's steady-state outer phases (see the TickProfiler construction in
+ * server/game.ts); the detailed sim.* sub-phases are captured only during an
+ * on-demand admin capture and are deliberately excluded to keep the exported
+ * series set small and bounded. A phase the source does not report is simply
+ * skipped, so the label set can never grow past this list.
+ */
+export const WOC_TICK_PHASES = [
+  'total',
+  'stale',
+  'tick',
+  'events',
+  'antibot',
+  'broadcast',
+  'bcastGrid',
+  'bcastSelf',
+  'social',
+] as const;
+
+/** The two per-phase stats exposed for each phase. */
+const TICK_PHASE_STATS = ['p95', 'max'] as const;
+
+/** Milliseconds per second, for the profiler's millisecond stats -> seconds conversion. */
+const MS_PER_SECOND = 1000;
+
+/** One phase's p95 and max, in MILLISECONDS (the unit GameServer's TickProfiler keeps). */
+export interface TickPhaseMillis {
+  p95: number;
+  max: number;
+}
+
+/**
+ * The live read surface the gauges pull from at scrape time. main.ts implements
+ * this over the boot GameServer and WebSocketServer; a test implements it with
+ * fixed values. Every method is a cheap live read: it must not block or throw.
+ */
+export interface GameStateSource {
+  /** Live characters online. */
+  playersOnline(): number;
+  /** Distinct accounts online. */
+  accountsOnline(): number;
+  /** Open WebSocket connections (joined or not). */
+  wsConnections(): number;
+  /** Active sim entity count. */
+  simEntities(): number;
+  /** Achieved sim Hz, or null while the rate meter is still warming up. */
+  simTickHz(): number | null;
+  /** Per-phase p95/max in MILLISECONDS, keyed by phase name; missing phases are skipped. */
+  tickPhaseMillis(): Record<string, TickPhaseMillis>;
+}
+
+/**
+ * Register the game-state gauges and throughput counters on `registry` and return
+ * the counter sink for main.ts to install process-wide via setGameMetricsCounters.
+ *
+ * The gauges are wired to `source` through per-metric collect() callbacks, so they
+ * read live at scrape time (no background sampling, no drift). The returned sink's
+ * methods never throw: a metric write must never break the path it measures, so
+ * each increment is guarded exactly like the attack-signal sink.
+ */
+export function registerGameStateMetrics(
+  registry: Registry,
+  source: GameStateSource,
+): GameMetricsCounters {
+  // Each gauge carries a collect() read at scrape time (registry.metrics()), so it
+  // reflects live state with no background sampling. `this` is the gauge instance
+  // (prom-client's CollectFunction<Gauge>), so collect() sets its own value.
+  new Gauge({
+    name: WOC_PLAYERS_ONLINE,
+    help: 'Live characters online (joined sessions).',
+    registers: [registry],
+    collect() {
+      this.set(source.playersOnline());
+    },
+  });
+
+  new Gauge({
+    name: WOC_ACCOUNTS_ONLINE,
+    help: 'Distinct accounts online.',
+    registers: [registry],
+    collect() {
+      this.set(source.accountsOnline());
+    },
+  });
+
+  new Gauge({
+    name: WOC_WS_CONNECTIONS,
+    help: 'Open WebSocket connections, including sockets connected but not yet joined.',
+    registers: [registry],
+    collect() {
+      this.set(source.wsConnections());
+    },
+  });
+
+  new Gauge({
+    name: WOC_SIM_ENTITIES,
+    help: 'Active entities in the authoritative sim.',
+    registers: [registry],
+    collect() {
+      this.set(source.simEntities());
+    },
+  });
+
+  new Gauge({
+    name: WOC_SIM_TICK_HZ,
+    help: 'Achieved sim ticks per wall-clock second (target 20). 0 while the rate meter warms up.',
+    registers: [registry],
+    collect() {
+      // The rate meter reports null for the first second of uptime; a scrape is a
+      // steady-state read, so map that brief warmup window to 0 rather than omit.
+      this.set(source.simTickHz() ?? 0);
+    },
+  });
+
+  new Gauge({
+    name: WOC_SIM_TICK_PHASE_SECONDS,
+    help: 'Per-phase authoritative-loop timing in seconds, by phase and stat (p95/max).',
+    labelNames: ['phase', 'stat'],
+    registers: [registry],
+    collect() {
+      const phases = source.tickPhaseMillis();
+      for (const phase of WOC_TICK_PHASES) {
+        const stats = phases[phase];
+        if (!stats) continue;
+        for (const stat of TICK_PHASE_STATS) {
+          this.set({ phase, stat }, stats[stat] / MS_PER_SECOND);
+        }
+      }
+    },
+  });
+
+  const wsMessages = new Counter({
+    name: WOC_WS_MESSAGES_TOTAL,
+    help: 'Total ws frames handled, labeled by direction (in, out).',
+    labelNames: ['direction'],
+    registers: [registry],
+  });
+
+  const chatMessages = new Counter({
+    name: WOC_CHAT_MESSAGES_TOTAL,
+    help: 'Total player chat messages routed to other players (any channel).',
+    registers: [registry],
+  });
+
+  const charactersCreated = new Counter({
+    name: WOC_CHARACTERS_CREATED_TOTAL,
+    help: 'Total characters successfully created.',
+    registers: [registry],
+  });
+
+  return {
+    wsMessage(direction: WsMessageDirection): void {
+      try {
+        wsMessages.inc({ direction });
+      } catch {
+        // Drop the sample rather than propagate into the message path.
+      }
+    },
+    chatMessage(): void {
+      try {
+        chatMessages.inc();
+      } catch {
+        // Drop the sample rather than propagate into the chat path.
+      }
+    },
+    characterCreated(): void {
+      try {
+        charactersCreated.inc();
+      } catch {
+        // Drop the sample rather than propagate into the create path.
+      }
+    },
+  };
+}

--- a/server/http/game_signals.ts
+++ b/server/http/game_signals.ts
@@ -1,0 +1,57 @@
+// The game-state counter seam: the throughput counters that live on the /metrics
+// exporter (woc_ws_messages_total, woc_chat_messages_total,
+// woc_characters_created_total) reach the exporter through this one process-wide
+// slot instead of each emission site (game.ts message dispatch, chat routing,
+// characters.ts create path) threading a sink through its constructors. main.ts
+// installs the real implementation (registerGameStateMetrics(...), so all three
+// counters share the exporter's one registry) once at boot, exactly like
+// setAttackSignalSink; before that, and in any test that never wires one, the slot
+// holds the no-op and every emission is dropped.
+//
+// This is the counter half of the game-state metrics. The gauges (players online,
+// tick rate, ...) are read live at scrape time and need no slot: they pull from a
+// GameStateSource the exporter registration captures. See server/http/game_metrics.ts.
+//
+// CARDINALITY IS BOUNDED BY DESIGN, same contract as server/http/metrics.ts: the
+// only label value here is the ws-message direction, one of a fixed two. Nothing
+// per-player (account id, character id, name, ip) is ever passed as a label.
+
+/** The two directions a ws frame is counted under: client-to-server or server-to-client. */
+export type WsMessageDirection = 'in' | 'out';
+
+/**
+ * The three game-state throughput emission hooks. Implementations must never
+ * throw: an observability write can never be allowed to break the message,
+ * chat, or character-create path it measures.
+ */
+export interface GameMetricsCounters {
+  /** One ws frame handled, in the given direction. */
+  wsMessage(direction: WsMessageDirection): void;
+  /** One player chat message routed to other players (any channel). */
+  chatMessage(): void;
+  /** One character successfully created. */
+  characterCreated(): void;
+}
+
+/** A sink that drops every signal; the slot default until boot wires the real one. */
+export const noopGameMetricsCounters: GameMetricsCounters = {
+  wsMessage() {},
+  chatMessage() {},
+  characterCreated() {},
+};
+
+let activeCounters: GameMetricsCounters = noopGameMetricsCounters;
+
+/**
+ * Install the process-wide game-state counter sink. Called once at boot with the
+ * exporter-backed implementation; tests install a recording fake and restore
+ * noopGameMetricsCounters when done.
+ */
+export function setGameMetricsCounters(sink: GameMetricsCounters): void {
+  activeCounters = sink;
+}
+
+/** The current game-state counter sink. Read at emission time, never captured at import. */
+export function gameMetricsCounters(): GameMetricsCounters {
+  return activeCounters;
+}

--- a/server/main.ts
+++ b/server/main.ts
@@ -135,6 +135,8 @@ import {
   createApiDispatcher,
   selectApiEntry,
 } from './http/dispatch';
+import { type GameStateSource, registerGameStateMetrics } from './http/game_metrics';
+import { setGameMetricsCounters } from './http/game_signals';
 import { handleLivez, handleMetricsGate, handleReadyz, markDraining } from './http/health';
 import { type Logger, logger } from './http/logger';
 import { createHttpMetrics } from './http/metrics';
@@ -2335,6 +2337,21 @@ export async function startServer(): Promise<http.Server> {
     bankBonusForAccount: async (id) => computeBankBonus(await bankBonusFactsForAccount(id)),
   });
   wsAuth.attachUpgrade(server, wss);
+
+  // Register the game-state gauges + throughput counters on the SAME registry the
+  // RED exporter built at module scope, then install the counter sink process-wide
+  // (mirrors setAttackSignalSink). Wired here, after `game` and `wss` exist, so the
+  // gauges read live state at scrape time; ws_connections is the raw open-socket
+  // count (joined or not), distinct from players_online (joined sessions).
+  const gameStateSource: GameStateSource = {
+    playersOnline: () => game.clients.size,
+    accountsOnline: () => game.liveAccountIds().size,
+    wsConnections: () => wss.clients.size,
+    simEntities: () => game.sim.entities.size,
+    simTickHz: () => game.simTickHz(),
+    tickPhaseMillis: () => game.tickPhaseMillis(),
+  };
+  setGameMetricsCounters(registerGameStateMetrics(httpMetrics.registry, gameStateSource));
 
   game.start();
   server.listen(config.port, () => {

--- a/tests/game_state_metrics.test.ts
+++ b/tests/game_state_metrics.test.ts
@@ -1,0 +1,148 @@
+// Wiring tests for the game-state metrics end to end through a live GameServer
+// (server/game.ts) and the exporter registration (server/http/game_metrics.ts):
+// the gauges reflect real joined sessions/accounts/entities at scrape time, and the
+// three throughput counters increment at their real emission sites (inbound ws
+// dispatch, outbound send, chat routing) via the process-wide slot
+// (server/http/game_signals.ts). The exporter's own unit tests
+// (tests/server/http/game_metrics.test.ts) pin the exposition shape; this file pins
+// that the GameServer actually feeds it.
+
+import { Registry } from 'prom-client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the db layer so no Postgres is needed (mirrors tests/snapshots.test.ts).
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+}));
+
+import { type ClientSession, GameServer } from '../server/game';
+import { type GameStateSource, registerGameStateMetrics } from '../server/http/game_metrics';
+import { noopGameMetricsCounters, setGameMetricsCounters } from '../server/http/game_signals';
+import type { PlayerClass } from '../src/sim/types';
+
+interface FakeClient {
+  sent: unknown[];
+  ws: { readyState: number; send: (payload: string) => void; bufferedAmount: number };
+}
+
+function fakeWs(): FakeClient {
+  const sent: unknown[] = [];
+  return {
+    sent,
+    ws: { readyState: 1, bufferedAmount: 0, send: (payload: string) => sent.push(payload) },
+  };
+}
+
+function join(
+  server: GameServer,
+  fc: FakeClient,
+  accountId: number,
+  characterId: number,
+  name: string,
+  cls: PlayerClass = 'warrior',
+): ClientSession {
+  const session = server.join(fc.ws as never, accountId, characterId, name, cls, null);
+  if ('error' in session) throw new Error(`join failed: ${session.error}`);
+  return session;
+}
+
+/** A source over the live server. wsConnections is bound to wss.clients.size in
+ *  main.ts (no WebSocketServer in a unit test), so here it stands in as the joined
+ *  session count; the exporter unit test pins its independent mapping. */
+function sourceOver(server: GameServer): GameStateSource {
+  return {
+    playersOnline: () => server.clients.size,
+    accountsOnline: () => server.liveAccountIds().size,
+    wsConnections: () => server.clients.size,
+    simEntities: () => server.sim.entities.size,
+    simTickHz: () => server.simTickHz(),
+    tickPhaseMillis: () => server.tickPhaseMillis(),
+  };
+}
+
+function value(text: string, re: RegExp): number {
+  const m = text.match(re);
+  return m ? Number(m[1]) : Number.NaN;
+}
+
+afterEach(() => {
+  setGameMetricsCounters(noopGameMetricsCounters);
+});
+
+describe('game-state metrics wiring: gauges reflect live GameServer state', () => {
+  it('reports players_online and accounts_online from the live sessions', async () => {
+    const server = new GameServer();
+    const registry = new Registry();
+    setGameMetricsCounters(registerGameStateMetrics(registry, sourceOver(server)));
+
+    // One live session per account (MAX_ACTIVE_SESSIONS_PER_ACCOUNT is 1), so three
+    // distinct accounts give three players across three accounts.
+    join(server, fakeWs(), 100, 1, 'Ayla');
+    join(server, fakeWs(), 200, 2, 'Bront');
+    join(server, fakeWs(), 300, 3, 'Cyra');
+
+    const text = await registry.metrics();
+    expect(value(text, /^woc_players_online (\d+)$/m)).toBe(3);
+    expect(value(text, /^woc_accounts_online (\d+)$/m)).toBe(3);
+    // Each joined player is a sim entity; the world may also hold mobs.
+    expect(value(text, /^woc_sim_entities (\d+)$/m)).toBeGreaterThanOrEqual(3);
+
+    server.stop();
+  });
+});
+
+describe('game-state metrics wiring: counters increment at their emission sites', () => {
+  it('counts inbound ws frames on handleMessage', async () => {
+    const server = new GameServer();
+    const registry = new Registry();
+    setGameMetricsCounters(registerGameStateMetrics(registry, sourceOver(server)));
+    const fc = fakeWs();
+    const session = join(server, fc, 100, 1, 'Ayla');
+
+    // Every inbound frame is counted at the top of handleMessage, even an empty
+    // object that dispatches to nothing.
+    server.handleMessage(session, '{}');
+    server.handleMessage(session, '{}');
+
+    const text = await registry.metrics();
+    expect(value(text, /^woc_ws_messages_total\{direction="in"\} (\d+)$/m)).toBe(2);
+
+    server.stop();
+  });
+
+  it('counts outbound ws frames when the server sends', async () => {
+    const server = new GameServer();
+    const registry = new Registry();
+    setGameMetricsCounters(registerGameStateMetrics(registry, sourceOver(server)));
+    join(server, fakeWs(), 100, 1, 'Ayla');
+    (server as unknown as { broadcastSnapshots(): void }).broadcastSnapshots();
+
+    const text = await registry.metrics();
+    expect(value(text, /^woc_ws_messages_total\{direction="out"\} (\d+)$/m)).toBeGreaterThan(0);
+
+    server.stop();
+  });
+
+  it('counts a routed chat message on the say channel', async () => {
+    const server = new GameServer();
+    const registry = new Registry();
+    setGameMetricsCounters(registerGameStateMetrics(registry, sourceOver(server)));
+    const fc = fakeWs();
+    const session = join(server, fc, 100, 1, 'Ayla');
+
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'chat', text: 'hello there' }));
+
+    const text = await registry.metrics();
+    expect(value(text, /^woc_chat_messages_total (\d+)$/m)).toBe(1);
+
+    server.stop();
+  });
+});

--- a/tests/server/characters.test.ts
+++ b/tests/server/characters.test.ts
@@ -28,6 +28,11 @@ import {
 } from '../../server/characters';
 import type { AccountModerationStatus, CharacterRow } from '../../server/db';
 import { compose } from '../../server/http/compose';
+import {
+  type GameMetricsCounters,
+  noopGameMetricsCounters,
+  setGameMetricsCounters,
+} from '../../server/http/game_signals';
 import { withErrors } from '../../server/http/middleware/with_errors';
 import type { Ctx, Method, Middleware } from '../../server/http/types';
 import {
@@ -211,6 +216,7 @@ afterEach(() => {
   resetCharactersRuntimeForTests();
   resetCharacterMutationRateLimits();
   resetRateLimitClock();
+  setGameMetricsCounters(noopGameMetricsCounters);
   vi.restoreAllMocks();
 });
 
@@ -469,6 +475,41 @@ describe('create handler', () => {
       skin: 2,
       forceRename: false,
     });
+  });
+
+  it('increments the characters-created counter on the created path', async () => {
+    let created = 0;
+    const counters: GameMetricsCounters = {
+      ...noopGameMetricsCounters,
+      characterCreated: () => {
+        created++;
+      },
+    };
+    setGameMetricsCounters(counters);
+    setCharactersDbForTests({ createCharacterCapped: async () => charRow({ id: 11 }) });
+    const res = await callHandler('POST', '/api/characters', {
+      account: { accountId: 7, scope: 'full' },
+      body: { name: 'Valid', class: 'warrior' },
+    });
+    expect(res.status).toBe(200);
+    expect(created).toBe(1);
+  });
+
+  it('does not increment the characters-created counter when creation is rejected', async () => {
+    let created = 0;
+    setGameMetricsCounters({
+      ...noopGameMetricsCounters,
+      characterCreated: () => {
+        created++;
+      },
+    });
+    setCharactersDbForTests({ createCharacterCapped: async () => null });
+    const res = await callHandler('POST', '/api/characters', {
+      account: { accountId: 7, scope: 'full' },
+      body: { name: 'Valid', class: 'warrior' },
+    });
+    expect(res.status).toBe(400);
+    expect(created).toBe(0);
   });
 
   it('400s an invalid name (normalizeCharName -> null)', async () => {

--- a/tests/server/http/game_metrics.test.ts
+++ b/tests/server/http/game_metrics.test.ts
@@ -1,0 +1,214 @@
+// Unit tests for the game-state half of the /metrics exporter
+// (server/http/game_metrics.ts): the woc_* gauges read live from an injected
+// GameStateSource at scrape time, and the three throughput counters pushed through
+// the returned sink. These pin the exposed metric NAMES as literals (a rename fails
+// the test, not just a constant swap), prove the gauges reflect the source at scrape
+// time, that the per-phase timing converts milliseconds to seconds and is bounded to
+// the fixed WOC_TICK_PHASES x {p95,max} label set (an unknown phase never becomes a
+// series), that the ws direction label is bounded to in/out, and that NO per-player
+// label (account/session/character/player/ip) ever appears.
+
+import { Registry } from 'prom-client';
+import { describe, expect, it } from 'vitest';
+import {
+  type GameStateSource,
+  registerGameStateMetrics,
+  type TickPhaseMillis,
+  WOC_ACCOUNTS_ONLINE,
+  WOC_CHARACTERS_CREATED_TOTAL,
+  WOC_CHAT_MESSAGES_TOTAL,
+  WOC_PLAYERS_ONLINE,
+  WOC_SIM_ENTITIES,
+  WOC_SIM_TICK_HZ,
+  WOC_SIM_TICK_PHASE_SECONDS,
+  WOC_TICK_PHASES,
+  WOC_WS_CONNECTIONS,
+  WOC_WS_MESSAGES_TOTAL,
+} from '../../../server/http/game_metrics';
+
+/** A GameStateSource returning fixed values; override any field per test. */
+function stubSource(overrides: Partial<GameStateSource> = {}): GameStateSource {
+  return {
+    playersOnline: () => 3,
+    accountsOnline: () => 2,
+    wsConnections: () => 5,
+    simEntities: () => 42,
+    simTickHz: () => 20,
+    tickPhaseMillis: () => ({}),
+    ...overrides,
+  };
+}
+
+/** Capture the numeric value on the first line matching `re` (one capture group). */
+function sampleValue(text: string, re: RegExp): string | undefined {
+  return text.match(re)?.[1];
+}
+
+/** Every woc_sim_tick_phase_seconds sample line (one per label combo). */
+function tickPhaseSeries(text: string): string[] {
+  return text.match(/^woc_sim_tick_phase_seconds\{[^}]*\} \d+(?:\.\d+)?$/gm) ?? [];
+}
+
+/** The set of distinct values of a given label across the whole exposition text. */
+function labelValues(text: string, label: string): Set<string> {
+  const values = new Set<string>();
+  const re = new RegExp(`${label}="([^"]*)"`, 'g');
+  for (const m of text.matchAll(re)) values.add(m[1]);
+  return values;
+}
+
+describe('registerGameStateMetrics: gauges read the source at scrape time', () => {
+  it('exposes every gauge under its exact exported name and value', async () => {
+    const registry = new Registry();
+    registerGameStateMetrics(registry, stubSource());
+    const text = await registry.metrics();
+
+    // Literal name pins: a rename of any gauge must fail this test.
+    expect(WOC_PLAYERS_ONLINE).toBe('woc_players_online');
+    expect(WOC_ACCOUNTS_ONLINE).toBe('woc_accounts_online');
+    expect(WOC_WS_CONNECTIONS).toBe('woc_ws_connections');
+    expect(WOC_SIM_ENTITIES).toBe('woc_sim_entities');
+    expect(WOC_SIM_TICK_HZ).toBe('woc_sim_tick_hz');
+
+    for (const name of [
+      WOC_PLAYERS_ONLINE,
+      WOC_ACCOUNTS_ONLINE,
+      WOC_WS_CONNECTIONS,
+      WOC_SIM_ENTITIES,
+      WOC_SIM_TICK_HZ,
+    ]) {
+      expect(text).toContain(`# TYPE ${name} gauge`);
+    }
+
+    expect(sampleValue(text, /^woc_players_online (\d+)$/m)).toBe('3');
+    expect(sampleValue(text, /^woc_accounts_online (\d+)$/m)).toBe('2');
+    expect(sampleValue(text, /^woc_ws_connections (\d+)$/m)).toBe('5');
+    expect(sampleValue(text, /^woc_sim_entities (\d+)$/m)).toBe('42');
+    expect(sampleValue(text, /^woc_sim_tick_hz (\d+)$/m)).toBe('20');
+  });
+
+  it('reflects a fresh source read on every scrape (no drift)', async () => {
+    const registry = new Registry();
+    let players = 1;
+    registerGameStateMetrics(registry, stubSource({ playersOnline: () => players }));
+
+    expect(sampleValue(await registry.metrics(), /^woc_players_online (\d+)$/m)).toBe('1');
+    players = 9;
+    expect(sampleValue(await registry.metrics(), /^woc_players_online (\d+)$/m)).toBe('9');
+  });
+
+  it('maps a null tick Hz (rate-meter warmup) to 0 rather than omitting the series', async () => {
+    const registry = new Registry();
+    registerGameStateMetrics(registry, stubSource({ simTickHz: () => null }));
+    const text = await registry.metrics();
+    expect(sampleValue(text, /^woc_sim_tick_hz (\d+)$/m)).toBe('0');
+  });
+});
+
+describe('registerGameStateMetrics: woc_sim_tick_phase_seconds', () => {
+  const phases: Record<string, TickPhaseMillis> = {
+    total: { p95: 3, max: 8 },
+    tick: { p95: 1.5, max: 4 },
+    // An unknown / detailed sub-phase the profiler may report: must be skipped so
+    // the exported label set can never grow past WOC_TICK_PHASES.
+    'sim.market': { p95: 99, max: 200 },
+  };
+
+  it('converts milliseconds to seconds and labels by phase and stat', async () => {
+    const registry = new Registry();
+    registerGameStateMetrics(registry, stubSource({ tickPhaseMillis: () => phases }));
+    const text = await registry.metrics();
+
+    expect(WOC_SIM_TICK_PHASE_SECONDS).toBe('woc_sim_tick_phase_seconds');
+    expect(text).toContain(`# TYPE ${WOC_SIM_TICK_PHASE_SECONDS} gauge`);
+
+    // 3 ms p95 -> 0.003 s, 8 ms max -> 0.008 s for the `total` phase.
+    expect(
+      sampleValue(text, /^woc_sim_tick_phase_seconds\{phase="total",stat="p95"\} (\S+)$/m),
+    ).toBe('0.003');
+    expect(
+      sampleValue(text, /^woc_sim_tick_phase_seconds\{phase="total",stat="max"\} (\S+)$/m),
+    ).toBe('0.008');
+    expect(
+      sampleValue(text, /^woc_sim_tick_phase_seconds\{phase="tick",stat="p95"\} (\S+)$/m),
+    ).toBe('0.0015');
+  });
+
+  it('keeps the label set bounded: only WOC_TICK_PHASES x {p95,max}, unknown phases skipped', async () => {
+    const registry = new Registry();
+    registerGameStateMetrics(registry, stubSource({ tickPhaseMillis: () => phases }));
+    const text = await registry.metrics();
+
+    // Two known phases reported (total, tick) x two stats = four series; the unknown
+    // sim.market phase is dropped.
+    expect(tickPhaseSeries(text)).toHaveLength(4);
+    expect(labelValues(text, 'phase')).toEqual(new Set(['total', 'tick']));
+    expect(labelValues(text, 'stat')).toEqual(new Set(['p95', 'max']));
+
+    // Every exposed phase label is a member of the fixed set (bounded by construction).
+    for (const phase of labelValues(text, 'phase')) {
+      expect(WOC_TICK_PHASES).toContain(phase);
+    }
+  });
+});
+
+describe('registerGameStateMetrics: throughput counters via the returned sink', () => {
+  it('exposes each counter under its exact exported name and increments through the sink', async () => {
+    const registry = new Registry();
+    const counters = registerGameStateMetrics(registry, stubSource());
+
+    expect(WOC_WS_MESSAGES_TOTAL).toBe('woc_ws_messages_total');
+    expect(WOC_CHAT_MESSAGES_TOTAL).toBe('woc_chat_messages_total');
+    expect(WOC_CHARACTERS_CREATED_TOTAL).toBe('woc_characters_created_total');
+
+    counters.wsMessage('in');
+    counters.wsMessage('in');
+    counters.wsMessage('out');
+    counters.chatMessage();
+    counters.characterCreated();
+    counters.characterCreated();
+    counters.characterCreated();
+
+    const text = await registry.metrics();
+    for (const name of [
+      WOC_WS_MESSAGES_TOTAL,
+      WOC_CHAT_MESSAGES_TOTAL,
+      WOC_CHARACTERS_CREATED_TOTAL,
+    ]) {
+      expect(text).toContain(`# TYPE ${name} counter`);
+    }
+
+    expect(sampleValue(text, /^woc_ws_messages_total\{direction="in"\} (\d+)$/m)).toBe('2');
+    expect(sampleValue(text, /^woc_ws_messages_total\{direction="out"\} (\d+)$/m)).toBe('1');
+    expect(sampleValue(text, /^woc_chat_messages_total (\d+)$/m)).toBe('1');
+    expect(sampleValue(text, /^woc_characters_created_total (\d+)$/m)).toBe('3');
+  });
+
+  it('bounds the ws direction label to in/out and emits no per-player label anywhere', async () => {
+    const registry = new Registry();
+    const counters = registerGameStateMetrics(
+      registry,
+      stubSource({ tickPhaseMillis: () => ({ total: { p95: 1, max: 2 } }) }),
+    );
+    counters.wsMessage('in');
+    counters.wsMessage('out');
+    const text = await registry.metrics();
+
+    expect(labelValues(text, 'direction')).toEqual(new Set(['in', 'out']));
+    // Cardinality rule: nothing request- or player-derived is ever a label.
+    for (const forbidden of [
+      'account',
+      'account_id',
+      'player',
+      'player_id',
+      'session',
+      'session_id',
+      'character',
+      'character_id',
+      'ip',
+      'name',
+    ]) {
+      expect(labelValues(text, forbidden).size).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
## What

Registers the game-state metrics on the existing `prom-client` registry served by `/metrics` (app-metrics plan, phase 2). These values are already measured in-memory; this exposes them.

New `woc_*` metrics:
- Gauges: `woc_players_online`, `woc_accounts_online`, `woc_ws_connections`, `woc_sim_entities`, `woc_sim_tick_hz`, `woc_sim_tick_phase_seconds{phase,stat}` (fixed 9-phase set x p95/max).
- Counters: `woc_ws_messages_total{direction}`, `woc_chat_messages_total`, `woc_characters_created_total`.

Gauges read live at scrape time via per-metric `collect()` over an injected `GameStateSource` (no background sampling, no drift). Counters are wired at their sources and guarded so they never throw into the measured path. No `env`/`service`/`server_name` labels from the game side (Prometheus attaches those at scrape).

## How

- `server/http/game_metrics.ts` (new): `registerGameStateMetrics(registry, source)` on the same registry `createHttpMetrics()` builds.
- `server/http/game_signals.ts` (new): process-wide counter slot, mirroring `attack_signals.ts` (no prom-client dependency).
- `server/game.ts`: public accessors `simTickHz()` / `tickPhaseMillis()`; counters wired at `handleMessage` / `sendRaw` / `logChat`.
- `server/characters.ts`: `woc_characters_created_total` on the created path (not on rejects).
- `server/main.ts`: builds the `GameStateSource` and installs the counter sink.

## Testing

- `tests/server/http/game_metrics.test.ts` (exporter unit: names, per-scrape reads, ms to s, bounded labels, no per-player labels, counter increments).
- `tests/game_state_metrics.test.ts` (end to end through a live GameServer: N clients -> `woc_players_online == N`).
- New cases in `tests/server/characters.test.ts`.

No behavior change; additive only. Metrics stay off until phase 1 enables `/metrics` (this just makes the series available once it is scraped).

Note: local `npm run gate` was red only from a Node 20 vs CI Node 22 `WebSocket` global difference in unrelated pre-existing tests; CI on Node 22 (`ci.yml`) is authoritative.
