### PR TITLE
fix(render): fail soft when a character visual's assets are missing

### DIFF
--- a/src/render/CLAUDE.md
+++ b/src/render/CLAUDE.md
@@ -28,6 +28,9 @@ Everything else is a sibling module in one of these families:
   Performance) and `crowd_lod.ts` (pure crowd policy: pulls character
   shadow/anim cadence in as rig counts climb; cosmetic-only, exempts what a
   player reacts to).
+- `view_create_retry.ts`: bounded cooldown state for fail-soft character builds
+  in per-frame paths, including required targets, form swaps, and visual-key
+  swaps (`tests/view_create_retry.test.ts`).
 - `self_motion.ts`/`facing_smooth.ts`: pure display-only self layers (bounded
   online pose extrapolation + rate-limited self yaw; never touch world state,
   see `src/net/CLAUDE.md`).

--- a/src/render/characters/CLAUDE.md
+++ b/src/render/characters/CLAUDE.md
@@ -22,6 +22,10 @@ no procedural-rig path here anymore. Reads the world; never mutates the sim.
   `tests/render_asset_preload.test.ts`). `prepareVisual(key)` memoizes
   normalize transform, resolved clips, click-capsule radius, and a baked
   idle-pose geo (far-LOD/shadow proxy).
+- `asset_miss_log.ts`: once-per-key dev logging for character-asset failures in
+  per-frame render paths; `createCharacterVisual` returns null on such a
+  failure so callers skip the view for the frame instead of stalling the
+  renderer (`tests/character_visual_fail_soft.test.ts`).
 - `rig_merge.ts`: merges a KayKit rig's quantized body-part SkinnedMeshes into
   one draw per material (`assets.ts` `assembleModel` calls it). Read its
   header bind-pose proof before touching bone inverses.

--- a/src/render/characters/asset_miss_log.ts
+++ b/src/render/characters/asset_miss_log.ts
@@ -1,0 +1,16 @@
+// Dev-channel dedupe for character-asset failures that surface in per-frame
+// render paths (a missed preload, a rejected lazy fetch). The first failure
+// for a key logs; repeats are dropped, so a permanent miss costs one log line
+// instead of one per frame (issue #2079; the per-frame variant was the log
+// spam half of the v0.27.0 training dummy freeze,
+// docs/training-dummy-preload-freeze-postmortem.md).
+const loggedKeys = new Set<string>();
+
+/** Log a per-frame asset failure once per key. Returns whether it logged. */
+export function logAssetMissOnce(key: string, message: string, detail?: unknown): boolean {
+  if (loggedKeys.has(key)) return false;
+  loggedKeys.add(key);
+  if (detail === undefined) console.error(message);
+  else console.error(message, detail);
+  return true;
+}

--- a/src/render/characters/index.ts
+++ b/src/render/characters/index.ts
@@ -3,6 +3,7 @@
 // with the preload gate, so createCharacterVisual is synchronous by the time
 // the Renderer constructs views.
 import type { Entity, PlayerClass } from '../../sim/types';
+import { logAssetMissOnce } from './asset_miss_log';
 import { mechHeldWeaponOverride, visualKeyFor } from './manifest';
 import { CharacterVisual } from './visual';
 
@@ -11,11 +12,16 @@ export type { PreviewAppearance } from './preview_appearance';
 export type { AnimState } from './visual';
 export { CharacterVisual, setWeaponVfxViewportHeight } from './visual';
 
