### PR TITLE
fix(sfx): let the Training Dummy keep its crit ding, only silence the hurt bark

### DIFF
--- a/src/ui/combat_sfx.ts
+++ b/src/ui/combat_sfx.ts
@@ -262,27 +262,36 @@ export function mobVoiceCueWithFallback(
   return mobVoiceCue(templateId, 'attack', hasCue);
 }
 
-/** Gates BOTH crit-reaction cues in hud.ts: the generic `combat_crit` ding
- *  (played directly whenever this returns true) and the mob-voice hurt bark
- *  (via mobVoiceActionForDamage below). A boss or the Training Dummy gets
- *  neither: a boss because a crit sting is a wrong emotional beat mid-boss-fight,
- *  the dummy because it soaks hits for the damage meter and was never meant
- *  to react like a real fight, the ding included. */
+/** Gates the generic `combat_crit` ding in hud.ts (played directly whenever
+ *  this returns true). A boss gets none: a crit sting is a wrong emotional
+ *  beat mid-boss-fight. The Training Dummy DOES still get the ding (2026-07-19
+ *  follow-up to #2116: the dummy soaks hits for the damage meter and was
+ *  never meant to react like a real fight with a pained hurt bark, but the
+ *  plain crit ding is fine and expected feedback while testing rotations
+ *  against it; see mobVoiceActionForDamage below for the hurt-bark-only
+ *  exclusion). */
 export function shouldPlayCritSfxForTarget(target: Entity): boolean {
-  return (
-    target.kind !== 'mob' || (!MOBS[target.templateId]?.boss && !MOBS[target.templateId]?.dummy)
-  );
+  return target.kind !== 'mob' || !MOBS[target.templateId]?.boss;
 }
 
 /** The mob-voice action a damage event's target should react with, or null
- *  for anything that isn't a crit against a non-boss, non-dummy mob (a miss,
- *  an ordinary hit, a player target, a boss immune to crit stingers, the
- *  Training Dummy, whose whole point is soaking hits for the damage meter
- *  without reacting like a real fight). Callers still gate the actual play
+ *  for anything that isn't a crit against a non-boss mob (a miss, an
+ *  ordinary hit, a player target, a boss immune to crit stingers), OR the
+ *  Training Dummy specifically: it still gets the plain combat_crit ding
+ *  (shouldPlayCritSfxForTarget above), just never the pained hurt-bark
+ *  vocalization, since it soaks hits for the damage meter and was never
+ *  meant to react like a real fight. Callers still gate the actual play
  *  through shouldPlayMobVoiceSfxForEntity (the Nythraxis mute list) before
  *  using the resolved cue. */
 export function mobVoiceActionForDamage(event: DamageEvent, target: Entity): MobVoiceAction | null {
-  if (!event.crit || target.kind !== 'mob' || !shouldPlayCritSfxForTarget(target)) return null;
+  if (
+    !event.crit ||
+    target.kind !== 'mob' ||
+    !shouldPlayCritSfxForTarget(target) ||
+    MOBS[target.templateId]?.dummy
+  ) {
+    return null;
+  }
   return 'hurt';
 }
 

--- a/tests/combat_sfx.test.ts
+++ b/tests/combat_sfx.test.ts
@@ -126,13 +126,14 @@ describe('combat SFX policy', () => {
     expect(mobVoiceCue('water_elemental', 'hurt')).toBe('mob_water_elemental_attack');
     expect(mobVoiceFamily('stormcrag_elemental')).toBe('elemental');
   });
-  it('suppresses crit stingers for boss and dummy targets', () => {
+  it('suppresses the crit ding for a boss but not the Training Dummy', () => {
     expect(shouldPlayCritSfxForTarget(target('mob', 'nythraxis_scourge_of_thornpeak'))).toBe(false);
     expect(shouldPlayCritSfxForTarget(target('mob', 'nythraxis_skeleton_warrior'))).toBe(true);
     expect(shouldPlayCritSfxForTarget(target('player', 'warrior'))).toBe(true);
-    // The Training Dummy soaks hits for the damage meter; it should never
-    // react to a crit like a real fight.
-    expect(shouldPlayCritSfxForTarget(target('mob', 'training_dummy'))).toBe(false);
+    // 2026-07-19 follow-up to #2116: the dummy still gets the plain crit
+    // ding (only the hurt-bark vocalization is suppressed for it, see
+    // mobVoiceActionForDamage below).
+    expect(shouldPlayCritSfxForTarget(target('mob', 'training_dummy'))).toBe(true);
   });
 
   it('suppresses Nythraxis add voice barks without muting ordinary undead', () => {
@@ -351,6 +352,8 @@ describe('combat SFX policy', () => {
     expect(mobVoiceActionForDamage(damage({ crit: true }), mob)).toBe('hurt');
     expect(mobVoiceActionForDamage(damage({ crit: false }), mob)).toBeNull();
     expect(mobVoiceActionForDamage(damage({ crit: true }), boss)).toBeNull();
+    // The dummy is excluded from the hurt bark specifically, even though it
+    // still gets the plain crit ding (shouldPlayCritSfxForTarget, tested above).
     expect(mobVoiceActionForDamage(damage({ crit: true }), dummy)).toBeNull();
     expect(mobVoiceActionForDamage(damage({ crit: true }), player)).toBeNull();
   });


### PR DESCRIPTION
## Summary

Follow-up to #2116. That PR excluded the Training Dummy from both crit-reaction cues (the generic `combat_crit` ding and the mob-voice hurt bark), which was wider than intended: the plain crit ding is useful feedback while testing rotations against the dummy, so only the pained hurt-bark vocalization should be suppressed (the dummy soaks hits for the damage meter and was never meant to react like a real fight with a pained bark).

`shouldPlayCritSfxForTarget` goes back to excluding only bosses (the ding stays gated for a boss, a crit sting is the wrong emotional beat mid-boss-fight). The dummy exclusion moves to `mobVoiceActionForDamage`, which now checks the dummy flag directly so it is skipped only on the hurt-bark path, not the ding.

Based on `release/v0.28.0` (branched from PR #2133's catch-up merge, so #2116 is already present to build on).

## Related issues

Follow-up to #2116.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx tsc --noEmit`, `npx vitest run tests/combat_sfx.test.ts`, full `npm test -- --maxWorkers=4` (1328 files / 16130 tests, 0 failures), scoped `npx @biomejs/biome check --write` on both touched files.
- Manual steps: none needed beyond the updated unit coverage (both branches of the split are directly asserted).

## Checklist

### Quality
- [x] The full gate passes (run manually step-by-step; `ci:changed` false-positive-floods on a diverged branch, a known separate issue, not introduced here).

### Localization (i18n)
- [x] N/A. No player-visible strings.

### Hygiene
- [x] No secrets/credentials committed.
- [x] No hand-edited generated files.