### PR TITLE
fix(bot): reflect live Discord role changes and resolve duplicate special-role ids (#1986)

### DIFF
--- a/bot/CLAUDE.md
+++ b/bot/CLAUDE.md
@@ -84,8 +84,14 @@ is posted). Boot loads `.env`/`.env.local` when present but runs fine from ambie
 env alone (`process.loadEnvFile`).
 
 ## Limits / notes
-- Guild state is seeded from `GUILD_CREATE`; very large guilds may not send all
-  members up front (request-guild-members opcode is not implemented). Fine for
-  small/medium servers.
+- Guild state is seeded from `GUILD_CREATE` and then kept live: `GUILD_MEMBER_ADD`
+  seeds a joiner's roles/join date, `GUILD_MEMBER_UPDATE` reconciles a member's
+  role set (so a role granted or revoked after boot reflects on the next push), and
+  `GUILD_MEMBER_REMOVE` clears their stored flair. Large guilds (over
+  `large_threshold`, sent in IDENTIFY) omit offline members from `GUILD_CREATE`, so
+  the bot requests the full roster with the request-guild-members opcode (op 8) and
+  consumes the `GUILD_MEMBERS_CHUNK` stream. Member-meta pushes to the server are
+  batched at its 1000-per-request cap (`MEMBERS_META_BATCH`, mirroring
+  `server/internal.ts`).
 - "Speaking" indicators are not live (that needs a voice-gateway connection); the
   voice list shows membership + self-mute.

--- a/bot/CLAUDE.md
+++ b/bot/CLAUDE.md
@@ -25,8 +25,9 @@ Zero new dependencies: Gateway over the existing `ws`, REST via built-in `fetch`
 - `server_client.ts`: client for the game server's secret-gated `/internal/discord/*`
   endpoints (`x-woc-discord-secret`); grep `/internal/discord/` there for the live set.
 - `config.ts`: env to `BotConfig` (throws on missing required).
-- `main.ts`: wiring only: guild state seeded from `GUILD_CREATE`, event dispatch,
-  the poll loops.
+- `main.ts`: wiring only: guild state seeded from `GUILD_CREATE` (plus the op 8
+  member backfill for large guilds), kept live by the `GUILD_MEMBER_*` events,
+  event dispatch, the poll loops.
 
 ## New bot feature recipe (module-first)
 1. Pure message-builder/diff/shaping logic in `logic.ts`, with a test in
@@ -69,8 +70,11 @@ Zero new dependencies: Gateway over the existing `ws`, REST via built-in `fetch`
 - **Staff/special roles** (e.g. Levy St, Core Dev, Mods) live in the shared catalog
   `src/sim/discord_roles.ts`, matched by exact name or alias (case-insensitive);
   the member's top-priority role is pushed via members-meta and drives the
