### PR TITLE
fix(sim): Professions 2.0 Phase 3 QA, two-phase trade swap + hcb live-broadcast coverage

### DIFF
--- a/docs/professions-2/phase-03-parity-bug-fixes.md
+++ b/docs/professions-2/phase-03-parity-bug-fixes.md
@@ -5,6 +5,17 @@ Release PR 2045 landed the instance-preserving trade fix on release/v0.27.0 (reg
 `tests/trade.test.ts`) before this phase started, so the only remaining Phase 3 deliverable is the
 `harvestClaimedBy` mirror below. Re-verify against code at session start per the docs anchor rule.
 
+AS-LANDED DEVIATION (2026-07-17, Phase 3 merge a8c65a2c2, reviewed by cross-platform-sync): the
+instructions below to register `hcb` in `ALL_DELTA_KEYS` / `TERSE_TO_IWORLD` were mis-specified.
+`harvestClaimedBy` is a PER-ENTITY field, so `hcb` rides `dynamicFields` in `server/game.ts`
+(sparse emit, auto-delta via the per-entity wire cache; the `tap` key is the template), and those
+two registries pin selfWireJson maybe() SELF keys only (their scrape test asserts set-equality, so
+listing `hcb` there would break it). The as-landed pin set: the round-trip and live-broadcast
+suites in `tests/snapshots.test.ts` and `tests/corpse_harvest_sim.test.ts` (the sparse-absence
+assertion in snapshots is the no-bloat tooth; `tests/bandwidth.test.ts` stays green but carries no
+hcb-specific scenario). Authority: the Phase 3 LANDED entry in `state.md`. Read the registry
+instructions below through this note.
+
 This phase fixes the two known host-parity data bugs so item instances and corpse claims are
 truthful in every host: trades currently strip `ItemInstancePayload` (the `removePreferFungible`
 return is discarded), and `harvestClaimedBy` is hardcoded `null` in `ClientWorld`, so the online
@@ -27,8 +38,9 @@ survive trades; Phase 4 gathering trusts corpse claims), and neither adds new ga
 - `src/sim/professions/combo_eligibility.ts`: the shared combo gate both hosts must consume
   (the 2033 stub trap: verify liveness, not just member shape).
 - `tests/trade.test.ts`, `tests/corpse_harvest_sim.test.ts`: the suites to extend.
-- `tests/snapshots.test.ts`: the `ALL_DELTA_KEYS` / `TERSE_TO_IWORLD` wire pins; the existing
-  `prof`/`gprof`/`ncd`/`tfocus` self-wire keys are the pattern for `hcb`.
+- `tests/snapshots.test.ts`: the `ALL_DELTA_KEYS` / `TERSE_TO_IWORLD` wire pins (SELF keys only;
+  as landed, `hcb` is a per-entity `dynamicFields` key patterned on `tap`, see the deviation note
+  above).
 - `CLAUDE.md` (root) plus `src/sim/CLAUDE.md`, `src/net/CLAUDE.md`, `server/CLAUDE.md`,
   `src/ui/hud/CLAUDE.md`, `tests/CLAUDE.md`.
 
@@ -79,9 +91,10 @@ Spawn an Explore agent to read and summarize:
   src/ui/hud/CLAUDE.md, tests/CLAUDE.md
 The agent must return: exactly where trade.ts discards the removePreferFungible return and what
 that return contains; the full ItemInstancePayload shape (signer, charges, rolled, boundTo) and
-the instance-preserving grant helpers in bags.ts; the recipe for adding a delta-omitted terse
-wire key (server emit in wireEntity, ClientWorld mirror, ALL_DELTA_KEYS + TERSE_TO_IWORLD pin
-updates); how the corpse picker sources harvestClaimedBy; how the crafting view consumes
+the instance-preserving grant helpers in bags.ts; the recipe for adding a sparse per-entity terse
+wire key (dynamicFields emit in server/game.ts, ClientWorld mirror; ALL_DELTA_KEYS +
+TERSE_TO_IWORLD are for SELF keys only, see the deviation note at the top); how the corpse picker
+sources harvestClaimedBy; how the crafting view consumes
 combo_eligibility today in each host; and the existing test patterns in the three suites.
 
 STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
@@ -100,9 +113,9 @@ Agent trade (sim) deliverables:
   with the right payloads landing on the right granted items.
 
 Agent wire (server + net) deliverables:
-- harvestClaimedBy rides the wire: a new terse key (hcb), delta-omitted like the existing
-  prof/gprof/ncd/tfocus keys, emitted from wireEntity in server/game.ts and registered in
-  ALL_DELTA_KEYS and TERSE_TO_IWORLD (re-pin tests/snapshots.test.ts deliberately).
+- harvestClaimedBy rides the wire: a new terse key (hcb), sparse-emitted from wireEntity's
+  dynamicFields in server/game.ts (as landed; NOT the self-key registries, see the deviation
+  note at the top), pinned by the snapshots round-trip suite.
 - ClientWorld mirrors hcb in src/net/online.ts, replacing the hardcoded null.
 - The corpse picker in src/ui/hud/loot/loot_window_controller.ts no longer offers claimed
   corpses online, with a test against a ClientWorld-shaped stub.
@@ -120,9 +133,10 @@ INVARIANTS THIS PHASE MUST KEEP:
   harvesting, and every existing wire consumer keep working unchanged.
 - Server authority: the server resolves all trade and claim outcomes; the client only mirrors
   and renders (the picker filters on mirrored truth, it never decides claims).
