### PR TITLE
docs(professions-2): land the 2026-07-17 design-review amendments

### DIFF
--- a/docs/professions-2/README.md
+++ b/docs/professions-2/README.md
@@ -56,6 +56,15 @@ starter prompt.
 
 Waves for orientation: phases 1 to 7 are the fun kernel (visibility, truth,
 and the first taste of identity); phases 8 to 15 are wave one (stations,
-content, quests, polish). Wave 2+ work (market instance carriage, commissions,
-Jack of All Trades, monster proficiency, salvage UI, battlefield experience)
-is tracked on epic #1866, not in this packet.
+content, quests, polish). End of Phase 7 is the vertical-slice checkpoint:
+the Phase 7 QA session plays the eight-step journey end to end (gather a
+rare event, craft, watch skill move, receive the Guild letter, visit the
+letter's named quest giver and attune via the quest flow (smith_haldren
+stands in until the Phase 8 masters land), celebrate a masterwork, trade
+it) before wave one begins. Ordering relief: Phase 6 depends on Phases 2
+and 4, NOT on Phase 5, so it may run ahead of the wheel window if the
+design-language rollout stalls Phase 5 (the state.md OPEN item).
+Wave 2+ work (market instance carriage, commissions, Jack of All Trades,
+monster proficiency, battlefield experience) is tracked on epic #1866, not
+in this packet; salvage wiring moved INTO Phase 13 by the 2026-07-17
+design-review amendments recorded in state.md.

--- a/docs/professions-2/asset-manifest.json
+++ b/docs/professions-2/asset-manifest.json
@@ -324,6 +324,18 @@
           "name": "Tier milestone set (per-craft, count lands Phase 15)",
           "deferred": true,
           "priority": 3
+        },
+        {
+          "id": "deed_prof_specialist",
+          "name": "Specialist (first 75-skill specialization, any craft)",
+          "description": "A masterfully kept tool resting on a velvet cloth",
+          "priority": 3
+        },
+        {
+          "id": "deed_prof_rare_finds",
+          "name": "Rare find set (pristine vein, ancient heartwood, moonlit bloom, perfect specimen)",
+          "deferred": true,
+          "priority": 3
         }
       ],
       "size": "512px source PNG, served 128px WebP"
@@ -341,7 +353,19 @@
         {
           "id": "marker_pristine_vein",
           "name": "Pristine vein marker",
-          "description": "The existing gather-node marker with a brief glint accent (reduced-motion aware)",
+          "description": "The existing gather-node marker with a brief glint accent (reduced-motion aware); the ore flavor of the rare-event marker family",
+          "priority": 2
+        },
+        {
+          "id": "marker_ancient_heartwood",
+          "name": "Ancient heartwood marker",
+          "description": "The wood flavor of the rare-event marker family, same glint treatment as the pristine vein",
+          "priority": 2
+        },
+        {
+          "id": "marker_moonlit_bloom",
+          "name": "Moonlit bloom marker",
+          "description": "The herb flavor of the rare-event marker family, same glint treatment as the pristine vein",
           "priority": 2
         }
       ]

