### PR TITLE
fix(sim): reclaim emptied spatial-grid cells instead of leaking them

### DIFF
--- a/src/sim/spatial.ts
+++ b/src/sim/spatial.ts
@@ -2,7 +2,7 @@
 // otherwise scan every entity. Cells are re-bucketed once per tick (gradual
 // movement) and kept exact on spawn/despawn/teleport, so queries always see
 // the same roster as the entities map.
-import { Entity } from './types';
+import type { Entity } from './types';
 
 // shifts negative cell coordinates into the positive range before packing
 const OFFSET = 32768;
@@ -14,7 +14,9 @@ export class SpatialGrid {
   constructor(readonly cellSize = 32) {}
 
   private keyAt(x: number, z: number): number {
-    return (Math.floor(x / this.cellSize) + OFFSET) * 65536 + (Math.floor(z / this.cellSize) + OFFSET);
+    return (
+      (Math.floor(x / this.cellSize) + OFFSET) * 65536 + (Math.floor(z / this.cellSize) + OFFSET)
+    );
   }
 
   insert(e: Entity): void {
@@ -39,6 +41,19 @@ export class SpatialGrid {
       list[i] = list[list.length - 1];
       list.pop();
     }
+    // An emptied cell is dropped entirely: entities constantly cross cell
+    // boundaries (movement, respawns, despawns) over a long-lived server
+    // process, so leaving a stale empty array behind here means `cells` grows
+    // without bound over uptime even though the live entity/player count stays
+    // flat. That unbounded Map growth is pure GC pressure with no gameplay
+    // benefit (a re-`insert` recreates the array on demand), so reclaim it now.
+    if (list.length === 0) this.cells.delete(key);
+  }
+
+  // Number of occupied cells currently tracked, for tests/diagnostics: proves
+  // an emptied cell is reclaimed rather than left behind as dead weight.
+  cellCount(): number {
+    return this.cells.size;
   }
 
   // Re-bucket an entity whose position changed cells (movement, teleport).

--- a/src/sim/spatial.ts
+++ b/src/sim/spatial.ts
@@ -41,12 +41,12 @@ export class SpatialGrid {
       list[i] = list[list.length - 1];
       list.pop();
     }
-    // An emptied cell is dropped entirely: entities constantly cross cell
-    // boundaries (movement, respawns, despawns) over a long-lived server
-    // process, so leaving a stale empty array behind here means `cells` grows
-    // without bound over uptime even though the live entity/player count stays
-    // flat. That unbounded Map growth is pure GC pressure with no gameplay
-    // benefit (a re-`insert` recreates the array on demand), so reclaim it now.
+    // An emptied cell is dropped entirely rather than left as dead weight.
+    // `insert()` reuses an existing array, so `cells.size` was already bounded
+    // by the number of distinct cells ever occupied (not by movement/spawn
+    // churn), so this is not unbounded growth. Still, a stale empty array
+    // serves no purpose (a re-`insert` recreates it on demand), so reclaim it
+    // now to keep `cells.size` tracking the true occupied-cell count.
     if (list.length === 0) this.cells.delete(key);
   }
 

--- a/tests/spatial.test.ts
+++ b/tests/spatial.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
 import { SpatialGrid } from '../src/sim/spatial';
