### PR TITLE
fix(ios): declare App Store encryption usage

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -35,6 +35,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
## Summary

- declares `ITSAppUsesNonExemptEncryption` as `false` in the native iOS bundle
- lets App Store Connect derive the export-compliance answer from the archived app metadata
- retains build number 24, which is already present on `release/v0.27.0`

## Type of change

- [x] Bug fix
- [x] Build, CI, or tooling

## How was this tested?

- `plutil -lint ios/App/App/Info.plist`
- `git diff --check`
- `npx vitest run tests/native_orientation.test.ts tests/native_discord.test.ts` (7 tests passed)
- pre-push QA floor (typecheck, guard tests, lint, and copy rules) passed
- `npm run gate` reached the full suite but the release base currently has 14 unrelated failures across WebSocket test globals, locale midnight formatting, watchdog timing, generated-artifact tracking assertions, Discord invite expectations, and other existing tests

## Checklist

### Quality

- [ ] The full gate passes. The scoped checks pass; inherited release-base failures are documented above.

### Localization

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` files are committed.
- [x] No generated files were hand-edited.