### PR TITLE
fix(content): thin overlapping forest wolf camps on the newbie corpse-run path (#1908)

### DIFF
--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -1109,9 +1109,18 @@ export const ZONE1_QUEST_ORDER = [
 // ---------------------------------------------------------------------------
 
 export const ZONE1_CAMPS: CampDef[] = [
-  // Wolves: north woods
-  { mobId: 'forest_wolf', center: { x: -15, z: 55 }, radius: 22, count: 7 },
-  { mobId: 'forest_wolf', center: { x: 20, z: 70 }, radius: 20, count: 6 },
+  // Wolves: north woods. The two camps near the graveyard corpse-run used to be
+  // dense (7 and 6) AND overlapping, so a level 1-2 player who corpse-rezzed at
+  // 50% HP walked straight back into a 13-wolf blob whose packFrenzy chain-killed
+  // them (see #1908). They are thinned to 4 each and pulled apart so their spawn
+  // discs no longer overlap; the surplus pack moves deep north near Brightwood
+  // Glade, off the newbie corpse-run line. The zone's total wolf headcount is
+  // unchanged (4 + 4 + 5 = 13), which keeps world-gen's draw order byte-identical
+  // and every seed-pinned spawn/delve roll stable (same rule as the tail-appended
+  // ZONE1_CHAPEL_CAMPS below).
+  { mobId: 'forest_wolf', center: { x: -32, z: 50 }, radius: 22, count: 4 },
+  { mobId: 'forest_wolf', center: { x: 24, z: 64 }, radius: 20, count: 4 },
+  { mobId: 'forest_wolf', center: { x: 8, z: 130 }, radius: 16, count: 5 },
   { mobId: 'old_greyjaw', center: { x: 0, z: 95 }, radius: 8, count: 1 },
   // Boars: east meadow
   { mobId: 'wild_boar', center: { x: 55, z: 12 }, radius: 22, count: 6 },

--- a/tests/zone1_wolf_density.test.ts
+++ b/tests/zone1_wolf_density.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { GRAVEYARD_POS, ZONE1_CAMPS } from '../src/sim/content/zone1';
+import type { CampDef } from '../src/sim/types';
+
+// Regression guard for #1908: the north-woods forest wolf camps sit on the
+// direct corpse-run line from the Eastbrook graveyard. The old layout packed 13
+// wolves into two dense, OVERLAPPING camps (counts 7 and 6, centers ~38 apart
+// with a combined reach of 42), so a level 1-2 player who corpse-rezzed at 50%
+// HP walked straight back into the blob and was chain-killed (packFrenzy makes
+// this worse). The fix thins and separates the near-graveyard camps and relocates
+// the surplus pack deep north, off the corpse-run line, without inventing any
+// AI/aggro-grace mechanic. These bounds pin that content-data density.
+
+// How far north of the graveyard a low-HP corpse-runner is still in the danger
+// stretch. Camps whose spawn disc reaches within this distance count as "on the
+// corpse run".
+const CORPSE_RUN_RADIUS = 100;
+
+function dist(a: { x: number; z: number }, b: { x: number; z: number }): number {
+  return Math.hypot(a.x - b.x, a.z - b.z);
+}
+
+const wolfCamps: CampDef[] = ZONE1_CAMPS.filter((c) => c.mobId === 'forest_wolf');
+
+describe('zone1 forest wolf pack density on the newbie corpse-run', () => {
+  it('keeps the zone-wide wolf headcount stable (13) for world-gen determinism', () => {
+    // Redistributing rather than deleting wolves keeps the world-construction RNG
+    // draw order byte-identical, so every seed-pinned spawn/delve roll is stable.
+    const total = wolfCamps.reduce((sum, c) => sum + c.count, 0);
+    expect(total).toBe(13);
+  });
+
+  it('does not overlap any two wolf camps (a clear gap between spawn discs)', () => {
+    // Old layout: the two camps sat ~38.1 apart with a combined reach of 42, so
+    // their discs overlapped by ~3.9 (gap < 0). Every pair must now have a
+    // comfortable positive gap between their edges.
+    for (let i = 0; i < wolfCamps.length; i++) {
+      for (let j = i + 1; j < wolfCamps.length; j++) {
+        const a = wolfCamps[i];
+        const b = wolfCamps[j];
+        const gap = dist(a.center, b.center) - (a.radius + b.radius);
+        expect(gap).toBeGreaterThanOrEqual(10);
+      }
+    }
+  });
+
+  it('bounds the wolves within reach of the graveyard corpse-run', () => {
+    // Old total on the corpse run was 7 + 6 = 13 (both camps near the graveyard);
+    // the surplus pack now lives deep north, so at most 8 wolves border the run a
+    // corpse-rezzer walks back along.
+    const nearRunWolves = wolfCamps
+      .filter((c) => dist(c.center, GRAVEYARD_POS) - c.radius <= CORPSE_RUN_RADIUS)
+      .reduce((sum, c) => sum + c.count, 0);
+    expect(nearRunWolves).toBeLessThanOrEqual(8);
+  });
+
+  it('keeps each wolf camp at a believable but non-lethal density', () => {
+    for (const c of wolfCamps) {
+      // No single camp packs the old dense pack's headcount (7/6), and each still
+      // fields real wolves (not emptied out).
+      expect(c.count).toBeGreaterThanOrEqual(3);
+      expect(c.count).toBeLessThanOrEqual(5);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The two `forest_wolf` camps in the Eastbrook Vale north woods sat on the direct corpse-run line from the graveyard and were both dense (counts 7 and 6) AND overlapping (centers about 38 apart with a combined reach of 42, so their spawn discs overlapped by about 4). A level 1-2 player who died there corpse-rezzed at 50% HP right inside a 13-wolf blob, and `packFrenzy` chained the re-aggro into repeat deaths.

This is a content-data density tune only: the two near-graveyard camps are thinned to 4 wolves each and pulled apart so their spawn discs no longer overlap, and the surplus pack is relocated deep north near Brightwood Glade, off the corpse-run line. No AI or aggro-grace mechanic is introduced (that would be a non-classic invention).

The zone-wide wolf headcount is deliberately kept at 13 (4 + 4 + 5). World construction draws its spawn RNG in camp order, so preserving the total keeps the draw sequence byte-identical and every seed-pinned spawn and delve roll stable (the same rule the tail-appended `ZONE1_CHAPEL_CAMPS` already documents). Cutting the count instead shifted the downstream stream and broke the `drowned_litany` parity golden, which this approach avoids.

## Related issues

Closes #1908

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/zone1_wolf_density.test.ts` (new, 4 assertions)
  - `npx vitest run tests/architecture.test.ts` (sim purity/determinism backstop)
  - `npx vitest run tests/parity/coverage.test.ts` (incl. `drowned_litany`) plus a broad determinism/spawn sweep (snapshots, mob_pack_frenzy, entity_roster, litany_spawn_collision, rare_ogre_spawn, quest_targets, and more): all green
  - `npx tsc --noEmit` clean for the changed files
  - `npx @biomejs/biome check` clean on the changed files
  - Codex review against `release/v0.27.0`: no actionable findings
- Manual steps: verified the new camp geometry pairwise (gaps A-B 15.7, A-C 51.4, B-C 31.9, all clear of overlap) and that the near-graveyard headcount drops from 13 to 8 while the zone total stays 13.

The new test fails against the old 7+6 overlapping layout (overlap gap negative, corpse-run count 13 > 8, per-camp count 7 > 5) and passes with the fix.

## Screenshots / recordings

N/A. Spawn-data tuning with no player-facing UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets or `.env`; `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated files hand-edited.
