### PR TITLE
fix(desktop): add Linux PRIME render-offload for the discrete GPU

### DIFF
--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -447,6 +447,15 @@ Rules that keep this working:
    the working lever there; Windows 11 with an attached eGPU can ignore the per-app
    preference while the eGPU is connected; pre-1803 Windows 10 ignores the key
    entirely.
+   On Linux, hybrid-graphics laptops (NVIDIA Optimus, AMD/Intel Mesa PRIME) have no
+   per-app OS preference and the Chromium switch is a no-op (the GPU adapter is
+   resolved by the driver's client library at dynamic-link time, before Chromium
+   parses its switches), so `gpu_preference.cjs` sets the standard PRIME
+   render-offload environment variables instead: `DRI_PRIME=1` (Mesa) and
+   `__NV_PRIME_RENDER_OFFLOAD=1` / `__GLX_VENDOR_LIBRARY_NAME=nvidia` /
+   `__VK_LAYER_NV_optimus=NVIDIA_only` (NVIDIA proprietary driver), applied on every
+   launch (packaged or dev) and never overriding a name the player's own environment
+   already set (e.g. their own `prime-run` wrapper).
 3. Login both paths: email/password in-app, and Discord via the external browser +
    `worldofclaudecraft://desktop-login` deep link handoff (app focuses and enters
    the world; second-instance and cold-start deep links both work).

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -450,12 +450,43 @@ Rules that keep this working:
    On Linux, hybrid-graphics laptops (NVIDIA Optimus, AMD/Intel Mesa PRIME) have no
    per-app OS preference and the Chromium switch is a no-op (the GPU adapter is
    resolved by the driver's client library at dynamic-link time, before Chromium
-   parses its switches), so `gpu_preference.cjs` sets the standard PRIME
-   render-offload environment variables instead: `DRI_PRIME=1` (Mesa) and
-   `__NV_PRIME_RENDER_OFFLOAD=1` / `__GLX_VENDOR_LIBRARY_NAME=nvidia` /
-   `__VK_LAYER_NV_optimus=NVIDIA_only` (NVIDIA proprietary driver), applied on every
-   launch (packaged or dev) and never overriding a name the player's own environment
-   already set (e.g. their own `prime-run` wrapper).
+   parses its switches). Setting the PRIME render-offload environment variables
+   (`DRI_PRIME=1` for Mesa; `__NV_PRIME_RENDER_OFFLOAD=1` /
+   `__GLX_VENDOR_LIBRARY_NAME=nvidia` / `__EGL_VENDOR_LIBRARY_FILENAMES=<nvidia glvnd
+   EGL ICD json>` / `__VK_LAYER_NV_optimus=NVIDIA_only` for the NVIDIA proprietary
+   driver) in the running main process does NOT reach the GPU process either:
+   Electron's Linux GPU process forks from a zygote that already exec'd (and
+   snapshotted its environ) before any main-process JS runs, so a process.env write
+   there is invisible to it. Verified on real hybrid hardware: `__GLX_VENDOR_LIBRARY_NAME`
+   alone is a decoy for this app (Chromium's context is EGL, not GLX, so it flips
+   `glxinfo` while the unmasked WebGL renderer stays on the iGPU); the
+   `__EGL_VENDOR_LIBRARY_FILENAMES` variable is the one that actually moves the
+   renderer to the NVIDIA adapter. The same hardware also crash-loops the GPU
+   process on a Wayland session once PRIME offload is requested (falls back to
+   software rendering, worse than the iGPU), so Chromium must additionally be
+   forced onto the X11 Ozone backend, which (like the env vars) only works as a
+   real argv flag present before Electron's own startup, never an `appendSwitch`
+   call in the running process.
+   `main.cjs` instead calls `relaunchForLinuxPrime` as the very first thing it does
+   (before crash reporting, logging, or any window): on Linux, if any PRIME
+   variable is missing from the environment, it re-execs the app with them baked
+   into the new process's environment from birth plus `--ozone-platform=x11`
+   appended to argv (a marker env var prevents a relaunch loop; an explicit player
+   `--ozone-platform` choice is never overridden), and the original process exits
+   immediately. Applied on every launch (packaged or dev), and never overriding an
+   env name the player's own environment already set (e.g. their own `prime-run`
+   wrapper) -- if every variable is already present, no relaunch happens at all.
+   Verify with `ps -o pid,ppid,cmd -C world-of-claudecraft` (or the AppImage/binary
+   name) showing the relaunched PID's parent already exited, and `[gpu] relaunching
+   for Linux PRIME render offload` in `main.log`.
+   Known follow-ups, not yet addressed: the relaunch is unconditional rather than
+   gated on detecting a hybrid adapter first (Electron's `getGPUInfo` needs `app`
+   ready, which is after the point a relaunch must decide), so a non-hybrid Linux
+   machine still pays for one extra process spawn per launch (harmless today since
+   the vars sit inert on that hardware, but worth tightening); and the relaunch's
+   interaction with the second-instance deep-link path (`worldofclaudecraft://`
+   login handoff) has not been verified against a login link that arrives during
+   the brief relaunch window.
 3. Login both paths: email/password in-app, and Discord via the external browser +
    `worldofclaudecraft://desktop-login` deep link handoff (app focuses and enters
    the world; second-instance and cold-start deep links both work).

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -457,36 +457,49 @@ Rules that keep this working:
    driver) in the running main process does NOT reach the GPU process either:
    Electron's Linux GPU process forks from a zygote that already exec'd (and
    snapshotted its environ) before any main-process JS runs, so a process.env write
-   there is invisible to it. Verified on real hybrid hardware: `__GLX_VENDOR_LIBRARY_NAME`
-   alone is a decoy for this app (Chromium's context is EGL, not GLX, so it flips
-   `glxinfo` while the unmasked WebGL renderer stays on the iGPU); the
-   `__EGL_VENDOR_LIBRARY_FILENAMES` variable is the one that actually moves the
-   renderer to the NVIDIA adapter. The same hardware also crash-loops the GPU
-   process on a Wayland session once PRIME offload is requested (falls back to
-   software rendering, worse than the iGPU), so Chromium must additionally be
-   forced onto the X11 Ozone backend, which (like the env vars) only works as a
-   real argv flag present before Electron's own startup, never an `appendSwitch`
-   call in the running process.
-   `main.cjs` instead calls `relaunchForLinuxPrime` as the very first thing it does
-   (before crash reporting, logging, or any window): on Linux, if any PRIME
-   variable is missing from the environment, it re-execs the app with them baked
-   into the new process's environment from birth plus `--ozone-platform=x11`
-   appended to argv (a marker env var prevents a relaunch loop; an explicit player
-   `--ozone-platform` choice is never overridden), and the original process exits
-   immediately. Applied on every launch (packaged or dev), and never overriding an
-   env name the player's own environment already set (e.g. their own `prime-run`
-   wrapper) -- if every variable is already present, no relaunch happens at all.
+   there is invisible to it. Which variable does the lifting depends on the path
+   Chromium takes (both measured on real hybrid hardware): under the
+   `--ozone-platform=x11` backend the shell forces, ANGLE binds through GLX and the
+   `__NV_PRIME_RENDER_OFFLOAD` + `__GLX_VENDOR_LIBRARY_NAME` pair selects the
+   adapter; on EGL paths (a player-forced Wayland ozone) that pair is a decoy (it
+   flips `glxinfo` while the unmasked renderer stays on the iGPU) and
+   `__EGL_VENDOR_LIBRARY_FILENAMES` is the lever. The EGL entry is only ever set
+   when the NVIDIA ICD json actually exists, because glvnd treats it as a
+   replacement of its vendor list and naming a missing file would leave a
+   non-NVIDIA machine with no EGL vendors at all. The same hardware also
+   crash-loops the GPU process on a Wayland session once PRIME offload is
+   requested (falls back to software rendering, worse than the iGPU), so Chromium
+   must additionally be forced onto the X11 Ozone backend, which (like the env
+   vars) only works as a real argv flag present before Electron's own startup,
+   never an `appendSwitch` call in the running process.
+   `main.cjs` therefore calls `relaunchForLinuxPrime` as the very first thing it
+   does (before crash reporting, logging, or any window): on a HYBRID Linux
+   machine (two or more GPUs under `/sys/class/drm`; single-GPU machines are left
+   completely untouched), it re-execs the app with the PRIME variables baked into
+   the new process's environment from birth plus `--ozone-platform=x11` appended
+   to argv, and the original process exits immediately. The spawn source is
+   `$APPIMAGE` (the outer AppImage file, the same source electron-updater restarts
+   from) when set, because inside an AppImage `process.execPath` lives in a FUSE
+   mount that dies with the exiting parent; other installs re-exec the binary
+   itself. An explicit player `--ozone-platform` choice is never overridden (a
+   bare `--ozone-platform-hint` deliberately does not count), and no env name the
+   player's own environment already set (their own `prime-run` wrapper) is ever
+   replaced: with no marker and every variable present, no relaunch happens at
+   all. The relaunch marker does NOT permanently suppress re-execs: a marked
+   process whose argv lost the ozone flag (electron-updater's restart-to-update
+   respawns with the current env but empty argv) relaunches once more purely to
+   restore the flag. The dev loop (`npm run electron:dev`) pre-applies the same
+   configuration to the electron it spawns, so no relaunch happens there and the
+   Vite teardown-on-exit logic keeps working.
    Verify with `ps -o pid,ppid,cmd -C world-of-claudecraft` (or the AppImage/binary
-   name) showing the relaunched PID's parent already exited, and `[gpu] relaunching
-   for Linux PRIME render offload` in `main.log`.
-   Known follow-ups, not yet addressed: the relaunch is unconditional rather than
-   gated on detecting a hybrid adapter first (Electron's `getGPUInfo` needs `app`
-   ready, which is after the point a relaunch must decide), so a non-hybrid Linux
-   machine still pays for one extra process spawn per launch (harmless today since
-   the vars sit inert on that hardware, but worth tightening); and the relaunch's
-   interaction with the second-instance deep-link path (`worldofclaudecraft://`
-   login handoff) has not been verified against a login link that arrives during
-   the brief relaunch window.
+   name) showing the relaunched PID's parent already exited, and `[gpu] running as
+   PRIME-relaunched child` in `main.log` (the child writes it; the parent exits
+   before file logging exists).
+   Known follow-ups, not yet addressed: the relaunch's interaction with the
+   second-instance deep-link path (`worldofclaudecraft://` login handoff) has not
+   been verified against a login link that arrives during the brief relaunch
+   window, and the Steam channel's process tracking (overlay, playtime) has not
+   been verified against the parent exiting within milliseconds of launch.
 3. Login both paths: email/password in-app, and Discord via the external browser +
    `worldofclaudecraft://desktop-login` deep link handoff (app focuses and enters
    the world; second-instance and cold-start deep links both work).

--- a/electron/gpu_preference.cjs
+++ b/electron/gpu_preference.cjs
@@ -55,6 +55,29 @@ const nodePath = require('node:path');
 //     binary (one orphan entry per worktree, steering everything else launched from that
 //     shared binary); only the stable installed exe path is worth pinning.
 //
