### PR TITLE
feat(metrics): add cohort-safe day-one engagement gauges

### DIFF
--- a/server/http/business_metrics.ts
+++ b/server/http/business_metrics.ts
@@ -5,6 +5,8 @@
 import { Gauge, type Registry } from 'prom-client';
 import { pool } from '../db';
 import {
+  DAY_ONE_FUNNEL_STAGES,
+  FIRST_DAY_PLAYTIME_BUCKETS,
   type PlayerBusinessDay,
   type PlayerBusinessSnapshot,
   playerBusinessSnapshot,
@@ -21,6 +23,10 @@ export const WOC_PLAYER_DAILY_PLAYTIME_SECONDS = 'woc_player_daily_playtime_seco
 export const WOC_PLAYER_FIRST_SESSION_MEDIAN_SECONDS = 'woc_player_first_session_median_seconds';
 export const WOC_PLAYER_FIRST_SESSION_LEVEL_RATE = 'woc_player_first_session_level_rate';
 export const WOC_PLAYER_RETENTION_RATE = 'woc_player_retention_rate';
+export const WOC_PLAYER_FIRST_DAY_PLAYTIME_SECONDS = 'woc_player_first_day_playtime_seconds';
+export const WOC_PLAYER_FIRST_DAY_SESSIONS = 'woc_player_first_day_sessions';
+export const WOC_PLAYER_FIRST_DAY_PLAYTIME_ACCOUNTS = 'woc_player_first_day_playtime_accounts';
+export const WOC_PLAYER_FUNNEL_ACCOUNTS = 'woc_player_funnel_accounts';
 
 /** Business data changes slowly; one bounded database sample every 15 minutes is enough. */
 export const BUSINESS_METRICS_REFRESH_MS = 15 * 60_000;
@@ -211,6 +217,78 @@ export function registerBusinessMetrics(
             (item) => item.period === period && item.day === day,
           );
           if (retention) setIfPresent(this, { period, day: String(day) }, retention.rate);
+        }
+      }
+    },
+  });
+
+  new Gauge({
+    name: WOC_PLAYER_FIRST_DAY_PLAYTIME_SECONDS,
+    help: 'First-day playtime percentiles in seconds for accounts that first played in a UTC calendar period.',
+    labelNames: ['period', 'stat'],
+    registers: [registry],
+    collect() {
+      this.reset();
+      const snapshot = collector.current();
+      if (!snapshot) return;
+      for (const period of PERIODS) {
+        const day = dayFor(snapshot, period);
+        if (!day) continue;
+        setIfPresent(this, { period, stat: 'p50' }, day.firstDayPlaytimeP50Seconds);
+        setIfPresent(this, { period, stat: 'p90' }, day.firstDayPlaytimeP90Seconds);
+      }
+    },
+  });
+
+  new Gauge({
+    name: WOC_PLAYER_FIRST_DAY_SESSIONS,
+    help: 'Median session count on the first day for accounts that first played in a UTC calendar period.',
+    labelNames: ['period', 'stat'],
+    registers: [registry],
+    collect() {
+      this.reset();
+      const snapshot = collector.current();
+      if (!snapshot) return;
+      for (const period of PERIODS) {
+        const day = dayFor(snapshot, period);
+        if (day) setIfPresent(this, { period, stat: 'p50' }, day.firstDaySessionsMedian);
+      }
+    },
+  });
+
+  new Gauge({
+    name: WOC_PLAYER_FIRST_DAY_PLAYTIME_ACCOUNTS,
+    help: 'Accounts that first played in a UTC calendar period, bucketed by first-day playtime.',
+    labelNames: ['period', 'bucket'],
+    registers: [registry],
+    collect() {
+      this.reset();
+      const snapshot = collector.current();
+      if (!snapshot) return;
+      for (const period of PERIODS) {
+        const day = dayFor(snapshot, period);
+        if (!day) continue;
+        for (const bucket of FIRST_DAY_PLAYTIME_BUCKETS) {
+          this.set({ period, bucket }, day.firstDayPlaytimeAccounts[bucket]);
+        }
+      }
+    },
+  });
+
+  new Gauge({
+    name: WOC_PLAYER_FUNNEL_ACCOUNTS,
+    help: 'Accounts created in a UTC calendar period that completed each stage during that same UTC day.',
+    labelNames: ['period', 'stage'],
+    registers: [registry],
+    collect() {
+      this.reset();
+      const snapshot = collector.current();
+      if (!snapshot) return;
+      for (const period of PERIODS) {
+        const day = dayFor(snapshot, period);
+        if (!day) continue;
+        for (const stage of DAY_ONE_FUNNEL_STAGES) {
+          this.set({ period, stage }, day.dayOneFunnelAccounts[stage]);
         }
       }
     },

--- a/server/player_metrics_db.ts
+++ b/server/player_metrics_db.ts
@@ -74,6 +74,29 @@ SELECT 1
 export const PLAYER_METRICS_INVALID_INDEX_DROP_SQL =
   'DROP INDEX CONCURRENTLY IF EXISTS play_sessions_account_started_id';
 
+/** Fixed first-day playtime buckets; a bounded label set, never per-player data. */
+export const FIRST_DAY_PLAYTIME_BUCKETS = [
+  'lt_10m',
+  '10m_30m',
+  '30m_1h',
+  '1h_3h',
+  'gte_3h',
+] as const;
+
+export type FirstDayPlaytimeBucket = (typeof FIRST_DAY_PLAYTIME_BUCKETS)[number];
+
+/** Ordered stages for the same-day account-created funnel. */
+export const DAY_ONE_FUNNEL_STAGES = [
+  'created',
+  'first_character',
+  'entered_world',
+  'played_10m',
+  'reached_level_2',
+  'reached_level_5',
+] as const;
+
+export type DayOneFunnelStage = (typeof DAY_ONE_FUNNEL_STAGES)[number];
+
 export interface PlayerBusinessDay {
   period: 'today' | 'yesterday';
   accountsCreated: number;
@@ -88,6 +111,11 @@ export interface PlayerBusinessDay {
   firstSessionMedianSeconds: number | null;
   firstSessionLevel2Rate: number | null;
   firstSessionLevel5Rate: number | null;
+  firstDayPlaytimeP50Seconds: number | null;
+  firstDayPlaytimeP90Seconds: number | null;
+  firstDaySessionsMedian: number | null;
+  firstDayPlaytimeAccounts: Record<FirstDayPlaytimeBucket, number>;
+  dayOneFunnelAccounts: Record<DayOneFunnelStage, number>;
 }
 
 export interface PlayerRetentionMetric {
@@ -396,10 +424,6 @@ WITH days(period, day) AS (
     ('yesterday'::text, current_date - 1)
 ), daily AS (
   SELECT days.period, days.day,
-         (SELECT count(*)::int
-            FROM accounts
-           WHERE created_at >= days.day
-             AND created_at < days.day + 1) AS accounts_created,
          COALESCE((SELECT characters_created
                      FROM player_business_daily
                     WHERE realm = $1 AND day = days.day), 0)::int AS characters_created,
@@ -407,93 +431,206 @@ WITH days(period, day) AS (
             FROM player_account_facts
            WHERE realm = $1
              AND first_character_at >= days.day
-             AND first_character_at < days.day + 1) AS first_character_accounts,
-         (SELECT count(*)::int
-            FROM player_account_facts
-           WHERE realm = $1
-             AND account_created_at >= days.day
-             AND account_created_at < days.day + 1
-             AND first_play_at >= days.day
-             AND first_play_at < days.day + 1) AS same_day_first_plays
+             AND first_character_at < days.day + 1) AS first_character_accounts
     FROM days
+), funnel AS (
+  -- Drive the signup funnel from the indexed accounts.created_at range so it
+  -- retains registrations with no lifecycle fact. Every later stage is the
+  -- subset of that same account-created cohort completing the stage that UTC
+  -- day. Realm facts and activity are primary-key lookups from those accounts.
+  SELECT days.period, funnel_stats.*
+    FROM days
+    CROSS JOIN LATERAL (
+      SELECT count(accounts.id)::int AS funnel_created,
+             count(facts.account_id) FILTER (
+               WHERE facts.first_character_at >= days.day
+                 AND facts.first_character_at < days.day + 1
+             )::int AS funnel_first_character,
+             count(facts.account_id) FILTER (
+               WHERE facts.first_character_at >= days.day
+                 AND facts.first_character_at < days.day + 1
+                 AND facts.first_play_at >= days.day
+                 AND facts.first_play_at < days.day + 1
+             )::int AS funnel_entered_world,
+             count(activity.account_id) FILTER (
+               WHERE facts.first_character_at >= days.day
+                 AND facts.first_character_at < days.day + 1
+                 AND facts.first_play_at >= days.day
+                 AND facts.first_play_at < days.day + 1
+                 AND activity.playtime_seconds >= 600
+             )::int AS funnel_played_10m,
+             count(activity.account_id) FILTER (
+               WHERE facts.first_character_at >= days.day
+                 AND facts.first_character_at < days.day + 1
+                 AND facts.first_play_at >= days.day
+                 AND facts.first_play_at < days.day + 1
+                 AND activity.max_level >= 2
+             )::int AS funnel_reached_level_2,
+             count(activity.account_id) FILTER (
+               WHERE facts.first_character_at >= days.day
+                 AND facts.first_character_at < days.day + 1
+                 AND facts.first_play_at >= days.day
+                 AND facts.first_play_at < days.day + 1
+                 AND activity.max_level >= 5
+             )::int AS funnel_reached_level_5
+        FROM accounts
+        LEFT JOIN LATERAL (
+          SELECT facts.account_id, facts.first_character_at, facts.first_play_at
+            FROM player_account_facts facts
+           WHERE facts.realm = $1 AND facts.account_id = accounts.id
+           LIMIT 1
+        ) AS facts ON true
+        LEFT JOIN LATERAL (
+          SELECT activity.account_id, activity.playtime_seconds, activity.max_level
+            FROM player_activity_daily activity
+           WHERE activity.realm = $1
+             AND activity.day = days.day
+             AND activity.account_id = accounts.id
+           LIMIT 1
+        ) AS activity ON true
+       WHERE accounts.created_at >= days.day
+         AND accounts.created_at < days.day + 1
+    ) AS funnel_stats
 ), activity AS (
-  SELECT days.period,
-         count(activity.account_id)::int AS active_total,
-         count(activity.account_id) FILTER (
-           WHERE facts.first_play_at >= days.day
-             AND facts.first_play_at < days.day + 1
-         )::int AS active_new,
-         avg(activity.playtime_seconds)::double precision AS avg_playtime_all,
-         avg(activity.playtime_seconds) FILTER (
-           WHERE facts.first_play_at >= days.day
-             AND facts.first_play_at < days.day + 1
-         )::double precision AS avg_playtime_new,
-         avg(activity.playtime_seconds) FILTER (
-           WHERE activity.max_level >= 20
-         )::double precision AS avg_playtime_level_20
+  -- Keep active-account reads proportional to each selected day. The lateral
+  -- range uses the activity primary key instead of letting a grouped two-day
+  -- join hash the durable activity and fact tables in full.
+  SELECT days.period, activity_stats.*
     FROM days
-    LEFT JOIN player_activity_daily activity
-      ON activity.realm = $1 AND activity.day = days.day
-    LEFT JOIN player_account_facts facts
-      ON facts.realm = activity.realm AND facts.account_id = activity.account_id
-    GROUP BY days.period, days.day
+    CROSS JOIN LATERAL (
+      SELECT count(activity.account_id)::int AS active_total,
+             avg(activity.playtime_seconds)::double precision AS avg_playtime_all,
+             avg(activity.playtime_seconds) FILTER (
+               WHERE activity.max_level >= 20
+             )::double precision AS avg_playtime_level_20
+        FROM player_activity_daily activity
+       WHERE activity.realm = $1 AND activity.day = days.day
+    ) AS activity_stats
+), day_one AS (
+  -- Day-one aggregates live in their own per-day LATERAL so the ordered-set
+  -- percentiles sort only that day's new-player cohort (facts via the
+  -- first_play partial index, one primary-key activity row per account).
+  -- Folding them into the activity CTE would disable hashed aggregation for
+  -- that node (ordered-set aggregates force sorted grouping) and push the
+  -- whole two-day rowset through an external sort; a per-day plain aggregate
+  -- has no grouping sort at all and still returns one row for an empty day.
+  SELECT days.period, day_stats.*
+    FROM days
+    CROSS JOIN LATERAL (
+      SELECT count(activity.account_id)::int AS active_new,
+             avg(activity.playtime_seconds)::double precision AS avg_playtime_new,
+             percentile_cont(0.5) WITHIN GROUP (
+               ORDER BY activity.playtime_seconds
+             )::double precision AS playtime_p50_new,
+             percentile_cont(0.9) WITHIN GROUP (
+               ORDER BY activity.playtime_seconds
+             )::double precision AS playtime_p90_new,
+             percentile_cont(0.5) WITHIN GROUP (
+               ORDER BY activity.sessions
+             )::double precision AS sessions_p50_new,
+             count(activity.account_id) FILTER (
+               WHERE activity.playtime_seconds < 600
+             )::int AS new_playtime_lt_10m,
+             count(activity.account_id) FILTER (
+               WHERE activity.playtime_seconds >= 600
+                 AND activity.playtime_seconds < 1800
+             )::int AS new_playtime_10m_30m,
+             count(activity.account_id) FILTER (
+               WHERE activity.playtime_seconds >= 1800
+                 AND activity.playtime_seconds < 3600
+             )::int AS new_playtime_30m_1h,
+             count(activity.account_id) FILTER (
+               WHERE activity.playtime_seconds >= 3600
+                 AND activity.playtime_seconds < 10800
+             )::int AS new_playtime_1h_3h,
+             count(activity.account_id) FILTER (
+               WHERE activity.playtime_seconds >= 10800
+             )::int AS new_playtime_gte_3h
+        FROM player_account_facts facts
+        JOIN player_activity_daily activity
+          ON activity.realm = $1
+         AND activity.day = days.day
+         AND activity.account_id = facts.account_id
+       WHERE facts.realm = $1
+         AND facts.first_play_at >= days.day
+         AND facts.first_play_at < days.day + 1
+    ) AS day_stats
 ), first_sessions AS (
-  SELECT days.period,
-         percentile_cont(0.5) WITHIN GROUP (
-           ORDER BY facts.first_session_seconds
-         )::double precision AS median_seconds,
-         count(*) FILTER (
-           WHERE facts.first_session_max_level >= 2
-         )::double precision / NULLIF(count(facts.account_id), 0) AS level_2_rate,
-         count(*) FILTER (
-           WHERE facts.first_session_max_level >= 5
-         )::double precision / NULLIF(count(facts.account_id), 0) AS level_5_rate
+  SELECT days.period, first_session_stats.*
     FROM days
-    LEFT JOIN player_account_facts facts
-      ON facts.realm = $1
-     AND facts.first_play_at >= days.day
-     AND facts.first_play_at < days.day + 1
-     AND facts.first_session_ended_at IS NOT NULL
-    GROUP BY days.period
+    CROSS JOIN LATERAL (
+      SELECT percentile_cont(0.5) WITHIN GROUP (
+               ORDER BY facts.first_session_seconds
+             )::double precision AS median_seconds,
+             count(*) FILTER (
+               WHERE facts.first_session_max_level >= 2
+             )::double precision / NULLIF(count(facts.account_id), 0) AS level_2_rate,
+             count(*) FILTER (
+               WHERE facts.first_session_max_level >= 5
+             )::double precision / NULLIF(count(facts.account_id), 0) AS level_5_rate
+        FROM player_account_facts facts
+       WHERE facts.realm = $1
+         AND facts.first_play_at >= days.day
+         AND facts.first_play_at < days.day + 1
+         AND facts.first_session_ended_at IS NOT NULL
+    ) AS first_session_stats
 ), retention_offsets(retention_day) AS (
   VALUES (1), (7), (30)
 ), retention AS (
-  SELECT days.period,
-         retention_offsets.retention_day,
-         count(activity.account_id)::double precision / NULLIF(count(facts.account_id), 0)
-           AS retention_rate
+  -- Resolve each fixed cohort through the first-play and daily-activity
+  -- indexes. Grouping all six cohorts together invites full-table hash joins
+  -- as the durable fact and activity tables grow.
+  SELECT days.period, retention_offsets.retention_day, retention_stats.retention_rate
     FROM days
     CROSS JOIN retention_offsets
-    LEFT JOIN player_account_facts facts
-      ON facts.realm = $1
-     AND facts.first_play_at >= days.day - retention_offsets.retention_day
-     AND facts.first_play_at < days.day - retention_offsets.retention_day + 1
-    LEFT JOIN player_activity_daily activity
-      ON activity.realm = facts.realm
-     AND activity.account_id = facts.account_id
-     AND activity.day = days.day
-   GROUP BY days.period, days.day, retention_offsets.retention_day
+    CROSS JOIN LATERAL (
+      SELECT count(activity.account_id)::double precision
+               / NULLIF(count(facts.account_id), 0) AS retention_rate
+        FROM player_account_facts facts
+        LEFT JOIN player_activity_daily activity
+          ON activity.realm = facts.realm
+         AND activity.account_id = facts.account_id
+         AND activity.day = days.day
+       WHERE facts.realm = $1
+         AND facts.first_play_at >= days.day - retention_offsets.retention_day
+         AND facts.first_play_at < days.day - retention_offsets.retention_day + 1
+    ) AS retention_stats
 )
 SELECT daily.period,
-       daily.accounts_created,
+       funnel.funnel_created AS accounts_created,
        daily.characters_created,
        daily.first_character_accounts,
-       daily.same_day_first_plays::double precision
-         / NULLIF(daily.accounts_created, 0) AS first_world_entry_rate,
-       activity.active_new,
-       GREATEST(activity.active_total - activity.active_new, 0)::int AS active_returning,
+       funnel.funnel_entered_world::double precision
+         / NULLIF(funnel.funnel_created, 0) AS first_world_entry_rate,
+       day_one.active_new,
+       GREATEST(activity.active_total - day_one.active_new, 0)::int AS active_returning,
        activity.avg_playtime_all,
-       activity.avg_playtime_new,
+       day_one.avg_playtime_new,
        activity.avg_playtime_level_20,
        first_sessions.median_seconds,
        first_sessions.level_2_rate,
        first_sessions.level_5_rate,
+       day_one.playtime_p50_new,
+       day_one.playtime_p90_new,
+       day_one.sessions_p50_new,
+       day_one.new_playtime_lt_10m,
+       day_one.new_playtime_10m_30m,
+       day_one.new_playtime_30m_1h,
+       day_one.new_playtime_1h_3h,
+       day_one.new_playtime_gte_3h,
+       funnel.funnel_first_character,
+       funnel.funnel_entered_world,
+       funnel.funnel_played_10m,
+       funnel.funnel_reached_level_2,
+       funnel.funnel_reached_level_5,
        (SELECT jsonb_object_agg(retention_day, retention_rate)
           FROM retention
          WHERE retention.period = daily.period) AS retention
   FROM daily
+  JOIN funnel USING (period)
   JOIN activity USING (period)
   JOIN first_sessions USING (period)
+  JOIN day_one USING (period)
  ORDER BY CASE daily.period WHEN 'today' THEN 0 ELSE 1 END
 `;
 
@@ -512,6 +649,24 @@ function mapBusinessDay(row: Record<string, unknown>): PlayerBusinessDay {
     firstSessionMedianSeconds: numberOrNull(row.median_seconds),
     firstSessionLevel2Rate: numberOrNull(row.level_2_rate),
     firstSessionLevel5Rate: numberOrNull(row.level_5_rate),
+    firstDayPlaytimeP50Seconds: numberOrNull(row.playtime_p50_new),
+    firstDayPlaytimeP90Seconds: numberOrNull(row.playtime_p90_new),
+    firstDaySessionsMedian: numberOrNull(row.sessions_p50_new),
+    firstDayPlaytimeAccounts: {
+      lt_10m: Number(row.new_playtime_lt_10m ?? 0),
+      '10m_30m': Number(row.new_playtime_10m_30m ?? 0),
+      '30m_1h': Number(row.new_playtime_30m_1h ?? 0),
+      '1h_3h': Number(row.new_playtime_1h_3h ?? 0),
+      gte_3h: Number(row.new_playtime_gte_3h ?? 0),
+    },
+    dayOneFunnelAccounts: {
+      created: Number(row.accounts_created ?? 0),
+      first_character: Number(row.funnel_first_character ?? 0),
+      entered_world: Number(row.funnel_entered_world ?? 0),
+      played_10m: Number(row.funnel_played_10m ?? 0),
+      reached_level_2: Number(row.funnel_reached_level_2 ?? 0),
+      reached_level_5: Number(row.funnel_reached_level_5 ?? 0),
+    },
   };
 }
 

--- a/tests/player_metrics_db.test.ts
+++ b/tests/player_metrics_db.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   closeOrphanPlayerSessions,
   closePlayerSession,
+  DAY_ONE_FUNNEL_STAGES,
   openPlayerSession,
   PLAYER_BUSINESS_SNAPSHOT_SQL,
   PLAYER_METRICS_CONCURRENT_INDEX_SQL,
@@ -102,6 +103,40 @@ describe('player business snapshot safety', () => {
     expect(PLAYER_BUSINESS_SNAPSHOT_SQL).not.toMatch(/FROM characters\b/);
   });
 
+  it('bounds first-play engagement and the account-created funnel to indexed daily cohorts', () => {
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS playtime_p50_new');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS playtime_p90_new');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS sessions_p50_new');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS new_playtime_lt_10m');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS new_playtime_10m_30m');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS new_playtime_30m_1h');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS new_playtime_1h_3h');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS new_playtime_gte_3h');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toMatch(
+      /WHERE facts\.realm = \$1\s+AND facts\.first_play_at >= days\.day/,
+    );
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS funnel_created');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS funnel_first_character');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS funnel_entered_world');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS funnel_played_10m');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS funnel_reached_level_2');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS funnel_reached_level_5');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('FROM accounts');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('facts.account_id = accounts.id');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('activity.account_id = accounts.id');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('accounts.created_at >= days.day');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('accounts.created_at < days.day + 1');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).not.toContain('facts.account_created_at');
+    expect(DAY_ONE_FUNNEL_STAGES).toEqual([
+      'created',
+      'first_character',
+      'entered_world',
+      'played_10m',
+      'reached_level_2',
+      'reached_level_5',
+    ]);
+  });
+
   it('uses read-only server-side timeouts and maps nullable rates', async () => {
     const query = vi.fn(async (sql: string, _params?: unknown[]) => {
       if (sql === PLAYER_BUSINESS_SNAPSHOT_SQL) {
@@ -121,6 +156,19 @@ describe('player business snapshot safety', () => {
               median_seconds: 60,
               level_2_rate: 0.75,
               level_5_rate: null,
+              playtime_p50_new: 90,
+              playtime_p90_new: null,
+              sessions_p50_new: 1,
+              new_playtime_lt_10m: 1,
+              new_playtime_10m_30m: 0,
+              new_playtime_30m_1h: 0,
+              new_playtime_1h_3h: 0,
+              new_playtime_gte_3h: 0,
+              funnel_first_character: 1,
+              funnel_entered_world: 1,
+              funnel_played_10m: 0,
+              funnel_reached_level_2: 1,
+              funnel_reached_level_5: 0,
               retention: { 1: 0.4, 7: null, 30: null },
             },
             {
@@ -137,6 +185,19 @@ describe('player business snapshot safety', () => {
               median_seconds: 40,
               level_2_rate: 0.5,
               level_5_rate: 0,
+              playtime_p50_new: 80,
+              playtime_p90_new: 80,
+              sessions_p50_new: 2,
+              new_playtime_lt_10m: 0,
+              new_playtime_10m_30m: 0,
+              new_playtime_30m_1h: 0,
+              new_playtime_1h_3h: 1,
+              new_playtime_gte_3h: 0,
+              funnel_first_character: 1,
+              funnel_entered_world: 1,
+              funnel_played_10m: 1,
+              funnel_reached_level_2: 1,
+              funnel_reached_level_5: 1,
               retention: { 1: 0.6, 7: 0.3, 30: null },
             },
           ],
@@ -172,6 +233,45 @@ describe('player business snapshot safety', () => {
       firstSessionMedianSeconds: 60,
       firstSessionLevel2Rate: 0.75,
       firstSessionLevel5Rate: null,
+      firstDayPlaytimeP50Seconds: 90,
+      firstDayPlaytimeP90Seconds: null,
+      firstDaySessionsMedian: 1,
+      firstDayPlaytimeAccounts: {
+        lt_10m: 1,
+        '10m_30m': 0,
+        '30m_1h': 0,
+        '1h_3h': 0,
+        gte_3h: 0,
+      },
+      dayOneFunnelAccounts: {
+        created: 2,
+        first_character: 1,
+        entered_world: 1,
+        played_10m: 0,
+        reached_level_2: 1,
+        reached_level_5: 0,
+      },
+    });
+    expect(result.days[1]).toMatchObject({
+      period: 'yesterday',
+      firstDayPlaytimeP50Seconds: 80,
+      firstDayPlaytimeP90Seconds: 80,
+      firstDaySessionsMedian: 2,
+      firstDayPlaytimeAccounts: {
+        lt_10m: 0,
+        '10m_30m': 0,
+        '30m_1h': 0,
+        '1h_3h': 1,
+        gte_3h: 0,
+      },
+      dayOneFunnelAccounts: {
+        created: 1,
+        first_character: 1,
+        entered_world: 1,
+        played_10m: 1,
+        reached_level_2: 1,
+        reached_level_5: 1,
+      },
     });
     expect(result.retention).toEqual([
       { period: 'today', day: 1, rate: 0.4 },

--- a/tests/player_metrics_db_integration.test.ts
+++ b/tests/player_metrics_db_integration.test.ts
@@ -32,6 +32,7 @@ describeDb('player metrics lifecycle SQL (real Postgres)', () => {
           id SERIAL PRIMARY KEY,
           created_at TIMESTAMPTZ NOT NULL DEFAULT now()
         );
+        CREATE INDEX accounts_created_at ON accounts(created_at DESC);
         CREATE TABLE characters (
           id SERIAL PRIMARY KEY,
           account_id INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
@@ -77,6 +78,7 @@ describeDb('player metrics lifecycle SQL (real Postgres)', () => {
   async function scopedClient() {
     const client = await pool.connect();
     await client.query(`SET search_path TO ${SCHEMA}`);
+    await client.query("SET TIME ZONE 'UTC'");
     return client;
   }
 
@@ -136,6 +138,21 @@ describeDb('player metrics lifecycle SQL (real Postgres)', () => {
     }
     await closePlayerSession(scopedPool(), sessionId, 'eastbrook', 5);
 
+    // Keep the snapshot fixture independent of the wall clock. During the
+    // first hour after UTC midnight, the one-hour session above correctly
+    // splits most playtime onto yesterday even though it opened today.
+    const activity = await scopedClient();
+    try {
+      await activity.query(
+        `UPDATE player_activity_daily
+            SET playtime_seconds = 3600
+          WHERE realm = 'eastbrook' AND day = current_date AND account_id = $1`,
+        [accountId],
+      );
+    } finally {
+      activity.release();
+    }
+
     const snapshot = await playerBusinessSnapshot(scopedPool(), 'eastbrook');
     const today = snapshot.days.find((day) => day.period === 'today');
     expect(today).toMatchObject({
@@ -147,9 +164,48 @@ describeDb('player metrics lifecycle SQL (real Postgres)', () => {
       activeReturning: 0,
       firstSessionLevel2Rate: 1,
       firstSessionLevel5Rate: 1,
+      dayOneFunnelAccounts: {
+        created: 1,
+        first_character: 1,
+        entered_world: 1,
+        played_10m: 1,
+        reached_level_2: 1,
+        reached_level_5: 1,
+      },
     });
     expect(today?.avgPlaytimeSecondsAll).toBeGreaterThanOrEqual(3599);
     expect(today?.firstSessionMedianSeconds).toBeGreaterThanOrEqual(3599);
+    expect(today?.firstDayPlaytimeP50Seconds).toBeGreaterThanOrEqual(3599);
+    expect(today?.firstDayPlaytimeP90Seconds).toBeGreaterThanOrEqual(3599);
+    expect(today?.firstDaySessionsMedian).toBe(1);
+    const buckets = today?.firstDayPlaytimeAccounts;
+    expect(buckets?.lt_10m).toBe(0);
+    // The one-hour session floors to right at the 1h edge; accept either side
+    // of it so a sub-second clock skew between statements cannot flake this.
+    expect((buckets?.['30m_1h'] ?? 0) + (buckets?.['1h_3h'] ?? 0)).toBe(1);
+    expect(buckets?.gte_3h).toBe(0);
+    const bucketTotal = Object.values(buckets ?? {}).reduce((sum, count) => sum + count, 0);
+    expect(bucketTotal).toBe(today?.activeNew);
+    const yesterday = snapshot.days.find((day) => day.period === 'yesterday');
+    expect(yesterday).toMatchObject({
+      dayOneFunnelAccounts: {
+        created: 0,
+        first_character: 0,
+        entered_world: 0,
+        played_10m: 0,
+        reached_level_2: 0,
+        reached_level_5: 0,
+      },
+      firstDayPlaytimeP50Seconds: null,
+      firstDaySessionsMedian: null,
+      firstDayPlaytimeAccounts: {
+        lt_10m: 0,
+        '10m_30m': 0,
+        '30m_1h': 0,
+        '1h_3h': 0,
+        gte_3h: 0,
+      },
+    });
     expect(snapshot.retention).toEqual([
       { period: 'today', day: 1, rate: null },
       { period: 'today', day: 7, rate: null },
@@ -158,6 +214,134 @@ describeDb('player metrics lifecycle SQL (real Postgres)', () => {
       { period: 'yesterday', day: 7, rate: null },
       { period: 'yesterday', day: 30, rate: null },
     ]);
+  });
+
+  it('keeps the signup funnel on one cohort while engagement follows first play', async () => {
+    const db = await scopedClient();
+    try {
+      const accounts = await db.query(
+        `INSERT INTO accounts (created_at)
+         VALUES
+           (current_date),
+           (current_date + interval '2 hours'),
+           (current_date + interval '3 hours'),
+           (current_date + 1),
+           (current_date + interval '4 hours'),
+           (current_date - 1 + interval '12 hours'),
+           (current_date + interval '5 hours')
+         RETURNING id`,
+      );
+      const ids = accounts.rows.map((row) => Number(row.id));
+      await db.query(
+        `INSERT INTO player_account_facts (
+           realm, account_id, account_created_at, first_character_at, first_play_at
+         ) VALUES
+           ('eastbrook', $1, current_date,
+            current_date + interval '2 hours', current_date + interval '3 hours'),
+           ('eastbrook', $2, current_date + interval '2 hours',
+            current_date + interval '3 hours', current_date + interval '4 hours'),
+           ('eastbrook', $3, current_date + interval '3 hours',
+            current_date + interval '4 hours', NULL),
+           ('eastbrook', $4, current_date - 1 + interval '12 hours',
+            current_date + interval '1 hour', current_date + interval '2 hours'),
+           ('other', $5, current_date + interval '5 hours',
+            current_date + interval '6 hours', current_date + interval '7 hours')`,
+        [ids[0], ids[1], ids[2], ids[5], ids[6]],
+      );
+      await db.query(
+        `INSERT INTO player_activity_daily (
+           realm, day, account_id, sessions, playtime_seconds, max_level
+         ) VALUES
+           ('eastbrook', current_date, $1, 1, 1200, 5),
+           ('eastbrook', current_date, $2, 1, 300, 1),
+           ('eastbrook', current_date, $3, 1, 3600, 10),
+           ('other', current_date, $4, 1, 7200, 20)`,
+        [ids[0], ids[1], ids[5], ids[6]],
+      );
+    } finally {
+      db.release();
+    }
+
+    const snapshot = await playerBusinessSnapshot(scopedPool(), 'eastbrook');
+    const today = snapshot.days.find((day) => day.period === 'today');
+    expect(today).toMatchObject({
+      accountsCreated: 5,
+      firstCharacterAccounts: 4,
+      firstWorldEntryRate: 0.4,
+      activeNew: 3,
+      firstDaySessionsMedian: 1,
+      firstDayPlaytimeAccounts: {
+        lt_10m: 1,
+        '10m_30m': 1,
+        '30m_1h': 0,
+        '1h_3h': 1,
+        gte_3h: 0,
+      },
+      dayOneFunnelAccounts: {
+        created: 5,
+        first_character: 3,
+        entered_world: 2,
+        played_10m: 1,
+        reached_level_2: 1,
+        reached_level_5: 1,
+      },
+    });
+    const funnel = today?.dayOneFunnelAccounts;
+    expect(funnel?.created).toBeGreaterThanOrEqual(funnel?.first_character ?? 0);
+    expect(funnel?.first_character).toBeGreaterThanOrEqual(funnel?.entered_world ?? 0);
+    expect(funnel?.entered_world).toBeGreaterThanOrEqual(funnel?.played_10m ?? 0);
+    expect(funnel?.entered_world).toBeGreaterThanOrEqual(funnel?.reached_level_2 ?? 0);
+    expect(funnel?.reached_level_2).toBeGreaterThanOrEqual(funnel?.reached_level_5 ?? 0);
+    expect(today?.firstDayPlaytimeP90Seconds).toBeGreaterThan(1200);
+  });
+
+  it('assigns exact first-day playtime boundaries to one bucket each', async () => {
+    const db = await scopedClient();
+    try {
+      const accounts = await db.query(
+        `INSERT INTO accounts (created_at)
+         SELECT current_date FROM generate_series(1, 5)
+         RETURNING id`,
+      );
+      const ids = accounts.rows.map((row) => Number(row.id));
+      await db.query(
+        `INSERT INTO player_account_facts (
+           realm, account_id, account_created_at, first_play_at
+         ) VALUES
+           ('eastbrook', $1, current_date, current_date),
+           ('eastbrook', $2, current_date, current_date),
+           ('eastbrook', $3, current_date, current_date),
+           ('eastbrook', $4, current_date, current_date),
+           ('eastbrook', $5, current_date, current_date)`,
+        ids,
+      );
+      await db.query(
+        `INSERT INTO player_activity_daily (
+           realm, day, account_id, sessions, playtime_seconds, max_level
+         ) VALUES
+           ('eastbrook', current_date, $1, 1, 599, 1),
+           ('eastbrook', current_date, $2, 1, 600, 1),
+           ('eastbrook', current_date, $3, 1, 1800, 1),
+           ('eastbrook', current_date, $4, 1, 3600, 1),
+           ('eastbrook', current_date, $5, 1, 10800, 1)`,
+        ids,
+      );
+    } finally {
+      db.release();
+    }
+
+    const snapshot = await playerBusinessSnapshot(scopedPool(), 'eastbrook');
+    const today = snapshot.days.find((day) => day.period === 'today');
+    expect(today).toMatchObject({
+      activeNew: 5,
+      firstDayPlaytimeAccounts: {
+        lt_10m: 1,
+        '10m_30m': 1,
+        '30m_1h': 1,
+        '1h_3h': 1,
+        gte_3h: 1,
+      },
+    });
   });
 
   it('keeps live and completed retention cohorts separate', async () => {

--- a/tests/server/http/business_metrics.test.ts
+++ b/tests/server/http/business_metrics.test.ts
@@ -8,9 +8,13 @@ import {
   WOC_PLAYER_DAILY_ACTIVE_ACCOUNTS,
   WOC_PLAYER_DAILY_PLAYTIME_SECONDS,
   WOC_PLAYER_FIRST_CHARACTER_ACCOUNTS,
+  WOC_PLAYER_FIRST_DAY_PLAYTIME_ACCOUNTS,
+  WOC_PLAYER_FIRST_DAY_PLAYTIME_SECONDS,
+  WOC_PLAYER_FIRST_DAY_SESSIONS,
   WOC_PLAYER_FIRST_SESSION_LEVEL_RATE,
   WOC_PLAYER_FIRST_SESSION_MEDIAN_SECONDS,
   WOC_PLAYER_FIRST_WORLD_ENTRY_RATE,
+  WOC_PLAYER_FUNNEL_ACCOUNTS,
   WOC_PLAYER_RETENTION_RATE,
 } from '../../../server/http/business_metrics';
 import type { PlayerBusinessSnapshot } from '../../../server/player_metrics_db';
@@ -32,6 +36,24 @@ function snapshot(): PlayerBusinessSnapshot {
         firstSessionMedianSeconds: 720,
         firstSessionLevel2Rate: 0.6,
         firstSessionLevel5Rate: 0.25,
+        firstDayPlaytimeP50Seconds: 480,
+        firstDayPlaytimeP90Seconds: 5400,
+        firstDaySessionsMedian: 1,
+        firstDayPlaytimeAccounts: {
+          lt_10m: 5,
+          '10m_30m': 1,
+          '30m_1h': 1,
+          '1h_3h': 1,
+          gte_3h: 0,
+        },
+        dayOneFunnelAccounts: {
+          created: 12,
+          first_character: 9,
+          entered_world: 8,
+          played_10m: 3,
+          reached_level_2: 2,
+          reached_level_5: 1,
+        },
       },
       {
         period: 'yesterday',
@@ -47,6 +69,24 @@ function snapshot(): PlayerBusinessSnapshot {
         firstSessionMedianSeconds: 700,
         firstSessionLevel2Rate: 0.5,
         firstSessionLevel5Rate: 0.2,
+        firstDayPlaytimeP50Seconds: null,
+        firstDayPlaytimeP90Seconds: null,
+        firstDaySessionsMedian: null,
+        firstDayPlaytimeAccounts: {
+          lt_10m: 4,
+          '10m_30m': 1,
+          '30m_1h': 0,
+          '1h_3h': 0,
+          gte_3h: 1,
+        },
+        dayOneFunnelAccounts: {
+          created: 10,
+          first_character: 7,
+          entered_world: 6,
+          played_10m: 2,
+          reached_level_2: 1,
+          reached_level_5: 0,
+        },
       },
     ],
     retention: [
@@ -106,6 +146,43 @@ describe('registerBusinessMetrics', () => {
     expect(sample(text, WOC_PLAYER_RETENTION_RATE, 'period="today",day="7"')).toBe('0.2');
     expect(sample(text, WOC_PLAYER_RETENTION_RATE, 'period="yesterday",day="30"')).toBe('0.05');
     expect(text).not.toContain('woc_player_retention_rate{period="today",day="30"}');
+
+    expect(WOC_PLAYER_FIRST_DAY_PLAYTIME_SECONDS).toBe('woc_player_first_day_playtime_seconds');
+    expect(WOC_PLAYER_FIRST_DAY_SESSIONS).toBe('woc_player_first_day_sessions');
+    expect(WOC_PLAYER_FIRST_DAY_PLAYTIME_ACCOUNTS).toBe('woc_player_first_day_playtime_accounts');
+    expect(WOC_PLAYER_FUNNEL_ACCOUNTS).toBe('woc_player_funnel_accounts');
+
+    expect(sample(text, WOC_PLAYER_FIRST_DAY_PLAYTIME_SECONDS, 'period="today",stat="p50"')).toBe(
+      '480',
+    );
+    expect(sample(text, WOC_PLAYER_FIRST_DAY_PLAYTIME_SECONDS, 'period="today",stat="p90"')).toBe(
+      '5400',
+    );
+    expect(text).not.toContain(
+      'woc_player_first_day_playtime_seconds{period="yesterday",stat="p50"}',
+    );
+    expect(sample(text, WOC_PLAYER_FIRST_DAY_SESSIONS, 'period="today",stat="p50"')).toBe('1');
+    expect(text).not.toContain('woc_player_first_day_sessions{period="yesterday",stat="p50"}');
+    expect(
+      sample(text, WOC_PLAYER_FIRST_DAY_PLAYTIME_ACCOUNTS, 'period="today",bucket="lt_10m"'),
+    ).toBe('5');
+    expect(
+      sample(text, WOC_PLAYER_FIRST_DAY_PLAYTIME_ACCOUNTS, 'period="yesterday",bucket="gte_3h"'),
+    ).toBe('1');
+    expect(sample(text, WOC_PLAYER_FUNNEL_ACCOUNTS, 'period="today",stage="created"')).toBe('12');
+    expect(sample(text, WOC_PLAYER_FUNNEL_ACCOUNTS, 'period="today",stage="first_character"')).toBe(
+      '9',
+    );
+    expect(sample(text, WOC_PLAYER_FUNNEL_ACCOUNTS, 'period="today",stage="entered_world"')).toBe(
+      '8',
+    );
+    expect(sample(text, WOC_PLAYER_FUNNEL_ACCOUNTS, 'period="today",stage="played_10m"')).toBe('3');
+    expect(sample(text, WOC_PLAYER_FUNNEL_ACCOUNTS, 'period="today",stage="reached_level_2"')).toBe(
+      '2',
+    );
+    expect(
+      sample(text, WOC_PLAYER_FUNNEL_ACCOUNTS, 'period="yesterday",stage="reached_level_5"'),
+    ).toBe('0');
   });
 
   it('never queries on scrape and bounds every label value', async () => {
@@ -124,6 +201,20 @@ describe('registerBusinessMetrics', () => {
     expect(labelValues('segment')).toEqual(new Set(['new', 'returning', 'all', 'level_20']));
     expect(labelValues('level')).toEqual(new Set(['2', '5']));
     expect(labelValues('day')).toEqual(new Set(['1', '7', '30']));
+    expect(labelValues('stat')).toEqual(new Set(['p50', 'p90']));
+    expect(labelValues('bucket')).toEqual(
+      new Set(['lt_10m', '10m_30m', '30m_1h', '1h_3h', 'gte_3h']),
+    );
+    expect(labelValues('stage')).toEqual(
+      new Set([
+        'created',
+        'first_character',
+        'entered_world',
+        'played_10m',
+        'reached_level_2',
+        'reached_level_5',
+      ]),
+    );
     for (const forbidden of ['account_id', 'character_id', 'player', 'name', 'ip']) {
       expect(labelValues(forbidden).size).toBe(0);
     }


### PR DESCRIPTION
## Summary

- Add a six-stage signup funnel where every stage is drawn from the same account-created UTC-day cohort.
- Keep first-day playtime, session, and retention metrics on their separate first-play UTC-day cohort.
- Reshape the snapshot into indexed per-day reads so it remains bounded under the existing collector timeouts.
- Cover delayed first play, no-fact registrations, realm isolation, UTC boundaries, and all playtime bucket edges on real PostgreSQL.

Companion Grafana dashboard PR: [woc-deploy#21](https://github.com/levy-street/woc-deploy/pull/21).

## Type of change

- [x] Feature: new functionality
- [x] Bug fix
- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- Commands:
  - `npm run check:types`
  - `npm run ci:changed`
  - `npm run security:gate`
  - `npx vitest run tests/player_metrics_db.test.ts tests/server/http/business_metrics.test.ts` (15 passed)
  - `TEST_DATABASE_URL=... npx vitest run tests/player_metrics_db_integration.test.ts` against PostgreSQL 14.15 (6 passed)
  - Repository pre-push QA floor (53 passed, 3 skipped)
- Database plan:
  - Exact-schema fixture with 200,000 accounts and more than 200,000 activity rows.
  - 56.381 ms execution under a 2-second statement timeout and 4 MB `work_mem`.
  - No temp I/O and no sequential scans of durable facts or activity tables.
- Review:
  - Database performance, test coverage, and security reviews report READY.
- Full gate note:
  - `npm run gate` was attempted locally, but the host had about 331 MiB free and a nested-checkout test hit `ENOSPC`, causing cascading unrelated worker failures. An unrelated existing snapshot test also fails in isolation because `WebSocket` is undefined. PR CI is the clean full-gate authority for this change.
- Manual steps:
  - Confirmed exporter metric names, fixed label domains, and dashboard contract alignment.

## Checklist

### Quality

- [ ] **The full gate passes.** Awaiting clean PR CI; see the local environment note above.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
