### PR TITLE
Palmreach palms + floating dock-pillar fix

### DIFF
--- a/src/render/jungle_features.ts
+++ b/src/render/jungle_features.ts
@@ -1,13 +1,14 @@
-// The Palmreach's dressing, render-only: procedural palms leaning over the
-// beach shelf (the sim's decoration grid skips the sand, so the strand
-// belongs to this module), giant vine-hung banyans at the greatTrees spots
-// (the same records the sim's trunk colliders use), and vine curtains under
-// their crowns. Same contract as the sibling realm modules: build once,
-// update(time) animates gently.
+// The Palmreach's dressing: the three shipped beach-palm models instanced over
+// the beach shelf, giant vine-hung banyans at the greatTrees spots (the same
+// records the sim's trunk colliders use), and vine curtains under their crowns.
+// The palms' placement AND their trunk colliders come from reachPalmSpots(seed)
+// in world.ts, so what you see on the strand is exactly what the sim blocks.
+// Same contract as the sibling realm modules: build once, update(time) animates
+// gently.
 import * as THREE from 'three';
 import { PALMREACH_PROPS } from '../sim/content/palmreach';
 import { hash2 } from '../sim/rng';
-import { reachLandness, terrainHeight, WATER_LEVEL } from '../sim/world';
+import { type ReachPalm, reachPalmSpots, terrainHeight, WATER_LEVEL } from '../sim/world';
 import { loadGltf } from './assets/loader';
 import { registerPreload } from './assets/preload';
 import { GFX } from './gfx';
@@ -17,8 +18,54 @@ export interface JungleFeaturesView {
   update(time: number): void;
 }
 
-const REACH_ZMIN = 700;
-const REACH_ZMAX = 1260;
+// The three beach-palm models, instanced per variant so the whole strand is a
+// handful of draws. Preloaded at import; buildJungleFeatures reads the cache.
+const PALM_URLS = [
+  '/models/biome/beach_palm_1.glb',
+  '/models/biome/beach_palm_2.glb',
+  '/models/biome/beach_palm_3.glb',
+];
+const palmScenes: (THREE.Group | null)[] = [null, null, null];
+PALM_URLS.forEach((url, i) => {
+  registerPreload(
+    loadGltf(url).then((gltf) => {
+      palmScenes[i] = gltf.scene;
+    }),
+  );
+});
+
+interface PalmPart {
+  geometry: THREE.BufferGeometry;
+  material: THREE.Material | THREE.Material[];
+}
+
+// Bake a preloaded palm GLB into instanceable parts. The shipped models are
+// meshopt-quantized, so attributes are converted to float32 before the node
+// transform is folded into the geometry — writing world-space values back into
+// normalized int16 attributes would clip (same recipe as foliage.ts).
+function bakePalmParts(scene: THREE.Group): PalmPart[] {
+  scene.updateMatrixWorld(true);
+  const parts: PalmPart[] = [];
+  scene.traverse((obj) => {
+    const mesh = obj as THREE.Mesh;
+    if (!mesh.isMesh) return;
+    const src = mesh.geometry;
+    const geo = new THREE.BufferGeometry();
+    for (const name of ['position', 'normal', 'uv']) {
+      const attr = src.getAttribute(name);
+      if (!attr) continue;
+      const out = new Float32Array(attr.count * attr.itemSize);
+      for (let i = 0; i < attr.count; i++)
+        for (let j = 0; j < attr.itemSize; j++)
+          out[i * attr.itemSize + j] = attr.getComponent(i, j);
+      geo.setAttribute(name, new THREE.BufferAttribute(out, attr.itemSize));
+    }
+    if (src.index) geo.setIndex(src.index.clone());
+    geo.applyMatrix4(mesh.matrixWorld);
+    parts.push({ geometry: geo, material: mesh.material });
+  });
+  return parts;
+}
 
 // The banyans reuse the twisted-elder model the Hollow's centerpiece and the
 // Wraithwood's giants wear (already preloaded twice over, so free), regrown
@@ -37,136 +84,39 @@ function mat(color: number, rough = 0.85): THREE.MeshStandardMaterial | THREE.Me
     : new THREE.MeshLambertMaterial({ color, flatShading: true });
 }
 
