### PR TITLE
fix(ui): professions 2.0 phase 5 QA, wheel window audit and fixes

### DIFF
--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -16,7 +16,7 @@ Update this file at the end of every implementation and QA session. Statuses:
 | 4 | Node materials and pristine veins | complete | 2026-07-18 | 2026-07-18 |
 | 4 QA | Verify node materials and pristine veins | complete | 2026-07-18 | 2026-07-18 |
 | 5 | The professions wheel window | complete | 2026-07-18 | 2026-07-18 |
-| 5 QA | Verify the professions wheel window | not started | | |
+| 5 QA | Verify the professions wheel window | complete | 2026-07-18 | 2026-07-18 |
 | 6 | Crafting window upgrades and celebrations | not started | | |
 | 6 QA | Verify crafting window upgrades | not started | | |
 | 7 | The Guild letter and quest objectives | not started | | |
@@ -278,6 +278,56 @@ short-viewport compaction gap tightened from 2px to 1px (652px of the
 660px budget) with the `crafting_launcher` guard re-pinned deliberately;
 the next button added must revisit the rail (DESIGN.md phase 3 replaces
 it with the launcher hub).
+
+Phase 5 QA (2026-07-18): PASS with fixes. QA-start HEAD aee72d830 (the
+PR 2145 merge; the phase diff is that merge's FIRST-PARENT diff, the
+branch having absorbed the #2133 SFX sweep mid-phase). Three packet
+audits plus the two matched dispatch-matrix rows (frontend seam,
+qa-checklist; no sim/server/wire/database row matched the pure-UI
+diff), all five reports complete first try under hard tool-call
+budgets. Zero blocking findings. Landed from the audit: the simplified
+raise-vs-start CTA decision moved from the painter into the view core
+as a SimplifiedCta union on SimplifiedCallToAction (model logic the
+both-worlds core tests could not reach), both arms pinned; the three
+unconsumed Hud wrappers (openProfessions, closeProfessions,
+professionsWindowOpen) dropped, toggleProfessions staying the one
+consumed entry point (closeDeeds and deedsWindowOpen carry the same
+dead-member debt pre-existing, left alone); sixteen new test pins
+across the three suites: the painter's simplified/syncing surface (the
+whole pre-cprof online render path had no DOM test), unknown gathering
+id renders no row plus all-unknown omits the section, above-display-cap
+saturation (pips, fraction, and max above 300, not only at it),
+missing-craft-key-equals-zero signature equivalence (a materializing
+zero can never trigger a spurious rebuild), gathering maxSkill as its
+own signature dimension, unknown-major null arc, the raise CTA and
+specialized perk-line interpolation arms, ring node/arc/chord emission
+gating, opener-focus restore-once, the PERK_THRESHOLDS uniformity
+premise behind the single perk explainer, and an icons manifest
+lockstep guard that reads asset-manifest.json itself (the deed crests
+are deed_prof_*, a separate namespace; two audit reports misread them
+as prof_* and dissolved on verification). Live verification:
+mobile_tray_overflow OK (19 buttons, none clipped) and an 18-assertion
+probe over the real dev client, all green (desktop Shift+KeyP, Esc,
+minimap button, stubbed attuned full mode with arc, chord, ten rows,
+perks, and switch cost 8, mobile More-tray open and close, no NaN in
+any state). Copy verified against sim constants: per-tier masterwork
+odds (MASTERWORK_PER_TIER_ABOVE_CHANCE) and the specialization
+material discount are real mechanics. Deferred with reasons: the
+switch-cost line rendering for never-attuned full-mode players (the
+amendment scopes the line without an attunement condition; maintainer
+copy call); richer CTA copy for the practically unreachable
+specialized-boundary corner (points stay arithmetically correct since
+the 75 threshold coincides with a tier boundary, documented in the
+core; a new key would need M16 fills); RingArc endpoint symmetry with
+RingChord (painter-side SVG assembly, math unit-pinned); the
+pr_shot_targets stateIsFn dual-shape guard (harmless script
+robustness); painter open-while-open and toggle branch pins (low
+value); a real-ClientWorld pre-sync empty-craftSkills pin (belongs to
+a Phase 3 net suite; the missing-key signature equivalence covers the
+risk). Also corrected: the state.md screenshot-convention drift note
+claimed a docs/pr-screenshots/ convention that never existed in the
+tree; the packet's shots live under docs/screenshots/ per root
+CLAUDE.md.
 
 ### Phase 6: Crafting window upgrades and celebrations
 - [ ] Recipe rows show profession + required skill + skill-gain difficulty tint (#2037)

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -292,10 +292,12 @@ tables, i18n key namespaces, files created)
     under the old ring. Do not roll v0.27.0 back to v0.26.0 once the
     attunement quests are live; mirror this in the v0.27.0 release notes
     at tag time.
