### PR TITLE
ci(desktop): add the signed Windows publish job

### DIFF
--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -7,10 +7,12 @@ name: Desktop publish
 #   - macOS: signed + notarized universal dmg + zip + blockmap, SHA256SUMS-mac,
 #     and latest-mac.yml. Requires the Apple signing secrets; the job refuses
 #     to publish an ad-hoc build.
-# Windows stays on the manual runbook until Azure Artifact Signing is
-# provisioned. The full runbook, including the one-time R2 and Apple
-# provisioning these jobs depend on, is docs/desktop-release.md
-# ("Publishing from CI").
+#   - Windows: the Azure-Key-Vault-signed universal NSIS installer (one exe
+#     covering x64 + arm64) + its blockmap + the per-arch zips,
+#     SHA256SUMS-windows, and latest.yml. Requires the Azure Key Vault signing
+#     secrets; the job refuses to publish an unsigned build.
+# The full runbook, including the one-time R2, Apple, and Azure provisioning
+# these jobs depend on, is docs/desktop-release.md ("Publishing from CI").
 #
 # Triggers:
 #   - a release tag (v<version>) pushed to a commit that is on main; the tag
@@ -331,3 +333,231 @@ jobs:
           put "SHA256SUMS-mac" text/plain "no-cache,max-age=60"
           put "latest-mac.yml" text/yaml "no-cache,max-age=60"
           echo "Published macOS ${VERSION} to https://updates.worldofclaudecraft.com/desktop/"
