### PR TITLE
Feature/sfx mob family fallback

### DIFF
--- a/scripts/sfx/sfx_manifest_builder.d.mts
+++ b/scripts/sfx/sfx_manifest_builder.d.mts
@@ -1,3 +1,5 @@
+export declare const MOB_ACTIONS: Set<string>;
+
 export interface CatalogEntry {
   key: string;
   loop?: boolean;

--- a/scripts/sfx/sfx_manifest_builder.mjs
+++ b/scripts/sfx/sfx_manifest_builder.mjs
@@ -10,7 +10,7 @@ import path from 'node:path';
 // manifest rebuild without being silently dropped.
 const PROBE_EXTS = ['.mp3', '.wav', '.flac', '.ogg'];
 
-// Valid mob vocalization actions — anchor for parsing subfamily filenames.
+// Valid mob vocalization actions, anchor for parsing subfamily filenames.
 // mob_beast_wolf_aggro_1.mp3 -> family=beast, subfamily=wolf, action=aggro, variant=1
 // mob_beast_aggro_1.mp3      -> family=beast, action=aggro, variant=1 (family-level)
 export const MOB_ACTIONS = new Set(['aggro', 'attack', 'death', 'hurt']);

--- a/scripts/sfx/sfx_manifest_builder.mjs
+++ b/scripts/sfx/sfx_manifest_builder.mjs
@@ -1,7 +1,7 @@
 // Manifest builder extracted from gen_sfx.mjs so it can be imported by tests
 // without triggering gen_sfx.mjs's top-level API-key / process.exit logic.
 
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 // Preference order when probing a bare key (no numbered variants).
@@ -9,6 +9,11 @@ import path from 'node:path';
 // every other extension; WAV/FLAC next so custom lossless recordings survive a
 // manifest rebuild without being silently dropped.
 const PROBE_EXTS = ['.mp3', '.wav', '.flac', '.ogg'];
+
+// Valid mob vocalization actions — anchor for parsing subfamily filenames.
+// mob_beast_wolf_aggro_1.mp3 -> family=beast, subfamily=wolf, action=aggro, variant=1
+// mob_beast_aggro_1.mp3      -> family=beast, action=aggro, variant=1 (family-level)
+export const MOB_ACTIONS = new Set(['aggro', 'attack', 'death', 'hurt']);
 
 /**
  * Rebuild the SFX manifest from the files actually on disk.
@@ -49,6 +54,44 @@ export function buildManifest(catalog, sfxDir, manifestPath) {
 
     if (urls.length > 0) entries[entry.key] = { urls, loop: !!entry.loop };
   }
+
+  // Scan for mob subfamily variant files not in the catalog.
+  // Pattern: mob_<family>_<sub>_<action>_<N>.mp3 where action is in MOB_ACTIONS.
+  // The action token anchors the parse; everything between family and action is
+  // the subfamily (per-creature subtype, e.g. wolf, bear, ghoul).
+  const mobFiles = existsSync(sfxDir)
+    ? readdirSync(sfxDir).filter((f) => f.startsWith('mob_') && f.endsWith('.mp3'))
+    : [];
+  for (const file of mobFiles) {
+    const stem = file.slice(0, -4); // strip .mp3
+    const parts = stem.split('_');
+    // Minimum shape: mob + family + sub + action + N (5 parts)
+    if (parts.length < 5 || !/^\d+$/.test(parts[parts.length - 1])) continue;
+    const family = parts[1];
+    const body = parts.slice(2, -1); // tokens between family and variant number
+    // Scan body right-to-left for the action token.
+    let actionIdx = -1;
+    for (let i = body.length - 1; i >= 0; i--) {
+      if (MOB_ACTIONS.has(body[i])) {
+        actionIdx = i;
+        break;
+      }
+    }
+    if (actionIdx === -1) {
+      errors.push(`invalid mob sfx filename (no recognized action): ${file}`);
+      continue;
+    }
+    const subParts = body.slice(0, actionIdx);
+    if (subParts.length === 0) continue; // family-level variant, already handled by catalog loop
+    const action = body[actionIdx];
+    const sub = subParts.join('_');
+    const key = `mob_${family}_${sub}_${action}`;
+    if (!entries[key]) entries[key] = { urls: [], loop: false };
+    entries[key].urls.push(`/audio/sfx/${file}`);
+  }
+
+  // Sort variant URLs within each entry for deterministic ordering.
+  for (const entry of Object.values(entries)) entry.urls.sort();
 
   const sorted = Object.fromEntries(
     Object.keys(entries)

--- a/src/game/sfx.ts
+++ b/src/game/sfx.ts
@@ -226,6 +226,13 @@ class Sfx {
     return pool[idx];
   }
 
+  /** True if at least one variant is loaded for this key. Used by hud.ts to
+   *  prefer a subfamily key (mob_beast_wolf_attack) over the family fallback
+   *  (mob_beast_attack) when the more specific clip exists. */
+  hasVariants(key: string): boolean {
+    return (this.variants.get(key)?.length ?? 0) > 0;
+  }
+
   /** Squared distance from the listener — callers can pre-cull, but playAt also
    *  guards internally so a far event is a cheap no-op. */
   private tooFar(x: number, z: number): boolean {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -780,6 +780,15 @@ function mobVoiceFamily(templateId: string): string | null {
   return fam && SFX_MOB_FAMILIES.has(fam) ? fam : null;
 }
 
+/** Most-specific SFX key for a mob action. Prefers the subfamily key
+ *  (mob_beast_wolf_attack) when that clip is loaded; falls back to the
+ *  family key (mob_beast_attack) otherwise. Resolved at runtime so new
+ *  creature-specific files just need a manifest rebuild — no code change. */
+function mobSfxKey(fam: string, templateId: string, action: string): string {
+  const subKey = `mob_${fam}_${templateId}_${action}`;
+  return sfx.hasVariants(subKey) ? subKey : `mob_${fam}_${action}`;
+}
+
 /** Sustained cast-loop clip for an ability's school, or null (physical/unknown). */
 function castKeyForAbility(ability: string): string | null {
   // Per-ability custom cast loop overrides (a player-provided clip that fits the
@@ -8315,7 +8324,7 @@ export class Hud {
         } else if (ev.crit && tgt.kind === 'mob' && shouldPlayCritSfxForTarget(tgt)) {
           const fam = mobVoiceFamily(tgt.templateId);
           if (fam && shouldPlayMobVoiceSfxForEntity(tgt))
-            this.combat(`mob_${fam}_attack`, tp.x, tp.y, tp.z, 0.6, { rate: 1.25, cooldown: 0.1 });
+            this.combat(mobSfxKey(fam, tgt.templateId, 'attack'), tp.x, tp.y, tp.z, 0.6, { rate: 1.25, cooldown: 0.1 });
         }
         return;
       }
@@ -8367,7 +8376,7 @@ export class Hud {
           this.mobAggroed.delete(ev.entityId);
           const fam = mobVoiceFamily(ent.templateId);
           if (fam && shouldPlayMobVoiceSfxForEntity(ent))
-            this.combat(`mob_${fam}_death`, p.x, p.y, p.z, 0.8);
+            this.combat(mobSfxKey(fam, ent.templateId, 'death'), p.x, p.y, p.z, 0.8);
         } else if (ent.kind === 'player' && ev.entityId !== sim.playerId) {
           this.combat('player_death', p.x, p.y, p.z, 0.7);
         }
@@ -8384,7 +8393,7 @@ export class Hud {
     this.mobAggroed.add(mob.id);
     const fam = mobVoiceFamily(mob.templateId);
     if (fam && shouldPlayMobVoiceSfxForEntity(mob))
-      this.combat(`mob_${fam}_aggro`, mob.pos.x, mob.pos.y, mob.pos.z, 0.7);
+      this.combat(mobSfxKey(fam, mob.templateId, 'aggro'), mob.pos.x, mob.pos.y, mob.pos.z, 0.7);
     return true;
   }
 
@@ -8395,7 +8404,7 @@ export class Hud {
       if (this.ensureMobEngaged(src)) return; // just fired the aggro alert
       const fam = mobVoiceFamily(src.templateId);
       if (fam && shouldPlayMobVoiceSfxForEntity(src))
-        this.combat(`mob_${fam}_attack`, src.pos.x, src.pos.y, src.pos.z, 0.55, { cooldown: 0.25 });
+        this.combat(mobSfxKey(fam, src.templateId, 'attack'), src.pos.x, src.pos.y, src.pos.z, 0.55, { cooldown: 0.25 });
     } else if (src.kind === 'player') {
       this.combat(weaponSwingKey(src.templateId), src.pos.x, src.pos.y, src.pos.z, 0.5, {
         cooldown: 0.08,

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -783,7 +783,7 @@ function mobVoiceFamily(templateId: string): string | null {
 /** Most-specific SFX key for a mob action. Prefers the subfamily key
  *  (mob_beast_wolf_attack) when that clip is loaded; falls back to the
  *  family key (mob_beast_attack) otherwise. Resolved at runtime so new
- *  creature-specific files just need a manifest rebuild — no code change. */
+ *  creature-specific files just need a manifest rebuild, no code change. */
 function mobSfxKey(fam: string, templateId: string, action: string): string {
   const subKey = `mob_${fam}_${templateId}_${action}`;
   return sfx.hasVariants(subKey) ? subKey : `mob_${fam}_${action}`;

--- a/tests/sfx.test.ts
+++ b/tests/sfx.test.ts
@@ -124,6 +124,37 @@ describe('footstep audio', () => {
   });
 });
 
+// hasVariants() is the predicate that drives mobSfxKey() in hud.ts:
+// mob_${fam}_${templateId}_${action} is preferred when hasVariants() returns
+// true, otherwise the family-level key mob_${fam}_${action} is used.
+describe('hasVariants', () => {
+  it('returns false for an unloaded key', () => {
+    expect(sfx.hasVariants('mob_beast_wolf_attack')).toBe(false);
+  });
+
+  it('returns true once a pool is injected for the key', () => {
+    (sfx as unknown as { variants: Map<string, { duration: number }[]> }).variants.set(
+      'mob_beast_wolf_attack',
+      [{ duration: 0.8 }],
+    );
+    expect(sfx.hasVariants('mob_beast_wolf_attack')).toBe(true);
+  });
+
+  it('subfamily key true + family key absent models the preferred-then-fallback flow', () => {
+    // When subfamily clips are deployed, hasVariants(subKey) is true and
+    // mobSfxKey returns the subfamily key.  Before deployment, hasVariants
+    // returns false and mobSfxKey falls back to the family key.
+    const subKey = 'mob_beast_bear_attack'; // distinct key so prior tests don't leak
+    const famKey = 'mob_beast_attack';
+    const variants = (sfx as unknown as { variants: Map<string, { duration: number }[]> }).variants;
+    variants.delete(subKey);
+    expect(sfx.hasVariants(subKey)).toBe(false); // no variants loaded yet
+    variants.set(subKey, [{ duration: 0.8 }]);
+    expect(sfx.hasVariants(subKey)).toBe(true);
+    expect(sfx.hasVariants(famKey)).toBe(false); // family key unrelated
+  });
+});
+
 // No-repeat random: the variant selection algorithm must never repeat the last
 // index back-to-back and must include every index on first play.
 describe('variant selection (nextBuffer)', () => {

--- a/tests/sfx_manifest.test.ts
+++ b/tests/sfx_manifest.test.ts
@@ -129,7 +129,7 @@ describe('mob subfamily scanning', () => {
     expect(errors[0]).toContain('mob_beast_wolf_bogus_1.mp3');
   });
 
-  it('skips family-level mob files (fewer than 5 parts) — covered by catalog loop', () => {
+  it('skips family-level mob files (fewer than 5 parts), covered by catalog loop', () => {
     // mob_beast_attack_1.mp3 has only 4 parts: mob + beast + attack + 1
     writeFileSync(path.join(sfxDir, 'mob_beast_attack_1.mp3'), '');
     const catalog = [{ key: 'mob_beast_attack' }];

--- a/tests/sfx_manifest.test.ts
+++ b/tests/sfx_manifest.test.ts
@@ -8,7 +8,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { buildManifest } from '../scripts/sfx/sfx_manifest_builder.mjs';
+import { buildManifest, MOB_ACTIONS } from '../scripts/sfx/sfx_manifest_builder.mjs';
 import { SFX } from '../scripts/sfx/sfx_prompts.mjs';
 
 const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -86,5 +86,69 @@ describe('buildManifest', () => {
     expect(count).toBeGreaterThan(0);
     const manifest = readFileSync(manifestPath, 'utf8');
     expect(manifest).toContain('cast_lightning_bolt');
+  });
+});
+
+// Mob subfamily file scanning: mob_<family>_<sub>_<action>_N.mp3 on disk gets
+// added under the key mob_<family>_<sub>_<action> so hud.ts can prefer it over
+// the family-level fallback via sfx.hasVariants().
+describe('mob subfamily scanning', () => {
+  it('adds a subfamily key from mob_<family>_<sub>_<action>_N.mp3', () => {
+    writeFileSync(path.join(sfxDir, 'mob_beast_wolf_attack_1.mp3'), '');
+    const { count } = buildManifest([], sfxDir, manifestPath);
+    expect(count).toBe(1);
+    const data = JSON.parse(
+      readFileSync(manifestPath, 'utf8')
+        .split('=\n')[1]
+        .replace(/ as const;/, ''),
+    );
+    expect(data.mob_beast_wolf_attack).toBeDefined();
+    expect(data.mob_beast_wolf_attack.urls).toEqual(['/audio/sfx/mob_beast_wolf_attack_1.mp3']);
+  });
+
+  it('groups multiple numbered variants under the same subfamily key (sorted)', () => {
+    writeFileSync(path.join(sfxDir, 'mob_beast_wolf_attack_2.mp3'), '');
+    writeFileSync(path.join(sfxDir, 'mob_beast_wolf_attack_1.mp3'), '');
+    buildManifest([], sfxDir, manifestPath);
+    const data = JSON.parse(
+      readFileSync(manifestPath, 'utf8')
+        .split('=\n')[1]
+        .replace(/ as const;/, ''),
+    );
+    expect(data.mob_beast_wolf_attack.urls).toEqual([
+      '/audio/sfx/mob_beast_wolf_attack_1.mp3',
+      '/audio/sfx/mob_beast_wolf_attack_2.mp3',
+    ]);
+  });
+
+  it('reports an error and sets errors[] for an unrecognized action token', () => {
+    writeFileSync(path.join(sfxDir, 'mob_beast_wolf_bogus_1.mp3'), '');
+    const { count, errors } = buildManifest([], sfxDir, manifestPath);
+    expect(count).toBe(0); // bogus file produces no valid key
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain('mob_beast_wolf_bogus_1.mp3');
+  });
+
+  it('skips family-level mob files (fewer than 5 parts) — covered by catalog loop', () => {
+    // mob_beast_attack_1.mp3 has only 4 parts: mob + beast + attack + 1
+    writeFileSync(path.join(sfxDir, 'mob_beast_attack_1.mp3'), '');
+    const catalog = [{ key: 'mob_beast_attack' }];
+    const { count } = buildManifest(catalog, sfxDir, manifestPath);
+    // The catalog loop picks it up; the mob scanner does not add a duplicate.
+    const data = JSON.parse(
+      readFileSync(manifestPath, 'utf8')
+        .split('=\n')[1]
+        .replace(/ as const;/, ''),
+    );
+    expect(count).toBe(1);
+    expect(Object.keys(data)).toEqual(['mob_beast_attack']);
+  });
+
+  it('MOB_ACTIONS covers the four expected vocalization types', () => {
+    expect(MOB_ACTIONS.has('aggro')).toBe(true);
+    expect(MOB_ACTIONS.has('attack')).toBe(true);
+    expect(MOB_ACTIONS.has('death')).toBe(true);
+    expect(MOB_ACTIONS.has('hurt')).toBe(true);
+    expect(MOB_ACTIONS.size).toBe(4);
   });
 });


### PR DESCRIPTION
Summary

Extends the SFX manifest pipeline and runtime to support per-creature vocalizations with automatic family fallback. Addresses the creature naming scalability concern from #1729.

The problem: Every beast-family mob (wolves, bears, lions) currently shares the same family-level clip (mob_beast_attack). As the creature roster grows, distinct animals need distinct sounds without requiring new code wiring for each one.

How it works:

Contributors drop correctly named files and rebuild the manifest — that's it:

mob_beast_wolf_aggro_1.mp3
mob_beast_wolf_attack_1.mp3
mob_beast_bear_attack_1.mp3

- gen_sfx.mjs scans for mob_<family>_<sub>_<action>_<N>.mp3, groups variants under the subfamily key, and validates action names (aggro/attack/death/hurt). Invalid filenames produce a build error rather than being silently ignored.
- sfx.ts gains hasVariants() so the runtime can check if a specific key is loaded.
- hud.ts gains mobSfxKey() which prefers the creature-specific clip when loaded, falling back to the family key otherwise. All four mob vocalization call sites (aggro, attack on swing, attack on crit, death) use it.

Right now: No subfamily files exist, so hasVariants() returns false everywhere and every mob plays exactly as before. The new code path is inert until files are added.

Related issues

Part of #1729. Depends on #1771.

Type of change

- [x] Feature: new functionality
- [x] Build, CI, or tooling

How was this tested?

- Commands: npx tsc --noEmit (clean), filename parsing logic validated with a Node test
- Manual steps: N/A — no subfamily files on disk, existing mob sounds unchanged

Screenshots / recordings

N/A — no visual change.

---
Checklist

Quality

- [ ] Tests pass. npm test is green.
- [ ] Typecheck passes. npx tsc --noEmit is clean.
- [ ] Builds succeed. npm run build

Cross-platform

- ~Tested on desktop and mobile.~ N/A
- ~Accessible.~ N/A

Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

Hygiene

- [x] No secrets or .env committed.
- [x] No generated files hand-edited.