### PR TITLE
perf(net): cache stable snapshot timers

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -2,6 +2,10 @@ import { randomUUID } from 'node:crypto';
 import type { WebSocket } from 'ws';
 import { createBotDetector } from '#bot-detector';
 import {
+  STABLE_TIMER_WIRE_VERSION,
+  type StableTimerWireVersion,
+} from '../src/net/snapshot_timer_wire';
+import {
   type AccountFlair,
   type ChatSenderFlair,
   EMPTY_ACCOUNT_FLAIR,
@@ -167,6 +171,7 @@ import { PartyFrameProjectionCache } from './party_frame_projection';
 import { nextRaidResetMs } from './raid_reset';
 import { REALM, REALM_PUBLIC_ORIGIN, REALM_RESET_TIME_ZONE } from './realm';
 import { createSerialWriter } from './serial_writer';
+import { StableAuraWireCache, StableSelfTimerWireCache } from './snapshot_timer_wire';
 import type { Presence, PresenceStatus, SocialActor, SocialTransport } from './social';
 import { SocialService } from './social';
 import { PgSocialDb } from './social_db';
@@ -634,6 +639,10 @@ export interface ClientSession {
   // serialized form of each delta self field as last sent to this client;
   // a field is omitted from a snapshot while its serialization is unchanged
   lastSent: Record<string, string>;
+  // Recipient-negotiated timer representation. Legacy remains the default for
+  // old and unknown clients throughout a rolling deploy.
+  timerWireVersion: 1 | StableTimerWireVersion;
+  timerWireCache: StableSelfTimerWireCache;
   // arena readout is reconciled at UI cadence instead of snapshot cadence
   lastArenaWireTick: number;
   // Vale Cup readout, same idea at its own cadence (VC_WIRE_HZ)
@@ -703,6 +712,10 @@ export interface ClientSession {
 interface SentEntityVersions {
   idVer: number;
   dynVer: number;
+  // Stable timer-wire recipients diff aura composition separately from the
+  // ordinary dynamic record, so a deferred distance-tier update cannot lose an
+  // aura change. Legacy recipients leave this at 0.
+  auraVer: number;
   // sim tick of the last full/lite record, so distance-tiered rates hold
   // even when one broadcast covers several catch-up sim ticks
   sentAtTick: number;
@@ -925,7 +938,7 @@ function wireAura(a: Aura): WireAura {
 
 // Dynamic fields are re-sent whole in every full or lite record, so the
 // conditional ones keep their absent-means-unset semantics.
-function dynamicFields(e: Entity): Record<string, unknown> {
+function dynamicFields(e: Entity, includeAuras = true): Record<string, unknown> {
   const out: Record<string, unknown> = {
     x: round2(e.pos.x),
     y: round2(e.pos.y),
@@ -981,7 +994,7 @@ function dynamicFields(e: Entity): Record<string, unknown> {
   if (e.rangedPower) out.rp = e.rangedPower;
   // top hate-table entries so the party threat meter shows real numbers
   if (e.kind === 'mob' && !e.dead && e.threat.size > 0) out.thr = threatEntries(e, 8);
-  if (e.auras.length > 0) {
+  if (includeAuras && e.auras.length > 0) {
     out.auras = e.auras.map(wireAura);
   }
   if (e.kind === 'mob' && e.lootable && e.loot) {
@@ -990,8 +1003,8 @@ function dynamicFields(e: Entity): Record<string, unknown> {
   return out;
 }
 
-export function wireEntity(e: Entity): Record<string, unknown> {
-  return { id: e.id, ...identityFields(e), ...dynamicFields(e) };
+export function wireEntity(e: Entity, includeAuras = true): Record<string, unknown> {
+  return { id: e.id, ...identityFields(e), ...dynamicFields(e, includeAuras) };
 }
 
 // npcs stay visible to the legacy radius (see the constants above);
@@ -1034,18 +1047,73 @@ function isUpdateDue(
 // Per-entity wire fragments, refreshed lazily at most once per tick and
 // shared by every recipient. The version counters bump only when the
 // serialized form actually changes, making per-session diffing O(1).
+interface EntityWireVariantCache {
+  tick: number;
+  idVer: number;
+  dynJson: string;
+  dynVer: number;
+  auraVer: number;
+  builtIdVer: number;
+  builtDynVer: number;
+  builtAuraVer: number;
+  fullJson: string;
+  liteJson: string;
+  fullAuraJson: string;
+  liteAuraJson: string;
+}
+
 interface EntityWireCache {
   tick: number;
   idJson: string;
-  dynJson: string;
+  baseDynJson: string;
+  idVer: number;
+  baseDynVer: number;
+  auraCache: StableAuraWireCache;
+  legacy: EntityWireVariantCache;
+  stable: EntityWireVariantCache;
+}
+
+interface EntityWireView {
   idVer: number;
   dynVer: number;
+  auraVer: number;
   fullJson: string;
   liteJson: string;
+  fullAuraJson: string;
+  liteAuraJson: string;
 }
 
 function round2(v: number): number {
   return Math.round(v * 100) / 100;
+}
+
+function emptyWireVariant(): EntityWireVariantCache {
+  return {
+    tick: -1,
+    idVer: 0,
+    dynJson: '',
+    dynVer: 0,
+    auraVer: 0,
+    builtIdVer: -1,
+    builtDynVer: -1,
+    builtAuraVer: -1,
+    fullJson: '',
+    liteJson: '',
+    fullAuraJson: '',
+    liteAuraJson: '',
+  };
+}
+
+function jsonWithField(objectJson: string, key: string, valueJson: string): string {
+  return `${objectJson.slice(0, -1)},"${key}":${valueJson}}`;
+}
+
+function fullEntityJson(id: number, idJson: string, dynJson: string): string {
+  return `{"id":${id},${idJson.slice(1, -1)},${dynJson.slice(1, -1)}}`;
+}
+
+function liteEntityJson(id: number, dynJson: string): string {
+  return `{"id":${id},${dynJson.slice(1, -1)}}`;
 }
 
 function logSocialErr(err: unknown): void {
@@ -1233,6 +1301,9 @@ export class GameServer {
   private bcSerializeNs = 0n;
   private bcVisits = 0;
   private bcSerializes = 0;
+  private bcBaseSerializes = 0;
+  private bcLegacySerializes = 0;
+  private bcStableSerializes = 0;
   // Mob-scan observability folded out of the loop body (server/mob_scan_tick_stats.ts):
   // the latest tick's aggro/threat visit counts surfaced on the [perf] heartbeat, plus
   // the four capture-window accumulators frozen into a PerfCaptureResult.
@@ -1735,6 +1806,9 @@ export class GameServer {
           this.bcSerializeNs = 0n;
           this.bcVisits = 0;
           this.bcSerializes = 0;
+          this.bcBaseSerializes = 0;
+          this.bcLegacySerializes = 0;
+          this.bcStableSerializes = 0;
           let mark = now;
           const lap = (phase: string): void => {
             const t = process.hrtime.bigint();
@@ -2453,6 +2527,7 @@ export class GameServer {
         fbc?: string | null;
         sourceUrl?: string | null;
         leaseNonce?: string;
+        timerWireVersion?: 1 | StableTimerWireVersion;
         // Server-recomputed bank bonus slots (ws_auth.ts, fresh-join arm) stamped into
         // the character state via addPlayer. Absent on a resume and for callers that
         // pass no meta (tests, the bot-detector overlay), which keep the saved value.
@@ -2558,6 +2633,9 @@ export class GameServer {
       lastInputSeq: 0,
       lastInputAt: this.sim.time,
       lastSent: {},
+      timerWireVersion:
+        meta.timerWireVersion === STABLE_TIMER_WIRE_VERSION ? STABLE_TIMER_WIRE_VERSION : 1,
+      timerWireCache: new StableSelfTimerWireCache(),
       lastArenaWireTick: -ARENA_WIRE_INTERVAL_TICKS,
       lastVcupWireTick: -VC_WIRE_INTERVAL_TICKS,
       lastDfWireTick: -DF_WIRE_INTERVAL_TICKS,
@@ -2718,6 +2796,9 @@ export class GameServer {
     session.lastInputSeq = 0;
     session.lastInputAt = this.sim.time;
     session.lastSent = {};
+    session.timerWireVersion =
+      meta.timerWireVersion === STABLE_TIMER_WIRE_VERSION ? STABLE_TIMER_WIRE_VERSION : 1;
+    session.timerWireCache = new StableSelfTimerWireCache();
     session.sentEnts = new Map();
     session.selfHeavyDirty = true;
     session.lastWireRev = -1;
@@ -3278,7 +3359,7 @@ export class GameServer {
     console.log(
       `[perf] online=${this.clients.size} ents=${this.sim.entities.size} tickHz=${this.tickHz == null ? 'n/a' : round2(this.tickHz)} tickMs=${round2(tickMs)}${overBudget ? ' OVER' : ''}` +
         ` | p95/max ${['total', 'tick', 'broadcast', 'bcastSelf', 'bcastGrid', 'events', 'social'].map(fmt).join(' ')}` +
-        ` | visits=${this.bcVisits} serializes=${this.bcSerializes} serializeMs=${round2(Number(this.bcSerializeNs) / 1e6)} aggroVisits=${this.mobScanTickStats.lastAggroScanVisits} threatVisits=${this.mobScanTickStats.lastThreatEntryVisits}`,
+        ` | visits=${this.bcVisits} serializes=${this.bcSerializes} serializeMs=${round2(Number(this.bcSerializeNs) / 1e6)} timerVariants=${this.bcLegacySerializes}/${this.bcStableSerializes} aggroVisits=${this.mobScanTickStats.lastAggroScanVisits} threatVisits=${this.mobScanTickStats.lastThreatEntryVisits}`,
     );
     // The sim.tick() internal breakdown, mean-sorted so the phase that actually eats
     // the average (not just a spike) leads. Populated only while detailed timing is on.
@@ -4928,6 +5009,7 @@ export class GameServer {
         const p = this.sim.entities.get(session.pid);
         const meta = this.sim.meta(session.pid);
         if (!p || !meta) return;
+        const stableTimerWire = session.timerWireVersion === STABLE_TIMER_WIRE_VERSION;
         let anchorEntity = p;
         let anchorMeta = meta;
         let anchorSession = session;
@@ -4966,30 +5048,33 @@ export class GameServer {
                 : interestLimitSq(e, known !== undefined);
             if (d2 > limitSq) return;
             present.add(e.id);
-            const cache = this.wireCacheFor(e);
+            const cache = this.wireCacheFor(e, stableTimerWire);
             if (known === undefined) {
               // first sight carries the at-rest state exactly, so no settle
               // record is owed until it moves again
-              ents.push(cache.fullJson);
+              ents.push(stableTimerWire ? cache.fullAuraJson : cache.fullJson);
               session.sentEnts.set(e.id, {
                 idVer: cache.idVer,
                 dynVer: cache.dynVer,
+                auraVer: cache.auraVer,
                 sentAtTick: tick,
                 settled: true,
               });
               return;
             }
+            const auraChanged = stableTimerWire && known.auraVer !== cache.auraVer;
             if (known.idVer !== cache.idVer) {
-              ents.push(cache.fullJson);
+              ents.push(auraChanged ? cache.fullAuraJson : cache.fullJson);
               known.idVer = cache.idVer;
               known.dynVer = cache.dynVer;
+              known.auraVer = cache.auraVer;
               known.sentAtTick = tick;
               known.settled = false;
               return;
             }
             if (
               !isUpdateDue(tick, e, d2, anchorEntity, known.sentAtTick) ||
-              (known.dynVer === cache.dynVer && known.settled)
+              (known.dynVer === cache.dynVer && !auraChanged && known.settled)
             ) {
               // not due at this distance tier yet, or unchanged and already
               // settled: a bare id keeps it alive on the client
@@ -4999,8 +5084,9 @@ export class GameServer {
             // due, and either changed or owing its one settle record
             known.settled = known.dynVer === cache.dynVer;
             known.dynVer = cache.dynVer;
+            known.auraVer = cache.auraVer;
             known.sentAtTick = tick;
-            ents.push(cache.liteJson);
+            ents.push(auraChanged ? cache.liteAuraJson : cache.liteJson);
           },
         );
         // forget entities that left interest, so a re-entry sends identity again
@@ -5037,9 +5123,10 @@ export class GameServer {
           );
         const temporalHourglassesJson =
           temporalHourglasses.length > 0 ? `,"hourglasses":[${temporalHourglasses.join(',')}]` : '';
+        const timerWireJson = stableTimerWire ? `,"tw":${STABLE_TIMER_WIRE_VERSION}` : '';
         this.sendRaw(
           session,
-          `${head},"self":${selfJson},"ents":[${ents.join(',')}]${frostRingsJson}${temporalHourglassesJson}${keepJson}}`,
+          `${head}${timerWireJson},"self":${selfJson},"ents":[${ents.join(',')}]${frostRingsJson}${temporalHourglassesJson}${keepJson}}`,
         );
       },
       (err, session) =>
@@ -5064,47 +5151,100 @@ export class GameServer {
     return d2 <= radius * radius;
   }
 
-  // each entity is serialized at most once per tick, shared by every
-  // recipient whose interest area contains it
-  private wireCacheFor(e: Entity): EntityWireCache {
+  private entityWireCacheFor(e: Entity): EntityWireCache {
     let cache = this.wireCache.get(e.id);
     if (!cache) {
       cache = {
         tick: -1,
         idJson: '',
-        dynJson: '',
+        baseDynJson: '',
         idVer: 0,
-        dynVer: 0,
-        fullJson: '',
-        liteJson: '',
+        baseDynVer: 0,
+        auraCache: new StableAuraWireCache(),
+        legacy: emptyWireVariant(),
+        stable: emptyWireVariant(),
       };
       this.wireCache.set(e.id, cache);
     }
-    if (cache.tick === this.sim.tickCount) return cache;
-    cache.tick = this.sim.tickCount;
-    const t0 = this.perfDetailActive ? process.hrtime.bigint() : 0n;
-    const idJson = JSON.stringify(identityFields(e));
-    const dynJson = JSON.stringify(dynamicFields(e));
-    let changed = false;
-    if (idJson !== cache.idJson) {
-      cache.idJson = idJson;
-      cache.idVer++;
-      changed = true;
-    }
-    if (dynJson !== cache.dynJson) {
-      cache.dynJson = dynJson;
-      cache.dynVer++;
-      changed = true;
-    }
-    if (changed) {
-      cache.fullJson = `{"id":${e.id},${idJson.slice(1, -1)},${dynJson.slice(1, -1)}}`;
-      cache.liteJson = `{"id":${e.id},${dynJson.slice(1, -1)}}`;
-    }
-    if (this.perfDetailActive) {
-      this.bcSerializeNs += process.hrtime.bigint() - t0;
-      this.bcSerializes++;
-    }
     return cache;
+  }
+
+  // Identity and non-aura dynamics are serialized once per entity/tick. The
+  // negotiated legacy and stable aura variants are then built lazily, at most
+  // once each, and shared by every compatible recipient.
+  private wireCacheFor(e: Entity, stableTimerWire: boolean): EntityWireView {
+    const cache = this.entityWireCacheFor(e);
+    const t0 = this.perfDetailActive ? process.hrtime.bigint() : 0n;
+    if (cache.tick !== this.sim.tickCount) {
+      cache.tick = this.sim.tickCount;
+      const idJson = JSON.stringify(identityFields(e));
+      const baseDynJson = JSON.stringify(dynamicFields(e, false));
+      if (idJson !== cache.idJson) {
+        cache.idJson = idJson;
+        cache.idVer++;
+      }
+      if (baseDynJson !== cache.baseDynJson) {
+        cache.baseDynJson = baseDynJson;
+        cache.baseDynVer++;
+      }
+      if (this.perfDetailActive) {
+        this.bcBaseSerializes++;
+        this.bcSerializes++;
+      }
+    }
+
+    const variant = stableTimerWire ? cache.stable : cache.legacy;
+    variant.idVer = cache.idVer;
+    if (variant.tick !== this.sim.tickCount) {
+      variant.tick = this.sim.tickCount;
+      if (stableTimerWire) {
+        const aura = cache.auraCache.encode(e.auras, this.sim.time, e.dead);
+        variant.dynJson = cache.baseDynJson;
+        variant.dynVer = cache.baseDynVer;
+        variant.auraVer = aura.revision;
+
+        const baseChanged =
+          variant.builtIdVer !== cache.idVer || variant.builtDynVer !== variant.dynVer;
+        const auraChanged = variant.builtAuraVer !== variant.auraVer;
+        if (baseChanged) {
+          variant.fullJson = fullEntityJson(e.id, cache.idJson, variant.dynJson);
+          variant.liteJson = liteEntityJson(e.id, variant.dynJson);
+        }
+        if (baseChanged || auraChanged) {
+          const dynWithAuras = jsonWithField(variant.dynJson, 'auras', aura.json);
+          variant.fullAuraJson = fullEntityJson(e.id, cache.idJson, dynWithAuras);
+          variant.liteAuraJson = liteEntityJson(e.id, dynWithAuras);
+          if (this.perfDetailActive) this.bcStableSerializes++;
+        }
+        variant.builtIdVer = cache.idVer;
+        variant.builtDynVer = variant.dynVer;
+        variant.builtAuraVer = variant.auraVer;
+      } else {
+        const auraJson = e.auras.length > 0 ? JSON.stringify(e.auras.map(wireAura)) : null;
+        const dynJson = auraJson
+          ? jsonWithField(cache.baseDynJson, 'auras', auraJson)
+          : cache.baseDynJson;
+        if (dynJson !== variant.dynJson) {
+          variant.dynJson = dynJson;
+          variant.dynVer++;
+        }
+        if (variant.builtIdVer !== cache.idVer || variant.builtDynVer !== variant.dynVer) {
+          variant.fullJson = fullEntityJson(e.id, cache.idJson, variant.dynJson);
+          variant.liteJson = liteEntityJson(e.id, variant.dynJson);
+          variant.fullAuraJson = variant.fullJson;
+          variant.liteAuraJson = variant.liteJson;
+          variant.builtIdVer = cache.idVer;
+          variant.builtDynVer = variant.dynVer;
+          if (this.perfDetailActive) this.bcLegacySerializes++;
+        }
+      }
+    }
+    if (this.perfDetailActive) this.bcSerializeNs += process.hrtime.bigint() - t0;
+    return variant;
+  }
+
+  private stableAuraWireFor(e: Entity): ReturnType<StableAuraWireCache['encode']> {
+    return this.entityWireCacheFor(e).auraCache.encode(e.auras, this.sim.time, e.dead);
   }
 
   private sweepWireCache(): void {
@@ -5119,7 +5259,8 @@ export class GameServer {
     meta: PlayerMeta,
     anchorSession: ClientSession = session,
   ): string {
-    const self = wireEntity(p);
+    const stableTimerWire = session.timerWireVersion === STABLE_TIMER_WIRE_VERSION;
+    const self = wireEntity(p, !stableTimerWire);
     Object.assign(self, {
       res: Math.round(p.resource * 10) / 10,
       mres: p.maxResource,
@@ -5156,12 +5297,14 @@ export class GameServer {
     // an absent field as "unchanged" (a fresh session always gets them all)
     const sent = session.lastSent;
     let extra = '';
-    const maybe = (key: string, value: unknown): void => {
-      const s = JSON.stringify(value ?? null);
+    const maybeSerialized = (key: string, s: string): void => {
       if (sent[key] !== s) {
         sent[key] = s;
         extra += `,"${key}":${s}`;
       }
+    };
+    const maybe = (key: string, value: unknown): void => {
+      maybeSerialized(key, JSON.stringify(value ?? null));
     };
     // Dynamic / latency-sensitive fields: diffed every tick. These change from
     // outside this session's own commands/events, party member HP from another
@@ -5181,7 +5324,15 @@ export class GameServer {
     // Delta-guarded: ships on death-release and clears on resurrect. The client
     // draws the corpse marker and gates the resurrect-at-corpse button on it.
     maybe('corpse', p.corpsePos);
-    maybe('cds', Object.fromEntries([...p.cooldowns.entries()].map(([k, v]) => [k, round2(v)])));
+    if (stableTimerWire) {
+      maybeSerialized('auras', this.stableAuraWireFor(p).json);
+      maybeSerialized(
+        'cds',
+        session.timerWireCache.encodeCooldowns(anchorSession.pid, p, this.sim.time).json,
+      );
+    } else {
+      maybe('cds', Object.fromEntries([...p.cooldowns.entries()].map(([k, v]) => [k, round2(v)])));
+    }
     // Per-player gather-node respawn cooldowns (#1866), same shape/semantics as
     // `cds` above: remaining seconds AS OF THIS TICK, ticking down tick over
     // tick (so `maybe` re-ships it while any node is still cooling down and
@@ -5189,24 +5340,42 @@ export class GameServer {
     // PlayerMeta.nodeHarvestReadyAt's own "absent means ready" contract (see
     // src/sim/professions/gathering.ts isNodeHarvestableBy). Only entries with
     // remaining time survive the filter, an already-elapsed timer reads as ready.
-    maybe(
-      'ncd',
-      Object.fromEntries(
-        Object.entries(meta.nodeHarvestReadyAt)
-          .filter(([, until]) => until > this.sim.time)
-          .map(([k, until]) => [k, round2(until - this.sim.time)]),
-      ),
-    );
+    if (stableTimerWire) {
+      maybeSerialized(
+        'ncd',
+        session.timerWireCache.encodeNodeCooldowns(
+          anchorSession.pid,
+          meta.nodeHarvestReadyAt,
+          this.sim.time,
+        ).json,
+      );
+    } else {
+      maybe(
+        'ncd',
+        Object.fromEntries(
+          Object.entries(meta.nodeHarvestReadyAt)
+            .filter(([, until]) => until > this.sim.time)
+            .map(([k, until]) => [k, round2(until - this.sim.time)]),
+        ),
+      );
+    }
     // Charge-limited ability live counts (abilityCharges, the one recharge
     // model: Twinstrike, Double Charge, Frost's second Ice Block): {abilityId:
     // charges}. The empty-pool recharge timer rides `cds`; the client derives
     // the max from its own known-list rebake (1 + bonusCharges).
-    maybe(
-      'achg',
-      p.abilityCharges
-        ? Object.fromEntries(Object.entries(p.abilityCharges).map(([k, v]) => [k, v.charges]))
-        : {},
-    );
+    if (stableTimerWire) {
+      maybeSerialized(
+        'achg',
+        session.timerWireCache.encodeCharges(anchorSession.pid, p.abilityCharges).json,
+      );
+    } else {
+      maybe(
+        'achg',
+        p.abilityCharges
+          ? Object.fromEntries(Object.entries(p.abilityCharges).map(([k, v]) => [k, v.charges]))
+          : {},
+      );
+    }
     maybe('stats', p.stats);
     maybe('weapon', p.weapon);
     maybe('party', this.partyWire(anchorSession.pid));

--- a/server/game.ts
+++ b/server/game.ts
@@ -173,7 +173,11 @@ import { PartyFrameProjectionCache } from './party_frame_projection';
 import { nextRaidResetMs } from './raid_reset';
 import { REALM, REALM_PUBLIC_ORIGIN, REALM_RESET_TIME_ZONE } from './realm';
 import { createSerialWriter } from './serial_writer';
-import { StableAuraWireCache, StableSelfTimerWireCache } from './snapshot_timer_wire';
+import {
+  jsonWithField,
+  StableAuraWireCache,
+  StableSelfTimerWireCache,
+} from './snapshot_timer_wire';
 import type { Presence, PresenceStatus, SocialActor, SocialTransport } from './social';
 import { SocialService } from './social';
 import { PgSocialDb } from './social_db';
@@ -1104,10 +1108,6 @@ function emptyWireVariant(): EntityWireVariantCache {
     fullAuraJson: '',
     liteAuraJson: '',
   };
-}
-
-function jsonWithField(objectJson: string, key: string, valueJson: string): string {
-  return `${objectJson.slice(0, -1)},"${key}":${valueJson}}`;
 }
 
 function fullEntityJson(id: number, idJson: string, dynJson: string): string {

--- a/server/game.ts
+++ b/server/game.ts
@@ -2,10 +2,6 @@ import { randomUUID } from 'node:crypto';
 import type { WebSocket } from 'ws';
 import { createBotDetector } from '#bot-detector';
 import {
-  STABLE_TIMER_WIRE_VERSION,
-  type StableTimerWireVersion,
-} from '../src/net/snapshot_timer_wire';
-import {
   type AccountFlair,
   type ChatSenderFlair,
   EMPTY_ACCOUNT_FLAIR,
@@ -80,7 +76,13 @@ import {
   type VcNationId,
 } from '../src/sim/types';
 import { isAtSowfield } from '../src/sim/vale_cup_layout';
-import { type BankBonusSource, type CommandName, isOverheadEmoteId } from '../src/world_api';
+import {
+  type BankBonusSource,
+  type CommandName,
+  isOverheadEmoteId,
+  STABLE_TIMER_WIRE_VERSION,
+  type StableTimerWireVersion,
+} from '../src/world_api';
 import { recordOnlineSample } from './admin_db';
 import { offensiveName } from './auth';
 import { recordBankOp } from './bank_ledger';
@@ -3359,7 +3361,7 @@ export class GameServer {
     console.log(
       `[perf] online=${this.clients.size} ents=${this.sim.entities.size} tickHz=${this.tickHz == null ? 'n/a' : round2(this.tickHz)} tickMs=${round2(tickMs)}${overBudget ? ' OVER' : ''}` +
         ` | p95/max ${['total', 'tick', 'broadcast', 'bcastSelf', 'bcastGrid', 'events', 'social'].map(fmt).join(' ')}` +
-        ` | visits=${this.bcVisits} serializes=${this.bcSerializes} serializeMs=${round2(Number(this.bcSerializeNs) / 1e6)} timerVariants=${this.bcLegacySerializes}/${this.bcStableSerializes} aggroVisits=${this.mobScanTickStats.lastAggroScanVisits} threatVisits=${this.mobScanTickStats.lastThreatEntryVisits}`,
+        ` | visits=${this.bcVisits} serializes=${this.bcSerializes} baseSerializes=${this.bcBaseSerializes} serializeMs=${round2(Number(this.bcSerializeNs) / 1e6)} timerVariants=${this.bcLegacySerializes}/${this.bcStableSerializes} aggroVisits=${this.mobScanTickStats.lastAggroScanVisits} threatVisits=${this.mobScanTickStats.lastThreatEntryVisits}`,
     );
     // The sim.tick() internal breakdown, mean-sorted so the phase that actually eats
     // the average (not just a spike) leads. Populated only while detailed timing is on.

--- a/server/snapshot_timer_wire.ts
+++ b/server/snapshot_timer_wire.ts
@@ -6,6 +6,11 @@ export interface SerializedTimerWire {
   revision: number;
 }
 
+export function jsonWithField(objectJson: string, key: string, valueJson: string): string {
+  const separator = objectJson === '{}' ? '' : ',';
+  return `${objectJson.slice(0, -1)}${separator}"${key}":${valueJson}}`;
+}
+
 type CooldownDeadline = StableCooldownWire;
 
 interface StableAuraRecord {

--- a/server/snapshot_timer_wire.ts
+++ b/server/snapshot_timer_wire.ts
@@ -1,5 +1,5 @@
-import type { StableCooldownWire } from '../src/net/snapshot_timer_wire';
 import type { Aura, Entity } from '../src/sim/types';
+import type { StableCooldownWire } from '../src/world_api';
 
 export interface SerializedTimerWire {
   json: string;

--- a/server/snapshot_timer_wire.ts
+++ b/server/snapshot_timer_wire.ts
@@ -1,0 +1,337 @@
+import type { StableCooldownWire } from '../src/net/snapshot_timer_wire';
+import type { Aura, Entity } from '../src/sim/types';
+
+export interface SerializedTimerWire {
+  json: string;
+  revision: number;
+}
+
+type CooldownDeadline = StableCooldownWire;
+
+interface StableAuraRecord {
+  id: string;
+  name: string;
+  kind: string;
+  duration: number;
+  value: number;
+  value2: number | undefined;
+  value3: number | undefined;
+  tickInterval: number | undefined;
+  school: string;
+  stacks: number | undefined;
+  charges: number | undefined;
+  empowerAbilities: readonly string[] | undefined;
+  sourceId: number;
+  paused: boolean;
+  deadline: number;
+}
+
+interface StableAuraWire {
+  id: string;
+  name: string;
+  kind: string;
+  dur: number;
+  exp?: number;
+  rem?: number;
+  value?: number;
+  value2?: number;
+  value3?: number;
+  tickInterval?: number;
+  school?: string;
+  stacks?: number;
+  charges?: number;
+  emp?: readonly string[];
+  src?: number;
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function sameStringList(
+  a: readonly string[] | undefined,
+  b: readonly string[] | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function auraMatches(
+  record: StableAuraRecord,
+  aura: Aura,
+  simTime: number,
+  paused: boolean,
+): boolean {
+  const deadline = round2(paused ? aura.remaining : simTime + aura.remaining);
+  return (
+    record.id === aura.id &&
+    record.name === aura.name &&
+    record.kind === aura.kind &&
+    record.duration === aura.duration &&
+    record.value === aura.value &&
+    record.value2 === aura.value2 &&
+    record.value3 === aura.value3 &&
+    record.tickInterval === aura.tickInterval &&
+    record.school === aura.school &&
+    record.stacks === (aura.stacks && aura.stacks > 1 ? aura.stacks : undefined) &&
+    record.charges === aura.charges &&
+    sameStringList(record.empowerAbilities, aura.empowerAbilities) &&
+    record.sourceId === aura.sourceId &&
+    record.paused === paused &&
+    record.deadline === deadline
+  );
+}
+
+function auraRecord(aura: Aura, simTime: number, paused: boolean): StableAuraRecord {
+  return {
+    id: aura.id,
+    name: aura.name,
+    kind: aura.kind,
+    duration: aura.duration,
+    value: aura.value,
+    value2: aura.value2,
+    value3: aura.value3,
+    tickInterval: aura.tickInterval,
+    school: aura.school,
+    stacks: aura.stacks && aura.stacks > 1 ? aura.stacks : undefined,
+    charges: aura.charges,
+    empowerAbilities: aura.empowerAbilities ? [...aura.empowerAbilities] : undefined,
+    sourceId: aura.sourceId,
+    paused,
+    deadline: round2(paused ? aura.remaining : simTime + aura.remaining),
+  };
+}
+
+function auraWire(record: StableAuraRecord): StableAuraWire {
+  const wire: StableAuraWire = {
+    id: record.id,
+    name: record.name,
+    kind: record.kind,
+    dur: record.duration,
+  };
+  if (record.paused) wire.rem = record.deadline;
+  else wire.exp = record.deadline;
+  if (record.value !== 0) wire.value = record.value;
+  if (record.value2 !== undefined) wire.value2 = record.value2;
+  if (record.value3 !== undefined) wire.value3 = record.value3;
+  if (record.tickInterval !== undefined) wire.tickInterval = record.tickInterval;
+  if (record.school !== 'physical') wire.school = record.school;
+  if (record.stacks !== undefined) wire.stacks = record.stacks;
+  if (record.charges !== undefined) wire.charges = record.charges;
+  if (record.empowerAbilities !== undefined) wire.emp = record.empowerAbilities;
+  if (record.sourceId) wire.src = record.sourceId;
+  return wire;
+}
+
+/**
+ * Per-entity v2 aura cache. Live countdowns are represented as absolute expiry
+ * times, so an ordinary tick does not allocate or stringify a new aura list.
+ */
+export class StableAuraWireCache {
+  private records: StableAuraRecord[] = [];
+  private result: SerializedTimerWire | null = null;
+  rebuilds = 0;
+
+  encode(auras: readonly Aura[], simTime: number, paused: boolean): SerializedTimerWire {
+    let changed = this.records.length !== auras.length;
+    if (!changed) {
+      for (let i = 0; i < auras.length; i++) {
+        if (!auraMatches(this.records[i], auras[i], simTime, paused)) {
+          changed = true;
+          break;
+        }
+      }
+    }
+    if (!changed && this.result) return this.result;
+
+    this.records = auras.map((aura) => auraRecord(aura, simTime, paused));
+    this.rebuilds++;
+    this.result = {
+      json: JSON.stringify(this.records.map(auraWire)),
+      revision: this.rebuilds,
+    };
+    return this.result;
+  }
+}
+
+function findProtectiveHourglass(auras: readonly Aura[]): Aura | null {
+  for (const aura of auras) {
+    if (
+      aura.id === 'temporal_hourglass' &&
+      aura.kind === 'stasis' &&
+      aura.remaining > 0 &&
+      aura.value > 1
+    ) {
+      return aura;
+    }
+  }
+  return null;
+}
+
+function cooldownDeadline(
+  abilityId: string,
+  remaining: number,
+  simTime: number,
+  hourglass: Aura | null,
+  dead: boolean,
+): CooldownDeadline {
+  if (abilityId === 'temporal_hourglass' || !hourglass) return round2(simTime + remaining);
+  const rate = hourglass.value;
+  const acceleratedFor = dead ? remaining / rate : Math.min(hourglass.remaining, remaining / rate);
+  const normalWork = Math.max(0, remaining - acceleratedFor * rate);
+  return [round2(simTime + acceleratedFor + normalWork), rate, round2(simTime + acceleratedFor)];
+}
+
+function cooldownDeadlineMatches(
+  prior: CooldownDeadline | undefined,
+  abilityId: string,
+  remaining: number,
+  simTime: number,
+  hourglass: Aura | null,
+  dead: boolean,
+): boolean {
+  if (abilityId === 'temporal_hourglass' || !hourglass) {
+    return prior === round2(simTime + remaining);
+  }
+  if (!Array.isArray(prior)) return false;
+  const rate = hourglass.value;
+  const acceleratedFor = dead ? remaining / rate : Math.min(hourglass.remaining, remaining / rate);
+  const normalWork = Math.max(0, remaining - acceleratedFor * rate);
+  return (
+    prior[0] === round2(simTime + acceleratedFor + normalWork) &&
+    prior[1] === rate &&
+    prior[2] === round2(simTime + acceleratedFor)
+  );
+}
+
+function deadlineMapJson(deadlines: ReadonlyMap<string, CooldownDeadline>): string {
+  return JSON.stringify(Object.fromEntries(deadlines));
+}
+
+/** Per-recipient cache for v2 self timers. A spectator owner change resets it. */
+export class StableSelfTimerWireCache {
+  private ownerId: number | null = null;
+  private cooldowns = new Map<string, CooldownDeadline>();
+  private cooldownResult: SerializedTimerWire | null = null;
+  private nodes = new Map<string, number>();
+  private nodeResult: SerializedTimerWire | null = null;
+  private charges = new Map<string, number>();
+  private chargeResult: SerializedTimerWire | null = null;
+  cooldownRebuilds = 0;
+  nodeCooldownRebuilds = 0;
+  chargeRebuilds = 0;
+
+  private setOwner(ownerId: number): void {
+    if (this.ownerId === ownerId) return;
+    this.ownerId = ownerId;
+    this.cooldowns.clear();
+    this.cooldownResult = null;
+    this.nodes.clear();
+    this.nodeResult = null;
+    this.charges.clear();
+    this.chargeResult = null;
+  }
+
+  encodeCooldowns(
+    ownerId: number,
+    entity: Pick<Entity, 'cooldowns' | 'auras' | 'dead'>,
+    simTime: number,
+  ): SerializedTimerWire {
+    this.setOwner(ownerId);
+    const hourglass = findProtectiveHourglass(entity.auras);
+    let count = 0;
+    let changed = false;
+    for (const [abilityId, remaining] of entity.cooldowns) {
+      if (!(remaining > 0) || !Number.isFinite(remaining)) continue;
+      count++;
+      if (
+        !cooldownDeadlineMatches(
+          this.cooldowns.get(abilityId),
+          abilityId,
+          remaining,
+          simTime,
+          hourglass,
+          entity.dead,
+        )
+      ) {
+        changed = true;
+      }
+    }
+    if (count !== this.cooldowns.size) changed = true;
+    if (!changed && this.cooldownResult) return this.cooldownResult;
+
+    const next = new Map<string, CooldownDeadline>();
+    for (const [abilityId, remaining] of entity.cooldowns) {
+      if (!(remaining > 0) || !Number.isFinite(remaining)) continue;
+      next.set(abilityId, cooldownDeadline(abilityId, remaining, simTime, hourglass, entity.dead));
+    }
+    this.cooldowns = next;
+    this.cooldownRebuilds++;
+    this.cooldownResult = {
+      json: deadlineMapJson(next),
+      revision: this.cooldownRebuilds,
+    };
+    return this.cooldownResult;
+  }
+
+  encodeNodeCooldowns(
+    ownerId: number,
+    readyAt: Readonly<Record<string, number>>,
+    simTime: number,
+  ): SerializedTimerWire {
+    this.setOwner(ownerId);
+    let count = 0;
+    let changed = false;
+    for (const key in readyAt) {
+      const value = readyAt[key];
+      if (!(value > simTime) || !Number.isFinite(value)) continue;
+      count++;
+      if (this.nodes.get(key) !== round2(value)) changed = true;
+    }
+    if (count !== this.nodes.size) changed = true;
+    if (!changed && this.nodeResult) return this.nodeResult;
+
+    const next = new Map<string, number>();
+    for (const key in readyAt) {
+      const value = readyAt[key];
+      if (value > simTime && Number.isFinite(value)) next.set(key, round2(value));
+    }
+    this.nodes = next;
+    this.nodeCooldownRebuilds++;
+    this.nodeResult = {
+      json: JSON.stringify(Object.fromEntries(next)),
+      revision: this.nodeCooldownRebuilds,
+    };
+    return this.nodeResult;
+  }
+
+  encodeCharges(ownerId: number, abilityCharges: Entity['abilityCharges']): SerializedTimerWire {
+    this.setOwner(ownerId);
+    let count = 0;
+    let changed = false;
+    if (abilityCharges) {
+      for (const key in abilityCharges) {
+        count++;
+        if (this.charges.get(key) !== abilityCharges[key].charges) changed = true;
+      }
+    }
+    if (count !== this.charges.size) changed = true;
+    if (!changed && this.chargeResult) return this.chargeResult;
+
+    const next = new Map<string, number>();
+    if (abilityCharges) {
+      for (const key in abilityCharges) next.set(key, abilityCharges[key].charges);
+    }
+    this.charges = next;
+    this.chargeRebuilds++;
+    this.chargeResult = {
+      json: JSON.stringify(Object.fromEntries(next)),
+      revision: this.chargeRebuilds,
+    };
+    return this.chargeResult;
+  }
+}

--- a/server/ws_auth.ts
+++ b/server/ws_auth.ts
@@ -244,7 +244,7 @@ export function createWsAuth(deps: WsAuthDeps): WsAuthHandlers {
     const clientSeed = typeof msg.clientSeed === 'string' ? msg.clientSeed : '';
     // Optional rolling-deploy capability. Exact numeric equality is deliberate:
     // strings, booleans, and unknown future versions stay on the legacy wire.
-    const timerWireVersion =
+    const timerWireVersion: 1 | typeof STABLE_TIMER_WIRE_VERSION =
       msg.timerWire === STABLE_TIMER_WIRE_VERSION ? STABLE_TIMER_WIRE_VERSION : 1;
     const accountId = await accountForToken(token);
     if (accountId === null || !Number.isFinite(characterId)) {

--- a/server/ws_auth.ts
+++ b/server/ws_auth.ts
@@ -15,6 +15,7 @@ import { randomUUID } from 'node:crypto';
 import type { EventEmitter } from 'node:events';
 import type * as http from 'node:http';
 import type { WebSocket, WebSocketServer } from 'ws';
+import { STABLE_TIMER_WIRE_VERSION } from '../src/net/snapshot_timer_wire';
 import type { BankBonusSource } from '../src/world_api';
 import type {
   AccountChatMuteStatus,
@@ -241,6 +242,10 @@ export function createWsAuth(deps: WsAuthDeps): WsAuthHandlers {
     const token = typeof msg.token === 'string' ? msg.token : '';
     const characterId = Number(msg.character ?? 'NaN');
     const clientSeed = typeof msg.clientSeed === 'string' ? msg.clientSeed : '';
+    // Optional rolling-deploy capability. Exact numeric equality is deliberate:
+    // strings, booleans, and unknown future versions stay on the legacy wire.
+    const timerWireVersion =
+      msg.timerWire === STABLE_TIMER_WIRE_VERSION ? STABLE_TIMER_WIRE_VERSION : 1;
     const accountId = await accountForToken(token);
     if (accountId === null || !Number.isFinite(characterId)) {
       rejectHandshake(ws, WS_AUTH_ERROR.notAuthenticated);
@@ -292,6 +297,7 @@ export function createWsAuth(deps: WsAuthDeps): WsAuthHandlers {
       isAdmin,
       adminPermissions,
       clientSeed,
+      timerWireVersion,
     };
     // Two genuinely concurrent handshakes for one character would race to stamp
     // the lease nonce; admit only the first and refuse the rest (never queue).

--- a/server/ws_auth.ts
+++ b/server/ws_auth.ts
@@ -15,8 +15,7 @@ import { randomUUID } from 'node:crypto';
 import type { EventEmitter } from 'node:events';
 import type * as http from 'node:http';
 import type { WebSocket, WebSocketServer } from 'ws';
-import { STABLE_TIMER_WIRE_VERSION } from '../src/net/snapshot_timer_wire';
-import type { BankBonusSource } from '../src/world_api';
+import { type BankBonusSource, STABLE_TIMER_WIRE_VERSION } from '../src/world_api';
 import type {
   AccountChatMuteStatus,
   AccountCosmetics,

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -1998,7 +1998,12 @@ export class ClientWorld implements IWorld {
       this.stableCooldownSchedules?.clear();
       this.stableNodeDeadlines?.clear();
     }
-    if (mode !== 'stable' || typeof rawTime !== 'number' || !Number.isFinite(rawTime)) {
+    if (
+      mode !== 'stable' ||
+      typeof rawTime !== 'number' ||
+      !Number.isFinite(rawTime) ||
+      rawTime < 0
+    ) {
       return { mode, time: null };
     }
 
@@ -2150,6 +2155,13 @@ export class ClientWorld implements IWorld {
     const prevSelf = this.entities.get(this.playerId);
     const prevSelfFacing = prevSelf?.facing;
     const prevSelfDead = prevSelf?.dead ?? false;
+
+    const auraRemaining = (aura: ClientWireAura): number => {
+      if (timerWire.mode !== 'stable' || timerWire.time === null) return Number(aura.rem);
+      const deadlineRemaining = stableDeadlineRemaining(aura.exp, timerWire.time);
+      if (deadlineRemaining !== null) return deadlineRemaining;
+      return typeof aura.rem === 'number' && Number.isFinite(aura.rem) ? aura.rem : 0;
+    };
 
     const applyWire = (w: any): Entity | null => {
       let e = this.entities.get(w.id);
@@ -2334,12 +2346,6 @@ export class ClientWorld implements IWorld {
         (timerWire.mode === 'stable' && timerWire.time !== null && w.auras !== undefined);
       if (shouldApplyAuras) {
         const wireAuras = (Array.isArray(w.auras) ? w.auras : []) as ClientWireAura[];
-        const auraRemaining = (aura: ClientWireAura): number => {
-          if (timerWire.mode !== 'stable' || timerWire.time === null) return Number(aura.rem);
-          const deadlineRemaining = stableDeadlineRemaining(aura.exp, timerWire.time);
-          if (deadlineRemaining !== null) return deadlineRemaining;
-          return typeof aura.rem === 'number' && Number.isFinite(aura.rem) ? aura.rem : 0;
-        };
         let sameAuraShape = e.auras.length === wireAuras.length;
         if (sameAuraShape) {
           for (let i = 0; i < wireAuras.length; i++) {

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -1987,6 +1987,10 @@ export class ClientWorld implements IWorld {
     rawTime: unknown,
   ): { mode: SnapshotTimerWireMode; time: number | null } {
     const mode = snapshotTimerWireMode(rawVersion);
+    // An unknown future marker may use timer fields this client cannot decode.
+    // Ignore those fields without disturbing the last understood v2 schedule,
+    // so one unsupported snapshot cannot freeze a later valid v2 stream.
+    if (mode === 'unsupported') return { mode, time: null };
     if (mode !== this.timerWireMode) {
       this.timerWireMode = mode;
       this.stableTimerTime = undefined;

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -39,6 +39,7 @@ import type { ResolvedAbility } from '../sim/sim';
 import { parseTalentAllocation } from '../sim/talent_allocation_input';
 import { repairTalentLoadouts } from '../sim/talent_loadouts';
 import {
+  type Aura,
   type DeedStats,
   type DungeonDifficulty,
   type Entity,
@@ -107,6 +108,32 @@ import type { MasterworkView } from '../world_api/professions';
 import { computeBackoffDelay } from './backoff';
 import { optimisticQuestState } from './quest_state_optimistic';
 import { isTransientReconnectRejection, isTransientTimeoutRejection } from './reconnect_policy';
+import {
+  type SnapshotTimerWireMode,
+  STABLE_TIMER_WIRE_VERSION,
+  type StableCooldownWire,
+  snapshotTimerWireMode,
+  stableCooldownRemaining,
+  stableDeadlineRemaining,
+} from './snapshot_timer_wire';
+
+interface ClientWireAura {
+  id: string;
+  name: string;
+  kind: Aura['kind'];
+  rem?: number;
+  exp?: number;
+  dur: number;
+  value?: number;
+  value2?: number;
+  value3?: number;
+  tickInterval?: number;
+  school?: Aura['school'];
+  stacks?: number;
+  charges?: number;
+  emp?: Aura['empowerAbilities'];
+  src?: number;
+}
 
 // ---------------------------------------------------------------------------
 // REST
@@ -171,8 +198,20 @@ export function buildWebSocketAuthMessage(
   token: string,
   characterId: number,
   clientSeed = '',
-): { t: 'auth'; token: string; character: number; clientSeed: string } {
-  return { t: 'auth', token, character: characterId, clientSeed };
+): {
+  t: 'auth';
+  token: string;
+  character: number;
+  clientSeed: string;
+  timerWire: typeof STABLE_TIMER_WIRE_VERSION;
+} {
+  return {
+    t: 'auth',
+    token,
+    character: characterId,
+    clientSeed,
+    timerWire: STABLE_TIMER_WIRE_VERSION,
+  };
 }
 
 export type RealmType = 'Normal' | 'PvP' | 'RP' | 'RP-PvP';
@@ -1397,6 +1436,14 @@ export class ClientWorld implements IWorld {
   // server-measured achieved sim tick rate (Hz), mirrored from the snap head;
   // null until the server's meter warms up (perf overlay hides the row)
   serverTickHz: number | null = null;
+  // Stable timer-wire decode state. These stay separate from the public
+  // remaining-time mirrors so an omitted v2 field can be re-derived from the
+  // server simulation clock without accumulating client-frame drift.
+  private timerWireMode: SnapshotTimerWireMode | undefined;
+  private stableTimerTime: number | undefined;
+  private stableTimerOwnerId: number | undefined;
+  private stableCooldownSchedules: Map<string, StableCooldownWire> | undefined = new Map();
+  private stableNodeDeadlines: Map<string, number> | undefined = new Map();
   // entity id -> performance.now() when it first went missing from a snapshot;
   // used for the despawn grace window (anti-flicker), cleared once it returns
   private missingSince = new Map<number, number>();
@@ -1935,11 +1982,89 @@ export class ClientWorld implements IWorld {
     return v;
   }
 
+  private prepareSnapshotTimers(
+    rawVersion: unknown,
+    rawTime: unknown,
+  ): { mode: SnapshotTimerWireMode; time: number | null } {
+    const mode = snapshotTimerWireMode(rawVersion);
+    if (mode !== this.timerWireMode) {
+      this.timerWireMode = mode;
+      this.stableTimerTime = undefined;
+      this.stableTimerOwnerId = undefined;
+      this.stableCooldownSchedules?.clear();
+      this.stableNodeDeadlines?.clear();
+    }
+    if (mode !== 'stable' || typeof rawTime !== 'number' || !Number.isFinite(rawTime)) {
+      return { mode, time: null };
+    }
+
+    if (this.stableCooldownSchedules === undefined) this.stableCooldownSchedules = new Map();
+    if (this.stableNodeDeadlines === undefined) this.stableNodeDeadlines = new Map();
+    if (this.stableTimerOwnerId !== this.playerId) {
+      this.stableTimerOwnerId = this.playerId;
+      this.stableCooldownSchedules.clear();
+      this.stableNodeDeadlines.clear();
+      this.nodeCooldowns = new Map();
+    }
+
+    const previous = this.stableTimerTime;
+    if (previous !== undefined && rawTime >= previous) {
+      const elapsed = rawTime - previous;
+      if (elapsed > 0) {
+        for (const entity of this.entities.values()) {
+          if (entity.dead || entity.auras.length === 0) continue;
+          let retained = 0;
+          for (const aura of entity.auras) {
+            if (Number.isFinite(aura.remaining))
+              aura.remaining = Math.max(0, aura.remaining - elapsed);
+            if (aura.remaining > 0) entity.auras[retained++] = aura;
+          }
+          entity.auras.length = retained;
+        }
+      }
+    } else if (previous !== undefined) {
+      // A reconnect can land on a restarted realm whose simulation clock is
+      // behind the prior socket. Its first snapshot is complete, so discard
+      // schedules tied to the old clock before decoding it.
+      this.stableCooldownSchedules.clear();
+      this.stableNodeDeadlines.clear();
+    }
+    this.stableTimerTime = rawTime;
+    this.refreshStableSelfTimers(rawTime);
+    return { mode, time: rawTime };
+  }
+
+  private refreshStableSelfTimers(now: number): void {
+    const player = this.entities.get(this.playerId);
+    if (player && this.stableCooldownSchedules) {
+      for (const [abilityId, schedule] of this.stableCooldownSchedules) {
+        const remaining = stableCooldownRemaining(schedule, now);
+        if (remaining !== null && remaining > 0) player.cooldowns.set(abilityId, remaining);
+        else {
+          this.stableCooldownSchedules.delete(abilityId);
+          player.cooldowns.delete(abilityId);
+        }
+      }
+    }
+    if (this.stableNodeDeadlines) {
+      if (this.nodeCooldowns === undefined) this.nodeCooldowns = new Map();
+      for (const [nodeId, deadline] of this.stableNodeDeadlines) {
+        const remaining = stableDeadlineRemaining(deadline, now);
+        if (remaining !== null && remaining > 0) this.nodeCooldowns.set(nodeId, remaining);
+        else {
+          this.stableNodeDeadlines.delete(nodeId);
+          this.nodeCooldowns.delete(nodeId);
+        }
+      }
+    }
+  }
+
   private applySnapshot(snap: any): void {
     const now = performance.now();
     if (typeof this.spectating === 'string' && typeof snap.self?.id === 'number') {
       this.playerId = snap.self.id;
     }
+    const timerWire = this.prepareSnapshotTimers(snap.tw, snap.time);
     // the interpolation alpha the render loop reached on its last frame
     // (same formula and caps as main.ts); used below to re-anchor the new
     // interpolation segment at the pose currently on screen
@@ -2200,56 +2325,67 @@ export class ClientWorld implements IWorld {
       // records in place: no array + per-aura object allocation per entity at 20 Hz, and the
       // preserved object identity matches the offline Sim (one live aura object across ticks).
       // Any composition change (gain/fade/reorder) falls back to the fresh build below.
-      const wireAuras: any[] = w.auras ?? [];
-      let sameAuraShape = e.auras.length === wireAuras.length;
-      if (sameAuraShape) {
-        for (let i = 0; i < wireAuras.length; i++) {
-          if (e.auras[i].id !== wireAuras[i].id) {
-            sameAuraShape = false;
-            break;
+      const shouldApplyAuras =
+        timerWire.mode === 'legacy' ||
+        (timerWire.mode === 'stable' && timerWire.time !== null && w.auras !== undefined);
+      if (shouldApplyAuras) {
+        const wireAuras = (Array.isArray(w.auras) ? w.auras : []) as ClientWireAura[];
+        const auraRemaining = (aura: ClientWireAura): number => {
+          if (timerWire.mode !== 'stable' || timerWire.time === null) return Number(aura.rem);
+          const deadlineRemaining = stableDeadlineRemaining(aura.exp, timerWire.time);
+          if (deadlineRemaining !== null) return deadlineRemaining;
+          return typeof aura.rem === 'number' && Number.isFinite(aura.rem) ? aura.rem : 0;
+        };
+        let sameAuraShape = e.auras.length === wireAuras.length;
+        if (sameAuraShape) {
+          for (let i = 0; i < wireAuras.length; i++) {
+            if (e.auras[i].id !== wireAuras[i].id) {
+              sameAuraShape = false;
+              break;
+            }
           }
         }
-      }
-      if (sameAuraShape) {
-        for (let i = 0; i < wireAuras.length; i++) {
-          const a = wireAuras[i];
-          const rec = e.auras[i];
-          rec.name = a.name;
-          rec.kind = a.kind;
-          rec.remaining = a.rem;
-          rec.duration = a.dur;
-          rec.value = a.value ?? 0;
-          rec.value2 = a.value2;
-          rec.value3 = a.value3;
-          rec.tickInterval = a.tickInterval;
-          rec.school = a.school ?? 'physical';
-          rec.stacks = a.stacks;
-          // Mirror the charge count for a charge-limited aura (Lightning Shield); the wire
-          // sends it only when defined (server/game.ts), so an ordinary aura or an old server
-          // decodes to undefined and the badge falls back to the stacks path, exactly as before.
-          rec.charges = a.charges;
-          rec.empowerAbilities = a.emp;
-          // The caster's entity id, for the target strip's own-aura prominence
-          // (auras_view ownFirst). An old server omits it; 0 matches no player id.
-          rec.sourceId = a.src ?? 0;
+        if (sameAuraShape) {
+          for (let i = 0; i < wireAuras.length; i++) {
+            const a = wireAuras[i];
+            const rec = e.auras[i];
+            rec.name = a.name;
+            rec.kind = a.kind;
+            rec.remaining = auraRemaining(a);
+            rec.duration = a.dur;
+            rec.value = a.value ?? 0;
+            rec.value2 = a.value2;
+            rec.value3 = a.value3;
+            rec.tickInterval = a.tickInterval;
+            rec.school = a.school ?? 'physical';
+            rec.stacks = a.stacks;
+            // Mirror the charge count for a charge-limited aura (Lightning Shield); the wire
+            // sends it only when defined (server/game.ts), so an ordinary aura or an old server
+            // decodes to undefined and the badge falls back to the stacks path, exactly as before.
+            rec.charges = a.charges;
+            rec.empowerAbilities = a.emp;
+            // The caster's entity id, for the target strip's own-aura prominence
+            // (auras_view ownFirst). An old server omits it; 0 matches no player id.
+            rec.sourceId = a.src ?? 0;
+          }
+        } else {
+          e.auras = wireAuras.map((a) => ({
+            id: a.id,
+            name: a.name,
+            kind: a.kind,
+            remaining: auraRemaining(a),
+            duration: a.dur,
+            value: a.value ?? 0,
+            value2: a.value2,
+            value3: a.value3,
+            tickInterval: a.tickInterval,
+            sourceId: a.src ?? 0,
+            school: a.school ?? 'physical',
+            stacks: a.stacks,
+            charges: a.charges,
+            empowerAbilities: a.emp,
+          }));
         }
-      } else {
-        e.auras = wireAuras.map((a: any) => ({
-          id: a.id,
-          name: a.name,
-          kind: a.kind,
-          remaining: a.rem,
-          duration: a.dur,
-          value: a.value ?? 0,
-          value2: a.value2,
-          value3: a.value3,
-          tickInterval: a.tickInterval,
-          sourceId: a.src ?? 0,
-          school: a.school ?? 'physical',
-          stacks: a.stacks,
-          charges: a.charges,
-          empowerAbilities: a.emp,
-        }));
       }
       e.loot = w.lootList ?? null;
       return e;
@@ -2296,7 +2432,20 @@ export class ClientWorld implements IWorld {
       // corpse position while a ghost (null once resurrected). Delta-guarded: kept
       // unchanged when the server omits it; drives the corpse marker + resurrect button.
       if (s.corpse !== undefined) e.corpsePos = s.corpse ?? null;
-      if (s.cds !== undefined) {
+      if (timerWire.mode === 'stable' && timerWire.time !== null && s.cds !== undefined) {
+        if (this.stableCooldownSchedules === undefined) this.stableCooldownSchedules = new Map();
+        this.stableCooldownSchedules.clear();
+        e.cooldowns.clear();
+        if (s.cds && typeof s.cds === 'object' && !Array.isArray(s.cds)) {
+          for (const abilityId in s.cds) {
+            const schedule = s.cds[abilityId] as unknown;
+            const remaining = stableCooldownRemaining(schedule, timerWire.time);
+            if (remaining === null || remaining <= 0) continue;
+            this.stableCooldownSchedules.set(abilityId, schedule as StableCooldownWire);
+            e.cooldowns.set(abilityId, remaining);
+          }
+        }
+      } else if (timerWire.mode === 'legacy' && s.cds !== undefined) {
         // in-place rebuild (same result as `new Map(Object.entries(...))`): no
         // intermediate entry arrays and no Map churn on the 20 Hz self record
         e.cooldowns.clear();
@@ -2306,7 +2455,20 @@ export class ClientWorld implements IWorld {
       // Map (always constructed by the shared entity factory), this field lives
       // on ClientWorld itself, and a hand-built test fixture (`Object.create`,
       // see tests/CLAUDE.md) may not have pre-initialized it.
-      if (s.ncd !== undefined) {
+      if (timerWire.mode === 'stable' && timerWire.time !== null && s.ncd !== undefined) {
+        if (this.stableNodeDeadlines === undefined) this.stableNodeDeadlines = new Map();
+        this.stableNodeDeadlines.clear();
+        this.nodeCooldowns = new Map();
+        if (s.ncd && typeof s.ncd === 'object' && !Array.isArray(s.ncd)) {
+          for (const nodeId in s.ncd) {
+            const deadline = s.ncd[nodeId] as unknown;
+            const remaining = stableDeadlineRemaining(deadline, timerWire.time);
+            if (remaining === null || remaining <= 0 || typeof deadline !== 'number') continue;
+            this.stableNodeDeadlines.set(nodeId, deadline);
+            this.nodeCooldowns.set(nodeId, remaining);
+          }
+        }
+      } else if (timerWire.mode === 'legacy' && s.ncd !== undefined) {
         this.nodeCooldowns = new Map(Object.entries(s.ncd).map(([k, v]) => [k, Number(v)]));
       }
       if (s.achg !== undefined) {

--- a/src/net/snapshot_timer_wire.ts
+++ b/src/net/snapshot_timer_wire.ts
@@ -1,19 +1,14 @@
-export const STABLE_TIMER_WIRE_VERSION = 2 as const;
+import {
+  STABLE_TIMER_WIRE_VERSION,
+  type StableCooldownWire,
+  type StableTimerWireVersion,
+} from '../world_api';
 
-export type StableTimerWireVersion = typeof STABLE_TIMER_WIRE_VERSION;
+export type { StableCooldownWire, StableTimerWireVersion };
+export { STABLE_TIMER_WIRE_VERSION };
 
-/**
- * A cooldown's absolute wall schedule in server simulation seconds.
- *
- * A plain number is the expiry time for a cooldown recovering at 1x. The
- * tuple carries an expiry time plus a temporary recovery-rate segment. The
- * segment ends at `acceleratedUntil`; after that, recovery continues at 1x
- * until `expiresAt`.
- */
-export type StableCooldownWire =
-  | number
-  | readonly [expiresAt: number, recoveryRate: number, acceleratedUntil: number];
-
+// Unknown markers are isolated from both legacy and v2 decoding so a future
+// server cannot make an older client reinterpret fields it does not understand.
 export type SnapshotTimerWireMode = 'legacy' | 'stable' | 'unsupported';
 
 export function snapshotTimerWireMode(value: unknown): SnapshotTimerWireMode {
@@ -27,12 +22,20 @@ export function isStableTimerWireVersion(value: unknown): value is StableTimerWi
 }
 
 export function stableDeadlineRemaining(value: unknown, now: number): number | null {
-  if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isFinite(now)) return null;
-  return Math.max(0, value - now);
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    value < 0 ||
+    !Number.isFinite(now) ||
+    now < 0
+  )
+    return null;
+  const remaining = Math.max(0, value - now);
+  return Number.isFinite(remaining) ? remaining : null;
 }
 
 export function stableCooldownRemaining(value: unknown, now: number): number | null {
-  if (!Number.isFinite(now)) return null;
+  if (!Number.isFinite(now) || now < 0) return null;
   if (typeof value === 'number') return stableDeadlineRemaining(value, now);
   if (!Array.isArray(value) || value.length !== 3) return null;
 
@@ -40,18 +43,21 @@ export function stableCooldownRemaining(value: unknown, now: number): number | n
   if (
     typeof expiresAt !== 'number' ||
     !Number.isFinite(expiresAt) ||
+    expiresAt < 0 ||
     typeof recoveryRate !== 'number' ||
     !Number.isFinite(recoveryRate) ||
     recoveryRate <= 0 ||
     typeof acceleratedUntilRaw !== 'number' ||
-    !Number.isFinite(acceleratedUntilRaw)
+    !Number.isFinite(acceleratedUntilRaw) ||
+    acceleratedUntilRaw < 0
   )
     return null;
 
   const acceleratedUntil = Math.min(expiresAt, acceleratedUntilRaw);
-  if (now >= acceleratedUntil) return Math.max(0, expiresAt - now);
-  return Math.max(
+  if (now >= acceleratedUntil) return stableDeadlineRemaining(expiresAt, now);
+  const remaining = Math.max(
     0,
     (acceleratedUntil - now) * recoveryRate + Math.max(0, expiresAt - acceleratedUntil),
   );
+  return Number.isFinite(remaining) ? remaining : null;
 }

--- a/src/net/snapshot_timer_wire.ts
+++ b/src/net/snapshot_timer_wire.ts
@@ -1,0 +1,57 @@
+export const STABLE_TIMER_WIRE_VERSION = 2 as const;
+
+export type StableTimerWireVersion = typeof STABLE_TIMER_WIRE_VERSION;
+
+/**
+ * A cooldown's absolute wall schedule in server simulation seconds.
+ *
+ * A plain number is the expiry time for a cooldown recovering at 1x. The
+ * tuple carries an expiry time plus a temporary recovery-rate segment. The
+ * segment ends at `acceleratedUntil`; after that, recovery continues at 1x
+ * until `expiresAt`.
+ */
+export type StableCooldownWire =
+  | number
+  | readonly [expiresAt: number, recoveryRate: number, acceleratedUntil: number];
+
+export type SnapshotTimerWireMode = 'legacy' | 'stable' | 'unsupported';
+
+export function snapshotTimerWireMode(value: unknown): SnapshotTimerWireMode {
+  if (value === undefined) return 'legacy';
+  if (value === STABLE_TIMER_WIRE_VERSION) return 'stable';
+  return 'unsupported';
+}
+
+export function isStableTimerWireVersion(value: unknown): value is StableTimerWireVersion {
+  return value === STABLE_TIMER_WIRE_VERSION;
+}
+
+export function stableDeadlineRemaining(value: unknown, now: number): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isFinite(now)) return null;
+  return Math.max(0, value - now);
+}
+
+export function stableCooldownRemaining(value: unknown, now: number): number | null {
+  if (!Number.isFinite(now)) return null;
+  if (typeof value === 'number') return stableDeadlineRemaining(value, now);
+  if (!Array.isArray(value) || value.length !== 3) return null;
+
+  const [expiresAt, recoveryRate, acceleratedUntilRaw] = value;
+  if (
+    typeof expiresAt !== 'number' ||
+    !Number.isFinite(expiresAt) ||
+    typeof recoveryRate !== 'number' ||
+    !Number.isFinite(recoveryRate) ||
+    recoveryRate <= 0 ||
+    typeof acceleratedUntilRaw !== 'number' ||
+    !Number.isFinite(acceleratedUntilRaw)
+  )
+    return null;
+
+  const acceleratedUntil = Math.min(expiresAt, acceleratedUntilRaw);
+  if (now >= acceleratedUntil) return Math.max(0, expiresAt - now);
+  return Math.max(
+    0,
+    (acceleratedUntil - now) * recoveryRate + Math.max(0, expiresAt - acceleratedUntil),
+  );
+}

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -104,6 +104,19 @@ export type {
   DeedStats,
   OverheadEmoteId,
 } from './sim/types';
+
+// Snapshot timer wire capability shared by the browser mirror and authoritative
+// server. Keep the version exact so rolling deploys can negotiate fail-closed.
+export const STABLE_TIMER_WIRE_VERSION = 2 as const;
+export type StableTimerWireVersion = typeof STABLE_TIMER_WIRE_VERSION;
+
+// Absolute cooldown schedule in server simulation seconds. A number is the
+// expiry for 1x recovery. The tuple adds a temporary recovery-rate segment;
+// after acceleratedUntil, recovery continues at 1x until expiresAt.
+export type StableCooldownWire =
+  | number
+  | readonly [expiresAt: number, recoveryRate: number, acceleratedUntil: number];
+
 // --- facet aux-type + value re-exports (each travels with its facet file) ---
 export type { BankBonusSource, BankInfo } from './world_api/bank';
 export type { CardMinigameInfo } from './world_api/card_minigame';

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -331,7 +331,7 @@ describe('src/sim architecture invariants', () => {
 
 // ---------------------------------------------------------------------------
 // IWorld seam purity (W1b). The seam render/ui depend on is src/world_api.ts (the
-// aggregate interface + the COMMAND_NAMES wire table) plus every facet interface
+// aggregate interface + shared wire constants) plus every facet interface
 // under src/world_api/. W1 split IWorld into those files as a string-free,
 // TYPE-ONLY boundary: every host (render/ui/game/net) and the server talk to the
 // world ONLY through it, so it sits ABOVE them and must import nothing from
@@ -340,8 +340,9 @@ describe('src/sim architecture invariants', () => {
 // i18n/UI logic (no t()/tSim()/tServer()). Without this scan the facet files'
 // purity is convention-only; a later W6-W10 re-home could add a net/ui import or a
 // t() call to a facet and no gate would redden. This closes that gap. The one
-// blessed value site is COMMAND_NAMES (world_api.ts); string literals are NOT
-// banned (only imports + DOM + i18n calls are). chat.ts's OVERHEAD_EMOTES +
+// blessed value sites are local protocol constants such as COMMAND_NAMES and
+// STABLE_TIMER_WIRE_VERSION (world_api.ts); string literals are NOT banned (only
+// imports + DOM + i18n calls are). chat.ts's OVERHEAD_EMOTES +
 // isOverheadEmoteId derive their runtime id set from OVERHEAD_EMOTES itself
 // (not sim/types' OVERHEAD_EMOTE_IDS), so there is currently no sanctioned
 // runtime sim import; SANCTIONED_VALUE_SIM_IMPORTS below stays as the escape

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -477,6 +477,28 @@ describe('src/world_api IWorld seam purity invariants', () => {
   });
 });
 
+describe('server host-layer import invariants', () => {
+  it('does not import browser host layers from the authoritative server', () => {
+    const serverRoot = join(repoRoot, 'server');
+    const violations: string[] = [];
+    for (const file of walk(serverRoot)) {
+      const src = stripComments(readFileSync(file, 'utf8'));
+      const specs: string[] = [];
+      for (const match of src.matchAll(IMPORT_RE)) specs.push(match[1]);
+      for (const match of src.matchAll(DYN_IMPORT_RE)) specs.push(match[1]);
+      for (const spec of specs) {
+        if (/(?:^|\/)(?:render|ui|game|net)\//.test(spec)) {
+          violations.push(`${relative(repoRoot, file)} imports '${spec}'`);
+        }
+      }
+    }
+    expect(
+      violations,
+      `the authoritative server must not import browser host layers:\n${violations.join('\n')}`,
+    ).toEqual([]);
+  });
+});
+
 describe('src/ui pure-core invariants', () => {
   it('lists only files that exist (the curated pure cores)', () => {
     const missing = UI_PURE_CORES.filter((f) => !statSync(f).isFile());

--- a/tests/client_snapshot_timer_wire.test.ts
+++ b/tests/client_snapshot_timer_wire.test.ts
@@ -108,10 +108,7 @@ describe('stable snapshot timer protocol', () => {
     expect(stableDeadlineRemaining(1, -1)).toBeNull();
     expect(stableDeadlineRemaining(Number.MAX_VALUE, -Number.MAX_VALUE)).toBeNull();
     expect(
-      stableCooldownRemaining(
-        [Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE],
-        0,
-      ),
+      stableCooldownRemaining([Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE], 0),
     ).toBeNull();
   });
 

--- a/tests/client_snapshot_timer_wire.test.ts
+++ b/tests/client_snapshot_timer_wire.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { ClientWorld } from '../src/net/online';
-import { snapshotTimerWireMode, stableCooldownRemaining } from '../src/net/snapshot_timer_wire';
+import {
+  snapshotTimerWireMode,
+  stableCooldownRemaining,
+  stableDeadlineRemaining,
+} from '../src/net/snapshot_timer_wire';
 import type { PlayerClass } from '../src/sim/types';
 
 function bareClient(pid: number, playerClass: PlayerClass = 'warrior'): ClientWorld {
@@ -100,6 +104,33 @@ describe('stable snapshot timer protocol', () => {
     expect(stableCooldownRemaining(accelerated, 1)).toBe(2);
     expect(stableCooldownRemaining(accelerated, 3)).toBe(0);
     expect(stableCooldownRemaining([3, 0, 1], 0)).toBeNull();
+    expect(stableDeadlineRemaining(-1, 0)).toBeNull();
+    expect(stableDeadlineRemaining(1, -1)).toBeNull();
+    expect(stableDeadlineRemaining(Number.MAX_VALUE, -Number.MAX_VALUE)).toBeNull();
+    expect(
+      stableCooldownRemaining(
+        [Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE],
+        0,
+      ),
+    ).toBeNull();
+  });
+
+  it('ignores negative stable clocks without poisoning retained schedules', () => {
+    const client = bareClient(1);
+    apply(client, {
+      tw: 2,
+      time: 10,
+      self: playerWire(1, {
+        auras: [aura('retained', { exp: 20 })],
+        cds: { cast: 20 },
+      }),
+    });
+
+    apply(client, { tw: 2, time: -Number.MAX_VALUE, self: playerWire(1) });
+    apply(client, { tw: 2, time: 11, self: playerWire(1) });
+
+    expect(client.player.auras[0]).toMatchObject({ id: 'retained', remaining: 9 });
+    expect(client.player.cooldowns.get('cast')).toBe(9);
   });
 
   it('ages omitted v2 timers and preserves auras on moving lite records', () => {

--- a/tests/client_snapshot_timer_wire.test.ts
+++ b/tests/client_snapshot_timer_wire.test.ts
@@ -188,6 +188,10 @@ describe('stable snapshot timer protocol', () => {
     expect(client.player.auras[0].id).toBe('stable');
     expect(client.player.cooldowns.get('cast')).toBe(4);
 
+    apply(client, { tw: 2, time: 12, self: playerWire(1) });
+    expect(client.player.auras[0]).toMatchObject({ id: 'stable', remaining: 3 });
+    expect(client.player.cooldowns.get('cast')).toBe(3);
+
     apply(client, {
       time: 2,
       self: playerWire(1, { auras: [aura('legacy-again', { rem: 3 })], cds: { cast: 3 } }),

--- a/tests/client_snapshot_timer_wire.test.ts
+++ b/tests/client_snapshot_timer_wire.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+import { ClientWorld } from '../src/net/online';
+import { snapshotTimerWireMode, stableCooldownRemaining } from '../src/net/snapshot_timer_wire';
+import type { PlayerClass } from '../src/sim/types';
+
+function bareClient(pid: number, playerClass: PlayerClass = 'warrior'): ClientWorld {
+  const client: any = Object.create(ClientWorld.prototype);
+  client.cfg = { seed: 20061, playerClass };
+  client.entities = new Map();
+  client.playerId = pid;
+  client.ownPlayerId = pid;
+  client.ownPlayerClass = playerClass;
+  client.spectating = null;
+  client.cupInfo = null;
+  client.sportRole = null;
+  client.moveInput = {};
+  client.inventory = [];
+  client.vendorBuyback = [];
+  client.equipment = {};
+  client.accountCosmetics = { completedQuestIds: [], mechChromaIds: [] };
+  client.copper = 0;
+  client.honor = 0;
+  client.lifetimeHonor = 0;
+  client.xp = 0;
+  client.known = [];
+  client.questLog = new Map();
+  client.questsDone = new Set();
+  client.pendingQuestCommands = new Map();
+  client.partyInfo = null;
+  client.selectedDungeonDifficulty = 'normal';
+  client.tradeInfo = null;
+  client.duelInfo = null;
+  client.lastSnapAt = 0;
+  client.snapInterval = 50;
+  client.serverTickHz = null;
+  client.missingSince = new Map();
+  client.pendingFacingDelta = 0;
+  client.connected = true;
+  client.eventQueue = [];
+  client.mouselookFacing = null;
+  client.lastInputSentAt = 0;
+  client.lastInputSig = '';
+  client.inputSeq = 0;
+  client.pendingInputSeqSentAt = new Map();
+  client.ackedInputSeq = 0;
+  client.inputEchoSamples = [];
+  client.spectateFacingPending = false;
+  client.pendingSpectateFacing = null;
+  client.nodeCooldowns = new Map();
+  return client;
+}
+
+function playerWire(id: number, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id,
+    k: 'player',
+    tid: 'warrior',
+    nm: `Player${id}`,
+    lv: 20,
+    x: 0,
+    y: 0,
+    z: 0,
+    f: 0,
+    hp: 100,
+    mhp: 100,
+    res: 0,
+    mres: 100,
+    rtype: 'rage',
+    ...extra,
+  };
+}
+
+function apply(client: ClientWorld, snapshot: Record<string, unknown>): void {
+  (client as unknown as { applySnapshot(value: unknown): void }).applySnapshot({
+    t: 'snap',
+    tick: 1,
+    ents: [],
+    ...snapshot,
+  });
+}
+
+const aura = (id: string, timer: Record<string, number>): Record<string, unknown> => ({
+  id,
+  name: id,
+  kind: 'buff_ap',
+  dur: 10,
+  ...timer,
+});
+
+describe('stable snapshot timer protocol', () => {
+  it('negotiates exact v2 only and decodes named cooldown schedules', () => {
+    expect(snapshotTimerWireMode(undefined)).toBe('legacy');
+    expect(snapshotTimerWireMode(2)).toBe('stable');
+    expect(snapshotTimerWireMode('2')).toBe('unsupported');
+    expect(snapshotTimerWireMode(3)).toBe('unsupported');
+
+    const accelerated = [3, 3, 1];
+    expect(stableCooldownRemaining(accelerated, 0)).toBe(5);
+    expect(stableCooldownRemaining(accelerated, 0.5)).toBe(3.5);
+    expect(stableCooldownRemaining(accelerated, 1)).toBe(2);
+    expect(stableCooldownRemaining(accelerated, 3)).toBe(0);
+    expect(stableCooldownRemaining([3, 0, 1], 0)).toBeNull();
+  });
+
+  it('ages omitted v2 timers and preserves auras on moving lite records', () => {
+    const client = bareClient(1);
+    apply(client, {
+      tw: 2,
+      time: 10,
+      ents: [playerWire(2, { auras: [aura('remote', { exp: 20 })] })],
+      self: playerWire(1, {
+        auras: [aura('self', { exp: 15 })],
+        cds: { cast: 15, accelerated: [13, 3, 11] },
+        ncd: { ore: 12 },
+      }),
+    });
+    expect(client.entities.get(2)?.auras[0].remaining).toBe(10);
+    expect(client.player.auras[0].remaining).toBe(5);
+    expect(client.player.cooldowns.get('cast')).toBe(5);
+    expect(client.player.cooldowns.get('accelerated')).toBe(5);
+    expect(client.nodeHarvestableByMe('ore')).toBe(false);
+
+    apply(client, {
+      tw: 2,
+      time: 11,
+      ents: [{ id: 2, x: 1, y: 0, z: 0, f: 0, hp: 100, mhp: 100 }],
+      self: playerWire(1),
+    });
+    expect(client.entities.get(2)?.auras[0].remaining).toBe(9);
+    expect(client.player.auras[0].remaining).toBe(4);
+    expect(client.player.cooldowns.get('cast')).toBe(4);
+    expect(client.player.cooldowns.get('accelerated')).toBe(2);
+
+    apply(client, { tw: 2, time: 13.1, keep: [2], self: playerWire(1) });
+    expect(client.nodeHarvestableByMe('ore')).toBe(true);
+    expect(client.player.cooldowns.has('accelerated')).toBe(false);
+    expect(client.player.cooldowns.get('cast')).toBeCloseTo(1.9, 8);
+
+    apply(client, {
+      tw: 2,
+      time: 13.1,
+      ents: [{ id: 2, x: 2, y: 0, z: 0, f: 0, hp: 100, mhp: 100, auras: [] }],
+      self: playerWire(1, { cds: {} }),
+    });
+    expect(client.entities.get(2)?.auras).toEqual([]);
+    expect(client.player.cooldowns.size).toBe(0);
+  });
+
+  it('freezes retained auras while ordinary cooldown deadlines continue', () => {
+    const client = bareClient(1);
+    apply(client, {
+      tw: 2,
+      time: 0,
+      self: playerWire(1, { auras: [aura('retained', { exp: 5 })], cds: { cast: 5 } }),
+    });
+    apply(client, {
+      tw: 2,
+      time: 1,
+      self: playerWire(1, { dead: 1, hp: 0, auras: [aura('retained', { rem: 4 })] }),
+    });
+    apply(client, { tw: 2, time: 2, self: playerWire(1, { dead: 1, hp: 0 }) });
+    expect(client.player.auras[0].remaining).toBe(4);
+    expect(client.player.cooldowns.get('cast')).toBe(3);
+  });
+
+  it('keeps v1 and v2 absence semantics isolated across rolling transitions', () => {
+    const client = bareClient(1);
+    apply(client, {
+      time: 1,
+      self: playerWire(1, { auras: [aura('legacy', { rem: 5 })], cds: { cast: 5 } }),
+    });
+    expect(client.player.auras[0].remaining).toBe(5);
+
+    apply(client, {
+      tw: 2,
+      time: 10,
+      self: playerWire(1, { auras: [aura('stable', { exp: 15 })], cds: { cast: 15 } }),
+    });
+    apply(client, { tw: 2, time: 11, self: playerWire(1) });
+    expect(client.player.auras[0]).toMatchObject({ id: 'stable', remaining: 4 });
+    expect(client.player.cooldowns.get('cast')).toBe(4);
+
+    apply(client, {
+      tw: 3,
+      time: 12,
+      self: playerWire(1, { auras: [aura('future', { exp: 99 })], cds: { cast: 99 } }),
+    });
+    expect(client.player.auras[0].id).toBe('stable');
+    expect(client.player.cooldowns.get('cast')).toBe(4);
+
+    apply(client, {
+      time: 2,
+      self: playerWire(1, { auras: [aura('legacy-again', { rem: 3 })], cds: { cast: 3 } }),
+    });
+    expect(client.player.auras[0]).toMatchObject({ id: 'legacy-again', remaining: 3 });
+    expect(client.player.cooldowns.get('cast')).toBe(3);
+    apply(client, { time: 2.05, self: playerWire(1) });
+    expect(client.player.auras).toEqual([]);
+  });
+});

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -85,6 +85,7 @@ describe('websocket authentication', () => {
       token: 'a'.repeat(64),
       character: 42,
       clientSeed: '',
+      timerWire: 2,
     });
   });
 
@@ -94,6 +95,7 @@ describe('websocket authentication', () => {
       token: 'a'.repeat(64),
       character: 42,
       clientSeed: 'seed-123',
+      timerWire: 2,
     });
   });
 });

--- a/tests/server/ws_auth.test.ts
+++ b/tests/server/ws_auth.test.ts
@@ -111,6 +111,11 @@ function setup() {
   return { ws, game, session, deps, req };
 }
 
+function joinedMeta(game: ReturnType<typeof setup>['game']): Record<string, unknown> {
+  const calls = game.join.mock.calls as unknown as unknown[][];
+  return calls[0][7] as Record<string, unknown>;
+}
+
 const authRaw = (over: Record<string, unknown> = {}) =>
   JSON.stringify({ t: 'auth', token: 'tok', character: 7, ...over });
 
@@ -287,12 +292,12 @@ describe('createWsAuth: timer-wire capability negotiation', () => {
       capable.req,
     );
     expect(capable.game.join).toHaveBeenCalledTimes(1);
-    expect(capable.game.join.mock.calls[0][7]).toMatchObject({ timerWireVersion: 2 });
+    expect(joinedMeta(capable.game)).toMatchObject({ timerWireVersion: 2 });
 
     const legacy = setup();
     await createWsAuth(legacy.deps).authenticateWebSocket(asWs(legacy.ws), authRaw(), legacy.req);
     expect(legacy.game.join).toHaveBeenCalledTimes(1);
-    expect(legacy.game.join.mock.calls[0][7]).toMatchObject({ timerWireVersion: 1 });
+    expect(joinedMeta(legacy.game)).toMatchObject({ timerWireVersion: 1 });
 
     const unknown = setup();
     await createWsAuth(unknown.deps).authenticateWebSocket(
@@ -301,7 +306,28 @@ describe('createWsAuth: timer-wire capability negotiation', () => {
       unknown.req,
     );
     expect(unknown.game.join).toHaveBeenCalledTimes(1);
-    expect(unknown.game.join.mock.calls[0][7]).toMatchObject({ timerWireVersion: 1 });
+    expect(joinedMeta(unknown.game)).toMatchObject({ timerWireVersion: 1 });
+
+    for (const coercible of ['2', true, { valueOf: () => 2 }]) {
+      const strict = setup();
+      await createWsAuth(strict.deps).authenticateWebSocket(
+        asWs(strict.ws),
+        authRaw({ timerWire: coercible }),
+        strict.req,
+      );
+      expect(strict.game.join).toHaveBeenCalledTimes(1);
+      expect(joinedMeta(strict.game)).toMatchObject({ timerWireVersion: 1 });
+    }
+
+    const resume = setup();
+    resume.game.hasSessionForCharacter.mockReturnValue(true);
+    await createWsAuth(resume.deps).authenticateWebSocket(
+      asWs(resume.ws),
+      authRaw({ timerWire: 2 }),
+      resume.req,
+    );
+    expect(resume.deps.acquireCharacterLease).not.toHaveBeenCalled();
+    expect(joinedMeta(resume.game)).toMatchObject({ timerWireVersion: 2 });
   });
 });
 

--- a/tests/server/ws_auth.test.ts
+++ b/tests/server/ws_auth.test.ts
@@ -278,6 +278,33 @@ describe('createWsAuth: authenticateWebSocket reject paths', () => {
   });
 });
 
+describe('createWsAuth: timer-wire capability negotiation', () => {
+  it('passes only the exact optional v2 capability into the recipient session meta', async () => {
+    const capable = setup();
+    await createWsAuth(capable.deps).authenticateWebSocket(
+      asWs(capable.ws),
+      authRaw({ timerWire: 2 }),
+      capable.req,
+    );
+    expect(capable.game.join).toHaveBeenCalledTimes(1);
+    expect(capable.game.join.mock.calls[0][7]).toMatchObject({ timerWireVersion: 2 });
+
+    const legacy = setup();
+    await createWsAuth(legacy.deps).authenticateWebSocket(asWs(legacy.ws), authRaw(), legacy.req);
+    expect(legacy.game.join).toHaveBeenCalledTimes(1);
+    expect(legacy.game.join.mock.calls[0][7]).toMatchObject({ timerWireVersion: 1 });
+
+    const unknown = setup();
+    await createWsAuth(unknown.deps).authenticateWebSocket(
+      asWs(unknown.ws),
+      authRaw({ timerWire: 99 }),
+      unknown.req,
+    );
+    expect(unknown.game.join).toHaveBeenCalledTimes(1);
+    expect(unknown.game.join.mock.calls[0][7]).toMatchObject({ timerWireVersion: 1 });
+  });
+});
+
 describe('createWsAuth: realm admission cap', () => {
   it('a. refuses an at-cap fresh join with "realm is full", before the lease and the join', async () => {
     const { ws, game, deps, req } = setup();

--- a/tests/snapshot_timer_wire.test.ts
+++ b/tests/snapshot_timer_wire.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { StableAuraWireCache, StableSelfTimerWireCache } from '../server/snapshot_timer_wire';
+import {
+  jsonWithField,
+  StableAuraWireCache,
+  StableSelfTimerWireCache,
+} from '../server/snapshot_timer_wire';
 import type { Aura, Entity } from '../src/sim/types';
 
 function aura(id: string, remaining: number): Aura {
@@ -22,6 +26,14 @@ function timerEntity(
 ): Pick<Entity, 'cooldowns' | 'auras' | 'dead'> {
   return { cooldowns, auras, dead };
 }
+
+describe('jsonWithField', () => {
+  it('adds the first field to an empty serialized object without a leading comma', () => {
+    const json = jsonWithField('{}', 'auras', '[]');
+
+    expect(JSON.parse(json)).toEqual({ auras: [] });
+  });
+});
 
 describe('StableAuraWireCache', () => {
   it('does not rebuild while live remaining time and sim time advance together', () => {

--- a/tests/snapshot_timer_wire.test.ts
+++ b/tests/snapshot_timer_wire.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import { StableAuraWireCache, StableSelfTimerWireCache } from '../server/snapshot_timer_wire';
+import type { Aura, Entity } from '../src/sim/types';
+
+function aura(id: string, remaining: number): Aura {
+  return {
+    id,
+    name: id,
+    kind: 'buff_ap',
+    remaining,
+    duration: remaining,
+    value: 4,
+    sourceId: 0,
+    school: 'physical',
+  };
+}
+
+function timerEntity(
+  cooldowns: Map<string, number>,
+  auras: Aura[] = [],
+  dead = false,
+): Pick<Entity, 'cooldowns' | 'auras' | 'dead'> {
+  return { cooldowns, auras, dead };
+}
+
+describe('StableAuraWireCache', () => {
+  it('does not rebuild while live remaining time and sim time advance together', () => {
+    const cache = new StableAuraWireCache();
+    const active = aura('long_buff', 10);
+    const first = cache.encode([active], 4, false);
+    expect(JSON.parse(first.json)).toEqual([expect.objectContaining({ id: 'long_buff', exp: 14 })]);
+    expect(cache.rebuilds).toBe(1);
+
+    active.remaining = 9.25;
+    const second = cache.encode([active], 4.75, false);
+    expect(second).toBe(first);
+    expect(cache.rebuilds).toBe(1);
+  });
+
+  it('rebuilds for every wire-visible mutation and explicit empty removal', () => {
+    const cache = new StableAuraWireCache();
+    const first = aura('first', 10);
+    const second = aura('second', 12);
+    cache.encode([first, second], 0, false);
+
+    first.remaining = 20;
+    expect(cache.encode([first, second], 0.1, false).revision).toBe(2);
+    second.value = 8;
+    expect(cache.encode([first, second], 0.1, false).revision).toBe(3);
+    second.stacks = 2;
+    expect(cache.encode([first, second], 0.1, false).revision).toBe(4);
+    second.charges = 3;
+    expect(cache.encode([first, second], 0.1, false).revision).toBe(5);
+    expect(cache.encode([second, first], 0.1, false).revision).toBe(6);
+    const removed = cache.encode([], 0.1, false);
+    expect(removed.revision).toBe(7);
+    expect(removed.json).toBe('[]');
+    expect(cache.rebuilds).toBe(7);
+  });
+
+  it('uses a stable frozen remaining value while dead and resumes an expiry when alive', () => {
+    const cache = new StableAuraWireCache();
+    const retained = aura('retained', 8);
+    cache.encode([retained], 2, false);
+
+    const frozen = cache.encode([retained], 2, true);
+    expect(JSON.parse(frozen.json)[0]).toMatchObject({ rem: 8 });
+    expect(JSON.parse(frozen.json)[0]).not.toHaveProperty('exp');
+    const rebuilds = cache.rebuilds;
+    expect(cache.encode([retained], 9, true)).toBe(frozen);
+    expect(cache.rebuilds).toBe(rebuilds);
+
+    const resumed = cache.encode([retained], 9, false);
+    expect(JSON.parse(resumed.json)[0]).toMatchObject({ exp: 17 });
+    expect(JSON.parse(resumed.json)[0]).not.toHaveProperty('rem');
+  });
+});
+
+describe('StableSelfTimerWireCache', () => {
+  it('reuses cooldown, node, and charge JSON until their semantic state changes', () => {
+    const cache = new StableSelfTimerWireCache();
+    const cooldowns = new Map([['cast', 5]]);
+    const entity = timerEntity(cooldowns);
+    const nodes: Record<string, number> = { ore: 30 };
+    const charges = {
+      cast: { charges: 1, maxCharges: 2, recharge: 5, rechargeLength: 5 },
+    };
+
+    const firstCooldowns = cache.encodeCooldowns(7, entity, 0);
+    const firstNodes = cache.encodeNodeCooldowns(7, nodes, 0);
+    const firstCharges = cache.encodeCharges(7, charges);
+    cooldowns.set('cast', 4.5);
+    expect(cache.encodeCooldowns(7, entity, 0.5)).toBe(firstCooldowns);
+    expect(cache.encodeNodeCooldowns(7, nodes, 0.5)).toBe(firstNodes);
+    expect(cache.encodeCharges(7, charges)).toBe(firstCharges);
+    expect(cache.cooldownRebuilds).toBe(1);
+    expect(cache.nodeCooldownRebuilds).toBe(1);
+    expect(cache.chargeRebuilds).toBe(1);
+
+    cooldowns.clear();
+    delete nodes.ore;
+    charges.cast.charges = 2;
+    expect(cache.encodeCooldowns(7, entity, 0.5).json).toBe('{}');
+    expect(cache.encodeNodeCooldowns(7, nodes, 0.5).json).toBe('{}');
+    expect(cache.encodeCharges(7, charges).json).toBe('{"cast":2}');
+    expect(cache.cooldownRebuilds).toBe(2);
+    expect(cache.nodeCooldownRebuilds).toBe(2);
+    expect(cache.chargeRebuilds).toBe(2);
+  });
+
+  it('keeps an accelerated Hourglass schedule stable, then revises it on expiry or removal', () => {
+    const cache = new StableSelfTimerWireCache();
+    const cooldowns = new Map([
+      ['cast', 5],
+      ['temporal_hourglass', 5],
+    ]);
+    const hourglass: Aura = {
+      ...aura('temporal_hourglass', 1),
+      kind: 'stasis',
+      value: 3,
+    };
+    const entity = timerEntity(cooldowns, [hourglass]);
+    const first = cache.encodeCooldowns(1, entity, 0);
+    expect(JSON.parse(first.json)).toEqual({ cast: [3, 3, 1], temporal_hourglass: 5 });
+
+    cooldowns.set('cast', 3.5);
+    cooldowns.set('temporal_hourglass', 4.5);
+    hourglass.remaining = 0.5;
+    expect(cache.encodeCooldowns(1, entity, 0.5)).toBe(first);
+
+    cooldowns.set('cast', 2);
+    cooldowns.set('temporal_hourglass', 4);
+    entity.auras.length = 0;
+    const expired = cache.encodeCooldowns(1, entity, 1);
+    expect(JSON.parse(expired.json)).toEqual({ cast: 3, temporal_hourglass: 5 });
+    expect(expired.revision).toBe(first.revision + 1);
+  });
+
+  it('resets all sub-caches when a spectator changes anchor owner', () => {
+    const cache = new StableSelfTimerWireCache();
+    const state = timerEntity(new Map([['cast', 5]]));
+    const first = cache.encodeCooldowns(1, state, 0);
+    expect(cache.encodeCooldowns(1, state, 0)).toBe(first);
+    const other = cache.encodeCooldowns(2, state, 0);
+    expect(other).not.toBe(first);
+    expect(cache.cooldownRebuilds).toBe(2);
+  });
+});

--- a/tests/snapshot_timer_wire.test.ts
+++ b/tests/snapshot_timer_wire.test.ts
@@ -43,19 +43,73 @@ describe('StableAuraWireCache', () => {
     const second = aura('second', 12);
     cache.encode([first, second], 0, false);
 
-    first.remaining = 20;
-    expect(cache.encode([first, second], 0.1, false).revision).toBe(2);
-    second.value = 8;
-    expect(cache.encode([first, second], 0.1, false).revision).toBe(3);
-    second.stacks = 2;
-    expect(cache.encode([first, second], 0.1, false).revision).toBe(4);
-    second.charges = 3;
-    expect(cache.encode([first, second], 0.1, false).revision).toBe(5);
-    expect(cache.encode([second, first], 0.1, false).revision).toBe(6);
+    const mutations = [
+      () => {
+        first.remaining = 20;
+      },
+      () => {
+        first.name = 'renamed';
+      },
+      () => {
+        first.kind = 'buff_int';
+      },
+      () => {
+        first.duration = 21;
+      },
+      () => {
+        second.value = 8;
+      },
+      () => {
+        second.value2 = 9;
+      },
+      () => {
+        second.value3 = 10;
+      },
+      () => {
+        second.tickInterval = 2;
+      },
+      () => {
+        second.school = 'arcane';
+      },
+      () => {
+        second.stacks = 2;
+      },
+      () => {
+        second.charges = 3;
+      },
+      () => {
+        second.empowerAbilities = ['cast_a', 'cast_b'];
+      },
+      () => {
+        second.empowerAbilities?.reverse();
+      },
+      () => {
+        second.sourceId = 42;
+      },
+    ];
+    let revision = 1;
+    for (const mutate of mutations) {
+      mutate();
+      expect(cache.encode([first, second], 0.1, false).revision).toBe(++revision);
+    }
+    expect(cache.encode([second, first], 0.1, false).revision).toBe(++revision);
     const removed = cache.encode([], 0.1, false);
-    expect(removed.revision).toBe(7);
+    expect(removed.revision).toBe(++revision);
     expect(removed.json).toBe('[]');
-    expect(cache.rebuilds).toBe(7);
+    expect(cache.rebuilds).toBe(revision);
+  });
+
+  it('absorbs floating-point drift across hundreds of ordinary ticks', () => {
+    const cache = new StableAuraWireCache();
+    const active = aura('drift', 20);
+    const first = cache.encode([active], 0, false);
+    let simTime = 0;
+    for (let i = 0; i < 200; i++) {
+      simTime += 0.05;
+      active.remaining -= 0.05;
+      expect(cache.encode([active], simTime, false)).toBe(first);
+    }
+    expect(cache.rebuilds).toBe(1);
   });
 
   it('uses a stable frozen remaining value while dead and resumes an expiry when alive', () => {
@@ -134,6 +188,50 @@ describe('StableSelfTimerWireCache', () => {
     const expired = cache.encodeCooldowns(1, entity, 1);
     expect(JSON.parse(expired.json)).toEqual({ cast: 3, temporal_hourglass: 5 });
     expect(expired.revision).toBe(first.revision + 1);
+  });
+
+  it('keeps a dead retained Hourglass schedule stable while normal cooldown work advances', () => {
+    const cache = new StableSelfTimerWireCache();
+    const hourglass: Aura = {
+      ...aura('temporal_hourglass', 2),
+      kind: 'stasis',
+      value: 2,
+    };
+    const cooldowns = new Map([['cast', 6]]);
+    const entity = timerEntity(cooldowns, [hourglass], true);
+    const first = cache.encodeCooldowns(1, entity, 4);
+    expect(JSON.parse(first.json)).toEqual({ cast: [7, 2, 7] });
+
+    cooldowns.set('cast', 5);
+    expect(cache.encodeCooldowns(1, entity, 4.5)).toBe(first);
+    expect(hourglass.remaining).toBe(2);
+  });
+
+  it('revises same-tick cooldown changes but ignores charge recharge countdown churn', () => {
+    const cache = new StableSelfTimerWireCache();
+    const cooldowns = new Map([['cast', 5]]);
+    const entity = timerEntity(cooldowns);
+    const firstCooldowns = cache.encodeCooldowns(1, entity, 10);
+    cooldowns.set('cast', 4);
+    const reduced = cache.encodeCooldowns(1, entity, 10);
+    expect(reduced).not.toBe(firstCooldowns);
+    expect(JSON.parse(reduced.json)).toEqual({ cast: 14 });
+
+    const charges = {
+      cast: {
+        charges: 1,
+        maxCharges: 2,
+        recharge: 4,
+        rechargeLength: 5,
+        recharges: [4],
+      },
+    };
+    const firstCharges = cache.encodeCharges(1, charges);
+    charges.cast.recharge = 3.5;
+    charges.cast.recharges[0] = 3.5;
+    expect(cache.encodeCharges(1, charges)).toBe(firstCharges);
+    charges.cast.charges = 2;
+    expect(cache.encodeCharges(1, charges)).not.toBe(firstCharges);
   });
 
   it('resets all sub-caches when a spectator changes anchor owner', () => {

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -4380,4 +4380,108 @@ describe('negotiated stable timer wire v2', () => {
     expect(client.player.auras[0].remaining).toBeCloseTo(5.85, 5);
     expect(client.player.cooldowns.get('old_cast')).toBeCloseTo(3.85, 5);
   });
+
+  it('omits stable auras from moving lite records, then sends an explicit remote removal', () => {
+    const server = new GameServer();
+    const viewerWs = fakeWs();
+    const subjectWs = fakeWs();
+    const viewer = joinServer(server, viewerWs, 1, 'MovingViewer', 'mage', timerV2);
+    const subject = joinServer(server, subjectWs, 2, 'MovingSubject', 'mage');
+    const subjectEntity = server.sim.entities.get(subject.pid)!;
+    subjectEntity.auras = [testAura('moving_aura', 20)];
+
+    broadcast(server);
+    const first = lastSnap(viewerWs.sent);
+    const client = bareClient(viewer.pid, 'mage');
+    (client as any).applySnapshot(first);
+    expect(client.entities.get(subject.pid)?.auras[0].remaining).toBe(20);
+
+    viewerWs.sent.length = 0;
+    server.sim.tick();
+    subjectEntity.pos.x += 1;
+    subjectEntity.prevPos.x += 1;
+    server.sim.grid.update(subjectEntity);
+    broadcast(server);
+    const moving = lastSnap(viewerWs.sent);
+    const lite = moving.ents.find((entity: any) => entity.id === subject.pid);
+    expect(lite).toBeDefined();
+    expect(lite.k).toBeUndefined();
+    expect(lite).not.toHaveProperty('auras');
+    (client as any).applySnapshot(moving);
+    expect(client.entities.get(subject.pid)?.auras[0].remaining).toBeCloseTo(19.95, 5);
+
+    subjectEntity.auras = [];
+    viewerWs.sent.length = 0;
+    server.sim.tick();
+    broadcast(server);
+    const removed = lastSnap(viewerWs.sent);
+    const removalRow = removed.ents.find((entity: any) => entity.id === subject.pid);
+    expect(removalRow.auras).toEqual([]);
+    (client as any).applySnapshot(removed);
+    expect(client.entities.get(subject.pid)?.auras).toEqual([]);
+  });
+
+  it('retains a remote aura revision across a non-due distance-tier tick', () => {
+    const server = new GameServer();
+    const viewerWs = fakeWs();
+    const subjectWs = fakeWs();
+    const viewer = joinServer(server, viewerWs, 1, 'DeferredViewer', 'mage', timerV2);
+    const subject = joinServer(server, subjectWs, 2, 'DeferredSubject', 'mage');
+    const viewerEntity = server.sim.entities.get(viewer.pid)!;
+    const subjectEntity = server.sim.entities.get(subject.pid)!;
+    subjectEntity.auras = [testAura('deferred_aura', 20, 2)];
+    subjectEntity.pos.x = viewerEntity.pos.x + 60;
+    subjectEntity.pos.z = viewerEntity.pos.z;
+    subjectEntity.prevPos = { ...subjectEntity.pos };
+    server.sim.grid.update(subjectEntity);
+
+    broadcast(server);
+    expect(lastSnap(viewerWs.sent).ents.some((entity: any) => entity.id === subject.pid)).toBe(
+      true,
+    );
+
+    server.sim.tick();
+    subjectEntity.auras[0].value = 9;
+    viewerWs.sent.length = 0;
+    broadcast(server);
+    const deferred = lastSnap(viewerWs.sent);
+    expect(deferred.ents.find((entity: any) => entity.id === subject.pid)).toBeUndefined();
+    expect(deferred.keep).toContain(subject.pid);
+
+    server.sim.tick();
+    viewerWs.sent.length = 0;
+    broadcast(server);
+    const delivered = lastSnap(viewerWs.sent).ents.find((entity: any) => entity.id === subject.pid);
+    expect(delivered.k).toBeUndefined();
+    expect(delivered.auras[0]).toMatchObject({ id: 'deferred_aura', value: 9 });
+  });
+
+  it('eliminates stable aura rebuild churn and aggregate bytes over 160 ticks', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'LongWindow', 'mage');
+    const player = server.sim.entities.get(session.pid)!;
+    player.auras = [testAura('long_window', 60)];
+    const internals = server as any;
+    internals.perfDetailActive = true;
+    internals.bcBaseSerializes = 0;
+    internals.bcLegacySerializes = 0;
+    internals.bcStableSerializes = 0;
+    let legacyBytes = 0;
+    let stableBytes = 0;
+
+    for (let i = 0; i < 160; i++) {
+      const legacy = internals.wireCacheFor(player, false);
+      const stable = internals.wireCacheFor(player, true);
+      legacyBytes += (i === 0 ? legacy.fullJson : legacy.liteJson).length;
+      stableBytes += i === 0 ? stable.fullAuraJson.length : `{"keep":[${player.id}]}`.length;
+      if (i < 159) server.sim.tick();
+    }
+
+    expect(internals.bcBaseSerializes).toBe(160);
+    expect(internals.bcLegacySerializes).toBeGreaterThan(150);
+    expect(internals.bcStableSerializes).toBe(1);
+    expect(internals.wireCache.get(player.id).auraCache.rebuilds).toBe(1);
+    expect(stableBytes).toBeLessThan(legacyBytes * 0.35);
+  });
 });

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('../server/db', () => ({
   pool: { query: vi.fn(async () => ({ rows: [] })) },
   saveCharacterState: vi.fn(async () => {}),
+  saveCharacterAndMarketState: vi.fn(async () => {}),
   openPlaySession: vi.fn(async () => 1),
   touchCharacterLogin: vi.fn(async () => {}),
   closePlaySession: vi.fn(async () => {}),
@@ -19,6 +20,7 @@ vi.mock('../server/db', () => ({
     weaponSkinIds: [],
     weaponSkinLoadout: {},
   })),
+  loadAccountFlair: vi.fn(async () => ({ ai: false, streamer: false, links: {} })),
 }));
 
 import { saveCharacterState } from '../server/db';
@@ -77,8 +79,9 @@ function joinServer(
   characterId: number,
   name: string,
   cls: PlayerClass = 'warrior',
+  meta: Parameters<GameServer['join']>[7] = {},
 ): ClientSession {
-  const session = server.join(fc.ws, characterId, characterId, name, cls, null);
+  const session = server.join(fc.ws, characterId, characterId, name, cls, null, false, meta);
   if ('error' in session) throw new Error(session.error);
   session.blockListLoaded = true;
   return session;
@@ -3976,5 +3979,405 @@ describe('authoritative interaction command outcomes', () => {
     expect(fc.sent).toContainEqual({ t: 'commandOutcome', rid: 43, ok: true });
     expect(server.sim.countItem('supply_crate', session.pid)).toBe(1);
     expect(object.lootable).toBe(false);
+  });
+});
+
+describe('negotiated stable timer wire v2', () => {
+  const timerV2 = { timerWireVersion: 2 } as unknown as Parameters<GameServer['join']>[7];
+
+  function testAura(id: string, remaining: number, value = 7): Aura {
+    return {
+      id,
+      name: id,
+      kind: 'buff_ap',
+      remaining,
+      duration: remaining,
+      value,
+      sourceId: 0,
+      school: 'physical',
+    };
+  }
+
+  it('keeps an unnegotiated recipient on the legacy remaining-time wire', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'Legacy', 'mage');
+    const player = server.sim.entities.get(session.pid)!;
+    const meta = server.sim.meta(session.pid)!;
+    player.auras = [];
+    player.auras.push(testAura('legacy_aura', 10));
+    player.cooldowns.set('legacy_cast', 5);
+    meta.nodeHarvestReadyAt.legacy_node = server.sim.time + 30;
+
+    broadcast(server);
+    const first = lastSnap(fc.sent);
+    expect(first.tw).toBeUndefined();
+    expect(first.self.auras[0]).toMatchObject({ id: 'legacy_aura', rem: 10 });
+    expect(first.self.auras[0]).not.toHaveProperty('exp');
+    expect(first.self.cds.legacy_cast).toBe(5);
+    expect(first.self.ncd.legacy_node).toBe(30);
+
+    fc.sent.length = 0;
+    server.sim.tick();
+    broadcast(server);
+    const second = lastSnap(fc.sent);
+    expect(second.self.auras[0].rem).toBeLessThan(10);
+    expect(second.self.cds.legacy_cast).toBeLessThan(5);
+    expect(second.self.ncd.legacy_node).toBeLessThan(30);
+  });
+
+  it('sends a complete stable first snapshot, then ages omitted timers across skipped ticks', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'Stable', 'mage', timerV2);
+    const player = server.sim.entities.get(session.pid)!;
+    const meta = server.sim.meta(session.pid)!;
+    player.auras = [];
+    player.auras.push(testAura('stable_aura', 10));
+    player.cooldowns.set('stable_cast', 5);
+    player.abilityCharges = {
+      stable_cast: {
+        charges: 1,
+        maxCharges: 2,
+        recharge: 5,
+        rechargeLength: 5,
+        recharges: [5],
+      },
+    };
+    meta.nodeHarvestReadyAt.stable_node = server.sim.time + 30;
+
+    broadcast(server);
+    const first = lastSnap(fc.sent);
+    expect(first.tw).toBe(2);
+    expect(first.self.auras[0]).toMatchObject({ id: 'stable_aura', exp: 10 });
+    expect(first.self.auras[0]).not.toHaveProperty('rem');
+    expect(first.self.cds.stable_cast).toBe(5);
+    expect(first.self.achg.stable_cast).toBe(1);
+    expect(first.self.ncd.stable_node).toBe(30);
+
+    const client = bareClient(session.pid);
+    (client as any).applySnapshot(first);
+    expect(client.player.auras[0].remaining).toBe(10);
+    expect(client.player.cooldowns.get('stable_cast')).toBe(5);
+    expect(client.nodeHarvestableByMe('stable_node')).toBe(false);
+
+    fc.sent.length = 0;
+    for (let i = 0; i < 5; i++) server.sim.tick();
+    broadcast(server);
+    const later = lastSnap(fc.sent);
+    expect(later.tick - first.tick).toBe(5);
+    expect(later.self).not.toHaveProperty('auras');
+    expect(later.self).not.toHaveProperty('cds');
+    expect(later.self).not.toHaveProperty('achg');
+    expect(later.self).not.toHaveProperty('ncd');
+
+    (client as any).applySnapshot(later);
+    expect(client.player.auras[0].remaining).toBeCloseTo(9.75, 5);
+    expect(client.player.cooldowns.get('stable_cast')).toBeCloseTo(4.75, 5);
+    expect(client.nodeHarvestableByMe('stable_node')).toBe(false);
+
+    player.auras.length = 0;
+    player.cooldowns.clear();
+    player.abilityCharges.stable_cast.charges = 2;
+    meta.nodeHarvestReadyAt.stable_node = server.sim.time - 1;
+    fc.sent.length = 0;
+    broadcast(server);
+    const cleared = lastSnap(fc.sent);
+    expect(cleared.self.auras).toEqual([]);
+    expect(cleared.self.cds).toEqual({});
+    expect(cleared.self.achg).toEqual({ stable_cast: 2 });
+    expect(cleared.self.ncd).toEqual({});
+
+    (client as any).applySnapshot(cleared);
+    expect(client.player.auras).toEqual([]);
+    expect(client.player.cooldowns.size).toBe(0);
+    expect(client.player.abilityCharges?.stable_cast?.charges).toBe(2);
+    expect(client.nodeHarvestableByMe('stable_node')).toBe(true);
+  });
+
+  it('re-sends aura refreshes, reorder, values, stacks, and charges without timer churn', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'AuraMutations', 'mage', timerV2);
+    const player = server.sim.entities.get(session.pid)!;
+    player.auras = [];
+    const firstAura = testAura('first', 10, 2);
+    const secondAura = testAura('second', 12, 3);
+    player.auras.push(firstAura, secondAura);
+
+    broadcast(server);
+    const first = lastSnap(fc.sent);
+    const firstExpiry = first.self.auras.find((a: any) => a.id === 'first').exp;
+    const client = bareClient(session.pid);
+    (client as any).applySnapshot(first);
+
+    server.sim.tick();
+    player.auras.reverse();
+    firstAura.remaining = 20;
+    secondAura.value = 9;
+    secondAura.stacks = 3;
+    secondAura.charges = 4;
+    fc.sent.length = 0;
+    broadcast(server);
+    const changed = lastSnap(fc.sent);
+    expect(changed.self.auras.map((a: any) => a.id)).toEqual(['second', 'first']);
+    expect(changed.self.auras[0]).toMatchObject({ value: 9, stacks: 3, charges: 4 });
+    expect(changed.self.auras[1].exp).toBeGreaterThan(firstExpiry);
+
+    (client as any).applySnapshot(changed);
+    expect(client.player.auras.map((a) => a.id)).toEqual(['second', 'first']);
+    expect(client.player.auras[0]).toMatchObject({ value: 9, stacks: 3, charges: 4 });
+    expect(client.player.auras[1].remaining).toBeCloseTo(20, 5);
+  });
+
+  it('keeps rate-aware cooldown deadlines stable through Temporal Hourglass acceleration', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'Accelerated', 'mage', timerV2);
+    const player = server.sim.entities.get(session.pid)!;
+    player.auras = [];
+    player.auras.push({
+      ...testAura('temporal_hourglass', 1, 3),
+      kind: 'stasis',
+      duration: 1,
+    });
+    player.cooldowns.set('accelerated_cast', 5);
+    player.cooldowns.set('temporal_hourglass', 5);
+
+    broadcast(server);
+    const first = lastSnap(fc.sent);
+    expect(first.self.cds.accelerated_cast).toEqual([3, 3, 1]);
+    expect(first.self.cds.temporal_hourglass).toBe(5);
+    const client = bareClient(session.pid);
+    (client as any).applySnapshot(first);
+    expect(client.player.cooldowns.get('accelerated_cast')).toBe(5);
+
+    fc.sent.length = 0;
+    for (let i = 0; i < 10; i++) server.sim.tick();
+    broadcast(server);
+    const accelerated = lastSnap(fc.sent);
+    expect(accelerated.self).not.toHaveProperty('cds');
+    (client as any).applySnapshot(accelerated);
+    expect(client.player.cooldowns.get('accelerated_cast')).toBeCloseTo(3.5, 5);
+
+    fc.sent.length = 0;
+    for (let i = 0; i < 10; i++) server.sim.tick();
+    broadcast(server);
+    const expired = lastSnap(fc.sent);
+    expect(expired.self.cds.accelerated_cast).toBe(3);
+    (client as any).applySnapshot(expired);
+    expect(client.player.cooldowns.get('accelerated_cast')).toBeCloseTo(2, 5);
+
+    player.cooldowns.set('accelerated_cast', 6);
+    player.auras.push({
+      ...testAura('temporal_hourglass', 2, 2),
+      kind: 'stasis',
+      duration: 2,
+    });
+    fc.sent.length = 0;
+    broadcast(server);
+    expect(lastSnap(fc.sent).self.cds.accelerated_cast).toEqual([5, 2, 3]);
+
+    player.auras = player.auras.filter((aura) => aura.id !== 'temporal_hourglass');
+    fc.sent.length = 0;
+    broadcast(server);
+    const removed = lastSnap(fc.sent);
+    expect(removed.self.cds.accelerated_cast).toBe(7);
+    (client as any).applySnapshot(removed);
+    expect(client.player.cooldowns.get('accelerated_cast')).toBe(6);
+  });
+
+  it('freezes retained auras while dead, then resumes absolute decay after resurrection', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'Paused', 'mage', timerV2);
+    const player = server.sim.entities.get(session.pid)!;
+    player.auras = [];
+    player.auras.push(testAura('retained', 8));
+    broadcast(server);
+    const client = bareClient(session.pid);
+    (client as any).applySnapshot(lastSnap(fc.sent));
+
+    player.dead = true;
+    player.hp = 0;
+    fc.sent.length = 0;
+    broadcast(server);
+    const frozen = lastSnap(fc.sent);
+    expect(frozen.self.auras[0]).toMatchObject({ id: 'retained', rem: 8 });
+    expect(frozen.self.auras[0]).not.toHaveProperty('exp');
+    (client as any).applySnapshot(frozen);
+    const frozenRemaining = client.player.auras[0].remaining;
+
+    fc.sent.length = 0;
+    for (let i = 0; i < 6; i++) server.sim.tick();
+    broadcast(server);
+    const whileDead = lastSnap(fc.sent);
+    expect(whileDead.self).not.toHaveProperty('auras');
+    (client as any).applySnapshot(whileDead);
+    expect(client.player.auras[0].remaining).toBe(frozenRemaining);
+
+    player.dead = false;
+    player.hp = player.maxHp;
+    fc.sent.length = 0;
+    broadcast(server);
+    const resumed = lastSnap(fc.sent);
+    expect(resumed.self.auras[0]).toHaveProperty('exp');
+    expect(resumed.self.auras[0]).not.toHaveProperty('rem');
+    (client as any).applySnapshot(resumed);
+
+    fc.sent.length = 0;
+    server.sim.tick();
+    server.sim.tick();
+    broadcast(server);
+    const decayed = lastSnap(fc.sent);
+    expect(decayed.self).not.toHaveProperty('auras');
+    (client as any).applySnapshot(decayed);
+    expect(client.player.auras[0].remaining).toBeCloseTo(frozenRemaining - 0.1, 5);
+  });
+
+  it('keeps legacy and v2 entity variants isolated and builds each at most once per tick', () => {
+    const server = new GameServer();
+    const stableWs = fakeWs();
+    const legacyWs = fakeWs();
+    const subjectWs = fakeWs();
+    const stable = joinServer(server, stableWs, 1, 'StableViewer', 'warrior', timerV2);
+    joinServer(server, legacyWs, 2, 'LegacyViewer');
+    const subject = joinServer(server, subjectWs, 3, 'Subject', 'mage');
+    const subjectEntity = server.sim.entities.get(subject.pid)!;
+    subjectEntity.auras = [];
+    subjectEntity.auras.push(testAura('shared_aura', 20));
+
+    (server as any).perfDetailActive = true;
+    (server as any).bcLegacySerializes = 0;
+    (server as any).bcStableSerializes = 0;
+    (server as any).bcBaseSerializes = 0;
+    broadcast(server);
+    const stableFirst = lastSnap(stableWs.sent);
+    const legacyFirst = lastSnap(legacyWs.sent);
+    const stableRow = stableFirst.ents.find((e: any) => e.id === subject.pid);
+    const legacyRow = legacyFirst.ents.find((e: any) => e.id === subject.pid);
+    expect(stableRow.auras[0]).toHaveProperty('exp');
+    expect(stableRow.auras[0]).not.toHaveProperty('rem');
+    expect(legacyRow.auras[0]).toHaveProperty('rem');
+    expect(legacyRow.auras[0]).not.toHaveProperty('exp');
+    expect((server as any).bcLegacySerializes).toBeLessThanOrEqual(server.sim.entities.size);
+    expect((server as any).bcStableSerializes).toBeLessThanOrEqual(server.sim.entities.size);
+    expect((server as any).bcBaseSerializes).toBeLessThanOrEqual(server.sim.entities.size);
+    expect(
+      (server as any).bcLegacySerializes + (server as any).bcStableSerializes,
+    ).toBeLessThanOrEqual(server.sim.entities.size * 2);
+
+    const stableClient = bareClient(stable.pid);
+    (stableClient as any).applySnapshot(stableFirst);
+    stableWs.sent.length = 0;
+    legacyWs.sent.length = 0;
+    subjectWs.sent.length = 0;
+    server.sim.tick();
+    broadcast(server);
+    const stableSecond = lastSnap(stableWs.sent);
+    const legacySecond = lastSnap(legacyWs.sent);
+    expect(stableSecond.ents.find((e: any) => e.id === subject.pid)).toBeUndefined();
+    expect(stableSecond.keep).toContain(subject.pid);
+    expect(legacySecond.ents.find((e: any) => e.id === subject.pid)?.auras[0]).toHaveProperty(
+      'rem',
+    );
+    expect(JSON.stringify(stableSecond).length).toBeLessThan(JSON.stringify(legacySecond).length);
+    (stableClient as any).applySnapshot(stableSecond);
+    expect(stableClient.entities.get(subject.pid)?.auras[0].remaining).toBeCloseTo(19.95, 5);
+  });
+
+  it('uses the recipient capability for spectator self records', () => {
+    const server = new GameServer();
+    const stableWs = fakeWs();
+    const legacyWs = fakeWs();
+    const targetWs = fakeWs();
+    const stableSpectator = joinServer(server, stableWs, 1, 'StableSpec', 'mage', timerV2);
+    const legacySpectator = joinServer(server, legacyWs, 2, 'LegacySpec', 'mage');
+    const target = joinServer(server, targetWs, 3, 'Observed', 'mage');
+    for (let i = 0; i < 5; i++) server.sim.tick();
+    const targetEntity = server.sim.entities.get(target.pid)!;
+    targetEntity.auras = [];
+    targetEntity.auras.push(testAura('observed_aura', 10));
+    targetEntity.cooldowns.set('observed_cast', 5);
+    (server as any).enterSpectate(stableSpectator, target);
+    (server as any).enterSpectate(legacySpectator, target);
+    stableWs.sent.length = 0;
+    legacyWs.sent.length = 0;
+    broadcast(server);
+
+    const stableSnap = lastSnap(stableWs.sent);
+    const legacySnap = lastSnap(legacyWs.sent);
+    expect(stableSnap.self.id).toBe(target.pid);
+    expect(stableSnap.tw).toBe(2);
+    expect(stableSnap.self.auras[0]).toHaveProperty('exp');
+    expect(stableSnap.self.cds.observed_cast).toBeCloseTo(server.sim.time + 5, 5);
+    expect(legacySnap.self.id).toBe(target.pid);
+    expect(legacySnap.tw).toBeUndefined();
+    expect(legacySnap.self.auras[0]).toHaveProperty('rem');
+    expect(legacySnap.self.cds.observed_cast).toBe(5);
+  });
+
+  it('refreshes the negotiated capability on linkdead resume in both directions', () => {
+    const server = new GameServer();
+    const legacyWs = fakeWs();
+    const original = joinServer(server, legacyWs, 1, 'ResumeWire');
+    legacyWs.ws.readyState = 3;
+    expect(server.socketClosed(original, legacyWs.ws)).toBe(true);
+
+    const stableWs = fakeWs();
+    const stableResult = server.join(
+      stableWs.ws,
+      1,
+      1,
+      'ResumeWire',
+      'warrior',
+      null,
+      false,
+      timerV2,
+    );
+    if ('error' in stableResult) throw new Error(stableResult.error);
+    expect(stableResult).toBe(original);
+    expect((stableResult as any).timerWireVersion).toBe(2);
+    stableWs.sent.length = 0;
+    broadcast(server);
+    expect(lastSnap(stableWs.sent).tw).toBe(2);
+
+    stableWs.ws.readyState = 3;
+    expect(server.socketClosed(stableResult, stableWs.ws)).toBe(true);
+    const fallbackWs = fakeWs();
+    const fallback = server.join(fallbackWs.ws, 1, 1, 'ResumeWire', 'warrior', null);
+    if ('error' in fallback) throw new Error(fallback.error);
+    expect(fallback).toBe(original);
+    expect((fallback as any).timerWireVersion).toBe(1);
+    fallbackWs.sent.length = 0;
+    broadcast(server);
+    expect(lastSnap(fallbackWs.sent).tw).toBeUndefined();
+  });
+
+  it('falls back to legacy decode solely when the snapshot has no v2 marker', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'OldServer', 'mage');
+    const player = server.sim.entities.get(session.pid)!;
+    player.auras = [];
+    player.auras.push(testAura('old_wire', 6));
+    player.cooldowns.set('old_cast', 4);
+    broadcast(server);
+    const first = lastSnap(fc.sent);
+    expect(first.tw).toBeUndefined();
+
+    const client = bareClient(session.pid);
+    (client as any).applySnapshot(first);
+    expect(client.player.auras[0].remaining).toBe(6);
+    expect(client.player.cooldowns.get('old_cast')).toBe(4);
+
+    fc.sent.length = 0;
+    for (let i = 0; i < 3; i++) server.sim.tick();
+    broadcast(server);
+    const second = lastSnap(fc.sent);
+    expect(second.tw).toBeUndefined();
+    (client as any).applySnapshot(second);
+    expect(client.player.auras[0].remaining).toBeCloseTo(5.85, 5);
+    expect(client.player.cooldowns.get('old_cast')).toBeCloseTo(3.85, 5);
   });
 });


### PR DESCRIPTION
## Summary

- Negotiate an exact `timerWire: 2` capability per recipient while preserving byte-compatible legacy snapshots for old clients and isolating unknown future markers.
- Serialize live aura, cooldown, and gathering-node timers as stable absolute schedules, cache their JSON until semantic state changes, and age omitted schedules client-side from authoritative simulation time.
- Keep legacy/stable entity variants shared and lazy without losing aura revisions across distance-tier deferral, spectator changes, linkdead resume, or mixed-client sessions.
- Harden timer parsing against negative, non-finite, and overflowing values, and pin the server layer boundary so authoritative code cannot import `src/net`.

In the 160-tick timer-heavy regression fixture, legacy aura serialization rebuilds more than 150 times while v2 rebuilds once. The v2 fixture payload is less than 35% of the legacy fixture payload. This is a focused fixture result, not a claim about whole-production bandwidth.

## Type of change

- [x] Bug fix
- [x] Refactor or performance (no behavior change)
- [x] Tests
- [ ] Breaking change

## How was this tested?

- Commands:
  - `npx vitest run tests/client_snapshot_timer_wire.test.ts tests/snapshot_timer_wire.test.ts tests/server/ws_auth.test.ts tests/snapshots.test.ts tests/security.test.ts tests/linkdead.test.ts tests/architecture.test.ts tests/mob_stall_parse.test.ts tests/party_frame_info.test.ts tests/party_frame_projection.test.ts --maxWorkers=4` (348 passed)
  - Independent review matrix (293 passed)
  - `npm run check:ts`
  - `npm run build:server`
  - `npm run ci:changed`
  - `git diff --check origin/main...HEAD`
- Manual steps: N/A. Wire behavior is covered with old/new server-client combinations, mixed recipients, spectators, resumes, dead timers, future markers, hostile values, and deferred entity updates.
- Local full-gate note: i18n freshness, malware scanning, and changed-file Biome checks passed. Vitest reproduced the two existing macOS `deploy_watchdog` timeout failures. The linked-worktree run then lost ignored i18n artifacts and produced invalid zero-test imports, so it was stopped. Fresh-clone GitHub CI remains required before merge.
- Dependency audit: the branch changes no dependencies. `npm audit --audit-level=high` reports the existing 10 transitive Solana/Reown findings (6 moderate, 4 high); the offered fix is a breaking force update.

---

## Checklist

### Quality

- [ ] **The full gate passes.** See the local full-gate note above; focused, type, build, lint, architecture, and security checks pass.

### Cross-platform

- [ ] N/A. No UI or platform-specific behavior changed.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
