### PR TITLE
fix(ui): close tutorial-start dialogue when the Marshal has nothing left to offer

### DIFF
--- a/src/ui/gossip_menu.ts
+++ b/src/ui/gossip_menu.ts
@@ -1,0 +1,32 @@
+// Pure decision for the NPC gossip/quest dialog: does the menu still have
+// anything worth showing after a quest accept/turn-in?
+//
+// Bug fixed: talking to the tutorial-start NPC (the Marshal) and accepting or
+// turning in the starter quest left `#quest-dialog` sitting open with only the
+// greeting line and no buttons, because renderGossip() always re-renders the
+// same window after `acceptQuest`/`turnInQuest` regardless of whether the NPC
+// still has anything to offer. A fresh character only has that one quest, so
+// the menu goes empty and the window should close itself instead of hanging
+// around inert. NPCs with more content (other quests, a shop, a delve board,
+// ...) correctly keep the window open so the player can pick the next thing.
+export interface GossipMenuContent {
+  questCount: number; // offerable/turn-in-ready quests shown as list items
+  discussionCount: number; // in-progress "discuss" entries
+  hasVendor: boolean;
+  hasMarket: boolean;
+  hasHeroicVendor: boolean;
+  hasDelveBoard: boolean;
+  hasVcup: boolean;
+}
+
+export function gossipMenuIsEmpty(content: GossipMenuContent): boolean {
+  return (
+    content.questCount === 0 &&
+    content.discussionCount === 0 &&
+    !content.hasVendor &&
+    !content.hasMarket &&
+    !content.hasHeroicVendor &&
+    !content.hasDelveBoard &&
+    !content.hasVcup
+  );
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -211,6 +211,7 @@ import { esc } from './esc';
 import { fctSpawnShape } from './fct_event';
 import { FctPainter } from './fct_painter';
 import { FocusManager, type FocusTrapHandle } from './focus_manager';
+import { gossipMenuIsEmpty } from './gossip_menu';
 import {
   type AimPoint,
   abilityAoeRadius,
@@ -8324,7 +8325,10 @@ export class Hud {
         } else if (ev.crit && tgt.kind === 'mob' && shouldPlayCritSfxForTarget(tgt)) {
           const fam = mobVoiceFamily(tgt.templateId);
           if (fam && shouldPlayMobVoiceSfxForEntity(tgt))
-            this.combat(mobSfxKey(fam, tgt.templateId, 'attack'), tp.x, tp.y, tp.z, 0.6, { rate: 1.25, cooldown: 0.1 });
+            this.combat(mobSfxKey(fam, tgt.templateId, 'attack'), tp.x, tp.y, tp.z, 0.6, {
+              rate: 1.25,
+              cooldown: 0.1,
+            });
         }
         return;
       }
@@ -8404,7 +8408,14 @@ export class Hud {
       if (this.ensureMobEngaged(src)) return; // just fired the aggro alert
       const fam = mobVoiceFamily(src.templateId);
       if (fam && shouldPlayMobVoiceSfxForEntity(src))
-        this.combat(mobSfxKey(fam, src.templateId, 'attack'), src.pos.x, src.pos.y, src.pos.z, 0.55, { cooldown: 0.25 });
+        this.combat(
+          mobSfxKey(fam, src.templateId, 'attack'),
+          src.pos.x,
+          src.pos.y,
+          src.pos.z,
+          0.55,
+          { cooldown: 0.25 },
+        );
     } else if (src.kind === 'player') {
       this.combat(weaponSwingKey(src.templateId), src.pos.x, src.pos.y, src.pos.z, 0.5, {
         cooldown: 0.08,
@@ -10553,10 +10564,13 @@ export class Hud {
     this.renderGossip(npc);
   }
 
-  private renderGossip(npc: Entity): void {
-    this.openGossipNpcId = npc.id;
-    this.openQuestDetailId = null;
-    const el = $('#quest-dialog');
+  // closeIfEmpty is set only when re-rendering after an accept/turn-in click:
+  // a fresh NPC visit (or navigating Back) always shows the greeting even with
+  // an empty menu, but once the player has just resolved the one thing the NPC
+  // had to offer (the common case for a tutorial giver with a single starter
+  // quest), an empty menu means there is nothing left to do here and the
+  // window should close itself instead of hanging open with just the greeting.
+  private renderGossip(npc: Entity, closeIfEmpty = false): void {
     const def = NPCS[npc.templateId];
     // accepted-but-unfinished quests are tracked in the quest log; the NPC
     // only offers new quests (at the giver) and turn-ins (at the turn-in NPC)
@@ -10578,6 +10592,29 @@ export class Hud {
         ),
       )
       .map((qp) => qp.questId);
+    const hasVendor = npc.vendorItems.length > 0;
+    const hasMarket = !!def?.market;
+    const hasHeroicVendor = !!def?.heroicVendor;
+    const hasDelveBoard = Object.values(DELVES).some((d) => d.boardNpcId === npc.templateId);
+    const hasVcup = npc.templateId === 'groundskeeper_bram';
+    if (
+      closeIfEmpty &&
+      gossipMenuIsEmpty({
+        questCount: interesting.length,
+        discussionCount: discussionQuests.length,
+        hasVendor,
+        hasMarket,
+        hasHeroicVendor,
+        hasDelveBoard,
+        hasVcup,
+      })
+    ) {
+      this.closeQuestDialog();
+      return;
+    }
+    this.openGossipNpcId = npc.id;
+    this.openQuestDetailId = null;
+    const el = $('#quest-dialog');
     markDialogRoot(el, { labelledBy: 'quest-dialog-title' });
     const npcName = def ? npcDisplayName(npc.templateId) : mobDisplayName(npc.templateId);
     const npcTitle = def ? npcDisplayTitle(def.id) : '';
@@ -10602,16 +10639,16 @@ export class Hud {
         html += `<button type="button" class="qd-list-item" data-discuss="${esc(qid)}" aria-label="${esc(t('questUi.dialog.discussQuestAria', { name: title }))}"><span class="gold">?</span> ${esc(t('questUi.dialog.discussQuest', { name: title }))}</button>`;
       }
     }
-    if (npc.vendorItems.length > 0) {
+    if (hasVendor) {
       html += `<button type="button" class="qd-list-item" data-vendor="1" aria-label="${esc(t('questUi.dialog.browseGoodsAria', { name: npcName }))}"><span class="quest-complete">$</span> ${esc(t('questUi.dialog.browseGoods'))}</button>`;
     }
-    if (def?.market) {
+    if (hasMarket) {
       html += `<button type="button" class="qd-list-item" data-market="1" aria-label="${esc(t('questUi.dialog.worldMarketAria'))}"><span class="gold">${svgIcon('market')}</span> ${esc(t('questUi.dialog.worldMarket'))}</button>`;
     }
-    if (def?.heroicVendor) {
+    if (hasHeroicVendor) {
       html += `<button type="button" class="qd-list-item" data-heroic-shop="1" aria-label="${esc(t('questUi.dialog.browseGoodsAria', { name: npcName }))}"><span class="quest-complete">$</span> ${esc(t('questUi.dialog.browseGoods'))}</button>`;
     }
-    if (Object.values(DELVES).some((d) => d.boardNpcId === npc.templateId)) {
+    if (hasDelveBoard) {
       const delveForNpc = Object.values(DELVES).find((d) => d.boardNpcId === npc.templateId);
       const openLabel = delveForNpc
         ? delveDisplayName(delveForNpc.id)
@@ -10620,7 +10657,7 @@ export class Hud {
     }
     // Groundskeeper Bram keeps the book of fixtures at the Sowfield gate: his
     // gossip menu opens the Vale Cup window (the delve-board button precedent).
-    if (npc.templateId === 'groundskeeper_bram') {
+    if (hasVcup) {
       html += `<button type="button" class="qd-list-item" data-vcup="1" aria-label="${esc(t('hudChrome.vcup.gossipOpenAria'))}"><span class="gold">${svgIcon('ball')}</span> ${esc(t('hudChrome.vcup.gossipOpen'))}</button>`;
     }
     el.innerHTML = html;
@@ -10711,7 +10748,7 @@ export class Hud {
         this.sim.reportTelemetry('quest_accept', {
           timeMs: performance.now() - this.questDialogOpenedAtMs,
         });
-        this.renderGossip(npc);
+        this.renderGossip(npc, true);
       });
       el.appendChild(btn);
     } else if (state === 'ready') {
@@ -10724,7 +10761,7 @@ export class Hud {
         this.sim.reportTelemetry('quest_turnin', {
           timeMs: performance.now() - this.questDialogOpenedAtMs,
         });
-        this.renderGossip(npc);
+        this.renderGossip(npc, true);
       });
       el.appendChild(btn);
     }

--- a/tests/gossip_menu.test.ts
+++ b/tests/gossip_menu.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { gossipMenuIsEmpty } from '../src/ui/gossip_menu';
+
+// Reproduces the tutorial bug report: after accepting/turning in the starter
+// quest with the Marshal (the only content a fresh character's gossip menu
+// ever has), the dialog should recognize the menu is now empty so the caller
+// can close it, instead of leaving a dead greeting-only window on screen.
+describe('gossipMenuIsEmpty', () => {
+  it('is empty when the NPC has no quests, shop, or board left to offer', () => {
+    expect(
+      gossipMenuIsEmpty({
+        questCount: 0,
+        discussionCount: 0,
+        hasVendor: false,
+        hasMarket: false,
+        hasHeroicVendor: false,
+        hasDelveBoard: false,
+        hasVcup: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('the Marshal case: quest just accepted/turned in, nothing else offered', () => {
+    // Mirrors marshal_redbrook's gossip state for a brand-new tutorial
+    // character right after acceptQuest/turnInQuest('q_wolves'): the quest is
+    // no longer 'available'/'ready' so it drops out of the list, and none of
+    // the other menu sources apply.
+    expect(
+      gossipMenuIsEmpty({
+        questCount: 0,
+        discussionCount: 0,
+        hasVendor: false,
+        hasMarket: false,
+        hasHeroicVendor: false,
+        hasDelveBoard: false,
+        hasVcup: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('stays non-empty with another offerable quest', () => {
+    expect(
+      gossipMenuIsEmpty({
+        questCount: 1,
+        discussionCount: 0,
+        hasVendor: false,
+        hasMarket: false,
+        hasHeroicVendor: false,
+        hasDelveBoard: false,
+        hasVcup: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('stays non-empty with an in-progress discussion quest', () => {
+    expect(
+      gossipMenuIsEmpty({
+        questCount: 0,
+        discussionCount: 1,
+        hasVendor: false,
+        hasMarket: false,
+        hasHeroicVendor: false,
+        hasDelveBoard: false,
+        hasVcup: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('stays non-empty for a vendor, market, heroic vendor, delve board, or Vale Cup NPC', () => {
+    expect(
+      gossipMenuIsEmpty({
+        questCount: 0,
+        discussionCount: 0,
+        hasVendor: true,
+        hasMarket: false,
+        hasHeroicVendor: false,
+        hasDelveBoard: false,
+        hasVcup: false,
+      }),
+    ).toBe(false);
+    expect(
+      gossipMenuIsEmpty({
+        questCount: 0,
+        discussionCount: 0,
+        hasVendor: false,
+        hasMarket: true,
+        hasHeroicVendor: false,
+        hasDelveBoard: false,
+        hasVcup: false,
+      }),
+    ).toBe(false);
+    expect(
+      gossipMenuIsEmpty({
+        questCount: 0,
+        discussionCount: 0,
+        hasVendor: false,
+        hasMarket: false,
+        hasHeroicVendor: true,
+        hasDelveBoard: false,
+        hasVcup: false,
+      }),
+    ).toBe(false);
+    expect(
+      gossipMenuIsEmpty({
+        questCount: 0,
+        discussionCount: 0,
+        hasVendor: false,
+        hasMarket: false,
+        hasHeroicVendor: false,
+        hasDelveBoard: true,
+        hasVcup: false,
+      }),
+    ).toBe(false);
+    expect(
+      gossipMenuIsEmpty({
+        questCount: 0,
+        discussionCount: 0,
+        hasVendor: false,
+        hasMarket: false,
+        hasHeroicVendor: false,
+        hasDelveBoard: false,
+        hasVcup: true,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Talking to `marshal_redbrook` (the tutorial-start giver/turn-in NPC) and accepting or
turning in the starter quest (`q_wolves`) left `#quest-dialog` sitting open with
only the greeting line. `renderGossip()` always re-rendered the same gossip window
after `acceptQuest`/`turnInQuest`, regardless of whether the NPC still had anything
to offer. A brand-new character only has that one quest at the Marshal, so once it
is accepted (or turned in) the menu goes empty and the window just sat there inert
instead of closing.

Root cause: the accept/turn-in button handlers in `renderGossip` always called
`this.renderGossip(npc)` to refresh the menu, with no check for "is there anything
left to show." NPCs with other quests, a shop, a delve board, etc. correctly want
that refresh to keep the window open; a tutorial giver with a single starter quest
does not.

Fix: extracted the "does this gossip menu still have anything to show" decision
into a small pure module, `src/ui/gossip_menu.ts` (`gossipMenuIsEmpty`), unit
tested on its own in `tests/gossip_menu.test.ts`. `renderGossip` now takes an
optional `closeIfEmpty` flag; the accept/turn-in handlers pass `true`, and when
the computed menu is empty the dialog closes itself instead of re-rendering an
inert greeting-only panel. A fresh "talk" open, or navigating Back from a detail
page, still always shows the greeting (`closeIfEmpty` defaults to `false`), so
this only changes the previously-broken post-action refresh.

## Related issues

Fixes a playtester-reported bug (Discord feedback): tutorial dialogue/quest window
doesn't close after finishing talking to the Marshal.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/gossip_menu.test.ts` (new test, reproduces the empty-menu
    decision and pins it green)
  - `npx vitest run --maxWorkers=4` (full suite, green)
  - `npx tsc --noEmit`
  - `npx @biomejs/biome ci --changed --since=up/release/v0.25.0` (clean on the
    actual PR base; see note below)
  - `npm run build:server`, `npm run build:env`, `npm run build`
- Manual steps: drove the offline client through the tutorial flow (walk to the
  Marshal, accept `q_wolves`) via a puppeteer-core script and confirmed
  `#quest-dialog` now closes itself once the menu has nothing left to offer,
  instead of staying open with just the greeting line (screenshots below).

Note on `npm run gate` in this environment: this sandbox's `origin/main` (the
fork) is far behind `release/v0.25.0`, so the gate's changed-files biome step
(which diffs against `origin/main` per `biome.json`) flags dozens of unrelated
files that are only "changed" relative to the stale fork `main`, not to this PR's
real base. Diffing correctly against `up/release/v0.25.0` (`biome ci --changed
--since=up/release/v0.25.0`) shows only this PR's 3 code files, 0 errors, 3
pre-existing warnings. Likewise `npm run sfx:check` already fails with the exact
same output on a clean `up/release/v0.25.0` checkout (pre-existing audio
conformance backlog, unrelated to this change). Typecheck, the full test suite,
and all three builds are green.

## Screenshots / recordings

Before (the bug): quest already accepted (see the "Wolves at the Door" tracker,
top right) but the Marshal's dialogue window is still open, showing only the
greeting with no buttons:

![Before: dialogue stuck open after accepting the quest](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/fix/tutorial-marshall-window-close/docs/screenshots/marshal-dialog-before-stuck-open.png)

After (fixed): accepting the same quest now closes the dialogue automatically
since the Marshal has nothing left to offer:

![After: dialogue closes itself once accepted](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/fix/tutorial-marshall-window-close/docs/screenshots/marshal-dialog-after-accept-closed.png)

---

## Checklist

### Quality

- [x] **The full gate passes** modulo the two environment-only caveats explained
      above (stale local `origin/main` skewing the changed-files diff, and a
      pre-existing `sfx:check` backlog present on a clean base checkout). tsc,
      the full test suite, and all builds are green; the changed-files biome
      check is clean against the real PR base.

### Cross-platform

- [x] **Tested on desktop.** Verified via the offline client at 1280x800 (see
      screenshots). Not separately verified at a phone-sized viewport; the
      dialog's own responsive/mobile layout is untouched by this change.
- [x] **Accessible.** No change to focus handling, ARIA, or keyboard operability;
      `closeQuestDialog()` (used by the new close-if-empty path) already restores
      focus correctly, unchanged.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings; it reuses existing rendering
      and closing paths.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
