### PR TITLE
fix(sim): bound pet recovery and add CPU incident profiling

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -268,6 +268,78 @@ unsupported extra key is rejected by the client and needs a normal game
 deployment instead. Compatible constrained mob-subfamily keys may be added by
 an artifact.
 
+## Automatic production CPU incident capture
+
+`npm run ops:cpu-monitor` watches Docker CPU and attaches to the game only after a
+confirmed trigger. By default it polls every 30 seconds, confirms that two of three
+samples exceed 90%, and then records a 20-second V8 CPU profile at a 4 ms sampling
+interval. The profile is temporary and event-triggered, so the profiler has no
+steady-state game-loop cost.
+
+Run the monitor as a supervised service on an always-on private operations host,
+not in the game container. The Levy Street deployment should manage that service
+in the private Ansible repo, where SSH aliases and credentials already live. A
+representative direct invocation from that host is:
+
+```bash
+npm run ops:cpu-monitor -- \
+  --direct \
+  --host world-of-claudecraft-prod \
+  --container eastbrook-game \
+  --out-dir /var/lib/woc-prod-cpu-monitor
+```
+
+The service unit should use `Restart=always`, `RestartSec=10`, `UMask=0077`, an
+unprivileged local user, and the repository checkout as its working directory. With
+systemd, use `StateDirectory=woc-prod-cpu-monitor` and
+`StateDirectoryMode=0700`; the monitor safely initializes an empty, private,
+service-owned directory on first use. The remote SSH principal needs narrowly
+controlled access to the Docker operations used by the script and to `flock` for
+capture serialization. General `sudo docker` access is effectively root access.
+Use a dedicated principal plus a root-owned forced-command or validation wrapper
+that admits only the expected container and monitor operations; do not grant a
+wildcard Docker sudo rule to an ordinary account.
+
+The monitor verifies private file ownership and permissions, uses local and remote
+exclusive locks, and retains at most 24 validated captures or 30 days of captures.
+Captures and process logs can contain sensitive operational data, so the artifact
+directory must stay private and must not be served over HTTP.
+
+Each incident directory includes `cpu.cpuprofile`, game and perf logs,
+container/process snapshots, Docker stats before/during/after, metadata, and SHA-256
+checksums. Open `cpu.cpuprofile` with the Load profile action in the Chrome DevTools
+Performance panel. Review `metadata.json` first: `complete` should be true and
+`profileStartDelayMs` records the delay until the profiler acknowledged it had
+started. A fully complete directory also contains a `COMPLETE` marker written after
+the metadata and checksum manifest. A valid CPU profile is retained even if
+supporting context is degraded. The `errors` array explains any missing auxiliary
+artifact without triggering a second profile every two minutes.
+
+Detailed tick-profiler JSON is optional. It requires an existing staff bearer that
+can access the `ops.perf` admin routes, supplied through a service-owned mode-0600
+file with `--ops-token-file`. The current role model does not provide a dedicated
+machine-only bearer, so do not copy a broad personal admin session into the service.
+Provision a narrowly scoped service credential in the server before enabling this
+option. When enabled, `tickCapture` in `metadata.json` must be `complete`.
+The tick result also records loop callback count, sim tick count, catch-up callback
+count, and maximum ticks per callback so callback aggregation is visible during a
+saturation event.
+
+Before enabling the service, verify its SSH user has only the required passwordless
+Docker commands and run one controlled check:
+
+```bash
+npm run ops:cpu-monitor -- --once --dry-run --direct \
+  --host world-of-claudecraft-prod \
+  --container eastbrook-game \
+  --out-dir /var/lib/woc-prod-cpu-monitor
+```
+
+Once automatic tick capture is working, remove `PERF_TICK_LOG=1` from production.
+The admin-triggered profiler enables detailed sim sub-phase timing only during its
+wall-clock capture window; leaving the environment flag enabled would keep that
+extra instrumentation active on every tick.
+
 ## Admin dashboard
 
 The admin dashboard (account/character/session metrics, live players,

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -297,8 +297,13 @@ service-owned directory on first use. The remote SSH principal needs narrowly
 controlled access to the Docker operations used by the script and to `flock` for
 capture serialization. General `sudo docker` access is effectively root access.
 Use a dedicated principal plus a root-owned forced-command or validation wrapper
-that admits only the expected container and monitor operations; do not grant a
-wildcard Docker sudo rule to an ordinary account.
+that admits only the exact expected commands for the named container; do not grant
+a wildcard Docker sudo rule to an ordinary account. The PID and profiler clients
+are immutable, root-owned helpers copied into `/app/ops` by the production image,
+and their `docker exec` calls do not consume client-supplied stdin. The wrapper must
+validate the complete `SSH_ORIGINAL_COMMAND`, reject unexpected stdin, and allow
+only those fixed helper paths. Checking only a `docker exec` command prefix still
+permits arbitrary code execution in the production container and is not sufficient.
 
 The monitor verifies private file ownership and permissions, uses local and remote
 exclusive locks, and retains at most 24 validated captures or 30 days of captures.

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ COPY --from=build /app/dist ./dist
 COPY --from=build /app/media-build ./media-build
 COPY --from=build /app/dist-server ./dist-server
 COPY --from=build /app/dist-bot ./dist-bot
+COPY --from=build /app/scripts/prod_cpu_game_helper.mjs /app/ops/
+COPY --from=build /app/scripts/prod_cpu_profile_client.mjs /app/ops/
 RUN mkdir -p /app/dist/media && chown -R node:node /app/dist/media
 EXPOSE 8787
 USER node

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "i18n:worklist": "node scripts/i18n_fill_worklist.mjs",
     "perf:tour": "node scripts/perf_tour.mjs",
     "perf:prewarm": "node scripts/prewarm_travel_bench.mjs",
+    "ops:cpu-monitor": "node scripts/prod_cpu_monitor.mjs",
     "feel:smoke": "node scripts/feel_smoke.mjs",
     "asset:budget": "node scripts/asset_budget.mjs",
     "assets:skills": "node scripts/convert_skill_icons_webp.mjs",

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -45,6 +45,7 @@ imported by a type-checked Vitest suite carries a hand-written `.d.mts` next to 
 | Scaffold / release | `new_endpoint.mjs` (`new:endpoint`, scaffolds a `RouteDef` module on the `server/http/` pipeline, see `server/http/CLAUDE.md`), `release_version.mjs` (`release:check`/`release:prepare`), `version_sync.mjs` (`version:sync`), `electron-dev.mjs`/`electron-build.mjs` (`electron:*`; both bundle vendor deps via `electron-vendor.mjs`) | none |
 | Data export | `export_loot_spreadsheet.mjs` (esbuild-bundles `src/sim` to a loot sheet in `docs/`) | none |
 | Admin / dev utils | `grant_admin.mjs`, `create_gm.mjs`; one-off DB migrations are `.ts` via `tsx` (`db:*` scripts) | `DATABASE_URL` |
+| Production ops | `prod_cpu_monitor*.mjs` (supervised CPU incident capture + container-local V8 profile client) | restricted SSH access to the production container; optional mode-0600 staff token for `ops.perf` tick detail |
 | Local realms | `dev-realms.mjs` (launches built server processes) | built server (`npm run realms`) |
 | Helper | `browser_path.mjs` (resolves Chrome/Edge/Chromium; override `BROWSER_PATH=`), shared pure helpers in `lib/` | none |
 

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -45,7 +45,7 @@ imported by a type-checked Vitest suite carries a hand-written `.d.mts` next to 
 | Scaffold / release | `new_endpoint.mjs` (`new:endpoint`, scaffolds a `RouteDef` module on the `server/http/` pipeline, see `server/http/CLAUDE.md`), `release_version.mjs` (`release:check`/`release:prepare`), `version_sync.mjs` (`version:sync`), `electron-dev.mjs`/`electron-build.mjs` (`electron:*`; both bundle vendor deps via `electron-vendor.mjs`) | none |
 | Data export | `export_loot_spreadsheet.mjs` (esbuild-bundles `src/sim` to a loot sheet in `docs/`) | none |
 | Admin / dev utils | `grant_admin.mjs`, `create_gm.mjs`; one-off DB migrations are `.ts` via `tsx` (`db:*` scripts) | `DATABASE_URL` |
-| Production ops | `prod_cpu_monitor*.mjs` (supervised CPU incident capture + container-local V8 profile client) | restricted SSH access to the production container; optional mode-0600 staff token for `ops.perf` tick detail |
+| Production ops | `prod_cpu_monitor*.mjs` (supervised CPU incident capture + immutable in-image PID/profile helpers) | exact-command restricted SSH access to the production container; optional mode-0600 staff token for `ops.perf` tick detail |
 | Local realms | `dev-realms.mjs` (launches built server processes) | built server (`npm run realms`) |
 | Helper | `browser_path.mjs` (resolves Chrome/Edge/Chromium; override `BROWSER_PATH=`), shared pure helpers in `lib/` | none |
 

--- a/scripts/prod_cpu_game_helper.mjs
+++ b/scripts/prod_cpu_game_helper.mjs
@@ -1,0 +1,59 @@
+// Immutable in-container helper for identifying and signaling the game Node process.
+
+import { readdir, readFile, readlink } from 'node:fs/promises';
+import path from 'node:path';
+
+async function findGamePid() {
+  const matches = [];
+  for (const name of await readdir('/proc')) {
+    if (!/^\d+$/.test(name)) continue;
+    const pid = Number(name);
+    if (pid === process.pid) continue;
+    const proc = `/proc/${name}`;
+    try {
+      const [executable, cmdline] = await Promise.all([
+        readlink(`${proc}/exe`),
+        readFile(`${proc}/cmdline`, 'utf8'),
+      ]);
+      const args = cmdline.split('\0');
+      if (
+        path.basename(executable) === 'node' &&
+        path.basename(args[0] ?? '') === 'node' &&
+        args[1] === 'dist-server/server.cjs'
+      ) {
+        matches.push(pid);
+      }
+    } catch {
+      // Processes can exit, or be unreadable, while /proc is being scanned.
+    }
+  }
+  if (matches.length !== 1) {
+    throw new Error(`expected one game Node process, found ${matches.length}`);
+  }
+  return matches[0];
+}
+
+async function main() {
+  const action = process.argv[2];
+  const pid = await findGamePid();
+  if (action === 'pid' && process.argv.length === 3) {
+    process.stdout.write(`${pid}\n`);
+    return;
+  }
+  if (action === 'signal' && process.argv.length === 4) {
+    const expectedPid = Number(process.argv[3]);
+    if (!Number.isInteger(expectedPid) || expectedPid <= 0) {
+      throw new Error('expected game PID must be a positive integer');
+    }
+    if (pid !== expectedPid) throw new Error('game Node PID changed before inspector signal');
+    process.kill(pid, 'SIGUSR1');
+    process.stdout.write(`${pid}\n`);
+    return;
+  }
+  throw new Error('usage: prod_cpu_game_helper.mjs pid | signal EXPECTED_PID');
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/prod_cpu_monitor.mjs
+++ b/scripts/prod_cpu_monitor.mjs
@@ -1,0 +1,761 @@
+// Production CPU watcher for eastbrook-game.
+//
+// Default: poll through minivac every 30 seconds. A confirmed CPU breach
+// collects protected logs and runtime context plus a V8 .cpuprofile. The watcher
+// never restarts the server, publishes the inspector, or reads container secrets.
+//
+//   node scripts/prod_cpu_monitor.mjs --once --dry-run
+//   node scripts/prod_cpu_monitor.mjs
+//
+// Optional game tick capture: point WOC_OPS_TOKEN_FILE at a mode-0600 file
+// containing an existing 64-hex bearer with ops.perf permission.
+
+import { chmod, lstat, mkdir, readFile, rename, unlink } from 'node:fs/promises';
+import { createServer } from 'node:net';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  markCaptureDirectory,
+  prepareOutputDirectory,
+  privateAtomicWrite,
+  privateWrite,
+  pruneCaptures,
+  writeChecksums,
+} from './prod_cpu_monitor_artifacts.mjs';
+import {
+  adminRequestCommand,
+  bundleHashCommand,
+  cpuSampleCommand,
+  dockerExecShellCommand,
+  duringStatsCommand,
+  gameNodePidScript,
+  hostContextCommand,
+  inspectorProbeCommand,
+  logsCommand,
+  oneStatsCommand,
+  processContextCommand,
+  profileCommand,
+  safeInspectCommand,
+} from './prod_cpu_monitor_commands.mjs';
+import {
+  buildSshArgs,
+  classifyIncidentEvidence,
+  errorMessage,
+  INITIAL_INCIDENT_STATE,
+  launchCaptureWork,
+  parseMonitorOptions,
+  pollOnce,
+  runPollingLoop,
+} from './prod_cpu_monitor_core.mjs';
+import { acquireRemoteCaptureLock, runProcess } from './prod_cpu_monitor_process.mjs';
+
+const HELP = `Usage: node scripts/prod_cpu_monitor.mjs [options]
+
+Options:
+  --once                         Poll once and exit
+  --dry-run                      Never profile, even if CPU is high
+  --host NAME                    SSH target (default: world-of-claudecraft-prod)
+  --jump-host NAME               SSH jump host (default: minivac)
+  --direct                       SSH directly from an always-on ops host
+  --container NAME               Docker container (default: eastbrook-game)
+  --threshold PERCENT            Trigger threshold (default: 90)
+  --interval-seconds N           Poll start-to-start interval (default: 30)
+  --profile-seconds N            V8 profile duration (default: 20)
+  --profile-sample-micros N      V8 sample interval (default: 4000)
+  --out-dir ABSOLUTE_PATH        Private durable artifact directory
+  --ops-token-file PATH          Existing 0600 ops.perf bearer file
+  --help                         Show this help
+`;
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const INSPECTOR_OWNER_FILE = 'inspector-owner.json';
+
+function runSsh(options, remoteCommand, runOptions) {
+  return runProcess('ssh', buildSshArgs(options, remoteCommand), {
+    ...runOptions,
+    signal: options.captureSignal ?? runOptions?.signal,
+  });
+}
+
+async function readRemoteCpu(options) {
+  const timeoutMs = 20_000 + options.sampleCount * (options.sampleSpacingSeconds + 5) * 1_000;
+  return (await runSsh(options, cpuSampleCommand(options), { timeoutMs })).stdout;
+}
+
+function captureId(date = new Date()) {
+  return `capture-${date.toISOString().replace(/[-:.]/g, '')}`;
+}
+
+async function collectRemoteArtifact(
+  options,
+  captureDir,
+  filename,
+  command,
+  timeoutMs = 30_000,
+  maxStdoutBytes = 32 * 1024 * 1024,
+) {
+  const output = path.join(captureDir, filename);
+  try {
+    await runSsh(options, command, { stdoutFile: output, timeoutMs, maxStdoutBytes });
+    return null;
+  } catch (error) {
+    await privateWrite(`${output}.error.txt`, `${errorMessage(error)}\n`);
+    return `${filename}: ${errorMessage(error)}`;
+  }
+}
+
+async function resolveGamePid(options, signal, expectedPid = null) {
+  const result = await runSsh(options, dockerExecShellCommand(options), {
+    input: gameNodePidScript({ signal, expectedPid }),
+    timeoutMs: 30_000,
+  });
+  const pid = Number(result.stdout.trim());
+  if (!Number.isInteger(pid) || pid <= 0)
+    throw new Error('game PID resolver returned invalid output');
+  return pid;
+}
+
+export function inspectorCleanupOptions(options) {
+  const { captureSignal: _captureSignal, ...cleanupOptions } = options;
+  return cleanupOptions;
+}
+
+async function inspectorIsOpen(options) {
+  const result = await runSsh(options, inspectorProbeCommand(options), { timeoutMs: 30_000 });
+  const status = result.stdout.trim();
+  if (status !== 'open' && status !== 'closed') {
+    throw new Error(`inspector probe returned ${JSON.stringify(status)}`);
+  }
+  return status === 'open';
+}
+
+async function ensureInspectorClosed(options) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (!(await inspectorIsOpen(options))) return;
+    await delay(500);
+  }
+  throw new Error('inspector remained open after CPU profiling');
+}
+
+async function cleanupOwnedInspectorUnlocked(options) {
+  const ownerPath = path.join(options.outDir, INSPECTOR_OWNER_FILE);
+  let owner;
+  try {
+    owner = JSON.parse(await readFile(ownerPath, 'utf8'));
+  } catch (error) {
+    if (error?.code === 'ENOENT') return;
+    throw error;
+  }
+  const gamePid = await resolveGamePid(options, false);
+  if (owner.targetHost !== options.targetHost || owner.container !== options.container) {
+    throw new Error('invalid inspector ownership marker');
+  }
+  if (owner.gamePid !== gamePid) {
+    await unlink(ownerPath);
+    return;
+  }
+  if (await inspectorIsOpen(options)) {
+    const profileSource = await readFile(
+      new URL('./prod_cpu_profile_client.mjs', import.meta.url),
+      'utf8',
+    );
+    await runSsh(options, profileCommand({ ...options, profileMs: 0 }, gamePid), {
+      input: profileSource,
+      timeoutMs: 45_000,
+    });
+  }
+  await ensureInspectorClosed(options);
+  await unlink(ownerPath);
+}
+
+async function cleanupOwnedInspector(options) {
+  try {
+    await lstat(path.join(options.outDir, INSPECTOR_OWNER_FILE));
+  } catch (error) {
+    if (error?.code === 'ENOENT') return;
+    throw error;
+  }
+  const lock = await acquireRemoteCaptureLock(options);
+  const abortController = new AbortController();
+  const cleanup = cleanupOwnedInspectorUnlocked({
+    ...options,
+    captureSignal: abortController.signal,
+  });
+  try {
+    await Promise.race([cleanup, lock.lost]);
+  } finally {
+    abortController.abort(new Error('inspector cleanup lock released'));
+    await Promise.allSettled([cleanup, lock.release()]);
+  }
+}
+
+export async function loadOpsToken(tokenFile) {
+  if (!tokenFile) return null;
+  const info = await lstat(tokenFile);
+  if (info.isSymbolicLink() || !info.isFile()) {
+    throw new Error('ops token path is not a real regular file');
+  }
+  if (process.getuid?.() !== info.uid)
+    throw new Error('ops token file must be owned by the monitor');
+  if ((info.mode & 0o077) !== 0) throw new Error('ops token file must have mode 0600');
+  const token = (await readFile(tokenFile, 'utf8')).trim();
+  if (!/^[a-f0-9]{64}$/.test(token))
+    throw new Error('ops token must be 64 lowercase hex characters');
+  return token;
+}
+
+function responseData(raw) {
+  const envelope = JSON.parse(raw);
+  if (envelope?.success !== true || !envelope.data) {
+    throw new Error(
+      `admin API rejected the request: ${String(envelope?.error ?? 'invalid response')}`,
+    );
+  }
+  return envelope.data;
+}
+
+async function adminRequest(options, token, method, endpoint, body) {
+  return (
+    await runSsh(options, adminRequestCommand(method, endpoint, body), {
+      input: `${token}\n`,
+      timeoutMs: 35_000,
+    })
+  ).stdout;
+}
+
+async function startTickCapture(options, captureDir, token) {
+  if (!token) return { started: false, reason: 'no-ops-token', captureId: null };
+  const beforeRaw = await adminRequest(options, token, 'GET', '/admin/api/perf/tick');
+  await privateWrite(path.join(captureDir, 'tick-status-before.json'), `${beforeRaw.trim()}\n`);
+  if (responseData(beforeRaw).capturing) {
+    return { started: false, reason: 'capture-already-running', captureId: null };
+  }
+  const startRaw = await adminRequest(options, token, 'POST', '/admin/api/perf/tick/capture', {
+    durationMs: options.tickCaptureMs,
+  });
+  const started = responseData(startRaw);
+  const captureId = started.captureId;
+  if (
+    typeof captureId !== 'string' ||
+    !/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/.test(captureId)
+  ) {
+    throw new Error('tick profiler returned an invalid capture id');
+  }
+  await privateWrite(path.join(captureDir, 'tick-capture-start.json'), `${startRaw.trim()}\n`);
+  return { started: true, reason: 'started', captureId };
+}
+
+async function awaitTickCapture(options, captureDir, token, tickStart, sleep) {
+  if (!token || !tickStart.started) return tickStart.reason;
+  const deadline = Date.now() + options.tickTimeoutMs;
+  while (Date.now() < deadline) {
+    const raw = await adminRequest(options, token, 'GET', '/admin/api/perf/tick');
+    const status = responseData(raw);
+    if (!status.capturing) {
+      if (status.last?.captureId !== tickStart.captureId) {
+        throw new Error('tick profiler returned a stale capture');
+      }
+      await privateWrite(path.join(captureDir, 'tick-capture-result.json'), `${raw.trim()}\n`);
+      return 'complete';
+    }
+    await sleep(5_000);
+  }
+  throw new Error(`tick profiler did not finish within ${options.tickTimeoutMs}ms`);
+}
+
+async function writePerfLogExcerpt(captureDir) {
+  try {
+    const logs = await readFile(path.join(captureDir, 'game.log'), 'utf8');
+    const lines = logs.split(/\r?\n/).filter((line) => /\[perf(?:\.sim)?\]/.test(line));
+    await privateWrite(path.join(captureDir, 'perf.log'), `${lines.join('\n')}\n`);
+    return null;
+  } catch (error) {
+    return `perf log excerpt: ${errorMessage(error)}`;
+  }
+}
+
+function appendError(errors, value) {
+  return value ? [...errors, value] : errors;
+}
+
+async function validateCpuProfile(captureDir) {
+  const profile = JSON.parse(await readFile(path.join(captureDir, 'cpu.cpuprofile'), 'utf8'));
+  if (!Array.isArray(profile.nodes) || profile.nodes.length === 0) {
+    throw new Error('CPU profile has no call-tree nodes');
+  }
+  if (!Array.isArray(profile.samples) || profile.samples.length === 0) {
+    throw new Error('CPU profile has no samples');
+  }
+  return {
+    nodeCount: profile.nodes.length,
+    sampleCount: profile.samples.length,
+    startTime: profile.startTime ?? null,
+    endTime: profile.endTime ?? null,
+  };
+}
+
+async function createIncidentCaptureLocked(options, trigger, { sleep }) {
+  const captureDir = path.join(options.outDir, captureId(new Date(trigger.observedAt)));
+  await mkdir(captureDir, { recursive: false, mode: 0o700 });
+  await chmod(captureDir, 0o700);
+  await markCaptureDirectory(captureDir);
+  let errors = [];
+  const metadata = {
+    schemaVersion: 1,
+    targetHost: options.targetHost,
+    jumpHost: options.jumpHost,
+    container: options.container,
+    threshold: options.threshold,
+    trigger,
+    profileMs: options.profileMs,
+    profileSampleIntervalUs: options.profileSampleIntervalUs,
+    tickCaptureRequested: Boolean(options.opsTokenFile),
+    startedAt: new Date().toISOString(),
+    complete: false,
+  };
+  await privateAtomicWrite(
+    path.join(captureDir, 'metadata.json'),
+    `${JSON.stringify(metadata, null, 2)}\n`,
+  );
+  await privateWrite(
+    path.join(captureDir, 'trigger-samples.txt'),
+    `${trigger.samples.join('%\n')}%\n`,
+  );
+
+  const profileSource = await readFile(
+    new URL('./prod_cpu_profile_client.mjs', import.meta.url),
+    'utf8',
+  );
+  let releaseSecondaryEvidence;
+  let secondaryReleased = false;
+  const secondaryReady = new Promise((resolve) => {
+    releaseSecondaryEvidence = resolve;
+  });
+  const releaseSecondary = () => {
+    if (secondaryReleased) return;
+    secondaryReleased = true;
+    releaseSecondaryEvidence();
+  };
+  const work = launchCaptureWork({
+    profile: async () => {
+      let profileError = null;
+      let inspectorInitiallyOpen = null;
+      let inspectorOwned = false;
+      let inspectorCleanupError = null;
+      let gamePid = null;
+      let profileStartedAt = null;
+      let profileFinishedAt = null;
+      let profileErrors = [];
+      try {
+        gamePid = await resolveGamePid(options, false);
+        inspectorInitiallyOpen = await inspectorIsOpen(options);
+        if (inspectorInitiallyOpen) {
+          throw new Error('inspector was already open; refusing to disrupt another operator');
+        }
+        await privateAtomicWrite(
+          path.join(options.outDir, INSPECTOR_OWNER_FILE),
+          `${JSON.stringify({
+            targetHost: options.targetHost,
+            container: options.container,
+            gamePid,
+            createdAt: new Date().toISOString(),
+          })}\n`,
+        );
+        inspectorOwned = true;
+        gamePid = await resolveGamePid(options, true, gamePid);
+        await sleep(750);
+        let profileStartAcknowledged = false;
+        let profileStopAcknowledged = false;
+        let profileStartupGateTimedOut = false;
+        const startupGateTimeout = setTimeout(() => {
+          profileStartupGateTimedOut = true;
+          releaseSecondary();
+        }, 30_000);
+        startupGateTimeout.unref();
+        const profileProcess = runSsh(options, profileCommand(options, gamePid), {
+          input: profileSource,
+          stdoutFile: path.join(captureDir, 'cpu.cpuprofile'),
+          timeoutMs: options.profileMs + 45_000,
+          maxStdoutBytes: 128 * 1024 * 1024,
+          onStderrLine: (line) => {
+            if (line === 'WOC_PROFILE_STARTED') {
+              profileStartAcknowledged = true;
+              profileStartedAt ??= Date.now();
+              clearTimeout(startupGateTimeout);
+              releaseSecondary();
+            } else if (line === 'WOC_PROFILE_STOPPED') {
+              profileStopAcknowledged = true;
+              profileFinishedAt = Date.now();
+            }
+          },
+        }).finally(() => {
+          clearTimeout(startupGateTimeout);
+          releaseSecondary();
+        });
+        const [profileResult, statsResult] = await Promise.allSettled([
+          profileProcess,
+          secondaryReady.then(() =>
+            collectRemoteArtifact(
+              options,
+              captureDir,
+              'stats-during.jsonl',
+              duringStatsCommand(options),
+              options.profileMs + 60_000,
+            ),
+          ),
+        ]);
+        if (profileResult.status === 'rejected') profileError = profileResult.reason;
+        if (profileResult.status === 'fulfilled' && !profileStartAcknowledged) {
+          profileError = new Error('CPU profiler did not acknowledge start');
+        }
+        if (profileResult.status === 'fulfilled' && !profileStopAcknowledged) {
+          profileErrors = [...profileErrors, 'CPU profiler did not acknowledge stop'];
+        }
+        if (profileStartupGateTimedOut) {
+          profileErrors = [...profileErrors, 'CPU profiler startup gate exceeded 30000ms'];
+        }
+        if (statsResult.status === 'fulfilled') {
+          profileErrors = appendError(profileErrors, statsResult.value);
+        } else {
+          profileErrors = [...profileErrors, `stats during: ${errorMessage(statsResult.reason)}`];
+        }
+      } catch (error) {
+        profileError = error;
+      } finally {
+        releaseSecondary();
+      }
+
+      if (inspectorOwned) {
+        const cleanupOptions = inspectorCleanupOptions(options);
+        try {
+          const cleanup = async (ownedOptions) => {
+            if (await inspectorIsOpen(ownedOptions)) {
+              await runSsh(
+                ownedOptions,
+                profileCommand({ ...ownedOptions, profileMs: 0 }, gamePid),
+                {
+                  input: profileSource,
+                  timeoutMs: 45_000,
+                },
+              );
+            }
+            await ensureInspectorClosed(ownedOptions);
+            await unlink(path.join(options.outDir, INSPECTOR_OWNER_FILE));
+          };
+          if (options.captureSignal?.aborted) {
+            const cleanupLock = await acquireRemoteCaptureLock(cleanupOptions);
+            const cleanupAbortController = new AbortController();
+            const guardedCleanup = cleanup({
+              ...cleanupOptions,
+              captureSignal: cleanupAbortController.signal,
+            });
+            try {
+              await Promise.race([guardedCleanup, cleanupLock.lost]);
+            } finally {
+              cleanupAbortController.abort(new Error('inspector cleanup lock released'));
+              await Promise.allSettled([guardedCleanup, cleanupLock.release()]);
+            }
+          } else {
+            await cleanup(cleanupOptions);
+          }
+        } catch (error) {
+          inspectorCleanupError = error;
+          profileErrors = [...profileErrors, `inspector shutdown: ${errorMessage(error)}`];
+        }
+      }
+      return {
+        errors: profileErrors,
+        inspectorCleanupError,
+        inspectorInitiallyOpen,
+        profileError,
+        profileFinishedAt,
+        profileStartedAt,
+      };
+    },
+    tick: async () => {
+      let token = null;
+      let tickStart = { started: false, reason: 'no-ops-token', captureId: null };
+      try {
+        token = await loadOpsToken(options.opsTokenFile);
+        tickStart = await startTickCapture(options, captureDir, token);
+      } catch (error) {
+        return {
+          errors: [`tick capture start: ${errorMessage(error)}`],
+          tickOutcome: 'start-failed',
+        };
+      }
+      try {
+        return {
+          errors: [],
+          tickOutcome: await awaitTickCapture(options, captureDir, token, tickStart, sleep),
+        };
+      } catch (error) {
+        return {
+          errors: [`tick capture result: ${errorMessage(error)}`],
+          tickOutcome: 'result-failed',
+        };
+      }
+    },
+    context: async () =>
+      Promise.all([
+        collectRemoteArtifact(options, captureDir, 'container.json', safeInspectCommand(options)),
+        collectRemoteArtifact(options, captureDir, 'host-before.txt', hostContextCommand(), 45_000),
+        collectRemoteArtifact(
+          options,
+          captureDir,
+          'processes-before.txt',
+          processContextCommand(options),
+        ),
+        collectRemoteArtifact(options, captureDir, 'stats-before.json', oneStatsCommand(options)),
+        collectRemoteArtifact(options, captureDir, 'bundle.sha256', bundleHashCommand(options)),
+      ]),
+    secondaryReady,
+  });
+
+  const [profileResult, tickResult, preResults] = await Promise.all([
+    work.profile,
+    work.tick,
+    work.context,
+  ]);
+  for (const result of preResults) errors = appendError(errors, result);
+  errors = [...errors, ...profileResult.errors, ...tickResult.errors];
+
+  const postResults = await Promise.all([
+    collectRemoteArtifact(
+      options,
+      captureDir,
+      'processes-after.txt',
+      processContextCommand(options),
+    ),
+    collectRemoteArtifact(options, captureDir, 'stats-after.json', oneStatsCommand(options)),
+    collectRemoteArtifact(options, captureDir, 'game.log', logsCommand(options), 90_000),
+  ]);
+  for (const result of postResults) errors = appendError(errors, result);
+  const perfLogError = await writePerfLogExcerpt(captureDir);
+  errors = appendError(errors, perfLogError);
+  if (profileResult.profileError) {
+    errors = [...errors, `cpu profile: ${errorMessage(profileResult.profileError)}`];
+  }
+  let profileSummary = null;
+  let profileValidationError = null;
+  if (!profileResult.profileError) {
+    try {
+      profileSummary = await validateCpuProfile(captureDir);
+    } catch (error) {
+      profileValidationError = error;
+      errors = [...errors, `cpu profile validation: ${errorMessage(error)}`];
+    }
+  }
+  const cpuProfileFailed = profileResult.profileError !== null || profileValidationError !== null;
+  const auxiliaryEvidenceFailed =
+    errors.length > 0 ||
+    postResults[2] !== null ||
+    perfLogError !== null ||
+    (metadata.tickCaptureRequested && tickResult.tickOutcome !== 'complete');
+  const evidenceStatus = classifyIncidentEvidence({
+    cpuProfileFailed,
+    auxiliaryEvidenceFailed,
+  });
+
+  const completedMetadata = {
+    ...metadata,
+    finishedAt: new Date().toISOString(),
+    complete: evidenceStatus.complete,
+    inspectorInitiallyOpen: profileResult.inspectorInitiallyOpen,
+    inspectorCleanupError:
+      profileResult.inspectorCleanupError === null
+        ? null
+        : errorMessage(profileResult.inspectorCleanupError),
+    profileFinishedAt:
+      profileResult.profileFinishedAt === null
+        ? null
+        : new Date(profileResult.profileFinishedAt).toISOString(),
+    profileStartedAt:
+      profileResult.profileStartedAt === null
+        ? null
+        : new Date(profileResult.profileStartedAt).toISOString(),
+    profileStartDelayMs:
+      profileResult.profileStartedAt === null
+        ? null
+        : profileResult.profileStartedAt - trigger.observedAt,
+    profileSummary,
+    tickCapture: tickResult.tickOutcome,
+    errors,
+  };
+  await privateAtomicWrite(
+    path.join(captureDir, 'metadata.json'),
+    `${JSON.stringify(completedMetadata, null, 2)}\n`,
+  );
+  await writeChecksums(captureDir);
+  if (evidenceStatus.complete) {
+    await privateWrite(path.join(captureDir, 'COMPLETE'), `${completedMetadata.finishedAt}\n`);
+  }
+  await pruneCaptures(options);
+  if (evidenceStatus.fatal) {
+    throw new Error(
+      `required incident evidence is incomplete; partial evidence is in ${captureDir}`,
+    );
+  }
+  return {
+    captureDir,
+    degradedErrors: evidenceStatus.complete ? [] : errors,
+  };
+}
+
+async function createIncidentCapture(options, trigger, dependencies) {
+  const lock = await acquireRemoteCaptureLock(options);
+  const abortController = new AbortController();
+  const capture = createIncidentCaptureLocked(
+    { ...options, captureSignal: abortController.signal },
+    trigger,
+    dependencies,
+  );
+  try {
+    return await Promise.race([capture, lock.lost]);
+  } finally {
+    abortController.abort(new Error('production capture lock released'));
+    await Promise.allSettled([capture, lock.release()]);
+  }
+}
+
+async function readIncidentState(outDir) {
+  try {
+    const parsed = JSON.parse(await readFile(path.join(outDir, 'state.json'), 'utf8'));
+    if (
+      typeof parsed.incidentActive === 'boolean' &&
+      Number.isInteger(parsed.healthyPolls) &&
+      (parsed.lastAttemptAt === null ||
+        parsed.lastAttemptAt === undefined ||
+        Number.isFinite(parsed.lastAttemptAt)) &&
+      (parsed.lastCaptureAt === null || Number.isFinite(parsed.lastCaptureAt)) &&
+      (parsed.lastAttemptFailed === undefined || typeof parsed.lastAttemptFailed === 'boolean')
+    ) {
+      return {
+        incidentActive: parsed.incidentActive,
+        healthyPolls: parsed.healthyPolls,
+        lastAttemptAt: parsed.lastAttemptAt ?? parsed.lastCaptureAt,
+        lastCaptureAt: parsed.lastCaptureAt,
+        lastAttemptFailed: parsed.lastAttemptFailed ?? false,
+      };
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  return { ...INITIAL_INCIDENT_STATE };
+}
+
+async function writeIncidentState(outDir, state) {
+  const finalPath = path.join(outDir, 'state.json');
+  const temporaryPath = `${finalPath}.${process.pid}.tmp`;
+  await privateWrite(temporaryPath, `${JSON.stringify(state, null, 2)}\n`);
+  await rename(temporaryPath, finalPath);
+  await chmod(finalPath, 0o600);
+}
+
+async function acquireLocalLock() {
+  const server = createServer();
+  await new Promise((resolve, reject) => {
+    server.once('error', (error) => {
+      if (error?.code === 'EADDRINUSE')
+        reject(new Error('production CPU monitor is already running'));
+      else reject(error);
+    });
+    server.listen({ host: '127.0.0.1', port: 43951, exclusive: true }, resolve);
+  });
+  return () => new Promise((resolve) => server.close(resolve));
+}
+
+function createStopController(log) {
+  let stopped = false;
+  let wake = null;
+  const stop = (signal) => {
+    if (stopped) return;
+    stopped = true;
+    log(`Stopping after ${signal}`);
+    wake?.();
+  };
+  return {
+    isStopped: () => stopped,
+    stop,
+    sleep: (ms) =>
+      new Promise((resolve) => {
+        const timer = setTimeout(resolve, ms);
+        wake = () => {
+          clearTimeout(timer);
+          resolve();
+        };
+      }).finally(() => {
+        wake = null;
+      }),
+  };
+}
+
+function timestampLog(message) {
+  console.log(`[${new Date().toISOString()}] ${message}`);
+}
+
+async function main() {
+  process.umask(0o077);
+  const options = parseMonitorOptions();
+  if (options.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+  await prepareOutputDirectory(options.outDir);
+  await pruneCaptures(options);
+  const releaseLock = await acquireLocalLock();
+  const stop = createStopController(timestampLog);
+  process.once('SIGINT', () => stop.stop('SIGINT'));
+  process.once('SIGTERM', () => stop.stop('SIGTERM'));
+
+  let state = await readIncidentState(options.outDir);
+  let lastResult = null;
+  const poll = async () => {
+    await cleanupOwnedInspector(options);
+    lastResult = await pollOnce({
+      readCpu: () => readRemoteCpu(options),
+      capture: async (trigger) => {
+        const result = await createIncidentCapture(options, trigger, { sleep: delay });
+        if (result.degradedErrors.length > 0) {
+          timestampLog(
+            `Capture degraded (${result.degradedErrors.length} auxiliary errors): ${result.captureDir}`,
+          );
+        }
+        return result.captureDir;
+      },
+      state,
+      options,
+      log: timestampLog,
+    });
+    state = lastResult.nextState;
+    await writeIncidentState(options.outDir, state);
+    await cleanupOwnedInspector(options);
+    if (options.once) stop.stop('single poll complete');
+  };
+
+  timestampLog(
+    `Watching ${options.container} on ${options.targetHost}${options.jumpHost ? ` through ${options.jumpHost}` : ' directly'} every ${options.intervalMs / 1_000}s`,
+  );
+  try {
+    await runPollingLoop({
+      poll,
+      sleep: stop.sleep,
+      intervalMs: options.intervalMs,
+      shouldStop: stop.isStopped,
+      log: timestampLog,
+    });
+  } finally {
+    await releaseLock();
+  }
+  if (options.once && ['poll-failed', 'capture-failed'].includes(lastResult?.status)) {
+    process.exitCode = 1;
+  }
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((error) => {
+    console.error(errorMessage(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/prod_cpu_monitor.mjs
+++ b/scripts/prod_cpu_monitor.mjs
@@ -25,10 +25,11 @@ import {
 import {
   adminRequestCommand,
   bundleHashCommand,
+  containerIdentityCommand,
+  containerIdentityMatchesOwner,
   cpuSampleCommand,
-  dockerExecShellCommand,
   duringStatsCommand,
-  gameNodePidScript,
+  gameProcessCommand,
   hostContextCommand,
   inspectorProbeCommand,
   logsCommand,
@@ -105,14 +106,29 @@ async function collectRemoteArtifact(
 }
 
 async function resolveGamePid(options, signal, expectedPid = null) {
-  const result = await runSsh(options, dockerExecShellCommand(options), {
-    input: gameNodePidScript({ signal, expectedPid }),
+  const result = await runSsh(options, gameProcessCommand(options, signal, expectedPid), {
     timeoutMs: 30_000,
   });
   const pid = Number(result.stdout.trim());
   if (!Number.isInteger(pid) || pid <= 0)
     throw new Error('game PID resolver returned invalid output');
   return pid;
+}
+
+async function readContainerIdentity(options) {
+  const result = await runSsh(options, containerIdentityCommand(options), { timeoutMs: 30_000 });
+  const identity = JSON.parse(result.stdout);
+  if (
+    !/^[a-f0-9]{64}$/.test(identity?.containerId) ||
+    typeof identity?.containerStartedAt !== 'string' ||
+    identity.containerStartedAt.length === 0
+  ) {
+    throw new Error('container identity returned invalid output');
+  }
+  return {
+    containerId: identity.containerId,
+    containerStartedAt: identity.containerStartedAt,
+  };
 }
 
 export function inspectorCleanupOptions(options) {
@@ -146,21 +162,21 @@ async function cleanupOwnedInspectorUnlocked(options) {
     if (error?.code === 'ENOENT') return;
     throw error;
   }
-  const gamePid = await resolveGamePid(options, false);
   if (owner.targetHost !== options.targetHost || owner.container !== options.container) {
     throw new Error('invalid inspector ownership marker');
   }
+  const identity = await readContainerIdentity(options);
+  if (!containerIdentityMatchesOwner(owner, identity)) {
+    await unlink(ownerPath);
+    return;
+  }
+  const gamePid = await resolveGamePid(options, false);
   if (owner.gamePid !== gamePid) {
     await unlink(ownerPath);
     return;
   }
   if (await inspectorIsOpen(options)) {
-    const profileSource = await readFile(
-      new URL('./prod_cpu_profile_client.mjs', import.meta.url),
-      'utf8',
-    );
     await runSsh(options, profileCommand({ ...options, profileMs: 0 }, gamePid), {
-      input: profileSource,
       timeoutMs: 45_000,
     });
   }
@@ -322,10 +338,6 @@ async function createIncidentCaptureLocked(options, trigger, { sleep }) {
     `${trigger.samples.join('%\n')}%\n`,
   );
 
-  const profileSource = await readFile(
-    new URL('./prod_cpu_profile_client.mjs', import.meta.url),
-    'utf8',
-  );
   let releaseSecondaryEvidence;
   let secondaryReleased = false;
   const secondaryReady = new Promise((resolve) => {
@@ -347,7 +359,12 @@ async function createIncidentCaptureLocked(options, trigger, { sleep }) {
       let profileFinishedAt = null;
       let profileErrors = [];
       try {
+        const containerIdentity = await readContainerIdentity(options);
         gamePid = await resolveGamePid(options, false);
+        const confirmedContainerIdentity = await readContainerIdentity(options);
+        if (!containerIdentityMatchesOwner(containerIdentity, confirmedContainerIdentity)) {
+          throw new Error('container restarted while preparing CPU profile');
+        }
         inspectorInitiallyOpen = await inspectorIsOpen(options);
         if (inspectorInitiallyOpen) {
           throw new Error('inspector was already open; refusing to disrupt another operator');
@@ -357,6 +374,7 @@ async function createIncidentCaptureLocked(options, trigger, { sleep }) {
           `${JSON.stringify({
             targetHost: options.targetHost,
             container: options.container,
+            ...containerIdentity,
             gamePid,
             createdAt: new Date().toISOString(),
           })}\n`,
@@ -373,7 +391,6 @@ async function createIncidentCaptureLocked(options, trigger, { sleep }) {
         }, 30_000);
         startupGateTimeout.unref();
         const profileProcess = runSsh(options, profileCommand(options, gamePid), {
-          input: profileSource,
           stdoutFile: path.join(captureDir, 'cpu.cpuprofile'),
           timeoutMs: options.profileMs + 45_000,
           maxStdoutBytes: 128 * 1024 * 1024,
@@ -428,20 +445,7 @@ async function createIncidentCaptureLocked(options, trigger, { sleep }) {
       if (inspectorOwned) {
         const cleanupOptions = inspectorCleanupOptions(options);
         try {
-          const cleanup = async (ownedOptions) => {
-            if (await inspectorIsOpen(ownedOptions)) {
-              await runSsh(
-                ownedOptions,
-                profileCommand({ ...ownedOptions, profileMs: 0 }, gamePid),
-                {
-                  input: profileSource,
-                  timeoutMs: 45_000,
-                },
-              );
-            }
-            await ensureInspectorClosed(ownedOptions);
-            await unlink(path.join(options.outDir, INSPECTOR_OWNER_FILE));
-          };
+          const cleanup = cleanupOwnedInspectorUnlocked;
           if (options.captureSignal?.aborted) {
             const cleanupLock = await acquireRemoteCaptureLock(cleanupOptions);
             const cleanupAbortController = new AbortController();

--- a/scripts/prod_cpu_monitor_artifacts.mjs
+++ b/scripts/prod_cpu_monitor_artifacts.mjs
@@ -1,0 +1,155 @@
+// Private filesystem lifecycle for production CPU incident artifacts.
+
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+import path from 'node:path';
+
+const OUTPUT_MARKER = 'woc-prod-cpu-monitor-v1\n';
+const CAPTURE_MARKER = 'woc-prod-cpu-capture-v1\n';
+
+export async function privateWrite(file, data) {
+  await writeFile(file, data, { mode: 0o600 });
+  await chmod(file, 0o600);
+}
+
+export async function privateAtomicWrite(file, data) {
+  const temporaryPath = `${file}.${process.pid}.tmp`;
+  await privateWrite(temporaryPath, data);
+  await rename(temporaryPath, file);
+  await chmod(file, 0o600);
+}
+
+export async function prepareOutputDirectory(outDir) {
+  const markerPath = path.join(outDir, '.woc-prod-cpu-monitor');
+  let directoryInfo;
+  try {
+    directoryInfo = await lstat(outDir);
+    if (directoryInfo.isSymbolicLink() || !directoryInfo.isDirectory()) {
+      throw new Error('monitor output path must be a real directory');
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+    await mkdir(outDir, { recursive: true, mode: 0o700 });
+    await privateWrite(markerPath, OUTPUT_MARKER);
+    await chmod(outDir, 0o700);
+    return;
+  }
+
+  const currentUid = process.getuid?.();
+  if (currentUid === undefined || directoryInfo.uid !== currentUid) {
+    throw new Error(`refusing unowned monitor output directory: ${outDir}`);
+  }
+
+  let markerInfo = null;
+  try {
+    markerInfo = await lstat(markerPath);
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  if (markerInfo === null) {
+    const empty = (await readdir(outDir)).length === 0;
+    const privateMode = (directoryInfo.mode & 0o077) === 0;
+    if (!empty || !privateMode) {
+      throw new Error(`refusing unowned monitor output directory: ${outDir}`);
+    }
+    await privateWrite(markerPath, OUTPUT_MARKER);
+  } else if (
+    markerInfo.isSymbolicLink() ||
+    !markerInfo.isFile() ||
+    markerInfo.uid !== directoryInfo.uid ||
+    (await readFile(markerPath, 'utf8')) !== OUTPUT_MARKER
+  ) {
+    throw new Error(`refusing unowned monitor output directory: ${outDir}`);
+  }
+  await chmod(outDir, 0o700);
+}
+
+export async function markCaptureDirectory(captureDir) {
+  await privateWrite(path.join(captureDir, '.woc-prod-cpu-capture'), CAPTURE_MARKER);
+}
+
+async function checksumFile(file) {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(file)) hash.update(chunk);
+  return hash.digest('hex');
+}
+
+export async function writeChecksums(captureDir) {
+  const names = (await readdir(captureDir)).filter((name) => name !== 'checksums.sha256').sort();
+  const lines = [];
+  for (const name of names) {
+    const file = path.join(captureDir, name);
+    if ((await stat(file)).isFile()) lines.push(`${await checksumFile(file)}  ${name}`);
+  }
+  await privateAtomicWrite(path.join(captureDir, 'checksums.sha256'), `${lines.join('\n')}\n`);
+}
+
+export async function pruneCaptures(options) {
+  const candidates = (await readdir(options.outDir)).filter((name) =>
+    /^capture-\d{8}T\d{9}Z$/.test(name),
+  );
+  const validated = [];
+  for (const name of candidates) {
+    const capturePath = path.join(options.outDir, name);
+    const info = await lstat(capturePath);
+    if (info.isSymbolicLink() || !info.isDirectory()) continue;
+    let allowIncompleteFallback = true;
+    try {
+      const metadata = JSON.parse(await readFile(path.join(capturePath, 'metadata.json'), 'utf8'));
+      if (metadata.schemaVersion === 1) {
+        allowIncompleteFallback = false;
+      }
+      if (
+        metadata.schemaVersion === 1 &&
+        metadata.targetHost === options.targetHost &&
+        metadata.container === options.container
+      ) {
+        validated.push({ name, capturePath, createdAt: Date.parse(metadata.startedAt) });
+        continue;
+      }
+    } catch {
+      // A monitor-owned capture marker safely identifies crash-incomplete output.
+    }
+    if (!allowIncompleteFallback) continue;
+    try {
+      const markerPath = path.join(capturePath, '.woc-prod-cpu-capture');
+      const marker = await lstat(markerPath);
+      if (
+        marker.isSymbolicLink() ||
+        !marker.isFile() ||
+        marker.uid !== info.uid ||
+        info.uid !== process.getuid?.() ||
+        (await readFile(markerPath, 'utf8')) !== CAPTURE_MARKER
+      ) {
+        continue;
+      }
+      validated.push({
+        name,
+        capturePath,
+        createdAt: Number.isFinite(info.birthtimeMs) ? info.birthtimeMs : info.mtimeMs,
+      });
+    } catch {
+      // Unknown directories are never removed by this monitor.
+    }
+  }
+  validated.sort((left, right) => left.name.localeCompare(right.name));
+  const expired = validated.filter(
+    (entry) =>
+      Number.isFinite(entry.createdAt) && Date.now() - entry.createdAt > options.maxCaptureAgeMs,
+  );
+  const current = validated.filter((entry) => !expired.includes(entry));
+  const overflow = current.slice(0, Math.max(0, current.length - options.maxCaptures));
+  const remove = [...new Set([...expired, ...overflow].map((entry) => entry.capturePath))];
+  await Promise.all(remove.map((capturePath) => rm(capturePath, { recursive: true })));
+}

--- a/scripts/prod_cpu_monitor_commands.mjs
+++ b/scripts/prod_cpu_monitor_commands.mjs
@@ -1,0 +1,122 @@
+// Pure remote-command builders for the production CPU monitor.
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", `'"'"'`)}'`;
+}
+
+export function cpuSampleCommand(options) {
+  const container = shellQuote(options.container);
+  return `set -eu
+i=1
+while [ "$i" -le ${options.sampleCount} ]; do
+  LC_ALL=C sudo -n docker stats --no-stream --format '{{.CPUPerc}}' ${container}
+  i=$((i + 1))
+  if [ "$i" -le ${options.sampleCount} ]; then sleep ${options.sampleSpacingSeconds}; fi
+done`;
+}
+
+export function safeInspectCommand(options) {
+  const format =
+    '{"id":{{json .Id}},"name":{{json .Name}},"imageId":{{json .Image}},"imageName":{{json .Config.Image}},"restartCount":{{.RestartCount}},"state":{{json .State}},"limits":{"memory":{{.HostConfig.Memory}},"nanoCpus":{{.HostConfig.NanoCpus}},"cpuQuota":{{.HostConfig.CpuQuota}},"cpuPeriod":{{.HostConfig.CpuPeriod}},"cpusetCpus":{{json .HostConfig.CpusetCpus}}}}';
+  return `sudo -n docker inspect --format ${shellQuote(format)} ${shellQuote(options.container)}`;
+}
+
+export function hostContextCommand() {
+  return `set -u
+date -u +'%Y-%m-%dT%H:%M:%SZ'
+hostname
+uptime
+free -h 2>&1 || true
+vmstat 1 3 2>&1 || true`;
+}
+
+export function processContextCommand(options) {
+  const container = shellQuote(options.container);
+  return `set -eu
+sudo -n docker top ${container} -eo pid,ppid,pcpu,pmem,stat,etime,comm,args
+host_pid=$(sudo -n docker inspect --format '{{.State.Pid}}' ${container})
+printf '\nHost PID: %s\n' "$host_pid"
+ps -L -p "$host_pid" -o pid,tid,ppid,pcpu,pmem,stat,etime,comm,args 2>&1 || true
+top -b -H -n 1 -p "$host_pid" 2>&1 | head -n 100 || true`;
+}
+
+export function oneStatsCommand(options) {
+  return `LC_ALL=C sudo -n docker stats --no-stream --format '{{json .}}' ${shellQuote(options.container)}`;
+}
+
+export function bundleHashCommand(options) {
+  return `sudo -n docker exec ${shellQuote(options.container)} sha256sum /app/dist-server/server.cjs`;
+}
+
+export function logsCommand(options) {
+  return `sudo -n docker logs --timestamps --since ${shellQuote(options.logSince)} --tail 20000 ${shellQuote(options.container)} 2>&1`;
+}
+
+export function gameNodePidScript({ signal, expectedPid = null }) {
+  if (expectedPid !== null && (!Number.isInteger(expectedPid) || expectedPid <= 0)) {
+    throw new Error('expected game PID must be a positive integer');
+  }
+  const expectedPidGuard =
+    expectedPid === null
+      ? ''
+      : `[ "$pid" = "${expectedPid}" ] || {
+  echo "game Node PID changed before inspector signal" >&2
+  exit 1
+}`;
+  return `set -eu
+count=0
+pid=''
+for proc in /proc/[0-9]*; do
+  [ "\${proc##*/}" = "$$" ] && continue
+  [ -r "$proc/cmdline" ] || continue
+  exe=$(readlink "$proc/exe" 2>/dev/null || true)
+  [ "\${exe##*/}" = "node" ] || continue
+  arg0=$(tr '\\000' '\\n' < "$proc/cmdline" | sed -n '1p')
+  arg1=$(tr '\\000' '\\n' < "$proc/cmdline" | sed -n '2p')
+  [ "\${arg0##*/}" = "node" ] || continue
+  [ "$arg1" = "dist-server/server.cjs" ] || continue
+  count=$((count + 1))
+  pid=\${proc##*/}
+done
+if [ "$count" -ne 1 ]; then
+  echo "expected one game Node process, found $count" >&2
+  exit 1
+fi
+${expectedPidGuard}
+${signal ? 'kill -USR1 "$pid"' : ':'}
+printf '%s\n' "$pid"`;
+}
+
+export function dockerExecShellCommand(options) {
+  return `sudo -n docker exec -i ${shellQuote(options.container)} sh`;
+}
+
+export function inspectorProbeCommand(options) {
+  const source =
+    "fetch('http://127.0.0.1:9229/json/list').then(r => console.log(r.ok ? 'open' : 'closed')).catch(() => console.log('closed'))";
+  return `sudo -n docker exec ${shellQuote(options.container)} node -e ${shellQuote(source)}`;
+}
+
+export function duringStatsCommand(options) {
+  const seconds = Math.ceil(options.profileMs / 1_000) + 5;
+  const container = shellQuote(options.container);
+  return `set -eu
+ends_at=$(( $(date +%s) + ${seconds} ))
+while [ "$(date +%s)" -lt "$ends_at" ]; do
+  at=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+  stats=$(LC_ALL=C sudo -n docker stats --no-stream --format '{{json .}}' ${container})
+  printf '{"at":"%s","stats":%s}\n' "$at" "$stats"
+done`;
+}
+
+export function profileCommand(options, gamePid) {
+  return `sudo -n docker exec -i ${shellQuote(options.container)} env -i PATH=/usr/local/bin:/usr/bin:/bin WOC_PROFILE_MS=${options.profileMs} WOC_PROFILE_SAMPLE_INTERVAL_US=${options.profileSampleIntervalUs} WOC_EXPECTED_PID=${gamePid} WOC_CLOSE_INSPECTOR=1 node --input-type=module -`;
+}
+
+export function adminRequestCommand(method, endpoint, body = null) {
+  const data = body === null ? '' : ` --data ${shellQuote(JSON.stringify(body))}`;
+  return `set -eu
+IFS= read -r token
+printf 'Authorization: Bearer %s\nContent-Type: application/json\n' "$token" |
+  curl --silent --show-error --max-time 20 --request ${method} --header @-${data} ${shellQuote(`http://127.0.0.1:8787${endpoint}`)}`;
+}

--- a/scripts/prod_cpu_monitor_commands.mjs
+++ b/scripts/prod_cpu_monitor_commands.mjs
@@ -52,43 +52,26 @@ export function logsCommand(options) {
   return `sudo -n docker logs --timestamps --since ${shellQuote(options.logSince)} --tail 20000 ${shellQuote(options.container)} 2>&1`;
 }
 
-export function gameNodePidScript({ signal, expectedPid = null }) {
-  if (expectedPid !== null && (!Number.isInteger(expectedPid) || expectedPid <= 0)) {
+export function gameProcessCommand(options, signal, expectedPid = null) {
+  if (signal && (!Number.isInteger(expectedPid) || expectedPid <= 0)) {
     throw new Error('expected game PID must be a positive integer');
   }
-  const expectedPidGuard =
-    expectedPid === null
-      ? ''
-      : `[ "$pid" = "${expectedPid}" ] || {
-  echo "game Node PID changed before inspector signal" >&2
-  exit 1
-}`;
-  return `set -eu
-count=0
-pid=''
-for proc in /proc/[0-9]*; do
-  [ "\${proc##*/}" = "$$" ] && continue
-  [ -r "$proc/cmdline" ] || continue
-  exe=$(readlink "$proc/exe" 2>/dev/null || true)
-  [ "\${exe##*/}" = "node" ] || continue
-  arg0=$(tr '\\000' '\\n' < "$proc/cmdline" | sed -n '1p')
-  arg1=$(tr '\\000' '\\n' < "$proc/cmdline" | sed -n '2p')
-  [ "\${arg0##*/}" = "node" ] || continue
-  [ "$arg1" = "dist-server/server.cjs" ] || continue
-  count=$((count + 1))
-  pid=\${proc##*/}
-done
-if [ "$count" -ne 1 ]; then
-  echo "expected one game Node process, found $count" >&2
-  exit 1
-fi
-${expectedPidGuard}
-${signal ? 'kill -USR1 "$pid"' : ':'}
-printf '%s\n' "$pid"`;
+  const action = signal ? `signal ${expectedPid}` : 'pid';
+  return `sudo -n docker exec ${shellQuote(options.container)} env -i PATH=/usr/local/bin:/usr/bin:/bin node /app/ops/prod_cpu_game_helper.mjs ${action}`;
 }
 
-export function dockerExecShellCommand(options) {
-  return `sudo -n docker exec -i ${shellQuote(options.container)} sh`;
+export function containerIdentityCommand(options) {
+  const format = '{"containerId":{{json .Id}},"containerStartedAt":{{json .State.StartedAt}}}';
+  return `sudo -n docker inspect --format ${shellQuote(format)} ${shellQuote(options.container)}`;
+}
+
+export function containerIdentityMatchesOwner(owner, identity) {
+  return (
+    typeof owner?.containerId === 'string' &&
+    owner.containerId === identity?.containerId &&
+    typeof owner?.containerStartedAt === 'string' &&
+    owner.containerStartedAt === identity?.containerStartedAt
+  );
 }
 
 export function inspectorProbeCommand(options) {
@@ -110,7 +93,7 @@ done`;
 }
 
 export function profileCommand(options, gamePid) {
-  return `sudo -n docker exec -i ${shellQuote(options.container)} env -i PATH=/usr/local/bin:/usr/bin:/bin WOC_PROFILE_MS=${options.profileMs} WOC_PROFILE_SAMPLE_INTERVAL_US=${options.profileSampleIntervalUs} WOC_EXPECTED_PID=${gamePid} WOC_CLOSE_INSPECTOR=1 node --input-type=module -`;
+  return `sudo -n docker exec ${shellQuote(options.container)} env -i PATH=/usr/local/bin:/usr/bin:/bin WOC_PROFILE_MS=${options.profileMs} WOC_PROFILE_SAMPLE_INTERVAL_US=${options.profileSampleIntervalUs} WOC_EXPECTED_PID=${gamePid} WOC_CLOSE_INSPECTOR=1 node /app/ops/prod_cpu_profile_client.mjs`;
 }
 
 export function adminRequestCommand(method, endpoint, body = null) {

--- a/scripts/prod_cpu_monitor_core.mjs
+++ b/scripts/prod_cpu_monitor_core.mjs
@@ -1,0 +1,329 @@
+// Pure configuration, threshold, incident-state, and polling helpers for the
+// production CPU watcher. Network and filesystem effects stay in the CLI module.
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+export const DEFAULT_MONITOR_OPTIONS = Object.freeze({
+  targetHost: 'world-of-claudecraft-prod',
+  jumpHost: 'minivac',
+  container: 'eastbrook-game',
+  threshold: 90,
+  recoveryThreshold: 80,
+  intervalMs: 30_000,
+  sampleCount: 3,
+  requiredHighSamples: 2,
+  sampleSpacingSeconds: 2,
+  profileMs: 20_000,
+  profileSampleIntervalUs: 4_000,
+  tickCaptureMs: 30_000,
+  tickTimeoutMs: 180_000,
+  healthyPollsToRearm: 2,
+  recaptureMs: 1_800_000,
+  failureRetryMs: 120_000,
+  logSince: '20m',
+  maxCaptures: 24,
+  maxCaptureAgeMs: 30 * 24 * 60 * 60 * 1_000,
+  outDir: path.join(repoRoot, 'tmp', 'prod-cpu-watch'),
+  opsTokenFile: null,
+  once: false,
+  dryRun: false,
+  help: false,
+});
+
+export const INITIAL_INCIDENT_STATE = Object.freeze({
+  incidentActive: false,
+  healthyPolls: 0,
+  lastAttemptAt: null,
+  lastCaptureAt: null,
+  lastAttemptFailed: false,
+});
+
+function optionValue(argv, index, name) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('--')) throw new Error(`${name} requires a value`);
+  return value;
+}
+
+function finiteNumber(value, name, min, max) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
+    throw new Error(`${name} must be between ${min} and ${max}`);
+  }
+  return parsed;
+}
+
+function integer(value, name, min, max) {
+  const parsed = finiteNumber(value, name, min, max);
+  if (!Number.isInteger(parsed)) throw new Error(`${name} must be an integer`);
+  return parsed;
+}
+
+function remoteIdentifier(value, name) {
+  if (!/^[A-Za-z0-9][A-Za-z0-9_.:@-]*$/.test(value)) {
+    throw new Error(`${name} contains unsafe characters`);
+  }
+  return value;
+}
+
+export function parseMonitorOptions(argv = process.argv.slice(2), env = process.env) {
+  let options = {
+    ...DEFAULT_MONITOR_OPTIONS,
+    targetHost: env.WOC_CPU_MONITOR_HOST ?? DEFAULT_MONITOR_OPTIONS.targetHost,
+    jumpHost: env.WOC_CPU_MONITOR_JUMP_HOST ?? DEFAULT_MONITOR_OPTIONS.jumpHost,
+    container: env.WOC_CPU_MONITOR_CONTAINER ?? DEFAULT_MONITOR_OPTIONS.container,
+    outDir: env.WOC_CPU_MONITOR_OUT_DIR ?? DEFAULT_MONITOR_OPTIONS.outDir,
+    opsTokenFile: env.WOC_OPS_TOKEN_FILE ?? DEFAULT_MONITOR_OPTIONS.opsTokenFile,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--once') options = { ...options, once: true };
+    else if (arg === '--dry-run') options = { ...options, dryRun: true };
+    else if (arg === '--help') options = { ...options, help: true };
+    else if (arg === '--direct') options = { ...options, jumpHost: null };
+    else if (arg === '--host') options = { ...options, targetHost: optionValue(argv, i++, arg) };
+    else if (arg === '--jump-host') options = { ...options, jumpHost: optionValue(argv, i++, arg) };
+    else if (arg === '--container')
+      options = { ...options, container: optionValue(argv, i++, arg) };
+    else if (arg === '--threshold')
+      options = {
+        ...options,
+        threshold: finiteNumber(optionValue(argv, i++, arg), arg, 0.01, 10_000),
+      };
+    else if (arg === '--interval-seconds')
+      options = {
+        ...options,
+        intervalMs: integer(optionValue(argv, i++, arg), arg, 10, 86_400) * 1_000,
+      };
+    else if (arg === '--profile-seconds')
+      options = {
+        ...options,
+        profileMs: integer(optionValue(argv, i++, arg), arg, 1, 300) * 1_000,
+      };
+    else if (arg === '--profile-sample-micros')
+      options = {
+        ...options,
+        profileSampleIntervalUs: integer(optionValue(argv, i++, arg), arg, 100, 100_000),
+      };
+    else if (arg === '--out-dir') {
+      const value = optionValue(argv, i++, arg);
+      if (!path.isAbsolute(value)) throw new Error(`${arg} must be an absolute path`);
+      options = { ...options, outDir: path.normalize(value) };
+    } else if (arg === '--ops-token-file')
+      options = { ...options, opsTokenFile: path.resolve(optionValue(argv, i++, arg)) };
+    else throw new Error(`unknown option: ${arg}`);
+  }
+
+  const targetHost = remoteIdentifier(options.targetHost, 'host');
+  const jumpHost =
+    options.jumpHost === null ? null : remoteIdentifier(options.jumpHost, 'jump host');
+  const container = remoteIdentifier(options.container, 'container');
+  if (!path.isAbsolute(options.outDir))
+    throw new Error('monitor output directory must be an absolute path');
+  return Object.freeze({ ...options, targetHost, jumpHost, container });
+}
+
+export function parseCpuSamples(raw) {
+  const text = String(raw ?? '').trim();
+  if (!text) throw new Error('docker stats returned no CPU samples');
+  return text.split(/\r?\n/).map((line) => {
+    const match = /^\s*([0-9]+(?:\.[0-9]+)?)%\s*$/.exec(line);
+    if (!match) throw new Error(`invalid Docker CPU sample: ${JSON.stringify(line)}`);
+    const value = Number(match[1]);
+    if (!Number.isFinite(value) || value < 0) throw new Error('invalid Docker CPU percentage');
+    return value;
+  });
+}
+
+export function shouldTriggerProfile(samples, threshold, requiredHighSamples) {
+  return samples.filter((sample) => sample > threshold).length >= requiredHighSamples;
+}
+
+function median(samples) {
+  const sorted = [...samples].sort((left, right) => left - right);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+export function planIncidentTransition(
+  state,
+  {
+    high,
+    representativeCpu,
+    now,
+    recoveryThreshold,
+    healthyPollsToRearm,
+    recaptureMs,
+    failureRetryMs,
+  },
+) {
+  if (high) {
+    const lastAttemptAt = state.lastAttemptAt ?? state.lastCaptureAt;
+    const retryAfterMs = state.lastAttemptFailed ? failureRetryMs : recaptureMs;
+    const recaptureDue =
+      state.incidentActive && lastAttemptAt !== null && now - lastAttemptAt >= retryAfterMs;
+    const capture = !state.incidentActive || recaptureDue;
+    return {
+      capture,
+      reason: state.lastAttemptFailed
+        ? 'failed-capture-retry'
+        : state.incidentActive
+          ? 'sustained-high-cpu'
+          : 'new-high-cpu-incident',
+      nextState: capture
+        ? { ...state, incidentActive: true, healthyPolls: 0, lastAttemptAt: now }
+        : { ...state, healthyPolls: 0 },
+    };
+  }
+
+  if (!state.incidentActive) {
+    return { capture: false, reason: 'healthy', nextState: { ...state, healthyPolls: 0 } };
+  }
+
+  const healthyPolls = representativeCpu < recoveryThreshold ? state.healthyPolls + 1 : 0;
+  if (healthyPolls >= healthyPollsToRearm) {
+    return {
+      capture: false,
+      reason: 'incident-rearmed',
+      nextState: {
+        incidentActive: false,
+        healthyPolls: 0,
+        lastAttemptAt: null,
+        lastCaptureAt: null,
+        lastAttemptFailed: false,
+      },
+    };
+  }
+  return {
+    capture: false,
+    reason: 'incident-cooling',
+    nextState: { ...state, healthyPolls },
+  };
+}
+
+export async function pollOnce({ readCpu, capture, state, options, now = Date.now, log }) {
+  let samples;
+  try {
+    samples = parseCpuSamples(await readCpu());
+    if (samples.length !== options.sampleCount) {
+      throw new Error(`expected ${options.sampleCount} CPU samples, received ${samples.length}`);
+    }
+  } catch (error) {
+    log(`CPU poll failed: ${errorMessage(error)}`);
+    return { status: 'poll-failed', nextState: state, error };
+  }
+
+  const observedAt = now();
+  const representativeCpu = median(samples);
+  const high = shouldTriggerProfile(samples, options.threshold, options.requiredHighSamples);
+  const transition = planIncidentTransition(state, {
+    high,
+    representativeCpu,
+    now: observedAt,
+    recoveryThreshold: options.recoveryThreshold,
+    healthyPollsToRearm: options.healthyPollsToRearm,
+    recaptureMs: options.recaptureMs,
+    failureRetryMs: options.failureRetryMs,
+  });
+  log(
+    `CPU samples=${samples.join(',')}% median=${representativeCpu}% threshold=>${options.threshold}% status=${transition.reason}`,
+  );
+
+  if (!transition.capture) {
+    return { status: high ? 'high-suppressed' : 'healthy', nextState: transition.nextState };
+  }
+  if (options.dryRun) {
+    log('Dry run: profile capture would start now');
+    return { status: 'would-capture', nextState: state };
+  }
+
+  try {
+    const captureDir = await capture({
+      samples,
+      representativeCpu,
+      observedAt,
+      reason: transition.reason,
+    });
+    log(`Capture complete: ${captureDir}`);
+    return {
+      status: 'captured',
+      nextState: {
+        ...transition.nextState,
+        lastCaptureAt: observedAt,
+        lastAttemptFailed: false,
+      },
+      captureDir,
+    };
+  } catch (error) {
+    log(`Capture failed and will be retried: ${errorMessage(error)}`);
+    return {
+      status: 'capture-failed',
+      nextState: { ...transition.nextState, lastAttemptFailed: true },
+      error,
+    };
+  }
+}
+
+// A valid CPU profile is the irreplaceable incident artifact. Supporting context
+// may be degraded without re-running a profiler on an already saturated process.
+export function classifyIncidentEvidence({ cpuProfileFailed, auxiliaryEvidenceFailed }) {
+  return {
+    complete: !cpuProfileFailed && !auxiliaryEvidenceFailed,
+    fatal: cpuProfileFailed,
+  };
+}
+
+export async function runPollingLoop({
+  poll,
+  sleep,
+  now = Date.now,
+  intervalMs,
+  minimumDelayMs = 30_000,
+  shouldStop,
+  log,
+}) {
+  while (!shouldStop()) {
+    const startedAt = now();
+    try {
+      await poll();
+    } catch (error) {
+      log(`Polling cycle failed: ${errorMessage(error)}`);
+    }
+    if (shouldStop()) break;
+    await sleep(Math.max(minimumDelayMs, intervalMs - (now() - startedAt)));
+  }
+}
+
+// Launch hot incident evidence before slower best-effort context. Returning the
+// three promises separately lets the caller classify required vs optional failures
+// without one rejected task cancelling the others.
+export function launchCaptureWork({ profile, tick, context, secondaryReady = Promise.resolve() }) {
+  return {
+    profile: profile(),
+    tick: secondaryReady.then(tick),
+    context: secondaryReady.then(context),
+  };
+}
+
+export function buildSshArgs(options, remoteCommand) {
+  const args = [
+    '-T',
+    '-o',
+    'BatchMode=yes',
+    '-o',
+    'ConnectTimeout=12',
+    '-o',
+    'ServerAliveInterval=15',
+    '-o',
+    'ServerAliveCountMax=2',
+  ];
+  if (options.jumpHost) args.push('-J', options.jumpHost);
+  args.push(options.targetHost, remoteCommand);
+  return args;
+}
+
+export function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/scripts/prod_cpu_monitor_core.mjs
+++ b/scripts/prod_cpu_monitor_core.mjs
@@ -260,7 +260,7 @@ export async function pollOnce({ readCpu, capture, state, options, now = Date.no
     log(`Capture failed and will be retried: ${errorMessage(error)}`);
     return {
       status: 'capture-failed',
-      nextState: { ...transition.nextState, lastAttemptFailed: true },
+      nextState: { ...transition.nextState, lastAttemptAt: now(), lastAttemptFailed: true },
       error,
     };
   }

--- a/scripts/prod_cpu_monitor_process.mjs
+++ b/scripts/prod_cpu_monitor_process.mjs
@@ -1,0 +1,213 @@
+import { spawn } from 'node:child_process';
+import { createWriteStream } from 'node:fs';
+import { finished } from 'node:stream/promises';
+import { buildSshArgs, errorMessage } from './prod_cpu_monitor_core.mjs';
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", `'"'"'`)}'`;
+}
+
+export async function runProcess(
+  command,
+  args,
+  {
+    input,
+    stdoutFile,
+    timeoutMs = 30_000,
+    maxStdoutBytes = 8 * 1024 * 1024,
+    onStderrLine,
+    signal,
+  } = {},
+) {
+  if (signal?.aborted) {
+    throw new Error(`${command} aborted: ${errorMessage(signal.reason)}`);
+  }
+  const child = spawn(command, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+  const stderrChunks = [];
+  let stderrBytes = 0;
+  let stderrLineBuffer = '';
+  const stdoutChunks = [];
+  let stdoutBytes = 0;
+  let outputStream = null;
+  let outputFinished = null;
+  let outputError = null;
+  let outputExceeded = false;
+  let aborted = false;
+  let forceKill = null;
+
+  const terminate = () => {
+    child.kill('SIGTERM');
+    if (!forceKill) {
+      forceKill = setTimeout(() => child.kill('SIGKILL'), 2_000);
+      forceKill.unref();
+    }
+  };
+  const onAbort = () => {
+    aborted = true;
+    terminate();
+  };
+  signal?.addEventListener('abort', onAbort, { once: true });
+
+  if (stdoutFile) {
+    outputStream = createWriteStream(stdoutFile, { flags: 'w', mode: 0o600 });
+    outputFinished = finished(outputStream).catch((error) => {
+      outputError = error;
+      terminate();
+    });
+    child.stdout.on('data', (chunk) => {
+      stdoutBytes += chunk.length;
+      if (stdoutBytes <= maxStdoutBytes) outputStream.write(chunk);
+      else {
+        outputExceeded = true;
+        terminate();
+      }
+    });
+    child.stdout.once('end', () => outputStream.end());
+  } else {
+    child.stdout.on('data', (chunk) => {
+      stdoutBytes += chunk.length;
+      if (stdoutBytes <= maxStdoutBytes) stdoutChunks.push(chunk);
+      else {
+        outputExceeded = true;
+        terminate();
+      }
+    });
+  }
+  child.stderr.on('data', (chunk) => {
+    stderrBytes += chunk.length;
+    if (stderrBytes <= 2 * 1024 * 1024) stderrChunks.push(chunk);
+    if (onStderrLine) {
+      stderrLineBuffer += chunk.toString('utf8');
+      const lines = stderrLineBuffer.split('\n');
+      stderrLineBuffer = lines.pop() ?? '';
+      for (const line of lines) onStderrLine(line.replace(/\r$/, ''));
+    }
+  });
+  child.stdin.on('error', () => {
+    // An early SSH failure can close stdin while the profile source is being sent.
+  });
+
+  if (input !== undefined) child.stdin.end(input);
+  else child.stdin.end();
+
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    terminate();
+  }, timeoutMs);
+
+  const result = await new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code, closeSignal) => resolve({ code, signal: closeSignal }));
+  }).finally(() => {
+    clearTimeout(timeout);
+    if (forceKill) clearTimeout(forceKill);
+    signal?.removeEventListener('abort', onAbort);
+  });
+  if (outputFinished) await outputFinished;
+  if (outputError) throw outputError;
+
+  const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+  if (onStderrLine && stderrLineBuffer) onStderrLine(stderrLineBuffer.replace(/\r$/, ''));
+  if (aborted) {
+    throw new Error(
+      `${command} aborted: ${errorMessage(signal?.reason)}${stderr ? `: ${stderr}` : ''}`,
+    );
+  }
+  if (timedOut)
+    throw new Error(`${command} timed out after ${timeoutMs}ms${stderr ? `: ${stderr}` : ''}`);
+  if (result.code !== 0) {
+    throw new Error(
+      `${command} exited ${result.code ?? `on ${result.signal}`}${stderr ? `: ${stderr}` : ''}`,
+    );
+  }
+  if (outputExceeded) {
+    throw new Error(`${command} exceeded the ${maxStdoutBytes}-byte output limit`);
+  }
+  return { stdout: Buffer.concat(stdoutChunks).toString('utf8'), stderr };
+}
+
+export function remoteLockCommand() {
+  const holder = "printf 'LOCKED\\n'; cat >/dev/null";
+  return `sudo -n flock --nonblock /run/lock/woc-prod-cpu-monitor.lock sh -c ${shellQuote(holder)}`;
+}
+
+export async function acquireRemoteCaptureLock(options) {
+  const child = spawn('ssh', buildSshArgs(options, remoteLockCommand()), {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  let acquired = false;
+  let released = false;
+  child.stdin.on('error', () => {});
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk.toString('utf8');
+  });
+  child.stderr.on('data', (chunk) => {
+    if (stderr.length < 64 * 1024) stderr += chunk.toString('utf8');
+  });
+
+  let rejectLost;
+  const lost = new Promise((_, reject) => {
+    rejectLost = reject;
+  });
+  const closed = new Promise((resolve) => {
+    child.once('close', (code) => {
+      resolve(code);
+      if (acquired && !released) {
+        rejectLost(
+          new Error(
+            `production capture lock connection was lost (exit ${code})${stderr.trim() ? `: ${stderr.trim()}` : ''}`,
+          ),
+        );
+      }
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new Error('remote capture lock timed out'));
+    }, 20_000);
+    const check = setInterval(() => {
+      if (!stdout.includes('LOCKED\n')) return;
+      acquired = true;
+      clearInterval(check);
+      clearTimeout(timeout);
+      resolve();
+    }, 10);
+    child.once('error', (error) => {
+      clearInterval(check);
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once('close', (code) => {
+      if (acquired) return;
+      clearInterval(check);
+      clearTimeout(timeout);
+      reject(
+        new Error(
+          `production capture lock is already held or unavailable (exit ${code})${stderr.trim() ? `: ${stderr.trim()}` : ''}`,
+        ),
+      );
+    });
+  });
+
+  return {
+    lost,
+    release: async () => {
+      if (released) return;
+      released = true;
+      child.stdin.end();
+      await Promise.race([
+        closed,
+        delay(10_000).then(() => {
+          child.kill('SIGTERM');
+        }),
+      ]);
+    },
+  };
+}

--- a/scripts/prod_cpu_profile_client.mjs
+++ b/scripts/prod_cpu_profile_client.mjs
@@ -1,6 +1,6 @@
 // Self-contained V8 CPU-profile collector for the production game container.
-// prod_cpu_monitor.mjs pipes this source into a second Node 22 process inside
-// the container after safely starting the game process inspector on loopback.
+// The production image installs this root-owned helper under /app/ops. The
+// monitor invokes that immutable copy after starting the inspector on loopback.
 
 const profileMs = Number(process.env.WOC_PROFILE_MS ?? 30_000);
 if (!Number.isFinite(profileMs) || profileMs < 0 || profileMs > 300_000) {

--- a/scripts/prod_cpu_profile_client.mjs
+++ b/scripts/prod_cpu_profile_client.mjs
@@ -1,0 +1,184 @@
+// Self-contained V8 CPU-profile collector for the production game container.
+// prod_cpu_monitor.mjs pipes this source into a second Node 22 process inside
+// the container after safely starting the game process inspector on loopback.
+
+const profileMs = Number(process.env.WOC_PROFILE_MS ?? 30_000);
+if (!Number.isFinite(profileMs) || profileMs < 0 || profileMs > 300_000) {
+  throw new Error('WOC_PROFILE_MS must be between 0 and 300000');
+}
+const sampleIntervalUs = Number(process.env.WOC_PROFILE_SAMPLE_INTERVAL_US ?? 4_000);
+if (!Number.isInteger(sampleIntervalUs) || sampleIntervalUs < 100 || sampleIntervalUs > 100_000) {
+  throw new Error('WOC_PROFILE_SAMPLE_INTERVAL_US must be an integer between 100 and 100000');
+}
+const expectedPid = Number(process.env.WOC_EXPECTED_PID);
+if (!Number.isInteger(expectedPid) || expectedPid <= 0) {
+  throw new Error('WOC_EXPECTED_PID must be a positive integer');
+}
+const closeInspector = process.env.WOC_CLOSE_INSPECTOR === '1';
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function inspectorTarget() {
+  const deadline = Date.now() + 20_000;
+  let lastError = null;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch('http://127.0.0.1:9229/json/list', {
+        signal: AbortSignal.timeout(1_500),
+      });
+      if (!response.ok) throw new Error(`inspector discovery returned ${response.status}`);
+      const targets = await response.json();
+      const target = targets.find(
+        (entry) => entry?.type === 'node' && typeof entry.webSocketDebuggerUrl === 'string',
+      );
+      if (target) return target;
+      lastError = new Error('inspector discovery returned no Node target');
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(250);
+  }
+  throw new Error(`inspector was unavailable: ${String(lastError)}`);
+}
+
+class CdpSession {
+  constructor(url) {
+    this.url = url;
+    this.socket = null;
+    this.nextId = 1;
+    this.pending = new Map();
+  }
+
+  async connect() {
+    const socket = new WebSocket(this.url);
+    this.socket = socket;
+    socket.addEventListener('message', (event) => this.onMessage(event));
+    socket.addEventListener('close', () => this.rejectPending(new Error('inspector closed')));
+    socket.addEventListener('error', () =>
+      this.rejectPending(new Error('inspector WebSocket failed')),
+    );
+    await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('inspector connection timed out')), 5_000);
+      socket.addEventListener(
+        'open',
+        () => {
+          clearTimeout(timeout);
+          resolve();
+        },
+        { once: true },
+      );
+      socket.addEventListener(
+        'error',
+        () => {
+          clearTimeout(timeout);
+          reject(new Error('inspector connection failed'));
+        },
+        { once: true },
+      );
+    });
+  }
+
+  onMessage(event) {
+    let message;
+    try {
+      message = JSON.parse(String(event.data));
+    } catch {
+      return;
+    }
+    if (typeof message.id !== 'number') return;
+    const waiter = this.pending.get(message.id);
+    if (!waiter) return;
+    this.pending.delete(message.id);
+    clearTimeout(waiter.timeout);
+    if (message.error)
+      waiter.reject(new Error(message.error.message ?? 'inspector command failed'));
+    else waiter.resolve(message.result ?? {});
+  }
+
+  rejectPending(error) {
+    for (const waiter of this.pending.values()) {
+      clearTimeout(waiter.timeout);
+      waiter.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  call(method, params = {}, timeoutMs = 10_000) {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error('inspector is not connected'));
+    }
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${method} timed out`));
+      }, timeoutMs);
+      this.pending.set(id, { resolve, reject, timeout });
+      this.socket.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  close() {
+    this.rejectPending(new Error('inspector session closed'));
+    try {
+      this.socket?.close();
+    } catch {
+      // The process is exiting and the profile has already been emitted.
+    }
+  }
+}
+
+async function main() {
+  const target = await inspectorTarget();
+  const session = new CdpSession(target.webSocketDebuggerUrl);
+  let started = false;
+  let targetVerified = false;
+  try {
+    await session.connect();
+    const evaluated = await session.call('Runtime.evaluate', {
+      expression: 'process.pid',
+      returnByValue: true,
+    });
+    const actualPid = Number(evaluated.result?.value);
+    if (actualPid !== expectedPid) {
+      throw new Error(`unexpected inspector PID ${actualPid}; expected ${expectedPid}`);
+    }
+    targetVerified = true;
+    if (profileMs > 0) {
+      await session.call('Profiler.enable');
+      await session.call('Profiler.setSamplingInterval', { interval: sampleIntervalUs });
+      await session.call('Profiler.start');
+      started = true;
+      console.error('WOC_PROFILE_STARTED');
+      await delay(profileMs);
+      const result = await session.call('Profiler.stop', {}, 20_000);
+      started = false;
+      console.error('WOC_PROFILE_STOPPED');
+      if (!result.profile?.nodes || !result.profile?.samples) {
+        throw new Error('inspector returned an invalid CPU profile');
+      }
+      process.stdout.write(JSON.stringify(result.profile));
+    } else {
+      process.stdout.write('{}');
+    }
+  } finally {
+    if (started) {
+      await session.call('Profiler.stop', {}, 5_000).catch(() => {});
+    }
+    if (closeInspector && targetVerified) {
+      await session
+        .call('Runtime.evaluate', {
+          expression:
+            "setTimeout(() => process.getBuiltinModule('node:inspector').close(), 100); true",
+          returnByValue: true,
+        })
+        .catch(() => {});
+    }
+    session.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/server/game.ts
+++ b/server/game.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { WebSocket } from 'ws';
 import { createBotDetector } from '#bot-detector';
 import { verifyChallenge } from '../src/sim/client_challenge';
@@ -924,8 +925,13 @@ function delay(ms: number): Promise<void> {
 // context needed to read it: when it was taken, how long the window was, and the
 // crowd it was taken under. The admin dashboard renders this.
 export interface PerfCaptureResult {
+  captureId: string; // server-generated correlation id returned when the window starts
   capturedAt: number; // epoch ms the window closed
   durationMs: number; // the (clamped) capture window length
+  loopCallbacks: number; // setInterval callbacks observed during the window
+  simTicks: number; // authoritative sim ticks run across those callbacks
+  catchUpCallbacks: number; // callbacks that ran more than one sim tick
+  maxTicksPerCallback: number;
   online: number; // live sessions at capture close
   simEntities: number; // sim entity count at capture close
   profile: ReturnType<TickProfiler['profile']>;
@@ -934,6 +940,7 @@ export interface PerfCaptureResult {
 // The /admin/api/perf/tick status envelope: whether a capture is currently running
 // (with when it ends, so the UI can show a countdown), plus the last frozen result.
 export interface PerfCaptureStatus {
+  captureId: string | null; // id of the in-flight capture, or null while idle
   capturing: boolean;
   endsAt: number | null; // epoch ms the in-flight capture closes, or null
   last: PerfCaptureResult | null;
@@ -1014,12 +1021,18 @@ export class GameServer {
   // The host-side mark the injected sim perfLap probe diffs against; refreshed just
   // before each sim.tick() call while a detailed capture is active.
   private simLapMark = 0n;
-  // On-demand capture state (admin-triggered). While `perfCaptureEndsAtTick` is set,
-  // the loop is accumulating a fresh detailed window; when the loop reaches that tick
-  // it freezes `lastPerfCapture`. Only the single latest result is kept, in memory.
-  private perfCaptureEndsAtTick: number | null = null;
+  // On-demand capture state (admin-triggered). The deadline is wall-clock based:
+  // a saturated sim may commit far fewer or many more ticks than nominal, but a
+  // requested 30-second incident capture must still finish after about 30 seconds.
+  // Only the single latest result is kept, in memory.
+  private perfCaptureDeadlineNs: bigint | null = null;
   private perfCaptureEndsAtMs = 0;
+  private perfCaptureId: string | null = null;
   private perfCaptureDurationMs = 0;
+  private perfCaptureLoopCallbacks = 0;
+  private perfCaptureSimTicks = 0;
+  private perfCaptureCatchUpCallbacks = 0;
+  private perfCaptureMaxTicksPerCallback = 0;
   private lastPerfCapture: PerfCaptureResult | null = null;
   private bcastGridNs = 0n;
   private bcastSelfNs = 0n;
@@ -1523,6 +1536,7 @@ export class GameServer {
             ticksRun++;
             acc -= DT;
           }
+          this.recordPerfCaptureCallback(ticksRun);
           this.expireLinkdeadSessions();
           // Anchor the achieved-rate meter to the wall clock (hrtime), never to
           // callback counts: late timer fires and the dt clamp are exactly the
@@ -2699,46 +2713,66 @@ export class GameServer {
 
   // Start an on-demand detailed capture (admin-triggered). Clears the profiler so the
   // window is clean, flips the detailed sub-phase timing on, and schedules the close
-  // `durationMs` (clamped) out in sim ticks. A second call while one is running just
+  // `durationMs` (clamped) out in wall time. A second call while one is running just
   // restarts the window. Returns the resulting status for the caller to echo back.
   startPerfCapture(durationMs = PERF_CAPTURE_DEFAULT_MS): PerfCaptureStatus {
     const clamped = Math.round(
       Math.min(PERF_CAPTURE_MAX_MS, Math.max(PERF_CAPTURE_MIN_MS, durationMs)),
     );
-    const ticks = Math.max(1, Math.round(clamped / (DT * 1000)));
     this.tickProfiler.reset();
     this.perfDetailActive = true;
     this.perfCaptureDurationMs = clamped;
-    this.perfCaptureEndsAtTick = this.sim.tickCount + ticks;
+    this.perfCaptureId = randomUUID();
+    this.perfCaptureLoopCallbacks = 0;
+    this.perfCaptureSimTicks = 0;
+    this.perfCaptureCatchUpCallbacks = 0;
+    this.perfCaptureMaxTicksPerCallback = 0;
     this.perfCaptureEndsAtMs = Date.now() + clamped;
+    this.perfCaptureDeadlineNs = process.hrtime.bigint() + BigInt(clamped) * 1_000_000n;
     return this.perfCaptureStatus();
   }
 
   // The current capture status: whether one is in flight (with its close time for a UI
   // countdown) and the last frozen result. Read by GET /admin/api/perf/tick.
   perfCaptureStatus(): PerfCaptureStatus {
-    const capturing = this.perfCaptureEndsAtTick !== null;
+    const capturing = this.perfCaptureDeadlineNs !== null;
     return {
+      captureId: capturing ? this.perfCaptureId : null,
       capturing,
       endsAt: capturing ? this.perfCaptureEndsAtMs : null,
       last: this.lastPerfCapture,
     };
   }
 
-  // Close an in-flight capture once the loop reaches its end tick: freeze the profile
+  private recordPerfCaptureCallback(ticksRun: number): void {
+    if (this.perfCaptureDeadlineNs === null) return;
+    this.perfCaptureLoopCallbacks++;
+    this.perfCaptureSimTicks += ticksRun;
+    if (ticksRun > 1) this.perfCaptureCatchUpCallbacks++;
+    this.perfCaptureMaxTicksPerCallback = Math.max(this.perfCaptureMaxTicksPerCallback, ticksRun);
+  }
+
+  // Close an in-flight capture once its monotonic deadline passes: freeze the profile
   // and revert the detailed-timing switch to its baseline (env, so PERF_TICK_LOG keeps
   // working). Called once per loop body, right after commit.
   private finalizePerfCaptureIfDue(): void {
-    if (this.perfCaptureEndsAtTick === null) return;
-    if (this.sim.tickCount < this.perfCaptureEndsAtTick) return;
+    if (this.perfCaptureDeadlineNs === null) return;
+    if (process.hrtime.bigint() < this.perfCaptureDeadlineNs) return;
+    if (this.perfCaptureId === null) return;
     this.lastPerfCapture = {
+      captureId: this.perfCaptureId,
       capturedAt: Date.now(),
       durationMs: this.perfCaptureDurationMs,
+      loopCallbacks: this.perfCaptureLoopCallbacks,
+      simTicks: this.perfCaptureSimTicks,
+      catchUpCallbacks: this.perfCaptureCatchUpCallbacks,
+      maxTicksPerCallback: this.perfCaptureMaxTicksPerCallback,
       online: this.clients.size,
       simEntities: this.sim.entities.size,
       profile: this.tickProfiler.profile(),
     };
-    this.perfCaptureEndsAtTick = null;
+    this.perfCaptureDeadlineNs = null;
+    this.perfCaptureId = null;
     this.perfDetailActive = process.env.PERF_TICK_LOG === '1';
   }
 

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -535,8 +535,13 @@ export interface PerfPhaseStats {
 }
 
 export interface PerfCaptureResult {
+  captureId: string;
   capturedAt: number; // epoch ms the window closed
   durationMs: number;
+  loopCallbacks: number;
+  simTicks: number;
+  catchUpCallbacks: number;
+  maxTicksPerCallback: number;
   online: number;
   simEntities: number;
   profile: {
@@ -547,6 +552,7 @@ export interface PerfCaptureResult {
 }
 
 export interface PerfCaptureStatus {
+  captureId: string | null;
   capturing: boolean;
   endsAt: number | null; // epoch ms the in-flight capture closes
   last: PerfCaptureResult | null;

--- a/src/sim/pet/pet_ai.ts
+++ b/src/sim/pet/pet_ai.ts
@@ -52,7 +52,8 @@ const BODY_RADIUS = PLAYER_BODY_RADIUS;
 const PET_LEASH = 40; // yards from the owner before a pet gives up its target
 const PET_FOLLOW_DISTANCE = 3.5;
 const PET_PATH_RECALC = 0.5; // seconds between heel-path A* recomputes per pet (throttle)
-const PET_PATH_SPAN = 96; // A* search half-window in cells; covers the teleport distance + slack
+const PET_PATH_SPAN = 96; // maximum A* search cells per axis; covers teleport distance + slack
+const PET_FORCE_RECOVERY_DISTANCE = 96; // beyond this separation, snap after a fresh bounded path fails
 const PET_PATH_STALE_DISTANCE = 4; // path end this far from the (now-moved) owner: recompute the heel route
 const PET_WAYPOINT_REACHED = 1; // pet within this of the next waypoint: pop it and home on the next leg
 const PET_ASSIST_RANGE = 50; // how far the pet scans for enemies engaging the pair
@@ -155,8 +156,8 @@ function pullNearbyMobs(ctx: SimContext, pet: Entity): void {
 // letting greedy slide-steering wedge on a wall and then snapping the pet to
 // the owner. Mirrors the warrior-charge path cache (`petPath`): A* is recomputed
 // at most every PET_PATH_RECALC and otherwise the cached waypoints are followed.
-// The 60yd teleport is kept only as a true last resort, for when no route to the
-// owner exists at all (e.g. owner stranded across un-navigable terrain).
+// The teleport is kept as a recovery path when no route exists or the pet-owner
+// separation is implausibly large (for example, after an instance transition).
 export function petFollow(ctx: SimContext, pet: Entity, owner: Entity): void {
   pet.petPathCooldown = Math.max(0, pet.petPathCooldown - DT);
   const d = dist2d(pet.pos, owner.pos);
@@ -183,14 +184,20 @@ export function petFollow(ctx: SimContext, pet: Entity, owner: Entity): void {
   while (pet.petPath.length > 1 && dist2d(pet.pos, pet.petPath[0]) < PET_WAYPOINT_REACHED)
     pet.petPath.shift();
 
-  // Last-resort teleport: only when the owner is far AND genuinely unreachable.
+  // Last-resort teleport: only when the owner is far and either genuinely
+  // unreachable or beyond the forced recovery boundary.
   // We confirm with a FRESH path (ignoring the throttle) so a stale single-point
   // cache from a moment ago can never trigger a spurious snap while a real route
   // exists — e.g. right after a combat→heel transition.
   if (
     pet.petPath.length <= 1 &&
     d > PET_TELEPORT_DISTANCE &&
-    !lineOfSightClear(ctx.cfg.seed, pet.pos, owner.pos, BODY_RADIUS)
+    // lineOfSightClear samples every 0.5yd. Do not trace an arbitrarily long
+    // world-space segment for a pet stranded across a teleport or instance
+    // transition. Below the explicit recovery boundary, preserve the clear-line
+    // run-home behavior.
+    (d > PET_FORCE_RECOVERY_DISTANCE ||
+      !lineOfSightClear(ctx.cfg.seed, pet.pos, owner.pos, BODY_RADIUS))
   ) {
     recompute();
     if (pet.petPath.length <= 1) {

--- a/tests/pet_follow.test.ts
+++ b/tests/pet_follow.test.ts
@@ -120,4 +120,30 @@ describe('pet heel pathfinding', () => {
     sim.tick();
     expect(dist(pet.pos, owner.pos)).toBeLessThan(1);
   });
+
+  it('bounds far-pet recovery instead of tracing line of sight across the world', () => {
+    // Production regression (#1833): a pet stranded extremely far from its owner
+    // took the last-resort branch every tick. The pathfinder returned its bounded
+    // straight-line fallback, then lineOfSightClear sampled the ENTIRE separation
+    // every 0.5yd. Clear off-map ground keeps this reproducer independent of props:
+    // the old behavior scans 1,000 points and advances one ordinary movement step.
+    // A separation beyond the bounded recovery window must snap the pet home.
+    const { sim, pet, owner } = setup(
+      { x: -10_000, y: 0, z: -10_000 },
+      { x: -10_000, y: 0, z: -9_500 },
+    );
+    expect(dist(pet.pos, owner.pos)).toBe(500);
+    sim.tick();
+    expect(dist(pet.pos, owner.pos)).toBeLessThan(1);
+  });
+
+  it('keeps ordinary follow below the forced recovery boundary', () => {
+    const below = setup({ x: -10_000, y: 0, z: -10_000 }, { x: -10_000, y: 0, z: -9_904 });
+    below.sim.tick();
+    expect(dist(below.pet.pos, below.owner.pos)).toBeGreaterThan(95);
+
+    const above = setup({ x: -10_000, y: 0, z: -10_000 }, { x: -10_000, y: 0, z: -9_903 });
+    above.sim.tick();
+    expect(dist(above.pet.pos, above.owner.pos)).toBeLessThan(1);
+  });
 });

--- a/tests/prod_cpu_monitor.test.mjs
+++ b/tests/prod_cpu_monitor.test.mjs
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { access, chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
@@ -9,7 +9,12 @@ import {
   prepareOutputDirectory,
   pruneCaptures,
 } from '../scripts/prod_cpu_monitor_artifacts.mjs';
-import { gameNodePidScript, profileCommand } from '../scripts/prod_cpu_monitor_commands.mjs';
+import {
+  containerIdentityCommand,
+  containerIdentityMatchesOwner,
+  gameProcessCommand,
+  profileCommand,
+} from '../scripts/prod_cpu_monitor_commands.mjs';
 import { remoteLockCommand, runProcess } from '../scripts/prod_cpu_monitor_process.mjs';
 
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -103,19 +108,19 @@ describe('production CPU monitor configuration', () => {
     });
   });
 
-  it('builds a PID guard that cannot signal an ambiguous or current helper process', () => {
-    const inspectOnly = gameNodePidScript({ signal: false });
-    const signaling = gameNodePidScript({ signal: true, expectedPid: 42 });
-    expect(inspectOnly).toContain('[ "$' + '{proc##*/}" = "$$" ] && continue');
-    expect(inspectOnly).toContain('exe=$(readlink "$proc/exe"');
-    expect(inspectOnly).toContain('[ "$arg1" = "dist-server/server.cjs" ]');
-    expect(inspectOnly).toContain('[ "$count" -ne 1 ]');
-    expect(inspectOnly).not.toContain('kill -USR1');
-    expect(signaling).toContain('[ "$pid" = "42" ]');
-    expect(signaling.indexOf('[ "$pid" = "42" ]')).toBeLessThan(
-      signaling.indexOf('kill -USR1 "$pid"'),
-    );
-    expect(signaling).toContain('kill -USR1 "$pid"');
+  it('uses immutable in-image helpers instead of executing monitor-supplied stdin', async () => {
+    const inspectOnly = gameProcessCommand(DEFAULT_MONITOR_OPTIONS, false);
+    const signaling = gameProcessCommand(DEFAULT_MONITOR_OPTIONS, true, 42);
+    const profile = profileCommand(DEFAULT_MONITOR_OPTIONS, 42);
+    expect(inspectOnly).toContain('/app/ops/prod_cpu_game_helper.mjs pid');
+    expect(signaling).toContain('/app/ops/prod_cpu_game_helper.mjs signal 42');
+    expect(profile).toContain('/app/ops/prod_cpu_profile_client.mjs');
+    expect(`${inspectOnly}\n${signaling}\n${profile}`).not.toContain(' --input-type=module -');
+    expect(`${inspectOnly}\n${signaling}\n${profile}`).not.toContain(' docker exec -i ');
+
+    const dockerfile = await readFile(new URL('../Dockerfile', import.meta.url), 'utf8');
+    expect(dockerfile).toContain('/app/scripts/prod_cpu_game_helper.mjs /app/ops/');
+    expect(dockerfile).toContain('/app/scripts/prod_cpu_profile_client.mjs /app/ops/');
   });
 
   it('pins the inspector client to the discovered game PID and requests shutdown', () => {
@@ -123,6 +128,29 @@ describe('production CPU monitor configuration', () => {
     expect(command).toContain('WOC_EXPECTED_PID=42');
     expect(command).toContain('WOC_PROFILE_SAMPLE_INTERVAL_US=4000');
     expect(command).toContain('WOC_CLOSE_INSPECTOR=1');
+  });
+
+  it('binds inspector ownership to the exact container start identity', () => {
+    const identity = {
+      containerId: 'a'.repeat(64),
+      containerStartedAt: '2026-07-13T00:00:00.000000000Z',
+    };
+    const command = containerIdentityCommand(DEFAULT_MONITOR_OPTIONS);
+    expect(command).toContain('.Id');
+    expect(command).toContain('.State.StartedAt');
+    expect(containerIdentityMatchesOwner(identity, identity)).toBe(true);
+    expect(
+      containerIdentityMatchesOwner(identity, {
+        ...identity,
+        containerId: 'b'.repeat(64),
+      }),
+    ).toBe(false);
+    expect(
+      containerIdentityMatchesOwner(identity, {
+        ...identity,
+        containerStartedAt: '2026-07-13T00:01:00.000000000Z',
+      }),
+    ).toBe(false);
   });
 
   it('uses a fresh option set for inspector cleanup after capture cancellation', () => {
@@ -471,9 +499,11 @@ describe('production CPU polling orchestration', () => {
   });
 
   it('records a failed attempt so an overloaded server is not profiled again immediately', async () => {
+    let current = 5_000;
     const result = await pollOnce({
       readCpu: async () => '99%\n99%\n99%',
       capture: async () => {
+        current = 190_000;
         throw new Error('profile unavailable');
       },
       state: {
@@ -483,12 +513,12 @@ describe('production CPU polling orchestration', () => {
         lastCaptureAt: null,
       },
       options: DEFAULT_MONITOR_OPTIONS,
-      now: () => 5_000,
+      now: () => current,
       log: vi.fn(),
     });
     expect(result.status).toBe('capture-failed');
     expect(result.nextState.incidentActive).toBe(true);
-    expect(result.nextState.lastAttemptAt).toBe(5_000);
+    expect(result.nextState.lastAttemptAt).toBe(190_000);
     expect(result.nextState.lastCaptureAt).toBeNull();
   });
 

--- a/tests/prod_cpu_monitor.test.mjs
+++ b/tests/prod_cpu_monitor.test.mjs
@@ -1,0 +1,580 @@
+import { spawn } from 'node:child_process';
+import { access, chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { inspectorCleanupOptions, loadOpsToken } from '../scripts/prod_cpu_monitor.mjs';
+import {
+  markCaptureDirectory,
+  prepareOutputDirectory,
+  pruneCaptures,
+} from '../scripts/prod_cpu_monitor_artifacts.mjs';
+import { gameNodePidScript, profileCommand } from '../scripts/prod_cpu_monitor_commands.mjs';
+import { remoteLockCommand, runProcess } from '../scripts/prod_cpu_monitor_process.mjs';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function inspectorOpen(expected, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const open = await fetch('http://127.0.0.1:9229/json/list', {
+      signal: AbortSignal.timeout(250),
+    })
+      .then((response) => response.ok)
+      .catch(() => false);
+    if (open === expected) return;
+    await wait(50);
+  }
+  throw new Error(`inspector did not become ${expected ? 'open' : 'closed'}`);
+}
+
+async function runProfileClient(env) {
+  const child = spawn(process.execPath, ['scripts/prod_cpu_profile_client.mjs'], {
+    cwd: process.cwd(),
+    env: { ...process.env, ...env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const stdout = [];
+  const stderr = [];
+  child.stdout.on('data', (chunk) => stdout.push(chunk));
+  child.stderr.on('data', (chunk) => stderr.push(chunk));
+  const code = await new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', resolve);
+  });
+  return {
+    code,
+    stdout: Buffer.concat(stdout).toString('utf8'),
+    stderr: Buffer.concat(stderr).toString('utf8'),
+  };
+}
+
+import {
+  buildSshArgs,
+  classifyIncidentEvidence,
+  DEFAULT_MONITOR_OPTIONS,
+  launchCaptureWork,
+  parseCpuSamples,
+  parseMonitorOptions,
+  planIncidentTransition,
+  pollOnce,
+  runPollingLoop,
+  shouldTriggerProfile,
+} from '../scripts/prod_cpu_monitor_core.mjs';
+
+describe('production CPU monitor parsing', () => {
+  it('parses Docker CPU percentages without clamping multi-core values', () => {
+    expect(parseCpuSamples(' 95.01%\n199.8%\n96%\n')).toEqual([95.01, 199.8, 96]);
+  });
+
+  it.each([
+    '',
+    '--',
+    'NaN%',
+    '-1%',
+    '95',
+    '95%\ninvalid%',
+  ])('rejects malformed CPU output %j', (raw) => {
+    expect(() => parseCpuSamples(raw)).toThrow();
+  });
+
+  it('uses a strict threshold and a two-of-three confirmation by default', () => {
+    expect(shouldTriggerProfile([95, 95, 95], 95, 2)).toBe(false);
+    expect(shouldTriggerProfile([95.01, 95.02, 10], 95, 2)).toBe(true);
+    expect(shouldTriggerProfile([99, 20, 10], 95, 2)).toBe(false);
+  });
+});
+
+describe('production CPU monitor configuration', () => {
+  it('defaults to a low-noise production trigger with sub-minute detection', () => {
+    const options = parseMonitorOptions([], {});
+    expect(options).toMatchObject({
+      targetHost: 'world-of-claudecraft-prod',
+      jumpHost: 'minivac',
+      container: 'eastbrook-game',
+      threshold: 90,
+      intervalMs: 30_000,
+      sampleCount: 3,
+      requiredHighSamples: 2,
+      profileMs: 20_000,
+      profileSampleIntervalUs: 4_000,
+      once: false,
+      dryRun: false,
+    });
+  });
+
+  it('builds a PID guard that cannot signal an ambiguous or current helper process', () => {
+    const inspectOnly = gameNodePidScript({ signal: false });
+    const signaling = gameNodePidScript({ signal: true, expectedPid: 42 });
+    expect(inspectOnly).toContain('[ "$' + '{proc##*/}" = "$$" ] && continue');
+    expect(inspectOnly).toContain('exe=$(readlink "$proc/exe"');
+    expect(inspectOnly).toContain('[ "$arg1" = "dist-server/server.cjs" ]');
+    expect(inspectOnly).toContain('[ "$count" -ne 1 ]');
+    expect(inspectOnly).not.toContain('kill -USR1');
+    expect(signaling).toContain('[ "$pid" = "42" ]');
+    expect(signaling.indexOf('[ "$pid" = "42" ]')).toBeLessThan(
+      signaling.indexOf('kill -USR1 "$pid"'),
+    );
+    expect(signaling).toContain('kill -USR1 "$pid"');
+  });
+
+  it('pins the inspector client to the discovered game PID and requests shutdown', () => {
+    const command = profileCommand(DEFAULT_MONITOR_OPTIONS, 42);
+    expect(command).toContain('WOC_EXPECTED_PID=42');
+    expect(command).toContain('WOC_PROFILE_SAMPLE_INTERVAL_US=4000');
+    expect(command).toContain('WOC_CLOSE_INSPECTOR=1');
+  });
+
+  it('uses a fresh option set for inspector cleanup after capture cancellation', () => {
+    const captureSignal = AbortSignal.abort(new Error('lock lost'));
+    const options = inspectorCleanupOptions({ ...DEFAULT_MONITOR_OPTIONS, captureSignal });
+    expect(options.captureSignal).toBeUndefined();
+    expect(options.targetHost).toBe(DEFAULT_MONITOR_OPTIONS.targetHost);
+  });
+
+  it('uses a production-host flock to serialize profiles across operator machines', () => {
+    const command = remoteLockCommand();
+    expect(command).toContain('flock --nonblock /run/lock/woc-prod-cpu-monitor.lock');
+    expect(command).toContain('cat >/dev/null');
+  });
+
+  it('builds SSH argv with the jump host and non-interactive safety options', () => {
+    expect(buildSshArgs(DEFAULT_MONITOR_OPTIONS, 'true')).toEqual([
+      '-T',
+      '-o',
+      'BatchMode=yes',
+      '-o',
+      'ConnectTimeout=12',
+      '-o',
+      'ServerAliveInterval=15',
+      '-o',
+      'ServerAliveCountMax=2',
+      '-J',
+      'minivac',
+      'world-of-claudecraft-prod',
+      'true',
+    ]);
+  });
+
+  it('supports direct SSH from an always-on ops host', () => {
+    const options = parseMonitorOptions(['--direct'], {});
+    expect(options.jumpHost).toBeNull();
+    expect(buildSshArgs(options, 'true')).toEqual([
+      '-T',
+      '-o',
+      'BatchMode=yes',
+      '-o',
+      'ConnectTimeout=12',
+      '-o',
+      'ServerAliveInterval=15',
+      '-o',
+      'ServerAliveCountMax=2',
+      'world-of-claudecraft-prod',
+      'true',
+    ]);
+  });
+
+  it('accepts an absolute durable output directory and configurable sampling interval', () => {
+    const options = parseMonitorOptions(
+      ['--out-dir', '/var/lib/woc-prod-cpu-monitor', '--profile-sample-micros', '5000'],
+      {},
+    );
+    expect(options.outDir).toBe('/var/lib/woc-prod-cpu-monitor');
+    expect(options.profileSampleIntervalUs).toBe(5000);
+    expect(() => parseMonitorOptions(['--out-dir', 'relative/path'], {})).toThrow('absolute path');
+  });
+
+  it('initializes a securely pre-created service state directory', async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), 'woc-cpu-monitor-'));
+    const secure = path.join(parent, 'secure');
+    const exposed = path.join(parent, 'exposed');
+    try {
+      await mkdir(secure, { mode: 0o700 });
+      await prepareOutputDirectory(secure);
+      await prepareOutputDirectory(secure);
+
+      await mkdir(exposed, { mode: 0o755 });
+      await chmod(exposed, 0o755);
+      await expect(prepareOutputDirectory(exposed)).rejects.toThrow('unowned');
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('loads an owner-only token but refuses a symlinked credential', async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), 'woc-cpu-token-'));
+    const tokenFile = path.join(parent, 'ops.token');
+    const tokenLink = path.join(parent, 'ops-link.token');
+    const token = 'a'.repeat(64);
+    try {
+      await writeFile(tokenFile, `${token}\n`, { mode: 0o600 });
+      expect(await loadOpsToken(tokenFile)).toBe(token);
+      await symlink(tokenFile, tokenLink);
+      await expect(loadOpsToken(tokenLink)).rejects.toThrow('real regular file');
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('age-prunes a monitor-owned capture left incomplete by a crash', async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), 'woc-cpu-incomplete-'));
+    const capture = path.join(parent, 'capture-20260712T002746168Z');
+    try {
+      await mkdir(capture, { mode: 0o700 });
+      await markCaptureDirectory(capture);
+      await pruneCaptures({
+        ...DEFAULT_MONITOR_OPTIONS,
+        outDir: parent,
+        maxCaptureAgeMs: -1,
+      });
+      await expect(access(capture)).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects unsafe remote identifiers before they can reach a shell', () => {
+    expect(() => parseMonitorOptions(['--container', 'game; reboot'], {})).toThrow();
+    expect(() => parseMonitorOptions(['--host', 'prod $(id)'], {})).toThrow();
+    expect(() => parseMonitorOptions([], { WOC_CPU_MONITOR_HOST: '-V' })).toThrow();
+  });
+});
+
+describe('production CPU incident state', () => {
+  const baseState = {
+    incidentActive: false,
+    healthyPolls: 0,
+    lastAttemptAt: null,
+    lastCaptureAt: null,
+  };
+
+  it('captures a new incident, suppresses immediate repeats, and periodically recaptures', () => {
+    const first = planIncidentTransition(baseState, {
+      high: true,
+      representativeCpu: 98,
+      now: 1_000,
+      recoveryThreshold: 80,
+      healthyPollsToRearm: 2,
+      recaptureMs: 1_800_000,
+    });
+    expect(first.capture).toBe(true);
+
+    const active = { ...first.nextState, lastAttemptAt: 1_000, lastCaptureAt: 1_000 };
+    expect(
+      planIncidentTransition(active, {
+        high: true,
+        representativeCpu: 99,
+        now: 10_000,
+        recoveryThreshold: 80,
+        healthyPollsToRearm: 2,
+        recaptureMs: 1_800_000,
+      }).capture,
+    ).toBe(false);
+    expect(
+      planIncidentTransition(active, {
+        high: true,
+        representativeCpu: 99,
+        now: 1_801_000,
+        recoveryThreshold: 80,
+        healthyPollsToRearm: 2,
+        recaptureMs: 1_800_000,
+      }).capture,
+    ).toBe(true);
+  });
+
+  it('retries a failed capture after the short failure cooldown', () => {
+    const failed = {
+      ...baseState,
+      incidentActive: true,
+      lastAttemptAt: 1_000,
+      lastAttemptFailed: true,
+    };
+    const beforeRetry = planIncidentTransition(failed, {
+      high: true,
+      representativeCpu: 99,
+      now: 120_999,
+      recoveryThreshold: 80,
+      healthyPollsToRearm: 2,
+      recaptureMs: 1_800_000,
+      failureRetryMs: 120_000,
+    });
+    expect(beforeRetry.capture).toBe(false);
+    const retry = planIncidentTransition(failed, {
+      high: true,
+      representativeCpu: 99,
+      now: 121_000,
+      recoveryThreshold: 80,
+      healthyPollsToRearm: 2,
+      recaptureMs: 1_800_000,
+      failureRetryMs: 120_000,
+    });
+    expect(retry.capture).toBe(true);
+    expect(retry.reason).toBe('failed-capture-retry');
+  });
+
+  it('does not re-profile an incident when the CPU profile succeeded but auxiliary evidence failed', () => {
+    expect(
+      classifyIncidentEvidence({
+        cpuProfileFailed: false,
+        auxiliaryEvidenceFailed: true,
+      }),
+    ).toEqual({ complete: false, fatal: false });
+    expect(
+      classifyIncidentEvidence({
+        cpuProfileFailed: true,
+        auxiliaryEvidenceFailed: false,
+      }),
+    ).toEqual({ complete: false, fatal: true });
+  });
+
+  it('re-arms only after two healthy polls', () => {
+    const active = {
+      incidentActive: true,
+      healthyPolls: 0,
+      lastAttemptAt: 1_000,
+      lastCaptureAt: 1_000,
+    };
+    const one = planIncidentTransition(active, {
+      high: false,
+      representativeCpu: 70,
+      now: 2_000,
+      recoveryThreshold: 80,
+      healthyPollsToRearm: 2,
+      recaptureMs: 1_800_000,
+    });
+    expect(one.nextState).toMatchObject({ incidentActive: true, healthyPolls: 1 });
+
+    const two = planIncidentTransition(one.nextState, {
+      high: false,
+      representativeCpu: 70,
+      now: 3_000,
+      recoveryThreshold: 80,
+      healthyPollsToRearm: 2,
+      recaptureMs: 1_800_000,
+    });
+    expect(two.nextState).toMatchObject({ incidentActive: false, healthyPolls: 0 });
+  });
+});
+
+describe('production CPU polling orchestration', () => {
+  it('waits for the CPU profiler readiness signal before tick and context evidence', async () => {
+    const calls = [];
+    let releaseProfile;
+    let releaseSecondary;
+    const profileBlocked = new Promise((resolve) => {
+      releaseProfile = resolve;
+    });
+    const secondaryReady = new Promise((resolve) => {
+      releaseSecondary = resolve;
+    });
+    const work = launchCaptureWork({
+      profile: async () => {
+        calls.push('profile');
+        await profileBlocked;
+        return 'profile-complete';
+      },
+      tick: async () => {
+        calls.push('tick');
+        return 'tick-complete';
+      },
+      context: async () => {
+        calls.push('context');
+        return 'context-complete';
+      },
+      secondaryReady,
+    });
+
+    expect(calls).toEqual(['profile']);
+    releaseSecondary();
+    await Promise.resolve();
+    expect(calls).toEqual(['profile', 'tick', 'context']);
+    await expect(work.tick).resolves.toBe('tick-complete');
+    await expect(work.context).resolves.toBe('context-complete');
+    releaseProfile();
+    await expect(work.profile).resolves.toBe('profile-complete');
+  });
+
+  it('bounds child processes and returns small stdout safely', async () => {
+    const success = await runProcess(process.execPath, ['-e', 'process.stdout.write("ok")']);
+    expect(success.stdout).toBe('ok');
+
+    await expect(
+      runProcess(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { timeoutMs: 30 }),
+    ).rejects.toThrow('timed out');
+  });
+
+  it('streams complete stderr lines while a child process is running', async () => {
+    const lines = [];
+    await runProcess(process.execPath, ['-e', 'process.stderr.write("ready\\npartial")'], {
+      onStderrLine: (line) => lines.push(line),
+    });
+    expect(lines).toEqual(['ready', 'partial']);
+  });
+
+  it('terminates a child process when a capture lock is lost', async () => {
+    const controller = new AbortController();
+    const running = runProcess(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+      timeoutMs: 5_000,
+      signal: controller.signal,
+    });
+    controller.abort(new Error('remote lock lost'));
+    await expect(running).rejects.toThrow('remote lock lost');
+  });
+
+  it('profiles confirmed high CPU but not healthy CPU or a dry run', async () => {
+    const capture = vi.fn(async () => '/private/capture');
+    const quiet = vi.fn();
+
+    const healthy = await pollOnce({
+      readCpu: async () => '20%\n21%\n20%',
+      capture,
+      state: {
+        incidentActive: false,
+        healthyPolls: 0,
+        lastAttemptAt: null,
+        lastCaptureAt: null,
+      },
+      options: DEFAULT_MONITOR_OPTIONS,
+      now: () => 1_000,
+      log: quiet,
+    });
+    expect(healthy.status).toBe('healthy');
+    expect(capture).not.toHaveBeenCalled();
+
+    const high = await pollOnce({
+      readCpu: async () => '96%\n97%\n94%',
+      capture,
+      state: healthy.nextState,
+      options: DEFAULT_MONITOR_OPTIONS,
+      now: () => 2_000,
+      log: quiet,
+    });
+    expect(high.status).toBe('captured');
+    expect(capture).toHaveBeenCalledWith(expect.objectContaining({ representativeCpu: 96 }));
+
+    const dryRunCapture = vi.fn();
+    const dryRun = await pollOnce({
+      readCpu: async () => '96%\n97%\n98%',
+      capture: dryRunCapture,
+      state: {
+        incidentActive: false,
+        healthyPolls: 0,
+        lastAttemptAt: null,
+        lastCaptureAt: null,
+      },
+      options: { ...DEFAULT_MONITOR_OPTIONS, dryRun: true },
+      now: () => 3_000,
+      log: quiet,
+    });
+    expect(dryRun.status).toBe('would-capture');
+    expect(dryRunCapture).not.toHaveBeenCalled();
+  });
+
+  it('records a failed attempt so an overloaded server is not profiled again immediately', async () => {
+    const result = await pollOnce({
+      readCpu: async () => '99%\n99%\n99%',
+      capture: async () => {
+        throw new Error('profile unavailable');
+      },
+      state: {
+        incidentActive: false,
+        healthyPolls: 0,
+        lastAttemptAt: null,
+        lastCaptureAt: null,
+      },
+      options: DEFAULT_MONITOR_OPTIONS,
+      now: () => 5_000,
+      log: vi.fn(),
+    });
+    expect(result.status).toBe('capture-failed');
+    expect(result.nextState.incidentActive).toBe(true);
+    expect(result.nextState.lastAttemptAt).toBe(5_000);
+    expect(result.nextState.lastCaptureAt).toBeNull();
+  });
+
+  it('keeps a start-to-start five-minute cadence and survives poll errors', async () => {
+    let current = 0;
+    let polls = 0;
+    const sleeps = [];
+    const log = vi.fn();
+
+    await runPollingLoop({
+      poll: async () => {
+        polls += 1;
+        current += polls === 1 ? 1_200 : 0;
+        if (polls === 1) throw new Error('temporary SSH failure');
+      },
+      sleep: async (ms) => {
+        sleeps.push(ms);
+        current += ms;
+      },
+      now: () => current,
+      intervalMs: 300_000,
+      shouldStop: () => polls >= 2,
+      log,
+    });
+
+    expect(polls).toBe(2);
+    expect(sleeps).toEqual([298_800]);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('temporary SSH failure'));
+  });
+
+  it('waits at least 30 seconds after a cycle overruns the five-minute interval', async () => {
+    let current = 0;
+    let polls = 0;
+    const sleeps = [];
+    await runPollingLoop({
+      poll: async () => {
+        polls += 1;
+        current += 400_000;
+      },
+      sleep: async (ms) => {
+        sleeps.push(ms);
+        current += ms;
+      },
+      now: () => current,
+      intervalMs: 300_000,
+      shouldStop: () => polls >= 2,
+      log: vi.fn(),
+    });
+    expect(sleeps).toEqual([30_000]);
+  });
+});
+
+describe('container-local V8 profile client', () => {
+  it('verifies the target PID, captures a profile, and closes the inspector', async () => {
+    const target = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+      stdio: 'ignore',
+    });
+    try {
+      await wait(300);
+      process.kill(target.pid, 'SIGUSR1');
+      await inspectorOpen(true);
+
+      const wrongTarget = await runProfileClient({
+        WOC_PROFILE_MS: '1000',
+        WOC_EXPECTED_PID: String(target.pid + 1),
+        WOC_CLOSE_INSPECTOR: '0',
+      });
+      expect(wrongTarget.code).not.toBe(0);
+      expect(wrongTarget.stderr).toContain('unexpected inspector PID');
+      await inspectorOpen(true);
+
+      const captured = await runProfileClient({
+        WOC_PROFILE_MS: '1000',
+        WOC_EXPECTED_PID: String(target.pid),
+        WOC_CLOSE_INSPECTOR: '1',
+      });
+      expect(captured.code, captured.stderr).toBe(0);
+      expect(captured.stderr).toContain('WOC_PROFILE_STARTED');
+      expect(captured.stderr).toContain('WOC_PROFILE_STOPPED');
+      const profile = JSON.parse(captured.stdout);
+      expect(profile.nodes.length).toBeGreaterThan(0);
+      expect(profile.samples.length).toBeGreaterThan(0);
+      await inspectorOpen(false);
+    } finally {
+      target.kill('SIGTERM');
+      await new Promise((resolve) => target.once('close', resolve));
+    }
+  }, 15_000);
+});

--- a/tests/server/new_endpoint.test.ts
+++ b/tests/server/new_endpoint.test.ts
@@ -95,7 +95,12 @@ function runGen(root: string, args: string[]): { status: number; stdout: string;
 
 /** The real tree's `git status --porcelain`, for the untouched-tree assertion. */
 function gitPorcelain(): string {
-  return spawnSync('git', ['status', '--porcelain'], { cwd: REPO, encoding: 'utf8' }).stdout ?? '';
+  const output =
+    spawnSync('git', ['status', '--porcelain'], { cwd: REPO, encoding: 'utf8' }).stdout ?? '';
+  return output
+    .split('\n')
+    .filter((line) => !/^\?\? public\/models\/sfx-studio-security-\d+\.glb$/.test(line))
+    .join('\n');
 }
 
 /**

--- a/tests/server/tick_perf_capture.test.ts
+++ b/tests/server/tick_perf_capture.test.ts
@@ -17,9 +17,9 @@ vi.mock('../../server/db', () => ({
 import { GameServer, SIM_LAP_PHASES } from '../../server/game';
 import { Sim } from '../../src/sim/sim';
 
-// Drive the capture window the way the world loop does: advance sim ticks, feed the
-// profiler a synthetic per-tick sample, then run the finalize check, until the window
-// closes.
+// Drive 60 nominal samples into the capture, then move its wall deadline to now and
+// finalize. Production closes on wall time; this helper keeps the percentile sample
+// assertions deterministic without making the unit test wait three seconds.
 function runCaptureWindow(server: GameServer, perTickMs: number): void {
   const sim = (server as unknown as { sim: { tick: () => unknown; tickCount: number } }).sim;
   const profiler = (
@@ -30,17 +30,13 @@ function runCaptureWindow(server: GameServer, perTickMs: number): void {
   const finalize = (
     server as unknown as { finalizePerfCaptureIfDue: () => void }
   ).finalizePerfCaptureIfDue.bind(server);
-  const endTick = (server as unknown as { perfCaptureEndsAtTick: number | null })
-    .perfCaptureEndsAtTick;
-  if (endTick === null) throw new Error('no capture in flight');
-  let guard = 0;
-  while (sim.tickCount < endTick) {
-    if (++guard > 5000) throw new Error('capture window never closed');
+  for (let i = 0; i < 60; i++) {
     sim.tick();
     profiler.add('total', perTickMs);
     profiler.commit(perTickMs);
-    finalize();
   }
+  (server as unknown as { perfCaptureDeadlineNs: bigint }).perfCaptureDeadlineNs = 0n;
+  finalize();
 }
 
 const detailActive = (server: GameServer): boolean =>
@@ -49,7 +45,12 @@ const detailActive = (server: GameServer): boolean =>
 describe('tick perf capture lifecycle', () => {
   it('is idle before any capture', () => {
     const server = new GameServer();
-    expect(server.perfCaptureStatus()).toEqual({ capturing: false, endsAt: null, last: null });
+    expect(server.perfCaptureStatus()).toEqual({
+      captureId: null,
+      capturing: false,
+      endsAt: null,
+      last: null,
+    });
     expect(detailActive(server)).toBe(false);
   });
 
@@ -58,6 +59,7 @@ describe('tick perf capture lifecycle', () => {
     const before = Date.now();
     const started = server.startPerfCapture(3000);
     expect(started.capturing).toBe(true);
+    expect(started.captureId).toMatch(/^[0-9a-f-]{36}$/);
     expect(started.endsAt).not.toBeNull();
     expect(started.endsAt!).toBeGreaterThanOrEqual(before + 3000);
     // The detailed sub-phase timing is on for the duration of the window.
@@ -72,6 +74,9 @@ describe('tick perf capture lifecycle', () => {
     // ...and the switch is back off so the steady-state loop pays nothing.
     expect(detailActive(server)).toBe(false);
     expect(status.last).not.toBeNull();
+    expect(status.last?.captureId).toBe(started.captureId);
+    expect(status.last?.loopCallbacks).toBe(0);
+    expect(status.last?.simTicks).toBe(0);
     expect(status.last!.durationMs).toBe(3000);
     expect(status.last!.online).toBe(0);
     // The frozen profile reflects the window's samples (7 ms every tick -> mean 7).
@@ -97,15 +102,63 @@ describe('tick perf capture lifecycle', () => {
     expect(duration(def)).toBe(10_000);
   });
 
-  it('restarts the window on a second capture, discarding the earlier profiler state', () => {
+  it('ends by wall time even when many sim ticks run during one saturated window', () => {
+    const server = new GameServer();
+    const profiler = (
+      server as unknown as {
+        tickProfiler: { commit: (ms: number) => void };
+      }
+    ).tickProfiler;
+    const finalize = (
+      server as unknown as { finalizePerfCaptureIfDue: () => void }
+    ).finalizePerfCaptureIfDue.bind(server);
+    server.startPerfCapture(3000);
+
+    // Catch-up work can advance far more than 60 sim ticks without reaching the
+    // monotonic deadline. It must not close the capture early.
+    for (let i = 0; i < 100; i++) {
+      server.sim.tick();
+      profiler.commit(7);
+      finalize();
+    }
+    expect(server.perfCaptureStatus().capturing).toBe(true);
+
+    (server as unknown as { perfCaptureDeadlineNs: bigint }).perfCaptureDeadlineNs = 0n;
+    finalize();
+    expect(server.perfCaptureStatus().capturing).toBe(false);
+  });
+
+  it('records catch-up sim ticks separately from loop callbacks', () => {
     const server = new GameServer();
     server.startPerfCapture(3000);
-    const firstEnd = (server as unknown as { perfCaptureEndsAtTick: number }).perfCaptureEndsAtTick;
-    // A second start resets the profiler and schedules a fresh end tick further out.
-    server.startPerfCapture(6000);
-    const secondEnd = (server as unknown as { perfCaptureEndsAtTick: number })
-      .perfCaptureEndsAtTick;
+    const internal = server as unknown as {
+      recordPerfCaptureCallback: (ticksRun: number) => void;
+      perfCaptureDeadlineNs: bigint;
+      finalizePerfCaptureIfDue: () => void;
+    };
+    internal.recordPerfCaptureCallback(1);
+    internal.recordPerfCaptureCallback(3);
+    internal.recordPerfCaptureCallback(0);
+    internal.perfCaptureDeadlineNs = 0n;
+    internal.finalizePerfCaptureIfDue();
+
+    expect(server.perfCaptureStatus().last).toMatchObject({
+      loopCallbacks: 3,
+      simTicks: 4,
+      catchUpCallbacks: 1,
+      maxTicksPerCallback: 3,
+    });
+  });
+
+  it('restarts the window on a second capture, discarding the earlier profiler state', () => {
+    const server = new GameServer();
+    const first = server.startPerfCapture(3000);
+    const firstEnd = (server as unknown as { perfCaptureEndsAtMs: number }).perfCaptureEndsAtMs;
+    // A second start resets the profiler and schedules a fresh wall deadline further out.
+    const second = server.startPerfCapture(6000);
+    const secondEnd = (server as unknown as { perfCaptureEndsAtMs: number }).perfCaptureEndsAtMs;
     expect(secondEnd).toBeGreaterThan(firstEnd);
+    expect(second.captureId).not.toBe(first.captureId);
     expect(server.perfCaptureStatus().capturing).toBe(true);
     expect(detailActive(server)).toBe(true);
   });

--- a/tests/sfx_studio_server_security.test.ts
+++ b/tests/sfx_studio_server_security.test.ts
@@ -150,7 +150,7 @@ describe.sequential('SFX Studio server security', () => {
     try {
       rmSync(sourceLink, { force: true });
       rmSync(executableSource, { force: true });
-      rmSync(escapedSourceDir, { force: true });
+      rmSync(escapedSourceDir, { recursive: true, force: true });
       rmSync(externalSourceDir, { recursive: true, force: true });
       rmSync(externalExportDir, { recursive: true, force: true });
       rmSync(versionAudio, { force: true });


### PR DESCRIPTION
## Summary

- Bounds clear-route pet recovery at 96 yards, preventing very distant pets from repeatedly running the unbounded line-of-sight walk that dominated the captured production CPU profile.
- Adds an event-triggered production CPU monitor that confirms sustained saturation, records a 20-second V8 CPU profile, and retains correlated logs, Docker context, checksums, and optional tick-profiler evidence.
- Adds immutable, root-owned in-image profiler helpers, container restart ownership guards, remote and local capture locks, secure artifact retention, and cooldowns that avoid repeatedly profiling an already overloaded process.
- Makes tick captures wall-clock bounded and records loop callbacks, sim ticks, catch-up callbacks, and maximum ticks per callback for incident correlation.
- Fixes two pre-existing parallel cleanup races exposed by the release gate.

## Related issues

Closes #1833

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [x] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests
- [x] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run gate` (all 10 steps green, 12,790 tests passed and 18 skipped)
  - `npx vitest run tests/pet_follow.test.ts tests/prod_cpu_monitor.test.mjs tests/server/tick_perf_capture.test.ts`
  - `npx vitest run tests/server/new_endpoint.test.ts tests/sfx_studio_server_security.test.ts --maxWorkers=2`
  - `npm run ops:cpu-monitor -- --help`
- Manual steps:
  - Reviewed the release integration and production monitor safety against `release/v0.25.0`; no blockers remain.
  - No live production profile was triggered from this branch.

## Rollout notes

This PR ships the monitor, server capture support, and immutable container helpers. Enabling continuous capture still requires a private operations follow-up: install the documented supervised service and an exact-command SSH wrapper from the private Ansible repository. Do not grant wildcard Docker access. CPU profiles work without a bearer token; the optional detailed tick capture should remain disabled until a narrow machine credential exists.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** N/A, no player UI changes.
- [ ] **Accessible.** N/A, no UI changes.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
