### PR TITLE
fix(valecup): possession-gated striking + confine match theatre to the Sowfield

### DIFF
--- a/src/sim/social/vale_cup.ts
+++ b/src/sim/social/vale_cup.ts
@@ -119,6 +119,15 @@ export const VC_KICKOFF_CIRCLE = 5; // yd
 // would be impossible; everyone else (either team) traps it immediately.
 export const VC_TRAP_KICK_GRACE = 0.4; // s the kicker is exempt from their own kick
 const VC_PLAYER_BODY_RADIUS = 0.5; // mirrors pathfind PLAYER_BODY_RADIUS
+// You may only STRIKE the loose ball (kick / pass / shoot) when it is genuinely
+// at your feet, never merely within the ability's aim range (18 to 42 yd), which
+// let a player launch the ball from anywhere on the pitch. This covers the
+// dribble/trap contact (VC_DRIBBLE_RADIUS + body), a dribbled ball riding a
+// stride ahead (its carry runs ~1.15x the dribbler's speed), and the bots'
+// swing reach (BOT_KICK_REACH in vale_cup_bots.ts, which MUST stay <= this so a
+// bot that commits to a kick actually connects). A keeper HOLDING the ball is
+// always exempt.
+export const VC_POSSESSION_RADIUS = 4; // yd from the ball you can play it
 const VC_DRIBBLE_MAX_BALL_HEIGHT = 1.2; // a ball overhead cannot be dribbled
 const VC_TRAP_MAX_BALL_HEIGHT = 1.8; // higher flight (the punt's arc) clears heads
 // Passing (sport_pass): auto-paced so it arrives at a controllable weight. Power
