### PR TITLE
fix(desktop): spawn npm and electron-builder through the shell on Windows

### DIFF
--- a/scripts/electron-build.mjs
+++ b/scripts/electron-build.mjs
@@ -79,7 +79,24 @@ const adhocMacSign =
     : [];
 
 function run(command, args) {
-  const result = spawnSync(command, args, { env, stdio: 'inherit', cwd: root });
+  // On Windows the npm and electron-builder launchers are .cmd batch shims, and
+  // Node 20.12+/22 (the CVE-2024-27980 hardening) refuses to spawn a batch file
+  // without a shell: spawnSync returns EINVAL with a null status and nothing on
+  // stderr. Route through the shell there, quoting any argument with spaces
+  // ourselves because shell mode joins argv without re-quoting. The sign hook's
+  // azuresigntool call stays shell-less on purpose (it is a real .exe and its
+  // argv carries the client secret, which must never pass through cmd.exe).
+  const useShell = process.platform === 'win32';
+  const shellArgs = useShell ? args.map((a) => (/\s/.test(a) ? `"${a}"` : a)) : args;
+  const result = spawnSync(command, shellArgs, {
+    env,
+    stdio: 'inherit',
+    cwd: root,
+    shell: useShell,
+  });
+  if (result.error) {
+    console.error(`electron-build: failed to spawn ${command}: ${result.error.message}`);
+  }
   if (result.status !== 0) process.exit(result.status ?? 1);
 }
 


### PR DESCRIPTION
## Summary

The first live Windows publish run (tag v0.26.0, run 29421074495) failed in 0.14 seconds with a silent exit 1 at the top of scripts/electron-build.mjs. Root cause: the script's run() helper spawns npm.cmd and electron-builder.cmd, and Node 20.12+/22 (the CVE-2024-27980 batch-file hardening) refuses to spawn a .cmd shim without a shell: spawnSync returns EINVAL with a null status, and run() exited without printing the error.

- run() now uses shell: true on win32, quoting arguments containing spaces itself (shell mode joins argv without re-quoting; the electron-builder --config argument is a temp-dir path).
- spawnSync errors are printed before exiting, so a spawn failure can never be silent again.
- scripts/electron-win-sign.mjs deliberately keeps shell: false: azuresigntool is a real .exe shim and its argv carries the Key Vault client secret, which must never pass through cmd.exe quoting.

## Test plan
- [x] npx vitest run tests/electron_builder_config.test.ts tests/electron_win_sign.test.ts (36 passed)
- [x] Biome clean
- [ ] After merge: workflow_dispatch dry run of Desktop publish (publish unchecked) to prove the Windows job end to end, then a publish=true dispatch to backfill the v0.26.0 Windows artifacts
