### PR TITLE
fix(sim): clear stale movement intent across death, revive, and delve respawn

### DIFF
--- a/src/sim/delves/runs.ts
+++ b/src/sim/delves/runs.ts
@@ -61,6 +61,7 @@ import {
   DT,
   dist2d,
   type Entity,
+  emptyMoveInput,
   INSTANCE_EMPTY_TIMEOUT,
   type RiteIntensity,
   type Vec3,
@@ -639,6 +640,7 @@ export function ejectToDelveDoor(
   p.combatTimer = 99;
   p.inCombat = false;
   p.autoAttack = false;
+  Object.assign(r.meta.moveInput, emptyMoveInput());
 }
 
 export function failDelveRun(ctx: SimContext, run: DelveRun): void {

--- a/src/sim/entity_roster.ts
+++ b/src/sim/entity_roster.ts
@@ -26,7 +26,7 @@ import { recalcPlayerStats } from './entity';
 import { aurasSurvivingDeath } from './resurrection';
 import type { SimContext } from './sim_context';
 import type { Entity, SimEvent, Vec3 } from './types';
-import { CAST_COMPLETE_EPS, DT } from './types';
+import { CAST_COMPLETE_EPS, DT, emptyMoveInput } from './types';
 
 // Mobs that despawn after sitting out of combat too long (boss adds that should not
 // litter the world). The idle timer is reset to DAMAGE_IDLE_DESPAWN_SECONDS whenever
@@ -184,6 +184,10 @@ export function releaseSpiritInDelve(ctx: SimContext, pid: number): void {
   // (or insta-killed) by an effect that was already active before they died.
   clearDrownedLitanyBellsAndMarks(ctx, run);
   p.facing = 0;
+  // A held movement key at the moment of death must not carry over into the respawned
+  // body, or it walks off on its own with no input held (same fix as the graveyard
+  // release/revive flow in spirit.ts).
+  Object.assign(r.meta.moveInput, emptyMoveInput());
   // The Keeper's Toll persists through a delve death too (see resurrection.ts); every
   // other aura clears on respawn.
   p.auras = aurasSurvivingDeath(p.auras);

--- a/src/sim/spirit.ts
+++ b/src/sim/spirit.ts
@@ -34,7 +34,7 @@ import {
 } from './resurrection';
 import type { PlayerMeta } from './sim';
 import type { SimContext } from './sim_context';
-import { dist2d, type Entity, type Vec3 } from './types';
+import { dist2d, emptyMoveInput, type Entity, type Vec3 } from './types';
 
 // --- tuning -----------------------------------------------------------------
 // A released spirit runs faster than the living, ignoring slows (a ghost cannot be
@@ -108,6 +108,10 @@ export function releasePlayerSpirit(ctx: SimContext, pid?: number): void {
   p.prevPos = { ...p.pos };
   ctx.rebucket(p);
   p.facing = 0;
+  // Whatever movement keys were held at the moment of death must not carry over: the
+  // ghost is teleported to the graveyard and should sit still until the player actually
+  // presses a key again, not keep walking in the last held direction.
+  Object.assign(meta.moveInput, emptyMoveInput());
   // The Keeper's Toll (Resurrection Sickness) persists through death and release: it
   // cannot be shed by dying. Every other aura clears when the spirit is released.
   p.auras = aurasSurvivingDeath(p.auras);
@@ -195,6 +199,10 @@ function reviveAt(
   p.prevPos = { ...p.pos };
   ctx.rebucket(p);
   p.facing = 0;
+  // As with the release above: a held movement key at the moment the revive lands must
+  // not carry over, or the freshly-revived body immediately walks off in whatever
+  // direction was last held (this is what made revived players drift with no input).
+  Object.assign(meta.moveInput, emptyMoveInput());
   // Keep The Keeper's Toll across the revive (it persists through death); a healer
   // resurrection refreshes it to full duration via applyResurrectionSickness below.
   p.auras = aurasSurvivingDeath(p.auras);

--- a/src/sim/spirit.ts
+++ b/src/sim/spirit.ts
@@ -34,7 +34,7 @@ import {
 } from './resurrection';
 import type { PlayerMeta } from './sim';
 import type { SimContext } from './sim_context';
-import { dist2d, emptyMoveInput, type Entity, type Vec3 } from './types';
+import { dist2d, type Entity, emptyMoveInput, type Vec3 } from './types';
 
 // --- tuning -----------------------------------------------------------------
 // A released spirit runs faster than the living, ignoring slows (a ghost cannot be

--- a/tests/spirit.test.ts
+++ b/tests/spirit.test.ts
@@ -350,6 +350,27 @@ describe('spirit: delve respawn (unchanged bounded rules)', () => {
     const events = sim.tick();
     expect(events.some((ev: any) => ev.type === 'delveFailed')).toBe(true);
   });
+
+  it('a delve respawn also clears a held movement key (#1651)', () => {
+    const sim = makeSim('rogue', 99);
+    const reliquary = DELVES.collapsed_reliquary;
+    sim.setPlayerLevel(reliquary.minLevel);
+    const p = sim.player as AnyEntity;
+    p.pos = { x: reliquary.doorPos.x, y: 0, z: reliquary.doorPos.z };
+    p.prevPos = { ...p.pos };
+    sim.rebucket(p);
+    sim.enterDelve('collapsed_reliquary', 'normal');
+    const run = sim.delveRunForPlayer(sim.playerId) as any;
+    run.modules = ['reliquary_finale'];
+    run.moduleIndex = 0;
+    (sim as any).spawnDelveModule(run);
+
+    sim.moveInput.strafeLeft = true;
+    p.dead = true;
+    sim.releaseSpirit();
+    expect(p.dead).toBe(false);
+    expect(sim.moveInput.strafeLeft).toBe(false);
+  });
 });
 
 describe('spirit: ghost movement (tick loop)', () => {
@@ -375,6 +396,63 @@ describe('spirit: ghost movement (tick loop)', () => {
     expect(p.dead).toBe(true);
     expect(p.ghost).toBe(true);
     expect(p.hp).toBe(p.maxHp);
+  });
+});
+
+describe('spirit: stale movement intent does not survive death (#1651)', () => {
+  it('releasing the spirit clears a held movement key, so the ghost does not walk on its own', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(10);
+    const p = sim.player as AnyEntity;
+    // the player was holding "back" the instant they died
+    sim.moveInput.back = true;
+    p.dead = true;
+    sim.releaseSpirit();
+    expect(sim.moveInput).toEqual({
+      forward: false,
+      back: false,
+      turnLeft: false,
+      turnRight: false,
+      strafeLeft: false,
+      strafeRight: false,
+      jump: false,
+    });
+    // ticking with the stale input gone, the ghost stays put
+    const posAfterRelease = { ...p.pos };
+    sim.tick();
+    expect(dist2d(p.pos, posAfterRelease)).toBeLessThan(0.01);
+  });
+
+  it('resurrecting at the corpse clears a held movement key, so the revived body does not walk on its own', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(10);
+    const p = sim.player as AnyEntity;
+    p.dead = true;
+    sim.releaseSpirit();
+    const corpse = { ...(p.corpsePos as { x: number; y: number; z: number }) };
+    p.pos = { x: corpse.x, y: corpse.y, z: corpse.z };
+    p.prevPos = { ...p.pos };
+    sim.rebucket(p);
+    // a key held while running the ghost back must not survive into the revived body
+    sim.moveInput.back = true;
+    sim.resurrectAtCorpse();
+    expect(p.dead).toBe(false);
+    expect(sim.moveInput.back).toBe(false);
+    const posAfterRevive = { ...p.pos };
+    sim.tick();
+    expect(dist2d(p.pos, posAfterRevive)).toBeLessThan(0.01);
+  });
+
+  it('resurrecting at the Spirit Healer also clears a held movement key', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(10);
+    const p = sim.player as AnyEntity;
+    p.dead = true;
+    sim.releaseSpirit();
+    sim.moveInput.forward = true;
+    sim.resurrectAtSpiritHealer();
+    expect(p.dead).toBe(false);
+    expect(sim.moveInput.forward).toBe(false);
   });
 });
 

