### PR TITLE
fix(render): default Apple Silicon Macs to medium graphics, not ultra (#1676)

### DIFF
--- a/src/render/gfx.ts
+++ b/src/render/gfx.ts
@@ -468,6 +468,7 @@ export function isConstrainedBrowser(hints: GfxRuntimeHints): boolean {
 export type GpuClass =
   | 'software'
   | 'strongDesktop'
+  | 'appleSilicon'
   | 'flagshipMobile'
   | 'midIntegrated'
   | 'midMobile'
@@ -487,11 +488,14 @@ export function classifyGpuRenderer(name: string | undefined): GpuClass {
   // mid-integrated bucket so an Iris Plus 6xx / UHD 6xx / HD 5xx-6xx stays weak, consistent with
   // the existing leanFoliage treatment in settingsFor).
   if (isWeakIntegratedGpu(name)) return 'weak';
-  // Strong desktop discrete + Apple Silicon. The `(\(tm\))?` tolerates the "(TM)" some Windows
-  // drivers print after "Radeon" ("Radeon(TM) RX 580").
-  if (
-    /\b(rtx|gtx)\b|geforce|radeon(\(tm\))?\s?(rx|pro|vii)|\barc\b|\bnvidia\b|apple\s?m[1-9]/.test(n)
-  )
+  // Apple Silicon (M1..M9). Split out of strongDesktop: these are thermally constrained laptop
+  // SoCs (the MacBook form factor has no active-cooling headroom), so the resolver defaults them
+  // to the safe middle tier rather than ultra (issue 1676). Kept AHEAD of strongDesktop, whose
+  // regex no longer claims `apple m`. A player can still pick ultra manually.
+  if (/apple\s?m[1-9]/.test(n)) return 'appleSilicon';
+  // Strong desktop discrete. The `(\(tm\))?` tolerates the "(TM)" some Windows drivers print
+  // after "Radeon" ("Radeon(TM) RX 580").
+  if (/\b(rtx|gtx)\b|geforce|radeon(\(tm\))?\s?(rx|pro|vii)|\barc\b|\bnvidia\b/.test(n))
     return 'strongDesktop';
   // Recent flagship mobile.
   if (
@@ -561,6 +565,12 @@ export function resolveDefaultGraphicsPreset(hints: GfxRuntimeHints): number {
   if (gpu === 'strongDesktop' && !isMobile) return ampleOrUnknownMem ? PRESET_ULTRA : PRESET_HIGH;
   // A strong/flagship GPU on a touch device: capped at HIGH (ultra is desktop-only) for thermals.
   if (gpu === 'flagshipMobile' || (gpu === 'strongDesktop' && isMobile)) return PRESET_HIGH;
+  // Apple Silicon: an M-series iPad (touch) keeps the mobile HIGH cap above; an M-series Mac
+  // (non-touch) defaults to the safe middle. These SoCs can render high, but the thermally
+  // constrained MacBook form factor overheats and drains battery on a sustained ultra load, so
+  // medium is the right auto-default (the runtime governor can still climb; ultra stays a manual
+  // opt-in). Issue 1676.
+  if (gpu === 'appleSilicon') return isMobile ? PRESET_HIGH : PRESET_MEDIUM;
   if (gpu === 'midIntegrated' || gpu === 'midMobile') return PRESET_MEDIUM;
   if (
     gpu === 'unknown' &&

--- a/tests/gfx.test.ts
+++ b/tests/gfx.test.ts
@@ -221,9 +221,12 @@ describe('graphics tier resolution', () => {
 
   it('classifies GPU renderer strings into device-capability buckets', () => {
     expect(classifyGpuRenderer('ANGLE (NVIDIA, NVIDIA GeForce RTX 4080)')).toBe('strongDesktop');
+    // Apple Silicon is its own class (split from strongDesktop) so it can default to the safe
+    // middle rather than ultra on thermally constrained MacBooks (issue 1676).
     expect(classifyGpuRenderer('ANGLE (Apple, ANGLE Metal Renderer: Apple M2)')).toBe(
-      'strongDesktop',
+      'appleSilicon',
     );
+    expect(classifyGpuRenderer('Apple M1 Pro')).toBe('appleSilicon');
     // AMD discrete + Intel Arc desktop -> strongDesktop (the "(TM)" Windows drivers print is tolerated)
     expect(classifyGpuRenderer('ANGLE (AMD, AMD Radeon RX 6800 XT Direct3D11 vs_5_0 ps_5_0)')).toBe(
       'strongDesktop',
@@ -322,10 +325,37 @@ describe('graphics tier resolution', () => {
       expect(
         resolveDefaultGraphicsPreset({ ...phone, gpuRenderer: 'Adreno (TM) 740', deviceMemory: 8 }),
       ).toBe(3); // flagship phone
-      // an M-series iPad (strong GPU on a touch device) is capped at HIGH (ultra is desktop-only)
+      // an M-series iPad (Apple Silicon on a touch device) is capped at HIGH (ultra is desktop-only);
+      // the touch cap is unchanged by the MacBook thermal default (issue 1676).
       expect(resolveDefaultGraphicsPreset({ ...phone, gpuRenderer: 'Apple M2' })).toBe(3);
       expect(resolveDefaultGraphicsPreset({ ...phone, gpuRenderer: 'Adreno (TM) 330' })).toBe(1); // old phone
       expect(resolveDefaultGraphicsPreset(phone)).toBe(2); // typical/unknown phone -> medium
+    });
+
+    it('defaults Apple Silicon Macs to MEDIUM, not ultra (thermally constrained laptops, issue 1676)', () => {
+      // A MacBook (Apple Silicon on a non-touch device) with ample RAM+cores would have earned
+      // ULTRA under the old strongDesktop bucket; it now defaults to the safe middle so the fanless
+      // form factor does not sit pinned at ultra. Ample corroborating signal must NOT promote it.
+      for (const gpuRenderer of ['ANGLE (Apple, ANGLE Metal Renderer: Apple M2)', 'Apple M3 Max']) {
+        expect(
+          resolveDefaultGraphicsPreset({
+            ...desktop,
+            gpuRenderer,
+            deviceMemory: 8,
+            hardwareConcurrency: 16,
+          }),
+        ).toBe(2);
+      }
+      // Non-regression: a real strong desktop discrete GPU still reaches ULTRA (the split did not
+      // demote NVIDIA/AMD/Arc).
+      expect(
+        resolveDefaultGraphicsPreset({
+          ...desktop,
+          gpuRenderer: 'ANGLE (NVIDIA, NVIDIA GeForce RTX 4080)',
+          deviceMemory: 8,
+          hardwareConcurrency: 16,
+        }),
+      ).toBe(4);
     });
 
     it('rewards a strong desktop: ULTRA with a corroborating signal (or unreported mem), else HIGH', () => {


### PR DESCRIPTION
## Problem

Apple Silicon Macs (M1/M2/M3/M4) are classified as `strongDesktop` in `classifyGpuRenderer` (src/render/gfx.ts), so `resolveDefaultGraphicsPreset` returns `PRESET_ULTRA` on first run. These are thermally constrained, fanless/laptop SoCs, not desktop discrete cards with active-cooling headroom, so the ultra default produces sustained high GPU load, fan spin-up, and battery drain during normal play (issue #1676).

## Fix

Split Apple Silicon out of `strongDesktop` into its own `GpuClass` (`'appleSilicon'`) and default it to the safe middle in the resolver:

- **Apple Silicon on a Mac (non-touch) -> `PRESET_MEDIUM`**, the same inconclusive-GPU fallback the runtime governor can climb from. Ultra stays a manual opt-in in the graphics picker.
- **An M-series iPad (touch) keeps its existing `HIGH` cap** (ultra is desktop-only) - the touch path is unchanged, so this is scoped to the MacBook thermal case the issue reports.
- **Strong desktop discrete GPUs (NVIDIA/AMD/Arc) still reach `ULTRA`** - the split did not demote them.

`classifyGpuRenderer` remains the single source of GPU classification; nothing else in the tree switches on `GpuClass`, and the change draws no new dependencies (pure classification + resolver).

## Tests

`tests/gfx.test.ts`:
- `classifyGpuRenderer('Apple M2' / 'Apple M1 Pro')` now returns `'appleSilicon'` (was `'strongDesktop'`).
- New: an Apple Silicon Mac with ample RAM+cores resolves to MEDIUM (2), not ultra, for both `Apple M2` and `Apple M3 Max`; a corroborating RAM/core signal does not promote it.
- Non-regression pinned in the same case: an NVIDIA RTX 4080 still resolves to ULTRA (4).
- The existing M-series iPad -> HIGH (3) touch-cap assertion is preserved.

`tsc --noEmit` clean; `tests/gfx.test.ts` + `tests/architecture.test.ts` green (47 passed); biome clean on both changed files.

## Scope

Render-only graphics-tier detection; no sim/wire/server/i18n surface touched, and no new player-visible strings. Gameplay-neutral: the change only moves the first-run DEFAULT tier for one GPU family (a cosmetic/perf default the player can override), and the medium tier is an already-shipped fair tier.

Fixes #1676.