### PR TITLE
fix(content): equalize heroic dungeon difficulty at level 22

### DIFF
--- a/src/sim/content/dungeon_difficulty.ts
+++ b/src/sim/content/dungeon_difficulty.ts
@@ -20,29 +20,30 @@ export interface HeroicDungeonTuning {
   marksPerParticipant: number;
 }
 
-// Tuning model follows classic-era (TBC) heroics: measured database pairs put
-// the heroic raw-damage jump at ~3.0-3.5x flat across leveling and endgame
-// dungeons (Gargolmar 3.00x, Nazan 3.28x, Omor 3.42x, cap-level Kargath
-// Bladefist 3.50x), with health following the cap-band level jump. The
-// damage multipliers below are calibrated against a GEARED level-20 roster
-// (endgame blues: tank ~1150 hp at 33% armor DR, cloth ~640 hp at 18%),
-// reproducing the TBC-heroic EXPERIENCE: a final boss chews a tank for
-// ~18-28% of max hp per swing (healers must actively pump), trash melee
-// takes ~30-55% of a clothie per hit, and boss melee on cloth is close to a
-// two-shot. That lands the raw heroic-vs-normal ratios above TBC's 3.5x
-// because this game's mitigation and hp pools are proportionally larger at
-// the cap; the EFFECTIVE severity is the calibration target. Recompute the
-// bands with the level-20 pin included (Hollow Crypt L10 mobs already gain
-// ~1.6x health and ~1.8x damage from the level bump alone). Mechanic damage
-// and support heals scale with the same multipliers
-// (mechanicDamageMult/mechanicHealMult in ../instances/difficulty.ts).
+// Tuning model: every heroic mob is pinned to LEVEL 22 (two above the level-20
+// player cap) and the four five-mans are damage-EQUALIZED, so a heroic feels
+// the same whichever one you run. The calibration target is an average elite
+// TRASH swing landing ~300 post-mitigation on the reference GEARED shaman
+// (full heroic mail: 2142 armor, 1493 hp, 48.55% DR vs a level-22 attacker),
+// i.e. ~20% of max hp per hit, with final bosses ~22-24%. Solving each dungeon
+// for that target INVERTS the multiplier ladder, because the harder dungeons
+// already carry bigger base weapon damage: hollow_crypt needs the largest
+// multiplier, gravewyrm_sanctum the smallest. Gear-band reference points at
+// these constants: full-heroic mail lands ~300 trash / ~330-350 boss per hit;
+// endgame blues tank (~1150 hp, ~31% DR at L22) ~35% trash / ~40% boss; blues
+// cloth (~640 hp, ~17% DR) ~76% per trash hit and a trash CRIT one-shots, so
+// heroics are gear-gated by design. Mechanic damage lands RAW (no armor step;
+// see aoePulse/stomp in ../mob/locomotion.ts) and scales with the same
+// per-dungeon multiplier via mechanicDamageMult; support heals scale with
+// mechanicHealMult (= healthMultiplier); both wired in
+// ../instances/difficulty.ts.
 export const HEROIC_DUNGEON_TUNING: Record<string, HeroicDungeonTuning> = {
   hollow_crypt: {
     id: 'hollow_crypt',
     difficulty: 'heroic',
-    level: 20,
+    level: 22,
     healthMultiplier: 1.9,
-    damageMultiplier: 3.4,
+    damageMultiplier: 6.8,
     armorMultiplier: 1.3,
     finalBossId: 'morthen',
     marksPerParticipant: 1,
@@ -50,9 +51,9 @@ export const HEROIC_DUNGEON_TUNING: Record<string, HeroicDungeonTuning> = {
   sunken_bastion: {
     id: 'sunken_bastion',
     difficulty: 'heroic',
-    level: 20,
+    level: 22,
     healthMultiplier: 2.0,
-    damageMultiplier: 3.8,
+    damageMultiplier: 6.2,
     armorMultiplier: 1.3,
     finalBossId: 'vael_the_mistcaller',
     marksPerParticipant: 1,
@@ -60,9 +61,9 @@ export const HEROIC_DUNGEON_TUNING: Record<string, HeroicDungeonTuning> = {
   drowned_temple: {
     id: 'drowned_temple',
     difficulty: 'heroic',
-    level: 20,
+    level: 22,
     healthMultiplier: 2.6,
-    damageMultiplier: 4.2,
+    damageMultiplier: 5.7,
     armorMultiplier: 1.25,
     finalBossId: 'ysolei',
     marksPerParticipant: 1,
@@ -70,18 +71,19 @@ export const HEROIC_DUNGEON_TUNING: Record<string, HeroicDungeonTuning> = {
   gravewyrm_sanctum: {
     id: 'gravewyrm_sanctum',
     difficulty: 'heroic',
-    level: 20,
+    level: 22,
     healthMultiplier: 2.0,
-    damageMultiplier: 4.6,
+    damageMultiplier: 5.4,
     armorMultiplier: 1.2,
     finalBossId: 'korzul_the_gravewyrm',
     marksPerParticipant: 1,
   },
   // The 10-player raid arena. Normal Nythraxis already swings ~3.7x harder
   // than Korzul, so the raid's heroic multiplier is small in RELATIVE terms
-  // while landing the hardest absolute hits in the game: the boss chews a
-  // geared tank for ~47% of max hp per 2.6s swing (a raid brings two or
-  // three healers), and add waves hit cloth for ~50%. The percentage
+  // while landing the hardest absolute hits in the game: at the level-22
+  // heroic pin (matching the 5-mans) the boss chews a geared tank for ~54%
+  // of max hp per 2.6s swing (a raid brings two or three healers), and add
+  // waves hit cloth for ~57%. The percentage
   // mechanics scale on heroic in the encounter script (Soul Rend 1.5x,
   // Deathless Rage lethal on a failed wardstone channel; see
   // encounters/nythraxis.ts). The attunement dungeon nythraxis_crypt is
@@ -91,7 +93,7 @@ export const HEROIC_DUNGEON_TUNING: Record<string, HeroicDungeonTuning> = {
   nythraxis_boss_arena: {
     id: 'nythraxis_boss_arena',
     difficulty: 'heroic',
-    level: 20,
+    level: 22,
     healthMultiplier: 1.6,
     damageMultiplier: 2.0,
     armorMultiplier: 1.2,

--- a/tests/dungeon_difficulty.test.ts
+++ b/tests/dungeon_difficulty.test.ts
@@ -55,7 +55,7 @@ describe('heroic tuning data contract', () => {
       nythraxis_boss_arena: 'nythraxis_scourge_of_thornpeak',
     });
     for (const tuning of Object.values(HEROIC_DUNGEON_TUNING)) {
-      expect(tuning.level).toBe(20);
+      expect(tuning.level).toBe(22);
       expect(MOBS[tuning.finalBossId], `${tuning.id} finalBossId is a real mob`).toBeTruthy();
     }
     expect(ITEMS[HEROIC_MARK_ITEM_ID]).toBeTruthy();
@@ -74,11 +74,13 @@ describe('heroic tuning data contract', () => {
   });
 
   it('pins the classic-era heroic multipliers per dungeon', () => {
-    // Calibrated against measured TBC pairs (see the tuning table's comment):
-    // overall raw ratios ~2.7-3.2x damage / ~2-3x health once the level-20
-    // pin is included, clamped to TBC's EFFECTIVE severity for the local
-    // armor math. Exact literals so an accidental retune (or a revert to the
-    // old ~1.1x elite bump) reddens deliberately.
+    // The four five-mans are damage-EQUALIZED at the level-22 pin: the raw
+    // damageMultiplier per dungeon is set so an average elite-trash swing lands
+    // ~300 post-mitigation on the reference geared shaman (see the tuning
+    // table's comment), which inverts the multiplier ladder because the harder
+    // dungeons already carry bigger base weapon damage. Exact literals so an
+    // accidental retune (or a revert to the old un-equalized ladder) reddens
+    // deliberately.
     expect(
       Object.fromEntries(
         Object.values(HEROIC_DUNGEON_TUNING).map((t) => [
@@ -87,10 +89,10 @@ describe('heroic tuning data contract', () => {
         ]),
       ),
     ).toEqual({
-      hollow_crypt: [1.9, 3.4, 1.3],
-      sunken_bastion: [2.0, 3.8, 1.3],
-      drowned_temple: [2.6, 4.2, 1.25],
-      gravewyrm_sanctum: [2.0, 4.6, 1.2],
+      hollow_crypt: [1.9, 6.8, 1.3],
+      sunken_bastion: [2.0, 6.2, 1.3],
+      drowned_temple: [2.6, 5.7, 1.25],
+      gravewyrm_sanctum: [2.0, 5.4, 1.2],
       // The raid multiplier is smaller in RELATIVE terms because normal
       // Nythraxis already lands the game's hardest hits (see the tuning
       // table's comment); its percentage mechanics scale separately in
@@ -121,14 +123,14 @@ describe('mobTemplateForDungeonDifficulty', () => {
   it('produces an exact heroic transform without mutating the base template', () => {
     const before = JSON.stringify(SYNTHETIC);
     const heroic = mobTemplateForDungeonDifficulty(SYNTHETIC, 'hollow_crypt', 'heroic');
-    // hollow_crypt tuning: health x1.9, damage x3.4, armor x1.3, level 20.
+    // hollow_crypt tuning: health x1.9, damage x6.8, armor x1.3, level 22.
     expect(heroic).not.toBe(SYNTHETIC);
-    expect(heroic.minLevel).toBe(20);
-    expect(heroic.maxLevel).toBe(20);
+    expect(heroic.minLevel).toBe(22);
+    expect(heroic.maxLevel).toBe(22);
     expect(heroic.hpBase).toBeCloseTo(190, 10);
     expect(heroic.hpPerLevel).toBeCloseTo(19, 10);
-    expect(heroic.dmgBase).toBeCloseTo(68, 10);
-    expect(heroic.dmgPerLevel).toBeCloseTo(6.8, 10);
+    expect(heroic.dmgBase).toBeCloseTo(136, 10);
+    expect(heroic.dmgPerLevel).toBeCloseTo(13.6, 10);
     expect(heroic.armorPerLevel).toBeCloseTo(5.2, 10);
     // Every heroic mob is floored to the anti-kite speed (player RUN_SPEED is
     // 7); a template already at or above the floor keeps its own speed.
@@ -145,7 +147,7 @@ describe('mobTemplateForDungeonDifficulty', () => {
 
 describe('mobLevelForDungeonDifficulty', () => {
   it('pins heroic spawns to the tuning level and passes rolled levels through otherwise', () => {
-    expect(mobLevelForDungeonDifficulty('hollow_crypt', 'heroic', 11)).toBe(20);
+    expect(mobLevelForDungeonDifficulty('hollow_crypt', 'heroic', 11)).toBe(22);
     expect(mobLevelForDungeonDifficulty('hollow_crypt', 'normal', 11)).toBe(11);
     expect(mobLevelForDungeonDifficulty('no_such_dungeon', 'heroic', 11)).toBe(11);
   });

--- a/tests/dungeons.test.ts
+++ b/tests/dungeons.test.ts
@@ -66,7 +66,7 @@ function mobInInstance(sim: AnySim, inst: any, templateId: string): AnyEntity {
 // Recompute the heroic spawn stats from the RAW base template and the tuning
 // record, independently of mobTemplateForDungeonDifficulty, mirroring createMob's
 // formulas. Dropping any multiplier from the transform reddens these pins even
-// though forcing level 20 alone would already raise the per-level stats.
+// though forcing level 22 alone would already raise the per-level stats.
 function expectedHeroicStats(template: MobTemplate, dungeonId: string) {
   const tuning = HEROIC_DUNGEON_TUNING[dungeonId];
   const levelUps = tuning.level - 1;
@@ -148,7 +148,7 @@ describe('dungeons: door-trigger entry/exit', () => {
 });
 
 describe('dungeons: heroic difficulty', () => {
-  it('claims heroic Hollow Crypt as a fixed heroic instance with level-20 transformed mobs', () => {
+  it('claims heroic Hollow Crypt as a fixed heroic instance with level-22 transformed mobs', () => {
     const heroic = makeSim(123);
     const heroicPid = heroic.addPlayer('warrior', 'Hero');
     heroic.setDungeonDifficulty('heroic', heroicPid);
@@ -159,10 +159,10 @@ describe('dungeons: heroic difficulty', () => {
     expect(heroicInst).toBeTruthy();
     expect(heroicInst.difficulty).toBe('heroic');
     const heroicMorthen = mobInInstance(heroic, heroicInst, 'morthen');
-    expect(heroicMorthen.level).toBe(20);
+    expect(heroicMorthen.level).toBe(22);
 
     // The health/damage/armor multipliers must survive independently of the
-    // level-20 bump: pin the exact recomputed values, not just a > compare.
+    // level-22 bump: pin the exact recomputed values, not just a > compare.
     const pins = expectedHeroicStats(MOBS.morthen, 'hollow_crypt');
     expect(heroicMorthen.maxHp).toBe(pins.maxHp);
     expect(heroicMorthen.weapon.min).toBe(pins.weaponMin);
@@ -242,7 +242,7 @@ describe('dungeons: heroic difficulty', () => {
 
       const inst = claimedDungeon(sim, dungeonId, 'heroic');
       expect(inst, `${dungeonId} did not claim a heroic instance`).toBeTruthy();
-      expect(mobInInstance(sim, inst, bossId).level).toBe(20);
+      expect(mobInInstance(sim, inst, bossId).level).toBe(22);
     }
   });
 
@@ -290,7 +290,7 @@ describe('dungeons: heroic difficulty', () => {
     enterDungeon(sim.ctx, 'hollow_crypt', pid);
     const heroicInst = claimedDungeon(sim, 'hollow_crypt', 'heroic');
     expect(heroicInst).toBeTruthy();
-    expect(mobInInstance(sim, heroicInst, 'morthen').level).toBe(20);
+    expect(mobInInstance(sim, heroicInst, 'morthen').level).toBe(22);
     // 6000+ ticks of empty-instance countdown: comfortably under a second alone,
     // but borderline at the 5s default under full-suite core contention.
   }, 20000);
@@ -330,7 +330,7 @@ describe('dungeons: heroic difficulty', () => {
     expect(sim.dungeonDifficulty(member)).toBe('heroic');
   });
 
-  it('boss adds summoned in a heroic instance spawn as level-20 transforms', () => {
+  it('boss adds summoned in a heroic instance spawn as level-22 transforms', () => {
     const sim = makeSim(31);
     const pid = sim.addPlayer('warrior', 'Adds');
     sim.setDungeonDifficulty('heroic', pid);
@@ -349,7 +349,7 @@ describe('dungeons: heroic difficulty', () => {
     const pins = expectedHeroicStats(MOBS.drowned_thrall, 'sunken_bastion');
     for (const add of adds) {
       expect(add.templateId).toBe('drowned_thrall');
-      expect(add.level).toBe(20);
+      expect(add.level).toBe(22);
       expect(add.maxHp).toBe(pins.maxHp);
       expect(add.mechanicDamageMult).toBe(HEROIC_DUNGEON_TUNING.sunken_bastion.damageMultiplier);
     }
@@ -757,7 +757,7 @@ describe('dungeons: heroic Nythraxis raid arena', () => {
 
     const boss = mobInInstance(sim, inst, NYTHRAXIS_BOSS_ID);
     const pins = expectedHeroicStats(MOBS[NYTHRAXIS_BOSS_ID], 'nythraxis_boss_arena');
-    expect(boss.level).toBe(20);
+    expect(boss.level).toBe(22);
     expect(boss.maxHp).toBe(pins.maxHp);
     expect(boss.weapon.min).toBe(pins.weaponMin);
     expect(boss.weapon.max).toBe(pins.weaponMax);
@@ -774,6 +774,7 @@ describe('dungeons: heroic Nythraxis raid arena', () => {
     const addPins = expectedHeroicStats(MOBS[NYTHRAXIS_ADD_ID], 'nythraxis_boss_arena');
     for (const add of adds) {
       expect(add.templateId).toBe(NYTHRAXIS_ADD_ID);
+      expect(add.level).toBe(22);
       expect(add.maxHp).toBe(addPins.maxHp);
       expect(add.mechanicDamageMult).toBe(
         HEROIC_DUNGEON_TUNING.nythraxis_boss_arena.damageMultiplier,


### PR DESCRIPTION
## Summary

Heroic 5-man difficulty was uneven and soft against geared characters. A full-item level-20 mail shaman was taking only ~160 damage per swing in heroic, roughly half the intended feel. Two root causes (both confirmed by tracing the shipped code, not the description):

1. **The per-dungeon `damageMultiplier` ladder (3.4 / 3.8 / 4.2 / 4.6) made the four heroics land wildly different hits** rather than equally difficult ones.
2. **Heroic mobs were pinned to level 20 (equal to the player cap), giving players maximum armor mitigation.** The "missing half" the reporter saw is their own armor: full heroic mail = 2142 armor = ~50% damage reduction, which halves the raw tuning-table swing. The multiplier was never lost; the numbers were just calibrated against blues-geared anchors, never a geared mail wearer.

## What changed

All heroic mobs now spawn at **level 22** (two above the cap), and the four five-mans are **damage-equalized**: each dungeon's multiplier is solved so an average elite-trash swing lands **~300 post-mitigation on the reference geared shaman** (2142 armor, 1493 hp, 48.55% DR vs a level-22 attacker), about 20% of max hp per hit, with final bosses at ~22-24%. Solving for that target **inverts** the multiplier ladder, because the harder dungeons already carry bigger base weapon damage:

| Dungeon | damageMultiplier | Trash avg hit on ref shaman | Final boss |
|---|---|---|---|
| Hollow Crypt | 3.4 -> **6.8** | ~290 (was ~133) | Morthen ~354 |
| Sunken Bastion | 3.8 -> **6.2** | ~295 (was ~162) | Vael ~321 |
| Drowned Temple | 4.2 -> **5.7** | ~284 (was ~197) | Ysolei ~328 |
| Gravewyrm Sanctum | 4.6 -> **5.4** | ~307 (was ~227) | Korzul ~345 |

The **Nythraxis raid arena** boss and its add waves also move to level 22. The raid keeps its 2.0 multiplier; the level bump raises its boss-on-tank swing from ~47% to ~54% of max hp and adds-on-cloth from ~50% to ~57%. (If we'd rather preserve the exact old raid feel, dropping its multiplier 2.0 -> 1.8 lands it back at today's numbers, but that was not requested.)

## Design consequences to be aware of (intended, flagged for sign-off)

- **Level 22 is a deliberate gear gate.** Blues cloth (~640 hp, ~17% DR) takes ~76% of max hp per trash hit and a trash crit one-shots; the reference mail shaman sits at ~20%. Heroics now expect gear, classic-heroic style.
- **Level 22 also lengthens fights on the player side:** white-swing miss goes 5% -> 19%, spell/CC hit 96% -> 82%, and mob armor/hp rise via the per-level terms (~28-34% longer TTK). Combined with roughly doubled incoming damage this is a real healer-mana squeeze.
- **Boss mechanic damage inherits the same multiplier and lands unmitigated** (no armor step), so e.g. Morthen's pulse doubles. Decoupling would be a small follow-up (an optional `mechanicDamageMultiplier` field).

## Test plan

- [x] `tests/dungeon_difficulty.test.ts`, `tests/dungeons.test.ts`, `tests/nythraxis_raid.test.ts` green (98/98); pins updated for level 22 and the new multiplier table, with new `add.level === 22` assertions on the raid add-wave test.
- [x] Related suites green: heroic vendor, warstomp/stoneskin fire-site scaling, snapshots, calibration snapshot, all raid/nythraxis suites, architecture/determinism guard.
- [x] `tsc` clean; `biome ci` clean on the changed files.
- [x] Empirically validated with a throwaway probe that spawned real heroic instances (including a forced Nythraxis add wave) and measured landed hits vs the reference shaman: every mob level 22, heroic transform intact, numbers within ~5% of the analytic target.
- [ ] Full `npm run gate` (release-tier) before merge.

## Follow-ups (not in this PR)

- Convert the throwaway damage probe into a committed post-mitigation band test (no shipped test currently asserts any post-armor heroic hit).
- Decide whether to soften the level-22 player-side miss/resist wall and/or decouple mechanic scaling from melee.