### PR TITLE
feat(professions): count any signed reagent toward the masterwork proc

### DIFF
--- a/src/sim/professions/crafting.ts
+++ b/src/sim/professions/crafting.ts
@@ -51,6 +51,14 @@
 // specialized crafter using their own self-signed material gets both
 // benefits and neither discount can ever waive a reagent entirely.
 //
+// The masterwork proc's signed-reagent term (masterwork.ts) is DELIBERATELY
+// wider than #1145 (the 2026-07-17 design ruling): it counts a held signed
+// instance with ANY player's signature, the crafter's own included, so buying
+// a gatherer's signed materials is worth as much to the proc as gathering
+// your own. It is also decoupled from the quantity discount: a count-1 signed
+// reagent feeds the proc even though the discount can never fire for it. Only
+// the quantity discount stays self-only.
+//
 // Combo-recipe requirement (issue #1132): a recipe may carry a
 // `comboRequirement` naming one specific adjacent craft pair and a minimum
 // tier both must meet. The character must be attuned to that exact unordered
@@ -202,6 +210,14 @@ function hasSelfSignedInstance(meta: PlayerMeta, itemId: string): boolean {
   return meta.inventory.some((s) => s.itemId === itemId && s.instance?.signer === meta.name);
 }
 
+/** Whether `meta` holds an inventory slot for `itemId` carrying a signed
+ *  instance with ANY signer (the crafter's own name included). Feeds the
+ *  masterwork proc's signed-reagent term (2026-07-17 ruling); the #1145
+ *  quantity discount keeps using the self-only check above. */
+function hasSignedInstance(meta: PlayerMeta, itemId: string): boolean {
+  return meta.inventory.some((s) => s.itemId === itemId && !!s.instance?.signer);
+}
+
 /** The result of resolving one reagent's required quantity: the final count
  *  after both discounts compose, plus whether the #1145 self-signed
  *  reduction specifically (not the composed total) actually lowered it. */
@@ -347,9 +363,14 @@ export function resolveCraftForRecipe(
   }
   const craftSkills = meta ? meta.craftSkills : {};
   let selfSignedBonusApplied = false;
+  // The masterwork signed-reagent input: a holding check over the recipe's
+  // reagents BEFORE consumption (removeItem consumes end-backward, so the
+  // signed copy itself may be what gets consumed), any signer counting.
+  let signedReagentUsed = false;
   for (const reagent of recipe.reagents) {
     const required = requiredReagentCount(meta, reagent, craftSkills, recipe.professionId);
     if (required.selfSignedBonusApplied) selfSignedBonusApplied = true;
+    if (meta && hasSignedInstance(meta, reagent.itemId)) signedReagentUsed = true;
     ctx.removeItem(reagent.itemId, required.count, pid);
   }
   // Masterwork proc draw (Phase 2): the single output-side rng draw, at the
