### PR TITLE
fix(worldboss): silence Thunzharr's per-mechanic barks, one zone-wide yell every ~45s

### DIFF
--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -847,6 +847,11 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     // the straight line through fences, buildings, and the waterline, so he can
     // always go directly at his target and never wedges on a collider.
     phasesThroughObstacles: true,
+    // His only periodic voice is the battle cry below (every ~45s, zone-wide). The
+    // per-mechanic log barks ("unleashes Seismic Stomp/Tectonic Heave/Mountainhide!"
+    // and "becomes enraged!") are silenced so an overworld pull does not spam the
+    // combat log; the mechanics still fire with their spellfx and damage.
+    quietMechanics: true,
     ccImmune: true,
     // A raid boss cannot be perma-snared by a wall of Frostbolts / Hamstrings: slows do
     // not stick to him (ccImmune already blocks stun/root/etc; slow is separate).
@@ -926,12 +931,13 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
       summon: 'Rise, stormlings! Tear them loose from my slopes!',
       enrage: 'The peak breaks, and the sky falls with it!',
     },
-    // Loud: a mountain-sized voice. Every yell (engage/summon/enrage + these battle
-    // cries) carries 350yd, far past the 100yd default, and he bellows one of these
-    // lines once a minute in combat: the whole of Thornpeak still knows he is awake,
-    // but the barks never drown out the raid's chat.
+    // Loud: a mountain-sized voice, and (with quietMechanics) his ONLY periodic
+    // voice. Every yell (engage/summon/enrage + these battle cries) carries 350yd,
+    // far past the 100yd default; he bellows one of these lines about every 45s in
+    // combat, so the whole of Thornpeak knows he is awake without the log ever
+    // filling with per-mechanic barks.
     battleYells: {
-      every: 60,
+      every: 45,
       range: 350,
       lines: [
         'THUNDER ANSWERS! The peak has teeth again!',

--- a/src/sim/mob/locomotion.ts
+++ b/src/sim/mob/locomotion.ts
@@ -418,12 +418,13 @@ function runMobAttackMechanics(ctx: SimContext, mob: Entity): void {
       mob.stompTimer = stomp.every;
       const school = stomp.school ?? 'physical';
       ctx.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
-      ctx.emit({
-        type: 'log',
-        text: `${mob.name} unleashes ${stomp.name}!`,
-        color: '#ff9933',
-        entityId: mob.id,
-      });
+      if (!MOBS[mob.templateId]?.quietMechanics)
+        ctx.emit({
+          type: 'log',
+          text: `${mob.name} unleashes ${stomp.name}!`,
+          color: '#ff9933',
+          entityId: mob.id,
+        });
       for (const meta of ctx.players.values()) {
         const pe = ctx.entities.get(meta.entityId);
         if (!pe || pe.dead || dist2d(pe.pos, mob.pos) > stomp.radius) continue;
@@ -462,12 +463,13 @@ function runMobAttackMechanics(ctx: SimContext, mob: Entity): void {
         mob.castTargetId = null;
         const school = (bigCast.school ?? 'nature') as Aura['school'];
         ctx.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
-        ctx.emit({
-          type: 'log',
-          text: `${mob.name} unleashes ${bigCast.name}!`,
-          color: '#ff9933',
-          entityId: mob.id,
-        });
+        if (!MOBS[mob.templateId]?.quietMechanics)
+          ctx.emit({
+            type: 'log',
+            text: `${mob.name} unleashes ${bigCast.name}!`,
+            color: '#ff9933',
+            entityId: mob.id,
+          });
         for (const meta of ctx.players.values()) {
           const pe = ctx.entities.get(meta.entityId);
           if (pe && !pe.dead && dist2d(pe.pos, mob.pos) <= bigCast.radius) {
@@ -501,12 +503,13 @@ function runMobAttackMechanics(ctx: SimContext, mob: Entity): void {
       mob.stoneskinTimer = stoneskin.every;
       const school = (stoneskin.school ?? 'physical') as Aura['school'];
       ctx.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
-      ctx.emit({
-        type: 'log',
-        text: `${mob.name} unleashes ${stoneskin.name}!`,
-        color: '#c9c2b5',
-        entityId: mob.id,
-      });
+      if (!MOBS[mob.templateId]?.quietMechanics)
+        ctx.emit({
+          type: 'log',
+          text: `${mob.name} unleashes ${stoneskin.name}!`,
+          color: '#c9c2b5',
+          entityId: mob.id,
+        });
       ctx.applyAura(mob, {
         id: `stoneskin_${mob.templateId}`,
         name: stoneskin.name,
@@ -528,12 +531,13 @@ function runMobAttackMechanics(ctx: SimContext, mob: Entity): void {
       mob.terrifyTimer = terrify.every;
       const school = terrify.school ?? 'shadow';
       ctx.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
-      ctx.emit({
-        type: 'log',
-        text: `${mob.name} unleashes ${terrify.name}!`,
-        color: '#ff9933',
-        entityId: mob.id,
-      });
+      if (!MOBS[mob.templateId]?.quietMechanics)
+        ctx.emit({
+          type: 'log',
+          text: `${mob.name} unleashes ${terrify.name}!`,
+          color: '#ff9933',
+          entityId: mob.id,
+        });
       for (const meta of ctx.players.values()) {
         const pe = ctx.entities.get(meta.entityId);
         if (!pe || pe.dead || dist2d(pe.pos, mob.pos) > terrify.radius) continue;

--- a/src/sim/mob/mob_swing.ts
+++ b/src/sim/mob/mob_swing.ts
@@ -510,12 +510,13 @@ export function runMobSwingAffixes(
     if (ctx.applyKnockback(mob, target, knockback.distance) > 0) {
       const school = (knockback.school ?? 'physical') as Aura['school'];
       ctx.emit({ type: 'spellfx', sourceId: mob.id, targetId: target.id, school, fx: 'nova' });
-      ctx.emit({
-        type: 'log',
-        text: `${mob.name} unleashes ${knockback.name}!`,
-        color: '#ff9933',
-        entityId: mob.id,
-      });
+      if (!MOBS[mob.templateId]?.quietMechanics)
+        ctx.emit({
+          type: 'log',
+          text: `${mob.name} unleashes ${knockback.name}!`,
+          color: '#ff9933',
+          entityId: mob.id,
+        });
     }
   }
   // slowStrike: a landed hit may mire the victim, slowing their attack speed.

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4719,12 +4719,13 @@ export class Sim {
       if (tmpl.yells?.enrage)
         emitMobYell(this.ctx, mob, tmpl.yells.enrage, tmpl.battleYells?.range);
       this.emit({ type: 'aura', targetId: mob.id, name: 'Enrage', gained: true });
-      this.emit({
-        type: 'log',
-        text: `${mob.name} becomes enraged!`,
-        color: '#ff6666',
-        entityId: mob.id,
-      });
+      if (!tmpl.quietMechanics)
+        this.emit({
+          type: 'log',
+          text: `${mob.name} becomes enraged!`,
+          color: '#ff6666',
+          entityId: mob.id,
+        });
       this.emit({
         type: 'spellfx',
         sourceId: mob.id,
@@ -4845,12 +4846,13 @@ export class Sim {
         if (allies.length > 0) {
           const school = tmpl.rally.school ?? 'physical';
           this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
-          this.emit({
-            type: 'log',
-            text: `${mob.name} unleashes ${tmpl.rally.name}!`,
-            color: '#ffcc33',
-            entityId: mob.id,
-          });
+          if (!tmpl.quietMechanics)
+            this.emit({
+              type: 'log',
+              text: `${mob.name} unleashes ${tmpl.rally.name}!`,
+              color: '#ffcc33',
+              entityId: mob.id,
+            });
           for (const ally of allies) {
             this.applyAura(ally, {
               id: `rally_${mob.templateId}`,

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -727,6 +727,11 @@ export interface MobTemplate {
   // who damaged it (gated to once per day per boss). The spawn schedule + location
   // live in src/sim/world_boss.ts; the loot roll runs through rollWorldBossLoot.
   worldBoss?: boolean;
+  // Suppresses the per-mechanic combat-log barks ("<Name> unleashes <Mechanic>!"
+  // and "<Name> becomes enraged!") for a mob whose only voice should be its
+  // periodic zone-wide battle cry (a world boss). The mechanics still fire, with
+  // their spellfx and damage: only the noisy log line is silenced.
+  quietMechanics?: boolean;
   // Elite scaling, classic-style: ~2.3x health, ~1.5x damage, double XP.
   elite?: boolean;
   // Kill-XP multiplier (default 1). 0 marks a puzzle-object mob (e.g. the 1 HP

--- a/tests/world_boss.test.ts
+++ b/tests/world_boss.test.ts
@@ -210,6 +210,7 @@ describe('world boss raid-tier combat (melee, Stormcall hardcast, yells)', () =>
     let sawCastBar = false;
     let castYell = false;
     let unleashed = false;
+    let wasCasting = false;
     // 40s cadence + 3.5s cast, with slack for chase/knockback interruptions.
     for (let t = 0; t < 20 * 60 && !unleashed; t++) {
       // Step back into melee after every Tectonic Heave shove, and keep chipping
@@ -220,14 +221,17 @@ describe('world boss raid-tier combat (melee, Stormcall hardcast, yells)', () =>
         (sim as any).dealDamage(p, boss, 1, false, 'physical', 'Chip', 'hit', true);
       }
       const events = sim.tick();
-      if (boss.castingAbility === 'thunzharr_stormcall') {
+      const castingNow = boss.castingAbility === 'thunzharr_stormcall';
+      if (castingNow) {
         sawCastBar = true;
         expect(boss.castTotal).toBeCloseTo(3.5, 5);
       }
       if (chatYells(events).some((e) => /The storm answers my call!/.test((e as any).text)))
         castYell = true;
-      if (events.some((e) => e.type === 'log' && /unleashes Stormcall!$/.test((e as any).text)))
-        unleashed = true;
+      // The quiet world boss no longer barks "unleashes Stormcall!", so the spell
+      // landing is the falling edge of the cast bar: casting last tick, cleared now.
+      if (wasCasting && !castingNow) unleashed = true;
+      wasCasting = castingNow;
     }
     expect(sawCastBar).toBe(true);
     expect(castYell).toBe(true);
@@ -777,6 +781,37 @@ describe('world boss is imposing and loud', () => {
     expect(yellTextTo(far).some((t) => /THUNDER ANSWERS/.test(t))).toBe(true);
     // ...but nothing reaches a player 400yd away, past the loud range.
     expect(yellTextTo(tooFar)).toHaveLength(0);
+  });
+});
+
+describe('world boss keeps a quiet combat log (quietMechanics)', () => {
+  it('opts into quiet mechanics and a battle cry about every 45s', () => {
+    expect(MOBS[BOSS_ID]?.quietMechanics).toBe(true);
+    expect(MOBS[BOSS_ID]?.battleYells?.every).toBe(45);
+  });
+
+  it('fires its mechanics without ever barking "unleashes X" or "becomes enraged" to the log', () => {
+    const sim = makeSim();
+    const tank = sim.addPlayer('warrior', 'Tank');
+    const { boss } = spawnBossNow(sim);
+    const p = (sim as any).entities.get(tank) as Entity;
+    p.gm = true; // survive the raid-tier melee so the pull runs for real seconds
+    p.maxHp = p.hp = 1_000_000;
+    let barks = 0;
+    let bossSpellfx = 0;
+    for (let t = 0; t < 20 * 60; t++) {
+      p.pos = { x: boss.pos.x + 2, z: boss.pos.z, y: boss.pos.y };
+      if (t % 10 === 0) (sim as any).dealDamage(p, boss, 1, false, 'physical', 'Chip', 'hit', true);
+      // Drop him under the 20% enrage threshold partway through so the enrage
+      // path (which also barked "becomes enraged!") runs during the sample.
+      if (t === 20 * 30) boss.hp = Math.floor(boss.maxHp * 0.15);
+      for (const e of sim.tick()) {
+        if (e.type === 'log' && /unleashes|becomes enraged/i.test((e as any).text)) barks++;
+        if (e.type === 'spellfx' && (e as any).sourceId === boss.id) bossSpellfx++;
+      }
+    }
+    expect(barks).toBe(0); // the log stayed quiet...
+    expect(bossSpellfx).toBeGreaterThan(0); // ...but the mechanics (spellfx novas) still fired
   });
 });
 


### PR DESCRIPTION
## Summary

Thunzharr spammed the combat log with a bark for every mechanic every few seconds:

```
Thunzharr, the Waking Peak unleashes Tectonic Heave!
Thunzharr, the Waking Peak unleashes Seismic Stomp!
Thunzharr, the Waking Peak becomes enraged!
Thunzharr, the Waking Peak unleashes Mountainhide!
```

This adds a `quietMechanics` MobTemplate flag that suppresses those per-mechanic log barks (the "<Name> unleashes <Mechanic>!" lines from stomp, knockback, stoneskin, terrify, rally, and the bigCast completion, plus "<Name> becomes enraged!"). The mechanics themselves are unchanged: they still fire with their spellfx novas and damage, only the noisy log line is gone. Thunzharr opts in.

His only periodic voice is now the zone-wide (350yd) battle cry, tightened from every 60s to about every 45s, so the whole zone still hears him without the log filling up. The one-shot engage/summon/enrage yells and the Stormcall cast-bar telegraph (with its warning yell) stay.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/world_boss.test.ts` (42 passed): new tests pin that the boss fires its mechanics (spellfx novas) while emitting zero "unleashes"/"becomes enraged" log lines, and that the template opts into quietMechanics with a 45s battle cry. The Stormcall hardcast test now detects the cast via the cast-bar falling edge instead of the removed bark.
  - `npx vitest run tests/localization_fixes.test.ts tests/architecture.test.ts tests/world_boss_cc.test.ts tests/parity` (219 passed): the S3 i18n guard stays green (the "unleashes"/"enraged" literals remain in place for ordinary mobs), and parity is unchanged (gating a log emit draws no rng).
- Manual steps: none; the change is a data flag plus emit guards.

Generated with [Claude Code](https://claude.com/claude-code)