### PR TITLE
fix(sim): grant a brief aggro-immunity grace on resurrect

### DIFF
--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -165,6 +165,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     ghost: false,
     corpsePos: null,
     corpseInstanceId: null,
+    rezGraceUntil: 0,
     scale: 1,
     color: 0xffffff,
     skinCatalog: 'class',

--- a/src/sim/mob/locomotion.ts
+++ b/src/sim/mob/locomotion.ts
@@ -252,7 +252,7 @@ export function updateMob(ctx: SimContext, mob: Entity): void {
         let detected: Entity | null = null;
         let detectedD = Infinity;
         ctx.playerGrid.forEachInRadius(mob.pos.x, mob.pos.z, 25, (e, d2) => {
-          if (e.dead) return;
+          if (e.dead || ctx.time < e.rezGraceUntil) return;
           const radius = Math.max(
             4,
             Math.min(MAX_AGGRO_RADIUS, template.aggroRadius + (mob.level - e.level) * 1.5),
@@ -270,7 +270,10 @@ export function updateMob(ctx: SimContext, mob: Entity): void {
       let detected: Entity | null = null;
       let detectedD = Infinity;
       ctx.playerGrid.forEachInRadius(mob.pos.x, mob.pos.z, 25, (e, d2) => {
-        if (e.dead) return;
+        // A freshly-revived player is immune to fresh proximity aggro (REZ_GRACE_SECONDS,
+        // src/sim/spirit.ts): without this, resurrecting at a corpse inside the same pack
+        // that just killed them re-aggros instantly and chains repeat deaths.
+        if (e.dead || ctx.time < e.rezGraceUntil) return;
         if (isTrivialTo(mob, e)) return;
         let radius = Math.max(
           4,

--- a/src/sim/spirit.ts
+++ b/src/sim/spirit.ts
@@ -51,6 +51,10 @@ export const RES_HP_FRACTION = 0.5;
 // hp/mana AND inflicts Resurrection Sickness, so the penalty-free corpse run is the
 // reward for running your spirit all the way back.
 export const RES_HEALER_HP_FRACTION = 0.2;
+// How long (seconds) a freshly-revived player is immune to a mob newly noticing them
+// by proximity. Long enough to walk clear of (or fight off, at half hp) the pack that
+// likely just killed them, short enough that it is never a meaningful PvE shortcut.
+export const REZ_GRACE_SECONDS = 6;
 // Resurrection Sickness (display "The Keeper's Toll"), its level-scaled duration, and the
 // "survives death" predicate live in ./resurrection (a leaf module shared by every
 // death/respawn site). Re-export the id so it stays importable from here.
@@ -205,6 +209,7 @@ function reviveAt(
   p.ghost = false;
   p.corpsePos = null;
   p.corpseInstanceId = null;
+  p.rezGraceUntil = ctx.time + REZ_GRACE_SECONDS;
   p.pos = ctx.groundPos(pos.x, pos.z);
   p.prevPos = { ...p.pos };
   ctx.rebucket(p);

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -2087,6 +2087,13 @@ export interface Entity {
   // Null for world corpses and saved ghosts. Instance exits are recreated on
   // every claim, so stale corpse coordinates cannot match a recycled slot.
   corpseInstanceId: number | null;
+  // Sim time (ctx.time) until which a freshly-revived player is immune to a mob
+  // newly noticing them by proximity: without this, resurrecting at a corpse in a
+  // dense mob pack (the very pack that killed them) re-aggros instantly and chains
+  // repeat deaths. 0 for the living and for every non-player entity. Does not
+  // suppress threat already on a mob's hate table (death already clears that) or
+  // stop combat a player re-enters voluntarily. Owned by src/sim/spirit.ts.
+  rezGraceUntil: number;
   scale: number;
   color: number;
   skinCatalog: SkinCatalog; // player appearance catalog: class texture set or cosmetic body.

--- a/tests/parity/golden/entity_roster.json
+++ b/tests/parity/golden/entity_roster.json
@@ -425,7 +425,7 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 411,
-      "state": "9616c11e",
+      "state": "e847380a",
       "events": "ae7a3896",
       "rng": {
         "draws": 4,
@@ -542,6 +542,7 @@
           },
           "potionCooldownUntil": -1,
           "resourceType": "rage",
+          "rezGraceUntil": 6.25,
           "spawnPos": {
             "x": 2,
             "y": 1.5,
@@ -569,7 +570,7 @@
       "tick": 6,
       "time": 0.3,
       "nextId": 411,
-      "state": "7bbe7b61",
+      "state": "e2ad6dbb",
       "events": "741638a5",
       "rng": {
         "draws": 4,
@@ -580,7 +581,7 @@
       "tick": 7,
       "time": 0.35,
       "nextId": 411,
-      "state": "ee7066d9",
+      "state": "96020e33",
       "events": "741638a5",
       "rng": {
         "draws": 4,
@@ -697,6 +698,7 @@
           },
           "potionCooldownUntil": -1,
           "resourceType": "rage",
+          "rezGraceUntil": 6.25,
           "spawnPos": {
             "x": 2,
             "y": 1.5,

--- a/tests/spirit.test.ts
+++ b/tests/spirit.test.ts
@@ -7,9 +7,11 @@ import { describe, expect, it } from 'vitest';
 import {
   DELVES,
   DUNGEON_X_THRESHOLD,
+  MOBS,
   OVERWORLD_GRAVEYARDS,
   SPIRIT_HEALER_NPC_ID,
 } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
 import { Sim } from '../src/sim/sim';
 import {
   CORPSE_REZ_RANGE,
@@ -17,6 +19,7 @@ import {
   RES_HEALER_HP_FRACTION,
   RES_HP_FRACTION,
   RESURRECTION_SICKNESS_ID,
+  REZ_GRACE_SECONDS,
   SPIRIT_HEALER_RANGE,
 } from '../src/sim/spirit';
 import { dist2d, type Entity } from '../src/sim/types';
@@ -168,6 +171,44 @@ describe('spirit: resurrect at corpse', () => {
     sim.resurrectAtCorpse();
     expect(p.dead).toBe(true);
     expect(p.ghost).toBe(true);
+  });
+});
+
+describe('spirit: post-resurrect aggro grace', () => {
+  // An idle hostile mob standing right on top of a spot, so it detects on the very
+  // first tick if nothing suppresses it.
+  function spawnAdjacentWolf(sim: AnySim, pos: { x: number; y: number; z: number }): AnyEntity {
+    const mob = createMob(sim.nextId++, MOBS['forest_wolf'], 1, { ...pos }) as AnyEntity;
+    mob.hostile = true;
+    mob.aiState = 'idle';
+    sim.addEntity(mob);
+    return mob;
+  }
+
+  it('does not re-aggro a mob standing on the corpse right after a corpse-run resurrect', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(1);
+    const p = sim.player as AnyEntity;
+    p.dead = true;
+    sim.releaseSpirit();
+    const corpse = { ...(p.corpsePos as { x: number; y: number; z: number }) };
+    const wolf = spawnAdjacentWolf(sim, corpse);
+    p.pos = { ...corpse };
+    p.prevPos = { ...p.pos };
+    sim.rebucket(p);
+    sim.resurrectAtCorpse();
+    expect(p.dead).toBe(false);
+    expect(p.rezGraceUntil).toBeGreaterThan(sim.time);
+
+    for (let i = 0; i < 20; i++) sim.tick();
+    expect(wolf.aiState).toBe('idle');
+    expect(wolf.aggroTargetId).toBeNull();
+
+    // once the grace window elapses, the same mob aggros normally
+    const ticksToElapse = Math.ceil(REZ_GRACE_SECONDS / (1 / 20)) + 5;
+    for (let i = 0; i < ticksToElapse; i++) sim.tick();
+    expect(wolf.aiState).not.toBe('idle');
+    expect(wolf.aggroTargetId).toBe(p.id);
   });
 });
 


### PR DESCRIPTION
## Summary

From the New Player Experience feedback doc, item 4: "When resurrecting at corpse you re-aggro mobs easily (annoying repeat new player deaths)."

`resurrectAtCorpse` (`src/sim/spirit.ts`) revives a player exactly where their ghost is standing, at 50% hp/mana, with no protection. In a dense mob pack (e.g. the level 1-3 wolf field), the same pack that just killed the player is often still standing right on top of the corpse, and passive proximity aggro (`src/sim/mob/locomotion.ts`) immediately re-detects and re-aggros the freshly-revived player, chaining repeat deaths. Note: threat tables are already cleared on death (`src/sim/combat/damage.ts`), so this is purely a fresh-proximity-detection problem, not a stale-threat one.

Adds a short (`REZ_GRACE_SECONDS = 6`) post-resurrection aggro-immunity window: a new `Entity.rezGraceUntil` sim-time field, set on every revive path (`reviveAt` in `src/sim/spirit.ts`, shared by corpse-run, Spirit Healer, and instance-reentry resurrection), and checked by the two passive proximity-detection loops in `src/sim/mob/locomotion.ts`. It only suppresses a mob *newly noticing* the player; it does not affect mobs already in combat, does not touch threat tables, and does not block the player from re-engaging voluntarily (e.g. via auto-attack).

## Related issues

Item 4 of the attached New Player Experience feedback (level 1-3 UX pass).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/spirit.test.ts tests/parity/parity.test.ts tests/world_api_parity.test.ts` (353 passed), `npx tsc --noEmit -p .` (clean), `npx @biomejs/biome check --write` on changed files (clean).
- Manual steps: added a new test (`spirit: post-resurrect aggro grace`) that spawns an idle hostile mob directly on the corpse, resurrects, and asserts the mob stays idle for the grace window and re-aggros normally once it elapses. Regenerated the one affected parity golden (`tests/parity/golden/entity_roster.json`) via `UPDATE_PARITY=1`, since `Entity` gained a field.

## Screenshots / recordings

N/A. Pure `src/sim/` behavior change, no player-visible UI (nothing new renders; the fix only changes whether a mob decides to aggro).

## Diagram

```mermaid
sequenceDiagram
    participant P as Player
    participant S as spirit.ts (reviveAt)
    participant E as Entity.rezGraceUntil
    participant M as mob/locomotion.ts (idle scan)

    P->>S: resurrectAtCorpse()
    S->>E: rezGraceUntil = ctx.time + REZ_GRACE_SECONDS
    S-->>P: dead=false, ghost=false, hp=50%

    loop every idle tick, nearby mobs
        M->>E: is ctx.time < rezGraceUntil?
        alt still in grace window
            M-->>M: skip (player invisible to fresh proximity aggro)
        else grace elapsed
            M->>P: normal aggro pickup resumes
        end
    end
```

---

## Checklist

### Quality

- [x] Ran the relevant test files, `tsc`, and biome directly (couldn't run the full `npm run gate` in this environment; dependencies were symlinked from a sibling checkout for testing).

### Cross-platform

- N/A. No UI/render change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed.
- [x] No generated files hand-edited.
