### PR TITLE
fix(deeds): heal permanently stranded deeds on world join

### DIFF
--- a/docs/design/deeds.md
+++ b/docs/design/deeds.md
@@ -32,7 +32,17 @@ the `renown` sum and the persisted `deedStats` lifetime counters, and emits
 the id-based `deedUnlocked` event (never English text); on world join it
 re-evaluates every predicate against loaded state and grants with
 `retro: true`, so veterans get credit for anything their character verifiably
-already did. The server is an observer, never the authority: it upserts
+already did. The same join pass carries the fallback heals
+(`retroFallbackGrants` in `src/sim/deeds.ts`), idempotent and re-run every
+login: PROOF inferences grant a deed whose evidence predates its counter (a
+positive craft skill proves the first craft; a completed single-source
+ground-pickup quest proves the first sparkle, pinned by
+`GROUND_PICKUP_PROVING_QUESTS`), and STRANDED heals grant a deed once it has
+become permanently impossible for that character (the five-up killing blow
+once no creditable mob can sit five levels above, ceiling pinned by
+`MAX_CREDITABLE_MOB_LEVEL`; rested XP at the cap where the pool is frozen),
+keeping rule 5 honest and `feat_book_complete` reachable. Both proof sets are
+re-derived from the live content tables by `tests/deeds_content.test.ts`. The server is an observer, never the authority: it upserts
 unlocks into the `character_deeds` table fire-and-forget
 (`server/deeds_records.ts`), fans out marquee broadcasts, and serves rarity
 percentages and the account-level Renown leaderboard (scored by
@@ -69,7 +79,13 @@ server store always canonical.
    one fits.
 4. **Skill tasks fail only through player error, never RNG.**
 5. **No permanently missable deeds.** Anything tied to seasonal or retired
-   content becomes a Feat, preserved visibly, never deleted.
+   content becomes a Feat, preserved visibly, never deleted. A deed that can
+   silently become permanently impossible for an individual character (an
+   earning window their level has passed, a pool frozen at the cap, a counter
+   whose only feed sits behind consumed one-shot quests) is healed at world
+   join instead: `retroFallbackGrants` grants it from proof where persisted
+   state demonstrates the action, or outright once no earn path can ever
+   exist again for that character (see Architecture).
 6. **Count outcomes, not attempts.** No deed may reward griefing, AFK
    attendance, or pure login. PvP uses rating thresholds and milestones that
    cannot be win-traded profitably; multiplayer deeds must be satisfiable

--- a/src/sim/deeds.ts
+++ b/src/sim/deeds.ts
@@ -70,6 +70,43 @@ const LEGACY_MILESTONE_TO_DEED: Record<string, string> = Object.fromEntries(
   Object.entries(MILESTONE_DEED_TO_LEGACY).map(([deed, legacy]) => [legacy, deed]),
 );
 
+// Quests whose collect objective can ONLY be satisfied through the ground
+// pickup path: the item is a ground-object spawn (a sparkle) with no mob
+// loot, vendor, trade, mail, or market source, so the quest sitting in
+// questsDone proves at least one successful pickup happened before the
+// groundObjectsLooted counter existed. Interact-objective quests (the Royal
+// Graves, the crypt ritual circle) and the crypt relic chain are deliberately
+// absent: those interaction routes return before the counter bump, so they
+// prove nothing about it. PINNED like the sibling literals; the
+// content-integrity test re-derives this exact set from the live tables.
+export const GROUND_PICKUP_PROVING_QUESTS: readonly string[] = [
+  'q_supplies',
+  'q_whispers',
+  'q_names_of_the_dead',
+  'q_gravecallers_trail',
+  'q_fenbridge_muster',
+  'q_fen_supplies',
+  'q_drowned_censers',
+  'q_bastion_door',
+  'q_aldrics_fallen_star',
+  'q_highwatch_summons',
+  'q_ogre_totems',
+  'q_wyrm_sigils',
+  'q_sanctum_gate',
+  'q_glimmermere_light',
+];
+
+// The highest level any giantslayer-creditable mob can ever spawn at: heroic
+// instances pin every mob to 22 (content/dungeon_difficulty.ts), two above
+// the player cap, and nothing outside heroic exceeds the cap itself (dummies,
+// the world boss, and owned pets are excluded from the killing-blow credit).
+// cmb_giantslayer needs a blow five levels up, so past this ceiling minus
+// five the deed is permanently out of reach for the character. PINNED:
+// shipping a higher-level creditable mob is a conscious re-decision of the
+// stranded threshold (the content-integrity test cross-checks the ceiling
+// against the real tables).
+export const MAX_CREDITABLE_MOB_LEVEL = 22;
+
 // Dungeon final bosses whose kill credit bumps deedStats.dungeonClears (keys
 // '<dungeonId>' and '<dungeonId>:heroic') and the dungeonFinalBossKills
 // counter. PINNED as of v1: a future dungeon's boss gets a new deed; this
@@ -1044,15 +1081,48 @@ export function seedItemDiscovery(ctx: SimContext, meta: PlayerMeta): void {
   }
 }
 
