### PR TITLE
Prediction fix

### DIFF
--- a/src/render/self_motion.ts
+++ b/src/render/self_motion.ts
@@ -26,12 +26,7 @@
 // against a real lagging Sim.
 
 import { resolveMovement } from '../sim/colliders';
-import {
-  BACKPEDAL_MULT,
-  moveSpeedMult,
-  type PlayerMotionDeps,
-  stepPlayerMotion,
-} from '../sim/player_motion';
+import { moveSpeedMult, type PlayerMotionDeps, stepPlayerMotion } from '../sim/player_motion';
 import { DT, type Entity, type MoveInput, RUN_SPEED } from '../sim/types';
 
 // Latency cap on the extrapolation window: at least one snapshot-ish interval
@@ -71,8 +66,6 @@ export const SELF_MOTION_DEADBAND_YD = 0.05;
 export const SELF_MOTION_SNAP_DIST_SQ = 6 * 6;
 const MAX_FRAME_DT = 0.25; // matches the main-loop frame clamp
 const LEASH_SLACK_YD = 0.05;
-const BLOCKED_INTENT_PROGRESS_FRACTION = 0.45;
-const BLOCKED_INTENT_MOVE_FRACTION = 0.75;
 // Pose-history ring: enough to look SELF_MOTION_CAP_MAX_MS into the past with
 // headroom even on high-refresh displays (128 entries covers 267 ms at 480 fps
 // and over 2 s at 60 fps).
@@ -99,29 +92,6 @@ interface Vec3Like {
 }
 
 const clamp = (n: number, min: number, max: number): number => Math.max(min, Math.min(max, n));
