### PR TITLE
feat(game): remember the camera zoom level across sessions (#1657)

### DIFF
--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -115,6 +115,10 @@ export class Input {
   camYaw = Math.PI;
   camPitch = 0.32;
   camDist = 12;
+  // Fired whenever the player changes the zoom distance (wheel / pinch), so main.ts can
+  // persist it to settings (issue 1657). Not fired on a direct camDist assignment (the
+  // startup restore / Reset path sets the field itself), so restoring never re-persists.
+  onCameraDistChange?: (dist: number) => void;
   autorun = false;
   suspendMovement = false;
   // click-to-move (#95): a world destination the player clicked; the frame loop
@@ -279,7 +283,10 @@ export class Input {
 
   /** Move the camera in/out, clamped to the zoom limits. Shared by wheel + touch pinch. */
   zoomBy(delta: number): void {
-    this.camDist = Math.min(22, Math.max(3, this.camDist + delta));
+    const next = Math.min(22, Math.max(3, this.camDist + delta));
+    if (next === this.camDist) return;
+    this.camDist = next;
+    this.onCameraDistChange?.(next);
   }
 
   /** True while a mouse button is held for camera drag. */

--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -38,6 +38,11 @@ export const SETTING_RANGES = {
   // a wider FOV shows more of the world (good for situational awareness) while
   // a narrower one zooms in. Purely a comfort/visibility preference.
   cameraFov: { min: 55, max: 100, def: 60 },
+  // Camera zoom distance (Input.camDist), remembered across sessions like the other
+  // camera settings. Range mirrors Input.zoomBy's clamp; def 12 is the shipped starting
+  // distance. Set by the wheel/pinch zoom (persisted debounced from main.ts), applied back
+  // to Input on boot via the startup apply-all loop and on Reset (issue 1657).
+  cameraZoom: { min: 3, max: 22, def: 12 },
   renderScale: { min: 0.5, max: 1, def: 1 },
   fullscreen: { min: 0, max: 1, def: 1 },
   // on by default: post-cap players see their overflow/virtual-level bar; turn

--- a/src/main.ts
+++ b/src/main.ts
@@ -1369,6 +1369,16 @@ async function startGame(
     input.setAttackMoveEnabled(settings.get('attackMove'));
   }
 
+  // Persist the camera zoom distance so it is remembered next session (issue 1657). Debounced so
+  // a wheel burst or a touch pinch (which fires zoomBy per move frame) writes localStorage once it
+  // settles, not on every delta. The saved value is applied back to Input on boot by the startup
+  // apply-all loop (the 'cameraZoom' case in applySetting).
+  let zoomPersistTimer: ReturnType<typeof setTimeout> | undefined;
+  input.onCameraDistChange = (dist) => {
+    if (zoomPersistTimer !== undefined) clearTimeout(zoomPersistTimer);
+    zoomPersistTimer = setTimeout(() => settings.set('cameraZoom', dist), 400);
+  };
+
   // Engine/version/device are fixed for the session; the renderer's GPU tier is
   // resolved by now (initGfxTier ran during renderer construction). Re-stamp all
   // classes on every call so a manual Esc-menu override repaints cleanly.
@@ -1545,6 +1555,11 @@ async function startGame(
         break;
       case 'cameraFov':
         renderer.setCameraFov(v);
+        break;
+      case 'cameraZoom':
+        // Restore the remembered zoom on boot (via the startup apply-all loop) and on Reset.
+        // Assigning the field does not fire onCameraDistChange, so this never re-persists.
+        input.camDist = v;
         break;
       case 'renderScale':
         renderer.setRenderScale(v);

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -910,3 +910,27 @@ describe('Input touch invert-look', () => {
     expect(dragYawDelta).toBeGreaterThan(rawYawDelta * 1.5);
   });
 });
+
+describe('Input camera zoom (issue 1657)', () => {
+  it('zoomBy clamps camDist to [3,22] and reports each change to onCameraDistChange', () => {
+    const { input } = makeInput();
+    const changes: number[] = [];
+    input.onCameraDistChange = (d) => changes.push(d);
+    expect(input.camDist).toBe(12);
+    input.zoomBy(4); // 12 -> 16
+    input.zoomBy(-100); // clamps to the 3 min
+    input.zoomBy(100); // clamps to the 22 max
+    expect(input.camDist).toBe(22);
+    expect(changes).toEqual([16, 3, 22]);
+  });
+
+  it('does not fire onCameraDistChange when the clamp leaves camDist unchanged (no spurious persist)', () => {
+    const { input } = makeInput();
+    input.zoomBy(-100); // camDist -> 3 (min)
+    const changes: number[] = [];
+    input.onCameraDistChange = (d) => changes.push(d);
+    input.zoomBy(-5); // already at the min, no change
+    expect(input.camDist).toBe(3);
+    expect(changes).toEqual([]);
+  });
+});

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -33,6 +33,19 @@ describe('Settings', () => {
     expect(s.get('graphicsPreset')).toBe(2);
   });
 
+  it('remembers the camera zoom distance across sessions, clamped to the zoom range (issue 1657)', () => {
+    // Range mirrors Input.zoomBy's clamp so a persisted value is always applicable; def 12 is the
+    // shipped starting distance.
+    expect(SETTING_RANGES.cameraZoom).toEqual({ min: 3, max: 22, def: 12 });
+    const s = new Settings();
+    expect(s.get('cameraZoom')).toBe(12);
+    expect(s.set('cameraZoom', 100)).toBe(22); // clamped to max
+    expect(s.set('cameraZoom', 1)).toBe(3); // clamped to min
+    expect(s.set('cameraZoom', 8)).toBe(8);
+    // Persisted like every other setting: a fresh Settings (next session) reads the saved value.
+    expect(new Settings().get('cameraZoom')).toBe(8);
+  });
+
   it('keeps graphicsDefaultApplied false through an unrelated save and clears it on reset', () => {
     const s = new Settings();
     expect(s.get('graphicsDefaultApplied')).toBe(false);


### PR DESCRIPTION
## Problem

The camera zoom level (`Input.camDist`) resets to the default every time you exit and re-enter the game. Zoom all the way in on your character, come back the next day, and it is back at the default distance, unlike UI scale and the other settings which are remembered (issue #1657).

## Fix

Persist the zoom distance like every other setting, through the existing `settings.ts` store (`woc_settings`):

- Add a `cameraZoom` numeric setting. Its range mirrors `Input.zoomBy`'s `[3, 22]` clamp so a persisted value is always applicable; `def` 12 is the shipped starting distance.
- `Input` fires a new `onCameraDistChange` callback whenever the wheel or touch pinch changes the zoom. It does **not** fire on a direct `camDist` assignment, so restoring the saved value on boot never re-persists.
- `main.ts` persists it **debounced** (a touch pinch calls `zoomBy` per move frame, so this writes `localStorage` once the gesture settles, not on every delta).
- The saved value is applied back onto `Input` on boot by the startup apply-all loop, via a new `cameraZoom` case in `applySetting` (which also re-applies it on **Reset**).

Scoped to the required behavior (remember the zoom). The issue's optional "reset zoom on login" toggle is intentionally left out to keep this focused; it can be a follow-up.

## Tests

- `tests/settings.test.ts`: `cameraZoom` is in `SETTING_RANGES` at `{min:3,max:22,def:12}`, defaults to 12, clamps at both ends, and round-trips through `localStorage` (a fresh `Settings` reads the saved value).
- `tests/input.test.ts`: `zoomBy` clamps `camDist` to `[3,22]` and reports each real change to `onCameraDistChange`, and stays silent when the clamp leaves `camDist` unchanged (no spurious persist).

`tsc --noEmit` clean; `settings`/`input` suites green (84 passed); biome clean on all changed files.

## Scope

Client input/settings only, no sim/wire/server surface and no new player-visible strings. Each module keeps its own `localStorage` key (`cameraZoom` lives in the existing `woc_settings` store), per `src/game/CLAUDE.md`.

Closes #1657.