### PR TITLE
feat(server): business + client-perf aggregates on /metrics (Phases 3-4)

### DIFF
--- a/server/client_perf_metrics_db.ts
+++ b/server/client_perf_metrics_db.ts
@@ -1,0 +1,174 @@
+import { pool } from './db';
+
+// Read-side aggregate for the client-perf /metrics gauges (Phase 4). This is NEW
+// SQL (it does not exist in admin_db.ts, whose clientPerfSummary aggregates a
+// different, uncapped shape for the admin dashboard), and its whole job is to
+// ENFORCE the Prometheus cardinality cap IN THE QUERY, not to hope the data is
+// small:
+//   - release window: only the CURRENT and PREVIOUS release_version by recency
+//     (at most two release label values), everything older is dropped.
+//   - GPU bucket: only the TOP-N gl_renderer_bucket by sample volume; every other
+//     bucket is folded into a single 'other' row.
+//   - time window: only rows in the last `hours` (default 1h), so the gauges track
+//     "now" and the read hits client_perf_reports_release_created / _gpu_created.
+// The resulting series count is bounded by 2 releases * (N + 1) GPU buckets,
+// regardless of how many distinct releases or GPUs the table actually holds.
+//
+// SQL lives only in db.ts / *_db.ts (server/CLAUDE.md invariant); the exporter
+// (server/http/client_perf_metrics.ts) does zero SQL and only shapes these rows
+// into gauges.
+
+/** One aggregated client-perf row for a (release_version, gl_renderer_bucket) pair. */
+export interface ClientPerfRow {
+  releaseVersion: string;
+  glRendererBucket: string;
+  /** Number of reports behind this row (used for a weighted long-frame rate). */
+  sampleCount: number;
+  /** Median (p50) of fps_avg across the row's reports. */
+  medianFps: number;
+  /** Median (p50) of frame_p95_ms across the row's reports, in SECONDS. */
+  frameP95Seconds: number;
+  /** Long frames per reported frame: sum(long_frame_count) / sum(sampled frames). */
+  longFramesRate: number;
+}
+
+/** Options for {@link clientPerfMetricRows}; all bounded and defaulted. */
+export interface ClientPerfMetricsOptions {
+  /** Recent window in hours (default 1). Clamped to [1, 24]. */
+  hours?: number;
+  /** Max distinct GPU buckets kept per release before 'other' (default 8). Clamped to [1, 25]. */
+  topGpuBuckets?: number;
+}
+
+/** The minimal query surface both the shared pool and a test pool satisfy. */
+export interface Queryable {
+  query(text: string, params: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
+}
+
+/** The label value every non-top GPU bucket is folded into. */
+export const OTHER_GPU_BUCKET = 'other';
+
+/** The number of releases the window keeps: the current and the previous one. */
+export const RELEASE_WINDOW = 2;
+
+const MS_PER_SECOND = 1000;
+
+function cleanHours(hours: number | undefined): number {
+  if (hours === undefined || !Number.isFinite(hours)) return 1;
+  return Math.min(24, Math.max(1, Math.floor(hours)));
+}
+
+function cleanTopGpuBuckets(n: number | undefined): number {
+  if (n === undefined || !Number.isFinite(n)) return 8;
+  return Math.min(25, Math.max(1, Math.floor(n)));
+}
+
+/**
+ * The capped aggregate SQL, parameterized by $1 = hours, $2 = release window,
+ * $3 = top-N GPU buckets. Exported (with mapClientPerfRow / runClientPerfMetricRows)
+ * so the SQL cap is exercised by an integration test against a real Postgres pool
+ * without reaching through the module-level shared pool.
+ */
+export const CLIENT_PERF_METRICS_SQL = `
+    WITH recent AS (
+      SELECT id, release_version, gl_renderer_bucket, fps_avg, frame_p95_ms,
+             long_frame_count, long_task_count
+      FROM client_perf_reports
+      WHERE created_at > now() - ($1 || ' hours')::interval
+    ),
+    -- The current + previous release, defined as the RELEASE_WINDOW releases with the
+    -- most recent activity in the window (ranked by their newest report id, a
+    -- monotonic proxy for recency). Older releases are dropped here, so
+    -- release_version can take at most RELEASE_WINDOW distinct label values.
+    top_releases AS (
+      SELECT release_version
+      FROM (
+        SELECT release_version,
+               row_number() OVER (ORDER BY max(id) DESC) AS rn
+        FROM recent
+        GROUP BY release_version
+      ) ranked
+      WHERE rn <= $2
+    ),
+    scoped AS (
+      SELECT * FROM recent WHERE release_version IN (SELECT release_version FROM top_releases)
+    ),
+    -- Rank GPU buckets WITHIN each release by sample volume; keep the top N, fold the
+    -- rest to 'other'. The fold is what makes the GPU label bounded regardless of how
+    -- many distinct buckets exist.
+    ranked_gpu AS (
+      SELECT release_version, gl_renderer_bucket,
+             row_number() OVER (
+               PARTITION BY release_version
+               ORDER BY count(*) DESC, gl_renderer_bucket ASC
+             ) AS rn
+      FROM scoped
+      GROUP BY release_version, gl_renderer_bucket
+    ),
+    labeled AS (
+      SELECT s.release_version,
+             CASE WHEN rg.rn <= $3 THEN s.gl_renderer_bucket ELSE '${OTHER_GPU_BUCKET}' END AS gpu_bucket,
+             s.fps_avg, s.frame_p95_ms, s.long_frame_count, s.long_task_count
+      FROM scoped s
+      JOIN ranked_gpu rg
+        ON rg.release_version = s.release_version
+       AND rg.gl_renderer_bucket = s.gl_renderer_bucket
+    )
+    SELECT
+      release_version,
+      gpu_bucket,
+      count(*)::int AS sample_count,
+      COALESCE(percentile_cont(0.5) WITHIN GROUP (ORDER BY fps_avg), 0)::real AS median_fps,
+      COALESCE(percentile_cont(0.5) WITHIN GROUP (ORDER BY frame_p95_ms), 0)::real AS median_frame_p95_ms,
+      COALESCE(sum(long_frame_count), 0)::bigint AS long_frames,
+      COALESCE(sum(long_task_count), 0)::bigint AS sampled_frames
+    FROM labeled
+    GROUP BY release_version, gpu_bucket
+    ORDER BY release_version, gpu_bucket
+    `;
+
+/** Map one raw aggregate row onto a ClientPerfRow (ms -> seconds, weighted rate). */
+export function mapClientPerfRow(r: Record<string, unknown>): ClientPerfRow {
+  const longFrames = Number(r.long_frames);
+  const sampledFrames = Number(r.sampled_frames);
+  return {
+    releaseVersion: String(r.release_version ?? ''),
+    glRendererBucket: String(r.gpu_bucket ?? ''),
+    sampleCount: Number(r.sample_count),
+    medianFps: Number(r.median_fps),
+    frameP95Seconds: Number(r.median_frame_p95_ms) / MS_PER_SECOND,
+    longFramesRate: sampledFrames > 0 ? longFrames / sampledFrames : 0,
+  };
+}
+
+/**
+ * Run the capped aggregate against any Queryable and map the rows. Used by the
+ * shared-pool entry point below and directly by the integration test's own pool.
+ */
+export async function runClientPerfMetricRows(
+  db: Queryable,
+  options: ClientPerfMetricsOptions = {},
+): Promise<ClientPerfRow[]> {
+  const hours = cleanHours(options.hours);
+  const topGpuBuckets = cleanTopGpuBuckets(options.topGpuBuckets);
+  const res = await db.query(CLIENT_PERF_METRICS_SQL, [
+    String(hours),
+    RELEASE_WINDOW,
+    topGpuBuckets,
+  ]);
+  return res.rows.map(mapClientPerfRow);
+}
+
+/**
+ * Aggregate recent client_perf_reports into the bounded gauge rows. The cap is
+ * enforced in SQL: at most RELEASE_WINDOW releases (current + previous by recency),
+ * and within each release at most `topGpuBuckets` real GPU buckets plus one 'other'
+ * fold, all over the last `hours`. Long frames per frame uses reported frame counts
+ * where present (long_task_count is the sampled-frame proxy the client reports), so
+ * the rate is a true fraction rather than a raw per-report sum.
+ */
+export async function clientPerfMetricRows(
+  options: ClientPerfMetricsOptions = {},
+): Promise<ClientPerfRow[]> {
+  return runClientPerfMetricRows(pool, options);
+}

--- a/server/http/business_metrics.ts
+++ b/server/http/business_metrics.ts
@@ -1,0 +1,173 @@
+// The business-aggregate half of the /metrics exporter (Phase 3): signups,
+// characters, active sessions, average playtime, and peak online, published as
+// bounded prom-client gauges on the SAME registry the RED exporter builds
+// (server/http/metrics.ts), exactly like the game-state half
+// (server/http/game_metrics.ts). Prometheus attaches env / service=game /
+// server_name at scrape time, so nothing here emits those.
+//
+// SAMPLED ON AN INTERVAL, CACHED, PUBLISHED AT SCRAPE TIME. Unlike the game-state
+// gauges (cheap in-memory live reads), each value here comes from a Postgres
+// aggregate, so a PeriodicCollector (server/http/periodic_collector.ts) runs the
+// ONE overviewCounts() batch on a 30-60s interval and caches it; the gauges publish
+// the cached snapshot when registry.metrics() runs. A scrape never hits the DB, so a
+// scrape storm can never become a query storm. Before the first refresh (or after a
+// failed one) the collector holds null and the gauges publish nothing.
+//
+// SQL IS REUSED, NOT DUPLICATED. Every value comes from overviewCounts() in
+// server/admin_db.ts (the admin dashboard's overview query); this module only maps
+// its fields onto gauges. No SQL lives here.
+//
+// CARDINALITY IS BOUNDED BY DESIGN, same contract as server/http/metrics.ts: the
+// only label is `window`, drawn from a fixed small set (today/week/month, all_time).
+// Nothing per-entity (account id, character id, name) is ever a label.
+
+import { Gauge, type Registry } from 'prom-client';
+import type { OverviewCounts } from '../admin_db';
+import { overviewCounts } from '../admin_db';
+import { PeriodicCollector } from './periodic_collector';
+
+/** Total registered accounts. */
+export const WOC_ACCOUNTS_TOTAL = 'woc_accounts_total';
+
+/** New account signups within a fixed window, labeled by `window` (today/week/month). */
+export const WOC_SIGNUPS_TOTAL = 'woc_signups_total';
+
+/** Total created characters. */
+export const WOC_CHARACTERS_TOTAL = 'woc_characters_total';
+
+/** Distinct accounts with an active play session in a window, labeled by `window` (today/week/month). */
+export const WOC_ACTIVE_SESSIONS = 'woc_active_sessions';
+
+/** Average lifetime playtime per account, in SECONDS. */
+export const WOC_AVG_PLAYTIME_SECONDS = 'woc_avg_playtime_seconds';
+
+/** Peak concurrent players online in a window, labeled by `window` (today/all_time). */
+export const WOC_PEAK_ONLINE = 'woc_peak_online';
+
+/**
+ * How often the collector re-runs overviewCounts(). 60s keeps the query cost
+ * negligible (one batched read per minute, independent of scrape frequency) while
+ * staying fresh enough for a business dashboard, and matches ADMIN_ONLINE_SAMPLE_MS
+ * so the peak-online sample it reads is at most one interval stale.
+ */
+export const BUSINESS_METRICS_REFRESH_MS = 60_000;
+
+/**
+ * The fixed signup windows exposed on woc_signups_total, mapped to their
+ * OverviewCounts field. This list (not the data) bounds the `window` label set.
+ */
+const SIGNUP_WINDOWS: ReadonlyArray<{ window: string; field: keyof OverviewCounts }> = [
+  { window: 'today', field: 'accountsToday' },
+  { window: 'week', field: 'accountsWeek' },
+  { window: 'month', field: 'accountsMonth' },
+];
+
+/** The fixed active-session windows exposed on woc_active_sessions. */
+const ACTIVE_SESSION_WINDOWS: ReadonlyArray<{ window: string; field: keyof OverviewCounts }> = [
+  { window: 'today', field: 'activeAccountsToday' },
+  { window: 'week', field: 'activeAccountsWeek' },
+  { window: 'month', field: 'activeAccountsMonth' },
+];
+
+/** The fixed peak-online windows exposed on woc_peak_online. */
+const PEAK_ONLINE_WINDOWS: ReadonlyArray<{ window: string; field: keyof OverviewCounts }> = [
+  { window: 'today', field: 'peakOnlineToday' },
+  { window: 'all_time', field: 'peakOnlineAllTime' },
+];
+
+/** The handle main.ts holds to start/stop the interval; tests refresh() it directly. */
+export type BusinessMetricsCollector = PeriodicCollector<OverviewCounts>;
+
+/**
+ * Register the business-aggregate gauges on `registry` and return the collector
+ * that feeds them. The gauges publish the collector's CACHED snapshot at scrape
+ * time (nothing if it is still null), so registry.metrics() never queries Postgres.
+ * Boot (main.ts) calls collector.start() to begin the interval; a test injects a
+ * fake query and calls refresh() by hand.
+ *
+ * @param registry the shared exporter registry.
+ * @param query the aggregate source; defaults to overviewCounts (admin_db.ts). A
+ *   test passes a fake so no Postgres is needed.
+ * @param intervalMs the refresh cadence; defaults to BUSINESS_METRICS_REFRESH_MS.
+ */
+export function registerBusinessMetrics(
+  registry: Registry,
+  query: () => Promise<OverviewCounts> = overviewCounts,
+  intervalMs: number = BUSINESS_METRICS_REFRESH_MS,
+): BusinessMetricsCollector {
+  const collector = new PeriodicCollector(query, intervalMs);
+
+  new Gauge({
+    name: WOC_ACCOUNTS_TOTAL,
+    help: 'Total registered accounts.',
+    registers: [registry],
+    collect() {
+      const counts = collector.current();
+      if (counts) this.set(counts.accounts);
+    },
+  });
+
+  new Gauge({
+    name: WOC_SIGNUPS_TOTAL,
+    help: 'New account signups within a fixed window, by window (today/week/month).',
+    labelNames: ['window'],
+    registers: [registry],
+    collect() {
+      const counts = collector.current();
+      if (!counts) return;
+      for (const { window, field } of SIGNUP_WINDOWS) {
+        this.set({ window }, counts[field]);
+      }
+    },
+  });
+
+  new Gauge({
+    name: WOC_CHARACTERS_TOTAL,
+    help: 'Total created characters.',
+    registers: [registry],
+    collect() {
+      const counts = collector.current();
+      if (counts) this.set(counts.characters);
+    },
+  });
+
+  new Gauge({
+    name: WOC_ACTIVE_SESSIONS,
+    help: 'Distinct accounts with an active play session in a window, by window (today/week/month).',
+    labelNames: ['window'],
+    registers: [registry],
+    collect() {
+      const counts = collector.current();
+      if (!counts) return;
+      for (const { window, field } of ACTIVE_SESSION_WINDOWS) {
+        this.set({ window }, counts[field]);
+      }
+    },
+  });
+
+  new Gauge({
+    name: WOC_AVG_PLAYTIME_SECONDS,
+    help: 'Average lifetime playtime per account, in seconds.',
+    registers: [registry],
+    collect() {
+      const counts = collector.current();
+      if (counts) this.set(counts.avgPlaytimeSeconds);
+    },
+  });
+
+  new Gauge({
+    name: WOC_PEAK_ONLINE,
+    help: 'Peak concurrent players online in a window, by window (today/all_time).',
+    labelNames: ['window'],
+    registers: [registry],
+    collect() {
+      const counts = collector.current();
+      if (!counts) return;
+      for (const { window, field } of PEAK_ONLINE_WINDOWS) {
+        this.set({ window }, counts[field]);
+      }
+    },
+  });
+
+  return collector;
+}

--- a/server/http/client_perf_metrics.ts
+++ b/server/http/client_perf_metrics.ts
@@ -1,0 +1,123 @@
+// The client-perf half of the /metrics exporter (Phase 4): real-user FPS, frame
+// p95, and long-frame rate aggregated from client_perf_reports, published as
+// BOUNDED prom-client gauges on the SAME registry the RED exporter builds
+// (server/http/metrics.ts), like the game-state and business halves. Prometheus
+// attaches env / service=game / server_name at scrape time, so nothing here emits
+// those.
+//
+// SAMPLED ON AN INTERVAL, CACHED, PUBLISHED AT SCRAPE TIME. Each value is a Postgres
+// aggregate over the last hour, so a PeriodicCollector (periodic_collector.ts) runs
+// the ONE capped query (client_perf_metrics_db.ts) on a 60s interval and caches the
+// rows; the gauges publish the cached snapshot when registry.metrics() runs. A
+// scrape never hits the DB. Before the first refresh the snapshot is null and the
+// gauges publish nothing.
+//
+// CARDINALITY IS BOUNDED IN THE QUERY, NOT HERE. clientPerfMetricRows enforces the
+// cap (at most current + previous release, top-N gl_renderer_bucket + 'other', last
+// 1h), so the label set is bounded by 2 * (N + 1) series per gauge no matter how
+// many releases or GPUs exist. This module trusts that cap: it reset()s each gauge
+// per publish and re-sets only the capped rows, so a bucket that drops out of the
+// top-N in a later window does not leave a stale series behind. Nothing per-session
+// (session id, account id, character id, ip) is ever a label.
+
+import { Gauge, type Registry } from 'prom-client';
+import type { ClientPerfRow } from '../client_perf_metrics_db';
+import { clientPerfMetricRows } from '../client_perf_metrics_db';
+import { PeriodicCollector } from './periodic_collector';
+
+/** Median real-user FPS, labeled by release_version and gl_renderer_bucket. */
+export const WOC_CLIENT_FPS = 'woc_client_fps';
+
+/** Median real-user frame p95 in SECONDS, labeled by release_version and gl_renderer_bucket. */
+export const WOC_CLIENT_FRAME_P95_SECONDS = 'woc_client_frame_p95_seconds';
+
+/** Long frames per reported frame, labeled by release_version and gl_renderer_bucket. */
+export const WOC_CLIENT_LONG_FRAMES_RATE = 'woc_client_long_frames_rate';
+
+/** The bounded label set shared by all three gauges. */
+const CLIENT_PERF_LABELS = ['release_version', 'gl_renderer_bucket'] as const;
+
+/**
+ * How often the collector re-runs the capped aggregate. 60s keeps the query cost
+ * negligible (one batched read per minute, independent of scrape frequency) while
+ * tracking "now" closely enough for a real-user perf dashboard.
+ */
+export const CLIENT_PERF_METRICS_REFRESH_MS = 60_000;
+
+/** The handle main.ts holds to start/stop the interval; tests refresh() it directly. */
+export type ClientPerfMetricsCollector = PeriodicCollector<ClientPerfRow[]>;
+
+/**
+ * Register the client-perf gauges on `registry` and return the collector that feeds
+ * them. The gauges publish the collector's CACHED rows at scrape time (nothing while
+ * null), so registry.metrics() never queries Postgres. Each publish reset()s the
+ * gauge and re-sets only the capped rows, so a series never lingers past the window
+ * in which its bucket was in the top-N. Boot (main.ts) calls collector.start(); a
+ * test injects a fake query and calls refresh() by hand.
+ *
+ * @param registry the shared exporter registry.
+ * @param query the aggregate source; defaults to clientPerfMetricRows
+ *   (client_perf_metrics_db.ts). A test passes a fake so no Postgres is needed.
+ * @param intervalMs the refresh cadence; defaults to CLIENT_PERF_METRICS_REFRESH_MS.
+ */
+export function registerClientPerfMetrics(
+  registry: Registry,
+  query: () => Promise<ClientPerfRow[]> = () => clientPerfMetricRows(),
+  intervalMs: number = CLIENT_PERF_METRICS_REFRESH_MS,
+): ClientPerfMetricsCollector {
+  const collector = new PeriodicCollector(query, intervalMs);
+
+  // Each gauge registers itself on `registry` at construction (registers: [registry])
+  // and is driven only by its own collect(), so nothing needs to hold the instance.
+  new Gauge({
+    name: WOC_CLIENT_FPS,
+    help: 'Median real-user FPS, by release_version and gl_renderer_bucket (current + previous release, top GPU buckets + other, last hour).',
+    labelNames: CLIENT_PERF_LABELS,
+    registers: [registry],
+    collect() {
+      publish(this, collector.current(), (row) => row.medianFps);
+    },
+  });
+
+  new Gauge({
+    name: WOC_CLIENT_FRAME_P95_SECONDS,
+    help: 'Median real-user frame p95 in seconds, by release_version and gl_renderer_bucket.',
+    labelNames: CLIENT_PERF_LABELS,
+    registers: [registry],
+    collect() {
+      publish(this, collector.current(), (row) => row.frameP95Seconds);
+    },
+  });
+
+  new Gauge({
+    name: WOC_CLIENT_LONG_FRAMES_RATE,
+    help: 'Long frames per reported frame, by release_version and gl_renderer_bucket.',
+    labelNames: CLIENT_PERF_LABELS,
+    registers: [registry],
+    collect() {
+      publish(this, collector.current(), (row) => row.longFramesRate);
+    },
+  });
+
+  return collector;
+}
+
+/**
+ * Publish one gauge from the cached rows: clear the previous label combinations,
+ * then set the given value for each current row. Skips entirely while the snapshot
+ * is null (before the first refresh), leaving the gauge empty rather than zeroed.
+ */
+function publish(
+  gauge: Gauge<(typeof CLIENT_PERF_LABELS)[number]>,
+  rows: ClientPerfRow[] | null,
+  value: (row: ClientPerfRow) => number,
+): void {
+  if (!rows) return;
+  gauge.reset();
+  for (const row of rows) {
+    gauge.set(
+      { release_version: row.releaseVersion, gl_renderer_bucket: row.glRendererBucket },
+      value(row),
+    );
+  }
+}

--- a/server/http/periodic_collector.ts
+++ b/server/http/periodic_collector.ts
@@ -1,0 +1,79 @@
+// A tiny periodic-cache primitive shared by the app-aggregate /metrics collectors
+// (business aggregates in server/http/business_metrics.ts, client-perf aggregates
+// in server/http/client_perf_metrics.ts). Both follow the same contract: run one
+// bounded aggregate query on a fixed interval, cache the result, and let the
+// prom-client gauges publish the CACHED snapshot at scrape time. The DB is never
+// touched per scrape, so a scrape storm can never turn into a query storm.
+//
+// This is deliberately NOT the game-state pattern (server/http/game_metrics.ts),
+// where every gauge's collect() reads a cheap in-memory source live at scrape time.
+// A Postgres aggregate is not a cheap live read, so these collectors sample on an
+// interval instead and the gauges read the last sample.
+//
+// The refresh is fire-and-forget and self-guarded: a failed query keeps the last
+// good snapshot (or the null start state) rather than throwing into the timer, so a
+// transient DB blip never crashes the process or wedges the interval.
+
+/**
+ * A periodic collector: it holds the latest snapshot of a bounded aggregate query,
+ * refreshes it on a fixed interval, and exposes the cached value for the gauges to
+ * publish. Construct it with the async query and the interval; call start() at boot
+ * (main.ts) and stop() on shutdown. Tests drive refresh() directly and never start
+ * the timer.
+ */
+export class PeriodicCollector<T> {
+  private snapshot: T | null = null;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  /**
+   * @param query the bounded aggregate to run; its result becomes the new snapshot.
+   * @param intervalMs how often to refresh (30-60s for these collectors).
+   * @param onError optional sink for a refresh failure (defaults to console.error);
+   *   a failure is swallowed after this so it never propagates into the timer.
+   */
+  constructor(
+    private readonly query: () => Promise<T>,
+    private readonly intervalMs: number,
+    private readonly onError: (err: unknown) => void = (err) =>
+      console.error('metrics collector refresh failed:', err),
+  ) {}
+
+  /** The latest cached snapshot, or null before the first successful refresh. */
+  current(): T | null {
+    return this.snapshot;
+  }
+
+  /**
+   * Run the query once and cache the result. Never throws: a failed query is
+   * reported via onError and leaves the previous snapshot in place. Returns the
+   * snapshot after the attempt (unchanged on failure) so a test can await it.
+   */
+  async refresh(): Promise<T | null> {
+    try {
+      this.snapshot = await this.query();
+    } catch (err) {
+      this.onError(err);
+    }
+    return this.snapshot;
+  }
+
+  /**
+   * Kick off an immediate refresh and then repeat every intervalMs. The interval is
+   * unref()'d so it never keeps the process alive on its own (mirrors the other boot
+   * intervals in main.ts). Idempotent: a second start() is a no-op while running.
+   */
+  start(): void {
+    if (this.timer) return;
+    void this.refresh();
+    this.timer = setInterval(() => void this.refresh(), this.intervalMs);
+    this.timer.unref();
+  }
+
+  /** Stop the interval. Safe to call when never started or already stopped. */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/server/main.ts
+++ b/server/main.ts
@@ -127,7 +127,9 @@ import { configureGithubContributorsRuntime, topContributors } from './github_co
 import { pruneGitHubOAuthStates } from './github_db';
 import { createAccessLogSink } from './http/access_log';
 import { setAttackSignalSink } from './http/attack_signals';
+import { registerBusinessMetrics } from './http/business_metrics';
 import { handleClientError } from './http/client_error';
+import { registerClientPerfMetrics } from './http/client_perf_metrics';
 import { type Config, DEFAULT_DISPATCH, type DispatchMode, loadConfig } from './http/config';
 import {
   type ApiDelegate,
@@ -2353,6 +2355,16 @@ export async function startServer(): Promise<http.Server> {
   };
   setGameMetricsCounters(registerGameStateMetrics(httpMetrics.registry, gameStateSource));
 
+  // The app-aggregate /metrics collectors (Phase 3 business, Phase 4 client-perf):
+  // each registers bounded gauges on the SAME exporter registry and runs ONE cached
+  // Postgres aggregate on a fixed interval, so a scrape publishes the cached snapshot
+  // and never queries the DB. start() kicks off an immediate refresh plus the
+  // interval (both unref()'d); shutdown stops them below.
+  const businessMetrics = registerBusinessMetrics(httpMetrics.registry);
+  const clientPerfMetrics = registerClientPerfMetrics(httpMetrics.registry);
+  businessMetrics.start();
+  clientPerfMetrics.start();
+
   game.start();
   server.listen(config.port, () => {
     console.log(`World of ClaudeCraft server listening on http://localhost:${config.port}`);
@@ -2366,6 +2378,11 @@ export async function startServer(): Promise<http.Server> {
     // /livez keep working through the drain).
     markDraining();
     console.log('shutting down: saving characters...');
+    // Stop the app-aggregate metric collectors so no refresh query races the pool
+    // close below (their intervals are unref()'d, but an in-flight tick could still
+    // fire before pool.end()).
+    businessMetrics.stop();
+    clientPerfMetrics.stop();
     game.stop();
     await game.saveAll('shutdown');
     await game.saveMarket();

--- a/tests/client_perf_metrics_db.test.ts
+++ b/tests/client_perf_metrics_db.test.ts
@@ -1,0 +1,179 @@
+// Integration coverage for the client-perf cardinality cap (Phase 4), which is
+// enforced IN THE SQL (server/client_perf_metrics_db.ts), not by hoping the data is
+// small. This runs the EXACT production query (CLIENT_PERF_METRICS_SQL via
+// runClientPerfMetricRows) against a real Postgres, seeding MANY releases and GPU
+// buckets, and asserts the result is capped to current + previous release and top-N
+// GPU buckets + 'other', with the total series count under the fixed ceiling.
+//
+// It needs a real Postgres (the cap uses window functions + percentile_cont that no
+// in-memory fake models), so it is GATED on TEST_DATABASE_URL / DATABASE_URL and
+// SKIPS cleanly when neither is set, keeping the default `vitest run` DB-free per
+// tests/CLAUDE.md. Locally: `npm run db:up` then
+// `TEST_DATABASE_URL=postgres://wocc:wocc@localhost:5433/wocc npx vitest run
+// tests/client_perf_metrics_db.test.ts`. It confines every object to a throwaway
+// schema it drops at the end, so it never touches real tables.
+
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  OTHER_GPU_BUCKET,
+  RELEASE_WINDOW,
+  runClientPerfMetricRows,
+} from '../server/client_perf_metrics_db';
+
+const DB_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const SCHEMA = 'client_perf_metrics_cap_test';
+
+// Skip the whole suite (rather than fail) when no test database is configured.
+const describeDb = DB_URL ? describe : describe.skip;
+
+describeDb('client-perf cardinality cap (SQL-enforced, real Postgres)', () => {
+  let pool: Pool;
+  let reachable = false;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DB_URL, max: 2 });
+    try {
+      await pool.query(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+      await pool.query(`CREATE SCHEMA ${SCHEMA}`);
+      await pool.query(`SET search_path TO ${SCHEMA}`);
+      await pool.query(`
+        CREATE TABLE client_perf_reports (
+          id BIGSERIAL PRIMARY KEY,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          release_version TEXT NOT NULL DEFAULT '',
+          gl_renderer_bucket TEXT NOT NULL DEFAULT '',
+          fps_avg REAL NOT NULL DEFAULT 0,
+          frame_p95_ms REAL NOT NULL DEFAULT 0,
+          long_frame_count INT NOT NULL DEFAULT 0,
+          long_task_count INT NOT NULL DEFAULT 0
+        )
+      `);
+      reachable = true;
+    } catch (err) {
+      // A configured-but-unreachable DB should not hard-fail the default suite.
+      console.warn('client-perf cap test: database unreachable, skipping:', err);
+    }
+  });
+
+  afterAll(async () => {
+    if (pool) {
+      try {
+        await pool.query(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+      } catch {
+        // best effort cleanup
+      }
+      await pool.end();
+    }
+  });
+
+  // A Queryable that pins search_path to the throwaway schema on every call, so the
+  // production SQL's unqualified `client_perf_reports` resolves to the seeded table.
+  function scopedDb() {
+    return {
+      async query(text: string, params: unknown[]) {
+        const client = await pool.connect();
+        try {
+          await client.query(`SET search_path TO ${SCHEMA}`);
+          return await client.query(text, params);
+        } finally {
+          client.release();
+        }
+      },
+    };
+  }
+
+  it('caps to current + previous release and top-N GPU buckets + other', async () => {
+    if (!reachable) return;
+    // Seed FIVE releases (only the two newest should survive) and, in each, MANY GPU
+    // buckets (well over the top-N so the rest fold into 'other'). Older releases get
+    // older ids so the id-recency ranking drops them.
+    const releases = ['v0.20.0', 'v0.21.0', 'v0.22.0', 'v0.22.1', 'v0.23.0'];
+    const GPU_COUNT = 30;
+    const values: string[] = [];
+    const params: unknown[] = [];
+    let p = 1;
+    for (let ri = 0; ri < releases.length; ri++) {
+      const release = releases[ri];
+      for (let g = 0; g < GPU_COUNT; g++) {
+        // Give higher-index GPUs more reports so the top-N ordering is deterministic,
+        // and make newer releases carry larger ids (inserted later).
+        const reportsForGpu = g + 1;
+        for (let n = 0; n < reportsForGpu; n++) {
+          values.push(`($${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++})`);
+          params.push(release, `gpu-${String(g).padStart(2, '0')}`, 60 - g, 10 + g, 1, 100);
+        }
+      }
+    }
+    await scopedDb().query(
+      `INSERT INTO client_perf_reports
+         (release_version, gl_renderer_bucket, fps_avg, frame_p95_ms, long_frame_count, long_task_count)
+       VALUES ${values.join(',')}`,
+      params,
+    );
+
+    const topN = 8;
+    const rows = await runClientPerfMetricRows(scopedDb(), { hours: 24, topGpuBuckets: topN });
+
+    // Release window: only the two newest releases survive.
+    const seenReleases = new Set(rows.map((r) => r.releaseVersion));
+    expect(seenReleases.size).toBe(RELEASE_WINDOW);
+    expect(seenReleases).toEqual(new Set(['v0.22.1', 'v0.23.0']));
+
+    // GPU cap: within each release, at most top-N real buckets plus one 'other'.
+    for (const release of seenReleases) {
+      const buckets = rows.filter((r) => r.releaseVersion === release);
+      expect(buckets.length).toBeLessThanOrEqual(topN + 1);
+      const others = buckets.filter((b) => b.glRendererBucket === OTHER_GPU_BUCKET);
+      expect(others.length).toBe(1); // the fold row exists (30 buckets > topN)
+      const realBuckets = buckets.filter((b) => b.glRendererBucket !== OTHER_GPU_BUCKET);
+      expect(realBuckets.length).toBe(topN);
+    }
+
+    // Total series count under the fixed ceiling regardless of the 5 releases x 30 GPUs seeded.
+    const ceiling = RELEASE_WINDOW * (topN + 1);
+    expect(rows.length).toBeLessThanOrEqual(ceiling);
+  });
+
+  it('computes median fps, frame p95 in seconds, and a weighted long-frame rate', async () => {
+    if (!reachable) return;
+    await scopedDb().query('TRUNCATE client_perf_reports', []);
+    // One release, one GPU bucket, three reports: fps 40/50/60 (median 50),
+    // frame_p95 20/30/40 ms (median 30 ms -> 0.03 s), long frames 1+2+3=6 over
+    // sampled frames 100+100+100=300 -> rate 0.02.
+    await scopedDb().query(
+      `INSERT INTO client_perf_reports
+         (release_version, gl_renderer_bucket, fps_avg, frame_p95_ms, long_frame_count, long_task_count)
+       VALUES
+         ('v0.23.0','gpu-a',40,20,1,100),
+         ('v0.23.0','gpu-a',50,30,2,100),
+         ('v0.23.0','gpu-a',60,40,3,100)`,
+      [],
+    );
+
+    const rows = await runClientPerfMetricRows(scopedDb(), { hours: 24, topGpuBuckets: 8 });
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+    expect(row.medianFps).toBeCloseTo(50, 5);
+    expect(row.frameP95Seconds).toBeCloseTo(0.03, 5);
+    expect(row.longFramesRate).toBeCloseTo(0.02, 5);
+  });
+
+  it('excludes reports outside the recent window', async () => {
+    if (!reachable) return;
+    await scopedDb().query('TRUNCATE client_perf_reports', []);
+    await scopedDb().query(
+      `INSERT INTO client_perf_reports
+         (created_at, release_version, gl_renderer_bucket, fps_avg, frame_p95_ms, long_frame_count, long_task_count)
+       VALUES
+         (now(), 'v0.23.0','gpu-a',60,16,0,100),
+         (now() - interval '5 hours', 'v0.23.0','gpu-a',10,99,50,100)`,
+      [],
+    );
+    // Only the fresh report is in the 1h window, so the median fps is 60, not ~35.
+    const rows = await runClientPerfMetricRows(scopedDb(), { hours: 1, topGpuBuckets: 8 });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].medianFps).toBeCloseTo(60, 5);
+    expect(rows[0].sampleCount).toBe(1);
+  });
+});

--- a/tests/server/http/business_metrics.test.ts
+++ b/tests/server/http/business_metrics.test.ts
@@ -1,0 +1,142 @@
+// Unit tests for the business-aggregate half of the /metrics exporter
+// (server/http/business_metrics.ts): the woc_* business gauges publish the CACHED
+// overviewCounts() snapshot at scrape time, sampled on an interval (NOT per scrape),
+// with only the fixed `window` label. These pin the exposed metric NAMES as literals
+// (a rename fails the test), prove the values match the injected aggregate, prove
+// the collector caches (many scrapes drive zero extra queries), and prove the
+// `window` label stays bounded with no per-entity label anywhere.
+
+import { Registry } from 'prom-client';
+import { describe, expect, it, vi } from 'vitest';
+import type { OverviewCounts } from '../../../server/admin_db';
+import {
+  registerBusinessMetrics,
+  WOC_ACCOUNTS_TOTAL,
+  WOC_ACTIVE_SESSIONS,
+  WOC_AVG_PLAYTIME_SECONDS,
+  WOC_CHARACTERS_TOTAL,
+  WOC_PEAK_ONLINE,
+  WOC_SIGNUPS_TOTAL,
+} from '../../../server/http/business_metrics';
+
+/** A fully populated OverviewCounts; override any field per test. */
+function counts(overrides: Partial<OverviewCounts> = {}): OverviewCounts {
+  return {
+    accounts: 1000,
+    characters: 2500,
+    accountsToday: 12,
+    accountsWeek: 80,
+    accountsMonth: 300,
+    sessionsToday: 40,
+    activeAccountsToday: 25,
+    activeAccountsWeek: 150,
+    activeAccountsMonth: 600,
+    returningAccountsToday: 10,
+    avgPlaytimeSeconds: 3600,
+    peakOnlineToday: 55,
+    peakOnlineAllTime: 210,
+    siteUsersNow: 7,
+    ...overrides,
+  };
+}
+
+function sampleValue(text: string, re: RegExp): string | undefined {
+  return text.match(re)?.[1];
+}
+
+function labelValues(text: string, label: string): Set<string> {
+  const values = new Set<string>();
+  const re = new RegExp(`${label}="([^"]*)"`, 'g');
+  for (const m of text.matchAll(re)) values.add(m[1]);
+  return values;
+}
+
+describe('registerBusinessMetrics: gauges publish the cached aggregate at scrape time', () => {
+  it('exposes every gauge under its exact exported name with the seeded values', async () => {
+    const registry = new Registry();
+    const query = vi.fn(async () => counts());
+    const collector = registerBusinessMetrics(registry, query, 60_000);
+    await collector.refresh();
+    const text = await registry.metrics();
+
+    // Literal name pins: a rename of any gauge must fail this test.
+    expect(WOC_ACCOUNTS_TOTAL).toBe('woc_accounts_total');
+    expect(WOC_SIGNUPS_TOTAL).toBe('woc_signups_total');
+    expect(WOC_CHARACTERS_TOTAL).toBe('woc_characters_total');
+    expect(WOC_ACTIVE_SESSIONS).toBe('woc_active_sessions');
+    expect(WOC_AVG_PLAYTIME_SECONDS).toBe('woc_avg_playtime_seconds');
+    expect(WOC_PEAK_ONLINE).toBe('woc_peak_online');
+
+    expect(sampleValue(text, /^woc_accounts_total (\d+)$/m)).toBe('1000');
+    expect(sampleValue(text, /^woc_characters_total (\d+)$/m)).toBe('2500');
+    expect(sampleValue(text, /^woc_avg_playtime_seconds (\d+)$/m)).toBe('3600');
+
+    expect(sampleValue(text, /^woc_signups_total\{window="today"\} (\d+)$/m)).toBe('12');
+    expect(sampleValue(text, /^woc_signups_total\{window="week"\} (\d+)$/m)).toBe('80');
+    expect(sampleValue(text, /^woc_signups_total\{window="month"\} (\d+)$/m)).toBe('300');
+
+    expect(sampleValue(text, /^woc_active_sessions\{window="today"\} (\d+)$/m)).toBe('25');
+    expect(sampleValue(text, /^woc_active_sessions\{window="week"\} (\d+)$/m)).toBe('150');
+    expect(sampleValue(text, /^woc_active_sessions\{window="month"\} (\d+)$/m)).toBe('600');
+
+    expect(sampleValue(text, /^woc_peak_online\{window="today"\} (\d+)$/m)).toBe('55');
+    expect(sampleValue(text, /^woc_peak_online\{window="all_time"\} (\d+)$/m)).toBe('210');
+  });
+
+  it('publishes no labeled series before the first successful refresh', async () => {
+    const registry = new Registry();
+    registerBusinessMetrics(
+      registry,
+      vi.fn(async () => counts()),
+      60_000,
+    );
+    // No refresh yet: the snapshot is null, so the WINDOWED gauges set nothing and
+    // emit no sample lines. (A bare unlabeled prom-client gauge defaults to 0 until
+    // set, so those are not a meaningful "nothing" signal; the labeled ones are.)
+    const text = await registry.metrics();
+    expect(text).not.toMatch(/^woc_signups_total\{/m);
+    expect(text).not.toMatch(/^woc_active_sessions\{/m);
+    expect(text).not.toMatch(/^woc_peak_online\{/m);
+  });
+
+  it('caches: many scrapes after one refresh drive zero extra queries', async () => {
+    const registry = new Registry();
+    const query = vi.fn(async () => counts());
+    const collector = registerBusinessMetrics(registry, query, 60_000);
+
+    await collector.refresh();
+    expect(query).toHaveBeenCalledTimes(1);
+
+    // A scrape storm: the gauges read the cached snapshot, never the DB.
+    for (let i = 0; i < 20; i++) await registry.metrics();
+    expect(query).toHaveBeenCalledTimes(1);
+
+    // Only an interval refresh re-queries.
+    await collector.refresh();
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
+  it('bounds the window label to the fixed set and emits no per-entity label', async () => {
+    const registry = new Registry();
+    const collector = registerBusinessMetrics(
+      registry,
+      vi.fn(async () => counts()),
+      60_000,
+    );
+    await collector.refresh();
+    const text = await registry.metrics();
+
+    expect(labelValues(text, 'window')).toEqual(new Set(['today', 'week', 'month', 'all_time']));
+    for (const forbidden of [
+      'account',
+      'account_id',
+      'character',
+      'character_id',
+      'player',
+      'name',
+      'ip',
+    ]) {
+      expect(labelValues(text, forbidden).size).toBe(0);
+    }
+  });
+});

--- a/tests/server/http/client_perf_metrics.test.ts
+++ b/tests/server/http/client_perf_metrics.test.ts
@@ -1,0 +1,193 @@
+// Unit tests for the client-perf half of the /metrics exporter
+// (server/http/client_perf_metrics.ts): the woc_client_* gauges publish the CACHED,
+// already-capped aggregate rows at scrape time, dimensioned only by release_version
+// and gl_renderer_bucket. These pin the exposed metric NAMES, prove the values match
+// the injected rows, prove the SERIES COUNT stays under a fixed ceiling when the
+// query returns the capped shape, prove a bucket that drops out of the top-N does
+// NOT leave a stale series behind (reset-per-publish), prove caching (a scrape storm
+// drives zero extra queries), and prove no per-session label ever appears.
+//
+// The cardinality CAP itself is enforced in SQL (server/client_perf_metrics_db.ts,
+// covered by tests/client_perf_metrics_db.test.ts against a real Postgres); this
+// file asserts the exporter faithfully publishes whatever capped rows it is given
+// and never widens them.
+
+import { Registry } from 'prom-client';
+import { describe, expect, it, vi } from 'vitest';
+import type { ClientPerfRow } from '../../../server/client_perf_metrics_db';
+import { OTHER_GPU_BUCKET } from '../../../server/client_perf_metrics_db';
+import {
+  registerClientPerfMetrics,
+  WOC_CLIENT_FPS,
+  WOC_CLIENT_FRAME_P95_SECONDS,
+  WOC_CLIENT_LONG_FRAMES_RATE,
+} from '../../../server/http/client_perf_metrics';
+
+function row(over: Partial<ClientPerfRow> = {}): ClientPerfRow {
+  return {
+    releaseVersion: 'v0.23.0',
+    glRendererBucket: 'apple-m-series',
+    sampleCount: 10,
+    medianFps: 60,
+    frameP95Seconds: 0.02,
+    longFramesRate: 0.05,
+    ...over,
+  };
+}
+
+function sampleValue(text: string, re: RegExp): string | undefined {
+  return text.match(re)?.[1];
+}
+
+function labelValues(text: string, label: string): Set<string> {
+  const values = new Set<string>();
+  const re = new RegExp(`${label}="([^"]*)"`, 'g');
+  for (const m of text.matchAll(re)) values.add(m[1]);
+  return values;
+}
+
+/** All woc_client_fps sample lines (one per label combo). */
+function fpsSeries(text: string): string[] {
+  return text.match(/^woc_client_fps\{[^}]*\} \S+$/gm) ?? [];
+}
+
+describe('registerClientPerfMetrics: gauges publish the cached rows at scrape time', () => {
+  it('exposes every gauge under its exact exported name with the seeded values', async () => {
+    const registry = new Registry();
+    const rows: ClientPerfRow[] = [
+      row({
+        releaseVersion: 'v0.23.0',
+        glRendererBucket: 'apple-m-series',
+        medianFps: 59.5,
+        frameP95Seconds: 0.018,
+        longFramesRate: 0.04,
+      }),
+    ];
+    const collector = registerClientPerfMetrics(
+      registry,
+      vi.fn(async () => rows),
+      60_000,
+    );
+    await collector.refresh();
+    const text = await registry.metrics();
+
+    expect(WOC_CLIENT_FPS).toBe('woc_client_fps');
+    expect(WOC_CLIENT_FRAME_P95_SECONDS).toBe('woc_client_frame_p95_seconds');
+    expect(WOC_CLIENT_LONG_FRAMES_RATE).toBe('woc_client_long_frames_rate');
+    for (const name of [
+      WOC_CLIENT_FPS,
+      WOC_CLIENT_FRAME_P95_SECONDS,
+      WOC_CLIENT_LONG_FRAMES_RATE,
+    ]) {
+      expect(text).toContain(`# TYPE ${name} gauge`);
+    }
+
+    // prom-client emits labels in labelNames order (release_version, gl_renderer_bucket).
+    const labels = '\\{release_version="v0.23.0",gl_renderer_bucket="apple-m-series"\\}';
+    expect(sampleValue(text, new RegExp(`^woc_client_fps${labels} (\\S+)$`, 'm'))).toBe('59.5');
+    expect(
+      sampleValue(text, new RegExp(`^woc_client_frame_p95_seconds${labels} (\\S+)$`, 'm')),
+    ).toBe('0.018');
+    expect(
+      sampleValue(text, new RegExp(`^woc_client_long_frames_rate${labels} (\\S+)$`, 'm')),
+    ).toBe('0.04');
+  });
+
+  it('publishes nothing before the first refresh', async () => {
+    const registry = new Registry();
+    registerClientPerfMetrics(
+      registry,
+      vi.fn(async () => [row()]),
+      60_000,
+    );
+    const text = await registry.metrics();
+    expect(text).not.toMatch(/^woc_client_fps\{/m);
+  });
+
+  it('holds the total series count under a fixed ceiling for the capped shape', async () => {
+    const registry = new Registry();
+    // The DB cap is two releases (current + previous) and top-N=8 GPU buckets + one
+    // 'other' fold, so at most 2 * 9 = 18 series per gauge. Seed exactly that worst
+    // case: two releases, nine GPU buckets (eight real + other) each.
+    const TOP_N = 8;
+    const releases = ['v0.23.0', 'v0.22.1'];
+    const buckets = [...Array.from({ length: TOP_N }, (_, i) => `gpu-${i}`), OTHER_GPU_BUCKET];
+    const rows: ClientPerfRow[] = [];
+    for (const releaseVersion of releases) {
+      for (const glRendererBucket of buckets) {
+        rows.push(row({ releaseVersion, glRendererBucket }));
+      }
+    }
+    const collector = registerClientPerfMetrics(
+      registry,
+      vi.fn(async () => rows),
+      60_000,
+    );
+    await collector.refresh();
+    const text = await registry.metrics();
+
+    const ceiling = 2 * (TOP_N + 1); // 18
+    expect(fpsSeries(text).length).toBe(ceiling);
+    expect(fpsSeries(text).length).toBeLessThanOrEqual(ceiling);
+    // Only the two seeded releases and the fixed bucket set appear.
+    expect(labelValues(text, 'release_version')).toEqual(new Set(releases));
+    expect(labelValues(text, 'gl_renderer_bucket')).toEqual(new Set(buckets));
+  });
+
+  it('evicts a series when its bucket drops out of a later window (reset per publish)', async () => {
+    const registry = new Registry();
+    let rows: ClientPerfRow[] = [row({ glRendererBucket: 'gpu-old' })];
+    const collector = registerClientPerfMetrics(
+      registry,
+      vi.fn(async () => rows),
+      60_000,
+    );
+
+    await collector.refresh();
+    expect(labelValues(await registry.metrics(), 'gl_renderer_bucket')).toContain('gpu-old');
+
+    // Next window: gpu-old is no longer in the top-N; the query returns only gpu-new.
+    rows = [row({ glRendererBucket: 'gpu-new' })];
+    await collector.refresh();
+    const buckets = labelValues(await registry.metrics(), 'gl_renderer_bucket');
+    expect(buckets).toContain('gpu-new');
+    expect(buckets).not.toContain('gpu-old');
+  });
+
+  it('caches: many scrapes after one refresh drive zero extra queries', async () => {
+    const registry = new Registry();
+    const query = vi.fn(async () => [row()]);
+    const collector = registerClientPerfMetrics(registry, query, 60_000);
+
+    await collector.refresh();
+    expect(query).toHaveBeenCalledTimes(1);
+    for (let i = 0; i < 20; i++) await registry.metrics();
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('carries only release_version and gl_renderer_bucket labels, nothing per-session', async () => {
+    const registry = new Registry();
+    const collector = registerClientPerfMetrics(
+      registry,
+      vi.fn(async () => [row()]),
+      60_000,
+    );
+    await collector.refresh();
+    const text = await registry.metrics();
+
+    expect(labelValues(text, 'release_version').size).toBeGreaterThan(0);
+    expect(labelValues(text, 'gl_renderer_bucket').size).toBeGreaterThan(0);
+    for (const forbidden of [
+      'session',
+      'session_id',
+      'account',
+      'account_id',
+      'character',
+      'character_id',
+      'ip',
+      'build_id',
+    ]) {
+      expect(labelValues(text, forbidden).size).toBe(0);
+    }
+  });
+});

--- a/tests/server/http/periodic_collector.test.ts
+++ b/tests/server/http/periodic_collector.test.ts
@@ -1,0 +1,68 @@
+// Unit tests for the periodic-cache primitive shared by the app-aggregate metric
+// collectors (server/http/periodic_collector.ts): it caches the last successful
+// query result, refresh() re-runs the query, and a failed query keeps the previous
+// snapshot rather than throwing into the timer. These are the caching + resilience
+// guarantees both the business and client-perf collectors rely on.
+
+import { describe, expect, it, vi } from 'vitest';
+import { PeriodicCollector } from '../../../server/http/periodic_collector';
+
+describe('PeriodicCollector', () => {
+  it('starts null and caches the result of a refresh', async () => {
+    const query = vi.fn(async () => 7);
+    const collector = new PeriodicCollector(query, 60_000);
+
+    expect(collector.current()).toBeNull();
+    await collector.refresh();
+    expect(collector.current()).toBe(7);
+  });
+
+  it('re-runs the query on each refresh and publishes the newest value', async () => {
+    let n = 1;
+    const query = vi.fn(async () => n);
+    const collector = new PeriodicCollector(query, 60_000);
+
+    await collector.refresh();
+    expect(collector.current()).toBe(1);
+    n = 42;
+    await collector.refresh();
+    expect(collector.current()).toBe(42);
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the last good snapshot when a refresh fails, and never throws', async () => {
+    let fail = false;
+    const onError = vi.fn();
+    const query = vi.fn(async () => {
+      if (fail) throw new Error('db down');
+      return 'ok';
+    });
+    const collector = new PeriodicCollector(query, 60_000, onError);
+
+    await collector.refresh();
+    expect(collector.current()).toBe('ok');
+
+    fail = true;
+    // Must not reject.
+    await expect(collector.refresh()).resolves.toBe('ok');
+    expect(collector.current()).toBe('ok');
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('start() triggers an immediate refresh and stop() is safe before/after start', async () => {
+    const query = vi.fn(async () => 5);
+    const collector = new PeriodicCollector(query, 60_000);
+
+    // Safe with no timer running.
+    collector.stop();
+
+    collector.start();
+    // start() kicks an immediate (async) refresh; let it settle.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(query).toHaveBeenCalled();
+
+    collector.stop();
+    collector.stop();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the app-aggregate half of the `/metrics` exporter, building on the Phase 2 metrics registry:

- **Phase 3 (business):** `woc_accounts_total`, `woc_signups_total{window}`, `woc_characters_total`, `woc_active_sessions{window}`, `woc_avg_playtime_seconds`, `woc_peak_online{window}`. Reuses `overviewCounts()` from `admin_db.ts` (no duplicated SQL). The only label is a fixed `window` (today/week/month, all_time); nothing per-entity.
- **Phase 4 (client-perf):** `woc_client_fps` (median), `woc_client_frame_p95_seconds`, `woc_client_long_frames_rate`, dimensioned by `release_version` and `gl_renderer_bucket`.

Both collectors are periodic and cached, NOT per-scrape: a `PeriodicCollector` runs one bounded Postgres aggregate on a 60s interval and the gauges publish the cached snapshot at scrape time, so a scrape storm can never become a query storm. `main.ts` starts both at boot and stops them on shutdown. Everything registers on the SAME prom-client registry the RED and game-state exporters use, and emits no env/service/server_name labels (Prometheus adds those).

## Cardinality is enforced in the SQL, not hoped for

Phase 4 adds a new capped aggregate (`server/client_perf_metrics_db.ts`) that enforces the cap in the query: only the current and previous release by recency, only the top-N `gl_renderer_bucket` per release with the rest folded into `other`, over the last hour. The series count is bounded by `2 * (N + 1)` per gauge regardless of how many releases or GPUs the table holds. The exporter `reset()`s each gauge per publish so a bucket that drops out of the top-N leaves no stale series.

## Files

- `server/http/periodic_collector.ts` - shared cached-interval primitive.
- `server/http/business_metrics.ts` - Phase 3 gauges + collector.
- `server/client_perf_metrics_db.ts` - Phase 4 capped aggregate SQL.
- `server/http/client_perf_metrics.ts` - Phase 4 gauges + collector.
- `server/main.ts` - register + start both collectors at boot, stop on shutdown.
- Tests: `tests/server/http/{periodic_collector,business_metrics,client_perf_metrics}.test.ts` (DB-free) and `tests/client_perf_metrics_db.test.ts` (real-Postgres SQL cap, gated + skips cleanly without a DB).

## Tests

DB-free exporter unit tests assert gauge values match the seeded aggregate, that the collectors cache (a scrape storm drives zero extra queries), the Phase 4 series-count ceiling, and that no per-entity label appears. A real-Postgres integration test seeds many releases and GPUs and asserts the SQL cap holds (current + previous release, top-N + other). All 17 new tests pass.

Gate: `npm run gate` on Node 22+ is green except for one pre-existing, unrelated flake (`tests/mail.test.ts` unread-index equivalence times out under 4-worker contention; passes in isolation). tsc clean, biome clean on changed files, malware scan and i18n gates pass, architecture invariants intact (SQL stays in `*_db.ts`, no metrics in `src/sim/`). No em/en dashes or emojis.

## Stacking

This PR STACKS ON #1678 (Phase 2, `feat/game-state-metrics-v0.23`) and its base is set to that branch. Once #1678 merges, retarget this PR base to `release/v0.23.0`.

Do not merge before #1678.
