### PR TITLE
feat: on-chain $WOC burn tracker (burn.html)

### DIFF
--- a/burn.html
+++ b/burn.html
@@ -1,0 +1,1037 @@
+<title>WOC Burn Tracker</title>
+<style>
+  /* ============ WOC burn chamber - deliberate single dark theme ============ */
+  :root { color-scheme: dark; }
+  .burncalc {
+    /* ground */
+    --page:        #0c0a06;
+    --surface:     #14110b;
+    --surface-2:   #1a1610;
+    --inset:       #0f0c07;
+    /* brand chrome (never a data series) */
+    --gold:        #d8b15a;
+    --gold-bright: #f3d489;
+    --gold-dim:    #6b5226;
+    /* ink */
+    --ink:         #e8dfc8;
+    --ink-2:       #b6ad95;
+    --ink-3:       #8a8270;
+    /* hairlines */
+    --line:        #2a2418;
+    --grid:        #221c11;
+    /* data accent (validated ≥3:1 on surface) */
+    --burn:        #d95926;
+
+    --serif: Georgia, 'Times New Roman', serif;
+    --sans: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;
+    --mono: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+  }
+  .burncalc {
+    background: var(--page);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 14px;
+    line-height: 1.5;
+    min-height: 100vh;
+    padding: 0 20px 72px;
+  }
+  .burncalc *, .burncalc *::before, .burncalc *::after { box-sizing: border-box; }
+  .shell { max-width: 980px; margin: 0 auto; display: flex; flex-direction: column; gap: 28px; }
+
+  /* ---------- runtime error surface ---------- */
+  .err {
+    display: none; margin-top: 16px; padding: 12px 16px; border-radius: 8px;
+    border: 1px solid #7a2a1a; background: #250f08; color: #e8b39a; font-size: 13px;
+  }
+  .err.show { display: block; }
+  .err b { color: #f3c8b0; }
+
+  /* ---------- header / hero ---------- */
+  .masthead { text-align: center; padding-top: 48px; display: flex; flex-direction: column; gap: 6px; }
+  .masthead .rule {
+    height: 1px; max-width: 420px; margin: 0 auto 18px; width: 100%;
+    background: linear-gradient(90deg, transparent, var(--gold-dim) 20%, var(--gold) 50%, var(--gold-dim) 80%, transparent);
+  }
+  .masthead .eyebrow {
+    font-size: 12px; letter-spacing: 5px; text-transform: uppercase; color: var(--ink-3);
+  }
+  .masthead h1 {
+    font-family: var(--serif); font-variant: small-caps; letter-spacing: 3px;
+    font-size: clamp(30px, 5vw, 44px); line-height: 1.1; color: var(--gold-bright);
+    margin: 0; text-wrap: balance; font-weight: 600;
+  }
+  .masthead .mint {
+    display: inline-block; margin: 8px auto 0; padding: 4px 14px; border-radius: 999px;
+    border: 1px solid var(--gold-dim); background: rgba(20, 17, 11, 0.8);
+    font-family: var(--mono); font-size: 11px; color: var(--ink-2); word-break: break-all;
+  }
+
+  .hero { display: flex; justify-content: center; align-items: stretch; gap: 0; flex-wrap: wrap; }
+  .hero .cell { padding: 10px 36px; text-align: center; }
+  .hero .cell + .cell { border-left: 1px solid var(--line); }
+  .hero .big {
+    font-family: var(--mono); font-size: clamp(30px, 4.5vw, 46px); line-height: 1.15; font-weight: 600;
+  }
+  .hero .big.woc { color: var(--burn); }
+  .hero .big.usd { color: var(--ink); }
+  .hero .cap { margin-top: 2px; font-size: 12px; letter-spacing: 2px; text-transform: uppercase; color: var(--ink-3); }
+  .hero .sub2 { margin-top: 4px; font-family: var(--mono); font-size: 10.5px; color: var(--ink-3); }
+  .hero .sub2.live { color: #9fe6a0; }
+  @media (max-width: 620px) {
+    .hero .cell + .cell { border-left: none; border-top: 1px solid var(--line); }
+    .hero { flex-direction: column; }
+  }
+
+  /* ---------- generic card ---------- */
+  .card {
+    background: linear-gradient(180deg, var(--surface-2), var(--surface));
+    border: 1px solid var(--line); border-radius: 10px; padding: 20px;
+    display: flex; flex-direction: column; gap: 14px;
+  }
+  .card > h2 {
+    font-family: var(--serif); font-variant: small-caps; letter-spacing: 2px; font-weight: 600;
+    font-size: 19px; color: var(--gold-bright); margin: 0;
+  }
+  .card .sub { font-size: 12.5px; color: var(--ink-3); margin: -8px 0 0; }
+  .cardhead { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; }
+
+  .chipbtn {
+    font: inherit; font-size: 12.5px; letter-spacing: 1px; cursor: pointer;
+    padding: 6px 14px; border-radius: 999px; border: 1px solid var(--line);
+    background: var(--inset); color: var(--ink-2);
+  }
+  .chipbtn:hover:not(:disabled) { border-color: var(--gold-dim); color: var(--gold-bright); }
+  .chipbtn:disabled { opacity: 0.5; cursor: default; }
+  .chipbtn:focus-visible, .seg button:focus-visible, .burncalc a:focus-visible {
+    outline: 2px solid var(--gold); outline-offset: 2px;
+  }
+
+  /* ---------- burn feed ---------- */
+  .feed { display: flex; flex-direction: column; gap: 8px; }
+  .brow {
+    display: grid; grid-template-columns: 1fr auto; gap: 4px 14px; align-items: center;
+    padding: 10px 14px; border: 1px solid var(--grid); border-radius: 8px; background: var(--inset);
+  }
+  .brow .l1 { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; min-width: 0; }
+  .brow .amt { font-family: var(--mono); font-size: 15px; font-weight: 600; color: var(--burn); white-space: nowrap; }
+  .brow .burned { font-size: 12px; color: var(--burn); letter-spacing: 1px; }
+  .brow .who {
+    font-family: var(--mono); font-size: 10.5px; color: var(--ink-3);
+    border: 1px solid var(--grid); border-radius: 999px; padding: 1px 8px; white-space: nowrap;
+  }
+  .brow .r { text-align: right; white-space: nowrap; }
+  .brow .r a { color: var(--ink-2); text-decoration: none; font-family: var(--mono); font-size: 11px; }
+  .brow .r a:hover { color: var(--gold-bright); text-decoration: underline; }
+  .brow .when { font-family: var(--mono); font-size: 11px; color: var(--ink-3); margin-left: 10px; }
+  .feed-empty {
+    padding: 26px 18px; text-align: center; border: 1px dashed var(--line); border-radius: 8px;
+    color: var(--ink-3); font-size: 13px;
+  }
+  .feed-empty b { color: var(--ink-2); }
+  .coverage { font-family: var(--mono); font-size: 10.5px; color: var(--ink-3); }
+
+  /* ---------- stat tiles + segmented ---------- */
+  .seg { display: inline-flex; border: 1px solid var(--line); border-radius: 999px; background: var(--inset); padding: 2px; }
+  .seg button {
+    font: inherit; font-size: 11.5px; letter-spacing: 1px; cursor: pointer; border: 1px solid transparent;
+    background: transparent; color: var(--ink-3); padding: 4px 12px; border-radius: 999px;
+  }
+  .seg button[aria-pressed="true"] { background: var(--surface-2); color: var(--gold-bright); border-color: var(--gold-dim); }
+
+  .statgrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+  @media (max-width: 860px) { .statgrid { grid-template-columns: 1fr; } }
+  .tiles { display: grid; grid-template-columns: 1fr; gap: 10px; }
+  .tile { background: var(--inset); border: 1px solid var(--grid); border-radius: 8px; padding: 12px 14px; min-width: 0; }
+  .tile .v { font-family: var(--mono); font-size: 21px; font-weight: 600; color: var(--ink); overflow-wrap: break-word; }
+  .tile .v.ember { color: var(--burn); }
+  .tile .k { font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ink-3); margin-top: 2px; }
+
+  /* ---------- chart ---------- */
+  .chartbox { position: relative; }
+  .chartbox svg { display: block; width: 100%; height: auto; }
+  .tip {
+    position: absolute; pointer-events: none; z-index: 5; display: none;
+    background: #0f0c07; border: 1px solid var(--gold-dim); border-radius: 7px;
+    padding: 8px 11px; font-size: 12px; color: var(--ink-2); white-space: nowrap;
+    box-shadow: 0 6px 22px rgba(0,0,0,0.6);
+  }
+  .tip b { color: var(--ink); font-family: var(--mono); font-weight: 600; }
+  .tip .t { color: var(--gold-bright); font-family: var(--serif); font-variant: small-caps; letter-spacing: 1px; }
+
+  /* ---------- tables ---------- */
+  .tblwrap { overflow-x: auto; }
+  table.data { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+  table.data th, table.data td { padding: 7px 10px; text-align: left; border-bottom: 1px solid var(--grid); }
+  table.data th {
+    font-size: 10.5px; letter-spacing: 1.5px; text-transform: uppercase; font-weight: 600;
+    color: var(--ink-3); border-bottom: 1px solid var(--line); white-space: nowrap;
+  }
+  table.data td { color: var(--ink-2); }
+  table.data td:first-child { color: var(--ink); }
+  table.data td.mono { font-family: var(--mono); font-size: 11.5px; white-space: nowrap; }
+  table.data td.wrap { font-size: 11px; font-family: var(--mono); }
+  .kind {
+    display: inline-block; font-family: var(--mono); font-size: 9px; letter-spacing: 1px;
+    text-transform: uppercase; padding: 1px 6px; border-radius: 999px;
+  }
+  .kind.code { color: #9fe6a0; border: 1px solid #2e6b34; }
+  .kind.assumption { color: #f3d489; border: 1px solid #7a6128; }
+
+  /* ---------- how it works ---------- */
+  .trio { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; text-align: center; }
+  @media (max-width: 760px) { .trio { grid-template-columns: 1fr; } }
+  .trio .step { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 10px 6px; }
+  .trio .glyph {
+    width: 52px; height: 52px; border-radius: 50%; display: grid; place-items: center;
+    border: 1px solid var(--gold-dim); background: radial-gradient(circle at 35% 30%, #2a2110, #14110b 70%);
+    font-size: 22px; color: var(--gold-bright);
+  }
+  .trio h3 {
+    font-family: var(--serif); font-variant: small-caps; letter-spacing: 2px;
+    font-size: 17px; color: var(--gold-bright); margin: 0; font-weight: 600;
+  }
+  .trio p { font-size: 12.5px; color: var(--ink-2); margin: 0; max-width: 30ch; }
+  @media (prefers-reduced-motion: no-preference) {
+    .glyph.fire { animation: emberpulse 3.2s ease-in-out infinite; }
+    @keyframes emberpulse {
+      0%, 100% { box-shadow: 0 0 10px rgba(217, 89, 38, 0.18); }
+      50%      { box-shadow: 0 0 26px rgba(217, 89, 38, 0.42); }
+    }
+  }
+
+  /* ---------- footnotes ---------- */
+  .foot p { font-size: 12px; color: var(--ink-3); margin: 0; }
+  .foot p + p { margin-top: 6px; }
+  .foot .nb { color: #b48a52; }
+</style>
+
+<div class="burncalc">
+  <div class="shell">
+
+    <div class="err" id="errBanner" role="alert"></div>
+
+    <header class="masthead">
+      <div class="rule" aria-hidden="true"></div>
+      <div class="eyebrow">World of ClaudeCraft</div>
+      <h1>$WOC Burn Tracker</h1>
+      <div class="mint">mint 3WjLscH2JsXLEFJZRA9z8ti8yRGxWGKbqymPd7UicRth &middot; on-chain ledger of every $WOC ever destroyed</div>
+    </header>
+
+    <section class="hero" aria-label="Totals">
+      <div class="cell">
+        <div class="big woc" id="heroWoc">-</div>
+        <div class="cap">Total burned</div>
+        <div class="sub2" id="chainStatus">loading…</div>
+      </div>
+      <div class="cell">
+        <div class="big usd" id="heroUsd">-</div>
+        <div class="cap">Total value</div>
+        <div class="sub2" id="priceStatus">loading…</div>
+      </div>
+    </section>
+
+    <!-- ================= burn feed ================= -->
+    <section class="card">
+      <div class="cardhead">
+        <h2>Burn Ledger</h2>
+        <div style="display:flex; gap:8px; align-items:center;">
+          <button class="chipbtn" id="refreshBtn" type="button">Refresh</button>
+          <button class="chipbtn" id="scanBtn" type="button">Scan deeper</button>
+        </div>
+      </div>
+      <p class="sub">Every spl-token burn of the $WOC mint found in its transaction history, newest first.</p>
+      <div class="feed" id="feed"></div>
+      <div style="display:flex; justify-content:space-between; align-items:center; gap:10px; flex-wrap:wrap;">
+        <span class="coverage" id="coverage"></span>
+        <button class="chipbtn" id="moreBtn" type="button" style="display:none;">Show more</button>
+      </div>
+    </section>
+
+    <!-- ================= stats ================= -->
+    <div class="statgrid">
+      <section class="card">
+        <div class="cardhead">
+          <h2>Period</h2>
+          <div class="seg" role="group" aria-label="Period">
+            <button data-period="day" aria-pressed="true">Day</button>
+            <button data-period="week" aria-pressed="false">Week</button>
+            <button data-period="month" aria-pressed="false">Month</button>
+          </div>
+        </div>
+        <div class="tiles">
+          <div class="tile"><div class="v ember" id="pWoc">-</div><div class="k" id="pWocK">$WOC burned / day</div></div>
+          <div class="tile"><div class="v" id="pUsd">-</div><div class="k" id="pUsdK">value / day</div></div>
+          <div class="tile"><div class="v" id="pTxs">-</div><div class="k" id="pTxsK">burn txs / day</div></div>
+        </div>
+        <p class="sub" id="periodNote"></p>
+      </section>
+
+      <section class="card">
+        <h2>Rate</h2>
+        <div class="tiles">
+          <div class="tile"><div class="v ember" id="rDay">-</div><div class="k">avg $WOC / day (scanned)</div></div>
+          <div class="tile"><div class="v" id="rUsdDay">-</div><div class="k">avg value / day</div></div>
+          <div class="tile"><div class="v" id="rLast">-</div><div class="k">last burn</div></div>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Supply</h2>
+        <div class="tiles">
+          <div class="tile"><div class="v" id="sNow">-</div><div class="k">current supply</div></div>
+          <div class="tile"><div class="v ember" id="sPct">-</div><div class="k">of 1B initial burned</div></div>
+          <div class="tile"><div class="v" id="sPrice">-</div><div class="k">$WOC price</div></div>
+        </div>
+      </section>
+    </div>
+
+    <!-- ================= cumulative chart ================= -->
+    <section class="card">
+      <h2>Burned Over Time</h2>
+      <p class="sub" id="chartNote">Cumulative $WOC destroyed, from the scanned burn history.</p>
+      <div class="chartbox" id="areaBox">
+        <svg id="areaSvg" role="img" aria-label="Cumulative WOC burned over time."></svg>
+        <div class="tip" id="areaTip"></div>
+      </div>
+    </section>
+
+    <!-- ================= how it works ================= -->
+    <section class="card" aria-label="How WOC burning works">
+      <h2 style="text-align:center;">How $WOC Burning Works</h2>
+      <div class="trio">
+        <div class="step">
+          <div class="glyph" aria-hidden="true">&#9878;</div>
+          <h3>Spend</h3>
+          <p>Players spend $WOC on renames, respecs, Logol wares, wagers and voice NPCs; players and brands pay USDC/SOL for skins, characters, subs and ads.</p>
+        </div>
+        <div class="step">
+          <div class="glyph" aria-hidden="true">&#8646;</div>
+          <h3>Split</h3>
+          <p>Every payment routes through a split constant in code: 100% for $WOC sinks, 50% of Aldrin subs, 30% of skins and character sales, 50% of $WOC ad spend.</p>
+        </div>
+        <div class="step">
+          <div class="glyph fire" aria-hidden="true">&#128293;</div>
+          <h3>Burn</h3>
+          <p>$WOC legs burn on-chain via SPL token burn; USD legs accumulate in burn vaults and a keeper market-buys $WOC and burns it. Supply only ever goes down.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================= mechanics provenance ================= -->
+    <section class="card foot" aria-label="Burn mechanics and caveats">
+      <h2>The Mechanics Behind the Burns</h2>
+      <div class="tblwrap">
+        <table class="data">
+          <thead><tr><th>Mechanic</th><th>Rate</th><th>Kind</th><th>Source</th></tr></thead>
+          <tbody id="mechTable"></tbody>
+        </table>
+      </div>
+      <p class="nb">Routes that do <b>not</b> burn: DEX-swap platform fee (25 bps &rarr; treasury &middot; svc #17), talent ware sales (80/20 performer/treasury &middot; #1554), USDC/SOL ad spend (treasury), merch &amp; Claudium card-rail margins (economy-service policy).</p>
+      <p>Total burned is computed as 1,000,000,000 (fixed pump.fun mint) minus the live on-chain supply - it is exact even when the transaction feed below has only been partially scanned. Data: Solana RPC + the game's price chain (Pyth/Jupiter). Add <span class="coverage">#p.rpc=https://your-rpc</span> to the URL to use a private RPC. Nothing on this page is financial advice.</p>
+    </section>
+
+  </div>
+</div>
+
+<script>
+/* __MODEL_START__ (generated from burn_model.js - do not edit here) */
+'use strict';
+/* ============================================================================
+ * WOC burn-tracker model - single source of truth.
+ *
+ * The tracker reports burns that have ALREADY happened on-chain:
+ *   - total burned  = initial supply (1e9, pump.fun fixed mint) minus the
+ *     mint's current on-chain supply (getTokenSupply) - always exact;
+ *   - the feed      = spl-token burn / burnChecked instructions found in the
+ *     mint's transaction history - best-effort, labeled by scan coverage.
+ *
+ * Everything here is pure and fail-closed (malformed/non-positive -> null,
+ * never a guess), mirroring the economy service's oracle style, and the node
+ * test suite executes this exact file (build.js embeds it byte-for-byte).
+ * ========================================================================== */
+
+/* --------------------------------------------------------------------------
+ * Market price - the same chain the game's economy service uses
+ * (svc-dexswap: claudium/oracle.ts + settlement/oracle_prices.ts): Pyth
+ * Hermes v2 when a feed id is configured, else the Jupiter price API (the
+ * aggregator the DEX-swap engine quotes through).
+ * ------------------------------------------------------------------------ */
+var PRICE_SOURCE = {
+  mint: '3WjLscH2JsXLEFJZRA9z8ti8yRGxWGKbqymPd7UicRth',            // WOC_MINT · woc_config.ts
+  jupiterUrl: 'https://lite-api.jup.ag/price/v3?ids=',              // DEX-swap quotes via Jupiter · svc #17
+  hermesUrl: 'https://hermes.pyth.network',                         // PYTH_HERMES_URL default shape · oracle.ts
+  pythFeedId: '',                                                   // PYTH_WOC_USD_FEED_ID - env-configured; none published in repo
+  maxAgeMs: 60000                                                   // CLAUDIUM_ORACLE_MAX_AGE_MS default · bootstrap.ts:166
+};
+
+/* Baked fallback for CSP-sandboxed hosts (the published artifact cannot make
+ * external requests). build.js refreshes this block on every build. */
+var PRICE_SNAPSHOT = /*__PRICE_SNAPSHOT_START__*/ {"usdPerWoc":0.00017699046166975,"source":"jupiter","fetchedAtMs":1784465855132} /*__PRICE_SNAPSHOT_END__*/;
+
+/* Pyth Hermes v2 shape: { parsed: [ { price: { price, expo, publish_time } } ] }
+ * Same math as the service: usdPerWoc = price * 10^expo. Staleness is the
+ * caller's check (publishMs vs maxAgeMs), as in fetchWocUsdPrice. */
+function parsePythV2(body) {
+  if (typeof body !== 'object' || body === null) return null;
+  var parsed = body.parsed;
+  if (!Array.isArray(parsed) || parsed.length === 0) return null;
+  var price = parsed[0] && parsed[0].price;
+  if (!price) return null;
+  var raw = Number(price.price);
+  var expo = Number(price.expo);
+  var publish = Number(price.publish_time);
+  if (!isFinite(raw) || expo !== Math.trunc(expo) || !isFinite(expo) || !isFinite(publish)) return null;
+  var usdPerWoc = raw * Math.pow(10, expo);
+  if (!(usdPerWoc > 0) || !isFinite(usdPerWoc)) return null;
+  return { usdPerWoc: usdPerWoc, publishMs: publish * 1000 };
+}
+
+/* Jupiter price v3 shape: { "<mint>": { usdPrice, ... } }. No publish time in
+ * the payload, so the caller stamps fetch time. */
+function parseJupiterV3(body, mint) {
+  if (typeof body !== 'object' || body === null) return null;
+  var entry = body[mint];
+  if (!entry || typeof entry !== 'object') return null;
+  var usd = Number(entry.usdPrice);
+  if (!(usd > 0) || !isFinite(usd)) return null;
+  return { usdPerWoc: usd, publishMs: null };
+}
+
+/* --------------------------------------------------------------------------
+ * Chain source - Solana JSON-RPC. The default public endpoint is rate-limited;
+ * a private RPC (e.g. Helius) can be supplied via the p.rpc URL param.
+ * ------------------------------------------------------------------------ */
+var CHAIN_SOURCE = {
+  rpcUrl: 'https://api.mainnet-beta.solana.com',
+  mint: PRICE_SOURCE.mint,
+  initialSupply: 1e9,        // pump.fun fixed 1B mint; matches WOC_MAX_SUPPLY · holder_tier.ts:8
+  decimals: 6,               // WOC_DECIMALS · woc_config.ts:34
+  sigPageLimit: 50,          // signatures per history page
+  explorerTxUrl: 'https://solscan.io/tx/'
+};
+
+/* Known burn authorities -> human labels. Attribution is additive: unknown
+ * authorities still show in the feed as plain on-chain burns. Extend as the
+ * game's mainnet keeper/treasury addresses become public. */
+var ATTRIBUTION = {};
+
+/* Baked chain snapshot (refreshed by build.js; live-refreshed by the page
+ * where the host allows fetches). burns: newest-first {sig, ms, amount,
+ * authority}. scannedSigs/oldestScannedMs describe feed coverage - the
+ * headline total NEVER depends on the feed. */
+var CHAIN_SNAPSHOT = /*__CHAIN_SNAPSHOT_START__*/ {"currentSupply":999557928.221353,"burns":[],"scannedSigs":120,"oldestScannedMs":1784441876000,"cursor":"ewKaSXgBAatSE1rjkTthF4hYajcnk7LGwahiVKQtQoEUGSiGyj3bjtxueRzuFV1GrcAoVcMXMu12MkN13kAGaEj","fetchedAtMs":1784466036339} /*__CHAIN_SNAPSHOT_END__*/;
+
+/* getTokenSupply result shape:
+ * { result: { value: { amount, decimals, uiAmount } } } */
+function parseTokenSupply(body) {
+  if (typeof body !== 'object' || body === null) return null;
+  var v = body.result && body.result.value;
+  if (!v) return null;
+  var ui = Number(v.uiAmount);
+  var dec = Number(v.decimals);
+  if (!(ui > 0) || !isFinite(ui) || !isFinite(dec)) return null;
+  return { uiAmount: ui, decimals: dec };
+}
+
+/* getSignaturesForAddress result shape:
+ * { result: [ { signature, blockTime, err, ... } ] }
+ * Failed transactions cannot have burned anything -> marked so callers skip
+ * hydrating them. */
+function parseSignatures(body) {
+  if (typeof body !== 'object' || body === null) return null;
+  var list = body.result;
+  if (!Array.isArray(list)) return null;
+  var out = [];
+  for (var i = 0; i < list.length; i++) {
+    var s = list[i];
+    if (!s || typeof s.signature !== 'string') continue;
+    out.push({
+      signature: s.signature,
+      blockTimeMs: isFinite(Number(s.blockTime)) ? Number(s.blockTime) * 1000 : 0,
+      failed: s.err !== null && s.err !== undefined
+    });
+  }
+  return out;
+}
+
+/* getTransaction (jsonParsed) -> burns of OUR mint inside this tx.
+ * Walks top-level and inner instructions for spl-token burn / burnChecked.
+ * amount: burn carries base units in info.amount; burnChecked carries
+ * info.tokenAmount.uiAmount. */
+function parseBurnsFromTx(body, mint, decimals) {
+  if (typeof body !== 'object' || body === null) return [];
+  var res = body.result;
+  if (!res || !res.transaction || !res.transaction.message) return [];
+  if (res.meta && res.meta.err) return []; // failed tx: nothing burned
+  var instrs = res.transaction.message.instructions || [];
+  var inner = [];
+  var groups = (res.meta && res.meta.innerInstructions) || [];
+  for (var g = 0; g < groups.length; g++) {
+    var gi = groups[g].instructions || [];
+    for (var j = 0; j < gi.length; j++) inner.push(gi[j]);
+  }
+  var all = instrs.concat(inner);
+  var sig = (res.transaction.signatures && res.transaction.signatures[0]) || '';
+  var ms = isFinite(Number(res.blockTime)) ? Number(res.blockTime) * 1000 : 0;
+  var burns = [];
+  for (var i = 0; i < all.length; i++) {
+    var p = all[i] && all[i].parsed;
+    if (!p || typeof p !== 'object') continue;
+    if (p.type !== 'burn' && p.type !== 'burnChecked') continue;
+    var info = p.info || {};
+    if (info.mint !== mint) continue;
+    var amount = null;
+    if (p.type === 'burn' && info.amount != null) {
+      var base = Number(info.amount);
+      if (isFinite(base) && base > 0) amount = base / Math.pow(10, decimals);
+    } else if (p.type === 'burnChecked' && info.tokenAmount) {
+      var ui = Number(info.tokenAmount.uiAmount);
+      if (isFinite(ui) && ui > 0) amount = ui;
+    }
+    if (!(amount > 0)) continue;
+    burns.push({
+      sig: sig,
+      ms: ms,
+      amount: amount,
+      authority: String(info.authority || info.multisigAuthority || '')
+    });
+  }
+  return burns;
+}
+
+/* Merge new burns into an existing list, dedupe by sig+amount, newest first. */
+function mergeBurns(existing, incoming) {
+  var seen = {};
+  existing.forEach(function (b) { seen[b.sig + '#' + b.amount] = true; });
+  var merged = existing.slice();
+  incoming.forEach(function (b) {
+    var k = b.sig + '#' + b.amount;
+    if (!seen[k]) { seen[k] = true; merged.push(b); }
+  });
+  merged.sort(function (a, b) { return b.ms - a.ms; });
+  return merged;
+}
+
+/* Rolling day/week/month stats over the scanned feed, ending at nowMs. */
+function windowStats(burns, nowMs) {
+  var W = { day: 86400000, week: 7 * 86400000, month: 30 * 86400000 };
+  var out = {};
+  Object.keys(W).forEach(function (k) {
+    var lo = nowMs - W[k], woc = 0, txs = 0;
+    burns.forEach(function (b) { if (b.ms >= lo && b.ms <= nowMs) { woc += b.amount; txs++; } });
+    out[k] = { woc: woc, txs: txs };
+  });
+  out.latestMs = burns.length ? burns[0].ms : 0;
+  return out;
+}
+
+/* p.rpc URL override: the only externalized-config knob the tracker takes.
+ * Only https URLs are accepted - anything else is reported, never applied. */
+function parseRpcOverride(search, hash) {
+  var qs = String(search || '').replace(/^\?/, '') + '&' + String(hash || '').replace(/^#/, '');
+  var params = new URLSearchParams(qs);
+  var raw = params.get('p.rpc');
+  if (raw == null || raw === '') return { rpcUrl: null, warnings: [] };
+  var ok = /^https:\/\/[\w.-]+(:\d+)?(\/[^\s]*)?$/.test(raw);
+  if (!ok) return { rpcUrl: null, warnings: ['ignoring p.rpc (must be an https URL): ' + raw] };
+  return { rpcUrl: raw, warnings: [] };
+}
+
+/* --------------------------------------------------------------------------
+ * The burn mechanics (display + provenance; the chain is the data source).
+ * kind 'code' = shipped constant · 'assumption' = no code constant exists.
+ * ------------------------------------------------------------------------ */
+var MECHANICS = [
+  { label: 'Character / guild renames, vanity, .sol subdomains', rate: '500 / 2,500 / 1,000 / 1,000 $WOC · 100% burn', kind: 'code', source: '#1496, #1499 · woc_config.ts (splitPrice, WOC_BURN_BPS=10000)' },
+  { label: 'Respec + loadout slots', rate: '750 / 1,500 $WOC · 100% burn', kind: 'code', source: '#1553 · woc_config.ts:83-84' },
+  { label: 'Voice NPC clone', rate: '25,000 $WOC · burn hardcoded (treasury=null)', kind: 'code', source: '#1099 · voice_npc.ts:145-147' },
+  { label: 'Logol merchant wares', rate: '5k-40k + 250k flagship · 100% burn', kind: 'code', source: '#1473 · content/logol.ts:160-201' },
+  { label: 'Arena wager rake', rate: '500 bps of pot, 100% burned · 1,000 bps hard cap', kind: 'code', source: '#799 · arena_wager_boot.ts:60 · woc_escrow lib.rs:32' },
+  { label: 'Aldrin Club subscription', rate: '$20/mo · 50% buy-and-burn', kind: 'code', source: '#938 · aldrin_config.ts:20,35' },
+  { label: 'Creator skins market', rate: '30% of USDC sales · buy-and-burn', kind: 'code', source: '#897 · marketplace.ts:56' },
+  { label: 'Character market', rate: '30% of sales · buyback-and-burn keeper', kind: 'code', source: '#1497 · character_market lib.rs:21' },
+  { label: 'Premium listing slots', rate: '$25 · 30% burn leg · 4 slots / 7 days', kind: 'code', source: '#1551 · premium_listings.ts:58-68' },
+  { label: '$WOC-rail ads', rate: '250 $WOC/min · 50% burned after approval', kind: 'code', source: 'ads fork #1 · woc_config.ts:142,153' },
+  { label: 'Talent slot fees', rate: '100% burned · tiered schedule, not in code', kind: 'assumption', source: 'talent/woc-featured-talent-program.md' },
+  { label: 'Claudium $WOC rail', rate: 'burn leg, BPS set by the economy service', kind: 'assumption', source: 'claudium_proxy.ts:57-64 · svc #16' }
+];
+
+/* --------------------------------------------------------------------------
+ * Formatters (pure; exercised by the tests).
+ * ------------------------------------------------------------------------ */
+function trimNum(x) {
+  var v = Math.abs(x) >= 100 ? Math.round(x) : Math.round(x * 10) / 10;
+  return String(v);
+}
+var fmt = {
+  n: function (n) {
+    if (!isFinite(n)) return '-';
+    var a = Math.abs(n);
+    if (a >= 1e9) return trimNum(n / 1e9) + 'B';
+    if (a >= 1e6) return trimNum(n / 1e6) + 'M';
+    if (a >= 1e3) return trimNum(n / 1e3) + 'K';
+    return trimNum(n);
+  },
+  usd: function (n) { return '$' + fmt.n(n); },
+  full: function (n) { return Math.round(n).toLocaleString('en-US'); },
+  full2: function (n) {
+    return n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  },
+  pct: function (x) {
+    if (x >= 10) return Math.round(x) + '%';
+    if (x >= 1) return (Math.round(x * 10) / 10) + '%';
+    return (Math.round(x * 1000) / 1000) + '%';
+  },
+  price: function (n) {
+    if (!isFinite(n) || n <= 0) return '-';
+    if (n >= 1) return '$' + n.toFixed(2);
+    if (n >= 0.01) return '$' + n.toFixed(4);
+    return '$' + Number(n.toPrecision(3));
+  },
+  ago: function (deltaMs) {
+    if (!isFinite(deltaMs) || deltaMs < 0) return '-';
+    var s = Math.round(deltaMs / 1000);
+    if (s < 60) return s + 's';
+    if (s < 3600) return Math.floor(s / 60) + 'm';
+    if (s < 86400) return Math.floor(s / 3600) + 'h';
+    return Math.floor(s / 86400) + 'd';
+  },
+  shortAddr: function (a) {
+    a = String(a || '');
+    return a.length > 12 ? a.slice(0, 4) + '…' + a.slice(-4) : a;
+  }
+};
+
+var WocBurnModel = {
+  PRICE_SOURCE: PRICE_SOURCE,
+  PRICE_SNAPSHOT: PRICE_SNAPSHOT,
+  parsePythV2: parsePythV2,
+  parseJupiterV3: parseJupiterV3,
+  CHAIN_SOURCE: CHAIN_SOURCE,
+  CHAIN_SNAPSHOT: CHAIN_SNAPSHOT,
+  ATTRIBUTION: ATTRIBUTION,
+  parseTokenSupply: parseTokenSupply,
+  parseSignatures: parseSignatures,
+  parseBurnsFromTx: parseBurnsFromTx,
+  mergeBurns: mergeBurns,
+  windowStats: windowStats,
+  parseRpcOverride: parseRpcOverride,
+  MECHANICS: MECHANICS,
+  fmt: fmt
+};
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = WocBurnModel;
+} else if (typeof window !== 'undefined') {
+  window.WocBurnModel = WocBurnModel;
+}
+
+/* __MODEL_END__ */
+</script>
+
+<script>
+(function () {
+  'use strict';
+
+  var M = window.WocBurnModel;
+  var $ = function (id) { return document.getElementById(id); };
+  var SVG_NS = 'http://www.w3.org/2000/svg';
+
+  /* ---------- runtime error surface ---------- */
+  function showError(msg) {
+    var b = $('errBanner');
+    b.innerHTML = '<b>Tracker error:</b> ' + String(msg).replace(/[<>&]/g, function (c) {
+      return { '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c];
+    }) + ' - reload to reset.';
+    b.classList.add('show');
+  }
+  window.addEventListener('error', function (e) { showError(e.message || 'unknown error'); });
+  window.addEventListener('unhandledrejection', function (e) { showError((e.reason && e.reason.message) || e.reason || 'unhandled rejection'); });
+
+  /* ---------- state (seeded from the build-time snapshot) ---------- */
+  var chain = {
+    currentSupply: M.CHAIN_SNAPSHOT.currentSupply || 0,
+    burns: (M.CHAIN_SNAPSHOT.burns || []).slice(),
+    scannedSigs: M.CHAIN_SNAPSHOT.scannedSigs || 0,
+    oldestScannedMs: M.CHAIN_SNAPSHOT.oldestScannedMs || 0,
+    cursor: M.CHAIN_SNAPSHOT.cursor || '',
+    fetchedAtMs: M.CHAIN_SNAPSHOT.fetchedAtMs || 0,
+    live: false
+  };
+  var price = {
+    usdPerWoc: M.PRICE_SNAPSHOT.usdPerWoc,
+    source: M.PRICE_SNAPSHOT.source,
+    fetchedAtMs: M.PRICE_SNAPSHOT.fetchedAtMs,
+    live: false
+  };
+  var ui = { period: 'day', feedExpanded: false, scanning: false };
+
+  var rpcUrl = M.CHAIN_SOURCE.rpcUrl;
+  var ov = M.parseRpcOverride(location.search, location.hash);
+  ov.warnings.forEach(function (w) { console.warn('[burntracker] ' + w); });
+  if (ov.rpcUrl) { rpcUrl = ov.rpcUrl; console.info('[burntracker] using custom RPC: ' + rpcUrl); }
+
+  /* ---------- fetch plumbing (fail-closed; snapshot survives any failure) ---------- */
+  function abortIn(ms) {
+    return (typeof AbortSignal !== 'undefined' && AbortSignal.timeout) ? AbortSignal.timeout(ms) : undefined;
+  }
+  function rpc(method, params, timeoutMs) {
+    return fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: method, params: params }),
+      signal: abortIn(timeoutMs || 12000)
+    }).then(function (r) {
+      if (r.status === 429) return Promise.reject(new Error('RPC rate-limited (429) - consider #p.rpc=<your https RPC>'));
+      if (!r.ok) return Promise.reject(new Error('RPC HTTP ' + r.status));
+      return r.json();
+    });
+  }
+
+  function fetchLivePrice() {
+    var src = M.PRICE_SOURCE;
+    function viaJupiter() {
+      return fetch(src.jupiterUrl + src.mint, { signal: abortIn(8000) })
+        .then(function (r) { return r.ok ? r.json() : Promise.reject(new Error('HTTP ' + r.status)); })
+        .then(function (body) {
+          var p = M.parseJupiterV3(body, src.mint);
+          return p ? { usdPerWoc: p.usdPerWoc, source: 'jupiter' } : Promise.reject(new Error('unparseable payload'));
+        });
+    }
+    if (!src.pythFeedId) return viaJupiter();
+    var url = src.hermesUrl.replace(/\/$/, '') + '/v2/updates/price/latest?ids[]=' + encodeURIComponent(src.pythFeedId);
+    return fetch(url, { signal: abortIn(8000) })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(new Error('HTTP ' + r.status)); })
+      .then(function (body) {
+        var p = M.parsePythV2(body);
+        if (p && Date.now() - p.publishMs <= src.maxAgeMs) return { usdPerWoc: p.usdPerWoc, source: 'pyth' };
+        return Promise.reject(new Error('pyth stale/unparseable'));
+      })
+      .catch(function () { return viaJupiter(); });
+  }
+
+  /* Hydrate a list of signatures into burns, gently (sequential, small gap). */
+  function hydrateSigs(sigs, onProgress) {
+    var found = [];
+    var i = 0;
+    function next() {
+      if (i >= sigs.length) return Promise.resolve(found);
+      var s = sigs[i++];
+      if (onProgress) onProgress(i, sigs.length);
+      return rpc('getTransaction', [s.signature, { encoding: 'jsonParsed', maxSupportedTransactionVersion: 0 }], 15000)
+        .then(function (body) {
+          M.parseBurnsFromTx(body, M.CHAIN_SOURCE.mint, M.CHAIN_SOURCE.decimals)
+            .forEach(function (b) { found.push(b); });
+        })
+        .catch(function (e) { console.warn('[burntracker] tx hydrate failed: ' + e.message); })
+        .then(function () { return new Promise(function (res) { setTimeout(res, 180); }); })
+        .then(next);
+    }
+    return next();
+  }
+
+  /* Refresh: supply + price + newest page of history. */
+  function refresh() {
+    $('refreshBtn').disabled = true;
+    var pSupply = rpc('getTokenSupply', [M.CHAIN_SOURCE.mint]).then(function (body) {
+      var s = M.parseTokenSupply(body);
+      if (!s) throw new Error('unparseable supply');
+      chain.currentSupply = s.uiAmount;
+      chain.fetchedAtMs = Date.now();
+      chain.live = true;
+      renderAll(); // headline goes live immediately; feed hydration continues behind
+    });
+    var pPrice = fetchLivePrice().then(function (live) {
+      price = { usdPerWoc: live.usdPerWoc, source: live.source, fetchedAtMs: Date.now(), live: true };
+      renderAll();
+    });
+    var pFeed = rpc('getSignaturesForAddress', [M.CHAIN_SOURCE.mint, { limit: M.CHAIN_SOURCE.sigPageLimit }])
+      .then(function (body) {
+        var sigs = M.parseSignatures(body);
+        if (!sigs) throw new Error('unparseable signatures');
+        var known = {};
+        chain.burns.forEach(function (b) { known[b.sig] = true; });
+        var fresh = sigs.filter(function (s) { return !s.failed && !known[s.signature]; }).slice(0, 25);
+        if (!chain.cursor && sigs.length) chain.cursor = sigs[sigs.length - 1].signature;
+        return hydrateSigs(fresh).then(function (burns) {
+          chain.burns = M.mergeBurns(chain.burns, burns);
+          chain.scannedSigs += fresh.length;
+          var oldest = sigs.length ? sigs[sigs.length - 1].blockTimeMs : 0;
+          if (!chain.oldestScannedMs || (oldest && oldest < chain.oldestScannedMs)) chain.oldestScannedMs = chain.oldestScannedMs || oldest;
+        });
+      });
+    return Promise.allSettled([pSupply, pPrice, pFeed]).then(function (results) {
+      results.forEach(function (r) { if (r.status === 'rejected') console.warn('[burntracker] refresh: ' + r.reason.message); });
+      $('refreshBtn').disabled = false;
+      renderAll();
+    });
+  }
+
+  /* Scan deeper: page back from the cursor, hydrate, merge. */
+  function scanDeeper() {
+    if (ui.scanning) return;
+    ui.scanning = true;
+    var btn = $('scanBtn');
+    btn.disabled = true;
+    var opts = { limit: M.CHAIN_SOURCE.sigPageLimit };
+    if (chain.cursor) opts.before = chain.cursor;
+    rpc('getSignaturesForAddress', [M.CHAIN_SOURCE.mint, opts])
+      .then(function (body) {
+        var sigs = M.parseSignatures(body);
+        if (!sigs || !sigs.length) {
+          btn.textContent = 'History fully scanned';
+          return;
+        }
+        chain.cursor = sigs[sigs.length - 1].signature;
+        var ok = sigs.filter(function (s) { return !s.failed; });
+        return hydrateSigs(ok, function (i, n) { btn.textContent = 'Scanning… ' + i + '/' + n; })
+          .then(function (burns) {
+            chain.burns = M.mergeBurns(chain.burns, burns);
+            chain.scannedSigs += ok.length;
+            var oldest = sigs[sigs.length - 1].blockTimeMs;
+            if (oldest && (!chain.oldestScannedMs || oldest < chain.oldestScannedMs)) chain.oldestScannedMs = oldest;
+            btn.textContent = 'Scan deeper';
+          });
+      })
+      .catch(function (e) {
+        console.warn('[burntracker] scan: ' + e.message);
+        btn.textContent = 'Scan failed - retry';
+      })
+      .then(function () {
+        ui.scanning = false;
+        btn.disabled = false;
+        renderAll();
+      });
+  }
+
+  /* ---------- render ---------- */
+  function totalBurned() {
+    return chain.currentSupply > 0 ? Math.max(0, M.CHAIN_SOURCE.initialSupply - chain.currentSupply) : 0;
+  }
+
+  function renderHero() {
+    var burned = totalBurned();
+    $('heroWoc').textContent = chain.currentSupply > 0 ? M.fmt.full2(burned) + ' WOC' : '-';
+    $('heroUsd').textContent = chain.currentSupply > 0 ? '$' + M.fmt.full2(burned * price.usdPerWoc) : '-';
+    var cs = $('chainStatus');
+    if (chain.currentSupply > 0) {
+      cs.textContent = (chain.live ? 'live · solana rpc · ' : 'snapshot · ') +
+        (chain.fetchedAtMs ? M.fmt.ago(Date.now() - chain.fetchedAtMs) + ' ago' : 'unknown age');
+      cs.className = 'sub2' + (chain.live ? ' live' : '');
+    } else {
+      cs.textContent = 'supply unavailable - refresh or set #p.rpc=<https rpc>';
+      cs.className = 'sub2';
+    }
+    var ps = $('priceStatus');
+    ps.textContent = (price.live ? 'live · ' : 'snapshot · ') + price.source + ' · ' + M.fmt.price(price.usdPerWoc) +
+      (price.fetchedAtMs ? ' · ' + M.fmt.ago(Date.now() - price.fetchedAtMs) + ' ago' : '');
+    ps.className = 'sub2' + (price.live ? ' live' : '');
+  }
+
+  function renderFeed() {
+    var feed = $('feed');
+    feed.textContent = '';
+    var burns = chain.burns;
+    if (!burns.length) {
+      var d = document.createElement('div');
+      d.className = 'feed-empty';
+      d.innerHTML = 'No burn transactions found in the scanned window yet - <b>the total above is exact regardless</b> (it comes from live supply math, not this feed). Every money rail ships fail-closed behind flags; this ledger lights up row by row as mechanics fire on mainnet. Try <b>Scan deeper</b> to walk further back in history.';
+      feed.appendChild(d);
+      $('moreBtn').style.display = 'none';
+    } else {
+      var show = ui.feedExpanded ? burns : burns.slice(0, 12);
+      show.forEach(function (b) {
+        var row = document.createElement('div');
+        row.className = 'brow';
+        var who = M.ATTRIBUTION[b.authority] || M.fmt.shortAddr(b.authority) || 'unknown authority';
+        var l = document.createElement('div');
+        l.className = 'l1';
+        l.innerHTML = '<span class="amt">' + M.fmt.full2(b.amount) + ' WOC</span>' +
+          '<span class="burned">Burned &#128293;</span>' +
+          '<span class="who">' + who + '</span>';
+        var r = document.createElement('div');
+        r.className = 'r';
+        var a = document.createElement('a');
+        a.href = M.CHAIN_SOURCE.explorerTxUrl + encodeURIComponent(b.sig);
+        a.target = '_blank';
+        a.rel = 'noopener noreferrer';
+        a.textContent = M.fmt.shortAddr(b.sig);
+        var when = document.createElement('span');
+        when.className = 'when';
+        when.textContent = b.ms ? M.fmt.ago(Date.now() - b.ms) + ' ago' : '';
+        r.appendChild(a);
+        r.appendChild(when);
+        row.appendChild(l);
+        row.appendChild(r);
+        feed.appendChild(row);
+      });
+      $('moreBtn').style.display = burns.length > 12 && !ui.feedExpanded ? '' : 'none';
+    }
+    var scannedTotal = burns.reduce(function (t, b) { return t + b.amount; }, 0);
+    $('coverage').textContent = 'feed covers ' + chain.scannedSigs + ' scanned mint txs'
+      + (chain.oldestScannedMs ? ' back to ' + new Date(chain.oldestScannedMs).toISOString().slice(0, 10) : '')
+      + ' · ' + M.fmt.full2(scannedTotal) + ' WOC attributed of ' + M.fmt.full2(totalBurned()) + ' total';
+  }
+
+  function renderStats() {
+    var stats = M.windowStats(chain.burns, Date.now());
+    var w = stats[ui.period];
+    var lbl = ui.period === 'day' ? 'day' : ui.period === 'week' ? 'week' : '30d';
+    $('pWoc').textContent = M.fmt.n(w.woc);
+    $('pUsd').textContent = M.fmt.usd(w.woc * price.usdPerWoc);
+    $('pTxs').textContent = String(w.txs);
+    $('pWocK').textContent = '$WOC burned / ' + lbl;
+    $('pUsdK').textContent = 'value / ' + lbl;
+    $('pTxsK').textContent = 'burn txs / ' + lbl;
+    $('periodNote').textContent = 'From the scanned feed - scan deeper for older burns.';
+
+    var spanMs = chain.oldestScannedMs ? Date.now() - chain.oldestScannedMs : 0;
+    var spanDays = Math.max(spanMs / 86400000, 1 / 24);
+    var scannedTotal = chain.burns.reduce(function (t, b) { return t + b.amount; }, 0);
+    var perDay = chain.burns.length ? scannedTotal / spanDays : 0;
+    $('rDay').textContent = chain.burns.length ? M.fmt.n(perDay) : '-';
+    $('rUsdDay').textContent = chain.burns.length ? M.fmt.usd(perDay * price.usdPerWoc) : '-';
+    $('rLast').textContent = stats.latestMs ? M.fmt.ago(Date.now() - stats.latestMs) + ' ago' : 'none scanned';
+
+    $('sNow').textContent = chain.currentSupply > 0 ? M.fmt.full(chain.currentSupply) : '-';
+    $('sPct').textContent = chain.currentSupply > 0
+      ? M.fmt.pct(totalBurned() / M.CHAIN_SOURCE.initialSupply * 100) : '-';
+    $('sPrice').textContent = M.fmt.price(price.usdPerWoc);
+  }
+
+  /* ---------- cumulative chart ---------- */
+  function el(tag, attrs) {
+    var e = document.createElementNS(SVG_NS, tag);
+    for (var k in attrs) e.setAttribute(k, attrs[k]);
+    return e;
+  }
+
+  function renderChart() {
+    var svg = $('areaSvg'), tip = $('areaTip'), box = $('areaBox');
+    svg.textContent = '';
+    var burns = chain.burns.slice().reverse(); // oldest first
+    var note = $('chartNote');
+    if (burns.length < 2) {
+      svg.setAttribute('viewBox', '0 0 640 80');
+      var t = el('text', { x: 320, y: 45, 'text-anchor': 'middle', 'font-size': '13', fill: '#8a8270' });
+      t.textContent = burns.length ? 'One burn scanned - chart appears with two or more.' : 'No burns in the scanned window yet.';
+      svg.appendChild(t);
+      note.textContent = 'Cumulative $WOC destroyed, from the scanned burn history.';
+      return;
+    }
+    var offset = Math.max(0, totalBurned() - burns.reduce(function (t, b) { return t + b.amount; }, 0));
+    note.textContent = offset > 0.005
+      ? 'Cumulative $WOC destroyed. ' + M.fmt.full2(offset) + ' WOC was burned before/outside the scanned window (baseline).'
+      : 'Cumulative $WOC destroyed, from the scanned burn history.';
+
+    var pts = [];
+    var cum = offset;
+    burns.forEach(function (b) { cum += b.amount; pts.push({ ms: b.ms, v: cum }); });
+
+    var W = 640, H = 220, PADL = 56, PADR = 16, PADT = 12, PADB = 26;
+    svg.setAttribute('viewBox', '0 0 ' + W + ' ' + H);
+    var pw = W - PADL - PADR, ph = H - PADT - PADB;
+    var t0 = pts[0].ms, t1 = pts[pts.length - 1].ms;
+    if (t1 <= t0) t1 = t0 + 1;
+    var vMax = pts[pts.length - 1].v, vMin = offset;
+    var pad = Math.max((vMax - vMin) * 0.1, vMax * 0.001, 1);
+    var y0 = Math.max(0, vMin - pad), y1 = vMax + pad;
+    var X = function (ms) { return PADL + (ms - t0) / (t1 - t0) * pw; };
+    var Y = function (v) { return PADT + (1 - (v - y0) / (y1 - y0)) * ph; };
+
+    [0, 0.5, 1].forEach(function (f) {
+      var v = y0 + f * (y1 - y0);
+      var y = Y(v);
+      svg.appendChild(el('line', { x1: PADL, x2: W - PADR, y1: y, y2: y, stroke: '#221c11', 'stroke-width': 1 }));
+      var t = el('text', { x: PADL - 8, y: y + 4, 'font-size': '10.5', 'text-anchor': 'end',
+        fill: '#8a8270', 'font-family': 'ui-monospace, Menlo, monospace' });
+      t.textContent = M.fmt.n(v);
+      svg.appendChild(t);
+    });
+    [0, 0.5, 1].forEach(function (f) {
+      var ms = t0 + f * (t1 - t0);
+      var t = el('text', { x: X(ms), y: H - 8, 'font-size': '10.5',
+        'text-anchor': f === 0 ? 'start' : f === 1 ? 'end' : 'middle',
+        fill: '#8a8270', 'font-family': 'ui-monospace, Menlo, monospace' });
+      t.textContent = new Date(ms).toISOString().slice(5, 10);
+      svg.appendChild(t);
+    });
+
+    // step path (burns are discrete events)
+    var d = 'M' + X(pts[0].ms) + ',' + Y(pts[0].v);
+    for (var i = 1; i < pts.length; i++) {
+      d += ' L' + X(pts[i].ms) + ',' + Y(pts[i - 1].v) + ' L' + X(pts[i].ms) + ',' + Y(pts[i].v);
+    }
+    var area = d + ' L' + X(t1) + ',' + Y(y0) + ' L' + X(t0) + ',' + Y(y0) + ' Z';
+    svg.appendChild(el('path', { d: area, fill: 'rgba(217,89,38,0.16)' }));
+    svg.appendChild(el('path', { d: d, fill: 'none', stroke: '#d95926', 'stroke-width': 2 }));
+    svg.appendChild(el('circle', { cx: X(t1), cy: Y(vMax), r: 5.5, fill: '#14110b' }));
+    svg.appendChild(el('circle', { cx: X(t1), cy: Y(vMax), r: 4, fill: '#d95926' }));
+
+    var cross = el('line', { x1: 0, x2: 0, y1: PADT, y2: H - PADB, stroke: '#6b5226', 'stroke-width': 1, visibility: 'hidden' });
+    svg.appendChild(cross);
+    var hit = el('rect', { x: PADL, y: PADT, width: pw, height: ph, fill: 'transparent' });
+    hit.addEventListener('mousemove', function (evt) {
+      var r = svg.getBoundingClientRect();
+      var fx = (evt.clientX - r.left) / r.width * W;
+      var best = 0, bd = Infinity;
+      for (var i = 0; i < pts.length; i++) {
+        var dd = Math.abs(X(pts[i].ms) - fx);
+        if (dd < bd) { bd = dd; best = i; }
+      }
+      var p = pts[best];
+      cross.setAttribute('x1', X(p.ms)); cross.setAttribute('x2', X(p.ms));
+      cross.setAttribute('visibility', 'visible');
+      tip.innerHTML = '<span class="t">' + new Date(p.ms).toISOString().slice(0, 10) + '</span><br>' +
+        'cumulative <b>' + M.fmt.full2(p.v) + '</b> WOC';
+      tip.style.display = 'block';
+      var br = box.getBoundingClientRect();
+      var lx = (evt.clientX - br.left) + 14;
+      tip.style.left = Math.min(lx, Math.max(br.width - tip.offsetWidth - 8, 0)) + 'px';
+      tip.style.top = (evt.clientY - br.top + 14) + 'px';
+    });
+    hit.addEventListener('mouseleave', function () {
+      tip.style.display = 'none'; cross.setAttribute('visibility', 'hidden');
+    });
+    svg.appendChild(hit);
+  }
+
+  function renderMechanics() {
+    var tb = $('mechTable');
+    tb.textContent = '';
+    M.MECHANICS.forEach(function (m) {
+      var tr = document.createElement('tr');
+      tr.innerHTML = '<td>' + m.label + '</td><td class="mono">' + m.rate + '</td>' +
+        '<td><span class="kind ' + m.kind + '">' + (m.kind === 'assumption' ? 'assumed' : m.kind) + '</span></td>' +
+        '<td class="wrap">' + m.source + '</td>';
+      tb.appendChild(tr);
+    });
+  }
+
+  function renderAll() {
+    renderHero();
+    renderFeed();
+    renderStats();
+    renderChart();
+  }
+
+  /* ---------- wiring ---------- */
+  document.querySelectorAll('.seg [data-period]').forEach(function (b) {
+    b.addEventListener('click', function () {
+      ui.period = b.getAttribute('data-period');
+      document.querySelectorAll('.seg [data-period]').forEach(function (x) {
+        x.setAttribute('aria-pressed', x === b ? 'true' : 'false');
+      });
+      renderStats();
+    });
+  });
+  $('refreshBtn').addEventListener('click', refresh);
+  $('scanBtn').addEventListener('click', scanDeeper);
+  $('moreBtn').addEventListener('click', function () { ui.feedExpanded = true; renderFeed(); });
+
+  /* ---------- boot ---------- */
+  renderMechanics();
+  renderAll();
+  refresh(); // upgrade snapshot -> live where the host allows fetches
+})();
+</script>

--- a/tools/burn-tracker/README.md
+++ b/tools/burn-tracker/README.md
@@ -1,0 +1,55 @@
+# $WOC Burn Tracker
+
+Single-file static page (`/burn.html`, sibling of `admin.html` and `guide.html`)
+showing $WOC that has actually been destroyed on-chain by the ecosystem's burn
+mechanics.
+
+## Data sources
+
+- **Total burned** is exact math, independent of any indexer: 1,000,000,000
+  (fixed pump.fun mint, matches `WOC_MAX_SUPPLY` in `src/sim/holder_tier.ts`)
+  minus the mint's live `getTokenSupply`.
+- **USD value** uses the same fail-closed price chain as the economy service:
+  Pyth Hermes v2 when `PYTH_WOC_USD_FEED_ID` is configured, otherwise the
+  Jupiter price API for the pinned mint.
+- **Burn ledger** parses `burn` / `burnChecked` instructions of the $WOC mint
+  out of `getSignaturesForAddress` + `getTransaction (jsonParsed)`. The feed is
+  labeled by scan coverage; the headline total never depends on it.
+
+The page seeds from build-time snapshots (so it renders under a strict CSP with
+no network) and upgrades to live data on hosts that allow fetches. Append
+`#p.rpc=https://your-rpc` to use a private RPC; the default public endpoint
+rate-limits history hydration.
+
+## Build
+
+```
+node tools/burn-tracker/build.cjs
+```
+
+Fetches the live price, the live supply, scans recent mint history for burns
+(budget via `BUILD_SCAN_TX`, default 120; private RPC via `BUILD_RPC_URL`),
+stamps both snapshots into `burn_model.cjs`, and emits `/burn.html`. The build
+fails if the price or supply fetch fails (`ALLOW_STALE_PRICE=1` /
+`ALLOW_STALE_CHAIN=1` to ship the previous snapshot instead).
+
+## Test
+
+```
+node tools/burn-tracker/test_burn_model.cjs
+```
+
+Zero-dependency suite: parser fixtures captured from real mainnet responses,
+two live endpoint tests (Jupiter price, `getTokenSupply`), and a parity test
+that asserts `burn.html` embeds `burn_model.cjs` byte-for-byte.
+
+## Files
+
+- `burn_model.cjs`: pure model (parsers, snapshots, mechanics provenance,
+  formatters). Single source of truth; UMD, runs in node and the page.
+- `page-template.html`: page shell; `build.cjs` injects the model at a marker.
+- `build.cjs` / `test_burn_model.cjs`: build and test entry points.
+
+The `ATTRIBUTION` map in `burn_model.cjs` (burn authority -> label) is empty on
+purpose; fill it as mainnet keeper and treasury addresses become public so feed
+rows name the mechanic that burned.

--- a/tools/burn-tracker/build.cjs
+++ b/tools/burn-tracker/build.cjs
@@ -1,0 +1,181 @@
+'use strict';
+/* Build the WOC burn tracker:
+ *   1. Fetch the live $WOC/USD price (Pyth if a feed id is configured, else
+ *      Jupiter - the game's chain) and stamp PRICE_SNAPSHOT.
+ *   2. Fetch the mint's current supply (getTokenSupply) and scan its
+ *      transaction history for burn instructions, stamping CHAIN_SNAPSHOT.
+ *      Scan budget: BUILD_SCAN_TX txs (default 120), env-overridable.
+ *   3. Inject burn_model.cjs verbatim into page-template.html at the marker.
+ * Fail-closed: price or supply fetch failure fails the build unless
+ * ALLOW_STALE_PRICE=1 / ALLOW_STALE_CHAIN=1; a partial burn scan only warns
+ * (the headline total never depends on the feed). */
+const fs = require('fs');
+const path = require('path');
+
+const dir = __dirname;
+const MODEL_PATH = path.join(dir, 'burn_model.cjs');
+const MARKER = '/* __MODEL__ - replaced by build.js with the exact contents of burn_model.cjs */';
+const PRICE_RE = /\/\*__PRICE_SNAPSHOT_START__\*\/[\s\S]*?\/\*__PRICE_SNAPSHOT_END__\*\//;
+const CHAIN_RE = /\/\*__CHAIN_SNAPSHOT_START__\*\/[\s\S]*?\/\*__CHAIN_SNAPSHOT_END__\*\//;
+
+const RPC_URL = process.env.BUILD_RPC_URL || null; // optional private RPC for the build scan
+const SCAN_TX_BUDGET = Number(process.env.BUILD_SCAN_TX || 120);
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+async function rpc(M, method, params, attempt) {
+  const url = RPC_URL || M.CHAIN_SOURCE.rpcUrl;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+    signal: AbortSignal.timeout(20000)
+  });
+  if (res.status === 429 && (attempt || 0) < 4) {
+    const wait = 1500 * ((attempt || 0) + 1);
+    await sleep(wait);
+    return rpc(M, method, params, (attempt || 0) + 1);
+  }
+  if (!res.ok) throw new Error(method + ' HTTP ' + res.status);
+  return res.json();
+}
+
+async function fetchLivePrice(M) {
+  const src = M.PRICE_SOURCE;
+  if (src.pythFeedId) {
+    try {
+      const url = src.hermesUrl.replace(/\/$/, '') + '/v2/updates/price/latest?ids[]=' + encodeURIComponent(src.pythFeedId);
+      const res = await fetch(url, { signal: AbortSignal.timeout(10000) });
+      if (res.ok) {
+        const p = M.parsePythV2(await res.json());
+        if (p && Date.now() - p.publishMs <= src.maxAgeMs) {
+          return { usdPerWoc: p.usdPerWoc, source: 'pyth', fetchedAtMs: Date.now() };
+        }
+      }
+      console.warn('build: pyth failed/stale, falling through to jupiter');
+    } catch (e) {
+      console.warn('build: pyth error (' + e.message + '), falling through to jupiter');
+    }
+  }
+  const res = await fetch(src.jupiterUrl + src.mint, { signal: AbortSignal.timeout(10000) });
+  if (!res.ok) throw new Error('jupiter price HTTP ' + res.status);
+  const p = M.parseJupiterV3(await res.json(), src.mint);
+  if (!p) throw new Error('jupiter price payload unparseable');
+  return { usdPerWoc: p.usdPerWoc, source: 'jupiter', fetchedAtMs: Date.now() };
+}
+
+async function scanChain(M) {
+  const supplyBody = await rpc(M, 'getTokenSupply', [M.CHAIN_SOURCE.mint]);
+  const supply = M.parseTokenSupply(supplyBody);
+  if (!supply) throw new Error('unparseable getTokenSupply response');
+  console.log('current supply:', supply.uiAmount, '=> burned:',
+    (M.CHAIN_SOURCE.initialSupply - supply.uiAmount).toFixed(6), 'WOC');
+
+  let burns = [];
+  let scanned = 0;
+  let cursor = '';
+  let oldestMs = 0;
+  try {
+    while (scanned < SCAN_TX_BUDGET) {
+      const opts = { limit: M.CHAIN_SOURCE.sigPageLimit };
+      if (cursor) opts.before = cursor;
+      const sigsBody = await rpc(M, 'getSignaturesForAddress', [M.CHAIN_SOURCE.mint, opts]);
+      const sigs = M.parseSignatures(sigsBody);
+      if (!sigs || !sigs.length) break;
+      cursor = sigs[sigs.length - 1].signature;
+      oldestMs = sigs[sigs.length - 1].blockTimeMs || oldestMs;
+      const ok = sigs.filter(s => !s.failed).slice(0, SCAN_TX_BUDGET - scanned);
+      for (const s of ok) {
+        try {
+          const txBody = await rpc(M, 'getTransaction',
+            [s.signature, { encoding: 'jsonParsed', maxSupportedTransactionVersion: 0 }]);
+          const found = M.parseBurnsFromTx(txBody, M.CHAIN_SOURCE.mint, M.CHAIN_SOURCE.decimals);
+          if (found.length) {
+            burns = M.mergeBurns(burns, found);
+            console.log('  burn found:', found.map(b => b.amount + ' WOC @ ' + b.sig.slice(0, 12)).join(', '));
+          }
+        } catch (e) {
+          console.warn('  tx hydrate failed (' + s.signature.slice(0, 12) + '…): ' + e.message);
+        }
+        scanned++;
+        await sleep(220);
+      }
+      if (sigs.length < M.CHAIN_SOURCE.sigPageLimit) break; // history exhausted
+    }
+  } catch (e) {
+    console.warn('build: burn scan stopped early (' + e.message + ') - shipping partial feed');
+  }
+  console.log('scanned', scanned, 'txs; burns found:', burns.length);
+  return {
+    currentSupply: supply.uiAmount,
+    burns,
+    scannedSigs: scanned,
+    oldestScannedMs: oldestMs,
+    cursor,
+    fetchedAtMs: Date.now()
+  };
+}
+
+function stamp(modelSrc, re, name, obj) {
+  const block = '/*__' + name + '_START__*/ ' + JSON.stringify(obj) + ' /*__' + name + '_END__*/';
+  if (!re.test(modelSrc)) throw new Error(name + ' markers missing in burn_model.js');
+  return modelSrc.replace(re, () => block);
+}
+
+(async () => {
+  const M = require(MODEL_PATH);
+  let modelSrc = fs.readFileSync(MODEL_PATH, 'utf8');
+
+  // 1. price snapshot
+  try {
+    const live = await fetchLivePrice(M);
+    modelSrc = stamp(modelSrc, PRICE_RE, 'PRICE_SNAPSHOT', live);
+    console.log('price snapshot:', live.usdPerWoc, 'USD/WOC via', live.source);
+  } catch (e) {
+    if (process.env.ALLOW_STALE_PRICE === '1') {
+      console.warn('build: price fetch FAILED (' + e.message + '); shipping previous snapshot');
+    } else {
+      console.error('build FAILED: cannot fetch live price (' + e.message + '). ALLOW_STALE_PRICE=1 to override.');
+      process.exit(1);
+    }
+  }
+
+  // 2. chain snapshot
+  try {
+    const chain = await scanChain(M);
+    modelSrc = stamp(modelSrc, CHAIN_RE, 'CHAIN_SNAPSHOT', chain);
+  } catch (e) {
+    if (process.env.ALLOW_STALE_CHAIN === '1') {
+      console.warn('build: chain fetch FAILED (' + e.message + '); shipping previous snapshot');
+    } else {
+      console.error('build FAILED: cannot fetch chain state (' + e.message + '). ALLOW_STALE_CHAIN=1 to override.');
+      process.exit(1);
+    }
+  }
+
+  fs.writeFileSync(MODEL_PATH, modelSrc);
+
+  // final parse check on the stamped model
+  delete require.cache[require.resolve(MODEL_PATH)];
+  const M2 = require(MODEL_PATH);
+  if (!(M2.PRICE_SNAPSHOT.usdPerWoc > 0)) {
+    console.error('build FAILED: snapshot price not positive after stamp');
+    process.exit(1);
+  }
+
+  // 3. inject into the template
+  const template = fs.readFileSync(path.join(dir, 'page-template.html'), 'utf8');
+  if (!template.includes(MARKER)) {
+    console.error('build FAILED: model marker not found in template');
+    process.exit(1);
+  }
+  // NB: replacer must be a function - a replacement STRING would interpret
+  // `$'` / `$&` sequences inside the model source as replace() patterns.
+  const out = template.replace(MARKER, () =>
+    '/* __MODEL_START__ (generated from burn_model.js - do not edit here) */\n'
+    + modelSrc + '\n/* __MODEL_END__ */');
+
+  const outPath = path.join(dir, '..', '..', 'burn.html');
+  fs.writeFileSync(outPath, out);
+  console.log('built', outPath, out.length, 'bytes');
+})();

