### PR TITLE
fix(sfx): scope SFX Studio publish discovery to the full catalog

### DIFF
--- a/scripts/sfx_studio/audio_io.mjs
+++ b/scripts/sfx_studio/audio_io.mjs
@@ -441,12 +441,12 @@ export async function analyzeLoopContinuity(path, channels) {
 }
 
 function publicPath(key, repoRoot = REPO_ROOT) {
-  const source = CATALOG.get(assertSfxKey(key));
+  assertSfxKey(key);
   const repo = realpathSync(repoRoot);
   const publicRoot = existingPlainDirectory(join(repo, 'public'), repo);
   const audioRoot = existingPlainDirectory(join(publicRoot, 'audio'), publicRoot);
   const sfxRoot = existingPlainDirectory(join(audioRoot, 'sfx'), audioRoot);
-  const discovered = discoverSfxTracks([source], sfxRoot);
+  const discovered = discoverSfxTracks(SFX, sfxRoot);
   if (discovered.errors.length) {
     throw new Error(`invalid published SFX inventory for ${key}: ${discovered.errors.join('; ')}`);
   }


### PR DESCRIPTION
## Summary

`publicPath()` in `scripts/sfx_studio/audio_io.mjs` calls `discoverSfxTracks([source], sfxRoot)` with a single-entry catalog array instead of the full `SFX` list, unlike the real build path (`manifest.mjs`), which passes the full catalog.

#1854 turned an `mob_*.mp3` file that matches neither a catalog entry nor the numbered subfamily pattern into a hard discovery error instead of a silent skip. That is correct for the real build path, which always sees the full catalog. But this narrower call site now fails on every OTHER mob family's files sitting in the same `public/audio/sfx` directory, not just the one key actually being published, since a one-element catalog can't recognize any of them.

This currently breaks 7 tests in `tests/sfx_studio_server_security.test.ts` and `tests/sfx_studio.test.ts` on a clean `release/v0.26.0` checkout, unrelated to any in-flight feature PR.

Fix: pass the full `SFX` catalog (already imported in this file) instead of `[source]`, matching how `manifest.mjs` calls the same function. Also dropped the now-unused `CATALOG.get(...)` lookup in favor of the `assertSfxKey` validation it already performed.

## Type of change

- [x] Bug fix

## How was this tested?

- Confirmed the failure reproduces on a clean `release/v0.26.0` checkout (no feature changes).
- `npx vitest run tests/sfx_studio_server_security.test.ts tests/sfx_studio.test.ts tests/sfx_manifest.test.ts` — 83 passing (was 7 failing).
- `npx tsc --noEmit` clean.
- `npm run gate` — PASS, all 11 steps green.

## Screenshots / recordings

N/A, build/test tooling only.

---
Checklist

Quality
- [x] Tests pass.
- [x] Typecheck passes.
- [x] Builds succeed.

Cross-platform
- ~Tested on desktop and mobile.~ N/A, build tooling only.

Localization (i18n)
- [x] N/A. No player-visible strings.

Hygiene
- [x] No secrets or .env committed.
- [x] No generated files hand-edited.