-/** Build the visual for an entity (or an explicit shapeshift/polymorph form key). */
+/** Build the visual for an entity (or an explicit shapeshift/polymorph form key).
+ *  Returns null when the visual's assets are unavailable (a missed preload, a
+ *  lazy fetch that has not landed): callers skip that entity's view for the
+ *  frame and the entity stays a future candidate. A synchronous throw here
+ *  would stall the per-frame render path forever (issue #2079, the v0.27.0
+ *  training dummy freeze). */
 export function createCharacterVisual(
   e: Entity,
   formKey?: 'form_sheep' | 'form_bear' | 'form_cat' | 'form_travel',
-): CharacterVisual {
+): CharacterVisual | null {
   // forms (sheep/bear/cat/travel) are their own models — skins and held weapons
   // only apply to the base body
   const key = formKey ?? visualKeyFor(e);
@@ -26,11 +32,23 @@ export function createCharacterVisual(
     !formKey && key === 'player_mech' && e.kind === 'player'
       ? mechHeldWeaponOverride(e.templateId as PlayerClass)
       : null;
-  return new CharacterVisual(
-    key,
-    e.color,
-    formKey ? 0 : (e.skin ?? 0),
-    formKey ? null : e.mainhandItemId,
-    weaponOverride,
-  );
+  try {
+    return new CharacterVisual(
+      key,
+      e.color,
+      formKey ? 0 : (e.skin ?? 0),
+      formKey ? null : e.mainhandItemId,
+      weaponOverride,
+    );
+  } catch (err) {
+    // key the dedupe on visual key PLUS message: two models failing with an
+    // identical generic error must both get their first log line
+    const detail = err instanceof Error ? err.message : String(err);
+    logAssetMissOnce(
+      `${key}:${detail}`,
+      `character visual unavailable, skipping view (${key}):`,
+      err,
+    );
+    return null;
+  }
 }

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -49,6 +49,7 @@ import {
   createCharacterVisual,
   setWeaponVfxViewportHeight,
 } from './characters';
+import { logAssetMissOnce } from './characters/asset_miss_log';
 import {
   mechAssetsReady,
   preloadMechAssets,
@@ -160,6 +161,12 @@ const VIEW_CREATE_BUDGET_HIGH = 8;
 const VIEW_CREATE_SLOW_FRAME_MS = 33;
 const VIEW_CREATE_HITCH_FRAME_MS = 50;
 const VIEW_CREATE_BACKOFF_SECONDS = 0.75;
+// Cooldown before re-attempting a view whose assets failed to build (the
+// fail-soft path, issue #2079). Without it a permanently failing entity
+// consumes a view-creation budget slot every frame; under the hitch backoff
+// the budget is 1, so a first-sorted failing entity would starve every other
+// pending view.
+const VIEW_CREATE_FAIL_RETRY_MS = 2000;
 const VIEW_PREWARM_RANGE_SQ = ENTITY_VIEW_CREATE_RANGE_SQ;
 const VIEW_PREWARM_MAX_MS = 12000;
 // Shader linking is the whole point of the prewarm: if it doesn't finish, the
@@ -758,6 +765,9 @@ export class Renderer {
   camera: THREE.PerspectiveCamera;
   webgl: THREE.WebGLRenderer;
   views = new Map<number, EntityView>();
+  // entity id -> performance.now() timestamp before which a failed view build
+  // (assets unavailable, the fail-soft path) is not retried; cleared on success
+  private viewCreateRetryAt = new Map<number, number>();
   // view groups that own a budgeted point light: exempt from the hidden-view
   // matrix gate (see the gate pass in sync and the note at registration)
   private lightOwnerGroups = new WeakSet<THREE.Object3D>();
@@ -2148,6 +2158,10 @@ export class Renderer {
     for (const candidate of this.viewCandidates) {
       if (created >= max || performance.now() >= deadlineMs) break;
       if (this.views.has(candidate.e.id)) continue;
+      // a recent failed build (assets unavailable) sits out its cooldown so it
+      // cannot burn a budget slot every frame
+      const retryAt = this.viewCreateRetryAt.get(candidate.e.id);
+      if (retryAt !== undefined && performance.now() < retryAt) continue;
       this.createView(candidate.e);
       this.sampleCreatedViewType(createdViewTypes, candidate.e);
       created++;
@@ -2337,8 +2351,11 @@ export class Renderer {
       if (!template) return;
       for (let i = 0; i < copies; i++) {
         const entity = this.prewarmEntity('mob', template.id, template.color, template.scale);
-        builtModels.add(visualKeyFor(entity));
         const visual = createCharacterVisual(entity);
+        // assets unavailable: skip the seed, leave the model unmarked so the
+        // dedup pass below can retry it
+        if (!visual) continue;
+        builtModels.add(visualKeyFor(entity));
         const poolKey = this.visualPoolKeyFor(entity);
         if (poolKey) this.storePooledVisual(poolKey, visual);
         visual.root.visible = true;
@@ -2384,8 +2401,10 @@ export class Renderer {
       const entity = this.prewarmEntity('npc', npc.id, npc.color, 1);
       const modelKey = visualKeyFor(entity);
       if (builtModels.has(modelKey)) continue;
-      builtModels.add(modelKey);
       const visual = createCharacterVisual(entity);
+      // assets unavailable: skip the seed, leave the model unmarked
+      if (!visual) continue;
+      builtModels.add(modelKey);
       const poolKey = this.visualPoolKeyFor(entity);
       if (poolKey) this.storePooledVisual(poolKey, visual);
       visual.root.visible = true;
@@ -2414,6 +2433,8 @@ export class Renderer {
         const color = CLASSES[cls]?.color ?? 0xffffff;
         const entity = this.prewarmEntity('player', cls, color, 1, skin, -11_000 - idx);
         const visual = createCharacterVisual(entity);
+        // assets unavailable: skip the seed
+        if (!visual) continue;
         visual.root.visible = true;
         place(visual.root);
       }
@@ -3445,13 +3466,17 @@ export class Renderer {
       const visualKey = visualKeyFor(e);
       if (visualKey === 'player_mech' && !mechAssetsReady()) {
         void preloadMechAssets().catch((err) =>
-          console.error('Failed to preload live mech cosmetic:', err),
+          logAssetMissOnce('preload:player_mech', 'Failed to preload live mech cosmetic:', err),
         );
         return;
       }
       if (visualKey === 'mob_training_dummy' && !trainingDummyAssetsReady()) {
         void preloadTrainingDummyAssets().catch((err) =>
-          console.error('Failed to preload the Training Dummy:', err),
+          logAssetMissOnce(
+            'preload:mob_training_dummy',
+            'Failed to preload the Training Dummy:',
+            err,
+          ),
         );
         return;
       }
@@ -3466,6 +3491,13 @@ export class Renderer {
         // ever recycled, so every mob past that count churned. Key is per-template, so
         // the pool stays bounded by the peak simultaneous count.
         visual = createCharacterVisual(e);
+        // assets unavailable: skip, the entity stays a view candidate but sits
+        // out the retry cooldown so it cannot starve the per-frame budget
+        if (!visual) {
+          this.viewCreateRetryAt.set(e.id, performance.now() + VIEW_CREATE_FAIL_RETRY_MS);
+          return;
+        }
+        this.viewCreateRetryAt.delete(e.id);
       }
       // entity scale is applied to the whole group below, so it can update live
       // (Fiesta size buffs) and also scale lazily-built form visuals for free.
@@ -3722,11 +3754,13 @@ export class Renderer {
     if (nextKey === v.visualKey) return;
     if (nextKey === 'player_mech' && !mechAssetsReady()) {
       void preloadMechAssets().catch((err) =>
-        console.error('Failed to preload live mech cosmetic:', err),
+        logAssetMissOnce('preload:player_mech', 'Failed to preload live mech cosmetic:', err),
       );
       return;
     }
+    // assets unavailable: keep the old visual, the key mismatch retries next frame
     const next = createCharacterVisual(e);
+    if (!next) return;
     next.setShadow(v.shadowOn);
     next.setFar(v.isFar);
     next.root.visible = v.visual.root.visible;
@@ -4573,21 +4607,35 @@ export class Renderer {
         groundHeight(e.pos.x, e.pos.z, this.sim.cfg.seed) < wl - 0.8;
 
       // lazy form visuals, swapped by visibility like the old sheep/bear rigs
+      // a null build (assets unavailable) leaves the field unset, so the
+      // form's visibility branch retries it next frame
       if (polyed && !v.sheepVisual) {
-        v.sheepVisual = createCharacterVisual(e, 'form_sheep');
-        v.group.add(v.sheepVisual.root); // group.scale already carries e.scale
+        const built = createCharacterVisual(e, 'form_sheep');
+        if (built) {
+          v.sheepVisual = built;
+          v.group.add(built.root); // group.scale already carries e.scale
+        }
       }
       if (bear && !v.bearVisual) {
-        v.bearVisual = createCharacterVisual(e, 'form_bear');
-        v.group.add(v.bearVisual.root);
+        const built = createCharacterVisual(e, 'form_bear');
+        if (built) {
+          v.bearVisual = built;
+          v.group.add(built.root);
+        }
       }
       if (cat && !v.catVisual) {
-        v.catVisual = createCharacterVisual(e, 'form_cat');
-        v.group.add(v.catVisual.root);
+        const built = createCharacterVisual(e, 'form_cat');
+        if (built) {
+          v.catVisual = built;
+          v.group.add(built.root);
+        }
       }
       if (travel && !v.travelVisual) {
-        v.travelVisual = createCharacterVisual(e, 'form_travel');
-        v.group.add(v.travelVisual.root);
+        const built = createCharacterVisual(e, 'form_travel');
+        if (built) {
+          v.travelVisual = built;
+          v.group.add(built.root);
+        }
       }
       if (v.sheepVisual) v.sheepVisual.root.visible = polyed;
       if (v.bearVisual) v.bearVisual.root.visible = bear;

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -3476,21 +3476,29 @@ export class Renderer {
       objectMesh = body;
     } else {
       const visualKey = visualKeyFor(e);
+      // The in-flight cooldown stops the deferring entity from burning a
+      // budget slot every frame, and clearing it when the fetch RESOLVES
+      // keeps pop-in at the next frame after readiness (only a rejected
+      // fetch waits out the full cooldown).
       if (visualKey === 'player_mech' && !mechAssetsReady()) {
-        void preloadMechAssets().catch((err) =>
-          logAssetMissOnce('preload:player_mech', 'Failed to preload live mech cosmetic:', err),
-        );
+        void preloadMechAssets()
+          .then(() => this.viewCreateRetry.markSucceeded(e.id, 'view'))
+          .catch((err) =>
+            logAssetMissOnce('preload:player_mech', 'Failed to preload live mech cosmetic:', err),
+          );
         this.viewCreateRetry.markFailed(e.id, 'view', performance.now());
         return;
       }
       if (visualKey === 'mob_training_dummy' && !trainingDummyAssetsReady()) {
-        void preloadTrainingDummyAssets().catch((err) =>
-          logAssetMissOnce(
-            'preload:mob_training_dummy',
-            'Failed to preload the Training Dummy:',
-            err,
-          ),
-        );
+        void preloadTrainingDummyAssets()
+          .then(() => this.viewCreateRetry.markSucceeded(e.id, 'view'))
+          .catch((err) =>
+            logAssetMissOnce(
+              'preload:mob_training_dummy',
+              'Failed to preload the Training Dummy:',
+              err,
+            ),
+          );
         this.viewCreateRetry.markFailed(e.id, 'view', performance.now());
         return;
       }
@@ -3769,9 +3777,13 @@ export class Renderer {
     const retrySlot = `base:${nextKey}`;
     if (!this.viewCreateRetry.canAttempt(e.id, retrySlot, performance.now())) return;
     if (nextKey === 'player_mech' && !mechAssetsReady()) {
-      void preloadMechAssets().catch((err) =>
-        logAssetMissOnce('preload:player_mech', 'Failed to preload live mech cosmetic:', err),
-      );
+      // in-flight cooldown; cleared on fetch resolution so the swap lands the
+      // next frame after readiness (see the createView gates)
+      void preloadMechAssets()
+        .then(() => this.viewCreateRetry.markSucceeded(e.id, retrySlot))
+        .catch((err) =>
+          logAssetMissOnce('preload:player_mech', 'Failed to preload live mech cosmetic:', err),
+        );
       this.viewCreateRetry.markFailed(e.id, retrySlot, performance.now());
       return;
     }

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -141,6 +141,7 @@ import { ValeCupPracticeSky } from './vale_cup_practice_sky';
 import { buildValeCupStadium, type ValeCupStadiumView } from './vale_cup_stadium';
 import { buildValeCupTeamRings, type ValeCupTeamRingsView } from './vale_cup_team_ring';
 import { SCHOOL_COLORS, Vfx } from './vfx';
+import { ViewCreateRetryGate } from './view_create_retry';
 import { buildWater, type WaterView } from './water';
 import { Weather } from './weather';
 import { buildWorldAmbientSources, crowdAmbienceAt, footstepSurfaceAt } from './world_audio';
@@ -765,9 +766,7 @@ export class Renderer {
   camera: THREE.PerspectiveCamera;
   webgl: THREE.WebGLRenderer;
   views = new Map<number, EntityView>();
-  // entity id -> performance.now() timestamp before which a failed view build
-  // (assets unavailable, the fail-soft path) is not retried; cleared on success
-  private viewCreateRetryAt = new Map<number, number>();
+  private viewCreateRetry = new ViewCreateRetryGate(VIEW_CREATE_FAIL_RETRY_MS);
   // view groups that own a budgeted point light: exempt from the hidden-view
   // matrix gate (see the gate pass in sync and the note at registration)
   private lightOwnerGroups = new WeakSet<THREE.Object3D>();
@@ -2129,6 +2128,7 @@ export class Renderer {
     for (const id of requiredIds) {
       const e = this.sim.entities.get(id);
       if (!e || this.views.has(e.id)) continue;
+      if (!this.viewCreateRetry.canAttempt(e.id, 'view', performance.now())) continue;
       this.createView(e);
       this.sampleCreatedViewType(createdViewTypes, e);
       created++;
@@ -2160,13 +2160,25 @@ export class Renderer {
       if (this.views.has(candidate.e.id)) continue;
       // a recent failed build (assets unavailable) sits out its cooldown so it
       // cannot burn a budget slot every frame
-      const retryAt = this.viewCreateRetryAt.get(candidate.e.id);
-      if (retryAt !== undefined && performance.now() < retryAt) continue;
+      if (!this.viewCreateRetry.canAttempt(candidate.e.id, 'view', performance.now())) continue;
       this.createView(candidate.e);
       this.sampleCreatedViewType(createdViewTypes, candidate.e);
       created++;
     }
     return created;
+  }
+
+  private createCharacterVisualWithRetry(
+    e: Entity,
+    slot: string,
+    formKey?: 'form_sheep' | 'form_bear' | 'form_cat' | 'form_travel',
+  ): CharacterVisual | null {
+    const now = performance.now();
+    if (!this.viewCreateRetry.canAttempt(e.id, slot, now)) return null;
+    const visual = createCharacterVisual(e, formKey);
+    if (visual) this.viewCreateRetry.markSucceeded(e.id, slot);
+    else this.viewCreateRetry.markFailed(e.id, slot, now);
+    return visual;
   }
 
   private prewarmWorldFrame(dt: number): void {
@@ -3468,6 +3480,7 @@ export class Renderer {
         void preloadMechAssets().catch((err) =>
           logAssetMissOnce('preload:player_mech', 'Failed to preload live mech cosmetic:', err),
         );
+        this.viewCreateRetry.markFailed(e.id, 'view', performance.now());
         return;
       }
       if (visualKey === 'mob_training_dummy' && !trainingDummyAssetsReady()) {
@@ -3478,6 +3491,7 @@ export class Renderer {
             err,
           ),
         );
+        this.viewCreateRetry.markFailed(e.id, 'view', performance.now());
         return;
       }
       visualPoolKey = this.visualPoolKeyFor(e);
@@ -3490,14 +3504,14 @@ export class Renderer {
         // "asset-upload" travel hitch. Before, only the few prewarm-seeded copies were
         // ever recycled, so every mob past that count churned. Key is per-template, so
         // the pool stays bounded by the peak simultaneous count.
-        visual = createCharacterVisual(e);
+        visual = this.createCharacterVisualWithRetry(e, 'view');
         // assets unavailable: skip, the entity stays a view candidate but sits
         // out the retry cooldown so it cannot starve the per-frame budget
         if (!visual) {
-          this.viewCreateRetryAt.set(e.id, performance.now() + VIEW_CREATE_FAIL_RETRY_MS);
           return;
         }
-        this.viewCreateRetryAt.delete(e.id);
+      } else {
+        this.viewCreateRetry.markSucceeded(e.id, 'view');
       }
       // entity scale is applied to the whole group below, so it can update live
       // (Fiesta size buffs) and also scale lazily-built form visuals for free.
@@ -3752,14 +3766,17 @@ export class Renderer {
     if (!v.visual) return;
     const nextKey = visualKeyFor(e);
     if (nextKey === v.visualKey) return;
+    const retrySlot = `base:${nextKey}`;
+    if (!this.viewCreateRetry.canAttempt(e.id, retrySlot, performance.now())) return;
     if (nextKey === 'player_mech' && !mechAssetsReady()) {
       void preloadMechAssets().catch((err) =>
         logAssetMissOnce('preload:player_mech', 'Failed to preload live mech cosmetic:', err),
       );
+      this.viewCreateRetry.markFailed(e.id, retrySlot, performance.now());
       return;
     }
-    // assets unavailable: keep the old visual, the key mismatch retries next frame
-    const next = createCharacterVisual(e);
+    // Assets unavailable: keep the old visual and retry after the shared cooldown.
+    const next = this.createCharacterVisualWithRetry(e, retrySlot);
     if (!next) return;
     next.setShadow(v.shadowOn);
     next.setFar(v.isFar);
@@ -4303,6 +4320,7 @@ export class Renderer {
       this.selfMotionOffset.set(0, 0, 0);
     }
     const now = performance.now();
+    this.viewCreateRetry.prune(now, sim.entities);
     const selfPos = this.updateSelfRenderPosition(alpha, dt, selfAlphaLead, selfMotion);
     markPhase('setup');
 
@@ -4607,31 +4625,30 @@ export class Renderer {
         groundHeight(e.pos.x, e.pos.z, this.sim.cfg.seed) < wl - 0.8;
 
       // lazy form visuals, swapped by visibility like the old sheep/bear rigs
-      // a null build (assets unavailable) leaves the field unset, so the
-      // form's visibility branch retries it next frame
+      // A null build leaves the field unset; the shared gate retries after its cooldown.
       if (polyed && !v.sheepVisual) {
-        const built = createCharacterVisual(e, 'form_sheep');
+        const built = this.createCharacterVisualWithRetry(e, 'form_sheep', 'form_sheep');
         if (built) {
           v.sheepVisual = built;
           v.group.add(built.root); // group.scale already carries e.scale
         }
       }
       if (bear && !v.bearVisual) {
-        const built = createCharacterVisual(e, 'form_bear');
+        const built = this.createCharacterVisualWithRetry(e, 'form_bear', 'form_bear');
         if (built) {
           v.bearVisual = built;
           v.group.add(built.root);
         }
       }
       if (cat && !v.catVisual) {
-        const built = createCharacterVisual(e, 'form_cat');
+        const built = this.createCharacterVisualWithRetry(e, 'form_cat', 'form_cat');
         if (built) {
           v.catVisual = built;
           v.group.add(built.root);
         }
       }
       if (travel && !v.travelVisual) {
-        const built = createCharacterVisual(e, 'form_travel');
+        const built = this.createCharacterVisualWithRetry(e, 'form_travel', 'form_travel');
         if (built) {
           v.travelVisual = built;
           v.group.add(built.root);

--- a/src/render/view_create_retry.ts
+++ b/src/render/view_create_retry.ts
@@ -1,0 +1,45 @@
+interface RetryEntry {
+  entityId: number;
+  retryAt: number;
+}
+
+/** Cooldown state for fail-soft character builds in per-frame render paths. */
+export class ViewCreateRetryGate {
+  private entries = new Map<string, RetryEntry>();
+
+  constructor(private readonly cooldownMs: number) {}
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  canAttempt(entityId: number, slot: string, now: number): boolean {
+    const key = this.key(entityId, slot);
+    const entry = this.entries.get(key);
+    if (!entry) return true;
+    if (now < entry.retryAt) return false;
+    this.entries.delete(key);
+    return true;
+  }
+
+  markFailed(entityId: number, slot: string, now: number): void {
+    this.entries.set(this.key(entityId, slot), {
+      entityId,
+      retryAt: now + this.cooldownMs,
+    });
+  }
+
+  markSucceeded(entityId: number, slot: string): void {
+    this.entries.delete(this.key(entityId, slot));
+  }
+
+  prune(now: number, activeEntities: { has(id: number): boolean }): void {
+    for (const [key, entry] of this.entries) {
+      if (now >= entry.retryAt || !activeEntities.has(entry.entityId)) this.entries.delete(key);
+    }
+  }
+
+  private key(entityId: number, slot: string): string {
+    return `${entityId}:${slot}`;
+  }
+}

--- a/tests/character_visual_fail_soft.test.ts
+++ b/tests/character_visual_fail_soft.test.ts
@@ -1,0 +1,102 @@
+import * as THREE from 'three';
+import { describe, expect, it, vi } from 'vitest';
+import type { Entity } from '../src/sim/types';
+
+// Issue #2079: a character asset that was never registered as preloaded used to
+// throw synchronously from resolvedGltf inside the per-frame render path
+// (Renderer.sync -> createView -> new CharacterVisual), which permanently
+// stalled rendering (the v0.27.0 training dummy freeze,
+// docs/training-dummy-preload-freeze-postmortem.md). The factory now fails
+// soft: it returns null so the caller skips that entity's view for the frame
+// (the entity stays a future view candidate), and the miss logs once per
+// asset, not once per frame.
+function mockGltfLoad(): void {
+  vi.doMock('../src/render/assets/loader', () => ({
+    loadGltf: vi.fn(() => Promise.resolve({ scene: {}, animations: [] })),
+    loadHdr: vi.fn(() => new Promise(() => undefined)),
+    loadTexture: vi.fn(() => new Promise(() => undefined)),
+    releaseGltf: vi.fn(),
+  }));
+}
+
+// The training dummy resolves to the lazyPreload mob_training_dummy visual,
+// whose GLB the eager boot sweep never fetches, so the factory hits the real
+// "character asset not preloaded" path with no asset work needed.
+const dummyEntity = {
+  kind: 'mob',
+  id: 1,
+  templateId: 'training_dummy',
+  color: 0xffffff,
+  skin: 0,
+  mainhandItemId: null,
+} as unknown as Entity;
+
+describe('createCharacterVisual fails soft on a missing preload (issue 2079)', () => {
+  it('returns null instead of throwing, and logs the miss once per asset', async () => {
+    vi.resetModules();
+    mockGltfLoad();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { createCharacterVisual } = await import('../src/render/characters/index');
+
+    const first = createCharacterVisual(dummyEntity);
+    const second = createCharacterVisual(dummyEntity);
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+
+    // One log for the first miss, none for the repeat; the log names the asset
+    // so a real incident is diagnosable from a single line.
+    const missLogs = errSpy.mock.calls.filter((args) =>
+      args.some((a) => typeof a === 'string' && a.includes('mob_training_dummy')),
+    );
+    expect(missLogs).toHaveLength(1);
+    errSpy.mockRestore();
+  });
+});
+
+describe('createCharacterVisual happy path (issue 2079)', () => {
+  it('builds a visual once the asset is preloaded, with no miss log', async () => {
+    vi.resetModules();
+    // A minimally real GLTF: a measurable mesh plus every clip the dummy's
+    // ClipMap names, so construction exercises the actual assemble/bake path.
+    const stubGltf = () => {
+      const scene = new THREE.Group();
+      const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 2, 1), new THREE.MeshStandardMaterial());
+      mesh.name = 'body';
+      scene.add(mesh);
+      const clip = (name: string) => new THREE.AnimationClip(name, 1, []);
+      return { scene, animations: ['Idle', 'Walk', 'Run', 'Attack', 'Hit', 'Death'].map(clip) };
+    };
+    vi.doMock('../src/render/assets/loader', () => ({
+      loadGltf: vi.fn(() => Promise.resolve(stubGltf())),
+      loadHdr: vi.fn(() => new Promise(() => undefined)),
+      loadTexture: vi.fn(() => new Promise(() => undefined)),
+      releaseGltf: vi.fn(),
+    }));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { preloadTrainingDummyAssets } = await import('../src/render/characters/assets');
+    await preloadTrainingDummyAssets();
+    const { createCharacterVisual } = await import('../src/render/characters/index');
+
+    const visual = createCharacterVisual(dummyEntity);
+    expect(visual).not.toBeNull();
+    const missLogs = errSpy.mock.calls.filter((args) =>
+      args.some((a) => typeof a === 'string' && a.includes('mob_training_dummy')),
+    );
+    expect(missLogs).toHaveLength(0);
+    errSpy.mockRestore();
+  });
+});
+
+describe('logAssetMissOnce (issue 2079)', () => {
+  it('logs a key the first time only, independently per key', async () => {
+    vi.resetModules();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { logAssetMissOnce } = await import('../src/render/characters/asset_miss_log');
+
+    expect(logAssetMissOnce('k1', 'first k1 failure:')).toBe(true);
+    expect(logAssetMissOnce('k1', 'repeat k1 failure:')).toBe(false);
+    expect(logAssetMissOnce('k2', 'first k2 failure:')).toBe(true);
+    expect(errSpy).toHaveBeenCalledTimes(2);
+    errSpy.mockRestore();
+  });
+});

--- a/tests/view_create_retry.test.ts
+++ b/tests/view_create_retry.test.ts
@@ -32,4 +32,21 @@ describe('ViewCreateRetryGate', () => {
     gate.prune(2_100, new Set([7]));
     expect(gate.size).toBe(0);
   });
+
+  it('retains an unexpired entry for a still-present entity across a prune', () => {
+    // A prune that cleared everything would silently defeat the throttle.
+    const gate = new ViewCreateRetryGate(2_000);
+    gate.markFailed(7, 'view', 100);
+
+    gate.prune(500, new Set([7]));
+    expect(gate.size).toBe(1);
+    expect(gate.canAttempt(7, 'view', 500)).toBe(false);
+  });
+
+  it('keys per entity: one entity failing a slot never blocks another', () => {
+    const gate = new ViewCreateRetryGate(2_000);
+    gate.markFailed(7, 'view', 100);
+
+    expect(gate.canAttempt(8, 'view', 100)).toBe(true);
+  });
 });

--- a/tests/view_create_retry.test.ts
+++ b/tests/view_create_retry.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { ViewCreateRetryGate } from '../src/render/view_create_retry';
+
+describe('ViewCreateRetryGate', () => {
+  it('throttles each entity build slot until its cooldown expires', () => {
+    const gate = new ViewCreateRetryGate(2_000);
+
+    expect(gate.canAttempt(7, 'view', 100)).toBe(true);
+    gate.markFailed(7, 'view', 100);
+    expect(gate.canAttempt(7, 'view', 2_099)).toBe(false);
+    expect(gate.canAttempt(7, 'form_bear', 2_099)).toBe(true);
+    expect(gate.canAttempt(7, 'view', 2_100)).toBe(true);
+    expect(gate.size).toBe(0);
+  });
+
+  it('clears successful slots and prunes entries for entities that left the world', () => {
+    const gate = new ViewCreateRetryGate(2_000);
+    gate.markFailed(7, 'view', 100);
+    gate.markFailed(8, 'base:player_mech', 100);
+
+    gate.markSucceeded(7, 'view');
+    expect(gate.size).toBe(1);
+
+    gate.prune(500, new Set([7]));
+    expect(gate.size).toBe(0);
+  });
+
+  it('prunes expired entries even when their entity is never retried', () => {
+    const gate = new ViewCreateRetryGate(2_000);
+    gate.markFailed(7, 'view', 100);
+
+    gate.prune(2_100, new Set([7]));
+    expect(gate.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

A character GLB that was never registered as preloaded used to throw synchronously from `resolvedGltf` inside the per-frame render path (`Renderer.sync` via `createCandidateViews`), which permanently stalled rendering while the sim tick and audio kept running. That is exactly the shape of the v0.27.0 training dummy freeze; PR #2078 fixed that one model by wiring its missing lazy-preload trigger, and this PR ships the systemic backstop it named as a follow-up.

`createCharacterVisual` (the factory every renderer construction path goes through: `createView`, the visual-key swap, the druid/polymorph form builds, and the three prewarm seeders) now catches a construction failure, logs it once per visual key and cause through the new `src/render/characters/asset_miss_log.ts` module, and returns null. Every call site skips that entity's view and leaves it a future candidate, so any future missing-preload entry (a new `lazyPreload` visual without a trigger, a manifest omission, a tier-alias divergence) degrades to an invisible entity plus one log line instead of a frozen client. A failed build also sits out a 2 second retry cooldown (`viewCreateRetryAt` in `createCandidateViews`): without it, a permanently failing entity would consume a view-creation budget slot every frame, and under the hitch backoff the budget is 1, so a first-sorted failing entity would starve every other pending view. The happy path is unchanged: assets that are preloaded resolve synchronously exactly as before, and a dedicated happy-path test pins that the catch does not swallow successful builds.

Two deliberate scope decisions, both from the issue's scope notes:

- The lazy preload gates (mech, training dummy) keep their memoized no-retry behavior; a per-frame retry would spam fetches on a permanent failure. Their catch logging now dedupes through the same module, one line per asset instead of one per frame. The gates share the retry cooldown while their fetch is in flight (so a deferring entity burns no per-frame budget slot) and clear it when the fetch resolves, so pop-in stays at the next frame after readiness; only a rejected fetch waits out the full cooldown.
- The post-construction weapon-swap path (`setWeapon` and the deferred stow swap) still resolves synchronously without a catch: weapon and weapon-skin URLs are pinned into the tier-independent preload union by `tests/render_asset_preload.test.ts`, and the renderer latches the diff field before the call, so a hypothetical miss there throws once per weapon change (no freeze) and is prevented by construction rather than handled at runtime. The armory inspect window's own construction paths (its separate GL loop) are likewise event-driven, pre-existing, and untouched.

The renderer-level acceptance criterion ("the renderer keeps painting, other entities keep their views") was verified end to end in a real browser, not just by inspection: with `mob_training_dummy`'s GLB deliberately renamed to a missing file (uncommitted local edit) and the client teleported to the postmortem coordinates (`/dev tp -90 668` equivalent), a scripted 10 second observation recorded zero uncaught page errors (pre-fix: one per frame), exactly one deduped miss log across multiple retry-cooldown cycles, 228 sim ticks advanced, pixels changing between screenshots 9 seconds apart, and the broken entity present in the sim with no view while the other 29 entities in range all received theirs. The unit tests additionally pin the factory contract (null plus one log on a miss, non-null with zero logs on the happy path), the log dedupe, and the retry-gate mechanics (cooldown boundary, per-entity and per-slot independence, prune retention and cleanup).

## Related issues

Closes #2079. Follow-up to #2078.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands: `npm run gate` (green through i18n, malware scan, biome, SFX, and the full unit suite; the browser-regressions step failed only on the known environmental `armory_mobile_layout.browser.test.ts` layout flake on this machine, which is unrelated to this diff and fails identically on a clean base, so `npx tsc --noEmit` and `npm run build` were then run manually and are green; PR CI is the arbiter for the browser suite). Also targeted `npx vitest run tests/character_visual_fail_soft.test.ts tests/training_dummy_preload.test.ts tests/render_asset_preload.test.ts tests/render_asset_fallback.test.ts tests/architecture.test.ts` and `npx @biomejs/biome check` on the changed files.
- Manual steps: none needed beyond the suites; the new test drives the real miss path (a lazyPreload visual under a mocked loader hits the actual `character asset not preloaded` throw inside `new CharacterVisual`) and pins the null return plus the once-per-asset log. The test was written first and failed on the base with the real throw.

## Checklist

### Quality

- [x] **The full gate passes** apart from the known environmental armory browser-layout flake on the dev machine (unrelated to this diff, fails identically on a clean base; details above). `npx tsc --noEmit` and `npm run build` were completed manually and are green, decisive tests were added for the changed behavior, and PR CI is the arbiter for the browser suite.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. (The new logging is dev-channel `console.error`, which stays English by policy.)

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
