### PR TITLE
fix(scripts): resolve asset pipeline ROOT via fileURLToPath so it runs on Windows

### DIFF
--- a/scripts/assets/build_assets.mjs
+++ b/scripts/assets/build_assets.mjs
@@ -27,13 +27,23 @@
 // - "copy": byte-for-byte copy (HDRIs, plain textures).
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { NodeIO } from '@gltf-transform/core';
 import { ALL_EXTENSIONS } from '@gltf-transform/extensions';
-import { dedup, mergeDocuments, meshopt, prune, resample, textureCompress } from '@gltf-transform/functions';
+import {
+  dedup,
+  mergeDocuments,
+  meshopt,
+  prune,
+  resample,
+  textureCompress,
+} from '@gltf-transform/functions';
 import { MeshoptDecoder, MeshoptEncoder } from 'meshoptimizer';
 import sharp from 'sharp';
 
-const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+// URL.pathname keeps a leading slash before a Windows drive letter, which
+// path.resolve mangles into "D:\D:\..."; fileURLToPath is correct on every OS.
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const PUBLIC_DIR = path.join(ROOT, 'public');
 
 function stripClipName(name) {
@@ -55,17 +65,24 @@ function resolveSrc(src) {
 function expandItems(items) {
   const out = [];
   for (const raw of items) {
-    if (!raw.srcDir) { out.push(raw); continue; }
+    if (!raw.srcDir) {
+      out.push(raw);
+      continue;
+    }
     const dir = resolveSrc(raw.srcDir);
     const exts = raw.exts ?? ['.gltf', '.glb'];
-    const files = fs.readdirSync(dir)
+    const files = fs
+      .readdirSync(dir)
       .filter((f) => exts.some((e) => f.toLowerCase().endsWith(e)))
       .sort();
     const { srcDir, outDir, exts: _drop, ...rest } = raw;
     for (const f of files) {
       const name = f
-        .replace(/\.gltf\.glb$/i, '').replace(/\.(gltf|glb)$/i, '')
-        .toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+        .replace(/\.gltf\.glb$/i, '')
+        .replace(/\.(gltf|glb)$/i, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '');
       out.push({ ...rest, src: path.join(dir, f), out: `${outDir}/${name}.glb` });
     }
   }
@@ -106,7 +123,8 @@ async function processModel(io, item) {
     }
     for (const scene of root.listScenes()) if (!origScenes.has(scene)) scene.dispose();
     for (const node of root.listNodes()) if (!origNodes.has(node)) node.dispose();
-    if (orphan) console.warn(`  WARN ${item.out}: ${orphan} merged channel(s) had no matching bone`);
+    if (orphan)
+      console.warn(`  WARN ${item.out}: ${orphan} merged channel(s) had no matching bone`);
   }
 
   // Bake standalone prop/weapon meshes onto a bone. KayKit ships weapons as
@@ -118,7 +136,10 @@ async function processModel(io, item) {
   if (item.attachMeshes) {
     for (const att of item.attachMeshes) {
       const bone = root.listNodes().find((n) => n.getName() === att.bone);
-      if (!bone) { console.warn(`  WARN ${item.out}: attach bone '${att.bone}' not found`); continue; }
+      if (!bone) {
+        console.warn(`  WARN ${item.out}: attach bone '${att.bone}' not found`);
+        continue;
+      }
       const before = new Set(root.listScenes());
       mergeDocuments(doc, await io.read(resolveSrc(att.from)));
       for (const scene of root.listScenes()) {
@@ -127,7 +148,10 @@ async function processModel(io, item) {
         const single = roots.length === 1;
         for (const node of roots) {
           scene.removeChild(node);
-          if (single) { node.setTranslation([0, 0, 0]); node.setRotation([0, 0, 0, 1]); }
+          if (single) {
+            node.setTranslation([0, 0, 0]);
+            node.setRotation([0, 0, 0, 1]);
+          }
           bone.addChild(node);
         }
         scene.dispose();
@@ -149,7 +173,10 @@ async function processModel(io, item) {
     let name = stripClipName(anim.getName());
     if (item.renameClips && item.renameClips[name]) name = item.renameClips[name];
     const drop = (item.keepClips && !item.keepClips.includes(name)) || seen.has(name);
-    if (drop) { anim.dispose(); continue; }
+    if (drop) {
+      anim.dispose();
+      continue;
+    }
     seen.add(name);
     anim.setName(name);
   }
@@ -160,9 +187,13 @@ async function processModel(io, item) {
 
   const transforms = [resample(), prune(), dedup()];
   if (item.maxTex) {
-    transforms.push(textureCompress({
-      encoder: sharp, targetFormat: 'webp', resize: [item.maxTex, item.maxTex],
-    }));
+    transforms.push(
+      textureCompress({
+        encoder: sharp,
+        targetFormat: 'webp',
+        resize: [item.maxTex, item.maxTex],
+      }),
+    );
   }
   transforms.push(meshopt({ encoder: MeshoptEncoder, level: 'high' }));
   await doc.transform(...transforms);
@@ -217,7 +248,9 @@ async function main() {
     const defaults = spec.defaults ?? {};
     let items = expandItems(spec.items);
     if (shard) items = items.filter((_, idx) => idx % shard.n === shard.i);
-    console.log(`spec: ${specFile} (${items.length} items${shard ? `, shard ${shard.i}/${shard.n}` : ''})`);
+    console.log(
+      `spec: ${specFile} (${items.length} items${shard ? `, shard ${shard.i}/${shard.n}` : ''})`,
+    );
     for (const raw of items) {
       const item = { ...defaults, ...raw };
       try {

--- a/scripts/assets/build_foliage.mjs
+++ b/scripts/assets/build_foliage.mjs
@@ -16,13 +16,16 @@
 // leaf sheet is autumn-red, which we shift to green (bushes) / olive (swamp).
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { NodeIO } from '@gltf-transform/core';
 import { ALL_EXTENSIONS } from '@gltf-transform/extensions';
 import { dedup, meshopt, prune, simplify, textureCompress, weld } from '@gltf-transform/functions';
 import { MeshoptDecoder, MeshoptEncoder, MeshoptSimplifier } from 'meshoptimizer';
 import sharp from 'sharp';
 
-const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+// URL.pathname keeps a leading slash before a Windows drive letter, which
+// path.resolve mangles into "D:\D:\..."; fileURLToPath is correct on every OS.
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const PUBLIC_DIR = path.join(ROOT, 'public');
 const SIMPLIFY_ERROR = 0.05;
 
@@ -75,15 +78,24 @@ async function processItem(io, item) {
 
   const transforms = [];
   if (item.simplify) {
-    transforms.push(weld(), simplify({
-      simplifier: MeshoptSimplifier, ratio: item.simplify, error: SIMPLIFY_ERROR,
-    }));
+    transforms.push(
+      weld(),
+      simplify({
+        simplifier: MeshoptSimplifier,
+        ratio: item.simplify,
+        error: SIMPLIFY_ERROR,
+      }),
+    );
   }
   transforms.push(prune(), dedup());
   if (item.maxTex) {
-    transforms.push(textureCompress({
-      encoder: sharp, targetFormat: 'webp', resize: [item.maxTex, item.maxTex],
-    }));
+    transforms.push(
+      textureCompress({
+        encoder: sharp,
+        targetFormat: 'webp',
+        resize: [item.maxTex, item.maxTex],
+      }),
+    );
   }
   transforms.push(meshopt({ encoder: MeshoptEncoder, level: 'high' }));
   await doc.transform(...transforms);

--- a/tests/scripts_windows_paths.test.ts
+++ b/tests/scripts_windows_paths.test.ts
@@ -1,0 +1,50 @@
+// Guards the scripts/ tooling against the Windows path-resolution trap:
+// `new URL(import.meta.url).pathname` keeps a leading slash before a drive
+// letter ("/D:/..."), which path.resolve/path.dirname then mangle into
+// "D:\D:\...", so any script resolving its repo root that way cannot run on
+// Windows at all. The portable form is fileURLToPath(import.meta.url)
+// (node:url), correct on every OS; see scripts/assets/build_assets.mjs.
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const scriptsRoot = join(repoRoot, 'scripts');
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      if (name === 'node_modules') continue;
+      out.push(...walk(full));
+    } else if (/\.(?:mjs|cjs|js|ts)$/.test(name) && !/\.d\.m?ts$/.test(name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('scripts/ Windows path safety', () => {
+  it('no script takes .pathname off a file URL (breaks on Windows drive letters)', () => {
+    const banned = /new URL\([^)]*import\.meta\.url[^)]*\)\s*\.pathname/;
+    const offenders = walk(scriptsRoot)
+      .filter((file) => banned.test(readFileSync(file, 'utf8')))
+      .map((file) => relative(repoRoot, file));
+    expect(
+      offenders,
+      `use path.dirname(fileURLToPath(import.meta.url)) from node:url instead: ${offenders.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('the asset pipeline entries resolve ROOT via fileURLToPath (the fixed form)', () => {
+    for (const entry of ['assets/build_assets.mjs', 'assets/build_foliage.mjs']) {
+      const src = readFileSync(join(scriptsRoot, entry), 'utf8');
+      expect(src, entry).toContain(
+        "path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')",
+      );
+      expect(src, entry).toContain("import { fileURLToPath } from 'node:url';");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`scripts/assets/build_assets.mjs` and `scripts/assets/build_foliage.mjs` computed their repo ROOT with `path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..')`. On Windows, `URL.pathname` keeps a leading slash before the drive letter (`/D:/...`), which `path.resolve` mangles into `D:\D:\...`, so neither asset pipeline entry could run on Windows at all.

Both now use `path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')` (via `node:url`), which is correct on every OS. A sweep of the tree found no other occurrence of the broken pattern.

A new guard test, `tests/scripts_windows_paths.test.ts`, walks every script under `scripts/` and fails on any `new URL(...import.meta.url...).pathname` usage, and pins that both asset pipeline entries use the `fileURLToPath` form. It fails on the pre-fix scripts and passes post-fix.

Both scripts also pick up the full biome format pass, required because `biome ci --changed` gates changed files on format diffs and these files carried pre-existing format debt. Every reformatted hunk is purely syntactic; no logic changed.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Build, CI, or tooling

## How was this tested?

- Commands:
  - `npx vitest run tests/scripts_windows_paths.test.ts`: fails with the fix reverted (both assertions), passes with it applied.
  - `node scripts/assets/build_assets.mjs <probe spec>` on Windows 11: ROOT now resolves to the real repo root (previously the mangled `D:\D:\...` path made the script unrunnable).
  - `node --check scripts/assets/build_foliage.mjs` passes.
  - Gate steps run individually on Windows: i18n gen + freshness, malware scan, `biome ci --changed`, sfx check, `check:types` (tsc + svelte-check, 0 errors), `build:env`, `build:server`, and the full `npm run build` (all five entries) are all green.
- Manual steps:
  - The full local `npm run gate` vitest step is red on this Windows machine, but identically red on the pristine `origin/release/v0.26.0` base: an A/B run of the whole suite shows the same 166 failing entries on both (golden-master fixture CRLF mismatches under `core.autocrlf=true`), with a delta of exactly one unrelated flaky test (`tests/chat_item_link_draft.test.ts`) that passes in isolation. The two tests this PR adds pass in both runs. Same story for the one `test:browser` failure (armory mobile layout, identical 393.625 vs 391 assertion on the untouched base). CI on Linux is unaffected by either.

## Checklist

### Quality

- [x] **The full gate passes.** Green except the pre-existing Windows-local vitest/browser failures shown above to be identical on the untouched release base; every other gate step is green, and the changed behavior has decisive new tests.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A, offline build tooling only.
- ~Accessible.~ N/A, no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (script output is dev-channel English).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

Generated with [Claude Code](https://claude.com/claude-code)
