### PR TITLE
test(professions): Phase 9 QA pass for station training

### DIFF
--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -721,3 +721,73 @@ resolveCraft denies combo_requirement_unmet before recipe_not_learned;
 wardweave_cowl/duskhide_wraps/sootscale_mantle genuinely consume
 thorium_ore, so the master-stock mapping is thorium-heavy by content,
 not by choice.
+
+Phase 9 QA (2026-07-19): PASS with fixes, zero blocking. Ten-agent
+fan-out (three packet audits plus privacy-security, migration-safety,
+cross-platform-sync, architecture, frontend-seam, test-coverage-
+auditor and the closing qa-checklist; database-performance did not
+match the diff), with the phase validation matrix pre-verified green
+at the untouched tip and passed to every agent as ground. Seven of
+ten completed inside the Workflow; frontend-seam, privacy-security
+and qa-checklist finished their investigations but failed structured
+delivery and were re-dispatched fresh via the Agent tool (the
+established recovery recipe), all completing there. Played behavior
+was verified twice over: the correctness audit ran six live
+headless-Sim probes (exact-balance train to zero, key-absent legacy
+blob, mobile-station craft beside the training deny, same-row ladder
+flip, multi-violation deny order, a grandfathered common crafted at
+skill 0), and the orchestrator drove the real offline client over
+CDP (gossip Train option, tier deny with the named "You need Alchemy
+25" line, exact-fee train, replay deny with no re-charge, fee-1
+cannot-afford, out-of-range, the 8yd proximity auto-close, the
+crafting-window known-filter in both directions, the station minimap
+marker and token, trained-not-known on a fresh character); the
+online arm rests on the live GameServer routing suite plus the
+snapshots cprof-mirror pin, both re-verified decisive. All nine
+acceptance criteria hold. Fixes landed: the exactly-affordable fee
+edge (copper equal to fee) pinned at the Sim level; per-pair deny
+reason-to-key mapping pins (a key swap inside the hud ternary chain
+previously passed every pin); isStationMasterNpc parametrized over
+all six STATIONS masters with a smith_haldren negative; a same-row
+locked-to-teachable flip pin at the 24/25 boundary; a full
+multi-violation deny-order pin; an explicit server-side
+recipesGrandfathered-true pin on a fresh online join; a key-absent
+(pre-#1299) legacy-save arm; and the accepted rollback caveat turned
+into a pin (a full current-shape blob stripped of the flag re-unions
+on return, fee-free, exactly the state.md release-notes wording).
+One frontend should-fix landed as a small extraction: the
+viewer-side knownness predicate was duplicated between the crafting
+window filter and the train ladder, now shared as train_view.ts
+isRecipeKnownForViewer (both call sites delegate; the known-filter
+source pin deliberately re-pinned to the delegation), and rowState
+now calls the sim's own teachTierMet instead of restating it.
+Dissolved on verification (the seventh phase running): the
+correctness agent's claim that the legacy fixture shape was wrong
+(knownRecipes existed at phase start d40f0a90f; the hand-frozen
+fixture is a genuine pre-Phase-9 shape). Deferred with reasons: the
+unknown-deny-reason fallback renders the out-of-range line instead
+of nothing (reachable only under client/server version skew on a
+closed 5-member union; maintainer call for a later phase); a
+same-state same-craft mobile-craft-versus-training-deny contrast is
+impossible in wave-one content (no plain station-gated alchemy
+recipe and no engineering trainer recipe exist; covered by
+cross-suite composition plus the live probe); the tokens-coverage
+pin for --color-minimap-station stays the accepted build-time
+deferral; the pr_shot_targets forge position literals are
+script-only. Privacy INFO for the economy owner: the master
+stocking makes thorium_ore and the six premium reagents purchasable
+in zones 1 and 2 where previously only quartermaster_bree (zone 3)
+sold them; deliberate, no price/arbitrage loop. The closing
+qa-checklist returned READY (zero blocking, zero should-fix); its
+five verify items all closed from session ground: the architecture
+suite ran green in the matrix, the fee table matches the state.md
+tuning targets verbatim (common free, uncommon 25s, rare 1g), the
+asset budget output is byte-identical to phase start (zero public/
+changes; its red rows are pre-existing debt outside the gate), guide
+freshness rides the gate's pretest wiki:content plus
+tests/guide.test.ts, and mobile rests on the green mobile window
+suites plus the phase's committed mobile screenshots (live mobile
+E2E not re-run, the Phase 8-precedent deferral). Its remaining INFO,
+a dedicated train_recipe rate limit, stays optional: the command is
+idempotent (already-known denies without charging) and the global
+command cadence limiter applies.

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -719,7 +719,14 @@ tables, i18n key namespaces, files created)
   maps get the sim gate with no props; the mobile-station prop stays
   deferred (pos/placedAtTick still consumer-less); smith_haldren does
   not train (the forge's masterNpcId is forgemistress_darva, the
-  locked Phase 8 seating). ROLLBACK CAVEAT (reviewed and consciously
+  locked Phase 8 seating); since the Phase 9 QA pass, the viewer-side
+  knownness predicate is the SHARED train_view.ts
+  isRecipeKnownForViewer (the train ladder's known state and the
+  crafting window's known-filter both delegate to it, and rowState
+  delegates to training.ts teachTierMet, so neither UI site can
+  drift from the sim's rule; the hud known-filter source pin in
+  tests/train_window_hud.test.ts pins the delegation itself).
+  ROLLBACK CAVEAT (reviewed and consciously
   accepted, migration-safety 2026-07-19): a character created under
   Phase 9 code whose save round-trips through pre-Phase-9 server code
   loses the unknown recipesGrandfathered field (old serialize rebuilds

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -303,7 +303,7 @@ import { QuestTrackerController } from './hud/quest/quest_tracker_controller';
 import { QuestLogWindow } from './hud/quest/questlog_window';
 import { buildHeroicVendorView } from './hud/vendor/heroic_vendor_view';
 import { renderHeroicVendorWindow } from './hud/vendor/heroic_vendor_window';
-import { buildTrainView } from './hud/vendor/train_view';
+import { buildTrainView, isRecipeKnownForViewer } from './hud/vendor/train_view';
 import { renderTrainWindow } from './hud/vendor/train_window';
 import { buildVendorView } from './hud/vendor/vendor_view';
 import { renderVendorWindow } from './hud/vendor/vendor_window';
@@ -10954,15 +10954,14 @@ export class Hud {
       this.sim.activeMobileStationCraft,
     );
     this.lastCraftingStationSig = stationTypesSignature(inRangeStations);
-    // Phase 9: the window lists only KNOWN recipes (isRecipeKnown semantics
-    // over the mirrored knownRecipes: a recipe with no/empty acquisition list
-    // is grandfathered known to everyone; otherwise its id must be in the
-    // viewer's known set), so an unlearned trainer recipe never renders as a
-    // craftable row. The server still re-validates recipe_not_learned.
+    // Phase 9: the window lists only KNOWN recipes, so an unlearned trainer
+    // recipe never renders as a craftable row (it surfaces in the Train
+    // ladder instead). The SAME viewer-side predicate the ladder's known
+    // state uses (train_view.ts isRecipeKnownForViewer), so the two windows
+    // cannot disagree. The server still re-validates recipe_not_learned.
     const knownRecipeIds = new Set(this.sim.craftingIdentity.knownRecipes);
-    const knownRecipes = this.sim.recipeList.filter(
-      (recipe) =>
-        !recipe.acquisition || recipe.acquisition.length === 0 || knownRecipeIds.has(recipe.id),
+    const knownRecipes = this.sim.recipeList.filter((recipe) =>
+      isRecipeKnownForViewer(recipe, knownRecipeIds),
     );
     renderCraftingWindow(
       $('#crafting-window'),

--- a/src/ui/hud/vendor/train_view.ts
+++ b/src/ui/hud/vendor/train_view.ts
@@ -18,7 +18,7 @@
 import { STATION_TYPE_BY_CRAFT, STATIONS } from '../../../sim/content/professions';
 import { ALL_RECIPES } from '../../../sim/content/recipes';
 import type { StationType } from '../../../sim/professions/stations';
-import { trainingFeeFor } from '../../../sim/professions/training';
+import { teachTierMet, trainingFeeFor } from '../../../sim/professions/training';
 import type { ProfessionRecipeRecord } from '../../../sim/professions/types';
 import { TIER_SKILL_STEP, tierForSkill } from '../../../sim/professions/wheel';
 import type { ItemDef } from '../../../sim/types';
@@ -66,22 +66,35 @@ export function isStationMasterNpc(masterNpcId: string): boolean {
   return STATIONS.some((station) => station.masterNpcId === masterNpcId);
 }
 
+/** The viewer-side knownness predicate over the MIRRORED known set: exactly
+ *  crafting.ts isRecipeKnown's rule (an empty or absent acquisition list is
+ *  grandfathered known to everyone; otherwise the id must be in the set),
+ *  restated for hosts that hold CraftingIdentityView data instead of
+ *  PlayerMeta. The crafting window's known-filter and the train ladder's
+ *  known state MUST agree, so both call this one helper. */
+export function isRecipeKnownForViewer(
+  recipe: ProfessionRecipeRecord,
+  known: ReadonlySet<string>,
+): boolean {
+  return !recipe.acquisition || recipe.acquisition.length === 0 || known.has(recipe.id);
+}
+
 function rowState(
   recipe: ProfessionRecipeRecord,
   known: ReadonlySet<string>,
   craftSkills: Readonly<Record<string, number>>,
 ): TrainRowState | null {
-  if (!recipe.acquisition || recipe.acquisition.length === 0 || known.has(recipe.id)) {
+  if (isRecipeKnownForViewer(recipe, known)) {
     return 'known';
   }
   // A recipe this master's station serves but that is not trainer-taught
   // (drop/quest acquisition; none exist today) has no honest row state at a
   // trainer: it is neither teachable nor tier-locked here, so it is omitted
   // rather than rendered with a misleading requirement.
-  if (!recipe.acquisition.includes('trainer')) return null;
-  const tierMet =
-    tierForSkill(craftSkills[recipe.professionId] ?? 0) >= tierForSkill(recipe.skillReq);
-  return tierMet ? 'teachable' : 'locked';
+  if (!recipe.acquisition?.includes('trainer')) return null;
+  // The sim's own predicate, not a mirror of it: the row can never drift
+  // from what resolveTrain will actually allow.
+  return teachTierMet(recipe, craftSkills) ? 'teachable' : 'locked';
 }
 
 /**

--- a/tests/professions_grandfather.test.ts
+++ b/tests/professions_grandfather.test.ts
@@ -178,6 +178,42 @@ describe('legacy save load (the one-time union) and persistence', () => {
     );
   });
 
+  it('a pre-#1299 save with NO knownRecipes key at all still unions the full record', () => {
+    // Even older than the hand-frozen fixture: before knownRecipes existed as
+    // a CharacterState key, the load guard's false arm leaves the constructed
+    // empty set in place and the union must still land all 21 ids.
+    const state = legacySave();
+    delete (state as { knownRecipes?: string[] }).knownRecipes;
+    const sim = makeSim();
+    const pid = sim.addPlayer('warrior', 'Ancient', { state });
+    const meta = metaOf(sim, pid);
+    expect(meta.recipesGrandfathered).toBe(true);
+    for (const id of PRE_TRAINING_RECIPE_IDS) {
+      expect(meta.knownRecipes.has(id), id).toBe(true);
+    }
+  });
+
+  it('the accepted rollback caveat, pinned: an old-code strip of the flag re-unions on return', () => {
+    // A full CURRENT-shape blob (not the sparse fixture): serialize a fresh
+    // Phase 9 character (flag true, nothing learned), then model the
+    // documented old-code round-trip, which rebuilds CharacterState WITHOUT
+    // the unknown recipesGrandfathered key while preserving knownRecipes.
+    // Returning to new code must re-run the union: the three combos read
+    // known fee-free, exactly the state.md release-notes caveat.
+    const sim = makeSim();
+    const full = sim.serializeCharacter(sim.playerId)!;
+    expect(full.recipesGrandfathered).toBe(true);
+    delete (full as { recipesGrandfathered?: boolean }).recipesGrandfathered;
+
+    const back = makeSim(11);
+    const pid = back.addPlayer('warrior', 'Returned', { state: full });
+    const meta = metaOf(back, pid);
+    expect(meta.recipesGrandfathered).toBe(true);
+    for (const recipe of COMBO_RECIPES) {
+      expect(isRecipeKnown(meta, recipe), recipe.id).toBe(true);
+    }
+  });
+
   it('a save WITH the flag and an empty knownRecipes stays empty (no re-union)', () => {
     // The flag, not the set contents, decides: a post-Phase-9 character who
     // has learned nothing must never be silently handed the combo recipes.

--- a/tests/professions_training.test.ts
+++ b/tests/professions_training.test.ts
@@ -173,6 +173,23 @@ describe('resolveTrain deny order (replay safety)', () => {
     expect(result.reason).toBe('train_out_of_range');
   });
 
+  it('full multi-violation state (out of range, tier 0, copper 0) still reads train_out_of_range', () => {
+    // The richest deny pile a real player can present: every arm below
+    // already_known/not_taught_here violated at once must still resolve in
+    // the documented order (range first), with the fee carried unpaid.
+    const sim = makeSim();
+    const meta = metaOf(sim, sim.playerId);
+    meta.copper = 0;
+    meta.craftSkills.alchemy = 0;
+    const result = resolveTrain(meta, FIELD_POS, ALCH_COMBO_ID);
+    expect(result).toEqual({
+      ok: false,
+      recipeId: ALCH_COMBO_ID,
+      reason: 'train_out_of_range',
+      fee: 2500,
+    });
+  });
+
   it('tier precedes fee: skill 24 at the station with 0 copper reads train_tier_unmet', () => {
     const sim = makeSim();
     const pid = sim.playerId;
@@ -317,6 +334,24 @@ describe('Sim.trainRecipe (fee exactly once, grant, event, probe)', () => {
     expect(meta.lastTrainResult).toMatchObject({ ok: false, reason: 'train_cannot_afford' });
     expect(meta.copper).toBe(2499);
     expect(meta.knownRecipes.has(ALCH_COMBO_ID)).toBe(false);
+  });
+
+  it('exactly-affordable trains ok: copper === fee (2500) succeeds and leaves 0', () => {
+    // Pins the strict `<` in resolveTrain's afford arm: an off-by-one to `<=`
+    // would deny a player holding the exact fee (the 2499 arm above cannot
+    // catch that regression on its own).
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = metaOf(sim, pid);
+    placeAtTrainerFor(sim, pid, ALCH_COMBO_ID);
+    meta.craftSkills.alchemy = 25;
+    meta.copper = 2500;
+
+    sim.trainRecipe(ALCH_COMBO_ID, pid);
+
+    expect(meta.lastTrainResult).toMatchObject({ ok: true, fee: 2500 });
+    expect(meta.copper).toBe(0);
+    expect(meta.knownRecipes.has(ALCH_COMBO_ID)).toBe(true);
   });
 
   it('records the malformed-id deny on the probe and event with no reason code', () => {

--- a/tests/professions_training_online.test.ts
+++ b/tests/professions_training_online.test.ts
@@ -131,6 +131,10 @@ describe('train_recipe over the live GameServer wire (session routing)', () => {
     const st = joinServer(server, fcTrainee, 97, 'Alchpupil');
     placeAt(server, st.pid, APOTHECARY_POS);
     const meta = metaOf(server, st.pid);
+    // A server-created fresh character sits past the grandfather cut too (the
+    // shared no-state addPlayer path): the explicit both-hosts pin.
+    expect(meta.recipesGrandfathered).toBe(true);
+    expect(meta.knownRecipes.size).toBe(0);
     meta.craftSkills.alchemy = 25;
     meta.copper = 10000;
 

--- a/tests/train_view.test.ts
+++ b/tests/train_view.test.ts
@@ -6,11 +6,13 @@
 // and a ClientWorld-mirror-shaped deps bag (the identity mirror carries the
 // same plain fields either way; sim-only junk must be ignored).
 import { describe, expect, it } from 'vitest';
+import { STATIONS } from '../src/sim/content/professions';
 import { COMBO_RECIPES } from '../src/sim/content/recipes';
 import { ITEMS } from '../src/sim/data';
 import { TIER_SKILL_STEP } from '../src/sim/professions/wheel';
 import {
   buildTrainView,
+  isRecipeKnownForViewer,
   isStationMasterNpc,
   type TrainViewDeps,
 } from '../src/ui/hud/vendor/train_view';
@@ -35,10 +37,27 @@ const SHAPES: Array<['sim' | 'client', Record<string, unknown>]> = [
 
 describe('isStationMasterNpc', () => {
   it('is true for every STATIONS master and false for anyone else', () => {
-    expect(isStationMasterNpc('forgemistress_darva')).toBe(true);
-    expect(isStationMasterNpc('alchemist_verane')).toBe(true);
+    // ALL six masters, parametrized over the registry itself: dropping any
+    // master from recognition (a non-combo master included) must fail here,
+    // not just the two combo-teaching ones.
+    for (const station of STATIONS) {
+      expect(isStationMasterNpc(station.masterNpcId), station.masterNpcId).toBe(true);
+    }
+    expect(STATIONS).toHaveLength(6);
     expect(isStationMasterNpc('marshal_redbrook')).toBe(false);
+    expect(isStationMasterNpc('smith_haldren')).toBe(false); // the stall smith is NOT the forge master
     expect(isStationMasterNpc('')).toBe(false);
+  });
+});
+
+describe('isRecipeKnownForViewer (the one shared viewer predicate)', () => {
+  it('grandfathered (no/empty acquisition) always known; trainer recipes only via the set', () => {
+    const grandfathered = COMBO_RECIPES[0] && { ...COMBO_RECIPES[0], acquisition: undefined };
+    const trainer = COMBO_RECIPES[0];
+    expect(isRecipeKnownForViewer(grandfathered, new Set())).toBe(true);
+    expect(isRecipeKnownForViewer({ ...trainer, acquisition: [] }, new Set())).toBe(true);
+    expect(isRecipeKnownForViewer(trainer, new Set())).toBe(false);
+    expect(isRecipeKnownForViewer(trainer, new Set([trainer.id]))).toBe(true);
   });
 });
 
@@ -77,6 +96,21 @@ describe('buildTrainView', () => {
     expect(byId.get('recipe_eastbrook_arming_sword')?.state).toBe('known'); // no acquisition
     expect(byId.get('recipe_ironbound_warplate_helm')?.state).toBe('teachable');
     expect(byId.get('recipe_forgeguard_bulwark_gauntlets')?.state).toBe('locked');
+  });
+
+  it('the SAME row flips locked to teachable across the 24/25 boundary', () => {
+    // The tri-state test above splits the boundary across two different rows;
+    // this pins the unlock moment the visible ladder points at: one row, one
+    // skill point, locked becomes teachable.
+    const at = (skill: number) =>
+      buildTrainView(
+        'forgemistress_darva',
+        deps({ craftSkills: { armorcrafting: skill } }),
+      ).rows.find((row) => row.recipeId === 'recipe_ironbound_warplate_helm');
+    expect(at(24)?.state).toBe('locked');
+    expect(at(24)?.requirement).toEqual({ craft: 'armorcrafting', skill: 25 });
+    expect(at(25)?.state).toBe('teachable');
+    expect(at(25)?.requirement).toBeUndefined();
   });
 
   it('a learned trainer recipe reads known (the mirrored knownRecipes arm)', () => {

--- a/tests/train_window_hud.test.ts
+++ b/tests/train_window_hud.test.ts
@@ -5,8 +5,8 @@
 //  - the trainResult event arm logs exactly one localized line per outcome,
 //    with NO banner/toast/audio (the grant-hub double-log trap), derives the
 //    tier threshold from static content, and repaints both open windows;
-//  - renderCrafting filters the recipe list to KNOWN recipes with the
-//    isRecipeKnown-shaped predicate before buildCraftingView;
+//  - renderCrafting filters the recipe list to KNOWN recipes through the
+//    SHARED isRecipeKnownForViewer predicate before buildCraftingView;
 //  - the train window wires the pure view core to the IWorld seam
 //    (identity.knownRecipes in, sim.trainRecipe out);
 //  - both HTML entries declare the #train-window container.
@@ -47,6 +47,21 @@ describe('hud.ts trainResult event arm (source pins)', () => {
     }
   });
 
+  it('pairs each deny reason with ITS OWN key (a key swap in the chain must fail here)', () => {
+    // The presence pins above cannot catch two keys swapped inside the ternary
+    // chain (all five keys and four reason literals would still be present), so
+    // pin each reason-to-key pairing. train_out_of_range is deliberately the
+    // fallback arm (its literal never appears in hud.ts), so its pairing is
+    // pinned as the else branch of the alreadyKnown arm.
+    const arm = trainResultArm();
+    expect(arm).toMatch(/'train_tier_unmet'\s*\?\s*t\('hudChrome\.training\.tierUnmet'/);
+    expect(arm).toMatch(/'train_cannot_afford'\s*\?\s*'hudChrome\.training\.cannotAfford'/);
+    expect(arm).toMatch(/'train_not_taught_here'\s*\?\s*'hudChrome\.training\.notTaughtHere'/);
+    expect(arm).toMatch(
+      /'train_already_known'\s*\?\s*'hudChrome\.training\.alreadyKnown'\s*:\s*'hudChrome\.training\.outOfRange'/,
+    );
+  });
+
   it('derives the tierUnmet craft and threshold from recipeId plus static content', () => {
     const arm = trainResultArm();
     // The event is text-free: the threshold is tier * step from the recipe
@@ -79,12 +94,16 @@ describe('hud.ts trainResult event arm (source pins)', () => {
 });
 
 describe('hud.ts crafting known-filter (source pins)', () => {
-  it('filters the recipe list with the isRecipeKnown-shaped predicate before the view build', () => {
-    expect(hudSource).toContain('const knownRecipes = this.sim.recipeList.filter(');
-    expect(hudSource).toContain(
-      '!recipe.acquisition || recipe.acquisition.length === 0 || knownRecipeIds.has(recipe.id)',
-    );
+  it('filters the recipe list through the SHARED viewer predicate before the view build', () => {
+    // Deliberate re-pin (Phase 9 QA): the filter must delegate to the one
+    // isRecipeKnownForViewer helper the train ladder also uses, never an
+    // inline restatement the two windows could let drift apart.
+    expect(hudSource).toContain('const knownRecipes = this.sim.recipeList.filter((recipe) =>');
+    expect(hudSource).toContain('isRecipeKnownForViewer(recipe, knownRecipeIds)');
     expect(hudSource).toContain('new Set(this.sim.craftingIdentity.knownRecipes)');
+    expect(hudSource).toMatch(
+      /import \{ buildTrainView, isRecipeKnownForViewer \} from '\.\/hud\/vendor\/train_view';/,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Phase 9 QA of Professions 2.0 (station presence and recipe training), audited over the phase diff d40f0a90f..791235152 per docs/professions-2/phase-09-qa.md. Verdict: PASS with fixes, zero blocking. Ten reviewer/audit agents (three packet audits plus privacy-security, migration-safety, cross-platform-sync, architecture, frontend-seam, test-coverage-auditor, qa-checklist; database-performance did not match the diff) with the full validation matrix pre-verified green at the untouched tip. All nine acceptance criteria hold, verified against real code and played live: six headless-Sim probes plus a CDP drive of the real offline client (gossip Train option, tier deny with the named requirement line, exact-fee train to zero copper, replay deny with no re-charge, out-of-range deny, the 8yd proximity auto-close, the crafting-window known-filter in both directions, the station minimap marker and token, trained-not-known on a fresh character). The grandfather stopping rule was proven on the legacy fixture through the real load path.

What this PR lands:

- test(professions): the exactly-affordable fee edge (copper equal to fee) at the Sim level; a full multi-violation deny-order pin; a pre-#1299 key-absent legacy-save arm; the accepted rollback caveat turned into a pin (a full current-shape blob stripped of the flag re-unions the combos fee-free on return, exactly the state.md release-notes wording); an explicit server-side recipesGrandfathered-true pin on a fresh online join.
- refactor(ui): the viewer-side knownness predicate was restated inline in both the crafting-window filter and the train ladder (frontend-seam should-fix, rule-of-three). Both now delegate to one exported train_view.ts isRecipeKnownForViewer, and rowState calls the sim's own teachTierMet instead of mirroring it. Rendering is byte-identical; the hud known-filter source pin is deliberately re-pinned to the delegation, plus per-pair deny reason-to-key mapping pins, an all-six-masters isStationMasterNpc pin with a smith_haldren negative, and a same-row locked-to-teachable flip pin at the 24/25 boundary.
- docs(professions-2): the Phase 9 QA record in progress.md and the shared-predicate drift note in state.md.

Deferred with reasons (in progress.md): the unknown-deny-reason fallback renders the out-of-range line rather than nothing (reachable only under client/server version skew on a closed 5-member union; maintainer call); a same-state same-craft mobile-craft-versus-training-deny contrast is impossible in wave-one content (covered by cross-suite composition plus the live probe); the --color-minimap-station tokens-coverage pin stays the accepted build-time deferral; a dedicated train_recipe rate limit stays optional (idempotent command, global cadence limiter applies). Maintainer eye invited on one economy INFO: master stocking makes thorium_ore and the six premium reagents purchasable in zones 1 and 2 (previously zone-3 Bree only); deliberate, no price loop.

## Related issues

Part of #1866. #2058 stays open for the Phase 14 quests arm.

## Type of change

- [x] Tests
- [x] Refactor or performance (no behavior change)
- [x] Documentation

## How was this tested?

- Commands: full validation matrix at the untouched tip and again after fixes (tsc, localization_fixes, mobile window suites, snapshots + env_protocol + bandwidth + world_api_parity, minimap_markers, i18n_completeness, architecture, the 7 phase suites, command census, full tests/parity); `npm run gate` under Node 24 (full suite 16620 passed; the only red is the known environmental armory browser pixel failure on this machine, PR CI is the arbiter; gate tail check:types + build:env + build:server + build finished manually, all green).
- Manual steps: drove the real offline client over CDP through the full training loop at Verane and the forge (deny ladder, learn, replay, auto-close, crafting-window filter both arms, minimap marker); six live headless-Sim probes via a throwaway vitest file (written, run 6/6, deleted).

## Screenshots / recordings

N/A: no visual change (the refactor renders byte-identically; the phase PR #2171 carries the Phase 9 before/after shots).

## Checklist

### Quality
- [x] **The full gate passes** (modulo the documented environmental armory browser red; see testing notes).

### Cross-platform
- [x] **Tested on desktop and mobile.** Desktop played live; mobile via the green mobile window suites plus the phase's committed mobile screenshots (no visual change in this PR).
- [x] **Accessible.** No UI surface changed; the train-window focus contract pins stay green.

### Localization (i18n)
- [x] N/A. This PR adds no player-visible strings.

### Hygiene
- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.