### PR TITLE
fix(render): dequantize baked-pose uv before merging character geometries

### DIFF
--- a/src/render/characters/assets.ts
+++ b/src/render/characters/assets.ts
@@ -15,6 +15,7 @@ import { loadGltf, loadTexture } from '../assets/loader';
 import { registerPreload } from '../assets/preload';
 import { addRimGlow, GFX } from '../gfx';
 import { backGripFor } from './back_grips';
+import { dequantizeAttribute } from './dequantize_attribute';
 import { type HandGrip, KAYKIT_SHIELD_ACCESSORIES, KAYKIT_SHIELD_GRIPS } from './held_item_grips';
 import {
   type AttachDef,
@@ -1101,7 +1102,11 @@ function bakeStaticPose(
     }
     out.setAttribute('position', new THREE.BufferAttribute(baked, 3));
     const uv = srcGeo.getAttribute('uv');
-    if (uv) out.setAttribute('uv', uv.clone());
+    // Different source primitives can quantize uv differently (e.g. a
+    // normalized Uint16Array on one, a plain Float32Array on another);
+    // dequantize so every baked geo's uv shares one typed-array type and
+    // mergeGeometries below can combine them.
+    if (uv) out.setAttribute('uv', dequantizeAttribute(uv as THREE.BufferAttribute));
     if (srcGeo.index) out.setIndex(srcGeo.index.clone());
     out.computeVertexNormals();
     geos.push(out);

--- a/src/render/characters/dequantize_attribute.ts
+++ b/src/render/characters/dequantize_attribute.ts
@@ -1,0 +1,17 @@
+// Baked GLB primitives can quantize non-position attributes (e.g. `uv` as a
+// normalized Uint16Array) differently per primitive. THREE.BufferGeometryUtils
+// .mergeGeometries() requires every geometry's copy of a given attribute name
+// to share the exact same typed-array constructor, so merging primitives whose
+// `uv` came from different source primitives can fail even though the values
+// themselves are compatible. Reading through get* denormalizes a quantized
+// source, so rebuilding into a fresh, un-normalized Float32Array attribute
+// makes differently quantized primitives mergeable.
+import * as THREE from 'three';
+
+export function dequantizeAttribute(attr: THREE.BufferAttribute): THREE.BufferAttribute {
+  const { count, itemSize } = attr;
+  const arr = new Float32Array(count * itemSize);
+  for (let i = 0; i < count; i++)
+    for (let c = 0; c < itemSize; c++) arr[i * itemSize + c] = attr.getComponent(i, c);
+  return new THREE.BufferAttribute(arr, itemSize);
+}

--- a/tests/character_uv_dequantize.test.ts
+++ b/tests/character_uv_dequantize.test.ts
@@ -1,0 +1,69 @@
+// Regression for the "BufferAttribute.array must be of consistent array types
+// across matching attributes" console error seen merging idle-pose bake
+// geometries in src/render/characters/assets.ts `bakeStaticPose`. KayKit
+// primitives can ship `uv` quantized as a normalized Uint16Array on one part
+// and plain Float32Array on another; naively cloning `uv` (as `bakeStaticPose`
+// used to) carries that mismatch straight into mergeGeometries and it silently
+// drops the whole merge (returns undefined, logs console.error).
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { describe, expect, it, vi } from 'vitest';
+import { dequantizeAttribute } from '../src/render/characters/dequantize_attribute';
+
+function geoWithUv(uv: THREE.BufferAttribute): THREE.BufferGeometry {
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute(
+    'position',
+    new THREE.BufferAttribute(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), 3),
+  );
+  geo.setAttribute('uv', uv);
+  geo.setIndex([0, 1, 2]);
+  return geo;
+}
+
+describe('dequantizeAttribute', () => {
+  it('denormalizes a quantized attribute into a plain Float32Array of the same values', () => {
+    const quantized = new THREE.BufferAttribute(
+      new Uint16Array([0, 0, 65535, 0, 0, 65535]),
+      2,
+      true,
+    );
+    const out = dequantizeAttribute(quantized);
+    expect(out.array).toBeInstanceOf(Float32Array);
+    expect(out.normalized).toBe(false);
+    expect(Array.from(out.array as Float32Array)).toEqual([0, 0, 1, 0, 0, 1]);
+  });
+
+  it('lets mergeGeometries combine primitives whose uv attributes were quantized differently', () => {
+    const floatUv = new THREE.BufferAttribute(new Float32Array([0, 0, 1, 0, 0, 1]), 2);
+    const quantizedUv = new THREE.BufferAttribute(
+      new Uint16Array([0, 0, 65535, 0, 0, 65535]),
+      2,
+      true,
+    );
+
+    const errors: unknown[] = [];
+    const spy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+      errors.push(args);
+    });
+
+    const naive = mergeGeometries([geoWithUv(floatUv), geoWithUv(quantizedUv.clone())]);
+    expect(naive).toBeNull();
+    expect(errors.length).toBeGreaterThan(0);
+
+    errors.length = 0;
+    const fixed = mergeGeometries([
+      geoWithUv(dequantizeAttribute(floatUv)),
+      geoWithUv(dequantizeAttribute(quantizedUv)),
+    ]);
+    expect(errors).toEqual([]);
+    expect(fixed).toBeDefined();
+    const mergedUv = fixed?.getAttribute('uv');
+    expect(mergedUv?.array).toBeInstanceOf(Float32Array);
+    expect(Array.from(mergedUv?.array as Float32Array)).toEqual([
+      0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1,
+    ]);
+
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- `bakeStaticPose` (`src/render/characters/assets.ts`) builds the per-key far-LOD / shadow-proxy idle geometry by merging every visible mesh's baked geometry with `mergeGeometries`. It cloned each source mesh's `uv` attribute verbatim, but KayKit GLB primitives quantize `uv` differently per part (a normalized `Uint16Array` on some, a plain `Float32Array` on others).
- `THREE.BufferGeometryUtils.mergeGeometries()` requires every geometry's copy of a given attribute name to share one typed-array constructor, so it rejected the mismatch (`BufferAttribute.array must be of consistent array types across matching attributes`, logged to console) and returned `null` for any affected visual key.
- That left `PreparedVisual.idleGeo` null, which silently drops the far-LOD proxy mesh and the shadow-only proxy mesh in `src/render/characters/visual.ts` (lines ~296-305): the affected character always renders its full skinned rig regardless of distance and never gets a cheap shadow proxy. Not a pixel-visible regression in a normal screenshot (it only changes an internal LOD/shadow fallback path, not geometry shape), so no before/after screenshots are attached; the mermaid below documents the root cause and fix instead.
- Fix: extracted `dequantizeAttribute` (`src/render/characters/dequantize_attribute.ts`), a small pure module that denormalizes any `BufferAttribute` into a fresh, un-normalized `Float32Array` via `getComponent` (same technique `rig_merge.ts`'s `rebakeGeometry` already uses for its own attributes), and used it for `uv` in `bakeStaticPose` so every baked geo shares one attribute type before merging.

```mermaid
flowchart TD
    A[bakeStaticPose per visible mesh] --> B["uv = srcGeo.getAttribute('uv')"]
    B -->|before| C["out.setAttribute('uv', uv.clone())<br/>keeps original typed-array type"]
    C --> D[mergeGeometries across parts]
    D -->|type mismatch: Uint16Array vs Float32Array| E["console.error + returns null<br/>idleGeo = null"]
    E --> F[visual.ts: no far-LOD proxy, no shadow proxy<br/>always renders full skinned rig]

    B -->|after| G["out.setAttribute('uv', dequantizeAttribute(uv))<br/>denormalizes into fresh Float32Array"]
    G --> D
    D -->|all uv now Float32Array| H[merge succeeds<br/>idleGeo populated]
    H --> I[visual.ts: far-LOD proxy + shadow proxy work as intended]
```

## Test plan
- [x] New `tests/character_uv_dequantize.test.ts`: reproduces the exact `mergeGeometries` failure with mismatched `uv` typed arrays (asserts it returns `null` and logs `console.error`), then asserts `dequantizeAttribute` makes the same merge succeed with correct values.
- [x] `npx vitest run tests/character_uv_dequantize.test.ts tests/rig_merge.test.ts tests/rig_merge_assets.test.ts tests/visual_manifest.test.ts tests/visual_anim_state.test.ts tests/architecture.test.ts tests/render_asset_preload.test.ts tests/render_glb_replacement_assets.test.ts tests/render_budget.test.ts` — all pass (107 tests).
- [x] `npx tsc --noEmit -p .` clean.
- [x] `npx @biomejs/biome check` on changed files clean (no new warnings).
- [x] pre-push QA hook green.