### PR TITLE
fix(net): mirror corpse claims online and pin instance payload parity (Professions 2.0 Phase 3)

### DIFF
--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -11,7 +11,7 @@ Update this file at the end of every implementation and QA session. Statuses:
 | 1 QA | Verify ring and identity foundations | complete | 2026-07-17 | 2026-07-17 |
 | 2 | Masterwork model | complete | 2026-07-17 | 2026-07-17 |
 | 2 QA | Verify masterwork model | complete | 2026-07-17 | 2026-07-17 |
-| 3 | Host-parity bug fixes | not started | | |
+| 3 | Host-parity bug fixes | complete | 2026-07-17 | 2026-07-17 |
 | 3 QA | Verify host-parity bug fixes | not started | | |
 | 4 | Node materials and pristine veins | not started | | |
 | 4 QA | Verify node materials and pristine veins | not started | | |
@@ -104,9 +104,30 @@ ignores unknown SimEvent types, so a new server's masterwork event is
 harmless to an old client.
 
 ### Phase 3: Host-parity bug fixes
-- [ ] Trade carries `ItemInstancePayload` end to end (regression test)
-- [ ] `harvestClaimedBy` mirrored online; corpse picker stops offering claimed corpses
-- [ ] Crafting view consumes the shared combo-eligibility rule in both hosts
+- [x] Trade carries `ItemInstancePayload` end to end (regression test)
+- [x] `harvestClaimedBy` mirrored online; corpse picker stops offering claimed corpses
+- [x] Crafting view consumes the shared combo-eligibility rule in both hosts
+
+Completed 2026-07-17. The trade code fix had pre-landed on release via
+PR 2045; this phase added the missing bidirectional full-payload pin
+(signer, charges, rolled including the masterwork marker, enchant,
+boundTo, both directions in one mixed trade). harvestClaimedBy rides
+the per-entity wire as the sparse hcb key (server/game.ts dynamicFields
+emit, unconditional ClientWorld reset in src/net/online.ts), pinned by
+the round-trip suite in tests/snapshots.test.ts and the online-picker
+parity suite in tests/corpse_harvest_sim.test.ts; hcb is deliberately
+NOT in ALL_DELTA_KEYS / TERSE_TO_IWORLD (those pin selfWireJson maybe()
+self keys; the per-entity round-trip + bandwidth pins are the teeth).
+Combo-gating liveness pinned in
+tests/crafting_view_combo_liveness.test.ts (Sim and ClientWorld arms
+fed by a real cprof broadcast; decisiveness mutation-tested). Review
+fan-out (cross-platform-sync, privacy-security, qa-checklist,
+test-coverage-auditor): PASS, zero blocking. Deferred to Phase 4:
+src/main.ts still passes harvestStateReliable = (online === null) at
+the three interaction open-gate sites, so the truthful mirror is not
+yet consumed at the online OPEN gate (harvest-only corpses still do
+not open online, pre-existing); flip with an open-gate test when
+Phase 4 makes gathering trust corpse claims (details in state.md).
 
 ### Phase 4: Node materials and pristine veins
 - [ ] Per-rarity node material tables replace placeholder junk (zone-1 stays low-tier)

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -201,11 +201,13 @@ Phase 13), and interaction handlers return an outcome boolean (#1982).
   throttle + gold sink (#1301). NO skillReq admission gate.
 - Instances: ItemInstancePayload {signer, charges, rolled, boundTo} rides the
   inv wire; bags/bank/equip/save-load correct; trade CARRIES payloads (the
-  Phase 3 trade deliverable pre-landed on release via PR 2045, regression
-  test in tests/trade.test.ts; Phase 3 keeps only the harvestClaimedBy
-  mirror); mail/market refuse instanced items (wave 2).
+  Phase 3 trade deliverable pre-landed on release via PR 2045; Phase 3 added
+  the bidirectional full-payload pin, signer/charges/rolled incl masterwork/
+  enchant/boundTo in one mixed trade, in tests/trade.test.ts); mail/market
+  refuse instanced items (wave 2).
 - Gathering: nodes (harvestNode both hosts, ncd cooldowns), corpse harvesting
-  (claims + focus picker + town focus, tfocus), fixed corpse rarity baseline
+  (claims + focus picker + town focus, tfocus; claims mirrored online via the
+  per-entity hcb key since Phase 3), fixed corpse rarity baseline
   40; node yields are placeholder junk until Phase 4.
 - Salvage/disenchant/enchant: sim-complete in salvage.ts / enchanting.ts;
   lastSalvageResult/lastDisenchantResult/lastEnchantResult on PlayerMeta;
@@ -379,7 +381,39 @@ tables, i18n key namespaces, files created)
   - Mixed-fleet check: the previous release's HUD event if-chain
     ignores unknown SimEvent types, so a new server's masterwork event
     is harmless to an old client during a staged rollout.
