### PR TITLE
fix(talents): trim shadow priest and frost mage mastery outliers to caster parity

### DIFF
--- a/src/sim/content/talents_classic.ts
+++ b/src/sim/content/talents_classic.ts
@@ -1255,14 +1255,17 @@ const MAGE_SPECS: SpecDef[] = [
     'A controlling caster who trades peak burst for survival and slows.',
     'icy_veins',
     'Brittlebreak',
-    'Increases your Frost spell damage by 25%. Increases armor by 10%.',
+    'Increases your Frost spell damage by 15%. Increases armor by 10%.',
     // The scalable mastery axis is the Frost-kit damage (ability-scoped so the
     // mage's fire/arcane baseline spells stay untouched); armor is the static
     // secondary. Crit-vs-rooted identity returns as a Shatter-style row option.
+    // The 15% magnitude matches the other caster masteries (arcane/elemental
+    // spellDmgPct 0.15) so frostbolt is not a permanent outlier over its siblings;
+    // the ability-scoping stays so the mage's off-school spells are untouched.
     {
       ability: [
-        { ability: 'frostbolt', dmgPct: 0.25 },
-        { ability: 'frost_nova', dmgPct: 0.25 },
+        { ability: 'frostbolt', dmgPct: 0.15 },
+        { ability: 'frost_nova', dmgPct: 0.15 },
       ],
       stats: { armorPct: 0.1 },
     },
@@ -2220,8 +2223,13 @@ const PRIEST_SPECS: SpecDef[] = [
     'A damage caster built around Shadow damage over time and mind spells.',
     'shadowform',
     'Gloamveil',
-    'Increases your damage-over-time damage by 15% and your spell damage by 10%.',
-    { global: { dotDmgPct: 0.15, spellDmgPct: 0.1 } },
+    'Increases your damage-over-time damage by 15%.',
+    // Single DoT lever. Gloamveil Form already amplifies ALL shadow damage (direct and
+    // periodic) by 15% school-scoped in damage.ts, so a second spellDmgPct on the mastery
+    // stacked into a triple multiply on DoTs (form x spellDmg x dotDmg = ~1.45), an outlier
+    // matching the pre-fix balance druid. Dropping spellDmgPct leaves the form as the general
+    // shadow multiplier and the mastery as the DoT specialization (DoT ~1.32, direct ~1.15).
+    { global: { dotDmgPct: 0.15 } },
   ),
 ];
 

--- a/tests/mastery_mechanism.test.ts
+++ b/tests/mastery_mechanism.test.ts
@@ -287,3 +287,30 @@ describe('Demonology damage redirect is not double-modified (F7)', () => {
     expect(wl0 - wl.hp).toBe(72); // 90 - 18
   });
 });
+
+describe('caster mastery outliers trimmed to sibling parity', () => {
+  it('Shadow Vespers is a single DoT lever (no spellDmgPct triple-stack with form)', () => {
+    // Gloamveil Form already amplifies ALL shadow damage +15% (school-scoped, damage.ts),
+    // so a mastery spellDmgPct compounded into form x spellDmg x dotDmg = ~1.45 on DoTs, an
+    // outlier matching the pre-fix balance druid. The mastery now carries only dotDmgPct, so
+    // the form is the general shadow multiplier and the mastery is the DoT specialization.
+    const mods = computeTalentModifiers('priest', { spec: 'shadow', ranks: {}, choices: {} }, 20);
+    expect(mods.global.dotDmgPct ?? 0).toBeCloseTo(0.15);
+    expect(mods.global.spellDmgPct ?? 0).toBe(0);
+  });
+
+  it('Frost Cryomancy mastery gives +15% on frostbolt (caster parity), not +25%', () => {
+    // Every other caster mastery is +15% on its primary; frost was +25% on frostbolt, the only
+    // permanent single-nuke outlier. Ability-scoping is kept (off-school mage spells untouched),
+    // only the magnitude drops to match arcane/elemental's 0.15.
+    const base = abilitiesKnownAt('mage', 20, undefined).find((a) => a.def.id === 'frostbolt');
+    const baseDd = base?.effects.find((e) => e.type === 'directDamage');
+    const mods = computeTalentModifiers('mage', { spec: 'frost', ranks: {}, choices: {} }, 20);
+    const frost = abilitiesKnownAt('mage', 20, mods).find((a) => a.def.id === 'frostbolt');
+    const frostDd = frost?.effects.find((e) => e.type === 'directDamage');
+    const baseMin = baseDd && 'min' in baseDd ? baseDd.min : 0;
+    const frostMin = frostDd && 'min' in frostDd ? frostDd.min : 0;
+    expect(baseMin).toBeGreaterThan(0);
+    expect(frostMin / baseMin).toBeCloseTo(1.15, 2); // not 1.25
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to the balance druid fix (#1919). Auditing all 27 specs for the same always-on multiplier problem surfaced two more caster masteries sitting well above their siblings.

**Shadow priest (Vespers)** carried two damage fields, `dotDmgPct 0.15` AND `spellDmgPct 0.10`. On a DoT those compound with Gloamveil Form's +15% shadow-school amp:

```
form_shadow 1.15  x  (1 + spellDmgPct 0.10)  x  (1 + dotDmgPct 0.15)  =  1.455 per tick
```

That is the pre-fix balance druid outlier (~1.45), before any talent point, on a DoT-centric spec. Every other caster mastery is a single damage field.

**Frost mage (Cryomancy)** gave `+25%` on frostbolt where every sibling caster mastery is `+15%` on its primary (arcane, elemental). It was the only permanent single-nuke outlier.

## Change

- Shadow: drop the `spellDmgPct 0.10` half of Vespers, leaving `dotDmgPct 0.15`. The form stays the general shadow multiplier and the mastery is the DoT specialization. DoT falls to ~1.32 (in band with feral bleed), direct shadow to ~1.15 (form only).
- Frost: frostbolt/frost_nova mastery `dmgPct 0.25` to `0.15`, matching arcane/elemental. The ability-scoping stays (the mage's off-school fire/arcane spells are untouched), only the magnitude drops. Aligns with the spec's own "trades peak burst for survival and slows" flavor.

## Considered and left alone

**Elemental shaman** was flagged in the audit but excluded: fully specced its primary nuke is ~1.53 vs arcane's ~1.59, so it is in band with its true sibling. The earlier flag compared a fully-specced node stack to a mastery-only yardstick. Nerfing it would put it below arcane.

## i18n

Non-English mastery descriptions generate from the effect automatically (`tTalent` -> `effectDescription`), so they track the new numbers with no overlay edits. The English descriptions are updated to match (pinned by `tests/talent_tooltip_accuracy`).

## Testing

- `tests/mastery_mechanism.test.ts`: pins both trims (shadow Vespers is dot-only with no spellDmgPct; frost frostbolt scales 1.15 not 1.25).
- Parity goldens unaffected (no golden trace casts these; suite green with no regen).
- `talent_tooltip_accuracy`, `talents`, `localization_fixes` (S3), `localization_coverage`, `guide`, `architecture` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)