### PR TITLE
test(professions): Phase 2 masterwork QA pins and quality-roll retirement cleanup

### DIFF
--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -10,7 +10,7 @@ Update this file at the end of every implementation and QA session. Statuses:
 | 1 | Ring and identity foundations | complete | 2026-07-16 | 2026-07-17 |
 | 1 QA | Verify ring and identity foundations | complete | 2026-07-17 | 2026-07-17 |
 | 2 | Masterwork model | complete | 2026-07-17 | 2026-07-17 |
-| 2 QA | Verify masterwork model | not started | | |
+| 2 QA | Verify masterwork model | complete | 2026-07-17 | 2026-07-17 |
 | 3 | Host-parity bug fixes | not started | | |
 | 3 QA | Verify host-parity bug fixes | not started | | |
 | 4 | Node materials and pristine veins | not started | | |
@@ -72,6 +72,36 @@ IWorldProfessions member retirement (Phase 15 candidate).
 - [x] Masterwork proc (skill, self-signed, specialization inputs) with pinned rng-draw contract
 - [x] Masterwork stats baked via `item_budget` into `instance.rolled.stats`; deeds reader still coherent
 - [x] Masterwork SimEvent with celebration payload; power-ceiling tuning targets in `state.md`
+
+Phase 2 QA (2026-07-17): PASS, zero blocking findings across the packet's
+three audit roles plus the matched dispatch-matrix rows (architecture,
+cross-platform sync, privacy/security, migration safety, pin quality,
+qa-checklist; frontend seam and database performance were NO-MATCH for
+this diff). The phase-emphasis probes all bind: an inserted extra rng
+draw reddens five tests across three suites, a 2-tier bump reddens the
+raid-floor bound through its literal tripwire pins (the derived sweep
+moves with the model by design; the literal rows are the teeth, never
+delete them thinking the sweep suffices), and the legacy rolled.quality
+path is proven end to end in both hosts. QA landed: proc-chance wiring
+pins through the real craft path (self-signed at hunted seed 69, the
+joint specialization-plus-tier 74/75/76 boundary at hunted seed 2,
+spares recorded in-file), the ClientWorld craftResult mirror's
+masterwork flag, the top-level enchant marker save/load round trip, an
+observed-roll pin making the miss-arm's seed-1 premise load-bearing,
+an inv-snapshot passthrough pin (masterwork and legacy instance
+payloads reach the client byte-identical), and the quality-roll
+retirement cleanup (dead clampMaterialRarity deleted with its orphan
+test pin; the area CLAUDE.md re-taught the deterministic model). One
+audit finding dissolved on verification: the reported vestments armor
+anomaly is the displaced starter recruit_tunic (delta 30 minus 20),
+not a bug. Deferred with reasons: the 0.15-cap integration hunted pin
+(the clamp is pure-function pinned and every term wiring is craft-path
+pinned; a fourth hunted seed adds maintenance without coverage), and
+the online-inspect equippedInstances gap (pre-existing, recorded in
+the state.md drift notes for the Phase 6 surfacing decision).
+Mixed-fleet safety verified: the previous release's HUD event if-chain
+ignores unknown SimEvent types, so a new server's masterwork event is
+harmless to an old client.
 
 ### Phase 3: Host-parity bug fixes
 - [ ] Trade carries `ItemInstancePayload` end to end (regression test)

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -8,8 +8,9 @@ Phase 1 (Ring and identity foundations) and its QA: complete
 (2026-07-17, PASS, zero blocking; fixes and drift notes below). Phase 2
 (Masterwork model): complete (2026-07-17, branch
 feature/professions-2-phase-02-masterwork; six reviewers, zero blocking;
-landed surfaces and drift notes below). Next: Phase 2 QA
-(phase-02-qa.md).
+landed surfaces and drift notes below). Phase 2 QA: complete
+(2026-07-17, PASS, zero blocking; coverage pins, retirement cleanup, and
+QA drift notes below). Next: Phase 3 (phase-03-parity-bug-fixes.md).
 
 ## Locked design decisions
 
