### PR TITLE
fix(sim): correct stealth gating for Cheap Shot and Sap

### DIFF
--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -45,7 +45,10 @@ function isStealthToggle(ability: AbilityDef): boolean {
 }
 
 function preservesStealth(ability: AbilityDef): boolean {
-  return isStealthToggle(ability) || ability.id === 'sprint';
+  // Sap is the classic no-reveal opener: it incapacitates from range without a
+  // melee swing, so unlike Cheap Shot/Ambush/Garrote it must not blow the
+  // caster's own stealth (issue #1890).
+  return isStealthToggle(ability) || ability.id === 'sprint' || ability.id === 'sap';
 }
 
 function consumeMatchingAura(

--- a/src/ui/action_bar_view.ts
+++ b/src/ui/action_bar_view.ts
@@ -125,6 +125,12 @@ export interface ActionBarPlayerInput {
   potionCdRemaining: number;
   queuedOnSwing: string | null;
   pos: Vec3;
+  /** Whether the player currently carries a `kind:'stealth'` aura (Stealth or
+   *  Vanish). Gates a `requiresStealth` ability's usable state (issue #1890):
+   *  without this the bar never dimmed Cheap Shot/Ambush/Garrote out of
+   *  stealth, so they looked equally "ready" whether or not the cast would
+   *  actually succeed. */
+  stealthed: boolean;
 }
 
 /** The target fields the bar reads; null when there is no current target. */
@@ -335,7 +341,8 @@ export function createActionBarView(
             : 0;
         slot.cdText = cd > COOLDOWN_TEXT_THRESHOLD ? deps.formatCount(Math.ceil(cd)) : '';
         slot.count = '';
-        slot.usable = !(player.resource < ability.cost);
+        slot.usable =
+          !(player.resource < ability.cost) && (!def.requiresStealth || player.stealthed);
         slot.outOfRange =
           def.requiresTarget &&
           tgtDist !== null &&

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -385,6 +385,7 @@ import {
   streamerActionPlatform,
   streamerMenuActions,
 } from './player_context_menu';
+import { playerStealthed } from './player_stealthed';
 import { hydratePortraits, portraitChipHtml } from './portrait_chip';
 import { maskProfanity } from './profanity';
 import { encodeItemLink, encodeQuestLink, parseChatSegments } from './quest_link';
@@ -7078,10 +7079,22 @@ export class Hud {
     // ActionBarPainter. Every per-slot icon / cooldown / dimming / count write
     // routes through the elided writer facet; the aria-label keeps its per-frame t()
     // call IN the core while the painter elides the DOM setAttribute (Top risk 4).
+    // Derive `stealthed` from the mirrored auras rather than trust the raw entity
+    // field: offline it is the live sim Entity's cache (kept current by
+    // Sim.updateAuras), but online it is the ClientWorld mirror's server-local
+    // interest-filtering cache, never encoded on the wire and never updated on the
+    // client (see src/net/online.ts, server/game.ts). The auras ARE mirrored, so
+    // this stays correct on both hosts. Shared by every action-bar-family view
+    // below (desktop bar, mobile ring, consumables quick bar).
+    const abPlayer = { ...p, stealthed: playerStealthed(p.auras) };
     this.renderPetBar();
     if (this.spellbookWindow.isOpen) this.spellbookWindow.tickOpen();
     this.actionBarPainter.paint(
-      this.actionBarView.tick({ player: p, target: target ?? null, inventory: sim.inventory }),
+      this.actionBarView.tick({
+        player: abPlayer,
+        target: target ?? null,
+        inventory: sim.inventory,
+      }),
     );
 
     // mobile action ring: the paged touch combat cluster, gated on the touch-mode
@@ -7091,7 +7104,7 @@ export class Hud {
     if (this.isMobileLayout() && this.mobileActionRingView && this.mobileActionRingPainter) {
       this.mobileActionRingPainter.paint(
         this.mobileActionRingView.tick({
-          player: p,
+          player: abPlayer,
           target: target ?? null,
           inventory: sim.inventory,
         }),
@@ -7115,7 +7128,7 @@ export class Hud {
     ) {
       this.consumableBarPainter.paint(
         this.consumableBarView.tick({
-          player: p,
+          player: abPlayer,
           target: target ?? null,
           inventory: sim.inventory,
         }),

--- a/src/ui/player_stealthed.ts
+++ b/src/ui/player_stealthed.ts
@@ -1,0 +1,12 @@
+// Derives the action-bar "carries a kind:'stealth' aura" flag from the player's
+// mirrored aura list, rather than trusting a raw entity field.
+//
+// Why: offline the entity IS the live sim Entity, whose `stealthed` field is kept
+// current every tick by Sim.updateAuras (see src/sim/sim.ts). Online the entity is
+// the ClientWorld mirror, constructed with `stealthed: false` and never updated
+// (see src/net/online.ts): it is a server-local interest-filtering cache (see
+// server/game.ts) that is not encoded on the wire. The wire DOES mirror auras, so
+// deriving the flag from `kind === 'stealth'` presence is correct on both hosts.
+export function playerStealthed(auras: readonly { kind: string }[]): boolean {
+  return auras.some((a) => a.kind === 'stealth');
+}

--- a/tests/action_bar_painter.test.ts
+++ b/tests/action_bar_painter.test.ts
@@ -196,6 +196,7 @@ function idleWorld(): ActionBarWorldInput {
       gcdRemaining: 0,
       potionCdRemaining: 0,
       queuedOnSwing: null,
+      stealthed: false,
       pos: { x: 0, y: 0, z: 0 },
     },
     target: null,

--- a/tests/action_bar_view.test.ts
+++ b/tests/action_bar_view.test.ts
@@ -91,6 +91,7 @@ interface WorldOpts {
   targetPos?: { x: number; y: number; z: number } | null;
   targetDead?: boolean;
   inventory?: { itemId: string; count: number }[];
+  stealthed?: boolean;
 }
 
 function world(opts: WorldOpts = {}): ActionBarWorldInput {
@@ -105,6 +106,7 @@ function world(opts: WorldOpts = {}): ActionBarWorldInput {
       potionCdRemaining: opts.potionCdRemaining ?? 0,
       queuedOnSwing: opts.queuedOnSwing ?? null,
       pos: opts.playerPos ?? { x: 0, y: 0, z: 0 },
+      stealthed: opts.stealthed ?? false,
     },
     target: targetPos === null ? null : { dead: opts.targetDead ?? false, pos: targetPos },
     inventory: opts.inventory ?? [],
@@ -198,6 +200,27 @@ describe('actionBarView: ability cooldown / usable / range / queued math', () =>
     const near = view.tick(world({ resource: 60, targetPos: { x: 1, y: 1, z: 1 } })).slots[0];
     expect(near.usable).toBe(true);
     expect(near.outOfRange).toBe(false);
+  });
+
+  it('a requiresStealth ability is usable only while the player is stealthed (issue #1890)', () => {
+    const view = createActionBarView(
+      descriptor(slot(1, { ability: ability('cheap_shot', { cost: 60, requiresStealth: true }) })),
+      fakeDeps(),
+    );
+    const outOfStealth = view.tick(world({ stealthed: false })).slots[0];
+    expect(outOfStealth.usable).toBe(false);
+
+    const inStealth = view.tick(world({ stealthed: true })).slots[0];
+    expect(inStealth.usable).toBe(true);
+  });
+
+  it('an ability with no stealth requirement ignores the stealthed flag', () => {
+    const view = createActionBarView(
+      descriptor(slot(1, { ability: ability('sinister_strike', { cost: 45 }) })),
+      fakeDeps(),
+    );
+    expect(view.tick(world({ stealthed: false })).slots[0].usable).toBe(true);
+    expect(view.tick(world({ stealthed: true })).slots[0].usable).toBe(true);
   });
 
   it('respects both range boundaries for an ability with a minimum range', () => {

--- a/tests/hud_perf_budget.test.ts
+++ b/tests/hud_perf_budget.test.ts
@@ -560,6 +560,7 @@ function idleWorld(): ActionBarWorldInput {
       gcdRemaining: 0,
       potionCdRemaining: 0,
       queuedOnSwing: null,
+      stealthed: false,
       pos: { x: 0, y: 0, z: 0 },
     },
     target: null,

--- a/tests/mobile_action_ring_painter.test.ts
+++ b/tests/mobile_action_ring_painter.test.ts
@@ -100,6 +100,7 @@ function idleWorld(): ActionBarWorldInput {
       gcdRemaining: 0,
       potionCdRemaining: 0,
       queuedOnSwing: null,
+      stealthed: false,
       pos: { x: 0, y: 0, z: 0 },
     },
     target: null,

--- a/tests/player_stealthed.test.ts
+++ b/tests/player_stealthed.test.ts
@@ -1,0 +1,31 @@
+// Regression test for the online/offline `stealthed` parity bug: the online
+// ClientWorld mirror entity is constructed with `stealthed: false` and never
+// updates it (see src/net/online.ts), since it is a server-local
+// interest-filtering cache never encoded on the wire (see server/game.ts). The
+// auras ARE mirrored, so hud.ts must derive `stealthed` from the aura list
+// rather than trust the raw entity field. This pins that derivation directly so
+// the parity cannot silently drift again; the action_bar_view tests pass
+// `stealthed` straight through and cannot catch this class of bug.
+
+import { describe, expect, it } from 'vitest';
+import { playerStealthed } from '../src/ui/player_stealthed';
+
+describe('playerStealthed', () => {
+  it('is true for an online-shaped entity: a kind:"stealth" aura present despite a stale stealthed:false field', () => {
+    // The mirrored aura list is the only thing playerStealthed reads; it never
+    // looks at a `stealthed` field at all, so this input models exactly the
+    // ClientWorld mirror shape the bug came from.
+    const auras = [{ kind: 'stealth' }];
+    expect(playerStealthed(auras)).toBe(true);
+  });
+
+  it('is false when no stealth aura is present', () => {
+    expect(playerStealthed([])).toBe(false);
+    expect(playerStealthed([{ kind: 'regen' }, { kind: 'form_bear' }])).toBe(false);
+  });
+
+  it('is true among unrelated auras (order independent)', () => {
+    const auras = [{ kind: 'regen' }, { kind: 'stealth' }, { kind: 'form_cat' }];
+    expect(playerStealthed(auras)).toBe(true);
+  });
+});

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -779,6 +779,58 @@ describe('rogue', () => {
     expect(vanish / base).toBeCloseTo(0.5, 1);
   });
 
+  it('Sap does not break the caster stealth (issue #1890)', () => {
+    const sim = makeSim('rogue');
+    sim.setPlayerLevel(10); // Sap learns at level 10
+    const mob = nearestMob(sim, 'forest_wolf');
+    mob.level = 1;
+    mob.inCombat = false;
+    mob.aggroTargetId = null;
+    teleportTo(sim, mob.pos.x + 2, mob.pos.z);
+    sim.player.inCombat = false;
+    sim.castAbility('stealth');
+    expect(sim.player.auras.some((a) => a.kind === 'stealth')).toBe(true);
+    sim.targetEntity(mob.id);
+    facePlayerAt(sim, mob);
+    sim.castAbility('sap');
+    sim.tick();
+    expect(mob.auras.some((a: any) => a.kind === 'incapacitate')).toBe(true);
+    expect(sim.player.auras.some((a) => a.kind === 'stealth')).toBe(true);
+  });
+
+  it('Low Blow (kidney_shot) works while invisible from Vanish (issue #1890)', () => {
+    const sim = makeSim('rogue');
+    sim.setPlayerLevel(20); // Vanish (18) and Low Blow (14) both known
+    const wolf = nearestMob(sim, 'forest_wolf');
+    wolf.level = 1;
+    teleportTo(sim, wolf.pos.x + 2, wolf.pos.z);
+    sim.targetEntity(wolf.id);
+    facePlayerAt(sim, wolf);
+    let guard = 0;
+    while (sim.player.comboPoints < 2 && guard++ < 20 * 120 && !wolf.dead) {
+      if (sim.player.resource >= 45 && sim.player.gcdRemaining <= 0)
+        sim.castAbility('sinister_strike');
+      sim.tick();
+      facePlayerAt(sim, wolf);
+    }
+    expect(sim.player.comboPoints).toBeGreaterThanOrEqual(2);
+    // The build-up loop can finish off a starter-level wolf; revive it fully so
+    // the assertion below is about Low Blow, not an incidental kill.
+    sim.stopAutoAttack();
+    wolf.dead = false;
+    wolf.hp = wolf.maxHp;
+    sim.castAbility('vanish');
+    expect(sim.player.auras.some((a) => a.kind === 'stealth')).toBe(true);
+    facePlayerAt(sim, wolf);
+    for (let i = 0; i < 30 && sim.player.gcdRemaining > 0; i++) {
+      sim.tick();
+      facePlayerAt(sim, wolf);
+    }
+    sim.castAbility('kidney_shot');
+    sim.tick();
+    expect(wolf.auras.some((a: any) => a.kind === 'stun')).toBe(true);
+  });
+
   it('rogue GCD is 1.0s', () => {
     const sim = makeSim('rogue');
     expect(sim.playerGcd).toBe(1.0);


### PR DESCRIPTION
## Summary

Three reported stealth-related rogue ability bugs, investigated independently:

1. **Cheap Shot not reflecting its stealth requirement (confirmed and fixed).** `action_bar_view.ts`'s `usable` computation never checked `ability.requiresStealth`, so the bar never distinguished a castable-in-stealth ability from one that would actually fail. Added a `stealthed` field to `ActionBarPlayerInput` and gated `usable` on it.
2. **Sap breaking the caster's own stealth (confirmed and fixed).** `preservesStealth()` only exempted stealth-toggle abilities and Sprint; every other cast, including Sap, called `breakStealth()`. Sap is the classic no-reveal opener (incapacitates at range, no melee swing) and must not blow the caster's own stealth. Added it to the exemption list.
3. **Low Blow (kidney_shot) not working while invisible (investigated, not reproducible).** Built a full combo-point setup, cast Vanish, then Low Blow: it lands correctly on the current code. No `requiresStealth` gate exists on it and nothing in the finisher path blocks casting while stealthed. Kept the test as a regression guard rather than claiming a fix for a bug I couldn't reproduce.

## Flow

```mermaid
flowchart TD
    A["Action bar usable check"] --> B{"requiresStealth?"}
    B -->|no| C["usable = resource sufficient"]
    B -->|"yes (Cheap Shot)"| D{"player.stealthed?"}
    D -->|"BEFORE: not checked at all"| E["usable never reflected stealth"]
    D -->|"AFTER: yes"| F["usable = resource sufficient"]
    D -->|"AFTER: no"| G["usable = false"]

    H["Ability cast (Sap)"] --> I{"preservesStealth(ability)?"}
    I -->|"BEFORE: only stealth-toggle / sprint"| J["Sap incorrectly calls breakStealth()"]
    I -->|"AFTER: + sap"| K["Sap no longer breaks stealth"]

    style E fill:#822,color:#fff
    style J fill:#822,color:#fff
    style F fill:#2d5,color:#000
    style G fill:#2d5,color:#000
    style K fill:#2d5,color:#000
```

## Test plan
- [x] `tests/sim.test.ts`: "Sap does not break the caster stealth (issue #1890)" and "Low Blow (kidney_shot) works while invisible from Vanish (issue #1890)".
- [x] `tests/action_bar_view.test.ts`: `requiresStealth` gates `usable` correctly; non-stealth abilities unaffected.
- [x] Updated `stealthed: false` fixtures in `tests/action_bar_painter.test.ts`, `tests/hud_perf_budget.test.ts`, `tests/mobile_action_ring_painter.test.ts` for the new required `ActionBarPlayerInput` field.
- [x] `npx vitest run tests/action_bar_view.test.ts tests/action_bar_painter.test.ts tests/hud_perf_budget.test.ts tests/mobile_action_ring_painter.test.ts` -- 76 passed, 3 skipped.
- [x] `npx vitest run tests/sim.test.ts -t "issue #1890"` -- 2 passed.
- [x] `npx tsc --noEmit -p .` -- clean.
- [x] `npx @biomejs/biome check --write` on changed files -- clean (warnings only).

No screenshots: sim/action-bar-usability logic change (a slot's dim/enabled state), not a layout change; the mermaid above documents the corrected gating.

Fixes #1890