-- Wire parity pins: every new terse key lands in ALL_DELTA_KEYS and TERSE_TO_IWORLD in the same
-  change; tests/snapshots.test.ts, tests/bandwidth.test.ts, and tests/world_api_parity.test.ts
-  stay green; hcb is delta-omitted and cheap.
+- Wire parity pins: every new SELF terse key lands in ALL_DELTA_KEYS and TERSE_TO_IWORLD in the
+  same change; a per-entity dynamicFields key (hcb, as landed) is pinned by its round-trip suite
+  instead; tests/snapshots.test.ts, tests/bandwidth.test.ts, and tests/world_api_parity.test.ts
+  stay green; hcb is sparse-emitted and cheap.
 - IWorld both worlds: any read the UI consumes exists on the facet and behaves identically in
   Sim and ClientWorld; verify liveness, not just member shape.
 - Determinism: all randomness via Rng; no Math.random, Date.now, or performance.now anywhere
@@ -173,8 +187,10 @@ STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
       online corpse picker matches sim truth and no longer offers claimed corpses (stub test
       green)
 - [ ] The combo-gating liveness test passes with Sim-shaped and ClientWorld-shaped inputs
-- [ ] ALL_DELTA_KEYS and TERSE_TO_IWORLD pins updated deliberately; tests/snapshots.test.ts,
-      tests/bandwidth.test.ts (hcb is cheap), and tests/world_api_parity.test.ts green
+- [ ] hcb pinned per its as-landed shape (per-entity dynamicFields key: the snapshots round-trip
+      suite incl. the sparse-absence assertion; deliberately absent from ALL_DELTA_KEYS and
+      TERSE_TO_IWORLD); tests/snapshots.test.ts, tests/bandwidth.test.ts, and
+      tests/world_api_parity.test.ts green
 - [ ] tests/trade.test.ts, tests/corpse_harvest_sim.test.ts, tests/env_protocol.test.ts,
       tests/architecture.test.ts, npx tsc --noEmit, and npm run ci:changed all green
 - [ ] Mail and market still refuse instanced items (untouched)

--- a/docs/professions-2/phase-03-qa.md
+++ b/docs/professions-2/phase-03-qa.md
@@ -55,8 +55,9 @@ Correctness agent:
   - The hcb claim key under interest-scope edges: a corpse leaving and re-entering the ~120 yd
     interest radius must arrive with the correct claim state, and a claim change while the
     corpse is out of scope must not leave a stale mirror.
-  - No snapshot bloat: hcb is delta-omitted, absent when unchanged, and tests/bandwidth.test.ts
-    confirms it is cheap.
+  - No snapshot bloat: hcb is sparse-emitted, absent when unclaimed (the snapshots.test.ts
+    sparse-absence assertion is the pin), and tests/bandwidth.test.ts stays green without
+    loosened budgets (it carries no hcb-specific scenario).
 - Verify the offline Sim path and the online ClientWorld path behave identically for trades,
   corpse claims, and combo gating; check edge cases (empty trade, self-claimed corpse, a corpse
   claimed by the viewing player, cancelled trade returning instances intact).
@@ -66,8 +67,10 @@ Test coverage agent:
   delta omission, the picker filter, the ClientWorld mirror).
 - Add missing tests, including a determinism test (same seed, same result) if sim logic changed
   (trade grant ordering is sim logic).
