### PR TITLE
fix(sim): credit heroic dungeon marks even when kill-credit resolution fails

### DIFF
--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -634,6 +634,22 @@ function reflectSpellWard(
   );
 }
 
+// Player ids (pets resolved to their owner) still on the mob's hate table at the
+// instant it dies, snapshotted BEFORE handleDeath clears the table. Mirrors
+// worldBossLootContributors's owner-resolution rule. Used as a fallback reward-
+// eligibility signal (see awardHeroicMarks call below): a party that actually
+// fought the boss must not lose its heroic marks just because the tap holder or
+// killing blow's credit failed to resolve to a live, connected player at the
+// exact death tick (a disconnect/reconnect racing the last hit).
+function threatContributorIds(ctx: SimContext, mob: Entity): Set<number> {
+  const out = new Set<number>();
+  for (const attackerId of mob.threat.keys()) {
+    const attacker = ctx.entities.get(attackerId);
+    out.add(attacker && attacker.ownerId !== null ? attacker.ownerId : attackerId);
+  }
+  return out;
+}
+
 export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): void {
   e.dead = true;
   e.hp = 0;
@@ -754,6 +770,9 @@ export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): 
       e.respawnTimer = Infinity;
       ctx.despawnSummonedAdds(e);
     }
+    // Snapshot combat contributors before the hate table is cleared below: the
+    // heroic-mark award needs this even when kill-credit resolution (below) fails.
+    const heroicDamagerIds = threatContributorIds(ctx, e);
     e.aggroTargetId = null;
     clearThreat(e);
     if (e.ownerId !== null) {
@@ -855,7 +874,7 @@ export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): 
     // Settle the heroic reward and its realm-reset lockout together. This runs
     // even without player credit so the owning group cannot dodge the lockout;
     // only the participation snapshot above receives marks.
-    ctx.awardHeroicMarks(e, heroicRewardRecipients);
+    ctx.awardHeroicMarks(e, heroicRewardRecipients, heroicDamagerIds);
     // Nythraxis normal and heroic raid lockouts use a wider room sweep than
     // generic dungeon claims. Run it after heroic settlement so its lock stamp
     // cannot make first-clear participants look previously rewarded.