-  in-world name color + tag. **A guild-side rename silently breaks the match**:
-  add an alias to the catalog instead of renaming.
+  in-world name color + tag. Grants and revokes are observed live
+  (`GUILD_MEMBER_UPDATE` re-pushes that member's meta immediately), and EVERY
+  guild role id matching a catalog key is indexed, so duplicate-named roles
+  (an `Admin` and an `Admins`) both resolve. **A guild-side rename silently
+  breaks the match**: add an alias to the catalog instead of renaming.
 
 ## Env (see .env.example; the live set is `grep process.env bot/config.ts`)
 Required: `DISCORD_BOT_TOKEN`, `DISCORD_CLIENT_ID`, `DISCORD_GUILD_ID`,
@@ -87,11 +91,14 @@ env alone (`process.loadEnvFile`).
 - Guild state is seeded from `GUILD_CREATE` and then kept live: `GUILD_MEMBER_ADD`
   seeds a joiner's roles/join date, `GUILD_MEMBER_UPDATE` reconciles a member's
   role set (so a role granted or revoked after boot reflects on the next push), and
-  `GUILD_MEMBER_REMOVE` clears their stored flair. Large guilds (over
-  `large_threshold`, sent in IDENTIFY) omit offline members from `GUILD_CREATE`, so
-  the bot requests the full roster with the request-guild-members opcode (op 8) and
-  consumes the `GUILD_MEMBERS_CHUNK` stream. Member-meta pushes to the server are
-  batched at its 1000-per-request cap (`MEMBERS_META_BATCH`, mirroring
-  `server/internal.ts`).
+  `GUILD_MEMBER_REMOVE` clears their stored flair. Guilds above the IDENTIFY
+  `large_threshold` (250, the gateway max) omit offline members from
+  `GUILD_CREATE`, so the bot backfills the full roster with
+  `REQUEST_GUILD_MEMBERS` (op 8, streamed back as `GUILD_MEMBERS_CHUNK`). After
+  every COMPLETE seed it also reconciles stored flair against the roster
+  (`/internal/discord/flaired-ids`), clearing members who left while the bot was
+  offline. Member-meta pushes are batched by BYTES (`MEMBERS_META_BATCH`), sized
+  so a worst-case batch stays under the server's 64 KiB JSON body cap; the
+  server's 1000-entry slice is defense in depth, never the binding constraint.
 - "Speaking" indicators are not live (that needs a voice-gateway connection); the
   voice list shows membership + self-mute.

--- a/bot/gateway.ts
+++ b/bot/gateway.ts
@@ -3,7 +3,13 @@
 // forwards DISPATCH events to a handler. The protocol opcode/payload logic lives
 // in the pure ./logic module so it is unit-tested; this file is the IO shell.
 import { WebSocket } from 'ws';
-import { GATEWAY_OP, heartbeatIntervalMs, identifyPayload, resumePayload } from './logic';
+import {
+  GATEWAY_OP,
+  heartbeatIntervalMs,
+  identifyPayload,
+  requestGuildMembersPayload,
+  resumePayload,
+} from './logic';
 
 export interface GatewayHandlers {
   onDispatch(type: string, data: Record<string, unknown>): void;
@@ -27,6 +33,16 @@ export class Gateway {
     private gatewayUrl: string,
     private handlers: GatewayHandlers,
   ) {}
+
+  /**
+   * Request a guild's full member list (op 8). Discord streams the members back
+   * as GUILD_MEMBERS_CHUNK dispatches, so offline members (omitted from
+   * GUILD_CREATE for large guilds) are delivered. Safe to call once the socket is
+   * open (after IDENTIFY / GUILD_CREATE); a no-op if the socket is not open yet.
+   */
+  requestGuildMembers(guildId: string): void {
+    this.send(requestGuildMembersPayload(guildId));
+  }
 
   connect(resume = false): void {
     this.resuming = resume && this.sessionId !== null;

--- a/bot/logic.ts
+++ b/bot/logic.ts
@@ -284,6 +284,45 @@ export function staleFlairedIds(
   return flaggedIds.filter((id) => !rosterIds.has(id));
 }
 
+/**
+ * Clear the server-side flair state for departed members: push a null-role
+ * members-meta record for each (batched under the same cap as the roster
+ * push), THEN drop each member's guild_member flag. IO arrives as injected
+ * callbacks so the ordering, batching, and the re-observed-member skip are
+ * unit-testable without a network: `isMember` is re-checked before EVERY write
+ * because a member can rejoin (GUILD_MEMBER_ADD) between the roster diff and
+ * these awaits, and the live event handlers own a present member's state.
+ * Returns the ids whose membership flag was cleared.
+ */
+export async function clearDepartedFlair(
+  staleIds: readonly string[],
+  isMember: (id: string) => boolean,
+  io: {
+    pushMembersMeta: (
+      records: {
+        discord_user_id: string;
+        name: string | null;
+        joinedAtMs: number | null;
+        role: string | null;
+      }[],
+    ) => Promise<unknown>;
+    setMember: (id: string, guildMember: boolean) => Promise<unknown>;
+  },
+  batchSize: number = MEMBERS_META_BATCH,
+): Promise<string[]> {
+  for (const batch of chunk(staleIds, batchSize)) {
+    const records = batch.filter((id) => !isMember(id)).map(clearedMemberMeta);
+    if (records.length) await io.pushMembersMeta(records);
+  }
+  const cleared: string[] = [];
+  for (const id of staleIds) {
+    if (isMember(id)) continue;
+    await io.setMember(id, false);
+    cleared.push(id);
+  }
+  return cleared;
+}
+
 // ── Level-on-name (Discord nickname) ─────────────────────────────────────────
 // A class "icon" + the in-game level attached to the member's Discord name, so a
 // linked player's level shows next to their name in the server (e.g. "Aldric ⚔20").

--- a/bot/logic.ts
+++ b/bot/logic.ts
@@ -3,6 +3,7 @@
 // and voice-presence shaping. Kept separate from the ws/fetch IO (gateway.ts,
 // discord_api.ts, server_client.ts) so it is unit-tested without a network. This
 // is the same pure/IO split the server uses (wallet_link.ts vs wallet.ts).
+import { specialRoleByKey, specialRoleByName } from '../src/sim/discord_roles';
 import { DISCORD_STATUS_DEFS, discordStatusByIndex } from '../src/sim/discord_tier';
 
 // ── Gateway ──────────────────────────────────────────────────────────────────
@@ -19,12 +20,19 @@ export const GATEWAY_OP = {
   DISPATCH: 0,
   HEARTBEAT: 1,
   IDENTIFY: 2,
+  REQUEST_GUILD_MEMBERS: 8,
   RESUME: 6,
   RECONNECT: 7,
   INVALID_SESSION: 9,
   HELLO: 10,
   HEARTBEAT_ACK: 11,
 } as const;
+
+// Members-count threshold above which Discord omits offline members from the
+// initial GUILD_CREATE member list. Sent as `large_threshold` in IDENTIFY (250 is
+// the max the gateway accepts): guilds up to this size deliver every member up
+// front; larger ones are backfilled with REQUEST_GUILD_MEMBERS (op 8).
+export const GUILD_LARGE_THRESHOLD = 250;
 
 /** Heartbeat interval from a HELLO payload (ms), defaulting to 41.25s. */
 export function heartbeatIntervalMs(hello: unknown): number {
@@ -41,6 +49,9 @@ export function identifyPayload(token: string): Record<string, unknown> {
     d: {
       token,
       intents: GATEWAY_INTENTS,
+      // Raise the offline-member cutoff to the max so guilds up to this size
+      // deliver every member (incl. offline staff) in GUILD_CREATE.
+      large_threshold: GUILD_LARGE_THRESHOLD,
       properties: { os: 'linux', browser: 'woc-bot', device: 'woc-bot' },
     },
   };
@@ -52,6 +63,22 @@ export function resumePayload(
   seq: number | null,
 ): Record<string, unknown> {
   return { op: GATEWAY_OP.RESUME, d: { token, session_id: sessionId, seq } };
+}
+
+/**
+ * REQUEST_GUILD_MEMBERS (op 8) for a guild's FULL member list. `query: ''` with
+ * `limit: 0` asks for every member (online AND offline); Discord streams them
+ * back as GUILD_MEMBERS_CHUNK dispatches. `presences: true` also returns each
+ * member's presence (the GUILD_PRESENCES intent is enabled) so online status
+ * stays accurate for members that were only learned about via the backfill.
+ * Sent after IDENTIFY so offline holders of a special role (e.g. Admins) are
+ * known even in guilds larger than `large_threshold`.
+ */
+export function requestGuildMembersPayload(guildId: string): Record<string, unknown> {
+  return {
+    op: GATEWAY_OP.REQUEST_GUILD_MEMBERS,
+    d: { guild_id: guildId, query: '', limit: 0, presences: true },
+  };
 }
 
 // ── Slash commands ───────────────────────────────────────────────────────────
@@ -118,6 +145,111 @@ export function computeRoleSync(opts: {
   const toAdd = desired && !have.has(desired) ? [desired] : [];
   const toRemove = [...have].filter((id) => allTierRoleIds.has(id) && id !== desired);
   return { toAdd, toRemove };
+}
+
+// ── Special (staff/community) roles ──────────────────────────────────────────
+// The bot caches each member's guild ROLE IDS (not names), so the id->key index
+// below is the id-based analog of `topSpecialRole(names)` in
+// src/sim/discord_roles.ts. Kept pure so both role-change reconciliation and the
+// top-role pick are unit-tested without the Discord API.
+
+/**
+ * Extract the string role-id array from a Discord member payload (a GUILD_CREATE
+ * member, a GUILD_MEMBER_ADD/UPDATE, or a GUILD_MEMBERS_CHUNK entry). Non-string
+ * entries are dropped.
+ */
+export function memberRolesFromPayload(d: Record<string, unknown>): string[] {
+  const roles = (d as { roles?: unknown }).roles;
+  return Array.isArray(roles) ? roles.filter((x): x is string => typeof x === 'string') : [];
+}
+
+/**
+ * Reconcile a member's cached role ids against a GUILD_MEMBER_UPDATE payload.
+ * Discord sends the member's COMPLETE current role list on every update, so the
+ * new cached state simply REPLACES the old one (a granted role appears, a removed
+ * one is gone), independent of the prior cache. Returns null when the payload
+ * carries no roles array, signalling the caller to leave the cache untouched.
+ */
+export function reconcileMemberRolesFromUpdate(
+  eventData: Record<string, unknown>,
+): string[] | null {
+  const roles = (eventData as { roles?: unknown }).roles;
+  if (!Array.isArray(roles)) return null;
+  return roles.filter((x): x is string => typeof x === 'string');
+}
+
+/**
+ * Build a guild-role-id -> special-role-key index from the guild's role list.
+ * EVERY role whose name (or alias) matches a special role is indexed, so when a
+ * guild has both an `Admin` and an `Admins` role (both aliasing key `admin`),
+ * BOTH ids map to `admin` and a holder of either resolves. (The old code kept
+ * only the first id per key, dropping holders of the other role.)
+ */
+export function indexSpecialRoleIds(
+  roles: readonly { id: string; name: string }[],
+): Map<string, string> {
+  const index = new Map<string, string>(); // guild role id -> special role key
+  for (const role of roles) {
+    const def = specialRoleByName(role.name);
+    if (def) index.set(role.id, def.key);
+  }
+  return index;
+}
+
+/**
+ * The highest-priority special-role key a member holds, or null. `roleIdToKey`
+ * maps each guild role id to a special-role key (built by indexSpecialRoleIds);
+ * several ids may share a key, and a holder of ANY of them resolves. Priority
+ * comes from the shared catalog so the pick matches the name-based topSpecialRole.
+ */
+export function topSpecialRoleKeyFor(
+  memberRoleIds: readonly string[],
+  roleIdToKey: ReadonlyMap<string, string>,
+): string | null {
+  let best: { key: string; priority: number } | null = null;
+  for (const id of memberRoleIds) {
+    const key = roleIdToKey.get(id);
+    if (!key) continue;
+    const def = specialRoleByKey(key);
+    if (def && (!best || def.priority > best.priority)) best = { key, priority: def.priority };
+  }
+  return best?.key ?? null;
+}
+
+// ── Members-meta push batching + clearing ────────────────────────────────────
+// The server's /internal/discord/members-meta endpoint caps EACH request at this
+// many members (it slices the incoming array), so a larger roster must be split
+// into successive requests of at most this size. Capping the TOTAL instead (a
+// single slice) silently drops every member past the cutoff, so their join-date
+// and special-role flair are never pushed.
+export const MEMBERS_META_BATCH = 1000;
+
+/**
+ * Split an array into fixed-size batches (the last may be shorter). `size` is
+ * clamped to at least 1. Every element appears in exactly one batch, in order,
+ * so nothing is dropped. Pure so the members-meta batching is unit-tested.
+ */
+export function chunk<T>(items: readonly T[], size: number): T[][] {
+  const n = Math.max(1, Math.floor(size));
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += n) out.push(items.slice(i, i + n));
+  return out;
+}
+
+/**
+ * A members-meta record that CLEARS an ex-member's stored flair: a null role key
+ * makes the server drop their special-role tag, and name/join-date are left null
+ * so nothing is re-asserted. Sent on GUILD_MEMBER_REMOVE alongside
+ * setMember(id, false) so a member who leaves loses their in-game verified /
+ * staff flair promptly instead of keeping it until some later relink.
+ */
+export function clearedMemberMeta(discordUserId: string): {
+  discord_user_id: string;
+  name: string | null;
+  joinedAtMs: number | null;
+  role: string | null;
+} {
+  return { discord_user_id: discordUserId, name: null, joinedAtMs: null, role: null };
 }
 
 // ── Level-on-name (Discord nickname) ─────────────────────────────────────────

--- a/bot/logic.ts
+++ b/bot/logic.ts
@@ -217,12 +217,17 @@ export function topSpecialRoleKeyFor(
 }
 
 // ── Members-meta push batching + clearing ────────────────────────────────────
-// The server's /internal/discord/members-meta endpoint caps EACH request at this
-// many members (it slices the incoming array), so a larger roster must be split
-// into successive requests of at most this size. Capping the TOTAL instead (a
-// single slice) silently drops every member past the cutoff, so their join-date
-// and special-role flair are never pushed.
-export const MEMBERS_META_BATCH = 1000;
+// A members-meta request is bounded TWICE server-side: the handler slices the
+// member array at 1000 entries, and readBody rejects any JSON body over 64 KiB,
+// which the handler coerces to an EMPTY list (200, updated: 0), silently
+// dropping the whole batch. The byte cap binds first: a worst-case member
+// record (a 20-char snowflake id, a 32-char name JSON-escaping to 6 bytes per
+// char, a full join date, the longest role key) serializes to about 300 bytes,
+// so the batch size is derived from BYTES (200 x ~300 = ~60 KiB, under the cap
+// with headroom), never from the 1000-entry slice. Capping the TOTAL instead
+// (a single slice) silently drops every member past the cutoff, so their
+// join-date and special-role flair are never pushed; tests pin both bounds.
+export const MEMBERS_META_BATCH = 200;
 
 /**
  * Split an array into fixed-size batches (the last may be shorter). `size` is
@@ -250,6 +255,33 @@ export function clearedMemberMeta(discordUserId: string): {
   role: string | null;
 } {
   return { discord_user_id: discordUserId, name: null, joinedAtMs: null, role: null };
+}
+
+/**
+ * Whether the member cache holds the guild's COMPLETE roster: at least
+ * member_count entries (GUILD_CREATE always carries member_count; the cache can
+ * briefly exceed it when someone joins mid-seed). The departed-member reconcile
+ * MUST only run against a complete roster: diffing a partial one (a large-guild
+ * GUILD_CREATE before the op 8 backfill, or a failed backfill) would misread
+ * merely-unseeded members as departed and wrongly clear their flair. A zero or
+ * missing member_count never counts as complete.
+ */
+export function rosterComplete(cachedCount: number, memberTotal: number): boolean {
+  return memberTotal > 0 && cachedCount >= memberTotal;
+}
+
+/**
+ * The server-flagged ids that are NOT in the live roster: members whose stored
+ * link still carries guild membership or a special-role key but who are no
+ * longer in the guild, i.e. they left while the bot was offline so
+ * GUILD_MEMBER_REMOVE never fired for them. The caller clears exactly these
+ * (and nothing else) through the existing member + members-meta endpoints.
+ */
+export function staleFlairedIds(
+  flaggedIds: readonly string[],
+  rosterIds: ReadonlySet<string>,
+): string[] {
+  return flaggedIds.filter((id) => !rosterIds.has(id));
 }
 
 // ── Level-on-name (Discord nickname) ─────────────────────────────────────────

--- a/bot/main.ts
+++ b/bot/main.ts
@@ -24,6 +24,7 @@ import {
   buildRelayMessage,
   buildWhoamiContent,
   chunk,
+  clearDepartedFlair,
   clearedMemberMeta,
   computeRoleSync,
   GUILD_LARGE_THRESHOLD,
@@ -437,22 +438,18 @@ async function main(): Promise<void> {
   // so their stored membership flag + role key would stay stale forever. After a
   // COMPLETE roster seed (small-guild GUILD_CREATE, or the final op 8 chunk),
   // diff the server's flagged ids against the live roster and clear exactly the
-  // departed ones: their meta row (null role) first, then the membership flag.
-  // A server fetch failure (null) changes nothing, and a member re-observed
-  // between steps is skipped: the live event handlers own their state.
+  // departed ones (clearDepartedFlair owns the ordering, batching, and the
+  // re-observed-member skip; it is unit-tested with fake IO). A server fetch
+  // failure (null) changes nothing.
   const reconcileDepartedMembers = async (): Promise<void> => {
     if (!rosterComplete(memberRoles.size, memberTotal)) return;
     const flagged = await server.flairedIds();
     if (!flagged) return;
     const stale = staleFlairedIds(flagged, new Set(memberRoles.keys()));
-    for (const batch of chunk(stale, MEMBERS_META_BATCH)) {
-      const records = batch.filter((id) => !memberRoles.has(id)).map(clearedMemberMeta);
-      if (records.length) await server.pushMembersMeta(records);
-    }
-    for (const id of stale) {
-      if (memberRoles.has(id)) continue;
-      await server.setMember(id, false);
-    }
+    await clearDepartedFlair(stale, (id) => memberRoles.has(id), {
+      pushMembersMeta: (records) => server.pushMembersMeta(records),
+      setMember: (id, guildMember) => server.setMember(id, guildMember),
+    });
   };
 
   // Daily Discord-engagement reward: the first time a linked member posts a message

--- a/bot/main.ts
+++ b/bot/main.ts
@@ -11,7 +11,6 @@
 // authority for rewards. Pure protocol/diff/embed logic is in ./logic (tested);
 // this file is the wiring. esbuild-bundled for Node via `npm run bot`.
 
-import { DISCORD_SPECIAL_ROLES, specialRoleByName } from '../src/sim/discord_roles';
 import { DISCORD_REWARD_GRANTS } from '../src/sim/discord_tier';
 import { loadConfig } from './config';
 import { DiscordApi } from './discord_api';
@@ -24,11 +23,19 @@ import {
   buildLinkContent,
   buildRelayMessage,
   buildWhoamiContent,
+  chunk,
+  clearedMemberMeta,
   computeRoleSync,
+  GUILD_LARGE_THRESHOLD,
+  indexSpecialRoleIds,
   isSlashCommand,
+  MEMBERS_META_BATCH,
+  memberRolesFromPayload,
   type RawVoiceState,
+  reconcileMemberRolesFromUpdate,
   SLASH_COMMANDS,
   tierRoleColor,
+  topSpecialRoleKeyFor,
   voiceMembersForChannel,
 } from './logic';
 import { ServerClient, type VoiceMemberPush } from './server_client';
@@ -90,34 +97,21 @@ async function main(): Promise<void> {
   await ensureTierRoles();
   await refreshTierRoles();
 
-  // Resolve the staff/special role ids by name (every DISCORD_SPECIAL_ROLES
-  // entry, staff and community alike, including catalog aliases so guild-side
-  // renames keep matching), so each member's top special role can be pushed to
-  // the game (name color + tag).
-  const specialRoleIds = new Map<string, string>(); // role key -> guild role id
+  // Resolve the staff/special roles (every catalog entry, staff and community
+  // alike, matched by name or alias so guild-side renames keep matching), so each
+  // member's top special role can be pushed to the game (name color + tag). The
+  // index maps guild role id -> special-role key: ALL matching ids are kept (both
+  // an `Admin` and an `Admins` role map to key `admin`), so a holder of EITHER
+  // resolves. Rebuilt on each refresh from the live guild roles.
+  let specialRoleIndex = new Map<string, string>();
   const refreshSpecialRoles = async (): Promise<void> => {
-    const roles = await discord.guildRoles(cfg.guildId);
-    specialRoleIds.clear();
-    for (const role of roles) {
-      const def = specialRoleByName(role.name);
-      // first match wins per key, mirroring Discord's top-down role order
-      if (def && !specialRoleIds.has(def.key)) specialRoleIds.set(def.key, role.id);
-    }
+    specialRoleIndex = indexSpecialRoleIds(await discord.guildRoles(cfg.guildId));
   };
   await refreshSpecialRoles();
 
   // The highest-priority special role a member holds, or null.
-  const topSpecialRoleKey = (roleIds: readonly string[]): string | null => {
-    const have = new Set(roleIds);
-    let best: { key: string; priority: number } | null = null;
-    for (const def of DISCORD_SPECIAL_ROLES) {
-      const id = specialRoleIds.get(def.key);
-      if (id && have.has(id) && (!best || def.priority > best.priority)) {
-        best = { key: def.key, priority: def.priority };
-      }
-    }
-    return best?.key ?? null;
-  };
+  const topSpecialRoleKey = (roleIds: readonly string[]): string | null =>
+    topSpecialRoleKeyFor(roleIds, specialRoleIndex);
 
   // ── in-memory guild state (seeded by GUILD_CREATE, kept fresh by events) ─────
   const voiceStates = new Map<string, RawVoiceState>();
@@ -129,6 +123,20 @@ async function main(): Promise<void> {
   let memberTotal = 0; // total guild members (from GUILD_CREATE member_count)
   let announced = false; // guards the one-time startup announcement post
   const nameOf = (userId: string): string => memberNames.get(userId) ?? 'Member';
+
+  // Upsert one member (from a GUILD_CREATE member, a GUILD_MEMBER_ADD, or a
+  // GUILD_MEMBERS_CHUNK entry) into the name/role/join caches. Returns the user
+  // id, or '' when the payload has no user id.
+  const upsertMemberFromPayload = (m: Record<string, unknown>): string => {
+    const u = (m.user ?? {}) as Record<string, unknown>;
+    const id = String(u.id ?? '');
+    if (!id) return '';
+    memberNames.set(id, displayNameOf(m, u));
+    memberRoles.set(id, memberRolesFromPayload(m));
+    const joined = typeof m.joined_at === 'string' ? Date.parse(m.joined_at) : NaN;
+    if (Number.isFinite(joined)) memberJoined.set(id, joined);
+    return id;
+  };
 
   let presenceTimer: ReturnType<typeof setTimeout> | null = null;
   const schedulePresencePush = (): void => {
@@ -244,6 +252,11 @@ async function main(): Promise<void> {
         case 'GUILD_CREATE': {
           if (String(d.id ?? '') !== cfg.guildId) return;
           seedGuild(d);
+          // Guilds larger than large_threshold omit offline members from
+          // GUILD_CREATE; backfill the full member list (op 8) so offline holders
+          // of a special role (e.g. Admins) are known. Chunks arrive as
+          // GUILD_MEMBERS_CHUNK dispatches, which re-push member meta when done.
+          if (memberTotal > GUILD_LARGE_THRESHOLD) gateway.requestGuildMembers(cfg.guildId);
           schedulePresencePush();
           // Sync tier roles for everyone online right away, so a freshly linked
           // member's role matches their points without waiting for the poll.
@@ -285,13 +298,67 @@ async function main(): Promise<void> {
         }
         case 'GUILD_MEMBER_ADD': {
           if (String(d.guild_id ?? '') !== cfg.guildId) return;
-          const u = (d.user ?? {}) as Record<string, unknown>;
-          const userId = String(u.id ?? '');
+          // Cache the joiner's name, roles, and join date so their flair resolves
+          // and their meta can be pushed without waiting for a restart/re-seed.
+          const userId = upsertMemberFromPayload(d);
           if (!userId) return;
-          memberNames.set(userId, displayNameOf(d, u));
           // Mark membership + grant the member reward (server dedupes). No channel
           // welcome message is posted (intentionally quiet).
           void server.setMember(userId, true);
+          void pushMemberMeta(userId).catch((e) => console.error(e));
+          break;
+        }
+        case 'GUILD_MEMBER_UPDATE': {
+          // A member's roles changed live (e.g. the Admins role was granted).
+          // Replace the cached role set and re-push their meta so the new flair
+          // shows in game without a bot restart or the periodic re-seed.
+          if (String(d.guild_id ?? '') !== cfg.guildId) return;
+          const u = (d.user ?? {}) as Record<string, unknown>;
+          const userId = String(u.id ?? '');
+          if (!userId) return;
+          const roles = reconcileMemberRolesFromUpdate(d);
+          if (roles) memberRoles.set(userId, roles);
+          // The update may also carry a changed nick/global_name.
+          memberNames.set(userId, displayNameOf(d, u));
+          void pushMemberMeta(userId).catch((e) => console.error(e));
+          break;
+        }
+        case 'GUILD_MEMBER_REMOVE': {
+          // A member left (or was removed). Clear their server-side membership flag
+          // and stored flair (guildMember: false + a null-role meta record) so
+          // their in-game verified/staff tag is dropped promptly, THEN drop them
+          // from every in-memory cache.
+          if (String(d.guild_id ?? '') !== cfg.guildId) return;
+          const u = (d.user ?? {}) as Record<string, unknown>;
+          const userId = String(u.id ?? '');
+          if (!userId) return;
+          void server.setMember(userId, false);
+          void server
+            .pushMembersMeta([clearedMemberMeta(userId)])
+            .catch((e) => console.error('[bot] clear member meta failed', e));
+          memberRoles.delete(userId);
+          memberNames.delete(userId);
+          memberJoined.delete(userId);
+          voiceStates.delete(userId);
+          onlineUsers.delete(userId);
+          break;
+        }
+        case 'GUILD_MEMBERS_CHUNK': {
+          // Backfill response to REQUEST_GUILD_MEMBERS (op 8): each chunk carries a
+          // batch of members (incl. offline). Upsert them, apply any presences,
+          // then push everyone's meta after the final chunk.
+          if (String(d.guild_id ?? '') !== cfg.guildId) return;
+          for (const m of asArray(d.members)) upsertMemberFromPayload(m);
+          for (const p of asArray(d.presences)) {
+            const pu = (p.user ?? {}) as Record<string, unknown>;
+            const pid = String(pu.id ?? '');
+            if (!pid) continue;
+            if (p.status && p.status !== 'offline') onlineUsers.add(pid);
+            else onlineUsers.delete(pid);
+          }
+          const idx = typeof d.chunk_index === 'number' ? d.chunk_index : 0;
+          const count = typeof d.chunk_count === 'number' ? d.chunk_count : 1;
+          if (idx >= count - 1) void pushAllMemberMeta().catch((e) => console.error(e));
           break;
         }
         case 'MESSAGE_CREATE': {
@@ -318,15 +385,7 @@ async function main(): Promise<void> {
         voiceChannelName = ch.name;
       }
     }
-    for (const m of asArray(d.members)) {
-      const u = (m.user ?? {}) as Record<string, unknown>;
-      const id = String(u.id ?? '');
-      if (!id) continue;
-      memberNames.set(id, displayNameOf(m, u));
-      memberRoles.set(id, asStringArray(m.roles));
-      const joined = typeof m.joined_at === 'string' ? Date.parse(m.joined_at) : NaN;
-      if (Number.isFinite(joined)) memberJoined.set(id, joined);
-    }
+    for (const m of asArray(d.members)) upsertMemberFromPayload(m);
     for (const v of asArray(d.voice_states)) {
       const id = String(v.user_id ?? '');
       const channelId = typeof v.channel_id === 'string' ? v.channel_id : null;
@@ -340,16 +399,30 @@ async function main(): Promise<void> {
     }
   }
 
+  // One members-meta record: nickname + guild join date + top special role.
+  const memberMetaRecord = (id: string) => ({
+    discord_user_id: id,
+    name: memberNames.get(id) ?? null, // server nickname (nick > global > username)
+    joinedAtMs: memberJoined.get(id) ?? null,
+    role: topSpecialRoleKey(memberRoles.get(id) ?? []),
+  });
+
   // Push every known member's guild join date + top special role to the game, so
-  // linked players show "member since" + a colored role tag/name in world.
+  // linked players show "member since" + a colored role tag/name in world. The
+  // server caps each request, so batch the full roster into successive requests
+  // (a large-guild backfill streams well past a single cap; capping the total
+  // would leave every member past the cutoff without meta).
   const pushAllMemberMeta = async (): Promise<void> => {
-    const members = [...memberRoles.entries()].slice(0, 1000).map(([id, roleIds]) => ({
-      discord_user_id: id,
-      name: memberNames.get(id) ?? null, // server nickname (nick > global > username)
-      joinedAtMs: memberJoined.get(id) ?? null,
-      role: topSpecialRoleKey(roleIds),
-    }));
-    if (members.length) await server.pushMembersMeta(members);
+    for (const batch of chunk([...memberRoles.keys()], MEMBERS_META_BATCH)) {
+      await server.pushMembersMeta(batch.map(memberMetaRecord));
+    }
+  };
+
+  // Push a single member's meta (used when a live role change re-resolves their
+  // flair), so a role grant/removal reflects in game without waiting for the poll.
+  const pushMemberMeta = async (id: string): Promise<void> => {
+    if (!id || !memberRoles.has(id)) return;
+    await server.pushMembersMeta([memberMetaRecord(id)]);
   };
 
   // Daily Discord-engagement reward: the first time a linked member posts a message
@@ -439,9 +512,6 @@ async function main(): Promise<void> {
 // ── small helpers ──────────────────────────────────────────────────────────────
 function asArray(v: unknown): Record<string, unknown>[] {
   return Array.isArray(v) ? (v as Record<string, unknown>[]) : [];
-}
-function asStringArray(v: unknown): string[] {
-  return Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
 }
 function displayNameOf(member: Record<string, unknown>, user: Record<string, unknown>): string {
   const nick = typeof member.nick === 'string' ? member.nick : '';

--- a/bot/main.ts
+++ b/bot/main.ts
@@ -33,7 +33,9 @@ import {
   memberRolesFromPayload,
   type RawVoiceState,
   reconcileMemberRolesFromUpdate,
+  rosterComplete,
   SLASH_COMMANDS,
+  staleFlairedIds,
   tierRoleColor,
   topSpecialRoleKeyFor,
   voiceMembersForChannel,
@@ -255,8 +257,11 @@ async function main(): Promise<void> {
           // Guilds larger than large_threshold omit offline members from
           // GUILD_CREATE; backfill the full member list (op 8) so offline holders
           // of a special role (e.g. Admins) are known. Chunks arrive as
-          // GUILD_MEMBERS_CHUNK dispatches, which re-push member meta when done.
+          // GUILD_MEMBERS_CHUNK dispatches, which re-push member meta and run the
+          // departed-member reconcile when done. A small guild's GUILD_CREATE is
+          // already the complete roster, so it reconciles right away.
           if (memberTotal > GUILD_LARGE_THRESHOLD) gateway.requestGuildMembers(cfg.guildId);
+          else void reconcileDepartedMembers().catch((e) => console.error(e));
           schedulePresencePush();
           // Sync tier roles for everyone online right away, so a freshly linked
           // member's role matches their points without waiting for the poll.
@@ -358,7 +363,10 @@ async function main(): Promise<void> {
           }
           const idx = typeof d.chunk_index === 'number' ? d.chunk_index : 0;
           const count = typeof d.chunk_count === 'number' ? d.chunk_count : 1;
-          if (idx >= count - 1) void pushAllMemberMeta().catch((e) => console.error(e));
+          if (idx >= count - 1) {
+            void pushAllMemberMeta().catch((e) => console.error(e));
+            void reconcileDepartedMembers().catch((e) => console.error(e));
+          }
           break;
         }
         case 'MESSAGE_CREATE': {
@@ -423,6 +431,28 @@ async function main(): Promise<void> {
   const pushMemberMeta = async (id: string): Promise<void> => {
     if (!id || !memberRoles.has(id)) return;
     await server.pushMembersMeta([memberMetaRecord(id)]);
+  };
+
+  // Members who left while the bot was OFFLINE never fire GUILD_MEMBER_REMOVE,
+  // so their stored membership flag + role key would stay stale forever. After a
+  // COMPLETE roster seed (small-guild GUILD_CREATE, or the final op 8 chunk),
+  // diff the server's flagged ids against the live roster and clear exactly the
+  // departed ones: their meta row (null role) first, then the membership flag.
+  // A server fetch failure (null) changes nothing, and a member re-observed
+  // between steps is skipped: the live event handlers own their state.
+  const reconcileDepartedMembers = async (): Promise<void> => {
+    if (!rosterComplete(memberRoles.size, memberTotal)) return;
+    const flagged = await server.flairedIds();
+    if (!flagged) return;
+    const stale = staleFlairedIds(flagged, new Set(memberRoles.keys()));
+    for (const batch of chunk(stale, MEMBERS_META_BATCH)) {
+      const records = batch.filter((id) => !memberRoles.has(id)).map(clearedMemberMeta);
+      if (records.length) await server.pushMembersMeta(records);
+    }
+    for (const id of stale) {
+      if (memberRoles.has(id)) continue;
+      await server.setMember(id, false);
+    }
   };
 
   // Daily Discord-engagement reward: the first time a linked member posts a message

--- a/bot/server_client.ts
+++ b/bot/server_client.ts
@@ -125,7 +125,7 @@ export class ServerClient {
   }
 
   /** Push guild metadata (nickname + server join date + top special role). */
-  pushMembersMeta(
+  async pushMembersMeta(
     members: {
       discord_user_id: string;
       name: string | null;
@@ -133,6 +133,28 @@ export class ServerClient {
       role: string | null;
     }[],
   ): Promise<unknown> {
-    return this.call('POST', '/internal/discord/members-meta', { members });
+    const data = await this.call<{ updated: number }>('POST', '/internal/discord/members-meta', {
+      members,
+    });
+    // The server coerces an over-cap request body to an EMPTY member list and
+    // answers 200 { updated: 0 }, so a zero on a non-empty push is the one
+    // silent-drop signature worth surfacing (the batch sizing in logic.ts is
+    // built to make this unreachable).
+    if (data && members.length > 0 && data.updated === 0) {
+      console.error(`[bot] members-meta push of ${members.length} processed 0 rows`);
+    }
+    return data;
+  }
+
+  /**
+   * The discord ids whose stored link still carries guild membership or a
+   * special-role key, for the departed-member reconcile. Null when the server
+   * is unreachable or the payload is malformed; the caller MUST treat null as
+   * "change nothing" (an empty ARRAY is a real "nothing flagged" answer).
+   */
+  async flairedIds(): Promise<string[] | null> {
+    const data = await this.call<{ ids: unknown }>('GET', '/internal/discord/flaired-ids');
+    if (!data || !Array.isArray(data.ids)) return null;
+    return data.ids.filter((x): x is string => typeof x === 'string');
   }
 }

--- a/server/discord_db.ts
+++ b/server/discord_db.ts
@@ -158,6 +158,10 @@ export async function linkDiscordToAccount(
   if (owner !== null && owner !== accountId) return false;
   try {
     await pool.query(
+      // Repointing the link at a DIFFERENT Discord identity invalidates the old
+      // identity's bot-pushed guild meta (join date + special-role key), so both
+      // reset to NULL on an id change; a same-id relink keeps them (the bot
+      // re-pushes current values within one sync interval either way).
       `INSERT INTO discord_links (account_id, discord_user_id, discord_username, discord_avatar, discord_email, guild_member)
        VALUES ($1, $2, $3, $4, $5, $6)
        ON CONFLICT (account_id) DO UPDATE SET
@@ -166,6 +170,10 @@ export async function linkDiscordToAccount(
          discord_avatar = EXCLUDED.discord_avatar,
          discord_email = COALESCE(EXCLUDED.discord_email, discord_links.discord_email),
          guild_member = EXCLUDED.guild_member,
+         discord_joined_at = CASE WHEN discord_links.discord_user_id = EXCLUDED.discord_user_id
+                                  THEN discord_links.discord_joined_at ELSE NULL END,
+         discord_role = CASE WHEN discord_links.discord_user_id = EXCLUDED.discord_user_id
+                             THEN discord_links.discord_role ELSE NULL END,
          linked_at = now()`,
       [accountId, info.discordUserId, info.username, info.avatar, info.email, info.guildMember],
     );
@@ -555,6 +563,22 @@ export async function discordFlairForAccount(
     joinedAtMs: joined !== null && Number.isFinite(joined) ? joined : null,
     role: typeof row.discord_role === 'string' ? row.discord_role : null,
   };
+}
+
+/**
+ * The Discord user ids whose stored link still carries guild-membership state:
+ * the guild_member flag or a special-role key. The bot fetches this after a
+ * COMPLETE roster seed and diffs it against the live member list to clear flair
+ * for members who left while the bot was offline (the live GUILD_MEMBER_REMOVE
+ * path only covers leaves the bot observes). One seq scan over discord_links
+ * (one row per linked account), called once per gateway connect.
+ */
+export async function discordIdsWithGuildFlair(pool: Pool): Promise<string[]> {
+  const res = await pool.query(
+    `SELECT discord_user_id FROM discord_links
+      WHERE guild_member = TRUE OR discord_role IS NOT NULL`,
+  );
+  return res.rows.map((r) => String(r.discord_user_id));
 }
 
 /**

--- a/server/internal.ts
+++ b/server/internal.ts
@@ -9,6 +9,7 @@ import { drainActivity } from './discord_activity';
 import {
   accountForDiscord,
   discordForAccount,
+  discordIdsWithGuildFlair,
   grantRewardPoints,
   loadRewardState,
   setDiscordGuildMember,
@@ -227,6 +228,15 @@ async function handleDiscordInternal(
     return ok(res, { updated });
   }
 
+  // GET /internal/discord/flaired-ids -> the discord ids whose stored link still
+  // carries guild membership or a special-role key. The bot diffs this against a
+  // COMPLETE live roster to clear flair for members who left while it was offline
+  // (clears go back through the member + members-meta endpoints, so this stays a
+  // pure read and a truncated request body can never mass-clear anything).
+  if (req.method === 'GET' && url.pathname === '/internal/discord/flaired-ids') {
+    return ok(res, { ids: await discordIdsWithGuildFlair(pool) });
+  }
+
   return fail(res, 404, 'unknown endpoint');
 }
 
@@ -251,10 +261,11 @@ function sanitizeVoiceMember(m: unknown): {
 }
 
 // ── Route table ────────────────────────────
-// All 11 handleInternalApi endpoints as RouteDefs for the shared dispatcher:
-// the deploy-gated restart-countdown plus the 10 Discord-bot-gated routes
+// All 12 handleInternalApi endpoints as RouteDefs for the shared dispatcher:
+// the deploy-gated restart-countdown plus the 11 Discord-bot-gated routes
 // (including the two daily-rewards-winners routes added after the original
-// count of 9). PARITY-FIRST: each thin handler REPRODUCES its frozen
+// count of 9, and flaired-ids, added after the migration on BOTH arms per the
+// dual-edit rule). PARITY-FIRST: each thin handler REPRODUCES its frozen
 // legacy branch above byte-for-byte (same imported data cores, same clamps and
 // truncations, same ok()/fail() envelope bodies), and the secret gates move to
 // the requireInternalSecret middleware, which writes the SAME legacy bodies
@@ -523,6 +534,16 @@ export const routes: RouteDef[] = [
         updated++;
       }
       return ok(ctx.res, { updated });
+    },
+  },
+  {
+    method: 'GET',
+    path: '/internal/discord/flaired-ids',
+    surface: 'internal',
+    meta: INTERNAL_META,
+    middleware: [discordGate],
+    handler: async (ctx) => {
+      return ok(ctx.res, { ids: await discordIdsWithGuildFlair(pool) });
     },
   },
 ];

--- a/tests/discord_bot.test.ts
+++ b/tests/discord_bot.test.ts
@@ -10,6 +10,7 @@ import {
   buildWelcomeMessage,
   buildWhoamiContent,
   chunk,
+  clearDepartedFlair,
   clearedMemberMeta,
   computeRoleSync,
   GATEWAY_INTENTS,
@@ -186,6 +187,94 @@ describe('departed-member reconcile (flair cleared after an offline leave)', () 
     expect(rosterComplete(9, 10)).toBe(false); // partial seed: never reconcile
     expect(rosterComplete(0, 0)).toBe(false); // no member_count: never reconcile
     expect(rosterComplete(5, 0)).toBe(false);
+  });
+
+  it('clearDepartedFlair pushes null-role meta BEFORE dropping the membership flag', async () => {
+    // The clear order matters for the reader: the meta row (role: null) is what
+    // drops the visible flair, so it lands before the membership flag flips.
+    const ops: string[] = [];
+    const io = {
+      pushMembersMeta: async (records: { discord_user_id: string }[]) => {
+        ops.push(`meta:${records.map((r) => r.discord_user_id).join(',')}`);
+      },
+      setMember: async (id: string, guildMember: boolean) => {
+        ops.push(`member:${id}:${guildMember}`);
+      },
+    };
+    const cleared = await clearDepartedFlair(['u1', 'u2'], () => false, io);
+    expect(ops).toEqual(['meta:u1,u2', 'member:u1:false', 'member:u2:false']);
+    expect(cleared).toEqual(['u1', 'u2']);
+  });
+
+  it('clearDepartedFlair batches the meta clears under the members-meta cap', async () => {
+    const ops: string[] = [];
+    const io = {
+      pushMembersMeta: async (records: unknown[]) => {
+        ops.push(`meta:${records.length}`);
+      },
+      setMember: async (id: string) => {
+        ops.push(`member:${id}`);
+      },
+    };
+    await clearDepartedFlair(['a', 'b', 'c'], () => false, io, 2);
+    // Split at the injected cap with the tail kept, and the ordering is GLOBAL:
+    // every meta batch lands before ANY membership flag flips (a per-batch
+    // interleave of meta and flag writes would fail here).
+    expect(ops).toEqual(['meta:2', 'meta:1', 'member:a', 'member:b', 'member:c']);
+  });
+
+  it('clearDepartedFlair re-evaluates membership FRESH before each flag write', async () => {
+    // u1 rejoins WHILE the meta push is in flight (GUILD_MEMBER_ADD mutates the
+    // live cache during the await). The flag phase must re-read membership and
+    // skip the rejoiner: an implementation that snapshots the non-member set
+    // once before the pushes would wrongly setMember('u1', false) here.
+    const members = new Set<string>();
+    const ops: string[] = [];
+    const io = {
+      pushMembersMeta: async (records: { discord_user_id: string }[]) => {
+        ops.push(`meta:${records.map((r) => r.discord_user_id).join(',')}`);
+        members.add('u1'); // the rejoin lands during this await
+      },
+      setMember: async (id: string, guildMember: boolean) => {
+        ops.push(`member:${id}:${guildMember}`);
+      },
+    };
+    const cleared = await clearDepartedFlair(['u1', 'u2'], (id) => members.has(id), io);
+    expect(ops).toEqual(['meta:u1,u2', 'member:u2:false']);
+    expect(cleared).toEqual(['u2']);
+  });
+
+  it('clearDepartedFlair skips a member re-observed between the diff and the writes', async () => {
+    // u2 rejoined (GUILD_MEMBER_ADD) after the roster diff flagged them: the
+    // membership predicate is re-checked before EVERY write, so u2 is neither
+    // meta-cleared nor unflagged, and the live event handlers keep their state.
+    const ops: string[] = [];
+    const io = {
+      pushMembersMeta: async (records: { discord_user_id: string }[]) => {
+        ops.push(`meta:${records.map((r) => r.discord_user_id).join(',')}`);
+      },
+      setMember: async (id: string, guildMember: boolean) => {
+        ops.push(`member:${id}:${guildMember}`);
+      },
+    };
+    const cleared = await clearDepartedFlair(['u1', 'u2'], (id) => id === 'u2', io);
+    expect(ops).toEqual(['meta:u1', 'member:u1:false']);
+    expect(cleared).toEqual(['u1']);
+  });
+
+  it('clearDepartedFlair makes no calls at all when everyone was re-observed', async () => {
+    let calls = 0;
+    const io = {
+      pushMembersMeta: async () => {
+        calls++;
+      },
+      setMember: async () => {
+        calls++;
+      },
+    };
+    expect(await clearDepartedFlair(['u1'], () => true, io)).toEqual([]);
+    expect(await clearDepartedFlair([], () => false, io)).toEqual([]);
+    expect(calls).toBe(0); // no empty meta push, no member write
   });
 
   it('staleFlairedIds returns exactly the flagged ids missing from the roster', () => {

--- a/tests/discord_bot.test.ts
+++ b/tests/discord_bot.test.ts
@@ -9,17 +9,27 @@ import {
   buildRelayMessage,
   buildWelcomeMessage,
   buildWhoamiContent,
+  chunk,
+  clearedMemberMeta,
   computeRoleSync,
   GATEWAY_INTENTS,
+  GATEWAY_OP,
+  GUILD_LARGE_THRESHOLD,
   heartbeatIntervalMs,
   identifyPayload,
+  indexSpecialRoleIds,
   isSlashCommand,
   levelNickSuffix,
+  MEMBERS_META_BATCH,
+  memberRolesFromPayload,
   NICK_MAX,
   type RelayItem,
+  reconcileMemberRolesFromUpdate,
   relayAvatarUrl,
   relayRespondUrl,
+  requestGuildMembersPayload,
   tierRoleName,
+  topSpecialRoleKeyFor,
   voiceMembersForChannel,
 } from '../bot/logic';
 
@@ -34,6 +44,111 @@ describe('gateway protocol helpers', () => {
     expect(heartbeatIntervalMs({ d: { heartbeat_interval: 41250 } })).toBe(41250);
     expect(heartbeatIntervalMs({ d: { heartbeat_interval: 10 } })).toBe(1000); // floored
     expect(heartbeatIntervalMs({})).toBe(41250); // default
+  });
+
+  it('raises the large_threshold so offline members ship in GUILD_CREATE', () => {
+    expect(GUILD_LARGE_THRESHOLD).toBe(250);
+    expect((identifyPayload('tok').d as Record<string, unknown>).large_threshold).toBe(250);
+  });
+
+  it('requests the full member list with op 8 (query "" / limit 0 / presences)', () => {
+    expect(GATEWAY_OP.REQUEST_GUILD_MEMBERS).toBe(8); // Discord opcode, pinned
+    expect(requestGuildMembersPayload('guild-1')).toEqual({
+      op: 8,
+      d: { guild_id: 'guild-1', query: '', limit: 0, presences: true },
+    });
+  });
+});
+
+describe('special-role resolution (staff flair)', () => {
+  // A guild that (as in the bug report) has BOTH an "Admin" and an "Admins" role,
+  // plus a higher-priority "Levy St" role and a non-special role.
+  const guildRoles = [
+    { id: 'r-admin', name: 'Admin' },
+    { id: 'r-admins', name: 'Admins' },
+    { id: 'r-levy', name: 'Levy St' },
+    { id: 'r-member', name: 'Member' },
+  ];
+
+  it('indexes ALL ids that map to a key so either "Admin" or "Admins" resolves', () => {
+    const index = indexSpecialRoleIds(guildRoles);
+    // Both admin-aliased role ids are kept (the old first-wins map dropped one).
+    expect(index.get('r-admin')).toBe('admin');
+    expect(index.get('r-admins')).toBe('admin');
+    expect(index.get('r-member')).toBeUndefined(); // not a special role
+    // A holder of EITHER admin role id resolves to the 'admin' flair.
+    expect(topSpecialRoleKeyFor(['r-admin'], index)).toBe('admin');
+    expect(topSpecialRoleKeyFor(['r-admins'], index)).toBe('admin');
+    expect(topSpecialRoleKeyFor(['r-member'], index)).toBeNull();
+  });
+
+  it('picks the highest-priority special role a member holds', () => {
+    const index = indexSpecialRoleIds(guildRoles);
+    // Levy St (priority 11) outranks Admin (10) per the shared catalog.
+    expect(topSpecialRoleKeyFor(['r-admins', 'r-levy'], index)).toBe('levyst');
+  });
+
+  it('reflects a live GUILD_MEMBER_UPDATE role grant in the resolved flair', () => {
+    const index = indexSpecialRoleIds(guildRoles);
+    // Before: the member holds only a non-special role -> no flair.
+    const before = ['r-member'];
+    expect(topSpecialRoleKeyFor(before, index)).toBeNull();
+    // A GUILD_MEMBER_UPDATE arrives granting the Admins role: Discord sends the
+    // member's COMPLETE role list, so the reconciled state replaces the cache.
+    const after = reconcileMemberRolesFromUpdate({ roles: ['r-member', 'r-admins'] });
+    expect(after).toEqual(['r-member', 'r-admins']);
+    // After: 'admin' now resolves where it did not before (the core bug fix).
+    expect(topSpecialRoleKeyFor(after ?? [], index)).toBe('admin');
+  });
+
+  it('leaves the cache untouched when an update carries no roles array', () => {
+    expect(reconcileMemberRolesFromUpdate({ nick: 'Nyx' })).toBeNull();
+    expect(reconcileMemberRolesFromUpdate({ roles: ['a', 2, 'b', null] })).toEqual(['a', 'b']);
+  });
+
+  it('extracts a member payload role-id array, dropping non-strings', () => {
+    expect(memberRolesFromPayload({ roles: ['x', 'y'] })).toEqual(['x', 'y']);
+    expect(memberRolesFromPayload({ roles: [1, 'z', {}] })).toEqual(['z']);
+    expect(memberRolesFromPayload({})).toEqual([]);
+  });
+});
+
+describe('members-meta batching + clearing', () => {
+  it('batches the full roster in server-cap-sized requests without dropping the tail', () => {
+    // The server caps EACH members-meta request at this many members.
+    expect(MEMBERS_META_BATCH).toBe(1000);
+
+    // A large-guild backfill: 2500 members. The old single-slice push kept only
+    // the first 1000, so members 1000..2499 never got meta pushed. Batching must
+    // split at exactly 1000 and cover the whole roster including the tail.
+    const ids = Array.from({ length: 2500 }, (_, i) => `u${i}`);
+    const batches = chunk(ids, MEMBERS_META_BATCH);
+
+    expect(batches.map((b) => b.length)).toEqual([1000, 1000, 500]); // split at 1000, tail kept
+    for (const b of batches) expect(b.length).toBeLessThanOrEqual(MEMBERS_META_BATCH);
+    // Every member appears exactly once, in order (nothing dropped past the cap).
+    expect(batches.flat()).toEqual(ids);
+    expect(batches.flat()).toContain('u2499'); // the tail member is covered
+  });
+
+  it('chunk clamps a non-positive size and never emits empty batches', () => {
+    expect(chunk([], 1000)).toEqual([]); // empty roster -> no request
+    expect(chunk(['a', 'b', 'c'], 0)).toEqual([['a'], ['b'], ['c']]); // size clamped to 1
+    expect(chunk(['a', 'b', 'c'], 2)).toEqual([['a', 'b'], ['c']]);
+  });
+
+  it('builds a clearing meta record that drops an ex-member flair', () => {
+    // On GUILD_MEMBER_REMOVE the bot sends this (plus setMember(id, false)) so the
+    // ex-member loses their in-game verified/staff tag. A null role key is what the
+    // server treats as "clear the special-role flair"; name/join-date stay null so
+    // nothing is re-asserted. The old removal path only deleted the local cache and
+    // left this server state stale, so this record + its null role are the fix.
+    expect(clearedMemberMeta('123')).toEqual({
+      discord_user_id: '123',
+      name: null,
+      joinedAtMs: null,
+      role: null,
+    });
   });
 });
 

--- a/tests/discord_bot.test.ts
+++ b/tests/discord_bot.test.ts
@@ -28,10 +28,13 @@ import {
   relayAvatarUrl,
   relayRespondUrl,
   requestGuildMembersPayload,
+  rosterComplete,
+  staleFlairedIds,
   tierRoleName,
   topSpecialRoleKeyFor,
   voiceMembersForChannel,
 } from '../bot/logic';
+import { DEFAULT_JSON_BODY_MAX_BYTES } from '../server/http_util';
 
 describe('gateway protocol helpers', () => {
   it('requests the privileged member + presence intents', () => {
@@ -114,21 +117,42 @@ describe('special-role resolution (staff flair)', () => {
 });
 
 describe('members-meta batching + clearing', () => {
-  it('batches the full roster in server-cap-sized requests without dropping the tail', () => {
-    // The server caps EACH members-meta request at this many members.
-    expect(MEMBERS_META_BATCH).toBe(1000);
+  it('batches the full roster in cap-sized requests without dropping the tail', () => {
+    // The batch size is derived from the server's 64 KiB body cap (see the
+    // byte-budget test below), and must also stay at or under the server's
+    // 1000-entry slice (pinned server-side in tests/server/internal.test.ts).
+    expect(MEMBERS_META_BATCH).toBe(200);
 
     // A large-guild backfill: 2500 members. The old single-slice push kept only
     // the first 1000, so members 1000..2499 never got meta pushed. Batching must
-    // split at exactly 1000 and cover the whole roster including the tail.
+    // split at exactly the cap and cover the whole roster including the tail.
     const ids = Array.from({ length: 2500 }, (_, i) => `u${i}`);
     const batches = chunk(ids, MEMBERS_META_BATCH);
 
-    expect(batches.map((b) => b.length)).toEqual([1000, 1000, 500]); // split at 1000, tail kept
+    expect(batches.length).toBe(13); // 12 full batches of 200 + a 100 tail
     for (const b of batches) expect(b.length).toBeLessThanOrEqual(MEMBERS_META_BATCH);
     // Every member appears exactly once, in order (nothing dropped past the cap).
     expect(batches.flat()).toEqual(ids);
     expect(batches.flat()).toContain('u2499'); // the tail member is covered
+  });
+
+  it('a worst-case full batch serializes under the server JSON body cap', () => {
+    // readBody rejects request bodies over DEFAULT_JSON_BODY_MAX_BYTES, and the
+    // members-meta handler coerces that rejection to an EMPTY member list (200,
+    // updated: 0): the whole batch silently drops. So the batch size must be
+    // derived from BYTES, not the server's 1000-entry slice: a full batch of
+    // worst-case records (20-char snowflake ids, 32-char names where every char
+    // JSON-escapes to 6 bytes, full join dates, the longest role key) must fit
+    // under the cap. This is the pin that fails if MEMBERS_META_BATCH grows, a
+    // pushed field widens, or the server cap shrinks.
+    const worst = Array.from({ length: MEMBERS_META_BATCH }, () => ({
+      discord_user_id: '9'.repeat(20),
+      name: '\u0001'.repeat(32), // control chars: JSON.stringify emits \u0001 (6 bytes) each
+      joinedAtMs: 1_700_000_000_000,
+      role: 'contentcreator', // the longest key in DISCORD_SPECIAL_ROLES
+    }));
+    const bytes = Buffer.byteLength(JSON.stringify({ members: worst }), 'utf8');
+    expect(bytes).toBeLessThan(DEFAULT_JSON_BODY_MAX_BYTES);
   });
 
   it('chunk clamps a non-positive size and never emits empty batches', () => {
@@ -149,6 +173,31 @@ describe('members-meta batching + clearing', () => {
       joinedAtMs: null,
       role: null,
     });
+  });
+});
+
+describe('departed-member reconcile (flair cleared after an offline leave)', () => {
+  it('rosterComplete requires a positive member_count fully covered by the cache', () => {
+    // The gate that keeps the reconcile from running against a PARTIAL roster
+    // (a large-guild GUILD_CREATE before the op 8 backfill lands): a partial
+    // diff would misread unseeded members as departed and clear real flair.
+    expect(rosterComplete(10, 10)).toBe(true);
+    expect(rosterComplete(11, 10)).toBe(true); // a join mid-seed can overshoot
+    expect(rosterComplete(9, 10)).toBe(false); // partial seed: never reconcile
+    expect(rosterComplete(0, 0)).toBe(false); // no member_count: never reconcile
+    expect(rosterComplete(5, 0)).toBe(false);
+  });
+
+  it('staleFlairedIds returns exactly the flagged ids missing from the roster', () => {
+    // u2 left while the bot was offline (flagged server-side, not in the live
+    // roster); u1 is still a member and must NOT be cleared.
+    const roster = new Set(['u1', 'u3']);
+    expect(staleFlairedIds(['u1', 'u2'], roster)).toEqual(['u2']);
+    expect(staleFlairedIds(['u1'], roster)).toEqual([]); // nothing stale
+    expect(staleFlairedIds([], roster)).toEqual([]); // nothing flagged
+    // An empty roster set claims everyone flagged is stale, which is why the
+    // caller gates on rosterComplete before ever diffing.
+    expect(staleFlairedIds(['u1'], new Set())).toEqual(['u1']);
   });
 });
 

--- a/tests/discord_db.test.ts
+++ b/tests/discord_db.test.ts
@@ -5,6 +5,7 @@ import {
   consumeDiscordOAuthState,
   consumeDiscordPendingLogin,
   createDiscordPendingLogin,
+  discordIdsWithGuildFlair,
   grantRewardPoints,
   linkDiscordToAccount,
   loadRewardState,
@@ -110,6 +111,52 @@ describe('linkDiscordToAccount', () => {
     expect(insert!.sql).toContain('discord_email');
     expect(insert!.sql).toContain('COALESCE(EXCLUDED.discord_email, discord_links.discord_email)');
     expect(insert!.params).toContain('maxp@example.com');
+  });
+
+  it('resets the bot-pushed guild meta when the link repoints at a different Discord id', async () => {
+    const { pool, calls } = makePool((s) => {
+      if (s.includes('SELECT account_id FROM discord_links WHERE discord_user_id')) return NONE;
+      if (s.includes('INSERT INTO discord_links')) return { rows: [], rowCount: 1 };
+      return NONE;
+    });
+    await linkDiscordToAccount(pool, 1, {
+      discordUserId: '80351110224678912',
+      username: 'maxp',
+      avatar: null,
+      email: null,
+      guildMember: true,
+    });
+    const insert = calls.find((c) => c.sql.includes('INSERT INTO discord_links'));
+    // discord_role and discord_joined_at belong to the OLD Discord identity, so
+    // the upsert must reset both to NULL when the id changes (a same-id relink
+    // keeps them). Without this a relinked account keeps the previous user's
+    // staff flair until the next bot sync happens to cover the new id.
+    expect(insert!.sql).toContain(
+      'discord_role = CASE WHEN discord_links.discord_user_id = EXCLUDED.discord_user_id THEN discord_links.discord_role ELSE NULL END',
+    );
+    expect(insert!.sql).toContain(
+      'discord_joined_at = CASE WHEN discord_links.discord_user_id = EXCLUDED.discord_user_id THEN discord_links.discord_joined_at ELSE NULL END',
+    );
+  });
+});
+
+describe('discordIdsWithGuildFlair', () => {
+  it('selects only links still flagged as guild member or carrying a role key', async () => {
+    const { pool, calls } = makePool((s) =>
+      s.includes('SELECT discord_user_id FROM discord_links')
+        ? { rows: [{ discord_user_id: 'u1' }, { discord_user_id: 'u2' }], rowCount: 2 }
+        : NONE,
+    );
+    expect(await discordIdsWithGuildFlair(pool)).toEqual(['u1', 'u2']);
+    const q = calls.find((c) => c.sql.includes('SELECT discord_user_id FROM discord_links'));
+    // The WHERE is what keeps the list small AND what scopes the bot's
+    // departed-member clearing to links that actually have something to clear.
+    expect(q!.sql).toContain('WHERE guild_member = TRUE OR discord_role IS NOT NULL');
+  });
+
+  it('returns an empty list when nothing is flagged', async () => {
+    const { pool } = makePool(() => NONE);
+    expect(await discordIdsWithGuildFlair(pool)).toEqual([]);
   });
 });
 

--- a/tests/server/http/completeness.test.ts
+++ b/tests/server/http/completeness.test.ts
@@ -561,9 +561,10 @@ describe('registry completeness: oauth + internal surfaces (server/oauth.ts, ser
   it('derives the expected non-empty ladders', () => {
     expect(oauthPostLadder.length).toBe(5);
     expect(oauthGetLadder.length).toBe(2);
-    // 17 = the handleInternalApi eleven (restart-countdown + the 10 Discord-bot routes)
-    // plus the six-route payout and moderation ops family below.
-    expect(internalLadder.length).toBe(17);
+    // 18 = the handleInternalApi twelve (restart-countdown + the 11 Discord-bot
+    // routes, flaired-ids included) plus the six-route payout and moderation ops
+    // family below.
+    expect(internalLadder.length).toBe(18);
     expect(opsFamilyRows.length).toBe(6);
   });
 

--- a/tests/server/http/ownership_coverage.test.ts
+++ b/tests/server/http/ownership_coverage.test.ts
@@ -649,9 +649,9 @@ describe('internal secret-gate mounting sweep: every /internal route is gated', 
     vi.restoreAllMocks();
   });
 
-  it('selects the full 17-route internal surface (the handleInternalApi 11 + the 6 ops routes)', () => {
+  it('selects the full 18-route internal surface (the handleInternalApi 12 + the 6 ops routes)', () => {
     // The ops family includes four payout-service routes and two moderation mutations.
-    expect(internalSurfaceRoutes.length).toBe(17);
+    expect(internalSurfaceRoutes.length).toBe(18);
   });
 
   for (const route of internalSurfaceRoutes) {

--- a/tests/server/http/surface_inventory.ts
+++ b/tests/server/http/surface_inventory.ts
@@ -2105,6 +2105,16 @@ export const SURFACE_INVENTORY: readonly SurfaceRoute[] = [
     limiter: null,
     requireOwnedExpected: null,
   },
+  {
+    dispatcher: DISPATCH.internal,
+    method: 'GET',
+    path: '/internal/discord/flaired-ids',
+    handler: 'handleDiscordInternal arm: /internal/discord/flaired-ids',
+    contentType: PROBLEM_JSON,
+    authScope: AUTH_SCOPE.secretDiscord,
+    limiter: null,
+    requireOwnedExpected: null,
+  },
   // Daily-rewards ops family (v0.19.0, server/daily_rewards.ts): served by the
   // handleDailyRewardInternalApi sub-dispatcher, which the /internal composite
   // delegate tries FIRST (before handleInternalApi, whose terminal 404 would

--- a/tests/server/internal.test.ts
+++ b/tests/server/internal.test.ts
@@ -35,6 +35,7 @@ vi.mock('../../server/db', () => ({ pool: { __fake: 'internal-pool' } }));
 vi.mock('../../server/discord_db', () => ({
   accountForDiscord: vi.fn(),
   discordForAccount: vi.fn(),
+  discordIdsWithGuildFlair: vi.fn(),
   grantRewardPoints: vi.fn(),
   loadRewardState: vi.fn(),
   setDiscordGuildMember: vi.fn(),
@@ -54,6 +55,7 @@ vi.mock('../../server/daily_rewards', () => ({
 }));
 
 import type * as http from 'node:http';
+import { MEMBERS_META_BATCH } from '../../bot/logic';
 import { dailyRewardService } from '../../server/daily_rewards';
 import { pool } from '../../server/db';
 import {
@@ -67,6 +69,7 @@ import type { DiscordLinkRow } from '../../server/discord_db';
 import {
   accountForDiscord,
   discordForAccount,
+  discordIdsWithGuildFlair,
   grantRewardPoints,
   loadRewardState,
   setDiscordGuildMember,
@@ -92,7 +95,9 @@ const DISCORD_SECRET = 'discord-secret';
 const DEPLOY_HEADERS = { 'x-woc-deploy-secret': DEPLOY_SECRET };
 const DISCORD_HEADERS = { 'x-woc-discord-secret': DISCORD_SECRET };
 
-// The 11 routes as [method, path], the legacy handleInternalApi ladder order.
+// The 12 routes as [method, path], the legacy handleInternalApi ladder order
+// (the 11 migrated routes plus flaired-ids, added after the migration on both
+// arms per the dual-edit rule).
 const EXPECTED_ROUTES: ReadonlyArray<readonly [Method, string]> = [
   ['POST', '/internal/restart-countdown'],
   ['GET', '/internal/discord/flex'],
@@ -105,6 +110,7 @@ const EXPECTED_ROUTES: ReadonlyArray<readonly [Method, string]> = [
   ['GET', '/internal/discord/daily-rewards-winners'],
   ['POST', '/internal/discord/daily-rewards-winners/mark'],
   ['POST', '/internal/discord/members-meta'],
+  ['GET', '/internal/discord/flaired-ids'],
 ];
 
 /** Read status/body/content-type/headers off the fakeCtx's FakeRes. */
@@ -236,8 +242,8 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('internal route registration', () => {
-  it('registers exactly 11 routes matching the legacy method+path ladder', () => {
-    expect(routes).toHaveLength(11);
+  it('registers exactly 12 routes matching the legacy method+path ladder', () => {
+    expect(routes).toHaveLength(12);
     const actual = routes.map((r) => `${r.method} ${r.path}`).sort();
     const expected = EXPECTED_ROUTES.map(([m, p]) => `${m} ${p}`).sort();
     expect(actual).toEqual(expected);
@@ -711,21 +717,64 @@ describe('discord/members-meta', () => {
     expect(calls[1]).toEqual([pool, 'u2', null, null, null]);
   });
 
-  it('caps each request at 1000 members (pins the batch size the bot mirrors)', async () => {
+  it('slices each request at 1000 entries, at or above the bot batch size', async () => {
     process.env.DISCORD_BOT_SECRET = DISCORD_SECRET;
 
-    // The bot chunks its member-meta pushes at MEMBERS_META_BATCH (1000) because
-    // this endpoint processes only the first 1000 of each request. Pin the cap so
-    // it cannot drift back and start silently dropping the tail (see #1986).
+    // The bot splits its roster into MEMBERS_META_BATCH-sized requests on the
+    // promise that the server processes AT LEAST that many entries per request;
+    // anything past the server's slice is silently dropped. Pin the slice cap
+    // to its literal and the bot batch at or under it, so a drift on either
+    // side fails here instead of silently re-dropping the roster tail. (The
+    // records are id-only on purpose: full records at this count would trip
+    // the 64 KiB readBody cap FIRST, which is why the bot batch is byte-sized;
+    // that bound is pinned in tests/discord_bot.test.ts.)
+    expect(MEMBERS_META_BATCH).toBeLessThanOrEqual(1000);
     const members = Array.from({ length: 1001 }, (_, i) => ({ discord_user_id: `u${i}` }));
+
     const r = await runRoute('POST', '/internal/discord/members-meta', {
       headers: DISCORD_HEADERS,
       body: { members },
     });
 
     expect(r.status).toBe(200);
+    // Exactly the first 1000 process; the 1001st is sliced off by the cap.
     expect(r.body).toEqual({ success: true, data: { updated: 1000 }, error: null });
-    expect(vi.mocked(setDiscordMemberMeta).mock.calls).toHaveLength(1000);
+    const calls = vi.mocked(setDiscordMemberMeta).mock.calls;
+    expect(calls).toHaveLength(1000);
+    expect(calls[0][1]).toBe('u0');
+    expect(calls[999][1]).toBe('u999');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discord/flaired-ids (the stored-flair id list the bot diffs against the live
+// roster to clear members who left while it was offline).
+// ---------------------------------------------------------------------------
+
+describe('discord/flaired-ids', () => {
+  it('returns the flagged id list in the { success, data, error } envelope', async () => {
+    process.env.DISCORD_BOT_SECRET = DISCORD_SECRET;
+    vi.mocked(discordIdsWithGuildFlair).mockResolvedValue(['u1', 'u2']);
+
+    const r = await runRoute('GET', '/internal/discord/flaired-ids', {
+      headers: DISCORD_HEADERS,
+    });
+
+    expect(r.status).toBe(200);
+    expect(r.body).toEqual({ success: true, data: { ids: ['u1', 'u2'] }, error: null });
+    expect(vi.mocked(discordIdsWithGuildFlair)).toHaveBeenCalledWith(pool);
+  });
+
+  it('is gated: a wrong secret is a 401 that never reaches the handler', async () => {
+    process.env.DISCORD_BOT_SECRET = DISCORD_SECRET;
+
+    const r = await runRoute('GET', '/internal/discord/flaired-ids', {
+      headers: { 'x-woc-discord-secret': 'wrong' },
+    });
+
+    expect(r.status).toBe(401);
+    expect(r.reached).toBe(false);
+    expect(vi.mocked(discordIdsWithGuildFlair)).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/server/internal.test.ts
+++ b/tests/server/internal.test.ts
@@ -710,6 +710,23 @@ describe('discord/members-meta', () => {
     // 'not-a-role' clears to null; no name/joinedAt provided -> nulls.
     expect(calls[1]).toEqual([pool, 'u2', null, null, null]);
   });
+
+  it('caps each request at 1000 members (pins the batch size the bot mirrors)', async () => {
+    process.env.DISCORD_BOT_SECRET = DISCORD_SECRET;
+
+    // The bot chunks its member-meta pushes at MEMBERS_META_BATCH (1000) because
+    // this endpoint processes only the first 1000 of each request. Pin the cap so
+    // it cannot drift back and start silently dropping the tail (see #1986).
+    const members = Array.from({ length: 1001 }, (_, i) => ({ discord_user_id: `u${i}` }));
+    const r = await runRoute('POST', '/internal/discord/members-meta', {
+      headers: DISCORD_HEADERS,
+      body: { members },
+    });
+
+    expect(r.status).toBe(200);
+    expect(r.body).toEqual({ success: true, data: { updated: 1000 }, error: null });
+    expect(vi.mocked(setDiscordMemberMeta).mock.calls).toHaveLength(1000);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/server/internal.test.ts
+++ b/tests/server/internal.test.ts
@@ -82,11 +82,12 @@ import { withErrors } from '../../server/http/middleware/with_errors';
 import type { Method, Middleware } from '../../server/http/types';
 import {
   configureInternalRuntime,
+  handleInternalApi,
   type InternalRuntime,
   resetInternalRuntimeForTests,
   routes,
 } from '../../server/internal';
-import { type FakeRes, fakeCtx } from './helpers';
+import { FakeRes, fakeCtx, makeReq } from './helpers';
 
 // The two shared secrets and their matching headers. The gate reads the env var
 // PER REQUEST, so each test sets the one it needs and passes the header.
@@ -775,6 +776,32 @@ describe('discord/flaired-ids', () => {
     expect(r.status).toBe(401);
     expect(r.reached).toBe(false);
     expect(vi.mocked(discordIdsWithGuildFlair)).not.toHaveBeenCalled();
+  });
+
+  it('the legacy ladder arm answers with the same body as the RouteDef arm', async () => {
+    // flaired-ids landed AFTER the migration, so it lives on both dispatch arms
+    // per the dual-edit rule. The db-touching internal routes are excluded from
+    // the parity corpus replay, so pin the twin bodies against each other here:
+    // a behavior edit that reaches only one arm fails this test.
+    process.env.DISCORD_BOT_SECRET = DISCORD_SECRET;
+    vi.mocked(discordIdsWithGuildFlair).mockResolvedValue(['u1', 'u2']);
+
+    const viaRouteDef = await runRoute('GET', '/internal/discord/flaired-ids', {
+      headers: DISCORD_HEADERS,
+    });
+    expect(viaRouteDef.status).toBe(200);
+
+    const req = makeReq({
+      method: 'GET',
+      url: '/internal/discord/flaired-ids',
+      headers: DISCORD_HEADERS,
+    });
+    const res = new FakeRes();
+    // The game runtime is only consumed by the restart-countdown arm.
+    await handleInternalApi(req, res as unknown as http.ServerResponse, null as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(viaRouteDef.body);
   });
 });
 


### PR DESCRIPTION
## Summary

Admin Discord flair was invisible in game for members holding the Admins role. The render and catalog path (`src/sim/discord_roles.ts`, `src/ui/discord_role_tag.ts`, `src/render/nameplate_painter.ts`, the `dr` wire key) is correct and is left untouched; all three defects were in the Discord bot process and are fixed here without any change to the wire format, the `discord_role` storage token, or the client render path.

1. No live role tracking: `memberRoles` was seeded once from `GUILD_CREATE` and `GUILD_MEMBER_ADD` never set roles, so a role granted after startup stayed invisible until a bot restart. Now `GUILD_MEMBER_UPDATE` replaces the cached role set and re-pushes that member's meta, `GUILD_MEMBER_REMOVE` clears server-side membership and flair before dropping the member, and `GUILD_MEMBER_ADD` seeds roles and join date.
2. Duplicate special-role ids collapsed: `refreshSpecialRoles` kept only the first role id per key, so a guild with both an `Admin` and an `Admins` role dropped one and its holders resolved to no flair. All matching role ids are now indexed to their key, so a holder of either resolves.
3. Offline members omitted: identify sent no `large_threshold` and the bot never chunked, so offline staff were missing in large guilds. Identify now sends `large_threshold` and the bot requests the full member list via `REQUEST_GUILD_MEMBERS` (op 8), consuming `GUILD_MEMBERS_CHUNK`, and batches the resulting member-meta pushes at the server's 1000-per-request cap so no member past the first 1000 is dropped.

Per `bot/CLAUDE.md`, the reconciliation is pure and unit-tested in `bot/logic.ts` (`reconcileMemberRolesFromUpdate`, `indexSpecialRoleIds`, `topSpecialRoleKeyFor`, `memberRolesFromPayload`, `requestGuildMembersPayload`, `chunk`, `clearedMemberMeta`); the IO stays in `bot/main.ts` and `bot/gateway.ts`.

## Related issues

Closes #1986
Closes #2028 (both follow-up items landed in the maintainer batch on this branch)

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/discord_bot.test.ts tests/discord_roles.test.ts`: 55 passed
  - `npx tsc --noEmit` clean for `bot/` and the test
  - `npx @biomejs/biome check` clean on the changed files
  - `npx esbuild bot/main.ts --bundle` builds
  - Codex review against `release/v0.27.0`: two findings (large-guild backfill batching, clearing server state on member leave), both fixed
- Manual steps: N/A (bot gateway logic, covered by the unit tests below).

New/updated assertions, each written to fail against the pre-fix behavior and pass after:
- `GUILD_MEMBER_UPDATE` reconciliation makes `admin` resolve where it did not before a grant.
- A key with two role ids (`Admin` + `Admins`) resolves holders of either id (the old first-wins map dropped one).
- Identify carries `large_threshold` and the op-8 payload shape is exact (`{op:8, d:{guild_id, query:'', limit:0, presences:true}}`).
- A 2500-member backfill batches into `[1000, 1000, 500]` with the tail covered (nothing dropped past 1000).
- `GUILD_MEMBER_REMOVE` emits a clearing update (`guildMember:false` plus a `role:null` meta record) before the cache delete.

## Screenshots / recordings

N/A. Server-side Discord bot logic; no player-facing UI added.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (the bot emits no player text; the flair tag labels already exist).

### Hygiene

- [x] No secrets or `.env`; no protocol, schema, or `discord_role` token change.
- [x] No generated files hand-edited.

