### PR TITLE
fix(ui): merge reconnecting party member's combat-meter row

### DIFF
--- a/src/ui/meters.ts
+++ b/src/ui/meters.ts
@@ -68,15 +68,26 @@ export class MeterData {
     this.allTime = { ...newEncounter(now), label: 'All (session)' };
   }
 
-  private tally(enc: Encounter, pid: number, name: string, cls: string | null): MemberTally {
+  private tally(
+    enc: Encounter,
+    pid: number,
+    name: string,
+    cls: string | null,
+    partyPids: Set<number>,
+  ): MemberTally {
     let t = enc.tallies.get(pid);
     if (t) return t;
     // a reconnect issues the same character a new entity id mid-encounter; find
     // its previous row by name and re-key it instead of starting a duplicate.
+    // Only treat a name match as a reconnect when the old pid is no longer a
+    // live party member: pet names come from their template/tamed-target name
+    // and are not unique, so two live same-named pets must stay separate
+    // rows instead of ping-ponging the merge back and forth.
     for (const [oldPid, existing] of enc.tallies) {
-      if (existing.name === name && oldPid !== pid) {
+      if (existing.name === name && oldPid !== pid && !partyPids.has(oldPid)) {
         enc.tallies.delete(oldPid);
         existing.pid = pid;
+        existing.cls = cls ?? existing.cls;
         enc.tallies.set(pid, existing);
         return existing;
       }
@@ -107,7 +118,7 @@ export class MeterData {
         const cls =
           member?.cls ?? (ev.sourceId === world.player.id ? world.player.templateId : null);
         for (const enc of [this.current, this.allTime]) {
-          const t = this.tally(enc, ev.sourceId, name, cls);
+          const t = this.tally(enc, ev.sourceId, name, cls, partyPids);
           t.dmg += ev.amount;
           if (enc === this.current) {
             t.dmgByMob.set(ev.targetId, (t.dmgByMob.get(ev.targetId) ?? 0) + ev.amount);
@@ -128,7 +139,7 @@ export class MeterData {
       const name = member?.name ?? src?.name ?? `#${ev.sourceId}`;
       const cls = member?.cls ?? (ev.sourceId === world.player.id ? world.player.templateId : null);
       for (const enc of [this.current, this.allTime]) {
-        this.tally(enc, ev.sourceId, name, cls).heal += ev.amount;
+        this.tally(enc, ev.sourceId, name, cls, partyPids).heal += ev.amount;
       }
     }
   }

--- a/src/ui/meters.ts
+++ b/src/ui/meters.ts
@@ -70,10 +70,19 @@ export class MeterData {
 
   private tally(enc: Encounter, pid: number, name: string, cls: string | null): MemberTally {
     let t = enc.tallies.get(pid);
-    if (!t) {
-      t = { pid, name, cls, dmg: 0, heal: 0, dmgByMob: new Map() };
-      enc.tallies.set(pid, t);
+    if (t) return t;
+    // a reconnect issues the same character a new entity id mid-encounter; find
+    // its previous row by name and re-key it instead of starting a duplicate.
+    for (const [oldPid, existing] of enc.tallies) {
+      if (existing.name === name && oldPid !== pid) {
+        enc.tallies.delete(oldPid);
+        existing.pid = pid;
+        enc.tallies.set(pid, existing);
+        return existing;
+      }
     }
+    t = { pid, name, cls, dmg: 0, heal: 0, dmgByMob: new Map() };
+    enc.tallies.set(pid, t);
     return t;
   }
 

--- a/tests/meters.test.ts
+++ b/tests/meters.test.ts
@@ -139,4 +139,27 @@ describe('combat meters', () => {
     expect(m.current!.tallies.get(3)!.name).toBe('Wolf Pet');
     expect(m.current!.tallies.get(3)!.dmg).toBe(18);
   });
+
+  it('merges a reconnecting party member into one row instead of duplicating them under their new pid', () => {
+    const w = fakeWorld();
+    const party = new Set([1, 2]);
+    const m = new MeterData(0);
+    // "Pal" deals damage under their original pid (2)...
+    m.onEvent(dmg(2, 50, 20), w, party, 1000);
+    // ...then relogs: the server issues a new entity id (3) for the same
+    // character, still named "Pal", and the HUD's party-pid set now includes it.
+    (w.entities as Map<number, any>).set(3, {
+      id: 3,
+      kind: 'player',
+      name: 'Pal',
+      templateId: 'priest',
+    });
+    (w.partyInfo as any).members = [{ pid: 3, name: 'Pal', cls: 'priest', group: 1 }];
+    const party2 = new Set([1, 3]);
+    m.onEvent(dmg(3, 50, 30), w, party2, 2000);
+    expect(m.current!.tallies.size).toBe(1); // one merged "Pal" row, not two
+    const palRows = [...m.current!.tallies.values()].filter((t) => t.name === 'Pal');
+    expect(palRows.length).toBe(1);
+    expect(palRows[0].dmg).toBe(50);
+  });
 });

--- a/tests/meters.test.ts
+++ b/tests/meters.test.ts
@@ -162,4 +162,34 @@ describe('combat meters', () => {
     expect(palRows.length).toBe(1);
     expect(palRows[0].dmg).toBe(50);
   });
+
+  it('keeps two live same-named pets in separate rows instead of merging them by name', () => {
+    const w = fakeWorld();
+    // two warlocks running the same demon template both have a pet named
+    // "Imp" (createDemonPet sets pet.name = template.name), each with its
+    // own live pid. Both stay in the party set the whole time, so this must
+    // never look like a reconnect.
+    (w.entities as Map<number, any>).set(10, {
+      id: 10,
+      kind: 'mob',
+      name: 'Imp',
+      templateId: 'imp',
+      ownerId: 1,
+    });
+    (w.entities as Map<number, any>).set(11, {
+      id: 11,
+      kind: 'mob',
+      name: 'Imp',
+      templateId: 'imp',
+      ownerId: 2,
+    });
+    const party = new Set([1, 2, 10, 11]);
+    const m = new MeterData(0);
+    m.onEvent(dmg(10, 50, 20), w, party, 1000);
+    m.onEvent(dmg(11, 50, 30), w, party, 1500);
+    m.onEvent(dmg(10, 50, 5), w, party, 2000);
+    expect(m.current!.tallies.size).toBe(2);
+    expect(m.current!.tallies.get(10)!.dmg).toBe(25);
+    expect(m.current!.tallies.get(11)!.dmg).toBe(30);
+  });
 });


### PR DESCRIPTION
## Summary

The Dmg/Heal/Threat combat meter (`src/ui/meters.ts`) keys each row by the numeric
source entity id (`ev.sourceId`) of the damage/heal event, not by a stable
character/account identity. When a party member relogs mid-encounter, the server
issues their character a new entity id, so the meter kept the stale-id row and
started a brand-new one under the new id for the same player: the same caster
showed up twice, with their total damage/healing split across two bars instead
of one.

`MeterData.tally()` now checks for an existing row with the same display name
under a different pid before allocating a new one, and re-keys that row onto the
current pid instead of creating a duplicate, so a reconnecting caster keeps a
single running total across the encounter and the session ("All") segment.

### Before: duplicate row on reconnect

```mermaid
sequenceDiagram
    participant Server
    participant Meters as MeterData.tally()
    participant Panel as Meters panel

    Server->>Meters: damage event, sourceId=2, name="Pal"
    Meters->>Meters: tallies.get(2) -> new row {pid:2, name:"Pal", dmg:20}
    Panel->>Panel: renders row "Pal" 20 dmg

    Note over Server: Pal disconnects and relogs<br/>server assigns a new entity id (3)

    Server->>Meters: damage event, sourceId=3, name="Pal"
    Meters->>Meters: tallies.get(3) -> MISS, creates new row {pid:3, name:"Pal", dmg:30}
    Panel->>Panel: renders TWO rows: "Pal" 20 dmg AND "Pal" 30 dmg
```

### After: reconnect merges into the existing row

```mermaid
sequenceDiagram
    participant Server
    participant Meters as MeterData.tally()
    participant Panel as Meters panel

    Server->>Meters: damage event, sourceId=2, name="Pal"
    Meters->>Meters: tallies.get(2) -> new row {pid:2, name:"Pal", dmg:20}
    Panel->>Panel: renders row "Pal" 20 dmg

    Note over Server: Pal disconnects and relogs<br/>server assigns a new entity id (3)

    Server->>Meters: damage event, sourceId=3, name="Pal"
    Meters->>Meters: tallies.get(3) -> MISS
    Meters->>Meters: scan rows for name="Pal" under a different pid -> found (pid 2)
    Meters->>Meters: re-key row 2 -> 3, keep accumulated dmg, add 30
    Panel->>Panel: renders ONE row: "Pal" 50 dmg
```

## Related issues

N/A (reported via screenshot, filing this PR directly per the reporter's request).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/meters.test.ts`
  - `npx tsc --noEmit -p .`
  - `npm run gate` (full CI-equivalent gate; two pre-existing failures unrelated
    to this change: `tests/deeds_window_focus.test.ts` (missing `localStorage`
    global in that test's env, reproduces identically on a clean
    `release/v0.27.0` checkout) and a `tests/server/http/parity.test.ts` timing
    flake)
- Manual steps: added a new unit test reproducing the exact reconnect scenario
  (same display name, damage split across two `sourceId`s within one encounter)
  and confirmed it fails without the fix and passes with it.

## Screenshots / recordings

No DOM/CSS change: the meter's rendering and layout are unchanged. This is a
pure aggregation-key fix in the data model behind the panel, reproducible only
via a live multiplayer reconnect (a fresh server-assigned entity id issued to
the same character mid-encounter), which isn't practical to capture as a static
screenshot. Covered instead by the new `tests/meters.test.ts` case:
"merges a reconnecting party member into one row instead of duplicating them
under their new pid", and by the sequence diagrams above.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green modulo the two
      pre-existing, unrelated failures noted above. Added a decisive regression
      test for the fixed behavior.

### Cross-platform

- [x] N/A — no DOM/CSS/layout change; the fix is internal to `MeterData.tally()`.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed; `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated files hand-edited.
