### PR TITLE
fix(tests): tolerate AAC encoder bitrate rounding in sfx conform fixture

### DIFF
--- a/tests/sfx_conform.test.ts
+++ b/tests/sfx_conform.test.ts
@@ -249,7 +249,10 @@ describe('shared conform command', () => {
         ffprobePath: ffprobeStatic.path,
       });
       expect(source.codec).toBe('aac');
-      expect(source.bitrate).toBeGreaterThanOrEqual(TARGET_BITRATE);
+      // ffmpeg's native AAC encoder approximates the requested bitrate rather than hitting it
+      // exactly, and can land a couple kbps under a CBR-style `-b:a` target; widen the floor so
+      // that rounding doesn't flake this otherwise-at-spec fixture.
+      expect(source.bitrate).toBeGreaterThanOrEqual(TARGET_BITRATE - 4);
       expect(source.bitrate).toBeLessThanOrEqual(TARGET_BITRATE + 8);
       expect(source.sampleRate).toBe(TARGET_SAMPLE_RATE);
       expect(Math.abs(source.lufs - TARGET_LUFS)).toBeLessThanOrEqual(NORM_TOLERANCE);


### PR DESCRIPTION
## Summary
- `tests/sfx_conform.test.ts`'s "fails strict conformance for an at-spec AAC source" test flakes intermittently across unrelated PRs in CI, failing with `expected 191 to be greater than or equal to 192`.
- Root cause: the test asks ffmpeg's native AAC encoder to produce a `192k`-target fixture, then asserts the probed bitrate lands in `[192, 200]`. ffmpeg's AAC encoder approximates the requested `-b:a` rather than hitting it exactly, and occasionally rounds a couple kbps under the target, which is expected encoder behavior, not a bug in the conform logic under test.
- Fix: widen the lower bound of the fixture's own self-check by 4kbps (`TARGET_BITRATE - 4`) so encoder rounding doesn't flake the test. This does not touch `classify()`/`sfx_conform_rules.mjs` production logic or its `TARGET_BITRATE`/`MIN_SOURCE_BITRATE` gates, which are unaffected and still strict.

## Test plan
- [x] `npx vitest run tests/sfx_conform.test.ts` passes (53/53), run 3x to confirm no flake.
- [x] `npx @biomejs/biome check --write tests/sfx_conform.test.ts` clean.
- [x] Local pre-push QA floor (`tsc`, guard tests, biome changed-files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)