### PR TITLE
fix(desktop): give package.json author an email so the Linux deb build can publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.23.0",
   "private": true,
   "license": "MIT",
-  "author": "levy-street",
+  "author": {
+    "name": "Levy Street",
+    "email": "woc@levystreet.com"
+  },
   "type": "module",
   "main": "electron/main.cjs",
   "description": "World of Claudecraft: a classic-style micro-MMO + headless RL training environment",


### PR DESCRIPTION
## Summary

The v0.23.0 tag fired the desktop-publish workflow (run 29004689551): the verify guards and the macOS publish succeeded, but the Linux job failed in **Build Linux desktop artifacts** with:

    failedTask=build stackTrace=Error: Please specify author 'email' in the application package.json

electron-builder requires an author email to stamp the deb package maintainer; package.json had `"author": "levy-street"` with no email, and there is no `build.deb.maintainer` override. The macOS targets do not need it, which is why mac published fine.

This changes `author` to the object form with the project contact address (`woc@levystreet.com`, the canonical address already used across the tree). A repo-wide grep confirms nothing else consumes the package.json author field, and the AppImage/mac/win targets ignore it, so the change only affects deb metadata.

## Why it matters now

v0.23.0 re-enabled the site's Linux download link (#1579), but the Linux artifacts never reached the update host because this build failed. Until the backfill publishes, that link points at nothing.

## Test plan

- [x] `node -e "require('./package.json')"` parses; author resolves to `{name, email}`
- [ ] CI green on this PR
- [ ] After merge: manually dispatch **Desktop publish** from main with `publish` ticked (the documented backfill path; version lockstep still guards, tag/main-ancestry checks are skipped) and confirm the Linux job passes and uploads AppImage/deb + SHA256SUMS-linux + both feed files