-  - Screenshot convention: this packet's phases commit PR shots under
-    docs/pr-screenshots/ (established earlier in the program), while root
-    CLAUDE.md names docs/screenshots. Keep the program-local convention
-    consistent within the packet; the maintainer may unify later.
+  - Screenshot convention (corrected by Phase 5 QA, 2026-07-18): the
+    packet's shots live under docs/screenshots/ per root CLAUDE.md. No
+    docs/pr-screenshots/ directory has ever existed in the tree; the
+    earlier version of this note recorded a packet-local convention that
+    was never actually used, and Phases 1 to 5 all committed under
+    docs/screenshots/.
 - Phase 2: (landed 2026-07-17, branch
   feature/professions-2-phase-02-masterwork) SimEvent masterwork
   { recipeId, itemId, crafter } (personal, pid = crafter, ids only),
@@ -523,6 +525,10 @@ tables, i18n key namespaces, files created)
   professionsState with a representative attuned Smith (renown-board
   precedent). Phase 11 touch point: the painter's GATHERING_NAME_KEYS
   map gains the fishing row and its catalog key with the fishing read.
+  QA (2026-07-18): the simplified raise-vs-start call-to-action decision
+  lives in the core (SimplifiedCta on SimplifiedCallToAction, both arms
+  pinned), not the painter; Hud exposes only toggleProfessions (the
+  open/close/isOpen wrappers were unconsumed and dropped).
 - Phase 7: (planned) trend detection module; Guild letter content; S3 scan
   list gains src/sim/quests/quest_commands.ts.
 - Phase 8: (planned) station registry (typed stations, multi-zone); master

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -10781,22 +10781,11 @@ export class Hud {
     return this.deedsWindow.isOpen;
   }
 
-  // The Professions window trio (keybind toggle, minimap/More-tray opens,
-  // Esc close), the deeds shape exactly.
-  openProfessions(): void {
-    this.professionsWindow.open();
-  }
-
-  closeProfessions(): void {
-    this.professionsWindow.close();
-  }
-
+  // The Professions window entry point (keybind, minimap, and More-tray all
+  // toggle; Esc closes via the managed-window case directly). Open/close/isOpen
+  // wrappers land only when a consumer lands with them.
   toggleProfessions(): void {
     this.professionsWindow.toggle();
-  }
-
-  get professionsWindowOpen(): boolean {
-    return this.professionsWindow.isOpen;
   }
 
   // Repaint the deed tracker from the live facet: the slow band, a watch

--- a/src/ui/professions_view.ts
+++ b/src/ui/professions_view.ts
@@ -255,10 +255,18 @@ export interface SwitchCostModel {
 
 export type ProfessionsWindowMode = 'simplified' | 'full';
 
+/** The copy decision for the one call-to-action line, derived in the core so
+ *  both worlds' tests pin it: 'raise' once the trending craft has any skill
+ *  and a milestone ahead, 'start' otherwise. `points` always equals the
+ *  distance to the next tier boundary: the specialized threshold only wins in
+ *  craftNextUnlock when it coincides with that boundary. */
+export type SimplifiedCta = { kind: 'raise'; craftId: string; points: number } | { kind: 'start' };
+
 export interface SimplifiedCallToAction {
   /** Highest-skill craft, ties broken by ring order. */
   trendingCraftId: string;
   nextUnlock: CraftNextUnlock;
+  cta: SimplifiedCta;
   /** The identity tutorial line, promoted ({ targetSkill: 25 } pre-first-tier). */
   tutorial: { targetSkill: number } | null;
 }
@@ -283,9 +291,15 @@ function buildSimplifiedCallToAction(identity: ProfessionIdentityModel): Simplif
   for (const row of identity.skills) {
     if (row.skill > trending.skill) trending = row;
   }
+  const nextUnlock = craftNextUnlock(trending.craftId, trending.skill);
+  const cta: SimplifiedCta =
+    trending.skill > 0 && nextUnlock.kind !== 'max'
+      ? { kind: 'raise', craftId: trending.craftId, points: nextUnlock.pointsRemaining }
+      : { kind: 'start' };
   return {
     trendingCraftId: trending.craftId,
-    nextUnlock: craftNextUnlock(trending.craftId, trending.skill),
+    nextUnlock,
+    cta,
     tutorial: identity.tutorial,
   };
 }

