### PR TITLE
feat(play): make /play online-only with Discord login, TOS links, and the hero backdrop

### DIFF
--- a/play.html
+++ b/play.html
@@ -471,9 +471,12 @@
     <!-- Keep the backdrop here at the top level so it spans the entire screen behind content -->
     <div id="start-screen-backdrop" aria-hidden="true">
       <!-- Looping cinematic background video; poster = static key-art for instant paint + fallback. -->
-      <video id="bg-home" class="bg-trailer bg-home" autoplay loop muted playsinline preload="auto" poster="/home-bg.png" aria-hidden="true">
-        <source src="/home-bg.mp4" type="video/mp4" />
-      </video>
+      <!-- Same backdrop as the landing-page hero (index.html). The poster paints
+           instantly; the looping trailer is NOT eagerly fetched (no autoplay, no
+           preload, no <source>): main.ts attaches the source and plays only on
+           capable devices (see applyLandingBackdrop). Phones, Save-Data, reduced
+           motion, and high contrast keep the poster only. -->
+      <video id="bg-home" class="bg-trailer bg-home" loop muted playsinline preload="none" poster="/home-bg.png" aria-hidden="true" data-trailer-src="/home-bg.mp4"></video>
       <div class="bg-trailer-scrim"></div>
       <div class="portal-ring"></div>
       <div class="portal-ring-reverse"></div>
@@ -535,58 +538,24 @@
         <img class="main-logo" id="title-logo" src="/worldofclaudecraft-logo.png" data-i18n-alt="serverUnavailable.logoAlt" alt="World of ClaudeCraft" />
 
         <div id="mode-select">
-          <div class="play-console">
-            <!-- Realm selector: a themed dropdown that defaults to Online and can switch to Offline.
-                 It only chooses the destination; the Play button below commits. -->
-            <div class="server-select" id="server-select" data-mode="online">
-              <button type="button" class="server-select-trigger" id="server-select-trigger"
-                aria-haspopup="listbox" aria-expanded="false" aria-controls="server-select-menu"
-                data-i18n-aria="mode.serverAria" aria-label="Select realm: Online or Offline">
-                <span class="server-dot" data-mode="online" aria-hidden="true"></span>
-                <span class="server-select-text">
-                  <span class="server-select-value" id="server-select-value" data-i18n="mode.serverOnline">Online</span>
-                  <span class="server-select-sub" id="server-select-sub">
-                    <span class="server-realm-line" data-mode="online">
-                      <b class="stats-value js-stat-accounts">…</b> <span data-i18n="stats.accountsCreated">Players</span>
-                    </span>
-                    <span class="server-sub-offline" data-mode="offline" data-i18n="mode.serverOfflineSub" hidden>Instant local world</span>
-                  </span>
-                </span>
-                <svg class="server-select-chevron" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-              </button>
-              <ul class="server-select-menu" id="server-select-menu" role="listbox" data-i18n-aria="mode.serverAria" aria-label="Select realm: Online or Offline" hidden>
-                <li class="server-select-option is-selected" id="server-opt-online" role="option" data-mode="online" tabindex="-1" aria-selected="true">
-                  <span class="server-dot" data-mode="online" aria-hidden="true"></span>
-                  <span class="server-opt-text">
-                    <span class="server-opt-name" data-i18n="mode.serverOnline">Online</span>
-                    <span class="server-opt-desc" data-i18n="mode.onlineDesc">Log in to the realm. Your characters live on the server and you share the world with everyone else who's on.</span>
-                    <span class="server-opt-stats">
-                      <b class="stats-value js-stat-accounts">…</b> <span data-i18n="stats.accountsCreated">Players</span>
-                    </span>
-                  </span>
-                  <svg class="server-opt-check" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
-                </li>
-                <li class="server-select-option" id="server-opt-offline" role="option" data-mode="offline" tabindex="-1" aria-selected="false">
-                  <span class="server-dot" data-mode="offline" aria-hidden="true"></span>
-                  <span class="server-opt-text">
-                    <span class="server-opt-name" data-i18n="mode.serverOffline">Offline</span>
-                    <span class="server-opt-desc" data-i18n="mode.offlineDesc">Instant single-player world in your browser. Nothing is saved: perfect for a quick brawl or testing.</span>
-                  </span>
-                  <svg class="server-opt-check" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
-                </li>
-              </ul>
-            </div>
-
+          <div class="play-console play-console-solo">
+            <!-- /play goes straight to the online realm: no Online/Offline selector on
+                 this entry (the landing page keeps it). The Play button commits directly
+                 to the online flow (login, or realm select when a session is restored). -->
             <button type="button" class="btn-play" id="btn-play" data-i18n-aria="mode.playAria" aria-label="Play World of ClaudeCraft">
               <span class="btn-play-sheen" aria-hidden="true"></span>
               <span class="btn-play-label" data-i18n="mode.play">Play</span>
             </button>
