### PR TITLE
feat(sfx): add conform pipeline script (192kbps/44.1kHz, hybrid norma…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,8 @@
         "electron": "^43.0.0",
         "electron-builder": "^26.15.6",
         "esbuild": "^0.28.1",
+        "ffmpeg-static": "^5.3.0",
+        "ffprobe-static": "^3.1.0",
         "jsdom": "^29.1.1",
         "lightningcss": "1.32.0",
         "playwright": "1.61.1",
@@ -813,6 +815,22 @@
         "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@donmccurdy/caporal": {
@@ -4508,6 +4526,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "dev": true,
@@ -4817,6 +4842,22 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -5814,6 +5855,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ffmpeg-static": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
+      "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ffmpeg-static/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ffmpeg-static/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ffprobe-static": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ffprobe-static/-/ffprobe-static-3.1.0.tgz",
+      "integrity": "sha512-Dvpa9uhVMOYivhHKWLGDoa512J751qN1WZAIO+Xw4L/mrUSPxS4DApzSUDbCFE/LUq2+xYnznEahTd63AqBSpA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/filelist": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
@@ -6231,6 +6323,23 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
@@ -7675,6 +7784,12 @@
       "version": "1.0.1",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
+      "dev": true
     },
     "node_modules/parse5": {
       "version": "8.0.1",
@@ -9489,6 +9604,13 @@
     },
     "node_modules/typed-query-selector": {
       "version": "2.12.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "voices:gen": "node scripts/gen_npc_voices.mjs",
     "voices:lines": "node scripts/gen_npc_lines.mjs",
     "sfx:gen": "node scripts/gen_sfx.mjs",
+    "sfx:check": "node scripts/sfx_conform.mjs",
+    "sfx:conform": "node scripts/sfx_conform.mjs --fix",
     "wiki:seed": "node scripts/mediawiki/build_seed.mjs",
     "sim:nythraxis-matrix": "tsx scripts/nythraxis_matrix.ts"
   },
@@ -121,6 +123,8 @@
     "electron": "^43.0.0",
     "electron-builder": "^26.15.6",
     "esbuild": "^0.28.1",
+    "ffmpeg-static": "^5.3.0",
+    "ffprobe-static": "^3.1.0",
     "jsdom": "^29.1.1",
     "lightningcss": "1.32.0",
     "playwright": "1.61.1",
@@ -235,6 +239,8 @@
     }
   },
   "allowScripts": {
-    "sharp@0.34.5": true
+    "sharp@0.34.5": true,
+    "ffmpeg-static@5.3.0": true,
+    "ffprobe-static@3.1.0": true
   }
 }

--- a/scripts/gate.mjs
+++ b/scripts/gate.mjs
@@ -38,6 +38,7 @@ const steps = [
   ],
   ['malware scan', 'npm', ['run', 'security:gate']],
   ['biome (changed files)', 'npm', ['run', 'ci:changed']],
+  ['sfx check', 'npm', ['run', 'sfx:check']],
   ['vitest (full suite)', 'npm', ['test', '--', `--maxWorkers=${workers}`]],
   ['typecheck', 'npx', ['tsc', '--noEmit']],
   ['env build', 'npm', ['run', 'build:env']],

--- a/scripts/sfx/sfx_conform_rules.d.mts
+++ b/scripts/sfx/sfx_conform_rules.d.mts
@@ -5,6 +5,7 @@ export declare const DURATION_THRESHOLD: number;
 export declare const TARGET_PEAK_DBFS: number;
 export declare const TARGET_LUFS: number;
 export declare const NORM_TOLERANCE: number;
