### PR TITLE
feat(mobile): support secure native Discord authentication

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -9,7 +9,8 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
-    implementation project(':capacitor-live-updates')
+    implementation project(':capacitor-app')
+    implementation project(':capacitor-browser')
 
 }
 

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -11,6 +11,7 @@ apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')
+    implementation project(':capacitor-live-updates')
 
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="worldofclaudecraft"
+                    android:host="discord-auth" />
+            </intent-filter>
+
         </activity>
 
         <provider

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -2,5 +2,8 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/android/capacitor')
 
-include ':capacitor-live-updates'
-project(':capacitor-live-updates').projectDir = new File('../node_modules/@capacitor/live-updates/android')
+include ':capacitor-app'
+project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
+
+include ':capacitor-browser'
+project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -7,3 +7,6 @@ project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/
 
 include ':capacitor-browser'
 project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')
+
+include ':capacitor-live-updates'
+project(':capacitor-live-updates').projectDir = new File('../node_modules/@capacitor/live-updates/android')

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -4,14 +4,6 @@ const config: CapacitorConfig = {
   appId: 'com.worldofclaudecraft',
   appName: 'World of ClaudeCraft',
   webDir: 'dist',
-  plugins: {
-    LiveUpdates: {
-      appId: '9fa1b0c1',
-      channel: 'Production',
-      autoUpdateMethod: 'none',
-      maxVersions: 2,
-    },
-  },
   server: {
     androidScheme: 'http',
   },

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -4,6 +4,14 @@ const config: CapacitorConfig = {
   appId: 'com.worldofclaudecraft',
   appName: 'World of ClaudeCraft',
   webDir: 'dist',
+  plugins: {
+    LiveUpdates: {
+      appId: '9fa1b0c1',
+      channel: 'Production',
+      autoUpdateMethod: 'none',
+      maxVersions: 2,
+    },
+  },
   server: {
     androidScheme: 'http',
   },

--- a/docs/mobile-store-release.md
+++ b/docs/mobile-store-release.md
@@ -73,37 +73,41 @@ VITE_API_ORIGIN=http://192.168.1.247 npm run native:sync
 Replace the IP with the Mac's current Wi-Fi/LAN address. Do not use
 `localhost` for a physical phone; that resolves to the phone itself.
 
-## Over The Air Updates
+## Native Discord Authentication
 
-The native apps include the Ionic Appflow Capacitor Live Updates SDK. It is
-configured in `capacitor.config.ts` with:
+Discord login and account linking open the system browser, return through the
+`worldofclaudecraft://discord-auth` app URL, and exchange a short-lived,
+single-use handoff code with the game server. The exchange also requires an
+app-generated verifier that never appears in the callback URL, so another app
+cannot use an intercepted custom-scheme callback. Starting the flow also uses
+the existing Apple DeviceCheck or Play Integrity proof, which prevents another
+app from initiating its own handoff with the shared URL scheme. The native return URL
+never carries a bearer session token or first-login link token. Discord itself
+continues to redirect to the existing
+HTTPS `/api/auth/discord/callback` URL, so no additional Discord Developer Portal
+redirect is required.
 
-| Setting | Value |
-|---|---|
-| Appflow app ID | `9fa1b0c1` |
-| Channel | `Production` |
-| Update method | `background` |
+Release QA must cover returning-user login, the first-time create-or-link chooser,
+linking from an existing signed-in account, cancellation, and an expired handoff
+on both iOS and Android. Confirm each browser flow returns to the app and that a
+consumed handoff code cannot be reused.
 
-Background updates are downloaded after app launch and become active on the next
-launch. Use this for web asset fixes only: HTML, CSS, JavaScript, bundled media,
-copy, and other client code already inside the Capacitor web build. Changes to
-native code, app icons, splash screens, permissions, entitlements, Capacitor
-config, or native plugin versions still require a new App Store or Play Store
-binary.
+## Store Updates Only
 
-After changing the Live Updates config or native dependencies, run:
+The native apps do not include the Ionic Appflow Capacitor Live Updates SDK and
+must not use Appflow over the air deployments. Every web or native change ships
+in a new App Store and Play Store binary.
 
-```sh
-npm run native:sync
-```
+Always run `npm run native:sync` before creating an archive. This rebuilds the
+native web client and copies the current assets into both platform projects.
+Confirm the version and build shown by the installed app match the intended
+release before submission.
 
-To ship an OTA update after the app-store binary containing Live Updates has
-been approved:
-
-1. Build the web app in Appflow from the target Git commit.
-2. Assign the web build to the `Production` Live Update channel.
-3. Test on a store or TestFlight build by launching once to download the update,
-   then closing and relaunching the app to apply it.
+Release QA must cover both a fresh install and an update over an existing store
+installation. For the update test, preserve the existing app data, install the
+new build over the old one, force quit and relaunch it several times, and confirm
+the app always uses the web assets bundled with the new binary. Also test one
+offline launch to ensure startup does not depend on an update service.
 
 ## Store Review Notes
 

--- a/docs/mobile-store-release.md
+++ b/docs/mobile-store-release.md
@@ -92,22 +92,37 @@ linking from an existing signed-in account, cancellation, and an expired handoff
 on both iOS and Android. Confirm each browser flow returns to the app and that a
 consumed handoff code cannot be reused.
 
-## Store Updates Only
+## Over The Air Updates
 
-The native apps do not include the Ionic Appflow Capacitor Live Updates SDK and
-must not use Appflow over the air deployments. Every web or native change ships
-in a new App Store and Play Store binary.
+The native apps include the Ionic Appflow Capacitor Live Updates SDK. It is
+configured in `capacitor.config.ts` with:
 
-Always run `npm run native:sync` before creating an archive. This rebuilds the
-native web client and copies the current assets into both platform projects.
-Confirm the version and build shown by the installed app match the intended
-release before submission.
+| Setting | Value |
+|---|---|
+| Appflow app ID | `9fa1b0c1` |
+| Channel | `Production` |
+| Update method | `background` |
 
-Release QA must cover both a fresh install and an update over an existing store
-installation. For the update test, preserve the existing app data, install the
-new build over the old one, force quit and relaunch it several times, and confirm
-the app always uses the web assets bundled with the new binary. Also test one
-offline launch to ensure startup does not depend on an update service.
+Background updates are downloaded after app launch and become active on the next
+launch. Use this for web asset fixes only: HTML, CSS, JavaScript, bundled media,
+copy, and other client code already inside the Capacitor web build. Changes to
+native code, app icons, splash screens, permissions, entitlements, Capacitor
+config, or native plugin versions still require a new App Store or Play Store
+binary.
+
+After changing the Live Updates config or native dependencies, run:
+
+```sh
+npm run native:sync
+```
+
+To ship an OTA update after the app-store binary containing Live Updates has
+been approved:
+
+1. Build the web app in Appflow from the target Git commit.
+2. Assign the web build to the `Production` Live Update channel.
+3. Test on a store or TestFlight build by launching once to download the update,
+   then closing and relaunching the app to apply it.
 
 ## Store Review Notes
 

--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -9,15 +9,6 @@
         "revision" : "2231987d85b8b0b289320b1d0947b4ae8345cde4",
         "version" : "8.4.1"
       }
-    },
-    {
-      "identity" : "ionic-live-updates-releases",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ionic-team/ionic-live-updates-releases.git",
-      "state" : {
-        "revision" : "e577a3735249a62f5dedd79d21c06d71e28f6855",
-        "version" : "0.5.8"
-      }
     }
   ],
   "version" : 3

--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -9,6 +9,15 @@
         "revision" : "2231987d85b8b0b289320b1d0947b4ae8345cde4",
         "version" : "8.4.1"
       }
