### PR TITLE
feat(trade): inspect offered items on hover in the trade window

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -5509,7 +5509,7 @@
   .soc-x:focus-visible,
   .soc-name.soc-link:focus-visible,
   .soc-sugg-item:focus-visible,
-  .trade-item.mine:focus-visible {
+  .trade-item:focus-visible {
     outline: 2px solid var(--color-border-focus);
     outline-offset: 2px;
   }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -15270,9 +15270,13 @@ export class Hud {
       const item = ITEMS[s.itemId];
       const label = `${item ? itemDisplayName(item) : s.itemId}${s.count > 1 ? ` x${formatNumber(s.count, { maximumFractionDigits: 0 })}` : ''}`;
       const inner = `${this.itemIcon(item)}<span>${esc(label)}</span>`;
+      // Both sides carry data-item so either can be hovered/focused to inspect it.
+      // Their (read-only) rows are non-interactive divs, so give them tabindex="0"
+      // to keep the inspect tooltip keyboard- and long-press-reachable like the
+      // clickable "mine" buttons.
       return mine
         ? `<button type="button" class="trade-item mine" data-item="${esc(s.itemId)}">${inner}</button>`
-        : `<div class="trade-item">${inner}</div>`;
+        : `<div class="trade-item" data-item="${esc(s.itemId)}" tabindex="0">${inner}</div>`;
     };
     el.innerHTML = `
       <div class="panel-title"><span>${esc(t('hud.trade.title', { name: info.otherName }))}</span><button type="button" class="x-btn" data-close aria-label="${esc(t('hud.trade.cancel'))}">${svgIcon('close')}</button></div>
@@ -15316,6 +15320,13 @@ export class Hud {
           this.pushTradeOffer();
         }
       });
+    });
+    // Trade item preview: hover, focus, or long-press any offered item (yours or
+    // theirs) to inspect it, reusing the shared item tooltip that bags, the vendor,
+    // and loot rows use. Guarded on a resolvable item so a stale id never throws.
+    el.querySelectorAll('.trade-item').forEach((row) => {
+      const item = ITEMS[(row as HTMLElement).dataset.item ?? ''];
+      if (item) this.attachTooltip(row as HTMLElement, () => this.itemTooltip(item));
     });
     const goldInput = el.querySelector('#trade-g') as HTMLInputElement;
     const silverInput = el.querySelector('#trade-s') as HTMLInputElement;

--- a/tests/trade_item_preview.test.ts
+++ b/tests/trade_item_preview.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// Source-scan guard (the honor_ui.test.ts style): the trade window is inline DOM in
+// hud.ts with no pure core to unit-test, so pin the item-preview wiring here so a
+// future edit cannot silently drop the hover-to-inspect behavior on trade items.
+const hud = readFileSync(new URL('../src/ui/hud.ts', import.meta.url), 'utf8');
+
+describe('trade item preview', () => {
+  const start = hud.indexOf('private updateTradeWindow(');
+  const body = hud.slice(
+    start,
+    hud.indexOf('private ', start + 'private updateTradeWindow('.length),
+  );
+
+  it('found the updateTradeWindow body to scan', () => {
+    expect(start).toBeGreaterThan(0);
+    expect(body.length).toBeGreaterThan(200);
+  });
+
+  it('carries a data-item on BOTH the mine and theirs rows so either can be inspected', () => {
+    // "mine" stays a clickable button (remove-from-trade); "theirs" is a read-only div
+    // made focusable (tabindex) so the inspect tooltip is keyboard- and long-press-reachable.
+    expect(body).toContain('class="trade-item mine" data-item=');
+    expect(body).toContain('class="trade-item" data-item=');
+    expect(body).toContain('tabindex="0"');
+  });
+
+  it('attaches the shared item tooltip to every offered item, guarded on a real item', () => {
+    expect(body).toMatch(/querySelectorAll\('\.trade-item'\)/);
+    expect(body).toContain("ITEMS[(row as HTMLElement).dataset.item ?? '']");
+    expect(body).toContain('this.attachTooltip(row as HTMLElement, () => this.itemTooltip(item))');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a trade item preview: hovering (or focusing, or long-pressing on touch) any item in either side of the trade window now shows its full item tooltip, the same inspect players already get in bags, the vendor, and loot lists. Previously you could see a trade item's name and icon but had no way to inspect its stats before accepting.

## What changed

- **Both sides carry a `data-item` id.** The clickable "mine" rows already had one (for remove-from-trade); the read-only "theirs" rows now do too, and are made focusable with `tabindex="0"` so the inspect tooltip is keyboard- and long-press-reachable, not mouse-only.
- **Every offered item gets the shared tooltip.** After the trade window renders, each `.trade-item` is wired with `attachTooltip(() => itemTooltip(item))`, guarded on a resolvable `ITEMS[id]`. This is the exact pattern bags, the vendor, and loot rows use (`attachTooltip` handles desktop hover, keyboard focus, and mobile long-press for free).
- **Focus ring.** The `:focus-visible` outline is generalized from `.trade-item.mine` to `.trade-item` so the newly focusable "theirs" rows show a ring, satisfying the HUD-chrome WCAG contract.

No sim, server, wire, or `IWorld` change: it reuses the existing `tradeInfo` offer data and the existing item tooltip.

## Testing

- `tests/trade_item_preview.test.ts` (new): a source-scan guard (the `honor_ui.test.ts` style) pinning the wiring, since the trade window is inline DOM in `hud.ts` with no pure core to unit-test: both rows carry `data-item`, the "theirs" row is focusable, and every `.trade-item` gets the shared item tooltip.
- Green: `tests/css_corpus`, `tests/css_value_validity`, `tests/focus_visible_guard`, `tests/styles_extraction`, `tests/trade`, `tests/architecture`, `tests/client_shell`. `tsc --noEmit` clean for the changed files.

Note: the tooltip is the established item tooltip (visually identical to the bag/vendor/loot inspect), so no new visual style is introduced; a headless screenshot would require standing up a live two-player trade, which the reused pattern does not warrant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