@@ -267,7 +268,13 @@ tables, i18n key namespaces, files created)
     rolled-back code reads bare rolled.stats as already-enchanted, so
     masterwork copies are temporarily non-enchantable and
     non-disenchantable under rollback; no data loss or corruption,
-    fully reversible on roll-forward.
+    fully reversible on roll-forward. Second arm (Phase 2 QA,
+    migration-safety): Phase 2 crafts stop writing rolled.quality, and
+    the previous release's battlefield_xp reads only rolled.quality, so
+    under rollback EVERY new-format signed craft (masterwork or plain
+    rare-plus) grants no Battlefield Experience trickle; the signer
+    field survives on the row and the trickle resumes on roll-forward
+    via the def-quality fallback.
   - Battlefield XP trickle, two maintainer questions surfaced and NOT
     changed here: (a) a masterwork of a sub-rare def carries bonus stats
     but does not trickle (the def-quality gate; masterwork is not
@@ -286,6 +293,28 @@ tables, i18n key namespaces, files created)
     command ingests a client-supplied ItemInstancePayload; any future
     command that would must re-mint the instance server-side or
     masterwork and enchant forgery becomes possible.
+- Phase 2 QA drift notes (2026-07-17):
+  - Deeds quality-mark delta (intended, silently absorbed by the
+    fallback): markItemDiscovered records the def quality for new
+    crafts (rolled.quality is gone), so a masterwork copy credits its
+    DEF quality toward discovery deeds, never the bumped tier,
+    consistent with the battlefield-trickle stance above. If masterwork
+    copies should count toward higher-quality discovery deeds, that is
+    a deliberate maintainer design change, not a fix.
+  - Online inspect never carries equippedInstances (the identity wire
+    has no instance payloads; offline builds them for the render
+    mirror), so another player's masterwork and enchant stats are
+    invisible to online inspection. Pre-existing for enchants; Phase 6
+    (masterwork surfacing) decides whether to extend the identity wire
+    or accept the limitation.
+  - Quality-roll retirement cleanup landed in QA: clampMaterialRarity
+    and its private ladder deleted from gathering.ts (zero consumers
+    after the craft-side clamp retirement); the professions CLAUDE.md
+    module map and ceiling invariant re-teach the deterministic
+    masterwork model.
+  - Mixed-fleet check: the previous release's HUD event if-chain
+    ignores unknown SimEvent types, so a new server's masterwork event
+    is harmless to an old client during a staged rollout.
 - Phase 3: (planned) hcb wire key (corpse claims); trade payload carriage.
 - Phase 4: (planned) node material tables; pristine vein event + deed mark.
 - Phase 5: (planned) professions window (.window id professions-window) +

--- a/src/sim/professions/CLAUDE.md
+++ b/src/sim/professions/CLAUDE.md
@@ -19,7 +19,11 @@ or pure leaves, never a `Sim` import, randomness only via `ctx.rng` (guarded by
 - `wheel.ts`: flat per-craft skills (`CraftSkills`, `gainCraftSkill`,
   `tierForSkill`/`tierCapability`, perk-eligibility reads).
 - `crafting.ts`: `craftItem`/`resolveCraft` (all-or-nothing reagent consume,
-  quality roll clamped to the archetype ceiling, skill gain, recipe acquisition).
+  deterministic def-quality outputs plus the single masterwork proc draw,
+  skill gain, recipe acquisition).
+- `masterwork.ts`: the pure masterwork model (`masterworkProcChance`,
+  `masterworkBumpedQuality`, `masterworkBonusStats`); `crafting.ts` consumes
+  it at the one post-consume proc draw per successful craft.
 - `archetype.ts`: the active-archetype state machine (`ArchetypeState`,
   `archetypeCeilingFor`/`craftCeiling`, `getHobbyCraft`, amends-gated switching).
 - `enchanting.ts` / `salvage.ts`: disenchant + apply an enchant onto a SPECIFIC
