### PR TITLE
fix(professions): Phase 4 QA, signed-harvest overflow fix plus cue and color pins

### DIFF
--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -14,7 +14,7 @@ Update this file at the end of every implementation and QA session. Statuses:
 | 3 | Host-parity bug fixes | complete | 2026-07-17 | 2026-07-17 |
 | 3 QA | Verify host-parity bug fixes | complete | 2026-07-17 | 2026-07-17 |
 | 4 | Node materials and pristine veins | complete | 2026-07-18 | 2026-07-18 |
-| 4 QA | Verify node materials and pristine veins | not started | | |
+| 4 QA | Verify node materials and pristine veins | complete | 2026-07-18 | 2026-07-18 |
 | 5 | The professions wheel window | not started | | |
 | 5 QA | Verify the professions wheel window | not started | | |
 | 6 | Crafting window upgrades and celebrations | not started | | |
@@ -195,6 +195,42 @@ manifest-gated). Deferred: node tier gating (Phase 12), recipe
 consumption of the new materials (Phase 10), rare-event deed authoring
 (Phase 15), a live-server instance-exclusion broadcast arm (unit-level
 covered).
+
+Phase 4 QA (2026-07-18): PASS with fixes. Three packet audits plus the
+four matched dispatch-matrix rows (architecture, cross-platform sync,
+frontend seam, qa-checklist; privacy/security, migration safety, and
+database performance were NO-MATCH), all seven reports complete first
+try with the hard tool-call budgets baked in. REAL FIND, fixed
+test-first: the signed harvest grant could overflow bag capacity by one
+slot per rare-or-better roll (the fungible canAddItem pre-gate passes
+on stack top-up room while a signed instance needs a fresh slot;
+runtime-confirmed via the crossing case of a slot-full bag holding a
+partial stack of the zone material). Every signed unit now requires a
+genuinely free slot, with an unsigned stack top-up fallback when none
+exists, so the truncation contract wins over signing in that edge; the
+draw order and the professions_gather golden are byte-identical. The
+corpse focus-harvest path carries the same pre-existing hole (it was
+the cited precedent) and is filed as #2139, deliberately not fixed
+here because it sits outside the phase diff. QA also landed: the
+crossing-case pin, the finder-only achievement-cue pin plus
+quality-color source pins (the unpinned halves of the D1 contract and
+acceptance criterion 5), and comment corrections (the gatherLine
+catalog comment described the exact loot-family wording the divergence
+pin forbids; the gathering.ts header still claimed no world nodes
+exist; gatherRareEvent's spare fields named as Phase 15 forward
+payload; corpseLootAvailability's harvestStateReliable documented as a
+deliberately retained seam whose false arm stays pinned POSITIONALLY
+in tests/corpse_loot_availability.test.ts and tests/interactions.test.ts,
+which a name-only grep misses, an audit claim that dissolved exactly
+there). Verified dismissals: finderName cannot smuggle the [[i:
+item-link token (validCharNameShape forbids brackets), and all four
+phase-emphasis probes bind. Deferred with reasons: the rare-event
+windfall's per-instance loot-line/cue burst (consistent with the D1
+cue-ownership decision, Phase 15 polish candidate), the zone-1 signed
+starter instances design confirm (maintainer, see state.md), the
+gatherEvent.* top-level catalog namespace (functional, moving it now
+is overlay churn without user value), and the pre-existing unused
+instanceOrigin import in tests/parity/scenarios.ts.
 
 ### Phase 5: The professions wheel window
 - [ ] New window at deeds quality per DESIGN.md: view core (UI_PURE_CORES), painter, styles, i18n

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -465,6 +465,39 @@ tables, i18n key namespaces, files created)
   sites trust the hcb mirror (open gate stays at the pre-existing
   INTERACT_RANGE + 1 boundary, so grace-frozen boundary corpses stay
   unreachable; tests/gather_open_gate.test.ts).
