### PR TITLE
feat(sfx): trigger idle mob-voice barks with a density-damped periodic sweep

### DIFF
--- a/docs/design/sound_effects.md
+++ b/docs/design/sound_effects.md
@@ -274,14 +274,17 @@ pitched-up `attack`. Families: `beast`, `boar`, `spider`, `mudfin`, `burrower`,
 | `demon` | a demon — sinister hissing snarl / shrieking demonic strike / agonized demonic death wail |
 
 ### Idle vocalizations (spatial, ambient bark)
-`mob_<family>_idle` (one per family, `reptile` included, 14 total), plus a
-subfamily-specific `mob_<family>_<subfamily>_idle` for the wolf and skeleton
-aliases (see `SUBFAMILY_ALIAS` in `src/ui/combat_sfx.ts`). Unlike the reactive
+`mob_<family>_idle` (one per family, `reptile` included, 13 total), plus a
+subfamily-specific `mob_<family>_<subfamily>_idle` for the wolf aliases (see
+`SUBFAMILY_ALIAS` in `src/ui/combat_sfx.ts`; a matching `mob_undead_skeleton_*`
+set exists on disk but is not currently wired to any live template, an
+inherited gap this feature did not introduce). Unlike the reactive
 aggro/attack/death/hurt vocalizations (fired directly off sim combat events),
 idle barks are presentation-only ambience: a shared periodic sweep
 (`Hud.sweepMobIdleBarks`, throttled to `MOB_IDLE_CHECK_INTERVAL_MS` from
-`update()`, never per-mob-per-frame) considers every non-combat, unmuted mob
-within `MOB_IDLE_SCAN_RADIUS` of the player and rolls each one independently
+`update()`, never per-mob-per-frame) considers every non-combat, unowned,
+non-dummy, unmuted mob within `MOB_IDLE_SCAN_RADIUS` of the player and rolls
+each one independently
 against `MOB_IDLE_BASE_CHANCE`, damped by how many same-family mobs are
 clustered nearby (`idleDensityFactor`, `src/ui/mob_idle_sfx.ts`) so a dense
 pack does not all bark in the same sweep. A per-entity cooldown

--- a/docs/design/sound_effects.md
+++ b/docs/design/sound_effects.md
@@ -273,6 +273,28 @@ pitched-up `attack`. Families: `beast`, `boar`, `spider`, `mudfin`, `burrower`,
 | `dragonkin` | a dragonkin — fierce roaring alert with wing flap / snapping bite roar / dying roar collapse |
 | `demon` | a demon — sinister hissing snarl / shrieking demonic strike / agonized demonic death wail |
 
+### Idle vocalizations (spatial, ambient bark)
+`mob_<family>_idle` (one per family, `reptile` included, 14 total), plus a
+subfamily-specific `mob_<family>_<subfamily>_idle` for the wolf and skeleton
+aliases (see `SUBFAMILY_ALIAS` in `src/ui/combat_sfx.ts`). Unlike the reactive
+aggro/attack/death/hurt vocalizations (fired directly off sim combat events),
+idle barks are presentation-only ambience: a shared periodic sweep
+(`Hud.sweepMobIdleBarks`, throttled to `MOB_IDLE_CHECK_INTERVAL_MS` from
+`update()`, never per-mob-per-frame) considers every non-combat, unmuted mob
+within `MOB_IDLE_SCAN_RADIUS` of the player and rolls each one independently
+against `MOB_IDLE_BASE_CHANCE`, damped by how many same-family mobs are
+clustered nearby (`idleDensityFactor`, `src/ui/mob_idle_sfx.ts`) so a dense
+pack does not all bark in the same sweep. A per-entity cooldown
+(`MOB_IDLE_PER_ENTITY_COOLDOWN_MS`) additionally rate-limits one mob's own
+repeats, stamped only when `sfx.playAt` reports the sound actually played
+(not merely attempted), so losing the shared per-key playback cooldown
+(`MOB_IDLE_KEY_COOLDOWN_S`, the backstop against two mobs barking the
+identical clip at once) does not silently bench a mob for the full
+per-entity window. Plays at `MOB_IDLE_GAIN`, a dedicated lower bucket
+distinct from the combat layer's `COMBAT_GAIN`. Timing is client-local and
+non-deterministic across players by design (presentation-only, same category
+as footstep variant choice, not gameplay-affecting).
+
 ### Ambient loops
 | key | loop | spatial | prompt summary |
 |---|---|---|---|

--- a/src/game/sfx.ts
+++ b/src/game/sfx.ts
@@ -392,13 +392,13 @@ class Sfx {
     return dx * dx + dz * dz > MAX_DISTANCE_SQ;
   }
 
-  /** Positional one-shot at world (x,y,z). */
-  /** Returns whether this call actually scheduled a sound (false for out of
-   *  range, an unbuffered clip still loading, the voice cap, or a per-key
-   *  cooldown block). A caller that only wants to know "did MY attempt make
-   *  a sound, not some other source that beat me to this key's cooldown"
-   *  (e.g. the mob idle-bark sweep's per-entity cooldown stamping, see
-   *  src/ui/mob_idle_sfx.ts) needs this instead of firing blind. */
+  /** Positional one-shot at world (x,y,z). Returns whether this call actually
+   *  scheduled a sound: false if the audio context is not yet initialized,
+   *  out of range, an unbuffered clip still loading, the voice cap, or a
+   *  per-key cooldown block. A caller that only wants to know "did MY
+   *  attempt make a sound, not some other source that beat me to this key's
+   *  cooldown" (e.g. the mob idle-bark sweep's per-entity cooldown stamping,
+   *  see src/ui/mob_idle_sfx.ts) needs this instead of firing blind. */
   playAt(key: string, x: number, y: number, z: number, opts?: PlayOpts): boolean {
     const ctx = this.ctx,
       master = this.master;

--- a/src/game/sfx.ts
+++ b/src/game/sfx.ts
@@ -393,11 +393,17 @@ class Sfx {
   }
 
   /** Positional one-shot at world (x,y,z). */
-  playAt(key: string, x: number, y: number, z: number, opts?: PlayOpts): void {
+  /** Returns whether this call actually scheduled a sound (false for out of
+   *  range, an unbuffered clip still loading, the voice cap, or a per-key
+   *  cooldown block). A caller that only wants to know "did MY attempt make
+   *  a sound, not some other source that beat me to this key's cooldown"
+   *  (e.g. the mob idle-bark sweep's per-entity cooldown stamping, see
+   *  src/ui/mob_idle_sfx.ts) needs this instead of firing blind. */
+  playAt(key: string, x: number, y: number, z: number, opts?: PlayOpts): boolean {
     const ctx = this.ctx,
       master = this.master;
-    if (!ctx || !master) return;
-    if (this.tooFar(x, z)) return;
+    if (!ctx || !master) return false;
+    if (this.tooFar(x, z)) return false;
     const variantIndex = this.nextVariantIndex(key);
     const cacheKey = assetCacheKey(key, variantIndex);
     const buf = this.buffers.get(cacheKey);
@@ -412,12 +418,12 @@ class Sfx {
           }
         });
       }
