### PR TITLE
fix(mobile): centered read-view chat with a resizable, in-front panel

### DIFF
--- a/src/game/chat_keyboard_dismiss.ts
+++ b/src/game/chat_keyboard_dismiss.ts
@@ -1,47 +1,20 @@
-// The mobile chat keyboard-dismiss seam: the pure decision that differentiates an
-// INTENTIONAL keyboard dismiss (blur the composer, keep chat open) from the existing
-// composer-CLOSE path (blur after the composer is hidden, which must recover the
-// mobile-chat viewport).
+// The mobile chat keyboard-dismiss seam: the pure decision that keeps an intentional
+// keyboard dismiss (blur, chat stays OPEN in its read view) apart from the composer-CLOSE
+// path (blur after the composer is hidden, which recovers the mobile-chat viewport).
+// DOM-free, Node-tested; main.ts wires it to the real composer element.
 //
-// On a touch HUD the chat toggle opens the composer focused (keyboard up), and until
-// now the only ways the keyboard dropped were closing chat entirely or the OS back
-// gesture. The dismiss chevron blurs the input WITHOUT closing chat: the log +
-// composer stay at their resting seat and the keyboard_viewport applier reflows chat
-// back automatically off the visualViewport resize.
-//
-// The distinguishing signal is the composer's display state at blur time. closeChat()
-// hides the composer (display:none) BEFORE it blurs, so its blur must trigger the
-// mobile-keyboard viewport recovery. A dismiss (or any focus loss while the composer
-// is still shown) leaves display:block, so it must NOT recover, keeping chat open.
-// This module is DOM-free and Node-testable; main.ts wires it to the real elements.
+// New model: tapping the Chat button opens a centered READ view (composer visible above
+// the panel, keyboard down). Tapping the composer raises the keyboard; hiding the keyboard
+// returns to the read view (chat stays open). Only the Chat button closes chat entirely.
 
 /**
- * Whether a `blur` on the chat composer should run the mobile-keyboard viewport
- * recovery (which removes `mobile-chat-open` and re-syncs the app viewport). True
- * only when the composer is already HIDDEN (`display === 'none'`), i.e. the blur came
- * from the close path (closeChat hides then blurs). A blur while the composer is still
- * shown (an intentional keyboard dismiss, or a focus loss that keeps chat open)
- * returns false, so chat stays open at its resting seat.
+ * Whether a `blur` on the chat composer should run the mobile-keyboard viewport recovery
+ * (which removes `mobile-chat-open` and re-syncs the app viewport). True ONLY when the
+ * composer is already HIDDEN (`display === 'none'`), i.e. the blur came from the close
+ * path (closeChat hides the composer, THEN blurs it). A blur while the composer is still
+ * shown is a keyboard dismiss that returns to the read view, so it returns false and chat
+ * stays open.
  */
 export function shouldRecoverOnComposerBlur(composerDisplay: string): boolean {
   return composerDisplay === 'none';
-}
-
-/**
- * The keyboard-dismiss action's effect, expressed as a pure decision the wiring
- * applies to the real composer: blur it (drop the keyboard) but keep chat OPEN (do
- * not hide the composer, do not recover the viewport). Returned as data so a Node
- * test can assert the intent without a DOM: `blurComposer` true, `closeChat` false.
- */
-export interface KeyboardDismissEffect {
-  /** Blur the chat input, which drops the on-screen keyboard on Android and iOS. */
-  blurComposer: boolean;
-  /** Never close chat on a dismiss: the log + composer stay visible. */
-  closeChat: boolean;
-}
-
-/** The dismiss chevron's effect: blur the composer, keep chat open. A constant-shaped
- *  decision (no inputs) so the wiring and a Node test share one source of truth. */
-export function keyboardDismissEffect(): KeyboardDismissEffect {
-  return { blurComposer: true, closeChat: false };
 }

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -115,7 +115,12 @@ export interface MobileControlCallbacks {
   onJump(): void;
   onInteract(): void;
   onAutorun(): boolean;
+  /** Open the composer focused (raise the keyboard): the keybind / whisper path. */
   onChat(): void;
+  /** Open the centered read view: composer bar visible but NOT focused (no keyboard). */
+  onChatOpen(): void;
+  /** Close chat entirely (hide the composer, drop the keyboard, recover the viewport). */
+  onChatClose(): void;
   onMenu(): void;
   onSocial(): void;
   /** Open the Discord entry (account panel when available, else the community invite). */
@@ -506,10 +511,17 @@ export class MobileControls {
     } else {
       // Reset any composer left open ONLY on a real transition INTO touch (not on a
       // redundant re-activation while already active, which would clear a draft the
-      // player is typing). exitChatReply clears input.value, so gate it on !wasActive.
+      // player is typing). This clears input.value, so gate it on !wasActive.
       if (!wasActive) {
         document.body.classList.remove('mobile-chat-open', 'mobile-chat-reply');
-        this.exitChatReply();
+        const input = document.getElementById('chat-input') as HTMLTextAreaElement | null;
+        if (input) {
+          input.value = '';
+          input.style.display = 'none';
+          input.style.height = '';
+          input.style.overflowY = '';
+          input.blur();
+        }
       }
       // Arm the idle-fade once for this activation (idempotent via ??=).
       this.chromeFade ??= startChromeFade(document.body);
@@ -620,67 +632,26 @@ export class MobileControls {
     button.addEventListener('pointerleave', cancel);
   }
 
-  /** Toggle the read-only chat-log peek. Opening it makes sure the composer (and
-   * keyboard) is dismissed; opening the composer elsewhere clears the peek. */
+  /** Toggle the read-only chat-log peek. Opening a peek closes the full chat first (so a
+   *  peek and the open panel are never both up); opening the panel elsewhere clears it. */
   private toggleLogPeek(): void {
     const peeking = document.body.classList.toggle('mobile-chatlog-peek');
     if (peeking && document.body.classList.contains('mobile-chat-open')) {
-      this.toggleChat();
+      this.callbacks.onChatClose();
     }
   }
 
-  /** The single top-left Chat button owns a simple two-state toggle (issue
-   * 1577 uiux-overlap: the separate in-log reply pill overlapped the chatbox,
-   * so it was removed; a later round tried a three-state open/read/reply
-   * cycle, since simplified back to two): hidden, or shown, with the log AND
-   * the composer appearing together immediately, composer focused. There is
-   * no separate read-only step to tap through first. */
+  /** The single top-left Chat button toggles the chat panel. Tapping it OPEN shows the
+   *  centered read view: the log plus the composer bar above it, keyboard DOWN (tapping
+   *  the composer bar raises the keyboard to type). Tapping it again CLOSES the panel;
+   *  if the keyboard is up, closing drops it too (closeChat blurs the composer). */
   private tapChat(): void {
-    // Two states only: hidden, or shown (log AND composer visible together,
-    // composer focused immediately). No separate read-only step in between.
-    const open = document.body.classList.contains('mobile-chat-open');
-    if (!open) {
-      this.enterChatReply();
-    } else {
-      this.toggleChat();
-    }
-  }
-
-  private toggleChat(): void {
-    document.body.classList.remove('mobile-chatlog-peek');
-    document.body.classList.toggle('mobile-chat-open');
     if (document.body.classList.contains('mobile-chat-open')) {
-      // Open the log in a read state, NOT the composer: the keyboard only rises
-      // once the player taps the Chat button again to enter reply mode.
-      // The composer stays hidden until enterChatReply focuses it.
+      this.callbacks.onChatClose();
     } else {
-      this.exitChatReply();
-    }
-  }
-
-  /** Enter reply mode: raise the keyboard and show the composer via the shared
-   *  onChat path. Reached by tapping the Chat button again while the log is
-   *  already open in its read state. */
-  private enterChatReply(): void {
-    if (!document.body.classList.contains('mobile-chat-open')) {
+      document.body.classList.remove('mobile-chatlog-peek');
       document.body.classList.add('mobile-chat-open');
-    }
-    document.body.classList.remove('mobile-chatlog-peek');
-    document.body.classList.add('mobile-chat-reply');
-    this.callbacks.onChat();
-  }
-
-  /** Leave reply mode and reset the composer back to its collapsed state. */
-  private exitChatReply(): void {
-    document.body.classList.remove('mobile-chat-reply');
-    const input = document.getElementById('chat-input') as HTMLTextAreaElement | null;
-    if (input) {
-      input.value = '';
-      input.style.display = 'none';
-      // clear the autosized height so the next open starts at one line
-      input.style.height = '';
-      input.style.overflowY = '';
-      input.blur();
+      this.callbacks.onChatOpen();
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import {
 } from './game/browser_env';
 import { isCameraDrivenFacingActive } from './game/camera_driven_facing';
 import { cameraFollowShouldSettle, updateFollowCameraYaw, wrapAngle } from './game/camera_follow';
-import { keyboardDismissEffect, shouldRecoverOnComposerBlur } from './game/chat_keyboard_dismiss';
+import { shouldRecoverOnComposerBlur } from './game/chat_keyboard_dismiss';
 import {
   clickMoveShouldWalk,
   clickMoveStep,
@@ -994,13 +994,34 @@ async function startGame(
     hud.clearPendingChatLinks();
     recoverFromMobileKeyboard();
   };
+  // On the touch HUD the composer is a desktop-style bar at the TOP of the chat panel
+  // (above the tabs + log), so on mobile it lives INSIDE #chatlog-wrap as its first child
+  // rather than as an absolutely-positioned sibling. Move it there once, lazily, the first
+  // time chat opens (idempotent; a no-op on desktop and after the first move).
+  const ensureMobileComposerInPanel = (): void => {
+    if (!document.body.classList.contains('mobile-touch')) return;
+    const wrap = document.getElementById('chatlog-wrap');
+    if (!wrap || chatInput.parentElement === wrap) return;
+    wrap.insertBefore(chatInput, wrap.firstChild);
+  };
   function openChat(): void {
     // reflect the active chat-channel tab in the placeholder (e.g. "Message World")
+    ensureMobileComposerInPanel();
     chatInput.placeholder = hud.activeChatPlaceholder();
     chatInput.style.display = 'block';
     anchorChatInput();
     autosizeChatInput();
     chatInput.focus();
+  }
+  // Mobile read view: tapping the Chat button opens the centered panel with the composer
+  // bar VISIBLE but NOT focused (no keyboard). Tapping the composer focuses it and raises
+  // the keyboard (native + the focus handler). Same as openChat minus the focus.
+  function openChatRead(): void {
+    ensureMobileComposerInPanel();
+    chatInput.placeholder = hud.activeChatPlaceholder();
+    chatInput.style.display = 'block';
+    document.body.classList.remove('mobile-chat-reply');
+    autosizeChatInput();
   }
   // Fired for every open path (keybind, whisper context menu, mobile toggle)
   // since they all call focus().
@@ -1060,21 +1081,17 @@ async function startGame(
   });
   chatInput.addEventListener('blur', () => {
     // Recover the mobile-chat viewport ONLY when the composer is already hidden (the
-    // close path: closeChat hides then blurs). An intentional keyboard dismiss (the
-    // #chat-dismiss chevron below) blurs while the composer is still shown, so this is
-    // false and chat stays open at its resting seat, reflowed by the keyboard_viewport
-    // applier off the visualViewport resize.
+    // close path: closeChat hides then blurs). A keyboard dismiss (the OS hide-keyboard
+    // key) blurs while the composer is still shown, so this is false and chat stays open
+    // in its centered READ view, reflowed by the keyboard_viewport applier off the
+    // visualViewport resize. Only the Chat button closes chat.
     if (shouldRecoverOnComposerBlur(chatInput.style.display)) recoverFromMobileKeyboard();
   });
-  // The mobile keyboard-dismiss chevron: blur the composer (dropping the on-screen
-  // keyboard on Android + iOS) WITHOUT closing chat. The effect is a pure decision
-  // (blurComposer true, closeChat false); we apply only the blur, so the log +
-  // composer stay visible and re-tapping the input re-raises the keyboard (native).
+  // The mobile keyboard-dismiss chevron (hidden on mobile in the current model; kept wired
+  // for parity): blur the composer to drop the keyboard and return to the read view,
+  // WITHOUT closing chat.
   const chatDismiss = document.getElementById('chat-dismiss');
-  chatDismiss?.addEventListener('click', () => {
-    const effect = keyboardDismissEffect();
-    if (effect.blurComposer) chatInput.blur();
-  });
+  chatDismiss?.addEventListener('click', () => chatInput.blur());
 
   const input = new Input(
     canvas,
@@ -1178,6 +1195,8 @@ async function startGame(
     onInteract: () => interactKey(),
     onAutorun: () => input.toggleAutorun(),
     onChat: () => openChat(),
+    onChatOpen: () => openChatRead(),
+    onChatClose: () => closeChat(),
     onMenu: () => hud.toggleOptionsMenu(),
     onSocial: () => hud.toggleSocial(),
     onDiscord: () => openDiscordEntry(),

--- a/src/styles/hud.mobile.css
+++ b/src/styles/hud.mobile.css
@@ -1397,8 +1397,127 @@
     display: none;
     z-index: 24;
   }
+  /* New model: tapping the Chat icon opens a centered READ panel; the composer is a
+     desktop-style bar at the TOP of that panel (main.ts moves #chat-input into
+     #chatlog-wrap as its first child on mobile), sitting above the tabs + log. Tapping
+     the composer bar raises the keyboard to type; hiding the keyboard returns to this read
+     view. Only the Chat icon closes the panel. One --mobile-chat-w var sizes the panel +
+     composer. Desktop is untouched; the long-press peek keeps its small bottom-left glance
+     (it clears mobile-chat-open, so none of this applies to it). */
+  body.mobile-touch.mobile-chat-open {
+    --mobile-chat-w: min(560px, calc(100vw - 24px));
+  }
   body.mobile-touch.mobile-chat-open #chatlog-wrap {
-    display: block;
+    display: flex;
+    flex-direction: column;
+    left: 50%;
+    right: auto;
+    /* Read view (keyboard down): a LARGE centered panel. Top clears the top-left
+       Chat/Social/More trio (a ~54px row scaled up to ~1.1x) so the Chat button stays
+       tappable ABOVE the panel to close it. The bottom is player-resizable: dragging the
+       bottom handle sets --mobile-chat-bottom (the bottom inset), clamped so the panel
+       keeps a usable minimum height and never runs off-screen. top + bottom + height:auto
+       stretches the panel between them. Default bottom is small so the panel is big. */
+    top: calc(max(8px, env(safe-area-inset-top)) + 64px);
+    bottom: calc(
+      env(safe-area-inset-bottom) +
+      clamp(12px, var(--mobile-chat-bottom, 52px), calc(100vh - 320px))
+    );
+    transform: translateX(-50%);
+    width: var(--mobile-chat-w);
+    height: auto;
+    /* In front of the sibling in-HUD frames (the ~19-45 z band) inside #ui; #ui itself
+       (z 80 on the touch HUD) already sits above #mobile-controls (z 60). */
+    z-index: 50;
+  }
+  /* The composer bar is the panel's first child (above the tabs + log), sized to the
+     panel width. It FLOWS in the flex column (not absolutely positioned / docked); order
+     -1 keeps it first even if it were inserted elsewhere. Reset the base composer's
+     absolute seat + chevron padding, and force off iOS Safari's native light textarea
+     appearance so it stays a dark panel bar (not a white box). */
+  body.mobile-touch.mobile-chat-open #chat-input {
+    position: static;
+    order: -1;
+    flex: 0 0 auto;
+    left: auto;
+    right: auto;
+    top: auto;
+    bottom: auto;
+    transform: none;
+    width: 100%;
+    margin: 0 0 6px 0;
+    padding: 9px 12px;
+    min-height: 40px;
+    box-sizing: border-box;
+    -webkit-appearance: none;
+    appearance: none;
+    background: #0d0d14f2;
+    color: #e8e8e8;
+    border: 1px solid var(--gold-dim, #6f5a2a);
+    border-radius: 8px;
+  }
+  /* Mobile chat resize handle (hud.ts creates it as a BODY-LEVEL element): a visible grab
+     bar pinned to the open panel's bottom edge via the SAME --mobile-chat-bottom var, so it
+     tracks the panel with no JS. A very high z-index keeps it above any overlay (the mystery
+     white bar included), and touch-action:none makes a drag a resize, not a scroll. Shown
+     only while the read panel is open. */
+  .chat-mobile-resize {
+    display: none;
+  }
+  body.mobile-touch.mobile-chat-open .chat-mobile-resize {
+    position: fixed;
+    left: 50%;
+    transform: translateX(-50%);
+    width: var(--mobile-chat-w);
+    /* Straddle the panel's bottom edge: the 30px bar is centred on the edge (edge - 15px). */
+    bottom: calc(
+      env(safe-area-inset-bottom) +
+      clamp(12px, var(--mobile-chat-bottom, 52px), calc(100vh - 320px)) -
+      15px
+    );
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 30px;
+    z-index: 300;
+    touch-action: none;
+    cursor: ns-resize;
+    pointer-events: auto;
+    border-radius: 0 0 8px 8px;
+    background: color-mix(in srgb, var(--panel-base, #14121c) 82%, transparent);
+    box-shadow: inset 0 1px 0 #ffffff10;
+  }
+  body.mobile-touch.mobile-chat-open .chat-mobile-resize::before {
+    content: "";
+    width: 56px;
+    height: 6px;
+    border-radius: 3px;
+    background: var(--gold-dim, #6f5a2a);
+    box-shadow:
+      0 0 0 1px #00000066,
+      inset 0 1px 0 #ffffff33;
+  }
+  /* The tab strip keeps its natural height; the log frame fills the rest of the panel
+     (the ~4-line strip cap only applies while closed or peeking). */
+  body.mobile-touch.mobile-chat-open #chatlog-tabs {
+    flex: 0 0 auto;
+  }
+  body.mobile-touch.mobile-chat-open #chatlog-frame {
+    flex: 1 1 auto;
+    min-height: 0;
+    height: auto;
+    max-height: none;
+  }
+  /* Bottom-anchor the log so recent lines sit at the BOTTOM of the pane (nearest the
+     input bar), not clustered at the top of a mostly-empty frame. margin-top:auto pushes
+     content down when there is slack and collapses to 0 on overflow (no top clipping the
+     way justify-content:flex-end would). Scoped to the open touch chat; desktop untouched. */
+  body.mobile-touch.mobile-chat-open #chatlog-frame .chat-pane.active {
+    display: flex;
+    flex-direction: column;
+  }
+  body.mobile-touch.mobile-chat-open #chatlog-frame .chat-pane.active > :first-child {
+    margin-top: auto;
   }
   /* Long-pressing the Chat button toggles a read-only peek at the log without
      raising the keyboard composer. It must not eat taps meant for the world. */
@@ -1466,145 +1585,43 @@
        last 40px lands on the button. box-sizing: border-box keeps the outer width fixed. */
     padding-right: 46px;
   }
-  /* The mobile keyboard-dismiss chevron (#chat-dismiss): a down-chevron button seated at
-     the chat composer's right corner, shown only while chat is open AND the on-screen
-     keyboard is up. Tapping it blurs the composer so the keyboard drops WITHOUT closing
-     chat (main.ts). Its reveal is keyed on body.mobile-keyboard-open (as well as
-     mobile-chat-open) so it never lingers as a dead control after it has dismissed the
-     keyboard: with no keyboard up there is nothing to hide. Hidden by default (the button
-     exists in the template even off-chat). The chevron reuses the hydrated `next` triangle
-     rotated to point DOWN (the SVG-chevron pattern, no unicode arrow). */
+  /* The in-app keyboard-dismiss chevron (#chat-dismiss) is hidden in the current model:
+     the OS keyboard's own hide key drops the keyboard and returns to the read view, and
+     the Chat icon closes the panel. The button stays in the template (harmless), it is
+     just never shown on mobile. */
   body.mobile-touch #chat-dismiss {
     display: none;
   }
-  body.mobile-touch.mobile-chat-open.mobile-keyboard-open #chat-dismiss {
-    position: fixed;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    right: auto;
-    /* Seated at the COMPOSER's right corner (not the screen edge): the composer is
-       centered (left:50%, translateX(-50%)) at width min(360px * chrome-scale,
-       100vw-40px), so its right edge is 50% + half that width; park the 40px chevron
-       just inside that, aligned with the composer's keyboard-open bottom (docked just
-       above the keyboard's top edge, matching #chat-input below). It reads as the
-       composer's own dismiss affordance rather than a disconnected button. */
-    left: calc(50% + min(calc(360px * var(--mobile-chrome-scale, 1)), 100vw - 40px) / 2 - 40px);
-    top: auto;
-    bottom: calc(100vh - var(--mobile-keyboard-visible-vh, 100vh) + 8px);
-    width: 40px;
-    height: 40px;
-    padding: 0;
-    border: 1px solid var(--mobile-glass-border, #cba43d8c);
-    border-radius: 10px;
-    background: var(--mobile-glass-bg, linear-gradient(160deg, #23212de3, #0e0d10eb));
-    -webkit-backdrop-filter: blur(var(--mobile-glass-blur, 8px));
-    backdrop-filter: blur(var(--mobile-glass-blur, 8px));
-    color: #d8b98a;
-    cursor: var(--cursor-point);
-    z-index: 26;
-    box-shadow:
-      inset 0 1px 0 #ffffff14,
-      0 2px 8px #0009;
-  }
-  body.mobile-touch.mobile-chat-open.mobile-keyboard-open #chat-dismiss:active {
-    border-color: var(--gold);
-    color: #fff;
-  }
-  /* The down chevron: the `next` triangle rotated a quarter turn to point down. */
-  body.mobile-touch #chat-dismiss .ui-icon {
-    width: 13px;
-    height: 13px;
-    transform: rotate(90deg);
-  }
-  /* Reply mode grows the composer to an 84px min-height; centre the 40px chevron on that
-     taller box so it reads as an attached part of the composer row (one unit) instead of
-     a button parked at the composer's bottom-right corner (the owner's "chevron floats
-     detached" report). It shares the composer's docked bottom (both keyed on
-     visible-vh), so the pair moves as one when the keyboard opens. The +30px is the base
-     +8px composer dock plus (84 - 40) / 2 = 22px to lift the chevron to the composer's
-     vertical centre. */
-  body.mobile-touch.mobile-chat-open.mobile-chat-reply.mobile-keyboard-open #chat-dismiss {
-    bottom: calc(100vh - var(--mobile-keyboard-visible-vh, 100vh) + 30px);
-  }
-  /* Issue 1577 (5) + the real-device chat-overlap fix: once the on-screen keyboard
-     opens (mobile-keyboard-open, toggled by keyboard_viewport_applier.ts off the
-     visualViewport resize event, the same signal main.ts/renderer.ts already use for
-     the stable game viewport), the log + composer abandon their normal bottom-anchored
-     seats -- which the keyboard would otherwise cover -- and re-lay as ONE
-     non-overlapping column above the keyboard. The wrap becomes a flex COLUMN anchored
-     from the safe-area top down to a bottom that RESERVES the docked composer's box:
-     the composer docks at (100vh - visible-vh + 8px) and autosizes while typing up to
-     the 110px CHAT_INPUT_MAX_H cap (main.ts autosizeChatInput; the 84px reply
-     min-height sits under that cap), so the wrap bottom sits that full 110px + an 8px
-     gap above the composer = +126px above the keyboard line. The tab strip keeps its
-     natural height at the TOP
-     of the column and the log frame FLEXES to fill only the space between the tabs and
-     the reserved composer, so neither the tabs nor the log can grow into the composer.
-     (The bug this fixes: the old height:100% frame plus the 40px tab strip overflowed
-     ~53px DOWN into the composer, interleaving the log text with the typed text.) */
+  /* Once the on-screen keyboard opens (mobile-keyboard-open, toggled by
+     keyboard_viewport_applier.ts off the visualViewport resize), the whole panel (composer
+     bar + tabs + log) re-lays as a flex column filling the space ABOVE the keyboard: the
+     composer stays at the TOP, the tab strip keeps its natural height, and the log frame
+     flexes to fill the rest. No composer reservation is needed, since the composer is a
+     flow item inside the panel (from the open rule above), not a separately-docked bar. */
   body.mobile-touch.mobile-keyboard-open.mobile-chat-open #chatlog-wrap {
     top: max(6px, env(safe-area-inset-top));
     bottom: auto;
