### PR TITLE
fix(combat): same-class group buffs no longer stack (no double Sureflight Aura)

### DIFF
--- a/src/sim/combat/aura_stacking.ts
+++ b/src/sim/combat/aura_stacking.ts
@@ -1,5 +1,10 @@
 import type { Aura } from '../types';
 
+// Persistent group buffs that are ONE per target regardless of caster: a second
+// same-class caster REPLACES the existing aura instead of stacking a duplicate (no
+// double Arcane Intellect, no two Sureflight Auras, etc.). Every party group buff
+// belongs here. The buffTarget party buffs use the ability id as the aura id, while
+// the hunter aura (aoeAllyAttackPower) applies as `${abilityId}_ap`.
 const SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS = new Set([
   'arcane_intellect',
   'battle_shout',
@@ -7,6 +12,7 @@ const SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS = new Set([
   'devotion_aura',
   'mark_of_the_wild',
   'power_word_fortitude',
+  'trueshot_aura_ap', // Sureflight Aura (hunter aoeAllyAttackPower)
 ]);
 
 export function auraReplacementConflicts(auras: readonly Aura[], aura: Aura): number[] {

--- a/tests/raid_buffs.test.ts
+++ b/tests/raid_buffs.test.ts
@@ -191,6 +191,35 @@ describe('standardized percent raid buffs', () => {
     expect(blessings[0].remaining).toBe(1800);
   });
 
+  it('does not stack Sureflight Aura from two hunters (same-class group buff)', () => {
+    // trueshot_aura (Sureflight Aura) is a talent-granted hunter aura applied as
+    // `${abilityId}_ap` by aoeAllyAttackPower. Two hunters used to stack two copies
+    // on the same target; now the second REPLACES the first (source-independent).
+    const sim = makeWorld();
+    const first = sim.addPlayer('hunter', 'Rax');
+    const second = sim.addPlayer('hunter', 'Vess');
+    const target = sim.entities.get(sim.addPlayer('warrior', 'War'))!;
+    const sureflight = (sourceId: number): Aura => ({
+      id: 'trueshot_aura_ap',
+      name: 'Sureflight Aura',
+      kind: 'buff_ap_pct',
+      remaining: 1800,
+      duration: 1800,
+      value: 10,
+      sourceId,
+      school: 'nature',
+    });
+    const applyAura = (a: Aura) =>
+      (sim as unknown as { applyAura(t: Entity, a: Aura): void }).applyAura(target, a);
+
+    applyAura(sureflight(first));
+    applyAura(sureflight(second));
+
+    const auras = target.auras.filter((a) => a.id === 'trueshot_aura_ap');
+    expect(auras).toHaveLength(1);
+    expect(auras[0].sourceId).toBe(second);
+  });
+
   it('keeps the newest stronger Blessing of Might value', () => {
     const sim = makeWorld();
     const first = sim.addPlayer('paladin', 'Ald');


### PR DESCRIPTION
## Problem

Two hunters could stack two copies of Sureflight Aura on the same target (and similarly any group buff not already deduped), double-dipping the effect.

## Cause

`auraReplacementConflicts` (`src/sim/combat/aura_stacking.ts`) only replaces an existing aura across DIFFERENT casters when the aura id is in `SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS`; otherwise a second caster stacks a duplicate. That set covered six of the seven party group buffs (Arcane Intellect, Battle Shout, Blessing of Might, Devotion/Steadfast Aura, Mark of the Wild, Power Word: Fortitude) but not the hunter's Sureflight Aura. Sureflight is `trueshot_aura` (talent-granted) applied by `aoeAllyAttackPower` as the aura id `trueshot_aura_ap`, so it was never deduped.

## Fix

Add `trueshot_aura_ap` to the source-independent set, so a second hunter's Sureflight replaces the first instead of stacking. Every party group buff is now in the set. Pure-leaf change: no rng, no parity impact.

## Testing

`tests/raid_buffs.test.ts` gains a case: two hunters applying Sureflight to a target leave exactly one aura (the newer caster's), mirroring the existing Blessing-of-Might replacement test. Parity and architecture suites green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)