### PR TITLE
feat(map): add world map pinch zoom

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -351,10 +351,11 @@ import { lowHealthVignette } from './low_health';
 import { lowResourceView } from './low_resource';
 import { mailIndicatorView } from './mailbox_view';
 import { MailboxWindow } from './mailbox_window';
+import { bindMapPinchZoom, finishMapTap, mapTapReleaseFromPointer } from './map_pinch_zoom';
+import { MAP_TAP_MOVE_TOLERANCE_PX, nextMapZoom } from './map_pinch_zoom_core';
 import { type MapRegion, mapCanvasHeight, paintTerrainRows } from './map_terrain';
 import { MapWindowPainter } from './map_window_painter';
 import {
-  MAP_MAX_ZOOM,
   type MapNpcMarker,
   type MapQuestAreaMarker,
   mapWindowMode,
@@ -1808,9 +1809,16 @@ export class Hud {
     );
     $('#map-zoom-in')?.addEventListener('click', () => this.zoomMap(1.4));
     $('#map-zoom-out')?.addEventListener('click', () => this.zoomMap(1 / 1.4));
+    const mapPinch = bindMapPinchZoom(mapCanvas, {
+      onPinchStart: () => {
+        this.mapDrag = null;
+        mapCanvas.style.cursor = '';
+      },
+      onZoom: (factor) => this.zoomMap(factor),
+    });
     // drag to pan (only meaningful while zoomed in; at zoom 1 the whole zone fits)
     mapCanvas.addEventListener('pointerdown', (ev) => {
-      if (!this.mapView || this.mapZoom <= 1) return;
+      if (mapPinch.isPinching() || !this.mapView || this.mapZoom <= 1) return;
       const base = this.mapCenter ?? { x: this.sim.player.pos.x, z: this.sim.player.pos.z };
       this.mapCenter = { ...base };
       this.mapDrag = { px: ev.clientX, py: ev.clientY, cx: base.x, cz: base.z };
@@ -1818,7 +1826,7 @@ export class Hud {
       mapCanvas.style.cursor = 'grabbing';
     });
     mapCanvas.addEventListener('pointermove', (ev) => {
-      if (!this.mapDrag || !this.mapView) return;
+      if (mapPinch.isPinching() || !this.mapDrag || !this.mapView) return;
       const rect = mapCanvas.getBoundingClientRect();
       // "grab the paper" pan: the world point under the cursor stays under it.
       // toMap draws +X to the left and +Z up (mx = (maxX-x)/span, my = (maxZ-z)/
@@ -1846,7 +1854,6 @@ export class Hud {
     // with live tracker progress. Both hit-tests run against the markers of the
     // last paint, scaled from CSS px to the canvas backing space the model projects
     // into.
-    const TAP_MOVE_TOLERANCE_PX = 10;
     let mapAreaTipShown = false;
     let mapTapStart: { x: number; y: number } | null = null;
     const hideMapAreaTip = (): void => {
@@ -1890,16 +1897,21 @@ export class Hud {
     // release can tell a stationary marker tap from a pan.
     mapCanvas.addEventListener('pointerdown', (ev) => {
       hideMapAreaTip();
-      mapTapStart = ev.pointerType === 'mouse' ? null : { x: ev.clientX, y: ev.clientY };
+      mapTapStart =
+        ev.pointerType === 'mouse' || mapPinch.isPinching()
+          ? null
+          : { x: ev.clientX, y: ev.clientY };
     });
     // A stationary touch release reveals the marker under the finger. iOS can raise
     // pointercancel (not pointerup) for a tap it briefly mistook for a gesture, so
     // both end the tap; a release that moved past the tolerance was a pan.
     const endMapTap = (ev: PointerEvent): void => {
-      if (ev.pointerType === 'mouse' || !mapTapStart) return;
-      const moved = Math.hypot(ev.clientX - mapTapStart.x, ev.clientY - mapTapStart.y);
+      finishMapTap(
+        mapPinch,
+        mapTapReleaseFromPointer(ev, mapTapStart, MAP_TAP_MOVE_TOLERANCE_PX),
+        showMapTipAt,
+      );
       mapTapStart = null;
-      if (moved <= TAP_MOVE_TOLERANCE_PX) showMapTipAt(ev.clientX, ev.clientY);
     };
     mapCanvas.addEventListener('pointerup', endMapTap);
     mapCanvas.addEventListener('pointercancel', endMapTap);
@@ -8911,7 +8923,7 @@ export class Hud {
   // scroll-wheel / button zoom for the world map (clamped to [1, MAP_MAX_ZOOM])
   private zoomMap(factor: number): void {
     const prev = this.mapZoom;
-    this.mapZoom = Math.max(1, Math.min(MAP_MAX_ZOOM, this.mapZoom * factor));
+    this.mapZoom = nextMapZoom(this.mapZoom, factor);
     // zooming back to 1 resumes following the player; a fresh zoom-in from the
     // follow view anchors the pan at the player so dragging starts from there
     if (this.mapZoom === 1) this.mapCenter = null;

--- a/src/ui/map_pinch_zoom.ts
+++ b/src/ui/map_pinch_zoom.ts
@@ -1,0 +1,84 @@
+// Thin DOM binding for the pure world-map pinch state machine.
+
+import {
+  MapPinchZoomCore,
+  type MapTapDecision,
+  type MapTapPoint,
+  type MapTapRelease,
+} from './map_pinch_zoom_core';
+
+export interface MapPinchZoomBinding {
+  isPinching(): boolean;
+  resolveTap(release: MapTapRelease): MapTapDecision;
+}
+
+interface MapPinchZoomHooks {
+  onPinchStart(): void;
+  onZoom(factor: number): void;
+}
+
+export function mapTapReleaseFromPointer(
+  event: Pick<PointerEvent, 'clientX' | 'clientY' | 'pointerId' | 'pointerType'>,
+  start: MapTapPoint | null,
+  tolerance: number,
+): MapTapRelease {
+  return {
+    pointerId: event.pointerId,
+    pointerType: event.pointerType,
+    start,
+    end: { x: event.clientX, y: event.clientY },
+    tolerance,
+  };
+}
+
+export function finishMapTap(
+  binding: MapPinchZoomBinding,
+  release: MapTapRelease,
+  showTap: (x: number, y: number) => unknown,
+): void {
+  if (binding.resolveTap(release) === 'show') showTap(release.end.x, release.end.y);
+}
+
+export function bindMapPinchZoom(
+  canvas: HTMLCanvasElement,
+  hooks: MapPinchZoomHooks,
+): MapPinchZoomBinding {
+  const core = new MapPinchZoomCore();
+
+  canvas.addEventListener('pointerdown', (event) => {
+    if (event.pointerType !== 'touch') return;
+    const transition = core.pointerDown({
+      pointerId: event.pointerId,
+      x: event.clientX,
+      y: event.clientY,
+    });
+    canvas.setPointerCapture(event.pointerId);
+    if (transition.preventDefault) event.preventDefault();
+    if (transition.pinchStarted) hooks.onPinchStart();
+  });
+
+  canvas.addEventListener('pointermove', (event) => {
+    const transition = core.pointerMove({
+      pointerId: event.pointerId,
+      x: event.clientX,
+      y: event.clientY,
+    });
+    if (transition.preventDefault) event.preventDefault();
+    if (transition.zoomFactor !== null) hooks.onZoom(transition.zoomFactor);
+  });
+
+  const endPinchPointer = (event: PointerEvent): void => {
+    core.pointerEnd(event.pointerId);
+  };
+  const losePinchPointer = (event: PointerEvent): void => {
+    core.pointerLost(event.pointerId);
+  };
+  canvas.addEventListener('pointerup', endPinchPointer);
+  canvas.addEventListener('pointercancel', endPinchPointer);
+  canvas.addEventListener('lostpointercapture', losePinchPointer);
+
+  return {
+    isPinching: () => core.isPinching(),
+    resolveTap: (release) => core.resolveTap(release),
+  };
+}

--- a/src/ui/map_pinch_zoom_core.ts
+++ b/src/ui/map_pinch_zoom_core.ts
@@ -1,0 +1,156 @@
+// Pure gesture state for world-map pinch zoom.
+//
+// Pointer-shaped inputs enter here, while the DOM binding owns PointerEvent,
+// pointer capture, and preventDefault. Keeping the state machine host-free makes
+// deadzone, pointer replacement, and tap arbitration directly testable.
+
+import { MAP_MAX_ZOOM } from './map_window_view';
+
+export const MAP_MIN_ZOOM = 1;
+export const MAP_PINCH_DEADZONE_PX = 8;
+export const MAP_TAP_MOVE_TOLERANCE_PX = 10;
+
+export interface MapPinchPointer {
+  pointerId: number;
+  x: number;
+  y: number;
+}
+
+export interface MapPinchTransition {
+  pinchStarted: boolean;
+  preventDefault: boolean;
+  zoomFactor: number | null;
+}
+
+export interface MapTapPoint {
+  x: number;
+  y: number;
+}
+
+export interface MapTapRelease {
+  pointerId: number;
+  pointerType: string;
+  start: MapTapPoint | null;
+  end: MapTapPoint;
+  tolerance: number;
+}
+
+export type MapTapDecision = 'ignore' | 'show' | 'suppressed';
+
+const idleTransition = (): MapPinchTransition => ({
+  pinchStarted: false,
+  preventDefault: false,
+  zoomFactor: null,
+});
+
+export function mapPinchZoomFactor(
+  previousDistance: number,
+  currentDistance: number,
+  deadzone = MAP_PINCH_DEADZONE_PX,
+): number {
+  if (
+    !Number.isFinite(previousDistance) ||
+    !Number.isFinite(currentDistance) ||
+    previousDistance <= 0 ||
+    currentDistance <= 0 ||
+    Math.abs(currentDistance - previousDistance) < deadzone
+  )
+    return 1;
+  return currentDistance / previousDistance;
+}
+
+export function nextMapZoom(currentZoom: number, factor: number): number {
+  return Math.max(MAP_MIN_ZOOM, Math.min(MAP_MAX_ZOOM, currentZoom * factor));
+}
+
+export class MapPinchZoomCore {
+  private readonly pointers = new Map<number, MapTapPoint>();
+  private readonly suppressedTaps = new Set<number>();
+  private previousDistance: number | null = null;
+
+  pointerDown(pointer: MapPinchPointer): MapPinchTransition {
+    this.pointers.set(pointer.pointerId, { x: pointer.x, y: pointer.y });
+    if (this.pointers.size < 2) return idleTransition();
+    for (const pointerId of this.pointers.keys()) this.suppressedTaps.add(pointerId);
+    if (this.pointers.size !== 2) {
+      this.previousDistance = null;
+      return idleTransition();
+    }
+    this.previousDistance = this.pinchDistance();
+    return {
+      pinchStarted: true,
+      preventDefault: true,
+      zoomFactor: null,
+    };
+  }
+
+  pointerMove(pointer: MapPinchPointer): MapPinchTransition {
+    if (!this.pointers.has(pointer.pointerId)) return idleTransition();
+    this.pointers.set(pointer.pointerId, { x: pointer.x, y: pointer.y });
+    if (this.pointers.size !== 2 || this.previousDistance === null) return idleTransition();
+
+    const currentDistance = this.pinchDistance();
+    if (!Number.isFinite(currentDistance) || currentDistance <= 0) {
+      this.previousDistance = currentDistance;
+      return {
+        pinchStarted: false,
+        preventDefault: true,
+        zoomFactor: null,
+      };
+    }
+    if (!Number.isFinite(this.previousDistance) || this.previousDistance <= 0) {
+      this.previousDistance = currentDistance;
+      return {
+        pinchStarted: false,
+        preventDefault: true,
+        zoomFactor: null,
+      };
+    }
+
+    const factor = mapPinchZoomFactor(this.previousDistance, currentDistance);
+    if (factor === 1) {
+      return {
+        pinchStarted: false,
+        preventDefault: true,
+        zoomFactor: null,
+      };
+    }
+    this.previousDistance = currentDistance;
+    return {
+      pinchStarted: false,
+      preventDefault: true,
+      zoomFactor: factor,
+    };
+  }
+
+  pointerEnd(pointerId: number): MapPinchTransition {
+    if (!this.pointers.delete(pointerId)) return idleTransition();
+    // Replacing one finger after a third touch only establishes a new baseline.
+    // The original pinch already cancelled map pan, so this is not a new start.
+    this.previousDistance = this.pointers.size === 2 ? this.pinchDistance() : null;
+    return idleTransition();
+  }
+
+  pointerLost(pointerId: number): MapPinchTransition {
+    const transition = this.pointerEnd(pointerId);
+    this.suppressedTaps.delete(pointerId);
+    return transition;
+  }
+
+  isPinching(): boolean {
+    return this.pointers.size > 1;
+  }
+
+  resolveTap(release: MapTapRelease): MapTapDecision {
+    if (this.suppressedTaps.delete(release.pointerId)) return 'suppressed';
+    if (release.pointerType === 'mouse' || !release.start) return 'ignore';
+    const moved = Math.hypot(release.end.x - release.start.x, release.end.y - release.start.y);
+    return moved <= release.tolerance ? 'show' : 'ignore';
+  }
+
+  private pinchDistance(): number {
+    if (this.pointers.size !== 2) return 0;
+    const [first, second] = [...this.pointers.values()];
+    return Math.hypot(second.x - first.x, second.y - first.y);
+  }
+}

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -161,6 +161,7 @@ const UI_PURE_CORES = [
   'src/ui/mailbox_view.ts',
   'src/ui/calendar_view.ts',
   'src/ui/char_view.ts',
+  'src/ui/map_pinch_zoom_core.ts',
   'src/ui/map_window_view.ts',
   'src/ui/map_quest_list_view.ts',
   'src/ui/arena_window_view.ts',

--- a/tests/map_pinch_zoom.test.ts
+++ b/tests/map_pinch_zoom.test.ts
@@ -1,0 +1,313 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  bindMapPinchZoom,
+  finishMapTap,
+  type MapPinchZoomBinding,
+  mapTapReleaseFromPointer,
+} from '../src/ui/map_pinch_zoom';
+import { MAP_TAP_MOVE_TOLERANCE_PX, nextMapZoom } from '../src/ui/map_pinch_zoom_core';
+
+const hudSource = readFileSync(new URL('../src/ui/hud.ts', import.meta.url), 'utf8');
+const pinchSource = readFileSync(new URL('../src/ui/map_pinch_zoom.ts', import.meta.url), 'utf8');
+
+function sourceSection(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  if (startIndex < 0 || endIndex < 0) throw new Error(`missing source section: ${start}`);
+  return source.slice(startIndex, endIndex);
+}
+
+const mapGestureSource = sourceSection(
+  hudSource,
+  'const mapPinch = bindMapPinchZoom(mapCanvas',
+  "$('#mm-bag').addEventListener",
+);
+const zoomMapSource = sourceSection(
+  hudSource,
+  'private zoomMap(factor: number): void {',
+  '// The map window shows the zone band',
+);
+
+function pointerHarness() {
+  const listeners = new Map<string, ((event: PointerEvent) => void)[]>();
+  const captured: number[] = [];
+  const canvas = {
+    addEventListener(type: string, listener: (event: PointerEvent) => void) {
+      const group = listeners.get(type) ?? [];
+      group.push(listener);
+      listeners.set(type, group);
+    },
+    setPointerCapture(pointerId: number) {
+      captured.push(pointerId);
+    },
+  } as unknown as HTMLCanvasElement;
+  const dispatch = (
+    type: string,
+    pointerId: number,
+    x: number,
+    y: number,
+    pointerType = 'touch',
+  ): boolean => {
+    let prevented = false;
+    const event = {
+      pointerId,
+      pointerType,
+      clientX: x,
+      clientY: y,
+      preventDefault: () => {
+        prevented = true;
+      },
+    } as unknown as PointerEvent;
+    for (const listener of listeners.get(type) ?? []) listener(event);
+    return prevented;
+  };
+  return { canvas, captured, dispatch };
+}
+
+describe('map pinch zoom', () => {
+  it('routes two-pointer gestures through map-only zoom state', () => {
+    expect(mapGestureSource).toContain('onZoom: (factor) => this.zoomMap(factor)');
+    expect(mapGestureSource).toMatch(
+      /onPinchStart: \(\) => \{\s*this\.mapDrag = null;\s*mapCanvas\.style\.cursor = '';\s*\}/,
+    );
+    expect(mapGestureSource).toContain(
+      'if (mapPinch.isPinching() || !this.mapView || this.mapZoom <= 1) return;',
+    );
+    expect(mapGestureSource).toContain(
+      'if (mapPinch.isPinching() || !this.mapDrag || !this.mapView) return;',
+    );
+    expect(mapGestureSource).toContain(
+      'mapTapReleaseFromPointer(ev, mapTapStart, MAP_TAP_MOVE_TOLERANCE_PX)',
+    );
+    expect(mapGestureSource).toContain('showMapTipAt,');
+    expect(zoomMapSource).toContain('this.mapZoom = nextMapZoom(this.mapZoom, factor)');
+    expect(zoomMapSource).not.toMatch(/\b(?:camera|renderer|input|zoomBy)\b/i);
+    expect(pinchSource).toContain("canvas.addEventListener('pointercancel', endPinchPointer)");
+    expect(pinchSource).not.toMatch(/from '\.\.\/(?:game|render)\//);
+    expect(pinchSource).not.toMatch(/\bcamera\b/i);
+  });
+
+  it('emits cumulative map zoom with two touches and suppresses both marker taps', () => {
+    const harness = pointerHarness();
+    const zooms: number[] = [];
+    let mapZoom = 1;
+    let starts = 0;
+    const pinch = bindMapPinchZoom(harness.canvas, {
+      onPinchStart: () => {
+        starts += 1;
+      },
+      onZoom: (factor) => {
+        zooms.push(factor);
+        mapZoom = nextMapZoom(mapZoom, factor);
+      },
+    });
+
+    expect(harness.dispatch('pointerdown', 1, 0, 0)).toBe(false);
+    expect(pinch.isPinching()).toBe(false);
+    expect(harness.dispatch('pointerdown', 2, 100, 0)).toBe(true);
+    expect(pinch.isPinching()).toBe(true);
+    expect(starts).toBe(1);
+    expect(harness.captured).toEqual([1, 2]);
+
+    harness.dispatch('pointermove', 2, 107, 0);
+    expect(zooms).toEqual([]);
+    harness.dispatch('pointermove', 2, 109, 0);
+    expect(zooms).toHaveLength(1);
+    expect(zooms[0]).toBeCloseTo(1.09);
+    expect(mapZoom).toBeCloseTo(1.09);
+
+    harness.dispatch('pointerup', 2, 109, 0);
+    expect(pinch.isPinching()).toBe(false);
+    harness.dispatch('pointerup', 1, 0, 0);
+    expect(
+      pinch.resolveTap({
+        pointerId: 1,
+        pointerType: 'touch',
+        start: { x: 0, y: 0 },
+        end: { x: 0, y: 0 },
+        tolerance: 10,
+      }),
+    ).toBe('suppressed');
+    expect(
+      pinch.resolveTap({
+        pointerId: 2,
+        pointerType: 'touch',
+        start: { x: 100, y: 0 },
+        end: { x: 109, y: 0 },
+        tolerance: 10,
+      }),
+    ).toBe('suppressed');
+  });
+
+  it('allows an ordinary stationary touch to reach map marker tap handling', () => {
+    const harness = pointerHarness();
+    const pinch = bindMapPinchZoom(harness.canvas, {
+      onPinchStart: () => {},
+      onZoom: () => {},
+    });
+    harness.dispatch('pointerdown', 1, 10, 10);
+    harness.dispatch('pointerup', 1, 14, 13);
+
+    expect(
+      pinch.resolveTap({
+        pointerId: 1,
+        pointerType: 'touch',
+        start: { x: 10, y: 10 },
+        end: { x: 14, y: 13 },
+        tolerance: 10,
+      }),
+    ).toBe('show');
+  });
+
+  it('shows a marker only when the binding resolves the release as a tap', () => {
+    const decisions = ['show', 'suppressed', 'ignore'] as const;
+    let decisionIndex = 0;
+    const binding: MapPinchZoomBinding = {
+      isPinching: () => false,
+      resolveTap: () => decisions[decisionIndex++],
+    };
+    const shown: Array<{ x: number; y: number }> = [];
+    const release = {
+      pointerId: 1,
+      pointerType: 'touch',
+      start: { x: 10, y: 10 },
+      end: { x: 14, y: 13 },
+      tolerance: 10,
+    };
+
+    finishMapTap(binding, release, (x, y) => shown.push({ x, y }));
+    finishMapTap(binding, release, (x, y) => shown.push({ x, y }));
+    finishMapTap(binding, release, (x, y) => shown.push({ x, y }));
+
+    expect(shown).toEqual([{ x: 14, y: 13 }]);
+  });
+
+  it('maps the complete pointer release payload into the tap core input', () => {
+    const start = { x: 10, y: 20 };
+    expect(
+      mapTapReleaseFromPointer(
+        {
+          pointerId: 7,
+          pointerType: 'touch',
+          clientX: 30,
+          clientY: 40,
+        } as PointerEvent,
+        start,
+        MAP_TAP_MOVE_TOLERANCE_PX,
+      ),
+    ).toEqual({
+      pointerId: 7,
+      pointerType: 'touch',
+      start,
+      end: { x: 30, y: 40 },
+      tolerance: MAP_TAP_MOVE_TOLERANCE_PX,
+    });
+  });
+
+  it('cleans up a cancelled pointer without losing tap suppression', () => {
+    const harness = pointerHarness();
+    const pinch = bindMapPinchZoom(harness.canvas, {
+      onPinchStart: () => {},
+      onZoom: () => {},
+    });
+    harness.dispatch('pointerdown', 1, 0, 0);
+    harness.dispatch('pointerdown', 2, 100, 0);
+
+    harness.dispatch('pointercancel', 2, 100, 0);
+
+    expect(pinch.isPinching()).toBe(false);
+    expect(
+      pinch.resolveTap({
+        pointerId: 2,
+        pointerType: 'touch',
+        start: { x: 100, y: 0 },
+        end: { x: 100, y: 0 },
+        tolerance: 10,
+      }),
+    ).toBe('suppressed');
+  });
+
+  it('cleans silent capture loss and starts a fresh pinch from a new baseline', () => {
+    const harness = pointerHarness();
+    const zooms: number[] = [];
+    let starts = 0;
+    const pinch = bindMapPinchZoom(harness.canvas, {
+      onPinchStart: () => {
+        starts += 1;
+      },
+      onZoom: (factor) => zooms.push(factor),
+    });
+    harness.dispatch('pointerdown', 1, 0, 0);
+    harness.dispatch('pointerdown', 2, 100, 0);
+
+    harness.dispatch('lostpointercapture', 2, 100, 0);
+    harness.dispatch('lostpointercapture', 1, 0, 0);
+
+    expect(pinch.isPinching()).toBe(false);
+    expect(
+      pinch.resolveTap({
+        pointerId: 1,
+        pointerType: 'touch',
+        start: null,
+        end: { x: 0, y: 0 },
+        tolerance: 10,
+      }),
+    ).toBe('ignore');
+    expect(
+      pinch.resolveTap({
+        pointerId: 2,
+        pointerType: 'touch',
+        start: null,
+        end: { x: 100, y: 0 },
+        tolerance: 10,
+      }),
+    ).toBe('ignore');
+    expect(harness.dispatch('pointerdown', 3, 0, 0)).toBe(false);
+    expect(pinch.isPinching()).toBe(false);
+    expect(harness.dispatch('pointerdown', 4, 100, 0)).toBe(true);
+    expect(starts).toBe(2);
+    harness.dispatch('pointermove', 4, 107, 0);
+    expect(zooms).toEqual([]);
+    harness.dispatch('pointermove', 4, 109, 0);
+    expect(zooms[0]).toBeCloseTo(1.09);
+  });
+
+  it('pauses for a third touch and re-baselines when two touches remain', () => {
+    const harness = pointerHarness();
+    const zooms: number[] = [];
+    const pinch = bindMapPinchZoom(harness.canvas, {
+      onPinchStart: () => {},
+      onZoom: (factor) => zooms.push(factor),
+    });
+    harness.dispatch('pointerdown', 1, 0, 0);
+    harness.dispatch('pointerdown', 2, 100, 0);
+    harness.dispatch('pointerdown', 3, 200, 0);
+
+    harness.dispatch('pointermove', 2, 120, 0);
+    expect(zooms).toEqual([]);
+    harness.dispatch('pointerup', 3, 200, 0);
+    expect(pinch.isPinching()).toBe(true);
+    harness.dispatch('pointermove', 2, 127, 0);
+    expect(zooms).toEqual([]);
+    harness.dispatch('pointermove', 2, 129, 0);
+    expect(zooms[0]).toBeCloseTo(129 / 120);
+  });
+
+  it('ignores mouse and pen pointers', () => {
+    const harness = pointerHarness();
+    let starts = 0;
+    const pinch = bindMapPinchZoom(harness.canvas, {
+      onPinchStart: () => {
+        starts += 1;
+      },
+      onZoom: () => {},
+    });
+
+    harness.dispatch('pointerdown', 1, 0, 0, 'mouse');
+    harness.dispatch('pointerdown', 2, 100, 0, 'pen');
+    expect(harness.captured).toEqual([]);
+    expect(pinch.isPinching()).toBe(false);
+    expect(starts).toBe(0);
+  });
+});

--- a/tests/map_pinch_zoom_core.test.ts
+++ b/tests/map_pinch_zoom_core.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAP_MIN_ZOOM,
+  MAP_PINCH_DEADZONE_PX,
+  MAP_TAP_MOVE_TOLERANCE_PX,
+  MapPinchZoomCore,
+  mapPinchZoomFactor,
+  nextMapZoom,
+} from '../src/ui/map_pinch_zoom_core';
+import { MAP_MAX_ZOOM } from '../src/ui/map_window_view';
+
+const pointer = (pointerId: number, x: number, y: number) => ({ pointerId, x, y });
+
+describe('map pinch zoom core', () => {
+  it('maps finger spread and pinch to multiplicative map zoom factors', () => {
+    expect(mapPinchZoomFactor(100, 150)).toBeCloseTo(1.5);
+    expect(mapPinchZoomFactor(150, 100)).toBeCloseTo(2 / 3);
+  });
+
+  it('pins the 8 px deadzone and accumulates smaller movement until its boundary', () => {
+    expect(MAP_PINCH_DEADZONE_PX).toBe(8);
+    expect(MAP_TAP_MOVE_TOLERANCE_PX).toBe(10);
+    expect(mapPinchZoomFactor(100, 107)).toBe(1);
+    expect(mapPinchZoomFactor(100, 108)).toBeCloseTo(1.08);
+  });
+
+  it('ignores invalid pinch distances', () => {
+    expect(mapPinchZoomFactor(0, 100)).toBe(1);
+    expect(mapPinchZoomFactor(Number.POSITIVE_INFINITY, 100)).toBe(1);
+    expect(mapPinchZoomFactor(100, 0)).toBe(1);
+    expect(mapPinchZoomFactor(100, Number.NaN)).toBe(1);
+  });
+
+  it('clamps map pinch zoom to the map-specific minimum and maximum', () => {
+    expect(MAP_MIN_ZOOM).toBe(1);
+    expect(MAP_MAX_ZOOM).toBe(6);
+    expect(nextMapZoom(1, 100)).toBe(6);
+    expect(nextMapZoom(6, 0.01)).toBe(1);
+  });
+
+  it('drives the pinch state machine through plain pointer inputs', () => {
+    const core = new MapPinchZoomCore();
+
+    expect(core.pointerDown(pointer(1, 0, 0))).toEqual({
+      pinchStarted: false,
+      preventDefault: false,
+      zoomFactor: null,
+    });
+    expect(core.pointerDown(pointer(2, 100, 0))).toEqual({
+      pinchStarted: true,
+      preventDefault: true,
+      zoomFactor: null,
+    });
+    expect(core.isPinching()).toBe(true);
+    expect(core.pointerMove(pointer(2, 107, 0)).zoomFactor).toBeNull();
+    expect(core.pointerMove(pointer(2, 109, 0)).zoomFactor).toBeCloseTo(1.09);
+  });
+
+  it('recovers from a zero-distance initial pair by taking a fresh positive baseline', () => {
+    const core = new MapPinchZoomCore();
+    core.pointerDown(pointer(1, 0, 0));
+    core.pointerDown(pointer(2, 0, 0));
+
+    expect(core.pointerMove(pointer(2, 100, 0)).zoomFactor).toBeNull();
+    expect(core.pointerMove(pointer(2, 107, 0)).zoomFactor).toBeNull();
+    expect(core.pointerMove(pointer(2, 108, 0)).zoomFactor).toBeCloseTo(1.08);
+  });
+
+  it('re-baselines when an original pinch pointer leaves and the third pointer remains', () => {
+    const core = new MapPinchZoomCore();
+    core.pointerDown(pointer(1, 0, 0));
+    expect(core.pointerDown(pointer(2, 100, 0)).pinchStarted).toBe(true);
+    core.pointerDown(pointer(3, 200, 0));
+    core.pointerMove(pointer(2, 120, 0));
+
+    expect(core.pointerEnd(1).pinchStarted).toBe(false);
+    expect(core.isPinching()).toBe(true);
+    expect(core.pointerMove(pointer(3, 207, 0)).zoomFactor).toBeNull();
+    expect(core.pointerMove(pointer(3, 209, 0)).zoomFactor).toBeCloseTo(89 / 80);
+  });
+
+  it('ignores unrelated pointer endings without discarding accumulated deadzone movement', () => {
+    const core = new MapPinchZoomCore();
+    core.pointerDown(pointer(1, 0, 0));
+    core.pointerDown(pointer(2, 100, 0));
+
+    expect(core.pointerMove(pointer(2, 107, 0)).zoomFactor).toBeNull();
+    core.pointerEnd(99);
+    expect(core.pointerMove(pointer(2, 108, 0)).zoomFactor).toBeCloseTo(1.08);
+  });
+
+  it('distinguishes ordinary touch taps from pinch-suppressed releases', () => {
+    const core = new MapPinchZoomCore();
+    core.pointerDown(pointer(1, 10, 10));
+    core.pointerEnd(1);
+
+    expect(
+      core.resolveTap({
+        pointerId: 1,
+        pointerType: 'touch',
+        start: { x: 10, y: 10 },
+        end: { x: 14, y: 13 },
+        tolerance: 10,
+      }),
+    ).toBe('show');
+    expect(
+      core.resolveTap({
+        pointerId: 4,
+        pointerType: 'touch',
+        start: { x: 0, y: 0 },
+        end: { x: 6, y: 8 },
+        tolerance: 10,
+      }),
+    ).toBe('show');
+
+    core.pointerDown(pointer(2, 0, 0));
+    core.pointerDown(pointer(3, 100, 0));
+    core.pointerEnd(2);
+    const pointer2Release = {
+      pointerId: 2,
+      pointerType: 'touch',
+      start: { x: 0, y: 0 },
+      end: { x: 0, y: 0 },
+      tolerance: MAP_TAP_MOVE_TOLERANCE_PX,
+    };
+    expect(core.resolveTap(pointer2Release)).toBe('suppressed');
+    expect(core.resolveTap(pointer2Release)).toBe('show');
+    core.pointerEnd(3);
+    expect(
+      core.resolveTap({
+        pointerId: 3,
+        pointerType: 'touch',
+        start: { x: 100, y: 0 },
+        end: { x: 100, y: 0 },
+        tolerance: 10,
+      }),
+    ).toBe('suppressed');
+
+    core.pointerDown(pointer(2, 10, 10));
+    core.pointerEnd(2);
+    expect(
+      core.resolveTap({
+        pointerId: 2,
+        pointerType: 'touch',
+        start: { x: 10, y: 10 },
+        end: { x: 10, y: 10 },
+        tolerance: 10,
+      }),
+    ).toBe('show');
+  });
+
+  it('ignores mouse releases, missing starts, and touch movement beyond tolerance', () => {
+    const core = new MapPinchZoomCore();
+    expect(
+      core.resolveTap({
+        pointerId: 1,
+        pointerType: 'mouse',
+        start: { x: 0, y: 0 },
+        end: { x: 0, y: 0 },
+        tolerance: 10,
+      }),
+    ).toBe('ignore');
+    expect(
+      core.resolveTap({
+        pointerId: 2,
+        pointerType: 'touch',
+        start: null,
+        end: { x: 0, y: 0 },
+        tolerance: 10,
+      }),
+    ).toBe('ignore');
+    expect(
+      core.resolveTap({
+        pointerId: 3,
+        pointerType: 'touch',
+        start: { x: 0, y: 0 },
+        end: { x: 11, y: 0 },
+        tolerance: 10,
+      }),
+    ).toBe('ignore');
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused two-finger pinch zoom to the world map for the v0.27 release branch.

- Tracks touch gesture state in a registered DOM-free pure core with a thin canvas binding.
- Uses an accumulated 8 px deadzone so minor finger jitter does not change zoom.
- Clamps world map zoom to the existing minimum of 1 and maximum of 6.
- Keeps pinch arbitration inside the map HUD path without touching the gameplay camera.
- Handles zero-distance starts, pointer up, cancellation, lost capture, third-touch replacement, and unrelated hybrid-device pointer endings.
- Preserves ordinary marker taps while suppressing every pointer that participated in a pinch.

This is extracted from #1761 so the map gesture can be reviewed and merged independently from the broader mobile HUD redesign.

## Related issues

- Extracted from #1761.
- No issue is closed by this PR.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [x] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - `npx vitest run tests/map_pinch_zoom_core.test.ts tests/map_pinch_zoom.test.ts tests/map_window_view.test.ts tests/map_window_painter.test.ts tests/architecture.test.ts tests/hud_perf_budget.test.ts tests/painter_host.test.ts tests/focus_manager.test.ts tests/focus_visible_guard.test.ts`
    - 125 passed, 3 skipped.
  - `npx tsc --noEmit`
    - Passed.
  - `npm run ci:changed`
    - Passed. Existing repository-wide warnings remain unchanged.
  - Pre-push QA floor
    - Typecheck, guard tests, Biome, and copy rules passed. Guard tests reported 53 passed, 3 skipped.
  - `.claude/hooks/qa-stop.sh`
    - Passed.
  - `git diff --check`
    - Passed.
  - `npm run gate`
    - Not run because another session had an active Puppeteer E2E process. This follows the repository CPU and load guidance.
- Manual steps:
  - Automated coverage verifies pinch in and out, zero-distance recovery, the 8 px deadzone, zoom bounds, tap suppression, ordinary taps, cancellation, capture loss, third-touch replacement, and unrelated pointer endings.
  - Real-device iOS and Android testing and phone-sized portrait and landscape browser verification have not been run yet.

## Screenshots / recordings

Not included yet. This change adds touch interaction without changing static layout or visual chrome. A mobile pinch interaction recording is still pending.

---

## Checklist

### Quality

- [ ] **The full gate passes.** `npm run gate` is pending because another session was running Puppeteer E2E. Targeted tests, typecheck, changed-file CI, and the pre-push QA floor pass.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Real-device and phone-sized portrait and landscape checks are still pending.
- [ ] **Accessible.** Existing localized zoom buttons remain available as the non-gesture alternative. Manual accessibility verification is still pending.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` files are committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] No generated files were hand-edited.

> Commit message and PR title use Conventional Commits with the required scope, and the commit includes the required explanatory body.