-    /* A DEFINITE height (not top+bottom auto-stretch, which needs a full-height
-       positioned ancestor #chatlog-wrap does not have): the visible area above the
-       keyboard is --mobile-keyboard-visible-vh; subtract the top inset and the 126px
-       composer reservation (the 110px autosize cap + 8px gap + 8px dock; reserving
-       only the 84px reply min-height let a long multi-line draft grow the composer
-       up into the log) so the wrap bottom stops a clear gap above the composer. */
+    /* A DEFINITE height (not a top+bottom stretch): the visible-above-keyboard band
+       (--mobile-keyboard-visible-vh) minus the top inset and an 8px gap above the keyboard
+       line, so the panel never sits under the keyboard. */
     height: calc(
       var(--mobile-keyboard-visible-vh, 100vh) -
       max(6px, env(safe-area-inset-top)) -
-      126px
+      8px
     );
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
   }
-  body.mobile-touch.mobile-keyboard-open.mobile-chat-open #chatlog-tabs {
-    /* Natural height at the top of the column; never shrunk or clipped into the log. */
-    flex: 0 0 auto;
-  }
-  body.mobile-touch.mobile-keyboard-open.mobile-chat-open #chatlog-frame {
-    /* Fill ONLY the gap between the tabs and the reserved composer; scroll internally. */
-    flex: 1 1 auto;
-    min-height: 0;
-    height: auto;
-    max-height: none;
-  }
-  body.mobile-touch.mobile-keyboard-open.mobile-chat-open #chat-input {
-    top: auto;
-    bottom: calc(100vh - var(--mobile-keyboard-visible-vh, 100vh) + 8px);
-  }
-  /* The low-priority Chat/Social/More trio yields while the keyboard is up so the
-     docked tab strip owns a clean top-left instead of a strip layered over the round
-     buttons (the owner's "tabs at the absolute top edge, badly positioned" report).
-     Keeping the trio would either crowd the tabs at every size or, if the column were
-     pushed below it, starve the log to a couple of unreadable pixels on a realistic
-     keyboard-open viewport. The trio is fairness-neutral chrome (menu buttons, never
-     actionable combat info) and returns the instant the keyboard drops via the dismiss
-     chevron, from where a Chat tap closes chat. */
+  /* The low-priority Chat/Social/More trio yields while the keyboard is up: the panel top
+     rises to the safe-area top and would otherwise sit over it (and the panel, in #ui z 80,
+     paints above the trio anyway). Fairness-neutral menu chrome; it returns the instant the
+     keyboard drops. */
   body.mobile-touch.mobile-keyboard-open.mobile-chat-open #mobile-combat-controls {
     display: none;
   }
