### PR TITLE
fix(ui): reset saved unit-frame positions once for the v0.24.1 revert

### DIFF
--- a/src/ui/frame_pos_reset.ts
+++ b/src/ui/frame_pos_reset.ts
@@ -1,0 +1,38 @@
+// One-time client-side reset of the persisted unit-frame drag positions.
+// v0.24.0 shipped the PR #1736 interface overhaul for about a day before
+// v0.24.1 reverted it; frame positions dragged against the overhaul layout
+// replay verbatim against the restored classic layout, leaving the player
+// frame detached in a stale spot. The stored {left,top} carries no version or
+// timestamp, so a targeted clear is impossible: v0.24.1 therefore clears BOTH
+// unit-frame position keys once per client, keyed by an epoch marker. Bump
+// LAYOUT_RESET_EPOCH if another forced layout reset is ever needed.
+
+export const LAYOUT_RESET_EPOCH = 1;
+export const LAYOUT_RESET_EPOCH_KEY = 'woc_layout_reset_epoch';
+// The MovableFrame storage keys hud.ts wires up; hud.ts imports these so the
+// reset and the movers can never drift apart.
+export const PLAYER_FRAME_POS_KEY = 'woc_player_frame_pos';
+export const TARGET_FRAME_POS_KEY = 'woc_target_frame_pos';
+export const FRAME_POS_RESET_KEYS = [PLAYER_FRAME_POS_KEY, TARGET_FRAME_POS_KEY] as const;
+
+// The subset of Storage the reset touches, so tests can pass a plain fake.
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+/** Clear the saved unit-frame positions once per client (per epoch) and stamp
+ *  the marker. Returns true when this call performed the reset. Must run
+ *  BEFORE the MovableFrames construct, since they apply a saved position (and
+ *  detach the player frame) in their constructors. Storage failures are
+ *  swallowed like MovableFrame's own: a client without storage never had a
+ *  saved position to clear. A corrupt marker counts as unseen (reset once,
+ *  marker repaired); a future epoch never re-clears on a downgrade. */
+export function resetFramePositionsOnce(storage: StorageLike): boolean {
+  try {
+    const seen = Number(storage.getItem(LAYOUT_RESET_EPOCH_KEY) ?? '0');
+    if (Number.isFinite(seen) && seen >= LAYOUT_RESET_EPOCH) return false;
+    for (const key of FRAME_POS_RESET_KEYS) storage.removeItem(key);
+    storage.setItem(LAYOUT_RESET_EPOCH_KEY, String(LAYOUT_RESET_EPOCH));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -210,6 +210,11 @@ import { fctSpawnShape } from './fct_event';
 import { FctPainter } from './fct_painter';
 import { FocusManager, type FocusTrapHandle } from './focus_manager';
 import {
+  PLAYER_FRAME_POS_KEY,
+  resetFramePositionsOnce,
+  TARGET_FRAME_POS_KEY,
+} from './frame_pos_reset';
+import {
   type AimPoint,
   abilityAoeRadius,
   cancelGroundAim,
@@ -694,9 +699,9 @@ const CHAT_GEOMETRY_KEY = 'woc_chat_geometry';
 // bottom resize handle. CSS clamps it to a valid range for the live viewport, so a value
 // saved in one orientation stays safe in another (never an off-screen / tiny panel).
 const MOBILE_CHAT_BOTTOM_KEY = 'woc_mobile_chat_bottom';
-// Persisted top-left for each movable unit frame (MovableFrame in movable_frame.ts).
-const TARGET_FRAME_POS_KEY = 'woc_target_frame_pos';
-const PLAYER_FRAME_POS_KEY = 'woc_player_frame_pos';
+// The persisted top-left keys for the movable unit frames live in
+// frame_pos_reset.ts (imported above) so the one-time reset clears the same
+// keys the MovableFrames read.
 const CHAT_TEMPLATE_KEYS = {
   party: 'hud.chat.templates.party',
   yell: 'hud.chat.templates.yell',
@@ -2567,6 +2572,10 @@ export class Hud {
   // -------------------------------------------------------------------------
 
   private initFrameMovers(): void {
+    // One-time v0.24.1 cleanup: drop frame drags saved against the reverted
+    // PR #1736 overhaul layout BEFORE the movers read them back (a saved
+    // position applies, and detaches the player frame, at construction).
+    resetFramePositionsOnce(localStorage);
     const isMobileLayout = () => this.isMobileLayout();
     // A live desktop-to-mobile viewport flip must re-home the anchored aura
     // bars (mobile owns its own aura placement), and the flip back re-anchors.

--- a/tests/frame_pos_reset.test.ts
+++ b/tests/frame_pos_reset.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  FRAME_POS_RESET_KEYS,
+  LAYOUT_RESET_EPOCH,
+  LAYOUT_RESET_EPOCH_KEY,
+  resetFramePositionsOnce,
+} from '../src/ui/frame_pos_reset';
+
+// Minimal Storage stand-in backed by a Map; the module only needs get/set/remove.
+function fakeStorage(seed: Record<string, string> = {}) {
+  const map = new Map<string, string>(Object.entries(seed));
+  return {
+    map,
+    getItem: (key: string) => map.get(key) ?? null,
+    setItem: (key: string, value: string) => void map.set(key, value),
+    removeItem: (key: string) => void map.delete(key),
+  };
+}
+
+describe('resetFramePositionsOnce', () => {
+  it('pins the storage keys the v0.24.1 reset clears', () => {
+    // Load-bearing wire tokens: these must match the MovableFrame keys in hud.ts.
+    expect(FRAME_POS_RESET_KEYS).toEqual(['woc_player_frame_pos', 'woc_target_frame_pos']);
+    expect(LAYOUT_RESET_EPOCH_KEY).toBe('woc_layout_reset_epoch');
+    expect(LAYOUT_RESET_EPOCH).toBe(1);
+  });
+
+  it('clears both frame positions and stamps the epoch on a first run', () => {
+    const storage = fakeStorage({
+      woc_player_frame_pos: '{"left":610,"top":190}',
+      woc_target_frame_pos: '{"left":40,"top":80}',
+    });
+    expect(resetFramePositionsOnce(storage)).toBe(true);
+    expect(storage.getItem('woc_player_frame_pos')).toBeNull();
+    expect(storage.getItem('woc_target_frame_pos')).toBeNull();
+    expect(storage.getItem(LAYOUT_RESET_EPOCH_KEY)).toBe(String(LAYOUT_RESET_EPOCH));
+  });
+
+  it('runs the reset even when no positions are saved (still stamps the epoch)', () => {
+    const storage = fakeStorage();
+    expect(resetFramePositionsOnce(storage)).toBe(true);
+    expect(storage.getItem(LAYOUT_RESET_EPOCH_KEY)).toBe(String(LAYOUT_RESET_EPOCH));
+  });
+
+  it('is a no-op on the second run: positions re-saved after the reset survive', () => {
+    const storage = fakeStorage();
+    resetFramePositionsOnce(storage);
+    storage.setItem('woc_player_frame_pos', '{"left":100,"top":100}');
+    expect(resetFramePositionsOnce(storage)).toBe(false);
+    expect(storage.getItem('woc_player_frame_pos')).toBe('{"left":100,"top":100}');
+  });
+
+  it('re-runs when the stored epoch is older than the current one', () => {
+    const storage = fakeStorage({
+      [LAYOUT_RESET_EPOCH_KEY]: '0',
+      woc_player_frame_pos: '{"left":610,"top":190}',
+    });
+    expect(resetFramePositionsOnce(storage)).toBe(true);
+    expect(storage.getItem('woc_player_frame_pos')).toBeNull();
+  });
+
+  it('treats a corrupt epoch marker as unseen, resets once, and repairs the marker', () => {
+    const storage = fakeStorage({
+      [LAYOUT_RESET_EPOCH_KEY]: 'garbage',
+      woc_player_frame_pos: '{"left":610,"top":190}',
+    });
+    expect(resetFramePositionsOnce(storage)).toBe(true);
+    expect(storage.getItem('woc_player_frame_pos')).toBeNull();
+    expect(storage.getItem(LAYOUT_RESET_EPOCH_KEY)).toBe(String(LAYOUT_RESET_EPOCH));
+    expect(resetFramePositionsOnce(storage)).toBe(false);
+  });
+
+  it('does not re-run for a future epoch (a downgrade never re-clears)', () => {
+    const storage = fakeStorage({
+      [LAYOUT_RESET_EPOCH_KEY]: String(LAYOUT_RESET_EPOCH + 1),
+      woc_player_frame_pos: '{"left":610,"top":190}',
+    });
+    expect(resetFramePositionsOnce(storage)).toBe(false);
+    expect(storage.getItem('woc_player_frame_pos')).toBe('{"left":610,"top":190}');
+  });
+
+  it('runs before the movers construct in hud.ts (they apply a saved pos at construction)', () => {
+    // Source-order guard: moving the reset below the MovableFrame constructors
+    // (which read the keys and detach the player frame) silently reintroduces
+    // the stale-position replay this module exists to clear.
+    const hudSrc = readFileSync(new URL('../src/ui/hud.ts', import.meta.url), 'utf8');
+    const movers = hudSrc.slice(hudSrc.indexOf('private initFrameMovers('));
+    const resetAt = movers.indexOf('resetFramePositionsOnce(localStorage)');
+    const firstMoverAt = movers.indexOf('new MovableFrame(');
+    expect(resetAt).toBeGreaterThan(-1);
+    expect(firstMoverAt).toBeGreaterThan(-1);
+    expect(resetAt).toBeLessThan(firstMoverAt);
+  });
+
+  it('swallows storage failures and reports no reset', () => {
+    const storage = {
+      getItem: () => {
+        throw new Error('storage unavailable');
+      },
+      setItem: () => {
+        throw new Error('storage unavailable');
+      },
+      removeItem: () => {
+        throw new Error('storage unavailable');
+      },
+    };
+    expect(resetFramePositionsOnce(storage)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Rides along with the v0.24.1 revert of the PR #1736 interface overhaul: a one-time, client-side reset of the saved unit-frame drag positions.

Positions persisted under `woc_player_frame_pos` / `woc_target_frame_pos` while the overhaul was live (v0.24.0, about one day) replay verbatim against the restored classic layout: any saved value detaches the player frame from the action-bar stack at construction, so affected players see it floating in a stale spot (see the incident screenshot). The stored `{left, top}` carries no version or timestamp, so a targeted clear is impossible; per the maintainer's call, this clears both keys once for every client.

Mechanics:

- New `src/ui/frame_pos_reset.ts`: pure, storage-injected `resetFramePositionsOnce()`, gated by a `woc_layout_reset_epoch` marker (bump `LAYOUT_RESET_EPOCH` if another forced reset is ever needed). Corrupt marker resets once and repairs; a future epoch never re-clears on downgrade; storage failures are swallowed like the movers' own.
- `hud.ts` calls it at the top of `initFrameMovers`, before the `MovableFrame` constructors read the keys, and now imports the key constants from the new module so the reset and the movers cannot drift apart.
- Players re-drag frames after the reset as usual; re-saved positions survive (the marker is already stamped).

Follow-up issues filed from the same investigation: #1791 (UI Scale compensation missing in the frame/chat drag paths), #1792 (keybind profiles saved on v0.24.0 carry the overhaul's defaults).

Suggested v0.24.1 release-note line:

> The interface overhaul from v0.24.0 has been reverted. Custom player/target frame positions were reset to their stock spots as part of the rollout; re-drag them from the corner move button to taste. If Q/E stopped strafing or other keys changed during v0.24.0, reset your keybinds in Options.

## Test plan

- [x] `npx vitest run tests/frame_pos_reset.test.ts` (9/9: clear + stamp, empty-storage stamp, idempotent no-op, older-epoch re-run, corrupt-marker repair, downgrade guard, storage-throw swallow, key-literal pins, hud.ts ordering guard)
- [x] `npx vitest run tests/target_frame_pos.test.ts tests/movable_frame.test.ts` (unchanged, green)
- [x] `npm run gate` (all 9 steps green)
- [x] `npx tsc --noEmit` clean; biome clean on the changed files
- [x] qa-checklist review: READY, zero blocking findings; test-coverage audit: pins decisive, ordering guard added on its recommendation