-- Update any existing tests broken by Phase 03; verify the ALL_DELTA_KEYS / TERSE_TO_IWORLD
-  re-pins were deliberate, not accidental.
+- Update any existing tests broken by Phase 03; verify hcb's ABSENCE from ALL_DELTA_KEYS /
+  TERSE_TO_IWORLD is the reviewed as-landed deviation (per-entity dynamicFields key, pinned by
+  its round-trip suites; see the deviation note atop phase-03-parity-bug-fixes.md), not an
+  accidental omission.
 - Remove orphaned tests for replaced behavior (for example a test pinning the old
   payload-stripping trade or the hardcoded-null harvestClaimedBy).
 - Verify assertions are decisive (they check payload field values and claim ids, not just "it
@@ -121,7 +124,8 @@ STOPPING RULES:
   correct items in both directions; probe stack splits and cancelled trades.
 - The hcb claim key under interest-scope edges: corpses crossing the interest radius must never
   show a stale or missing claim in `ClientWorld`.
-- No snapshot bloat: `hcb` is delta-omitted and absent when unchanged; `tests/bandwidth.test.ts`
-  stays green without loosened budgets.
+- No snapshot bloat: `hcb` is sparse-emitted and absent when unclaimed (the `tests/snapshots.test.ts`
+  sparse-absence assertion is the pin); `tests/bandwidth.test.ts` stays green without loosened
+  budgets (no hcb-specific scenario lives there).
 - Liveness, not shape: the combo-gating test must prove live `combo_eligibility` values flow
   through `ClientWorld`, not merely that the member exists (the #2033 trap).

--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -12,7 +12,7 @@ Update this file at the end of every implementation and QA session. Statuses:
 | 2 | Masterwork model | complete | 2026-07-17 | 2026-07-17 |
 | 2 QA | Verify masterwork model | complete | 2026-07-17 | 2026-07-17 |
 | 3 | Host-parity bug fixes | complete | 2026-07-17 | 2026-07-17 |
-| 3 QA | Verify host-parity bug fixes | not started | | |
+| 3 QA | Verify host-parity bug fixes | complete | 2026-07-17 | 2026-07-17 |
 | 4 | Node materials and pristine veins | not started | | |
 | 4 QA | Verify node materials and pristine veins | not started | | |
 | 5 | The professions wheel window | not started | | |
@@ -103,7 +103,39 @@ Mixed-fleet safety verified: the previous release's HUD event if-chain
 ignores unknown SimEvent types, so a new server's masterwork event is
 harmless to an old client.
 
-### Phase 3: Host-parity bug fixes
+Phase 3 QA (2026-07-17): PASS, zero blocking findings across the
+packet's three audit roles plus the matched dispatch-matrix rows
+(architecture, cross-platform sync, pin quality, qa-checklist;
+privacy/security, migration safety, frontend seam, and database
+performance were NO-MATCH for the QA diff). One real correctness
+defect found and fixed test-first, in the pre-landed PR 2045 trade
+code rather than the phase diff: tradeConfirm ran the a-to-b transfer
+to completion before removing b's give, so same-itemId bidirectional
+trades cross-contaminated (a swapped instance bounced straight back
+to its owner; a plain-for-instance offer spared the instance and
+mis-routed a plain copy). The swap is now two-phase (removeOffer both
+sides, then grantOffer both sides), matching the model fitsAfterSwap
+already validated; conservation held in all variants, so no dupe or
+loss ever occurred. QA landed: the two sequencing repro pins (revert
+experiment confirms both red on the old code and only they guard the
+reorder), a partial-stack sparing pin (removePreferFungible must
+choose), a no-escrow cancel contract pin, the live GameServer
+broadcast suite for hcb (claim-after-first-sight arrives as a lite
+dyn-only record, pinned by hcb-present plus no-nm; interest-scope
+eviction and re-entry deliver claims AND clears made out of view, and
+a delta-guarded mirror mutation reds the clear arm), and the
+claimed-corpse arms of corpseLootAvailability (self-claimed viewer,
+claimed-by-another, claimed-with-personal-loot stays openable). Docs:
+the hcb as-landed deviation swept into the phase file and QA twin
+(the amend-the-twin trap), the phantom bandwidth hcb pin claim
+corrected (the snapshots sparse-absence assertion is the no-bloat
+tooth), the bareClient drift note rescoped to the real 21-copy
+repo-wide idiom (extraction filed as #2088, a standalone chore), and
+the Phase 4 despawn-grace heads-up recorded. Deferred with reasons: a
+bandwidth claimed-corpse scenario (docs now truthful instead; the
+sparse-absence pin covers the regression that matters) and a
+distinct-itemId slot-order byte-equivalence pin (the push-to-end plus
+splice-compaction reasoning is airtight per the architecture review).
 - [x] Trade carries `ItemInstancePayload` end to end (regression test)
 - [x] `harvestClaimedBy` mirrored online; corpse picker stops offering claimed corpses
 - [x] Crafting view consumes the shared combo-eligibility rule in both hosts

--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -117,7 +117,9 @@ emit, unconditional ClientWorld reset in src/net/online.ts), pinned by
 the round-trip suite in tests/snapshots.test.ts and the online-picker
 parity suite in tests/corpse_harvest_sim.test.ts; hcb is deliberately
 NOT in ALL_DELTA_KEYS / TERSE_TO_IWORLD (those pin selfWireJson maybe()
-self keys; the per-entity round-trip + bandwidth pins are the teeth).
+self keys; the per-entity round-trip pins are the teeth, with the
+snapshots sparse-absence assertion as the no-bloat pin; bandwidth stays
+green but has no hcb-specific scenario).
 Combo-gating liveness pinned in
 tests/crafting_view_combo_liveness.test.ts (Sim and ClientWorld arms
 fed by a real cprof broadcast; decisiveness mutation-tested). Review

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -423,7 +423,21 @@ tables, i18n key namespaces, files created)
     professions suites are byte-near-identical copies): Phase 3 QA judged
     the extraction a standalone chore, not QA churn (a shared
     tests/helpers/bare_client.ts adopted first by the three identical
-    copies; the 18 divergent variants need per-file verification).
+    copies; the 18 divergent variants need per-file verification; filed
+    as issue 2088).
+  - Phase 3 QA: PASS 2026-07-17, zero blocking. Found and fixed
+    test-first the tradeConfirm sequencing defect in the pre-landed
+    PR 2045 code (same-itemId bidirectional trades cross-contaminated:
+    grant-before-remove let the second removal consume just-granted
+    stock; now two-phase, removeOffer both sides then grantOffer both
+    sides, matching the fitsAfterSwap model; no dupe or loss existed,
+    conservation always held). Coverage closed: live GameServer
+    broadcast suite for hcb (lite delta record + scope
+    eviction/re-entry, claims and clears made out of view),
+    partial-stack sparing pin, no-escrow cancel pin, claimed-corpse
+    arms of corpseLootAvailability. Reviewer fan-out (architecture,
+    cross-platform-sync, test-coverage-auditor with revert
+    experiments, qa-checklist): all PASS. Details in progress.md.
 - Phase 4: (planned) node material tables; per-node-type rare events
   (pristine vein / ancient heartwood / moonlit bloom) + deed-mark hooks.
 - Phase 5: (planned) professions window (.window id professions-window) +

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -391,8 +391,11 @@ tables, i18n key namespaces, files created)
   a ClientWorld-shaped mirror). hcb is deliberately NOT in ALL_DELTA_KEYS or
   TERSE_TO_IWORLD: those pin selfWireJson maybe() self keys only (the scrape
   test asserts set-equality), and a per-entity dynamicFields key is pinned by
-  the round-trip + bandwidth tests instead; the phase file's pin instruction
-  was written for self keys (deviation reviewed, cross-platform-sync PASS).
+  its round-trip suites instead (the snapshots sparse-absence assertion is
+  the no-bloat tooth; bandwidth.test.ts stays green but carries no
+  hcb-specific scenario); the phase file's pin instruction was written for
+  self keys (deviation reviewed, cross-platform-sync PASS; as-landed note
+  swept into the phase file + QA twin by Phase 3 QA).
   Trade payload carriage pre-landed via PR 2045; Phase 3 added the
   bidirectional full-payload pin (tests/trade.test.ts) and the combo-gating
   liveness pin (tests/crafting_view_combo_liveness.test.ts: Sim and
@@ -405,15 +408,22 @@ tables, i18n key namespaces, files created)
     OPEN gate: a harvest-only corpse (tags, no regular loot) still never
     opens online, a pre-existing limitation, not a Phase 3 regression. Flip
     the three sites to trust the mirror, with an open-gate test, when