-  /* Issue 1577 round 2 (8): while actively replying with the keyboard open,
-     expand the composer to a comfortable multi-line box within the now-expanded
-     chatbox above. Builds on that seat, only growing the height/padding. */
-  body.mobile-touch.mobile-chat-reply.mobile-keyboard-open #chat-input {
-    min-height: 84px;
-    /* Keep the 46px right padding (the dismiss chevron overlays this seat while typing,
-       exactly when reply mode is active) even as reply mode grows the other paddings. */
-    padding: 10px 46px 10px 12px;
-    line-height: 1.4;
-  }
-  /* Issue 1577 round 2 (7): while actively replying (composer focused), fade the
-     chat window's background noticeably so the world behind it stays visible
-     while typing. --chat-opacity is the Chat Background Opacity var the frame's
-     background mixes against; dropping it here makes the panel much more
-     see-through than its normal state. */
-  body.mobile-touch.mobile-chat-reply #chatlog-frame {
-    --chat-opacity: 0.14;
-  }
+  /* The open chat frame stays a solid, readable panel (it uses the player's normal Chat
+     Background Opacity, --chat-opacity default 0.95). An earlier build faded it to ~0.14
+     while replying "to see the world behind it"; on a real device that made the chatbox
+     nearly invisible, which is the opposite of what an open chat wants. Glancing at the
+     log without opening it is the long-press peek's job instead. */
   /* Own HP/mana lives bottom-center, the one part of the screen every other
      mobile element deliberately leaves empty (move joystick bottom-left,
      combat cluster + hotbar bottom-right, low-frequency verbs + minimap rail
@@ -3537,14 +3554,8 @@
       bottom: calc(250px + env(safe-area-inset-bottom));
       width: min(calc(330px * var(--mobile-chrome-scale, 1)), 44vw);
     }
-    /* Follows the landscape composer's own centered width (330px * chrome-scale,
-       44vw): re-seat only the chevron's horizontal position; the keyboard-docked
-       bottom from the portrait-level rule still applies (the chevron only shows
-       while the keyboard is up). Same three-class selector as that rule so this
-       later landscape override wins the left seat. */
-    body.mobile-touch.mobile-chat-open.mobile-keyboard-open #chat-dismiss {
-      left: calc(50% + min(calc(330px * var(--mobile-chrome-scale, 1)), 44vw) / 2 - 40px);
-    }
+    /* The dismiss chevron tracks the shared --mobile-chat-w in every orientation, so
+       the portrait-level rule already seats it correctly here (no landscape override). */
     body.mobile-touch #player-frame {
       left: 50%;
       top: auto;
