### PR TITLE
fix(chat): stay in guild after a bare /g send online (chat reverts to previous channel)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1178,8 +1178,9 @@ async function startGame(
         if (text) {
           world.chat(text);
           // Remember the channel this line reached so the next open (on the All
-          // tab) defaults there and tints the input to its color.
-          hud.noteSentChannel(text);
+          // tab) defaults there and tints the input to its color. Pass the host so a
+          // bare "/g" sticks to guild online but general offline.
+          hud.noteSentChannel(text, online != null);
         }
       }
       // a typed "/join world"/"/leave lfg" opens or closes its channel tab too,

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -2650,8 +2650,8 @@ export class Hud {
     this.chatWindow.applyInputPresentation();
   }
 
-  noteSentChannel(sentLine: string): void {
-    this.chatWindow.noteSentChannel(sentLine);
+  noteSentChannel(sentLine: string, online: boolean): void {
+    this.chatWindow.noteSentChannel(sentLine, online);
   }
 
   composeChatSend(typed: string): string {

--- a/src/ui/hud/chat/chat_channels.ts
+++ b/src/ui/hud/chat/chat_channels.ts
@@ -208,6 +208,22 @@ export function sentLineTarget(line: string): ChatInputTintTarget | null {
   return sentLineChannel(line);
 }
 
+// Host-aware sticky resolution for the ONE alias sentLineTarget cannot resolve on
+// its own: bare "/g". It routes to GUILD online (the server intercepts it, see
+// server/game.ts) but GENERAL offline (the sim router, src/sim/social/chat.ts), so
+// the host-independent map deliberately returns null for it. The client knows its
+// host, so it resolves "/g" here and keeps the player in the channel they just spoke
+// in (the reported bug: talking in guild via "/g" then reverting to General). Every
+// other line, including the unambiguous "/gu"/"/guild", falls through to
+// sentLineTarget unchanged.
+export function sentLineTargetForHost(
+  line: string,
+  opts: { online: boolean },
+): ChatInputTintTarget | null {
+  if (/^\/g\s/i.test(line.trim())) return opts.online ? 'guild' : 'general';
+  return sentLineTarget(line);
+}
+
 // Persistence: the ordered list of channel tabs the player has opened. The
 // built-in `all` / `combat` views are implicit and not stored. Parsing is
 // defensive: unknown, duplicate, or malformed entries are dropped so a corrupt

--- a/src/ui/hud/chat/chat_channels.ts
+++ b/src/ui/hud/chat/chat_channels.ts
@@ -168,8 +168,8 @@ export function composeWhisperReply(typed: string): string {
 // there. Plain text (no leading slash) went to `say`. An explicit slash command
 // maps by its leading token; only the standing channels below are recognized, so
 // whisper / reply (`/w`, `/r`), emotes (`/me`, `/dance`), rolls (`/roll`),
-// channel membership (`/join`, `/leave`), the ambiguous bare `/g` (say offline,
-// guild online), and any unknown command return null and leave the sticky
+// channel membership (`/join`, `/leave`), the ambiguous bare `/g` (general
+// offline, guild online), and any unknown command return null and leave the sticky
 // channel unchanged. A `!` community command (`!lfg`, `!events`) is a transient
 // command like a roll, and it is host-dependent anyway (the server relay gate
 // consumes it online; offline it would land in say), so it also returns null.

--- a/src/ui/hud/chat/chat_window_controller.ts
+++ b/src/ui/hud/chat/chat_window_controller.ts
@@ -16,7 +16,7 @@ import {
   isChatOpenTab,
   isChatTabChannel,
   parseChatTabs,
-  sentLineTarget,
+  sentLineTargetForHost,
   serializeChatTabs,
   WHISPER_TAB,
   WHISPER_TAB_LABEL_KEY,
@@ -126,9 +126,11 @@ export class ChatWindowController {
   // Remember the target a just-sent line reached as the sticky default for the next
   // chat open on the All tab: a standing channel, or `whisper` for a `/r` reply so a
   // whisper conversation keeps going. An explicit `/w Name`, emotes, rolls, channel
-  // membership, and unknown commands leave the sticky target unchanged.
-  noteSentChannel(sentLine: string): void {
-    const target = sentLineTarget(sentLine);
+  // membership, and unknown commands leave the sticky target unchanged. `online`
+  // disambiguates the one host-sensitive alias, bare `/g` (guild online, general
+  // offline), so the sticky follows a guild send made with the classic command.
+  noteSentChannel(sentLine: string, online: boolean): void {
+    const target = sentLineTargetForHost(sentLine, { online });
     if (target) this.stickyTarget = target;
   }
 

--- a/tests/chat_channels.test.ts
+++ b/tests/chat_channels.test.ts
@@ -13,6 +13,7 @@ import {
   parseChatTabs,
   sentLineChannel,
   sentLineTarget,
+  sentLineTargetForHost,
   serializeChatTabs,
   WHISPER_TAB,
   WHISPER_TAB_LABEL_KEY,
@@ -311,5 +312,27 @@ describe('chat channel tabs — pure model', () => {
     expect(sentLineTarget('/1 hey')).toBe('general');
     expect(sentLineTarget('/p on my way')).toBe('party');
     expect(sentLineTarget('hello')).toBe('say');
+  });
+
+  describe('sentLineTargetForHost (host-aware sticky for the ambiguous /g alias)', () => {
+    it('sticks a bare /g send to guild online and general offline', () => {
+      // "/g" routes to GUILD online (the server intercepts it) but GENERAL offline
+      // (the sim), so the host-independent sentLineTarget leaves it null; the client
+      // knows its host and keeps the player in the channel they just spoke in.
+      expect(sentLineTargetForHost('/g raid tonight', { online: true })).toBe('guild');
+      expect(sentLineTargetForHost('/g raid tonight', { online: false })).toBe('general');
+    });
+
+    it('delegates every other line to the host-independent sentLineTarget', () => {
+      for (const online of [true, false]) {
+        expect(sentLineTargetForHost('/1 hey', { online })).toBe('general');
+        expect(sentLineTargetForHost('/general hey', { online })).toBe('general');
+        expect(sentLineTargetForHost('/gu ready', { online })).toBe('guild');
+        expect(sentLineTargetForHost('/p on my way', { online })).toBe('party');
+        expect(sentLineTargetForHost('/r sure', { online })).toBe(WHISPER_TAB);
+        expect(sentLineTargetForHost('hello', { online })).toBe('say');
+        expect(sentLineTargetForHost('/w Bob hi', { online })).toBeNull();
+      }
+    });
   });
 });

--- a/tests/chat_channels.test.ts
+++ b/tests/chat_channels.test.ts
@@ -213,7 +213,7 @@ describe('chat channel tabs — pure model', () => {
       expect(sentLineChannel('')).toBeNull();
     });
 
-    it('never maps the host-ambiguous bare /g (say offline, guild online)', () => {
+    it('never maps the host-ambiguous bare /g (general offline, guild online)', () => {
       // composeChatLine only ever emits /general for the general channel, and /g is
       // routed differently offline vs online, so it must not move the sticky channel.
       expect(sentLineChannel('/g hi')).toBeNull();
@@ -332,6 +332,21 @@ describe('chat channel tabs — pure model', () => {
         expect(sentLineTargetForHost('/r sure', { online })).toBe(WHISPER_TAB);
         expect(sentLineTargetForHost('hello', { online })).toBe('say');
         expect(sentLineTargetForHost('/w Bob hi', { online })).toBeNull();
+      }
+    });
+
+    it('round-trips every send-capable channel prefix on both hosts', () => {
+      // Closure pin: a line composed with any channel's send prefix must resolve
+      // back to that same channel, so the sticky follows the player into ANY
+      // channel (yell included) and a future channel addition stays sticky-correct
+      // by construction.
+      for (const online of [true, false]) {
+        for (const channel of CHAT_TAB_CHANNELS) {
+          const line = channelSendPrefix(channel) + 'hello there';
+          expect(sentLineTargetForHost(line, { online }), `${channel} online=${online}`).toBe(
+            channel,
+          );
+        }
       }
     });
   });

--- a/tests/chat_hud_client_seam.test.ts
+++ b/tests/chat_hud_client_seam.test.ts
@@ -55,14 +55,40 @@ describe('Hud to ClientWorld chat seam', () => {
     };
 
     // Send in party: the sticky target follows there.
-    hud.noteSentChannel(hud.composeChatSend('/p on my way'));
+    hud.noteSentChannel(hud.composeChatSend('/p on my way'), true);
     expect(state.stickyTarget).toBe('party');
 
     // Reply to a whisper: the sticky target follows to whisper, and the NEXT plain
     // line keeps replying (/r) instead of snapping back to party (the regression).
-    hud.noteSentChannel(hud.composeChatSend('/r sure thing'));
+    hud.noteSentChannel(hud.composeChatSend('/r sure thing'), true);
     expect(state.stickyTarget).toBe('whisper');
     expect(hud.composeChatSend('and thanks')).toBe('/r and thanks');
     expect(state.inputTintTarget()).toBe('whisper');
+  });
+
+  it('stays in guild after a /g send online, instead of snapping back to General', () => {
+    // The reported bug: talk in General, then Guild via the classic /g command, and
+    // the next plain line reverts to General. "/g" reaches guild online but is not a
+    // host-independent standing channel, so the sticky target must follow it here.
+    vi.stubGlobal('WebSocket', { OPEN: 1 });
+    const hud = Object.create(Hud.prototype) as InstanceType<typeof Hud>;
+    // Same bare-instance setup as above: field defaults are the All tab and a
+    // sticky say target, and compose/noteSent exercise no dep.
+    const controller = new ChatWindowController({} as ChatWindowControllerDeps);
+    (hud as unknown as { chatWindow: ChatWindowController }).chatWindow = controller;
+    const state = controller as unknown as {
+      stickyTarget: string;
+      inputTintTarget(): string;
+    };
+
+    // Talk in General (the /1 shortcut), then in Guild (the classic /g), both online.
+    hud.noteSentChannel(hud.composeChatSend('/1 hey all'), true);
+    expect(state.stickyTarget).toBe('general');
+    hud.noteSentChannel(hud.composeChatSend('/g coming'), true);
+
+    // The next plain line stays in guild (/gu), not back to /general.
+    expect(state.stickyTarget).toBe('guild');
+    expect(hud.composeChatSend('on my way')).toBe('/gu on my way');
+    expect(state.inputTintTarget()).toBe('guild');
   });
 });

--- a/tests/chat_hud_client_seam.test.ts
+++ b/tests/chat_hud_client_seam.test.ts
@@ -91,4 +91,18 @@ describe('Hud to ClientWorld chat seam', () => {
     expect(hud.composeChatSend('on my way')).toBe('/gu on my way');
     expect(state.inputTintTarget()).toBe('guild');
   });
+
+  it('threads the host flag through: a bare /g send offline sticks to General', () => {
+    // The other arm of the host-aware resolution, exercised through the same
+    // Hud delegation: offline the sim routes bare /g to General, so the sticky
+    // follows it there (a controller that ignored the flag would fail here).
+    vi.stubGlobal('WebSocket', { OPEN: 1 });
+    const hud = Object.create(Hud.prototype) as InstanceType<typeof Hud>;
+    const controller = new ChatWindowController({} as ChatWindowControllerDeps);
+    (hud as unknown as { chatWindow: ChatWindowController }).chatWindow = controller;
+    const state = controller as unknown as { stickyTarget: string };
+
+    hud.noteSentChannel('/g anyone around', false);
+    expect(state.stickyTarget).toBe('general');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the reported chat bug where, after talking in guild with the classic `/g` command, the next plain line snapped back to the previously used channel (General in the report) instead of staying in guild.

Root cause: the sticky send target is updated from the just-sent line by `sentLineTarget`, which deliberately leaves a bare `/g` unresolved (`null`) because it is host-ambiguous: the server routes `/g` to **guild** online, but the sim routes `/g` to **general** offline. So a `/g` guild send never moved the sticky target, and the following plain line composed with the stale channel and reverted.

This is the case PR #1975 ("stay on the last channel sent") could not cover from a host-independent helper.

## Fix

- `chat_channels.ts`: add a small host-aware resolver `sentLineTargetForHost(line, { online })` that resolves a bare `/g` to `guild` online and `general` offline, and delegates every other line (including the unambiguous `/gu` / `/guild`) to `sentLineTarget` unchanged.
- `hud.ts`: `noteSentChannel(sentLine, online)` now uses it.
- `main.ts`: passes the host at the one call site (`online != null`), which it already knows (offline uses `Sim`, online uses `ClientWorld`).

No new player-facing strings, no sim/server behavior change; the pure `sentLineChannel` / `sentLineTarget` stay host-independent (and their existing `/g` -> null tests stay green).

## Testing (fails before, passes after)

Two tests were written first and fail on the pre-fix code:

- `tests/chat_channels.test.ts`: `sentLineTargetForHost` sticks a bare `/g` to guild online and general offline, and delegates everything else.
- `tests/chat_hud_client_seam.test.ts`: reproduces the report end to end. Send in General (`/1`), then Guild (`/g`) online; assert the next plain line stays guild (`/gu on my way`) and the input tint is guild.

Pre-fix, the HUD-seam test fails with `expected 'general' to be 'guild'` (the exact bug). Post-fix:

```
Test Files  2 passed (2)
Tests  39 passed (39)
```

`tsc --noEmit` is clean for the changed files, and biome reports no fixes on them.

## Base

Targets `release/v0.27.0` (the current release, which already has PR #1975). `main` is a release behind and does not contain #1975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
