### PR TITLE
fix(render): retry boot-time glTF/HDR/texture loads on transient failure

### DIFF
--- a/src/render/assets/load_retry.ts
+++ b/src/render/assets/load_retry.ts
@@ -1,0 +1,11 @@
+// Retry policy for boot-time asset fetches (glTF/HDR/texture). A single
+// transient network blip (common on mobile connections) must not permanently
+// fail the whole `assetsReady()` gate and strand the player on the loading
+// screen with no recourse but "Return to Login".
+export const MAX_LOAD_ATTEMPTS = 3;
+
+/** Delay before the given retry attempt (1-indexed: the delay before the
+ *  2nd, 3rd, ... try). Fixed schedule, no randomness, so tests stay exact. */
+export function retryDelayMs(attempt: number): number {
+  return 400 * attempt;
+}

--- a/src/render/assets/loader.ts
+++ b/src/render/assets/loader.ts
@@ -5,6 +5,7 @@ import * as THREE from 'three';
 import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
 import { type GLTF, GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
+import { MAX_LOAD_ATTEMPTS, retryDelayMs } from './load_retry';
 import { assetUrl } from './media';
 import { assetLoadStarted, recordAssetLoad } from './stats';
 
@@ -55,6 +56,23 @@ function scheduleLoad<T>(q: AssetQueue, run: () => Promise<T>): Promise<T> {
   });
 }
 
