### PR TITLE
feat(sim): grant character XP from gathering and crafting

### DIFF
--- a/src/sim/content/gather_nodes.ts
+++ b/src/sim/content/gather_nodes.ts
@@ -7,29 +7,110 @@ import type { GatherNodeDef, GatherNodeType } from '../types';
 
 export const GATHER_NODE_TYPES: readonly GatherNodeType[] = ['ore', 'wood', 'herb'];
 
+// `level` (issue: profession XP) is a one-time snapshot of each node's zone
+// levelRange midpoint (eastbrook_vale [1,7] -> 4; mirefen_marsh, zone2's
+// levelRange [6,13] -> 10), not a live lookup: see types.ts GatherNodeDef.
 export const GATHER_NODES: GatherNodeDef[] = [
   // Eastbrook Vale (eastbrook_vale), ore near Boar Meadow's rocky outcrops
-  { id: 'ore_eastbrook_1', zoneId: 'eastbrook_vale', type: 'ore', pos: { x: 72, z: 8 } },
-  { id: 'ore_eastbrook_2', zoneId: 'eastbrook_vale', type: 'ore', pos: { x: 78, z: -6 } },
-  { id: 'ore_eastbrook_3', zoneId: 'eastbrook_vale', type: 'ore', pos: { x: 66, z: 22 } },
+  { id: 'ore_eastbrook_1', zoneId: 'eastbrook_vale', type: 'ore', pos: { x: 72, z: 8 }, level: 4 },
+  {
+    id: 'ore_eastbrook_2',
+    zoneId: 'eastbrook_vale',
+    type: 'ore',
+    pos: { x: 78, z: -6 },
+    level: 4,
+  },
+  {
+    id: 'ore_eastbrook_3',
+    zoneId: 'eastbrook_vale',
+    type: 'ore',
+    pos: { x: 66, z: 22 },
+    level: 4,
+  },
 
   // Eastbrook Vale, wood stands around Webwood
-  { id: 'wood_eastbrook_1', zoneId: 'eastbrook_vale', type: 'wood', pos: { x: -62, z: 8 } },
-  { id: 'wood_eastbrook_2', zoneId: 'eastbrook_vale', type: 'wood', pos: { x: -57, z: -6 } },
-  { id: 'wood_eastbrook_3', zoneId: 'eastbrook_vale', type: 'wood', pos: { x: -68, z: 18 } },
+  {
+    id: 'wood_eastbrook_1',
+    zoneId: 'eastbrook_vale',
+    type: 'wood',
+    pos: { x: -62, z: 8 },
+    level: 4,
+  },
+  {
+    id: 'wood_eastbrook_2',
+    zoneId: 'eastbrook_vale',
+    type: 'wood',
+    pos: { x: -57, z: -6 },
+    level: 4,
+  },
+  {
+    id: 'wood_eastbrook_3',
+    zoneId: 'eastbrook_vale',
+    type: 'wood',
+    pos: { x: -68, z: 18 },
+    level: 4,
+  },
 
   // Eastbrook Vale, herb patches near Mirror Lake
-  { id: 'herb_eastbrook_1', zoneId: 'eastbrook_vale', type: 'herb', pos: { x: -86, z: 90 } },
-  { id: 'herb_eastbrook_2', zoneId: 'eastbrook_vale', type: 'herb', pos: { x: -92, z: 80 } },
-  { id: 'herb_eastbrook_3', zoneId: 'eastbrook_vale', type: 'herb', pos: { x: -80, z: 95 } },
+  {
+    id: 'herb_eastbrook_1',
+    zoneId: 'eastbrook_vale',
+    type: 'herb',
+    pos: { x: -86, z: 90 },
+    level: 4,
+  },
+  {
+    id: 'herb_eastbrook_2',
+    zoneId: 'eastbrook_vale',
+    type: 'herb',
+    pos: { x: -92, z: 80 },
+    level: 4,
+  },
+  {
+    id: 'herb_eastbrook_3',
+    zoneId: 'eastbrook_vale',
+    type: 'herb',
+    pos: { x: -80, z: 95 },
+    level: 4,
+  },
 
   // Mirefen Marsh (mirefen_marsh)
-  { id: 'ore_mirefen_1', zoneId: 'mirefen_marsh', type: 'ore', pos: { x: 40, z: 340 } },
-  { id: 'ore_mirefen_2', zoneId: 'mirefen_marsh', type: 'ore', pos: { x: -30, z: 360 } },
+  { id: 'ore_mirefen_1', zoneId: 'mirefen_marsh', type: 'ore', pos: { x: 40, z: 340 }, level: 10 },
+  {
+    id: 'ore_mirefen_2',
+    zoneId: 'mirefen_marsh',
+    type: 'ore',
+    pos: { x: -30, z: 360 },
+    level: 10,
+  },
 
-  { id: 'wood_mirefen_1', zoneId: 'mirefen_marsh', type: 'wood', pos: { x: 10, z: 330 } },
-  { id: 'wood_mirefen_2', zoneId: 'mirefen_marsh', type: 'wood', pos: { x: -15, z: 355 } },
+  {
+    id: 'wood_mirefen_1',
+    zoneId: 'mirefen_marsh',
+    type: 'wood',
+    pos: { x: 10, z: 330 },
+    level: 10,
+  },
+  {
+    id: 'wood_mirefen_2',
+    zoneId: 'mirefen_marsh',
+    type: 'wood',
+    pos: { x: -15, z: 355 },
+    level: 10,
+  },
 
-  { id: 'herb_mirefen_1', zoneId: 'mirefen_marsh', type: 'herb', pos: { x: 60, z: 385 } },
-  { id: 'herb_mirefen_2', zoneId: 'mirefen_marsh', type: 'herb', pos: { x: -45, z: 452 } },
+  {
+    id: 'herb_mirefen_1',
+    zoneId: 'mirefen_marsh',
+    type: 'herb',
+    pos: { x: 60, z: 385 },
+    level: 10,
+  },
+  {
+    id: 'herb_mirefen_2',
+    zoneId: 'mirefen_marsh',
+    type: 'herb',
+    pos: { x: -45, z: 452 },
+    level: 10,
+  },
 ];