+            <div class="play-online-status">
+              <span class="server-dot" data-mode="online" aria-hidden="true"></span>
+              <b class="stats-value js-stat-accounts">…</b> <span data-i18n="stats.accountsCreated">Players</span>
+            </div>
           </div>
 
-          <!-- Hidden, non-focusable compatibility triggers. Stable hooks the automated
-               tours / E2E scripts use to drive the online & offline flows directly. -->
+          <!-- Hidden, non-focusable compatibility trigger. Stable hook the automated
+               tours / E2E scripts use to drive the online flow directly. This entry is
+               online-only, so there is no #btn-offline here (index.html keeps both). -->
           <button type="button" id="btn-online" class="play-compat-trigger" tabindex="-1" aria-hidden="true"></button>
-          <button type="button" id="btn-offline" class="play-compat-trigger" tabindex="-1" aria-hidden="true"></button>
 
           <!-- Tip — part of the same play container (divider above). -->
           <div class="play-tip">
@@ -596,7 +565,13 @@
 
         <form id="login-panel" class="panel auth-panel auth-panel-premium" data-auth-mode="login" hidden novalidate>
           <h2 class="auth-title" id="auth-title" data-i18n="auth.enterRealm">Enter the Realm</h2>
-          
+          <!-- First-class onboarding: Continue with Discord at the top of the form. -->
+          <button type="button" class="btn" id="btn-login-discord" hidden style="width:100%;margin:4px 0 12px;background:linear-gradient(180deg,#5865f2,#404ac4);border-color:#2a2f7a;color:#fff;display:flex;align-items:center;justify-content:center;gap:8px;font-weight:600;min-height:42px;">
+            <svg viewBox="0 0 127.14 96.36" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M107.7 8.07A105.15 105.15 0 0 0 81.47 0a72.06 72.06 0 0 0-3.36 6.83 97.68 97.68 0 0 0-29.11 0A72.37 72.37 0 0 0 45.64 0a105.89 105.89 0 0 0-26.25 8.09C2.79 32.65-1.71 56.6.54 80.21a105.73 105.73 0 0 0 32.17 16.15 77.7 77.7 0 0 0 6.89-11.11 68.42 68.42 0 0 1-10.85-5.18c.91-.66 1.8-1.34 2.66-2a75.57 75.57 0 0 0 64.32 0c.87.71 1.76 1.39 2.66 2a68.68 68.68 0 0 1-10.87 5.19 77 77 0 0 0 6.89 11.1 105.25 105.25 0 0 0 32.19-16.14c2.64-27.38-4.51-51.11-18.9-72.15zM42.45 65.69C36.18 65.69 31 60 31 53s5-12.74 11.43-12.74S54 46 53.89 53s-5.05 12.69-11.44 12.69zm42.24 0C78.41 65.69 73.25 60 73.25 53s5-12.74 11.44-12.74S96.23 46 96.12 53s-5.04 12.69-11.43 12.69z"/></svg>
+            <span data-i18n="hudChrome.discord.loginCta">Continue with Discord</span>
+          </button>
+          <div id="auth-or-divider" class="auth-or" hidden><span data-i18n="hudChrome.discord.orEmail">or use email</span></div>
+
           <div class="auth-field">
             <label for="login-user" class="auth-label" data-i18n="auth.username">Username</label>
             <div id="login-user-error" class="auth-field-error" aria-live="polite" data-i18n="auth.usernameError">Please enter your username.</div>
