### PR TITLE
docs: add the Professions 2.0 phased implementation plan

### DIFF
--- a/docs/professions-2/README.md
+++ b/docs/professions-2/README.md
@@ -1,0 +1,61 @@
+# Professions 2.0 planning packet
+
+The phased implementation plan for completing the professions system as
+approved in the 2026-07-16 maintainer brainstorm: six deep crafts with
+pair-named archetypes, station masters in the open world, deterministic
+crafting with celebrated masterworks, gathering with rare events, an economy
+that pays skillers without touching raid loot, and a wheel window at Book of
+Deeds quality. Built on epic #1866 and PR 2039.
+
+Each phase runs as its own fresh Claude Code session (Opus 4.8, xhigh effort;
+`ultracode` where a phase says so). Start a phase by pasting its starter prompt
+from the phase file. Every implementation phase is followed by its QA phase.
+
+## Reading order for a new session
+
+1. `state.md`: locked decisions, validation matrix, current phase pointer.
+2. `progress.md`: status table and deliverable checklists.
+3. Your phase file below.
+
+Do not read the whole packet into a session; spawn an Explore agent per the
+starter prompt.
+
+## Cross-cutting docs
+
+- [brainstorm.md](brainstorm.md): vision, pillars, locked rulings, current
+  state, out-of-scope list.
+- [implementation-plan.md](implementation-plan.md): canonical team workflow,
+  review dispatch matrix, phase summary table.
+- [progress.md](progress.md): status and per-phase checklists.
+- [state.md](state.md): the cross-phase cheat sheet (decisions, validation
+  matrix, new surfaces per phase).
+- [qa-checklist.md](qa-checklist.md): the whole-feature integration matrix for
+  the final QA phase.
+- [asset-manifest.json](asset-manifest.json): every designer-replaceable image
+  slot this feature ships procedurally, with purpose, size, and format.
+
+## Phases
+
+| # | Phase | QA |
+|---|---|---|
+| 1 | [Ring and identity foundations](phase-01-ring-and-identity.md) | [QA](phase-01-qa.md) |
+| 2 | [Masterwork model](phase-02-masterwork-model.md) | [QA](phase-02-qa.md) |
+| 3 | [Host-parity bug fixes](phase-03-parity-bug-fixes.md) | [QA](phase-03-qa.md) |
+| 4 | [Node materials and pristine veins](phase-04-node-materials.md) | [QA](phase-04-qa.md) |
+| 5 | [The professions wheel window](phase-05-wheel-window.md) | [QA](phase-05-qa.md) |
+| 6 | [Crafting window upgrades and celebrations](phase-06-crafting-window.md) | [QA](phase-06-qa.md) |
+| 7 | [The Guild letter and quest objectives](phase-07-guild-letter.md) | [QA](phase-07-qa.md) |
+| 8 | [Stations and masters (sim and server)](phase-08-stations-masters.md) | [QA](phase-08-qa.md) |
+| 9 | [Station presence and recipe training](phase-09-station-training.md) | [QA](phase-09-qa.md) |
+| 10 | [Recipe ladders and materials content](phase-10-recipe-ladders.md) | [QA](phase-10-qa.md) |
+| 11 | [Fishing joins the framework](phase-11-fishing.md) | [QA](phase-11-qa.md) |
+| 12 | [Base tool tier gating](phase-12-tool-gating.md) | [QA](phase-12-qa.md) |
+| 13 | [Enchanting reachable](phase-13-enchanting.md) | [QA](phase-13-qa.md) |
+| 14 | [Attunement quests and nudges](phase-14-attunement-quests.md) | [QA](phase-14-qa.md) |
+| 15 | [Deeds, tuning, and polish](phase-15-deeds-polish.md) | [Final QA + teardown](phase-15-qa.md) |
+
+Waves for orientation: phases 1 to 7 are the fun kernel (visibility, truth,
+and the first taste of identity); phases 8 to 15 are wave one (stations,
+content, quests, polish). Wave 2+ work (market instance carriage, commissions,
+Jack of All Trades, monster proficiency, salvage UI, battlefield experience)
+is tracked on epic #1866, not in this packet.

--- a/docs/professions-2/asset-manifest.json
+++ b/docs/professions-2/asset-manifest.json
@@ -1,0 +1,350 @@
+{
+  "meta": {
+    "feature": "Professions 2.0",
+    "date": "2026-07-16",
+    "purpose": "Every designer-replaceable art slot this feature ships. All slots ship with procedural placeholders (the game's icon compositor or existing GLBs), so nothing blocks on art. Designers replace slots by delivering files per deliveryFormat; the pipeline and fallback behavior below mirror the shipped deeds icon pipeline (docs/achievements/icon-brief.md is the precedent).",
+    "deliveryFormat": {
+      "icons": "512x512 transparent-background PNG, sRGB, painted style matching the existing item/deed icon sets, named exactly <asset id>.png. The converter downscales to a 128px square WebP (q82) served from public/ui/<set>/; WebP becomes the committed source of truth. Icons must read clearly at 46px (desktop button) and 40px (mobile).",
+      "worldProps": "GLB (glTF binary), CC0 or licensed with a CREDITS.md row, low-poly matching the KayKit-adjacent world style. The models/props asset-budget group allows 4 MiB total; every GLB needs a media-manifest regen and a registerPreload entry.",
+      "chromeGlyphs": "Monochrome inline SVG (single path preferred), added to the svgIcon registry; used only for secondary controls, never primary destinations."
+    },
+    "pipeline": "Icons: drop PNGs into public/ui/professions/ (new set), run the professions converter (cloned from scripts/convert_item_icons_webp.mjs at Phase 5; regenerates the checked-in id set; a bijection test pins art to wiring). Item-family icons instead go to public/ui/items/ via npm run assets:items and ITEM_IMAGE_IDS. Deed crests go to public/ui/deeds/ via npm run assets:deeds.",
+    "fallback": "Every icon id has a procedural recipe (icons.ts r() helper) or an automatic kind/keyword fallback, so an unshipped slot renders a coherent placeholder, never a blank.",
+    "styleNotes": "Classic dark-fantasy: blue-black grounds, antique gold accents, warm parchment light. No emoji-style art, no flat modern glyphs for painted slots, no text baked into icons (localization). Palette and mood notes per asset below."
+  },
+  "categories": [
+    {
+      "name": "Profession icons (painted, public/ui/professions/)",
+      "note": "Used as the wheel-window ring nodes, crafting-window section headers, and tooltip headers. One per craft on the ten-craft wheel; the six deep crafts are priority 1, the shallow three priority 3 (engineering counts as deep for tools).",
+      "assets": [
+        {
+          "id": "prof_weaponcrafting",
+          "name": "Weaponcrafting",
+          "description": "A sword blade mid-forge across an anvil horn, ember glow",
+          "palette": "steel blue, ember orange, antique gold rim",
+          "priority": 1
+        },
+        {
+          "id": "prof_armorcrafting",
+          "name": "Armorcrafting",
+          "description": "A breastplate with a raised hammer, rivet detail",
+          "palette": "gunmetal, warm bronze",
+          "priority": 1
+        },
+        {
+          "id": "prof_tailoring",
+          "name": "Tailoring",
+          "description": "A bone needle drawing gold thread through folded cloth",
+          "palette": "deep indigo cloth, parchment thread",
+          "priority": 1
+        },
+        {
+          "id": "prof_leatherworking",
+          "name": "Leatherworking",
+          "description": "A curved skinning knife over a stretched hide",
+          "palette": "russet leather, dark walnut",
+          "priority": 1
+        },
+        {
+          "id": "prof_cooking",
+          "name": "Cooking",
+          "description": "A steaming ladle over a hearth pot",
+          "palette": "copper pot, warm firelight",
+          "priority": 1
+        },
+        {
+          "id": "prof_alchemy",
+          "name": "Alchemy",
+          "description": "A round-bottom flask mid-swirl with rising motes",
+          "palette": "emerald liquid, violet motes",
+          "priority": 1
+        },
+        {
+          "id": "prof_engineering",
+          "name": "Engineering",
+          "description": "Interlocked brass gears with a small wrench",
+          "palette": "brass, oiled iron",
+          "priority": 1
+        },
+        {
+          "id": "prof_enchanting",
+          "name": "Enchanting",
+          "description": "A rune-etched rod trailing arcane ribbon",
+          "palette": "arcane violet, silver",
+          "priority": 3
+        },
+        {
+          "id": "prof_jewelcrafting",
+          "name": "Jewelcrafting",
+          "description": "A faceted gem in a jeweler's clamp catching light",
+          "palette": "sapphire, gold prongs",
+          "priority": 3
+        },
+        {
+          "id": "prof_inscription",
+          "name": "Inscription",
+          "description": "A quill inking a glowing glyph on parchment",
+          "palette": "parchment, ink black, gold glyph",
+          "priority": 3
+        }
+      ],
+      "size": "512px source PNG, served 128px WebP",
+      "usedIn": ["professions wheel window", "crafting window section headers", "tooltips"]
+    },
+    {
+      "name": "Gathering skill icons (painted, public/ui/professions/)",
+      "assets": [
+        {
+          "id": "gather_mining",
+          "name": "Mining",
+          "description": "A pick striking an ore seam with a spark",
+          "palette": "slate, copper spark",
+          "priority": 1
+        },
+        {
+          "id": "gather_logging",
+          "name": "Logging",
+          "description": "A woodaxe sunk into a rings-visible stump",
+          "palette": "bark brown, pale ringwood",
+          "priority": 1
+        },
+        {
+          "id": "gather_herbalism",
+          "name": "Herbalism",
+          "description": "A sprig with three leaves and one luminous bloom",
+          "palette": "deep green, moonpetal white",
+          "priority": 1
+        },
+        {
+          "id": "gather_fishing",
+          "name": "Fishing",
+          "description": "A hooked fish curling above water rings",
+          "palette": "river blue, silver scale",
+          "priority": 1
+        }
+      ],
+      "size": "512px source PNG, served 128px WebP",
+      "usedIn": ["professions wheel window", "character window gathering rows"]
+    },
+    {
+      "name": "Archetype crests (painted, public/ui/professions/)",
+      "note": "The identity art: shown on the wheel window identity panel, the attunement quest preview, and the title tooltip. Wave-one four are priority 1; the six future pairs are deferred but listed so the whole set can be commissioned in one sitting (deeds-brief convention).",
+      "assets": [
+        {
+          "id": "archetype_smith",
+          "name": "The Smith",
+          "description": "Crossed hammer and sword over an anvil, shield-crest framing",
+          "palette": "forge orange on gunmetal, gold frame",
+          "priority": 1
+        },
+        {
+          "id": "archetype_outfitter",
+          "name": "The Outfitter",
+          "description": "Needle and skinning knife crossed over a folded cloak",
+          "palette": "indigo and russet, gold frame",
+          "priority": 1
+        },
+        {
+          "id": "archetype_apothecary",
+          "name": "The Apothecary",
+          "description": "Flask pouring into a hearth pot, herb sprig behind",
+          "palette": "emerald and copper, gold frame",
+          "priority": 1
+        },
+        {
+          "id": "archetype_bombardier",
+          "name": "The Bombardier",
+          "description": "A round bomb with a lit fuse over crossed gears",
+          "palette": "iron black, fuse gold, ember",
+          "priority": 1
+        },
+        { "id": "archetype_trapper", "name": "The Trapper", "deferred": true },
+        { "id": "archetype_mageweaver", "name": "The Mageweaver", "deferred": true },
+        { "id": "archetype_arcanist", "name": "The Arcanist", "deferred": true },
+        { "id": "archetype_gembinder", "name": "The Gembinder", "deferred": true },
+        { "id": "archetype_bladewright", "name": "The Bladewright", "deferred": true },
+        { "id": "archetype_cogsmith", "name": "The Cogsmith", "deferred": true }
+      ],
+      "size": "512px source PNG, served 128px WebP",
+      "usedIn": [
+        "professions wheel window identity panel",
+        "attunement quest preview",
+        "title tooltip"
+      ]
+    },
+    {
+      "name": "Masterwork and provenance marks",
+      "assets": [
+        {
+          "id": "masterwork_seal",
+          "name": "Masterwork seal",
+          "kind": "icon-overlay",
+          "description": "A small eight-point gold burst seal, legible as a corner overlay at 16 to 24px on top of any item icon; also shown large in the masterwork toast",
+          "palette": "antique gold on transparent",
+          "size": "512px source PNG; must survive downscale to 20px",
+          "usedIn": [
+            "item tooltips",
+            "bag slot corner overlay",
+            "masterwork toast",
+            "zone-chat broadcast row"
+          ],
+          "priority": 1
+        },
+        {
+          "id": "makers_mark_glyph",
+          "name": "Maker's mark",
+          "kind": "chrome-glyph",
+          "description": "A tiny quill-stroke signature flourish rendered inline before the crafter's name in tooltips; monochrome SVG in the svgIcon registry (currentColor)",
+          "palette": "currentColor",
+          "size": "single-path SVG, 16px box",
+          "usedIn": ["item tooltip 'Crafted by' line"],
+          "priority": 2
+        }
+      ]
+    },
+    {
+      "name": "Material item icons (painted, public/ui/items/ via npm run assets:items)",
+      "note": "Phase 4 and Phase 10 introduce real gathered materials and craft reagents. Exact item ids land with those phases and get appended here; every one has a procedural fallback from item kind + name keywords, so this batch is deliberately LAST to commission. Families and approximate counts below.",
+      "families": [
+        {
+          "family": "ores and bars",
+          "count": "6 to 9 (3 tiers x ore/bar, plus rare variants)",
+          "palette": "copper, iron slate, thorium glow"
+        },
+        { "family": "logs and lumber", "count": "3 to 5", "palette": "bark, cut grain" },
+        { "family": "herbs", "count": "4 to 6", "palette": "greens with one luminous accent each" },
+        {
+          "family": "fibers and cloth",
+          "count": "3 to 4 (plant fiber, bolt tiers)",
+          "palette": "flax, undyed linen, dyed bolt"
+        },
+        { "family": "hides and leathers", "count": "3 to 4", "palette": "russet, tanned tan" },
+        {
+          "family": "fish",
+          "count": "4 to 6 (zone catches + the rare)",
+          "palette": "river silver, one iridescent rare"
+        },
+        {
+          "family": "monster components",
+          "count": "4 to 6 (hide, silk, venom sac, fang, meat, replacing quest-item collisions)",
+          "palette": "muted organics"
+        }
+      ],
+      "size": "512px source PNG, served 128px WebP",
+      "priority": 3
+    },
+    {
+      "name": "Station world props (GLB, public/models/props/)",
+      "note": "One prop per typed station, placed beside its master NPC. anvil.glb already exists (reuse for the forge); a campfire prop exists for field cooking. Keep the whole batch within the 4 MiB models/props budget; CC0 preferred with CREDITS.md rows.",
+      "assets": [
+        {
+          "id": "prop_station_forge",
+          "name": "Forge station",
+          "description": "Anvil + quench barrel + small coal hearth cluster",
+          "reuse": "anvil.glb exists; hearth/barrel are the new pieces",
+          "priority": 1
+        },
+        {
+          "id": "prop_station_kitchens",
+          "name": "Kitchens station",
+          "description": "Brick stove with hanging pots and a prep table",
+          "priority": 1
+        },
+        {
+          "id": "prop_station_apothecary",
+          "name": "Apothecary station",
+          "description": "Bench with alembic, shelf of bottles",
+          "priority": 1
+        },
+        {
+          "id": "prop_station_tannery",
+          "name": "Tannery station",
+          "description": "Hide stretching rack and a dye vat",
+          "priority": 1
+        },
+        {
+          "id": "prop_station_loom",
+          "name": "Loom station",
+          "description": "Standing loom with warp threads and a cloth roll",
+          "priority": 1
+        },
+        {
+          "id": "prop_station_toolworks",
+          "name": "Toolworks station",
+          "description": "Workbench with vise, gear pile, hanging tools",
+          "priority": 2
+        }
+      ],
+      "size": "GLB, each roughly 0.3 to 0.6 MiB, batch under the 4 MiB props budget",
+      "usedIn": ["world render beside master NPCs", "station minimap marker anchor"]
+    },
+    {
+      "name": "Master NPC appearances",
+      "note": "Ships on existing KayKit character GLBs via NPC_KEYS (npc_smith and npc_villager exist). No new art required for wave one; optional bespoke costume textures listed as a deferred nice-to-have.",
+      "assets": [
+        {
+          "id": "npc_master_costumes",
+          "name": "Master NPC costume set",
+          "description": "Six themed tints/attachments (smith apron, cook's hat, alchemist satchel, tanner gloves, weaver shawl, engineer goggles) on the existing character rigs",
+          "deferred": true,
+          "priority": 3
+        }
+      ]
+    },
+    {
+      "name": "Deed crests for new profession deeds (public/ui/deeds/ via npm run assets:deeds)",
+      "note": "Follows the existing deeds icon brief format exactly (docs/achievements/icon-brief.md). Ids land with Phase 15; category crest fallback covers them until art arrives.",
+      "assets": [
+        {
+          "id": "deed_prof_first_craft",
+          "name": "First Craft",
+          "description": "A single finished sword on an anvil, first light",
+          "priority": 2
+        },
+        {
+          "id": "deed_prof_first_masterwork",
+          "name": "First Masterwork",
+          "description": "The masterwork seal bursting over an open palm",
+          "priority": 2
+        },
+        {
+          "id": "deed_prof_first_attunement",
+          "name": "Attuned",
+          "description": "A guild letter with a wax seal, broken open",
+          "priority": 2
+        },
+        {
+          "id": "deed_prof_rare_catch",
+          "name": "The Rare Catch",
+          "description": "An iridescent koi mid-leap over moonlit water",
+          "priority": 2
+        },
+        {
+          "id": "deed_prof_tier_milestones",
+          "name": "Tier milestone set (per-craft, count lands Phase 15)",
+          "deferred": true,
+          "priority": 3
+        }
+      ],
+      "size": "512px source PNG, served 128px WebP"
+    },
+    {
+      "name": "Minimap and map markers (painter work, not image files)",
+      "note": "Station markers render via the minimap painter with --color-minimap-* tokens (a new marker variant in the discriminated union), NOT as image assets. Listed here so designers know the shapes to expect and can propose glyph refinements later.",
+      "assets": [
+        {
+          "id": "marker_station",
+          "name": "Station marker",
+          "description": "A small anvil-silhouette dot variant per station type; must stay legible at minimap scale and identical across graphics tiers",
+          "priority": 2
+        },
+        {
+          "id": "marker_pristine_vein",
+          "name": "Pristine vein marker",
+          "description": "The existing gather-node marker with a brief glint accent (reduced-motion aware)",
+          "priority": 2
+        }
+      ]
+    }
+  ]
+}

--- a/docs/professions-2/brainstorm.md
+++ b/docs/professions-2/brainstorm.md
@@ -1,0 +1,138 @@
+# Professions 2.0: brainstorm and vision
+
+The approved design for completing the professions system, distilled from the
+2026-07-16 maintainer brainstorm. This file is the WHY behind the packet; the
+phase files are the HOW. Locked decisions also appear in `state.md` (the
+cross-phase cheat sheet); when in doubt, `state.md` wins.
+
+## Vision
+
+A WoW-and-RuneScape hybrid professions system with an identity of its own:
+
+> You become a Smith by smithing. The game notices, writes you a letter, and a
+> named master in the world takes you on. Your work carries your mark, your
+> masterworks get celebrated in chat, and the things you gather and cook and
+> forge feed every other player in the game.
+
+Fun for every audience: skillers get a visible ladder, milestones, and income;
+questers get lore quests and guild letters; explorers get rare nodes and
+far-flung stations; combat players get gear, consumables, and monster
+harvesting that feeds it all.
+
+## The five pillars
+
+1. **Identity emerges from play.** Specialization is offered by the game in
+   response to what you craft, never picked from a menu. Titles are earned.
+2. **RNG on the way in, determinism on the way out.** Luck lives in gathering
+   (rare fish, pristine veins, rare components). Crafting output is
+   deterministic; a rare masterwork proc can only add, so no craft ever rolls
+   badly.
+3. **Stations are people.** Field recipes craft anywhere (the T window stays);
+   everything uncommon and up happens at a named master NPC's station in the
+   world, who also teaches recipes, sells supplies, and gives quests.
+4. **Players trade with players.** Gatherers sell to crafters, crafters sell to
+   everyone; NPCs only sink gold. Consumables are the economy's engine; raids
+   keep the power summit.
+5. **Nothing breaks.** The prime directive for every phase: existing items,
+   deeds, quests, saves, and muscle memory keep working.
+
+## Locked design decisions (maintainer rulings, 2026-07-16)
+
+- **Pacing: fast early, slow top.** Common and uncommon tiers in hours, rare in
+  days, epic and legendary gated by scarce adventure materials over weeks.
+  Scarcity is the clock; there is still NO skillReq admission gate on known
+  recipes (the documented no-gate rule stands).
+- **Economy scale: about 100 concurrent players and growing.** Real
+  player-to-player interdependence with graceful small-population fallbacks.
+- **Gathering feel: ambient plus rare events.** Base harvesting stays one
+  click; rare spawns and events add texture. No forced minigame per node.
+- **Doc-vs-code forks resolve per the synthesis report recommendations**, most
+  importantly:
+  - Adopt the design doc's ring order in `CRAFT_RING` (the wave-one pairs force
+    this geometry: alchemy must neighbor both cooking and engineering). Do it
+    inside PR 2039's merge window, while zero players hold archetype state.
+  - Combos REQUIRE the matching attunement (deny when `activeArchetype` is
+    null); the pre-attunement rare-cap pass is retired.
+  - Archetypes are pair-named identities (Smith, Outfitter, Apothecary,
+    Bombardier), replacing single-craft practitioner titles.
+  - Keep the no-admission-gate rule and the self-signed reagent-quantity bonus.
+  - Jack of All Trades returns later (wave 2, issue #1296), not in this packet.
+- **Wave-one crafts (six deep + toolmaker):** weaponcrafting + armorcrafting
+  (Smith), tailoring + leatherworking (Outfitter), cooking + alchemy
+  (Apothecary; alchemy + engineering also enables Bombardier), engineering as
+  the toolmaker line. Jewelcrafting, inscription, and enchanting stay shallow
+  on the wheel as future content beats (enchanting keeps its existing enchant
+  line and becomes reachable in this packet).
+- **Feeders:** mining, herbalism (live today), fishing (joins the gathering
+  framework, keeping its minigame), and corpse harvesting (hide, silk, meat,
+  components: the adventurer's feeder).
+- **Masterwork replaces the five-way quality roll.** Every craft yields the
+  deterministic, budgeted item. A proc (scaling with skill, self-signed
+  materials, and specialization) yields a masterwork: bounded bonus stats via
+  the existing item-budget machinery, maker's mark, toast plus zone-chat
+  celebration. Power ladder: baseline crafted < dungeon drops; masterwork
+  rivals dungeon drops and stays below the raid floor; raids keep the summit.
+- **Tools: base tools only.** Pick/axe/sickle/rod tier gating ships; the
+  slotted-effect/charge/recharge layer stays parked (its tested pure modules
+  remain dormant) and returns later reframed as enchanting content.
+- **Identity costs: cheap to try, meaningful to keep.** First attunement free
+  and celebrated; first switch cheap; repeat switching escalates (the existing
+  5 + 3 per prior switch machinery). Requires per-archetype attunement history
+  on `ArchetypeState` (the current state cannot express lore-vs-amends).
+- **Deeds: basic and universal only.** First craft, first masterwork, first
+  attunement, tier milestones, the rare fish. No archetype-exclusive deed
+  trees. Cosmetic only, as always.
+- **UX bar: the Book of Deeds.** The professions window and crafting-window
+  upgrades follow the deeds window's quality and patterns, styled per the root
+  DESIGN.md design language, fully responsive desktop and mobile.
+- **Designer asset slots.** Placeholder art ships procedural (per the existing
+  icon system); every needed image is cataloged in `asset-manifest.json` with
+  purpose, usage, size, and format so designers can replace them later.
+
+## Current state (from the 2026-07-16 six-agent audit)
+
+Full detail lives in the audit and blueprint artifacts (maintainer has links);
+the load-bearing facts:
+
+- The sim already implements most hard mechanics, tested: the ten-craft ring
+  with adjacency/opposite math, additive-only skill, the archetype ceiling
+  (2 majors / hobby at rare / common floor), escalating make-amends, quality
+  rolls, signed materials, the self-signed reagent bonus, specialization perks
+  (material discount live), a complete tool layer, salvage, disenchant, enchant
+  application, focus re-spec costs, battlefield experience (one hook).
+- Almost none of it is player-reachable: 8 tested subsystems have no call
+  path; no UI shows a craft skill number; the identity half was stubbed online
+  until PR 2039 (in review at packet-creation time: cprof wire + shared combo
+  eligibility; 5 should-fix review items posted).
+- 21 recipes exist (9 common, 6 tool, 3 caster-hub, 3 combo), all auto-known;
+  jewelcrafting and inscription have zero.
+- Known bugs: trade strips `ItemInstancePayload` (silent data loss);
+  `harvestClaimedBy` never mirrored online (corpse picker offers claimed
+  corpses); two stale/weak test pins (tool no-op premise; the
+  one-recipe-per-craft test that only asserts a count).
+- Node harvests grant placeholder junk; the rarity roll rides an event nobody
+  consumes; nodes carry no tier; monster-harvest rarity uses a fixed baseline.
+- Corpse component rewards collide with quest items (a wolf hide advances a
+  boar quest); unmapped tags consume the claim for nothing.
+- The S3 localization scanner does not scan `src/sim/quests/quest_commands.ts`
+  (new quest player text can ship unlocalized without failing gates).
+
+## What we are NOT doing (this packet)
+
+- Wave 2+: market/mail carriage for instanced goods (#1146), commissions and
+  boundTo semantics (#1298), Jack of All Trades (#1296), monster-harvest
+  proficiency, salvage UI, battlefield experience expansion, item biographies,
+  tool effects, jewelcrafting/inscription depth. These stay filed on the epic.
+- Growing or shrinking the ten-craft wheel. Growth routes through gathering
+  skills and off-wheel systems per the design doc's fragility rules.
+- Any admission gate on known recipes, client-decided outcomes, or
+  graphics-tier gameplay differences.
+
+## Open items
+
+- PR 2039 must merge (with its 5 should-fix items addressed) before or
+  alongside Phase 1; the ring adoption lands inside that window.
+- Exact masterwork bonus curve and economy tuning numbers are named targets
+  with placeholder values in `state.md`, tuned in Phase 15 against live data.
+- Cloth material sourcing: humanoid corpse components plus a plant fiber from
+  herbalism (decided in brainstorm; exact item list lands in Phase 10).

--- a/docs/professions-2/implementation-plan.md
+++ b/docs/professions-2/implementation-plan.md
@@ -14,7 +14,13 @@ Workflow-orchestrated batch or verify-heavy work).
 1. **Step 0, pre-flight:** `git status` clean (a concurrent session may share
    the checkout); scan Claude Code memory (`MEMORY.md` index) for entries
    matching the phase domain (professions, design language, gate/Node quirks,
-   PR 2039).
+   PR 2039). Then **sync with the LATEST release branch**: fetch
+   `refs/heads/release/*`, pick the newest by version sort (`git branch -r
+   --list "origin/release/*" | sort -V | tail -1`; today that is
+   release/v0.27.0, tomorrow v0.28.0 and onward), base fresh branches on it,
+   and merge it into any existing feature branch at session start, running the
+   `release-merge-audit` skill on every such merge. The packet never falls
+   behind the active integration base.
 2. **Step 1, load context:** spawn an Explore agent to read and summarize
    `state.md`, `progress.md`, this phase's file, and the phase-relevant source
    and CLAUDE.md files. The main session does NOT read planning docs or
@@ -67,7 +73,16 @@ landed. Therefore every UI phase in this packet:
 - MUST NOT introduce DESIGN.md phase vocabulary (new ramp/radius/duration
   tokens, retuned gold-edge recipe, font flips, self-hosted fonts, window
   grammar fragments): that is a PR-blocking piecemeal re-land (DESIGN.md 14,
-  `src/styles/CLAUDE.md` dead-ends note).
+  `src/styles/CLAUDE.md` dead-ends note). This guardrail is CONDITIONAL on the
+  design-language program's rollout state: each UI phase checks at session
+  start whether DESIGN.md phases have landed (does `src/styles/tokens.css`
+  carry the ink/gold ramps and `--radius-window`? has `src/styles/CLAUDE.md`
+  been updated to point at DESIGN.md?). Once a DESIGN.md phase HAS landed, its
+  vocabulary is the baseline and new work consumes it. The maintainer intends
+  the professions windows to be the first feature under the new design system,
+  so the ideal sequencing is DESIGN.md phase 1 (tokens/theme/type) landing
+  before packet Phase 5; either way, building grammar-ready means the windows
+  inherit the restyle automatically.
 - Zero hex literals outside `tokens.css`/`theme.ts`; themed-vs-static token
   split respected (preset-aware jobs go through `theme.ts` knobs); focus via
   the `--color-border-focus` outline mechanism only.

--- a/docs/professions-2/implementation-plan.md
+++ b/docs/professions-2/implementation-plan.md
@@ -1,0 +1,114 @@
+# Professions 2.0: implementation plan
+
+The canonical workflow and phase index. Each phase is a fresh Claude Code
+session running its own starter prompt from `phase-NN-*.md`; each is followed
+by its QA session (`phase-NN-qa.md`). Locked decisions live in `state.md`;
+the vision lives in `brainstorm.md`.
+
+## Team workflow (every phase)
+
+Every phase runs on **Opus 4.8 at xhigh effort** (1m context variant where the
+file load demands it; add `ultracode` where the phase file says so, for
+Workflow-orchestrated batch or verify-heavy work).
+
+1. **Step 0, pre-flight:** `git status` clean (a concurrent session may share
+   the checkout); scan Claude Code memory (`MEMORY.md` index) for entries
+   matching the phase domain (professions, design language, gate/Node quirks,
+   PR 2039).
+2. **Step 1, load context:** spawn an Explore agent to read and summarize
+   `state.md`, `progress.md`, this phase's file, and the phase-relevant source
+   and CLAUDE.md files. The main session does NOT read planning docs or
+   coordinator monoliths directly.
+3. **Step 2, choose orchestration and execute:** lightest tool that fits;
+   request fan-out explicitly; give agents only the Explore summary. Worktree
+   isolation only when agents edit overlapping files in parallel.
+4. **Step 3, validation and review dispatch:** run the validation matrix rows
+   from `state.md` for the change type, then spawn ONLY the review agents
+   whose row matches the diff (matrix below). Prompt every review agent for
+   COVERAGE, not filtering. No commit while any BLOCKING finding stands.
+5. **Step 4, docs and memory:** update `progress.md` and `state.md`; record
+   surprises to memory; commit with explicit paths (never `git add -A`),
+   Conventional Commits with a body, no em dashes or emojis.
+
+### Review dispatch matrix (the one canonical copy)
+
+| Agent | Spawn ONLY when the diff touches | Skip it for |
+|-------|----------------------------------|-------------|
+| `privacy-security-review` | `server/`, `src/admin/`, `src/net/`, a deploy/secret file, OR introduces SQL / auth / a secret / `ALLOW_DEV_COMMANDS` / a new `Math.random`\|`Date.now`\|`performance.now` in `src/sim/` | a pure `src/ui` / `src/render` / `src/game` / `src/sim/content` / docs / test change |
+| `migration-safety` | `server/db.ts`, `server/social_db.ts`, a `server/*_db.ts`, or a `characters.state` JSONB serialize/deserialize path | any diff with no DDL and no persisted-state shape change |
+| `database-performance-reviewer` | SQL or a database call site, schema/indexes, query cadence or cardinality, pool/lock/timeout behavior, scheduled database work, a database driver or Postgres engine/config change, or stored-data growth | any diff that cannot change database work or growth |
+| `cross-platform-sync` | `src/world_api.ts` or `src/world_api/**`, `src/sim/` behavior/obs/`SimEvent`, `src/net/online.ts`, `server/game.ts` wire/dispatch, the matchers `src/ui/sim_i18n.ts`\|`src/ui/server_i18n.ts`, or the RL surface (`headless/`, `python/`) | a pure i18n catalog refactor with `t()` keys unchanged |
+| `architecture-reviewer` | a `src/sim/` change: determinism, rng draw-order, tick-phase order, the `SimContext` seam, or a move-not-rewrite relocation | a non-sim change, or a pure data/content/test change |
+| `frontend-seam-reviewer` | `src/ui/`, `src/render/`, `src/game/`, or `src/styles/` | a diff with no frontend surface |
+| `qa-checklist` | a phase / deliverable set is COMPLETE | per-commit / mid-phase work, or a docs/test-only change |
+
+If NO row matches, spawn NO review agent.
+
+### Code hygiene (every phase)
+
+- Module-first behind existing seams; never grow `sim.ts`, `hud.ts`,
+  `renderer.ts`, or `main.ts`; fix bugs test-first (`extract-and-test` skill).
+- Every new system, command, `IWorld` member, endpoint, and behavior gets
+  tests; determinism tests for new sim logic; re-pin deliberately when
+  changing pinned behavior; delete dead code and orphaned tests in the same
+  change.
+- `src/sim/` purity: no DOM/Three imports, no render/ui/game/net imports, all
+  randomness through `Rng`.
+- No hand-edits to generated files; regenerate via the owning build step.
+
+### Design-language guardrails (every UI phase; from the 2026-07-16 recon)
+
+DESIGN.md is the adopted standard but ZERO of its six rollout phases have
+landed. Therefore every UI phase in this packet:
+
+- Builds on TODAY'S tokens (`src/styles/tokens.css`) and the shared window
+  shell (`.window.panel`, drag/resize/focus/closeAll/z-band), grammar-ready
+  for the future DESIGN.md phase 5 restyle.
+- MUST NOT introduce DESIGN.md phase vocabulary (new ramp/radius/duration
+  tokens, retuned gold-edge recipe, font flips, self-hosted fonts, window
+  grammar fragments): that is a PR-blocking piecemeal re-land (DESIGN.md 14,
+  `src/styles/CLAUDE.md` dead-ends note).
+- Zero hex literals outside `tokens.css`/`theme.ts`; themed-vs-static token
+  split respected (preset-aware jobs go through `theme.ts` knobs); focus via
+  the `--color-border-focus` outline mechanism only.
+- New window body CSS lands as a ten-dash banner section in `components.css`
+  inside `@layer components`; every new `.window` id gets a deliberate
+  `body.mobile-touch` rule in `hud.mobile.css` (or a reasoned
+  `MOBILE_WINDOW_EXCEPTIONS` entry); `left` re-pins re-declare `transform`;
+  40px mobile tap floor; 16px input font floor.
+- Every player string is a `t()` key (English only; M16 wordy strings carry
+  five non-Latin fills); entity names via `tEntity`; keycaps via `keyLabel`.
+- Every visual phase ships before/after screenshots (desktop AND mobile,
+  `pr-screenshots` skill) committed under `docs/screenshots`.
+
+## Phase summary
+
+Phases 1 to 7 are the fun kernel; 8 to 15 are wave one. PR 2039 (open at
+packet creation; 104 files; adds `craftingIdentity`/`cprof`, the shared
+`combo_eligibility` rule with attunement-gated combos, `attunedPairs`
+pair-level history, craft/gather quest objectives, quest-driven attunement
+with selection, and an identity card view) merges as the foundation inside
+Phase 1.
+
+| # | Phase | One line | Primary surfaces |
+|---|---|---|---|
+| 1 | Ring and identity foundations | Merge-window amendments on PR 2039: adopt the blueprint ring, pair-named archetype titles, the 5 review items | sim content, i18n, tests |
+| 2 | Masterwork model | Deterministic outputs + masterwork proc with stats via `item_budget`; retire the five-way roll and `trivialAt` | sim, wire event, tests |
+| 3 | Host-parity bug fixes | Trade instance carriage; corpse claims on the wire | sim, net, server, tests |
+| 4 | Node materials and pristine veins | Real per-rarity node yields, signed rare+ yields, one rare event, gather feedback | sim content, ui, render |
+| 5 | The professions wheel window | The flagship window at deeds quality on the deeds recipe | ui, styles, i18n |
+| 6 | Crafting window upgrades and celebrations | Skill display, combo/station legibility, masterwork toast/broadcast, maker's mark tooltips | ui, i18n |
+| 7 | The Guild letter | Trend detection, the letter via mail, the first-attunement hook; S3 scanner gap closed | sim, content, tests |
+| 8 | Stations and masters (sim/server) | Typed station registry, master NPC records, placement-safety test, mobile-station perk live | sim, content, server |
+| 9 | Station presence and training | Station props + masters rendered, recipe training on `acquireRecipe`, shops, hands-vs-stations live | render, ui, content |
+| 10 | Recipe ladders and materials (ultracode) | Six deep crafts' tier ladders + material families + economy invariant tests | content, tests |
+| 11 | Fishing joins the framework | Fishing proficiency + catch rarity ladder feeding cooking | sim, content, ui |
+| 12 | Base tool tier gating | Node tiers; tool tier + skill gates; tools matter; effects stay parked | sim, content, tests |
+| 13 | Enchanting reachable | Disenchant + enchant-apply on IWorld/wire/UI in both hosts | world_api, net, server, ui |
+| 14 | Attunement quests and nudges | Lore quests at the masters for four archetypes; nudges; celebration | content, sim, ui |
+| 15 | Deeds, tuning, and polish | Universal profession deeds, economy tuning, wiki rewrite, final gate | content, docs, tests |
+
+Wave 2+ (NOT this packet, tracked on epic #1866): market/mail instance
+carriage (#1146), commissions and boundTo (#1298), Jack of All Trades
+(#1296), monster-harvest proficiency, salvage UI, battlefield experience
+expansion, item biographies, tool effects, jewelcrafting/inscription depth.

--- a/docs/professions-2/phase-01-qa.md
+++ b/docs/professions-2/phase-01-qa.md
@@ -1,0 +1,137 @@
+# Phase 01 QA: Verify Ring and identity foundations
+
+Audit the Phase 01 ring reorder, pair-named archetype identity, and PR 2039 review resolutions
+before Phase 2 builds on the new canonical pair ids.
+
+## Phase-specific QA emphasis
+
+- Hunt every derivation of ring order: grep for index math on `CRAFT_RING` (`indexOf`, modulo
+  and offset arithmetic, adjacency helpers) across `src/` and `tests/`; any survivor still
+  encoding the old rotation is BLOCKING.
+- Verify `attunedPairs` round-trips with the new canonical pair ids: serialize, load through
+  `normalizeArchetypeState`, attune again; a pre-reorder fixture must map or cleanly default.
+- Verify no i18n key orphans from the practitioner-title retirement: retired keys absent from
+  the catalog and generated bundles, no consumer still references them, and the ten new pair
+  keys are complete.
+
+## QA Starter Prompt
+
+```
+This is Phase 01 QA of the Professions 2.0 feature: Verify Ring and identity foundations.
+
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: audit the Phase 01 implementation for correctness, missing tests, dead code, determinism,
+three-host parity, and i18n completeness for THIS phase (ring reorder, pair-named titles, the
+PR 2039 review resolutions).
+
+STEP 0 - PRE-FLIGHT:
+- Verify `git status` is clean (the Phase 01 implementation should already be committed). If
+  dirty, ask the user (a concurrent session may share this checkout).
+- Memory scan: check the MEMORY.md index for entries relevant to this phase, at minimum: the
+  node25 gate rule (run npm run gate under Node 24), the PR 2039 state, and the
+  combo-recipes-broken-online entry (#2033, the ClientWorld stub trap for professions wire
+  parity).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn an Explore agent to read and summarize:
+- docs/professions-2/state.md (locked decisions, validation matrix, what Phase 1 recorded under
+  "New surfaces per phase")
+- docs/professions-2/progress.md (the Phase 1 deliverable checklist and claimed status)
+- docs/professions-2/phase-01-ring-and-identity.md (what was promised: deliverables, acceptance
+  criteria, stopping rules, and the phase-specific QA emphasis in the same file's companion,
+  docs/professions-2/phase-01-qa.md)
+- The full diff of Phase 01: git diff --name-only and git diff against the phase-start commit
+The summary must return: the full list of Phase 01 deliverables and acceptance criteria, every
+file created or modified, the new hudChrome pair-title key names, the re-pinned test names, the
+PR 2039 resolution status, and any known issues or deferrals noted in progress.md.
+
+STEP 2 - QA AUDIT:
+Spawn THREE parallel audit agents (explicit fan-out), each given ONLY the Explore summary.
+Prompt each for COVERAGE, not filtering: report every issue including low-severity and
+uncertain ones; ranking happens in a later step.
+
+Correctness agent:
+- Verify every Phase 01 deliverable was actually implemented and every acceptance criterion in
+  the phase prompt is met.
+- Run the phase's validation commands: npx tsc --noEmit; npx vitest run
+  tests/professions.test.ts tests/archetype_ceiling.test.ts tests/combo_eligibility.test.ts
+  tests/snapshots.test.ts tests/world_api_parity.test.ts; npx vitest run
+  tests/architecture.test.ts tests/env_protocol.test.ts tests/bandwidth.test.ts; npm run
+  i18n:gen then npx vitest run tests/i18n_completeness.test.ts tests/localization_fixes.test.ts.
+- Exercise the real behavior, not just the tests: confirm CRAFT_RING matches the blueprint
+  order; confirm both COMBO_RECIPES pairs pass combo_eligibility under the new ring; confirm
+  getArchetypeTitle resolves the pair name on the identity card, attunement preview, dialog
+  labels, and nameplate title path in BOTH the offline Sim and the online ClientWorld
+  (liveness, not member shape: the 2033 stub trap).
+- EMPHASIS: hunt every derivation of ring order. Grep src/ and tests/ for index math on
+  CRAFT_RING (indexOf, modulo or offset arithmetic, adjacency helpers); any surface still
+  encoding the old rotation is BLOCKING.
+- EMPHASIS: verify attunedPairs round-trips with the new canonical ids. Build a fixture
+  ArchetypeState with pre-reorder pair ids, load it through normalizeArchetypeState, and
+  confirm it maps or cleanly defaults; then attune, serialize, and reload to confirm the new
+  ids are stable.
+- Verify the five PR 2039 should-fix items are actually closed (matcher rows for the two
+  quest_commands.ts error strings plus the S3 scan-list line, the "Part of #1295" reword, the
+  13 Latin-overlay hand fills reverted, commit bodies present, PRD staleness fixed).
+
+Test coverage agent:
+- Identify new or changed code paths without tests (ring derivation helpers, pair-id
+  canonicalization, the normalizeArchetypeState back-compat branch, the title resolution path).
+- Add missing tests, including a same-seed determinism test if any sim logic (not just content
+  data) changed in this phase.
+- Verify the re-pins are deliberate assertions of the new canonical values, never loosened or
+  deleted assertions; verify the combo-pair adjacency pin exists.
+- Update tests broken by the phase; remove orphaned tests for the retired practitioner titles
+  or the old ring order.
+- Verify assertions are decisive (they would fail if the behavior regressed), not just "it
+  runs".
+
+Dead code and cleanup agent:
+- Find unused imports, functions, types, and constants left behind by the reorder and the title
+  retirement.
+- EMPHASIS: verify no i18n key orphans from the title retirement. The ten retired per-craft
+  practitioner keys are absent from src/ui/i18n.catalog/hud_chrome.ts and the generated
+  bundles, no locale-overlay rows dangle, and no consumer still references them; the ten new
+  pair keys (Smith, Outfitter, Apothecary, Bombardier, Trapper, Mageweaver, Arcanist,
+  Gembinder, Bladewright, Cogsmith) are all present in English only.
+- Verify sim purity holds: src/sim/ has no DOM, Three.js, render, ui, game, or net imports, and
+  no Math.random / Date.now / performance.now.
+- Check for leftover TODO or FIXME items, commented-out code, and naming inconsistent with the
+  surrounding modules.
+
+Multi-agent review dispatch: apply the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md; check git diff --name-only against the phase-start
+commit and spawn ONLY the matching rows, plus the qa-checklist agent (this is the
+phase-completion QA gate). Prompt each for COVERAGE, not filtering.
+Resume any agent that truncates with: "Stop reading more files. Output the full report now
+based on what you've already seen. No more tool calls. Format: BLOCKING / SHOULD-FIX /
+NICE-TO-HAVE / VERDICT."
+
+STEP 3 - FIX:
+- Apply every BLOCKING and SHOULD-FIX item.
+- Rerun the validation commands from STEP 2 (the net/wire, sim, and i18n matrix rows plus the
+  phase suite list) until green.
+- Commit the fixes with EXPLICIT paths, never git add -A; Conventional Commits with a scope and
+  a body, separate from the doc updates so the history stays reviewable.
+
+STEP 4 - UPDATE DOCS + MEMORY:
+- Update docs/professions-2/progress.md: mark Phase 1 QA complete; note anything deferred to a
+  follow-up.
+- Update docs/professions-2/state.md with any drift QA discovered (a missed derivation site, a
+  corrected key name, a revised locked decision).
+- Record to memory any surprising rule learned during QA.
+
+STEP 5 - FINAL RESPONSE FORMAT:
+End your turn with: QA verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL), counts of BLOCKING,
+SHOULD-FIX, and NICE-TO-HAVE items found and fixed, deferred items, and a one-line handoff for
+the Phase 2 implementation session.
+
+STOPPING RULES:
+- Stop and surface to the user if any BLOCKING item cannot be fixed without changing the phase
+  scope.
+- Stop and surface to the maintainer if QA finds that any production player already holds
+  attunedPairs pair ids derived from the old ring (a save migration becomes required).
+- Stop and surface to the maintainer if PR 2039 did not merge inside its window; Phase 2 must
+  not start on an unmerged foundation.
+```

--- a/docs/professions-2/phase-01-ring-and-identity.md
+++ b/docs/professions-2/phase-01-ring-and-identity.md
@@ -41,6 +41,11 @@ five PR 2039 review resolutions) inside PR 2039's merge window, before any playe
 ids derived from the old ring.
 
 STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
 - Verify `git status` is clean before starting. If not, ask the user (a concurrent session may
   share this checkout).
 - Memory scan: check the MEMORY.md index for entries relevant to this phase, at minimum: the

--- a/docs/professions-2/phase-01-ring-and-identity.md
+++ b/docs/professions-2/phase-01-ring-and-identity.md
@@ -1,0 +1,208 @@
+# Phase 01: Ring and identity foundations
+
+This phase lands the blueprint identity foundations inside PR 2039's merge window: the
+`CRAFT_RING` reorder to the design-doc order, pair-named archetype titles replacing the ten
+per-craft practitioner titles, and the five should-fix review items on PR 2039 itself. It is its
+own slice because the ring order, and the canonical pair ids derived from it, become persistent
+the moment any player attunes: everything here must land before a single player persists
+`attunedPairs` pair ids derived from the old ring, and no later phase can wait on that window.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: locked ring order, the validation matrix, and the verified
+  post-2039 surfaces (archetype module shape, `cprof` wire key, combo gate).
+- `docs/professions-2/progress.md`: the Phase 1 deliverable checklist to mirror on completion.
+- `docs/professions-2/implementation-plan.md`: team workflow and the Review Dispatch Matrix.
+- `src/sim/content/professions.ts`: `CRAFT_RING`, the reorder target.
+- `src/sim/professions/archetype.ts`: `archetypePairId`, `ARCHETYPE_PAIR_TARGETS`,
+  `attunedPairs`, `hobbyCandidatesForPair`; every ring-derived surface and the
+  `normalizeArchetypeState` back-compat path live here.
+- `src/sim/professions/combo_eligibility.ts`: the shared combo gate (deny reasons
+  `not_attuned` / `wrong_pair` / `tier_unmet`) that must keep working across the reorder.
+- `src/sim/content/recipes.ts`: `COMBO_RECIPES`, the two pairs whose ring adjacency must survive
+  the reorder (armorcrafting plus weaponcrafting, alchemy plus engineering).
+- `src/ui/i18n.catalog/hud_chrome.ts`: the existing per-craft `archetypeTitle` keys to retire and
+  the home for the ten new pair-title keys.
+- `getArchetypeTitle` and every consumer: the identity card, the attunement preview, dialog
+  labels, and the nameplate title path (the Explore agent locates the exact call sites).
+- Pinned suites to re-pin: `tests/professions.test.ts`, `tests/archetype_ceiling.test.ts`,
+  `tests/combo_eligibility.test.ts`, `tests/snapshots.test.ts`.
+- `CLAUDE.md` (root), `src/sim/CLAUDE.md`, `src/ui/CLAUDE.md`.
+
+## Starter Prompt
+
+```
+This is Phase 01 of the Professions 2.0 feature: Ring and identity foundations.
+
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: land the blueprint identity foundations (ring reorder, pair-named archetype titles, the
+five PR 2039 review resolutions) inside PR 2039's merge window, before any player persists pair
+ids derived from the old ring.
+
+STEP 0 - PRE-FLIGHT:
+- Verify `git status` is clean before starting. If not, ask the user (a concurrent session may
+  share this checkout).
+- Memory scan: check the MEMORY.md index for entries relevant to this phase, at minimum: the
+  node25 gate rule (run npm run gate under Node 24), the PR 2039 state and merge-window
+  coordination, and the combo-recipes-broken-online entry (#2033, the ClientWorld stub trap for
+  professions wire parity).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn an Explore agent to read and summarize:
+- docs/professions-2/state.md (locked decisions, validation matrix, key existing surfaces)
+- docs/professions-2/progress.md (Phase 1 status plus deliverable checklist)
+- docs/professions-2/phase-01-ring-and-identity.md (this prompt; verify the agent has the same
+  understanding)
+- src/sim/content/professions.ts (CRAFT_RING)
+- src/sim/professions/archetype.ts (archetypePairId, ARCHETYPE_PAIR_TARGETS, attunedPairs,
+  hobbyCandidatesForPair, normalizeArchetypeState)
+- src/sim/professions/combo_eligibility.ts
+- src/sim/content/recipes.ts (COMBO_RECIPES)
+- src/ui/i18n.catalog/hud_chrome.ts (the archetypeTitle keys)
+- tests/professions.test.ts, tests/archetype_ceiling.test.ts, tests/combo_eligibility.test.ts,
+  tests/snapshots.test.ts
+- CLAUDE.md (root), src/sim/CLAUDE.md, src/ui/CLAUDE.md
+The summary must return: the current CRAFT_RING order; every surface that derives from ring
+order or adjacency (index math, opposite and hobby maps, pair-id canonicalization, pinned test
+expectations); the attunedPairs shape and how normalizeArchetypeState loads it; the two
+COMBO_RECIPES pairs and their eligibility path; the exact archetypeTitle key names and every
+consumer of getArchetypeTitle (identity card, attunement preview, dialog labels, nameplate title
+path); and the five outstanding PR 2039 should-fix review items with their locations.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
+Fan out THREE agents in parallel (request the fan-out explicitly; Opus 4.8 will not
+self-initiate it). Give each agent ONLY the Explore summary, never the raw planning docs.
+Worktree isolation is unnecessary unless two agents end up editing the same file.
+
+Agent sim-content deliverables:
+- Reorder CRAFT_RING in src/sim/content/professions.ts to the design-doc order: engineering,
+  alchemy, cooking, leatherworking, tailoring, inscription, enchanting, jewelcrafting,
+  weaponcrafting, armorcrafting.
+- Audit EVERY surface deriving from ring order or adjacency and regenerate each one:
+  ARCHETYPE_PAIR_TARGETS, the opposite and hobby maps (hobbyCandidatesForPair), the
+  archetypePairId canonical ids, and any index math on CRAFT_RING anywhere in src/sim/.
+- Verify both content COMBO_RECIPES pairs stay ring-adjacent under the new order (they do:
+  armorcrafting plus weaponcrafting, alchemy plus engineering); pin that adjacency in a test so
+  a future reorder cannot silently break a combo recipe.
+- Re-pin every geometry and pair expectation in tests/professions.test.ts,
+  tests/archetype_ceiling.test.ts, tests/combo_eligibility.test.ts, and
+  tests/snapshots.test.ts (deliberate re-pins with the new canonical values, never loosened
+  assertions).
+- Back-compat: make normalizeArchetypeState map or cleanly default any pre-reorder attunedPairs
+  ids. First assert that no player data exists yet (PR 2039 is unmerged, so none should); if
+  that assertion cannot be made, write the explicit id mapping.
+
+Agent i18n-identity deliverables:
+- Add the ten pair-archetype title keys to src/ui/i18n.catalog/hud_chrome.ts in ENGLISH only:
+  Smith, Outfitter, Apothecary, Bombardier, Trapper, Mageweaver, Arcanist, Gembinder,
+  Bladewright, Cogsmith (map each name to its canonical pair id from ARCHETYPE_PAIR_TARGETS).
+- Change getArchetypeTitle to resolve the PAIR name, and update every consumer so the pair name
+  renders wherever a title shows: the identity card, the attunement preview, dialog labels, and
+  the nameplate title path.
+- Retire the ten per-craft practitioner title keys with full i18n hygiene: remove the keys,
+  remove every reference, run npm run i18n:gen, and confirm no orphaned rows remain in the
+  generated bundles or locale overlays (never hand-edit the overlays).
+
+Agent coordination deliverables (PR 2039 review items):
+- Resolve all five should-fix review items so PR 2039 merges:
+  1. Matcher rows for the two src/sim/quests/quest_commands.ts error strings plus the S3
+     scan-list line (sim-origin player text needs its sim_i18n matcher rows in the same change).
+  2. Reword "Part of #1295" in the PR body.
+  3. Revert the 13 Latin-overlay hand fills (locale overlays are release-time maintainer work).
+  4. Add bodies to the commits that lack them.
+  5. Fix the PRD staleness.
+- Note the merge-window coordination in the final response: whether the Phase 1 amendments land
+  in PR 2039 itself or as an immediate follow-up inside one deploy window (the state.md OPEN
+  item; coordinate with the maintainer).
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Determinism: all randomness via Rng; no Math.random / Date.now / performance.now anywhere in
+  src/sim/ (guarded by tests/architecture.test.ts).
+- JSONB back-compat: normalizeArchetypeState must map or cleanly default any pre-reorder
+  attunedPairs; assert no player data exists yet or write the mapping. Never lose or corrupt
+  persisted state.
+- Wire parity (cprof): craftingIdentity stays live in BOTH Sim and ClientWorld; any IWorld
+  surface touched is implemented in both worlds and parity-pinned in
+  tests/world_api_parity.test.ts. Verify liveness, not just member shape (the 2033 stub trap).
+- Server authority: the client never decides combo eligibility outcomes; the server
+  re-validates. The pre-cprof syncing state keeps the combo Craft button optimistically enabled
+  by design (locked decision in state.md).
+- i18n: every new player string is a t() key added in ENGLISH ONLY to
+  src/ui/i18n.catalog/hud_chrome.ts; never edit the locale overlays; sim/server player text
+  gets its matcher rule in src/ui/sim_i18n.ts / src/ui/server_i18n.ts in the SAME change (the
+  S3 guard, tests/localization_fixes.test.ts, enforces it).
+- Prime directive: nothing existing breaks. Every existing suite stays green; deprecate rather
+  than delete anything players may hold.
+
+Out of scope (do NOT do in this phase):
+- The masterwork model (Phase 2).
+- Stations in any form (Phases 8 and 9).
+- The professions wheel window (Phase 5).
+- Any new quest content (Phases 7 and 14).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+- Run the state.md validation matrix rows for this change type: the net/wire row, the sim row,
+  and the i18n row.
+  - npx tsc --noEmit
+  - npx vitest run tests/professions.test.ts tests/archetype_ceiling.test.ts
+    tests/combo_eligibility.test.ts tests/snapshots.test.ts tests/world_api_parity.test.ts
+  - npx vitest run tests/architecture.test.ts (sim purity plus determinism guard)
+  - npx vitest run tests/env_protocol.test.ts tests/bandwidth.test.ts (rest of the net/wire row)
+  - npm run i18n:gen, then npx vitest run tests/i18n_completeness.test.ts
+    tests/localization_fixes.test.ts (i18n row plus the S3 guard)
+- Spawn review agents per the Review Dispatch Matrix in
+  docs/professions-2/implementation-plan.md; check git diff --name-only against the phase-start
+  commit and spawn ONLY matching rows.
+- Prompt every review agent for COVERAGE, not filtering: report every issue including
+  low-severity and uncertain ones; ranking happens in a later step.
+- Resume any agent that truncates with: "Stop reading more files. Output the full report now
+  based on what you've already seen. No more tool calls. Format: BLOCKING / SHOULD-FIX /
+  NICE-TO-HAVE / VERDICT."
+- Do not commit while any BLOCKING finding stands.
+
+STEP 4 - COMMIT CADENCE:
+Aim for three commits (Conventional Commits with a scope; EXPLICIT paths, never git add -A;
+every commit carries a body of 1 to 4 sentences saying what changed and why):
+- feat(professions): adopt the blueprint craft ring order
+- feat(i18n): pair-named archetype titles
+- chore(professions): resolve PR 2039 review items
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] CRAFT_RING matches the blueprint order exactly: engineering, alchemy, cooking,
+      leatherworking, tailoring, inscription, enchanting, jewelcrafting, weaponcrafting,
+      armorcrafting.
+- [ ] Zero surfaces still derive from the old rotation: the derivation audit found and
+      regenerated every one (pair targets, opposite and hobby maps, canonical pair ids, index
+      math, test pins).
+- [ ] Both COMBO_RECIPES pairs verified ring-adjacent under the new order, pinned by a test.
+- [ ] Pair names render everywhere a title shows: identity card, attunement preview, dialog
+      labels, nameplate title path; the per-craft practitioner keys are gone with no orphans.
+- [ ] normalizeArchetypeState back-compat is asserted (no pre-reorder player data exists) or
+      the explicit id mapping is written and tested.
+- [ ] All five PR 2039 should-fix review items closed; the PR merges inside the window.
+- [ ] Parity and snapshot suites green: tests/world_api_parity.test.ts,
+      tests/snapshots.test.ts, plus the three professions suites.
+
+STEP 6 - DOC UPDATES + MEMORY:
+- Update docs/professions-2/progress.md: Phase 1 status plus the mirrored deliverable
+  checkboxes.
+- Update docs/professions-2/state.md. It gains: the final hudChrome pair-title key names under
+  "New surfaces per phase" (the Phase 1 row moves from planned to landed, with the re-pinned
+  ring geometry test names); the locked-decision note confirmed in place, that the pre-cprof
+  syncing state keeps the combo Craft button optimistically enabled (the server re-validates);
+  and the PR 2039 OPEN item resolved with the actual merge outcome and timing.
+- Record to memory anything surprising (an unexpected ring derivation site, a 2039 merge
+  complication) for the next session.
+
+STEP 7 - FINAL RESPONSE FORMAT:
+End your turn with: phase status, files touched, validation results, review-agent verdicts, any
+deferred items, and a one-line handoff for the Phase 01 QA session.
+
+STOPPING RULES:
+- Stop and surface to the maintainer if PR 2039 cannot merge in this window; the ring reorder
+  must not land detached from it.
+- Stop and surface to the maintainer if any production player already holds attunedPairs pair
+  ids derived from the old ring: a save migration becomes required and is not in this phase's
+  scope to improvise.
+```

--- a/docs/professions-2/phase-01-ring-and-identity.md
+++ b/docs/professions-2/phase-01-ring-and-identity.md
@@ -37,8 +37,9 @@ This is Phase 01 of the Professions 2.0 feature: Ring and identity foundations.
 Model: Opus 4.8, xhigh effort. Harness: Claude Code.
 
 Goal: land the blueprint identity foundations (ring reorder, pair-named archetype titles, the
-five PR 2039 review resolutions) inside PR 2039's merge window, before any player persists pair
-ids derived from the old ring.
+five PR 2039 review resolutions) DIRECTLY ON the PR 2039 branch, which the maintainer now owns
+outright, so the PR merges once, already correct, and pair ids derived from the old ring never
+exist in any deployed build.
 
 STEP 0 - PRE-FLIGHT:
 - Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
@@ -49,9 +50,15 @@ STEP 0 - PRE-FLIGHT:
 - Verify `git status` is clean before starting. If not, ask the user (a concurrent session may
   share this checkout).
 - Memory scan: check the MEMORY.md index for entries relevant to this phase, at minimum: the
-  node25 gate rule (run npm run gate under Node 24), the PR 2039 state and merge-window
-  coordination, and the combo-recipes-broken-online entry (#2033, the ClientWorld stub trap for
-  professions wire parity).
+  node25 gate rule (run npm run gate under Node 24), the professions-2-program entry (the
+  maintainer owns the PR 2039 branch; amendments land on it pre-merge), and the
+  combo-recipes-broken-online entry (#2033, the ClientWorld stub trap for professions wire
+  parity).
+- This phase's working branch IS the PR 2039 branch: bring its head into a maintainer-owned
+  branch (or push rights on the existing head), apply the release-branch sync above TO IT
+  (2039 was cut from an older release/v0.27.0 head; merge the newest release in and run the
+  release-merge-audit skill), and do all Phase 1 work on top. The PR history is yours to
+  clean: rewrite or squash so every commit carries a body.
 
 STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
 Spawn an Explore agent to read and summarize:
@@ -117,9 +124,8 @@ Agent coordination deliverables (PR 2039 review items):
   3. Revert the 13 Latin-overlay hand fills (locale overlays are release-time maintainer work).
   4. Add bodies to the commits that lack them.
   5. Fix the PRD staleness.
-- Note the merge-window coordination in the final response: whether the Phase 1 amendments land
-  in PR 2039 itself or as an immediate follow-up inside one deploy window (the state.md OPEN
-  item; coordinate with the maintainer).
+- All amendments land in PR 2039 itself (the maintainer owns the branch; nothing is set in
+  stone). The final response records the amended PR's head and its green CI run.
 
 INVARIANTS THIS PHASE MUST KEEP:
 - Determinism: all randomness via Rng; no Math.random / Date.now / performance.now anywhere in
@@ -205,8 +211,9 @@ End your turn with: phase status, files touched, validation results, review-agen
 deferred items, and a one-line handoff for the Phase 01 QA session.
 
 STOPPING RULES:
-- Stop and surface to the maintainer if PR 2039 cannot merge in this window; the ring reorder
-  must not land detached from it.
+- Stop and surface to the maintainer if the PR 2039 branch cannot be updated or its release
+  merge produces conflicts beyond this phase's scope; the ring reorder must not land detached
+  from the PR.
 - Stop and surface to the maintainer if any production player already holds attunedPairs pair
   ids derived from the old ring: a save migration becomes required and is not in this phase's
   scope to improvise.

--- a/docs/professions-2/phase-02-masterwork-model.md
+++ b/docs/professions-2/phase-02-masterwork-model.md
@@ -1,0 +1,176 @@
+# Phase 02: Masterwork model
+
+This phase replaces the five-way output quality roll with deterministic craft outputs plus a
+single celebrated masterwork proc whose bonus stats are baked from the item budget. It is its
+own slice because it rewrites the output-side RNG contract of crafting: every later phase
+(node materials in Phase 4, the crafting window and celebrations in Phase 6, recipe ladders in
+Phase 10, deeds and tuning in Phase 15) builds on deterministic outputs, so this contract must
+land and be pinned before content phases pin recipes against it.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: the locked masterwork decision (Locked design decisions), the
+  proc tuning targets (Tuning targets section), and the sim-only validation matrix row.
+- `docs/professions-2/progress.md`: the Phase 2 checklist and any Phase 1 notes.
+- `docs/professions-2/implementation-plan.md`: team workflow and the Review Dispatch Matrix.
+- `src/sim/professions/crafting.ts`: `resolveCraftForRecipe` quality path, the five-way roll
+  to retire.
+- `src/sim/professions/gathering.ts`: `rollMaterialRarity`, input-side RNG that stays untouched.
+- `src/sim/item_budget.ts`: `primaryStatBudget`, `normalizePrimaryStats`.
+- `src/sim/types.ts`: `ItemInstancePayload.rolled`.
+- `src/sim/professions/types.ts`: `trivialAt`, to be removed.
+- `src/sim/deeds.ts`: the rolled-quality reader that must stay coherent.
+- `src/sim/content/recipes.ts`: recipe records carrying `trivialAt`.
+- Tests pinning the old behavior: `tests/professions_crafting.test.ts`,
+  `tests/professions_rarity_roll.test.ts`, `tests/archetype_ceiling.test.ts`,
+  `tests/deeds.test.ts`, `tests/item_instance.test.ts`.
+- Local conventions: the root `CLAUDE.md`, `src/sim/CLAUDE.md`, `tests/CLAUDE.md`.
+
+## Starter Prompt
+
+```
+This is Phase 02 of the Professions 2.0 feature: Masterwork model.
+
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: replace the five-way output quality roll with deterministic craft outputs plus a
+masterwork proc whose bonus stats are baked from the item budget.
+
+STEP 0 - PRE-FLIGHT:
+- Confirm git status is clean (a concurrent session may share the checkout); stop and report
+  if it is not.
+- Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries, at minimum:
+  node25-breaks-jsdom-gate (run the gate under Node 24), the PR 2039 merge state (the Phase 1
+  foundation this phase builds on), and combo-recipes-broken-online (the #2033 ClientWorld
+  stub trap: verify liveness when mirroring anything online, not just member shape).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize:
+- docs/professions-2/state.md (locked masterwork decision, tuning targets, validation matrix)
+- docs/professions-2/progress.md (Phase 2 checklist, Phase 1 notes)
+- docs/professions-2/phase-02-masterwork-model.md (this phase file)
+- src/sim/professions/crafting.ts (the resolveCraftForRecipe quality path)
+- src/sim/professions/gathering.ts (rollMaterialRarity, input-side, stays)
+- src/sim/item_budget.ts (primaryStatBudget, normalizePrimaryStats)
+- src/sim/types.ts (ItemInstancePayload.rolled)
+- src/sim/professions/types.ts (trivialAt)
+- src/sim/deeds.ts (the rolled-quality reader)
+- src/sim/content/recipes.ts (recipe records carrying trivialAt)
+- CLAUDE.md files: the root one, src/sim/CLAUDE.md, tests/CLAUDE.md
+The summary must return: the locked masterwork decision and the tuning targets verbatim; where
+the five-way output quality roll happens and every Rng draw on the craft path in draw order;
+the ItemInstancePayload.rolled shape and every reader of rolled.quality (deeds, tooltips,
+recalcPlayerStats, save/load); the exact signatures of primaryStatBudget and
+normalizePrimaryStats and how quality tiers map to budget; the existing SimEvent emit plus
+wire mirror pattern to copy; every test file that pins the old roll or trivialAt; the sim-only
+validation matrix row from state.md.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
+Fan out three agents in parallel; give each ONLY the Explore summary, never the planning docs.
+Use worktree isolation only if two agents must edit the same file.
+
+Agent sim (proc module plus crafting path) deliverables:
+- New pure module src/sim/professions/masterwork.ts: proc chance computed from craft skill,
+  any self-signed reagent, and the 75-skill specialization threshold, per the tuning targets
+  in state.md (base 3 percent at recipe tier parity, +1 percent per skill tier above,
+  +2 percent with any self-signed reagent, +3 percent at the 75-skill specialization
+  threshold, cap 15 percent). Exactly one Rng draw decides the proc; the draw order on the
+  craft path is pinned by test.
+- Craft outputs become deterministic: every craft yields the recipe's declared output. The
+  five-way output quality roll is retired from the craft path only; input-side
+  rollMaterialRarity in gathering.ts is untouched.
+- trivialAt removed from ProfessionRecipeRecord and from all content in
+  src/sim/content/recipes.ts; no consumer remains anywhere.
+- A masterwork SimEvent with an id-based payload (recipe id, item id, crafter) emitted on
+  proc and mirrored into ClientWorld state for Phase 6 to render; the mirror must be live in
+  BOTH hosts (the #2033 trap: no dead stubs).
+
+Agent instance/stats (budget baking plus reader coherence) deliverables:
+- On proc, the crafted instance gains rolled.masterwork plus rolled.stats baked via
+  primaryStatBudget with a +1 quality-tier budget bump; the result stays bounded below the
+  raid floor band, and a test asserts the bound.
+- Equip path: masterwork stats on the instance apply through recalcPlayerStats.
+- The deeds item-discovery reader stays coherent: masterwork maps into its quality-tier read,
+  or the reader is updated with its own test. Do not change deed semantics.
+- Legacy instances with the old rolled.quality still load, tooltip, and equip correctly
+  (normalize-on-load, additive JSONB).
+
+Agent tests deliverables:
+- Re-pin every test that pinned the old five-way roll or trivialAt.
+- Determinism test: the same seed over a craft sequence yields identical outputs, including
+  proc occurrences (the rng draw-order pin).
+- The raid-floor bound test, the legacy rolled.quality load/tooltip test, and a parity test
+  for the masterwork SimEvent mirror.
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Determinism: all randomness through Rng, exactly one proc draw, draw order pinned; never
+  Math.random, Date.now, or performance.now in sim code.
+- IWorld/event parity: everything mirrored online lands live in BOTH Sim and ClientWorld,
+  parity pinned in the same change; verify liveness, not just member shape.
+- Server authority: the proc resolves server-side online; the client only renders.
+- i18n: sim and server stay language-agnostic; the masterwork event carries ids only. Any
+  player-visible text this phase would emit follows the S3 matcher duty in the same change
+  (expected: none; all text is Phase 6).
+- Prime directive: nothing existing breaks. Existing instances with old rolled.quality still
+  load and tooltip correctly; never delete an ItemDef players may hold.
+
+Out of scope (do NOT do in this phase):
+- Any UI: the toast, zone-chat broadcast, and tooltip work are Phase 6.
+- Material-tier proc inputs: they need Phase 4 materials; leave a named hook and record it as
+  a Phase 10 hook in state.md.
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+- Run the sim-only validation matrix row from state.md: npx tsc --noEmit, the affected
+  suites, tests/architecture.test.ts, and the determinism check.
+- Explicitly: npx vitest run tests/professions_crafting.test.ts
+  tests/professions_rarity_roll.test.ts tests/archetype_ceiling.test.ts tests/deeds.test.ts
+  tests/item_instance.test.ts tests/architecture.test.ts
+- If the diff touches src/net or a wire key for the event mirror, also run the net/wire row:
+  npx vitest run tests/snapshots.test.ts tests/world_api_parity.test.ts
+- Spawn review agents per the Review Dispatch Matrix in
+  docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY
+  matching rows (expected here: architecture-reviewer, cross-platform-sync, and qa-checklist
+  once the deliverable set is complete).
+- Prompt every review agent for COVERAGE, not filtering: report every correctness or
+  requirement gap with confidence and severity; filtering happens afterward in this session.
+- If any agent response comes back truncated, re-spawn that agent with a narrower scope and
+  merge the results; never accept a truncated report as complete.
+- No commit while any BLOCKING finding stands.
+
+STEP 4 - COMMIT CADENCE:
+Commit in slices with explicit paths (never git add -A); every commit carries a body:
+- feat(professions): add the masterwork proc module
+- feat(professions): bake budget-bounded masterwork stats into crafted instances
+- chore(professions): retire the output quality roll and trivialAt
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] Same seed, same outputs across a craft sequence, including proc occurrences.
+- [ ] A masterwork's stats live on the instance (rolled.masterwork, rolled.stats) and apply
+      on equip via recalcPlayerStats.
+- [ ] The five-way output quality roll is gone from the craft path; rollMaterialRarity for
+      gathering inputs is untouched; no consumer of trivialAt remains.
+- [ ] The masterwork SimEvent is emitted on proc and mirrored live into ClientWorld state.
+- [ ] The raid-floor bound is asserted by a test that actually binds.
+- [ ] Legacy instances with rolled.quality load, tooltip, and equip unchanged.
+- [ ] The STEP 3 validation commands are green.
+
+STEP 6 - DOC UPDATES + MEMORY:
+- Update docs/professions-2/progress.md: the Phase 2 status row and the Phase 2 checklist
+  mirror; record the phase-start and final commit hashes in the notes section so the QA
+  session can diff the phase.
+- Update docs/professions-2/state.md: move the Phase 2 entry under "New surfaces per phase"
+  from planned to landed, naming the masterwork SimEvent and its payload shape, the
+  instance.rolled.masterwork field, the rng draw-order pin test, the trivialAt removal, the
+  files created (src/sim/professions/masterwork.ts), and the named Phase 10 hook for
+  material-tier proc inputs.
+- Record any surprises to Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT:
+Phase status; files touched; validation results (each command, pass or fail); review agent
+verdicts; deferrals with reasons; one line handing off to phase-02-qa.md.
+
+STOPPING RULES:
+- Stop and ask the maintainer if the deeds reader cannot stay coherent without redefining
+  deed semantics; that is a maintainer call.
+- Stop and ask if any deliverable would require changing a locked decision in state.md.
+```

--- a/docs/professions-2/phase-02-masterwork-model.md
+++ b/docs/professions-2/phase-02-masterwork-model.md
@@ -37,6 +37,11 @@ Goal: replace the five-way output quality roll with deterministic craft outputs 
 masterwork proc whose bonus stats are baked from the item budget.
 
 STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
 - Confirm git status is clean (a concurrent session may share the checkout); stop and report
   if it is not.
 - Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries, at minimum:

--- a/docs/professions-2/phase-02-qa.md
+++ b/docs/professions-2/phase-02-qa.md
@@ -1,0 +1,106 @@
+# Phase 02 QA: Verify Masterwork model
+
+Audit the Phase 02 masterwork model for correctness, test coverage, determinism, three-host
+parity, and cleanup, then fix what the audit finds before Phase 3 begins.
+
+## Phase-specific QA emphasis
+
+- Rng draw-order regression across a craft sequence: replay a fixed-seed sequence of mixed
+  crafts (with and without self-signed reagents, above and below the 75-skill threshold) and
+  confirm outputs and proc occurrences are identical run to run; confirm the draw-order pin
+  fails when an extra draw is inserted.
+- The raid-floor bound test actually binds: raise the +1 quality-tier budget bump locally and
+  confirm the bound test fails, then revert. A bound test that cannot fail is a defect.
+- Legacy-instance load path: an instance persisted with the old `rolled.quality` loads,
+  tooltips, and equips with no stat change and no crash, in both hosts.
+
+## QA Starter Prompt
+
+```
+This is Phase 02 QA of the Professions 2.0 feature: Verify Masterwork model.
+
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: audit the Phase 02 change for correctness, missing tests, dead code, determinism,
+three-host parity, and i18n completeness for this phase, then fix what the audit finds.
+
+STEP 0 - PRE-FLIGHT:
+- Confirm git status is clean (a concurrent session may share the checkout); stop and report
+  if it is not.
+- Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries, at minimum:
+  node25-breaks-jsdom-gate (run the gate under Node 24), the PR 2039 merge state, and
+  combo-recipes-broken-online (the #2033 liveness trap for mirrored state).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize:
+- docs/professions-2/state.md and docs/professions-2/progress.md
+- docs/professions-2/phase-02-masterwork-model.md (deliverables and acceptance criteria)
+- the git diff against the phase-start commit recorded in progress.md (name every touched
+  file)
+The summary must return: each Phase 02 deliverable and acceptance criterion paired with where
+the diff claims to satisfy it; the locations of the proc module, the rng draw-order pin, the
+raid-floor bound test, and the event mirror path in both hosts; the phase validation
+commands from state.md's sim-only matrix row.
+
+STEP 2 - QA AUDIT:
+Fan out three agents in parallel, each with ONLY the Explore summary. Prompt each for
+COVERAGE, not filtering: report every gap with confidence and severity; this session filters.
+
+Agent correctness deliverables:
+- Verify every deliverable and acceptance criterion against the real code, not the phase
+  file's claims or the commit messages.
+- Run the phase validation commands: npx tsc --noEmit; npx vitest run
+  tests/professions_crafting.test.ts tests/professions_rarity_roll.test.ts
+  tests/archetype_ceiling.test.ts tests/deeds.test.ts tests/item_instance.test.ts
+  tests/architecture.test.ts; plus the net/wire row (tests/snapshots.test.ts,
+  tests/world_api_parity.test.ts) if the diff touches src/net or a wire key.
+- Exercise the real behavior: a fixed-seed craft sequence run twice must match, including
+  proc occurrences; a forced proc yields rolled.masterwork plus rolled.stats that apply on
+  equip via recalcPlayerStats; the deeds reader result for a masterwork item is coherent.
+- Probe the phase emphasis items: the rng draw-order regression across a mixed craft
+  sequence; prove the raid-floor bound test binds (raise the budget bump locally, watch the
+  test fail, revert); walk the legacy rolled.quality load path end to end in both hosts.
+
+Agent test-coverage deliverables:
+- Find untested paths: the proc-chance table edges (recipe tier parity, each bonus term, the
+  15 percent cap, the 75-skill threshold boundary), self-signed reagent detection, the
+  masterwork SimEvent mirror, save/load of rolled.masterwork.
+- Add missing tests, including a determinism test if sim logic changed and one is missing.
+- Remove orphaned tests still pinning the five-way roll or trivialAt.
+
+Agent dead-code-and-cleanup deliverables:
+- Unused imports, types, and content fields left behind by the trivialAt and quality-roll
+  removal, across src/sim/professions/ and src/sim/content/recipes.ts.
+- Sim purity: no DOM/Three imports, no Math.random, Date.now, or performance.now, all
+  randomness via Rng.
+- Leftover TODOs and debug remnants in the phase's diff.
+
+Also: spawn review agents per the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY matching
+rows; and run the qa-checklist agent over the phase diff, since the deliverable set is
+complete. Prompt all of them for COVERAGE, not filtering.
+If any agent response comes back truncated, re-spawn that agent with a narrower scope and
+merge the results; never accept a truncated report as complete.
+
+STEP 3 - FIX:
+- Apply every BLOCKING and SHOULD-FIX finding; defer only with a written reason.
+- Rerun the STEP 2 validation commands until green.
+- Commit with explicit paths (never git add -A), Conventional Commits with a scope and a
+  body, for example fix(professions): ... or test(professions): ... .
+
+STEP 4 - UPDATE DOCS + MEMORY:
+- Update docs/professions-2/progress.md: the Phase 2 QA status row, checklist deltas, and
+  notes on deferrals.
+- Update docs/professions-2/state.md if any surface changed during fixes.
+- Record any surprises to Claude Code memory.
+
+STEP 5 - FINAL RESPONSE FORMAT:
+Verdict: PASS, PASS-WITH-FOLLOWUPS, or FAIL; counts of BLOCKING, SHOULD-FIX, and deferred
+findings; the deferral list with reasons; one line handing off to Phase 3
+(phase-03-parity-bug-fixes.md).
+
+STOPPING RULES:
+- Stop and ask the maintainer if a fix would redefine deed semantics to keep the deeds
+  reader coherent; that is a maintainer call.
+- Stop and ask if a fix would change a locked decision in state.md.
+```

--- a/docs/professions-2/phase-03-parity-bug-fixes.md
+++ b/docs/professions-2/phase-03-parity-bug-fixes.md
@@ -1,0 +1,185 @@
+# Phase 03: Host-parity bug fixes
+
+This phase fixes the two known host-parity data bugs so item instances and corpse claims are
+truthful in every host: trades currently strip `ItemInstancePayload` (the `removePreferFungible`
+return is discarded), and `harvestClaimedBy` is hardcoded `null` in `ClientWorld`, so the online
+corpse picker offers corpses the sim has already claimed. It is its own slice because both bugs are
+pure parity repairs on surfaces later phases build on (masterwork instances from Phase 2 must
+survive trades; Phase 4 gathering trusts corpse claims), and neither adds new gameplay.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: locked decisions, the validation matrix (net/wire row), and the
+  "Key existing surfaces" section (instances, gathering, wire key pattern).
+- `docs/professions-2/progress.md`: the Phase 3 deliverable checklist.
+- `src/sim/social/trade.ts`: the trade resolver; the `removePreferFungible` return value is
+  discarded, which strips instance payloads on grant.
+- `src/sim/bags.ts`: `removePreferFungible` and the instance-preserving grant helpers.
+- `server/game.ts`: `wireEntity`, where the new `hcb` terse key joins the snapshot.
+- `src/net/online.ts`: `ClientWorld`, where `harvestClaimedBy` is hardcoded `null` today.
+- `src/ui/hud/loot/loot_window_controller.ts`: the corpse picker that must stop offering claimed
+  corpses online.
+- `src/sim/professions/combo_eligibility.ts`: the shared combo gate both hosts must consume
+  (the 2033 stub trap: verify liveness, not just member shape).
+- `tests/trade.test.ts`, `tests/corpse_harvest_sim.test.ts`: the suites to extend.
+- `tests/snapshots.test.ts`: the `ALL_DELTA_KEYS` / `TERSE_TO_IWORLD` wire pins; the existing
+  `prof`/`gprof`/`ncd`/`tfocus` self-wire keys are the pattern for `hcb`.
+- `CLAUDE.md` (root) plus `src/sim/CLAUDE.md`, `src/net/CLAUDE.md`, `server/CLAUDE.md`,
+  `src/ui/hud/CLAUDE.md`, `tests/CLAUDE.md`.
+
+## Starter Prompt
+
+```
+This is Phase 03 of the Professions 2.0 feature: Host-parity bug fixes.
+
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: fix the two known host-parity data bugs so instances and corpse claims are truthful
+everywhere.
+
+STEP 0 - PRE-FLIGHT:
+- Verify `git status` is clean before starting. If not, ask the user (a concurrent session may
+  share this checkout).
+- Memory scan (if you use Claude Code memory): check your MEMORY.md index and any entries
+  relevant to this phase's domain (suggested topics: combo-recipes-broken-online, the #2033
+  ClientWorld stub trap; node25-breaks-jsdom-gate, run the gate under Node 24; PR 2039 state,
+  the professions foundation this packet builds on).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn an Explore agent to read and summarize:
+- docs/professions-2/state.md (locked decisions, validation matrix, key existing surfaces)
+- docs/professions-2/progress.md (Phase 3 status + deliverable checklist)
+- docs/professions-2/phase-03-parity-bug-fixes.md (this prompt); verify the agent has the same
+  understanding
+- src/sim/social/trade.ts (where the removePreferFungible return is discarded)
+- src/sim/bags.ts (removePreferFungible and the instance-preserving grant path)
+- server/game.ts (wireEntity and how existing terse keys are delta-guarded)
+- src/net/online.ts (where harvestClaimedBy is hardcoded null; how cprof/prof/gprof/ncd/tfocus
+  mirror into ClientWorld)
+- src/ui/hud/loot/loot_window_controller.ts (how the corpse picker filters candidates)
+- src/sim/professions/combo_eligibility.ts (the shared combo gate)
+- tests/trade.test.ts, tests/corpse_harvest_sim.test.ts, tests/snapshots.test.ts (the
+  ALL_DELTA_KEYS / TERSE_TO_IWORLD pins)
+- CLAUDE.md (root) + src/sim/CLAUDE.md, src/net/CLAUDE.md, server/CLAUDE.md,
+  src/ui/hud/CLAUDE.md, tests/CLAUDE.md
+The agent must return: exactly where trade.ts discards the removePreferFungible return and what
+that return contains; the full ItemInstancePayload shape (signer, charges, rolled, boundTo) and
+the instance-preserving grant helpers in bags.ts; the recipe for adding a delta-omitted terse
+wire key (server emit in wireEntity, ClientWorld mirror, ALL_DELTA_KEYS + TERSE_TO_IWORLD pin
+updates); how the corpse picker sources harvestClaimedBy; how the crafting view consumes
+combo_eligibility today in each host; and the existing test patterns in the three suites.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
+Spawn three agents in parallel (explicit fan-out; Opus 4.8 will not self-initiate it). Give
+each agent ONLY the Explore summary plus its own file list, never the raw planning docs. Fix
+bugs test-first (the extract-and-test skill): reproduce each bug with a failing test that
+exercises the real code path, then make the smallest change that turns it green.
+
+Agent trade (sim) deliverables:
+- Trade carries ItemInstancePayload end to end: thread the consumed payloads from
+  removePreferFungible in src/sim/social/trade.ts into instance-preserving grants on the
+  receiving side, in BOTH trade directions.
+- A regression test in tests/trade.test.ts that trades an enchanted + signed + masterwork
+  instance and asserts full payload survival (signer, rolled, charges, boundTo intact after
+  the trade). Cover a mixed offer too: fungible stacks alongside instanced items in one trade,
+  with the right payloads landing on the right granted items.
+
+Agent wire (server + net) deliverables:
+- harvestClaimedBy rides the wire: a new terse key (hcb), delta-omitted like the existing
+  prof/gprof/ncd/tfocus keys, emitted from wireEntity in server/game.ts and registered in
+  ALL_DELTA_KEYS and TERSE_TO_IWORLD (re-pin tests/snapshots.test.ts deliberately).
+- ClientWorld mirrors hcb in src/net/online.ts, replacing the hardcoded null.
+- The corpse picker in src/ui/hud/loot/loot_window_controller.ts no longer offers claimed
+  corpses online, with a test against a ClientWorld-shaped stub.
+
+Agent tests deliverables:
+- A liveness test asserting the crafting view's combo gating consumes the shared
+  combo_eligibility result identically in Sim-shaped and ClientWorld-shaped inputs (the 2033
+  stub trap: assert live values flow, not just that the member exists).
+- Verify no wire pin, parity pin, or bandwidth pin is left stale by the other two agents'
+  changes; extend tests/corpse_harvest_sim.test.ts where the claim behavior gained a wire
+  surface.
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Prime directive: nothing existing breaks. Trades of plain fungible stacks, offline corpse
+  harvesting, and every existing wire consumer keep working unchanged.
+- Server authority: the server resolves all trade and claim outcomes; the client only mirrors
+  and renders (the picker filters on mirrored truth, it never decides claims).
+- Wire parity pins: every new terse key lands in ALL_DELTA_KEYS and TERSE_TO_IWORLD in the same
+  change; tests/snapshots.test.ts, tests/bandwidth.test.ts, and tests/world_api_parity.test.ts
+  stay green; hcb is delta-omitted and cheap.
+- IWorld both worlds: any read the UI consumes exists on the facet and behaves identically in
+  Sim and ClientWorld; verify liveness, not just member shape.
+- Determinism: all randomness via Rng; no Math.random, Date.now, or performance.now anywhere
+  in src/sim/; grant ordering in trade resolution stays deterministic.
+- i18n: this phase should add no player-visible text; if any string does become player-visible,
+  it is a t() key added in ENGLISH ONLY to the matching src/ui/i18n.catalog/<domain>.ts module,
+  and any sim/server player text gets a matcher rule in src/ui/sim_i18n.ts or
+  src/ui/server_i18n.ts in the SAME change (the S3 guard enforces it).
+
+Out of scope (do NOT do in this phase):
+- Mail and market instance carriage (wave 2, #1146): mail and market keep refusing instanced
+  items; do not touch their refusal paths.
+- boundTo semantics (commissions, #1298): carry the field verbatim; do not interpret it.
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+- Run the net/wire row of the validation matrix in docs/professions-2/state.md plus the phase
+  suites:
+  npx vitest run tests/trade.test.ts tests/snapshots.test.ts tests/bandwidth.test.ts
+    tests/corpse_harvest_sim.test.ts tests/world_api_parity.test.ts
+  npx vitest run tests/env_protocol.test.ts (the remaining net/wire row member)
+  npx vitest run tests/architecture.test.ts (sim files changed)
+  npx tsc --noEmit
+  npm run ci:changed
+- Spawn review agents per the Review Dispatch Matrix in
+  docs/professions-2/implementation-plan.md; check git diff --name-only against the phase-start
+  commit and spawn ONLY matching rows (this diff will likely match cross-platform-sync,
+  architecture-reviewer, privacy-security-review, and frontend-seam-reviewer; dispatch from the
+  actual diff, not this guess).
+- Prompt each agent you spawn for COVERAGE not filtering: report every issue including
+  low-severity and uncertain ones; ranking happens in a later step.
+- Resume any agent that truncates with: "Stop reading more files. Output the full report now
+  based on what you've already seen. No more tool calls. Format: BLOCKING / SHOULD-FIX /
+  NICE-TO-HAVE / VERDICT."
+- Do not commit while any BLOCKING finding stands.
+
+STEP 4 - COMMIT CADENCE:
+Aim for 3 commits with these headlines (Conventional Commits with a scope; EXPLICIT paths,
+never git add -A; every commit carries a body saying what changed and why; no em dashes or
+emojis):
+- fix(sim): trade preserves item instance payloads end to end
+- fix(net): mirror corpse harvest claims online via the hcb wire key
+- test(ui): pin combo gating liveness across Sim and ClientWorld shapes
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] Traded instances keep signer, rolled, charges, and boundTo, in both trade directions,
+      including a mixed fungible + instanced offer (regression test green)
+- [ ] harvestClaimedBy rides the wire as hcb (delta-omitted) and ClientWorld mirrors it; the
+      online corpse picker matches sim truth and no longer offers claimed corpses (stub test
+      green)
+- [ ] The combo-gating liveness test passes with Sim-shaped and ClientWorld-shaped inputs
+- [ ] ALL_DELTA_KEYS and TERSE_TO_IWORLD pins updated deliberately; tests/snapshots.test.ts,
+      tests/bandwidth.test.ts (hcb is cheap), and tests/world_api_parity.test.ts green
+- [ ] tests/trade.test.ts, tests/corpse_harvest_sim.test.ts, tests/env_protocol.test.ts,
+      tests/architecture.test.ts, npx tsc --noEmit, and npm run ci:changed all green
+- [ ] Mail and market still refuse instanced items (untouched)
+
+STEP 6 - DOC UPDATES + MEMORY:
+- Update docs/professions-2/progress.md: mark Phase 3 status and check its deliverable boxes;
+  note any deferrals.
+- Update docs/professions-2/state.md: flip the Phase 3 line under "New surfaces per phase" from
+  planned to landed (the hcb wire key with its pin locations, the trade payload carriage path
+  in trade.ts/bags.ts, and the liveness test file name); update the "Key existing surfaces"
+  instances bullet (trade no longer strips payloads).
+- If you use Claude Code memory, record any surprising rules or current-state notes for the
+  next session.
+
+STEP 7 - FINAL RESPONSE FORMAT:
+End your turn with: phase status, files touched, validation results, review-agent verdicts,
+any deferred items, and a one-line handoff for the Phase 3 QA session.
+
+STOPPING RULES:
+- No phase-specific stopping rules. Packet defaults apply: stop and ask the user if a fix would
+  force a backwards-incompatible wire change or a persisted characters.state shape change, and
+  stop if any BLOCKING review finding cannot be resolved inside this phase's scope.
+```

--- a/docs/professions-2/phase-03-parity-bug-fixes.md
+++ b/docs/professions-2/phase-03-parity-bug-fixes.md
@@ -38,6 +38,11 @@ Goal: fix the two known host-parity data bugs so instances and corpse claims are
 everywhere.
 
 STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
 - Verify `git status` is clean before starting. If not, ask the user (a concurrent session may
   share this checkout).
 - Memory scan (if you use Claude Code memory): check your MEMORY.md index and any entries

--- a/docs/professions-2/phase-03-qa.md
+++ b/docs/professions-2/phase-03-qa.md
@@ -1,0 +1,127 @@
+# Phase 03 QA: Verify Host-parity bug fixes
+
+Audit the Phase 03 parity fixes (trade instance carriage, corpse claims on the wire, combo-gating
+liveness) for correctness, coverage, and cleanliness before Phase 4 builds on them.
+
+## QA Starter Prompt
+
+```
+This is Phase 03 QA of the Professions 2.0 feature: Verify Host-parity bug fixes.
+
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: Audit the Phase 03 implementation for correctness, missing tests, dead code, determinism,
+three-host parity, and i18n completeness for this phase.
+
+STEP 0 - PRE-FLIGHT:
+- Verify `git status` is clean (the Phase 03 implementation should already be committed). If
+  dirty, ask the user (a concurrent session may share this checkout).
+- Memory scan (if you use Claude Code memory): check entries from the Phase 03 domain
+  (suggested topics: combo-recipes-broken-online, the #2033 stub trap this phase closes;
+  node25-breaks-jsdom-gate, run the gate under Node 24).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn an Explore agent to read and summarize:
+- docs/professions-2/state.md (the Phase 3 entry under "New surfaces per phase": the hcb wire
+  key, the trade payload carriage path, the liveness test)
+- docs/professions-2/progress.md (the Phase 3 deliverable checklist + acceptance criteria)
+- docs/professions-2/phase-03-parity-bug-fixes.md (the implementation prompt: what was promised)
+- The git diff against the Phase 03 start commit (git diff --name-only first, then the diffs of
+  every file it lists)
+- CLAUDE.md (root) + src/sim/CLAUDE.md, src/net/CLAUDE.md, server/CLAUDE.md,
+  src/ui/hud/CLAUDE.md, tests/CLAUDE.md
+The agent must return: the full list of Phase 03 deliverables and acceptance criteria, all new
+and modified files, how the trade payload threading and the hcb key were actually implemented,
+and any known issues or deferrals noted in progress.md.
+
+STEP 2 - QA AUDIT (spawn three parallel agents using the Explore summary; prompt each for
+COVERAGE not filtering: report every issue including low-severity and uncertain ones; ranking
+happens in a later step):
+
+Correctness agent:
+- Verify every Phase 03 deliverable was actually implemented and every acceptance criterion in
+  the phase prompt is met.
+- Run the phase's validation commands: npx vitest run tests/trade.test.ts
+  tests/snapshots.test.ts tests/bandwidth.test.ts tests/corpse_harvest_sim.test.ts
+  tests/world_api_parity.test.ts, plus tests/env_protocol.test.ts, tests/architecture.test.ts,
+  and npx tsc --noEmit.
+- Exercise the real behavior, not just the tests: trade an enchanted + signed + masterwork
+  instance both directions and inspect the granted payloads; claim a corpse and confirm the
+  mirrored harvestClaimedBy reaches the picker filter.
+- Phase-specific emphasis (probe each explicitly):
+  - Partial-stack trades: an offer mixing fungible stacks with instanced items must grant the
+    right payloads to the right items, with no payload duplicated onto a fungible grant and no
+    instance flattened into a stack.
+  - The hcb claim key under interest-scope edges: a corpse leaving and re-entering the ~120 yd
+    interest radius must arrive with the correct claim state, and a claim change while the
+    corpse is out of scope must not leave a stale mirror.
+  - No snapshot bloat: hcb is delta-omitted, absent when unchanged, and tests/bandwidth.test.ts
+    confirms it is cheap.
+- Verify the offline Sim path and the online ClientWorld path behave identically for trades,
+  corpse claims, and combo gating; check edge cases (empty trade, self-claimed corpse, a corpse
+  claimed by the viewing player, cancelled trade returning instances intact).
+
+Test coverage agent:
+- Identify Phase 03 code paths without tests (both trade directions, the mixed offer, the hcb
+  delta omission, the picker filter, the ClientWorld mirror).
+- Add missing tests, including a determinism test (same seed, same result) if sim logic changed
+  (trade grant ordering is sim logic).
+- Update any existing tests broken by Phase 03; verify the ALL_DELTA_KEYS / TERSE_TO_IWORLD
+  re-pins were deliberate, not accidental.
+- Remove orphaned tests for replaced behavior (for example a test pinning the old
+  payload-stripping trade or the hardcoded-null harvestClaimedBy).
+- Verify assertions are decisive (they check payload field values and claim ids, not just "it
+  runs").
+
+Dead code and cleanup agent:
+- Find unused imports, functions, and types left behind in src/sim/social/trade.ts,
+  src/sim/bags.ts, server/game.ts, src/net/online.ts, and
+  src/ui/hud/loot/loot_window_controller.ts.
+- Verify sim purity holds: src/sim/ imports nothing from render/ui/game/net, no DOM or Three
+  imports, no Math.random / Date.now / performance.now (tests/architecture.test.ts green).
+- Remove commented-out code and resolve or file any leftover TODO/FIXME from the phase.
+- Check naming consistency (hcb follows the prof/gprof/ncd/tfocus key conventions) and that no
+  duplicate claim-filtering logic was left in the picker.
+
+Multi-agent review dispatch: apply the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md; check git diff --name-only against the phase-start
+commit and spawn ONLY the agents whose row matches, plus qa-checklist (this is the
+phase-completion QA gate). Prompt every spawned agent for COVERAGE not filtering. Resume any
+agent that truncates mid-analysis with: "Stop reading more files. Output the full report now
+based on what you've already seen. No more tool calls. Format: BLOCKING / SHOULD-FIX /
+NICE-TO-HAVE / VERDICT."
+
+STEP 3 - FIX:
+Apply all BLOCKING and SHOULD-FIX items. Rerun the validation commands above (at minimum
+npx tsc --noEmit plus the affected vitest files; the S3 guard
+tests/localization_fixes.test.ts if any player text changed). Commit fixes with EXPLICIT
+paths (never git add -A), Conventional Commits with a body, separate from the QA verdicts so
+the history is reviewable.
+
+STEP 4 - UPDATE DOCS + MEMORY:
+- Update docs/professions-2/progress.md (mark Phase 3 QA complete; note items deferred to
+  follow-up).
+- Update docs/professions-2/state.md (any drift discovered during QA, for example a pin
+  location or payload field the implementation summary got wrong).
+- If you use Claude Code memory, record any surprising rules learned during QA.
+
+STEP 5 - FINAL RESPONSE FORMAT:
+End your turn with: QA verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL), counts of BLOCKING /
+SHOULD-FIX / NICE-TO-HAVE found and fixed, deferred items, and a one-line handoff for Phase 4.
+
+STOPPING RULES:
+- Stop and surface to the user if any BLOCKING item cannot be fixed without changing the phase
+  scope (for example if truthful claims require a wire shape change beyond a delta-omitted
+  key).
+```
+
+## Phase-specific QA emphasis
+
+- Partial-stack trades: mixed fungible + instanced offers must grant correct payloads on the
+  correct items in both directions; probe stack splits and cancelled trades.
+- The hcb claim key under interest-scope edges: corpses crossing the interest radius must never
+  show a stale or missing claim in `ClientWorld`.
+- No snapshot bloat: `hcb` is delta-omitted and absent when unchanged; `tests/bandwidth.test.ts`
+  stays green without loosened budgets.
+- Liveness, not shape: the combo-gating test must prove live `combo_eligibility` values flow
+  through `ClientWorld`, not merely that the member exists (the #2033 trap).

--- a/docs/professions-2/phase-04-node-materials.md
+++ b/docs/professions-2/phase-04-node-materials.md
@@ -1,0 +1,196 @@
+# Phase 04: Node materials and pristine veins
+
+This phase makes node gathering yield real materials: per-node-type tables keyed by rolled
+rarity replace the placeholder junk grants, rare+ yields are signed like corpse yields, one
+rare event (the pristine vein) lands, and the long-dormant `gatherResult` event finally gets
+visible feedback (SFX cue plus a rarity-colored loot line). It is its own slice because it
+closes the gathering input loop end to end, on top of the Phase 2 signing model and ahead of
+recipe consumption (Phase 10) and tier gating (Phase 12), so materials exist and feel
+rewarding before anything spends them.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: locked decisions (RNG in, determinism out; prime directive;
+  zone-1 stockpiling mitigation), the pristine vein tuning target (roughly 1 per zone per
+  20 minutes, 5x yield, always signed), the validation matrix, and the "Gathering" row under
+  key existing surfaces.
+- `docs/professions-2/progress.md`: status table and the Phase 4 deliverable checklist.
+- `docs/professions-2/implementation-plan.md`: team workflow, the Review Dispatch Matrix,
+  code hygiene, and the design-language guardrails.
+- `src/sim/professions/gathering.ts`: `NODE_HARVEST_TABLE`, `resolveHarvest`, and the
+  `gatherResult` event (emitted today, consumed by nobody).
+- `src/sim/content/gather_nodes.ts`: node definitions per zone (node types, placement).
+- `src/sim/content/items.ts`: the ItemDef catalog; new material defs land here.
+- `src/sim/interaction.ts`: the corpse signing precedent for signed yield instances.
+- `src/ui/`: the HUD log (loot line consumer) and the quality token family for rarity colors;
+  the client matchers `src/ui/sim_i18n.ts` / `src/ui/server_i18n.ts` for id-based sim text.
+- `src/game/`: the sampled WebAudio SFX entry point for the gather cue.
+- Local conventions: root `CLAUDE.md`, `src/sim/CLAUDE.md`, `src/ui/CLAUDE.md`,
+  `tests/CLAUDE.md`.
+
+## Starter Prompt
+
+```
+This is Phase 04 of the Professions 2.0 feature: Node materials and pristine veins.
+
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: make node gathering yield real materials with rarity, signed rare+ yields, one rare
+event (the pristine vein), and visible feedback for every harvest.
+
+STEP 0 - PRE-FLIGHT:
+- Confirm `git status` is clean (a concurrent session may share the checkout). Record the
+  current HEAD hash; the QA session diffs against it (note it in progress.md at STEP 6).
+- Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries: the node25 gate
+  rule (run `npm run gate` under Node 24), PR 2039 state (the professions foundation this
+  packet builds on), and the design-language program (DESIGN.md guardrails for any UI touch).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn an Explore agent to read and summarize:
+- docs/professions-2/state.md and docs/professions-2/progress.md
+- docs/professions-2/phase-04-node-materials.md (this file)
+- src/sim/professions/gathering.ts, src/sim/content/gather_nodes.ts,
+  src/sim/content/items.ts, src/sim/interaction.ts
+- the HUD log module and SFX cue entry point it locates under src/ui/ and src/game/
+- root CLAUDE.md, src/sim/CLAUDE.md, src/ui/CLAUDE.md, tests/CLAUDE.md
+The summary must return: the NODE_HARVEST_TABLE shape and where the placeholder junk grants
+live; the resolveHarvest flow and its exact Rng draw order; the gatherResult event payload
+and the absence of consumers; how corpse yields get signed in interaction.ts (the precedent
+to copy); ItemDef catalog conventions (fields, English names, procedural icon fallback); the
+quality token family used for rarity colors; the pristine vein tuning target from state.md;
+the validation matrix rows for sim-only and content-only changes; and any locked decision
+that constrains this phase (zone-1 stockpiling mitigation, prime directive, RNG model).
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
+Fan out three parallel agents. Each agent receives ONLY the Explore summary, never the raw
+planning docs. Keep file ownership disjoint (sim/content agent owns gathering.ts and the
+content files; event/feedback agent owns the new vein module plus ui/game consumers; tests
+agent owns tests/); if ownership must overlap, sequence those agents or worktree-isolate per
+implementation-plan.md.
+
+Agent sim/content deliverables:
+- Replace the placeholder junk grants in NODE_HARVEST_TABLE with per-node-type material
+  tables keyed by the rolled rarity: ores for mining nodes, logs for timber, herbs for herb
+  nodes, at zone-appropriate tiers. Zone 1 stays common/low tier per the stockpiling
+  mitigation locked in state.md.
+- Add the new material ItemDefs to src/sim/content/items.ts with English names in the items
+  catalog and procedural icon fallbacks (no new WebP assets this phase).
+- Rare+ node yields become signed instances exactly like corpse yields: follow the corpse
+  signing precedent in src/sim/interaction.ts, signer = the gathering player.
+- Do NOT delete or alter the junk ItemDefs (bone_fragments, linen_scrap, spider_leg).
+  Players hold them; only their node sources go away (prime directive).
+
+Agent event/feedback deliverables:
+- Pristine vein: a rare per-player node state rolled through Rng at the state.md tuning
+  cadence (roughly 1 per zone per 20 minutes), five-fold yield, always signed. Land it as
+  its own small module behind the SimContext seam (module-first), never a method cluster on
+  a coordinator, called from the resolveHarvest path.
+- The vein emits an id-based soft zone broadcast: sim/server stays language-agnostic (stable
+  id plus values); add the client matcher rows in the SAME change (S3 guard).
+- Leave a named deed-mark hook at the vein resolution site; deed registration is deferred to
+  Phase 15. Do not author any deed records now.
+- Consume gatherResult in the client: play the SFX cue and append a rarity-colored loot line
+  to the HUD log. Colors come from the existing quality token family only; the feedback is
+  identical on every graphics tier (fairness invariant). New player strings are English-only
+  t() keys in the matching src/ui/i18n.catalog/ module.
+
+Agent tests deliverables:
+- Determinism pin: the Rng draw order through resolveHarvest INCLUDING the new vein roll;
+  same seed gives the same yields. If the extra roll changes existing pinned draws, re-pin
+  deliberately and say so in the commit body.
+- Rarity distribution test against the pinned roll (tests/professions_rarity_roll.test.ts).
+- Signing tests: rare+ yields carry a signer; pristine vein yields are always signed.
+- Zone-1 cap test: zone 1 node tables can only produce common/low-tier materials.
+- Acceptance test: no node grants bone_fragments, linen_scrap, or spider_leg anymore, while
+  those ItemDefs remain defined in the catalog.
+- S3 guard coverage for the broadcast id and matcher (tests/localization_fixes.test.ts).
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Determinism: all randomness through Rng (never Math.random, Date.now, performance.now in
+  sim logic); the vein roll's draw order is pinned by a test.
+- Sim purity: src/sim/ gains zero DOM/Three imports and never imports render/ui/game/net.
+- Server authority: yields, rarity, signing, and vein rolls resolve in the sim on the
+  server; the client only renders gatherResult and the broadcast.
+- IWorld both worlds: if any new read or event crosses the render/ui seam, add it to the
+  matching facet file (src/world_api/<domain>.ts), implement it in BOTH Sim and ClientWorld,
+  and update tests/world_api_parity.test.ts in the same change. Verify liveness online, not
+  just member shape (the 2033 stub trap).
+- i18n: every player-visible string is an English-only t() key in the catalog; material
+  names are English catalog entries; the broadcast and loot line are id-based and localized
+  via the client matcher in the same change (the S3 guard enforces it).
+- Fairness: the cue and loot line are identical on every graphics tier; rarity colors come
+  only from the existing quality token family.
+- Prime directive: nothing existing breaks. Junk ItemDefs stay defined; existing gathering
+  flows (harvestNode in both hosts, ncd cooldowns) keep working.
+
+Out of scope (do NOT do in this phase):
+- Node TIER gating (Phase 12).
+- Recipe consumption of these materials (Phase 10).
+- Fishing (Phase 11).
+- Pristine vein deed authoring or registration (Phase 15; leave only the named hook).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+- Run the state.md validation matrix rows for sim-only and content-only changes:
+  npx tsc --noEmit
+  npx vitest run tests/gather_node_harvest.test.ts tests/professions_rarity_roll.test.ts \
+    tests/gathering.test.ts tests/localization_fixes.test.ts tests/architecture.test.ts
+- npm run wiki:content (new player-facing items feed the guide). If new t() keys were added:
+  npm run i18n:gen, then npx vitest run tests/i18n_completeness.test.ts.
+- npm run ci:changed; format only changed files with a scoped
+  npx @biomejs/biome check --write <file>.
+- Spawn review agents per the Review Dispatch Matrix in
+  docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY
+  matching rows.
+- Prompt every review agent for COVERAGE, not filtering: report every correctness or
+  requirement gap with confidence and severity; the main session filters afterward. No
+  commit while any BLOCKING finding stands.
+- If any agent reply comes back truncated, resume that agent and have it continue from where
+  it stopped; do not restart completed work.
+
+STEP 4 - COMMIT CADENCE:
+Three commits, in this order, each staging explicit paths (never git add -A; the worktree
+may be shared) and each carrying a body (what changed and why, 1 to 4 sentences):
+- feat(professions): real node material tables
+  (gathering.ts tables, gather_nodes.ts, items.ts material defs, table tests)
+- feat(professions): pristine veins
+  (vein module, rare+ signing, broadcast id, deed hook, determinism re-pin if any)
+- feat(ui): gather feedback line and cue
+  (gatherResult consumers, loot line, SFX cue, matcher rows, i18n catalog keys)
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] No node grants bone_fragments, linen_scrap, or spider_leg anymore; those ItemDefs
+      themselves remain untouched in the catalog.
+- [ ] Rarity distribution matches the pinned roll (tests/professions_rarity_roll.test.ts
+      green against the new tables).
+- [ ] Rare+ node yields are signed instances, matching the corpse signing precedent.
+- [ ] Pristine vein: rolled through Rng at the state.md cadence, five-fold yield, always
+      signed, id-based soft zone broadcast emitted and matcher-localized; named deed hook
+      left dormant.
+- [ ] gatherResult consumed: SFX cue plus rarity-colored loot line in the HUD log, colors
+      from the quality token family, identical on every graphics tier.
+- [ ] Loot line and broadcast fully localized (English catalog keys plus matcher rows; the
+      S3 guard tests/localization_fixes.test.ts is green).
+- [ ] Zone-1 tables cap at common/low tier (pinned by a test).
+- [ ] All STEP 3 validation commands pass.
+
+STEP 6 - DOC UPDATES + MEMORY:
+- Update docs/professions-2/progress.md: Phase 4 row status and dates, mirror the checked
+  acceptance boxes, note the phase-start and phase-end commit hashes and any deferrals.
+- Update docs/professions-2/state.md: replace the planned "Phase 4" row under "New surfaces
+  per phase" with what actually landed: the material table symbol names, the new material
+  ItemDef id namespace, the pristine vein module path and its SimEvent/broadcast id, the
+  deed-mark hook location, and the gather feedback i18n key namespace.
+- Record any surprises (draw-order re-pins, matcher quirks) to Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT:
+- Phase status (complete / partial with reasons).
+- Files touched (grouped by commit).
+- Validation results (each command, pass/fail).
+- Review agent verdicts and how each finding was resolved.
+- Deferrals with the phase that owns them.
+- One-line QA handoff for the phase-04-qa.md session.
+
+STOPPING RULES:
+- None special for this phase. If satisfying a deliverable would contradict a locked
+  decision in state.md, stop and report instead of improvising.
+```

--- a/docs/professions-2/phase-04-node-materials.md
+++ b/docs/professions-2/phase-04-node-materials.md
@@ -39,6 +39,11 @@ Goal: make node gathering yield real materials with rarity, signed rare+ yields,
 event (the pristine vein), and visible feedback for every harvest.
 
 STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
 - Confirm `git status` is clean (a concurrent session may share the checkout). Record the
   current HEAD hash; the QA session diffs against it (note it in progress.md at STEP 6).
 - Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries: the node25 gate

--- a/docs/professions-2/phase-04-qa.md
+++ b/docs/professions-2/phase-04-qa.md
@@ -1,0 +1,116 @@
+# Phase 04 QA: Verify Node materials and pristine veins
+
+Independent audit of the Phase 04 diff: confirm node material tables, signed yields, the
+pristine vein, and the gather feedback landed correctly, completely, and cleanly.
+
+## QA Starter Prompt
+
+```
+This is Phase 04 QA of the Professions 2.0 feature: Verify Node materials and pristine
+veins.
+
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: audit the Phase 04 diff for correctness, missing tests, dead code, determinism,
+three-host parity, and i18n completeness for THIS phase, then fix what the audit finds.
+
+STEP 0 - PRE-FLIGHT:
+- Confirm `git status` is clean (a concurrent session may share the checkout).
+- Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries: the node25 gate
+  rule (run `npm run gate` under Node 24), PR 2039 state, and the design-language program
+  (guardrails for the HUD loot-line touch).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn an Explore agent to read and summarize:
+- docs/professions-2/state.md and docs/professions-2/progress.md
+- docs/professions-2/phase-04-node-materials.md
+- the git diff against the phase-start commit recorded in progress.md notes (fallback: the
+  merge-base with the release branch)
+The summary must return: every Phase 04 deliverable and acceptance criterion, the files the
+phase touched, the phase's validation commands, the phase-specific QA emphasis items from
+phase-04-qa.md, and any deferrals or re-pins the implementation session recorded.
+
+STEP 2 - QA AUDIT:
+Fan out three parallel audit agents, each given only the Explore summary. Prompt every
+agent for COVERAGE, not filtering: report every gap with confidence and severity
+(BLOCKING / SHOULD-FIX / DEFERRABLE); the main session filters afterward. If any agent
+reply comes back truncated, resume that agent and have it continue from where it stopped;
+do not restart completed work.
+
+Agent correctness:
+- Verify every deliverable and acceptance criterion against the real code, not the phase
+  summary: per-node-type tables keyed by rolled rarity, zone-appropriate tiers, rare+
+  signing matching the corpse precedent, the pristine vein cadence/yield/signing, the
+  broadcast, the deed hook, the loot line and cue.
+- Run the phase validation commands:
+  npx tsc --noEmit
+  npx vitest run tests/gather_node_harvest.test.ts tests/professions_rarity_roll.test.ts \
+    tests/gathering.test.ts tests/localization_fixes.test.ts tests/architecture.test.ts
+- Exercise the real behavior: in a seeded sim run, harvest nodes across rarities and zones,
+  force a pristine vein through the pinned Rng path, and confirm the signed payloads, the
+  broadcast id and values, and that gatherResult drives the HUD log line and SFX cue.
+- Probe the phase-specific QA emphasis items listed in this file.
+
+Agent test coverage:
+- Find untested paths: the vein cadence bounds, the zone-1 tier cap, signing at exactly the
+  rare boundary, the deed hook no-op, matcher rows for the broadcast, and the loot line's
+  quality-color mapping.
+- Add missing tests, including a determinism test if sim logic changed and none pins the new
+  draw order (same seed, same yields, vein roll included).
+- Remove orphaned tests, especially any that still pin the old placeholder junk grants.
+
+Agent dead code and cleanup:
+- Unused imports/types, leftover placeholder table entries or constants, dead branches from
+  the junk-grant removal.
+- Sim purity: no DOM/Three/render/ui/game/net imports in src/sim/; no Math.random,
+  Date.now, or performance.now in sim logic.
+- Leftover TODOs. The pristine vein deed-mark hook is the one sanctioned deferral: verify it
+  is a named, dormant hook (not a stray TODO comment) and that nothing else was left half
+  wired.
+
+Also spawn review agents per the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md: check git diff --name-only and spawn ONLY
+matching rows, plus the qa-checklist agent over the whole phase diff (the phase is claimed
+complete). Prompt them for COVERAGE, not filtering, same as above.
+
+STEP 3 - FIX:
+- Apply every BLOCKING and SHOULD-FIX finding; leave DEFERRABLE items as recorded
+  deferrals with an owning phase.
+- Rerun the phase validation commands until green; npm run ci:changed; format only changed
+  files with a scoped npx @biomejs/biome check --write <file>.
+- Commit fixes with explicit paths (never git add -A), Conventional Commits with a scope
+  and a body (for example fix(professions): ... or test(professions): ...).
+
+STEP 4 - UPDATE DOCS + MEMORY:
+- Update docs/professions-2/progress.md: Phase 4 QA row status and dates; correct the
+  mirrored Phase 4 checkboxes if the audit changed their truth; append findings and
+  deferrals to the notes section.
+- Correct docs/professions-2/state.md if the audit changed any "New surfaces per phase"
+  entry for Phase 4.
+- Record surprises (flaky draws, matcher gaps, parity traps) to Claude Code memory.
+
+STEP 5 - FINAL RESPONSE FORMAT:
+- Verdict: PASS / PASS-WITH-FOLLOWUPS / FAIL.
+- Counts: findings by severity (BLOCKING / SHOULD-FIX / DEFERRABLE) and how many of each
+  were fixed in STEP 3.
+- Deferrals with reasons and the phase that owns each.
+- One-line handoff to the next phase session (Phase 05).
+
+STOPPING RULES:
+- None special for this phase. If a fix would contradict a locked decision in state.md,
+  stop and report instead of improvising.
+```
+
+## Phase-specific QA emphasis
+
+- Draw-order stability with the extra vein roll: confirm the determinism pin covers the
+  pristine vein draw, that pre-existing seeded runs still reproduce, and that any re-pin of
+  prior draws was deliberate and explained in a commit body, never silent.
+- Junk items still exist as defs: `bone_fragments`, `linen_scrap`, and `spider_leg` remain
+  valid ItemDefs (players hold them); only their node sources were removed. Verify catalog
+  entries, icons, and English names are untouched.
+- Zone-1 tables cap at low tiers: no zone 1 node can yield above the common/low tier band
+  (the stockpiling mitigation locked in state.md), and a test pins it.
+- Feedback fairness and i18n: the zone broadcast is id-based and matcher-localized (S3
+  guard green); the loot line and cue are identical on every graphics tier and colored only
+  through the existing quality token family.

--- a/docs/professions-2/phase-05-qa.md
+++ b/docs/professions-2/phase-05-qa.md
@@ -1,0 +1,118 @@
+# Phase 05 QA: Verify the professions wheel window
+
+Audit the Phase 05 diff for correctness, missing tests, dead code, determinism, three-host
+parity, and i18n completeness, then fix what the audit finds.
+
+## Phase-specific QA emphasis
+
+- Painter write-elision and rebuild discipline: an unchanged refresh signature must produce zero
+  DOM writes, and a full rebuild must preserve scroll position and keyboard focus.
+- The ring rendering path: if canvas, token reads must be cached (no per-frame getComputedStyle)
+  and contain zero hex literals; if DOM, the same token-only rule applies. Verify the recorded
+  rationale for the choice exists in the phase notes.
+- The ClientWorld pre-cprof (synced false) empty state: the window must render a sane empty
+  state online before the first cprof delta arrives, with no crash, no NaN bars, and no
+  misleading identity claim.
+
+## QA Starter Prompt
+
+```
+This is Phase 05 QA of the Professions 2.0 feature: verify the professions wheel window.
+
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: audit the Phase 05 diff for correctness, missing tests, dead code, determinism, three-host
+parity (the window renders from both Sim- and ClientWorld-shaped inputs with no new IWorld
+members), and i18n completeness for THIS phase; then fix what the audit finds.
+
+STEP 0 - PRE-FLIGHT:
+- Run git status; the checkout must be clean (a concurrent session may share it).
+- Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries; at minimum read:
+  the node25-breaks-jsdom-gate rule (run gate commands under Node 24), the PR 2039 state (the
+  cprof key and identity card this window builds on), and the design-language program entry
+  (DESIGN.md adopted but unlanded; no piecemeal re-lands).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize:
+- docs/professions-2/state.md and docs/professions-2/progress.md
+- docs/professions-2/phase-05-wheel-window.md (the acceptance criteria and invariants)
+- git diff against the phase-start commit recorded in the progress.md Phase 5 notes (name-only
+  first, then the full diff of the touched files)
+The summary must return: every file the phase touched, every acceptance criterion with where it
+claims to be satisfied, the validation commands the phase file names, the canvas-vs-DOM and
+absorb-vs-compose decisions and their recorded rationale, and any deliverable the diff appears
+to be missing.
+
+STEP 2 - QA AUDIT:
+Fan out three parallel audit agents; give each ONLY the Explore summary plus its block below.
+Prompt every agent for COVERAGE, not filtering: report every gap with confidence and severity
+(BLOCKING / SHOULD-FIX / NIT); filtering happens in STEP 3. If any agent's output is truncated,
+re-spawn it to resume from its last complete finding; never act on a truncated report.
+
+Agent Correctness:
+- Verify every deliverable and every acceptance criterion in phase-05-wheel-window.md against
+  the real code, not the phase report.
+- Run the phase's validation commands (the ui/render and i18n matrix rows from state.md,
+  including the mobile guard trio and the S3 guard) and record each result.
+- Exercise the real behavior: open the window on the desktop keybind and from the mobile More
+  tray via a screenshot script run; check the identity card, ring, ten skill bars, tier pips,
+  and perks readout against Sim-shaped and ClientWorld-shaped inputs, including the pre-cprof
+  (synced false) empty state.
+- Probe the phase-specific emphasis items: write-elision on an unchanged refresh signature,
+  focus and scroll preservation across a rebuild, and cached token reads in the ring path with
+  zero hex literals.
+
+Agent Test coverage:
+- Find untested paths in professions_view.ts and professions_window.ts (empty states, a hobby
+  chord with no hobby, skill at tier boundaries, the 75-skill perk threshold, refresh-signature
+  stability) and add the missing tests.
+- Add a determinism test if any sim logic changed (none should have; if it did, that is also a
+  BLOCKING scope finding).
+- Remove orphaned tests: anything pinning the pre-window identity card wiring or a superseded
+  view path.
+- Verify the icons bijection test really pins the converter scaffold and that the empty image
+  set passes.
+
+Agent Dead code and cleanup:
+- Unused imports, types, and exports across the new files; leftover TODOs and commented-out
+  blocks.
+- Sim purity: confirm the phase added nothing to src/sim/ and nothing in the new UI files leaks
+  into sim; tests/architecture.test.ts must be green.
+- If the identity card was absorbed, confirm the old profession_identity_view wiring is fully
+  retired (no dead module, no stale UI_PURE_CORES entry); if composed, confirm no duplicated
+  model logic.
+- Zero hex literals and no DESIGN.md phase vocabulary anywhere in the new css/ts.
+
+Then spawn review agents per the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY matching
+rows (expected: frontend-seam-reviewer; plus the qa-checklist agent, since the phase deliverable
+set is complete). Prompt them for COVERAGE, not filtering, with the same truncation-resume rule.
+
+STEP 3 - FIX:
+- Apply every BLOCKING and SHOULD-FIX finding; record NITs as deferrals with reasons.
+- Rerun the full validation set from STEP 2 after the fixes.
+- Commit with explicit paths, never git add -A; Conventional Commits with a body, no em dashes
+  or emojis (for example fix(ui): harden professions window empty state, or
+  test(ui): cover professions view tier boundaries).
+
+STEP 4 - UPDATE DOCS + MEMORY:
+- Update docs/professions-2/progress.md: the Phase 5 QA row (status, dates) and any checklist
+  corrections; append findings and deferrals to the Notes section.
+- Update docs/professions-2/state.md only if QA changed a surface the phase recorded.
+- Record durable surprises (a trap in the deeds pattern, a guard-test gap) to memory.
+
+STEP 5 - PACKET TEARDOWN:
+Not applicable; the packet-teardown offer happens only in Phase 15 QA.
+
+STEP 6 - FINAL RESPONSE FORMAT:
+Report: verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL); finding counts by severity and how many
+were fixed; tests added and removed; validation results after fixes; deferrals with reasons; and
+a one-line handoff naming the next phase (Phase 6, crafting window upgrades).
+
+STOPPING RULES:
+- Stop if a fix would require a new design token beyond the phase's ONE-semantic-token allowance
+  or any DESIGN.md ramp vocabulary; surface the gap to the maintainer instead.
+- Stop if a fix would require new wire data, a new IWorld member, or crafting-window changes;
+  those are out of scope (Phase 6 or later), so file the finding as a deferral rather than
+  expanding the diff.
+```

--- a/docs/professions-2/phase-05-wheel-window.md
+++ b/docs/professions-2/phase-05-wheel-window.md
@@ -1,0 +1,210 @@
+# Phase 05: The professions wheel window
+
+This phase ships the flagship professions window at Book of Deeds quality on today's design
+tokens: identity, the craft ring visualization, ten per-craft skill bars with tier pips, and a
+live perks readout. It is its own slice because it is pure UI on reads that already exist after
+PR 2039 (no new wire data, no sim behavior), so it can land independently of the crafting-window
+upgrades that follow in Phase 6.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: locked decisions (CRAFT_RING order, pair-named archetypes, the
+  pre-cprof optimistic client rule), the validation matrix (ui/render and i18n rows), and the
+  "Key existing surfaces" section (wheel math, cprof wire key, icons recipe, the deeds UX bar).
+- `docs/professions-2/implementation-plan.md`: the design-language guardrails (tokens only, no
+  DESIGN.md phase vocabulary, ten-dash banner, mobile rules) and the Review Dispatch Matrix.
+- `docs/professions-2/progress.md`: the Phase 5 deliverable checklist to mirror on completion.
+- `docs/professions-2/asset-manifest.json`: the designer slots for `prof_*` and `gather_*` icons
+  and the archetype crests; already authored, do not re-author.
+- The deeds exemplar: `src/ui/deeds_view.ts`, `src/ui/deeds_window.ts`,
+  `src/ui/deed_tracker_painter.ts` (pure core + cold painter + hot strip pattern).
+- `src/ui/crafting_view.ts`: how an existing view core consumes profession reads.
+- `src/world_api/professions.ts` (`craftingIdentity`) and `src/world_api/progression_xp.ts`
+  (`craftSkills`): the reads this window is built from, plus the existing professions-state and
+  gathering rows.
+- The PR 2039 identity card view (`profession_identity_view`): this phase absorbs or composes it.
+- `src/ui/icons.ts`: procedural icon recipes and the WebP override-set pattern.
+- `src/styles/components.css` and `src/styles/hud.mobile.css`: where the new window's styles land.
+- `tests/mobile_window_coverage.test.ts`: the guard the new `.window` id must satisfy.
+- Local conventions: `src/ui/CLAUDE.md`, `src/ui/hud/CLAUDE.md`, `src/styles/CLAUDE.md`.
+
+## Starter Prompt
+
+```
+This is Phase 05 of the Professions 2.0 feature: The professions wheel window.
+
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: ship the flagship professions window at Book of Deeds quality on today's design tokens,
+built entirely from reads that already exist post-2039.
+
+STEP 0 - PRE-FLIGHT:
+- Run git status; the checkout must be clean (a concurrent session may share it). Record
+  git rev-parse HEAD as the phase-start commit; you will write it into progress.md at STEP 6.
+- Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries; at minimum read:
+  the node25-breaks-jsdom-gate rule (run the gate under Node 24), the PR 2039 state (the cprof
+  wire key and identity card this window builds on), and the design-language program entry
+  (DESIGN.md is adopted but unlanded; no piecemeal re-lands).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize:
+- docs/professions-2/state.md and docs/professions-2/progress.md
+- docs/professions-2/phase-05-wheel-window.md (this file)
+- src/ui/deeds_view.ts, src/ui/deeds_window.ts, src/ui/deed_tracker_painter.ts
+- src/ui/crafting_view.ts and the PR 2039 identity card view (profession_identity_view)
+- src/world_api/professions.ts (craftingIdentity) and src/world_api/progression_xp.ts
+  (craftSkills), plus the existing professions-state and gathering-row reads they sit beside
+- src/ui/icons.ts, src/styles/components.css, src/styles/hud.mobile.css
+- tests/mobile_window_coverage.test.ts
+- src/ui/CLAUDE.md, src/ui/hud/CLAUDE.md, src/styles/CLAUDE.md
+The summary must return: the deeds pure-core + cold-painter recipe as concretely used (injected
+deps, rebuild discipline, markDialogRoot, esc(), audio.click); the exact shapes of
+craftingIdentity, craftSkills, and the gathering rows in BOTH Sim and ClientWorld (including the
+pre-cprof synced:false state); how UI_PURE_CORES registration works; the icon recipe + WebP
+override-set + converter + bijection pattern; the components.css ten-dash banner and
+hud.mobile.css rules for a comparable window; how existing windows register launcher rows, the
+mobile More tray entry, and a keybind; and the Phase 5 deliverable checklist from progress.md.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
+Fan out four agents; give each ONLY the Explore summary plus its deliverable block below. The
+view-core agent goes first (the others consume its module surface); the painter/styles,
+icons/i18n, and tests agents then run in parallel. Use worktree isolation only if two agents
+must edit the same file.
+
+Agent view-core deliverables:
+- src/ui/professions_view.ts: a pure, DOM-free view core registered in the UI_PURE_CORES
+  allowlist in tests/architecture.test.ts.
+- The window model built from craftingIdentity + craftSkills + professionsState + the gathering
+  rows; it must render correctly from both Sim-shaped and ClientWorld-shaped inputs, including
+  the pre-cprof (synced false) empty state.
+- Ring layout math: node positions for the ten crafts in CRAFT_RING order, arcs for the active
+  attuned pair, and the hobby chord.
+- The per-craft skill bar + tier pip model, and the perks readout with the material discount
+  live (the 75-skill materialCostMultiplier from src/sim/professions/wheel.ts).
+- A refresh signature for slow-band diffing (cheap to compute, changes only when the model
+  changes).
+- Absorb or compose the PR 2039 identity card view (profession_identity_view): pick one and
+  record why in the phase notes.
+
+Agent painter/styles deliverables:
+- src/ui/professions_window.ts: a cold painter on the deeds pattern (injected deps, full rebuild
+  that preserves scroll position and focus, markDialogRoot, esc() on every interpolation,
+  audio.click on interactions).
+- The ring rendered either on a small canvas with cached token reads (tokens resolved from CSS
+  custom properties once and cached, zero hex literals) or as DOM nodes; the agent picks one and
+  records why in the phase notes.
+- A ten-dash banner section in src/styles/components.css inside @layer components, existing
+  tokens only.
+- A deliberate body.mobile-touch rule for the new .window id in src/styles/hud.mobile.css: safe
+  areas respected, transform re-declared on any left re-pin, 40px tap targets.
+- Launcher entries: the window row, the mobile More tray entry, and a keybind following the
+  existing keybind registration pattern (mirror how the deeds window is wired).
+
+Agent icons/i18n deliverables:
+- hudChrome.professions.* English keys in the matching src/ui/i18n.catalog module (English only;
+  the maintainer fills locales at release; M16 applies if any new value is wordy).
+- prof_* and gather_* procedural icon recipes in src/ui/icons.ts (the ten crafts and the four
+  gathering skills; ids per asset-manifest.json).
+- The professions WebP converter scaffold (cloned from the existing item-icon converter,
+  targeting public/ui/professions/) plus its bijection test; an empty image set is valid.
+- Do NOT re-author asset-manifest.json; it already lists the designer slots.
+
+Agent tests deliverables:
+- Node-only tests for professions_view: model construction from Sim-shaped and
+  ClientWorld-shaped inputs (including pre-cprof synced false), ring layout math, tier pip and
+  perk derivation, and refresh-signature stability.
+- Painter-level coverage where feasible (rebuild preserves focus and scroll; no writes when the
+  refresh signature is unchanged).
+- Confirm the new .window id passes the mobile guard trio and the UI_PURE_CORES registration
+  passes tests/architecture.test.ts.
+- The icons bijection test wired to the converter scaffold.
+
+After the agents land, the main session captures desktop + mobile before/after screenshots via
+the pr-screenshots recipe and commits them under docs/screenshots.
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Determinism: no Math.random, Date.now, or performance.now anywhere; all sim randomness goes
+  through Rng (this phase should touch no sim logic at all; tests/architecture.test.ts guards).
+- IWorld both worlds: this window consumes EXISTING IWorld members only; it must render from
+  both Sim- and ClientWorld-shaped inputs. If any new member proves unavoidable, stop (see
+  STOPPING RULES): new wire data is out of scope.
+- Server authority: the window is read-only; it never decides or predicts outcomes.
+- i18n: every player-visible string in this phase is a t() key added in ENGLISH ONLY to the
+  matching src/ui/i18n.catalog module; if any sim- or server-origin text surfaces here, its
+  matcher lands in src/ui/sim_i18n.ts or src/ui/server_i18n.ts in the SAME change (the S3 guard,
+  tests/localization_fixes.test.ts, enforces it).
+- Design-language guardrails from implementation-plan.md: no DESIGN.md phase vocabulary, tokens
+  only (zero hex literals outside tokens.css/theme.ts), focus via the --color-border-focus
+  outline mechanism only, ten-dash banner section, mobile coverage rules.
+- Fairness: skill data shown is identical at every graphics tier; no preset hides or degrades
+  profession information.
+- Prime directive: nothing existing breaks; every currently passing test stays green.
+
+Out of scope (do NOT do in this phase):
+- Crafting-window changes of any kind (Phase 6).
+- Any new wire data, IWorld member, delta key, or command; everything this window reads exists
+  post-2039.
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+Run the ui/render and i18n rows from the validation matrix in state.md:
+- npx tsc --noEmit
+- npx vitest run tests/architecture.test.ts tests/mobile_window_coverage.test.ts
+  tests/mobile_window_transform.test.ts tests/mobile_window_layout.test.ts
+  tests/localization_fixes.test.ts
+- npx vitest run on the new professions_view / professions_window test files and the icons
+  bijection test
+- npm run i18n:gen, then npx vitest run tests/i18n_completeness.test.ts
+  tests/localization_fixes.test.ts
+- A mobile screenshot script run (the scripts/mobile_*.mjs family) against a running dev client.
+Then spawn review agents per the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY matching
+rows (expected: frontend-seam-reviewer for the ui/styles surface, qa-checklist once the
+deliverable set is complete; no sim/server/wire rows should match). Prompt every review agent
+for COVERAGE, not filtering: report every correctness or requirement gap with confidence and
+severity; filtering happens in a later pass. If any agent's output is truncated, re-spawn it to
+resume from its last complete finding; never act on a truncated report. No commit while any
+BLOCKING finding stands.
+
+STEP 4 - COMMIT CADENCE:
+Commit with explicit paths, never git add -A; every commit carries a body (what changed and
+why), Conventional Commits, no em dashes or emojis:
+1. feat(ui): professions view core
+2. feat(ui): professions window painter and styles
+3. feat(ui): professions icons and i18n
+4. docs(screenshots): professions window desktop and mobile captures
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] The window opens on the desktop keybind and from the mobile More tray.
+- [ ] Identity (title, majors, hobby), the ring visualization, ten per-craft skill bars, tier
+      pips, and the perks readout all render from both Sim- and ClientWorld-shaped inputs,
+      including the pre-cprof (synced false) empty state.
+- [ ] src/ui/professions_view.ts is registered in UI_PURE_CORES and is DOM-free.
+- [ ] Zero hex literals in every new file; existing tokens only; no DESIGN.md phase vocabulary.
+- [ ] The mobile guard trio is green (coverage, transform, layout).
+- [ ] hudChrome.professions.* keys are English-only and the S3 guard is green.
+- [ ] The icons bijection test is green with the empty image set.
+- [ ] Desktop and mobile before/after screenshots are committed under docs/screenshots.
+
+STEP 6 - DOC UPDATES + MEMORY:
+- Update docs/professions-2/progress.md: Phase 5 row (status, dates, the phase-start commit in
+  the notes) and mirror the deliverable checklist.
+- Update docs/professions-2/state.md, "New surfaces per phase", Phase 5 gains: the professions
+  window (.window id professions-window), src/ui/professions_view.ts and
+  src/ui/professions_window.ts, the hudChrome.professions.* key namespace, the prof_* and
+  gather_* icon recipes plus the professions WebP converter and bijection test, and the launcher
+  entries (window row, More tray, keybind).
+- Record any surprises (pattern deviations, canvas-vs-DOM decision rationale) to memory.
+
+STEP 7 - FINAL RESPONSE FORMAT:
+Report: phase status; files touched; validation results (each command, pass or fail); review
+agent verdicts; deferrals with reasons; and a one-line QA handoff naming the phase-start commit
+for the diff.
+
+STOPPING RULES:
+- Stop if the window cannot be built without new tokens. The only allowed relief is adding ONE
+  semantic token to tokens.css with a written justification; never add a DESIGN.md ramp, radius,
+  duration, or font token. If one semantic token does not cover it, stop and surface the gap to
+  the maintainer instead of working around it.
+- Stop if the window turns out to need data that is not already on IWorld in both worlds; new
+  wire data is out of scope, so report the gap rather than adding a member.
+```

--- a/docs/professions-2/phase-05-wheel-window.md
+++ b/docs/professions-2/phase-05-wheel-window.md
@@ -39,6 +39,11 @@ Goal: ship the flagship professions window at Book of Deeds quality on today's d
 built entirely from reads that already exist post-2039.
 
 STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
 - Run git status; the checkout must be clean (a concurrent session may share it). Record
   git rev-parse HEAD as the phase-start commit; you will write it into progress.md at STEP 6.
 - Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries; at minimum read:

--- a/docs/professions-2/phase-06-crafting-window.md
+++ b/docs/professions-2/phase-06-crafting-window.md
@@ -44,6 +44,11 @@ Goal: make the crafting window legible (skill, combo, station) and make masterwo
 celebrated moment.
 
 STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
 - Verify `git status` is clean before starting. If not, ask the user (a concurrent session
   may share this checkout).
 - Memory scan (if you use Claude Code memory): check your `MEMORY.md` index and any entries

--- a/docs/professions-2/phase-06-crafting-window.md
+++ b/docs/professions-2/phase-06-crafting-window.md
@@ -1,0 +1,227 @@
+# Phase 06: Crafting window upgrades and celebrations
+
+This phase makes the crafting window legible (profession, required skill, combo requirement,
+station binding) and makes a masterwork craft a celebrated moment (toast, zone-chat broadcast,
+tooltip seal, maker's mark). It is its own slice because it is pure presentation over surfaces
+earlier phases already shipped: Phase 2's masterwork SimEvent and instance flag, PR 2039's shared
+`combo_eligibility` rule, and today's `requiresHubStation` station gate. Nothing here touches sim
+behavior or the wire; it renders what already exists, so it can land and be verified visually on
+its own.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: locked decisions (combo eligibility deny reasons and the
+  optimistic `syncing` button, the masterwork model, the fairness and design constraints), the
+  validation matrix (ui/render row and i18n row), and the "Key existing surfaces" section
+  (crafting gates, `ItemInstancePayload`, stations today).
+- `docs/professions-2/progress.md`: the Phase 6 deliverable checklist to mirror on completion.
+- `docs/professions-2/implementation-plan.md`: team workflow, the Review Dispatch Matrix (the one
+  canonical copy), and the design-language guardrails every UI phase must obey.
+- `src/ui/crafting_view.ts`: the DOM-free rows model (the view core this phase extends).
+- `src/ui/crafting_window.ts`: the window painter that renders the rows model.
+- `src/ui/hud.ts`: the `craftResult` toast arm and the item tooltip composition. Read narrowly;
+  it is an active extraction target and must never grow (new logic goes in sibling modules).
+- `src/sim/professions/combo_eligibility.ts`: the shared eligibility rule and its reason union
+  (`not_attuned`, `wrong_pair`, `tier_unmet`); this phase only reads it.
+- `src/sim/professions/wheel.ts`: `tierForSkill` and `tierCapability`, the inputs to the
+  skill-gain difficulty tint.
+- `src/ui/i18n.catalog/hud_chrome.ts`: where every new English key lands.
+- `src/ui/sim_i18n.ts`: the matcher that re-localizes id-based sim text (the masterwork
+  broadcast row resolves here).
+- Issue #2037 (recipe skill legibility): this phase closes its scope.
+- `CLAUDE.md` (root), `src/ui/CLAUDE.md`, `src/styles/CLAUDE.md`.
+
+## Starter Prompt
+
+```
+This is Phase 06 of the Professions 2.0 feature: Crafting window upgrades and celebrations.
+
+Model: Opus 4.8, xhigh effort (reserve max for genuinely frontier problems), 1m context
+variant where the file load demands it.
+Harness: Claude Code.
+
+Goal: make the crafting window legible (skill, combo, station) and make masterworks a
+celebrated moment.
+
+STEP 0 - PRE-FLIGHT:
+- Verify `git status` is clean before starting. If not, ask the user (a concurrent session
+  may share this checkout).
+- Memory scan (if you use Claude Code memory): check your `MEMORY.md` index and any entries
+  relevant to this phase's domain (suggested topics: the design-language program and its
+  guardrails for src/styles/ and HUD chrome, the node25-breaks-jsdom-gate rule for running
+  `npm run gate` under Node 24, and the PR 2039 / combo-recipes-online state that produced
+  the shared combo_eligibility rule and the cprof syncing flag).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly, save your context):
+Spawn an Explore agent to read and summarize:
+- docs/professions-2/state.md (locked decisions, validation matrix, key existing surfaces)
+- docs/professions-2/progress.md (Phase 6 status and deliverable checklist)
+- docs/professions-2/phase-06-crafting-window.md (this prompt); verify the agent has the
+  same understanding of the deliverables
+- src/ui/crafting_view.ts, src/ui/crafting_window.ts
+- src/ui/hud.ts (ONLY the craftResult toast arm and the item tooltip composition)
+- src/sim/professions/combo_eligibility.ts and src/sim/professions/wheel.ts
+- src/ui/i18n.catalog/hud_chrome.ts and src/ui/sim_i18n.ts
+- CLAUDE.md (root), src/ui/CLAUDE.md, src/styles/CLAUDE.md
+The agent must return: the current rows-model shape in crafting_view.ts and its test file;
+the full combo_eligibility reason union plus how the client syncing state reaches the view;
+how requiresHubStation and canUseCraftingHubStation are exposed today; the exact Phase 2
+masterwork SimEvent id and payload plus the instance.rolled.masterwork flag on the inv-wire
+ItemInstancePayload (and the signer field for the maker's mark); the craftResult toast arm
+and item tooltip composition points in hud.ts; the deed-fireworks celebration gate pattern
+(pure module, reduced-motion aware) to copy; the existing hudChrome key namespaces and the
+sim_i18n matcher rule pattern; and the design-language guardrails in play (tokens only, no
+DESIGN.md phase vocabulary, mobile rules).
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
+Spawn three agents in parallel (request the fan-out explicitly; Opus 4.8 will not
+self-initiate it). Give each ONLY the Explore summary, not raw planning docs. Never
+`mode: "plan"` on teammates. The three own disjoint files, so no worktree isolation is
+needed; the presentation agent consumes the rows-model contract stated in the summary.
+
+Agent view (rows model; owns src/ui/crafting_view.ts and its tests) deliverables:
+- Recipe rows surface profession, required skill, and a skill-gain difficulty tint derived
+  from tierForSkill/tierCapability (this is the #2037 scope). Tint colors come from the
+  quality tokens and are tier-identical: the same value on every graphics preset.
+- Combo rows carry the eligibility reason from combo_eligibility (not_attuned, wrong_pair,
+  tier_unmet with the unmet crafts named). The client syncing state (pre-cprof) keeps the
+  button enabled optimistically per the locked decision in state.md; the server
+  re-validates.
+- requiresHubStation joins RecipeDefLike: station-bound rows carry a station badge flag
+  and, when the player is out of range, the inline disable reason.
+- The view core stays DOM-free and Node-tested (it is in the UI_PURE_CORES allowlist);
+  every new branch gets a unit test in tests/crafting_view.test.ts.
+
+Agent presentation (window, tooltip, toast; owns src/ui/crafting_window.ts plus thin
+touch points in src/ui/hud.ts) deliverables:
+- Render the extended rows model: profession and skill line, difficulty tint, combo reason
+  text, station badge, and the inline out-of-range disable reason. No eligibility state may
+  render as a bare disabled button; every disabled state names its reason.
+- Masterwork celebration: the craft toast shows the masterwork state; the celebration gate
+  is a pure, reduced-motion-aware module in the deed-fireworks style (new logic in a
+  sibling module, hud.ts stays a thin consumer).
+- The zone-chat broadcast row renders from the Phase 2 masterwork SimEvent (id-based; text
+  resolves through the sim_i18n matcher, coordinate the rule with the i18n agent).
+- Item tooltips gain the maker's mark line (Crafted by {name}) and the masterwork seal
+  overlay for flagged instances, sourced from the inv-wire ItemInstancePayload. Legacy
+  signed instances without a masterwork flag keep a correct tooltip (mark line, no seal).
+- Window body CSS follows the design guardrails: today's tokens only, zero hex literals
+  outside tokens.css/theme.ts, the mobile rules for the crafting window (40px tap floor)
+  respected.
+
+Agent i18n/matcher (owns src/ui/i18n.catalog/hud_chrome.ts and src/ui/sim_i18n.ts)
+deliverables:
+- Every new player string is an English-only t() key in the hud_chrome catalog module
+  (M16: a wordy new English value also needs its five non-Latin fills in the same change).
+  This covers the skill line, the difficulty tint labels, all three combo reasons, the
+  station badge and disable reason, the toast masterwork text, the broadcast row, the
+  maker's mark line, and the seal label.
+- A matcher rule in src/ui/sim_i18n.ts for the id-based masterwork broadcast so the S3
+  guard (tests/localization_fixes.test.ts) passes.
+- Values interpolate through the placeholder contract ({name}, {crafts}); never
+  concatenate; numbers through the formatters.
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Determinism: this phase should not touch src/sim/ at all; if any sim file must change,
+  all randomness goes through Rng (never Math.random, Date.now, or performance.now) and
+  tests/architecture.test.ts must stay green.
+- Seam: this phase renders existing IWorld data (craftingIdentity, inventory instances,
+  craftResult); if a new IWorld member becomes necessary, add it to the matching facet
+  file, implement it in BOTH Sim and ClientWorld, and re-pin
+  tests/world_api_parity.test.ts in the same change. Verify liveness, not just member
+  shape (the 2033 stub trap).
+- Server authority: the client renders eligibility and outcomes; it never decides them.
+  The optimistic syncing button still submits to the server, which re-validates.
+- i18n: every new player string is a t() key added in ENGLISH ONLY to
+  src/ui/i18n.catalog/hud_chrome.ts (never edit the locale overlays); the sim-originated
+  broadcast is re-localized via a matcher rule in src/ui/sim_i18n.ts in the SAME change
+  (the S3 guard enforces it).
+- Fairness: the difficulty tint, eligibility reasons, and station badges are actionable
+  information and must be identical across every graphics preset and tier; reduced motion
+  may trim celebration MOTION only, never the information (the toast, broadcast, and
+  tooltip still convey the masterwork).
+- Design-language guardrails: build on today's tokens and the shared window shell; do NOT
+  introduce DESIGN.md phase vocabulary (that is a PR-blocking piecemeal re-land).
+- Prime directive: nothing existing breaks. The crafting window keeps working for every
+  recipe and host exactly as before where this phase adds nothing.
+
+Out of scope (do NOT do in this phase):
+- The professions wheel window (Phase 5 owns it).
+- Station SYSTEM changes (Phase 8 owns typed stations and masters): only render what
+  requiresHubStation and canUseCraftingHubStation already expose today.
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+- Run the state.md matrix rows for this change type (ui/render plus i18n keys added):
+  - npx tsc --noEmit
+  - npx vitest run tests/crafting_view.test.ts tests/localization_fixes.test.ts plus every
+    crafting window test you updated
+  - the mobile guard trio: npx vitest run tests/mobile_window_coverage.test.ts
+    tests/mobile_window_transform.test.ts tests/mobile_window_layout.test.ts
+  - npm run i18n:gen, then npx vitest run tests/i18n_completeness.test.ts
+    tests/localization_fixes.test.ts
+  - a mobile screenshot of the crafting window (pr-screenshots skill; desktop and mobile,
+    committed under docs/screenshots).
+- Spawn review agents per the Review Dispatch Matrix in
+  docs/professions-2/implementation-plan.md; check `git diff --name-only` against the
+  phase-start commit and spawn ONLY matching rows (expected here: frontend-seam-reviewer
+  for the src/ui/ surface, cross-platform-sync because src/ui/sim_i18n.ts changed, and
+  qa-checklist once the deliverable set is complete; if no row matches a part of the diff,
+  spawn nothing extra).
+- Prompt each review agent you spawn for COVERAGE not filtering: report every issue
+  including low-severity and uncertain ones; ranking happens in a later step.
+- Resume any agent that truncates with: "Stop reading more files. Output the full report
+  now based on what you've already seen. No more tool calls. Format: BLOCKING /
+  SHOULD-FIX / NICE-TO-HAVE / VERDICT."
+- Do not commit while any BLOCKING finding stands.
+
+STEP 4 - COMMIT CADENCE:
+Aim for 2 commits with these headlines (Conventional Commits with a scope; EXPLICIT paths,
+never `git add -A`; every commit carries a body; no em dashes or emojis):
+- feat(ui): recipe skill and requirement legibility
+  (src/ui/crafting_view.ts, src/ui/crafting_window.ts, src/ui/i18n.catalog/hud_chrome.ts,
+  tests/crafting_view.test.ts and the window tests)
+- feat(ui): masterwork celebrations and maker's mark
+  (the hud.ts toast arm and tooltip touch points, the celebration gate module,
+  src/ui/sim_i18n.ts, remaining hud_chrome keys, tests, docs/screenshots)
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] #2037's scope is closed: recipe rows show profession, required skill, and the
+      skill-gain difficulty tint derived from tierForSkill/tierCapability, in quality-token
+      colors, identical on every graphics tier
+- [ ] Combo rows name their requirement for every eligibility branch (not_attuned,
+      wrong_pair, tier_unmet with the unmet crafts); the syncing state keeps the optimistic
+      enabled button
+- [ ] Station-bound rows show the badge; out-of-range rows show the inline disable reason
+      (requiresHubStation joined RecipeDefLike)
+- [ ] No eligibility state renders as a bare disabled button anywhere in the window
+- [ ] A masterwork craft produces the toast, the zone-chat broadcast row, and the tooltip
+      seal; the celebration gate is pure and reduced-motion aware
+- [ ] Tooltips show the maker's mark (Crafted by {name}); legacy signed instances without
+      a masterwork flag render correctly (mark line, no seal, no throw)
+- [ ] Craft button never lies: the window uses the same shared eligibility rule as the sim
+      in both hosts
+- [ ] Every new string is an English-only t() key; the S3 matcher rule landed in the same
+      change; tests/localization_fixes.test.ts and tests/i18n_completeness.test.ts green
+- [ ] The ui/render and i18n validation rows pass; desktop and mobile screenshots captured
+      and committed under docs/screenshots
+
+STEP 6 - DOC UPDATES + MEMORY:
+- Update docs/professions-2/progress.md: mark Phase 6 status and mirror the checklist; note
+  any deferrals.
+- Update docs/professions-2/state.md, "New surfaces per phase" gains the Phase 6 entry:
+  the hudChrome crafting key namespace added, the sim_i18n masterwork broadcast matcher
+  rule, requiresHubStation on RecipeDefLike, and the celebration gate module path.
+- If you use Claude Code memory, record any surprising rules or current-state notes for
+  the next session.
+
+STEP 7 - FINAL RESPONSE FORMAT:
+End your turn with: phase status, files touched, validation results, review-agent
+verdicts, any deferred items, and a one-line handoff for the Phase 6 QA session.
+
+STOPPING RULES:
+- No phase-specific stopping rules. Packet defaults apply: stop and ask if git status is
+  dirty at pre-flight; stop and surface if the Phase 2 masterwork SimEvent or the
+  instance-payload masterwork flag is not actually available (this phase only renders
+  them); stop and ask if a deliverable turns out to require a sim, wire, or station-system
+  change beyond consuming what already exists (that is Phase 2 or Phase 8 scope).
+```

--- a/docs/professions-2/phase-06-qa.md
+++ b/docs/professions-2/phase-06-qa.md
@@ -1,0 +1,129 @@
+# Phase 06 QA: Verify Crafting window upgrades and celebrations
+
+Audit the Phase 6 implementation (crafting window legibility, masterwork celebrations, maker's
+mark tooltips) for correctness, missing tests, dead code, determinism, three-host parity, and
+i18n completeness.
+
+## QA Starter Prompt
+
+```
+This is Phase 06 QA of the Professions 2.0 feature: Verify Crafting window upgrades and
+celebrations.
+
+Model: Opus 4.8, xhigh effort (reserve max for genuinely frontier problems), 1m context
+variant where the file load demands it.
+Harness: Claude Code.
+
+Goal: Audit the Phase 6 implementation for correctness, missing tests, dead code,
+determinism, three-host parity, and i18n completeness for THIS phase's surfaces.
+
+STEP 0 - PRE-FLIGHT:
+- Verify `git status` is clean (Phase 6 implementation should already be committed). If
+  dirty, ask the user (a concurrent session may share this checkout).
+- Memory scan (if you use Claude Code memory): check your `MEMORY.md` index and entries
+  from this phase's domain (suggested topics: the design-language program guardrails, the
+  node25-breaks-jsdom-gate rule for Node 24 gating, and the PR 2039 / combo-recipes-online
+  state behind combo_eligibility and the cprof syncing flag).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly, save your context):
+Spawn an Explore agent to read and summarize:
+- docs/professions-2/state.md (the Phase 6 entry under "New surfaces per phase", the
+  locked combo-eligibility and masterwork decisions, the validation matrix)
+- docs/professions-2/progress.md (the Phase 6 deliverables checklist and any noted
+  deferrals)
+- docs/professions-2/phase-06-crafting-window.md (the implementation prompt: what was
+  promised, the acceptance criteria)
+- All files created or modified in Phase 6 (use `git diff` against the phase-start commit)
+- CLAUDE.md (root), src/ui/CLAUDE.md, src/styles/CLAUDE.md
+The agent must return: the full list of Phase 6 deliverables and acceptance criteria, all
+new and modified files, the new hudChrome keys and the sim_i18n matcher rule, and any
+known issues or deferrals noted in progress.md.
+
+STEP 2 - QA AUDIT (spawn the three agents below in parallel, using only the Explore
+summary; prompt each for COVERAGE not filtering: report every issue including low-severity
+and uncertain ones, ranking happens in a later step):
+
+Correctness agent:
+- Verify every Phase 6 deliverable was actually implemented and every acceptance
+  criterion in the phase prompt is met.
+- Run the phase's validation commands: npx tsc --noEmit; npx vitest run
+  tests/crafting_view.test.ts tests/localization_fixes.test.ts plus the updated window
+  tests; the mobile guard trio (tests/mobile_window_coverage.test.ts,
+  mobile_window_transform.test.ts, mobile_window_layout.test.ts); npm run i18n:gen then
+  npx vitest run tests/i18n_completeness.test.ts tests/localization_fixes.test.ts.
+- Exercise the real behavior, not just the tests: with npm run dev (and npm run server
+  for the online host), open the crafting window, walk recipes across skill tiers, force
+  each eligibility state, craft until a masterwork procs (dev commands allowed locally),
+  and confirm the toast, broadcast row, and tooltip seal appear; capture the mobile
+  screenshot of the crafting window.
+- Verify the offline Sim path and the online ClientWorld path present identical rows,
+  reasons, and celebrations (the craft button never lies in either host).
+- Check edge cases: empty recipe list, unknown recipes, boundary skill values at tier
+  edges for the difficulty tint, a tier_unmet reason naming multiple unmet crafts.
+
+Test coverage agent:
+- Identify new code paths without tests: every rows-model branch (each eligibility
+  reason, the station badge and out-of-range reason, each tint band), the celebration
+  gate (including its reduced-motion arm), the tooltip composition for signed, masterwork,
+  and plain instances.
+- Add the missing tests; if any src/sim/ file changed in Phase 6, add a determinism test
+  (same seed, same result) and run tests/architecture.test.ts.
+- Update tests broken by Phase 6, remove orphaned tests for replaced code, and verify
+  assertions are decisive (they pin the rendered reason text ids, not just "it runs").
+
+Dead code and cleanup agent:
+- Find unused imports, types, helpers, and CSS left behind in src/ui/crafting_view.ts,
+  src/ui/crafting_window.ts, src/ui/hud.ts, and the new celebration module.
+- Verify sim purity holds: src/sim/ gained no ui/render/game/net or DOM imports, and the
+  view core stayed DOM-free (UI_PURE_CORES).
+- Verify zero hex literals landed outside tokens.css/theme.ts and no DESIGN.md phase
+  vocabulary crept in.
+- Remove commented-out code and resolve or file every leftover TODO/FIXME.
+
+PHASE-SPECIFIC QA EMPHASIS (probe these explicitly):
+- Exercise EVERY combo_eligibility branch against the rendered rows: not_attuned,
+  wrong_pair, tier_unmet (with the unmet crafts named, including the multi-craft case),
+  eligible, and the client syncing state, which must keep the optimistic enabled button
+  per the locked decision in state.md while the server still re-validates.
+- Legacy signed instances WITHOUT a masterwork flag (signed before Phase 2): the maker's
+  mark tooltip line renders, no seal overlay appears, and nothing throws.
+- Fairness: the difficulty tint, eligibility reasons, and station badges are identical
+  across every graphics preset and tier; reduced motion trims celebration motion only,
+  never the masterwork information (toast, broadcast, and seal still convey it).
+- The bare-disabled-button sweep: enumerate every disabled state the window can produce
+  and confirm each one names its reason inline.
+
+Multi-agent review dispatch: apply the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md (the plan carries the one canonical copy).
+Check `git diff --name-only` against the phase-start commit and spawn ONLY the agents
+whose row matches (expected here: frontend-seam-reviewer, and cross-platform-sync if
+src/ui/sim_i18n.ts changed), plus qa-checklist (this is the phase-completion QA gate).
+Prompt each for COVERAGE not filtering. Resume any review agent that truncates
+mid-analysis with: "Stop reading more files. Output the full report now. No more tool
+calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT."
+
+STEP 3 - FIX:
+Apply all BLOCKING and SHOULD-FIX items. Rerun the validation rows from state.md (at
+minimum npx tsc --noEmit, tests/crafting_view.test.ts, the S3 guard
+tests/localization_fixes.test.ts, and the mobile guard trio if window CSS changed).
+Commit fixes with EXPLICIT paths (never `git add -A`), Conventional Commits with a body,
+in separate commits from the QA verdicts so the history is reviewable.
+
+STEP 4 - UPDATE DOCS + MEMORY:
+- Update docs/professions-2/progress.md (mark Phase 6 QA complete; note any items
+  deferred to follow-up).
+- Update docs/professions-2/state.md (any drift discovered during QA, e.g. a corrected
+  key namespace or module path in the Phase 6 entry).
+- If you use Claude Code memory, record any surprising rules learned during QA.
+
+STEP 5 - FINAL RESPONSE FORMAT:
+End your turn with: QA verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL), counts of BLOCKING /
+SHOULD-FIX / NICE-TO-HAVE found and fixed, deferred items, and a one-line handoff for the
+Phase 7 implementation session.
+(The packet-teardown offer is Phase 15 QA only and does not apply to this phase.)
+
+STOPPING RULES:
+- Stop and surface to the user if any BLOCKING item cannot be fixed without changing the
+  phase scope (for example, if a fix would require sim, wire, or station-system changes
+  that belong to Phase 2 or Phase 8).
+```

--- a/docs/professions-2/phase-07-guild-letter.md
+++ b/docs/professions-2/phase-07-guild-letter.md
@@ -46,6 +46,11 @@ through the existing mail system naming the master for the 2039 intro attunement
 the S3 quest-text localization blind spot closes for good.
 
 STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
 - Run git status; the checkout must be clean (a concurrent session may share it). If it is
   dirty, stop and report instead of working around it.
 - Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries; at minimum read:

--- a/docs/professions-2/phase-07-guild-letter.md
+++ b/docs/professions-2/phase-07-guild-letter.md
@@ -1,0 +1,212 @@
+# Phase 07: The Guild letter
+
+This phase makes the game notice a player's crafting trend and respond in-world: a pure
+trending-pair classifier (the #1295 gap) watches `craftSkills`, and when the leading adjacent
+pair first crosses the letter threshold on an unattuned character, the Crafting Guild sends
+exactly one letter through the existing mail system naming the master to visit for the 2039
+intro attunement quest. It is its own slice because it is the first moment the professions
+loop reaches out to the player, it depends only on surfaces that already exist (the wheel,
+the mail pipeline, the 2039 quest content), and it carries a standalone hygiene payoff: the
+S3 localization scanner finally covers `src/sim/quests/quest_commands.ts`.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: locked decisions, the validation matrix, key existing
+  surfaces (wheel math, archetype state, quest surfaces), and the planned Phase 7 entry
+  under "New surfaces per phase".
+- `docs/professions-2/progress.md`: phase status; check whether Phase 1 already resolved
+  the 2039-review tutorial-panel timing item (deliverable 4 is conditional on this).
+- `docs/professions-2/implementation-plan.md`: the team workflow and the Review Dispatch
+  Matrix (the one canonical copy).
+- `src/sim/professions/wheel.ts`: the 2039 `nearTier`/`dormantKnowledge` nudges,
+  `TIER_SKILL_STEP`, `tierForSkill`; the trend classifier is a sibling module here.
+- `src/sim/professions/archetype.ts`: `attunedPairs`, `archetypePairId`,
+  `ARCHETYPE_PAIR_TARGETS`; the "player is unattuned" check and the master-name mapping.
+- `src/sim/mail/post_office.ts` and `src/sim/content/letters.ts`: the mail delivery path
+  and the id-based letters pipeline the Guild letter must ride.
+- The 2039 profession intro attunement quest content: quest ids and the master NPCs the
+  letter must name.
+- `src/sim/quests/quest_commands.ts`: the file joining the S3 scan list; every
+  player-facing string in it needs matcher coverage.
+- `tests/localization_fixes.test.ts`: the S3 scan list and guard.
+- `src/ui/sim_i18n.ts`: the sim-text matcher where letter body and quest-command strings
+  resolve to `t()` keys.
+- `src/sim/CLAUDE.md`, `tests/CLAUDE.md`, `src/ui/CLAUDE.md`: local conventions for the
+  three areas this phase touches.
+
+## Starter Prompt
+
+```
+This is Phase 07 of the Professions 2.0 feature: The Guild letter.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: the game notices a player's crafting trend via a pure trending-pair classifier, an
+unattuned character crossing the letter threshold receives exactly one Crafting Guild letter
+through the existing mail system naming the master for the 2039 intro attunement quest, and
+the S3 quest-text localization blind spot closes for good.
+
+STEP 0 - PRE-FLIGHT:
+- Run git status; the checkout must be clean (a concurrent session may share it). If it is
+  dirty, stop and report instead of working around it.
+- Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries; at minimum read:
+  node25-breaks-jsdom-gate (run the gate under Node 24), the PR 2039 professions state
+  (toolchain and merge context for the intro quest content this phase links to), and
+  combo-recipes-broken-online (the ClientWorld stub trap: verify liveness, not shape, for
+  anything that must reach the online client).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize:
+- docs/professions-2/state.md and docs/professions-2/progress.md
+- docs/professions-2/phase-07-guild-letter.md (this file)
+- src/sim/professions/wheel.ts and src/sim/professions/archetype.ts
+- src/sim/mail/post_office.ts and src/sim/content/letters.ts
+- the 2039 profession intro attunement quest content (locate it under src/sim/content/)
+- src/sim/quests/quest_commands.ts, tests/localization_fixes.test.ts, src/ui/sim_i18n.ts
+- src/sim/CLAUDE.md, tests/CLAUDE.md, src/ui/CLAUDE.md
+The summary must return: the locked decisions and validation matrix rows that bind this
+phase; the wheel constants and nudge signals the classifier can build on; the exact shape of
+PlayerMeta.craftSkills and the attunement state (attunedPairs, archetypePairId); how a letter
+is authored, id-resolved, and delivered today (content record, post_office call sites, client
+matcher); the intro attunement quest ids and their master names per pair; the current S3 scan
+list mechanics and which quest_commands.ts strings are player-facing; whether progress.md
+shows the Phase 1 session already fixed the tutorial-panel timing item; and any surprises
+that contradict this phase file.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
+Fan out three agents in parallel; give each ONLY the Explore summary, never raw planning
+docs. Worktree isolation is not needed unless two agents must edit the same file.
+
+Agent sim deliverables (trend module + letter trigger):
+- A pure trending-pair classifier module, sibling to wheel.ts under src/sim/professions/
+  (suggested: src/sim/professions/trend.ts). Input: a craftSkills map. Output: the leading
+  ADJACENT pair on CRAFT_RING (adjacency per the locked ring order in state.md) and whether
+  it crossed the letter threshold. Export a named letter-threshold constant chosen against
+  the existing wheel tier steps (do not invent an unrelated number); deterministic, pure,
+  host-agnostic, no Rng draw needed. This closes the #1295 gap.
+- The letter trigger: when the classifier reports a first threshold crossing AND the player
+  is unattuned (no attunedPairs entry, no archetypePairId), deliver the Crafting Guild
+  letter once via the existing mail system. Persist a one-shot sent flag on PlayerMeta
+  (additive JSONB with a normalize-on-load default). The flag, not a re-evaluated predicate,
+  is the single-fire gate.
+- The backfill guard: an existing character already past the threshold at load gets exactly
+  one letter on its first evaluation and never another on later loads or logins; no burst.
+- The tutorial-panel timing fix from the 2039 review (the panel renders exactly once at the
+  first cap moment): first check the Explore summary; if Phase 1 already resolved it, record
+  that and skip; otherwise fix it test-first, even if the defect lives in UI code.
+
+Agent content/i18n deliverables (letter text + matcher):
+- The Crafting Guild letter content record in src/sim/content/letters.ts: id-based body per
+  the letters pipeline, parameterized on the leading pair and the master to visit, pointing
+  the player at the 2039 intro attunement quest. The sim stays language-agnostic: it emits
+  the letter id plus values only.
+- English catalog entries for the letter body and subject in the matching
+  src/ui/i18n.catalog/<domain>.ts module (English only; if any value is wordy per M16, add
+  its five non-Latin fills in the same change).
+- Matcher coverage in src/ui/sim_i18n.ts for the letter body id and for EVERY player-facing
+  string already in src/sim/quests/quest_commands.ts.
+
+Agent tests deliverables:
+- Unit tests for the classifier: leading-pair selection, adjacency per the locked ring,
+  threshold boundary behavior, and determinism (same input, same output).
+- Letter delivery tests: fresh character crosses the threshold and gets exactly one letter
+  naming the correct master; attuned character gets none; skill hovering at the threshold
+  never re-fires (hysteresis via the one-shot flag); backfill single-fire for a high-skill
+  character loaded from a legacy save shape.
+- The S3 scan-list change in tests/localization_fixes.test.ts:
+  src/sim/quests/quest_commands.ts joins the scan scope, and the guard test proves the file
+  is scanned (the guard must FAIL if the file leaves the list).
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Determinism: the sim is a fixed 20 Hz tick; all randomness through Rng (the classifier
+  itself must be pure and draw nothing); no Math.random, Date.now, or performance.now in
+  src/sim/ (guarded by tests/architecture.test.ts).
+- src/sim/ stays language-agnostic and DOM-free: the letter body travels as an id plus
+  values; English lives in the catalog; the S3 matcher duty is satisfied in the SAME change.
+- Server authority: letter delivery and the sent flag resolve in the sim that the server
+  runs; the client never decides delivery.
+- IWorld both-worlds where relevant: this phase should ride the EXISTING mail wire surface;
+  if any new IWorld member proves necessary, implement it in BOTH Sim and ClientWorld and
+  update the parity pin (tests/world_api_parity.test.ts) in the same change, verifying
+  liveness rather than member shape.
+- i18n: every new player-visible string is an English-only t() key in the catalog; never
+  edit locale overlays.
+- Prime directive: nothing existing breaks. The letter fires once, never spams existing
+  characters (the backfill guard), and all persisted-state changes are additive with
+  normalize-on-load defaults.
+
+Out of scope (do NOT do in this phase):
+- The full attunement quest content for the four wave-one archetypes (Phase 14).
+- Trend nudge CHAT cadence beyond the letter (Phase 14).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+Run the state.md validation matrix rows for this change type (sim-only plus i18n keys
+added):
+- npx tsc --noEmit
+- npx vitest run tests/localization_fixes.test.ts tests/professions_skill.test.ts
+- npx vitest run <the new trend and letter test files>
+- npx vitest run tests/architecture.test.ts
+- npm run i18n:gen, then npx vitest run tests/i18n_completeness.test.ts
+- npm run ci:changed; format only changed files with a scoped
+  npx @biomejs/biome check --write <file>
+Then spawn review agents per the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY
+matching rows (expected here: architecture-reviewer for the src/sim/ change,
+cross-platform-sync for the sim_i18n.ts matcher and any sim behavior change,
+frontend-seam-reviewer only if the tutorial-panel fix touched src/ui/, and qa-checklist once
+the deliverable set is complete). Prompt every review agent for COVERAGE, not filtering:
+report every correctness or requirement gap with confidence and severity; filtering happens
+in a later pass. If any agent's output is truncated, spawn a fresh agent to resume from the
+last complete item rather than re-running the whole task. No commit while any BLOCKING
+finding stands.
+
+STEP 4 - COMMIT CADENCE:
+Commit with explicit paths, never git add -A; every commit carries a body (what changed and
+why, wrapped near 72 columns). Expected sequence:
+- feat(professions): add the trending-pair classifier
+  (src/sim/professions/trend.ts plus its test file)
+- feat(content): deliver the Crafting Guild letter on first trend crossing
+  (letters content, post_office trigger, catalog keys, matcher rules, letter tests)
+- fix(i18n): bring quest commands into the S3 scan list
+  (tests/localization_fixes.test.ts, src/ui/sim_i18n.ts)
+- fix(ui): render the profession tutorial panel exactly once (ONLY if the Phase 1 check
+  shows the item unresolved)
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] A fresh character crossing the letter threshold receives exactly one Crafting Guild
+      letter naming the correct master for its leading adjacent pair.
+- [ ] An existing high-skill character already past the threshold receives exactly one
+      letter on first evaluation, never a burst, and never another on later loads.
+- [ ] An attuned character never receives the letter; skill hovering at the threshold never
+      re-fires it.
+- [ ] The classifier is pure and deterministic, unit-tested, and exported from its own
+      module under src/sim/professions/.
+- [ ] The letter body is id-based in the sim; English text lives in the catalog; the
+      matcher resolves it; the S3 guard is green.
+- [ ] The S3 guard FAILS if src/sim/quests/quest_commands.ts leaves the scan list, and
+      every player-facing string in that file has matcher coverage.
+- [ ] The tutorial panel renders exactly once at the first cap moment, or progress.md
+      documents that Phase 1 already resolved it.
+- [ ] All STEP 3 validation commands are green and no BLOCKING review finding stands.
+
+STEP 6 - DOC UPDATES + MEMORY:
+- Update docs/professions-2/progress.md: Phase 7 status, dates, and the mirrored
+  deliverable checkboxes; append any deferral or surprise to Notes.
+- Update docs/professions-2/state.md "New surfaces per phase": replace the planned Phase 7
+  line with the actual surfaces (the trend module path and exported symbols including the
+  letter-threshold constant, the Guild letter content id, the one-shot PlayerMeta flag name
+  and its normalize-on-load default, and the S3 scan list gaining
+  src/sim/quests/quest_commands.ts). Record the phase-start commit hash for the QA session.
+- Record genuine surprises (not routine progress) to Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT:
+Report: phase status (complete / partial with reasons); files touched (absolute paths);
+validation results (each command and its outcome); review verdicts per spawned agent;
+deferrals with owners; and a one-line QA handoff naming the phase-start commit for
+phase-07-qa.md to diff against.
+
+STOPPING RULES:
+No phase-specific rules. Baseline applies: stop and report if pre-flight finds a dirty
+checkout, if a locked decision in state.md contradicts this phase file, or if validation
+cannot be brought green without violating an invariant; never commit past a BLOCKING
+finding.
+```

--- a/docs/professions-2/phase-07-qa.md
+++ b/docs/professions-2/phase-07-qa.md
@@ -1,0 +1,120 @@
+# Phase 07 QA: Verify The Guild letter
+
+Independent audit of the Phase 07 diff: correctness of the trend classifier and the one-shot
+letter delivery, test coverage, dead code, determinism, three-host parity, and i18n
+completeness for this phase.
+
+## Phase-specific QA emphasis
+
+- Threshold hysteresis: skill values hovering at, crossing, and re-crossing the letter
+  threshold must never re-fire the letter; prove the one-shot sent flag, not a re-evaluated
+  predicate, is the gate.
+- Offline vs online delivery parity: the letter must arrive identically in the offline `Sim`
+  and through the server-authoritative online path; watch for the ClientWorld stub trap
+  (verify liveness of the mail surface online, not just member shape).
+- Backfill single-fire proof: a legacy character loaded already far past the threshold gets
+  exactly one letter on first evaluation and never another on later loads, logins, or skill
+  changes; no burst across multiple qualifying pairs.
+
+## QA Starter Prompt
+
+```
+This is Phase 07 QA of the Professions 2.0 feature: verify The Guild letter.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: audit the Phase 07 diff for correctness, missing tests, dead code, determinism,
+three-host parity, and i18n completeness; fix what the audit finds; leave the phase in a
+provably shippable state.
+
+STEP 0 - PRE-FLIGHT:
+- Run git status; the checkout must be clean. If dirty, stop and report.
+- Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries; at minimum read:
+  node25-breaks-jsdom-gate (run the gate under Node 24), combo-recipes-broken-online (the
+  ClientWorld stub trap that parity checks must not repeat), and the PR 2039 professions
+  state.
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize:
+- docs/professions-2/state.md and docs/professions-2/progress.md
+- docs/professions-2/phase-07-guild-letter.md (the phase file, including its acceptance
+  criteria and validation commands)
+- git diff against the phase-start commit recorded in the Phase 7 handoff (fall back to the
+  last commit before the first Phase 7 commit if unrecorded): file list plus the full diff
+  of the sim, content, matcher, and test changes
+The summary must return: every Phase 07 deliverable and acceptance criterion; the actual
+files and symbols the phase added or changed (the trend module and its exported
+letter-threshold constant, the letter content id, the one-shot PlayerMeta flag, the S3 scan
+list change); the validation commands the phase file names; any acceptance criterion the
+implementation session marked deferred; and anything in the diff the phase file never asked
+for.
+
+STEP 2 - QA AUDIT:
+Fan out three parallel audit agents; give each ONLY the Explore summary. Prompt every agent
+for COVERAGE, not filtering: report every gap with confidence and severity (BLOCKING /
+SHOULD-FIX / NIT); filtering happens in STEP 3. If any agent's output is truncated, spawn a
+fresh agent to resume from the last complete item rather than re-running the whole audit.
+
+Agent correctness:
+- Verify every deliverable and acceptance criterion in phase-07-guild-letter.md against the
+  real code, not the phase session's claims.
+- Run the phase's validation commands (npx tsc --noEmit; npx vitest run
+  tests/localization_fixes.test.ts tests/professions_skill.test.ts; the new trend and letter
+  test files; tests/architecture.test.ts; npm run i18n:gen then
+  tests/i18n_completeness.test.ts).
+- Exercise the real behavior, not just the tests: drive a sim where a fresh character
+  crosses the threshold (exactly one letter, correct master named); an attuned character
+  (no letter); a hovering skill value crossing the threshold repeatedly (no re-fire:
+  threshold hysteresis); a legacy high-skill save (exactly one backfill letter, then silence
+  across repeated loads).
+- Prove offline vs online delivery parity: the letter reaches the player identically via the
+  offline Sim and the server-authoritative online path; confirm the online mail surface is
+  live, not a stub default (the 2033 trap).
+
+Agent test coverage:
+- Find untested paths: threshold boundary values, adjacency and tie-breaking between pairs,
+  the attuned skip, sent-flag persistence round-trip, the backfill guard across multiple
+  loads, and the tutorial-panel single-render fix if this phase made it.
+- Add missing tests, including a determinism test if sim logic changed (same seed and same
+  inputs produce the same letter on the same tick).
+- Remove orphaned tests the phase left behind or made meaningless.
+
+Agent dead code and cleanup:
+- Unused imports, types, and exports introduced by the phase; leftover TODOs and debug
+  logging.
+- Sim purity: no DOM/browser/Three imports and no Math.random, Date.now, or performance.now
+  anywhere the phase touched in src/sim/.
+- Catalog and matcher hygiene: no orphaned t() keys, no English fallbacks outside the
+  catalog, locale overlays untouched.
+
+Then spawn review agents per the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY
+matching rows. Because the Phase 07 deliverable set is complete, also spawn the qa-checklist
+agent over the full phase diff. Prompt them all for COVERAGE, not filtering.
+
+STEP 3 - FIX:
+- Apply every BLOCKING and SHOULD-FIX finding; record NITs as follow-ups if not worth the
+  churn.
+- Rerun the full STEP 2 validation command set until green, plus npm run ci:changed; format
+  only changed files with a scoped npx @biomejs/biome check --write <file>.
+- Commit fixes with explicit paths, never git add -A; Conventional Commits with a scope and
+  a body (for example fix(professions): ..., test(sim): ...).
+
+STEP 4 - UPDATE DOCS + MEMORY:
+- Update docs/professions-2/progress.md: the Phase 7 QA row (status, dates), mirror any
+  checkbox changes, and append deferrals and surprises to Notes.
+- Update docs/professions-2/state.md if QA changed any surface the phase recorded (renamed
+  symbols, a changed flag default, an added test pin).
+- Record genuine surprises to Claude Code memory.
+
+STEP 5 - FINAL RESPONSE FORMAT:
+Report: verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL); finding counts by severity and how many
+were fixed vs deferred; the validation command results; deferrals with owners; and a
+one-line handoff for the next phase session (Phase 8, stations and masters).
+(The packet-teardown offer is Phase 15 QA only and does not apply to this phase.)
+
+STOPPING RULES:
+No phase-specific rules. Baseline applies: stop and report if pre-flight finds a dirty
+checkout or the phase-start commit cannot be identified; never commit past a BLOCKING
+finding; the verdict is FAIL if any acceptance criterion cannot be verified against the real
+code.
+```

--- a/docs/professions-2/phase-08-qa.md
+++ b/docs/professions-2/phase-08-qa.md
@@ -1,0 +1,124 @@
+# Phase 08 QA: Verify stations and masters (sim and server)
+
+Independent audit of the Phase 8 diff: correctness, test coverage, dead code, determinism,
+three-host parity, and i18n completeness for the typed station registry, the six masters, the
+hands-vs-stations gate, and the placement-safety proof.
+
+## Phase-specific QA emphasis
+
+- The nine hub recipes' migration to typed stations, with special attention to the three
+  `CASTER_HUB_RECIPES`: crafting them at their station must behave exactly as it did under
+  `requiresHubStation` (no behavior regression in gate order, level rule, or proximity radius).
+- The deny reason localization: the sim emits a stable id, the `sim_i18n` matcher resolves it to
+  a real English `t()` key, and the S3 guard (`tests/localization_fixes.test.ts`) actually covers
+  the new emit site; no raw id or English concat ever reaches the player.
+- FIELD_RECIPES exactness: the set is EXACTLY the pre-phase nine `COMMON_RECIPES` ids, nothing
+  more, nothing fewer; each of the nine crafts away from every station and via the T window.
+- The placement test derives from spawn content (camps plus `aggroRadius`), not hardcoded
+  coordinates, and demonstrably fails when a master is placed next to a hostile spawn.
+
+## QA Starter Prompt
+
+```
+This is Phase 08 QA of the Professions 2.0 feature: verify Stations and masters (sim and server).
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: audit the Phase 8 diff for correctness, missing tests, dead code, determinism, three-host
+parity, and i18n completeness for THIS phase; fix what the audit finds; leave the phase provably
+done.
+
+STEP 0 - PRE-FLIGHT:
+- Run `git status`: the working tree must be clean (a concurrent session may share the checkout).
+  If it is not clean, stop and report.
+- Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries, at minimum:
+  node25-breaks-jsdom-gate (run gate commands under Node 24), the PR 2039 professions state, and
+  combo-recipes-broken-online (#2033: verify liveness, not just member shape, on any professions
+  surface).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize:
+- docs/professions-2/state.md and docs/professions-2/progress.md (including the phase-start and
+  phase-end commit hashes recorded in the Phase 8 notes)
+- docs/professions-2/phase-08-stations-masters.md (deliverables, invariants, acceptance criteria,
+  validation commands, and the phase-specific QA emphasis section of phase-08-qa.md)
+- git diff <phase-start-commit>..HEAD --stat and the full diff of the professions, content, and
+  tests files it names
+The summary MUST return: every deliverable and acceptance criterion with its claimed status; the
+list of files and new symbols the diff introduces (station registry module, StationType,
+stationType recipe field, FIELD_RECIPES, deny reason id, the six master NPC ids, the placement
+test file, the mobile-station wiring); the validation commands for this phase; and any diff hunk
+that looks unrelated to the phase.
+
+STEP 2 - QA AUDIT:
+Fan out three parallel audit agents. Give each ONLY the Explore summary plus its charge below.
+Prompt every agent for COVERAGE, not filtering: report every gap with confidence and severity
+(BLOCKING / SHOULD-FIX / NIT); filtering happens in STEP 3. If any agent's output arrives
+truncated, re-spawn it with a narrower scope and merge results; never proceed on partial output.
+
+Agent correctness deliverables:
+- Verify EVERY deliverable and acceptance criterion in phase-08-stations-masters.md against the
+  real code, not the phase session's claims.
+- Run the phase's validation commands: npx tsc --noEmit; npx vitest run
+  tests/professions_crafting_hub.test.ts tests/professions_crafting.test.ts
+  tests/progression.test.ts plus the placement test; npx vitest run tests/architecture.test.ts;
+  npx vitest run tests/localization_fixes.test.ts; npm run i18n:gen plus
+  tests/i18n_completeness.test.ts if keys were added.
+- Exercise the REAL behavior in a headless Sim harness, not just existing assertions: craft an
+  uncommon+ recipe away from its station (expect the stable deny id), at the WRONG station type
+  (expect deny), at the right station (expect success); craft each of the nine field recipes away
+  from any station; activate a mobile station and craft through the gate, then let it expire and
+  confirm the deny returns.
+- Probe the phase-specific QA emphasis items: the CASTER_HUB_RECIPES migration (no regression
+  against the old requiresHubStation behavior), the deny reason matcher path end to end, and
+  FIELD_RECIPES exactness (exactly the pre-phase nine COMMON_RECIPES ids).
+- Confirm the prime directive: every recipe craftable before the phase is still craftable at its
+  station or in the field; nothing strands a mid-progress player.
+
+Agent test-coverage deliverables:
+- Find untested paths in the diff: the wrong-station-type deny, the proximity boundary (just
+  inside vs just outside the station radius), mobile-station expiry, the placement buffer math,
+  the FIELD_RECIPES set pin, the deny reason id contract.
+- Add the missing tests, including a determinism test if sim logic changed (same seed, same
+  world; the new NPCs and gate draw no rng and shift no draw order).
+- Remove orphaned tests: stale requiresHubStation pins, superseded canUseCraftingHubStation
+  assertions, any temporary mutation left in the placement test.
+
+Agent dead-code-and-cleanup deliverables:
+- Unused imports, types, and exports: requiresHubStation leftovers, dead CRAFTING_HUB_STATIONS
+  consumers, duplicate station sources of truth.
+- Sim purity: no DOM/Three/render/ui/game/net imports in src/sim/; all randomness through Rng;
+  no Math.random, Date.now, or performance.now in the diff.
+- Leftover TODOs, debug output, commented-out code; the mobile_station.ts header accurately
+  describes the wired state; state.md and progress.md match what actually landed.
+
+Also: spawn review agents per the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY matching
+rows. Finish with the qa-checklist agent over the whole phase diff. Prompt all of them for
+COVERAGE, not filtering; same truncation rule as above.
+
+STEP 3 - FIX:
+- Apply every BLOCKING and SHOULD-FIX finding (NITs at your judgment; defer with a note if out of
+  phase scope). Fix bugs test-first where a finding is a behavior bug.
+- Rerun the STEP 2 validation commands until green.
+- Commit with EXPLICIT paths (never git add -A), Conventional Commits with a scope and a body,
+  for example fix(professions): <finding> or test(professions): <gap closed>.
+
+STEP 4 - UPDATE DOCS + MEMORY:
+- docs/professions-2/progress.md: mark the Phase 8 QA row, update mirrored checkboxes, append a
+  note listing findings by severity and their outcomes.
+- docs/professions-2/state.md: correct any Phase 8 surface entry the audit proved wrong; append
+  QA-discovered surfaces.
+- Record durable surprises (traps, contracts, tuning notes) to memory.
+
+STEP 5 - FINAL RESPONSE FORMAT:
+Report: verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; counts (findings by severity: found, fixed,
+deferred); validation results (each command, pass or fail); deferrals with owners and target
+phases; and a one-line handoff for the Phase 9 session (station presence and training builds on
+these registry and master surfaces).
+
+STOPPING RULES:
+- Stop IMMEDIATELY if the audit finds that any existing recipe became uncraftable for a player
+  mid-progress; that is a FAIL verdict and a maintainer escalation, not a quiet fix.
+- Stop if a fix would require changing a locked decision in state.md; ask first.
+- No commit while any BLOCKING finding stands; if validation cannot go green without expanding
+  scope beyond Phase 8, stop and report FAIL with the evidence.
+```

--- a/docs/professions-2/phase-08-stations-masters.md
+++ b/docs/professions-2/phase-08-stations-masters.md
@@ -1,0 +1,225 @@
+# Phase 08: Stations and masters (sim and server)
+
+This phase makes crafting stations real in the world model: a typed station registry with named
+master NPCs, the hands-vs-stations rule live in the sim-side craft gate, and an automated proof
+that no profession NPC or station sits inside hostile aggro range. It is its own slice because it
+is pure sim and content work with no rendering: Phase 9 (props, minimap, training UX) can only
+build on stations that already exist, gate correctly, and are provably placed safely.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: locked decisions (hands vs stations, FIELD_RECIPES default of the
+  nine common recipes, economy sinks, prime directive) and the validation matrix.
+- `docs/professions-2/progress.md`: the Phase 8 deliverable checklist to mirror on completion.
+- `docs/professions-2/implementation-plan.md`: team workflow and the Review Dispatch Matrix.
+- `src/sim/professions/crafting_hub.ts`: today's gate, `canUseCraftingHubStation(pos, level)` with
+  its proximity radius and min-level rule; the model this phase generalizes.
+- `src/sim/content/professions.ts`: `CRAFTING_HUB_STATIONS` (per-craft coordinates derived from
+  `CRAFT_RING`, unrendered); the new `STATIONS` records land beside it.
+- `src/sim/professions/types.ts`: `ProfessionRecipeRecord.requiresHubStation` (the boolean this
+  phase replaces with a typed `stationType`).
+- `src/sim/professions/crafting.ts`: `resolveCraft` / `resolveCraftForRecipe`, the sim-side gate
+  chain (station, combo eligibility, known recipe, materials, throttle plus gold sink).
+- `src/sim/professions/mobile_station.ts`: the dormant mobile-station perk module,
+  `isStationActive(station, nowTick)`, and its inert-module header comment.
+- `src/sim/content/recipes.ts`: `COMMON_RECIPES` (the nine field recipes), `TOOL_RECIPES` (six)
+  and `CASTER_HUB_RECIPES` (three) which carry `requiresHubStation: true` today, `COMBO_RECIPES`.
+- `src/sim/content/zone1.ts`: `ZONE1_NPCS` (`trader_wilkes` is the NpcDef exemplar with
+  `vendorItems`, `questIds`, `greeting`), `ZONE1_MOBS` (`aggroRadius`), `ZONE1_CAMPS`.
+- `src/sim/types.ts`: `NpcDef`, `CampDef` (`mobId`, `center`, `radius`, `count`), `MobTemplate`
+  (`aggroRadius`), the CAMPS draw-order determinism contract on `WorldContent`.
+- `src/ui/world_entity_i18n.ts`: entity name i18n registration (`tEntity` resolution path) for the
+  six master names, titles, and greetings.
+- `src/sim/CLAUDE.md`, `src/sim/content/CLAUDE.md`, `src/sim/professions/CLAUDE.md`,
+  `src/ui/CLAUDE.md` (S3 matcher duty), `tests/CLAUDE.md`.
+
+## Starter Prompt
+
+```
+This is Phase 08 of the Professions 2.0 feature: Stations and masters (sim and server).
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: typed stations with named masters exist in the world model, the hands-vs-stations rule is
+live in the sim-side craft gate, and placement is provably safe via an automated test.
+
+STEP 0 - PRE-FLIGHT:
+- Run `git status`: the working tree must be clean (a concurrent session may share the checkout).
+  If it is not clean, stop and report.
+- Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries, at minimum:
+  node25-breaks-jsdom-gate (run the gate under Node 24), the PR 2039 professions state
+  (combo_eligibility, cprof, attunedPairs), and combo-recipes-broken-online (#2033: the
+  liveness-not-shape trap for professions surfaces).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize:
+- docs/professions-2/state.md and docs/professions-2/progress.md
+- docs/professions-2/phase-08-stations-masters.md (this phase file)
+- src/sim/professions/crafting_hub.ts, src/sim/professions/crafting.ts (the resolveCraft /
+  resolveCraftForRecipe gate chain), src/sim/professions/types.ts,
+  src/sim/professions/mobile_station.ts
+- src/sim/content/professions.ts (CRAFTING_HUB_STATIONS, CRAFT_RING) and
+  src/sim/content/recipes.ts (COMMON_RECIPES, TOOL_RECIPES, CASTER_HUB_RECIPES, COMBO_RECIPES,
+  every requiresHubStation carrier)
+- src/sim/content/zone1.ts (ZONE1_NPCS with trader_wilkes as the NpcDef exemplar, ZONE1_MOBS
+  aggroRadius, ZONE1_CAMPS) and the NpcDef / CampDef / MobTemplate shapes in src/sim/types.ts
+- src/ui/world_entity_i18n.ts (entity-name i18n registration path)
+- src/sim/CLAUDE.md, src/sim/content/CLAUDE.md, src/sim/professions/CLAUDE.md, src/ui/CLAUDE.md
+  (the S3 matcher duty), tests/CLAUDE.md
+The summary MUST return: the exact gate order inside resolveCraftForRecipe and where the station
+check sits; the current proximity radius and level rule in canUseCraftingHubStation; the exact id
+list of the nine COMMON_RECIPES and of the nine requiresHubStation recipes with their
+professionId; the NpcDef field set and how entity names localize (tEntity); the CampDef and
+aggroRadius fields the placement test needs plus the CAMPS append-only determinism contract; how
+mobile_station.ts expects to be wired per its header; where sim-origin deny reasons get matched
+to t() keys today (sim_i18n matcher) and which test guards it (S3).
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
+Fan out three parallel implementation agents: a sim agent (station registry plus gate), a content
+agent (masters plus placement), and a tests agent. Give each agent ONLY the Explore summary plus
+its deliverable list below; they do not read planning docs. The sim and content agents both touch
+src/sim/content/professions.ts and src/sim/professions/types.ts surfaces, so sequence those two
+edits (sim agent lands types and registry first, content agent fills records after) or isolate in
+worktrees; the tests agent runs after both.
+
+Agent sim deliverables:
+- A typed station registry as its own module, src/sim/professions/stations.ts (module-first; do
+  not grow crafting.ts beyond the gate hook): a StationType union
+  'forge' | 'kitchens' | 'apothecary' | 'tannery' | 'loom' | 'toolworks', a StationDef record
+  { id, type, zoneId, pos, masterNpcId }, and pure lookup helpers (stations of a type, standing
+  at a station of a type using the existing proximity rule from crafting_hub.ts).
+- STATIONS content records in src/sim/content/professions.ts, generalizing CRAFTING_HUB_STATIONS
+  (data-as-code, so the table itself belongs in content). Migrate or delegate the old
+  CRAFTING_HUB_STATIONS consumers; do not leave two competing sources of truth.
+- ProfessionRecipeRecord gains stationType (optional StationType), generalizing
+  requiresHubStation. Map the nine existing requiresHubStation recipes (six TOOL_RECIPES, three
+  CASTER_HUB_RECIPES) to the station type of their professionId. Retire requiresHubStation and
+  its readers in the same change if nothing else consumes it; otherwise delegate it.
+- The gate in resolveCraftForRecipe: recipes in FIELD_RECIPES craft anywhere; every uncommon+
+  recipe requires standing at its stationType. Deny with a STABLE reason id (for example
+  'station_required' carrying the stationType value); add the matching t() key (English only)
+  and the sim_i18n matcher rule in the SAME change (S3 duty).
+- FIELD_RECIPES: a named set that is exactly the nine existing COMMON_RECIPES ids today. The T
+  window keeps working for them everywhere.
+- Mobile crafting station goes live: an active station (isStationActive) satisfies the station
+  gate; the placement command becomes reachable (dev-gated or specialization-gated, following the
+  existing perk command pattern); update the inert-module header in mobile_station.ts to describe
+  the now-wired state.
+
+Agent content deliverables:
+- Six master NpcDefs in ZONE1_NPCS, one per station type: a smith at the forge (covers both
+  weaponcrafting and armorcrafting, matching the Smith pair), a cook at the kitchens, an
+  alchemist at the apothecary, a leatherworker at the tannery, a tailor at the loom, and
+  engineering's toolwright at the toolworks. Follow the trader_wilkes exemplar shape.
+- Each master: a real name and title and greeting registered through the entity i18n path
+  (src/ui/world_entity_i18n.ts, tEntity); starter vendorItems (base tools and reagents, stock
+  only, training UX is Phase 9); an EMPTY questIds hook array for Phase 14.
+- Names are content flavor the maintainer may rename (state.md OPEN item); make them real, not
+  lorem, and note the naming-pass flag in the PR body.
+- Station placements: guard-safe town locations inside the zone 1 hub, each master beside its
+  station; reuse CRAFTING_HUB_STATIONS coordinates where they are already guard-safe.
+- Adding the masters must NOT shift the shared Rng draw order (the CAMPS append-only contract;
+  NPC creation draws no rng).
+
+Agent tests deliverables:
+- The automated placement-safety test (a new tests file, for example
+  tests/professions_station_placement.test.ts): derived from spawn CONTENT, not hardcoded
+  distances. For every profession NPC and every STATIONS record, distance to every hostile camp
+  (mob template aggroRadius > 0) must exceed camp.radius plus the template's aggroRadius plus a
+  buffer. Choose the buffer as the strictest value every existing town NPC already satisfies and
+  document it in the test; prove the test can fail by temporarily moving one master next to a
+  camp, observing the failure, then restoring.
+- Gate tests (extend tests/professions_crafting_hub.test.ts or a sibling): an uncommon+ recipe
+  denies with the stable station reason id away from its station and succeeds at it; each of the
+  nine FIELD_RECIPES crafts away from any station; a recipe denies at the WRONG station type;
+  an active mobile station bypasses the gate and an expired one does not.
+- A determinism check: same seed, same world; the new NPCs and the gate change do not shift rng
+  draw order (pin via the existing determinism harness pattern).
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Server authority: the station gate resolves sim-side inside resolveCraftForRecipe; the client
+  never decides craft outcomes. No client-side-only gating.
+- Determinism: all sim randomness through Rng; NPC creation draws no rng; CAMPS and content
+  ordering contracts respected; tests/architecture.test.ts stays green.
+- Sim purity: no DOM/Three/render/ui/game/net imports anywhere in src/sim/.
+- IWorld both worlds: if ANY new read or command must surface to render/ui (it should not this
+  phase; the deny reason rides the existing craft-result surface), it lands on a facet file,
+  implemented in BOTH Sim and ClientWorld, parity-pinned, in the same change. Verify liveness,
+  not just member shape (the 2033 stub trap).
+- i18n: every new player-visible string is an English-only t() key in the matching
+  src/ui/i18n.catalog/ module; sim-origin deny text is a stable id plus values with its
+  sim_i18n matcher rule in the SAME change (S3 guard); entity names via tEntity; never edit
+  src/ui/i18n.locales/ overlays.
+- Prime directive: nothing existing breaks. Every recipe craftable BEFORE this phase remains
+  craftable at its station or in the field; nothing strands. The T window keeps working for
+  field recipes everywhere. No ItemDef deletions.
+
+Out of scope (do NOT do in this phase):
+- Rendering, station props, minimap markers, and master interaction UX (Phase 9).
+- Recipe training and shop UX on the acquireRecipe gate (Phase 9); stocking vendorItems is fine.
+- Attunement lore quests at the masters (Phase 14); the questIds hooks stay empty.
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+Run the state.md validation matrix rows for a sim plus content change:
+- npx tsc --noEmit
+- npx vitest run tests/professions_crafting_hub.test.ts tests/professions_crafting.test.ts
+  tests/progression.test.ts plus the new placement test file
+- npx vitest run tests/architecture.test.ts (purity plus determinism guard)
+- npx vitest run tests/localization_fixes.test.ts (S3 matcher duty for the deny reason)
+- if i18n keys were added: npm run i18n:gen then npx vitest run tests/i18n_completeness.test.ts
+- npm run wiki:content (player-facing content changed: masters, station-bound recipes)
+- npm run ci:changed; format ONLY changed files with a scoped npx @biomejs/biome check --write
+Then spawn review agents per the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY matching
+rows. Prompt every review agent for COVERAGE, not filtering: report every correctness or
+requirement gap with confidence and severity; filtering happens in a later pass. If any agent's
+output arrives truncated, re-spawn it with a narrower scope and merge results; never proceed on
+partial review output. No commit while any BLOCKING finding stands.
+
+STEP 4 - COMMIT CADENCE:
+Commit in slices with EXPLICIT paths (never git add -A; the checkout may be shared), Conventional
+Commits, and every commit carries a body (1 to 4 sentences: what changed and why):
+- feat(professions): typed station registry and station gate
+- feat(content): the six crafting masters and station placements
+- test(content): station and master placement safety
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] STATIONS registry exists with typed records { id, type, zoneId, pos, masterNpcId }; recipe
+      records carry stationType; the nine hub recipes map to their profession's station type;
+      requiresHubStation is retired or delegates
+- [ ] Uncommon+ recipes deny with a localized station reason away from their station and succeed
+      at the right station type
+- [ ] FIELD_RECIPES is exactly the nine pre-phase COMMON_RECIPES ids; all nine craft anywhere and
+      the T window works for them everywhere
+- [ ] Six masters exist with entity i18n names/titles/greetings, starter vendorItems, empty
+      questIds hooks, placed guard-safe beside their stations
+- [ ] The placement-safety test is green AND proven: it fails when a master is moved next to a
+      hostile spawn (mutation tried and reverted)
+- [ ] The mobile crafting station perk is live: isStationActive satisfies the gate, the placement
+      command is reachable, the inert-module header is updated
+- [ ] Every recipe craftable before this phase remains craftable (station or field); nothing
+      strands
+- [ ] All STEP 3 validation commands green; no BLOCKING review finding open
+
+STEP 6 - DOC UPDATES + MEMORY:
+- Update docs/professions-2/progress.md: Phase 8 status row, mirror the acceptance checkboxes,
+  and record the phase-start and phase-end commit hashes in the Notes section (the QA session
+  diffs against the phase-start commit).
+- Update docs/professions-2/state.md: the "New surfaces per phase" Phase 8 entry gains the
+  station registry module and StationType union, the stationType recipe field, the FIELD_RECIPES
+  set, the six master NPC ids, the deny reason id and its i18n key namespace, the mobile-station
+  activation command, and the placement test file name. Amend "Key existing surfaces" where
+  requiresHubStation / CRAFTING_HUB_STATIONS statements went stale.
+- Record surprises (gate order gotchas, rng draw-order traps, naming decisions) to memory.
+
+STEP 7 - FINAL RESPONSE FORMAT:
+Report: phase status (complete / partial with reasons); files touched (absolute paths); validation
+results (each command, pass or fail); review agent verdicts (per agent, findings fixed or open);
+deferrals with owners; and a one-line QA handoff naming the phase-start commit for the diff.
+
+STOPPING RULES:
+- Stop IMMEDIATELY if any existing recipe would become uncraftable for a player mid-progress (an
+  uncommon+ recipe with no reachable station of its type and no FIELD_RECIPES membership); report
+  to the maintainer instead of shipping.
+- Stop if honoring a deliverable would require changing a locked decision in state.md; ask first.
+- No commit while any BLOCKING review finding stands; if validation cannot go green without
+  expanding scope beyond this phase, stop and report.
+```

--- a/docs/professions-2/phase-08-stations-masters.md
+++ b/docs/professions-2/phase-08-stations-masters.md
@@ -42,6 +42,11 @@ Goal: typed stations with named masters exist in the world model, the hands-vs-s
 live in the sim-side craft gate, and placement is provably safe via an automated test.
 
 STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
 - Run `git status`: the working tree must be clean (a concurrent session may share the checkout).
   If it is not clean, stop and report.
 - Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries, at minimum:

--- a/docs/professions-2/phase-09-qa.md
+++ b/docs/professions-2/phase-09-qa.md
@@ -1,0 +1,97 @@
+# Phase 09 QA: Verify Station presence and recipe training
+
+Independent audit of Phase 9: stations visible in both hosts, training live and
+server-authoritative, and no existing character lost a recipe.
+
+## Phase-specific QA emphasis
+
+- Train command replay/idempotency: a duplicated or replayed wire command must never
+  double-charge the fee or double-grant a recipe; prove it with a test, not by reading the code.
+- Grandfather normalize on a legacy save fixture: load a real pre-phase state blob and prove
+  every previously craftable recipe id reads as known after normalize, and that a second
+  normalize pass changes nothing.
+- GLB budget unchanged if no new GLB landed; if one did land, verify the media manifest regen,
+  `registerPreload`, and `npm run asset:budget` all hold.
+
+## QA Starter Prompt
+
+```
+This is Phase 09 QA of the Professions 2.0 feature: verify Station presence and recipe
+training.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: audit the Phase 9 diff for correctness, missing tests, dead code, determinism,
+three-host parity, and i18n completeness for THIS phase; fix what the audit finds; return a
+verdict.
+
+STEP 0 - PRE-FLIGHT:
+- Run git status. The tree must be clean (a concurrent session may share this checkout);
+  stop and report if it is not.
+- Scan Claude Code memory (the MEMORY.md index) for: node25-breaks-jsdom-gate (run the gate
+  under Node 24), the PR 2039 state (the professions foundation surfaces), and the
+  design-language program (today's tokens only; no DESIGN.md phase vocabulary).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize:
+- docs/professions-2/state.md and docs/professions-2/progress.md
+- docs/professions-2/phase-09-station-training.md (deliverables, acceptance criteria,
+  validation commands, invariants, and the phase-specific QA emphasis bullets)
+- The Phase 9 diff: git diff against the phase-start commit recorded in progress.md's Phase 9
+  entry (if absent, the commit before the first Phase 9 commit); the stat plus the full diff
+  of every touched file.
+The summary must return: every deliverable and acceptance criterion, the exact validation
+commands, the touched files grouped by domain (render, ui, sim, world_api, net, server,
+tests), and the emphasis bullets.
+
+STEP 2 - QA AUDIT:
+Spawn three parallel agents, each given ONLY the Explore summary. Prompt every agent for
+COVERAGE, not filtering: report every correctness or requirement gap with confidence and
+severity; filtering happens in a later pass.
+- Correctness agent: verify every deliverable and acceptance criterion against the real code;
+  run the phase's validation commands (the ui/render and net/wire matrix rows plus
+  npx vitest run tests/minimap_markers.test.ts tests/snapshots.test.ts
+  tests/world_api_parity.test.ts and the new train and grandfather tests); exercise the real
+  behavior, not just the tests (walk to a station, confirm the minimap marker, open the Train
+  view, learn a recipe in BOTH the offline Sim and the online ClientWorld; drive the denial
+  paths: out of range, insufficient gold, not teachable here, already known). Probe the
+  emphasis items explicitly: train replay/idempotency (no double-charge, no double-grant),
+  the grandfather normalize on a legacy save fixture, and the GLB budget unchanged if no new
+  GLB landed.
+- Test coverage agent: find untested paths (every denial branch, the exactly-affordable fee
+  edge, the marker variant against both host shapes, normalize idempotency on a second load);
+  ADD the missing tests, including a determinism test if sim logic changed in this phase;
+  remove orphaned tests the phase left behind.
+- Dead code and cleanup agent: unused imports and types, sim purity (no DOM/Three or
+  render/ui/game/net imports in src/sim/; all randomness through Rng; no Math.random,
+  Date.now, or performance.now), leftover TODOs and debug logging, stray placeholder props
+  not driven by the STATIONS registry, and hex literals outside tokens.css/theme.ts.
+- Also spawn review agents per the Review Dispatch Matrix in
+  docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY
+  matching rows. Run the qa-checklist agent over the complete phase diff.
+- If any agent response comes back truncated, re-spawn that agent to resume from its last
+  completed item; never treat partial output as a full report.
+
+STEP 3 - FIX:
+- Apply every BLOCKING and SHOULD-FIX finding, test-first where a bug reproduces (reproduce
+  with a failing test, then the smallest change that turns it green).
+- Rerun the validation commands from STEP 2 until green.
+- Commit with explicit paths (never git add -A), Conventional Commits with a scope and a body
+  (fix(professions), fix(ui), test(professions) as they fit).
+
+STEP 4 - UPDATE DOCS + MEMORY:
+- Update docs/professions-2/progress.md (the Phase 9 QA result and findings summary) and
+  docs/professions-2/state.md if any surface changed during fixes.
+- Record durable surprises (fixture traps, wire quirks, flaky suites) to Claude Code memory.
+
+STEP 5 - FINAL RESPONSE FORMAT:
+- Verdict: PASS, PASS-WITH-FOLLOWUPS, or FAIL.
+- Counts: findings by severity, fixed versus deferred, tests added and removed.
+- Deferrals with reasons and owners.
+- A one-line handoff for Phase 10: recipe ladders may rely on live training and the
+  trained-not-known default.
+
+STOPPING RULES:
+- Stop and report FAIL if grandfathering cannot be proven on the legacy fixture; that was the
+  phase's gate, do not paper over it.
+- Stop if a fix would require violating a locked decision in state.md; defer it with a written
+  reason instead.
+```

--- a/docs/professions-2/phase-09-station-training.md
+++ b/docs/professions-2/phase-09-station-training.md
@@ -41,6 +41,11 @@ Goal: make stations visible places whose masters teach recipes for fees, and tur
 acquisition on without stranding any existing character.
 
 STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
 - Run git status. The tree must be clean (a concurrent session may share this checkout);
   stop and report if it is not.
 - Scan Claude Code memory (the MEMORY.md index) for: node25-breaks-jsdom-gate (run the gate

--- a/docs/professions-2/phase-09-station-training.md
+++ b/docs/professions-2/phase-09-station-training.md
@@ -1,0 +1,212 @@
+# Phase 09: Station presence and recipe training
+
+Phase 8 landed the typed station registry and master NPC records in sim and server; this phase
+makes them real to players. Stations render as visible props in the world, show on the minimap,
+and their masters teach recipes for gold through a Train view, while a grandfathering step
+backfills every pre-existing recipe as known so acquisition goes live without stranding anyone.
+It is its own slice because it is the presentation-and-wire half of stations: the sim/server
+truth exists (Phase 8), and the recipe ladder content that depends on live training is Phase 10.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: locked decisions binding this phase (acquisition via
+  `acquireRecipe`, the grandfathering rule, training fee tuning targets, hands vs stations),
+  the validation matrix, and the Phase 8 "New surfaces" entry (station registry, master NpcDefs).
+- `docs/professions-2/progress.md`: current status and the Phase 8 handoff.
+- `docs/professions-2/implementation-plan.md`: review dispatch matrix and design-language
+  guardrails (today's tokens only; no DESIGN.md phase vocabulary).
+- `src/render/props.ts` (prop placement patterns) and `src/render/characters/manifest.ts`
+  (`NPC_KEYS`; `npc_smith` exists, `npc_villager` is the fallback), plus `src/render/CLAUDE.md`.
+- `src/ui/minimap_markers.ts` and `src/ui/minimap_painter.ts`: the marker union and painter.
+- `src/ui/hud/vendor/`: the vendor window family (`vendor_view.ts` pure core,
+  `vendor_window.ts` painter; the heroic variant shows how the family extends).
+- `src/sim/professions/crafting.ts` (`acquireRecipe`, `acquireRecipeForRecipe`,
+  `isRecipeKnown`), `src/sim/professions/types.ts` (`knownRecipes`),
+  `src/sim/professions/crafting_hub.ts` (today's station gate), and the Phase 8 station
+  registry module named in `state.md`.
+- `src/world_api/professions.ts` (the facet for the new command) and
+  `tests/world_api_parity.test.ts` (the pin).
+- `server/game.ts` (command dispatch) and `src/net/online.ts` (wire command send plus the
+  `ClientWorld` mirror; `prof`/`gprof`/`ncd`/`cprof` self-wire keys are the pattern).
+- Local conventions: `src/sim/CLAUDE.md`, `src/sim/professions/CLAUDE.md`,
+  `src/render/CLAUDE.md`, `src/ui/CLAUDE.md`, `src/ui/hud/CLAUDE.md`,
+  `src/world_api/CLAUDE.md`, `src/styles/CLAUDE.md`.
+
+## Starter Prompt
+
+```
+This is Phase 09 of the Professions 2.0 feature: Station presence and recipe training.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: make stations visible places whose masters teach recipes for fees, and turn recipe
+acquisition on without stranding any existing character.
+
+STEP 0 - PRE-FLIGHT:
+- Run git status. The tree must be clean (a concurrent session may share this checkout);
+  stop and report if it is not.
+- Scan Claude Code memory (the MEMORY.md index) for: node25-breaks-jsdom-gate (run the gate
+  under Node 24), the PR 2039 state (the professions foundation surfaces this phase builds on),
+  and the design-language program (DESIGN.md is adopted but unlanded; today's tokens only).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize:
+- docs/professions-2/state.md and docs/professions-2/progress.md
+- docs/professions-2/phase-09-station-training.md (this phase file)
+- src/render/props.ts, src/render/characters/manifest.ts (NPC_KEYS), src/ui/minimap_markers.ts,
+  src/ui/minimap_painter.ts, the src/ui/hud/vendor/ modules, src/sim/professions/crafting.ts,
+  src/sim/professions/types.ts, src/sim/professions/crafting_hub.ts, the Phase 8 station
+  registry module (see state.md "New surfaces per phase"), src/world_api/professions.ts,
+  server/game.ts (command dispatch only), src/net/online.ts (command send + ClientWorld mirror)
+- CLAUDE.md files: src/sim/CLAUDE.md, src/sim/professions/CLAUDE.md, src/render/CLAUDE.md,
+  src/ui/CLAUDE.md, src/ui/hud/CLAUDE.md, src/world_api/CLAUDE.md, src/styles/CLAUDE.md
+The summary must return: the locked decisions and fee tuning targets that bind this phase;
+the STATIONS registry shape and the master NpcDef ids from Phase 8; the vendor window family
+pattern (pure view core + painter, and how the heroic variant extends it); the minimap marker
+union shape and how markers are tested against both host shapes; the existing wire command and
+self-wire delta-key patterns in online.ts and game.ts to copy; where knownRecipes persists and
+where normalize-on-load steps live; the ui/render and net/wire validation matrix rows; and
+where the review dispatch matrix lives.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
+Fan out four agents; give each ONLY the Explore summary plus the files it owns. The render, ui,
+and sim/wire agents edit disjoint files and run in parallel; the tests agent runs after them.
+
+Agent render deliverables:
+- src/render/stations.ts: a new module the renderer calls (never a method bank on renderer.ts)
+  that places props per the STATIONS registry. Reuse anvil.glb for the smithing-family stations
+  and the existing campfire for cooking; simple prop-cluster placeholders (existing crates,
+  tables, props) for the rest. Prefer reuse this phase: any NEW GLB must go through the media
+  manifest regen + registerPreload + the asset budget, so avoid one unless indispensable.
+- Masters render via NPC_KEYS entries in src/render/characters/manifest.ts (npc_smith exists;
+  the npc_villager fallback is acceptable for the remaining masters this phase).
+- A station minimap marker variant: extend the marker union in src/ui/minimap_markers.ts and
+  paint it in src/ui/minimap_painter.ts with token colors only (zero hex literals outside
+  tokens.css/theme.ts) and tier-identical rendering (no graphics preset may hide or degrade it).
+
+Agent ui deliverables:
+- The master dialog gains a Train view on the vendor window family (src/ui/hud/vendor/): a
+  DOM-free pure view core (registered in UI_PURE_CORES if it is a new module) plus a thin
+  write-elided painter, following the heroic vendor variant as the extension template.
+- Rows show the recipe, the fee (formatMoney), and known/teachable state; the Train action
+  issues the IWorld command; denial reasons render through the server/sim matcher keys.
+- Every player-visible string is an English-only t() key in the matching
+  src/ui/i18n.catalog/<domain>.ts module; mobile rules per src/styles/CLAUDE.md (a deliberate
+  body.mobile-touch rule or a reasoned MOBILE_WINDOW_EXCEPTIONS entry; 40px tap floor).
+
+Agent sim/wire deliverables:
+- A trainRecipe command: a member on the IWorld professions facet (src/world_api/professions.ts),
+  implemented in BOTH worlds (Sim: full validation + grant offline; ClientWorld: send the wire
+  command online), with the parity pin updated in tests/world_api_parity.test.ts in the same
+  change. Verify liveness, not just member shape (the 2033 stub trap).
+- Server validation in the command dispatch (server/game.ts): proximity to the master's
+  station, fee affordable and charged, recipe teachable at this master; on success grant via
+  acquireRecipe. Fee and grant resolve SERVER-side; the client never decides. Fees follow the
+  state.md tuning targets (common tier free, uncommon 25s, rare 1g) and are a gold sink.
+- Denial reasons are emitted as stable ids the client matcher re-localizes (S3 duty, in the
+  SAME change).
+- Grandfathering: a normalize-on-load step backfills every recipe id that existed before this
+  phase as known, for offline saves and server-persisted state alike; deterministic and
+  idempotent (running it twice changes nothing).
+- New tier recipes from Phase 10 onward default to trained-not-known: set that default on the
+  recipe definition now and document it at the type, since the acquisition path is now live.
+
+Agent tests deliverables:
+- Train command tests: the happy path (fee charged exactly once, recipe known after), the
+  denial paths (out of range, insufficient gold, not teachable at this master, already known),
+  and replay/idempotency (a resent or duplicated command cannot double-charge or double-grant).
+- A grandfather test on a legacy save fixture (a pre-phase state blob with craftable recipes
+  and no acquisition records) proving nothing is lost. This test is the phase gate.
+- The minimap marker variant tested against BOTH host shapes (tests/minimap_markers.test.ts).
+- Parity and wire pins updated (tests/world_api_parity.test.ts; the ALL_DELTA_KEYS and
+  TERSE_TO_IWORLD pins in tests/snapshots.test.ts if a new wire key lands).
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Determinism: all sim randomness through Rng; never Math.random, Date.now, or performance.now
+  in src/sim/; the fixed 20 Hz tick (guarded by tests/architecture.test.ts).
+- Server authority: the fee and the grant resolve server-side; the client is a renderer and
+  never decides outcomes.
+- IWorld both worlds: every new read or command lands on a facet file, implemented live in
+  BOTH Sim and ClientWorld, parity-pinned in the same change.
+- i18n: every player-visible string is an English-only t() key; sim/server player text ships
+  as stable ids with matcher rules in the SAME change (S3 guard:
+  tests/localization_fixes.test.ts).
+- Design language: today's tokens and the shared window shell only; no DESIGN.md phase
+  vocabulary (new ramp/radius/duration tokens, font flips, window grammar fragments).
+- Prime directive: nothing existing breaks. The grandfathering test is the gate; every
+  pre-phase character keeps everything it could craft.
+
+Out of scope (do NOT do in this phase):
+- Recipe ladder content (tier ladders, material families): Phase 10.
+- Quest hooks at the masters (attunement quests, nudges): Phase 14.
+- Tool effects/charges (parked), salvage or enchanting UI (Phase 13), market/mail instance
+  carriage (wave 2).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+- Run the ui/render and net/wire rows of the validation matrix in docs/professions-2/state.md:
+  npx tsc --noEmit
+  npx vitest run tests/localization_fixes.test.ts
+  npx vitest run tests/mobile_window_coverage.test.ts tests/mobile_window_transform.test.ts
+    tests/mobile_window_layout.test.ts
+  npx vitest run tests/snapshots.test.ts tests/env_protocol.test.ts tests/bandwidth.test.ts
+    tests/world_api_parity.test.ts
+- Plus the phase-named suites and the new tests:
+  npx vitest run tests/minimap_markers.test.ts tests/snapshots.test.ts
+    tests/world_api_parity.test.ts plus the new train and grandfather test files
+- i18n keys were added: npm run i18n:gen, then
+  npx vitest run tests/i18n_completeness.test.ts tests/localization_fixes.test.ts
+- Sim changed: npx vitest run tests/architecture.test.ts
+- Desktop AND mobile screenshots (the station visible in the world; the Train view open) via
+  the pr-screenshots skill, committed under docs/screenshots.
+- Spawn review agents per the Review Dispatch Matrix in
+  docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY
+  matching rows.
+- Prompt every review agent for COVERAGE, not filtering: report every correctness or
+  requirement gap with confidence and severity; filtering happens in a later pass.
+- If any agent response comes back truncated, re-spawn that agent to resume from its last
+  completed item; never treat partial output as a full report.
+
+STEP 4 - COMMIT CADENCE (explicit paths, never git add -A; every commit carries a body):
+- feat(render): station presence (stations module, master NPC keys, minimap marker variant)
+- feat(professions): recipe training command with server-side fee and grant, plus
+  grandfathering
+- feat(ui): the Train view on the vendor window family
+- docs(professions-2): Phase 9 progress, state surfaces, and screenshots
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] A player can walk to a visible station in the world (props placed per the STATIONS
+      registry).
+- [ ] The station shows on the minimap with the new marker variant, token-colored and
+      tier-identical, tested against both host shapes.
+- [ ] Opening the master presents the Train view; learning a recipe charges the fee and grants
+      it via acquireRecipe in BOTH the offline Sim and the online ClientWorld.
+- [ ] Fees match the state.md tuning targets (common free, uncommon 25s, rare 1g), are charged
+      server-side as a gold sink, and a replayed command cannot double-charge or double-grant.
+- [ ] Every character that existed before this phase knows every recipe it could previously
+      craft (grandfather normalize step plus the legacy fixture test, green).
+- [ ] New recipes default to trained-not-known from Phase 10 onward (default in place and
+      pinned by a test).
+- [ ] All STEP 3 validation commands green; parity pin updated; no BLOCKING review finding
+      stands; desktop and mobile screenshots committed under docs/screenshots.
+- [ ] No new GLB shipped; or, if one was truly needed, the media manifest was regenerated,
+      registerPreload wired, and npm run asset:budget is green.
+
+STEP 6 - DOC UPDATES + MEMORY:
+- Update docs/professions-2/progress.md (Phase 9 checklist and status, plus the phase-start
+  commit for the QA diff) and docs/professions-2/state.md: the "New surfaces per phase" list
+  gains Phase 9 (src/render/stations.ts; the station minimap marker variant; the trainRecipe
+  facet member and wire command; the grandfather normalize step; the Train view i18n key
+  namespace; the trained-not-known recipe default). Resolve or explicitly defer the OPEN item
+  "exact FIELD_RECIPES membership" (the default stands: the 9 common recipes stay
+  field-craftable) and record the outcome in state.md.
+- Record durable surprises (wire quirks, fixture gotchas) to Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT:
+- Phase status (complete, or partial with why), files touched, validation results per command,
+  review verdicts per agent, deferrals with reasons, and a one-line QA handoff naming the
+  phase-start commit for the diff.
+
+STOPPING RULES:
+- Stop immediately, without committing the acquisition switch, if grandfathering cannot be
+  proven on a legacy save fixture; report what the fixture shows and wait for the maintainer.
+- Stop and report if any deliverable would require violating a locked decision in state.md;
+  never improvise around one.
+```

--- a/docs/professions-2/phase-10-qa.md
+++ b/docs/professions-2/phase-10-qa.md
@@ -1,0 +1,131 @@
+# Phase 10 QA: Verify Recipe ladders and materials content
+
+Audit the Phase 10 content drop: the six tier ladders, the material families, the corpse
+component collision fix, and the pinned economy invariant.
+
+## Phase-specific QA emphasis
+
+- Cross-craft material demand sanity: every gathered or harvested material (Phase 4 node
+  yields, the new corpse components, fiber and cloth) has at least one consuming recipe;
+  flag every orphan material.
+- The collision fix must not break existing quest saves mid-objective: exercise a save that
+  holds old quest items with a quest partially counted, load it, and verify credit
+  continues correctly.
+- Count the ladders against the `state.md` craft list: exactly the six deep crafts get
+  ladders (engineering is the toolmaker line, not a seventh ladder; jewelcrafting,
+  inscription, and enchanting stay shallow).
+- Economy invariant decisiveness: the test must enumerate EVERY recipe (not a sample) and
+  price vendor reagents at their purchase price, not their sell price.
+
+## QA Starter Prompt
+
+```
+This is Phase 10 QA of the Professions 2.0 feature: Verify Recipe ladders and materials
+content.
+
+Model: Opus 4.8, xhigh effort (reserve max for genuinely frontier problems), 1m context
+variant where the file load demands it.
+Harness: Claude Code.
+ULTRACODE: this phase was a batch content drop across hundreds of records; add the keyword
+`ultracode` so you can run an adversarial-verify Workflow (each finding independently
+confirmed by a skeptic agent before it counts).
+
+Goal: audit the Phase 10 implementation for correctness, missing tests, dead code,
+determinism, three-host parity, and i18n completeness.
+
+STEP 0 - PRE-FLIGHT:
+- Verify git status is clean (Phase 10 should already be committed). If dirty, ask the
+  user (a concurrent session may share this checkout).
+- Memory scan (if you use Claude Code memory): check entries from the professions domain
+  (suggested topics: node25-breaks-jsdom-gate for the gate rule, PR 2039 state,
+  combo-recipes-broken-online for the 2033 stub trap).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly, save your context):
+Spawn an Explore agent to read and summarize:
+- docs/professions-2/state.md (locked decisions, validation matrix, the Phase 10 entry in
+  New surfaces: material item families, ladder locations, the economy test path)
+- docs/professions-2/progress.md (the Phase 10 deliverables checklist and acceptance
+  criteria)
+- docs/professions-2/phase-10-recipe-ladders.md (the implementation prompt: what was
+  promised, including the acceptance criteria and stopping rules)
+- git diff against the Phase 10 start commit (git diff --name-only first, then the
+  substantive files: src/sim/content/recipes.ts, src/sim/content/items.ts,
+  src/sim/content/professions.ts, src/ui/i18n.catalog/items.ts, the new tests)
+- CLAUDE.md (root) + src/sim/CLAUDE.md + src/ui/CLAUDE.md + src/guide/CLAUDE.md
+The agent must return: the full Phase 10 deliverable list, every file created or
+modified, the new material and fish item ids, the ladder recipe counts per craft, the
+economy test path, and any deferrals noted in progress.md.
+
+STEP 2 - QA AUDIT (spawn three parallel agents using the Explore summary; prompt each for
+COVERAGE not filtering: report every issue including low-severity and uncertain ones;
+ranking happens in a later step):
+
+Correctness agent:
+- Verify every Phase 10 deliverable was actually implemented and every acceptance
+  criterion in the phase prompt is met.
+- Run the phase's validation commands: npx tsc --noEmit; npx vitest run
+  tests/progression.test.ts tests/professions_crafting.test.ts
+  tests/mob_component_tags.test.ts tests/localization_fixes.test.ts; the economy
+  invariant test; npm run i18n:gen + npx vitest run tests/i18n_completeness.test.ts;
+  npm run wiki:content.
+- Exercise the real behavior, not just the tests: train a new recipe at its master and
+  craft it end to end in the sim (materials consumed, output produced, fee charged);
+  harvest a corpse and confirm the dedicated material drops while quest credit still
+  flows only from the correct mobs.
+- Probe the phase-specific emphasis items: every gathered material has a consumer
+  (flag orphans); an existing quest save mid-objective with old quest items still
+  progresses after the collision fix; the ladder count matches the state.md craft list
+  exactly (six deep crafts, engineering excluded); the economy test enumerates every
+  recipe and prices vendor reagents at purchase price.
+- Verify no pre-existing recipe changed in cost or output, and no ItemDef players may
+  hold was deleted.
+
+Test coverage agent:
+- Identify new content paths without tests: untested ladders, tiers, training links,
+  material mappings, and the fish forward references.
+- Add missing tests, including a determinism test (same seed, same result) if any sim
+  logic changed alongside the content (crafting resolution, harvest yields).
+- Verify the economy invariant and referential integrity suites are decisive: they fail
+  on a seeded bad record, not just pass on the current data.
+- Update existing tests broken by Phase 10; remove orphaned tests for replaced
+  placeholder content. Verify assertions are meaningful, not just "it runs".
+
+Dead code and cleanup agent:
+- Find unused imports, types, helper functions, and leftover placeholder records from the
+  pre-ladder recipe tables.
+- Verify sim purity: src/sim/ has no DOM/Three imports, imports nothing from
+  render/ui/game/net, and all randomness goes through Rng.
+- Verify no TODO/FIXME items were left unresolved and no commented-out code remains;
+  check naming consistency with the existing content tables.
+
+Multi-agent review dispatch: apply the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md; check git diff --name-only against the
+phase-start commit and spawn ONLY the agents whose row matches, plus qa-checklist (this
+is the phase-completion QA gate). Prompt each for COVERAGE not filtering.
+Resume any agent that truncates mid-analysis with: "Stop reading more files. Output the
+full report now based on what you've already seen. No more tool calls. Format:
+BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT."
+
+STEP 3 - FIX:
+Apply all BLOCKING and SHOULD-FIX items. Rerun the validation matrix rows from state.md
+(at minimum npx tsc --noEmit, the four vitest files above, the economy test, and
+npm run wiki:content). Commit fixes separately from the QA verdicts so the history is
+reviewable; EXPLICIT paths, never git add -A; Conventional Commits with a body.
+
+STEP 4 - UPDATE DOCS + MEMORY:
+- Update docs/professions-2/progress.md (mark Phase 10 QA complete; note items deferred
+  to follow-up).
+- Update docs/professions-2/state.md (any drift discovered during QA: corrected item ids,
+  test paths, ladder counts).
+- If you use Claude Code memory, record any surprising rules learned during QA.
+
+STEP 5 - FINAL RESPONSE FORMAT:
+End your turn with: QA verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL), counts of BLOCKING /
+SHOULD-FIX / NICE-TO-HAVE found and fixed, deferred items, and a one-line handoff for the
+Phase 11 implementation session.
+
+STOPPING RULES:
+- Stop and surface to the user if any BLOCKING item cannot be fixed without changing the
+  phase scope (for example, a material whose only viable source turns out to be wave-2
+  content, or a collision fix that cannot preserve existing quest saves).
+```

--- a/docs/professions-2/phase-10-recipe-ladders.md
+++ b/docs/professions-2/phase-10-recipe-ladders.md
@@ -1,0 +1,221 @@
+# Phase 10: Recipe ladders and materials content
+
+This phase turns the six deep crafts into real progressions: common to rare tier ladders that
+consume the Phase 4 node materials, corpse components, fish, and vendor reagents, backed by a
+pinned economy invariant so no recipe ever vendors above its inputs. It is its own slice because
+it is pure batch content work (hundreds of records across a handful of tables) with no new sim
+behavior: everything it needs (wheel math, masterwork, stations, training) landed in Phases 1
+to 9, and everything that consumes it (fishing supply, node tiers, tuning) comes after.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: locked decisions (the six deep crafts, the economy invariant,
+  pacing, training-fee placeholders), the validation matrix, and the New surfaces entries for
+  Phases 4, 8, and 9 (where the node material tables and masters landed).
+- `docs/professions-2/progress.md`: the Phase 10 deliverable checklist.
+- `docs/professions-2/implementation-plan.md`: the Review Dispatch Matrix (the one canonical copy).
+- `src/sim/content/recipes.ts`: the existing recipe table and record shape; the ladders land here.
+- `src/sim/content/items.ts`: `ItemDef` records; every new material and every recipe output.
+- `src/sim/content/professions.ts`: `HARVEST_COMPONENT_ITEMS`, where the corpse component
+  quest-item collision lives today.
+- The Phase 4 material tables (per-rarity node yields; exact paths are recorded in the Phase 4
+  entry of `state.md`).
+- `src/ui/i18n.catalog/items.ts`: English catalog rows for every new item and recipe name.
+- The wiki content generator under `scripts/` (`npm run wiki:content`, freshness-gated by
+  `tests/guide.test.ts`) and `src/guide/CLAUDE.md` for any new `guide.*` prose keys.
+- `src/sim/CLAUDE.md` and `src/ui/CLAUDE.md` for content and i18n conventions.
+- `tests/progression.test.ts`, `tests/professions_crafting.test.ts`,
+  `tests/mob_component_tags.test.ts`: the pinned suites this phase must keep green and extend.
+
+## Starter Prompt
+
+```
+This is Phase 10 of the Professions 2.0 feature: Recipe ladders and materials content.
+
+Model: Opus 4.8, xhigh effort (reserve max for genuinely frontier problems), 1m context
+variant where the file load demands it.
+Harness: Claude Code.
+ULTRACODE: this phase is batch-heavy (six full recipe ladders plus a material sweep across
+the content tables). Add the keyword `ultracode` to this prompt and orchestrate via a
+Workflow (per-craft pipeline plus adversarial verification of referential integrity), not
+hand-spawned agents.
+
+Goal: give all six deep crafts real common to rare tier ladders consuming real materials
+(Phase 4 node yields, dedicated corpse components, fish, vendor reagents), end the corpse
+component quest-item collision, and pin the economy invariant that no recipe vendors above
+its inputs.
+
+STEP 0 - PRE-FLIGHT:
+- Verify `git status` is clean before starting. If not, ask the user (a concurrent session
+  may share this checkout).
+- Memory scan (if you use Claude Code memory): check your MEMORY.md index and any entries
+  relevant to this phase's domain (suggested topics: node25-breaks-jsdom-gate for the gate
+  rule, PR 2039 state for the professions foundation, combo-recipes-broken-online for the
+  2033 stub trap in the professions wire surface).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly, save your context):
+Spawn an Explore agent to read and summarize:
+- docs/professions-2/state.md (locked decisions, validation matrix, the New surfaces
+  entries for Phases 4, 8, and 9)
+- docs/professions-2/progress.md (Phase 10 status + deliverable checklist)
+- docs/professions-2/phase-10-recipe-ladders.md (this prompt); verify the agent has the
+  same understanding
+- src/sim/content/recipes.ts (recipe record shape, existing recipes, how tiers and
+  stations are expressed)
+- src/sim/content/items.ts (ItemDef shape, vendor value fields, existing material items)
+- src/sim/content/professions.ts (HARVEST_COMPONENT_ITEMS and the current corpse component
+  to quest-item collision)
+- the Phase 4 node material tables (paths per state.md)
+- src/ui/i18n.catalog/items.ts (catalog row conventions for item names)
+- CLAUDE.md (root) + src/sim/CLAUDE.md + src/ui/CLAUDE.md + src/guide/CLAUDE.md
+The agent must return: the recipe and ItemDef record shapes with the exact fields a new
+record needs; the full list of Phase 4 gatherable materials by craft; the current
+HARVEST_COMPONENT_ITEMS mapping and every quest that references those items; the Phase 9
+master ids and the acquireRecipe training path; the vendor-value convention (buy vs sell
+price fields); and the i18n catalog row format for items.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
+Run this phase as an ultracode Workflow. Give every stage ONLY the Explore summary, never
+the raw planning docs. Suggested pipeline (structured outputs between stages):
+- Stage 1: the materials/collision agent (its output ids feed every later stage).
+- Stage 2: six craft content agents in parallel, one per craft (weaponcrafting,
+  armorcrafting, tailoring, leatherworking, cooking, alchemy). Have each return its ladder
+  as structured output (recipe records, ItemDef records, English catalog rows against a
+  shared schema); a single integration step then writes the shared content files, so the
+  parallel agents never edit recipes.ts, items.ts, or the catalog concurrently. If you let
+  agents write files directly instead, use isolation: "worktree".
+- Stage 3: the economy-test agent (runs after the tables exist).
+- Stage 4: the adversarial verify stage (re-derives every reference from the written
+  tables; a finding counts only when independently confirmed).
+
+Materials/collision agent deliverables:
+- Dedicated material ItemDefs for hide, silk, venomSac, and meat (plus any other corpse
+  component the audit surfaces), with HARVEST_COMPONENT_ITEMS remapped so harvesting
+  yields the new materials.
+- The old quest items keep their quest roles ONLY: quest drops and quest credit paths
+  stay exactly as they are, with a regression test proving quest credit still works and
+  that a wolf hide no longer advances a boar quest.
+- Cloth sourcing lands: plant fiber from the Phase 4 herbalism tables plus humanoid cloth
+  components, so tailoring's input family is complete.
+- Never delete an ItemDef players may hold; deprecate by removing sources only.
+
+Craft content agent deliverables (each of the six, for its craft):
+- A common to rare tier ladder; epic and above are stubbed as wave-2 hooks only (no
+  craftable or trainable epic recipe this phase).
+- Each tier's recipes consume Phase 4 node materials, the new corpse component materials,
+  fish (cooking: author the recipes and the fish ItemDefs now; Phase 11 lands the supply),
+  and vendor reagents.
+- Every output is a real ItemDef with an English catalog row and the procedural icon
+  fallback (bespoke WebP icon overrides are not required this phase).
+- Every new recipe is trained, not known, at the matching master via the Phase 9
+  acquireRecipe path, using the state.md fee placeholders (common free, uncommon 25s,
+  rare 1g).
+- Every recipe that existed before this phase keeps its exact costs and outputs.
+
+Economy-test agent deliverables:
+- The pinned economy invariant: a test (suggested: tests/recipe_economy.test.ts) that
+  computes the vendor value of EVERY recipe's output against the vendor value of its full
+  input list (vendor reagents priced at their purchase price) and fails on any
+  gold-positive recipe.
+- Referential integrity extensions: every recipe input and output id resolves to a real
+  ItemDef; every trained recipe maps to an existing Phase 8/9 master.
+
+Verify stage (adversarial) deliverables:
+- Re-derive every reference independently from the written tables: input ids, output ids,
+  master and training links, catalog keys, component mappings.
+- Confirm every gathered or harvested material introduced by Phases 4 and 10 has at least
+  one consuming recipe.
+- Report every issue including low-severity and uncertain ones; ranking happens later.
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Prime directive: nothing existing breaks. Existing recipes are unchanged in cost and
+  output; players holding old quest items are unaffected; never delete an ItemDef players
+  may hold.
+- Determinism: all randomness via Rng; no Math.random / Date.now / performance.now in
+  src/sim/. Content records must not introduce nondeterministic evaluation.
+- Server authority: the client never decides craft outcomes; this phase is content plus
+  tests and must not move any decision client-side.
+- Seam: this phase should need no new IWorld surface. If one becomes necessary, it lands
+  on a facet file, implemented in BOTH Sim and ClientWorld with the parity pin updated in
+  the same change, and verified LIVE, not just shaped (the 2033 stub trap).
+- i18n: every new player-visible string is a t() key added in ENGLISH ONLY to
+  src/ui/i18n.catalog/items.ts (never edit the locale overlays). This is the M16 watch
+  phase: every wordy new English name also needs its five non-Latin fills in the same
+  change. Any sim/server-emitted player text gets its matcher rule in src/ui/sim_i18n.ts
+  or src/ui/server_i18n.ts in the SAME change (the S3 guard enforces it).
+- The referential integrity suites stay green and grow with the new content.
+
+Out of scope (do NOT do in this phase):
+- Balance fine-tuning of costs, yields, or fees (Phase 15 tunes against live data).
+- Fishing supply, the minigame, or catch tables (Phase 11); author only the fish ItemDefs
+  and the cooking recipes that consume them.
+- Node tiers and tool tier gating (Phase 12).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+- Run the state.md content-only row plus the new economy test:
+  npx tsc --noEmit
+  npx vitest run tests/progression.test.ts tests/professions_crafting.test.ts
+    tests/mob_component_tags.test.ts tests/localization_fixes.test.ts
+  npx vitest run tests/recipe_economy.test.ts (or the path you chose for the invariant)
+  plus the referential integrity suites for the touched domain.
+- i18n keys were added, so also run the state.md i18n row: npm run i18n:gen, then
+  npx vitest run tests/i18n_completeness.test.ts tests/localization_fixes.test.ts.
+- npm run wiki:content must regen clean; the recipe and station data feeds the professions
+  guide page skeleton.
+- Spawn review agents per the Review Dispatch Matrix in
+  docs/professions-2/implementation-plan.md; check git diff --name-only against the
+  phase-start commit and spawn ONLY matching rows (a content, tests, and i18n-catalog diff
+  typically triggers qa-checklist at completion and little else; if no row matches, spawn
+  none).
+- Prompt each agent you spawn for COVERAGE not filtering: report every issue including
+  low-severity and uncertain ones; ranking happens in a later step.
+- Resume any agent that truncates with: "Stop reading more files. Output the full report
+  now based on what you've already seen. No more tool calls. Format: BLOCKING /
+  SHOULD-FIX / NICE-TO-HAVE / VERDICT."
+- Do not commit while any BLOCKING finding stands.
+
+STEP 4 - COMMIT CADENCE:
+Aim for 4 commits with these headlines (Conventional Commits with a scope; EXPLICIT
+paths, never git add -A; every commit carries a body; no em dashes or emojis):
+- feat(content): weaponcrafting and armorcrafting tier ladders
+- feat(content): tailoring and leatherworking tier ladders
+- feat(content): alchemy and cooking tier ladders
+- feat(content): component materials and the recipe economy invariant
+Land the component materials commit FIRST if the ladders reference the new material ids,
+so every commit keeps tsc and the suites green.
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] Each of the six deep crafts (weaponcrafting, armorcrafting, tailoring,
+      leatherworking, cooking, alchemy) has a common to rare ladder; the count matches
+      the state.md craft list exactly.
+- [ ] Every ladder material is obtainable from wave-one sources (fish is the one
+      sanctioned forward reference: recipes authored now, supply lands in Phase 11).
+- [ ] No recipe vendors gold-positive; the economy invariant test is pinned and green.
+- [ ] A wolf hide no longer advances a boar quest; quest credit regression tests green.
+- [ ] Every pre-existing recipe is unchanged in cost and output; players holding old
+      quest items are unaffected.
+- [ ] Every new recipe is trained-not-known at its matching master.
+- [ ] Every new item and recipe has an English catalog row; wordy names carry their five
+      non-Latin fills (M16).
+- [ ] npm run wiki:content regenerates clean.
+
+STEP 6 - DOC UPDATES + MEMORY:
+- Update docs/professions-2/progress.md (mark Phase 10 status; note deferrals).
+- Update docs/professions-2/state.md: the Phase 10 entry in New surfaces gains the new
+  material item id families (hide/silk/venomSac/meat/fiber/cloth), the ladder table
+  locations, the economy invariant test path, the i18n key namespaces added, the fish
+  item ids authored ahead of Phase 11, and the per-master trained recipe mapping.
+- If you use Claude Code memory, record any surprising rules or current-state notes for
+  the next session.
+
+STEP 7 - FINAL RESPONSE FORMAT:
+End your turn with: phase status, files touched, validation results, review-agent
+verdicts, any deferred items, and a one-line handoff for the QA session.
+
+STOPPING RULES:
+- Stop and surface to the user if any recipe material's ONLY source would be wave-2
+  content; every wave-one recipe must be satisfiable inside this packet (Phase 11 fish
+  supply is the one sanctioned pending source).
+- Stop and ask if ending the quest-item collision would require deleting or reshaping an
+  ItemDef players may hold (prime directive).
+```

--- a/docs/professions-2/phase-10-recipe-ladders.md
+++ b/docs/professions-2/phase-10-recipe-ladders.md
@@ -46,6 +46,11 @@ component quest-item collision, and pin the economy invariant that no recipe ven
 its inputs.
 
 STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
 - Verify `git status` is clean before starting. If not, ask the user (a concurrent session
   may share this checkout).
 - Memory scan (if you use Claude Code memory): check your MEMORY.md index and any entries

--- a/docs/professions-2/phase-11-fishing.md
+++ b/docs/professions-2/phase-11-fishing.md
@@ -40,6 +40,11 @@ Goal: make fishing a real gathering skill feeding cooking (proficiency plus a ca
 ladder) without touching what makes the minigame fun.
 
 STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
 - `git status` must be clean (a concurrent session may share the checkout); stop and report if it
   is not.
 - Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries, at minimum:

--- a/docs/professions-2/phase-11-fishing.md
+++ b/docs/professions-2/phase-11-fishing.md
@@ -1,0 +1,192 @@
+# Phase 11: Fishing joins the framework
+
+Fishing becomes a real gathering skill that feeds cooking: a proficiency counter in the gathering
+framework and a catch rarity ladder over the existing tables, without touching what makes the
+minigame fun. It is its own slice because it converts one self-contained system (the fishing block
+inside `src/sim/sim.ts`) onto seams that already exist (gathering proficiency, `gprof`,
+`rollMaterialRarity`), and the module extraction it requires must land as one atomic
+move-not-rewrite change.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: locked decisions, the validation matrix, and the OPEN item this
+  phase resolves (whether fishing keeps a separate skill id or folds into the `professionsState`
+  shape; the answer here is: follow the gathering row pattern).
+- `docs/professions-2/progress.md`: what Phases 4 (rarity-colored gather feedback), 5 (the
+  professions wheel window) and 10 (cooking inputs for higher-band catches) actually landed.
+- `docs/professions-2/implementation-plan.md`: the Review Dispatch Matrix (the one canonical copy).
+- `src/sim/sim.ts` fishing block: `startFishing`, `completeFishing`, and the `FISHING_TABLES` /
+  `FISHING_RARE_ID` usage (imports near the top, logic around the two private methods).
+- `src/sim/professions/gathering.ts`: the gathering proficiency accrual pattern and
+  `rollMaterialRarity` (one draw, pinned), the model fishing adopts.
+- `src/sim/deeds.ts`: the fish marks (the glimmerfin rare-catch deed path) that must keep working.
+- Server wire: the `prof`/`gprof` self-wire pattern (`server/game.ts` delta emit,
+  `src/net/online.ts` absorb, `ALL_DELTA_KEYS` / `TERSE_TO_IWORLD` pins in
+  `tests/snapshots.test.ts`).
+- `src/ui/gathering_view.ts`: `buildGatheringProficiencyRows` and its character window consumer;
+  plus the Phase 5 professions wheel window (see the state.md "New surfaces per phase" entry for
+  its landed paths).
+- `src/sim/CLAUDE.md`, `src/sim/professions/CLAUDE.md`, `src/ui/CLAUDE.md`: local conventions for
+  the areas touched.
+
+## Starter Prompt
+
+```
+This is Phase 11 of the Professions 2.0 feature: Fishing joins the framework.
+
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: make fishing a real gathering skill feeding cooking (proficiency plus a catch rarity
+ladder) without touching what makes the minigame fun.
+
+STEP 0 - PRE-FLIGHT:
+- `git status` must be clean (a concurrent session may share the checkout); stop and report if it
+  is not.
+- Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries, at minimum:
+  node25-breaks-jsdom-gate (run the gate under Node 24), combo-recipes-broken-online (the 2033
+  stub trap: the gprof/cprof self-wire recipe and the liveness duty), and the design language
+  program (no DESIGN.md phase vocabulary in the new UI rows).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize:
+- docs/professions-2/state.md and docs/professions-2/progress.md
+- docs/professions-2/phase-11-fishing.md (this phase file)
+- src/sim/sim.ts fishing block: startFishing, completeFishing, and every FISHING_TABLES /
+  FISHING_RARE_ID touch point
+- src/sim/professions/gathering.ts: gathering proficiency accrual and rollMaterialRarity
+- src/sim/deeds.ts fish marks (the glimmerfin deed path)
+- server/game.ts gprof delta emit and src/net/online.ts gprof self-wire, plus the
+  ALL_DELTA_KEYS / TERSE_TO_IWORLD pins in tests/snapshots.test.ts
+- src/ui/gathering_view.ts (buildGatheringProficiencyRows and its character window consumer) and
+  the Phase 5 professions wheel window modules named in state.md
+- src/sim/CLAUDE.md, src/sim/professions/CLAUDE.md, src/ui/CLAUDE.md
+The summary must return: the exact boundaries of the fishing block in sim.ts (every symbol and
+private field it touches), the Rng draw sequence for a cast and a catch, the gathering
+proficiency accrual and band pattern, the gprof wire path end to end, where gathering rows
+render in the character window and the wheel window, what the Phase 4 rarity-colored loot line
+module is, the glimmerfin deed trigger, and which tests currently pin fishing, deeds, and
+snapshots.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
+Fan out three agents; each gets ONLY the Explore summary, never the planning docs. The sim agent
+lands first (the extraction plus mechanics); the integration and tests agents run against its
+result.
+
+Agent sim deliverables:
+- Extract the fishing logic from src/sim/sim.ts into a new src/sim/professions/fishing.ts module
+  behind the SimContext seam, in the same change as the mechanics below (module-first; sim.ts is
+  an active extraction target). Move-not-rewrite: the relocated code keeps its exact Rng draw
+  order for the cast timer and table draws; sim.ts becomes a thin consumer and its net line
+  count must not grow.
+- Fishing proficiency: an additive counter in the gathering framework, following the gathering
+  row pattern (the professionsState / gprof shape), gained per successful catch. This resolves
+  the state.md OPEN item: fishing folds into the gathering proficiency shape; no separate skill
+  id.
+- Catch rarity ladder: FISHING_TABLES keyed by proficiency band through the shared
+  rollMaterialRarity pattern (one draw, pinned). The rare catch (FISHING_RARE_ID) and its deed
+  stay exactly as shipped; higher-band catches are the cooking inputs authored in Phase 10, no
+  new items here.
+
+Agent integration deliverables:
+- Wire: fishing proficiency rides the existing gprof pattern end to end (server/game.ts emit,
+  src/net/online.ts absorb, the IWorld gathering read). Any new or widened IWorld member lands
+  on the matching src/world_api facet file, implemented in BOTH Sim and ClientWorld, with the
+  parity pin in tests/world_api_parity.test.ts updated in the same change. Verify liveness, not
+  just member shape (the 2033 stub trap).
+- UI: fishing rows in the character window gathering panel (via the gathering_view.ts row
+  builder) and in the professions wheel window; catch feedback uses the Phase 4 rarity-colored
+  loot line. Every player string is an English-only t() key in the matching
+  src/ui/i18n.catalog/<domain>.ts module; respect the design-language guardrails in
+  docs/professions-2/implementation-plan.md (today's tokens only, mobile rules).
+- Capture before/after screenshots (desktop and mobile, the pr-screenshots skill), committed
+  under docs/screenshots.
+
+Agent tests deliverables:
+- A determinism test for the extracted module: fixed seed, the cast timer and catch sequence are
+  identical across runs, and band 0 reproduces the shipped FISHING_TABLES results (draw order
+  unchanged by the extraction).
+- Proficiency tests: catches accrue proficiency in the gathering shape; rarity band rises at the
+  band thresholds; the one-draw rollMaterialRarity usage is pinned.
+- Wire tests: the gprof round trip carries the fishing row (snapshot pins updated deliberately);
+  the glimmerfin deed still completes (tests/deeds.test.ts, extended if the trigger moved files).
+- Update, never orphan, any existing fishing tests the extraction relocates.
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Determinism: all randomness through Rng (never Math.random / Date.now / performance.now in
+  sim logic); the cast timer and table draws keep their existing draw order; the extraction is
+  move-not-rewrite.
+- Server authority: catches, proficiency gain, and loot resolve server-side; the client renders.
+- IWorld both worlds: every new read lands on a facet file, implemented in BOTH Sim and
+  ClientWorld, parity-pinned in the same change; verify liveness, not member shape.
+- Wire parity: the gprof shape stays consistent across server, ClientWorld, and the RL surface.
+- i18n: every player-visible string is an English-only t() key; sim/server player text ships as
+  a stable id plus values re-localized by the client matcher, in the SAME change (the S3 guard,
+  tests/localization_fixes.test.ts).
+- Prime directive: nothing existing breaks. The fishing pole, the shipped FISHING_TABLES
+  behavior at the baseline band, the rare catch, and the glimmerfin deed all keep working
+  exactly as shipped.
+
+Out of scope (do NOT do in this phase):
+- New fishing spots or fishing zone content.
+- Tool tiers for rods (Phase 12 covers rods with the rest of tool gating).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+Run the state.md validation matrix rows for sim and net/wire changes, plus the ui/render and
+i18n rows for the UI-facing part of the diff:
+- npx tsc --noEmit
+- npx vitest run <the fishing tests, existing and new>
+- npx vitest run tests/deeds.test.ts
+- npx vitest run tests/snapshots.test.ts tests/env_protocol.test.ts tests/bandwidth.test.ts
+  tests/world_api_parity.test.ts
+- npx vitest run tests/architecture.test.ts
+- npm run i18n:gen, then npx vitest run tests/i18n_completeness.test.ts
+  tests/localization_fixes.test.ts
+- the mobile guard trio if a window changed (tests/mobile_window_coverage.test.ts,
+  mobile_window_transform.test.ts, mobile_window_layout.test.ts)
+- npm run ci:changed; format only changed files with a scoped
+  npx @biomejs/biome check --write <file>
+Then spawn review agents per the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY matching
+rows (expect architecture-reviewer, cross-platform-sync, frontend-seam-reviewer, and
+qa-checklist once the deliverable set is complete). Prompt every review agent for COVERAGE, not
+filtering: report every correctness or requirement gap with confidence and severity; filtering
+happens afterward in the main session. If any subagent output is truncated, re-spawn it to
+resume from the truncation point instead of restarting the whole pass.
+
+STEP 4 - COMMIT CADENCE:
+2 to 4 commits, explicit paths only (never git add -A), Conventional Commits, every commit
+carries a body:
+- refactor(sim): extract the fishing module behind SimContext
+- feat(professions): fishing proficiency and catch rarity ladder
+- feat(ui): fishing rows in the gathering panel and wheel window
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] Successful catches grant fishing proficiency in both hosts (offline Sim, and online via
+      the gprof round trip).
+- [ ] Catch rarity rises with proficiency band; band 0 reproduces the shipped tables for the
+      same seed.
+- [ ] The glimmerfin rare catch and its deed still complete unchanged.
+- [ ] src/sim/professions/fishing.ts exists behind SimContext; the sim.ts net line count did
+      not grow.
+- [ ] All STEP 3 validation commands pass and no BLOCKING review finding stands.
+
+STEP 6 - DOC UPDATES + MEMORY:
+- Update docs/professions-2/progress.md: phase status, decisions made, deferrals, the
+  phase-start commit hash for QA.
+- Update docs/professions-2/state.md: append a Phase 11 entry to "New surfaces per phase"
+  (src/sim/professions/fishing.ts, the fishing row in the gprof/professionsState shape, the
+  proficiency-band FISHING_TABLES keying, the UI rows and their i18n key namespace), and resolve
+  the fishing OPEN item (fishing folds into the gathering proficiency shape; remove the OPEN
+  row).
+- Record durable surprises to memory.
+
+STEP 7 - FINAL RESPONSE FORMAT:
+Report: phase status; files touched; validation results per command; review verdicts per agent;
+deferrals; one line for the QA handoff (the phase-start commit hash plus what QA should probe
+first).
+
+STOPPING RULES:
+No phase-specific stopping rules. Packet defaults apply: stop and report rather than force a
+fix if a determinism pin fails in a way that implies the draw order changed, or if the
+extraction cannot stay move-not-rewrite without a behavior change.
+```

--- a/docs/professions-2/phase-11-qa.md
+++ b/docs/professions-2/phase-11-qa.md
@@ -1,0 +1,95 @@
+# Phase 11 QA: Verify Fishing joins the framework
+
+Audit the Phase 11 diff (fishing proficiency, catch rarity ladder, the fishing module extraction,
+wire and UI rows) and fix what the audit finds.
+
+## QA Starter Prompt
+
+```
+This is Phase 11 QA of the Professions 2.0 feature: verify Fishing joins the framework.
+
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: audit the Phase 11 diff for correctness, missing tests, dead code, determinism, three-host
+parity (browser Sim, server, headless RL), and i18n completeness for this phase; then fix what
+the audit finds.
+
+STEP 0 - PRE-FLIGHT:
+- `git status` must be clean (a concurrent session may share the checkout); stop and report if
+  it is not.
+- Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries, at minimum:
+  node25-breaks-jsdom-gate (run the gate under Node 24), combo-recipes-broken-online (the 2033
+  stub trap: gprof liveness, not member shape), and the design language program (no DESIGN.md
+  phase vocabulary in the UI rows).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize:
+- docs/professions-2/state.md and docs/professions-2/progress.md
+- docs/professions-2/phase-11-fishing.md (the phase contract: deliverables, invariants,
+  acceptance criteria, validation commands)
+- git diff <phase-start commit>..HEAD (name-only first, then the full diff of
+  src/sim/professions/fishing.ts, the sim.ts fishing removal, and the wire and UI changes); the
+  phase-start commit hash is in the Phase 11 entry of progress.md
+The summary must return: every deliverable and where it landed, the acceptance criteria
+checklist, the validation commands the phase ran, and any TODO or deferral the phase recorded.
+
+STEP 2 - QA AUDIT:
+Fan out three parallel audit agents; each gets ONLY the Explore summary. Prompt each for
+COVERAGE, not filtering: report every gap with confidence (high/medium/low) and severity
+(BLOCKING / SHOULD-FIX / NIT); filtering happens afterward in the main session.
+- Correctness agent: verify every deliverable and acceptance criterion against the real code,
+  not the phase's claims. Rerun the phase's validation commands (the fishing tests,
+  tests/deeds.test.ts, tests/snapshots.test.ts, tests/env_protocol.test.ts,
+  tests/bandwidth.test.ts, tests/world_api_parity.test.ts, tests/architecture.test.ts,
+  npx tsc --noEmit, and the i18n pair: npm run i18n:gen then
+  tests/i18n_completeness.test.ts + tests/localization_fixes.test.ts). Exercise the real
+  behavior: a scripted Sim run that casts, catches, gains proficiency, and crosses a rarity
+  band; then the same read through ClientWorld snapshots for the gprof path.
+- Test coverage agent: find untested paths (band thresholds and boundaries, the rare catch
+  coexisting with the ladder, proficiency accrual, the wire round trip, the character window
+  and wheel window rows). Add missing tests, including a determinism test if any is missing for
+  the extracted sim logic (fixed seed, identical cast and catch sequence across runs). Remove
+  orphaned tests left behind by the extraction.
+- Dead code and cleanup agent: unused imports, types, or private fields left in src/sim/sim.ts
+  after the extraction; sim purity in src/sim/professions/fishing.ts (no DOM/Three or
+  render/ui/game/net imports, all randomness through Rng); leftover TODOs and debug output;
+  confirm the sim.ts net line count did not grow.
+
+PHASE-SPECIFIC QA EMPHASIS (probe these explicitly):
+- Move-not-rewrite verification on the extraction: compare src/sim/professions/fishing.ts
+  against the pre-phase sim.ts fishing block; the logic must be relocated, not rewritten.
+  Dispatch architecture-reviewer on exactly this question.
+- Draw-order stability for existing seeds: with a fixed seed, the cast timer and table draws
+  must consume Rng in the same order as before the phase, and band 0 must reproduce the shipped
+  FISHING_TABLES results.
+- gprof round trip: fishing proficiency emitted by server/game.ts, absorbed by the
+  src/net/online.ts self-wire, and readable through the IWorld member the UI rows consume;
+  verify LIVENESS with a real value change, not member shape (the 2033 stub trap).
+- The glimmerfin rare catch and its deed complete unchanged in both hosts (tests/deeds.test.ts
+  plus a real-path exercise).
+
+Then spawn review agents per the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY matching
+rows; also spawn the qa-checklist agent (the phase deliverable set is complete). Prompt all of
+them for COVERAGE, not filtering. If any subagent output is truncated, re-spawn it to resume
+from the truncation point instead of restarting the whole pass.
+
+STEP 3 - FIX:
+Apply every BLOCKING and SHOULD-FIX finding (NITs at your judgment, deferred with a written
+reason). Rerun the affected validation commands until green. Commit fixes with explicit paths
+(never git add -A), Conventional Commits with a body.
+
+STEP 4 - UPDATE DOCS + MEMORY:
+Update docs/professions-2/progress.md (QA verdict, fixes applied, deferrals) and
+docs/professions-2/state.md if QA changed any surface the phase recorded. Record durable
+surprises to memory.
+
+STEP 5 - FINAL RESPONSE FORMAT:
+Report: verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL); finding counts by severity (found, fixed,
+deferred); deferrals with reasons; one line handing off to the next phase.
+
+STOPPING RULES:
+No phase-specific stopping rules. Packet defaults apply: stop and report rather than force a
+fix if a finding implies the extraction changed draw order or observable behavior; that is a
+phase defect to send back, not a QA patch.
+```

--- a/docs/professions-2/phase-12-qa.md
+++ b/docs/professions-2/phase-12-qa.md
@@ -1,0 +1,120 @@
+# Phase 12 QA: Verify Base tool tier gating
+
+Audit the Phase 12 implementation (node tiers plus tool tier gating) for correctness, missing
+tests, dead code, determinism, three-host parity, and i18n completeness.
+
+## QA Starter Prompt
+
+```
+This is Phase 12 QA of the Professions 2.0 feature: Verify Base tool tier gating.
+
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: audit the Phase 12 implementation for correctness, missing tests, dead code, determinism,
+three-host parity, and i18n completeness for this phase.
+
+STEP 0 - PRE-FLIGHT:
+- Verify `git status` is clean (the Phase 12 implementation should already be committed). If
+  dirty, ask the user (a concurrent session may share this checkout).
+- Memory scan: check the `MEMORY.md` index for entries relevant to this phase's domain.
+  Suggested topics: node25-breaks-jsdom-gate (run the gate under Node 24),
+  combo-recipes-broken-online (the 2033 stub trap: verify liveness in BOTH hosts).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly, save your context):
+Spawn an Explore agent to read and summarize:
+- docs/professions-2/state.md (the Phase 12 entry: GatherNodeDef.tier, the bare-hands rule,
+  owned-best semantics, denial reason ids and key namespace; the tool-effects PARKED rule)
+- docs/professions-2/progress.md (Phase 12 deliverable checklist and acceptance criteria)
+- docs/professions-2/phase-12-tool-gating.md (the implementation prompt: what was promised)
+- Every file created or modified in Phase 12: run `git diff --name-only` against the
+  phase-start commit (find it via the Phase 12 commits in `git log` or the progress.md note)
+- CLAUDE.md (root) plus src/sim/CLAUDE.md, src/sim/professions/CLAUDE.md, src/ui/CLAUDE.md,
+  tests/CLAUDE.md
+The agent should return: the full list of Phase 12 deliverables and acceptance criteria, all
+new or modified files, the denial reason ids and their catalog keys, the tier assignment per
+node def (pre-phase vs new), and any known issues noted in progress.md.
+
+STEP 2 - QA AUDIT (spawn three parallel agents using the Explore summary; prompt each for
+COVERAGE not filtering: report every issue including low-severity and uncertain ones; ranking
+happens in a later step):
+
+Correctness agent:
+- Verify every Phase 12 deliverable was actually implemented and every acceptance criterion in
+  the phase prompt is met.
+- Run the phase's validation commands: `npx tsc --noEmit`;
+  `npx vitest run tests/professions_tools.test.ts tests/gather_node_harvest.test.ts
+  tests/gathering.test.ts tests/architecture.test.ts`; `npm run i18n:gen` then
+  `npx vitest run tests/i18n_completeness.test.ts tests/localization_fixes.test.ts`.
+- Exercise the real behavior, not just the tests: drive a bare-hands harvest of a tier-1 node,
+  a denied harvest of a tier-3 vein with the localized reason, an unlocked harvest after adding
+  a higher-tier pick to the bags, a rare corpse pull with and without the matching tool, and a
+  higher fishing catch band with and without the rod.
+- Verify the offline Sim path and the online ClientWorld path behave identically (liveness, not
+  just member shape: the 2033 stub trap); denial reasons render localized in BOTH hosts.
+- Check edge cases: empty bags, multiple tools of equal tier, a wrong-profession tool, a node
+  with no tier authored (should be impossible if the field is required), boundary tiers.
+
+Test coverage agent:
+- Identify new code paths without tests (the gating branch in harvestNode, the rare-pull branch
+  in harvestCorpse, the fishing band gate, the denial emission in each host).
+- Add missing unit tests, including a determinism test (same seed, same result) if sim logic
+  changed without one.
+- Verify the lockout-prevention test really walks EVERY pre-phase node def rather than a
+  sample, and that the retired no-op pin left no orphaned or weakened assertions behind.
+- Update tests broken by Phase 12; remove orphaned tests for replaced behavior; verify test
+  assertions are decisive, not just "it runs".
+
+Dead code and cleanup agent:
+- Find unused imports, functions, and types left behind by the wiring.
+- Verify sim purity holds: src/sim/ imports nothing from render/ui/game/net, no DOM/Three
+  imports, no Math.random / Date.now / performance.now (tests/architecture.test.ts).
+- Verify the parked effect/recharge half of src/sim/professions/tools.ts gained NO callers and
+  was NOT deleted (the state.md rule: dormant, not removed).
+- Remove commented-out code; verify no unresolved TODO/FIXME items; check naming consistency
+  with the rest of src/sim/professions/.
+
+PHASE-SPECIFIC QA EMPHASIS (probe these specifically):
+- The lockout-prevention invariant on EVERY pre-phase node: enumerate the node defs that
+  existed before Phase 12 and prove each one still resolves as bare-hands harvestable; any
+  single gated pre-phase node is a BLOCKING finding.
+- Owned-best resolution with multiple tools: bags holding several matching tools pick the
+  highest tier; a higher-tier tool for the WRONG profession never counts; resolution is per
+  profession within one bag.
+- Corpse rare-pull gating does not affect the claim: the claim resolution outcome is identical
+  whether the rare pull succeeds, is denied, or the player owns no tool at all.
+- Fairness and both-host denial: the tier requirement shown in the node tooltip and minimap
+  ready-state is identical across graphics presets, and the denial reason is localized in both
+  the offline Sim and the online ClientWorld.
+
+Multi-agent review dispatch: apply the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md (the one canonical copy). Check
+`git diff --name-only` against the phase-start commit and spawn ONLY the agents whose row
+matches, plus `qa-checklist` (this is the phase-completion QA gate). Prompt each for COVERAGE
+not filtering. Resume any review agent that truncates mid-analysis with: "Stop reading more
+files. Output the full report now. No more tool calls. Format: BLOCKING / SHOULD-FIX /
+NICE-TO-HAVE / VERDICT."
+
+STEP 3 - FIX:
+Apply all BLOCKING and SHOULD-FIX items. Rerun the validation commands above (at minimum
+`npx tsc --noEmit` plus the four named vitest files, and the S3 i18n guard if player text
+changed). Commit fixes separately from the QA verdicts so the history is reviewable, with
+EXPLICIT paths (never `git add -A`), Conventional Commits with a body, no em dashes or emojis.
+
+STEP 4 - UPDATE DOCS + MEMORY:
+- Update docs/professions-2/progress.md (mark Phase 12 QA complete; note items deferred to
+  follow-up).
+- Update docs/professions-2/state.md (any drift discovered during QA, e.g. denial id or key
+  namespace corrections).
+- Record any surprising rules learned during QA to memory for the next session.
+
+STEP 5 - FINAL RESPONSE FORMAT:
+End your turn with: QA verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL), counts of BLOCKING /
+SHOULD-FIX / NICE-TO-HAVE found and fixed, deferred items, and a one-line handoff for the
+Phase 13 implementation session.
+
+STOPPING RULES:
+- Stop and surface to the user if any BLOCKING item cannot be fixed without changing the phase
+  scope.
+- Stop immediately if fixing a finding would gate any pre-phase content behind a tool or would
+  wire the parked tool-effect modules.
+```

--- a/docs/professions-2/phase-12-tool-gating.md
+++ b/docs/professions-2/phase-12-tool-gating.md
@@ -45,6 +45,11 @@ on the player's best owned matching tool tier plus skill, while every piece of p
 stays bare-hands harvestable.
 
 STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
 - Verify `git status` is clean before starting. If not, ask the user (a concurrent session may
   share this checkout).
 - Memory scan: check the `MEMORY.md` index for entries relevant to this phase's domain.

--- a/docs/professions-2/phase-12-tool-gating.md
+++ b/docs/professions-2/phase-12-tool-gating.md
@@ -1,0 +1,230 @@
+# Phase 12: Base tool tier gating
+
+Tools finally matter: `GatherNodeDef` gains a tier, and the player's best owned matching tool plus
+skill decide what they can harvest, skin, and catch. The pure gating functions in
+`src/sim/professions/tools.ts` (`gatherToolTier`, `canGatherTier`, `canHarvestMonsterMaterial`)
+already exist, are tested, and have zero callers; this phase wires them into the live harvest
+paths and gives the existing tool items and six tool recipes a real purpose. It is its own slice
+because it depends on the node materials (Phase 4), recipe ladders (Phase 10), and fishing catch
+ladder (Phase 11) all being in place, while tool effects and charges stay parked for wave 2+.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: locked decisions (tool effects PARKED; prime directive), the
+  validation matrix (sim row, i18n-keys row), and the Phase 11 fishing entry under "New surfaces
+  per phase".
+- `docs/professions-2/progress.md`: Phase 12 status row and deliverable checklist.
+- `src/sim/professions/tools.ts`: `gatherToolTier`, `canGatherTier`, `canHarvestMonsterMaterial`,
+  `isGatherToolUse`, `GatherToolUse`. Pure, tested, zero callers today. The effect/recharge half
+  of the file (`slotEffect`, `resolveToolEffectUse`, `rechargeEffect`) stays dormant.
+- `src/sim/types.ts`: `GatherNodeDef` (currently `id`, `zoneId`, `type`, `pos`, `level`; gains
+  `tier`).
+- `src/sim/content/gather_nodes.ts`: `GATHER_NODES`, every pre-phase node def across the three
+  existing zones.
+- `src/sim/professions/gathering.ts`: `harvestNode` (the node outcome path), `resolveHarvest`,
+  `isNodeHarvestableBy`, the existing denial handling.
+- `src/sim/interaction.ts`: `harvestCorpse` (corpse component pulls, claims).
+- The fishing catch band surface Phase 11 landed (locate via `state.md`; rods gate the higher
+  bands the same way).
+- `tests/professions_tools.test.ts`: carries the stale pin "using a gathering tool is a safe
+  no-op until the gather-node system lands"; this phase retires it.
+- `tests/gather_node_harvest.test.ts`, `tests/gathering.test.ts`, `tests/architecture.test.ts`:
+  the phase's named validation suites.
+- `CLAUDE.md` (root), `src/sim/CLAUDE.md`, `src/sim/professions/CLAUDE.md`, `src/ui/CLAUDE.md`,
+  `tests/CLAUDE.md`.
+
+## Starter Prompt
+
+```
+This is Phase 12 of the Professions 2.0 feature: Base tool tier gating.
+
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+
+Goal: give tools real purpose by adding node tiers and gating node, corpse, and fishing harvests
+on the player's best owned matching tool tier plus skill, while every piece of pre-phase content
+stays bare-hands harvestable.
+
+STEP 0 - PRE-FLIGHT:
+- Verify `git status` is clean before starting. If not, ask the user (a concurrent session may
+  share this checkout).
+- Memory scan: check the `MEMORY.md` index for entries relevant to this phase's domain.
+  Suggested topics: node25-breaks-jsdom-gate (run the gate under Node 24),
+  combo-recipes-broken-online (the 2033 stub trap: verify liveness in BOTH hosts, not just
+  member shape), design-language-program (the node tooltip touch must not introduce DESIGN.md
+  phase vocabulary).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly, save your context):
+Spawn an Explore agent to read and summarize:
+- docs/professions-2/state.md (locked decisions, validation matrix, Phase 11 fishing surface,
+  tool-effects PARKED rule)
+- docs/professions-2/progress.md (Phase 12 status + deliverable checklist)
+- docs/professions-2/phase-12-tool-gating.md (this prompt; verify the agent has the same
+  understanding)
+- src/sim/professions/tools.ts (gatherToolTier, canGatherTier, canHarvestMonsterMaterial; the
+  dormant effect/recharge half stays dormant)
+- src/sim/types.ts (GatherNodeDef)
+- src/sim/content/gather_nodes.ts (every pre-phase node def)
+- src/sim/professions/gathering.ts (harvestNode, resolveHarvest, isNodeHarvestableBy, denial
+  handling)
+- src/sim/interaction.ts (harvestCorpse, claim resolution)
+- the fishing catch band module Phase 11 landed (find it via state.md's Phase 11 entry)
+- tests/professions_tools.test.ts (the stale no-op pin this phase retires)
+- CLAUDE.md (root) plus src/sim/CLAUDE.md, src/sim/professions/CLAUDE.md, src/ui/CLAUDE.md,
+  tests/CLAUDE.md
+The agent should return: the exact canGatherTier comparator semantics; how harvestNode denies
+today and how a denial reaches the player in BOTH hosts; the full list of pre-phase node defs
+per zone; every existing tool ItemDef (its GatherToolUse professionId and tier) and the six tool
+recipes; the fishing catch band shape from Phase 11; how the node tooltip and minimap ready-state
+are produced today; and the exact assertion of the stale no-op pin.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
+Spawn four agents in parallel (sim, content, ui, tests). Give each agent ONLY the Explore
+summary, not raw planning docs. Never `mode: "plan"` on teammates. Use worktree isolation only
+if agents edit overlapping files in parallel (the sim and tests agents both touch
+tests/professions_tools.test.ts; sequence or isolate them).
+
+Locked semantics all four agents share:
+- Bare hands resolve to effective tool tier 1, so every tier-1 node (and all pre-phase content)
+  stays harvestable with no tool. Only tiers 2 and up gate behind a tool.
+- Owned-best resolution: the harvest path scans the player's OWNED items (bags) for the best
+  matching tool via gatherToolTier for the node's profession and takes the highest tier. There
+  is no equip UI and none is added.
+- The prime directive concretely: every node def that exists before this phase keeps a tier
+  bare hands can harvest. The tier ramp comes from NEW higher-tier node defs added to the
+  existing three zones (zone 1 stays all tier 1; zones 2 and 3 gain new tier-2 and tier-3
+  veins). No pre-phase node, corpse pull, or fishing catch a player could complete before this
+  phase may gate behind a tool.
+
+Agent sim deliverables:
+- `harvestNode` consults the player's best owned matching tool via gatherToolTier plus
+  canGatherTier before resolving; a failed gate denies with a stable, localized reason id
+  carrying the required tier (follow the existing denial pattern in gathering.ts).
+- `harvestCorpse` consults canHarvestMonsterMaterial for rare and above component pulls only;
+  common and uncommon pulls stay ungated. The claim resolution is computed exactly as before
+  and is never affected by a denied pull.
+- Fishing rods gate the higher catch bands the same way (canGatherTier against the band tier);
+  everything catchable before this phase stays catchable bare-handed or with the basic rod.
+- Denial reason ids are emitted identically in the offline Sim and through the server so both
+  hosts surface the same reasons (server authority: the server decides the outcome online).
+
+Agent content deliverables:
+- `GatherNodeDef` gains a required `tier` field (src/sim/types.ts).
+- A content pass over src/sim/content/gather_nodes.ts assigns tiers zone-appropriately: every
+  pre-phase node def gets tier 1; new tier-2 veins land in zone 2 and new tier-2 and tier-3
+  veins land in zone 3 so the three existing zones ramp.
+- New node defs follow the existing authoring pattern (id, zoneId, type, pos, level snapshot)
+  and get render prop coverage per the note at the top of gather_nodes.ts.
+
+Agent ui deliverables:
+- Denial reasons render as `t()` keys: English-only catalog entries in the matching
+  src/ui/i18n.catalog/<domain>.ts module plus the sim matcher rule in src/ui/sim_i18n.ts in the
+  SAME change (the S3 guard enforces it).
+- The node tooltip and minimap ready-state show the tier requirement. This is actionable info:
+  it must be tier-identical across every graphics preset (the fairness invariant), and it must
+  work in BOTH hosts. Prefer reading the tier from the shared content def; if any new IWorld
+  member is genuinely needed, add it to the matching facet file, implement it in BOTH Sim and
+  ClientWorld, and update the parity pin in tests/world_api_parity.test.ts in the same change.
+- No DESIGN.md phase vocabulary; today's tokens only.
+
+Agent tests deliverables:
+- Retire the stale pin "using a gathering tool is a safe no-op until the gather-node system
+  lands" in tests/professions_tools.test.ts; replace it with tests proving tools change
+  outcomes (a better pick unlocks a higher-tier vein; a wrong-profession tool does not count).
+- A lockout-prevention test that walks EVERY pre-phase node def and asserts a bare-hands player
+  can still harvest it (this pins the prime directive).
+- Owned-best resolution tests: multiple matching tools in bags picks the highest tier;
+  mixed-profession bags resolve per profession.
+- Corpse gating tests: rare and above pulls gate; common and uncommon pulls do not; the claim
+  outcome is identical whether or not the pull is denied.
+- A determinism test (same seed, same world) covering the new gating paths.
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Prime directive: nothing existing breaks. Tier-1 nodes and ALL current content stay
+  bare-hands harvestable; no existing player is locked out of anything they could do before.
+  Only NEW higher tiers gate.
+- Determinism: all randomness via `Rng`; no `Math.random` / `Date.now` / `performance.now` in
+  src/sim/; new draws take a fixed place in the shared draw order.
+- Seam: any new IWorld member lands on a facet file and is implemented in BOTH Sim and
+  ClientWorld with the parity pin updated, verified live (not just member shape).
+- Server authority: online, the server decides every harvest outcome and denial; the client
+  never does.
+- i18n: every new player string is a `t()` key added in ENGLISH ONLY to the matching
+  src/ui/i18n.catalog/<domain>.ts module; sim denial ids get their matcher rule in
+  src/ui/sim_i18n.ts in the SAME change; never edit the locale overlays.
+- Fairness: the tier requirement display is identical across graphics presets.
+- Tool effects/charges/recharge stay PARKED: do not wire resolveToolEffectUse, rechargeEffect,
+  or any slot state; do not delete them either.
+
+Out of scope (do NOT do in this phase):
+- Tool effects, charges, and recharge (parked for wave 2+; the pure modules stay dormant).
+- Crafted tool recipe additions or recipe ladder changes (Phase 10 owns recipe content).
+- An equip UI or tool slots (owned-best semantics only).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+- Run the state.md sim row: `npx tsc --noEmit`, then
+  `npx vitest run tests/professions_tools.test.ts tests/gather_node_harvest.test.ts
+  tests/gathering.test.ts tests/architecture.test.ts`, plus the determinism check.
+- New denial i18n keys were added, so also run the i18n row: `npm run i18n:gen` then
+  `npx vitest run tests/i18n_completeness.test.ts tests/localization_fixes.test.ts`.
+- Any code change: `npm run ci:changed`; format only touched files with a SCOPED
+  `npx @biomejs/biome check --write <file>`.
+- Spawn review agents per the Review Dispatch Matrix in
+  docs/professions-2/implementation-plan.md; check `git diff --name-only` against the
+  phase-start commit and spawn ONLY matching rows (expect architecture-reviewer,
+  cross-platform-sync, and frontend-seam-reviewer to match; if no row matches, spawn none).
+- Prompt each review agent for COVERAGE not filtering: report every issue including
+  low-severity and uncertain ones; ranking happens in a later step.
+- Resume any agent that truncates with: "Stop reading more files. Output the full report now
+  based on what you've already seen. No more tool calls. Format: BLOCKING / SHOULD-FIX /
+  NICE-TO-HAVE / VERDICT."
+- Do not commit while any BLOCKING finding stands.
+
+STEP 4 - COMMIT CADENCE:
+Aim for three commits with these headlines (Conventional Commits with a scope; EXPLICIT paths,
+never `git add -A`; every commit carries a body of 1 to 4 sentences saying what changed and
+why; no em dashes or emojis):
+- `feat(professions): add gather node tiers`
+- `feat(professions): gate harvesting on owned tool tier`
+- `test(professions): retire the tool no-op pin`
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] A bare-hands player harvests every node, corpse component, and fishing catch they could
+      before this phase (the lockout-prevention test walks every pre-phase node def)
+- [ ] A bare-hands player cannot harvest a tier-3 vein and sees a localized denial reason
+- [ ] Buying or crafting a better pick changes outcomes; owned-best resolution picks the
+      highest matching tier among multiple owned tools, per profession
+- [ ] `harvestCorpse` gates rare and above component pulls via canHarvestMonsterMaterial, and
+      the claim resolution is unaffected by a denied pull
+- [ ] Fishing rods gate the higher catch bands the same way
+- [ ] Denial reasons are localized ids surfaced in BOTH hosts (catalog keys + S3 matcher rule
+      in the same change; the S3 guard is green)
+- [ ] The node tooltip and minimap ready-state show the tier requirement identically across
+      graphics presets
+- [ ] The stale no-op pin is replaced with tests proving tools change outcomes; the existing
+      tool items and six tool recipes now have real purpose
+- [ ] Tool effects/charges remain parked: no new callers of the effect/recharge half of
+      tools.ts
+- [ ] The validation matrix rows above are green, including tests/architecture.test.ts
+
+STEP 6 - DOC UPDATES + MEMORY:
+- Update docs/professions-2/progress.md (mark Phase 12 status; mirror the checkboxes; note
+  deferrals).
+- Update docs/professions-2/state.md: Phase 12 entry under "New surfaces per phase"
+  (GatherNodeDef.tier; the bare-hands-equals-effective-tier-1 rule; owned-best resolution
+  semantics; the new denial reason ids and their i18n key namespace; the new tier-2 and tier-3
+  node defs; note that tools.ts gating fns now have live callers while the effect half stays
+  dormant).
+- Record any surprising rules or current-state notes to memory for the next session.
+
+STEP 7 - FINAL RESPONSE FORMAT:
+End your turn with: phase status, files touched, validation results, review-agent verdicts, any
+deferred items, and a one-line handoff for the Phase 12 QA session.
+
+STOPPING RULES:
+- Stop immediately if any pre-phase content would gate behind a tool; that violates the prime
+  directive and the tier assignment must be reworked instead.
+- Stop and ask the user if the Phase 11 fishing surface landed with a shape that cannot express
+  catch band tiers without redesign.
+- Stop and ask the user if the gating cannot be added without wiring the parked tool-effect
+  modules.
+```

--- a/docs/professions-2/phase-13-enchanting.md
+++ b/docs/professions-2/phase-13-enchanting.md
@@ -36,6 +36,11 @@ Goal: make the finished enchanting sim (disenchant and enchant application) reac
 in both hosts, from the bags UI through IWorld, the wire, and server dispatch.
 
 STEP 0 - PRE-FLIGHT: run git status; the tree must be clean (a concurrent session may share this
+Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+before proceeding. Never base work on main or an older release branch than the newest.
 checkout); if it is dirty with work you did not create, stop and ask. Scan Claude Code memory
 (the MEMORY.md index) for: the node25 gate rule (run npm run gate under Node 24), combo recipes
 broken online (the #2033 ClientWorld stub trap: never land IWorld members as dead stubs; the

--- a/docs/professions-2/phase-13-enchanting.md
+++ b/docs/professions-2/phase-13-enchanting.md
@@ -1,0 +1,163 @@
+# Phase 13: Enchanting reachable
+
+The enchanting sim is already complete and tested (`resolveDisenchant` and `resolveApplyEnchant` in
+`src/sim/professions/enchanting.ts`) but no player can reach it: there are no `IWorld` members, no
+wire commands, and no UI. This phase wires disenchant and enchant application to players in both
+hosts: bags context actions with a destruction confirm, server-validated commands, and results
+mirrored online. It is its own slice because it is pure seam-plus-UI work over a finished sim
+surface, independent of the content phases around it, and salvage deliberately stays behind.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: locked decisions, the validation matrix, and the key-surfaces row
+  for salvage/disenchant/enchant (sim-complete, `lastDisenchantResult`/`lastEnchantResult` stashes
+  on `PlayerMeta`, no IWorld/wire/UI yet; salvage stays wave 2).
+- `docs/professions-2/progress.md`: phase status and the phase-start commit record.
+- `docs/professions-2/implementation-plan.md`: team workflow and the review dispatch matrix.
+- `src/sim/professions/enchanting.ts`: `resolveDisenchant`, `resolveApplyEnchant` (do not change
+  the resolution logic; this phase only makes it reachable).
+- `src/sim/sim.ts`: the `lastDisenchantResult`/`lastEnchantResult` stashes and command plumbing.
+- `src/world_api/professions.ts` and `src/world_api/CLAUDE.md`: the facet file and the
+  both-worlds rule.
+- `src/net/online.ts`: `ClientWorld`; the `ncd`/`gprof` self-wire delta-key pattern (the fix
+  template from the #2033 stub trap).
+- `server/game.ts`: command dispatch and server-side re-validation.
+- `src/ui/` bags context menu surface and `src/ui/CLAUDE.md`: context actions, confirm dialogs,
+  toasts, i18n rules; the Phase 5 professions wheel window module for skill visibility.
+- Pins: `tests/world_api_parity.test.ts`, `tests/snapshots.test.ts` (`ALL_DELTA_KEYS` +
+  `TERSE_TO_IWORLD`), `tests/professions_enchanting.test.ts`.
+
+## Starter Prompt
+
+```
+This is Phase 13 of the Professions 2.0 feature: Enchanting reachable.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: make the finished enchanting sim (disenchant and enchant application) reachable by players
+in both hosts, from the bags UI through IWorld, the wire, and server dispatch.
+
+STEP 0 - PRE-FLIGHT: run git status; the tree must be clean (a concurrent session may share this
+checkout); if it is dirty with work you did not create, stop and ask. Scan Claude Code memory
+(the MEMORY.md index) for: the node25 gate rule (run npm run gate under Node 24), combo recipes
+broken online (the #2033 ClientWorld stub trap: never land IWorld members as dead stubs; the
+ncd/gprof self-wire pattern is the fix template), and the design-language program (DESIGN.md is
+adopted but unlanded; UI work uses today's tokens and the shared window shell only). Record the
+phase-start commit hash for the QA session.
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly): spawn one Explore agent to read and
+summarize: docs/professions-2/state.md, docs/professions-2/progress.md,
+docs/professions-2/phase-13-enchanting.md, src/sim/professions/enchanting.ts, the
+lastDisenchantResult/lastEnchantResult stashes and command plumbing in src/sim/sim.ts,
+src/world_api/professions.ts, the cprof/ncd/gprof wiring in src/net/online.ts, the command
+dispatch in server/game.ts, the bags context menu surface in src/ui/, and the CLAUDE.md files
+for src/sim/, src/world_api/, src/ui/, and server/. The summary must return: the exact
+signatures and result shapes of resolveDisenchant and resolveApplyEnchant; where the last-result
+stashes live and how existing last-result reads reach IWorld; the self-wire delta-key recipe and
+its pins (ALL_DELTA_KEYS + TERSE_TO_IWORLD in tests/snapshots.test.ts); how bags context actions
+and confirm dialogs are built today; the state.md validation rows for net/wire, ui/render, and
+i18n changes; and the review dispatch matrix.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE: run the seam agent first (it fixes the member names and
+wire keys), then fan out the ui agent and the tests agent in parallel against the landed seam.
+Each agent gets ONLY the Explore summary plus its deliverables below, never the planning docs.
+
+Agent seam deliverables:
+- IWorld members on src/world_api/professions.ts: disenchantItem and applyEnchant commands plus
+  last-result reads mirroring lastDisenchantResult/lastEnchantResult (typed views, not raw sim
+  objects).
+- Implement in BOTH Sim and ClientWorld in the same change. The ClientWorld arm must be LIVE
+  (the #2033 stub trap): commands go over the wire, and results mirror back on a delta key
+  following the ncd/gprof self-wire pattern.
+- server/game.ts dispatch: proximity, ownership, and eligibility are re-checked server-side and
+  never trusted from the client; destruction and grants resolve server-side and are replay-safe
+  (a replayed or duplicated command cannot double-destroy an item or double-grant dust).
+- Update the parity pin in tests/world_api_parity.test.ts and the ALL_DELTA_KEYS +
+  TERSE_TO_IWORLD pins in tests/snapshots.test.ts in the same change.
+
+Agent ui deliverables:
+- Bags context action Disenchant, shown on eligible items only, behind a confirm dialog (this is
+  destructive). A masterwork or signed instance gets an explicit stronger warning before
+  destruction; the plain confirm is not enough for those.
+- Apply Enchant flow: starts from the enchant consumable and flows to an eligible target item.
+- Result toasts localized: every player string is an English t() key in the matching
+  src/ui/i18n.catalog/ module; server-sent result text arrives as a stable id plus values and is
+  re-localized by the client matcher (the S3 duty, tests/localization_fixes.test.ts).
+- Enchanting skill visible in the wheel window (it levels via the existing #1712 gains; display
+  only, no new leveling logic).
+- Salvage stays wave 2: do NOT wire it; leave a short comment at the salvage sim surface marking
+  the exclusion as deliberate.
+
+Agent tests deliverables:
+- Command tests: server-side validation (proximity, ownership, eligibility), replay and
+  duplicate safety on destruction and grants, and the offline Sim path.
+- Parity and wire tests: both-worlds LIVENESS for the new members (results actually arrive and
+  update in ClientWorld), not just member shape.
+- UI tests: context-action eligibility, the confirm path, and the signed/masterwork warning
+  path; pure view logic lands DOM-free and Node-tested per the UI pure-core rules.
+- Keep tests/professions_enchanting.test.ts green without weakening existing pins.
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Determinism: all sim randomness goes through Rng; never Math.random, Date.now, or
+  performance.now in sim logic; the 20 Hz tick is untouched.
+- Server authority: destruction and grants resolve server-side only and are replay-safe; the
+  client never decides outcomes.
+- IWorld both worlds: every new member lands on the facet file, implemented LIVE in BOTH Sim and
+  ClientWorld, parity-pinned in the same change.
+- i18n: English-only catalog keys; all sim/server player text is a stable id plus values,
+  re-localized by the client matcher (the S3 guard).
+- Prime directive: nothing existing breaks. No existing item flow (bags, trade, equip, bank)
+  changes behavior unless the player invokes the new actions.
+
+Out of scope (do NOT do in this phase):
+- Salvage wiring (wave 2; the sim module stays dormant).
+- Enchanting recipe or content depth.
+- Tool-enchant reframing (wave 2+).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+- Run the state.md net/wire row: npx vitest run tests/snapshots.test.ts
+  tests/env_protocol.test.ts tests/bandwidth.test.ts tests/world_api_parity.test.ts.
+- npx vitest run tests/professions_enchanting.test.ts plus every new command/UI test file.
+- i18n row for the new keys: npm run i18n:gen, then npx vitest run
+  tests/i18n_completeness.test.ts tests/localization_fixes.test.ts.
+- ui/render row: npx tsc --noEmit, the mobile guard trio, and a mobile screenshot of the bags
+  context action (pr-screenshots skill) committed under docs/screenshots.
+- Spawn review agents per the Review Dispatch Matrix in
+  docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY matching
+  rows.
+- Prompt every review agent for COVERAGE, not filtering: report every correctness or requirement
+  gap with confidence and severity; filtering happens afterward in the main session.
+- If any agent's output is truncated, re-spawn it to resume from its last completed item; never
+  restart finished work.
+
+STEP 4 - COMMIT CADENCE: commit with explicit paths (never git add -A); every commit carries a
+body saying what changed and why:
+- feat(professions): expose disenchant and enchant-apply through IWorld and the wire
+- feat(ui): bags disenchant and enchant-apply actions with destruction confirm
+- docs(professions-2): record phase 13 surfaces in state.md and progress.md
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] A player can disenchant an eligible junk item into dust offline (Sim) and online
+      (ClientWorld against the server).
+- [ ] A player can apply an enchant consumable to eligible gear offline and online.
+- [ ] A replayed or duplicated command cannot double-grant dust or double-destroy an item.
+- [ ] Destroying a signed or masterwork instance requires the explicit warning path.
+- [ ] The new IWorld members are live in BOTH worlds; parity and snapshot pins updated in the
+      same change.
+- [ ] The enchanting skill shows in the wheel window.
+- [ ] Salvage remains unwired and the exclusion is noted as deliberate.
+- [ ] All validation rows above are green; the mobile screenshot is committed.
+
+STEP 6 - DOC UPDATES + MEMORY: update docs/professions-2/progress.md (phase 13 checklist, status,
+and the phase commit range so QA can diff against the phase-start commit). Update
+docs/professions-2/state.md: move the current-phase pointer, and replace the planned Phase 13
+line under "New surfaces per phase" with actuals (the exact IWorld member names, wire command
+and delta keys, i18n key namespaces, and files created). Record genuine surprises (traps,
+broken assumptions) to Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT: phase status (complete or partial), files touched, validation
+results (each command with pass or fail), review verdicts per agent, deferrals with reasons,
+and a one-line QA handoff naming the phase-start commit.
+
+STOPPING RULES: none special for this phase. Stop and surface to the user only if the pre-flight
+tree is dirty with work you did not create, or if a locked decision in state.md would need to
+change.
+```

--- a/docs/professions-2/phase-13-qa.md
+++ b/docs/professions-2/phase-13-qa.md
@@ -1,0 +1,76 @@
+# Phase 13 QA: Verify Enchanting reachable
+
+Audits the Phase 13 diff: enchanting reachable in both hosts, replay-safe destruction, live
+`ClientWorld` result mirroring, and complete tests and i18n for this phase.
+
+## QA Starter Prompt
+
+```
+This is Phase 13 QA of the Professions 2.0 feature: verify Enchanting reachable.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: audit the Phase 13 diff for correctness, missing tests, dead code, determinism, three-host
+parity, and i18n completeness for this phase.
+
+STEP 0 - PRE-FLIGHT: run git status; the tree must be clean (a concurrent session may share this
+checkout); if it is dirty with work you did not create, stop and ask. Scan Claude Code memory
+(the MEMORY.md index) for: the node25 gate rule (run npm run gate under Node 24), combo recipes
+broken online (the #2033 ClientWorld stub trap), and the design-language program (today's tokens
+only in UI work).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly): spawn one Explore agent to read and
+summarize: docs/professions-2/state.md, docs/professions-2/progress.md,
+docs/professions-2/phase-13-enchanting.md, and the output of git diff <phase-start>..HEAD (the
+phase-start commit is recorded in progress.md). The summary must return: the phase's deliverable
+groups and acceptance criteria, the actual IWorld members and wire keys that landed, every file
+the diff touched, and the state.md validation rows that apply to the change type.
+
+STEP 2 - QA AUDIT: spawn three parallel agents, each given ONLY the Explore summary:
+- Correctness agent: verify every deliverable and acceptance criterion against the real code;
+  run the phase's validation commands (net/wire row: npx vitest run tests/snapshots.test.ts
+  tests/env_protocol.test.ts tests/bandwidth.test.ts tests/world_api_parity.test.ts; npx vitest
+  run tests/professions_enchanting.test.ts plus the phase's new test files; npm run i18n:gen
+  then npx vitest run tests/i18n_completeness.test.ts tests/localization_fixes.test.ts; npx tsc
+  --noEmit); exercise the REAL behavior: actually disenchant an item and apply an enchant in the
+  offline sim and against a running server, not just through the tests.
+- Test coverage agent: find untested paths (server rejection branches, the signed/masterwork
+  warning path, ClientWorld result mirroring, duplicate-command handling); add missing tests,
+  including a determinism test if any sim logic changed; remove orphaned tests.
+- Dead code and cleanup agent: unused imports and types in the diff, sim purity (no
+  DOM/Three/render/ui/game/net imports in src/sim/, all randomness through Rng), leftover TODOs
+  and debug residue.
+Also spawn review agents per the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md: check git diff --name-only and spawn ONLY matching
+rows, plus the qa-checklist agent (the phase deliverable set is complete).
+Prompt every agent for COVERAGE, not filtering: report every correctness or requirement gap with
+confidence and severity; the main session filters afterward.
+If any agent's output is truncated, re-spawn it to resume from its last completed item; never
+restart finished work.
+
+PHASE-SPECIFIC QA EMPHASIS (probe these directly, not just by reading):
+- Replay and race safety on destruction: fire the same disenchant command twice (duplicate and
+  replay) and prove exactly one destruction and one grant; race a disenchant against a
+  concurrent move or trade of the same item and prove no dupe or double-destroy.
+- ClientWorld last-result mirroring: confirm the lastDisenchantResult/lastEnchantResult reads
+  are LIVE in ClientWorld (values actually arrive over the wire and update after each command),
+  not shape-only stubs (the #2033 trap).
+- Confirm-dialog focus trap: keyboard focus stays inside the confirm dialog, Escape cancels,
+  and Enter cannot silently destroy a signed or masterwork instance without the explicit
+  warning path.
+- Prime directive spot check: no existing bags, trade, equip, or bank flow changed behavior
+  unless the player invokes the new actions; salvage remains unwired and marked deliberate.
+
+STEP 3 - FIX: apply every BLOCKING and SHOULD-FIX finding; rerun the failed validation rows
+until green; commit with explicit paths (never git add -A), Conventional Commits with a body.
+
+STEP 4 - UPDATE DOCS + MEMORY: update docs/professions-2/progress.md with the QA row and
+verdict; correct docs/professions-2/state.md if the audit found the recorded Phase 13 surfaces
+wrong; record genuine surprises to Claude Code memory.
+
+STEP 5 - FINAL RESPONSE FORMAT: verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; counts of findings by
+severity and how many were fixed versus deferred; the deferral list with reasons; a one-line
+handoff to the next phase.
+
+STOPPING RULES: none special for this phase. Stop and surface to the user only if a BLOCKING
+finding cannot be fixed without changing a locked decision in state.md, or if the pre-flight
+tree is dirty with work you did not create.
+```

--- a/docs/professions-2/phase-14-attunement-quests.md
+++ b/docs/professions-2/phase-14-attunement-quests.md
@@ -42,6 +42,11 @@ wave-one archetypes, honest switching costs, and the legibility layer (nudges, c
 pre-commit preview, celebration).
 
 STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
 - Run git status; the checkout must be clean (a concurrent session may share it). Record the
   current HEAD as the phase-start commit in docs/professions-2/progress.md Notes.
 - Scan Claude Code memory (MEMORY.md index) for phase-relevant entries: the node25 gate rule

--- a/docs/professions-2/phase-14-attunement-quests.md
+++ b/docs/professions-2/phase-14-attunement-quests.md
@@ -1,0 +1,201 @@
+# Phase 14: Attunement quests and nudges
+
+This phase makes the identity journey live end to end: acceptance lore quests at the masters for
+all four wave-one archetypes, honest switching costs through repeatable make-amends quests, and
+the legibility layer (trend nudges that complete #1295, a pre-commit preview that explains
+everything, and the attunement celebration). It is its own slice because it is the first phase
+where the PR 2039 quest machinery, the Phase 7 trend classifier, and the Phase 8 masters meet in
+player-facing content: every hook it fills already exists, and nothing later depends on it except
+the Phase 15 deed pass.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: locked identity costs (first attunement free; make-amends
+  escalation 5 + 3 * switchCount with cheap early costs), the validation matrix, and the key
+  existing surfaces list (quests, archetype, NPCs).
+- `docs/professions-2/progress.md`: the Phase 14 checklist and notes from Phases 7, 8, and 13.
+- `docs/professions-2/implementation-plan.md`: team workflow and the Review Dispatch Matrix.
+- `src/sim/quests/profession_quest_effects.ts`: the 2039 `completionEffect` handlers
+  (`attunePair`, `switchHobby`) and the selection validation this phase's quests ride on.
+- `src/sim/quests/quest_commands.ts`: the quest command path; in the S3 scanner scope since
+  Phase 7.
+- `src/sim/professions/archetype.ts`: `attunedPairs`, `archetypePairId`,
+  `ARCHETYPE_PAIR_TARGETS`, `hobbyCandidatesForPair`, `attuneArchetypePair`.
+- `src/sim/content/zone1.ts`, `src/sim/content/zone2.ts`, `src/sim/content/zone3.ts`, and
+  `src/sim/content/professions.ts`: quest records and the Phase 8 master `NpcDef` rows whose
+  `questIds` hooks this phase fills; `src/sim/content/letters.ts` for the letter voice.
+- The Phase 7 trend detection module (path recorded in the `state.md` "New surfaces per phase"
+  entry for Phase 7): the trending-pair classifier the nudges consume.
+- `src/ui/hud/quest/quest_dialog_controller.ts`, `src/ui/profession_identity_card.ts`, and
+  `src/ui/profession_identity_view.ts`: the quest dialog and attunement preview surfaces.
+- `src/ui/sim_i18n.ts`: the matcher for sim-origin player text (broadcast, nudges).
+- Local conventions: `src/sim/CLAUDE.md`, `src/sim/professions/CLAUDE.md`,
+  `src/sim/content/CLAUDE.md`, `src/ui/CLAUDE.md`, `tests/CLAUDE.md`.
+
+## Starter Prompt
+
+```
+This is Phase 14 of the Professions 2.0 feature: Attunement quests and nudges.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: make the identity journey live end to end: lore quests at the masters for all four
+wave-one archetypes, honest switching costs, and the legibility layer (nudges, complete
+pre-commit preview, celebration).
+
+STEP 0 - PRE-FLIGHT:
+- Run git status; the checkout must be clean (a concurrent session may share it). Record the
+  current HEAD as the phase-start commit in docs/professions-2/progress.md Notes.
+- Scan Claude Code memory (MEMORY.md index) for phase-relevant entries: the node25 gate rule
+  (run npm run gate under Node 24), the PR 2039 state (attunement machinery and its review
+  gaps), and the design-language program (DESIGN.md guardrails for any UI chrome this phase
+  touches).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn an Explore agent to read and summarize:
+- docs/professions-2/state.md and docs/professions-2/progress.md
+- docs/professions-2/phase-14-attunement-quests.md (this phase file)
+- src/sim/quests/profession_quest_effects.ts and src/sim/quests/quest_commands.ts
+- src/sim/professions/archetype.ts
+- src/sim/content/zone1.ts, zone2.ts, zone3.ts, professions.ts, letters.ts (quest records,
+  the Phase 8 master NpcDefs and their questIds hooks, the retired placeholder quest rows)
+- the Phase 7 trend detection module (path in state.md New surfaces, Phase 7 entry)
+- src/ui/hud/quest/quest_dialog_controller.ts, src/ui/profession_identity_card.ts,
+  src/ui/profession_identity_view.ts, src/ui/sim_i18n.ts
+- src/sim/CLAUDE.md, src/sim/professions/CLAUDE.md, src/sim/content/CLAUDE.md,
+  src/ui/CLAUDE.md, tests/CLAUDE.md
+The summary must return: the attunePair/switchHobby completionEffect contract and where
+selection validation runs; the selection whitelist shape and whether it can express each
+wave-one target pair; each master's NpcDef location and its empty questIds hook; the current
+placeholder quest rows (q_archetype_acceptance, q_prof_make_amends) and every reference to
+them (content, i18n keys, locale fills, tests); the trend classifier API and any existing
+cadence or tutorial-panel surface; the preview surfaces' current copy and the missing
+make-amends return cost line; the i18n pipeline for quest text (entity/quest pipeline,
+matcher scope including quest_commands.ts); and the existing suites to extend
+(tests/profession_attunement_quests.test.ts, tests/prof_intro_quest.test.ts).
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
+Fan out four agents; give each ONLY the Explore summary, never the planning docs. Use
+worktree isolation only if two agents must edit the same file in parallel.
+
+Agent content deliverables:
+- Four acceptance lore quests, one per wave-one archetype (Smith, Outfitter, Apothecary,
+  Bombardier), each given by its matching master (fill the Phase 8 questIds hooks), each
+  using the 2039 attunePair completionEffect with selection.
+- Each quest's text explains majors, hobby, dormancy, and the make-amends return cost BEFORE
+  the player commits (the legibility rule; no surprise costs after the fact).
+- Make-amends live at the masters as repeatable quests (QuestDef.repeatable) using the
+  switchHobby path, with the state.md escalation formula (5 + 3 * switchCount); the FIRST
+  switch is deliberately cheap per state.md.
+- Retire the placeholder quest rows q_archetype_acceptance and q_prof_make_amends cleanly:
+  remove the content rows, their i18n keys, and their locale fills per the workflow rules;
+  no dangling questIds or orphaned references anywhere.
+
+Agent sim deliverables:
+- Switch cost wiring: the escalation formula resolves in the sim through the make-amends
+  completion path, reading attunedPairs history; validation stays server-side.
+- Trend nudges completing #1295: the trending-pair chat nudge driven by the Phase 7
+  classifier, then a letter-voice follow-up; both cadence-capped so they can never spam.
+- The tutorial panel fires exactly once, at the first cap moment, and never again for that
+  character.
+
+Agent ui deliverables:
+- Attunement preview completeness: the preview (identity card/view plus the quest dialog
+  surface) gains the make-amends return cost line, closing that 2039 review gap; the full
+  picture (majors, hobby, dormancy, return cost) is visible pre-commit in both hosts.
+- Attunement celebration: banner plus title grant plus an id-based zone broadcast that
+  re-localizes through the sim_i18n matcher; the deed hook is left for Phase 15.
+
+Agent tests deliverables:
+- Extend tests/profession_attunement_quests.test.ts and tests/prof_intro_quest.test.ts:
+  all four quests attune their pair; the quest availability matrix (unattuned, attuned to
+  the matching pair, attuned to a wrong pair) at each master; escalation formula values
+  including the cheap first switch; nudge cadence cap and the once-only tutorial panel;
+  the preview return cost line; matcher coverage for the broadcast and nudge strings.
+- A determinism test for the new sim logic (nudge cadence and switch cost resolution under
+  a fixed seed).
+- Remove tests pinned to the retired placeholder quests; re-pin deliberately where behavior
+  moved to the new quests.
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Determinism: all sim randomness through Rng; no Math.random, Date.now, or performance.now
+  in sim logic; cadence timing derives from ticks, never wall clock.
+- IWorld both worlds: any new read or command lands on the matching facet file, is
+  implemented in BOTH Sim and ClientWorld (live, not a stub), and updates the parity pin in
+  tests/world_api_parity.test.ts in the same change.
+- Server authority: selection validation and every quest, switch, and cost outcome resolve
+  server-side; the client never decides.
+- i18n: English-only catalog keys; quest text goes through the entity/quest pipeline; every
+  sim/server-origin player string (broadcast, nudges, letter) ships its matcher rule in the
+  SAME change; the S3 scanner covers quest_commands.ts, so its player text is in scope.
+- Prime directive: nothing existing breaks. Players already attuned via 2039's intro quest
+  keep their state; characters mid-placeholder-quest load cleanly (normalize on load, never
+  crash); existing quests, deeds, and titles stay earnable.
+
+Out of scope (do NOT do in this phase):
+- Jack of All Trades (#1296, wave 2).
+- The six future archetype quests (content beats come later).
+- The attunement deed itself (Phase 15; only leave the hook).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+Run the state.md validation matrix rows for content and sim changes:
+- npx tsc --noEmit
+- npx vitest run tests/progression.test.ts tests/professions_crafting.test.ts (content row,
+  plus the referential suites for the touched domain); npm run wiki:content (player-facing
+  quest content changed)
+- npx vitest run tests/architecture.test.ts plus the affected sim suites; determinism check
+- The 2039 attunement suites plus quest suites plus the S3 guard: npx vitest run
+  tests/profession_attunement_quests.test.ts tests/prof_intro_quest.test.ts
+  tests/quest_commands.test.ts tests/quest_credit.test.ts tests/localization_fixes.test.ts
+- i18n keys changed: npm run i18n:gen then npx vitest run tests/i18n_completeness.test.ts
+  tests/localization_fixes.test.ts
+- npm run ci:changed; format only changed files with a scoped biome check --write
+Then spawn review agents per the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY
+matching rows. Prompt every review agent for COVERAGE, not filtering: report every
+correctness or requirement gap with confidence and severity; filtering happens afterward in
+the main session. If any agent's report comes back truncated, re-invoke it to resume and
+emit the remainder before acting; never act on a truncated report. No commit while any
+BLOCKING finding stands.
+
+STEP 4 - COMMIT CADENCE:
+Commit in slices with explicit paths, never git add -A; every commit carries a body:
+- feat(content): archetype lore quests at the wave-one masters
+- feat(professions): switch costs and nudge cadence
+- feat(ui): attunement preview and celebration
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] A fresh character can be noticed (trend nudge), walk to a master, attune, see the full
+      picture pre-commit, switch once cheaply, and pay escalating amends after.
+- [ ] All four wave-one archetypes are reachable: each master offers its lore quest and the
+      attunePair effect lands the correct pair.
+- [ ] The pre-commit preview explains majors, hobby, dormancy, and the make-amends return
+      cost, in both hosts.
+- [ ] Make-amends is repeatable at the masters with the 5 + 3 * switchCount escalation and a
+      deliberately cheap first switch.
+- [ ] Nudges never spam: cadence cap enforced, letter-voice follow-up once per trend window,
+      tutorial panel fires exactly once at the first cap moment.
+- [ ] Attunement celebration lands: banner, title grant, id-based zone broadcast with
+      matcher coverage; deed hook present but inert.
+- [ ] q_archetype_acceptance and q_prof_make_amends are fully retired: no content rows,
+      i18n keys, locale fills, tests, or questIds references remain.
+- [ ] Players attuned via 2039's intro quest keep their state; mid-quest placeholder
+      characters load cleanly.
+- [ ] All STEP 3 validation commands green.
+
+STEP 6 - DOC UPDATES + MEMORY:
+Update docs/professions-2/progress.md (status table row, Phase 14 checklist, notes with the
+phase-start commit and any deferrals). Update docs/professions-2/state.md: the New surfaces
+per phase list gains the Phase 14 entry (the four lore quest ids and the make-amends quest
+ids, the nudge cadence surface and its i18n key namespaces, the celebration broadcast id and
+matcher rule, and the note that the placeholder quest rows are gone). Record surprises to
+Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT:
+Phase status (complete / partial with reasons); files touched; validation results (each
+command, pass or fail); review verdicts per spawned agent; deferrals with issue links; one
+line QA handoff naming the phase-start commit for the QA diff.
+
+STOPPING RULES:
+- Stop if 2039's selection whitelist cannot express a quest's target pair: report the gap
+  and the proposed whitelist change; do not widen the whitelist ad hoc without recording the
+  decision in state.md.
+```

--- a/docs/professions-2/phase-14-qa.md
+++ b/docs/professions-2/phase-14-qa.md
@@ -1,0 +1,114 @@
+# Phase 14 QA: Verify attunement quests and nudges
+
+Audit the Phase 14 diff for correctness, missing tests, dead code, determinism, three-host
+parity, and i18n completeness before the phase is marked complete.
+
+## QA Starter Prompt
+
+```
+This is Phase 14 QA of the Professions 2.0 feature: verify attunement quests and nudges.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: audit the Phase 14 diff for correctness, missing tests, dead code, determinism,
+three-host parity, and i18n completeness for THIS phase, then fix what the audit finds.
+
+STEP 0 - PRE-FLIGHT:
+- Run git status; the checkout must be clean (a concurrent session may share it).
+- Scan Claude Code memory (MEMORY.md index) for phase-relevant entries: the node25 gate rule
+  (run npm run gate under Node 24), the PR 2039 state (attunement machinery and its review
+  gaps), and the design-language program (DESIGN.md guardrails for the celebration and
+  preview UI).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn an Explore agent to read and summarize:
+- docs/professions-2/state.md and docs/professions-2/progress.md
+- docs/professions-2/phase-14-attunement-quests.md (deliverables, invariants, acceptance
+  criteria, validation commands)
+- the git diff against the Phase 14 start commit recorded in progress.md Notes
+  (git diff <phase-start>..HEAD, plus --name-only for the file list)
+The summary must return: every deliverable and acceptance criterion, the full list of files
+touched, the STEP 3 validation command set from the phase file, and any deferrals the
+implementation session recorded.
+
+STEP 2 - QA AUDIT:
+Fan out three parallel audit agents; give each ONLY the Explore summary. Prompt every agent
+for COVERAGE, not filtering: report every gap with confidence and severity (BLOCKING /
+SHOULD-FIX / NICE-TO-HAVE); filtering happens in the main session afterward. If any agent's
+report comes back truncated, re-invoke it to resume and emit the remainder before acting;
+never act on a truncated report.
+
+Agent Correctness deliverables:
+- Verify every deliverable and acceptance criterion from the phase file against the real
+  code, not the progress notes.
+- Run the phase's validation commands (tsc, the content and sim matrix rows,
+  tests/profession_attunement_quests.test.ts, tests/prof_intro_quest.test.ts,
+  tests/quest_commands.test.ts, tests/quest_credit.test.ts,
+  tests/localization_fixes.test.ts, tests/i18n_completeness.test.ts,
+  tests/architecture.test.ts) and record each result.
+- Exercise the real behavior, not just the suites: in the offline sim, walk a fresh
+  character through nudge, master, lore quest, attunement, one cheap switch, and an
+  escalating amends repeat; confirm selection validation rejects a pair outside the
+  whitelist and that outcomes resolve server-side online.
+- Probe the phase-specific emphasis list:
+  - Quest availability matrix: at each of the four masters, verify offer/deny in every
+    identity state (unattuned, attuned to the matching pair, attuned to a wrong pair,
+    mid-quest, repeat make-amends), in both hosts.
+  - Preview copy completeness against the legibility rule: majors, hobby, dormancy, and the
+    make-amends return cost are all visible BEFORE commit; no path lets a player commit
+    without the full picture.
+  - Broadcast matcher coverage: the celebration zone broadcast, the chat nudge, and the
+    letter-voice follow-up all re-localize through the matchers; the S3 guard passes with
+    quest_commands.ts in scope.
+
+Agent Test coverage deliverables:
+- Find untested paths: availability matrix states, the escalation formula boundaries (first
+  switch cheap, 5 + 3 * switchCount thereafter), the cadence cap edge (the tick at the cap),
+  the once-only tutorial panel, the preview return cost line, matcher rules for every new
+  sim-origin string.
+- Add missing tests, including a determinism test if sim logic changed (nudge cadence and
+  switch cost resolution under a fixed seed; this phase changed sim logic, so expect one).
+- Remove orphaned tests: anything still pinning q_archetype_acceptance or
+  q_prof_make_amends, and any stale re-pin the implementation session missed.
+
+Agent Dead code and cleanup deliverables:
+- Unused imports, types, and helpers left behind by the placeholder quest retirement;
+  dangling questIds or i18n keys; locale fills for retired keys.
+- Sim purity: no DOM/Three imports in src/sim/, all randomness through Rng, no Date.now or
+  performance.now in cadence logic.
+- Leftover TODOs, debug logging, or commented-out code in the phase diff.
+
+Then check git diff --name-only and spawn ONLY matching rows of the Review Dispatch Matrix
+in docs/professions-2/implementation-plan.md, and spawn the qa-checklist agent over the
+whole phase diff. Prompt them for COVERAGE, not filtering, same as above.
+
+STEP 3 - FIX:
+Apply every BLOCKING and SHOULD-FIX finding (record NICE-TO-HAVE as deferrals with issue
+links). Rerun the validation commands the fixes touch until green. Commit with explicit
+paths, never git add -A, Conventional Commits with a body, for example
+fix(professions): phase 14 QA follow-ups or test(sim): cover attunement quest availability
+matrix.
+
+STEP 4 - UPDATE DOCS + MEMORY:
+Update docs/professions-2/progress.md (Phase 14 QA status row, mirror the checklist state,
+append notes and deferrals). Update docs/professions-2/state.md if a fix changed a surface
+recorded there. Record surprises to Claude Code memory.
+
+STEP 5 - FINAL RESPONSE FORMAT:
+Verdict: PASS / PASS-WITH-FOLLOWUPS / FAIL. Counts: findings by severity, findings fixed,
+tests added, tests removed. Deferrals with issue links. Validation results (each command,
+pass or fail). One line handoff for Phase 15 (deed hook location and any tuning notes).
+
+STOPPING RULES:
+- Stop if the audit finds that 2039's selection whitelist cannot express a quest's target
+  pair: report the gap and the proposed whitelist change; do not widen the whitelist ad hoc
+  without recording the decision in state.md.
+```
+
+## Phase-specific QA emphasis
+
+- Quest availability matrix: every identity state (unattuned, attuned to the matching pair,
+  attuned to a wrong pair, mid-quest, repeat make-amends) at each of the four masters, both
+  hosts; the deny reasons must be legible, never a silent missing quest.
+- Preview copy completeness against the doc's legibility rule: majors, hobby, dormancy, and the
+  make-amends return cost all visible before commit, with no commit path that skips the preview.
+- Broadcast matcher coverage: the celebration zone broadcast and both nudge voices re-localize
+  via the matchers; the S3 guard is green with `src/sim/quests/quest_commands.ts` in scope.

--- a/docs/professions-2/phase-15-deeds-polish.md
+++ b/docs/professions-2/phase-15-deeds-polish.md
@@ -39,6 +39,11 @@ tuning numbers to named constants, rewriting the wiki professions page to descri
 system, finishing asset-manifest.json, and running the whole-feature QA matrix plus the gate.
 
 STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
 - Run git status; the checkout must be clean (a concurrent session may share it). Stop if dirty.
 - Record the current HEAD as the phase-start commit in docs/professions-2/progress.md.
 - Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries; at minimum read:

--- a/docs/professions-2/phase-15-deeds-polish.md
+++ b/docs/professions-2/phase-15-deeds-polish.md
@@ -1,0 +1,191 @@
+# Phase 15: Deeds, tuning, and polish
+
+This phase closes the Professions 2.0 packet. It registers the basic universal profession deeds
+(cosmetic only, per the locked decision in `state.md`), replaces the placeholder tuning targets
+with the maintainer's final numbers in named constants, rewrites the `/wiki` professions page so
+the guide describes the system that actually shipped, finishes the `asset-manifest.json` designer
+handoff, and then runs the whole-feature QA matrix plus the release gate. It is its own slice
+because every earlier phase must be landed before deeds can trigger on real behavior, tuning can
+be judged against the live system, and the wiki can tell the truth.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: locked decisions, the "Tuning targets" section (the numbers this
+  phase finalizes), the validation matrix, and the "New surfaces per phase" appendix that names
+  where each tuning constant landed.
+- `docs/professions-2/progress.md`: per-phase status and deliverable checklists.
+- `docs/professions-2/qa-checklist.md`: the whole-feature integration matrix this phase runs end
+  to end with evidence.
+- `docs/professions-2/asset-manifest.json`: the designer-replaceable slot list to finish.
+- `docs/professions-2/implementation-plan.md`: the review dispatch matrix and team workflow.
+- `src/sim/content/deeds.ts` and `src/sim/deeds.ts`: the deed catalog and trigger system; author
+  per `docs/design/deeds.md` and the 12-step deeds recipe summarized in `state.md`.
+- `tests/deeds_content.test.ts` and `tests/deeds.test.ts`: the catalog pin (append-only proof)
+  and trigger behavior suites.
+- Tuning constant homes named in `state.md`: the masterwork proc constants (Phase 2), the
+  pristine vein cadence (Phase 4), the training fees (Phase 9), and the #1301 craft fee and
+  throttle constants in the crafting resolver path.
+- `src/guide/pages/professions.ts` plus the wiki content generator (`npm run wiki:content`,
+  freshness-gated by `tests/guide.test.ts`); conventions in `src/guide/CLAUDE.md`.
+- Local conventions: `src/sim/CLAUDE.md`, `src/guide/CLAUDE.md`, `tests/CLAUDE.md`.
+
+## Starter Prompt
+
+```
+This is Phase 15 of the Professions 2.0 feature: Deeds, tuning, and polish.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: close the packet by registering the universal profession deeds, applying the maintainer's
+tuning numbers to named constants, rewriting the wiki professions page to describe the shipped
+system, finishing asset-manifest.json, and running the whole-feature QA matrix plus the gate.
+
+STEP 0 - PRE-FLIGHT:
+- Run git status; the checkout must be clean (a concurrent session may share it). Stop if dirty.
+- Record the current HEAD as the phase-start commit in docs/professions-2/progress.md.
+- Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries; at minimum read:
+  node25-breaks-jsdom-gate (the gate MUST run under Node 24), design-language-program (no
+  DESIGN.md phase vocabulary in any copy or styling this phase touches), and any professions /
+  PR 2039 packet entries recorded by earlier phases.
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize:
+- docs/professions-2/state.md, docs/professions-2/progress.md, and this phase file
+  (docs/professions-2/phase-15-deeds-polish.md).
+- docs/professions-2/qa-checklist.md and docs/professions-2/asset-manifest.json.
+- docs/design/deeds.md, src/sim/content/deeds.ts, src/sim/deeds.ts,
+  tests/deeds_content.test.ts, tests/deeds.test.ts.
+- The tuning constant files named in state.md's "New surfaces per phase" appendix (masterwork
+  proc, pristine vein cadence, training fees, the #1301 fee and throttle).
+- src/guide/pages/professions.ts and the wiki generator path, plus src/guide/CLAUDE.md,
+  src/sim/CLAUDE.md, and tests/CLAUDE.md.
+The summary must return: the locked deed scope and tuning targets verbatim from state.md; the
+deed authoring rules (record shape, trigger wiring, i18n-by-id, category crest icon fallback,
+catalog pin mechanics); the exact file and symbol for every tuning constant; how the guide page
+is generated and freshness-gated; the current asset-manifest slot list; and the validation
+matrix rows for deeds content, content-only, i18n keys added, and full-stack changes.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
+Fan out three parallel agents (deeds, tuning, guide); each gets ONLY the Explore summary, never
+the planning docs. Their file sets are disjoint, so no worktree isolation is needed; if any
+overlap appears, serialize that overlap. After all three land, the main session runs the QA
+matrix (see STEP 3).
+
+Agent deeds deliverables:
+- Register the basic universal profession deeds in src/sim/content/deeds.ts with triggers wired
+  in src/sim/deeds.ts: first craft, first masterwork, first attunement, per-craft tier
+  milestones (rare tier), and the pristine vein find. The rare fish deed already exists: verify
+  it, do not duplicate it.
+- Icons via the category crest fallback (no bespoke art required; note any bespoke-worthy slot
+  in asset-manifest.json instead).
+- Deed i18n added English-only by deed id per the deeds recipe; catalog pins in
+  tests/deeds_content.test.ts updated; the pin must prove the catalog is APPEND-ONLY so ALL
+  existing deeds stay earnable.
+- A scripted playthrough test (Vitest driving the real Sim) that unlocks every new deed.
+
+Agent tuning deliverables:
+- Review masterwork proc bounds, training fees, pristine vein cadence, and the #1301 craft fee
+  and throttle against the state.md tuning targets, applying the maintainer's numbers. If a
+  maintainer number is missing for any constant, stop and ask; never invent balance numbers.
+- Every constant is a NAMED export in its owning module; none inline at a call site. Pin each
+  final value in the matching test.
+
+Agent guide deliverables:
+- Rewrite the guide/wiki professions page (src/guide/pages/professions.ts) to describe the
+  SHIPPED system: archetypes and attunement, masterworks, stations and masters, training,
+  gathering and pristine veins, fishing, enchanting reach, and the deeds. Recipe and station
+  data must feed the page from src/sim/ content, not hand-copied tables.
+- npm run wiki:content regenerated and the freshness gate (tests/guide.test.ts) green; any new
+  guide.* prose keys added English-only.
+- Final asset-manifest.json pass: append every id that shipped procedurally across the packet,
+  with purpose, size, format, and replacement notes.
+
+Then, in the main session: run docs/professions-2/qa-checklist.md end to end, recording evidence
+(test name, command output, or screenshot path) per row; then npm run gate under Node 24; then
+offer packet teardown per the house rule (surface deferrals first, ask for explicit maintainer
+confirmation before deleting docs/professions-2/; if the maintainer defers, the Phase 15 QA
+session re-offers).
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Deeds are cosmetic-only: titles and Renown, never power.
+- Determinism: all sim randomness through Rng; deed triggers must not perturb existing Rng draw
+  order; no Math.random, Date.now, or performance.now in src/sim/.
+- IWorld both-worlds parity where relevant: any new read lands on a facet, implemented in BOTH
+  Sim and ClientWorld, parity-pinned in the same change (verify liveness, not just shape).
+- Server authority: deed credit and every tuned outcome resolve server-side.
+- i18n: English-only catalog keys; sim/server-origin player text ships its matcher rule (the S3
+  guard, tests/localization_fixes.test.ts) in the SAME change; M16 for wordy strings.
+- Docs anchor rule: cite stable paths, exported symbols, and pinned tests; no literal counts or
+  line numbers that rot.
+- Prime directive: nothing existing breaks. All existing deeds stay earnable; never delete an
+  ItemDef players may hold; no hand-edits to generated files.
+
+Out of scope (do NOT do in this phase):
+- Anything wave 2: market/mail instance carriage (#1146), commissions and boundTo (#1298),
+  Jack of All Trades (#1296), monster-harvest proficiency, salvage UI, battlefield experience
+  expansion, item biographies, tool effects (parked and dormant), jewelcrafting or inscription
+  depth.
+- No new deed UI systems; the deeds window and celebration pipeline already exist.
+- No deletion of docs/professions-2/ without the explicit teardown confirmation.
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+Run the state.md validation matrix rows for this change type:
+- deeds content row: npx vitest run tests/deeds_content.test.ts tests/deeds.test.ts
+- guide freshness: npx vitest run tests/guide.test.ts and npm run wiki:content
+- i18n keys added row: npm run i18n:gen then npx vitest run tests/i18n_completeness.test.ts
+  tests/localization_fixes.test.ts
+- sim purity: npx vitest run tests/architecture.test.ts and npx tsc --noEmit
+- any code change row: npm run ci:changed; format with a SCOPED
+  npx @biomejs/biome check --write <file>
+- full-stack row: the full docs/professions-2/qa-checklist.md matrix with evidence, then
+  npm run gate under Node 24 (the known armory browser-test failure aborts the gate early;
+  finish tsc and the builds manually; PR CI is the arbiter).
+Then spawn review agents per the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY matching
+rows (qa-checklist always spawns here: the phase, and the packet, are complete). Prompt every
+review agent for COVERAGE, not filtering: report every correctness or requirement gap with
+confidence and severity; filtering happens in a later pass. If any agent's output comes back
+truncated, re-prompt that agent to resume and finish its report before acting on it. No commit
+while any BLOCKING finding stands.
+
+STEP 4 - COMMIT CADENCE:
+Commit in slices with explicit paths (never git add -A); every commit carries a body (1 to 4
+sentences on what changed and why), Conventional Commits with a scope:
+- feat(content): register universal profession deeds
+- chore(professions): apply the Phase 15 tuning pass
+- docs(guide): rewrite the professions wiki page for the shipped system
+- docs(professions): finish asset-manifest and update packet status docs
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] Every deed in the packet is unlockable in a scripted playthrough (the Vitest run proves
+      first craft, first masterwork, first attunement, rare-tier milestones, the rare fish, and
+      the pristine vein find all unlock).
+- [ ] tests/deeds_content.test.ts pins the catalog append-only; all pre-packet deeds unchanged.
+- [ ] Every tuning constant is named, exported, pinned, and matches the maintainer's numbers.
+- [ ] The wiki professions page describes the shipped system; npm run wiki:content freshness
+      green.
+- [ ] asset-manifest.json lists every procedurally shipped id from the packet.
+- [ ] docs/professions-2/qa-checklist.md fully checked with evidence per row.
+- [ ] npm run gate green (Node 24 rule respected).
+- [ ] Packet teardown offered and answered (or explicitly deferred to the QA session).
+
+STEP 6 - DOC UPDATES + MEMORY:
+Update docs/professions-2/progress.md (Phase 15 status, deliverable checklist, phase-start and
+phase-end commits) and docs/professions-2/state.md: the "Tuning targets" section becomes final
+numbers with their constant names and files; "New surfaces per phase" gains the Phase 15 row
+(deed ids registered, deed i18n namespace, scripted playthrough test path, guide page anchor,
+asset-manifest final status); the "Current phase" pointer moves to "Phase 15 done, final QA
+pending". Record any surprises to Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT:
+Report: phase status; files touched; validation results (each command and its outcome,
+including every qa-checklist row's evidence); review agent verdicts; deferrals; and a one-line
+handoff for the Phase 15 QA session.
+
+STOPPING RULES:
+- Stop if any qa-checklist.md row cannot be evidenced; report the row and why instead of
+  checking it on vibes.
+- Stop and ask if any tuning constant lacks a maintainer-confirmed number; never invent balance
+  numbers.
+- Stop if a pre-existing deed pin would need weakening to pass; that signals a broken existing
+  deed, not a re-pin.
+- Never delete docs/professions-2/ without the explicit teardown confirmation.
+```

--- a/docs/professions-2/phase-15-qa.md
+++ b/docs/professions-2/phase-15-qa.md
@@ -1,0 +1,117 @@
+# Phase 15 QA: Verify Deeds, tuning, and polish
+
+Audit the Phase 15 diff and run the whole-feature integration matrix: this QA session is the
+final audit of the entire Professions 2.0 packet, ending with the teardown offer.
+
+## Phase-specific QA emphasis
+
+- This session IS the final integration audit for the whole packet, not just Phase 15: every
+  row of `docs/professions-2/qa-checklist.md` needs fresh evidence (test name, command output,
+  or screenshot path), even rows earlier phase QAs already checked.
+- Prove the deed catalog is append-only: all pre-packet deeds remain earnable and pinned, and
+  every new deed unlocks in the scripted playthrough test.
+- Verify every tuning constant against the final numbers in `state.md`: named export, pinned
+  value, nothing inline at a call site, no placeholder target left behind.
+- Spot-check the rewritten wiki professions page against the real sim code: every claim the
+  page makes must be true of the shipped system, and the teardown offer must follow the house
+  rule exactly.
+
+## QA Starter Prompt
+
+```
+This is Phase 15 QA of the Professions 2.0 feature: verify Deeds, tuning, and polish, and run
+the final whole-packet integration audit.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: audit the Phase 15 work for correctness, missing tests, dead code, determinism,
+three-host parity, and i18n completeness, then evidence the entire whole-feature QA matrix and
+close the packet.
+
+STEP 0 - PRE-FLIGHT:
+- Run git status; the checkout must be clean. Stop if dirty.
+- Scan Claude Code memory (the MEMORY.md index) for phase-relevant entries; at minimum read:
+  node25-breaks-jsdom-gate (the gate MUST run under Node 24), design-language-program (no
+  DESIGN.md phase vocabulary in guide or HUD copy), and any professions / PR 2039 packet
+  entries recorded by earlier phases.
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize:
+- docs/professions-2/state.md, docs/professions-2/progress.md, and
+  docs/professions-2/phase-15-deeds-polish.md (including its acceptance criteria).
+- docs/professions-2/qa-checklist.md and the evidence the implementation session recorded.
+- git diff against the phase-start commit recorded in progress.md (git diff --stat and the
+  full diff for src/sim/, src/guide/, and test files).
+The summary must return: every Phase 15 deliverable and acceptance criterion; the list of new
+deed ids and their trigger wiring; each tuning constant's file, symbol, and final value versus
+the state.md targets; the guide page's generated-data feeds; the validation commands for this
+phase; and any deferral or open item the implementation session left.
+
+STEP 2 - QA AUDIT:
+Fan out three parallel audit agents; each gets ONLY the Explore summary. Prompt every agent for
+COVERAGE, not filtering: report every gap with confidence and severity; filtering happens in
+the fix pass. If any agent's output comes back truncated, re-prompt that agent to resume and
+finish its report before acting on it.
+
+Agent correctness deliverables:
+- Verify every Phase 15 deliverable and acceptance criterion against the real code, not the
+  progress notes.
+- Run the phase's validation commands: npx vitest run tests/deeds_content.test.ts
+  tests/deeds.test.ts tests/guide.test.ts; npm run wiki:content; npx vitest run
+  tests/architecture.test.ts tests/localization_fixes.test.ts; npx tsc --noEmit.
+- Exercise the real behavior: run the scripted playthrough test and confirm every new deed
+  unlocks; confirm the rare fish deed was verified, not duplicated; diff each tuning constant
+  against state.md's final numbers; spot-check the wiki page's claims against src/sim/ source.
+
+Agent test coverage deliverables:
+- Find untested paths: any deed trigger without a pinned test, any tuning constant without a
+  value pin, any guide data feed without freshness coverage.
+- Add missing tests, including a determinism test if Phase 15 touched sim logic (same seed,
+  same deed unlock sequence; deed triggers must not perturb existing Rng draw order).
+- Remove orphaned tests (pins for placeholder tuning values or pre-rewrite guide content).
+
+Agent dead code and cleanup deliverables:
+- Unused imports and types across the Phase 15 diff; leftover TODOs and placeholder targets.
+- Sim purity in every touched src/sim/ file: no DOM or Three imports, no Math.random, Date.now,
+  or performance.now.
+- Stale asset-manifest.json rows and any packet-era scaffolding that should not ship.
+
+Then spawn review agents per the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md; check git diff --name-only and spawn ONLY matching
+rows, plus the qa-checklist agent (the packet is complete). Prompt them all for COVERAGE, not
+filtering, with the same truncation-resume rule.
+Finally, in the main session, run docs/professions-2/qa-checklist.md end to end and record
+fresh evidence per row: this QA session is the final integration audit for the whole packet.
+
+STEP 3 - FIX:
+Apply every BLOCKING and SHOULD-FIX finding (defer only nice-to-haves, listed explicitly).
+Rerun the validation commands above plus any qa-checklist rows the fixes invalidated, then
+npm run gate under Node 24 (the known armory browser-test failure aborts the gate early; finish
+tsc and the builds manually; PR CI is the arbiter). Commit fixes with explicit paths (never
+git add -A), Conventional Commits with a scope and a body.
+
+STEP 4 - UPDATE DOCS + MEMORY:
+Update docs/professions-2/progress.md (Phase 15 QA verdict, fix commits, packet completion) and
+docs/professions-2/state.md (current-phase pointer to packet complete; any constant or surface
+the fixes changed). Record surprises to Claude Code memory.
+
+STEP 5 - PACKET TEARDOWN OFFER (this step exists ONLY because this is Phase 15):
+Offer packet teardown exactly per the house rule: first surface every deferral and open item
+from the whole packet (state.md OPEN items, per-phase deferrals, wave 2 pointers) so nothing is
+lost with the docs; then ask the maintainer for EXPLICIT confirmation to delete
+docs/professions-2/ before the final PR. Only delete on an explicit yes; commit the deletion
+with explicit paths, never git add -A. If the answer is no or deferred, leave the packet in
+place and record the decision in progress.md.
+
+STEP 6 - FINAL RESPONSE FORMAT:
+Report: verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL); counts of findings by severity (blocking,
+should-fix, deferred) and how many were fixed; the qa-checklist evidence summary; deferrals
+carried forward; the teardown outcome; and a one-line handoff (the packet's final state and
+where the PR stands).
+
+STOPPING RULES:
+- Stop if any qa-checklist.md row cannot be evidenced; report the row and the missing evidence
+  instead of checking it on vibes.
+- Stop if a fix would require weakening a pre-existing deed or economy pin; that is a defect to
+  report, not a re-pin.
+- No commit while any BLOCKING finding stands.
+- Never delete docs/professions-2/ without the explicit maintainer confirmation in STEP 5.
+```

--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -1,0 +1,132 @@
+# Professions 2.0: progress
+
+Update this file at the end of every implementation and QA session. Statuses:
+`not started` / `in progress` / `complete` / `deferred (note why)`.
+
+## Status table
+
+| Phase | Title | Status | Started | Completed |
+|---|---|---|---|---|
+| 1 | Ring and identity foundations | not started | | |
+| 1 QA | Verify ring and identity foundations | not started | | |
+| 2 | Masterwork model | not started | | |
+| 2 QA | Verify masterwork model | not started | | |
+| 3 | Host-parity bug fixes | not started | | |
+| 3 QA | Verify host-parity bug fixes | not started | | |
+| 4 | Node materials and pristine veins | not started | | |
+| 4 QA | Verify node materials and pristine veins | not started | | |
+| 5 | The professions wheel window | not started | | |
+| 5 QA | Verify the professions wheel window | not started | | |
+| 6 | Crafting window upgrades and celebrations | not started | | |
+| 6 QA | Verify crafting window upgrades | not started | | |
+| 7 | The Guild letter and quest objectives | not started | | |
+| 7 QA | Verify the Guild letter and quest objectives | not started | | |
+| 8 | Stations and masters (sim and server) | not started | | |
+| 8 QA | Verify stations and masters | not started | | |
+| 9 | Station presence and recipe training | not started | | |
+| 9 QA | Verify station presence and training | not started | | |
+| 10 | Recipe ladders and materials content | not started | | |
+| 10 QA | Verify recipe ladders and materials | not started | | |
+| 11 | Fishing joins the framework | not started | | |
+| 11 QA | Verify fishing framework | not started | | |
+| 12 | Base tool tier gating | not started | | |
+| 12 QA | Verify tool tier gating | not started | | |
+| 13 | Enchanting reachable | not started | | |
+| 13 QA | Verify enchanting reachable | not started | | |
+| 14 | Attunement quests and nudges | not started | | |
+| 14 QA | Verify attunement quests and nudges | not started | | |
+| 15 | Deeds, tuning, and polish | not started | | |
+| 15 QA | Final integration QA and packet teardown | not started | | |
+
+## Per-phase deliverable checklists
+
+Each phase file (`phase-NN-*.md`) carries the authoritative acceptance
+criteria; mirror the checkboxes here as phases complete.
+
+### Phase 1: Ring and identity foundations
+- [ ] `CRAFT_RING` adopts the blueprint ring order (design-doc order); geometry tests re-pinned
+- [ ] `ArchetypeState` carries per-archetype attunement history (JSONB additive, back-compat load)
+- [ ] Combo eligibility requires the matching attunement in the shared rule, both hosts
+- [ ] Pair-named archetype title keys land (Smith, Outfitter, Apothecary, Bombardier + the six future pairs)
+- [ ] PR 2039 should-fix items resolved; ring adoption landed inside its merge window
+
+### Phase 2: Masterwork model
+- [ ] Craft outputs deterministic; five-way quality roll retired; `trivialAt` retired
+- [ ] Masterwork proc (skill, self-signed, specialization inputs) with pinned rng-draw contract
+- [ ] Masterwork stats baked via `item_budget` into `instance.rolled.stats`; deeds reader still coherent
+- [ ] Masterwork SimEvent with celebration payload; power-ceiling tuning targets in `state.md`
+
+### Phase 3: Host-parity bug fixes
+- [ ] Trade carries `ItemInstancePayload` end to end (regression test)
+- [ ] `harvestClaimedBy` mirrored online; corpse picker stops offering claimed corpses
+- [ ] Crafting view consumes the shared combo-eligibility rule in both hosts
+
+### Phase 4: Node materials and pristine veins
+- [ ] Per-rarity node material tables replace placeholder junk (zone-1 stays low-tier)
+- [ ] Rare+ node yields signed like corpse yields
+- [ ] Pristine vein rare event (spawn, soft broadcast, deed mark)
+- [ ] `gatherResult` consumed: gather cue + rarity-colored loot line
+
+### Phase 5: The professions wheel window
+- [ ] New window at deeds quality per DESIGN.md: view core (UI_PURE_CORES), painter, styles, i18n
+- [ ] Ring visualization, per-craft skill bars, tier pips, title/majors/hobby, live perks
+- [ ] Desktop + mobile responsive; screenshots captured for the PR
+- [ ] Launchers (minimap or window row + keybind) consistent with existing windows
+
+### Phase 6: Crafting window upgrades and celebrations
+- [ ] Recipe rows show profession + required skill + skill-gain difficulty tint (#2037)
+- [ ] Combo rows name their requirement; station-bound rows show a badge and disable reason
+- [ ] Masterwork toast + zone-chat broadcast; maker's mark and masterwork in item tooltips
+- [ ] Craft button never lies: same eligibility rule as the sim in both hosts
+
+### Phase 7: The Guild letter and quest objectives
+- [ ] Craft/gather quest objective types (minimal set for the letter quest)
+- [ ] The Guild letter arrives via the mail system on trend detection; starts the first-attunement quest hook
+- [ ] S3 scanner gap closed: `src/sim/quests/quest_commands.ts` in scan scope, guard test updated
+
+### Phase 8: Stations and masters (sim and server)
+- [ ] Station registry generalizes `requiresHubStation` to typed stations (forge, kitchens, apothecary, tannery, loom)
+- [ ] Master NPC content records (shop, teach, quest-hook capable) for the six deep crafts
+- [ ] Automated placement-safety test: no profession NPC or station within aggro-plus-buffer of hostile spawns
+- [ ] Mobile crafting station perk activates (bypasses the station gate; specialization-gated)
+
+### Phase 9: Station presence and recipe training
+- [ ] Stations render as world props; masters render and are interactable; minimap markers
+- [ ] Recipe training at masters on the `acquireRecipe` gate; every existing recipe grandfathered known
+- [ ] Master shops stocked (base tools, reagents); training fees are gold sinks
+- [ ] Hands-vs-stations split live: field recipes craft anywhere, uncommon+ at stations
+
+### Phase 10: Recipe ladders and materials content
+- [ ] Tier ladders for all six deep crafts (common through rare at minimum) with material families
+- [ ] Cloth sourcing: humanoid components + plant fiber; corpse component quest-item collision ended
+- [ ] Economy invariant test pinned: no recipe vendors for more than its inputs
+- [ ] Wiki content regenerated; recipe data feeds the guide
+
+### Phase 11: Fishing joins the framework
+- [ ] Fishing proficiency (additive, framework-integrated) while the minigame stays as-is
+- [ ] Catch rarity ladder feeds cooking tiers; rare catch integrates (deed intact)
+
+### Phase 12: Base tool tier gating
+- [ ] Nodes carry tiers; tool tier + skill gate node and corpse-material access
+- [ ] The 15 existing tools change outcomes; stale no-op test pin replaced
+- [ ] Tool effects remain parked (explicitly out of scope)
+
+### Phase 13: Enchanting reachable
+- [ ] Disenchant + enchant-apply on IWorld, wire commands, bags context UI, both hosts
+- [ ] Enchanting skill visible in the wheel window
+
+### Phase 14: Attunement quests and nudges
+- [ ] Acceptance lore quests at the masters for all four wave-one archetypes
+- [ ] Repeatable-quest support; make-amends wired; cheap-first-switch costs
+- [ ] Trend nudges (chat first, Guild letter voice); attunement summary explains everything before commit
+- [ ] Title celebration on attunement
+
+### Phase 15: Deeds, tuning, and polish
+- [ ] Basic universal profession deeds (first craft, first masterwork, first attunement, tier milestones, the rare fish)
+- [ ] Economy tuning targets applied (#1301 fee/throttle, training fees, masterwork bounds)
+- [ ] Guide/wiki professions page rewritten; asset manifest final
+- [ ] Whole-feature qa-checklist.md matrix green; packet teardown offered
+
+## Notes
+
+(append per-phase notes, deferrals, and surprises here as sessions complete)

--- a/docs/professions-2/qa-checklist.md
+++ b/docs/professions-2/qa-checklist.md
@@ -1,0 +1,94 @@
+# Professions 2.0: whole-feature QA matrix
+
+Verified once at packet completion (Phase 15 QA), on top of the per-phase QA
+sessions. Every row must be checked with evidence (test name, command output,
+or screenshot path), not vibes.
+
+## Three-host parity
+- [ ] Craft skills, archetype identity (title, majors, hobby, history), combo
+      eligibility, masterwork results, station gating, node cooldowns, corpse
+      claims, fishing proficiency, and known recipes read identically in the
+      offline `Sim` and online `ClientWorld`; the headless env is unaffected or
+      consistent where it reads professions state.
+- [ ] `tests/world_api_parity.test.ts` pins every new member; no ClientWorld
+      stub defaults remain for any surface this packet ships (the shape-only
+      pin trap: verify liveness, not just member presence).
+- [ ] Wire suites green: `npx vitest run tests/snapshots.test.ts tests/env_protocol.test.ts tests/bandwidth.test.ts`.
+
+## Determinism
+- [ ] All new randomness (masterwork proc, pristine vein spawns, node rarity,
+      fishing catches) draws through `Rng` with pinned draw-order tests; no
+      `Math.random` / `Date.now` / `performance.now` anywhere in `src/sim/`.
+- [ ] `npx vitest run tests/architecture.test.ts` green.
+- [ ] Same-seed determinism test covers a full gather-craft-masterwork sequence.
+
+## Server authority
+- [ ] Every new command (train recipe, disenchant, enchant apply, quest
+      advance) validates server-side; the client never decides craft outcomes,
+      masterwork procs, harvest rewards, or quest credit.
+- [ ] Invalid or replayed commands cannot duplicate rewards, recipes, or skill.
+
+## Persistence
+- [ ] Characters saved before this packet load cleanly: legacy `ArchetypeState`
+      (no history), legacy craft skills, legacy known recipes (grandfathered),
+      legacy instances (no masterwork flag) all default correctly.
+- [ ] Save/load round-trip tests cover archetype history, fishing proficiency,
+      known recipes, and masterwork instances.
+- [ ] All DDL (if any) is additive and idempotent under the boot advisory lock.
+
+## Economy invariants
+- [ ] Pinned test: no recipe's output vendors for more than its inputs.
+- [ ] Training fees, craft fees (#1301), and market cut are the sinks; NPC
+      shops never buy crafted goods above trivial value.
+- [ ] Masterwork power stays within the tuning bounds in `state.md` (below the
+      raid floor); baseline crafted gear sits below dungeon best-in-slot.
+
+## i18n completeness
+- [ ] Every new player-visible string (window chrome, recipe rows, station
+      badges, toasts, broadcasts, NPC names and dialogue, quest text, letters,
+      deed names) is a `t()` key in ENGLISH in the matching
+      `src/ui/i18n.catalog/<domain>.ts`; locale overlays untouched; M16 wordy
+      strings carry their five non-Latin fills.
+- [ ] Sim/server-origin player text has matcher rules in `src/ui/sim_i18n.ts`
+      or `src/ui/server_i18n.ts` in the same change; the S3 guard
+      (`npx vitest run tests/localization_fixes.test.ts`) is green AND the
+      Phase 7 scanner-gap fix means `src/sim/quests/quest_commands.ts` is in
+      scope.
+- [ ] Numbers, money, and dates go through `formatNumber` / `formatMoney` /
+      `formatDateTime`.
+
+## Design language and UX (the deeds bar)
+- [ ] The wheel window and crafting-window upgrades follow DESIGN.md tokens and
+      chrome (no hardcoded colors, correct layer usage per `src/styles/CLAUDE.md`).
+- [ ] Desktop and mobile screenshots captured (`scripts/mobile_*.mjs` family)
+      and committed under `docs/screenshots`, referenced from the PR body.
+- [ ] Tap targets comfortable; no hover-only information; safe areas respected.
+- [ ] Graphics-settings fairness: no preset hides actionable profession info.
+
+## Content integrity
+- [ ] Placement-safety test green: no profession NPC or station within
+      aggro-plus-buffer of hostile spawns.
+- [ ] Every deep craft has a full tier ladder; every recipe's materials are
+      obtainable in-world; referential integrity tests green.
+- [ ] Corpse component rewards no longer grant unrelated quest credit; every
+      mapped tag yields a real item.
+- [ ] All existing deeds remain earnable; new profession deeds registered and
+      pinned in `tests/deeds_content.test.ts`.
+
+## Classic fidelity and copy
+- [ ] No invented balance formulas where a classic-era reference exists; XP and
+      gray-out curves match the documented model.
+- [ ] No em dashes, en dashes, or emojis in any player-facing text, code,
+      comments, or docs from this packet.
+
+## Build gate and cleanup
+- [ ] `npm run gate` green on the release branch tier (run under Node 24 per
+      memory: node25-breaks-jsdom-gate).
+- [ ] No dead code from the replaced systems: five-way quality roll consumers,
+      `trivialAt`, practitioner-title keys, placeholder junk table entries,
+      stale test pins (tool no-op, one-recipe-per-craft) all removed or
+      re-pinned.
+- [ ] `asset-manifest.json` lists every placeholder asset shipped, with size,
+      format, usage, and replacement notes for designers.
+- [ ] Packet teardown offered (delete `docs/professions-2/` before the final PR)
+      only on explicit maintainer confirmation.

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -65,6 +65,11 @@ Phase 1 (Ring and identity foundations): not started.
 - Prime directive: nothing breaks. Never delete an ItemDef players may hold;
   deprecate by removing sources. Existing deeds stay earnable. Additive JSONB
   with normalize-on-load defaults. The T window keeps working.
+- Release-branch currency: every session syncs with the NEWEST release/**
+  branch at start (version-sort the remote list; 0.27 gives way to 0.28 and
+  onward); fresh branches base on it, existing feature branches merge it in
+  immediately with the release-merge-audit skill run on the merge. Never base
+  work on main or a stale release branch.
 - Shared-worktree commit care: explicit paths, never `git add -A`.
 - npm run gate under Node 24 (memory: node25-breaks-jsdom-gate); the known
   armory browser-test failure aborts the gate early, finish tsc + builds
@@ -172,6 +177,13 @@ tables, i18n key namespaces, files created)
 - Pristine vein: roughly 1 per zone per 20 minutes, 5x yield, always signed.
 
 ## OPEN items
+
+- Design-system sequencing: the maintainer wants professions to be the first
+  feature under the new design system (root DESIGN.md). Ideal order: the
+  design-language program's phase 1 (tokens/theme/type) lands before packet
+  Phase 5 (the wheel window). Each UI phase probes the rollout state at
+  session start (see implementation-plan.md guardrails) and uses the new
+  vocabulary once it exists; until then, today's tokens, grammar-ready.
 
 - PR 2039 merge timing and who lands the Phase 1 amendments (same PR vs
   immediate follow-up in one deploy window). Coordinate with the maintainer.

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -1,0 +1,183 @@
+# Professions 2.0: state (the cross-phase cheat sheet)
+
+The ONLY file every session must trust. Update it at the end of every phase.
+
+## Current phase
+
+Phase 1 (Ring and identity foundations): not started.
+
+## Locked design decisions
+
+- Six deep crafts: weaponcrafting, armorcrafting, tailoring, leatherworking,
+  cooking, alchemy; engineering ships as the toolmaker line. Jewelcrafting,
+  inscription shallow; enchanting shallow but reachable (Phase 13).
+- Four wave-one archetypes: Smith (weapon+armor), Outfitter (tailor+leather),
+  Apothecary (alchemy+cooking), Bombardier (engineering+alchemy).
+- CRAFT_RING adopts the design-doc order: engineering, alchemy, cooking,
+  leatherworking, tailoring, inscription, enchanting, jewelcrafting,
+  weaponcrafting, armorcrafting. MUST land inside PR 2039's merge window
+  (before players persist attunedPairs pair ids derived from the old ring).
+- Archetypes are pair-named identities: pair-level i18n keys replace the ten
+  per-craft practitioner titles. Pair-level attunement history (2039's
+  attunedPairs) IS the lore-vs-amends mechanism and stays.
+- Combos require the matching attunement (2039's combo_eligibility: deny
+  'not_attuned' / 'wrong_pair' / 'tier_unmet'). Client 'syncing' state
+  (pre-cprof): keep the button enabled optimistically (server re-validates);
+  revisit only if players report confusion.
+- Masterwork model: deterministic outputs; proc chance from skill +
+  self-signed materials + specialization; bounded bonus stats baked via
+  src/sim/item_budget.ts into instance.rolled.stats; no five-way quality
+  roll; trivialAt retired. Power bounds: baseline crafted below dungeon BiS;
+  masterwork at dungeon-drop level, always below the raid floor.
+- RNG in, determinism out: input RNG (node rarity, pristine veins, fishing
+  catches, corpse components) stays and grows; output RNG is only the
+  masterwork proc (add-only, never a downgrade).
+- Hands vs stations: field recipes (a named FIELD_RECIPES subset) craft
+  anywhere; every uncommon+ recipe requires its typed station. Stations are
+  master NPCs (shop + teach + quest hooks) in guard-safe locations. The
+  mobile-crafting-station specialization perk bypasses the gate.
+- Recipe acquisition: training at masters on the existing acquireRecipe gate;
+  every recipe that exists before Phase 9 is grandfathered known on load.
+- No skillReq admission gate on known recipes, ever (documented rule stands).
+- Pacing: fast early, slow top; scarcity (materials, adventure) is the clock.
+- Economy: players trade with players; NPCs only sink (training fees, tools,
+  reagents, #1301 craft fee, market cut, make-amends costs); pinned invariant
+  that no recipe vendors above its input value.
+- Deeds: basic universal only (first craft, first masterwork, first
+  attunement, per-craft tier milestones, the rare fish). Cosmetic only.
+- Identity costs: first attunement free; make-amends escalation stays
+  5 + 3 * switchCount with cheap early costs.
+- Tool effects/charges/recharge: PARKED. Pure modules in
+  src/sim/professions/tools.ts stay dormant; do not wire, do not delete.
+- Wave 2+ excluded from this packet (see implementation-plan.md).
+
+## Non-negotiable constraints
+
+- Sim purity + 20 Hz determinism (all randomness via Rng; guarded by
+  tests/architecture.test.ts). Server authority for every outcome.
+- IWorld-first: new reads/commands land on a facet file, implemented in BOTH
+  Sim and ClientWorld, parity-pinned, in the same change. Verify liveness,
+  not just member shape (the 2033 stub trap).
+- i18n: English-only catalog keys; sim/server text via ids + matchers (S3
+  guard); M16 for wordy strings; entity names via tEntity.
+- Design language: today's tokens + shared shell only; NO DESIGN.md phase
+  vocabulary in feature PRs (see implementation-plan.md guardrails).
+- Prime directive: nothing breaks. Never delete an ItemDef players may hold;
+  deprecate by removing sources. Existing deeds stay earnable. Additive JSONB
+  with normalize-on-load defaults. The T window keeps working.
+- Shared-worktree commit care: explicit paths, never `git add -A`.
+- npm run gate under Node 24 (memory: node25-breaks-jsdom-gate); the known
+  armory browser-test failure aborts the gate early, finish tsc + builds
+  manually; PR CI is the arbiter.
+- package-lock.json regenerates ONLY via `npx npm@10 install
+  --package-lock-only`.
+
+## Validation matrix by change type
+
+- sim-only: `npx tsc --noEmit` + `npx vitest run tests/<affected>.ts` +
+  `npx vitest run tests/architecture.test.ts`; determinism check.
+- content-only: `npx tsc --noEmit` + `npx vitest run tests/progression.test.ts
+  tests/professions_crafting.test.ts` (+ referential suites for the touched
+  domain); `npm run wiki:content` if player-facing content changed.
+- server-only: relevant server suites + `npx tsc --noEmit` + `npm run
+  build:server`.
+- net/wire: `npx vitest run tests/snapshots.test.ts tests/env_protocol.test.ts
+  tests/bandwidth.test.ts tests/world_api_parity.test.ts`.
+- ui/render: `npx tsc --noEmit` + `npx vitest run
+  tests/localization_fixes.test.ts` (if text) + the mobile guard trio
+  (`tests/mobile_window_coverage.test.ts`, `mobile_window_transform.test.ts`,
+  `mobile_window_layout.test.ts`) + a mobile screenshot script.
+- i18n keys added: `npm run i18n:gen` then `npx vitest run
+  tests/i18n_completeness.test.ts tests/localization_fixes.test.ts`.
+- deeds content: `npx vitest run tests/deeds_content.test.ts tests/deeds.test.ts`.
+- icons/assets: the matching converter (`npm run assets:items` family) + its
+  bijection test; new GLBs need media manifest regen + `npm run asset:budget`
+  + registerPreload.
+- full-stack / pre-merge: `npm run gate` (Node 24; release-tier on release/**).
+- any code change: `npm run ci:changed`; format with a SCOPED
+  `npx @biomejs/biome check --write <file>`.
+
+## Key existing surfaces (verified 2026-07-16, release/v0.27.0 + PR 2039)
+
+- Craft skills: PlayerMeta.craftSkills; wheel math in
+  src/sim/professions/wheel.ts (TIER_SKILL_STEP=25, tierForSkill,
+  tierCapability, tierProgressMultiplier 1/0.5/0, materialCostMultiplier at
+  75 skill).
+- Archetype: src/sim/professions/archetype.ts (post-2039: attunedPairs,
+  archetypePairId, ARCHETYPE_PAIR_TARGETS, hobbyCandidatesForPair,
+  attuneArchetypePair, ceilings with explicit hobby). Combo gate:
+  src/sim/professions/combo_eligibility.ts (shared by resolver + UI).
+- Wire: cprof delta key -> IWorldProfessions.craftingIdentity
+  (CraftingIdentityView, atomic, synced flag). Existing prof/gprof/ncd/tfocus
+  self-wire keys are the pattern for any new key (ALL_DELTA_KEYS +
+  TERSE_TO_IWORLD pins in tests/snapshots.test.ts).
+- Quests: objective union has 'craft' and 'gather' (2039);
+  QuestDef.repeatable/completionEffect ('attunePair'|'switchHobby');
+  QuestProgress.selection + resolvedCounts; profession_quest_effects.ts.
+- Crafting: resolveCraftForRecipe gates = station (crafting_hub.ts),
+  combo_eligibility, isRecipeKnown (acquireRecipe, #1299), materials,
+  throttle + gold sink (#1301). NO skillReq admission gate.
+- Instances: ItemInstancePayload {signer, charges, rolled, boundTo} rides the
+  inv wire; bags/bank/equip/save-load correct; trade STRIPS payloads (Phase 3
+  bug); mail/market refuse instanced items (wave 2).
+- Gathering: nodes (harvestNode both hosts, ncd cooldowns), corpse harvesting
+  (claims + focus picker + town focus, tfocus), fixed corpse rarity baseline
+  40; node yields are placeholder junk until Phase 4.
+- Salvage/disenchant/enchant: sim-complete in salvage.ts / enchanting.ts;
+  lastSalvageResult/lastDisenchantResult/lastEnchantResult on PlayerMeta;
+  no IWorld/wire/UI until Phase 13 (salvage stays wave 2).
+- Stations today: requiresHubStation + CRAFTING_HUB_STATIONS (per-craft
+  coordinates, unrendered) + canUseCraftingHubStation.
+- Icons: iconDataUrl(kind, id, size), procedural recipes + WebP override sets
+  (ITEM_IMAGE_IDS / ABILITY_IMAGE_IDS / DEED_IMAGE_IDS), converters
+  npm run assets:items|skills|deeds, 128px WebP under public/ui/<set>/,
+  bijection tests. Designer slot recipe: see asset-manifest.json.
+- NPCs: NpcDef in ZONE{N}_NPCS (vendorItems, questIds, greeting); render via
+  NPC_KEYS in src/render/characters/manifest.ts (npc_villager fallback);
+  minimap glyphs automatic for kind 'npc'; vendor window pure-core pair under
+  src/ui/hud/vendor/.
+- Deeds recipe (the UX bar): docs/design/deeds.md + the 12-step recipe in the
+  packet recon; view core in UI_PURE_CORES, cold painter class, hot strips
+  separate, celebrations behind a pure gate, i18n by id with lazy locale
+  chunks, icons via category crest + bespoke recipes + WebP overrides.
+
+## New surfaces per phase
+
+(append as phases land: IWorld members, SimEvents, wire keys, commands,
+tables, i18n key namespaces, files created)
+
+- Phase 1: (planned) pair-title i18n keys hudChrome.archetypePair.*;
+  re-pinned ring geometry tests.
+- Phase 2: (planned) masterwork SimEvent; instance.rolled.masterwork;
+  masterwork proc rng-draw pin.
+- Phase 3: (planned) hcb wire key (corpse claims); trade payload carriage.
+- Phase 4: (planned) node material tables; pristine vein event + deed mark.
+- Phase 5: (planned) professions window (.window id professions-window) +
+  view core + painter + hudChrome.professions.* keys.
+- Phase 7: (planned) trend detection module; Guild letter content; S3 scan
+  list gains src/sim/quests/quest_commands.ts.
+- Phase 8: (planned) station registry (typed stations); master NpcDefs;
+  placement-safety test.
+- Phase 13: (planned) disenchantItem/applyEnchant IWorld members + wire
+  commands.
+
+## Tuning targets (placeholders until Phase 15 tunes against live data)
+
+- Masterwork proc: base 3 percent at recipe tier parity, +1 percent per tier
+  of skill above, +2 percent with any self-signed reagent, +3 percent at the
+  75-skill specialization threshold; cap 15 percent. Masterwork bonus: +1
+  quality tier for the stat budget, never above the raid floor band.
+- Training fees: common tier free (starter recipes), uncommon 25s, rare 1g.
+- Craft fee (#1301) and throttle: unchanged until live data.
+- Pristine vein: roughly 1 per zone per 20 minutes, 5x yield, always signed.
+
+## OPEN items
+
+- PR 2039 merge timing and who lands the Phase 1 amendments (same PR vs
+  immediate follow-up in one deploy window). Coordinate with the maintainer.
+- Exact FIELD_RECIPES membership (Phase 9 decides; default: the 9 common
+  recipes stay field-craftable so nothing breaks).
+- Master NPC names/personalities (content flavor, Phase 8; maintainer may
+  want a naming pass).
+- Whether fishing keeps a separate skill id or folds into professionsState
+  shape (Phase 11 decides; wire shape follows gprof pattern either way).

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -185,8 +185,10 @@ tables, i18n key namespaces, files created)
   session start (see implementation-plan.md guardrails) and uses the new
   vocabulary once it exists; until then, today's tokens, grammar-ready.
 
-- PR 2039 merge timing and who lands the Phase 1 amendments (same PR vs
-  immediate follow-up in one deploy window). Coordinate with the maintainer.
+- RESOLVED (2026-07-16): the maintainer owns the PR 2039 branch outright.
+  Phase 1 amendments (ring reorder, pair titles, review fixes, release sync,
+  commit-history cleanup) land ON the PR itself before it merges; no
+  merge-window coordination remains.
 - Exact FIELD_RECIPES membership (Phase 9 decides; default: the 9 common
   recipes stay field-craftable so nothing breaks).
 - Master NPC names/personalities (content flavor, Phase 8; maintainer may


### PR DESCRIPTION
## Summary

Adds the Professions 2.0 planning packet under docs/professions-2/: the phased implementation plan for completing the professions system per the 2026-07-16 maintainer brainstorm. 15 implementation phases with paired QA sessions (fun kernel: identity foundations on PR #2039, the masterwork model, parity bug fixes, node materials, the professions wheel window, crafting window legibility, the Guild letter; wave one: stations and master NPCs, recipe training, tier ladders for six crafts, fishing, tool tier gating, enchanting, attunement quests, deeds and tuning), plus the cross-phase state cheat sheet, whole-feature QA matrix, and a designer asset manifest (asset-manifest.json) cataloging every placeholder art slot with sizes, formats, and pipeline notes.

Docs only; no runtime behavior changes.

## Related issues

Part of #1866 (the professions epic; its body is being updated to point at this packet as the definition of done).

## Type of change

- [x] Documentation

## How was this tested?

- Commands: pre-push QA floor (tsc, guard tests, changed-files biome, copy rules) green under Node 24; packet scanned for em dashes, en dashes, and emojis (clean); Biome formatting applied to asset-manifest.json.
- Manual steps: every phase file verified against the feature-plan template structure (STEP 0 to 7 + stopping rules, QA structure, teardown step only in phase 15) by an independent review pass.

## Checklist

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files. (i18n.status.json was regenerated locally via `npm run i18n:gen` and is not committed.)
- N/A: This PR adds no player-visible strings, no UI, and no behavior; the gate's full run is not applicable to a docs-only packet (pre-push floor was green).
