### PR TITLE
fix(ui): fit store content on mobile landscape

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1942,6 +1942,9 @@
     overflow-y: auto;
     border-left: 1px solid var(--rarity);
   }
+  .armory-inspect-details {
+    display: contents;
+  }
   .armory-inspect-head {
     display: flex;
     flex-wrap: wrap;

--- a/src/styles/hud.mobile.css
+++ b/src/styles/hud.mobile.css
@@ -2274,6 +2274,84 @@
   body.mobile-touch .armory-inspect-actions button {
     min-height: 44px;
   }
+  /* The game is landscape-only on touch. Keep a complete Armory card within
+     the store scrollport instead of stretching two square previews across the
+     full phone width. The inspect dialog uses that same wide viewport as two
+     columns, reserving a fixed footer for Buy / Apply / Detach while only the
+     lore copy scrolls. */
+  @media (orientation: landscape) {
+    body.mobile-touch .woc-store-hero {
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 12px;
+      min-height: 118px;
+      padding: 12px 14px;
+    }
+    body.mobile-touch .woc-store-balance {
+      align-self: center;
+    }
+    body.mobile-touch .armory-section {
+      margin-top: 10px;
+    }
+    body.mobile-touch .armory-section > header {
+      padding: 6px 8px;
+    }
+    body.mobile-touch .armory-grid {
+      grid-template-columns: repeat(auto-fit, minmax(104px, 1fr));
+      gap: 8px;
+      padding: 8px;
+    }
+    body.mobile-touch .armory-card {
+      width: 100%;
+      max-width: 116px;
+      justify-self: center;
+    }
+    body.mobile-touch .armory-card-copy {
+      gap: 2px;
+      padding: 6px 7px 7px;
+    }
+    body.mobile-touch .armory-inspect-overlay {
+      padding: max(8px, env(safe-area-inset-top)) max(8px, env(safe-area-inset-right))
+        max(8px, env(safe-area-inset-bottom)) max(8px, env(safe-area-inset-left));
+    }
+    body.mobile-touch .armory-inspect {
+      grid-template-columns: minmax(0, 1.25fr) minmax(260px, 0.8fr);
+      grid-template-rows: minmax(0, 1fr);
+      width: min(920px, 100%);
+      height: 100%;
+      max-height: none;
+    }
+    body.mobile-touch .armory-inspect-stage {
+      min-width: 0;
+      min-height: 0;
+    }
+    body.mobile-touch .armory-inspect-panel {
+      min-width: 0;
+      min-height: 0;
+      gap: 6px;
+      padding: 12px;
+      overflow: hidden;
+      border-top: none;
+      border-left: 1px solid var(--rarity);
+    }
+    body.mobile-touch .armory-inspect-details {
+      display: flex;
+      flex: 1 1 auto;
+      flex-direction: column;
+      gap: 6px;
+      min-height: 0;
+      padding-inline-end: 40px;
+      overflow-y: auto;
+    }
+    body.mobile-touch .armory-lore {
+      padding: 8px 10px;
+    }
+    body.mobile-touch .armory-inspect-actions {
+      flex: 0 0 auto;
+      gap: 8px;
+      margin-top: 0;
+      padding-top: 8px;
+    }
+  }
   body.mobile-touch .woc-store-card {
     min-height: 214px;
   }

--- a/src/ui/armory_inspect.ts
+++ b/src/ui/armory_inspect.ts
@@ -105,6 +105,7 @@ export class ArmoryInspect {
       ).join('') +
       `</div></div></div>` +
       `<div class="armory-inspect-panel">` +
+      `<div class="armory-inspect-details">` +
       `<div class="armory-inspect-head">` +
       `<span class="armory-collection">${esc(t('hudChrome.wocStore.collectionLine', { collection: copy.collection }))}</span>` +
       `<span class="armory-rarity-pill">${esc(rarityLabel(row.skin.rarity))}</span>` +
@@ -116,6 +117,7 @@ export class ArmoryInspect {
       `<p class="armory-type-line">${esc(weaponTypeLabel(row.skin.weaponType))} · ${esc(t('hudChrome.wocStore.seasonOne'))}</p>` +
       `<p class="armory-look">${esc(copy.look)}</p>` +
       `<div class="armory-lore"><h3>${esc(t('hudChrome.wocStore.lore'))}</h3><p>${esc(copy.lore)}</p></div>` +
+      `</div>` +
       `<div class="armory-inspect-actions" data-armory-actions></div>` +
       `</div></div>`;
     document.body.appendChild(overlay);

--- a/tests/browser/armory_mobile_layout.browser.test.ts
+++ b/tests/browser/armory_mobile_layout.browser.test.ts
@@ -1,0 +1,146 @@
+// Mobile Armory regression coverage. The live game is landscape-only on touch:
+// cards must fit within the store scrollport, and the inspect action row must
+// remain visible beside the preview instead of being clipped below it.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import { cleanup, host } from './_harness';
+
+const EPSILON = 1;
+
+beforeEach(async () => {
+  await page.viewport(844, 390);
+  document.body.className = 'mobile-touch game-active';
+  document.documentElement.style.setProperty('--app-vw', '844px');
+  document.documentElement.style.setProperty('--app-vh', '390px');
+  document.documentElement.style.setProperty('--ui-scale', '1');
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.className = '';
+  document.documentElement.style.removeProperty('--app-vw');
+  document.documentElement.style.removeProperty('--app-vh');
+  document.documentElement.style.removeProperty('--ui-scale');
+});
+
+function armoryCard(index: number): string {
+  return (
+    '<article class="armory-card rarity-rare">' +
+    `<button type="button" aria-label="Inspect test skin ${index}">` +
+    '<span class="armory-card-art"><img alt=""></span>' +
+    '<span class="armory-card-copy"><span class="armory-card-type">Sword</span>' +
+    `<h4>Test skin ${index}</h4><span class="armory-cost">500</span></span>` +
+    '</button></article>'
+  );
+}
+
+describe('mobile Armory landscape layout', () => {
+  it('keeps a complete cosmetic card within the store body height', () => {
+    const store = host('daily-rewards-window');
+    store.classList.add('store-active');
+    store.innerHTML =
+      '<div class="panel-title"><span>WOC Store</span><button class="x-btn">Close</button></div>' +
+      '<div class="woc-store-tabs"><button>Store</button><button>Daily Rewards</button></div>' +
+      '<div class="dr-body woc-store-body">' +
+      '<section class="armory-section rarity-rare"><header><div><span>Rare</span>' +
+      '<h3>Test Collection</h3></div><span class="armory-section-price">500</span></header>' +
+      `<div class="armory-grid">${[1, 2, 3, 4].map(armoryCard).join('')}</div>` +
+      '</section></div>';
+
+    const body = store.querySelector<HTMLElement>('.woc-store-body');
+    const card = store.querySelector<HTMLElement>('.armory-card');
+    expect(body).not.toBeNull();
+    expect(card).not.toBeNull();
+
+    const storeRect = store.getBoundingClientRect();
+    const bodyRect = body?.getBoundingClientRect();
+    const cardRect = card?.getBoundingClientRect();
+    const visibleBodyTop = Math.max(0, storeRect.top, bodyRect?.top ?? 0);
+    const visibleBodyBottom = Math.min(
+      window.innerHeight,
+      storeRect.bottom,
+      bodyRect?.bottom ?? Number.POSITIVE_INFINITY,
+    );
+    expect(visibleBodyBottom).toBeGreaterThan(visibleBodyTop);
+    expect(cardRect?.width ?? 0).toBeGreaterThan(0);
+    expect(cardRect?.height ?? 0).toBeGreaterThan(0);
+    expect(cardRect?.top ?? Number.NEGATIVE_INFINITY).toBeGreaterThanOrEqual(
+      visibleBodyTop - EPSILON,
+    );
+    expect(cardRect?.bottom ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(
+      visibleBodyBottom + EPSILON,
+    );
+  });
+
+  it('keeps the inspect action row visible beside the preview', async () => {
+    await page.viewport(667, 375);
+    document.documentElement.style.setProperty('--app-vw', '667px');
+    document.documentElement.style.setProperty('--app-vh', '375px');
+    const overlay = document.createElement('div');
+    overlay.className = 'armory-inspect-overlay open';
+    overlay.innerHTML =
+      '<div class="armory-inspect rarity-rare" role="dialog">' +
+      '<button class="x-btn armory-inspect-close">Close</button>' +
+      '<div class="armory-inspect-stage"><canvas></canvas><div class="armory-inspect-controls">' +
+      '<div class="armory-mode-toggle"><button>Try On</button><button>Weapon</button></div>' +
+      '<div class="armory-scene-toggle"><button>Day</button><button>Dusk</button><button>Night</button></div>' +
+      '</div></div>' +
+      '<div class="armory-inspect-panel"><div class="armory-inspect-details">' +
+      '<div class="armory-inspect-head">Rare collection</div>' +
+      '<h2>Test skin</h2><p class="armory-type-line">Sword</p>' +
+      '<p class="armory-look">A detailed weapon appearance for the character preview.</p>' +
+      '<div class="armory-lore"><h3>Lore</h3><p>' +
+      'A long description that remains scrollable without pushing the purchase controls ' +
+      'below the landscape viewport. '.repeat(20) +
+      '</p></div></div>' +
+      '<div class="armory-inspect-actions"><span class="armory-price">500</span>' +
+      '<button type="button">Buy skin</button></div></div></div>';
+    document.body.appendChild(overlay);
+
+    const dialog = overlay.querySelector<HTMLElement>('.armory-inspect');
+    const stage = overlay.querySelector<HTMLElement>('.armory-inspect-stage');
+    const panel = overlay.querySelector<HTMLElement>('.armory-inspect-panel');
+    const details = overlay.querySelector<HTMLElement>('.armory-inspect-details');
+    const head = overlay.querySelector<HTMLElement>('.armory-inspect-head');
+    const close = overlay.querySelector<HTMLElement>('.armory-inspect-close');
+    const actions = overlay.querySelector<HTMLElement>('.armory-inspect-actions');
+    expect(dialog).not.toBeNull();
+    expect(stage).not.toBeNull();
+    expect(panel).not.toBeNull();
+    expect(details).not.toBeNull();
+    expect(head).not.toBeNull();
+    expect(close).not.toBeNull();
+    expect(actions).not.toBeNull();
+
+    const dialogRect = dialog?.getBoundingClientRect();
+    const stageRect = stage?.getBoundingClientRect();
+    const panelRect = panel?.getBoundingClientRect();
+    const headRect = head?.getBoundingClientRect();
+    const closeRect = close?.getBoundingClientRect();
+    const actionsRect = actions?.getBoundingClientRect();
+    expect(panelRect?.left ?? 0).toBeGreaterThan((stageRect?.left ?? 0) + EPSILON);
+    expect(closeRect?.left ?? Number.NEGATIVE_INFINITY).toBeGreaterThanOrEqual(
+      (headRect?.right ?? Number.POSITIVE_INFINITY) - EPSILON,
+    );
+    expect(details?.scrollHeight ?? 0).toBeGreaterThan(details?.clientHeight ?? 0);
+    expect(['auto', 'scroll']).toContain(getComputedStyle(details as HTMLElement).overflowY);
+    expect(actionsRect?.width ?? 0).toBeGreaterThan(0);
+    expect(actionsRect?.height ?? 0).toBeGreaterThan(0);
+    expect(actionsRect?.top ?? Number.NEGATIVE_INFINITY).toBeGreaterThanOrEqual(
+      (panelRect?.top ?? 0) - EPSILON,
+    );
+    expect(actionsRect?.bottom ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(
+      (panelRect?.bottom ?? 0) + EPSILON,
+    );
+    expect(panelRect?.bottom ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(
+      (dialogRect?.bottom ?? 0) + EPSILON,
+    );
+    if (details) details.scrollTop = 20;
+    expect(details?.scrollTop ?? 0).toBeGreaterThan(0);
+    const scrolledActionsRect = actions?.getBoundingClientRect();
+    expect(
+      Math.abs((scrolledActionsRect?.top ?? Number.POSITIVE_INFINITY) - (actionsRect?.top ?? 0)),
+    ).toBeLessThanOrEqual(EPSILON);
+  });
+});

--- a/tests/woc_store_window_contract.test.ts
+++ b/tests/woc_store_window_contract.test.ts
@@ -70,6 +70,17 @@ describe('WOC Store window contract', () => {
     expect(inspect).toContain("button.setAttribute('aria-pressed'");
   });
 
+  it('keeps scrollable inspect details separate from the fixed action row', () => {
+    const panelMarkup = inspect.slice(
+      inspect.indexOf('`<div class="armory-inspect-panel">`'),
+      inspect.indexOf('document.body.appendChild(overlay)'),
+    );
+    expect(panelMarkup).toContain('`<div class="armory-inspect-details">`');
+    expect(panelMarkup).toMatch(
+      /armory-lore[^`]*<\/div>` \+\s*`<\/div>` \+\s*`<div class="armory-inspect-actions"/,
+    );
+  });
+
   it('keeps the Claudium window focused on currency purchases', () => {
     expect(claudiumWindow).not.toContain('private storeHtml(');
     expect(claudiumWindow).not.toContain('data-item=');


### PR DESCRIPTION
## Summary

- Compact WOC Store cards and hero content so complete cosmetic cards fit the visible mobile landscape scrollport.
- Keep the Armory inspector preview and details side by side, with long details scrolling independently from the always-visible Buy, Apply, and Detach actions.
- Respect device safe areas and reserve space for the 40x40 close target without changing the desktop inspector layout.
- Add browser geometry coverage for 844x390 and 667x375 landscape viewports plus a production-markup contract.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run --config vitest.browser.config.ts tests/browser/armory_mobile_layout.browser.test.ts`
  - `npx vitest run tests/woc_store_window_contract.test.ts tests/mobile_window_layout.test.ts`
  - `npx biome check src/ui/armory_inspect.ts tests/browser/armory_mobile_layout.browser.test.ts tests/woc_store_window_contract.test.ts src/styles/components.css src/styles/hud.mobile.css`
  - `npx tsc --noEmit`
  - `npm run build`
- Browser checks:
  - Complete card containment at 844x390.
  - Inspector actions, scrolling, safe close-button spacing, and panel containment at 667x375.
- Review:
  - Scoped frontend and test-coverage reviews found no remaining concrete issues.
- Pre-push floor:
  - Typecheck, 53 guard tests, changed-file lint, and copy rules passed.

### Gate note

`npm run gate` reaches the full suite but the release branch currently remains red on eight unrelated localization and SFX assertions, including the existing pending-translation set and `foot_dirt.mp3` production-level mismatch. The focused tests, typecheck, formatting checks, production build, and pre-push floor for this change pass.

## Checklist

### Quality

- [ ] **The full gate passes.** See the gate note above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Automated Chromium landscape coverage is included; no physical-device pass was performed.
- [x] **Accessible.** Existing controls and semantics are preserved, mobile touch targets remain at least 40x40px, and the close target no longer overlaps content.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` files are committed.
- [x] Generated files were not hand-edited.