--- a/src/ui/professions_window.ts
+++ b/src/ui/professions_window.ts
@@ -187,14 +187,11 @@ export class ProfessionsWindow {
       model.identity.state === 'syncing'
         ? t('hudChrome.professions.syncing')
         : t('hudChrome.professions.unattunedIdentity');
-    const trending = model.crafts.find(
-      (row) => row.identity.craftId === simplified.trendingCraftId,
-    );
     const cta =
-      trending !== undefined && trending.identity.skill > 0 && simplified.nextUnlock.kind !== 'max'
+      simplified.cta.kind === 'raise'
         ? t('hudChrome.professions.ctaRaise', {
-            craft: craftNameText(simplified.trendingCraftId),
-            points: this.fmt(simplified.nextUnlock.pointsRemaining),
+            craft: craftNameText(simplified.cta.craftId),
+            points: this.fmt(simplified.cta.points),
           })
         : t('hudChrome.professions.ctaStart');
     const tutorial = simplified.tutorial

--- a/tests/profession_icons.test.ts
+++ b/tests/profession_icons.test.ts
@@ -161,6 +161,27 @@ describe('profession webp icons', () => {
     ]);
   });
 
+  it('stays in lockstep with the prof_/gather_ icon ids the asset manifest declares', () => {
+    // The pin above is a literal list; this guard reads the manifest itself so
+    // the two cannot drift apart silently. Deed crest ids are deed_prof_*, a
+    // different namespace, and stay out of this window's set by prefix.
+    const manifest = JSON.parse(
+      readFileSync(path.join(repoRoot, 'docs/professions-2/asset-manifest.json'), 'utf8'),
+    ) as unknown;
+    const declared: string[] = [];
+    const collect = (node: unknown): void => {
+      if (Array.isArray(node)) {
+        for (const item of node) collect(item);
+      } else if (node !== null && typeof node === 'object') {
+        const rec = node as Record<string, unknown>;
+        if (typeof rec.id === 'string' && /^(prof|gather)_/.test(rec.id)) declared.push(rec.id);
+        for (const value of Object.values(rec)) collect(value);
+      }
+    };
+    collect(manifest);
+    expect([...declared].sort()).toEqual([...ICON_IDS].sort());
+  });
+
   it('A) every image-backed profession id resolves to a committed, valid .webp', () => {
     const broken: string[] = [];
     for (const id of PROFESSION_IMAGE_IDS) {

--- a/tests/professions_view.test.ts
+++ b/tests/professions_view.test.ts
@@ -105,6 +105,7 @@ describe('buildProfessionsView: model construction', () => {
     expect(model.simplified).toEqual({
       trendingCraftId: 'engineering',
       nextUnlock: { kind: 'tier', targetTier: 1, pointsRemaining: 25 },
+      cta: { kind: 'start' },
       tutorial: { targetSkill: 25 },
     });
     expect(model.ring.pairArc).toBeNull();
@@ -164,6 +165,11 @@ describe('ring layout', () => {
     expect(buildRingLayout(null, null).pairArc).toBeNull();
     expect(buildRingLayout(null, null).hobbyChord).toBeNull();
     expect(buildRingLayout(null, 'fishing').hobbyChord).toBeNull();
+  });
+
+  it('yields no arc when either major id is unknown to the ring', () => {
+    expect(buildRingLayout(['fishing', 'engineering'], null).pairArc).toBeNull();
+    expect(buildRingLayout(['engineering', 'fishing'], null).pairArc).toBeNull();
   });
 
   it('draws the hobby chord from the hobby node to its ring opposite', () => {
@@ -229,6 +235,17 @@ describe('tier pips and perks', () => {
     expect(buildSkillBar(45, 300).fillFraction).toBeCloseTo(0.15, 12);
   });
 
+  it('saturates pips, fill, and fraction above the display cap', () => {
+    // Sim craft skill is uncapped (wheel.ts gainCraftSkill), so a mirrored
+    // skill above 300 must clamp every bar-facing field, not just fillFraction.
+    expect(buildSkillBar(450, CRAFT_MAX_SKILL)).toMatchObject({
+      pipSlots: 12,
+      filledPips: 12,
+      tierFraction: 0,
+      fillFraction: 1,
+    });
+  });
+
   it('flips specialized exactly at the content threshold', () => {
     // Deliberate literal pin: silent content drift in the specialization
     // constants must fail here, not just re-derive.
@@ -249,6 +266,16 @@ describe('tier pips and perks', () => {
     expect(at.materialCostMultiplier).toBeCloseTo(0.8, 12);
     expect(at.specializedSkillThreshold).toBe(threshold);
     expect(at.materialDiscountPct).toBe(PERK_THRESHOLDS.engineering.materialDiscountPct);
+  });
+
+  it('pins the perk thresholds uniform across the ring (the single-explainer premise)', () => {
+    // The painter's unspecialized explainer renders the FIRST craft row's
+    // threshold for all ten crafts; a per-craft divergence (Phase 9/10) must
+    // fail here first and force a per-craft explainer.
+    const first = PERK_THRESHOLDS[CRAFT_RING[0].id];
+    for (const craft of CRAFT_RING) {
+      expect(PERK_THRESHOLDS[craft.id]).toEqual(first);
+    }
   });
 });
 
@@ -293,6 +320,10 @@ describe('craftNextUnlock', () => {
     });
     expect(craftNextUnlock('engineering', CRAFT_MAX_SKILL)).toEqual({ kind: 'max' });
     expect(() => craftNextUnlock('fishing', 0)).toThrow();
+  });
+
+  it('stays max above the display cap, not only exactly at it', () => {
+    expect(craftNextUnlock('engineering', CRAFT_MAX_SKILL + 150)).toEqual({ kind: 'max' });
   });
 });
 
@@ -357,6 +388,16 @@ describe('progressive disclosure', () => {
     expect(tied?.nextUnlock).toEqual({ kind: 'tier', targetTier: 1, pointsRemaining: 15 });
     expect(tied?.tutorial).toEqual({ targetSkill: 25 });
   });
+
+  it('derives the cta in the core: start at zero skill, raise once any skill exists', () => {
+    // The raise-vs-start choice is model logic, so it is pinned here against
+    // both simplified triggers, not decided in the painter.
+    expect(view(identity()).simplified?.cta).toEqual({ kind: 'start' });
+    expect(
+      view(identity({ craftSkills: { ...ZERO_SKILLS, cooking: 10 } })).simplified?.cta,
+    ).toEqual({ kind: 'raise', craftId: 'cooking', points: 15 });
+    expect(view({ ...attunedIdentity, synced: false }).simplified?.cta.kind).toBe('raise');
+  });
 });
 
 describe('professionsRefreshSig', () => {
@@ -378,6 +419,14 @@ describe('professionsRefreshSig', () => {
     expect(professionsRefreshSig(input(), ['tab:perks'])).toBe(
       professionsRefreshSig(input(), ['tab:perks']),
     );
+  });
+
+  it('treats a missing craft key as zero, so a materialized zero never repaints', () => {
+    // Pre-sync ClientWorld records may omit zero-skill keys entirely; the
+    // CRAFT_RING enumeration with ?? 0 must make {} and explicit zeros equal.
+    expect(
+      professionsRefreshSig({ identity: identity({ craftSkills: { cooking: 30 } }), gathering }),
+    ).toBe(professionsRefreshSig(input()));
   });
 
   it('moves when any single repaint dimension moves', () => {
@@ -408,6 +457,14 @@ describe('professionsRefreshSig', () => {
       }),
     ).not.toBe(base);
     expect(professionsRefreshSig(input(), ['craft:alchemy'])).not.toBe(base);
+    // The gathering cap is its own repaint dimension (Phase 11 rows may cap
+    // differently), so a cap move alone must move the signature.
+    expect(
+      professionsRefreshSig({
+        ...input(),
+        gathering: [{ professionId: 'mining', skill: 12, maxSkill: 450 }],
+      }),
+    ).not.toBe(base);
   });
 });
 

