### PR TITLE
fix(sim): give the moored fishing-dock rowboat a collider

### DIFF
--- a/src/sim/colliders.ts
+++ b/src/sim/colliders.ts
@@ -80,6 +80,15 @@ function rotY(lx: number, lz: number, rot: number): { x: number; z: number } {
   return { x: lx * c + lz * s, z: -lx * s + lz * c };
 }
 
+// The moored rowboat props.ts draws beside each fishing-dock (dock-local, a
+// ~2.4u hull) had no collider, so the player walked straight through it. A
+// circle rather than an OBB, because props.ts jitters the boat heading per dock:
+// a heading-invariant shape covers the hull whichever way it is moored. The
+// radius conservatively spans the hull length.
+const BOAT_LOCAL_X = 2.4;
+const BOAT_LOCAL_Z = -5.0;
+const BOAT_RADIUS = 1.1;
+
 // ---------------------------------------------------------------------------
 // Collider sets
 // ---------------------------------------------------------------------------
@@ -132,7 +141,7 @@ function staticWorldColliders(seed: number): Collider[] {
     out.push({ type: 'circle', x, z, r: 5, cameraTopY: topY(seed, x, z, 5.2), camGhost: true });
   }
 
-  // dock huts
+  // dock huts + the moored rowboat beside each dock
   for (const d of PROPS.docks) {
     const hut = rotY(d.hutLocal.x, d.hutLocal.z, d.rot);
     const x = d.x + hut.x,
@@ -145,6 +154,20 @@ function staticWorldColliders(seed: number): Collider[] {
       hd: d.hutLocal.hd,
       rot: d.rot,
       cameraTopY: topY(seed, x, z, 2.9),
+      camGhost: true,
+    });
+    // The rowboat (props.ts draws it at BOAT_LOCAL_X/Z beside the deck) was
+    // walk-through; give it its own circle at the world position the renderer
+    // places it. Both docks share this geometry, so this covers zone1 and zone2.
+    const boat = rotY(BOAT_LOCAL_X, BOAT_LOCAL_Z, d.rot);
+    const bx = d.x + boat.x,
+      bz = d.z + boat.z;
+    out.push({
+      type: 'circle',
+      x: bx,
+      z: bz,
+      r: BOAT_RADIUS,
+      cameraTopY: topY(seed, bx, bz, 1.0),
       camGhost: true,
     });
   }

--- a/tests/rowboat_collision.test.ts
+++ b/tests/rowboat_collision.test.ts
@@ -1,0 +1,59 @@
+// The moored rowboat props.ts draws beside each fishing-dock (dock-local 2.4,
+// -5.0) had no collider, so the player walked straight through its hull while
+// every other structure blocks. colliders.ts emitted only the dock hut OBB and
+// never covered the boat. Both docks (zone1 + zone2) share the geometry, so one
+// derived collider fixes both. This pins that the hull is now solid, and that
+// the circle footprint stays bounded (water past the hull remains walkable).
+import { afterEach, describe, expect, it } from 'vitest';
+import { isBlocked } from '../src/sim/colliders';
+import { BUILTIN_WORLD, setActiveWorldContent } from '../src/sim/data';
+
+const SEED = 20061;
+
+// Mirror colliders.ts rotY: rotate a local (lx,lz) offset by a rotation.y angle.
+function rotY(lx: number, lz: number, rot: number): { x: number; z: number } {
+  const c = Math.cos(rot);
+  const s = Math.sin(rot);
+  return { x: lx * c + lz * s, z: -lx * s + lz * c };
+}
+// World point for a dock-local offset.
+function dockLocal(
+  dock: { x: number; z: number; rot: number },
+  lx: number,
+  lz: number,
+): { x: number; z: number } {
+  const o = rotY(lx, lz, dock.rot);
+  return { x: dock.x + o.x, z: dock.z + o.z };
+}
+
+// The two docks from content (zone1.ts / zone2.ts); the boat-local offset
+// matches BOAT_LOCAL_X/Z in colliders.ts (and boatLx/boatLz in render/props.ts).
+const DOCKS = [
+  { x: -64, z: 60, rot: -2.2 }, // zone 1
+  { x: -66, z: 305, rot: 1.68 }, // zone 2 (Deepfen)
+];
+const BOAT_LX = 2.4;
+const BOAT_LZ = -5.0;
+
+describe('moored rowboat collision', () => {
+  afterEach(() => setActiveWorldContent(null));
+
+  it('blocks the rowboat hull at both docks (previously walk-through)', () => {
+    setActiveWorldContent(BUILTIN_WORLD);
+    for (const dock of DOCKS) {
+      const p = dockLocal(dock, BOAT_LX, BOAT_LZ);
+      expect(isBlocked(SEED, p.x, p.z), `rowboat of dock at ${dock.x},${dock.z}`).toBe(true);
+    }
+  });
+
+  it('leaves water past the hull walkable (circle footprint bounded, ~1.1u radius)', () => {
+    setActiveWorldContent(BUILTIN_WORLD);
+    for (const dock of DOCKS) {
+      // ~2.2u out along local +x from the boat centre: clear of the ~1.1u circle.
+      const past = dockLocal(dock, BOAT_LX + 2.2, BOAT_LZ);
+      expect(isBlocked(SEED, past.x, past.z), `past-boat of dock at ${dock.x},${dock.z}`).toBe(
+        false,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The moored rowboat that `src/render/props.ts` draws beside each fishing-dock (dock-local `2.4, -5.0`, a ~2.4u hull) had no collider, so the player walked straight through its hull while every other structure blocks. `src/sim/colliders.ts` emitted only the dock hut OBB and never covered the boat.

This adds a rotation-safe **circle** collider at the boat's world position in the `PROPS.docks` loop. A circle rather than an OBB because `props.ts` jitters the boat heading per dock, so a heading-invariant shape covers the hull whichever way it is moored; `BOAT_RADIUS` conservatively spans the hull length. Both docks share the geometry, so this covers zone1 and zone2. It is `camGhost` like the neighbouring dock props (blocks movement, the chase cam passes through).

This is the follow-up to the plank-deck collider fix (#1573): reviewing that change, @zfreiberg confirmed the deck reads solid but flagged that the rowboat next to it was still walk-through (its local position falls outside the deck's footprint). The boat is the same class of gap as the pier, on a different object, so it gets its own collider here.

## Related issues

Part of #1500 (dock collision). Complements #1573.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/rowboat_collision.test.ts` (new; both docks)
  - `npx vitest run tests/architecture.test.ts` (sim purity guard)
  - `npx tsc --noEmit` (clean for the changed files)
- New test `tests/rowboat_collision.test.ts` pins that the hull is now blocked at both docks (it was walk-through before) and that the circle footprint stays bounded (water past the hull remains walkable, so it does not over-block the bank).

## Screenshots / recordings

N/A: this is a collision-only change (no rendered pixels change; the boat already renders). The walk-through it fixes is documented in @zfreiberg's review screenshots on #1573.

---

## Checklist

### Quality

- [x] Decisive tests added for the changed behavior; determinism / sim-purity guard run.