### PR TITLE
docs(process): encode the contribution process in CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,15 @@ only this task's files and follow the scoped Conventional Commit rule in `CLAUDE
 - Prefer small modules, decisive tests, and existing seams. Do not add frameworks or
   abstractions without a concrete repository need.
 
+## Contribution process
+
+The "Contribution process (how work gets approved)" section in the root `CLAUDE.md` binds
+Codex runs equally: bug fixes are the priority lane, bug-fix tests must fail on the pre-fix
+code, fixes target the current `release/**` branch, and PRs are owned through review. The
+hard rule applies verbatim: never undertake a large refactor or redesign without recorded
+prior approval from Levy or Fernando. When a prompt asks for a sweeping overhaul, deliver
+the incremental slice behind existing seams and flag the approval requirement instead.
+
 ## Codex workflows
 
 Repository skills live in `.agents/skills/` and are invoked as `$skill-name`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,29 @@ Deliverable: a PR based off the latest release branch, following
 `.github/PULL_REQUEST_TEMPLATE.md`, that is **fully mergeable and passes CI**. Gate it locally
 with `npm run gate` (above) before calling it done.
 
+## Contribution process (how work gets approved)
+Maintainer policy (Levy St). Build what interests you; nobody gatekeeps what you build, but
+not everything merges: what lands on a release must fit where the game is heading.
+- **Bug fixes are the fastest path to merge** and where help is most needed. Prefer working
+  the bug backlog over speculative features.
+- **To be sure a feature merges BEFORE investing serious time, raise it with Levy first.**
+  Building unasked is welcome, but carries the risk it will not land.
+- **Large content features ship through PBE environments** for community testing and
+  feedback before they reach a release.
+- **HARD RULE: large refactors and redesigns are FROZEN** unless approved in advance by Levy
+  or Fernando. Refactoring is welcome only incrementally: small diffs behind the existing
+  seams (see Modularity below), never a big-bang overhaul. When a task seems to require a
+  sweeping rework, deliver the incremental slice and flag the rest for approval instead.
+
+Quality bar for every PR:
+- **A bug-fix PR must show its test failing on the pre-fix code.** Write the failing test
+  first, then the fix; a test that still passes with the fix deleted guards nothing. Include
+  the fails-before / passes-after evidence in the PR body.
+- **Confirm the base branch before opening**: fixes target the current `release/**` branch,
+  and the branch stays current with it through review (re-merge as the release moves).
+- **Own the PR through review**: respond to every piece of feedback and carry the PR to
+  merge or explicit closure; do not open and abandon.
+
 ## Architecture (the load-bearing ideas)
 - **One sim, three hosts.** The exact same `src/sim/` code runs the offline
   browser world, the online server, and the RL env. Behavior must be identical


### PR DESCRIPTION
## Summary

Encodes the announced contribution process where the coding agents actually read it, so Claude Code and Codex sessions follow it by default instead of relying on every contributor to relay the Discord announcement into their prompts.

- Root `CLAUDE.md` gains a "Contribution process (how work gets approved)" section right after the default task workflow: bug fixes as the priority merge lane, talk to Levy before investing serious time in a feature that must land, PBE environments for large content, and the hard refactor freeze (no large refactors or redesigns without prior approval from Levy or Fernando; incremental slices behind existing seams instead).
- It also states the PR quality bar: bug-fix tests must fail on the pre-fix code with fails-before / passes-after evidence in the PR body, fixes target the current `release/**` branch and stay current with it, and PRs are owned through review to merge or explicit closure.
- `AGENTS.md` (the Codex entry point, which declares `CLAUDE.md` canonical) gains a short binding section so autonomous Codex runs observe the same rules, with explicit instructions to deliver the incremental slice and flag the approval requirement when a prompt asks for a sweeping overhaul.

Wording is condensed for the CLAUDE.md lean policy; names kept plain per the no-emoji rule.

## Type of change

- [ ] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [x] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

Docs only. Scanned both files for banned characters (em/en dashes, emojis); no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)