### PR TITLE
fix(chat): keep whispering the same player after an explicit /w Name

### DIFF
--- a/src/ui/hud/chat/chat_channels.ts
+++ b/src/ui/hud/chat/chat_channels.ts
@@ -163,6 +163,27 @@ export function composeWhisperReply(typed: string): string {
   return `/r ${text}`;
 }
 
+// The specific target of an explicit whisper command (/w, /whisper, /t, /tell): the
+// first whitespace-delimited token after the command. This is what lets the chat input
+// KEEP whispering the same player after you whisper them, instead of snapping back to
+// the previous standing channel (the reported bug). Multi-word names resolve server-side
+// (longest-online-name match), so the first token is what the client re-sends. A `/r`
+// reply returns null (its target is the last whisperer, known only to the server), as
+// does any non-whisper line.
+export function whisperTargetName(line: string): string | null {
+  const m = /^\/(?:w|whisper|t|tell)\s+(\S+)/i.exec(line.trim());
+  return m ? m[1] : null;
+}
+
+// Compose the text sent for a plain line typed while a specific whisper target is sticky
+// (after an explicit /w to that player): keep whispering them. An explicit slash command
+// the player typed still wins, mirroring composeChatLine / composeWhisperReply.
+export function composeWhisperTo(name: string, typed: string): string {
+  const text = typed.trim();
+  if (!text || text.startsWith('/')) return text;
+  return `/w ${name} ${text}`;
+}
+
 // The standing channel the actually-sent line reached, used to update the sticky
 // "last used" send channel so the next opened input (on the All tab) defaults
 // there. Plain text (no leading slash) went to `say`. An explicit slash command