-- Phase 3: (planned) hcb wire key (corpse claims); trade payload carriage.
+- Phase 3: LANDED 2026-07-17. hcb wire key (corpse claims): sparse per-entity
+  emit in server/game.ts dynamicFields (present only when claimed, so the
+  entity delta cache elides unclaimed corpses byte-unchanged) + unconditional
+  reset-on-absence mirror in src/net/online.ts applyWire. Pinned by the
+  round-trip suite in tests/snapshots.test.ts (claimed, sparse absence,
+  stale-claim clear) and the online-picker parity suite in
+  tests/corpse_harvest_sim.test.ts (claimed corpse harvestable false against
+  a ClientWorld-shaped mirror). hcb is deliberately NOT in ALL_DELTA_KEYS or
+  TERSE_TO_IWORLD: those pin selfWireJson maybe() self keys only (the scrape
+  test asserts set-equality), and a per-entity dynamicFields key is pinned by
+  the round-trip + bandwidth tests instead; the phase file's pin instruction
+  was written for self keys (deviation reviewed, cross-platform-sync PASS).
+  Trade payload carriage pre-landed via PR 2045; Phase 3 added the
+  bidirectional full-payload pin (tests/trade.test.ts) and the combo-gating
+  liveness pin (tests/crafting_view_combo_liveness.test.ts: Sim and
+  ClientWorld arms fed by a real cprof broadcast, decisiveness
+  mutation-tested). No IWorld member changes; world_api_parity untouched.
+  - DEFERRED to Phase 4 (gathering trusts corpse claims): src/main.ts still
+    passes harvestStateReliable = (online === null) at its three interaction
+    open-gate sites, so the truthful mirror is consumed by the in-window
+    picker (hud.ts wiring defaults reliable true) but not yet at the online
+    OPEN gate: a harvest-only corpse (tags, no regular loot) still never
+    opens online, a pre-existing limitation, not a Phase 3 regression. Flip
+    the three sites to trust the mirror, with an open-gate test, when
+    Phase 4 makes gathering trust corpse claims.
+  - Drift notes: instance-level boundTo copies are tradeable (tradeSetOffer
+    gates only def-level soulbound; carried verbatim per #1298, possible
+    design follow-up); vendor sellItem buyback still re-grants a plain copy
+    losing the payload (pre-existing, documented in trade.ts's header, out
+    of scope); the bareClient test fixture now has three hand-rolled copies
+    (snapshots, corpse_harvest_sim, combo liveness suites): rule-of-three
+    tripped, a shared tests/helpers/ extraction is a Phase 3 QA or Phase 15
+    cleanup candidate.
 - Phase 4: (planned) node material tables; per-node-type rare events
   (pristine vein / ancient heartwood / moonlit bloom) + deed-mark hooks.
 - Phase 5: (planned) professions window (.window id professions-window) +

--- a/server/game.ts
+++ b/server/game.ts
@@ -978,6 +978,9 @@ function dynamicFields(e: Entity): Record<string, unknown> {
   if (e.weaponStowed) out.ws = 1; // Z-key sheathe: weapons render on the back
   if (e.aggroTargetId !== null) out.aggro = e.aggroTargetId;
   if (e.tappedById !== null) out.tap = e.tappedById;
+  // corpse harvest claim (single-use, first-come): the online corpse picker
+  // must stop offering a corpse another player already harvested
+  if (e.harvestClaimedBy !== null) out.hcb = e.harvestClaimedBy;
   if (e.ownerId !== null) out.own = e.ownerId;
   if (e.overheadEmoteId) {
     out.emo = e.overheadEmoteId;

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -2096,6 +2096,9 @@ export class ClientWorld implements IWorld {
       e.weaponStowed = !!w.ws;
       e.aggroTargetId = w.aggro ?? null;
       e.tappedById = w.tap ?? null;
+      // corpse harvest claim: unconditional so a record without hcb (unclaimed,
+      // or a respawn that cleared the claim) resets any stale mirrored pid
+      e.harvestClaimedBy = typeof w.hcb === 'number' ? w.hcb : null;
       e.ownerId = w.own ?? null;
       e.petMode = w.pm ?? 'defensive';
       e.petTauntTimer = w.pt ?? 0;

--- a/tests/corpse_harvest_sim.test.ts
+++ b/tests/corpse_harvest_sim.test.ts
@@ -1,4 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the db layer so no Postgres is needed; only wireEntity is under test.
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+}));
+
+import { wireEntity } from '../server/game';
+import { corpseLootAvailability } from '../src/game/corpse_loot_availability';
+import { ClientWorld } from '../src/net/online';
 import { bagCapacity, stackSizeOf } from '../src/sim/bags';
 import { HARVEST_COMPONENT_ITEMS } from '../src/sim/content/professions';
 import { ITEMS, MOBS } from '../src/sim/data';
