### PR TITLE
fix(sim): make scripted boss control unbreakable

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -826,6 +826,8 @@ interface WireAura {
   // per-viewer), so the per-entity dyn cache keeps eliding; an old client ignores it and
   // an old server's omission decodes to 0, which matches no player id.
   src?: number;
+  // Encounter-owned control marker. Omitted for ordinary auras.
+  ub?: 1;
 }
 
 interface WhoRosterRow {
@@ -961,6 +963,7 @@ function wireAura(a: Aura): WireAura {
   // The caster's entity id, for the client's own-aura prominence on the target strip
   // (auras_view ownFirst). Omitted for the rare 0/absent source, which decodes to 0.
   if (a.sourceId) w.src = a.sourceId;
+  if (a.unbreakableControl) w.ub = 1;
   return w;
 }
 

--- a/server/snapshot_timer_wire.ts
+++ b/server/snapshot_timer_wire.ts
@@ -27,6 +27,7 @@ interface StableAuraRecord {
   charges: number | undefined;
   empowerAbilities: readonly string[] | undefined;
   sourceId: number;
+  unbreakableControl: boolean;
   paused: boolean;
   deadline: number;
 }
@@ -47,6 +48,7 @@ interface StableAuraWire {
   charges?: number;
   emp?: readonly string[];
   src?: number;
+  ub?: 1;
 }
 
 function round2(value: number): number {
@@ -86,6 +88,7 @@ function auraMatches(
     record.charges === aura.charges &&
     sameStringList(record.empowerAbilities, aura.empowerAbilities) &&
     record.sourceId === aura.sourceId &&
+    record.unbreakableControl === (aura.unbreakableControl === true) &&
     record.paused === paused &&
     record.deadline === deadline
   );
@@ -106,6 +109,7 @@ function auraRecord(aura: Aura, simTime: number, paused: boolean): StableAuraRec
     charges: aura.charges,
     empowerAbilities: aura.empowerAbilities ? [...aura.empowerAbilities] : undefined,
     sourceId: aura.sourceId,
+    unbreakableControl: aura.unbreakableControl === true,
     paused,
     deadline: round2(paused ? aura.remaining : simTime + aura.remaining),
   };
@@ -129,6 +133,7 @@ function auraWire(record: StableAuraRecord): StableAuraWire {
   if (record.charges !== undefined) wire.charges = record.charges;
   if (record.empowerAbilities !== undefined) wire.emp = record.empowerAbilities;
   if (record.sourceId) wire.src = record.sourceId;
+  if (record.unbreakableControl) wire.ub = 1;
   return wire;
 }
 

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -135,6 +135,7 @@ interface ClientWireAura {
   charges?: number;
   emp?: Aura['empowerAbilities'];
   src?: number;
+  ub?: 1;
 }
 
 // ---------------------------------------------------------------------------
@@ -2410,6 +2411,7 @@ export class ClientWorld implements IWorld {
             // The caster's entity id, for the target strip's own-aura prominence
             // (auras_view ownFirst). An old server omits it; 0 matches no player id.
             rec.sourceId = a.src ?? 0;
+            rec.unbreakableControl = a.ub === 1 ? true : undefined;
           }
         } else {
           e.auras = wireAuras.map((a) => ({
@@ -2427,6 +2429,7 @@ export class ClientWorld implements IWorld {
             stacks: a.stacks,
             charges: a.charges,
             empowerAbilities: a.emp,
+            unbreakableControl: a.ub === 1 ? true : undefined,
           }));
         }
       }

--- a/src/sim/aura_classify.ts
+++ b/src/sim/aura_classify.ts
@@ -3,7 +3,8 @@
 // i18n), so it lives in src/sim/ and both src/ui/hud.ts and src/sim/sim.ts import
 // it. Keeping ONE classifier avoids the drift where the HUD treated silence/disarm/
 // blind/etc. as debuffs but /targetbuffs (a narrower set) tagged them as buffs.
-import type { AuraKind } from './types';
+import { isUnbreakableControlAura } from './combat/cc';
+import type { Aura, AuraKind } from './types';
 
 // A kind that is harmful by nature regardless of its value. Mirrors classic-era
 // "Debuff" framing: damage-over-time, crowd control, stat/armor reductions, and
