### PR TITLE
fix: include prod_cpu ops scripts in docker build context (fixes v0.25.0 prod build)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,8 @@ scripts/*
 !scripts/build_sitemap.mjs
 !scripts/browserslist_targets.mjs
 !scripts/check_backdrop_survival.mjs
+!scripts/prod_cpu_game_helper.mjs
+!scripts/prod_cpu_profile_client.mjs
 !scripts/i18n_*.mjs
 !scripts/sfx/
 !scripts/sfx/**


### PR DESCRIPTION
## Problem

The production Docker image fails to build on `main` (v0.25.0):

```
#39 COPY --from=build /app/scripts/prod_cpu_profile_client.mjs /app/ops/
    ERROR: "/app/scripts/prod_cpu_profile_client.mjs": not found
#35 COPY --from=build /app/scripts/prod_cpu_game_helper.mjs /app/ops/
    ERROR: "/app/scripts/prod_cpu_game_helper.mjs": not found
```

`Dockerfile` (lines 36-37) COPYs `scripts/prod_cpu_game_helper.mjs` and `scripts/prod_cpu_profile_client.mjs` from the build stage into `/app/ops`, but `.dockerignore` excludes everything under `scripts/` via `scripts/*` and the allow-list never re-included these two files. The files exist in git and on disk, but are stripped from the **build context**, so the stage-1 COPY can't find them.

These files + the Dockerfile COPY lines were added in v0.25.0 (they were absent from the feature branch head, which is why every dev build passed). Server-image build isn't part of CI, so it wasn't caught.

## Fix

Add the two missing re-includes to `.dockerignore`:

```
!scripts/prod_cpu_game_helper.mjs
!scripts/prod_cpu_profile_client.mjs
```

## Impact

Blocks the v0.25.0 production deploy. The deploy fails at the build step (before the restart countdown / before the game is stopped), so prod is untouched — but no prod deploy can succeed until this merges.

## Test plan

- [ ] `docker compose build game` succeeds past the stage-1 `COPY --from=build /app/scripts/prod_cpu_*.mjs` steps.