@@ -279,5 +296,90 @@ describe('signed materials (#1145)', () => {
     // This seed's focus-tier roll lands above the poor floor, so the fungible
     // grant is more than a single unit (harvestTierQuantity(tier), #1142).
     expect(sim.countItem('boar_hide', a)).toBe(2);
+  });
+});
+
+// A ClientWorld without the WebSocket plumbing, to drive applySnapshot directly
+// (the established bare-client idiom; see bareClient in tests/snapshots.test.ts
+// and tests/CLAUDE.md).
+function bareClient(pid: number): ClientWorld {
+  const c: any = Object.create(ClientWorld.prototype);
+  c.cfg = { seed: 20061, playerClass: 'warrior' };
+  c.entities = new Map();
+  c.playerId = pid;
+  c.ownPlayerId = pid;
+  c.ownPlayerClass = 'warrior';
+  c.spectating = null;
+  c.cupInfo = null;
+  c.sportRole = null;
+  c.moveInput = {};
+  c.inventory = [];
+  c.vendorBuyback = [];
+  c.equipment = {};
+  c.accountCosmetics = { completedQuestIds: [], mechChromaIds: [] };
+  c.copper = 0;
+  c.honor = 0;
+  c.lifetimeHonor = 0;
+  c.xp = 0;
+  c.known = [];
+  c.questLog = new Map();
+  c.questsDone = new Set();
+  c.pendingQuestCommands = new Map();
+  c.partyInfo = null;
+  c.selectedDungeonDifficulty = 'normal';
+  c.tradeInfo = null;
+  c.duelInfo = null;
+  c.lastSnapAt = 0;
+  c.snapInterval = 50;
+  c.serverTickHz = null;
+  c.missingSince = new Map();
+  c.pendingFacingDelta = 0;
+  c.connected = true;
+  c.eventQueue = [];
+  c.mouselookFacing = null;
+  c.lastInputSentAt = 0;
+  c.lastInputSig = '';
+  c.inputSeq = 0;
+  c.pendingInputSeqSentAt = new Map();
+  c.ackedInputSeq = 0;
+  c.inputEchoSamples = [];
+  c.spectateFacingPending = false;
+  c.pendingSpectateFacing = null;
+  c.nodeCooldowns = new Map();
+  return c;
+}
+
+// The online half of the claim: the server encodes harvestClaimedBy as the
+// sparse terse key `hcb` (server/game.ts wireEntity), ClientWorld mirrors it,
+// and the corpse picker's availability core (corpseLootAvailability) therefore
+// stops offering an already-claimed corpse online, exactly as offline.
+describe('corpse harvest claim over the wire (online picker parity)', () => {
+  it('a real claim rides hcb, mirrors into ClientWorld, and gates the picker', () => {
+    const { sim, mob, a, b } = setup();
+    sim.harvestCorpse(mob.id, undefined, a);
+    expect(mob.harvestClaimedBy).toBe(a);
+
+    const w = wireEntity(mob);
+    expect(w.hcb).toBe(a);
+
+    // Bravo's client sees Alpha's claim mirrored, and the picker refuses it.
+    const client = bareClient(b);
+    (client as any).applySnapshot({ t: 'snap', ents: [w] });
+    const mirrored = client.entities.get(mob.id)!;
+    expect(mirrored.harvestClaimedBy).toBe(a);
+    expect(corpseLootAvailability(mirrored, b).harvestable).toBe(false);
+  });
+
+  it('an unclaimed tagged corpse stays harvestable through the mirror', () => {
+    const { mob, b } = setup();
+
+    const w = wireEntity(mob);
+    expect(w).not.toHaveProperty('hcb');
+
+    const client = bareClient(b);
+    (client as any).applySnapshot({ t: 'snap', ents: [w] });
+    const mirrored = client.entities.get(mob.id)!;
+    expect(mirrored.harvestClaimedBy).toBeNull();
+    expect(corpseLootAvailability(mirrored, b).harvestable).toBe(true);
   });
 });

