### PR TITLE
feat(game): show own nameplate by default

### DIFF
--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -207,11 +207,11 @@ export const BOOL_SETTINGS = {
   // Purely a local display preference: the badge is still earned and broadcast
   // either way, this only controls whether THIS client renders it.
   showDevBadges: { def: true },
-  // off by default (the classic self-view keeps no plate over your head): when
-  // on, render your OWN overhead nameplate (name, level, guild, hp, $WOC holder
-  // tier, dev badge, linked-Discord PFP) exactly as other players see it, so you
-  // can see how your character presents. Purely a local display preference.
-  showOwnNameplate: { def: false },
+  // on by default: render your OWN overhead nameplate (name, level, guild, hp,
+  // $WOC holder tier, dev badge, linked-Discord PFP) exactly as other players see
+  // it, so Discord linking and other flair changes have immediate visual feedback.
+  // Purely a local display preference; players can turn it off for the classic view.
+  showOwnNameplate: { def: true },
   // off by default: invert the vertical axis of mouselook (push mouse forward
   // to look down), the classic flight-sim preference.
   invertLookY: { def: false },

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -166,6 +166,14 @@ describe('Settings', () => {
     expect(b.get('mobileCameraJoystick')).toBe(true);
   });
 
+  it('defaults the own nameplate on for a fresh player and preserves an existing off choice', () => {
+    const fresh = new Settings();
+    expect(fresh.get('showOwnNameplate')).toBe(true);
+
+    fresh.set('showOwnNameplate', false);
+    expect(new Settings().get('showOwnNameplate')).toBe(false);
+  });
+
   it('defaults footstep sounds off and persists re-enabling across instances', () => {
     const a = new Settings();
     expect(a.get('footstepSfx')).toBe(false);


### PR DESCRIPTION
## Summary

- Enable Show My Nameplate by default when no saved value exists.
- Preserve an existing saved off choice.
- Make Discord avatar and linked-account flair immediately visible to the player.

## Testing

- `npx vitest run tests/settings.test.ts tests/architecture.test.ts tests/localization_fixes.test.ts`
- `npm run test:browser`
- `npm run check:types`
- `npm run build:env`
- `npm run build:server`
- `npm run build`
- Pre-push QA floor

Release tracker: #1857