### PR TITLE
test(professions): Phase 8 QA pass over stations and masters

### DIFF
--- a/docs/professions-2/phase-09-station-training.md
+++ b/docs/professions-2/phase-09-station-training.md
@@ -24,9 +24,9 @@ truth exists (Phase 8), and the recipe ladder content that depends on live train
 - `src/ui/hud/vendor/`: the vendor window family (`vendor_view.ts` pure core,
   `vendor_window.ts` painter; the heroic variant shows how the family extends).
 - `src/sim/professions/crafting.ts` (`acquireRecipe`, `acquireRecipeForRecipe`,
-  `isRecipeKnown`), `src/sim/professions/types.ts` (`knownRecipes`),
-  `src/sim/professions/crafting_hub.ts` (today's station gate), and the Phase 8 station
-  registry module named in `state.md`.
+  `isRecipeKnown`, and the `resolveCraftForRecipe` station gate),
+  `src/sim/professions/types.ts` (`knownRecipes`), and the Phase 8 station registry
+  `src/sim/professions/stations.ts` named in `state.md` (`crafting_hub.ts` is deleted).
 - `src/world_api/professions.ts` (the facet for the new command) and
   `tests/world_api_parity.test.ts` (the pin).
 - `server/game.ts` (command dispatch) and `src/net/online.ts` (wire command send plus the
@@ -61,8 +61,8 @@ Spawn one Explore agent to read and summarize:
 - docs/professions-2/phase-09-station-training.md (this phase file)
 - src/render/props.ts, src/render/characters/manifest.ts (NPC_KEYS), src/ui/minimap_markers.ts,
   src/ui/minimap_painter.ts, the src/ui/hud/vendor/ modules, src/sim/professions/crafting.ts,
-  src/sim/professions/types.ts, src/sim/professions/crafting_hub.ts, the Phase 8 station
-  registry module (see state.md "New surfaces per phase"), src/world_api/professions.ts,
+  src/sim/professions/types.ts, src/sim/professions/stations.ts (the Phase 8 station
+  registry; see state.md "New surfaces per phase"), src/world_api/professions.ts,
   server/game.ts (command dispatch only), src/net/online.ts (command send + ClientWorld mirror)
 - CLAUDE.md files: src/sim/CLAUDE.md, src/sim/professions/CLAUDE.md, src/render/CLAUDE.md,
   src/ui/CLAUDE.md, src/ui/hud/CLAUDE.md, src/world_api/CLAUDE.md, src/styles/CLAUDE.md

--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -22,7 +22,7 @@ Update this file at the end of every implementation and QA session. Statuses:
 | 7 | The Guild letter and quest objectives | complete | 2026-07-19 | 2026-07-19 |
 | 7 QA | Verify the Guild letter and quest objectives | complete | 2026-07-19 | 2026-07-19 |
 | 8 | Stations and masters (sim and server) | complete | 2026-07-19 | 2026-07-19 |
-| 8 QA | Verify stations and masters | not started | | |
+| 8 QA | Verify stations and masters | complete | 2026-07-19 | 2026-07-19 |
 | 9 | Station presence and recipe training | not started | | |
 | 9 QA | Verify station presence and training | not started | | |
 | 10 | Recipe ladders and materials content | not started | | |
@@ -647,3 +647,43 @@ Eastbrook, a deliberate buy-then-travel loop to reconsider in Phase 9
 stocking. STILL OPEN (unchanged from Phase 7): the Guild letter's
 call to action dead-ends pre-q_prof_intro; the masters ship with
 EMPTY questIds hooks and no redirect was silently implemented.
+
+Phase 8 QA (2026-07-19): PASS with fixes, zero blocking. Nine-agent
+fan-out (three packet audits plus privacy-security, migration-safety,
+cross-platform-sync, architecture, frontend-seam and the closing
+qa-checklist; database-performance did not match the diff), every
+agent complete first try under the 30-call budget, with the phase
+validation matrix pre-verified green at the untouched tip and passed
+to every agent as ground. The correctness audit ran six live
+headless-Sim probes (deny away from the station, wrong-type deny,
+at-station success, all nine field recipes far from any station, the
+full mobile place/craft/expire cycle against real ticks, caster-recipe
+radius behavior at 19 vs 30 out) plus proof that FIELD_RECIPES equals
+the pre-phase nine COMMON_RECIPES ids. Findings: 18 total, 3
+should-fix, all fixed: the Phase 9 phase file still pointed its
+reader at the deleted crafting_hub.ts (swept to stations.ts and the
+crafting.ts gate), the /dev mobilestation arm had zero coverage (now
+proves the cheat routes through the real specialization gate), and
+the hud station_required deny toast had no binding pin (source-pinned
+in profession_identity_card.test.ts). Fixed NITs: the FIELD_RECIPES
+set pin was a tautology against its own definition source (now pins
+the nine literal ids), the mobile expiry boundary was only incidental
+(exact strict-below pin added: active at expiry-1, expired at the
+expiry tick), and two comments (stations.ts header, CraftResultView)
+implied a mobile-arm proximity check the spec'd gate deliberately
+does not have (reworded). Dissolved on verification: the
+crafting_hub test filename misnomer (its header documents the
+deliberate keep for the deeds.ts anchors), the hud fallthrough
+mislabel (unreachable by construction and documented in-code), the
+slow-band set allocation (cold painter, throttled, pre-phase
+equivalent), and the place_mobile_station rate-limit worry
+(self-scoped transient slot overwrite, no growth, no rng, no db).
+Closed decisively: guide freshness (wiki:content regenerates no
+diff; the guide does not enumerate town NPCs). Deferred with notes
+in state.md: the Eastbrook loom-toolworks radius overlap (design
+observation for Phase 9 props and minimap), the consumer-less
+MobileCraftingStation pos/placedAtTick/playerId fields (Phase 9
+props are the natural consumer), the expired station object
+lingering on the meta slot until the next placement (benign, every
+reader checks isStationActive), and the mobile-viewport station row
+being screenshot-verified only.

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -649,7 +649,21 @@ tables, i18n key namespaces, files created)
   desc fills dropped for the release refill). The nine former hub
   recipes relocated from Highwatch to their typed stations (seven in
   Eastbrook, tannery in Fenbridge); Highwatch keeps the apothecary
