### PR TITLE
fix(sim): stop mob disarm procs from chain-refreshing past their duration

### DIFF
--- a/src/sim/mob/mob_swing.ts
+++ b/src/sim/mob/mob_swing.ts
@@ -301,13 +301,18 @@ export function runMobSwingAffixes(
   // disarm: a brutal swing can knock the weapon from a player's grip, suppressing
   // their auto-attack for a duration. Players only (only they run the primary-target
   // auto-attack path) and hostile only, so a friendly pet (mobSwing's other caller)
-  // never disarms the party. Refreshes by id; never stacks.
+  // never disarms the party. Never stacks, and never refreshes while already active:
+  // a landed hit is only able to seed a FRESH disarm window, so a run of procs (one
+  // brute swinging faster than its own duration, or several in the same pack each
+  // rolling their own chance) cannot chain-extend the lockout past its stated
+  // duration (issue #1969, "Autoattack ... Cant start swingtimer again").
   const disarm = MOBS[mob.templateId]?.disarm;
   if (
     disarm &&
     mob.hostile &&
     target.kind === 'player' &&
     !target.dead &&
+    !target.auras.some((a) => a.kind === 'disarm') &&
     ctx.rng.chance(disarm.chance)
   ) {
     ctx.applyAura(target, {

--- a/src/sim/mob/mob_swing.ts
+++ b/src/sim/mob/mob_swing.ts
@@ -19,6 +19,7 @@
 // (applyAura/dealDamage/effectiveArmor/recalcPlayer + the rng/emit/players/entities
 // primitives), all of which still resolve on Sim.
 
+import { isDisarmed } from '../combat/cc';
 import { applyThornsReaction } from '../combat/thorns_charge';
 import { MOBS } from '../data';
 import * as deedsMod from '../deeds';
@@ -305,15 +306,17 @@ export function runMobSwingAffixes(
   // a landed hit is only able to seed a FRESH disarm window, so a run of procs (one
   // brute swinging faster than its own duration, or several in the same pack each
   // rolling their own chance) cannot chain-extend the lockout past its stated
-  // duration (issue #1969, "Autoattack ... Cant start swingtimer again").
+  // duration. The already-disarmed check sits AFTER the rng roll so a swing at an
+  // already-disarmed target still draws its proc roll, keeping every downstream draw
+  // at its documented stream position.
   const disarm = MOBS[mob.templateId]?.disarm;
   if (
     disarm &&
     mob.hostile &&
     target.kind === 'player' &&
     !target.dead &&
-    !target.auras.some((a) => a.kind === 'disarm') &&
-    ctx.rng.chance(disarm.chance)
+    ctx.rng.chance(disarm.chance) &&
+    !isDisarmed(target)
   ) {
     ctx.applyAura(target, {
       id: `disarm_${mob.templateId}`,

--- a/tests/mob_disarm.test.ts
+++ b/tests/mob_disarm.test.ts
@@ -3,9 +3,9 @@
 // it suppresses weapon swings (auto-attack, melee and ranged) for a duration but
 // leaves movement, spells and instant abilities untouched.
 import { describe, expect, it } from 'vitest';
-import { Sim } from '../src/sim/sim';
 import { MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
+import { Sim } from '../src/sim/sim';
 import type { Entity } from '../src/sim/types';
 
 function makeSim(playerClass: 'warrior' | 'mage' = 'warrior') {
@@ -15,7 +15,11 @@ function makeSim(playerClass: 'warrior' | 'mage' = 'warrior') {
 // Spawn a Thornpeak Crusher adjacent to the player, engaged and ready to swing.
 function spawnCrusher(sim: Sim, target: Entity): Entity {
   const template = MOBS['ogre_crusher'];
-  const mob = createMob((sim as any).nextId++, template, 17, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  const mob = createMob((sim as any).nextId++, template, 17, {
+    x: target.pos.x,
+    y: target.pos.y,
+    z: target.pos.z,
+  });
   mob.hostile = true;
   (sim as any).addEntity(mob);
   return mob;
@@ -29,14 +33,18 @@ function swing(sim: Sim, mob: Entity, target: Entity) {
 describe('mob disarm ("Disarming Smash")', () => {
   it('seeds the disarm mechanic on the Thornpeak Crusher', () => {
     expect(MOBS['ogre_crusher'].disarm).toEqual({
-      chance: 0.25, duration: 6, name: 'Disarming Smash', school: 'physical',
+      chance: 0.25,
+      duration: 6,
+      name: 'Disarming Smash',
+      school: 'physical',
     });
   });
 
   it('applies a disarm aura on a landed hit when it rolls', () => {
     const sim = makeSim();
     const p = sim.player;
-    p.maxHp = 100000; p.hp = 100000;
+    p.maxHp = 100000;
+    p.hp = 100000;
     const mob = spawnCrusher(sim, p);
     MOBS['ogre_crusher'].disarm!.chance = 1; // deterministic for the test
     swing(sim, mob, p);
@@ -52,8 +60,14 @@ describe('mob disarm ("Disarming Smash")', () => {
     const p = sim.player;
     const meta = (sim as any).players.get(p.id);
     // A defenseless dummy directly in front of the player, inside melee range.
-    const dummy = createMob((sim as any).nextId++, MOBS['ogre_crusher'], 1, { x: p.pos.x + 1, y: p.pos.y, z: p.pos.z });
-    dummy.hostile = true; dummy.maxHp = 100000; dummy.hp = 100000;
+    const dummy = createMob((sim as any).nextId++, MOBS['ogre_crusher'], 1, {
+      x: p.pos.x + 1,
+      y: p.pos.y,
+      z: p.pos.z,
+    });
+    dummy.hostile = true;
+    dummy.maxHp = 100000;
+    dummy.hp = 100000;
     (sim as any).addEntity(dummy);
     p.targetId = dummy.id;
     p.autoAttack = true;
@@ -61,8 +75,14 @@ describe('mob disarm ("Disarming Smash")', () => {
 
     // Disarmed: a ready swing must NOT land.
     p.auras.push({
-      id: 'disarm_x', name: 'Disarming Smash', kind: 'disarm',
-      remaining: 6, duration: 6, value: 0, sourceId: 999, school: 'physical',
+      id: 'disarm_x',
+      name: 'Disarming Smash',
+      kind: 'disarm',
+      remaining: 6,
+      duration: 6,
+      value: 0,
+      sourceId: 999,
+      school: 'physical',
     });
     p.swingTimer = 0;
     const before = dummy.hp;
@@ -105,7 +125,8 @@ describe('mob disarm ("Disarming Smash")', () => {
   it('a friendly pet swing never disarms its target', () => {
     const sim = makeSim();
     const p = sim.player;
-    p.maxHp = 100000; p.hp = 100000;
+    p.maxHp = 100000;
+    p.hp = 100000;
     const pet = spawnCrusher(sim, p);
     pet.hostile = false; // a friendly shape sharing the mobSwing path
     pet.ownerId = p.id;

--- a/tests/mob_disarm.test.ts
+++ b/tests/mob_disarm.test.ts
@@ -76,6 +76,32 @@ describe('mob disarm ("Disarming Smash")', () => {
     expect(dummy.hp).toBeLessThan(before);
   });
 
+  // Bug: Disarming Smash refreshes its full 6s duration on every landed proc,
+  // with no guard against re-applying while already active. A single Thornpeak
+  // Crusher swings every 2.6s, so a run of lucky 25%-chance procs (or a second
+  // crusher in the same pack landing its own roll) can keep re-arming the debuff
+  // faster than it falls off, locking the player out of auto-attack for far
+  // longer than the stated 6s window ("Autoattack on Thornpeak Crusher freqently
+  // does not work. Cant start swingtimer again").
+  it('does not extend disarm past its base duration on a repeat proc while already active', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(60); // enough HP to survive incidental mob swings during the tick loop
+    const p = sim.player;
+    const mob = spawnCrusher(sim, p);
+    MOBS['ogre_crusher'].disarm!.chance = 1; // deterministic: every landed hit procs
+    swing(sim, mob, p); // first proc: applies the debuff, 6s remaining
+    const first = p.auras.find((a) => a.kind === 'disarm');
+    expect(first?.remaining).toBe(6);
+    // Let 5s pass (still disarmed: 1s left), then land a second proc before it
+    // falls off. The debuff must NOT reset back up to a fresh 6s.
+    for (let i = 0; i < 20 * 5; i++) sim.tick();
+    swing(sim, mob, p);
+    MOBS['ogre_crusher'].disarm!.chance = 0.25;
+    const second = p.auras.find((a) => a.kind === 'disarm');
+    expect(second).toBeTruthy();
+    expect(second!.remaining).toBeLessThanOrEqual(1.01);
+  });
+
   it('a friendly pet swing never disarms its target', () => {
     const sim = makeSim();
     const p = sim.player;

--- a/tests/mob_disarm.test.ts
+++ b/tests/mob_disarm.test.ts
@@ -108,18 +108,21 @@ describe('mob disarm ("Disarming Smash")', () => {
     sim.setPlayerLevel(60); // enough HP to survive incidental mob swings during the tick loop
     const p = sim.player;
     const mob = spawnCrusher(sim, p);
-    MOBS['ogre_crusher'].disarm!.chance = 1; // deterministic: every landed hit procs
-    swing(sim, mob, p); // first proc: applies the debuff, 6s remaining
-    const first = p.auras.find((a) => a.kind === 'disarm');
-    expect(first?.remaining).toBe(6);
-    // Let 5s pass (still disarmed: 1s left), then land a second proc before it
-    // falls off. The debuff must NOT reset back up to a fresh 6s.
-    for (let i = 0; i < 20 * 5; i++) sim.tick();
-    swing(sim, mob, p);
-    MOBS['ogre_crusher'].disarm!.chance = 0.25;
-    const second = p.auras.find((a) => a.kind === 'disarm');
-    expect(second).toBeTruthy();
-    expect(second!.remaining).toBeLessThanOrEqual(1.01);
+    try {
+      MOBS['ogre_crusher'].disarm!.chance = 1; // deterministic: every landed hit procs
+      swing(sim, mob, p); // first proc: applies the debuff, 6s remaining
+      const first = p.auras.find((a) => a.kind === 'disarm');
+      expect(first?.remaining).toBe(6);
+      // Let 5s pass (still disarmed: 1s left), then land a second proc before it
+      // falls off. The debuff must NOT reset back up to a fresh 6s.
+      for (let i = 0; i < 20 * 5; i++) sim.tick();
+      swing(sim, mob, p);
+      const second = p.auras.find((a) => a.kind === 'disarm');
+      expect(second).toBeTruthy();
+      expect(second!.remaining).toBeCloseTo(1, 1);
+    } finally {
+      MOBS['ogre_crusher'].disarm!.chance = 0.25;
+    }
   });
 
   it('a friendly pet swing never disarms its target', () => {


### PR DESCRIPTION
## Summary

Disarming Smash (the Thornpeak Crusher's on-hit disarm, `src/sim/content/zone3.ts`)
refreshed its full 6s duration on every landed proc, with no guard against
reapplying while already active. A single Crusher swings every 2.6s, so a run
of lucky 25%-chance procs, or a second Crusher in the same pack landing its
own independent roll, could keep re-arming the debuff faster than it fell off,
locking a player out of auto-attack for far longer than the stated 6s window.

```mermaid
sequenceDiagram
    participant Crusher as Thornpeak Crusher
    participant Player

    Note over Crusher,Player: BEFORE — refreshes while already active
    Crusher->>Player: landed swing, 25% proc
    Player-->>Player: Disarmed (6s remaining)
    Note right of Player: 5s pass, 1s remaining...
    Crusher->>Player: landed swing, 25% proc (again)
    Player-->>Player: Disarmed RESET to 6s remaining
    Note right of Player: chain repeats, auto-attack never resumes

    Note over Crusher,Player: AFTER — proc only seeds a fresh window
    Crusher->>Player: landed swing, 25% proc
    Player-->>Player: Disarmed (6s remaining)
    Note right of Player: 5s pass, 1s remaining...
    Crusher->>Player: landed swing, proc skipped (already disarmed)
    Note right of Player: debuff falls off on schedule, auto-attack resumes
```

Fix: gate the proc in `src/sim/mob/mob_swing.ts` on the target not already
carrying a `disarm` aura, so a landed hit can only seed a fresh disarm window
rather than extend an active one. The proc chance (25%) and duration (6s) are
unchanged; only the refresh-while-active case is fixed.

## Related issues

Matches the "Autoattack on Thornpeak Crusher freqently does not work. Cant
start swingtimer again" report from the in-game bug reports admin panel.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/mob_disarm.test.ts` (added a regression test:
    landing a second proc 5s into an active disarm no longer resets it back
    to a fresh 6s)
  - `npx vitest run tests/parity` (sim golden-trace/rng-draw-order gate, no drift)
  - `npx tsc --noEmit`
  - `npm run gate` (full CI-equivalent gate). Two pre-existing failures on a
    clean, unmodified checkout of this same release branch and unrelated to
    this change: `tests/deeds_window_focus.test.ts` (missing `localStorage`
    global in that suite's jsdom env) and an occasional
    `tests/server/http/parity.test.ts` timeout under full-suite core
    contention (passes standalone). Everything else, including the full sim
    test suite, `tsc`, biome on the changed files, and all builds, is green.
- Manual steps: n/a (sim-only combat logic; no UI surface to exercise).

## Screenshots / recordings

N/A. This is a `src/sim/` combat-mechanic fix with no rendered UI change.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green apart from the two
      pre-existing, unrelated failures noted above.

### Cross-platform

- [x] N/A. No UI surface touched.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.