+
+  windows:
+    name: Build and publish Windows artifacts
+    needs: verify
+    runs-on: windows-latest
+    timeout-minutes: 90
+
+    # The runner's default shell is pwsh; the R2 upload and verification steps
+    # keep the same bash + put() shape as the linux/mac jobs, so default the
+    # whole job to bash (present on the windows runners). The one step that
+    # genuinely needs PowerShell (Get-AuthenticodeSignature) overrides back.
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      # HARD DEPENDENCY: an unsigned installer trips SmartScreen hard and
+      # taints publisher reputation, so this job refuses to run unsigned
+      # rather than publish an unsigned build. These five secrets activate
+      # the Azure Key Vault sign hook (scripts/electron-win-sign.mjs) inside
+      # scripts/electron-builder-config.mjs; checked before the long
+      # install/build. The timestamp/digest secrets are optional (the hook
+      # defaults them to DigiCert + sha256).
+      - name: Verify signing secrets are configured
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_KEY_VAULT_URL: ${{ secrets.AZURE_KEY_VAULT_URL }}
+          AZURE_KEY_VAULT_CERTIFICATE: ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE }}
+        run: |
+          missing=""
+          for name in AZURE_TENANT_ID AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_KEY_VAULT_URL AZURE_KEY_VAULT_CERTIFICATE; do
+            if [ -z "${!name}" ]; then missing="${missing} ${name}"; fi
+          done
+          if [ -n "$missing" ]; then
+            echo "Azure Key Vault signing secrets are not configured:${missing}. See docs/desktop-release.md (Publishing from CI)." >&2
+            exit 1
+          fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The sign hook shells out to the AzureSignTool dotnet global tool; the
+      # runner's dotnet tools directory is already on PATH.
+      - name: Install AzureSignTool
+        run: dotnet tool install --global AzureSignTool
+
+      # Full website-channel build: the Windows target matrix from
+      # package.json "build" is nsis + zip for x64 + arm64, and with no nsis
+      # block electron-builder's buildUniversalInstaller default emits ONE
+      # combined installer covering both arches, plus latest.yml. Every
+      # signable file (the installer, the app exe inside the per-arch zips,
+      # the uninstaller) is signed by the hook as electron-builder emits it.
+      - name: Build signed Windows desktop artifacts
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_KEY_VAULT_URL: ${{ secrets.AZURE_KEY_VAULT_URL }}
+          AZURE_KEY_VAULT_CERTIFICATE: ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE }}
+          CODE_SIGN_TIMESTAMP_URL: ${{ secrets.CODE_SIGN_TIMESTAMP_URL }}
+          CODE_SIGN_FILE_DIGEST: ${{ secrets.CODE_SIGN_FILE_DIGEST }}
+          CODE_SIGN_TIMESTAMP_DIGEST: ${{ secrets.CODE_SIGN_TIMESTAMP_DIGEST }}
+        run: npm run electron:build
+
+      # Mirrors the mac job's signature gate: a build whose installer is not
+      # Authenticode-Valid must fail here, never publish. The installer name
+      # comes from the feed, not a pinned literal (docs/desktop-release.md:
+      # verify the emitted name from latest.yml rather than assume it).
+      - name: Verify Authenticode signature
+        shell: pwsh
+        run: |
+          $feed = Get-Content release/latest.yml -Raw
+          $names = [regex]::Matches($feed, '(?m)^\s*(?:-\s*)?(?:url|path):\s*"?([^"\s]+)"?') |
+            ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique
+          $exes = @($names | Where-Object { $_ -like '*.exe' })
+          if ($exes.Count -eq 0) {
+            Write-Error 'latest.yml lists no installer to verify; refusing to publish.'
+            exit 1
+          }
+          foreach ($name in $exes) {
+            $sig = Get-AuthenticodeSignature -FilePath "release/$name"
+            if ($sig.Status -ne 'Valid') {
+              Write-Error "release/$name Authenticode status is $($sig.Status), not Valid; refusing to publish an unsigned build."
+              exit 1
+            }
+            Write-Output "release/$name signed by $($sig.SignerCertificate.Subject) (status: $($sig.Status))"
+          }
+
+      # Checksums so Windows users can validate their download; bare filenames
+      # for "sha256sum -c", named per-platform like the other jobs.
+      - name: Generate SHA256SUMS-windows
+        run: |
+          cd release
+          sha256sum *.exe *.zip > SHA256SUMS-windows
+          cat SHA256SUMS-windows
+
+      # Unlike the linux/mac jobs this does NOT pin literal filenames: the
+      # universal-NSIS installer name is defined by what electron-builder
+      # emitted into latest.yml (docs/desktop-release.md), so the feed is the
+      # source of truth and every file it references must exist, carry this
+      # release's version, and (for the installer) have its blockmap. A
+      # dev*.yml misbake fails here instead of publishing. Runs on dry runs
+      # too, so a rehearsal proves the same contract a release relies on.
+      - name: Verify expected artifacts
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          if [ ! -f release/latest.yml ]; then
+            echo "release/latest.yml was not produced (a dev-origin misbake emits dev.yml instead); refusing to publish." >&2
+            ls release >&2
+            exit 1
+          fi
+          if ls release/dev*.yml >/dev/null 2>&1; then
+            echo "dev-channel feed files found next to latest.yml; the build was not baked for production. Refusing to publish." >&2
+            ls release >&2
+            exit 1
+          fi
+          FEED_FILES="$(node -e '
+            const text = require("fs").readFileSync("release/latest.yml", "utf8");
+            const names = new Set();
+            for (const m of text.matchAll(/^\s*(?:-\s*)?(?:url|path):\s*"?([^"\s]+)"?\s*$/gm)) names.add(m[1]);
+            console.log([...names].join("\n"));
+          ')"
+          if [ -z "$FEED_FILES" ]; then
+            echo "latest.yml lists no artifacts; refusing to publish." >&2
+            exit 1
+          fi
+          FOUND_EXE=0
+          while IFS= read -r file; do
+            if [ ! -f "release/${file}" ]; then
+              echo "latest.yml references ${file}, which was not produced; refusing to publish a partial release." >&2
+              ls release >&2
+              exit 1
+            fi
+            case "$file" in
+              *"${VERSION}"*) ;;
+              *)
+                echo "latest.yml references ${file}, which does not carry version ${VERSION}; stale feed or half-bumped release." >&2
+                exit 1
+                ;;
+            esac
+            case "$file" in
+              *.exe)
+                FOUND_EXE=1
+                if [ ! -f "release/${file}.blockmap" ]; then
+                  echo "Installer blockmap release/${file}.blockmap was not produced; differential updates would break." >&2
+                  exit 1
+                fi
+                ;;
+            esac
+          done <<< "$FEED_FILES"
+          if [ "$FOUND_EXE" != "1" ]; then
+            echo "latest.yml lists no NSIS installer; refusing to publish." >&2
+            exit 1
+          fi
+          if [ ! -f release/SHA256SUMS-windows ]; then
+            echo "release/SHA256SUMS-windows was not produced." >&2
+            exit 1
+          fi
+
+      - name: Attach artifacts to the run (dry run only)
+        if: github.event_name == 'workflow_dispatch' && !inputs.publish
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-windows
+          retention-days: 7
+          path: |
+            release/*.exe
+            release/*.exe.blockmap
+            release/*.zip
+            release/SHA256SUMS-windows
+            release/latest.yml
+
+      # Same rules as the other uploads: immutable caching for the versioned
+      # artifacts, near-uncached checksum + feed, and the feed file
+      # (latest.yml) uploads LAST. Versioned names come from the feed plus the
+      # per-arch zips, matching the verification above.
+      - name: Upload to the update host (R2)
+        if: github.event_name == 'push' || inputs.publish
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_EC2_METADATA_DISABLED: 'true'
+          AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+          AWS_RESPONSE_CHECKSUM_VALIDATION: when_required
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          if [ -z "$R2_ACCOUNT_ID" ] || [ -z "$R2_BUCKET" ] || [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+            echo "R2 secrets are not configured (R2_ACCOUNT_ID, R2_BUCKET, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY). See docs/desktop-release.md." >&2
+            exit 1
+          fi
+          VERSION="$(node -p "require('./package.json').version")"
+          ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          put() {
+            aws s3 cp "release/$1" "s3://${R2_BUCKET}/desktop/$1" \
+              --endpoint-url "$ENDPOINT" --content-type "$2" --cache-control "$3"
+          }
+          for file in release/world-of-claudecraft-"${VERSION}"-win-*.zip; do
+            put "$(basename "$file")" application/zip "public,max-age=31536000,immutable"
+          done
+          FEED_FILES="$(node -e '
+            const text = require("fs").readFileSync("release/latest.yml", "utf8");
+            const names = new Set();
+            for (const m of text.matchAll(/^\s*(?:-\s*)?(?:url|path):\s*"?([^"\s]+)"?\s*$/gm)) names.add(m[1]);
+            console.log([...names].join("\n"));
+          ')"
+          while IFS= read -r file; do
+            case "$file" in *.zip) continue ;; esac
+            put "$file" application/octet-stream "public,max-age=31536000,immutable"
+            if [ -f "release/${file}.blockmap" ]; then
+              put "${file}.blockmap" application/octet-stream "public,max-age=31536000,immutable"
+            fi
+          done <<< "$FEED_FILES"
+          put "SHA256SUMS-windows" text/plain "no-cache,max-age=60"
+          put "latest.yml" text/yaml "no-cache,max-age=60"
+          echo "Published Windows ${VERSION} to https://updates.worldofclaudecraft.com/desktop/"

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -74,6 +74,7 @@ Linux artifacts on Linux). Cross-building is not part of this runbook.
 | App Store Connect API key (Team Key, App Manager role) | notarization (notarytool) | CI secrets `APPLE_API_KEY` (path to .p8), `APPLE_API_KEY_ID`, `APPLE_API_ISSUER` |
 | Azure subscription + Artifact Signing account (Basic, USD 9.99/mo, 5000 sigs) | Windows signing | account + certificate profile in the Azure portal (needs identity validation; individuals: US/Canada only, orgs also EU/UK) |
 | Azure service principal with "Trusted Signing Certificate Profile Signer" role | CI auth for signing | CI secrets `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` |
+| Alternative: a code-signing certificate in Azure Key Vault (Route B, what CI uses) | Windows signing via AzureSignTool | CI secrets `AZURE_KEY_VAULT_URL`, `AZURE_KEY_VAULT_CERTIFICATE` (plus the service principal secrets above, granted vault sign/get access) |
 | Update host: a static HTTPS host / bucket serving `https://updates.worldofclaudecraft.com/desktop/` | website auto-update feed + installer downloads | e.g. Cloudflare R2 bucket behind that hostname (any static host works; the app only GETs) |
 | Steam partner account + app ID + three depot IDs | Steam distribution | partner.steamgames.com |
 | Steamworks publisher Web API key (+ `STEAM_ENABLED=1`, `STEAM_APP_ID`) | the Book of Deeds achievement mirror + account link (`server/steam/`) | game-server runtime env `STEAM_WEB_API_KEY` (see `DEPLOY.md`) |
@@ -139,9 +140,10 @@ the nested Electron frameworks).
 - Verify after a signed build: `codesign --verify --deep --strict "release/mac-universal/World of ClaudeCraft.app"`
   and `spctl -a -t exec -vv <app>` says "accepted, source=Notarized Developer ID".
 
-## Windows: Azure Artifact Signing
+## Windows: Azure signing (two routes)
 
-Signing activates when all four `WIN_SIGN_*` env vars are present at build time on a
+Route A, Azure Artifact Signing (Trusted Signing, electron-builder native):
+activates when all four `WIN_SIGN_*` env vars are present at build time on a
 Windows runner (injected as `win.azureSignOptions` by `scripts/electron-build.mjs`):
 
 - `WIN_SIGN_PUBLISHER_NAME`: must EXACTLY match the certificate subject CN (the
@@ -153,6 +155,29 @@ Windows runner (injected as `win.azureSignOptions` by `scripts/electron-build.mj
 Auth comes from `AZURE_TENANT_ID` + `AZURE_CLIENT_ID` + `AZURE_CLIENT_SECRET`
 (electron-builder drives the TrustedSigning PowerShell module, which reads the
 standard Azure EnvironmentCredential). Timestamping defaults to Microsoft's server.
+
+Route B, Azure Key Vault certificate (what CI uses): activates when the five
+`AZURE_*` env vars below are all present (and the `WIN_SIGN_*` set is not; Route A
+wins if both are configured). `scripts/electron-builder-config.mjs` injects the
+custom sign hook `scripts/electron-win-sign.mjs` as `win.signtoolOptions.sign`
+(pinned to a single sha256 pass); electron-builder invokes the hook for every
+signable file it emits (the NSIS installer, the app exe inside the per-arch zips,
+the uninstaller), and the hook shells out to the
+[AzureSignTool](https://github.com/vcsjones/AzureSignTool) dotnet global tool:
+
+- `AZURE_KEY_VAULT_URL`: the vault URL, e.g. `https://<vault>.vault.azure.net`.
+- `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`: the service
+  principal with certificate/key access to the vault.
+- `AZURE_KEY_VAULT_CERTIFICATE`: the certificate NAME inside the vault (not a URL).
+- Optional: `CODE_SIGN_TIMESTAMP_URL` (only honored when it is an http(s) URL,
+  otherwise the hook defaults to `http://timestamp.digicert.com`),
+  `CODE_SIGN_FILE_DIGEST` and `CODE_SIGN_TIMESTAMP_DIGEST` (default `sha256`).
+
+Note: `WINDOWS_PUBLISHER_NAME` and `CSC_NAME` are NOT read by the Key Vault route.
+`CSC_NAME` is a macOS keychain identity concept, and the publisher name plays no
+part in an AzureSignTool invocation; `WINDOWS_PUBLISHER_NAME` should simply match
+the certificate subject CN so humans comparing the installer's signature details
+against the secret see the same name.
 
 SmartScreen reality: a newly signed app STILL shows "Windows protected your PC" until
 the file hash + publisher accumulate reputation (weeks, hundreds of clean installs).
@@ -170,9 +195,9 @@ website download page offers the AppImage (not the deb): it runs on immutable
 Fedora atomic desktops (Bazzite, Steam Deck) with no system install, just
 `chmod +x` and launch, which the deb cannot do there.
 
-## Publishing from CI (Linux + macOS)
+## Publishing from CI (all three platforms)
 
-The `.github/workflows/desktop-publish.yml` workflow publishes two of the three
+The `.github/workflows/desktop-publish.yml` workflow publishes all three
 platforms automatically:
 
 - Linux: AppImage + deb (x64 + arm64), `SHA256SUMS-linux`, and both per-arch
@@ -182,10 +207,18 @@ platforms automatically:
   (`codesign --verify --deep --strict`, `spctl -a -t exec`) before uploading
   and refuses to run at all without the Apple secrets, so an ad-hoc build can
   never publish.
+- Windows: the Key-Vault-signed universal NSIS installer (one exe covering
+  x64 + arm64) + its `.exe.blockmap` + the per-arch zips, `SHA256SUMS-windows`,
+  and `latest.yml`. The job verifies the installer is Authenticode-signed
+  (`Get-AuthenticodeSignature` must report `Valid`) before uploading and
+  refuses to run at all without the Azure Key Vault secrets, so an unsigned
+  build can never publish. Because the universal installer's exact filename is
+  defined by what electron-builder emits, the job takes the artifact list from
+  `latest.yml` (and rejects a `dev*.yml` misbake) instead of pinning literal
+  names like the linux/mac jobs do.
 
-Windows stays on the manual steps below until Azure Artifact Signing is
-provisioned in CI. The platform jobs are independent: a mac signing failure
-never blocks the Linux publish and vice versa.
+The platform jobs are independent: a mac signing failure never blocks the
+Linux publish and vice versa.
 
 Triggers:
 
@@ -227,7 +260,13 @@ One-time provisioning (maintainer):
      `.p8` file (the workflow writes it to disk and points `APPLE_API_KEY` at
      it; note the manual flow passes a file path here instead).
    - `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`: as in the manual flow.
-5. Public read: the custom domain makes the bucket publicly readable through
+5. GitHub repo secrets, Azure set (the five required ones or the windows job
+   refuses to run): `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`,
+   `AZURE_KEY_VAULT_URL`, `AZURE_KEY_VAULT_CERTIFICATE`, plus the optional
+   `CODE_SIGN_TIMESTAMP_URL`, `CODE_SIGN_FILE_DIGEST`,
+   `CODE_SIGN_TIMESTAMP_DIGEST` (see "Windows: Azure signing", Route B;
+   `WINDOWS_PUBLISHER_NAME` and `CSC_NAME` are not consumed by this path).
+6. Public read: the custom domain makes the bucket publicly readable through
    that hostname only, which is exactly what the updater and download page need;
    do not additionally enable the `r2.dev` public URL.
 
@@ -248,13 +287,12 @@ SHA256SUMS-mac --ignore-missing` on macOS) from their download directory.
 1. Bump `version` in `package.json` (the feed is version-ordered; see rollback),
    and match `DESKTOP_VERSION` in `src/game/desktop_download.ts` so the download
    page links point at the new build (the static hrefs in `index.html` are the
-   no-JS fallback; keep them on the same version). The page offers macOS (dmg)
-   and Linux (AppImage); Windows stays "pending" until its installer is uploaded.
+   no-JS fallback; keep them on the same version).
 2. Build on each OS runner with signing env present: `npm run electron:build`,
-   with `VITE_DESKTOP_API_ORIGIN` unset or set to the production origin. macOS
-   and Linux are built and published by CI on the release tag (see "Publishing
-   from CI"); CI leaves the origin unset, so it always bakes production. Only
-   Windows still needs a manual runner. A
+   with `VITE_DESKTOP_API_ORIGIN` unset or set to the production origin. All
+   three platforms are built and published by CI on the release tag (see
+   "Publishing from CI"); CI leaves the origin unset, so it always bakes
+   production. A
    production release MUST emit `latest*.yml` feed files (`latest.yml` on
    Windows, `latest-mac.yml`, `latest-linux*.yml`); if the build produced
    `dev*.yml` instead, it was baked with a non-production origin: rebuild, do
@@ -273,7 +311,9 @@ SHA256SUMS-mac --ignore-missing` on macOS) from their download directory.
    - macOS: handled by CI; the manual list, should CI ever be bypassed:
      `world-of-claudecraft-<v>-mac-universal.dmg` (download page),
      `...-mac-universal.zip` + `.zip.blockmap` (updater), `latest-mac.yml`.
-   - Windows: with x64+arm64 and no `nsis` block, electron-builder's
+   - Windows: handled by CI (which takes the artifact list from `latest.yml`,
+     see "Publishing from CI"). For a manual upload, should CI ever be
+     bypassed: with x64+arm64 and no `nsis` block, electron-builder's
      `buildUniversalInstaller` default (true) emits ONE combined NSIS installer
      covering both arches (not per-arch `-win-x64.exe` / `-win-arm64.exe`), plus
      its `.exe.blockmap` and `latest.yml`. Upload exactly what `release/` holds;

--- a/scripts/electron-build.mjs
+++ b/scripts/electron-build.mjs
@@ -7,6 +7,7 @@ import {
   azureSignOptionsFromEnv,
   desktopBuilderConfig,
   isChannelFeedFile,
+  keyVaultSignConfigFromEnv,
   stampChannelFeedFiles,
 } from './electron-builder-config.mjs';
 import { buildElectronVendor } from './electron-vendor.mjs';
@@ -101,6 +102,9 @@ const config = desktopBuilderConfig({
   loginOrigin,
   crashSubmitUrl: process.env.WOC_CRASH_SUBMIT_URL ?? '',
   azureSign: process.platform === 'win32' ? azureSignOptionsFromEnv(process.env) : null,
+  // The Azure Key Vault certificate route (the AzureSignTool hook); the config
+  // derivation prefers azureSign when both credential sets are present.
+  keyVaultSign: process.platform === 'win32' ? keyVaultSignConfigFromEnv(process.env) : null,
   // The update track defaults from apiOrigin (production origin publishes the
   // 'latest' feed, anything else 'dev'); WOC_UPDATE_CHANNEL=dev stages a
   // production-origin artifact on the dev track for update-pipeline testing.

--- a/scripts/electron-builder-config.d.mts
+++ b/scripts/electron-builder-config.d.mts
@@ -15,6 +15,15 @@ export function azureSignOptionsFromEnv(
   env?: Record<string, string | undefined>,
 ): AzureSignOptions | null;
 
+export interface KeyVaultSignConfig {
+  sign: string;
+  signingHashAlgorithms: string[];
+}
+
+export function keyVaultSignConfigFromEnv(
+  env?: Record<string, string | undefined>,
+): KeyVaultSignConfig | null;
+
 export interface DesktopBuilderConfig {
   extraMetadata: {
     wocDesktop: {
@@ -28,7 +37,11 @@ export interface DesktopBuilderConfig {
   publish: { channel?: UpdateChannel; [key: string]: unknown } | null;
   directories: { output?: string; [key: string]: unknown };
   mac: { [key: string]: unknown };
-  win: { azureSignOptions?: AzureSignOptions; [key: string]: unknown };
+  win: {
+    azureSignOptions?: AzureSignOptions;
+    signtoolOptions?: KeyVaultSignConfig & { [key: string]: unknown };
+    [key: string]: unknown;
+  };
   linux: { [key: string]: unknown };
   files?: string[];
   asarUnpack?: string[];
@@ -43,6 +56,7 @@ export function desktopBuilderConfig(input: {
   loginOrigin?: string;
   crashSubmitUrl?: string;
   azureSign?: AzureSignOptions | null;
+  keyVaultSign?: KeyVaultSignConfig | null;
   updateChannel?: string | null;
   steamAppId?: string;
   steamworksInstalled?: (() => boolean) | null;

--- a/scripts/electron-builder-config.mjs
+++ b/scripts/electron-builder-config.mjs
@@ -20,9 +20,12 @@
 //    has nothing to read even if it were reached), and every OS targets 'dir'
 //    because SteamPipe depots upload the loose installed layout (mac: the
 //    signed .app; win: win-unpacked; linux: linux-unpacked), never installers.
-//  - windows signing: Azure Artifact Signing options are injected only when the
-//    caller resolved a complete set from the environment, so unsigned local
-//    builds never trip the signing step.
+//  - windows signing: two routes, each injected only when the caller resolved
+//    a complete credential set from the environment, so unsigned local builds
+//    never trip the signing step. Azure Trusted Signing (WIN_SIGN_*) injects
+//    win.azureSignOptions and wins when both are configured; the Azure Key
+//    Vault certificate route (AZURE_KEY_VAULT_* + AZURE_TENANT_ID/CLIENT_*)
+//    injects the AzureSignTool hook via win.signtoolOptions.
 //
 // Kept free of child_process/fs so tests/electron_builder_config.test.ts can pin
 // the channel differences directly.
@@ -48,6 +51,31 @@ export function azureSignOptionsFromEnv(env = {}) {
   return null;
 }
 
+// The other Windows signing route: an Azure KEY VAULT certificate driven by
+// the AzureSignTool hook (scripts/electron-win-sign.mjs) via
+// win.signtoolOptions, as opposed to the Trusted Signing account/profile
+// shape azureSignOptionsFromEnv covers. Returns the signtoolOptions block only
+// when the complete credential set is present, so unsigned local builds never
+// trip the hook. The hook reads the credentials from env at sign time; only
+// the module path and the single-pass sha256 pin land in the derived config
+// (which is written to a tmp file, so no secret may ever ride in it).
+export function keyVaultSignConfigFromEnv(env = {}) {
+  const required = [
+    'AZURE_KEY_VAULT_URL',
+    'AZURE_TENANT_ID',
+    'AZURE_CLIENT_ID',
+    'AZURE_CLIENT_SECRET',
+    'AZURE_KEY_VAULT_CERTIFICATE',
+  ];
+  if (!required.every((name) => typeof env[name] === 'string' && env[name] !== '')) return null;
+  return {
+    sign: './scripts/electron-win-sign.mjs',
+    // One signing pass per file: the default ['sha1', 'sha256'] dual-signing
+    // would re-invoke the hook for a sha1 pass AzureSignTool cannot append.
+    signingHashAlgorithms: ['sha256'],
+  };
+}
+
 // Collapse [{target, arch}] entries to bare target names so `pack` mode builds
 // only the host arch: the full arch matrix (mac universal, win/linux x64+arm64)
 // is a RELEASE concern, and a local --dir verification pack should stay fast.
@@ -66,6 +94,7 @@ export function desktopBuilderConfig({
   loginOrigin = '',
   crashSubmitUrl = '',
   azureSign = null,
+  keyVaultSign = null,
   updateChannel = null,
   steamAppId = '',
   steamworksInstalled = null,
@@ -120,8 +149,17 @@ export function desktopBuilderConfig({
     }
     config.publish = { ...config.publish, channel };
   }
+  // Windows signing routes, mutually exclusive with Trusted Signing first:
+  // both resolvers require a complete env set, so at most one is normally
+  // non-null, and if an operator ever configures both, the native Trusted
+  // Signing path wins over the custom hook.
   if (azureSign) {
     config.win = { ...(config.win ?? {}), azureSignOptions: azureSign };
+  } else if (keyVaultSign) {
+    config.win = {
+      ...(config.win ?? {}),
+      signtoolOptions: { ...(config.win?.signtoolOptions ?? {}), ...keyVaultSign },
+    };
   }
   if (distribution === 'steam') {
     // A packaged depot cannot recover the app id from env (electron/steam.cjs

--- a/scripts/electron-win-sign.d.mts
+++ b/scripts/electron-win-sign.d.mts
@@ -1,0 +1,14 @@
+// Hand-written declarations for scripts/electron-win-sign.mjs so the Vitest
+// suite type-checks its imports (same convention as
+// scripts/electron-builder-config.d.mts). Keep in sync with the .mjs exports.
+
+export const KEY_VAULT_SIGN_ENV_VARS: string[];
+
+export function resolveTimestampUrl(value: string | undefined): string;
+
+export function azureSignToolArgs(
+  env: Record<string, string | undefined>,
+  filePath: string,
+): string[];
+
+export default function sign(configuration: { path: string; hash?: string }): Promise<void>;

--- a/scripts/electron-win-sign.mjs
+++ b/scripts/electron-win-sign.mjs
@@ -1,0 +1,93 @@
+// Custom electron-builder Windows sign hook for the Azure KEY VAULT
+// certificate setup (AzureSignTool), as opposed to the Azure Trusted Signing
+// account/profile shape the WIN_SIGN_* / win.azureSignOptions route covers.
+// Wired as win.signtoolOptions.sign by scripts/electron-builder-config.mjs
+// (keyVaultSignConfigFromEnv); electron-builder invokes the default export
+// once per signable file (the NSIS installer, the app exe that rides inside
+// the per-arch zips, uninstaller stubs, ...) and per signingHashAlgorithms
+// entry, with { path, hash, isNest, ... }. The config pins ['sha256'] so each
+// file gets exactly one signing pass.
+//
+// Credentials come from env at sign time (never from the derived config file):
+// AZURE_KEY_VAULT_URL + AZURE_TENANT_ID + AZURE_CLIENT_ID + AZURE_CLIENT_SECRET
+// + AZURE_KEY_VAULT_CERTIFICATE (the certificate name inside the vault).
+// Requires the AzureSignTool dotnet global tool on PATH.
+
+import { spawnSync } from 'node:child_process';
+
+export const KEY_VAULT_SIGN_ENV_VARS = [
+  'AZURE_KEY_VAULT_URL',
+  'AZURE_TENANT_ID',
+  'AZURE_CLIENT_ID',
+  'AZURE_CLIENT_SECRET',
+  'AZURE_KEY_VAULT_CERTIFICATE',
+];
+
+const DEFAULT_TIMESTAMP_URL = 'http://timestamp.digicert.com';
+const DEFAULT_DIGEST = 'sha256';
+
+// Only a value that is actually a URL is trusted; anything else (unset, empty,
+// or a junk string in the CI secret) falls back to DigiCert's public RFC 3161
+// server. Timestamp servers are commonly plain http; that is fine, the
+// timestamp token itself is signed.
+export function resolveTimestampUrl(value) {
+  return typeof value === 'string' && /^https?:\/\//.test(value) ? value : DEFAULT_TIMESTAMP_URL;
+}
+
+// Pure argv construction so the test suite can pin the exact AzureSignTool
+// invocation without spawning anything. Digest overrides accept the sha
+// family only; anything else falls back to sha256 rather than handing
+// AzureSignTool a junk algorithm name.
+export function azureSignToolArgs(env, filePath) {
+  const digest = (value) => (/^sha(256|384|512)$/.test(value ?? '') ? value : DEFAULT_DIGEST);
+  return [
+    'sign',
+    '-kvu',
+    env.AZURE_KEY_VAULT_URL,
+    '-kvt',
+    env.AZURE_TENANT_ID,
+    '-kvi',
+    env.AZURE_CLIENT_ID,
+    '-kvs',
+    env.AZURE_CLIENT_SECRET,
+    '-kvc',
+    env.AZURE_KEY_VAULT_CERTIFICATE,
+    '-tr',
+    resolveTimestampUrl(env.CODE_SIGN_TIMESTAMP_URL),
+    '-td',
+    digest(env.CODE_SIGN_TIMESTAMP_DIGEST),
+    '-fd',
+    digest(env.CODE_SIGN_FILE_DIGEST),
+    filePath,
+  ];
+}
+
+export default async function sign(configuration) {
+  // The config pins signingHashAlgorithms to ['sha256']; guard anyway so a
+  // future dual-signing config cannot silently append a sha1 pass AzureSignTool
+  // would treat as a fresh (overwriting) signature.
+  if (configuration.hash && configuration.hash !== 'sha256') {
+    throw new Error(
+      `the Key Vault sign hook only supports sha256, got a ${configuration.hash} pass; ` +
+        'keep win.signtoolOptions.signingHashAlgorithms pinned to ["sha256"]',
+    );
+  }
+  const missing = KEY_VAULT_SIGN_ENV_VARS.filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(`Key Vault signing env vars are missing: ${missing.join(', ')}`);
+  }
+  // No shell: the client secret must never pass through cmd.exe quoting. The
+  // dotnet global tool shim resolves as azuresigntool.exe from PATH.
+  const result = spawnSync('azuresigntool', azureSignToolArgs(process.env, configuration.path), {
+    stdio: 'inherit',
+  });
+  if (result.error) {
+    throw new Error(
+      `failed to run azuresigntool (is the AzureSignTool dotnet global tool installed ` +
+        `and on PATH?): ${result.error.message}`,
+    );
+  }
+  if (result.status !== 0) {
+    throw new Error(`azuresigntool exited with status ${result.status} for ${configuration.path}`);
+  }
+}

--- a/tests/electron_builder_config.test.ts
+++ b/tests/electron_builder_config.test.ts
@@ -7,6 +7,7 @@ import {
   azureSignOptionsFromEnv,
   desktopBuilderConfig,
   isChannelFeedFile,
+  keyVaultSignConfigFromEnv,
   stampChannelFeedFiles,
   stampFeedFile,
 } from '../scripts/electron-builder-config.mjs';
@@ -295,6 +296,27 @@ describe('desktopBuilderConfig', () => {
     expect(plain.win.azureSignOptions).toBeUndefined();
   });
 
+  it('injects the Key Vault sign hook only when provided, and Trusted Signing wins', () => {
+    const keyVaultSign = {
+      sign: './scripts/electron-win-sign.mjs',
+      signingHashAlgorithms: ['sha256'],
+    };
+    const config = desktopBuilderConfig({ base, distribution: 'website', keyVaultSign });
+    expect(config.win.signtoolOptions).toEqual(keyVaultSign);
+    expect(config.win.azureSignOptions).toBeUndefined();
+    const azureSign = {
+      publisherName: 'CN=Example Corp',
+      endpoint: 'https://eus.codesigning.azure.net',
+      codeSigningAccountName: 'example-account',
+      certificateProfileName: 'example-profile',
+    };
+    const both = desktopBuilderConfig({ base, distribution: 'website', azureSign, keyVaultSign });
+    expect(both.win.azureSignOptions).toEqual(azureSign);
+    expect(both.win.signtoolOptions).toBeUndefined();
+    const plain = desktopBuilderConfig({ base, distribution: 'website' });
+    expect(plain.win.signtoolOptions).toBeUndefined();
+  });
+
   it('rejects an unknown distribution loudly', () => {
     expect(() => desktopBuilderConfig({ base, distribution: 'beta' })).toThrow(
       /unknown desktop distribution/,
@@ -439,5 +461,30 @@ describe('azureSignOptionsFromEnv', () => {
     expect(azureSignOptionsFromEnv({ ...full, WIN_SIGN_ENDPOINT: '' })).toBeNull();
     const { WIN_SIGN_PROFILE_NAME, ...partial } = full;
     expect(azureSignOptionsFromEnv(partial)).toBeNull();
+  });
+});
+
+describe('keyVaultSignConfigFromEnv', () => {
+  const full = {
+    AZURE_KEY_VAULT_URL: 'https://example.vault.azure.net',
+    AZURE_TENANT_ID: 'tenant-id',
+    AZURE_CLIENT_ID: 'client-id',
+    AZURE_CLIENT_SECRET: 'client-secret',
+    AZURE_KEY_VAULT_CERTIFICATE: 'woc-code-signing',
+  };
+
+  it('returns the sign-hook signtoolOptions only when every env var is set and non-empty', () => {
+    expect(keyVaultSignConfigFromEnv(full)).toEqual({
+      sign: './scripts/electron-win-sign.mjs',
+      signingHashAlgorithms: ['sha256'],
+    });
+  });
+
+  it('returns null on any missing or empty variable (unsigned local builds)', () => {
+    expect(keyVaultSignConfigFromEnv({})).toBeNull();
+    expect(keyVaultSignConfigFromEnv()).toBeNull();
+    expect(keyVaultSignConfigFromEnv({ ...full, AZURE_CLIENT_SECRET: '' })).toBeNull();
+    const { AZURE_KEY_VAULT_CERTIFICATE, ...partial } = full;
+    expect(keyVaultSignConfigFromEnv(partial)).toBeNull();
   });
 });

--- a/tests/electron_win_sign.test.ts
+++ b/tests/electron_win_sign.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  azureSignToolArgs,
+  KEY_VAULT_SIGN_ENV_VARS,
+  resolveTimestampUrl,
+} from '../scripts/electron-win-sign.mjs';
+
+const env = {
+  AZURE_KEY_VAULT_URL: 'https://example.vault.azure.net',
+  AZURE_TENANT_ID: 'tenant-id',
+  AZURE_CLIENT_ID: 'client-id',
+  AZURE_CLIENT_SECRET: 'client-secret',
+  AZURE_KEY_VAULT_CERTIFICATE: 'woc-code-signing',
+};
+
+describe('resolveTimestampUrl', () => {
+  it('honors an http(s) URL', () => {
+    expect(resolveTimestampUrl('https://timestamp.acs.microsoft.com')).toBe(
+      'https://timestamp.acs.microsoft.com',
+    );
+    expect(resolveTimestampUrl('http://timestamp.digicert.com')).toBe(
+      'http://timestamp.digicert.com',
+    );
+  });
+
+  it('falls back to DigiCert on junk, empty, or unset values', () => {
+    // "advanced" is the literal junk value observed in the operator's CI
+    // secret; the fallback keeps the build timestamped instead of failing.
+    expect(resolveTimestampUrl('advanced')).toBe('http://timestamp.digicert.com');
+    expect(resolveTimestampUrl('')).toBe('http://timestamp.digicert.com');
+    expect(resolveTimestampUrl(undefined)).toBe('http://timestamp.digicert.com');
+  });
+});
+
+describe('azureSignToolArgs', () => {
+  it('pins the exact AzureSignTool invocation', () => {
+    expect(
+      azureSignToolArgs(
+        { ...env, CODE_SIGN_TIMESTAMP_URL: 'http://timestamp.digicert.com' },
+        'release/woc-setup.exe',
+      ),
+    ).toEqual([
+      'sign',
+      '-kvu',
+      'https://example.vault.azure.net',
+      '-kvt',
+      'tenant-id',
+      '-kvi',
+      'client-id',
+      '-kvs',
+      'client-secret',
+      '-kvc',
+      'woc-code-signing',
+      '-tr',
+      'http://timestamp.digicert.com',
+      '-td',
+      'sha256',
+      '-fd',
+      'sha256',
+      'release/woc-setup.exe',
+    ]);
+  });
+
+  it('defaults junk or missing digest overrides to sha256 and honors real ones', () => {
+    const junk = azureSignToolArgs(
+      { ...env, CODE_SIGN_FILE_DIGEST: 'advanced', CODE_SIGN_TIMESTAMP_DIGEST: '' },
+      'a.exe',
+    );
+    expect(junk[junk.indexOf('-fd') + 1]).toBe('sha256');
+    expect(junk[junk.indexOf('-td') + 1]).toBe('sha256');
+    const real = azureSignToolArgs(
+      { ...env, CODE_SIGN_FILE_DIGEST: 'sha384', CODE_SIGN_TIMESTAMP_DIGEST: 'sha512' },
+      'a.exe',
+    );
+    expect(real[real.indexOf('-fd') + 1]).toBe('sha384');
+    expect(real[real.indexOf('-td') + 1]).toBe('sha512');
+  });
+});
+
+describe('KEY_VAULT_SIGN_ENV_VARS', () => {
+  it('pins the credential set the CI job and the config resolver require', () => {
+    expect(KEY_VAULT_SIGN_ENV_VARS).toEqual([
+      'AZURE_KEY_VAULT_URL',
+      'AZURE_TENANT_ID',
+      'AZURE_CLIENT_ID',
+      'AZURE_CLIENT_SECRET',
+      'AZURE_KEY_VAULT_CERTIFICATE',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the missing third platform to the Desktop publish workflow: a windows-latest job that builds, signs, verifies, and publishes the Windows desktop artifacts, replacing the manual runbook that was waiting on Azure signing provisioning.

- New windows job in .github/workflows/desktop-publish.yml mirroring the linux/mac jobs: fail-fast secrets check, npm ci, AzureSignTool install, signed electron-builder build, Authenticode verification gate (Get-AuthenticodeSignature must be Valid), SHA256SUMS-windows, artifact verification, dry-run artifact attach on manual dispatch, and the ordered R2 upload with latest.yml uploaded last.
- New custom sign hook scripts/electron-win-sign.mjs (wired as win.signtoolOptions.sign by scripts/electron-builder-config.mjs) that signs every signable file via AzureSignTool against an Azure Key Vault certificate. The existing WIN_SIGN_* Azure Trusted Signing route stays first priority and unchanged; local unsigned builds are unchanged.
- Artifact verification is dynamic-from-feed: with x64+arm64 and buildUniversalInstaller defaulting true, electron-builder emits one combined NSIS installer whose name the runbook says to verify from latest.yml rather than assume, so every url/path in the feed must exist, carry the release version, and the installer must have its blockmap. A dev*.yml misbake fails instead of publishing.
- docs/desktop-release.md updated: the two Windows signing routes with exact secret names, Publishing from CI now covers all three platforms.

## Secrets

Uses the already-provisioned AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_KEY_VAULT_URL, CODE_SIGN_TIMESTAMP_URL, CODE_SIGN_FILE_DIGEST, CODE_SIGN_TIMESTAMP_DIGEST plus the shared R2_* upload secrets.

Action needed before the first run:
- [ ] Add the AZURE_KEY_VAULT_CERTIFICATE repo secret (the certificate name inside the Key Vault); the job hard-fails without it.
- [ ] Fix or delete the CODE_SIGN_TIMESTAMP_URL secret (currently holds the junk value "advanced"; the hook falls back to http://timestamp.digicert.com so this is not blocking).
- [ ] Grant the service principal Key Vault sign/get access for the certificate and key (AzureSignTool needs it; no CI check can verify this in advance).

WINDOWS_PUBLISHER_NAME and CSC_NAME are not consumed by the Key Vault path (CSC_NAME is a macOS keychain identity concept); WINDOWS_PUBLISHER_NAME should match the certificate subject CN and is documented as such.

## Test plan
- [x] npx vitest run tests/electron_builder_config.test.ts tests/electron_win_sign.test.ts (36 passed: hook argv pinned exactly, injection priority WIN_SIGN_* over Key Vault, timestamp/digest fallbacks)
- [x] npx tsc --noEmit clean; Biome clean on changed files
- [ ] First real run: workflow_dispatch DRY RUN (build + sign + verify, artifacts attached to the run, no upload), then eyeball the emitted installer name in latest.yml
- [ ] Consider adding the Windows download link to index.html/play.html once the installer name is confirmed (the download page currently offers mac/linux only)