### PR TITLE
fix(sfx): fail loudly on a mob sfx file that matches nothing

### DIFF
--- a/scripts/sfx/sfx_manifest_builder.mjs
+++ b/scripts/sfx/sfx_manifest_builder.mjs
@@ -52,6 +52,10 @@ export function discoverSfxTracks(catalog, sfxDir) {
   const entries = {};
   const errors = [];
   const catalogKeys = new Set();
+  // Filenames already accounted for by a catalog entry (bare or numbered), so
+  // the mob-extension pass below can tell "this belongs to the catalog loop"
+  // apart from "this looks like a mob sfx file but matches nothing."
+  const consumedFilenames = new Set();
   const sfxFiles = existsSync(sfxDir) ? readdirSync(sfxDir).sort() : [];
 
   for (const source of catalog) {
@@ -71,6 +75,7 @@ export function discoverSfxTracks(catalog, sfxDir) {
       .map((filename) => ({ filename, id: filename.match(numberedPattern)?.[1] ?? null }))
       .filter((candidate) => candidate.id !== null);
     for (const candidate of numbered) {
+      consumedFilenames.add(candidate.filename);
       const numericId = Number(candidate.id);
       if (
         !/^[1-9]\d*$/.test(candidate.id) ||
@@ -97,6 +102,7 @@ export function discoverSfxTracks(catalog, sfxDir) {
         const filename = `${source.key}${extension}`;
         if (!existsSync(path.join(sfxDir, filename))) continue;
         tracks.push(track('main', filename));
+        consumedFilenames.add(filename);
         break;
       }
     }
@@ -115,9 +121,19 @@ export function discoverSfxTracks(catalog, sfxDir) {
     (filename) => filename.startsWith('mob_') && filename.endsWith('.mp3'),
   );
   for (const filename of mobFiles) {
+    if (consumedFilenames.has(filename)) continue;
     const stem = filename.slice(0, -4);
     const parts = stem.split('_');
-    if (parts.length < 5 || !/^\d+$/.test(parts.at(-1) ?? '')) continue;
+    if (parts.length < 5 || !/^\d+$/.test(parts.at(-1) ?? '')) {
+      // Not a fixed catalog file (already handled above) and not a valid
+      // mob_<family>_<subfamily>_<action>_<N>.mp3 subfamily file either.
+      // A file shaped like this was never meant to be silently ignored: flag
+      // it instead of letting it vanish from every rebuild with no signal.
+      errors.push(
+        `unrecognized mob sfx file (not a catalog entry, not a valid numbered subfamily file): ${filename}`,
+      );
+      continue;
+    }
 
     const variantId = parts.at(-1) ?? '';
     const variantNumber = Number(variantId);

--- a/tests/sfx_manifest.test.ts
+++ b/tests/sfx_manifest.test.ts
@@ -246,6 +246,42 @@ describe('mob subfamily scanning', () => {
     expect(Object.keys(data)).toEqual(['mob_beast_attack']);
   });
 
+  // Decisive regression pin: a mob_*.mp3 file that matches neither a real
+  // catalog entry nor a valid numbered subfamily pattern used to be silently
+  // ignored (a `continue` with no error), the same silent-omission class as
+  // the cast_lightning_bolt bug. It must now fail loudly instead.
+  it('reports an error for a bare subfamily file missing its numbered suffix', () => {
+    // mob_beast_wolf_hurt.mp3 has no _<N> suffix and no matching catalog
+    // entry, so it is neither a valid subfamily file nor a catalog match.
+    writeFileSync(path.join(sfxDir, 'mob_beast_wolf_hurt.mp3'), '');
+    const { count, errors } = buildManifest([], sfxDir, manifestPath);
+    expect(count).toBe(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('mob_beast_wolf_hurt.mp3');
+    expect(errors[0]).toContain('unrecognized mob sfx file');
+  });
+
+  it('reports an error for a family-level mob file with no matching catalog entry', () => {
+    // No catalog entry for 'mob_reptile_aggro' exists, so this bare file
+    // matches nothing: not the catalog loop, not the subfamily scanner.
+    writeFileSync(path.join(sfxDir, 'mob_reptile_aggro.mp3'), '');
+    const { count, errors } = buildManifest([], sfxDir, manifestPath);
+    expect(count).toBe(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('mob_reptile_aggro.mp3');
+    expect(errors[0]).toContain('unrecognized mob sfx file');
+  });
+
+  it('does not flag a family-level file that legitimately matches a catalog entry', () => {
+    // Same shape as the two error cases above, but this time a catalog entry
+    // exists, so it must be consumed silently and cleanly, no error.
+    writeFileSync(path.join(sfxDir, 'mob_ogre_hurt.mp3'), '');
+    const catalog = [{ key: 'mob_ogre_hurt' }];
+    const { count, errors } = buildManifest(catalog, sfxDir, manifestPath);
+    expect(count).toBe(1);
+    expect(errors).toEqual([]);
+  });
+
   it('MOB_ACTIONS covers the four expected vocalization types', () => {
     expect(MOB_ACTIONS.has('aggro')).toBe(true);
     expect(MOB_ACTIONS.has('attack')).toBe(true);


### PR DESCRIPTION
## Summary

Fixes a silent-failure gap in mob sfx discovery: a `mob_*.mp3` file that matches neither a real catalog entry nor a correctly-numbered subfamily pattern (`mob_<family>_<sub>_<action>_<N>.mp3`) was silently skipped with no error, the same failure class as the `cast_lightning_bolt` bug fixed in #1771.

Concretely: a subfamily file missing its numbered suffix (e.g. `mob_beast_wolf_hurt.mp3` instead of `mob_beast_wolf_hurt_1.mp3`), or a family-level file with no matching catalog entry (e.g. dropping `mob_reptile_aggro.mp3` in without adding the catalog row), would just vanish from every manifest rebuild. No error, no warning, nothing in the discovery result's `errors` array. The contributor gets a silently-mute mob and no clue why.

`discoverSfxTracks` now tracks which filenames the catalog loop already consumed (bare or numbered), and any `mob_*.mp3` file that matches neither that set nor the numbered subfamily pattern gets a real error pushed instead of a silent `continue`. That error surfaces through `buildSfxManifestData`'s existing hard-fail (`throw` on any discovery error), which runs as part of `npm run build`/`npm run gate` and on every CI job, so it now blocks with a clear message naming the exact bad filename instead of shipping silently broken.

Scoped to just this one gap, no unrelated changes. Verified zero overlap with #1828 (that PR only touches `src/ui/combat_sfx.ts` + its test file).

## Type of change

- [x] Bug fix
- [x] Test: new/updated coverage

## How was this tested?

- `npx tsc --noEmit` clean
- `npx vitest run tests/sfx_manifest.test.ts tests/sfx.test.ts tests/sfx_conform.test.ts tests/combat_sfx.test.ts tests/architecture.test.ts` — 96 tests passing
- Added 3 new decisive tests: a bare subfamily file with no number now errors, a family-level file with no catalog match now errors, and confirmed the fix does NOT false-positive on a family-level file that legitimately matches a real catalog entry
- Ran `npm run sfx:manifest` against the real repo content: builds cleanly, 138 clips, zero errors — confirmed all 33 currently-shipped `mob_*.mp3` files are bare catalog entries already correctly consumed by the catalog loop, none get newly flagged
- Confirmed the check only fires on `npm run build`/`npm run gate`/CI, not `npm run dev`, so it doesn't interfere with casual local play/testing

## Screenshots / recordings

N/A — no visual change, this only affects build-time validation output.

---
Checklist

Quality
- [x] Tests pass.
- [x] Typecheck passes.
- [ ] Builds succeed. (ran `sfx:manifest` directly; full `npm run build` not run locally this pass)

Cross-platform
- ~Tested on desktop and mobile.~ N/A, build tooling only

Localization (i18n)
- [x] N/A. This PR adds no player-visible strings.

Hygiene
- [x] No secrets or .env committed.
- [x] No generated files hand-edited.
