### PR TITLE
fix(game): reland the camera follow release hold (mouselook release settle stutter)

### DIFF
--- a/src/game/camera_follow.ts
+++ b/src/game/camera_follow.ts
@@ -89,6 +89,93 @@ function clickMoveSettleScale(absDelta: number): number {
   return CLICK_MOVE_BIG_TURN_FLOOR + (1 - CLICK_MOVE_BIG_TURN_FLOOR) * eased;
 }
 
+// --- Camera release hold -----------------------------------------------------
+// While mouselook (right-mouse drag, touch swipe-look, the camera joystick) or
+// Mouse Camera movement is live, the camera owns the player's heading: follow
+// is bypassed and every facing commit is an echo of camYaw. Those echoes are
+// only VISIBLE through the render-interpolated facing, which lags the commit
+// by up to one sim tick offline and a full round trip online. The instant the
+// drag releases, follow re-engages, and its rigid term replays that catch-up
+// sweep into camYaw: the camera runs PAST the heading the player chose, and
+// the settle term then drags it back. That overshoot-and-return is the "camera
+// briefly shakes before stabilizing" bug. The hold below keeps follow
+// disengaged (cameraDriven) from the release until the interpolated facing
+// converges onto the released yaw, so the echo of the camera's own writes is
+// never fed back into the camera.
+
+// Converged once the interpolated facing is within this of the released yaw.
+// Sized to cover the wire's 0.01 rad facing rounding (see keyboard_turn_facing
+// HANDOFF_EPS): the mirror can legitimately sit half a rounding step away.
+export const CAMERA_RELEASE_HOLD_EPS = 0.02; // rad (~1.1 degrees)
+// Backstop for a facing the server refuses (stun/corpse) or that another
+// system takes over: give up and let the settle ease whatever remains. Matches
+// keyboard_turn_facing's release-grace floor; scaled up by the measured input
+// echo online so a slow link gets its full round trip before follow re-engages.
+export const CAMERA_RELEASE_HOLD_MAX_MS = 350;
+
+export interface CameraReleaseHoldState {
+  /** The camYaw latched on the release edge; null = no hold in progress. */
+  facing: number | null;
+  /** Time spent holding since the release edge (ms). */
+  heldMs: number;
+  /** Previous frame's cameraOwned, for the falling-edge latch. */
+  wasOwned: boolean;
+}
+
+export function newCameraReleaseHold(): CameraReleaseHoldState {
+  return { facing: null, heldMs: 0, wasOwned: false };
+}
+
+export interface CameraReleaseHoldArgs {
+  /** True while the camera owns the heading (mouselook active, or Mouse Camera
+   *  mode with a movement key held): the drag itself, not the release. */
+  cameraOwned: boolean;
+  camYaw: number;
+  /** The same render-interpolated facing the follow camera runs on. */
+  interpFacing: number;
+  frameDt: number;
+  /** Measured input echo (ms), online only; scales the give-up grace. */
+  echoMs?: number;
+  /** True while keyboard turn keys are held: a manual turn owns the heading
+   *  next, so the hold must break instead of freezing the follow camera. */
+  manualTurn?: boolean;
+}
+
+/**
+ * Advance the release hold one frame. Returns true while auto-follow must stay
+ * disengaged (pass it into updateFollowCameraYaw's cameraDriven, which still
+ * advances lastInterpFacing so re-coupling never snaps). The frame that ends
+ * the hold (convergence, manual turn, or timeout) still suppresses, so its
+ * interp step never leaks into the rigid follow term.
+ */
+export function stepCameraReleaseHold(
+  state: CameraReleaseHoldState,
+  args: CameraReleaseHoldArgs,
+): boolean {
+  if (args.cameraOwned) {
+    // Live drag: follow is already bypassed by the mouselook/cameraDriven
+    // flags. Arm the edge detection; the latch happens on the release frame,
+    // when camYaw holds the final yaw including the last flick's deltas.
+    state.wasOwned = true;
+    state.facing = null;
+    state.heldMs = 0;
+    return false;
+  }
+  if (state.wasOwned) {
+    state.wasOwned = false;
+    state.facing = args.camYaw;
+    state.heldMs = 0;
+  }
+  if (state.facing === null) return false;
+  state.heldMs += Math.max(0, args.frameDt) * 1000;
+  const gap = Math.abs(wrapAngle(args.interpFacing - state.facing));
+  const graceMs = Math.max(CAMERA_RELEASE_HOLD_MAX_MS, (args.echoMs ?? 0) * 1.5 + 120);
+  if (args.manualTurn || gap <= CAMERA_RELEASE_HOLD_EPS || state.heldMs >= graceMs) {
+    state.facing = null;
+  }
+  return true;
+}
+
 export function updateFollowCameraYaw(input: CameraFollowInput): CameraFollowResult {
   let camYaw = input.camYaw;
   if (!input.mouselook && !input.cameraDriven) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,13 @@ import {
   readBrowserEnv,
 } from './game/browser_env';
 import { isCameraDrivenFacingActive } from './game/camera_driven_facing';
-import { cameraFollowShouldSettle, updateFollowCameraYaw, wrapAngle } from './game/camera_follow';
+import {
+  cameraFollowShouldSettle,
+  newCameraReleaseHold,
+  stepCameraReleaseHold,
+  updateFollowCameraYaw,
+  wrapAngle,
+} from './game/camera_follow';
 import { shouldRecoverOnComposerBlur } from './game/chat_keyboard_dismiss';
 import {
   clickMoveShouldWalk,
@@ -2386,7 +2392,15 @@ async function startGame(
   // channel, passed through on the one engage-edge frame so the server still
   // sees a manual turn (breaks /follow, marks anti-AFK activity).
   const kbTurn = newKeyboardTurnState();
-  function updateCamera(frameDt: number, interpFacing: number): void {
+  // Release hold for camera-owned headings (touch swipe-look, the camera
+  // joystick, right-mouse mouselook, Mouse Camera movement): after the drag
+  // releases, the render-interpolated facing spends up to a tick offline (a
+  // round trip online) replaying facing commits the camera itself authored.
+  // Feeding that echo back through the rigid follow term overshoots the
+  // released heading and the settle then drags it back: the visible release
+  // bounce. The hold keeps follow disengaged until the echo converges.
+  const cameraReleaseHold = newCameraReleaseHold();
+  function updateCamera(frameDt: number, interpFacing: number, echoMs = 0): void {
     const mi = input.readMoveInput();
     const clickMoving = !!input.clickMoveTarget && !input.suspendMovement && !movementFrozen();
     // When click-to-move ends, the player's facing snaps from the (camera-lagging)
@@ -2396,15 +2410,25 @@ async function startGame(
     // handoff stays smooth even in pure-follow (non-camera-driven) mode.
     if (wasClickMoving && !clickMoving) lastInterpFacing = interpFacing;
     wasClickMoving = clickMoving;
+    const mouselook = input.isMouselookActive();
+    const mouseCameraDriven = input.isMouseCameraMode() && cameraMoveActive();
+    const releaseHold = stepCameraReleaseHold(cameraReleaseHold, {
+      cameraOwned: mouselook || mouseCameraDriven,
+      camYaw: input.camYaw,
+      interpFacing,
+      frameDt,
+      echoMs,
+      manualTurn: mi.turnLeft || mi.turnRight,
+    });
     const next = updateFollowCameraYaw({
       camYaw: input.camYaw,
       interpFacing,
       frameDt,
       lastInterpFacing,
-      mouselook: input.isMouselookActive(),
+      mouselook,
       moving: cameraFollowShouldSettle(mi, clickMoving),
       clickMoving,
-      cameraDriven: input.isMouseCameraMode() && cameraMoveActive(),
+      cameraDriven: mouseCameraDriven || releaseHold,
       orbiting: input.leftDown && input.isCameraDragActive(),
     });
     input.camYaw = next.camYaw;
@@ -2847,12 +2871,16 @@ async function startGame(
           alpha,
           frameDt,
         };
-    perf.trace('camera.follow', () => updateCamera(frameDt, kbFacing ?? interpServerFacing), {
-      mode: 'online',
-      alpha,
-      frameDtMs: frameDt * 1000,
-      lastSnapAge: net.lastSnapAt > 0 ? performance.now() - net.lastSnapAt : -1,
-    });
+    perf.trace(
+      'camera.follow',
+      () => updateCamera(frameDt, kbFacing ?? interpServerFacing, onlineInputEchoMs),
+      {
+        mode: 'online',
+        alpha,
+        frameDtMs: frameDt * 1000,
+        lastSnapAge: net.lastSnapAt > 0 ? performance.now() - net.lastSnapAt : -1,
+      },
+    );
     introCameraTick(now);
     renderer.camYaw = input.camYaw;
     renderer.camPitch = input.camPitch;

--- a/tests/camera_follow.test.ts
+++ b/tests/camera_follow.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   cameraFollowShouldSettle,
   cameraIsManual,
+  newCameraReleaseHold,
+  stepCameraReleaseHold,
   updateFollowCameraYaw,
   wrapAngle,
 } from '../src/game/camera_follow';
@@ -212,5 +214,265 @@ describe('camera follow', () => {
     expect(Math.PI - large.camYaw).toBeGreaterThan(0);
     expect(Math.PI - large.camYaw).toBeLessThan(0.01);
     expect(0.25 - small.camYaw).toBeGreaterThan(Math.PI - large.camYaw);
+  });
+});
+
+// BUG: "camera briefly shakes before stabilizing" after a touch-look (or
+// right-mouse mouselook) release. While the drag is live the follow system is
+// bypassed and each sim tick commits facing = camYaw; but the render-
+// interpolated facing lags that commit by up to a tick (offline) or a round
+// trip (online). The instant the drag releases, follow re-engages and its
+// rigid term replays that catch-up sweep into camYaw, pushing the camera PAST
+// the heading the player chose; the settle term then drags it back: a visible
+// overshoot-and-return bounce. The fix holds follow disengaged (cameraDriven)
+// until the interpolated facing converges onto the released yaw.
+describe('camera release hold (touch-look release bounce)', () => {
+  const DT = 1 / 20; // the sim tick, mirrors src/sim (20 Hz)
+  const TURN_RATE = 2.5; // rad/s of finger swipe while dragging
+  const DRAG_S = 0.58; // drag long enough to cross several ticks, release mid-window
+  const SETTLE_S = 1.2;
+
+  // Mirrors the main.ts offline frame loop: pointer deltas land before the
+  // frame body; the accumulator runs 20 Hz ticks; while mouselook is active
+  // each tick commits facing = camYaw; the camera-driven falling edge latches
+  // the final yaw (mouselookReleaseFacing -> pendingReleaseFacing) so the next
+  // tick commits it; updateFollowCameraYaw runs on the render-interpolated
+  // facing after the ticks.
+  function simulateTouchLookRelease(
+    fps: number,
+    useHold: boolean,
+  ): { trace: Array<{ t: number; yaw: number }>; releaseYaw: number; releaseAt: number } {
+    const dtF = 1 / fps;
+    const dragFrames = Math.ceil(DRAG_S / dtF);
+    const totalFrames = dragFrames + Math.ceil(SETTLE_S / dtF);
+    let camYaw = 0;
+    let facing = 0;
+    let prevFacing = 0;
+    let acc = 0;
+    let lastInterpFacing: number | null = null;
+    let pendingReleaseFacing: number | null = null;
+    let mouselook = true;
+    let releaseYaw = 0;
+    const hold = newCameraReleaseHold();
+    const trace: Array<{ t: number; yaw: number }> = [];
+    for (let f = 0; f < totalFrames; f++) {
+      if (f < dragFrames) {
+        camYaw += TURN_RATE * dtF; // the finger's pointer deltas this frame
+      } else if (mouselook) {
+        mouselook = false; // finger lifted between the previous frame and this one
+        releaseYaw = camYaw;
+        pendingReleaseFacing = camYaw; // the falling-edge commit (mouselook_release.ts)
+      }
+      acc += dtF;
+      while (acc >= DT) {
+        prevFacing = facing;
+        const stepFacing = mouselook ? camYaw : pendingReleaseFacing;
+        if (stepFacing !== null) facing = stepFacing;
+        pendingReleaseFacing = null;
+        acc -= DT;
+      }
+      const interpFacing = prevFacing + wrapAngle(facing - prevFacing) * (acc / DT);
+      const holdActive = useHold
+        ? stepCameraReleaseHold(hold, {
+            cameraOwned: mouselook,
+            camYaw,
+            interpFacing,
+            frameDt: dtF,
+          })
+        : false;
+      const next = updateFollowCameraYaw({
+        camYaw,
+        interpFacing,
+        frameDt: dtF,
+        lastInterpFacing,
+        mouselook,
+        moving: true, // the player keeps running on the joystick
+        orbiting: false,
+        cameraDriven: holdActive,
+      });
+      camYaw = next.camYaw;
+      lastInterpFacing = next.lastInterpFacing;
+      trace.push({ t: (f + 1) * dtF, yaw: camYaw });
+    }
+    return { trace, releaseYaw, releaseAt: dragFrames * dtF };
+  }
+
+  it('documents the pre-fix mechanism: instant follow re-engage replays the facing sweep and bounces', () => {
+    const sim = simulateTouchLookRelease(60, false);
+    const post = sim.trace.filter((p) => p.t > sim.releaseAt);
+    const overshoot = Math.max(...post.map((p) => wrapAngle(p.yaw - sim.releaseYaw)));
+    // The camera runs PAST the heading the finger chose...
+    expect(overshoot).toBeGreaterThan(0.05);
+    // ...and the settle then drags it back where it already was: the visible shake.
+    const final = post[post.length - 1];
+    expect(Math.abs(wrapAngle(final.yaw - sim.releaseYaw))).toBeLessThan(0.02);
+  });
+
+  it('holds the released heading: no overshoot past the release yaw at 30/60/144 fps', () => {
+    for (const fps of [30, 60, 144]) {
+      const sim = simulateTouchLookRelease(fps, true);
+      const post = sim.trace.filter((p) => p.t > sim.releaseAt);
+      expect(post.length).toBeGreaterThan(0);
+      for (const p of post) {
+        expect(Math.abs(wrapAngle(p.yaw - sim.releaseYaw))).toBeLessThanOrEqual(0.021);
+      }
+    }
+  });
+
+  it('settles without oscillation: the post-release yaw never reverses direction past tolerance', () => {
+    const tol = 0.005;
+    for (const fps of [30, 60, 144]) {
+      const sim = simulateTouchLookRelease(fps, true);
+      const post = sim.trace.filter((p) => p.t > sim.releaseAt);
+      let sawForward = false;
+      for (let i = 1; i < post.length; i++) {
+        const v = wrapAngle(post[i].yaw - post[i - 1].yaw);
+        if (v > tol) sawForward = true;
+        // Once the camera moved forward after release, it must never swing back:
+        // that reversal IS the reported shake.
+        if (sawForward) expect(v).toBeGreaterThanOrEqual(-tol);
+      }
+    }
+  });
+
+  it('release behavior is frame-rate independent: 30/60/144 fps land on the same heading', () => {
+    const finals = [30, 60, 144].map((fps) => {
+      const sim = simulateTouchLookRelease(fps, true);
+      const final = sim.trace[sim.trace.length - 1];
+      return wrapAngle(final.yaw - sim.releaseYaw);
+    });
+    for (const e of finals) expect(Math.abs(e)).toBeLessThanOrEqual(0.021);
+    expect(Math.abs(finals[0] - finals[1])).toBeLessThanOrEqual(0.02);
+    expect(Math.abs(finals[1] - finals[2])).toBeLessThanOrEqual(0.02);
+  });
+
+  it('re-engages follow after convergence instead of suppressing it forever', () => {
+    const hold = newCameraReleaseHold();
+    // Live drag: never suppresses (the mouselook flag already bypasses follow).
+    expect(
+      stepCameraReleaseHold(hold, {
+        cameraOwned: true,
+        camYaw: 1,
+        interpFacing: 0,
+        frameDt: 1 / 60,
+      }),
+    ).toBe(false);
+    // Release with the interpolated facing still behind: suppress...
+    expect(
+      stepCameraReleaseHold(hold, {
+        cameraOwned: false,
+        camYaw: 1,
+        interpFacing: 0.9,
+        frameDt: 1 / 60,
+      }),
+    ).toBe(true);
+    // ...until it converges within the wire-rounding seam; the converging frame
+    // still suppresses so its interp step never leaks into the rigid term...
+    expect(
+      stepCameraReleaseHold(hold, {
+        cameraOwned: false,
+        camYaw: 1,
+        interpFacing: 0.995,
+        frameDt: 1 / 60,
+      }),
+    ).toBe(true);
+    // ...and afterwards the auto-follow owns the camera again.
+    expect(
+      stepCameraReleaseHold(hold, {
+        cameraOwned: false,
+        camYaw: 1,
+        interpFacing: 0.995,
+        frameDt: 1 / 60,
+      }),
+    ).toBe(false);
+  });
+
+  it('gives up after the grace timeout when the facing never converges (e.g. server refusal)', () => {
+    const hold = newCameraReleaseHold();
+    stepCameraReleaseHold(hold, { cameraOwned: true, camYaw: 2, interpFacing: 0, frameDt: 1 / 60 });
+    let suppressed = 0;
+    for (let f = 0; f < 60; f++) {
+      if (
+        stepCameraReleaseHold(hold, {
+          cameraOwned: false,
+          camYaw: 2,
+          interpFacing: 0,
+          frameDt: 1 / 60,
+        })
+      )
+        suppressed += 1;
+    }
+    // Held for the grace window (350ms ~ 21 frames at 60fps), then released.
+    expect(suppressed).toBeGreaterThan(15);
+    expect(suppressed).toBeLessThan(30);
+  });
+
+  it('a manual keyboard turn breaks the hold so the follow camera tracks the turn', () => {
+    const hold = newCameraReleaseHold();
+    stepCameraReleaseHold(hold, { cameraOwned: true, camYaw: 2, interpFacing: 0, frameDt: 1 / 60 });
+    expect(
+      stepCameraReleaseHold(hold, {
+        cameraOwned: false,
+        camYaw: 2,
+        interpFacing: 0,
+        frameDt: 1 / 60,
+        manualTurn: true,
+      }),
+    ).toBe(true); // the breaking frame still suppresses (keeps lastInterpFacing fresh)
+    expect(
+      stepCameraReleaseHold(hold, {
+        cameraOwned: false,
+        camYaw: 2,
+        interpFacing: 0,
+        frameDt: 1 / 60,
+      }),
+    ).toBe(false);
+  });
+
+  it('plain moving settle stays frame-rate independent and never oscillates (regression pin)', () => {
+    const settleTrace = (fps: number): Array<{ t: number; yaw: number }> => {
+      const dtF = 1 / fps;
+      let camYaw = 1.2;
+      let lastInterpFacing: number | null = 0;
+      const trace: Array<{ t: number; yaw: number }> = [];
+      for (let f = 0; f * dtF < 1.0; f++) {
+        const next = updateFollowCameraYaw({
+          camYaw,
+          interpFacing: 0,
+          frameDt: dtF,
+          lastInterpFacing,
+          mouselook: false,
+          moving: true,
+          orbiting: false,
+        });
+        camYaw = next.camYaw;
+        lastInterpFacing = next.lastInterpFacing;
+        trace.push({ t: (f + 1) * dtF, yaw: camYaw });
+      }
+      return trace;
+    };
+    const sampleAt = (trace: Array<{ t: number; yaw: number }>, t: number): number => {
+      // linear interpolation between the two nearest frames
+      let i = 0;
+      while (i < trace.length - 1 && trace[i + 1].t < t) i++;
+      const a = trace[i];
+      const b = trace[Math.min(i + 1, trace.length - 1)];
+      if (b.t === a.t) return a.yaw;
+      const k = Math.min(1, Math.max(0, (t - a.t) / (b.t - a.t)));
+      return a.yaw + (b.yaw - a.yaw) * k;
+    };
+    const traces = [30, 60, 144].map(settleTrace);
+    for (const t of [0.1, 0.3, 0.5, 0.7, 0.9]) {
+      const yaws = traces.map((tr) => sampleAt(tr, t));
+      expect(Math.abs(yaws[0] - yaws[1])).toBeLessThanOrEqual(0.05);
+      expect(Math.abs(yaws[1] - yaws[2])).toBeLessThanOrEqual(0.05);
+    }
+    // No oscillation: the error decays toward 0 and never crosses below it.
+    for (const tr of traces) {
+      for (let i = 1; i < tr.length; i++) {
+        expect(tr[i].yaw).toBeLessThanOrEqual(tr[i - 1].yaw + 1e-9);
+        expect(tr[i].yaw).toBeGreaterThanOrEqual(-1e-9);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Problem

In the default control mode, releasing a right-mouse mouselook drag makes the camera visibly stutter as it settles: it keeps rotating briefly past where the player aimed, then stops dead (or gets dragged back while moving). Mouse Camera mode does not show it.

## Root cause

While the drag is live, the facing channel streams camYaw to the server and the mirrored, render-interpolated facing lags that stream by the measured input echo plus roughly one snapshot interval online (up to one 50 ms tick offline). The instant the drag releases, updateFollowCameraYaw re-engages and its rigid follow term (targetYaw += wrapAngle(interpFacing - lastInterpFacing)) replays the still-arriving echo of the drag straight into camYaw: the camera overshoots past the chosen heading by the echo residual. A frame-by-frame numeric repro on the pure module measured a 0.30 rad (17 deg) post-release kick for a 3 rad/s drag at a 100 ms echo, and 0.15 rad for the offline one-tick analogue.

Mouse Camera mode escapes it because a pure left/right-click camera drag never streams facing (the facing override there requires a movement key), so the mirror never moves and the same follow math computes a zero delta (repro: exactly 0 post-release motion). That is the whole mode asymmetry in the report.

## This is a regression, and this PR is a scoped reland

The exact fix already landed as 68fe706f7 (2026-07-10, "fix(game): hold camera follow through the touch-look release echo (no shake)", also covering touch swipe-look and the camera joystick) but rode inside the #1736 interface-overhaul branch and was deleted as unflagged collateral by the #1788 revert (a45d20eb3): 87 lines of camera_follow.ts and 262 test lines removed with no mention in the revert description.

Re-landed here standalone onto release/v0.26.0:

- src/game/camera_follow.ts: stepCameraReleaseHold, a pure release hold that latches the final camYaw on the falling edge of camera ownership and keeps follow disengaged (via the cameraDriven flag, which still advances lastInterpFacing so re-coupling never snaps) until the interpolated facing converges within 0.02 rad, a manual keyboard turn takes the heading, or an echo-scaled grace lapses (max(350, echo*1.5+120) ms, the same formula keyboard_turn_facing already ships).
- src/main.ts: wires the hold into updateCamera for both the offline and online paths, plumbing the measured input echo online.
- tests/camera_follow.test.ts: the restored 30/60/144 fps release-trace tests (pre-fix mechanism pin, no overshoot, no direction reversal, frame-rate-independent settling).

camera_follow.ts and the test file are byte-identical to the original commit; the main.ts wiring is byte-identical in body (only surrounding context drifted).

Overlap note: PR #1815 (the full #1736 restore, currently targeting v0.25.0) carries this same fix inside the overhaul; whichever lands second will hit a trivial identical-content conflict in these three files.

## Residual not covered here

A smaller, purely cosmetic character-model wobble remains on release: releaseSelfFacing (src/render/facing_smooth.ts) steps the model yaw toward the echo-lagged interpolated facing before snapshots deliver the released heading, a back-then-forward twitch of the body only. It cannot move the camera (camera placement reads only camYaw/camPitch/camDist plus position, never the mesh rotation). A follow-up could hold the model release target at the released camYaw until the mirror converges, mirroring the keyboard-turn grace pattern.

## Test plan

- [x] tests/camera_follow.test.ts: 21/21 green
- [x] Mutation check: forcing the fixed arm back to cameraDriven=false turns the no-overshoot and no-oscillation tests red, so the suite would catch a re-deletion
- [x] Adjacent suites green (69 tests): camera_driven_facing, facing_smooth, facing_stability, keyboard_turn_facing, mouselook_release_facing, self_motion
- [x] npm run gate: PASS, all 11 steps
- [x] QA gate (qa-checklist): READY, 0 blocking, 0 should-fix
- [ ] Manual on a live server: classic mode, flick right-drag and release at LAN and ~100 ms echo, camera stops where aimed with no settle kick; Mouse Camera mode drag and movement-key release unchanged