### PR TITLE
fix(game): restore mobile pinch gesture lifecycle

### DIFF
--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -307,6 +307,11 @@ export class MobileControls {
   private swipeLookActive = false;
   private swipeLookDownAt = 0;
   private lastSwipeTapAt = 0;
+  // A finger inherited from a pinch may have moved outside the canvas before
+  // the other finger lifted. Resync its first live move before rotating, and
+  // never treat that inherited pointer as a camera-recenter tap.
+  private swipeLookResync = false;
+  private swipeLookAdopted = false;
 
   private chatPressTimer: ReturnType<typeof setTimeout> | null = null;
   private chatLongFired = false;
@@ -398,26 +403,31 @@ export class MobileControls {
     window.addEventListener('pointermove', (e) => {
       this.onMoveMove(e);
       this.onCameraMove(e);
+      this.onPinchMove(e);
     });
     window.addEventListener('pointerup', (e) => {
+      this.onPinchEnd(e);
+      this.onSwipeLookEnd(e);
       this.onMoveEnd(e);
       this.onCameraEnd(e);
     });
     window.addEventListener('pointercancel', (e) => {
+      this.onPinchEnd(e);
+      this.onSwipeLookEnd(e);
       this.onMoveEnd(e);
       this.onCameraEnd(e);
     });
     window.addEventListener('blur', () => {
       this.releaseMove();
       this.releaseCamera();
-      this.releaseSwipeLook();
+      this.releasePinch();
       this.touchOwners.releaseAll();
     });
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'hidden') {
         this.releaseMove();
         this.releaseCamera();
-        this.releaseSwipeLook();
+        this.releasePinch();
         this.touchOwners.releaseAll();
       }
     });
