### PR TITLE
fix(sfx): silence the crit stinger and hurt bark on the Training Dummy

### DIFF
--- a/src/ui/combat_sfx.ts
+++ b/src/ui/combat_sfx.ts
@@ -262,15 +262,25 @@ export function mobVoiceCueWithFallback(
   return mobVoiceCue(templateId, 'attack', hasCue);
 }
 
+/** Gates BOTH crit-reaction cues in hud.ts: the generic `combat_crit` ding
+ *  (played directly whenever this returns true) and the mob-voice hurt bark
+ *  (via mobVoiceActionForDamage below). A boss or the Training Dummy gets
+ *  neither: a boss because a crit sting is a wrong emotional beat mid-boss-fight,
+ *  the dummy because it soaks hits for the damage meter and was never meant
+ *  to react like a real fight, the ding included. */
 export function shouldPlayCritSfxForTarget(target: Entity): boolean {
-  return target.kind !== 'mob' || !MOBS[target.templateId]?.boss;
+  return (
+    target.kind !== 'mob' || (!MOBS[target.templateId]?.boss && !MOBS[target.templateId]?.dummy)
+  );
 }
 
 /** The mob-voice action a damage event's target should react with, or null
- *  for anything that isn't a crit against a non-boss mob (a miss, an
- *  ordinary hit, a player target, a boss immune to crit stingers). Callers
- *  still gate the actual play through shouldPlayMobVoiceSfxForEntity (the
- *  Nythraxis mute list) before using the resolved cue. */
+ *  for anything that isn't a crit against a non-boss, non-dummy mob (a miss,
+ *  an ordinary hit, a player target, a boss immune to crit stingers, the
+ *  Training Dummy, whose whole point is soaking hits for the damage meter
+ *  without reacting like a real fight). Callers still gate the actual play
+ *  through shouldPlayMobVoiceSfxForEntity (the Nythraxis mute list) before
+ *  using the resolved cue. */
 export function mobVoiceActionForDamage(event: DamageEvent, target: Entity): MobVoiceAction | null {
   if (!event.crit || target.kind !== 'mob' || !shouldPlayCritSfxForTarget(target)) return null;
   return 'hurt';

--- a/tests/combat_sfx.test.ts
+++ b/tests/combat_sfx.test.ts
@@ -126,10 +126,13 @@ describe('combat SFX policy', () => {
     expect(mobVoiceCue('water_elemental', 'hurt')).toBe('mob_water_elemental_attack');
     expect(mobVoiceFamily('stormcrag_elemental')).toBe('elemental');
   });
-  it('suppresses crit stingers for boss targets only', () => {
+  it('suppresses crit stingers for boss and dummy targets', () => {
     expect(shouldPlayCritSfxForTarget(target('mob', 'nythraxis_scourge_of_thornpeak'))).toBe(false);
     expect(shouldPlayCritSfxForTarget(target('mob', 'nythraxis_skeleton_warrior'))).toBe(true);
     expect(shouldPlayCritSfxForTarget(target('player', 'warrior'))).toBe(true);
+    // The Training Dummy soaks hits for the damage meter; it should never
+    // react to a crit like a real fight.
+    expect(shouldPlayCritSfxForTarget(target('mob', 'training_dummy'))).toBe(false);
   });
 
   it('suppresses Nythraxis add voice barks without muting ordinary undead', () => {
@@ -340,13 +343,15 @@ describe('combat SFX policy', () => {
     expect(Object.keys(MOB_VOICE_CUES).sort()).toEqual([...SFX_MOB_EXTENSION_FAMILIES].sort());
   });
 
-  it('requests a hurt reaction only for a crit against a non-boss mob', () => {
+  it('requests a hurt reaction only for a crit against a non-boss, non-dummy mob', () => {
     const mob = target('mob', 'crypt_shambler');
     const boss = target('mob', 'nythraxis_scourge_of_thornpeak');
+    const dummy = target('mob', 'training_dummy');
     const player = target('player', 'warrior');
     expect(mobVoiceActionForDamage(damage({ crit: true }), mob)).toBe('hurt');
     expect(mobVoiceActionForDamage(damage({ crit: false }), mob)).toBeNull();
     expect(mobVoiceActionForDamage(damage({ crit: true }), boss)).toBeNull();
+    expect(mobVoiceActionForDamage(damage({ crit: true }), dummy)).toBeNull();
     expect(mobVoiceActionForDamage(damage({ crit: true }), player)).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

Every crit against the Training Dummy played the generic `combat_crit` ding and a mob-voice hurt bark, same as a real fight. `shouldPlayCritSfxForTarget` already excludes bosses from these cues (a crit sting mid-boss-fight is the wrong emotional beat), but the dummy fell through the same gap since it has no `boss` field to exclude it.

The dummy soaks hits for the damage meter and was never meant to react like a real fight. Adds the same `MOBS[...].dummy` check alongside the existing boss check.

Note on scope (caught in review): `shouldPlayCritSfxForTarget` gates two consumers in `hud.ts`, not one: the `combat_crit` ding (played directly whenever it returns true) and the mob-voice hurt bark (via `mobVoiceActionForDamage`). This fix silences both, which is the coherent/intended behavior (matches how a boss is already treated), documented explicitly in the updated doc comment.

## Related issues

N/A

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands: `npx tsc --noEmit`, `npx vitest run tests/combat_sfx.test.ts` (20/20 pass, two new cases), scoped `npx @biomejs/biome check`
- Manual steps: N/A (pure logic change, no player-facing UI; behavior is audio-only and covered by the new test cases distinguishing old vs. new behavior)

## Screenshots / recordings

N/A (non-visual audio fix)

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.