### PR TITLE
refactor(deeds): remove the retired deedCount wire field

### DIFF
--- a/docs/design/deeds.md
+++ b/docs/design/deeds.md
@@ -133,8 +133,8 @@ and it surfaces as Renown, never as a count.
 number shown on a ranked surface must be either recomputable by the player
 from an in-game surface or explicitly labeled with its set and scope. The
 Renown board therefore displays Renown alone: there is no deed-count column
-(the retired wire field is deprecated and tracked for removal in issue
-#2044), the account scope is stated in visible text on the tab
+and no count rides the wire (the deprecated wire-compat output was removed
+by issue #2044), the account scope is stated in visible text on the tab
 (`hudChrome.deeds.lbScopeNote`), and the self line carries the account's
 board-scored Renown so a single-character player can verify it against their
 Book. If a deed count is ever re-added to a ranked surface, it must be named

--- a/scripts/pr_shot_targets.mjs
+++ b/scripts/pr_shot_targets.mjs
@@ -403,8 +403,6 @@ export const TARGETS = [
         if (!game) return;
         const fakePage = {
           leaders: [
-            // deedCount rides the wire for stale clients (issue #2044); the
-            // pre-change painter renders it, the current one never reads it.
             {
               rank: 1,
               name: 'Aldwin',
@@ -412,7 +410,6 @@ export const TARGETS = [
               cls: 'warrior',
               level: 20,
               renown: 1620,
-              deedCount: 129,
               title: 'prog_veteran',
             },
             {
@@ -422,7 +419,6 @@ export const TARGETS = [
               cls: 'mage',
               level: 20,
               renown: 1490,
-              deedCount: 117,
               title: null,
             },
             {
@@ -432,7 +428,6 @@ export const TARGETS = [
               cls: 'priest',
               level: 19,
               renown: 1390,
-              deedCount: 112,
               title: null,
             },
             {
@@ -442,7 +437,6 @@ export const TARGETS = [
               cls: 'rogue',
               level: 20,
               renown: 1350,
-              deedCount: 108,
               title: 'prog_veteran',
             },
             {
@@ -452,7 +446,6 @@ export const TARGETS = [
               cls: 'druid',
               level: 18,
               renown: 1245,
-              deedCount: 97,
               title: null,
             },
           ],

--- a/server/db.ts
+++ b/server/db.ts
@@ -3016,9 +3016,7 @@ export async function topGuilds(
 // completionTime is max over the scoring set of each deed's EARLIEST earn; the
 // display character is the account's highest per-character Renown character,
 // ties to the lowest id; ordering is renown desc, completion asc, accountId
-// asc. deed_count (the scoring-set size) is a deprecated wire-compat output
-// removed next release together with the pure spec's field (issue #2044,
-// executable-spec lockstep both times); it is not displayed by current clients.
+// asc.
 export async function deedsBoardRanked(
   deedIds: readonly string[],
   renowns: readonly number[],
@@ -3049,7 +3047,6 @@ export async function deedsBoardRanked(
      account_agg AS (
        SELECT pd.account_id,
               sum(r.renown)::int AS renown,
-              count(*)::int AS deed_count,
               max(pd.first_earned) AS completion_time
          FROM per_deed pd
          JOIN renown r ON r.deed_id = pd.deed_id
@@ -3072,7 +3069,6 @@ export async function deedsBoardRanked(
      )
      SELECT aa.account_id,
             aa.renown,
-            aa.deed_count,
             aa.completion_time,
             d.character_id AS display_character_id
        FROM account_agg aa
@@ -3083,7 +3079,6 @@ export async function deedsBoardRanked(
     const ranked: RankedDeedsAccount[] = res.rows.map((r) => ({
       accountId: Number(r.account_id),
       renown: Number(r.renown),
-      deedCount: Number(r.deed_count),
       // TIMESTAMPTZ back to epoch ms (Date via pg; string tolerated for driver
       // config drift), matching computeDeedsBoard's earnedMs.
       completionTime: new Date(r.completion_time).getTime(),

--- a/server/deeds_board.ts
+++ b/server/deeds_board.ts
@@ -45,12 +45,6 @@ export interface RankedDeedsAccount {
   accountId: number;
   /** Sum of renown over the scoring set (distinct renown-bearing deed ids). */
   renown: number;
-  /** @deprecated Wire-compat only, removed next release (issue #2044): the
-   *  size of the scoring set, still computed so a stale client's column
-   *  renders real data. Never displayed by current clients; zero-renown deeds
-   *  are outside the SCORING set (never score, never move the tie-break), and
-   *  the player-facing completion count is src/sim/deeds_completion.ts. */
-  deedCount: number;
   /** When the account's current score was reached: max over the scoring set of
    *  each deed's EARLIEST earn (a re-earn on a second character adds no score,
    *  so it cannot move this either). Epoch ms. */
@@ -84,9 +78,9 @@ function earnedMs(earnedAt: Date | string): number {
 }
 
 interface AccountAgg {
-  /** Counted set: deed id -> the account's earliest earn of it (epoch ms). */
+  /** Scoring set: deed id -> the account's earliest earn of it (epoch ms). */
   deedFirstEarn: Map<string, number>;
-  /** Per character: its OWN counted set, for the display-character pick. */
+  /** Per character: its OWN scoring set, for the display-character pick. */
   charDeeds: Map<number, Set<string>>;
 }
 
@@ -154,7 +148,6 @@ export function computeDeedsBoard(
     ranked.push({
       accountId,
       renown,
-      deedCount: agg.deedFirstEarn.size,
       completionTime,
       displayCharacterId,
     });
@@ -204,7 +197,6 @@ export function buildDeedsBoardEntries(
       cls: display.class,
       level: display.level,
       renown: account.renown,
-      deedCount: account.deedCount,
       title: display.activeTitle,
     });
   }

--- a/src/ui/deeds_leaderboard_view.ts
+++ b/src/ui/deeds_leaderboard_view.ts
@@ -25,8 +25,9 @@ import type { DeedsLeaderboardPage } from '../world_api';
 import type { LeaderboardPager } from './leaderboard_view';
 
 /** One ranked account row, faced by its display character. Renown is the one
- *  ranked number on the row: the deprecated wire deedCount is deliberately NOT
- *  mapped here (issue #2044; the completion count lives in the Book header). */
+ *  ranked number on the row (the ranked-surface rule, docs/design/deeds.md:
+ *  no deed count rides this board; the completion count lives in the Book
+ *  of Deeds header). */
 export interface DeedsLeaderboardRow {
   rank: number;
   name: string;

--- a/src/world_api/deeds.ts
+++ b/src/world_api/deeds.ts
@@ -39,12 +39,6 @@ export interface DeedsLeaderboardEntry {
   cls: PlayerClass;
   level: number;
   renown: number;
-  /** @deprecated Wire-compat only, removed next release (issue #2044): the
-   *  board displays no deed count anymore (Renown is the one ranked number;
-   *  the completion count lives in the Book of Deeds header). The server
-   *  keeps populating it so a stale client's column renders real data; new
-   *  clients never read it. */
-  deedCount: number;
   // The display character's selected title: a deed id the client localizes
   // through deed_i18n.ts (never display text), or null when untitled.
   title: string | null;

--- a/tests/deeds_completion.test.ts
+++ b/tests/deeds_completion.test.ts
@@ -11,9 +11,9 @@
 //    list makes that a conscious, reviewed act instead of a silent default,
 //  - cross-surface parity: the Book of Deeds header (buildDeedsView), the
 //    predicate, and the character sheet (characterSheet) agree on one earned
-//    state, while the board's deprecated deedCount agrees ONLY on an
-//    all-renown-bearing set (the scoring set is a different concept by
-//    design; issue #2044 removes that wire field),
+//    state, while the board's Renown sums the SCORING set (a different
+//    concept by design: invariant under zero-renown earns, which the
+//    completion pair counts),
 //  - the two-character account fixture: the board unions each deed once per
 //    account, the ONE sanctioned scope difference from the per-character Book.
 
@@ -205,19 +205,37 @@ describe('cross-surface parity', () => {
     expect(sheet.deeds.earnedCount).toBe(pair.earned);
   });
 
-  it('the board deedCount equals the completion count ONLY for an all-renown-bearing set', () => {
-    // The scoring set and the completion set are different concepts that
-    // coincide exactly when every earned deed bears renown; the deprecated
-    // deedCount (issue #2044) is the scoring-set size.
-    const CATALOG: Record<string, DeedDef> = { a: deed('a', 25), b: deed('b', 50) };
-    const rows: DeedsBoardSourceRow[] = [
+  it('an earned zero-renown deed grows the completion count but never the board score', () => {
+    // The 142-vs-129 class, restated in renown-sum terms: the board's score
+    // is invariant under a zero-renown earn (it sums the SCORING set), while
+    // the Book's completion pair counts it. The two surfaces stay coherent
+    // because the board shows no count at all, only Renown.
+    const CATALOG: Record<string, DeedDef> = {
+      a: deed('a', 25),
+      b: deed('b', 50),
+      z: deed('z', 0),
+    };
+    const ORDER = ['a', 'b', 'z'];
+    const base: DeedsBoardSourceRow[] = [
       { accountId: 1, characterId: 11, deedId: 'a', earnedAt: '2026-07-01T00:00:00.000Z' },
       { accountId: 1, characterId: 11, deedId: 'b', earnedAt: '2026-07-02T00:00:00.000Z' },
     ];
-    const board = computeDeedsBoard(rows, CATALOG).ranked;
-    const pair = completionCounts(new Set(['a', 'b']), CATALOG, ['a', 'b']);
-    expect(board).toHaveLength(1);
-    expect(board[0].deedCount).toBe(pair.earned);
+    const withZero: DeedsBoardSourceRow[] = [
+      ...base,
+      { accountId: 1, characterId: 11, deedId: 'z', earnedAt: '2026-07-03T00:00:00.000Z' },
+    ];
+    // The board score equals the renown summed over the earned completion set
+    // (here every scoring deed also completes), and the zero-renown earn moves
+    // the completion count from 2 to 3 without moving the score.
+    const baseBoard = computeDeedsBoard(base, CATALOG).ranked;
+    const withZeroBoard = computeDeedsBoard(withZero, CATALOG).ranked;
+    expect(baseBoard[0].renown).toBe(75);
+    expect(withZeroBoard[0].renown).toBe(75);
+    // Nor the tie-break: if 'z' entered the scoring set, its later earn would
+    // drag completionTime past the score point (the 'b' earn).
+    expect(withZeroBoard[0].completionTime).toBe(Date.parse('2026-07-02T00:00:00.000Z'));
+    expect(completionCounts(new Set(['a', 'b']), CATALOG, ORDER).earned).toBe(2);
+    expect(completionCounts(new Set(['a', 'b', 'z']), CATALOG, ORDER).earned).toBe(3);
   });
 
   it('two characters, one account: the board unions once, each Book counts its own', () => {
@@ -233,9 +251,9 @@ describe('cross-surface parity', () => {
     ];
     const board = computeDeedsBoard(rows, CATALOG).ranked;
     expect(board).toHaveLength(1);
-    // Union renown 75: 'a' scores once for the account despite two earners.
+    // Union renown 75 (25 + 50), never the raw-row 100: 'a' scores once for
+    // the account despite two earners.
     expect(board[0].renown).toBe(75);
-    expect(board[0].deedCount).toBe(2);
     // Per-character Books: char 11 completed 1 of 2, char 12 completed 2 of 2.
     expect(completionCounts(new Set(['a']), CATALOG, ['a', 'b']).earned).toBe(1);
     expect(completionCounts(new Set(['a', 'b']), CATALOG, ['a', 'b']).earned).toBe(2);

--- a/tests/deeds_leaderboard_view.test.ts
+++ b/tests/deeds_leaderboard_view.test.ts
@@ -1,10 +1,7 @@
 // Tests for the Renown-tab pure core (deeds_leaderboard_view.ts):
 //  - the async state machine: loading / error / empty / ranked discriminators,
 //  - row derivation (rank, name, realm, class + knownClass, level, renown,
-//    and the TITLE passed through as a DEED ID, never text; the deprecated
-//    wire deedCount stays on the entry FIXTURE, pinning the wire shape a
-//    stale client still reads, and is deliberately NOT mapped onto rows,
-//    issue #2044),
+//    and the TITLE passed through as a DEED ID, never text),
 //  - the viewer's own row flagged `me` by the server-resolved account rank,
 //  - the server-resolved `self` standing passed through (null when absent;
 //    renown rides it from a current server and is absent from an older one),
@@ -31,7 +28,6 @@ function entry(over: Partial<DeedsLeaderboardEntry> = {}): DeedsLeaderboardEntry
     cls: 'warrior',
     level: 20,
     renown: 425,
-    deedCount: 37,
     title: 'prog_veteran',
     ...over,
   };
@@ -63,7 +59,7 @@ describe('buildDeedsLeaderboardView', () => {
       kind: 'page',
       page: page({
         leaders: [
-          entry({ rank: 1, name: 'Aldwin', renown: 425, deedCount: 37, title: 'prog_veteran' }),
+          entry({ rank: 1, name: 'Aldwin', renown: 425, title: 'prog_veteran' }),
           entry({ rank: 2, name: 'Berrin', realm: 'Duskhold', renown: 300, title: null }),
         ],
         total: 2,
@@ -72,8 +68,8 @@ describe('buildDeedsLeaderboardView', () => {
     const view = buildDeedsLeaderboardView(input);
     expect(view.kind).toBe('ranked');
     if (view.kind !== 'ranked') return;
-    // toEqual is exact: the deprecated wire deedCount on the input entries
-    // must NOT surface on the rows (Renown is the one ranked number).
+    // toEqual is exact: a row carries Renown as its one ranked number and
+    // nothing beyond the pinned shape (the ranked-surface rule).
     expect(view.rows).toEqual([
       {
         rank: 1,

--- a/tests/deeds_rarity_client.test.ts
+++ b/tests/deeds_rarity_client.test.ts
@@ -73,7 +73,6 @@ describe('ClientWorld.deedsLeaderboard', () => {
           cls: 'warrior',
           level: 20,
           renown: 50,
-          deedCount: 2,
           title: 'prog_veteran',
         },
       ],

--- a/tests/leaderboard_window.test.ts
+++ b/tests/leaderboard_window.test.ts
@@ -272,10 +272,11 @@ describe('leaderboard_window: Renown (deeds) board tab', () => {
   });
 
   it('renders no deed-count column: Renown is the one ranked number on the board', () => {
-    // The column was removed deliberately (issue #2044): the completion count
-    // lives in the Book of Deeds header, never on a ranked surface.
+    // The column was removed deliberately (the ranked-surface rule in
+    // docs/design/deeds.md): the completion count lives in the Book of Deeds
+    // header, never on a ranked surface, and the entry type carries no count
+    // field for the painter to read.
     expect(code).not.toContain('lb-deeds-count');
-    expect(code).not.toContain('deedCount');
   });
 
   it('renders the localized Renown-tab empty state', () => {

--- a/tests/leaderboard_window_stale.test.ts
+++ b/tests/leaderboard_window_stale.test.ts
@@ -90,7 +90,6 @@ describe('LeaderboardWindow: stale async board responses', () => {
           cls: 'mage',
           level: 20,
           renown: 4200,
-          deedCount: 77,
           title: null,
         },
       ],

--- a/tests/server/deeds_board.test.ts
+++ b/tests/server/deeds_board.test.ts
@@ -3,8 +3,8 @@
 // keys (score desc, completionTime asc, accountId asc), display-character
 // selection, the self rank + topPercent + renown read, and unknown-deed
 // tolerance. Plain fixtures, no db import: the module is host-agnostic by
-// design. deedCount is a deprecated wire-compat output (issue #2044): still
-// asserted populated here until its removal, never displayed by clients.
+// design. The board SCORES the renown-bearing scoring set; it carries no
+// deed count (the completion count lives in the Book of Deeds header).
 
 import { describe, expect, it } from 'vitest';
 import {
@@ -65,20 +65,18 @@ function ranked(rows: DeedsBoardSourceRow[]): RankedDeedsAccount[] {
 }
 
 describe('computeDeedsBoard scoring', () => {
-  it('sums renown over the distinct counted set and reports deedCount', () => {
+  it('sums renown over the distinct scoring set', () => {
     const board = ranked([row(1, 11, 'd25a', T1), row(1, 11, 'd10a', T2), row(1, 12, 'd25b', T3)]);
     expect(board).toHaveLength(1);
     expect(board[0].accountId).toBe(1);
     expect(board[0].renown).toBe(60);
-    expect(board[0].deedCount).toBe(3);
   });
 
-  it('counts a deed once per account even when two characters both earned it', () => {
+  it('scores a deed once per account even when two characters both earned it', () => {
     const board = ranked([row(1, 11, 'd50', T1), row(1, 12, 'd50', T3), row(1, 11, 'd25a', T2)]);
     expect(board).toHaveLength(1);
     // 50 + 25, never 50 + 50 + 25: the roll-up dedupes per account by deed id.
     expect(board[0].renown).toBe(75);
-    expect(board[0].deedCount).toBe(2);
     // The duplicate's later earn does not move completionTime either: the deed
     // first contributed renown at its EARLIEST earn (T1), so the score was
     // reached at max(T1, T2) = T2.
@@ -93,7 +91,7 @@ describe('computeDeedsBoard scoring', () => {
 });
 
 describe('zero-renown deeds sit outside the scoring set', () => {
-  it('never score, and never enter the deprecated deedCount output', () => {
+  it('never add to the account score', () => {
     const board = ranked([
       row(1, 11, 'd50', T1),
       row(1, 11, 'feat0', T2),
@@ -102,7 +100,6 @@ describe('zero-renown deeds sit outside the scoring set', () => {
     ]);
     expect(board).toHaveLength(1);
     expect(board[0].renown).toBe(75);
-    expect(board[0].deedCount).toBe(2);
   });
 
   it('a zero-renown FEAT does not shift the tie-break', () => {
@@ -245,7 +242,6 @@ describe('buildDeedsBoardEntries', () => {
         cls: 'warrior',
         level: 20,
         renown: 75,
-        deedCount: 2,
         title: 'd50',
       },
       {
@@ -255,7 +251,6 @@ describe('buildDeedsBoardEntries', () => {
         cls: 'warrior',
         level: 20,
         renown: 50,
-        deedCount: 1,
         title: null,
       },
     ]);

--- a/tests/server/deeds_board_sql.test.ts
+++ b/tests/server/deeds_board_sql.test.ts
@@ -112,18 +112,16 @@ describe('deedsBoardRanked SQL shape (mocked pool)', () => {
     // with the exact unnest element types.
     expect(agg).toContain('unnest($1::text[], $2::int[])');
     // Zero-renown deeds never enter the SCORING set: they never score and
-    // never move the tie-break or the entry floor. (deed_count, the scoring
-    // set's size, is a deprecated wire-compat output; issue #2044.)
+    // never move the tie-break or the entry floor.
     expect(agg).toContain('WHERE u.renown > 0');
     // Per-deed earliest earn (a re-earn on a second character cannot move it).
     expect(agg).toContain('per_deed AS (');
     expect(agg).toContain('min(cd.earned_at) AS first_earned');
     expect(agg).toContain('GROUP BY cd.account_id, cd.deed_id');
-    // Account score = sum over the counted set; deedCount = size; completionTime =
-    // max of the per-deed earliest earns; floor applied server-side, inclusive.
+    // Account score = sum over the scoring set; completionTime = max of the
+    // per-deed earliest earns; floor applied server-side, inclusive.
     expect(agg).toContain('account_agg AS (');
     expect(agg).toContain('sum(r.renown)::int AS renown');
-    expect(agg).toContain('count(*)::int AS deed_count');
     expect(agg).toContain('max(pd.first_earned) AS completion_time');
     expect(agg).toContain('HAVING sum(r.renown) >= $3');
     // Display character = highest per-character Renown, ties to lowest id.
@@ -135,8 +133,8 @@ describe('deedsBoardRanked SQL shape (mocked pool)', () => {
     expect(agg).toContain('ORDER BY aa.renown DESC, aa.completion_time ASC, aa.account_id ASC');
 
     // The eligibility fragment is embedded VERBATIM at BOTH roll-up sites (per-deed
-    // and per-character), so a banned/suspended account is delisted from the score,
-    // the count, AND the display pick.
+    // and per-character), so a banned/suspended account is delisted from the score
+    // AND the display pick.
     expect(agg.split(ELIGIBLE_ACCOUNT_SQL).length - 1).toBe(2);
     expect(agg).toContain('JOIN accounts a ON a.id = cd.account_id');
     // Belt over the ON DELETE CASCADE: only rows whose character still exists.
@@ -164,14 +162,12 @@ describe('deedsBoardRanked SQL shape (mocked pool)', () => {
           {
             account_id: 1,
             renown: 75,
-            deed_count: 2,
             completion_time: new Date(T2),
             display_character_id: 11,
           },
           {
             account_id: 2,
             renown: 50,
-            deed_count: 1,
             completion_time: new Date(T2),
             display_character_id: 21,
           },
@@ -185,7 +181,6 @@ describe('deedsBoardRanked SQL shape (mocked pool)', () => {
     expect(out.ranked[0]).toEqual({
       accountId: 1,
       renown: 75,
-      deedCount: 2,
       completionTime: Date.parse(T2),
       displayCharacterId: 11,
     });
@@ -199,7 +194,6 @@ describe('deedsBoardRanked SQL shape (mocked pool)', () => {
           {
             account_id: 9,
             renown: 50,
-            deed_count: 1,
             completion_time: T1,
             display_character_id: 90,
           },
@@ -385,7 +379,6 @@ describe.skipIf(!PG_ON)('deedsBoardRanked differential vs computeDeedsBoard (pg-
     ]);
     expect(sql[0]).toMatchObject({
       renown: 75,
-      deedCount: 2,
       completionTime: Date.parse(T2),
       displayCharacterId: 99110111,
     });
@@ -398,9 +391,8 @@ describe.skipIf(!PG_ON)('deedsBoardRanked differential vs computeDeedsBoard (pg-
   it('flags the unknown deed id and excludes it (and the zero-renown feat) from every score', async () => {
     const full = await deedsBoardRanked(DEED_IDS, RENOWNS, DEEDS_BOARD_ENTRY_FLOOR);
     expect(full.unknownDeedIds).toContain('sql_gone');
-    // score75's counted set is {d50, d25a} = 75, never inflated by sql_feat0 or sql_gone.
+    // score75's scoring set is {d50, d25a} = 75, never inflated by sql_feat0 or sql_gone.
     const top = full.ranked.find((a) => a.accountId === ACCT.score75);
     expect(top?.renown).toBe(75);
-    expect(top?.deedCount).toBe(2);
   });
 });

--- a/tests/server/leaderboard.test.ts
+++ b/tests/server/leaderboard.test.ts
@@ -100,7 +100,6 @@ function deedsRow(rank: number): DeedsLeaderboardEntry {
     cls: 'warrior' as DeedsLeaderboardEntry['cls'],
     level: 20,
     renown: 500 - rank,
-    deedCount: 40 - rank,
     title: rank === 1 ? 'prog_veteran' : null,
   };
 }
@@ -292,11 +291,18 @@ describe('response builders (convention B deferred: leaders key preserved)', () 
     const first = (body.leaders as Record<string, unknown>[])[0];
     expect(first.name).toBe('Chronicler1');
     expect(first.renown).toBe(499);
-    // deedCount stays POPULATED on the wire this release (deprecated
-    // wire-compat for stale clients, issue #2044); current clients never
-    // display it.
-    expect(first.deedCount).toBe(39);
     expect(first.title).toBe('prog_veteran');
+    // The exact wire key set: Renown is the one ranked number the entry
+    // carries (the ranked-surface rule; the retired count output is gone).
+    expect(Object.keys(first).sort()).toEqual([
+      'cls',
+      'level',
+      'name',
+      'rank',
+      'realm',
+      'renown',
+      'title',
+    ]);
     expect('accountId' in first).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

Executes issue #2044, the deferred follow-up to #2046: the Renown leaderboard stopped displaying a deed count in v0.27.0, and the deprecated `deedCount` wire field stayed populated for one release so pre-#2046 clients kept rendering real data. With v0.27.0 now in production, this PR deletes the field everywhere, in executable-spec lockstep (the pure spec and its SQL twin change in the same commit):

- **Facet:** `DeedsLeaderboardEntry.deedCount` and its deprecation jsdoc are gone from `src/world_api/deeds.ts`. No other `IWorld` member changed; the parity pin needs no edit for an aux-type field deletion and stays green.
- **Pure spec:** `RankedDeedsAccount.deedCount`, its fill in `computeDeedsBoard`, and the entry fill in `buildDeedsBoardEntries` are removed from `server/deeds_board.ts`; remaining count-arm prose is rewritten to scoring-set language.
- **SQL twin:** `deedsBoardRanked` (`server/db.ts`) drops the `count(*)::int AS deed_count` aggregate, its select output, the `Number(r.deed_count)` row mapping, and the header comment's deprecation paragraph. The `WHERE u.renown > 0` scoring-set fragment survives byte-identical, and board ordering (renown desc, completion asc, accountId asc), the entry floor, and the completion-time tie-break are untouched.
- **Tests:** the populated-count pins across eight suites are reworked to scoring-set and renown-sum semantics: the cross-surface suite now pins that an earned zero-renown deed grows the completion count but moves neither the board score nor the tie-break, the route suite pins the exact wire key set of an entry, and the `toEqual`-exact shapes plus the type-level deletion keep resurrection impossible. The painter suite keeps its `lb-deeds-count` column-resurrection guard.
- **Hygiene:** the `scripts/pr_shot_targets.mjs` fake board page drops the fixture fields; `docs/design/deeds.md` records the wire output as removed.

After the removal, a tree-wide grep finds zero `deedCount` / `deed_count` references outside git history. A v0.26-or-earlier client renders a blank column for the absent field, which #2044 sanctions; v0.27.0 clients never read it.

Note for the merger: this PR targets `release/v0.28.0`, and release-branch merges never auto-close issues, so #2044 needs a manual close at merge.

## Related issues

Closes #2044. Follow-up to #2046.

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Tests
- [x] Breaking change (please call it out in the summary): the sanctioned removal of a deprecated wire output, scoped to this release by #2044.

## How was this tested?

- Commands: `npm run gate` under Node 24. Every step green up to the browser suite; the single failure is the known pre-existing environmental armory mobile-layout flake (`tests/browser/armory_mobile_layout.browser.test.ts`, the same one documented in #2046, untouched by this diff), after which the four remaining steps (typecheck, env build, server build, client build) were completed manually, all green. Targeted `npx vitest run` over the ten affected and guard suites (444 passed, 3 Postgres-gated skips). `npx tsc --noEmit` clean; Biome on the changed files only.
- Review: three read-only reviewers (qa-checklist, test-coverage-auditor, cross-platform-sync) ran over the diff; zero blocking findings, and their one improvement item (pin the tie-break in the reworked zero-renown test) is applied in this commit.
- Manual steps: tree-wide reference grep (zero hits) and a byte check of the `WHERE u.renown > 0` pin.

---

## Checklist

### Quality

- [x] **The full gate passes.** (One documented environmental browser flake, detailed above; PR CI is the arbiter.)

### Cross-platform

- [x] N/A for new UI: no pixel changes (the board stopped rendering the count in v0.27.0); both worlds compile against the narrowed entry type.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings, and `npm run i18n:gen` leaves the tree clean.

### Hygiene

- [x] No secrets, no `.env`, no `ALLOW_DEV_COMMANDS` in any production path.
- [x] No generated files hand-edited.