--- a/src/ui/hud/chat/chat_window_controller.ts
+++ b/src/ui/hud/chat/chat_window_controller.ts
@@ -13,6 +13,7 @@ import {
   chatOpenTabLabelKey,
   composeChatLine,
   composeWhisperReply,
+  composeWhisperTo,
   isChatOpenTab,
   isChatTabChannel,
   parseChatTabs,
@@ -20,6 +21,7 @@ import {
   serializeChatTabs,
   WHISPER_TAB,
   WHISPER_TAB_LABEL_KEY,
+  whisperTargetName,
 } from './chat_channels';
 
 const CHAT_TABS_KEY = 'woc_chat_tabs';
@@ -68,6 +70,12 @@ export class ChatWindowController {
   // generic placeholder). Tracking whisper here is what keeps a reply conversation
   // going instead of snapping the input back to the previous standing channel.
   private stickyTarget: ChatInputTintTarget = 'say';
+  // When the last explicit whisper was "/w Name" (not a /r reply), the specific target
+  // name sticks here so the next plain line keeps whispering that person via "/w Name",
+  // not "/r" (which the server routes to whoever last whispered YOU). A /r reply or any
+  // standing-channel send clears it. Only meaningful while stickyTarget is the whisper
+  // collector and the active view falls back to the sticky (not the dedicated whisper tab).
+  private stickyWhisperName: string | null = null;
   private tabsWheelBound = false;
   private initialized = false;
   private pendingLinks: readonly { display: string; token: string }[] = [];
@@ -124,20 +132,39 @@ export class ChatWindowController {
   }
 
   // Remember the target a just-sent line reached as the sticky default for the next
-  // chat open on the All tab: a standing channel, or `whisper` for a `/r` reply so a
-  // whisper conversation keeps going. An explicit `/w Name`, emotes, rolls, channel
-  // membership, and unknown commands leave the sticky target unchanged. `online`
-  // disambiguates the one host-sensitive alias, bare `/g` (guild online, general
-  // offline), so the sticky follows a guild send made with the classic command.
+  // chat open on the All tab: a standing channel, `whisper` for a `/r` reply, or a
+  // SPECIFIC player for an explicit `/w Name` so the conversation keeps whispering that
+  // person (the reported bug). Emotes, rolls, channel membership, and unknown commands
+  // leave the sticky target unchanged. `online` disambiguates the one host-sensitive
+  // alias, bare `/g` (guild online, general offline), so the sticky follows a guild send
+  // made with the classic command.
   noteSentChannel(sentLine: string, online: boolean): void {
+    const whisperName = whisperTargetName(sentLine);
+    if (whisperName !== null) {
+      this.stickyTarget = WHISPER_TAB;
+      this.stickyWhisperName = whisperName;
+      return;
+    }
     const target = sentLineTargetForHost(sentLine, { online });
-    if (target) this.stickyTarget = target;
+    if (target) {
+      this.stickyTarget = target;
+      // A /r reply keeps the whisper sticky but has no client-known name (it replies to
+      // the last whisperer); any standing-channel send drops the specific target too.
+      this.stickyWhisperName = null;
+    }
   }
 
   composeSend(typed: string): string {
     const withLinks = this.applyPendingLinks(typed);
     const target = this.effectiveSendTarget();
-    if (target === WHISPER_TAB) return composeWhisperReply(withLinks);
+    if (target === WHISPER_TAB) {
+      // A specific /w target (from the All/combat sticky) keeps whispering that player;
+      // the dedicated whisper collector tab, and a /r-sticky, reply to the last whisperer.
+      if (this.activeChatTab !== WHISPER_TAB && this.stickyWhisperName) {
+        return composeWhisperTo(this.stickyWhisperName, withLinks);
+      }
+      return composeWhisperReply(withLinks);
+    }
     return composeChatLine(target, withLinks);
   }
 
@@ -169,9 +196,14 @@ export class ChatWindowController {
   // Placeholder for the chat input reflecting the active tab and sticky target.
   activePlaceholder(): string {
     const target = this.effectiveSendTarget();
-    // The whisper collector (its own tab, or a sticky `/r` reply) prompts "Whisper".
+    // The whisper collector (its own tab, or a sticky `/r` reply) prompts "Whisper"; a
+    // sticky `/w Name` target names the player so it is clear who plain text will reach.
     if (target === WHISPER_TAB) {
-      return t('hud.core.chatChannels.sendingTo', { channel: t(WHISPER_TAB_LABEL_KEY) });
+      const channel =
+        this.activeChatTab !== WHISPER_TAB && this.stickyWhisperName
+          ? this.stickyWhisperName
+          : t(WHISPER_TAB_LABEL_KEY);
+      return t('hud.core.chatChannels.sendingTo', { channel });
     }
     // A channel-bound tab keeps its "Message {channel}" prompt (unchanged, incl. a
     // Say tab). On the All/combat views a non-say sticky channel surfaces the same

--- a/tests/chat_channels.test.ts
+++ b/tests/chat_channels.test.ts
@@ -8,6 +8,7 @@ import {
   chatOpenTabLabelKey,
   composeChatLine,
   composeWhisperReply,
+  composeWhisperTo,
   isChatOpenTab,
   isChatTabChannel,
   parseChatTabs,
@@ -17,6 +18,7 @@ import {
   serializeChatTabs,
   WHISPER_TAB,
   WHISPER_TAB_LABEL_KEY,
+  whisperTargetName,
 } from '../src/ui/hud/chat/chat_channels';
 
 describe('chat channel tabs — pure model', () => {
@@ -123,8 +125,43 @@ describe('chat channel tabs — pure model', () => {
         expect(composeWhisperReply('/p inc')).toBe('/p inc');
       });
 
-      it('drops empty input', () => {
+      it('leaves blank input empty', () => {
         expect(composeWhisperReply('   ')).toBe('');
+      });
+    });
+
+    describe('whisperTargetName (the sticky target of an explicit /w)', () => {
+      it('extracts the first-token name from every whisper alias', () => {
+        expect(whisperTargetName('/w strong hey')).toBe('strong');
+        expect(whisperTargetName('/whisper Bob meet me')).toBe('Bob');
+        expect(whisperTargetName('/t Alice hi')).toBe('Alice');
+        expect(whisperTargetName('/tell Carol yo')).toBe('Carol');
+        expect(whisperTargetName('  /w  Dana  padded  ')).toBe('Dana');
+      });
+
+      it('returns null for /r and every non-whisper line (no client-known target)', () => {
+        // /r replies to whoever last whispered YOU, a target only the server knows.
+        expect(whisperTargetName('/r on my way')).toBeNull();
+        expect(whisperTargetName('/reply ok')).toBeNull();
+        expect(whisperTargetName('/p inc')).toBeNull();
+        expect(whisperTargetName('hello')).toBeNull();
+        expect(whisperTargetName('')).toBeNull();
+      });
+    });
+
+    describe('composeWhisperTo (keep whispering a specific player)', () => {
+      it('prepends /w <name> to plain text', () => {
+        expect(composeWhisperTo('strong', 'you there?')).toBe('/w strong you there?');
+        expect(composeWhisperTo('Bob', '  hi  ')).toBe('/w Bob hi');
+      });
+
+      it('lets an explicit slash command win (a one-off to someone else)', () => {
+        expect(composeWhisperTo('strong', '/p inc')).toBe('/p inc');
+        expect(composeWhisperTo('strong', '/w Bob hi')).toBe('/w Bob hi');
+      });
+
+      it('leaves blank input empty', () => {
+        expect(composeWhisperTo('strong', '   ')).toBe('');
       });
     });
   });

--- a/tests/chat_window_controller.test.ts
+++ b/tests/chat_window_controller.test.ts
@@ -151,4 +151,48 @@ describe('ChatWindowController', () => {
     expect(harness.controller.composeSend('ready')).toBe('/r ready');
     expect(harness.input.style.color).toBe('#ff80ff');
   });
+
+  it('keeps whispering the same player after an explicit /w Name (the reported bug)', () => {
+    const harness = makeHarness();
+    harness.controller.init();
+
+    // The player whispers "strong": the explicit command passes through untouched, and
+    // noteSentChannel records the target as the sticky whisper.
+    const sent = harness.controller.composeSend('/w strong hey');
+    expect(sent).toBe('/w strong hey');
+    harness.controller.noteSentChannel(sent, false);
+
+    // The next plain line must keep whispering strong, not fall back to /say.
+    expect(harness.controller.composeSend('you there?')).toBe('/w strong you there?');
+
+    // And the input tints to the whisper color so the mode is visible.
+    harness.controller.applyInputPresentation();
+    expect(harness.input.style.color).toBe('#ff80ff');
+  });
+
+  it('drops the specific whisper target once the next send goes to a standing channel', () => {
+    const harness = makeHarness();
+    harness.controller.init();
+
+    harness.controller.noteSentChannel('/w strong hey', false);
+    expect(harness.controller.composeSend('again')).toBe('/w strong again');
+
+    // Sending to a standing channel moves the sticky and clears the whisper target,
+    // so plain text no longer whispers.
+    const partySent = harness.controller.composeSend('/p inc');
+    expect(partySent).toBe('/p inc');
+    harness.controller.noteSentChannel(partySent, false);
+    expect(harness.controller.composeSend('gg')).toBe('/p gg');
+  });
+
+  it('a /r reply keeps the whisper sticky but does not glue to a specific /w target', () => {
+    const harness = makeHarness();
+    harness.controller.init();
+
+    // First /w strong, then a /r reply: the reply routes to whoever last whispered you,
+    // so the next plain line must compose as /r, not /w strong.
+    harness.controller.noteSentChannel('/w strong hey', false);
+    harness.controller.noteSentChannel('/r sure', false);
+    expect(harness.controller.composeSend('coming')).toBe('/r coming');
+  });
 });


### PR DESCRIPTION
## What

Whispering someone now persists: after you `/w strong hey`, the next plain line keeps whispering strong instead of reverting to `/say`.

## The bug

The chat input has a "sticky" send target (classic behavior: your next plain line goes wherever you last spoke). The sticky model deliberately stuck a `/r` reply but never an explicit `/w Name`, so after whispering a specific player the next line fell back to your previous standing channel (usually `/say`). See the screenshot in the issue: "To strong: hey" is followed by "says: test".

The reason `/w Name` was excluded: sticking it as a bare whisper would compose the next line as `/r`, which the server routes to whoever last whispered *you*, not the person you whispered. So the sticky had no way to remember *which* player.

## The fix

The controller now tracks the specific whisper target name:
- Sending `/w Name ...` records `Name` as the sticky whisper target.
- The next plain line composes as `/w Name ...`, so the conversation continues to that player.
- A `/r` reply still sticks to the whisper collector (reply-to-last-whisperer) but drops the specific name; any standing-channel send clears it.
- The input placeholder names the target and tints to the whisper color, so it is clear who plain text will reach.

Two small pure helpers carry the logic, `whisperTargetName` and `composeWhisperTo`, both in the existing DOM-free `chat_channels.ts` and unit-tested. No new i18n keys (reuses the existing `sendingTo` placeholder).

## Testing

Test-first (all fail on the pre-fix code):
- `tests/chat_channels.test.ts`: unit tests for `whisperTargetName` (every whisper alias `/w`, `/whisper`, `/t`, `/tell`; null for `/r` and non-whisper lines) and `composeWhisperTo`.
- `tests/chat_window_controller.test.ts`: reproduces the reported bug end to end (whisper strong, then a plain line composes `/w strong ...` not `/say ...`), plus the target-drop-on-standing-channel case and the `/r`-stays-a-reply case.

Green locally: `chat_channels`, `chat_window_controller`, `chat_hud_client_seam`, `chat_item_link_draft`, `chat_tab_strip`, `chat_filter_commands`. `tsc` clean, biome clean.

Base: `release/v0.28.0`.
