### PR TITLE
fix(chat): /1 General shortcut, working !lfg/!events, and stay on the last channel sent (main)

### DIFF
--- a/src/sim/discord_relay.ts
+++ b/src/sim/discord_relay.ts
@@ -75,7 +75,13 @@ export const RELAY_COMMANDS: readonly RelayCommand[] = [
 ];
 
 export function relayCommandById(id: string): RelayCommand | undefined {
-  return RELAY_COMMANDS.find((c) => c.id === id.toLowerCase());
+  const key = id.toLowerCase();
+  const exact = RELAY_COMMANDS.find((c) => c.id === key);
+  if (exact) return exact;
+  // Accept a natural plural ("!events" -> event, "!lfgs" -> lfg) only when the exact
+  // word is unknown, so "!event" written as "!events" still posts.
+  if (key.endsWith('s')) return RELAY_COMMANDS.find((c) => c.id === key.slice(0, -1));
+  return undefined;
 }
 
 /**

--- a/src/sim/social/chat.ts
+++ b/src/sim/social/chat.ts
@@ -761,9 +761,11 @@ export function chat(ctx: SimContext, text: string, pid?: number): SentChat | nu
     return { channel: 'party', message: clean };
   }
 
-  // "/g message": world-wide general channel (no pid = broadcast to all)
-  if (/^\/g(eneral)?\s/i.test(raw)) {
-    const clean = raw.replace(/^\/g(eneral)?\s+/i, '').trim();
+  // "/g message" / "/1 message": world-wide general channel (no pid = broadcast to
+  // all). "/1" is the classic numbered-channel shortcut for General; unlike "/g" it
+  // is never claimed by the online guild router, so it always reaches General.
+  if (/^\/(?:g(?:eneral)?|1)\s/i.test(raw)) {
+    const clean = raw.replace(/^\/(?:g(?:eneral)?|1)\s+/i, '').trim();
     if (!clean) return null;
     ctx.emit({
       type: 'chat',

--- a/src/ui/chat_channels.ts
+++ b/src/ui/chat_channels.ts
@@ -170,11 +170,15 @@ export function composeWhisperReply(typed: string): string {
 // whisper / reply (`/w`, `/r`), emotes (`/me`, `/dance`), rolls (`/roll`),
 // channel membership (`/join`, `/leave`), the ambiguous bare `/g` (say offline,
 // guild online), and any unknown command return null and leave the sticky
-// channel unchanged. Host-independent by design: only prefixes that route
-// identically offline and online are mapped (hence `/gu`/`/general`, never `/g`).
+// channel unchanged. A `!` community command (`!lfg`, `!events`) is a transient
+// command like a roll, and it is host-dependent anyway (the server relay gate
+// consumes it online; offline it would land in say), so it also returns null.
+// Host-independent by design: only prefixes that route identically offline and
+// online are mapped (hence `/gu`/`/general`, never `/g`).
 export function sentLineChannel(line: string): ChatTabChannel | null {
   const text = line.trim();
   if (!text) return null;
+  if (text.startsWith('!')) return null;
   if (!text.startsWith('/')) return 'say';
   if (/^\/p(arty)?\s/i.test(text)) return 'party';
   if (/^\/y(ell)?\s/i.test(text)) return 'yell';

--- a/src/ui/chat_channels.ts
+++ b/src/ui/chat_channels.ts
@@ -141,10 +141,13 @@ export function chatInputTint(channel: ChatInputTintTarget | null): string | nul
 
 // Compose the text actually sent for a message typed while a channel tab is
 // active. An explicit slash command the player typed always wins (so "/w bob hi"
-// from the World tab still whispers); otherwise the channel prefix is prepended.
+// from the World tab still whispers); a "!" community command (lfg/wts/event/...)
+// is likewise passed through untouched, so the server's "!" relay intercept still
+// fires (prefixing it as "/say !lfg ..." would hide it from that gate); otherwise
+// the channel prefix is prepended.
 export function composeChatLine(channel: ChatTabChannel, typed: string): string {
   const text = typed.trim();
-  if (!text || text.startsWith('/')) return text;
+  if (!text || text.startsWith('/') || text.startsWith('!')) return text;
   return channelSendPrefix(channel) + text;
 }
 
@@ -178,10 +181,27 @@ export function sentLineChannel(line: string): ChatTabChannel | null {
   if (/^\/s(ay)?\s/i.test(text)) return 'say';
   if (/^\/gu(ild)?\s/i.test(text)) return 'guild';
   if (/^\/o(fficer)?\s/i.test(text)) return 'officer';
-  if (/^\/general\s/i.test(text)) return 'general';
+  // "/1" is the numbered-channel shortcut for General (see sentLineTarget below and
+  // the sim router); "/g" is intentionally NOT here because it routes to guild online.
+  if (/^\/(?:general|1)\s/i.test(text)) return 'general';
   if (/^\/world\s/i.test(text)) return 'world';
   if (/^\/lfg\s/i.test(text)) return 'lfg';
   return null;
+}
+
+// Like sentLineChannel, but ALSO recognizes a whisper REPLY (`/r`, `/reply`) as
+// the 'whisper' target. This is what makes the chat input STAY on the last thing
+// you sent: after you reply to a whisper, the next plain line keeps replying
+// (composeWhisperReply -> `/r`, which the server routes to the same last-whisperer)
+// instead of snapping back to your previous standing channel. Only `/r` sticks, not
+// an explicit `/w Name`: the latter is a deliberate one-off to a specific person,
+// and sticking it would send the NEXT plain line to whoever last whispered YOU (the
+// server's `/r` target), not that person. Emotes, rolls, channel membership, and
+// unknown commands still return null (sticky unchanged).
+export function sentLineTarget(line: string): ChatInputTintTarget | null {
+  const text = line.trim();
+  if (/^\/r(eply)?\s/i.test(text)) return WHISPER_TAB;
+  return sentLineChannel(line);
 }
 
 // Persistence: the ordered list of channel tabs the player has opened. The

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -183,7 +183,7 @@ import {
   isChatOpenTab,
   isChatTabChannel,
   parseChatTabs,
-  sentLineChannel,
+  sentLineTarget,
   serializeChatTabs,
   WHISPER_TAB,
   WHISPER_TAB_LABEL_KEY,
@@ -1069,11 +1069,13 @@ export class Hud {
   // shown, and drives both the log filter and the send channel.
   private chatTabs: ChatOpenTab[] = [];
   private activeChatTab: ChatTabId = 'all';
-  // The last standing channel the player actually sent to (classic sticky-channel
-  // behavior). On the All/combat views a plain typed line goes here and the input
-  // is tinted with its color; a channel-bound tab always overrides it. `say` is
-  // the neutral default (no tint, generic placeholder). Whisper never sets it.
-  private stickyChannel: ChatTabChannel = 'say';
+  // The last target the player actually sent to (classic sticky-channel behavior):
+  // a standing channel OR the whisper collector (a `/r` reply). On the All/combat
+  // views a plain typed line goes here and the input is tinted to match; a
+  // channel-bound tab always overrides it. `say` is the neutral default (no tint,
+  // generic placeholder). Tracking whisper here is what keeps a reply conversation
+  // going instead of snapping the input back to the previous standing channel.
+  private stickyTarget: ChatInputTintTarget = 'say';
   // Bind the tab-strip wheel-to-horizontal-scroll listener exactly once (renderChatTabs
   // rebuilds the strip's children but the bar element itself persists).
   private chatTabsWheelBound = false;
@@ -3074,20 +3076,19 @@ export class Hud {
     return tab !== null && isChatTabChannel(tab) ? tab : null;
   }
 
-  // The standing channel a plain typed line actually reaches, honoring both the
-  // active tab and the sticky "last used" channel: a channel-bound tab wins (its
-  // bound channel), otherwise the All/combat views fall back to the sticky
-  // channel (`say` by default). The whisper tab is handled separately in
-  // composeChatSend (it has no standing channel), so this is only reached off it.
-  private effectiveSendChannel(): ChatTabChannel {
-    return this.chatSendChannel() ?? this.stickyChannel;
+  // The target a plain typed line actually reaches, honoring the active tab and the
+  // sticky "last used" target: the whisper collector wins on its own tab, else a
+  // channel-bound tab wins (its bound channel), else the All/combat views fall back
+  // to the sticky target (`say` by default, or `whisper` right after a reply).
+  private effectiveSendTarget(): ChatInputTintTarget {
+    if (this.activeChatTab === WHISPER_TAB) return WHISPER_TAB;
+    return this.chatSendChannel() ?? this.stickyTarget;
   }
 
-  // The channel the chat input's tint should signal: the whisper collector when
-  // on its tab (plain text replies as a whisper), else the effective send
-  // channel. chatInputTint maps `say` to no tint (the default input color).
+  // The target the chat input's tint should signal. chatInputTint maps `say` to no
+  // tint (the default input color) and `whisper` to the whisper color.
   private chatInputTintTarget(): ChatInputTintTarget {
-    return this.activeChatTab === WHISPER_TAB ? WHISPER_TAB : this.effectiveSendChannel();
+    return this.effectiveSendTarget();
   }
 
   private applyChatFilter(): void {
@@ -3120,12 +3121,13 @@ export class Hud {
     input.style.color = chatInputTint(this.chatInputTintTarget()) ?? '';
   }
 
-  // Remember the standing channel a just-sent line reached as the sticky default
-  // for the next chat open on the All tab. Whisper/reply, emotes, rolls, channel
-  // membership, and unknown commands leave the sticky channel unchanged.
+  // Remember the target a just-sent line reached as the sticky default for the next
+  // chat open on the All tab: a standing channel, or `whisper` for a `/r` reply so a
+  // whisper conversation keeps going. An explicit `/w Name`, emotes, rolls, channel
+  // membership, and unknown commands leave the sticky target unchanged.
   noteSentChannel(sentLine: string): void {
-    const ch = sentLineChannel(sentLine);
-    if (ch) this.stickyChannel = ch;
+    const target = sentLineTarget(sentLine);
+    if (target) this.stickyTarget = target;
   }
 
   // The line actually sent for what the player typed, honoring the active tab and
@@ -3135,8 +3137,9 @@ export class Hud {
   // the last whisperer (/r) instead of binding a channel.
   composeChatSend(typed: string): string {
     const withLinks = this.applyPendingChatLinks(typed);
-    if (this.activeChatTab === WHISPER_TAB) return composeWhisperReply(withLinks);
-    return composeChatLine(this.effectiveSendChannel(), withLinks);
+    const target = this.effectiveSendTarget();
+    if (target === WHISPER_TAB) return composeWhisperReply(withLinks);
+    return composeChatLine(target, withLinks);
   }
 
   // Shift-click a quest-log entry: open the chat input and insert a readable
@@ -3197,17 +3200,18 @@ export class Hud {
     return true;
   }
 
-  // Placeholder for the chat input reflecting the active tab and sticky channel.
+  // Placeholder for the chat input reflecting the active tab and sticky target.
   activeChatPlaceholder(): string {
-    if (this.activeChatTab === WHISPER_TAB)
+    const target = this.effectiveSendTarget();
+    // The whisper collector (its own tab, or a sticky `/r` reply) prompts "Whisper".
+    if (target === WHISPER_TAB)
       return t('hud.core.chatChannels.sendingTo', { channel: t(WHISPER_TAB_LABEL_KEY) });
     // A channel-bound tab keeps its "Message {channel}" prompt (unchanged, incl. a
     // Say tab). On the All/combat views a non-say sticky channel surfaces the same
     // "Message {channel}" prompt so the player sees where plain text will go.
     const bound = this.chatSendChannel();
-    const ch = bound ?? this.stickyChannel;
-    if (bound !== null || ch !== 'say')
-      return t('hud.core.chatChannels.sendingTo', { channel: t(CHANNEL_LABEL_KEYS[ch]) });
+    if (bound !== null || target !== 'say')
+      return t('hud.core.chatChannels.sendingTo', { channel: t(CHANNEL_LABEL_KEYS[target]) });
     // Default (All tab, sticky say): the compact touch composer has no room for the
     // desktop slash-command legend (/s, /w, /r, ...), so use a short prompt on the
     // mobile HUD. The channel-aware "Message {channel}" variants above are already

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -189,6 +189,23 @@ describe('chat channels', () => {
     expect(msgs[0].text).toBe('LFG crypt');
   });
 
+  it('the /1 shortcut reaches the General channel, like /general', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const far = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, far, 0, -900);
+    sim.tick();
+
+    const sent = sim.chat('/1 anyone for crypt', a);
+    expect(sent).toEqual({ channel: 'general', message: 'anyone for crypt' });
+    const msgs = chatEvents(sim.tick());
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].channel).toBe('general');
+    expect(msgs[0].pid).toBeUndefined();
+    expect(msgs[0].text).toBe('anyone for crypt');
+  });
+
   it('unknown slash commands error instead of being said out loud', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');

--- a/tests/chat_channels.test.ts
+++ b/tests/chat_channels.test.ts
@@ -285,6 +285,15 @@ describe('chat channel tabs — pure model', () => {
     expect(composeChatLine('party', '/w Bob hi')).toBe('/w Bob hi');
   });
 
+  it('a "!" community command is transient: it never resets the sticky channel to say', () => {
+    // noteSentChannel runs on every send; if a "!" line mapped like plain text
+    // it would return 'say' and firing "!lfg ..." mid-conversation would drop
+    // your NEXT plain line from party/general to say. It stays null, like the
+    // other transient commands (whispers, emotes, rolls).
+    expect(sentLineTarget('!lfg need a healer')).toBeNull();
+    expect(sentLineChannel('!events raid at the fountain')).toBeNull();
+  });
+
   it('sentLineChannel maps the /1 shortcut to General (but never /g, which is guild online)', () => {
     expect(sentLineChannel('/1 hey everyone')).toBe('general');
     expect(sentLineChannel('/general hey everyone')).toBe('general');

--- a/tests/chat_channels.test.ts
+++ b/tests/chat_channels.test.ts
@@ -12,6 +12,7 @@ import {
   isChatTabChannel,
   parseChatTabs,
   sentLineChannel,
+  sentLineTarget,
   serializeChatTabs,
   WHISPER_TAB,
   WHISPER_TAB_LABEL_KEY,
@@ -270,5 +271,36 @@ describe('chat channel tabs — pure model', () => {
     expect(isChatTabChannel('')).toBe(false);
     expect(isChatTabChannel(null)).toBe(false);
     expect(isChatTabChannel(7)).toBe(false);
+  });
+
+  it('passes a "!" community command through untouched (never wraps it in a channel prefix)', () => {
+    // The v0.26.0 regression prefixed non-slash lines, so "!lfg ..." became
+    // "/say !lfg ..." and the server "!" relay gate (text.startsWith("!")) missed it.
+    expect(composeChatLine('party', '!lfg need a healer')).toBe('!lfg need a healer');
+    expect(composeChatLine('say', '!events raid at the fountain')).toBe(
+      '!events raid at the fountain',
+    );
+    // A plain line still gets the channel prefix; an explicit slash still wins.
+    expect(composeChatLine('party', 'hello')).toBe('/p hello');
+    expect(composeChatLine('party', '/w Bob hi')).toBe('/w Bob hi');
+  });
+
+  it('sentLineChannel maps the /1 shortcut to General (but never /g, which is guild online)', () => {
+    expect(sentLineChannel('/1 hey everyone')).toBe('general');
+    expect(sentLineChannel('/general hey everyone')).toBe('general');
+    expect(sentLineChannel('/p on my way')).toBe('party');
+    expect(sentLineChannel('/w Bob hi')).toBeNull();
+    expect(sentLineChannel('/r sure')).toBeNull();
+  });
+
+  it('sentLineTarget also sticks to whisper after a /r reply, so the input keeps replying', () => {
+    expect(sentLineTarget('/r sure thing')).toBe(WHISPER_TAB);
+    expect(sentLineTarget('/reply ok')).toBe(WHISPER_TAB);
+    // An explicit one-off "/w Name" does NOT stick (its next reply would target the
+    // wrong person); standing channels still carry through, including /1 -> general.
+    expect(sentLineTarget('/w Bob hi')).toBeNull();
+    expect(sentLineTarget('/1 hey')).toBe('general');
+    expect(sentLineTarget('/p on my way')).toBe('party');
+    expect(sentLineTarget('hello')).toBe('say');
   });
 });

--- a/tests/chat_hud_client_seam.test.ts
+++ b/tests/chat_hud_client_seam.test.ts
@@ -18,12 +18,12 @@ describe('Hud to ClientWorld chat seam', () => {
     const hud = Object.create(Hud.prototype) as InstanceType<typeof Hud>;
     const state = hud as unknown as {
       activeChatTab: string;
-      stickyChannel: string;
+      stickyTarget: string;
       pendingChatLinks: readonly unknown[];
       chatInputTintTarget(): string;
     };
     state.activeChatTab = 'all';
-    state.stickyChannel = 'say';
+    state.stickyTarget = 'say';
     state.pendingChatLinks = [];
 
     const sent: unknown[] = [];
@@ -38,5 +38,31 @@ describe('Hud to ClientWorld chat seam', () => {
     client.chat(hud.composeChatSend('hello nearby players'));
 
     expect(sent).toEqual([{ t: 'cmd', cmd: 'chat', text: '/say hello nearby players' }]);
+  });
+
+  it('stays on the last channel sent, including a whisper reply (v0.26.0 regression)', () => {
+    vi.stubGlobal('WebSocket', { OPEN: 1 });
+    const hud = Object.create(Hud.prototype) as InstanceType<typeof Hud>;
+    const state = hud as unknown as {
+      activeChatTab: string;
+      stickyTarget: string;
+      pendingChatLinks: readonly unknown[];
+      chatInputTintTarget(): string;
+      noteSentChannel(line: string): void;
+    };
+    state.activeChatTab = 'all';
+    state.stickyTarget = 'say';
+    state.pendingChatLinks = [];
+
+    // Send in party: the sticky target follows there.
+    state.noteSentChannel(hud.composeChatSend('/p on my way'));
+    expect(state.stickyTarget).toBe('party');
+
+    // Reply to a whisper: the sticky target follows to whisper, and the NEXT plain
+    // line keeps replying (/r) instead of snapping back to party (the regression).
+    state.noteSentChannel(hud.composeChatSend('/r sure thing'));
+    expect(state.stickyTarget).toBe('whisper');
+    expect(hud.composeChatSend('and thanks')).toBe('/r and thanks');
+    expect(state.chatInputTintTarget()).toBe('whisper');
   });
 });

--- a/tests/discord_relay.test.ts
+++ b/tests/discord_relay.test.ts
@@ -68,4 +68,19 @@ describe('dropdown helpers', () => {
     expect(isRelayInput('hello')).toBe(false);
     expect(isRelayInput('/who')).toBe(false);
   });
+
+  it('accepts a natural plural so "!events" posts as the event command', () => {
+    // The command word is "event"; a player typing the plural "!events" still posts.
+    expect(relayCommandById('events')?.id).toBe('event');
+    expect(parseRelayCommand('!events raid at the fountain')).toEqual({
+      command: RELAY_COMMANDS.find((c) => c.id === 'event'),
+      message: 'raid at the fountain',
+    });
+    // The exact word wins; a real "!lfg" is unaffected and still parses.
+    expect(relayCommandById('event')?.id).toBe('event');
+    expect(parseRelayCommand('!lfg need a healer')?.command.id).toBe('lfg');
+    // A genuinely unknown word is still rejected (not force-singularized to a match).
+    expect(relayCommandById('zzz')).toBeUndefined();
+    expect(parseRelayCommand('!zzz hi')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Hotfix for three chat issues. All three are client-side (plus the sim `/1` alias); the online server paths already handle them correctly once the client stops mangling the lines, so there is no server change.

### 1. `/1` is a shortcut for General chat

The sim chat router (`src/sim/social/chat.ts`) now routes `/1 message` to the General channel alongside `/g` / `/general`, and the client sticky map (`chat_channels.sentLineChannel`) recognizes it. `/1` is used rather than `/g` because the online server claims `/g` for guild, whereas `/1` always reaches General (offline and online). It updates the server's remembered channel to General like any General send.

### 2. `!lfg` and `!events` work again

Root cause: the v0.26.0 sticky-channel change made `composeChatLine` prepend a channel prefix to any line not starting with `/`, so `!lfg need a healer` was sent as `/say !lfg need a healer` and never reached the server's `text.startsWith('!')` relay gate. `composeChatLine` now passes a `!` community command through untouched (like an explicit slash command). Separately, `!events` (the natural plural of the `!event` command) now resolves via a plural fallback in `relayCommandById` when the exact word is unknown; a genuinely unknown word is still rejected.

### 3. The chat input stays on the last channel you sent in (including a whisper reply)

Root cause: the same v0.26.0 change made the client force its sticky *standing* channel onto every plain line, overriding the server's remembered-channel routing and, crucially, ignoring whisper. After replying to a whisper, the input snapped back to your previous channel instead of continuing the reply. The sticky is now a *target* (a channel OR whisper): a `/r` reply sticks to whisper so the next plain line keeps replying (`composeWhisperReply` -> `/r`), which the server routes to the same last-whisperer. An explicit one-off `/w Name` deliberately does not stick (its next reply would target whoever last whispered you, not that person). Standing channels behave exactly as before.

## Testing

- `tests/chat_channels.test.ts`: `composeChatLine` passes `!` commands through; `sentLineChannel` maps `/1` -> general (never `/g`); `sentLineTarget` sticks to whisper on `/r` but not on `/w`.
- `tests/discord_relay.test.ts`: `!events` -> event, `!lfg` unaffected, unknown word rejected.
- `tests/chat.test.ts`: the sim routes `/1` to the General channel.
- `tests/chat_hud_client_seam.test.ts`: a regression test that a party send followed by a `/r` reply keeps the input on whisper (`/r`), reproducing and fixing issue 3.
- All chat-logic suites, the S3 localization guard, and `tests/architecture.test.ts` green; `tsc --noEmit` clean for the changed files. (`chat_line.test.ts` fails on a missing `@testing-library/svelte` dev dependency in this fresh worktree, pre-existing and unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Re-opened against `main`: this is the same content as #1975 (already merged into `release/v0.27.0`), re-based onto `main` so the hotfix ships there directly. It also includes the review's should-fix: a `!` community command returns null from `sentLineChannel`/`sentLineTarget`, so firing `!lfg` mid-conversation no longer resets the sticky channel to say (with the `sentLineTarget('!lfg ...') -> null` assertion next to the passthrough test). Cherry-picks apply cleanly on `main`, no merge conflicts; the four chat suites, the S3 guard, `tests/architecture.test.ts`, and `tsc --noEmit` are green on this head.

@FernandoX7 could you take a look and approve? Same change you merged in #1975, targeting main this time.