-/** Retro grants that a state predicate cannot express: every craft skill
- *  except enchanting only ever comes from successful crafts, so a positive
- *  value on any other craft proves the first craft happened before the
- *  counter existed. Enchanting is excluded because disenchant and
- *  apply-enchant (professions/enchanting.ts) gain that skill without any
- *  craft, and it has no recipes, so its value can never prove one. */
-export function retroFallbackGrants(ctx: SimContext, meta: PlayerMeta): void {
+/** Retro grants that a state predicate cannot express, in two shapes, both
+ *  idempotent and re-run on every world join:
+ *  - PROOF inferences: persisted state proves the action happened before its
+ *    counter existed, so the deed is back-credited exactly like the rollout's
+ *    retro pass did for state predicates.
+ *  - STRANDED heals: the earning action has become permanently impossible for
+ *    THIS character (no earn path can ever exist again), so leaving the deed
+ *    visible-but-unearnable would violate the no-permanently-missable rule
+ *    (docs/design/deeds.md rule 5) and dead-end feat_book_complete. The deed
+ *    is granted rather than left stranded. */
+export function retroFallbackGrants(ctx: SimContext, meta: PlayerMeta, player: Entity): void {
+  // Proof: every craft skill except enchanting only ever comes from
+  // successful crafts, so a positive value on any other craft proves the
+  // first craft happened before the counter existed. Enchanting is excluded
+  // because disenchant and apply-enchant (professions/enchanting.ts) gain
+  // that skill without any craft, and it has no recipes, so its value can
+  // never prove one.
   if (Object.entries(meta.craftSkills).some(([craftId, v]) => craftId !== 'enchanting' && v > 0)) {
     grantDeed(ctx, meta, 'prog_first_craft', { retro: true });
+  }
+  // Proof: every ground object is a quest item whose pickup is denied unless
+  // its quest is active (interaction.ts), so a done proving quest can only
+  // have been completed through the pickup path. The counter itself stays
+  // honest at whatever the character actually accrued since the rollout.
+  if (GROUND_PICKUP_PROVING_QUESTS.some((q) => meta.questsDone.has(q))) {
+    grantDeed(ctx, meta, 'exp_something_shiny', { retro: true });
+  }
+  // Stranded: once no creditable mob can sit five levels up (the heroic pin
+  // is the ceiling), the killing blow is permanently out of reach; a level
+  // never goes back down (prestige is cosmetic), so past the window the deed
+  // strands for the character's whole future. Below the threshold the live
+  // kill site stays the only grant path.
+  if (player.level + 5 > MAX_CREDITABLE_MOB_LEVEL) {
+    grantDeed(ctx, meta, 'cmb_giantslayer', { retro: true });
+  }
+  // Stranded: rested XP neither accrues nor drains at the cap (the accrual
+  // gate in progression/xp.ts and the fromKill drain gate in
+  // combat/damage.ts), so a capped character with an empty pool can never
+  // flip the hasRestedXp flag; a nonzero frozen pool already retro-grants
+  // through the flag predicate on this same join.
+  if (player.level >= MAX_LEVEL && meta.restedXp <= 0) {
+    grantDeed(ctx, meta, 'prog_well_rested', { retro: true });
   }
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2221,13 +2221,14 @@ export class Sim {
     }
     // Book of Deeds retro-on-join, after the saved state is fully restored:
     // seed the discovery ledger from current holdings, apply the retro
-    // fallbacks a predicate cannot express, then evaluate every predicate
-    // against the loaded state (a pure function of that state and the
-    // catalog: no rng, so join order cannot fork the draw order). Counters
-    // start at zero, so counter deeds never retro-grant; the emitted events
-    // carry retro: true and drain with the next tick to this player only.
+    // fallbacks a predicate cannot express (proof inferences plus the
+    // stranded-deed heals), then evaluate every predicate against the loaded
+    // state (a pure function of that state and the catalog: no rng, so join
+    // order cannot fork the draw order). Counters start at zero, so counter
+    // deeds never retro-grant; the emitted events carry retro: true and
+    // drain with the next tick to this player only.
     deedsMod.seedItemDiscovery(this.ctx, meta);
-    deedsMod.retroFallbackGrants(this.ctx, meta);
+    deedsMod.retroFallbackGrants(this.ctx, meta, player);
     deedsMod.evaluateDeedsFor(this.ctx, meta, player, true);
     this.deedDirtyPids.delete(player.id);
     this.deedDirtyKeys.delete(player.id);

--- a/tests/deeds.test.ts
+++ b/tests/deeds.test.ts
@@ -620,6 +620,100 @@ describe('retro on join', () => {
       [...b.players.get(pb)!.deedsEarned.keys()].sort(),
     );
   });
+
+  it('a done ground-pickup quest proves the sparkle and heals Something Shiny', () => {
+    // Every ground object is a quest item whose pickup is denied once its
+    // quest is done, so an all-quests-done veteran can never bump the counter
+    // again; the done proving quest is itself the evidence the pickup
+    // happened before the counter existed.
+    const sim = makeSim();
+    const state = veteranState();
+    state.questsDone = ['q_supplies'];
+    const pid = sim.addPlayer('warrior', 'Supplier', { state });
+    const meta = sim.players.get(pid)!;
+    expect(meta.deedsEarned.has('exp_something_shiny')).toBe(true);
+    // The heal grants the deed; the lifetime counter stays honest at zero.
+    expect(meta.deedStats.counters.groundObjectsLooted).toBe(0);
+    const evs = deedEvents(sim.tick());
+    const ev = evs.find((e) => e.deedId === 'exp_something_shiny');
+    expect(ev?.retro).toBe(true);
+    expect(ev?.pid).toBe(pid);
+
+    // Interact-objective chains and mob-drop collect chains prove nothing:
+    // those routes return before the counter bump, so they must not heal.
+    const sim2 = makeSim();
+    const s2 = veteranState();
+    s2.questsDone = ['q_nythraxis_graves', 'q_nythraxis_sealed_crypt', 'q_the_codfather'];
+    const pid2 = sim2.addPlayer('warrior', 'Interactor', { state: s2 });
+    expect(sim2.players.get(pid2)!.deedsEarned.has('exp_something_shiny')).toBe(false);
+  });
+
+  it('Giantslayer heals exactly where no mob can sit five levels up', () => {
+    // The heroic pin (level 22) is the highest creditable spawn in the game,
+    // so level 18 is the first permanently stranded level and 17 the last
+    // one where the live kill site can still fire.
+    const sim = makeSim();
+    const capped = sim.addPlayer('warrior', 'Capped', {
+      state: { ...veteranState(), level: 20 },
+    });
+    expect(sim.players.get(capped)!.deedsEarned.has('cmb_giantslayer')).toBe(true);
+    const edge = sim.addPlayer('warrior', 'Edge', { state: { ...veteranState(), level: 18 } });
+    expect(sim.players.get(edge)!.deedsEarned.has('cmb_giantslayer')).toBe(true);
+    const leveler = sim.addPlayer('warrior', 'Leveler', {
+      state: { ...veteranState(), level: 17 },
+    });
+    expect(sim.players.get(leveler)!.deedsEarned.has('cmb_giantslayer')).toBe(false);
+    // The heal is a retro grant: flagged on the event, delivered to the
+    // healed player only.
+    const evs = deedEvents(sim.tick());
+    const ev = evs.find((e) => e.deedId === 'cmb_giantslayer' && e.pid === capped);
+    expect(ev?.retro).toBe(true);
+  });
+
+  it('the heals unlock feat_book_complete in the same join for an otherwise complete book', () => {
+    // The motivating payoff: when the three healed deeds were the last holes
+    // in a veteran's book, the meta pass that runs right after the fallback
+    // arms must complete the feat on the SAME login, not one login later.
+    const healed = ['exp_something_shiny', 'cmb_giantslayer', 'prog_well_rested'];
+    const bookIds = (DEEDS.feat_book_complete.trigger as { deedIds: string[] }).deedIds;
+    const deeds: Record<string, string> = {};
+    for (const id of bookIds) {
+      if (!healed.includes(id)) deeds[id] = '2026-07-01';
+    }
+    const sim = makeSim();
+    const state: CharacterState = {
+      ...veteranState(),
+      level: MAX_LEVEL,
+      restedXp: 0,
+      questsDone: ['q_supplies'],
+      deeds,
+    };
+    const pid = sim.addPlayer('warrior', 'Completionist', { state });
+    const meta = sim.players.get(pid)!;
+    for (const id of healed) expect(meta.deedsEarned.has(id), id).toBe(true);
+    expect(meta.deedsEarned.has('feat_book_complete')).toBe(true);
+  });
+
+  it('Well Rested heals only at the cap where the pool is frozen', () => {
+    // Rested XP neither accrues nor drains at MAX_LEVEL, so a capped save
+    // with an empty pool is permanently stranded; below the cap the pool can
+    // still accrue and the deed must stay earned-by-play.
+    const sim = makeSim();
+    const dry = sim.addPlayer('warrior', 'CappedDry', {
+      state: { ...veteranState(), level: MAX_LEVEL, restedXp: 0 },
+    });
+    expect(sim.players.get(dry)!.deedsEarned.has('prog_well_rested')).toBe(true);
+    const leveling = sim.addPlayer('warrior', 'StillRests', {
+      state: { ...veteranState(), level: MAX_LEVEL - 1, restedXp: 0 },
+    });
+    expect(sim.players.get(leveling)!.deedsEarned.has('prog_well_rested')).toBe(false);
+    // A frozen nonzero pool retro-grants through the flag predicate already;
+    // the heal must not be the only path that covers it.
+    const banked = sim.addPlayer('warrior', 'Banked', {
+      state: { ...veteranState(), level: MAX_LEVEL, restedXp: 50 },
+    });
+    expect(sim.players.get(banked)!.deedsEarned.has('prog_well_rested')).toBe(true);
+  });
 });
 
 describe('milestone unification', () => {

--- a/tests/deeds_content.test.ts
+++ b/tests/deeds_content.test.ts
@@ -8,10 +8,28 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { POWERUPS } from '../src/sim/content/augments';
 import { DEED_ORDER, DEEDS, DEEDS_ERA } from '../src/sim/content/deeds';
+import { DELVE_MOBS } from '../src/sim/content/delves/mobs';
+import { HEROIC_DUNGEON_TUNING } from '../src/sim/content/dungeon_difficulty';
 import { FISHING_TABLES } from '../src/sim/content/items';
 import { CRAFT_RING, GATHERING_PROFESSION_IDS } from '../src/sim/content/professions';
-import { DELVES, DUNGEONS, ITEMS, MOBS, NPCS, QUESTS, ZONES } from '../src/sim/data';
-import { MILESTONE_DEED_TO_LEGACY, VISITED_MARK_NAMESPACES } from '../src/sim/deeds';
+import { WARLOCK_PET_MOBS } from '../src/sim/content/warlock_pets';
+import { YUMI_TEMPLATE_ID } from '../src/sim/content/yumi';
+import {
+  DELVES,
+  DUNGEONS,
+  GROUND_OBJECTS,
+  ITEMS,
+  MOBS,
+  NPCS,
+  QUESTS,
+  ZONES,
+} from '../src/sim/data';
+import {
+  GROUND_PICKUP_PROVING_QUESTS,
+  MAX_CREDITABLE_MOB_LEVEL,
+  MILESTONE_DEED_TO_LEGACY,
+  VISITED_MARK_NAMESPACES,
+} from '../src/sim/deeds';
 import { DEED_STAT_KEYS, type DeedCategory, MILESTONES } from '../src/sim/types';
 
 const ALL = DEED_ORDER.map((id) => DEEDS[id]);
@@ -161,6 +179,81 @@ describe('frozen trigger + renown catalog (design rule 9: never retro-edit a tri
         'allowed but re-baselines this hash. If the change is deliberate, regenerate ' +
         'FROZEN_CATALOG_SHA256 with the one-liner in the comment above and commit it here.',
     ).toBe(FROZEN_CATALOG_SHA256);
+  });
+});
+
+describe('retro fallback proof sets stay anchored to the real tables', () => {
+  it('the ground-pickup proving quests are exactly the single-source collect quests', () => {
+    // A quest proves a sparkle pickup only when its collect objective's item
+    // can come from nowhere but the ground pickup path: any mob-loot or
+    // vendor source would break the inference, and interact objectives never
+    // bump the counter at all. Re-derive that set from the live tables and
+    // hold the pin to it, so a new ground object, loot entry, or vendor row
+    // forces a conscious re-decision here.
+    const groundItemIds = new Set(GROUND_OBJECTS.map((g) => g.itemId));
+    const lootItemIds = new Set(
+      Object.values(MOBS).flatMap((m) => (m.loot ?? []).map((l) => l.itemId)),
+    );
+    const vendorItemIds = new Set(Object.values(NPCS).flatMap((n) => n.vendorItems ?? []));
+    const derived: string[] = [];
+    for (const [questId, quest] of Object.entries(QUESTS)) {
+      const proves = quest.objectives.some(
+        (obj) =>
+          obj.type === 'collect' &&
+          groundItemIds.has(obj.itemId) &&
+          !lootItemIds.has(obj.itemId) &&
+          !vendorItemIds.has(obj.itemId),
+      );
+      if (proves) derived.push(questId);
+    }
+    expect([...GROUND_PICKUP_PROVING_QUESTS].sort()).toEqual(derived.sort());
+    // The pickup gate itself requires the item def to carry the quest id, so
+    // every proving quest's evidence chain resolves end to end.
+    for (const questId of GROUND_PICKUP_PROVING_QUESTS) {
+      const quest = QUESTS[questId];
+      expect(quest, questId).toBeDefined();
+      const collect = quest.objectives.find(
+        (o) => o.type === 'collect' && groundItemIds.has(o.itemId),
+      );
+      expect(collect, questId).toBeDefined();
+      const item = ITEMS[(collect as { itemId: string }).itemId];
+      // kind 'quest' is also the non-transferability guarantee: trade
+      // (social/trade.ts), mail (mail/post_office.ts), and the market
+      // (market.ts) all hard-block that kind, so questsDone proves THIS
+      // character performed the pickup, not a trading partner.
+      expect(item?.kind, questId).toBe('quest');
+      expect(item?.questId, questId).toBe(questId);
+      // A repeatable proving quest would weaken nothing, but none exists; a
+      // future one should be reconsidered here rather than slip in.
+      expect(quest.repeatable ?? false, questId).toBe(false);
+    }
+  });
+
+  it('the creditable mob-level ceiling is the heroic pin', () => {
+    // Giantslayer's stranded heal keys on the highest level a creditable mob
+    // can ever spawn at. Heroic instances pin every mob to one shared level;
+    // outside heroic no spawnable template exceeds the player cap. The only
+    // templates authored above the ceiling can never be credited: warlock
+    // pets sync to their owner's level and die outside kill credit
+    // (combat/damage.ts owned-pet early return), and the Yumi cat's damage
+    // is intercepted before the death path (social/yumi.ts).
+    const heroicLevels = Object.values(HEROIC_DUNGEON_TUNING).map((t) => t.level);
+    expect(Math.max(...heroicLevels)).toBe(MAX_CREDITABLE_MOB_LEVEL);
+    const neverCreditable = new Set([...Object.keys(WARLOCK_PET_MOBS), YUMI_TEMPLATE_ID]);
+    for (const [id, m] of Object.entries(MOBS)) {
+      if (m.dummy || m.worldBoss || neverCreditable.has(id)) continue;
+      expect(m.maxLevel, id).toBeLessThanOrEqual(MAX_CREDITABLE_MOB_LEVEL);
+    }
+    // Delve spawns bypass maxLevel: the live level is minLevel plus the
+    // tier's enemyLevelBonus (delves/runs.ts). Guard the whole delve mob
+    // table against the highest bonus any delve ships, so a future tier or
+    // higher-level delve mob cannot silently pass the ceiling.
+    const maxDelveBonus = Math.max(
+      ...Object.values(DELVES).flatMap((d) => d.tiers.map((t) => t.enemyLevelBonus)),
+    );
+    for (const [id, m] of Object.entries(DELVE_MOBS)) {
+      expect(m.minLevel + maxDelveBonus, id).toBeLessThanOrEqual(MAX_CREDITABLE_MOB_LEVEL);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

A Discord report showed two Book of Deeds entries that are legitimately impossible for some characters, stranding their Book forever:

- **Something Shiny** (`exp_something_shiny`, stat `groundObjectsLooted`): every lootable ground object in the game is a quest item, and `pickUpObject` denies the pickup unless that quest is active or ready. A veteran who completed every quest before the deeds rollout (when all lifetime counters started at zero) has no remaining path to bump the counter, ever. Confirmed by walking all 18 `GROUND_OBJECTS` defs plus the 6 dungeon-spawned pickups: all quest-bound, all single-source.
- **Giantslayer** (`cmb_giantslayer`, manual: killing blow on a mob at least 5 levels up): the highest creditable mob level anywhere is the heroic pin at 22, so the deed is permanently impossible from level 18 on, for every character, not just pre-rollout veterans. At the level cap it would need a level 25 mob that cannot exist.

The investigation also surfaced a third member of the same class, **Well Rested** (`prog_well_rested`): rested XP neither accrues nor drains at the cap, so a capped character with an empty pool can never flip the flag. All three block `feat_book_complete`, which is a shipped Steam achievement (`ACH_BOOK_COMPLETE`).

The fix extends `retroFallbackGrants` (the same seam the rollout used to heal `prog_first_craft`) with two kinds of join-time heal, both idempotent, zero-rng, and re-run on every login so every affected character self-heals at their next world join on any host:

- **Proof heal**: `exp_something_shiny` is granted when `questsDone` contains any of the 14 pinned `GROUND_PICKUP_PROVING_QUESTS`, quests whose collect item can only come from a ground pickup (no mob loot, no vendor, and `kind: 'quest'` blocks trade, mail, and market). The done quest is the evidence the pickup happened before the counter existed. The lifetime counter itself stays honest at zero.
- **Stranded heal**: `cmb_giantslayer` is granted at level 18 and above (`level + 5 > MAX_CREDITABLE_MOB_LEVEL`, pinned 22), and `prog_well_rested` at the cap with an empty pool. Below those boundaries the live earn paths remain the only grant sites.

`docs/design/deeds.md` rule 5 and the Architecture section now record the policy, and both proof sets are re-derived from the live content tables by `tests/deeds_content.test.ts` (including a guard on the delve `minLevel + enemyLevelBonus` spawn path), so a future ground object, loot entry, vendor row, higher heroic pin, or hotter delve tier forces a conscious re-decision here.

**Design consequence that wants your explicit sign-off before merge:** the stranded heals are unconditional by state, so every character at level 18+ without Giantslayer receives it on next login (10 Renown), and every capped character with an empty rested pool receives Well Rested (5 Renown). That includes post-rollout characters who simply skipped the mechanic while leveling: in the long run Giantslayer effectively becomes "reach level 18" for anyone who missed the window, its rarity climbs toward 100 percent of the 18+ population, and many accounts get a one-time Renown board bump on next login (increase-only, so the score-never-decreases rule holds). The alternatives considered: shipping level 23+ content (a balance decision), narrowing the heal to pre-rollout characters only (no persisted state can identify them), or reclassifying as a Feat (forbidden: it would strip 10 Renown from legitimate earners). If you prefer a different remedy for Giantslayer, the arm is one isolated `if` in `retroFallbackGrants`.

Also verified from the same report, needing no fix:

- The reporter's quest expectation is already correct in code: all pure quest-trigger deeds retro-grant from `questsDone` on every login (pinned by `tests/deeds.test.ts`). Their "80 quests" exactly matches the completable pre-professions-loop set (84 total minus `q_prof_intro` and the 3 repeatables un-retired by #2039), so they legitimately lack only `prog_callused_hands`, which is earnable today by doing the new professions intro quest. Chronicle chapters intentionally require live-play components, all still re-earnable at cap.
- Deeds are strictly per-character (only the Renown board aggregates per account), so each affected character heals individually at its next login.

Operational note: no backfill script is needed (the heal runs on every join), but rarity percentages for the healed deeds will drift upward as the affected population logs in, on the existing lazy `character_deeds` fill semantics.

## Related issues

Player report from Discord (Ember, 2026-07-17); no tracked issue.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npm run gate` under Node 24: full unit suite green (15048 passed). The gate aborts at the known environmental `armory_mobile_layout` browser failure (pre-existing on this machine, unrelated to this diff, which touches no CSS/UI); `npx tsc --noEmit` and `npm run build` (all five entries) were then run manually, both green.
  - `npx vitest run tests/deeds.test.ts tests/deeds_content.test.ts` (103 passed), plus `tests/deeds_sites`, `tests/deeds_reconcile`, `tests/deeds_completion`, `tests/parity` (draw-order digest unchanged), `tests/architecture.test.ts`, and the S3 guard `tests/localization_fixes.test.ts`.
- Manual steps: none beyond the suites; the change is join-path sim logic with no UI surface. Reviewed by the repo's architecture-reviewer (clean: zero rng, join-path only, parity green), qa-checklist (READY; the design sign-off above is its one open item), and test-coverage-auditor (its delve spawn-path guard and fragility findings are folded in).

---

## Checklist

### Quality

- [x] **The full gate passes.** Green except the pre-existing environmental armory browser failure noted above; tsc and all builds pass, and PR CI is the arbiter. Decisive tests added for every new behavior, including boundary negatives (level 17 vs 18, below-cap rested, non-proving quests) and the same-join `feat_book_complete` unlock.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI change.
- ~Accessible.~ N/A: no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (grants emit the existing id-based `deedUnlocked` event; deed names re-localize client-side).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