@@ -1306,7 +1315,11 @@ export function vcupBallKick(
   if (!ball) return;
   if (ball.holderPid !== null && ball.holderPid !== caster.id) return; // held: unkickable by others
   const maxRange = range > 0 ? range : MELEE_RANGE;
-  if (dist2d(caster.pos, ballVec(ball)) > maxRange) return;
+  // Possession gate: strike only a ball you actually have (holding it as keeper,
+  // or the loose ball at your feet). maxRange below stays the aim/touch reach.
+  if (ball.holderPid === null && dist2d(caster.pos, ballVec(ball)) > VC_POSSESSION_RADIUS) {
+    return;
+  }
   if (ball.holderPid === caster.id) {
     ball.holderPid = null; // launch from the hold
     ball.holdUntil = 0;
@@ -1434,6 +1447,7 @@ function pickPassReceiver(
   match: VcMatch,
   caster: Entity,
   team: 'A' | 'B',
+  maxSeek: number = VC_PASS_MAX_RANGE,
 ): Entity | null {
   const mates = team === 'A' ? match.teamA : match.teamB;
   const selfPid = caster.id;
@@ -1469,7 +1483,7 @@ function pickPassReceiver(
     let mx = mate.pos.x - caster.pos.x;
     let mz = mate.pos.z - caster.pos.z;
     const ml = Math.hypot(mx, mz);
-    if (ml < 1e-6 || ml > VC_PASS_MAX_RANGE) continue;
+    if (ml < 1e-6 || ml > maxSeek) continue;
     mx /= ml;
     mz /= ml;
     const dot = dirX * mx + dirZ * mz;
@@ -1496,8 +1510,12 @@ export function vcupBallPass(
   if (!ball) return;
   if (ball.holderPid !== null && ball.holderPid !== caster.id) return; // held by someone else
   const maxRange = range > 0 ? range : MELEE_RANGE;
-  if (dist2d(caster.pos, ballVec(ball)) > maxRange) return; // must be near the ball to play it
-  const receiver = pickPassReceiver(ctx, match, caster, team);
+  // Possession gate: you must have the ball (holding it, or loose at your feet),
+  // not merely be within the pass's reach.
+  if (ball.holderPid === null && dist2d(caster.pos, ballVec(ball)) > VC_POSSESSION_RADIUS) {
+    return;
+  }
+  const receiver = pickPassReceiver(ctx, match, caster, team, maxRange);
   if (!receiver) return; // nobody to pass to: the whistle stays quiet, no wild boot
   if (ball.holderPid === caster.id) {
     ball.holderPid = null;
@@ -1553,7 +1571,11 @@ export function vcupShoot(
   if (!ball) return;
   if (ball.holderPid !== null && ball.holderPid !== caster.id) return; // held by someone else
   const maxRange = range > 0 ? range : MELEE_RANGE;
-  if (dist2d(caster.pos, ballVec(ball)) > maxRange) return; // must be on the ball
+  // Possession gate: only shoot a ball at your feet (or one you hold as keeper).
+  // maxRange below is the charge/aim reach, not the possession radius.
+  if (ball.holderPid === null && dist2d(caster.pos, ballVec(ball)) > VC_POSSESSION_RADIUS) {
+    return;
+  }
   if (ball.holderPid === caster.id) {
     ball.holderPid = null;
     ball.holdUntil = 0;

--- a/src/sim/social/vale_cup_bots.ts
+++ b/src/sim/social/vale_cup_bots.ts
@@ -329,7 +329,10 @@ const BOT_CAST_PERIOD = 44; // ticks (~2.2s) between a field bot's ability decis
 const BOT_KEEPER_CAST_PERIOD = 8; // ticks between a keeper's dive/clear checks (stays sharp)
 const BOT_KEEPER_SHADE = 5.2; // yd the keeper shades off center (tracks the wider goal mouth)
 const VC_KEEPER_GUARD_DEPTH = 1; // yd the keeper stands off its own goal line
-const BOT_KICK_REACH = 3.5; // yd from the ball a bot will swing a kick
+// yd from the ball a bot will swing a kick. MUST stay <= VC_POSSESSION_RADIUS
+// (vale_cup.ts): the strike handlers reject a kick/shoot/pass beyond that, so a
+// bot committing to a swing from farther would connect with nothing.
+const BOT_KICK_REACH = 3.5;
 const BOT_SPRINT_BALL_DIST = 13; // yd from a loose ball a chaser pops Fresh Legs to reach it
 const BOT_SHOOT_RANGE = 14; // yd from the goal mouth a bot will shoot; farther: build up
 const BOT_PASS_MIN_LEAD = 6; // a teammate this much nearer the enemy goal is "ahead"

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -476,10 +476,12 @@ const SHOOT_CHARGE_MS = 850;
 const SHOOT_TAP_CHARGE = 0.6;
 const MOBILE_CONTEXT_LONG_PRESS_MS = 650;
 // Vale Cup walk-up "theatre": the anchored kickoff/goal/save/golden/end/countdown
-// banners + crowd fx. Played only when the emitting match's pitch is within
-// VCUP_THEATRE_RADIUS of the local player (the Sowfield you walked up to, or your
-// own practice pitch), so a distant match never leaks its alerts in. Personal
-// events (vcupFound/Result/BetSettled) are NOT here and always reach their owner.
+// banners + crowd fx. The real Sowfield match's theatre is gated to the stadium
+// footprint (isAtSowfield, the same predicate that arms the stadium music), so no
+// alert leaves the football ground; a private practice pitch (a far, isolated
+// instance) shows its theatre only to someone within VCUP_THEATRE_RADIUS of that
+// pitch. Personal events (vcupFound/Result/BetSettled) are NOT here and always
+// reach their owner.
 const VCUP_WALKUP_EVENTS = new Set([
   'vcupCountdown',
   'vcupKickoff',
@@ -8406,9 +8408,19 @@ export class Hud {
       // batch here, so this proximity gate is what keeps matches from crossing.
       if (VCUP_WALKUP_EVENTS.has(ev.type)) {
         const a = ev as unknown as { x: number; z: number };
-        const dx = a.x - sim.player.pos.x;
-        const dz = a.z - sim.player.pos.z;
-        if (dx * dx + dz * dz > VCUP_THEATRE_RADIUS * VCUP_THEATRE_RADIUS) continue;
+        if (isAtSowfield(a.x, a.z)) {
+          // Real Sowfield match: its theatre is gated to the stadium footprint,
+          // the same predicate that arms the stadium music, so no kickoff/goal
+          // banner leaks into Eastbrook or the wider map.
+          if (!isAtSowfield(sim.player.pos.x, sim.player.pos.z)) continue;
+        } else {
+          // A private practice instance (a far, isolated pitch): show its
+          // theatre only to someone standing on that same pitch, never the main
+          // match's audience.
+          const dx = a.x - sim.player.pos.x;
+          const dz = a.z - sim.player.pos.z;
+          if (dx * dx + dz * dz > VCUP_THEATRE_RADIUS * VCUP_THEATRE_RADIUS) continue;
+        }
       }
       // visual effects (swings, projectiles, glows) — for everyone nearby,
       // not just events involving this player

--- a/tests/vale_cup.test.ts
+++ b/tests/vale_cup.test.ts
@@ -7,8 +7,15 @@
 // assertion here compares exact inventories; the kit round-trip compares the
 // ABILITY list, not bags.
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { SPORT_KITS, VALE_CUP_BALL_TEMPLATE_ID } from '../src/sim/content/vale_cup';
+
+// The full-match bot sims here run thousands of deterministic ticks; the 5s
+// vitest default is too tight for them under CI's parallel load (they complete
+// in well under a second locally). Give the file the headroom the other heavy
+// sim suites use (climb_slope, sim, dungeons).
+vi.setConfig({ testTimeout: 30000 });
+
 import { DUNGEON_X_THRESHOLD, MOBS } from '../src/sim/data';
 import { Sim } from '../src/sim/sim';
 import {

--- a/tests/vale_cup.test.ts
+++ b/tests/vale_cup.test.ts
@@ -82,6 +82,63 @@ function tickUntil(sim: Sim, pred: () => boolean, maxTicks: number): SimEvent[] 
   return out;
 }
 
+describe('Vale Cup: possession gate (must be on the ball to play it)', () => {
+  // Stage a resting ball near the east goal, park the opponent in a far corner
+  // so it cannot trap, and return the live match + ball for a strike attempt.
+  function stageRestingBall(sim: Sim, a: number, b: number) {
+    const match = startBout(sim, a, b);
+    teleport(sim, b, PITCH.xMin + 1, PITCH.zMin + 1);
+    const ball = match.ball!;
+    ball.x = GOAL_LINE_EAST_X - 6;
+    ball.z = PITCH_CENTER.z;
+    ball.y = groundHeight(ball.x, ball.z, sim.cfg.seed);
+    ball.vx = 0;
+    ball.vy = 0;
+    ball.vz = 0;
+    ball.holderPid = null;
+    return { match, ball };
+  }
+  const ballSpeed = (ball: { vx: number; vz: number }) => Math.hypot(ball.vx, ball.vz);
+  const aimAtGoal = { x: GOAL_LINE_EAST_X + 12, z: PITCH_CENTER.z };
+
+  it('rejects a shot from off the ball (the reported anywhere-on-the-map bug)', () => {
+    const sim = makeWorld();
+    const a = addAt(sim, 'warrior', 'Aleph');
+    const b = addAt(sim, 'mage', 'Bet', 2, -40);
+    const { ball } = stageRestingBall(sim, a, b);
+    // Stand ~24yd off the ball: inside the old sport_shoot.range (34) that let a
+    // shot fire from anywhere, but well outside actual possession.
+    teleport(sim, a, ball.x - 24, ball.z);
+    sim.entities.get(a)!.facing = Math.PI / 2;
+    sim.castAbility('sport_shoot', a, aimAtGoal);
+    expect(ballSpeed(ball)).toBe(0); // no possession, no launch
+  });
+
+  it('rejects a kick and a pass from off the ball', () => {
+    const sim = makeWorld();
+    const a = addAt(sim, 'warrior', 'Aleph');
+    const b = addAt(sim, 'mage', 'Bet', 2, -40);
+    const { ball } = stageRestingBall(sim, a, b);
+    teleport(sim, a, ball.x - 16, ball.z); // inside sport_kick(18)/sport_pass(42) range
+    sim.entities.get(a)!.facing = Math.PI / 2;
+    sim.castAbility('sport_kick', a, aimAtGoal);
+    expect(ballSpeed(ball)).toBe(0);
+    sim.castAbility('sport_pass', a, aimAtGoal);
+    expect(ballSpeed(ball)).toBe(0);
+  });
+
+  it('lets you strike the ball once it is at your feet', () => {
+    const sim = makeWorld();
+    const a = addAt(sim, 'warrior', 'Aleph');
+    const b = addAt(sim, 'mage', 'Bet', 2, -40);
+    const { ball } = stageRestingBall(sim, a, b);
+    teleport(sim, a, ball.x - 2, ball.z); // on the ball (within VC_POSSESSION_RADIUS)
+    sim.entities.get(a)!.facing = Math.PI / 2;
+    sim.castAbility('sport_shoot', a, aimAtGoal);
+    expect(ballSpeed(ball)).toBeGreaterThan(0); // struck: the shot launches
+  });
+});
+
 describe('Vale Cup: queue guards', () => {
   it('rejects a dead, instanced, dueling-free litany with the arena literals', () => {
     const sim = makeWorld();


### PR DESCRIPTION
Two Vale Cup fixes that were made after PR #1586 merged and so never landed in `release/v0.23.0`. Re-cut cleanly onto the current base.

### 1. You must possess the ball to play it (major bug)
Kick / Pass / Shoot gated their contact check on the ability's **aim range** (`sport_kick` 18, `sport_shoot` 34, `sport_pass` 42 yd), so a player could launch the ball at goal from tens of yards away, effectively shooting from anywhere on the pitch without ever being on the ball.

- Striking now requires **possession**: within `VC_POSSESSION_RADIUS` (4 yd) of the loose ball, or holding it as keeper. The ability's range stays the aim/charge/touch reach.
- 4 yd covers the dribble/trap contact plus a dribbled ball riding a stride ahead, and stays at or above the bots' swing reach (`BOT_KICK_REACH` 3.5, with a cross-referenced invariant), so bots still connect while a ball across the pitch never responds.
- `pickPassReceiver` takes the seek cap as a param so the pass's `range` stays meaningful.
- Regression tests pin both directions: a shot/kick/pass from off the ball does not move it; a strike with the ball at your feet launches it.

### 2. Confine kickoff/goal theatre to the Sowfield
The live-score indicator was already gated to the stadium footprint, but the walk-up banners (countdown / kickoff / goal / save / golden / end) were still on a 200yd radius, which reaches into Eastbrook. They now gate on `isAtSowfield` (the predicate that arms the stadium music), so no alert leaves the football ground; a private practice instance keeps the proximity check for its own isolated pitch.

### Verification
- `npx tsc --noEmit` clean; `biome` clean; pre-push QA floor green.
- Full suite green: **11293 passing**, 14 skipped, 0 failing.
- Cut fresh off the current `release/v0.23.0`; the possession change is sim-only and adds no rng draw (a distance check + early return), so the vcup tick path stays parity-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)