@@ -835,42 +810,9 @@
           </div>
         </div>
 
-        <div id="offline-select" class="panel auth-panel auth-panel-premium cs-wow" hidden>
-          <h2 class="auth-title" data-i18n="auth.offlineCharacter">Offline Character</h2>
-          <div class="charselect-layout">
-            <!-- Left Column: Character Name & Class Chips & Actions -->
-            <div class="charselect-col-left">
-              <div class="char-create">
-                <label for="char-name" class="auth-label" data-i18n="auth.characterName">Character Name</label>
-                <div class="char-input-group">
-                  <input id="char-name" maxlength="16" data-i18n-placeholder="auth.characterNamePlaceholder" placeholder="Character name" value="" aria-describedby="offline-error" autocomplete="off" />
-                  <div id="offline-error" class="auth-error" aria-live="polite"></div>
-                </div>
-                <ul class="mini-class-row" role="list">
-                  <li class="mini-class" data-class="warrior" role="button" tabindex="0" data-i18n-aria="classes.warriorAria" data-i18n="classes.warrior" aria-label="Warrior class" aria-pressed="false">Warrior</li>
-                  <li class="mini-class" data-class="paladin" role="button" tabindex="0" data-i18n-aria="classes.paladinAria" data-i18n="classes.paladin" aria-label="Paladin class" aria-pressed="false">Paladin</li>
-                  <li class="mini-class" data-class="hunter" role="button" tabindex="0" data-i18n-aria="classes.hunterAria" data-i18n="classes.hunter" aria-label="Hunter class" aria-pressed="false">Hunter</li>
-                  <li class="mini-class" data-class="rogue" role="button" tabindex="0" data-i18n-aria="classes.rogueAria" data-i18n="classes.rogue" aria-label="Rogue class" aria-pressed="false">Rogue</li>
-                  <li class="mini-class" data-class="priest" role="button" tabindex="0" data-i18n-aria="classes.priestAria" data-i18n="classes.priest" aria-label="Priest class" aria-pressed="false">Priest</li>
-                  <li class="mini-class" data-class="shaman" role="button" tabindex="0" data-i18n-aria="classes.shamanAria" data-i18n="classes.shaman" aria-label="Shaman class" aria-pressed="false">Shaman</li>
-                  <li class="mini-class" data-class="mage" role="button" tabindex="0" data-i18n-aria="classes.mageAria" data-i18n="classes.mage" aria-label="Mage class" aria-pressed="false">Mage</li>
-                  <li class="mini-class" data-class="warlock" role="button" tabindex="0" data-i18n-aria="classes.warlockAria" data-i18n="classes.warlock" aria-label="Warlock class" aria-pressed="false">Warlock</li>
-                  <li class="mini-class" data-class="druid" role="button" tabindex="0" data-i18n-aria="classes.druidAria" data-i18n="classes.druid" aria-label="Druid class" aria-pressed="false">Druid</li>
-                </ul>
-                <div id="offline-skin-row" class="skin-row" role="list" data-i18n-aria="auth.appearance" aria-label="Skin"></div>
-                <div class="auth-actions">
-                  <button type="button" class="btn btn-primary" id="btn-start-offline" data-i18n="auth.enterWorld">Enter World</button>
-                  <button type="button" class="btn btn-secondary" id="btn-offline-back" data-i18n="auth.back">Back</button>
-                </div>
-              </div>
-            </div>
-            <!-- Right Column: Detailed Class Info & Preview -->
-            <div class="charselect-col-right">
-              <div class="char-preview-container" id="offline-preview-container"></div>
-              <div id="offline-class-details" class="class-details-panel" aria-live="polite"></div>
-            </div>
-          </div>
-        </div>
+        <!-- This entry is online-only: the offline single-player flow (#offline-select)
+             lives on the landing page (index.html); /play goes straight to the online
+             realm. main.ts guards the offline wiring on element presence. -->
       </section>
 
       <section id="highscores-view" class="view-section" hidden aria-hidden="true">
@@ -957,6 +899,10 @@
         </a>
       </div>
       <div id="game-version">v0.24.1</div>
+      </div>
+      <div class="footer-legal-row">
+        <a href="/terms" class="footer-link" data-i18n="footer.terms">Terms of Service</a>
+        <a href="/privacy" class="footer-link" data-i18n="footer.privacy">Privacy Policy</a>
       </div>
       <div class="footer-lang-row">
         <div class="language-selector">

--- a/src/main.ts
+++ b/src/main.ts
@@ -6832,20 +6832,27 @@ function wireStartScreens(): void {
     handleKeyboardActivation(e as KeyboardEvent, handleOnlineSelect),
   );
 
-  offlineBtn.addEventListener('click', handleOfflineSelect);
-  offlineBtn.addEventListener('keydown', (e) =>
-    handleKeyboardActivation(e as KeyboardEvent, handleOfflineSelect),
-  );
+  // play.html is online-only: it ships no #btn-offline compat trigger, no
+  // #offline-select panel, and no realm dropdown, so every offline / dropdown
+  // hook below resolves defensively and skips wiring when the markup is absent.
+  if (offlineBtn) {
+    offlineBtn.addEventListener('click', handleOfflineSelect);
+    offlineBtn.addEventListener('keydown', (e) =>
+      handleKeyboardActivation(e as KeyboardEvent, handleOfflineSelect),
+    );
+  }
 
   // --- Play console: realm dropdown + single Play CTA -----------------------
   // The dropdown only chooses the destination (defaults to Online); the Play
   // button commits, routing to the same online/offline flows as the legacy cards.
+  // play.html has no dropdown: its Play button commits straight to online below.
   const serverSelect = $('#server-select');
-  const serverTrigger = $('#server-select-trigger') as HTMLButtonElement;
+  const serverTrigger = $('#server-select-trigger') as HTMLButtonElement | null;
   const serverMenu = $('#server-select-menu');
   const serverValue = $('#server-select-value');
   const serverSub = $('#server-select-sub');
-  const serverTriggerDot = serverTrigger.querySelector('.server-dot') as HTMLElement | null;
+  const serverTriggerDot = (serverTrigger?.querySelector('.server-dot') ??
+    null) as HTMLElement | null;
   const btnPlay = $('#btn-play') as HTMLButtonElement;
 
   if (serverSelect && serverTrigger && serverMenu && btnPlay) {
@@ -6972,16 +6979,24 @@ function wireStartScreens(): void {
     });
 
     applyServerMode('online');
+  } else if (btnPlay) {
+    // Online-only entry (play.html): no realm dropdown in the console, so the
+    // Play button commits straight to the online flow.
+    btnPlay.addEventListener('click', handleOnlineSelect);
   }
 
