### PR TITLE
fix(sim): resummoning a same-alive warlock demon now gives a fresh pet

### DIFF
--- a/src/sim/pet/pet_commands.ts
+++ b/src/sim/pet/pet_commands.ts
@@ -313,15 +313,6 @@ export function summonPet(ctx: SimContext, owner: Entity, templateId: string): v
   const existing = petOf(ctx, owner.id, true);
   if (existing) {
     despawnPersistentPet(ctx, existing);
-    if (existing.templateId === templateId && !existing.dead) {
-      ctx.emit({
-        type: 'log',
-        text: `${existing.name} fades back into the void.`,
-        color: '#b894ff',
-        pid: owner.id,
-      });
-      return;
-    }
   }
 
   const pet = createDemonPet(ctx, owner, templateId);

--- a/tests/parity/coverage.test.ts
+++ b/tests/parity/coverage.test.ts
@@ -155,7 +155,7 @@ describe('coverage: each scenario fires its subsystem', () => {
     // Demon swap AND same-demon re-summon both produce a fresh demon answering the call
     // (re-summoning while the current demon is alive dismisses it and summons anew, it
     // never toggles off into no pet).
-    expect(logs.filter((t) => t.includes('answers your summons')).length).toBeGreaterThanOrEqual(3);
+    expect(logs.filter((t) => t.includes('answers your summons')).length).toBeGreaterThanOrEqual(4);
     // despawnPet scrubbed the hunter's targetId (set to the demon, nulled on its hard despawn).
     expect((rec.sim as any).player.targetId).toBeNull();
     // abandon's despawnPersistentPet scrub pulled the biter off the (now-gone) pet.

--- a/tests/parity/coverage.test.ts
+++ b/tests/parity/coverage.test.ts
@@ -152,9 +152,10 @@ describe('coverage: each scenario fires its subsystem', () => {
     expect(logs.some((t) => t.startsWith('You abandon'))).toBe(true);
     // Demon Heal channel ticked: applyDemonHealTick emits a heal2 with ability 'Demon Heal'.
     expect(ev.some((e) => e.type === 'heal2' && e.ability === 'Demon Heal')).toBe(true);
-    // Demon swap exercised BOTH branches: a new demon answered, then the same demon faded.
-    expect(logs.some((t) => t.includes('answers your summons'))).toBe(true);
-    expect(logs.some((t) => t.includes('fades back into the void'))).toBe(true);
+    // Demon swap AND same-demon re-summon both produce a fresh demon answering the call
+    // (re-summoning while the current demon is alive dismisses it and summons anew, it
+    // never toggles off into no pet).
+    expect(logs.filter((t) => t.includes('answers your summons')).length).toBeGreaterThanOrEqual(3);
     // despawnPet scrubbed the hunter's targetId (set to the demon, nulled on its hard despawn).
     expect((rec.sim as any).player.targetId).toBeNull();
     // abandon's despawnPersistentPet scrub pulled the biter off the (now-gone) pet.

--- a/tests/parity/golden/pet_commands.json
+++ b/tests/parity/golden/pet_commands.json
@@ -2290,14 +2290,14 @@
     {
       "tick": 80,
       "time": 4,
-      "nextId": 415,
-      "state": "e04c8549",
-      "events": "e3337e5d",
+      "nextId": 416,
+      "state": "2806ab15",
+      "events": "d9be4bae",
       "rng": {
         "draws": 158,
         "digest": "878ecdcb"
       },
-      "label": "demon-faded",
+      "label": "demon-resummoned",
       "players": [
         {
           "activeLoadout": -1,
@@ -2565,15 +2565,56 @@
             "min": 3,
             "speed": 2.9
           }
+        },
+        {
+          "aiState": "idle",
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.05,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.05,
+          "fallStartY": -0.525705,
+          "fiveSecondRule": 99,
+          "hp": 378,
+          "id": 415,
+          "kind": "mob",
+          "level": 12,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 378,
+          "moveSpeed": 5,
+          "onGround": true,
+          "overpowerUntil": -1,
+          "ownerId": 412,
+          "petMode": "defensive",
+          "pos": {
+            "x": 34,
+            "y": -0.525705,
+            "z": -1
+          },
+          "potionCooldownUntil": -1,
+          "spawnPos": {
+            "x": 34,
+            "y": -0.525705,
+            "z": -1
+          },
+          "stats": {
+            "armor": 495
+          },
+          "templateId": "gloomshade",
+          "weapon": {
+            "max": 15,
+            "min": 10,
+            "speed": 2
+          }
         }
       ]
     },
     {
       "tick": 80,
       "time": 4,
-      "nextId": 417,
-      "state": "d4caaf06",
-      "events": "4966d07c",
+      "nextId": 418,
+      "state": "34d84926",
+      "events": "2cf8a2d5",
       "rng": {
         "draws": 158,
         "digest": "878ecdcb"
@@ -2859,7 +2900,7 @@
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 50000,
-          "id": 416,
+          "id": 417,
           "inCombat": true,
           "kind": "mob",
           "level": 8,
@@ -2883,7 +2924,7 @@
           "stats": {
             "armor": 70
           },
-          "targetId": 415,
+          "targetId": 416,
           "templateId": "forest_wolf",
           "threat": [
             [
@@ -2902,8 +2943,8 @@
     {
       "tick": 80,
       "time": 4,
-      "nextId": 417,
-      "state": "d4caaf06",
+      "nextId": 418,
+      "state": "34d84926",
       "events": "741638a5",
       "rng": {
         "draws": 158,
@@ -3190,7 +3231,7 @@
           "fiveSecondRule": 99,
           "hostile": true,
           "hp": 50000,
-          "id": 416,
+          "id": 417,
           "inCombat": true,
           "kind": "mob",
           "level": 8,
@@ -3214,7 +3255,7 @@
           "stats": {
             "armor": 70
           },
-          "targetId": 415,
+          "targetId": 416,
           "templateId": "forest_wolf",
           "threat": [
             [

--- a/tests/parity/scenarios.ts
+++ b/tests/parity/scenarios.ts
@@ -558,10 +558,12 @@ function petAi(): Scenario {
 // on the pet so despawnPersistentPet's threat-scrub + retargetMob draws; then re-tames,
 // revives a dead pet, and a stow/restore round-trip (serializePet -> despawnPersistentPet
 // -> restorePet). A warlock summons a demon, channels Demon Heal (applyDemonHealTick:
-// heal2 + healingThreat), swaps demons (despawnPersistentPet + the "answers your summons"
-// vs "fades back into the void" branches), then stows a demon so despawnPet runs its
-// player-target + threat scrub (retargetMob draw). The despawn scrubs are the slice's
-// only rng draws, so the draw-order log pins them; the snapshots pin every state change.
+// heal2 + healingThreat), swaps demons (despawnPersistentPet + "answers your summons"),
+// then re-summons the SAME demon while it is alive (despawnPersistentPet + a fresh
+// full-health demon answers, rather than toggling off), then stows a demon so despawnPet
+// runs its player-target + threat scrub (retargetMob draw). The despawn scrubs are the
+// slice's only rng draws, so the draw-order log pins them; the snapshots pin every state
+// change.
 function petCommands(): Scenario {
   return {
     name: 'pet_commands',
@@ -665,8 +667,11 @@ function petCommands(): Scenario {
       const vw = sim.petOf(wpid) as AnyEntity;
       rec.notes.voidId = vw.id;
       rec.track(vw.id);
-      (sim as any).summonPet(warlock, 'gloomshade'); // same template, alive: "fades back into the void" (no new pet)
-      rec.snapshot('demon-faded');
+      (sim as any).summonPet(warlock, 'gloomshade'); // same template, alive: dismissed + a fresh full-health demon answers
+      const vw2 = sim.petOf(wpid) as AnyEntity;
+      rec.notes.void2Id = vw2.id;
+      rec.track(vw2.id);
+      rec.snapshot('demon-resummoned');
 
       // despawnPet (demon hard despawn): re-summon, point a player target + mob threat at it, stow the demon.
       (sim as any).summonPet(warlock, 'emberkin');

--- a/tests/pet_commands_module.test.ts
+++ b/tests/pet_commands_module.test.ts
@@ -181,9 +181,17 @@ describe('pet_commands module (P1b)', () => {
     expect(vw.id).not.toBe(imp.id);
     expect(sim.entities.has(imp.id)).toBe(false); // old demon hard-gone
 
-    // Swap to the SAME demon while alive: it fades into the void, leaving NO pet.
+    // Re-summon the SAME demon while alive: the old one is dismissed and a fresh,
+    // full-health one answers in its place (not a toggle-off into no pet).
+    const woundedId = vw.id;
+    vw.hp = Math.floor(vw.maxHp * 0.4);
     summonPet(sim.ctx, warlock, 'gloomshade');
-    expect(petOf(sim.ctx, wpid, true)).toBeNull();
+    const freshVw = petOf(sim.ctx, wpid) as AnyEntity;
+    expect(freshVw).toBeTruthy();
+    expect(freshVw.templateId).toBe('gloomshade');
+    expect(freshVw.id).not.toBe(woundedId);
+    expect(freshVw.hp).toBe(freshVw.maxHp);
+    expect(sim.entities.has(woundedId)).toBe(false);
   });
 
   it('is deterministic on seeded replay (same seed + same drive => identical state)', () => {

--- a/tests/pet_commands_module.test.ts
+++ b/tests/pet_commands_module.test.ts
@@ -153,7 +153,7 @@ describe('pet_commands module (P1b)', () => {
     expect(pet.autoAttack).toBe(false);
   });
 
-  it('warlock demon swap: answers vs fades-into-the-void + Demon Heal tick', () => {
+  it('warlock demon swap: fresh demon answers on swap + resummon + Demon Heal tick', () => {
     const sim = new Sim({ seed: 13, playerClass: 'warlock', noPlayer: true }) as AnySim;
     const wpid = sim.addPlayer('warlock', 'Demonist') as number;
     sim.setPlayerLevel(12, wpid);

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -1663,7 +1663,7 @@ describe('warlock demon summons', () => {
     expect(voidwalker.petTauntTimer).toBeGreaterThan(0);
   });
 
-  it('recasting the same demon unsummons it', () => {
+  it('recasting the same demon dismisses it and summons a fresh one', () => {
     const sim = makeSim('warlock');
     const demon = summonImp(sim);
     expect(demon.templateId).toBe('emberkin');
@@ -1673,7 +1673,11 @@ describe('warlock demon summons', () => {
     for (let i = 0; i < 20 * 5; i++) sim.tick();
 
     expect(sim.entities.has(demon.id)).toBe(false);
-    expect(sim.petOf(sim.playerId, true)).toBe(null);
+    const fresh = sim.petOf(sim.playerId, true);
+    expect(fresh).not.toBe(null);
+    expect(fresh?.templateId).toBe('emberkin');
+    expect(fresh?.id).not.toBe(demon.id);
+    expect(fresh?.hp).toBe(fresh?.maxHp);
   });
 
   it('recasting a dead demon resummons it instead of dismissing', () => {


### PR DESCRIPTION
## Problem

Fixes #1355.

Re-casting a warlock demon summon while you already have that demon (alive) dismisses the pet instead of giving you a fresh one. `summonPet` despawns the existing demon, then, if it is the same template and still alive, returned early ("fades back into the void"), leaving you with no pet. Swapping to a different demon, or resummoning a dead one, already produced a fresh full-health pet; only the same-demon-alive case toggled off.

## Steps to reproduce (before fix)

1. As a warlock, summon a Voidwalker (it is alive).
2. Cast Summon Voidwalker again.
3. Observe the pet vanish with no new pet in its place.

## Fix

`summonPet` (`src/sim/pet/pet_commands.ts`) had a same-template-alive branch that despawned the existing pet and then `return`ed before reaching `createDemonPet`. Every other branch (different template, or the same template but dead) already fell through to `createDemonPet` and got a fresh pet. Removing the early-return branch makes the same-demon-alive case behave the same as every other resummon: dismiss the old one, summon a fresh full-health one.

```mermaid
flowchart TD
    A["Warlock casts Summon Voidwalker\n(already has an alive voidwalker)"] --> B{"existing pet?"}
    B -- yes --> C["despawnPersistentPet(existing)"]
    B -- no --> E["createDemonPet(templateId)"]
    C --> D{"same template AND alive?"}
    D -- "before fix: yes" --> F["return early\n'fades back into the void'\n(NO PET LEFT)"]
    D -- "after fix: removed" --> E
    E --> G["fresh full-health demon answers\n'answers your summons'"]

    style F fill:#4a1f1f,stroke:#c0392b,color:#fff
    style G fill:#1f4a2b,stroke:#2ecc71,color:#fff
```

![flow diagram](https://cdn.jsdelivr.net/gh/jgyy/world-of-claudecraft@a4c2b30058f398d9c70ab45d5433a890b3773c78/pet_resummon_diagram.png)

## Verification

Live in the offline client (warlock, level 20): summon Voidwalker, then re-cast the same summon while it's alive.

```
post-resummon pet state: { hasPet: true, hp: 258, maxHp: 258 }
```

`hasPet: true` and `hp === maxHp` confirm a fresh, full-health demon answered instead of the old dismiss-with-nothing-left behavior.

![warlock resummon smoke test](https://cdn.jsdelivr.net/gh/jgyy/world-of-claudecraft@a4c2b30058f398d9c70ab45d5433a890b3773c78/pr1355_pet_resummon.png)

## Tests

- `tests/pet_commands_module.test.ts`: same-demon-alive resummon now asserts a fresh pet (different id, full health) instead of asserting no pet.
- `tests/threat.test.ts`: renamed/updated "recasting the same demon unsummons it" -> "recasting the same demon dismisses it and summons a fresh one", asserting the same.
- `tests/parity/coverage.test.ts` + `tests/parity/scenarios.ts` + regenerated `tests/parity/golden/pet_commands.json`: the parity scenario's same-demon-alive re-summon step now tracks and asserts the replacement pet instead of an emptied pet slot.

All of `tests/pet_commands_module.test.ts`, `tests/threat.test.ts`, `tests/parity/parity.test.ts`, `tests/parity/coverage.test.ts`, `tests/architecture.test.ts`, `tests/localization_fixes.test.ts` pass; `npx tsc --noEmit` is clean; `npm run build` succeeds; changed-file Biome is clean (only pre-existing whole-repo warnings, none introduced by this diff).

No merge conflicts against `release/v0.23.0` (branched from its current tip).
