### PR TITLE
fix(combat): taunts always land (never miss or resist)

### DIFF
--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -843,8 +843,12 @@ function applyAbility(ctx: SimContext, p: Entity, meta: PlayerMeta, res: Resolve
     // like a physical attack; a target can only fully RESIST them (classic-era
     // semantics), so a spell's on-impact roll uses isSpellResisted and emits a 'resist'.
     // A physical shot has no resist roll; its hit/crit resolve inside runEffects.
+    // Taunts (e.g. Sacred Goad) ALWAYS land: a resisted taunt would silently break
+    // tanking, so a taunt ability skips the resist roll entirely (physical taunts like
+    // Goad / Menace already never roll, since they resolve instantly below).
+    const isTaunt = res.effects.some((eff) => eff.type === 'taunt');
     scheduleProjectile(ctx, p, target, (src, tgt) => {
-      if (isSpell && isSpellResisted(ctx.rng, src.level, tgt.level)) {
+      if (isSpell && !isTaunt && isSpellResisted(ctx.rng, src.level, tgt.level)) {
         ctx.emit({
           type: 'damage',
           sourceId: src.id,

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -414,6 +414,40 @@ describe('taunt and growl', () => {
     expect(wolf.forcedTargetTimer).toBeGreaterThan(0);
   });
 
+  it('Sacred Goad always lands (never resists), even against a higher-level mob', () => {
+    // The paladin taunt is holy-school (a spell), so on impact it used to roll a full
+    // resist. A resisted taunt silently breaks tanking, so taunts now skip the roll.
+    // Against a +3 mob the old roll would resist a large fraction of the time; across
+    // many seeds the taunt must now land every time and never emit a 'resist'.
+    for (let seed = 1; seed <= 40; seed++) {
+      const sim = new Sim({ seed, playerClass: 'paladin', noPlayer: true });
+      const tank = sim.entities.get(sim.addPlayer('paladin', 'Tank'))!;
+      const dps = sim.entities.get(sim.addPlayer('mage', 'Dps'))!;
+      sim.setPlayerLevel(10, tank.id);
+      const wolf = nearestMob(sim, 'forest_wolf', tank);
+      wolf.level = tank.level + 3; // a wide level gap: a spell would often fully resist
+      teleport(sim, tank, wolf.pos.x + 25, wolf.pos.z);
+      teleport(sim, dps, wolf.pos.x - 2, wolf.pos.z);
+      wolf.threat.set(dps.id, 1000);
+      wolf.aggroTargetId = dps.id;
+      wolf.aiState = 'chase';
+      wolf.inCombat = true;
+      sim.targetEntity(wolf.id, tank.id);
+      tank.facing = Math.atan2(wolf.pos.x - tank.pos.x, wolf.pos.z - tank.pos.z);
+
+      sim.castAbility('holy_taunt', tank.id);
+      let resisted = false;
+      for (let i = 0; i < 25; i++) {
+        for (const ev of sim.tick()) {
+          if (ev.type === 'damage' && ev.kind === 'resist' && ev.ability === 'Sacred Goad')
+            resisted = true;
+        }
+      }
+      expect(resisted, `seed ${seed}`).toBe(false);
+      expect(wolf.aggroTargetId, `seed ${seed}`).toBe(tank.id);
+    }
+  });
+
   it('growl requires bear form', () => {
     const sim = makeSim('druid');
     sim.setPlayerLevel(10);


### PR DESCRIPTION
## Problem

A taunt that misses or resists silently breaks tanking: the mob keeps hitting a healer or DPS while the tank thinks it grabbed aggro. The paladin taunt (Sacred Goad) is holy-school, so it travelled as a spell bolt and rolled a full resist on impact, so it could quietly fail. Warrior Goad and druid Menace are physical and already never rolled.

## Fix

Any ability whose effects include a `taunt` skips the on-impact resist roll (`src/sim/combat/casting_lifecycle.ts`), so taunts always apply regardless of the caster/target level gap. Physical taunts are unchanged (they resolve instantly with no roll); this only removes the spell resist for spell-school taunts like Sacred Goad.

## Testing

`tests/threat.test.ts` adds a case: across 40 seeds, casting Sacred Goad at a +3 mob (where a spell would resist a large fraction of the time) lands the taunt every time and never emits a `resist`. Parity is green (no golden casts a spell-taunt, so no draw-order regen), architecture and the S3 i18n guard pass, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)