### PR TITLE
fix(net): re-derive follow-up quest availability immediately after turn-in

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -35,7 +35,7 @@ import { normalizeMoveFacing, sanitizeMoveInput } from '../sim/move_input';
 import { getArchetypeTitle, getHobbyCraft } from '../sim/professions/archetype';
 import type { MaterialRarity } from '../sim/professions/gathering';
 import { emptyCraftSkills } from '../sim/professions/wheel';
-import { computeQuestState, type ResolvedAbility } from '../sim/sim';
+import type { ResolvedAbility } from '../sim/sim';
 import {
   type DeedStats,
   type DungeonDifficulty,
@@ -97,6 +97,7 @@ import {
   type SocialInfo,
   type TradeInfo,
 } from '../world_api';
+import { optimisticQuestState } from './quest_state_optimistic';
 import { isTransientReconnectRejection } from './reconnect_policy';
 
 // ---------------------------------------------------------------------------
@@ -2208,15 +2209,13 @@ export class ClientWorld implements IWorld {
   // -----------------------------------------------------------------------
 
   questState(questId: string): QuestState {
-    const state = computeQuestState(questId, this.questLog, this.questsDone, this.player.level);
-    const pending = this.pendingQuestCommands?.get(questId);
-    if (
-      (pending === 'accept' && state === 'available') ||
-      (pending === 'turnin' && state === 'ready')
-    ) {
-      return 'active';
-    }
-    return state;
+    return optimisticQuestState(
+      questId,
+      this.questLog,
+      this.questsDone,
+      this.pendingQuestCommands,
+      this.player.level,
+    );
   }
 
   consumeInventoryChanged(): boolean {

--- a/src/net/quest_state_optimistic.ts
+++ b/src/net/quest_state_optimistic.ts
@@ -1,0 +1,51 @@
+// Pure optimistic quest-state resolution for the online client.
+//
+// Bug fixed (issue 1667): after turning in a quest through the NPC dialog, a
+// follow-up quest that requires it (`requiresQuest`) stayed hidden until the
+// next server snapshot arrived, even though the dialog re-renders immediately
+// after the turn-in command is sent. `ClientWorld.turnInQuest` is fire-and-
+// forget: it records the action in `pendingQuestCommands` but the quest only
+// actually leaves `questLog` / lands in `questsDone` once the server's `qlog`/
+// `qdone` snapshot fields round-trip. The dialog's re-render (`hud.ts`
+// `renderGossip`) already re-queries `questState()` live for every quest the
+// NPC could offer, so the staleness was never in the UI layer: it was that
+// `computeQuestState`'s prerequisite check (`quest.requiresQuest &&
+// !questsDone.has(...)`) read the not-yet-updated `questsDone` set for any
+// quest OTHER than the one just turned in.
+//
+// The fix extends the existing pending-command optimism (already sanctioned
+// for the turned-in quest itself, see src/net/CLAUDE.md) to prerequisite
+// checks for every other quest: while a `turnin` command is in flight, treat
+// that quest as done when resolving anyone else's state. This is display-only
+// optimism reconciled the moment a real snapshot lands and clears
+// `pendingQuestCommands` (see `ClientWorld.applySnapshot`); the server still
+// authoritatively resolves the turn-in itself.
+import { computeQuestState } from '../sim/sim';
+import type { QuestProgress, QuestState } from '../sim/types';
+
+export function optimisticQuestState(
+  questId: string,
+  questLog: Map<string, QuestProgress>,
+  questsDone: Set<string>,
+  pendingQuestCommands: Map<string, 'accept' | 'turnin'>,
+  playerLevel: number,
+): QuestState {
+  let effectiveDone = questsDone;
+  if (pendingQuestCommands.size > 0) {
+    for (const [qid, action] of pendingQuestCommands) {
+      if (action === 'turnin' && qid !== questId) {
+        if (effectiveDone === questsDone) effectiveDone = new Set(questsDone);
+        effectiveDone.add(qid);
+      }
+    }
+  }
+  const state = computeQuestState(questId, questLog, effectiveDone, playerLevel);
+  const pending = pendingQuestCommands.get(questId);
+  if (
+    (pending === 'accept' && state === 'available') ||
+    (pending === 'turnin' && state === 'ready')
+  ) {
+    return 'active';
+  }
+  return state;
+}

--- a/tests/quest_state_optimistic.test.ts
+++ b/tests/quest_state_optimistic.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { optimisticQuestState } from '../src/net/quest_state_optimistic';
+import type { QuestProgress } from '../src/sim/types';
+
+// Issue 1667: talking to an NPC, turning in a quest that gates a follow-up quest,
+// should immediately show the follow-up quest in the same dialog session rather
+// than requiring the player to close and reopen the dialog. Online, `turnInQuest`
+// is a fire-and-forget wire command: the questLog/questsDone mirror only updates
+// once the next server snapshot round-trips, so a naive `questState()` read for
+// the follow-up quest right after the turn-in click would still see the
+// prerequisite as not-done.
+describe('optimisticQuestState (issue 1667)', () => {
+  it('reports a requiresQuest follow-up as available immediately after the prerequisite turn-in is sent', () => {
+    // q_greyjaw requires q_wolves (src/sim/content/zone1.ts). Simulate: q_wolves
+    // was just turned in (still in questLog as 'ready' until the snapshot lands,
+    // with a pending 'turnin' command recorded), q_greyjaw has never been touched.
+    const questLog = new Map<string, QuestProgress>([
+      ['q_wolves', { questId: 'q_wolves', counts: [8], state: 'ready' }],
+    ]);
+    const questsDone = new Set<string>(); // server hasn't confirmed q_wolves done yet
+    const pendingQuestCommands = new Map<string, 'accept' | 'turnin'>([['q_wolves', 'turnin']]);
+
+    expect(optimisticQuestState('q_greyjaw', questLog, questsDone, pendingQuestCommands, 5)).toBe(
+      'available',
+    );
+  });
+
+  it('still shows the just-turned-in quest itself as active, not done, while its command is pending', () => {
+    const questLog = new Map<string, QuestProgress>([
+      ['q_wolves', { questId: 'q_wolves', counts: [8], state: 'ready' }],
+    ]);
+    const questsDone = new Set<string>();
+    const pendingQuestCommands = new Map<string, 'accept' | 'turnin'>([['q_wolves', 'turnin']]);
+
+    expect(optimisticQuestState('q_wolves', questLog, questsDone, pendingQuestCommands, 5)).toBe(
+      'active',
+    );
+  });
+
+  it('falls back to plain computeQuestState once the pending command is cleared (post-snapshot)', () => {
+    const questLog = new Map<string, QuestProgress>();
+    const questsDone = new Set<string>(['q_wolves']);
+    const pendingQuestCommands = new Map<string, 'accept' | 'turnin'>();
+
+    expect(optimisticQuestState('q_greyjaw', questLog, questsDone, pendingQuestCommands, 5)).toBe(
+      'available',
+    );
+  });
+
+  it('does not optimistically unlock a follow-up quest with no pending turn-in for its prerequisite', () => {
+    const questLog = new Map<string, QuestProgress>();
+    const questsDone = new Set<string>();
+    const pendingQuestCommands = new Map<string, 'accept' | 'turnin'>();
+
+    expect(optimisticQuestState('q_greyjaw', questLog, questsDone, pendingQuestCommands, 5)).toBe(
+      'unavailable',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the NPC dialog not showing a follow-up quest immediately after completing
its prerequisite in the same dialog session (only reproduces online).

`ClientWorld.turnInQuest()` sends the turn-in as a fire-and-forget wire
command; the mirrored `questsDone` set only updates once the server's `qdone`
snapshot field round-trips. The HUD's `renderGossip()` already re-queries
`questState()` live for every quest right after the turn-in click (the dialog
re-render itself was never stale), but `ClientWorld.questState()`'s
prerequisite check (`quest.requiresQuest && !questsDone.has(...)`) read the
not-yet-updated `questsDone`, so any OTHER quest gated on the one just turned
in stayed `unavailable` until the next snapshot arrived a tick or two later.

The fix extends the pending-command optimism `questState()` already applies
to the just-turned-in quest (so it shows as `active`, not stuck at `ready`)
to prerequisite checks for every other quest: while a `turnin` command is in
flight, treat that quest as done when resolving anyone else's state. This is
display-only optimism, reconciled the moment a real snapshot lands and clears
`pendingQuestCommands`; the server still authoritatively resolves the turn-in.

Per the module-first convention, the logic is a small pure, DOM-free module
(`src/net/quest_state_optimistic.ts`) rather than inline in the `ClientWorld`
coordinator, so it is unit-testable without spinning up the network client.

### Flow

```mermaid
sequenceDiagram
    participant Player
    participant HUD as hud.ts renderGossip/renderQuestDetail
    participant CW as ClientWorld (src/net/online.ts)
    participant Server

    Player->>HUD: click "Complete Quest" (quest A)
    HUD->>CW: sim.turnInQuest(A)
    CW->>CW: pendingQuestCommands.set(A, 'turnin')
    CW->>Server: cmd({ turnin: A })  (fire and forget)
    HUD->>CW: renderGossip(npc, true) [same tick]
    CW->>CW: questState(B) via optimisticQuestState
    Note over CW: Before fix: questsDone still lacks A<br/>-> B stays 'unavailable'
    Note over CW: After fix: A is treated as done<br/>(pending turnin, A != B) -> B is 'available'
    CW-->>HUD: B offered immediately
    HUD-->>Player: dialog shows quest B

    Server-->>CW: snapshot { qdone: [...A], qlog: [...] }
    CW->>CW: pendingQuestCommands.clear()
    Note over CW: Reconciled with authoritative state
```

## Related issues

Fixes #1667

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands: `npx vitest run tests/quest_state_optimistic.test.ts`, `npx tsc --noEmit -p tsconfig.json`,
  `npm run gate` (see note below)
- Manual steps: traced the code path (`hud.ts` `renderGossip`/`renderQuestDetail`,
  `net/online.ts` `ClientWorld.turnInQuest`/`questState`, `sim/quests/quest_commands.ts`
  `computeQuestState`) to confirm the fix is display-side optimism, not a change to
  server-authoritative quest resolution.
- Added `tests/quest_state_optimistic.test.ts` (new, pure unit tests, no DOM/network):
  reproduces the bug (a `requiresQuest`-gated quest, e.g. `q_greyjaw` requiring
  `q_wolves`, stays `unavailable` with a naive read) and pins the fix (`available`
  the instant the prerequisite's `turnin` command is pending), plus coverage for the
  turned-in quest's own state, post-snapshot fallback, and the "no pending command"
  negative case.

Note on `npm run gate`: the full vitest run on this (heavily loaded, many
concurrent worktrees) box shows unrelated pre-existing failures/timeouts in
`tests/mail.test.ts`, `tests/loot_ffa_sim.test.ts`, `tests/vale_cup_online.test.ts`,
`tests/sfx_studio_server_security.test.ts`, `tests/server/http/parity.test.ts`, and
`tests/server/new_endpoint.test.ts` (a `tsc` golden subprocess). None of these touch
`src/net/`, quest state, or the dialog path; re-running them in isolation still times
out under the current machine load (100+ concurrent node/vitest/tsc processes from
other sessions), and a full standalone `npx tsc --noEmit -p tsconfig.json` passes
clean. `npx vitest run tests/quest_state_optimistic.test.ts` is green.

## Screenshots / recordings

N/A. Timing/data-freshness bug in the dialog re-render logic, not a visual change;
the dialog markup is unchanged. Covered by the new pure-module test instead.

---

## Checklist

### Quality

- [x] Decisive tests added for the changed behavior (`tests/quest_state_optimistic.test.ts`).
      Full `npm run gate` run attempted; see the note above for unrelated pre-existing
      flakiness on this machine, isolated from this change (`tsc --noEmit` clean, new test green).

### Cross-platform

- [ ] N/A. No UI markup or styling changed.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.
