### PR TITLE
fix(bot): stop level-on-name Discord nicknames from compounding

### DIFF
--- a/bot/CLAUDE.md
+++ b/bot/CLAUDE.md
@@ -52,8 +52,10 @@ Zero new dependencies: Gateway over the existing `ws`, REST via built-in `fetch`
 - Role sync + members-meta push: every `ROLE_SYNC_INTERVAL_MS` (5 min), plus once on
   `GUILD_CREATE`. Tier-role refresh + special-roles refresh: once at startup (before the
   gateway connects) and every 5 min, NOT on `GUILD_CREATE`. The same sync also
-  sets the level-on-name nickname (`buildLevelNick`, built from the stable Discord
-  handle so re-syncs never compound; `DISCORD_SYNC_NICKNAMES=0` disables).
+  sets the level-on-name nickname (`buildLevelNick`; the base name fallback can be
+  the member's own already-suffixed live nick, so `buildLevelNick` strips any
+  existing suffix first to stay idempotent across re-syncs;
+  `DISCORD_SYNC_NICKNAMES=0` disables).
 - Presence push: debounced `PRESENCE_DEBOUNCE_MS` (4 s) after voice/presence events.
 - Relay, activity feed, daily-rewards winners: drained every `RELAY_POLL_MS` (3 s).
   Daily-rewards days are marked back on the server only after a successful post,

--- a/bot/logic.ts
+++ b/bot/logic.ts
@@ -346,16 +346,33 @@ export function levelNickSuffix(level: number, className: string): string {
   return ` ${emoji}${level}`;
 }
 