--- a/src/sim/content/recipes.ts
+++ b/src/sim/content/recipes.ts
@@ -46,6 +46,7 @@ export const COMMON_RECIPES: ProfessionRecipeRecord[] = [
     skillReq: 0,
     trivialAt: 25,
     itemLevelBudget: 10,
+    level: 10,
   },
   {
     id: 'recipe_eastbrook_chain_vest',
@@ -56,6 +57,7 @@ export const COMMON_RECIPES: ProfessionRecipeRecord[] = [
     skillReq: 0,
     trivialAt: 25,
     itemLevelBudget: 10,
+    level: 10,
   },
   {
     id: 'recipe_eastbrook_wool_trousers',
@@ -66,6 +68,7 @@ export const COMMON_RECIPES: ProfessionRecipeRecord[] = [
     skillReq: 0,
     trivialAt: 25,
     itemLevelBudget: 8,
+    level: 8,
   },
   {
     id: 'recipe_tanned_leather_jerkin',
@@ -79,6 +82,7 @@ export const COMMON_RECIPES: ProfessionRecipeRecord[] = [
     skillReq: 0,
     trivialAt: 25,
     itemLevelBudget: 9,
+    level: 9,
   },
   {
     id: 'recipe_tough_jerky',
@@ -89,6 +93,7 @@ export const COMMON_RECIPES: ProfessionRecipeRecord[] = [
     skillReq: 0,
     trivialAt: 25,
     itemLevelBudget: 1,
+    level: 1,
   },
   {
     id: 'recipe_minor_healing_potion',
@@ -102,6 +107,7 @@ export const COMMON_RECIPES: ProfessionRecipeRecord[] = [
     skillReq: 0,
     trivialAt: 25,
     itemLevelBudget: 1,
+    level: 1,
   },
 ];
 
@@ -135,6 +141,7 @@ export const TOOL_RECIPES: ProfessionRecipeRecord[] = [
     skillReq: 75,
     trivialAt: 125,
     itemLevelBudget: 20,
+    level: 20,
     requiresHubStation: true,
   },
   {
@@ -149,6 +156,7 @@ export const TOOL_RECIPES: ProfessionRecipeRecord[] = [
     skillReq: 150,
     trivialAt: 200,
     itemLevelBudget: 30,
+    level: 20,
     requiresHubStation: true,
   },
   {
@@ -163,6 +171,7 @@ export const TOOL_RECIPES: ProfessionRecipeRecord[] = [
     skillReq: 75,
     trivialAt: 125,
     itemLevelBudget: 20,
+    level: 20,
     requiresHubStation: true,
   },
   {
@@ -177,6 +186,7 @@ export const TOOL_RECIPES: ProfessionRecipeRecord[] = [
     skillReq: 150,
     trivialAt: 200,
     itemLevelBudget: 30,
+    level: 20,
     requiresHubStation: true,
   },
   {
@@ -191,6 +201,7 @@ export const TOOL_RECIPES: ProfessionRecipeRecord[] = [
     skillReq: 75,
     trivialAt: 125,
     itemLevelBudget: 20,
+    level: 20,
     requiresHubStation: true,
   },
   {
@@ -205,6 +216,7 @@ export const TOOL_RECIPES: ProfessionRecipeRecord[] = [
     skillReq: 150,
     trivialAt: 200,
     itemLevelBudget: 30,
+    level: 20,
     requiresHubStation: true,
   },
 ];
@@ -226,6 +238,7 @@ export const COMBO_RECIPES: ProfessionRecipeRecord[] = [
     skillReq: 25,
     trivialAt: 50,
     itemLevelBudget: 20,
+    level: 15,
     comboRequirement: { craftA: 'armorcrafting', craftB: 'weaponcrafting', minTier: 1 },
   },
   {
@@ -240,6 +253,7 @@ export const COMBO_RECIPES: ProfessionRecipeRecord[] = [
     skillReq: 25,
     trivialAt: 50,
     itemLevelBudget: 18,
+    level: 15,
     comboRequirement: { craftA: 'armorcrafting', craftB: 'weaponcrafting', minTier: 1 },
   },
   {
@@ -254,6 +268,7 @@ export const COMBO_RECIPES: ProfessionRecipeRecord[] = [
     skillReq: 25,
     trivialAt: 50,
     itemLevelBudget: 16,
+    level: 15,
     comboRequirement: { craftA: 'alchemy', craftB: 'engineering', minTier: 1 },
   },
 ];

--- a/src/sim/professions/crafting.ts
+++ b/src/sim/professions/crafting.ts
@@ -74,6 +74,7 @@ import {
   type MaterialRarity,
   rollMaterialRarity,
 } from './gathering';
+import { craftActionXp } from './profession_xp';
 import type { ProfessionReagent, ProfessionRecipeRecord } from './types';
 import {
   type CraftSkillState,
@@ -395,6 +396,11 @@ export function resolveCraftForRecipe(
         : tierProgressMultiplier(tierCapability(meta.craftSkills, recipe.professionId), recipeTier);
     gainCraftSkill(meta.craftSkills, recipe.professionId, CRAFT_SKILL_GAIN * multiplier);
     meta.craftThrottle.count += 1;
+    // Character XP for the craft (profession_xp.ts), tier-scaled and
+    // level-gated the same way gathering/kill XP are: a max-level player
+    // spamming a trivial (gray) recipe gets zero.
+    const entity = ctx.entities.get(pid);
+    if (entity) ctx.grantXp(craftActionXp(recipe.level, entity.level), meta);
   }
   return {
     ok: true,

--- a/src/sim/professions/gathering.ts
+++ b/src/sim/professions/gathering.ts
@@ -21,6 +21,7 @@ import type { Rng } from '../rng';
 import type { PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
 import { type GatherNodeDef, type GatherNodeType, INTERACT_RANGE, type ItemDef } from '../types';
+import { gatherActionXp } from './profession_xp';
 import type { PlayerProfessionSkill } from './types';
 
 // Quest-gated bonus grant (#1701 follow-up review): while the paired quest is
@@ -237,6 +238,10 @@ export function harvestNode(ctx: SimContext, nodeId: string, pid?: number): void
   if (questItemId && ctx.canAddItem(questItemId, 1, meta.entityId)) {
     ctx.addItem(questItemId, 1, meta.entityId);
   }
+  // Character XP for the harvest (profession_xp.ts), tier-scaled and
+  // level-gated the same way kill XP is: a max-level player farming a
+  // trivial (gray) node gets zero.
+  ctx.grantXp(gatherActionXp(node.level, p.level), meta);
 }
 
 export interface PendingGatherGrant {

--- a/src/sim/professions/profession_xp.ts
+++ b/src/sim/professions/profession_xp.ts
@@ -1,0 +1,54 @@
+// Character XP for gathering and crafting actions. Two independently tuned
+// curves, both following the same classic green/gray shape as combat XP
+// (types.ts mobXpValue/zeroDiff): full or scaled-up XP against content at or
+// above the player's level, linearly reduced below it, and zero once the
+// content is `zeroDiff(playerLevel)` or more levels below the player (the
+// gray band). Kept separate from mobXpValue on purpose: a node/recipe isn't
+// a mob, and gathering/crafting are lower-effort, repeatable actions with no
+// miss/death risk, so both bases are tuned well under the kill-XP curve.
+//
+// Base constants are a first-pass tuning value, not a balance number pulled
+// from a classic-era formula reference (unlike combat math elsewhere in this
+// repo): there is no equivalent real-MMO gathering/crafting XP table to
+// match against. Adjust GATHER_XP_BASE/GATHER_XP_PER_LEVEL and
+// CRAFT_XP_BASE/CRAFT_XP_PER_LEVEL directly once real playtesting data
+// exists; the shape (green/gray falloff) should not change.
+//
+// Pure, no randomness, zero DOM/browser/Three.js imports (src/sim/ purity,
+// guarded by tests/architecture.test.ts).
+
+import { zeroDiff } from '../types';
+
+const GATHER_XP_BASE = 10;
+const GATHER_XP_PER_LEVEL = 2;
+
+const CRAFT_XP_BASE = 20;
+const CRAFT_XP_PER_LEVEL = 4;
+
+function professionActionXp(base: number, contentLevel: number, playerLevel: number): number {
+  const diff = contentLevel - playerLevel;
+  if (diff >= 0) {
+    return Math.round(base * (1 + 0.05 * Math.min(diff, 4)));
+  }
+  const zd = zeroDiff(playerLevel);
+  if (-diff >= zd) return 0; // gray: no XP from trivial content
+  return Math.round(base * (1 - -diff / zd));
+}
+
+// XP for one gathering-node harvest (gathering.ts harvestNode).
+export function gatherActionXp(nodeLevel: number, playerLevel: number): number {
+  return professionActionXp(
+    GATHER_XP_BASE + GATHER_XP_PER_LEVEL * nodeLevel,
+    nodeLevel,
+    playerLevel,
+  );
+}
+
+// XP for one successful craft (crafting.ts resolveCraftForRecipe).
+export function craftActionXp(recipeLevel: number, playerLevel: number): number {
+  return professionActionXp(
+    CRAFT_XP_BASE + CRAFT_XP_PER_LEVEL * recipeLevel,
+    recipeLevel,
+    playerLevel,
+  );
+}

--- a/src/sim/professions/types.ts
+++ b/src/sim/professions/types.ts
@@ -51,6 +51,12 @@ export interface ProfessionRecipeRecord {
   // quality roll and gate access. A common-tier recipe always has skillReq 0
   // per the free-floor rule.
   itemLevelBudget: number;
+  // Effective content level for the profession-XP green/gray curve
+  // (professions/profession_xp.ts craftActionXp). Seeded from
+  // itemLevelBudget at authoring time (same numeric scale as character
+  // level) and hand-adjusted where a recipe's intended character level
+  // clearly diverges from its gold-sink budget.
+  level: number;
   // Dual-craft requirement (issue #1132): a combo recipe exclusive to one
   // specific adjacent pair on the CRAFT_RING (src/sim/content/professions.ts
   // adjacentCrafts). When present, the crafting player must hold BOTH

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1556,6 +1556,10 @@ export interface GatherNodeDef {
   zoneId: string;
   type: GatherNodeType;
   pos: { x: number; z: number };
+  // Effective content level for the profession-XP green/gray curve
+  // (professions/profession_xp.ts gatherActionXp), snapshotted at authoring
+  // time from the node's zone levelRange midpoint rather than looked up live.
+  level: number;
 }
 
 export interface DungeonSpawn {

--- a/tests/archetype_ceiling.test.ts
+++ b/tests/archetype_ceiling.test.ts
@@ -195,6 +195,7 @@ describe('resolveCraftForRecipe reads the archetype-gated ceiling for skill-gain
       skillReq: 50, // recipeTier = 2
       trivialAt: 100,
       itemLevelBudget: 10,
+      level: 10,
     };
     const result = resolveCraftForRecipe(ctxOf(sim), pid, recipe);
 
@@ -223,6 +224,7 @@ describe('resolveCraftForRecipe reads the archetype-gated ceiling for skill-gain
       skillReq: 25, // recipeTier = 1, above the common (0) dormancy ceiling
       trivialAt: 50,
       itemLevelBudget: 10,
+      level: 10,
     };
     const result = resolveCraftForRecipe(ctxOf(sim), pid, recipe);
 
@@ -246,6 +248,7 @@ describe('resolveCraftForRecipe reads the archetype-gated ceiling for skill-gain
       skillReq: 0, // recipeTier = 0 (common, the free floor)
       trivialAt: 25,
       itemLevelBudget: 1,
+      level: 1,
     };
     const result = resolveCraftForRecipe(ctxOf(sim), pid, recipe);
 
@@ -269,6 +272,7 @@ describe('resolveCraftForRecipe reads the archetype-gated ceiling for skill-gain
       skillReq: 100, // recipeTier = 4, exactly at capability -> full progress
       trivialAt: 200,
       itemLevelBudget: 10,
+      level: 10,
     };
     const result = resolveCraftForRecipe(ctxOf(sim), pid, recipe);
 
@@ -292,6 +296,7 @@ describe('resolveCraftForRecipe reads the archetype-gated ceiling for skill-gain
       skillReq: 100,
       trivialAt: 200,
       itemLevelBudget: 10,
+      level: 10,
     };
     const result = resolveCraftForRecipe(ctxOf(sim), pid, recipe);
 
@@ -315,6 +320,7 @@ describe('resolveCraftForRecipe reads the archetype-gated ceiling for skill-gain
       skillReq: 75, // recipeTier = 3, above the rare ceiling
       trivialAt: 100,
       itemLevelBudget: 10,
+      level: 10,
     };
     const result = resolveCraftForRecipe(ctxOf(sim), pid, recipe);
 
@@ -346,6 +352,7 @@ describe('resolveCraftForRecipe reads the archetype-gated ceiling for skill-gain
       skillReq: 75, // recipeTier = 3, far above raw capability, within the unlimited ceiling
       trivialAt: 200,
       itemLevelBudget: 10,
+      level: 10,
     };
     const result = resolveCraftForRecipe(ctxOf(sim), pid, recipe);
 
@@ -369,6 +376,7 @@ describe('resolveCraftForRecipe reads the archetype-gated ceiling for skill-gain
       skillReq: 50, // recipeTier = 2: above raw capability, exactly at the ceiling
       trivialAt: 100,
       itemLevelBudget: 10,
+      level: 10,
     };
     const result = resolveCraftForRecipe(ctxOf(sim), pid, recipe);
 
@@ -391,6 +399,7 @@ describe('resolveCraftForRecipe reads the archetype-gated ceiling for skill-gain
       skillReq: 75, // recipeTier = 3, above the pre-archetype rare ceiling
       trivialAt: 100,
       itemLevelBudget: 10,
+      level: 10,
     };
     const result = resolveCraftForRecipe(ctxOf(sim), pid, recipe);
 
@@ -433,6 +442,7 @@ describe('resolveCraftForRecipe clamps output quality to the empowerment ceiling
       skillReq: 0,
       trivialAt: 25,
       itemLevelBudget: 1,
+      level: 1,
     };
     const result = resolveCraftForRecipe(ctxOf(sim), pid, recipe);
 
@@ -456,6 +466,7 @@ describe('resolveCraftForRecipe clamps output quality to the empowerment ceiling
       skillReq: 0,
       trivialAt: 25,
       itemLevelBudget: 1,
+      level: 1,
     };
     const result = resolveCraftForRecipe(ctxOf(sim), pid, recipe);
 

--- a/tests/gather_node_harvest.test.ts
+++ b/tests/gather_node_harvest.test.ts
@@ -196,6 +196,33 @@ describe('gather node harvest (#1121)', () => {
     expect(after).toBe((before ?? 0) + 1);
   });
 
+  it('a harvest grants character XP scaled to the node level (profession XP)', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'XpMiner');
+    teleportOntoNode(sim, pid, NODE_ID);
+    const meta = mustMeta(sim, pid);
+    const before = meta.xp;
+
+    sim.harvestNode(NODE_ID, pid);
+    sim.tick();
+
+    expect(meta.xp).toBeGreaterThan(before);
+  });
+
+  it('a harvest of a node far below a high-level player grants zero XP (gray band)', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'MaxLevelMiner');
+    teleportOntoNode(sim, pid, NODE_ID);
+    sim.setPlayerLevel(20);
+    const meta = mustMeta(sim, pid);
+    const before = meta.xp;
+
+    sim.harvestNode(NODE_ID, pid);
+    sim.tick();
+
+    expect(meta.xp).toBe(before);
+  });
+
   it('denies harvest for a dead player without granting the item or the timer', () => {
     const sim = makeWorld();
     const pid = sim.addPlayer('warrior', 'Ghost');

--- a/tests/profession_xp.test.ts
+++ b/tests/profession_xp.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { craftActionXp, gatherActionXp } from '../src/sim/professions/profession_xp';
+import { zeroDiff } from '../src/sim/types';
+
+describe('profession_xp', () => {
+  it('grants positive XP for same-level content', () => {
+    expect(gatherActionXp(5, 5)).toBeGreaterThan(0);
+    expect(craftActionXp(5, 5)).toBeGreaterThan(0);
+  });
+
+  it('the gather and craft curves are not identical', () => {
+    expect(gatherActionXp(5, 5)).not.toBe(craftActionXp(5, 5));
+  });
+
+  it('grants zero XP once content is zeroDiff(playerLevel) or more levels below the player', () => {
+    const playerLevel = 10;
+    const zd = zeroDiff(playerLevel);
+    expect(gatherActionXp(playerLevel - zd, playerLevel)).toBe(0);
+    expect(craftActionXp(playerLevel - zd, playerLevel)).toBe(0);
+  });
+
+  it('grants reduced (but nonzero) XP just inside the gray band', () => {
+    const playerLevel = 10;
+    const zd = zeroDiff(playerLevel);
+    const justAbove = gatherActionXp(playerLevel - (zd - 1), playerLevel);
+    expect(justAbove).toBeGreaterThan(0);
+    expect(justAbove).toBeLessThan(gatherActionXp(playerLevel, playerLevel));
+  });
+
+  it('scales up for content above the player level, capped at a +4-level multiplier', () => {
+    const atLevel = gatherActionXp(5, 5);
+    const above = gatherActionXp(9, 5); // +4 levels: the multiplier cap
+    expect(above).toBeGreaterThan(atLevel);
+    // The scale-UP multiplier caps at diff=4 (matches mobXpValue's
+    // Math.min(diff, 4)): both a +4 and a +15 level gap must use the exact
+    // same 1.2x multiplier on their own (higher) content-level base.
+    const baseAt9 = 10 + 2 * 9;
+    const baseAt20 = 10 + 2 * 20;
+    expect(above).toBe(Math.round(baseAt9 * 1.2));
+    expect(gatherActionXp(20, 5)).toBe(Math.round(baseAt20 * 1.2)); // +15 levels
+  });
+
+  it('determinism: pure function, same inputs always produce the same output', () => {
+    expect(gatherActionXp(7, 4)).toBe(gatherActionXp(7, 4));
+    expect(craftActionXp(12, 9)).toBe(craftActionXp(12, 9));
+  });
+});

--- a/tests/professions_acquisition_salvage_sink.test.ts
+++ b/tests/professions_acquisition_salvage_sink.test.ts
@@ -37,6 +37,7 @@ const GATED_RECIPE: ProfessionRecipeRecord = {
   skillReq: 0,
   trivialAt: 25,
   itemLevelBudget: 1,
+  level: 1,
   acquisition: ['trainer'],
 };
 

--- a/tests/professions_crafting.test.ts
+++ b/tests/professions_crafting.test.ts
@@ -81,6 +81,50 @@ describe('TOOL_RECIPES (#1135 de-stub): tier 4/5 tool recipes', () => {
   });
 });
 
+describe('profession XP on craft (profession_xp.ts)', () => {
+  it('a successful craft grants character XP', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = (sim as any).players.get(pid);
+    const recipe = recipeById('recipe_tough_jerky')!;
+    grantItem(sim, 'spider_leg', 1, pid);
+    const before = meta.xp;
+
+    const result = resolveCraft((sim as any).ctx, pid, recipe.id);
+
+    expect(result.ok).toBe(true);
+    expect(meta.xp).toBeGreaterThan(before);
+  });
+
+  it('a trivial craft for a high-level player grants zero XP (gray band)', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    sim.setPlayerLevel(20);
+    const meta = (sim as any).players.get(pid);
+    const recipe = recipeById('recipe_tough_jerky')!; // level 1
+    grantItem(sim, 'spider_leg', 1, pid);
+    const before = meta.xp;
+
+    const result = resolveCraft((sim as any).ctx, pid, recipe.id);
+
+    expect(result.ok).toBe(true);
+    expect(meta.xp).toBe(before);
+  });
+
+  it('a denied craft (insufficient materials) grants no XP', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = (sim as any).players.get(pid);
+    const recipe = recipeById('recipe_tough_jerky')!;
+    const before = meta.xp;
+
+    const result = resolveCraft((sim as any).ctx, pid, recipe.id);
+
+    expect(result.ok).toBe(false);
+    expect(meta.xp).toBe(before);
+  });
+});
+
 describe('resolveCraft (#1127)', () => {
   it('consumes exactly the required materials and produces the correct output', () => {
     const sim = makeSim();
@@ -332,6 +376,7 @@ describe('tiered mastery gating (#1128)', () => {
     skillReq: 25,
     trivialAt: 50,
     itemLevelBudget: 10,
+    level: 10,
   };
 
   function setSkill(sim: Sim, pid: number, craftId: string, value: number) {

--- a/tests/professions_perks.test.ts
+++ b/tests/professions_perks.test.ts
@@ -73,6 +73,7 @@ describe('material-cost discount when crafting (#1134, crafting.ts)', () => {
     skillReq: 0,
     trivialAt: 25,
     itemLevelBudget: 10,
+    level: 10,
   };
 
   it('a non-specialized player pays the full listed material cost', () => {


### PR DESCRIPTION
## Summary

Gathering nodes and crafting recipes previously granted only profession
proficiency, with zero character XP: leveling was combat-only. This makes
professions a genuinely relevant way to level, not just a side activity.

Both actions now grant character XP through the existing `grantXp` seam,
tier-scaled and level-gated with the same classic green/gray falloff kill
XP already uses (`mobXpValue`/`zeroDiff` in `src/sim/types.ts`), so a
max-level character farming trivial nodes/recipes gets nothing free, and a
fresh character gets a meaningful amount from either path.

```mermaid
flowchart TD
    subgraph Gathering
        A[Player harvests a node] --> B[harvestNode: grants material item + gathering proficiency]
        B --> C["gatherActionXp(node.level, player.level)"]
    end
    subgraph Crafting
        D[Player crafts a recipe] --> E[resolveCraftForRecipe: consumes reagents, grants item + craft skill]
        E --> F["craftActionXp(recipe.level, player.level)"]
    end
    C --> G["ctx.grantXp(amount, meta)"]
    F --> G
    G --> H[existing level-up path: XP bar, level-up FCT/toast]

    style C fill:#2d5,stroke:#333
    style F fill:#2d5,stroke:#333
    style G fill:#59f,stroke:#333
```

```mermaid
graph LR
    subgraph "professionActionXp(base, contentLevel, playerLevel)"
        direction LR
        X["diff = contentLevel - playerLevel"] --> Y{"diff >= 0?"}
        Y -- yes --> Z["base * (1 + 0.05 * min(diff, 4))<br/>content at/above player level: full or scaled-up XP"]
        Y -- no --> W{"-diff >= zeroDiff(playerLevel)?"}
        W -- yes --> V["0 XP (gray band)"]
        W -- no --> U["base * (1 - -diff / zeroDiff)<br/>linear falloff below player level"]
    end
```

## Related issues

N/A (implements the "nodes and crafting give exp" idea from discussion; no
tracking issue was filed for this specific slice).

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## What changed

- `src/sim/types.ts`: `GatherNodeDef` gains a `level` field.
- `src/sim/content/gather_nodes.ts`: `level` populated for all 15 existing
  nodes, snapshotted from their zone's `levelRange` midpoint (e.g.
  `eastbrook_vale [1,7]` -> 4).
- `src/sim/professions/types.ts`: `ProfessionRecipeRecord` gains a `level`
  field.
- `src/sim/content/recipes.ts`: `level` populated for all 15 existing
  recipes (seeded from `itemLevelBudget`, hand-adjusted where a recipe's
  intended character level clearly diverged from its gold-sink budget).
- `src/sim/professions/profession_xp.ts` (new): `gatherActionXp` /
  `craftActionXp`, two independently tuned green/gray curves (crafting
  scores higher than gathering, since it consumes reagents). Pure,
  deterministic, no DOM/browser imports, no randomness.
- `src/sim/professions/gathering.ts`: `harvestNode` calls `ctx.grantXp(...)`
  on a successful harvest.
- `src/sim/professions/crafting.ts`: `resolveCraftForRecipe` calls
  `ctx.grantXp(...)` on a successful craft.
- Tests: new `tests/profession_xp.test.ts` (curve unit tests: same-level,
  gray-band, reduced-band, scale-up cap, determinism); XP-grant and
  gray-band regression tests added to `tests/gather_node_harvest.test.ts`
  and `tests/professions_crafting.test.ts`; three other test files updated
  with the new required `level` field on their `ProfessionRecipeRecord`
  fixtures.

## How was this tested?

- Commands: `npx tsc --noEmit`; `npx vitest run` across
  `tests/profession_xp.test.ts`, `tests/gather_node_harvest.test.ts`,
  `tests/professions_crafting.test.ts`, `tests/professions_gathering.test.ts`,
  `tests/gathering.test.ts`, `tests/gather_nodes.test.ts`,
  `tests/professions_perks.test.ts`, `tests/archetype_ceiling.test.ts`,
  `tests/professions_acquisition_salvage_sink.test.ts`,
  `tests/architecture.test.ts`, `tests/professions.test.ts`,
  `tests/professions_crafting_hub.test.ts`, `tests/sim.test.ts`,
  `tests/progression.test.ts`, `tests/parity/harness.test.ts`,
  `tests/guide.test.ts`, `tests/localization_fixes.test.ts`; `npm run build`.
  All green. `npx @biomejs/biome check --write` on every changed file, no
  format diffs remaining.
- `npm run gate`: green except `sfx check`, which fails identically on a
  clean checkout of `release/v0.25.0` with none of this PR's changes
  applied (confirmed via `git stash`) — a pre-existing, environment-local
  audio-tooling mismatch unrelated to this change (no audio files touched).
- Manual steps: none (this is a `src/sim/` behavior change with no new UI;
  the XP gain flows through the existing level-up/XP-bar/FCT pipeline
  unchanged).

## Screenshots / recordings

N/A. This is a `src/sim/` gameplay-math change only: no new UI, window,
tooltip, or HUD element. The XP gain renders through the pre-existing
level-up/XP-bar/FCT pipeline, which is visually unchanged (there is nothing
new to compare before/after in a screenshot). See the mermaid diagrams
above for the flow instead.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green except the
      pre-existing, environment-local `sfx check` failure noted above (verified
      unrelated by reproducing it on the same base with no changes applied). I
      added decisive tests for the new behavior (see "How was this tested?").

### Cross-platform

- [ ] N/A. No UI, so no desktop/mobile viewport or a11y surface changed.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings: XP gain reuses the
      existing level-up/XP-bar/FCT pipeline verbatim, which already renders
      through `t()`. No new toast/message is introduced (kill XP doesn't get
      one either, for consistency).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS`
      is not enabled in any production path.
- [x] I didn't hand-edit generated files.
