### PR TITLE
fix(audio): restore no-repeat-biased random SFX variant selection

### DIFF
--- a/src/game/sfx.ts
+++ b/src/game/sfx.ts
@@ -103,7 +103,7 @@ class Sfx {
   private loading = new Map<string, Promise<AudioBuffer | null>>();
   private failedLoads = new Set<string>();
   private pendingOneShots = new Set<string>();
-  private variantCursor = new Map<string, number>();
+  private lastVariant = new Map<string, number>(); // last played index per key (no-repeat-biased random)
   private pendingLoops = new Map<string, PendingLoop>();
   private pendingLoopLoads = new Map<string, string>();
   private pendingLoopVariants = new Map<string, number>();
@@ -171,19 +171,39 @@ class Sfx {
     return this.entry(key)?.playbackRate ?? 1;
   }
 
+  // Weighted so the immediately previous variant is heavily deprioritized, not
+  // outright excluded. A hard exclusion on a 2-take pool degenerates into rigid
+  // A-B-A-B alternation, which reads as just as metronomic as the round-robin
+  // it replaces; a low but nonzero weight keeps a small pool sounding genuinely
+  // random while still making an audible back-to-back repeat rare.
+  private static readonly REPEAT_VARIANT_WEIGHT = 0.15;
+
+  /** No-repeat-biased random variant selection. Picks a weighted-random usable
+   *  variant each play; the immediately previous one is downweighted (not
+   *  excluded) so it can still recur occasionally, just rarely, instead of
+   *  double-hitting on a predictable cadence. A variant that failed to load is
+   *  skipped entirely, same as the old round-robin scan. */
   private nextVariantIndex(key: string): number {
     const count = Math.max(1, this.entry(key)?.variants.length ?? 1);
-    const start = (this.variantCursor.get(key) ?? 0) % count;
-    for (let offset = 0; offset < count; offset++) {
-      const index = (start + offset) % count;
-      if (!this.failedLoads.has(assetCacheKey(key, index))) return index;
+    const usable: number[] = [];
+    for (let index = 0; index < count; index++) {
+      if (!this.failedLoads.has(assetCacheKey(key, index))) usable.push(index);
     }
-    return start;
+    if (usable.length === 0) return 0;
+    if (usable.length === 1) return usable[0];
+    const last = this.lastVariant.get(key);
+    const weights = usable.map((index) => (index === last ? Sfx.REPEAT_VARIANT_WEIGHT : 1));
+    const total = weights.reduce((sum, weight) => sum + weight, 0);
+    let roll = Math.random() * total;
+    for (let i = 0; i < usable.length; i++) {
+      roll -= weights[i];
+      if (roll <= 0) return usable[i];
+    }
+    return usable[usable.length - 1];
   }
 
   private commitVariant(key: string, variantIndex: number): void {
-    const count = Math.max(1, this.entry(key)?.variants.length ?? 1);
-    this.variantCursor.set(key, (variantIndex + 1) % count);
+    this.lastVariant.set(key, variantIndex);
   }
 
   private loadBuffer(key: string, variantIndex = 0): Promise<AudioBuffer | null> {

--- a/tests/sfx.test.ts
+++ b/tests/sfx.test.ts
@@ -195,8 +195,9 @@ describe('hasVariants', () => {
 // crit-only cue like hurt has exactly one trigger, so it can lose the race
 // to fetch+decode unless warmed ahead of time or checked before playing).
 // Both must account for EVERY variant a key can have, not just index 0:
-// playAt round-robins variants, so a two-take family (mob_dragonkin_hurt,
-// mob_spider_hurt) can have variant 0 warm and variant 1 still cold.
+// playAt no-repeat-randoms across variants, so a two-take family
+// (mob_dragonkin_hurt, mob_spider_hurt) can have variant 0 warm and variant 1
+// still cold.
 describe('isBuffered/preload', () => {
   it('reports false until every variant of a multi-take key is buffered', () => {
     const key = 'mob_dragonkin_hurt';

--- a/tests/sfx_loading.test.ts
+++ b/tests/sfx_loading.test.ts
@@ -517,9 +517,16 @@ describe('sampled SFX loading', () => {
     expect(ctx.sources[0].started).toBe(true);
   });
 
-  it('cycles ordered runtime takes only when a one-shot source is accepted', () => {
+  it('no-repeat-randoms ordered runtime takes only when a one-shot source is accepted', () => {
     vi.stubGlobal('fetch', vi.fn());
+    // The previous variant is downweighted (weight 0.15 of 1), not excluded, so
+    // this needs three concrete roll values rather than one flat stub: 0 with no
+    // prior pick lands on index 0 (equal weights); 0.9 against weights [0.15, 1]
+    // (total 1.15) clears the first bucket and lands on index 1; 0 against
+    // weights [1, 0.15] (total 1.15) lands back on index 0 immediately.
+    const random = vi.spyOn(Math, 'random');
     const { player, ctx } = startWithStartupCached();
+    random.mockReturnValueOnce(0).mockReturnValueOnce(0.9).mockReturnValueOnce(0);
     const state = internals(player);
     const key = 'ui_click';
     const second = { duration: 0.6 } as AudioBuffer;
@@ -552,9 +559,87 @@ describe('sampled SFX loading', () => {
     expect(ctx.sources.map((source) => source.buffer)).toEqual([BUFFER, second, BUFFER]);
   });
 
+  function threeVariantClips(state: SfxInternals, key: keyof typeof SFX_CLIPS) {
+    const second = { duration: 0.6 } as AudioBuffer;
+    const third = { duration: 0.7 } as AudioBuffer;
+    const entry = SFX_CLIPS[key];
+    state.clips = {
+      ...state.clips,
+      [key]: {
+        ...entry,
+        variants: [
+          { ...entry.variants[0], id: '1' },
+          {
+            id: '2',
+            url: `/audio/sfx/blobs/${'a'.repeat(64)}.mp3`,
+            bytes: 1,
+            sha256: 'a'.repeat(64),
+          },
+          {
+            id: '3',
+            url: `/audio/sfx/blobs/${'b'.repeat(64)}.mp3`,
+            bytes: 1,
+            sha256: 'b'.repeat(64),
+          },
+        ],
+      },
+    };
+    state.buffers.set(`${key}:1`, second);
+    state.buffers.set(`${key}:2`, third);
+    return { second, third };
+  }
+
+  it('lands on a distinct variant across a 3-take pool when rolls clear the repeat weight', () => {
+    vi.stubGlobal('fetch', vi.fn());
+    const random = vi.spyOn(Math, 'random');
+    const { player, ctx } = startWithStartupCached();
+    const key = 'ui_click';
+    const { second, third } = threeVariantClips(internals(player), key);
+
+    // Drives every "which weight bucket does the roll land in" branch: first
+    // pick unweighted (equal odds over [0,1,2]); each following roll is high
+    // enough to clear the previous index's downweighted (0.15) bucket, landing
+    // on a fresh variant instead. See REPEAT_VARIANT_WEIGHT in sfx.ts.
+    random.mockReturnValueOnce(0); // equal weights [1,1,1] -> index 0
+    random.mockReturnValueOnce(0.3); // weights [0.15,1,1] clears bucket 0 -> index 1
+    random.mockReturnValueOnce(0.9); // weights [1,0.15,1] clears buckets 0-1 -> index 2
+    random.mockReturnValueOnce(0); // weights [1,1,0.15] -> index 0
+
+    for (let i = 0; i < 4; i++) player.playUi(key, { jitter: false });
+
+    const played = ctx.sources.map((source) => source.buffer);
+    expect(played).toEqual([BUFFER, second, third, BUFFER]);
+    for (let i = 1; i < played.length; i++) expect(played[i]).not.toBe(played[i - 1]);
+  });
+
+  it('can still repeat the immediately previous variant on a low roll, unlike hard exclusion', () => {
+    vi.stubGlobal('fetch', vi.fn());
+    const random = vi.spyOn(Math, 'random');
+    const { player, ctx } = startWithStartupCached();
+    const key = 'ui_click';
+    threeVariantClips(internals(player), key);
+
+    random.mockReturnValueOnce(0); // equal weights [1,1,1] -> index 0
+    // weights [0.15,1,1], total 2.15: a roll under 0.15 / 2.15 lands back in
+    // the downweighted bucket 0, repeating the immediately previous variant.
+    random.mockReturnValueOnce(0.05);
+
+    player.playUi(key, { jitter: false });
+    player.playUi(key, { jitter: false });
+
+    const played = ctx.sources.map((source) => source.buffer);
+    expect(played).toEqual([BUFFER, BUFFER]);
+  });
+
   it('does not advance the ordered take when cooldown rejects a positional play', () => {
     vi.stubGlobal('fetch', vi.fn());
+    // nextVariantIndex is called on every attempt, including a cooldown-rejected
+    // one, but commitVariant only fires once the play is accepted. So the
+    // rejected middle call still consumes a roll (value irrelevant, it is never
+    // committed) between the two that matter: see the weighting comment above.
+    const random = vi.spyOn(Math, 'random');
     const { player, ctx } = startWithStartupCached();
+    random.mockReturnValueOnce(0).mockReturnValueOnce(0.5).mockReturnValueOnce(0.9);
     const state = internals(player);
     const key = 'combat_crit';
     const second = { duration: 0.6 } as AudioBuffer;
@@ -590,7 +675,12 @@ describe('sampled SFX loading', () => {
 
   it('pins a loop to one runtime take while independent loop slots advance the cycle', () => {
     vi.stubGlobal('fetch', vi.fn());
+    // A reused loop id (the second 'cast:first' call) skips variant selection
+    // entirely (its slot already exists), so only two rolls happen: one for
+    // the id's first-ever pick, one for the second, distinct loop id.
+    const random = vi.spyOn(Math, 'random');
     const { player, ctx } = startWithStartupCached();
+    random.mockReturnValueOnce(0).mockReturnValueOnce(0.9);
     const state = internals(player);
     const key = 'cast_fire';
     const second = { duration: 0.6 } as AudioBuffer;


### PR DESCRIPTION
## Summary

#1818 (the SFX Studio production overhaul) replaced the no-repeat-random variant picker from #1771 with a plain sequential cursor: `nextVariantIndex`/`commitVariant` just incremented 1, 2, 3, 1, 2... This wasn't a deliberate change, it was collateral damage from a from-scratch rewrite of the buffer/loading model (`variants: Map<string, AudioBuffer[]>` became `clips: Record<string, SfxEntry>` plus on-demand `buffers`/`loading` maps), but it turned every multi-take SFX, most audibly footsteps, into a metronomic cadence instead of sounding organic.

This restores randomized selection, adapted to the current architecture rather than #1771's original shape. It's weighted rather than hard-excluded this time: the immediately previous variant gets a low (`0.15`) weight instead of zero. A hard exclusion on a 2-take pool degenerates into rigid A-B-A-B alternation, which is itself still metronomic, so a low but nonzero weight keeps a small pool sounding genuinely random while an audible back-to-back repeat stays rare. A variant that failed to load is still skipped outright (matching the existing scan behavior; #1771's original didn't need this, lazy loading didn't exist yet).

## Type of change

- [x] Bug fix

## How was this tested?

- `npx vitest run tests/sfx.test.ts tests/sfx_loading.test.ts` — 34 passing, 10 consecutive reruns with zero flakiness (deterministic via `Math.random` stubs, not statistical).
- Updated the three `sfx_loading.test.ts` tests that pinned the old sequential order to the new weighted rolls (with the exact bucket-boundary math documented inline).
- Added two decisive tests: one proving distinct variants land correctly across a 3-take pool when rolls clear the repeat-weight bucket, one proving an occasional repeat is still reachable (not hard-excluded) on a low roll, exercising the actual "some randomness even at 2 variants" property this PR restores.
- `npx tsc --noEmit` clean.
- `npm run gate` — PASS, all 11 steps green, run in isolation.

## Screenshots / recordings

N/A, audio-only behavior change, nothing visual.

---
Checklist

Quality
- [x] Tests pass.
- [x] Typecheck passes.
- [x] Builds succeed.

Cross-platform
- ~Tested on desktop and mobile.~ N/A, no UI/render change.

Localization (i18n)
- [x] N/A. No player-visible strings.

Hygiene
- [x] No secrets or .env committed.
- [x] No generated files hand-edited.