### PR TITLE
fix(game): downgrade saved Ultra graphics preset on iOS Safari, not just the native app

### DIFF
--- a/src/game/startup_graphics_safety.ts
+++ b/src/game/startup_graphics_safety.ts
@@ -1,0 +1,21 @@
+import type { BrowserEngine } from './browser_env';
+
+// iOS WebKit (the native app shell's WKWebView AND iOS Safari itself, same
+// engine and per-tab WebContent-process memory ceiling) can terminate that
+// process mid-scene-build on an Ultra/Advanced world entry on recent phones.
+// The tab or the native shell then reloads back to the start screen before
+// the in-game Options menu is ever reachable, so a persisted Ultra/Advanced
+// choice traps the player in a repeated-reload loop with no way to back out.
+// Pure so it unit-tests without a DOM; main.ts is the thin caller.
+export function safeStartupGraphicsPreset(
+  isNative: boolean,
+  engine: BrowserEngine,
+  mobile: boolean,
+  preset: number,
+  ultraPreset: number,
+  highPreset: number,
+): number {
+  const isIosWebkit = engine === 'webkit' && mobile;
+  if ((isNative || isIosWebkit) && preset >= ultraPreset) return highPreset;
+  return preset;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,6 +74,7 @@ import {
   spawnCinematicFor,
   spawnCinematicPose,
 } from './game/spawn_cinematic';
+import { safeStartupGraphicsPreset } from './game/startup_graphics_safety';
 import { resolveUiEffectsProfile } from './game/ui_effects_profile';
 import { currentUtcDay } from './game/utc_day';
 import { voice } from './game/voice';
@@ -957,12 +958,21 @@ async function startGame(
     settings.set('graphicsPreset', autoPreset);
     settings.set('graphicsDefaultApplied', true);
   }
-  // Native iOS WebKit can terminate the WebContent process during Ultra world
-  // startup on recent phones, which reloads back to the start screen before the
-  // in-game options menu is reachable. Persist the safe startup tier so a saved
-  // Ultra/Advanced choice cannot trap the native app in that reload loop.
-  if (isNativeRuntime() && settings.get('graphicsPreset') >= GRAPHICS_PRESET_ULTRA) {
-    settings.set('graphicsPreset', GRAPHICS_PRESET_HIGH);
+  // iOS WebKit can terminate the tab's WebContent process during Ultra world
+  // startup on recent phones (native app shell AND iOS Safari alike, same
+  // engine/process limits), reloading back to the start screen before the
+  // in-game options menu is reachable. See startup_graphics_safety.ts.
+  const startupBrowserEnv = readBrowserEnv();
+  const safePreset = safeStartupGraphicsPreset(
+    isNativeRuntime(),
+    startupBrowserEnv.engine,
+    startupBrowserEnv.mobile,
+    settings.get('graphicsPreset'),
+    GRAPHICS_PRESET_ULTRA,
+    GRAPHICS_PRESET_HIGH,
+  );
+  if (safePreset !== settings.get('graphicsPreset')) {
+    settings.set('graphicsPreset', safePreset);
   }
   // UI theming: apply the persisted theme's CSS variables to :root, then keep a
   // hook so the Options panel can switch preset / override colours live.

--- a/tests/startup_graphics_safety.test.ts
+++ b/tests/startup_graphics_safety.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { safeStartupGraphicsPreset } from '../src/game/startup_graphics_safety';
+
+const ULTRA = 4;
+const HIGH = 3;
+const MEDIUM = 2;
+
+describe('safeStartupGraphicsPreset', () => {
+  it('downgrades a saved Ultra preset on iOS Safari (webkit + mobile, not native)', () => {
+    expect(safeStartupGraphicsPreset(false, 'webkit', true, ULTRA, ULTRA, HIGH)).toBe(HIGH);
+  });
+
+  it('downgrades a saved Ultra preset in the native iOS app shell', () => {
+    expect(safeStartupGraphicsPreset(true, 'webkit', true, ULTRA, ULTRA, HIGH)).toBe(HIGH);
+  });
+
+  it('leaves desktop Safari alone (webkit but not mobile)', () => {
+    expect(safeStartupGraphicsPreset(false, 'webkit', false, ULTRA, ULTRA, HIGH)).toBe(ULTRA);
+  });
+
+  it('leaves mobile Chrome alone (mobile but not webkit)', () => {
+    expect(safeStartupGraphicsPreset(false, 'chromium', true, ULTRA, ULTRA, HIGH)).toBe(ULTRA);
+  });
+
+  it('never touches a preset already below Ultra', () => {
+    expect(safeStartupGraphicsPreset(false, 'webkit', true, MEDIUM, ULTRA, HIGH)).toBe(MEDIUM);
+  });
+});


### PR DESCRIPTION
## Summary
- iOS Safari players reported the game reloading itself repeatedly right at world entry, both in the offline sim and online, and could never get far enough to open Settings and turn graphics down.
- Root cause: `src/main.ts` already had a documented workaround for iOS WebKit terminating the tab's WebContent process on an Ultra/Advanced world entry (recent phones), but the downgrade was gated to `isNativeRuntime()` only, so it protected the Capacitor iOS app shell and left iOS Safari itself, which runs the identical WebKit engine and hits the identical per-tab memory ceiling, completely unprotected.
- A player who had ever saved Ultra/Advanced on an iPhone (or who just has a beefy iPhone that auto-detects a high tier) got stuck in a load, crash, reload loop in Safari before the in-game Options menu was ever reachable to back out. Because the crash happens during `startGame()`'s shared, synchronous `Renderer`/`Hud` scene-build step, it reproduces identically offline and online, matching the "regardless online or offline" report.
- Fix: extract the decision into a small pure module (`src/game/startup_graphics_safety.ts`, `safeStartupGraphicsPreset`), matching this repo's `ui_effects_profile.ts`/`ui_tier_knobs.ts` pure-resolver pattern, and widen the gate to any WebKit-mobile browser environment (`readBrowserEnv().engine === 'webkit' && mobile`) in addition to the native runtime check. Desktop Safari and mobile Chrome/Firefox are unaffected (webkit-desktop and non-webkit-mobile both fall through untouched).

## Root cause diagram

```mermaid
flowchart TD
    A[startGame boots: offline Sim or online ClientWorld] --> B[Synchronous Renderer + Hud scene build]
    B --> C{Saved graphicsPreset >= Ultra?}
    C -- No --> Z[World entry completes normally]
    C -- Yes --> D{Runtime is WebKit mobile?}
    D -- "Before this fix: only checked isNativeRuntime()" --> E["iOS Safari: NOT caught -> WebKit kills WebContent process -> tab reloads -> back to start screen, preset still Ultra -> loop"]
    D -- "After this fix: isNativeRuntime() OR (webkit && mobile)" --> F[Preset downgraded to High before scene build] --> Z
```

## Test plan
- [x] `npx vitest run tests/startup_graphics_safety.test.ts` (new: iOS Safari downgrade, native app downgrade, desktop Safari untouched, mobile Chrome untouched, sub-Ultra preset untouched)
- [x] `npx vitest run tests/architecture.test.ts tests/settings.test.ts`
- [x] `npx tsc --noEmit -p .`
- [x] Verified the diff's own changed files (`src/main.ts`, `src/game/startup_graphics_safety.ts`, `tests/startup_graphics_safety.test.ts`) are biome-clean; the local `--changed` floor also flags pre-existing, unrelated files because it diffs against `origin/main` rather than this branch's `release/v0.27.0` base, a known base-branch mismatch, not a regression from this change.
- [ ] Could not reproduce on a real iPhone/iOS Safari (no macOS/iOS hardware in this environment); Android emulation was ruled out as a substitute since Android has no WebKit engine and cannot reproduce this class of bug. Root-caused instead from the existing native-only mitigation's own code comment plus the reported symptom shape (online + offline, load-time, iOS-only).

No UI/render/CSS change, so before/after screenshots do not apply to this fix.