@@ -3731,6 +3742,27 @@
      short-viewport constraint the overlap audit still notes (never a hard fail). */
   body.mobile-touch.hud-mobile-compact #chat-input {
     bottom: calc(276px + env(safe-area-inset-bottom));
+  }
+  /* Compact (phones: width <= 700 or height <= 480, i.e. the primary case) uses the same
+     centered, in-front, PLAYER-RESIZABLE panel as the other tiers; the closed-seat
+     width/bottom rules above would otherwise pin the open chat to a narrow fixed strip. The
+     bottom MUST use the same --mobile-chat-bottom clamp as the base open rule, or the resize
+     handle moves but the panel does not (the bug that hid the resize on real phones). */
+  body.mobile-touch.hud-mobile-compact.mobile-chat-open #chatlog-wrap {
+    width: var(--mobile-chat-w);
+    bottom: calc(
+      env(safe-area-inset-bottom) +
+      clamp(12px, var(--mobile-chat-bottom, 52px), calc(100vh - 320px))
+    );
+  }
+  body.mobile-touch.hud-mobile-compact.mobile-chat-open #chatlog-frame {
+    flex: 1 1 auto;
+    min-height: 0;
+    height: auto;
+    max-height: none;
+  }
+  body.mobile-touch.hud-mobile-compact.mobile-chat-open #chat-input {
+    bottom: calc(env(safe-area-inset-bottom) + 68px);
   }
   body.mobile-touch.hud-mobile-compact #right-tracker-stack {
     width: calc(148px * var(--mobile-chrome-scale, 1));

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -687,6 +687,10 @@ const CHAT_ACTIVE_TAB_KEY = 'woc_chat_active_tab';
 // Persisted chat-window geometry (drag position + resize size). Desktop only —
 // the mobile layout owns its own placement and ignores this.
 const CHAT_GEOMETRY_KEY = 'woc_chat_geometry';