--- a/tools/burn-tracker/burn_model.cjs
+++ b/tools/burn-tracker/burn_model.cjs
@@ -1,0 +1,290 @@
+'use strict';
+/* ============================================================================
+ * WOC burn-tracker model - single source of truth.
+ *
+ * The tracker reports burns that have ALREADY happened on-chain:
+ *   - total burned  = initial supply (1e9, pump.fun fixed mint) minus the
+ *     mint's current on-chain supply (getTokenSupply) - always exact;
+ *   - the feed      = spl-token burn / burnChecked instructions found in the
+ *     mint's transaction history - best-effort, labeled by scan coverage.
+ *
+ * Everything here is pure and fail-closed (malformed/non-positive -> null,
+ * never a guess), mirroring the economy service's oracle style, and the node
+ * test suite executes this exact file (build.js embeds it byte-for-byte).
+ * ========================================================================== */
+
+/* --------------------------------------------------------------------------
+ * Market price - the same chain the game's economy service uses
+ * (svc-dexswap: claudium/oracle.ts + settlement/oracle_prices.ts): Pyth
+ * Hermes v2 when a feed id is configured, else the Jupiter price API (the
+ * aggregator the DEX-swap engine quotes through).
+ * ------------------------------------------------------------------------ */
+var PRICE_SOURCE = {
+  mint: '3WjLscH2JsXLEFJZRA9z8ti8yRGxWGKbqymPd7UicRth',            // WOC_MINT · woc_config.ts
+  jupiterUrl: 'https://lite-api.jup.ag/price/v3?ids=',              // DEX-swap quotes via Jupiter · svc #17
+  hermesUrl: 'https://hermes.pyth.network',                         // PYTH_HERMES_URL default shape · oracle.ts
+  pythFeedId: '',                                                   // PYTH_WOC_USD_FEED_ID - env-configured; none published in repo
+  maxAgeMs: 60000                                                   // CLAUDIUM_ORACLE_MAX_AGE_MS default · bootstrap.ts:166
+};
+
+/* Baked fallback for CSP-sandboxed hosts (the published artifact cannot make
+ * external requests). build.js refreshes this block on every build. */
+var PRICE_SNAPSHOT = /*__PRICE_SNAPSHOT_START__*/ {"usdPerWoc":0.00017699046166975,"source":"jupiter","fetchedAtMs":1784465855132} /*__PRICE_SNAPSHOT_END__*/;
+
+/* Pyth Hermes v2 shape: { parsed: [ { price: { price, expo, publish_time } } ] }
+ * Same math as the service: usdPerWoc = price * 10^expo. Staleness is the
+ * caller's check (publishMs vs maxAgeMs), as in fetchWocUsdPrice. */
+function parsePythV2(body) {
+  if (typeof body !== 'object' || body === null) return null;
+  var parsed = body.parsed;
+  if (!Array.isArray(parsed) || parsed.length === 0) return null;
+  var price = parsed[0] && parsed[0].price;
+  if (!price) return null;
+  var raw = Number(price.price);
+  var expo = Number(price.expo);
+  var publish = Number(price.publish_time);
+  if (!isFinite(raw) || expo !== Math.trunc(expo) || !isFinite(expo) || !isFinite(publish)) return null;
+  var usdPerWoc = raw * Math.pow(10, expo);
+  if (!(usdPerWoc > 0) || !isFinite(usdPerWoc)) return null;
+  return { usdPerWoc: usdPerWoc, publishMs: publish * 1000 };
+}
+
+/* Jupiter price v3 shape: { "<mint>": { usdPrice, ... } }. No publish time in
+ * the payload, so the caller stamps fetch time. */
+function parseJupiterV3(body, mint) {
+  if (typeof body !== 'object' || body === null) return null;
+  var entry = body[mint];
+  if (!entry || typeof entry !== 'object') return null;
+  var usd = Number(entry.usdPrice);
+  if (!(usd > 0) || !isFinite(usd)) return null;
+  return { usdPerWoc: usd, publishMs: null };
+}
+
+/* --------------------------------------------------------------------------
+ * Chain source - Solana JSON-RPC. The default public endpoint is rate-limited;
+ * a private RPC (e.g. Helius) can be supplied via the p.rpc URL param.
+ * ------------------------------------------------------------------------ */
+var CHAIN_SOURCE = {
+  rpcUrl: 'https://api.mainnet-beta.solana.com',
+  mint: PRICE_SOURCE.mint,
+  initialSupply: 1e9,        // pump.fun fixed 1B mint; matches WOC_MAX_SUPPLY · holder_tier.ts:8
+  decimals: 6,               // WOC_DECIMALS · woc_config.ts:34
+  sigPageLimit: 50,          // signatures per history page
+  explorerTxUrl: 'https://solscan.io/tx/'
+};
+
+/* Known burn authorities -> human labels. Attribution is additive: unknown
+ * authorities still show in the feed as plain on-chain burns. Extend as the
+ * game's mainnet keeper/treasury addresses become public. */
+var ATTRIBUTION = {};
+
+/* Baked chain snapshot (refreshed by build.js; live-refreshed by the page
+ * where the host allows fetches). burns: newest-first {sig, ms, amount,
+ * authority}. scannedSigs/oldestScannedMs describe feed coverage - the
+ * headline total NEVER depends on the feed. */
+var CHAIN_SNAPSHOT = /*__CHAIN_SNAPSHOT_START__*/ {"currentSupply":999557928.221353,"burns":[],"scannedSigs":120,"oldestScannedMs":1784441876000,"cursor":"ewKaSXgBAatSE1rjkTthF4hYajcnk7LGwahiVKQtQoEUGSiGyj3bjtxueRzuFV1GrcAoVcMXMu12MkN13kAGaEj","fetchedAtMs":1784466036339} /*__CHAIN_SNAPSHOT_END__*/;
+
+/* getTokenSupply result shape:
+ * { result: { value: { amount, decimals, uiAmount } } } */
+function parseTokenSupply(body) {
+  if (typeof body !== 'object' || body === null) return null;
+  var v = body.result && body.result.value;
+  if (!v) return null;
+  var ui = Number(v.uiAmount);
+  var dec = Number(v.decimals);
+  if (!(ui > 0) || !isFinite(ui) || !isFinite(dec)) return null;
+  return { uiAmount: ui, decimals: dec };
+}
+
+/* getSignaturesForAddress result shape:
+ * { result: [ { signature, blockTime, err, ... } ] }
+ * Failed transactions cannot have burned anything -> marked so callers skip
+ * hydrating them. */
+function parseSignatures(body) {
+  if (typeof body !== 'object' || body === null) return null;
+  var list = body.result;
+  if (!Array.isArray(list)) return null;
+  var out = [];
+  for (var i = 0; i < list.length; i++) {
+    var s = list[i];
+    if (!s || typeof s.signature !== 'string') continue;
+    out.push({
+      signature: s.signature,
+      blockTimeMs: isFinite(Number(s.blockTime)) ? Number(s.blockTime) * 1000 : 0,
+      failed: s.err !== null && s.err !== undefined
+    });
+  }
+  return out;
+}
+
+/* getTransaction (jsonParsed) -> burns of OUR mint inside this tx.
+ * Walks top-level and inner instructions for spl-token burn / burnChecked.
+ * amount: burn carries base units in info.amount; burnChecked carries
+ * info.tokenAmount.uiAmount. */
+function parseBurnsFromTx(body, mint, decimals) {
+  if (typeof body !== 'object' || body === null) return [];
+  var res = body.result;
+  if (!res || !res.transaction || !res.transaction.message) return [];
+  if (res.meta && res.meta.err) return []; // failed tx: nothing burned
+  var instrs = res.transaction.message.instructions || [];
+  var inner = [];
+  var groups = (res.meta && res.meta.innerInstructions) || [];
+  for (var g = 0; g < groups.length; g++) {
+    var gi = groups[g].instructions || [];
+    for (var j = 0; j < gi.length; j++) inner.push(gi[j]);
+  }
+  var all = instrs.concat(inner);
+  var sig = (res.transaction.signatures && res.transaction.signatures[0]) || '';
+  var ms = isFinite(Number(res.blockTime)) ? Number(res.blockTime) * 1000 : 0;
+  var burns = [];
+  for (var i = 0; i < all.length; i++) {
+    var p = all[i] && all[i].parsed;
+    if (!p || typeof p !== 'object') continue;
+    if (p.type !== 'burn' && p.type !== 'burnChecked') continue;
+    var info = p.info || {};
+    if (info.mint !== mint) continue;
+    var amount = null;
+    if (p.type === 'burn' && info.amount != null) {
+      var base = Number(info.amount);
+      if (isFinite(base) && base > 0) amount = base / Math.pow(10, decimals);
+    } else if (p.type === 'burnChecked' && info.tokenAmount) {
+      var ui = Number(info.tokenAmount.uiAmount);
+      if (isFinite(ui) && ui > 0) amount = ui;
+    }
+    if (!(amount > 0)) continue;
+    burns.push({
+      sig: sig,
+      ms: ms,
+      amount: amount,
+      authority: String(info.authority || info.multisigAuthority || '')
+    });
+  }
+  return burns;
+}
+
+/* Merge new burns into an existing list, dedupe by sig+amount, newest first. */
+function mergeBurns(existing, incoming) {
+  var seen = {};
+  existing.forEach(function (b) { seen[b.sig + '#' + b.amount] = true; });
+  var merged = existing.slice();
+  incoming.forEach(function (b) {
+    var k = b.sig + '#' + b.amount;
+    if (!seen[k]) { seen[k] = true; merged.push(b); }
+  });
+  merged.sort(function (a, b) { return b.ms - a.ms; });
+  return merged;
+}
+
+/* Rolling day/week/month stats over the scanned feed, ending at nowMs. */
+function windowStats(burns, nowMs) {
+  var W = { day: 86400000, week: 7 * 86400000, month: 30 * 86400000 };
+  var out = {};
+  Object.keys(W).forEach(function (k) {
+    var lo = nowMs - W[k], woc = 0, txs = 0;
+    burns.forEach(function (b) { if (b.ms >= lo && b.ms <= nowMs) { woc += b.amount; txs++; } });
+    out[k] = { woc: woc, txs: txs };
+  });
+  out.latestMs = burns.length ? burns[0].ms : 0;
+  return out;
+}
+
+/* p.rpc URL override: the only externalized-config knob the tracker takes.
+ * Only https URLs are accepted - anything else is reported, never applied. */
+function parseRpcOverride(search, hash) {
+  var qs = String(search || '').replace(/^\?/, '') + '&' + String(hash || '').replace(/^#/, '');
+  var params = new URLSearchParams(qs);
+  var raw = params.get('p.rpc');
+  if (raw == null || raw === '') return { rpcUrl: null, warnings: [] };
+  var ok = /^https:\/\/[\w.-]+(:\d+)?(\/[^\s]*)?$/.test(raw);
+  if (!ok) return { rpcUrl: null, warnings: ['ignoring p.rpc (must be an https URL): ' + raw] };
+  return { rpcUrl: raw, warnings: [] };
+}
+
+/* --------------------------------------------------------------------------
+ * The burn mechanics (display + provenance; the chain is the data source).
+ * kind 'code' = shipped constant · 'assumption' = no code constant exists.
+ * ------------------------------------------------------------------------ */
+var MECHANICS = [
+  { label: 'Character / guild renames, vanity, .sol subdomains', rate: '500 / 2,500 / 1,000 / 1,000 $WOC · 100% burn', kind: 'code', source: '#1496, #1499 · woc_config.ts (splitPrice, WOC_BURN_BPS=10000)' },
+  { label: 'Respec + loadout slots', rate: '750 / 1,500 $WOC · 100% burn', kind: 'code', source: '#1553 · woc_config.ts:83-84' },
+  { label: 'Voice NPC clone', rate: '25,000 $WOC · burn hardcoded (treasury=null)', kind: 'code', source: '#1099 · voice_npc.ts:145-147' },
+  { label: 'Logol merchant wares', rate: '5k-40k + 250k flagship · 100% burn', kind: 'code', source: '#1473 · content/logol.ts:160-201' },
+  { label: 'Arena wager rake', rate: '500 bps of pot, 100% burned · 1,000 bps hard cap', kind: 'code', source: '#799 · arena_wager_boot.ts:60 · woc_escrow lib.rs:32' },
+  { label: 'Aldrin Club subscription', rate: '$20/mo · 50% buy-and-burn', kind: 'code', source: '#938 · aldrin_config.ts:20,35' },
+  { label: 'Creator skins market', rate: '30% of USDC sales · buy-and-burn', kind: 'code', source: '#897 · marketplace.ts:56' },
+  { label: 'Character market', rate: '30% of sales · buyback-and-burn keeper', kind: 'code', source: '#1497 · character_market lib.rs:21' },
+  { label: 'Premium listing slots', rate: '$25 · 30% burn leg · 4 slots / 7 days', kind: 'code', source: '#1551 · premium_listings.ts:58-68' },
+  { label: '$WOC-rail ads', rate: '250 $WOC/min · 50% burned after approval', kind: 'code', source: 'ads fork #1 · woc_config.ts:142,153' },
+  { label: 'Talent slot fees', rate: '100% burned · tiered schedule, not in code', kind: 'assumption', source: 'talent/woc-featured-talent-program.md' },
+  { label: 'Claudium $WOC rail', rate: 'burn leg, BPS set by the economy service', kind: 'assumption', source: 'claudium_proxy.ts:57-64 · svc #16' }
+];
+
+/* --------------------------------------------------------------------------
+ * Formatters (pure; exercised by the tests).
+ * ------------------------------------------------------------------------ */
+function trimNum(x) {
+  var v = Math.abs(x) >= 100 ? Math.round(x) : Math.round(x * 10) / 10;
+  return String(v);
+}
+var fmt = {
+  n: function (n) {
+    if (!isFinite(n)) return '-';
+    var a = Math.abs(n);
+    if (a >= 1e9) return trimNum(n / 1e9) + 'B';
+    if (a >= 1e6) return trimNum(n / 1e6) + 'M';
+    if (a >= 1e3) return trimNum(n / 1e3) + 'K';
+    return trimNum(n);
+  },
+  usd: function (n) { return '$' + fmt.n(n); },
+  full: function (n) { return Math.round(n).toLocaleString('en-US'); },
+  full2: function (n) {
+    return n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  },
+  pct: function (x) {
+    if (x >= 10) return Math.round(x) + '%';
+    if (x >= 1) return (Math.round(x * 10) / 10) + '%';
+    return (Math.round(x * 1000) / 1000) + '%';
+  },
+  price: function (n) {
+    if (!isFinite(n) || n <= 0) return '-';
+    if (n >= 1) return '$' + n.toFixed(2);
+    if (n >= 0.01) return '$' + n.toFixed(4);
+    return '$' + Number(n.toPrecision(3));
+  },
+  ago: function (deltaMs) {
+    if (!isFinite(deltaMs) || deltaMs < 0) return '-';
+    var s = Math.round(deltaMs / 1000);
+    if (s < 60) return s + 's';
+    if (s < 3600) return Math.floor(s / 60) + 'm';
+    if (s < 86400) return Math.floor(s / 3600) + 'h';
+    return Math.floor(s / 86400) + 'd';
+  },
+  shortAddr: function (a) {
+    a = String(a || '');
+    return a.length > 12 ? a.slice(0, 4) + '…' + a.slice(-4) : a;
+  }
+};
+
+var WocBurnModel = {
+  PRICE_SOURCE: PRICE_SOURCE,
+  PRICE_SNAPSHOT: PRICE_SNAPSHOT,
+  parsePythV2: parsePythV2,
+  parseJupiterV3: parseJupiterV3,
+  CHAIN_SOURCE: CHAIN_SOURCE,
+  CHAIN_SNAPSHOT: CHAIN_SNAPSHOT,
+  ATTRIBUTION: ATTRIBUTION,
+  parseTokenSupply: parseTokenSupply,
+  parseSignatures: parseSignatures,
+  parseBurnsFromTx: parseBurnsFromTx,
+  mergeBurns: mergeBurns,
+  windowStats: windowStats,
+  parseRpcOverride: parseRpcOverride,
+  MECHANICS: MECHANICS,
+  fmt: fmt
+};
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = WocBurnModel;
+} else if (typeof window !== 'undefined') {
+  window.WocBurnModel = WocBurnModel;
+}

