### PR TITLE
fix(daily-rewards): exclude 1v1 matches from rewards

### DIFF
--- a/server/daily_rewards.ts
+++ b/server/daily_rewards.ts
@@ -776,10 +776,10 @@ export class DailyRewardService {
       completedAt?: Date;
     },
   ): Promise<number> {
-    // Protect Yumi (yumi3/yumi5) is an unranked objective mode: its bouts do
-    // not count toward the arena daily-reward task (maintainer decision;
-    // fiesta keeps its historical counting behavior).
-    if (result.format === 'yumi3' || result.format === 'yumi5') return 0;
+    // One-player teams are too easy to coordinate for daily-reward scoring.
+    // Protect Yumi (yumi3/yumi5) is also an unranked objective mode. Fiesta
+    // keeps its historical counting behavior.
+    if (result.format === '1v1' || result.format === 'yumi3' || result.format === 'yumi5') return 0;
     const completedAt = result.completedAt ?? new Date();
     const { day, config } = await dailyRewardClock(completedAt);
     await this.db.ensureDay(day, config.prizePoolUsd, config.wocUsdPrice);
@@ -932,6 +932,7 @@ export class DailyRewardService {
       completedAt: Date;
     },
   ): Promise<number> {
+    if (result.bracket === 1) return 0;
     if (!result.won) return 0;
     if (result.rated === false && result.hasBots !== true && result.practice !== true) return 0;
     const completedAt = result.completedAt;

--- a/src/ui/daily_rewards_view.ts
+++ b/src/ui/daily_rewards_view.ts
@@ -16,6 +16,16 @@ export type DailyRewardsInput =
   | { kind: 'error'; message: string }
   | { kind: 'status'; status: DailyRewardStatus; history: DailyRewardHistory };
 
+export function dailyRewardTaskDescription(
+  type: string,
+  description: string,
+  oneVsOneRestriction: string,
+): string {
+  return type === 'arena_result' || type === 'vale_cup_result'
+    ? `${description} ${oneVsOneRestriction}`
+    : description;
+}
+
 export function buildDailyRewardsView(input: DailyRewardsInput): DailyRewardsView {
   if (input.kind === 'loading') return { kind: 'loading' };
   if (input.kind === 'error') return { kind: 'error', message: input.message };

--- a/src/ui/daily_rewards_window.ts
+++ b/src/ui/daily_rewards_window.ts
@@ -8,7 +8,11 @@ import {
   weaponSkinCollectionLabel,
   weaponTypeLabel,
 } from './armory_labels';
-import { buildDailyRewardsView, type DailyRewardsView } from './daily_rewards_view';
+import {
+  buildDailyRewardsView,
+  type DailyRewardsView,
+  dailyRewardTaskDescription,
+} from './daily_rewards_view';
 import { markDialogRoot } from './dialog_root';
 import { tEntity } from './entity_i18n';
 import { esc } from './esc';
@@ -834,7 +838,12 @@ export class DailyRewardsWindow {
           typeof task.multiplier === 'number' && Number.isFinite(task.multiplier)
             ? `<em>${esc(t('hudChrome.dailyRewards.taskMultiplier', { multiplier: formatNumber(task.multiplier, { maximumFractionDigits: 2 }) }))}</em>`
             : '';
-        return `<li class="${task.completed ? 'done' : ''}"><span>${esc(task.title)}</span><small><span>${esc(task.description)}</span>${multiplier}</small><b>${formatNumber(task.points, { maximumFractionDigits: 0 })}</b></li>`;
+        const description = dailyRewardTaskDescription(
+          task.type,
+          task.description,
+          t('hudChrome.dailyRewards.oneVsOneExcluded'),
+        );
+        return `<li class="${task.completed ? 'done' : ''}"><span>${esc(task.title)}</span><small><span>${esc(description)}</span>${multiplier}</small><b>${formatNumber(task.points, { maximumFractionDigits: 0 })}</b></li>`;
       })
       .join('');
     return (

--- a/src/ui/i18n.catalog/hud_chrome.ts
+++ b/src/ui/i18n.catalog/hud_chrome.ts
@@ -86,6 +86,7 @@ export const hudChromeStrings = {
     spinButton: 'Spin',
     tasks: 'Tasks',
     taskMultiplier: 'x{multiplier} multiplier',
+    oneVsOneExcluded: '1v1 matches do not grant daily reward points.',
     pointsGained: '{points} daily rewards points gained.',
     showChestButton: 'Show Chest',
     hideChestButton: 'Hide Chest',

--- a/src/ui/i18n.catalog/translation_keys.generated.ts
+++ b/src/ui/i18n.catalog/translation_keys.generated.ts
@@ -4574,6 +4574,7 @@ export type TranslationKeyFlat =
   | 'hudChrome.dailyRewards.loading'
   | 'hudChrome.dailyRewards.noHistory'
   | 'hudChrome.dailyRewards.noLeaders'
+  | 'hudChrome.dailyRewards.oneVsOneExcluded'
   | 'hudChrome.dailyRewards.pointsGained'
   | 'hudChrome.dailyRewards.prize'
   | 'hudChrome.dailyRewards.reason.banned'

--- a/src/ui/i18n.locales/cs_CZ.ts
+++ b/src/ui/i18n.locales/cs_CZ.ts
@@ -2953,6 +2953,7 @@ export const cs_CZ: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.spinResult': '+{points} bodů',
   'hudChrome.dailyRewards.spinTitle': 'Denní zatočení',
   'hudChrome.dailyRewards.taskMultiplier': 'násobitel x{multiplier}',
+  'hudChrome.dailyRewards.oneVsOneExcluded': 'Zápasy 1 proti 1 neudělují body denních odměn.',
   'hudChrome.dailyRewards.tasks': 'Úkoly',
   'hudChrome.dailyRewards.title': 'Denní odměny',
   'hudChrome.dailyRewards.totalPlayer': '{count} hráč dnes',

--- a/src/ui/i18n.locales/da_DK.ts
+++ b/src/ui/i18n.locales/da_DK.ts
@@ -1127,6 +1127,8 @@ export const da_DK: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.hideChestConfirmTitle': 'Skjul kisten med daglige belønninger?',
   'hudChrome.dailyRewards.pointsGained': '{points} daglige belønningspoint optjent.',
   'hudChrome.dailyRewards.taskMultiplier': 'x{multiplier} multiplikator',
+  'hudChrome.dailyRewards.oneVsOneExcluded':
+    '1 mod 1-kampe giver ikke point til daglige belønninger.',
   'hudChrome.dailyRewards.totalPlayer': '{count} spiller i dag',
   'hudChrome.dailyRewards.totalPlayers': '{count} spillere i dag',
   'hudChrome.death.resurrectAtCorpse': 'Genopstå ved liget',

--- a/src/ui/i18n.locales/de_DE.ts
+++ b/src/ui/i18n.locales/de_DE.ts
@@ -1178,6 +1178,8 @@ export const de_DE: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.hideChestConfirmTitle': 'Truhe der täglichen Belohnungen ausblenden?',
   'hudChrome.dailyRewards.pointsGained': '{points} Punkte für tägliche Belohnungen erhalten.',
   'hudChrome.dailyRewards.taskMultiplier': 'x{multiplier}-Multiplikator',
+  'hudChrome.dailyRewards.oneVsOneExcluded':
+    '1-gegen-1-Matches gewähren keine Punkte für tägliche Belohnungen.',
   'hudChrome.dailyRewards.totalPlayer': '{count} Spieler heute',
   'hudChrome.dailyRewards.totalPlayers': '{count} Spieler heute',
   'hudChrome.death.resurrectAtCorpse': 'Am Leichnam wiederbeleben',

--- a/src/ui/i18n.locales/es.ts
+++ b/src/ui/i18n.locales/es.ts
@@ -1176,6 +1176,8 @@ export const es: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.hideChestConfirmTitle': '¿Ocultar el cofre de recompensas diarias?',
   'hudChrome.dailyRewards.pointsGained': '{points} puntos de recompensas diarias obtenidos.',
   'hudChrome.dailyRewards.taskMultiplier': 'Multiplicador x{multiplier}',
+  'hudChrome.dailyRewards.oneVsOneExcluded':
+    'Las partidas 1 contra 1 no otorgan puntos de recompensas diarias.',
   'hudChrome.dailyRewards.totalPlayer': '{count} jugador hoy',
   'hudChrome.dailyRewards.totalPlayers': '{count} jugadores hoy',
   'hudChrome.death.resurrectAtCorpse': 'Resucitar en el cadáver',

--- a/src/ui/i18n.locales/fr_FR.ts
+++ b/src/ui/i18n.locales/fr_FR.ts
@@ -1542,6 +1542,8 @@ export const fr_FR: Partial<Record<TranslationKey, string>> = {
     'Masquer le coffre des récompenses quotidiennes ?',
   'hudChrome.dailyRewards.pointsGained': '{points} points de récompenses quotidiennes gagnés.',
   'hudChrome.dailyRewards.taskMultiplier': 'Multiplicateur x{multiplier}',
+  'hudChrome.dailyRewards.oneVsOneExcluded':
+    'Les matchs en 1 contre 1 ne rapportent pas de points de récompenses quotidiennes.',
   'hudChrome.dailyRewards.totalPlayer': "{count} joueur aujourd'hui",
   'hudChrome.dailyRewards.totalPlayers': "{count} joueurs aujourd'hui",
   'hudChrome.death.resurrectAtCorpse': 'Ressusciter près du cadavre',

--- a/src/ui/i18n.locales/id_ID.ts
+++ b/src/ui/i18n.locales/id_ID.ts
@@ -1207,6 +1207,8 @@ export const id_ID: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.hideChestConfirmTitle': 'Sembunyikan Peti Hadiah Harian?',
   'hudChrome.dailyRewards.pointsGained': '{points} poin hadiah harian diperoleh.',
   'hudChrome.dailyRewards.taskMultiplier': 'pengali x{multiplier}',
+  'hudChrome.dailyRewards.oneVsOneExcluded':
+    'Pertandingan 1 lawan 1 tidak memberikan poin hadiah harian.',
   'hudChrome.dailyRewards.totalPlayer': '{count} pemain hari ini',
   'hudChrome.dailyRewards.totalPlayers': '{count} pemain hari ini',
   'hudChrome.death.resurrectAtCorpse': 'Bangkit di Jasad',

--- a/src/ui/i18n.locales/it_IT.ts
+++ b/src/ui/i18n.locales/it_IT.ts
@@ -1177,6 +1177,8 @@ export const it_IT: Partial<Record<TranslationKey, string>> = {
     'Nascondere il forziere delle ricompense giornaliere?',
   'hudChrome.dailyRewards.pointsGained': '{points} punti ricompense giornaliere ottenuti.',
   'hudChrome.dailyRewards.taskMultiplier': 'Moltiplicatore x{multiplier}',
+  'hudChrome.dailyRewards.oneVsOneExcluded':
+    'Le partite 1 contro 1 non assegnano punti per le ricompense giornaliere.',
   'hudChrome.dailyRewards.totalPlayer': '{count} giocatore oggi',
   'hudChrome.dailyRewards.totalPlayers': '{count} giocatori oggi',
   'hudChrome.death.resurrectAtCorpse': 'Risorgi al cadavere',

--- a/src/ui/i18n.locales/ja_JP.ts
+++ b/src/ui/i18n.locales/ja_JP.ts
@@ -334,6 +334,7 @@ export const ja_JP: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.spinButton': 'スピン',
   'hudChrome.dailyRewards.tasks': 'タスク',
   'hudChrome.dailyRewards.taskMultiplier': '{multiplier}倍倍率',
+  'hudChrome.dailyRewards.oneVsOneExcluded': '1対1の試合ではデイリー報酬ポイントを獲得できません。',
   'hudChrome.dailyRewards.pointsGained': '{points} デイリー報酬ポイントを獲得しました。',
   'hudChrome.dailyRewards.showChestButton': '宝箱を表示',
   'hudChrome.dailyRewards.hideChestButton': '宝箱を隠す',

--- a/src/ui/i18n.locales/ko_KR.ts
+++ b/src/ui/i18n.locales/ko_KR.ts
@@ -331,6 +331,8 @@ export const ko_KR: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.spinButton': '돌리기',
   'hudChrome.dailyRewards.tasks': '과제',
   'hudChrome.dailyRewards.taskMultiplier': '{multiplier}배 배율',
+  'hudChrome.dailyRewards.oneVsOneExcluded':
+    '1대1 경기에서는 일일 보상 포인트를 획득할 수 없습니다.',
   'hudChrome.dailyRewards.pointsGained': '{points} 일일 보상 포인트를 획득했습니다.',
   'hudChrome.dailyRewards.showChestButton': '보물상자 표시',
   'hudChrome.dailyRewards.hideChestButton': '보물상자 숨기기',

--- a/src/ui/i18n.locales/nl_NL.ts
+++ b/src/ui/i18n.locales/nl_NL.ts
@@ -1155,6 +1155,8 @@ export const nl_NL: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.hideChestConfirmTitle': 'Kist met dagelijkse beloningen verbergen?',
   'hudChrome.dailyRewards.pointsGained': '{points} punten voor dagelijkse beloningen verdiend.',
   'hudChrome.dailyRewards.taskMultiplier': 'x{multiplier} vermenigvuldiger',
+  'hudChrome.dailyRewards.oneVsOneExcluded':
+    '1-tegen-1-wedstrijden leveren geen punten voor dagelijkse beloningen op.',
   'hudChrome.dailyRewards.totalPlayer': '{count} speler vandaag',
   'hudChrome.dailyRewards.totalPlayers': '{count} spelers vandaag',
   'hudChrome.death.resurrectAtCorpse': 'Herrijs bij je lijk',

--- a/src/ui/i18n.locales/pl_PL.ts
+++ b/src/ui/i18n.locales/pl_PL.ts
@@ -1143,6 +1143,8 @@ export const pl_PL: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.hideChestConfirmTitle': 'Ukryć skrzynię codziennych nagród?',
   'hudChrome.dailyRewards.pointsGained': 'Zdobyto {points} pkt. codziennych nagród.',
   'hudChrome.dailyRewards.taskMultiplier': 'mnożnik x{multiplier}',
+  'hudChrome.dailyRewards.oneVsOneExcluded':
+    'Mecze 1 na 1 nie przyznają punktów codziennych nagród.',
   'hudChrome.dailyRewards.totalPlayer': '{count} gracz dzisiaj',
   'hudChrome.dailyRewards.totalPlayers': '{count} graczy dzisiaj',
   'hudChrome.death.resurrectAtCorpse': 'Odrodź się przy zwłokach',

--- a/src/ui/i18n.locales/pt_BR.ts
+++ b/src/ui/i18n.locales/pt_BR.ts
@@ -1166,6 +1166,8 @@ export const pt_BR: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.hideChestConfirmTitle': 'Ocultar o Baú de Recompensas Diárias?',
   'hudChrome.dailyRewards.pointsGained': '{points} pontos de recompensas diárias ganhos.',
   'hudChrome.dailyRewards.taskMultiplier': 'Multiplicador x{multiplier}',
+  'hudChrome.dailyRewards.oneVsOneExcluded':
+    'Partidas 1 contra 1 não concedem pontos de recompensas diárias.',
   'hudChrome.dailyRewards.totalPlayer': '{count} jogador hoje',
   'hudChrome.dailyRewards.totalPlayers': '{count} jogadores hoje',
   'hudChrome.death.resurrectAtCorpse': 'Ressuscitar no Cadáver',

--- a/src/ui/i18n.locales/ru_RU.ts
+++ b/src/ui/i18n.locales/ru_RU.ts
@@ -333,6 +333,7 @@ export const ru_RU: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.spinButton': 'Крутить',
   'hudChrome.dailyRewards.tasks': 'Задания',
   'hudChrome.dailyRewards.taskMultiplier': 'Множитель x{multiplier}',
+  'hudChrome.dailyRewards.oneVsOneExcluded': 'Матчи 1 на 1 не приносят очки ежедневных наград.',
   'hudChrome.dailyRewards.pointsGained': 'Получено {points} очков ежедневных наград.',
   'hudChrome.dailyRewards.showChestButton': 'Показать сундук',
   'hudChrome.dailyRewards.hideChestButton': 'Скрыть сундук',

--- a/src/ui/i18n.locales/sv_SE.ts
+++ b/src/ui/i18n.locales/sv_SE.ts
@@ -1134,6 +1134,8 @@ export const sv_SE: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.hideChestConfirmTitle': 'Dölj kistan för dagliga belöningar?',
   'hudChrome.dailyRewards.pointsGained': '{points} poäng för dagliga belöningar intjänade.',
   'hudChrome.dailyRewards.taskMultiplier': 'x{multiplier} multiplikator',
+  'hudChrome.dailyRewards.oneVsOneExcluded':
+    '1 mot 1-matcher ger inga poäng för dagliga belöningar.',
   'hudChrome.dailyRewards.totalPlayer': '{count} spelare i dag',
   'hudChrome.dailyRewards.totalPlayers': '{count} spelare i dag',
   'hudChrome.death.resurrectAtCorpse': 'Återuppstå vid liket',

--- a/src/ui/i18n.locales/tr_TR.ts
+++ b/src/ui/i18n.locales/tr_TR.ts
@@ -1197,6 +1197,7 @@ export const tr_TR: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.hideChestConfirmTitle': 'Günlük Ödül Sandığı gizlensin mi?',
   'hudChrome.dailyRewards.pointsGained': '{points} günlük ödül puanı kazanıldı.',
   'hudChrome.dailyRewards.taskMultiplier': 'x{multiplier} çarpan',
+  'hudChrome.dailyRewards.oneVsOneExcluded': "1'e 1 maçlar günlük ödül puanı kazandırmaz.",
   'hudChrome.dailyRewards.totalPlayer': 'Bugün {count} oyuncu',
   'hudChrome.dailyRewards.totalPlayers': 'Bugün {count} oyuncu',
   'hudChrome.death.resurrectAtCorpse': 'Cesedinin Başında Diril',

--- a/src/ui/i18n.locales/vi_VN.ts
+++ b/src/ui/i18n.locales/vi_VN.ts
@@ -1196,6 +1196,7 @@ export const vi_VN: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.hideChestConfirmTitle': 'Ẩn Rương Phần Thưởng Hằng Ngày?',
   'hudChrome.dailyRewards.pointsGained': 'Nhận được {points} điểm phần thưởng hằng ngày.',
   'hudChrome.dailyRewards.taskMultiplier': 'hệ số x{multiplier}',
+  'hudChrome.dailyRewards.oneVsOneExcluded': 'Trận đấu 1v1 không trao điểm phần thưởng hằng ngày.',
   'hudChrome.dailyRewards.totalPlayer': '{count} người chơi hôm nay',
   'hudChrome.dailyRewards.totalPlayers': '{count} người chơi hôm nay',
   'hudChrome.death.resurrectAtCorpse': 'Hồi Sinh Tại Xác Chết',

--- a/src/ui/i18n.locales/zh_CN.ts
+++ b/src/ui/i18n.locales/zh_CN.ts
@@ -325,6 +325,7 @@ export const zh_CN: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.spinButton': '转动',
   'hudChrome.dailyRewards.tasks': '任务',
   'hudChrome.dailyRewards.taskMultiplier': '{multiplier}倍倍率',
+  'hudChrome.dailyRewards.oneVsOneExcluded': '1对1比赛不会获得每日奖励积分。',
   'hudChrome.dailyRewards.pointsGained': '已获得 {points} 每日奖励积分。',
   'hudChrome.dailyRewards.showChestButton': '显示宝箱',
   'hudChrome.dailyRewards.hideChestButton': '隐藏宝箱',

--- a/src/ui/i18n.locales/zh_TW.ts
+++ b/src/ui/i18n.locales/zh_TW.ts
@@ -325,6 +325,7 @@ export const zh_TW: Partial<Record<TranslationKey, string>> = {
   'hudChrome.dailyRewards.spinButton': '轉動',
   'hudChrome.dailyRewards.tasks': '任務',
   'hudChrome.dailyRewards.taskMultiplier': '{multiplier}倍倍率',
+  'hudChrome.dailyRewards.oneVsOneExcluded': '1對1比賽不會獲得每日獎勵點數。',
   'hudChrome.dailyRewards.pointsGained': '已獲得 {points} 每日獎勵點數。',
   'hudChrome.dailyRewards.showChestButton': '顯示寶箱',
   'hudChrome.dailyRewards.hideChestButton': '隱藏寶箱',

--- a/src/ui/i18n.resolved.generated/cs_CZ.ts
+++ b/src/ui/i18n.resolved.generated/cs_CZ.ts
@@ -366,6 +366,7 @@ export const cs_CZ: EnTranslations = {
       "spinButton": "Zatočit",
       "tasks": "Úkoly",
       "taskMultiplier": "násobitel x{multiplier}",
+      "oneVsOneExcluded": "Zápasy 1 proti 1 neudělují body denních odměn.",
       "pointsGained": "Získáno {points} bodů denních odměn.",
       "showChestButton": "Zobrazit truhlu",
       "hideChestButton": "Skrýt truhlu",

--- a/src/ui/i18n.resolved.generated/da_DK.ts
+++ b/src/ui/i18n.resolved.generated/da_DK.ts
@@ -366,6 +366,7 @@ export const da_DK: EnTranslations = {
       "spinButton": "Drej",
       "tasks": "Opgaver",
       "taskMultiplier": "x{multiplier} multiplikator",
+      "oneVsOneExcluded": "1 mod 1-kampe giver ikke point til daglige belønninger.",
       "pointsGained": "{points} daglige belønningspoint optjent.",
       "showChestButton": "Vis kiste",
       "hideChestButton": "Skjul kiste",

--- a/src/ui/i18n.resolved.generated/de_DE.ts
+++ b/src/ui/i18n.resolved.generated/de_DE.ts
@@ -366,6 +366,7 @@ export const de_DE: EnTranslations = {
       "spinButton": "Drehen",
       "tasks": "Aufgaben",
       "taskMultiplier": "x{multiplier}-Multiplikator",
+      "oneVsOneExcluded": "1-gegen-1-Matches gewähren keine Punkte für tägliche Belohnungen.",
       "pointsGained": "{points} Punkte für tägliche Belohnungen erhalten.",
       "showChestButton": "Truhe anzeigen",
       "hideChestButton": "Truhe ausblenden",

--- a/src/ui/i18n.resolved.generated/en.ts
+++ b/src/ui/i18n.resolved.generated/en.ts
@@ -366,6 +366,7 @@ export const en: EnTranslations = {
       "spinButton": "Spin",
       "tasks": "Tasks",
       "taskMultiplier": "x{multiplier} multiplier",
+      "oneVsOneExcluded": "1v1 matches do not grant daily reward points.",
       "pointsGained": "{points} daily rewards points gained.",
       "showChestButton": "Show Chest",
       "hideChestButton": "Hide Chest",

--- a/src/ui/i18n.resolved.generated/en_CA.ts
+++ b/src/ui/i18n.resolved.generated/en_CA.ts
@@ -366,6 +366,7 @@ export const en_CA: EnTranslations = {
       "spinButton": "Spin",
       "tasks": "Tasks",
       "taskMultiplier": "x{multiplier} multiplier",
+      "oneVsOneExcluded": "1v1 matches do not grant daily reward points.",
       "pointsGained": "{points} daily rewards points gained.",
       "showChestButton": "Show Chest",
       "hideChestButton": "Hide Chest",

--- a/src/ui/i18n.resolved.generated/en_XA.ts
+++ b/src/ui/i18n.resolved.generated/en_XA.ts
@@ -366,6 +366,7 @@ export const en_XA: EnTranslations = {
       "spinButton": "[Šþíñ]",
       "tasks": "[Ţášķš]",
       "taskMultiplier": "[ẋ{multiplier} ɱúļţíþļíéŕ]",
+      "oneVsOneExcluded": "[1ʋ1 ɱáţçĥéš ðó ñóţ ĝŕáñţ ðáíļý ŕéŵáŕð þóíñţš.]",
       "pointsGained": "[{points} ðáíļý ŕéŵáŕðš þóíñţš ĝáíñéð.]",
       "showChestButton": "[Šĥóŵ Çĥéšţ]",
       "hideChestButton": "[Ĥíðé Çĥéšţ]",

--- a/src/ui/i18n.resolved.generated/es.ts
+++ b/src/ui/i18n.resolved.generated/es.ts
@@ -366,6 +366,7 @@ export const es: EnTranslations = {
       "spinButton": "Girar",
       "tasks": "Tareas",
       "taskMultiplier": "Multiplicador x{multiplier}",
+      "oneVsOneExcluded": "Las partidas 1 contra 1 no otorgan puntos de recompensas diarias.",
       "pointsGained": "{points} puntos de recompensas diarias obtenidos.",
       "showChestButton": "Mostrar cofre",
       "hideChestButton": "Ocultar cofre",

--- a/src/ui/i18n.resolved.generated/es_ES.ts
+++ b/src/ui/i18n.resolved.generated/es_ES.ts
@@ -366,6 +366,7 @@ export const es_ES: EnTranslations = {
       "spinButton": "Girar",
       "tasks": "Tareas",
       "taskMultiplier": "Multiplicador x{multiplier}",
+      "oneVsOneExcluded": "Las partidas 1 contra 1 no otorgan puntos de recompensas diarias.",
       "pointsGained": "{points} puntos de recompensas diarias obtenidos.",
       "showChestButton": "Mostrar cofre",
       "hideChestButton": "Ocultar cofre",

--- a/src/ui/i18n.resolved.generated/fr_CA.ts
+++ b/src/ui/i18n.resolved.generated/fr_CA.ts
@@ -366,6 +366,7 @@ export const fr_CA: EnTranslations = {
       "spinButton": "Tourner",
       "tasks": "Tâches",
       "taskMultiplier": "Multiplicateur x{multiplier}",
+      "oneVsOneExcluded": "Les matchs en 1 contre 1 ne rapportent pas de points de récompenses quotidiennes.",
       "pointsGained": "{points} points de récompenses quotidiennes gagnés.",
       "showChestButton": "Afficher le coffre",
       "hideChestButton": "Masquer le coffre",

--- a/src/ui/i18n.resolved.generated/fr_FR.ts
+++ b/src/ui/i18n.resolved.generated/fr_FR.ts
@@ -366,6 +366,7 @@ export const fr_FR: EnTranslations = {
       "spinButton": "Tourner",
       "tasks": "Tâches",
       "taskMultiplier": "Multiplicateur x{multiplier}",
+      "oneVsOneExcluded": "Les matchs en 1 contre 1 ne rapportent pas de points de récompenses quotidiennes.",
       "pointsGained": "{points} points de récompenses quotidiennes gagnés.",
       "showChestButton": "Afficher le coffre",
       "hideChestButton": "Masquer le coffre",

--- a/src/ui/i18n.resolved.generated/id_ID.ts
+++ b/src/ui/i18n.resolved.generated/id_ID.ts
@@ -366,6 +366,7 @@ export const id_ID: EnTranslations = {
       "spinButton": "Putar",
       "tasks": "Tugas",
       "taskMultiplier": "pengali x{multiplier}",
+      "oneVsOneExcluded": "Pertandingan 1 lawan 1 tidak memberikan poin hadiah harian.",
       "pointsGained": "{points} poin hadiah harian diperoleh.",
       "showChestButton": "Tampilkan Peti",
       "hideChestButton": "Sembunyikan Peti",

--- a/src/ui/i18n.resolved.generated/it_IT.ts
+++ b/src/ui/i18n.resolved.generated/it_IT.ts
@@ -366,6 +366,7 @@ export const it_IT: EnTranslations = {
       "spinButton": "Gira",
       "tasks": "Incarichi",
       "taskMultiplier": "Moltiplicatore x{multiplier}",
+      "oneVsOneExcluded": "Le partite 1 contro 1 non assegnano punti per le ricompense giornaliere.",
       "pointsGained": "{points} punti ricompense giornaliere ottenuti.",
       "showChestButton": "Mostra forziere",
       "hideChestButton": "Nascondi forziere",

--- a/src/ui/i18n.resolved.generated/ja_JP.ts
+++ b/src/ui/i18n.resolved.generated/ja_JP.ts
@@ -366,6 +366,7 @@ export const ja_JP: EnTranslations = {
       "spinButton": "スピン",
       "tasks": "タスク",
       "taskMultiplier": "{multiplier}倍倍率",
+      "oneVsOneExcluded": "1対1の試合ではデイリー報酬ポイントを獲得できません。",
       "pointsGained": "{points} デイリー報酬ポイントを獲得しました。",
       "showChestButton": "宝箱を表示",
       "hideChestButton": "宝箱を隠す",

--- a/src/ui/i18n.resolved.generated/ko_KR.ts
+++ b/src/ui/i18n.resolved.generated/ko_KR.ts
@@ -366,6 +366,7 @@ export const ko_KR: EnTranslations = {
       "spinButton": "돌리기",
       "tasks": "과제",
       "taskMultiplier": "{multiplier}배 배율",
+      "oneVsOneExcluded": "1대1 경기에서는 일일 보상 포인트를 획득할 수 없습니다.",
       "pointsGained": "{points} 일일 보상 포인트를 획득했습니다.",
       "showChestButton": "보물상자 표시",
       "hideChestButton": "보물상자 숨기기",

--- a/src/ui/i18n.resolved.generated/nl_NL.ts
+++ b/src/ui/i18n.resolved.generated/nl_NL.ts
@@ -366,6 +366,7 @@ export const nl_NL: EnTranslations = {
       "spinButton": "Draaien",
       "tasks": "Taken",
       "taskMultiplier": "x{multiplier} vermenigvuldiger",
+      "oneVsOneExcluded": "1-tegen-1-wedstrijden leveren geen punten voor dagelijkse beloningen op.",
       "pointsGained": "{points} punten voor dagelijkse beloningen verdiend.",
       "showChestButton": "Kist tonen",
       "hideChestButton": "Kist verbergen",

--- a/src/ui/i18n.resolved.generated/pl_PL.ts
+++ b/src/ui/i18n.resolved.generated/pl_PL.ts
@@ -366,6 +366,7 @@ export const pl_PL: EnTranslations = {
       "spinButton": "Zakręć",
       "tasks": "Zadania",
       "taskMultiplier": "mnożnik x{multiplier}",
+      "oneVsOneExcluded": "Mecze 1 na 1 nie przyznają punktów codziennych nagród.",
       "pointsGained": "Zdobyto {points} pkt. codziennych nagród.",
       "showChestButton": "Pokaż skrzynię",
       "hideChestButton": "Ukryj skrzynię",

--- a/src/ui/i18n.resolved.generated/pt_BR.ts
+++ b/src/ui/i18n.resolved.generated/pt_BR.ts
@@ -366,6 +366,7 @@ export const pt_BR: EnTranslations = {
       "spinButton": "Girar",
       "tasks": "Tarefas",
       "taskMultiplier": "Multiplicador x{multiplier}",
+      "oneVsOneExcluded": "Partidas 1 contra 1 não concedem pontos de recompensas diárias.",
       "pointsGained": "{points} pontos de recompensas diárias ganhos.",
       "showChestButton": "Mostrar Baú",
       "hideChestButton": "Ocultar Baú",

--- a/src/ui/i18n.resolved.generated/ru_RU.ts
+++ b/src/ui/i18n.resolved.generated/ru_RU.ts
@@ -366,6 +366,7 @@ export const ru_RU: EnTranslations = {
       "spinButton": "Крутить",
       "tasks": "Задания",
       "taskMultiplier": "Множитель x{multiplier}",
+      "oneVsOneExcluded": "Матчи 1 на 1 не приносят очки ежедневных наград.",
       "pointsGained": "Получено {points} очков ежедневных наград.",
       "showChestButton": "Показать сундук",
       "hideChestButton": "Скрыть сундук",

--- a/src/ui/i18n.resolved.generated/sv_SE.ts
+++ b/src/ui/i18n.resolved.generated/sv_SE.ts
@@ -366,6 +366,7 @@ export const sv_SE: EnTranslations = {
       "spinButton": "Snurra",
       "tasks": "Uppgifter",
       "taskMultiplier": "x{multiplier} multiplikator",
+      "oneVsOneExcluded": "1 mot 1-matcher ger inga poäng för dagliga belöningar.",
       "pointsGained": "{points} poäng för dagliga belöningar intjänade.",
       "showChestButton": "Visa kista",
       "hideChestButton": "Dölj kista",

--- a/src/ui/i18n.resolved.generated/tr_TR.ts
+++ b/src/ui/i18n.resolved.generated/tr_TR.ts
@@ -366,6 +366,7 @@ export const tr_TR: EnTranslations = {
       "spinButton": "Çevir",
       "tasks": "Görevler",
       "taskMultiplier": "x{multiplier} çarpan",
+      "oneVsOneExcluded": "1'e 1 maçlar günlük ödül puanı kazandırmaz.",
       "pointsGained": "{points} günlük ödül puanı kazanıldı.",
       "showChestButton": "Sandığı Göster",
       "hideChestButton": "Sandığı Gizle",

--- a/src/ui/i18n.resolved.generated/vi_VN.ts
+++ b/src/ui/i18n.resolved.generated/vi_VN.ts
@@ -366,6 +366,7 @@ export const vi_VN: EnTranslations = {
       "spinButton": "Quay",
       "tasks": "Nhiệm Vụ",
       "taskMultiplier": "hệ số x{multiplier}",
+      "oneVsOneExcluded": "Trận đấu 1v1 không trao điểm phần thưởng hằng ngày.",
       "pointsGained": "Nhận được {points} điểm phần thưởng hằng ngày.",
       "showChestButton": "Hiện rương",
       "hideChestButton": "Ẩn rương",

--- a/src/ui/i18n.resolved.generated/zh_CN.ts
+++ b/src/ui/i18n.resolved.generated/zh_CN.ts
@@ -366,6 +366,7 @@ export const zh_CN: EnTranslations = {
       "spinButton": "转动",
       "tasks": "任务",
       "taskMultiplier": "{multiplier}倍倍率",
+      "oneVsOneExcluded": "1对1比赛不会获得每日奖励积分。",
       "pointsGained": "已获得 {points} 每日奖励积分。",
       "showChestButton": "显示宝箱",
       "hideChestButton": "隐藏宝箱",

--- a/src/ui/i18n.resolved.generated/zh_TW.ts
+++ b/src/ui/i18n.resolved.generated/zh_TW.ts
@@ -366,6 +366,7 @@ export const zh_TW: EnTranslations = {
       "spinButton": "轉動",
       "tasks": "任務",
       "taskMultiplier": "{multiplier}倍倍率",
+      "oneVsOneExcluded": "1對1比賽不會獲得每日獎勵點數。",
       "pointsGained": "已獲得 {points} 每日獎勵點數。",
       "showChestButton": "顯示寶箱",
       "hideChestButton": "隱藏寶箱",

--- a/src/world_api/daily_rewards.ts
+++ b/src/world_api/daily_rewards.ts
@@ -1,5 +1,6 @@
 export interface DailyRewardTaskView {
   id: string;
+  type: string;
   title: string;
   description: string;
   points: number;

--- a/tests/daily_rewards.test.ts
+++ b/tests/daily_rewards.test.ts
@@ -36,7 +36,7 @@ import {
   resetDailyRewardPriceCacheForTests,
   rewardDayForDate,
 } from '../server/daily_rewards';
-import { buildDailyRewardsView } from '../src/ui/daily_rewards_view';
+import { buildDailyRewardsView, dailyRewardTaskDescription } from '../src/ui/daily_rewards_view';
 
 class FakeDailyRewardDb implements DailyRewardDb {
   banReason: string | null = null;
@@ -587,29 +587,39 @@ describe('daily rewards', () => {
         new Date(`2026-06-30T12:${String(minute).padStart(2, '0')}:00.000Z`),
       );
     }
-    await service.recordArenaResult(1, {
+    const excluded = await service.recordArenaResult(1, {
       won: true,
       format: '1v1',
       ratingBefore: 1500,
       ratingAfter: 1516,
       completedAt: new Date('2026-06-30T13:00:00.000Z'),
     });
+    expect(excluded).toBe(0);
+    expect(db.events.filter((event) => event.kind === 'task')).toHaveLength(0);
+
+    await service.recordArenaResult(1, {
+      won: true,
+      format: '2v2',
+      ratingBefore: 1500,
+      ratingAfter: 1516,
+      completedAt: new Date('2026-06-30T13:01:00.000Z'),
+    });
     await service.recordArenaResult(1, {
       won: false,
-      format: '1v1',
+      format: '2v2',
       ratingBefore: 1516,
       ratingAfter: 1500,
-      completedAt: new Date('2026-06-30T13:01:00.000Z'),
+      completedAt: new Date('2026-06-30T13:02:00.000Z'),
     });
     const taskEvents = db.events.filter((event) => event.kind === 'task');
     expect(taskEvents).toHaveLength(2);
     expect(taskEvents[0]).toMatchObject({
       points: 60,
-      meta: { format: '1v1', won: true, onlineMinutes: 60, multiplier: 3, basePoints: 20 },
+      meta: { format: '2v2', won: true, onlineMinutes: 60, multiplier: 3, basePoints: 20 },
     });
     expect(taskEvents[1]).toMatchObject({
       points: 30,
-      meta: { format: '1v1', won: false, onlineMinutes: 60, multiplier: 3, basePoints: 10 },
+      meta: { format: '2v2', won: false, onlineMinutes: 60, multiplier: 3, basePoints: 10 },
     });
     expect(db.score).toBe(90);
   });
@@ -718,19 +728,28 @@ describe('daily rewards', () => {
       matchId: 42,
       completedAt: new Date('2026-06-30T13:01:00.000Z'),
     });
+    expect(db.events.filter((event) => event.kind === 'task')).toHaveLength(0);
+    expect(db.score).toBe(0);
+
+    await service.recordValeCupResult(1, {
+      won: true,
+      bracket: 2,
+      matchId: 45,
+      completedAt: new Date('2026-06-30T13:01:30.000Z'),
+    });
 
     const taskEvents = db.events.filter((event) => event.kind === 'task');
     expect(taskEvents).toHaveLength(1);
     expect(taskEvents[0]).toMatchObject({
       points: 75,
-      key: 'task:vale_cup_ranked_wins:vale_cup:42:win:2026-06-30T13:01:00.000Z',
+      key: 'task:vale_cup_ranked_wins:vale_cup:45:win:2026-06-30T13:01:30.000Z',
       meta: {
         taskId: 'vale_cup_ranked_wins',
         taskType: 'vale_cup_result',
-        bracket: 1,
-        matchId: 42,
+        bracket: 2,
+        matchId: 45,
         completionId: null,
-        completedAt: '2026-06-30T13:01:00.000Z',
+        completedAt: '2026-06-30T13:01:30.000Z',
         won: true,
         matchType: 'ranked',
         rated: true,
@@ -744,7 +763,7 @@ describe('daily rewards', () => {
 
     await service.recordValeCupResult(1, {
       won: true,
-      bracket: 1,
+      bracket: 2,
       matchId: 43,
       rated: false,
       hasBots: true,
@@ -758,7 +777,7 @@ describe('daily rewards', () => {
       meta: {
         taskId: 'vale_cup_ranked_wins',
         taskType: 'vale_cup_result',
-        bracket: 1,
+        bracket: 2,
         matchId: 43,
         completionId: null,
         completedAt: '2026-06-30T13:02:00.000Z',
@@ -776,7 +795,7 @@ describe('daily rewards', () => {
 
     await service.recordValeCupResult(1, {
       won: true,
-      bracket: 1,
+      bracket: 2,
       matchId: 44,
       rated: false,
       hasBots: true,
@@ -791,7 +810,7 @@ describe('daily rewards', () => {
       meta: {
         taskId: 'vale_cup_ranked_wins',
         taskType: 'vale_cup_result',
-        bracket: 1,
+        bracket: 2,
         matchId: 44,
         completionId: null,
         completedAt: '2026-06-30T13:03:00.000Z',
@@ -844,14 +863,14 @@ describe('daily rewards', () => {
       const completedAt = new Date('2026-06-30T20:59:00.000Z');
       const beforeRestartResult = {
         won: true,
-        bracket: 1,
+        bracket: 2,
         matchId: 7,
         completionId: 'before-restart-match-7',
         completedAt,
       };
       const afterRestartResult = {
         won: true,
-        bracket: 1,
+        bracket: 2,
         matchId: 7,
         completionId: 'after-restart-match-7',
         completedAt,
@@ -901,7 +920,7 @@ describe('daily rewards', () => {
         },
       ],
     });
-    const result = { won: true, bracket: 1, matchId: 7 };
+    const result = { won: true, bracket: 2, matchId: 7 };
     const firstCompletedAt = new Date('2026-06-30T13:20:00.000Z');
     const secondCompletedAt = new Date('2026-06-30T13:21:00.000Z');
 
@@ -1273,5 +1292,21 @@ describe('daily rewards', () => {
       },
     });
     expect(view).toMatchObject({ kind: 'ready', locked: true, lockReason: 'under_minimum' });
+  });
+
+  it('marks Arena and Vale Cup task descriptions with the 1v1 restriction', () => {
+    const restriction = '1v1 matches do not grant daily reward points.';
+    expect(dailyRewardTaskDescription('arena_result', 'Complete arena matches.', restriction)).toBe(
+      `Complete arena matches. ${restriction}`,
+    );
+    expect(
+      dailyRewardTaskDescription('vale_cup_result', 'Win Vale Cup matches.', restriction),
+    ).toBe(`Win Vale Cup matches. ${restriction}`);
+    expect(dailyRewardTaskDescription('quest_completion', 'Complete quests.', restriction)).toBe(
+      'Complete quests.',
+    );
+    expect(dailyRewardTaskDescription('delve_clear', 'Complete delves.', restriction)).toBe(
+      'Complete delves.',
+    );
   });
 });


### PR DESCRIPTION
## Summary

- exclude Arena 1v1 results from daily-reward point grants
- exclude Vale Cup 1v1 brackets from daily-reward point grants
- append a localized 1v1 exclusion notice to affected task descriptions
- preserve scoring for Arena and Vale Cup matches with teams of two or more

## Testing

- focused daily-rewards and localization tests: 67 passed, 3 skipped
- release-tier localization tests: 40 passed with zero pending translations
- browser regression tests: 64 passed
- TypeScript checks passed
- environment, server, and client builds passed
- SFX and malware checks passed
- task-scoped Biome and copy checks passed

## QA notes

The repository-wide changed-file Biome command currently scans the inherited release/v0.27.0-to-main delta and reports six pre-existing errors in unrelated release files. All files changed by this PR pass explicit Biome validation.