### PR TITLE
fix(dungeons): lock the whole heroic party on the final-boss kill

### DIFF
--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -622,6 +622,10 @@ export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): 
       });
     }
     if (e.templateId === NYTHRAXIS_BOSS_ID) ctx.grantNythraxisLockout(e);
+    // Heroic daily lockout lands HERE, on the kill itself (credit or no credit),
+    // for the whole group that owns the claim: the marks award further down is
+    // credit- and participation-gated, so it must not carry the lockout.
+    ctx.grantHeroicKillLockout(e);
     e.aiState = 'dead';
     e.corpseTimer = CORPSE_DURATION;
     e.respawnTimer =

--- a/src/sim/content/dungeon_difficulty.ts
+++ b/src/sim/content/dungeon_difficulty.ts
@@ -88,8 +88,8 @@ export const HEROIC_DUNGEON_TUNING: Record<string, HeroicDungeonTuning> = {
   // Deathless Rage lethal on a failed wardstone channel; see
   // encounters/nythraxis.ts). The attunement dungeon nythraxis_crypt is
   // story content and deliberately has NO heroic record. The daily raid
-  // lockout is keyed by dungeon id, so it is SHARED across difficulties:
-  // one Nythraxis kill per day, normal or heroic.
+  // lockout is difficulty-scoped (the :heroic key beside the plain dungeon
+  // id): one normal AND one heroic Nythraxis kill per day.
   nythraxis_boss_arena: {
     id: 'nythraxis_boss_arena',
     difficulty: 'heroic',

--- a/src/sim/encounters/nythraxis.ts
+++ b/src/sim/encounters/nythraxis.ts
@@ -29,7 +29,7 @@ import { isStunned } from '../combat/cc';
 import { ITEMS, MOBS, NPCS, QUESTS } from '../data';
 import { createMob, createNpc } from '../entity';
 import { applyHeroicMobTuning, mobTemplateForDungeonDifficulty } from '../instances/difficulty';
-import { heroicLockoutId } from '../instances/dungeons';
+import { heroicLockoutId, instanceLockoutMetas } from '../instances/dungeons';
 import type { PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
 import { clearThreat, threatEntries } from '../threat';
@@ -506,7 +506,14 @@ export function grantNythraxisLockout(ctx: SimContext, boss: Entity): void {
   const lockId = isHeroicNythraxis(ctx, boss)
     ? heroicLockoutId('nythraxis_boss_arena')
     : 'nythraxis_boss_arena';
-  for (const meta of nythraxisRoomMetas(ctx, boss)) {
+  // The kill locks the WHOLE owning raid group plus anyone inside the arena
+  // (instanceLockoutMetas), not just the players standing in the boss room: a
+  // raider who released, camped the entrance, or never zoned in must not stay
+  // unlocked, or one unlocked member re-claims the arena for the locked raid.
+  // Room-radius survives only as the fallback for a boss outside any claim.
+  const inst = ctx.instances.find((i) => i.partyKey !== null && i.mobIds.includes(boss.id));
+  const metas = inst ? instanceLockoutMetas(ctx, inst) : nythraxisRoomMetas(ctx, boss);
+  for (const meta of metas) {
     meta.raidLockouts.set(lockId, until);
   }
 }

--- a/src/sim/encounters/nythraxis.ts
+++ b/src/sim/encounters/nythraxis.ts
@@ -506,14 +506,22 @@ export function grantNythraxisLockout(ctx: SimContext, boss: Entity): void {
   const lockId = isHeroicNythraxis(ctx, boss)
     ? heroicLockoutId('nythraxis_boss_arena')
     : 'nythraxis_boss_arena';
-  // The kill locks the WHOLE owning raid group plus anyone inside the arena
-  // (instanceLockoutMetas), not just the players standing in the boss room: a
-  // raider who released, camped the entrance, or never zoned in must not stay
-  // unlocked, or one unlocked member re-claims the arena for the locked raid.
-  // Room-radius survives only as the fallback for a boss outside any claim.
+  // The kill locks the UNION of the room and the claim sweep. The claim sweep
+  // (instanceLockoutMetas) covers the whole owning raid group plus anyone
+  // inside the generic instance footprint: a raider who released, camped the
+  // entrance, or never zoned in must not stay unlocked, or one unlocked member
+  // re-claims the arena for the locked raid. The room metas stay in the union
+  // because the arena interior is WIDER than the generic 120-yd footprint
+  // (walls at roughly +/-230 local x): a raider who left the raid while parked
+  // in a side wing sits outside both claim arms yet can still hold the tap and
+  // its rewards, so the 260-yd boss room must keep locking them.
+  const metas = new Map<number, PlayerMeta>();
+  for (const meta of nythraxisRoomMetas(ctx, boss)) metas.set(meta.entityId, meta);
   const inst = ctx.instances.find((i) => i.partyKey !== null && i.mobIds.includes(boss.id));
-  const metas = inst ? instanceLockoutMetas(ctx, inst) : nythraxisRoomMetas(ctx, boss);
-  for (const meta of metas) {
+  if (inst) {
+    for (const meta of instanceLockoutMetas(ctx, inst)) metas.set(meta.entityId, meta);
+  }
+  for (const meta of metas.values()) {
     meta.raidLockouts.set(lockId, until);
   }
 }

--- a/src/sim/instances/dungeons.ts
+++ b/src/sim/instances/dungeons.ts
@@ -148,16 +148,19 @@ export function enterDungeon(ctx: SimContext, dungeonId: string, pid?: number): 
     }
   }
   // A locked player may walk back into a LIVE heroic claim only when its final
-  // boss is already down (the corpse-run / loot-retrieval path the kill lockout
-  // deliberately leaves open). While that boss is alive, the lockout bars the
-  // door: without this, one unlocked member (a fresh recruit, or a camper the
-  // kill never locked) could claim a fresh heroic instance and ferry the whole
-  // locked party into another full run.
+  // boss is already down AND that kill is the one their lock came from (the
+  // claim's clearedBy set): the corpse-run / loot-retrieval path the kill
+  // lockout deliberately leaves open. Anything else bars the door. Without the
+  // boss-alive arm, one unlocked member (a fresh recruit, or a camper the kill
+  // never locked) could claim a fresh heroic instance and ferry the whole
+  // locked party into another full run; without the clearedBy arm, a player
+  // locked by an EARLIER run could walk into someone else's cleared claim and
+  // loot its epics through the tapper's-party corpse rights.
   if (
     inst &&
     inst.difficulty === 'heroic' &&
     isRaidLocked(ctx, r.meta, heroicLockoutId(dungeonId)) &&
-    heroicFinalBossAlive(ctx, inst)
+    (heroicFinalBossAlive(ctx, inst) || !inst.clearedBy.has(r.meta.entityId))
   ) {
     ctx.error(r.meta.entityId, `You are locked to Heroic ${dungeon.name}.`);
     return;
@@ -291,6 +294,7 @@ function claimInstance(
   inst.partyKey = key;
   inst.difficulty = difficulty;
   inst.emptyFor = 0;
+  inst.clearedBy = new Set();
   const origin = instanceOriginOf(inst);
   for (const spawn of dungeon.spawns) {
     const template = MOBS[spawn.mobId];
@@ -362,6 +366,7 @@ function freeInstance(ctx: SimContext, inst: InstanceSlot): void {
   inst.objectIds = [];
   inst.exitId = null;
   inst.emptyFor = 0;
+  inst.clearedBy = new Set();
 }
 
 // Kill-time lockout recipients for a claimed instance: every CURRENT member of
@@ -384,13 +389,32 @@ export function instanceLockoutMetas(ctx: SimContext, inst: InstanceSlot): Playe
   return out;
 }
 
+// Stamp one player's heroic daily lockout for this claim. A player whose lock
+// FIRST lands with this kill also joins the claim's `clearedBy` set: the
+// heroic door's cleared-run exception (enterDungeon) admits only them, so a
+// player locked by an EARLIER run can never treat someone else's cleared claim
+// as their own loot run (corpse loot rights ride the tapper's current party,
+// so an open door would hand them the epics too).
+function lockToHeroicClaim(
+  ctx: SimContext,
+  inst: InstanceSlot,
+  meta: PlayerMeta,
+  lockedUntil: number,
+): void {
+  const lockId = heroicLockoutId(inst.dungeonId);
+  if (!isRaidLocked(ctx, meta, lockId)) inst.clearedBy.add(meta.entityId);
+  meta.raidLockouts.set(lockId, lockedUntil);
+}
+
 // Heroic KILL lockout, the sibling of awardHeroicMarks on the death path.
 // combat/damage.ts calls it for EVERY mob death (credit or no credit): when the
 // dead mob is the final boss of a heroic claim, the whole owning group (plus
 // anyone inside) is locked to that heroic dungeon until the daily reset (the
 // same realm-local boundary the Nythraxis raid uses), scoped to the :heroic
 // key so the normal difficulty is never consumed. Marks stay participation-
-// gated below; the lockout deliberately is not.
+// gated below; the lockout deliberately is not. Death-time reward recipients
+// (a departed tap holder) are the third arm of the union, stamped in
+// awardHeroicMarks where that snapshot exists.
 export function grantHeroicKillLockout(ctx: SimContext, mob: Entity): void {
   const inst = ctx.instances.find((i) => i.partyKey !== null && i.mobIds.includes(mob.id));
   if (!inst || inst.difficulty !== 'heroic') return;
@@ -398,7 +422,7 @@ export function grantHeroicKillLockout(ctx: SimContext, mob: Entity): void {
   if (!tuning || mob.templateId !== tuning.finalBossId) return;
   const lockedUntil = ctx.raidResetMs(ctx.lockoutNowMs());
   for (const meta of instanceLockoutMetas(ctx, inst)) {
-    meta.raidLockouts.set(heroicLockoutId(inst.dungeonId), lockedUntil);
+    lockToHeroicClaim(ctx, inst, meta, lockedUntil);
   }
 }
 
@@ -424,8 +448,16 @@ export function awardHeroicMarks(ctx: SimContext, mob: Entity, recipients: Playe
   const tuning = HEROIC_DUNGEON_TUNING[inst.dungeonId];
   if (!tuning || mob.templateId !== tuning.finalBossId) return;
   const loot = mob.loot ?? { copper: 0, items: [] };
+  // Death-time reward recipients are the third arm of the kill-lockout union
+  // (grantHeroicKillLockout covers the owning group and the occupants): a tap
+  // holder who left the party and the instance before the kill still walks
+  // away with the mark slot and the corpse loot rights, so they must carry the
+  // daily lockout too. Stamped before the marks daily gate below, like the
+  // pre-split code, so an already-marked recipient is still locked.
+  const lockedUntil = ctx.raidResetMs(ctx.lockoutNowMs());
   const earners: number[] = [];
   for (const meta of recipients) {
+    lockToHeroicClaim(ctx, inst, meta, lockedUntil);
     // `utcDay` comes from the host, never the wall clock (determinism). Both
     // hosts stamp it (server/game.ts, main.ts); with an empty day the set
     // simply never resets, the same semantics as delveDaily.

--- a/src/sim/instances/dungeons.ts
+++ b/src/sim/instances/dungeons.ts
@@ -48,6 +48,12 @@ export function instanceOriginOf(inst: InstanceSlot): { x: number; z: number } {
   return instanceOrigin(DUNGEONS[inst.dungeonId].index, inst.slot);
 }
 
+// The one instance-footprint envelope (shared by occupancy, position lookup,
+// and the kill-lockout sweep): is `pos` inside the slot anchored at `origin`?
+function instanceContains(origin: { x: number; z: number }, pos: Vec3): boolean {
+  return Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250;
+}
+
 // Difficulty-scoped lockout key: heroic clears lock beside the normal key, so
 // the two difficulties never consume each other's daily lockout.
 export function heroicLockoutId(dungeonId: string): string {
@@ -141,10 +147,26 @@ export function enterDungeon(ctx: SimContext, dungeonId: string, pid?: number): 
       return;
     }
   }
+  // A locked player may walk back into a LIVE heroic claim only when its final
+  // boss is already down (the corpse-run / loot-retrieval path the kill lockout
+  // deliberately leaves open). While that boss is alive, the lockout bars the
+  // door: without this, one unlocked member (a fresh recruit, or a camper the
+  // kill never locked) could claim a fresh heroic instance and ferry the whole
+  // locked party into another full run.
+  if (
+    inst &&
+    inst.difficulty === 'heroic' &&
+    isRaidLocked(ctx, r.meta, heroicLockoutId(dungeonId)) &&
+    heroicFinalBossAlive(ctx, inst)
+  ) {
+    ctx.error(r.meta.entityId, `You are locked to Heroic ${dungeon.name}.`);
+    return;
+  }
   if (!inst) {
-    // Heroic five-mans lock on the KILL, not the door: a locked player can
-    // still corpse-run back into a live claim, but cannot claim a fresh
-    // heroic run until the daily reset. Normal claims are never gated.
+    // Heroic five-mans lock on the KILL: a locked player can still corpse-run
+    // back into a cleared live claim (gated on the boss being down, above), but
+    // cannot claim a fresh heroic run until the daily reset. Normal claims are
+    // never gated.
     if (difficulty === 'heroic' && isRaidLocked(ctx, r.meta, heroicLockoutId(dungeonId))) {
       ctx.error(r.meta.entityId, `You are locked to Heroic ${dungeon.name}.`);
       return;
@@ -191,6 +213,20 @@ function isRaidLocked(ctx: SimContext, meta: PlayerMeta, dungeonId: string): boo
     return false;
   }
   return true;
+}
+
+// Is the claimed heroic instance's final boss still up? Gates the locked-player
+// door rule in enterDungeon: a cleared run (boss down, or its corpse already
+// swept) stays re-enterable for loot and corpse-runs; a run with the boss alive
+// is a fresh farm a locked player must not join.
+function heroicFinalBossAlive(ctx: SimContext, inst: InstanceSlot): boolean {
+  const tuning = HEROIC_DUNGEON_TUNING[inst.dungeonId];
+  if (!tuning) return false;
+  for (const id of inst.mobIds) {
+    const e = ctx.entities.get(id);
+    if (e && e.templateId === tuning.finalBossId && !e.dead) return true;
+  }
+  return false;
 }
 
 // The royal door seals once Nythraxis is engaged (pulled, alive, pre-death).
@@ -328,6 +364,44 @@ function freeInstance(ctx: SimContext, inst: InstanceSlot): void {
   inst.emptyFor = 0;
 }
 
+// Kill-time lockout recipients for a claimed instance: every CURRENT member of
+// the group that owns the claim, wherever they stand (at the entrance, dead, or
+// released outside), plus any player physically inside the instance footprint
+// (a member who left the party mid-run is still on the hook). Position alone
+// was the old rule, and it let a door-camper or an early-released ghost escape
+// the daily lockout and later claim a fresh run for the whole locked party.
+export function instanceLockoutMetas(ctx: SimContext, inst: InstanceSlot): PlayerMeta[] {
+  const origin = instanceOriginOf(inst);
+  const out: PlayerMeta[] = [];
+  for (const meta of ctx.players.values()) {
+    if (instanceKeyFor(ctx, meta.entityId) === inst.partyKey) {
+      out.push(meta);
+      continue;
+    }
+    const e = ctx.entities.get(meta.entityId);
+    if (e && instanceContains(origin, e.pos)) out.push(meta);
+  }
+  return out;
+}
+
+// Heroic KILL lockout, the sibling of awardHeroicMarks on the death path.
+// combat/damage.ts calls it for EVERY mob death (credit or no credit): when the
+// dead mob is the final boss of a heroic claim, the whole owning group (plus
+// anyone inside) is locked to that heroic dungeon until the daily reset (the
+// same realm-local boundary the Nythraxis raid uses), scoped to the :heroic
+// key so the normal difficulty is never consumed. Marks stay participation-
+// gated below; the lockout deliberately is not.
+export function grantHeroicKillLockout(ctx: SimContext, mob: Entity): void {
+  const inst = ctx.instances.find((i) => i.partyKey !== null && i.mobIds.includes(mob.id));
+  if (!inst || inst.difficulty !== 'heroic') return;
+  const tuning = HEROIC_DUNGEON_TUNING[inst.dungeonId];
+  if (!tuning || mob.templateId !== tuning.finalBossId) return;
+  const lockedUntil = ctx.raidResetMs(ctx.lockoutNowMs());
+  for (const meta of instanceLockoutMetas(ctx, inst)) {
+    meta.raidLockouts.set(heroicLockoutId(inst.dungeonId), lockedUntil);
+  }
+}
+
 // Heroic participation reward: the final boss of a heroic instance drops
 // Heroic Marks for every eligible participant (marksPerParticipant on the
 // tuning record: 1 for the five-mans, 3 for the Nythraxis raid). `recipients`
@@ -335,7 +409,8 @@ function freeInstance(ctx: SimContext, inst: InstanceSlot): void {
 // loot rights. Each mark is its own personalFor slot (the loot pickup arm
 // grants one item per personal slot, so a single loot click takes them all)
 // and nobody can take another player's. Draws no rng, so the corpse loot
-// draw order is untouched.
+// draw order is untouched. The daily LOCKOUT is not granted here: it covers
+// the whole owning group, credit or no credit (grantHeroicKillLockout above).
 //
 // Daily income gate: each dungeon pays a given character at most once per host
 // UTC day (delveDaily pattern), so the instance-reset farm cannot print marks.
@@ -349,14 +424,8 @@ export function awardHeroicMarks(ctx: SimContext, mob: Entity, recipients: Playe
   const tuning = HEROIC_DUNGEON_TUNING[inst.dungeonId];
   if (!tuning || mob.templateId !== tuning.finalBossId) return;
   const loot = mob.loot ?? { copper: 0, items: [] };
-  // Every participant is locked to this heroic instance until the daily reset
-  // (the same realm-local boundary the Nythraxis raid uses). Granted on the
-  // KILL, independent of the marks daily gate below, and scoped to the
-  // :heroic key so the normal difficulty is never consumed.
-  const lockedUntil = ctx.raidResetMs(ctx.lockoutNowMs());
   const earners: number[] = [];
   for (const meta of recipients) {
-    meta.raidLockouts.set(heroicLockoutId(inst.dungeonId), lockedUntil);
     // `utcDay` comes from the host, never the wall clock (determinism). Both
     // hosts stamp it (server/game.ts, main.ts); with an empty day the set
     // simply never resets, the same semantics as delveDaily.
@@ -391,7 +460,7 @@ export function updateInstances(ctx: SimContext): void {
     let occupied = false;
     for (const meta of ctx.players.values()) {
       const e = ctx.entities.get(meta.entityId);
-      if (e && Math.abs(e.pos.x - origin.x) < 120 && Math.abs(e.pos.z - origin.z) < 250) {
+      if (e && instanceContains(origin, e.pos)) {
         occupied = true;
         break;
       }
@@ -414,8 +483,7 @@ export function instanceInfoAt(
   pos: Vec3,
 ): { slot: number; dungeonId: string } | null {
   for (const inst of ctx.instances) {
-    const origin = instanceOriginOf(inst);
-    if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) {
+    if (instanceContains(instanceOriginOf(inst), pos)) {
       return { slot: inst.slot, dungeonId: inst.dungeonId };
     }
   }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -299,6 +299,7 @@ import {
   awardHeroicMarks as awardHeroicMarksImpl,
   enterCrypt as enterCryptImpl,
   enterDungeon as enterDungeonImpl,
+  grantHeroicKillLockout as grantHeroicKillLockoutImpl,
   instanceInfoAt as instanceInfoAtImpl,
   instanceKeyFor as instanceKeyForImpl,
   instanceOriginOf as instanceOriginOfImpl,
@@ -2880,6 +2881,9 @@ export class Sim {
       dungeonDifficulty: sim.dungeonDifficulty.bind(sim),
       setDungeonDifficulty: sim.setDungeonDifficulty.bind(sim),
       awardHeroicMarks: sim.awardHeroicMarks.bind(sim),
+      // Kill-site heroic daily lockout (instances/dungeons): C1's death hub calls it
+      // for every mob death, credit or no credit; late-bound arrow, no Sim facade.
+      grantHeroicKillLockout: (mob) => grantHeroicKillLockoutImpl(sim.ctx, mob),
       addEntity: sim.addEntity.bind(sim),
       dropEntity: sim.dropEntity.bind(sim),
       rebucket: sim.rebucket.bind(sim),

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -724,6 +724,11 @@ export interface InstanceSlot {
   objectIds: number[];
   exitId: number | null;
   emptyFor: number;
+  // Players whose heroic daily lockout FIRST landed with THIS claim's final-boss
+  // kill (instances/dungeons lockToHeroicClaim). The heroic door's cleared-run
+  // exception admits only these: a player locked by an earlier run can never
+  // treat someone else's cleared claim as their own loot run.
+  clearedBy: Set<number>;
 }
 
 export interface ResolvedAbility {
@@ -1459,6 +1464,7 @@ export class Sim {
             objectIds: [],
             exitId: null,
             emptyFor: 0,
+            clearedBy: new Set(),
           });
         }
         continue;
@@ -1485,6 +1491,7 @@ export class Sim {
           objectIds: [],
           exitId: null,
           emptyFor: 0,
+          clearedBy: new Set(),
         });
       }
     }

--- a/src/sim/sim_context.ts
+++ b/src/sim/sim_context.ts
@@ -213,6 +213,12 @@ export interface SimContextCallbacks {
   dungeonDifficulty(pid?: number): DungeonDifficulty;
   setDungeonDifficulty(difficulty: DungeonDifficulty, pid?: number): void;
   awardHeroicMarks(mob: Entity, recipients: PlayerMeta[]): void;
+  // grantHeroicKillLockout is awardHeroicMarks' sibling on the death path, owned by
+  // instances/dungeons: the C1 death hub calls it for EVERY mob death (credit or no
+  // credit). A heroic claim's final-boss kill locks the whole owning group (plus
+  // anyone inside the instance) to the :heroic key until the daily reset, so the
+  // lockout cannot be dodged by camping the door or releasing before the kill.
+  grantHeroicKillLockout(mob: Entity): void;
 
   // C1 damage/death hub + the casting/leash/arena/duel/fiesta/loot teardown it
   // drives mid-tick. `dealDamage` is the post-mitigation entry (crit/dodge/miss and
@@ -851,6 +857,7 @@ export function createSimContext(host: SimContextHost): SimContext {
     dungeonDifficulty: host.dungeonDifficulty,
     setDungeonDifficulty: host.setDungeonDifficulty,
     awardHeroicMarks: host.awardHeroicMarks,
+    grantHeroicKillLockout: host.grantHeroicKillLockout,
     dealDamage: host.dealDamage,
     handleDeath: host.handleDeath,
     cancelCast: host.cancelCast,

--- a/tests/dungeons.test.ts
+++ b/tests/dungeons.test.ts
@@ -910,6 +910,103 @@ describe('dungeons: heroic daily lockouts', () => {
     ).toBe(true);
   });
 
+  it('a tap-runner who left the party and the instance is still locked by the kill', () => {
+    const sim = makeSim(5);
+    const leader = sim.addPlayer('warrior', 'Lead');
+    const runner = sim.addPlayer('mage', 'Runner');
+    const buddy = sim.addPlayer('priest', 'Buddy');
+    sim.partyInvite(runner, leader);
+    sim.partyAccept(runner);
+    sim.partyInvite(buddy, leader);
+    sim.partyAccept(buddy);
+    sim.setDungeonDifficulty('heroic', leader);
+    enterDungeon(sim.ctx, 'hollow_crypt', leader);
+    enterDungeon(sim.ctx, 'hollow_crypt', runner);
+    const inst = claimedDungeon(sim, 'hollow_crypt', 'heroic');
+    const morthen = mobInInstance(sim, inst, 'morthen');
+    const le = sim.entities.get(leader) as AnyEntity;
+    const re = sim.entities.get(runner) as AnyEntity;
+    teleport(sim, le, morthen.pos.x + 1, morthen.pos.z);
+    teleport(sim, re, morthen.pos.x - 1, morthen.pos.z);
+
+    // The runner first-taps the boss, then leaves the party AND the dungeon.
+    // The tap persists, so the death-time credit (loot rights + the mark slot)
+    // still lands on the runner, wherever they now stand.
+    (sim as any).dealDamage(re, morthen, 10, false, 'physical', null, 'hit');
+    expect(morthen.tappedById).toBe(runner);
+    sim.partyLeave(runner);
+    teleport(sim, re, 0, 0);
+    (sim as any).dealDamage(le, morthen, morthen.hp + 10, false, 'physical', null, 'hit');
+    expect(morthen.dead).toBe(true);
+    const marks = ((morthen.loot?.items ?? []) as any[]).filter(
+      (s) => s.itemId === HEROIC_MARK_ITEM_ID,
+    );
+    expect(marks).toHaveLength(1);
+    expect(marks[0].personalFor).toEqual([runner]); // the reward really went to the runner
+
+    // The rewarded runner carries the daily lockout like everyone else: a
+    // rewarded-but-unlocked runner could otherwise claim a fresh solo heroic
+    // and double the day's epics.
+    expect(sim.players.get(runner)!.raidLockouts.has('hollow_crypt:heroic')).toBe(true);
+    expect(sim.players.get(leader)!.raidLockouts.has('hollow_crypt:heroic')).toBe(true);
+
+    // Rejoining the party still lets the runner back into the CLEARED claim to
+    // collect the mark (this clear is theirs).
+    sim.partyInvite(runner, leader);
+    sim.partyAccept(runner);
+    sim.drainEvents();
+    enterDungeon(sim.ctx, 'hollow_crypt', runner);
+    expect(re.pos.x).toBeGreaterThan(DUNGEON_X_THRESHOLD);
+  });
+
+  it('a locked player cannot enter a clear they took no part in, even after its boss dies', () => {
+    const sim = makeSim(5);
+    // A clears heroic solo and is locked; the claim frees.
+    const a = sim.addPlayer('warrior', 'LockedA');
+    sim.setDungeonDifficulty('heroic', a);
+    enterDungeon(sim.ctx, 'hollow_crypt', a);
+    const first = claimedDungeon(sim, 'hollow_crypt', 'heroic');
+    const boss1 = mobInInstance(sim, first, 'morthen');
+    const ae = sim.entities.get(a) as AnyEntity;
+    teleport(sim, ae, boss1.pos.x + 1, boss1.pos.z);
+    (sim as any).dealDamage(ae, boss1, boss1.hp + 10, false, 'physical', null, 'hit');
+    leaveDungeon(sim.ctx, a);
+    teleport(sim, ae, 0, 0);
+    first.emptyFor = 100000;
+    for (let i = 0; i < 40; i++) sim.tick();
+    expect(first.partyKey).toBeNull();
+
+    // An unlocked recruit parties up with A, claims a fresh heroic, and kills
+    // its boss alone while A waits outside.
+    const c = sim.addPlayer('priest', 'Fresh');
+    sim.partyInvite(a, c);
+    sim.partyAccept(a);
+    sim.setDungeonDifficulty('heroic', c);
+    enterDungeon(sim.ctx, 'hollow_crypt', c);
+    const fresh = claimedDungeon(sim, 'hollow_crypt', 'heroic');
+    const boss2 = mobInInstance(sim, fresh, 'morthen');
+    const ce = sim.entities.get(c) as AnyEntity;
+    teleport(sim, ce, boss2.pos.x + 1, boss2.pos.z);
+    (sim as any).dealDamage(ce, boss2, boss2.hp + 10, false, 'physical', null, 'hit');
+    expect(boss2.dead).toBe(true);
+
+    // The dead boss does NOT open the door for A: this clear was never A's,
+    // and corpse loot rights ride the tapper's current party, so an open door
+    // would hand A the epics of a second run that day.
+    sim.drainEvents();
+    enterDungeon(sim.ctx, 'hollow_crypt', a);
+    expect(ae.pos.x).toBeLessThan(DUNGEON_X_THRESHOLD);
+    expect(
+      (sim.drainEvents() as any[]).some(
+        (e) => e.type === 'error' && e.text === 'You are locked to Heroic The Hollow Crypt.',
+      ),
+    ).toBe(true);
+    // The recruit, whose clear it is, can still walk back in.
+    leaveDungeon(sim.ctx, c);
+    enterDungeon(sim.ctx, 'hollow_crypt', c);
+    expect(ce.pos.x).toBeGreaterThan(DUNGEON_X_THRESHOLD);
+  });
+
   it('a locked player still walks back into the cleared live claim (corpse-run / loot)', () => {
     const sim = makeSim(5);
     const pid = sim.addPlayer('warrior', 'Raider');

--- a/tests/dungeons.test.ts
+++ b/tests/dungeons.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect, it } from 'vitest';
 import { HEROIC_DUNGEON_TUNING, HEROIC_MARK_ITEM_ID } from '../src/sim/content/dungeon_difficulty';
 import { HEROIC_BOSS_LOOT } from '../src/sim/content/heroic_loot';
-import { DUNGEONS, ITEMS, instanceOrigin, MOBS } from '../src/sim/data';
+import { DUNGEON_X_THRESHOLD, DUNGEONS, ITEMS, instanceOrigin, MOBS } from '../src/sim/data';
 import { spawnNythraxisAdds } from '../src/sim/encounters/nythraxis';
 import {
   enterDungeon,
@@ -555,6 +555,8 @@ describe('dungeons: heroic marks', () => {
     expect(
       ((nMorthen.loot?.items ?? []) as any[]).some((s) => s.itemId === HEROIC_MARK_ITEM_ID),
     ).toBe(false);
+    // A NORMAL final-boss kill also never grants the daily lockout.
+    expect(normal.players.get(nPid)!.raidLockouts.size).toBe(0);
 
     const heroic = makeSim(11);
     const hPid = heroic.addPlayer('warrior', 'Hero');
@@ -580,6 +582,8 @@ describe('dungeons: heroic marks', () => {
         (s) => s.itemId === HEROIC_MARK_ITEM_ID,
       ),
     ).toBe(false);
+    // Heroic TRASH kills never grant the daily lockout either (finalBossId gate).
+    expect(heroic.players.get(hPid)!.raidLockouts.size).toBe(0);
   });
 });
 
@@ -758,6 +762,173 @@ describe('dungeons: heroic daily lockouts', () => {
     sim.setDungeonDifficulty('heroic', pid);
     enterDungeon(sim.ctx, 'hollow_crypt', pid);
     expect(claimedDungeon(sim, 'hollow_crypt', 'heroic')).toBeTruthy();
+  });
+
+  it('the kill locks EVERY current party member, wherever they stand', () => {
+    const sim = makeSim(5);
+    const leader = sim.addPlayer('warrior', 'Lead');
+    const camper = sim.addPlayer('mage', 'Camper');
+    sim.partyInvite(camper, leader);
+    sim.partyAccept(camper);
+    sim.setDungeonDifficulty('heroic', leader);
+    enterDungeon(sim.ctx, 'hollow_crypt', leader);
+    const inst = claimedDungeon(sim, 'hollow_crypt', 'heroic');
+    const morthen = mobInInstance(sim, inst, 'morthen');
+    const le = sim.entities.get(leader) as AnyEntity;
+    teleport(sim, le, morthen.pos.x + 1, morthen.pos.z);
+    // The camper never walks through the door: they idle back at the world
+    // spawn, far outside the instance and the party-xp corpse range.
+    teleport(sim, sim.entities.get(camper) as AnyEntity, 0, 0);
+
+    (sim as any).dealDamage(le, morthen, morthen.hp + 10, false, 'physical', null, 'hit');
+    expect(morthen.dead).toBe(true);
+
+    // Both party members are locked to the heroic claim for the day (and only
+    // the :heroic key: the plain normal key must stay untouched)...
+    for (const pid of [leader, camper]) {
+      expect(sim.players.get(pid)!.raidLockouts.has('hollow_crypt:heroic'), `pid ${pid}`).toBe(
+        true,
+      );
+      expect(sim.players.get(pid)!.raidLockouts.has('hollow_crypt'), `plain key pid ${pid}`).toBe(
+        false,
+      );
+    }
+    // ...while the marks stay participation-gated: the camper earned none.
+    const marks = ((morthen.loot?.items ?? []) as any[]).filter(
+      (s) => s.itemId === HEROIC_MARK_ITEM_ID,
+    );
+    expect(marks).toHaveLength(1);
+    expect(marks[0].personalFor).toEqual([leader]);
+  });
+
+  it('a member who left the party mid-run but stayed inside is still locked by the kill', () => {
+    const sim = makeSim(5);
+    const leader = sim.addPlayer('warrior', 'Lead');
+    const buddy = sim.addPlayer('priest', 'Buddy');
+    const quitter = sim.addPlayer('mage', 'Quit');
+    sim.partyInvite(buddy, leader);
+    sim.partyAccept(buddy);
+    sim.partyInvite(quitter, leader);
+    sim.partyAccept(quitter);
+    sim.setDungeonDifficulty('heroic', leader);
+    enterDungeon(sim.ctx, 'hollow_crypt', leader);
+    enterDungeon(sim.ctx, 'hollow_crypt', buddy);
+    enterDungeon(sim.ctx, 'hollow_crypt', quitter);
+    const inst = claimedDungeon(sim, 'hollow_crypt', 'heroic');
+    const morthen = mobInInstance(sim, inst, 'morthen');
+    const le = sim.entities.get(leader) as AnyEntity;
+    teleport(sim, le, morthen.pos.x + 1, morthen.pos.z);
+    teleport(sim, sim.entities.get(buddy) as AnyEntity, morthen.pos.x - 1, morthen.pos.z);
+    teleport(sim, sim.entities.get(quitter) as AnyEntity, morthen.pos.x, morthen.pos.z + 2);
+    sim.partyLeave(quitter); // no longer in the group, still standing in the boss room
+
+    (sim as any).dealDamage(le, morthen, morthen.hp + 10, false, 'physical', null, 'hit');
+    expect(morthen.dead).toBe(true);
+
+    for (const pid of [leader, buddy, quitter]) {
+      expect(sim.players.get(pid)!.raidLockouts.has('hollow_crypt:heroic'), `pid ${pid}`).toBe(
+        true,
+      );
+      expect(sim.players.get(pid)!.raidLockouts.has('hollow_crypt'), `plain key pid ${pid}`).toBe(
+        false,
+      );
+    }
+  });
+
+  it('an uncredited final-boss death still locks the owning party (no marks, no credit)', () => {
+    const sim = makeSim(5);
+    const leader = sim.addPlayer('warrior', 'Lead');
+    const member = sim.addPlayer('mage', 'Mate');
+    sim.partyInvite(member, leader);
+    sim.partyAccept(member);
+    sim.setDungeonDifficulty('heroic', leader);
+    enterDungeon(sim.ctx, 'hollow_crypt', leader);
+    enterDungeon(sim.ctx, 'hollow_crypt', member);
+    const inst = claimedDungeon(sim, 'hollow_crypt', 'heroic');
+    const morthen = mobInInstance(sim, inst, 'morthen');
+    expect(morthen.tappedById ?? null).toBeNull(); // nobody ever hit him
+
+    // A source-less killing blow: no tap, no player credit resolves, so the
+    // whole credited block in handleDeath (xp, loot, marks) is skipped.
+    (sim as any).dealDamage(null, morthen, morthen.hp + 10, false, 'physical', null, 'hit');
+    expect(morthen.dead).toBe(true);
+
+    // No credit means no marks were created...
+    expect(
+      ((morthen.loot?.items ?? []) as any[]).some((s) => s.itemId === HEROIC_MARK_ITEM_ID),
+    ).toBe(false);
+    // ...but the kill-site lockout is credit-free and still locks the party.
+    expect(sim.players.get(leader)!.raidLockouts.has('hollow_crypt:heroic')).toBe(true);
+    expect(sim.players.get(member)!.raidLockouts.has('hollow_crypt:heroic')).toBe(true);
+  });
+
+  it('a locked party cannot ride an unlocked recruit into a fresh heroic claim', () => {
+    const sim = makeSim(5);
+    const leader = sim.addPlayer('warrior', 'Lead');
+    const member = sim.addPlayer('mage', 'Mate');
+    sim.partyInvite(member, leader);
+    sim.partyAccept(member);
+    sim.setDungeonDifficulty('heroic', leader);
+    enterDungeon(sim.ctx, 'hollow_crypt', leader);
+    enterDungeon(sim.ctx, 'hollow_crypt', member);
+    const inst = claimedDungeon(sim, 'hollow_crypt', 'heroic');
+    const morthen = mobInInstance(sim, inst, 'morthen');
+    const le = sim.entities.get(leader) as AnyEntity;
+    const me = sim.entities.get(member) as AnyEntity;
+    teleport(sim, le, morthen.pos.x + 1, morthen.pos.z);
+    teleport(sim, me, morthen.pos.x - 1, morthen.pos.z);
+    (sim as any).dealDamage(le, morthen, morthen.hp + 10, false, 'physical', null, 'hit');
+
+    // Everyone leaves; the empty claim frees (fast-forwarded).
+    leaveDungeon(sim.ctx, leader);
+    leaveDungeon(sim.ctx, member);
+    teleport(sim, le, 0, 0);
+    teleport(sim, me, 0, 0);
+    inst.emptyFor = 100000;
+    for (let i = 0; i < 40; i++) sim.tick();
+    expect(inst.partyKey).toBeNull();
+
+    // A fresh recruit (never locked) joins the party and claims a NEW heroic
+    // instance with a living boss.
+    const recruit = sim.addPlayer('priest', 'Fresh');
+    sim.partyInvite(recruit, leader);
+    sim.partyAccept(recruit);
+    enterDungeon(sim.ctx, 'hollow_crypt', recruit);
+    const fresh = claimedDungeon(sim, 'hollow_crypt', 'heroic');
+    expect(fresh).toBeTruthy();
+    expect(mobInInstance(sim, fresh, 'morthen').dead).toBe(false);
+
+    // The locked members are barred at the door while that boss is alive: one
+    // unlocked recruit must not ferry the whole locked party into another run.
+    sim.drainEvents();
+    enterDungeon(sim.ctx, 'hollow_crypt', leader);
+    expect(le.pos.x).toBeLessThan(DUNGEON_X_THRESHOLD); // still outside
+    expect(
+      (sim.drainEvents() as any[]).some(
+        (e) => e.type === 'error' && e.text === 'You are locked to Heroic The Hollow Crypt.',
+      ),
+    ).toBe(true);
+  });
+
+  it('a locked player still walks back into the cleared live claim (corpse-run / loot)', () => {
+    const sim = makeSim(5);
+    const pid = sim.addPlayer('warrior', 'Raider');
+    sim.setDungeonDifficulty('heroic', pid);
+    enterDungeon(sim.ctx, 'hollow_crypt', pid);
+    const inst = claimedDungeon(sim, 'hollow_crypt', 'heroic');
+    const morthen = mobInInstance(sim, inst, 'morthen');
+    const p = sim.entities.get(pid) as AnyEntity;
+    teleport(sim, p, morthen.pos.x + 1, morthen.pos.z);
+    (sim as any).dealDamage(p, morthen, morthen.hp + 10, false, 'physical', null, 'hit');
+    expect(sim.players.get(pid)!.raidLockouts.has('hollow_crypt:heroic')).toBe(true);
+
+    // Step out and walk back in: the claim is still live and its final boss is
+    // down, so the lockout does NOT bar the door (loot retrieval / corpse-run).
+    leaveDungeon(sim.ctx, pid);
+    expect(p.pos.x).toBeLessThan(DUNGEON_X_THRESHOLD);
+    enterDungeon(sim.ctx, 'hollow_crypt', pid);
+    expect(p.pos.x).toBeGreaterThan(DUNGEON_X_THRESHOLD);
+    expect(inst.partyKey).not.toBeNull();
   });
 });
 

--- a/tests/entity_roster.test.ts
+++ b/tests/entity_roster.test.ts
@@ -198,6 +198,7 @@ function makeCtx() {
     dungeonDifficulty: vi.fn(() => 'normal' as const),
     setDungeonDifficulty: vi.fn(),
     awardHeroicMarks: vi.fn(),
+    grantHeroicKillLockout: vi.fn(),
     addEntity: vi.fn(),
     dropEntity: vi.fn(),
     rebucket: vi.fn(),

--- a/tests/nythraxis_raid.test.ts
+++ b/tests/nythraxis_raid.test.ts
@@ -2409,6 +2409,38 @@ describe('Nythraxis raid encounter', () => {
     expect(tank.pos.x).toBeGreaterThan(3000); // lockout lifted, re-entry allowed
   });
 
+  it('the kill locks EVERY raid member, even one who never entered the arena', () => {
+    const now = Date.UTC(2025, 5, 29, 16, 0, 0);
+    const reset = nextRaidResetMs(now);
+    const sim = makeWorld(
+      () => now,
+      (nowMs) => nextRaidResetMs(nowMs),
+    );
+    const tankPid = sim.addPlayer('warrior', 'Tank');
+    // enterRaid moves only the tank through the door: the raid fills stay at the
+    // world spawn, outside the arena and the boss room. A member who released
+    // (or camped the door) must still be locked by the kill, or one unlocked
+    // raider re-claims the arena for the whole locked raid.
+    enterRaid(sim, tankPid);
+    const tank = sim.entities.get(tankPid)!;
+    const boss = mob(sim, 'nythraxis_scourge_of_thornpeak');
+    engage(boss, tank);
+    killMob(sim, boss, tank);
+
+    const members = sim.partyOf(tankPid)!.members;
+    expect(members.length).toBeGreaterThanOrEqual(5);
+    for (const pid of members) {
+      // The fills really are outside the arena footprint (never zoned in), so
+      // this exercises the party-membership arm, not the position arm.
+      if (pid !== tankPid) {
+        expect(sim.entities.get(pid)!.pos.x, `fill ${pid} outside`).toBeLessThan(3000);
+      }
+      expect(sim.players.get(pid)!.raidLockouts.get('nythraxis_boss_arena'), `pid ${pid}`).toBe(
+        reset,
+      );
+    }
+  });
+
   it('a heroic kill locks the :heroic key only; the normal raid stays open that day', () => {
     const now = Date.UTC(2025, 5, 29, 16, 0, 0);
     const reset = nextRaidResetMs(now);

--- a/tests/nythraxis_raid.test.ts
+++ b/tests/nythraxis_raid.test.ts
@@ -2441,6 +2441,35 @@ describe('Nythraxis raid encounter', () => {
     }
   });
 
+  it('a raider who left the raid while parked in a side wing is still locked by the kill', () => {
+    const now = Date.UTC(2025, 5, 29, 16, 0, 0);
+    const reset = nextRaidResetMs(now);
+    const sim = makeWorld(
+      () => now,
+      (nowMs) => nextRaidResetMs(nowMs),
+    );
+    const tankPid = sim.addPlayer('warrior', 'Tank');
+    const origin = enterRaid(sim, tankPid);
+    // Bring one raider inside and park them in the east wing: inside the arena
+    // walls (the 260yd boss room) but OUTSIDE the generic 120-wide instance
+    // footprint, then have them leave the raid. Neither the group arm nor the
+    // footprint arm of the sweep sees them, so only the room-radius union does.
+    const wingPid = sim.partyOf(tankPid)!.members.find((pid) => pid !== tankPid)!;
+    sim.enterDungeon('nythraxis_boss_arena', wingPid);
+    teleport(sim, wingPid, origin.x + 200, origin.z + 82);
+    const boss = mob(sim, 'nythraxis_scourge_of_thornpeak');
+    const wing = sim.entities.get(wingPid)!;
+    expect(Math.abs(wing.pos.x - origin.x)).toBeGreaterThan(120); // outside the footprint
+    expect(dist2d(wing.pos, boss.spawnPos)).toBeLessThanOrEqual(260); // inside the room
+    sim.partyLeave(wingPid);
+    expect(sim.partyOf(wingPid)).toBeNull();
+
+    const tank = sim.entities.get(tankPid)!;
+    engage(boss, tank);
+    killMob(sim, boss, tank);
+    expect(sim.players.get(wingPid)!.raidLockouts.get('nythraxis_boss_arena')).toBe(reset);
+  });
+
   it('a heroic kill locks the :heroic key only; the normal raid stays open that day', () => {
     const now = Date.UTC(2025, 5, 29, 16, 0, 0);
     const reset = nextRaidResetMs(now);

--- a/tests/sim_context.test.ts
+++ b/tests/sim_context.test.ts
@@ -144,6 +144,7 @@ const CALLBACK_KEYS = [
   'dungeonDifficulty',
   'setDungeonDifficulty',
   'awardHeroicMarks',
+  'grantHeroicKillLockout',
   // M3 mob-swing affix cascade surface.
   'effectiveArmor',
   'recalcPlayer',
@@ -352,6 +353,7 @@ function makeFakeHost() {
     dungeonDifficulty: vi.fn(() => 'normal' as const),
     setDungeonDifficulty: vi.fn(),
     awardHeroicMarks: vi.fn(),
+    grantHeroicKillLockout: vi.fn(),
     addEntity: vi.fn(),
     dropEntity: vi.fn(),
     rebucket: vi.fn(),


### PR DESCRIPTION
## Summary

Closes the heroic re-run abuse reported on Discord ("if someone doesn't loot the boss gem, the whole party can re-enter"). The unlooted gem was a correlate, not the cause: the daily lockout was already granted on the kill, but only to party members within 80yd of the corpse, and the five-man door only lockout-checked the player claiming a FRESH instance. One unlocked member (a door camper, an early-released ghost, or a freshly recruited player) could claim a new heroic instance and the whole locked party walked in behind them for another set of heroic epics. The Nythraxis raid had the same range hole (260yd room radius). Verified byte-identical on the deployed PBE SHA (bfc229787).

## Changes

- New grantHeroicKillLockout (src/sim/instances/dungeons.ts), called unconditionally from the death hub beside grantNythraxisLockout: a heroic claim's final-boss kill locks every CURRENT member of the owning group (wherever they stand, even never zoned in) plus any player physically inside the instance, credit or no credit. The lockout no longer rides awardHeroicMarks; marks stay participation-gated.
- grantNythraxisLockout (src/sim/encounters/nythraxis.ts) now locks the whole owning raid group via the same instanceLockoutMetas sweep, both difficulties; the old room-radius rule survives only as a no-claim fallback.
- New enterDungeon door gate: a locked player may enter a LIVE heroic claim only when its final boss is already down, so corpse-runs and loot retrieval into a cleared run still work but a locked party can no longer ride an unlocked recruit into a fresh run. Reuses the existing locked error string, no new i18n keys.
- Extracted instanceContains (the shared 120/250 instance footprint envelope) and wired the new SimContext callback (declaration, host passthrough, late-bound arrow, fake-ctx updates).

## Test plan

- [x] RED first: 4 new five-man tests + 1 raid test reproduced the abuse before the fix (camper not locked, party-leaver not locked, recruit ferry allowed, raid fills not locked)
- [x] Whole-party lock including a never-entered member, with the marks-stay-participation-gated pin
- [x] Left-party-but-still-inside member locked (position arm)
- [x] Locked party cannot ride an unlocked recruit's fresh claim (door gate, exact error string pinned)
- [x] Locked player still re-enters the CLEARED live claim (corpse-run / loot pin)
- [x] Uncredited final-boss death still locks the owning party (no marks, no credit)
- [x] Normal final-boss and heroic trash kills lock nobody; :heroic key never leaks onto the plain key
- [x] Whole-raid lock with exact reset timestamp, fills asserted outside the arena
- [x] npm run gate green on the final diff (all 9 steps); parity goldens unchanged (lockout paths draw no rng)
- [x] Reviewed by architecture-reviewer, test-coverage-auditor, cross-platform-sync and qa-checklist agents: zero blocking findings, all coverage gaps closed

## Notes for deploy

- PBE runs release/v0.24.0-ptr: this fix must be merged or cherry-picked there to stop the live abuse.
- Accepted residual: a member fully OFFLINE at kill time cannot be personally locked (no live session), but the door gate keeps the locked rest of the party out, so it degrades to a legitimate fresh run rather than a ferry.
- Benign redundancy: a heroic Nythraxis kill writes the same lockout key through both granters (idempotent, same value).