--- a/tools/burn-tracker/page-template.html
+++ b/tools/burn-tracker/page-template.html
@@ -1,0 +1,745 @@
+<title>WOC Burn Tracker</title>
+<style>
+  /* ============ WOC burn chamber - deliberate single dark theme ============ */
+  :root { color-scheme: dark; }
+  .burncalc {
+    /* ground */
+    --page:        #0c0a06;
+    --surface:     #14110b;
+    --surface-2:   #1a1610;
+    --inset:       #0f0c07;
+    /* brand chrome (never a data series) */
+    --gold:        #d8b15a;
+    --gold-bright: #f3d489;
+    --gold-dim:    #6b5226;
+    /* ink */
+    --ink:         #e8dfc8;
+    --ink-2:       #b6ad95;
+    --ink-3:       #8a8270;
+    /* hairlines */
+    --line:        #2a2418;
+    --grid:        #221c11;
+    /* data accent (validated ≥3:1 on surface) */
+    --burn:        #d95926;
+
+    --serif: Georgia, 'Times New Roman', serif;
+    --sans: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;
+    --mono: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+  }
+  .burncalc {
+    background: var(--page);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 14px;
+    line-height: 1.5;
+    min-height: 100vh;
+    padding: 0 20px 72px;
+  }
+  .burncalc *, .burncalc *::before, .burncalc *::after { box-sizing: border-box; }
+  .shell { max-width: 980px; margin: 0 auto; display: flex; flex-direction: column; gap: 28px; }
+
+  /* ---------- runtime error surface ---------- */
+  .err {
+    display: none; margin-top: 16px; padding: 12px 16px; border-radius: 8px;
+    border: 1px solid #7a2a1a; background: #250f08; color: #e8b39a; font-size: 13px;
+  }
+  .err.show { display: block; }
+  .err b { color: #f3c8b0; }
+
+  /* ---------- header / hero ---------- */
+  .masthead { text-align: center; padding-top: 48px; display: flex; flex-direction: column; gap: 6px; }
+  .masthead .rule {
+    height: 1px; max-width: 420px; margin: 0 auto 18px; width: 100%;
+    background: linear-gradient(90deg, transparent, var(--gold-dim) 20%, var(--gold) 50%, var(--gold-dim) 80%, transparent);
+  }
+  .masthead .eyebrow {
+    font-size: 12px; letter-spacing: 5px; text-transform: uppercase; color: var(--ink-3);
+  }
+  .masthead h1 {
+    font-family: var(--serif); font-variant: small-caps; letter-spacing: 3px;
+    font-size: clamp(30px, 5vw, 44px); line-height: 1.1; color: var(--gold-bright);
+    margin: 0; text-wrap: balance; font-weight: 600;
+  }
+  .masthead .mint {
+    display: inline-block; margin: 8px auto 0; padding: 4px 14px; border-radius: 999px;
+    border: 1px solid var(--gold-dim); background: rgba(20, 17, 11, 0.8);
+    font-family: var(--mono); font-size: 11px; color: var(--ink-2); word-break: break-all;
+  }
+
+  .hero { display: flex; justify-content: center; align-items: stretch; gap: 0; flex-wrap: wrap; }
+  .hero .cell { padding: 10px 36px; text-align: center; }
+  .hero .cell + .cell { border-left: 1px solid var(--line); }
+  .hero .big {
+    font-family: var(--mono); font-size: clamp(30px, 4.5vw, 46px); line-height: 1.15; font-weight: 600;
+  }
+  .hero .big.woc { color: var(--burn); }
+  .hero .big.usd { color: var(--ink); }
+  .hero .cap { margin-top: 2px; font-size: 12px; letter-spacing: 2px; text-transform: uppercase; color: var(--ink-3); }
+  .hero .sub2 { margin-top: 4px; font-family: var(--mono); font-size: 10.5px; color: var(--ink-3); }
+  .hero .sub2.live { color: #9fe6a0; }
+  @media (max-width: 620px) {
+    .hero .cell + .cell { border-left: none; border-top: 1px solid var(--line); }
+    .hero { flex-direction: column; }
+  }
+
+  /* ---------- generic card ---------- */
+  .card {
+    background: linear-gradient(180deg, var(--surface-2), var(--surface));
+    border: 1px solid var(--line); border-radius: 10px; padding: 20px;
+    display: flex; flex-direction: column; gap: 14px;
+  }
+  .card > h2 {
+    font-family: var(--serif); font-variant: small-caps; letter-spacing: 2px; font-weight: 600;
+    font-size: 19px; color: var(--gold-bright); margin: 0;
+  }
+  .card .sub { font-size: 12.5px; color: var(--ink-3); margin: -8px 0 0; }
+  .cardhead { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; }
+
+  .chipbtn {
+    font: inherit; font-size: 12.5px; letter-spacing: 1px; cursor: pointer;
+    padding: 6px 14px; border-radius: 999px; border: 1px solid var(--line);
+    background: var(--inset); color: var(--ink-2);
+  }
+  .chipbtn:hover:not(:disabled) { border-color: var(--gold-dim); color: var(--gold-bright); }
+  .chipbtn:disabled { opacity: 0.5; cursor: default; }
+  .chipbtn:focus-visible, .seg button:focus-visible, .burncalc a:focus-visible {
+    outline: 2px solid var(--gold); outline-offset: 2px;
+  }
+
+  /* ---------- burn feed ---------- */
+  .feed { display: flex; flex-direction: column; gap: 8px; }
+  .brow {
+    display: grid; grid-template-columns: 1fr auto; gap: 4px 14px; align-items: center;
+    padding: 10px 14px; border: 1px solid var(--grid); border-radius: 8px; background: var(--inset);
+  }
+  .brow .l1 { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; min-width: 0; }
+  .brow .amt { font-family: var(--mono); font-size: 15px; font-weight: 600; color: var(--burn); white-space: nowrap; }
+  .brow .burned { font-size: 12px; color: var(--burn); letter-spacing: 1px; }
+  .brow .who {
+    font-family: var(--mono); font-size: 10.5px; color: var(--ink-3);
+    border: 1px solid var(--grid); border-radius: 999px; padding: 1px 8px; white-space: nowrap;
+  }
+  .brow .r { text-align: right; white-space: nowrap; }
+  .brow .r a { color: var(--ink-2); text-decoration: none; font-family: var(--mono); font-size: 11px; }
+  .brow .r a:hover { color: var(--gold-bright); text-decoration: underline; }
+  .brow .when { font-family: var(--mono); font-size: 11px; color: var(--ink-3); margin-left: 10px; }
+  .feed-empty {
+    padding: 26px 18px; text-align: center; border: 1px dashed var(--line); border-radius: 8px;
+    color: var(--ink-3); font-size: 13px;
+  }
+  .feed-empty b { color: var(--ink-2); }
+  .coverage { font-family: var(--mono); font-size: 10.5px; color: var(--ink-3); }
+
+  /* ---------- stat tiles + segmented ---------- */
+  .seg { display: inline-flex; border: 1px solid var(--line); border-radius: 999px; background: var(--inset); padding: 2px; }
+  .seg button {
+    font: inherit; font-size: 11.5px; letter-spacing: 1px; cursor: pointer; border: 1px solid transparent;
+    background: transparent; color: var(--ink-3); padding: 4px 12px; border-radius: 999px;
+  }
+  .seg button[aria-pressed="true"] { background: var(--surface-2); color: var(--gold-bright); border-color: var(--gold-dim); }
+
+  .statgrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+  @media (max-width: 860px) { .statgrid { grid-template-columns: 1fr; } }
+  .tiles { display: grid; grid-template-columns: 1fr; gap: 10px; }
+  .tile { background: var(--inset); border: 1px solid var(--grid); border-radius: 8px; padding: 12px 14px; min-width: 0; }
+  .tile .v { font-family: var(--mono); font-size: 21px; font-weight: 600; color: var(--ink); overflow-wrap: break-word; }
+  .tile .v.ember { color: var(--burn); }
+  .tile .k { font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ink-3); margin-top: 2px; }
+
+  /* ---------- chart ---------- */
+  .chartbox { position: relative; }
+  .chartbox svg { display: block; width: 100%; height: auto; }
+  .tip {
+    position: absolute; pointer-events: none; z-index: 5; display: none;
+    background: #0f0c07; border: 1px solid var(--gold-dim); border-radius: 7px;
+    padding: 8px 11px; font-size: 12px; color: var(--ink-2); white-space: nowrap;
+    box-shadow: 0 6px 22px rgba(0,0,0,0.6);
+  }
+  .tip b { color: var(--ink); font-family: var(--mono); font-weight: 600; }
+  .tip .t { color: var(--gold-bright); font-family: var(--serif); font-variant: small-caps; letter-spacing: 1px; }
+
+  /* ---------- tables ---------- */
+  .tblwrap { overflow-x: auto; }
+  table.data { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+  table.data th, table.data td { padding: 7px 10px; text-align: left; border-bottom: 1px solid var(--grid); }
+  table.data th {
+    font-size: 10.5px; letter-spacing: 1.5px; text-transform: uppercase; font-weight: 600;
+    color: var(--ink-3); border-bottom: 1px solid var(--line); white-space: nowrap;
+  }
+  table.data td { color: var(--ink-2); }
+  table.data td:first-child { color: var(--ink); }
+  table.data td.mono { font-family: var(--mono); font-size: 11.5px; white-space: nowrap; }
+  table.data td.wrap { font-size: 11px; font-family: var(--mono); }
+  .kind {
+    display: inline-block; font-family: var(--mono); font-size: 9px; letter-spacing: 1px;
+    text-transform: uppercase; padding: 1px 6px; border-radius: 999px;
+  }
+  .kind.code { color: #9fe6a0; border: 1px solid #2e6b34; }
+  .kind.assumption { color: #f3d489; border: 1px solid #7a6128; }
+
+  /* ---------- how it works ---------- */
+  .trio { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; text-align: center; }
+  @media (max-width: 760px) { .trio { grid-template-columns: 1fr; } }
+  .trio .step { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 10px 6px; }
+  .trio .glyph {
+    width: 52px; height: 52px; border-radius: 50%; display: grid; place-items: center;
+    border: 1px solid var(--gold-dim); background: radial-gradient(circle at 35% 30%, #2a2110, #14110b 70%);
+    font-size: 22px; color: var(--gold-bright);
+  }
+  .trio h3 {
+    font-family: var(--serif); font-variant: small-caps; letter-spacing: 2px;
+    font-size: 17px; color: var(--gold-bright); margin: 0; font-weight: 600;
+  }
+  .trio p { font-size: 12.5px; color: var(--ink-2); margin: 0; max-width: 30ch; }
+  @media (prefers-reduced-motion: no-preference) {
+    .glyph.fire { animation: emberpulse 3.2s ease-in-out infinite; }
+    @keyframes emberpulse {
+      0%, 100% { box-shadow: 0 0 10px rgba(217, 89, 38, 0.18); }
+      50%      { box-shadow: 0 0 26px rgba(217, 89, 38, 0.42); }
+    }
+  }
+
+  /* ---------- footnotes ---------- */
+  .foot p { font-size: 12px; color: var(--ink-3); margin: 0; }
+  .foot p + p { margin-top: 6px; }
+  .foot .nb { color: #b48a52; }
+</style>
+
+<div class="burncalc">
+  <div class="shell">
+
+    <div class="err" id="errBanner" role="alert"></div>
+
+    <header class="masthead">
+      <div class="rule" aria-hidden="true"></div>
+      <div class="eyebrow">World of ClaudeCraft</div>
+      <h1>$WOC Burn Tracker</h1>
+      <div class="mint">mint 3WjLscH2JsXLEFJZRA9z8ti8yRGxWGKbqymPd7UicRth &middot; on-chain ledger of every $WOC ever destroyed</div>
+    </header>
+
+    <section class="hero" aria-label="Totals">
+      <div class="cell">
+        <div class="big woc" id="heroWoc">-</div>
+        <div class="cap">Total burned</div>
+        <div class="sub2" id="chainStatus">loading…</div>
+      </div>
+      <div class="cell">
+        <div class="big usd" id="heroUsd">-</div>
+        <div class="cap">Total value</div>
+        <div class="sub2" id="priceStatus">loading…</div>
+      </div>
+    </section>
+
+    <!-- ================= burn feed ================= -->
+    <section class="card">
+      <div class="cardhead">
+        <h2>Burn Ledger</h2>
+        <div style="display:flex; gap:8px; align-items:center;">
+          <button class="chipbtn" id="refreshBtn" type="button">Refresh</button>
+          <button class="chipbtn" id="scanBtn" type="button">Scan deeper</button>
+        </div>
+      </div>
+      <p class="sub">Every spl-token burn of the $WOC mint found in its transaction history, newest first.</p>
+      <div class="feed" id="feed"></div>
+      <div style="display:flex; justify-content:space-between; align-items:center; gap:10px; flex-wrap:wrap;">
+        <span class="coverage" id="coverage"></span>
+        <button class="chipbtn" id="moreBtn" type="button" style="display:none;">Show more</button>
+      </div>
+    </section>
+
+    <!-- ================= stats ================= -->
+    <div class="statgrid">
+      <section class="card">
+        <div class="cardhead">
+          <h2>Period</h2>
+          <div class="seg" role="group" aria-label="Period">
+            <button data-period="day" aria-pressed="true">Day</button>
+            <button data-period="week" aria-pressed="false">Week</button>
+            <button data-period="month" aria-pressed="false">Month</button>
+          </div>
+        </div>
+        <div class="tiles">
+          <div class="tile"><div class="v ember" id="pWoc">-</div><div class="k" id="pWocK">$WOC burned / day</div></div>
+          <div class="tile"><div class="v" id="pUsd">-</div><div class="k" id="pUsdK">value / day</div></div>
+          <div class="tile"><div class="v" id="pTxs">-</div><div class="k" id="pTxsK">burn txs / day</div></div>
+        </div>
+        <p class="sub" id="periodNote"></p>
+      </section>
+
+      <section class="card">
+        <h2>Rate</h2>
+        <div class="tiles">
+          <div class="tile"><div class="v ember" id="rDay">-</div><div class="k">avg $WOC / day (scanned)</div></div>
+          <div class="tile"><div class="v" id="rUsdDay">-</div><div class="k">avg value / day</div></div>
+          <div class="tile"><div class="v" id="rLast">-</div><div class="k">last burn</div></div>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Supply</h2>
+        <div class="tiles">
+          <div class="tile"><div class="v" id="sNow">-</div><div class="k">current supply</div></div>
+          <div class="tile"><div class="v ember" id="sPct">-</div><div class="k">of 1B initial burned</div></div>
+          <div class="tile"><div class="v" id="sPrice">-</div><div class="k">$WOC price</div></div>
+        </div>
+      </section>
+    </div>
+
+    <!-- ================= cumulative chart ================= -->
+    <section class="card">
+      <h2>Burned Over Time</h2>
+      <p class="sub" id="chartNote">Cumulative $WOC destroyed, from the scanned burn history.</p>
+      <div class="chartbox" id="areaBox">
+        <svg id="areaSvg" role="img" aria-label="Cumulative WOC burned over time."></svg>
+        <div class="tip" id="areaTip"></div>
+      </div>
+    </section>
+
+    <!-- ================= how it works ================= -->
+    <section class="card" aria-label="How WOC burning works">
+      <h2 style="text-align:center;">How $WOC Burning Works</h2>
+      <div class="trio">
+        <div class="step">
+          <div class="glyph" aria-hidden="true">&#9878;</div>
+          <h3>Spend</h3>
+          <p>Players spend $WOC on renames, respecs, Logol wares, wagers and voice NPCs; players and brands pay USDC/SOL for skins, characters, subs and ads.</p>
+        </div>
+        <div class="step">
+          <div class="glyph" aria-hidden="true">&#8646;</div>
+          <h3>Split</h3>
+          <p>Every payment routes through a split constant in code: 100% for $WOC sinks, 50% of Aldrin subs, 30% of skins and character sales, 50% of $WOC ad spend.</p>
+        </div>
+        <div class="step">
+          <div class="glyph fire" aria-hidden="true">&#128293;</div>
+          <h3>Burn</h3>
+          <p>$WOC legs burn on-chain via SPL token burn; USD legs accumulate in burn vaults and a keeper market-buys $WOC and burns it. Supply only ever goes down.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================= mechanics provenance ================= -->
+    <section class="card foot" aria-label="Burn mechanics and caveats">
+      <h2>The Mechanics Behind the Burns</h2>
+      <div class="tblwrap">
+        <table class="data">
+          <thead><tr><th>Mechanic</th><th>Rate</th><th>Kind</th><th>Source</th></tr></thead>
+          <tbody id="mechTable"></tbody>
+        </table>
+      </div>
+      <p class="nb">Routes that do <b>not</b> burn: DEX-swap platform fee (25 bps &rarr; treasury &middot; svc #17), talent ware sales (80/20 performer/treasury &middot; #1554), USDC/SOL ad spend (treasury), merch &amp; Claudium card-rail margins (economy-service policy).</p>
+      <p>Total burned is computed as 1,000,000,000 (fixed pump.fun mint) minus the live on-chain supply - it is exact even when the transaction feed below has only been partially scanned. Data: Solana RPC + the game's price chain (Pyth/Jupiter). Add <span class="coverage">#p.rpc=https://your-rpc</span> to the URL to use a private RPC. Nothing on this page is financial advice.</p>
+    </section>
+
+  </div>
+</div>
+
+<script>
+/* __MODEL__ - replaced by build.js with the exact contents of burn_model.cjs */
+</script>
+
+<script>
+(function () {
+  'use strict';
+
+  var M = window.WocBurnModel;
+  var $ = function (id) { return document.getElementById(id); };
+  var SVG_NS = 'http://www.w3.org/2000/svg';
+
+  /* ---------- runtime error surface ---------- */
+  function showError(msg) {
+    var b = $('errBanner');
+    b.innerHTML = '<b>Tracker error:</b> ' + String(msg).replace(/[<>&]/g, function (c) {
+      return { '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c];
+    }) + ' - reload to reset.';
+    b.classList.add('show');
+  }
+  window.addEventListener('error', function (e) { showError(e.message || 'unknown error'); });
+  window.addEventListener('unhandledrejection', function (e) { showError((e.reason && e.reason.message) || e.reason || 'unhandled rejection'); });
+
+  /* ---------- state (seeded from the build-time snapshot) ---------- */
+  var chain = {
+    currentSupply: M.CHAIN_SNAPSHOT.currentSupply || 0,
+    burns: (M.CHAIN_SNAPSHOT.burns || []).slice(),
+    scannedSigs: M.CHAIN_SNAPSHOT.scannedSigs || 0,
+    oldestScannedMs: M.CHAIN_SNAPSHOT.oldestScannedMs || 0,
+    cursor: M.CHAIN_SNAPSHOT.cursor || '',
+    fetchedAtMs: M.CHAIN_SNAPSHOT.fetchedAtMs || 0,
+    live: false
+  };
+  var price = {
+    usdPerWoc: M.PRICE_SNAPSHOT.usdPerWoc,
+    source: M.PRICE_SNAPSHOT.source,
+    fetchedAtMs: M.PRICE_SNAPSHOT.fetchedAtMs,
+    live: false
+  };
+  var ui = { period: 'day', feedExpanded: false, scanning: false };
+
+  var rpcUrl = M.CHAIN_SOURCE.rpcUrl;
+  var ov = M.parseRpcOverride(location.search, location.hash);
+  ov.warnings.forEach(function (w) { console.warn('[burntracker] ' + w); });
+  if (ov.rpcUrl) { rpcUrl = ov.rpcUrl; console.info('[burntracker] using custom RPC: ' + rpcUrl); }
+
+  /* ---------- fetch plumbing (fail-closed; snapshot survives any failure) ---------- */
+  function abortIn(ms) {
+    return (typeof AbortSignal !== 'undefined' && AbortSignal.timeout) ? AbortSignal.timeout(ms) : undefined;
+  }
+  function rpc(method, params, timeoutMs) {
+    return fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: method, params: params }),
+      signal: abortIn(timeoutMs || 12000)
+    }).then(function (r) {
+      if (r.status === 429) return Promise.reject(new Error('RPC rate-limited (429) - consider #p.rpc=<your https RPC>'));
+      if (!r.ok) return Promise.reject(new Error('RPC HTTP ' + r.status));
+      return r.json();
+    });
+  }
+
+  function fetchLivePrice() {
+    var src = M.PRICE_SOURCE;
+    function viaJupiter() {
+      return fetch(src.jupiterUrl + src.mint, { signal: abortIn(8000) })
+        .then(function (r) { return r.ok ? r.json() : Promise.reject(new Error('HTTP ' + r.status)); })
+        .then(function (body) {
+          var p = M.parseJupiterV3(body, src.mint);
+          return p ? { usdPerWoc: p.usdPerWoc, source: 'jupiter' } : Promise.reject(new Error('unparseable payload'));
+        });
+    }
+    if (!src.pythFeedId) return viaJupiter();
+    var url = src.hermesUrl.replace(/\/$/, '') + '/v2/updates/price/latest?ids[]=' + encodeURIComponent(src.pythFeedId);
+    return fetch(url, { signal: abortIn(8000) })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(new Error('HTTP ' + r.status)); })
+      .then(function (body) {
+        var p = M.parsePythV2(body);
+        if (p && Date.now() - p.publishMs <= src.maxAgeMs) return { usdPerWoc: p.usdPerWoc, source: 'pyth' };
+        return Promise.reject(new Error('pyth stale/unparseable'));
+      })
+      .catch(function () { return viaJupiter(); });
+  }
+
+  /* Hydrate a list of signatures into burns, gently (sequential, small gap). */
+  function hydrateSigs(sigs, onProgress) {
+    var found = [];
+    var i = 0;
+    function next() {
+      if (i >= sigs.length) return Promise.resolve(found);
+      var s = sigs[i++];
+      if (onProgress) onProgress(i, sigs.length);
+      return rpc('getTransaction', [s.signature, { encoding: 'jsonParsed', maxSupportedTransactionVersion: 0 }], 15000)
+        .then(function (body) {
+          M.parseBurnsFromTx(body, M.CHAIN_SOURCE.mint, M.CHAIN_SOURCE.decimals)
+            .forEach(function (b) { found.push(b); });
+        })
+        .catch(function (e) { console.warn('[burntracker] tx hydrate failed: ' + e.message); })
+        .then(function () { return new Promise(function (res) { setTimeout(res, 180); }); })
+        .then(next);
+    }
+    return next();
+  }
+
+  /* Refresh: supply + price + newest page of history. */
+  function refresh() {
+    $('refreshBtn').disabled = true;
+    var pSupply = rpc('getTokenSupply', [M.CHAIN_SOURCE.mint]).then(function (body) {
+      var s = M.parseTokenSupply(body);
+      if (!s) throw new Error('unparseable supply');
+      chain.currentSupply = s.uiAmount;
+      chain.fetchedAtMs = Date.now();
+      chain.live = true;
+      renderAll(); // headline goes live immediately; feed hydration continues behind
+    });
+    var pPrice = fetchLivePrice().then(function (live) {
+      price = { usdPerWoc: live.usdPerWoc, source: live.source, fetchedAtMs: Date.now(), live: true };
+      renderAll();
+    });
+    var pFeed = rpc('getSignaturesForAddress', [M.CHAIN_SOURCE.mint, { limit: M.CHAIN_SOURCE.sigPageLimit }])
+      .then(function (body) {
+        var sigs = M.parseSignatures(body);
+        if (!sigs) throw new Error('unparseable signatures');
+        var known = {};
+        chain.burns.forEach(function (b) { known[b.sig] = true; });
+        var fresh = sigs.filter(function (s) { return !s.failed && !known[s.signature]; }).slice(0, 25);
+        if (!chain.cursor && sigs.length) chain.cursor = sigs[sigs.length - 1].signature;
+        return hydrateSigs(fresh).then(function (burns) {
+          chain.burns = M.mergeBurns(chain.burns, burns);
+          chain.scannedSigs += fresh.length;
+          var oldest = sigs.length ? sigs[sigs.length - 1].blockTimeMs : 0;
+          if (!chain.oldestScannedMs || (oldest && oldest < chain.oldestScannedMs)) chain.oldestScannedMs = chain.oldestScannedMs || oldest;
+        });
+      });
+    return Promise.allSettled([pSupply, pPrice, pFeed]).then(function (results) {
+      results.forEach(function (r) { if (r.status === 'rejected') console.warn('[burntracker] refresh: ' + r.reason.message); });
+      $('refreshBtn').disabled = false;
+      renderAll();
+    });
+  }
+
+  /* Scan deeper: page back from the cursor, hydrate, merge. */
+  function scanDeeper() {
+    if (ui.scanning) return;
+    ui.scanning = true;
+    var btn = $('scanBtn');
+    btn.disabled = true;
+    var opts = { limit: M.CHAIN_SOURCE.sigPageLimit };
+    if (chain.cursor) opts.before = chain.cursor;
+    rpc('getSignaturesForAddress', [M.CHAIN_SOURCE.mint, opts])
+      .then(function (body) {
+        var sigs = M.parseSignatures(body);
+        if (!sigs || !sigs.length) {
+          btn.textContent = 'History fully scanned';
+          return;
+        }
+        chain.cursor = sigs[sigs.length - 1].signature;
+        var ok = sigs.filter(function (s) { return !s.failed; });
+        return hydrateSigs(ok, function (i, n) { btn.textContent = 'Scanning… ' + i + '/' + n; })
+          .then(function (burns) {
+            chain.burns = M.mergeBurns(chain.burns, burns);
+            chain.scannedSigs += ok.length;
+            var oldest = sigs[sigs.length - 1].blockTimeMs;
+            if (oldest && (!chain.oldestScannedMs || oldest < chain.oldestScannedMs)) chain.oldestScannedMs = oldest;
+            btn.textContent = 'Scan deeper';
+          });
+      })
+      .catch(function (e) {
+        console.warn('[burntracker] scan: ' + e.message);
+        btn.textContent = 'Scan failed - retry';
+      })
+      .then(function () {
+        ui.scanning = false;
+        btn.disabled = false;
+        renderAll();
+      });
+  }
+
+  /* ---------- render ---------- */
+  function totalBurned() {
+    return chain.currentSupply > 0 ? Math.max(0, M.CHAIN_SOURCE.initialSupply - chain.currentSupply) : 0;
+  }
+
+  function renderHero() {
+    var burned = totalBurned();
+    $('heroWoc').textContent = chain.currentSupply > 0 ? M.fmt.full2(burned) + ' WOC' : '-';
+    $('heroUsd').textContent = chain.currentSupply > 0 ? '$' + M.fmt.full2(burned * price.usdPerWoc) : '-';
+    var cs = $('chainStatus');
+    if (chain.currentSupply > 0) {
+      cs.textContent = (chain.live ? 'live · solana rpc · ' : 'snapshot · ') +
+        (chain.fetchedAtMs ? M.fmt.ago(Date.now() - chain.fetchedAtMs) + ' ago' : 'unknown age');
+      cs.className = 'sub2' + (chain.live ? ' live' : '');
+    } else {
+      cs.textContent = 'supply unavailable - refresh or set #p.rpc=<https rpc>';
+      cs.className = 'sub2';
+    }
+    var ps = $('priceStatus');
+    ps.textContent = (price.live ? 'live · ' : 'snapshot · ') + price.source + ' · ' + M.fmt.price(price.usdPerWoc) +
+      (price.fetchedAtMs ? ' · ' + M.fmt.ago(Date.now() - price.fetchedAtMs) + ' ago' : '');
+    ps.className = 'sub2' + (price.live ? ' live' : '');
+  }
+
+  function renderFeed() {
+    var feed = $('feed');
+    feed.textContent = '';
+    var burns = chain.burns;
+    if (!burns.length) {
+      var d = document.createElement('div');
+      d.className = 'feed-empty';
+      d.innerHTML = 'No burn transactions found in the scanned window yet - <b>the total above is exact regardless</b> (it comes from live supply math, not this feed). Every money rail ships fail-closed behind flags; this ledger lights up row by row as mechanics fire on mainnet. Try <b>Scan deeper</b> to walk further back in history.';
+      feed.appendChild(d);
+      $('moreBtn').style.display = 'none';
+    } else {
+      var show = ui.feedExpanded ? burns : burns.slice(0, 12);
+      show.forEach(function (b) {
+        var row = document.createElement('div');
+        row.className = 'brow';
+        var who = M.ATTRIBUTION[b.authority] || M.fmt.shortAddr(b.authority) || 'unknown authority';
+        var l = document.createElement('div');
+        l.className = 'l1';
+        l.innerHTML = '<span class="amt">' + M.fmt.full2(b.amount) + ' WOC</span>' +
+          '<span class="burned">Burned &#128293;</span>' +
+          '<span class="who">' + who + '</span>';
+        var r = document.createElement('div');
+        r.className = 'r';
+        var a = document.createElement('a');
+        a.href = M.CHAIN_SOURCE.explorerTxUrl + encodeURIComponent(b.sig);
+        a.target = '_blank';
+        a.rel = 'noopener noreferrer';
+        a.textContent = M.fmt.shortAddr(b.sig);
+        var when = document.createElement('span');
+        when.className = 'when';
+        when.textContent = b.ms ? M.fmt.ago(Date.now() - b.ms) + ' ago' : '';
+        r.appendChild(a);
+        r.appendChild(when);
+        row.appendChild(l);
+        row.appendChild(r);
+        feed.appendChild(row);
+      });
+      $('moreBtn').style.display = burns.length > 12 && !ui.feedExpanded ? '' : 'none';
+    }
+    var scannedTotal = burns.reduce(function (t, b) { return t + b.amount; }, 0);
+    $('coverage').textContent = 'feed covers ' + chain.scannedSigs + ' scanned mint txs'
+      + (chain.oldestScannedMs ? ' back to ' + new Date(chain.oldestScannedMs).toISOString().slice(0, 10) : '')
+      + ' · ' + M.fmt.full2(scannedTotal) + ' WOC attributed of ' + M.fmt.full2(totalBurned()) + ' total';
+  }
+
+  function renderStats() {
+    var stats = M.windowStats(chain.burns, Date.now());
+    var w = stats[ui.period];
+    var lbl = ui.period === 'day' ? 'day' : ui.period === 'week' ? 'week' : '30d';
+    $('pWoc').textContent = M.fmt.n(w.woc);
+    $('pUsd').textContent = M.fmt.usd(w.woc * price.usdPerWoc);
+    $('pTxs').textContent = String(w.txs);
+    $('pWocK').textContent = '$WOC burned / ' + lbl;
+    $('pUsdK').textContent = 'value / ' + lbl;
+    $('pTxsK').textContent = 'burn txs / ' + lbl;
+    $('periodNote').textContent = 'From the scanned feed - scan deeper for older burns.';
+
+    var spanMs = chain.oldestScannedMs ? Date.now() - chain.oldestScannedMs : 0;
+    var spanDays = Math.max(spanMs / 86400000, 1 / 24);
+    var scannedTotal = chain.burns.reduce(function (t, b) { return t + b.amount; }, 0);
+    var perDay = chain.burns.length ? scannedTotal / spanDays : 0;
+    $('rDay').textContent = chain.burns.length ? M.fmt.n(perDay) : '-';
+    $('rUsdDay').textContent = chain.burns.length ? M.fmt.usd(perDay * price.usdPerWoc) : '-';
+    $('rLast').textContent = stats.latestMs ? M.fmt.ago(Date.now() - stats.latestMs) + ' ago' : 'none scanned';
+
+    $('sNow').textContent = chain.currentSupply > 0 ? M.fmt.full(chain.currentSupply) : '-';
+    $('sPct').textContent = chain.currentSupply > 0
+      ? M.fmt.pct(totalBurned() / M.CHAIN_SOURCE.initialSupply * 100) : '-';
+    $('sPrice').textContent = M.fmt.price(price.usdPerWoc);
+  }
+
+  /* ---------- cumulative chart ---------- */
+  function el(tag, attrs) {
+    var e = document.createElementNS(SVG_NS, tag);
+    for (var k in attrs) e.setAttribute(k, attrs[k]);
+    return e;
+  }
+
+  function renderChart() {
+    var svg = $('areaSvg'), tip = $('areaTip'), box = $('areaBox');
+    svg.textContent = '';
+    var burns = chain.burns.slice().reverse(); // oldest first
+    var note = $('chartNote');
+    if (burns.length < 2) {
+      svg.setAttribute('viewBox', '0 0 640 80');
+      var t = el('text', { x: 320, y: 45, 'text-anchor': 'middle', 'font-size': '13', fill: '#8a8270' });
+      t.textContent = burns.length ? 'One burn scanned - chart appears with two or more.' : 'No burns in the scanned window yet.';
+      svg.appendChild(t);
+      note.textContent = 'Cumulative $WOC destroyed, from the scanned burn history.';
+      return;
+    }
+    var offset = Math.max(0, totalBurned() - burns.reduce(function (t, b) { return t + b.amount; }, 0));
+    note.textContent = offset > 0.005
+      ? 'Cumulative $WOC destroyed. ' + M.fmt.full2(offset) + ' WOC was burned before/outside the scanned window (baseline).'
+      : 'Cumulative $WOC destroyed, from the scanned burn history.';
+
+    var pts = [];
+    var cum = offset;
+    burns.forEach(function (b) { cum += b.amount; pts.push({ ms: b.ms, v: cum }); });
+
+    var W = 640, H = 220, PADL = 56, PADR = 16, PADT = 12, PADB = 26;
+    svg.setAttribute('viewBox', '0 0 ' + W + ' ' + H);
+    var pw = W - PADL - PADR, ph = H - PADT - PADB;
+    var t0 = pts[0].ms, t1 = pts[pts.length - 1].ms;
+    if (t1 <= t0) t1 = t0 + 1;
+    var vMax = pts[pts.length - 1].v, vMin = offset;
+    var pad = Math.max((vMax - vMin) * 0.1, vMax * 0.001, 1);
+    var y0 = Math.max(0, vMin - pad), y1 = vMax + pad;
+    var X = function (ms) { return PADL + (ms - t0) / (t1 - t0) * pw; };
+    var Y = function (v) { return PADT + (1 - (v - y0) / (y1 - y0)) * ph; };
+
+    [0, 0.5, 1].forEach(function (f) {
+      var v = y0 + f * (y1 - y0);
+      var y = Y(v);
+      svg.appendChild(el('line', { x1: PADL, x2: W - PADR, y1: y, y2: y, stroke: '#221c11', 'stroke-width': 1 }));
+      var t = el('text', { x: PADL - 8, y: y + 4, 'font-size': '10.5', 'text-anchor': 'end',
+        fill: '#8a8270', 'font-family': 'ui-monospace, Menlo, monospace' });
+      t.textContent = M.fmt.n(v);
+      svg.appendChild(t);
+    });
+    [0, 0.5, 1].forEach(function (f) {
+      var ms = t0 + f * (t1 - t0);
+      var t = el('text', { x: X(ms), y: H - 8, 'font-size': '10.5',
+        'text-anchor': f === 0 ? 'start' : f === 1 ? 'end' : 'middle',
+        fill: '#8a8270', 'font-family': 'ui-monospace, Menlo, monospace' });
+      t.textContent = new Date(ms).toISOString().slice(5, 10);
+      svg.appendChild(t);
+    });
+
+    // step path (burns are discrete events)
+    var d = 'M' + X(pts[0].ms) + ',' + Y(pts[0].v);
+    for (var i = 1; i < pts.length; i++) {
+      d += ' L' + X(pts[i].ms) + ',' + Y(pts[i - 1].v) + ' L' + X(pts[i].ms) + ',' + Y(pts[i].v);
+    }
+    var area = d + ' L' + X(t1) + ',' + Y(y0) + ' L' + X(t0) + ',' + Y(y0) + ' Z';
+    svg.appendChild(el('path', { d: area, fill: 'rgba(217,89,38,0.16)' }));
+    svg.appendChild(el('path', { d: d, fill: 'none', stroke: '#d95926', 'stroke-width': 2 }));
+    svg.appendChild(el('circle', { cx: X(t1), cy: Y(vMax), r: 5.5, fill: '#14110b' }));
+    svg.appendChild(el('circle', { cx: X(t1), cy: Y(vMax), r: 4, fill: '#d95926' }));
+
+    var cross = el('line', { x1: 0, x2: 0, y1: PADT, y2: H - PADB, stroke: '#6b5226', 'stroke-width': 1, visibility: 'hidden' });
+    svg.appendChild(cross);
+    var hit = el('rect', { x: PADL, y: PADT, width: pw, height: ph, fill: 'transparent' });
+    hit.addEventListener('mousemove', function (evt) {
+      var r = svg.getBoundingClientRect();
+      var fx = (evt.clientX - r.left) / r.width * W;
+      var best = 0, bd = Infinity;
+      for (var i = 0; i < pts.length; i++) {
+        var dd = Math.abs(X(pts[i].ms) - fx);
+        if (dd < bd) { bd = dd; best = i; }
+      }
+      var p = pts[best];
+      cross.setAttribute('x1', X(p.ms)); cross.setAttribute('x2', X(p.ms));
+      cross.setAttribute('visibility', 'visible');
+      tip.innerHTML = '<span class="t">' + new Date(p.ms).toISOString().slice(0, 10) + '</span><br>' +
+        'cumulative <b>' + M.fmt.full2(p.v) + '</b> WOC';
+      tip.style.display = 'block';
+      var br = box.getBoundingClientRect();
+      var lx = (evt.clientX - br.left) + 14;
+      tip.style.left = Math.min(lx, Math.max(br.width - tip.offsetWidth - 8, 0)) + 'px';
+      tip.style.top = (evt.clientY - br.top + 14) + 'px';
+    });
+    hit.addEventListener('mouseleave', function () {
+      tip.style.display = 'none'; cross.setAttribute('visibility', 'hidden');
+    });
+    svg.appendChild(hit);
+  }
+
+  function renderMechanics() {
+    var tb = $('mechTable');
+    tb.textContent = '';
+    M.MECHANICS.forEach(function (m) {
+      var tr = document.createElement('tr');
+      tr.innerHTML = '<td>' + m.label + '</td><td class="mono">' + m.rate + '</td>' +
+        '<td><span class="kind ' + m.kind + '">' + (m.kind === 'assumption' ? 'assumed' : m.kind) + '</span></td>' +
+        '<td class="wrap">' + m.source + '</td>';
+      tb.appendChild(tr);
+    });
+  }
+
+  function renderAll() {
+    renderHero();
+    renderFeed();
+    renderStats();
+    renderChart();
+  }
+
+  /* ---------- wiring ---------- */
+  document.querySelectorAll('.seg [data-period]').forEach(function (b) {
+    b.addEventListener('click', function () {
+      ui.period = b.getAttribute('data-period');
+      document.querySelectorAll('.seg [data-period]').forEach(function (x) {
+        x.setAttribute('aria-pressed', x === b ? 'true' : 'false');
+      });
+      renderStats();
+    });
+  });
+  $('refreshBtn').addEventListener('click', refresh);
+  $('scanBtn').addEventListener('click', scanDeeper);
+  $('moreBtn').addEventListener('click', function () { ui.feedExpanded = true; renderFeed(); });
+
+  /* ---------- boot ---------- */
+  renderMechanics();
+  renderAll();
+  refresh(); // upgrade snapshot -> live where the host allows fetches
+})();
+</script>

--- a/tools/burn-tracker/test_burn_model.cjs
+++ b/tools/burn-tracker/test_burn_model.cjs
@@ -1,0 +1,260 @@
+'use strict';
+/* Real-execution test suite for the WOC burn-tracker model. Zero dependencies,
+ * no mocks of the code under test: it requires the exact burn_model.js that
+ * build.js embeds into the page. Parser fixtures use REAL captured response
+ * shapes from mainnet RPC / Jupiter; two LIVE tests hit the real endpoints. */
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const M = require(path.join(__dirname, 'burn_model.cjs'));
+
+let passed = 0;
+const failures = [];
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); } // sync and async
+function close(actual, expected, name, eps) {
+  const e = eps == null ? 1e-9 : eps;
+  assert.ok(Math.abs(actual - expected) <= e * Math.max(1, Math.abs(expected)),
+    (name || 'value') + ': expected ' + expected + ', got ' + actual);
+}
+
+const MINT = M.CHAIN_SOURCE.mint;
+
+/* ---------------- price parsers (ports of the service's oracle) ---------------- */
+test('parsePythV2 matches the service math on a Hermes-shaped payload', () => {
+  const body = { parsed: [{ price: { price: '17499', expo: -8, publish_time: 1782950400 } }] };
+  const p = M.parsePythV2(body);
+  close(p.usdPerWoc, 17499e-8, 'price * 10^expo');
+  assert.strictEqual(p.publishMs, 1782950400000);
+  assert.strictEqual(M.parsePythV2({}), null);
+  assert.strictEqual(M.parsePythV2({ parsed: [] }), null);
+  assert.strictEqual(M.parsePythV2({ parsed: [{ price: { price: '-5', expo: -8, publish_time: 1 } }] }), null, 'non-positive fails closed');
+  assert.strictEqual(M.parsePythV2({ parsed: [{ price: { price: 'x', expo: -8, publish_time: 1 } }] }), null);
+});
+
+test('parseJupiterV3 parses the real captured payload shape, fail-closed otherwise', () => {
+  // shape captured live from lite-api.jup.ag on 2026-07-19
+  const body = {};
+  body[MINT] = { createdAt: '2026-06-12T08:29:19Z', liquidity: 21032.54, usdPrice: 0.00017499572561668891, blockId: 433891851, decimals: 6, priceChange24h: -34.65 };
+  const p = M.parseJupiterV3(body, MINT);
+  close(p.usdPerWoc, 0.00017499572561668891, 'usdPrice');
+  assert.strictEqual(p.publishMs, null);
+  assert.strictEqual(M.parseJupiterV3({}, MINT), null, 'missing mint');
+  assert.strictEqual(M.parseJupiterV3({ [MINT]: { usdPrice: 0 } }, MINT), null, 'zero price fails closed');
+  assert.strictEqual(M.parseJupiterV3(null, MINT), null);
+});
+
+/* ---------------- chain parsers ---------------- */
+test('parseTokenSupply parses the real captured mainnet shape', () => {
+  // captured live from api.mainnet-beta.solana.com on 2026-07-19
+  const body = { jsonrpc: '2.0', result: { context: { apiVersion: '4.1.0', slot: 433893013 },
+    value: { amount: '999557928221353', decimals: 6, uiAmount: 999557928.221353, uiAmountString: '999557928.221353' } }, id: 1 };
+  const s = M.parseTokenSupply(body);
+  close(s.uiAmount, 999557928.221353, 'uiAmount');
+  assert.strictEqual(s.decimals, 6);
+  assert.strictEqual(M.parseTokenSupply({}), null);
+  assert.strictEqual(M.parseTokenSupply({ result: { value: { uiAmount: 0 } } }), null, 'zero supply fails closed');
+  assert.strictEqual(M.parseTokenSupply(null), null);
+});
+
+test('parseSignatures keeps blockTime, marks failed txs', () => {
+  // shape captured live on 2026-07-19 (memo/err fields as returned)
+  const body = { result: [
+    { blockTime: 1784462593, confirmationStatus: 'finalized', err: null, memo: null, signature: 'SIG_A', slot: 433891851 },
+    { blockTime: 1784462130, err: { InstructionError: [2, { Custom: 6004 }] }, memo: null, signature: 'SIG_B', slot: 433890746 },
+    { blockTime: null, err: null, signature: 'SIG_C', slot: 1 }
+  ] };
+  const sigs = M.parseSignatures(body);
+  assert.strictEqual(sigs.length, 3);
+  assert.strictEqual(sigs[0].signature, 'SIG_A');
+  assert.strictEqual(sigs[0].blockTimeMs, 1784462593000);
+  assert.strictEqual(sigs[0].failed, false);
+  assert.strictEqual(sigs[1].failed, true, 'errored tx marked failed');
+  assert.strictEqual(sigs[2].blockTimeMs, 0, 'null blockTime tolerated');
+  assert.strictEqual(M.parseSignatures({}), null);
+});
+
+test('parseBurnsFromTx finds burn + burnChecked of OUR mint only, top-level and inner', () => {
+  const tx = { result: {
+    blockTime: 1784462593,
+    meta: { err: null, innerInstructions: [{ index: 3, instructions: [
+      { program: 'spl-token', parsed: { type: 'burnChecked', info: { mint: MINT, authority: 'AuthInner11111111111111111111111111111111111', tokenAmount: { uiAmount: 1234.5, decimals: 6 } } } },
+      { program: 'spl-token', parsed: { type: 'burn', info: { mint: 'OtherMint1111111111111111111111111111111111', amount: '999000000', authority: 'X' } } }
+    ] }] },
+    transaction: { signatures: ['SIG_BURN'], message: { instructions: [
+      { program: 'spl-token', parsed: { type: 'burn', info: { mint: MINT, amount: '250000000000', authority: 'AuthTop111111111111111111111111111111111111' } } },
+      { program: 'spl-token', parsed: { type: 'transfer', info: { mint: MINT, amount: '5' } } }
+    ] } }
+  } };
+  const burns = M.parseBurnsFromTx(tx, MINT, 6);
+  assert.strictEqual(burns.length, 2, 'two burns of our mint');
+  close(burns[0].amount, 250000, 'base units / 10^6');
+  assert.strictEqual(burns[0].authority, 'AuthTop111111111111111111111111111111111111');
+  close(burns[1].amount, 1234.5, 'burnChecked uiAmount');
+  assert.strictEqual(burns[0].sig, 'SIG_BURN');
+  assert.strictEqual(burns[0].ms, 1784462593000);
+  // failed tx burns nothing
+  const failed = JSON.parse(JSON.stringify(tx));
+  failed.result.meta.err = { InstructionError: [0, 'Custom'] };
+  assert.strictEqual(M.parseBurnsFromTx(failed, MINT, 6).length, 0, 'failed tx excluded');
+  assert.strictEqual(M.parseBurnsFromTx({}, MINT, 6).length, 0);
+  assert.strictEqual(M.parseBurnsFromTx(null, MINT, 6).length, 0);
+});
+
+test('mergeBurns dedupes by sig+amount and sorts newest first', () => {
+  const a = [{ sig: 'S1', ms: 100, amount: 10, authority: 'A' }];
+  const b = [
+    { sig: 'S1', ms: 100, amount: 10, authority: 'A' },   // dupe
+    { sig: 'S1', ms: 100, amount: 20, authority: 'A' },   // same tx, second burn instr
+    { sig: 'S2', ms: 300, amount: 5, authority: 'B' }
+  ];
+  const merged = M.mergeBurns(a, b);
+  assert.strictEqual(merged.length, 3);
+  assert.strictEqual(merged[0].sig, 'S2', 'newest first');
+});
+
+test('windowStats computes rolling day/week/month windows', () => {
+  const now = 1784462593000;
+  const H = 3600000, D = 86400000;
+  const burns = [
+    { sig: 'a', ms: now - 2 * H, amount: 100 },
+    { sig: 'b', ms: now - 20 * H, amount: 50 },
+    { sig: 'c', ms: now - 3 * D, amount: 1000 },
+    { sig: 'd', ms: now - 20 * D, amount: 10000 },
+    { sig: 'e', ms: now - 40 * D, amount: 100000 }
+  ];
+  const s = M.windowStats(burns, now);
+  close(s.day.woc, 150, 'day sum'); assert.strictEqual(s.day.txs, 2);
+  close(s.week.woc, 1150, 'week sum'); assert.strictEqual(s.week.txs, 3);
+  close(s.month.woc, 11150, 'month sum'); assert.strictEqual(s.month.txs, 4);
+  assert.strictEqual(s.latestMs, now - 2 * H);
+});
+
+/* ---------------- config override ---------------- */
+test('parseRpcOverride accepts only https URLs', () => {
+  assert.strictEqual(M.parseRpcOverride('', '#p.rpc=https://rpc.helius.xyz/?api-key=x').rpcUrl, 'https://rpc.helius.xyz/?api-key=x');
+  assert.strictEqual(M.parseRpcOverride('?p.rpc=https://api.mainnet-beta.solana.com', '').rpcUrl, 'https://api.mainnet-beta.solana.com');
+  const bad = M.parseRpcOverride('?p.rpc=http://evil.example', '');
+  assert.strictEqual(bad.rpcUrl, null);
+  assert.strictEqual(bad.warnings.length, 1, 'http rejected with warning');
+  assert.strictEqual(M.parseRpcOverride('?p.rpc=javascript:alert(1)', '').rpcUrl, null);
+  assert.strictEqual(M.parseRpcOverride('', '').rpcUrl, null);
+});
+
+/* ---------------- snapshots (stamped by build) ---------------- */
+test('price snapshot is a real stamped market price', () => {
+  const s = M.PRICE_SNAPSHOT;
+  assert.ok(s.usdPerWoc > 0 && isFinite(s.usdPerWoc), 'positive price');
+  assert.ok(['jupiter', 'pyth'].includes(s.source), 'source is a real oracle');
+  assert.ok(s.fetchedAtMs > 1750000000000, 'stamped with a real fetch time');
+});
+
+test('chain snapshot holds a real supply below the 1B initial mint', () => {
+  const c = M.CHAIN_SNAPSHOT;
+  assert.ok(c.currentSupply > 0 && c.currentSupply <= M.CHAIN_SOURCE.initialSupply, 'supply in range');
+  assert.ok(M.CHAIN_SOURCE.initialSupply - c.currentSupply > 0, 'burns have happened on-chain');
+  assert.ok(Array.isArray(c.burns), 'burns array');
+  c.burns.forEach(b => {
+    assert.ok(b.amount > 0 && typeof b.sig === 'string' && b.sig.length > 20, 'well-formed burn row');
+  });
+  assert.ok(c.fetchedAtMs > 1750000000000, 'stamped');
+});
+
+/* ---------------- provenance ---------------- */
+test('every mechanic declares kind and source', () => {
+  assert.ok(M.MECHANICS.length >= 10);
+  M.MECHANICS.forEach(m => {
+    assert.ok(['code', 'assumption'].includes(m.kind), m.label + ' kind');
+    assert.ok(typeof m.source === 'string' && m.source.length > 5, m.label + ' source');
+    assert.ok(typeof m.rate === 'string' && m.rate.length > 3, m.label + ' rate');
+  });
+});
+
+/* ---------------- formatters ---------------- */
+test('formatters behave at magnitude boundaries', () => {
+  assert.strictEqual(M.fmt.n(0), '0');
+  assert.strictEqual(M.fmt.n(1234), '1.2K');
+  assert.strictEqual(M.fmt.n(12500000), '12.5M');
+  assert.strictEqual(M.fmt.n(1e9), '1B');
+  assert.strictEqual(M.fmt.n(NaN), '-');
+  assert.strictEqual(M.fmt.full(1234567.4), '1,234,567');
+  assert.strictEqual(M.fmt.full2(442071.778647), '442,071.78');
+  assert.strictEqual(M.fmt.pct(0.0442), '0.044%');
+  assert.strictEqual(M.fmt.price(0.00017499572561668891), '$0.000175');
+  assert.strictEqual(M.fmt.price(1.5), '$1.50');
+  assert.strictEqual(M.fmt.price(0), '-');
+  assert.strictEqual(M.fmt.ago(15000), '15s');
+  assert.strictEqual(M.fmt.ago(3540000), '59m');
+  assert.strictEqual(M.fmt.ago(90000000), '1d');
+  assert.strictEqual(M.fmt.shortAddr('3WjLscH2JsXLEFJZRA9z8ti8yRGxWGKbqymPd7UicRth'), '3WjL…cRth');
+});
+
+/* ---------------- build parity + self-containment ---------------- */
+test('built HTML embeds burn_model.js byte-for-byte', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', '..', 'burn.html'), 'utf8');
+  const model = fs.readFileSync(path.join(__dirname, 'burn_model.cjs'), 'utf8');
+  const start = html.indexOf('/* __MODEL_START__');
+  const end = html.indexOf('/* __MODEL_END__ */');
+  assert.ok(start !== -1 && end !== -1, 'markers present in built HTML');
+  const embedded = html.slice(html.indexOf('\n', start) + 1, end);
+  assert.strictEqual(embedded.trim(), model.trim(), 'embedded model matches source');
+  assert.ok(!html.includes('__MODEL__ - replaced'), 'template marker replaced');
+});
+
+test('built HTML loads no external resources (links/fetches are runtime-optional)', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', '..', 'burn.html'), 'utf8');
+  // static resource loads would break under the artifact CSP - none allowed
+  const external = html.match(/(src|href)\s*=\s*["']https?:\/\//gi);
+  assert.strictEqual(external, null, 'no external src/href attributes in static HTML');
+  assert.ok(!/@import|url\(\s*["']?https?:/i.test(html), 'no external CSS/font URLs');
+});
+
+/* ---------------- LIVE endpoints (real network, same calls the page makes) ---------------- */
+test('LIVE: Jupiter price endpoint returns a parseable positive price', async () => {
+  const src = M.PRICE_SOURCE;
+  const res = await fetch(src.jupiterUrl + src.mint, { signal: AbortSignal.timeout(10000) });
+  assert.ok(res.ok, 'HTTP ' + res.status);
+  const p = M.parseJupiterV3(await res.json(), src.mint);
+  assert.ok(p && p.usdPerWoc > 0, 'live price parses positive');
+  console.log('      live $WOC/USD via jupiter: ' + p.usdPerWoc);
+});
+
+test('LIVE: getTokenSupply returns a parseable supply at or below 1B', async () => {
+  const res = await fetch(M.CHAIN_SOURCE.rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'getTokenSupply', params: [MINT] }),
+    signal: AbortSignal.timeout(15000)
+  });
+  assert.ok(res.ok, 'HTTP ' + res.status);
+  const s = M.parseTokenSupply(await res.json());
+  assert.ok(s && s.uiAmount > 0 && s.uiAmount <= M.CHAIN_SOURCE.initialSupply, 'live supply in range');
+  console.log('      live supply: ' + s.uiAmount + ' (burned ' + (M.CHAIN_SOURCE.initialSupply - s.uiAmount).toFixed(6) + ')');
+});
+
+/* ---------------- performance ---------------- */
+test('parseBurnsFromTx + windowStats stay fast at scale', () => {
+  const tx = { result: { blockTime: 1784462593, meta: { err: null, innerInstructions: [] },
+    transaction: { signatures: ['S'], message: { instructions: [
+      { parsed: { type: 'burn', info: { mint: MINT, amount: '1000000', authority: 'A' } } }
+    ] } } } };
+  const burns = [];
+  for (let i = 0; i < 5000; i++) burns.push({ sig: 'S' + i, ms: 1784462593000 - i * 60000, amount: 1 });
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < 2000; i++) M.parseBurnsFromTx(tx, MINT, 6);
+  for (let i = 0; i < 200; i++) M.windowStats(burns, 1784462593000);
+  const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+  console.log('      2,000 tx parses + 200 window scans over 5,000 burns: ' + ms.toFixed(1) + 'ms');
+  assert.ok(ms < 2000, 'perf budget');
+});
+
+/* ---------------- runner + summary ---------------- */
+(async () => {
+  for (const t of tests) {
+    try { await t.fn(); passed++; console.log('  ok  ' + t.name); }
+    catch (e) { failures.push(t.name); console.error('FAIL  ' + t.name + '\n      ' + e.message); }
+  }
+  console.log('\n' + passed + ' passed, ' + failures.length + ' failed'
+    + (failures.length ? ': ' + failures.join(', ') : ''));
+  process.exit(failures.length ? 1 : 0);
+})();


