### PR TITLE
test(professions): Phase 7 QA, verify the Guild letter

### DIFF
--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -20,7 +20,7 @@ Update this file at the end of every implementation and QA session. Statuses:
 | 6 | Crafting window upgrades and celebrations | complete | 2026-07-18 | 2026-07-19 |
 | 6 QA | Verify crafting window upgrades | complete | 2026-07-19 | 2026-07-19 |
 | 7 | The Guild letter and quest objectives | complete | 2026-07-19 | 2026-07-19 |
-| 7 QA | Verify the Guild letter and quest objectives | not started | | |
+| 7 QA | Verify the Guild letter and quest objectives | complete | 2026-07-19 | 2026-07-19 |
 | 8 | Stations and masters (sim and server) | not started | | |
 | 8 QA | Verify stations and masters | not started | | |
 | 9 | Station presence and recipe training | not started | | |
@@ -546,3 +546,68 @@ mailArrived events into event digests. Fixed in passing: the status
 table's Phase 6 QA row (completion was recorded in Notes but the row
 still said not started). Phase 7 QA plays the vertical-slice checkpoint
 (phase-07-qa.md).
+
+2026-07-19 Phase 7 QA complete: PASS with fixes, zero blocking. Seven
+agent fan-out (correctness, test-coverage, dead-code packet audits plus
+migration-safety, cross-platform-sync, architecture, qa-checklist per
+the dispatch matrix; privacy-security, database-performance, and
+frontend-seam did not match the diff), 5 should-fix findings deduping to
+3 unique, all fixed on the QA branch: (1) the online path was verified
+live by inspection by three agents independently but had no pin, closed
+by the live GameServer session-routing suite
+tests/guild_letter_online.test.ts (owner-only mailArrived with exact
+payload, mailU unread mirror 2 vs 1, booking-level one-shot when a
+second pair qualifies); (2) the activeArchetype eligibility clause had
+no isolating negative (the attuned test flips two fields at once),
+closed by per-clause unit negatives on the exported
+maybeSendGuildTrendLetter plus a flip-before-send spy pin, both
+mutation-verified (deleting the guard or the finiteness check each
+kills exactly one test); (3) no same-seed determinism pin for the sweep
+through the real Sim, closed with an identical-arrival-tick run-twice
+test. Also landed: skillOf now enforces its own positive-FINITE comment
+contract (Number.isFinite; Infinity or NaN in a malformed save can no
+longer classify as crossed), the system MailKind and Guild sender
+pinned on the real mailInfo mailbox surface, a two-player same-sweep
+case, and the letters.ts header enumerating all four authored families.
+The vertical-slice checkpoint (kernel exit) PLAYED end to end in the
+seeded offline world: pristine vein fired at harvest 41 with the finder
+line and x5 signed mats; crafting surfaced loot line, XP, Crafted line,
+Made By Hand deed, live identity-card skill movement and the first-tier
+next-unlock hint; the crossing craft flipped guildLetterSent 12 ticks
+later (the 1 Hz sweep) and the raven landed at exactly 90 seconds with
+banner, whisper cue, chat line, correct pair letter (system kind, The
+Crafting Guild) whose body names the Smith title and Smith Haldren; the
+acceptance quest flow attuned the pair through the 10-archetype chooser
+with its live Result line (Title Smith, majors uncapped, hobby
+Leatherworking); a masterwork procced with the full-screen marquee,
+personal toast line, AND the zone-broadcast line; the sole-copy
+masterwork traded to a second player with signer + rolled.masterwork +
+stats payload intact. ONE experiential finding, DEFERRED to the
+maintainer (design decision): the letter's call to action dead-ends for
+a player who has not done q_prof_intro, Smith Haldren shows only his
+greeting and vendor line (q_archetype_acceptance reads unavailable
+behind requiresQuest, no locked-row hint, no redirect to Foreman
+Odell), so the letter's promise silently fails for exactly its target
+audience (players who leveled crafts without the mining intro); options
+recorded: a locked-quest hint row in the dialog, a letter-body pointer
+to the Copper Dig (needs the 5 overlay refills), or softening the
+requiresQuest gate when skills already qualify. Observations, no
+action: the starter weapon recipe (arming sword) can never masterwork,
+masterworkBonusStats is null for its stat-less def, so the tier-1 Smith
+proc path is the caster-stat warded leggings (design note for Phase
+8/10 recipe ladders); zone-1 pristine copper feeds no recipe (the
+recorded Phase 4 zone-1 mitigation), so the signed-mats-into-craft link
+starts with battlefield-drop reagents or zone 2+; trade removal prefers
+fungible copies, a signed copy transfers only when it is the only copy
+(the recorded Phase 3 model, a specific-instance offer UX is a future
+call); the mail arrival banner is lost if the recipient is offline when
+the raven lands (pre-existing PostOffice announce semantics, welcome
+letter identical); an old client renders an unknown guild_trend_
+letterId as the raw id (pre-existing letters behavior, system-wide
+resolver fallback filed as a future nicety). NITs recorded, not worth
+churn: source-scan pins tolerate commented-out entries (accepted
+precedent), replaceAll clarity in the letterId scheme, the sweep bills
+to the postOffice lap bucket, a third backfill load, a dedicated parity
+scenario (the determinism pin covers the risk, the sweep draws zero
+rng). Release cut reminder: the 10 letters' pending rows for the
+non-M16 locales fill at the release-tier gate as usual.

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -604,6 +604,16 @@ tables, i18n key namespaces, files created)
   + M16 fills in the five non-Latin overlays; the S3 scan list ALREADY
   contained src/sim/quests/quest_commands.ts (PR 2039), its membership
   now pinned by a meta-guard in tests/localization_fixes.test.ts.