@@ -389,7 +410,7 @@ export function resolveCraftForRecipe(
   const procChance = masterworkProcChance({
     tiersAboveRecipe:
       tierCapability(craftSkills, recipe.professionId) - tierForSkill(recipe.skillReq),
-    selfSignedReagent: selfSignedBonusApplied,
+    signedReagent: signedReagentUsed,
     specialized: isSpecialized(craftSkills, recipe.professionId),
   });
   // Effect gate (gates the EFFECT, never the draw): the def must bake a

--- a/src/sim/professions/masterwork.ts
+++ b/src/sim/professions/masterwork.ts
@@ -15,13 +15,16 @@
 import { normalizePrimaryStats, PRIMARY_STATS, primaryStatBudget } from '../item_budget';
 import type { CoreStats, ItemDef, ItemSlot } from '../types';
 
-// Locked Phase 2 tuning: base chance at recipe-tier parity, plus a small bump
-// per tier of craft skill above the recipe's tier, plus flat bonuses for a
-// self-signed reagent and for reaching the specialization threshold, hard
+// Locked Phase 2 tuning, amended 2026-07-17: base chance at recipe-tier
+// parity, plus a small bump per tier of craft skill above the recipe's tier,
+// plus flat bonuses for a signed reagent (ANY player's signature, the
+// crafter's own included; the amendment widened this from self-signed-only so
+// buying a gatherer's signed materials is worth as much to the proc as
+// gathering your own) and for reaching the specialization threshold, hard
 // capped. Fractions of 1 (0.03 = 3 percent).
 export const MASTERWORK_BASE_CHANCE = 0.03;
 export const MASTERWORK_PER_TIER_ABOVE_CHANCE = 0.01;
-export const MASTERWORK_SELF_SIGNED_CHANCE = 0.02;
+export const MASTERWORK_SIGNED_CHANCE = 0.02;
 export const MASTERWORK_SPECIALIZATION_CHANCE = 0.03;
 export const MASTERWORK_CHANCE_CAP = 0.15;
 
@@ -30,9 +33,12 @@ export interface MasterworkChanceInput {
   // tier (wheel.ts tierCapability / tierForSkill). Clamped below at 0 here, so
   // crafting ABOVE one's tier never subtracts from the base chance.
   tiersAboveRecipe: number;
-  // At least one consumed reagent was self-signed (crafting.ts's existing
-  // #1145 self-signed-reagent computation).
-  selfSignedReagent: boolean;
+  // At least one consumed reagent is a signed instance, ANY player's
+  // signature (crafting.ts's holding check over the recipe's reagents).
+  // Deliberately DECOUPLED from the #1145 self-signed quantity discount,
+  // which stays self-only: a count-1 signed reagent qualifies here even
+  // though the discount can never fire for it.
+  signedReagent: boolean;
   // The crafter has reached the specialization threshold in the recipe's craft
   // (wheel.ts isSpecialized, content-driven, never hardcoded).
   specialized: boolean;
@@ -50,7 +56,7 @@ export function masterworkProcChance(input: MasterworkChanceInput): number {
   const chance =
     MASTERWORK_BASE_CHANCE +
     MASTERWORK_PER_TIER_ABOVE_CHANCE * tiersAbove +
-    (input.selfSignedReagent ? MASTERWORK_SELF_SIGNED_CHANCE : 0) +
+    (input.signedReagent ? MASTERWORK_SIGNED_CHANCE : 0) +
     (input.specialized ? MASTERWORK_SPECIALIZATION_CHANCE : 0) +
     (input.materialTierBonus ?? 0);
   return Math.min(MASTERWORK_CHANCE_CAP, chance);

--- a/tests/parity/scenarios.ts
+++ b/tests/parity/scenarios.ts
@@ -4154,8 +4154,9 @@ function professionsCraft(seed = 21): Scenario {
       meta.craftSkills.tailoring = 200;
       // The one self-signed linen scrap satisfies the whole linen requirement (the
       // #1145 minus-one reduction composes with the #1134 specialization discount:
-      // 3 -> 2 -> floor(2 * 0.8) = 1) and marks selfSignedBonusApplied for the
-      // proc-chance input, mirroring the crafting suite's proc test.
+      // 3 -> 2 -> floor(2 * 0.8) = 1) and feeds the signed-reagent proc-chance
+      // input (any-signed since the 2026-07-17 ruling; a self-signed copy still
+      // qualifies), mirroring the crafting suite's proc test.
       sim.addItemInstance('linen_scrap', { signer: meta.name }, pid);
       sim.addItem('spider_leg', 1, pid);
       sim.craftItem('recipe_eastbrook_ritual_vestments', pid);

--- a/tests/professions_masterwork.test.ts
+++ b/tests/professions_masterwork.test.ts
@@ -19,7 +19,7 @@ import {
   MASTERWORK_CHANCE_CAP,
   MASTERWORK_PER_TIER_ABOVE_CHANCE,
   MASTERWORK_QUALITY_LADDER,
-  MASTERWORK_SELF_SIGNED_CHANCE,
+  MASTERWORK_SIGNED_CHANCE,
   MASTERWORK_SPECIALIZATION_CHANCE,
   type MasterworkQuality,
   masterworkBonusStats,
@@ -44,60 +44,60 @@ describe('masterworkProcChance (Phase 2 tuning)', () => {
     // would satisfy, so the constants themselves are pinned here.
     expect(MASTERWORK_BASE_CHANCE).toBe(0.03);
     expect(MASTERWORK_PER_TIER_ABOVE_CHANCE).toBe(0.01);
-    expect(MASTERWORK_SELF_SIGNED_CHANCE).toBe(0.02);
+    expect(MASTERWORK_SIGNED_CHANCE).toBe(0.02);
     expect(MASTERWORK_SPECIALIZATION_CHANCE).toBe(0.03);
     expect(MASTERWORK_CHANCE_CAP).toBe(0.15);
   });
 
   it('is 3 percent at recipe-tier parity with no bonuses', () => {
     expect(
-      masterworkProcChance({ tiersAboveRecipe: 0, selfSignedReagent: false, specialized: false }),
+      masterworkProcChance({ tiersAboveRecipe: 0, signedReagent: false, specialized: false }),
     ).toBe(0.03);
   });
 
   it('adds 1 percent per tier of capability above the recipe tier', () => {
     expect(
-      masterworkProcChance({ tiersAboveRecipe: 1, selfSignedReagent: false, specialized: false }),
+      masterworkProcChance({ tiersAboveRecipe: 1, signedReagent: false, specialized: false }),
     ).toBeCloseTo(0.04, 12);
     expect(
-      masterworkProcChance({ tiersAboveRecipe: 2, selfSignedReagent: false, specialized: false }),
+      masterworkProcChance({ tiersAboveRecipe: 2, signedReagent: false, specialized: false }),
     ).toBeCloseTo(0.05, 12);
   });
 
-  it('adds 2 percent for a self-signed consumed reagent', () => {
+  it('adds 2 percent for a signed consumed reagent (any signer)', () => {
     expect(
-      masterworkProcChance({ tiersAboveRecipe: 0, selfSignedReagent: true, specialized: false }),
+      masterworkProcChance({ tiersAboveRecipe: 0, signedReagent: true, specialized: false }),
     ).toBeCloseTo(0.05, 12);
   });
 
   it('adds 3 percent when specialized', () => {
     expect(
-      masterworkProcChance({ tiersAboveRecipe: 0, selfSignedReagent: false, specialized: true }),
+      masterworkProcChance({ tiersAboveRecipe: 0, signedReagent: false, specialized: true }),
     ).toBeCloseTo(0.06, 12);
   });
 
   it('stacks every bonus additively while under the cap', () => {
     // 0.03 + 0.05 + 0.02 + 0.03 = 0.13, below the 0.15 cap: no clamp.
     expect(
-      masterworkProcChance({ tiersAboveRecipe: 5, selfSignedReagent: true, specialized: true }),
+      masterworkProcChance({ tiersAboveRecipe: 5, signedReagent: true, specialized: true }),
     ).toBeCloseTo(0.13, 12);
   });
 
   it('clamps a sum exceeding the cap to exactly 15 percent', () => {
     // 0.03 + 0.08 + 0.02 + 0.03 = 0.16 exceeds the cap and clamps.
     expect(
-      masterworkProcChance({ tiersAboveRecipe: 8, selfSignedReagent: true, specialized: true }),
+      masterworkProcChance({ tiersAboveRecipe: 8, signedReagent: true, specialized: true }),
     ).toBe(0.15);
   });
 
   it('clamps a negative tiersAboveRecipe to 0 (never below the base chance)', () => {
     expect(
-      masterworkProcChance({ tiersAboveRecipe: -1, selfSignedReagent: false, specialized: false }),
+      masterworkProcChance({ tiersAboveRecipe: -1, signedReagent: false, specialized: false }),
     ).toBe(0.03);
     expect(
       masterworkProcChance({
         tiersAboveRecipe: -100,
-        selfSignedReagent: false,
+        signedReagent: false,
         specialized: false,
       }),
     ).toBe(0.03);
@@ -106,12 +106,12 @@ describe('masterworkProcChance (Phase 2 tuning)', () => {
   it('materialTierBonus (the Phase 10 hook) defaults to 0 and is a real additive summand', () => {
     const omitted = masterworkProcChance({
       tiersAboveRecipe: 0,
-      selfSignedReagent: false,
+      signedReagent: false,
       specialized: false,
     });
     const explicitZero = masterworkProcChance({
       tiersAboveRecipe: 0,
-      selfSignedReagent: false,
+      signedReagent: false,
       specialized: false,
       materialTierBonus: 0,
     });
@@ -122,7 +122,7 @@ describe('masterworkProcChance (Phase 2 tuning)', () => {
     expect(
       masterworkProcChance({
         tiersAboveRecipe: 0,
-        selfSignedReagent: false,
+        signedReagent: false,
         specialized: false,
         materialTierBonus: 0.025,
       }),
@@ -131,7 +131,7 @@ describe('masterworkProcChance (Phase 2 tuning)', () => {
     expect(
       masterworkProcChance({
         tiersAboveRecipe: 0,
-        selfSignedReagent: false,
+        signedReagent: false,
         specialized: false,
         materialTierBonus: 0.2,
       }),
@@ -505,9 +505,10 @@ describe('proc-chance wiring over a real Sim (hunted boundary-window seeds)', ()
 
   it('a self-signed reagent feeds the proc chance: the same seed procs only with the signed copy', () => {
     // Seed 69, hunted: the single proc draw lands in [0.03, 0.05), above the
-    // 3 percent base but under base plus the 2 percent self-signed bonus, so
-    // the proc fires ONLY when crafting.ts passes selfSignedBonusApplied into
-    // masterworkProcChance. Spares on record: 89, 117, 134, 185.
+    // 3 percent base but under base plus the 2 percent signed-reagent bonus,
+    // so the proc fires ONLY when crafting.ts passes the signed-reagent
+    // holding check into masterworkProcChance. Spares on record: 89, 117,
+    // 134, 185.
     const SEED = 69;
     const signed = craftVestments(SEED, (sim, pid) => {
       const meta = (sim as any).players.get(pid);
@@ -531,6 +532,40 @@ describe('proc-chance wiring over a real Sim (hunted boundary-window seeds)', ()
     expect(plain.ok).toBe(true);
     expect(plain.selfSignedBonusApplied).toBe(false);
     expect(plain.masterwork).toBeUndefined();
+  });
+
+  it("another player's signed reagent feeds the proc chance equally (the 2026-07-17 any-signed ruling)", () => {
+    // Same hunted seed-69 window: the draw sits in [0.03, 0.05), so the proc
+    // fires exactly when the 2 percent signed-reagent term applies. The signed
+    // copy carries SOMEONE ELSE'S signature, so the #1145 quantity discount
+    // must NOT apply (all 3 linen are required and consumed) while the proc
+    // bonus MUST: trade-bought signed materials are worth as much to the proc
+    // as self-gathered ones.
+    const SEED = 69;
+    const traded = craftVestments(SEED, (sim, pid) => {
+      sim.addItemInstance('linen_scrap', { signer: 'Gatherer Friend' }, pid);
+      sim.addItem('linen_scrap', 2, pid);
+      sim.addItem('spider_leg', 1, pid);
+    });
+    expect(traded.ok).toBe(true);
+    expect(traded.selfSignedBonusApplied).toBe(false);
+    expect(traded.masterwork).toBe(true);
+  });
+
+  it('a count-1 signed reagent feeds the proc chance (decoupled from the quantity-discount flag)', () => {
+    // Same hunted seed-69 window. The signed copy is the SPIDER LEG, whose
+    // reagent count is 1: the #1145 reduction floors at 1 so the discount
+    // flag can never set for it (the old coupling made this exact case lose
+    // the proc bonus). The signed-reagent term must fire anyway.
+    const SEED = 69;
+    const countOne = craftVestments(SEED, (sim, pid) => {
+      const meta = (sim as any).players.get(pid);
+      for (let i = 0; i < 3; i++) sim.addItem('linen_scrap', 1, pid);
+      sim.addItemInstance('spider_leg', { signer: meta.name }, pid);
+    });
+    expect(countOne.ok).toBe(true);
+    expect(countOne.selfSignedBonusApplied).toBe(false);
+    expect(countOne.masterwork).toBe(true);
   });
 
   it('the specialization threshold binds in the craft path: skill 74 misses where 75 and 76 proc', () => {


### PR DESCRIPTION
## Summary

Implements the 2026-07-17 design-review ruling recorded in `docs/professions-2/state.md` (PR #2084): the masterwork proc's +2% signed-reagent term now counts a held signed instance of any required reagent with ANY player's signature, not only the crafter's own. Buying a gatherer's signed materials is now worth exactly as much to the proc as gathering your own, which aligns the mechanic with the players-trade-with-players economy pillar. The #1145 self-signed reagent-quantity discount is deliberately unchanged (self-only).

Decoupling the proc term from the discount flag also fixes a latent gap: a reagent with a listed count of 1 could never earn the +2% because `selfSignedBonusApplied` only set when a count was actually reduced (requires count >= 2), diverging from the documented "+2 percent with any self-signed reagent".

Mechanics: `MASTERWORK_SELF_SIGNED_CHANCE` renamed to `MASTERWORK_SIGNED_CHANCE`, `MasterworkChanceInput.selfSignedReagent` to `signedReagent`; `crafting.ts` gains a `hasSignedInstance` holding check computed per reagent BEFORE consumption. Draw order is untouched: still exactly one unconditional proc draw per successful craft, zero on denials.

## Related issues

Part of #1866. Companion to #2084 (the packet amendment that records the ruling; its Phase 3 pre-flight verifies this change landed).

## Type of change

- [x] Feature: new functionality
- [x] Bug fix (the count-1 coupling gap)

## How was this tested?

- Commands: `npx vitest run tests/professions_masterwork.test.ts tests/professions_crafting.test.ts tests/professions_perks.test.ts tests/archetype_ceiling.test.ts` (122 passed, including two new hunted-seed-69 pins that fail on the old code: another player's signature procs with the quantity discount not firing, and a count-1 self-signed reagent procs); `npx vitest run tests/parity tests/architecture.test.ts` (198 passed, 1 pre-existing env-gated skip; the professions_craft golden is byte-identical because the scenario's chance inputs are equal under both conditions); `npx tsc --noEmit`; scoped biome; `npm run ci:changed`. All under Node 24.
- Review: a fresh architecture-reviewer pass over the diff returned zero BLOCKING and zero SHOULD-FIX findings (draw-order, pre-consumption ordering, parity, purity, rename completeness, and test decisiveness all verified).

## Screenshots / recordings

N/A (no visual surface; the celebration UI lands in packet Phase 6).
