### PR TITLE
fix(sfx): scope SFX Studio publish inventory scan to the full catalog

### DIFF
--- a/scripts/sfx_studio/audio_io.mjs
+++ b/scripts/sfx_studio/audio_io.mjs
@@ -441,12 +441,12 @@ export async function analyzeLoopContinuity(path, channels) {
 }
 
 function publicPath(key, repoRoot = REPO_ROOT) {
-  const source = CATALOG.get(assertSfxKey(key));
+  assertSfxKey(key);
   const repo = realpathSync(repoRoot);
   const publicRoot = existingPlainDirectory(join(repo, 'public'), repo);
   const audioRoot = existingPlainDirectory(join(publicRoot, 'audio'), publicRoot);
   const sfxRoot = existingPlainDirectory(join(audioRoot, 'sfx'), audioRoot);
-  const discovered = discoverSfxTracks([source], sfxRoot);
+  const discovered = discoverSfxTracks([...CATALOG.values()], sfxRoot);
   if (discovered.errors.length) {
     throw new Error(`invalid published SFX inventory for ${key}: ${discovered.errors.join('; ')}`);
   }


### PR DESCRIPTION
## Summary
- `publicPath()` in `scripts/sfx_studio/audio_io.mjs` called `discoverSfxTracks` with a single-entry catalog array containing only the key being published, so every other fixed-catalog `mob_<family>_<action>.mp3` file already committed under `public/audio/sfx/` was misclassified as an unrecognized mob subfamily file and failed the publish/export inventory check for any unrelated key.
- Pass the full `CATALOG` instead so discovery consumes every fixed-catalog filename before falling through to the mob-subfamily pass.
- This was breaking `tests/sfx_studio.test.ts` and `tests/sfx_studio_server_security.test.ts` (and therefore the "PR gate (English-only legal)" CI job, since it runs the full PR-tier test suite) for every PR against `release/v0.26.0`, independent of any specific PR's own changes.

## Test plan
- [x] `npx vitest run tests/sfx_studio.test.ts tests/sfx_studio_server_security.test.ts` (60/60 passing, was 46/60 before the fix)
- [x] `npx tsc --noEmit`
- [x] `npx @biomejs/biome check scripts/sfx_studio/audio_io.mjs`
- [x] Confirmed the failure reproduces on unmodified `release/v0.26.0` (pre-existing, unrelated to any in-flight PR)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>