--- a/src/sim/instances/dungeons.ts
+++ b/src/sim/instances/dungeons.ts
@@ -501,7 +501,21 @@ function heroicRewardWindowToken(lockedUntil: number): string {
 // authoritative lockout boundary the only income gate and removes the former
 // UTC-day mismatch. Marks go straight into inventory, so corpse cleanup, a UI
 // failure, or logout cannot persist an entitlement without its reward.
-export function awardHeroicMarks(ctx: SimContext, mob: Entity, recipients: PlayerMeta[]): void {
+//
+// `recipients` is the kill-credit participation snapshot (tap/killer resolved to
+// a live, connected player); `damagerIds` is the boss's hate-table contributors
+// (pets resolved to owner), snapshotted before handleDeath clears it. Kill-credit
+// resolution can legitimately come up empty on a clean, fully-party-fought kill
+// (the tap holder or killing blow's source disconnects/reconnects at the exact
+// death tick), which must not zero the whole group's marks: a lockout recipient
+// who genuinely fought the boss (on the hate table) still earns their mark even
+// when `recipients` is empty or missing them.
+export function awardHeroicMarks(
+  ctx: SimContext,
+  mob: Entity,
+  recipients: PlayerMeta[],
+  damagerIds: ReadonlySet<number>,
+): void {
   const inst = ctx.instances.find((i) => i.partyKey !== null && i.mobIds.includes(mob.id));
   if (!inst || inst.difficulty !== 'heroic') return;
   const tuning = HEROIC_DUNGEON_TUNING[inst.dungeonId];
@@ -510,7 +524,10 @@ export function awardHeroicMarks(ctx: SimContext, mob: Entity, recipients: Playe
   const rewardWindow = heroicRewardWindowToken(lockedUntil);
   const rewardIds = new Set(recipients.map((meta) => meta.entityId));
   const lockoutRecipients = new Map<number, PlayerMeta>();
-  for (const meta of instanceLockoutMetas(ctx, inst)) lockoutRecipients.set(meta.entityId, meta);
+  for (const meta of instanceLockoutMetas(ctx, inst)) {
+    lockoutRecipients.set(meta.entityId, meta);
+    if (damagerIds.has(meta.entityId)) rewardIds.add(meta.entityId);
+  }
   // A tap holder who left both party and instance before the kill remains in
   // the death snapshot and must receive the same lockout as their reward.
   for (const meta of recipients) lockoutRecipients.set(meta.entityId, meta);

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -7308,8 +7308,8 @@ export class Sim {
 
   // Owned by instances/dungeons (heroic final-boss reward + lockout settlement);
   // the C1 death hub reaches it through the seam, this delegate keeps the facade.
-  awardHeroicMarks(mob: Entity, recipients: PlayerMeta[]): void {
-    awardHeroicMarksImpl(this.ctx, mob, recipients);
+  awardHeroicMarks(mob: Entity, recipients: PlayerMeta[], damagerIds: ReadonlySet<number>): void {
+    awardHeroicMarksImpl(this.ctx, mob, recipients, damagerIds);
   }
 
   // Heroic Quartermaster purchase (owned by instances/heroic_vendor.ts): the

--- a/src/sim/sim_context.ts
+++ b/src/sim/sim_context.ts
@@ -242,7 +242,7 @@ export interface SimContextCallbacks {
   leaveDungeon(pid?: number): void;
   dungeonDifficulty(pid?: number): DungeonDifficulty;
   setDungeonDifficulty(difficulty: DungeonDifficulty, pid?: number): void;
-  awardHeroicMarks(mob: Entity, recipients: PlayerMeta[]): void;
+  awardHeroicMarks(mob: Entity, recipients: PlayerMeta[], damagerIds: ReadonlySet<number>): void;
 
   // C1 damage/death hub + the casting/leash/arena/duel/fiesta/loot teardown it
   // drives mid-tick. `dealDamage` is the post-mitigation entry (crit/dodge/miss and

--- a/tests/dungeons.test.ts
+++ b/tests/dungeons.test.ts
@@ -937,6 +937,50 @@ describe('dungeons: heroic daily lockouts', () => {
     expect(sim.players.get(member)!.raidLockouts.has('hollow_crypt:heroic')).toBe(true);
   });
 
+  it('a clean party kill still pays marks when the killing blow credits a disconnecting player (issue 1891)', () => {
+    // Regression for issue 1891: multiple heroic clears reported crediting 0 marks
+    // despite a clean, no-wipe kill. Root cause: kill-credit resolution (tap holder
+    // or killing-blow source) requires a LIVE, non-leaving player at the exact death
+    // tick. An authoritative leave teardown racing the last hit (the killer flips
+    // `meta.leaving` before the kill event is processed) zeroed credit entirely, so
+    // the whole party's heroic marks were dropped even though every member (buddy,
+    // here) genuinely fought the boss and stayed connected.
+    const sim = makeSim(5);
+    const leader = sim.addPlayer('warrior', 'Lead');
+    const buddy = sim.addPlayer('priest', 'Buddy');
+    sim.partyInvite(buddy, leader);
+    sim.partyAccept(buddy);
+    sim.setDungeonDifficulty('heroic', leader);
+    enterDungeon(sim.ctx, 'hollow_crypt', leader);
+    enterDungeon(sim.ctx, 'hollow_crypt', buddy);
+    const inst = claimedDungeon(sim, 'hollow_crypt', 'heroic');
+    const morthen = mobInInstance(sim, inst, 'morthen');
+    const le = sim.entities.get(leader) as AnyEntity;
+    const be = sim.entities.get(buddy) as AnyEntity;
+    teleport(sim, le, morthen.pos.x + 1, morthen.pos.z);
+    teleport(sim, be, morthen.pos.x - 1, morthen.pos.z);
+
+    // Leader opens on the boss first (owns tap), then buddy joins in, landing
+    // real threat-table damage of their own.
+    (sim as any).dealDamage(le, morthen, 10, false, 'physical', null, 'hit');
+    expect(morthen.tappedById).toBe(leader);
+    (sim as any).dealDamage(be, morthen, 10, false, 'physical', null, 'hit');
+    expect(morthen.dead).toBe(false);
+    expect(morthen.threat.has(buddy)).toBe(true);
+
+    // The leader's session begins tearing down (disconnect/reconnect) the instant
+    // before their killing blow lands: both the tap holder AND the killing-blow
+    // source are the same leaving player, so kill-credit resolution comes back
+    // null entirely. Buddy is still fully connected, in the raid, and on the
+    // hate table: the fix must still pay them.
+    sim.players.get(leader)!.leaving = true;
+    (sim as any).dealDamage(le, morthen, morthen.hp + 10, false, 'physical', null, 'hit');
+    expect(morthen.dead).toBe(true);
+
+    expect(sim.players.get(buddy)!.raidLockouts.has('hollow_crypt:heroic')).toBe(true);
+    expect(sim.countItem(HEROIC_MARK_ITEM_ID, buddy)).toBe(1);
+  });
+
   it('a locked party cannot ride an unlocked recruit into a fresh heroic claim', () => {
     const sim = makeSim(5);
     const leader = sim.addPlayer('warrior', 'Lead');

--- a/tests/heroic_vendor.test.ts
+++ b/tests/heroic_vendor.test.ts
@@ -204,7 +204,7 @@ describe('heroic mark reward persistence', () => {
 
     now = nextReset;
     nextReset += DAY_MS;
-    sim.awardHeroicMarks(morthen, [meta]);
+    sim.awardHeroicMarks(morthen, [meta], new Set([meta.entityId]));
 
     expect(sim.utcDay).toBe('2026-07-07');
     expect(sim.countItem(HEROIC_MARK_ITEM_ID, pid)).toBe(2);
@@ -235,7 +235,7 @@ describe('heroic mark reward persistence', () => {
           (entity: AnyEntity | undefined) =>
             entity?.templateId === HEROIC_DUNGEON_TUNING[dungeonId].finalBossId,
         ) as AnyEntity;
-      sim.awardHeroicMarks(boss, [meta]);
+      sim.awardHeroicMarks(boss, [meta], new Set([meta.entityId]));
     }
     sim.tick();
 


### PR DESCRIPTION
## Summary

Root cause: heroic mark credit only paid the `recipients` list resolved from kill-credit (tap holder / killing-blow source), which requires that player to still be a live, non-leaving session at the exact death tick. Reports described clean, no-wipe heroic clears crediting 0 marks (or fewer than expected across several dungeons in one session) -- consistent with a disconnect/reconnect racing the killing blow, which zeroes kill-credit resolution for the whole party even though everyone actually fought the boss.

Fix: `awardHeroicMarks` now also pays any player still on the boss's hate table at the instant of death (pets resolved to their owner), snapshotted in `handleDeath` before the hate table is cleared, as a fallback alongside the existing `recipients` list. A party that genuinely fought the boss can no longer lose its marks to a kill-credit resolution race.

## Flow

```mermaid
flowchart TD
    A["Boss dies"] --> B["Snapshot hate-table contributors<br/>(pets -> owner) BEFORE clearThreat"]
    B --> C["Resolve kill-credit recipients<br/>(tap holder / killing-blow source)"]
    C --> D{"awardHeroicMarks"}
    D --> E["Pay recipients list"]
    D --> F["ALSO pay any hate-table<br/>contributor not already paid"]
    E --> G["Marks + lockout settled"]
    F --> G

    style F fill:#2d5,color:#000
```

## Test plan
- [x] Added `tests/dungeons.test.ts`: "a clean party kill still pays marks when the killing blow credits a disconnecting player (issue 1891)" -- leader's session starts leaving right before the killing blow (so kill-credit resolution comes back null), buddy stays connected and on the hate table; asserts buddy still gets the mark and lockout.
- [x] Updated `tests/heroic_vendor.test.ts` calls to the new `awardHeroicMarks` signature.
- [x] `npx vitest run tests/dungeons.test.ts tests/heroic_vendor.test.ts` -- 65 passed.
- [x] `npx tsc --noEmit -p .` -- clean.
- [x] `npx @biomejs/biome check --write` on changed files -- clean (warnings only, pre-existing `any` casts in test helpers).

No screenshots: server-authoritative reward-credit logic, not a visual change.

Fixes #1891