### PR DESCRIPTION
## Summary

Adds `burn.html`, a self-contained static page (sibling of `admin.html` and `guide.html`) that tracks $WOC actually destroyed on-chain by the ecosystem's burn mechanics, plus its build and test rig under `tools/burn-tracker/`.

- **Total burned is exact math, not indexer-dependent:** 1,000,000,000 (fixed pump.fun mint, matches `WOC_MAX_SUPPLY` in `src/sim/holder_tier.ts`) minus the mint's live `getTokenSupply`. At build time: 442,071.78 $WOC burned.
- **USD value** uses the same fail-closed price chain as the economy service: Pyth Hermes v2 when `PYTH_WOC_USD_FEED_ID` is configured, otherwise the Jupiter price API for the pinned mint.
- **Burn ledger** parses `burn` / `burnChecked` instructions of the mint from `getSignaturesForAddress` + `getTransaction (jsonParsed)`, newest first with Solscan links, rolling day/week/month stats, and a cumulative chart. The feed is labeled by scan coverage and never affects the headline total.
- **Works everywhere:** the page seeds from build-time snapshots (renders with zero network under a strict CSP) and upgrades to live data where fetches are allowed. `#p.rpc=https://your-rpc` switches to a private RPC since the public endpoint rate-limits history hydration.
- **Provenance table** cites every burn mechanic to its PR and source file (renames #1496/#1499, respec #1553, voice NPC #1099, Logol #1473, arena rake #799, Aldrin #938, skins #897, character market #1497, premium listings #1551, ads, talent, Claudium), and explicitly lists the routes that do NOT burn.

## Build and test

- `node tools/burn-tracker/build.cjs` fetches live price + supply, scans recent mint history for burns, stamps snapshots, and emits `/burn.html`. Fail-closed: price or supply fetch failure fails the build.
- `node tools/burn-tracker/test_burn_model.cjs`: 17 tests, zero dependencies, no mocks of the code under test. Parser fixtures are captured real mainnet/Jupiter response shapes; two live endpoint tests hit Jupiter and mainnet RPC; a parity test asserts `burn.html` embeds `burn_model.cjs` byte-for-byte. Suite is green from this branch.

## Notes for review

- Pure addition: no game, server, or package.json changes; no new dependencies. The page is plain HTML/CSS/JS with system fonts.
- The `ATTRIBUTION` map (burn authority -> label) ships empty on purpose; filling it as mainnet keeper/treasury addresses become public will let feed rows name the mechanic that burned.
- Nothing on the page is financial advice; it reports on-chain history only.