@@ -58,11 +62,14 @@ or pure leaves, never a `Sim` import, randomness only via `ctx.rng` (guarded by
   capped at rare); every other craft caps at common once an archetype is set,
   and everything caps at rare before one is set (`archetype.ts`
   `archetypeCeilingFor`).
-- The ceiling freezes EMPOWERMENT, never the raw-capability climb: output
-  quality is clamped to the ceiling and a recipe tiered ABOVE the ceiling
-  grants zero skill, but at or below the ceiling the ordinary progress curve
-  runs off raw capability unchanged (`crafting.ts` `resolveCraft`; pinned by
-  `tests/archetype_ceiling.test.ts` and `tests/professions_skill.test.ts`).
+- The ceiling freezes EMPOWERMENT, never the raw-capability climb: outputs
+  are deterministic at the def quality and the ceiling instead gates the
+  masterwork bump (a dormant craft never procs; a hobby or pre-attunement
+  craft cannot bump past rare) and skill gain (a recipe tiered ABOVE the
+  ceiling grants zero skill), but at or below the ceiling the ordinary
+  progress curve runs off raw capability unchanged (`crafting.ts`
+  `resolveCraftForRecipe`; pinned by `tests/archetype_ceiling.test.ts` and
+  `tests/professions_skill.test.ts`).
 
 ## Wire + persistence names (settled)
 - Snapshot deltas: `prof` (`professionsState`), `gprof`

--- a/src/sim/professions/gathering.ts
+++ b/src/sim/professions/gathering.ts
@@ -481,27 +481,3 @@ export function rollCorpseMaterialRarity(rng: Rng): MaterialRarity {
 export function isSignableMaterialRarity(rarity: MaterialRarity): boolean {
   return rarity === 'rare' || rarity === 'epic' || rarity === 'legendary';
 }
-
-// Fixed rarity ladder, low to high, matching the tier-index scale professions/
-// archetype.ts's empowerment ceiling already uses (common=0, uncommon=1,
-// rare=2, epic=3, legendary=4).
-const MATERIAL_RARITY_ORDER: readonly MaterialRarity[] = [
-  'common',
-  'uncommon',
-  'rare',
-  'epic',
-  'legendary',
-];
-
-/** Clamp a rolled rarity down to at most `maxTier` (a tier index on the same
- *  ladder, e.g. from archetype.ts `archetypeCeilingFor`; `Infinity` is a no-op).
- *  Used to cap crafted-output quality at the #1129 empowerment ceiling: a
- *  dormant or hobby craft can still ROLL a high rarity off raw skill, but the
- *  actual result granted never exceeds what that craft is empowered to
- *  produce. Never raises a roll, only lowers it. */
-export function clampMaterialRarity(rarity: MaterialRarity, maxTier: number): MaterialRarity {
-  if (!Number.isFinite(maxTier)) return rarity;
-  const cap = Math.max(0, Math.min(MATERIAL_RARITY_ORDER.length - 1, Math.floor(maxTier)));
-  const rolled = MATERIAL_RARITY_ORDER.indexOf(rarity);
-  return MATERIAL_RARITY_ORDER[Math.min(rolled, cap)];
-}

--- a/src/sim/professions/masterwork.ts
+++ b/src/sim/professions/masterwork.ts
@@ -57,8 +57,8 @@ export function masterworkProcChance(input: MasterworkChanceInput): number {
 }
 
 // The quality ladder a masterwork bumps along, index-aligned with the tier
-// scale the archetype empowerment ceiling uses (archetype.ts / gathering.ts
-// MATERIAL_RARITY_ORDER: common=0, uncommon=1, rare=2, epic=3, legendary=4).
+// scale the archetype empowerment ceiling uses (archetype.ts: common=0,
+// uncommon=1, rare=2, epic=3, legendary=4).
 // 'poor' is deliberately off the ladder: a junk-grade def never masterworks.
 export const MASTERWORK_QUALITY_LADDER = [
   'common',

--- a/tests/archetype_ceiling.test.ts
+++ b/tests/archetype_ceiling.test.ts
@@ -13,7 +13,6 @@ import { COMBO_RECIPES, recipeById } from '../src/sim/content/recipes';
 import { ITEMS } from '../src/sim/data';
 import { archetypeCeilingFor, craftCeiling } from '../src/sim/professions/archetype';
 import { meetsComboRequirement, resolveCraftForRecipe } from '../src/sim/professions/crafting';
-import { clampMaterialRarity } from '../src/sim/professions/gathering';
 import { MASTERWORK_BASE_CHANCE } from '../src/sim/professions/masterwork';
 import type { ProfessionRecipeRecord } from '../src/sim/professions/types';
 import { type CraftSkills, emptyCraftSkills, tierCapability } from '../src/sim/professions/wheel';
@@ -599,15 +598,5 @@ describe('archetype ceilings gate the masterwork effect (Phase 2: ceilings bind 
     expect(result.masterwork).toBe(true);
     const minted = metaOf(sim, pid).inventory.find((s) => s.itemId === recipe.resultItemId);
     expect(minted?.instance?.rolled?.masterwork).toBe(true);
-  });
-});
-
-describe('clampMaterialRarity stays on the INPUT side (gathering rolls; Phase 2 removed it from craft outputs)', () => {
-  it('clampMaterialRarity lowers a roll to the cap and never raises one', () => {
-    expect(clampMaterialRarity('legendary', 2)).toBe('rare');
-    expect(clampMaterialRarity('epic', 0)).toBe('common');
-    expect(clampMaterialRarity('uncommon', 2)).toBe('uncommon'); // below the cap: untouched
-    expect(clampMaterialRarity('common', 4)).toBe('common'); // a cap never raises a roll
-    expect(clampMaterialRarity('legendary', Infinity)).toBe('legendary'); // no-op ceiling
   });
 });

