### PR TITLE
feat(rewards): automate and moderate daily payouts

### DIFF
--- a/server/daily_rewards.ts
+++ b/server/daily_rewards.ts
@@ -9,7 +9,14 @@ import type {
   DailyRewardSpinResult,
   DailyRewardStatus,
 } from '../src/world_api';
-import { type DailyRewardDb, type DailyRewardTaskSeed, PgDailyRewardDb } from './daily_rewards_db';
+import {
+  type DailyRewardDb,
+  type DailyRewardInternalPayoutRow,
+  type DailyRewardPayoutActor,
+  type DailyRewardPayoutAttemptRow,
+  type DailyRewardTaskSeed,
+  PgDailyRewardDb,
+} from './daily_rewards_db';
 import { accountAndScopeForToken, moderationStatusForAccount, walletForAccount } from './db';
 import { ctxAccountId } from './http/context';
 import { type BearerActiveGuardDb, createActiveGuard } from './http/middleware/bearer_active_guard';
@@ -1012,12 +1019,19 @@ export class DailyRewardService {
     await this.db.finalizeDay(previous, config.prizePoolUsd, DAILY_REWARD_SPLITS);
   }
 
-  async pendingPayouts(limit = 20): Promise<unknown> {
+  async pendingPayouts(limit = 20, day?: string): Promise<unknown> {
     await this.finalizePreviousDay();
-    return { payouts: await this.db.pendingPayouts(limit) };
+    return { payouts: await this.db.pendingPayouts(limit, day) };
   }
 
-  async markPayout(body: unknown): Promise<{ ok: true } | { error: string; status: number }> {
+  async markPayout(body: unknown): Promise<
+    | {
+        ok: true;
+        payout?: DailyRewardInternalPayoutRow;
+        attempt?: DailyRewardPayoutAttemptRow;
+      }
+    | { error: string; status: number }
+  > {
     const record = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
     const day = typeof record.day === 'string' ? record.day : '';
     const rank = Number(record.rank);
@@ -1027,11 +1041,123 @@ export class DailyRewardService {
     if (!/^\d{4}-\d{2}-\d{2}$/.test(day) || !Number.isInteger(rank) || rank < 1 || rank > 10) {
       return { error: 'invalid payout target', status: 400 };
     }
-    if (status !== 'paid' && status !== 'failed')
+    if (
+      !['processing', 'paid', 'failed', 'resend_processing', 'resent', 'resend_failed'].includes(
+        status,
+      )
+    )
       return { error: 'invalid payout status', status: 400 };
+    if (
+      ['processing', 'paid', 'resend_processing', 'resent', 'resend_failed'].includes(status) &&
+      !txSignature
+    ) {
+      return { error: 'transaction signature is required', status: 400 };
+    }
+    const signedTransaction =
+      typeof record.signedTransaction === 'string' ? record.signedTransaction : null;
+    if (signedTransaction && signedTransaction.length > 5000) {
+      return { error: 'signed transaction is too large', status: 400 };
+    }
+    const operationId = typeof record.operationId === 'string' ? record.operationId.trim() : '';
+    if (status.startsWith('resend') || status === 'resent') {
+      if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(operationId)) {
+        return { error: 'valid resend operation id is required', status: 400 };
+      }
+    }
+    if (status === 'processing') {
+      const result = await this.db.claimPayout(day, rank, txSignature as string, signedTransaction);
+      if (result.outcome === 'not_found') return { error: 'payout not found', status: 404 };
+      if (result.outcome === 'invalid_status') {
+        return { error: 'payout cannot be claimed', status: 409 };
+      }
+      return { ok: true, payout: result.payout };
+    }
+    if (status === 'resend_processing') {
+      const result = await this.db.claimPayoutResend(
+        day,
+        rank,
+        operationId,
+        txSignature as string,
+        signedTransaction,
+      );
+      if (result.outcome === 'not_found') return { error: 'paid payout not found', status: 404 };
+      if (result.outcome === 'invalid_status') {
+        return { error: 'only paid payouts can be resent', status: 409 };
+      }
+      return { ok: true, attempt: result.attempt };
+    }
+    if (status === 'resent' || status === 'resend_failed') {
+      const ok = await this.db.markPayoutResend(
+        day,
+        rank,
+        operationId,
+        status === 'resent' ? 'paid' : 'failed',
+        txSignature as string,
+        error,
+      );
+      return ok ? { ok: true } : { error: 'resend attempt not found', status: 404 };
+    }
     const ok = await this.db.markPayout(day, rank, status, txSignature, error);
     return ok ? { ok: true } : { error: 'payout not found', status: 404 };
   }
+
+  async voidPayout(
+    body: unknown,
+  ): Promise<
+    { ok: true; payout: DailyRewardInternalPayoutRow } | { error: string; status: number }
+  > {
+    const record = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+    const target = payoutModerationTarget(record);
+    if ('error' in target) return target;
+    const reason = typeof record.reason === 'string' ? record.reason.trim() : '';
+    if (reason.length < 3 || reason.length > 500) {
+      return { error: 'invalid void reason', status: 400 };
+    }
+    const actor = payoutModerationActor(record);
+    if (!actor) return { error: 'invalid payout actor', status: 400 };
+    const result = await this.db.voidPayout(target.day, target.rank, reason, actor);
+    if (result.outcome === 'not_found') return { error: 'payout not found', status: 404 };
+    if (result.outcome === 'invalid_status') {
+      return { error: 'payout cannot be voided', status: 409 };
+    }
+    return { ok: true, payout: result.payout };
+  }
+
+  async restorePayout(
+    body: unknown,
+  ): Promise<
+    { ok: true; payout: DailyRewardInternalPayoutRow } | { error: string; status: number }
+  > {
+    const record = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+    const target = payoutModerationTarget(record);
+    if ('error' in target) return target;
+    const actor = payoutModerationActor(record);
+    if (!actor) return { error: 'invalid payout actor', status: 400 };
+    const result = await this.db.restorePayout(target.day, target.rank, actor);
+    if (result.outcome === 'not_found') return { error: 'payout not found', status: 404 };
+    if (result.outcome === 'invalid_status') {
+      return { error: 'payout cannot be restored', status: 409 };
+    }
+    return { ok: true, payout: result.payout };
+  }
+}
+
+function payoutModerationTarget(
+  record: Record<string, unknown>,
+): { day: string; rank: number } | { error: string; status: 400 } {
+  const day = typeof record.day === 'string' ? record.day : '';
+  const rank = Number(record.rank);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(day) || !Number.isInteger(rank) || rank < 1 || rank > 10) {
+    return { error: 'invalid payout target', status: 400 };
+  }
+  return { day, rank };
+}
+
+function payoutModerationActor(record: Record<string, unknown>): DailyRewardPayoutActor | null {
+  const id = typeof record.actorId === 'string' ? record.actorId.trim() : '';
+  const username = typeof record.actorUsername === 'string' ? record.actorUsername.trim() : '';
+  if (!id || id.length > 200 || !username || username.length > 100) return null;
+  return { id, username };
 }
 
 function secretsMatch(actual: string, expected: string): boolean {
@@ -1100,8 +1226,14 @@ export async function handleDailyRewardInternalApi(
     return true;
   }
   if (req.method === 'POST' && url.pathname === '/internal/daily-rewards/pending-payouts') {
+    const requestedDay = url.searchParams.get('day');
+    if (requestedDay !== null && !/^\d{4}-\d{2}-\d{2}$/.test(requestedDay)) {
+      json(res, 400, { success: false, data: null, error: 'invalid reward day' });
+      return true;
+    }
     const data = await dailyRewardService.pendingPayouts(
       Number(url.searchParams.get('limit')) || DAILY_OPS_PENDING_PAYOUTS_LIMIT,
+      requestedDay ?? undefined,
     );
     json(res, 200, { success: true, data, error: null });
     return true;
@@ -1131,6 +1263,24 @@ export async function handleDailyRewardInternalApi(
     else json(res, 200, { success: true, data: result, error: null });
     return true;
   }
+  if (req.method === 'POST' && url.pathname === '/internal/daily-rewards/void-payout') {
+    const result = await dailyRewardService.voidPayout(await readBody(req));
+    if ('error' in result) {
+      json(res, result.status, { success: false, data: null, error: result.error });
+    } else {
+      json(res, 200, { success: true, data: result, error: null });
+    }
+    return true;
+  }
+  if (req.method === 'POST' && url.pathname === '/internal/daily-rewards/restore-payout') {
+    const result = await dailyRewardService.restorePayout(await readBody(req));
+    if ('error' in result) {
+      json(res, result.status, { success: false, data: null, error: result.error });
+    } else {
+      json(res, 200, { success: true, data: result, error: null });
+    }
+    return true;
+  }
   json(res, 404, { success: false, data: null, error: 'unknown endpoint' });
   return true;
 }
@@ -1145,6 +1295,8 @@ export async function handleDailyRewardInternalApi(
 //   POST /internal/daily-rewards/payout-history    payout service ops
 //   POST /internal/daily-rewards/leaderboard       payout service ops
 //   POST /internal/daily-rewards/mark-payout       payout service ops
+//   POST /internal/daily-rewards/void-payout       payout moderation ops
+//   POST /internal/daily-rewards/restore-payout    payout moderation ops
 // The legacy dispatch stays as the flag-off rollback path until the ladder-deletion PR: the
 // main.ts prefix arm (startsWith('/api/daily-rewards'), bearerActiveAccount
 // BEFORE delegating) for the player family, and the /internal composite
@@ -1161,7 +1313,7 @@ export async function handleDailyRewardInternalApi(
 // dailyRewardsOpsBodyValidationRemap deviation). Off-table shapes (wrong
 // method, unknown subpath, the no-slash '/api/daily-rewardsX' sibling, HEAD)
 // resolve unmatched and delegate to the ladder unchanged. v0.20.0 grew each
-// family by its paginated leaderboard read (four player + four ops routes).
+// family by its paginated leaderboard read (four player + six ops routes).
 //
 // The player guard is the shared legacy-body createActiveGuard (mirrors the
 // prefix arm's bearerActiveAccount byte-for-byte). The ops gate is the
@@ -1208,7 +1360,7 @@ export function resetDailyRewardDbForTests(): void {
 /** Full active session gate (mirrors the prefix arm's bearerActiveAccount). */
 const activeGuard = createActiveGuard(() => dailyRewardGuardDb());
 
-/** The fail-closed payout-service gate, one instance shared by the four ops routes. */
+/** The fail-closed payout-service gate, one instance shared by the six ops routes. */
 const dailyRewardOpsGate = requireInternalSecretFailClosed({
   header: DAILY_REWARD_SECRET_HEADER,
   envVar: DAILY_REWARD_SECRET_ENV,
@@ -1288,6 +1440,22 @@ export const routes: RouteDef[] = [
   {
     method: 'POST',
     path: '/internal/daily-rewards/mark-payout',
+    surface: 'internal',
+    meta: { envelope: 'admin' },
+    middleware: [dailyRewardOpsGate],
+    handler: dailyRewardOpsHandler,
+  },
+  {
+    method: 'POST',
+    path: '/internal/daily-rewards/void-payout',
+    surface: 'internal',
+    meta: { envelope: 'admin' },
+    middleware: [dailyRewardOpsGate],
+    handler: dailyRewardOpsHandler,
+  },
+  {
+    method: 'POST',
+    path: '/internal/daily-rewards/restore-payout',
     surface: 'internal',
     meta: { envelope: 'admin' },
     middleware: [dailyRewardOpsGate],

--- a/server/daily_rewards_db.ts
+++ b/server/daily_rewards_db.ts
@@ -46,6 +46,7 @@ export interface DailyRewardSpinRow {
 
 export interface DailyRewardPayoutRow {
   day: string;
+  realm: string;
   rank: number;
   accountId: number;
   username: string;
@@ -56,11 +57,43 @@ export interface DailyRewardPayoutRow {
   status: string;
   txSignature: string | null;
   paidAt: string | null;
+  voidReason: string | null;
+  voidedById: string | null;
+  voidedByUsername: string | null;
+  voidedAt: string | null;
 }
 
 export interface DailyRewardInternalPayoutRow extends DailyRewardPayoutRow {
   realm: string;
+  signedTransaction: string | null;
 }
+
+export interface DailyRewardPayoutActor {
+  id: string;
+  username: string;
+}
+
+export type DailyRewardPayoutModerationResult =
+  | { outcome: 'updated'; payout: DailyRewardInternalPayoutRow }
+  | { outcome: 'not_found' }
+  | { outcome: 'invalid_status'; status: string };
+
+export type DailyRewardPayoutClaimResult =
+  | { outcome: 'claimed' | 'existing'; payout: DailyRewardInternalPayoutRow }
+  | { outcome: 'not_found' }
+  | { outcome: 'invalid_status'; status: string };
+
+export interface DailyRewardPayoutAttemptRow {
+  status: 'prepared' | 'paid' | 'failed';
+  operationId: string;
+  txSignature: string;
+  signedTransaction: string | null;
+}
+
+export type DailyRewardPayoutAttemptClaimResult =
+  | { outcome: 'claimed' | 'existing'; attempt: DailyRewardPayoutAttemptRow }
+  | { outcome: 'not_found' }
+  | { outcome: 'invalid_status'; status: string };
 
 export interface DailyRewardWinnerAnnouncement {
   day: string;
@@ -105,7 +138,7 @@ export interface DailyRewardDb {
   ): Promise<boolean>;
   recentPayouts(limit: number): Promise<DailyRewardPayoutRow[]>;
   finalizeDay(day: string, prizePoolUsd: number, splits: readonly number[]): Promise<void>;
-  pendingPayouts(limit: number): Promise<DailyRewardInternalPayoutRow[]>;
+  pendingPayouts(limit: number, day?: string): Promise<DailyRewardInternalPayoutRow[]>;
   unannouncedWinnerDays(limit: number): Promise<DailyRewardWinnerAnnouncement[]>;
   markWinnersAnnounced(day: string): Promise<boolean>;
   markPayout(
@@ -115,6 +148,38 @@ export interface DailyRewardDb {
     txSignature: string | null,
     error: string | null,
   ): Promise<boolean>;
+  claimPayout(
+    day: string,
+    rank: number,
+    txSignature: string,
+    signedTransaction: string | null,
+  ): Promise<DailyRewardPayoutClaimResult>;
+  claimPayoutResend(
+    day: string,
+    rank: number,
+    operationId: string,
+    txSignature: string,
+    signedTransaction: string | null,
+  ): Promise<DailyRewardPayoutAttemptClaimResult>;
+  markPayoutResend(
+    day: string,
+    rank: number,
+    operationId: string,
+    status: 'paid' | 'failed',
+    txSignature: string,
+    error: string | null,
+  ): Promise<boolean>;
+  voidPayout(
+    day: string,
+    rank: number,
+    reason: string,
+    actor: DailyRewardPayoutActor,
+  ): Promise<DailyRewardPayoutModerationResult>;
+  restorePayout(
+    day: string,
+    rank: number,
+    actor: DailyRewardPayoutActor,
+  ): Promise<DailyRewardPayoutModerationResult>;
 }
 
 export interface DailyRewardTaskSeed {
@@ -142,6 +207,7 @@ function recordConfig(value: unknown): Record<string, unknown> {
 function payoutRow(row: Record<string, unknown>): DailyRewardPayoutRow {
   return {
     day: String(row.day),
+    realm: String(row.realm),
     rank: Number(row.rank),
     accountId: Number(row.account_id),
     username: String(row.username),
@@ -151,7 +217,19 @@ function payoutRow(row: Record<string, unknown>): DailyRewardPayoutRow {
     prizeUsd: Number(row.prize_usd),
     status: String(row.status),
     txSignature: optionalString(row.tx_signature),
-    paidAt: optionalString(row.paid_at),
+    paidAt: dateString(row.paid_at),
+    voidReason: optionalString(row.void_reason),
+    voidedById: optionalString(row.voided_by_id),
+    voidedByUsername: optionalString(row.voided_by_username),
+    voidedAt: dateString(row.voided_at),
+  };
+}
+
+function internalPayoutRow(row: Record<string, unknown>): DailyRewardInternalPayoutRow {
+  return {
+    ...payoutRow(row),
+    realm: String(row.realm),
+    signedTransaction: optionalString(row.signed_transaction),
   };
 }
 
@@ -513,14 +591,16 @@ export class PgDailyRewardDb implements DailyRewardDb {
 
   async recentPayouts(limit: number): Promise<DailyRewardPayoutRow[]> {
     const res = await pool.query(
-      `SELECT p.day, p.rank, p.account_id, p.username,
+      `SELECT p.day, p.realm, p.rank, p.account_id, p.username,
               COALESCE(p.wallet_pubkey, wl.pubkey) AS wallet_pubkey, p.points, p.prize_percent,
-              p.prize_usd, p.status, p.tx_signature, p.paid_at
+              p.prize_usd, p.status, p.tx_signature, p.paid_at, p.void_reason,
+              p.voided_by_id, p.voided_by_username, p.voided_at
          FROM daily_reward_payouts p
          LEFT JOIN wallet_links wl ON wl.account_id = p.account_id
+        WHERE p.realm = $1
         ORDER BY p.day DESC, p.rank ASC
-        LIMIT $1`,
-      [Math.max(1, Math.min(100, limit))],
+        LIMIT $2`,
+      [REALM, Math.max(1, Math.min(100, limit))],
     );
     return res.rows.map(payoutRow);
   }
@@ -578,22 +658,29 @@ export class PgDailyRewardDb implements DailyRewardDb {
     }
   }
 
-  async pendingPayouts(limit: number): Promise<DailyRewardInternalPayoutRow[]> {
+  async pendingPayouts(limit: number, day?: string): Promise<DailyRewardInternalPayoutRow[]> {
+    const boundedLimit = Math.max(1, Math.min(100, limit));
+    const dayFilter = day ? 'AND p.day = $2' : '';
+    const limitPlaceholder = day ? '$3' : '$2';
     const res = await pool.query(
       `SELECT p.day, p.realm, p.rank, p.account_id, p.username,
               COALESCE(p.wallet_pubkey, wl.pubkey) AS wallet_pubkey, p.points,
-              p.prize_percent, p.prize_usd, p.status, p.tx_signature, p.paid_at
+              p.prize_percent, p.prize_usd, p.status, p.tx_signature, p.paid_at,
+              p.signed_transaction, p.void_reason, p.voided_by_id,
+              p.voided_by_username, p.voided_at
          FROM daily_reward_payouts p
          LEFT JOIN wallet_links wl ON wl.account_id = p.account_id
-        WHERE p.status IN ('pending', 'failed')
+        WHERE p.realm = $1
+          AND p.status IN ('pending', 'failed', 'processing')
+          ${dayFilter}
           AND EXISTS (SELECT 1 FROM accounts a
                        WHERE a.id = p.account_id AND ${ELIGIBLE_ACCOUNT_SQL})
           AND NOT EXISTS (SELECT 1 FROM daily_reward_excluded_accounts b WHERE b.account_id = p.account_id)
         ORDER BY p.day ASC, p.rank ASC
-        LIMIT $1`,
-      [Math.max(1, Math.min(100, limit))],
+        LIMIT ${limitPlaceholder}`,
+      day ? [REALM, day, boundedLimit] : [REALM, boundedLimit],
     );
-    return res.rows.map((row) => ({ ...payoutRow(row), realm: String(row.realm) }));
+    return res.rows.map(internalPayoutRow);
   }
 
   async unannouncedWinnerDays(limit: number): Promise<DailyRewardWinnerAnnouncement[]> {
@@ -617,7 +704,8 @@ export class PgDailyRewardDb implements DailyRewardDb {
       const payouts = await pool.query(
         `SELECT p.day, p.realm, p.rank, p.account_id, p.username,
                 COALESCE(p.wallet_pubkey, wl.pubkey) AS wallet_pubkey, p.points,
-                p.prize_percent, p.prize_usd, p.status, p.tx_signature, p.paid_at
+                p.prize_percent, p.prize_usd, p.status, p.tx_signature, p.paid_at,
+                p.void_reason, p.voided_by_id, p.voided_by_username, p.voided_at
            FROM daily_reward_payouts p
            LEFT JOIN wallet_links wl ON wl.account_id = p.account_id
           WHERE p.day = $1 AND p.realm = $2
@@ -631,7 +719,7 @@ export class PgDailyRewardDb implements DailyRewardDb {
         realm: String(day.realm),
         prizePoolUsd: Number(day.prize_pool_usd),
         finalizedAt: dateString(day.finalized_at),
-        payouts: payouts.rows.map((row) => ({ ...payoutRow(row), realm: String(row.realm) })),
+        payouts: payouts.rows.map(internalPayoutRow),
       });
     }
     return out;
@@ -654,16 +742,388 @@ export class PgDailyRewardDb implements DailyRewardDb {
     txSignature: string | null,
     error: string | null,
   ): Promise<boolean> {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const res = await client.query(
+        `UPDATE daily_reward_payouts
+            SET status = $4,
+                error = $6,
+                paid_at = CASE WHEN $4 = 'paid' THEN now() ELSE paid_at END,
+                updated_at = now()
+          WHERE day = $1 AND realm = $2 AND rank = $3
+            AND (
+              (status = 'processing' AND tx_signature = $5)
+              OR (status IN ('pending', 'failed') AND $4 = 'failed' AND $5 IS NULL)
+            )`,
+        [day, REALM, rank, status, txSignature, error],
+      );
+      let updated = (res.rowCount ?? 0) === 1;
+      if (!updated && status === 'paid' && txSignature) {
+        const existing = await client.query(
+          `SELECT 1
+             FROM daily_reward_payouts
+            WHERE day = $1 AND realm = $2 AND rank = $3
+              AND status = 'paid' AND tx_signature = $4`,
+          [day, REALM, rank, txSignature],
+        );
+        updated = (existing.rowCount ?? 0) === 1;
+      }
+      if ((res.rowCount ?? 0) === 1 && txSignature) {
+        await client.query(
+          `UPDATE daily_reward_payout_attempts
+              SET status = $4, error = $5, updated_at = now()
+            WHERE day = $1 AND realm = $2 AND rank = $3
+              AND tx_signature = $6 AND kind = 'payout'`,
+          [day, REALM, rank, status, error, txSignature],
+        );
+      }
+      await client.query('COMMIT');
+      return updated;
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => undefined);
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async claimPayout(
+    day: string,
+    rank: number,
+    txSignature: string,
+    signedTransaction: string | null,
+  ): Promise<DailyRewardPayoutClaimResult> {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const current = await client.query(
+        `SELECT p.day, p.realm, p.rank, p.account_id, p.username,
+                COALESCE(p.wallet_pubkey, wl.pubkey) AS wallet_pubkey, p.points,
+                p.prize_percent, p.prize_usd, p.status, p.tx_signature, p.paid_at,
+                p.signed_transaction, p.void_reason, p.voided_by_id,
+                p.voided_by_username, p.voided_at
+           FROM daily_reward_payouts p
+           LEFT JOIN wallet_links wl ON wl.account_id = p.account_id
+          WHERE p.day = $1 AND p.realm = $2 AND p.rank = $3
+          FOR UPDATE OF p`,
+        [day, REALM, rank],
+      );
+      const row = current.rows[0] as Record<string, unknown> | undefined;
+      if (!row) {
+        await client.query('COMMIT');
+        return { outcome: 'not_found' };
+      }
+      const status = String(row.status);
+      if (status === 'processing' || status === 'paid') {
+        await client.query('COMMIT');
+        return { outcome: 'existing', payout: internalPayoutRow(row) };
+      }
+      if (status !== 'pending' && status !== 'failed') {
+        await client.query('COMMIT');
+        return { outcome: 'invalid_status', status };
+      }
+      await client.query(
+        `INSERT INTO daily_reward_payout_attempts
+          (day, realm, rank, kind, status, tx_signature, signed_transaction)
+         VALUES ($1, $2, $3, 'payout', 'prepared', $4, $5)`,
+        [day, REALM, rank, txSignature, signedTransaction],
+      );
+      await client.query(
+        `UPDATE daily_reward_payouts
+            SET status = 'processing', tx_signature = $4, signed_transaction = $5,
+                error = NULL, updated_at = now()
+          WHERE day = $1 AND realm = $2 AND rank = $3`,
+        [day, REALM, rank, txSignature, signedTransaction],
+      );
+      await client.query('COMMIT');
+      return {
+        outcome: 'claimed',
+        payout: internalPayoutRow({
+          ...row,
+          status: 'processing',
+          tx_signature: txSignature,
+          signed_transaction: signedTransaction,
+        }),
+      };
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => undefined);
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async claimPayoutResend(
+    day: string,
+    rank: number,
+    operationId: string,
+    txSignature: string,
+    signedTransaction: string | null,
+  ): Promise<DailyRewardPayoutAttemptClaimResult> {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const payout = await client.query(
+        `SELECT status
+           FROM daily_reward_payouts
+          WHERE day = $1 AND realm = $2 AND rank = $3
+          FOR UPDATE`,
+        [day, REALM, rank],
+      );
+      if (!payout.rows[0]) {
+        await client.query('COMMIT');
+        return { outcome: 'not_found' };
+      }
+      if (String(payout.rows[0].status) !== 'paid') {
+        await client.query('COMMIT');
+        return { outcome: 'invalid_status', status: String(payout.rows[0].status) };
+      }
+      const existing = await client.query(
+        `SELECT status, operation_id, tx_signature, signed_transaction
+           FROM daily_reward_payout_attempts
+          WHERE day = $1 AND realm = $2 AND rank = $3
+            AND kind = 'resend' AND operation_id = $4
+          ORDER BY id DESC
+          LIMIT 1`,
+        [day, REALM, rank, operationId],
+      );
+      if (existing.rows[0]) {
+        await client.query('COMMIT');
+        return {
+          outcome: 'existing',
+          attempt: {
+            status: String(existing.rows[0].status) as 'prepared' | 'paid' | 'failed',
+            operationId: String(existing.rows[0].operation_id),
+            txSignature: String(existing.rows[0].tx_signature),
+            signedTransaction: optionalString(existing.rows[0].signed_transaction),
+          },
+        };
+      }
+      await client.query(
+        `INSERT INTO daily_reward_payout_attempts
+          (day, realm, rank, kind, operation_id, status, tx_signature, signed_transaction)
+         VALUES ($1, $2, $3, 'resend', $4, 'prepared', $5, $6)`,
+        [day, REALM, rank, operationId, txSignature, signedTransaction],
+      );
+      await client.query('COMMIT');
+      return {
+        outcome: 'claimed',
+        attempt: { status: 'prepared', operationId, txSignature, signedTransaction },
+      };
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => undefined);
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async markPayoutResend(
+    day: string,
+    rank: number,
+    operationId: string,
+    status: 'paid' | 'failed',
+    txSignature: string,
+    error: string | null,
+  ): Promise<boolean> {
     const res = await pool.query(
-      `UPDATE daily_reward_payouts
-          SET status = $4,
-              tx_signature = $5,
-              error = $6,
-              paid_at = CASE WHEN $4 = 'paid' THEN now() ELSE paid_at END,
-              updated_at = now()
-        WHERE day = $1 AND realm = $2 AND rank = $3`,
-      [day, REALM, rank, status, txSignature, error],
+      `UPDATE daily_reward_payout_attempts a
+          SET status = $5, error = $7, updated_at = now()
+        WHERE a.day = $1 AND a.realm = $2 AND a.rank = $3
+          AND a.kind = 'resend' AND a.operation_id = $4
+          AND a.status = 'prepared' AND a.tx_signature = $6
+          AND EXISTS (
+            SELECT 1 FROM daily_reward_payouts p
+             WHERE p.day = a.day AND p.realm = a.realm AND p.rank = a.rank
+               AND p.status = 'paid'
+          )`,
+      [day, REALM, rank, operationId, status, txSignature, error],
     );
-    return (res.rowCount ?? 0) > 0;
+    if ((res.rowCount ?? 0) > 0) return true;
+    if (status !== 'paid') return false;
+    const existing = await pool.query(
+      `SELECT 1 FROM daily_reward_payout_attempts
+        WHERE day = $1 AND realm = $2 AND rank = $3
+          AND kind = 'resend' AND operation_id = $4
+          AND status = 'paid' AND tx_signature = $5`,
+      [day, REALM, rank, operationId, txSignature],
+    );
+    return (existing.rowCount ?? 0) > 0;
+  }
+
+  async voidPayout(
+    day: string,
+    rank: number,
+    reason: string,
+    actor: DailyRewardPayoutActor,
+  ): Promise<DailyRewardPayoutModerationResult> {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const current = await client.query(
+        `SELECT p.day, p.realm, p.rank, p.account_id, p.username,
+                COALESCE(p.wallet_pubkey, wl.pubkey) AS wallet_pubkey, p.points,
+                p.prize_percent, p.prize_usd, p.status, p.tx_signature, p.paid_at,
+                p.void_reason, p.voided_by_id, p.voided_by_username, p.voided_at
+           FROM daily_reward_payouts p
+           LEFT JOIN wallet_links wl ON wl.account_id = p.account_id
+          WHERE p.day = $1 AND p.realm = $2 AND p.rank = $3
+          FOR UPDATE OF p`,
+        [day, REALM, rank],
+      );
+      const row = current.rows[0] as Record<string, unknown> | undefined;
+      if (!row) {
+        await client.query('COMMIT');
+        return { outcome: 'not_found' };
+      }
+      const previousStatus = String(row.status);
+      if (previousStatus !== 'pending' && previousStatus !== 'failed') {
+        await client.query('COMMIT');
+        return { outcome: 'invalid_status', status: previousStatus };
+      }
+      const updated = await client.query(
+        `UPDATE daily_reward_payouts
+            SET status = 'voided',
+                void_reason = $4,
+                voided_by_id = $5,
+                voided_by_username = $6,
+                voided_at = now(),
+                updated_at = now()
+          WHERE day = $1 AND realm = $2 AND rank = $3
+            AND status IN ('pending', 'failed')
+        RETURNING voided_at`,
+        [day, REALM, rank, reason, actor.id, actor.username],
+      );
+      if ((updated.rowCount ?? 0) !== 1) throw new Error('payout void transition lost its lock');
+      await client.query(
+        `INSERT INTO daily_reward_payout_moderation_audit
+          (day, realm, rank, account_id, action, previous_status, next_status, reason,
+           actor_id, actor_username)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+        [
+          day,
+          REALM,
+          rank,
+          Number(row.account_id),
+          'void',
+          previousStatus,
+          'voided',
+          reason,
+          actor.id,
+          actor.username,
+        ],
+      );
+      await client.query('COMMIT');
+      return {
+        outcome: 'updated',
+        payout: {
+          ...internalPayoutRow({
+            ...row,
+            status: 'voided',
+            void_reason: reason,
+            voided_by_id: actor.id,
+            voided_by_username: actor.username,
+            voided_at: updated.rows[0]?.voided_at,
+          }),
+        },
+      };
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => undefined);
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async restorePayout(
+    day: string,
+    rank: number,
+    actor: DailyRewardPayoutActor,
+  ): Promise<DailyRewardPayoutModerationResult> {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const current = await client.query(
+        `SELECT p.day, p.realm, p.rank, p.account_id, p.username,
+                COALESCE(p.wallet_pubkey, wl.pubkey) AS wallet_pubkey, p.points,
+                p.prize_percent, p.prize_usd, p.status, p.tx_signature, p.paid_at,
+                p.void_reason, p.voided_by_id, p.voided_by_username, p.voided_at
+           FROM daily_reward_payouts p
+           LEFT JOIN wallet_links wl ON wl.account_id = p.account_id
+          WHERE p.day = $1 AND p.realm = $2 AND p.rank = $3
+          FOR UPDATE OF p`,
+        [day, REALM, rank],
+      );
+      const row = current.rows[0] as Record<string, unknown> | undefined;
+      if (!row) {
+        await client.query('COMMIT');
+        return { outcome: 'not_found' };
+      }
+      const previousStatus = String(row.status);
+      if (previousStatus !== 'voided') {
+        await client.query('COMMIT');
+        return { outcome: 'invalid_status', status: previousStatus };
+      }
+      const reason = optionalString(row.void_reason) ?? 'Unknown void reason';
+      const updated = await client.query(
+        `UPDATE daily_reward_payouts
+            SET status = 'pending',
+                tx_signature = NULL,
+                signed_transaction = NULL,
+                error = NULL,
+                void_reason = NULL,
+                voided_by_id = NULL,
+                voided_by_username = NULL,
+                voided_at = NULL,
+                updated_at = now()
+          WHERE day = $1 AND realm = $2 AND rank = $3
+            AND status = 'voided'
+        RETURNING status`,
+        [day, REALM, rank],
+      );
+      if ((updated.rowCount ?? 0) !== 1) {
+        throw new Error('payout restore transition lost its lock');
+      }
+      await client.query(
+        `INSERT INTO daily_reward_payout_moderation_audit
+          (day, realm, rank, account_id, action, previous_status, next_status, reason,
+           actor_id, actor_username)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+        [
+          day,
+          REALM,
+          rank,
+          Number(row.account_id),
+          'restore',
+          previousStatus,
+          'pending',
+          reason,
+          actor.id,
+          actor.username,
+        ],
+      );
+      await client.query('COMMIT');
+      return {
+        outcome: 'updated',
+        payout: {
+          ...internalPayoutRow({
+            ...row,
+            status: 'pending',
+            tx_signature: null,
+            signed_transaction: null,
+            void_reason: null,
+            voided_by_id: null,
+            voided_by_username: null,
+            voided_at: null,
+          }),
+        },
+      };
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => undefined);
+      throw err;
+    } finally {
+      client.release();
+    }
   }
 }

--- a/server/db.ts
+++ b/server/db.ts
@@ -711,8 +711,50 @@ CREATE TABLE IF NOT EXISTS daily_reward_payouts (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (day, realm, rank)
 );
+ALTER TABLE daily_reward_payouts ADD COLUMN IF NOT EXISTS void_reason TEXT;
+ALTER TABLE daily_reward_payouts ADD COLUMN IF NOT EXISTS voided_by_id TEXT;
+ALTER TABLE daily_reward_payouts ADD COLUMN IF NOT EXISTS voided_by_username TEXT;
+ALTER TABLE daily_reward_payouts ADD COLUMN IF NOT EXISTS voided_at TIMESTAMPTZ;
+ALTER TABLE daily_reward_payouts ADD COLUMN IF NOT EXISTS signed_transaction TEXT;
 CREATE INDEX IF NOT EXISTS daily_reward_payouts_status
   ON daily_reward_payouts(status, day DESC, realm);
+CREATE TABLE IF NOT EXISTS daily_reward_payout_moderation_audit (
+  id BIGSERIAL PRIMARY KEY,
+  day TEXT NOT NULL,
+  realm TEXT NOT NULL,
+  rank INT NOT NULL,
+  account_id INT NOT NULL,
+  action TEXT NOT NULL CHECK (action IN ('void', 'restore')),
+  previous_status TEXT NOT NULL,
+  next_status TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  actor_id TEXT NOT NULL,
+  actor_username TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS daily_reward_payout_moderation_target
+  ON daily_reward_payout_moderation_audit(day, realm, rank, created_at DESC);
+CREATE TABLE IF NOT EXISTS daily_reward_payout_attempts (
+  id BIGSERIAL PRIMARY KEY,
+  day TEXT NOT NULL,
+  realm TEXT NOT NULL,
+  rank INT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('payout', 'resend')),
+  operation_id TEXT,
+  status TEXT NOT NULL CHECK (status IN ('prepared', 'paid', 'failed')),
+  tx_signature TEXT NOT NULL UNIQUE,
+  signed_transaction TEXT,
+  error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  FOREIGN KEY (day, realm, rank) REFERENCES daily_reward_payouts(day, realm, rank)
+);
+CREATE INDEX IF NOT EXISTS daily_reward_payout_attempts_target
+  ON daily_reward_payout_attempts(day, realm, rank, created_at DESC);
+ALTER TABLE daily_reward_payout_attempts ADD COLUMN IF NOT EXISTS operation_id TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS daily_reward_payout_attempts_operation
+  ON daily_reward_payout_attempts(day, realm, rank, kind, operation_id)
+  WHERE operation_id IS NOT NULL;
 -- Shareable player cards (docs/prd/woc/player-card.md). One card per character;
 -- the PNG is composited client-side and stored here as bytes so any realm
 -- process (all share this database) can serve /p/<slug> and the OG image. slug

--- a/tests/daily_rewards.test.ts
+++ b/tests/daily_rewards.test.ts
@@ -2,6 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   DailyRewardDb,
   DailyRewardInternalPayoutRow,
+  DailyRewardPayoutActor,
+  DailyRewardPayoutAttemptClaimResult,
+  DailyRewardPayoutClaimResult,
+  DailyRewardPayoutModerationResult,
   DailyRewardPayoutRow,
   DailyRewardScoreRow,
   DailyRewardSpinRow,
@@ -173,6 +177,30 @@ class FakeDailyRewardDb implements DailyRewardDb {
   }
   async markPayout(): Promise<boolean> {
     return true;
+  }
+  async claimPayout(): Promise<DailyRewardPayoutClaimResult> {
+    return { outcome: 'not_found' };
+  }
+  async claimPayoutResend(): Promise<DailyRewardPayoutAttemptClaimResult> {
+    return { outcome: 'not_found' };
+  }
+  async markPayoutResend(): Promise<boolean> {
+    return true;
+  }
+  async voidPayout(
+    _day: string,
+    _rank: number,
+    _reason: string,
+    _actor: DailyRewardPayoutActor,
+  ): Promise<DailyRewardPayoutModerationResult> {
+    return { outcome: 'not_found' };
+  }
+  async restorePayout(
+    _day: string,
+    _rank: number,
+    _actor: DailyRewardPayoutActor,
+  ): Promise<DailyRewardPayoutModerationResult> {
+    return { outcome: 'not_found' };
   }
 }
 

--- a/tests/daily_rewards_payout_moderation_db.test.ts
+++ b/tests/daily_rewards_payout_moderation_db.test.ts
@@ -1,0 +1,452 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const state = {
+    row: null as Record<string, unknown> | null,
+    audit: [] as Array<{ sql: string; params: unknown[] }>,
+    attempts: [] as Array<{
+      kind: 'payout' | 'resend';
+      status: 'prepared' | 'paid' | 'failed';
+      operationId: unknown;
+      signature: unknown;
+      transaction: unknown;
+    }>,
+  };
+  const query = vi.fn(async (sql: string, params: unknown[] = []) => {
+    const statement = String(sql);
+    if (statement.includes('FOR UPDATE OF p')) {
+      return { rows: state.row ? [{ ...state.row }] : [], rowCount: state.row ? 1 : 0 };
+    }
+    if (statement.includes('SELECT status') && statement.includes('FOR UPDATE')) {
+      return state.row
+        ? { rows: [{ status: state.row.status }], rowCount: 1 }
+        : { rows: [], rowCount: 0 };
+    }
+    if (
+      statement.includes('SELECT status, operation_id, tx_signature, signed_transaction') &&
+      statement.includes("kind = 'resend'")
+    ) {
+      const attempt = [...state.attempts]
+        .reverse()
+        .find((item) => item.kind === 'resend' && item.operationId === params[3]);
+      return attempt
+        ? {
+            rows: [
+              {
+                status: attempt.status,
+                operation_id: attempt.operationId,
+                tx_signature: attempt.signature,
+                signed_transaction: attempt.transaction,
+              },
+            ],
+            rowCount: 1,
+          }
+        : { rows: [], rowCount: 0 };
+    }
+    if (statement.includes('SELECT 1') && statement.includes('FROM daily_reward_payout_attempts')) {
+      const matches = state.attempts.some(
+        (item) =>
+          item.kind === 'resend' &&
+          item.status === 'paid' &&
+          item.operationId === params[3] &&
+          item.signature === params[4],
+      );
+      return { rows: matches ? [{ '?column?': 1 }] : [], rowCount: matches ? 1 : 0 };
+    }
+    if (statement.includes('SELECT 1') && statement.includes("status = 'paid'")) {
+      const matches = state.row?.status === 'paid' && state.row.tx_signature === params[3];
+      return { rows: matches ? [{ '?column?': 1 }] : [], rowCount: matches ? 1 : 0 };
+    }
+    if (statement.includes("SET status = 'voided'")) {
+      if (!state.row || !['pending', 'failed'].includes(String(state.row.status))) {
+        return { rows: [], rowCount: 0 };
+      }
+      state.row = {
+        ...state.row,
+        status: 'voided',
+        void_reason: params[3],
+        voided_by_id: params[4],
+        voided_by_username: params[5],
+        voided_at: new Date('2026-07-15T01:02:03.000Z'),
+      };
+      return { rows: [{ ...state.row }], rowCount: 1 };
+    }
+    if (statement.includes("SET status = 'pending'")) {
+      if (state.row?.status !== 'voided') return { rows: [], rowCount: 0 };
+      state.row = {
+        ...state.row,
+        status: 'pending',
+        void_reason: null,
+        voided_by_id: null,
+        voided_by_username: null,
+        voided_at: null,
+      };
+      return { rows: [{ ...state.row }], rowCount: 1 };
+    }
+    if (statement.includes('INSERT INTO daily_reward_payout_attempts')) {
+      const resend = statement.includes("'resend'");
+      state.attempts.push({
+        kind: resend ? 'resend' : 'payout',
+        status: 'prepared',
+        operationId: resend ? params[3] : null,
+        signature: params[resend ? 4 : 3],
+        transaction: params[resend ? 5 : 4],
+      });
+      return { rows: [], rowCount: 1 };
+    }
+    if (
+      statement.includes('UPDATE daily_reward_payout_attempts') &&
+      statement.includes("kind = 'resend'")
+    ) {
+      const attempt = state.attempts.find(
+        (item) =>
+          item.kind === 'resend' &&
+          item.status === 'prepared' &&
+          item.operationId === params[3] &&
+          item.signature === params[5],
+      );
+      if (!attempt) return { rows: [], rowCount: 0 };
+      attempt.status = params[4] as 'paid' | 'failed';
+      return { rows: [], rowCount: 1 };
+    }
+    if (statement.includes("SET status = 'processing'")) {
+      if (!state.row) return { rows: [], rowCount: 0 };
+      state.row = {
+        ...state.row,
+        status: 'processing',
+        tx_signature: params[3],
+        signed_transaction: params[4],
+      };
+      return { rows: [{ ...state.row }], rowCount: 1 };
+    }
+    if (statement.includes('INSERT INTO daily_reward_payout_moderation_audit')) {
+      state.audit.push({ sql: statement, params });
+      return { rows: [], rowCount: 1 };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+  const release = vi.fn();
+  return {
+    state,
+    query,
+    release,
+    connect: vi.fn(async () => ({ query, release })),
+    poolQuery: vi.fn(async (_sql: string, _params: unknown[] = []) => ({ rows: [], rowCount: 0 })),
+  };
+});
+
+vi.mock('../server/db', () => ({
+  ELIGIBLE_ACCOUNT_SQL: 'a.banned_at IS NULL',
+  pool: { query: h.poolQuery, connect: h.connect },
+}));
+vi.mock('../server/realm', () => ({ REALM: 'test-realm' }));
+
+import { PgDailyRewardDb } from '../server/daily_rewards_db';
+
+function payout(status: string): Record<string, unknown> {
+  return {
+    day: '2026-07-14',
+    realm: 'test-realm',
+    rank: 1,
+    account_id: 42,
+    username: 'alice',
+    wallet_pubkey: 'Wallet111',
+    points: 500,
+    prize_percent: '0.2',
+    prize_usd: '30',
+    status,
+    tx_signature: null,
+    paid_at: null,
+    void_reason: null,
+    voided_by_id: null,
+    voided_by_username: null,
+    voided_at: null,
+  };
+}
+
+describe('daily reward payout moderation persistence', () => {
+  beforeEach(() => {
+    h.state.row = payout('pending');
+    h.state.audit.length = 0;
+    h.state.attempts.length = 0;
+    h.query.mockClear();
+    h.connect.mockClear();
+    h.release.mockClear();
+    h.poolQuery.mockClear();
+  });
+
+  it.each([
+    'pending',
+    'failed',
+  ])('atomically voids a %s payout and appends an audit row', async (status) => {
+    h.state.row = payout(status);
+
+    const result = await new PgDailyRewardDb().voidPayout(
+      '2026-07-14',
+      1,
+      'Payment requires manual review',
+      { id: 'operator-7', username: 'moderator' },
+    );
+
+    expect(result.outcome).toBe('updated');
+    if (result.outcome === 'updated') {
+      expect(result.payout).toMatchObject({
+        status: 'voided',
+        voidReason: 'Payment requires manual review',
+        voidedById: 'operator-7',
+        voidedByUsername: 'moderator',
+        voidedAt: '2026-07-15T01:02:03.000Z',
+      });
+    }
+    expect(h.state.audit).toHaveLength(1);
+    expect(h.state.audit[0].params).toEqual([
+      '2026-07-14',
+      'test-realm',
+      1,
+      42,
+      'void',
+      status,
+      'voided',
+      'Payment requires manual review',
+      'operator-7',
+      'moderator',
+    ]);
+    expect(h.query.mock.calls.map(([sql]) => String(sql))).toEqual(
+      expect.arrayContaining(['BEGIN', 'COMMIT']),
+    );
+    expect(h.release).toHaveBeenCalledOnce();
+  });
+
+  it('protects paid payouts from voiding without writing audit history', async () => {
+    h.state.row = payout('paid');
+
+    const result = await new PgDailyRewardDb().voidPayout('2026-07-14', 1, 'Too late', {
+      id: 'operator-7',
+      username: 'moderator',
+    });
+
+    expect(result).toEqual({ outcome: 'invalid_status', status: 'paid' });
+    expect(h.state.row.status).toBe('paid');
+    expect(h.state.audit).toEqual([]);
+  });
+
+  it('atomically restores only voided payouts to pending and retains the void reason in audit', async () => {
+    h.state.row = {
+      ...payout('voided'),
+      void_reason: 'Duplicate winner account',
+      voided_by_id: 'operator-7',
+      voided_by_username: 'moderator',
+      voided_at: new Date('2026-07-15T01:02:03.000Z'),
+    };
+
+    const result = await new PgDailyRewardDb().restorePayout('2026-07-14', 1, {
+      id: 'operator-8',
+      username: 'reviewer',
+    });
+
+    expect(result.outcome).toBe('updated');
+    if (result.outcome === 'updated') {
+      expect(result.payout).toMatchObject({
+        status: 'pending',
+        voidReason: null,
+        voidedById: null,
+        voidedByUsername: null,
+        voidedAt: null,
+      });
+    }
+    expect(h.state.audit).toHaveLength(1);
+    expect(h.state.audit[0].params).toEqual([
+      '2026-07-14',
+      'test-realm',
+      1,
+      42,
+      'restore',
+      'voided',
+      'pending',
+      'Duplicate winner account',
+      'operator-8',
+      'reviewer',
+    ]);
+  });
+
+  it('keeps voided payouts out of pending work and prevents mark-payout from overwriting them', async () => {
+    const db = new PgDailyRewardDb();
+    await db.pendingPayouts(20);
+    await db.markPayout('2026-07-14', 1, 'paid', 'signature', null);
+
+    const pendingSql = String(h.poolQuery.mock.calls[0][0]);
+    const markSql = String(
+      h.query.mock.calls.find(([sql]) => String(sql).includes('UPDATE daily_reward_payouts'))?.[0],
+    );
+    expect(pendingSql).toContain("p.status IN ('pending', 'failed', 'processing')");
+    expect(pendingSql).toContain('p.realm = $1');
+    expect(markSql).toContain("status = 'processing' AND tx_signature = $5");
+    expect(markSql).not.toContain("status = 'paid' AND $4 = 'paid'");
+  });
+
+  it('optionally filters pending work by day before ordering and limiting it', async () => {
+    const db = new PgDailyRewardDb();
+    await db.pendingPayouts(100, '2026-07-14');
+
+    const sql = String(h.poolQuery.mock.calls[0][0]);
+    expect(sql).toContain('p.day = $2');
+    expect(sql.indexOf('p.day = $2')).toBeLessThan(sql.indexOf('ORDER BY'));
+    expect(h.poolQuery.mock.calls[0][1]).toEqual(['test-realm', '2026-07-14', 100]);
+  });
+
+  it('durably claims one signed transaction and makes competing workers reuse it', async () => {
+    const db = new PgDailyRewardDb();
+    const first = await db.claimPayout('2026-07-14', 1, 'signature-one', 'signed-one');
+    const second = await db.claimPayout('2026-07-14', 1, 'signature-two', 'signed-two');
+
+    expect(first).toMatchObject({
+      outcome: 'claimed',
+      payout: {
+        status: 'processing',
+        txSignature: 'signature-one',
+        signedTransaction: 'signed-one',
+      },
+    });
+    expect(second).toMatchObject({
+      outcome: 'existing',
+      payout: {
+        status: 'processing',
+        txSignature: 'signature-one',
+        signedTransaction: 'signed-one',
+      },
+    });
+    expect(h.state.attempts).toEqual([
+      {
+        kind: 'payout',
+        status: 'prepared',
+        operationId: null,
+        signature: 'signature-one',
+        transaction: 'signed-one',
+      },
+    ]);
+  });
+
+  it('treats completion of an already-paid authoritative signature as idempotent success', async () => {
+    h.state.row = { ...payout('paid'), tx_signature: 'authoritative-signature' };
+
+    await expect(
+      new PgDailyRewardDb().markPayout('2026-07-14', 1, 'paid', 'authoritative-signature', null),
+    ).resolves.toBe(true);
+    expect(h.state.row).toMatchObject({
+      status: 'paid',
+      tx_signature: 'authoritative-signature',
+    });
+  });
+
+  it('reuses one resend operation after response loss while allowing a later resend', async () => {
+    h.state.row = { ...payout('paid'), tx_signature: 'original-signature' };
+    const db = new PgDailyRewardDb();
+
+    const first = await db.claimPayoutResend(
+      '2026-07-14',
+      1,
+      'operation-one',
+      'resend-signature',
+      'resend-transaction',
+    );
+    const competing = await db.claimPayoutResend(
+      '2026-07-14',
+      1,
+      'operation-one',
+      'discarded-signature',
+      'discarded-transaction',
+    );
+    h.poolQuery.mockImplementationOnce(async () => {
+      h.state.attempts[0].status = 'paid';
+      return { rows: [], rowCount: 1 };
+    });
+    const marked = await db.markPayoutResend(
+      '2026-07-14',
+      1,
+      'operation-one',
+      'paid',
+      'resend-signature',
+      null,
+    );
+    const recovered = await db.claimPayoutResend(
+      '2026-07-14',
+      1,
+      'operation-one',
+      'another-discarded-signature',
+      'another-discarded-transaction',
+    );
+    const later = await db.claimPayoutResend(
+      '2026-07-14',
+      1,
+      'operation-two',
+      'later-signature',
+      'later-transaction',
+    );
+
+    expect(first).toMatchObject({ outcome: 'claimed', attempt: { status: 'prepared' } });
+    expect(competing).toMatchObject({
+      outcome: 'existing',
+      attempt: {
+        status: 'prepared',
+        operationId: 'operation-one',
+        txSignature: 'resend-signature',
+        signedTransaction: 'resend-transaction',
+      },
+    });
+    expect(marked).toBe(true);
+    expect(recovered).toMatchObject({
+      outcome: 'existing',
+      attempt: {
+        status: 'paid',
+        operationId: 'operation-one',
+        txSignature: 'resend-signature',
+        signedTransaction: 'resend-transaction',
+      },
+    });
+    expect(later).toMatchObject({
+      outcome: 'claimed',
+      attempt: {
+        status: 'prepared',
+        operationId: 'operation-two',
+        txSignature: 'later-signature',
+      },
+    });
+    expect(h.state.row.tx_signature).toBe('original-signature');
+  });
+
+  it('returns a terminally failed resend operation without replacing it', async () => {
+    h.state.row = { ...payout('paid'), tx_signature: 'original-signature' };
+    h.state.attempts.push({
+      kind: 'resend',
+      status: 'failed',
+      operationId: 'operation-one',
+      signature: 'failed-signature',
+      transaction: 'failed-transaction',
+    });
+
+    const result = await new PgDailyRewardDb().claimPayoutResend(
+      '2026-07-14',
+      1,
+      'operation-one',
+      'discarded-signature',
+      'discarded-transaction',
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'existing',
+      attempt: {
+        status: 'failed',
+        operationId: 'operation-one',
+        txSignature: 'failed-signature',
+      },
+    });
+    expect(h.state.attempts).toHaveLength(1);
+  });
+
+  it('scopes payout history to the active realm', async () => {
+    await new PgDailyRewardDb().recentPayouts(25);
+    const [sql, params] = h.poolQuery.mock.calls[0];
+    expect(String(sql)).toContain('WHERE p.realm = $1');
+    expect(params).toEqual(['test-realm', 25]);
+  });
+});

--- a/tests/schema_wiring.test.ts
+++ b/tests/schema_wiring.test.ts
@@ -111,6 +111,39 @@ describe('ensureSchema wires every schema module at boot', () => {
     expect(applied).toContain('password_set');
   });
 
+  it('applies payout void metadata and append-only moderation audit storage', async () => {
+    await ensureSchema();
+    const applied = h.calls.join('\n');
+    expect(applied).toContain(
+      'ALTER TABLE daily_reward_payouts ADD COLUMN IF NOT EXISTS void_reason TEXT',
+    );
+    expect(applied).toContain(
+      'ALTER TABLE daily_reward_payouts ADD COLUMN IF NOT EXISTS voided_by_id TEXT',
+    );
+    expect(applied).toContain(
+      'ALTER TABLE daily_reward_payouts ADD COLUMN IF NOT EXISTS voided_by_username TEXT',
+    );
+    expect(applied).toContain(
+      'ALTER TABLE daily_reward_payouts ADD COLUMN IF NOT EXISTS voided_at TIMESTAMPTZ',
+    );
+    expect(applied).toContain('CREATE TABLE IF NOT EXISTS daily_reward_payout_moderation_audit');
+    expect(applied).toContain("action TEXT NOT NULL CHECK (action IN ('void', 'restore'))");
+    expect(applied).toContain('actor_id TEXT NOT NULL');
+    expect(applied).toContain('actor_username TEXT NOT NULL');
+    expect(applied).toContain(
+      'ALTER TABLE daily_reward_payouts ADD COLUMN IF NOT EXISTS signed_transaction TEXT',
+    );
+    expect(applied).toContain('CREATE TABLE IF NOT EXISTS daily_reward_payout_attempts');
+    expect(applied).toContain("kind TEXT NOT NULL CHECK (kind IN ('payout', 'resend'))");
+    expect(applied).toContain(
+      'ALTER TABLE daily_reward_payout_attempts ADD COLUMN IF NOT EXISTS operation_id TEXT',
+    );
+    expect(applied).toContain(
+      'CREATE UNIQUE INDEX IF NOT EXISTS daily_reward_payout_attempts_operation',
+    );
+    expect(applied).toContain('tx_signature TEXT NOT NULL UNIQUE');
+  });
+
   it('applies the bank-system tables (character_leases, bank_ledger) idempotently', async () => {
     // Bank system tables: the per-character load lease and the append-only
     // bank op ledger both live inline in the core SCHEMA string. Pin them by name so

--- a/tests/server/daily_rewards_routes.test.ts
+++ b/tests/server/daily_rewards_routes.test.ts
@@ -43,6 +43,11 @@ const h = vi.hoisted(() => {
     recentPayouts: [] as unknown[],
     pendingPayouts: [] as unknown[],
     markPayoutOk: true,
+    claimPayoutResult: { outcome: 'not_found' } as unknown,
+    claimPayoutResendResult: { outcome: 'not_found' } as unknown,
+    markPayoutResendOk: true,
+    voidPayoutResult: { outcome: 'not_found' } as unknown,
+    restorePayoutResult: { outcome: 'not_found' } as unknown,
     ensureDayThrows: false,
     wallet: null as { account_id: number; pubkey: string; linked_at: string } | null,
     balance: null as number | null,
@@ -78,6 +83,11 @@ const h = vi.hoisted(() => {
     unannouncedWinnerDays: vi.fn(async () => [] as unknown[]),
     markWinnersAnnounced: vi.fn(async () => true),
     markPayout: vi.fn(async () => state.markPayoutOk),
+    claimPayout: vi.fn(async () => state.claimPayoutResult),
+    claimPayoutResend: vi.fn(async () => state.claimPayoutResendResult),
+    markPayoutResend: vi.fn(async () => state.markPayoutResendOk),
+    voidPayout: vi.fn(async () => state.voidPayoutResult),
+    restorePayout: vi.fn(async () => state.restorePayoutResult),
   };
   const wallet = { walletForAccount: vi.fn(async (_accountId: number) => state.wallet) };
   const balance = { cachedWocBalance: vi.fn(async (_pubkey: string) => state.balance) };
@@ -112,6 +122,11 @@ vi.mock('../../server/daily_rewards_db', async (importOriginal) => {
     unannouncedWinnerDays = h.db.unannouncedWinnerDays;
     markWinnersAnnounced = h.db.markWinnersAnnounced;
     markPayout = h.db.markPayout;
+    claimPayout = h.db.claimPayout;
+    claimPayoutResend = h.db.claimPayoutResend;
+    markPayoutResend = h.db.markPayoutResend;
+    voidPayout = h.db.voidPayout;
+    restorePayout = h.db.restorePayout;
   }
   return { ...actual, PgDailyRewardDb: FakePgDailyRewardDb };
 });
@@ -153,8 +168,7 @@ const OPS_SECRET_ENV = 'WOC_DAILY_REWARD_SERVICE_SECRET';
 const OPS_SECRET = 'ops-secret';
 const OPS_HEADERS = { [OPS_HEADER]: OPS_SECRET };
 
-// The eight routes, in declared order, as `${method} ${path}` (v0.20.0 added
-// the paginated leaderboard read to each family).
+// The ten routes, in declared order: four player reads/mutations and six payout ops.
 const PLAYER_PATHS: ReadonlyArray<readonly [Method, string]> = [
   ['GET', '/api/daily-rewards'],
   ['GET', '/api/daily-rewards/leaderboard'],
@@ -166,6 +180,8 @@ const OPS_PATHS: ReadonlyArray<readonly [Method, string]> = [
   ['POST', '/internal/daily-rewards/payout-history'],
   ['POST', '/internal/daily-rewards/leaderboard'],
   ['POST', '/internal/daily-rewards/mark-payout'],
+  ['POST', '/internal/daily-rewards/void-payout'],
+  ['POST', '/internal/daily-rewards/restore-payout'],
 ];
 
 /** A full DailyRewardPayoutRow, so history/payout-history map to a known shape. */
@@ -182,6 +198,12 @@ function payoutRow(rank: number) {
     status: 'pending',
     txSignature: null,
     paidAt: null,
+    voidReason: null,
+    voidedById: null,
+    voidedByUsername: null,
+    voidedAt: null,
+    realm: 'test-realm',
+    signedTransaction: null,
   };
 }
 
@@ -316,6 +338,11 @@ beforeEach(() => {
   h.state.recentPayouts = [];
   h.state.pendingPayouts = [];
   h.state.markPayoutOk = true;
+  h.state.claimPayoutResult = { outcome: 'not_found' };
+  h.state.claimPayoutResendResult = { outcome: 'not_found' };
+  h.state.markPayoutResendOk = true;
+  h.state.voidPayoutResult = { outcome: 'not_found' };
+  h.state.restorePayoutResult = { outcome: 'not_found' };
   h.state.ensureDayThrows = false;
   h.state.wallet = null;
   h.state.balance = null;
@@ -341,7 +368,7 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('daily-rewards route table', () => {
-  it('registers exactly the eight routes in the declared order', () => {
+  it('registers the player and payout-operations routes in the declared order', () => {
     expect(routes.map((r) => `${r.method} ${r.path}`)).toEqual([
       'GET /api/daily-rewards',
       'GET /api/daily-rewards/leaderboard',
@@ -351,6 +378,8 @@ describe('daily-rewards route table', () => {
       'POST /internal/daily-rewards/payout-history',
       'POST /internal/daily-rewards/leaderboard',
       'POST /internal/daily-rewards/mark-payout',
+      'POST /internal/daily-rewards/void-payout',
+      'POST /internal/daily-rewards/restore-payout',
     ]);
   });
 
@@ -380,7 +409,7 @@ describe('daily-rewards route table', () => {
   it('shares one activeGuard across the player family and one gate across the ops family, distinct from each other', () => {
     const playerGuards = new Set(PLAYER_PATHS.map(([m, p]) => routeFor(m, p).middleware?.[0]));
     const opsGates = new Set(OPS_PATHS.map(([m, p]) => routeFor(m, p).middleware?.[0]));
-    // All three player routes carry the SAME guard instance; all three ops routes the SAME
+    // All four player routes carry the SAME guard instance; all six ops routes the SAME
     // gate instance; the guard is not the gate.
     expect(playerGuards.size).toBe(1);
     expect(opsGates.size).toBe(1);
@@ -606,7 +635,37 @@ describe('ops routes: fail-closed secret gate', () => {
       error: null,
     });
     expect(r.reached).toBe(true);
-    expect(h.db.pendingPayouts).toHaveBeenCalledWith(20);
+    expect(h.db.pendingPayouts).toHaveBeenCalledWith(20, undefined);
+  });
+
+  it('filters pending payouts to a validated reward day', async () => {
+    process.env[OPS_SECRET_ENV] = OPS_SECRET;
+    const r = await runRoute('POST', '/internal/daily-rewards/pending-payouts', {
+      url: '/internal/daily-rewards/pending-payouts?day=2026-07-01&limit=100',
+      headers: OPS_HEADERS,
+    });
+    expect(r.status).toBe(200);
+    expect(r.body).toEqual({ success: true, data: { payouts: [] }, error: null });
+    expect(h.db.pendingPayouts).toHaveBeenCalledWith(100, '2026-07-01');
+  });
+
+  it.each([
+    '2026-7-01',
+    '2026/07/01',
+    'not-a-day',
+  ])('rejects an invalid pending-payout day filter: %s', async (day) => {
+    process.env[OPS_SECRET_ENV] = OPS_SECRET;
+    const r = await runRoute('POST', '/internal/daily-rewards/pending-payouts', {
+      url: `/internal/daily-rewards/pending-payouts?day=${encodeURIComponent(day)}`,
+      headers: OPS_HEADERS,
+    });
+    expect(r.status).toBe(400);
+    expect(r.body).toEqual({
+      success: false,
+      data: null,
+      error: 'invalid reward day',
+    });
+    expect(h.db.pendingPayouts).not.toHaveBeenCalled();
   });
 
   it('runs payout-history to a 200 admin envelope on the correct secret', async () => {
@@ -676,11 +735,11 @@ describe('ops mark-payout validation', () => {
     h.state.markPayoutOk = false;
     const r = await runRoute('POST', '/internal/daily-rewards/mark-payout', {
       headers: OPS_HEADERS,
-      body: { day: '2026-07-01', rank: 1, status: 'paid' },
+      body: { day: '2026-07-01', rank: 1, status: 'paid', txSignature: 'signature' },
     });
     expect(r.status).toBe(404);
     expect(r.body).toEqual({ success: false, data: null, error: 'payout not found' });
-    expect(h.db.markPayout).toHaveBeenCalledWith('2026-07-01', 1, 'paid', null, null);
+    expect(h.db.markPayout).toHaveBeenCalledWith('2026-07-01', 1, 'paid', 'signature', null);
   });
 
   it('200s { ok: true } when markPayout succeeds', async () => {
@@ -692,6 +751,234 @@ describe('ops mark-payout validation', () => {
     expect(r.status).toBe(200);
     expect(r.body).toEqual({ success: true, data: { ok: true }, error: null });
     expect(h.db.markPayout).toHaveBeenCalledWith('2026-07-01', 1, 'paid', 'sig', null);
+  });
+
+  it('claims and returns the authoritative signed transaction before broadcast', async () => {
+    h.state.claimPayoutResult = {
+      outcome: 'claimed',
+      payout: {
+        ...payoutRow(1),
+        status: 'processing',
+        txSignature: 'authoritative-signature',
+        signedTransaction: 'authoritative-transaction',
+      },
+    };
+    const r = await runRoute('POST', '/internal/daily-rewards/mark-payout', {
+      headers: OPS_HEADERS,
+      body: {
+        day: '2026-07-01',
+        rank: 1,
+        status: 'processing',
+        txSignature: 'proposed-signature',
+        signedTransaction: 'proposed-transaction',
+      },
+    });
+
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({
+      success: true,
+      data: {
+        ok: true,
+        payout: {
+          txSignature: 'authoritative-signature',
+          signedTransaction: 'authoritative-transaction',
+        },
+      },
+    });
+    expect(h.db.claimPayout).toHaveBeenCalledWith(
+      '2026-07-01',
+      1,
+      'proposed-signature',
+      'proposed-transaction',
+    );
+  });
+
+  it('claims a durable resend attempt before broadcast', async () => {
+    h.state.claimPayoutResendResult = {
+      outcome: 'claimed',
+      attempt: {
+        status: 'prepared',
+        operationId: 'operation-one',
+        txSignature: 'resend-signature',
+        signedTransaction: 'resend-transaction',
+      },
+    };
+    const r = await runRoute('POST', '/internal/daily-rewards/mark-payout', {
+      headers: OPS_HEADERS,
+      body: {
+        day: '2026-07-01',
+        rank: 1,
+        status: 'resend_processing',
+        operationId: 'operation-one',
+        txSignature: 'resend-signature',
+        signedTransaction: 'resend-transaction',
+      },
+    });
+
+    expect(r.status).toBe(200);
+    expect(h.db.claimPayoutResend).toHaveBeenCalledWith(
+      '2026-07-01',
+      1,
+      'operation-one',
+      'resend-signature',
+      'resend-transaction',
+    );
+    expect(h.db.markPayout).not.toHaveBeenCalled();
+    expect(r.body).toMatchObject({
+      success: true,
+      data: {
+        attempt: {
+          status: 'prepared',
+          operationId: 'operation-one',
+          txSignature: 'resend-signature',
+          signedTransaction: 'resend-transaction',
+        },
+      },
+    });
+  });
+
+  it('requires an explicit operation id for resend idempotency', async () => {
+    const r = await runRoute('POST', '/internal/daily-rewards/mark-payout', {
+      headers: OPS_HEADERS,
+      body: {
+        day: '2026-07-01',
+        rank: 1,
+        status: 'resend_processing',
+        txSignature: 'resend-signature',
+        signedTransaction: 'resend-transaction',
+      },
+    });
+
+    expect(r.status).toBe(400);
+    expect(r.body).toMatchObject({
+      success: false,
+      error: 'valid resend operation id is required',
+    });
+    expect(h.db.claimPayoutResend).not.toHaveBeenCalled();
+  });
+
+  it('marks the prepared resend attempt paid without changing the original payout', async () => {
+    const r = await runRoute('POST', '/internal/daily-rewards/mark-payout', {
+      headers: OPS_HEADERS,
+      body: {
+        day: '2026-07-01',
+        rank: 1,
+        status: 'resent',
+        operationId: 'operation-one',
+        txSignature: 'resend-signature',
+      },
+    });
+
+    expect(r.status).toBe(200);
+    expect(h.db.markPayoutResend).toHaveBeenCalledWith(
+      '2026-07-01',
+      1,
+      'operation-one',
+      'paid',
+      'resend-signature',
+      null,
+    );
+    expect(h.db.markPayout).not.toHaveBeenCalled();
+  });
+});
+
+describe('ops payout moderation', () => {
+  beforeEach(() => {
+    process.env[OPS_SECRET_ENV] = OPS_SECRET;
+  });
+
+  it.each(['', 'ab', 'x'.repeat(501)])('rejects an invalid void reason', async (reason) => {
+    const r = await runRoute('POST', '/internal/daily-rewards/void-payout', {
+      headers: OPS_HEADERS,
+      body: {
+        day: '2026-07-01',
+        rank: 1,
+        reason,
+        actorId: 'operator-7',
+        actorUsername: 'moderator',
+      },
+    });
+    expect(r.status).toBe(400);
+    expect(r.body).toEqual({ success: false, data: null, error: 'invalid void reason' });
+    expect(h.db.voidPayout).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing actor identity', async () => {
+    const r = await runRoute('POST', '/internal/daily-rewards/restore-payout', {
+      headers: OPS_HEADERS,
+      body: { day: '2026-07-01', rank: 1 },
+    });
+    expect(r.status).toBe(400);
+    expect(r.body).toEqual({ success: false, data: null, error: 'invalid payout actor' });
+    expect(h.db.restorePayout).not.toHaveBeenCalled();
+  });
+
+  it('voids a payout with the authenticated operator metadata', async () => {
+    const payout = { ...payoutRow(1), status: 'voided', voidReason: 'Duplicate account' };
+    h.state.voidPayoutResult = {
+      outcome: 'updated',
+      payout,
+    };
+    const r = await runRoute('POST', '/internal/daily-rewards/void-payout', {
+      headers: OPS_HEADERS,
+      body: {
+        day: '2026-07-01',
+        rank: 1,
+        reason: '  Duplicate account  ',
+        actorId: 'operator-7',
+        actorUsername: 'moderator',
+      },
+    });
+    expect(r.status).toBe(200);
+    expect(r.body).toEqual({
+      success: true,
+      data: { ok: true, payout },
+      error: null,
+    });
+    expect(h.db.voidPayout).toHaveBeenCalledWith('2026-07-01', 1, 'Duplicate account', {
+      id: 'operator-7',
+      username: 'moderator',
+    });
+  });
+
+  it('returns conflict when a paid payout cannot be voided', async () => {
+    h.state.voidPayoutResult = { outcome: 'invalid_status', status: 'paid' };
+    const r = await runRoute('POST', '/internal/daily-rewards/void-payout', {
+      headers: OPS_HEADERS,
+      body: {
+        day: '2026-07-01',
+        rank: 1,
+        reason: 'Manual review required',
+        actorId: 'operator-7',
+        actorUsername: 'moderator',
+      },
+    });
+    expect(r.status).toBe(409);
+    expect(r.body).toEqual({ success: false, data: null, error: 'payout cannot be voided' });
+  });
+
+  it('restores a voided payout to pending', async () => {
+    const payout = payoutRow(1);
+    h.state.restorePayoutResult = { outcome: 'updated', payout };
+    const r = await runRoute('POST', '/internal/daily-rewards/restore-payout', {
+      headers: OPS_HEADERS,
+      body: {
+        day: '2026-07-01',
+        rank: 1,
+        actorId: 'operator-8',
+        actorUsername: 'reviewer',
+      },
+    });
+    expect(r.status).toBe(200);
+    expect(r.body).toEqual({
+      success: true,
+      data: { ok: true, payout },
+      error: null,
+    });
+    expect(h.db.restorePayout).toHaveBeenCalledWith('2026-07-01', 1, {
+      id: 'operator-8',
+      username: 'reviewer',
+    });
   });
 });
 

--- a/tests/server/fixtures/internal/daily_rewards_restore_payout_no_secret_401.json
+++ b/tests/server/fixtures/internal/daily_rewards_restore_payout_no_secret_401.json
@@ -1,0 +1,13 @@
+{
+  "body": "{\"data\":null,\"error\":\"not authenticated\",\"success\":false}",
+  "headers": {
+    "content-length": 57,
+    "content-type": "application/json",
+    "cross-origin-opener-policy": "same-origin",
+    "cross-origin-resource-policy": "same-origin",
+    "permissions-policy": "accelerometer=(), ambient-light-sensor=(), battery=(), bluetooth=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), serial=(), usb=(), xr-spatial-tracking=()",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "x-content-type-options": "nosniff"
+  },
+  "status": 401
+}

--- a/tests/server/fixtures/internal/daily_rewards_restore_payout_secret_unset_401.json
+++ b/tests/server/fixtures/internal/daily_rewards_restore_payout_secret_unset_401.json
@@ -1,0 +1,13 @@
+{
+  "body": "{\"data\":null,\"error\":\"not authenticated\",\"success\":false}",
+  "headers": {
+    "content-length": 57,
+    "content-type": "application/json",
+    "cross-origin-opener-policy": "same-origin",
+    "cross-origin-resource-policy": "same-origin",
+    "permissions-policy": "accelerometer=(), ambient-light-sensor=(), battery=(), bluetooth=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), serial=(), usb=(), xr-spatial-tracking=()",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "x-content-type-options": "nosniff"
+  },
+  "status": 401
+}

--- a/tests/server/fixtures/internal/daily_rewards_void_payout_no_secret_401.json
+++ b/tests/server/fixtures/internal/daily_rewards_void_payout_no_secret_401.json
@@ -1,0 +1,13 @@
+{
+  "body": "{\"data\":null,\"error\":\"not authenticated\",\"success\":false}",
+  "headers": {
+    "content-length": 57,
+    "content-type": "application/json",
+    "cross-origin-opener-policy": "same-origin",
+    "cross-origin-resource-policy": "same-origin",
+    "permissions-policy": "accelerometer=(), ambient-light-sensor=(), battery=(), bluetooth=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), serial=(), usb=(), xr-spatial-tracking=()",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "x-content-type-options": "nosniff"
+  },
+  "status": 401
+}

--- a/tests/server/fixtures/internal/daily_rewards_void_payout_secret_unset_401.json
+++ b/tests/server/fixtures/internal/daily_rewards_void_payout_secret_unset_401.json
@@ -1,0 +1,13 @@
+{
+  "body": "{\"data\":null,\"error\":\"not authenticated\",\"success\":false}",
+  "headers": {
+    "content-length": 57,
+    "content-type": "application/json",
+    "cross-origin-opener-policy": "same-origin",
+    "cross-origin-resource-policy": "same-origin",
+    "permissions-policy": "accelerometer=(), ambient-light-sensor=(), battery=(), bluetooth=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), serial=(), usb=(), xr-spatial-tracking=()",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "x-content-type-options": "nosniff"
+  },
+  "status": 401
+}

--- a/tests/server/http/characterization_admin_oauth_internal.test.ts
+++ b/tests/server/http/characterization_admin_oauth_internal.test.ts
@@ -390,6 +390,8 @@ describe('characterization: internal handleDailyRewardInternalApi (late-arrival 
     { path: '/internal/daily-rewards/pending-payouts', name: 'daily_rewards_pending_payouts' },
     { path: '/internal/daily-rewards/payout-history', name: 'daily_rewards_payout_history' },
     { path: '/internal/daily-rewards/mark-payout', name: 'daily_rewards_mark_payout' },
+    { path: '/internal/daily-rewards/void-payout', name: 'daily_rewards_void_payout' },
+    { path: '/internal/daily-rewards/restore-payout', name: 'daily_rewards_restore_payout' },
   ] as const;
 
   // Fail-closed gate, captured PER ROUTE: with the env secret UNSET the family

--- a/tests/server/http/completeness.test.ts
+++ b/tests/server/http/completeness.test.ts
@@ -557,10 +557,10 @@ describe('registry completeness: oauth + internal surfaces (server/oauth.ts, ser
   it('derives the expected non-empty ladders', () => {
     expect(oauthPostLadder.length).toBe(5);
     expect(oauthGetLadder.length).toBe(2);
-    // 15 = the handleInternalApi eleven (restart-countdown + the 10 Discord-bot routes)
-    // plus the ops family below (v0.20.0 added its paginated leaderboard read).
-    expect(internalLadder.length).toBe(15);
-    expect(opsFamilyRows.length).toBe(4);
+    // 17 = the handleInternalApi eleven (restart-countdown + the 10 Discord-bot routes)
+    // plus the six-route payout and moderation ops family below.
+    expect(internalLadder.length).toBe(17);
+    expect(opsFamilyRows.length).toBe(6);
   });
 
   it('registers exactly the oauth POST ladder routes', () => {

--- a/tests/server/http/known_deviations.ts
+++ b/tests/server/http/known_deviations.ts
@@ -1154,13 +1154,15 @@ export const KNOWN_DEVIATIONS: readonly KnownDeviation[] = [
       '/internal/daily-rewards/pending-payouts',
       '/internal/daily-rewards/payout-history',
       '/internal/daily-rewards/mark-payout',
+      '/internal/daily-rewards/void-payout',
+      '/internal/daily-rewards/restore-payout',
     ],
     currentBehavior:
       'The legacy ops family is the FIRST arm of the /internal composite delegate ' +
       '(handleDailyRewardInternalApi, tried before handleInternalApi), fired ' +
       'fire-and-forget with NO outer catch: mark-payout self-reads its body via an ' +
       'UN-caught readBody (unlike internal.ts, which .catch(() => ({}))s every read), ' +
-      'so a malformed/over-cap body AND any DB throw in the three handlers become an ' +
+      'so a malformed/over-cap body AND any DB throw in the five handlers become an ' +
       'unhandled rejection: NO response is written and the payout service request ' +
       'HANGS. The gate itself is FAIL-CLOSED: an unset ' +
       'WOC_DAILY_REWARD_SERVICE_SECRET and a wrong x-woc-daily-reward-secret header ' +
@@ -1168,7 +1170,7 @@ export const KNOWN_DEVIATIONS: readonly KnownDeviation[] = [
       "(never the other internal gates' feature-off 404, never a " +
       'RESTART_COUNTDOWN_SECRET fallback).',
     intendedBehavior:
-      'The migration registers the three ops routes behind the new ' +
+      'The migration registers the five ops routes behind the new ' +
       'requireInternalSecretFailClosed gate (same fail-closed 401 semantics, ' +
       'per-request env read, length-guarded timingSafeEqual) with handlers calling ' +
       'the SAME handleDailyRewardInternalApi core, and routes the rejection to the ' +

--- a/tests/server/http/ownership_coverage.test.ts
+++ b/tests/server/http/ownership_coverage.test.ts
@@ -649,10 +649,9 @@ describe('internal secret-gate mounting sweep: every /internal route is gated', 
     vi.restoreAllMocks();
   });
 
-  it('selects the full 15-route internal surface (the handleInternalApi 11 + the 4 ops routes)', () => {
-    // The ops family is 4 since v0.20.0 added its paginated leaderboard read to
-    // the 3 late-arrival rows.
-    expect(internalSurfaceRoutes.length).toBe(15);
+  it('selects the full 17-route internal surface (the handleInternalApi 11 + the 6 ops routes)', () => {
+    // The ops family includes four payout-service routes and two moderation mutations.
+    expect(internalSurfaceRoutes.length).toBe(17);
   });
 
   for (const route of internalSurfaceRoutes) {

--- a/tests/server/http/surface_inventory.ts
+++ b/tests/server/http/surface_inventory.ts
@@ -2120,6 +2120,26 @@ export const SURFACE_INVENTORY: readonly SurfaceRoute[] = [
     limiter: null,
     requireOwnedExpected: null,
   },
+  {
+    dispatcher: DISPATCH.internal,
+    method: 'POST',
+    path: '/internal/daily-rewards/void-payout',
+    handler: 'handleDailyRewardInternalApi arm: /internal/daily-rewards/void-payout',
+    contentType: PROBLEM_JSON,
+    authScope: AUTH_SCOPE.secretDailyReward,
+    limiter: null,
+    requireOwnedExpected: null,
+  },
+  {
+    dispatcher: DISPATCH.internal,
+    method: 'POST',
+    path: '/internal/daily-rewards/restore-payout',
+    handler: 'handleDailyRewardInternalApi arm: /internal/daily-rewards/restore-payout',
+    contentType: PROBLEM_JSON,
+    authScope: AUTH_SCOPE.secretDailyReward,
+    limiter: null,
+    requireOwnedExpected: null,
+  },
 ];
 
 // The four API prefixes every dispatched route descriptor begins with. The


### PR DESCRIPTION
## Summary

- add durable daily reward payout claims and append-only payout attempt records
- expose authenticated internal APIs for automatic payout processing
- allow pending or failed payouts to be voided with an operator reason and audit record
- allow voided payouts to be restored to pending without retaining stale transaction state
- make paid completion and resend recovery idempotent
- include realm and resend operation identity throughout the payout protocol
- add route, persistence, schema, authorization, and HTTP surface tests

Companion PRs:

- https://github.com/levy-street/woc-daily-rewards-service/pull/20
- https://github.com/levy-street/woc-daily-rewards-dashboard/pull/7

## Type of change

- [x] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - focused Biome checks for all changed game files
  - focused Vitest suite: 353 tests passed
  - TypeScript typecheck
  - git diff check
  - pre-push QA floor: green
- Manual steps:
  - N/A

The full npm run gate was also attempted. It remains blocked by four pre-existing SFX loudness and export assertions in tests/sfx_export_bundle.test.ts and tests/sfx_studio_server_security.test.ts, unrelated to this payout change.

## Screenshots / recordings

N/A. This repository change adds internal APIs and persistence without player-facing UI.

---

## Checklist

### Quality

- [ ] The full gate passes. See the unrelated SFX baseline failures above.

### Localization

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or environment files are committed.
- [x] No generated files were hand-edited.