### PR TITLE
perf(server): cache party frame projections per broadcast

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -9,7 +9,6 @@ import {
   wireStreamerLinks,
 } from '../src/sim/account_flair';
 import { verifyChallenge } from '../src/sim/client_challenge';
-import { echoVisibleTo } from '../src/sim/combat/chronomancy';
 import { damageTakenWithin } from '../src/sim/combat/damage_history';
 import { rewindHealAmount } from '../src/sim/combat/rewind';
 import { DEEDS } from '../src/sim/content/deeds';
@@ -46,7 +45,6 @@ import { parseMoveInputFrame } from '../src/sim/move_input';
 import {
   partyFrameAbsorb,
   partyFrameAggroTargets,
-  partyFrameAuras,
   partyFrameIncomingHeals,
   partyFrameRole,
 } from '../src/sim/party_frame_info';
@@ -71,7 +69,6 @@ import {
   isDungeonDifficulty,
   MAX_LEVEL,
   type MobFamily,
-  PARTY_MEMBER_AURA_CAP,
   RUN_SPEED,
   type SimEvent,
   type SportRole,
@@ -166,6 +163,7 @@ import {
   ModerationService,
 } from './moderation_service';
 import { consumeMsgToken, createMsgRateBucket, type MsgRateBucketState } from './msg_rate_limit';
+import { PartyFrameProjectionCache } from './party_frame_projection';
 import { nextRaidResetMs } from './raid_reset';
 import { REALM, REALM_PUBLIC_ORIGIN, REALM_RESET_TIME_ZONE } from './realm';
 import { createSerialWriter } from './serial_writer';
@@ -1117,14 +1115,15 @@ export class GameServer {
   private readonly moderation: ModerationService<ClientSession>;
   private wireCache = new Map<number, EntityWireCache>();
   // partyFrameAggroTargets / partyFrameIncomingHeals scan the whole entity set and
-  // are GLOBAL (identical for every grouped session), yet partyWire runs once per
-  // grouped session per tick. Memoize both once per tick so a 40-raid does one scan,
-  // not one per member. (see review #1864, finding 1)
+  // are GLOBAL (identical for every grouped session), yet partyWire runs once for
+  // each grouped session. Memoize both for one broadcast so each party does one
+  // scan, not one per member. (see review #1864, finding 1)
   private partyFrameGlobalsCache: {
     tick: number;
     aggroTargets: ReturnType<typeof partyFrameAggroTargets>;
     incomingHeals: ReturnType<typeof partyFrameIncomingHeals>;
   } | null = null;
+  private readonly partyFrameProjectionCache = new PartyFrameProjectionCache();
   private lastWireSweepTick = 0;
   private interval: NodeJS.Timeout | null = null;
   private holderTierInterval: NodeJS.Timeout | null = null;
@@ -4895,6 +4894,8 @@ export class GameServer {
 
   private broadcastSnapshots(): void {
     if (this.clients.size === 0) return;
+    this.partyFrameGlobalsCache = null;
+    this.partyFrameProjectionCache.beginBroadcast();
     const tick = this.sim.tickCount;
     // tickHz rides the head at ~2 Hz, not on every snapshot: it is omitted while
     // the meter warms up (first ~1s, so a fresh server never shows a bogus
@@ -5338,7 +5339,7 @@ export class GameServer {
   }
 
   // Global party-frame aggregates (aggro holders + incoming heals), scanned once
-  // per tick and shared by every partyWire call in that tick.
+  // per broadcast and shared by every partyWire call in that broadcast.
   private partyFrameGlobals(): {
     aggroTargets: ReturnType<typeof partyFrameAggroTargets>;
     incomingHeals: ReturnType<typeof partyFrameIncomingHeals>;
@@ -5361,51 +5362,52 @@ export class GameServer {
     const party = this.sim.partyOf(pid);
     if (!party) return null;
     const { aggroTargets, incomingHeals } = this.partyFrameGlobals();
-    return {
-      leader: party.leader,
-      raid: party.raid,
-      master: { ...party.lootStrategies.master },
-      members: party.members
-        .map((mPid) => {
-          const meta = this.sim.meta(mPid);
-          const e = this.sim.entities.get(mPid);
-          const pos = this.clients.get(mPid)?.spectating?.savedPos ?? e?.pos;
-          return meta && e && pos
-            ? {
-                pid: mPid,
-                name: meta.name,
-                cls: meta.cls,
-                level: e.level,
-                hp: e.hp,
-                mhp: e.maxHp,
-                res: Math.round(e.resource),
-                mres: e.maxResource,
-                rtype: e.resourceType,
-                x: round2(pos.x),
-                z: round2(pos.z),
-                dead: e.dead ? 1 : 0,
-                inCombat: e.inCombat ? 1 : 0,
-                group: party.raidGroups.get(mPid) ?? 1,
-                absorb: partyFrameAbsorb(e.auras),
-                role: partyFrameRole(meta.talentMods.role),
-                // Effective health Rewind could currently restore to this member
-                // (combat/rewind.ts); 0 for members with no recent recorded loss.
-                rewind: rewindHealAmount(damageTakenWithin(e, this.sim.tickCount), e.hp, e.maxHp),
-                connected:
-                  meta.isDevBot || (this.clients.has(mPid) && !this.clients.get(mPid)?.linkdead)
-                    ? 1
-                    : 0,
-                hasAggro: aggroTargets.has(mPid) ? 1 : 0,
-                incomingHeal: incomingHeals.get(mPid) ?? 0,
-                // Temporal Echo marks are filtered per-viewer to `pid`'s own, so
-                // other chronomancers' echoes (which still heal in the sim) never
-                // show in this player's group/raid strip.
-                auras: partyFrameAuras(e.auras.filter((a) => echoVisibleTo(a, pid))),
-              }
-            : null;
-        })
-        .filter(Boolean),
-    };
+    return this.partyFrameProjectionCache.forViewer(
+      {
+        id: party.id,
+        leader: party.leader,
+        raid: party.raid,
+        master: party.lootStrategies.master,
+        members: party.members,
+      },
+      pid,
+      (mPid) => {
+        const meta = this.sim.meta(mPid);
+        const e = this.sim.entities.get(mPid);
+        const pos = this.clients.get(mPid)?.spectating?.savedPos ?? e?.pos;
+        if (!meta || !e || !pos) return null;
+        return {
+          member: {
+            pid: mPid,
+            name: meta.name,
+            cls: meta.cls,
+            level: e.level,
+            hp: e.hp,
+            mhp: e.maxHp,
+            res: Math.round(e.resource),
+            mres: e.maxResource,
+            rtype: e.resourceType,
+            x: round2(pos.x),
+            z: round2(pos.z),
+            dead: e.dead ? 1 : 0,
+            inCombat: e.inCombat ? 1 : 0,
+            group: party.raidGroups.get(mPid) ?? 1,
+            absorb: partyFrameAbsorb(e.auras),
+            role: partyFrameRole(meta.talentMods.role),
+            // Effective health Rewind could currently restore to this member
+            // (combat/rewind.ts); 0 for members with no recent recorded loss.
+            rewind: rewindHealAmount(damageTakenWithin(e, this.sim.tickCount), e.hp, e.maxHp),
+            connected:
+              meta.isDevBot || (this.clients.has(mPid) && !this.clients.get(mPid)?.linkdead)
+                ? 1
+                : 0,
+            hasAggro: aggroTargets.has(mPid) ? 1 : 0,
+            incomingHeal: incomingHeals.get(mPid) ?? 0,
+          },
+          auras: e.auras,
+        };
+      },
+    );
   }
 
   // Raid markers the player's party can see, as { entityId: markerId }; null

--- a/server/party_frame_projection.ts
+++ b/server/party_frame_projection.ts
@@ -1,0 +1,89 @@
+import {
+  type PreparedPartyFrameAura,
+  partyFrameAurasForViewer,
+  preparePartyFrameAuras,
+} from '../src/sim/party_frame_info';
+import type { Aura } from '../src/sim/types';
+import type { PartyInfo, PartyMemberInfo } from '../src/world_api';
+
+export interface PartyFrameProjectionParty {
+  id: number;
+  leader: number;
+  raid: boolean;
+  master: PartyInfo['master'];
+  members: readonly number[];
+}
+
+export interface PartyFrameMemberProjection {
+  member: Omit<PartyMemberInfo, 'auras'>;
+  auras: readonly Aura[];
+}
+
+export type ProjectPartyFrameMember = (pid: number) => PartyFrameMemberProjection | null;
+
+interface CachedPartyFrameMember {
+  member: Omit<PartyMemberInfo, 'auras'>;
+  auras: PreparedPartyFrameAura[];
+}
+
+interface CachedPartyFrameProjection {
+  leader: number;
+  raid: boolean;
+  master: PartyInfo['master'];
+  members: CachedPartyFrameMember[];
+}
+
+/**
+ * Shares viewer-independent party member projection work across every recipient
+ * in one broadcast. Temporal Echo visibility remains viewer-specific.
+ */
+export class PartyFrameProjectionCache {
+  private readonly parties = new Map<number, CachedPartyFrameProjection>();
+
+  beginBroadcast(): void {
+    this.parties.clear();
+  }
+
+  forViewer(
+    party: PartyFrameProjectionParty,
+    viewerId: number,
+    projectMember: ProjectPartyFrameMember,
+  ): PartyInfo {
+    let projection = this.parties.get(party.id);
+    if (!projection) {
+      projection = this.projectParty(party, projectMember);
+      this.parties.set(party.id, projection);
+    }
+
+    return {
+      leader: projection.leader,
+      raid: projection.raid,
+      master: { ...projection.master },
+      members: projection.members.map(({ member, auras }) => ({
+        ...member,
+        auras: partyFrameAurasForViewer(auras, viewerId),
+      })),
+    };
+  }
+
+  private projectParty(
+    party: PartyFrameProjectionParty,
+    projectMember: ProjectPartyFrameMember,
+  ): CachedPartyFrameProjection {
+    const members: CachedPartyFrameMember[] = [];
+    for (const pid of party.members) {
+      const projection = projectMember(pid);
+      if (!projection) continue;
+      members.push({
+        member: projection.member,
+        auras: preparePartyFrameAuras(projection.auras),
+      });
+    }
+    return {
+      leader: party.leader,
+      raid: party.raid,
+      master: { ...party.master },
+      members,
+    };
+  }
+}

--- a/server/party_frame_projection.ts
+++ b/server/party_frame_projection.ts
@@ -61,6 +61,8 @@ export class PartyFrameProjectionCache {
       master: { ...projection.master },
       members: projection.members.map(({ member, auras }) => ({
         ...member,
+        // Prepared summaries are immutable for the lifetime of this broadcast.
+        // Only the per-viewer array is new; rows are safe to share through stringify.
         auras: partyFrameAurasForViewer(auras, viewerId),
       })),
     };

--- a/src/sim/party_frame_info.ts
+++ b/src/sim/party_frame_info.ts
@@ -1,5 +1,5 @@
 import { isPartyFrameRelevantAura } from './aura_classify';
-import { partyAuraPriority } from './combat/chronomancy';
+import { echoVisibleTo, partyAuraPriority } from './combat/chronomancy';
 import type { Role } from './content/talents';
 import type { AbilityEffect, Aura, Entity } from './types';
 import { PARTY_MEMBER_AURA_CAP } from './types';
@@ -13,6 +13,49 @@ export interface PartyFrameAuraSummary {
 
 export interface PartyFrameResolvedAbility {
   effects: readonly AbilityEffect[];
+}
+
+export interface PreparedPartyFrameAura {
+  summary: PartyFrameAuraSummary;
+  sourceId: number;
+}
+
+/** Perform the relevance, priority, and summary work once before applying a
+ * viewer-specific Temporal Echo visibility filter. */
+export function preparePartyFrameAuras(auras: readonly Aura[]): PreparedPartyFrameAura[] {
+  const relevant = auras.filter((aura) => isPartyFrameRelevantAura(aura));
+  relevant.sort((a, b) => partyAuraPriority(a) - partyAuraPriority(b));
+  return relevant.map((aura) => ({
+    sourceId: aura.sourceId,
+    summary: {
+      id: aura.id,
+      kind: aura.kind,
+      ...(aura.value < 0 ? { neg: 1 as const } : {}),
+      remaining: Math.max(0, Math.ceil(aura.remaining)),
+    },
+  }));
+}
+
+/** Apply only the cheap viewer-specific Echo filter and cap to prepared rows. */
+export function partyFrameAurasForViewer(
+  prepared: readonly PreparedPartyFrameAura[],
+  viewerId?: number,
+  cap = PARTY_MEMBER_AURA_CAP,
+): PartyFrameAuraSummary[] {
+  const normalizedCap = Number.isNaN(cap) ? 0 : Math.trunc(cap);
+  if (normalizedCap === 0) return [];
+  const visible: PartyFrameAuraSummary[] = [];
+  for (const aura of prepared) {
+    if (
+      viewerId !== undefined &&
+      !echoVisibleTo({ kind: aura.summary.kind, sourceId: aura.sourceId }, viewerId)
+    ) {
+      continue;
+    }
+    visible.push(aura.summary);
+    if (normalizedCap > 0 && visible.length === normalizedCap) break;
+  }
+  return normalizedCap < 0 ? visible.slice(0, normalizedCap) : visible;
 }
 
 /** Compact actionable auras for a party row. Filtering before the cap prevents

--- a/src/sim/party_frame_info.ts
+++ b/src/sim/party_frame_info.ts
@@ -67,6 +67,9 @@ export function partyFrameAuras(
   auras: readonly Aura[],
   cap = PARTY_MEMBER_AURA_CAP,
 ): PartyFrameAuraSummary[] {
+  // Keep the offline path single-pass. Routing it through the prepared server
+  // representation would allocate both an intermediate wrapper list and the
+  // final summaries for every offline tick.
   const relevant = auras.filter((aura) => isPartyFrameRelevantAura(aura));
   relevant.sort((a, b) => partyAuraPriority(a) - partyAuraPriority(b));
   return relevant.slice(0, cap).map((aura) => ({

--- a/tests/party_frame_info.test.ts
+++ b/tests/party_frame_info.test.ts
@@ -5,7 +5,11 @@
 // remaining). Both hosts (offline sim and server wire) consume this module.
 
 import { describe, expect, it } from 'vitest';
-import { partyFrameAuras } from '../src/sim/party_frame_info';
+import {
+  partyFrameAuras,
+  partyFrameAurasForViewer,
+  preparePartyFrameAuras,
+} from '../src/sim/party_frame_info';
 import type { Aura } from '../src/sim/types';
 import { PARTY_MEMBER_AURA_CAP } from '../src/sim/types';
 
@@ -72,6 +76,7 @@ describe('partyFrameAuras', () => {
   });
 
   it('returns no summaries when the caller sets a zero cap', () => {
-    expect(partyFrameAuras([aura({ id: 'renew', kind: 'hot', value: 20 })], 0)).toEqual([]);
+    const prepared = preparePartyFrameAuras([aura({ id: 'renew', kind: 'hot', value: 20 })]);
+    expect(partyFrameAurasForViewer(prepared, 1, 0)).toEqual([]);
   });
 });

--- a/tests/party_frame_info.test.ts
+++ b/tests/party_frame_info.test.ts
@@ -70,4 +70,8 @@ describe('partyFrameAuras', () => {
     partyFrameAuras(input);
     expect(input.map((a) => a.id)).toEqual(before);
   });
+
+  it('returns no summaries when the caller sets a zero cap', () => {
+    expect(partyFrameAuras([aura({ id: 'renew', kind: 'hot', value: 20 })], 0)).toEqual([]);
+  });
 });

--- a/tests/party_frame_projection.test.ts
+++ b/tests/party_frame_projection.test.ts
@@ -26,9 +26,10 @@ const party: PartyFrameProjectionParty = {
 };
 
 describe('PartyFrameProjectionCache', () => {
-  it('projects each member once per tick while preserving viewer-owned Echo auras', () => {
+  it('projects each member once per broadcast while preserving viewer-owned Echo auras', () => {
     const cache = new PartyFrameProjectionCache();
     let memberProjections = 0;
+    let hp = 900;
     const projectMember = (pid: number) => {
       memberProjections++;
       return {
@@ -37,7 +38,7 @@ describe('PartyFrameProjectionCache', () => {
           name: `Player ${pid}`,
           cls: 'mage' as const,
           level: 60,
-          hp: 900,
+          hp,
           mhp: 1_000,
           res: 80,
           mres: 100,
@@ -71,13 +72,17 @@ describe('PartyFrameProjectionCache', () => {
             remaining: 22.1,
           }),
           aura({ id: 'renew', kind: 'hot', value: 20, sourceId: 33 }),
+          ...Array.from({ length: 7 }, (_, index) =>
+            aura({ id: `hot_${index}`, kind: 'hot', value: 20, sourceId: 33 }),
+          ),
         ],
       };
     };
 
-    const forEleven = cache.forViewer(100, party, 11, projectMember);
-    const forTwentyTwo = cache.forViewer(100, party, 22, projectMember);
-    const forThirtyThree = cache.forViewer(100, party, 33, projectMember);
+    cache.beginBroadcast();
+    const forEleven = cache.forViewer(party, 11, projectMember);
+    const forTwentyTwo = cache.forViewer(party, 22, projectMember);
+    const forThirtyThree = cache.forViewer(party, 33, projectMember);
 
     // Three viewers of a three-person party must perform three common member
     // projections, not the previous 3 x 3 history/aura projection work.
@@ -86,18 +91,39 @@ describe('PartyFrameProjectionCache', () => {
       { id: 'rend', kind: 'dot', remaining: 10 },
       { id: 'temporal_echo', kind: 'temporal_echo', remaining: 12 },
       { id: 'renew', kind: 'hot', remaining: 10 },
+      { id: 'hot_0', kind: 'hot', remaining: 10 },
+      { id: 'hot_1', kind: 'hot', remaining: 10 },
+      { id: 'hot_2', kind: 'hot', remaining: 10 },
+      { id: 'hot_3', kind: 'hot', remaining: 10 },
+      { id: 'hot_4', kind: 'hot', remaining: 10 },
     ]);
     expect(forTwentyTwo.members[0].auras).toEqual([
       { id: 'rend', kind: 'dot', remaining: 10 },
       { id: 'temporal_echo', kind: 'temporal_echo', remaining: 23 },
       { id: 'renew', kind: 'hot', remaining: 10 },
+      { id: 'hot_0', kind: 'hot', remaining: 10 },
+      { id: 'hot_1', kind: 'hot', remaining: 10 },
+      { id: 'hot_2', kind: 'hot', remaining: 10 },
+      { id: 'hot_3', kind: 'hot', remaining: 10 },
+      { id: 'hot_4', kind: 'hot', remaining: 10 },
     ]);
     expect(forThirtyThree.members[0].auras).toEqual([
       { id: 'rend', kind: 'dot', remaining: 10 },
       { id: 'renew', kind: 'hot', remaining: 10 },
+      { id: 'hot_0', kind: 'hot', remaining: 10 },
+      { id: 'hot_1', kind: 'hot', remaining: 10 },
+      { id: 'hot_2', kind: 'hot', remaining: 10 },
+      { id: 'hot_3', kind: 'hot', remaining: 10 },
+      { id: 'hot_4', kind: 'hot', remaining: 10 },
+      { id: 'hot_5', kind: 'hot', remaining: 10 },
     ]);
 
-    cache.forViewer(101, party, 11, projectMember);
+    // A second broadcast can happen without a sim tick. It must rebuild from
+    // live state rather than reuse the previous broadcast's projection.
+    hp = 700;
+    cache.beginBroadcast();
+    const nextBroadcast = cache.forViewer(party, 11, projectMember);
     expect(memberProjections).toBe(party.members.length * 2);
+    expect(nextBroadcast.members[0].hp).toBe(700);
   });
 });

--- a/tests/party_frame_projection.test.ts
+++ b/tests/party_frame_projection.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PartyFrameProjectionCache,
+  type PartyFrameProjectionParty,
+} from '../server/party_frame_projection';
+import type { Aura } from '../src/sim/types';
+
+function aura(partial: Partial<Aura> & Pick<Aura, 'id' | 'kind'>): Aura {
+  return {
+    name: partial.id,
+    remaining: 10,
+    duration: 10,
+    value: 1,
+    sourceId: 1,
+    school: 'holy',
+    ...partial,
+  } as Aura;
+}
+
+const party: PartyFrameProjectionParty = {
+  id: 7,
+  leader: 11,
+  raid: true,
+  master: { enabled: true, looter: 11, threshold: 'rare' },
+  members: [11, 22, 33],
+};
+
+describe('PartyFrameProjectionCache', () => {
+  it('projects each member once per tick while preserving viewer-owned Echo auras', () => {
+    const cache = new PartyFrameProjectionCache();
+    let memberProjections = 0;
+    const projectMember = (pid: number) => {
+      memberProjections++;
+      return {
+        member: {
+          pid,
+          name: `Player ${pid}`,
+          cls: 'mage' as const,
+          level: 60,
+          hp: 900,
+          mhp: 1_000,
+          res: 80,
+          mres: 100,
+          rtype: 'mana' as const,
+          x: pid,
+          z: -pid,
+          dead: 0,
+          inCombat: 1,
+          group: 1 as const,
+          absorb: 25,
+          role: 'healer' as const,
+          rewind: 100,
+          connected: 1,
+          hasAggro: 0,
+          incomingHeal: 200,
+        },
+        auras: [
+          aura({ id: 'rend', kind: 'dot', value: 5, sourceId: 99 }),
+          aura({
+            id: 'temporal_echo',
+            kind: 'temporal_echo',
+            value: 0,
+            sourceId: 11,
+            remaining: 11.1,
+          }),
+          aura({
+            id: 'temporal_echo',
+            kind: 'temporal_echo',
+            value: 0,
+            sourceId: 22,
+            remaining: 22.1,
+          }),
+          aura({ id: 'renew', kind: 'hot', value: 20, sourceId: 33 }),
+        ],
+      };
+    };
+
+    const forEleven = cache.forViewer(100, party, 11, projectMember);
+    const forTwentyTwo = cache.forViewer(100, party, 22, projectMember);
+    const forThirtyThree = cache.forViewer(100, party, 33, projectMember);
+
+    // Three viewers of a three-person party must perform three common member
+    // projections, not the previous 3 x 3 history/aura projection work.
+    expect(memberProjections).toBe(party.members.length);
+    expect(forEleven.members[0].auras).toEqual([
+      { id: 'rend', kind: 'dot', remaining: 10 },
+      { id: 'temporal_echo', kind: 'temporal_echo', remaining: 12 },
+      { id: 'renew', kind: 'hot', remaining: 10 },
+    ]);
+    expect(forTwentyTwo.members[0].auras).toEqual([
+      { id: 'rend', kind: 'dot', remaining: 10 },
+      { id: 'temporal_echo', kind: 'temporal_echo', remaining: 23 },
+      { id: 'renew', kind: 'hot', remaining: 10 },
+    ]);
+    expect(forThirtyThree.members[0].auras).toEqual([
+      { id: 'rend', kind: 'dot', remaining: 10 },
+      { id: 'renew', kind: 'hot', remaining: 10 },
+    ]);
+
+    cache.forViewer(101, party, 11, projectMember);
+    expect(memberProjections).toBe(party.members.length * 2);
+  });
+});

--- a/tests/party_frame_projection.test.ts
+++ b/tests/party_frame_projection.test.ts
@@ -56,6 +56,10 @@ describe('PartyFrameProjectionCache', () => {
           incomingHeal: 200,
         },
         auras: [
+          // The server cache must discard maintenance buffs and priority-sort
+          // actionable rows rather than trusting the entity's aura order.
+          aura({ id: 'maintenance', kind: 'buff_ap', value: 2, sourceId: 33 }),
+          aura({ id: 'renew', kind: 'hot', value: 20, sourceId: 33 }),
           aura({ id: 'rend', kind: 'dot', value: 5, sourceId: 99 }),
           aura({
             id: 'temporal_echo',
@@ -71,7 +75,6 @@ describe('PartyFrameProjectionCache', () => {
             sourceId: 22,
             remaining: 22.1,
           }),
-          aura({ id: 'renew', kind: 'hot', value: 20, sourceId: 33 }),
           ...Array.from({ length: 7 }, (_, index) =>
             aura({ id: `hot_${index}`, kind: 'hot', value: 20, sourceId: 33 }),
           ),
@@ -125,5 +128,51 @@ describe('PartyFrameProjectionCache', () => {
     const nextBroadcast = cache.forViewer(party, 11, projectMember);
     expect(memberProjections).toBe(party.members.length * 2);
     expect(nextBroadcast.members[0].hp).toBe(700);
+  });
+
+  it('isolates party cache keys and skips members that disappeared during projection', () => {
+    const cache = new PartyFrameProjectionCache();
+    const firstParty = { ...party, id: 8, members: [11, 22] };
+    const secondParty = { ...party, id: 9, leader: 44, members: [44] };
+    const projected: number[] = [];
+    const projectMember = (pid: number) => {
+      projected.push(pid);
+      if (pid === 22) return null;
+      return {
+        member: {
+          pid,
+          name: `Player ${pid}`,
+          cls: 'warrior' as const,
+          level: 60,
+          hp: 1_000,
+          mhp: 1_000,
+          res: 0,
+          mres: 100,
+          rtype: 'rage' as const,
+          x: 0,
+          z: 0,
+          dead: 0,
+          inCombat: 0,
+          group: 1 as const,
+          absorb: 0,
+          role: 'dps' as const,
+          rewind: 0,
+          connected: 1,
+          hasAggro: 0,
+          incomingHeal: 0,
+        },
+        auras: [],
+      };
+    };
+
+    cache.beginBroadcast();
+    const first = cache.forViewer(firstParty, 11, projectMember);
+    const second = cache.forViewer(secondParty, 44, projectMember);
+    const firstAgain = cache.forViewer(firstParty, 11, projectMember);
+
+    expect(first.members.map((member) => member.pid)).toEqual([11]);
+    expect(second.members.map((member) => member.pid)).toEqual([44]);
+    expect(firstAgain.members.map((member) => member.pid)).toEqual([11]);
+    expect(projected).toEqual([11, 22, 44]);
   });
 });

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -1179,6 +1179,95 @@ describe('raid party wire', () => {
       connected: 0,
     });
   });
+
+  it('projects common party member history once per broadcast and refreshes same-tick broadcasts', () => {
+    const server = new GameServer();
+    const leaderClient = fakeWs();
+    const leader = joinServer(server, leaderClient, 11, 'Leader');
+    const memberClient = fakeWs();
+    const member = joinServer(server, memberClient, 22, 'Member');
+    const thirdClient = fakeWs();
+    const third = joinServer(server, thirdClient, 33, 'Third');
+    server.sim.partyInvite(member.pid, leader.pid);
+    server.sim.partyAccept(member.pid);
+    server.sim.partyInvite(third.pid, leader.pid);
+    server.sim.partyAccept(third.pid);
+
+    let historyReads = 0;
+    for (const pid of [leader.pid, member.pid, third.pid]) {
+      const entity = server.sim.entities.get(pid)!;
+      let history = [{ tick: server.sim.tickCount, amount: 10 }];
+      Object.defineProperty(entity, 'damageHistory', {
+        configurable: true,
+        get: () => {
+          historyReads++;
+          return history;
+        },
+        set: (next) => {
+          history = next ?? [];
+        },
+      });
+    }
+
+    broadcast(server);
+    expect(historyReads).toBe(3);
+
+    const memberEntity = server.sim.entities.get(member.pid)!;
+    memberEntity.hp = 777;
+    broadcast(server);
+    expect(historyReads).toBe(6);
+    const memberRow = lastSnap(leaderClient.sent).self.party.members.find(
+      (row: any) => row.pid === member.pid,
+    );
+    expect(memberRow.hp).toBe(777);
+  });
+
+  it('uses the observed player as the Echo viewer for a spectator party snapshot', () => {
+    const moderatorClient = fakeWs();
+    const moderator = joinServer(server, moderatorClient, 3, 'Modera');
+    const target = server.sim.entities.get(member.pid)!;
+    target.auras.push(
+      {
+        id: 'temporal_echo',
+        name: 'Temporal Echo',
+        kind: 'temporal_echo',
+        remaining: 11.1,
+        duration: 15,
+        value: 0,
+        sourceId: leader.pid,
+        school: 'arcane',
+      },
+      {
+        id: 'temporal_echo',
+        name: 'Temporal Echo',
+        kind: 'temporal_echo',
+        remaining: 22.1,
+        duration: 15,
+        value: 0,
+        sourceId: member.pid,
+        school: 'arcane',
+      },
+    );
+    (server as any).enterSpectate(moderator, leader);
+
+    broadcast(server);
+
+    const echoAurasFor = (client: FakeClient) => {
+      const memberRow = lastSnap(client.sent).self.party.members.find(
+        (row: any) => row.pid === member.pid,
+      );
+      return memberRow.auras.filter((row: any) => row.kind === 'temporal_echo');
+    };
+    expect(echoAurasFor(fcLeader)).toEqual([
+      { id: 'temporal_echo', kind: 'temporal_echo', remaining: 12 },
+    ]);
+    expect(echoAurasFor(fcMember)).toEqual([
+      { id: 'temporal_echo', kind: 'temporal_echo', remaining: 23 },
+    ]);
+    expect(echoAurasFor(moderatorClient)).toEqual([
+      { id: 'temporal_echo', kind: 'temporal_echo', remaining: 12 },
+    ]);
+  });
 });
 
 describe('dungeon difficulty wire', () => {


### PR DESCRIPTION
## Summary

- Cache common party-frame member projection once per member per broadcast.
- Keep Temporal Echo visibility viewer-specific, including spectator views anchored to the observed player.
- Reset projection and aggregate caches on every broadcast, including repeated broadcasts at the same sim tick.
- Preserve the existing offline projection path and party aura ordering/cap behavior.

The decisive integration test reduces expensive projection reads from 9 to 3 for a three-member party with three viewers. At raid size 10, this component falls from 100 to 10 projections per broadcast. Viewer-specific object creation and JSON serialization remain outside this PR, so this does not claim the same reduction for total broadcast time.

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/party_frame_info.test.ts tests/party_frame_projection.test.ts tests/snapshots.test.ts tests/architecture.test.ts`
  - `npm run build:server`
  - `npm run ci:changed`
  - `npm run gate`
- Results:
  - 161 focused and architecture tests passed.
  - Server build, TypeScript, changed-file checks, and independent review passed.
  - The full gate passed 16,118 tests and failed 2 existing `deploy_watchdog` timeout assertions. Both failures reproduce when that unchanged test file runs alone on macOS.
- Manual steps: N/A. This is a server hot-path change with deterministic integration coverage.

---

## Checklist

### Quality

- [ ] **The full gate passes.** The two unchanged deploy-watchdog timeout assertions described above remain red locally; all changed-path checks are green.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I did not hand-edit generated files.