+//  3. Linux PRIME render-offload environment variables. On a Linux hybrid-graphics laptop
+//     (NVIDIA Optimus, AMD/Intel Mesa PRIME) there is no per-app OS-level preference to write
+//     (no registry equivalent) and force-high-performance-gpu is a no-op: the driver decides
+//     which adapter serves EGL/GLX at DYNAMIC-LINK time, before Chromium's own switch parsing
+//     ever runs. The standard offload contract (what `prime-run`/`optirun` wrapper scripts
+//     set) is a handful of environment variables read by the vendor's client driver when it
+//     resolves the GPU vendor library: DRI_PRIME=1 (Mesa: AMD/Intel PRIME offload, ignored by
+//     the NVIDIA proprietary driver), and for NVIDIA's proprietary PRIME render offload,
+//     __NV_PRIME_RENDER_OFFLOAD=1 plus __GLX_VENDOR_LIBRARY_NAME=nvidia (GLX) and
+//     __VK_LAYER_NV_optimus=NVIDIA_only (Vulkan, which Chromium's ANGLE backend can select).
+//     All four are set unconditionally: a single-GPU or non-hybrid machine, or a machine
+//     without the corresponding vendor library installed, simply never resolves those names
+//     and the variables sit inert (this mirrors the existing "append both switch spellings,
+//     harmless if unmatched" posture above). Electron's GPU process on Linux is a fresh
+//     fork+exec, not a fork of an already-initialized zygote sharing loaded GL libraries, so
+//     it re-resolves the vendor library from environ at spawn time; setting process.env here
+//     (before app.whenReady(), same call site as the other two levers) lands before that
+//     spawn and is effective the current launch. Applied on EVERY launch (packaged or not):
+//     unlike the Windows registry lever there is no persistent host state to avoid polluting,
+//     so the dev loop benefits too. A caller-supplied override in the parent environment
+//     (say, the player already launches via their own `prime-run`) is left untouched: we only
+//     set a variable that is not already present, never overwrite one the player configured.
+//
 // The arg-building, query parsing, and token merging are pure and dependency-injected so
 // tests exercise them without a real registry or a real Electron app.
 
@@ -160,6 +183,31 @@ function hasUnparseableValueType(regQueryStdout) {
   return /\bREG_(?!SZ\b|EXPAND_SZ\b)[A-Z_]+/.test(String(regQueryStdout ?? ''));
 }
 
+// The Linux PRIME render-offload variables (see lever 3 above): Mesa's DRI_PRIME plus
+// NVIDIA's proprietary-driver GLX/Vulkan offload trio. Exported so a caller can log or pin
+// exactly which names this module sets.
+const LINUX_PRIME_ENV = Object.freeze({
+  DRI_PRIME: '1',
+  __NV_PRIME_RENDER_OFFLOAD: '1',
+  __GLX_VENDOR_LIBRARY_NAME: 'nvidia',
+  __VK_LAYER_NV_optimus: 'NVIDIA_only',
+});
+
+/**
+ * The env additions needed to request PRIME render offload, skipping any name the caller's
+ * environment already sets (a player who already launches via their own `prime-run` or has
+ * hand-picked `__GLX_VENDOR_LIBRARY_NAME` keeps their own value). Pure: returns only the
+ * NEW entries to apply, never mutates `existingEnv`.
+ */
+function buildLinuxPrimeEnv(existingEnv) {
+  const env = existingEnv ?? {};
+  const additions = {};
+  for (const [name, value] of Object.entries(LINUX_PRIME_ENV)) {
+    if (env[name] === undefined) additions[name] = value;
+  }
+  return additions;
+}
+
 // Vendor ids as getGPUInfo reports them: NVIDIA 0x10de, AMD 0x1002, Intel 0x8086,
 // Microsoft 0x1414 (the WARP software adapter).
 const DISCRETE_VENDOR_IDS = [0x10de, 0x1002];
@@ -206,6 +254,16 @@ function forceHighPerformanceGpu(deps = {}) {
       app?.commandLine?.appendSwitch(name);
     } catch (err) {
       log?.warn?.('[gpu] could not append switch', name, err);
+    }
+  }
+
+  if (platform === 'linux') {
+    const additions = buildLinuxPrimeEnv(env);
+    for (const [name, value] of Object.entries(additions)) {
+      env[name] = value;
+    }
+    if (Object.keys(additions).length > 0) {
+      log?.info?.('[gpu] set Linux PRIME render-offload env vars', Object.keys(additions));
     }
   }
 