+  Phase 7 QA additions (2026-07-19): skillOf counts only positive
+  FINITE numbers (Number.isFinite, the comment contract made real);
+  per-clause eligibility negatives and a flip-before-send pin on the
+  exported maybeSendGuildTrendLetter, the system MailKind pinned on the
+  mailInfo surface, a two-player same-sweep case, and a same-seed
+  determinism pin (tests/professions_trend.test.ts); live GameServer
+  session-routing suite tests/guild_letter_online.test.ts (owner-only
+  mailArrived, mailU mirrors, booking-level one-shot). OPEN maintainer
+  decision from the vertical slice: the letter to Haldren hop dead-ends
+  pre-q_prof_intro (no locked-row hint, no redirect to Odell).
 - Phase 8: (planned) station registry (typed stations, multi-zone); master
   NpcDefs across the three hubs; placement-safety test.
 - Phase 13: (planned) disenchantItem/applyEnchant/salvageItem IWorld

--- a/src/sim/content/letters.ts
+++ b/src/sim/content/letters.ts
@@ -1,7 +1,9 @@
 // Authored mail content for the Ravenpost (the in-game mail service): the
-// welcome letter every character receives once, and the NPC thank-you letters
-// select quests send after their turn-in. Data-as-code, merged nowhere: the
-// PostOffice (src/sim/mail/post_office.ts) reads these tables directly.
+// welcome letter every character receives once, the Heroic Marks reward
+// letter, the NPC thank-you letters select quests send after their turn-in,
+// and the Guild trend letters (one per adjacent craft pair, Professions 2.0
+// Phase 7). Data-as-code, merged nowhere: the PostOffice
+// (src/sim/mail/post_office.ts) reads these tables directly.
 //
 // English here is the source of truth; the client localizes each letter by its
 // stable `letterId` through the entity dictionary (src/ui/entity_i18n.ts kind