-      return;
+      return false;
     }
-    if (this.active >= MAX_VOICES) return;
+    if (this.active >= MAX_VOICES) return false;
     const now = ctx.currentTime;
     const cd = opts?.cooldown ?? 0.03;
-    if (now - (this.lastPlay.get(key) ?? -1) < cd) return;
+    if (now - (this.lastPlay.get(key) ?? -1) < cd) return false;
     this.lastPlay.set(key, now);
     this.commitVariant(key, variantIndex);
 
@@ -443,6 +449,7 @@ class Sfx {
       panner.disconnect();
     };
     this.applyEnvelope(src, g, peak, now, opts);
+    return true;
   }
 
   /** Set the gain envelope on a one-shot source and start it. With no

--- a/src/ui/combat_sfx.ts
+++ b/src/ui/combat_sfx.ts
@@ -7,7 +7,7 @@ type DamageEvent = Extract<SimEvent, { type: 'damage' }>;
 type SpellFxEvent = Extract<SimEvent, { type: 'spellfx' }>;
 type AuraEvent = Extract<SimEvent, { type: 'aura' }>;
 type MagicSchool = 'fire' | 'frost' | 'arcane' | 'shadow' | 'holy' | 'nature';
-export type MobVoiceAction = 'aggro' | 'attack' | 'death' | 'hurt';
+export type MobVoiceAction = 'aggro' | 'attack' | 'death' | 'hurt' | 'idle';
 
 const SCHOOL_CUES = {
   fire: { cast: 'cast_fire', projectile: 'proj_fire', impact: 'impact_fire' },
@@ -39,72 +39,84 @@ export const MOB_VOICE_CUES = {
     attack: 'mob_beast_attack',
     death: 'mob_beast_death',
     hurt: 'mob_beast_hurt',
+    idle: 'mob_beast_idle',
   },
   boar: {
     aggro: 'mob_boar_aggro',
     attack: 'mob_boar_attack',
     death: 'mob_boar_death',
     hurt: 'mob_boar_hurt',
+    idle: 'mob_boar_idle',
   },
   spider: {
     aggro: 'mob_spider_aggro',
     attack: 'mob_spider_attack',
     death: 'mob_spider_death',
     hurt: 'mob_spider_hurt',
+    idle: 'mob_spider_idle',
   },
   mudfin: {
     aggro: 'mob_mudfin_aggro',
     attack: 'mob_mudfin_attack',
     death: 'mob_mudfin_death',
     hurt: 'mob_mudfin_hurt',
+    idle: 'mob_mudfin_idle',
   },
   burrower: {
     aggro: 'mob_burrower_aggro',
     attack: 'mob_burrower_attack',
     death: 'mob_burrower_death',
     hurt: 'mob_burrower_hurt',
+    idle: 'mob_burrower_idle',
   },
   humanoid: {
     aggro: 'mob_humanoid_aggro',
     attack: 'mob_humanoid_attack',
     death: 'mob_humanoid_death',
     hurt: 'mob_humanoid_hurt',
+    idle: 'mob_humanoid_idle',
   },
   undead: {
     aggro: 'mob_undead_aggro',
     attack: 'mob_undead_attack',
     death: 'mob_undead_death',
     hurt: 'mob_undead_hurt',
+    idle: 'mob_undead_idle',
   },
   troll: {
     aggro: 'mob_troll_aggro',
     attack: 'mob_troll_attack',
     death: 'mob_troll_death',
     hurt: 'mob_troll_hurt',
+    idle: 'mob_troll_idle',
   },
   ogre: {
     aggro: 'mob_ogre_aggro',
     attack: 'mob_ogre_attack',
     death: 'mob_ogre_death',
     hurt: 'mob_ogre_hurt',
+    idle: 'mob_ogre_idle',
   },
   elemental: {
     aggro: 'mob_elemental_aggro',
     attack: 'mob_elemental_attack',
     death: 'mob_elemental_death',
     hurt: 'mob_elemental_hurt',
+    idle: 'mob_elemental_idle',
   },
   dragonkin: {
     aggro: 'mob_dragonkin_aggro',
     attack: 'mob_dragonkin_attack',
     death: 'mob_dragonkin_death',
     hurt: 'mob_dragonkin_hurt',
+    idle: 'mob_dragonkin_idle',
   },
   demon: {
     aggro: 'mob_demon_aggro',
     attack: 'mob_demon_attack',
     death: 'mob_demon_death',
     hurt: 'mob_demon_hurt',
+    idle: 'mob_demon_idle',
   },
   // deepfen_spearjaw (The Drowned Litany delve) is the family's first mob:
   // a velociraptor model, retagged from its former 'beast' mistag.
@@ -113,6 +125,7 @@ export const MOB_VOICE_CUES = {
     attack: 'mob_reptile_attack',
     death: 'mob_reptile_death',
     hurt: 'mob_reptile_hurt',
+    idle: 'mob_reptile_idle',
   },
 } as const satisfies Record<string, Record<MobVoiceAction, SfxId>>;
 

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -337,10 +337,10 @@ import {
 } from './minimap_zoom';
 import {
   type IdleBarkCandidate,
+  isIdleBarkCandidate,
   MOB_IDLE_CHECK_INTERVAL_MS,
   MOB_IDLE_GAIN,
   MOB_IDLE_KEY_COOLDOWN_S,
-  MOB_IDLE_SCAN_RADIUS,
   pickIdleBarkCandidates,
 } from './mob_idle_sfx';
 import { type MobTooltipI18n, type MobTooltipModel, mobTooltipHtml } from './mob_tooltip_view';
@@ -7675,13 +7675,7 @@ export class Hud {
     const p = sim.player;
     const candidates: IdleBarkCandidate[] = [];
     for (const e of sim.entities.values()) {
-      if (
-        e.kind === 'mob' &&
-        !e.dead &&
-        !this.mobAggroed.has(e.id) &&
-        shouldPlayMobVoiceSfxForEntity(e) &&
-        dist2d(p.pos, e.pos) <= MOB_IDLE_SCAN_RADIUS
-      ) {
+      if (isIdleBarkCandidate(e, p.pos, this.mobAggroed)) {
         candidates.push({ id: e.id, templateId: e.templateId, x: e.pos.x, y: e.pos.y, z: e.pos.z });
       }
     }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -7675,13 +7675,13 @@ export class Hud {
     const p = sim.player;
     const candidates: IdleBarkCandidate[] = [];
     for (const e of sim.entities.values()) {
-      if (isIdleBarkCandidate(e, p.pos, this.mobAggroed)) {
+      if (isIdleBarkCandidate(e, p.pos)) {
         candidates.push({ id: e.id, templateId: e.templateId, x: e.pos.x, y: e.pos.y, z: e.pos.z });
       }
     }
     if (!candidates.length) return;
     const now = performance.now();
-    const picked = pickIdleBarkCandidates(candidates, now, this.mobLastIdleBarkAt);
+    const picked = pickIdleBarkCandidates(candidates, now, this.mobLastIdleBarkAt, Math.random);
     for (const c of picked) {
       const voice = availableMobVoiceCue(c.templateId, 'idle');
       if (!voice) continue;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -335,6 +335,14 @@ import {
   minimapZoomValue,
   nextMinimapZoom,
 } from './minimap_zoom';
+import {
+  type IdleBarkCandidate,
+  MOB_IDLE_CHECK_INTERVAL_MS,
+  MOB_IDLE_GAIN,
+  MOB_IDLE_KEY_COOLDOWN_S,
+  MOB_IDLE_SCAN_RADIUS,
+  pickIdleBarkCandidates,
+} from './mob_idle_sfx';
 import { type MobTooltipI18n, type MobTooltipModel, mobTooltipHtml } from './mob_tooltip_view';
 import { MovableFrame } from './movable_frame';
 import { OptionsWindow } from './options_window';
@@ -1206,6 +1214,12 @@ export class Hud {
   // roars and subsequent strikes use the attack vocalization). Cleared on death
   // or when the entity leaves interest (reconcileSfx).
   private mobAggroed = new Set<number>();
+  // entity id -> performance.now() of its last successful idle bark (see
+  // sweepMobIdleBarks). Only stamped when sfx.playAt reports the sound
+  // actually played, not merely attempted (see pickIdleBarkCandidates' doc
+  // comment for why). Pruned in reconcileSfx, same pattern as mobAggroed.
+  private mobLastIdleBarkAt = new Map<number, number>();
+  private lastIdleSweepAt = 0;
   // entity ids with a sustained cast-loop SFX playing, so reconcileSfx can stop
   // loops for casters that left interest mid-channel (no castStop/death arrives).
   private castLoopIds = new Set<number>();
@@ -6363,6 +6377,10 @@ export class Hud {
       this.lastHudFastAt = now;
       this.reconcileSfx();
     }
+    if (now - this.lastIdleSweepAt >= MOB_IDLE_CHECK_INTERVAL_MS) {
+      this.lastIdleSweepAt = now;
+      this.sweepMobIdleBarks();
+    }
     const mediumHud = now - this.lastHudMediumAt >= 250;
     if (mediumHud) this.lastHudMediumAt = now;
     const slowHud = now - this.lastHudSlowAt >= 500;
@@ -7629,6 +7647,11 @@ export class Hud {
     if (this.mobAggroed.size) {
       for (const id of this.mobAggroed) if (!sim.entities.has(id)) this.mobAggroed.delete(id);
     }
+    if (this.mobLastIdleBarkAt.size) {
+      for (const id of this.mobLastIdleBarkAt.keys()) {
+        if (!sim.entities.has(id)) this.mobLastIdleBarkAt.delete(id);
+      }
+    }
     if (this.castLoopIds.size) {
       for (const id of this.castLoopIds) {
         const ent = sim.entities.get(id);
@@ -7637,6 +7660,42 @@ export class Hud {
           this.castLoopIds.delete(id);
         }
       }
+    }
+  }
+
+  // Ambient "the world is alive" bark pass: a shared periodic sweep (throttled
+  // in update(), not per-mob-per-frame) rather than each mob rolling its own
+  // dice, so this stays O(n) over nearby mobs instead of O(mobs * frames). Only
+  // considers mobs the player can currently hear (MOB_IDLE_SCAN_RADIUS) that
+  // are not already mid-combat (aggroed) or muted (Nythraxis); the actual
+  // density damping and per-entity cooldown check live in the pure
+  // pickIdleBarkCandidates so they are independently testable.
+  private sweepMobIdleBarks(): void {
+    const sim = this.sim;
+    const p = sim.player;
+    const candidates: IdleBarkCandidate[] = [];
+    for (const e of sim.entities.values()) {
+      if (
+        e.kind === 'mob' &&
+        !e.dead &&
+        !this.mobAggroed.has(e.id) &&
+        shouldPlayMobVoiceSfxForEntity(e) &&
+        dist2d(p.pos, e.pos) <= MOB_IDLE_SCAN_RADIUS
+      ) {
+        candidates.push({ id: e.id, templateId: e.templateId, x: e.pos.x, y: e.pos.y, z: e.pos.z });
+      }
+    }
+    if (!candidates.length) return;
+    const now = performance.now();
+    const picked = pickIdleBarkCandidates(candidates, now, this.mobLastIdleBarkAt);
+    for (const c of picked) {
+      const voice = availableMobVoiceCue(c.templateId, 'idle');
+      if (!voice) continue;
+      const played = sfx.playAt(voice, c.x, c.y, c.z, {
+        gain: MOB_IDLE_GAIN,
+        cooldown: MOB_IDLE_KEY_COOLDOWN_S,
+      });
+      if (played) this.mobLastIdleBarkAt.set(c.id, now);
     }
   }
 

--- a/src/ui/mob_idle_sfx.ts
+++ b/src/ui/mob_idle_sfx.ts
@@ -1,3 +1,4 @@
+import { MOBS } from '../sim/data';
 import type { Entity, Vec3 } from '../sim/types';
 import { dist2d } from '../sim/types';
 import { mobVoiceFamily, shouldPlayMobVoiceSfxForEntity } from './combat_sfx';
@@ -27,21 +28,25 @@ export function idleDensityFactor(sameFamilyCount: number): number {
 }
 
 /** Whether `e` is even eligible to be considered for an idle bark this
- *  sweep: a living mob, not already mid-combat (aggroed, tracked by the
- *  caller's own id set since idle barks defer to the reactive
- *  aggro/attack/hurt/death vocalizations, see hud.ts's mobAggroed), not
- *  muted (the Nythraxis mute list, shouldPlayMobVoiceSfxForEntity), and
- *  within earshot of the player. Pulled out of hud.ts's sweep so the
- *  exclusion logic is testable without a running Hud/DOM. */
-export function isIdleBarkCandidate(
-  e: Entity,
-  playerPos: Vec3,
-  aggroedIds: ReadonlySet<number>,
-): boolean {
+ *  sweep: a living, unowned, non-dummy mob, not currently chasing/being
+ *  chased (`aggroTargetId`, mirrored on both hosts and correctly cleared on
+ *  leash/evade, unlike the aggro-voice-dedupe `mobAggroed` set in hud.ts,
+ *  which is a different concern: idle barks defer to the reactive
+ *  aggro/attack/hurt/death vocalizations, but only while combat is actually
+ *  live), not muted (the Nythraxis mute list, shouldPlayMobVoiceSfxForEntity),
+ *  and within earshot of the player. `ownerId === null` excludes tamed/
+ *  summoned pets and delve companions (owned mob entities that stand next to
+ *  you all session and would otherwise bark at point-blank range); the dummy
+ *  check excludes the Training Dummy (a stationary practice target, not a
+ *  living creature). Pulled out of hud.ts's sweep so the exclusion logic is
+ *  testable without a running Hud/DOM. */
+export function isIdleBarkCandidate(e: Entity, playerPos: Vec3): boolean {
   return (
     e.kind === 'mob' &&
     !e.dead &&
-    !aggroedIds.has(e.id) &&
+    e.ownerId === null &&
+    !MOBS[e.templateId]?.dummy &&
+    e.aggroTargetId === null &&
     shouldPlayMobVoiceSfxForEntity(e) &&
     dist2d(playerPos, e.pos) <= MOB_IDLE_SCAN_RADIUS
   );
@@ -69,7 +74,7 @@ export function pickIdleBarkCandidates(
   candidates: readonly IdleBarkCandidate[],
   now: number,
   lastBarkAt: ReadonlyMap<number, number>,
-  rng: () => number = Math.random,
+  rng: () => number,
 ): IdleBarkCandidate[] {
   const familyCounts = new Map<string, number>();
   for (const c of candidates) {

--- a/src/ui/mob_idle_sfx.ts
+++ b/src/ui/mob_idle_sfx.ts
@@ -1,0 +1,66 @@
+import { mobVoiceFamily } from './combat_sfx';
+
+// Idle mob-voice bark trigger tuning. See docs/design/sound_effects.md for
+// the design writeup; the short version: a shared periodic sweep (not
+// per-mob-per-frame) picks which nearby mobs attempt an idle bark, damped by
+// how many same-family mobs are clustered together so a pack does not all
+// bark in the same sweep. The mastered idle takes are quiet even boosted, so
+// these constants start on the generous side; tune by ear in-game.
+export const MOB_IDLE_CHECK_INTERVAL_MS = 2500;
+export const MOB_IDLE_SCAN_RADIUS = 40;
+export const MOB_IDLE_BASE_CHANCE = 0.35;
+export const MOB_IDLE_PER_ENTITY_COOLDOWN_MS = 12_000;
+export const MOB_IDLE_KEY_COOLDOWN_S = 3;
+export const MOB_IDLE_GAIN = 0.55;
+
+/** Same-family cluster damping: a lone mob barks at the full base chance, a
+ *  cluster of N mobs of the same family each roll at roughly 1/sqrt(N) of
+ *  it, so a dense pack does not all bark in the same sweep while still
+ *  sounding "populated" rather than silent. */
+export function idleDensityFactor(sameFamilyCount: number): number {
+  if (sameFamilyCount <= 1) return 1;
+  return 1 / Math.sqrt(sameFamilyCount);
+}
+
+export interface IdleBarkCandidate {
+  id: number;
+  templateId: string;
+  x: number;
+  y: number;
+  z: number;
+}
+
+/** Pure selection: which of `candidates` (already filtered by the caller to
+ *  non-combat, in-range, non-muted, alive mobs) should attempt an idle bark
+ *  this sweep. Deliberately does NOT stamp `lastBarkAt`: a mob that rolls a
+ *  bark but loses the shared per-key playback cooldown to another mob of the
+ *  same cue (see sfx.playAt's own `cooldown` option, the backstop against
+ *  two mobs barking the identical clip in the same instant) must get another
+ *  chance next sweep rather than being silently benched for
+ *  MOB_IDLE_PER_ENTITY_COOLDOWN_MS for a bark that never actually played.
+ *  The caller stamps `lastBarkAt` itself, only when `sfx.playAt` returns
+ *  true. */
+export function pickIdleBarkCandidates(
+  candidates: readonly IdleBarkCandidate[],
+  now: number,
+  lastBarkAt: ReadonlyMap<number, number>,
+  rng: () => number = Math.random,
+): IdleBarkCandidate[] {
+  const familyCounts = new Map<string, number>();
+  for (const c of candidates) {
+    const family = mobVoiceFamily(c.templateId);
+    if (!family) continue;
+    familyCounts.set(family, (familyCounts.get(family) ?? 0) + 1);
+  }
+
+  const picked: IdleBarkCandidate[] = [];
+  for (const c of candidates) {
+    const family = mobVoiceFamily(c.templateId);
+    if (!family) continue;
+    const last = lastBarkAt.get(c.id);
+    if (last !== undefined && now - last < MOB_IDLE_PER_ENTITY_COOLDOWN_MS) continue;
+    const chance = MOB_IDLE_BASE_CHANCE * idleDensityFactor(familyCounts.get(family) ?? 1);
+    if (rng() < chance) picked.push(c);
+  }
+  return picked;
+}

--- a/src/ui/mob_idle_sfx.ts
+++ b/src/ui/mob_idle_sfx.ts
@@ -1,4 +1,6 @@
-import { mobVoiceFamily } from './combat_sfx';
+import type { Entity, Vec3 } from '../sim/types';
+import { dist2d } from '../sim/types';
+import { mobVoiceFamily, shouldPlayMobVoiceSfxForEntity } from './combat_sfx';
 
 // Idle mob-voice bark trigger tuning. See docs/design/sound_effects.md for
 // the design writeup; the short version: a shared periodic sweep (not
@@ -20,6 +22,27 @@ export const MOB_IDLE_GAIN = 0.55;
 export function idleDensityFactor(sameFamilyCount: number): number {
   if (sameFamilyCount <= 1) return 1;
   return 1 / Math.sqrt(sameFamilyCount);
+}
+
+/** Whether `e` is even eligible to be considered for an idle bark this
+ *  sweep: a living mob, not already mid-combat (aggroed, tracked by the
+ *  caller's own id set since idle barks defer to the reactive
+ *  aggro/attack/hurt/death vocalizations, see hud.ts's mobAggroed), not
+ *  muted (the Nythraxis mute list, shouldPlayMobVoiceSfxForEntity), and
+ *  within earshot of the player. Pulled out of hud.ts's sweep so the
+ *  exclusion logic is testable without a running Hud/DOM. */
+export function isIdleBarkCandidate(
+  e: Entity,
+  playerPos: Vec3,
+  aggroedIds: ReadonlySet<number>,
+): boolean {
+  return (
+    e.kind === 'mob' &&
+    !e.dead &&
+    !aggroedIds.has(e.id) &&
+    shouldPlayMobVoiceSfxForEntity(e) &&
+    dist2d(playerPos, e.pos) <= MOB_IDLE_SCAN_RADIUS
+  );
 }
 
 export interface IdleBarkCandidate {

--- a/src/ui/mob_idle_sfx.ts
+++ b/src/ui/mob_idle_sfx.ts
@@ -6,11 +6,13 @@ import { mobVoiceFamily, shouldPlayMobVoiceSfxForEntity } from './combat_sfx';
 // the design writeup; the short version: a shared periodic sweep (not
 // per-mob-per-frame) picks which nearby mobs attempt an idle bark, damped by
 // how many same-family mobs are clustered together so a pack does not all
-// bark in the same sweep. The mastered idle takes are quiet even boosted, so
-// these constants start on the generous side; tune by ear in-game.
+// bark in the same sweep. MOB_IDLE_BASE_CHANCE started at 0.35 (generous, on
+// the theory that the mastered idle takes are quiet even boosted) and was
+// tuned down by ear in-game to 0.17, which felt right around both the wolf
+// camps and the ogre war-camp.
 export const MOB_IDLE_CHECK_INTERVAL_MS = 2500;
 export const MOB_IDLE_SCAN_RADIUS = 40;
-export const MOB_IDLE_BASE_CHANCE = 0.35;
+export const MOB_IDLE_BASE_CHANCE = 0.17;
 export const MOB_IDLE_PER_ENTITY_COOLDOWN_MS = 12_000;
 export const MOB_IDLE_KEY_COOLDOWN_S = 3;
 export const MOB_IDLE_GAIN = 0.55;

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -123,6 +123,7 @@ const UI_PURE_CORES = [
   'src/ui/char_bags_pairing_core.ts',
   'src/ui/equip_drop_core.ts',
   'src/ui/log_event_route.ts',
+  'src/ui/mob_idle_sfx.ts',
   'src/ui/unit_portrait.ts',
   'src/ui/xp_bar.ts',
   'src/ui/absorb_bar.ts',
@@ -238,6 +239,7 @@ const RENDER_PURE_CORES = [
 // updating this list) fails the cross-check instead of silently escaping the
 // reverse-completeness guard.
 const BARE_NAMED = [
+  'src/ui/mob_idle_sfx.ts',
   'src/ui/unit_portrait.ts',
   'src/ui/xp_bar.ts',
   'src/ui/absorb_bar.ts',

--- a/tests/combat_sfx.test.ts
+++ b/tests/combat_sfx.test.ts
@@ -311,6 +311,29 @@ describe('combat SFX policy', () => {
     }
   });
 
+  it('resolves a real idle cue for every mob family, same table as hurt', () => {
+    const familyByTemplateId: Record<string, string> = {
+      forest_wolf: 'beast',
+      wild_boar: 'boar',
+      mire_widow: 'spider',
+      mudfin_murloc: 'mudfin',
+      tunnel_rat: 'burrower',
+      mogger: 'humanoid',
+      crypt_shambler: 'undead',
+      fen_troll: 'troll',
+      korgath_the_bound: 'ogre',
+      stormcrag_elemental: 'elemental',
+      sanctum_drakonid: 'dragonkin',
+      emberkin: 'demon',
+      deepfen_spearjaw: 'reptile',
+    };
+    for (const [templateId, family] of Object.entries(familyByTemplateId)) {
+      const expected = `mob_${family}_idle`;
+      expect(mobVoiceCue(templateId, 'idle'), templateId).toBe(expected);
+      expect(expected in SFX_CLIPS, expected).toBe(true);
+    }
+  });
+
   it('keeps MOB_VOICE_CUES in lockstep with the real family list', () => {
     // A family added to one and forgotten in the other resolves at runtime
     // to a key with no clip: no error, it just plays nothing.

--- a/tests/combat_sfx.test.ts
+++ b/tests/combat_sfx.test.ts
@@ -311,26 +311,16 @@ describe('combat SFX policy', () => {
     }
   });
 
-  it('resolves a real idle cue for every mob family, same table as hurt', () => {
-    const familyByTemplateId: Record<string, string> = {
-      forest_wolf: 'beast',
-      wild_boar: 'boar',
-      mire_widow: 'spider',
-      mudfin_murloc: 'mudfin',
-      tunnel_rat: 'burrower',
-      mogger: 'humanoid',
-      crypt_shambler: 'undead',
-      fen_troll: 'troll',
-      korgath_the_bound: 'ogre',
-      stormcrag_elemental: 'elemental',
-      sanctum_drakonid: 'dragonkin',
-      emberkin: 'demon',
-      deepfen_spearjaw: 'reptile',
-    };
-    for (const [templateId, family] of Object.entries(familyByTemplateId)) {
-      const expected = `mob_${family}_idle`;
-      expect(mobVoiceCue(templateId, 'idle'), templateId).toBe(expected);
-      expect(expected in SFX_CLIPS, expected).toBe(true);
+  it('stages a real, buffered idle clip for every family in MOB_VOICE_CUES', () => {
+    // Iterates the live catalog (not a hardcoded template-id table) so a
+    // future 14th family is automatically covered; the `satisfies` clause on
+    // MOB_VOICE_CUES only forces a cue STRING at compile time, not that a
+    // clip is actually staged, which is what this asserts at runtime.
+    const families = Object.entries(MOB_VOICE_CUES);
+    expect(families).toHaveLength(13);
+    for (const [family, cues] of families) {
+      expect(cues.idle, family).toBe(`mob_${family}_idle`);
+      expect(cues.idle in SFX_CLIPS, cues.idle).toBe(true);
     }
   });
 

--- a/tests/mob_idle_sfx.test.ts
+++ b/tests/mob_idle_sfx.test.ts
@@ -24,6 +24,8 @@ function mob(overrides: Partial<Entity> = {}): Entity {
     templateId: 'forest_wolf',
     pos: { x: 0, y: 0, z: 0 },
     dead: false,
+    ownerId: null,
+    aggroTargetId: null,
     ...overrides,
   } as unknown as Entity;
 }
@@ -40,43 +42,51 @@ describe('idleDensityFactor', () => {
 describe('isIdleBarkCandidate', () => {
   const playerPos = { x: 0, y: 0, z: 0 };
 
-  it('accepts a living, non-aggroed, unmuted, in-range mob', () => {
-    expect(isIdleBarkCandidate(mob(), playerPos, new Set())).toBe(true);
+  it('accepts a living, unowned, non-dummy, non-aggroed, unmuted, in-range mob', () => {
+    expect(isIdleBarkCandidate(mob(), playerPos)).toBe(true);
   });
 
   it('rejects a non-mob entity (player, npc)', () => {
-    expect(isIdleBarkCandidate(mob({ kind: 'player' }), playerPos, new Set())).toBe(false);
-    expect(isIdleBarkCandidate(mob({ kind: 'npc' }), playerPos, new Set())).toBe(false);
+    expect(isIdleBarkCandidate(mob({ kind: 'player' }), playerPos)).toBe(false);
+    expect(isIdleBarkCandidate(mob({ kind: 'npc' }), playerPos)).toBe(false);
   });
 
   it('rejects a dead mob', () => {
-    expect(isIdleBarkCandidate(mob({ dead: true }), playerPos, new Set())).toBe(false);
+    expect(isIdleBarkCandidate(mob({ dead: true }), playerPos)).toBe(false);
   });
 
-  it('rejects a mob already tracked as aggroed (mid-combat)', () => {
-    expect(isIdleBarkCandidate(mob({ id: 5 }), playerPos, new Set([5]))).toBe(false);
-    // A DIFFERENT mob's id in the aggroed set does not exclude this one.
-    expect(isIdleBarkCandidate(mob({ id: 5 }), playerPos, new Set([6]))).toBe(true);
+  it('rejects a mob currently chasing or being chased (aggroTargetId set)', () => {
+    expect(isIdleBarkCandidate(mob({ aggroTargetId: 42 }), playerPos)).toBe(false);
+  });
+
+  it('accepts a mob that fought and then leashed/evaded (aggroTargetId cleared)', () => {
+    // The bug this replaced: gating on a "ever fought" set never re-admits an
+    // evaded mob for the rest of the session. aggroTargetId is the live signal.
+    expect(isIdleBarkCandidate(mob({ aggroTargetId: null }), playerPos)).toBe(true);
+  });
+
+  it('rejects an owned entity (tamed/summoned pet, delve companion)', () => {
+    expect(isIdleBarkCandidate(mob({ ownerId: 7 }), playerPos)).toBe(false);
+  });
+
+  it('rejects a dummy mob (the Training Dummy)', () => {
+    expect(isIdleBarkCandidate(mob({ templateId: 'training_dummy' }), playerPos)).toBe(false);
   });
 
   it('rejects a muted mob (the Nythraxis mute list)', () => {
     expect(
-      isIdleBarkCandidate(
-        mob({ templateId: 'nythraxis_scourge_of_thornpeak' }),
-        playerPos,
-        new Set(),
-      ),
+      isIdleBarkCandidate(mob({ templateId: 'nythraxis_scourge_of_thornpeak' }), playerPos),
     ).toBe(false);
-    expect(
-      isIdleBarkCandidate(mob({ templateId: 'nythraxis_skeleton_warrior' }), playerPos, new Set()),
-    ).toBe(false);
+    expect(isIdleBarkCandidate(mob({ templateId: 'nythraxis_skeleton_warrior' }), playerPos)).toBe(
+      false,
+    );
   });
 
   it('rejects a mob outside the scan radius, accepts one just inside it', () => {
     const justOutside = mob({ pos: { x: MOB_IDLE_SCAN_RADIUS + 0.1, y: 0, z: 0 } });
     const justInside = mob({ pos: { x: MOB_IDLE_SCAN_RADIUS - 0.1, y: 0, z: 0 } });
-    expect(isIdleBarkCandidate(justOutside, playerPos, new Set())).toBe(false);
-    expect(isIdleBarkCandidate(justInside, playerPos, new Set())).toBe(true);
+    expect(isIdleBarkCandidate(justOutside, playerPos)).toBe(false);
+    expect(isIdleBarkCandidate(justInside, playerPos)).toBe(true);
   });
 });
 

--- a/tests/mob_idle_sfx.test.ts
+++ b/tests/mob_idle_sfx.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type IdleBarkCandidate,
+  idleDensityFactor,
+  MOB_IDLE_BASE_CHANCE,
+  MOB_IDLE_PER_ENTITY_COOLDOWN_MS,
+  pickIdleBarkCandidates,
+} from '../src/ui/mob_idle_sfx';
+
+const alwaysRolls = () => 0; // rng() < chance is always true
+const neverRolls = () => 1; // rng() < chance is always false
+
+function candidate(id: number, templateId: string): IdleBarkCandidate {
+  return { id, templateId, x: 0, y: 0, z: 0 };
+}
+
+describe('idleDensityFactor', () => {
+  it('is 1 for a lone mob and shrinks as the same-family cluster grows', () => {
+    expect(idleDensityFactor(0)).toBe(1);
+    expect(idleDensityFactor(1)).toBe(1);
+    expect(idleDensityFactor(4)).toBe(0.5);
+    expect(idleDensityFactor(9)).toBeCloseTo(1 / 3);
+  });
+});
+
+describe('pickIdleBarkCandidates', () => {
+  it('rolls every eligible mob independently when the rng always succeeds', () => {
+    const candidates = [candidate(1, 'forest_wolf'), candidate(2, 'wild_boar')];
+    const picked = pickIdleBarkCandidates(candidates, 1000, new Map(), alwaysRolls);
+    expect(picked.map((c) => c.id).sort()).toEqual([1, 2]);
+  });
+
+  it('picks nobody when the rng always fails', () => {
+    const candidates = [candidate(1, 'forest_wolf')];
+    const picked = pickIdleBarkCandidates(candidates, 1000, new Map(), neverRolls);
+    expect(picked).toEqual([]);
+  });
+
+  it('skips a template id with no recognized mob family', () => {
+    const candidates = [candidate(1, 'not_a_real_mob_template')];
+    const picked = pickIdleBarkCandidates(candidates, 1000, new Map(), alwaysRolls);
+    expect(picked).toEqual([]);
+  });
+
+  it('respects the per-entity cooldown, not just the base chance', () => {
+    const candidates = [candidate(1, 'forest_wolf')];
+    const lastBarkAt = new Map([[1, 1000]]);
+    const stillOnCooldown = pickIdleBarkCandidates(
+      candidates,
+      1000 + MOB_IDLE_PER_ENTITY_COOLDOWN_MS - 1,
+      lastBarkAt,
+      alwaysRolls,
+    );
+    expect(stillOnCooldown).toEqual([]);
+
+    const cooldownElapsed = pickIdleBarkCandidates(
+      candidates,
+      1000 + MOB_IDLE_PER_ENTITY_COOLDOWN_MS,
+      lastBarkAt,
+      alwaysRolls,
+    );
+    expect(cooldownElapsed.map((c) => c.id)).toEqual([1]);
+  });
+
+  it('damps the per-mob chance by same-family cluster size, not global count', () => {
+    // Three wolves and one boar clustered together: each wolf's chance is
+    // damped by the wolf count (3), the boar's chance is undamped (count 1),
+    // since density is measured per family, not the whole candidate set.
+    const candidates = [
+      candidate(1, 'forest_wolf'),
+      candidate(2, 'forest_wolf'),
+      candidate(3, 'forest_wolf'),
+      candidate(4, 'wild_boar'),
+    ];
+    const rolls: number[] = [];
+    const recordingRng = () => {
+      // Roll just under the boar's undamped chance but at/above the wolves'
+      // damped chance, so only the boar (and no wolf) should be picked.
+      const roll = MOB_IDLE_BASE_CHANCE * idleDensityFactor(3) + 0.001;
+      rolls.push(roll);
+      return roll;
+    };
+    const picked = pickIdleBarkCandidates(candidates, 1000, new Map(), recordingRng);
+    expect(picked.map((c) => c.id)).toEqual([4]);
+    expect(rolls.length).toBe(4);
+  });
+});

--- a/tests/mob_idle_sfx.test.ts
+++ b/tests/mob_idle_sfx.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
+import type { Entity } from '../src/sim/types';
 import {
   type IdleBarkCandidate,
   idleDensityFactor,
+  isIdleBarkCandidate,
   MOB_IDLE_BASE_CHANCE,
   MOB_IDLE_PER_ENTITY_COOLDOWN_MS,
+  MOB_IDLE_SCAN_RADIUS,
   pickIdleBarkCandidates,
 } from '../src/ui/mob_idle_sfx';
 
@@ -14,12 +17,66 @@ function candidate(id: number, templateId: string): IdleBarkCandidate {
   return { id, templateId, x: 0, y: 0, z: 0 };
 }
 
+function mob(overrides: Partial<Entity> = {}): Entity {
+  return {
+    id: 1,
+    kind: 'mob',
+    templateId: 'forest_wolf',
+    pos: { x: 0, y: 0, z: 0 },
+    dead: false,
+    ...overrides,
+  } as unknown as Entity;
+}
+
 describe('idleDensityFactor', () => {
   it('is 1 for a lone mob and shrinks as the same-family cluster grows', () => {
     expect(idleDensityFactor(0)).toBe(1);
     expect(idleDensityFactor(1)).toBe(1);
     expect(idleDensityFactor(4)).toBe(0.5);
     expect(idleDensityFactor(9)).toBeCloseTo(1 / 3);
+  });
+});
+
+describe('isIdleBarkCandidate', () => {
+  const playerPos = { x: 0, y: 0, z: 0 };
+
+  it('accepts a living, non-aggroed, unmuted, in-range mob', () => {
+    expect(isIdleBarkCandidate(mob(), playerPos, new Set())).toBe(true);
+  });
+
+  it('rejects a non-mob entity (player, npc)', () => {
+    expect(isIdleBarkCandidate(mob({ kind: 'player' }), playerPos, new Set())).toBe(false);
+    expect(isIdleBarkCandidate(mob({ kind: 'npc' }), playerPos, new Set())).toBe(false);
+  });
+
+  it('rejects a dead mob', () => {
+    expect(isIdleBarkCandidate(mob({ dead: true }), playerPos, new Set())).toBe(false);
+  });
+
+  it('rejects a mob already tracked as aggroed (mid-combat)', () => {
+    expect(isIdleBarkCandidate(mob({ id: 5 }), playerPos, new Set([5]))).toBe(false);
+    // A DIFFERENT mob's id in the aggroed set does not exclude this one.
+    expect(isIdleBarkCandidate(mob({ id: 5 }), playerPos, new Set([6]))).toBe(true);
+  });
+
+  it('rejects a muted mob (the Nythraxis mute list)', () => {
+    expect(
+      isIdleBarkCandidate(
+        mob({ templateId: 'nythraxis_scourge_of_thornpeak' }),
+        playerPos,
+        new Set(),
+      ),
+    ).toBe(false);
+    expect(
+      isIdleBarkCandidate(mob({ templateId: 'nythraxis_skeleton_warrior' }), playerPos, new Set()),
+    ).toBe(false);
+  });
+
+  it('rejects a mob outside the scan radius, accepts one just inside it', () => {
+    const justOutside = mob({ pos: { x: MOB_IDLE_SCAN_RADIUS + 0.1, y: 0, z: 0 } });
+    const justInside = mob({ pos: { x: MOB_IDLE_SCAN_RADIUS - 0.1, y: 0, z: 0 } });
+    expect(isIdleBarkCandidate(justOutside, playerPos, new Set())).toBe(false);
+    expect(isIdleBarkCandidate(justInside, playerPos, new Set())).toBe(true);
   });
 });
 

--- a/tests/sfx.test.ts
+++ b/tests/sfx.test.ts
@@ -234,6 +234,29 @@ describe('isBuffered/preload', () => {
   });
 });
 
+// playAt's boolean return is the load-bearing contract behind the mob
+// idle-bark per-entity cooldown (src/ui/mob_idle_sfx.ts, hud.ts): a caller
+// stamps its own cooldown only when this returns true, so a false positive
+// here (returning true on a cooldown-blocked or unbuffered attempt) would
+// silently bench a mob for the full cooldown window over a bark that never
+// actually played, the exact bug the design's own doc comment warns about.
+describe('playAt return value', () => {
+  it('returns false for an unbuffered key (kicks off the async load instead)', () => {
+    expect(sfx.playAt('mob_beast_idle', 0, 0, 0)).toBe(false);
+  });
+
+  it('returns true for a scheduled play, then false for an immediate repeat blocked by the per-key cooldown', () => {
+    const buffers = (sfx as unknown as { buffers: Map<string, { duration: number }> }).buffers;
+    buffers.set('foot_stone', { duration: 0.3 });
+
+    expect(sfx.playAt('foot_stone', 0, 0, 0)).toBe(true);
+    expect(sfx.playAt('foot_stone', 0, 0, 0)).toBe(false); // same instant, default 0.03s cooldown blocks it
+
+    nowT += 1; // clear the cooldown
+    expect(sfx.playAt('foot_stone', 0, 0, 0)).toBe(true);
+  });
+});
+
 // Footstep sounds ship OFF by default and are toggleable via the footstepSfx
 // setting. While disabled, footstep() must be a no-op (no source created) for
 // self and other entities alike; re-enabling resumes playback.


### PR DESCRIPTION
## Summary

Idle mob vocalizations were fully staged, conformed, and gain-mapped for every mob family (13 base families plus the wolf and skeleton subfamily aliases, 26 audio files total), but nothing ever called them: `idle` was missing from `MobVoiceAction` entirely at the type level.

Adds `idle` to `MobVoiceAction` and to every `MOB_VOICE_CUES` family entry (`src/ui/combat_sfx.ts`; all `mob_<family>_idle` keys already existed in the manifest). New pure module `src/ui/mob_idle_sfx.ts` (`pickIdleBarkCandidates`, `idleDensityFactor`, `isIdleBarkCandidate`) picks which nearby, non-combat, unmuted mobs attempt a bark on a shared throttled sweep (`Hud.sweepMobIdleBarks`, hooked into `update()` alongside the existing `reconcileSfx` throttle) rather than each mob rolling dice per frame. Same-family cluster size damps the per-mob chance so a pack does not all bark in the same sweep, while still sounding "populated" (expected total barks scale with the square root of the crowd size, not linearly). A per-entity cooldown map (`mobLastIdleBarkAt`, pruned in `reconcileSfx` the same way as the existing `mobAggroed` set) rate-limits repeats.

`sfx.playAt` now returns whether it actually scheduled a sound (previously `void`), so the per-entity cooldown is only stamped on a real play, not a bark that lost the existing per-key playback cooldown race to another mob's identical cue in the same instant.

Tuning starts on the generous side rather than maximally conservative: the mastered idle takes measure quiet even boosted in-game, so under-triggering felt like the bigger risk than spam. All six knobs (check interval, scan radius, base chance, per-entity cooldown, per-key cooldown, gain) are plain exported constants in `src/ui/mob_idle_sfx.ts`, easy to retune by ear later.

## Related issues

N/A

## Type of change

- [x] Feature: new functionality
- [x] Tests

## How was this tested?

- Commands: `npx tsc --noEmit`, full `npm test` (1210/1210 test files), scoped `npx @biomejs/biome check` on every changed file, all three build steps (`build:env`/`build:server`/`build`)
- Manual steps: in-game listening pass around the two `forest_wolf` camps and the `old_greyjaw` rare near the starting area, and the `thornpeak_ogre`/`ogre_crusher` camps in zone3, confirming barks feel populated without being spammy, vary in volume/panning with distance, and no single mob repeats rapidly

## Screenshots / recordings

N/A (audio-only change)

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files. `src/game/sfx_manifest.generated.ts` is regenerated via `npm run sfx:manifest`.