-  (no alchemy station recipe exists yet, forward content).
+  (no alchemy station recipe exists yet, forward content). Phase 8 QA
+  drift notes (2026-07-19): Eastbrook loom-to-toolworks separation is
+  about 13.6 against STATION_RADIUS 20, so standing at the loom also
+  satisfies the toolworks gate (and forge-to-kitchens clears by only
+  1.6), accepted town-square density with no strand and no info
+  hiding, for Phase 9 props/minimap to be aware of;
+  MobileCraftingStation.pos, placedAtTick, and playerId are recorded
+  but consumer-less today (the gate reads craftId plus expiresAtTick
+  only; Phase 9 props are the natural pos consumer); an expired
+  mobileStation object lingers on the meta slot until the next
+  placement (benign, every reader checks isStationActive);
+  content/professions.ts reads ZONE1/2/3_ZONE.id at module init (no
+  runtime cycle today because the zone modules never import
+  professions content, but a future reverse import would see
+  undefined during init).
 - Phase 13: (planned) disenchantItem/applyEnchant/salvageItem IWorld
   members + wire commands.
 

--- a/src/sim/professions/stations.ts
+++ b/src/sim/professions/stations.ts
@@ -1,9 +1,9 @@
 // Crafting stations (Professions 2.0 Phase 8): the hands-vs-stations split.
 // Field recipes (content/recipes.ts FIELD_RECIPES) craft anywhere; a recipe
 // carrying a `stationType` (professions/types.ts ProfessionRecipeRecord)
-// resolves only while the crafter stands at a matching station, or next to
-// their own active mobile station (mobile_station.ts) whose craft maps to
-// that type. This replaces the retired level-20 crafting-hub gate (#1297's
+// resolves only while the crafter stands at a matching station, or while
+// their own mobile station (mobile_station.ts) whose craft maps to that
+// type is ACTIVE (the mobile arm checks activity and type, never distance). This replaces the retired level-20 crafting-hub gate (#1297's
 // crafting_hub.ts): the level arm is gone entirely (2026-07-17 maintainer
 // ruling), and the single hub circle is replaced by per-type stations spread
 // across the towns (content/professions.ts STATIONS).