--- a/docs/professions-2/brainstorm.md
+++ b/docs/professions-2/brainstorm.md
@@ -67,8 +67,10 @@ harvesting that feeds it all.
   framework, keeping its minigame), and corpse harvesting (hide, silk, meat,
   components: the adventurer's feeder).
 - **Masterwork replaces the five-way quality roll.** Every craft yields the
-  deterministic, budgeted item. A proc (scaling with skill, self-signed
-  materials, and specialization) yields a masterwork: bounded bonus stats via
+  deterministic, budgeted item. A proc (scaling with skill, signed
+  materials, and specialization; amended 2026-07-17 from self-signed-only to
+  any player's signature, see the addendum below) yields a masterwork:
+  bounded bonus stats via
   the existing item-budget machinery, maker's mark, toast plus zone-chat
   celebration. Power ladder: baseline crafted < dungeon drops; masterwork
   rivals dungeon drops and stays below the raid floor; raids keep the summit.
@@ -121,8 +123,10 @@ the load-bearing facts:
 
 - Wave 2+: market/mail carriage for instanced goods (#1146), commissions and
   boundTo semantics (#1298), Jack of All Trades (#1296), monster-harvest
-  proficiency, salvage UI, battlefield experience expansion, item biographies,
-  tool effects, jewelcrafting/inscription depth. These stay filed on the epic.
+  proficiency, battlefield experience expansion, item biographies,
+  tool effects, jewelcrafting/inscription depth. These stay filed on the
+  epic. (Salvage UI left this list on 2026-07-17: its wiring joins Phase 13
+  per the design-review amendments below.)
 - Growing or shrinking the ten-craft wheel. Growth routes through gathering
   skills and off-wheel systems per the design doc's fragility rules.
 - Any admission gate on known recipes, client-decided outcomes, or
@@ -136,3 +140,35 @@ the load-bearing facts:
   with placeholder values in `state.md`, tuned in Phase 15 against live data.
 - Cloth material sourcing: humanoid corpse components plus a plant fiber from
   herbalism (decided in brainstorm; exact item list lands in Phase 10).
+
+## 2026-07-17 design-review amendments (approved)
+
+After Phase 2 landed, the maintainer reviewed an external design review of
+the packet (the Codex review) and approved a set of amendments. state.md
+records them as binding rulings under "2026-07-17 design-review amendments";
+each owning phase file carries the updated deliverables. In one line each:
+
+- The masterwork signed-reagent proc term counts ANY player's signature
+  (rewarding trade with gatherers, not vertical self-sufficiency); the
+  self-signed reagent-quantity discount stays self-only.
+- Recipe training is skill-tier gated at the masters, with locked rows
+  always visible in the Train view: the RuneScape-style unlock ladder,
+  delivered on the LEARNING side; known recipes are never use-gated.
+- Masters spread across the three zone hubs (every archetype keeps a zone 1
+  anchor; the tannery and apothecary root in Fenbridge and Highwatch),
+  delivering the vision's far-flung-stations promise.
+- The Phase 4 rare event ships per-node-type flavors (pristine vein,
+  ancient heartwood, moonlit bloom); corpse harvesting gains the perfect
+  specimen component in Phase 10, so every gathering family has a jackpot.
+- Salvage wiring joins Phase 13, giving obsolete crafted gear a wave-one
+  destination.
+- Profession deeds carry titles and marquee-tier renown, so the deeds
+  pipeline (nameplates, marquee broadcast, Renown board) celebrates
+  professions; a Specialist deed marks the 75-skill threshold.
+- Masters gain recurring pull: cadence-capped work-order quests and
+  tier-crossing congratulation mail (Phase 14).
+- Phase 6 resolves the masterwork broadcast audience (zone-visible via the
+  Phase 4 soft-zone mechanism), extends the identity wire so masterworks
+  are inspectable online, and adds tier-up toasts.
+- End of Phase 7 is the vertical-slice checkpoint: the Phase 7 QA session
+  plays the eight-step journey end to end before wave one begins.

--- a/docs/professions-2/implementation-plan.md
+++ b/docs/professions-2/implementation-plan.md
@@ -98,7 +98,11 @@ landed. Therefore every UI phase in this packet:
 
 ## Phase summary
 
-Phases 1 to 7 are the fun kernel; 8 to 15 are wave one. PR 2039 (open at
+Phases 1 to 7 are the fun kernel; 8 to 15 are wave one. End of Phase 7 is
+the vertical-slice checkpoint (see README). Phase 6 depends on Phases 2 and
+4, not on Phase 5, and may run ahead of the wheel window if the
+design-language rollout stalls Phase 5. The 2026-07-17 design-review
+amendments in state.md bind their owning phases below. PR 2039 (open at
 packet creation; 104 files; adds `craftingIdentity`/`cprof`, the shared
 `combo_eligibility` rule with attunement-gated combos, `attunedPairs`
 pair-level history, craft/gather quest objectives, quest-driven attunement
@@ -110,20 +114,21 @@ Phase 1.
 | 1 | Ring and identity foundations | Merge-window amendments on PR 2039: adopt the blueprint ring, pair-named archetype titles, the 5 review items | sim content, i18n, tests |
 | 2 | Masterwork model | Deterministic outputs + masterwork proc with stats via `item_budget`; retire the five-way roll and `trivialAt` | sim, wire event, tests |
 | 3 | Host-parity bug fixes | Trade instance carriage; corpse claims on the wire | sim, net, server, tests |
-| 4 | Node materials and pristine veins | Real per-rarity node yields, signed rare+ yields, one rare event, gather feedback | sim content, ui, render |
+| 4 | Node materials and pristine veins | Real per-rarity node yields, signed rare+ yields, per-node-type rare events, gather feedback | sim content, ui, render |
 | 5 | The professions wheel window | The flagship window at deeds quality on the deeds recipe | ui, styles, i18n |
-| 6 | Crafting window upgrades and celebrations | Skill display, combo/station legibility, masterwork toast/broadcast, maker's mark tooltips | ui, i18n |
+| 6 | Crafting window upgrades and celebrations | Skill display, combo/station legibility, masterwork toast + zone broadcast, tier-up toasts, maker's mark tooltips, inspectable instances | ui, i18n, net, sim |
 | 7 | The Guild letter | Trend detection, the letter via mail, the first-attunement hook; S3 scanner gap closed | sim, content, tests |
-| 8 | Stations and masters (sim/server) | Typed station registry, master NPC records, placement-safety test, mobile-station perk live | sim, content, server |
-| 9 | Station presence and training | Station props + masters rendered, recipe training on `acquireRecipe`, shops, hands-vs-stations live | render, ui, content |
-| 10 | Recipe ladders and materials (ultracode) | Six deep crafts' tier ladders + material families + economy invariant tests | content, tests |
+| 8 | Stations and masters (sim/server) | Typed station registry, masters across the three zone hubs, placement-safety test, specialization-gated mobile station | sim, content, server |
+| 9 | Station presence and training | Station props + masters rendered, skill-tier-gated training with a visible locked-row ladder, shops, hands-vs-stations live | render, ui, content |
+| 10 | Recipe ladders and materials (ultracode) | Six deep crafts' tier ladders + material families + economy invariant tests + the materialTierBonus wire | content, sim, tests |
 | 11 | Fishing joins the framework | Fishing proficiency + catch rarity ladder feeding cooking | sim, content, ui |
 | 12 | Base tool tier gating | Node tiers; tool tier + skill gates; tools matter; effects stay parked | sim, content, tests |
-| 13 | Enchanting reachable | Disenchant + enchant-apply on IWorld/wire/UI in both hosts | world_api, net, server, ui |
-| 14 | Attunement quests and nudges | Lore quests at the masters for four archetypes; nudges; celebration | content, sim, ui |
+| 13 | Enchanting reachable | Disenchant, enchant-apply, and salvage on IWorld/wire/UI in both hosts | world_api, net, server, ui |
+| 14 | Attunement quests and nudges | Lore quests, work orders, and tier mail at the masters; nudges; celebration | content, sim, ui |
 | 15 | Deeds, tuning, and polish | Universal profession deeds, economy tuning, wiki rewrite, final gate | content, docs, tests |
 
 Wave 2+ (NOT this packet, tracked on epic #1866): market/mail instance
 carriage (#1146), commissions and boundTo (#1298), Jack of All Trades
-(#1296), monster-harvest proficiency, salvage UI, battlefield experience
-expansion, item biographies, tool effects, jewelcrafting/inscription depth.
+(#1296), monster-harvest proficiency, battlefield experience expansion,
+item biographies, tool effects, jewelcrafting/inscription depth. (Salvage
+wiring left this list on 2026-07-17; it joins Phase 13.)

--- a/docs/professions-2/phase-03-parity-bug-fixes.md
+++ b/docs/professions-2/phase-03-parity-bug-fixes.md
@@ -50,6 +50,11 @@ STEP 0 - PRE-FLIGHT:
   before proceeding. Never base work on main or an older release branch than the newest.
 - Verify `git status` is clean before starting. If not, ask the user (a concurrent session may
   share this checkout).
+- Verify the any-signed masterwork amendment (the 2026-07-17 design-review ruling in
+  state.md, shipped as its own pre-phase code change) has landed on the release branch:
+  grep for MASTERWORK_SIGNED_CHANCE in src/sim/professions/masterwork.ts. If it is absent,
+  the amendment PR is still open: land or merge it FIRST (never re-implement it inline),
+  then proceed.
 - Memory scan (if you use Claude Code memory): check your MEMORY.md index and any entries
   relevant to this phase's domain (suggested topics: combo-recipes-broken-online, the #2033
   ClientWorld stub trap; node25-breaks-jsdom-gate, run the gate under Node 24; PR 2039 state,

--- a/docs/professions-2/phase-04-node-materials.md
+++ b/docs/professions-2/phase-04-node-materials.md
@@ -1,8 +1,10 @@
 # Phase 04: Node materials and pristine veins
 
 This phase makes node gathering yield real materials: per-node-type tables keyed by rolled
-rarity replace the placeholder junk grants, rare+ yields are signed like corpse yields, one
-rare event (the pristine vein) lands, and the long-dormant `gatherResult` event finally gets
+rarity replace the placeholder junk grants, rare+ yields are signed like corpse yields, the
+per-node-type rare events land (pristine vein for ore, ancient heartwood for wood, moonlit
+bloom for herbs; the 2026-07-17 amendment, so every node family gets its own jackpot
+fantasy), and the long-dormant `gatherResult` event finally gets
 visible feedback (SFX cue plus a rarity-colored loot line). It is its own slice because it
 closes the gathering input loop end to end, on top of the Phase 2 signing model and ahead of
 recipe consumption (Phase 10) and tier gating (Phase 12), so materials exist and feel
@@ -11,8 +13,9 @@ rewarding before anything spends them.
 ## Context pointers
 
 - `docs/professions-2/state.md`: locked decisions (RNG in, determinism out; prime directive;
-  zone-1 stockpiling mitigation), the pristine vein tuning target (roughly 1 per zone per
-  20 minutes, 5x yield, always signed), the validation matrix, and the "Gathering" row under
+  zone-1 stockpiling mitigation; the 2026-07-17 per-node-type rare-event amendment), the
+  rare-event tuning target (roughly 1 per zone per 20 minutes, 5x yield, always signed; one
+  shared cadence knob), the validation matrix, and the "Gathering" row under
   key existing surfaces.
 - `docs/professions-2/progress.md`: status table and the Phase 4 deliverable checklist.
 - `docs/professions-2/implementation-plan.md`: team workflow, the Review Dispatch Matrix,
@@ -35,8 +38,9 @@ This is Phase 04 of the Professions 2.0 feature: Node materials and pristine vei
 
 Model: Opus 4.8, xhigh effort. Harness: Claude Code.
 
-Goal: make node gathering yield real materials with rarity, signed rare+ yields, one rare
-event (the pristine vein), and visible feedback for every harvest.
+Goal: make node gathering yield real materials with rarity, signed rare+ yields, the
+per-node-type rare events (pristine vein, ancient heartwood, moonlit bloom), and visible
+feedback for every harvest.
 
 STEP 0 - PRE-FLIGHT:
 - Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
@@ -62,7 +66,7 @@ The summary must return: the NODE_HARVEST_TABLE shape and where the placeholder 
 live; the resolveHarvest flow and its exact Rng draw order; the gatherResult event payload
 and the absence of consumers; how corpse yields get signed in interaction.ts (the precedent
 to copy); ItemDef catalog conventions (fields, English names, procedural icon fallback); the
-quality token family used for rarity colors; the pristine vein tuning target from state.md;
+quality token family used for rarity colors; the rare-event tuning target from state.md;
 the validation matrix rows for sim-only and content-only changes; and any locked decision
 that constrains this phase (zone-1 stockpiling mitigation, prime directive, RNG model).
 
@@ -86,25 +90,31 @@ Agent sim/content deliverables:
   Players hold them; only their node sources go away (prime directive).
 
 Agent event/feedback deliverables:
-- Pristine vein: a rare per-player node state rolled through Rng at the state.md tuning
-  cadence (roughly 1 per zone per 20 minutes), five-fold yield, always signed. Land it as
-  its own small module behind the SimContext seam (module-first), never a method cluster on
-  a coordinator, called from the resolveHarvest path.
-- The vein emits an id-based soft zone broadcast: sim/server stays language-agnostic (stable
-  id plus values); add the client matcher rows in the SAME change (S3 guard).
-- Leave a named deed-mark hook at the vein resolution site; deed registration is deferred to
-  Phase 15. Do not author any deed records now.
+- The rare-event module: ONE small module behind the SimContext seam (module-first, called
+  from the resolveHarvest path, never a method cluster on a coordinator) carrying a
+  per-node-type flavor: pristine vein (ore), ancient heartwood (wood), moonlit bloom (herb).
+  Each flavor is a rare per-player node state rolled through Rng at the shared state.md
+  tuning cadence (roughly 1 per zone per 20 minutes), five-fold yield, always signed. The
+  node's type decides the flavor; one shared cadence knob until Phase 15 tunes per family.
+- Each flavor emits its own id-based soft zone broadcast (three additive ids): sim/server
+  stays language-agnostic (stable id plus values); add the client matcher rows for all
+  three in the SAME change (S3 guard).
+- Leave a named per-flavor deed-mark hook at the event resolution site; deed registration is
+  deferred to Phase 15. Do not author any deed records now.
 - Consume gatherResult in the client: play the SFX cue and append a rarity-colored loot line
   to the HUD log. Colors come from the existing quality token family only; the feedback is
   identical on every graphics tier (fairness invariant). New player strings are English-only
   t() keys in the matching src/ui/i18n.catalog/ module.
 
 Agent tests deliverables:
-- Determinism pin: the Rng draw order through resolveHarvest INCLUDING the new vein roll;
-  same seed gives the same yields. If the extra roll changes existing pinned draws, re-pin
-  deliberately and say so in the commit body.
+- Determinism pin: the Rng draw order through resolveHarvest INCLUDING the new rare-event
+  roll; same seed gives the same yields. If the extra roll changes existing pinned draws,
+  re-pin deliberately and say so in the commit body.
+- Flavor mapping test: an event on an ore node is a pristine vein, on a wood node an
+  ancient heartwood, on an herb node a moonlit bloom; each emits its own broadcast id.
 - Rarity distribution test against the pinned roll (tests/professions_rarity_roll.test.ts).
-- Signing tests: rare+ yields carry a signer; pristine vein yields are always signed.
+- Signing tests: rare+ yields carry a signer; rare-event yields (all three flavors) are
+  always signed.
 - Zone-1 cap test: zone 1 node tables can only produce common/low-tier materials.
 - Acceptance test: no node grants bone_fragments, linen_scrap, or spider_leg anymore, while
   those ItemDefs remain defined in the catalog.
@@ -112,9 +122,9 @@ Agent tests deliverables:
 
 INVARIANTS THIS PHASE MUST KEEP:
 - Determinism: all randomness through Rng (never Math.random, Date.now, performance.now in
-  sim logic); the vein roll's draw order is pinned by a test.
+  sim logic); the rare-event roll's draw order is pinned by a test.
 - Sim purity: src/sim/ gains zero DOM/Three imports and never imports render/ui/game/net.
-- Server authority: yields, rarity, signing, and vein rolls resolve in the sim on the
+- Server authority: yields, rarity, signing, and rare-event rolls resolve in the sim on the
   server; the client only renders gatherResult and the broadcast.
 - IWorld both worlds: if any new read or event crosses the render/ui seam, add it to the
   matching facet file (src/world_api/<domain>.ts), implement it in BOTH Sim and ClientWorld,
@@ -131,8 +141,10 @@ INVARIANTS THIS PHASE MUST KEEP:
 Out of scope (do NOT do in this phase):
 - Node TIER gating (Phase 12).
 - Recipe consumption of these materials (Phase 10).
-- Fishing (Phase 11).
-- Pristine vein deed authoring or registration (Phase 15; leave only the named hook).
+- Fishing (Phase 11; the glimmerfin rare catch already covers its jackpot).
+- The corpse-harvest perfect specimen component (Phase 10).
+- Rare-event deed authoring or registration (Phase 15; leave only the named per-flavor
+  hooks).
 
 STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
 - Run the state.md validation matrix rows for sim-only and content-only changes:
@@ -157,8 +169,9 @@ Three commits, in this order, each staging explicit paths (never git add -A; the
 may be shared) and each carrying a body (what changed and why, 1 to 4 sentences):
 - feat(professions): real node material tables
   (gathering.ts tables, gather_nodes.ts, items.ts material defs, table tests)
-- feat(professions): pristine veins
-  (vein module, rare+ signing, broadcast id, deed hook, determinism re-pin if any)
+- feat(professions): per-node-type rare events
+  (event module with the three flavors, rare+ signing, broadcast ids, deed hooks,
+  determinism re-pin if any)
 - feat(ui): gather feedback line and cue
   (gatherResult consumers, loot line, SFX cue, matcher rows, i18n catalog keys)
 
@@ -168,9 +181,10 @@ STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
 - [ ] Rarity distribution matches the pinned roll (tests/professions_rarity_roll.test.ts
       green against the new tables).
 - [ ] Rare+ node yields are signed instances, matching the corpse signing precedent.
-- [ ] Pristine vein: rolled through Rng at the state.md cadence, five-fold yield, always
-      signed, id-based soft zone broadcast emitted and matcher-localized; named deed hook
-      left dormant.
+- [ ] The rare events: rolled through Rng at the shared state.md cadence, five-fold yield,
+      always signed, with the flavor decided by node type (pristine vein / ancient
+      heartwood / moonlit bloom), per-flavor id-based soft zone broadcasts emitted and
+      matcher-localized; named per-flavor deed hooks left dormant.
 - [ ] gatherResult consumed: SFX cue plus rarity-colored loot line in the HUD log, colors
       from the quality token family, identical on every graphics tier.
 - [ ] Loot line and broadcast fully localized (English catalog keys plus matcher rows; the
@@ -183,8 +197,8 @@ STEP 6 - DOC UPDATES + MEMORY:
   acceptance boxes, note the phase-start and phase-end commit hashes and any deferrals.
 - Update docs/professions-2/state.md: replace the planned "Phase 4" row under "New surfaces
   per phase" with what actually landed: the material table symbol names, the new material
-  ItemDef id namespace, the pristine vein module path and its SimEvent/broadcast id, the
-  deed-mark hook location, and the gather feedback i18n key namespace.
+  ItemDef id namespace, the rare-event module path and its per-flavor SimEvent/broadcast
+  ids, the deed-mark hook locations, and the gather feedback i18n key namespace.
 - Record any surprises (draw-order re-pins, matcher quirks) to Claude Code memory.
 
 STEP 7 - FINAL RESPONSE FORMAT:

--- a/docs/professions-2/phase-04-qa.md
+++ b/docs/professions-2/phase-04-qa.md
@@ -1,7 +1,8 @@
 # Phase 04 QA: Verify Node materials and pristine veins
 
 Independent audit of the Phase 04 diff: confirm node material tables, signed yields, the
-pristine vein, and the gather feedback landed correctly, completely, and cleanly.
+per-node-type rare events (pristine vein, ancient heartwood, moonlit bloom), and the gather
+feedback landed correctly, completely, and cleanly.
 
 ## QA Starter Prompt
 
@@ -40,23 +41,25 @@ do not restart completed work.
 Agent correctness:
 - Verify every deliverable and acceptance criterion against the real code, not the phase
   summary: per-node-type tables keyed by rolled rarity, zone-appropriate tiers, rare+
-  signing matching the corpse precedent, the pristine vein cadence/yield/signing, the
-  broadcast, the deed hook, the loot line and cue.
+  signing matching the corpse precedent, the rare-event cadence/yield/signing across all
+  three flavors (pristine vein, ancient heartwood, moonlit bloom), the per-flavor
+  broadcasts, the deed hooks, the loot line and cue.
 - Run the phase validation commands:
   npx tsc --noEmit
   npx vitest run tests/gather_node_harvest.test.ts tests/professions_rarity_roll.test.ts \
     tests/gathering.test.ts tests/localization_fixes.test.ts tests/architecture.test.ts
 - Exercise the real behavior: in a seeded sim run, harvest nodes across rarities and zones,
-  force a pristine vein through the pinned Rng path, and confirm the signed payloads, the
-  broadcast id and values, and that gatherResult drives the HUD log line and SFX cue.
+  force EACH rare-event flavor through the pinned Rng path (ore, wood, and herb nodes), and
+  confirm the signed payloads, the per-flavor broadcast ids and values, and that
+  gatherResult drives the HUD log line and SFX cue.
 - Probe the phase-specific QA emphasis items listed in this file.
 
 Agent test coverage:
-- Find untested paths: the vein cadence bounds, the zone-1 tier cap, signing at exactly the
-  rare boundary, the deed hook no-op, matcher rows for the broadcast, and the loot line's
-  quality-color mapping.
+- Find untested paths: the event cadence bounds, the node-type-to-flavor mapping, the
+  zone-1 tier cap, signing at exactly the rare boundary, the deed hook no-ops, matcher rows
+  for all three broadcasts, and the loot line's quality-color mapping.
 - Add missing tests, including a determinism test if sim logic changed and none pins the new
-  draw order (same seed, same yields, vein roll included).
+  draw order (same seed, same yields, rare-event roll included).
 - Remove orphaned tests, especially any that still pin the old placeholder junk grants.
 
 Agent dead code and cleanup:
@@ -64,9 +67,9 @@ Agent dead code and cleanup:
   the junk-grant removal.
 - Sim purity: no DOM/Three/render/ui/game/net imports in src/sim/; no Math.random,
   Date.now, or performance.now in sim logic.
-- Leftover TODOs. The pristine vein deed-mark hook is the one sanctioned deferral: verify it
-  is a named, dormant hook (not a stray TODO comment) and that nothing else was left half
-  wired.
+- Leftover TODOs. The per-flavor deed-mark hooks are the one sanctioned deferral: verify
+  they are named, dormant hooks (not stray TODO comments) and that nothing else was left
+  half wired.
 
 Also spawn review agents per the Review Dispatch Matrix in
 docs/professions-2/implementation-plan.md: check git diff --name-only and spawn ONLY
@@ -103,8 +106,8 @@ STOPPING RULES:
 
 ## Phase-specific QA emphasis
 
-- Draw-order stability with the extra vein roll: confirm the determinism pin covers the
-  pristine vein draw, that pre-existing seeded runs still reproduce, and that any re-pin of
+- Draw-order stability with the extra event roll: confirm the determinism pin covers the
+  rare-event draw, that pre-existing seeded runs still reproduce, and that any re-pin of
   prior draws was deliberate and explained in a commit body, never silent.
 - Junk items still exist as defs: `bone_fragments`, `linen_scrap`, and `spider_leg` remain
   valid ItemDefs (players hold them); only their node sources were removed. Verify catalog

--- a/docs/professions-2/phase-05-qa.md
+++ b/docs/professions-2/phase-05-qa.md
@@ -12,7 +12,15 @@ parity, and i18n completeness, then fix what the audit finds.
   rationale for the choice exists in the phase notes.
 - The ClientWorld pre-cprof (synced false) empty state: the window must render a sane empty
   state online before the first cprof delta arrives, with no crash, no NaN bars, and no
-  misleading identity claim.
+  misleading identity claim. Distinguish it from the SIMPLIFIED unattuned/pre-first-tier
+  state below: syncing is a wire condition, simplified is a design state; they must not be
+  conflated.
+- The 2026-07-17 amendment deliverables: the absorbed model preserves per-craft role
+  (major/hobby/dormant/unattuned), ceiling, nudges, and tutorial state; the next-unlock
+  and switch-cost lines render from existing reads (switchCount on CraftingIdentityView;
+  no new wire data); the simplified unattuned/pre-first-tier state shows one clear next
+  step and the full ring takes over at first tier or attunement. Probe each with a real
+  render, not a grep.
 
 ## QA Starter Prompt
 

--- a/docs/professions-2/phase-05-wheel-window.md
+++ b/docs/professions-2/phase-05-wheel-window.md
@@ -89,7 +89,25 @@ Agent view-core deliverables:
 - A refresh signature for slow-band diffing (cheap to compute, changes only when the model
   changes).
 - Absorb or compose the PR 2039 identity card view (profession_identity_view): pick one and
-  record why in the phase notes.
+  record why in the phase notes. Either way, the resulting model PRESERVES the
+  identity-view semantics (2026-07-17 amendment): per-craft role (major / hobby / dormant /
+  unattuned), ceiling (unlimited / rare / common), the nearTier and dormantKnowledge
+  nudges, and the pre-first-tier tutorial state. Dropping any of these is a spec violation,
+  not an implementer choice.
+- A per-craft next-unlock line (2026-07-17 amendment): points to the next tier pip and what
+  crossing it changes (the masterwork-odds step; the 75-skill specialization perks). Phase
+  9's teach tiers and Phase 10's ladders enrich the same line later without a model change;
+  render only from reads that exist today.
+- A switch-cost-at-rest line (2026-07-17 amendment): "next switch costs N" computed
+  client-side from the locked 5 + 3 * switchCount formula using the switchCount already on
+  CraftingIdentityView (src/world_api/professions.ts; profession_identity_view.ts surfaces
+  it to players as returnCount). Display-only; the server still resolves the real cost
+  (Phase 14 owns the pre-commit preview).
+- Progressive disclosure (2026-07-17 amendment): the unattuned and pre-first-tier states
+  render a SIMPLIFIED view: the identity paragraph, one clear call to action (the trending
+  craft and its next step), and the tutorial line promoted; the full ring, ten bars, and
+  perks readout take over at first tier or attunement. A new player sees one next step,
+  never ten bars first.
 
 Agent painter/styles deliverables:
 - src/ui/professions_window.ts: a cold painter on the deeds pattern (injected deps, full rebuild
@@ -183,6 +201,11 @@ STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
 - [ ] Identity (title, majors, hobby), the ring visualization, ten per-craft skill bars, tier
       pips, and the perks readout all render from both Sim- and ClientWorld-shaped inputs,
       including the pre-cprof (synced false) empty state.
+- [ ] Per-craft role and ceiling, the nudges, and the tutorial state survive from the
+      absorbed identity view; the next-unlock and switch-cost lines render from existing
+      reads only.
+- [ ] The unattuned / pre-first-tier simplified state shows a single clear next step; the
+      full ring takes over at first tier or attunement.
 - [ ] src/ui/professions_view.ts is registered in UI_PURE_CORES and is DOM-free.
 - [ ] Zero hex literals in every new file; existing tokens only; no DESIGN.md phase vocabulary.
 - [ ] The mobile guard trio is green (coverage, transform, layout).

--- a/docs/professions-2/phase-06-crafting-window.md
+++ b/docs/professions-2/phase-06-crafting-window.md
@@ -1,12 +1,17 @@
 # Phase 06: Crafting window upgrades and celebrations
 
 This phase makes the crafting window legible (profession, required skill, combo requirement,
-station binding) and makes a masterwork craft a celebrated moment (toast, zone-chat broadcast,
-tooltip seal, maker's mark). It is its own slice because it is pure presentation over surfaces
-earlier phases already shipped: Phase 2's masterwork SimEvent and instance flag, PR 2039's shared
-`combo_eligibility` rule, and today's `requiresHubStation` station gate. Nothing here touches sim
-behavior or the wire; it renders what already exists, so it can land and be verified visually on
-its own.
+station binding) and makes progress a celebrated moment: the masterwork toast, a zone-visible
+masterwork broadcast, tier-up toasts at every skill-tier crossing, the tooltip seal, and the
+maker's mark. It builds on surfaces earlier phases already shipped: Phase 2's masterwork
+SimEvent and instance flag, PR 2039's shared `combo_eligibility` rule, and today's
+`requiresHubStation` station gate. It is ALMOST pure presentation; the 2026-07-17 amendments
+sanction exactly two seam touches: (1) the zone-visible masterwork broadcast (the Phase 2
+SimEvent is PERSONAL, pid = crafter, so the zone audience rides the Phase 4
+soft-zone-broadcast mechanism via a small deliberate emit at the craft site) and (2) the
+identity-wire extension that makes another player's masterwork and enchant stats inspectable
+online (the Phase 2 QA drift decision resolves as EXTEND). Everything else renders what
+already exists.
 
 ## Context pointers
 
@@ -40,8 +45,9 @@ Model: Opus 4.8, xhigh effort (reserve max for genuinely frontier problems), 1m 
 variant where the file load demands it.
 Harness: Claude Code.
 
-Goal: make the crafting window legible (skill, combo, station) and make masterworks a
-celebrated moment.
+Goal: make the crafting window legible (skill, combo, station) and make progress a
+celebrated moment: masterworks (toast + zone-visible broadcast + inspectable seal) and
+skill-tier crossings (tier-up toasts).
 
 STEP 0 - PRE-FLIGHT:
 - Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
@@ -79,9 +85,9 @@ sim_i18n matcher rule pattern; and the design-language guardrails in play (token
 DESIGN.md phase vocabulary, mobile rules).
 
 STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
-Spawn three agents in parallel (request the fan-out explicitly; Opus 4.8 will not
+Spawn four agents in parallel (request the fan-out explicitly; Opus 4.8 will not
 self-initiate it). Give each ONLY the Explore summary, not raw planning docs. Never
-`mode: "plan"` on teammates. The three own disjoint files, so no worktree isolation is
+`mode: "plan"` on teammates. The four own disjoint files, so no worktree isolation is
 needed; the presentation agent consumes the rows-model contract stated in the summary.
 
 Agent view (rows model; owns src/ui/crafting_view.ts and its tests) deliverables:
@@ -105,8 +111,14 @@ touch points in src/ui/hud.ts) deliverables:
 - Masterwork celebration: the craft toast shows the masterwork state; the celebration gate
   is a pure, reduced-motion-aware module in the deed-fireworks style (new logic in a
   sibling module, hud.ts stays a thin consumer).
-- The zone-chat broadcast row renders from the Phase 2 masterwork SimEvent (id-based; text
-  resolves through the sim_i18n matcher, coordinate the rule with the i18n agent).
+- The crafter's own toast renders from the Phase 2 masterwork SimEvent (personal,
+  pid = crafter). The ZONE-visible broadcast row renders the seam agent's emit (the Phase
+  4 soft-zone-broadcast mechanism, id-based; text resolves through the sim_i18n matcher,
+  coordinate the rule with the i18n agent); this agent owns only the rendering side.
+- Tier-up celebration: a toast at every TIER_SKILL_STEP crossing (25/50/75), derived
+  CLIENT-side from craftSkills transitions on craft results (both hosts read identical
+  data; no wire change); it reuses the same toast pipeline and celebration gate as the
+  masterwork toast, reduced-motion aware.
 - Item tooltips gain the maker's mark line (Crafted by {name}) and the masterwork seal
   overlay for flagged instances, sourced from the inv-wire ItemInstancePayload. Legacy
   signed instances without a masterwork flag keep a correct tooltip (mark line, no seal).
@@ -114,22 +126,45 @@ touch points in src/ui/hud.ts) deliverables:
   outside tokens.css/theme.ts, the mobile rules for the crafting window (40px tap floor)
   respected.
 
+Agent seam (owns BOTH sanctioned seam touches: the identity/inspect wire touch points in
+src/net/online.ts, server/game.ts, and the matching world_api facet, PLUS the
+zone-broadcast emit module in src/sim/ that the presentation agent's broadcast row
+consumes) deliverables:
+- The masterwork zone-broadcast emit: a small module beside the Phase 4 event broadcasts
+  (module-first, called at the craft site), emitting the id-based soft-zone broadcast the
+  presentation agent renders. It draws NO rng and must leave the Phase 2 drawCounts pins
+  green.
+- Extend the online identity/inspect surface so another player's equipped items carry
+  their ItemInstancePayload (masterwork flag, enchant, signer): the offline render mirror
+  already builds them; the online inspect path gains the payloads so the tooltip seal and
+  maker's mark work on OTHER players' gear (the 2026-07-17 resolution of the Phase 2 QA
+  drift decision: extend, do not accept the limitation).
+- Both-worlds parity: the inspect read renders identically from Sim- and
+  ClientWorld-shaped inputs; parity and wire pins updated in the same change; verify
+  liveness, not shape (the 2033 stub trap).
+- Server authority: the payloads are server-minted rows mirrored outward; no wire command
+  may ingest a client-supplied ItemInstancePayload (the standing Phase 2 security
+  invariant; re-assert it in a test if the surface makes it expressible).
+
 Agent i18n/matcher (owns src/ui/i18n.catalog/hud_chrome.ts and src/ui/sim_i18n.ts)
 deliverables:
 - Every new player string is an English-only t() key in the hud_chrome catalog module
   (M16: a wordy new English value also needs its five non-Latin fills in the same change).
   This covers the skill line, the difficulty tint labels, all three combo reasons, the
-  station badge and disable reason, the toast masterwork text, the broadcast row, the
-  maker's mark line, and the seal label.
+  station badge and disable reason, the toast masterwork text, the tier-up toast text, the
+  broadcast row, the maker's mark line, and the seal label.
 - A matcher rule in src/ui/sim_i18n.ts for the id-based masterwork broadcast so the S3
   guard (tests/localization_fixes.test.ts) passes.
 - Values interpolate through the placeholder contract ({name}, {crafts}); never
   concatenate; numbers through the formatters.
 
 INVARIANTS THIS PHASE MUST KEEP:
-- Determinism: this phase should not touch src/sim/ at all; if any sim file must change,
-  all randomness goes through Rng (never Math.random, Date.now, or performance.now) and
-  tests/architecture.test.ts must stay green.
+- Determinism: the only sanctioned sim BEHAVIOR change is the zone-broadcast emit (a
+  Sim-side facet-member implementation required by the inspect seam touch is part of that
+  touch, not a third change); neither draws ANY rng nor perturbs the craft path draw
+  order (the Phase 2 drawCounts pins stay green); all randomness goes through Rng (never
+  Math.random, Date.now, or performance.now) and tests/architecture.test.ts must stay
+  green.
 - Seam: this phase renders existing IWorld data (craftingIdentity, inventory instances,
   craftResult); if a new IWorld member becomes necessary, add it to the matching facet
   file, implement it in BOTH Sim and ClientWorld, and re-pin
@@ -166,10 +201,16 @@ STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
     tests/localization_fixes.test.ts
   - a mobile screenshot of the crafting window (pr-screenshots skill; desktop and mobile,
     committed under docs/screenshots).
+- The seam touches add validation rows: the net/wire row (npx vitest run
+  tests/snapshots.test.ts tests/env_protocol.test.ts tests/bandwidth.test.ts
+  tests/world_api_parity.test.ts) and the sim rows (npx vitest run
+  tests/architecture.test.ts tests/professions_masterwork.test.ts
+  tests/professions_crafting.test.ts; the drawCounts pins must stay green).
 - Spawn review agents per the Review Dispatch Matrix in
   docs/professions-2/implementation-plan.md; check `git diff --name-only` against the
   phase-start commit and spawn ONLY matching rows (expected here: frontend-seam-reviewer
-  for the src/ui/ surface, cross-platform-sync because src/ui/sim_i18n.ts changed, and
+  for the src/ui/ surface, cross-platform-sync for the sim_i18n matcher, the SimEvent
+  emit, and the identity-wire extension, architecture-reviewer for the sim touch, and
   qa-checklist once the deliverable set is complete; if no row matches a part of the diff,
   spawn nothing extra).
 - Prompt each review agent you spawn for COVERAGE not filtering: report every issue
@@ -180,14 +221,17 @@ STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
 - Do not commit while any BLOCKING finding stands.
 
 STEP 4 - COMMIT CADENCE:
-Aim for 2 commits with these headlines (Conventional Commits with a scope; EXPLICIT paths,
+Aim for 3 commits with these headlines (Conventional Commits with a scope; EXPLICIT paths,
 never `git add -A`; every commit carries a body; no em dashes or emojis):
 - feat(ui): recipe skill and requirement legibility
   (src/ui/crafting_view.ts, src/ui/crafting_window.ts, src/ui/i18n.catalog/hud_chrome.ts,
   tests/crafting_view.test.ts and the window tests)
-- feat(ui): masterwork celebrations and maker's mark
+- feat(ui): masterwork and tier-up celebrations and maker's mark
   (the hud.ts toast arm and tooltip touch points, the celebration gate module,
   src/ui/sim_i18n.ts, remaining hud_chrome keys, tests, docs/screenshots)
+- feat(professions): masterwork zone broadcast and inspectable instances
+  (the sim emit module, the identity wire extension, parity and snapshot pins, liveness
+  tests)
 
 STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
 - [ ] #2037's scope is closed: recipe rows show profession, required skill, and the
@@ -199,8 +243,14 @@ STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
 - [ ] Station-bound rows show the badge; out-of-range rows show the inline disable reason
       (requiresHubStation joined RecipeDefLike)
 - [ ] No eligibility state renders as a bare disabled button anywhere in the window
-- [ ] A masterwork craft produces the toast, the zone-chat broadcast row, and the tooltip
-      seal; the celebration gate is pure and reduced-motion aware
+- [ ] A masterwork craft produces the crafter's toast AND a zone-visible broadcast row for
+      nearby players (the Phase 4 soft-zone mechanism), plus the tooltip seal; the
+      celebration gate is pure and reduced-motion aware
+- [ ] Tier crossings (25/50/75) produce the tier-up toast in both hosts, client-derived
+      from craftSkills transitions, no wire change
+- [ ] Online inspect shows another player's masterwork seal, enchant, and maker's mark
+      (identity wire extended, parity pinned, liveness verified); no wire command ingests
+      a client-supplied ItemInstancePayload
 - [ ] Tooltips show the maker's mark (Crafted by {name}); legacy signed instances without
       a masterwork flag render correctly (mark line, no seal, no throw)
 - [ ] Craft button never lies: the window uses the same shared eligibility rule as the sim
@@ -215,7 +265,9 @@ STEP 6 - DOC UPDATES + MEMORY:
   any deferrals.
 - Update docs/professions-2/state.md, "New surfaces per phase" gains the Phase 6 entry:
   the hudChrome crafting key namespace added, the sim_i18n masterwork broadcast matcher
-  rule, requiresHubStation on RecipeDefLike, and the celebration gate module path.
+  rule, the zone-broadcast emit site, the tier-up toast module, requiresHubStation on
+  RecipeDefLike, the celebration gate module path, and the identity-wire inspect payload
+  extension with its parity pins.
 - If you use Claude Code memory, record any surprising rules or current-state notes for
   the next session.
 
@@ -224,9 +276,11 @@ End your turn with: phase status, files touched, validation results, review-agen
 verdicts, any deferred items, and a one-line handoff for the Phase 6 QA session.
 
 STOPPING RULES:
-- No phase-specific stopping rules. Packet defaults apply: stop and ask if git status is
-  dirty at pre-flight; stop and surface if the Phase 2 masterwork SimEvent or the
-  instance-payload masterwork flag is not actually available (this phase only renders
-  them); stop and ask if a deliverable turns out to require a sim, wire, or station-system
-  change beyond consuming what already exists (that is Phase 2 or Phase 8 scope).
+- Packet defaults apply: stop and ask if git status is dirty at pre-flight; stop and
+  surface if the Phase 2 masterwork SimEvent or the instance-payload masterwork flag is
+  not actually available; stop and ask if a deliverable turns out to require a sim, wire,
+  or station-system change beyond the TWO sanctioned seam touches (the zone-broadcast emit
+  and the inspect payload extension); station-system changes stay Phase 8 scope.
+- If Phase 4 has not landed its soft-zone-broadcast mechanism when this phase runs, stop
+  and surface the ordering problem instead of inventing a second broadcast path.
 ```

--- a/docs/professions-2/phase-06-qa.md
+++ b/docs/professions-2/phase-06-qa.md
@@ -1,7 +1,9 @@
 # Phase 06 QA: Verify Crafting window upgrades and celebrations
 
-Audit the Phase 6 implementation (crafting window legibility, masterwork celebrations, maker's
-mark tooltips) for correctness, missing tests, dead code, determinism, three-host parity, and
+Audit the Phase 6 implementation (crafting window legibility, masterwork celebrations with the
+zone-visible broadcast, tier-up toasts, maker's mark tooltips, and the two sanctioned seam
+touches: the zone-broadcast sim emit and the online-inspect identity-wire extension) for
+correctness, missing tests, dead code, determinism, three-host parity, and
 i18n completeness.
 
 ## QA Starter Prompt
@@ -50,11 +52,19 @@ Correctness agent:
   tests/crafting_view.test.ts tests/localization_fixes.test.ts plus the updated window
   tests; the mobile guard trio (tests/mobile_window_coverage.test.ts,
   mobile_window_transform.test.ts, mobile_window_layout.test.ts); npm run i18n:gen then
-  npx vitest run tests/i18n_completeness.test.ts tests/localization_fixes.test.ts.
+  npx vitest run tests/i18n_completeness.test.ts tests/localization_fixes.test.ts; the
+  seam-touch rows: npx vitest run tests/snapshots.test.ts tests/env_protocol.test.ts
+  tests/bandwidth.test.ts tests/world_api_parity.test.ts tests/architecture.test.ts
+  tests/professions_masterwork.test.ts tests/professions_crafting.test.ts (the Phase 2
+  drawCounts pins must be green: the zone-broadcast emit draws no rng).
 - Exercise the real behavior, not just the tests: with npm run dev (and npm run server
   for the online host), open the crafting window, walk recipes across skill tiers, force
   each eligibility state, craft until a masterwork procs (dev commands allowed locally),
-  and confirm the toast, broadcast row, and tooltip seal appear; capture the mobile
+  and confirm the toast, the ZONE broadcast row (a SECOND nearby client must see it, the
+  crafter's own toast is not the probe), the tier-up toast at a 25/50/75 crossing in both
+  hosts, and the tooltip seal appear; inspect the crafter from the second client and
+  confirm the masterwork seal, enchant, and maker's mark render from the extended
+  identity wire (liveness, not shape: the 2033 stub trap); capture the mobile
   screenshot of the crafting window.
 - Verify the offline Sim path and the online ClientWorld path present identical rows,
   reasons, and celebrations (the craft button never lies in either host).
@@ -92,12 +102,24 @@ PHASE-SPECIFIC QA EMPHASIS (probe these explicitly):
   never the masterwork information (toast, broadcast, and seal still convey it).
 - The bare-disabled-button sweep: enumerate every disabled state the window can produce
   and confirm each one names its reason inline.
+- The zone-broadcast audience (2026-07-17 seam touch): a nearby player sees the
+  masterwork broadcast row and a distant player does not; the crafter's own toast still
+  renders from the personal Phase 2 SimEvent; the emit rides the Phase 4 soft-zone
+  mechanism and draws no rng (drawCounts pins green).
+- Tier-up toasts: fire at every TIER_SKILL_STEP crossing, client-derived identically in
+  both hosts, never on a non-crossing skill gain, and reduced-motion aware.
+- Online-inspect payloads (2026-07-17 seam touch): another player's masterwork and
+  enchant stats are visible via inspect in the ONLINE host (parity-pinned, live); and
+  the standing security invariant holds: no wire command ingests a client-supplied
+  ItemInstancePayload (attempt one; the server must re-mint or reject).
 
 Multi-agent review dispatch: apply the Review Dispatch Matrix in
 docs/professions-2/implementation-plan.md (the plan carries the one canonical copy).
 Check `git diff --name-only` against the phase-start commit and spawn ONLY the agents
-whose row matches (expected here: frontend-seam-reviewer, and cross-platform-sync if
-src/ui/sim_i18n.ts changed), plus qa-checklist (this is the phase-completion QA gate).
+whose row matches (expected here: frontend-seam-reviewer, cross-platform-sync for the
+sim_i18n matcher, the SimEvent emit, and the identity-wire extension, and
+architecture-reviewer for the sanctioned sim touch), plus qa-checklist (this is the
+phase-completion QA gate).
 Prompt each for COVERAGE not filtering. Resume any review agent that truncates
 mid-analysis with: "Stop reading more files. Output the full report now. No more tool
 calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT."
@@ -124,6 +146,8 @@ Phase 7 implementation session.
 
 STOPPING RULES:
 - Stop and surface to the user if any BLOCKING item cannot be fixed without changing the
-  phase scope (for example, if a fix would require sim, wire, or station-system changes
-  that belong to Phase 2 or Phase 8).
+  phase scope. Fixes to the TWO sanctioned seam touches (the zone-broadcast emit and the
+  inspect payload extension) ARE Phase 6 scope; anything beyond them (station-system
+  changes, new craft mechanics) belongs to Phase 2 or Phase 8 and must be surfaced, not
+  fixed here.
 ```

--- a/docs/professions-2/phase-07-qa.md
+++ b/docs/professions-2/phase-07-qa.md
@@ -15,6 +15,16 @@ completeness for this phase.
 - Backfill single-fire proof: a legacy character loaded already far past the threshold gets
   exactly one letter on first evaluation and never another on later loads, logins, or skill
   changes; no burst across multiple qualifying pairs.
+- The vertical-slice checkpoint (2026-07-17 amendment): this QA session is the kernel
+  exit. Drive the eight-step journey end to end in one seeded run: gather until a rare
+  event fires, craft, watch skill and the next-unlock line move, receive the Guild letter,
+  visit the letter's named quest giver and attune via the quest flow (the Phase 8 master
+  NPCs do not exist yet at this checkpoint; smith_haldren and the 2039 intro-quest givers
+  stand in, and the letter must name a giver that actually exists), proc and celebrate a
+  masterwork (toast plus the zone-visible broadcast, if Phase 6 has landed; the personal
+  toast alone if not), and trade the result. A step that is mechanically present but
+  experientially broken (silent, illegible, or celebration-free) is a SHOULD-FIX at
+  minimum, never a pass.
 
 ## QA Starter Prompt
 
@@ -69,6 +79,10 @@ Agent correctness:
 - Prove offline vs online delivery parity: the letter reaches the player identically via the
   offline Sim and the server-authoritative online path; confirm the online mail surface is
   live, not a stub default (the 2033 trap).
+- Play the vertical slice (the kernel-exit checkpoint from the QA emphasis above): the
+  eight-step journey in one seeded run, recording where each beat surfaces (loot line,
+  toast, mail, broadcast, title). Report the experiential gaps, not just the mechanical
+  ones; they are findings like any other.
 
 Agent test coverage:
 - Find untested paths: threshold boundary values, adjacency and tie-breaking between pairs,

--- a/docs/professions-2/phase-08-qa.md
+++ b/docs/professions-2/phase-08-qa.md
@@ -8,7 +8,15 @@ hands-vs-stations gate, and the placement-safety proof.
 
 - The nine hub recipes' migration to typed stations, with special attention to the three
   `CASTER_HUB_RECIPES`: crafting them at their station must behave exactly as it did under
-  `requiresHubStation` (no behavior regression in gate order, level rule, or proximity radius).
+  `requiresHubStation` in gate order and proximity radius. The LEVEL rule is the one
+  DELIBERATE change (the 2026-07-17 placement ruling): `CRAFTING_HUB_MIN_LEVEL` is retired
+  and no station gate reads player level; verify the retirement is complete AND that no
+  recipe strands for any character in the transition (do not report the level-gate removal
+  as a regression).
+- The multi-zone placement (2026-07-17 ruling): the placement-safety derivation runs PER
+  ZONE (the Fenbridge tannery checks zone 2 camps, the Highwatch apothecary zone 3 camps),
+  and the master-to-zone assignment pin (four archetype anchors in zone 1; tannery
+  Fenbridge; apothecary Highwatch) matches the state.md default as literals.
 - The deny reason localization: the sim emits a stable id, the `sim_i18n` matcher resolves it to
   a real English `t()` key, and the S3 guard (`tests/localization_fixes.test.ts`) actually covers
   the new emit site; no raw id or English concat ever reaches the player.

--- a/docs/professions-2/phase-08-stations-masters.md
+++ b/docs/professions-2/phase-08-stations-masters.md
@@ -26,6 +26,9 @@ build on stations that already exist, gate correctly, and are provably placed sa
   and `CASTER_HUB_RECIPES` (three) which carry `requiresHubStation: true` today, `COMBO_RECIPES`.
 - `src/sim/content/zone1.ts`: `ZONE1_NPCS` (`trader_wilkes` is the NpcDef exemplar with
   `vendorItems`, `questIds`, `greeting`), `ZONE1_MOBS` (`aggroRadius`), `ZONE1_CAMPS`.
+- `src/sim/content/zone2.ts` (`ZONE2_NPCS`, the Fenbridge hub) and `src/sim/content/zone3.ts`
+  (`ZONE3_NPCS`, the Highwatch hub): the out-of-hub masters live here per the 2026-07-17
+  placement ruling in `state.md`.
 - `src/sim/types.ts`: `NpcDef`, `CampDef` (`mobId`, `center`, `radius`, `count`), `MobTemplate`
   (`aggroRadius`), the CAMPS draw-order determinism contract on `WorldContent`.
 - `src/ui/world_entity_i18n.ts`: entity name i18n registration (`tEntity` resolution path) for the
@@ -65,7 +68,9 @@ Spawn one Explore agent to read and summarize:
   src/sim/content/recipes.ts (COMMON_RECIPES, TOOL_RECIPES, CASTER_HUB_RECIPES, COMBO_RECIPES,
   every requiresHubStation carrier)
 - src/sim/content/zone1.ts (ZONE1_NPCS with trader_wilkes as the NpcDef exemplar, ZONE1_MOBS
-  aggroRadius, ZONE1_CAMPS) and the NpcDef / CampDef / MobTemplate shapes in src/sim/types.ts
+  aggroRadius, ZONE1_CAMPS), src/sim/content/zone2.ts (ZONE2_NPCS) and src/sim/content/zone3.ts
+  (ZONE3_NPCS) for the out-of-hub masters, and the NpcDef / CampDef / MobTemplate shapes in
+  src/sim/types.ts
 - src/ui/world_entity_i18n.ts (entity-name i18n registration path)
 - src/sim/CLAUDE.md, src/sim/content/CLAUDE.md, src/sim/professions/CLAUDE.md, src/ui/CLAUDE.md
   (the S3 matcher duty), tests/CLAUDE.md
@@ -102,25 +107,37 @@ Agent sim deliverables:
   recipe requires standing at its stationType. Deny with a STABLE reason id (for example
   'station_required' carrying the stationType value); add the matching t() key (English only)
   and the sim_i18n matcher rule in the SAME change (S3 duty).
+- Retire the level gate: the STATIONS registry replaces CRAFTING_HUB_MIN_LEVEL and no
+  station gate reads player level (the 2026-07-17 placement ruling); migrate or retire
+  canUseCraftingHubStation's level arm with its consumers and prove no recipe strands.
 - FIELD_RECIPES: a named set that is exactly the nine existing COMMON_RECIPES ids today. The T
   window keeps working for them everywhere.
 - Mobile crafting station goes live: an active station (isStationActive) satisfies the station
-  gate; the placement command becomes reachable (dev-gated or specialization-gated, following the
-  existing perk command pattern); update the inert-module header in mobile_station.ts to describe
-  the now-wired state.
+  gate; the placement command becomes reachable, SPECIALIZATION-gated per the locked decision
+  (the 75-skill perk is the craft-anywhere unlock beat; an additional dev-command path for
+  testing is fine), following the existing perk command pattern; update the inert-module header
+  in mobile_station.ts to describe the now-wired state.
 
 Agent content deliverables:
-- Six master NpcDefs in ZONE1_NPCS, one per station type: a smith at the forge (covers both
-  weaponcrafting and armorcrafting, matching the Smith pair), a cook at the kitchens, an
-  alchemist at the apothecary, a leatherworker at the tannery, a tailor at the loom, and
-  engineering's toolwright at the toolworks. Follow the trader_wilkes exemplar shape.
+- Six master NpcDefs, one per station type, spread across the three zone hubs per the
+  2026-07-17 placement ruling in state.md: in the zone 1 hub (ZONE1_NPCS) the smith at the
+  forge (covers both weaponcrafting and armorcrafting, matching the Smith pair), the cook
+  at the kitchens, the tailor at the loom, and engineering's toolwright at the toolworks,
+  so every wave-one archetype keeps a zone-1 anchor master; the leatherworker's tannery
+  roots in Fenbridge (ZONE2_NPCS); the alchemist's apothecary roots in Highwatch
+  (ZONE3_NPCS, keeping the #1297 crafting-hub lore without its level gate). Follow the
+  trader_wilkes exemplar shape. The maintainer may reshuffle the assignment in PR review
+  (a data-only move); flag it in the PR body beside the naming pass.
 - Each master: a real name and title and greeting registered through the entity i18n path
   (src/ui/world_entity_i18n.ts, tEntity); starter vendorItems (base tools and reagents, stock
   only, training UX is Phase 9); an EMPTY questIds hook array for Phase 14.
 - Names are content flavor the maintainer may rename (state.md OPEN item); make them real, not
   lorem, and note the naming-pass flag in the PR body.
-- Station placements: guard-safe town locations inside the zone 1 hub, each master beside its
-  station; reuse CRAFTING_HUB_STATIONS coordinates where they are already guard-safe.
+- Station placements: guard-safe town locations inside each hosting hub, each master beside
+  its station. CRAFTING_HUB_STATIONS offsets are ZONE-3 coordinates (offsets from
+  CRAFTING_HUB_POS at the Highwatch hub, per src/sim/content/professions.ts): they may seed
+  only the Highwatch apothecary placement; the Eastbrook and Fenbridge placements are new
+  coordinates. (The level-gate retirement itself is the sim agent's deliverable above.)
 - Adding the masters must NOT shift the shared Rng draw order (the CAMPS append-only contract;
   NPC creation draws no rng).
 
@@ -129,9 +146,13 @@ Agent tests deliverables:
   tests/professions_station_placement.test.ts): derived from spawn CONTENT, not hardcoded
   distances. For every profession NPC and every STATIONS record, distance to every hostile camp
   (mob template aggroRadius > 0) must exceed camp.radius plus the template's aggroRadius plus a
-  buffer. Choose the buffer as the strictest value every existing town NPC already satisfies and
-  document it in the test; prove the test can fail by temporarily moving one master next to a
-  camp, observing the failure, then restoring.
+  buffer, derived PER ZONE (a Fenbridge master checks against zone 2 camps, the Highwatch
+  master against zone 3 camps). Choose the buffer as the strictest value every existing town
+  NPC already satisfies and document it in the test; prove the test can fail by temporarily
+  moving one master next to a camp, observing the failure, then restoring.
+- A master-to-zone assignment pin: the state.md default (four archetype anchors in zone 1;
+  tannery in Fenbridge; apothecary in Highwatch) pinned as literals so an accidental move
+  fails the test; a deliberate maintainer reshuffle re-pins with a commit-body note.
 - Gate tests (extend tests/professions_crafting_hub.test.ts or a sibling): an uncommon+ recipe
   denies with the stable station reason id away from its station and succeeds at it; each of the
   nine FIELD_RECIPES crafts away from any station; a recipe denies at the WRONG station type;
@@ -195,11 +216,15 @@ STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
 - [ ] FIELD_RECIPES is exactly the nine pre-phase COMMON_RECIPES ids; all nine craft anywhere and
       the T window works for them everywhere
 - [ ] Six masters exist with entity i18n names/titles/greetings, starter vendorItems, empty
-      questIds hooks, placed guard-safe beside their stations
+      questIds hooks, placed guard-safe beside their stations across the three hubs per the
+      state.md assignment (four archetype anchors in zone 1; tannery in Fenbridge;
+      apothecary in Highwatch), with the assignment pinned by a test
 - [ ] The placement-safety test is green AND proven: it fails when a master is moved next to a
       hostile spawn (mutation tried and reverted)
 - [ ] The mobile crafting station perk is live: isStationActive satisfies the gate, the placement
-      command is reachable, the inert-module header is updated
+      command is reachable and SPECIALIZATION-gated, the inert-module header is updated
+- [ ] CRAFTING_HUB_MIN_LEVEL is retired: no station gate reads player level, and no recipe
+      strands in the transition (pinned)
 - [ ] Every recipe craftable before this phase remains craftable (station or field); nothing
       strands
 - [ ] All STEP 3 validation commands green; no BLOCKING review finding open
@@ -210,9 +235,10 @@ STEP 6 - DOC UPDATES + MEMORY:
   diffs against the phase-start commit).
 - Update docs/professions-2/state.md: the "New surfaces per phase" Phase 8 entry gains the
   station registry module and StationType union, the stationType recipe field, the FIELD_RECIPES
-  set, the six master NPC ids, the deny reason id and its i18n key namespace, the mobile-station
-  activation command, and the placement test file name. Amend "Key existing surfaces" where
-  requiresHubStation / CRAFTING_HUB_STATIONS statements went stale.
+  set, the six master NPC ids with their zone assignment, the deny reason id and its i18n key
+  namespace, the mobile-station activation command, and the placement test file name. Amend
+  "Key existing surfaces" where requiresHubStation / CRAFTING_HUB_STATIONS /
+  CRAFTING_HUB_MIN_LEVEL statements went stale.
 - Record surprises (gate order gotchas, rng draw-order traps, naming decisions) to memory.
 
 STEP 7 - FINAL RESPONSE FORMAT:

--- a/docs/professions-2/phase-09-qa.md
+++ b/docs/professions-2/phase-09-qa.md
@@ -12,6 +12,12 @@ server-authoritative, and no existing character lost a recipe.
   normalize pass changes nothing.
 - GLB budget unchanged if no new GLB landed; if one did land, verify the media manifest regen,
   `registerPreload`, and `npm run asset:budget` all hold.
+- The teach-tier gate and the visible ladder (the 2026-07-17 amendment): a below-tier train
+  attempt denies with the localized tier reason; the Train view SHOWS the locked row with
+  its named requirement (never hidden); crossing the threshold flips it to teachable; the
+  hobby craft uses the same thresholds; common recipes never lock; and a KNOWN recipe is
+  never use-gated regardless of skill (drive a real craft to prove the no-admission-gate
+  rule survived the new predicate).
 
 ## QA Starter Prompt
 

--- a/docs/professions-2/phase-09-station-training.md
+++ b/docs/professions-2/phase-09-station-training.md
@@ -2,7 +2,9 @@
 
 Phase 8 landed the typed station registry and master NPC records in sim and server; this phase
 makes them real to players. Stations render as visible props in the world, show on the minimap,
-and their masters teach recipes for gold through a Train view, while a grandfathering step
+and their masters teach recipes for gold through a Train view that is skill-tier gated with a
+visible locked-row ladder (the 2026-07-17 amendment: the RuneScape-style unlock ladder,
+delivered on the LEARNING side, never on use), while a grandfathering step
 backfills every pre-existing recipe as known so acquisition goes live without stranding anyone.
 It is its own slice because it is the presentation-and-wire half of stations: the sim/server
 truth exists (Phase 8), and the recipe ladder content that depends on live training is Phase 10.
@@ -10,7 +12,8 @@ truth exists (Phase 8), and the recipe ladder content that depends on live train
 ## Context pointers
 
 - `docs/professions-2/state.md`: locked decisions binding this phase (acquisition via
-  `acquireRecipe`, the grandfathering rule, training fee tuning targets, hands vs stations),
+  `acquireRecipe`, the grandfathering rule, training fee AND teach-tier tuning targets, hands
+  vs stations, the 2026-07-17 skill-tier training ruling),
   the validation matrix, and the Phase 8 "New surfaces" entry (station registry, master NpcDefs).
 - `docs/professions-2/progress.md`: current status and the Phase 8 handoff.
 - `docs/professions-2/implementation-plan.md`: review dispatch matrix and design-language
@@ -37,8 +40,8 @@ truth exists (Phase 8), and the recipe ladder content that depends on live train
 ```
 This is Phase 09 of the Professions 2.0 feature: Station presence and recipe training.
 Model: Opus 4.8, xhigh effort. Harness: Claude Code.
-Goal: make stations visible places whose masters teach recipes for fees, and turn recipe
-acquisition on without stranding any existing character.
+Goal: make stations visible places whose masters teach recipes for fees behind a visible
+skill-tier ladder, and turn recipe acquisition on without stranding any existing character.
 
 STEP 0 - PRE-FLIGHT:
 - Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
@@ -91,7 +94,10 @@ Agent ui deliverables:
 - The master dialog gains a Train view on the vendor window family (src/ui/hud/vendor/): a
   DOM-free pure view core (registered in UI_PURE_CORES if it is a new module) plus a thin
   write-elided painter, following the heroic vendor variant as the extension template.
-- Rows show the recipe, the fee (formatMoney), and known/teachable state; the Train action
+- Rows show the recipe, the fee (formatMoney), and a KNOWN / TEACHABLE / LOCKED tri-state.
+  Locked rows are the visible ladder (2026-07-17 ruling): always SHOWN, grayed, with their
+  requirement named ("Taught at <craft> 50"), never hidden; crossing the threshold is the
+  unlock moment the ladder points at. The Train action
   issues the IWorld command; denial reasons render through the server/sim matcher keys.
 - Every player-visible string is an English-only t() key in the matching
   src/ui/i18n.catalog/<domain>.ts module; mobile rules per src/styles/CLAUDE.md (a deliberate
@@ -103,11 +109,19 @@ Agent sim/wire deliverables:
   command online), with the parity pin updated in tests/world_api_parity.test.ts in the same
   change. Verify liveness, not just member shape (the 2033 stub trap).
 - Server validation in the command dispatch (server/game.ts): proximity to the master's
-  station, fee affordable and charged, recipe teachable at this master; on success grant via
+  station, fee affordable and charged, recipe teachable at this master, AND the skill-tier
+  gate (the 2026-07-17 ruling): a master teaches a recipe only when tierForSkill(the
+  player's craft skill) >= tierForSkill(the recipe's skillReq), the general predicate, so
+  the wave-one ladder is common always, uncommon at 25, rare at 50, and any
+  higher-skillReq recipe a later phase authors gates by the same formula with no extra
+  rule (the state.md teach-tier tuning target). Hobby crafts use the same thresholds. The gate is
+  on LEARNING only; known recipes are never use-gated (the no-admission-gate rule stands
+  untouched). On success grant via
   acquireRecipe. Fee and grant resolve SERVER-side; the client never decides. Fees follow the
   state.md tuning targets (common tier free, uncommon 25s, rare 1g) and are a gold sink.
 - Denial reasons are emitted as stable ids the client matcher re-localizes (S3 duty, in the
-  SAME change).
+  SAME change), including the tier denial (for example 'train_tier_unmet' carrying the
+  craft and the required skill value).
 - Grandfathering: a normalize-on-load step backfills every recipe id that existed before this
   phase as known, for offline saves and server-persisted state alike; deterministic and
   idempotent (running it twice changes nothing).
@@ -116,8 +130,13 @@ Agent sim/wire deliverables:
 
 Agent tests deliverables:
 - Train command tests: the happy path (fee charged exactly once, recipe known after), the
-  denial paths (out of range, insufficient gold, not teachable at this master, already known),
-  and replay/idempotency (a resent or duplicated command cannot double-charge or double-grant).
+  denial paths (out of range, insufficient gold, not teachable at this master, already known,
+  BELOW the teach tier), and replay/idempotency (a resent or duplicated command cannot
+  double-charge or double-grant).
+- Teach-tier gate tests: a below-tier player is denied with the stable tier reason and sees
+  the locked row; crossing the threshold flips the row to teachable; the hobby craft uses
+  the same thresholds; common recipes never lock; a known recipe is NEVER use-gated
+  regardless of skill (pin the no-admission-gate rule against the new predicate).
 - A grandfather test on a legacy save fixture (a pre-phase state blob with craftable recipes
   and no acquisition records) proving nothing is lost. This test is the phase gate.
 - The minimap marker variant tested against BOTH host shapes (tests/minimap_markers.test.ts).
@@ -171,7 +190,7 @@ STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
 
 STEP 4 - COMMIT CADENCE (explicit paths, never git add -A; every commit carries a body):
 - feat(render): station presence (stations module, master NPC keys, minimap marker variant)
-- feat(professions): recipe training command with server-side fee and grant, plus
+- feat(professions): skill-tier-gated recipe training with server-side fee and grant, plus
   grandfathering
 - feat(ui): the Train view on the vendor window family
 - docs(professions-2): Phase 9 progress, state surfaces, and screenshots
@@ -183,6 +202,9 @@ STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
       tier-identical, tested against both host shapes.
 - [ ] Opening the master presents the Train view; learning a recipe charges the fee and grants
       it via acquireRecipe in BOTH the offline Sim and the online ClientWorld.
+- [ ] The Train view shows locked rows with their named requirement; a below-tier train
+      attempt denies with the localized tier reason; crossing the tier makes the row
+      teachable (the visible ladder); a known recipe is never use-gated regardless of skill.
 - [ ] Fees match the state.md tuning targets (common free, uncommon 25s, rare 1g), are charged
       server-side as a gold sink, and a replayed command cannot double-charge or double-grant.
 - [ ] Every character that existed before this phase knows every recipe it could previously
@@ -198,7 +220,8 @@ STEP 6 - DOC UPDATES + MEMORY:
 - Update docs/professions-2/progress.md (Phase 9 checklist and status, plus the phase-start
   commit for the QA diff) and docs/professions-2/state.md: the "New surfaces per phase" list
   gains Phase 9 (src/render/stations.ts; the station minimap marker variant; the trainRecipe
-  facet member and wire command; the grandfather normalize step; the Train view i18n key
+  facet member and wire command; the teach-tier predicate and its denial id; the grandfather
+  normalize step; the Train view i18n key
   namespace; the trained-not-known recipe default). Resolve or explicitly defer the OPEN item
   "exact FIELD_RECIPES membership" (the default stands: the 9 common recipes stay
   field-craftable) and record the outcome in state.md.

--- a/docs/professions-2/phase-10-qa.md
+++ b/docs/professions-2/phase-10-qa.md
@@ -16,6 +16,12 @@ component collision fix, and the pinned economy invariant.
   inscription, and enchanting stay shallow).
 - Economy invariant decisiveness: the test must enumerate EVERY recipe (not a sample) and
   price vendor reagents at their purchase price, not their sell price.
+- The 2026-07-17 amendment deliverables: every rare recipe consumes at least one
+  lower-tier material family (cross-tier composition); cooking and alchemy carry
+  combat-worthy consumables at EVERY tier; the perfect specimen component rides
+  rollCorpseMaterialRarity and is always signed at rare+; and the materialTierBonus hook
+  is wired with pinned values at the crafting.ts call site (higher-tier materials raise
+  the proc chance, the cap and the drawCounts pins stay green).
 
 ## QA Starter Prompt
 

--- a/docs/professions-2/phase-10-recipe-ladders.md
+++ b/docs/professions-2/phase-10-recipe-ladders.md
@@ -3,8 +3,9 @@
 This phase turns the six deep crafts into real progressions: common to rare tier ladders that
 consume the Phase 4 node materials, corpse components, fish, and vendor reagents, backed by a
 pinned economy invariant so no recipe ever vendors above its inputs. It is its own slice because
-it is pure batch content work (hundreds of records across a handful of tables) with no new sim
-behavior: everything it needs (wheel math, masterwork, stations, training) landed in Phases 1
+it is almost pure batch content work (hundreds of records across a handful of tables): the one
+sanctioned sim touch is wiring the named Phase 2 materialTierBonus hook at its crafting.ts call
+site. Everything else it needs (wheel math, masterwork, stations, training) landed in Phases 1
 to 9, and everything that consumes it (fishing supply, node tiers, tuning) comes after.
 
 ## Context pointers
@@ -97,6 +98,15 @@ Materials/collision agent deliverables:
 - Dedicated material ItemDefs for hide, silk, venomSac, and meat (plus any other corpse
   component the audit surfaces), with HARVEST_COMPONENT_ITEMS remapped so harvesting
   yields the new materials.
+- The perfect specimen (2026-07-17 amendment): a rare corpse-component family riding the
+  EXISTING rollCorpseMaterialRarity roll and the signable-rarity floor (rare+, always
+  signed): corpse harvesting's jackpot fantasy, celebrated by the Phase 4 loot-line
+  treatment. No new event system and no proficiency work (monster-harvest proficiency
+  stays wave 2).
+- Wire the Phase 2 materialTierBonus hook (the named hook in
+  src/sim/professions/masterwork.ts): real material-tier values at the crafting.ts call
+  site keyed by the consumed materials' rarity, pinned in the masterwork tests. Higher-tier
+  materials now visibly raise masterwork odds; the cap and draw order are untouched.
 - The old quest items keep their quest roles ONLY: quest drops and quest credit paths
   stay exactly as they are, with a regression test proving quest credit still works and
   that a wolf hide no longer advances a boar quest.
@@ -110,6 +120,12 @@ Craft content agent deliverables (each of the six, for its craft):
 - Each tier's recipes consume Phase 4 node materials, the new corpse component materials,
   fish (cooking: author the recipes and the fish ItemDefs now; Phase 11 lands the supply),
   and vendor reagents.
+- Cross-tier composition (2026-07-17 amendment): higher-tier recipes also consume SOME
+  lower-tier materials (at least one lower-tier material family per rare recipe) so new
+  gatherers keep selling into a mature economy.
+- Cooking and alchemy only: combat-worthy consumables at EVERY tier (food and potion
+  outputs a raider actually uses), keeping a permanent destruction channel for low-tier
+  materials (2026-07-17 amendment).
 - Every output is a real ItemDef with an English catalog row and the procedural icon
   fallback (bespoke WebP icon overrides are not required this phase).
 - Every new recipe is trained, not known, at the matching master via the Phase 9
@@ -130,6 +146,9 @@ Verify stage (adversarial) deliverables:
   master and training links, catalog keys, component mappings.
 - Confirm every gathered or harvested material introduced by Phases 4 and 10 has at least
   one consuming recipe.
+- Confirm the cross-tier rule (every rare recipe consumes at least one lower-tier material
+  family) and the every-tier consumable rule (cooking and alchemy output combat-worthy
+  consumables at each tier).
 - Report every issue including low-severity and uncertain ones; ranking happens later.
 
 INVARIANTS THIS PHASE MUST KEEP:
@@ -202,13 +221,21 @@ STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
 - [ ] Every new recipe is trained-not-known at its matching master.
 - [ ] Every new item and recipe has an English catalog row; wordy names carry their five
       non-Latin fills (M16).
+- [ ] Every rare recipe consumes at least one lower-tier material family; cooking and
+      alchemy have combat-worthy consumables at every tier.
+- [ ] The materialTierBonus hook is wired with pinned values; higher-tier materials raise
+      the masterwork proc chance; the cap and draw-order pins stay green.
+- [ ] The perfect specimen family exists, rides the corpse rarity roll, and is always
+      signed at rare+.
 - [ ] npm run wiki:content regenerates clean.
 
 STEP 6 - DOC UPDATES + MEMORY:
 - Update docs/professions-2/progress.md (mark Phase 10 status; note deferrals).
 - Update docs/professions-2/state.md: the Phase 10 entry in New surfaces gains the new
-  material item id families (hide/silk/venomSac/meat/fiber/cloth), the ladder table
-  locations, the economy invariant test path, the i18n key namespaces added, the fish
+  material item id families (hide/silk/venomSac/meat/fiber/cloth), the perfect specimen
+  family, the ladder table
+  locations, the economy invariant test path, the wired materialTierBonus values, the
+  i18n key namespaces added, the fish
   item ids authored ahead of Phase 11, and the per-master trained recipe mapping.
 - If you use Claude Code memory, record any surprising rules or current-state notes for
   the next session.

--- a/docs/professions-2/phase-13-enchanting.md
+++ b/docs/professions-2/phase-13-enchanting.md
@@ -1,17 +1,24 @@
 # Phase 13: Enchanting reachable
 
-The enchanting sim is already complete and tested (`resolveDisenchant` and `resolveApplyEnchant` in
-`src/sim/professions/enchanting.ts`) but no player can reach it: there are no `IWorld` members, no
-wire commands, and no UI. This phase wires disenchant and enchant application to players in both
-hosts: bags context actions with a destruction confirm, server-validated commands, and results
-mirrored online. It is its own slice because it is pure seam-plus-UI work over a finished sim
-surface, independent of the content phases around it, and salvage deliberately stays behind.
+The enchanting and salvage sims are already complete and tested (`resolveDisenchant` and
+`resolveApplyEnchant` in `src/sim/professions/enchanting.ts`; `resolveSalvage` in
+`src/sim/professions/salvage.ts`) but no player can reach them: there are no `IWorld` members, no
+wire commands, and no UI. This phase wires disenchant, enchant application, AND salvage to
+players in both hosts: bags context actions with a destruction confirm, server-validated
+commands, and results mirrored online. It is its own slice because it is pure seam-plus-UI work
+over finished sim surfaces, independent of the content phases around it. Salvage joins per the
+2026-07-17 amendment: this phase builds the exact machinery it needs, so obsolete crafted gear
+gets a wave-one destination instead of waiting for wave 2.
 
 ## Context pointers
 
 - `docs/professions-2/state.md`: locked decisions, the validation matrix, and the key-surfaces row
-  for salvage/disenchant/enchant (sim-complete, `lastDisenchantResult`/`lastEnchantResult` stashes
-  on `PlayerMeta`, no IWorld/wire/UI yet; salvage stays wave 2).
+  for salvage/disenchant/enchant (sim-complete,
+  `lastSalvageResult`/`lastDisenchantResult`/`lastEnchantResult` stashes
+  on `PlayerMeta`, no IWorld/wire/UI yet; salvage joins this phase per the 2026-07-17
+  amendments).
+- `src/sim/professions/salvage.ts`: `resolveSalvage` and its existing sim suite (do not change
+  the resolution logic; this phase only makes it reachable).
 - `docs/professions-2/progress.md`: phase status and the phase-start commit record.
 - `docs/professions-2/implementation-plan.md`: team workflow and the review dispatch matrix.
 - `src/sim/professions/enchanting.ts`: `resolveDisenchant`, `resolveApplyEnchant` (do not change
@@ -32,15 +39,17 @@ surface, independent of the content phases around it, and salvage deliberately s
 ```
 This is Phase 13 of the Professions 2.0 feature: Enchanting reachable.
 Model: Opus 4.8, xhigh effort. Harness: Claude Code.
-Goal: make the finished enchanting sim (disenchant and enchant application) reachable by players
-in both hosts, from the bags UI through IWorld, the wire, and server dispatch.
+Goal: make the finished enchanting and salvage sims (disenchant, enchant application, salvage)
+reachable by players in both hosts, from the bags UI through IWorld, the wire, and server
+dispatch.
 
-STEP 0 - PRE-FLIGHT: run git status; the tree must be clean (a concurrent session may share this
+STEP 0 - PRE-FLIGHT:
 Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
 the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
 starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
 that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
 before proceeding. Never base work on main or an older release branch than the newest.
+Then run git status; the tree must be clean (a concurrent session may share this
 checkout); if it is dirty with work you did not create, stop and ask. Scan Claude Code memory
 (the MEMORY.md index) for: the node25 gate rule (run npm run gate under Node 24), combo recipes
 broken online (the #2033 ClientWorld stub trap: never land IWorld members as dead stubs; the
@@ -50,12 +59,15 @@ phase-start commit hash for the QA session.
 
 STEP 1 - LOAD CONTEXT (do NOT read planning docs directly): spawn one Explore agent to read and
 summarize: docs/professions-2/state.md, docs/professions-2/progress.md,
-docs/professions-2/phase-13-enchanting.md, src/sim/professions/enchanting.ts, the
-lastDisenchantResult/lastEnchantResult stashes and command plumbing in src/sim/sim.ts,
+docs/professions-2/phase-13-enchanting.md, src/sim/professions/enchanting.ts,
+src/sim/professions/salvage.ts, the
+lastSalvageResult/lastDisenchantResult/lastEnchantResult stashes and command plumbing in
+src/sim/sim.ts,
 src/world_api/professions.ts, the cprof/ncd/gprof wiring in src/net/online.ts, the command
 dispatch in server/game.ts, the bags context menu surface in src/ui/, and the CLAUDE.md files
 for src/sim/, src/world_api/, src/ui/, and server/. The summary must return: the exact
-signatures and result shapes of resolveDisenchant and resolveApplyEnchant; where the last-result
+signatures and result shapes of resolveDisenchant, resolveApplyEnchant, and resolveSalvage;
+where the last-result
 stashes live and how existing last-result reads reach IWorld; the self-wire delta-key recipe and
 its pins (ALL_DELTA_KEYS + TERSE_TO_IWORLD in tests/snapshots.test.ts); how bags context actions
 and confirm dialogs are built today; the state.md validation rows for net/wire, ui/render, and
@@ -66,15 +78,17 @@ wire keys), then fan out the ui agent and the tests agent in parallel against th
 Each agent gets ONLY the Explore summary plus its deliverables below, never the planning docs.
 
 Agent seam deliverables:
-- IWorld members on src/world_api/professions.ts: disenchantItem and applyEnchant commands plus
-  last-result reads mirroring lastDisenchantResult/lastEnchantResult (typed views, not raw sim
+- IWorld members on src/world_api/professions.ts: disenchantItem, applyEnchant, and
+  salvageItem commands plus last-result reads mirroring
+  lastDisenchantResult/lastEnchantResult/lastSalvageResult (typed views, not raw sim
   objects).
 - Implement in BOTH Sim and ClientWorld in the same change. The ClientWorld arm must be LIVE
   (the #2033 stub trap): commands go over the wire, and results mirror back on a delta key
   following the ncd/gprof self-wire pattern.
 - server/game.ts dispatch: proximity, ownership, and eligibility are re-checked server-side and
   never trusted from the client; destruction and grants resolve server-side and are replay-safe
-  (a replayed or duplicated command cannot double-destroy an item or double-grant dust).
+  (a replayed or duplicated command cannot double-destroy an item or double-grant dust or
+  salvage returns), for all three commands.
 - Update the parity pin in tests/world_api_parity.test.ts and the ALL_DELTA_KEYS +
   TERSE_TO_IWORLD pins in tests/snapshots.test.ts in the same change.
 
@@ -88,12 +102,16 @@ Agent ui deliverables:
   re-localized by the client matcher (the S3 duty, tests/localization_fixes.test.ts).
 - Enchanting skill visible in the wheel window (it levels via the existing #1712 gains; display
   only, no new leveling logic).
-- Salvage stays wave 2: do NOT wire it; leave a short comment at the salvage sim surface marking
-  the exclusion as deliberate.
+- Bags context action Salvage on eligible crafted gear, behind the SAME confirm-dialog
+  machinery as Disenchant (destructive; masterwork and signed instances get the stronger
+  warning). One confirm family serves all three actions; do not build a second dialog pattern.
 
 Agent tests deliverables:
-- Command tests: server-side validation (proximity, ownership, eligibility), replay and
-  duplicate safety on destruction and grants, and the offline Sim path.
+- Command tests for ALL THREE commands (disenchant, enchant-apply, salvage): server-side
+  validation (proximity, ownership, eligibility), replay and
+  duplicate safety on destruction and grants, and the offline Sim path. Keep the existing
+  salvage sim suite green by name (find it beside tests/professions_enchanting.test.ts)
+  and run it in STEP 3.
 - Parity and wire tests: both-worlds LIVENESS for the new members (results actually arrive and
   update in ClientWorld), not just member shape.
 - UI tests: context-action eligibility, the confirm path, and the signed/masterwork warning
@@ -113,7 +131,7 @@ INVARIANTS THIS PHASE MUST KEEP:
   changes behavior unless the player invokes the new actions.
 
 Out of scope (do NOT do in this phase):
-- Salvage wiring (wave 2; the sim module stays dormant).
+- Batch or salvage-all UI (wave 2 polish; single-item salvage only this phase).
 - Enchanting recipe or content depth.
 - Tool-enchant reframing (wave 2+).
 
@@ -135,20 +153,22 @@ STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
 
 STEP 4 - COMMIT CADENCE: commit with explicit paths (never git add -A); every commit carries a
 body saying what changed and why:
-- feat(professions): expose disenchant and enchant-apply through IWorld and the wire
-- feat(ui): bags disenchant and enchant-apply actions with destruction confirm
+- feat(professions): expose disenchant, enchant-apply, and salvage through IWorld and the wire
+- feat(ui): bags disenchant, enchant-apply, and salvage actions with destruction confirm
 - docs(professions-2): record phase 13 surfaces in state.md and progress.md
 
 STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
 - [ ] A player can disenchant an eligible junk item into dust offline (Sim) and online
       (ClientWorld against the server).
 - [ ] A player can apply an enchant consumable to eligible gear offline and online.
-- [ ] A replayed or duplicated command cannot double-grant dust or double-destroy an item.
+- [ ] A player can salvage eligible crafted gear into materials offline and online, behind
+      the confirm (and the stronger signed/masterwork warning).
+- [ ] A replayed or duplicated command cannot double-grant dust or salvage returns, or
+      double-destroy an item, for any of the three commands.
 - [ ] Destroying a signed or masterwork instance requires the explicit warning path.
 - [ ] The new IWorld members are live in BOTH worlds; parity and snapshot pins updated in the
       same change.
 - [ ] The enchanting skill shows in the wheel window.
-- [ ] Salvage remains unwired and the exclusion is noted as deliberate.
 - [ ] All validation rows above are green; the mobile screenshot is committed.
 
 STEP 6 - DOC UPDATES + MEMORY: update docs/professions-2/progress.md (phase 13 checklist, status,

--- a/docs/professions-2/phase-13-qa.md
+++ b/docs/professions-2/phase-13-qa.md
@@ -1,7 +1,7 @@
 # Phase 13 QA: Verify Enchanting reachable
 
-Audits the Phase 13 diff: enchanting reachable in both hosts, replay-safe destruction, live
-`ClientWorld` result mirroring, and complete tests and i18n for this phase.
+Audits the Phase 13 diff: enchanting AND salvage reachable in both hosts, replay-safe
+destruction, live `ClientWorld` result mirroring, and complete tests and i18n for this phase.
 
 ## QA Starter Prompt
 
@@ -30,7 +30,8 @@ STEP 2 - QA AUDIT: spawn three parallel agents, each given ONLY the Explore summ
   tests/env_protocol.test.ts tests/bandwidth.test.ts tests/world_api_parity.test.ts; npx vitest
   run tests/professions_enchanting.test.ts plus the phase's new test files; npm run i18n:gen
   then npx vitest run tests/i18n_completeness.test.ts tests/localization_fixes.test.ts; npx tsc
-  --noEmit); exercise the REAL behavior: actually disenchant an item and apply an enchant in the
+  --noEmit); exercise the REAL behavior: actually disenchant an item, apply an enchant, and
+  salvage a crafted item in the
   offline sim and against a running server, not just through the tests.
 - Test coverage agent: find untested paths (server rejection branches, the signed/masterwork
   warning path, ClientWorld result mirroring, duplicate-command handling); add missing tests,
@@ -47,17 +48,21 @@ If any agent's output is truncated, re-spawn it to resume from its last complete
 restart finished work.
 
 PHASE-SPECIFIC QA EMPHASIS (probe these directly, not just by reading):
-- Replay and race safety on destruction: fire the same disenchant command twice (duplicate and
-  replay) and prove exactly one destruction and one grant; race a disenchant against a
+- Replay and race safety on destruction: fire the same disenchant and salvage commands twice
+  (duplicate and
+  replay) and prove exactly one destruction and one grant; race each against a
   concurrent move or trade of the same item and prove no dupe or double-destroy.
-- ClientWorld last-result mirroring: confirm the lastDisenchantResult/lastEnchantResult reads
+- ClientWorld last-result mirroring: confirm the
+  lastDisenchantResult/lastEnchantResult/lastSalvageResult reads
   are LIVE in ClientWorld (values actually arrive over the wire and update after each command),
-  not shape-only stubs (the #2033 trap).
+  not shape-only stubs (the #2033 trap). lastSalvageResult is the one brand-new read: probe it
+  hardest.
 - Confirm-dialog focus trap: keyboard focus stays inside the confirm dialog, Escape cancels,
   and Enter cannot silently destroy a signed or masterwork instance without the explicit
   warning path.
 - Prime directive spot check: no existing bags, trade, equip, or bank flow changed behavior
-  unless the player invokes the new actions; salvage remains unwired and marked deliberate.
+  unless the player invokes the new actions; salvage carries the same replay-safety and
+  warning guarantees as disenchant (probe it with the same duplicate/race protocol).
 
 STEP 3 - FIX: apply every BLOCKING and SHOULD-FIX finding; rerun the failed validation rows
 until green; commit with explicit paths (never git add -A), Conventional Commits with a body.

--- a/docs/professions-2/phase-14-attunement-quests.md
+++ b/docs/professions-2/phase-14-attunement-quests.md
@@ -1,7 +1,9 @@
 # Phase 14: Attunement quests and nudges
 
 This phase makes the identity journey live end to end: acceptance lore quests at the masters for
-all four wave-one archetypes, honest switching costs through repeatable make-amends quests, and
+all four wave-one archetypes, honest switching costs through repeatable make-amends quests, the
+masters' recurring pull (cadence-capped work-order quests and tier-crossing congratulation
+mail, the 2026-07-17 amendment), and
 the legibility layer (trend nudges that complete #1295, a pre-commit preview that explains
 everything, and the attunement celebration). It is its own slice because it is the first phase
 where the PR 2039 quest machinery, the Phase 7 trend classifier, and the Phase 8 masters meet in
@@ -38,7 +40,8 @@ the Phase 15 deed pass.
 This is Phase 14 of the Professions 2.0 feature: Attunement quests and nudges.
 Model: Opus 4.8, xhigh effort. Harness: Claude Code.
 Goal: make the identity journey live end to end: lore quests at the masters for all four
-wave-one archetypes, honest switching costs, and the legibility layer (nudges, complete
+wave-one archetypes, honest switching costs, the masters' recurring pull (work orders and
+tier mail), and the legibility layer (nudges, complete
 pre-commit preview, celebration).
 
 STEP 0 - PRE-FLIGHT:
@@ -93,6 +96,14 @@ Agent content deliverables:
 - Retire the placeholder quest rows q_archetype_acceptance and q_prof_make_amends cleanly:
   remove the content rows, their i18n keys, and their locale fills per the workflow rules;
   no dangling questIds or orphaned references anywhere.
+- One repeatable work-order quest per master (six total; the 2026-07-17 amendment): a
+  cadence-capped craft-objective turn-in ("the master needs N of X") on QuestDef.repeatable
+  plus the 2039 craft objective, consuming that master's craft materials: a recurring
+  material sink with a face on it. Rewards use the state.md work-order tuning target
+  (MAINTAINER numbers; stop and ask if they are still absent; never gold-positive against
+  the input vendor value) and the cadence cap reuses the nudge cadence pattern so the loop
+  can never become an unbounded XP or gold faucet (the q_prof_hobby_switch lesson in
+  state.md OPEN items).
 
 Agent sim deliverables:
 - Switch cost wiring: the escalation formula resolves in the sim through the make-amends
@@ -101,6 +112,12 @@ Agent sim deliverables:
   classifier, then a letter-voice follow-up; both cadence-capped so they can never spam.
 - The tutorial panel fires exactly once, at the first cap moment, and never again for that
   character.
+- Tier-crossing mail (the 2026-07-17 amendment): a one-shot-per-tier congratulation letter
+  from the attuned archetype's ANCHOR master (the giver of its lore quest, always the
+  zone 1 master under the state.md assignment) when a MAJOR craft crosses a
+  TIER_SKILL_STEP boundary, in the Phase 7 letter voice and delivery infra; one-shot flags
+  per tier, cadence-safe, never for hobby or dormant crafts, never for unattuned
+  characters (the Phase 7 Guild letter owns that moment).
 
 Agent ui deliverables:
 - Attunement preview completeness: the preview (identity card/view plus the quest dialog
@@ -117,6 +134,9 @@ Agent tests deliverables:
   the preview return cost line; matcher coverage for the broadcast and nudge strings.
 - A determinism test for the new sim logic (nudge cadence and switch cost resolution under
   a fixed seed).
+- Work-order and tier-mail tests: work-order credit and its cadence cap (a loop of
+  immediate re-turn-ins is bounded and never gold-positive); the tier mail fires exactly
+  once per tier per craft, only for attuned majors, and never re-fires on load.
 - Remove tests pinned to the retired placeholder quests; re-pin deliberately where behavior
   moved to the new quests.
 
@@ -164,7 +184,8 @@ BLOCKING finding stands.
 STEP 4 - COMMIT CADENCE:
 Commit in slices with explicit paths, never git add -A; every commit carries a body:
 - feat(content): archetype lore quests at the wave-one masters
-- feat(professions): switch costs and nudge cadence
+- feat(content): work-order quests at the masters
+- feat(professions): switch costs, nudge cadence, and tier-crossing mail
 - feat(ui): attunement preview and celebration
 
 STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
@@ -180,6 +201,11 @@ STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
       tutorial panel fires exactly once at the first cap moment.
 - [ ] Attunement celebration lands: banner, title grant, id-based zone broadcast with
       matcher coverage; deed hook present but inert.
+- [ ] Each master offers its cadence-capped work order; turning one in consumes the
+      materials and cannot be looped for unbounded XP or gold.
+- [ ] Crossing a major-craft tier delivers exactly one congratulation mail from the
+      archetype's master; re-crossings, hobby crossings, and unattuned characters deliver
+      none.
 - [ ] q_archetype_acceptance and q_prof_make_amends are fully retired: no content rows,
       i18n keys, locale fills, tests, or questIds references remain.
 - [ ] Players attuned via 2039's intro quest keep their state; mid-quest placeholder
@@ -189,8 +215,9 @@ STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
 STEP 6 - DOC UPDATES + MEMORY:
 Update docs/professions-2/progress.md (status table row, Phase 14 checklist, notes with the
 phase-start commit and any deferrals). Update docs/professions-2/state.md: the New surfaces
-per phase list gains the Phase 14 entry (the four lore quest ids and the make-amends quest
-ids, the nudge cadence surface and its i18n key namespaces, the celebration broadcast id and
+per phase list gains the Phase 14 entry (the four lore quest ids, the make-amends quest
+ids, the six work-order quest ids and their cadence cap, the tier-mail one-shot flags, the
+nudge cadence surface and its i18n key namespaces, the celebration broadcast id and
 matcher rule, and the note that the placeholder quest rows are gone). Record surprises to
 Claude Code memory.
 

--- a/docs/professions-2/phase-14-qa.md
+++ b/docs/professions-2/phase-14-qa.md
@@ -112,3 +112,10 @@ STOPPING RULES:
   make-amends return cost all visible before commit, with no commit path that skips the preview.
 - Broadcast matcher coverage: the celebration zone broadcast and both nudge voices re-localize
   via the matchers; the S3 guard is green with `src/sim/quests/quest_commands.ts` in scope.
+- Work orders (the 2026-07-17 amendment): each master offers its repeatable work order; a
+  loop of immediate re-turn-ins is BOUNDED by the cadence cap and never gold-positive
+  against the input vendor value; the turn-in consumes the materials (a recurring sink,
+  not a faucet); probe the loop with a real repeated turn-in, not a formula read.
+- Tier-crossing mail (the 2026-07-17 amendment): exactly one letter per tier per major
+  craft, from the archetype's anchor master; re-crossings, hobby and dormant crossings,
+  unattuned characters, and repeated loads deliver none.

--- a/docs/professions-2/phase-15-deeds-polish.md
+++ b/docs/professions-2/phase-15-deeds-polish.md
@@ -23,7 +23,7 @@ be judged against the live system, and the wiki can tell the truth.
 - `tests/deeds_content.test.ts` and `tests/deeds.test.ts`: the catalog pin (append-only proof)
   and trigger behavior suites.
 - Tuning constant homes named in `state.md`: the masterwork proc constants (Phase 2), the
-  pristine vein cadence (Phase 4), the training fees (Phase 9), and the #1301 craft fee and
+  rare-event cadence (Phase 4, one shared knob), the training fees (Phase 9), and the #1301 craft fee and
   throttle constants in the crafting resolver path.
 - `src/guide/pages/professions.ts` plus the wiki content generator (`npm run wiki:content`,
   freshness-gated by `tests/guide.test.ts`); conventions in `src/guide/CLAUDE.md`.
@@ -59,7 +59,7 @@ Spawn one Explore agent to read and summarize:
 - docs/design/deeds.md, src/sim/content/deeds.ts, src/sim/deeds.ts,
   tests/deeds_content.test.ts, tests/deeds.test.ts.
 - The tuning constant files named in state.md's "New surfaces per phase" appendix (masterwork
-  proc, pristine vein cadence, training fees, the #1301 fee and throttle).
+  proc, rare-event cadence, training fees, the #1301 fee and throttle).
 - src/guide/pages/professions.ts and the wiki generator path, plus src/guide/CLAUDE.md,
   src/sim/CLAUDE.md, and tests/CLAUDE.md.
 The summary must return: the locked deed scope and tuning targets verbatim from state.md; the
@@ -77,8 +77,16 @@ matrix (see STEP 3).
 Agent deeds deliverables:
 - Register the basic universal profession deeds in src/sim/content/deeds.ts with triggers wired
   in src/sim/deeds.ts: first craft, first masterwork, first attunement, per-craft tier
-  milestones (rare tier), and the pristine vein find. The rare fish deed already exists: verify
+  milestones (rare tier), the Specialist deed at the 75-skill specialization threshold, and
+  the rare-find deeds for the Phase 4 event flavors (pristine vein, ancient heartwood,
+  moonlit bloom) plus the Phase 10 perfect specimen. The rare fish deed already exists: verify
   it, do not duplicate it.
+- Notability through the deeds pipeline (the 2026-07-17 ruling): first attunement and first
+  masterwork carry TITLE rewards and marquee-tier renown (>= 25) so the existing pipeline
+  fires in full: nameplate title, banner, fireworks gate, celebration sound,
+  guild-and-friends marquee broadcast, Renown board. Deed titles are the nameplate surface
+  (archetype titles do not render on nameplates; the Phase 1 QA drift note). Still
+  cosmetic-only, still append-only.
 - Icons via the category crest fallback (no bespoke art required; note any bespoke-worthy slot
   in asset-manifest.json instead).
 - Deed i18n added English-only by deed id per the deeds recipe; catalog pins in
@@ -87,16 +95,25 @@ Agent deeds deliverables:
 - A scripted playthrough test (Vitest driving the real Sim) that unlocks every new deed.
 
 Agent tuning deliverables:
-- Review masterwork proc bounds, training fees, pristine vein cadence, and the #1301 craft fee
-  and throttle against the state.md tuning targets, applying the maintainer's numbers. If a
+- Review masterwork proc bounds, training fees, teach tiers, work-order rewards, the
+  rare-event cadence, and the #1301 craft fee
+  and throttle against the state.md tuning targets, applying the maintainer's numbers. The
+  rare-event cadence review decides per FAMILY: the Phase 4 shared knob may split into
+  per-flavor cadences (vein, heartwood, bloom) with maintainer numbers if live data says
+  the families need different rhythms. If a
   maintainer number is missing for any constant, stop and ask; never invent balance numbers.
 - Every constant is a NAMED export in its owning module; none inline at a call site. Pin each
   final value in the matching test.
+- Faucet-vs-sink review (the 2026-07-17 amendment): with live data, weigh the material and
+  gold faucets (gathering, work-order rewards, quest gold) against the sinks (consumables,
+  crafting inputs, salvage and disenchant destruction, training and craft fees) and record
+  the balance with evidence in the phase notes; revisit the commissions (#1298) wave
+  assignment with that evidence and file the follow-up on epic #1866.
 
 Agent guide deliverables:
 - Rewrite the guide/wiki professions page (src/guide/pages/professions.ts) to describe the
   SHIPPED system: archetypes and attunement, masterworks, stations and masters, training,
-  gathering and pristine veins, fishing, enchanting reach, and the deeds. Recipe and station
+  gathering and the rare events, fishing, enchanting reach, salvage, and the deeds. Recipe and station
   data must feed the page from src/sim/ content, not hand-copied tables.
 - npm run wiki:content regenerated and the freshness gate (tests/guide.test.ts) green; any new
   guide.* prose keys added English-only.
@@ -125,7 +142,8 @@ INVARIANTS THIS PHASE MUST KEEP:
 
 Out of scope (do NOT do in this phase):
 - Anything wave 2: market/mail instance carriage (#1146), commissions and boundTo (#1298),
-  Jack of All Trades (#1296), monster-harvest proficiency, salvage UI, battlefield experience
+  Jack of All Trades (#1296), monster-harvest proficiency, batch salvage UI (single-item
+  salvage landed in Phase 13), battlefield experience
   expansion, item biographies, tool effects (parked and dormant), jewelcrafting or inscription
   depth.
 - No new deed UI systems; the deeds window and celebration pipeline already exist.
@@ -161,8 +179,12 @@ sentences on what changed and why), Conventional Commits with a scope:
 
 STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
 - [ ] Every deed in the packet is unlockable in a scripted playthrough (the Vitest run proves
-      first craft, first masterwork, first attunement, rare-tier milestones, the rare fish, and
-      the pristine vein find all unlock).
+      first craft, first masterwork, first attunement, rare-tier milestones, the Specialist,
+      the rare fish, and every rare-find deed all unlock).
+- [ ] First attunement and first masterwork deeds carry titles and marquee-tier renown; the
+      scripted playthrough proves the nameplate title, banner, and marquee broadcast fire.
+- [ ] The faucet-vs-sink review is recorded with evidence and the commissions follow-up
+      filed on epic #1866.
 - [ ] tests/deeds_content.test.ts pins the catalog append-only; all pre-packet deeds unchanged.
 - [ ] Every tuning constant is named, exported, pinned, and matches the maintainer's numbers.
 - [ ] The wiki professions page describes the shipped system; npm run wiki:content freshness

--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -111,19 +111,22 @@ harmless to an old client.
 ### Phase 4: Node materials and pristine veins
 - [ ] Per-rarity node material tables replace placeholder junk (zone-1 stays low-tier)
 - [ ] Rare+ node yields signed like corpse yields
-- [ ] Pristine vein rare event (spawn, soft broadcast, deed mark)
+- [ ] Per-node-type rare events: pristine vein / ancient heartwood / moonlit bloom (spawns, per-flavor soft broadcasts, deed-mark hooks)
 - [ ] `gatherResult` consumed: gather cue + rarity-colored loot line
 
 ### Phase 5: The professions wheel window
 - [ ] New window at deeds quality per DESIGN.md: view core (UI_PURE_CORES), painter, styles, i18n
 - [ ] Ring visualization, per-craft skill bars, tier pips, title/majors/hobby, live perks
+- [ ] Identity-view semantics preserved (role, ceiling, nudges, tutorial); next-unlock and switch-cost lines
+- [ ] Progressive disclosure: simplified unattuned / pre-first-tier state
 - [ ] Desktop + mobile responsive; screenshots captured for the PR
 - [ ] Launchers (minimap or window row + keybind) consistent with existing windows
 
 ### Phase 6: Crafting window upgrades and celebrations
 - [ ] Recipe rows show profession + required skill + skill-gain difficulty tint (#2037)
 - [ ] Combo rows name their requirement; station-bound rows show a badge and disable reason
-- [ ] Masterwork toast + zone-chat broadcast; maker's mark and masterwork in item tooltips
+- [ ] Masterwork toast + zone-visible broadcast (Phase 4 soft-zone mechanism); tier-up toasts; maker's mark and masterwork in item tooltips
+- [ ] Online inspect carries instance payloads (identity wire extended, parity pinned)
 - [ ] Craft button never lies: same eligibility rule as the sim in both hosts
 
 ### Phase 7: The Guild letter and quest objectives
@@ -132,14 +135,14 @@ harmless to an old client.
 - [ ] S3 scanner gap closed: `src/sim/quests/quest_commands.ts` in scan scope, guard test updated
 
 ### Phase 8: Stations and masters (sim and server)
-- [ ] Station registry generalizes `requiresHubStation` to typed stations (forge, kitchens, apothecary, tannery, loom)
-- [ ] Master NPC content records (shop, teach, quest-hook capable) for the six deep crafts
+- [ ] Station registry generalizes `requiresHubStation` to typed stations (forge, kitchens, apothecary, tannery, loom, toolworks); `CRAFTING_HUB_MIN_LEVEL` retired
+- [ ] Master NPC records for the six deep crafts, spread across the three zone hubs (four archetype anchors in zone 1; tannery in Fenbridge; apothecary in Highwatch; assignment pinned)
 - [ ] Automated placement-safety test: no profession NPC or station within aggro-plus-buffer of hostile spawns
 - [ ] Mobile crafting station perk activates (bypasses the station gate; specialization-gated)
 
 ### Phase 9: Station presence and recipe training
 - [ ] Stations render as world props; masters render and are interactable; minimap markers
-- [ ] Recipe training at masters on the `acquireRecipe` gate; every existing recipe grandfathered known
+- [ ] Skill-tier-gated recipe training at masters on the `acquireRecipe` gate, with the visible locked-row ladder; every existing recipe grandfathered known
 - [ ] Master shops stocked (base tools, reagents); training fees are gold sinks
 - [ ] Hands-vs-stations split live: field recipes craft anywhere, uncommon+ at stations
 
@@ -147,6 +150,7 @@ harmless to an old client.
 - [ ] Tier ladders for all six deep crafts (common through rare at minimum) with material families
 - [ ] Cloth sourcing: humanoid components + plant fiber; corpse component quest-item collision ended
 - [ ] Economy invariant test pinned: no recipe vendors for more than its inputs
+- [ ] Cross-tier composition; combat-worthy consumables at every cooking/alchemy tier; materialTierBonus wired; the perfect specimen
 - [ ] Wiki content regenerated; recipe data feeds the guide
 
 ### Phase 11: Fishing joins the framework
@@ -159,24 +163,35 @@ harmless to an old client.
 - [ ] Tool effects remain parked (explicitly out of scope)
 
 ### Phase 13: Enchanting reachable
-- [ ] Disenchant + enchant-apply on IWorld, wire commands, bags context UI, both hosts
+- [ ] Disenchant + enchant-apply + salvage on IWorld, wire commands, bags context UI, both hosts
 - [ ] Enchanting skill visible in the wheel window
 
 ### Phase 14: Attunement quests and nudges
 - [ ] Acceptance lore quests at the masters for all four wave-one archetypes
 - [ ] Repeatable-quest support; make-amends wired; cheap-first-switch costs
 - [ ] Trend nudges (chat first, Guild letter voice); attunement summary explains everything before commit
+- [ ] Work-order quests per master (cadence-capped) and one-shot-per-tier master mail
 - [ ] Title celebration on attunement
 
 ### Phase 15: Deeds, tuning, and polish
-- [ ] Basic universal profession deeds (first craft, first masterwork, first attunement, tier milestones, the rare fish)
-- [ ] Economy tuning targets applied (#1301 fee/throttle, training fees, masterwork bounds)
+- [ ] Universal profession deeds incl. titles + marquee renown on first attunement and first masterwork, the Specialist deed, and the rare-find deeds (plus the rare fish, verified)
+- [ ] Economy tuning targets applied (#1301 fee/throttle, training fees, teach tiers, work orders, masterwork bounds); faucet-vs-sink review recorded
 - [ ] Guide/wiki professions page rewritten; asset manifest final
 - [ ] Whole-feature qa-checklist.md matrix green; packet teardown offered
 
 ## Notes
 
 (append per-phase notes, deferrals, and surprises here as sessions complete)
+
+2026-07-17 design-review amendments: a maintainer design review (the
+response to the external Codex review) amended the packet between Phases 2
+and 3. state.md records the rulings under "2026-07-17 design-review
+amendments"; the owning phase and QA files, the cross-cutting docs, and the
+asset manifest carry the updated deliverables (see the amendment PR's diff
+for the full file list). The any-signed masterwork condition ships as its
+own code change ahead of Phase 3, verified by the Phase 3 pre-flight. The
+checklists above were updated in the same pass; unchecked items describe
+the AMENDED deliverables.
 
 Phase 2 (2026-07-17): phase-start commit 9a5ce7a93 (the Phase 1 QA merge,
 the release/v0.27.0 head); code-final commit 90ba58f17 (the

--- a/docs/professions-2/qa-checklist.md
+++ b/docs/professions-2/qa-checklist.md
@@ -16,16 +16,16 @@ or screenshot path), not vibes.
 - [ ] Wire suites green: `npx vitest run tests/snapshots.test.ts tests/env_protocol.test.ts tests/bandwidth.test.ts`.
 
 ## Determinism
-- [ ] All new randomness (masterwork proc, pristine vein spawns, node rarity,
+- [ ] All new randomness (masterwork proc, rare gather events, node rarity,
       fishing catches) draws through `Rng` with pinned draw-order tests; no
       `Math.random` / `Date.now` / `performance.now` anywhere in `src/sim/`.
 - [ ] `npx vitest run tests/architecture.test.ts` green.
 - [ ] Same-seed determinism test covers a full gather-craft-masterwork sequence.
 
 ## Server authority
-- [ ] Every new command (train recipe, disenchant, enchant apply, quest
-      advance) validates server-side; the client never decides craft outcomes,
-      masterwork procs, harvest rewards, or quest credit.
+- [ ] Every new command (train recipe, disenchant, enchant apply, salvage,
+      quest advance) validates server-side; the client never decides craft
+      outcomes, masterwork procs, harvest rewards, or quest credit.
 - [ ] Invalid or replayed commands cannot duplicate rewards, recipes, or skill.
 
 ## Persistence
@@ -42,6 +42,12 @@ or screenshot path), not vibes.
       shops never buy crafted goods above trivial value.
 - [ ] Masterwork power stays within the tuning bounds in `state.md` (below the
       raid floor); baseline crafted gear sits below dungeon best-in-slot.
+- [ ] Recurring destruction is live: consumables at every cooking/alchemy
+      tier, salvage and disenchant, and the cadence-capped work orders all
+      consume materials or items in play; the Phase 15 faucet-vs-sink review
+      is recorded with evidence.
+- [ ] The masterwork signed-reagent term counts ANY player's signature
+      (buying a gatherer's signed materials works; the count-1 case works).
 
 ## i18n completeness
 - [ ] Every new player-visible string (window chrome, recipe rows, station
@@ -64,6 +70,8 @@ or screenshot path), not vibes.
       and committed under `docs/screenshots`, referenced from the PR body.
 - [ ] Tap targets comfortable; no hover-only information; safe areas respected.
 - [ ] Graphics-settings fairness: no preset hides actionable profession info.
+- [ ] The eight-step journey (the Phase 7 vertical-slice checkpoint)
+      re-verified end to end on the finished packet, desktop and mobile.
 
 ## Content integrity
 - [ ] Placement-safety test green: no profession NPC or station within
@@ -72,8 +80,18 @@ or screenshot path), not vibes.
       obtainable in-world; referential integrity tests green.
 - [ ] Corpse component rewards no longer grant unrelated quest credit; every
       mapped tag yields a real item.
+- [ ] Every gathering family has its rare-event fantasy and each fires,
+      localizes, and celebrates: pristine vein (ore), ancient heartwood
+      (wood), moonlit bloom (herb), the glimmerfin catch (fishing), the
+      perfect specimen (corpse harvesting).
+- [ ] The visible ladder holds end to end: locked Train rows name their tier
+      requirement, the wheel window's next-unlock and switch-cost lines
+      render, tier crossings toast (and mail for attuned majors), and a known
+      recipe is NEVER use-gated (the no-admission-gate rule).
 - [ ] All existing deeds remain earnable; new profession deeds registered and
-      pinned in `tests/deeds_content.test.ts`.
+      pinned in `tests/deeds_content.test.ts`; first attunement and first
+      masterwork carry titles and marquee-tier renown and the pipeline fires
+      (nameplate, banner, marquee broadcast).
 
 ## Classic fidelity and copy
 - [ ] No invented balance formulas where a classic-era reference exists; XP and

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -34,19 +34,26 @@ QA drift notes below). Next: Phase 3 (phase-03-parity-bug-fixes.md).
   revisit only if players report confusion. Confirmed in place at Phase 1
   (2026-07-17).
 - Masterwork model: deterministic outputs; proc chance from skill +
-  self-signed materials + specialization; bounded bonus stats baked via
+  signed materials + specialization; bounded bonus stats baked via
   src/sim/item_budget.ts into instance.rolled.stats; no five-way quality
   roll; trivialAt retired. Power bounds: baseline crafted below dungeon BiS;
   masterwork at dungeon-drop level, always below the raid floor.
-- RNG in, determinism out: input RNG (node rarity, pristine veins, fishing
-  catches, corpse components) stays and grows; output RNG is only the
-  masterwork proc (add-only, never a downgrade).
+  AMENDED 2026-07-17 (design review): the signed-reagent proc term counts
+  ANY player's signature, not only the crafter's own, and is decoupled from
+  the #1145 quantity-discount flag (a count-1 signed reagent qualifies).
+  The self-signed reagent-QUANTITY discount stays self-only. Ships as its
+  own code change ahead of Phase 3, not inside a phase.
+- RNG in, determinism out: input RNG (node rarity, the per-node-type rare
+  events, fishing catches, corpse components) stays and grows; output RNG is
+  only the masterwork proc (add-only, never a downgrade).
 - Hands vs stations: field recipes (a named FIELD_RECIPES subset) craft
   anywhere; every uncommon+ recipe requires its typed station. Stations are
   master NPCs (shop + teach + quest hooks) in guard-safe locations. The
   mobile-crafting-station specialization perk bypasses the gate.
 - Recipe acquisition: training at masters on the existing acquireRecipe gate;
   every recipe that exists before Phase 9 is grandfathered known on load.
+  AMENDED 2026-07-17: training is additionally skill-tier gated (see the
+  Phase 9 amendment below); the gate is on learning, never on use.
 - No skillReq admission gate on known recipes, ever (documented rule stands).
 - Pacing: fast early, slow top; scarcity (materials, adventure) is the clock.
 - Economy: players trade with players; NPCs only sink (training fees, tools,
@@ -54,11 +61,67 @@ QA drift notes below). Next: Phase 3 (phase-03-parity-bug-fixes.md).
   that no recipe vendors above its input value.
 - Deeds: basic universal only (first craft, first masterwork, first
   attunement, per-craft tier milestones, the rare fish). Cosmetic only.
+  AMENDED 2026-07-17: plus the Specialist deed and the rare-find deeds, and
+  first attunement / first masterwork carry titles and marquee-tier renown
+  (see the Phase 15 amendment below). Still cosmetic-only.
 - Identity costs: first attunement free; make-amends escalation stays
   5 + 3 * switchCount with cheap early costs.
 - Tool effects/charges/recharge: PARKED. Pure modules in
   src/sim/professions/tools.ts stay dormant; do not wire, do not delete.
-- Wave 2+ excluded from this packet (see implementation-plan.md).
+- Wave 2+ excluded from this packet (see implementation-plan.md); EXCEPTION
+  2026-07-17: salvage wiring moved INTO Phase 13 (see the amendments below).
+- 2026-07-17 design-review amendments (maintainer-approved; the response to
+  the external Codex review). Each binds its owning phase file, which
+  carries the full deliverable wording:
+  - Phase 4: the rare-event module ships PER-NODE-TYPE flavors on one
+    shared cadence knob: pristine vein (ore), ancient heartwood (wood),
+    moonlit bloom (herb); per-flavor broadcast ids and deed-mark hooks.
+    Fishing keeps the shipped glimmerfin catch; corpse harvesting gains
+    the perfect specimen component in Phase 10.
+  - Phase 5: the wheel window preserves the identity-view semantics (role,
+    ceiling, nudges, tutorial), adds a per-craft next-unlock line and a
+    client-computed switch-cost-at-rest line, and renders a SIMPLIFIED
+    pre-first-tier/unattuned state (progressive disclosure).
+  - Phase 6: the zone-visible masterwork broadcast rides the Phase 4
+    soft-zone-broadcast mechanism (the Phase 2 SimEvent is personal,
+    pid = crafter, and keeps feeding the crafter's own toast); online
+    inspect EXTENDS the identity wire with equipped instance payloads
+    (the Phase 2 QA drift decision resolves as extend); client-derived
+    tier-up toasts fire at every TIER_SKILL_STEP crossing.
+  - Phase 7 QA is the vertical-slice checkpoint: play the eight-step
+    journey end to end before wave one begins (see README).
+  - Phase 8: masters spread across the three zone hubs. Default
+    assignment: forge, kitchens, loom, toolworks in the zone 1 hub (every
+    wave-one archetype keeps a zone-1 anchor master); the tannery roots
+    in Fenbridge (zone 2); the apothecary in Highwatch (zone 3, keeping
+    the #1297 hub lore, dropping its level gate). CRAFTING_HUB_STATIONS
+    offsets are ZONE-3 coordinates and may seed only the Highwatch
+    placement. The mobile-station perk ships SPECIALIZATION-gated.
+  - Phase 9: recipe training is skill-tier gated at the masters. The
+    general predicate: a master teaches a recipe only at
+    tierForSkill(craft skill) >= tierForSkill(recipe skillReq). Wave-one
+    ladder: common always, uncommon at 25, rare at 50; any
+    higher-skillReq recipe a later phase authors (the existing
+    TOOL_RECIPES sit at 75/150 but are grandfathered known) gates by the
+    same formula with no extra rule. The gate is on LEARNING via
+    acquireRecipe, never on using a known recipe (the no-admission-gate
+    rule stands). Hobby crafts use the same thresholds. The Train view
+    always SHOWS locked rows with their named requirement (the visible
+    ladder).
+  - Phase 10: higher-tier recipes also consume some lower-tier materials;
+    cooking and alchemy carry combat-worthy consumables at EVERY tier;
+    the named Phase 2 materialTierBonus hook gets wired with real values.
+  - Phase 13: salvage wiring joins disenchant/enchant on the same seam
+    and confirm machinery (salvage.ts is already sim-complete).
+  - Phase 14: one cadence-capped repeatable work-order quest per master
+    (a recurring material sink with a face) and a one-shot-per-tier
+    congratulation mail from the attuned archetype's master.
+  - Phase 15: first attunement and first masterwork deeds carry TITLE
+    rewards and marquee-tier renown (>= 25) so the deeds pipeline
+    (nameplate title, banner, marquee broadcast, Renown board) celebrates
+    professions; a cosmetic Specialist deed lands at the 75-skill
+    threshold; a faucet-vs-sink review runs in the tuning pass. Still
+    basic, universal, cosmetic-only, append-only.
 
 ## Non-negotiable constraints
 
@@ -146,7 +209,8 @@ Phase 13), and interaction handlers return an outcome boolean (#1982).
   40; node yields are placeholder junk until Phase 4.
 - Salvage/disenchant/enchant: sim-complete in salvage.ts / enchanting.ts;
   lastSalvageResult/lastDisenchantResult/lastEnchantResult on PlayerMeta;
-  no IWorld/wire/UI until Phase 13 (salvage stays wave 2).
+  no IWorld/wire/UI until Phase 13 (salvage wiring JOINS Phase 13 per the
+  2026-07-17 amendments; it no longer waits for wave 2).
 - Stations today: requiresHubStation + CRAFTING_HUB_STATIONS (per-craft
   coordinates, unrendered) + canUseCraftingHubStation.
 - Icons: iconDataUrl(kind, id, size), procedural recipes + WebP override sets
@@ -304,9 +368,9 @@ tables, i18n key namespaces, files created)
   - Online inspect never carries equippedInstances (the identity wire
     has no instance payloads; offline builds them for the render
     mirror), so another player's masterwork and enchant stats are
-    invisible to online inspection. Pre-existing for enchants; Phase 6
-    (masterwork surfacing) decides whether to extend the identity wire
-    or accept the limitation.
+    invisible to online inspection. Pre-existing for enchants.
+    RESOLVED 2026-07-17: Phase 6 EXTENDS the identity wire (see the
+    design-review amendments above); the choice is no longer open.
   - Quality-roll retirement cleanup landed in QA: clampMaterialRarity
     and its private ladder deleted from gathering.ts (zero consumers
     after the craft-side clamp retirement); the professions CLAUDE.md
@@ -316,25 +380,36 @@ tables, i18n key namespaces, files created)
     ignores unknown SimEvent types, so a new server's masterwork event
     is harmless to an old client during a staged rollout.
 - Phase 3: (planned) hcb wire key (corpse claims); trade payload carriage.
-- Phase 4: (planned) node material tables; pristine vein event + deed mark.
+- Phase 4: (planned) node material tables; per-node-type rare events
+  (pristine vein / ancient heartwood / moonlit bloom) + deed-mark hooks.
 - Phase 5: (planned) professions window (.window id professions-window) +
   view core + painter + hudChrome.professions.* keys.
 - Phase 7: (planned) trend detection module; Guild letter content; S3 scan
   list gains src/sim/quests/quest_commands.ts.
-- Phase 8: (planned) station registry (typed stations); master NpcDefs;
-  placement-safety test.
-- Phase 13: (planned) disenchantItem/applyEnchant IWorld members + wire
-  commands.
+- Phase 8: (planned) station registry (typed stations, multi-zone); master
+  NpcDefs across the three hubs; placement-safety test.
+- Phase 13: (planned) disenchantItem/applyEnchant/salvageItem IWorld
+  members + wire commands.
 
 ## Tuning targets (placeholders until Phase 15 tunes against live data)
 
 - Masterwork proc: base 3 percent at recipe tier parity, +1 percent per tier
-  of skill above, +2 percent with any self-signed reagent, +3 percent at the
-  75-skill specialization threshold; cap 15 percent. Masterwork bonus: +1
-  quality tier for the stat budget, never above the raid floor band.
+  of skill above, +2 percent with any signed reagent (any player's
+  signature; decoupled from the quantity-discount flag per the 2026-07-17
+  amendment), +3 percent at the 75-skill specialization threshold; cap 15
+  percent. Masterwork bonus: +1 quality tier for the stat budget, never
+  above the raid floor band.
 - Training fees: common tier free (starter recipes), uncommon 25s, rare 1g.
+- Teach tiers (Phase 9): the general predicate is tierForSkill(craft skill)
+  >= tierForSkill(recipe skillReq); the wave-one ladder is common always,
+  uncommon at 25 skill, rare at 50. Hobby crafts use the same thresholds.
 - Craft fee (#1301) and throttle: unchanged until live data.
-- Pristine vein: roughly 1 per zone per 20 minutes, 5x yield, always signed.
+- Rare gather events (all three node flavors): roughly 1 per zone per 20
+  minutes, 5x yield, always signed; one shared cadence knob until Phase 15
+  tunes per family.
+- Work-order quests (Phase 14): reward numbers need MAINTAINER numbers
+  before Phase 14 runs (never gold-positive against the input vendor value;
+  the cadence cap reuses the nudge cadence pattern). Flagged in OPEN items.
 
 ## OPEN items
 
@@ -344,6 +419,8 @@ tables, i18n key namespaces, files created)
   Phase 5 (the wheel window). Each UI phase probes the rollout state at
   session start (see implementation-plan.md guardrails) and uses the new
   vocabulary once it exists; until then, today's tokens, grammar-ready.
+  Relief valve (2026-07-17): Phase 6 depends on Phases 2 and 4, not on
+  Phase 5, and may leapfrog the wheel window if the rollout stalls it.
 
 - RESOLVED (2026-07-16): the maintainer owns the PR 2039 branch outright.
   Phase 1 amendments (ring reorder, pair titles, review fixes, release sync,
@@ -365,3 +442,14 @@ tables, i18n key namespaces, files created)
   player can ping-pong the hobby between the two candidates for 75 XP per
   cycle. Maintainer decision (xpReward 0, or drop repeatable) in a tuning
   phase; do not change balance numbers inside QA.
+- Master-to-zone assignment (2026-07-17 default): forge, kitchens, loom,
+  toolworks in Eastbrook; tannery in Fenbridge; apothecary in Highwatch.
+  The maintainer may reshuffle in the Phase 8 PR review; positions are
+  data-only records, so a move is cheap before Phase 9 renders them.
+- Work-order reward numbers (see Tuning targets): maintainer numbers
+  required before Phase 14 runs; never invent balance numbers.
+- Masterwork discovery-deed credit: a masterwork copy credits its DEF
+  quality toward discovery deeds, never the bumped tier (Phase 2 QA drift
+  note, intended). Flagged 2026-07-17 for a maintainer call; if masterworks
+  should credit the bumped tier, that is a deliberate design change for a
+  tuning phase, never a QA fix.


### PR DESCRIPTION
## Summary

Records the maintainer-approved outcome of the 2026-07-17 professions design review (the response to the external Codex review of the Professions 2.0 packet) as binding amendments, so Phases 3 through 15 execute against the amended spec. `state.md` gains the rulings block; every owning phase file, its QA file, the cross-cutting docs (README, implementation-plan, progress, qa-checklist), and the asset manifest carry the updated deliverables.

The rulings, one line each:

- The masterwork signed-reagent proc term counts ANY player's signature and is decoupled from the quantity-discount flag (ships as its own code change, next PR; the quantity discount stays self-only).
- Recipe training is skill-tier gated at the masters (general predicate: `tierForSkill(skill) >= tierForSkill(recipe.skillReq)`; wave-one ladder common/25/50) with locked rows always visible in the Train view: the unlock ladder lives on LEARNING, and known recipes are never use-gated.
- Masters spread across the three zone hubs (four archetype anchors in Eastbrook, tannery in Fenbridge, apothecary in Highwatch keeping the #1297 hub lore); the phase-08 zone-3 coordinate contradiction is resolved and `CRAFTING_HUB_MIN_LEVEL` is deliberately retired.
- The Phase 4 rare event ships per-node-type flavors (pristine vein / ancient heartwood / moonlit bloom); the perfect specimen corpse component joins Phase 10, so every gathering family has a jackpot.
- Salvage wiring joins Phase 13 beside disenchant (the sim is already complete).
- Profession deeds celebrate through the deeds pipeline: titles plus marquee-tier renown on first attunement and first masterwork, a Specialist deed at 75.
- Masters gain recurring pull: cadence-capped work-order quests and one-shot-per-tier congratulation mail (Phase 14).
- Phase 6 resolves the masterwork broadcast audience (zone-visible via the Phase 4 soft-zone mechanism), extends the identity wire so masterworks are inspectable online, and adds tier-up toasts.
- End of Phase 7 is the vertical-slice checkpoint: Phase 7 QA plays the eight-step journey end to end before wave one begins; Phase 6 may leapfrog Phase 5 if the design-language rollout stalls the wheel window.

## Related issues

Part of #1866.

## Type of change

- [x] Documentation

## How was this tested?

- Commands: dash/emoji scan over the diff (clean); `asset-manifest.json` parsed with `json.load` (valid); stale-reference sweeps for the superseded wording (self-signed-only, salvage-as-wave-2, zone-1-only placement, single rare event); pre-push floor (tsc, guard tests, biome, copy scan) green under Node 24.
- Review: a four-lens adversarial workflow over the diff (cross-file consistency, approved-scope coverage, code-truth of every phase premise, style/executability); all BLOCKING and SHOULD-FIX findings fixed in this diff, including mirroring every amended phase's QA prompt and verifying each premise (resolveHarvest node-type visibility, the personal masterwork SimEvent, `tierForSkill`, `resolveSalvage`, `ZONE2_NPCS`/`ZONE3_NPCS`, the quantity-discount coupling) against the shipped code.

## Screenshots / recordings

N/A (docs only).