+/** Retries a fetch-and-parse attempt on failure: a single transient network
+ *  blip (common on mobile connections) must not permanently sink a boot-time
+ *  asset load. Only the LAST attempt's error escapes; earlier ones are
+ *  swallowed since the caller only cares whether it eventually succeeded. */
+function withRetry<T>(attemptOnce: () => Promise<T>): Promise<T> {
+  const attempt = (n: number): Promise<T> =>
+    attemptOnce().catch((err: unknown) => {
+      if (n >= MAX_LOAD_ATTEMPTS) throw err;
+      return new Promise<T>((resolve, reject) => {
+        globalThis.setTimeout(() => {
+          attempt(n + 1).then(resolve, reject);
+        }, retryDelayMs(n));
+      });
+    });
+  return attempt(1);
+}
+
 function loader(): GLTFLoader {
   if (!gltfLoader) {
     gltfLoader = new GLTFLoader();
@@ -70,30 +88,29 @@ export function loadGltf(url: string): Promise<GLTF> {
   let p = gltfCache.get(resolved);
   if (!p) {
     const startedAt = assetLoadStarted();
-    p = scheduleLoad(
-      gltfQueue,
-      () =>
-        new Promise<GLTF>((resolve, reject) => {
-          loader().load(
-            resolved,
-            (gltf) => {
-              recordAssetLoad('gltf', resolved, startedAt);
-              resolve(gltf);
-            },
-            undefined,
-            () => {
-              recordAssetLoad('gltf', resolved, startedAt, true);
-              reject(new Error(`asset load failed: ${url} (missing file or bad GLB)`));
-            },
-          );
-        }),
-    ).catch((err: unknown) => {
-      // Evict the rejected promise so the next call re-fetches rather than
-      // permanently caching a failure (black void bug: rejected promise poisons
-      // ensureDungeonAssets for the whole session).
-      gltfCache.delete(resolved);
-      throw err;
-    });
+    p = scheduleLoad(gltfQueue, () =>
+      withRetry(
+        () =>
+          new Promise<GLTF>((resolve, reject) => {
+            loader().load(resolved, resolve, undefined, () =>
+              reject(new Error(`asset load failed: ${url} (missing file or bad GLB)`)),
+            );
+          }),
+      ),
+    ).then(
+      (gltf) => {
+        recordAssetLoad('gltf', resolved, startedAt);
+        return gltf;
+      },
+      (err: unknown) => {
+        recordAssetLoad('gltf', resolved, startedAt, true);
+        // Evict the rejected promise so the next call re-fetches rather than
+        // permanently caching a failure (black void bug: rejected promise poisons
+        // ensureDungeonAssets for the whole session).
+        gltfCache.delete(resolved);
+        throw err;
+      },
+    );
     gltfCache.set(resolved, p);
   }
   return p;
@@ -113,24 +130,30 @@ export function loadHdr(url: string): Promise<THREE.DataTexture> {
   let p = hdrCache.get(resolved);
   if (!p) {
     const startedAt = assetLoadStarted();
-    p = scheduleLoad(
-      hdrQueue,
-      () =>
-        new Promise<THREE.DataTexture>((resolve, reject) => {
-          new RGBELoader().load(
-            resolved,
-            (tex) => {
-              tex.mapping = THREE.EquirectangularReflectionMapping;
-              recordAssetLoad('hdr', resolved, startedAt);
-              resolve(tex);
-            },
-            undefined,
-            () => {
-              recordAssetLoad('hdr', resolved, startedAt, true);
-              reject(new Error(`hdr load failed: ${url}`));
-            },
-          );
-        }),
+    p = scheduleLoad(hdrQueue, () =>
+      withRetry(
+        () =>
+          new Promise<THREE.DataTexture>((resolve, reject) => {
+            new RGBELoader().load(
+              resolved,
+              (tex) => {
+                tex.mapping = THREE.EquirectangularReflectionMapping;
+                resolve(tex);
+              },
+              undefined,
+              () => reject(new Error(`hdr load failed: ${url}`)),
+            );
+          }),
+      ),
+    ).then(
+      (tex) => {
+        recordAssetLoad('hdr', resolved, startedAt);
+        return tex;
+      },
+      (err: unknown) => {
+        recordAssetLoad('hdr', resolved, startedAt, true);
+        throw err;
+      },
     );
     hdrCache.set(resolved, p);
   }
@@ -147,25 +170,31 @@ export function loadTexture(
   let p = texCache.get(key);
   if (!p) {
     const startedAt = assetLoadStarted();
-    p = scheduleLoad(
-      textureQueue,
-      () =>
-        new Promise<THREE.Texture>((resolve, reject) => {
-          new THREE.TextureLoader().load(
-            resolved,
-            (tex) => {
-              if (opts.srgb) tex.colorSpace = THREE.SRGBColorSpace;
-              if (opts.repeat) tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
-              recordAssetLoad('texture', resolved, startedAt);
-              resolve(tex);
-            },
-            undefined,
-            () => {
-              recordAssetLoad('texture', resolved, startedAt, true);
-              reject(new Error(`texture load failed: ${url}`));
-            },
-          );
-        }),
+    p = scheduleLoad(textureQueue, () =>
+      withRetry(
+        () =>
+          new Promise<THREE.Texture>((resolve, reject) => {
+            new THREE.TextureLoader().load(
+              resolved,
+              (tex) => {
+                if (opts.srgb) tex.colorSpace = THREE.SRGBColorSpace;
+                if (opts.repeat) tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+                resolve(tex);
+              },
+              undefined,
+              () => reject(new Error(`texture load failed: ${url}`)),
+            );
+          }),
+      ),
+    ).then(
+      (tex) => {
+        recordAssetLoad('texture', resolved, startedAt);
+        return tex;
+      },
+      (err: unknown) => {
+        recordAssetLoad('texture', resolved, startedAt, true);
+        throw err;
+      },
     );
     texCache.set(key, p);
   }

--- a/tests/render_asset_load_retry.test.ts
+++ b/tests/render_asset_load_retry.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MAX_LOAD_ATTEMPTS, retryDelayMs } from '../src/render/assets/load_retry';
+
+// Bug: a single transient network failure (common on mobile) permanently
+// killed a boot-time glTF fetch, surfacing "asset load failed ... missing
+// file or bad GLB" for a perfectly fine file and stranding the player behind
+// the fatal "Return to Login" overlay. loadGltf must retry a bounded number
+// of times before giving up.
+describe('asset load retry policy', () => {
+  it('backs off with a fixed, increasing schedule', () => {
+    expect(retryDelayMs(1)).toBeGreaterThan(0);
+    expect(retryDelayMs(2)).toBeGreaterThan(retryDelayMs(1));
+    // Deterministic, not random: same attempt number always yields the same delay.
+    expect(retryDelayMs(1)).toBe(retryDelayMs(1));
+  });
+
+  it('caps at a small number of attempts (not unbounded retry-storm)', () => {
+    expect(MAX_LOAD_ATTEMPTS).toBeGreaterThanOrEqual(2);
+    expect(MAX_LOAD_ATTEMPTS).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('loadGltf retries a transient failure before rejecting', () => {
+  const url = 'models/chars/enemies/skeleton_mage.glb';
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('succeeds if a later attempt loads fine', async () => {
+    let calls = 0;
+    const fakeGltf = { scene: {} };
+    vi.doMock('three/addons/loaders/GLTFLoader.js', () => ({
+      GLTFLoader: class {
+        setMeshoptDecoder(): void {}
+        load(
+          _url: string,
+          onLoad: (g: unknown) => void,
+          _onProgress: unknown,
+          onError: () => void,
+        ): void {
+          calls++;
+          if (calls < MAX_LOAD_ATTEMPTS) onError();
+          else onLoad(fakeGltf);
+        }
+      },
+    }));
+    vi.doMock('three/addons/libs/meshopt_decoder.module.js', () => ({ MeshoptDecoder: {} }));
+
+    const { loadGltf } = await import('../src/render/assets/loader');
+    const result = await loadGltf(url);
+    expect(result).toBe(fakeGltf);
+    expect(calls).toBe(MAX_LOAD_ATTEMPTS);
+  });
+
+  it('rejects, and evicts the cache entry, once every attempt fails', async () => {
+    let calls = 0;
+    vi.doMock('three/addons/loaders/GLTFLoader.js', () => ({
+      GLTFLoader: class {
+        setMeshoptDecoder(): void {}
+        load(_url: string, _onLoad: unknown, _onProgress: unknown, onError: () => void): void {
+          calls++;
+          onError();
+        }
+      },
+    }));
+    vi.doMock('three/addons/libs/meshopt_decoder.module.js', () => ({ MeshoptDecoder: {} }));
+
+    const { loadGltf } = await import('../src/render/assets/loader');
+    await expect(loadGltf(url)).rejects.toThrow('missing file or bad GLB');
+    expect(calls).toBe(MAX_LOAD_ATTEMPTS);
+
+    // Cache was evicted: a later call re-attempts from scratch rather than
+    // permanently replaying the same rejected promise.
+    calls = 0;
+    await expect(loadGltf(url)).rejects.toThrow('missing file or bad GLB');
+    expect(calls).toBe(MAX_LOAD_ATTEMPTS);
+  });
+});


### PR DESCRIPTION
## Problem

Players intermittently hit a fatal loading-screen error on boot:

```
Asset loading failed: try reloading. Asset preload failed (3): Error: asset
load failed: models/chars/enemies/skeleton_mage.glb (missing file or bad
GLB); Error: asset load failed: models/chars/enemies/skeleton_golem.glb
(missing file or bad GLB); Error: asset load failed:
models/chars/players/rogue_hooded.glb (missing file or bad GLB)
```

The named GLBs are not actually missing or corrupt (verified: valid glTF
binary headers, and their content hashes match the media manifest exactly).
All three failures land in the same `assetsReady()` batch, which is the
signature of a transient network blip (this report came from a mobile
client) rather than a bad asset.

## Root cause

`loadGltf`/`loadHdr`/`loadTexture` in `src/render/assets/loader.ts` each make
exactly one fetch attempt. A single dropped/failed request on a flaky
connection permanently rejects that asset's cached promise, which fails the
whole `Promise.allSettled` gate in `assets/preload.ts`, which `main.ts`
surfaces as the fatal "Return to Login" overlay with no retry path
available to the player.

## Fix

Added a small deterministic retry policy, `src/render/assets/load_retry.ts`
(`MAX_LOAD_ATTEMPTS`, `retryDelayMs`), and wrapped all three loader entry
points with it: a failed attempt is retried with backoff before the promise
is allowed to reject. Only after every attempt fails does the asset actually
fail (still evicting the cache entry, same as before, so a later manual
retry re-fetches from scratch).

```mermaid
sequenceDiagram
    participant Boot as main.ts (startGame)
    participant Preload as assets/preload.ts
    participant Loader as assets/loader.ts
    participant Net as Network fetch

    Boot->>Preload: assetsReady()
    Preload->>Loader: loadGltf(url)
    Loader->>Net: attempt 1
    Net-->>Loader: transient failure
    Loader->>Loader: retryDelayMs(1) backoff
    Loader->>Net: attempt 2
    Net-->>Loader: transient failure
    Loader->>Loader: retryDelayMs(2) backoff
    Loader->>Net: attempt 3
    Net-->>Loader: success
    Loader-->>Preload: resolved GLTF
    Preload-->>Boot: assetsReady() resolves
    Note over Boot: Previously: attempt 1 failing alone<br/>rejected assetsReady() and showed<br/>the fatal "Return to Login" overlay.
```

Not a visual/UI change (loading-robustness only), so no before/after
screenshots per the PR template's screenshot rule.

## Test plan

- [x] New `tests/render_asset_load_retry.test.ts`: pins the retry-policy
      shape (bounded, deterministic, increasing backoff) and drives
      `loadGltf` through a mocked `GLTFLoader` that fails N-1 times then
      succeeds (asserts eventual success), and one that always fails
      (asserts eventual rejection + cache eviction for a clean re-attempt).
- [x] `npx tsc --noEmit`
- [x] `npx vitest run tests/render_asset_load_retry.test.ts
      tests/render_asset_fallback.test.ts tests/render_asset_preload.test.ts
      tests/render_glb_replacement_assets.test.ts tests/assets_stats.test.ts
      tests/glb_assets.test.ts tests/architecture.test.ts
      tests/localization_fixes.test.ts` — all green
- [x] `npx @biomejs/biome check` on changed files — clean (one pre-existing
      unrelated warning on an untouched line)
- [x] Local `pre-push` QA floor passed (typecheck, guard tests, lint, copy
      rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)