-import { Entity, dist2d } from '../src/sim/types';
+import { dist2d, type Entity } from '../src/sim/types';
 
 function bruteForceInRadius(sim: Sim, x: number, z: number, radius: number): Set<number> {
   const out = new Set<number>();
@@ -55,6 +55,25 @@ describe('spatial grid', () => {
     expect(gridInRadius(grid, 0, 0, 2).has(1)).toBe(false);
   });
 
+  it('reclaims an emptied cell instead of leaking it forever', () => {
+    // Root cause of a production tick-time/GC sawtooth that grew with server
+    // uptime rather than player/entity count: remove() left a stale empty
+    // array behind in `cells` whenever the last occupant of a cell moved out,
+    // so a long-lived process accumulated one dead Map entry per distinct
+    // cell any entity ever vacated, forever. Simulate an entity wandering
+    // through many distinct cells (as happens over hours of real movement)
+    // and assert the tracked cell count stays at the true occupied count (1)
+    // instead of growing with the number of moves.
+    const grid = new SpatialGrid();
+    const e = { id: 1, pos: { x: 0, y: 0, z: 0 } } as Entity;
+    grid.insert(e);
+    for (let i = 1; i <= 500; i++) {
+      e.pos.x = i * 40; // 40 > cellSize (32), so every step crosses a cell boundary
+      grid.update(e);
+    }
+    expect(grid.cellCount()).toBe(1);
+  });
+
   it('player combat flag matches per-player scan semantics', () => {
     const sim = new Sim({ seed: 20061, playerClass: 'warrior' });
     const p = sim.entities.get(sim.primaryId)!;
@@ -65,7 +84,12 @@ describe('spatial grid', () => {
       meta.moveInput.forward = true;
       sim.tick();
       for (const e of sim.entities.values()) {
-        if (e.kind === 'mob' && !e.dead && (e.aiState === 'chase' || e.aiState === 'attack') && e.aggroTargetId === p.id) {
+        if (
+          e.kind === 'mob' &&
+          !e.dead &&
+          (e.aiState === 'chase' || e.aiState === 'attack') &&
+          e.aggroTargetId === p.id
+        ) {
           aggroed = true;
         }
       }

--- a/tests/spatial.test.ts
+++ b/tests/spatial.test.ts
@@ -56,14 +56,13 @@ describe('spatial grid', () => {
   });
 
   it('reclaims an emptied cell instead of leaking it forever', () => {
-    // Root cause of a production tick-time/GC sawtooth that grew with server
-    // uptime rather than player/entity count: remove() left a stale empty
-    // array behind in `cells` whenever the last occupant of a cell moved out,
-    // so a long-lived process accumulated one dead Map entry per distinct
-    // cell any entity ever vacated, forever. Simulate an entity wandering
-    // through many distinct cells (as happens over hours of real movement)
-    // and assert the tracked cell count stays at the true occupied count (1)
-    // instead of growing with the number of moves.
+    // remove() used to leave a stale empty array behind in `cells` whenever
+    // the last occupant of a cell moved out, so a long-lived process
+    // accumulated one dead Map entry per distinct cell any entity ever
+    // vacated. Simulate an entity wandering through many distinct cells (as
+    // happens over hours of real movement) and assert the tracked cell count
+    // stays at the true occupied count (1) instead of growing with the
+    // number of moves.
     const grid = new SpatialGrid();
     const e = { id: 1, pos: { x: 0, y: 0, z: 0 } } as Entity;
     grid.insert(e);


### PR DESCRIPTION
## Summary

Players reported bad framerates, lag, and frequent disconnects, especially on mobile.
Grafana ("Game Server Health" and "Triage / Correlation" dashboards, prod, 6h window
spanning two "Game deploy / restart" markers) showed a distinctive sawtooth: Sim Tick
Time (p95/max, 50ms budget) and Event-Loop Lag p99 both climbed steadily within each
multi-hour window between restarts, then reset right after every restart, and climbed
again. Heap Used showed the same rising-sawtooth GC pattern. HTTP latency (p95/p99)
followed the identical shape. Meanwhile players online, host CPU, host memory, disk,
and network stayed flat and unsaturated the whole time. That combination rules out
simple overload (more players, more load) and points at a per-tick server cost that
grows with **uptime**, not with concurrent player/entity count.

Bug found while investigating: `SpatialGrid.remove()` (`src/sim/spatial.ts`) deleted an
entity from its cell's array but never deleted the `cells` Map entry once that array
became empty. Every entity that crosses a cell boundary during ordinary movement, or
any mob spawn/despawn, can leave a dead, permanently retained empty-array entry behind.
This is a real, uptime-correlated memory leak and worth fixing regardless.

**Update per review (Rubsey):** the review confirmed the fix and the regression test
are correct, but pushed back on the root-cause narrative below, and that pushback
holds up: `forEachInRadius` looks up cells by computed key (`cells.get(key)`), it never
iterates the `cells` Map itself, so a dead cell outside the query window costs nothing,
and `insert()` reuses the existing empty array rather than growing per spawn/despawn,
so `cells.size` is bounded by distinct occupied cells (on this world's layout, in the
low thousands, a few hundred KB), not by traffic churn. That is very unlikely to
produce a climbing, multi-hour sawtooth that resets on restart. This PR is merged as a
correct, worthwhile bookkeeping fix, but it probably is not the fix for the sawtooth;
the perf investigation (Grafana Sim Tick / Event-Loop Lag / Heap sawtooth) stays open
as a separate, unresolved issue.

```mermaid
flowchart TB
    subgraph before["Before: cell map only grows"]
        direction TB
        A1["Entity moves / mob spawns or despawns"] --> A2["SpatialGrid.remove()<br/>drops entity from cell's array"]
        A2 --> A3{"array now empty?"}
        A3 -->|yes, previously| A4["cells Map entry LEFT BEHIND<br/>(dead weight, never reclaimed)"]
        A4 --> A5["cells.size grows forever<br/>with server uptime"]
        A5 --> A6["forEachInRadius scans more<br/>dead cells every tick"]
        A6 --> A7["Tick p95/max + event-loop lag<br/>climb; GC pressure rises"]
        A7 --> A8["Mobile clients trip keepalive/<br/>reconnect timeouts first"]
    end
    subgraph after["After: cell map stays bounded"]
        direction TB
        B1["Entity moves / mob spawns or despawns"] --> B2["SpatialGrid.remove()<br/>drops entity from cell's array"]
        B2 --> B3{"array now empty?"}
        B3 -->|yes, now| B4["cells.delete(key)<br/>cell reclaimed immediately"]
        B4 --> B5["cells.size tracks true<br/>occupied-cell count"]
        B5 --> B6["Tick time and event-loop lag<br/>stay flat regardless of uptime"]
    end
```

*(Diagram shows the bookkeeping fix itself; see the review update above for why this
alone is unlikely to explain the observed sawtooth.)*

## Related issues

Filed from a Grafana-driven perf investigation (bad framerate / lag / mobile
disconnect reports), no pre-existing tracked issue number. Per Rubsey's review, the
underlying sawtooth is still unexplained; a follow-up issue should track that
investigation separately from this bookkeeping fix.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/spatial.test.ts` (new regression test: an entity walked
    through 500 distinct cells now leaves `cellCount()` at 1 instead of growing with
    the number of moves; verified test-first by reverting the fix and confirming the
    test fails, then restoring it and confirming it passes)
  - `npx tsc --noEmit` (clean)
  - `npx @biomejs/biome check src/sim/spatial.ts tests/spatial.test.ts` (no new
    warnings or format diffs)
  - `npm run gate` (full suite: 16010 passed, 3 unrelated pre-existing failures
    confirmed present on the unmodified base branch too: a jsdom/Node localStorage
    sandbox quirk in `tests/deeds_window_focus.test.ts`, and two `http/characterization`
    and `http/parity` tests that time out only under heavy parallel worker load and
    pass cleanly in isolation; neither touches `src/sim/spatial.ts` or its callers)
- Manual steps: none; this is an internal bookkeeping fix inside `SpatialGrid` with
  no observable gameplay or wire-protocol change, so no state/golden regen or manual
  play-test was needed.

## Screenshots / recordings

N/A. This is a server-internal performance fix (spatial-index bookkeeping); nothing a
player or operator sees changes.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green apart from three pre-existing
      failures confirmed present on the unmodified base branch (see above). I added a
      decisive regression test for the fixed behavior.

### Cross-platform

- [ ] Tested on desktop and mobile. N/A: no UI surface touched.
- [ ] Accessible. N/A: no UI surface touched.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.

