### PR TITLE
feat(druid): wand basic attack in caster and Moonwing form, gated off in melee shapeshifts

### DIFF
--- a/src/sim/combat/auto_attack.ts
+++ b/src/sim/combat/auto_attack.ts
@@ -123,7 +123,7 @@ export function updatePlayerAutoAttack(ctx: SimContext, p: Entity, meta: PlayerM
   if (facingDiff > MELEE_ARC) return;
 
   // ranged auto-attack: hunters (auto shot, dead zone inside minRange) and
-  // casters (wand-style, no dead zone so they don't run into melee — #94).
+  // casters (wand-style, no dead zone so they don't run into melee, #94).
   // Form-aware: a druid keeps the class wand only in caster or Moonwing Form;
   // bear/cat/travel resolve to undefined here and fall through to melee.
   const ranged = rangedAutoProfile(p, meta.cls);

--- a/src/sim/combat/auto_attack.ts
+++ b/src/sim/combat/auto_attack.ts
@@ -48,7 +48,7 @@ import { spendResource } from './casting_lifecycle';
 import { blindMissBonus, isDisarmed, isStunned } from './cc';
 import { consumeNextAttackCrit } from './empower_next';
 import { runWeaponProcs } from './equip_procs';
-import { baseSwingSpeed } from './form_swing';
+import { baseSwingSpeed, rangedAutoProfile } from './form_swing';
 import { rangedShotProfile } from './ranged_shot';
 import { applyThornsReaction } from './thorns_charge';
 
@@ -123,8 +123,10 @@ export function updatePlayerAutoAttack(ctx: SimContext, p: Entity, meta: PlayerM
   if (facingDiff > MELEE_ARC) return;
 
   // ranged auto-attack: hunters (auto shot, dead zone inside minRange) and
-  // casters (wand-style, no dead zone so they don't run into melee — #94)
-  const ranged = CLASSES[meta.cls].ranged;
+  // casters (wand-style, no dead zone so they don't run into melee — #94).
+  // Form-aware: a druid keeps the class wand only in caster or Moonwing Form;
+  // bear/cat/travel resolve to undefined here and fall through to melee.
+  const ranged = rangedAutoProfile(p, meta.cls);
   if (ranged && d <= ranged.maxRange && d >= (ranged.wand ? 0 : ranged.minRange)) {
     if (!ctx.hasLineOfSight(p, t)) return;
     ctx.breakGhostWolf(p);

--- a/src/sim/combat/form_swing.ts
+++ b/src/sim/combat/form_swing.ts
@@ -1,4 +1,6 @@
-// Form-aware base swing speed (a pure leaf, unit-tested directly).
+// Form-aware auto-attack resolution (a pure leaf, unit-tested directly): the
+// base swing speed, plus which ranged auto profile (class wand) a shapeshifted
+// player still has.
 //
 // A druid in Wolf Form (internally the `form_cat` shapeshift aura) fights with
 // claws, not the staff/mace it carries, so its auto-attack cadence must NOT come
@@ -9,7 +11,7 @@
 // content tables, so it stays deterministic and host-agnostic.
 
 import { CLASSES, ITEMS } from '../data';
-import type { Entity } from '../types';
+import type { Entity, PlayerClass } from '../types';
 
 // The rogue's baseline weapon speed (its starting dagger). Sourcing it from the
 // content tables keeps Wolf Form genuinely "same as rogue" even if the rogue's
@@ -22,4 +24,30 @@ export const ROGUE_BASE_SWING_SPEED: number = ITEMS[CLASSES.rogue.startWeapon].w
 export function baseSwingSpeed(e: Entity): number {
   for (const a of e.auras) if (a.kind === 'form_cat') return ROGUE_BASE_SWING_SPEED;
   return e.weapon.speed;
+}
+
+// The druid shapeshifts that fight with claws (or hooves): while one is active
+// the class wand is unavailable, exactly like a weapon it cannot hold. Caster
+// form and Moonwing Form (`form_moonkin`) keep the wand. Deliberately a
+// blocklist of the druid melee/travel forms, so the priest's `form_shadow` and
+// the warlock's `form_metamorph` keep their existing wand behavior.
+const WANDLESS_FORMS = new Set(['form_bear', 'form_cat', 'form_travel']);
+
+export function wandAllowedInForm(e: Entity): boolean {
+  for (const a of e.auras) if (WANDLESS_FORMS.has(a.kind)) return false;
+  return true;
+}
+
+// The class ranged auto profile the player can fire RIGHT NOW: a hunter's Auto
+// Shot always, a caster's wand only in a form that can hold it. This is the one
+// resolver every ranged-auto consumer (the swing loop, the /attack readout)
+// goes through, so a shapeshifted druid never wands from bear or cat form.
+export function rangedAutoProfile(
+  e: Entity,
+  cls: PlayerClass,
+): (typeof CLASSES)[PlayerClass]['ranged'] {
+  const ranged = CLASSES[cls].ranged;
+  if (!ranged) return undefined;
+  if (ranged.wand && !wandAllowedInForm(e)) return undefined;
+  return ranged;
 }

--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -332,6 +332,11 @@ export const CLASSES: Record<PlayerClass, ClassDef> = {
     startWeapon: 'gnarled_staff',
     startChest: 'footpad_jerkin',
     startItems: START_RATIONS_MANA,
+    // The same fixed class wand the other casters carry, in the druid's nature
+    // school. Form-aware: available only in caster form and Moonwing Form; the
+    // bear/cat/travel shapeshifts fight with claws (see combat/form_swing.ts
+    // rangedAutoProfile, which the auto-attack loop resolves through).
+    ranged: { min: 3, max: 6, speed: 1.8, maxRange: 30, minRange: 0, wand: true, school: 'nature' },
     abilities: [
       'wrath',
       'healing_touch',

--- a/src/sim/social/chat_readouts.ts
+++ b/src/sim/social/chat_readouts.ts
@@ -12,6 +12,7 @@
 
 import { isDebuffAura } from '../aura_classify';
 import { isRooted } from '../combat/cc';
+import { baseSwingSpeed, rangedAutoProfile } from '../combat/form_swing';
 import {
   FIRST_TALENT_LEVEL,
   pointsSpent,
@@ -263,8 +264,9 @@ export function attackReadout(ctx: SimContext, p: Entity, meta: PlayerMeta): str
   const t = p.targetId !== null ? ctx.entities.get(p.targetId) : null;
   if (!t || t.dead) return 'Auto-attack is on, but you have no valid target.';
   // ranged classes (hunter auto shot, caster wands) swing at their ranged
-  // speed; everyone else uses the equipped weapon's speed
-  const base = CLASSES[meta.cls].ranged?.speed ?? p.weapon.speed;
+  // speed; everyone else, including a druid shifted into a wandless form,
+  // uses the form-aware melee cadence (bear: weapon, cat: claw baseline)
+  const base = rangedAutoProfile(p, meta.cls)?.speed ?? baseSwingSpeed(p);
   const interval = base * ctx.swingIntervalMult(p);
   const next = p.swingTimer <= 0 ? 'now' : `in ${p.swingTimer.toFixed(1)}s`;
   return `Auto-attack is on against ${t.name} — next swing ${next} (${interval.toFixed(1)}s swing).`;

--- a/src/sim/social/fiesta_bots.ts
+++ b/src/sim/social/fiesta_bots.ts
@@ -18,6 +18,7 @@
 // power-up draws use the per-match stream in fiesta.ts. Import-isolated (no DOM /
 // Three, rng-only) so tests/architecture.test.ts still passes.
 
+import { rangedAutoProfile } from '../combat/form_swing';
 import { arenaOrigin, CLASSES, DUNGEON_X_THRESHOLD } from '../data';
 import type { PlayerMeta, Sim } from '../sim';
 import {
@@ -147,7 +148,9 @@ function driveFiestaBot(sim: Sim, pid: number): void {
   if (!target) return;
 
   e.facing = steadyAngleTo(e.pos, target.pos, e.facing);
-  const engageRange = CLASSES[meta.cls].ranged ? 22 : MELEE_RANGE * 0.9;
+  // Form-aware (rangedAutoProfile): bots never shapeshift today, but if one
+  // ever does, a wandless form correctly collapses its standoff to melee.
+  const engageRange = rangedAutoProfile(e, meta.cls) ? 22 : MELEE_RANGE * 0.9;
   if (best > engageRange) meta.moveInput.forward = true;
   e.targetId = target.id;
   if (!e.autoAttack) sim.startAutoAttack(pid);

--- a/tests/druid_wand.test.ts
+++ b/tests/druid_wand.test.ts
@@ -86,6 +86,19 @@ describe('druid wand: caster and Moonwing form fire the class wand at range', ()
     expect(CLASSES.druid.ranged?.speed).toBe(1.8);
   });
 
+  it('a caster-form druid wands even at point-blank range, like the other casters', () => {
+    // Wand profiles have no dead zone (#94), so a caster druid never melee
+    // white-hits; in-reach auto-attacks still fire the bolt, exactly like a
+    // mage. (tests/form_swing.test.ts moved its staff-cadence control to bear
+    // form for this reason.)
+    const { sim, p } = makeSim();
+    const mob = spawnDummy(sim, p, 2);
+    const events = capture(sim);
+    (sim as any).startAutoAttack(p.id);
+    for (let i = 0; i < 60 && !events.some(isWandBolt); i++) sim.tick();
+    expect(events.some(isWandBolt)).toBe(true);
+  });
+
   it('a Moonwing-form druid keeps the wand', () => {
     const { sim, p } = makeSim();
     enterMoonwing(sim, p);

--- a/tests/druid_wand.test.ts
+++ b/tests/druid_wand.test.ts
@@ -1,0 +1,168 @@
+// Druid class wand (the caster-form ranged basic attack): in caster form and
+// Moonwing Form (`form_moonkin`) the druid auto-attacks at range with the same
+// fixed class wand the mage/priest/warlock carry (nature school); shifted into
+// bear, cat, or travel form the wand is unavailable and auto-attack falls back
+// to the form's melee swing. The form gate is the pure
+// combat/form_swing.rangedAutoProfile resolver, consumed by
+// updatePlayerAutoAttack and the /attack readout.
+
+import { describe, expect, it } from 'vitest';
+import { rangedAutoProfile, wandAllowedInForm } from '../src/sim/combat/form_swing';
+import { CLASSES, MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import { Sim } from '../src/sim/sim';
+import type { AuraKind, Entity, PlayerClass } from '../src/sim/types';
+import { MELEE_RANGE } from '../src/sim/types';
+
+type AnySim = Sim & Record<string, any>;
+type AnyEntity = Entity & Record<string, any>;
+type Ev = Record<string, any>;
+
+function makeSim(seed = 7): { sim: AnySim; p: AnyEntity } {
+  const sim = new Sim({ seed, playerClass: 'druid', autoEquip: true }) as AnySim;
+  sim.setPlayerLevel(20);
+  const p = sim.player as AnyEntity;
+  p.resource = p.maxResource;
+  return { sim, p };
+}
+
+// An idle hostile mob, beefed, in front of the player at distance dz, targeted + faced.
+function spawnDummy(sim: AnySim, p: AnyEntity, dz: number): AnyEntity {
+  const mob = createMob(sim.nextId++, MOBS['forest_wolf'], 5, {
+    x: p.pos.x,
+    y: p.pos.y,
+    z: p.pos.z + dz,
+  }) as AnyEntity;
+  mob.maxHp = 500000;
+  mob.hp = 500000;
+  mob.hostile = true;
+  mob.aiState = 'idle';
+  sim.addEntity(mob);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  sim.targetEntity(mob.id, p.id);
+  return mob;
+}
+
+function capture(sim: AnySim): Ev[] {
+  const events: Ev[] = [];
+  const orig = (sim as any).emit.bind(sim);
+  (sim as any).emit = (e: Ev) => {
+    events.push(e);
+    orig(e);
+  };
+  return events;
+}
+
+const isWandBolt = (e: Ev) => e.type === 'spellfx' && e.fx === 'projectile' && e.wand === true;
+
+// Enter Moonwing Form directly via the aura (the ability is a Balance spec
+// signature; the form gate reads the aura kind, not how it was granted).
+function enterMoonwing(sim: AnySim, p: AnyEntity): void {
+  (sim as any).applyAura(p, {
+    id: 'moonkin_form',
+    name: 'Moonwing Form',
+    kind: 'form_moonkin' as AuraKind,
+    remaining: 3600,
+    duration: 3600,
+    value: 0,
+    sourceId: p.id,
+    school: 'arcane' as const,
+  });
+}
+
+describe('druid wand: caster and Moonwing form fire the class wand at range', () => {
+  it('a caster-form druid auto-attacks a 25yd target with a nature wand bolt', () => {
+    const { sim, p } = makeSim();
+    const mob = spawnDummy(sim, p, 25);
+    const events = capture(sim);
+    (sim as any).startAutoAttack(p.id);
+    const hp0 = mob.hp;
+    for (let i = 0; i < 60 && mob.hp === hp0; i++) sim.tick();
+    const bolt = events.find(isWandBolt);
+    expect(bolt).toBeTruthy();
+    expect(bolt?.school).toBe('nature');
+    expect(mob.hp).toBeLessThan(hp0); // the bolt landed
+    // The cadence is the class wand's, not the equipped staff's.
+    expect(CLASSES.druid.ranged?.speed).toBe(1.8);
+  });
+
+  it('a Moonwing-form druid keeps the wand', () => {
+    const { sim, p } = makeSim();
+    enterMoonwing(sim, p);
+    const mob = spawnDummy(sim, p, 25);
+    const events = capture(sim);
+    (sim as any).startAutoAttack(p.id);
+    for (let i = 0; i < 60 && !events.some(isWandBolt); i++) sim.tick();
+    expect(events.some(isWandBolt)).toBe(true);
+  });
+});
+
+describe('druid wand: melee and travel shapeshifts cannot fire it', () => {
+  const shiftedHasNoWand = (formAbility: string) => {
+    const { sim, p } = makeSim();
+    sim.castAbility(formAbility);
+    sim.tick();
+    const mob = spawnDummy(sim, p, 25);
+    const events = capture(sim);
+    (sim as any).startAutoAttack(p.id);
+    for (let i = 0; i < 60; i++) sim.tick();
+    expect(events.some(isWandBolt)).toBe(false);
+    return { sim, p, mob };
+  };
+
+  it('cat form never fires a bolt at range, and still melees in reach', () => {
+    const { sim, p, mob } = shiftedHasNoWand('cat_form');
+    // Walk the same mob into melee reach: the form swings claws instead.
+    mob.pos = { x: p.pos.x, y: p.pos.y, z: p.pos.z + MELEE_RANGE * 0.5 };
+    mob.prevPos = { ...mob.pos };
+    (sim as any).rebucket(mob);
+    const events = capture(sim);
+    const hp0 = mob.hp;
+    for (let i = 0; i < 60 && mob.hp === hp0; i++) sim.tick();
+    expect(mob.hp).toBeLessThan(hp0);
+    expect(events.some(isWandBolt)).toBe(false);
+    expect(
+      events.some((e) => e.type === 'damage' && e.school === 'physical' && e.sourceId === p.id),
+    ).toBe(true);
+  });
+
+  it('bear form never fires a bolt at range', () => {
+    shiftedHasNoWand('bear_form');
+  });
+
+  it('travel form never fires a bolt at range', () => {
+    shiftedHasNoWand('travel_form');
+  });
+});
+
+describe('rangedAutoProfile (the pure form gate)', () => {
+  const fakeEntity = (kinds: string[]): Entity =>
+    ({ auras: kinds.map((kind) => ({ kind })) }) as unknown as Entity;
+
+  it('blocks the wand in exactly the bear, cat, and travel forms', () => {
+    expect(wandAllowedInForm(fakeEntity([]))).toBe(true);
+    expect(wandAllowedInForm(fakeEntity(['form_moonkin']))).toBe(true);
+    expect(wandAllowedInForm(fakeEntity(['form_bear']))).toBe(false);
+    expect(wandAllowedInForm(fakeEntity(['form_cat']))).toBe(false);
+    expect(wandAllowedInForm(fakeEntity(['form_travel']))).toBe(false);
+  });
+
+  it('resolves the druid profile in caster or Moonwing form, undefined when shifted', () => {
+    expect(rangedAutoProfile(fakeEntity([]), 'druid')).toBe(CLASSES.druid.ranged);
+    expect(rangedAutoProfile(fakeEntity(['form_moonkin']), 'druid')).toBe(CLASSES.druid.ranged);
+    expect(rangedAutoProfile(fakeEntity(['form_cat']), 'druid')).toBeUndefined();
+    expect(rangedAutoProfile(fakeEntity(['form_bear']), 'druid')).toBeUndefined();
+  });
+
+  it('never gates the other wand carriers or the hunter Auto Shot', () => {
+    // Shadowform priests and metamorphosed warlocks keep their wands; the
+    // hunter's Auto Shot is not a wand, so no form can gate it.
+    expect(rangedAutoProfile(fakeEntity(['form_shadow']), 'priest')).toBe(CLASSES.priest.ranged);
+    expect(rangedAutoProfile(fakeEntity(['form_metamorph']), 'warlock')).toBe(
+      CLASSES.warlock.ranged,
+    );
+    expect(rangedAutoProfile(fakeEntity(['form_bear']), 'hunter')).toBe(CLASSES.hunter.ranged);
+    const meleeClasses: PlayerClass[] = ['warrior', 'rogue', 'paladin', 'shaman'];
+    for (const cls of meleeClasses) expect(rangedAutoProfile(fakeEntity([]), cls)).toBeUndefined();
+  });
+});

--- a/tests/form_swing.test.ts
+++ b/tests/form_swing.test.ts
@@ -111,14 +111,19 @@ describe('Wolf Form swing speed', () => {
     giveForm(sim, a, 'form_cat', 'Wolf Form');
     const wolf = firstWhiteHit(sim, a);
 
-    // A control druid on the same staff but NOT in form: AP normalized by the slow staff.
+    // The control druid on the same staff in BEAR form: a melee shapeshift that
+    // keeps the weapon cadence, so its AP is normalized by the slow staff. (It
+    // used to be an un-shifted druid, but a caster-form druid now auto-attacks
+    // with the class wand at any range, wand-style, so it never lands a melee
+    // white hit; bear form preserves the staff-speed control this test needs.)
     const sim2 = makeWorld();
-    const b = sim2.addPlayer('druid', 'Caster');
+    const b = sim2.addPlayer('druid', 'Bruin');
     sim2.setPlayerLevel(20, b);
     sim2.tick();
+    giveForm(sim2, b, 'form_bear', 'Bear Form');
     const staff = firstWhiteHit(sim2, b);
 
-    // Wolf Form's per-swing AP uses the rogue speed (1.8); the staff druid's the staff.
+    // Wolf Form's per-swing AP uses the rogue speed (1.8); the bear druid's the staff.
     expect(wolf.amount).toBe(expectAt(wolf.ap, ROGUE_BASE_SWING_SPEED, wolf.dr));
     expect(staff.amount).toBe(expectAt(staff.ap, staffSpeed, staff.dr));
     // The bug would have been Wolf Form normalizing by the slow staff instead: prove


### PR DESCRIPTION
## Summary

Gives druids a wand-style ranged basic attack, matching the mage/priest/warlock casters:

- **Caster form:** the druid class kit now carries the same fixed class wand the other casters have (`min 3, max 6, speed 1.8, 30yd, no dead zone`), in the druid's nature school. Any damaging engage auto-attacks at range exactly like a mage, including point-blank (wands have no dead zone, #94), and the "Attack on Ability Use" QoL works unchanged.
- **Moonwing Form (`form_moonkin`):** keeps the wand, so a Balance druid auto-attacks at range in form.
- **Bear, cat, and travel forms:** the wand is unavailable (a shapeshift fighting with claws cannot hold it); auto-attack falls back to the form's melee swing at its real cadence.

The form gate is a new pure resolver in the existing form-aware combat leaf: `combat/form_swing.rangedAutoProfile` (with `wandAllowedInForm`), consumed by the auto-attack swing loop and the `/attack` readout. It is a deliberate blocklist of the three druid melee/travel forms, so the priest's shadowform and the warlock's metamorphosis keep their existing wand behavior, and the hunter's Auto Shot (not a wand) is never gated.

One test adaptation: `tests/form_swing.test.ts`'s staff-cadence control druid moved from caster form to bear form, because a caster-form druid now never lands a melee white hit (it wands, like a mage). The new `tests/druid_wand.test.ts` pins that interaction explicitly.

## Type of change

- [x] Feature: new functionality

## How was this tested?

- Commands:
  - `npx vitest run tests/druid_wand.test.ts` (new suite, 9 tests: caster-form nature bolt fires and lands at 25yd, point-blank wand like the other casters, Moonwing keeps it, bear/cat/travel never fire it and cat still claws in reach, plus the pure resolver matrix incl. shadowform/metamorph/hunter non-gating)
  - `npx vitest run tests/form_swing.test.ts tests/combat_auto_attack.test.ts tests/threat.test.ts tests/chat.test.ts tests/progression.test.ts tests/architecture.test.ts tests/guide.test.ts tests/fiesta.test.ts tests/sim.test.ts tests/parity` (all green; parity needed NO golden regen, the wand only fires when a druid engages ranged auto-attack, which no golden covers)
  - `npm run gate`: the only failure is `tests/deploy_watchdog.test.ts`, which fails identically on an untouched checkout on this machine (environmental, pre-existing).
- Manual steps: none required (sim-only behavior; the wand bolt reuses the existing wand projectile event/VFX path shared with mage/priest/warlock).

## Checklist

### Quality

- [x] **The full gate passes** modulo the pre-existing environmental failure above. Decisive tests added for every changed behavior.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A (no UI change; the sim behavior is identical on all three hosts by construction, and the wand bolt renders through the existing shared projectile path).

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (the wand reuses the existing Wand label and projectile events; guide content regen produced no diff).

### Hygiene

- [x] No secrets, credentials, or `.env` committed; `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated files hand-edited.


**Side effect worth knowing:** `fiesta_bots.ts` keys its engage posture on `CLASSES[cls].ranged`, so a druid fiesta bot now holds the 22yd caster standoff instead of walking to melee. Verified benign: fiesta bots never shapeshift (forms are self-buffs a bot never picks), so a bot is never stranded at range without the wand, and the fiesta suite stays green.