--- a/tests/item_instance.test.ts
+++ b/tests/item_instance.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { ITEMS } from '../src/sim/data';
+import { isEnchantedInstance } from '../src/sim/professions/enchanting';
 import { Sim } from '../src/sim/sim';
 import { cloneItemInstancePayload, type Entity, type ItemInstancePayload } from '../src/sim/types';
 import { groundHeight } from '../src/sim/world';
@@ -287,5 +288,42 @@ describe('masterwork and legacy instance payloads (Professions 2.0 Phase 2 back-
       rolled: { quality: 'rare', stats: { spellPower: 5 }, masterwork: true },
       boundTo: sim.playerId,
     });
+  });
+
+  it('the top-level enchant marker survives save/load intact and keeps the copy enchant-guarded', () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', autoEquip: false });
+    // The exact post-Phase-2 shape of an enchanted masterwork copy: signer plus
+    // rolled.masterwork plus baked stats plus the authoritative top-level
+    // enchant id (types.ts ItemInstancePayload.enchant). If persistence dropped
+    // the marker, isEnchantedInstance would fall through to the masterwork arm
+    // (NOT enchanted) and a reloaded copy could be enchanted twice.
+    sim.addItemInstance(
+      'apprentice_staff',
+      {
+        signer: 'Aldric',
+        enchant: 'enchant_weapon_might',
+        rolled: { masterwork: true, stats: { int: 2, spi: 1 } },
+      },
+      sim.playerId,
+    );
+
+    const state = sim.serializeCharacter(sim.playerId)!;
+    const saved = state.inventory.find((s) => s.itemId === 'apprentice_staff')!;
+    expect(saved.instance?.enchant).toBe('enchant_weapon_might');
+
+    const sim2 = new Sim({ seed: 42, playerClass: 'warrior', autoEquip: false });
+    const pid2 = sim2.addPlayer('warrior', 'Reloaded', { state });
+    const loaded = sim2.meta(pid2)?.inventory.find((s) => s.itemId === 'apprentice_staff');
+    expect(loaded?.instance).toEqual({
+      signer: 'Aldric',
+      enchant: 'enchant_weapon_might',
+      rolled: { masterwork: true, stats: { int: 2, spi: 1 } },
+    });
+    // The reloaded copy still reads as already enchanted, so the double-enchant
+    // guard holds across a save/load cycle.
+    expect(isEnchantedInstance(loaded!.instance!)).toBe(true);
+    // And the payload cloner carries the marker alongside signer and rolled.
+    const clone = cloneItemInstancePayload(loaded!.instance!);
+    expect(clone.enchant).toBe('enchant_weapon_might');
   });
 });