@@ -268,6 +326,8 @@ module.exports = {
   USER_GPU_PREFERENCES_KEY,
   HIGH_PERFORMANCE_PREFERENCE,
   HIGH_PERF_GPU_SWITCHES,
+  LINUX_PRIME_ENV,
+  buildLinuxPrimeEnv,
   buildRegQueryArgs,
   buildRegWriteArgs,
   parseRegQueryData,

--- a/electron/gpu_preference.cjs
+++ b/electron/gpu_preference.cjs
@@ -1,4 +1,4 @@
-const { execFileSync: nodeExecFileSync } = require('node:child_process');
+const { execFileSync: nodeExecFileSync, spawn: nodeSpawn } = require('node:child_process');
 const nodePath = require('node:path');
 
 // Force the app onto the discrete (high-performance) GPU on hybrid systems, with ZERO
@@ -55,7 +55,7 @@ const nodePath = require('node:path');
 //     binary (one orphan entry per worktree, steering everything else launched from that
 //     shared binary); only the stable installed exe path is worth pinning.
 //
-//  3. Linux PRIME render-offload environment variables. On a Linux hybrid-graphics laptop
+//  3. Linux PRIME render-offload via a self-relaunch. On a Linux hybrid-graphics laptop
 //     (NVIDIA Optimus, AMD/Intel Mesa PRIME) there is no per-app OS-level preference to write
 //     (no registry equivalent) and force-high-performance-gpu is a no-op: the driver decides
 //     which adapter serves EGL/GLX at DYNAMIC-LINK time, before Chromium's own switch parsing
@@ -65,18 +65,28 @@ const nodePath = require('node:path');
 //     the NVIDIA proprietary driver), and for NVIDIA's proprietary PRIME render offload,
 //     __NV_PRIME_RENDER_OFFLOAD=1 plus __GLX_VENDOR_LIBRARY_NAME=nvidia (GLX) and
 //     __VK_LAYER_NV_optimus=NVIDIA_only (Vulkan, which Chromium's ANGLE backend can select).
-//     All four are set unconditionally: a single-GPU or non-hybrid machine, or a machine
-//     without the corresponding vendor library installed, simply never resolves those names
-//     and the variables sit inert (this mirrors the existing "append both switch spellings,
-//     harmless if unmatched" posture above). Electron's GPU process on Linux is a fresh
-//     fork+exec, not a fork of an already-initialized zygote sharing loaded GL libraries, so
-//     it re-resolves the vendor library from environ at spawn time; setting process.env here
-//     (before app.whenReady(), same call site as the other two levers) lands before that
-//     spawn and is effective the current launch. Applied on EVERY launch (packaged or not):
-//     unlike the Windows registry lever there is no persistent host state to avoid polluting,
-//     so the dev loop benefits too. A caller-supplied override in the parent environment
-//     (say, the player already launches via their own `prime-run`) is left untouched: we only
-//     set a variable that is not already present, never overwrite one the player configured.
+//     Mutating process.env for these at this call site (before app.whenReady(), same as the
+//     other two levers) does NOT work on Linux, unlike on Windows/macOS: Chromium's GPU
+//     process here is forked from an ALREADY-RUNNING zygote, and that zygote fork/exec'd off
+//     an environ snapshot the zygote took at ITS OWN exec, at the very first line of the
+//     Electron binary, before any of this script's JS ever ran. The zygote fork protocol
+//     passes argv and file descriptors, not the browser process's live environment, so a
+//     later process.env write in the main process is simply invisible to it (measured against
+//     real hybrid hardware: a variable set here changes nothing, while the identical variable
+//     set in the PARENT shell before the binary even starts changes GPU behavior immediately).
+//     The only lever early enough is to re-exec the whole process before Electron's own
+//     startup: relaunchForLinuxPrime spawns a fresh child (same binary, same argv) with the
+//     PRIME variables baked into ITS environ from birth, so the zygote it starts (and every
+//     GPU/renderer/utility process that zygote later forks) inherits them for real. The
+//     caller must invoke this and, if it returns true, exit immediately without creating any
+//     window or spawning the GPU process itself; a relaunch-marker env var guards against a
+//     relaunch loop. All four variables are set unconditionally in the child's env: a
+//     single-GPU or non-hybrid machine, or one missing the corresponding vendor library,
+//     simply never resolves those names and they sit inert (mirrors the "append both switch
+//     spellings, harmless if unmatched" posture above). A caller-supplied override already
+//     present in the parent environment (say, the player already launches via their own
+//     `prime-run`) is left untouched, and if every variable is already present the relaunch
+//     is skipped entirely (no infinite-relaunch risk even without the marker in that case).
 //
 // The arg-building, query parsing, and token merging are pure and dependency-injected so
 // tests exercise them without a real registry or a real Electron app.
@@ -184,14 +194,37 @@ function hasUnparseableValueType(regQueryStdout) {
 }
 
 // The Linux PRIME render-offload variables (see lever 3 above): Mesa's DRI_PRIME plus
-// NVIDIA's proprietary-driver GLX/Vulkan offload trio. Exported so a caller can log or pin
-// exactly which names this module sets.
+// NVIDIA's proprietary-driver offload set. Exported so a caller can log or pin exactly
+// which names this module sets.
+//
+// __GLX_VENDOR_LIBRARY_NAME alone is a decoy for this app: Chromium's GPU process creates
+// its context through EGL, not GLX, so the GLX var flips `glxinfo` to NVIDIA (making a fix
+// LOOK verified) while the unmasked WebGL renderer stays on the Intel iGPU. Verified on real
+// hybrid hardware (Intel Arrow Lake iGPU + NVIDIA RTX 5090 Laptop, proprietary driver 580,
+// Wayland session, Electron 43): only adding __EGL_VENDOR_LIBRARY_FILENAMES, pointed at the
+// NVIDIA GLVND EGL ICD json (the standard install path across glvnd-based distros), actually
+// moved the unmasked renderer to "ANGLE (NVIDIA Corporation, NVIDIA GeForce RTX 5090 Laptop
+// GPU ...)". The GLX/Vulkan vars are kept anyway (harmless if unmatched, and DRI_PRIME is
+// still the whole story for the Mesa-hybrid AMD/Intel case, which never touches EGL vendor
+// selection), but __EGL_VENDOR_LIBRARY_FILENAMES is the one that carries the NVIDIA
+// proprietary path documented above.
 const LINUX_PRIME_ENV = Object.freeze({
   DRI_PRIME: '1',
   __NV_PRIME_RENDER_OFFLOAD: '1',
   __GLX_VENDOR_LIBRARY_NAME: 'nvidia',
+  __EGL_VENDOR_LIBRARY_FILENAMES: '/usr/share/glvnd/egl_vendor.d/10_nvidia.json',
   __VK_LAYER_NV_optimus: 'NVIDIA_only',
 });
+
+// Same hardware test found the packaged app's GPU process crash-loops on a Wayland session
+// once PRIME offload is requested (exit_code=8704, "not compatible with Vulkan"), silently
+// falling back to software rendering, which is worse than the iGPU it started on. Chromium
+// picks its Ozone backend before any main-script JS runs (an appendSwitch call at this
+// call site, same as the PRIME env, measurably does nothing: verified against the same
+// hardware), so relaunchForLinuxPrime adds this as a real argv flag on the relaunched
+// process instead. Never added if the player's own argv already names an --ozone-platform
+// (their own explicit choice wins).
+const LINUX_OZONE_X11_ARG = '--ozone-platform=x11';
 
 /**
  * The env additions needed to request PRIME render offload, skipping any name the caller's
@@ -206,6 +239,67 @@ function buildLinuxPrimeEnv(existingEnv) {
     if (env[name] === undefined) additions[name] = value;
   }
   return additions;
+}
+
+// Guards relaunchForLinuxPrime against a relaunch loop: set on the child's env before
+// spawn, so a second call in that child (its argv/execPath resolve identically) sees the
+// marker and skips relaunching again. Without a real infinite loop risk even so, since
+// shouldRelaunchForLinuxPrime is also false once every variable is present, but the marker
+// is the cheap, explicit guard, checked first.
+const PRIME_RELAUNCH_MARKER = 'WOC_PRIME_RELAUNCHED';
+
+/**
+ * Whether this process should re-exec itself with the Linux PRIME env applied: not already a
+ * relaunched child (the marker), and at least one PRIME variable is actually missing (a
+ * player who already launches via their own `prime-run`, or a non-hybrid machine with no
+ * vendor library resolving the names anyway, still gets a no-op skip rather than a pointless
+ * relaunch).
+ */
+function shouldRelaunchForLinuxPrime(env) {
+  if (env?.[PRIME_RELAUNCH_MARKER] === '1') return false;
+  return Object.keys(buildLinuxPrimeEnv(env)).length > 0;
+}
+
+/**
+ * Re-exec the current process (same executable, same argv) with the Linux PRIME
+ * render-offload variables baked into the child's environment from birth. See lever 3 in the
+ * file header for why an in-process process.env mutation cannot work here: only an
+ * environment present before Electron's own startup (before the zygote's exec) ever reaches
+ * the GPU process. Detached + unref'd so the parent can exit without waiting on the child;
+ * stdio inherited so the player's console/log output is uninterrupted. Returns true when a
+ * relaunch was spawned, in which case the CALLER must exit immediately (app.exit()) without
+ * creating a window or doing any further Electron startup work in this process; returns false
+ * (nothing to do) on any other platform, when every variable is already present, or if the
+ * spawn itself fails.
+ */
+function relaunchForLinuxPrime(deps = {}) {
+  const platform = deps.platform ?? process.platform;
+  const env = deps.env ?? process.env;
+  const log = deps.log;
+
+  if (platform !== 'linux') return false;
+  if (!shouldRelaunchForLinuxPrime(env)) return false;
+
+  const spawnFn = deps.spawn ?? nodeSpawn;
+  const execPath = deps.execPath ?? process.execPath;
+  const baseArgv = deps.argv ?? process.argv.slice(1);
+  // A Wayland session's GPU process crash-loops once PRIME offload is requested unless
+  // Chromium is forced onto the X11 Ozone backend (see LINUX_OZONE_X11_ARG above); never
+  // added if the player's own argv already names an --ozone-platform.
+  const hasOzoneArg = baseArgv.some((a) => a.startsWith('--ozone-platform'));
+  const argv = hasOzoneArg ? baseArgv : [...baseArgv, LINUX_OZONE_X11_ARG];
+  const additions = buildLinuxPrimeEnv(env);
+  const childEnv = { ...env, ...additions, [PRIME_RELAUNCH_MARKER]: '1' };
+
+  try {
+    const child = spawnFn(execPath, argv, { env: childEnv, stdio: 'inherit', detached: true });
+    child.unref?.();
+    log?.info?.('[gpu] relaunching for Linux PRIME render offload', Object.keys(additions));
+    return true;
+  } catch (err) {
+    log?.warn?.('[gpu] could not relaunch for Linux PRIME render offload', err);
+    return false;
+  }
 }
 
 // Vendor ids as getGPUInfo reports them: NVIDIA 0x10de, AMD 0x1002, Intel 0x8086,
@@ -241,6 +335,10 @@ function summarizeGpuDevices(gpuDevices) {
  * write is logged and swallowed so the app always boots. MUST be called before app 'ready'
  * (so the switches are read) and before the first window (so the registry write beats the
  * GPU process on the current launch).
+ *
+ * Does NOT handle Linux: relaunchForLinuxPrime is a separate, earlier call the caller must
+ * make (and act on) before this function, since it requires a full process re-exec rather
+ * than an in-process env mutation (see lever 3 in the file header for why).
  */
 function forceHighPerformanceGpu(deps = {}) {
   const app = deps.app;
@@ -254,16 +352,6 @@ function forceHighPerformanceGpu(deps = {}) {
       app?.commandLine?.appendSwitch(name);
     } catch (err) {
       log?.warn?.('[gpu] could not append switch', name, err);
-    }
-  }
-
-  if (platform === 'linux') {
-    const additions = buildLinuxPrimeEnv(env);
-    for (const [name, value] of Object.entries(additions)) {
-      env[name] = value;
-    }
-    if (Object.keys(additions).length > 0) {
-      log?.info?.('[gpu] set Linux PRIME render-offload env vars', Object.keys(additions));
     }
   }
 
@@ -327,7 +415,10 @@ module.exports = {
   HIGH_PERFORMANCE_PREFERENCE,
   HIGH_PERF_GPU_SWITCHES,
   LINUX_PRIME_ENV,
+  LINUX_OZONE_X11_ARG,
   buildLinuxPrimeEnv,
+  shouldRelaunchForLinuxPrime,
+  relaunchForLinuxPrime,
   buildRegQueryArgs,
   buildRegWriteArgs,
   parseRegQueryData,

--- a/electron/gpu_preference.cjs
+++ b/electron/gpu_preference.cjs
@@ -1,4 +1,5 @@
 const { execFileSync: nodeExecFileSync, spawn: nodeSpawn } = require('node:child_process');
+const { existsSync: nodeExistsSync, readdirSync: nodeReaddirSync } = require('node:fs');
 const nodePath = require('node:path');
 
 // Force the app onto the discrete (high-performance) GPU on hybrid systems, with ZERO
@@ -79,14 +80,36 @@ const nodePath = require('node:path');
 //     PRIME variables baked into ITS environ from birth, so the zygote it starts (and every
 //     GPU/renderer/utility process that zygote later forks) inherits them for real. The
 //     caller must invoke this and, if it returns true, exit immediately without creating any
-//     window or spawning the GPU process itself; a relaunch-marker env var guards against a
-//     relaunch loop. All four variables are set unconditionally in the child's env: a
-//     single-GPU or non-hybrid machine, or one missing the corresponding vendor library,
-//     simply never resolves those names and they sit inert (mirrors the "append both switch
-//     spellings, harmless if unmatched" posture above). A caller-supplied override already
-//     present in the parent environment (say, the player already launches via their own
-//     `prime-run`) is left untouched, and if every variable is already present the relaunch
-//     is skipped entirely (no infinite-relaunch risk even without the marker in that case).
+//     window or spawning the GPU process itself. Four constraints shape the details:
+//     (a) HYBRID-GATED: the relaunch only happens when /sys/class/drm exposes two or more
+//         GPUs (isLinuxHybridGpu). A single-GPU machine gets neither the extra spawn nor a
+//         forced --ozone-platform=x11 (which would silently move native-Wayland players onto
+//         XWayland for no benefit, and would strand a Wayland-only setup with no XWayland).
+//     (b) APPIMAGE-AWARE SPAWN SOURCE: in an AppImage, process.execPath points INSIDE the
+//         runtime's FUSE mount, and that mount's daemon is the runtime process, which
+//         unmounts and exits the moment its child (this process) exits; a child spawned from
+//         execPath loses its own binary mid-startup (measured: killing the runtime yields
+//         EIO on already-open fds). So the spawn source is env.APPIMAGE (the outer file,
+//         same source electron-updater restarts from) whenever it is set, execPath otherwise.
+//     (c) THE SKIP CONDITION COVERS BOTH HALVES of the fix, env AND argv. The env half
+//         propagates by inheritance but the argv half does not: electron-updater's
+//         restart-to-update respawns the app with the CURRENT env (marker and PRIME vars
+//         included) and EMPTY argv, so a marker-only skip would leave the updated process
+//         running PRIME without --ozone-platform=x11, the exact Wayland crash-loop state
+//         documented below. Once the marker is present, the relaunch re-fires if and only
+//         if argv still lacks an explicit --ozone-platform choice; every relaunch produces
+//         a child that HAS one, so this cannot loop.
+//     (d) A caller-supplied override already present in the parent environment (say, the
+//         player already launches via their own `prime-run`) is left untouched per name,
+//         and with no marker and every variable already present the relaunch is skipped
+//         entirely (that environment is wholly the player's own choice).
+//     The variables themselves are safe to set on any hybrid machine: a machine missing the
+//     corresponding vendor library never resolves those names and they sit inert (mirrors
+//     the "append both switch spellings, harmless if unmatched" posture above). The ONE
+//     exception is __EGL_VENDOR_LIBRARY_FILENAMES, which glvnd treats as a REPLACEMENT of
+//     its EGL vendor list, not an addition: naming a json that does not exist leaves EGL
+//     with zero vendors and no GL at all, so that entry is included only when the file
+//     actually exists (buildLinuxPrimeEnv's fileExists gate).
 //
 // The arg-building, query parsing, and token merging are pure and dependency-injected so
 // tests exercise them without a real registry or a real Electron app.
@@ -197,17 +220,20 @@ function hasUnparseableValueType(regQueryStdout) {
 // NVIDIA's proprietary-driver offload set. Exported so a caller can log or pin exactly
 // which names this module sets.
 //
-// __GLX_VENDOR_LIBRARY_NAME alone is a decoy for this app: Chromium's GPU process creates
-// its context through EGL, not GLX, so the GLX var flips `glxinfo` to NVIDIA (making a fix
-// LOOK verified) while the unmasked WebGL renderer stays on the Intel iGPU. Verified on real
+// Which variable does the lifting depends on the path Chromium takes, both measured on real
 // hybrid hardware (Intel Arrow Lake iGPU + NVIDIA RTX 5090 Laptop, proprietary driver 580,
-// Wayland session, Electron 43): only adding __EGL_VENDOR_LIBRARY_FILENAMES, pointed at the
-// NVIDIA GLVND EGL ICD json (the standard install path across glvnd-based distros), actually
-// moved the unmasked renderer to "ANGLE (NVIDIA Corporation, NVIDIA GeForce RTX 5090 Laptop
-// GPU ...)". The GLX/Vulkan vars are kept anyway (harmless if unmatched, and DRI_PRIME is
-// still the whole story for the Mesa-hybrid AMD/Intel case, which never touches EGL vendor
-// selection), but __EGL_VENDOR_LIBRARY_FILENAMES is the one that carries the NVIDIA
-// proprietary path documented above.
+// Electron 43): under the --ozone-platform=x11 flow this module forces, ANGLE binds through
+// GLX (renderer strings report desktop "OpenGL", not "OpenGL ES") and the GLX pair
+// (__NV_PRIME_RENDER_OFFLOAD + __GLX_VENDOR_LIBRARY_NAME) selects the adapter; the same set
+// minus the EGL line still lands on the NVIDIA GPU there. On EGL paths (a player-forced
+// Wayland ozone), the GLX pair is a decoy (it flips `glxinfo` to NVIDIA while the unmasked
+// WebGL renderer stays on the iGPU) and __EGL_VENDOR_LIBRARY_FILENAMES, pointed at the
+// NVIDIA GLVND EGL ICD json, is the lever that moves the renderer. So the EGL entry is
+// belt-and-suspenders for the shipped flow and load-bearing for the EGL one; it stays, but
+// gated on the json actually existing (see lever 3 (d) and buildLinuxPrimeEnv), because on a
+// machine without the NVIDIA driver glvnd would otherwise be left with ZERO EGL vendors.
+// DRI_PRIME remains the whole story for the Mesa-hybrid AMD/Intel case, which never touches
+// EGL vendor selection.
 const LINUX_PRIME_ENV = Object.freeze({
   DRI_PRIME: '1',
   __NV_PRIME_RENDER_OFFLOAD: '1',
@@ -222,55 +248,95 @@ const LINUX_PRIME_ENV = Object.freeze({
 // picks its Ozone backend before any main-script JS runs (an appendSwitch call at this
 // call site, same as the PRIME env, measurably does nothing: verified against the same
 // hardware), so relaunchForLinuxPrime adds this as a real argv flag on the relaunched
-// process instead. Never added if the player's own argv already names an --ozone-platform
-// (their own explicit choice wins).
+// process instead. Never added when the player's own argv already makes an EXPLICIT
+// --ozone-platform=... choice (that wins). A bare --ozone-platform-hint does NOT suppress
+// it: a hint is a preference Chromium lets an explicit flag override, and honoring a
+// hint-of-wayland while injecting PRIME would recreate the crash-loop.
 const LINUX_OZONE_X11_ARG = '--ozone-platform=x11';
+
+/**
+ * Whether argv already contains an explicit --ozone-platform choice (the exact flag or its
+ * =value form). --ozone-platform-hint deliberately does not count; see LINUX_OZONE_X11_ARG.
+ */
+function hasExplicitOzonePlatformArg(argv) {
+  return (argv ?? []).some((a) => a === '--ozone-platform' || a.startsWith('--ozone-platform='));
+}
 
 /**
  * The env additions needed to request PRIME render offload, skipping any name the caller's
  * environment already sets (a player who already launches via their own `prime-run` or has
- * hand-picked `__GLX_VENDOR_LIBRARY_NAME` keeps their own value). Pure: returns only the
- * NEW entries to apply, never mutates `existingEnv`.
+ * hand-picked `__GLX_VENDOR_LIBRARY_NAME` keeps their own value). The
+ * __EGL_VENDOR_LIBRARY_FILENAMES entry is additionally skipped when the json it names does
+ * not exist on this machine: glvnd treats that variable as a REPLACEMENT of its vendor
+ * list, so naming a missing file would leave EGL with zero vendors and no GL at all
+ * (every non-NVIDIA machine lacks the file). `fileExists` is injectable for tests. Returns
+ * only the NEW entries to apply, never mutates `existingEnv`.
  */
-function buildLinuxPrimeEnv(existingEnv) {
+function buildLinuxPrimeEnv(existingEnv, fileExists = nodeExistsSync) {
   const env = existingEnv ?? {};
   const additions = {};
   for (const [name, value] of Object.entries(LINUX_PRIME_ENV)) {
-    if (env[name] === undefined) additions[name] = value;
+    if (env[name] !== undefined) continue;
+    if (name === '__EGL_VENDOR_LIBRARY_FILENAMES' && !fileExists(value)) continue;
+    additions[name] = value;
   }
   return additions;
 }
 
-// Guards relaunchForLinuxPrime against a relaunch loop: set on the child's env before
-// spawn, so a second call in that child (its argv/execPath resolve identically) sees the
-// marker and skips relaunching again. Without a real infinite loop risk even so, since
-// shouldRelaunchForLinuxPrime is also false once every variable is present, but the marker
-// is the cheap, explicit guard, checked first.
+// Marks a process whose environment THIS module configured (as opposed to a player's own
+// prime-run/wrapper env): set on the child's env before spawn. It is deliberately NOT a
+// blanket "never relaunch again" switch, because the env half of the fix propagates by
+// inheritance while the argv half does not: electron-updater's restart-to-update respawns
+// the app with the current env (marker included) and EMPTY argv, and that process still
+// needs --ozone-platform=x11 re-applied (see lever 3 (c)). Loop safety comes from the argv
+// check instead: every relaunch produces a child whose argv carries an explicit
+// --ozone-platform, and a marked process with one never relaunches.
 const PRIME_RELAUNCH_MARKER = 'WOC_PRIME_RELAUNCHED';
 
 /**
- * Whether this process should re-exec itself with the Linux PRIME env applied: not already a
- * relaunched child (the marker), and at least one PRIME variable is actually missing (a
- * player who already launches via their own `prime-run`, or a non-hybrid machine with no
- * vendor library resolving the names anyway, still gets a no-op skip rather than a pointless
- * relaunch).
+ * Whether this process should re-exec itself with the Linux PRIME env applied.
+ * - Marker present (this env was configured by a previous relaunch, then possibly inherited
+ *   through an updater restart): relaunch only if argv still lacks an explicit
+ *   --ozone-platform choice, i.e. only to restore the argv half. Cannot loop: the relaunch
+ *   always yields a child with an explicit --ozone-platform in argv.
+ * - No marker: relaunch if at least one PRIME variable is missing. A player who already
+ *   launches via their own `prime-run` (every variable present, no marker) gets a no-op
+ *   skip: that environment is wholly their own choice, flag included or not.
  */
-function shouldRelaunchForLinuxPrime(env) {
-  if (env?.[PRIME_RELAUNCH_MARKER] === '1') return false;
-  return Object.keys(buildLinuxPrimeEnv(env)).length > 0;
+function shouldRelaunchForLinuxPrime(env, argv, fileExists = nodeExistsSync) {
+  if (env?.[PRIME_RELAUNCH_MARKER] === '1') return !hasExplicitOzonePlatformArg(argv);
+  return Object.keys(buildLinuxPrimeEnv(env, fileExists)).length > 0;
 }
 
 /**
- * Re-exec the current process (same executable, same argv) with the Linux PRIME
- * render-offload variables baked into the child's environment from birth. See lever 3 in the
- * file header for why an in-process process.env mutation cannot work here: only an
- * environment present before Electron's own startup (before the zygote's exec) ever reaches
- * the GPU process. Detached + unref'd so the parent can exit without waiting on the child;
- * stdio inherited so the player's console/log output is uninterrupted. Returns true when a
- * relaunch was spawned, in which case the CALLER must exit immediately (app.exit()) without
- * creating a window or doing any further Electron startup work in this process; returns false
- * (nothing to do) on any other platform, when every variable is already present, or if the
- * spawn itself fails.
+ * True when /sys/class/drm exposes two or more GPU card devices, the hybrid-graphics case
+ * this whole lever exists for. Needs no Electron API (getGPUInfo needs app ready, far too
+ * late to decide a relaunch), so it can run at the very top of main. On any read failure
+ * (exotic sandbox, no /sys) it returns false: when we cannot tell, we impose neither the
+ * extra spawn nor a forced X11 backend on the player. `readdir` is injectable for tests.
+ */
+function isLinuxHybridGpu(readdir = nodeReaddirSync) {
+  try {
+    const cards = readdir('/sys/class/drm').filter((name) => /^card\d+$/.test(name));
+    return cards.length >= 2;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Re-exec the current process (same argv, PRIME env baked into the child's environment from
+ * birth). See lever 3 in the file header for why an in-process process.env mutation cannot
+ * work here: only an environment present before Electron's own startup (before the zygote's
+ * exec) ever reaches the GPU process. Hybrid-gated (lever 3 (a)); the spawn source is
+ * env.APPIMAGE when set, because in an AppImage process.execPath dies with the parent's
+ * FUSE mount (lever 3 (b)). Detached + unref'd so the parent can exit without waiting on
+ * the child; stdio inherited so the player's console output is uninterrupted. Returns true
+ * when a relaunch was spawned, in which case the CALLER must exit immediately via
+ * process.exit(0), which stops the main script before any further statement runs (app.exit
+ * also works but only after the app module is usable; process.exit needs nothing). Returns
+ * false (nothing to do) on any other platform, on a non-hybrid machine, when this process
+ * is already correctly configured, or if the spawn itself fails.
  */
 function relaunchForLinuxPrime(deps = {}) {
   const platform = deps.platform ?? process.platform;
@@ -278,23 +344,40 @@ function relaunchForLinuxPrime(deps = {}) {
   const log = deps.log;
 
   if (platform !== 'linux') return false;
-  if (!shouldRelaunchForLinuxPrime(env)) return false;
+  const isHybrid = deps.isHybridGpu ?? isLinuxHybridGpu;
+  if (!isHybrid()) return false;
+  const fileExists = deps.fileExists ?? nodeExistsSync;
+  const baseArgv = deps.argv ?? process.argv.slice(1);
+  if (!shouldRelaunchForLinuxPrime(env, baseArgv, fileExists)) return false;
 
   const spawnFn = deps.spawn ?? nodeSpawn;
+  // In an AppImage, execPath points inside the runtime's FUSE mount, which dies the moment
+  // this process exits; the outer AppImage file (env.APPIMAGE, the same source
+  // electron-updater restarts from) survives and brings up a fresh runtime + mount.
   const execPath = deps.execPath ?? process.execPath;
-  const baseArgv = deps.argv ?? process.argv.slice(1);
+  const appImage =
+    typeof env.APPIMAGE === 'string' && nodePath.isAbsolute(env.APPIMAGE) ? env.APPIMAGE : null;
+  const spawnTarget = appImage ?? execPath;
   // A Wayland session's GPU process crash-loops once PRIME offload is requested unless
   // Chromium is forced onto the X11 Ozone backend (see LINUX_OZONE_X11_ARG above); never
-  // added if the player's own argv already names an --ozone-platform.
-  const hasOzoneArg = baseArgv.some((a) => a.startsWith('--ozone-platform'));
-  const argv = hasOzoneArg ? baseArgv : [...baseArgv, LINUX_OZONE_X11_ARG];
-  const additions = buildLinuxPrimeEnv(env);
+  // added when the player's own argv already makes an explicit --ozone-platform choice.
+  const argv = hasExplicitOzonePlatformArg(baseArgv)
+    ? baseArgv
+    : [...baseArgv, LINUX_OZONE_X11_ARG];
+  const additions = buildLinuxPrimeEnv(env, fileExists);
   const childEnv = { ...env, ...additions, [PRIME_RELAUNCH_MARKER]: '1' };
 
   try {
-    const child = spawnFn(execPath, argv, { env: childEnv, stdio: 'inherit', detached: true });
+    const child = spawnFn(spawnTarget, argv, {
+      env: childEnv,
+      stdio: 'inherit',
+      detached: true,
+    });
     child.unref?.();
-    log?.info?.('[gpu] relaunching for Linux PRIME render offload', Object.keys(additions));
+    log?.info?.('[gpu] relaunching for Linux PRIME render offload', {
+      spawnTarget,
+      added: Object.keys(additions),
+    });
     return true;
   } catch (err) {
     log?.warn?.('[gpu] could not relaunch for Linux PRIME render offload', err);
@@ -416,7 +499,10 @@ module.exports = {
   HIGH_PERF_GPU_SWITCHES,
   LINUX_PRIME_ENV,
   LINUX_OZONE_X11_ARG,
+  PRIME_RELAUNCH_MARKER,
   buildLinuxPrimeEnv,
+  hasExplicitOzonePlatformArg,
+  isLinuxHybridGpu,
   shouldRelaunchForLinuxPrime,
   relaunchForLinuxPrime,
   buildRegQueryArgs,

--- a/electron/gpu_preference.d.cts
+++ b/electron/gpu_preference.d.cts
@@ -5,7 +5,11 @@
 export const USER_GPU_PREFERENCES_KEY: string;
 export const HIGH_PERFORMANCE_PREFERENCE: string;
 export const HIGH_PERF_GPU_SWITCHES: readonly string[];
+export const LINUX_PRIME_ENV: Readonly<Record<string, string>>;
 
+export function buildLinuxPrimeEnv(
+  existingEnv?: Record<string, string | undefined>,
+): Record<string, string>;
 export function buildRegQueryArgs(exePath: string): string[];
 export function buildRegWriteArgs(exePath: string, data?: string): string[];
 export function parseRegQueryData(regQueryStdout: unknown): string;

--- a/electron/gpu_preference.d.cts
+++ b/electron/gpu_preference.d.cts
@@ -6,10 +6,26 @@ export const USER_GPU_PREFERENCES_KEY: string;
 export const HIGH_PERFORMANCE_PREFERENCE: string;
 export const HIGH_PERF_GPU_SWITCHES: readonly string[];
 export const LINUX_PRIME_ENV: Readonly<Record<string, string>>;
+export const LINUX_OZONE_X11_ARG: string;
 
 export function buildLinuxPrimeEnv(
   existingEnv?: Record<string, string | undefined>,
 ): Record<string, string>;
+export function shouldRelaunchForLinuxPrime(env?: Record<string, string | undefined>): boolean;
+
+export interface RelaunchForLinuxPrimeDeps {
+  platform?: string;
+  env?: Record<string, string | undefined>;
+  spawn?: (command: string, args: string[], options?: unknown) => { unref?(): void };
+  execPath?: string;
+  argv?: string[];
+  log?: {
+    info?(...args: unknown[]): void;
+    warn?(...args: unknown[]): void;
+  };
+}
+export function relaunchForLinuxPrime(deps?: RelaunchForLinuxPrimeDeps): boolean;
+
 export function buildRegQueryArgs(exePath: string): string[];
 export function buildRegWriteArgs(exePath: string, data?: string): string[];
 export function parseRegQueryData(regQueryStdout: unknown): string;

--- a/electron/gpu_preference.d.cts
+++ b/electron/gpu_preference.d.cts
@@ -7,11 +7,19 @@ export const HIGH_PERFORMANCE_PREFERENCE: string;
 export const HIGH_PERF_GPU_SWITCHES: readonly string[];
 export const LINUX_PRIME_ENV: Readonly<Record<string, string>>;
 export const LINUX_OZONE_X11_ARG: string;
+export const PRIME_RELAUNCH_MARKER: string;
 
 export function buildLinuxPrimeEnv(
   existingEnv?: Record<string, string | undefined>,
+  fileExists?: (path: string) => boolean,
 ): Record<string, string>;
-export function shouldRelaunchForLinuxPrime(env?: Record<string, string | undefined>): boolean;
+export function hasExplicitOzonePlatformArg(argv?: string[]): boolean;
+export function isLinuxHybridGpu(readdir?: (path: string) => string[]): boolean;
+export function shouldRelaunchForLinuxPrime(
+  env?: Record<string, string | undefined>,
+  argv?: string[],
+  fileExists?: (path: string) => boolean,
+): boolean;
 
 export interface RelaunchForLinuxPrimeDeps {
   platform?: string;
@@ -19,6 +27,8 @@ export interface RelaunchForLinuxPrimeDeps {
   spawn?: (command: string, args: string[], options?: unknown) => { unref?(): void };
   execPath?: string;
   argv?: string[];
+  isHybridGpu?: () => boolean;
+  fileExists?: (path: string) => boolean;
   log?: {
     info?(...args: unknown[]): void;
     warn?(...args: unknown[]): void;

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -40,6 +40,7 @@ const { attachRendererCrashRecovery, installProcessCrashGuards } = require('./cr
 const { initUpdater } = require('./updater.cjs');
 const {
   forceHighPerformanceGpu,
+  PRIME_RELAUNCH_MARKER,
   relaunchForLinuxPrime,
   summarizeGpuDevices,
 } = require('./gpu_preference.cjs');
@@ -54,11 +55,13 @@ const {
 // GPU process forks from a zygote that already exec'd (and snapshotted its environ) before
 // any of this script's lines run, so a later process.env write is invisible to it. This is
 // the earliest point re-exec can happen (before crash reporting, logging, or any window are
-// set up in this soon-to-exit process), and it must run before app 'ready'.
-if (relaunchForLinuxPrime({ app })) {
-  // process.exit (not app.exit, which only quits asynchronously) stops this script from
-  // executing any further statement below, so the rest of this soon-to-be-replaced
-  // process never sets up crash reporting, logging, or a window.
+// set up in this soon-to-exit process), and it must run before app 'ready'. log: console
+// because file logging is deliberately not initialized yet in this soon-to-exit process; the
+// durable main.log evidence is the relaunched-child line the child writes below.
+if (relaunchForLinuxPrime({ log: console })) {
+  // process.exit stops the main script before any statement below runs, so this
+  // soon-to-be-replaced process never sets up crash reporting, logging, or a window
+  // (app.exit would also exit promptly, but process.exit depends on nothing).
   process.exit(0);
 }
 
@@ -129,6 +132,13 @@ crashReporter.start({
 // diagnosable; the renderer's warnings/errors and uncaught exceptions are
 // mirrored into the same file below.
 const { log, filePath: logFilePath } = initLogging({ isPackaged: app.isPackaged });
+
+// The durable evidence that the Linux PRIME relaunch happened: the parent that spawned us
+// exited before logging existed, so the CHILD records it (docs/desktop-release.md points
+// its GPU verification checklist at this line).
+if (process.platform === 'linux' && process.env[PRIME_RELAUNCH_MARKER] === '1') {
+  log.info('[gpu] running as PRIME-relaunched child (Linux discrete-GPU offload env active)');
+}
 
 // Force the discrete high-performance GPU on hybrid (Optimus) systems, with zero user
 // action. Runs before app 'ready' (so the Chromium switches are read) and before any

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -38,11 +38,29 @@ const { initLogging } = require('./logging.cjs');
 const { DEFAULT_SHELL_STRINGS, sanitizeShellStrings } = require('./shell_strings.cjs');
 const { attachRendererCrashRecovery, installProcessCrashGuards } = require('./crash_guard.cjs');
 const { initUpdater } = require('./updater.cjs');
-const { forceHighPerformanceGpu, summarizeGpuDevices } = require('./gpu_preference.cjs');
+const {
+  forceHighPerformanceGpu,
+  relaunchForLinuxPrime,
+  summarizeGpuDevices,
+} = require('./gpu_preference.cjs');
 const {
   buildWalletHandoffBrowserUrl,
   parseWalletHandoffDeepLink,
 } = require('./wallet_handoff.cjs');
+
+// On a Linux hybrid-graphics laptop, the PRIME render-offload env vars (DRI_PRIME,
+// __NV_PRIME_RENDER_OFFLOAD, etc; see electron/gpu_preference.cjs) only reach the GPU
+// process if they are present in THIS process's environment from birth: Electron's Linux
+// GPU process forks from a zygote that already exec'd (and snapshotted its environ) before
+// any of this script's lines run, so a later process.env write is invisible to it. This is
+// the earliest point re-exec can happen (before crash reporting, logging, or any window are
+// set up in this soon-to-exit process), and it must run before app 'ready'.
+if (relaunchForLinuxPrime({ app })) {
+  // process.exit (not app.exit, which only quits asynchronously) stops this script from
+  // executing any further statement below, so the rest of this soon-to-be-replaced
+  // process never sets up crash reporting, logging, or a window.
+  process.exit(0);
+}
 
 const APP_ORIGIN = 'app://worldofclaudecraft';
 // The Vite dev server URL is a DEV-ONLY seam (electron-dev.mjs sets it): its

--- a/scripts/electron-dev.mjs
+++ b/scripts/electron-dev.mjs
@@ -1,6 +1,33 @@
 import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
 import { setTimeout as delay } from 'node:timers/promises';
 import { buildElectronVendor } from './electron-vendor.mjs';
+
+const {
+  buildLinuxPrimeEnv,
+  isLinuxHybridGpu,
+  LINUX_OZONE_X11_ARG,
+  PRIME_RELAUNCH_MARKER,
+  shouldRelaunchForLinuxPrime,
+} = createRequire(import.meta.url)('../electron/gpu_preference.cjs');
+
+// On Linux hybrid-graphics machines main.cjs re-execs itself to bake the PRIME offload env
+// in (see electron/gpu_preference.cjs lever 3). In THIS orchestrator that would be fatal:
+// the parent electron exits immediately, the 'exit' handler below tears down Vite, and the
+// detached child is left running against a dead dev server. So the dev spawn pre-applies
+// the exact configuration the relaunch would have produced (env additions + marker + the
+// explicit ozone flag), which both suppresses the relaunch and gives Linux dev runs the
+// discrete-GPU offload for real. Same-machine no-ops (non-Linux, non-hybrid, or an env the
+// player already configured) fall out of the same predicates main.cjs uses.
+function linuxPrimeDevConfig() {
+  if (process.platform !== 'linux') return { env: {}, args: [] };
+  if (!isLinuxHybridGpu()) return { env: {}, args: [] };
+  if (!shouldRelaunchForLinuxPrime(process.env, [])) return { env: {}, args: [] };
+  return {
+    env: { ...buildLinuxPrimeEnv(process.env), [PRIME_RELAUNCH_MARKER]: '1' },
+    args: [LINUX_OZONE_X11_ARG],
+  };
+}
 
 const viteUrl = process.env.VITE_DEV_SERVER_URL ?? 'http://127.0.0.1:5173';
 const onlineOrigin = process.env.VITE_DESKTOP_API_ORIGIN ?? 'https://worldofclaudecraft.com';
@@ -53,9 +80,11 @@ try {
   // before launching the shell.
   buildElectronVendor();
   await waitForVite();
-  const electron = spawn(electronCommand, ['.'], {
+  const prime = linuxPrimeDevConfig();
+  const electron = spawn(electronCommand, ['.', ...prime.args], {
     env: {
       ...process.env,
+      ...prime.env,
       VITE_DEV_SERVER_URL: viteUrl,
       VITE_DESKTOP_API_ORIGIN: onlineOrigin,
       VITE_DESKTOP_LOGIN_ORIGIN: viteUrl,

--- a/tests/electron_gpu_preference.test.ts
+++ b/tests/electron_gpu_preference.test.ts
@@ -2,12 +2,14 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 import {
   alreadyHighPerformance,
+  buildLinuxPrimeEnv,
   buildRegQueryArgs,
   buildRegWriteArgs,
   forceHighPerformanceGpu,
   HIGH_PERF_GPU_SWITCHES,
   HIGH_PERFORMANCE_PREFERENCE,
   hasUnparseableValueType,
+  LINUX_PRIME_ENV,
   mergeHighPerformancePreference,
   parseRegQueryData,
   summarizeGpuDevices,
@@ -262,6 +264,31 @@ describe('summarizeGpuDevices', () => {
   });
 });
 
+describe('buildLinuxPrimeEnv', () => {
+  it('offers all four PRIME offload variables against an empty environment', () => {
+    expect(buildLinuxPrimeEnv({})).toEqual(LINUX_PRIME_ENV);
+  });
+
+  it('never overrides a variable the caller already set', () => {
+    // A player who already launches via their own `prime-run`, or who hand-picked a
+    // vendor library, keeps their own value; we only fill in what is missing.
+    const existing = { __GLX_VENDOR_LIBRARY_NAME: 'mesa', UNRELATED: 'x' };
+    const additions = buildLinuxPrimeEnv(existing);
+    expect(additions).toEqual({
+      DRI_PRIME: '1',
+      __NV_PRIME_RENDER_OFFLOAD: '1',
+      __VK_LAYER_NV_optimus: 'NVIDIA_only',
+    });
+    expect(additions).not.toHaveProperty('__GLX_VENDOR_LIBRARY_NAME');
+  });
+
+  it('does not mutate the environment object passed in', () => {
+    const existing = { FOO: 'bar' };
+    buildLinuxPrimeEnv(existing);
+    expect(existing).toEqual({ FOO: 'bar' });
+  });
+});
+
 describe('forceHighPerformanceGpu', () => {
   it('appends both switches on non-Windows and never touches the registry', () => {
     const { app, switches } = fakeApp();
@@ -269,6 +296,31 @@ describe('forceHighPerformanceGpu', () => {
     forceHighPerformanceGpu({ app, platform: 'darwin', execFileSync });
     expect(switches).toEqual(['force-high-performance-gpu', 'force_high_performance_gpu']);
     expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('sets the Linux PRIME offload env vars (and never touches the registry)', () => {
+    const { app, switches } = fakeApp();
+    const execFileSync = vi.fn();
+    const env = {};
+    forceHighPerformanceGpu({ app, platform: 'linux', execFileSync, env });
+    expect(switches).toEqual(['force-high-performance-gpu', 'force_high_performance_gpu']);
+    expect(env).toEqual(LINUX_PRIME_ENV);
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('leaves a caller-configured Linux env var alone', () => {
+    const { app } = fakeApp();
+    const env: Record<string, string> = { __GLX_VENDOR_LIBRARY_NAME: 'mesa' };
+    forceHighPerformanceGpu({ app, platform: 'linux', execFileSync: vi.fn(), env });
+    expect(env.__GLX_VENDOR_LIBRARY_NAME).toBe('mesa');
+    expect(env.DRI_PRIME).toBe('1');
+  });
+
+  it('applies the Linux env vars on an UNPACKAGED run too (no persistent host state to protect)', () => {
+    const { app } = fakeApp({ isPackaged: false });
+    const env = {};
+    forceHighPerformanceGpu({ app, platform: 'linux', execFileSync: vi.fn(), env });
+    expect(env).toEqual(LINUX_PRIME_ENV);
   });
 
   it('appends the switches but skips the registry in an unpackaged (dev) run', () => {

--- a/tests/electron_gpu_preference.test.ts
+++ b/tests/electron_gpu_preference.test.ts
@@ -9,9 +9,12 @@ import {
   HIGH_PERF_GPU_SWITCHES,
   HIGH_PERFORMANCE_PREFERENCE,
   hasUnparseableValueType,
+  LINUX_OZONE_X11_ARG,
   LINUX_PRIME_ENV,
   mergeHighPerformancePreference,
   parseRegQueryData,
+  relaunchForLinuxPrime,
+  shouldRelaunchForLinuxPrime,
   summarizeGpuDevices,
   USER_GPU_PREFERENCES_KEY,
 } from '../electron/gpu_preference.cjs';
@@ -277,6 +280,7 @@ describe('buildLinuxPrimeEnv', () => {
     expect(additions).toEqual({
       DRI_PRIME: '1',
       __NV_PRIME_RENDER_OFFLOAD: '1',
+      __EGL_VENDOR_LIBRARY_FILENAMES: LINUX_PRIME_ENV.__EGL_VENDOR_LIBRARY_FILENAMES,
       __VK_LAYER_NV_optimus: 'NVIDIA_only',
     });
     expect(additions).not.toHaveProperty('__GLX_VENDOR_LIBRARY_NAME');
@@ -289,6 +293,122 @@ describe('buildLinuxPrimeEnv', () => {
   });
 });
 
+describe('shouldRelaunchForLinuxPrime', () => {
+  it('is true when at least one PRIME variable is missing', () => {
+    expect(shouldRelaunchForLinuxPrime({})).toBe(true);
+  });
+
+  it('is false once every PRIME variable is already present', () => {
+    expect(shouldRelaunchForLinuxPrime({ ...LINUX_PRIME_ENV })).toBe(false);
+  });
+
+  it('is false once the relaunch marker is set, even if variables are still missing', () => {
+    // Guards against a relaunch loop: a child whose spawn options somehow still lack a
+    // variable must not relaunch itself again.
+    expect(shouldRelaunchForLinuxPrime({ WOC_PRIME_RELAUNCHED: '1' })).toBe(false);
+  });
+});
+
+describe('relaunchForLinuxPrime', () => {
+  function fakeSpawn() {
+    const calls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
+    const unref = vi.fn();
+    const spawn = vi.fn((command: string, args: string[], options?: unknown) => {
+      calls.push({ command, args, options: options as Record<string, unknown> });
+      return { unref };
+    });
+    return { spawn, calls, unref };
+  }
+
+  it('does nothing on a non-Linux platform', () => {
+    const { spawn } = fakeSpawn();
+    expect(relaunchForLinuxPrime({ platform: 'win32', spawn, env: {} })).toBe(false);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when every PRIME variable is already present', () => {
+    const { spawn } = fakeSpawn();
+    const env = { ...LINUX_PRIME_ENV };
+    expect(relaunchForLinuxPrime({ platform: 'linux', spawn, env })).toBe(false);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the relaunch marker is already set (loop guard)', () => {
+    const { spawn } = fakeSpawn();
+    const env = { WOC_PRIME_RELAUNCHED: '1' };
+    expect(relaunchForLinuxPrime({ platform: 'linux', spawn, env })).toBe(false);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('re-execs the same binary and argv with the PRIME env baked in, and unrefs the child', () => {
+    const { spawn, calls, unref } = fakeSpawn();
+    const env = { UNRELATED: 'x' };
+    const result = relaunchForLinuxPrime({
+      platform: 'linux',
+      spawn,
+      env,
+      execPath: '/usr/bin/world-of-claudecraft',
+      argv: ['--some-flag'],
+      log: { info: vi.fn() },
+    });
+    expect(result).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe('/usr/bin/world-of-claudecraft');
+    expect(calls[0].args).toEqual(['--some-flag', LINUX_OZONE_X11_ARG]);
+    expect(calls[0].options).toMatchObject({ stdio: 'inherit', detached: true });
+    const childEnv = calls[0].options.env as Record<string, string>;
+    expect(childEnv).toMatchObject({
+      ...LINUX_PRIME_ENV,
+      UNRELATED: 'x',
+      WOC_PRIME_RELAUNCHED: '1',
+    });
+    expect(unref).toHaveBeenCalled();
+  });
+
+  it('never overrides a variable the caller already set in the child env', () => {
+    const { spawn, calls } = fakeSpawn();
+    const env = { __GLX_VENDOR_LIBRARY_NAME: 'mesa' };
+    relaunchForLinuxPrime({ platform: 'linux', spawn, env, execPath: 'x', argv: [] });
+    const childEnv = calls[0].options.env as Record<string, string>;
+    expect(childEnv.__GLX_VENDOR_LIBRARY_NAME).toBe('mesa');
+    expect(childEnv.DRI_PRIME).toBe('1');
+  });
+
+  it('appends --ozone-platform=x11 to the relaunch argv (Wayland GPU-process crash-loop guard)', () => {
+    const { spawn, calls } = fakeSpawn();
+    relaunchForLinuxPrime({
+      platform: 'linux',
+      spawn,
+      env: {},
+      execPath: 'x',
+      argv: ['--some-flag'],
+    });
+    expect(calls[0].args).toEqual(['--some-flag', LINUX_OZONE_X11_ARG]);
+  });
+
+  it('never overrides a player-supplied --ozone-platform argv flag', () => {
+    const { spawn, calls } = fakeSpawn();
+    relaunchForLinuxPrime({
+      platform: 'linux',
+      spawn,
+      env: {},
+      execPath: 'x',
+      argv: ['--ozone-platform=wayland'],
+    });
+    expect(calls[0].args).toEqual(['--ozone-platform=wayland']);
+  });
+
+  it('returns false and logs a warning when spawn itself throws', () => {
+    const spawn = vi.fn(() => {
+      throw new Error('spawn EACCES');
+    });
+    const warn = vi.fn();
+    const result = relaunchForLinuxPrime({ platform: 'linux', spawn, env: {}, log: { warn } });
+    expect(result).toBe(false);
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
 describe('forceHighPerformanceGpu', () => {
   it('appends both switches on non-Windows and never touches the registry', () => {
     const { app, switches } = fakeApp();
@@ -298,29 +418,17 @@ describe('forceHighPerformanceGpu', () => {
     expect(execFileSync).not.toHaveBeenCalled();
   });
 
-  it('sets the Linux PRIME offload env vars (and never touches the registry)', () => {
+  it('appends the switches on Linux too, and never touches the registry (relaunch is a separate call)', () => {
+    // forceHighPerformanceGpu no longer touches process.env on Linux at all: an in-process
+    // mutation here never reaches the GPU process (see gpu_preference.cjs lever 3), so that
+    // job belongs entirely to relaunchForLinuxPrime, called earlier by main.cjs.
     const { app, switches } = fakeApp();
     const execFileSync = vi.fn();
     const env = {};
     forceHighPerformanceGpu({ app, platform: 'linux', execFileSync, env });
     expect(switches).toEqual(['force-high-performance-gpu', 'force_high_performance_gpu']);
-    expect(env).toEqual(LINUX_PRIME_ENV);
+    expect(env).toEqual({});
     expect(execFileSync).not.toHaveBeenCalled();
-  });
-
-  it('leaves a caller-configured Linux env var alone', () => {
-    const { app } = fakeApp();
-    const env: Record<string, string> = { __GLX_VENDOR_LIBRARY_NAME: 'mesa' };
-    forceHighPerformanceGpu({ app, platform: 'linux', execFileSync: vi.fn(), env });
-    expect(env.__GLX_VENDOR_LIBRARY_NAME).toBe('mesa');
-    expect(env.DRI_PRIME).toBe('1');
-  });
-
-  it('applies the Linux env vars on an UNPACKAGED run too (no persistent host state to protect)', () => {
-    const { app } = fakeApp({ isPackaged: false });
-    const env = {};
-    forceHighPerformanceGpu({ app, platform: 'linux', execFileSync: vi.fn(), env });
-    expect(env).toEqual(LINUX_PRIME_ENV);
   });
 
   it('appends the switches but skips the registry in an unpackaged (dev) run', () => {

--- a/tests/electron_gpu_preference.test.ts
+++ b/tests/electron_gpu_preference.test.ts
@@ -8,10 +8,13 @@ import {
   forceHighPerformanceGpu,
   HIGH_PERF_GPU_SWITCHES,
   HIGH_PERFORMANCE_PREFERENCE,
+  hasExplicitOzonePlatformArg,
   hasUnparseableValueType,
+  isLinuxHybridGpu,
   LINUX_OZONE_X11_ARG,
   LINUX_PRIME_ENV,
   mergeHighPerformancePreference,
+  PRIME_RELAUNCH_MARKER,
   parseRegQueryData,
   relaunchForLinuxPrime,
   shouldRelaunchForLinuxPrime,
@@ -60,6 +63,21 @@ describe('GPU preference constants (load-bearing literals)', () => {
     expect(USER_GPU_PREFERENCES_KEY).toBe('HKCU\\Software\\Microsoft\\DirectX\\UserGpuPreferences');
     // 2 = high performance (discrete); 1 = power saving (integrated); 0 = let Windows decide.
     expect(HIGH_PERFORMANCE_PREFERENCE).toBe('GpuPreference=2;');
+  });
+
+  it('pins the Linux PRIME env, ozone flag, and relaunch marker to their literal values', () => {
+    // Every value here is a wire token a driver, glvnd, or Chromium parses; asserting them
+    // against themselves elsewhere would let a typo (say, ozone-platform=wayland, which
+    // reintroduces the GPU-process crash-loop) ship with green tests.
+    expect(LINUX_PRIME_ENV).toEqual({
+      DRI_PRIME: '1',
+      __NV_PRIME_RENDER_OFFLOAD: '1',
+      __GLX_VENDOR_LIBRARY_NAME: 'nvidia',
+      __EGL_VENDOR_LIBRARY_FILENAMES: '/usr/share/glvnd/egl_vendor.d/10_nvidia.json',
+      __VK_LAYER_NV_optimus: 'NVIDIA_only',
+    });
+    expect(LINUX_OZONE_X11_ARG).toBe('--ozone-platform=x11');
+    expect(PRIME_RELAUNCH_MARKER).toBe('WOC_PRIME_RELAUNCHED');
   });
 });
 
@@ -267,20 +285,43 @@ describe('summarizeGpuDevices', () => {
   });
 });
 
+// The default fileExists is the real fs.existsSync probing the NVIDIA ICD json, which
+// differs per machine (present with the NVIDIA driver, absent everywhere else), so every
+// test injects it to stay hermetic.
+const eglJsonPresent = () => true;
+const eglJsonAbsent = (path: string) => {
+  expect(path).toBe('/usr/share/glvnd/egl_vendor.d/10_nvidia.json');
+  return false;
+};
+
 describe('buildLinuxPrimeEnv', () => {
-  it('offers all four PRIME offload variables against an empty environment', () => {
-    expect(buildLinuxPrimeEnv({})).toEqual(LINUX_PRIME_ENV);
+  it('offers all five PRIME offload variables against an empty environment', () => {
+    expect(buildLinuxPrimeEnv({}, eglJsonPresent)).toEqual(LINUX_PRIME_ENV);
+  });
+
+  it('omits __EGL_VENDOR_LIBRARY_FILENAMES when the NVIDIA EGL ICD json does not exist', () => {
+    // glvnd treats that variable as a REPLACEMENT of its vendor list: naming a missing
+    // file leaves EGL with zero vendors and no GL at all, so on a machine without the
+    // NVIDIA driver (where the json is absent) the entry must not be set.
+    const additions = buildLinuxPrimeEnv({}, eglJsonAbsent);
+    expect(additions).not.toHaveProperty('__EGL_VENDOR_LIBRARY_FILENAMES');
+    expect(additions).toEqual({
+      DRI_PRIME: '1',
+      __NV_PRIME_RENDER_OFFLOAD: '1',
+      __GLX_VENDOR_LIBRARY_NAME: 'nvidia',
+      __VK_LAYER_NV_optimus: 'NVIDIA_only',
+    });
   });
 
   it('never overrides a variable the caller already set', () => {
     // A player who already launches via their own `prime-run`, or who hand-picked a
     // vendor library, keeps their own value; we only fill in what is missing.
     const existing = { __GLX_VENDOR_LIBRARY_NAME: 'mesa', UNRELATED: 'x' };
-    const additions = buildLinuxPrimeEnv(existing);
+    const additions = buildLinuxPrimeEnv(existing, eglJsonPresent);
     expect(additions).toEqual({
       DRI_PRIME: '1',
       __NV_PRIME_RENDER_OFFLOAD: '1',
-      __EGL_VENDOR_LIBRARY_FILENAMES: LINUX_PRIME_ENV.__EGL_VENDOR_LIBRARY_FILENAMES,
+      __EGL_VENDOR_LIBRARY_FILENAMES: '/usr/share/glvnd/egl_vendor.d/10_nvidia.json',
       __VK_LAYER_NV_optimus: 'NVIDIA_only',
     });
     expect(additions).not.toHaveProperty('__GLX_VENDOR_LIBRARY_NAME');
@@ -288,24 +329,81 @@ describe('buildLinuxPrimeEnv', () => {
 
   it('does not mutate the environment object passed in', () => {
     const existing = { FOO: 'bar' };
-    buildLinuxPrimeEnv(existing);
+    buildLinuxPrimeEnv(existing, eglJsonPresent);
     expect(existing).toEqual({ FOO: 'bar' });
+  });
+});
+
+describe('hasExplicitOzonePlatformArg', () => {
+  it('matches the explicit flag in both spellings', () => {
+    expect(hasExplicitOzonePlatformArg(['--ozone-platform=wayland'])).toBe(true);
+    expect(hasExplicitOzonePlatformArg(['--ozone-platform'])).toBe(true);
+  });
+
+  it('does NOT count --ozone-platform-hint as an explicit choice', () => {
+    // A hint is a preference Chromium lets an explicit flag override; treating it as a
+    // choice would suppress the x11 append and reintroduce the Wayland crash-loop.
+    expect(hasExplicitOzonePlatformArg(['--ozone-platform-hint=auto'])).toBe(false);
+    expect(hasExplicitOzonePlatformArg([])).toBe(false);
+    expect(hasExplicitOzonePlatformArg(undefined)).toBe(false);
+  });
+});
+
+describe('isLinuxHybridGpu', () => {
+  it('is true when /sys/class/drm exposes two or more card devices', () => {
+    const readdir = (path: string) => {
+      expect(path).toBe('/sys/class/drm');
+      return ['card0', 'card0-eDP-1', 'card1', 'renderD128', 'renderD129', 'version'];
+    };
+    expect(isLinuxHybridGpu(readdir)).toBe(true);
+  });
+
+  it('is false on a single-GPU machine (render nodes and connectors do not count)', () => {
+    expect(isLinuxHybridGpu(() => ['card0', 'card0-eDP-1', 'renderD128', 'version'])).toBe(false);
+  });
+
+  it('is false when /sys is unreadable (impose nothing when we cannot tell)', () => {
+    expect(
+      isLinuxHybridGpu(() => {
+        throw new Error('ENOENT');
+      }),
+    ).toBe(false);
   });
 });
 
 describe('shouldRelaunchForLinuxPrime', () => {
   it('is true when at least one PRIME variable is missing', () => {
-    expect(shouldRelaunchForLinuxPrime({})).toBe(true);
+    expect(shouldRelaunchForLinuxPrime({}, [], eglJsonPresent)).toBe(true);
   });
 
-  it('is false once every PRIME variable is already present', () => {
-    expect(shouldRelaunchForLinuxPrime({ ...LINUX_PRIME_ENV })).toBe(false);
+  it('is false with no marker once every PRIME variable is already present', () => {
+    // That environment is wholly the player's own (their prime-run wrapper), flag or not.
+    expect(shouldRelaunchForLinuxPrime({ ...LINUX_PRIME_ENV }, [], eglJsonPresent)).toBe(false);
   });
 
-  it('is false once the relaunch marker is set, even if variables are still missing', () => {
-    // Guards against a relaunch loop: a child whose spawn options somehow still lack a
-    // variable must not relaunch itself again.
-    expect(shouldRelaunchForLinuxPrime({ WOC_PRIME_RELAUNCHED: '1' })).toBe(false);
+  it('is false for a marked process whose argv carries an explicit ozone choice', () => {
+    // The normal relaunched child: env half AND argv half both present.
+    expect(
+      shouldRelaunchForLinuxPrime(
+        { ...LINUX_PRIME_ENV, WOC_PRIME_RELAUNCHED: '1' },
+        ['--ozone-platform=x11'],
+        eglJsonPresent,
+      ),
+    ).toBe(false);
+  });
+
+  it('is TRUE for a marked process whose argv lost the ozone flag (updater restart)', () => {
+    // electron-updater's restart-to-update respawns with the current env (marker and PRIME
+    // vars included) but EMPTY argv; without this arm the updated process would run PRIME
+    // on the session default backend, the documented Wayland crash-loop. Loop-safe: the
+    // relaunch it triggers always yields a child WITH an explicit ozone arg.
+    expect(
+      shouldRelaunchForLinuxPrime(
+        { ...LINUX_PRIME_ENV, WOC_PRIME_RELAUNCHED: '1' },
+        [],
+        eglJsonPresent,
+      ),
+    ).toBe(true);
   });
 });
 
@@ -320,82 +418,142 @@ describe('relaunchForLinuxPrime', () => {
     return { spawn, calls, unref };
   }
 
+  // Hermetic defaults: a hybrid machine with the NVIDIA EGL json installed. Individual
+  // tests override the arms they exercise.
+  function deps(overrides: Record<string, unknown> = {}) {
+    return { platform: 'linux', isHybridGpu: () => true, fileExists: eglJsonPresent, ...overrides };
+  }
+
   it('does nothing on a non-Linux platform', () => {
     const { spawn } = fakeSpawn();
-    expect(relaunchForLinuxPrime({ platform: 'win32', spawn, env: {} })).toBe(false);
+    expect(relaunchForLinuxPrime(deps({ platform: 'win32', spawn, env: {} }))).toBe(false);
     expect(spawn).not.toHaveBeenCalled();
   });
 
-  it('does nothing when every PRIME variable is already present', () => {
+  it('does nothing on a single-GPU machine (hybrid gate)', () => {
+    // A non-hybrid machine gets neither the extra spawn nor a forced X11 backend.
+    const { spawn } = fakeSpawn();
+    const result = relaunchForLinuxPrime(deps({ spawn, env: {}, isHybridGpu: () => false }));
+    expect(result).toBe(false);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when every PRIME variable is already present without the marker', () => {
     const { spawn } = fakeSpawn();
     const env = { ...LINUX_PRIME_ENV };
-    expect(relaunchForLinuxPrime({ platform: 'linux', spawn, env })).toBe(false);
+    expect(relaunchForLinuxPrime(deps({ spawn, env, argv: [] }))).toBe(false);
     expect(spawn).not.toHaveBeenCalled();
   });
 
-  it('does nothing when the relaunch marker is already set (loop guard)', () => {
+  it('does nothing for a relaunched child (marker plus explicit ozone argv)', () => {
     const { spawn } = fakeSpawn();
-    const env = { WOC_PRIME_RELAUNCHED: '1' };
-    expect(relaunchForLinuxPrime({ platform: 'linux', spawn, env })).toBe(false);
+    const env = { ...LINUX_PRIME_ENV, WOC_PRIME_RELAUNCHED: '1' };
+    const result = relaunchForLinuxPrime(deps({ spawn, env, argv: ['--ozone-platform=x11'] }));
+    expect(result).toBe(false);
     expect(spawn).not.toHaveBeenCalled();
   });
 
   it('re-execs the same binary and argv with the PRIME env baked in, and unrefs the child', () => {
     const { spawn, calls, unref } = fakeSpawn();
     const env = { UNRELATED: 'x' };
-    const result = relaunchForLinuxPrime({
-      platform: 'linux',
-      spawn,
-      env,
-      execPath: '/usr/bin/world-of-claudecraft',
-      argv: ['--some-flag'],
-      log: { info: vi.fn() },
-    });
+    const result = relaunchForLinuxPrime(
+      deps({
+        spawn,
+        env,
+        execPath: '/usr/bin/world-of-claudecraft',
+        argv: ['--some-flag'],
+        log: { info: vi.fn() },
+      }),
+    );
     expect(result).toBe(true);
     expect(calls).toHaveLength(1);
     expect(calls[0].command).toBe('/usr/bin/world-of-claudecraft');
-    expect(calls[0].args).toEqual(['--some-flag', LINUX_OZONE_X11_ARG]);
-    expect(calls[0].options).toMatchObject({ stdio: 'inherit', detached: true });
-    const childEnv = calls[0].options.env as Record<string, string>;
-    expect(childEnv).toMatchObject({
-      ...LINUX_PRIME_ENV,
-      UNRELATED: 'x',
-      WOC_PRIME_RELAUNCHED: '1',
+    expect(calls[0].args).toEqual(['--some-flag', '--ozone-platform=x11']);
+    // Full options pin (not a subset match): a stray option here changes spawn semantics.
+    expect(calls[0].options).toEqual({
+      env: {
+        ...LINUX_PRIME_ENV,
+        UNRELATED: 'x',
+        WOC_PRIME_RELAUNCHED: '1',
+      },
+      stdio: 'inherit',
+      detached: true,
     });
     expect(unref).toHaveBeenCalled();
+  });
+
+  it('re-execs a marked-but-flagless process to restore the argv half (updater restart)', () => {
+    // The post-auto-update state: env inherited from the relaunched child (marker and all
+    // PRIME vars present), argv empty. The relaunch must fire again purely to restore
+    // --ozone-platform=x11, and the marker stays set on the new child.
+    const { spawn, calls } = fakeSpawn();
+    const env = { ...LINUX_PRIME_ENV, WOC_PRIME_RELAUNCHED: '1' };
+    const result = relaunchForLinuxPrime(deps({ spawn, env, execPath: 'x', argv: [] }));
+    expect(result).toBe(true);
+    expect(calls[0].args).toEqual(['--ozone-platform=x11']);
+    const childEnv = calls[0].options.env as Record<string, string>;
+    expect(childEnv.WOC_PRIME_RELAUNCHED).toBe('1');
+  });
+
+  it('spawns the outer AppImage (env.APPIMAGE), never execPath, inside an AppImage', () => {
+    // execPath points inside the runtime's FUSE mount, which dies the moment this process
+    // exits; the outer file survives and brings up a fresh runtime + mount (the same
+    // source electron-updater restarts from).
+    const { spawn, calls } = fakeSpawn();
+    const env = { APPIMAGE: '/home/p/Applications/world-of-claudecraft.AppImage' };
+    relaunchForLinuxPrime(deps({ spawn, env, execPath: '/tmp/.mount_worldXYZ/binary', argv: [] }));
+    expect(calls[0].command).toBe('/home/p/Applications/world-of-claudecraft.AppImage');
+  });
+
+  it('ignores a non-absolute APPIMAGE value and falls back to execPath', () => {
+    const { spawn, calls } = fakeSpawn();
+    const env = { APPIMAGE: 'relative/evil.AppImage' };
+    relaunchForLinuxPrime(deps({ spawn, env, execPath: '/usr/bin/woc', argv: [] }));
+    expect(calls[0].command).toBe('/usr/bin/woc');
   });
 
   it('never overrides a variable the caller already set in the child env', () => {
     const { spawn, calls } = fakeSpawn();
     const env = { __GLX_VENDOR_LIBRARY_NAME: 'mesa' };
-    relaunchForLinuxPrime({ platform: 'linux', spawn, env, execPath: 'x', argv: [] });
+    relaunchForLinuxPrime(deps({ spawn, env, execPath: 'x', argv: [] }));
     const childEnv = calls[0].options.env as Record<string, string>;
     expect(childEnv.__GLX_VENDOR_LIBRARY_NAME).toBe('mesa');
     expect(childEnv.DRI_PRIME).toBe('1');
   });
 
-  it('appends --ozone-platform=x11 to the relaunch argv (Wayland GPU-process crash-loop guard)', () => {
+  it('omits the EGL vendor replacement when the NVIDIA ICD json is absent on this machine', () => {
     const { spawn, calls } = fakeSpawn();
-    relaunchForLinuxPrime({
-      platform: 'linux',
-      spawn,
-      env: {},
-      execPath: 'x',
-      argv: ['--some-flag'],
-    });
-    expect(calls[0].args).toEqual(['--some-flag', LINUX_OZONE_X11_ARG]);
+    relaunchForLinuxPrime(
+      deps({ spawn, env: {}, execPath: 'x', argv: [], fileExists: () => false }),
+    );
+    const childEnv = calls[0].options.env as Record<string, string>;
+    expect(childEnv).not.toHaveProperty('__EGL_VENDOR_LIBRARY_FILENAMES');
+    expect(childEnv.__NV_PRIME_RENDER_OFFLOAD).toBe('1');
   });
 
-  it('never overrides a player-supplied --ozone-platform argv flag', () => {
+  it('appends --ozone-platform=x11 to the relaunch argv (Wayland GPU-process crash-loop guard)', () => {
     const { spawn, calls } = fakeSpawn();
-    relaunchForLinuxPrime({
-      platform: 'linux',
-      spawn,
-      env: {},
-      execPath: 'x',
-      argv: ['--ozone-platform=wayland'],
-    });
+    relaunchForLinuxPrime(deps({ spawn, env: {}, execPath: 'x', argv: ['--some-flag'] }));
+    expect(calls[0].args).toEqual(['--some-flag', '--ozone-platform=x11']);
+  });
+
+  it('never overrides a player-supplied explicit --ozone-platform argv flag', () => {
+    const { spawn, calls } = fakeSpawn();
+    relaunchForLinuxPrime(
+      deps({ spawn, env: {}, execPath: 'x', argv: ['--ozone-platform=wayland'] }),
+    );
     expect(calls[0].args).toEqual(['--ozone-platform=wayland']);
+  });
+
+  it('still appends the explicit flag when argv only carries an ozone HINT', () => {
+    // --ozone-platform-hint is a preference, not a choice; Chromium lets the explicit
+    // flag we append override it, and honoring a wayland hint under PRIME would recreate
+    // the crash-loop.
+    const { spawn, calls } = fakeSpawn();
+    relaunchForLinuxPrime(
+      deps({ spawn, env: {}, execPath: 'x', argv: ['--ozone-platform-hint=auto'] }),
+    );
+    expect(calls[0].args).toEqual(['--ozone-platform-hint=auto', '--ozone-platform=x11']);
   });
 
   it('returns false and logs a warning when spawn itself throws', () => {
@@ -403,7 +561,7 @@ describe('relaunchForLinuxPrime', () => {
       throw new Error('spawn EACCES');
     });
     const warn = vi.fn();
-    const result = relaunchForLinuxPrime({ platform: 'linux', spawn, env: {}, log: { warn } });
+    const result = relaunchForLinuxPrime(deps({ spawn, env: {}, log: { warn } }));
     expect(result).toBe(false);
     expect(warn).toHaveBeenCalled();
   });
@@ -698,6 +856,31 @@ describe('main.cjs gpu wiring pin', () => {
     expect(callAt).toBeLessThan(readyAt);
   });
 
+  it('guards the whole startup behind relaunchForLinuxPrime, exiting the parent immediately', () => {
+    // The Linux fix only works as a re-exec BEFORE any Electron startup: the guard must
+    // sit at module scope (column 0), run before forceHighPerformanceGpu and before any
+    // logging or window setup, and the parent must stop executing via process.exit(0).
+    // Any of these moving (into whenReady, below initLogging, losing the exit) silently
+    // kills the fix while the pure-function tests above stay green.
+    // One regex pins the whole shape: guard at column 0 with process.exit(0) as the block
+    // body (comments aside) and nothing else inside.
+    expect(source).toMatch(
+      /^if \(relaunchForLinuxPrime\(\{ log: console \}\)\) \{\n(?:\s*\/\/[^\n]*\n)*\s*process\.exit\(0\);\n\}/m,
+    );
+    const guardAt = source.indexOf('if (relaunchForLinuxPrime({ log: console })) {');
+    expect(guardAt).toBeGreaterThan(-1);
+    expect(guardAt).toBeLessThan(source.indexOf('forceHighPerformanceGpu({ app, log });'));
+    expect(guardAt).toBeLessThan(source.indexOf('initLogging('));
+  });
+
+  it('logs the PRIME-relaunched-child line the docs verification checklist points at', () => {
+    // The parent exits before file logging exists, so the CHILD records the durable
+    // evidence; docs/desktop-release.md tells the release verifier to grep main.log for
+    // exactly this line.
+    expect(source).toContain('[gpu] running as PRIME-relaunched child');
+    expect(source).toContain('process.env[PRIME_RELAUNCH_MARKER]');
+  });
+
   it('re-logs GPU status on every load, not just the first (crash-recovery reloads)', () => {
     // A GPU-process crash followed by the recovery auto-reload is exactly when the adapter
     // can flip to the WARP software fallback; .once would keep only the pre-crash reading.
@@ -711,5 +894,28 @@ describe('main.cjs gpu wiring pin', () => {
     expect(source).toContain('summarizeGpuDevices');
     expect(source).toContain('discreteInactive');
     expect(source).toContain('discrete GPU is present but INACTIVE');
+  });
+});
+
+describe('electron-dev.mjs PRIME pre-apply pin', () => {
+  // The dev orchestrator kills Vite the moment its electron child exits, so on a Linux
+  // hybrid machine the main.cjs relaunch would tear down the dev server under the
+  // detached grandchild. The dev spawn therefore pre-applies the exact configuration the
+  // relaunch would have produced (env additions + marker + explicit ozone flag), which
+  // suppresses the relaunch entirely. Pin that wiring textually, same approach as the
+  // main.cjs block above.
+  const source = readFileSync(new URL('../scripts/electron-dev.mjs', import.meta.url), 'utf8');
+
+  it('pre-applies the PRIME env, marker, and ozone flag using the module predicates', () => {
+    expect(source).toContain("createRequire(import.meta.url)('../electron/gpu_preference.cjs')");
+    expect(source).toContain('shouldRelaunchForLinuxPrime(process.env, [])');
+    expect(source).toContain('isLinuxHybridGpu()');
+    expect(source).toContain("[PRIME_RELAUNCH_MARKER]: '1'");
+    expect(source).toContain('[LINUX_OZONE_X11_ARG]');
+  });
+
+  it('feeds the pre-applied config into the electron spawn (env and argv both)', () => {
+    expect(source).toContain("spawn(electronCommand, ['.', ...prime.args]");
+    expect(source).toContain('...prime.env,');
   });
 });


### PR DESCRIPTION
## Summary
- The desktop shell already forces the discrete GPU on Windows (`GpuPreference=2` in the per-app `UserGpuPreferences` registry value) and appends the cross-platform Chromium `force-high-performance-gpu` switch, but on a Linux hybrid-graphics laptop (NVIDIA Optimus, AMD/Intel Mesa PRIME) the app still bound the integrated GPU.
- **Updated after review** (see discussion below): an in-process `process.env` mutation before `app.whenReady()` does NOT work on Linux, unlike on Windows/macOS - Electron's Linux GPU process forks from a zygote that already exec'd and snapshotted its environ before any main-process JS ever runs. `electron/gpu_preference.cjs` now exports `relaunchForLinuxPrime`, which `main.cjs` calls as the very first thing it does: on Linux, if any PRIME variable is missing, it re-execs the whole app (same binary, same argv) with the variables baked into the *new* process's environment from birth, then the original process exits immediately (a marker env var prevents a relaunch loop).
- The variable set was also corrected against real hybrid hardware: `__GLX_VENDOR_LIBRARY_NAME` alone is a decoy for this app (Chromium's GPU context is EGL, not GLX, so it flips `glxinfo` without moving the actual renderer); `__EGL_VENDOR_LIBRARY_FILENAMES` (pointed at the NVIDIA glvnd EGL ICD) is the variable that verifiably moves the unmasked WebGL renderer to the discrete adapter. The relaunch also appends `--ozone-platform=x11` to argv (never overriding a player's own `--ozone-platform` choice), since the same hardware showed the GPU process crash-looping on Wayland once PRIME offload is requested, falling back to software rendering.
- `DRI_PRIME=1` (Mesa AMD/Intel PRIME offload) is unaffected by any of the above and still applies.
- Documents the corrected lever, and two known follow-ups (the relaunch isn't yet gated on detecting a hybrid adapter first, and its interaction with the second-instance deep-link login path is unverified) in `docs/desktop-release.md`'s GPU verification checklist.

## Why this is the right fix
This repo's `IWorld`/sim architecture is unaffected (this is a desktop-shell-only change, no `src/sim/` or `src/render/` touch). The web client (played in a browser, not the Electron shell) already requests `powerPreference: 'high-performance'` in its `WebGLRenderer` (`src/render/renderer.ts`), which is the only lever a web page has; true adapter switching on Linux for a browser tab requires OS/browser-level configuration outside this repo's control (`prime-run`, `DRI_PRIME`, or the distro's GPU-switching tool), so this PR is scoped to what the codebase can actually fix: the packaged desktop app.

## Test plan
- [x] `npx vitest run tests/electron_gpu_preference.test.ts` - 62/62 passing (new cases cover `shouldRelaunchForLinuxPrime`, `relaunchForLinuxPrime`'s spawn/env/argv/loop-guard/error-handling behavior, and the corrected `buildLinuxPrimeEnv` variable set).
- [x] `npx vitest run tests/architecture.test.ts tests/localization_fixes.test.ts` - sim purity and i18n matcher guards green.
- [x] `npx tsc --noEmit -p .` - clean.
- [x] `npx biome check` on every file this PR touches - clean.
- [x] `git merge-tree` against `up/release/v0.27.0` - clean merge, no conflicts.
- Not applicable: no visual/UI change (Electron main-process startup logic only), so no before/after screenshots.