+// Persisted MOBILE chat panel size: the panel's bottom inset in px, dragged via the
+// bottom resize handle. CSS clamps it to a valid range for the live viewport, so a value
+// saved in one orientation stays safe in another (never an off-screen / tiny panel).
+const MOBILE_CHAT_BOTTOM_KEY = 'woc_mobile_chat_bottom';
 // Persisted top-left for each movable unit frame (MovableFrame in movable_frame.ts).
 const TARGET_FRAME_POS_KEY = 'woc_target_frame_pos';
 const PLAYER_FRAME_POS_KEY = 'woc_player_frame_pos';
@@ -1257,6 +1261,9 @@ export class Hud {
         startH: number;
       }
     | null = null;
+  // Mobile chat resize gesture (drag the bottom handle to set the panel's bottom inset).
+  private mobileChatResize: { pointerId: number; startY: number; startBottom: number } | null =
+    null;
   // Movable unit frames (the shared MovableFrame controller, movable_frame.ts):
   // the target frame and the player frame each get a corner move/lock button, a
   // pointer drag, and a persisted top-left. Constructed once in initFrameMovers.
@@ -2279,6 +2286,36 @@ export class Hud {
     grip.setAttribute('aria-hidden', 'true');
     frame.appendChild(grip);
 
+    // Mobile-only resize handle: a BODY-LEVEL bar pinned by CSS to the open panel's bottom
+    // edge (it shares the panel's --mobile-chat-bottom var, so they move together) with a
+    // very high z-index so nothing can overlay it, and touch-action:none so a drag on it is
+    // a RESIZE, not a page scroll. Dragging it sets --mobile-chat-bottom (clamped by CSS).
+    // It is a direct child of body (not #ui / the wrap) so its z-index is not capped by an
+    // ancestor stacking context. Hidden on desktop via CSS.
+    const resizeHandle = document.createElement('div');
+    resizeHandle.className = 'chat-mobile-resize';
+    resizeHandle.title = t('hudChrome.chatWindow.resize');
+    resizeHandle.setAttribute('aria-hidden', 'true');
+    document.body.appendChild(resizeHandle);
+    resizeHandle.addEventListener('pointerdown', (ev) =>
+      this.onMobileChatResizeStart(ev, resizeHandle),
+    );
+    resizeHandle.addEventListener('pointermove', (ev) => this.onMobileChatResizeMove(ev));
+    const endMobileResize = (ev: PointerEvent) => this.onMobileChatResizeEnd(ev);
+    resizeHandle.addEventListener('pointerup', endMobileResize);
+    resizeHandle.addEventListener('pointercancel', endMobileResize);
+    try {
+      const savedBottom = localStorage.getItem(MOBILE_CHAT_BOTTOM_KEY);
+      if (savedBottom) {
+        // Clamp on restore so a value saved from a larger viewport (or an earlier build)
+        // cannot land out of range and make the first drag feel dead.
+        const clamped = this.clampMobileChatBottom(Number.parseInt(savedBottom, 10) || 52);
+        document.documentElement.style.setProperty('--mobile-chat-bottom', `${clamped}px`);
+      }
+    } catch {
+      /* storage unavailable */
+    }
+
     // touch-action lives in CSS now: `none` on desktop so a touch-drag on the empty
     // strip moves the chat box (the move gesture is desktop-only, see
     // onChatBoxMoveStart), and `pan-x` on mobile so overflowed tabs can be swiped
@@ -2388,6 +2425,57 @@ export class Hud {
     this.chatBoxGesture = null;
     document.body.classList.remove('chat-box-dragging');
     this.persistChatBoxGeometry();
+  }
+
+  // Clamp the panel's bottom inset to the same range the CSS clamp uses (12px .. viewport
+  // minus a reserved top band), so the stored value never drifts out of range. If it did,
+  // the CSS clamps it for display but a drag starting from the out-of-range raw value would
+  // not move the (already-clamped) panel until the raw crossed back in, which reads as a
+  // dead drag. Clamping in JS too keeps the drag responsive from the first pixel.
+  private clampMobileChatBottom(v: number): number {
+    const hi = Math.max(12, window.innerHeight - 320);
+    return Math.min(hi, Math.max(12, v));
+  }
+
+  // Mobile chat resize: drag the bottom handle to set --mobile-chat-bottom (the panel's
+  // bottom inset). Dragging DOWN lowers the inset (taller panel); UP raises it (shorter).
+  // The handle has touch-action:none and captures the pointer, so the drag is a resize (not
+  // a scroll) and follows the finger.
+  private onMobileChatResizeStart(ev: PointerEvent, handle: HTMLElement): void {
+    if (!this.isMobileLayout()) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    const raw = document.documentElement.style.getPropertyValue('--mobile-chat-bottom');
+    const startBottom = this.clampMobileChatBottom(raw ? Number.parseInt(raw, 10) || 52 : 52);
+    this.mobileChatResize = { pointerId: ev.pointerId, startY: ev.clientY, startBottom };
+    document.body.classList.add('chat-box-dragging');
+    try {
+      handle.setPointerCapture?.(ev.pointerId);
+    } catch {
+      /* synthetic pointer */
+    }
+  }
+
+  private onMobileChatResizeMove(ev: PointerEvent): void {
+    const g = this.mobileChatResize;
+    if (!g || g.pointerId !== ev.pointerId) return;
+    ev.preventDefault();
+    // Finger moving down (clientY grows) shrinks the bottom inset so the panel grows down.
+    const bottom = this.clampMobileChatBottom(g.startBottom - (ev.clientY - g.startY));
+    document.documentElement.style.setProperty('--mobile-chat-bottom', `${Math.round(bottom)}px`);
+  }
+
+  private onMobileChatResizeEnd(ev: PointerEvent): void {
+    const g = this.mobileChatResize;
+    if (!g || g.pointerId !== ev.pointerId) return;
+    this.mobileChatResize = null;
+    document.body.classList.remove('chat-box-dragging');
+    const bottom = document.documentElement.style.getPropertyValue('--mobile-chat-bottom');
+    try {
+      if (bottom) localStorage.setItem(MOBILE_CHAT_BOTTOM_KEY, bottom.trim());
+    } catch {
+      /* storage unavailable */
+    }
   }
 
   private applyChatBoxGeometry(): void {

--- a/tests/chat_keyboard_dismiss.test.ts
+++ b/tests/chat_keyboard_dismiss.test.ts
@@ -1,45 +1,23 @@
-// The mobile chat keyboard-dismiss seam: the pure decision that keeps an intentional
-// keyboard dismiss (blur, chat stays open) apart from the composer-close path (blur
-// after hide, which recovers the mobile-chat viewport). DOM-free, Node-tested.
+// The mobile chat keyboard-dismiss seam: the pure decision that keeps a keyboard dismiss
+// (blur, chat stays OPEN in its read view) apart from the composer-close path (blur after
+// the composer is hidden, which recovers the mobile-chat viewport). DOM-free, Node-tested.
 
 import { describe, expect, it } from 'vitest';
-import {
-  keyboardDismissEffect,
-  shouldRecoverOnComposerBlur,
-} from '../src/game/chat_keyboard_dismiss';
+import { shouldRecoverOnComposerBlur } from '../src/game/chat_keyboard_dismiss';
 
-describe('shouldRecoverOnComposerBlur (dismiss vs close differentiation)', () => {
+describe('shouldRecoverOnComposerBlur (dismiss keeps chat open in read view)', () => {
   it('recovers on a blur only when the composer is already hidden (the close path)', () => {
     // closeChat() sets display:none BEFORE blurring, so its blur must recover the
     // mobile-chat viewport (remove mobile-chat-open, re-sync the app viewport).
     expect(shouldRecoverOnComposerBlur('none')).toBe(true);
   });
 
-  it('does NOT recover on a blur while the composer is still shown (the dismiss / keep-open path)', () => {
-    // The keyboard-dismiss chevron blurs while the composer is still display:block, so
-    // this returns false and chat STAYS OPEN at its resting seat. Any non-'none' display
-    // (the composer stays visible) keeps chat open.
+  it('does NOT recover on a blur while the composer is still shown (the read-view dismiss)', () => {
+    // Hiding the keyboard blurs the composer while it is still display:block, so this
+    // returns false and chat STAYS OPEN in its centered read view. Any non-'none' display
+    // (the composer stays visible) keeps chat open; only the Chat button closes it.
     expect(shouldRecoverOnComposerBlur('block')).toBe(false);
     expect(shouldRecoverOnComposerBlur('')).toBe(false);
     expect(shouldRecoverOnComposerBlur('flex')).toBe(false);
-  });
-});
-
-describe('keyboardDismissEffect (the dismiss chevron intent)', () => {
-  it('blurs the composer but never closes chat', () => {
-    // The dismiss drops the keyboard (blur) while keeping the log + composer up. Pinning
-    // both fields proves a regression that funnelled dismiss into the close path (which
-    // would set closeChat true) fails here.
-    expect(keyboardDismissEffect()).toEqual({ blurComposer: true, closeChat: false });
-  });
-
-  it('is a pure constant (input-free: this module owns ONLY the dismiss decision)', () => {
-    // The dismiss effect is input-free and stable. main.ts applies ONLY effect.blurComposer
-    // at the chevron's click (it never reads effect.closeChat); the Enter-send, Escape-close,
-    // and chat-toggle paths keep their own closeChat calls, which hide then blur, so
-    // shouldRecoverOnComposerBlur('none') is true for them (proven above). The value pin at
-    // the top of this describe is the real guard; a self-equal comparison would pass for
-    // ANY constant, so it is deliberately omitted here.
-    expect(keyboardDismissEffect().blurComposer).toBe(true);
   });
 });

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -433,29 +433,21 @@ describe('client HTML shell', () => {
         /id="chat-dismiss"[^>]*data-i18n-aria="hudChrome\.mobile\.hideKeyboard"/,
       );
     }
-    // Hidden by default EVERYWHERE via a base rule (so it is not a stray button on
-    // desktop, which has no mobile-touch-scoped rule to hide it), then revealed only
-    // under body.mobile-touch.mobile-chat-open.mobile-keyboard-open (a later @layer wins
-    // there): the chevron shows ONLY while there is a keyboard to hide, never as a dead
-    // control after it has dropped the keyboard.
+    // Hidden by default (desktop) AND hidden on mobile in the current model: the OS
+    // keyboard's own hide key returns to the read view and the Chat icon closes the panel,
+    // so there is no in-app chevron shown (no mobile show rule reveals it).
     expect(hudCss).toContain('#chat-dismiss {\n    display: none;\n  }');
     expect(hudMobileCss).toContain('body.mobile-touch #chat-dismiss {\n    display: none;');
-    const openRule =
-      hudMobileCss.match(
-        /body\.mobile-touch\.mobile-chat-open\.mobile-keyboard-open #chat-dismiss \{([^}]*)\}/,
-      )?.[1] ?? '';
-    expect(openRule).toMatch(/width:\s*40px/);
-    expect(openRule).toMatch(/height:\s*40px/);
-    expect(openRule).toMatch(/display:\s*inline-flex/);
-    // The dismiss blur does NOT close chat: the pure seam differentiates it from the
-    // close path (recover only when the composer is already hidden).
+    expect(hudMobileCss).not.toMatch(/#chat-dismiss \{[^}]*display:\s*inline-flex/);
+    // Dismissing the keyboard KEEPS chat open in the read view: the composer's blur handler
+    // recovers the viewport ONLY on the close path (composer already hidden), never on a
+    // still-shown-composer blur. Only the Chat button closes chat.
     expect(mainTs).toContain(
       'if (shouldRecoverOnComposerBlur(chatInput.style.display)) recoverFromMobileKeyboard();',
     );
-    // The wiring pins BOTH the lookup (the literal id string, so a getElementById typo
-    // cannot silently pass) and the blur-only apply.
+    // The chevron (kept wired for parity) blurs the composer to drop the keyboard, not close.
     expect(mainTs).toContain("document.getElementById('chat-dismiss')");
-    expect(mainTs).toContain('if (effect.blurComposer) chatInput.blur();');
+    expect(mainTs).toContain("chatDismiss?.addEventListener('click', () => chatInput.blur());");
     // Chat surfaces stay full-contrast while open (the idle fade never dims the log/composer).
     expect(hudMobileCss).toContain(
       'body.mobile-touch.mobile-chat-open #chatlog-wrap,\n  body.mobile-touch.mobile-chat-open #chatlog-tabs,\n  body.mobile-touch.mobile-chat-open #chat-input,\n  body.mobile-touch.mobile-chat-open #mobile-chat {\n    opacity: 1;',
@@ -472,62 +464,36 @@ describe('client HTML shell', () => {
     );
   });
 
-  it('docks the keyboard-open chat as a non-overlapping column that reserves the composer', () => {
-    // Real-device chat-overlap fix: while the on-screen keyboard is up the chat log used to
-    // overflow DOWN into the composer (the log's lower lines rendered under the typed text).
-    // The wrap is now a flex COLUMN with a DEFINITE height that reserves the docked composer:
-    // it subtracts the top inset and a 126px composer reservation (the 110px autosize cap
-    // CHAT_INPUT_MAX_H + 8px gap + 8px dock) from the visible-above-keyboard height, so the
-    // log frame can only fill the space ABOVE the composer, never over it, even when a long
-    // multi-line draft grows the composer to its cap.
+  it('fills the keyboard-open chat as a flex column above the keyboard (composer is a flow item)', () => {
+    // While the keyboard is up the whole panel (composer bar + tabs + log) re-lays as a flex
+    // column filling the space ABOVE the keyboard: the log frame flexes to fill, and the
+    // composer is a FLOW item at the top of the panel (from the open rule), not a separately
+    // docked bar, so no composer reservation is needed.
     const wrapRule =
       hudMobileCss.match(
         /body\.mobile-touch\.mobile-keyboard-open\.mobile-chat-open #chatlog-wrap \{([^}]*)\}/,
       )?.[1] ?? '';
-    expect(wrapRule).toMatch(/display:\s*flex/);
-    expect(wrapRule).toMatch(/flex-direction:\s*column/);
-    // The height RESERVES the composer: visible-vh minus the top inset minus the 126px
-    // composer box. The literal 126px reservation is load-bearing (a regression that drops it
-    // re-introduces the overlap), so pin it alongside the var.
+    // Definite height: the visible-above-keyboard band minus the top inset minus an 8px gap.
+    expect(wrapRule).toMatch(/top:\s*max\(6px, env\(safe-area-inset-top\)\)/);
     expect(wrapRule).toMatch(/var\(--mobile-keyboard-visible-vh, 100vh\)/);
-    // Whitespace-tolerant: biome breaks the long calc across lines.
-    expect(wrapRule).toMatch(/-\s+126px/);
-    // The log frame FLEXES to fill only the tabs-to-composer gap (not height:100%, the old bug
-    // that made the frame overflow past the wrap by the tab strip's height).
+    expect(wrapRule).toMatch(/-\s+8px/);
+    // No composer reservation any more (the composer is a flow item, not a docked bar).
+    expect(wrapRule).not.toMatch(/--mobile-composer-h/);
+    // The composer is a flow item in the panel (from the open rule), not absolutely docked.
+    const openInputRule =
+      hudMobileCss.match(/body\.mobile-touch\.mobile-chat-open #chat-input \{([^}]*)\}/)?.[1] ?? '';
+    expect(openInputRule).toMatch(/position:\s*static/);
+    expect(openInputRule).toMatch(/order:\s*-1/);
+    // The log frame fills the rest of the panel (from the open rule); not height:100%.
     const frameRule =
-      hudMobileCss.match(
-        /body\.mobile-touch\.mobile-keyboard-open\.mobile-chat-open #chatlog-frame \{([^}]*)\}/,
-      )?.[1] ?? '';
+      hudMobileCss.match(/body\.mobile-touch\.mobile-chat-open #chatlog-frame \{([^}]*)\}/)?.[1] ??
+      '';
     expect(frameRule).toMatch(/flex:\s*1 1 auto/);
-    expect(frameRule).toMatch(/min-height:\s*0/);
     expect(frameRule).not.toMatch(/height:\s*100%/);
-    // The tab strip keeps its natural height at the top of the column (never shrunk).
-    const tabsRule =
-      hudMobileCss.match(
-        /body\.mobile-touch\.mobile-keyboard-open\.mobile-chat-open #chatlog-tabs \{([^}]*)\}/,
-      )?.[1] ?? '';
-    expect(tabsRule).toMatch(/flex:\s*0 0 auto/);
-    // The composer still docks just above the keyboard's top edge.
-    const inputRule =
-      hudMobileCss.match(
-        /body\.mobile-touch\.mobile-keyboard-open\.mobile-chat-open #chat-input \{([^}]*)\}/,
-      )?.[1] ?? '';
-    expect(inputRule).toMatch(
-      /bottom:\s*calc\(100vh - var\(--mobile-keyboard-visible-vh, 100vh\) \+ 8px\)/,
-    );
-    // The low-priority Chat/Social/More trio yields while the keyboard is up so the docked tab
-    // strip owns a clean top-left (fairness-neutral menu chrome, restored on keyboard dismiss).
+    // The low-priority Chat/Social/More trio yields while the keyboard is up (fairness-neutral
+    // menu chrome, restored on keyboard dismiss).
     expect(hudMobileCss).toMatch(
       /body\.mobile-touch\.mobile-keyboard-open\.mobile-chat-open #mobile-combat-controls \{\s*display:\s*none;/,
-    );
-    // The dismiss chevron is CENTERED in the 84px reply composer's row (an attached part of the
-    // composer, not a corner button): base dock (+8px) plus (84 - 40) / 2 = 22px => +30px.
-    const chevronReplyRule =
-      hudMobileCss.match(
-        /body\.mobile-touch\.mobile-chat-open\.mobile-chat-reply\.mobile-keyboard-open #chat-dismiss \{([^}]*)\}/,
-      )?.[1] ?? '';
-    expect(chevronReplyRule).toMatch(
-      /bottom:\s*calc\(100vh - var\(--mobile-keyboard-visible-vh, 100vh\) \+ 30px\)/,
     );
   });
 

--- a/tests/mobile_chat_centered.test.ts
+++ b/tests/mobile_chat_centered.test.ts
@@ -1,0 +1,165 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const mainTs = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8').replace(
+  /\r\n/g,
+  '\n',
+);
+const hudTs = readFileSync(new URL('../src/ui/hud.ts', import.meta.url), 'utf8').replace(
+  /\r\n/g,
+  '\n',
+);
+
+// Mobile chat "centered + large + in front" fix. On touch, tapping the Chat button
+// used to open the log as a small strip pinned to the bottom-left corner (and the
+// composer sat BEHIND the #mobile-controls layer, z-index 25 vs 60). The fix makes
+// the open chat a large, horizontally-centered panel that renders in front of the
+// in-game controls. These assertions pin that layout so a future edit cannot quietly
+// shrink it back into the corner. Everything here is scoped to body.mobile-touch, so
+// the classic desktop bottom-left chat panel is untouched.
+const hudMobileCss = readFileSync(
+  new URL('../src/styles/hud.mobile.css', import.meta.url),
+  'utf8',
+).replace(/\r\n/g, '\n');
+
+// The z-index of the full-screen #mobile-controls layer the open chat must beat to
+// read as "in front of the other content". Pinned from the same file so the two
+// numbers can never silently diverge.
+function mobileControlsZ(): number {
+  const body =
+    hudMobileCss.match(/body\.mobile-touch\.game-active #mobile-controls \{([^}]*)\}/)?.[1] ?? '';
+  const m = body.match(/z-index:\s*(\d+)/);
+  expect(m, 'mobile-controls z-index should be pinned in hud.mobile.css').toBeTruthy();
+  return Number(m?.[1] ?? 0);
+}
+
+function ruleBody(selector: string): string {
+  // selector is already regex-escaped by the caller.
+  return hudMobileCss.match(new RegExp(`${selector} \\{([^}]*)\\}`))?.[1] ?? '';
+}
+
+describe('mobile chat centered/large/in-front layout', () => {
+  it('defines a large shared panel width var on the open chat', () => {
+    const body = ruleBody('body\\.mobile-touch\\.mobile-chat-open');
+    // A single DRY width var drives the wrap AND the composer AND the dismiss-chevron
+    // offset, so they always agree. It is large: a generous cap that falls back to
+    // (viewport - a small margin) on a phone, never the old ~340px strip.
+    expect(body).toMatch(/--mobile-chat-w:\s*min\(560px,\s*calc\(100vw - 24px\)\)/);
+  });
+
+  it('centers the open chat log horizontally as a wide, tall, elevated panel', () => {
+    const wrap = ruleBody('body\\.mobile-touch\\.mobile-chat-open #chatlog-wrap');
+    // Horizontally centered (not corner-pinned).
+    expect(wrap).toMatch(/left:\s*50%/);
+    expect(wrap).toMatch(/transform:\s*translateX\(-50%\)/);
+    // Uses the shared large width var, not a narrow fixed strip.
+    expect(wrap).toMatch(/width:\s*var\(--mobile-chat-w\)/);
+    // A flex column so the tab strip stays natural and the frame fills the rest.
+    expect(wrap).toMatch(/display:\s*flex/);
+    expect(wrap).toMatch(/flex-direction:\s*column/);
+    // Tall: its top clears the top-left Chat button trio (so the close tap survives),
+    // pinned decisively (safe-area inset + a real gap that clears the trio), not merely
+    // "some calc", so a regression to top:0 that re-covers the Chat button would fail here.
+    expect(wrap).toMatch(/top:\s*calc\(max\(8px, env\(safe-area-inset-top\)\) \+ 64px\)/);
+    // The bottom is player-resizable via a CLAMPED --mobile-chat-bottom (drag handle), with
+    // a small default so the panel is large by default. Whitespace-tolerant: biome breaks
+    // the long calc across lines.
+    expect(wrap).toMatch(/bottom:\s*calc\([\s\S]*env\(safe-area-inset-bottom\)/);
+    expect(wrap).toMatch(/clamp\([\s\S]*var\(--mobile-chat-bottom, 52px\)/);
+    // Raised above the sibling in-HUD frames (which sit in the ~19-45 band).
+    const z = Number(wrap.match(/z-index:\s*(\d+)/)?.[1] ?? '0');
+    expect(z).toBeGreaterThanOrEqual(50);
+  });
+
+  it('fills the open panel with the log frame (drops the ~4-line strip cap)', () => {
+    const frame = ruleBody('body\\.mobile-touch\\.mobile-chat-open #chatlog-frame');
+    expect(frame).toMatch(/flex:\s*1 1 auto/);
+    expect(frame).toMatch(/min-height:\s*0/);
+    // The old strip cap (a fixed 4-line height) must not survive into the open state.
+    expect(frame).toMatch(/height:\s*auto/);
+    const tabs = ruleBody('body\\.mobile-touch\\.mobile-chat-open #chatlog-tabs');
+    expect(tabs).toMatch(/flex:\s*0 0 auto/);
+  });
+
+  it('places the composer as a flow bar at the top of the panel (desktop-style, in front)', () => {
+    const input = ruleBody('body\\.mobile-touch\\.mobile-chat-open #chat-input');
+    // The composer is the panel's FIRST child (order -1), a static flow item above the tabs
+    // + log, not an absolutely-positioned / docked bar. It no longer needs a z-index lift:
+    // main.ts moves it INSIDE #chatlog-wrap (in #ui, z 80), which already paints above the
+    // #mobile-controls layer (z 60).
+    expect(input).toMatch(/position:\s*static/);
+    expect(input).toMatch(/order:\s*-1/);
+    expect(input).toMatch(/width:\s*100%/);
+    // The move is done in main.ts (a flow item inside the panel, not a sibling of #ui).
+    expect(mainTs).toContain('ensureMobileComposerInPanel');
+    expect(mainTs).toContain('wrap.insertBefore(chatInput, wrap.firstChild)');
+    // mobileControlsZ() stays referenced so the pinned control-layer z-index cannot drift
+    // out from under the "panel paints in front" reasoning above.
+    expect(mobileControlsZ()).toBe(60);
+  });
+
+  it('applies the centered/large/in-front panel on the compact tier (portrait phones)', () => {
+    // resolveTier() returns 'compact' whenever width <= 700, so a portrait phone runs
+    // the compact tier: its overrides are the PRIMARY path, not an edge case. Without
+    // them, the tier's own closed-seat width/height/bottom rules (which are later in the
+    // file at equal specificity) would pin the open chat back to a narrow bottom strip.
+    const wrap = ruleBody(
+      'body\\.mobile-touch\\.hud-mobile-compact\\.mobile-chat-open #chatlog-wrap',
+    );
+    expect(wrap).toMatch(/width:\s*var\(--mobile-chat-w\)/);
+    // The compact bottom MUST track --mobile-chat-bottom (not a fixed value), or the resize
+    // handle moves but the panel never changes size (the real-device resize bug).
+    expect(wrap).toMatch(/var\(--mobile-chat-bottom, 52px\)/);
+    const frame = ruleBody(
+      'body\\.mobile-touch\\.hud-mobile-compact\\.mobile-chat-open #chatlog-frame',
+    );
+    expect(frame).toMatch(/flex:\s*1 1 auto/);
+    expect(frame).toMatch(/height:\s*auto/);
+  });
+
+  it('bottom-anchors the open log so recent lines sit near the composer', () => {
+    // Classic chat grows from the bottom; in a tall panel the lines must sit at the
+    // bottom (nearest the composer), not cluster at the top of a mostly-empty frame.
+    const pane = ruleBody(
+      'body\\.mobile-touch\\.mobile-chat-open #chatlog-frame \\.chat-pane\\.active',
+    );
+    expect(pane).toMatch(/display:\s*flex/);
+    expect(pane).toMatch(/flex-direction:\s*column/);
+    // The non-clipping bottom-anchor trick (collapses to 0 on overflow, unlike
+    // justify-content:flex-end which would hide the top of a long log).
+    const firstLine = ruleBody(
+      'body\\.mobile-touch\\.mobile-chat-open #chatlog-frame \\.chat-pane\\.active > :first-child',
+    );
+    expect(firstLine).toMatch(/margin-top:\s*auto/);
+  });
+
+  it('fills the keyboard-open panel above the keyboard (composer is a flow item, no reservation)', () => {
+    const wrap = ruleBody(
+      'body\\.mobile-touch\\.mobile-keyboard-open\\.mobile-chat-open #chatlog-wrap',
+    );
+    // The panel fills the visible-above-keyboard band. The composer is a flow item at the
+    // top of the panel, so there is NO --mobile-composer-h reservation and NO --mobile-chat-top
+    // clamp (both belonged to the removed docked-composer / drag-resize models).
+    expect(wrap).toMatch(/var\(--mobile-keyboard-visible-vh, 100vh\)/);
+    expect(wrap).not.toMatch(/--mobile-composer-h/);
+    // The keyboard-open wrap has no composer reservation; the composer flows at the top.
+    expect(wrap).not.toMatch(/--mobile-chat-bottom/);
+  });
+
+  it('gives the read panel a drag-to-resize bottom handle (persisted)', () => {
+    // The panel's bottom inset is player-resizable: a bottom grabber drives
+    // --mobile-chat-bottom, clamped in CSS so a saved value stays valid across orientations.
+    expect(hudMobileCss).toContain('.chat-mobile-resize {\n    display: none;\n  }');
+    const handle = ruleBody('body\\.mobile-touch\\.mobile-chat-open \\.chat-mobile-resize');
+    expect(handle).toMatch(/display:\s*flex/);
+    // A vertical drag must resize, not scroll the log/page; and a high z-index keeps it
+    // above any overlay (so nothing can swallow the drag).
+    expect(handle).toMatch(/touch-action:\s*none/);
+    expect(Number(handle.match(/z-index:\s*(\d+)/)?.[1] ?? '0')).toBeGreaterThanOrEqual(200);
+    // hud.ts creates the handle as a body-level element (high z) and persists the size.
+    expect(hudTs).toContain("resizeHandle.className = 'chat-mobile-resize';");
+    expect(hudTs).toContain('document.body.appendChild(resizeHandle)');
+    expect(hudTs).toContain("document.documentElement.style.setProperty('--mobile-chat-bottom'");
+    expect(hudTs).toContain('localStorage.setItem(MOBILE_CHAT_BOTTOM_KEY');
+  });
+});

--- a/tests/mobile_controls.test.ts
+++ b/tests/mobile_controls.test.ts
@@ -491,6 +491,8 @@ function mobileCallbacks() {
     onInteract: noop,
     onAutorun: () => false,
     onChat: noop,
+    onChatOpen: noop,
+    onChatClose: noop,
     onMenu: noop,
     onSocial: noop,
     onDiscord: noop,


### PR DESCRIPTION
## Summary

Reworks the mobile (touch) chat into a centered, desktop-style model. On the touch HUD:

- Tapping the Chat icon opens a large, centered READ panel in the middle of the screen (keyboard down), with the input bar at the TOP of the panel (above the tabs and log), mirroring desktop.
- Tapping the input bar raises the on-screen keyboard to type; hiding the keyboard returns to the read view (chat stays open). The Chat icon toggles the panel closed (and drops the keyboard if it is up).
- The composer is moved into the panel as a flow item (mobile only), so it no longer renders behind the `#mobile-controls` layer.
- The panel is player-resizable: a body-level drag handle on the bottom edge sets `--mobile-chat-bottom`, clamped in CSS and JS. The handle uses a high z-index plus `touch-action: none` so the drag registers reliably, and the value is clamped on restore/start/move so a stale out-of-range value can never make the drag feel stuck. The compact tier (phones: width <= 700 or height <= 480) reads the same var, so the panel actually resizes there.
- The open panel is a solid, readable surface (the reply-mode transparency fade was removed).

All of this is scoped to `body.mobile-touch`; the classic desktop chat (bottom-left, corner-grip resize) is unchanged.

## Behavior changes vs the previous mobile chat

- Tapping Chat no longer jumps straight to the keyboard; it opens a read view first.
- Hiding the keyboard returns to the read view instead of leaving a half-open state; only the Chat icon closes the panel.
- The in-app dismiss chevron is hidden on mobile (the OS keyboard hide key returns to the read view).

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full Vitest suite: 11,259 passed / 14 skipped
- [x] Production build succeeds
- [x] biome (changed files) clean; no em/en dashes or emojis
- [x] New `tests/mobile_chat_centered.test.ts` pins the centered/large/in-front layout, composer-as-top-bar, the resize handle (touch-action / z-index / body-level), and the compact-tier bottom using the resize var (the real-device resize regression). Updated `client_shell` / `chat_keyboard_dismiss` / `mobile_controls` tests for the new model.
- [x] Verified on a physical Pixel (landscape web): read view, tap-to-type, dismiss-returns-to-read, close-via-Chat, and drag-to-resize.

## Known follow-up (not this PR)

An inert white "Chat" bar shows at the bottom of the panel on-device; it could not be reproduced headlessly or traced to this change (nothing in the chat UI is styled white and it is unresponsive to taps). It does not affect the resize (the drag is grabbed above it). Needs a live-device inspect; flagged for a follow-up.