--- a/tests/spirit.test.ts
+++ b/tests/spirit.test.ts
@@ -371,6 +371,33 @@ describe('spirit: delve respawn (unchanged bounded rules)', () => {
     expect(p.dead).toBe(false);
     expect(sim.moveInput.strafeLeft).toBe(false);
   });
+
+  it('a second delve death (run-failing eject to the door) also clears a held movement key', () => {
+    const sim = makeSim('rogue', 99);
+    const reliquary = DELVES.collapsed_reliquary;
+    sim.setPlayerLevel(reliquary.minLevel);
+    const p = sim.player as AnyEntity;
+    p.pos = { x: reliquary.doorPos.x, y: 0, z: reliquary.doorPos.z };
+    p.prevPos = { ...p.pos };
+    sim.rebucket(p);
+    sim.enterDelve('collapsed_reliquary', 'normal');
+    const run = sim.delveRunForPlayer(sim.playerId) as any;
+    run.modules = ['reliquary_finale'];
+    run.moduleIndex = 0;
+    (sim as any).spawnDelveModule(run);
+
+    p.dead = true;
+    sim.releaseSpirit();
+    expect(p.dead).toBe(false);
+
+    const e2 = sim.entities.get(sim.playerId) as AnyEntity;
+    sim.moveInput.back = true;
+    e2.dead = true;
+    sim.releaseSpirit();
+    const events = sim.tick();
+    expect(events.some((ev: any) => ev.type === 'delveFailed')).toBe(true);
+    expect(sim.moveInput.back).toBe(false);
+  });
 });
 
 describe('spirit: ghost movement (tick loop)', () => {


### PR DESCRIPTION
## Summary

Fixes a class of bug where a character keeps moving on its own, with no key
held, right after dying and reviving.

`PlayerMeta.moveInput` (the last movement-key snapshot the server applies on
every 20 Hz tick) was never cleared at any of the three respawn/teleport
sites: `releasePlayerSpirit`, the shared `reviveAt` (used by both
`resurrectAtCorpse` and `resurrectAtSpiritHealer`), and the first-death delve
respawn path (`releaseSpiritInDelve`). It was also missing from
`ejectToDelveDoor`, used by the second-death (run-failing) delve eject and
every other delve eject caller.

```mermaid
sequenceDiagram
    participant Player
    participant Server as Server (Sim)
    participant Meta as PlayerMeta.moveInput

    Player->>Server: holds "Back" while fighting
    Server->>Meta: back = true
    Note over Server: killing blow lands, p.dead = true
    Note over Meta: back stays true (stale, uncleared) until a real keyup

    rect rgb(255, 220, 220)
    Note over Server: BEFORE FIX
    Server->>Server: releasePlayerSpirit() / reviveAt() / delve eject teleports player
    Server->>Server: tick() applies stale moveInput.back every 20 Hz
    Server-->>Player: ghost / revived body walks backward, no key held
    end

    rect rgb(210, 245, 210)
    Note over Server: AFTER FIX
    Server->>Server: releasePlayerSpirit() teleports ghost to graveyard
    Server->>Meta: Object.assign(moveInput, emptyMoveInput())
    Server->>Server: resurrectAtCorpse() / resurrectAtSpiritHealer() / delve first-death / delve door-eject all clear moveInput
    Server-->>Player: character stands still until a key is actually pressed
    end
```

The fix clears `meta.moveInput` at each of these sites, the same pattern
already used elsewhere in `server/game.ts` for spectate-swap, stale-input
timeout, and linkdead (`clearStaleInputs`, `socketClosed`, `enterSpectate`),
just applied to the death/revive flow in `src/sim/spirit.ts`,
`src/sim/entity_roster.ts`, and `src/sim/delves/runs.ts`.

## Related issues

Related to #1651. As flagged in review, an online client actually keeps
streaming input frames while dead (`src/net/online.ts` has no dead gate),
and `clearStaleInputs` already self-corrects stray server-side input within
~0.75s of a client going silent, so the online reproduction described in
#1651 needs its own client-side fix (likely in `src/game/input.ts` or the
touch joystick path) rather than this PR alone. This change is still correct
hardening: it fixes the class outright for headless/bot/direct-drive hosts
and shrinks the online window to sub-second, so it's a real step toward
#1651 without fully closing it on its own.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/spirit.test.ts` (23 passed, including 5 regression
    tests for this bug: release, corpse-rez, healer-rez, first delve
    respawn, and second-death delve door-eject all now clear a held
    movement key)
  - `npx vitest run tests/architecture.test.ts tests/resurrection.test.ts tests/world_api_parity.test.ts tests/parity` (green, no golden regen needed since `moveInput` isn't part of the serialized/wire state)
  - `npx tsc --noEmit -p .` (clean)
  - pre-push QA floor (typecheck, guard tests, changed-files biome, copy rules): green
- Manual steps: this is a server-authoritative sim-tick bug with no new UI
  surface, so verification is via the new deterministic Vitest cases (hold a
  movement key, kill the player, release the spirit / revive / delve-eject,
  assert the server no longer moves them on a tick with no input) rather
  than a visual screenshot.

## Screenshots / recordings

N/A — this is a `src/sim/` behavior fix (movement-intent state on the
server), not a UI/HUD change. No new player-visible surface to screenshot;
see the mermaid sequence diagram above for the before/after behavior and the
new tests in `tests/spirit.test.ts` for the reproduction.

---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** Verified via `npm run gate`.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A, no UI surface.
- ~Accessible.~ N/A, no UI surface.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS`
      is not enabled in any production path.
- [x] I didn't hand-edit generated files.