### PR TITLE
chore(deploy): revert pg_stat_statements preload from postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,16 +3,6 @@ services:
     image: postgres:16-alpine
     container_name: eastbrook-db
     restart: unless-stopped
-    # Preload pg_stat_statements so monitoring can track per-query stats
-    # (slowest/most-frequent queries) via postgres_exporter. Takes effect on the
-    # next DB restart. One-time `CREATE EXTENSION pg_stat_statements;` is needed
-    # afterwards, handled idempotently by the monitoring deploy (woc-deploy).
-    command:
-      - "postgres"
-      - "-c"
-      - "shared_preload_libraries=pg_stat_statements"
-      - "-c"
-      - "pg_stat_statements.track=all"
     environment:
       POSTGRES_USER: eastbrook
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env. See .env.example.}


### PR DESCRIPTION
## What

Reverts the `pg_stat_statements` preload on the `eastbrook-db` postgres service, undoing #1661. Removes the `command:` (`shared_preload_libraries=pg_stat_statements`, `track=all`); postgres returns to its default command.

## Why

The postgres monitoring that used it has been removed. The `postgres_exporter` read `pg_stat_statements` every 15s (with query-text reconstruction and a stat lock), and alongside its default collectors it contended with the game's own DB writes, causing in-game stutter. Confirmed on dev: stopping the exporter fixed it. With the exporter gone (woc-deploy: removed), the preload is unused and only adds per-query overhead to the game, so it should come out.

## Impact

No app behaviour change. Takes effect on the next DB restart (the container recreates without the preload). Prod never ran this preload (not deployed there), so this only affects dev + the release branch. Already applied on dev via a temporary host override; this makes it permanent in code.

## Notes

Companion cleanup (separate, mostly done): woc-deploy removed the exporter + scrape jobs + Postgres dashboard (merged); the exporters are already stopped on dev and prod; the resources SG `:9187` rules are left for a later terraform pass.