+  - Phase 4 QA: PASS with fixes 2026-07-18. Found and fixed test-first:
+    the signed harvest grant could overflow bag capacity (the fungible
+    canAddItem pre-gate counts stack top-up room; a signed instance
+    needs a fresh slot). Landed policy: every signed unit requires a
+    genuinely free slot, and with none the yield falls back to an
+    UNSIGNED stack top-up of what fits, so the truncation contract wins
+    over signing in that self-inflicted edge (crossing-case pin in
+    tests/gather_rare_events.test.ts; draw order and the
+    professions_gather golden untouched). The corpse focus-harvest path
+    keeps the same pre-existing hole (fitsAll fungible simulation vs
+    rare+ signed instance grants) and is filed as #2139 with the
+    gathering fix as the reference policy.
+  - Phase 4 QA drift notes (2026-07-18): a signed rare-event windfall
+    emits one grant-hub loot line + cue PER INSTANCE (up to five) on
+    top of the single "You gather: x5" line and the broadcast line;
+    consistent with the D1 cue-ownership decision but reads as spam,
+    Phase 15 polish candidate (batch or debounce). Zone-1 signed
+    starter instances are a design-confirm item for the maintainer:
+    signing tracks rarity/rare events, never zone tier, so
+    high-proficiency zone-1 farming mints signed sellValue-4 starters
+    (self-limiting: signed units never merge, so they consume slots
+    fast, and the stockpiling mitigation caps the item TIER as locked).
+    corpseLootAvailability's harvestStateReliable parameter is a
+    deliberately retained seam: production always uses the default
+    (true) since the open-gate flip, and its false arm stays pinned
+    POSITIONALLY (no named reference) in
+    tests/corpse_loot_availability.test.ts and tests/interactions.test.ts,
+    so name-greps miss it; documented at the helper. gatherEvent.* as a
+    top-level catalog namespace (not hudChrome.gathering) is accepted
+    as landed: the skinEvent idiom, overlays filled, moving it is
+    churn without user value. finderName cannot smuggle the [[i:
+    item-link token into the chat parser: validCharNameShape forbids
+    brackets server-side.
 - Phase 5: (planned) professions window (.window id professions-window) +
   view core + painter + hudChrome.professions.* keys.
 - Phase 7: (planned) trend detection module; Guild letter content; S3 scan

--- a/src/game/corpse_loot_availability.ts
+++ b/src/game/corpse_loot_availability.ts
@@ -1,7 +1,14 @@
 import { MOBS } from '../sim/data';
 import type { Entity } from '../sim/types';
 
-/** Resolve the exact corpse content the local player can open in the loot popup. */
+/** Resolve the exact corpse content the local player can open in the loot popup.
+ *  `harvestStateReliable` is true on every production path since the Phase 4
+ *  open-gate flip (no caller passes it: offline is sim-local truth, online
+ *  mirrors harvestClaimedBy via the hcb wire key). The parameter is a
+ *  deliberately retained seam for a transport that cannot mirror harvest
+ *  claims; its false arm stays pinned in tests/corpse_loot_availability.test.ts
+ *  and tests/interactions.test.ts (positional third argument), so do not
+ *  remove it as dead plumbing without sweeping those pins. */
 export function corpseLootAvailability(mob: Entity, playerId: number, harvestStateReliable = true) {
   const componentTags = MOBS[mob.templateId]?.componentTags;
   const harvestable =

--- a/src/sim/professions/gathering.ts
+++ b/src/sim/professions/gathering.ts
@@ -2,12 +2,12 @@
 // SimContext seam. The backing counters live on PlayerMeta (sim.ts); this
 // module holds the pure functions. Each gathering profession is an
 // independent, additive counter: granting one never touches another (no
-// shared/conserved pool). No world nodes exist yet (see issue #1119), so the
-// only producer today is the ALLOW_DEV_COMMANDS `/dev gather` chat cheat
-// (src/sim/social/chat.ts), which QUEUES a grant here; the queue is drained
-// once per player during the normal 20 Hz tick loop (sim.ts `tick()`, next to
-// `updateRested`), so a grant only ever takes effect on the deterministic tick
-// path, never out of band.
+// shared/conserved pool). Proficiency producers: world-node harvests
+// (resolveHarvest below, via the harvestNode command) and the
+// ALLOW_DEV_COMMANDS `/dev gather` chat cheat (src/sim/social/chat.ts). Both
+// QUEUE a grant here; the queue is drained once per player during the normal
+// 20 Hz tick loop (sim.ts `tick()`, next to `updateRested`), so a grant only
+// ever takes effect on the deterministic tick path, never out of band.
 
 import { bagCapacity } from '../bags';
 import { GATHER_NODES } from '../content/gather_nodes';
@@ -304,25 +304,32 @@ export function harvestNode(ctx: SimContext, nodeId: string, pid?: number): bool
   // the truncation. Both rng draws already happened in resolveHarvest, so
   // truncation never shifts the draw order.
   let grantedQty = 0;
-  if (signed) {
-    // Signed instances never merge into stacks (bags.ts addStacked, #1165):
-    // each unit is its own slot. The first unit lands unconditionally on the
-    // strength of the fungible pre-gate above (the corpse-harvest precedent,
-    // interaction.ts); every further unit needs a genuinely free slot, so an
-    // oversized rare-event windfall truncates instead of overflowing the bag.
-    const capacity = bagCapacity(meta.bags);
-    for (let i = 0; i < qty; i++) {
-      if (i > 0 && meta.inventory.length >= capacity) break;
-      ctx.addItemInstance(itemId, { signer: meta.name }, meta.entityId);
-      grantedQty++;
-    }
-  } else {
-    // Fungible grant: find the largest count that still fits (stack top-up
-    // plus free slots, ctx.canAddItem). The pre-gate guarantees at least 1.
+  // Fungible grant: find the largest count that still fits (stack top-up
+  // plus free slots, ctx.canAddItem). The pre-gate guarantees at least 1.
+  const grantFungibleFit = (): number => {
     let fit = qty;
     while (fit > 1 && !ctx.canAddItem(itemId, fit, meta.entityId)) fit--;
     ctx.addItem(itemId, fit, meta.entityId);
-    grantedQty = fit;
+    return fit;
+  };
+  if (signed) {
+    // Signed instances never merge into stacks (bags.ts addStacked, #1165):
+    // each unit is its own slot, so EVERY unit (the first included) needs a
+    // genuinely free slot and an oversized rare-event windfall truncates
+    // instead of overflowing the bag. The fungible pre-gate above can pass on
+    // stack top-up room alone, so when no free slot exists the yield falls
+    // back to an unsigned top-up grant (the truncation contract wins over
+    // signing in that self-inflicted edge; the crossing-case pin lives in
+    // tests/gather_rare_events.test.ts).
+    const capacity = bagCapacity(meta.bags);
+    for (let i = 0; i < qty; i++) {
+      if (meta.inventory.length >= capacity) break;
+      ctx.addItemInstance(itemId, { signer: meta.name }, meta.entityId);
+      grantedQty++;
+    }
+    if (grantedQty === 0) grantedQty = grantFungibleFit();
+  } else {
+    grantedQty = grantFungibleFit();
   }
   ctx.onNodeGatheredForQuests(node, itemId, meta);
   // Zone gather mark: one entry per zone and node type ever harvested.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -3516,7 +3516,10 @@ export type SimEvent = { pid?: number } & (
   // emitted per player currently in the node's zone, `pid` being the RECIPIENT
   // (the chat fanout idiom); finderPid/finderName identify the harvester. Ids
   // plus values only, text-free on purpose: the client renders its own
-  // localized line off `flavor` (the gatherEvent.* keys).
+  // localized line off `flavor` (the gatherEvent.* keys). The HUD reads only
+  // flavor/finderName/finderPid today; zoneId/nodeType/itemId are forward
+  // payload for the Phase 15 per-family deeds/tuning consumers (asserted by
+  // the Phase 4 tests so the shape is already load-bearing on the wire).
   | {
       type: 'gatherRareEvent';
       pid: number;

--- a/src/ui/i18n.catalog/hud_chrome.ts
+++ b/src/ui/i18n.catalog/hud_chrome.ts
@@ -2178,8 +2178,11 @@ export const hudChromeStrings = {
     // #1866: click/tap/interact-key error when a targeted node's per-viewer
     // respawn timer has not elapsed yet (IWorldProfessions#nodeHarvestableByMe).
     notReady: 'This resource node has not respawned for you yet.',
-    // Harvest loot line (Professions 2.0 Phase 4), rendered from the id-based
-    // gatherResult SimEvent in the "You receive:" loot-family wording.
+    // Harvest feedback line (Professions 2.0 Phase 4), rendered from the
+    // id-based gatherResult SimEvent. Deliberately worded APART from the
+    // loot family: the grant hub's own 'loot' event already prints
+    // "You receive:" for the same harvest, so this line must never regress
+    // into that wording (divergence pin: tests/gather_event_i18n.test.ts).
     gatherLine: 'You gather: {name}.',
     gatherLineQty: 'You gather: {name} x{qty}.',
   },

--- a/tests/gather_event_i18n.test.ts
+++ b/tests/gather_event_i18n.test.ts
@@ -101,4 +101,35 @@ describe('hud event switch stays wired to the ids', () => {
     const block = source.slice(caseStart, source.indexOf('break;', caseStart));
     expect(block.includes('audio.lootItem')).toBe(false);
   });
+
+  it('the achievement cue on gatherRareEvent is finder-only (the other D1 half)', () => {
+    // The zone fanout delivers one copy per in-zone recipient; only the
+    // finder may hear the celebratory cue. A regression that cues every
+    // recipient (or drops the cue) would pass the wording pins above, so
+    // bind the cue call to the finder guard: the conditional must appear in
+    // the case block BEFORE the cue call (same index-order technique as the
+    // flavor-to-key pin).
+    const source = readFileSync(path.resolve(process.cwd(), 'src/ui/hud.ts'), 'utf8');
+    const caseStart = source.indexOf("case 'gatherRareEvent'");
+    expect(caseStart).toBeGreaterThan(-1);
+    const block = source.slice(caseStart, source.indexOf('break;', caseStart));
+    const guard = block.indexOf('ev.finderPid === sim.playerId');
+    const cue = block.indexOf('audio.achievement()');
+    expect(guard).toBeGreaterThan(-1);
+    expect(cue).toBeGreaterThan(guard);
+  });
+
+  it('both lines color through the existing quality token family only', () => {
+    // Acceptance criterion 5: the gather line is rarity-colored and the
+    // broadcast line rides the epic token; a regression to a fixed default
+    // color (or an ad-hoc hex) keeps every wording pin green, so pin the
+    // color arguments at the source level.
+    const source = readFileSync(path.resolve(process.cwd(), 'src/ui/hud.ts'), 'utf8');
+    const gatherStart = source.indexOf("case 'gatherResult'");
+    const gatherBlock = source.slice(gatherStart, source.indexOf('break;', gatherStart));
+    expect(gatherBlock.includes('QUALITY_COLOR[ev.rarity]')).toBe(true);
+    const rareStart = source.indexOf("case 'gatherRareEvent'");
+    const rareBlock = source.slice(rareStart, source.indexOf('break;', rareStart));
+    expect(rareBlock.includes('QUALITY_COLOR.epic')).toBe(true);
+  });
 });

--- a/tests/gather_rare_events.test.ts
+++ b/tests/gather_rare_events.test.ts
@@ -438,6 +438,42 @@ describe('grant truncation at the command boundary (full bags)', () => {
     throw new Error('no rare event within 2000 harvests');
   });
 
+  it('a signed roll with zero free slots grants unsigned into the stack, never past capacity', () => {
+    const { sim, pid, nodeId, meta } = simAtOreNode();
+    const capacity = bagCapacity(meta.bags);
+    // Max proficiency so signed (rare-or-better) rolls appear quickly.
+    meta.gatheringProficiency.mining = 100;
+    for (let i = 0; i < 3000; i++) {
+      // The crossing case: the bag is slot-full and the ONLY room is fungible
+      // top-up on a partial copper stack. That room passes the capacity
+      // pre-gate (ctx.canAddItem counts stack top-up), but a signed instance
+      // needs a genuinely free slot (instances never merge), so a signed roll
+      // here must fall back to an unsigned top-up grant, never overflow.
+      meta.inventory.length = 0;
+      for (let f = 0; f < capacity - 1; f++)
+        meta.inventory.push({ itemId: 'bone_fragments', count: 1 });
+      meta.inventory.push({ itemId: 'copper_ore', count: 15 });
+      delete meta.nodeHarvestReadyAt[nodeId];
+      if (!sim.harvestNode(nodeId, pid)) continue;
+      const events = sim.drainEvents();
+      const gather = events.find((e) => e.type === 'gatherResult');
+      if (gather?.type !== 'gatherResult') throw new Error('expected gatherResult');
+      // Truncation, not overflow, on EVERY iteration (fungible rolls included).
+      expect(meta.inventory.length).toBeLessThanOrEqual(capacity);
+      const wouldSign = gather.rareEvent !== null || isSignableMaterialRarity(gather.rarity);
+      if (!wouldSign) continue;
+      // The signed-roll arm: no instance landed, the stack absorbed the
+      // granted count, and gatherResult.qty reports that granted count.
+      expect(meta.inventory.length).toBe(capacity);
+      expect(meta.inventory.filter((s) => s.itemId === 'copper_ore' && s.instance)).toHaveLength(0);
+      const stack = meta.inventory.find((s) => s.itemId === 'copper_ore' && !s.instance);
+      expect(gather.qty).toBeGreaterThanOrEqual(1);
+      expect(stack?.count).toBe(15 + gather.qty);
+      return;
+    }
+    throw new Error('no signed roll within 3000 attempts');
+  });
+
   it('a fungible yield larger than the remaining stack room truncates to what fits', () => {
     const { sim, pid, nodeId, meta } = simAtOreNode();
     const capacity = bagCapacity(meta.bags);


### PR DESCRIPTION
## Summary

Phase 4 QA of the Professions 2.0 program (docs/professions-2/phase-04-qa.md): an independent audit of the PR #2123 diff (node materials, rare gather events, the open-gate flip), then fixes for what the audit found. Seven-agent fan-out (three packet audits plus the matched dispatch-matrix reviewers: architecture, cross-platform-sync, frontend-seam, qa-checklist), all findings independently verified before acting.

The one real defect, fixed test-first: **a signed harvest grant could overflow bag capacity by one slot per rare-or-better roll.** The capacity pre-gate (`ctx.canAddItem(itemId, 1)`) counts fungible stack top-up room, but a signed instance always takes a fresh slot, so a slot-full bag holding a partial stack of the zone material passed the gate and then overflowed, repeatably, contradicting the code's own "truncates instead of overflowing" contract (the shipped truncation pin only covered the free-slot arm). Every signed unit now requires a genuinely free slot; when none exists the yield falls back to an unsigned stack top-up of what fits, so the truncation contract wins over signing in that self-inflicted edge and the player always receives at least one unit. Both rng draws still happen before any bag-dependent branch: the draw order and the `professions_gather` parity golden are byte-identical.

The corpse focus-harvest path (the cited precedent for the old code) carries the same pre-existing hole; it sits outside the phase diff, so it is filed as #2139 with this fix as the reference policy rather than fixed here.

Also landed:

- The crossing-case pin (zero free slots plus a partial stack plus a hunted signed roll) that reproduced the overflow.
- The finder-only achievement-cue pin and quality-color source pins in `tests/gather_event_i18n.test.ts` (the unpinned halves of the D1 cue-ownership contract and acceptance criterion 5).
- Comment corrections: the `hudChrome.gathering.gatherLine` catalog comment described the exact loot-family wording its own divergence pin forbids; the `gathering.ts` module header still claimed no world nodes exist; `gatherRareEvent`'s spare fields are named as Phase 15 forward payload; `corpseLootAvailability` documents `harvestStateReliable` as a deliberately retained seam whose false arm is pinned positionally in tests (a name-only grep misses it).
- progress.md Phase 4 QA row plus notes, and state.md drift notes (windfall loot-line/cue burst deferred to Phase 15, zone-1 signed starter instances flagged for a maintainer design confirm, `gatherEvent.*` top-level namespace accepted as landed).

Audit verdict recorded in progress.md: PASS with fixes, zero remaining blocking findings. Verified dismissals: `finderName` cannot smuggle the `[[i:` item-link token (server name shape forbids brackets); the four phase-emphasis probes (draw-order stability, junk defs intact, zone-1 tier cap, feedback fairness) all bind.

## Related issues

Part of #1866. Files #2139 (corpse-side sibling of the overflow fix).

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation

## How was this tested?

- Commands:
  - `npm run gate` under Node 24: green through i18n gen + freshness, malware scan, changed-files biome, SFX conformance, and the full vitest suite (16191 passed, 27 skipped); the known environmental armory-browser pixel red on this machine aborts the gate there (reproduces on the untouched release tip; PR CI is the arbiter), so the remaining contract ran manually: `npm run check:types && npm run build:env && npm run build:server && npm run build`, all green.
  - Phase validation matrix: `npx tsc --noEmit` plus `npx vitest run` over gather_node_harvest, professions_rarity_roll, gathering, localization_fixes, architecture, node_material_table, gather_rare_events, gather_rare_event_online, gather_event_i18n, gather_open_gate, corpse_loot_availability, interactions, client_shell, and tests/parity: all green, no golden changed.
  - The new crossing-case test was written first and reproduced the overflow (expected 17 to be at most 16) before the fix turned it green.
- Manual steps: none beyond the audits; the fix is fully covered by the pinned suites.

## Screenshots / recordings

N/A: no visual change (the Phase 4 screenshots in docs/screenshots are unchanged; this QA pass alters grant capacity logic, test pins, comments, and packet docs only).

---

## Checklist

### Quality

- [x] **The full gate passes.** Green locally through the full vitest suite with the one known environmental browser red (armory pixel height, reproduces on the untouched tip); typecheck and all five builds green. Decisive tests added for the changed behavior.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI surface changed.
- ~Accessible.~ N/A: no UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (comment-only catalog edits; values untouched, generated bundles unchanged).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files. The i18n regen was verified byte-clean against the committed bundles.
