### PR TITLE
fix(game): restore mobile pinch gesture lifecycle

### DIFF
--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -301,6 +301,11 @@ export class MobileControls {
   private swipeLookActive = false;
   private swipeLookDownAt = 0;
   private lastSwipeTapAt = 0;
+  // A finger inherited from a pinch may have moved outside the canvas before
+  // the other finger lifted. Resync its first live move before rotating, and
+  // never treat that inherited pointer as a camera-recenter tap.
+  private swipeLookResync = false;
+  private swipeLookAdopted = false;
 
   private chatPressTimer: ReturnType<typeof setTimeout> | null = null;
   private chatLongFired = false;
@@ -396,22 +401,26 @@ export class MobileControls {
     window.addEventListener('pointerup', (e) => {
       this.onMoveEnd(e);
       this.onCameraEnd(e);
+      this.onPinchEnd(e);
+      this.onSwipeLookEnd(e);
     });
     window.addEventListener('pointercancel', (e) => {
       this.onMoveEnd(e);
       this.onCameraEnd(e);
+      this.onPinchEnd(e);
+      this.onSwipeLookEnd(e);
     });
     window.addEventListener('blur', () => {
       this.releaseMove();
       this.releaseCamera();
-      this.releaseSwipeLook();
+      this.releasePinch();
       this.touchOwners.releaseAll();
     });
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'hidden') {
         this.releaseMove();
         this.releaseCamera();
-        this.releaseSwipeLook();
+        this.releasePinch();
         this.touchOwners.releaseAll();
       }
     });
@@ -986,8 +995,41 @@ export class MobileControls {
   }
 
   private onPinchEnd(e: PointerEvent): void {
-    this.pinchPointers.delete(e.pointerId);
+    // Canvas releases also reach the window listener, so only the first event
+    // for this pointer may change the gesture state.
+    if (!this.pinchPointers.delete(e.pointerId)) return;
     if (this.pinchPointers.size < 2) this.pinchPrevDist = null;
+    else this.pinchPrevDist = this.currentPinchDist();
+
+    if (
+      this.pinchPointers.size !== 1 ||
+      !this.active ||
+      this.swipeLookPointer !== null ||
+      this.lookPointer !== null ||
+      document.body.classList.contains('mobile-window-open')
+    )
+      return;
+
+    const remainingId = this.pinchPointers.keys().next().value;
+    if (remainingId === undefined) return;
+    const position = this.pinchPointers.get(remainingId);
+    if (!position) return;
+
+    this.touchOwners.set(remainingId, 'camera');
+    this.swipeLookPointer = remainingId;
+    this.swipeLookStartX = position.x;
+    this.swipeLookStartY = position.y;
+    this.swipeLookLastX = position.x;
+    this.swipeLookLastY = position.y;
+    this.swipeLookActive = false;
+    this.swipeLookDownAt = this.now();
+    this.swipeLookResync = true;
+    this.swipeLookAdopted = true;
+    try {
+      this.canvas?.setPointerCapture(remainingId);
+    } catch {
+      /* synthetic test event */
+    }
   }
 
   private releasePinch(): void {
@@ -1043,6 +1085,14 @@ export class MobileControls {
       this.releaseSwipeLook();
       return;
     }
+    if (this.swipeLookResync) {
+      this.swipeLookResync = false;
+      this.swipeLookStartX = e.clientX;
+      this.swipeLookStartY = e.clientY;
+      this.swipeLookLastX = e.clientX;
+      this.swipeLookLastY = e.clientY;
+      return;
+    }
     const totalDx = e.clientX - this.swipeLookStartX;
     const totalDy = e.clientY - this.swipeLookStartY;
     if (!this.swipeLookActive) {
@@ -1069,7 +1119,10 @@ export class MobileControls {
     // never crossed the swipe deadzone (never became a drag); two of those in
     // quick succession recenter the camera, mirroring the joystick logic.
     const now = this.now();
-    const quickTap = !this.swipeLookActive && now - this.swipeLookDownAt <= RECENTER_DOUBLE_TAP_MS;
+    const quickTap =
+      !this.swipeLookAdopted &&
+      !this.swipeLookActive &&
+      now - this.swipeLookDownAt <= RECENTER_DOUBLE_TAP_MS;
     if (quickTap && isRecenterDoubleTap(this.lastSwipeTapAt, now, this.swipeLookActive)) {
       this.callbacks.onRecenterCamera();
       this.lastSwipeTapAt = 0;
@@ -1096,6 +1149,8 @@ export class MobileControls {
       this.input.setTouchLookVector({ x: 0, y: 0 });
     }
     this.swipeLookActive = false;
+    this.swipeLookResync = false;
+    this.swipeLookAdopted = false;
   }
 }
 

--- a/tests/mobile_controls.test.ts
+++ b/tests/mobile_controls.test.ts
@@ -1909,6 +1909,174 @@ describe('MobileControls pointer lifecycle', () => {
   });
 });
 
