### PR TITLE
fix(sim): group buffs do not stack, newest supersedes across casters

### DIFF
--- a/src/sim/combat/aura_stacking.ts
+++ b/src/sim/combat/aura_stacking.ts
@@ -1,0 +1,21 @@
+import type { Aura } from '../types';
+
+const SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS = new Set([
+  'arcane_intellect',
+  'battle_shout',
+  'blessing_of_might',
+  'devotion_aura',
+  'mark_of_the_wild',
+  'power_word_fortitude',
+]);
+
+export function auraReplacementConflicts(auras: readonly Aura[], aura: Aura): number[] {
+  const replaceAcrossSources = SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS.has(aura.id);
+  const out: number[] = [];
+  for (let i = auras.length - 1; i >= 0; i--) {
+    const existing = auras[i];
+    if (existing.id !== aura.id) continue;
+    if (replaceAcrossSources || existing.sourceId === aura.sourceId) out.push(i);
+  }
+  return out;
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -16,6 +16,7 @@ import * as bankMod from './bank';
 import { type BankState, clampBonusSlots, sanitizeBankState } from './bank';
 import { lineOfSightClear, resolveMovement, resolvePosition } from './colliders';
 import { auraAffectsStats, removeCancelableAura } from './combat/aura_cancel';
+import { auraReplacementConflicts } from './combat/aura_stacking';
 import {
   cleanseFriendlyNpcAuras,
   isRejectedFriendlyNpcAura,
@@ -3844,10 +3845,7 @@ export class Sim {
       aura.sourceId !== target.id
     )
       return;
-    const existing = target.auras.findIndex(
-      (a) => a.id === aura.id && a.sourceId === aura.sourceId,
-    );
-    if (existing >= 0) {
+    for (const existing of auraReplacementConflicts(target.auras, aura)) {
       this.applyNonPlayerStatAura(target, target.auras[existing], -1);
       target.auras.splice(existing, 1);
     }

--- a/tests/raid_buffs.test.ts
+++ b/tests/raid_buffs.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { ABILITIES, MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
 import { Sim } from '../src/sim/sim';
-import { FAERIE_FIRE_ARMOR_PCT, SUNDER_ARMOR_PCT_PER_STACK } from '../src/sim/types';
+import {
+  type Aura,
+  type Entity,
+  FAERIE_FIRE_ARMOR_PCT,
+  SUNDER_ARMOR_PCT_PER_STACK,
+} from '../src/sim/types';
 import { groundHeight } from '../src/sim/world';
 
 // Standardized percent raid buffs (resurrecting PR #1038 on release/v0.21.0): the six
@@ -33,6 +38,17 @@ const ready = (sim: Sim, pid: number) => {
   const e = sim.entities.get(pid)!;
   e.resource = e.maxResource;
 };
+
+const blessingAura = (sourceId: number, value: number, remaining = 1800): Aura => ({
+  id: 'blessing_of_might',
+  name: 'Oath of Iron',
+  kind: 'buff_ap_pct',
+  remaining,
+  duration: remaining,
+  value,
+  sourceId,
+  school: 'holy',
+});
 
 describe('standardized percent raid buffs', () => {
   it('the six raid-buff abilities carry the percent-point buffTarget shape', () => {
@@ -147,6 +163,54 @@ describe('standardized percent raid buffs', () => {
     sim.castAbility('devotion_aura', pal);
     expect(sim.entities.get(ally)!.auras.some((a) => a.kind === 'buff_armor_pct')).toBe(true);
     expect(sim.entities.get(ally)!.stats.armor).toBe(Math.round(armorBefore * 1.1));
+  });
+
+  it('replaces the previous Blessing of Might from another caster', () => {
+    const sim = makeWorld();
+    const first = sim.addPlayer('paladin', 'Ald');
+    const second = sim.addPlayer('paladin', 'Borin');
+    const targetId = sim.addPlayer('warrior', 'War');
+    const target = sim.entities.get(targetId)!;
+    sim.setPlayerLevel(4, first);
+    sim.setPlayerLevel(4, second);
+
+    ready(sim, first);
+    sim.targetEntity(targetId, first);
+    sim.castAbility('blessing_of_might', first);
+    const firstAura = target.auras.find((a) => a.id === 'blessing_of_might')!;
+    firstAura.remaining = 1200;
+
+    ready(sim, second);
+    sim.targetEntity(targetId, second);
+    sim.castAbility('blessing_of_might', second);
+
+    const blessings = target.auras.filter((a) => a.id === 'blessing_of_might');
+    expect(blessings).toHaveLength(1);
+    expect(blessings[0].sourceId).toBe(second);
+    expect(blessings[0].value).toBe(10);
+    expect(blessings[0].remaining).toBe(1800);
+  });
+
+  it('keeps the newest stronger Blessing of Might value', () => {
+    const sim = makeWorld();
+    const first = sim.addPlayer('paladin', 'Ald');
+    const second = sim.addPlayer('paladin', 'Borin');
+    const target = sim.entities.get(sim.addPlayer('warrior', 'War'))!;
+
+    (sim as unknown as { applyAura(target: Entity, aura: Aura): void }).applyAura(
+      target,
+      blessingAura(first, 10, 900),
+    );
+    (sim as unknown as { applyAura(target: Entity, aura: Aura): void }).applyAura(
+      target,
+      blessingAura(second, 15, 1800),
+    );
+
+    const blessings = target.auras.filter((a) => a.id === 'blessing_of_might');
+    expect(blessings).toHaveLength(1);
+    expect(blessings[0].sourceId).toBe(second);
+    expect(blessings[0].value).toBe(15);
+    expect(blessings[0].duration).toBe(1800);
   });
 });
 


### PR DESCRIPTION
## Summary

Two casters applying the same group buff to one target used to leave two stacked auras. Now a given group buff replaces any existing instance of the same buff regardless of who cast it, keeping the newest (its value and duration win).

Covers the classic raid buffs: Blessing of Might, Arcane Intellect, Power Word: Fortitude, Mark of the Wild, Battle Shout, Devotion Aura. A new `src/sim/combat/aura_stacking.ts` module holds the source-independent buff list and the replacement rule; `applyAura` consults it. Non-group auras keep their normal per-source stacking. No new randomness.

## Type of change

- [x] Bug fix

## How was this tested?

- `npx vitest run tests/raid_buffs.test.ts` (14 passed): two casters apply the same blessing and only one aura remains, with the newest value and duration.
- `npx vitest run tests/architecture.test.ts tests/parity` (188 passed, 1 skipped): determinism/draw-order unchanged.
- `npx tsc --noEmit` clean (pre-existing prom-client gap aside).

Generated with [Claude Code](https://claude.com/claude-code)