@@ -992,8 +1002,48 @@ export class MobileControls {
   }
 
   private onPinchEnd(e: PointerEvent): void {
-    this.pinchPointers.delete(e.pointerId);
+    // Canvas releases also reach the window listener, so only the first event
+    // for this pointer may change the gesture state.
+    if (!this.pinchPointers.delete(e.pointerId)) return;
     if (this.pinchPointers.size < 2) this.pinchPrevDist = null;
+    else this.pinchPrevDist = this.currentPinchDist();
+
+    if (
+      !this.active ||
+      this.pinchPointers.size !== 1 ||
+      this.swipeLookPointer !== null ||
+      this.lookPointer !== null ||
+      document.body.classList.contains('mobile-window-open')
+    )
+      return;
+
+    const remainingId = this.pinchPointers.keys().next().value;
+    if (remainingId === undefined) return;
+    const position = this.pinchPointers.get(remainingId);
+    if (!position) return;
+
+    const owner = this.touchOwners.get(remainingId);
+    const adoptedOwner = owner === 'groundAim' ? 'groundAim' : 'camera';
+    this.touchOwners.set(remainingId, adoptedOwner);
+    this.swipeLookPointer = remainingId;
+    this.swipeLookStartX = position.x;
+    this.swipeLookStartY = position.y;
+    this.swipeLookLastX = position.x;
+    this.swipeLookLastY = position.y;
+    this.swipeLookActive = false;
+    this.swipeLookDownAt = this.now();
+    this.swipeLookResync = true;
+    this.swipeLookAdopted = true;
+    // Re-capturing the surviving finger supersedes the deliberate release
+    // performed when the pinch began. Browsers may then suppress that older
+    // lostpointercapture event, so its marker must not be allowed to swallow a
+    // later, genuine capture loss for the newly adopted camera drag.
+    this.releasingCaptureForPointer.delete(remainingId);
+    try {
+      this.canvas?.setPointerCapture(remainingId);
+    } catch {
+      /* synthetic test event */
+    }
   }
 
   private releasePinch(): void {
@@ -1063,6 +1113,14 @@ export class MobileControls {
       this.releaseSwipeLook();
       return;
     }
+    if (this.swipeLookResync) {
+      this.swipeLookResync = false;
+      this.swipeLookStartX = e.clientX;
+      this.swipeLookStartY = e.clientY;
+      this.swipeLookLastX = e.clientX;
+      this.swipeLookLastY = e.clientY;
+      return;
+    }
     const totalDx = e.clientX - this.swipeLookStartX;
     const totalDy = e.clientY - this.swipeLookStartY;
     if (!this.swipeLookActive) {
@@ -1085,7 +1143,9 @@ export class MobileControls {
     if (e.pointerId !== this.swipeLookPointer) return;
     if (owner === 'groundAim') {
       e.preventDefault();
-      if (e.type === 'pointerup') this.callbacks.onGroundAimTap(e.clientX, e.clientY);
+      if (!this.swipeLookAdopted && e.type === 'pointerup') {
+        this.callbacks.onGroundAimTap(e.clientX, e.clientY);
+      }
       this.lastSwipeTapAt = 0;
       this.releaseSwipeLook();
       return;
@@ -1097,7 +1157,10 @@ export class MobileControls {
     // never crossed the swipe deadzone (never became a drag); two of those in
     // quick succession recenter the camera, mirroring the joystick logic.
     const now = this.now();
-    const quickTap = !this.swipeLookActive && now - this.swipeLookDownAt <= RECENTER_DOUBLE_TAP_MS;
+    const quickTap =
+      !this.swipeLookAdopted &&
+      !this.swipeLookActive &&
+      now - this.swipeLookDownAt <= RECENTER_DOUBLE_TAP_MS;
     if (quickTap && this.callbacks.onGroundAimTap(e.clientX, e.clientY)) {
       this.lastSwipeTapAt = 0;
       this.releaseSwipeLook();
@@ -1129,6 +1192,8 @@ export class MobileControls {
       this.input.setTouchLookVector({ x: 0, y: 0 });
     }
     this.swipeLookActive = false;
+    this.swipeLookResync = false;
+    this.swipeLookAdopted = false;
   }
 }
 

--- a/tests/mobile_controls.test.ts
+++ b/tests/mobile_controls.test.ts
@@ -358,6 +358,7 @@ class FakeElement extends EventTarget {
   value = '';
   blur(): void {}
   private captured = new Set<number>();
+  private captureGeneration = new Map<number, number>();
   /** Selectors this element (or a simulated ancestor) matches, for closest();
    *  drives touch_router.ts's isInteractiveHudElement checks in tests. */
   matchedSelectors: string[] = [];
@@ -373,11 +374,13 @@ class FakeElement extends EventTarget {
   }
 
   setPointerCapture(pointerId: number): void {
+    this.captureGeneration.set(pointerId, (this.captureGeneration.get(pointerId) ?? 0) + 1);
     this.captured.add(pointerId);
   }
 
   releasePointerCapture(pointerId: number): void {
     if (!this.captured.has(pointerId)) return;
+    const releasedGeneration = this.captureGeneration.get(pointerId) ?? 0;
     this.captured.delete(pointerId);
     // Real browsers dispatch lostpointercapture for both an explicit
     // releasePointerCapture() call and an implicit capture loss (spec
@@ -388,6 +391,14 @@ class FakeElement extends EventTarget {
     // uncaught: queue it with queueMicrotask so callers observe the same
     // non-reentrant timing as a real browser instead of synchronous recursion.
     queueMicrotask(() => {
+      // A new capture established before the pending loss is dispatched
+      // supersedes the old release. Browsers do not emit that stale loss for
+      // the new capture generation, so the fake must not either.
+      if (
+        this.captured.has(pointerId) ||
+        this.captureGeneration.get(pointerId) !== releasedGeneration
+      )
+        return;
       this.dispatchEvent(
         Object.defineProperties(
           new Event('lostpointercapture', { bubbles: true, cancelable: true }),
@@ -669,6 +680,65 @@ describe('MobileControls ground placement tap', () => {
       }),
     );
     expect(taps).toHaveLength(2);
+  });
+
+  it('commits a slow ground-target drag when the release arrives on the window path', () => {
+    const { canvas, windowTarget } = installMobileControlDom();
+    const moves: Array<{ x: number; y: number }> = [];
+    const taps: Array<{ x: number; y: number }> = [];
+    const lookDeltas: Array<{ x: number; y: number }> = [];
+    const callbacks = {
+      ...mobileCallbacks(),
+      onGroundAimMove: (x: number, y: number) => {
+        moves.push({ x, y });
+        return true;
+      },
+      onGroundAimTap: (x: number, y: number) => {
+        taps.push({ x, y });
+        return true;
+      },
+    };
+    const input = inputWithoutLook();
+    input.applyTouchLookDelta = (x: number, y: number) => lookDeltas.push({ x, y });
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(1000);
+    try {
+      new MobileControls(input, callbacks).start();
+
+      canvas.dispatchEvent(
+        pointerEvent('pointerdown', {
+          pointerId: 73,
+          pointerType: 'touch',
+          clientX: 200,
+          clientY: 300,
+        }),
+      );
+      canvas.dispatchEvent(
+        pointerEvent('pointermove', {
+          pointerId: 73,
+          pointerType: 'touch',
+          clientX: 260,
+          clientY: 340,
+        }),
+      );
+      nowSpy.mockReturnValue(1000 + RECENTER_DOUBLE_TAP_MS + 1);
+      windowTarget.dispatchEvent(
+        pointerEvent('pointerup', {
+          pointerId: 73,
+          pointerType: 'touch',
+          clientX: 260,
+          clientY: 340,
+        }),
+      );
+
+      expect(moves).toEqual([
+        { x: 200, y: 300 },
+        { x: 260, y: 340 },
+      ]);
+      expect(taps).toEqual([{ x: 260, y: 340 }]);
+      expect(lookDeltas).toEqual([]);
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 });
 
@@ -2013,6 +2083,291 @@ describe('MobileControls pointer lifecycle', () => {
       }),
     );
     expect(lookActive).toEqual([true, false, false]);
+  });
+});
+
+describe('MobileControls pinch lifecycle after camera zoom', () => {
+  function gestureRecorder(): {
+    input: Input;
+    deltas: Array<{ dx: number; dy: number }>;
+    zooms: number[];
+  } {
+    const deltas: Array<{ dx: number; dy: number }> = [];
+    const zooms: number[] = [];
+    const input = {
+      setTouchMove: () => {},
+      clearTouchMove: () => {},
+      setTouchLook: () => {},
+      setTouchLookVector: () => {},
+      applyTouchLookDelta: (dx: number, dy: number) => {
+        deltas.push({ dx, dy });
+      },
+      zoomBy: (delta: number) => {
+        zooms.push(delta);
+      },
+    } as unknown as Input;
+    return { input, deltas, zooms };
+  }
+
+  function touch(target: EventTarget, type: string, pointerId: number, x: number, y: number): void {
+    target.dispatchEvent(
+      pointerEvent(type, { pointerId, pointerType: 'touch', clientX: x, clientY: y }),
+    );
+  }
+
+  it('restores camera rotation when a pinch finger lifts over HUD chrome', () => {
+    const { canvas, windowTarget } = installMobileControlDom();
+    const { input, deltas, zooms } = gestureRecorder();
+    new MobileControls(input, mobileCallbacks()).start();
+
+    touch(canvas, 'pointerdown', 31, 140, 300);
+    touch(canvas, 'pointerdown', 32, 260, 300);
+    touch(canvas, 'pointermove', 31, 160, 300);
+    expect(zooms.length).toBeGreaterThan(0);
+    const zoomsDuringPinch = zooms.length;
+
+    windowTarget.dispatchEvent(
+      pointerEvent('pointerup', {
+        pointerId: 31,
+        pointerType: 'touch',
+        clientX: 80,
+        clientY: 600,
+      }),
+    );
+    touch(windowTarget, 'pointerup', 32, 260, 300);
+
+    touch(canvas, 'pointerdown', 33, 150, 300);
+    touch(canvas, 'pointermove', 33, 190, 300);
+    touch(canvas, 'pointermove', 33, 230, 300);
+    expect(deltas.length).toBeGreaterThan(0);
+    expect(zooms.length).toBe(zoomsDuringPinch);
+  });
+
+  it('restores camera rotation when browser gesture takeover cancels the pinch', () => {
+    const { canvas, windowTarget } = installMobileControlDom();
+    const { input, deltas, zooms } = gestureRecorder();
+    let recenters = 0;
+    new MobileControls(input, {
+      ...mobileCallbacks(),
+      onRecenterCamera: () => {
+        recenters += 1;
+      },
+    }).start();
+
+    // Seed the first half of a valid recenter double-tap. The inherited pinch
+    // finger below must not be accepted as its second half when it is canceled.
+    touch(canvas, 'pointerdown', 30, 100, 300);
+    touch(canvas, 'pointerup', 30, 100, 300);
+
+    touch(canvas, 'pointerdown', 34, 140, 300);
+    touch(canvas, 'pointerdown', 35, 260, 300);
+    touch(canvas, 'pointermove', 34, 160, 300);
+    expect(zooms.length).toBeGreaterThan(0);
+    const zoomsDuringPinch = zooms.length;
+
+    windowTarget.dispatchEvent(
+      pointerEvent('pointercancel', { pointerId: 34, pointerType: 'touch' }),
+    );
+    windowTarget.dispatchEvent(
+      pointerEvent('pointercancel', { pointerId: 35, pointerType: 'touch' }),
+    );
+
+    touch(canvas, 'pointerdown', 36, 150, 300);
+    touch(canvas, 'pointermove', 36, 190, 300);
+    touch(canvas, 'pointermove', 36, 230, 300);
+    expect(deltas.length).toBeGreaterThan(0);
+    expect(zooms.length).toBe(zoomsDuringPinch);
+    expect(recenters).toBe(0);
+  });
+
+  it('hands the remaining finger to camera drag when a pinch becomes one finger', () => {
+    const { canvas } = installMobileControlDom();
+    const { input, deltas, zooms } = gestureRecorder();
+    new MobileControls(input, mobileCallbacks()).start();
+
+    touch(canvas, 'pointerdown', 41, 140, 300);
+    touch(canvas, 'pointerdown', 42, 260, 300);
+    touch(canvas, 'pointermove', 41, 160, 300);
+    expect(zooms.length).toBeGreaterThan(0);
+    const zoomsDuringPinch = zooms.length;
+
+    touch(canvas, 'pointerup', 41, 160, 300);
+    touch(canvas, 'pointermove', 42, 300, 300);
+    expect(deltas).toEqual([]);
+    touch(canvas, 'pointermove', 42, 340, 300);
+    expect(deltas).toEqual([{ dx: 40, dy: 0 }]);
+    touch(canvas, 'pointermove', 42, 380, 300);
+    touch(canvas, 'pointerup', 42, 380, 300);
+
+    expect(deltas.length).toBeGreaterThan(0);
+    expect(zooms.length).toBe(zoomsDuringPinch);
+  });
+
+  it('keeps pinch zoom tracking when a pinch move arrives on the window path', () => {
+    const { canvas, windowTarget } = installMobileControlDom();
+    const { input, zooms } = gestureRecorder();
+    new MobileControls(input, mobileCallbacks()).start();
+
+    touch(canvas, 'pointerdown', 43, 140, 300);
+    touch(canvas, 'pointerdown', 44, 260, 300);
+    touch(windowTarget, 'pointermove', 44, 320, 300);
+
+    expect(zooms.length).toBe(1);
+    expect(Math.abs(zooms[0] ?? 0)).toBeGreaterThan(0);
+  });
+
+  it('keeps an adopted ground-target finger on the ground aim path after pinch', () => {
+    const { canvas } = installMobileControlDom();
+    const { input, deltas, zooms } = gestureRecorder();
+    const aimMoves: Array<{ x: number; y: number }> = [];
+    const aimTaps: Array<{ x: number; y: number }> = [];
+    new MobileControls(input, {
+      ...mobileCallbacks(),
+      onGroundAimMove: (x: number, y: number) => {
+        aimMoves.push({ x, y });
+        return true;
+      },
+      onGroundAimTap: (x: number, y: number) => {
+        aimTaps.push({ x, y });
+        return true;
+      },
+    }).start();
+
+    touch(canvas, 'pointerdown', 45, 140, 300);
+    expect(aimMoves).toEqual([{ x: 140, y: 300 }]);
+    touch(canvas, 'pointerdown', 46, 260, 300);
+    touch(canvas, 'pointermove', 46, 300, 300);
+    expect(zooms.length).toBeGreaterThan(0);
+
+    touch(canvas, 'pointerup', 46, 300, 300);
+    touch(canvas, 'pointermove', 45, 180, 320);
+
+    expect(aimMoves[aimMoves.length - 1]).toEqual({ x: 180, y: 320 });
+    expect(deltas).toEqual([]);
+    expect(aimTaps).toEqual([]);
+  });
+
+  it('does not commit a ground-target tap when an adopted pinch survivor lifts', () => {
+    const { canvas } = installMobileControlDom();
+    const { input } = gestureRecorder();
+    let aimTaps = 0;
+    new MobileControls(input, {
+      ...mobileCallbacks(),
+      onGroundAimMove: () => true,
+      onGroundAimTap: () => {
+        aimTaps += 1;
+        return true;
+      },
+    }).start();
+
+    touch(canvas, 'pointerdown', 46, 140, 300);
+    touch(canvas, 'pointerdown', 47, 260, 300);
+    touch(canvas, 'pointerup', 47, 260, 300);
+    touch(canvas, 'pointerup', 46, 140, 300);
+
+    expect(aimTaps).toBe(0);
+  });
+
+  it('clears pinch tracking on blur before the next touch', () => {
+    const { canvas, windowTarget } = installMobileControlDom();
+    const { input, deltas, zooms } = gestureRecorder();
+    new MobileControls(input, mobileCallbacks()).start();
+
+    touch(canvas, 'pointerdown', 51, 140, 300);
+    touch(canvas, 'pointerdown', 52, 260, 300);
+    (windowTarget as unknown as EventTarget).dispatchEvent(new Event('blur'));
+
+    touch(canvas, 'pointerdown', 53, 150, 300);
+    touch(canvas, 'pointermove', 53, 190, 300);
+    touch(canvas, 'pointermove', 53, 230, 300);
+    expect(deltas.length).toBeGreaterThan(0);
+    expect(zooms).toEqual([]);
+  });
+
+  it('clears pinch tracking when the document becomes hidden', () => {
+    const { canvas } = installMobileControlDom();
+    const { input, deltas, zooms } = gestureRecorder();
+    new MobileControls(input, mobileCallbacks()).start();
+
+    touch(canvas, 'pointerdown', 54, 140, 300);
+    touch(canvas, 'pointerdown', 55, 260, 300);
+
+    const hiddenDocument = document as unknown as EventTarget & {
+      visibilityState: DocumentVisibilityState;
+    };
+    hiddenDocument.visibilityState = 'hidden';
+    hiddenDocument.dispatchEvent(new Event('visibilitychange'));
+
+    touch(canvas, 'pointerdown', 56, 150, 300);
+    touch(canvas, 'pointermove', 56, 190, 300);
+    touch(canvas, 'pointermove', 56, 230, 300);
+    expect(deltas.length).toBeGreaterThan(0);
+    expect(zooms).toEqual([]);
+  });
+
+  it('handles a genuine capture loss after a pinch survivor is re-captured', async () => {
+    const { canvas } = installMobileControlDom();
+    const { input, deltas } = gestureRecorder();
+    new MobileControls(input, mobileCallbacks()).start();
+
+    touch(canvas, 'pointerdown', 57, 140, 300);
+    touch(canvas, 'pointermove', 57, 180, 300);
+    touch(canvas, 'pointerdown', 58, 260, 300);
+    deltas.length = 0;
+
+    // Lift the second finger before the deliberate release echo for pointer 57
+    // runs. Re-capturing 57 supersedes that pending echo in real browsers.
+    touch(canvas, 'pointerup', 58, 260, 300);
+    await Promise.resolve();
+
+    // Simulate a later implicit capture loss. It must finalize the adopted
+    // swipe instead of being swallowed by the stale deliberate-release guard.
+    canvas.releasePointerCapture(57);
+    await Promise.resolve();
+
+    touch(canvas, 'pointerdown', 59, 150, 300);
+    touch(canvas, 'pointermove', 59, 190, 300);
+    touch(canvas, 'pointermove', 59, 230, 300);
+    expect(deltas.length).toBeGreaterThan(0);
+  });
+
+  it('keeps the normal full pinch cycle intact', () => {
+    const { canvas } = installMobileControlDom();
+    const { input, deltas, zooms } = gestureRecorder();
+    new MobileControls(input, mobileCallbacks()).start();
+
+    touch(canvas, 'pointerdown', 61, 140, 300);
+    touch(canvas, 'pointerdown', 62, 260, 300);
+    touch(canvas, 'pointermove', 61, 160, 300);
+    touch(canvas, 'pointerup', 62, 260, 300);
+    touch(canvas, 'pointerup', 61, 160, 300);
+    expect(zooms.length).toBeGreaterThan(0);
+    const zoomsDuringPinch = zooms.length;
+
+    touch(canvas, 'pointerdown', 63, 150, 300);
+    touch(canvas, 'pointermove', 63, 190, 300);
+    touch(canvas, 'pointermove', 63, 230, 300);
+    expect(deltas.length).toBeGreaterThan(0);
+    expect(zooms.length).toBe(zoomsDuringPinch);
+  });
+
+  it('re-baselines the surviving pair on a three to two finger transition', () => {
+    const { canvas } = installMobileControlDom();
+    const { input, zooms } = gestureRecorder();
+    new MobileControls(input, mobileCallbacks()).start();
+
+    touch(canvas, 'pointerdown', 71, 100, 300);
+    touch(canvas, 'pointerdown', 72, 200, 300);
+    touch(canvas, 'pointerdown', 73, 500, 300);
+    const zoomsBeforeLift = zooms.length;
+
+    touch(canvas, 'pointerup', 71, 100, 300);
+    touch(canvas, 'pointermove', 72, 201, 300);
+    expect(zooms.length).toBe(zoomsBeforeLift);
+
+    touch(canvas, 'pointermove', 72, 300, 300);
+    expect(zooms.length).toBe(zoomsBeforeLift + 1);
+    expect(zooms[zooms.length - 1]).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Summary

This extracts the joystick, camera, and touch gesture lifecycle bugfix from #1761 into a focused PR based on the current `release/v0.27.0` branch.

The current release still left pinch pointers active when a finger ended over HUD chrome or focus was lost. Multi-touch transitions also retained stale geometry, which caused an incorrect zoom baseline or a camera jump when pinch handed control to swipe-look.

This change:

- finalizes pinch and swipe-look pointers at window level
- clears the complete pinch lifecycle on blur and hidden-document transitions
- re-baselines the surviving pair when a three-finger gesture becomes a two-finger pinch
- hands the remaining finger from pinch to swipe-look without applying stale coordinates as a camera delta
- prevents an inherited pinch finger from being interpreted as a double-tap recenter gesture
- preserves the existing deliberate `lostpointercapture` protection
- retires a superseded release marker when the surviving finger is re-captured, so a later genuine capture loss cannot be swallowed

Safe-area offsets already exist for the movement joystick and optional camera joystick in `release/v0.27.0`, so this PR does not change CSS. The custom mobile HUD editor is not present on this release branch, so editor geometry is also outside this bugfix. No redesign, layout editor, or player-visible string is included.

## Related issues

Part of #1761.

Supersedes #2068, which GitHub closed automatically when the contributor branch was renamed to follow `CONTRIBUTING.md`.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Full gate on the final `release/v0.27.0` base (`fbfa6bafd`):
  - `npm run gate` under Node 22.22.2 with GNU coreutils `timeout`
  - PASS: all 11 gate steps completed successfully
  - Vitest: 14,999 passed and 26 skipped
  - browser regressions: 64 passed
  - TypeScript and Svelte checks passed with 0 errors and 0 warnings
  - environment, server, and client production builds passed
- Focused gesture regression checks:
  - `./node_modules/.bin/vitest run tests/mobile_controls.test.ts tests/touch_router.test.ts` — 93 tests passed
  - `./node_modules/.bin/biome ci --changed` — no errors; 11 existing warnings in shared test helpers
  - pre-push architecture and localization guard tests — 53 passed, 3 skipped
  - `git diff --check` — passed
- Browser-agent responsive smoke check:
  - entered the local offline world at 844x390 landscape and 390x844 portrait
  - the document remained exactly viewport-sized in both orientations, with no page overflow
  - the browser agent exposes a fine pointer and desktop mode, so it cannot validate real multi-touch pointer capture, iOS focus loss, or system-edge gesture behavior
- Mutation checks:
  - removing window-level swipe finalization fails the HUD-release regression
  - removing the inherited-pointer recenter guard fails the seeded double-tap regression
  - retaining a superseded capture-release marker fails the later genuine-capture-loss regression
- Manual steps:
  - physical mobile gesture flow verified by the contributor after this build; repository CI remains pending

## Screenshots / recordings

N/A. This changes pointer lifecycle behavior without changing rendered UI. The no-jump handoff and cleanup paths are pinned by regression tests.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` completed all 11 steps successfully under Node 22.22.2 with GNU coreutils `timeout`.

### Cross-platform

- [x] **Tested on desktop and mobile.** Automated touch-pointer tests, responsive browser checks, and contributor verification on a physical mobile device pass.
- [x] **Accessible.** N/A. This PR adds no controls, targets, text, or visual states.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` files are committed, and `ALLOW_DEV_COMMANDS` is not enabled in a production path.
- [x] Generated files were not hand-edited.


