### PR TITLE
docs(terms): add multi-account prize and moderator discretion clauses

### DIFF
--- a/public/terms.html
+++ b/public/terms.html
@@ -29,7 +29,7 @@
     "description": "Terms and Conditions for World of ClaudeCraft, covering accounts, acceptable use, virtual items, app store terms, and legal notices.",
     "inLanguage": "en",
     "isPartOf": { "@type": "WebSite", "name": "World of ClaudeCraft", "url": "https://worldofclaudecraft.com/" },
-    "dateModified": "2026-07-03"
+    "dateModified": "2026-07-13"
   }
   </script>
   <link rel="icon" href="/favicon.ico" sizes="any" />
@@ -83,7 +83,7 @@
       <header class="hero">
         <p class="eyebrow">Legal</p>
         <h1>Terms and Conditions</h1>
-        <p class="updated">Last updated: 3 July 2026</p>
+        <p class="updated">Last updated: 13 July 2026</p>
       </header>
       <article class="content">
         <p><strong>World of ClaudeCraft</strong></p>
@@ -99,6 +99,7 @@
         <p>The Game's source code is published in a public repository for viewing only. All rights in the source code are reserved. Making the repository publicly viewable does not grant you any licence or right to use, copy, modify, distribute, or create derivative works from the code, for commercial or non-commercial purposes, except with our prior written permission. These Terms govern your use of the hosted Service we operate, which is separate from any rights in the code.</p>
         <h2>5. Accounts</h2>
         <p>To play online you create an account. You agree to provide accurate information, to keep your credentials secure, and to be responsible for all activity under your account. Do not share your account or use anyone else's. Tell us promptly if you suspect unauthorised use. We may refuse, reclaim, or rename accounts or characters that breach these Terms or that use names which are offensive, infringing, impersonating, or misleading.</p>
+        <p>Using more than one account may make you ineligible for prizes, competitions, giveaways, and similar promotions. We may disqualify entries, or withhold or reclaim prizes, where we believe multiple accounts have been used to gain an unfair advantage.</p>
         <h2>6. Acceptable use and rules of conduct</h2>
         <p>The Service is a shared space. These rules apply across the Game, chat, and any feature where you can communicate or create text. Breaking them can lead to enforcement under Section 18.</p>
         <ul>
@@ -109,6 +110,7 @@
         <li><strong>Exploits and bugs.</strong> Do not deliberately use bugs for advantage, including duplicating items or currency, abusing vendor or economy bugs, or skipping intended restrictions through a known bug. Reporting a bug is welcome and is never punished. Exploiting one is the offence.</li>
         <li><strong>General.</strong> Do not break the law, infringe anyone's rights, or interfere with the Service, its security, or other players' enjoyment of it.</li>
         </ul>
+        <p>These rules cannot cover every situation. Our moderators may use reasonable discretion to interpret and apply them, and to act against conduct that harms the Service or other players even where it is not listed here. Decisions are made case by case.</p>
         <h2>7. User content</h2>
         <p>The Service lets you create content, including character names and chat messages ("User Content"). You keep any rights you have in your User Content. You grant us a worldwide, non-exclusive, royalty-free licence to host, store, reproduce, transmit, display, and moderate your User Content for the purpose of operating, securing, and improving the Service.</p>
         <p>You are responsible for your User Content and confirm you have the right to share it and that it does not breach these Terms or any law. We may review, moderate, refuse, or remove User Content, and may withhold or remove names, at our discretion. We are not obliged to monitor User Content, but we may.</p>


### PR DESCRIPTION
Amends the live Terms and Conditions (`public/terms.html`) to add two provisions, with **no other content changed**.

### What changed
- **Section 5 (Accounts)** — new closing paragraph:
  > Using more than one account may make you ineligible for prizes, competitions, giveaways, and similar promotions. We may disqualify entries, or withhold or reclaim prizes, where we believe multiple accounts have been used to gain an unfair advantage.
- **Section 6 (Acceptable use and rules of conduct)** — new closing paragraph:
  > These rules cannot cover every situation. Our moderators may use reasonable discretion to interpret and apply them, and to act against conduct that harms the Service or other players even where it is not listed here. Decisions are made case by case.
- **`Last updated` date** bumped `3 July 2026` → `13 July 2026` (visible line + JSON-LD `dateModified`), per Section 2 which requires re-dating on material changes.

The two clauses are verbatim as supplied. The full diff is four lines: the two new paragraphs and the two date references. No existing wording was altered and no sections were renumbered.

### Notes
- Only `public/terms.html` (the served page behind `worldofclaudecraft.com/terms`) is touched. The stale root `TERMS_AND_CONDITIONS.md` draft (dated 21 June, divergent Section 6) is **not** the served source and was intentionally left untouched.
- Rendered locally and verified both paragraphs appear in the right sections.
- **Going live** still requires the production Ansible redeploy on `idyllic-games-prod` — there is no auto-deploy on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
