### PR TITLE
feat(daily-rewards): show task names in Discord winners

### DIFF
--- a/bot/logic.ts
+++ b/bot/logic.ts
@@ -435,6 +435,8 @@ export interface DailyRewardWinner {
 
 export interface DailyRewardWinnersDay {
   day: string;
+  taskName: string;
+  nextTaskName: string;
   realm: string;
   prizePoolUsd: number;
   finalizedAt: string | null;
@@ -469,12 +471,13 @@ export function buildDailyRewardWinnersMessage(
     embeds: [
       {
         color: 0xf0b743,
-        author: { name: 'Daily Rewards' },
+        author: { name: `Task: ${day.taskName}` },
         title: `Top ${Math.min(day.payouts.length, 10)} Winners - ${day.day}`,
         description,
         fields: [
           { name: 'Realm', value: day.realm, inline: true },
           { name: 'Prize Pool', value: usd(day.prizePoolUsd), inline: true },
+          { name: 'Next task', value: day.nextTaskName, inline: false },
         ],
         footer: { text: 'World of ClaudeCraft' },
       },

--- a/server/daily_rewards.ts
+++ b/server/daily_rewards.ts
@@ -232,6 +232,13 @@ function fallbackRuntimeConfig(): DailyRewardRuntimeConfig {
   };
 }
 
+function featuredDailyRewardTaskName(config: DailyRewardRuntimeConfig): string {
+  const [task] = config.tasks
+    .filter((candidate) => candidate.active !== false)
+    .sort((left, right) => left.sortOrder - right.sortOrder);
+  return task?.title ?? DEFAULT_TASKS[0].title;
+}
+
 function parseRuntimeConfigPayload(payload: unknown): DailyRewardRuntimeConfig {
   const record = payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : {};
   const fallback = fallbackRuntimeConfig();
@@ -997,7 +1004,23 @@ export class DailyRewardService {
 
   async discordWinnerAnnouncements(limit = 1): Promise<unknown> {
     await this.finalizePreviousDay();
-    return { days: await this.db.unannouncedWinnerDays(limit) };
+    const days = await this.db.unannouncedWinnerDays(limit);
+    const rewardDays = [...new Set(days.flatMap((day) => [day.day, addRewardDays(day.day, 1)]))];
+    const taskNames = new Map(
+      await Promise.all(
+        rewardDays.map(
+          async (day) =>
+            [day, featuredDailyRewardTaskName(await dailyRewardRuntimeConfig(day))] as const,
+        ),
+      ),
+    );
+    return {
+      days: days.map((day) => ({
+        ...day,
+        taskName: taskNames.get(day.day) ?? DEFAULT_TASKS[0].title,
+        nextTaskName: taskNames.get(addRewardDays(day.day, 1)) ?? DEFAULT_TASKS[0].title,
+      })),
+    };
   }
 
   async markDiscordWinnersAnnounced(

--- a/tests/daily_rewards.test.ts
+++ b/tests/daily_rewards.test.ts
@@ -40,6 +40,7 @@ import { buildDailyRewardsView } from '../src/ui/daily_rewards_view';
 
 class FakeDailyRewardDb implements DailyRewardDb {
   banReason: string | null = null;
+  winnerAnnouncements: DailyRewardWinnerAnnouncement[] = [];
   score = 0;
   spin: { outcomeKey: string; points: number; createdAt: string } | null = null;
   tasks: DailyRewardTaskSeed[] = [];
@@ -170,7 +171,7 @@ class FakeDailyRewardDb implements DailyRewardDb {
     return [];
   }
   async unannouncedWinnerDays(): Promise<DailyRewardWinnerAnnouncement[]> {
-    return [];
+    return this.winnerAnnouncements;
   }
   async markWinnersAnnounced(): Promise<boolean> {
     return true;
@@ -391,6 +392,89 @@ describe('daily rewards', () => {
     expect(db.tasks).toMatchObject([
       { id: 'quests_today', type: 'quest_completion', title: 'Quest push', basePoints: 12 },
     ]);
+  });
+
+  it('adds the current and next task names to Discord winner announcements', async () => {
+    const db = new FakeDailyRewardDb();
+    db.winnerAnnouncements = [
+      {
+        day: '2026-06-30',
+        realm: 'Claudemoon',
+        prizePoolUsd: 150,
+        finalizedAt: '2026-07-01T00:00:00.000Z',
+        payouts: [],
+      },
+    ];
+    resetDailyRewardPriceCacheForTests();
+    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
+      const day = new URL(String(input)).searchParams.get('day');
+      const tasks: DailyRewardTaskSeed[] =
+        day === '2026-07-01'
+          ? [
+              {
+                id: 'arena_today',
+                type: 'arena_result',
+                title: 'Win an arena match',
+                description: 'Win an arena match.',
+                points: 10,
+                basePoints: 10,
+                sortOrder: 1,
+                active: true,
+                config: {},
+              },
+            ]
+          : [
+              {
+                id: 'inactive_task',
+                type: 'quest_completion',
+                title: 'Inactive task',
+                description: 'Inactive task.',
+                points: 10,
+                basePoints: 10,
+                sortOrder: 0,
+                active: false,
+                config: {},
+              },
+              {
+                id: 'later_task',
+                type: 'quest_completion',
+                title: 'Complete later task',
+                description: 'Complete later task.',
+                points: 10,
+                basePoints: 10,
+                sortOrder: 2,
+                active: true,
+                config: {},
+              },
+              {
+                id: 'quests_today',
+                type: 'quest_completion',
+                title: 'Complete quests',
+                description: 'Complete quests.',
+                points: 10,
+                basePoints: 10,
+                sortOrder: 1,
+                active: true,
+                config: {},
+              },
+            ];
+      return new Response(JSON.stringify(rewardConfig({ tasks })), { status: 200 });
+    });
+    const service = new DailyRewardService(db);
+    vi.spyOn(service, 'finalizePreviousDay').mockResolvedValue();
+
+    const result = (await service.discordWinnerAnnouncements(1)) as {
+      days: Array<{ day: string; taskName: string; nextTaskName: string }>;
+    };
+
+    expect(result.days).toEqual([
+      expect.objectContaining({
+        day: '2026-06-30',
+        taskName: 'Complete quests',
+        nextTaskName: 'Win an arena match',
+      }),
+    ]);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
   });
 
   it('awards quest task points using the online-time multiplier', async () => {

--- a/tests/discord_bot.test.ts
+++ b/tests/discord_bot.test.ts
@@ -299,6 +299,8 @@ describe('daily rewards winner cards', () => {
   it('formats the top-10 daily rewards winners without pings', () => {
     const msg = buildDailyRewardWinnersMessage({
       day: '2026-06-30',
+      taskName: 'Complete quests',
+      nextTaskName: 'Win an arena match',
       realm: 'Claudemoon',
       prizePoolUsd: 150,
       finalizedAt: '2026-07-01T00:00:00.000Z',
@@ -327,6 +329,7 @@ describe('daily rewards winner cards', () => {
     }) as {
       allowed_mentions: unknown;
       embeds: Array<{
+        author: { name: string };
         title: string;
         description: string;
         fields: Array<{ name: string; value: string; inline: boolean }>;
@@ -334,13 +337,14 @@ describe('daily rewards winner cards', () => {
     };
 
     expect(msg.allowed_mentions).toEqual({ parse: [] });
+    expect(msg.embeds[0].author).toEqual({ name: 'Task: Complete quests' });
     expect(msg.embeds[0].title).toBe('Top 2 Winners - 2026-06-30');
     expect(msg.embeds[0].description).toContain('**#1** titoisking - 12,345 pts - $30.00 (20%)');
     expect(msg.embeds[0].description).toContain('**#2** alice - 1,000 pts - $22.50 (15%)');
-    expect(msg.embeds[0].fields).toContainEqual({
-      name: 'Prize Pool',
-      value: '$150.00',
-      inline: true,
-    });
+    expect(msg.embeds[0].fields).toEqual([
+      { name: 'Realm', value: 'Claudemoon', inline: true },
+      { name: 'Prize Pool', value: '$150.00', inline: true },
+      { name: 'Next task', value: 'Win an arena match', inline: false },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Show the active daily rewards task above each Discord winners announcement.
- Show the next scheduled task below the Realm and Prize Pool fields.
- Resolve both labels from the authoritative per-day reward configuration, selecting the first active task by sort order.
- Add regression coverage for message layout and current/next-day task resolution.

## Type of change

- [x] Feature: new functionality
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/discord_bot.test.ts tests/daily_rewards.test.ts` (44 passed)
  - `npm run ci:changed` (passed, existing warnings only)
  - `npx tsc --noEmit` (passed)
  - `git diff --check` (passed)
  - pre-push QA floor (53 passed, 3 skipped)
  - `npm run gate` (14,321 passed, 22 skipped, 6 unrelated release-base failures)
- Full-gate failures outside this diff:
  - two deploy watchdog timeout assertions
  - Discord invite URL fixture mismatch
  - two generated i18n files tracked by the release base despite tests expecting them untracked
  - new endpoint generator timeout
- Manual steps: N/A

## Checklist

### Quality

- [ ] **The full gate passes.** The feature-focused checks pass, but the release base currently has the six unrelated failures listed above.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I did not hand-edit generated files.