### PR TITLE
feat(sim): emit a gather-success SimEvent for audio hooks (#1729)

### DIFF
--- a/src/sim/professions/gathering.ts
+++ b/src/sim/professions/gathering.ts
@@ -231,6 +231,20 @@ export function harvestNode(ctx: SimContext, nodeId: string, pid?: number): void
     return;
   }
   ctx.addItem(result.itemId!, 1, meta.entityId);
+  // Personal gather-success cue (#1729, part 1): text-free structured event the
+  // client can hook a gather SFX onto. Carries `pid` (the harvesting player's
+  // own entity id) so it stays personal, never proximity-broadcast, and the
+  // rolled rarity from resolveHarvest. Additive read only: it consumes no rng
+  // (the one rarity draw already happened inside resolveHarvest above) and does
+  // not change the tick phase or draw order.
+  ctx.emit({
+    type: 'gatherResult',
+    pid: meta.entityId,
+    professionId: entry.professionId,
+    nodeId: node.id,
+    itemId: entry.itemId,
+    rarity: result.rarity!,
+  });
   // Resolved against the timer/bags gates above, before the timer-consuming
   // resolveHarvest call, so a full-bags quest item never eats the node's
   // per-player respawn timer on its own.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -2426,6 +2426,20 @@ export type SimEvent = { pid?: number } & (
         | 'throttled'
         | 'not_at_hub';
     }
+  // Successful gathering-node harvest (#1729, part 1): a personal (carries `pid`)
+  // one-shot cue the client can hook a gather SFX onto, mirroring skinEvent/
+  // craftResult. Text-free on purpose: the client renders any copy off the
+  // structured fields, so no sim/server i18n matcher rule is needed. Carries the
+  // harvesting profession, the node and material granted, and the rolled material
+  // rarity (so a fancier cue can react to a rare-or-better haul). Emitted only on a
+  // granted harvest; a denied/blocked harvest emits nothing.
+  | {
+      type: 'gatherResult';
+      professionId: GatheringProfessionId;
+      nodeId: string;
+      itemId: string;
+      rarity: Exclude<NonNullable<ItemDef['quality']>, 'poor'>;
+    }
 );
 
 export interface MoveInput {

--- a/tests/gather_node_harvest.test.ts
+++ b/tests/gather_node_harvest.test.ts
@@ -235,6 +235,54 @@ describe('gather node harvest (#1121)', () => {
     expect(sim.nodeHarvestableByMeFor(NODE_ID, pid)).toBe(true);
   });
 
+  it('a granted harvest emits exactly one personal gatherResult carrying pid, profession, node, and a valid rarity (#1729)', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Harvester');
+    // A second player, standing on the same node, who never harvests: proves the
+    // emitted event is delivered personally (carries the harvesting player's pid),
+    // not proximity-broadcast to everyone near the node.
+    const bystanderPid = sim.addPlayer('warrior', 'Bystander');
+    teleportOntoNode(sim, pid, NODE_ID);
+    teleportOntoNode(sim, bystanderPid, NODE_ID);
+
+    const node = mustNode(NODE_ID);
+    const entry = NODE_HARVEST_TABLE[node.type];
+
+    sim.harvestNode(NODE_ID, pid);
+    const events = sim.tick();
+    const gatherResults = events.filter((e) => e.type === 'gatherResult');
+    expect(gatherResults).toHaveLength(1);
+    const ev = gatherResults[0];
+    // Personal: the event's pid is the harvesting player's own entity id, never
+    // the bystander's and never absent (an absent pid would broadcast it).
+    expect(ev.pid).toBe(pid);
+    expect(ev.pid).not.toBe(bystanderPid);
+    expect(ev.professionId).toBe(entry.professionId);
+    expect(ev.nodeId).toBe(NODE_ID);
+    expect(ev.itemId).toBe(entry.itemId);
+    // Rarity is one of the material ladder tiers (poor is excluded from harvests).
+    expect(['common', 'uncommon', 'rare', 'epic', 'legendary']).toContain(ev.rarity);
+  });
+
+  it('a denied/blocked harvest emits no gatherResult (#1729)', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Blocked');
+    teleportOntoNode(sim, pid, NODE_ID);
+
+    // First harvest succeeds and emits the event.
+    sim.harvestNode(NODE_ID, pid);
+    expect(sim.tick().filter((e) => e.type === 'gatherResult')).toHaveLength(1);
+
+    // Immediately harvesting again is denied (this player's own timer has not
+    // elapsed): no gatherResult is emitted on the denial path.
+    sim.harvestNode(NODE_ID, pid);
+    expect(sim.tick().filter((e) => e.type === 'gatherResult')).toHaveLength(0);
+
+    // An unknown node id is likewise denied with no event.
+    sim.harvestNode('not_a_real_node', pid);
+    expect(sim.tick().filter((e) => e.type === 'gatherResult')).toHaveLength(0);
+  });
+
   it('spends exactly one rng draw on a granted harvest and none on any denial path', () => {
     const sim = makeWorld();
     const pid = sim.addPlayer('warrior', 'DrawCount');


### PR DESCRIPTION
## Summary

Part 1 of #1729: emit a `SimEvent` on a successful gathering-node harvest so the client has something to hook a gather SFX onto. This is the sim-side prerequisite the audio work is blocked on; the recorded clips, manifest entries, and `hud.ts` wiring (parts 2 and 3 of the issue) are a separate follow-up and are not in this PR.

Crafting already emits a structured `craftResult` event (craft-complete and craft-rare are derivable from its `ok`/`quality` fields), so the only gap was gathering, whose `harvestNode` granted the item but emitted nothing on success. This adds a new text-free, personal `gatherResult` event mirroring the `skinEvent`/`craftResult` precedent.

Design notes:
- Text-free and structured (carries `professionId`, `nodeId`, `itemId`, `rarity`), so the client renders any copy off the fields and no sim/server i18n matcher rule is needed.
- Personal: it carries the harvesting player's `pid`, so the server routes it only to that player (never proximity-broadcast), matching a self audio cue.
- Additive read only: it consumes no `Rng` (the single rarity draw already happened in `resolveHarvest`) and does not change the tick phase or event draw order.
- No wire/snapshot field, no read-surface mirror, no `HEAVY_SELF_EVENTS` entry: the co-emitted `loot` event already refreshes the bags. Client consumers are non-exhaustive switches, so the unhandled variant is a safe no-op until the audio wiring lands.

## Related issues

Part of #1729 (part 1: the SimEvent prerequisite).

## Type of change

- [x] Feature: new functionality

## How was this tested?

- Commands: `npx tsc --noEmit`; `npx vitest run tests/gather_node_harvest.test.ts tests/architecture.test.ts tests/world_api_parity.test.ts tests/parity/parity.test.ts tests/snapshots.test.ts tests/localization_fixes.test.ts` (all green; parity/snapshot goldens unaffected since the event is additive and text-free).
- New tests (`tests/gather_node_harvest.test.ts`): a granted harvest emits exactly one `gatherResult` with `pid === harvester` (and `!== bystander`, proving it is personal not broadcast) plus the correct `professionId`/`nodeId`/`itemId` and a valid non-poor rarity; denied paths (timer not elapsed, unknown node) emit zero `gatherResult`.
- Determinism: verified no new `Rng` draw and no tick-phase/draw-order change.

## Screenshots / recordings

N/A (no visual change; this is a sim-side event hook).
