### PR TITLE
fix(mage): correct Fire release abilities

### DIFF
--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -31,6 +31,7 @@ import { isDispellableAura } from '../aura_classify';
 import { ITEMS, isDelvePos, MOBS } from '../data';
 import { recalcPlayerStats } from '../entity';
 import { isShieldItem } from '../equipment_rules';
+import { instanceInfoAt } from '../instances/dungeons';
 import { scheduleProjectile } from '../projectile_travel';
 import type { PlayerMeta, ResolvedAbility } from '../sim';
 import type { SimContext } from '../sim_context';
@@ -179,6 +180,34 @@ function hasAbilityCharge(
   return !!state && state.charges > 0;
 }
 
+type ActiveCastRestriction = 'combat' | 'instance';
+
+function activeCastRestriction(
+  ctx: SimContext,
+  player: Entity,
+  ability: AbilityDef,
+): ActiveCastRestriction | null {
+  if (ability.requiresOutOfCombat && player.inCombat) {
+    return 'combat';
+  }
+  if (ability.requiresOutsideInstance && instanceInfoAt(ctx, player.pos)) {
+    return 'instance';
+  }
+  return null;
+}
+
+function emitActiveCastRestrictionError(
+  ctx: SimContext,
+  playerId: number,
+  restriction: ActiveCastRestriction,
+): void {
+  if (restriction === 'combat') {
+    ctx.error(playerId, "You can't do that while in combat.");
+  } else {
+    ctx.error(playerId, 'Leave the dungeon first.');
+  }
+}
+
 export function updateCasting(ctx: SimContext, p: Entity, meta: PlayerMeta): void {
   if (!p.castingAbility) {
     // a queued press held back by a still-running GCD (see fireQueuedCast) retries
@@ -192,6 +221,14 @@ export function updateCasting(ctx: SimContext, p: Entity, meta: PlayerMeta): voi
     return;
   }
   const activeCast = ctx.resolvedAbility(p.castingAbility, p.id);
+  if (activeCast) {
+    const restriction = activeCastRestriction(ctx, p, activeCast.def);
+    if (restriction) {
+      cancelCast(ctx, p);
+      emitActiveCastRestrictionError(ctx, p.id, restriction);
+      return;
+    }
+  }
   if (activeCast && isMassResurrectionAbility(activeCast.def)) {
     if (p.inCombat) {
       cancelCast(ctx, p);
@@ -502,6 +539,7 @@ export function castAbility(
   const sharedCooldown = isShamanShock(ability.id)
     ? SHAMAN_SHOCK_COOLDOWN_IDS.find((id) => p.cooldowns.has(id))
     : undefined;
+  const leavingRestrictedToggle = togglingOff && ability.requiresOutsideInstance;
   // Charge-limited abilities (the abilityCharges recharge model, driven by
   // bonusCharges: Double Charge, extra Blink/Frost Nova/Ice Block): a running
   // cooldown is only the RECHARGE timer; the cast is blocked only once every
@@ -582,8 +620,9 @@ export function castAbility(
     ctx.error(p.id, 'You must be stealthed.');
     return;
   }
-  if (ability.requiresOutOfCombat && p.inCombat) {
-    ctx.error(p.id, "You can't do that while in combat.");
+  const restriction = leavingRestrictedToggle ? null : activeCastRestriction(ctx, p, ability);
+  if (restriction) {
+    emitActiveCastRestrictionError(ctx, p.id, restriction);
     return;
   }
   if (isMassResurrectionAbility(ability) && !hasDeadGroupMember(ctx, p)) {

--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -1351,6 +1351,8 @@ export const ABILITIES: Record<string, AbilityDef> = {
     range: 0,
     school: 'fire',
     requiresTarget: false,
+    requiresOutOfCombat: true,
+    requiresOutsideInstance: true,
     effects: [{ type: 'selfBuff', kind: 'form_fireball', value: 1.4, duration: 3600 }],
     description:
       'Transform into a blazing ember, increasing movement speed by $b%. You cannot attack or cast spells while transformed. Recast to return to your normal form.',
@@ -1935,7 +1937,8 @@ export const ABILITIES: Record<string, AbilityDef> = {
     // Owner rule 2026-07-11: a real cast, EXCEPT under Hot Streak, whose
     // next_cast_instant makes it instant and free (the spender machinery).
     castTime: 2,
-    cooldown: 12,
+    // Owner release rule 2026-07-19: cast time and the GCD pace it, no cooldown.
+    cooldown: 0,
     range: 30,
     school: 'fire',
     requiresTarget: false,

--- a/src/sim/instances/dungeons.ts
+++ b/src/sim/instances/dungeons.ts
@@ -119,7 +119,7 @@ export function instanceOriginOf(inst: InstanceSlot): { x: number; z: number } {
 export function instanceClaimIdAt(ctx: SimContext, pos: Vec3): number | null {
   for (const inst of ctx.instances) {
     if (inst.partyKey === null || inst.exitId === null) continue;
-    if (instanceClaimContains(ctx, inst, pos)) return inst.exitId;
+    if (instanceClaimContains(inst, pos)) return inst.exitId;
   }
   return null;
 }
@@ -130,20 +130,26 @@ function instanceContains(origin: { x: number; z: number }, pos: Vec3): boolean 
   return Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250;
 }
 
-function instanceClaimContains(ctx: SimContext, inst: InstanceSlot, pos: Vec3): boolean {
+function instanceClaimContains(inst: InstanceSlot, pos: Vec3): boolean {
   const origin = instanceOriginOf(inst);
   if (instanceContains(origin, pos)) return true;
   if (inst.dungeonId !== 'nythraxis_boss_arena') return false;
-  const boss = inst.mobIds
-    .map((id) => ctx.entities.get(id))
-    .find((entity) => entity?.templateId === NYTHRAXIS_BOSS_ID);
+  const bossSpawn = DUNGEONS.nythraxis_boss_arena.spawns.find(
+    (spawn) => spawn.mobId === NYTHRAXIS_BOSS_ID,
+  );
   // The raid room is wider than the generic instance footprint, so its claim
   // includes the side wings. Keep that wider circle clipped to this slot's z
-  // band or it reaches into the adjacent arena slot 500 yards away.
+  // band or it reaches into the adjacent arena slot 500 yards away. Derive the
+  // centre from content rather than the live boss entity: the room remains a
+  // raid instance after Nythraxis' corpse has despawned.
   return (
-    !!boss &&
+    !!bossSpawn &&
     Math.abs(pos.z - origin.z) < 250 &&
-    dist2d(pos, boss.spawnPos) <= NYTHRAXIS_ROOM_RADIUS
+    dist2d(pos, {
+      x: origin.x + bossSpawn.x,
+      y: pos.y,
+      z: origin.z + bossSpawn.z,
+    }) <= NYTHRAXIS_ROOM_RADIUS
   );
 }
 
@@ -431,7 +437,7 @@ function defeatedNythraxisCorpseRunClaim(
       candidate.dungeonId === 'nythraxis_boss_arena' &&
       candidate.partyKey === partyKey &&
       candidate.exitId === p.corpseInstanceId &&
-      instanceClaimContains(ctx, candidate, corpsePos),
+      instanceClaimContains(candidate, corpsePos),
   );
   if (!inst || !isDefeatedNythraxisParticipant(ctx, inst, p.id)) return undefined;
   return inst;
@@ -460,9 +466,7 @@ export function leaveDungeon(ctx: SimContext, pid?: number): boolean {
   // e.g. their pet) from every inside mob's hate table: dancing in and out of
   // the exit portal cannot be used to kite a pull to the door and back.
   // Re-entering means earning aggro from scratch.
-  const inst = ctx.instances.find(
-    (i) => i.partyKey !== null && instanceClaimContains(ctx, i, p.pos),
-  );
+  const inst = ctx.instances.find((i) => i.partyKey !== null && instanceClaimContains(i, p.pos));
   if (inst) scrubInstanceThreat(ctx, inst, p.id);
   p.pos = ctx.groundPos(dungeon.doorPos.x, dungeon.doorPos.z - 4);
   p.prevPos = { ...p.pos };
@@ -715,7 +719,7 @@ export function instanceLockoutMetas(ctx: SimContext, inst: InstanceSlot): Playe
     const matchingInstanceCorpse =
       e?.ghost && e.corpsePos && e.corpseInstanceId === inst.exitId ? e.corpsePos : null;
     const lockoutPos = matchingInstanceCorpse ?? e?.pos;
-    if (lockoutPos && instanceClaimContains(ctx, inst, lockoutPos)) out.push(meta);
+    if (lockoutPos && instanceClaimContains(inst, lockoutPos)) out.push(meta);
   }
   return out;
 }
@@ -829,7 +833,7 @@ export function instanceInfoAt(
   pos: Vec3,
 ): { slot: number; dungeonId: string } | null {
   for (const inst of ctx.instances) {
-    if (instanceContains(instanceOriginOf(inst), pos)) {
+    if (instanceClaimContains(inst, pos)) {
       return { slot: inst.slot, dungeonId: inst.dungeonId };
     }
   }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -2217,6 +2217,10 @@ export interface AbilityDef {
   exclusiveGroup?: string;
   requiresStealth?: boolean; // ambush
   requiresOutOfCombat?: boolean; // stealth
+  // The ability cannot be activated while physically inside a claimed dungeon or
+  // raid instance. Toggle buffs may still be cancelled there to avoid trapping the
+  // player in an action-locking form.
+  requiresOutsideInstance?: boolean;
   // Usable only while the caster wears an aura of this kind (Victory Rush's
   // on-kill window); runEffects consumes the enabling aura on a successful cast.
   requiresAuraKind?: AuraKind;

--- a/tests/combat_casting_lifecycle.test.ts
+++ b/tests/combat_casting_lifecycle.test.ts
@@ -373,13 +373,13 @@ describe('casting_lifecycle: spell queue (#1360)', () => {
     expect(p.queuedCastAim).toBeNull();
     // Flamestrike is a real 2s cast now (fire-spec redesign, instant only under Hot
     // Streak): once the queued cast fires it becomes the active cast, carrying the
-    // queued aim point through. Draining it lands the blast and arms its cooldown.
+    // queued aim point through. Draining it lands the blast without a cooldown.
     expect(p.castingAbility).toBe('flamestrike');
     // The queued aim point carried through (the cast resolves a y ground height).
     expect(p.castAim?.x).toBe(aim.x);
     expect(p.castAim?.z).toBe(aim.z);
     while (p.castingAbility) sim.tick();
-    expect(p.cooldowns.has('flamestrike')).toBe(true);
+    expect(p.cooldowns.has('flamestrike')).toBe(false);
   });
 
   it('holds a queued cast that would complete before the arming GCD clears, and fires it once the GCD does', () => {

--- a/tests/fire_mage.test.ts
+++ b/tests/fire_mage.test.ts
@@ -246,6 +246,26 @@ describe('playtest round four (owner hotfixes)', () => {
     expect(events.some((e) => e.type === 'spellfx' && e.fx === 'projectile')).toBe(false);
   });
 
+  it('Fire Blast lands instantly without disturbing a Fireball already being cast', () => {
+    const { sim, p } = mageWithSpec('fire');
+    const mob = addDummy(sim, 18);
+    sim.castAbility('fireball');
+    collect(sim, 0.5);
+    const remainingBefore = p.castRemaining;
+    const castTargetBefore = p.castTargetId;
+    const hpBefore = mob.hp;
+    sim.drainEvents();
+
+    sim.castAbility('fire_blast');
+
+    const events = sim.drainEvents();
+    expect(mob.hp).toBeLessThan(hpBefore);
+    expect(events.some((e) => e.type === 'spellfx' && e.fx === 'projectile')).toBe(false);
+    expect(p.castingAbility).toBe('fireball');
+    expect(p.castRemaining).toBe(remainingBefore);
+    expect(p.castTargetId).toBe(castTargetBefore);
+  });
+
   it('Scorch casts on the move', () => {
     const { sim, p } = mageWithSpec('fire');
     addDummy(sim, 10);
@@ -365,6 +385,22 @@ describe('playtest round five (owner hotfixes)', () => {
     expect(p.castingAbility).toBeNull(); // instant under the streak
     expect(p.resource).toBe(mana0); // and free
     expect(p.auras.some((a) => a.id === 'hot_streak')).toBe(false); // spent
+  });
+
+  it('Flamestrike has no cooldown and can be cast again after its GCD', () => {
+    const { sim, p } = mageWithSpec('fire');
+    const mob = addDummy(sim);
+
+    expect(ABILITIES.flamestrike.cooldown).toBe(0);
+    sim.castAbilityAt('flamestrike', { x: mob.pos.x, z: mob.pos.z });
+    expect(p.castingAbility).toBe('flamestrike');
+    while (p.castingAbility) collect(sim, 0.05);
+    expect(p.cooldowns.has('flamestrike')).toBe(false);
+
+    gcdReset(p);
+    p.resource = p.maxResource;
+    sim.castAbilityAt('flamestrike', { x: mob.pos.x, z: mob.pos.z });
+    expect(p.castingAbility).toBe('flamestrike');
   });
 
   it('Rune of Power is a deliberate cast now', () => {

--- a/tests/mage_fireball_form.test.ts
+++ b/tests/mage_fireball_form.test.ts
@@ -1,17 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import { abilitiesKnownAt } from '../src/sim/content/classes';
 import { computeTalentModifiers, emptyAllocation } from '../src/sim/content/talents';
-import { ABILITIES, MOBS } from '../src/sim/data';
+import { ABILITIES, DUNGEONS, instanceOrigin, MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
+import { enterDungeon } from '../src/sim/instances/dungeons';
 import { Sim } from '../src/sim/sim';
-import type { Entity } from '../src/sim/types';
+import { type Entity, NYTHRAXIS_BOSS_ID } from '../src/sim/types';
 import { abilityBuffValue } from '../src/ui/ability_damage';
 import { hasExplicitAbilityIcon } from '../src/ui/icons';
 
 const FORM_ID = 'fireball_form';
 
-function mageWithSpec(spec: 'fire' | 'frost' | 'arcane'): Sim {
-  const sim = new Sim({ seed: 73, playerClass: 'mage', autoEquip: true });
+function mageWithSpec(spec: 'fire' | 'frost' | 'arcane', devCommands = false): Sim {
+  const sim = new Sim({ seed: 73, playerClass: 'mage', autoEquip: true, devCommands });
   sim.setPlayerLevel(11);
   expect(sim.setSpec(spec)).toBe(true);
   sim.tick();
@@ -64,6 +65,118 @@ describe('Mage Fireball Form', () => {
 
     expect(sim.player.castingAbility).toBeNull();
     expect(sim.player.auras.some((aura) => aura.kind === 'form_fireball')).toBe(true);
+  });
+
+  it('cannot be activated while the Mage is in combat', () => {
+    const sim = mageWithSpec('fire');
+    const resourceBefore = sim.player.resource;
+    sim.player.inCombat = true;
+    sim.drainEvents();
+
+    sim.castAbility(FORM_ID);
+
+    expect(sim.player.castingAbility).toBeNull();
+    expect(sim.player.auras.some((aura) => aura.kind === 'form_fireball')).toBe(false);
+    expect(sim.player.resource).toBe(resourceBefore);
+    expect(sim.player.cooldowns.has(FORM_ID)).toBe(false);
+    expect(sim.drainEvents()).toContainEqual(
+      expect.objectContaining({ type: 'error', text: "You can't do that while in combat." }),
+    );
+  });
+
+  it.each([
+    ['a dungeon', 'hollow_crypt'],
+    ['a raid', 'nythraxis_crypt'],
+  ] as const)('cannot be activated inside %s instance', (_label, dungeonId) => {
+    const sim = mageWithSpec('fire');
+    const resourceBefore = sim.player.resource;
+    expect(sim.enterDungeon(dungeonId)).toBe(true);
+    expect(sim.instanceInfoAt(sim.player.pos)?.dungeonId).toBe(dungeonId);
+    sim.drainEvents();
+
+    sim.castAbility(FORM_ID);
+
+    expect(sim.player.castingAbility).toBeNull();
+    expect(sim.player.auras.some((aura) => aura.kind === 'form_fireball')).toBe(false);
+    expect(sim.player.resource).toBe(resourceBefore);
+    expect(sim.player.cooldowns.has(FORM_ID)).toBe(false);
+    expect(sim.drainEvents()).toContainEqual(
+      expect.objectContaining({ type: 'error', text: 'Leave the dungeon first.' }),
+    );
+  });
+
+  it('cancels its running cast when combat starts before the transformation completes', () => {
+    const sim = mageWithSpec('fire');
+    const resourceBefore = sim.player.resource;
+    sim.castAbility(FORM_ID);
+    expect(sim.player.castingAbility).toBe(FORM_ID);
+    sim.drainEvents();
+
+    sim.player.inCombat = true;
+    const events = sim.tick();
+
+    expect(sim.player.castingAbility).toBeNull();
+    expect(sim.player.auras.some((aura) => aura.kind === 'form_fireball')).toBe(false);
+    expect(sim.player.resource).toBe(resourceBefore);
+    expect(sim.player.cooldowns.has(FORM_ID)).toBe(false);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'castStop', entityId: sim.player.id, success: false }),
+        expect.objectContaining({ type: 'error', text: "You can't do that while in combat." }),
+      ]),
+    );
+  });
+
+  it.each([
+    ['a dungeon', 'hollow_crypt'],
+    ['a raid', 'nythraxis_crypt'],
+  ] as const)(
+    'cancels its running cast when the Mage enters %s before completion',
+    (_label, dungeonId) => {
+      const sim = mageWithSpec('fire');
+      const resourceBefore = sim.player.resource;
+      sim.castAbility(FORM_ID);
+      expect(sim.player.castingAbility).toBe(FORM_ID);
+      sim.drainEvents();
+
+      expect(sim.enterDungeon(dungeonId)).toBe(true);
+      const events = sim.tick();
+
+      expect(sim.player.castingAbility).toBeNull();
+      expect(sim.player.auras.some((aura) => aura.kind === 'form_fireball')).toBe(false);
+      expect(sim.player.resource).toBe(resourceBefore);
+      expect(sim.player.cooldowns.has(FORM_ID)).toBe(false);
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'castStop', entityId: sim.player.id, success: false }),
+          expect.objectContaining({ type: 'error', text: 'Leave the dungeon first.' }),
+        ]),
+      );
+    },
+  );
+
+  it('cannot be activated in the wide wings after the Nythraxis boss despawns', () => {
+    const sim = mageWithSpec('fire', true);
+    expect(enterDungeon(sim.ctx, 'nythraxis_boss_arena', sim.player.id, true)).toBe(true);
+    const boss = [...sim.entities.values()].find(
+      (entity) => entity.templateId === NYTHRAXIS_BOSS_ID,
+    );
+    expect(boss).toBeDefined();
+    if (!boss) throw new Error('Nythraxis missing from the claimed raid');
+    sim.entities.delete(boss.id);
+    const origin = instanceOrigin(DUNGEONS.nythraxis_boss_arena.index, 0);
+    sim.player.pos = { ...sim.player.pos, x: origin.x + 130, z: origin.z + 96 };
+    sim.player.prevPos = { ...sim.player.pos };
+    sim.drainEvents();
+
+    sim.castAbility(FORM_ID);
+
+    expect(sim.instanceInfoAt(sim.player.pos)?.dungeonId).toBe('nythraxis_boss_arena');
+    expect(sim.player.castingAbility).toBeNull();
+    expect(sim.player.auras.some((aura) => aura.kind === 'form_fireball')).toBe(false);
+    expect(sim.drainEvents()).toContainEqual(
+      expect.objectContaining({ type: 'error', text: 'Leave the dungeon first.' }),
+    );
   });
 
   it('applies the canonical 40 percent movement bonus without dealing damage', () => {
@@ -131,6 +244,37 @@ describe('Mage Fireball Form', () => {
 
     sim.startAutoAttack();
     expect(player.autoAttack).toBe(false);
+  });
+
+  it('can still be toggled off after combat starts', () => {
+    const sim = mageWithSpec('arcane');
+    activate(sim);
+    sim.player.gcdRemaining = 0;
+    sim.player.inCombat = true;
+
+    sim.castAbility(FORM_ID);
+
+    expect(sim.player.auras.some((aura) => aura.kind === 'form_fireball')).toBe(false);
+  });
+
+  it.each([
+    ['a dungeon', 'hollow_crypt'],
+    ['a raid', 'nythraxis_crypt'],
+  ] as const)('can still be toggled off inside %s', (_label, dungeonId) => {
+    const sim = mageWithSpec('arcane');
+    activate(sim);
+    sim.player.gcdRemaining = 0;
+    expect(sim.enterDungeon(dungeonId)).toBe(true);
+    sim.drainEvents();
+
+    sim.castAbility(FORM_ID);
+
+    expect(sim.player.auras.some((aura) => aura.kind === 'form_fireball')).toBe(false);
+    expect(
+      sim
+        .drainEvents()
+        .some((event) => event.type === 'error' && event.text === 'Leave the dungeon first.'),
+    ).toBe(false);
   });
 
   it('toggles off through its running cooldown and restores normal control and speed', () => {


### PR DESCRIPTION
## Summary
- restrict Ember Form activation and cast completion in combat, dungeons, and raids while preserving safe toggle-off
- remove Flamestrike cooldown
- pin Cinderfall/Lluvia de Ascuas as instant, non-projectile, off-GCD, and usable during another cast
- cover Nythraxis' wide raid footprint even after the boss despawns

## Validation
- `npx vitest run tests/mage_fireball_form.test.ts tests/fire_mage.test.ts tests/combat_casting_lifecycle.test.ts tests/dungeons.test.ts tests/architecture.test.ts tests/localization_fixes.test.ts` (204 passed, 3 skipped)
- `npm run check:types` (pass)
- `npm run build`, `npm run build:env`, `npm run build:server` (pass)
- `npm run security:gate` (pass, 0 high)
- pre-push QA floor (pass)

## Known release baseline
`npm run gate` reaches the full Vitest suite and stops on unrelated existing failures. The Chronomancy shield expectation and Armory mobile browser failure reproduce unchanged on a clean `origin/release/v0.28.0` worktree.