-// One palm, merged into two geometries (trunk wood + frond green) so the
-// whole strand instances as two draws: a leaning segmented trunk and a
-// crown of drooping frond blades.
-function palmGeos(): { trunk: THREE.BufferGeometry; fronds: THREE.BufferGeometry } {
-  const trunkParts: THREE.BufferGeometry[] = [];
-  const SEGS = 5;
-  const H = 7.2;
-  let px = 0;
-  for (let i = 0; i < SEGS; i++) {
-    const seg = new THREE.CylinderGeometry(0.16 - i * 0.014, 0.19 - i * 0.014, H / SEGS + 0.12, 5);
-    px += (i + 0.5) * 0.16; // the lean: each segment steps seaward
-    seg.translate(px, (i + 0.5) * (H / SEGS), 0);
-    seg.rotateZ(-0.06 * i);
-    trunkParts.push(seg.toNonIndexed());
-  }
-  const frondParts: THREE.BufferGeometry[] = [];
-  const crownX = px + 0.35;
-  for (let i = 0; i < 8; i++) {
-    const ang = (i / 8) * Math.PI * 2;
-    const frond = new THREE.ConeGeometry(0.34, 3.4, 3);
-    frond.scale(1, 1, 0.22); // flatten into a blade
-    frond.rotateX(Math.PI / 2); // point outward
-    frond.rotateZ(0); // droop handled below
-    const droop = 0.55 + ((i * 5) % 3) * 0.12;
-    const m = new THREE.Matrix4()
-      .makeRotationY(ang)
-      .multiply(new THREE.Matrix4().makeRotationX(droop));
-    frond.translate(0, 3.4 / 2, 0); // pivot at the crown
-    frond.applyMatrix4(new THREE.Matrix4().makeRotationX(-droop));
-    frond.applyMatrix4(new THREE.Matrix4().makeRotationY(ang));
-    frond.translate(crownX, H, 0);
-    frondParts.push(frond.toNonIndexed());
-  }
-  // coconuts: a small cluster under the crown
-  for (let i = 0; i < 3; i++) {
-    const nut = new THREE.SphereGeometry(0.14, 5, 4);
-    nut.translate(crownX + (i - 1) * 0.16, H - 0.25, (i % 2) * 0.18 - 0.09);
-    trunkParts.push(nut.toNonIndexed());
-  }
-  const merge = (parts: THREE.BufferGeometry[]): THREE.BufferGeometry => {
-    let total = 0;
-    for (const g of parts) total += g.getAttribute('position').count;
-    const pos = new Float32Array(total * 3);
-    const norm = new Float32Array(total * 3);
-    let off = 0;
-    for (const g of parts) {
-      pos.set(g.getAttribute('position').array as Float32Array, off);
-      norm.set(g.getAttribute('normal').array as Float32Array, off);
-      off += g.getAttribute('position').count * 3;
-    }
-    const out = new THREE.BufferGeometry();
-    out.setAttribute('position', new THREE.BufferAttribute(pos, 3));
-    out.setAttribute('normal', new THREE.BufferAttribute(norm, 3));
-    return out;
-  };
-  return { trunk: merge(trunkParts), fronds: merge(frondParts) };
-}
-
-const PALM_TRUNK_TINTS = [0xa8845c, 0x9a7852, 0xb08e66];
-const PALM_FROND_TINTS = [0x3fa04a, 0x4cb058, 0x36923f];
-
 export function buildJungleFeatures(seed: number): JungleFeaturesView {
   const group = new THREE.Group();
   group.name = 'jungle-features';
 
-  const instance = (
-    geo: THREE.BufferGeometry,
-    material: THREE.Material,
-    spots: { x: number; z: number; y: number; s: number; rot: number; tint?: number }[],
-    tinted = false,
-  ) => {
-    if (spots.length === 0) return;
-    const mesh = new THREE.InstancedMesh(geo, material, spots.length);
+  // --- the palms: the three beach models instanced across the strand, each
+  // at the deterministic spot (world.ts) the sim also gives a trunk collider,
+  // so the strand you walk matches the one the sim blocks ---
+  {
+    const byVariant: ReachPalm[][] = [[], [], []];
+    for (const sp of reachPalmSpots(seed)) byVariant[sp.variant]?.push(sp);
     const m = new THREE.Matrix4();
     const q = new THREE.Quaternion();
     const up = new THREE.Vector3(0, 1, 0);
     const v = new THREE.Vector3();
     const sc = new THREE.Vector3();
-    spots.forEach((sp, i) => {
-      q.setFromAxisAngle(up, sp.rot);
-      v.set(sp.x, sp.y, sp.z);
-      sc.set(sp.s, sp.s, sp.s);
-      mesh.setMatrixAt(i, m.compose(v, q, sc));
-      if (tinted && sp.tint !== undefined) mesh.setColorAt(i, new THREE.Color(sp.tint));
-    });
-    mesh.instanceMatrix.needsUpdate = true;
-    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
-    mesh.castShadow = true;
-    mesh.receiveShadow = true;
-    mesh.computeBoundingSphere();
-    group.add(mesh);
-  };
-
-  // --- the palms: a deterministic grid over the beach shelf, leaning at
-  // the sea (each palm's own lean is baked into the geometry; the rot
-  // spreads them so the strand never repeats) ---
-  {
-    const geos = palmGeos();
-    const spots: { x: number; z: number; y: number; s: number; rot: number; tint: number }[] = [];
-    for (let gx = -536; gx <= -184; gx += 8) {
-      for (let gz = REACH_ZMIN + 10; gz <= REACH_ZMAX - 10; gz += 8) {
-        const r = hash2(gx, gz, seed + 5101);
-        if (r > 0.62) continue;
-        const x = gx + (hash2(gx, gz, seed + 5111) - 0.5) * 7;
-        const z = gz + (hash2(gz, gx, seed + 5121) - 0.5) * 7;
-        const land = reachLandness(x, z);
-        // the beach band only: off the deep jungle, out of the surf
-        if (land < 0.045 || land > 0.24) continue;
-        const y = terrainHeight(x, z, seed);
-        if (y < WATER_LEVEL + 0.5 || y > 3.6) continue;
-        spots.push({
-          x,
-          z,
-          y: y - 0.15,
-          s: 0.85 + hash2(x, z, seed + 5131) * 0.5,
-          rot: hash2(z, x, seed + 5141) * Math.PI * 2,
-          tint: 0,
+    byVariant.forEach((list, variant) => {
+      const scene = palmScenes[variant];
+      if (!scene || list.length === 0) return;
+      for (const part of bakePalmParts(scene)) {
+        const mesh = new THREE.InstancedMesh(part.geometry, part.material, list.length);
+        list.forEach((sp, i) => {
+          q.setFromAxisAngle(up, sp.rot);
+          v.set(sp.x, sp.y, sp.z);
+          sc.set(sp.scale, sp.scale, sp.scale);
+          mesh.setMatrixAt(i, m.compose(v, q, sc));
         });
+        mesh.instanceMatrix.needsUpdate = true;
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        mesh.computeBoundingSphere();
+        group.add(mesh);
       }
-    }
-    const trunkSpots = spots.map((sp, i) => ({
-      ...sp,
-      tint: PALM_TRUNK_TINTS[i % PALM_TRUNK_TINTS.length],
-    }));
-    const frondSpots = spots.map((sp, i) => ({
-      ...sp,
-      tint: PALM_FROND_TINTS[i % PALM_FROND_TINTS.length],
-    }));
-    instance(geos.trunk, mat(0xffffff, 0.9), trunkSpots, true);
-    instance(geos.fronds, mat(0xffffff, 0.8), frondSpots, true);
+    });
   }
 
   // --- the banyans: the twisted elder regrown lush, hung with vines ---

--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -1196,12 +1196,22 @@ export function buildProps(seed: number, delveLabel?: (delveId: string) => strin
         scale: [0.78, 0.52, 0.85],
       });
     }
-    const hut = propAsset('house3');
-    addParts(g, 'house3', {
-      x: d.hutLocal.x,
-      z: d.hutLocal.z,
-      scale: [(d.hutLocal.hw * 2) / hut.size.x, 2.6 / hut.size.y, (d.hutLocal.hd * 2) / hut.size.z],
-    });
+    // hw/hd 0 means this dock carries no stone hut (e.g. the Farshore Landing).
+    // Skip it entirely: a zero-scale mesh has a degenerate (non-invertible)
+    // transform, which reads as NaN normals and flickers as a black square.
+    const hasHut = d.hutLocal.hw > 0 && d.hutLocal.hd > 0;
+    if (hasHut) {
+      const hut = propAsset('house3');
+      addParts(g, 'house3', {
+        x: d.hutLocal.x,
+        z: d.hutLocal.z,
+        scale: [
+          (d.hutLocal.hw * 2) / hut.size.x,
+          2.6 / hut.size.y,
+          (d.hutLocal.hd * 2) / hut.size.z,
+        ],
+      });
+    }
     if (!lowProps) {
       addParts(g, 'barrel', {
         x: 0.55,
@@ -1236,14 +1246,16 @@ export function buildProps(seed: number, delveLabel?: (delveId: string) => strin
     g.rotation.y = d.rot;
     group.add(shadowed(g));
     // stone hut OBB — same offset/extents/rotation as the collider
-    const hc = Math.cos(d.rot),
-      hs = Math.sin(d.rot);
-    const hx = d.x + d.hutLocal.x * hc + d.hutLocal.z * hs;
-    const hz = d.z - d.hutLocal.x * hs + d.hutLocal.z * hc;
-    registerHideable(
-      g,
-      obbFootprint(hx, hz, d.hutLocal.hw, d.hutLocal.hd, d.rot, ground(hx, hz) + 2.9),
-    );
+    if (hasHut) {
+      const hc = Math.cos(d.rot),
+        hs = Math.sin(d.rot);
+      const hx = d.x + d.hutLocal.x * hc + d.hutLocal.z * hs;
+      const hz = d.z - d.hutLocal.x * hs + d.hutLocal.z * hc;
+      registerHideable(
+        g,
+        obbFootprint(hx, hz, d.hutLocal.hw, d.hutLocal.hd, d.rot, ground(hx, hz) + 2.9),
+      );
+    }
   }
 
   // ---- delve entrance: Meshy portal-door + animated void + carved name lintel -

--- a/src/sim/colliders.ts
+++ b/src/sim/colliders.ts
@@ -34,6 +34,7 @@ import {
   type Decoration,
   generateDecorationsInBounds,
   groundHeight,
+  reachPalmSpots,
 } from './world';
 import { yumiMazeColliders } from './yumi_maze_layout';
 
@@ -132,6 +133,19 @@ function staticWorldColliders(seed: number): Collider[] {
       cameraTopY: topY(seed, t.x, t.z, 7),
       camGhost: true,
     });
+  // The Palmreach strand: a slim trunk collider at the base of every beach
+  // palm, from the same deterministic list the renderer instances the models
+  // from (world.ts). camGhost so the chase cam passes through instead of
+  // slamming in when a palm crosses the eye line.
+  for (const p of reachPalmSpots(seed))
+    out.push({
+      type: 'circle',
+      x: p.x,
+      z: p.z,
+      r: p.r,
+      cameraTopY: topY(seed, p.x, p.z, 7),
+      camGhost: true,
+    });
   for (const s of PROPS.stalls)
     out.push({
       type: 'circle',
@@ -150,8 +164,9 @@ function staticWorldColliders(seed: number): Collider[] {
     out.push({ type: 'circle', x, z, r: 5, cameraTopY: topY(seed, x, z, 5.2), camGhost: true });
   }
 
-  // dock huts
+  // dock huts (hw/hd 0 means no hut on this dock, e.g. the Farshore Landing)
   for (const d of PROPS.docks) {
+    if (d.hutLocal.hw <= 0 || d.hutLocal.hd <= 0) continue;
     const hut = rotY(d.hutLocal.x, d.hutLocal.z, d.rot);
     const x = d.x + hut.x,
       z = d.z + hut.z;

--- a/src/sim/content/farshore.ts
+++ b/src/sim/content/farshore.ts
@@ -301,7 +301,9 @@ export const FARSHORE_PROPS: ZonePropsDef = {
     { x: 314, z: 70, rot: -1.8, scale: 1 },
     { x: 292, z: 62, rot: 2.3, scale: 1 },
   ],
-  // the Landing's fishing pier, at the island end of the causeway
-  docks: [{ x: 246, z: 12, rot: -1.7, hutLocal: { x: 40, z: 40, hw: 0.1, hd: 0.1 } }],
+  // the Landing's fishing pier, at the island end of the causeway. No stone
+  // hut on this dock: hw/hd 0 collapse the optional hut to nothing (with the
+  // old 0.1/0.1 it drew as a thin post floating out over the water).
+  docks: [{ x: 246, z: 12, rot: -1.7, hutLocal: { x: 40, z: 40, hw: 0, hd: 0 } }],
   graveyards: [{ x: 290, z: 86 }],
 };

--- a/src/sim/content/galecrest.ts
+++ b/src/sim/content/galecrest.ts
@@ -204,8 +204,8 @@ export const GALECREST_PROPS: ZonePropsDef = {
     [420, 356],
     [196, 434], // the Windway's waycamp
   ],
-  // the harbor: a working dock running into the cove east of town
-  docks: [{ x: 436, z: 372, rot: 2.2, hutLocal: { x: 40, z: 40, hw: 0.1, hd: 0.1 } }],
+  // the harbor: a working dock running into the cove east of town (hw/hd 0: no hut)
+  docks: [{ x: 436, z: 372, rot: 2.2, hutLocal: { x: 40, z: 40, hw: 0, hd: 0 } }],
   fences: [
     // windbreak lines, the only fences that matter here
     { x1: 406, z1: 346, x2: 434, z2: 346 },

--- a/src/sim/content/palmreach.ts
+++ b/src/sim/content/palmreach.ts
@@ -217,7 +217,9 @@ export const PALMREACH_PROPS: ZonePropsDef = {
     [-418, 720], // the Tanglemouth's waycamp
   ],
   // a fishing dock running off the village beach into the shallows
-  docks: [{ x: -286, z: 838, rot: 0.6, hutLocal: { x: 40, z: 40, hw: 0.1, hd: 0.1 } }],
+  // Drifthaven's beach dock (kept on the strand: the flat coast has no open
+  // water nearby to reach). hw/hd 0: no hut, so no thin post floats off it.
+  docks: [{ x: -286, z: 838, rot: 0.6, hutLocal: { x: 40, z: 40, hw: 0, hd: 0 } }],
   mudHuts: [
     [-316, 826],
     [-290, 808],

--- a/src/sim/world.ts
+++ b/src/sim/world.ts
@@ -796,6 +796,63 @@ export function reachLandness(x: number, z: number): number {
   return metaballLandness(REACH_LAND_LOBES, REACH_BAYS, x, z);
 }
 
+// The Palmreach strand: the three shipped beach-palm models scattered on a
+// deterministic grid over the beach shelf. The renderer draws them
+// (render/jungle_features.ts) and the sim gives each a trunk collider
+// (sim/colliders.ts) from THIS one list, so what you bump into is exactly the
+// trunk you see. Pure function of the world seed, memoized (both hosts call it
+// with the same seed and must agree byte-for-byte).
+export interface ReachPalm {
+  x: number;
+  z: number;
+  y: number; // trunk base, sunk slightly into the sand
+  rot: number; // yaw
+  variant: number; // 0..2 -> beach_palm_{1,2,3}
+  scale: number; // uniform world scale applied to the model
+  r: number; // trunk collider radius, world units
+}
+
+// Native trunk heights of beach_palm_{1,2,3}.glb (pivot on the ground) and the
+// native trunk radius near the base, measured from the shipped GLBs. The
+// per-variant height normalizes all three to PALM_TARGET_H before the
+// per-spot size jitter, so the strand reads as one canopy height like the
+// neighbouring pines rather than three different species sizes.
+const PALM_NATIVE_H = [2.685, 2.689, 3.587];
+const PALM_TRUNK_R = 0.17; // native trunk radius (all three ~equal)
+const PALM_TARGET_H = 9; // rendered trunk height at size factor 1.0
+
+let reachPalmCache: { seed: number; spots: ReachPalm[] } | null = null;
+
+export function reachPalmSpots(seed: number): ReachPalm[] {
+  if (reachPalmCache && reachPalmCache.seed === seed) return reachPalmCache.spots;
+  const spots: ReachPalm[] = [];
+  for (let gx = -536; gx <= -184; gx += 8) {
+    for (let gz = REACH_ZMIN + 10; gz <= REACH_ZMAX - 10; gz += 8) {
+      if (hash2(gx, gz, seed + 5101) > 0.62) continue; // thin the grid (~38% kept)
+      const x = gx + (hash2(gx, gz, seed + 5111) - 0.5) * 7;
+      const z = gz + (hash2(gz, gx, seed + 5121) - 0.5) * 7;
+      const land = reachLandness(x, z);
+      if (land < 0.045 || land > 0.24) continue; // the beach band only
+      const y = terrainHeight(x, z, seed);
+      if (y < WATER_LEVEL + 0.5 || y > 3.6) continue; // out of the surf, off the bluff
+      const variant = Math.floor(hash2(x, z, seed + 5151) * 3);
+      const scale =
+        (PALM_TARGET_H / PALM_NATIVE_H[variant]) * (0.85 + hash2(x, z, seed + 5131) * 0.5);
+      spots.push({
+        x,
+        z,
+        y: y - 0.15,
+        rot: hash2(z, x, seed + 5141) * Math.PI * 2,
+        variant,
+        scale,
+        r: PALM_TRUNK_R * scale,
+      });
+    }
+  }
+  reachPalmCache = { seed, spots };
+  return spots;
+}
+
 // The tropical coast: the fen recipe, then every low shore flattened into a
 // broad sand shelf (the beach cap) so the strand runs wide and walkable.
 function applyReachCoast(x: number, z: number, h: number): number {


### PR DESCRIPTION
Hey @enriquegf — small content/render cleanup I split out on top of the `feature/procedural-dungeons` branch so it's easy to review on its own. Two things: a **palm-tree update** and the **removal of the floating dock pillar**.

## 1. Palm trees (the Palmreach)

The Palmreach's beach palms were procedurally built from cylinders + cones in `render/jungle_features.ts` and read as broken/placeholder. I replaced them with the three shipped GLB models (`public/models/biome/beach_palm_{1,2,3}.glb`):

- **Instanced, not cloned** — one `InstancedMesh` per variant, so the whole ~134-palm strand is **3 draw calls**. The meshopt-quantized attributes are baked to float32 before folding in the node transform (same recipe as `foliage.ts`).
- **Scaled to match the biome pines** — each variant is normalized to a ~9u trunk height (the three models ship at different native sizes) before the per-spot size jitter, so the strand reads as one canopy height instead of three species.
- **Placement + colliders share one source of truth.** New pure `reachPalmSpots(seed)` in `sim/world.ts` (the same deterministic beach grid the old render code used) now feeds *both* the renderer **and** `sim/colliders.ts`, which drops a slim trunk collider at each palm (`r ≈ 0.17·scale`, `camGhost` like the banyans). So the trunk you bump into is exactly the trunk you see, and both hosts stay byte-identical.

## 2. Floating "dock pillar" removal

Every dock draws an *optional* stone hut in `render/props.ts` (from `ZonePropsDef.docks[].hutLocal`). Docks using the `{x:40, z:40, hw:0.1, hd:0.1}` "no hut" sentinel — Farshore, Galecrest, Palmreach (Willowfen's own comment says *"so no hut renders"*) — never actually suppressed it: it drew as a **0.2 × 2.6 thin post floating ~50u out over the water**. That's the pillar.

Fix: the renderer **and** the collider now **skip the hut entirely when its footprint is zero**, and those three docks set `hw/hd` to `0`. (Zero-*scaling* the mesh instead — my first attempt — leaves a degenerate non-invertible transform that flickers as a black square, so skipping the build is the right move.) The real stone huts (Eastbrook / Mirefen, `hw 1.7`) are untouched, and **no dock positions changed**.

### Notes / not done
- **Willowfen's** dock is the moat **bridge**, not a fishing pier, so I left it alone (still has its `0.1` stub).
- The docks sit slightly inland of their shorelines. I tried auto-snapping them to jut out over the water and backed it out — it's a per-zone hand-placement job, left for a follow-up if we want it.

### Testing
- `tsc` clean; biome clean on the changed files.
- Verified in offline Chrome (`go.palm()`, `go.isle()`, …): palms render + scale right, trunk collisions match the meshes (checked via the sim's own `resolveMove`), the Farshore/Palmreach floating posts are gone with no black-square flicker, and general movement is unchanged (normal run speed, open ground resolves freely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