@@ -49,9 +50,10 @@ export function isDebuffAura(kind: AuraKind, value: number): boolean {
 // and the cast's direction picks the polarity (an OFFENSIVE dispel strips a
 // benefit off an enemy; a friendly one strips a harmful effect off an ally).
 export function isDispellableAura(
-  aura: { kind: AuraKind; value: number; school: string },
+  aura: Pick<Aura, 'kind' | 'value' | 'school' | 'unbreakableControl'>,
   offensive: boolean,
 ): boolean {
+  if (isUnbreakableControlAura(aura)) return false;
   if (aura.school === 'physical') return false;
   const harmful = isDebuffAura(aura.kind, aura.value);
   return offensive ? !harmful : harmful;

--- a/src/sim/combat/aura_cancel.ts
+++ b/src/sim/combat/aura_cancel.ts
@@ -7,6 +7,7 @@
 // provably the same set and can never drift apart.
 import { isDebuffAura as classifyDebuffAura } from '../aura_classify';
 import type { Aura } from '../types';
+import { isUnbreakableControlAura } from './cc';
 
 // A debuff is anything in the harmful set, OR a stat aura riding a `buff_*` kind
 // with a negative value (an enfeeble / wither drain reuses a buff_* kind but saps
@@ -19,7 +20,7 @@ export function isDebuffAura(a: Aura): boolean {
 // classic right-click-cancel includes forms, stances, and stealth (canceling a
 // form aura reverts to caster form) since none of those are harmful.
 export function isCancelableAura(a: Aura): boolean {
-  return !isDebuffAura(a);
+  return !isUnbreakableControlAura(a) && !isDebuffAura(a);
 }
 
 // Whether removing this aura changes derived stats and so needs a recalc to

--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -55,7 +55,15 @@ import {
   normAngle,
 } from '../types';
 import { drawWeapon } from '../weapon_stow';
-import { isInStasis, isLockedOut, isSilenced, isStunned, tonguesMult } from './cc';
+import {
+  hasUnbreakableMovementLock,
+  isInStasis,
+  isLockedOut,
+  isSilenced,
+  isStunned,
+  isUnbreakableControlAura,
+  tonguesMult,
+} from './cc';
 import {
   ARCANE_SURGE_ID,
   aetherDartsBoltBonus,
@@ -127,12 +135,23 @@ function isStasisToggle(ability: AbilityDef): boolean {
 }
 
 function cancelStasisToggle(ctx: SimContext, entity: Entity, ability: AbilityDef): boolean {
-  if (!isStasisToggle(ability) || !entity.auras.some((aura) => aura.id === ability.id)) {
+  if (
+    !isStasisToggle(ability) ||
+    !entity.auras.some(
+      (aura) =>
+        aura.id === ability.id && aura.sourceId === entity.id && !isUnbreakableControlAura(aura),
+    )
+  ) {
     return false;
   }
   for (let index = entity.auras.length - 1; index >= 0; index--) {
     const aura = entity.auras[index];
-    if (aura.id !== ability.id && aura.id !== `${ability.id}_absorb`) continue;
+    if (
+      (aura.id !== ability.id && aura.id !== `${ability.id}_absorb`) ||
+      aura.sourceId !== entity.id ||
+      isUnbreakableControlAura(aura)
+    )
+      continue;
     entity.auras.splice(index, 1);
     ctx.emit({ type: 'aura', targetId: entity.id, name: aura.name, gained: false });
   }
@@ -448,10 +467,9 @@ export function castAbility(
   meta.lastActiveTick = ctx.tickCount; // a cast attempt is a deliberate action
   const ability = res.def;
   if (cancelStasisToggle(ctx, p, ability)) return;
-  // Ice Block (usableWhileControlled) ignores control: it may be pressed while
-  // stunned, polymorphed, incapacitated, silenced, or locked out, so it always frees
-  // the caster (its cleanseSelf effect then strips the debuffs). Its own stasis is the
-  // one control it still respects, but the recast toggle above already handles that.
+  // Ice Block (usableWhileControlled) may be pressed through ordinary control;
+  // cleanseSelf removes the player-breakable debuffs while encounter-authored
+  // unbreakable control remains. Its own stasis is handled by the recast toggle above.
   if (!ability.usableWhileControlled) {
     if (isInStasis(p)) return;
     if (isStunned(p)) {
@@ -466,6 +484,18 @@ export function castAbility(
       ctx.error(p.id, 'You are silenced!');
       return;
     }
+  }
+  if (
+    hasUnbreakableMovementLock(p) &&
+    res.effects.some(
+      (effect) =>
+        effect.type === 'blinkForward' ||
+        effect.type === 'repositionToAim' ||
+        effect.type === 'charge',
+    )
+  ) {
+    ctx.error(p.id, 'You are stunned!');
+    return;
   }
   // Blink While Casting (mage choice row): Flickerstep slips through the busy
   // guard AND the GCD, an escape button that never touches the cast in

--- a/src/sim/combat/cc.ts
+++ b/src/sim/combat/cc.ts
@@ -11,6 +11,34 @@
 
 import type { Aura, DamageBreakBudget, Entity } from '../types';
 
+// Some scripted encounter control is part of the encounter timeline rather
+// than ordinary combat CC. Player immunity, cleanse, dispel, control-break, and
+// damage-break paths all consult this predicate. Expiry and encounter-owned
+// cleanup deliberately do not, so the encounter remains the lifecycle owner.
+export function isUnbreakableControlAura(aura: Pick<Aura, 'unbreakableControl'>): boolean {
+  return aura.unbreakableControl === true;
+}
+
+const MOVEMENT_LOCK_AURA_KINDS: ReadonlySet<Aura['kind']> = new Set([
+  'stun',
+  'stasis',
+  'root',
+  'incapacitate',
+  'polymorph',
+]);
+
+export function hasUnbreakableMovementLock(
+  entity: Pick<Entity, 'auras'>,
+  excludedAura?: Aura,
+): boolean {
+  return entity.auras.some(
+    (aura) =>
+      aura !== excludedAura &&
+      MOVEMENT_LOCK_AURA_KINDS.has(aura.kind) &&
+      isUnbreakableControlAura(aura),
+  );
+}
+
 export function damageBreakThreshold(maxHp: number, budget: DamageBreakBudget): number {
   return Math.min(budget.max, Math.max(budget.min, Math.round(maxHp * budget.maxHpPct)));
 }

--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -56,6 +56,7 @@ import {
   xpForLevel,
 } from '../types';
 import { WORLD_BOSS_CORPSE_SECONDS, worldBossLootContributors } from '../world_boss';
+import { isUnbreakableControlAura } from './cc';
 import { chronomancyConvertArcaneDamage, stripTemporalEchoes } from './chronomancy';
 import { recordDamageTaken } from './damage_history';
 import {
@@ -706,7 +707,7 @@ export function dealDamage(
     }
     for (let i = target.auras.length - 1; i >= 0; i--) {
       const breakable = target.auras[i];
-      if (breakable.breaksOnDamage) {
+      if (breakable.breaksOnDamage && !isUnbreakableControlAura(breakable)) {
         if (breakable.breakThreshold !== undefined && breakable.breakThreshold > amount) {
           breakable.breakThreshold -= amount;
           continue;
@@ -1004,9 +1005,8 @@ export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): 
   e.dead = true;
   e.hp = 0;
   ctx.clearNonPlayerStatAuras(e);
-  // The Keeper's Toll (Resurrection Sickness) is the one debuff that survives death: it
-  // must not be sheddable by dying and releasing the spirit. Only a player ever carries
-  // it, so mobs still clear fully.
+  // Death cannot shed persistent death penalties or encounter-owned unbreakable
+  // control. The encounter script remains responsible for releasing its markers.
   e.auras = aurasSurvivingDeath(e.auras);
   e.ccDr.clear();
   e.castingAbility = null;

--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -55,7 +55,12 @@ import {
   hasSweepingStrikes,
   sweepStrikeDamage,
 } from './area_echo';
-import { damageBreakThreshold, isRootedOrChilled } from './cc';
+import {
+  damageBreakThreshold,
+  hasUnbreakableMovementLock,
+  isRootedOrChilled,
+  isUnbreakableControlAura,
+} from './cc';
 import {
   ARCANE_SURGE_ID,
   aetherSurgeAddStack,
@@ -135,7 +140,7 @@ function exclusiveGroupOfAura(id: string): string | undefined {
 function removeRootAuras(ctx: SimContext, entity: Entity): void {
   for (let index = entity.auras.length - 1; index >= 0; index--) {
     const aura = entity.auras[index];
-    if (aura.kind !== 'root') continue;
+    if (aura.kind !== 'root' || isUnbreakableControlAura(aura)) continue;
     entity.auras.splice(index, 1);
     ctx.emit({ type: 'aura', targetId: entity.id, name: aura.name, gained: false });
   }
@@ -1003,12 +1008,12 @@ export function runEffects(
         break;
       }
       case 'cleanseSelf': {
-        // Ice Block: strip EVERY debuff off the caster (control, DoTs, stat saps, ...),
-        // broader than breakControl. Uses the shared classifier so the split matches
-        // the buff/debuff frame exactly. Emits the aura-lost event so client bars clear.
+        // Ice Block strips every player-removable debuff off the caster (control,
+        // DoTs, stat saps, ...), broader than breakControl. Encounter-authored
+        // unbreakable control stays until its owning script releases it.
         for (let i = p.auras.length - 1; i >= 0; i--) {
           const aura = p.auras[i];
-          if (isDebuffAura(aura.kind, aura.value)) {
+          if (isDebuffAura(aura.kind, aura.value) && !isUnbreakableControlAura(aura)) {
             p.auras.splice(i, 1);
             ctx.emit({ type: 'aura', targetId: p.id, name: aura.name, gained: false });
           }
@@ -2146,11 +2151,12 @@ export function runEffects(
         for (let i = p.auras.length - 1; i >= 0; i--) {
           const aura = p.auras[i];
           if (
-            ctx.isControlAura(aura.kind) ||
-            aura.kind === 'silence' ||
-            aura.kind === 'blind' ||
-            aura.kind === 'disarm' ||
-            aura.kind === 'slow'
+            !isUnbreakableControlAura(aura) &&
+            (ctx.isControlAura(aura.kind) ||
+              aura.kind === 'silence' ||
+              aura.kind === 'blind' ||
+              aura.kind === 'disarm' ||
+              aura.kind === 'slow')
           ) {
             p.auras.splice(i, 1);
             ctx.emit({ type: 'aura', targetId: p.id, name: aura.name, gained: false });
@@ -2159,11 +2165,12 @@ export function runEffects(
         break;
       }
       case 'repositionToAim': {
-        if (!eff.landingAoe) break;
+        if (!eff.landingAoe || hasUnbreakableMovementLock(p)) break;
         armHeroicLeap(ctx, p, p.castAim ?? p.pos, eff.landingAoe, ability);
         break;
       }
       case 'blinkForward': {
+        if (hasUnbreakableMovementLock(p)) break;
         if (eff.breakRoots) removeRootAuras(ctx, p);
         let distance = eff.distance;
         let facing = p.facing;
@@ -2437,7 +2444,7 @@ export function runEffects(
         break;
       }
       case 'charge': {
-        if (!target) break;
+        if (!target || hasUnbreakableMovementLock(p)) break;
         // the stun effect in the same ability lands this tick; the player
         // then runs the route at charge speed instead of teleporting
         p.chargeTargetId = target.id;

--- a/src/sim/combat/heroic_leap.ts
+++ b/src/sim/combat/heroic_leap.ts
@@ -2,6 +2,7 @@ import { PLAYER_BODY_RADIUS, PLAYER_MAX_CLIMB_SLOPE, PLAYER_SWIM_DEPTH } from '.
 import type { SimContext } from '../sim_context';
 import { type AbilityDef, DT, type Entity, type Vec3 } from '../types';
 import { groundHeight, terrainSteepnessAt, waterLevelAt } from '../world';
+import { hasUnbreakableMovementLock } from './cc';
 
 const SWEEP_STEP = 0.5;
 const FLIGHT_DURATION = 0.6;
@@ -93,6 +94,7 @@ export function armHeroicLeap(
   landingAoe: { min: number; max: number; radius: number },
   ability: Pick<AbilityDef, 'name' | 'school'>,
 ): void {
+  if (hasUnbreakableMovementLock(entity)) return;
   const landing = sweptLanding(ctx, entity, aim);
   entity.chargeTargetId = null;
   entity.chargePath = [];
@@ -111,7 +113,7 @@ export function armHeroicLeap(
 export function advanceHeroicLeap(ctx: SimContext, entity: Entity): boolean {
   const flight = entity.leap;
   if (!flight) return false;
-  if (entity.dead || wasExternallyRelocated(entity)) {
+  if (entity.dead || hasUnbreakableMovementLock(entity) || wasExternallyRelocated(entity)) {
     entity.leap = null;
     return false;
   }

--- a/src/sim/combat/resurrection_offer.ts
+++ b/src/sim/combat/resurrection_offer.ts
@@ -4,7 +4,8 @@
 
 import type { SimContext } from '../sim_context';
 import { revivePlayerAt } from '../spirit';
-import type { Entity } from '../types';
+import type { Aura, Entity } from '../types';
+import { isUnbreakableControlAura } from './cc';
 
 export const RESURRECTION_OFFER_SECONDS = 30;
 
@@ -33,9 +34,37 @@ export function respondToResurrection(ctx: SimContext, accept: boolean, pid?: nu
   ctx.pendingResurrections.delete(r.e.id);
   if (!accept || ctx.time >= offer.expiresAt || !r.e.dead) return;
   const caster = ctx.entities.get(offer.casterId);
-  const destination =
-    caster?.kind === 'player' && !caster.dead ? caster.pos : offer.fallbackDestination;
+  const arrivalAnchor = caster?.kind === 'player' && !caster.dead ? caster : null;
+  const destination = arrivalAnchor?.pos ?? offer.fallbackDestination;
   revivePlayerAt(ctx, r.e.id, destination, offer.hpFrac);
+  if (arrivalAnchor) inheritArrivalAnchorControl(ctx, arrivalAnchor, r.e);
+}
+
+// A live caster is also the authoritative arrival anchor. If that anchor is held
+// by encounter-owned control, accepting an older resurrection offer must not open
+// a same-call action window before the encounter's next update (notably when the
+// caster itself has just accepted a chained resurrection into the encounter).
+function inheritArrivalAnchorControl(ctx: SimContext, anchor: Entity, target: Entity): void {
+  for (const aura of anchor.auras) {
+    if (!isUnbreakableControlAura(aura) || aura.remaining <= 0) continue;
+    if (
+      target.auras.some(
+        (existing) =>
+          existing.id === aura.id &&
+          existing.sourceId === aura.sourceId &&
+          existing.kind === aura.kind &&
+          isUnbreakableControlAura(existing),
+      )
+    )
+      continue;
+    ctx.applyAura(target, cloneAura(aura));
+  }
+}
+
+function cloneAura(aura: Aura): Aura {
+  return aura.empowerAbilities
+    ? { ...aura, empowerAbilities: [...aura.empowerAbilities] }
+    : { ...aura };
 }
 
 export function updateResurrectionOffers(ctx: SimContext): void {

--- a/src/sim/encounters/nythraxis.ts
+++ b/src/sim/encounters/nythraxis.ts
@@ -25,7 +25,7 @@
 // directly (already pure); everything that touches not-yet-owned Sim state routes
 // through the seam.
 
-import { isStunned } from '../combat/cc';
+import { isStunned, isUnbreakableControlAura } from '../combat/cc';
 import { ITEMS, MOBS, NPCS, QUESTS } from '../data';
 import * as deedsMod from '../deeds';
 import { createMob, createNpc } from '../entity';
@@ -35,7 +35,6 @@ import type { PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
 import { clearThreat, threatEntries } from '../threat';
 import {
-  type Aura,
   type AuraKind,
   angleTo,
   armorReduction,
@@ -116,7 +115,7 @@ const NYTHRAXIS_DREAD_CURSE_MAX_STACKS = 10;
 const NYTHRAXIS_DEATHLESS_SOUL_REND_LOCKOUT = 15;
 const NYTHRAXIS_PHASE_TWO_SETTLE_DELAY = 5;
 const NYTHRAXIS_TRANSITION_DURATION = 21;
-const NYTHRAXIS_TRANSITION_STUN = 21.5;
+const NYTHRAXIS_TRANSITION_CONTROL_GRACE = 0.5;
 const NYTHRAXIS_FINAL_STAND_HP = 0.05;
 // Brother Aldric enters on the door side of the arena (the raid's side, lower z
 // than the boss spawn) and walks toward the boss. Distances are yards in front
@@ -184,14 +183,6 @@ export function isNythraxisControllableAdd(target: Entity): boolean {
   );
 }
 
-export function isNythraxisScriptedControl(target: Entity, aura: Aura): boolean {
-  return (
-    target.kind === 'mob' &&
-    (isNythraxisRaidAddTemplate(target.templateId) || target.ownerId !== null) &&
-    aura.id === 'nythraxis_transition_stun'
-  );
-}
-
 // ----- skeleton-warrior add AI (consumed by mob retarget on Sim) ------------------
 
 export function findNythraxisBossForAdd(ctx: SimContext, add: Entity): Entity | null {
@@ -225,18 +216,19 @@ export function scheduleNythraxisAddDespawnIfBossReset(ctx: SimContext, add: Ent
 // ----- boss-death dialogue hook (fired from updateMob's dead-branch via ctx) -------
 
 export function onBossDeath(ctx: SimContext, mob: Entity): void {
-  if (mob.templateId === NYTHRAXIS_BOSS_ID && mob.nythraxis && !mob.nythraxis.deathSpoken) {
-    mob.nythraxis.deathSpoken = true;
-    mob.nythraxis.phase = 'dead';
-    nythraxisDialogueSet(ctx, mob, [
-      { speaker: 'nythraxis', text: 'Malric...', delay: 0 },
-      {
-        speaker: 'nythraxis',
-        text: 'What have you done',
-        delay: NYTHRAXIS_DIALOGUE_LINE_SECONDS,
-      },
-    ]);
-  }
+  if (mob.templateId !== NYTHRAXIS_BOSS_ID || !mob.nythraxis) return;
+  if (mob.nythraxis.deathSpoken) return;
+  clearNythraxisTransitionControl(ctx, mob);
+  mob.nythraxis.deathSpoken = true;
+  mob.nythraxis.phase = 'dead';
+  nythraxisDialogueSet(ctx, mob, [
+    { speaker: 'nythraxis', text: 'Malric...', delay: 0 },
+    {
+      speaker: 'nythraxis',
+      text: 'What have you done',
+      delay: NYTHRAXIS_DIALOGUE_LINE_SECONDS,
+    },
+  ]);
 }
 
 // ----- encounter lifecycle --------------------------------------------------------
@@ -279,9 +271,7 @@ export function resetNythraxisEncounter(ctx: SimContext, boss: Entity): void {
     );
     clearNythraxisWardChannelCast(p);
   }
-  for (const e of nythraxisTransitionStunTargets(ctx, boss)) {
-    if (e.kind !== 'player') e.auras = e.auras.filter((a) => a.id !== 'nythraxis_transition_stun');
-  }
+  clearNythraxisTransitionControl(ctx, boss);
   const aldric = findNythraxisAldric(ctx, boss);
   if (aldric) ctx.dropEntity(aldric.id);
   for (const ward of nythraxisDeathlessChannelObjects(ctx, boss)) {
@@ -549,11 +539,25 @@ export function playersInNythraxisRoom(ctx: SimContext, boss: Entity): Entity[] 
 export function nythraxisTransitionStunTargets(ctx: SimContext, boss: Entity): Entity[] {
   return [...ctx.entities.values()].filter(
     (e) =>
-      !e.dead &&
-      dist2d(e.pos, boss.spawnPos) <= NYTHRAXIS_ROOM_RADIUS &&
       (e.kind === 'player' ||
-        (e.kind === 'mob' && (isNythraxisRaidAddTemplate(e.templateId) || e.ownerId !== null))),
+        (e.kind === 'mob' && (isNythraxisRaidAddTemplate(e.templateId) || e.ownerId !== null))) &&
+      willBeInNythraxisRoomAfterResurrection(ctx, boss, e),
   );
+}
+
+function willBeInNythraxisRoomAfterResurrection(
+  ctx: SimContext,
+  boss: Entity,
+  entity: Entity,
+): boolean {
+  if (dist2d(entity.pos, boss.spawnPos) <= NYTHRAXIS_ROOM_RADIUS) return true;
+  if (entity.kind !== 'player' || !entity.dead) return false;
+  const offer = ctx.pendingResurrections.get(entity.id);
+  if (!offer || ctx.time >= offer.expiresAt) return false;
+  const caster = ctx.entities.get(offer.casterId);
+  const destination =
+    caster?.kind === 'player' && !caster.dead ? caster.pos : offer.fallbackDestination;
+  return dist2d(destination, boss.spawnPos) <= NYTHRAXIS_ROOM_RADIUS;
 }
 
 export function nythraxisRoomMetas(ctx: SimContext, boss: Entity): PlayerMeta[] {
@@ -850,24 +854,14 @@ export function startNythraxisTransition(
     school: 'physical',
     fx: 'nova',
   });
-  for (const e of nythraxisTransitionStunTargets(ctx, boss)) {
-    ctx.applyAura(e, {
-      id: 'nythraxis_transition_stun',
-      name: 'Shuddering Stomp',
-      kind: 'stun',
-      remaining: NYTHRAXIS_TRANSITION_STUN,
-      duration: NYTHRAXIS_TRANSITION_STUN,
-      value: 0,
-      sourceId: boss.id,
-      school: 'physical',
-    });
-  }
+  applyNythraxisTransitionControl(ctx, boss, st);
+  const transitionControlDuration = st.transitionTimer + NYTHRAXIS_TRANSITION_CONTROL_GRACE;
   ctx.applyAura(boss, {
     id: 'nythraxis_transition_pause',
     name: 'Shuddering Stomp',
     kind: 'stun',
-    remaining: NYTHRAXIS_TRANSITION_STUN,
-    duration: NYTHRAXIS_TRANSITION_STUN,
+    remaining: transitionControlDuration,
+    duration: transitionControlDuration,
     value: 0,
     sourceId: boss.id,
     school: 'physical',
@@ -876,6 +870,51 @@ export function startNythraxisTransition(
   lightNythraxisWardstones(ctx, boss);
   nythraxisDialogueSet(ctx, boss, transitionLines, false, true);
   st.transitionCues = [];
+}
+
+function applyNythraxisTransitionControl(
+  ctx: SimContext,
+  boss: Entity,
+  st: NonNullable<Entity['nythraxis']>,
+): void {
+  const transitionControlDuration = st.transitionTimer + NYTHRAXIS_TRANSITION_CONTROL_GRACE;
+  for (const e of nythraxisTransitionStunTargets(ctx, boss)) {
+    if (
+      e.auras.some(
+        (aura) =>
+          aura.id === 'nythraxis_transition_stun' &&
+          aura.kind === 'stun' &&
+          aura.sourceId === boss.id &&
+          aura.remaining > st.transitionTimer &&
+          isUnbreakableControlAura(aura),
+      )
+    )
+      continue;
+    // Generic aura application recalculates player stats; for a dead ghost that
+    // temporarily zeros the full grey display pools established on release.
+    // This control has no stat payload, so preserve those display-only values.
+    const ghostDisplay = e.kind === 'player' && e.dead && e.ghost ? [e.hp, e.resource] : null;
+    ctx.applyAura(e, {
+      id: 'nythraxis_transition_stun',
+      name: 'Shuddering Stomp',
+      kind: 'stun',
+      remaining: transitionControlDuration,
+      duration: transitionControlDuration,
+      value: 0,
+      sourceId: boss.id,
+      school: 'physical',
+      unbreakableControl: true,
+    });
+    if (ghostDisplay) [e.hp, e.resource] = ghostDisplay;
+  }
+}
+
+function clearNythraxisTransitionControl(ctx: SimContext, boss: Entity): void {
+  for (const entity of ctx.entities.values()) {
+    entity.auras = entity.auras.filter(
+      (aura) => aura.id !== 'nythraxis_transition_stun' || aura.sourceId !== boss.id,
+    );
+  }
 }
 
 export function spawnNythraxisAldric(ctx: SimContext, boss: Entity): void {
@@ -905,6 +944,7 @@ export function updateNythraxisTransition(
   boss: Entity,
   st: NonNullable<Entity['nythraxis']>,
 ): void {
+  applyNythraxisTransitionControl(ctx, boss, st);
   const aldric = findNythraxisAldric(ctx, boss);
   if (aldric) {
     const dest = ctx.groundPos(boss.spawnPos.x, boss.spawnPos.z - NYTHRAXIS_ALDRIC_WALK_DIST);
@@ -918,9 +958,7 @@ export function updateNythraxisTransition(
   st.soulRendTimer = NYTHRAXIS_PHASE_TWO_SETTLE_DELAY;
   st.deathlessTimer = NYTHRAXIS_PHASE_TWO_SETTLE_DELAY + 15;
   boss.auras = boss.auras.filter((a) => a.id !== 'nythraxis_transition_pause');
-  for (const e of nythraxisTransitionStunTargets(ctx, boss)) {
-    e.auras = e.auras.filter((a) => a.id !== 'nythraxis_transition_stun');
-  }
+  clearNythraxisTransitionControl(ctx, boss);
 }
 
 export function lightNythraxisWardstones(ctx: SimContext, boss: Entity): void {

--- a/src/sim/mob/locomotion.ts
+++ b/src/sim/mob/locomotion.ts
@@ -26,6 +26,7 @@
 // sibling targeting module are imported directly (already pure); everything that
 // touches not-yet-extracted Sim state routes through the seam.
 
+import { hasUnbreakableMovementLock } from '../combat/cc';
 import { VALE_CUP_BALL_TEMPLATE_ID } from '../content/vale_cup';
 import { YUMI_TEMPLATE_ID } from '../content/yumi';
 import { DUNGEON_X_THRESHOLD, MOBS } from '../data';
@@ -240,7 +241,8 @@ export function updateMob(ctx: SimContext, mob: Entity): void {
     // is stunned, since the stun path skips updateMobTarget where it normally ticks.
     tickForcedTarget(mob);
     if (ctx.updateFearMovement(mob)) return;
-    if (mob.auras.some((a) => a.kind === 'polymorph')) {
+    const polymorphAura = mob.auras.find((a) => a.kind === 'polymorph');
+    if (polymorphAura && !hasUnbreakableMovementLock(mob, polymorphAura)) {
       mob.wanderTimer -= DT;
       if (mob.wanderTimer <= 0) {
         mob.wanderTimer = ctx.rng.range(0.8, 2);

--- a/src/sim/pet/pet_commands.ts
+++ b/src/sim/pet/pet_commands.ts
@@ -35,6 +35,7 @@
 // directly (already pure); everything that touches not-yet-extracted Sim state
 // routes through the seam.
 
+import { hasUnbreakableMovementLock } from '../combat/cc';
 import { DUNGEON_X_THRESHOLD, ITEMS, isDelvePos, MOBS } from '../data';
 import { createMob } from '../entity';
 import type { PetState } from '../sim';
@@ -66,6 +67,15 @@ const PET_NAME_RE = /^[A-Za-z][A-Za-z '-]{1,15}$/;
 // so the surfaced error must say why instead of implying the pet was lost.
 function noPetError(e: Entity, fallback = 'You have no pet.'): string {
   return isDelvePos(e.pos.x) ? 'Pets are not allowed inside the delves.' : fallback;
+}
+
+// Encounter-authored movement locks freeze the owner's direct command surface too.
+// This guard intentionally lives only on user-issued commands: passive pet AI and
+// system lifecycle operations (summon/restore/stow) remain encounter-owned.
+function petCommandBlockedByControl(ctx: SimContext, owner: Entity): boolean {
+  if (!hasUnbreakableMovementLock(owner)) return false;
+  ctx.error(owner.id, 'You are stunned.');
+  return true;
 }
 
 // -------------------------------------------------------------------------
@@ -451,6 +461,7 @@ export function abandonPet(ctx: SimContext, pid?: number): void {
     ctx.error(r.e.id, 'Only hunters can abandon pets.');
     return;
   }
+  if (petCommandBlockedByControl(ctx, r.e)) return;
   const pet = petOf(ctx, r.e.id, true);
   if (!pet) {
     ctx.error(r.e.id, noPetError(r.e));
@@ -467,6 +478,7 @@ export function renamePet(ctx: SimContext, name: string, pid?: number): void {
     ctx.error(r.e.id, 'Only pet classes can rename pets.');
     return;
   }
+  if (petCommandBlockedByControl(ctx, r.e)) return;
   const pet = petOf(ctx, r.e.id, true);
   if (!pet) {
     ctx.error(r.e.id, noPetError(r.e));
@@ -491,6 +503,7 @@ export function revivePet(ctx: SimContext, pid?: number): void {
     ctx.error(r.e.id, 'Only pet classes can revive pets.');
     return;
   }
+  if (petCommandBlockedByControl(ctx, r.e)) return;
   const pet = petOf(ctx, r.e.id, true);
   if (!pet) {
     ctx.error(r.e.id, noPetError(r.e));
@@ -531,6 +544,7 @@ export function petAttack(ctx: SimContext, pid?: number): void {
     ctx.error(r.e.id, 'Only pet classes can command pets.');
     return;
   }
+  if (petCommandBlockedByControl(ctx, r.e)) return;
   r.meta.lastActiveTick = ctx.tickCount; // commanding the pet is a deliberate action
   const pet = petOf(ctx, r.e.id);
   if (!pet) {
@@ -554,6 +568,7 @@ export function petTaunt(ctx: SimContext, pid?: number): void {
     ctx.error(r.e.id, 'Only pet classes can command pets.');
     return;
   }
+  if (petCommandBlockedByControl(ctx, r.e)) return;
   r.meta.lastActiveTick = ctx.tickCount; // commanding the pet is a deliberate action
   const pet = petOf(ctx, r.e.id);
   if (!pet) {
@@ -590,6 +605,7 @@ export function petTaunt(ctx: SimContext, pid?: number): void {
 export function petWaterJet(ctx: SimContext, pid?: number): void {
   const r = ctx.resolve(pid);
   if (!r) return;
+  if (petCommandBlockedByControl(ctx, r.e)) return;
   const pet = petOf(ctx, r.e.id);
   const jet = pet ? MOBS[pet.templateId]?.petRanged?.jet : undefined;
   if (!pet || !jet || pet.dead || pet.castingAbility || pet.petTauntTimer > 0) return;
@@ -609,6 +625,7 @@ export function feedPet(ctx: SimContext, itemId: string, pid?: number): void {
     ctx.error(r.e.id, 'Only hunters can feed pets.');
     return;
   }
+  if (petCommandBlockedByControl(ctx, r.e)) return;
   const pet = petOf(ctx, r.e.id);
   if (!pet) {
     ctx.error(r.e.id, noPetError(r.e, 'You have no living pet.'));
@@ -651,6 +668,7 @@ export function healPet(ctx: SimContext, pid?: number): void {
     ctx.error(r.e.id, 'Only warlocks can channel demon healing.');
     return;
   }
+  if (petCommandBlockedByControl(ctx, r.e)) return;
   if (r.e.dead) {
     ctx.error(r.e.id, 'You are dead.');
     return;
@@ -706,6 +724,7 @@ export function setPetMode(ctx: SimContext, mode: PetMode, pid?: number): void {
     ctx.error(r.e.id, 'Only pet classes can command pets.');
     return;
   }
+  if (petCommandBlockedByControl(ctx, r.e)) return;
   r.meta.lastActiveTick = ctx.tickCount; // commanding the pet is a deliberate action
   const pet = petOf(ctx, r.e.id, true);
   if (!pet) {
@@ -729,6 +748,7 @@ export function setPetAutoTaunt(ctx: SimContext, enabled: boolean, pid?: number)
     ctx.error(r.e.id, 'Only pet classes can command pets.');
     return;
   }
+  if (petCommandBlockedByControl(ctx, r.e)) return;
   r.meta.lastActiveTick = ctx.tickCount; // commanding the pet is a deliberate action
   const pet = petOf(ctx, r.e.id, true);
   if (!pet) {
@@ -753,6 +773,7 @@ export function setPetAutoWaterJet(ctx: SimContext, enabled: boolean, pid?: numb
     ctx.error(r.e.id, 'Only pet classes can command pets.');
     return;
   }
+  if (petCommandBlockedByControl(ctx, r.e)) return;
   r.meta.lastActiveTick = ctx.tickCount; // commanding the pet is a deliberate action
   const pet = petOf(ctx, r.e.id, true);
   if (!pet) {

--- a/src/sim/resurrection.ts
+++ b/src/sim/resurrection.ts
@@ -29,11 +29,15 @@ export function resSicknessDuration(level: number): number {
 }
 
 // Auras that survive a death / respawn reset: Resurrection Sickness (The Keeper's
-// Toll) and the Cauterize lockout ('cauterize_fatigue', combat/fire_mage.ts). Both
-// must not be sheddable by dying: res sickness IS the death penalty, and the
-// Cauterize fatigue is what stops die-revive-die from earning a second lethal save
-// inside the window. Every other aura clears. Used at every player death/respawn
-// site so the rule cannot drift.
+// Toll), the Cauterize lockout ('cauterize_fatigue', combat/fire_mage.ts), and
+// encounter-owned unbreakable control. None may be shed by dying; the encounter
+// script remains responsible for releasing its own control. Every other aura clears.
+// Used at every player death/respawn site so the rule cannot drift.
 export function aurasSurvivingDeath(auras: Aura[]): Aura[] {
-  return auras.filter((a) => a.id === RESURRECTION_SICKNESS_ID || a.kind === 'cauterize_fatigue');
+  return auras.filter(
+    (a) =>
+      a.id === RESURRECTION_SICKNESS_ID ||
+      a.kind === 'cauterize_fatigue' ||
+      a.unbreakableControl === true,
+  );
 }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -44,7 +44,14 @@ import {
   spendResource as spendResourceImpl,
   updateCasting as updateCastingImpl,
 } from './combat/casting_lifecycle';
-import { isLockedOut, isRooted, isSilenced, isStunned } from './combat/cc';
+import {
+  hasUnbreakableMovementLock,
+  isLockedOut,
+  isRooted,
+  isSilenced,
+  isStunned,
+  isUnbreakableControlAura,
+} from './combat/cc';
 import { aetherSurgeCostMult, echoVisibleTo } from './combat/chronomancy';
 import {
   dealDamage as dealDamageImpl,
@@ -4439,7 +4446,8 @@ export class Sim {
   }
   private updateFearMovement(e: Entity): boolean {
     const aura = this.fearAura(e);
-    if (!aura || e.auras.some((a) => a.kind === 'root')) return false;
+    if (!aura || e.auras.some((a) => a.kind === 'root') || hasUnbreakableMovementLock(e, aura))
+      return false;
     const angle = Number.isFinite(aura.value) ? aura.value : e.facing;
     const dest = this.groundPos(e.pos.x + Math.sin(angle) * 10, e.pos.z + Math.cos(angle) * 10);
     this.moveToward(e, dest, this.fleeMoveSpeed(e));
@@ -4473,16 +4481,12 @@ export class Sim {
     );
   }
   // Nythraxis CC-immunity predicates moved to encounters/nythraxis.ts (N1); Sim keeps
-  // thin delegates because the hot applyAura immunity path reads them via this.X
-  // (isNythraxisControlAura routes back through ctx.isControlAura, which stays on Sim).
+  // thin delegates because the hot applyAura immunity path reads them via this.X.
   private isNythraxisControlAura(kind: AuraKind): boolean {
     return nythraxis.isNythraxisControlAura(this.ctx, kind);
   }
   private isNythraxisRaidEnemy(target: Entity): boolean {
     return nythraxis.isNythraxisRaidEnemy(target);
-  }
-  private isNythraxisScriptedControl(target: Entity, aura: Aura): boolean {
-    return nythraxis.isNythraxisScriptedControl(target, aura);
   }
   // L1 loot distribution moved to loot/loot_roll.ts (behind SimContext). Sim keeps a
   // thin delegate for partyLootCandidatesForMob because dead_party_loot.test.ts reaches
@@ -5045,7 +5049,8 @@ export class Sim {
     if (
       this.isIceBlocked(target) &&
       this.isIceBlockCrowdControlAura(aura.kind) &&
-      aura.sourceId !== target.id
+      aura.sourceId !== target.id &&
+      !isUnbreakableControlAura(aura)
     )
       return;
     if (
@@ -5053,7 +5058,7 @@ export class Sim {
       !nythraxis.isNythraxisControllableAdd(target) && // priest + stalker are meant to be CC'd
       this.isNythraxisControlAura(aura.kind) &&
       aura.sourceId !== target.id &&
-      !this.isNythraxisScriptedControl(target, aura)
+      !isUnbreakableControlAura(aura)
     )
       return;
     if (
@@ -5061,7 +5066,7 @@ export class Sim {
       (MOBS[target.templateId]?.ccImmune || target.ccImmune) &&
       this.isControlAura(aura.kind) &&
       aura.sourceId !== target.id &&
-      !this.isNythraxisScriptedControl(target, aura)
+      !isUnbreakableControlAura(aura)
     )
       return;
     // Slow immunity is separate from ccImmune: snares (kind 'slow') are not control auras,
@@ -5072,17 +5077,21 @@ export class Sim {
       target.kind === 'mob' &&
       (MOBS[target.templateId]?.slowImmune || target.slowImmune) &&
       aura.kind === 'slow' &&
-      aura.sourceId !== target.id
+      aura.sourceId !== target.id &&
+      !isUnbreakableControlAura(aura)
     )
       return;
     // Temporal Rift (mage choice row): every 20 sec the next stun, root or
     // silence to land on the wearer is cleansed instantly, i.e. never applied.
     // The ICD rides an 'internal_cd' aura (no new entity field enters the
     // parity state hash) that the player can watch tick down. Draws no rng.
+    // Encounter-authored unbreakable control is never a cleanse target: the
+    // whole raid freezes for the sequence. Combat CC stays cleansable.
     if (
       target.kind === 'player' &&
       (aura.kind === 'stun' || aura.kind === 'root' || aura.kind === 'silence') &&
-      aura.sourceId !== target.id
+      aura.sourceId !== target.id &&
+      !isUnbreakableControlAura(aura)
     ) {
       const riftMeta = this.players.get(target.id);
       if (
@@ -5104,7 +5113,13 @@ export class Sim {
         return;
       }
     }
-    for (const existing of auraReplacementConflicts(target.auras, aura)) {
+    const replacementConflicts = auraReplacementConflicts(target.auras, aura);
+    if (
+      !isUnbreakableControlAura(aura) &&
+      replacementConflicts.some((index) => isUnbreakableControlAura(target.auras[index]))
+    )
+      return;
+    for (const existing of replacementConflicts) {
       this.applyNonPlayerStatAura(target, target.auras[existing], -1);
       target.auras.splice(existing, 1);
     }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -446,6 +446,9 @@ export interface Aura {
   tickTimer?: number;
   sourceId: number;
   school: 'physical' | 'fire' | 'frost' | 'arcane' | 'shadow' | 'holy' | 'nature';
+  // Encounter-authored control that must land through immunity and cannot be
+  // removed by player counters. Natural expiry and encounter cleanup still own it.
+  unbreakableControl?: true;
   breaksOnDamage?: boolean;
   // Lingering Dread lets a break-on-damage fear absorb this much damage before
   // breaking. Undefined retains the normal break-on-any-damage behavior.
@@ -1771,8 +1774,8 @@ export type AbilityEffect =
   | { type: 'aoeFear'; duration: number; radius: number; maxTargets?: number }
   | { type: 'clearCooldowns'; abilities: string[] }
   | { type: 'breakControl' }
-  // Ice Block: strip EVERY debuff (control, DoTs, stat saps, ...) off the caster.
-  // Broader than breakControl (which covers control auras only). See effect_dispatch.
+  // Ice Block: strip every player-removable debuff (control, DoTs, stat saps, ...)
+  // off the caster. Broader than breakControl. See effect_dispatch.
   | { type: 'cleanseSelf' }
   | {
       type: 'repositionToAim';

--- a/src/ui/auras_view.ts
+++ b/src/ui/auras_view.ts
@@ -115,6 +115,9 @@ export interface AuraInput {
   // and the mirror decodes 0, which matches no player id, so the strip degrades to the
   // un-prioritized layout instead of misattributing.
   sourceId?: number;
+  // Encounter-owned control cannot be canceled by the player. Mirrored over the
+  // online aura wire so the cancel affordance matches the authoritative sim.
+  unbreakableControl?: true;
 }
 
 /** The entity fields the core reads: just its aura list. */
@@ -304,7 +307,7 @@ export function createAurasView(
         // The buff bar (mode 'buffs', the player's own auras) offers right-click-cancel;
         // a helpful buff is cancelable, a debuff never. The target debuff strip
         // (mode 'debuffs') is read-only, so nothing there is cancelable.
-        slot.cancelable = mode === 'buffs' && !debuff;
+        slot.cancelable = mode === 'buffs' && !debuff && a.unbreakableControl !== true;
         slot.effectHtml = deps.auraEffectHtml(a);
         slot.own = own;
         count++;

--- a/tests/aura_cancel.test.ts
+++ b/tests/aura_cancel.test.ts
@@ -67,6 +67,15 @@ describe('isDebuffAura', () => {
       expect(isCancelableAura(aura('x', kind))).toBe(true);
     }
   });
+
+  it('never exposes unbreakable encounter control as player-cancelable', () => {
+    const scriptedStasis = {
+      ...aura('scripted_stasis', 'stasis'),
+      unbreakableControl: true,
+    } as Aura;
+
+    expect(isCancelableAura(scriptedStasis)).toBe(false);
+  });
 });
 
 describe('auraAffectsStats', () => {

--- a/tests/aura_classify.test.ts
+++ b/tests/aura_classify.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { isDebuffAura } from '../src/sim/aura_classify';
-import type { AuraKind } from '../src/sim/types';
+import { isDebuffAura, isDispellableAura } from '../src/sim/aura_classify';
+import type { Aura, AuraKind } from '../src/sim/types';
 
 // Every harmful kind the HUD and /targetbuffs treat as a debuff. Keeping this
 // list here (not importing the module's own set) is deliberate: the test pins
@@ -86,5 +86,18 @@ describe('isDebuffAura', () => {
   it('keeps a harmful kind a debuff regardless of value sign', () => {
     expect(isDebuffAura('dot', 0)).toBe(true);
     expect(isDebuffAura('slow', 0.5)).toBe(true);
+  });
+});
+
+describe('isDispellableAura', () => {
+  it('never offers unbreakable encounter control to a player dispel', () => {
+    const aura = {
+      kind: 'silence',
+      value: 0,
+      school: 'shadow',
+      unbreakableControl: true,
+    } as Pick<Aura, 'kind' | 'value' | 'school'> & { unbreakableControl: true };
+
+    expect(isDispellableAura(aura, false)).toBe(false);
   });
 });

--- a/tests/auras_view.test.ts
+++ b/tests/auras_view.test.ts
@@ -130,6 +130,22 @@ describe('createAurasView: derivation per mode', () => {
     expect(createAurasView('debuffs', deps()).tick(entity([bleedVulnerability])).count).toBe(1);
   });
 
+  it('never presents protected helpful control as right-click cancelable', () => {
+    const ordinaryStasis = aura({ id: 'ordinary_stasis', kind: 'stasis' });
+    const protectedStasis = aura({
+      id: 'scripted_stasis',
+      kind: 'stasis',
+      unbreakableControl: true,
+    });
+
+    expect(
+      createAurasView('buffs', deps()).tick(entity([ordinaryStasis])).slots[0].cancelable,
+    ).toBe(true);
+    expect(
+      createAurasView('buffs', deps()).tick(entity([protectedStasis])).slots[0].cancelable,
+    ).toBe(false);
+  });
+
   it('emits one slot PER aura even when two share an id (no core-side dedup)', () => {
     // The sim dedups by id+sourceId, so one entity can carry two auras with the same id
     // from different sources. The core must NOT collapse them (that is the painter's job,

--- a/tests/combat_auras.test.ts
+++ b/tests/combat_auras.test.ts
@@ -64,6 +64,33 @@ describe('auras: isRejectedFriendlyNpcAura', () => {
   });
 });
 
+describe('auras: unbreakable control replacement', () => {
+  it('cannot be downgraded by an ordinary refresh and can refresh as protected', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    const protectedStun = {
+      ...aura('stun', 0, { id: 'scripted_stun', sourceId: 9000 }),
+      unbreakableControl: true,
+    } as const;
+    sim.ctx.applyAura(p, protectedStun);
+
+    sim.ctx.applyAura(
+      p,
+      aura('stun', 0, {
+        id: 'scripted_stun',
+        sourceId: 9000,
+        remaining: 3,
+        duration: 3,
+      }),
+    );
+    expect(p.auras.filter((entry) => entry.id === 'scripted_stun')).toEqual([protectedStun]);
+
+    const refreshed = { ...protectedStun, remaining: 90, duration: 90 };
+    sim.ctx.applyAura(p, refreshed);
+    expect(p.auras.filter((entry) => entry.id === 'scripted_stun')).toEqual([refreshed]);
+  });
+});
+
 describe('auras: updateTimers', () => {
   it('decrements gcd, advances rule/combat timers, and expires cooldowns', () => {
     const sim = makeSim();

--- a/tests/combat_cc.test.ts
+++ b/tests/combat_cc.test.ts
@@ -8,11 +8,13 @@ import { describe, expect, it } from 'vitest';
 import {
   blindMissBonus,
   damageBreakThreshold,
+  hasUnbreakableMovementLock,
   isDisarmed,
   isLockedOut,
   isRooted,
   isSilenced,
   isStunned,
+  isUnbreakableControlAura,
   tonguesMult,
 } from '../src/sim/combat/cc';
 import type { AbilityEffect, Aura, Entity } from '../src/sim/types';
@@ -104,6 +106,25 @@ describe('cc: isRooted', () => {
   });
   it('is false with no root/stun-family aura', () => {
     expect(isRooted(withAuras(aura('silence')))).toBe(false);
+  });
+});
+
+describe('cc: unbreakable encounter control', () => {
+  it('identifies protected auras and only movement-locking kinds stop relocation', () => {
+    for (const kind of ['stun', 'stasis', 'root', 'incapacitate', 'polymorph'] as const) {
+      const protectedAura = aura(kind, 0, { unbreakableControl: true });
+      expect(isUnbreakableControlAura(protectedAura)).toBe(true);
+      expect(hasUnbreakableMovementLock(withAuras(protectedAura))).toBe(true);
+      expect(hasUnbreakableMovementLock(withAuras(protectedAura), protectedAura)).toBe(false);
+    }
+
+    expect(
+      hasUnbreakableMovementLock(withAuras(aura('silence', 0, { unbreakableControl: true }))),
+    ).toBe(false);
+    expect(
+      hasUnbreakableMovementLock(withAuras(aura('slow', 0, { unbreakableControl: true }))),
+    ).toBe(false);
+    expect(hasUnbreakableMovementLock(withAuras(aura('root')))).toBe(false);
   });
 });
 

--- a/tests/combat_damage.test.ts
+++ b/tests/combat_damage.test.ts
@@ -50,6 +50,28 @@ describe('combat/damage dealDamage (post-mitigation)', () => {
     expect(dmg.amount).toBe(100);
   });
 
+  it('does not break unbreakable encounter control when the target takes damage', () => {
+    const sim = makeSim();
+    const player = sim.player as AnyEntity;
+    const mob = spawnHostileMob(sim, 'forest_wolf', 5);
+    player.auras.push({
+      id: 'scripted_incapacitate',
+      name: 'Scripted Incapacitate',
+      kind: 'incapacitate',
+      remaining: 10,
+      duration: 10,
+      value: 0,
+      sourceId: mob.id,
+      school: 'shadow',
+      breaksOnDamage: true,
+      unbreakableControl: true,
+    } as Aura & { unbreakableControl: true });
+
+    dealDamage(sim.ctx, mob, player, 1, false, 'physical', null, 'hit');
+
+    expect(player.auras.some((a: Aura) => a.id === 'scripted_incapacitate')).toBe(true);
+  });
+
   it('vulnerability amplifies before absorb soaks', () => {
     const sim = makeSim();
     sim.setPlayerLevel(10);

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -1690,6 +1690,54 @@ describe('warrior charge', () => {
     sim.tick();
     expect(p.chargeTargetId).toBe(null);
   });
+
+  it('does not bill or arm charge through unbreakable encounter control', () => {
+    const { sim, p, wolf } = chargeSetup();
+    const rageBefore = p.resource;
+    p.auras.push({
+      id: 'scripted_root',
+      name: 'Scripted Root',
+      kind: 'root',
+      remaining: 10,
+      duration: 10,
+      value: 0,
+      sourceId: 9000,
+      school: 'shadow',
+      unbreakableControl: true,
+    });
+
+    sim.castAbility('charge');
+
+    expect(p.chargeTargetId).toBe(null);
+    expect(p.resource).toBe(rageBefore);
+    expect(p.cooldowns.has('charge')).toBe(false);
+    expect(wolf.auras.some((a) => a.kind === 'stun')).toBe(false);
+  });
+
+  it('stops an in-flight charge when unbreakable encounter control lands', () => {
+    const { sim, p } = chargeSetup();
+    sim.castAbility('charge');
+    sim.tick();
+    expect(p.chargeTargetId).not.toBe(null);
+    const heldAt = { ...p.pos };
+    p.auras.push({
+      id: 'scripted_stun',
+      name: 'Scripted Stun',
+      kind: 'stun',
+      remaining: 10,
+      duration: 10,
+      value: 0,
+      sourceId: 9000,
+      school: 'shadow',
+      unbreakableControl: true,
+    });
+
+    sim.tick();
+
+    expect(p.chargeTargetId).toBe(null);
+    expect(p.pos.x).toBeCloseTo(heldAt.x, 5);
+    expect(p.pos.z).toBeCloseTo(heldAt.z, 5);
+  });
 });
 
 describe('mob tap rights', () => {

--- a/tests/heroic_leap.test.ts
+++ b/tests/heroic_leap.test.ts
@@ -71,6 +71,59 @@ describe('Heroic Leap: arcs over time, slams on landing', () => {
     expect(Math.abs(p.pos.x - aim.x)).toBeGreaterThan(6);
     expect(p.leap).not.toBeNull();
   });
+
+  it('cannot arm or continue through unbreakable encounter control', () => {
+    const rooted = new Sim({ seed: 31, playerClass: 'warrior', autoEquip: true }) as AnySim;
+    rooted.setPlayerLevel(MAX_LEVEL);
+    const rootedPlayer = rooted.player;
+    const rootedStart = { ...rootedPlayer.pos };
+    const rootedResource = rootedPlayer.resource;
+    rootedPlayer.auras.push({
+      id: 'scripted_root',
+      name: 'Scripted Root',
+      kind: 'root',
+      remaining: 10,
+      duration: 10,
+      value: 0,
+      sourceId: 9000,
+      school: 'shadow',
+      unbreakableControl: true,
+    });
+    rooted.castAbility('heroic_leap', rootedPlayer.id, {
+      x: rootedPlayer.pos.x + 12,
+      z: rootedPlayer.pos.z,
+    });
+    expect(rootedPlayer.leap ?? null).toBeNull();
+    expect(rootedPlayer.pos).toEqual(rootedStart);
+    expect(rootedPlayer.resource).toBe(rootedResource);
+    expect(rootedPlayer.cooldowns.has('heroic_leap')).toBe(false);
+
+    const stunned = new Sim({ seed: 32, playerClass: 'warrior', autoEquip: true }) as AnySim;
+    stunned.setPlayerLevel(MAX_LEVEL);
+    const stunnedPlayer = stunned.player;
+    stunned.castAbility('heroic_leap', stunnedPlayer.id, {
+      x: stunnedPlayer.pos.x + 12,
+      z: stunnedPlayer.pos.z,
+    });
+    stunned.tick();
+    expect(stunnedPlayer.leap).not.toBeNull();
+    const heldAt = { ...stunnedPlayer.pos };
+    stunnedPlayer.auras.push({
+      id: 'scripted_stun',
+      name: 'Scripted Stun',
+      kind: 'stun',
+      remaining: 10,
+      duration: 10,
+      value: 0,
+      sourceId: 9000,
+      school: 'shadow',
+      unbreakableControl: true,
+    });
+    stunned.tick();
+    expect(stunnedPlayer.leap).toBeNull();
+    expect(stunnedPlayer.pos.x).toBeCloseTo(heldAt.x, 5);
+    expect(stunnedPlayer.pos.z).toBeCloseTo(heldAt.z, 5);
+  });
 });
 
 // The flight must die with the caster or with any external relocation: a stale

--- a/tests/ice_block.test.ts
+++ b/tests/ice_block.test.ts
@@ -55,6 +55,15 @@ function debuff(id: string, kind: Aura['kind'], value = 0): Aura {
   return { id, name: id, kind, value, remaining: 30, duration: 30, sourceId: 0, school: 'shadow' };
 }
 
+function unbreakableControl(
+  id: string,
+  kind: Aura['kind'],
+): Aura & {
+  unbreakableControl: true;
+} {
+  return { ...debuff(id, kind), unbreakableControl: true };
+}
+
 describe('Ice Block: immunity + cleanse + control', () => {
   it('grants total immunity and blocks your own actions, then restores on expiry', () => {
     const { sim, p } = rigMage();
@@ -105,6 +114,36 @@ describe('Ice Block: immunity + cleanse + control', () => {
     for (const id of ['test_stun', 'test_poly', 'test_dot', 'test_slow']) {
       expect(p.auras.some((a) => a.id === id)).toBe(false);
     }
+  });
+
+  it('cannot cleanse unbreakable encounter control but still cleanses ordinary debuffs', () => {
+    const { sim, p } = rigMage();
+    p.auras.push(unbreakableControl('scripted_stun', 'stun'));
+    p.auras.push(debuff('ordinary_dot', 'dot', 50));
+
+    sim.castAbility('ice_block');
+
+    expect(p.auras.some((a) => a.id === 'scripted_stun')).toBe(true);
+    expect(p.auras.some((a) => a.id === 'ordinary_dot')).toBe(false);
+    expect(p.auras.some((a) => a.id === 'ice_block' && a.kind === 'stasis')).toBe(true);
+  });
+
+  it('cannot prevent unbreakable encounter control from landing', () => {
+    const { sim, p } = rigMage();
+    const mob = addTargetMob(sim);
+    const applyAura = (aura: Aura) =>
+      (sim as unknown as { applyAura(target: Entity, aura: Aura): void }).applyAura(p, aura);
+    const scripted = unbreakableControl('scripted_stun', 'stun');
+    scripted.sourceId = mob.id;
+    const ordinary = debuff('ordinary_stun', 'stun');
+    ordinary.sourceId = mob.id;
+
+    sim.castAbility('ice_block');
+    applyAura(scripted);
+    applyAura(ordinary);
+
+    expect(p.auras.some((a) => a.id === 'scripted_stun')).toBe(true);
+    expect(p.auras.some((a) => a.id === 'ordinary_stun')).toBe(false);
   });
 
   it('rejects every incoming external crowd-control aura until Ice Block ends', () => {
@@ -165,6 +204,23 @@ describe('Ice Block: immunity + cleanse + control', () => {
     tickSeconds(sim, 1);
     sim.castAbility('ice_block');
     expect(p.auras.some((a) => a.kind === 'stasis')).toBe(false);
+  });
+
+  it('recast removes only caster-owned stasis when an aura id collides', () => {
+    const { sim, p } = rigMage();
+    const protectedAura = {
+      ...unbreakableControl('ice_block', 'stasis'),
+      sourceId: 9000,
+    };
+    const ownedStasis = { ...debuff('ice_block', 'stasis'), sourceId: p.id };
+    const ownedAbsorb = { ...debuff('ice_block_absorb', 'absorb', 100), sourceId: p.id };
+    p.auras.push(protectedAura, ownedStasis, ownedAbsorb);
+
+    sim.castAbility('ice_block');
+
+    expect(p.auras).toContain(protectedAura);
+    expect(p.auras).not.toContain(ownedStasis);
+    expect(p.auras).not.toContain(ownedAbsorb);
   });
 
   it('Frost carries two Ice Block charges; other specs carry one', () => {

--- a/tests/mage_choice_rows.test.ts
+++ b/tests/mage_choice_rows.test.ts
@@ -177,6 +177,41 @@ describe('mage choice rows (owner tree)', () => {
     expect(p.auras.some((a) => a.kind === 'stun')).toBe(true); // ICD running
   });
 
+  it('Temporal Rift never eats scripted encounter control (Nythraxis transition stun)', () => {
+    const { sim, p } = rig({ 8: 'mag_r8_temporal_rift' });
+    const mob = addTargetMob(sim);
+    const anySim = sim as unknown as { applyAura(t: Entity, a: object): void };
+    // The phase-two cinematic room stun, boss-sourced exactly as the encounter
+    // applies it (encounters/nythraxis.ts startNythraxisTransition).
+    anySim.applyAura(p, {
+      id: 'nythraxis_transition_stun',
+      name: 'Shuddering Stomp',
+      kind: 'stun',
+      value: 0,
+      remaining: 6,
+      duration: 6,
+      sourceId: mob.id,
+      school: 'physical',
+      unbreakableControl: true,
+    });
+    // The scripted stun LANDS and the rift charge is not consumed.
+    expect(p.auras.some((a) => a.id === 'nythraxis_transition_stun')).toBe(true);
+    expect(p.auras.some((a) => a.id === 'temporal_rift_cd')).toBe(false);
+    // An ordinary combat stun immediately after is still cleansed as normal.
+    anySim.applyAura(p, {
+      id: 'test_stun',
+      name: 'Test Stun',
+      kind: 'stun',
+      value: 0,
+      remaining: 3,
+      duration: 3,
+      sourceId: mob.id,
+      school: 'physical',
+    });
+    expect(p.auras.some((a) => a.id === 'test_stun')).toBe(false);
+    expect(p.auras.some((a) => a.id === 'temporal_rift_cd')).toBe(true);
+  });
+
   it('Greater Invisibility strips 2 DoTs, vanishes, and cuts damage 90%', () => {
     const { sim, p } = rig({ 8: 'mag_r8_greater_invis' });
     const mob = addTargetMob(sim);

--- a/tests/mob_dread.test.ts
+++ b/tests/mob_dread.test.ts
@@ -66,6 +66,35 @@ describe('Dread fear-on-hit affix', () => {
     expect(p.auras.some((a) => a.id === 'fear_incap')).toBe(true);
     // updateFearMovement returns true while the fear is active and no root holds.
     expect((sim as any).updateFearMovement(p)).toBe(true);
+    const fear = p.auras.find((a) => a.id === 'fear_incap')!;
+    fear.unbreakableControl = true;
+    expect((sim as any).updateFearMovement(p)).toBe(true);
+  });
+
+  it('unbreakable encounter control freezes an already-feared player', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000;
+    p.hp = 100000;
+    const mob = createMob(900604, dreadCarrier(), 12, { x: 0, y: 0, z: 0 });
+    for (let i = 0; i < 60 && !p.auras.some((a) => a.id === 'fear_incap'); i++) {
+      p.hp = p.maxHp;
+      (sim as any).mobSwing(mob, p);
+    }
+    expect(p.auras.some((a) => a.id === 'fear_incap')).toBe(true);
+    p.auras.push({
+      id: 'scripted_stun',
+      name: 'Scripted Stun',
+      kind: 'stun',
+      remaining: 10,
+      duration: 10,
+      value: 0,
+      sourceId: mob.id,
+      school: 'shadow',
+      unbreakableControl: true,
+    });
+
+    expect((sim as any).updateFearMovement(p)).toBe(false);
   });
 
   it('a friendly pet swing (hostile=false) never fears the party', () => {

--- a/tests/nythraxis_encounter.test.ts
+++ b/tests/nythraxis_encounter.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from 'vitest';
 import * as nythraxis from '../src/sim/encounters/nythraxis';
 import { Sim } from '../src/sim/sim';
 import type { SimContext } from '../src/sim/sim_context';
-import { dist2d, type Entity, NYTHRAXIS_ADD_ID, NYTHRAXIS_BOSS_ID } from '../src/sim/types';
+import { dist2d, type Entity, NYTHRAXIS_BOSS_ID } from '../src/sim/types';
 import { groundHeight } from '../src/sim/world';
 
 type AnySim = Sim & Record<string, any>;
@@ -62,7 +62,7 @@ function setup(opts: { difficulty?: 'normal' | 'heroic'; dpsCount?: number } = {
 }
 
 describe('Nythraxis encounter module (N1)', () => {
-  it('CC-immunity predicates classify raid enemies, control auras, and the scripted stun', () => {
+  it('CC-immunity predicates classify raid enemies and control auras', () => {
     const { ctx, boss } = setup();
     expect(nythraxis.isNythraxisRaidEnemy(boss)).toBe(true);
     expect(nythraxis.isNythraxisRaidEnemy({ kind: 'player' } as Entity)).toBe(false);
@@ -70,12 +70,6 @@ describe('Nythraxis encounter module (N1)', () => {
     expect(nythraxis.isNythraxisControlAura(ctx, 'slow')).toBe(true);
     expect(nythraxis.isNythraxisControlAura(ctx, 'stun')).toBe(true);
     expect(nythraxis.isNythraxisControlAura(ctx, 'dot')).toBe(false);
-    // The transition stun is the one scripted control that lands on adds / pets.
-    const add = { kind: 'mob', templateId: NYTHRAXIS_ADD_ID, ownerId: null } as Entity;
-    expect(
-      nythraxis.isNythraxisScriptedControl(add, { id: 'nythraxis_transition_stun' } as never),
-    ).toBe(true);
-    expect(nythraxis.isNythraxisScriptedControl(add, { id: 'frost_nova' } as never)).toBe(false);
   });
 
   it('Raise Fallen seeds and re-arms on the 30 second cadence (both difficulties)', () => {
@@ -98,7 +92,9 @@ describe('Nythraxis encounter module (N1)', () => {
     boss.hp = Math.floor(boss.maxHp * 0.69);
     nythraxis.updateNythraxisEncounter(ctx, boss);
     expect(boss.nythraxis?.phase).toBe('transition');
-    expect(tank.auras.some((a) => a.id === 'nythraxis_transition_stun')).toBe(true);
+    expect(tank.auras.find((a) => a.id === 'nythraxis_transition_stun')).toMatchObject({
+      unbreakableControl: true,
+    });
     const aldric = [...ctx.entities.values()].find(
       (e) => e.templateId === 'brother_aldric_raid' && !e.dead,
     );
@@ -111,6 +107,177 @@ describe('Nythraxis encounter module (N1)', () => {
     );
     expect(wards.length).toBe(3);
     expect(wards.every((w) => w.auras.some((a) => a.id === 'nythraxis_wardstone_lit'))).toBe(true);
+  });
+
+  it('keeps the room stunned while queued dialogue extends the transition', () => {
+    const { sim, ctx, boss, tank } = setup();
+    nythraxis.updateNythraxisEncounter(ctx, boss);
+    const st = boss.nythraxis!;
+    st.dialogueBusyUntil = ctx.time + 6;
+    boss.hp = Math.floor(boss.maxHp * 0.69);
+    nythraxis.updateNythraxisEncounter(ctx, boss);
+
+    const transitionStun = tank.auras.find((a) => a.id === 'nythraxis_transition_stun');
+    expect(transitionStun?.remaining).toBeGreaterThan(st.transitionTimer);
+
+    for (let tick = 0; tick < 22 * 20; tick++) sim.tick();
+    expect(st.phase).toBe('transition');
+    expect(tank.auras.some((a) => a.id === 'nythraxis_transition_stun')).toBe(true);
+
+    for (let tick = 0; tick < 6 * 20; tick++) sim.tick();
+    expect(st.phase).toBe(2);
+    expect(tank.auras.some((a) => a.id === 'nythraxis_transition_stun')).toBe(false);
+  });
+
+  it('enforces transition control through death, immediate revival, and unexpected removal', () => {
+    const { sim, ctx, boss, tank, dps } = setup();
+    nythraxis.updateNythraxisEncounter(ctx, boss);
+    const latePlayer = dps[0];
+    sim.setPlayerLevel(20, latePlayer.id);
+    latePlayer.dead = true;
+    latePlayer.hp = 0;
+    latePlayer.corpsePos = { ...latePlayer.pos };
+    ctx.pendingResurrections.set(latePlayer.id, {
+      casterId: tank.id,
+      hpFrac: 0.35,
+      fallbackDestination: { ...tank.pos },
+      expiresAt: ctx.time + 30,
+    });
+    boss.hp = Math.floor(boss.maxHp * 0.69);
+    nythraxis.updateNythraxisEncounter(ctx, boss);
+    const st = boss.nythraxis!;
+    expect(latePlayer.auras.some((a) => a.id === 'nythraxis_transition_stun')).toBe(true);
+
+    sim.respondToResurrection(true, latePlayer.id);
+    expect(latePlayer.dead).toBe(false);
+    expect(latePlayer.auras.some((a) => a.id === 'nythraxis_transition_stun')).toBe(true);
+    const revivedAt = { ...latePlayer.pos };
+    const revivedResource = latePlayer.resource;
+    sim.meta(latePlayer.id)!.moveInput.forward = true;
+    sim.castAbility('blink', latePlayer.id);
+    expect(latePlayer.resource).toBe(revivedResource);
+    expect(latePlayer.cooldowns.has('blink')).toBe(false);
+    sim.tick();
+    expect(dist2d(latePlayer.pos, revivedAt)).toBeLessThan(0.01);
+
+    latePlayer.auras = [
+      ...latePlayer.auras.filter((a) => a.id !== 'nythraxis_transition_stun'),
+      {
+        id: 'nythraxis_transition_stun',
+        name: 'Downgraded Stun',
+        kind: 'stun',
+        remaining: 1,
+        duration: 1,
+        value: 0,
+        sourceId: boss.id,
+        school: 'physical',
+      },
+    ];
+    nythraxis.updateNythraxisTransition(ctx, boss, st);
+    expect(latePlayer.auras.filter((a) => a.id === 'nythraxis_transition_stun')).toEqual([
+      expect.objectContaining({
+        name: 'Shuddering Stomp',
+        sourceId: boss.id,
+        unbreakableControl: true,
+      }),
+    ]);
+
+    latePlayer.pos.x += 500;
+    st.transitionTimer = 0.01;
+    nythraxis.updateNythraxisTransition(ctx, boss, st);
+    expect(latePlayer.auras.some((a) => a.id === 'nythraxis_transition_stun')).toBe(false);
+  });
+
+  it('pre-marks a released raider whose pending resurrection returns them to the room', () => {
+    const { sim, ctx, boss, tank, dps } = setup();
+    const releasedRaider = dps[0];
+    releasedRaider.dead = true;
+    releasedRaider.hp = 0;
+    sim.releaseSpirit(releasedRaider.id);
+    expect(dist2d(releasedRaider.pos, boss.spawnPos)).toBeGreaterThan(300);
+    ctx.pendingResurrections.set(releasedRaider.id, {
+      casterId: tank.id,
+      hpFrac: 0.35,
+      fallbackDestination: { ...tank.pos },
+      expiresAt: ctx.time + 30,
+    });
+
+    boss.hp = Math.floor(boss.maxHp * 0.69);
+    nythraxis.updateNythraxisEncounter(ctx, boss);
+    expect(releasedRaider.auras.some((a) => a.id === 'nythraxis_transition_stun')).toBe(true);
+    expect(releasedRaider.hp).toBe(releasedRaider.maxHp);
+
+    sim.respondToResurrection(true, releasedRaider.id);
+    const revivedAt = { ...releasedRaider.pos };
+    sim.castAbility('blink', releasedRaider.id);
+
+    expect(releasedRaider.dead).toBe(false);
+    expect(releasedRaider.auras.some((a) => a.id === 'nythraxis_transition_stun')).toBe(true);
+    expect(releasedRaider.pos).toEqual(revivedAt);
+    expect(releasedRaider.cooldowns.has('blink')).toBe(false);
+  });
+
+  it('keeps a chained resurrection arrival controlled before the next encounter tick', () => {
+    const { sim, ctx, boss, tank, dps } = setup();
+    const [arrivalAnchor, chainedRaider] = dps;
+    for (const raider of [arrivalAnchor, chainedRaider]) {
+      raider.dead = true;
+      raider.hp = 0;
+      sim.releaseSpirit(raider.id);
+      expect(dist2d(raider.pos, boss.spawnPos)).toBeGreaterThan(300);
+    }
+    // The chained raider's offer was made while its caster was still a distant
+    // ghost, so its fallback does not reveal that the caster will revive in-room.
+    ctx.pendingResurrections.set(chainedRaider.id, {
+      casterId: arrivalAnchor.id,
+      hpFrac: 0.35,
+      fallbackDestination: { ...arrivalAnchor.pos },
+      expiresAt: ctx.time + 30,
+    });
+    ctx.pendingResurrections.set(arrivalAnchor.id, {
+      casterId: tank.id,
+      hpFrac: 0.35,
+      fallbackDestination: { ...tank.pos },
+      expiresAt: ctx.time + 30,
+    });
+
+    boss.hp = Math.floor(boss.maxHp * 0.69);
+    nythraxis.updateNythraxisEncounter(ctx, boss);
+    expect(arrivalAnchor.auras.some((a) => a.id === 'nythraxis_transition_stun')).toBe(true);
+    expect(chainedRaider.auras.some((a) => a.id === 'nythraxis_transition_stun')).toBe(false);
+
+    sim.respondToResurrection(true, arrivalAnchor.id);
+    sim.respondToResurrection(true, chainedRaider.id);
+    const revivedAt = { ...chainedRaider.pos };
+    sim.castAbility('blink', chainedRaider.id);
+
+    expect(chainedRaider.dead).toBe(false);
+    expect(chainedRaider.auras.some((a) => a.id === 'nythraxis_transition_stun')).toBe(true);
+    expect(chainedRaider.pos).toEqual(revivedAt);
+    expect(chainedRaider.cooldowns.has('blink')).toBe(false);
+  });
+
+  it('releases every transition marker when the boss dies mid-transition', () => {
+    const { ctx, boss, tank, dps } = setup();
+    const deadRaider = dps[0];
+    deadRaider.dead = true;
+    deadRaider.hp = 0;
+    boss.hp = Math.floor(boss.maxHp * 0.69);
+    nythraxis.updateNythraxisEncounter(ctx, boss);
+    expect(boss.nythraxis?.phase).toBe('transition');
+    expect(tank.auras.some((a) => a.id === 'nythraxis_transition_stun')).toBe(true);
+    expect(deadRaider.auras.some((a) => a.id === 'nythraxis_transition_stun')).toBe(true);
+
+    boss.dead = true;
+    boss.hp = 0;
+    nythraxis.onBossDeath(ctx, boss);
+
+    expect(boss.nythraxis?.phase).toBe('dead');
+    for (const entity of ctx.entities.values()) {
+      expect(
+        entity.auras.some((a) => a.id === 'nythraxis_transition_stun' && a.sourceId === boss.id),
+      ).toBe(false);
+    }
   });
 
   it('heroic Soul Rend marks six distinct non-tank players', () => {

--- a/tests/nythraxis_raid.test.ts
+++ b/tests/nythraxis_raid.test.ts
@@ -1741,6 +1741,27 @@ describe('Nythraxis raid encounter', () => {
       add.swingTimer = 0;
       add.threat.set(tank.id, 1000);
     }
+    adds[0].auras.push({
+      id: 'fear_incap',
+      name: 'Fear',
+      kind: 'incapacitate',
+      remaining: 30,
+      duration: 30,
+      value: 0,
+      sourceId: tank.id,
+      school: 'shadow',
+    });
+    adds[1].auras.push({
+      id: 'polymorph',
+      name: 'Polymorph',
+      kind: 'polymorph',
+      remaining: 30,
+      duration: 30,
+      value: 0,
+      sourceId: tank.id,
+      school: 'arcane',
+    });
+    const transitionAddPositions = adds.map((add) => ({ ...add.pos }));
 
     boss.hp = Math.floor(boss.maxHp * 0.69);
     sim.tick();
@@ -1760,6 +1781,9 @@ describe('Nythraxis raid encounter', () => {
     ).toBe(false);
     expect(tank.hp).toBe(transitionHp);
     expect(boss.nythraxis?.phase).toBe('transition');
+    expect(adds.map((add, index) => dist2d(add.pos, transitionAddPositions[index]))).toEqual([
+      0, 0,
+    ]);
   });
 
   it('stuns active pets during the Aldric transition so they cannot keep attacking', () => {

--- a/tests/parity/golden/nythraxis_full_pull.json
+++ b/tests/parity/golden/nythraxis_full_pull.json
@@ -1745,7 +1745,7 @@
       "tick": 43,
       "time": 2.15,
       "nextId": 428,
-      "state": "e6107e09",
+      "state": "85bafa1f",
       "events": "e5643833",
       "rng": {
         "draws": 15,
@@ -2221,13 +2221,14 @@
               "sourceId": 415
             },
             {
-              "duration": 21.5,
+              "duration": 26,
               "id": "nythraxis_transition_stun",
               "kind": "stun",
               "name": "Shuddering Stomp",
-              "remaining": 21.5,
+              "remaining": 26,
               "school": "physical",
-              "sourceId": 420
+              "sourceId": 420,
+              "unbreakableControl": true
             }
           ],
           "blockChance": 0.05,
@@ -2284,13 +2285,14 @@
           "attackPower": 10,
           "auras": [
             {
-              "duration": 21.5,
+              "duration": 26,
               "id": "nythraxis_transition_stun",
               "kind": "stun",
               "name": "Shuddering Stomp",
-              "remaining": 21.5,
+              "remaining": 26,
               "school": "physical",
-              "sourceId": 420
+              "sourceId": 420,
+              "unbreakableControl": true
             }
           ],
           "combatTimer": 101.15,
@@ -2343,13 +2345,14 @@
           "attackPower": 10,
           "auras": [
             {
-              "duration": 21.5,
+              "duration": 26,
               "id": "nythraxis_transition_stun",
               "kind": "stun",
               "name": "Shuddering Stomp",
-              "remaining": 21.5,
+              "remaining": 26,
               "school": "physical",
-              "sourceId": 420
+              "sourceId": 420,
+              "unbreakableControl": true
             }
           ],
           "combatTimer": 101.15,
@@ -2402,13 +2405,14 @@
           "attackPower": 10,
           "auras": [
             {
-              "duration": 21.5,
+              "duration": 26,
               "id": "nythraxis_transition_stun",
               "kind": "stun",
               "name": "Shuddering Stomp",
-              "remaining": 21.5,
+              "remaining": 26,
               "school": "physical",
-              "sourceId": 420
+              "sourceId": 420,
+              "unbreakableControl": true
             }
           ],
           "combatTimer": 101.15,
@@ -2461,13 +2465,14 @@
           "attackPower": 10,
           "auras": [
             {
-              "duration": 21.5,
+              "duration": 26,
               "id": "nythraxis_transition_stun",
               "kind": "stun",
               "name": "Shuddering Stomp",
-              "remaining": 21.5,
+              "remaining": 26,
               "school": "physical",
-              "sourceId": 420
+              "sourceId": 420,
+              "unbreakableControl": true
             }
           ],
           "combatTimer": 101.15,
@@ -2520,11 +2525,11 @@
           "aiState": "attack",
           "auras": [
             {
-              "duration": 21.5,
+              "duration": 26,
               "id": "nythraxis_transition_pause",
               "kind": "stun",
               "name": "Shuddering Stomp",
-              "remaining": 21.45,
+              "remaining": 25.95,
               "school": "physical",
               "sourceId": 420
             }
@@ -2743,13 +2748,14 @@
           "aiState": "chase",
           "auras": [
             {
-              "duration": 21.5,
+              "duration": 26,
               "id": "nythraxis_transition_stun",
               "kind": "stun",
               "name": "Shuddering Stomp",
-              "remaining": 21.45,
+              "remaining": 25.95,
               "school": "physical",
-              "sourceId": 420
+              "sourceId": 420,
+              "unbreakableControl": true
             }
           ],
           "combatTimer": 99.1,
@@ -2805,13 +2811,14 @@
           "aiState": "chase",
           "auras": [
             {
-              "duration": 21.5,
+              "duration": 26,
               "id": "nythraxis_transition_stun",
               "kind": "stun",
               "name": "Shuddering Stomp",
-              "remaining": 21.45,
+              "remaining": 25.95,
               "school": "physical",
-              "sourceId": 420
+              "sourceId": 420,
+              "unbreakableControl": true
             }
           ],
           "combatTimer": 99.1,
@@ -2906,7 +2913,7 @@
       "tick": 50,
       "time": 2.5,
       "nextId": 428,
-      "state": "5487c851",
+      "state": "f9c00c8e",
       "events": "741638a5",
       "rng": {
         "draws": 37,
@@ -2917,7 +2924,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 428,
-      "state": "00fa0b73",
+      "state": "8cace924",
       "events": "741638a5",
       "rng": {
         "draws": 76,

--- a/tests/pet_commands_module.test.ts
+++ b/tests/pet_commands_module.test.ts
@@ -7,10 +7,16 @@ import {
   completeTame,
   feedPet,
   healPet,
+  petAttack,
   petOf,
+  petTaunt,
+  petWaterJet,
+  renamePet,
   restorePet,
   revivePet,
   serializePet,
+  setPetAutoTaunt,
+  setPetAutoWaterJet,
   setPetMode,
   summonPet,
 } from '../src/sim/pet/pet_commands';
@@ -48,6 +54,110 @@ function spawnWolf(sim: AnySim, near: AnyEntity, level = 2): AnyEntity {
 }
 
 describe('pet_commands module (P1b)', () => {
+  it('an unbreakable owner movement lock blocks every user-issued pet command', () => {
+    const { sim, hid, hunter } = hunterWorld();
+    const tame = spawnWolf(sim, hunter);
+    completeTame(sim.ctx, hunter, tame);
+    const pet = petOf(sim.ctx, hid) as AnyEntity;
+    const target = spawnWolf(sim, hunter);
+    hunter.targetId = target.id;
+    sim.ctx.applyAura(hunter, {
+      id: 'scripted_boss_lock',
+      name: 'Scripted Boss Lock',
+      kind: 'root',
+      value: 0,
+      remaining: 10,
+      duration: 10,
+      sourceId: target.id,
+      school: 'shadow',
+      unbreakableControl: true,
+    });
+
+    // Revival is immediate rather than tick-driven, so it must be rejected at the
+    // command boundary instead of waiting for the encounter to mark the pet again.
+    pet.dead = true;
+    pet.hp = 0;
+    revivePet(sim.ctx, hid);
+    expect(pet.dead).toBe(true);
+    expect(pet.hp).toBe(0);
+
+    // Put the pet back into a neutral live state as a system/encounter operation,
+    // then prove every direct control surface remains side-effect free.
+    pet.dead = false;
+    pet.hp = Math.floor(pet.maxHp * 0.5);
+    pet.aiState = 'idle';
+    pet.aggroTargetId = null;
+    pet.inCombat = false;
+    pet.petTauntTimer = 0;
+    pet.petManualTauntPending = false;
+    sim.addItem('baked_bread', 1, hid);
+    const breadBefore = sim.countItem('baked_bread', hid);
+
+    petAttack(sim.ctx, hid);
+    expect(pet.aggroTargetId).toBeNull();
+    expect(pet.inCombat).toBe(false);
+    expect(target.threat.has(pet.id)).toBe(false);
+
+    petTaunt(sim.ctx, hid);
+    expect(pet.petTauntTimer).toBe(0);
+    expect(pet.petManualTauntPending).toBe(false);
+    expect(target.forcedTargetId).not.toBe(pet.id);
+
+    feedPet(sim.ctx, 'baked_bread', hid);
+    expect(sim.countItem('baked_bread', hid)).toBe(breadBefore);
+    expect(pet.auras.some((a) => a.id === 'feed_pet')).toBe(false);
+
+    setPetMode(sim.ctx, 'aggressive', hid);
+    setPetAutoTaunt(sim.ctx, true, hid);
+    expect(pet.petMode).toBe('defensive');
+    expect(pet.petAutoTaunt).toBe(false);
+
+    // Exercise the mage-only active/autocast seam on the same owned entity.
+    pet.templateId = 'water_elemental';
+    setPetAutoWaterJet(sim.ctx, true, hid);
+    petWaterJet(sim.ctx, hid);
+    expect(pet.petAutoWaterJet).toBe(false);
+    expect(pet.castingAbility).toBeNull();
+    expect(pet.petTauntTimer).toBe(0);
+    expect(target.auras.some((a) => a.id === 'water_jet')).toBe(false);
+
+    const nameBefore = pet.name;
+    renamePet(sim.ctx, 'Locked', hid);
+    abandonPet(sim.ctx, hid);
+    expect(pet.name).toBe(nameBefore);
+    expect(sim.entities.has(pet.id)).toBe(true);
+  });
+
+  it('an unbreakable owner movement lock cannot spend mana or arm Demon Heal', () => {
+    const sim = new Sim({ seed: 12, playerClass: 'warlock', noPlayer: true }) as AnySim;
+    const pid = sim.addPlayer('warlock', 'Demonist') as number;
+    const owner = sim.entities.get(pid) as AnyEntity;
+    summonPet(sim.ctx, owner, 'emberkin');
+    const pet = petOf(sim.ctx, pid) as AnyEntity;
+    pet.hp = Math.max(1, pet.maxHp - 50);
+    owner.resource = owner.maxResource;
+    sim.ctx.applyAura(owner, {
+      id: 'scripted_boss_lock',
+      name: 'Scripted Boss Lock',
+      kind: 'root',
+      value: 0,
+      remaining: 10,
+      duration: 10,
+      sourceId: pet.id,
+      school: 'shadow',
+      unbreakableControl: true,
+    });
+    const manaBefore = owner.resource;
+    const gcdBefore = owner.gcdRemaining;
+
+    healPet(sim.ctx, pid);
+
+    expect(owner.resource).toBe(manaBefore);
+    expect(owner.gcdRemaining).toBe(gcdBefore);
+    expect(owner.castingAbility).toBeNull();
+    expect(owner.channeling).toBe(false);
+  });
+
   it('hunter lifecycle: tame -> setMode -> feed -> revive -> abandon', () => {
     const { sim, hid, hunter } = hunterWorld();
     const wolf = spawnWolf(sim, hunter);

--- a/tests/resurrection.test.ts
+++ b/tests/resurrection.test.ts
@@ -63,6 +63,12 @@ describe('resurrection: aurasSurvivingDeath predicate', () => {
     expect(survivors[0].id).toBe(RESURRECTION_SICKNESS_ID);
   });
 
+  it('keeps encounter-owned unbreakable control until its script releases it', () => {
+    const scriptedStun = { ...aura('scripted_stun'), unbreakableControl: true } as const;
+
+    expect(aurasSurvivingDeath([aura('rejuvenation'), scriptedStun])).toEqual([scriptedStun]);
+  });
+
   it('returns an empty list when nothing survives', () => {
     expect(aurasSurvivingDeath([aura('rejuvenation')])).toEqual([]);
     expect(aurasSurvivingDeath([])).toEqual([]);

--- a/tests/snapshot_timer_wire.test.ts
+++ b/tests/snapshot_timer_wire.test.ts
@@ -49,6 +49,21 @@ describe('StableAuraWireCache', () => {
     expect(cache.rebuilds).toBe(1);
   });
 
+  it('serializes unbreakable control and rebuilds when its protection changes', () => {
+    const cache = new StableAuraWireCache();
+    const active = aura('scripted_stasis', 10);
+    active.kind = 'stasis';
+    active.unbreakableControl = true;
+
+    const protectedWire = cache.encode([active], 0, false);
+    expect(JSON.parse(protectedWire.json)[0]).toMatchObject({ ub: 1 });
+
+    active.unbreakableControl = undefined;
+    const ordinaryWire = cache.encode([active], 0, false);
+    expect(ordinaryWire.revision).toBe(protectedWire.revision + 1);
+    expect(JSON.parse(ordinaryWire.json)[0]).not.toHaveProperty('ub');
+  });
+
   it('rebuilds for every wire-visible mutation and explicit empty removal', () => {
     const cache = new StableAuraWireCache();
     const first = aura('first', 10);

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -3693,6 +3693,24 @@ describe('aura magnitude over the wire (buff/debuff tooltip parity)', () => {
     expect(desc?.school).toBe('shadow');
   });
 
+  it('round-trips unbreakable control so the client never offers cancellation', () => {
+    const scriptedStasis: Aura = {
+      id: 'scripted_stasis',
+      name: 'Scripted Stasis',
+      kind: 'stasis',
+      remaining: 10,
+      duration: 10,
+      value: 0,
+      sourceId: 0,
+      school: 'arcane',
+      unbreakableControl: true,
+    };
+
+    const { wire, mirror } = roundTrip(scriptedStasis);
+    expect(wireAura(wire, 'scripted_stasis').ub).toBe(1);
+    expect(mirror.unbreakableControl).toBe(true);
+  });
+
   it('round-trips the imbue judgement range (value2/value3), value omitted when 0', () => {
     const imbue: Aura = {
       id: 'holy_might',

--- a/tests/talent_effect_primitives_v026.test.ts
+++ b/tests/talent_effect_primitives_v026.test.ts
@@ -56,6 +56,15 @@ function aura(
   };
 }
 
+function unbreakableControl(
+  owner: Entity,
+  id: string,
+  kind: Aura['kind'],
+  school: Aura['school'],
+): Aura & { unbreakableControl: true } {
+  return { ...aura(owner, id, kind, 0, school), unbreakableControl: true };
+}
+
 function step(sim: Sim, ticks: number): void {
   for (let index = 0; index < ticks; index++) sim.tick();
 }
@@ -235,6 +244,65 @@ describe('Talents V2 movement and control primitives', () => {
     runAbilityEffect(mage, null, 'blink');
     expect(mage.player.auras.some((entry) => entry.kind === 'root')).toBe(false);
     expect(resolvedSteps).toBeGreaterThan(0);
+  });
+
+  it('preserves unbreakable encounter control across player removal primitives', () => {
+    const warrior = new Sim({ seed: 81, playerClass: 'warrior', autoEquip: true });
+    warrior.player.auras.push(
+      unbreakableControl(warrior.player, 'scripted_stun', 'stun', 'shadow'),
+    );
+    runAbilityEffect(warrior, null, 'avatar');
+    expect(warrior.player.auras.some((entry) => entry.id === 'scripted_stun')).toBe(true);
+
+    const mage = new Sim({ seed: 82, playerClass: 'mage', autoEquip: true });
+    mage.player.auras.push(unbreakableControl(mage.player, 'scripted_root', 'root', 'nature'));
+    const mageStart = { ...mage.player.pos };
+    const originalResolve = mage.ctx.resolveMovePoint;
+    let protectedRootMoveSteps = 0;
+    (mage.ctx as { resolveMovePoint: typeof originalResolve }).resolveMovePoint = (
+      x,
+      z,
+      radius,
+      mover,
+    ) => {
+      protectedRootMoveSteps++;
+      return originalResolve(x, z, radius, mover);
+    };
+    runAbilityEffect(mage, null, 'blink');
+    expect(mage.player.auras.some((entry) => entry.id === 'scripted_root')).toBe(true);
+    expect(mage.player.pos).toEqual(mageStart);
+    expect(protectedRootMoveSteps).toBe(0);
+
+    const castingMage = new Sim({ seed: 85, playerClass: 'mage', autoEquip: true });
+    castingMage.setPlayerLevel(20);
+    castingMage.tick();
+    castingMage.player.gcdRemaining = 0;
+    castingMage.player.resource = castingMage.player.maxResource;
+    castingMage.player.auras.push(
+      unbreakableControl(castingMage.player, 'scripted_root', 'root', 'nature'),
+    );
+    const castingMageStart = { ...castingMage.player.pos };
+    const castingMageResource = castingMage.player.resource;
+    castingMage.castAbility('blink');
+    expect(castingMage.player.pos).toEqual(castingMageStart);
+    expect(castingMage.player.resource).toBe(castingMageResource);
+    expect(castingMage.player.cooldowns.has('blink')).toBe(false);
+
+    const rogue = new Sim({ seed: 84, playerClass: 'rogue', autoEquip: true });
+    const shadowstepTarget = addHostile(rogue, 10);
+    rogue.player.auras.push(unbreakableControl(rogue.player, 'scripted_root', 'root', 'nature'));
+    const rogueStart = { ...rogue.player.pos };
+    runAbilityEffect(rogue, shadowstepTarget, 'shadowstep');
+    expect(rogue.player.pos).toEqual(rogueStart);
+
+    const paladin = new Sim({ seed: 83, playerClass: 'paladin', noPlayer: true });
+    const casterId = paladin.addPlayer('paladin', 'Caster');
+    const allyId = paladin.addPlayer('mage', 'Ally');
+    const ally = paladin.entities.get(allyId);
+    if (!ally || paladin.player.id !== casterId) throw new Error('missing dispel rig entities');
+    ally.auras.push(unbreakableControl(paladin.player, 'scripted_silence', 'silence', 'shadow'));
+    runAbilityEffect(paladin, ally, 'cleansing_verdict');
+    expect(ally.auras.some((entry) => entry.id === 'scripted_silence')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Problem

Nythraxis scripted transition control could be consumed, prevented, or removed by player mechanics such as Temporal Rift and Ice Block. Adversarial review also found same-tick escape windows through pet revival and chained resurrection.

## Fix

- Add an aura-level unbreakableControl contract for encounter-authored CC.
- Protected control lands through player and mob immunities and cannot be removed by cleanse, dispel, control-break, damage-break, manual cancellation, death, resurrection, or an unprotected same-ID replacement.
- Block protected movement escapes and user-issued pet commands before costs, cooldowns, or state changes occur.
- Make Nythraxis own the transition stun lifecycle: account for queued dialogue, reassert late or resurrected participants, and clear globally on transition end, reset, or boss death.
- Inherit active protected control synchronously when a resurrection arrives at a controlled caster.
- Mirror the protection flag through snapshots and the aura UI.

Ordinary combat boss CC remains removable; only explicitly authored scripted control uses this contract.

## Test plan

- [x] 527 focused boss-control, Ice Block, movement, pet, resurrection, wire, and UI regressions
- [x] Parity suite: 180 passed
- [x] Browser suite: 66 passed
- [x] TypeScript and Svelte checks clean
- [x] Client, server, and environment builds clean
- [x] Malware/security gate clean
- [x] Final adversarial review found no high or medium issues

The full local suite produced 16,717 passes. Two deploy-watchdog assertions reproduce on a clean release checkout in this macOS environment; one load-only SFX timeout passes 45/45 in isolation.