+    },
+    {
+      "identity" : "ionic-live-updates-releases",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ionic-team/ionic-live-updates-releases.git",
+      "state" : {
+        "revision" : "e577a3735249a62f5dedd79d21c06d71e28f6855",
+        "version" : "0.5.8"
+      }
     }
   ],
   "version" : 3

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -8,6 +8,19 @@
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
         <string>World of ClaudeCraft</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.worldofclaudecraft.oauth</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>worldofclaudecraft</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -13,7 +13,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.1"),
         .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app"),
-        .package(name: "CapacitorBrowser", path: "../../../node_modules/@capacitor/browser")
+        .package(name: "CapacitorBrowser", path: "../../../node_modules/@capacitor/browser"),
+        .package(name: "CapacitorLiveUpdates", path: "../../../node_modules/@capacitor/live-updates")
     ],
     targets: [
         .target(
@@ -22,7 +23,8 @@ let package = Package(
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
                 .product(name: "CapacitorApp", package: "CapacitorApp"),
-                .product(name: "CapacitorBrowser", package: "CapacitorBrowser")
+                .product(name: "CapacitorBrowser", package: "CapacitorBrowser"),
+                .product(name: "CapacitorLiveUpdates", package: "CapacitorLiveUpdates")
             ]
         )
     ]

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -12,7 +12,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.1"),
-        .package(name: "CapacitorLiveUpdates", path: "../../../node_modules/@capacitor/live-updates")
+        .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app"),
+        .package(name: "CapacitorBrowser", path: "../../../node_modules/@capacitor/browser")
     ],
     targets: [
         .target(
@@ -20,7 +21,8 @@ let package = Package(
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
-                .product(name: "CapacitorLiveUpdates", package: "CapacitorLiveUpdates")
+                .product(name: "CapacitorApp", package: "CapacitorApp"),
+                .product(name: "CapacitorBrowser", package: "CapacitorBrowser")
             ]
         )
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-sesv2": "^3.1084.0",
         "@capacitor/app": "^8.1.0",
         "@capacitor/browser": "^8.0.3",
+        "@capacitor/live-updates": "^0.5.0",
         "@noble/curves": "^1.9.7",
         "@solana/wallet-standard-chains": "^1.1.2",
         "@solana/wallet-standard-features": "^1.4.0",
@@ -667,6 +668,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.4.0"
+      }
+    },
+    "node_modules/@capacitor/live-updates": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/live-updates/-/live-updates-0.5.0.tgz",
+      "integrity": "sha512-qJBD+gVg4JwfRryM/i366Uzw9DRYqCAmFl5+k9ph9kDbvikvT69UiITcdJw840C3Q3RA2z+rLC7LZOZ5L56cuQ==",
+      "license": "Commercial",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@colors/colors": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-sesv2": "^3.1084.0",
-        "@capacitor/live-updates": "^0.5.0",
+        "@capacitor/app": "^8.1.0",
+        "@capacitor/browser": "^8.0.3",
         "@noble/curves": "^1.9.7",
         "@solana/wallet-standard-chains": "^1.1.2",
         "@solana/wallet-standard-features": "^1.4.0",
@@ -594,6 +595,24 @@
         "@capacitor/core": "^8.4.0"
       }
     },
