### PR TITLE
fix(metrics): bound and isolate funnel refreshes

### DIFF
--- a/server/http/business_metrics.ts
+++ b/server/http/business_metrics.ts
@@ -1,15 +1,18 @@
-// Cached player and business gauges. The refresh reads only compact indexed
-// lifecycle facts through playerBusinessSnapshot(); Prometheus scrapes never
-// query Postgres, and the fixed period/segment/day labels bound cardinality.
+// Cached player and business gauges. Separate engagement and funnel refreshes
+// read compact indexed lifecycle facts; Prometheus scrapes never query Postgres,
+// and the fixed period/segment/day labels bound cardinality.
 
-import { Gauge, type Registry } from 'prom-client';
+import { Counter, Gauge, type Registry } from 'prom-client';
 import { pool } from '../db';
 import {
   DAY_ONE_FUNNEL_STAGES,
   FIRST_DAY_PLAYTIME_BUCKETS,
   type PlayerBusinessDay,
   type PlayerBusinessSnapshot,
+  type PlayerFunnelDay,
+  type PlayerFunnelSnapshot,
   playerBusinessSnapshot,
+  playerFunnelSnapshot,
 } from '../player_metrics_db';
 import { REALM } from '../realm';
 import { PeriodicCollector } from './periodic_collector';
@@ -27,18 +30,37 @@ export const WOC_PLAYER_FIRST_DAY_PLAYTIME_SECONDS = 'woc_player_first_day_playt
 export const WOC_PLAYER_FIRST_DAY_SESSIONS = 'woc_player_first_day_sessions';
 export const WOC_PLAYER_FIRST_DAY_PLAYTIME_ACCOUNTS = 'woc_player_first_day_playtime_accounts';
 export const WOC_PLAYER_FUNNEL_ACCOUNTS = 'woc_player_funnel_accounts';
+export const WOC_METRICS_COLLECTOR_REFRESH_FAILURES =
+  'woc_metrics_collector_refresh_failures_total';
+export const WOC_METRICS_COLLECTOR_SNAPSHOT_AGE_SECONDS =
+  'woc_metrics_collector_snapshot_age_seconds';
 
-/** Business data changes slowly; one bounded database sample every 15 minutes is enough. */
+/** Business data changes slowly; each bounded snapshot refreshes every 15 minutes. */
 export const BUSINESS_METRICS_REFRESH_MS = 15 * 60_000;
+/** Keep the two bounded snapshots from competing for a pooled client in one process. */
+export const FUNNEL_METRICS_INITIAL_DELAY_MS = 5_000;
 
 const PERIODS = ['today', 'yesterday'] as const;
 const PLAYTIME_SEGMENTS = ['all', 'new', 'level_20'] as const;
 const FIRST_SESSION_LEVELS = [2, 5] as const;
 const RETENTION_DAYS = [1, 7, 30] as const;
 
-export type BusinessMetricsCollector = PeriodicCollector<PlayerBusinessSnapshot>;
+export interface BusinessMetricQueries {
+  business: () => Promise<PlayerBusinessSnapshot>;
+  funnel: () => Promise<PlayerFunnelSnapshot>;
+}
+
+export interface BusinessMetricsCollector {
+  refresh(): Promise<void>;
+  start(): void;
+  stop(): Promise<void>;
+}
 
 function dayFor(snapshot: PlayerBusinessSnapshot, period: string): PlayerBusinessDay | undefined {
+  return snapshot.days.find((day) => day.period === period);
+}
+
+function funnelDayFor(snapshot: PlayerFunnelSnapshot, period: string): PlayerFunnelDay | undefined {
   return snapshot.days.find((day) => day.period === period);
 }
 
