### PR TITLE
fix(render): Nythraxis phase-2 court uses the Aldren / Malric / Voss models

### DIFF
--- a/src/render/characters/manifest.ts
+++ b/src/render/characters/manifest.ts
@@ -1109,6 +1109,13 @@ const MOB_KEYS: Record<string, string> = {
   fallen_captain_aldren: 'skel_warrior',
   corrupted_priest_malric: 'skel_necromancer',
   deathstalker_voss: 'skel_rogue',
+  // The Nythraxis phase-2 heroic court is Aldren / Malric / Voss risen again, so
+  // the "Spirit of X" adds reuse each character's crypt visual above. Without these
+  // the ids fall through to FAMILY_KEYS.undead (skel_minion) and the whole court
+  // renders as identical generic skeletons. See spawnNythraxisHeroicAdds.
+  nythraxis_heroic_warrior_add: 'skel_warrior', // Spirit of Aldren
+  nythraxis_heroic_priest_add: 'skel_necromancer', // Spirit of Malric
+  nythraxis_heroic_rogue_add: 'skel_rogue', // Spirit of Voss
   vision_aldren_warrior: 'player_warrior',
   vision_malric_mage: 'player_mage',
   vision_deathstalker_voss: 'player_rogue',

--- a/tests/visual_manifest.test.ts
+++ b/tests/visual_manifest.test.ts
@@ -106,6 +106,24 @@ describe('character visual manifest', () => {
     expect(VISUALS.mob_boar.deathTimeScale).toBeUndefined();
   });
 
+  it('renders the Nythraxis phase-2 court as Aldren / Malric / Voss, not generic skeletons', () => {
+    // The heroic "Spirit of X" adds are the same characters risen again, so they
+    // must reuse each named crypt boss's visual. Without the MOB_KEYS entries they
+    // fall through to FAMILY_KEYS.undead (skel_minion) and the court renders as
+    // three identical grunts. Each add is pinned to its counterpart's key.
+    const court: Array<[string, string]> = [
+      ['nythraxis_heroic_warrior_add', 'fallen_captain_aldren'],
+      ['nythraxis_heroic_priest_add', 'corrupted_priest_malric'],
+      ['nythraxis_heroic_rogue_add', 'deathstalker_voss'],
+    ];
+    for (const [addId, namedId] of court) {
+      const addKey = visualKeyFor({ kind: 'mob', templateId: addId } as never);
+      const namedKey = visualKeyFor({ kind: 'mob', templateId: namedId } as never);
+      expect(addKey, addId).toBe(namedKey);
+      expect(addKey, addId).not.toBe('skel_minion');
+    }
+  });
+
   it('points the Combat Mech manifest at animation clips baked into the GLB', async () => {
     const visual = VISUALS.player_mech;
     const animationNames = await glbAnimationNames(`public/${visual.url}`);


### PR DESCRIPTION
## Problem

In the Nythraxis raid's phase-2 heroic summon, the court that rises again (Spirit of Aldren, Spirit of Malric, Spirit of Voss) all render as identical generic skeletons instead of the three distinct characters.

## Cause

The phase-2 add templates (`nythraxis_heroic_warrior_add` / `_priest_add` / `_rogue_add`, spawned by `spawnNythraxisHeroicAdds`) are missing from `MOB_KEYS` in `src/render/characters/manifest.ts`. `visualKeyFor` therefore falls through to `FAMILY_KEYS.undead` = `skel_minion` for all three. Their named crypt counterparts are mapped correctly (`fallen_captain_aldren` -> `skel_warrior`, `corrupted_priest_malric` -> `skel_necromancer`, `deathstalker_voss` -> `skel_rogue`), so the raid court looked nothing like the characters it is meant to be.

## Fix

Map the three court add ids to the same visuals their named versions already use:

- `nythraxis_heroic_warrior_add` (Aldren) -> `skel_warrior`
- `nythraxis_heroic_priest_add` (Malric) -> `skel_necromancer`
- `nythraxis_heroic_rogue_add` (Voss) -> `skel_rogue`

Those visuals are already in the tier-independent character preload set (the crypt bosses use them), so there is no new asset or preload change. Presentation-only: no sim, gameplay, wire, or parity impact.

## Testing

`tests/visual_manifest.test.ts` gains a case that pins each court add to its named counterpart's visual key and asserts it is never `skel_minion`. `tests/render_asset_preload.test.ts` still passes (no new asset to preload). `tsc` clean.

No screenshots: this is a phase-2 raid encounter (heroic Nythraxis, boss past the summon phase) that is impractical to reach headless; the manifest resolution is deterministic and covered by the unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)