### PR TITLE
fix(rewards): award Vale Cup win task points

### DIFF
--- a/server/daily_rewards.ts
+++ b/server/daily_rewards.ts
@@ -867,21 +867,24 @@ export class DailyRewardService {
     return awardedPoints;
   }
 
-  // Vale Cup daily task: ranked wins only. The game loop gates this to rated
-  // matches (the sim marks bot-backfilled and practice matches unrated); this
-  // method also no-ops losses so the task cannot award participation points.
-  // The match id keys the dedupe row, so one match yields at most one grant per
-  // account.
+  // Vale Cup daily task: wins only. Rated wins use the full task value; bot-filled
+  // and practice wins use a much smaller base so they can contribute without competing
+  // with real ranked match rewards. The match id keys the dedupe row, so one match
+  // yields at most one grant per account.
   async recordValeCupResult(
     accountId: number,
     result: {
       won: boolean;
       bracket: number;
       matchId: number;
+      rated?: boolean;
+      hasBots?: boolean;
+      practice?: boolean;
       completedAt?: Date;
     },
   ): Promise<number> {
     if (!result.won) return 0;
+    if (result.rated === false && result.hasBots !== true && result.practice !== true) return 0;
     const completedAt = result.completedAt ?? new Date();
     const { day, config } = await dailyRewardClock(completedAt);
     await this.db.ensureDay(day, config.prizePoolUsd, config.wocUsdPrice);
@@ -894,21 +897,36 @@ export class DailyRewardService {
     let awardedPoints = 0;
     for (const task of tasks) {
       const taskConfig = task.config ?? {};
-      const basePoints = numberConfig(taskConfig, 'winBasePoints', task.basePoints ?? task.points);
+      const rankedBasePoints = numberConfig(
+        taskConfig,
+        'winBasePoints',
+        task.basePoints ?? task.points,
+      );
+      const botFallbackPoints = Math.max(1, Math.floor(rankedBasePoints * 0.2));
+      const reducedMatch = result.hasBots === true || result.practice === true;
+      const basePoints = reducedMatch
+        ? numberConfig(taskConfig, 'botWinBasePoints', botFallbackPoints)
+        : rankedBasePoints;
       const { points, multiplier } = onlineMultiplierPoints(basePoints, taskConfig, onlineMinutes);
       if (points <= 0) continue;
+      const outcomeKey =
+        result.practice === true ? 'practice_win' : reducedMatch ? 'bot_win' : 'win';
       const recorded = await this.db.addPoints(
         day,
         accountId,
         'task',
         points,
-        `task:${task.taskId}:vale_cup:${result.matchId}:win`,
+        `task:${task.taskId}:vale_cup:${result.matchId}:${outcomeKey}`,
         {
           taskId: task.taskId,
           taskType: task.type,
           bracket: result.bracket,
           matchId: result.matchId,
           won: true,
+          matchType: result.practice === true ? 'practice' : reducedMatch ? 'bot' : 'ranked',
+          rated: result.rated !== false,
+          hasBots: result.hasBots === true,
+          practice: result.practice === true,
           onlineMinutes,
           multiplier,
           basePoints,

--- a/server/game.ts
+++ b/server/game.ts
@@ -4325,24 +4325,32 @@ export class GameServer {
           .catch((err) => console.error('daily reward delve chest task failed:', err));
       } else if (ev.type === 'vcupResult' && !ev.draw && ev.pid !== undefined) {
         // A decided Vale Cup bout. The match record survives through the
-        // 'over' aftermath, so the rated gate reads from it: bot-backfilled
-        // and practice matches are unrated in the sim and earn no credit.
-        // Bots have no session, so this.clients.get filters them naturally.
+        // 'over' aftermath. Rated wins earn the full task value; bot-filled
+        // and practice wins earn the reduced bot-match value. Bots have no
+        // session, so this.clients.get filters bot result events naturally.
         const s = this.clients.get(ev.pid);
         if (!s) continue;
         const match = this.sim.vcupMatchOf(ev.pid);
-        if (!match || !match.rated) continue;
+        if (!match) continue;
+        const practice = Boolean(match.practice);
+        const matchHasBots =
+          practice || [...match.rosterA, ...match.rosterB].some((player) => player.bot);
+        if (!match.rated && !matchHasBots) continue;
         if (!ev.won) continue;
         void dailyRewardService
           .recordValeCupResult(s.accountId, {
             won: true,
             bracket: match.bracket,
             matchId: match.id,
+            rated: match.rated,
+            hasBots: matchHasBots,
+            practice,
           })
           .then((points) => {
             if (points > 0) this.sendDailyRewardPointsGained(s, points);
           })
           .catch((err) => console.error('daily reward vale cup task failed:', err));
+        if (!match.rated) continue;
         // One card per decided match: every winner's vcupResult lands on the
         // same tick and the match-id dedupe key collapses them, so the first
         // one enumerates the whole winning side (linked teammates get tagged

--- a/tests/daily_rewards.test.ts
+++ b/tests/daily_rewards.test.ts
@@ -486,7 +486,7 @@ describe('daily rewards', () => {
     expect(db.events.filter((event) => event.kind === 'task')).toHaveLength(1);
   });
 
-  it('awards Vale Cup task points for ranked wins only', async () => {
+  it('awards Vale Cup task points for ranked wins and reduced bot-match wins', async () => {
     const db = new FakeDailyRewardDb();
     const service = new DailyRewardService(db);
     resetDailyRewardPriceCacheForTests();
@@ -495,15 +495,16 @@ describe('daily rewards', () => {
         {
           id: 'vale_cup_ranked_wins',
           type: 'vale_cup_result',
-          title: 'Win ranked Vale Cup matches',
-          description: 'Win ranked football matches today.',
+          title: 'Win Vale Cup matches',
+          description:
+            'Win Vale Cup football matches today. Bot-filled and practice wins award fewer points.',
           points: 25,
           basePoints: 25,
           sortOrder: 1,
           active: true,
           config: {
             winBasePoints: 25,
-            lossBasePoints: 10,
+            botWinBasePoints: 5,
             minMultiplier: 1,
             maxMultiplier: 3,
             minutesPerMultiplier: 30,
@@ -530,6 +531,17 @@ describe('daily rewards', () => {
     await service.recordValeCupResult(1, {
       won: true,
       bracket: 1,
+      matchId: 41,
+      rated: false,
+      hasBots: false,
+      completedAt: new Date('2026-06-30T13:00:30.000Z'),
+    });
+    expect(db.events.filter((event) => event.kind === 'task')).toHaveLength(0);
+    expect(db.score).toBe(0);
+
+    await service.recordValeCupResult(1, {
+      won: true,
+      bracket: 1,
       matchId: 42,
       completedAt: new Date('2026-06-30T13:01:00.000Z'),
     });
@@ -545,12 +557,76 @@ describe('daily rewards', () => {
         bracket: 1,
         matchId: 42,
         won: true,
+        matchType: 'ranked',
+        rated: true,
+        hasBots: false,
         onlineMinutes: 60,
         multiplier: 3,
         basePoints: 25,
       },
     });
     expect(db.score).toBe(75);
+
+    await service.recordValeCupResult(1, {
+      won: true,
+      bracket: 1,
+      matchId: 43,
+      rated: false,
+      hasBots: true,
+      completedAt: new Date('2026-06-30T13:02:00.000Z'),
+    });
+
+    const botEvent = db.events.filter((event) => event.kind === 'task')[1];
+    expect(botEvent).toMatchObject({
+      points: 15,
+      key: 'task:vale_cup_ranked_wins:vale_cup:43:bot_win',
+      meta: {
+        taskId: 'vale_cup_ranked_wins',
+        taskType: 'vale_cup_result',
+        bracket: 1,
+        matchId: 43,
+        won: true,
+        matchType: 'bot',
+        rated: false,
+        hasBots: true,
+        practice: false,
+        onlineMinutes: 60,
+        multiplier: 3,
+        basePoints: 5,
+      },
+    });
+    expect(db.score).toBe(90);
+
+    await service.recordValeCupResult(1, {
+      won: true,
+      bracket: 1,
+      matchId: 44,
+      rated: false,
+      hasBots: true,
+      practice: true,
+      completedAt: new Date('2026-06-30T13:03:00.000Z'),
+    });
+
+    const practiceEvent = db.events.filter((event) => event.kind === 'task')[2];
+    expect(practiceEvent).toMatchObject({
+      points: 15,
+      key: 'task:vale_cup_ranked_wins:vale_cup:44:practice_win',
+      meta: {
+        taskId: 'vale_cup_ranked_wins',
+        taskType: 'vale_cup_result',
+        bracket: 1,
+        matchId: 44,
+        won: true,
+        matchType: 'practice',
+        rated: false,
+        hasBots: true,
+        practice: true,
+        onlineMinutes: 60,
+        multiplier: 3,
+        basePoints: 5,
+      },
+    });
+    expect(db.score).toBe(105);
   });
 
   it('awards delve clear task points with level, tier, and online-time scaling', async () => {

--- a/tests/vale_cup_online.test.ts
+++ b/tests/vale_cup_online.test.ts
@@ -305,6 +305,9 @@ describe('vale cup: online integration (GameServer)', () => {
       won: true,
       bracket: 1,
       matchId: match.id,
+      rated: true,
+      hasBots: false,
+      practice: false,
     });
 
     // one Discord card for the decided match, tagging the winning side
@@ -336,7 +339,7 @@ describe('vale cup: online integration (GameServer)', () => {
     rewardSpy.mockRestore();
   });
 
-  it('gates the daily-reward arm: draws, matchless results, and unrated matches grant nothing', () => {
+  it('gates the daily-reward arm: draws and matchless results grant nothing, practice uses reduced path', () => {
     const rewardSpy = vi.spyOn(dailyRewardService, 'recordValeCupResult').mockResolvedValue(0);
     const fc = fakeWs();
     const session = joinServer(server, fc, 20, 'Gated');
@@ -349,13 +352,16 @@ describe('vale cup: online integration (GameServer)', () => {
     detect({ type: 'vcupResult', won: true, draw: false, pid: session.pid });
     expect(rewardSpy).not.toHaveBeenCalled();
 
-    // an unrated (bot-backfilled / practice) match earns neither points nor a card
-    const fakeMatch = {
+    // Private practice wins use the reduced bot-match task path and do not create a public card.
+    const fakeMatch: any = {
       id: 999,
       bracket: 1,
       rated: false,
+      practice: { ownerPid: session.pid, slot: 0 },
       teamA: [session.pid],
-      teamB: [],
+      teamB: [9999],
+      rosterA: [{ pid: session.pid, bot: false }],
+      rosterB: [{ pid: 9999, bot: true }],
       scoreA: 5,
       scoreB: 0,
       nationA: 'vale',
@@ -363,18 +369,50 @@ describe('vale cup: online integration (GameServer)', () => {
     };
     (server.sim as any).vcup.match = fakeMatch;
     detect({ type: 'vcupResult', won: true, draw: false, pid: session.pid });
-    expect(rewardSpy).not.toHaveBeenCalled();
-    expect(drainActivity().filter((c) => c.kind === 'vale_cup')).toHaveLength(0);
-
-    // A rated loss is still not a daily-reward task: the variant is ranked wins only.
-    fakeMatch.rated = true;
-    detect({ type: 'vcupResult', won: false, draw: false, pid: session.pid });
-    expect(rewardSpy).not.toHaveBeenCalled();
-    expect(drainActivity().filter((c) => c.kind === 'vale_cup')).toHaveLength(0);
-
-    // flipping the same match to a rated win proves the gate is ranked wins.
-    detect({ type: 'vcupResult', won: true, draw: false, pid: session.pid });
     expect(rewardSpy).toHaveBeenCalledTimes(1);
+    expect(rewardSpy).toHaveBeenLastCalledWith(
+      session.accountId,
+      expect.objectContaining({
+        won: true,
+        bracket: 1,
+        matchId: 999,
+        rated: false,
+        hasBots: true,
+        practice: true,
+      }),
+    );
+    expect(drainActivity().filter((c) => c.kind === 'vale_cup')).toHaveLength(0);
+
+    detect({ type: 'vcupResult', won: false, draw: false, pid: session.pid });
+    expect(rewardSpy).toHaveBeenCalledTimes(1);
+
+    // An unrated, non-practice bot-filled match earns reduced task points but no public card.
+    fakeMatch.practice = undefined;
+    detect({ type: 'vcupResult', won: true, draw: false, pid: session.pid });
+    expect(rewardSpy).toHaveBeenCalledTimes(2);
+    expect(rewardSpy).toHaveBeenLastCalledWith(
+      session.accountId,
+      expect.objectContaining({
+        won: true,
+        bracket: 1,
+        matchId: 999,
+        rated: false,
+        hasBots: true,
+        practice: false,
+      }),
+    );
+    expect(drainActivity().filter((c) => c.kind === 'vale_cup')).toHaveLength(0);
+
+    // A rated loss is still not a daily-reward task: the variant is wins only.
+    fakeMatch.rated = true;
+    fakeMatch.rosterB[0].bot = false;
+    detect({ type: 'vcupResult', won: false, draw: false, pid: session.pid });
+    expect(rewardSpy).toHaveBeenCalledTimes(2);
+    expect(drainActivity().filter((c) => c.kind === 'vale_cup')).toHaveLength(0);
+
+    // Flipping the same match to a rated win proves the full-value rated path.
+    detect({ type: 'vcupResult', won: true, draw: false, pid: session.pid });
+    expect(rewardSpy).toHaveBeenCalledTimes(3);
     expect(drainActivity().filter((c) => c.kind === 'vale_cup')).toHaveLength(1);
     (server.sim as any).vcup.match = null;
     rewardSpy.mockRestore();


### PR DESCRIPTION
## Summary

Updates the Vale Cup daily reward task so completed wins can award points outside the old ranked-only path.

- Rated Vale Cup wins use the full `winBasePoints` value.
- Bot-filled and practice wins use the reduced `botWinBasePoints` value, falling back to 20% of full win points if unset.
- Losses, draws, and unrated non-bot results award no points.
- Adds metadata for rated/bot/practice match type and covers the server event bridge with focused tests.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit --pretty false`
  - `npx vitest run tests/daily_rewards.test.ts tests/vale_cup_online.test.ts`
  - `git diff --check`
- Manual steps: N/A. Server-side reward logic only.

## Screenshots / recordings

N/A. No UI changes.

---

## Checklist

### Quality

- [x] **Tests pass.** Focused daily reward and Vale Cup server tests pass.
- [x] **Typecheck passes.** `npx tsc --noEmit --pretty false` is clean.
- [ ] **Builds succeed.** Not run, server logic/test-only change.

### Cross-platform

- [ ] **Tested on desktop and mobile.** N/A, no UI changes.
- [ ] **Accessible.** N/A, no UI changes.

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.** N/A.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters. N/A.
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at the client boundary in this same change. N/A.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