@@ -52,10 +74,47 @@ function setIfPresent(
 
 export function registerBusinessMetrics(
   registry: Registry,
-  query: () => Promise<PlayerBusinessSnapshot> = () => playerBusinessSnapshot(pool, REALM),
+  queries: BusinessMetricQueries = {
+    business: () => playerBusinessSnapshot(pool, REALM),
+    funnel: () => playerFunnelSnapshot(pool, REALM),
+  },
   intervalMs: number = BUSINESS_METRICS_REFRESH_MS,
+  funnelInitialDelayMs: number = FUNNEL_METRICS_INITIAL_DELAY_MS,
 ): BusinessMetricsCollector {
-  const collector = new PeriodicCollector(query, intervalMs);
+  const refreshFailures = new Counter({
+    name: WOC_METRICS_COLLECTOR_REFRESH_FAILURES,
+    help: 'Failed refresh attempts for a cached database-backed metrics collector.',
+    labelNames: ['collector'],
+    registers: [registry],
+  });
+  const onError = (collector: 'engagement' | 'funnel') => (err: unknown) => {
+    refreshFailures.inc({ collector });
+    console.error(`metrics collector refresh failed (${collector}):`, err);
+  };
+  const engagementCollector = new PeriodicCollector(
+    queries.business,
+    intervalMs,
+    onError('engagement'),
+  );
+  const funnelCollector = new PeriodicCollector(queries.funnel, intervalMs, onError('funnel'));
+
+  new Gauge({
+    name: WOC_METRICS_COLLECTOR_SNAPSHOT_AGE_SECONDS,
+    help: 'Age in seconds of the last successful cached database-backed metrics snapshot.',
+    labelNames: ['collector'],
+    registers: [registry],
+    collect() {
+      for (const [name, collector] of [
+        ['engagement', engagementCollector],
+        ['funnel', funnelCollector],
+      ] as const) {
+        const refreshedAt = collector.lastSuccessfulRefreshAtMs();
+        if (refreshedAt !== null) {
+          this.set({ collector: name }, Math.max(0, (Date.now() - refreshedAt) / 1_000));
+        }
+      }
+    },
+  });
 
   new Gauge({
     name: WOC_PLAYER_ACCOUNTS_CREATED,
@@ -64,10 +123,10 @@ export function registerBusinessMetrics(
     registers: [registry],
     collect() {
       this.reset();
-      const snapshot = collector.current();
+      const snapshot = funnelCollector.current();
       if (!snapshot) return;
       for (const period of PERIODS) {
-        const day = dayFor(snapshot, period);
+        const day = funnelDayFor(snapshot, period);
         if (day) this.set({ period }, day.accountsCreated);
       }
     },
@@ -80,7 +139,7 @@ export function registerBusinessMetrics(
     registers: [registry],
     collect() {
       this.reset();
-      const snapshot = collector.current();
+      const snapshot = engagementCollector.current();
       if (!snapshot) return;
       for (const period of PERIODS) {
         const day = dayFor(snapshot, period);
@@ -96,7 +155,7 @@ export function registerBusinessMetrics(
     registers: [registry],
     collect() {
       this.reset();
-      const snapshot = collector.current();
+      const snapshot = engagementCollector.current();
       if (!snapshot) return;
       for (const period of PERIODS) {
         const day = dayFor(snapshot, period);
@@ -112,10 +171,10 @@ export function registerBusinessMetrics(
     registers: [registry],
     collect() {
       this.reset();
-      const snapshot = collector.current();
+      const snapshot = funnelCollector.current();
       if (!snapshot) return;
       for (const period of PERIODS) {
-        const day = dayFor(snapshot, period);
+        const day = funnelDayFor(snapshot, period);
         if (day) setIfPresent(this, { period }, day.firstWorldEntryRate);
       }
     },
@@ -128,7 +187,7 @@ export function registerBusinessMetrics(
     registers: [registry],
     collect() {
       this.reset();
-      const snapshot = collector.current();
+      const snapshot = engagementCollector.current();
       if (!snapshot) return;
       for (const period of PERIODS) {
         const day = dayFor(snapshot, period);
@@ -146,7 +205,7 @@ export function registerBusinessMetrics(
     registers: [registry],
     collect() {
       this.reset();
-      const snapshot = collector.current();
+      const snapshot = engagementCollector.current();
       if (!snapshot) return;
       for (const period of PERIODS) {
         const day = dayFor(snapshot, period);
@@ -170,7 +229,7 @@ export function registerBusinessMetrics(
     registers: [registry],
     collect() {
       this.reset();
-      const snapshot = collector.current();
+      const snapshot = engagementCollector.current();
       if (!snapshot) return;
       for (const period of PERIODS) {
         const day = dayFor(snapshot, period);
@@ -186,7 +245,7 @@ export function registerBusinessMetrics(
     registers: [registry],
     collect() {
       this.reset();
-      const snapshot = collector.current();
+      const snapshot = engagementCollector.current();
       if (!snapshot) return;
       for (const period of PERIODS) {
         const day = dayFor(snapshot, period);
@@ -209,7 +268,7 @@ export function registerBusinessMetrics(
     registers: [registry],
     collect() {
       this.reset();
-      const snapshot = collector.current();
+      const snapshot = engagementCollector.current();
       if (!snapshot) return;
       for (const period of PERIODS) {
         for (const day of RETENTION_DAYS) {
@@ -229,7 +288,7 @@ export function registerBusinessMetrics(
     registers: [registry],
     collect() {
       this.reset();
-      const snapshot = collector.current();
+      const snapshot = engagementCollector.current();
       if (!snapshot) return;
       for (const period of PERIODS) {
         const day = dayFor(snapshot, period);
@@ -247,7 +306,7 @@ export function registerBusinessMetrics(
     registers: [registry],
     collect() {
       this.reset();
-      const snapshot = collector.current();
+      const snapshot = engagementCollector.current();
       if (!snapshot) return;
       for (const period of PERIODS) {
         const day = dayFor(snapshot, period);
@@ -263,7 +322,7 @@ export function registerBusinessMetrics(
     registers: [registry],
     collect() {
       this.reset();
-      const snapshot = collector.current();
+      const snapshot = engagementCollector.current();
       if (!snapshot) return;
       for (const period of PERIODS) {
         const day = dayFor(snapshot, period);
@@ -282,10 +341,10 @@ export function registerBusinessMetrics(
     registers: [registry],
     collect() {
       this.reset();
-      const snapshot = collector.current();
+      const snapshot = funnelCollector.current();
       if (!snapshot) return;
       for (const period of PERIODS) {
-        const day = dayFor(snapshot, period);
+        const day = funnelDayFor(snapshot, period);
         if (!day) continue;
         for (const stage of DAY_ONE_FUNNEL_STAGES) {
           this.set({ period, stage }, day.dayOneFunnelAccounts[stage]);
@@ -294,5 +353,20 @@ export function registerBusinessMetrics(
     },
   });
 
-  return collector;
+  return {
+    async refresh() {
+      await engagementCollector.refresh();
+      await funnelCollector.refresh();
+    },
+    start() {
+      engagementCollector.start();
+      funnelCollector.start(funnelInitialDelayMs);
+    },
+    async stop() {
+      const engagementStop = engagementCollector.stop();
+      const funnelStop = funnelCollector.stop();
+      await engagementStop;
+      await funnelStop;
+    },
+  };
 }

--- a/server/http/periodic_collector.ts
+++ b/server/http/periodic_collector.ts
@@ -23,6 +23,8 @@
  */
 export class PeriodicCollector<T> {
   private snapshot: T | null = null;
+  private lastSuccessAtMs: number | null = null;
+  private initialTimer: ReturnType<typeof setTimeout> | null = null;
   private timer: ReturnType<typeof setInterval> | null = null;
   private inFlight: Promise<T | null> | null = null;
 
@@ -44,6 +46,11 @@ export class PeriodicCollector<T> {
     return this.snapshot;
   }
 
+  /** Wall-clock time of the last successful refresh, or null before the first one. */
+  lastSuccessfulRefreshAtMs(): number | null {
+    return this.lastSuccessAtMs;
+  }
+
   /**
    * Run the query once and cache the result. Never throws: a failed query is
    * reported via onError and leaves the previous snapshot in place. Returns the
@@ -54,6 +61,7 @@ export class PeriodicCollector<T> {
     const run = (async () => {
       try {
         this.snapshot = await this.query();
+        this.lastSuccessAtMs = Date.now();
       } catch (err) {
         this.onError(err);
       }
@@ -68,19 +76,33 @@ export class PeriodicCollector<T> {
   }
 
   /**
-   * Kick off an immediate refresh and then repeat every intervalMs. The interval is
-   * unref()'d so it never keeps the process alive on its own (mirrors the other boot
-   * intervals in main.ts). Idempotent: a second start() is a no-op while running.
+   * Kick off a refresh after the optional delay and then repeat every intervalMs.
+   * The interval is unref()'d so it never keeps the process alive on its own
+   * (mirrors the other boot intervals in main.ts). Idempotent: a second start() is
+   * a no-op while running.
    */
-  start(): void {
-    if (this.timer) return;
-    void this.refresh();
-    this.timer = setInterval(() => void this.refresh(), this.intervalMs);
-    this.timer.unref();
+  start(initialDelayMs = 0): void {
+    if (this.initialTimer || this.timer) return;
+    const begin = () => {
+      this.initialTimer = null;
+      void this.refresh();
+      this.timer = setInterval(() => void this.refresh(), this.intervalMs);
+      this.timer.unref();
+    };
+    if (initialDelayMs <= 0) {
+      begin();
+      return;
+    }
+    this.initialTimer = setTimeout(begin, initialDelayMs);
+    this.initialTimer.unref();
   }
 
   /** Stop the interval and wait for any current refresh to settle. */
   async stop(): Promise<void> {
+    if (this.initialTimer) {
+      clearTimeout(this.initialTimer);
+      this.initialTimer = null;
+    }
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;

--- a/server/main.ts
+++ b/server/main.ts
@@ -2752,10 +2752,10 @@ export async function startServer(): Promise<http.Server> {
   // tests/server/game_boot_order.test.ts pins against).
   registerLivenessSource(gameStateSource);
 
-  // Business gauges run one bounded, timeout-protected fact query every 15 minutes.
-  // Scrapes publish only the cached snapshot and never query Postgres. Client FPS
-  // stays available in the admin tooling but is intentionally not polled for the
-  // business dashboard.
+  // Business gauges use isolated, staggered, timeout-protected engagement and
+  // funnel snapshots every 15 minutes. Scrapes publish only cached data and never
+  // query Postgres. Client FPS stays available in the admin tooling but is
+  // intentionally not polled for the business dashboard.
   const businessMetrics = registerBusinessMetrics(httpMetrics.registry);
   businessMetrics.start();
 

--- a/server/player_metrics_db.ts
+++ b/server/player_metrics_db.ts
@@ -99,10 +99,8 @@ export type DayOneFunnelStage = (typeof DAY_ONE_FUNNEL_STAGES)[number];
 
 export interface PlayerBusinessDay {
   period: 'today' | 'yesterday';
-  accountsCreated: number;
   charactersCreated: number;
   firstCharacterAccounts: number;
-  firstWorldEntryRate: number | null;
   activeNew: number;
   activeReturning: number;
   avgPlaytimeSecondsAll: number | null;
@@ -115,6 +113,12 @@ export interface PlayerBusinessDay {
   firstDayPlaytimeP90Seconds: number | null;
   firstDaySessionsMedian: number | null;
   firstDayPlaytimeAccounts: Record<FirstDayPlaytimeBucket, number>;
+}
+
+export interface PlayerFunnelDay {
+  period: 'today' | 'yesterday';
+  accountsCreated: number;
+  firstWorldEntryRate: number | null;
   dayOneFunnelAccounts: Record<DayOneFunnelStage, number>;
 }
 
@@ -129,6 +133,10 @@ export interface PlayerBusinessSnapshot {
   retention: PlayerRetentionMetric[];
 }
 
+export interface PlayerFunnelSnapshot {
+  days: PlayerFunnelDay[];
+}
+
 interface Queryable {
   query(text: string, values?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
 }
@@ -136,8 +144,8 @@ interface Queryable {
 /** Whole-refresh deadline, including waiting for a pooled client. */
 export const PLAYER_BUSINESS_SNAPSHOT_TIMEOUT_MS = 3_000;
 
-function snapshotTimeoutError(): Error {
-  return new Error('player business snapshot timed out');
+function snapshotTimeoutError(snapshotName = 'player metrics snapshot'): Error {
+  return new Error(`${snapshotName} timed out`);
 }
 
 /**
@@ -433,64 +441,6 @@ WITH days(period, day) AS (
              AND first_character_at >= days.day
              AND first_character_at < days.day + 1) AS first_character_accounts
     FROM days
-), funnel AS (
-  -- Drive the signup funnel from the indexed accounts.created_at range so it
-  -- retains registrations with no lifecycle fact. Every later stage is the
-  -- subset of that same account-created cohort completing the stage that UTC
-  -- day. Realm facts and activity are primary-key lookups from those accounts.
-  SELECT days.period, funnel_stats.*
-    FROM days
-    CROSS JOIN LATERAL (
-      SELECT count(accounts.id)::int AS funnel_created,
-             count(facts.account_id) FILTER (
-               WHERE facts.first_character_at >= days.day
-                 AND facts.first_character_at < days.day + 1
-             )::int AS funnel_first_character,
-             count(facts.account_id) FILTER (
-               WHERE facts.first_character_at >= days.day
-                 AND facts.first_character_at < days.day + 1
-                 AND facts.first_play_at >= days.day
-                 AND facts.first_play_at < days.day + 1
-             )::int AS funnel_entered_world,
-             count(activity.account_id) FILTER (
-               WHERE facts.first_character_at >= days.day
-                 AND facts.first_character_at < days.day + 1
-                 AND facts.first_play_at >= days.day
-                 AND facts.first_play_at < days.day + 1
-                 AND activity.playtime_seconds >= 600
-             )::int AS funnel_played_10m,
-             count(activity.account_id) FILTER (
-               WHERE facts.first_character_at >= days.day
-                 AND facts.first_character_at < days.day + 1
-                 AND facts.first_play_at >= days.day
-                 AND facts.first_play_at < days.day + 1
-                 AND activity.max_level >= 2
-             )::int AS funnel_reached_level_2,
-             count(activity.account_id) FILTER (
-               WHERE facts.first_character_at >= days.day
-                 AND facts.first_character_at < days.day + 1
-                 AND facts.first_play_at >= days.day
-                 AND facts.first_play_at < days.day + 1
-                 AND activity.max_level >= 5
-             )::int AS funnel_reached_level_5
-        FROM accounts
-        LEFT JOIN LATERAL (
-          SELECT facts.account_id, facts.first_character_at, facts.first_play_at
-            FROM player_account_facts facts
-           WHERE facts.realm = $1 AND facts.account_id = accounts.id
-           LIMIT 1
-        ) AS facts ON true
-        LEFT JOIN LATERAL (
-          SELECT activity.account_id, activity.playtime_seconds, activity.max_level
-            FROM player_activity_daily activity
-           WHERE activity.realm = $1
-             AND activity.day = days.day
-             AND activity.account_id = accounts.id
-           LIMIT 1
-        ) AS activity ON true
-       WHERE accounts.created_at >= days.day
-         AND accounts.created_at < days.day + 1
-    ) AS funnel_stats
 ), activity AS (
   -- Keep active-account reads proportional to each selected day. The lateral
   -- range uses the activity primary key instead of letting a grouped two-day
@@ -597,11 +547,8 @@ WITH days(period, day) AS (
     ) AS retention_stats
 )
 SELECT daily.period,
-       funnel.funnel_created AS accounts_created,
        daily.characters_created,
        daily.first_character_accounts,
-       funnel.funnel_entered_world::double precision
-         / NULLIF(funnel.funnel_created, 0) AS first_world_entry_rate,
        day_one.active_new,
        GREATEST(activity.active_total - day_one.active_new, 0)::int AS active_returning,
        activity.avg_playtime_all,
@@ -618,29 +565,93 @@ SELECT daily.period,
        day_one.new_playtime_30m_1h,
        day_one.new_playtime_1h_3h,
        day_one.new_playtime_gte_3h,
-       funnel.funnel_first_character,
-       funnel.funnel_entered_world,
-       funnel.funnel_played_10m,
-       funnel.funnel_reached_level_2,
-       funnel.funnel_reached_level_5,
        (SELECT jsonb_object_agg(retention_day, retention_rate)
           FROM retention
          WHERE retention.period = daily.period) AS retention
   FROM daily
-  JOIN funnel USING (period)
   JOIN activity USING (period)
   JOIN first_sessions USING (period)
   JOIN day_one USING (period)
  ORDER BY CASE daily.period WHEN 'today' THEN 0 ELSE 1 END
 `;
 
+export const PLAYER_FUNNEL_SNAPSHOT_SQL = `
+WITH days(period, day) AS (
+  VALUES
+    ('today'::text, current_date),
+    ('yesterday'::text, current_date - 1)
+), created AS (
+  -- Count factless registrations with one contiguous accounts.created_at range
+  -- scan per selected day. Later stages never probe from this account rowset.
+  SELECT days.period, days.day, count(accounts.id)::int AS funnel_created
+    FROM days
+    LEFT JOIN accounts
+      ON accounts.created_at >= days.day
+     AND accounts.created_at < days.day + 1
+   GROUP BY days.period, days.day
+), first_character AS (
+  -- Start at the completed stage, not at every signup. account_created_at keeps
+  -- this on the same account-created cohort while first_character_at selects the
+  -- existing realm/day index before applying that residual cohort check.
+  SELECT days.period,
+         count(facts.account_id)::int AS funnel_first_character
+    FROM days
+    LEFT JOIN player_account_facts facts
+      ON facts.realm = $1
+     AND facts.first_character_at >= days.day
+     AND facts.first_character_at < days.day + 1
+     AND facts.account_created_at >= days.day
+     AND facts.account_created_at < days.day + 1
+   GROUP BY days.period
+), play_stages AS (
+  -- First-play and activity stages are one set join over the small completed
+  -- cohort. A factless signup never causes a facts or activity primary-key probe.
+  SELECT days.period,
+         count(facts.account_id)::int AS funnel_entered_world,
+         count(activity.account_id) FILTER (
+           WHERE activity.playtime_seconds >= 600
+         )::int AS funnel_played_10m,
+         count(activity.account_id) FILTER (
+           WHERE activity.max_level >= 2
+         )::int AS funnel_reached_level_2,
+         count(activity.account_id) FILTER (
+           WHERE activity.max_level >= 5
+         )::int AS funnel_reached_level_5
+    FROM days
+    LEFT JOIN player_account_facts facts
+      ON facts.realm = $1
+     AND facts.first_play_at >= days.day
+     AND facts.first_play_at < days.day + 1
+     AND facts.first_character_at >= days.day
+     AND facts.first_character_at < days.day + 1
+     AND facts.account_created_at >= days.day
+     AND facts.account_created_at < days.day + 1
+    LEFT JOIN player_activity_daily activity
+      ON activity.realm = $1
+     AND activity.day = days.day
+     AND activity.account_id = facts.account_id
+   GROUP BY days.period
+)
+SELECT created.period,
+       created.funnel_created AS accounts_created,
+       play_stages.funnel_entered_world::double precision
+         / NULLIF(created.funnel_created, 0) AS first_world_entry_rate,
+       first_character.funnel_first_character,
+       play_stages.funnel_entered_world,
+       play_stages.funnel_played_10m,
+       play_stages.funnel_reached_level_2,
+       play_stages.funnel_reached_level_5
+  FROM created
+  JOIN first_character USING (period)
+  JOIN play_stages USING (period)
+ ORDER BY CASE created.period WHEN 'today' THEN 0 ELSE 1 END
+`;
+
 function mapBusinessDay(row: Record<string, unknown>): PlayerBusinessDay {
   return {
     period: row.period === 'yesterday' ? 'yesterday' : 'today',
-    accountsCreated: Number(row.accounts_created ?? 0),
     charactersCreated: Number(row.characters_created ?? 0),
     firstCharacterAccounts: Number(row.first_character_accounts ?? 0),
-    firstWorldEntryRate: numberOrNull(row.first_world_entry_rate),
     activeNew: Number(row.active_new ?? 0),
     activeReturning: Number(row.active_returning ?? 0),
     avgPlaytimeSecondsAll: numberOrNull(row.avg_playtime_all),
@@ -659,6 +670,14 @@ function mapBusinessDay(row: Record<string, unknown>): PlayerBusinessDay {
       '1h_3h': Number(row.new_playtime_1h_3h ?? 0),
       gte_3h: Number(row.new_playtime_gte_3h ?? 0),
     },
+  };
+}
+
+function mapFunnelDay(row: Record<string, unknown>): PlayerFunnelDay {
+  return {
+    period: row.period === 'yesterday' ? 'yesterday' : 'today',
+    accountsCreated: Number(row.accounts_created ?? 0),
+    firstWorldEntryRate: numberOrNull(row.first_world_entry_rate),
     dayOneFunnelAccounts: {
       created: Number(row.accounts_created ?? 0),
       first_character: Number(row.funnel_first_character ?? 0),
@@ -682,14 +701,19 @@ function mapRetention(
   }));
 }
 
-/** Run the bounded snapshot under fail-fast database safety limits. */
-export async function playerBusinessSnapshot(
+/** Run one bounded metrics snapshot under the shared fail-fast database limits. */
+async function playerMetricsSnapshotRows(
   pool: Pool,
   realm: string,
-  timeoutMs: number = PLAYER_BUSINESS_SNAPSHOT_TIMEOUT_MS,
-): Promise<PlayerBusinessSnapshot> {
+  sql: string,
+  snapshotName: string,
+  timeoutMs: number,
+): Promise<Record<string, unknown>[]> {
   const deadline = new AbortController();
-  const timer = setTimeout(() => deadline.abort(snapshotTimeoutError()), Math.max(1, timeoutMs));
+  const timer = setTimeout(
+    () => deadline.abort(snapshotTimeoutError(snapshotName)),
+    Math.max(1, timeoutMs),
+  );
   timer.unref();
 
   let client: PoolClient | null = null;
@@ -710,14 +734,9 @@ export async function playerBusinessSnapshot(
     await client.query("SET LOCAL lock_timeout = '250ms'");
     await client.query("SET LOCAL statement_timeout = '2000ms'");
     await client.query("SET LOCAL TIME ZONE 'UTC'");
-    const res = await client.query(PLAYER_BUSINESS_SNAPSHOT_SQL, [realm]);
+    const res = await client.query(sql, [realm]);
     await client.query('COMMIT');
-    return {
-      days: res.rows.map((row) => mapBusinessDay(row as Record<string, unknown>)),
-      retention: res.rows.flatMap((row) =>
-        mapRetention(row.period === 'yesterday' ? 'yesterday' : 'today', row.retention),
-      ),
-    };
+    return res.rows as Record<string, unknown>[];
   } catch (err) {
     if (client && !released) await client.query('ROLLBACK').catch(() => {});
     if (deadline.signal.aborted && deadline.signal.reason instanceof Error) {
@@ -729,4 +748,39 @@ export async function playerBusinessSnapshot(
     deadline.signal.removeEventListener('abort', abortActiveClient);
     releaseClient();
   }
+}
+
+export async function playerBusinessSnapshot(
+  pool: Pool,
+  realm: string,
+  timeoutMs: number = PLAYER_BUSINESS_SNAPSHOT_TIMEOUT_MS,
+): Promise<PlayerBusinessSnapshot> {
+  const rows = await playerMetricsSnapshotRows(
+    pool,
+    realm,
+    PLAYER_BUSINESS_SNAPSHOT_SQL,
+    'player business snapshot',
+    timeoutMs,
+  );
+  return {
+    days: rows.map(mapBusinessDay),
+    retention: rows.flatMap((row) =>
+      mapRetention(row.period === 'yesterday' ? 'yesterday' : 'today', row.retention),
+    ),
+  };
+}
+
+export async function playerFunnelSnapshot(
+  pool: Pool,
+  realm: string,
+  timeoutMs: number = PLAYER_BUSINESS_SNAPSHOT_TIMEOUT_MS,
+): Promise<PlayerFunnelSnapshot> {
+  const rows = await playerMetricsSnapshotRows(
+    pool,
+    realm,
+    PLAYER_FUNNEL_SNAPSHOT_SQL,
+    'player funnel snapshot',
+    timeoutMs,
+  );
+  return { days: rows.map(mapFunnelDay) };
 }

--- a/tests/player_metrics_db.test.ts
+++ b/tests/player_metrics_db.test.ts
@@ -5,9 +5,11 @@ import {
   DAY_ONE_FUNNEL_STAGES,
   openPlayerSession,
   PLAYER_BUSINESS_SNAPSHOT_SQL,
+  PLAYER_FUNNEL_SNAPSHOT_SQL,
   PLAYER_METRICS_CONCURRENT_INDEX_SQL,
   PLAYER_METRICS_SCHEMA,
   playerBusinessSnapshot,
+  playerFunnelSnapshot,
   recordCharacterCreation,
 } from '../server/player_metrics_db';
 
@@ -103,7 +105,7 @@ describe('player business snapshot safety', () => {
     expect(PLAYER_BUSINESS_SNAPSHOT_SQL).not.toMatch(/FROM characters\b/);
   });
 
-  it('bounds first-play engagement and the account-created funnel to indexed daily cohorts', () => {
+  it('keeps first-play engagement separate from the account-created funnel', () => {
     expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS playtime_p50_new');
     expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS playtime_p90_new');
     expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS sessions_p50_new');
@@ -115,18 +117,23 @@ describe('player business snapshot safety', () => {
     expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toMatch(
       /WHERE facts\.realm = \$1\s+AND facts\.first_play_at >= days\.day/,
     );
-    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS funnel_created');
-    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS funnel_first_character');
-    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS funnel_entered_world');
-    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS funnel_played_10m');
-    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS funnel_reached_level_2');
-    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('AS funnel_reached_level_5');
-    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('FROM accounts');
-    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('facts.account_id = accounts.id');
-    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('activity.account_id = accounts.id');
-    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('accounts.created_at >= days.day');
-    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).toContain('accounts.created_at < days.day + 1');
-    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).not.toContain('facts.account_created_at');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).not.toContain('AS funnel_created');
+    expect(PLAYER_BUSINESS_SNAPSHOT_SQL).not.toContain('FROM accounts');
+
+    expect(PLAYER_FUNNEL_SNAPSHOT_SQL).toContain('AS funnel_created');
+    expect(PLAYER_FUNNEL_SNAPSHOT_SQL).toContain('AS funnel_first_character');
+    expect(PLAYER_FUNNEL_SNAPSHOT_SQL).toContain('AS funnel_entered_world');
+    expect(PLAYER_FUNNEL_SNAPSHOT_SQL).toContain('AS funnel_played_10m');
+    expect(PLAYER_FUNNEL_SNAPSHOT_SQL).toContain('AS funnel_reached_level_2');
+    expect(PLAYER_FUNNEL_SNAPSHOT_SQL).toContain('AS funnel_reached_level_5');
+    expect(PLAYER_FUNNEL_SNAPSHOT_SQL).toContain('accounts.created_at >= days.day');
+    expect(PLAYER_FUNNEL_SNAPSHOT_SQL).toContain('facts.first_character_at >= days.day');
+    expect(PLAYER_FUNNEL_SNAPSHOT_SQL).toContain('facts.first_play_at >= days.day');
+    expect(PLAYER_FUNNEL_SNAPSHOT_SQL).toContain('facts.account_created_at >= days.day');
+    expect(PLAYER_FUNNEL_SNAPSHOT_SQL).toContain('activity.account_id = facts.account_id');
+    expect(PLAYER_FUNNEL_SNAPSHOT_SQL).not.toContain('facts.account_id = accounts.id');
+    expect(PLAYER_FUNNEL_SNAPSHOT_SQL).not.toContain('activity.account_id = accounts.id');
+    expect(PLAYER_FUNNEL_SNAPSHOT_SQL).not.toContain('LEFT JOIN LATERAL');
     expect(DAY_ONE_FUNNEL_STAGES).toEqual([
       'created',
       'first_character',
@@ -144,10 +151,8 @@ describe('player business snapshot safety', () => {
           rows: [
             {
               period: 'today',
-              accounts_created: 2,
               characters_created: 3,
               first_character_accounts: 2,
-              first_world_entry_rate: 0.5,
               active_new: 1,
               active_returning: 4,
               avg_playtime_all: 100,
@@ -164,19 +169,12 @@ describe('player business snapshot safety', () => {
               new_playtime_30m_1h: 0,
               new_playtime_1h_3h: 0,
               new_playtime_gte_3h: 0,
-              funnel_first_character: 1,
-              funnel_entered_world: 1,
-              funnel_played_10m: 0,
-              funnel_reached_level_2: 1,
-              funnel_reached_level_5: 0,
               retention: { 1: 0.4, 7: null, 30: null },
             },
             {
               period: 'yesterday',
-              accounts_created: 1,
               characters_created: 1,
               first_character_accounts: 1,
-              first_world_entry_rate: 1,
               active_new: 1,
               active_returning: 0,
               avg_playtime_all: 80,
@@ -193,11 +191,6 @@ describe('player business snapshot safety', () => {
               new_playtime_30m_1h: 0,
               new_playtime_1h_3h: 1,
               new_playtime_gte_3h: 0,
-              funnel_first_character: 1,
-              funnel_entered_world: 1,
-              funnel_played_10m: 1,
-              funnel_reached_level_2: 1,
-              funnel_reached_level_5: 1,
               retention: { 1: 0.6, 7: 0.3, 30: null },
             },
           ],
@@ -221,10 +214,8 @@ describe('player business snapshot safety', () => {
     expect(query.mock.calls[4][1]).toEqual(['eastbrook']);
     expect(result.days[0]).toMatchObject({
       period: 'today',
-      accountsCreated: 2,
       charactersCreated: 3,
       firstCharacterAccounts: 2,
-      firstWorldEntryRate: 0.5,
       activeNew: 1,
       activeReturning: 4,
       avgPlaytimeSecondsAll: 100,
@@ -243,14 +234,6 @@ describe('player business snapshot safety', () => {
         '1h_3h': 0,
         gte_3h: 0,
       },
-      dayOneFunnelAccounts: {
-        created: 2,
-        first_character: 1,
-        entered_world: 1,
-        played_10m: 0,
-        reached_level_2: 1,
-        reached_level_5: 0,
-      },
     });
     expect(result.days[1]).toMatchObject({
       period: 'yesterday',
@@ -264,14 +247,6 @@ describe('player business snapshot safety', () => {
         '1h_3h': 1,
         gte_3h: 0,
       },
-      dayOneFunnelAccounts: {
-        created: 1,
-        first_character: 1,
-        entered_world: 1,
-        played_10m: 1,
-        reached_level_2: 1,
-        reached_level_5: 1,
-      },
     });
     expect(result.retention).toEqual([
       { period: 'today', day: 1, rate: 0.4 },
@@ -280,6 +255,81 @@ describe('player business snapshot safety', () => {
       { period: 'yesterday', day: 1, rate: 0.6 },
       { period: 'yesterday', day: 7, rate: 0.3 },
       { period: 'yesterday', day: 30, rate: null },
+    ]);
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it('runs and maps the isolated funnel under the same read-only safety limits', async () => {
+    const query = vi.fn(async (sql: string, _params?: unknown[]) => {
+      if (sql === PLAYER_FUNNEL_SNAPSHOT_SQL) {
+        return {
+          rows: [
+            {
+              period: 'today',
+              accounts_created: 2,
+              first_world_entry_rate: 0.5,
+              funnel_first_character: 1,
+              funnel_entered_world: 1,
+              funnel_played_10m: 0,
+              funnel_reached_level_2: 1,
+              funnel_reached_level_5: 0,
+            },
+            {
+              period: 'yesterday',
+              accounts_created: 1,
+              first_world_entry_rate: 1,
+              funnel_first_character: 1,
+              funnel_entered_world: 1,
+              funnel_played_10m: 1,
+              funnel_reached_level_2: 1,
+              funnel_reached_level_5: 1,
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+    const release = vi.fn();
+    const pool = { connect: vi.fn(async () => ({ query, release })) };
+
+    const result = await playerFunnelSnapshot(pool as never, 'eastbrook');
+
+    expect(query.mock.calls.map((call) => call[0])).toEqual([
+      'BEGIN READ ONLY',
+      "SET LOCAL lock_timeout = '250ms'",
+      "SET LOCAL statement_timeout = '2000ms'",
+      "SET LOCAL TIME ZONE 'UTC'",
+      PLAYER_FUNNEL_SNAPSHOT_SQL,
+      'COMMIT',
+    ]);
+    expect(query.mock.calls[4][1]).toEqual(['eastbrook']);
+    expect(result.days).toEqual([
+      {
+        period: 'today',
+        accountsCreated: 2,
+        firstWorldEntryRate: 0.5,
+        dayOneFunnelAccounts: {
+          created: 2,
+          first_character: 1,
+          entered_world: 1,
+          played_10m: 0,
+          reached_level_2: 1,
+          reached_level_5: 0,
+        },
+      },
+      {
+        period: 'yesterday',
+        accountsCreated: 1,
+        firstWorldEntryRate: 1,
+        dayOneFunnelAccounts: {
+          created: 1,
+          first_character: 1,
+          entered_world: 1,
+          played_10m: 1,
+          reached_level_2: 1,
+          reached_level_5: 1,
+        },
+      },
     ]);
     expect(release).toHaveBeenCalledOnce();
   });

--- a/tests/player_metrics_db_integration.test.ts
+++ b/tests/player_metrics_db_integration.test.ts
@@ -6,11 +6,13 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import {
   closePlayerSession,
   openPlayerSession,
+  PLAYER_FUNNEL_SNAPSHOT_SQL,
   PLAYER_METRICS_CONCURRENT_INDEX_SQL,
   PLAYER_METRICS_INVALID_INDEX_CHECK_SQL,
   PLAYER_METRICS_INVALID_INDEX_DROP_SQL,
   PLAYER_METRICS_SCHEMA,
   playerBusinessSnapshot,
+  playerFunnelSnapshot,
   recordCharacterCreation,
 } from '../server/player_metrics_db';
 
@@ -154,16 +156,19 @@ describeDb('player metrics lifecycle SQL (real Postgres)', () => {
     }
 
     const snapshot = await playerBusinessSnapshot(scopedPool(), 'eastbrook');
+    const funnelSnapshot = await playerFunnelSnapshot(scopedPool(), 'eastbrook');
     const today = snapshot.days.find((day) => day.period === 'today');
     expect(today).toMatchObject({
-      accountsCreated: 1,
       charactersCreated: 1,
       firstCharacterAccounts: 1,
-      firstWorldEntryRate: 1,
       activeNew: 1,
       activeReturning: 0,
       firstSessionLevel2Rate: 1,
       firstSessionLevel5Rate: 1,
+    });
+    expect(funnelSnapshot.days.find((day) => day.period === 'today')).toMatchObject({
+      accountsCreated: 1,
+      firstWorldEntryRate: 1,
       dayOneFunnelAccounts: {
         created: 1,
         first_character: 1,
@@ -188,14 +193,6 @@ describeDb('player metrics lifecycle SQL (real Postgres)', () => {
     expect(bucketTotal).toBe(today?.activeNew);
     const yesterday = snapshot.days.find((day) => day.period === 'yesterday');
     expect(yesterday).toMatchObject({
-      dayOneFunnelAccounts: {
-        created: 0,
-        first_character: 0,
-        entered_world: 0,
-        played_10m: 0,
-        reached_level_2: 0,
-        reached_level_5: 0,
-      },
       firstDayPlaytimeP50Seconds: null,
       firstDaySessionsMedian: null,
       firstDayPlaytimeAccounts: {
@@ -204,6 +201,18 @@ describeDb('player metrics lifecycle SQL (real Postgres)', () => {
         '30m_1h': 0,
         '1h_3h': 0,
         gte_3h: 0,
+      },
+    });
+    expect(funnelSnapshot.days.find((day) => day.period === 'yesterday')).toMatchObject({
+      accountsCreated: 0,
+      firstWorldEntryRate: null,
+      dayOneFunnelAccounts: {
+        created: 0,
+        first_character: 0,
+        entered_world: 0,
+        played_10m: 0,
+        reached_level_2: 0,
+        reached_level_5: 0,
       },
     });
     expect(snapshot.retention).toEqual([
@@ -263,11 +272,10 @@ describeDb('player metrics lifecycle SQL (real Postgres)', () => {
     }
 
     const snapshot = await playerBusinessSnapshot(scopedPool(), 'eastbrook');
+    const funnelSnapshot = await playerFunnelSnapshot(scopedPool(), 'eastbrook');
     const today = snapshot.days.find((day) => day.period === 'today');
     expect(today).toMatchObject({
-      accountsCreated: 5,
       firstCharacterAccounts: 4,
-      firstWorldEntryRate: 0.4,
       activeNew: 3,
       firstDaySessionsMedian: 1,
       firstDayPlaytimeAccounts: {
@@ -277,6 +285,11 @@ describeDb('player metrics lifecycle SQL (real Postgres)', () => {
         '1h_3h': 1,
         gte_3h: 0,
       },
+    });
+    const funnelToday = funnelSnapshot.days.find((day) => day.period === 'today');
+    expect(funnelToday).toMatchObject({
+      accountsCreated: 5,
+      firstWorldEntryRate: 0.4,
       dayOneFunnelAccounts: {
         created: 5,
         first_character: 3,
@@ -286,7 +299,7 @@ describeDb('player metrics lifecycle SQL (real Postgres)', () => {
         reached_level_5: 1,
       },
     });
-    const funnel = today?.dayOneFunnelAccounts;
+    const funnel = funnelToday?.dayOneFunnelAccounts;
     expect(funnel?.created).toBeGreaterThanOrEqual(funnel?.first_character ?? 0);
     expect(funnel?.first_character).toBeGreaterThanOrEqual(funnel?.entered_world ?? 0);
     expect(funnel?.entered_world).toBeGreaterThanOrEqual(funnel?.played_10m ?? 0);
@@ -294,6 +307,139 @@ describeDb('player metrics lifecycle SQL (real Postgres)', () => {
     expect(funnel?.reached_level_2).toBeGreaterThanOrEqual(funnel?.reached_level_5 ?? 0);
     expect(today?.firstDayPlaytimeP90Seconds).toBeGreaterThan(1200);
   });
+
+  it('keeps a launch-day factless signup spike set-based and inside the production timeout', async () => {
+    const db = await scopedClient();
+    try {
+      await db.query(
+        `INSERT INTO accounts (created_at)
+         SELECT CASE
+                  WHEN n <= 250000 THEN current_date + interval '1 hour'
+                  ELSE current_date - 1 + interval '1 hour'
+                END
+           FROM generate_series(1, 500000) AS generated(n)`,
+      );
+      await db.query(
+        `INSERT INTO player_account_facts (
+           realm, account_id, account_created_at, first_character_at, first_play_at
+         )
+         SELECT 'eastbrook', id, created_at,
+                created_at + interval '1 hour', created_at + interval '2 hours'
+           FROM (
+             (SELECT id, created_at
+                FROM accounts
+               WHERE created_at >= current_date
+               ORDER BY id
+               LIMIT 100)
+             UNION ALL
+             (SELECT id, created_at
+                FROM accounts
+               WHERE created_at >= current_date - 1
+                 AND created_at < current_date
+               ORDER BY id
+               LIMIT 100)
+           ) AS selected`,
+      );
+      await db.query(
+        `INSERT INTO player_account_facts (
+           realm, account_id, account_created_at, first_character_at, first_play_at
+         )
+         SELECT 'other', id, created_at,
+                created_at + interval '1 hour', created_at + interval '2 hours'
+           FROM accounts
+          ORDER BY id
+          LIMIT 10000`,
+      );
+      await db.query(
+        `INSERT INTO player_activity_daily (
+           realm, day, account_id, sessions, playtime_seconds, max_level
+         )
+         SELECT realm, account_created_at::date, account_id, 1, 1200, 5
+           FROM player_account_facts`,
+      );
+      await db.query('ANALYZE accounts');
+      await db.query('ANALYZE player_account_facts');
+      await db.query('ANALYZE player_activity_daily');
+    } finally {
+      db.release();
+    }
+
+    const snapshot = await playerFunnelSnapshot(scopedPool(), 'eastbrook');
+    expect(snapshot.days).toEqual([
+      {
+        period: 'today',
+        accountsCreated: 250000,
+        firstWorldEntryRate: 100 / 250000,
+        dayOneFunnelAccounts: {
+          created: 250000,
+          first_character: 100,
+          entered_world: 100,
+          played_10m: 100,
+          reached_level_2: 100,
+          reached_level_5: 100,
+        },
+      },
+      {
+        period: 'yesterday',
+        accountsCreated: 250000,
+        firstWorldEntryRate: 100 / 250000,
+        dayOneFunnelAccounts: {
+          created: 250000,
+          first_character: 100,
+          entered_world: 100,
+          played_10m: 100,
+          reached_level_2: 100,
+          reached_level_5: 100,
+        },
+      },
+    ]);
+
+    const planDb = await scopedClient();
+    try {
+      await planDb.query('BEGIN READ ONLY');
+      await planDb.query("SET LOCAL statement_timeout = '2000ms'");
+      await planDb.query("SET LOCAL work_mem = '4MB'");
+      const explained = await planDb.query(
+        `EXPLAIN (ANALYZE, BUFFERS, WAL, SETTINGS, FORMAT JSON)
+         ${PLAYER_FUNNEL_SNAPSHOT_SQL}`,
+        ['eastbrook'],
+      );
+      const root = explained.rows[0]['QUERY PLAN'][0] as Record<string, unknown>;
+      const nodes: Record<string, unknown>[] = [];
+      const visit = (node: Record<string, unknown>) => {
+        nodes.push(node);
+        for (const child of (node.Plans as Record<string, unknown>[] | undefined) ?? []) {
+          visit(child);
+        }
+      };
+      visit(root.Plan as Record<string, unknown>);
+
+      const factOrActivityScans = nodes.filter((node) =>
+        ['player_account_facts', 'player_activity_daily'].includes(String(node['Relation Name'])),
+      );
+      expect(factOrActivityScans.every((node) => Number(node['Actual Loops'] ?? 0) <= 200)).toBe(
+        true,
+      );
+      expect(nodes.some((node) => node['Index Name'] === 'accounts_created_at')).toBe(true);
+      expect(
+        nodes.some((node) => node['Index Name'] === 'player_account_facts_first_character'),
+      ).toBe(true);
+      expect(nodes.some((node) => node['Index Name'] === 'player_account_facts_first_play')).toBe(
+        true,
+      );
+      expect(nodes.some((node) => node['Index Name'] === 'player_activity_daily_pkey')).toBe(true);
+      expect(Number(root['Execution Time'])).toBeLessThan(2_000);
+      expect(nodes.reduce((total, node) => total + Number(node['Temp Read Blocks'] ?? 0), 0)).toBe(
+        0,
+      );
+      expect(
+        nodes.reduce((total, node) => total + Number(node['Temp Written Blocks'] ?? 0), 0),
+      ).toBe(0);
+    } finally {
+      await planDb.query('ROLLBACK').catch(() => {});
+      planDb.release();
+    }
+  }, 120_000);
 
   it('assigns exact first-day playtime boundaries to one bucket each', async () => {
     const db = await scopedClient();

--- a/tests/server/http/business_metrics.test.ts
+++ b/tests/server/http/business_metrics.test.ts
@@ -1,8 +1,11 @@
 import { Registry } from 'prom-client';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   BUSINESS_METRICS_REFRESH_MS,
+  FUNNEL_METRICS_INITIAL_DELAY_MS,
   registerBusinessMetrics,
+  WOC_METRICS_COLLECTOR_REFRESH_FAILURES,
+  WOC_METRICS_COLLECTOR_SNAPSHOT_AGE_SECONDS,
   WOC_PLAYER_ACCOUNTS_CREATED,
   WOC_PLAYER_CHARACTERS_CREATED,
   WOC_PLAYER_DAILY_ACTIVE_ACCOUNTS,
@@ -17,17 +20,23 @@ import {
   WOC_PLAYER_FUNNEL_ACCOUNTS,
   WOC_PLAYER_RETENTION_RATE,
 } from '../../../server/http/business_metrics';
-import type { PlayerBusinessSnapshot } from '../../../server/player_metrics_db';
+import type {
+  PlayerBusinessSnapshot,
+  PlayerFunnelSnapshot,
+} from '../../../server/player_metrics_db';
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
 
 function snapshot(): PlayerBusinessSnapshot {
   return {
     days: [
       {
         period: 'today',
-        accountsCreated: 12,
         charactersCreated: 18,
         firstCharacterAccounts: 9,
-        firstWorldEntryRate: 0.75,
         activeNew: 8,
         activeReturning: 21,
         avgPlaytimeSecondsAll: 1800,
@@ -46,21 +55,11 @@ function snapshot(): PlayerBusinessSnapshot {
           '1h_3h': 1,
           gte_3h: 0,
         },
-        dayOneFunnelAccounts: {
-          created: 12,
-          first_character: 9,
-          entered_world: 8,
-          played_10m: 3,
-          reached_level_2: 2,
-          reached_level_5: 1,
-        },
       },
       {
         period: 'yesterday',
-        accountsCreated: 10,
         charactersCreated: 14,
         firstCharacterAccounts: 7,
-        firstWorldEntryRate: 0.7,
         activeNew: 6,
         activeReturning: 20,
         avgPlaytimeSecondsAll: 1700,
@@ -79,14 +78,6 @@ function snapshot(): PlayerBusinessSnapshot {
           '1h_3h': 0,
           gte_3h: 1,
         },
-        dayOneFunnelAccounts: {
-          created: 10,
-          first_character: 7,
-          entered_world: 6,
-          played_10m: 2,
-          reached_level_2: 1,
-          reached_level_5: 0,
-        },
       },
     ],
     retention: [
@@ -100,6 +91,39 @@ function snapshot(): PlayerBusinessSnapshot {
   };
 }
 
+function funnelSnapshot(createdToday = 12): PlayerFunnelSnapshot {
+  return {
+    days: [
+      {
+        period: 'today',
+        accountsCreated: createdToday,
+        firstWorldEntryRate: 0.75,
+        dayOneFunnelAccounts: {
+          created: createdToday,
+          first_character: 9,
+          entered_world: 8,
+          played_10m: 3,
+          reached_level_2: 2,
+          reached_level_5: 1,
+        },
+      },
+      {
+        period: 'yesterday',
+        accountsCreated: 10,
+        firstWorldEntryRate: 0.7,
+        dayOneFunnelAccounts: {
+          created: 10,
+          first_character: 7,
+          entered_world: 6,
+          played_10m: 2,
+          reached_level_2: 1,
+          reached_level_5: 0,
+        },
+      },
+    ],
+  };
+}
+
 function sample(text: string, metric: string, labels: string): string | undefined {
   return text.match(new RegExp(`^${metric}\\{${labels}\\} ([^\\n]+)$`, 'm'))?.[1];
 }
@@ -107,13 +131,17 @@ function sample(text: string, metric: string, labels: string): string | undefine
 describe('registerBusinessMetrics', () => {
   it('refreshes the database snapshot no more often than every 15 minutes by default', () => {
     expect(BUSINESS_METRICS_REFRESH_MS).toBe(15 * 60_000);
+    expect(FUNNEL_METRICS_INITIAL_DELAY_MS).toBe(5_000);
   });
 
-  it('publishes the fixed player-business gauges from one cached snapshot', async () => {
+  it('publishes fixed engagement and funnel gauges from independent cached snapshots', async () => {
     const registry = new Registry();
-    const query = vi.fn(async () => snapshot());
-    const collector = registerBusinessMetrics(registry, query);
+    const business = vi.fn(async () => snapshot());
+    const funnel = vi.fn(async () => funnelSnapshot());
+    const collector = registerBusinessMetrics(registry, { business, funnel });
     await collector.refresh();
+    expect(business).toHaveBeenCalledTimes(1);
+    expect(funnel).toHaveBeenCalledTimes(1);
     const text = await registry.metrics();
 
     expect(WOC_PLAYER_ACCOUNTS_CREATED).toBe('woc_player_accounts_created');
@@ -187,12 +215,14 @@ describe('registerBusinessMetrics', () => {
 
   it('never queries on scrape and bounds every label value', async () => {
     const registry = new Registry();
-    const query = vi.fn(async () => snapshot());
-    const collector = registerBusinessMetrics(registry, query);
+    const business = vi.fn(async () => snapshot());
+    const funnel = vi.fn(async () => funnelSnapshot());
+    const collector = registerBusinessMetrics(registry, { business, funnel });
     await collector.refresh();
 
     for (let i = 0; i < 20; i++) await registry.metrics();
-    expect(query).toHaveBeenCalledTimes(1);
+    expect(business).toHaveBeenCalledTimes(1);
+    expect(funnel).toHaveBeenCalledTimes(1);
 
     const text = await registry.metrics();
     const labelValues = (label: string) =>
@@ -220,12 +250,139 @@ describe('registerBusinessMetrics', () => {
     }
   });
 
+  it('keeps engagement fresh when the isolated funnel refresh fails and later recovers', async () => {
+    const registry = new Registry();
+    let charactersCreated = 18;
+    let createdToday = 12;
+    let failFunnel = false;
+    const business = vi.fn(async () => {
+      const value = snapshot();
+      const today = value.days.find((day) => day.period === 'today');
+      if (today) today.charactersCreated = charactersCreated;
+      return value;
+    });
+    const funnel = vi.fn(async () => {
+      if (failFunnel) throw new Error('funnel timeout');
+      return funnelSnapshot(createdToday);
+    });
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const collector = registerBusinessMetrics(registry, { business, funnel });
+
+    await collector.refresh();
+    charactersCreated = 24;
+    createdToday = 15;
+    failFunnel = true;
+    await collector.refresh();
+
+    let text = await registry.metrics();
+    expect(sample(text, WOC_PLAYER_CHARACTERS_CREATED, 'period="today"')).toBe('24');
+    expect(sample(text, WOC_PLAYER_ACCOUNTS_CREATED, 'period="today"')).toBe('12');
+    expect(sample(text, WOC_METRICS_COLLECTOR_REFRESH_FAILURES, 'collector="funnel"')).toBe('1');
+    expect(error).toHaveBeenCalledTimes(1);
+
+    failFunnel = false;
+    await collector.refresh();
+    text = await registry.metrics();
+    expect(sample(text, WOC_PLAYER_ACCOUNTS_CREATED, 'period="today"')).toBe('15');
+    expect(business).toHaveBeenCalledTimes(3);
+    expect(funnel).toHaveBeenCalledTimes(3);
+    error.mockRestore();
+  });
+
+  it('publishes snapshot age and phases the funnel refresh after engagement', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-17T00:00:00Z'));
+    const registry = new Registry();
+    const calls: string[] = [];
+    const collector = registerBusinessMetrics(
+      registry,
+      {
+        business: vi.fn(async () => {
+          calls.push(`engagement:${Date.now()}`);
+          return snapshot();
+        }),
+        funnel: vi.fn(async () => {
+          calls.push(`funnel:${Date.now()}`);
+          return funnelSnapshot();
+        }),
+      },
+      60_000,
+      5_000,
+    );
+
+    collector.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls).toEqual(['engagement:1784246400000']);
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(calls).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(calls).toEqual(['engagement:1784246400000', 'funnel:1784246405000']);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    const text = await registry.metrics();
+    expect(
+      Number(sample(text, WOC_METRICS_COLLECTOR_SNAPSHOT_AGE_SECONDS, 'collector="engagement"')),
+    ).toBe(15);
+    expect(
+      Number(sample(text, WOC_METRICS_COLLECTOR_SNAPSHOT_AGE_SECONDS, 'collector="funnel"')),
+    ).toBe(10);
+
+    await vi.advanceTimersByTimeAsync(45_000);
+    expect(calls).toEqual([
+      'engagement:1784246400000',
+      'funnel:1784246405000',
+      'engagement:1784246460000',
+    ]);
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(calls).toHaveLength(3);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(calls).toEqual([
+      'engagement:1784246400000',
+      'funnel:1784246405000',
+      'engagement:1784246460000',
+      'funnel:1784246465000',
+    ]);
+
+    await collector.stop();
+    vi.useRealTimers();
+  });
+
+  it('keeps snapshot age anchored to the last successful refresh after a failure', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-17T00:00:00Z'));
+    const registry = new Registry();
+    let failFunnel = false;
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const collector = registerBusinessMetrics(registry, {
+      business: vi.fn(async () => snapshot()),
+      funnel: vi.fn(async () => {
+        if (failFunnel) throw new Error('funnel timeout');
+        return funnelSnapshot();
+      }),
+    });
+
+    await collector.refresh();
+    await vi.advanceTimersByTimeAsync(15_000);
+    failFunnel = true;
+    await collector.refresh();
+
+    const text = await registry.metrics();
+    expect(
+      Number(sample(text, WOC_METRICS_COLLECTOR_SNAPSHOT_AGE_SECONDS, 'collector="engagement"')),
+    ).toBe(0);
+    expect(
+      Number(sample(text, WOC_METRICS_COLLECTOR_SNAPSHOT_AGE_SECONDS, 'collector="funnel"')),
+    ).toBe(15);
+    expect(sample(text, WOC_METRICS_COLLECTOR_REFRESH_FAILURES, 'collector="funnel"')).toBe('1');
+    expect(error).toHaveBeenCalledTimes(1);
+  });
+
   it('publishes no labeled samples before the first successful refresh', async () => {
     const registry = new Registry();
-    registerBusinessMetrics(
-      registry,
-      vi.fn(async () => snapshot()),
-    );
+    registerBusinessMetrics(registry, {
+      business: vi.fn(async () => snapshot()),
+      funnel: vi.fn(async () => funnelSnapshot()),
+    });
     const text = await registry.metrics();
     expect(text).not.toMatch(/^woc_player_.*\{/m);
   });

--- a/tests/server/http/periodic_collector.test.ts
+++ b/tests/server/http/periodic_collector.test.ts
@@ -4,8 +4,12 @@
 // snapshot rather than throwing into the timer. These are the caching + resilience
 // guarantees both the business and client-perf collectors rely on.
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { PeriodicCollector } from '../../../server/http/periodic_collector';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('PeriodicCollector', () => {
   it('starts null and caches the result of a refresh', async () => {
@@ -13,8 +17,10 @@ describe('PeriodicCollector', () => {
     const collector = new PeriodicCollector(query, 60_000);
 
     expect(collector.current()).toBeNull();
+    expect(collector.lastSuccessfulRefreshAtMs()).toBeNull();
     await collector.refresh();
     expect(collector.current()).toBe(7);
+    expect(collector.lastSuccessfulRefreshAtMs()).not.toBeNull();
   });
 
   it('re-runs the query on each refresh and publishes the newest value', async () => {
@@ -97,5 +103,18 @@ describe('PeriodicCollector', () => {
     resolve(4);
     await stopping;
     expect(stopped).toBe(true);
+  });
+
+  it('can phase the initial refresh and cancel it before it starts', async () => {
+    vi.useFakeTimers();
+    const query = vi.fn(async () => 5);
+    const collector = new PeriodicCollector(query, 60_000);
+
+    collector.start(5_000);
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(query).not.toHaveBeenCalled();
+    await collector.stop();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(query).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Replace the account-driven lifecycle probes identified in the post-merge review of #2042 with set-based reads over indexed day cohorts.
- Preserve factless signup counts while bounding facts and activity work to players who completed each stage.
- Isolate engagement and funnel refreshes into staggered caches with the existing 2-second statement and 3-second whole-refresh deadlines.
- Expose bounded refresh-failure and snapshot-age metrics so stale data is visible.
- Companion Grafana PR: levy-street/woc-deploy#22.

## Related issues

Follow-up to #2042 and the post-merge performance review from Fernando.

## Type of change

- [x] Bug fix
- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- `npx vitest run tests/player_metrics_db.test.ts tests/server/http/periodic_collector.test.ts tests/server/http/business_metrics.test.ts`: 26 passed.
- PostgreSQL 16 integration suite: 7 passed, including 500,000 registrations with only 200 relevant lifecycle facts under the production timeout and 4 MB work memory.
- `npm run ci:changed`: passed.
- `npx tsc --noEmit`: passed.
- Pre-push QA floor: 53 passed, 3 skipped; typecheck, lint, and copy rules passed.
- Required finished-diff database-performance, security, and test-coverage reviews: READY.
- `npm run gate` reached the full suite and stopped with 13 failures in nine untouched test files out of 14,804 tests. The two simulation/mail timeouts passed when rerun alone. The remaining failures reproduce in isolation on this machine from locale `24:00`, missing global `WebSocket`, and fake-Docker watchdog behavior. No metrics test failed.

## Checklist

### Quality

- [ ] The full gate passes. See the unrelated local-environment failures documented above.

### Localization

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I did not hand-edit generated files.