-
-function horizontalIntent(
-  facing: number,
-  input: MoveInput,
-): { x: number; z: number; step: number } | null {
-  let mx = 0;
-  let mz = 0;
-  if (input.forward) mz += 1;
-  if (input.back) mz -= 1;
-  if (input.strafeLeft) mx -= 1;
-  if (input.strafeRight) mx += 1;
-  const len = Math.hypot(mx, mz);
-  if (len === 0) return null;
-  mx /= len;
-  mz /= len;
-  const sin = Math.sin(facing);
-  const cos = Math.cos(facing);
-  return {
-    x: mz * sin - mx * cos,
-    z: mz * cos + mx * sin,
-    step: RUN_SPEED * (mz < 0 ? BACKPEDAL_MULT : 1) * DT,
-  };
-}
 
 export class SelfMotionPredictor {
   /**
@@ -303,30 +273,24 @@ export class SelfMotionPredictor {
     inp.strafeLeft = frame.moveInput.strafeLeft;
     inp.strafeRight = frame.moveInput.strafeRight;
     inp.jump = frame.moveInput.jump;
-    const intent = horizontalIntent(frame.displayFacing, inp);
-    let blockedHorizontalIntent = false;
+    // A blocked step needs NO special handling, and must never get any. The
+    // kernel runs the same swept static collision as the server, so when the
+    // display stops at a wall it is already RIGHT and the authoritative anchor
+    // is merely one echo behind, still mid-approach. Both converge on the wall
+    // face on their own, and the divergence measurement below sees ~zero error
+    // throughout (it compares the anchor against the display one echo ago, and
+    // the display stopped one echo ago too). Detecting the block and stripping
+    // the forward lead against the anchor instead yanks the avatar backward by
+    // RUN_SPEED x echo in a SINGLE frame (a yard at 200ms, unsmoothed, because
+    // the renderer follows this pose exactly), and then walks it back into the
+    // wall: the "collide and snap back" artifact. Leave the block alone.
     this.acc = Math.min(this.acc + dt, MAX_FRAME_DT);
     while (this.acc >= DT) {
-      const beforeX = actor.pos.x;
-      const beforeZ = actor.pos.z;
       actor.prevPos.x = actor.pos.x;
       actor.prevPos.y = actor.pos.y;
       actor.prevPos.z = actor.pos.z;
       actor.facing = frame.displayFacing;
       stepPlayerMotion(this.deps, actor, inp);
-      if (intent) {
-        const stepX = actor.pos.x - beforeX;
-        const stepZ = actor.pos.z - beforeZ;
-        const progress = stepX * intent.x + stepZ * intent.z;
-        const moved = Math.hypot(stepX, stepZ);
-        const expectedStep = intent.step * moveSpeedMult(actor, 0);
-        if (
-          progress < expectedStep * BLOCKED_INTENT_PROGRESS_FRACTION &&
-          moved < expectedStep * BLOCKED_INTENT_MOVE_FRACTION
-        ) {
-          blockedHorizontalIntent = true;
-        }
-      }
       this.acc -= DT;
     }
     const frac = this.acc / DT;
@@ -386,16 +350,6 @@ export class SelfMotionPredictor {
       // turned each 20Hz kernel step into a visible forward/back sawtooth.
       actor.pos.x = ax + (ex * budget) / elen;
       actor.pos.z = az + (ez * budget) / elen;
-    }
-
-    if (blockedHorizontalIntent && intent) {
-      const lead = (actor.pos.x - ax) * intent.x + (actor.pos.z - az) * intent.z;
-      if (lead > 0) {
-        actor.pos.x -= intent.x * lead;
-        actor.pos.z -= intent.z * lead;
-        actor.prevPos.x -= intent.x * lead;
-        actor.prevPos.z -= intent.z * lead;
-      }
     }
 
     this.out.x = actor.prevPos.x + (actor.pos.x - actor.prevPos.x) * frac;

--- a/tests/self_motion.test.ts
+++ b/tests/self_motion.test.ts
@@ -148,21 +148,68 @@ describe('SelfMotionPredictor', () => {
     expect(lab.srv.player.pos.z).toBeCloseTo(-40, 3);
   });
 
-  it('does not lead into a blocker and then reconcile back while forward is held', () => {
-    const lab = new Lab(120, FRAME_MS, { start: { x: 0, z: -0.15 }, facing: 0 });
+  // Running into a blocker is the case the predictor must NOT "correct": the
+  // display stops at the wall a full echo before the server does, and that is
+  // right. Stripping the lead against the lagging anchor teleports the avatar
+  // backward by RUN_SPEED x echo on the contact frame. A normal forward step at
+  // 60 fps is RUN_SPEED/60 = 0.117 yd, so any backward frame step of that order
+  // reads as a snap; the leash + divergence servo alone keep it sub-centimeter.
+  it.each([100, 200, 300])('does not snap the pose backward on contact at %ims echo', (lagMs) => {
+    const lab = new Lab(lagMs, FRAME_MS, { start: { x: 0, z: -6 }, facing: 0 });
     lab.frame();
-    const before = lab.frame();
-    if (!before.pose) throw new Error('no initial pose');
-
+    lab.frame();
     lab.setInput(mi({ forward: true }));
-    let farthestLead = 0;
-    for (let i = 0; i < 6; i++) {
+
+    let prevZ: number | null = null;
+    let worstBackwardStep = 0;
+    for (let i = 0; i < 240; i++) {
       const r = lab.frame();
       if (!r.pose) throw new Error('predictor disabled unexpectedly');
-      farthestLead = Math.max(farthestLead, r.pose.z - before.pose.z);
+      if (prevZ !== null) worstBackwardStep = Math.min(worstBackwardStep, r.pose.z - prevZ);
+      prevZ = r.pose.z;
     }
 
-    expect(farthestLead).toBeLessThan(0.03);
+    // The blocked-intent lead removal produced -0.30/-0.99/-1.69 yd here.
+    expect(worstBackwardStep).toBeGreaterThan(-0.05);
+    // and the pose still settles onto the wall the server stopped at.
+    expect(prevZ ?? Number.NaN).toBeCloseTo(lab.srv.player.pos.z, 1);
+  });
+
+  it('never renders the pose through a blocker it is running into', () => {
+    const lab = new Lab(200, FRAME_MS, { start: { x: 0, z: -6 }, facing: 0 });
+    lab.frame();
+    lab.frame();
+    lab.setInput(mi({ forward: true }));
+
+    let farthest = Number.NEGATIVE_INFINITY;
+    for (let i = 0; i < 240; i++) {
+      const r = lab.frame();
+      if (!r.pose) throw new Error('predictor disabled unexpectedly');
+      farthest = Math.max(farthest, r.pose.z);
+    }
+
+    // The predictor runs the same swept static collision as the server, so it
+    // cannot walk into the wall; only the divergence servo can nudge it a few
+    // centimetres past the resting face.
+    expect(farthest).toBeLessThan(lab.srv.player.pos.z + 0.1);
+  });
+
+  it('holds a settled pose while forward is held against a wall', () => {
+    const lab = new Lab(120, FRAME_MS, { start: { x: 0, z: -0.15 }, facing: 0 });
+    lab.setInput(mi({ forward: true }));
+    for (let i = 0; i < 60; i++) lab.frame(); // run in and settle
+
+    let prev = lab.frame().pose;
+    if (!prev) throw new Error('predictor disabled unexpectedly');
+    let worstJitter = 0;
+    for (let i = 0; i < 120; i++) {
+      const r = lab.frame();
+      if (!r.pose) throw new Error('predictor disabled unexpectedly');
+      worstJitter = Math.max(worstJitter, Math.hypot(r.pose.x - prev.x, r.pose.z - prev.z));
+      prev = r.pose;
+    }
+
+    expect(worstJitter).toBeLessThan(0.01);
   });
 
   it('keeps the horizontal error inside the latency leash for the whole run', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to World of ClaudeCraft!

New here? The contributing guide is available in your language:
https://github.com/levy-street/world-of-claudecraft/blob/main/CONTRIBUTING.md

Filling this out helps reviewers understand and merge your work faster. Anything
that doesn't apply to your change, feel free to delete or mark as N/A.
-->

## Summary

<!-- What does this PR change, and why? Link the motivation or design if there is one. -->

## Related issues

<!-- e.g. "Closes #123" or "Part of #456". Remove this section if it doesn't apply. -->

## Type of change

<!-- Check all that apply. -->

- [ ] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

<!-- The commands you ran and the manual steps you walked through. Be specific. -->

- Commands:
- Manual steps:

## Screenshots / recordings

<!--
If this PR changes anything a player or operator sees (HUD, windows, tooltips,
mobile controls, admin dashboard), please add before/after screenshots or a
short clip, on desktop and mobile where relevant. Remove this section for non-UI
changes.
-->

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [ ] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [ ] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [ ] N/A. This PR adds no player-visible strings.

### Hygiene

- [ ] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [ ] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

> **Tip:** commit messages and PR titles use [Conventional Commits](https://www.conventionalcommits.org/)
> with a scope where it fits (`feat(talents): ...`, `fix(net): ...`). It's a
> convention we like, not a requirement. Clear, descriptive messages are what
> matter most.

---

A complete checklist and a green CI run (tests, typecheck, and builds) are what
we look for before merging. Smaller, focused PRs land faster than large ones, and
reviewers may suggest changes, which is a normal and friendly part of the
process. Thank you for helping build World of ClaudeCraft. Questions? Join us on
[Discord](https://discord.gg/GjhnUsBtw).