--- a/tests/crafting_view_combo_liveness.test.ts
+++ b/tests/crafting_view_combo_liveness.test.ts
@@ -1,0 +1,333 @@
+// Combo-gating liveness parity (Professions 2.0 Phase 3): the crafting view's
+// combo gate must consume the shared combo_eligibility result identically and
+// LIVELY for Sim-shaped and ClientWorld-shaped inputs. This guards the #2033
+// stub trap: a ClientWorld member that exists (so the type checks and a
+// members-exist parity sweep passes) but never mirrors live server values.
+// Every assertion here is about values FLOWING and CHANGING outcomes: an
+// all-zero craftSkills stub or a craftingIdentity that stops tracking cprof
+// deltas fails these tests, mere member existence does not pass them.
+//
+// The online arm always feeds values through the real wire path: a GameServer
+// broadcast encoded by selfWireJson (`cprof` via the maybe() delta diff) and
+// decoded by ClientWorld.applySnapshot, never by poking mirror fields.
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the db layer so no Postgres is needed (the snapshots.test.ts idiom);
+// hoisted, so it must stay above the server/game import.
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
+  loadAccountFlair: vi.fn(async () => ({ ai: false, streamer: false, links: {} })),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  setAccountWeaponSkinLoadout: vi.fn(async () => ({
+    completedQuestIds: [],
+    mechChromaIds: [],
+    weaponSkinIds: [],
+    weaponSkinLoadout: {},
+  })),
+}));
+
+import { type ClientSession, GameServer } from '../server/game';
+import { ClientWorld } from '../src/net/online';
+import { COMBO_RECIPES } from '../src/sim/content/recipes';
+import { ITEMS } from '../src/sim/data';
+import { emptyCraftSkills } from '../src/sim/professions/wheel';
+import { Sim } from '../src/sim/sim';
+import type { InvSlot } from '../src/sim/types';
+import { buildCraftingView, type CraftingRecipeRow } from '../src/ui/crafting_view';
+
+// The armorcrafting+weaponcrafting minTier-1 combo recipe (content pinned by
+// tests/professions_contracts.test.ts; reagents bone_fragments x4, linen_scrap x2).
+const RECIPE = COMBO_RECIPES.find((entry) => entry.id === 'recipe_ironbound_warplate_helm')!;
+
+function makeReagents(): InvSlot[] {
+  return [
+    { itemId: 'bone_fragments', count: 4 },
+    { itemId: 'linen_scrap', count: 2 },
+  ];
+}
+
+// The exact pair the recipe requires, attuned, in the wire fixture shape
+// (snapshots.test.ts full self-state fixture).
+function makePairArchetype() {
+  return {
+    activeArchetype: 'armorcrafting',
+    pairedMajor: 'weaponcrafting',
+    hobbyCraft: 'leatherworking',
+    attunedPairs: ['weaponcrafting+armorcrafting'],
+    switchCount: 0,
+    amendsProgress: 0,
+  };
+}
+
+// A pair that does NOT match the recipe (wrong_pair from the shared gate).
+function makeWrongPairArchetype() {
+  return {
+    activeArchetype: 'alchemy',
+    pairedMajor: 'engineering',
+    hobbyCraft: null,
+    attunedPairs: ['alchemy+engineering'],
+    switchCount: 0,
+    amendsProgress: 0,
+  };
+}
+
+// The one shape both arms are read through: the exact IWorld members the
+// crafting window consumes. Sim and ClientWorld both satisfy it structurally.
+interface ComboWorldReads {
+  inventory: readonly InvSlot[];
+  craftSkills: Readonly<Record<string, number>>;
+  craftingIdentity: {
+    synced: boolean;
+    activeArchetype: string | null;
+    pairedMajor: string | null;
+    hobbyCraft: string | null;
+  };
+}
+
+function comboRow(world: ComboWorldReads): CraftingRecipeRow {
+  return buildCraftingView(
+    [RECIPE],
+    world.inventory,
+    ITEMS,
+    world.craftSkills,
+    world.craftingIdentity,
+  ).recipes[0];
+}
+
+interface FakeClient {
+  sent: any[];
+  ws: any;
+}
+
+function fakeWs(): FakeClient {
+  const sent: any[] = [];
+  return { sent, ws: { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) } };
+}
+
+function lastSnap(sent: any[]): any {
+  for (let i = sent.length - 1; i >= 0; i--) {
+    if (sent[i].t === 'snap') return sent[i];
+  }
+  return null;
+}
+
+function joinServer(server: GameServer, fc: FakeClient, id: number, name: string): ClientSession {
+  const session = server.join(fc.ws, id, id, name, 'warrior', null);
+  if ('error' in session) throw new Error(session.error);
+  session.blockListLoaded = true;
+  return session;
+}
+
+function broadcast(server: GameServer): void {
+  (server as any).broadcastSnapshots();
+}
+
+// A ClientWorld without the WebSocket plumbing, to drive applySnapshot directly
+// (the snapshots.test.ts bareClient idiom). Object.create skips class field
+// initializers, so the two crafting mirrors are initialized here to their
+// declaration defaults (all-zero skills, synced false), exactly the state a
+// freshly constructed online client holds before its first cprof arrives.
+function bareClient(pid: number): ClientWorld {
+  const c: any = Object.create(ClientWorld.prototype);
+  c.cfg = { seed: 20061, playerClass: 'warrior' };
+  c.entities = new Map();
+  c.playerId = pid;
+  c.ownPlayerId = pid;
+  c.ownPlayerClass = 'warrior';
+  c.spectating = null;
+  c.cupInfo = null;
+  c.sportRole = null;
+  c.moveInput = {};
+  c.inventory = [];
+  c.vendorBuyback = [];
+  c.equipment = {};
+  c.accountCosmetics = { completedQuestIds: [], mechChromaIds: [] };
+  c.copper = 0;
+  c.honor = 0;
+  c.lifetimeHonor = 0;
+  c.xp = 0;
+  c.known = [];
+  c.questLog = new Map();
+  c.questsDone = new Set();
+  c.pendingQuestCommands = new Map();
+  c.partyInfo = null;
+  c.selectedDungeonDifficulty = 'normal';
+  c.tradeInfo = null;
+  c.duelInfo = null;
+  c.lastSnapAt = 0;
+  c.snapInterval = 50;
+  c.serverTickHz = null;
+  c.missingSince = new Map();
+  c.pendingFacingDelta = 0;
+  c.connected = true;
+  c.eventQueue = [];
+  c.mouselookFacing = null;
+  c.lastInputSentAt = 0;
+  c.lastInputSig = '';
+  c.inputSeq = 0;
+  c.pendingInputSeqSentAt = new Map();
+  c.ackedInputSeq = 0;
+  c.inputEchoSamples = [];
+  c.spectateFacingPending = false;
+  c.pendingSpectateFacing = null;
+  c.nodeCooldowns = new Map();
+  c.craftSkills = emptyCraftSkills();
+  c.craftingIdentity = {
+    version: 1,
+    synced: false,
+    craftSkills: c.craftSkills,
+    activeArchetype: null,
+    pairedMajor: null,
+    hobbyCraft: null,
+    attunedPairs: [],
+    switchCount: 0,
+    amendsProgress: 0,
+    amendsRequired: 0,
+  };
+  return c;
+}
+
+describe('crafting view combo gate liveness across both IWorld arms', () => {
+  it('offline Sim arm: the live IWorld reads carry the arranged values and open the gate', () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
+    const meta = sim.meta(sim.player.id)!;
+    meta.craftSkills.armorcrafting = 25;
+    meta.craftSkills.weaponcrafting = 25;
+    meta.archetype = makePairArchetype();
+    meta.inventory = makeReagents();
+    // The reads flow the arranged values, not a zeroed default.
+    expect(sim.craftSkills).toMatchObject({ armorcrafting: 25, weaponcrafting: 25 });
+    expect(sim.craftingIdentity.synced).toBe(true);
+    expect(sim.craftingIdentity.activeArchetype).toBe('armorcrafting');
+    expect(sim.craftingIdentity.pairedMajor).toBe('weaponcrafting');
+    const row = comboRow(sim);
+    expect(row.comboRequirement?.met).toBe(true);
+    expect(row.comboRequirement?.reason).toBeNull();
+    expect(row.reagents.every((r) => r.satisfied)).toBe(true);
+    expect(row.craftable).toBe(true);
+  });
+
+  it('online arm mirrors equal values through a real cprof snapshot and yields the identical view', () => {
+    // Offline arm.
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
+    const offMeta = sim.meta(sim.player.id)!;
+    offMeta.craftSkills.armorcrafting = 25;
+    offMeta.craftSkills.weaponcrafting = 25;
+    offMeta.archetype = makePairArchetype();
+    offMeta.inventory = makeReagents();
+    // Online arm: the SAME underlying values, fed through the wire.
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 71, 'Combo');
+    const onMeta = server.sim.meta(session.pid)!;
+    onMeta.craftSkills.armorcrafting = 25;
+    onMeta.craftSkills.weaponcrafting = 25;
+    onMeta.archetype = makePairArchetype();
+    onMeta.inventory = makeReagents();
+    broadcast(server);
+    const client = bareClient(session.pid);
+    (client as any).applySnapshot(lastSnap(fc.sent));
+    // Stub guard: the mirror holds the live server values, not defaults.
+    expect(client.craftingIdentity.synced).toBe(true);
+    expect(client.craftSkills).toMatchObject({ armorcrafting: 25, weaponcrafting: 25 });
+    expect(client.craftingIdentity.activeArchetype).toBe('armorcrafting');
+    expect(client.craftingIdentity.pairedMajor).toBe('weaponcrafting');
+    const offRow = comboRow(sim);
+    const onRow = comboRow(client);
+    // The shared outcome must be the ELIGIBLE one (two equally broken arms
+    // would still deep-equal, so the absolute outcome is asserted first).
+    expect(onRow.craftable).toBe(true);
+    expect(onRow.comboRequirement?.met).toBe(true);
+    expect(onRow.comboRequirement?.reason).toBeNull();
+    // Full-row parity: same craftable, same combo verdict, same reagent rows.
+    expect(onRow).toEqual(offRow);
+  });
+
+  it('liveness: successive cprof snapshots move the combo outcome on the same client', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 72, 'Livey');
+    const meta = server.sim.meta(session.pid)!;
+    meta.inventory = makeReagents();
+    meta.craftSkills.armorcrafting = 25;
+    meta.craftSkills.weaponcrafting = 25;
+    meta.archetype = makeWrongPairArchetype();
+    const client = bareClient(session.pid);
+
+    // Snapshot 1: skills suffice but the attuned pair is the wrong one.
+    broadcast(server);
+    (client as any).applySnapshot(lastSnap(fc.sent));
+    let row = comboRow(client);
+    expect(row.comboRequirement?.met).toBe(false);
+    expect(row.comboRequirement?.reason).toBe('wrong_pair');
+    expect(row.craftable).toBe(false);
+
+    // Snapshot 2: the right pair attunes but both skills sit one point below
+    // the tier threshold. A frozen mirror would still read the first snapshot.
+    meta.archetype = makePairArchetype();
+    meta.craftSkills.armorcrafting = 24;
+    meta.craftSkills.weaponcrafting = 24;
+    broadcast(server);
+    (client as any).applySnapshot(lastSnap(fc.sent));
+    expect(client.craftSkills).toMatchObject({ armorcrafting: 24, weaponcrafting: 24 });
+    expect(client.craftingIdentity.activeArchetype).toBe('armorcrafting');
+    row = comboRow(client);
+    expect(row.comboRequirement?.met).toBe(false);
+    expect(row.comboRequirement?.reason).toBe('tier_unmet');
+    expect(row.comboRequirement?.unmetCrafts).toEqual(['armorcrafting', 'weaponcrafting']);
+    expect(row.craftable).toBe(false);
+
+    // Snapshot 3: skills cross the tier threshold and the SAME client flips
+    // to craftable. This is the assertion an all-zero stub can never pass.
+    meta.craftSkills.armorcrafting = 25;
+    meta.craftSkills.weaponcrafting = 25;
+    broadcast(server);
+    (client as any).applySnapshot(lastSnap(fc.sent));
+    expect(client.craftSkills).toMatchObject({ armorcrafting: 25, weaponcrafting: 25 });
+    row = comboRow(client);
+    expect(row.comboRequirement?.met).toBe(true);
+    expect(row.comboRequirement?.reason).toBeNull();
+    expect(row.craftable).toBe(true);
+  });
+
+  it('before any cprof arrives the gate reads syncing and stays optimistically enabled', () => {
+    const client = bareClient(1);
+    // A snapshot WITHOUT the cprof delta key (the delta-omission path): the
+    // identity mirror must keep its pre-sync declaration default.
+    (client as any).applySnapshot({
+      t: 'snap',
+      ents: [],
+      self: {
+        id: 1,
+        k: 'player',
+        tid: 'warrior',
+        nm: 'Sync',
+        lv: 15,
+        x: 0,
+        y: 0,
+        z: 0,
+        f: 0,
+        hp: 100,
+        mhp: 100,
+        inv: makeReagents(),
+      },
+    });
+    expect(client.craftingIdentity.synced).toBe(false);
+    expect(client.inventory).toEqual(makeReagents());
+    const row = comboRow(client);
+    expect(row.comboRequirement?.reason).toBe('syncing');
+    expect(row.comboRequirement?.met).toBeNull();
+    // Reagents are satisfied, so the button stays optimistically enabled while
+    // the identity is still syncing (the locked design: never disable on a
+    // not-yet-arrived mirror).
+    expect(row.reagents.every((r) => r.satisfied)).toBe(true);
+    expect(row.craftable).toBe(true);
+  });
+});

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -26,7 +26,8 @@ import { type ClientSession, GameServer, wireEntity } from '../server/game';
 import { ClientWorld } from '../src/net/online';
 import { mechHeldWeaponOverride, visualKeyFor } from '../src/render/characters/manifest';
 import { COMBO_RECIPES } from '../src/sim/content/recipes';