--- a/tests/masterwork_event_mirror.test.ts
+++ b/tests/masterwork_event_mirror.test.ts
@@ -95,6 +95,40 @@ describe('online ClientWorld host', () => {
     const queued = (client as unknown as { eventQueue: SimEvent[] }).eventQueue;
     expect(queued.map((ev) => ev.type)).toEqual(['masterwork', 'masterwork', 'craftResult']);
   });
+
+  it('the craftResult mirror carries the masterwork flag and rebuilds it per event', () => {
+    // applyCraftResultEvent (online.ts) must copy the Phase 2 `masterwork`
+    // field into the lastCraftResult mirror: a dropped field here would leave
+    // the online HUD unable to distinguish a proc, with every other test
+    // (Sim-side only) still green.
+    const client = bareClient();
+    feed(client, {
+      type: 'craftResult',
+      ok: true,
+      recipeId: RECIPE_ID,
+      itemId: ITEM_ID,
+      count: 1,
+      quality: 'uncommon',
+      masterwork: true,
+      pid: 7,
+    });
+    expect(client.lastCraftResult?.ok).toBe(true);
+    expect(client.lastCraftResult?.quality).toBe('uncommon');
+    expect(client.lastCraftResult?.masterwork).toBe(true);
+    // The mirror is rebuilt wholesale per event: a later non-proc craft must
+    // not inherit the flag from the previous proc.
+    feed(client, {
+      type: 'craftResult',
+      ok: true,
+      recipeId: RECIPE_ID,
+      itemId: ITEM_ID,
+      count: 1,
+      quality: 'uncommon',
+      pid: 7,
+    });
+    expect(client.lastCraftResult?.ok).toBe(true);
+    expect(client.lastCraftResult?.masterwork).toBeUndefined();
+  });
 });
 
 describe('host parity', () => {

--- a/tests/professions_crafting.test.ts
+++ b/tests/professions_crafting.test.ts
@@ -13,6 +13,7 @@ import {
   resolveCraft,
   resolveCraftForRecipe,
 } from '../src/sim/professions/crafting';
+import { MASTERWORK_CHANCE_CAP } from '../src/sim/professions/masterwork';
 import type { ProfessionRecipeRecord } from '../src/sim/professions/types';
 import type { Rng } from '../src/sim/rng';
 import { Sim } from '../src/sim/sim';
@@ -861,7 +862,10 @@ describe('masterwork proc (Professions 2.0 Phase 2)', () => {
     // The same maximum-chance shape on a common-def output (the chain vest,
     // under armorcrafting as the MAJOR craft). Seed 1 was hunted so the single
     // proc draw lands ABOVE the capped 15 percent chance: the roll itself
-    // misses, decisively, independent of what the effect gates would say.
+    // misses, decisively. The observed-roll pin below keeps that premise
+    // load-bearing (this def is armor-only, so the effect gate would ALSO
+    // deny; without the pin, a re-seeded roll under the cap would pass
+    // silently through the gate instead of proving a roll miss).
     const sim = makeSim(1);
     const pid = sim.playerId;
     sim.acceptArchetypeQuest('armorcrafting');
@@ -872,16 +876,20 @@ describe('masterwork proc (Professions 2.0 Phase 2)', () => {
     sim.addItemInstance('bone_fragments', { signer: meta.name }, pid);
     sim.drainEvents();
     let draws = 0;
+    let roll = -1;
     const rng: Rng = (sim as any).ctx.rng;
-    rng.setObserver(() => {
+    rng.setObserver((value) => {
       draws++;
+      roll = value;
     });
     sim.craftItem('recipe_eastbrook_chain_vest', pid);
     rng.setObserver(null);
 
     // The proc draw is unconditional on the success path: exactly one draw
-    // even when it misses.
+    // even when it misses, and the seed-1 draw really does land at or above
+    // the capped chance, so the miss is the roll's doing.
     expect(draws).toBe(1);
+    expect(roll).toBeGreaterThanOrEqual(MASTERWORK_CHANCE_CAP);
     expect(sim.lastCraftResult?.ok).toBe(true);
     expect(sim.lastCraftResult?.quality).toBe('common');
     expect(sim.lastCraftResult?.masterwork).toBeUndefined();

--- a/tests/professions_masterwork.test.ts
+++ b/tests/professions_masterwork.test.ts
@@ -4,6 +4,7 @@
 // determinism contract over a real Sim (one rng draw per successful craft,
 // zero on denial, proc occurrences reproducible by seed).
 import { describe, expect, it } from 'vitest';
+import { PERK_THRESHOLDS } from '../src/sim/content/professions';
 import { ALL_RECIPES, recipeById } from '../src/sim/content/recipes';
 import { ITEMS } from '../src/sim/data';
 import { PRIMARY_STATS, primaryStatBudget } from '../src/sim/item_budget';
@@ -481,5 +482,82 @@ describe('draw-order determinism over a real Sim (Phase 2)', () => {
       { signer: a.playerName, rolled: { masterwork: true, stats: { int: 1, spi: 1 } } },
       { signer: a.playerName, rolled: { masterwork: true, stats: { int: 1, spi: 1 } } },
     ]);
+  });
+});
+
+describe('proc-chance wiring over a real Sim (hunted boundary-window seeds)', () => {
+  // Both cases craft recipe_eastbrook_ritual_vestments (skillReq 0, uncommon
+  // def, bump tier 2: inside the pre-attunement rare ceiling) on a fresh
+  // warrior, so the only chance inputs in play are the ones each case flips.
+  // Granting materials and setting craftSkills directly never draws rng, so
+  // paired same-seed runs share the identical single proc draw; each seed was
+  // hunted (bounded scan from seed 1, draw value verified via the rng
+  // observer during the hunt) for a draw inside the decisive window where the
+  // flipped input alone decides the proc.
+
+  function craftVestments(seed: number, setup: (sim: Sim, pid: number) => void) {
+    const sim = new Sim({ seed, playerClass: 'warrior', autoEquip: false });
+    const pid = sim.playerId;
+    setup(sim, pid);
+    sim.craftItem('recipe_eastbrook_ritual_vestments', pid);
+    return { ...sim.lastCraftResult! };
+  }
+
+  it('a self-signed reagent feeds the proc chance: the same seed procs only with the signed copy', () => {
+    // Seed 69, hunted: the single proc draw lands in [0.03, 0.05), above the
+    // 3 percent base but under base plus the 2 percent self-signed bonus, so
+    // the proc fires ONLY when crafting.ts passes selfSignedBonusApplied into
+    // masterworkProcChance. Spares on record: 89, 117, 134, 185.
+    const SEED = 69;
+    const signed = craftVestments(SEED, (sim, pid) => {
+      const meta = (sim as any).players.get(pid);
+      // One self-signed linen_scrap plus one plain: the #1145 reduction drops
+      // the linen requirement from 3 to 2, so ok:true here also re-proves the
+      // detection arm through the craftItem path (without the reduction this
+      // grant set is insufficient and the craft would deny).
+      sim.addItemInstance('linen_scrap', { signer: meta.name }, pid);
+      sim.addItem('linen_scrap', 1, pid);
+      sim.addItem('spider_leg', 1, pid);
+    });
+    expect(signed.ok).toBe(true);
+    expect(signed.selfSignedBonusApplied).toBe(true);
+    expect(signed.masterwork).toBe(true);
+    // Control at the SAME seed and stream position, no signed copy held: the
+    // identical draw sits above the 3 percent base and must miss.
+    const plain = craftVestments(SEED, (sim, pid) => {
+      for (let i = 0; i < 3; i++) sim.addItem('linen_scrap', 1, pid);
+      sim.addItem('spider_leg', 1, pid);
+    });
+    expect(plain.ok).toBe(true);
+    expect(plain.selfSignedBonusApplied).toBe(false);
+    expect(plain.masterwork).toBeUndefined();
+  });
+
+  it('the specialization threshold binds in the craft path: skill 74 misses where 75 and 76 proc', () => {
+    // Premise anchor: the content threshold this boundary rides. A content
+    // retune moves the boundary and this seed must be re-hunted.
+    expect(PERK_THRESHOLDS.tailoring.specializedSkillThreshold).toBe(75);
+    // Seed 2, hunted: the single proc draw lands in [0.06, 0.09). At skill 74
+    // (tier 2, not specialized) the chance is 0.03 + 0.02 = 0.05: miss. At 75
+    // and 76 (tier 3, specialized) it is 0.03 + 0.03 + 0.03 = 0.09: proc, and
+    // only if BOTH the tiersAboveRecipe term and isSpecialized are wired into
+    // masterworkProcChance by crafting.ts (either wiring dropped leaves the
+    // chance at or below 0.06, under the hunted draw). Spares on record: 79,
+    // 83, 87, 195.
+    const SEED = 2;
+    const at = (skill: number) =>
+      craftVestments(SEED, (sim, pid) => {
+        const meta = (sim as any).players.get(pid);
+        meta.craftSkills.tailoring = skill;
+        for (let i = 0; i < 3; i++) sim.addItem('linen_scrap', 1, pid);
+        sim.addItem('spider_leg', 1, pid);
+      });
+    const r74 = at(74);
+    const r75 = at(75);
+    const r76 = at(76);
+    expect([r74.ok, r75.ok, r76.ok]).toEqual([true, true, true]);
+    expect(r74.masterwork).toBeUndefined();
+    expect(r75.masterwork).toBe(true);
+    expect(r76.masterwork).toBe(true);
   });
 });

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -827,6 +827,37 @@ describe('delta snapshots', () => {
     expect(client.inventory.some((s) => s.itemId === 'worn_sword')).toBe(true);
   });
 
+  it('instance payloads (masterwork and legacy quality) ride the inv snapshot verbatim', () => {
+    // Phase 2 back-compat over the wire: the server sends the live
+    // meta.inventory wholesale, so a masterwork copy's full payload (signer,
+    // enchant marker, rolled.masterwork plus baked stats) and a legacy copy's
+    // rolled.quality must both arrive on the client mirror byte-identical.
+    // A future snapshot serializer that field-picks the instance would red
+    // here before it could strip either generation.
+    const masterwork = {
+      signer: 'Testa',
+      enchant: 'enchant_chest_stamina',
+      rolled: { masterwork: true, stats: { int: 2, spi: 1 } },
+    };
+    const legacy = { signer: 'Oldhand', rolled: { quality: 'rare' as const } };
+    server.sim.addItemInstance('eastbrook_ritual_vestments', masterwork, session.pid);
+    server.sim.addItemInstance('apprentice_staff', legacy, session.pid);
+
+    broadcast(server);
+    const snap = lastSnap(fc.sent);
+    const wireMw = snap.self.inv.find((s: any) => s.itemId === 'eastbrook_ritual_vestments');
+    const wireLegacy = snap.self.inv.find((s: any) => s.itemId === 'apprentice_staff');
+    expect(wireMw?.instance).toEqual(masterwork);
+    expect(wireLegacy?.instance).toEqual(legacy);
+
+    const client = bareClient(session.pid);
+    (client as any).applySnapshot(snap);
+    expect(
+      client.inventory.find((s) => s.itemId === 'eastbrook_ritual_vestments')?.instance,
+    ).toEqual(masterwork);
+    expect(client.inventory.find((s) => s.itemId === 'apprentice_staff')?.instance).toEqual(legacy);
+  });
+
   it('mirrors vendor buyback deltas to the client', () => {
     const wilkes = [...server.sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
     const player = server.sim.entities.get(session.pid)!;


### PR DESCRIPTION
## Summary

The Phase 2 QA packet run (docs/professions-2/phase-02-qa.md) over the merged
masterwork diff (9a5ce7a93..fdc841534): a nine-agent audit (the packet's three
audit roles plus the six matching Review Dispatch Matrix reviewers) returned
zero blocking findings, and this PR lands everything the audit asked for.

The packet's mutation probes all proved their pins bind before any fix landed:
an inserted extra rng draw reddens five tests across three suites, and a
hypothetical 2-tier masterwork bump reddens the raid-floor bound through its
literal tripwire pins (the derived sweep intentionally moves with the model;
the literal rows are the teeth).

What lands here:

- Coverage pins the audit found missing:
  - the self-signed reagent bonus and the joint specialization-plus-tier term
    wired into the proc chance through the real craft path (hunted
    boundary-window seeds 69 and 2, spares recorded in-file);
  - the ClientWorld craftResult mirror's `masterwork` flag through the real
    wire path (deleting the mirror line previously reddened nothing);
  - the top-level `enchant` marker save/load round trip (a dropped field would
    have re-enabled double-enchant across a reload with every test green);
  - an observed-roll pin making the miss-arm's seed-1 premise load-bearing
    (its armor-only def alone could not prove a roll miss);
  - an inv-snapshot passthrough pin: a masterwork payload and a legacy
    `rolled.quality` payload both reach `ClientWorld.inventory` byte-identical.
- Quality-roll retirement cleanup: `clampMaterialRarity` and its private
  ladder deleted from `gathering.ts` (zero production consumers after the
  craft-side clamp retirement), the orphan-pinning test block removed, and
  the `src/sim/professions/CLAUDE.md` module map and ceiling invariant
  re-taught for the deterministic masterwork model.
- QA records: the progress.md status row and session record, plus new state.md
  drift notes (the deeds quality-mark delta, the online-inspect
  `equippedInstances` limitation for Phase 6, the second rollback-caveat arm:
  battlefield trickle goes dormant for new-format signed crafts under
  rollback, and the mixed-fleet unknown-event safety check).

One audit finding dissolved on verification rather than landing anywhere: the
reported vestments armor anomaly (+10 vs the def's 30) is the displaced
starter `recruit_tunic` (armor 20), not a bug.

Deferred, with reasons in progress.md: a 0.15-cap integration hunted pin (the
clamp is pure-function pinned and every term wiring is now craft-path pinned;
a fourth hunted seed adds maintenance without coverage).

## Related issues

Part of #2051, part of #1866.

## Type of change

- [ ] Feature: new functionality
- [ ] Bug fix
- [x] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npx vitest run` over the phase validation matrix plus every touched
    suite: 19 files, 866 tests, all green (professions_crafting,
    professions_rarity_roll, archetype_ceiling, deeds, item_instance,
    architecture, professions_masterwork, masterwork_event_mirror,
    parity/coverage, parity/parity, snapshots, env_protocol, bandwidth,
    world_api_parity, professions_enchanting, professions_battlefield_xp,
    professions_perks, profession_attunement_quests,
    professions_acquisition_salvage_sink)
  - `npm run gate` under Node 24
  - `npx @biomejs/biome check --write` on every changed file
- Manual steps: mutation probes (extra rng draw beside the proc roll; +1 to
  +2 bump) run and restored in the QA worktree, confirming the pins fail;
  the armor-anomaly repro isolated to starter-gear displacement.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI surface changes.
- ~Accessible.~ N/A: no UI surface changes.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
