### PR TITLE
feat(social): add /playtime for lifetime played time (#1703)

### DIFF
--- a/scripts/i18n_blocked_seed.mjs
+++ b/scripts/i18n_blocked_seed.mjs
@@ -288,6 +288,7 @@ export const V07_SLASH = [
   'Threat is only tracked on enemies; Aki is not one.',
   'Threat on Aki (5): Aki.',
   'Time played this session: Aki.',
+  'Total time played: Aki.',
   'Unknown command: Aki. Type /help for a list.',
   'Vendor buyback (5): Aki. Repurchase at any merchant.',
   'You are Aki.',

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -988,9 +988,10 @@ export interface CharacterState {
   unlockedMilestones?: string[];
   // Rested XP pool. Optional so pre-rested-XP saves load cleanly (defaults to 0).
   restedXp?: number;
-  // Lifetime played time in whole seconds, accumulated across every prior session
-  // (this session's elapsed time is folded in at save; see PlayerMeta.totalPlayedSeconds
-  // and /playtime in social/chat.ts). Optional so pre-/playtime saves load cleanly
+  // Lifetime played time in seconds (unfloored, for drift-free accumulation; only
+  // the display floors), accumulated across every prior session (this session's
+  // elapsed time is folded in at save; see PlayerMeta.totalPlayedSeconds and
+  // /playtime in social/chat.ts). Optional so pre-/playtime saves load cleanly
   // (defaults to 0).
   totalPlayedSeconds?: number;
   // Gathering profession proficiency (JSONB; optional so pre-professions saves

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -847,6 +847,11 @@ export interface PlayerMeta {
   // sim.time when this character entered the world; powers /played. Session-only
   // (sim.time resets to 0 each server boot), so it reports time this session.
   joinedAt: number;
+  // Seconds played across every session BEFORE this one (loaded from the save;
+  // powers /playtime). Combined with `this.time - joinedAt` for the running
+  // lifetime total; folded into a new persisted baseline by serializeCharacter
+  // on save, so it only ever advances while the character is actually in the world.
+  totalPlayedSeconds: number;
   // Tick of the player's last deliberate action (movement, ability cast, or pet
   // command). Session-only, never persisted. Powers the anti-AFK gate on
   // aggressive pet auto-pull (see PET_OWNER_IDLE_TICKS) so an idle owner's pet
@@ -983,6 +988,11 @@ export interface CharacterState {
   unlockedMilestones?: string[];
   // Rested XP pool. Optional so pre-rested-XP saves load cleanly (defaults to 0).
   restedXp?: number;
+  // Lifetime played time in whole seconds, accumulated across every prior session
+  // (this session's elapsed time is folded in at save; see PlayerMeta.totalPlayedSeconds
+  // and /playtime in social/chat.ts). Optional so pre-/playtime saves load cleanly
+  // (defaults to 0).
+  totalPlayedSeconds?: number;
   // Gathering profession proficiency (JSONB; optional so pre-professions saves
   // load cleanly, defaulting every profession to 0). `professions` is the legacy
   // pre-rename key, kept for back-compat with old saves; `gatheringProficiency`
@@ -1700,6 +1710,7 @@ export class Sim {
       counters: freshCounters(),
       autoEquip: opts?.autoEquip ?? false,
       joinedAt: this.time,
+      totalPlayedSeconds: Math.max(0, savedState?.totalPlayedSeconds ?? 0),
       lastActiveTick: this.tickCount,
       arenaRating: savedArena1v1.rating,
       arenaWins: savedArena1v1.wins,
@@ -2055,6 +2066,10 @@ export class Sim {
       prestigeRank: meta.prestigeRank,
       unlockedMilestones: [...meta.unlockedMilestones],
       restedXp: meta.restedXp,
+      // Fold this session's elapsed time into the persisted baseline (see
+      // PlayerMeta.totalPlayedSeconds); /playtime reads the running total the
+      // same way without waiting for a save.
+      totalPlayedSeconds: meta.totalPlayedSeconds + Math.max(0, this.time - meta.joinedAt),
       professions: { ...meta.gatheringProficiency },
       gatheringProficiency: { ...meta.gatheringProficiency },
       copper: meta.copper,

--- a/src/sim/social/chat.ts
+++ b/src/sim/social/chat.ts
@@ -423,6 +423,26 @@ export function chat(ctx: SimContext, text: string, pid?: number): SentChat | nu
     return null;
   }
 
+  // "/playtime": report this character's LIFETIME played time, accumulated
+  // across every session and persisted server-side (see PlayerMeta.
+  // totalPlayedSeconds + serializeCharacter). Unlike /played (session-only,
+  // resets on relog), this figure only ever grows while the character is
+  // actually in the world.
+  if (/^\/playtime(?:\s|$)/i.test(raw)) {
+    const secs = Math.max(0, Math.floor(r.meta.totalPlayedSeconds + (ctx.time - r.meta.joinedAt)));
+    const d = Math.floor(secs / 86400);
+    const h = Math.floor((secs % 86400) / 3600);
+    const m = Math.floor((secs % 3600) / 60);
+    const s = secs % 60;
+    const parts: string[] = [];
+    if (d) parts.push(`${d}d`);
+    if (d || h) parts.push(`${h}h`);
+    if (d || h || m) parts.push(`${m}m`);
+    parts.push(`${s}s`);
+    ctx.error(r.meta.entityId, `Total time played: ${parts.join(' ')}.`);
+    return null;
+  }
+
   // Self-only readouts: emit a private system line and never become chat.
   if (/^\/(?:where|loc|zone)(?:\s|$)/i.test(raw)) {
     const zone = zoneAt(r.e.pos.z);
@@ -1066,7 +1086,7 @@ export function helpLines(): string[] {
     'Chat channels: /s say, /y yell, /general, /p party, /world, /lfg.',
     'Whisper a player with /w <name> <message>, reply with /r.',
     'Other commands: /join <world|lfg>, /roll, /invite <name>, /inspect <name>, /follow <name>, /unfollow, /assist <name>, /afk, /dnd, /who.',
-    'Character readouts: /played, /xp, /gold, /stats, /bags, /gear, /abilities, /buffs, /cooldowns, /quest, /completed.',
+    'Character readouts: /played, /playtime, /xp, /gold, /stats, /bags, /gear, /abilities, /buffs, /cooldowns, /quest, /completed.',
     'World readouts: /where, /zones, /nearby, /pois, /graveyard, /dungeons, /arena, /session, /listings, /buyback.',
     'Combat readouts: /target, /targetbuffs, /range, /attack, /casting, /combat, /threat, /consider, /combo, /overpower.',
     'State readouts: /pet, /pettaunt, /speed, /consumable, /potion, /form, /manaregen, /falling, /queued, /savedmana.',

--- a/src/ui/i18n.status.summary.json
+++ b/src/ui/i18n.status.summary.json
@@ -37,7 +37,7 @@
     "translated": 136712,
     "pending": 435,
     "blocked": 193,
-    "blockedSource": 93
+    "blockedSource": 94
   },
   "perLocale": {
     "es": {

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -270,6 +270,65 @@ describe('chat channels', () => {
     );
   });
 
+  it('/playtime reports zero on a freshly joined character', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+    sim.chat('/playtime', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'error',
+        pid: a,
+        text: 'Total time played: 0s.',
+      }),
+    );
+  });
+
+  it('/playtime accumulates as the sim advances, unlike /played it survives a relog', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 0, -40);
+    // 20 ticks per sim-second; advance just over a minute of world time
+    for (let i = 0; i < 20 * 65; i++) sim.tick();
+
+    const state = sim.serializeCharacter(a);
+    expect(state?.totalPlayedSeconds).toBeGreaterThanOrEqual(64.9);
+
+    // Relog: a fresh Sim (server restart resets sim.time to 0) loading the saved state.
+    const sim2 = makeWorld();
+    const b = sim2.addPlayer('warrior', 'Aleph', { state: state! });
+    teleport(sim2, b, 0, -40);
+    sim2.tick();
+    sim2.chat('/playtime', b);
+    const events = sim2.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    const played = events.find(
+      (e): e is Extract<SimEvent, { type: 'error' }> =>
+        e.type === 'error' && e.text.startsWith('Total time played'),
+    );
+    // still reports the prior session's accumulated total, even though the new
+    // sim's clock (and this session's /played) has reset to zero.
+    expect(played?.text).toMatch(/^Total time played: 1m \d+s\.$/);
+
+    // Continuing to play in the new session keeps accumulating on top of that baseline.
+    for (let i = 0; i < 20 * 10; i++) sim2.tick();
+    sim2.chat('/playtime', b);
+    const events2 = sim2.tick();
+    const played2 = events2.find(
+      (e): e is Extract<SimEvent, { type: 'error' }> =>
+        e.type === 'error' && e.text.startsWith('Total time played'),
+    );
+    expect(played2?.text).toMatch(/^Total time played: 1m \d+s\.$/);
+    const secondsOf = (t: string) => {
+      const m = /(\d+)m (\d+)s/.exec(t)!;
+      return Number(m[1]) * 60 + Number(m[2]);
+    };
+    expect(secondsOf(played2!.text)).toBeGreaterThan(secondsOf(played!.text));
+  });
+
   it("/where reports the caller's zone, level range, and coordinates", () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');

--- a/tests/parity/golden/chat_social.json
+++ b/tests/parity/golden/chat_social.json
@@ -898,7 +898,7 @@
       "time": 0,
       "nextId": 408,
       "state": "67ca95fa",
-      "events": "515acb00",
+      "events": "010fb630",
       "rng": {
         "draws": 0,
         "digest": "811c9dc5"


### PR DESCRIPTION
## Summary

Closes #1703.

- Adds a `/playtime` chat command reporting a character's **lifetime**
  total time played, persisted server-side and surviving relog/server
  restart. This is distinct from the existing `/played`, which only
  reports the current session and resets to zero after logging back
  in.
- New `PlayerMeta.totalPlayedSeconds` (session-baseline, loaded from
  the save) combines with the existing `joinedAt` session clock the
  same way `/played` already does; `serializeCharacter()` folds the
  elapsed session into the persisted baseline on every save, so the
  figure only ever grows while the character is actually in the
  world.
- New optional `CharacterState.totalPlayedSeconds` field (defaults to
  `0` so pre-existing saves load cleanly); no schema change needed —
  character state is stored as JSONB and `saveCharacterState` persists
  the whole blob generically.
- `/playtime` is added to the `/help` character-readouts line.

```mermaid
sequenceDiagram
    participant P as Player
    participant S as Sim (server)
    participant DB as Postgres (JSONB state)

    P->>S: /played
    S-->>P: "Time played this session: 2m 5s."
    P->>S: /playtime
    S-->>P: "Total time played: 2m 5s."

    Note over S,DB: logout / server restart
    S->>DB: serializeCharacter() folds session into totalPlayedSeconds
    DB-->>S: addPlayer() loads savedState.totalPlayedSeconds

    P->>S: /played (new session)
    S-->>P: "Time played this session: 0s."
    P->>S: /playtime
    S-->>P: "Total time played: 2m 5s."
```

## Not a UI change

This is a chat-command-only feature (no HUD/render surface), so there
are no before/after screenshots per the PR template's visual-change
guidance. In lieu of that, here's an actual run against the built sim
showing `/played` resetting across a simulated relog while `/playtime`
keeps the lifetime total (`sim.time` resets to 0 to model a server
restart, `savedState` round-trips through `serializeCharacter`/
`addPlayer` exactly as a real save/load would):

```
[server->Aleph] Time played this session: 2m 5s.
[server->Aleph] Total time played: 2m 5s.

-- relog (server restart, sim.time resets to 0) --

[server->Aleph] Time played this session: 0s.
[server->Aleph] Total time played: 2m 5s.
```

## i18n

`/playtime`'s reply text follows the exact precedent of the
pre-existing `/played` command in the same file: both are self-only
`ctx.error` readouts from the v0.7 slash-command surface, which ships
English as a documented backstop (see the `ALLOW_V07_SLASH` comment in
`tests/localization_fixes.test.ts`). I added the new concrete string
to `scripts/i18n_blocked_seed.mjs` alongside `/played`'s and
regenerated `src/ui/i18n.status.json` / `i18n.status.summary.json` via
`npm run i18n:gen` so the S3 drift guard stays green.

## Test plan

- [x] New Vitest coverage in `tests/chat.test.ts`:
  - `/playtime` reports `0s` on a freshly joined character.
  - `/playtime` accumulates as the sim advances and, unlike `/played`,
    survives a simulated relog (`serializeCharacter` -> fresh `Sim` ->
    `addPlayer({ state })`), continuing to accumulate on top of the
    prior total in the new session.
- [x] `npx vitest run tests/chat.test.ts tests/localization_fixes.test.ts tests/parity/parity.test.ts tests/architecture.test.ts tests/sim.test.ts` — all green.
- [x] `UPDATE_PARITY=1` regen of `tests/parity/golden/chat_social.json` (new field appears in serialized player state).
- [x] `npx tsc --noEmit` clean.
- [x] `npm run gate` full suite green (11k+ tests) after fixing a local worktree env gap (missing `.env`/`node_modules`) unrelated to this change; confirmed the one remaining flaky suite (`tests/server/http/parity.test.ts`, a DB-timing sensitive HTTP dispatch-parity harness) reproduces identically on a clean, unmodified `release/v0.24.0` checkout, so it predates this change.
- [x] `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