-import { DELVES, GATHER_NODES, ITEMS } from '../src/sim/data';
+import { DELVES, GATHER_NODES, ITEMS, MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
 import { Sim } from '../src/sim/sim';
 import { type Aura, DT, type PlayerClass } from '../src/sim/types';
 import { terrainHeight } from '../src/sim/world';
@@ -458,6 +459,62 @@ describe('account flair over the wire', () => {
     const client = bareClient(e.id + 1000);
     (client as any).applySnapshot({ t: 'snap', ents: [wire] });
     expect(client.entities.get(e.id)!.streamerLinks).toBeUndefined();
+  });
+});
+
+// Corpse harvest claims over the wire. The corpse picker
+// (src/game/corpse_loot_availability.ts) reads mob.harvestClaimedBy; offline the
+// Sim entity carries it, so online the same field must ride the sparse terse key
+// `hcb` or the online picker keeps offering already-claimed corpses. Same pin
+// shape as the account-flair suite above: the REAL server emit (wireEntity) into
+// the REAL client mirror (applySnapshot), never a hand-built wire record alone.
+describe('corpse harvest claim over the wire', () => {
+  function deadWolfCorpse(id: number): ReturnType<typeof createMob> {
+    const template = MOBS.forest_wolf;
+    const mob = createMob(id, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+    mob.dead = true;
+    return mob;
+  }
+
+  it('mirrors the claimer pid onto another player client via hcb', () => {
+    const claimer = 42;
+    const mob = deadWolfCorpse(9001);
+    mob.harvestClaimedBy = claimer;
+
+    const w = wireEntity(mob);
+    expect(w.hcb).toBe(claimer);
+
+    const client = bareClient(claimer + 1000);
+    (client as any).applySnapshot({ t: 'snap', ents: [w] });
+    expect(client.entities.get(mob.id)!.harvestClaimedBy).toBe(claimer);
+  });
+
+  it('keeps an unclaimed corpse sparse: no hcb key, mirrored as null', () => {
+    const mob = deadWolfCorpse(9002);
+
+    const w = wireEntity(mob);
+    // Absent, not `hcb: null`: an unclaimed corpse's record must be byte-unchanged
+    // by this feature, so the per-entity delta cache keeps eliding it.
+    expect(w).not.toHaveProperty('hcb');
+
+    const client = bareClient(1);
+    (client as any).applySnapshot({ t: 'snap', ents: [w] });
+    expect(client.entities.get(mob.id)!.harvestClaimedBy).toBeNull();
+  });
+
+  it('clears a stale mirrored claim when a later record arrives without hcb', () => {
+    const mob = deadWolfCorpse(9003);
+    mob.harvestClaimedBy = 42;
+
+    const client = bareClient(1);
+    (client as any).applySnapshot({ t: 'snap', ents: [wireEntity(mob)] });
+    expect(client.entities.get(mob.id)!.harvestClaimedBy).toBe(42);
+
+    // Respawn clears the claim server-side (src/sim/mob/lifecycle.ts); the next
+    // record simply omits hcb, and the mirror must reset, not keep the stale pid.
+    mob.harvestClaimedBy = null;
+    (client as any).applySnapshot({ t: 'snap', ents: [wireEntity(mob)] });
+    expect(client.entities.get(mob.id)!.harvestClaimedBy).toBeNull();
   });
 });
 

--- a/tests/trade.test.ts
+++ b/tests/trade.test.ts
@@ -318,6 +318,56 @@ describe('trade module (direct, no Sim)', () => {
     expect(instanced?.instance).toEqual(instance);
   });
 
+  it('keeps full payloads (signer/charges/rolled/enchant/boundTo) for instances in both directions', () => {
+    // The phase acceptance criterion end to end: side A's offer mixes a plain
+    // copy with a fully-loaded instanced copy while side B offers a different
+    // instanced item in the SAME trade, so tradeConfirm's second transferOffer
+    // call (offerB, b to a) moves an instance too, and every payload field
+    // (signer, charges, rolled incl. the Phase 2 masterwork marker, the enchant
+    // marker, boundTo) must land intact on the right receiver's granted item.
+    const instA = {
+      signer: 'Ayla',
+      charges: { lifesteal: 2 },
+      rolled: { stats: { atk: 3 }, masterwork: true },
+      enchant: 'flame_weapon',
+      boundTo: 1,
+    };
+    const instB = {
+      signer: 'Borin',
+      charges: { warmth: 5 },
+      rolled: { stats: { sta: 2 }, masterwork: true },
+      enchant: 'hearth_ward',
+      boundTo: 2,
+    };
+    const { ctx, players } = makeInstancedTradeCtx(
+      [
+        { itemId: 'wolf_fang', count: 1 },
+        { itemId: 'wolf_fang', count: 1, instance: instA },
+      ],
+      [{ itemId: 'baked_bread', count: 1, instance: instB }],
+    );
+
+    tradeMod.tradeRequest(ctx, 2, 1);
+    tradeMod.tradeAccept(ctx, 2);
+    tradeMod.tradeSetOffer(ctx, [{ itemId: 'wolf_fang', count: 2 }], 0, 1);
+    tradeMod.tradeSetOffer(ctx, [{ itemId: 'baked_bread', count: 1 }], 0, 2);
+    tradeMod.tradeConfirm(ctx, 1);
+    tradeMod.tradeConfirm(ctx, 2);
+
+    // b to a: the instanced bread lands on A with its whole payload.
+    expect(players.get(1).inventory).toHaveLength(1);
+    expect(players.get(1).inventory[0].itemId).toBe('baked_bread');
+    expect(players.get(1).inventory[0].instance).toEqual(instB);
+    // a to b: one plain fang plus the instanced fang carrying instA, not instB.
+    expect(players.get(2).inventory).toHaveLength(2);
+    const plain = players.get(2).inventory.find((s: any) => !s.instance);
+    const instanced = players.get(2).inventory.find((s: any) => s.instance);
+    expect(plain?.itemId).toBe('wolf_fang');
+    expect(plain?.count).toBe(1);
+    expect(instanced?.itemId).toBe('wolf_fang');
+    expect(instanced?.instance).toEqual(instA);
+  });
+
   it('updateTradesAndInvites expires stale invites and cancels drifted trades', () => {
     const h = makeTradeCtx();
     h.addPlayer(1, 'Ayla', 0, 0);


### PR DESCRIPTION
## Summary

Phase 3 of the Professions 2.0 packet (docs/professions-2/phase-03-parity-bug-fixes.md): make item instances and corpse claims truthful in every host.

- Corpse claims now ride the wire. `harvestClaimedBy` is emitted as the sparse per-entity key `hcb` from `dynamicFields` in `server/game.ts` (present only while claimed, so the entity delta cache elides unclaimed corpses byte-unchanged) and mirrored unconditionally in `src/net/online.ts` `applyWire` (a record without `hcb` clears a stale claim). This replaces ClientWorld's hardcoded null, so the online harvest picker stops offering already-claimed corpses. The picker itself needed no change: `corpseLootAvailability` already filters on the mirrored field.
- The trade instance-payload code fix pre-landed on release via PR #2045; this PR adds the missing decisive pin: a mixed trade with instanced items flowing in both directions, asserting every payload field (signer, charges, rolled including the masterwork marker, enchant, boundTo) lands intact on the right receiver.
- New combo-gating liveness suite (`tests/crafting_view_combo_liveness.test.ts`) guards the #2033 stub trap: `buildCraftingView` consumes live cprof-mirrored values identically in Sim-shaped and ClientWorld-shaped worlds (row parity, an outcome change across successive cprof snapshots, and the optimistic syncing state before the first cprof).

Deliberate deviation from the phase file: `hcb` is NOT registered in `ALL_DELTA_KEYS` / `TERSE_TO_IWORLD`. Those pins cover selfWireJson `maybe()` self keys only (the scrape test asserts set-equality with the `maybe()` calls); a per-entity `dynamicFields` key is pinned by the new round-trip suite plus the bandwidth test instead. Reviewed by the cross-platform-sync reviewer: PASS.

Deferred to Phase 4, documented in `docs/professions-2/state.md`: `src/main.ts` still passes `harvestStateReliable = (online === null)` at the three interaction open-gate sites, so the truthful mirror is not yet consumed at the online open gate (a harvest-only corpse still never opens online, a pre-existing limitation, not a regression from this PR). Phase 4 (gathering trusts corpse claims) flips those sites with an open-gate test.

## Related issues

Closes #2049. Closes #2052. Part of #1866.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation

## How was this tested?

- Commands:
  - `npx vitest run tests/trade.test.ts tests/snapshots.test.ts tests/bandwidth.test.ts tests/corpse_harvest_sim.test.ts tests/world_api_parity.test.ts tests/crafting_view_combo_liveness.test.ts` (406 passed)
  - `npx vitest run tests/env_protocol.test.ts` (5 passed) and `npx vitest run tests/architecture.test.ts` (24 passed)
  - `npx tsc --noEmit`, `npm run ci:changed`, and the full `npm run gate` (Node 24)
- Test-first evidence: all new suites were observed failing for the right reason before the fix (no `hcb` key emitted, mirror stuck at null, naive transferOffer dropping payloads); the liveness suite's decisiveness was mutation-tested (temporarily disabling the cprof mirror reds it; mutation reverted).
- Review fan-out over the diff: cross-platform-sync, privacy-security-review, qa-checklist, test-coverage-auditor, all PASS with zero blocking findings.
- Manual steps: none (no visual surface; wire, tests, and docs only).

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI surface change.
- ~Accessible.~ N/A: no UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files. They're regenerated by the build.