--- a/src/sim/professions/trend.ts
+++ b/src/sim/professions/trend.ts
@@ -28,7 +28,7 @@ export interface CraftTrend {
 // normalized upstream, but this classifier stays total over any input).
 function skillOf(skills: CraftSkills, craftId: string): number {
   const value = skills[craftId];
-  return typeof value === 'number' && value > 0 ? value : 0;
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
 }
 
 /** Classify the leading adjacent-pair trend in `skills`, or null when every

--- a/tests/guild_letter_online.test.ts
+++ b/tests/guild_letter_online.test.ts
@@ -1,0 +1,135 @@
+// The Guild trend letter over the live GameServer wire (Professions 2.0
+// Phase 7 QA): the offline delivery suite (tests/professions_trend.test.ts)
+// pins the sweep through the real Sim, but nothing pinned that the SERVER-side
+// sweep books the letter and that the raven's mailArrived routes to only the
+// owning session over the real pump (sim.tick() returning the buffered
+// events, then routeEvents fanning per session), with the unread-envelope
+// mirror (mailU) counting it. That is the 2033 stub-trap class of regression:
+// if mailArrived were dropped from routing or the letterId stripped on the
+// wire, every offline test would stay green. Modeled on the
+// masterwork_zone_broadcast session-routing suite (Phase 6 QA).
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the db layer so the live GameServer suite needs no Postgres; only the
+// sim sweep and the tick -> routeEvents wire pump are under test, never
+// persistence (the corpse_harvest_sim broadcast-suite precedent; the vi.mock
+// hoisting caveat from #2088 applies: this block cannot be imported).
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
+  loadAccountFlair: vi.fn(async () => ({ ai: false, streamer: false, links: {} })),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  setAccountWeaponSkinLoadout: vi.fn(async () => ({
+    completedQuestIds: [],
+    mechChromaIds: [],
+    weaponSkinIds: [],
+    weaponSkinLoadout: {},
+  })),
+}));
+
+import { type ClientSession, GameServer } from '../server/game';
+import type { PlayerMeta } from '../src/sim/sim';
+import type { SimEvent } from '../src/sim/types';
+
+const LETTER_ID = 'guild_trend_weaponcrafting_armorcrafting';
+
+// Booking happens on the 1 Hz sweep within a second of the crossing; the raven
+// then flies the standard 90 second NPC delivery delay (the professions_trend
+// suite mirrors the same literal). 95 sim-seconds covers both with margin.
+const DELIVERY_WINDOW_TICKS = 95 * 20;
+const ONLINE_SUITE_TIMEOUT_MS = 40_000;
+
+function fakeWs(): { sent: { t: string; list?: SimEvent[]; [k: string]: unknown }[]; ws: unknown } {
+  const sent: { t: string; list?: SimEvent[] }[] = [];
+  return {
+    sent,
+    ws: { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) },
+  };
+}
+
+function joinServer(
+  server: GameServer,
+  fc: ReturnType<typeof fakeWs>,
+  id: number,
+  name: string,
+): ClientSession {
+  const session = server.join(fc.ws as never, id, id, name, 'warrior', null);
+  if ('error' in session) throw new Error(session.error);
+  session.blockListLoaded = true;
+  return session;
+}
+
+describe('guild letter over the live GameServer wire (session routing)', () => {
+  it(
+    'the server sweep books on crossing; mailArrived routes to only the owning session; mailU counts it; the one-shot holds',
+    () => {
+      const server = new GameServer();
+      const fcCross = fakeWs();
+      const fcOther = fakeWs();
+      const fcThird = fakeWs();
+      const sc = joinServer(server, fcCross, 81, 'Crosser');
+      joinServer(server, fcOther, 82, 'Watcher');
+      joinServer(server, fcThird, 83, 'Wanderer');
+
+      // Drive the crosser past the threshold on the LIVE server sim (the
+      // sweep reads meta.craftSkills; it draws no rng, so no seed hunting).
+      const players = (server.sim as unknown as { players: Map<number, PlayerMeta> }).players;
+      const meta = players.get(sc.pid);
+      if (!meta) throw new Error('no crosser meta');
+      meta.craftSkills.weaponcrafting = 13;
+      meta.craftSkills.armorcrafting = 12;
+
+      // The REAL pump: tick returns the buffered emits, routeEvents fans them
+      // per session (the Phase 6 masterworkZone suite idiom).
+      const route = (evs: SimEvent[]) =>
+        (server as unknown as { routeEvents(e: SimEvent[]): void }).routeEvents(evs);
+      for (let i = 0; i < DELIVERY_WINDOW_TICKS; i++) route(server.sim.tick());
+
+      const guildEvsOf = (sent: { t: string; list?: SimEvent[] }[]) =>
+        sent
+          .filter((m) => m.t === 'events')
+          .flatMap((m) => m.list ?? [])
+          .filter(
+            (ev) =>
+              ev.type === 'mailArrived' &&
+              ((ev as { letterId?: string }).letterId ?? '').startsWith('guild_trend_'),
+          );
+      // Exactly one arrival, exact wire payload, owner session only.
+      expect(guildEvsOf(fcCross.sent)).toEqual([
+        { type: 'mailArrived', senderName: 'The Crafting Guild', letterId: LETTER_ID, pid: sc.pid },
+      ]);
+      expect(guildEvsOf(fcOther.sent)).toEqual([]);
+      expect(guildEvsOf(fcThird.sent)).toEqual([]);
+      expect(meta.guildLetterSent).toBe(true);
+
+      // The unread-envelope mirror: the welcome letter (delay 0) plus the
+      // guild letter for the crosser, welcome only for the bystanders. Read
+      // the same authoritative counter the snapshot's mailU key wires
+      // (server/game.ts maybe('mailU', sim.mailUnreadFor(pid))).
+      const unreadFor = (pid: number) =>
+        (server.sim as unknown as { mailUnreadFor(pid: number): number }).mailUnreadFor(pid);
+      const otherPids = [...players.keys()].filter((pid) => pid !== sc.pid);
+      expect(unreadFor(sc.pid)).toBe(2);
+      for (const pid of otherPids) expect(unreadFor(pid)).toBe(1);
+
+      // One-shot at the booking level over the server path: a second
+      // qualifying pair never re-books (asserted against the PostOffice store
+      // so no second 90 second flight is needed).
+      meta.craftSkills.jewelcrafting = 100;
+      meta.craftSkills.enchanting = 100;
+      for (let i = 0; i < 40; i++) route(server.sim.tick());
+      const mailStore = (server.sim as unknown as { postOffice: { mail: { letterId?: string }[] } })
+        .postOffice.mail;
+      expect(mailStore.filter((m) => (m.letterId ?? '').startsWith('guild_trend_'))).toHaveLength(
+        1,
+      );
+    },
+    ONLINE_SUITE_TIMEOUT_MS,
+  );
+});

--- a/tests/professions_trend.test.ts
+++ b/tests/professions_trend.test.ts
@@ -8,11 +8,13 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { GUILD_TREND_LETTERS } from '../src/sim/content/letters';
+import { GUILD_TREND_LETTERS, type LetterDef } from '../src/sim/content/letters';
 import { ARCHETYPE_PAIR_TARGETS, craftsForPairTarget } from '../src/sim/professions/archetype';
+import { maybeSendGuildTrendLetter } from '../src/sim/professions/guild_letter';
 import { classifyCraftTrend, GUILD_LETTER_SKILL_THRESHOLD } from '../src/sim/professions/trend';
 import { TIER_SKILL_STEP } from '../src/sim/professions/wheel';
-import { Sim } from '../src/sim/sim';
+import { type PlayerMeta, Sim } from '../src/sim/sim';
+import type { SimContext } from '../src/sim/sim_context';
 import type { SimEvent } from '../src/sim/types';
 
 // The ten canonical adjacent-pair ids over the locked CRAFT_RING order,
@@ -119,6 +121,10 @@ describe('classifyCraftTrend: the pure leading-pair classifier', () => {
     expect(classifyCraftTrend(zero)).toBeNull();
     // Non-positive entries count as 0, so a lone negative is still null.
     expect(classifyCraftTrend({ engineering: -5 })).toBeNull();
+    // Malformed values never count either: only positive FINITE numbers score,
+    // so an Infinity or NaN entry can never classify a pair as crossed.
+    expect(classifyCraftTrend({ engineering: Number.POSITIVE_INFINITY })).toBeNull();
+    expect(classifyCraftTrend({ engineering: Number.NaN })).toBeNull();
   });
 
   it('is deterministic and never mutates its input', () => {
@@ -301,6 +307,166 @@ describe('the Guild letter through the real Sim', () => {
       expect(guildLetters(events, pid2)).toHaveLength(0);
     },
     GUILD_DELIVERY_TEST_TIMEOUT_MS,
+  );
+});
+
+// --- maybeSendGuildTrendLetter eligibility clauses (isolating negatives) ---
+
+// A synthetic PlayerMeta carrying exactly the fields the predicate reads, plus
+// a spy ctx. Each of the three eligibility clauses gets a negative where ONLY
+// that clause disqualifies, so deleting any single guard line in
+// maybeSendGuildTrendLetter fails exactly one test here (the attuned/amends
+// delivery tests above each flip two fields at once and cannot isolate them).
+function unitMeta(overrides: {
+  guildLetterSent?: boolean;
+  activeArchetype?: string | null;
+  attunedPairs?: string[];
+  craftSkills?: Record<string, number>;
+}): PlayerMeta {
+  return {
+    guildLetterSent: overrides.guildLetterSent ?? false,
+    archetype: {
+      activeArchetype: overrides.activeArchetype ?? null,
+      attunedPairs: overrides.attunedPairs ?? [],
+    },
+    craftSkills: overrides.craftSkills ?? { engineering: 15, alchemy: 15 },
+  } as unknown as PlayerMeta;
+}
+
+function spyCtx(): {
+  ctx: SimContext;
+  booked: { letter: LetterDef; flagAtCall: boolean }[];
+} {
+  const booked: { letter: LetterDef; flagAtCall: boolean }[] = [];
+  const ctx = {
+    mailAuthoredLetter: (meta: PlayerMeta, letter: LetterDef) => {
+      booked.push({ letter, flagAtCall: meta.guildLetterSent === true });
+    },
+  } as unknown as SimContext;
+  return { ctx, booked };
+}
+
+describe('maybeSendGuildTrendLetter eligibility clauses', () => {
+  it('books for a fully eligible character, one-shot flag flipped BEFORE the send', () => {
+    const meta = unitMeta({});
+    const { ctx, booked } = spyCtx();
+    expect(maybeSendGuildTrendLetter(meta, ctx)).toBe(true);
+    expect(booked).toHaveLength(1);
+    expect(booked[0].letter.letterId).toBe('guild_trend_engineering_alchemy');
+    // The re-entrant-save contract: the callback must already observe the flag.
+    expect(booked[0].flagAtCall).toBe(true);
+    expect(meta.guildLetterSent).toBe(true);
+  });
+
+  it('guildLetterSent alone disqualifies', () => {
+    const meta = unitMeta({ guildLetterSent: true });
+    const { ctx, booked } = spyCtx();
+    expect(maybeSendGuildTrendLetter(meta, ctx)).toBe(false);
+    expect(booked).toHaveLength(0);
+  });
+
+  it('a non-null activeArchetype alone disqualifies, attunedPairs empty', () => {
+    const meta = unitMeta({ activeArchetype: 'engineering' });
+    const { ctx, booked } = spyCtx();
+    expect(maybeSendGuildTrendLetter(meta, ctx)).toBe(false);
+    expect(booked).toHaveLength(0);
+    expect(meta.guildLetterSent).toBe(false);
+  });
+
+  it('non-empty attunedPairs alone disqualifies, activeArchetype null', () => {
+    const meta = unitMeta({ attunedPairs: ['engineering+alchemy'] });
+    const { ctx, booked } = spyCtx();
+    expect(maybeSendGuildTrendLetter(meta, ctx)).toBe(false);
+    expect(booked).toHaveLength(0);
+    expect(meta.guildLetterSent).toBe(false);
+  });
+
+  it('an uncrossed trend books nothing and never burns the one-shot flag', () => {
+    const meta = unitMeta({ craftSkills: { engineering: 12, alchemy: 12 } });
+    const { ctx, booked } = spyCtx();
+    expect(maybeSendGuildTrendLetter(meta, ctx)).toBe(false);
+    expect(booked).toHaveLength(0);
+    expect(meta.guildLetterSent).toBe(false);
+  });
+});
+
+// --- delivery hardening: kind, multi-player sweep, determinism ---
+
+describe('the Guild letter delivery contract', () => {
+  it(
+    'the booked mail is the system kind from The Crafting Guild on the mailbox surface',
+    () => {
+      const sim = makeWorld();
+      const pid = sim.addPlayer('warrior', 'Tinker');
+      sim.gainCraftSkill(pid, 'engineering', 15);
+      sim.gainCraftSkill(pid, 'alchemy', 15);
+      tickFor(sim, letterDelay('engineering+alchemy') + 5);
+      // Read the REAL mailbox window surface (proximity-gated): park the
+      // character at the Eastbrook raven pillar and stream mailInfo.
+      const e = sim.entities.get(pid);
+      if (!e) throw new Error('no entity');
+      e.pos.x = 7;
+      e.pos.z = -8;
+      sim.tick();
+      const info = sim.mailInfoFor(pid);
+      if (!info) throw new Error('expected mailInfo at the mailbox');
+      const guild = info.messages.find((m) => (m.letterId ?? '').startsWith('guild_trend_'));
+      expect(guild).toMatchObject({
+        kind: 'system',
+        letterId: 'guild_trend_engineering_alchemy',
+        senderName: 'The Crafting Guild',
+        subject: 'Your work in Engineering and Alchemy',
+        read: false,
+      });
+    },
+    GUILD_DELIVERY_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'two players crossing in the same sweep each get exactly their own pair letter',
+    () => {
+      const sim = makeWorld();
+      const a = sim.addPlayer('warrior', 'Anvil');
+      const b = sim.addPlayer('mage', 'Loom');
+      sim.gainCraftSkill(a, 'weaponcrafting', 15);
+      sim.gainCraftSkill(a, 'armorcrafting', 15);
+      sim.gainCraftSkill(b, 'tailoring', 15);
+      sim.gainCraftSkill(b, 'inscription', 15);
+      const events = tickFor(sim, letterDelay('weaponcrafting+armorcrafting') + 5);
+      const la = guildLetters(events, a);
+      const lb = guildLetters(events, b);
+      expect(la).toHaveLength(1);
+      expect(la[0]).toMatchObject({ letterId: 'guild_trend_weaponcrafting_armorcrafting' });
+      expect(lb).toHaveLength(1);
+      expect(lb[0]).toMatchObject({ letterId: 'guild_trend_tailoring_inscription' });
+    },
+    GUILD_DELIVERY_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'same seed, same inputs: the letter arrives on the same tick with an identical event',
+    () => {
+      const run = () => {
+        const sim = makeWorld();
+        const pid = sim.addPlayer('warrior', 'Tinker');
+        sim.gainCraftSkill(pid, 'engineering', 15);
+        sim.gainCraftSkill(pid, 'alchemy', 15);
+        const arrivals: { tick: number; ev: SimEvent }[] = [];
+        const total = Math.ceil((letterDelay('engineering+alchemy') + 5) * 20);
+        for (let t = 0; t < total; t++) {
+          for (const ev of sim.tick()) {
+            if (ev.type === 'mailArrived' && (ev.letterId ?? '').startsWith('guild_trend_')) {
+              arrivals.push({ tick: t, ev });
+            }
+          }
+        }
+        return arrivals;
+      };
+      const first = run();
+      expect(first).toHaveLength(1);
+      expect(run()).toEqual(first);
+    },
+    2 * GUILD_DELIVERY_TEST_TIMEOUT_MS,
   );
 });
 


### PR DESCRIPTION
## Summary

Phase 7 QA of the Professions 2.0 packet (the Guild letter, PR #2158): a 7-agent audit over the merge's first-parent diff (3 packet audits plus migration-safety, cross-platform-sync, architecture-reviewer, and qa-checklist per the dispatch matrix), the vertical-slice kernel-exit checkpoint played end to end in the seeded offline world, and the fixes the audit produced. Zero blocking findings; 5 should-fixes deduping to 3 unique, all fixed here.

What landed:

- **Online delivery pin** (found independently by three agents): the server-side path was verified live by inspection, but nothing pinned it, the 2033 stub-trap regression class. `tests/guild_letter_online.test.ts` drives a live `GameServer` with three sessions through the real `tick` to `routeEvents` pump: the crossing player's session alone receives the `mailArrived` with the exact `guild_trend_` payload, `mailU` unread mirrors read 2 vs 1, and the one-shot holds at the PostOffice booking level when a second pair qualifies (no second 90 second flight needed). Modeled on the Phase 6 masterworkZone routing suite.
- **Per-clause eligibility negatives**: the attuned and amends delivery tests each flip two fields at once, so deleting the `activeArchetype` guard left the whole suite green. Added isolating unit negatives on the exported `maybeSendGuildTrendLetter` plus a flip-before-send spy pin; mutation-verified (removing the guard kills exactly one test).
- **Same-seed determinism pin** for the sweep through the real Sim (identical arrival tick and event across two runs), plus a two-player same-sweep case, and the `system` MailKind + Guild sender pinned on the real `mailInfoFor` mailbox surface.
- **`skillOf` finiteness**: the comment promised a positive FINITE number but the code only checked positivity, so a malformed save carrying Infinity could classify as crossed. `Number.isFinite` added (mutation-verified) with Infinity/NaN totality lines; `letters.ts` header now enumerates all four authored letter families.

The vertical-slice checkpoint (played, one seeded run): pristine vein fired at harvest 41 with the finder line and the x5 signed grant; crafting surfaced the loot line, XP, Crafted line, deed toast, live identity-card skill movement and the first-tier hint; the crossing craft flipped `guildLetterSent` 12 ticks later and the raven landed at exactly 90 seconds with banner, whisper cue, chat line, and a pair-correct system letter naming the Smith title and Smith Haldren; the acceptance quest attuned the pair through the 10-archetype chooser with its live Result line; a masterwork procced with the full-screen marquee, personal toast, and zone-broadcast line; the sole-copy masterwork traded to a second player with the full instance payload intact.

**One experiential finding, deferred to the maintainer (design call, options in progress.md Notes):** the letter's call to action dead-ends for a player who has not done `q_prof_intro`. Smith Haldren's dialog shows only his greeting and vendor line (`q_archetype_acceptance` reads unavailable behind `requiresQuest`, no locked-row hint, no redirect to Foreman Odell), so the letter's promise silently fails for exactly its target audience. Options: a locked-quest hint row, a letter-body pointer to the Copper Dig (needs the five overlay refills), or softening the gate when skills already qualify.

Also recorded (observations, no action): the starter arming sword can never masterwork (stat-less def, `masterworkBonusStats` null), so the tier-1 Smith proc path is the caster-stat warded leggings; trade removal prefers fungible copies so a signed copy transfers only when it is the only copy (the recorded Phase 3 model); the arrival banner is lost when the recipient is offline at landing (pre-existing PostOffice semantics, welcome letter identical).

## Related issues

Part of #1866.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation

## How was this tested?

- Commands: `npm run gate` under Node 24 (known environmental armory browser red only; the tail `check:types` + `build:env` + `build:server` + `build` finished green manually, PR CI is the arbiter); `npx tsc --noEmit`; `npx vitest run` over the phase validation matrix plus the new suite (12 files, 225 passed, 6 skipped); `npm run ci:changed`; scoped `npx @biomejs/biome check --write` on the four changed source/test files.
- Manual steps: the eight-step vertical-slice checkpoint driven through the dev client on a long-lived headless Chromium (real harvest draws, real Craft clicks, the real quest dialog with the pair chooser, the real mailbox window, the real trade commands); two mutation experiments confirming the new pins are decisive.

## Screenshots / recordings

N/A: no UI change in this diff (tests, a sim guard, comments, docs). The vertical-slice evidence (letter body, masterwork marquee, attuned identity card) is described in progress.md Notes.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green up to the known environmental armory browser red on this machine; the gate tail was finished manually and PR CI is the arbiter. Decisive tests added for every changed behavior.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI change.
- ~Accessible.~ N/A: no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