+    "node_modules/@capacitor/app": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz",
+      "integrity": "sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/browser": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-8.0.3.tgz",
+      "integrity": "sha512-WJWPHEPbweiFoHYmVlCbZf5yrqJ2Rchx2Xvbmd+3Lf+Zkpq3nXBThThY2CF69lYEg1NINGF9BcHThIOEU1gZlQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/cli": {
       "version": "8.4.1",
       "dev": true,
@@ -648,15 +667,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.4.0"
-      }
-    },
-    "node_modules/@capacitor/live-updates": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/live-updates/-/live-updates-0.5.0.tgz",
-      "integrity": "sha512-qJBD+gVg4JwfRryM/i366Uzw9DRYqCAmFl5+k9ph9kDbvikvT69UiITcdJw840C3Q3RA2z+rLC7LZOZ5L56cuQ==",
-      "license": "Commercial",
-      "peerDependencies": {
-        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@colors/colors": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@aws-sdk/client-sesv2": "^3.1084.0",
     "@capacitor/app": "^8.1.0",
     "@capacitor/browser": "^8.0.3",
+    "@capacitor/live-updates": "^0.5.0",
     "@noble/curves": "^1.9.7",
     "@solana/wallet-standard-chains": "^1.1.2",
     "@solana/wallet-standard-features": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-sesv2": "^3.1084.0",
-    "@capacitor/live-updates": "^0.5.0",
+    "@capacitor/app": "^8.1.0",
+    "@capacitor/browser": "^8.0.3",
     "@noble/curves": "^1.9.7",
     "@solana/wallet-standard-chains": "^1.1.2",
     "@solana/wallet-standard-features": "^1.4.0",

--- a/server/discord.ts
+++ b/server/discord.ts
@@ -80,6 +80,12 @@ import {
 } from './http/middleware/bearer_active_guard';
 import type { Ctx, Middleware, Next, RouteDef } from './http/types';
 import { isUniqueViolation, json, moderationErrorBody } from './http_util';
+import { verifyNativeAttestation } from './native_attestation';
+import {
+  consumeNativeDiscordHandoff,
+  createNativeDiscordHandoff,
+  validNativeDiscordChallenge,
+} from './native_discord_handoff';
 import {
   authThrottled,
   clearAuthFailures,
@@ -95,6 +101,8 @@ const STATE_TTL_MINUTES = 10;
 // than the OAuth state TTL since a human decision sits in the middle.
 const PENDING_LOGIN_TTL_MINUTES = 15;
 const DEFAULT_INVITE = 'https://discord.gg/GjhnUsBtw';
+const NATIVE_DISCORD_REDIRECT = 'worldofclaudecraft://discord-auth';
+const NATIVE_REDIRECT_STATE_PREFIX = `${NATIVE_DISCORD_REDIRECT}?challenge=`;
 
 // Lightweight local instrumentation hook. Admin-dashboard usage metrics require a
 // registered typed key + per-locale label, which is more coupling than this
@@ -195,7 +203,13 @@ export function discordPresenceCache(): DiscordPresenceSnapshot {
 export async function handleDiscordStart(
   req: http.IncomingMessage,
   res: http.ServerResponse,
-  opts: { mode: DiscordLinkMode; accountId: number | null },
+  opts: {
+    mode: DiscordLinkMode;
+    accountId: number | null;
+    native?: boolean;
+    nativeChallenge?: string;
+    nativeAttestation?: unknown;
+  },
 ): Promise<void> {
   note('discord.start.request');
   const cfg = discordConfig();
@@ -208,6 +222,12 @@ export async function handleDiscordStart(
     note('discord.start.rate_limited');
     return json(res, 429, { error: 'rate limited' });
   }
+  if (opts.native && !validNativeDiscordChallenge(opts.nativeChallenge)) {
+    return json(res, 400, { error: 'invalid native challenge' });
+  }
+  if (opts.native && !(await verifyNativeAttestation(req, opts.nativeAttestation))) {
+    return json(res, 403, { error: 'native verification failed' });
+  }
   const state = newToken();
   const codeVerifier = newToken();
   const codeChallenge = pkceChallengeFromVerifier(codeVerifier);
@@ -216,7 +236,7 @@ export async function handleDiscordStart(
     codeVerifier,
     mode: opts.mode,
     accountId: opts.accountId,
-    redirectTo: null,
+    redirectTo: opts.native ? `${NATIVE_REDIRECT_STATE_PREFIX}${opts.nativeChallenge}` : null,
     ttlMinutes: STATE_TTL_MINUTES,
   });
   const url = buildAuthorizeUrl({
@@ -241,19 +261,26 @@ export async function handleDiscordStart(
 export async function handleDiscordCallback(
   req: http.IncomingMessage,
   res: http.ServerResponse,
+  isIpBlocked: (ip: string) => boolean = () => false,
 ): Promise<void> {
   note('discord.callback.request');
+  const u = new URL(req.url ?? '/', 'http://localhost');
+  const state = u.searchParams.get('state') ?? '';
+  // Preserve the callback's established abuse-control and HTML error contract even
+  // when Discord is not configured. A callback carrying state defers this check
+  // until the state is consumed so a verified native flow can return to the app.
+  if (!state && isIpBlocked(requestIp(req))) {
+    return bouncePage(res, 403, { ok: false, mode: 'login', error: 'server_error' });
+  }
   const cfg = discordConfig();
   if (!cfg) return bouncePage(res, 503, { ok: false, mode: 'login', error: 'not_configured' });
-  const u = new URL(req.url ?? '/', 'http://localhost');
   const code = u.searchParams.get('code') ?? '';
-  const state = u.searchParams.get('state') ?? '';
-  if (u.searchParams.get('error')) {
-    // User clicked "Cancel" on Discord's consent screen.
+  if (u.searchParams.get('error') && !state) {
+    // Preserve the legacy web cancellation response for providers or old links
+    // that omit state. A native flow always has state and takes the app return path.
     return bouncePage(res, 200, { ok: false, mode: 'login', error: 'cancelled' });
   }
-  if (!code || !state)
-    return bouncePage(res, 400, { ok: false, mode: 'login', error: 'bad_request' });
+  if (!state) return bouncePage(res, 400, { ok: false, mode: 'login', error: 'bad_request' });
 
   const stateRow = await consumeDiscordOAuthState(pool, state);
   if (!stateRow) {
@@ -261,6 +288,21 @@ export async function handleDiscordCallback(
     return bouncePage(res, 400, { ok: false, mode: 'login', error: 'expired' });
   }
   const mode: DiscordLinkMode = isDiscordLinkMode(stateRow.mode) ? stateRow.mode : 'login';
+  const nativeChallenge = nativeChallengeFromState(stateRow.redirect_to);
+  const native = nativeChallenge !== null;
+  const respond = (status: number, payload: BouncePayload): void =>
+    discordOAuthResponse(req, res, status, payload, native);
+
+  if (isIpBlocked(requestIp(req))) {
+    return respond(403, { ok: false, mode, error: 'server_error' });
+  }
+
+  if (u.searchParams.get('error')) {
+    // User clicked "Cancel" on Discord's consent screen. Consume the state first so
+    // native callers can be returned to the app without trusting a query flag.
+    return respond(200, { ok: false, mode, error: 'cancelled' });
+  }
+  if (!code) return respond(400, { ok: false, mode, error: 'bad_request' });
 
   const identity = await exchangeCodeForIdentity(
     code,
@@ -270,18 +312,18 @@ export async function handleDiscordCallback(
   );
   if (!identity) {
     note('discord.callback.exchange_failed');
-    return bouncePage(res, 502, { ok: false, mode, error: 'discord_error' });
+    return respond(502, { ok: false, mode, error: 'discord_error' });
   }
   const { user, guildMember } = identity;
 
   try {
     if (mode === 'link') {
-      return await completeLink(res, stateRow.account_id, user, guildMember, mode);
+      return await completeLink(respond, stateRow.account_id, user, guildMember, mode);
     }
-    return await completeLogin(req, res, user, guildMember);
+    return await completeLogin(req, respond, user, guildMember, nativeChallenge);
   } catch (err) {
     logger.error({ err }, 'discord callback error');
-    return bouncePage(res, 500, { ok: false, mode, error: 'server_error' });
+    return respond(500, { ok: false, mode, error: 'server_error' });
   }
 }
 
@@ -299,13 +341,13 @@ async function captureDiscordEmail(
 
 // Link an authenticated session's account to the Discord identity.
 async function completeLink(
-  res: http.ServerResponse,
+  respond: (status: number, payload: BouncePayload) => void,
   accountId: number | null,
   user: DiscordUser,
   guildMember: boolean,
   mode: DiscordLinkMode,
 ): Promise<void> {
-  if (accountId === null) return bouncePage(res, 400, { ok: false, mode, error: 'no_session' });
+  if (accountId === null) return respond(400, { ok: false, mode, error: 'no_session' });
   const linked = await linkDiscordToAccount(pool, accountId, {
     discordUserId: user.id,
     username: discordDisplayName(user),
@@ -315,12 +357,12 @@ async function completeLink(
   });
   if (!linked) {
     note('discord.link.conflict');
-    return bouncePage(res, 409, { ok: false, mode, error: 'already_linked' });
+    return respond(409, { ok: false, mode, error: 'already_linked' });
   }
   await captureDiscordEmail(accountId, user.email, user.emailVerified);
   await grantLinkRewards(accountId, guildMember);
   note('discord.link.success');
-  return bouncePage(res, 200, { ok: true, mode, username: discordDisplayName(user) });
+  return respond(200, { ok: true, mode, username: discordDisplayName(user) });
 }
 
 // Log in the account that owns this Discord identity, OR (first time) hand the
@@ -330,9 +372,10 @@ async function completeLink(
 // be an account-takeover vector).
 async function completeLogin(
   req: http.IncomingMessage,
-  res: http.ServerResponse,
+  respond: (status: number, payload: BouncePayload) => void,
   user: DiscordUser,
   guildMember: boolean,
+  nativeChallenge: string | null,
 ): Promise<void> {
   const meta = { ip: requestIp(req), userAgent: String(req.headers['user-agent'] ?? '') };
   const accountId = await accountForDiscord(pool, user.id);
@@ -353,7 +396,20 @@ async function completeLogin(
       ttlMinutes: PENDING_LOGIN_TTL_MINUTES,
     });
     note('discord.login.choose');
-    return bouncePage(res, 200, {
+    if (nativeChallenge) {
+      const nativeCode = createNativeDiscordHandoff(nativeChallenge, {
+        kind: 'choose',
+        linkToken,
+        username: discordDisplayName(user),
+      });
+      return respond(200, {
+        ok: true,
+        mode: 'login',
+        nativeCode,
+        username: discordDisplayName(user),
+      });
+    }
+    return respond(200, {
       ok: true,
       mode: 'login',
       choose: true,
@@ -371,9 +427,22 @@ async function completeLogin(
   if (guildMember) await grantGuildReward(accountId);
   note('discord.login.returning');
   const status = await moderationStatusForAccount(accountId);
-  if (status.locked) return bouncePage(res, 403, { ok: false, mode: 'login', error: 'locked' });
+  if (status.locked) return respond(403, { ok: false, mode: 'login', error: 'locked' });
+  if (nativeChallenge) {
+    const nativeCode = createNativeDiscordHandoff(nativeChallenge, {
+      kind: 'login',
+      accountId,
+      username: acct?.username ?? 'player',
+    });
+    return respond(200, {
+      ok: true,
+      mode: 'login',
+      nativeCode,
+      username: acct?.username ?? 'player',
+    });
+  }
   const token = await issueDiscordSession(accountId, meta);
-  return bouncePage(res, 200, {
+  return respond(200, {
     ok: true,
     mode: 'login',
     token,
@@ -918,6 +987,65 @@ interface BouncePayload {
   // under `linkToken`; the SPA shows the create-new / link-existing chooser.
   choose?: boolean;
   linkToken?: string;
+  // Native returning login: short-lived single-use code exchanged through the
+  // existing desktop handoff endpoint. A bearer session never appears in a URL.
+  nativeCode?: string;
+}
+
+function nativeChallengeFromState(redirectTo: string | null): string | null {
+  if (!redirectTo?.startsWith(NATIVE_REDIRECT_STATE_PREFIX)) return null;
+  const challenge = redirectTo.slice(NATIVE_REDIRECT_STATE_PREFIX.length);
+  return validNativeDiscordChallenge(challenge) ? challenge : null;
+}
+
+function discordOAuthResponse(
+  _req: http.IncomingMessage,
+  res: http.ServerResponse,
+  status: number,
+  payload: BouncePayload,
+  native: boolean,
+): void {
+  if (!native) {
+    bouncePage(res, status, payload);
+    return;
+  }
+  const url = new URL(NATIVE_DISCORD_REDIRECT);
+  url.searchParams.set('ok', payload.ok ? '1' : '0');
+  url.searchParams.set('mode', payload.mode);
+  if (payload.nativeCode) url.searchParams.set('code', payload.nativeCode);
+  if (payload.choose && payload.linkToken) {
+    url.searchParams.set('choose', '1');
+    url.searchParams.set('linkToken', payload.linkToken);
+  }
+  if (payload.username) url.searchParams.set('username', payload.username);
+  if (payload.error) url.searchParams.set('error', payload.error);
+  res.writeHead(302, {
+    Location: url.toString(),
+    'Cache-Control': 'no-store',
+    Pragma: 'no-cache',
+  });
+  res.end();
+}
+
+export async function handleNativeDiscordExchange(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): Promise<void> {
+  if (!discordRateLimited(req, 0).allowed) return json(res, 429, { error: 'rate limited' });
+  const body = await readJsonBody(req);
+  const handoff = consumeNativeDiscordHandoff(body.code, body.verifier);
+  if (!handoff) return json(res, 401, { error: 'invalid or expired native login code' });
+  if (handoff.kind === 'choose') {
+    return json(res, 200, {
+      choose: true,
+      linkToken: handoff.linkToken,
+      username: handoff.username,
+    });
+  }
+  const status = await moderationStatusForAccount(handoff.accountId);
+  if (status.locked) return json(res, 403, moderationErrorBody(status));
+  const token = await issueDiscordSession(handoff.accountId, requestMeta(req));
+  return json(res, 200, { token, username: handoff.username });
 }
 
 // Render the callback result as an HTML page that messages the SPA. Works whether
@@ -1135,18 +1263,25 @@ async function discordStartHandler(ctx: Ctx): Promise<void> {
   // A blocked IP must not open the OAuth flow (login mode can provision an account
   // via the callback). Opaque 429, matching login/new + login/link.
   if (useRuntime().isIpBlocked(ctx.ip)) return json(ctx.res, 429, { error: 'rate limited' });
-  return handleDiscordStart(ctx.req, ctx.res, { mode, accountId });
+  const native = ctx.url.searchParams.get('native') === '1';
+  const nativeChallenge = ctx.url.searchParams.get('challenge') ?? undefined;
+  const body = native ? await readJsonBody(ctx.req) : {};
+  return handleDiscordStart(ctx.req, ctx.res, {
+    mode,
+    accountId,
+    native,
+    nativeChallenge,
+    nativeAttestation: body.nativeAttestation,
+  });
 }
 
 /** GET /api/auth/discord/callback: OAuth callback (HTML bounce; never problem+json). */
 async function discordCallbackHandler(ctx: Ctx): Promise<void> {
-  // A blocked IP must not mint a returning-user session through the callback. Opaque
-  // HTML bounce (the existing 'server_error' the SPA already handles), so the block
-  // is never revealed and the response stays HTML, not problem+json.
-  if (useRuntime().isIpBlocked(ctx.ip)) {
-    return bouncePage(ctx.res, 403, { ok: false, mode: 'login', error: 'server_error' });
-  }
-  return handleDiscordCallback(ctx.req, ctx.res);
+  return handleDiscordCallback(ctx.req, ctx.res, useRuntime().isIpBlocked);
+}
+
+async function nativeDiscordExchangeHandler(ctx: Ctx): Promise<void> {
+  return handleNativeDiscordExchange(ctx.req, ctx.res);
 }
 
 /** POST /api/auth/discord/login/new: first-login "create new account" chooser. */
@@ -1213,6 +1348,12 @@ export const routes: RouteDef[] = [
     path: '/api/auth/discord/login/link',
     surface: 'api',
     handler: discordLoginLinkHandler,
+  },
+  {
+    method: 'POST',
+    path: '/api/auth/discord/native/exchange',
+    surface: 'api',
+    handler: nativeDiscordExchangeHandler,
   },
   {
     method: 'GET',

--- a/server/main.ts
+++ b/server/main.ts
@@ -115,6 +115,7 @@ import {
   handleDiscordStart,
   handleDiscordStatus,
   handleDiscordUnlink,
+  handleNativeDiscordExchange,
 } from './discord';
 import { pruneDiscordOAuthStates, pruneDiscordPendingLogins } from './discord_db';
 import { emailAccountCreated } from './email';
@@ -1613,10 +1614,10 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
     // web-login guard, which is login/register-only). Mutations go through
     // bearerActiveAccount; the dedicated Discord rate-limit bucket guards them.
     if (req.method === 'POST' && url === '/api/auth/discord/start') {
-      const mode =
-        new URL(req.url ?? '/', 'http://localhost').searchParams.get('mode') === 'link'
-          ? 'link'
-          : 'login';
+      const discordStartUrl = new URL(req.url ?? '/', 'http://localhost');
+      const mode = discordStartUrl.searchParams.get('mode') === 'link' ? 'link' : 'login';
+      const native = discordStartUrl.searchParams.get('native') === '1';
+      const nativeChallenge = discordStartUrl.searchParams.get('challenge') ?? undefined;
       let accountId: number | null = null;
       if (mode === 'link') {
         accountId = await bearerActiveAccount(req, res);
@@ -1624,10 +1625,17 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       }
       if (!discordRateLimited(req, accountId ?? 0).allowed)
         return json(res, 429, { error: 'rate limited' });
-      return handleDiscordStart(req, res, { mode, accountId });
+      const body = native ? await readBody(req) : {};
+      return handleDiscordStart(req, res, {
+        mode,
+        accountId,
+        native,
+        nativeChallenge,
+        nativeAttestation: body.nativeAttestation,
+      });
     }
     if (req.method === 'GET' && url === '/api/auth/discord/callback') {
-      return handleDiscordCallback(req, res);
+      return handleDiscordCallback(req, res, (ip) => liveGame().isIpBlocked(ip));
     }
     // First-time-login chooser endpoints. Unauthenticated like /callback: the
     // authorization is the single-use pending-login token (minted only after a
@@ -1638,6 +1646,9 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
     }
     if (req.method === 'POST' && url === '/api/auth/discord/login/link') {
       return handleDiscordLoginLink(req, res, (ip) => liveGame().isIpBlocked(ip));
+    }
+    if (req.method === 'POST' && url === '/api/auth/discord/native/exchange') {
+      return handleNativeDiscordExchange(req, res);
     }
     if (req.method === 'GET' && url === '/api/discord') {
       const accountId = await bearerActiveAccount(req, res);

--- a/server/native_discord_handoff.ts
+++ b/server/native_discord_handoff.ts
@@ -1,0 +1,68 @@
+import crypto from 'node:crypto';
+
+export const NATIVE_DISCORD_HANDOFF_TTL_MS = 5 * 60 * 1000;
+const CODE_BYTES = 20;
+const PROOF_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+
+export type NativeDiscordHandoff =
+  | { kind: 'login'; accountId: number; username: string }
+  | { kind: 'choose'; linkToken: string; username: string };
+
+interface StoredHandoff {
+  payload: NativeDiscordHandoff;
+  challenge: string;
+  issuedAt: number;
+}
+
+const handoffs = new Map<string, StoredHandoff>();
+
+function challengeFor(verifier: string): string {
+  return crypto.createHash('sha256').update(verifier).digest('base64url');
+}
+
+function prune(): void {
+  const cutoff = Date.now() - NATIVE_DISCORD_HANDOFF_TTL_MS;
+  for (const [code, entry] of handoffs) {
+    if (entry.issuedAt < cutoff) handoffs.delete(code);
+  }
+}
+
+export function validNativeDiscordChallenge(value: unknown): value is string {
+  return typeof value === 'string' && PROOF_PATTERN.test(value);
+}
+
+export function createNativeDiscordHandoff(
+  challenge: string,
+  payload: NativeDiscordHandoff,
+): string {
+  if (!validNativeDiscordChallenge(challenge)) throw new Error('invalid native Discord challenge');
+  prune();
+  const code = crypto.randomBytes(CODE_BYTES).toString('base64url');
+  handoffs.set(code, {
+    payload,
+    challenge,
+    issuedAt: Date.now(),
+  });
+  return code;
+}
+
+export function consumeNativeDiscordHandoff(
+  code: unknown,
+  verifier: unknown,
+): NativeDiscordHandoff | null {
+  prune();
+  if (typeof code !== 'string' || !/^[A-Za-z0-9_-]{20,80}$/.test(code)) return null;
+  if (typeof verifier !== 'string' || !PROOF_PATTERN.test(verifier)) return null;
+  const entry = handoffs.get(code);
+  if (!entry) return null;
+  if (Date.now() - entry.issuedAt > NATIVE_DISCORD_HANDOFF_TTL_MS) return null;
+  const actual = Buffer.from(challengeFor(verifier));
+  const expected = Buffer.from(entry.challenge);
+  if (actual.length !== expected.length || !crypto.timingSafeEqual(actual, expected)) return null;
+  handoffs.delete(code);
+  return entry.payload;
+}
+
+export function resetNativeDiscordHandoffsForTest(): void {
+  handoffs.clear();
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -81,6 +81,13 @@ import {
 import { charselectPrimaryAction } from './net/charselect_action';
 import { createNativeAttestationProof } from './net/native_attestation';
 import {
+  createNativeDiscordProof,
+  installNativeDiscordUrlHandler,
+  type NativeDiscordResult,
+  openNativeDiscordOAuth,
+  takeNativeDiscordVerifier,
+} from './net/native_discord';
+import {
   Api,
   ApiError,
   type CharacterSummary,
@@ -5619,9 +5626,8 @@ function flashWalletError(message: string): void {
 // Refreshed after login: ask the server which wallet (if any) this account has
 // linked, so the button can show the verified ✓ state.
 // ── Discord login/onboarding ─────────────────────────────────────────────────
-// Discord UI is on unless the native app build disables it.
-const DISCORD_BUILD_ENABLED =
-  !NATIVE_APP && String(import.meta.env.VITE_DISCORD_DISABLED ?? '').trim() !== '1';
+// Discord UI is available on web and native unless explicitly disabled at build time.
+const DISCORD_BUILD_ENABLED = String(import.meta.env.VITE_DISCORD_DISABLED ?? '').trim() !== '1';
 // Community links for the mobile More tray. The invite mirrors the hardcoded
 // invite on the shells' community links and is the fallback when the server-fed
 // discordInviteUrl() is not known yet (logged out, offline).
@@ -5643,6 +5649,19 @@ function startDiscordOAuth(mode: 'login' | 'link'): void {
     } catch {
       /* storage disabled */
     }
+    if (NATIVE_APP) {
+      void createNativeDiscordProof()
+        .then(async ({ verifier, challenge }) => {
+          const attestation = await createNativeAttestationProof(api.base, 'discord');
+          const { url } = await api.discordStart('login', true, challenge, attestation);
+          await openNativeDiscordOAuth(url, verifier);
+        })
+        .catch((err) => {
+          console.error('[discord] could not start native oauth', err);
+          flashDiscordError();
+        });
+      return;
+    }
     // LOGIN from the auth screen: a FULL-PAGE redirect, not a popup. The popup's
     // window.opener is severed by the cross-origin hop to Discord (COOP), so the
     // result never returns; a same-tab redirect always lands the callback, which
@@ -5654,6 +5673,19 @@ function startDiscordOAuth(mode: 'login' | 'link'): void {
       })
       .catch((err) => {
         console.error('[discord] could not start oauth', err);
+        flashDiscordError();
+      });
+    return;
+  }
+  if (NATIVE_APP) {
+    void createNativeDiscordProof()
+      .then(async ({ verifier, challenge }) => {
+        const attestation = await createNativeAttestationProof(api.base, 'discord');
+        const { url } = await api.discordStart('link', true, challenge, attestation);
+        await openNativeDiscordOAuth(url, verifier);
+      })
+      .catch((err) => {
+        console.error('[discord] could not start native oauth', err);
         flashDiscordError();
       });
     return;
@@ -5672,6 +5704,52 @@ function startDiscordOAuth(mode: 'login' | 'link'): void {
       popup?.close();
       flashDiscordError();
     });
+}
+
+async function handleNativeDiscordResult(result: NativeDiscordResult): Promise<void> {
+  if (!result.ok) {
+    flashDiscordError();
+    return;
+  }
+  if (result.mode === 'link') {
+    takeNativeDiscordVerifier();
+    await refreshDiscordStatus();
+    return;
+  }
+  if (!result.code) {
+    flashDiscordError();
+    return;
+  }
+  const verifier = takeNativeDiscordVerifier();
+  if (!verifier) {
+    flashDiscordError();
+    return;
+  }
+  try {
+    const exchange = await api.exchangeNativeDiscordCode(result.code, verifier);
+    if (exchange.choose && exchange.linkToken) {
+      localStorage.setItem(
+        'woc_discord_choice',
+        JSON.stringify({
+          linkToken: exchange.linkToken,
+          username: exchange.username,
+          ts: Date.now(),
+        }),
+      );
+    } else {
+      api.saveSession();
+    }
+    window.location.reload();
+  } catch (err) {
+    console.error('[discord] could not exchange native login code', err);
+    flashDiscordError();
+  }
+}
+
+if (NATIVE_APP && DISCORD_BUILD_ENABLED) {
+  void installNativeDiscordUrlHandler(handleNativeDiscordResult).catch((err) => {
+    console.error('[discord] could not install native url handler', err);
+  });
 }
 
 // Popup bounce-page result (link mode; login uses a full redirect). Same-origin only.
@@ -5900,8 +5978,8 @@ function updateDiscordCtaBanner(): void {
 
 // Show the Discord entry in the mobile "More" tray. Mobile has no keyboard, so
 // the U-key panel toggle is unreachable there; this button is the touch path to
-// Discord. Hidden only when the client build disables Discord entirely (native
-// app / VITE_DISCORD_DISABLED); what a tap opens is decided per-tap in
+// Discord. Hidden only when the client build disables Discord entirely through
+// VITE_DISCORD_DISABLED; what a tap opens is decided per-tap in
 // openDiscordEntry, so the entry works logged-out and offline too.
 function syncDiscordMobileEntry(): void {
   const btn = document.getElementById('mobile-discord');

--- a/src/net/native_discord.ts
+++ b/src/net/native_discord.ts
@@ -1,0 +1,96 @@
+import { App } from '@capacitor/app';
+import { Browser } from '@capacitor/browser';
+
+export interface NativeDiscordResult {
+  ok: boolean;
+  mode: 'login' | 'link';
+  code: string;
+  username: string;
+  error: string;
+}
+
+export function parseNativeDiscordUrl(value: string): NativeDiscordResult | null {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'worldofclaudecraft:' || url.hostname !== 'discord-auth') return null;
+  const mode = url.searchParams.get('mode');
+  if (mode !== 'login' && mode !== 'link') return null;
+  return {
+    ok: url.searchParams.get('ok') === '1',
+    mode,
+    code: url.searchParams.get('code') ?? '',
+    username: url.searchParams.get('username') ?? '',
+    error: url.searchParams.get('error') ?? '',
+  };
+}
+
+const VERIFIER_KEY = 'woc_native_discord_verifier';
+
+function base64Url(bytes: Uint8Array): string {
+  let value = '';
+  for (const byte of bytes) value += String.fromCharCode(byte);
+  return btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export async function createNativeDiscordProof(): Promise<{
+  verifier: string;
+  challenge: string;
+}> {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  const verifier = base64Url(bytes);
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  return { verifier, challenge: base64Url(new Uint8Array(digest)) };
+}
+
+export async function openNativeDiscordOAuth(url: string, verifier: string): Promise<void> {
+  localStorage.setItem(VERIFIER_KEY, verifier);
+  await Browser.open({ url });
+}
+
+export function takeNativeDiscordVerifier(): string {
+  const verifier = localStorage.getItem(VERIFIER_KEY) ?? '';
+  localStorage.removeItem(VERIFIER_KEY);
+  return verifier;
+}
+
+export function createNativeDiscordUrlDeduper(
+  windowMs = 10_000,
+  now: () => number = Date.now,
+): (url: string) => boolean {
+  let lastUrl = '';
+  let lastAt = 0;
+  return (url: string): boolean => {
+    const at = now();
+    if (url === lastUrl && at - lastAt < windowMs) return false;
+    lastUrl = url;
+    lastAt = at;
+    return true;
+  };
+}
+
+export async function installNativeDiscordUrlHandler(
+  onResult: (result: NativeDiscordResult) => void | Promise<void>,
+): Promise<void> {
+  const shouldHandle = createNativeDiscordUrlDeduper();
+  const handle = async (value: string): Promise<void> => {
+    const result = parseNativeDiscordUrl(value);
+    if (!result) return;
+    if (!shouldHandle(value)) return;
+    try {
+      await Browser.close();
+    } catch {
+      // Android Custom Tabs close automatically when the app deep link opens.
+    }
+    await onResult(result);
+  };
+
+  await App.addListener('appUrlOpen', ({ url }) => {
+    void handle(url);
+  });
+  const launch = await App.getLaunchUrl();
+  if (launch?.url) await handle(launch.url);
+}

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -619,8 +619,31 @@ export class Api {
   // ── Discord link/login + status ────────────────────────────────────────────
   // Returns the discord.com authorize URL the browser navigates to (login = new
   // session, link = attach to the current account).
-  async discordStart(mode: 'login' | 'link'): Promise<{ url: string }> {
-    return this.post(`/api/auth/discord/start?mode=${mode}`, {});
+  async discordStart(
+    mode: 'login' | 'link',
+    native = false,
+    challenge = '',
+    nativeAttestation: unknown = undefined,
+  ): Promise<{ url: string }> {
+    const nativeQuery = native ? `&native=1&challenge=${encodeURIComponent(challenge)}` : '';
+    return this.post(`/api/auth/discord/start?mode=${mode}${nativeQuery}`, { nativeAttestation });
+  }
+
+  async exchangeNativeDiscordCode(
+    code: string,
+    verifier: string,
+  ): Promise<{ choose: boolean; linkToken: string; username: string }> {
+    const data = await this.post('/api/auth/discord/native/exchange', { code, verifier });
+    if (data.choose === true) {
+      return {
+        choose: true,
+        linkToken: typeof data.linkToken === 'string' ? data.linkToken : '',
+        username: typeof data.username === 'string' ? data.username : '',
+      };
+    }
+    this.token = data.token;
+    this.username = data.username;
+    return { choose: false, linkToken: '', username: this.username ?? '' };
   }
 
   // First-time Discord login chooser: create a brand-new account for the verified

--- a/tests/discord_server.test.ts
+++ b/tests/discord_server.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { Readable } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -24,11 +25,13 @@ import {
   handleDiscordStart,
   handleDiscordStatus,
   handleDiscordUnlink,
+  handleNativeDiscordExchange,
   handleSwagClaim,
 } from '../server/discord';
+import { resetNativeDiscordHandoffsForTest } from '../server/native_discord_handoff';
 import { resetAuthFailures, resetDiscordRateLimits } from '../server/ratelimit';
 
-function makeReq(opts: { url?: string; body?: unknown } = {}): any {
+function makeReq(opts: { url?: string; body?: unknown; origin?: string } = {}): any {
   const req: any =
     opts.body !== undefined
       ? Readable.from([Buffer.from(JSON.stringify(opts.body))])
@@ -38,7 +41,7 @@ function makeReq(opts: { url?: string; body?: unknown } = {}): any {
           },
         });
   req.url = opts.url ?? '/';
-  req.headers = { host: 'worldofclaudecraft.com' };
+  req.headers = { host: 'worldofclaudecraft.com', ...(opts.origin ? { origin: opts.origin } : {}) };
   req.socket = { remoteAddress: '127.0.0.1' };
   return req;
 }
@@ -126,6 +129,7 @@ beforeEach(() => {
   findAccountRows = [];
   accountInsertRow = [{ id: 5, username: 'Maxp', password_hash: 'h' }];
   resetDiscordRateLimits();
+  resetNativeDiscordHandoffsForTest();
   resetAuthFailures();
   dbMock.query.mockReset();
   dbMock.query.mockImplementation((sql: string) => Promise.resolve(defaultRouter(sql)));
@@ -135,6 +139,9 @@ afterEach(() => {
 });
 
 const noopGrant = () => {};
+const NATIVE_VERIFIER = 'A'.repeat(43);
+const NATIVE_CHALLENGE = createHash('sha256').update(NATIVE_VERIFIER).digest('base64url');
+const NATIVE_STATE_REDIRECT = `worldofclaudecraft://discord-auth?challenge=${NATIVE_CHALLENGE}`;
 function parse(res: any) {
   return { status: res.statusCode, data: res.body ? JSON.parse(res.body) : {} };
 }
@@ -201,6 +208,20 @@ describe('POST /api/auth/discord/start', () => {
     );
     expect(insert).toBeTruthy();
     expect(url.searchParams.get('code_challenge')).not.toBeNull();
+  });
+
+  it('marks native starts with the allowlisted app return URL', async () => {
+    const res = makeRes();
+    await handleDiscordStart(makeReq({ origin: 'capacitor://localhost' }), res, {
+      mode: 'login',
+      accountId: null,
+      native: true,
+      nativeChallenge: NATIVE_CHALLENGE,
+    });
+    const insert = dbMock.query.mock.calls.find((c) =>
+      String(c[0]).includes('INSERT INTO discord_oauth_states'),
+    );
+    expect(insert?.[1]?.[4]).toBe(NATIVE_STATE_REDIRECT);
   });
 
   it('503s when Discord is not configured', async () => {
@@ -584,6 +605,158 @@ describe('GET /api/auth/discord/callback', () => {
     // A session token is minted in the payload; the chooser is not offered.
     expect(res.body).toContain('"token"');
     expect(res.body).not.toContain('"choose":true');
+  });
+
+  it('returns a native returning user through a one-time handoff code', async () => {
+    stateRows = [
+      {
+        state: 's',
+        code_verifier: 'v',
+        mode: 'login',
+        account_id: null,
+        redirect_to: NATIVE_STATE_REDIRECT,
+      },
+    ];
+    ownerRows = [{ account_id: 1 }];
+    accountByIdRows = [{ id: 1, username: 'maxp', password_set: true }];
+    mockDiscordFetch();
+    const res = makeRes();
+    await handleDiscordCallback(
+      makeReq({ url: '/api/auth/discord/callback?code=abc&state=s' }),
+      res,
+    );
+    expect(res.statusCode).toBe(302);
+    const location = new URL(String(res.headers.Location));
+    expect(location.protocol).toBe('worldofclaudecraft:');
+    expect(location.hostname).toBe('discord-auth');
+    expect(location.searchParams.get('mode')).toBe('login');
+    const handoffCode = location.searchParams.get('code') ?? '';
+    expect(handoffCode).toMatch(/^[A-Za-z0-9_-]{20,80}$/);
+    expect(location.searchParams.has('token')).toBe(false);
+    expect(location.searchParams.has('linkToken')).toBe(false);
+
+    const exchange = makeRes();
+    await handleNativeDiscordExchange(
+      makeReq({ body: { code: handoffCode, verifier: NATIVE_VERIFIER } }),
+      exchange,
+    );
+    expect(parse(exchange).status).toBe(200);
+    expect(parse(exchange).data.token).toMatch(/^[a-f0-9]{64}$/);
+    expect(parse(exchange).data.username).toBe('maxp');
+  });
+
+  it('keeps a first-time native chooser secret behind the app-held verifier', async () => {
+    stateRows = [
+      {
+        state: 's',
+        code_verifier: 'v',
+        mode: 'login',
+        account_id: null,
+        redirect_to: NATIVE_STATE_REDIRECT,
+      },
+    ];
+    ownerRows = [];
+    mockDiscordFetch();
+    const callback = makeRes();
+    await handleDiscordCallback(
+      makeReq({ url: '/api/auth/discord/callback?code=abc&state=s' }),
+      callback,
+    );
+    const location = new URL(String(callback.headers.Location));
+    const handoffCode = location.searchParams.get('code') ?? '';
+    expect(callback.statusCode).toBe(302);
+    expect(location.searchParams.has('linkToken')).toBe(false);
+    expect(location.searchParams.has('choose')).toBe(false);
+
+    const intercepted = makeRes();
+    await handleNativeDiscordExchange(
+      makeReq({ body: { code: handoffCode, verifier: 'B'.repeat(43) } }),
+      intercepted,
+    );
+    expect(parse(intercepted).status).toBe(401);
+
+    const exchange = makeRes();
+    await handleNativeDiscordExchange(
+      makeReq({ body: { code: handoffCode, verifier: NATIVE_VERIFIER } }),
+      exchange,
+    );
+    expect(parse(exchange).status).toBe(200);
+    expect(parse(exchange).data.choose).toBe(true);
+    expect(parse(exchange).data.linkToken).toMatch(/^[a-f0-9]{64}$/);
+    expect(parse(exchange).data.token).toBeUndefined();
+  });
+
+  it('returns a native cancellation to the app after consuming its state', async () => {
+    stateRows = [
+      {
+        state: 's',
+        code_verifier: 'v',
+        mode: 'login',
+        account_id: null,
+        redirect_to: NATIVE_STATE_REDIRECT,
+      },
+    ];
+    const fetchSpy = vi.spyOn(globalThis, 'fetch' as any);
+    const res = makeRes();
+    await handleDiscordCallback(
+      makeReq({ url: '/api/auth/discord/callback?error=access_denied&state=s' }),
+      res,
+    );
+    expect(res.statusCode).toBe(302);
+    const location = new URL(String(res.headers.Location));
+    expect(location.protocol).toBe('worldofclaudecraft:');
+    expect(location.searchParams.get('ok')).toBe('0');
+    expect(location.searchParams.get('error')).toBe('cancelled');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns a blocked native callback to the app without revealing the block', async () => {
+    stateRows = [
+      {
+        state: 's',
+        code_verifier: 'v',
+        mode: 'login',
+        account_id: null,
+        redirect_to: NATIVE_STATE_REDIRECT,
+      },
+    ];
+    const fetchSpy = vi.spyOn(globalThis, 'fetch' as any);
+    const res = makeRes();
+    await handleDiscordCallback(
+      makeReq({ url: '/api/auth/discord/callback?code=abc&state=s' }),
+      res,
+      () => true,
+    );
+    expect(res.statusCode).toBe(302);
+    const location = new URL(String(res.headers.Location));
+    expect(location.searchParams.get('ok')).toBe('0');
+    expect(location.searchParams.get('error')).toBe('server_error');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns a successful native link to the app', async () => {
+    stateRows = [
+      {
+        state: 's',
+        code_verifier: 'v',
+        mode: 'link',
+        account_id: 1,
+        redirect_to: NATIVE_STATE_REDIRECT,
+      },
+    ];
+    ownerRows = [];
+    mockDiscordFetch();
+    const res = makeRes();
+    await handleDiscordCallback(
+      makeReq({ url: '/api/auth/discord/callback?code=abc&state=s' }),
+      res,
+    );
+    expect(res.statusCode).toBe(302);
+    const location = new URL(String(res.headers.Location));
+    expect(location.protocol).toBe('worldofclaudecraft:');
+    expect(location.searchParams.get('ok')).toBe('1');
+    expect(location.searchParams.get('mode')).toBe('link');
+    expect(location.searchParams.get('username')).toBe('Maxp');
   });
 });
 

--- a/tests/native_discord.test.ts
+++ b/tests/native_discord.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  createNativeDiscordProof,
+  createNativeDiscordUrlDeduper,
+  parseNativeDiscordUrl,
+} from '../src/net/native_discord';
+
+describe('native Discord OAuth deep link', () => {
+  it('parses a returning login handoff', () => {
+    expect(
+      parseNativeDiscordUrl(
+        'worldofclaudecraft://discord-auth?ok=1&mode=login&code=abc_123&username=Player',
+      ),
+    ).toEqual({
+      ok: true,
+      mode: 'login',
+      code: 'abc_123',
+      username: 'Player',
+      error: '',
+    });
+  });
+
+  it('registers the callback on both native platforms', () => {
+    const ios = readFileSync('ios/App/App/Info.plist', 'utf8');
+    const android = readFileSync('android/app/src/main/AndroidManifest.xml', 'utf8');
+    expect(ios).toContain('<string>worldofclaudecraft</string>');
+    expect(android).toContain('android:scheme="worldofclaudecraft"');
+    expect(android).toContain('android:host="discord-auth"');
+  });
+
+  it('creates a verifier and matching SHA-256 challenge', async () => {
+    const proof = await createNativeDiscordProof();
+    expect(proof.verifier).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(proof.challenge).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(proof.verifier));
+    const expected = Buffer.from(digest).toString('base64url');
+    expect(proof.challenge).toBe(expected);
+  });
+
+  it('deduplicates immediate duplicate delivery but permits a later identical relink', () => {
+    let now = 100;
+    const shouldHandle = createNativeDiscordUrlDeduper(10_000, () => now);
+    expect(shouldHandle('same')).toBe(true);
+    expect(shouldHandle('same')).toBe(false);
+    now += 10_001;
+    expect(shouldHandle('same')).toBe(true);
+  });
+
+  it('rejects unrelated schemes, hosts, and modes', () => {
+    expect(parseNativeDiscordUrl('https://worldofclaudecraft.com/discord-auth')).toBeNull();
+    expect(parseNativeDiscordUrl('worldofclaudecraft://desktop-login?mode=login')).toBeNull();
+    expect(parseNativeDiscordUrl('worldofclaudecraft://discord-auth?mode=nope')).toBeNull();
+  });
+});

--- a/tests/native_discord_handler.test.ts
+++ b/tests/native_discord_handler.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const nativeMocks = vi.hoisted(() => ({
+  addListener: vi.fn(),
+  getLaunchUrl: vi.fn(),
+  close: vi.fn(),
+}));
+
+vi.mock('@capacitor/app', () => ({
+  App: {
+    addListener: nativeMocks.addListener,
+    getLaunchUrl: nativeMocks.getLaunchUrl,
+  },
+}));
+
+vi.mock('@capacitor/browser', () => ({
+  Browser: {
+    close: nativeMocks.close,
+    open: vi.fn(),
+  },
+}));
+
+import { installNativeDiscordUrlHandler } from '../src/net/native_discord';
+
+const CALLBACK = 'worldofclaudecraft://discord-auth?ok=1&mode=login&code=handoff';
+
+beforeEach(() => {
+  nativeMocks.addListener.mockReset();
+  nativeMocks.getLaunchUrl.mockReset();
+  nativeMocks.close.mockReset();
+  nativeMocks.close.mockResolvedValue(undefined);
+});
+
+describe('native Discord URL handler', () => {
+  it('handles a cold-launch callback and closes the browser first', async () => {
+    nativeMocks.addListener.mockResolvedValue({ remove: vi.fn() });
+    nativeMocks.getLaunchUrl.mockResolvedValue({ url: CALLBACK });
+    const events: string[] = [];
+
+    await installNativeDiscordUrlHandler(async (result) => {
+      events.push(`${result.mode}:${result.code}`);
+    });
+
+    expect(nativeMocks.close).toHaveBeenCalledOnce();
+    expect(events).toEqual(['login:handoff']);
+  });
+
+  it('handles a warm callback even when Browser.close is unsupported', async () => {
+    let listener: ((event: { url: string }) => void) | undefined;
+    nativeMocks.addListener.mockImplementation((_name, callback) => {
+      listener = callback;
+      return Promise.resolve({ remove: vi.fn() });
+    });
+    nativeMocks.getLaunchUrl.mockResolvedValue(undefined);
+    nativeMocks.close.mockRejectedValue(new Error('unsupported'));
+    const onResult = vi.fn();
+    await installNativeDiscordUrlHandler(onResult);
+
+    listener?.({ url: CALLBACK });
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledOnce());
+    expect(onResult.mock.calls[0]?.[0].code).toBe('handoff');
+  });
+
+  it('deduplicates the warm event followed by the same launch URL', async () => {
+    let listener: ((event: { url: string }) => void) | undefined;
+    nativeMocks.addListener.mockImplementation((_name, callback) => {
+      listener = callback;
+      return Promise.resolve({ remove: vi.fn() });
+    });
+    nativeMocks.getLaunchUrl.mockResolvedValue({ url: CALLBACK });
+    const onResult = vi.fn();
+    await installNativeDiscordUrlHandler(onResult);
+    listener?.({ url: CALLBACK });
+    await Promise.resolve();
+
+    expect(onResult).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/server/http/completeness.test.ts
+++ b/tests/server/http/completeness.test.ts
@@ -254,6 +254,7 @@ describe('registry completeness: migrated baseline (public reads + auth + charac
     { method: 'GET', path: '/api/auth/discord/callback' },
     { method: 'POST', path: '/api/auth/discord/login/new' },
     { method: 'POST', path: '/api/auth/discord/login/link' },
+    { method: 'POST', path: '/api/auth/discord/native/exchange' },
     { method: 'GET', path: '/api/discord' },
     { method: 'DELETE', path: '/api/discord' },
     { method: 'POST', path: '/api/discord/swag/claim' },

--- a/tests/server/http/content_type_classification.ts
+++ b/tests/server/http/content_type_classification.ts
@@ -109,6 +109,7 @@ export const API_CONTENT_TYPE: Readonly<Record<string, ContentTypeClass>> = {
   '/api/auth/discord/callback': HTML,
   '/api/auth/discord/login/new': PROBLEM_JSON,
   '/api/auth/discord/login/link': PROBLEM_JSON,
+  '/api/auth/discord/native/exchange': PROBLEM_JSON,
   '/api/discord': PROBLEM_JSON,
   '/api/auth/github/start': PROBLEM_JSON,
   '/api/auth/github/callback': HTML,

--- a/tests/server/http/parity.test.ts
+++ b/tests/server/http/parity.test.ts
@@ -637,13 +637,17 @@ describe('/api dispatch parity (legacy flag vs new flag)', () => {
     expect(stableStringify(newCap)).toBe(stableStringify(oldCap));
   });
 
-  // The two chooser routes (login/new + login/link) are ALSO masked by
+  // The two chooser routes (login/new + login/link) and native exchange are ALSO masked by
   // newLimiterDiscord but have no corpus fixture (every non-429 branch reads the db:
   // the pending-login token lookup is the first thing after the body). Their one
   // deterministic, db-free branch is the shared handler self-limit (checked BEFORE
   // the body read on both the legacy arm and the RouteDef), so each is re-pinned by
   // draining the discord bucket before each pass and proving the 429 byte-identical.
-  for (const chooserPath of ['/api/auth/discord/login/new', '/api/auth/discord/login/link']) {
+  for (const chooserPath of [
+    '/api/auth/discord/login/new',
+    '/api/auth/discord/login/link',
+    '/api/auth/discord/native/exchange',
+  ]) {
     it(`POST ${chooserPath} with a drained bucket is identical old-vs-new and is a 429 (re-pins masked chooser route)`, async () => {
       const drainedCapture = async (dispatch: Dispatch) => {
         isolate();

--- a/tests/server/http/surface_inventory.ts
+++ b/tests/server/http/surface_inventory.ts
@@ -727,6 +727,16 @@ export const SURFACE_INVENTORY: readonly SurfaceRoute[] = [
   },
   {
     dispatcher: DISPATCH.mainApi,
+    method: 'POST',
+    path: '/api/auth/discord/native/exchange',
+    handler: 'handleApi arm: /api/auth/discord/native/exchange (handleNativeDiscordExchange)',
+    contentType: PROBLEM_JSON,
+    authScope: AUTH_SCOPE.public,
+    limiter: 'discordRateLimited',
+    requireOwnedExpected: null,
+  },
+  {
+    dispatcher: DISPATCH.mainApi,
     method: 'GET',
     path: '/api/discord',
     handler: 'handleApi arm: /api/discord (GET, handleDiscordStatus)',


### PR DESCRIPTION
## Summary

Adds Discord login and account linking to the native iOS and Android apps using the system browser and an app deep-link callback.

The native OAuth handoff is protected by platform attestation and a PKCE-style verifier. The custom URL callback contains only a short-lived, single-use handoff code, and the app must exchange it using the verifier retained on-device.

## Type of change

- [x] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests
- [x] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run native:sync`
  - `npx tsc --noEmit`
  - `npx vitest run tests/server/discord.test.ts tests/discord_server.test.ts`
  - Focused native Discord, attestation, and HTTP surface suites: 176 tests passed
  - Pre-push QA floor: typecheck, 53 guard tests, changed-file lint, and copy rules passed
  - Android `assembleDebug`: passed
  - iOS simulator Debug build: passed
  - `npm run gate`: 11,423 tests passed; one unrelated i18n artifact subprocess exceeded the suite-wide 5-second timeout. The i18n equivalence test passes when run directly.
- Manual steps:
  - Confirmed the native Discord authorization flow opens Discord and returns to the iOS app through the registered callback scheme.

## Checklist

### Quality

- [ ] **The full gate passes.** The only remaining failure is the unrelated suite-wide i18n subprocess timeout documented above; the test passes directly.

### Cross-platform

- [x] **Tested on desktop and mobile.** Native builds and automated lifecycle coverage pass; final TestFlight and Play internal-track testing remains.
- [ ] **Accessible.** No new UI controls or interaction patterns were added.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
