### PR TITLE
fix(net): resume into the world after a mobile WebView reload

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -108,9 +108,11 @@ import {
   type ReleaseEntry,
 } from './net/online';
 import { realmPopulation } from './net/realm_population';
+import { RECONNECT_CONFLICT_ERROR } from './net/reconnect_policy';
 import {
   clearPlayMarker,
-  freshMarkerCharacterId,
+  freshMarker,
+  markResumeAttempt,
   readPlayMarker,
   refreshPlayMarker,
   savePlayMarker,
@@ -292,10 +294,10 @@ let pendingDeleteCharacter: CharacterSummary | null = null;
 // instead of a per-row one; it acts on whichever character is selected. Mobile
 // and narrow layouts keep the per-row buttons and never read this.
 let charselectSelected: CharacterSummary | null = null;
-// One-shot: set by the boot resume path to the character id to auto-enter, then
-// consumed by refreshCharacters once its list has loaded (mobile WebView-reload
-// resume; see src/net/resume_play.ts).
-let pendingResumeCharacterId: number | null = null;
+// One-shot: set by the boot resume path to the character (and the realm it was
+// playing on) to auto-enter, then consumed by refreshCharacters once its list
+// has loaded (mobile WebView-reload resume; see src/net/resume_play.ts).
+let pendingResume: { characterId: number; realm: string } | null = null;
 let homepageMusic: HTMLAudioElement | null = null;
 let homepageMusicStarted = false;
 let homepageMusicMuted = readHomepageMusicMuted();
@@ -4017,6 +4019,7 @@ function setupAccountPortal(): void {
     try {
       await api.deactivateAccount(deUser.value, dePass.value);
       api.clearSession();
+      clearPlayMarker();
       setAccountFieldMsg('#account-deactivate-msg', t('hudChrome.account.deactivated'), true);
       window.setTimeout(() => location.reload(), 1200);
     } catch (e2) {
@@ -4171,7 +4174,7 @@ function showRealmList(dir?: import('./net/online').RealmDirectory): void {
   // (no remembered realm). Drop any pending resume intent here so a later manual
   // realm pick does not surprise-enter the world on a decision made at boot; the
   // player continues through normal realm + character select.
-  pendingResumeCharacterId = null;
+  pendingResume = null;
   show('#realm-panel');
   const listEl = $('#realm-list');
   const render = (d: import('./net/online').RealmDirectory) => {
@@ -4459,27 +4462,31 @@ async function refreshCharacters(): Promise<void> {
     if (chars.some((c) => c.skinCatalog === 'mech')) void preloadMechAssets();
     if (api.realm) $('#charselect-realm').textContent = api.realm;
     listEl.innerHTML = '';
-    if (chars.length === 0) {
-      // No characters on this realm, drop straight into the create screen.
-      listEl.innerHTML = `<li class="char-list-message">${escapeHtml(t('character.noneYet'))}</li>`;
-      show('#charcreate-panel');
-      return;
-    }
     // Boot resume: a WebView reload during play sent us here with a persisted
-    // active-play marker. If that character still exists, re-enter the world
-    // directly instead of showing char-select (a linkdead session resumes
-    // seamlessly; a genuinely live duplicate falls back to the fatal overlay,
-    // same as a manual enter). One-shot: consume the pending id either way, and
-    // clear the persisted marker if the character is gone so we stop retrying.
-    if (pendingResumeCharacterId !== null) {
-      const resumeId = pendingResumeCharacterId;
-      pendingResumeCharacterId = null;
-      const target = chars.find((c) => c.id === resumeId);
+    // active-play marker. If that character still exists on the marker's realm,
+    // re-enter the world directly instead of showing char-select (a linkdead
+    // session resumes seamlessly; a genuinely live duplicate falls back to the
+    // fatal overlay, same as a manual enter). One-shot: consume the pending
+    // intent either way (including the empty-roster case below), and clear the
+    // persisted marker if the character or realm is gone so we stop retrying.
+    // The realm check closes the cross-realm id-collision hole: character ids
+    // are only unique per realm database.
+    if (pendingResume !== null) {
+      const resume = pendingResume;
+      pendingResume = null;
+      const target =
+        resume.realm === api.realm ? chars.find((c) => c.id === resume.characterId) : undefined;
       if (target) {
         void enterWorld(target);
         return;
       }
       clearPlayMarker();
+    }
+    if (chars.length === 0) {
+      // No characters on this realm, drop straight into the create screen.
+      listEl.innerHTML = `<li class="char-list-message">${escapeHtml(t('character.noneYet'))}</li>`;
+      show('#charcreate-panel');
+      return;
     }
     for (const c of chars) {
       const row = document.createElement('li');
@@ -4593,11 +4600,22 @@ async function refreshCharacters(): Promise<void> {
       renderClassDetails('charselect-class-details', 'warrior');
     }
   } catch (err) {
+    // A failed roster load must also drop any boot resume intent: leaving it
+    // armed would auto-enter the world on whatever unrelated refresh (sort,
+    // realm switch, rename) happens to succeed next.
+    pendingResume = null;
     listEl.innerHTML = `<li class="char-list-message char-list-error">${escapeHtml(userFacingApiError(err))}</li>`;
   }
 }
 
-function fatalOverlay(message: string): void {
+function fatalOverlay(message: string, opts?: { keepResumeMarker?: boolean }): void {
+  // A fatal overlay is a terminal client state whose only exit is a reload, so
+  // clearing the resume marker HERE covers every present and future caller: the
+  // reload lands on the normal boot path instead of auto-resuming into the same
+  // failure. The one exception is a duplicate-session conflict ("character
+  // already in world"): the session is alive in another tab or device, and
+  // clearing would erase THAT session's marker, so the caller opts out.
+  if (!opts?.keepResumeMarker) clearPlayMarker();
   hideLoadingScreen(); // its art would bleed through the translucent backdrop
   if (document.getElementById('disconnect-overlay')) return; // first reason wins
   const el = document.createElement('div');
@@ -4710,18 +4728,19 @@ async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Prom
   const poll = setInterval(() => {
     if (world.connected && world.entities.has(world.playerId)) {
       clearInterval(poll);
-      // Remember the active session so a WebView reload during play resumes
-      // straight back into the world instead of the home/login screen.
-      savePlayMarker(c.id, Date.now());
+      // Remember the active session (character + realm) so a WebView reload
+      // during play resumes straight back into the world instead of the
+      // home/login screen. Also resets the resume-attempt budget: entry
+      // completed, the session is known-good.
+      if (api.realm) savePlayMarker(c.id, api.realm, Date.now());
       void startGame(world, null, world, `char:${c.id}`, true);
     } else if (Date.now() - waitStart > 10000) {
       clearInterval(poll);
       world.close();
       clearCardProviders();
       hideReconnectOverlay();
-      // Entry never completed: drop any resume marker so the next boot does not
-      // loop straight back into a session that will not start.
-      clearPlayMarker();
+      // Entry never completed: fatalOverlay drops the resume marker so the next
+      // boot does not loop straight back into a session that will not start.
       fatalOverlay(t('loading.enterTimeout'));
     }
   }, 50);
@@ -4732,9 +4751,14 @@ async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Prom
     clearCardProviders();
     hideReconnectOverlay();
     // The session ended for good (retries exhausted, kick, takeover, auth fail):
-    // clear the resume marker so a reload does not loop back into a dead session.
-    clearPlayMarker();
-    fatalOverlay(userFacingApiError(reason));
+    // fatalOverlay clears the resume marker so a reload does not loop back into
+    // a dead session. Exception: a duplicate-session conflict means the
+    // character is ALIVE in another tab or device, so the marker (theirs, via
+    // the shared localStorage) must survive; the bounded resume-attempt budget
+    // in resume_play.ts keeps this tab from looping on the overlay forever.
+    fatalOverlay(userFacingApiError(reason), {
+      keepResumeMarker: reason === RECONNECT_CONFLICT_ERROR,
+    });
   };
   // an unexpected drop is not fatal: the server holds the character in-world
   // (linkdead) while ClientWorld auto-reconnects, so just veil the game until
@@ -6671,6 +6695,7 @@ function wireRecoveryEmailModal(): void {
     // return to the login screen. They are prompted again on the next sign-in.
     void api.logout().catch(() => {});
     api.clearSession();
+    clearPlayMarker();
     closeRecoveryEmailModal();
     enterLoggedOutChrome();
     switchMainView('#hero-view');
@@ -7084,8 +7109,13 @@ function wireStartScreens(): void {
 
   const goToLoggedInPlay = () => {
     void enterRealmFlow().catch((err) => {
+      // Entering play failed before character select: drop any boot resume
+      // intent (it must not fire on a later unrelated roster refresh), and on
+      // an auth failure clear the marker with the session it belonged to.
+      pendingResume = null;
       if (isAuthError(err)) {
         api.clearSession();
+        clearPlayMarker();
         enterLoggedOutChrome();
       } else {
         loginError(userFacingApiError(err));
@@ -8362,12 +8392,28 @@ function wireStartScreens(): void {
       // WebView-reload resume: if the session survived revalidation and a fresh
       // active-play marker is present, re-enter the world directly instead of
       // leaving the player parked on the home/character-select chrome. The
-      // Discord-onboarding arm below already enters play, so skip it there.
+      // Discord-onboarding arm below already enters play, so skip it there, and
+      // the desktop-login handoff page must mint its code, never load the game.
       if (discordOnboarding) return;
+      if (isDesktopLoginPage()) return;
       if (!api.token) return; // revalidation cleared a stale session
-      const resumeId = freshMarkerCharacterId(readPlayMarker(), Date.now());
-      if (resumeId === null) return;
-      pendingResumeCharacterId = resumeId;
+      const marker = readPlayMarker();
+      const resume = freshMarker(marker, Date.now());
+      if (resume === null) {
+        // A marker that exists but no longer resumes (stale, or its attempt
+        // budget is spent) is dead weight: clear it so the restamp handlers
+        // below cannot keep it around indefinitely.
+        if (marker) clearPlayMarker();
+        return;
+      }
+      // Count this consumption against the marker's bounded attempt budget (a
+      // completed entry resets it), then route through the normal realm flow:
+      // restoring the marker's realm as the remembered one makes enterRealmFlow
+      // auto-select it even if the player browsed other realms before the
+      // reload, and refreshCharacters consumes the pending intent.
+      markResumeAttempt();
+      pendingResume = { characterId: resume.characterId, realm: resume.realm };
+      localStorage.setItem(LAST_REALM_KEY, resume.realm);
       goToLoggedInPlay();
     });
     // Re-bind the account's linked wallet on a restored session (not just on fresh

--- a/src/main.ts
+++ b/src/main.ts
@@ -8413,7 +8413,12 @@ function wireStartScreens(): void {
       // reload, and refreshCharacters consumes the pending intent.
       markResumeAttempt();
       pendingResume = { characterId: resume.characterId, realm: resume.realm };
-      localStorage.setItem(LAST_REALM_KEY, resume.realm);
+      try {
+        localStorage.setItem(LAST_REALM_KEY, resume.realm);
+      } catch {
+        // fail-soft like the resume_play wrappers: a blocked write only loses
+        // the realm auto-pick, the resume then falls to the realm list.
+      }
       goToLoggedInPlay();
     });
     // Re-bind the account's linked wallet on a restored session (not just on fresh

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,6 +108,13 @@ import {
   type ReleaseEntry,
 } from './net/online';
 import { realmPopulation } from './net/realm_population';
+import {
+  clearPlayMarker,
+  freshMarkerCharacterId,
+  readPlayMarker,
+  refreshPlayMarker,
+  savePlayMarker,
+} from './net/resume_play';
 import { openStripeCheckout } from './net/stripe_checkout';
 // The wallet module is loaded lazily via dynamic import() in the wallet
 // controller below, so it stays out of the main entry chunk and only loads when
@@ -285,6 +292,10 @@ let pendingDeleteCharacter: CharacterSummary | null = null;
 // instead of a per-row one; it acts on whichever character is selected. Mobile
 // and narrow layouts keep the per-row buttons and never read this.
 let charselectSelected: CharacterSummary | null = null;
+// One-shot: set by the boot resume path to the character id to auto-enter, then
+// consumed by refreshCharacters once its list has loaded (mobile WebView-reload
+// resume; see src/net/resume_play.ts).
+let pendingResumeCharacterId: number | null = null;
 let homepageMusic: HTMLAudioElement | null = null;
 let homepageMusicStarted = false;
 let homepageMusicMuted = readHomepageMusicMuted();
@@ -1808,6 +1819,8 @@ async function startGame(
       // Signal the server to leave immediately, skipping the linkdead grace, so
       // the character is not held in-world after a deliberate logout.
       online?.sendLogout();
+      // A deliberate logout is not a resumable drop: forget the active session.
+      clearPlayMarker();
       location.reload();
     },
     captureKey: (cb) => input.captureNextKey(cb),
@@ -3752,6 +3765,7 @@ function enterLoggedOutChrome(): void {
 function logoutAccount(): void {
   const finish = () => {
     api.clearSession();
+    clearPlayMarker();
     location.reload();
   };
   if (!api.token) {
@@ -3836,6 +3850,7 @@ const loggedOutModel = () =>
 
 function handleAccountSessionExpired(): void {
   api.clearSession();
+  clearPlayMarker();
   enterLoggedOutChrome();
   paintAccountPortal(loggedOutModel());
 }
@@ -4152,6 +4167,11 @@ function setupSecuritySection(): void {
 }
 
 function showRealmList(dir?: import('./net/online').RealmDirectory): void {
+  // Reaching the realm list means the boot resume could not auto-select a realm
+  // (no remembered realm). Drop any pending resume intent here so a later manual
+  // realm pick does not surprise-enter the world on a decision made at boot; the
+  // player continues through normal realm + character select.
+  pendingResumeCharacterId = null;
   show('#realm-panel');
   const listEl = $('#realm-list');
   const render = (d: import('./net/online').RealmDirectory) => {
@@ -4445,6 +4465,22 @@ async function refreshCharacters(): Promise<void> {
       show('#charcreate-panel');
       return;
     }
+    // Boot resume: a WebView reload during play sent us here with a persisted
+    // active-play marker. If that character still exists, re-enter the world
+    // directly instead of showing char-select (a linkdead session resumes
+    // seamlessly; a genuinely live duplicate falls back to the fatal overlay,
+    // same as a manual enter). One-shot: consume the pending id either way, and
+    // clear the persisted marker if the character is gone so we stop retrying.
+    if (pendingResumeCharacterId !== null) {
+      const resumeId = pendingResumeCharacterId;
+      pendingResumeCharacterId = null;
+      const target = chars.find((c) => c.id === resumeId);
+      if (target) {
+        void enterWorld(target);
+        return;
+      }
+      clearPlayMarker();
+    }
     for (const c of chars) {
       const row = document.createElement('li');
       row.className = `char-row${c.online ? ' online' : ''}${c.forceRename ? ' rename-required' : ''}`;
@@ -4674,12 +4710,18 @@ async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Prom
   const poll = setInterval(() => {
     if (world.connected && world.entities.has(world.playerId)) {
       clearInterval(poll);
+      // Remember the active session so a WebView reload during play resumes
+      // straight back into the world instead of the home/login screen.
+      savePlayMarker(c.id, Date.now());
       void startGame(world, null, world, `char:${c.id}`, true);
     } else if (Date.now() - waitStart > 10000) {
       clearInterval(poll);
       world.close();
       clearCardProviders();
       hideReconnectOverlay();
+      // Entry never completed: drop any resume marker so the next boot does not
+      // loop straight back into a session that will not start.
+      clearPlayMarker();
       fatalOverlay(t('loading.enterTimeout'));
     }
   }, 50);
@@ -4689,6 +4731,9 @@ async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Prom
     clearInterval(poll);
     clearCardProviders();
     hideReconnectOverlay();
+    // The session ended for good (retries exhausted, kick, takeover, auth fail):
+    // clear the resume marker so a reload does not loop back into a dead session.
+    clearPlayMarker();
     fatalOverlay(userFacingApiError(reason));
   };
   // an unexpected drop is not fatal: the server holds the character in-world
@@ -8313,7 +8358,18 @@ function wireStartScreens(): void {
     showDiscordChoice(parkedDiscordChoice);
   } else if (api.restoreSession()) {
     enterLoggedInChrome();
-    void revalidateAccountSession();
+    void revalidateAccountSession().then(() => {
+      // WebView-reload resume: if the session survived revalidation and a fresh
+      // active-play marker is present, re-enter the world directly instead of
+      // leaving the player parked on the home/character-select chrome. The
+      // Discord-onboarding arm below already enters play, so skip it there.
+      if (discordOnboarding) return;
+      if (!api.token) return; // revalidation cleared a stale session
+      const resumeId = freshMarkerCharacterId(readPlayMarker(), Date.now());
+      if (resumeId === null) return;
+      pendingResumeCharacterId = resumeId;
+      goToLoggedInPlay();
+    });
     // Re-bind the account's linked wallet on a restored session (not just on fresh
     // login), so an auto-reconnected wallet shows verified and is NOT treated as
     // unverified and disconnected (the bug that forced a re-sign on every reload).
@@ -8329,6 +8385,16 @@ function wireStartScreens(): void {
     enterLoggedOutChrome();
     if (isDesktopLoginPage()) show('#login-panel');
   }
+
+  // Keep the active-play resume marker fresh right up to the moment the app is
+  // backgrounded (the pre-eviction instant on iOS), so even a long play session
+  // resumes into the world on the reload that follows an OS WebView eviction. A
+  // no-op when no session is in play, so it is safe to register unconditionally.
+  const restampResumeMarker = () => {
+    if (document.visibilityState === 'hidden') refreshPlayMarker(Date.now());
+  };
+  document.addEventListener('visibilitychange', restampResumeMarker);
+  window.addEventListener('pagehide', () => refreshPlayMarker(Date.now()));
 
   // Header Logo click listener to return to homepage
   const headerLogoBtn = $('#header-logo-btn');

--- a/src/net/resume_play.ts
+++ b/src/net/resume_play.ts
@@ -8,13 +8,24 @@
 // all the way to the login screen. Reported as "it randomly returns me to the
 // login screen".
 //
-// This module persists "actively in-world playing character N" so the boot path
-// can re-enter the world instead of the home screen. It is FRESHNESS-SCOPED: the
-// marker is only honored for a bounded window after it was last stamped, so a
-// cold open of a long-closed tab still lands on home as before, and only a
-// genuine reload-during-play resumes. The window comfortably covers a
-// background/eviction round trip; a session that re-enters within the server's
-// linkdead grace resumes seamlessly, and past it a fresh join is still correct.
+// This module persists "actively in-world playing character N on realm R" so
+// the boot path can re-enter the world instead of the home screen. The marker
+// is bounded three ways:
+// - FRESHNESS: honored only for a bounded window after it was last stamped, so
+//   a cold open of a long-closed tab still lands on home as before, and only a
+//   genuine reload-during-play resumes. Re-stamping refuses to resurrect an
+//   already-stale marker (it clears it instead), so the window can never be
+//   extended past its documented size by backgrounding an idle tab.
+// - REALM: the marker names the realm it was stamped on, so a resume can never
+//   enter a same-id character on a different realm (realm directories whose
+//   realms live on separate databases can collide on character ids).
+// - ATTEMPTS: each boot-time resume consumption increments a persisted attempt
+//   counter, and only a completed world entry resets it. A resume that keeps
+//   failing terminally (for example "character already in world" from a live
+//   duplicate session in another tab) therefore self-disarms after
+//   MAX_RESUME_ATTEMPTS reloads instead of trapping the tab in a fatal-overlay
+//   reload loop, while still leaving enough retries for the server's keepalive
+//   sweep to flip a black-holed session linkdead.
 //
 // This is client-only (src/net), so wall-clock time is allowed: the pure helpers
 // take `now` as a parameter (unit-testable), and the thin storage wrappers read
@@ -29,9 +40,18 @@ export const RESUME_KEY = 'woc_active_play';
 // landing.
 export const RESUME_MAX_AGE_MS = 30 * 60 * 1000;
 
+// A marker consumed this many times without a completed world entry stops
+// resuming: the boot path treats it as spent and clears it. Keeps a terminally
+// failing auto-resume (live duplicate session, persistent entry failure) from
+// looping forever, while covering the one-or-two-reload window a black-holed
+// drop needs before the server's keepalive sweep flips the session linkdead.
+export const MAX_RESUME_ATTEMPTS = 3;
+
 export interface PlayMarker {
   characterId: number;
+  realm: string;
   savedAt: number;
+  attempts: number;
 }
 
 export function serializeMarker(marker: PlayMarker): string {
@@ -39,36 +59,45 @@ export function serializeMarker(marker: PlayMarker): string {
 }
 
 // Parse a stored marker, rejecting anything malformed (a positive integer
-// characterId and a finite savedAt are required).
+// characterId, a non-empty realm name, a finite savedAt, and a non-negative
+// integer attempts count are required; a missing attempts field reads as 0).
 export function parseMarker(raw: string | null): PlayMarker | null {
   if (!raw) return null;
   try {
-    const v = JSON.parse(raw) as { characterId?: unknown; savedAt?: unknown };
-    const characterId = v.characterId;
-    const savedAt = v.savedAt;
+    const v = JSON.parse(raw) as {
+      characterId?: unknown;
+      realm?: unknown;
+      savedAt?: unknown;
+      attempts?: unknown;
+    };
+    const { characterId, realm, savedAt } = v;
     if (typeof characterId !== 'number' || !Number.isInteger(characterId) || characterId <= 0) {
       return null;
     }
+    if (typeof realm !== 'string' || realm === '') return null;
     if (typeof savedAt !== 'number' || !Number.isFinite(savedAt)) return null;
-    return { characterId, savedAt };
+    const attempts = v.attempts === undefined ? 0 : v.attempts;
+    if (typeof attempts !== 'number' || !Number.isInteger(attempts) || attempts < 0) return null;
+    return { characterId, realm, savedAt, attempts };
   } catch {
     return null;
   }
 }
 
 // The pure resume decision: given a parsed marker and the current time, return
-// the character id to resume, or null when there is no marker or it is stale.
-// The negative-age guard covers a backwards clock change (never resume on a
-// marker that claims to be from the future).
-export function freshMarkerCharacterId(
+// the marker to resume on, or null when there is no marker, it is stale, or its
+// resume attempts are spent. The negative-age guard covers a backwards clock
+// change (never resume on a marker that claims to be from the future).
+export function freshMarker(
   marker: PlayMarker | null,
   now: number,
   maxAgeMs = RESUME_MAX_AGE_MS,
-): number | null {
+): PlayMarker | null {
   if (!marker) return null;
   const age = now - marker.savedAt;
   if (age < 0 || age > maxAgeMs) return null;
-  return marker.characterId;
+  if (marker.attempts >= MAX_RESUME_ATTEMPTS) return null;
+  return marker;
 }
 
 // localStorage is unavailable in private mode / SSR / some WebViews; every
@@ -93,18 +122,35 @@ export function readPlayMarker(): PlayMarker | null {
   return parseMarker(readRaw());
 }
 
-// Stamp the marker for the character just entered (or refresh its timestamp).
-export function savePlayMarker(characterId: number, now: number): void {
-  writeRaw({ characterId, savedAt: now });
+// Stamp the marker for the character just entered on its realm. A completed
+// entry is also the point that resets the attempt counter: the session is
+// known-good again, so the next reload gets its full retry budget back.
+export function savePlayMarker(characterId: number, realm: string, now: number): void {
+  writeRaw({ characterId, realm, savedAt: now, attempts: 0 });
 }
 
 // Re-stamp the existing marker's savedAt without changing the character, so a
 // long play session stays inside the resume window right up to the moment the
-// app is backgrounded. No-op when no marker is stored.
+// app is backgrounded. Only a still-fresh marker is re-stamped: a stale one is
+// cleared instead of resurrected (backgrounding the homepage days after playing
+// must not re-arm the resume). No-op when no marker is stored.
 export function refreshPlayMarker(now: number): void {
   const existing = readPlayMarker();
   if (!existing) return;
-  writeRaw({ characterId: existing.characterId, savedAt: now });
+  if (!freshMarker(existing, now)) {
+    clearPlayMarker();
+    return;
+  }
+  writeRaw({ ...existing, savedAt: now });
+}
+
+// Record that the boot path consumed the marker for an auto-resume attempt.
+// Called before the entry outcome is known; a completed entry resets the
+// counter via savePlayMarker, so only attempts that never finish accumulate.
+export function markResumeAttempt(): void {
+  const existing = readPlayMarker();
+  if (!existing) return;
+  writeRaw({ ...existing, attempts: existing.attempts + 1 });
 }
 
 export function clearPlayMarker(): void {

--- a/src/net/resume_play.ts
+++ b/src/net/resume_play.ts
@@ -1,0 +1,116 @@
+// Active-play resume marker.
+//
+// On mobile (notably iOS), the OS evicts a backgrounded WebView under memory
+// pressure; when the player foregrounds the app it RELOADS index.html. The
+// client is a single-page app whose boot path lands a restored session on the
+// home / character-select chrome, never back in the world, so the player is
+// silently dropped out of the game and (if the token also fails revalidation)
+// all the way to the login screen. Reported as "it randomly returns me to the
+// login screen".
+//
+// This module persists "actively in-world playing character N" so the boot path
+// can re-enter the world instead of the home screen. It is FRESHNESS-SCOPED: the
+// marker is only honored for a bounded window after it was last stamped, so a
+// cold open of a long-closed tab still lands on home as before, and only a
+// genuine reload-during-play resumes. The window comfortably covers a
+// background/eviction round trip; a session that re-enters within the server's
+// linkdead grace resumes seamlessly, and past it a fresh join is still correct.
+//
+// This is client-only (src/net), so wall-clock time is allowed: the pure helpers
+// take `now` as a parameter (unit-testable), and the thin storage wrappers read
+// the clock and localStorage at the impure boundary, matching the Api
+// saveSession/clearSession idiom.
+
+export const RESUME_KEY = 'woc_active_play';
+
+// Honor the marker only if it was stamped within this window. Re-stamped while
+// the app is being backgrounded (the pre-eviction moment), so even a long play
+// session resumes; a marker older than this falls through to the normal home
+// landing.
+export const RESUME_MAX_AGE_MS = 30 * 60 * 1000;
+
+export interface PlayMarker {
+  characterId: number;
+  savedAt: number;
+}
+
+export function serializeMarker(marker: PlayMarker): string {
+  return JSON.stringify(marker);
+}
+
+// Parse a stored marker, rejecting anything malformed (a positive integer
+// characterId and a finite savedAt are required).
+export function parseMarker(raw: string | null): PlayMarker | null {
+  if (!raw) return null;
+  try {
+    const v = JSON.parse(raw) as { characterId?: unknown; savedAt?: unknown };
+    const characterId = v.characterId;
+    const savedAt = v.savedAt;
+    if (typeof characterId !== 'number' || !Number.isInteger(characterId) || characterId <= 0) {
+      return null;
+    }
+    if (typeof savedAt !== 'number' || !Number.isFinite(savedAt)) return null;
+    return { characterId, savedAt };
+  } catch {
+    return null;
+  }
+}
+
+// The pure resume decision: given a parsed marker and the current time, return
+// the character id to resume, or null when there is no marker or it is stale.
+// The negative-age guard covers a backwards clock change (never resume on a
+// marker that claims to be from the future).
+export function freshMarkerCharacterId(
+  marker: PlayMarker | null,
+  now: number,
+  maxAgeMs = RESUME_MAX_AGE_MS,
+): number | null {
+  if (!marker) return null;
+  const age = now - marker.savedAt;
+  if (age < 0 || age > maxAgeMs) return null;
+  return marker.characterId;
+}
+
+// localStorage is unavailable in private mode / SSR / some WebViews; every
+// wrapper fails soft so a storage error can never break boot or play.
+function readRaw(): string | null {
+  try {
+    return localStorage.getItem(RESUME_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeRaw(marker: PlayMarker): void {
+  try {
+    localStorage.setItem(RESUME_KEY, serializeMarker(marker));
+  } catch {
+    // ignore: resume is a best-effort convenience, never load-bearing
+  }
+}
+
+export function readPlayMarker(): PlayMarker | null {
+  return parseMarker(readRaw());
+}
+
+// Stamp the marker for the character just entered (or refresh its timestamp).
+export function savePlayMarker(characterId: number, now: number): void {
+  writeRaw({ characterId, savedAt: now });
+}
+
+// Re-stamp the existing marker's savedAt without changing the character, so a
+// long play session stays inside the resume window right up to the moment the
+// app is backgrounded. No-op when no marker is stored.
+export function refreshPlayMarker(now: number): void {
+  const existing = readPlayMarker();
+  if (!existing) return;
+  writeRaw({ characterId: existing.characterId, savedAt: now });
+}
+
+export function clearPlayMarker(): void {
+  try {
+    localStorage.removeItem(RESUME_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/tests/resume_play.test.ts
+++ b/tests/resume_play.test.ts
@@ -1,7 +1,10 @@
+import { readFileSync } from 'node:fs';
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   clearPlayMarker,
-  freshMarkerCharacterId,
+  freshMarker,
+  MAX_RESUME_ATTEMPTS,
+  markResumeAttempt,
   parseMarker,
   RESUME_KEY,
   RESUME_MAX_AGE_MS,
@@ -28,10 +31,23 @@ function installStorage(): void {
 
 beforeEach(() => installStorage());
 
+const MARKER = { characterId: 42, realm: 'Aldergate', savedAt: 1_000_000, attempts: 0 };
+
+describe('storage contract (literals, not self-comparison)', () => {
+  it('pins the storage key: renaming it orphans every player stored marker', () => {
+    expect(RESUME_KEY).toBe('woc_active_play');
+  });
+
+  it('pins the serialized shape: changing it invalidates stored markers', () => {
+    expect(serializeMarker(MARKER)).toBe(
+      '{"characterId":42,"realm":"Aldergate","savedAt":1000000,"attempts":0}',
+    );
+  });
+});
+
 describe('parseMarker', () => {
   it('round-trips a valid marker', () => {
-    const m = { characterId: 42, savedAt: 1_000_000 };
-    expect(parseMarker(serializeMarker(m))).toEqual(m);
+    expect(parseMarker(serializeMarker(MARKER))).toEqual(MARKER);
   });
 
   it('rejects null / empty / malformed json', () => {
@@ -41,57 +57,95 @@ describe('parseMarker', () => {
   });
 
   it('rejects a non-positive or non-integer characterId', () => {
-    expect(parseMarker(JSON.stringify({ characterId: 0, savedAt: 1 }))).toBeNull();
-    expect(parseMarker(JSON.stringify({ characterId: -3, savedAt: 1 }))).toBeNull();
-    expect(parseMarker(JSON.stringify({ characterId: 4.5, savedAt: 1 }))).toBeNull();
-    expect(parseMarker(JSON.stringify({ characterId: '7', savedAt: 1 }))).toBeNull();
+    expect(parseMarker(JSON.stringify({ ...MARKER, characterId: 0 }))).toBeNull();
+    expect(parseMarker(JSON.stringify({ ...MARKER, characterId: -3 }))).toBeNull();
+    expect(parseMarker(JSON.stringify({ ...MARKER, characterId: 4.5 }))).toBeNull();
+    expect(parseMarker(JSON.stringify({ ...MARKER, characterId: '7' }))).toBeNull();
+  });
+
+  it('rejects a missing or empty or non-string realm', () => {
+    expect(parseMarker(JSON.stringify({ characterId: 7, savedAt: 1 }))).toBeNull();
+    expect(parseMarker(JSON.stringify({ ...MARKER, realm: '' }))).toBeNull();
+    expect(parseMarker(JSON.stringify({ ...MARKER, realm: 5 }))).toBeNull();
   });
 
   it('rejects a missing or non-finite savedAt', () => {
-    expect(parseMarker(JSON.stringify({ characterId: 7 }))).toBeNull();
-    expect(parseMarker(JSON.stringify({ characterId: 7, savedAt: 'x' }))).toBeNull();
+    expect(parseMarker(JSON.stringify({ characterId: 7, realm: 'A' }))).toBeNull();
+    expect(parseMarker(JSON.stringify({ ...MARKER, savedAt: 'x' }))).toBeNull();
     // JSON cannot carry Infinity, but a hand-built object shape must still reject it.
-    expect(parseMarker('{"characterId":7,"savedAt":null}')).toBeNull();
+    expect(parseMarker('{"characterId":7,"realm":"A","savedAt":null}')).toBeNull();
+  });
+
+  it('defaults a missing attempts to 0 and rejects a malformed one', () => {
+    expect(parseMarker('{"characterId":7,"realm":"A","savedAt":1}')).toEqual({
+      characterId: 7,
+      realm: 'A',
+      savedAt: 1,
+      attempts: 0,
+    });
+    expect(parseMarker(JSON.stringify({ ...MARKER, attempts: -1 }))).toBeNull();
+    expect(parseMarker(JSON.stringify({ ...MARKER, attempts: 1.5 }))).toBeNull();
+    expect(parseMarker(JSON.stringify({ ...MARKER, attempts: '2' }))).toBeNull();
   });
 });
 
-describe('freshMarkerCharacterId', () => {
+describe('freshMarker', () => {
   const now = 10_000_000;
+  const at = (savedAt: number, attempts = 0) => ({ ...MARKER, savedAt, attempts });
 
-  it('returns the id for a marker inside the freshness window', () => {
-    expect(freshMarkerCharacterId({ characterId: 9, savedAt: now - 1000 }, now)).toBe(9);
+  it('returns the marker inside the freshness window', () => {
+    expect(freshMarker(at(now - 1000), now)).toEqual(at(now - 1000));
     // exactly at the boundary is still honored
-    expect(freshMarkerCharacterId({ characterId: 9, savedAt: now - RESUME_MAX_AGE_MS }, now)).toBe(
-      9,
-    );
+    expect(freshMarker(at(now - RESUME_MAX_AGE_MS), now)).toEqual(at(now - RESUME_MAX_AGE_MS));
   });
 
   it('returns null for a stale marker (older than the window)', () => {
-    expect(
-      freshMarkerCharacterId({ characterId: 9, savedAt: now - RESUME_MAX_AGE_MS - 1 }, now),
-    ).toBeNull();
+    expect(freshMarker(at(now - RESUME_MAX_AGE_MS - 1), now)).toBeNull();
   });
 
   it('returns null for a null marker', () => {
-    expect(freshMarkerCharacterId(null, now)).toBeNull();
+    expect(freshMarker(null, now)).toBeNull();
   });
 
   it('returns null on a backwards clock (marker from the future)', () => {
-    expect(freshMarkerCharacterId({ characterId: 9, savedAt: now + 5000 }, now)).toBeNull();
+    expect(freshMarker(at(now + 5000), now)).toBeNull();
+  });
+
+  it('returns null once the resume attempt budget is spent', () => {
+    expect(freshMarker(at(now - 1000, MAX_RESUME_ATTEMPTS - 1), now)).not.toBeNull();
+    expect(freshMarker(at(now - 1000, MAX_RESUME_ATTEMPTS), now)).toBeNull();
+    expect(freshMarker(at(now - 1000, MAX_RESUME_ATTEMPTS + 1), now)).toBeNull();
   });
 });
 
 describe('storage wrappers', () => {
-  it('save then read a marker at the given time', () => {
-    savePlayMarker(123, 555);
-    expect(readPlayMarker()).toEqual({ characterId: 123, savedAt: 555 });
+  it('save then read a marker at the given time, attempts reset to 0', () => {
+    savePlayMarker(123, 'Aldergate', 555);
+    expect(readPlayMarker()).toEqual({
+      characterId: 123,
+      realm: 'Aldergate',
+      savedAt: 555,
+      attempts: 0,
+    });
     expect(localStorage.getItem(RESUME_KEY)).not.toBeNull();
   });
 
-  it('refresh re-stamps savedAt but keeps the character', () => {
-    savePlayMarker(123, 555);
+  it('refresh re-stamps savedAt of a fresh marker, keeping character and realm', () => {
+    savePlayMarker(123, 'Aldergate', 555);
     refreshPlayMarker(9_999);
-    expect(readPlayMarker()).toEqual({ characterId: 123, savedAt: 9_999 });
+    expect(readPlayMarker()).toEqual({
+      characterId: 123,
+      realm: 'Aldergate',
+      savedAt: 9_999,
+      attempts: 0,
+    });
+  });
+
+  it('refresh CLEARS a stale marker instead of resurrecting it', () => {
+    savePlayMarker(123, 'Aldergate', 0);
+    refreshPlayMarker(RESUME_MAX_AGE_MS + 1);
+    expect(readPlayMarker()).toBeNull();
+    expect(localStorage.getItem(RESUME_KEY)).toBeNull();
   });
 
   it('refresh is a no-op when no marker is stored', () => {
@@ -99,18 +153,40 @@ describe('storage wrappers', () => {
     expect(readPlayMarker()).toBeNull();
   });
 
+  it('markResumeAttempt increments the persisted budget until fresh rejects it', () => {
+    savePlayMarker(123, 'Aldergate', 555);
+    markResumeAttempt();
+    expect(readPlayMarker()?.attempts).toBe(1);
+    for (let i = 1; i < MAX_RESUME_ATTEMPTS; i++) markResumeAttempt();
+    expect(readPlayMarker()?.attempts).toBe(MAX_RESUME_ATTEMPTS);
+    expect(freshMarker(readPlayMarker(), 556)).toBeNull();
+    // a completed entry resets the budget
+    savePlayMarker(123, 'Aldergate', 557);
+    expect(readPlayMarker()?.attempts).toBe(0);
+  });
+
+  it('markResumeAttempt is a no-op when no marker is stored', () => {
+    markResumeAttempt();
+    expect(readPlayMarker()).toBeNull();
+  });
+
   it('clear removes the marker', () => {
-    savePlayMarker(123, 555);
+    savePlayMarker(123, 'Aldergate', 555);
     clearPlayMarker();
     expect(readPlayMarker()).toBeNull();
     expect(localStorage.getItem(RESUME_KEY)).toBeNull();
   });
 
   it('a stale saved marker is rejected by the freshness gate end-to-end', () => {
-    savePlayMarker(77, 0);
+    savePlayMarker(77, 'Aldergate', 0);
     // A read gives the marker back verbatim, but the fresh gate rejects it.
-    expect(readPlayMarker()).toEqual({ characterId: 77, savedAt: 0 });
-    expect(freshMarkerCharacterId(readPlayMarker(), RESUME_MAX_AGE_MS + 1)).toBeNull();
+    expect(readPlayMarker()).toEqual({
+      characterId: 77,
+      realm: 'Aldergate',
+      savedAt: 0,
+      attempts: 0,
+    });
+    expect(freshMarker(readPlayMarker(), RESUME_MAX_AGE_MS + 1)).toBeNull();
   });
 
   it('fails soft when localStorage throws (private mode / SSR)', () => {
@@ -126,9 +202,52 @@ describe('storage wrappers', () => {
       },
     };
     // None of these may throw.
-    expect(() => savePlayMarker(1, 1)).not.toThrow();
+    expect(() => savePlayMarker(1, 'A', 1)).not.toThrow();
     expect(readPlayMarker()).toBeNull();
     expect(() => refreshPlayMarker(1)).not.toThrow();
+    expect(() => markResumeAttempt()).not.toThrow();
     expect(() => clearPlayMarker()).not.toThrow();
+  });
+});
+
+// The behavior the fix delivers lives in main.ts wiring; pin the load-bearing
+// call sites so a refactor cannot silently drop one (same readFileSync idiom as
+// tests/play_online_only.test.ts).
+describe('main.ts resume wiring', () => {
+  const mainTs = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8').replace(
+    /\r\n/g,
+    '\n',
+  );
+
+  it('saves the marker (with realm) when world entry completes', () => {
+    expect(mainTs).toContain('if (api.realm) savePlayMarker(c.id, api.realm, Date.now());');
+  });
+
+  it('clears the marker inside fatalOverlay, with the conflict opt-out', () => {
+    expect(mainTs).toContain('if (!opts?.keepResumeMarker) clearPlayMarker();');
+    expect(mainTs).toContain('keepResumeMarker: reason === RECONNECT_CONFLICT_ERROR,');
+  });
+
+  it('clears the marker beside every clearSession-style logout site', () => {
+    // deliberate in-game logout, account logout, session expiry, deactivate,
+    // recovery-email hatch, and the boot auth failure all clear the marker.
+    const clears = mainTs.match(/clearPlayMarker\(\);/g) ?? [];
+    expect(clears.length).toBeGreaterThanOrEqual(7);
+    expect(mainTs).toContain('api.clearSession();\n    clearPlayMarker();');
+  });
+
+  it('boot resume counts an attempt, restores the realm, and is desktop-guarded', () => {
+    expect(mainTs).toContain('markResumeAttempt();');
+    expect(mainTs).toContain('localStorage.setItem(LAST_REALM_KEY, resume.realm);');
+    expect(mainTs).toContain('if (isDesktopLoginPage()) return;');
+  });
+
+  it('the roster consume gate requires the marker realm to match the api realm', () => {
+    expect(mainTs).toContain('resume.realm === api.realm');
+  });
+
+  it('re-stamps on hide and pagehide via the freshness-gated refresh', () => {
+    expect(mainTs).toContain("if (document.visibilityState === 'hidden') refreshPlayMarker(");
+    expect(mainTs).toContain("window.addEventListener('pagehide', () => refreshPlayMarker(");
   });
 });

--- a/tests/resume_play.test.ts
+++ b/tests/resume_play.test.ts
@@ -229,21 +229,41 @@ describe('main.ts resume wiring', () => {
   });
 
   it('clears the marker beside every clearSession-style logout site', () => {
-    // deliberate in-game logout, account logout, session expiry, deactivate,
-    // recovery-email hatch, and the boot auth failure all clear the marker.
+    // Exact count: in-game logout, account logout, session expiry, deactivate,
+    // recovery-email hatch, boot auth failure, roster mismatch, fatalOverlay,
+    // and the boot dead-marker clear. A new terminal site must bump this; a
+    // silently deleted one fails it.
     const clears = mainTs.match(/clearPlayMarker\(\);/g) ?? [];
-    expect(clears.length).toBeGreaterThanOrEqual(7);
+    expect(clears.length).toBe(9);
     expect(mainTs).toContain('api.clearSession();\n    clearPlayMarker();');
   });
 
-  it('boot resume counts an attempt, restores the realm, and is desktop-guarded', () => {
+  it('boot resume counts an attempt, restores the realm, and is guarded', () => {
     expect(mainTs).toContain('markResumeAttempt();');
     expect(mainTs).toContain('localStorage.setItem(LAST_REALM_KEY, resume.realm);');
     expect(mainTs).toContain('if (isDesktopLoginPage()) return;');
+    // the Discord-onboarding arm enters play itself; resume must not double-enter
+    expect(mainTs).toContain('if (discordOnboarding) return;');
+    // a marker that no longer resumes (stale or spent) is cleared, not kept
+    expect(mainTs).toContain('if (marker) clearPlayMarker();');
+  });
+
+  it('drops the pending intent on every non-entry landing', () => {
+    // the realm list (no remembered realm) and a failed roster load both disarm
+    expect(mainTs).toContain("pendingResume = null;\n  show('#realm-panel');");
+    expect(mainTs).toContain(
+      'pendingResume = null;\n    listEl.innerHTML = `<li class="char-list-message char-list-error">',
+    );
   });
 
   it('the roster consume gate requires the marker realm to match the api realm', () => {
-    expect(mainTs).toContain('resume.realm === api.realm');
+    expect(mainTs).toContain(
+      'resume.realm === api.realm ? chars.find((c) => c.id === resume.characterId) : undefined',
+    );
+    // a missing character or realm mismatch clears the persisted marker
+    expect(mainTs).toContain(
+      'if (target) {\n        void enterWorld(target);\n        return;\n      }\n      clearPlayMarker();',
+    );
   });
 
   it('re-stamps on hide and pagehide via the freshness-gated refresh', () => {

--- a/tests/resume_play.test.ts
+++ b/tests/resume_play.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearPlayMarker,
+  freshMarkerCharacterId,
+  parseMarker,
+  RESUME_KEY,
+  RESUME_MAX_AGE_MS,
+  readPlayMarker,
+  refreshPlayMarker,
+  savePlayMarker,
+  serializeMarker,
+} from '../src/net/resume_play';
+
+// minimal localStorage stub (the test env is plain node, no DOM)
+function installStorage(): void {
+  const map = new Map<string, string>();
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      map.set(k, v);
+    },
+    removeItem: (k: string) => {
+      map.delete(k);
+    },
+    clear: () => map.clear(),
+  };
+}
+
+beforeEach(() => installStorage());
+
+describe('parseMarker', () => {
+  it('round-trips a valid marker', () => {
+    const m = { characterId: 42, savedAt: 1_000_000 };
+    expect(parseMarker(serializeMarker(m))).toEqual(m);
+  });
+
+  it('rejects null / empty / malformed json', () => {
+    expect(parseMarker(null)).toBeNull();
+    expect(parseMarker('')).toBeNull();
+    expect(parseMarker('{not json')).toBeNull();
+  });
+
+  it('rejects a non-positive or non-integer characterId', () => {
+    expect(parseMarker(JSON.stringify({ characterId: 0, savedAt: 1 }))).toBeNull();
+    expect(parseMarker(JSON.stringify({ characterId: -3, savedAt: 1 }))).toBeNull();
+    expect(parseMarker(JSON.stringify({ characterId: 4.5, savedAt: 1 }))).toBeNull();
+    expect(parseMarker(JSON.stringify({ characterId: '7', savedAt: 1 }))).toBeNull();
+  });
+
+  it('rejects a missing or non-finite savedAt', () => {
+    expect(parseMarker(JSON.stringify({ characterId: 7 }))).toBeNull();
+    expect(parseMarker(JSON.stringify({ characterId: 7, savedAt: 'x' }))).toBeNull();
+    // JSON cannot carry Infinity, but a hand-built object shape must still reject it.
+    expect(parseMarker('{"characterId":7,"savedAt":null}')).toBeNull();
+  });
+});
+
+describe('freshMarkerCharacterId', () => {
+  const now = 10_000_000;
+
+  it('returns the id for a marker inside the freshness window', () => {
+    expect(freshMarkerCharacterId({ characterId: 9, savedAt: now - 1000 }, now)).toBe(9);
+    // exactly at the boundary is still honored
+    expect(freshMarkerCharacterId({ characterId: 9, savedAt: now - RESUME_MAX_AGE_MS }, now)).toBe(
+      9,
+    );
+  });
+
+  it('returns null for a stale marker (older than the window)', () => {
+    expect(
+      freshMarkerCharacterId({ characterId: 9, savedAt: now - RESUME_MAX_AGE_MS - 1 }, now),
+    ).toBeNull();
+  });
+
+  it('returns null for a null marker', () => {
+    expect(freshMarkerCharacterId(null, now)).toBeNull();
+  });
+
+  it('returns null on a backwards clock (marker from the future)', () => {
+    expect(freshMarkerCharacterId({ characterId: 9, savedAt: now + 5000 }, now)).toBeNull();
+  });
+});
+
+describe('storage wrappers', () => {
+  it('save then read a marker at the given time', () => {
+    savePlayMarker(123, 555);
+    expect(readPlayMarker()).toEqual({ characterId: 123, savedAt: 555 });
+    expect(localStorage.getItem(RESUME_KEY)).not.toBeNull();
+  });
+
+  it('refresh re-stamps savedAt but keeps the character', () => {
+    savePlayMarker(123, 555);
+    refreshPlayMarker(9_999);
+    expect(readPlayMarker()).toEqual({ characterId: 123, savedAt: 9_999 });
+  });
+
+  it('refresh is a no-op when no marker is stored', () => {
+    refreshPlayMarker(9_999);
+    expect(readPlayMarker()).toBeNull();
+  });
+
+  it('clear removes the marker', () => {
+    savePlayMarker(123, 555);
+    clearPlayMarker();
+    expect(readPlayMarker()).toBeNull();
+    expect(localStorage.getItem(RESUME_KEY)).toBeNull();
+  });
+
+  it('a stale saved marker is rejected by the freshness gate end-to-end', () => {
+    savePlayMarker(77, 0);
+    // A read gives the marker back verbatim, but the fresh gate rejects it.
+    expect(readPlayMarker()).toEqual({ characterId: 77, savedAt: 0 });
+    expect(freshMarkerCharacterId(readPlayMarker(), RESUME_MAX_AGE_MS + 1)).toBeNull();
+  });
+
+  it('fails soft when localStorage throws (private mode / SSR)', () => {
+    (globalThis as any).localStorage = {
+      getItem: () => {
+        throw new Error('denied');
+      },
+      setItem: () => {
+        throw new Error('denied');
+      },
+      removeItem: () => {
+        throw new Error('denied');
+      },
+    };
+    // None of these may throw.
+    expect(() => savePlayMarker(1, 1)).not.toThrow();
+    expect(readPlayMarker()).toBeNull();
+    expect(() => refreshPlayMarker(1)).not.toThrow();
+    expect(() => clearPlayMarker()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

iPhone players report the game "randomly returns me to the login screen" (iPhone 17 Pro Max, multiple users). Root cause: iOS evicts the backgrounded WKWebView under memory pressure, so on foreground the app reloads `index.html`. The client is a single-page app whose boot path lands a restored session on the home / character-select chrome and **never re-enters the world**, silently dropping the player out of the game (and, if the stored token also fails revalidation, all the way to the login screen).

This PR fixes the dominant cause: it persists an **active-play marker** (`characterId` + `savedAt`) so the boot path can re-enter the world instead of home.

- New pure leaf `src/net/resume_play.ts`: marker parse/serialize + freshness decision (unit-tested), plus fail-soft `localStorage` wrappers.
- The marker is **freshness-scoped**: a 30-minute window, re-stamped on `visibilitychange -> hidden` / `pagehide` (the pre-eviction instant). A cold open of a long-closed tab still lands on home as before; only a genuine reload-during-play resumes. The window sits inside the server's 5-minute linkdead grace for a seamless resume, and past it a fresh join is still correct.
- Resume routes through the existing `enterWorld` path (not `takeOverAndEnter`): a linkdead session resumes seamlessly, and a genuinely **live duplicate on another device** is rejected with `character already in world` and falls to the fatal overlay, so resume can never silently kick another device.
- The marker is cleared on every terminal exit (deliberate in-game / account logout, 401/403 session expiry, entry timeout, fatal disconnect), and the boot resume intent is dropped when the realm list is shown, so it can never linger into a non-playing char-select and cause a spurious auto-enter.

`src/main.ts` stays a thin consumer (save on `enterWorld`, consume on boot, clear on the terminal sites).

### Known follow-ups (not in this PR)

Two secondary contributors remain, worth a sibling fix:
- The session token has a hard 7-day TTL (`server/db.ts` `saveToken`) with no client refresh or server sliding renewal, so a reconnect after expiry still routes to login. Recommend sliding renewal on WS re-auth / REST use.
- A WiFi/cellular black-hole handoff can exhaust `MAX_CONFLICT_REJECTIONS = 8` (`src/net/reconnect_policy.ts`) before the server sweeps the dead socket.

## Related issues

Reported on Discord (iPhone 17 Pro Max "returns to login" during play). Part of the mobile-stability effort.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/resume_play.test.ts` (14 cases: parse/serialize round-trip, malformed/`null`/non-integer/negative `characterId`, missing/non-finite `savedAt`, both freshness boundaries, backward-clock guard, storage round-trip, private-mode fail-soft)
  - `npx vitest run tests/play_online_only.test.ts tests/main_api_error.test.ts tests/net_online_visibility_reconnect.test.ts` (main.ts contract + reconnect suites)
  - `npx tsc --noEmit`, `biome check` (changed files), `npx vite build` (client bundles, green), guard tests (`architecture`, `localization_fixes`)
- Manual steps: N/A automated; the fix is a boot-flow change. Suggested device check: enter the world on iOS, background the app until the WebView is evicted, foreground, and confirm it resumes into the world instead of home/login.

## Screenshots / recordings

N/A: no visual/UI surface changes (boot-flow behavior only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)