### PR TITLE
feat(talents): extend shared proc responses

### DIFF
--- a/src/sim/combat/auto_attack.ts
+++ b/src/sim/combat/auto_attack.ts
@@ -385,6 +385,7 @@ export function meleeSwing(
     // weaponStrike path threads it here so per-ability crit talents reach the
     // shared hit table.
     critBonus?: number;
+    abilityId?: string;
     onDealt?: (amount: number) => void;
     whiteDualWieldPenalty?: boolean;
   },
@@ -486,7 +487,7 @@ export function meleeSwing(
   // Landed-swing talent responses resolve before the target retaliates or the
   // weapon's on-hit proc fires. This is observable for defensive healing and
   // preserves the authored Oathwheel, Venom Dividend, and imbue proc cadence.
-  if (attacker.kind === 'player') onMeleeSwing(ctx, attacker);
+  if (attacker.kind === 'player') onMeleeSwing(ctx, attacker, opts.abilityId ?? 'auto_attack');
   // thorns / lightning shield: melee attackers take damage back. Charge-limited
   // thorns (Lightning Shield) consume a charge and gate on an internal cooldown.
   if (!attacker.dead) {

--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -317,6 +317,7 @@ export function runEffects(
           // Ability-scoped crit talents (ResolvedAbilityMod.critPct, e.g. the
           // Redhanded Craven Thrust mastery) ride the shared hit table.
           critBonus: mods.abilities[ability.id]?.critPct ?? 0,
+          abilityId: ability.id,
           onDealt:
             areaEcho || sweeping
               ? (amount) => {

--- a/src/sim/combat/talent_procs.ts
+++ b/src/sim/combat/talent_procs.ts
@@ -1,9 +1,10 @@
 // Talent proc engine: the shared primitive behind behavior-changing choice-row
 // options (docs/design/choice-row-quality-pass.md). A row option carries a
 // declarative ProcDef; combat code reports moments (cast completed, crit,
-// shield consumed, HoT expired, big hit taken, imbued swing) through single
+// shield consumed, HoT expired, big hit taken, landed melee hit, imbued swing) through single
 // delegating calls here, and this module holds the per-player counters and
-// internal cooldowns and applies the response. Counters and icds are plain
+// internal cooldowns and applies the response. Responses can also stack a visible
+// aura, add charges to an owned aura, or restore a percentage resource. Counters and icds are plain
 // tick math; a trigger with an optional `chance` draws through the sim Rng
 // only at the moment it would otherwise fire, so players without such a proc
 // draw no rng and replay determinism is untouched. Nothing is persisted.
@@ -100,19 +101,56 @@ function fireOne(
       if (response.resourceType !== undefined && player.resourceType !== response.resourceType) {
         break;
       }
-      player.resource = Math.min(player.maxResource, player.resource + response.amount);
-      break;
-    case 'heal':
-      ctx.applyHeal(
-        player,
-        subject,
-        response.amountPctSourceMaxHp !== undefined
-          ? Math.round(player.maxHp * response.amountPctSourceMaxHp)
-          : response.amountPctMaxHp !== undefined
-            ? Math.round(subject.maxHp * response.amountPctMaxHp)
-            : (response.amount ?? 0),
-        def.name,
+      player.resource = Math.min(
+        player.maxResource,
+        player.resource + (response.amount ?? player.maxResource * response.pctMax),
       );
+      break;
+    case 'stackAura': {
+      const existing = player.auras.find(
+        (aura) => aura.id === def.id && aura.sourceId === player.id,
+      );
+      if (existing) {
+        existing.stacks = Math.min(response.maxStacks, (existing.stacks ?? 0) + 1);
+        existing.remaining = response.duration;
+        existing.duration = response.duration;
+      } else {
+        ctx.applyAura(player, {
+          id: def.id,
+          name: def.name,
+          kind: response.aura,
+          remaining: response.duration,
+          duration: response.duration,
+          value: 0,
+          stacks: 1,
+          sourceId: player.id,
+          school: def.school ?? 'physical',
+        });
+      }
+      break;
+    }
+    case 'addAuraCharges': {
+      const aura = player.auras.find(
+        (entry) => entry.id === response.ability && entry.sourceId === player.id,
+      );
+      if (!aura) break;
+      aura.charges = Math.min(response.maxCharges, (aura.charges ?? 0) + response.amount);
+      break;
+    }
+    case 'heal':
+      {
+        const recipient = response.applyTo === 'self' ? player : subject;
+        ctx.applyHeal(
+          player,
+          recipient,
+          response.amountPctSourceMaxHp !== undefined
+            ? Math.round(player.maxHp * response.amountPctSourceMaxHp)
+            : response.amountPctMaxHp !== undefined
+              ? Math.round(recipient.maxHp * response.amountPctMaxHp)
+              : (response.amount ?? 0),
+          def.name,
+        );
+      }
       break;
     case 'absorb':
       ctx.applyAura(subject, {
@@ -282,9 +320,23 @@ export function onDamageTaken(ctx: SimContext, player: Entity, amount: number): 
   }
 }
 
-export function onMeleeSwing(ctx: SimContext, player: Entity): void {
+export function onMeleeSwing(ctx: SimContext, player: Entity, abilityId = 'auto_attack'): void {
   for (const def of procsFor(ctx, player)) {
     const trigger = def.trigger;
+    if (trigger.on === 'meleeHit') {
+      if (!trigger.abilities.includes(abilityId)) continue;
+      if (
+        trigger.auraKind !== undefined &&
+        !player.auras.some((aura) => aura.kind === trigger.auraKind)
+      ) {
+        continue;
+      }
+      if (trigger.icd !== undefined && state(player).icds[def.id] !== undefined) continue;
+      if (trigger.chance !== undefined && !ctx.rng.chance(trigger.chance)) continue;
+      if (trigger.icd !== undefined) state(player).icds[def.id] = trigger.icd;
+      fire(ctx, player, def, player);
+      continue;
+    }
     if (trigger.on !== 'meleeSwingWhile') continue;
     if (!player.auras.some((aura) => aura.kind === trigger.auraKind)) continue;
     // G2/G4 (mirrors the cast triggers): optional internal cooldown and fire

--- a/src/sim/content/talents.ts
+++ b/src/sim/content/talents.ts
@@ -162,6 +162,13 @@ export type ProcTrigger =
   | { on: 'shieldConsumed'; ability: string }
   | { on: 'hotExpired'; ability: string }
   | { on: 'bigHitTaken'; hpFrac: number; icd: number }
+  | {
+      on: 'meleeHit';
+      abilities: string[];
+      auraKind?: AuraKind;
+      icd?: number;
+      chance?: number;
+    }
   | { on: 'meleeSwingWhile'; auraKind: string; icd?: number; chance?: number }
   | { on: 'thornsReflect'; ability: string };
 
@@ -174,7 +181,12 @@ export type ProcResponse =
       costPct?: number;
     }
   | { kind: 'cooldownRefund'; ability: string; seconds: number | 'reset' }
-  | { kind: 'resource'; amount: number; resourceType?: ResourceType }
+  | ({ kind: 'resource'; resourceType?: ResourceType } & (
+      | { amount: number; pctMax?: never }
+      | { amount?: never; pctMax: number }
+    ))
+  | { kind: 'stackAura'; aura: AuraKind; maxStacks: number; duration: number }
+  | { kind: 'addAuraCharges'; ability: string; amount: number; maxCharges: number }
   // The pct-of-max-health variants (phase-2 defensive pass) override the flat
   // number when present. Most scale with the wearer; source scaling is for
   // shields whose proc owner can differ from the protected ally.
@@ -183,6 +195,7 @@ export type ProcResponse =
       amount?: number;
       amountPctMaxHp?: number;
       amountPctSourceMaxHp?: number;
+      applyTo?: 'self';
     }
   | { kind: 'absorb'; amount?: number; amountPctMaxHp?: number; duration: number; name: string }
   | {
@@ -222,6 +235,7 @@ export interface SpecDef {
   icon: string;
   description: string;
   signature: string;
+  extraGrants?: string[];
   mastery: { name: string; description: string; effect: TalentEffect };
 }
 
@@ -691,6 +705,7 @@ export function computeTalentModifiers(
     modifiers.spec = spec.id;
     modifiers.role = spec.role;
     modifiers.grants.push({ ability: spec.signature, rank: 1 });
+    for (const ability of spec.extraGrants ?? []) modifiers.grants.push({ ability, rank: 1 });
     accumulateTalentEffect(modifiers, spec.mastery.effect, Math.min(1, Math.max(0, level) / 20));
   }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -5436,6 +5436,7 @@ export class Sim {
       threatMult?: number;
       forceCrit?: boolean;
       critBonus?: number;
+      abilityId?: string;
       onDealt?: (amount: number) => void;
     },
   ): boolean {

--- a/src/sim/sim_context.ts
+++ b/src/sim/sim_context.ts
@@ -689,6 +689,7 @@ export interface SimContextCallbacks {
       threatMult?: number;
       forceCrit?: boolean;
       critBonus?: number;
+      abilityId?: string;
       onDealt?: (amount: number) => void;
     },
   ): boolean;

--- a/src/ui/talent_i18n.ts
+++ b/src/ui/talent_i18n.ts
@@ -9132,6 +9132,8 @@ function procTriggerDescription(
       return `${abilityName(trigger.ability)}: 0 s`;
     case 'bigHitTaken':
       return `>= ${formatPercent(trigger.hpFrac, lang)} ${text.statLabels.maxHpPct} (${seconds(trigger.icd, lang)} ${text.statLabels.cooldown})`;
+    case 'meleeHit':
+      return `${text.statLabels.meleeDmgPct}: ${abilityList(trigger.abilities)}`;
     case 'meleeSwingWhile':
       return `${text.statLabels.meleeDmgPct} @ ${t('hudChrome.auraEffect.imbue')}`;
     case 'thornsReflect':
@@ -9157,7 +9159,15 @@ function procResponseDescription(
     case 'cooldownRefund':
       return `${abilityName(response.ability)}: -${response.seconds === 'reset' ? formatPercent(1, lang) : seconds(response.seconds, lang)} ${text.statLabels.cooldown}`;
     case 'resource':
-      return `+${formatNumber(response.amount, lang)} ${t('classDetails.labels.resource')}`;
+      return `+${
+        response.amount !== undefined
+          ? formatNumber(response.amount, lang)
+          : formatPercent(response.pctMax, lang)
+      } ${t('classDetails.labels.resource')}`;
+    case 'stackAura':
+      return `x${formatNumber(response.maxStacks, lang)} (${seconds(response.duration, lang)})`;
+    case 'addAuraCharges':
+      return `${abilityName(response.ability)}: +${formatNumber(response.amount, lang)}`;
     case 'heal': {
       const healValue =
         response.amountPctSourceMaxHp !== undefined

--- a/tests/talent_procs.test.ts
+++ b/tests/talent_procs.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   onCastCompleted,
   onDamageTaken,
+  onMeleeSwing,
   type ProcDef,
   tickProcState,
 } from '../src/sim/combat/talent_procs';
@@ -107,5 +108,72 @@ describe('talent proc engine', () => {
     p.cooldowns.set('exorcism', 12);
     onCastCompleted(ctx, p, 'judgement');
     expect(p.cooldowns.has('exorcism')).toBe(false);
+  });
+
+  it('meleeHit filters the landed ability and stacks its aura to the authored cap', () => {
+    const proc: ProcDef = {
+      id: 'test_stacks',
+      name: 'Test Stacks',
+      trigger: { on: 'meleeHit', abilities: ['auto_attack', 'stormstrike'] },
+      responses: [{ kind: 'stackAura', aura: 'icicles', maxStacks: 2, duration: 8 }],
+    };
+    const { p, ctx } = fakePlayer([proc]);
+
+    onMeleeSwing(ctx, p, 'sinister_strike');
+    expect(p.auras).toHaveLength(0);
+
+    onMeleeSwing(ctx, p, 'auto_attack');
+    onMeleeSwing(ctx, p, 'stormstrike');
+    onMeleeSwing(ctx, p, 'auto_attack');
+
+    expect(p.auras).toHaveLength(1);
+    expect(p.auras[0]).toMatchObject({ id: 'test_stacks', kind: 'icicles', stacks: 2 });
+  });
+
+  it('supports percent resource restoration and adding charges to an owned aura', () => {
+    const proc: ProcDef = {
+      id: 'test_current',
+      name: 'Test Current',
+      trigger: { on: 'castNth', n: 1, abilities: ['earth_shock'] },
+      responses: [
+        { kind: 'resource', pctMax: 0.08, resourceType: 'mana' },
+        { kind: 'addAuraCharges', ability: 'lightning_shield', amount: 1, maxCharges: 9 },
+      ],
+    };
+    const { p, ctx } = fakePlayer([proc]);
+    p.resourceType = 'mana';
+    p.auras.push({
+      id: 'lightning_shield',
+      name: 'Lightning Shield',
+      kind: 'thorns',
+      remaining: 60,
+      duration: 60,
+      value: 1,
+      charges: 3,
+      sourceId: p.id,
+      school: 'nature',
+    });
+
+    onCastCompleted(ctx, p, 'earth_shock');
+
+    expect(p.resource).toBe(58);
+    expect(p.auras[0].charges).toBe(4);
+  });
+
+  it('can direct a proc heal to its owner instead of the cast target', () => {
+    const proc: ProcDef = {
+      id: 'test_self_heal',
+      name: 'Test Self Heal',
+      trigger: { on: 'castNth', n: 1, abilities: ['healing_wave'] },
+      responses: [{ kind: 'heal', amountPctMaxHp: 0.1, applyTo: 'self' }],
+    };
+    const { p, ctx } = fakePlayer([proc]);
+    const ally = { ...p, id: 2, hp: 100, maxHp: 1000, auras: [] } as Entity;
+    p.hp = 200;
+
+    onCastCompleted(ctx, p, 'healing_wave', ally);
+
+    expect(p.hp).toBe(240);
+    expect(ally.hp).toBe(100);
   });
 });


### PR DESCRIPTION
## Summary

- add filtered landed-melee proc triggers, including ability, aura-kind, chance, ICD, and melee-source filters
- add reusable proc responses for percent resources, aura stacks and charges, and self-healing
- expose landed melee ability ids, specification extra grants, and exhaustive talent tooltip rendering

## Why

This is the shared infrastructure slice extracted from #1980 for the v0.28.0 class-owner work. It keeps class content out of the common engine PR so Hunter, Shaman, Priest, and the other owner passes can be reviewed independently.

The additions stay behind the existing talent proc and specification seams; they do not redesign the combat pipeline or change any class by themselves.

## Validation

- `npx vitest run tests/talent_procs.test.ts` — 7 passed
- `npm run check:ts` — passed
- included in the rebased Shaman stack's focused suite — 182 passed, 3 skipped
- full dependent stack: `npm run gate` — all 11 steps passed