--- a/tests/professions_window_focus.test.ts
+++ b/tests/professions_window_focus.test.ts
@@ -65,7 +65,10 @@ function baseState(): WorldState {
   };
 }
 
-function makeWindow(state: WorldState): { w: ProfessionsWindow; el: HTMLElement } {
+function makeWindow(
+  state: WorldState,
+  depsOver: Partial<ProfessionsWindowDeps> = {},
+): { w: ProfessionsWindow; el: HTMLElement } {
   const el = document.createElement('div');
   el.id = 'professions-window';
   document.body.appendChild(el);
@@ -88,6 +91,7 @@ function makeWindow(state: WorldState): { w: ProfessionsWindow; el: HTMLElement 
     moneyHtml: () => '',
     itemTooltip: () => '',
     attachTooltip: () => {},
+    ...depsOver,
   };
   const w = new ProfessionsWindow(deps);
   w.open();
@@ -164,5 +168,116 @@ describe('ProfessionsWindow: focus and scroll survive rebuilds', () => {
     expect(el.querySelector('[data-close]')).toBe(closeBtn);
     expect(el.firstElementChild).toBe(firstChild);
     expect(el.innerHTML).toBe(html);
+  });
+});
+
+describe('ProfessionsWindow: mode and row gating', () => {
+  it('renders the simplified syncing surface over the pre-sync ClientWorld shape', () => {
+    // The tests/professions_contracts.test.ts pin: a fresh ClientWorld serves
+    // synced false, an empty craftSkills record, and professionsState
+    // { skills: [] }. The painter must map that empty array and paint the
+    // graceful syncing surface (identity paragraph plus one CTA), never the
+    // full ring, craft rows, or gathering section.
+    const state = baseState();
+    state.identity.synced = false;
+    state.identity.craftSkills = {};
+    state.gathering = [];
+    const { el } = makeWindow(state);
+    expect(el.querySelector('.prof-identity-paragraph')).not.toBeNull();
+    expect(el.querySelector('.prof-cta')).not.toBeNull();
+    expect(el.querySelector('.prof-ring')).toBeNull();
+    expect(el.querySelector('.prof-crafts')).toBeNull();
+    expect(el.querySelector('.prof-gathering')).toBeNull();
+  });
+
+  it('renders no gathering row for an unknown profession id', () => {
+    // gather_fishing ships an icon but no window read until Phase 11: an id
+    // with no GATHERING_NAME_KEYS entry renders no row BY DESIGN, while the
+    // known ids beside it still render.
+    const state = baseState();
+    state.gathering = [
+      { professionId: 'mining', skill: 30, maxSkill: 300 },
+      { professionId: 'fishing', skill: 10, maxSkill: 300 },
+    ];
+    const { el } = makeWindow(state);
+    expect(el.querySelectorAll('.prof-gather-row')).toHaveLength(1);
+    expect(el.querySelector('.prof-gathering')).not.toBeNull();
+  });
+
+  it('omits the gathering section entirely when every injected id is unknown', () => {
+    const state = baseState();
+    state.gathering = [{ professionId: 'fishing', skill: 10, maxSkill: 300 }];
+    const { el } = makeWindow(state);
+    expect(el.querySelectorAll('.prof-gather-row')).toHaveLength(0);
+    expect(el.querySelector('.prof-gathering')).toBeNull();
+  });
+
+  it('promotes the raise CTA once the trending craft has any skill', () => {
+    // The two simplified CTA arms: zero skill everywhere renders the start
+    // copy; any trending skill renders the raise copy with the interpolated
+    // points to the next boundary (15 here), plus the promoted tutorial line.
+    const startState = baseState();
+    startState.identity.synced = false;
+    startState.identity.craftSkills = {};
+    startState.gathering = [];
+    const start = makeWindow(startState).el.querySelector('.prof-cta-line')?.textContent ?? '';
+    const raiseState = baseState();
+    raiseState.identity.craftSkills = { cooking: 10 };
+    raiseState.identity.activeArchetype = null;
+    raiseState.identity.pairedMajor = null;
+    raiseState.identity.hobbyCraft = null;
+    raiseState.identity.attunedPairs = [];
+    raiseState.gathering = [];
+    const { el } = makeWindow(raiseState);
+    const raise = el.querySelector('.prof-cta-line')?.textContent ?? '';
+    expect(raise).toContain('15');
+    expect(raise).not.toBe(start);
+    expect(el.querySelector('.prof-tutorial')).not.toBeNull();
+  });
+
+  it('renders ten ring nodes, with arc and chord only while attuned', () => {
+    // The RingLayout math is unit-pinned in professions_view.test.ts; this
+    // pins the painter's conditional SVG emission on top of it.
+    const attuned = makeWindow(baseState());
+    expect(attuned.el.querySelectorAll('.prof-ring-node')).toHaveLength(10);
+    expect(attuned.el.querySelector('.prof-ring-arc')).not.toBeNull();
+    expect(attuned.el.querySelector('.prof-ring-chord')).not.toBeNull();
+    document.body.innerHTML = '';
+    const bare = baseState();
+    bare.identity.activeArchetype = null;
+    bare.identity.pairedMajor = null;
+    bare.identity.hobbyCraft = null;
+    bare.identity.attunedPairs = [];
+    const unattuned = makeWindow(bare);
+    expect(unattuned.el.querySelectorAll('.prof-ring-node')).toHaveLength(10);
+    expect(unattuned.el.querySelector('.prof-ring-arc')).toBeNull();
+    expect(unattuned.el.querySelector('.prof-ring-chord')).toBeNull();
+  });
+
+  it('restores the captured opener focus on close, and only once', () => {
+    const opener = document.createElement('button');
+    document.body.appendChild(opener);
+    const restored: (HTMLElement | null)[] = [];
+    const { w } = makeWindow(baseState(), {
+      captureFocus: () => opener,
+      restoreFocus: (target) => restored.push(target),
+    });
+    w.close();
+    expect(restored).toEqual([opener]);
+    w.close();
+    expect(restored).toEqual([opener]);
+  });
+
+  it('lists the specialized perk line once a craft crosses the threshold', () => {
+    // baseState tops out at skill 60, so every other full render exercises
+    // only the threshold explainer; this pins the perk-list arm and the ONE
+    // perkSpecializedLine key with its interpolated discount percent.
+    const state = baseState();
+    state.identity.craftSkills.engineering = 80;
+    const { el } = makeWindow(state);
+    expect(el.querySelector('.prof-perk-list')).not.toBeNull();
+    const lines = el.querySelectorAll('.prof-perk-line');
+    expect(lines).toHaveLength(1);
+    expect(lines[0].textContent).toContain('20');
   });
 });