+export declare const LOSSLESS_EXTENSIONS: Set<string>;
 
 export interface FileStats {
   duration: number;
@@ -12,6 +13,7 @@ export interface FileStats {
   sampleRate: number;
   peakDb?: number | null;
   lufs?: number | null;
+  isLossless?: boolean;
 }
 
 export interface Classification {

--- a/scripts/sfx/sfx_conform_rules.d.mts
+++ b/scripts/sfx/sfx_conform_rules.d.mts
@@ -1,0 +1,23 @@
+export declare const TARGET_BITRATE: number;
+export declare const MIN_SOURCE_BITRATE: number;
+export declare const TARGET_SAMPLE_RATE: number;
+export declare const DURATION_THRESHOLD: number;
+export declare const TARGET_PEAK_DBFS: number;
+export declare const TARGET_LUFS: number;
+export declare const NORM_TOLERANCE: number;
+
+export interface FileStats {
+  duration: number;
+  bitrate: number;
+  sampleRate: number;
+  peakDb?: number | null;
+  lufs?: number | null;
+}
+
+export interface Classification {
+  reject: boolean;
+  problems: string[];
+  normBranch: 'peak' | 'lufs' | null;
+}
+
+export declare function classify(stats: FileStats): Classification;

--- a/scripts/sfx/sfx_conform_rules.mjs
+++ b/scripts/sfx/sfx_conform_rules.mjs
@@ -8,23 +8,37 @@ export const TARGET_PEAK_DBFS = -6;
 export const TARGET_LUFS = -14;
 export const NORM_TOLERANCE = 0.5; // dB/LU tolerance window for loudness checks
 
+// Lossless formats always get transcoded to 192kbps MP3. Their bitrate is
+// meaningless for the quality gate and is never flagged as a problem.
+export const LOSSLESS_EXTENSIONS = new Set(['.wav', '.flac', '.aiff', '.aif']);
+
 /**
  * Classify a file's measured stats and return what problems need fixing.
  *
- * @param {{ duration: number, bitrate: number, sampleRate: number, peakDb?: number|null, lufs?: number|null }} stats
+ * For lossless sources (isLossless=true):
+ *   - The reject gate is skipped (lossless is always acceptable quality).
+ *   - The bitrate check is skipped (lossless bitrate is irrelevant).
+ *   - 'lossless source' is always present in problems so the file is always processed.
+ *   - Sample rate and loudness checks still apply.
+ *
+ * @param {{ duration: number, bitrate: number, sampleRate: number, peakDb?: number|null, lufs?: number|null, isLossless?: boolean }} stats
  * @returns {{ reject: boolean, problems: string[], normBranch: 'peak'|'lufs'|null }}
  */
-export function classify({ duration, bitrate, sampleRate, peakDb = null, lufs = null }) {
-  if (bitrate < MIN_SOURCE_BITRATE) {
+export function classify({ duration, bitrate, sampleRate, peakDb = null, lufs = null, isLossless = false }) {
+  if (!isLossless && bitrate < MIN_SOURCE_BITRATE) {
     return { reject: true, problems: [], normBranch: null };
   }
 
   const problems = [];
 
-  if (bitrate < TARGET_BITRATE) {
-    problems.push(`${bitrate}kbps (want ${TARGET_BITRATE}kbps)`);
-  } else if (bitrate > TARGET_BITRATE + 8) {
-    problems.push(`${bitrate}kbps (want ${TARGET_BITRATE}kbps)`);
+  if (isLossless) {
+    problems.push('lossless source');
+  } else {
+    if (bitrate < TARGET_BITRATE) {
+      problems.push(`${bitrate}kbps (want ${TARGET_BITRATE}kbps)`);
+    } else if (bitrate > TARGET_BITRATE + 8) {
+      problems.push(`${bitrate}kbps (want ${TARGET_BITRATE}kbps)`);
+    }
   }
 
   if (sampleRate !== TARGET_SAMPLE_RATE) {

--- a/scripts/sfx/sfx_conform_rules.mjs
+++ b/scripts/sfx/sfx_conform_rules.mjs
@@ -1,0 +1,48 @@
+// Pure classification logic for sfx_conform.mjs. No I/O, no side effects.
+
+export const TARGET_BITRATE = 192;
+export const MIN_SOURCE_BITRATE = 112;
+export const TARGET_SAMPLE_RATE = 44100;
+export const DURATION_THRESHOLD = 1.0; // clips below this use peak norm; at/above use LUFS
+export const TARGET_PEAK_DBFS = -6;
+export const TARGET_LUFS = -14;
+export const NORM_TOLERANCE = 0.5; // dB/LU tolerance window for loudness checks
+
+/**
+ * Classify a file's measured stats and return what problems need fixing.
+ *
+ * @param {{ duration: number, bitrate: number, sampleRate: number, peakDb?: number|null, lufs?: number|null }} stats
+ * @returns {{ reject: boolean, problems: string[], normBranch: 'peak'|'lufs'|null }}
+ */
+export function classify({ duration, bitrate, sampleRate, peakDb = null, lufs = null }) {
+  if (bitrate < MIN_SOURCE_BITRATE) {
+    return { reject: true, problems: [], normBranch: null };
+  }
+
+  const problems = [];
+
+  if (bitrate < TARGET_BITRATE) {
+    problems.push(`${bitrate}kbps (want ${TARGET_BITRATE}kbps)`);
+  } else if (bitrate > TARGET_BITRATE + 8) {
+    problems.push(`${bitrate}kbps (want ${TARGET_BITRATE}kbps)`);
+  }
+
+  if (sampleRate !== TARGET_SAMPLE_RATE) {
+    problems.push(`${sampleRate}Hz (want ${TARGET_SAMPLE_RATE}Hz)`);
+  }
+
+  const normBranch = duration < DURATION_THRESHOLD ? 'peak' : 'lufs';
+
+  if (normBranch === 'peak' && peakDb !== null) {
+    if (Math.abs(peakDb - TARGET_PEAK_DBFS) > NORM_TOLERANCE) {
+      problems.push(`peak ${peakDb.toFixed(1)}dBFS (want ${TARGET_PEAK_DBFS}dBFS)`);
+    }
+  }
+  if (normBranch === 'lufs' && lufs !== null) {
+    if (Math.abs(lufs - TARGET_LUFS) > NORM_TOLERANCE) {
+      problems.push(`${lufs.toFixed(1)} LUFS (want ${TARGET_LUFS} LUFS)`);
+    }
+  }
+
+  return { reject: false, problems, normBranch };
+}

--- a/scripts/sfx_conform.mjs
+++ b/scripts/sfx_conform.mjs
@@ -148,6 +148,8 @@ const allFiles = existsSync(sfxDir)
   : [];
 
 const byKey = new Map(); // stem -> filename
+const conflicts = []; // stems with ambiguous duplicates that block processing
+
 for (const name of allFiles) {
   const stem = path.basename(name, path.extname(name));
   const ext = path.extname(name).toLowerCase();
@@ -160,12 +162,18 @@ for (const name of allFiles) {
   const newIsLossless = LOSSLESS_EXTENSIONS.has(ext);
   const existingIsLossless = LOSSLESS_EXTENSIONS.has(existingExt);
   if (newIsLossless && !existingIsLossless) {
-    console.log(`  WARN ${stem}: ${name} (lossless) takes priority over ${existing} -- remove the lossy copy`);
+    // Unambiguous: lossless always beats lossy.
+    console.log(`  WARN ${stem}: ${name} (lossless) takes priority over ${existing} -- remove the lossy copy after conforming`);
     byKey.set(stem, name);
   } else if (!newIsLossless && existingIsLossless) {
-    console.log(`  WARN ${stem}: ${existing} (lossless) takes priority over ${name} -- remove the lossy copy`);
+    // Unambiguous: existing lossless stays.
+    console.log(`  WARN ${stem}: ${existing} (lossless) takes priority over ${name} -- remove the lossy copy after conforming`);
   } else {
-    console.log(`  WARN ${stem}: duplicate files (${existing}, ${name}) -- keeping ${existing}, remove the other`);
+    // Two lossless or two lossy files for the same key: ambiguous, cannot determine
+    // which is correct. Skip both and force the contributor to resolve it manually.
+    console.log(`  ERROR ${stem}: ambiguous duplicate (${existing} vs ${name}) -- remove one and rerun`);
+    byKey.delete(stem);
+    conflicts.push(stem);
   }
 }
 
@@ -235,6 +243,9 @@ for (const name of files) {
 }
 
 console.log('');
+if (conflicts.length > 0) {
+  console.log(`${conflicts.length} key(s) skipped due to ambiguous duplicates: ${conflicts.join(', ')}. Remove one file per key and rerun.`);
+}
 if (rejected > 0) {
   console.log(`${rejected} file(s) rejected: source bitrate below ${MIN_SOURCE_BITRATE}kbps. Re-export from your DAW and resubmit.`);
 }
@@ -243,4 +254,4 @@ if (fix) {
 } else if (issues > 0) {
   console.log(`${issues} file(s) out of spec. Run with --fix to conform them.`);
 }
-if (failures > 0 || rejected > 0 || (!fix && issues > 0)) process.exit(1);
+if (failures > 0 || conflicts.length > 0 || rejected > 0 || (!fix && issues > 0)) process.exit(1);

--- a/scripts/sfx_conform.mjs
+++ b/scripts/sfx_conform.mjs
@@ -1,10 +1,18 @@
-// Inspect and optionally conform all MP3s in public/audio/sfx/ to the project standard:
+// Inspect and optionally conform all audio files in public/audio/sfx/ to the project standard:
 //   Format:      MP3
 //   Bitrate:     192 kbps
 //   Sample rate: 44.1 kHz
 //   Normalization:
 //     < 1 s  -> -6 dBFS peak
 //     >= 1 s -> -14 LUFS  (loudnorm=I=-14:LRA=7:TP=-1)
+//
+// Accepted input formats: .mp3 .wav .flac .aiff .aif .ogg .opus .m4a
+// All non-MP3 inputs are transcoded to <stem>.mp3 and the original is removed.
+//
+// Conflict resolution: if both <stem>.wav and <stem>.mp3 exist (or any two
+// formats for the same stem), the lossless file takes priority. If two lossy
+// files conflict, the first alphabetically wins and a warning is printed.
+// This policy is intentional: lossless is always the better source.
 //
 // Usage:
 //   node scripts/sfx_conform.mjs            # check only, exit 1 if anything is out of spec
@@ -18,13 +26,15 @@ import ffmpegPath from 'ffmpeg-static';
 import ffprobeStatic from 'ffprobe-static';
 import {
   classify,
+  LOSSLESS_EXTENSIONS,
   MIN_SOURCE_BITRATE,
   TARGET_BITRATE,
   TARGET_SAMPLE_RATE,
   TARGET_PEAK_DBFS,
-  TARGET_LUFS,
   DURATION_THRESHOLD,
 } from './sfx/sfx_conform_rules.mjs';
+
+const AUDIO_EXTENSIONS = new Set(['.mp3', '.wav', '.flac', '.aiff', '.aif', '.ogg', '.opus', '.m4a']);
 
 const fix = process.argv.includes('--fix');
 const root = process.cwd();
@@ -78,47 +88,88 @@ function getLufs(file) {
 }
 
 // Temp files go to the system temp directory so a crashed run cannot leave
-// an orphan .tmp.mp3 inside the scanned sfxDir on the next run.
-function conformPeak(file, peakDb) {
+// an orphan inside the scanned sfxDir on the next run.
+// inputFile and outputFile differ when converting a non-MP3 to MP3; on success
+// the original source file is removed.
+function conformPeak(inputFile, outputFile, peakDb) {
   const adjustment = TARGET_PEAK_DBFS - peakDb;
-  const tmp = path.join(tmpdir(), `sfx_conform_${path.basename(file)}`);
+  const tmp = path.join(tmpdir(), `sfx_conform_${path.basename(outputFile)}`);
   try {
     execFileSync(ffmpegPath, [
       '-hide_banner', '-loglevel', 'error',
-      '-y', '-i', file,
+      '-y', '-i', inputFile,
       '-af', `volume=${adjustment}dB,aformat=sample_rates=${TARGET_SAMPLE_RATE}`,
       '-ar', String(TARGET_SAMPLE_RATE),
       '-b:a', `${TARGET_BITRATE}k`,
       '-codec:a', 'libmp3lame',
       tmp,
     ]);
-    renameSync(tmp, file);
+    renameSync(tmp, outputFile);
   } finally {
     try { unlinkSync(tmp); } catch { /* already renamed or never created */ }
   }
+  if (inputFile !== outputFile) {
+    try { unlinkSync(inputFile); } catch (e) {
+      console.warn(`  WARN could not remove source file ${path.basename(inputFile)}: ${e.message}`);
+    }
+  }
 }
 
-function conformLufs(file) {
-  const tmp = path.join(tmpdir(), `sfx_conform_${path.basename(file)}`);
+function conformLufs(inputFile, outputFile) {
+  const tmp = path.join(tmpdir(), `sfx_conform_${path.basename(outputFile)}`);
   try {
     execFileSync(ffmpegPath, [
       '-hide_banner', '-loglevel', 'error',
-      '-y', '-i', file,
+      '-y', '-i', inputFile,
       '-af', `loudnorm=I=-14:LRA=7:TP=-1,aformat=sample_rates=${TARGET_SAMPLE_RATE}`,
       '-ar', String(TARGET_SAMPLE_RATE),
       '-b:a', `${TARGET_BITRATE}k`,
       '-codec:a', 'libmp3lame',
       tmp,
     ]);
-    renameSync(tmp, file);
+    renameSync(tmp, outputFile);
   } finally {
     try { unlinkSync(tmp); } catch { /* already renamed or never created */ }
   }
+  if (inputFile !== outputFile) {
+    try { unlinkSync(inputFile); } catch (e) {
+      console.warn(`  WARN could not remove source file ${path.basename(inputFile)}: ${e.message}`);
+    }
+  }
 }
 
-const files = existsSync(sfxDir)
-  ? readdirSync(sfxDir).filter(f => f.endsWith('.mp3')).sort()
+// Build the list of files to process, one per stem.
+// If multiple formats share a stem, lossless wins over lossy.
+// Two lossless or two lossy files for the same stem: first alphabetically wins, warn.
+const allFiles = existsSync(sfxDir)
+  ? readdirSync(sfxDir)
+      .filter(f => AUDIO_EXTENSIONS.has(path.extname(f).toLowerCase()))
+      .sort()
   : [];
+
+const byKey = new Map(); // stem -> filename
+for (const name of allFiles) {
+  const stem = path.basename(name, path.extname(name));
+  const ext = path.extname(name).toLowerCase();
+  const existing = byKey.get(stem);
+  if (!existing) {
+    byKey.set(stem, name);
+    continue;
+  }
+  const existingExt = path.extname(existing).toLowerCase();
+  const newIsLossless = LOSSLESS_EXTENSIONS.has(ext);
+  const existingIsLossless = LOSSLESS_EXTENSIONS.has(existingExt);
+  if (newIsLossless && !existingIsLossless) {
+    console.log(`  WARN ${stem}: ${name} (lossless) takes priority over ${existing} -- remove the lossy copy`);
+    byKey.set(stem, name);
+  } else if (!newIsLossless && existingIsLossless) {
+    console.log(`  WARN ${stem}: ${existing} (lossless) takes priority over ${name} -- remove the lossy copy`);
+  } else {
+    console.log(`  WARN ${stem}: duplicate files (${existing}, ${name}) -- keeping ${existing}, remove the other`);
+  }
+}
+
+const files = [...byKey.values()].sort();
 
 let issues = 0;
 let fixed = 0;
@@ -127,13 +178,17 @@ let rejected = 0;
 
 for (const name of files) {
   const file = path.join(sfxDir, name);
+  const ext = path.extname(name).toLowerCase();
+  const stem = path.basename(name, ext);
+  const isLossless = LOSSLESS_EXTENSIONS.has(ext);
+  const outputFile = path.join(sfxDir, `${stem}.mp3`);
   const { duration, bitrate, sampleRate } = getStats(file);
 
-  // Source quality gate: re-encoding a low-bitrate MP3 to 192kbps does not recover
-  // lost quality; it produces a larger file that sounds the same or worse. The floor
-  // is 112kbps (not 128kbps) because ElevenLabs 128kbps exports can probe slightly
-  // low due to encoding variance, and we must not false-reject legitimate assets.
-  const preliminary = classify({ duration, bitrate, sampleRate });
+  // Source quality gate (lossy only): re-encoding a low-bitrate MP3 to 192kbps
+  // does not recover lost quality. The floor is 112kbps, not 128kbps, because
+  // ElevenLabs 128kbps exports can probe slightly low due to encoding variance.
+  // Lossless sources skip this gate entirely.
+  const preliminary = classify({ duration, bitrate, sampleRate, isLossless });
   if (preliminary.reject) {
     console.log(`  REJECT ${name}  [${bitrate}kbps source, minimum ${MIN_SOURCE_BITRATE}kbps; re-export at 128kbps or higher]`);
     rejected++;
@@ -149,7 +204,7 @@ for (const name of files) {
     lufs = getLufs(file);
   }
 
-  const { problems, normBranch } = classify({ duration, bitrate, sampleRate, peakDb, lufs });
+  const { problems, normBranch } = classify({ duration, bitrate, sampleRate, peakDb, lufs, isLossless });
 
   if (problems.length === 0) {
     console.log(`  ok   ${name}`);
@@ -163,9 +218,9 @@ for (const name of files) {
     process.stdout.write(`  fix  ${name}  [${problems.join(', ')}]  (${normLabel})... `);
     try {
       if (normBranch === 'peak') {
-        conformPeak(file, peakDb);
+        conformPeak(file, outputFile, peakDb);
       } else {
-        conformLufs(file);
+        conformLufs(file, outputFile);
       }
       console.log('done');
       fixed++;

--- a/scripts/sfx_conform.mjs
+++ b/scripts/sfx_conform.mjs
@@ -22,6 +22,7 @@ const sfxDir = path.join(root, 'public/audio/sfx');
 const ffprobePath = ffprobeStatic.path;
 
 const TARGET_BITRATE = 192;
+const MIN_SOURCE_BITRATE = 128; // below this the source is too lossy to transcode — reject outright
 const TARGET_SAMPLE_RATE = 44100;
 const DURATION_THRESHOLD = 1.0;
 const TARGET_PEAK_DBFS = -6;
@@ -94,10 +95,21 @@ const files = readdirSync(sfxDir)
 
 let issues = 0;
 let fixed = 0;
+let rejected = 0;
 
 for (const name of files) {
   const file = path.join(sfxDir, name);
   const { duration, bitrate, sampleRate } = getStats(file);
+
+  // Source quality gate: below 128kbps the file is too lossy to transcode acceptably.
+  // Re-encoding low-bitrate MP3 to 192kbps does not recover lost quality — it just
+  // makes a larger file that sounds the same or worse. Reject and tell the contributor
+  // to re-export from their DAW at a higher bitrate.
+  if (bitrate < MIN_SOURCE_BITRATE) {
+    console.log(`  REJECT ${name}  [${bitrate}kbps source — minimum ${MIN_SOURCE_BITRATE}kbps required; re-export from your DAW]`);
+    rejected++;
+    continue;
+  }
 
   const problems = [];
   if (bitrate < TARGET_BITRATE) problems.push(`${bitrate}kbps (want ${TARGET_BITRATE}kbps)`);
@@ -132,11 +144,12 @@ for (const name of files) {
 }
 
 console.log('');
+if (rejected > 0) {
+  console.log(`${rejected} file(s) rejected: source bitrate below ${MIN_SOURCE_BITRATE}kbps. Re-export from your DAW and resubmit.`);
+}
 if (fix) {
-  console.log(`${fixed}/${issues} files conformed. ${files.length - issues} already at spec.`);
+  console.log(`${fixed}/${issues} files conformed. ${files.length - issues - rejected} already at spec.`);
 } else if (issues > 0) {
   console.log(`${issues} file(s) out of spec. Run with --fix to conform them.`);
-  process.exit(1);
-} else {
-  console.log('All files at spec.');
 }
+if (rejected > 0 || (!fix && issues > 0)) process.exit(1);

--- a/scripts/sfx_conform.mjs
+++ b/scripts/sfx_conform.mjs
@@ -1,0 +1,142 @@
+// Inspect and optionally conform all MP3s in public/audio/sfx/ to the project standard:
+//   Format:      MP3
+//   Bitrate:     192 kbps
+//   Sample rate: 44.1 kHz
+//   Normalization:
+//     < 1 s  -> -6 dBFS peak
+//     >= 1 s -> -14 LUFS  (loudnorm=I=-14:LRA=7:TP=-1)
+//
+// Usage:
+//   node scripts/sfx_conform.mjs            # check only, exit 1 if anything is out of spec
+//   node scripts/sfx_conform.mjs --fix      # check and fix non-conforming files in place
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { readdirSync, renameSync } from 'node:fs';
+import path from 'node:path';
+import ffmpegPath from 'ffmpeg-static';
+import ffprobeStatic from 'ffprobe-static';
+
+const fix = process.argv.includes('--fix');
+const root = process.cwd();
+const sfxDir = path.join(root, 'public/audio/sfx');
+const ffprobePath = ffprobeStatic.path;
+
+const TARGET_BITRATE = 192;
+const TARGET_SAMPLE_RATE = 44100;
+const DURATION_THRESHOLD = 1.0;
+const TARGET_PEAK_DBFS = -6;
+
+function ffprobe(file) {
+  const out = execFileSync(ffprobePath, [
+    '-v', 'quiet',
+    '-print_format', 'json',
+    '-show_format',
+    '-show_streams',
+    file,
+  ]);
+  return JSON.parse(out.toString());
+}
+
+function getStats(file) {
+  const info = ffprobe(file);
+  const stream = info.streams.find(s => s.codec_type === 'audio');
+  const duration = parseFloat(info.format.duration ?? '0');
+  const bitrate = Math.round(parseInt(info.format.bit_rate ?? '0') / 1000);
+  const sampleRate = parseInt(stream?.sample_rate ?? '0');
+  return { duration, bitrate, sampleRate };
+}
+
+// Returns the peak dBFS of a file using ffmpeg volumedetect.
+// volumedetect writes to stderr, so we use spawnSync to capture it.
+function getPeakDb(file) {
+  const result = spawnSync(ffmpegPath, [
+    '-hide_banner', '-i', file,
+    '-af', 'volumedetect',
+    '-f', 'null', '/dev/null',
+  ], { encoding: 'utf8' });
+  const match = (result.stderr || '').match(/max_volume:\s*([-\d.]+)\s*dB/);
+  return match ? parseFloat(match[1]) : 0;
+}
+
+function conformPeak(file) {
+  const peakDb = getPeakDb(file);
+  const adjustment = TARGET_PEAK_DBFS - peakDb;
+  const tmp = file + '.tmp.mp3';
+  execFileSync(ffmpegPath, [
+    '-hide_banner', '-loglevel', 'error',
+    '-y', '-i', file,
+    '-af', `volume=${adjustment}dB,aformat=sample_rates=${TARGET_SAMPLE_RATE}`,
+    '-ar', String(TARGET_SAMPLE_RATE),
+    '-b:a', `${TARGET_BITRATE}k`,
+    '-codec:a', 'libmp3lame',
+    tmp,
+  ]);
+  renameSync(tmp, file);
+}
+
+function conformLufs(file) {
+  const tmp = file + '.tmp.mp3';
+  execFileSync(ffmpegPath, [
+    '-hide_banner', '-loglevel', 'error',
+    '-y', '-i', file,
+    '-af', `loudnorm=I=-14:LRA=7:TP=-1,aformat=sample_rates=${TARGET_SAMPLE_RATE}`,
+    '-ar', String(TARGET_SAMPLE_RATE),
+    '-b:a', `${TARGET_BITRATE}k`,
+    '-codec:a', 'libmp3lame',
+    tmp,
+  ]);
+  renameSync(tmp, file);
+}
+
+const files = readdirSync(sfxDir)
+  .filter(f => f.endsWith('.mp3'))
+  .sort();
+
+let issues = 0;
+let fixed = 0;
+
+for (const name of files) {
+  const file = path.join(sfxDir, name);
+  const { duration, bitrate, sampleRate } = getStats(file);
+
+  const problems = [];
+  if (bitrate < TARGET_BITRATE) problems.push(`${bitrate}kbps (want ${TARGET_BITRATE}kbps)`);
+  if (sampleRate !== TARGET_SAMPLE_RATE) problems.push(`${sampleRate}Hz (want ${TARGET_SAMPLE_RATE}Hz)`);
+
+  if (problems.length === 0) {
+    console.log(`  ok   ${name}`);
+    continue;
+  }
+
+  issues++;
+  const short = duration < DURATION_THRESHOLD;
+  const normLabel = short ? `peak ${TARGET_PEAK_DBFS}dBFS` : '-14 LUFS';
+
+  if (fix) {
+    process.stdout.write(`  fix  ${name}  [${problems.join(', ')}]  (${normLabel})… `);
+    try {
+      if (short) {
+        conformPeak(file);
+      } else {
+        conformLufs(file);
+      }
+      console.log('done');
+      fixed++;
+    } catch (err) {
+      console.log('FAILED');
+      console.error(`       ${err.message}`);
+    }
+  } else {
+    console.log(`  FAIL ${name}  [${problems.join(', ')}]  (would apply ${normLabel})`);
+  }
+}
+
+console.log('');
+if (fix) {
+  console.log(`${fixed}/${issues} files conformed. ${files.length - issues} already at spec.`);
+} else if (issues > 0) {
+  console.log(`${issues} file(s) out of spec. Run with --fix to conform them.`);
+  process.exit(1);
+} else {
+  console.log('All files at spec.');
+}

--- a/scripts/sfx_conform.mjs
+++ b/scripts/sfx_conform.mjs
@@ -11,23 +11,25 @@
 //   node scripts/sfx_conform.mjs --fix      # check and fix non-conforming files in place
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { readdirSync, renameSync } from 'node:fs';
+import { existsSync, readdirSync, renameSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import ffmpegPath from 'ffmpeg-static';
 import ffprobeStatic from 'ffprobe-static';
+import {
+  classify,
+  MIN_SOURCE_BITRATE,
+  TARGET_BITRATE,
+  TARGET_SAMPLE_RATE,
+  TARGET_PEAK_DBFS,
+  TARGET_LUFS,
+  DURATION_THRESHOLD,
+} from './sfx/sfx_conform_rules.mjs';
 
 const fix = process.argv.includes('--fix');
 const root = process.cwd();
 const sfxDir = path.join(root, 'public/audio/sfx');
 const ffprobePath = ffprobeStatic.path;
-
-const TARGET_BITRATE = 192;
-const MIN_SOURCE_BITRATE = 112; // below this the source is too lossy to transcode — reject outright
-                                // (128kbps ElevenLabs files can probe slightly low due to encoding
-                                // variance, so the floor sits well below 128 to avoid false rejects)
-const TARGET_SAMPLE_RATE = 44100;
-const DURATION_THRESHOLD = 1.0;
-const TARGET_PEAK_DBFS = -6;
 
 function ffprobe(file) {
   const out = execFileSync(ffprobePath, [
@@ -50,72 +52,104 @@ function getStats(file) {
 }
 
 // Returns the peak dBFS of a file using ffmpeg volumedetect.
-// volumedetect writes to stderr, so we use spawnSync to capture it.
+// Throws if the output cannot be parsed rather than silently returning 0.
 function getPeakDb(file) {
   const result = spawnSync(ffmpegPath, [
     '-hide_banner', '-i', file,
     '-af', 'volumedetect',
-    '-f', 'null', '/dev/null',
+    '-f', 'null', '-',
   ], { encoding: 'utf8' });
   const match = (result.stderr || '').match(/max_volume:\s*([-\d.]+)\s*dB/);
-  return match ? parseFloat(match[1]) : 0;
+  if (!match) throw new Error(`volumedetect parse failed for ${path.basename(file)}`);
+  return parseFloat(match[1]);
 }
 
-function conformPeak(file) {
-  const peakDb = getPeakDb(file);
+// Returns the integrated loudness in LUFS using ffmpeg ebur128.
+// Throws if the output cannot be parsed.
+function getLufs(file) {
+  const result = spawnSync(ffmpegPath, [
+    '-hide_banner', '-i', file,
+    '-af', 'ebur128=peak=true',
+    '-f', 'null', '-',
+  ], { encoding: 'utf8' });
+  const match = (result.stderr || '').match(/I:\s*([-\d.]+)\s*LUFS/);
+  if (!match) throw new Error(`ebur128 parse failed for ${path.basename(file)}`);
+  return parseFloat(match[1]);
+}
+
+// Temp files go to the system temp directory so a crashed run cannot leave
+// an orphan .tmp.mp3 inside the scanned sfxDir on the next run.
+function conformPeak(file, peakDb) {
   const adjustment = TARGET_PEAK_DBFS - peakDb;
-  const tmp = file + '.tmp.mp3';
-  execFileSync(ffmpegPath, [
-    '-hide_banner', '-loglevel', 'error',
-    '-y', '-i', file,
-    '-af', `volume=${adjustment}dB,aformat=sample_rates=${TARGET_SAMPLE_RATE}`,
-    '-ar', String(TARGET_SAMPLE_RATE),
-    '-b:a', `${TARGET_BITRATE}k`,
-    '-codec:a', 'libmp3lame',
-    tmp,
-  ]);
-  renameSync(tmp, file);
+  const tmp = path.join(tmpdir(), `sfx_conform_${path.basename(file)}`);
+  try {
+    execFileSync(ffmpegPath, [
+      '-hide_banner', '-loglevel', 'error',
+      '-y', '-i', file,
+      '-af', `volume=${adjustment}dB,aformat=sample_rates=${TARGET_SAMPLE_RATE}`,
+      '-ar', String(TARGET_SAMPLE_RATE),
+      '-b:a', `${TARGET_BITRATE}k`,
+      '-codec:a', 'libmp3lame',
+      tmp,
+    ]);
+    renameSync(tmp, file);
+  } finally {
+    try { unlinkSync(tmp); } catch { /* already renamed or never created */ }
+  }
 }
 
 function conformLufs(file) {
-  const tmp = file + '.tmp.mp3';
-  execFileSync(ffmpegPath, [
-    '-hide_banner', '-loglevel', 'error',
-    '-y', '-i', file,
-    '-af', `loudnorm=I=-14:LRA=7:TP=-1,aformat=sample_rates=${TARGET_SAMPLE_RATE}`,
-    '-ar', String(TARGET_SAMPLE_RATE),
-    '-b:a', `${TARGET_BITRATE}k`,
-    '-codec:a', 'libmp3lame',
-    tmp,
-  ]);
-  renameSync(tmp, file);
+  const tmp = path.join(tmpdir(), `sfx_conform_${path.basename(file)}`);
+  try {
+    execFileSync(ffmpegPath, [
+      '-hide_banner', '-loglevel', 'error',
+      '-y', '-i', file,
+      '-af', `loudnorm=I=-14:LRA=7:TP=-1,aformat=sample_rates=${TARGET_SAMPLE_RATE}`,
+      '-ar', String(TARGET_SAMPLE_RATE),
+      '-b:a', `${TARGET_BITRATE}k`,
+      '-codec:a', 'libmp3lame',
+      tmp,
+    ]);
+    renameSync(tmp, file);
+  } finally {
+    try { unlinkSync(tmp); } catch { /* already renamed or never created */ }
+  }
 }
 
-const files = readdirSync(sfxDir)
-  .filter(f => f.endsWith('.mp3'))
-  .sort();
+const files = existsSync(sfxDir)
+  ? readdirSync(sfxDir).filter(f => f.endsWith('.mp3')).sort()
+  : [];
 
 let issues = 0;
 let fixed = 0;
+let failures = 0;
 let rejected = 0;
 
 for (const name of files) {
   const file = path.join(sfxDir, name);
   const { duration, bitrate, sampleRate } = getStats(file);
 
-  // Source quality gate: below 128kbps the file is too lossy to transcode acceptably.
-  // Re-encoding low-bitrate MP3 to 192kbps does not recover lost quality — it just
-  // makes a larger file that sounds the same or worse. Reject and tell the contributor
-  // to re-export from their DAW at a higher bitrate.
-  if (bitrate < MIN_SOURCE_BITRATE) {
-    console.log(`  REJECT ${name}  [${bitrate}kbps source — minimum ${MIN_SOURCE_BITRATE}kbps required; re-export at 128kbps or higher]`);
+  // Source quality gate: re-encoding a low-bitrate MP3 to 192kbps does not recover
+  // lost quality; it produces a larger file that sounds the same or worse. The floor
+  // is 112kbps (not 128kbps) because ElevenLabs 128kbps exports can probe slightly
+  // low due to encoding variance, and we must not false-reject legitimate assets.
+  const preliminary = classify({ duration, bitrate, sampleRate });
+  if (preliminary.reject) {
+    console.log(`  REJECT ${name}  [${bitrate}kbps source, minimum ${MIN_SOURCE_BITRATE}kbps; re-export at 128kbps or higher]`);
     rejected++;
     continue;
   }
 
-  const problems = [];
-  if (bitrate < TARGET_BITRATE) problems.push(`${bitrate}kbps (want ${TARGET_BITRATE}kbps)`);
-  if (sampleRate !== TARGET_SAMPLE_RATE) problems.push(`${sampleRate}Hz (want ${TARGET_SAMPLE_RATE}Hz)`);
+  // Measure actual loudness so check mode catches loudness drift, not just bitrate/rate.
+  let peakDb = null;
+  let lufs = null;
+  if (preliminary.normBranch === 'peak') {
+    peakDb = getPeakDb(file);
+  } else {
+    lufs = getLufs(file);
+  }
+
+  const { problems, normBranch } = classify({ duration, bitrate, sampleRate, peakDb, lufs });
 
   if (problems.length === 0) {
     console.log(`  ok   ${name}`);
@@ -123,14 +157,13 @@ for (const name of files) {
   }
 
   issues++;
-  const short = duration < DURATION_THRESHOLD;
-  const normLabel = short ? `peak ${TARGET_PEAK_DBFS}dBFS` : '-14 LUFS';
+  const normLabel = normBranch === 'peak' ? `peak ${TARGET_PEAK_DBFS}dBFS` : '-14 LUFS';
 
   if (fix) {
-    process.stdout.write(`  fix  ${name}  [${problems.join(', ')}]  (${normLabel})… `);
+    process.stdout.write(`  fix  ${name}  [${problems.join(', ')}]  (${normLabel})... `);
     try {
-      if (short) {
-        conformPeak(file);
+      if (normBranch === 'peak') {
+        conformPeak(file, peakDb);
       } else {
         conformLufs(file);
       }
@@ -139,6 +172,7 @@ for (const name of files) {
     } catch (err) {
       console.log('FAILED');
       console.error(`       ${err.message}`);
+      failures++;
     }
   } else {
     console.log(`  FAIL ${name}  [${problems.join(', ')}]  (would apply ${normLabel})`);
@@ -154,4 +188,4 @@ if (fix) {
 } else if (issues > 0) {
   console.log(`${issues} file(s) out of spec. Run with --fix to conform them.`);
 }
-if (rejected > 0 || (!fix && issues > 0)) process.exit(1);
+if (failures > 0 || rejected > 0 || (!fix && issues > 0)) process.exit(1);

--- a/scripts/sfx_conform.mjs
+++ b/scripts/sfx_conform.mjs
@@ -22,7 +22,9 @@ const sfxDir = path.join(root, 'public/audio/sfx');
 const ffprobePath = ffprobeStatic.path;
 
 const TARGET_BITRATE = 192;
-const MIN_SOURCE_BITRATE = 128; // below this the source is too lossy to transcode — reject outright
+const MIN_SOURCE_BITRATE = 112; // below this the source is too lossy to transcode — reject outright
+                                // (128kbps ElevenLabs files can probe slightly low due to encoding
+                                // variance, so the floor sits well below 128 to avoid false rejects)
 const TARGET_SAMPLE_RATE = 44100;
 const DURATION_THRESHOLD = 1.0;
 const TARGET_PEAK_DBFS = -6;
@@ -106,7 +108,7 @@ for (const name of files) {
   // makes a larger file that sounds the same or worse. Reject and tell the contributor
   // to re-export from their DAW at a higher bitrate.
   if (bitrate < MIN_SOURCE_BITRATE) {
-    console.log(`  REJECT ${name}  [${bitrate}kbps source — minimum ${MIN_SOURCE_BITRATE}kbps required; re-export from your DAW]`);
+    console.log(`  REJECT ${name}  [${bitrate}kbps source — minimum ${MIN_SOURCE_BITRATE}kbps required; re-export at 128kbps or higher]`);
     rejected++;
     continue;
   }

--- a/tests/sfx_conform.test.ts
+++ b/tests/sfx_conform.test.ts
@@ -7,6 +7,7 @@ import {
   TARGET_PEAK_DBFS,
   TARGET_LUFS,
   NORM_TOLERANCE,
+  LOSSLESS_EXTENSIONS,
 } from '../scripts/sfx/sfx_conform_rules.mjs';
 
 // A file already at every spec dimension.
@@ -108,5 +109,46 @@ describe('classify: loudness gate', () => {
     // If caller passes neither peakDb nor lufs, no loudness problem is reported.
     const { problems } = classify({ ...AT_SPEC });
     expect(problems.filter(p => p.includes('dBFS') || p.includes('LUFS'))).toHaveLength(0);
+  });
+});
+
+describe('classify: lossless sources', () => {
+  // WAV/FLAC probe at high bitrates that are meaningless for the quality gate.
+  const LOSSLESS = { duration: 2.0, bitrate: 1411, sampleRate: TARGET_SAMPLE_RATE, isLossless: true };
+
+  it('does not reject lossless sources regardless of bitrate', () => {
+    expect(classify(LOSSLESS).reject).toBe(false);
+  });
+
+  it('always marks lossless sources for processing (lossless source in problems)', () => {
+    const { problems } = classify({ ...LOSSLESS, lufs: TARGET_LUFS });
+    expect(problems.some(p => p.includes('lossless'))).toBe(true);
+  });
+
+  it('does not flag lossless bitrate as a kbps problem', () => {
+    const { problems } = classify({ ...LOSSLESS, lufs: TARGET_LUFS });
+    expect(problems.filter(p => p.includes('kbps'))).toHaveLength(0);
+  });
+
+  it('still checks sample rate for lossless sources', () => {
+    const { problems } = classify({ ...LOSSLESS, sampleRate: 48000, lufs: TARGET_LUFS });
+    expect(problems.some(p => p.includes('48000Hz'))).toBe(true);
+  });
+
+  it('still checks loudness for lossless sources', () => {
+    const { problems } = classify({ ...LOSSLESS, lufs: -20.0 });
+    expect(problems.some(p => p.includes('LUFS'))).toBe(true);
+  });
+
+  it('LOSSLESS_EXTENSIONS contains wav, flac, aiff, aif', () => {
+    for (const ext of ['.wav', '.flac', '.aiff', '.aif']) {
+      expect(LOSSLESS_EXTENSIONS.has(ext)).toBe(true);
+    }
+  });
+
+  it('LOSSLESS_EXTENSIONS does not contain lossy formats', () => {
+    for (const ext of ['.mp3', '.ogg', '.opus', '.m4a']) {
+      expect(LOSSLESS_EXTENSIONS.has(ext)).toBe(false);
+    }
   });
 });

--- a/tests/sfx_conform.test.ts
+++ b/tests/sfx_conform.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classify,
+  TARGET_BITRATE,
+  MIN_SOURCE_BITRATE,
+  TARGET_SAMPLE_RATE,
+  TARGET_PEAK_DBFS,
+  TARGET_LUFS,
+  NORM_TOLERANCE,
+} from '../scripts/sfx/sfx_conform_rules.mjs';
+
+// A file already at every spec dimension.
+const AT_SPEC = { duration: 2.0, bitrate: TARGET_BITRATE, sampleRate: TARGET_SAMPLE_RATE };
+
+describe('classify: source quality gate', () => {
+  it('rejects a file one kbps below MIN_SOURCE_BITRATE', () => {
+    expect(classify({ ...AT_SPEC, bitrate: MIN_SOURCE_BITRATE - 1 }).reject).toBe(true);
+  });
+
+  it('does not reject a file at exactly MIN_SOURCE_BITRATE', () => {
+    expect(classify({ ...AT_SPEC, bitrate: MIN_SOURCE_BITRATE }).reject).toBe(false);
+  });
+
+  it('returns no problems and null normBranch when rejecting', () => {
+    const { problems, normBranch } = classify({ ...AT_SPEC, bitrate: 64 });
+    expect(problems).toHaveLength(0);
+    expect(normBranch).toBeNull();
+  });
+});
+
+describe('classify: bitrate and sample rate', () => {
+  it('passes a file fully at spec', () => {
+    const { reject, problems } = classify({ ...AT_SPEC, lufs: TARGET_LUFS });
+    expect(reject).toBe(false);
+    expect(problems).toHaveLength(0);
+  });
+
+  it('flags bitrate below target', () => {
+    const { problems } = classify({ ...AT_SPEC, bitrate: 128 });
+    expect(problems.some(p => p.includes('128kbps'))).toBe(true);
+  });
+
+  it('flags bitrate significantly above target', () => {
+    const { problems } = classify({ ...AT_SPEC, bitrate: 320 });
+    expect(problems.some(p => p.includes('320kbps'))).toBe(true);
+  });
+
+  it('does not flag bitrate within the ffprobe tolerance window', () => {
+    const { problems } = classify({ ...AT_SPEC, bitrate: TARGET_BITRATE + 4 });
+    expect(problems.filter(p => p.includes('kbps'))).toHaveLength(0);
+  });
+
+  it('flags sample rate mismatch', () => {
+    const { problems } = classify({ ...AT_SPEC, sampleRate: 48000 });
+    expect(problems.some(p => p.includes('48000Hz'))).toBe(true);
+  });
+});
+
+describe('classify: normalization branch routing', () => {
+  it('routes clips below DURATION_THRESHOLD to peak', () => {
+    expect(classify({ ...AT_SPEC, duration: 0.5 }).normBranch).toBe('peak');
+  });
+
+  it('routes clips at exactly DURATION_THRESHOLD to lufs', () => {
+    expect(classify({ ...AT_SPEC, duration: 1.0 }).normBranch).toBe('lufs');
+  });
+
+  it('routes clips above DURATION_THRESHOLD to lufs', () => {
+    expect(classify({ ...AT_SPEC, duration: 3.0 }).normBranch).toBe('lufs');
+  });
+});
+
+describe('classify: loudness gate', () => {
+  it('flags peak loudness out of spec for short clips', () => {
+    const { problems } = classify({ ...AT_SPEC, duration: 0.5, peakDb: TARGET_PEAK_DBFS - 6 });
+    expect(problems.some(p => p.includes('dBFS'))).toBe(true);
+  });
+
+  it('does not flag peak loudness within the tolerance window', () => {
+    const inSpec = TARGET_PEAK_DBFS + (NORM_TOLERANCE - 0.1);
+    const { problems } = classify({ ...AT_SPEC, duration: 0.5, peakDb: inSpec });
+    expect(problems.filter(p => p.includes('dBFS'))).toHaveLength(0);
+  });
+
+  it('flags LUFS out of spec for long clips', () => {
+    const { problems } = classify({ ...AT_SPEC, lufs: -20.0 });
+    expect(problems.some(p => p.includes('LUFS'))).toBe(true);
+  });
+
+  it('does not flag LUFS within the tolerance window', () => {
+    const inSpec = TARGET_LUFS + (NORM_TOLERANCE - 0.1);
+    const { problems } = classify({ ...AT_SPEC, lufs: inSpec });
+    expect(problems.filter(p => p.includes('LUFS'))).toHaveLength(0);
+  });
+
+  it('ignores peakDb for long clips (uses lufs branch)', () => {
+    // A bad peak value on a long clip must not surface as a peak problem.
+    const { problems } = classify({ ...AT_SPEC, duration: 2.0, peakDb: 0, lufs: TARGET_LUFS });
+    expect(problems.filter(p => p.includes('dBFS'))).toHaveLength(0);
+  });
+
+  it('ignores lufs for short clips (uses peak branch)', () => {
+    const { problems } = classify({ ...AT_SPEC, duration: 0.5, peakDb: TARGET_PEAK_DBFS, lufs: -40 });
+    expect(problems.filter(p => p.includes('LUFS'))).toHaveLength(0);
+  });
+
+  it('does not check loudness when loudness is not provided', () => {
+    // If caller passes neither peakDb nor lufs, no loudness problem is reported.
+    const { problems } = classify({ ...AT_SPEC });
+    expect(problems.filter(p => p.includes('dBFS') || p.includes('LUFS'))).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a conform pipeline for the sfx asset directory: a script that inspects every audio file in `public/audio/sfx/` and optionally re-encodes non-conforming files to the project spec (192 kbps MP3, 44.1 kHz, hybrid loudness normalization). Wires two npm scripts, a 25-test suite, and a gate step.

**Spec:**
- Format: MP3, 192 kbps, 44.1 kHz
- Normalization: clips under 1 second get -6 dBFS peak normalization; clips 1 second and over get -14 LUFS (loudnorm=I=-14:LRA=7:TP=-1)

**Input formats accepted:** `.mp3` `.wav` `.flac` `.aiff` `.aif` `.ogg` `.opus` `.m4a`
All non-MP3 inputs are transcoded to `<stem>.mp3` and the original is removed on success.

**Lossless sources** (.wav, .flac, .aiff, .aif) skip the bitrate quality gate and the bitrate problem check entirely. Their sample rate and loudness are still validated and they are always transcoded.

**Source quality gate (lossy only):** files probing below 112 kbps are hard-rejected with a message to re-export from the DAW. Re-encoding a low-bitrate MP3 to 192 kbps does not recover lost quality. The floor is 112 kbps rather than 128 kbps to give headroom for ElevenLabs exports that probe slightly low due to encoding variance.

**Conflict resolution:** if two formats share a stem, lossless wins over lossy (WAV beats MP3) with a warning. Two same-type files for the same stem are an error: both are skipped and the script exits non-zero, forcing the contributor to remove the ambiguous file before conforming will proceed.

**npm scripts:**
- `npm run sfx:check` -- check-only; exits 1 and lists every out-of-spec file
- `npm run sfx:conform` -- check and fix; re-encodes non-conforming files in place

**Gate:** `sfx:check` added as a step in `scripts/gate.mjs` between biome and vitest so non-conforming audio blocks the gate before merge.

**Dependencies:** `ffmpeg-static` and `ffprobe-static` added to devDependencies so CI and contributors get the correct binaries via `npm install` (no system ffmpeg required).

**Architecture:** pure classification logic extracted to `scripts/sfx/sfx_conform_rules.mjs` with a `.d.mts` declaration file. The main script is a thin ffmpeg driver that imports from it. This separation makes the decision logic unit-testable without any I/O.

## Related issues

Part of #1729

## Type of change

- [x] Build, CI, or tooling

## How was this tested?

- 25 unit tests in `tests/sfx_conform.test.ts` cover the full `classify()` decision surface: reject gate, bitrate and sample rate flags, norm branch routing (peak vs LUFS), loudness tolerance windows, and lossless source handling
- `npx tsc --noEmit` clean (declaration file provides types for the test import)
- `npm run sfx:check` run against all files in `public/audio/sfx/`; output verified to surface both bitrate and loudness issues in check-only mode
- Lossless path verified: `cast_lightning_bolt.wav` (48 kHz source) correctly flagged as `[lossless source, 48000Hz, -70.0 LUFS]`
- Conflict detection verified: placing two lossy files for the same stem produces an ERROR line and non-zero exit without touching either file

## Screenshots / recordings

N/A -- no UI changes.

---

## Checklist

**Quality**

- [x] Tests pass (25/25 in `tests/sfx_conform.test.ts`)
- [x] Typecheck passes (`npx tsc --noEmit` clean via `.d.mts` declarations)
- [x] N/A for builds -- script is not part of the vite/esbuild build

**Cross-platform**

- [x] N/A -- no UI changes; `/dev/null` replaced with `-f null -` for Windows compat

**Localization (i18n)**

- [x] N/A. This PR adds no player-visible strings.

**Hygiene**

- [x] No secrets, credentials, or .env committed.
- [x] No generated files hand-edited.