### PR TITLE
refactor(render): extract shared toFloatAttribute GLB dequantizer

### DIFF
--- a/src/render/attribute_float.ts
+++ b/src/render/attribute_float.ts
@@ -1,0 +1,22 @@
+// Shared dequantizer for GLB geometry baking (foliage, dungeon kits, event
+// scenes). The shipped GLBs are meshopt-quantized: positions/normals/uvs/colors
+// live in normalized integer (sometimes interleaved) attributes with a
+// dequantization node transform. Reading through getComponent denormalizes
+// quantized sources and flattens interleaved ones, so the result is a plain
+// float32 attribute that applyMatrix4/mergeGeometries/instancing can consume
+// without clamping world-space values into the [-1, 1] range.
+import * as THREE from 'three';
+
+export function toFloatAttribute(
+  attr: THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+): THREE.BufferAttribute {
+  if ((attr as THREE.BufferAttribute).isBufferAttribute && !attr.normalized) {
+    const plain = attr as THREE.BufferAttribute;
+    if (plain.array instanceof Float32Array) return plain.clone();
+  }
+  const out = new Float32Array(attr.count * attr.itemSize);
+  for (let i = 0; i < attr.count; i++) {
+    for (let c = 0; c < attr.itemSize; c++) out[i * attr.itemSize + c] = attr.getComponent(i, c);
+  }
+  return new THREE.BufferAttribute(out, attr.itemSize);
+}

