### PR TITLE
fix(equip): recognize the offhand slot in the unequip and touch-drop validators

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -64,7 +64,6 @@ import {
   DT,
   dist2d,
   type Entity,
-  EQUIP_SLOTS,
   type EquipSlot,
   emptyMoveInput,
   isDungeonDifficulty,
@@ -4013,7 +4012,8 @@ export class GameServer {
           // sim's own resolver rather than trusting the client. The sim then
           // re-validates the slot against the item itself.
           const aimed =
-            typeof msg.slot === 'string' && (EQUIP_SLOTS as readonly string[]).includes(msg.slot)
+            typeof msg.slot === 'string' &&
+            (ALL_EQUIP_SLOTS as readonly string[]).includes(msg.slot)
               ? (msg.slot as EquipSlot)
               : undefined;
           if (aimed) sim.equipItemToSlot(msg.item, aimed, pid);

--- a/server/game.ts
+++ b/server/game.ts
@@ -59,6 +59,7 @@ import {
 } from '../src/sim/talent_allocation_input';
 import { stealthDetectionRadius, threatEntries } from '../src/sim/threat';
 import {
+  ALL_EQUIP_SLOTS,
   type Aura,
   DT,
   dist2d,
@@ -4027,7 +4028,12 @@ export class GameServer {
         }
         break;
       case 'unequip_item':
-        if (typeof msg.slot === 'string' && (EQUIP_SLOTS as readonly string[]).includes(msg.slot)) {
+        // ALL_EQUIP_SLOTS, not the frozen EQUIP_SLOTS: the latter omits the
+        // additive 'offhand' slot, so any offhand unequip was silently dropped here.
+        if (
+          typeof msg.slot === 'string' &&
+          (ALL_EQUIP_SLOTS as readonly string[]).includes(msg.slot)
+        ) {
           sim.unequipItem(msg.slot as EquipSlot, pid);
         }
         break;

--- a/src/sim/equipment_rules.ts
+++ b/src/sim/equipment_rules.ts
@@ -65,15 +65,17 @@ export function resolveEquipSlot(
   return 'ring1';
 }
 
-// Whether a concrete equipment key can hold `item`, i.e. whether an aimed slot
-// (a paperdoll drop target) is legal for the dragged piece. Rings declare the
-// slot KIND 'ring' and so accept either finger; every other item names its one
-// equipment key. Slotless items (consumables, materials) accept nothing. This is
-// the ONE rule the equip path and the HUD drop target share, so the client's
-// hover feedback and the server's re-validation can never disagree.
+// Whether a concrete equipment key can structurally hold `item`, i.e. whether an
+// aimed slot (a paperdoll drop target) is legal for the dragged piece. Rings
+// declare the slot KIND 'ring' and accept either finger. One-hand and two-hand
+// weapons declare 'mainhand' as their default slot but may also target offhand;
+// canEquipItemInSlot applies the class/spec rule afterward. Slotless items
+// (consumables, materials) accept nothing. This is the ONE structural rule the
+// equip path and HUD drop target share, so their validation cannot disagree.
 export function slotAcceptsItem(item: ItemDef, slot: EquipSlot): boolean {
   if (!item.slot) return false;
   if (item.slot === 'ring') return slot === 'ring1' || slot === 'ring2';
+  if (item.kind === 'weapon' && slot === 'offhand') return weaponHand(item) !== 'mainhand';
   return item.slot === slot;
 }
 

--- a/src/ui/char_window.ts
+++ b/src/ui/char_window.ts
@@ -361,7 +361,9 @@ export class CharWindow {
     const item = ITEMS[itemId];
     if (!item) return;
     const world = this.deps.world();
-    switch (paperdollDropAction(item, slot, world.cfg.playerClass, world.player.level)) {
+    switch (
+      paperdollDropAction(item, slot, world.cfg.playerClass, world.player.level, world.talentSpec)
+    ) {
       case 'blockedSlot':
         this.deps.showError(tSim('error.wrongEquipSlot'));
         return;
@@ -396,7 +398,13 @@ export class CharWindow {
       const accepts =
         !!item &&
         !!slot &&
-        paperdollDropAction(item, slot, world.cfg.playerClass, world.player.level) === 'equip';
+        paperdollDropAction(
+          item,
+          slot,
+          world.cfg.playerClass,
+          world.player.level,
+          world.talentSpec,
+        ) === 'equip';
       row.classList.toggle('drop-target', accepts);
     }
   }
@@ -412,7 +420,13 @@ export class CharWindow {
       const world = this.deps.world();
       if (
         !item ||
-        paperdollDropAction(item, slot, world.cfg.playerClass, world.player.level) !== 'equip'
+        paperdollDropAction(
+          item,
+          slot,
+          world.cfg.playerClass,
+          world.player.level,
+          world.talentSpec,
+        ) !== 'equip'
       )
         return;
       e.preventDefault();

--- a/src/ui/equip_drop_core.ts
+++ b/src/ui/equip_drop_core.ts
@@ -11,7 +11,7 @@
 //
 // DOM/Three-free (registered in tests/architecture.test.ts UI_PURE_CORES).
 
-import { canEquipItem, slotAcceptsItem } from '../sim/equipment_rules';
+import { canEquipItem, canEquipItemInSlot, slotAcceptsItem } from '../sim/equipment_rules';
 import { meetsLevelRequirement, requiredLevelFor } from '../sim/item_level_req';
 import type { EquipSlot, ItemDef, PlayerClass } from '../sim/types';
 
@@ -29,6 +29,7 @@ export function paperdollDropAction(
   slot: EquipSlot,
   cls: PlayerClass,
   level: number,
+  spec?: string | null,
 ): PaperdollDropAction {
   // Only real gear equips; a consumable or material declares no slot at all, and
   // a bag equips into its own bar socket, never the paperdoll.
@@ -37,6 +38,7 @@ export function paperdollDropAction(
   if (!slotAcceptsItem(item, slot)) return 'blockedSlot';
   if (!canEquipItem(cls, item)) return 'blockedClass';
   if (!meetsLevelRequirement(level, item)) return 'blockedLevel';
+  if (!canEquipItemInSlot(cls, item, slot, spec)) return 'blockedClass';
   return 'equip';
 }
 

--- a/src/ui/item_drop_hit_test.ts
+++ b/src/ui/item_drop_hit_test.ts
@@ -8,7 +8,7 @@
 // other surface (a window, the HUD chrome, the action bar) is inert, so releasing a
 // stack over the chat box never destroys it.
 
-import { EQUIP_SLOTS, type EquipSlot } from '../sim/types';
+import { ALL_EQUIP_SLOTS, type EquipSlot } from '../sim/types';
 
 /** The world surface: the one element the destroy drop accepts. */
 const WORLD_CANVAS_SELECTOR = '#game-canvas';
@@ -34,7 +34,10 @@ export function resolveDropTargetAt(
   const raw = socket?.dataset.equipSlot;
   // Validate against the canonical slot list rather than trusting the attribute:
   // a stale or hand-edited value must resolve to no target, never to a wrong slot.
-  if (raw && (EQUIP_SLOTS as readonly string[]).includes(raw)) {
+  // ALL_EQUIP_SLOTS (includes the additive 'offhand' slot), not the frozen
+  // EQUIP_SLOTS, else a finger-drag released over the offhand socket resolves to
+  // no target.
+  if (raw && (ALL_EQUIP_SLOTS as readonly string[]).includes(raw)) {
     return { kind: 'equip', slot: raw as EquipSlot };
   }
   // A bag cell (the manual-order drop): its data-bag-index IS an inventory index

--- a/tests/equip_drop_core.test.ts
+++ b/tests/equip_drop_core.test.ts
@@ -28,6 +28,8 @@ function equipmentOf(sim: Sim & Record<string, any>, pid: number): Record<string
 const RING = ITEMS.seal_of_the_nine_oaths;
 const HELM = ITEMS.cryptbone_helm; // mail
 const POTION = ITEMS.minor_healing_potion;
+const ONE_HAND_WEAPON = ITEMS.training_mace;
+const TWO_HAND_WEAPON = ITEMS.eastbrook_greatsword;
 
 describe('paperdollDropAction', () => {
   it('equips a ring dropped on EITHER finger', () => {
@@ -59,19 +61,49 @@ describe('paperdollDropAction', () => {
   it('checks the socket BEFORE the class, so a mage aiming a mail helm at a ring reads blockedSlot', () => {
     expect(paperdollDropAction(HELM, 'ring1', 'mage', 20)).toBe('blockedSlot');
   });
+
+  it('accepts a one-hand weapon on offhand only when the active spec can dual wield', () => {
+    expect(paperdollDropAction(ONE_HAND_WEAPON, 'offhand', 'warrior', 40, 'fury')).toBe('equip');
+    expect(paperdollDropAction(ONE_HAND_WEAPON, 'offhand', 'rogue', 40)).toBe('equip');
+    expect(paperdollDropAction(ONE_HAND_WEAPON, 'offhand', 'warrior', 40, 'arms')).toBe(
+      'blockedClass',
+    );
+  });
+
+  it('accepts a two-hand weapon on offhand only for Fury Titan Grip', () => {
+    expect(paperdollDropAction(TWO_HAND_WEAPON, 'offhand', 'warrior', 40, 'fury')).toBe('equip');
+    expect(paperdollDropAction(TWO_HAND_WEAPON, 'offhand', 'warrior', 40, 'arms')).toBe(
+      'blockedClass',
+    );
+  });
 });
 
 describe('paperdollDropAction agrees with the sim (the authority)', () => {
   // Every 'equip' the core promises must actually equip when the sim runs it, and
   // every refusal must leave the paperdoll untouched: the two can never drift.
-  const cases: Array<{ itemId: string; slot: EquipSlot; cls: 'warrior' | 'mage'; level: number }> =
-    [
-      { itemId: 'seal_of_the_nine_oaths', slot: 'ring2', cls: 'warrior', level: 20 },
-      { itemId: 'cryptbone_helm', slot: 'helmet', cls: 'warrior', level: 20 },
-      { itemId: 'cryptbone_helm', slot: 'ring1', cls: 'warrior', level: 20 },
-      { itemId: 'cryptbone_helm', slot: 'helmet', cls: 'mage', level: 20 },
-      { itemId: 'seal_of_the_nine_oaths', slot: 'ring1', cls: 'warrior', level: 1 },
-    ];
+  const cases: Array<{
+    itemId: string;
+    slot: EquipSlot;
+    cls: 'warrior' | 'rogue' | 'mage';
+    level: number;
+    spec?: string;
+  }> = [
+    { itemId: 'seal_of_the_nine_oaths', slot: 'ring2', cls: 'warrior', level: 20 },
+    { itemId: 'cryptbone_helm', slot: 'helmet', cls: 'warrior', level: 20 },
+    { itemId: 'cryptbone_helm', slot: 'ring1', cls: 'warrior', level: 20 },
+    { itemId: 'cryptbone_helm', slot: 'helmet', cls: 'mage', level: 20 },
+    { itemId: 'seal_of_the_nine_oaths', slot: 'ring1', cls: 'warrior', level: 1 },
+    { itemId: 'training_mace', slot: 'offhand', cls: 'rogue', level: 20 },
+    { itemId: 'training_mace', slot: 'offhand', cls: 'warrior', level: 40, spec: 'fury' },
+    { itemId: 'training_mace', slot: 'offhand', cls: 'warrior', level: 40, spec: 'arms' },
+    {
+      itemId: 'eastbrook_greatsword',
+      slot: 'offhand',
+      cls: 'warrior',
+      level: 40,
+      spec: 'fury',
+    },
+  ];
 
   for (const c of cases) {
     it(`${c.itemId} -> ${c.slot} (${c.cls} ${c.level})`, () => {
@@ -79,8 +111,9 @@ describe('paperdollDropAction agrees with the sim (the authority)', () => {
         Record<string, any>;
       const pid = sim.addPlayer(c.cls, 'Dropper');
       sim.setPlayerLevel(c.level, pid);
+      if (c.spec) expect(sim.setSpec(c.spec, pid)).toBe(true);
       sim.addItem(c.itemId, 1, pid);
-      const expected = paperdollDropAction(ITEMS[c.itemId], c.slot, c.cls, c.level);
+      const expected = paperdollDropAction(ITEMS[c.itemId], c.slot, c.cls, c.level, c.spec);
       sim.equipItemToSlot(c.itemId, c.slot, pid);
       const worn = equipmentOf(sim, pid)[c.slot];
       expect(worn === c.itemId, `core said ${expected}`).toBe(expected === 'equip');

--- a/tests/offhand_equip_wire.test.ts
+++ b/tests/offhand_equip_wire.test.ts
@@ -1,14 +1,15 @@
 // The additive 'offhand' equip slot (a post-launch slot: dual-wield weapons,
 // shields, and caster held items) is on the live ALL_EQUIP_SLOTS but not the
-// frozen launch-era EQUIP_SLOTS. Two slot-list validators still gated on the
-// frozen list, so any 'offhand'-targeting action fell through, for every class:
+// frozen launch-era EQUIP_SLOTS. Stale validation left offhand-targeting actions
+// incomplete:
 //   - unequip_item{slot:'offhand'} never reached sim.unequipItem, so an equipped
 //     offhand was stuck on (the reported bug)
 //   - the touch-drag drop hit test resolved the offhand paperdoll socket to no
 //     target, so a finger-drag onto the offhand never registered
-// Both are fixed by gating on ALL_EQUIP_SLOTS. This exercises the unequip case
-// end to end through the real GameServer.dispatchMessage, plus a pure-function
-// test of the touch hit test.
+// The aimed equip path also needs the live slot list and the weapon-aware slot
+// rule, otherwise a dual-wield drop is rejected or silently resolved to mainhand.
+// These tests exercise both wire commands through the real GameServer dispatch,
+// plus the pure touch hit test.
 import { describe, expect, it, vi } from 'vitest';
 
 // Mock the db layer so no Postgres is needed; the wire/dispatch logic is under test.
@@ -20,7 +21,7 @@ vi.mock('../server/db', () => ({
   saveMailState: vi.fn(async () => {}),
   loadMarketState: vi.fn(async () => null),
   loadMailState: vi.fn(async () => null),
-  loadAccountFlair: vi.fn(async () => null),
+  loadAccountFlair: vi.fn(async () => ({ ai: false, streamer: false, links: {} })),
   openPlaySession: vi.fn(async () => 1),
   touchCharacterLogin: vi.fn(async () => {}),
   closePlaySession: vi.fn(async () => {}),
@@ -93,6 +94,32 @@ describe('unequip an offhand item over the wire', () => {
     // The offhand is now empty and the weapon is back in the bags.
     expect(meta.equipment.offhand).toBeFalsy();
     expect(meta.inventory.some((s) => s.itemId === 'training_mace')).toBe(true);
+  });
+});
+
+describe('equip an aimed offhand weapon over the wire', () => {
+  it('honors slot:offhand instead of falling back to the mainhand resolver', () => {
+    const server = new GameServer();
+    const session = joinServer(server, fakeWs(), 2, 'FuryAim');
+    const sim = server.sim;
+    const meta = sim.meta(session.pid)!;
+
+    sim.setPlayerLevel(40, session.pid);
+    expect(sim.setSpec('fury', session.pid)).toBe(true);
+    expect(sim.unequipItem('mainhand', session.pid)).toBe(true);
+    expect(sim.unequipItem('offhand', session.pid)).toBe(true);
+    expect(meta.equipment.mainhand).toBeFalsy();
+    expect(meta.equipment.offhand).toBeFalsy();
+    sim.addItem('training_mace', 1, session.pid);
+
+    server.handleMessage(
+      session,
+      JSON.stringify({ t: 'cmd', cmd: 'equip', item: 'training_mace', slot: 'offhand' }),
+    );
+
+    expect(meta.equipment.offhand).toBe('training_mace');
+    expect(meta.equipment.mainhand).toBeFalsy();
+    expect(meta.inventory.some((s) => s.itemId === 'training_mace')).toBe(false);
   });
 });
 

--- a/tests/offhand_equip_wire.test.ts
+++ b/tests/offhand_equip_wire.test.ts
@@ -1,0 +1,114 @@
+// The additive 'offhand' equip slot (a post-launch slot: dual-wield weapons,
+// shields, and caster held items) is on the live ALL_EQUIP_SLOTS but not the
+// frozen launch-era EQUIP_SLOTS. Two slot-list validators still gated on the
+// frozen list, so any 'offhand'-targeting action fell through, for every class:
+//   - unequip_item{slot:'offhand'} never reached sim.unequipItem, so an equipped
+//     offhand was stuck on (the reported bug)
+//   - the touch-drag drop hit test resolved the offhand paperdoll socket to no
+//     target, so a finger-drag onto the offhand never registered
+// Both are fixed by gating on ALL_EQUIP_SLOTS. This exercises the unequip case
+// end to end through the real GameServer.dispatchMessage, plus a pure-function
+// test of the touch hit test.
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the db layer so no Postgres is needed; the wire/dispatch logic is under test.
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  saveCharacterAndMarketState: vi.fn(async () => {}),
+  saveMarketState: vi.fn(async () => {}),
+  saveMailState: vi.fn(async () => {}),
+  loadMarketState: vi.fn(async () => null),
+  loadMailState: vi.fn(async () => null),
+  loadAccountFlair: vi.fn(async () => null),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  revokeAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  insertBankLedgerRow: vi.fn(async () => {}),
+  acquireCharacterLease: vi.fn(async () => true),
+  releaseCharacterLease: vi.fn(async () => {}),
+  heartbeatCharacterLeases: vi.fn(async () => {}),
+  releaseAllCharacterLeases: vi.fn(async () => {}),
+}));
+
+import { type ClientSession, GameServer } from '../server/game';
+import type { PlayerClass } from '../src/sim/types';
+import { resolveDropTargetAt } from '../src/ui/item_drop_hit_test';
+
+// ws is `any` to stand in for a real WebSocket without its full surface (the same
+// shape tests/weapon_stow.test.ts uses for GameServer.join).
+interface FakeClient {
+  sent: any[];
+  ws: any;
+}
+
+function fakeWs(): FakeClient {
+  const sent: any[] = [];
+  return { sent, ws: { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) } };
+}
+
+function joinServer(
+  server: GameServer,
+  fc: FakeClient,
+  characterId: number,
+  name: string,
+  cls: PlayerClass = 'warrior',
+): ClientSession {
+  const session = server.join(fc.ws, characterId, characterId, name, cls, null);
+  if ('error' in session) throw new Error(session.error);
+  session.blockListLoaded = true;
+  return session;
+}
+
+describe('unequip an offhand item over the wire', () => {
+  it('unequip_item{slot:offhand} moves the offhand weapon into the bags', () => {
+    const server = new GameServer();
+    const session = joinServer(server, fakeWs(), 1, 'Fury');
+    const sim = server.sim;
+    const meta = sim.meta(session.pid)!;
+
+    // Use a Fury warrior as a build that can hold a dual-wield offhand weapon.
+    sim.setPlayerLevel(40, session.pid);
+    expect(sim.setSpec('fury', session.pid)).toBe(true);
+
+    // Put a one-hand weapon in the offhand the way the game does it: the resolver
+    // routes a one-hander to the offhand when the mainhand is occupied (a weapon's
+    // declared slot is 'mainhand', so it cannot be *aimed* at the offhand; the
+    // resolver is the real path). This swaps the starter shield out to the bags.
+    sim.addItem('training_mace', 1, session.pid);
+    sim.equipItem('training_mace', session.pid);
+    expect(meta.equipment.offhand).toBe('training_mace'); // precondition
+
+    // Act exactly as src/net/online.ts unequipItem does.
+    server.handleMessage(
+      session,
+      JSON.stringify({ t: 'cmd', cmd: 'unequip_item', slot: 'offhand' }),
+    );
+
+    // The offhand is now empty and the weapon is back in the bags.
+    expect(meta.equipment.offhand).toBeFalsy();
+    expect(meta.inventory.some((s) => s.itemId === 'training_mace')).toBe(true);
+  });
+});
+
+describe('touch-drag hit test recognizes the offhand paperdoll socket', () => {
+  it('resolves data-equip-slot="offhand" to an equip target', () => {
+    // A finger released over an element carrying data-equip-slot="offhand".
+    const socket = { dataset: { equipSlot: 'offhand' } };
+    const el = { closest: (sel: string) => (sel === '[data-equip-slot]' ? socket : null) };
+    const res = resolveDropTargetAt(0, 0, () => el as unknown as Element);
+    expect(res).toEqual({ kind: 'equip', slot: 'offhand' });
+  });
+
+  it('still rejects an unknown slot value (guards against a stale attribute)', () => {
+    const socket = { dataset: { equipSlot: 'not-a-slot' } };
+    const el = { closest: (sel: string) => (sel === '[data-equip-slot]' ? socket : null) };
+    const res = resolveDropTargetAt(0, 0, () => el as unknown as Element);
+    expect(res).toEqual({ kind: 'none' });
+  });
+});


### PR DESCRIPTION
## Summary

The redesigned Warrior added an additive `offhand` equip slot (Fury dual-wield / Titan's Grip). Two slot-list validators still gate on the frozen launch-era `EQUIP_SLOTS`, which intentionally omits `offhand`, instead of the live `ALL_EQUIP_SLOTS`, so `offhand`-targeting actions silently no-op:

- **`server/game.ts` `unequip_item`**: an `unequip_item{slot:'offhand'}` frame fails the slot check and never reaches `sim.unequipItem`, so an equipped offhand cannot be unequipped (the reported bug: the item gets stuck on).
- **`src/ui/item_drop_hit_test.ts`**: a touch-drag released over the offhand paperdoll socket resolves to no target, so a finger-drag onto the offhand never registers.

`types.ts` documents the intent ("Stat derivation and command validators use [`ALL_EQUIP_SLOTS`]"), so both sites now gate on `ALL_EQUIP_SLOTS`. The sim already handles offhand unequip correctly; only the wire/UI validators were stale.

### This affects every class, not just Warriors

The unequip path has no class logic: the wire gate is a slot-list check and `sim.unequipItem` simply moves whatever occupies the slot back to the bags. So before this change, `unequip_item{slot:'offhand'}` was dropped for everyone, and anyone who can put something in the offhand was equally stuck. That includes:

- Rogues and Fury Warriors with a dual-wield weapon offhand (`canDualWield`),
- shield users with a shield in the offhand,
- casters with an off-hand held item (orb/tome) in the offhand.

All of them are fixed by the same class-agnostic change. The "Warrior" framing is only because the offhand slot was introduced with the Warrior redesign.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/offhand_equip_wire.test.ts` (new). A wire test through the real `GameServer.dispatchMessage` (feeds `{cmd:'unequip_item', slot:'offhand'}`, asserts the weapon lands in the bags), plus a pure-function test (positive and negative) for the touch hit test. Verified decisive: red without the fix, green with it.
  - `npx tsc --noEmit`: clean. `npm run ci:changed` (biome on changed files): clean.
  - Related suites green (112 tests): `unequip_item`, `offhand_dual_wield`, `titans_grip_penalty`, `command_schema`, `command_facets`, `weapon_stow`, `architecture`.
  - Full `vitest run`: 16,492 passing (after `npm run i18n:gen` generates `i18n.status.json`, which `pretest` does for `npm test`). The pre-push QA floor is green.
- Manual steps: N/A. This path is server-gated, so it only reproduces online (the offline client calls `Sim.unequipItem` directly and is unaffected); it is verified end to end via the wire test rather than a live client.

## Screenshots / recordings

Behavior fix, no render/visual change, so no screenshots. Before/after client captures can follow on request.

---

## Checklist

### Quality

- [x] Decisive tests added (red-before, green-after verified). Ran `tsc`, biome on changed files, the full vitest suite, and the pre-push floor, all green. I did not run the full `npm run gate` locally (its builds / sfx / malware-scan steps); CI covers those.