-  btnStartOffline.addEventListener('click', () => {
-    const selCard = document.querySelector('#offline-select .mini-class.sel') as HTMLElement | null;
-    if (selCard) {
-      handleOfflineStart(selCard.dataset.class as PlayerClass);
-    } else {
-      offlineError.textContent = t('errors.selectClass');
-    }
-  });
+  if (btnStartOffline) {
+    btnStartOffline.addEventListener('click', () => {
+      const selCard = document.querySelector(
+        '#offline-select .mini-class.sel',
+      ) as HTMLElement | null;
+      if (selCard) {
+        handleOfflineStart(selCard.dataset.class as PlayerClass);
+      } else {
+        offlineError.textContent = t('errors.selectClass');
+      }
+    });
+  }
 
   // offline class chips
   document.querySelectorAll('#offline-select .mini-class').forEach((card) => {
@@ -7092,7 +7107,7 @@ function wireStartScreens(): void {
     offlineNameInput.classList.remove('user-invalid-fallback');
     offlineNameInput.removeAttribute('aria-invalid');
   };
-  offlineBackBtn.addEventListener('click', handleOfflineBack);
+  if (offlineBackBtn) offlineBackBtn.addEventListener('click', handleOfflineBack);
 
   // login
   const doAuth = async (mode: 'login' | 'register') => {
@@ -7558,8 +7573,9 @@ function wireStartScreens(): void {
     }
   });
 
-  // Wire dynamic validation clearing on typing
-  [offlineNameInput, newCharNameInput].forEach((input) => {
+  // Wire dynamic validation clearing on typing. The offline name input only
+  // exists on the landing page (play.html is online-only), so skip a missing one.
+  [offlineNameInput, newCharNameInput].filter(Boolean).forEach((input) => {
     const errorEl = input.id === 'char-name' ? offlineError : charselectError;
     input.addEventListener('input', () => {
       errorEl.textContent = '';
@@ -8196,9 +8212,11 @@ function wireStartScreens(): void {
 
   // Initialize 3D character preview once assets are ready
   assetsReady().then(() => {
-    const activePanelId = ['#charselect-panel', '#offline-select'].find(
-      (id) => !$(id).hasAttribute('hidden'),
-    );
+    // Resolve each panel defensively: play.html (online-only) has no #offline-select.
+    const activePanelId = ['#charselect-panel', '#offline-select'].find((id) => {
+      const panel = $(id) as HTMLElement | null;
+      return panel !== null && !panel.hasAttribute('hidden');
+    });
     const containerId =
       activePanelId === '#offline-select'
         ? '#offline-preview-container'

--- a/src/styles/play.extra.css
+++ b/src/styles/play.extra.css
@@ -5,9 +5,10 @@
 
    play.html is otherwise reconciled to the canonical modules (its inline <style>
    was emptied, so it now renders from the shared src/styles layers exactly like
-   index.html). The ONLY intentional per-entry difference is the #rotate-device
+   index.html). The intentional per-entry differences are: the #rotate-device
    orientation gate (landscape-only in-game): play.html SHOWS the
-   rotate-to-landscape overlay in portrait while in-game, matching index.extra.css.
+   rotate-to-landscape overlay in portrait while in-game, matching index.extra.css;
+   and the online-only play console (/play has no Online/Offline realm selector).
    Layer name is flat (play-extra), NOT dotted, so it is a top-level layer placed
    last by the order below, after hud-mobile. */
 @layer tokens, base, layout, components, hud, shell, hud-mobile, index-extra, play-extra;
@@ -17,5 +18,33 @@
     body.mobile-touch.game-active #rotate-device {
       display: flex;
     }
+  }
+
+  /* /play is online-only: the play console is just the Play button over a live
+     players line (no realm selector). Undo the two-column landscape grid the
+     shared hud.mobile.css applies to the selector + button pair. */
+  .play-console-solo,
+  body.mobile-touch .play-console-solo {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    max-width: 420px;
+    margin-inline: auto;
+  }
+  .play-console-solo .btn-play {
+    width: 100%;
+  }
+  .play-online-status {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--font-ui);
+    font-size: 13px;
+    color: var(--color-text-muted);
+    text-shadow: 1px 1px 2px #000;
+  }
+  .play-online-status .stats-value {
+    color: var(--color-text-light);
   }
 }

--- a/tests/play_online_only.test.ts
+++ b/tests/play_online_only.test.ts
@@ -1,0 +1,121 @@
+// The /play entry (play.html) goes straight to the ONLINE realm: it ships no
+// Online/Offline realm dropdown and no offline single-player panel (both stay on
+// the landing page, index.html), carries the Continue with Discord login and the
+// Terms of Service footer link, and uses the same lazily-attached hero backdrop
+// as the landing page. main.ts is shared by both entries, so every hook the
+// online-only entry omits must be resolved defensively there; these tests pin
+// both sides of that contract so one entry cannot silently break the other.
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const read = (p: string) =>
+  readFileSync(new URL(`../${p}`, import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+const playHtml = read('play.html');
+const indexHtml = read('index.html');
+const mainTs = read('src/main.ts');
+const playExtraCss = read('src/styles/play.extra.css');
+
+describe('/play is online-only', () => {
+  it('play.html has no realm dropdown and no offline flow', () => {
+    for (const id of [
+      'server-select',
+      'server-select-menu',
+      'server-opt-offline',
+      'offline-select',
+      'btn-offline',
+      'btn-start-offline',
+      'btn-offline-back',
+    ]) {
+      expect(playHtml).not.toContain(`id="${id}"`);
+    }
+    // The online compat trigger stays: E2E tours drive the online flow through it.
+    expect(playHtml).toContain('id="btn-online"');
+    // The solo console keeps the single Play CTA plus the live players line.
+    expect(playHtml).toContain('class="play-console play-console-solo"');
+    expect(playHtml).toContain('id="btn-play"');
+    expect(playHtml).toContain('js-stat-accounts');
+  });
+
+  it('index.html (the landing page) keeps the realm dropdown and offline flow', () => {
+    for (const id of ['server-select', 'server-opt-offline', 'offline-select', 'btn-offline']) {
+      expect(indexHtml).toContain(`id="${id}"`);
+    }
+  });
+
+  it('main.ts wires the Play button straight to online when the dropdown is absent', () => {
+    // The dropdown block is conditional; without it the Play button must still be
+    // wired (to the online flow), or /play renders a dead Play button.
+    expect(mainTs).toContain("btnPlay.addEventListener('click', handleOnlineSelect);");
+  });
+
+  it('main.ts resolves every /play-absent hook defensively', () => {
+    // Each of these throws at boot on /play if resolved without a guard.
+    expect(mainTs).toContain('if (offlineBtn) {');
+    expect(mainTs).toContain('if (btnStartOffline) {');
+    expect(mainTs).toContain("if (offlineBackBtn) offlineBackBtn.addEventListener('click'");
+    expect(mainTs).toContain("serverTrigger?.querySelector('.server-dot')");
+    // The character-preview boot probe must skip a missing #offline-select, not
+    // dereference it (and a missing panel must not be treated as the active one).
+    expect(mainTs).toContain('return panel !== null && !panel.hasAttribute(');
+  });
+});
+
+describe('/play login panel carries Continue with Discord', () => {
+  it('play.html ships the Discord login button and the or-email divider', () => {
+    expect(playHtml).toContain('id="btn-login-discord"');
+    expect(playHtml).toContain('data-i18n="hudChrome.discord.loginCta"');
+    expect(playHtml).toContain('id="auth-or-divider"');
+  });
+
+  it('main.ts reveals the button only when present and Discord is enabled', () => {
+    expect(mainTs).toContain('if (discordLoginBtn && DISCORD_BUILD_ENABLED)');
+  });
+});
+
+describe('/play footer carries the legal links', () => {
+  it('play.html links the Terms of Service and Privacy Policy', () => {
+    expect(playHtml).toContain('href="/terms"');
+    expect(playHtml).toContain('data-i18n="footer.terms"');
+    expect(playHtml).toContain('href="/privacy"');
+    expect(playHtml).toContain('data-i18n="footer.privacy"');
+  });
+});
+
+describe('/play uses the landing hero backdrop', () => {
+  it('play.html defers the trailer exactly like index.html (poster paints first)', () => {
+    // Same lazily-attached pattern as the landing hero: data-trailer-src, no
+    // eager <source>, no autoplay, preload="none" (applyLandingBackdrop attaches
+    // and plays the trailer only on capable devices).
+    expect(playHtml).toContain('data-trailer-src="/home-bg.mp4"');
+    expect(playHtml).toContain('poster="/home-bg.png"');
+    expect(playHtml).not.toContain('<source src="/home-bg.mp4"');
+    const playVideoTag = /<video id="bg-home"[^>]*>/.exec(playHtml)?.[0] ?? '';
+    const indexVideoTag = /<video id="bg-home"[^>]*>/.exec(indexHtml)?.[0] ?? '';
+    expect(playVideoTag).not.toContain('autoplay');
+    expect(playVideoTag).toContain('preload="none"');
+    expect(playVideoTag).toBe(indexVideoTag);
+  });
+});
+
+describe('/play keeps its tracking and SEO head', () => {
+  it('play.html keeps the Google tag with the localhost guard', () => {
+    expect(playHtml).toContain('googletagmanager.com/gtag/js?id=G-BR5Z7GT7C2');
+    expect(playHtml).toContain("gtag('config', 'G-BR5Z7GT7C2')");
+    expect(playHtml).toContain("['localhost', '127.0.0.1', '[::1]'].includes(location.hostname)");
+  });
+
+  it('play.html keeps its canonical /play SEO surface', () => {
+    expect(playHtml).toContain(
+      '<link rel="canonical" href="https://worldofclaudecraft.com/play" />',
+    );
+    expect(playHtml).toContain('property="og:url" content="https://worldofclaudecraft.com/play"');
+  });
+});
+
+describe('/play solo console styling stays per-entry', () => {
+  it('play.extra.css styles the solo console (and only play.html loads it)', () => {
+    expect(playExtraCss).toContain('.play-console-solo');
+    expect(playExtraCss).toContain('.play-online-status');
+    expect(indexHtml).not.toContain('play.extra.css');
+  });
+});


### PR DESCRIPTION
## Summary

The /play entry now goes straight to the ONLINE realm, per the v0.25.0 release work (#1777):

- **Online-only console**: the Online/Offline realm dropdown (`#server-select`) and the offline single-player panel (`#offline-select`) are removed from play.html only; the landing page (index.html) keeps both. The console is now a solo Play button over a live players line, and Play commits straight to the online flow (login, or realm select when a session is restored).
- **Continue with Discord**: the login panel gains the first-class Discord login button and the or-use-email divider, byte-for-byte mirroring index.html. It is revealed by the existing guarded wiring (`DISCORD_BUILD_ENABLED`).
- **TOS**: the footer gains the legal row with the Terms of Service and Privacy Policy links, matching the landing page.
- **Hero backdrop**: the backdrop video switches from eager `autoplay preload="auto"` to the landing hero's lazy `data-trailer-src` pattern; the poster paints first and `applyLandingBackdrop` attaches the trailer only on capable devices (phones / Save-Data / reduced-motion / high-contrast keep the poster).
- **Tracking kept**: the gtag block (localhost-guarded), canonical /play URL, hreflang set, OG/Twitter/JSON-LD head are all unchanged (pinned by the new test).

src/main.ts is shared by both entries, so every hook /play no longer ships is resolved defensively (offline triggers, offline panel wiring, the realm dropdown trigger dot, the name-input validation loop, the assetsReady character-preview probe), and the Play button is wired straight to `handleOnlineSelect` when the dropdown is absent. A boot-time crash for any entry missing `#offline-select` (`$('#offline-select').hasAttribute`) is fixed along the way.

Only existing i18n keys are reused (no new English strings, no locale overlay edits).

## Tests

- New `tests/play_online_only.test.ts` pins both sides of the contract: play.html drops the dropdown/offline ids while index.html keeps them, Discord CTA + legal links + deferred backdrop parity with index.html, the gtag/SEO head, and the main.ts guards.
- Full suite green: 1016 files / 12752 tests passed; `tsc --noEmit` clean; `npm run build` succeeds; biome clean on changed files.
- Verified in a real browser (desktop + mobile-landscape emulation): zero page errors on both / and /play, Play opens the login panel with the visible Discord CTA, the trailer attaches lazily, and the solo console lays out correctly under `body.mobile-touch`.
- QA gate (qa-checklist) run over the diff: zero blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)