--- a/src/render/dungeon.ts
+++ b/src/render/dungeon.ts
@@ -35,6 +35,7 @@ import {
 import { polygonContainsPoint, polygonXAtZ } from '../sim/geometry2d';
 import { loadGltf, releaseGltf } from './assets/loader';
 import { registerPreload } from './assets/preload';
+import { toFloatAttribute } from './attribute_float';
 import {
   placeLitanyMarshDressing,
   placeMarshBlackwaterPools,
@@ -278,11 +279,7 @@ let dungeonAssetsPromise: Promise<void> | null = null;
 function attributeToFloat(geo: THREE.BufferGeometry, name: string): void {
   const attr = geo.getAttribute(name);
   if (!attr || (attr.array instanceof Float32Array && !attr.normalized)) return;
-  const out = new Float32Array(attr.count * attr.itemSize);
-  for (let i = 0; i < attr.count; i++) {
-    for (let c = 0; c < attr.itemSize; c++) out[i * attr.itemSize + c] = attr.getComponent(i, c);
-  }
-  geo.setAttribute(name, new THREE.BufferAttribute(out, attr.itemSize));
+  geo.setAttribute(name, toFloatAttribute(attr));
 }
 
 function extractModule(name: string, pack: Pack, gltf: GLTF): void {

--- a/src/render/foliage.ts
+++ b/src/render/foliage.ts
@@ -22,6 +22,7 @@ import {
 } from '../sim/world';
 import { loadGltf } from './assets/loader';
 import { registerPreload } from './assets/preload';
+import { toFloatAttribute } from './attribute_float';
 import { configureMaskedDoubleSidedVegetationMaterial, GFX, sharedUniforms } from './gfx';
 import { grassTuftTexture } from './textures';
 
@@ -416,20 +417,9 @@ function foliageMaterial(src: THREE.Material, hasVertexColors: boolean): THREE.M
   return mat;
 }
 
-// The shipped GLBs are meshopt-quantized: positions/normals/colors live in
-// normalized integer attributes with a dequantization node transform. Bake
+// The shipped GLBs are meshopt-quantized (see attribute_float.ts). Bake
 // everything to float32 + world space once so geometries can be shared by
 // InstancedMeshes and merged into clusters without overflow.
-function toFloatAttribute(
-  attr: THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
-): THREE.BufferAttribute {
-  const out = new Float32Array(attr.count * attr.itemSize);
-  for (let i = 0; i < attr.count; i++) {
-    for (let j = 0; j < attr.itemSize; j++) out[i * attr.itemSize + j] = attr.getComponent(i, j);
-  }
-  return new THREE.BufferAttribute(out, attr.itemSize);
-}
-
 function bakeGeometry(mesh: THREE.Mesh): THREE.BufferGeometry {
   const src = mesh.geometry;
   const out = new THREE.BufferGeometry();

--- a/src/render/vale_cup_stadium.ts
+++ b/src/render/vale_cup_stadium.ts
@@ -44,6 +44,7 @@ import { terrainHeight } from '../sim/world';
 import type { CupInfo } from '../world_api/vale_cup';
 import { loadGltf, releaseGltf } from './assets/loader';
 import { registerPreload } from './assets/preload';
+import { toFloatAttribute } from './attribute_float';
 import { GFX, sharedUniforms } from './gfx';
 import { groundSplatMaps } from './textures';
 import { flagTexture } from './vale_cup_flags';
@@ -109,14 +110,12 @@ interface KitAsset {
 const kitAssets = new Map<string, KitAsset>();
 let kitSourceMaterial: THREE.MeshStandardMaterial | null = null;
 
+// Meshopt-quantized attributes are normalized ints; bake them to plain floats
+// so applyMatrix4/merge cannot clamp world-space values into the [-1,1] range.
 function attributeToFloat(geo: THREE.BufferGeometry, name: string): void {
   const attr = geo.getAttribute(name);
   if (!attr || (attr.array instanceof Float32Array && !attr.normalized)) return;
-  const out = new Float32Array(attr.count * attr.itemSize);
-  for (let i = 0; i < attr.count; i++) {
-    for (let c = 0; c < attr.itemSize; c++) out[i * attr.itemSize + c] = attr.getComponent(i, c);
-  }
-  geo.setAttribute(name, new THREE.BufferAttribute(out, attr.itemSize));
+  geo.setAttribute(name, toFloatAttribute(attr));
 }
 
 function extractKitPiece(name: string, gltf: GLTF): void {

--- a/tests/attribute_float.test.ts
+++ b/tests/attribute_float.test.ts
@@ -1,0 +1,64 @@
+// The shared dequantizer behind the GLB geometry bakes (foliage, dungeon kits,
+// the Sowfield): meshopt-quantized (normalized-integer) and interleaved sources
+// must come out as plain float32 attributes, and already-plain float32
+// attributes must come out as independent copies.
+import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
+import { toFloatAttribute } from '../src/render/attribute_float';
+
+describe('toFloatAttribute', () => {
+  it('copies a plain non-normalized float32 attribute (fast path)', () => {
+    const src = new THREE.BufferAttribute(new Float32Array([1, 2, 3, 4, 5, 6]), 3);
+    const out = toFloatAttribute(src);
+    expect(out).not.toBe(src);
+    expect(out.array).toBeInstanceOf(Float32Array);
+    expect(out.itemSize).toBe(3);
+    expect(out.count).toBe(2);
+    expect(out.normalized).toBe(false);
+    expect(Array.from(out.array as Float32Array)).toEqual([1, 2, 3, 4, 5, 6]);
+    // Independent storage: the callers applyMatrix4/merge the result, which
+    // must never write back into the shared GLB cache.
+    (out.array as Float32Array)[0] = 99;
+    expect((src.array as Float32Array)[0]).toBe(1);
+  });
+
+  it('denormalizes a normalized uint16 attribute into [0, 1] floats', () => {
+    const src = new THREE.BufferAttribute(new Uint16Array([0, 65535, 32768, 16384]), 2, true);
+    const out = toFloatAttribute(src);
+    expect(out.array).toBeInstanceOf(Float32Array);
+    expect(out.normalized).toBe(false);
+    const a = out.array as Float32Array;
+    expect(a[0]).toBe(0);
+    expect(a[1]).toBe(1);
+    expect(a[2]).toBeCloseTo(32768 / 65535, 6);
+    expect(a[3]).toBeCloseTo(16384 / 65535, 6);
+  });
+
+  it('flattens an interleaved source into a plain attribute', () => {
+    // Two vertices of [x, y, z, u, v]; the uv attribute reads at offset 3.
+    const buf = new THREE.InterleavedBuffer(
+      new Float32Array([1, 2, 3, 0.5, 0.25, 4, 5, 6, 0.75, 0.125]),
+      5,
+    );
+    const uv = new THREE.InterleavedBufferAttribute(buf, 2, 3);
+    const out = toFloatAttribute(uv);
+    expect(out).toBeInstanceOf(THREE.BufferAttribute);
+    expect(out.itemSize).toBe(2);
+    expect(out.count).toBe(2);
+    expect(Array.from(out.array as Float32Array)).toEqual([0.5, 0.25, 0.75, 0.125]);
+  });
+
+  it('denormalizes and flattens a normalized interleaved uint16 source (the meshopt shape)', () => {
+    const buf = new THREE.InterleavedBuffer(new Uint16Array([0, 65535, 9999, 65535, 0, 9999]), 3);
+    const pos = new THREE.InterleavedBufferAttribute(buf, 2, 0, true);
+    const out = toFloatAttribute(pos);
+    expect(out.array).toBeInstanceOf(Float32Array);
+    expect(out.itemSize).toBe(2);
+    expect(out.count).toBe(2);
+    const a = out.array as Float32Array;
+    expect(a[0]).toBe(0);
+    expect(a[1]).toBe(1);
+    expect(a[2]).toBe(1);
+    expect(a[3]).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Rule-of-three extraction: three render modules carried near-identical private helpers that dequantize a meshopt-quantized BufferAttribute (normalized integers, sometimes interleaved) into a plain Float32Array attribute by reading through getComponent: toFloatAttribute in src/render/foliage.ts, and attributeToFloat in src/render/dungeon.ts and src/render/vale_cup_stadium.ts.

This PR extracts one shared module, src/render/attribute_float.ts, exporting a single toFloatAttribute(attr):

- Fast path: a plain non-normalized Float32Array BufferAttribute returns an independent clone (BufferAttribute.clone deep-copies the array, so the immutable GLB loader cache is never aliased into geometry that later gets applyMatrix4).
- Slow path: copies via getComponent, which denormalizes quantized sources and flattens InterleavedBufferAttribute ones.

Call-site semantics are preserved exactly:
- foliage.ts consumes the shared helper directly in bakeGeometry (its old copy always looped; the fast path returns identical values with independent storage).
- dungeon.ts and vale_cup_stadium.ts keep their thin in-place wrappers with the original early-out (skip when the attribute is missing or already plain non-normalized float32) and delegate only the copy.

The module deliberately imports three, so it is not a *_core pure core (RENDER_PURE_CORES) and is directly unit-tested instead, same precedent as src/render/characters/rig_merge.ts. The getComponent loops inside rig_merge.ts rebakeGeometry are intentionally left alone: that function applies per-attribute matrix transforms and keeps integer skin attributes integral, a different responsibility.

Note: a fourth copy of this recipe (toFloatUv in the static idle-pose bake) is in flight on #1877, which is not on this base yet. Once both land, that helper body can be replaced by this shared import as a drop-in (same signature and behavior).

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/attribute_float.test.ts tests/rig_merge.test.ts tests/nythraxis_raid.test.ts tests/vale_cup_render.test.ts tests/render_asset_preload.test.ts tests/architecture.test.ts` (6 files, 114 tests, green)
  - `npx tsc --noEmit` (clean)
  - `npm run ci:changed` (clean; explicit `biome check` over the five touched files: no errors, no format diffs)
  - QA gate: qa-checklist and frontend-seam-reviewer passes over the diff, 0 blocking / 0 should-fix findings
- Manual steps: none needed; all three call sites are build-time asset bakes, not per-frame paths.

New unit test tests/attribute_float.test.ts pins: the float32 fast path (value equality plus write-back isolation from the source array), normalized Uint16 denormalization into [0, 1], interleaved source flattening, and the combined normalized-interleaved meshopt shape.

---

## Checklist

### Quality

- [x] **Decisive tests added.** Local full `npm run gate` is affected by a known Windows CRLF fixture issue unrelated to this change; the commands above cover the touched surface and CI runs the authoritative gate.

### Cross-platform

- ~Tested on desktop and mobile~ N/A, no visual or behavior change.
- ~Accessible~ N/A, no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