-    Phase 4 makes gathering trust corpse claims.
+    Phase 4 makes gathering trust corpse claims. Phase 4 heads-up (QA): the
+    client's despawn-grace window (online.ts anti-flicker retention) freezes
+    a boundary-lingering corpse's mirrored claim until the prune or a
+    re-entry record; harmless today because the picker acts at
+    INTERACT_RANGE, far inside the interest radius, but confirm the flipped
+    open gate still cannot act on a grace-window corpse.
   - Drift notes: instance-level boundTo copies are tradeable (tradeSetOffer
     gates only def-level soulbound; carried verbatim per #1298, possible
     design follow-up); vendor sellItem buyback still re-grants a plain copy
-    losing the payload (pre-existing, documented in trade.ts's header, out
-    of scope); the bareClient test fixture now has three hand-rolled copies
-    (snapshots, corpse_harvest_sim, combo liveness suites): rule-of-three
-    tripped, a shared tests/helpers/ extraction is a Phase 3 QA or Phase 15
-    cleanup candidate.
+    losing the payload (pre-existing, documented in the removeOffer comment
+    in trade.ts, out of scope); the bareClient fixture is hand-rolled in 21
+    test files repo-wide (tests/CLAUDE.md blesses the idiom; the three
+    professions suites are byte-near-identical copies): Phase 3 QA judged
+    the extraction a standalone chore, not QA churn (a shared
+    tests/helpers/bare_client.ts adopted first by the three identical
+    copies; the 18 divergent variants need per-file verification).
 - Phase 4: (planned) node material tables; per-node-type rare events
   (pristine vein / ancient heartwood / moonlit bloom) + deed-mark hooks.
 - Phase 5: (planned) professions window (.window id professions-window) +

--- a/src/sim/social/trade.ts
+++ b/src/sim/social/trade.ts
@@ -16,7 +16,7 @@ import { ITEMS } from '../data';
 import { removePreferFungible } from '../items';
 import type { PlayerMeta, TradeSession } from '../sim';
 import type { SimContext } from '../sim_context';
-import { dist2d, type InvSlot } from '../types';
+import { dist2d, type InvSlot, type ItemInstancePayload } from '../types';
 
 // A trade is only offered/kept while both parties are within this many yards;
 // the drift sweep cancels an open session once they wander past TRADE_RANGE + 4.
@@ -120,21 +120,37 @@ export function tradeSetOffer(
   session.acceptedB = false;
 }
 
-// Moves one side's offer, preserving each slot's ItemInstancePayload (enchants,
-// signed materials, rolled quality, boundTo) instead of re-granting plain copies.
+// Removal phase of the swap: consumes one side's offer out of their bags,
+// preserving each slot's ItemInstancePayload (enchants, signed materials,
+// rolled quality, boundTo) for grantOffer instead of re-granting plain copies.
 // removePreferFungible already reports exactly which consumed slots carried an