+// Matches one or more trailing " {classEmoji}{digits}" suffixes, so a name that
+// already carries one or several (from a prior compounding bug, or from being fed
+// a live Discord nick instead of the stable base) is fully cleaned before the
+// fresh suffix is appended.
+const CLASS_EMOJI_ALT = Object.values(CLASS_EMOJI)
+  .map((e) => e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  .join('|');
+const LEVEL_SUFFIX_RE = new RegExp(`(?: (?:${CLASS_EMOJI_ALT})\\d+)+$`, 'u');
+
+/** Strip every trailing class-icon+level suffix, leaving the bare base name. */
+export function stripLevelSuffix(name: string): string {
+  const stripped = name.replace(LEVEL_SUFFIX_RE, '').trimEnd();
+  return stripped || name;
+}
+
 /**
  * Build a Discord server nickname that appends a class icon + level to the base
- * name, capped at Discord's 32-char limit. Built from the STABLE base (the Discord
- * handle), never the current nick, so re-syncs are idempotent (no compounding).
- * Code-point aware so an emoji is never split.
+ * name, capped at Discord's 32-char limit. Any existing level suffix (one or
+ * several, e.g. from a prior compounding bug) is stripped first, so the result
+ * always carries exactly one class icon + level regardless of what base name is
+ * passed in; re-syncs are idempotent (no compounding). Code-point aware so an
+ * emoji is never split.
  */
 export function buildLevelNick(baseName: string, level: number, className: string): string {
   const suffix = levelNickSuffix(level, className);
   const suffixLen = [...suffix].length;
-  const base = [...baseName]
+  const base = [...stripLevelSuffix(baseName)]
     .slice(0, Math.max(1, NICK_MAX - suffixLen))
     .join('')
     .trimEnd();

--- a/bot/main.ts
+++ b/bot/main.ts
@@ -234,8 +234,10 @@ async function main(): Promise<void> {
         console.error(e);
       }
     }
-    // Attach the in-game level + class icon to the member's Discord nickname
-    // (built from the stable Discord handle so re-syncs don't compound).
+    // Attach the in-game level + class icon to the member's Discord nickname.
+    // The base name fallback can be the member's already-suffixed live nick
+    // (flex.username is null for older links), so buildLevelNick strips any
+    // existing suffix first to stay idempotent across re-syncs.
     if (cfg.syncNicknames && flex.character) {
       const base = flex.username ?? memberNames.get(userId) ?? 'Member';
       const nick = buildLevelNick(base, flex.character.level, flex.character.class);

--- a/tests/discord_bot.test.ts
+++ b/tests/discord_bot.test.ts
@@ -31,6 +31,7 @@ import {
   requestGuildMembersPayload,
   rosterComplete,
   staleFlairedIds,
+  stripLevelSuffix,
   tierRoleName,
   topSpecialRoleKeyFor,
   voiceMembersForChannel,
@@ -372,6 +373,37 @@ describe('level-on-name nickname', () => {
 
   it('is idempotent when built from the same stable base', () => {
     expect(buildLevelNick('Aldric', 20, 'warrior')).toBe(buildLevelNick('Aldric', 20, 'warrior'));
+  });
+
+  it('replaces an existing suffix instead of compounding it', () => {
+    // Simulates a re-sync fed the CURRENT (already-suffixed) nick as its base,
+    // e.g. because the fallback chain reused the live Discord nick.
+    const first = buildLevelNick('Aldric', 20, 'warrior');
+    const second = buildLevelNick(first, 21, 'warrior');
+    expect(second).toBe(`Aldric${levelNickSuffix(21, 'warrior')}`);
+  });
+
+  it('collapses several stacked suffixes from a prior compounding bug down to one', () => {
+    // Simulates a name mangled by the old compounding bug: several suffixes
+    // (possibly from different classes/levels) stacked back to back.
+    const stacked =
+      'Enrik' +
+      levelNickSuffix(20, 'warrior').repeat(5) +
+      levelNickSuffix(2, 'warrior') +
+      levelNickSuffix(20, 'warrior');
+    expect(buildLevelNick(stacked, 20, 'warrior')).toBe(`Enrik${levelNickSuffix(20, 'warrior')}`);
+
+    const stackedMixed =
+      'jgyy' +
+      levelNickSuffix(1, 'rogue').repeat(3) +
+      levelNickSuffix(1, 'priest') +
+      levelNickSuffix(1, 'rogue').repeat(3) +
+      levelNickSuffix(1, 'priest').repeat(2);
+    expect(stripLevelSuffix(stackedMixed)).toBe('jgyy');
+  });
+
+  it('stripLevelSuffix leaves a name with no suffix unchanged', () => {
+    expect(stripLevelSuffix('Aldric')).toBe('Aldric');
   });
 });
 


### PR DESCRIPTION
## Summary

- Fixes the Discord bot's level-on-name nickname sync compounding a class icon +
  level suffix onto itself every 5-minute re-sync (`Enrik ⚔20 ⚔20 ⚔20 ⚔20 ⚔20 ⚔2 ⚔20`
  instead of `Enrik ⚔20`), reported from a live screenshot of the server.
- `buildLevelNick` now strips any existing trailing class-icon+level suffix (one or
  several) from the base name before appending the fresh one, so the result always
  carries exactly one icon + level no matter what base name feeds it. Re-syncs stay
  on the existing 5-minute cadence; this also self-heals nicknames already broken by
  the compounding bug on their next periodic sync, with no manual cleanup needed.

## Root cause

```mermaid
sequenceDiagram
    participant Poll as syncRolesFor (every 5 min)
    participant Server as game server /flex
    participant Cache as memberNames cache
    participant Discord as Discord REST (setNickname)

    Note over Poll,Discord: BEFORE: fallback reused the CURRENT (already-suffixed) nick
    Poll->>Server: flex(userId)
    Server-->>Poll: flex.username = null (older link, no stored handle)
    Poll->>Cache: memberNames.get(userId)
    Cache-->>Poll: "Aldric ⚔20" (already suffixed from the LAST sync)
    Poll->>Poll: buildLevelNick("Aldric ⚔20", 20, warrior)
    Poll->>Discord: setNickname("Aldric ⚔20 ⚔20")
    Discord-->>Cache: GUILD_MEMBER_UPDATE (re-caches the newly stacked nick)
    Note over Poll,Discord: Every subsequent cycle appends ANOTHER suffix
```

```mermaid
sequenceDiagram
    participant Poll as syncRolesFor (every 5 min)
    participant Server as game server /flex
    participant Cache as memberNames cache
    participant Discord as Discord REST (setNickname)

    Note over Poll,Discord: AFTER: buildLevelNick strips ANY existing suffix first
    Poll->>Server: flex(userId)
    Server-->>Poll: flex.username = null
    Poll->>Cache: memberNames.get(userId)
    Cache-->>Poll: "Aldric ⚔20" (or even a stacked "Aldric ⚔20 ⚔20 ⚔20")
    Poll->>Poll: stripLevelSuffix() removes EVERY trailing suffix -> "Aldric"
    Poll->>Poll: buildLevelNick("Aldric", 20, warrior)
    Poll->>Discord: setNickname("Aldric ⚔20")
    Note over Poll,Discord: Idempotent: exactly one icon + level, every cycle, self-healing
```

## Changes

- `bot/logic.ts`: `stripLevelSuffix()` (new, exported) strips one or more trailing
  ` {classEmoji}{level}` suffixes via a regex built from `CLASS_EMOJI`.
  `buildLevelNick()` now calls it on the base name before appending the fresh suffix.
- `tests/discord_bot.test.ts`: covers replacing (not compounding) an existing
  suffix, collapsing several stacked suffixes down to one, and the no-suffix
  passthrough case.

## Test plan

- [x] `npx vitest run tests/discord_bot.test.ts` (44 tests, all green, including 3 new)
- [x] `npx vitest run tests/architecture.test.ts` (sim purity guard, unaffected)
- [x] `npx tsc --noEmit`
- [x] `npx @biomejs/biome check --write bot/logic.ts tests/discord_bot.test.ts` (no new
      warnings; the pre-existing `noExplicitAny` warnings are unrelated pre-existing debt)
- [x] Pre-push QA floor (`.githooks/pre-push`): green
- [x] Merge-tree against `release/v0.28.0`: clean, no conflicts