### PR DESCRIPTION
## Summary

Phase 5 QA of the Professions 2.0 program: the full audit pass over the professions wheel window diff (the PR #2145 merge's first-parent diff), plus the fixes it produced. Three packet audit charters and the two matched dispatch-matrix reviewers (frontend-seam, qa-checklist) ran to completion; no sim/server/wire/database row matched the pure-UI diff. Verdict: PASS with fixes, zero blocking findings.

What landed from the audit:

- **Simplified CTA decision moved into the view core** (the frontend-seam should-fix): the raise-vs-start choice was model logic living in the painter, unreachable by the both-worlds core tests. `SimplifiedCallToAction` gains a `SimplifiedCta` union derived in `professions_view.ts`; the painter only maps the decision onto its two catalog keys. Rendering is unchanged.
- **Three unconsumed Hud wrappers dropped** (the dead-code should-fix): `openProfessions`, `closeProfessions`, and the `professionsWindowOpen` getter had zero consumers anywhere; `toggleProfessions` stays as the single consumed entry point on the no-growth coordinator. (`closeDeeds`/`deedsWindowOpen` carry the same debt pre-existing and are left for a separate chore.)
- **Sixteen new test pins** across the three Phase 5 suites (11 from the coverage audit, 5 follow-ons): the simplified/syncing DOM surface (the whole pre-cprof online render path had no painter test), unknown-gathering-id row gating (the `gather_fishing` Phase 11 contract), above-display-cap saturation, missing-craft-key-equals-zero refresh-signature equivalence, gathering `maxSkill` as its own signature dimension, unknown-major null arc, both CTA arms and the specialized perk-line interpolation, ring node/arc/chord emission gating, opener-focus restore-once, the `PERK_THRESHOLDS` uniformity premise behind the single perk explainer, and an icons manifest-lockstep guard that reads `asset-manifest.json` itself.
- **Docs**: Phase 5 QA row and full findings/deferral record in `progress.md`; `state.md` gains the QA surface note and a correction to the screenshot-convention drift note (no `docs/pr-screenshots/` directory has ever existed; the packet ships under `docs/screenshots/` per root CLAUDE.md).

Deferrals (recorded with reasons in `progress.md`): the switch-cost line rendering for never-attuned full-mode players (maintainer copy call; the amendment scopes the line without an attunement condition), richer CTA copy for the practically unreachable specialized-boundary corner (the points stay arithmetically correct; a new key would need M16 fills), RingArc endpoint symmetry with RingChord, the `pr_shot_targets` dual-shape guard, painter open-while-open branch pins, and a real-ClientWorld pre-sync empty-`craftSkills` pin (belongs to a Phase 3 net suite).

## Related issues

Part of #1866 (Professions 2.0 epic). QA of the Phase 5 merge (PR #2145).

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation

## How was this tested?

- Commands:
  - `npm run gate` under Node 24: every stage green through the full vitest suite (i18n gen + freshness, malware scan, changed-files biome, SFX conformance, full tests); the run stops at the known environmental armory browser-layout failure on this machine (`tests/browser/armory_mobile_layout.browser.test.ts`, pre-existing, unrelated), so the four post-abort stages ran manually and passed: `check:types`, `build:env`, `build:server`, `build` (all five entries).
  - `npx vitest run tests/professions_view.test.ts tests/professions_window_focus.test.ts tests/profession_icons.test.ts`: 55/55.
  - Guard set: architecture, the mobile window trio, localization_fixes, i18n_completeness, crafting_launcher, mobile_controls: 159 passed, 3 skipped.
  - `npx @biomejs/biome check` scoped to every changed file: clean (three pre-existing hud.ts lint warnings exist at HEAD and are untouched).
- Manual steps:
  - `scripts/mobile_tray_overflow.mjs` against the dev client: 19 More-tray buttons (professions included), none clipped.
  - An 18-assertion live probe over the running dev client, all green, before and after the fixes: desktop Shift+KeyP opens, Escape closes, the minimap micro-button reopens, the stubbed attuned identity renders full mode (pair arc, hobby chord, ten craft rows, three gathering rows, two specialized perk lines, switch cost 8 matching `requiredAmendsProgress(1)`), the mobile More tray opens the full-screen sheet, close works, and no NaN appears in any state.
  - Copy claims verified against sim constants: per-tier masterwork odds (`MASTERWORK_PER_TIER_ABOVE_CHANCE`) and the specialization material discount are real mechanics.

## Screenshots / recordings

N/A: rendering is byte-identical (the CTA refactor moves the decision, not the copy; the Hud change deletes dead API; the rest is tests and docs). The Phase 5 PR (#2145) carries the window's before/after captures.

---

## Checklist

### Quality

- [x] **The full gate passes.** Green through the full suite; the single stop is the known environmental armory browser failure on this machine, with the four post-abort stages (typecheck and the three builds) run manually and green. PR CI is the arbiter.

### Cross-platform

- [x] **Tested on desktop and mobile.** Live probe on a 1280x800 desktop and a 740x360 landscape touch viewport; the More-tray reachability script passed.
- [x] **Accessible.** The opener-focus restore contract is now pinned; Close keeps focus on open; no ARIA changes.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (and changes none).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