-// instance; this only had to route those payloads back in through addItemInstance
-// rather than discarding them, the same way discardItem never needed to because a
-// discarded item's payload does not need to reappear anywhere. sellItem is NOT the
-// same case: it records vendor buyback (items.ts sellItem), and buyback re-grants
-// a plain copy today, so a sold instanced item still loses its payload there; that
-// is a pre-existing sibling of this bug, not fixed by this change.
-function transferOffer(ctx: SimContext, items: InvSlot[], fromPid: number, toPid: number): void {
+// instance; grantOffer only had to route those payloads back in through
+// addItemInstance rather than discarding them, the same way discardItem never
+// needed to because a discarded item's payload does not need to reappear
+// anywhere. sellItem is NOT the same case: it records vendor buyback (items.ts
+// sellItem), and buyback re-grants a plain copy today, so a sold instanced item
+// still loses its payload there; that is a pre-existing sibling of this bug,
+// not fixed by this change.
+// BOTH removals must run before EITHER grant: when the two offers share an
+// itemId, granting first inflates the counter-party's stock, so their removal
+// consumes just-received copies (removeItem scans highest-index-first, exactly
+// where addItemInstance pushes) and a swapped instance bounces straight back
+// to its owner, or gets spared while a plain copy crosses in its place.
+type PendingGrant = { itemId: string; plainCount: number; instances: ItemInstancePayload[] };
+
+function removeOffer(ctx: SimContext, items: InvSlot[], fromPid: number): PendingGrant[] {
+  const grants: PendingGrant[] = [];
   for (const s of items) {
     const instances = removePreferFungible(ctx, s.itemId, s.count, fromPid);
-    const plainCount = s.count - instances.length;
-    if (plainCount > 0) ctx.addItem(s.itemId, plainCount, toPid);
-    for (const instance of instances) ctx.addItemInstance(s.itemId, instance, toPid);
+    grants.push({ itemId: s.itemId, plainCount: s.count - instances.length, instances });
+  }
+  return grants;
+}
+
+function grantOffer(ctx: SimContext, grants: PendingGrant[], toPid: number): void {
+  for (const g of grants) {
+    if (g.plainCount > 0) ctx.addItem(g.itemId, g.plainCount, toPid);
+    for (const instance of g.instances) ctx.addItemInstance(g.itemId, instance, toPid);
   }
 }
 
@@ -167,7 +183,7 @@ export function tradeConfirm(ctx: SimContext, pid?: number): void {
   }
   // capacity gate: each side must fit what they RECEIVE after what they GIVE
   // leaves their bags (simulated on a scratch copy; nothing moved yet). A
-  // receive is not uniformly fungible: transferOffer (below) grants each
+  // receive is not uniformly fungible: grantOffer (below) grants each
   // instanced copy via addItemInstance, which always takes a fresh slot and
   // never merges into a plain stack of the same itemId (bags.ts addStacked
   // skips slots with `.instance`). fitsAll alone assumes every unit of a
@@ -211,8 +227,10 @@ export function tradeConfirm(ctx: SimContext, pid?: number): void {
   // swap
   metaA.copper = metaA.copper - session.offerA.copper + session.offerB.copper;
   metaB.copper = metaB.copper - session.offerB.copper + session.offerA.copper;
-  transferOffer(ctx, session.offerA.items, session.a, session.b);
-  transferOffer(ctx, session.offerB.items, session.b, session.a);
+  const grantsToB = removeOffer(ctx, session.offerA.items, session.a);
+  const grantsToA = removeOffer(ctx, session.offerB.items, session.b);
+  grantOffer(ctx, grantsToB, session.b);
+  grantOffer(ctx, grantsToA, session.a);
   for (const tPid of [session.a, session.b]) {
     ctx.emit({ type: 'log', text: 'Trade complete.', color: '#8df', pid: tPid });
     ctx.emit({ type: 'tradeDone', pid: tPid });

--- a/tests/corpse_harvest_sim.test.ts
+++ b/tests/corpse_harvest_sim.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 
-// Mock the db layer so no Postgres is needed; only wireEntity is under test.
+// Mock the db layer so no Postgres is needed; only the wire encode/decode and
+// broadcast paths are under test (wireEntity round-trips plus a real GameServer
+// snapshot pipeline), never persistence.
 vi.mock('../server/db', () => ({
   pool: { query: vi.fn(async () => ({ rows: [] })) },
   saveCharacterState: vi.fn(async () => {}),
@@ -9,11 +11,18 @@ vi.mock('../server/db', () => ({
   closePlaySession: vi.fn(async () => {}),
   insertChatLogs: vi.fn(async () => {}),
   walletForAccount: vi.fn(async () => null),
+  loadAccountFlair: vi.fn(async () => ({ ai: false, streamer: false, links: {} })),
   markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
   grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  setAccountWeaponSkinLoadout: vi.fn(async () => ({
+    completedQuestIds: [],
+    mechChromaIds: [],
+    weaponSkinIds: [],
+    weaponSkinLoadout: {},
+  })),
 }));
 
-import { wireEntity } from '../server/game';
+import { type ClientSession, GameServer, wireEntity } from '../server/game';
 import { corpseLootAvailability } from '../src/game/corpse_loot_availability';
 import { ClientWorld } from '../src/net/online';
 import { bagCapacity, stackSizeOf } from '../src/sim/bags';
@@ -381,5 +390,139 @@ describe('corpse harvest claim over the wire (online picker parity)', () => {
     const mirrored = client.entities.get(mob.id)!;
     expect(mirrored.harvestClaimedBy).toBeNull();
     expect(corpseLootAvailability(mirrored, b).harvestable).toBe(true);
+  });
+});
+
+// The LIVE broadcast path (the hand-assembled snap envelopes above are always
+// fullJson-shaped): the per-session entity cache sends identity only on first
+// sight, so a claim landing AFTER a viewer has seen the corpse rides a lite
+// (dyn-only) record, and leaving interest scope evicts the corpse from the
+// session's sent set so re-entry gets a fresh full record. Both arms must
+// deliver claim truth to the mirror.
+interface FakeClient {
+  sent: any[];
+  ws: any;
+}
+
+function fakeWs(): FakeClient {
+  const sent: any[] = [];
+  return { sent, ws: { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) } };
+}
+
+function lastSnap(sent: any[]): any {
+  for (let i = sent.length - 1; i >= 0; i--) {
+    if (sent[i].t === 'snap') return sent[i];
+  }
+  return null;
+}
+
+function joinServer(server: GameServer, fc: FakeClient, id: number, name: string): ClientSession {
+  const session = server.join(fc.ws, id, id, name, 'warrior', null);
+  if ('error' in session) throw new Error(session.error);
+  session.blockListLoaded = true;
+  return session;
+}
+
+function broadcast(server: GameServer): void {
+  (server as any).broadcastSnapshots();
+}
+
+describe('corpse harvest claim over the live broadcast (delta + interest scope)', () => {
+  function liveSetup() {
+    const server = new GameServer();
+    const fcA = fakeWs();
+    const fcB = fakeWs();
+    const sa = joinServer(server, fcA, 81, 'Alpha');
+    const sb = joinServer(server, fcB, 82, 'Bravo');
+    const internals = server.sim as unknown as SimInternals;
+    for (const pid of [sa.pid, sb.pid]) {
+      const e = internals.entities.get(pid)!;
+      e.pos = { x: 0, y: 0, z: 0 };
+      e.prevPos = { x: 0, y: 0, z: 0 };
+    }
+    // A dead wolf corpse beside both players, with a world-unique entity id
+    // (the server sim is a full generated world, so 9999 could collide).
+    const template = MOBS.forest_wolf;
+    const mobId = Math.max(...internals.entities.keys()) + 1;
+    const mob = createMob(mobId, template, template.maxLevel, { x: 2, y: 0, z: 0 });
+    mob.dead = true;
+    mob.aiState = 'dead';
+    mob.corpseTimer = 9999;
+    mob.respawnTimer = 9999;
+    internals.entities.set(mob.id, mob);
+    // One tick re-indexes the spatial grid the interest scan reads
+    // (forEachInRadius), so the moved players and the inserted corpse land in
+    // their cells before the first broadcast.
+    server.sim.tick();
+    return { server, internals, fcB, sa, sb, mob };
+  }
+
+  it('a claim landing after first sight arrives as a lite delta record and gates the picker', () => {
+    const { server, fcB, sa, sb, mob } = liveSetup();
+
+    // First sight: Bravo's client mirrors the unclaimed corpse via a full record.
+    broadcast(server);
+    const client = bareClient(sb.pid);
+    (client as any).applySnapshot(lastSnap(fcB.sent));
+    const first = client.entities.get(mob.id)!;
+    expect(first.harvestClaimedBy).toBeNull();
+    expect(corpseLootAvailability(first, sb.pid).harvestable).toBe(true);
+
+    // Alpha claims AFTER Bravo has seen the corpse: the next broadcast carries
+    // the claim as a dyn-only lite record (identity already sent), the exact
+    // production sequence the hcb mirror exists for.
+    server.sim.harvestCorpse(mob.id, undefined, sa.pid);
+    expect(mob.harvestClaimedBy).toBe(sa.pid);
+    server.sim.tick(); // advance past the first broadcast's tick so the update is due
+    broadcast(server);
+    const snap = lastSnap(fcB.sent);
+    const rec = snap.ents.find((e: any) => e.id === mob.id);
+    expect(rec.hcb).toBe(sa.pid);
+    expect(rec).not.toHaveProperty('nm'); // lite record: no identity resend
+
+    (client as any).applySnapshot(snap);
+    const mirrored = client.entities.get(mob.id)!;
+    expect(mirrored.harvestClaimedBy).toBe(sa.pid);
+    expect(corpseLootAvailability(mirrored, sb.pid).harvestable).toBe(false);
+  });
+
+  it('scope re-entry rebuilds claim truth: claims and clears made out of view arrive on return', () => {
+    const { server, internals, fcB, sa, sb, mob } = liveSetup();
+
+    broadcast(server);
+    const client = bareClient(sb.pid);
+    (client as any).applySnapshot(lastSnap(fcB.sent));
+    expect(client.entities.get(mob.id)!.harvestClaimedBy).toBeNull();
+
+    // Bravo walks far out of interest range; the server evicts the corpse from
+    // this session's sent set, and the claim lands while it is out of view.
+    const bEnt = internals.entities.get(sb.pid)!;
+    const walkTo = (x: number) => {
+      bEnt.pos = { x, y: 0, z: 0 };
+      bEnt.prevPos = { x, y: 0, z: 0 };
+      server.sim.tick(); // re-index the interest grid at the new position
+      broadcast(server);
+      (client as any).applySnapshot(lastSnap(fcB.sent));
+    };
+    walkTo(5000);
+    server.sim.harvestCorpse(mob.id, undefined, sa.pid);
+    broadcast(server);
+    (client as any).applySnapshot(lastSnap(fcB.sent));
+
+    // Re-entry: the fresh full record carries the claim made out of view.
+    walkTo(0);
+    const back = client.entities.get(mob.id)!;
+    expect(back.harvestClaimedBy).toBe(sa.pid);
+    expect(corpseLootAvailability(back, sb.pid).harvestable).toBe(false);
+
+    // Inverse arm: the claim clears out of view (the respawn sweep write,
+    // mob lifecycle), so the re-entry record omits hcb and the stale
+    // mirrored pid must reset, not linger.
+    walkTo(5000);
+    mob.harvestClaimedBy = null;
+    walkTo(0);
+    const cleared = client.entities.get(mob.id)!;
+    expect(cleared.harvestClaimedBy).toBeNull();
+    expect(corpseLootAvailability(cleared, sb.pid).harvestable).toBe(true);
   });
 });

--- a/tests/corpse_loot_availability.test.ts
+++ b/tests/corpse_loot_availability.test.ts
@@ -51,6 +51,46 @@ describe('corpseLootAvailability', () => {
     expect(result.canOpen).toBe(true);
   });
 
+  it('refuses a corpse the viewing player claimed themselves', () => {
+    // A claim means CONSUMED, for everyone including the claimer: the sim's
+    // authority (resolveCorpseHarvest) denies any non-null claim, and the claim
+    // is only ever written after a successful harvest. Re-offering the corpse
+    // to its own claimer would advertise an action the server refuses; a future
+    // "claimer may reopen" change must consciously flip this pin.
+    const result = corpseLootAvailability(
+      corpse({ templateId: 'forest_wolf', loot: null, harvestClaimedBy: 1 }),
+      1,
+    );
+
+    expect(result.harvestable).toBe(false);
+    expect(result.canOpen).toBe(false);
+  });
+
+  it('refuses a corpse claimed by another player', () => {
+    const result = corpseLootAvailability(
+      corpse({ templateId: 'forest_wolf', loot: null, harvestClaimedBy: 9 }),
+      1,
+    );
+
+    expect(result.harvestable).toBe(false);
+    expect(result.canOpen).toBe(false);
+  });
+
+  it('keeps a claimed corpse openable when the viewer still has personal loot in it', () => {
+    const result = corpseLootAvailability(
+      corpse({
+        templateId: 'forest_wolf',
+        loot: { copper: 0, items: [{ itemId: 'wolf_fang', count: 1, personalFor: [1] }] },
+        harvestClaimedBy: 9,
+      }),
+      1,
+    );
+
+    expect(result.harvestable).toBe(false);
+    expect(result.hasLoot).toBe(true);
+    expect(result.canOpen).toBe(true);
+  });
+
   it('does not infer harvest availability when the host cannot mirror claim state', () => {
     const result = corpseLootAvailability(
       corpse({ templateId: 'forest_wolf', loot: null, harvestClaimedBy: null }),

--- a/tests/trade.test.ts
+++ b/tests/trade.test.ts
@@ -149,7 +149,7 @@ describe('trade module (direct, no Sim)', () => {
   // models real per-slot inventory arrays with instanced payloads explicitly,
   // mirroring how removePreferFungible/addItemInstance behave on the real Sim
   // (src/sim/items.ts), so the trade payload-preservation fix and the capacity
-  // gate (src/sim/social/trade.ts transferOffer/fitsAfterSwap) are exercised end
+  // gate (src/sim/social/trade.ts removeOffer/grantOffer/fitsAfterSwap) are exercised end
   // to end. countFungibleItem/removeItem/countItem honor `s.count` and only
   // treat `!s.instance` slots as fungible, matching the real sim.ts contract.
   function makeInstancedTradeCtx(inv1: any[], inv2: any[]) {
@@ -293,7 +293,7 @@ describe('trade module (direct, no Sim)', () => {
 
   it('splits a mixed offer between the giver’s plain and instanced copies in one transfer', () => {
     // Covers the untested arm: an offer count partly satisfied by plain copies
-    // and partly by an instanced one, so transferOffer's plainCount and
+    // and partly by an instanced one, so the swap's plainCount and
     // instance arms both fire in the same call.
     const instance = { signer: 'Ayla' };
     const { ctx, players } = makeInstancedTradeCtx(
@@ -321,8 +321,8 @@ describe('trade module (direct, no Sim)', () => {
   it('keeps full payloads (signer/charges/rolled/enchant/boundTo) for instances in both directions', () => {
     // The phase acceptance criterion end to end: side A's offer mixes a plain
     // copy with a fully-loaded instanced copy while side B offers a different
-    // instanced item in the SAME trade, so tradeConfirm's second transferOffer
-    // call (offerB, b to a) moves an instance too, and every payload field
+    // instanced item in the SAME trade, so tradeConfirm's second offer leg
+    // (offerB, b to a) moves an instance too, and every payload field
     // (signer, charges, rolled incl. the Phase 2 masterwork marker, the enchant
     // marker, boundTo) must land intact on the right receiver's granted item.
     const instA = {
@@ -366,6 +366,108 @@ describe('trade module (direct, no Sim)', () => {
     expect(plain?.count).toBe(1);
     expect(instanced?.itemId).toBe('wolf_fang');
     expect(instanced?.instance).toEqual(instA);
+  });
+
+  it('swaps same-itemId instances across the trade, not back to their owners', () => {
+    // The sequencing hazard this pins: tradeConfirm used to run the a-to-b
+    // transfer to completion (granting into b's bag) before removing b's give,
+    // so with the SAME itemId on both sides b's removal (highest-index-first,
+    // exactly where addItemInstance pushes) consumed the copy a had just
+    // granted and sent it straight back: the trade "completed" with both
+    // signatures unmoved.
+    const instA = { signer: 'Ayla', rolled: { masterwork: true } };
+    const instB = { signer: 'Borin', rolled: { masterwork: true } };
+    const { ctx, players } = makeInstancedTradeCtx(
+      [{ itemId: 'wolf_fang', count: 1, instance: instA }],
+      [{ itemId: 'wolf_fang', count: 1, instance: instB }],
+    );
+
+    tradeMod.tradeRequest(ctx, 2, 1);
+    tradeMod.tradeAccept(ctx, 2);
+    tradeMod.tradeSetOffer(ctx, [{ itemId: 'wolf_fang', count: 1 }], 0, 1);
+    tradeMod.tradeSetOffer(ctx, [{ itemId: 'wolf_fang', count: 1 }], 0, 2);
+    tradeMod.tradeConfirm(ctx, 1);
+    tradeMod.tradeConfirm(ctx, 2);
+
+    expect(players.get(1).inventory).toHaveLength(1);
+    expect(players.get(1).inventory[0].instance).toEqual(instB);
+    expect(players.get(2).inventory).toHaveLength(1);
+    expect(players.get(2).inventory[0].instance).toEqual(instA);
+  });
+
+  it('routes the instanced copy across when plain copies of the same item flow the other way', () => {
+    // Sibling of the swap pin above: a offers two plain fangs, b offers their
+    // signed one. Granting a's plain copies first used to inflate b's fungible
+    // stock, so b's removal spared the instance and a received a plain copy
+    // back instead of the signed one.
+    const instB = { signer: 'Borin', enchant: 'flame_weapon' };
+    const { ctx, players } = makeInstancedTradeCtx(
+      [{ itemId: 'wolf_fang', count: 2 }],
+      [{ itemId: 'wolf_fang', count: 1, instance: instB }],
+    );
+
+    tradeMod.tradeRequest(ctx, 2, 1);
+    tradeMod.tradeAccept(ctx, 2);
+    tradeMod.tradeSetOffer(ctx, [{ itemId: 'wolf_fang', count: 2 }], 0, 1);
+    tradeMod.tradeSetOffer(ctx, [{ itemId: 'wolf_fang', count: 1 }], 0, 2);
+    tradeMod.tradeConfirm(ctx, 1);
+    tradeMod.tradeConfirm(ctx, 2);
+
+    expect(players.get(1).inventory).toHaveLength(1);
+    expect(players.get(1).inventory[0].instance).toEqual(instB);
+    const bPlain = players.get(2).inventory.filter((s: any) => !s.instance);
+    expect(bPlain.reduce((n: number, s: any) => n + s.count, 0)).toBe(2);
+    expect(players.get(2).inventory.some((s: any) => s.instance)).toBe(false);
+  });
+
+  it('spares the instanced copy when the giver has enough plain stock to cover the offer', () => {
+    // removePreferFungible must CHOOSE here: the giver holds two plain copies
+    // plus one signed copy and offers two, so the signed copy stays home with
+    // its payload and the receiver gets plain ones only. A regression to
+    // bag-order removal (eating the instance first) passes the mixed-offer
+    // test above but fails this pin.
+    const instance = { signer: 'Ayla' };
+    const { ctx, players } = makeInstancedTradeCtx(
+      [
+        { itemId: 'wolf_fang', count: 2 },
+        { itemId: 'wolf_fang', count: 1, instance },
+      ],
+      [],
+    );
+
+    tradeMod.tradeRequest(ctx, 2, 1);
+    tradeMod.tradeAccept(ctx, 2);
+    tradeMod.tradeSetOffer(ctx, [{ itemId: 'wolf_fang', count: 2 }], 0, 1);
+    tradeMod.tradeConfirm(ctx, 1);
+    tradeMod.tradeConfirm(ctx, 2);
+
+    expect(players.get(1).inventory).toHaveLength(1);
+    expect(players.get(1).inventory[0].instance).toEqual(instance);
+    expect(players.get(2).inventory).toHaveLength(1);
+    expect(players.get(2).inventory[0].count).toBe(2);
+    expect(players.get(2).inventory[0].instance).toBeUndefined();
+  });
+
+  it('leaves both inventories untouched by an offer plus cancel (no escrow)', () => {
+    // Offers are declarative session state: items only move inside
+    // tradeConfirm's swap. This pins that contract so a future escrow refactor
+    // must consciously add the return path for instanced payloads.
+    const instance = { signer: 'Ayla', enchant: 'flame_weapon' };
+    const inv1 = [{ itemId: 'wolf_fang', count: 1, instance }];
+    const inv2 = [{ itemId: 'baked_bread', count: 2 }];
+    const { ctx, players } = makeInstancedTradeCtx(inv1, inv2);
+    const snap1 = JSON.parse(JSON.stringify(inv1));
+    const snap2 = JSON.parse(JSON.stringify(inv2));
+
+    tradeMod.tradeRequest(ctx, 2, 1);
+    tradeMod.tradeAccept(ctx, 2);
+    tradeMod.tradeSetOffer(ctx, [{ itemId: 'wolf_fang', count: 1 }], 0, 1);
+    tradeMod.tradeConfirm(ctx, 1);
+    tradeMod.tradeCancel(ctx, 2);
+
+    expect(tradeMod.tradeFor(ctx, 1)).toBe(null);
+    expect(players.get(1).inventory).toEqual(snap1);
+    expect(players.get(2).inventory).toEqual(snap2);
   });
 
   it('updateTradesAndInvites expires stale invites and cancels drifted trades', () => {


### PR DESCRIPTION
## Summary

Phase 3 QA of the Professions 2.0 program (the QA twin of PR #2087, per docs/professions-2/phase-03-qa.md): a three-agent audit (correctness, coverage, cleanup) plus the dispatch-matrix reviewer fan-out over the phase diff, with every should-fix applied. QA verdict: PASS, zero blocking.

The one real correctness defect found lives in the pre-landed PR 2045 trade code, not the Phase 3 diff: tradeConfirm ran the a-to-b transfer to completion (granting into b's bag) before removing b's give, so when both offers shared an itemId the second removal consumed just-granted stock. A swapped instance bounced straight back to its owner (removeItem scans highest-index-first, exactly where addItemInstance pushes), and a plain-for-instance offer spared the instance while mis-routing a plain copy. Conservation always held (no dupe or loss), but the payload carriage the fix exists to guarantee silently failed for same-item trades. The swap is now two-phase (removeOffer both sides, then grantOffer both sides), which matches the model the fitsAfterSwap capacity gate already validated. Reproduced test-first; the coverage reviewer's revert experiment confirms both repro pins red on the old code and the parity draw-order golden is unchanged (the module draws no rng).

Coverage closed on the phase's most valuable gap: the Phase 3 hcb pins drove hand-assembled snap envelopes (always fullJson-shaped), so the exact production sequence the mirror exists for never ran in any test. A new live GameServer broadcast suite pins the claim-after-first-sight lite delta record (hcb present, no identity resend) and interest-scope eviction/re-entry (claims AND clears made out of view arrive on return; a delta-guarded mirror mutation reds the clear arm). Also added: a partial-stack sparing pin (removePreferFungible must choose to spare the instanced copy), a no-escrow trade-cancel contract pin, and the claimed-corpse arms of corpseLootAvailability (self-claimed viewer, claimed-by-another, claimed-with-personal-loot stays openable).

Docs: the hcb as-landed deviation is swept into the phase file and its QA twin (the known amend-the-twin trap: both still instructed the abandoned ALL_DELTA_KEYS / TERSE_TO_IWORLD registration), the phantom bandwidth hcb pin claim is corrected (the snapshots sparse-absence assertion is the real no-bloat tooth), the bareClient drift note is rescoped to the real 21-copy repo-wide idiom (extraction filed as #2088), the Phase 4 despawn-grace heads-up is recorded, and the Phase 3 QA row is flipped.

Deferred with reasons (recorded in progress.md): a bandwidth claimed-corpse scenario (docs made truthful instead) and a distinct-itemId slot-order byte-equivalence pin (the push-to-end plus splice-compaction reasoning is airtight per the architecture review). The harvestStateReliable open-gate flip remains the documented Phase 4 deferral.

## Related issues

Part of #1866. The bareClient fixture extraction chore is filed as #2088.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation

## How was this tested?

- Commands:
  - `npx vitest run tests/trade.test.ts tests/snapshots.test.ts tests/bandwidth.test.ts tests/corpse_harvest_sim.test.ts tests/world_api_parity.test.ts tests/crafting_view_combo_liveness.test.ts tests/corpse_loot_availability.test.ts tests/env_protocol.test.ts tests/architecture.test.ts tests/parity.test.ts tests/localization_fixes.test.ts` (10 files, 477 passed)
  - `npx tsc --noEmit` clean; `npm run gate` under Node 24 (known environmental armory browser red on this machine; typecheck and all builds completed manually after it, PR CI is the arbiter)
  - Reviewer fan-out over this QA diff: architecture-reviewer, cross-platform-sync, test-coverage-auditor (with revert/mutation experiments), qa-checklist: all PASS, zero blocking
- Manual steps: the trade sequencing bug was reproduced test-first (both repro tests red on a8c65a2c2, green after the two-phase fix); the coverage reviewer independently re-ran the revert experiment.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green up to the known environmental armory browser failure on this machine (pre-existing, reproduces on an untouched release tip); typecheck and all builds were completed manually after it. Decisive tests added for all changed behavior.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
