### PR TITLE
fix(sim): stop Nature's Fury spamming its buff-gained cue every second

### DIFF
--- a/src/sim/combat/natures_fury.ts
+++ b/src/sim/combat/natures_fury.ts
@@ -22,6 +22,19 @@ export function tickNaturesFury(ctx: SimContext, p: Entity, meta: PlayerMeta): v
   if (!p.auras.some((aura) => aura.kind === 'form_moonkin')) return;
   if (ctx.tickCount % PULSE_EVERY_TICKS !== p.id % PULSE_EVERY_TICKS) return;
   const apply = (target: Entity): void => {
+    // A pulse this cadence just extends an aura that is already up: refresh the
+    // window in place rather than round-tripping through applyAura, which would
+    // re-fire an 'aura' gained:true SimEvent (buff-gained FCT/SFX) every second
+    // even though nothing actually changed for the player.
+    const existing = target.auras.find(
+      (aura) => aura.id === NATURES_FURY_ID && aura.sourceId === p.id,
+    );
+    if (existing) {
+      existing.remaining = REFRESH_SECONDS;
+      existing.duration = REFRESH_SECONDS;
+      existing.value = pct;
+      return;
+    }
     ctx.applyAura(target, {
       id: NATURES_FURY_ID,
       name: "Nature's Fury",

--- a/tests/natures_fury.test.ts
+++ b/tests/natures_fury.test.ts
@@ -84,4 +84,29 @@ describe("Nature's Fury", () => {
     sim.setPlayerLevel(20);
     expect(sim.resolvedAbility('hurricane')?.def.name).toBe('Galeheart');
   });
+
+  it('does not re-announce a gained buff on every 1s refresh pulse', () => {
+    const { sim, druid } = setup();
+    (sim as unknown as { applyAura(t: Entity, a: Aura): void }).applyAura(
+      druid,
+      moonwingAura(druid.id),
+    );
+    let druidGainedCount = 0;
+    // 4 seconds: long enough to cross several 1s refresh pulses (each pulse
+    // carries a 3s window), while the druid stays in form the whole time. The
+    // druid should only ever "gain" the buff once; later pulses just extend it.
+    for (let i = 0; i < 80; i++) {
+      for (const ev of sim.tick()) {
+        if (
+          ev.type === 'aura' &&
+          ev.name === "Nature's Fury" &&
+          ev.gained &&
+          ev.targetId === druid.id
+        )
+          druidGainedCount++;
+      }
+    }
+    expect(druidGainedCount).toBe(1);
+    expect(fury(druid)?.remaining).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary
- Nature's Fury (druid level-20 row) pulses once a second to refresh its 3s
  spell-crit window on the moonwing druid and nearby party members, by design,
  so a missed pulse never lets the buff flicker off. The bug: every pulse
  round-tripped through `applyAura()`, which unconditionally emits an
  `'aura' gained:true` `SimEvent` -- so the buff-gained FCT/sound cue fired
  again every single second even though nothing had actually changed for the
  player. It looked and sounded like the buff was constantly reapplying itself
  and never settling, exactly as reported ("spamming every second for a 3
  second duration, it never stops").
- Fix: when a refresh pulse finds the aura already present from the same
  source, refresh its `remaining`/`duration` in place instead of calling
  `applyAura` again, so the "gained" event (and its cue) fires exactly once,
  on the real first application. The aura still lapses correctly if the
  druid drops out of Moonwing Form or the party member moves out of range
  (unchanged, covered by the existing tests).
- Scoped to `src/sim/combat/natures_fury.ts`; draws no rng, so no golden
  parity regen is needed.

## Why this bug happened (mermaid)
```mermaid
sequenceDiagram
    participant Sim as Sim.tick()
    participant NF as tickNaturesFury
    participant Aura as Entity.auras
    participant Client as Client HUD/SFX

    Note over Sim,Client: Every 1s pulse (each Nature's Fury window is 3s)

    rect rgb(255, 230, 230)
    Note right of NF: BEFORE
    loop every 1s while in Moonwing Form
        Sim->>NF: tick
        NF->>Aura: applyAura() (always)
        Aura-->>Client: emit aura gained:true
        Client-->>Client: buff_apply SFX + FCT (every second, forever)
    end
    end

    rect rgb(220, 245, 220)
    Note right of NF: AFTER
    Sim->>NF: tick (1st pulse)
    NF->>Aura: applyAura() (new)
    Aura-->>Client: emit aura gained:true
    Client-->>Client: buff_apply SFX + FCT (once)
    loop every 1s thereafter, still in form
        Sim->>NF: tick
        NF->>Aura: refresh remaining/duration in place (no re-apply)
        Note right of Aura: no gained event emitted
    end
    end
```

## Test plan
- [x] Added a failing-first repro test (`tests/natures_fury.test.ts`): ticks a
      moonwing druid through several 1s refresh pulses and asserts the
      druid's `'aura' gained:true` event for Nature's Fury fires exactly once,
      not once per pulse. Confirmed it failed before the fix (8 gained events
      over 4s across druid+ally) and passes after.
- [x] `npx tsc --noEmit`
- [x] `npx vitest run tests/natures_fury.test.ts tests/architecture.test.ts tests/localization_fixes.test.ts tests/parity` -- all green
- [x] `npx @biomejs/biome check` on both changed files -- clean
- [x] No visual/HUD change, so no before/after screenshots (this is a sim
      event-emission fix; the reproduction is a SimEvent-count assertion, not
      a rendered surface).