### PR TITLE
fix(ui): party-frame selection cue (targeted member highlight), corrected z-order

### DIFF
--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -4082,7 +4082,7 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
-    z-index: 5;
+    z-index: 7;
   }
   /* The painter nests the member rows one level down in a .party-rows wrapper (so the
      mobile collapse chip can sit alone on its own line). On desktop the wrapper is
@@ -4235,6 +4235,12 @@
   .party-frame:hover {
     outline: 1px solid var(--gold-dim);
     opacity: 1;
+  }
+  .party-frame.selected {
+    position: relative;
+    z-index: 1;
+    outline: 1px solid var(--gold);
+    box-shadow: 0 0 calc(8px * var(--fx-shadow, 1)) var(--gold-dim);
   }
   /* Reset opacity on a keyboard-focused dimmed (dead 0.7 / out-of-range 0.45) row so the
      global [tabindex="0"]:focus-visible outline (shell.css) is drawn at full strength, not

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -4082,7 +4082,7 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
-    z-index: 7;
+    z-index: 5;
   }
   /* The painter nests the member rows one level down in a .party-rows wrapper (so the
      mobile collapse chip can sit alone on its own line). On desktop the wrapper is
@@ -4241,6 +4241,14 @@
     z-index: 1;
     outline: 1px solid var(--gold);
     box-shadow: 0 0 calc(8px * var(--fx-shadow, 1)) var(--gold-dim);
+  }
+  /* A row that is both in-combat and selected keeps the red combat glow AND the gold
+     selection glow: the two box-shadows are layered so neither clobbers the other
+     (equal specificity, .selected wins on box-shadow otherwise). */
+  .party-frame.combat.selected {
+    box-shadow:
+      0 0 calc(7px * var(--fx-shadow, 1)) #e74c3c99,
+      0 0 calc(8px * var(--fx-shadow, 1)) var(--gold-dim);
   }
   /* Reset opacity on a keyboard-focused dimmed (dead 0.7 / out-of-range 0.45) row so the
      global [tabindex="0"]:focus-visible outline (shell.css) is drawn at full strength, not

--- a/src/styles/hud.mobile.css
+++ b/src/styles/hud.mobile.css
@@ -1663,7 +1663,7 @@
     flex-direction: column;
     align-items: flex-start;
     width: auto;
-    z-index: 7;
+    z-index: 5;
   }
   /* The member-rows wrapper carries the adaptive double-stack the container used to: a
      CSS grid with grid-auto-flow: column and 2 explicit rows does the adaptive part with

--- a/src/styles/hud.mobile.css
+++ b/src/styles/hud.mobile.css
@@ -1663,7 +1663,7 @@
     flex-direction: column;
     align-items: flex-start;
     width: auto;
-    z-index: 5;
+    z-index: 7;
   }
   /* The member-rows wrapper carries the adaptive double-stack the container used to: a
      CSS grid with grid-auto-flow: column and 2 explicit rows does the adaptive part with

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -13973,16 +13973,26 @@ export class Hud {
     // Hoist the cheap signature (a single string pass, no intermediate arrays) AHEAD
     // of the selector so an unchanged party short-circuits before selectPartyFrameMembers
     // allocates its sorted / filtered / mapped arrays.
-    const sig = partyFrameSignature(info, this.sim.playerId, this.sim.player.pos);
+    const sig = partyFrameSignature(
+      info,
+      this.sim.playerId,
+      this.sim.player.pos,
+      this.sim.player.targetId,
+    );
     if (sig === this.lastPartySig) return;
     this.lastPartySig = sig;
-    const others = selectPartyFrameMembers(info, this.sim.playerId, this.sim.player.pos);
-    this.partyFramesPainter.sync(others, info.leader, info.raid);
+    const members = selectPartyFrameMembers(
+      info,
+      this.sim.playerId,
+      this.sim.player.pos,
+      this.sim.player.targetId,
+    );
+    this.partyFramesPainter.sync(members, info.leader, info.raid);
     // Re-dock the Loot Settings panel below the (just re-synced) party frames when their
     // size changes (row count / raid grouping). Gated so the layout measure runs on a real
     // geometry change, not every combat tick; positionLootSettingsPanel honors a manual drag.
     if (this.lootSettingsOpen) {
-      const geomSig = `${others.length}/${info.raid ? 1 : 0}`;
+      const geomSig = `${members.length}/${info.raid ? 1 : 0}`;
       if (geomSig !== this.lastLootGeomSig) {
         this.lastLootGeomSig = geomSig;
         this.positionLootSettingsPanel();

--- a/src/ui/party_frames.ts
+++ b/src/ui/party_frames.ts
@@ -6,7 +6,7 @@ export type PartyFrameMember = PartyMemberInfo & { oor: boolean; selected: boole
 
 export function selectPartyFrameMembers(
   info: PartyInfo,
-  _playerId: number,
+  playerId: number,
   playerPos: { x: number; z: number },
   selectedId: number | null = null,
   rangeYd = PARTY_FRAME_RANGE_YD,
@@ -17,9 +17,11 @@ export function selectPartyFrameMembers(
       info.raid ? a.member.group - b.member.group || a.index - b.index : a.index - b.index,
     )
     .map(({ member }) => member)
+    .filter((m) => m.pid !== playerId)
     .map((m) => ({
       ...m,
       oor: !m.dead && Math.hypot(m.x - playerPos.x, m.z - playerPos.z) > rangeYd,
+      // The selection cue: the currently targeted party member's row is highlighted.
       selected: m.pid === selectedId,
     }));
 }
@@ -31,8 +33,10 @@ export function selectPartyFrameMembers(
  * filtered / mapped arrays) is ever called. It encodes exactly the inputs the frames
  * render from: per member the pid, group, hp/maxHp, resource, dead,
  * in-combat, the out-of-range flag (computed inline, identically to the selector),
- * selected flag, level, and the aura strip (id + kind + sap flag per aura, in order),
- * plus the leader, raid flag, and the player's own group.
+ * the selected flag, level, and the aura strip (id + kind + sap flag per aura, in
+ * order), plus the leader, raid flag, and the player's own group. The player is
+ * skipped (the frames never show the local player, who owns #player-frame), matching
+ * the selector's `pid !== playerId`.
  *
  * Pure and deterministic (only `Math.hypot` and string building). It iterates in raw
  * member order rather than the selector's sorted order; the server's party member
@@ -53,6 +57,7 @@ export function partyFrameSignature(
   for (const m of info.members) {
     if (m.pid === playerId) {
       myGroup = m.group;
+      continue;
     }
     const oor = !m.dead && Math.hypot(m.x - playerPos.x, m.z - playerPos.z) > rangeYd;
     sig += `${m.pid}:${m.group}:${m.hp}/${m.mhp}:${m.res}:${m.dead}:${m.inCombat}:${oor ? 1 : 0}:${m.pid === selectedId ? 1 : 0}:${m.level}:`;

--- a/src/ui/party_frames.ts
+++ b/src/ui/party_frames.ts
@@ -2,12 +2,13 @@ import type { PartyInfo, PartyMemberInfo } from '../world_api';
 
 export const PARTY_FRAME_RANGE_YD = 100;
 
-export type PartyFrameMember = PartyMemberInfo & { oor: boolean };
+export type PartyFrameMember = PartyMemberInfo & { oor: boolean; selected: boolean };
 
 export function selectPartyFrameMembers(
   info: PartyInfo,
-  playerId: number,
+  _playerId: number,
   playerPos: { x: number; z: number },
+  selectedId: number | null = null,
   rangeYd = PARTY_FRAME_RANGE_YD,
 ): PartyFrameMember[] {
   return info.members
@@ -16,10 +17,10 @@ export function selectPartyFrameMembers(
       info.raid ? a.member.group - b.member.group || a.index - b.index : a.index - b.index,
     )
     .map(({ member }) => member)
-    .filter((m) => m.pid !== playerId)
     .map((m) => ({
       ...m,
       oor: !m.dead && Math.hypot(m.x - playerPos.x, m.z - playerPos.z) > rangeYd,
+      selected: m.pid === selectedId,
     }));
 }
 
@@ -30,9 +31,8 @@ export function selectPartyFrameMembers(
  * filtered / mapped arrays) is ever called. It encodes exactly the inputs the frames
  * render from: per member the pid, group, hp/maxHp, resource, dead,
  * in-combat, the out-of-range flag (computed inline, identically to the selector),
- * level, and the aura strip (id + kind + sap flag per aura, in order), plus the
- * leader, raid flag, and the player's own group. The player is skipped (the
- * frames never show the local player), matching the selector's `pid !== playerId`.
+ * selected flag, level, and the aura strip (id + kind + sap flag per aura, in order),
+ * plus the leader, raid flag, and the player's own group.
  *
  * Pure and deterministic (only `Math.hypot` and string building). It iterates in raw
  * member order rather than the selector's sorted order; the server's party member
@@ -45,6 +45,7 @@ export function partyFrameSignature(
   info: PartyInfo,
   playerId: number,
   playerPos: { x: number; z: number },
+  selectedId: number | null = null,
   rangeYd = PARTY_FRAME_RANGE_YD,
 ): string {
   let sig = '';
@@ -52,10 +53,9 @@ export function partyFrameSignature(
   for (const m of info.members) {
     if (m.pid === playerId) {
       myGroup = m.group;
-      continue;
     }
     const oor = !m.dead && Math.hypot(m.x - playerPos.x, m.z - playerPos.z) > rangeYd;
-    sig += `${m.pid}:${m.group}:${m.hp}/${m.mhp}:${m.res}:${m.dead}:${m.inCombat}:${oor ? 1 : 0}:${m.level}:`;
+    sig += `${m.pid}:${m.group}:${m.hp}/${m.mhp}:${m.res}:${m.dead}:${m.inCombat}:${oor ? 1 : 0}:${m.pid === selectedId ? 1 : 0}:${m.level}:`;
     // The aura strip, appended inline (no intermediate array): a joined/left aura,
     // a kind flip, or a sap-sign flip changes the string and repaints the row.
     if (m.auras) {

--- a/src/ui/party_frames_painter.ts
+++ b/src/ui/party_frames_painter.ts
@@ -46,6 +46,9 @@ const CLASS_COLOR_PROP = '--cls';
 // The combat highlight class. dead / out-of-range are owned by the family's state
 // classes; combat is the party-only extra (dead wins, so combat is off when dead).
 const COMBAT_CLASS = 'combat';
+// The current target highlight. It is a paint-only cue; CSS uses outline/shadow
+// so selecting a member never changes row geometry.
+const SELECTED_CLASS = 'selected';
 // The container class that drops the frames below the target frame.
 const BELOW_TARGET_CLASS = 'below-target';
 // The mobile collapse classes on #party-frames: the chip's presence (so CSS can
@@ -341,6 +344,7 @@ export class PartyFramesPainter {
     this.writers.setStyleProp(row.el, CLASS_COLOR_PROP, this.deps.classCss(m.cls));
     const inCombat = !!m.inCombat && !m.dead;
     this.writers.toggleClass(row.el, COMBAT_CLASS, inCombat);
+    this.writers.toggleClass(row.el, SELECTED_CLASS, !!m.selected);
     // The shared frame (name / level / hp + resource fills / dead + out-of-range
     // classes) through the family instance, byte-faithful to the inline markup. The
     // family writes ONLY the level number into .lead-num now; the leader star is the

--- a/tests/party_frames.test.ts
+++ b/tests/party_frames.test.ts
@@ -20,7 +20,7 @@ const member = (pid: number, group: 1 | 2, x = 0, z = 0): PartyMemberInfo => ({
 });
 
 describe('party frame member selection', () => {
-  it('shows every other raid member across raid groups', () => {
+  it('shows every raid member across raid groups', () => {
     const info: PartyInfo = {
       leader: 1,
       raid: true,
@@ -41,7 +41,7 @@ describe('party frame member selection', () => {
 
     const frames = selectPartyFrameMembers(info, 1, { x: 0, z: 0 });
 
-    expect(frames.map((m) => m.pid)).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(frames.map((m) => m.pid)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     expect(frames.filter((m) => m.group === 2)).toHaveLength(5);
   });
 
@@ -55,7 +55,7 @@ describe('party frame member selection', () => {
 
     const frames = selectPartyFrameMembers(info, 1, { x: 0, z: 0 });
 
-    expect(frames.map((m) => m.pid)).toEqual([2, 3, 4, 6, 7]);
+    expect(frames.map((m) => m.pid)).toEqual([1, 2, 3, 4, 6, 7]);
   });
 
   it('marks live out-of-range members without hiding them', () => {
@@ -66,10 +66,29 @@ describe('party frame member selection', () => {
       members: [member(1, 1), member(2, 2, 150, 0)],
     };
 
-    expect(selectPartyFrameMembers(info, 1, { x: 0, z: 0 })[0]).toMatchObject({
-      pid: 2,
-      oor: true,
-    });
+    expect(selectPartyFrameMembers(info, 1, { x: 0, z: 0 }).find((m) => m.pid === 2)).toMatchObject(
+      {
+        pid: 2,
+        oor: true,
+      },
+    );
+  });
+
+  it('marks the current target without filtering the selected member', () => {
+    const info: PartyInfo = {
+      leader: 1,
+      raid: false,
+      master: { enabled: false, looter: 0, threshold: 'uncommon' },
+      members: [member(1, 1), member(2, 1), member(3, 1)],
+    };
+
+    const frames = selectPartyFrameMembers(info, 1, { x: 0, z: 0 }, 2);
+
+    expect(frames.map((m) => [m.pid, m.selected])).toEqual([
+      [1, false],
+      [2, true],
+      [3, false],
+    ]);
   });
 });
 
@@ -87,10 +106,10 @@ describe('party frame signature (the per-frame short-circuit)', () => {
     expect(partyFrameSignature(info(), 1, pos)).toBe(partyFrameSignature(info(), 1, pos));
   });
 
-  it('skips the local player but encodes every other member + leader / raid / group', () => {
+  it('encodes the local player plus every party member + leader / raid / group', () => {
     const sig = partyFrameSignature(info(), 1, { x: 0, z: 0 });
-    // pid 1 is the local player (skipped); 2 and 3 are encoded.
-    expect(sig).not.toContain('1:1:');
+    // pid 1 is the local player and is still encoded as a party frame member.
+    expect(sig).toContain('1:1:');
     expect(sig).toContain('2:1:');
     expect(sig).toContain('3:1:');
     expect(sig).toContain('L1:R0:G1');
@@ -131,6 +150,9 @@ describe('party frame signature (the per-frame short-circuit)', () => {
         pos,
       ),
     ).not.toBe(base);
+    // Selecting a member flips only that member's selected digit, so the row can
+    // highlight without changing layout.
+    expect(partyFrameSignature(info(), 1, pos, 2)).not.toBe(base);
     // A member gaining an aura (a fresh shield) changes it too, so the mini aura
     // strip repaints; and losing it again changes it back to the base string.
     const shielded = partyFrameSignature(
@@ -193,8 +215,8 @@ describe('ClientWorld-vs-Sim out-of-range parity', () => {
         master: { enabled: false, looter: 0, threshold: 'uncommon' },
         members: [member(1, 1), member(2, 1, round2(dist), 0)],
       };
-      expect(selectPartyFrameMembers(mirror, 1, playerPos)[0].oor).toBe(
-        selectPartyFrameMembers(sim, 1, playerPos)[0].oor,
+      expect(selectPartyFrameMembers(mirror, 1, playerPos).find((m) => m.pid === 2)?.oor).toBe(
+        selectPartyFrameMembers(sim, 1, playerPos).find((m) => m.pid === 2)?.oor,
       );
       // If the oor shape matches, the whole signature matches (round2 touches only x/z,
       // which feed only the oor boolean).
@@ -224,7 +246,7 @@ describe('ClientWorld-vs-Sim out-of-range parity', () => {
       master: { enabled: false, looter: 0, threshold: 'uncommon' },
       members: [member(1, 1), member(2, 1, round2(dist), 0)],
     };
-    expect(selectPartyFrameMembers(sim, 1, playerPos)[0].oor).toBe(true);
-    expect(selectPartyFrameMembers(mirror, 1, playerPos)[0].oor).toBe(false);
+    expect(selectPartyFrameMembers(sim, 1, playerPos).find((m) => m.pid === 2)?.oor).toBe(true);
+    expect(selectPartyFrameMembers(mirror, 1, playerPos).find((m) => m.pid === 2)?.oor).toBe(false);
   });
 });

--- a/tests/party_frames.test.ts
+++ b/tests/party_frames.test.ts
@@ -20,7 +20,7 @@ const member = (pid: number, group: 1 | 2, x = 0, z = 0): PartyMemberInfo => ({
 });
 
 describe('party frame member selection', () => {
-  it('shows every raid member across raid groups', () => {
+  it('shows every other raid member across raid groups', () => {
     const info: PartyInfo = {
       leader: 1,
       raid: true,
@@ -41,7 +41,7 @@ describe('party frame member selection', () => {
 
     const frames = selectPartyFrameMembers(info, 1, { x: 0, z: 0 });
 
-    expect(frames.map((m) => m.pid)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(frames.map((m) => m.pid)).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10]);
     expect(frames.filter((m) => m.group === 2)).toHaveLength(5);
   });
 
@@ -55,7 +55,7 @@ describe('party frame member selection', () => {
 
     const frames = selectPartyFrameMembers(info, 1, { x: 0, z: 0 });
 
-    expect(frames.map((m) => m.pid)).toEqual([1, 2, 3, 4, 6, 7]);
+    expect(frames.map((m) => m.pid)).toEqual([2, 3, 4, 6, 7]);
   });
 
   it('marks live out-of-range members without hiding them', () => {
@@ -66,15 +66,13 @@ describe('party frame member selection', () => {
       members: [member(1, 1), member(2, 2, 150, 0)],
     };
 
-    expect(selectPartyFrameMembers(info, 1, { x: 0, z: 0 }).find((m) => m.pid === 2)).toMatchObject(
-      {
-        pid: 2,
-        oor: true,
-      },
-    );
+    expect(selectPartyFrameMembers(info, 1, { x: 0, z: 0 })[0]).toMatchObject({
+      pid: 2,
+      oor: true,
+    });
   });
 
-  it('marks the current target without filtering the selected member', () => {
+  it('marks the currently targeted member as selected (the row highlight cue)', () => {
     const info: PartyInfo = {
       leader: 1,
       raid: false,
@@ -82,10 +80,10 @@ describe('party frame member selection', () => {
       members: [member(1, 1), member(2, 1), member(3, 1)],
     };
 
+    // Local player (1) is filtered; targeting member 2 flags only its row selected.
     const frames = selectPartyFrameMembers(info, 1, { x: 0, z: 0 }, 2);
 
     expect(frames.map((m) => [m.pid, m.selected])).toEqual([
-      [1, false],
       [2, true],
       [3, false],
     ]);
@@ -106,10 +104,10 @@ describe('party frame signature (the per-frame short-circuit)', () => {
     expect(partyFrameSignature(info(), 1, pos)).toBe(partyFrameSignature(info(), 1, pos));
   });
 
-  it('encodes the local player plus every party member + leader / raid / group', () => {
+  it('skips the local player but encodes every other member + leader / raid / group', () => {
     const sig = partyFrameSignature(info(), 1, { x: 0, z: 0 });
-    // pid 1 is the local player and is still encoded as a party frame member.
-    expect(sig).toContain('1:1:');
+    // pid 1 is the local player (skipped); 2 and 3 are encoded.
+    expect(sig).not.toContain('1:1:');
     expect(sig).toContain('2:1:');
     expect(sig).toContain('3:1:');
     expect(sig).toContain('L1:R0:G1');
@@ -215,8 +213,8 @@ describe('ClientWorld-vs-Sim out-of-range parity', () => {
         master: { enabled: false, looter: 0, threshold: 'uncommon' },
         members: [member(1, 1), member(2, 1, round2(dist), 0)],
       };
-      expect(selectPartyFrameMembers(mirror, 1, playerPos).find((m) => m.pid === 2)?.oor).toBe(
-        selectPartyFrameMembers(sim, 1, playerPos).find((m) => m.pid === 2)?.oor,
+      expect(selectPartyFrameMembers(mirror, 1, playerPos)[0].oor).toBe(
+        selectPartyFrameMembers(sim, 1, playerPos)[0].oor,
       );
       // If the oor shape matches, the whole signature matches (round2 touches only x/z,
       // which feed only the oor boolean).

--- a/tests/party_frames_painter.test.ts
+++ b/tests/party_frames_painter.test.ts
@@ -74,6 +74,7 @@ describe('partyRowHandlers: the closures read the LIVE slot, never a captured me
     inCombat: 0,
     group: 1,
     oor: false,
+    selected: false,
   });
 
   it('a row recycled to a new member targets the NEW pid + name (not the stale one)', () => {
@@ -262,6 +263,7 @@ const member = (over: Partial<PartyFrameMember> & { pid: number }): PartyFrameMe
   inCombat: 0,
   group: 1,
   oor: false,
+  selected: false,
   ...over,
 });
 
@@ -491,7 +493,7 @@ describe('PartyFramesPainter: keyed pool over the elided writers', () => {
     painter.sync(
       [
         member({ pid: 2, name: 'Alice', dead: 0, inCombat: 1, hp: 50, mhp: 100, oor: false }),
-        member({ pid: 3, name: 'Bob', dead: 1, oor: false }),
+        member({ pid: 3, name: 'Bob', dead: 1, oor: false, selected: true }),
         member({ pid: 4, name: 'Cora', dead: 0, inCombat: 0, oor: true }),
       ],
       2, // leader = pid 2 (Alice)
@@ -508,6 +510,7 @@ describe('PartyFramesPainter: keyed pool over the elided writers', () => {
     );
     // combat (party-only), dead + oor (family state classes) all via toggleClass.
     expect(has('toggleClass', (c) => c.args[0] === 'combat' && c.args[1] === true)).toBe(true);
+    expect(has('toggleClass', (c) => c.args[0] === 'selected' && c.args[1] === true)).toBe(true);
     expect(has('toggleClass', (c) => c.args[0] === 'dead' && c.args[1] === true)).toBe(true);
     expect(has('toggleClass', (c) => c.args[0] === 'oor' && c.args[1] === true)).toBe(true);
     // A combat member is NOT also dead (dead wins), so its combat is on but dead off.


### PR DESCRIPTION
## What

Adds a selection cue to the party frames: the currently targeted party member's row is highlighted with an outline/glow. The cue is paint-only (no layout shift), keyed by stable player id.

## Rescoped per review (Rubsey)

The original headline (adding the local player to the party frames) is dropped. That reversed a deliberate, test-pinned decision (the local player owns `#player-frame`; showing them here double-renders the player), so it is out of scope as a "bug fix". This PR is now just the selection cue plus the z-order fix Rubsey endorsed:

- **Show-self reverted (blocking):** the self-filter in `selectPartyFrameMembers` and the skip in `partyFrameSignature` are restored; the tests are back to the original `skips the local player` assertions. Only the `selected` flag is added.
- **z-order corrected (should-fix):** the party container `z-index` bump `5 -> 7` is reverted, so party rows no longer paint over the target's debuff strip and cast bar (actionable info).
- **Combat-glow clobber fixed (nit):** a row that is both in-combat and selected now layers the red combat glow AND the gold selection glow (`.party-frame.combat.selected`), instead of the selection replacing the combat glow.
- The mobile third-column and right-click-self nits are moot once the local player is not shown.

## Base

Rebased onto `release/v0.26.0`.

## Testing

`tests/party_frames.test.ts` keeps the restored self-skip assertions and adds a selection-cue case (targeting a member flags only its row); `tests/party_frames_painter.test.ts` covers the class toggle. CSS corpus/validity guards, `tsc`, and the suite are green.

The selection cue is cosmetic (outline/box-shadow, no `data-fx-level` gating), so it does not touch the party-HP graphics-fairness rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)