--- a/src/world_api/professions.ts
+++ b/src/world_api/professions.ts
@@ -51,7 +51,8 @@ export interface CraftResultView {
     | 'throttled'
     // Phase 8 (supersedes #1297's not_at_hub): denied because the recipe is
     // station-bound and the player is neither at a station of its type nor
-    // beside their own active mobile station for that craft. The ui resolves
+    // holding an ACTIVE mobile station for that craft (the mobile arm checks
+    // activity and type, never distance). The ui resolves
     // WHICH station from recipeById(recipeId)?.stationType (static content,
     // identical in both worlds): no station field rides the event.
     | 'station_required';

--- a/tests/dev_commands.test.ts
+++ b/tests/dev_commands.test.ts
@@ -138,6 +138,22 @@ describe('dev commands', () => {
     expect(sim.player.inCombat).toBe(false);
   });
 
+  it('mobilestation places through the REAL specialization gate, not around it', () => {
+    const sim = devSim();
+    const meta = (sim as any).players.get(sim.playerId);
+
+    // Unspecialized: the cheat saves the walk, never the gate (dev_commands.ts
+    // routes through placeMobileStationForPlayer).
+    sim.chat('/dev mobilestation engineering');
+    expect(meta.mobileStation).toBeNull();
+
+    meta.craftSkills.engineering = 75; // the specialization threshold (#1134)
+    sim.chat('/dev mobilestation ENGINEERING'); // the arm lowercases the craft id
+    expect(meta.mobileStation?.craftId).toBe('engineering');
+    // The IWorld read agrees while the station is active.
+    expect(sim.activeMobileStationCraft).toBe('engineering');
+  });
+
   it('is inert when dev commands are disabled', () => {
     const sim = new Sim({ seed: 42, playerClass: 'warrior', devCommands: false });
     const beforeIds = [...sim.entities.keys()];

--- a/tests/profession_identity_card.test.ts
+++ b/tests/profession_identity_card.test.ts
@@ -368,3 +368,18 @@ describe('crafting window station-range repaint liveness (source pins)', () => {
     expect(hud).toContain('this.lastCraftingStationSig = stationTypesSignature(inRangeStations);');
   });
 });
+
+describe('craftResult deny toast names the station (source pins)', () => {
+  const hud = readFileSync(path.resolve(process.cwd(), 'src/ui/hud.ts'), 'utf8');
+
+  it('station_required resolves the type from recipe content (no station field rides the event)', () => {
+    expect(hud).toMatch(
+      /ev\.reason === 'station_required' \? recipeById\(ev\.recipeId\)\?\.stationType : undefined/,
+    );
+  });
+
+  it('a resolved type renders the NAMED toast via stationRequired + stationNameText', () => {
+    expect(hud).toContain("t('hudChrome.crafting.stationRequired', {");
+    expect(hud).toContain('station: stationNameText(deniedStationType),');
+  });
+});

--- a/tests/professions_crafting_hub.test.ts
+++ b/tests/professions_crafting_hub.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   CRAFT_RING,
+  MOBILE_CRAFTING_STATION_DURATION_TICKS,
   STATION_RADIUS,
   STATION_TYPE_BY_CRAFT,
   STATIONS,
@@ -26,7 +27,10 @@ import { ZONE2_ZONE } from '../src/sim/content/zone2';
 import { ZONE3_ZONE } from '../src/sim/content/zone3';
 import { ITEMS, NPCS } from '../src/sim/data';
 import { craftItem, resolveCraft } from '../src/sim/professions/crafting';
-import { placeMobileStationForPlayer } from '../src/sim/professions/mobile_station';
+import {
+  isStationActive,
+  placeMobileStationForPlayer,
+} from '../src/sim/professions/mobile_station';
 import { isAtStation, stationsOfType, stationTypeForCraft } from '../src/sim/professions/stations';
 import { Sim } from '../src/sim/sim';
 
@@ -120,7 +124,23 @@ describe('station content (Phase 8)', () => {
 
   it('FIELD_RECIPES is exactly the nine common recipes, and stamps split hands-vs-stations', () => {
     expect(COMMON_RECIPES.length).toBe(9);
-    expect([...FIELD_RECIPES].sort()).toEqual(COMMON_RECIPES.map((r) => r.id).sort());
+    // Pinned to the nine LITERAL ids, not COMMON_RECIPES-derived: FIELD_RECIPES
+    // is defined AS Set(COMMON_RECIPES ids) (recipes.ts), so a derived compare
+    // is a tautology; only the literal list trips when a content edit adds,
+    // drops, or swaps a common recipe.
+    expect([...FIELD_RECIPES].sort()).toEqual(
+      [
+        'recipe_eastbrook_arming_sword',
+        'recipe_eastbrook_chain_vest',
+        'recipe_eastbrook_wool_trousers',
+        'recipe_tanned_leather_jerkin',
+        'recipe_tough_jerky',
+        'recipe_minor_healing_potion',
+        'recipe_eastbrook_ritual_vestments',
+        'recipe_eastbrook_druids_hide',
+        'recipe_eastbrook_warded_leggings',
+      ].sort(),
+    );
     // Hands: no common or combo recipe carries a stationType.
     for (const recipe of [...COMMON_RECIPES, ...COMBO_RECIPES]) {
       expect(recipe.stationType, `${recipe.id} must stay field-craftable`).toBeUndefined();
@@ -288,6 +308,25 @@ describe('resolveCraft station gate (Phase 8: position-only, per type)', () => {
     const reloaded = makeSim(7);
     const reloadedPid = reloaded.addPlayer('warrior', 'Reloaded', { state: state ?? undefined });
     expect((reloaded as any).players.get(reloadedPid).mobileStation).toBeNull();
+  });
+
+  it('mobile-station activity is strict at the boundary: active at expiry-1, expired AT expiry', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = (sim as any).players.get(pid);
+    meta.craftSkills.engineering = 75;
+    const station = placeMobileStationForPlayer((sim as any).ctx, 'engineering', pid);
+    expect(station).toBeDefined();
+    if (!station) return;
+    // isStationActive is a strict < on expiresAtTick: the expiry tick itself
+    // is already inactive (the offline expired-arm test above overwrites the
+    // tick wholesale, so only this pin holds the exact boundary).
+    expect(isStationActive(station, station.expiresAtTick - 1)).toBe(true);
+    expect(isStationActive(station, station.expiresAtTick)).toBe(false);
+    // The window is the content constant, anchored at the placement tick.
+    expect(station.expiresAtTick - station.placedAtTick).toBe(
+      MOBILE_CRAFTING_STATION_DURATION_TICKS,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Phase 8 QA of the Professions 2.0 program (docs/professions-2/phase-08-qa.md): an independent audit of the stations-and-masters diff (571ab0219..e61c7856d, PR #2162) for correctness, test coverage, dead code, determinism, three-host parity, and i18n completeness.

Verdict: PASS with fixes, zero blocking. A nine-agent audit (three packet audits plus the privacy-security, migration-safety, cross-platform-sync, architecture, and frontend-seam reviewers, closed by qa-checklist) returned 18 findings: 3 should-fix, all fixed here; the rest fixed, dissolved on verification, or deferred with notes in state.md. The correctness audit exercised the real behavior in a live headless Sim: station deny away/wrong-type/success, all nine field recipes far from any station, the full mobile place/craft/expire cycle against real ticks, caster-recipe radius behavior at 19 vs 30 out, and FIELD_RECIPES set-equality against the pre-phase nine COMMON_RECIPES ids. The prime directive holds: no recipe strands for any mid-progress player.

What this PR changes:

- test(professions): the /dev mobilestation arm gets coverage proving the cheat routes through the real specialization gate; the hud station_required deny toast gets binding source pins; the FIELD_RECIPES pin swaps a tautological derived compare for the nine literal recipe ids; isStationActive gets an exact expiry-boundary pin (active at expiry-1, expired at the expiry tick).
- chore(professions): two comments (stations.ts header, CraftResultView) implied a mobile-arm proximity check the spec'd gate deliberately does not have; both now say the arm checks activity and craft type only.
- docs(professions-2): the 8 QA row is marked complete with the findings ledger; QA drift notes appended to the state.md Phase 8 entry (Eastbrook loom-to-toolworks radius overlap, consumer-less MobileCraftingStation fields, lingering expired slot object, zone-id init-order coupling); phase-09-station-training.md's two references to the deleted crafting_hub.ts are swept onto stations.ts and the crafting.ts gate.

Maintainer observations (no action taken): Eastbrook loom and toolworks sit about 13.6 apart against STATION_RADIUS 20, so standing at the loom also satisfies the toolworks gate (accepted town-square density; Phase 9 props/minimap should be aware); the open decisions from PR #2162 (Guild-letter dead-end, mobile-station type scope, Bree reagent stocking) are untouched.

## Related issues

Part of #1866.

## Type of change

- [x] Tests
- [x] Documentation

## How was this tested?

- Commands: the full phase validation matrix ran green at the untouched tip BEFORE the audit (npx tsc --noEmit; npx vitest run over professions_crafting_hub, professions_crafting, professions_station_placement, professions_station_online, progression, architecture, localization_fixes, i18n_completeness, world_api_parity, chronomancy, parity/parity, parity/coverage); after the fixes, the touched suites (professions_crafting_hub, dev_commands, profession_identity_card: 42 passed) plus npx tsc --noEmit and npm run wiki:content (no diff, guide freshness confirmed); npm run gate under Node 24.
- Manual steps: six behavioral probes in a throwaway headless-Sim vitest file (written, run 6/6 green, deleted; tree verified clean); subagent findings independently re-verified against source before any fix landed.

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green (the one known environmental armory browser red on this machine reproduces on an untouched release tip; the gate tail was completed manually and PR CI is the arbiter). Decisive tests added for every closed gap.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI behavior change (tests, comments, docs only).
- ~Accessible.~ N/A.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