+describe('MobileControls pinch lifecycle after camera zoom', () => {
+  function gestureRecorder(): {
+    input: Input;
+    deltas: Array<{ dx: number; dy: number }>;
+    zooms: number[];
+  } {
+    const deltas: Array<{ dx: number; dy: number }> = [];
+    const zooms: number[] = [];
+    const input = {
+      setTouchMove: () => {},
+      clearTouchMove: () => {},
+      setTouchLook: () => {},
+      setTouchLookVector: () => {},
+      applyTouchLookDelta: (dx: number, dy: number) => {
+        deltas.push({ dx, dy });
+      },
+      zoomBy: (delta: number) => {
+        zooms.push(delta);
+      },
+    } as unknown as Input;
+    return { input, deltas, zooms };
+  }
+
+  function touch(target: EventTarget, type: string, pointerId: number, x: number, y: number): void {
+    target.dispatchEvent(
+      pointerEvent(type, { pointerId, pointerType: 'touch', clientX: x, clientY: y }),
+    );
+  }
+
+  it('restores camera rotation when a pinch finger lifts over HUD chrome', () => {
+    const { canvas, windowTarget } = installMobileControlDom();
+    const { input, deltas, zooms } = gestureRecorder();
+    new MobileControls(input, mobileCallbacks()).start();
+
+    touch(canvas, 'pointerdown', 31, 140, 300);
+    touch(canvas, 'pointerdown', 32, 260, 300);
+    touch(canvas, 'pointermove', 31, 160, 300);
+    expect(zooms.length).toBeGreaterThan(0);
+    const zoomsDuringPinch = zooms.length;
+
+    windowTarget.dispatchEvent(
+      pointerEvent('pointerup', {
+        pointerId: 31,
+        pointerType: 'touch',
+        clientX: 80,
+        clientY: 600,
+      }),
+    );
+    touch(canvas, 'pointerup', 32, 260, 300);
+
+    touch(canvas, 'pointerdown', 33, 150, 300);
+    touch(canvas, 'pointermove', 33, 190, 300);
+    touch(canvas, 'pointermove', 33, 230, 300);
+    expect(deltas.length).toBeGreaterThan(0);
+    expect(zooms.length).toBe(zoomsDuringPinch);
+  });
+
+  it('restores camera rotation when browser gesture takeover cancels the pinch', () => {
+    const { canvas, windowTarget } = installMobileControlDom();
+    const { input, deltas, zooms } = gestureRecorder();
+    let recenters = 0;
+    new MobileControls(input, {
+      ...mobileCallbacks(),
+      onRecenterCamera: () => {
+        recenters += 1;
+      },
+    }).start();
+
+    touch(canvas, 'pointerdown', 34, 140, 300);
+    touch(canvas, 'pointerdown', 35, 260, 300);
+    touch(canvas, 'pointermove', 34, 160, 300);
+    expect(zooms.length).toBeGreaterThan(0);
+    const zoomsDuringPinch = zooms.length;
+
+    windowTarget.dispatchEvent(
+      pointerEvent('pointercancel', { pointerId: 34, pointerType: 'touch' }),
+    );
+    windowTarget.dispatchEvent(
+      pointerEvent('pointercancel', { pointerId: 35, pointerType: 'touch' }),
+    );
+
+    touch(canvas, 'pointerdown', 36, 150, 300);
+    touch(canvas, 'pointermove', 36, 190, 300);
+    touch(canvas, 'pointermove', 36, 230, 300);
+    expect(deltas.length).toBeGreaterThan(0);
+    expect(zooms.length).toBe(zoomsDuringPinch);
+    expect(recenters).toBe(0);
+  });
+
+  it('hands the remaining finger to camera drag when a pinch becomes one finger', () => {
+    const { canvas } = installMobileControlDom();
+    const { input, deltas, zooms } = gestureRecorder();
+    new MobileControls(input, mobileCallbacks()).start();
+
+    touch(canvas, 'pointerdown', 41, 140, 300);
+    touch(canvas, 'pointerdown', 42, 260, 300);
+    touch(canvas, 'pointermove', 41, 160, 300);
+    expect(zooms.length).toBeGreaterThan(0);
+    const zoomsDuringPinch = zooms.length;
+
+    touch(canvas, 'pointerup', 41, 160, 300);
+    touch(canvas, 'pointermove', 42, 300, 300);
+    expect(deltas).toEqual([]);
+    touch(canvas, 'pointermove', 42, 340, 300);
+    expect(deltas).toEqual([{ dx: 40, dy: 0 }]);
+    touch(canvas, 'pointermove', 42, 380, 300);
+    touch(canvas, 'pointerup', 42, 380, 300);
+
+    expect(deltas.length).toBeGreaterThan(0);
+    expect(zooms.length).toBe(zoomsDuringPinch);
+  });
+
+  it('clears pinch tracking on blur before the next touch', () => {
+    const { canvas, windowTarget } = installMobileControlDom();
+    const { input, deltas, zooms } = gestureRecorder();
+    new MobileControls(input, mobileCallbacks()).start();
+
+    touch(canvas, 'pointerdown', 51, 140, 300);
+    touch(canvas, 'pointerdown', 52, 260, 300);
+    (windowTarget as unknown as EventTarget).dispatchEvent(new Event('blur'));
+
+    touch(canvas, 'pointerdown', 53, 150, 300);
+    touch(canvas, 'pointermove', 53, 190, 300);
+    touch(canvas, 'pointermove', 53, 230, 300);
+    expect(deltas.length).toBeGreaterThan(0);
+    expect(zooms).toEqual([]);
+  });
+
+  it('keeps the normal full pinch cycle intact', () => {
+    const { canvas } = installMobileControlDom();
+    const { input, deltas, zooms } = gestureRecorder();
+    new MobileControls(input, mobileCallbacks()).start();
+
+    touch(canvas, 'pointerdown', 61, 140, 300);
+    touch(canvas, 'pointerdown', 62, 260, 300);
+    touch(canvas, 'pointermove', 61, 160, 300);
+    touch(canvas, 'pointerup', 62, 260, 300);
+    touch(canvas, 'pointerup', 61, 160, 300);
+    expect(zooms.length).toBeGreaterThan(0);
+    const zoomsDuringPinch = zooms.length;
+
+    touch(canvas, 'pointerdown', 63, 150, 300);
+    touch(canvas, 'pointermove', 63, 190, 300);
+    touch(canvas, 'pointermove', 63, 230, 300);
+    expect(deltas.length).toBeGreaterThan(0);
+    expect(zooms.length).toBe(zoomsDuringPinch);
+  });
+
+  it('re-baselines the surviving pair on a three to two finger transition', () => {
+    const { canvas } = installMobileControlDom();
+    const { input, zooms } = gestureRecorder();
+    new MobileControls(input, mobileCallbacks()).start();
+
+    touch(canvas, 'pointerdown', 71, 100, 300);
+    touch(canvas, 'pointerdown', 72, 200, 300);
+    touch(canvas, 'pointerdown', 73, 500, 300);
+    const zoomsBeforeLift = zooms.length;
+
+    touch(canvas, 'pointerup', 71, 100, 300);
+    touch(canvas, 'pointermove', 72, 201, 300);
+    expect(zooms.length).toBe(zoomsBeforeLift);
+
+    touch(canvas, 'pointermove', 72, 300, 300);
+    expect(zooms.length).toBe(zoomsBeforeLift + 1);
+    expect(zooms[zooms.length - 1]).toBeGreaterThan(0);
+  });
+});
+
 describe('MobileControls chrome idle-fade lifecycle', () => {
   afterEach(() => {
     vi.useRealTimers();


### PR DESCRIPTION
## Summary\n\nThis extracts the joystick, camera, and touch gesture lifecycle bugfix from #1761 into a focused PR based on the latest release/v0.27.0.\n\n- finalize pinch and swipe-look pointers at window level so releases over HUD chrome cannot leave a phantom pinch active\n- clear the complete pinch lifecycle on blur and hidden-document transitions\n- re-baseline the surviving pair when a three-finger gesture becomes a two-finger pinch\n- hand the remaining finger from pinch to swipe-look without applying the stale pinch position as a camera delta\n- prevent an inherited pinch finger from being treated as a double-tap recenter gesture\n- preserve the existing lostpointercapture handling from release/v0.27.0\n\nVerification against the current base found that the four gesture lifecycle bugs were still present before this patch. Five new regression cases failed on the unmodified base and pass with this commit.\n\nTwo items from the original #1761 scope intentionally need no code here:\n\n- safe-area offsets are already applied to the movement joystick and optional camera joystick in the current release/v0.27.0 CSS\n- the custom mobile HUD layout editor is not present in release/v0.27.0, so there is no editor default geometry to correct in this bugfix\n\nNo mobile HUD redesign, layout editor, CSS, or player-visible strings are included.\n\n## Related issues\n\nPart of #1761.\n\n## Type of change\n\n- [ ] Feature: new functionality\n- [x] Bug fix\n- [ ] Refactor or performance (no behavior change)\n- [ ] Documentation\n- [x] Tests\n- [ ] Build, CI, or tooling\n- [ ] Breaking change\n\n## How was this tested?\n\n- Commands:\n  - ./node_modules/.bin/tsc --noEmit\n  - ./node_modules/.bin/biome ci src/game/mobile_controls.ts tests/mobile_controls.test.ts (0 errors; 11 pre-existing warnings in test helpers)\n  - ./node_modules/.bin/vitest run tests/mobile_controls.test.ts tests/touch_router.test.ts (91 passed)\n  - pre-push guard tests: 53 passed, 3 skipped\n  - full unit suite: 14,888 passed; 12 unrelated existing failures in deeds_window_focus, deploy_watchdog, and sfx_studio\n  - git diff --check\n- Manual steps: N/A for this automated gesture lifecycle regression patch.\n- Build and E2E were not run. The repository instruction asks not to start them while another browser session is active and they are not required for this focused non-visual change.\n\n## Screenshots / recordings\n\nN/A. This PR changes pointer lifecycle behavior only and does not change rendered UI.\n\n---\n\n## Checklist\n\n### Quality\n\n- [ ] **The full gate passes.** The focused checks pass; the complete unit suite still has the unrelated failures recorded above.\n\n### Cross-platform\n\n- [ ] **Tested on desktop and mobile.** Covered with synthetic touch pointer lifecycle tests; physical-device verification remains for review.\n- [ ] **Accessible.** N/A; no UI or interaction target was added.\n\n### Localization (i18n)\n\n- [x] N/A. This PR adds no player-visible strings.\n\n### Hygiene\n\n- [x] No secrets, credentials, or .env committed, and ALLOW_DEV_COMMANDS is not enabled in any production path.\n- [x] I did not hand-edit generated files.