### PR TITLE
perf(sim): scan the spatial grid for nearby mob-mechanic allies

### DIFF
--- a/src/sim/mob/nearby_allies.ts
+++ b/src/sim/mob/nearby_allies.ts
@@ -1,0 +1,30 @@
+import type { SpatialGrid } from '../spatial';
+import type { Entity } from '../types';
+
+// Shared same-faction ally scan for mob support mechanics (Mend, Ward, the
+// channeled protectee heal, Rally, War Cadence). Each of those periodically
+// walks every living friendly mob within a radius of the caster; this queries
+// the SpatialGrid instead of the full entity map so the cost tracks nearby
+// entities, not total world population. `predicate` layers on any
+// mechanic-specific filter (wounded-only, exclude self, ...).
+export function findNearbyAllies(
+  grid: SpatialGrid,
+  mob: Entity,
+  radius: number,
+  predicate: (ally: Entity) => boolean = () => true,
+): Entity[] {
+  const found: Entity[] = [];
+  grid.forEachInRadius(mob.pos.x, mob.pos.z, radius, (e) => {
+    if (e.kind !== 'mob' || e.dead || e.ownerId !== null) return; // skip players, pets, corpses
+    if (e.hostile !== mob.hostile) return; // same-faction mobs only
+    if (!predicate(e)) return;
+    found.push(e);
+  });
+  // The grid yields entities in cell-bucket order, not the entity-creation
+  // order the old `entities.values()` scan relied on for per-ally rng draw
+  // mapping (mendAlly) and max-hp tie-breaking (channelHeal's protectee
+  // pick). Entity ids are assigned monotonically, so sorting by id restores
+  // that same creation order deterministically.
+  found.sort((a, b) => a.id - b.id);
+  return found;
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -233,6 +233,7 @@ import { NYTHRAXIS_SPIRIT_MENDING_CAST_ID } from './mob/healer_channel';
 import * as lifecycle from './mob/lifecycle';
 import { resetEvadingMob as resetEvadingMobFn, updateMob as updateMobFn } from './mob/locomotion';
 import { runMobSwingAffixes } from './mob/mob_swing';
+import { findNearbyAllies } from './mob/nearby_allies';
 import {
   createMobScanCounters,
   type MobScanCounters,
@@ -6067,13 +6068,12 @@ export class Sim {
       mob.mendTimer -= DT;
       if (mob.mendTimer <= 0) {
         mob.mendTimer = tmpl.mendAlly.every;
-        const wounded: Entity[] = [];
-        for (const ally of this.entities.values()) {
-          if (ally.kind !== 'mob' || ally.dead || ally.ownerId !== null) continue; // skip players, pets, corpses
-          if (ally.hostile !== mob.hostile || ally.hp >= ally.maxHp) continue; // only wounded same-faction mobs
-          if (dist2d(ally.pos, mob.pos) > tmpl.mendAlly.radius) continue;
-          wounded.push(ally);
-        }
+        const wounded = findNearbyAllies(
+          this.grid,
+          mob,
+          tmpl.mendAlly.radius,
+          (ally) => ally.hp < ally.maxHp, // only wounded same-faction mobs
+        );
         if (wounded.length > 0) {
           const school = tmpl.mendAlly.school ?? 'nature';
           this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
@@ -6101,13 +6101,7 @@ export class Sim {
       mob.wardTimer -= DT;
       if (mob.wardTimer <= 0) {
         mob.wardTimer = tmpl.wardAllies.every;
-        const allies: Entity[] = [];
-        for (const ally of this.entities.values()) {
-          if (ally.kind !== 'mob' || ally.dead || ally.ownerId !== null) continue; // skip players, pets, corpses
-          if (ally.hostile !== mob.hostile) continue; // same-faction mobs only
-          if (dist2d(ally.pos, mob.pos) > tmpl.wardAllies.radius) continue;
-          allies.push(ally);
-        }
+        const allies = findNearbyAllies(this.grid, mob, tmpl.wardAllies.radius);
         if (allies.length > 0) {
           const school = tmpl.wardAllies.school ?? 'holy';
           this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
@@ -6169,11 +6163,14 @@ export class Sim {
         mob.channelTimer -= DT;
         if (mob.channelTimer <= 0) {
           mob.channelTimer = ch.every;
+          const candidates = findNearbyAllies(
+            this.grid,
+            mob,
+            ch.radius,
+            (ally) => ally.id !== mob.id, // same-faction, not self
+          );
           let protectee: Entity | null = null;
-          for (const ally of this.entities.values()) {
-            if (ally.kind !== 'mob' || ally.dead || ally.ownerId !== null) continue; // skip players, pets, corpses
-            if (ally.hostile !== mob.hostile || ally.id === mob.id) continue; // same-faction, not self
-            if (dist2d(ally.pos, mob.pos) > ch.radius) continue;
+          for (const ally of candidates) {
             if (!protectee || ally.maxHp > protectee.maxHp) protectee = ally; // the boss = biggest pool
           }
           if (protectee && protectee.hp < protectee.maxHp) {
@@ -6217,13 +6214,7 @@ export class Sim {
       mob.rallyTimer -= DT;
       if (mob.rallyTimer <= 0) {
         mob.rallyTimer = tmpl.rally.every;
-        const allies: Entity[] = [];
-        for (const ally of this.entities.values()) {
-          if (ally.kind !== 'mob' || ally.dead || ally.ownerId !== null) continue; // skip players, pets, corpses
-          if (ally.hostile !== mob.hostile) continue; // only same-faction mobs
-          if (dist2d(ally.pos, mob.pos) > tmpl.rally.radius) continue;
-          allies.push(ally);
-        }
+        const allies = findNearbyAllies(this.grid, mob, tmpl.rally.radius);
         if (allies.length > 0) {
           const school = tmpl.rally.school ?? 'physical';
           this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
@@ -6256,13 +6247,7 @@ export class Sim {
       mob.warcryTimer -= DT;
       if (mob.warcryTimer <= 0) {
         mob.warcryTimer = tmpl.warcry.every;
-        const allies: Entity[] = [];
-        for (const ally of this.entities.values()) {
-          if (ally.kind !== 'mob' || ally.dead || ally.ownerId !== null) continue; // skip players, pets, corpses
-          if (ally.hostile !== mob.hostile) continue; // same-faction only
-          if (dist2d(ally.pos, mob.pos) > tmpl.warcry.radius) continue;
-          allies.push(ally);
-        }
+        const allies = findNearbyAllies(this.grid, mob, tmpl.warcry.radius);
         if (allies.length > 0) {
           const school = tmpl.warcry.school ?? 'physical';
           const auraId = `warcry_${mob.templateId}`;

--- a/tests/mob_nearby_allies.test.ts
+++ b/tests/mob_nearby_allies.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { findNearbyAllies } from '../src/sim/mob/nearby_allies';
+import { SpatialGrid } from '../src/sim/spatial';
+import type { Entity } from '../src/sim/types';
+
+function mob(id: number, x: number, z: number, opts: Partial<Entity> = {}): Entity {
+  return {
+    id,
+    kind: 'mob',
+    dead: false,
+    ownerId: null,
+    hostile: true,
+    hp: 100,
+    maxHp: 100,
+    pos: { x, y: 0, z },
+    ...opts,
+  } as Entity;
+}
+
+describe('findNearbyAllies', () => {
+  it('finds same-faction mobs within radius via the grid, matching a brute-force scan', () => {
+    const grid = new SpatialGrid();
+    const caster = mob(1, 0, 0);
+    const near = mob(2, 10, 0);
+    const far = mob(3, 500, 0);
+    const enemy = mob(4, 5, 0, { hostile: false });
+    const player = mob(5, 5, 0, { kind: 'player' });
+    const pet = mob(6, 5, 0, { ownerId: 99 });
+    const corpse = mob(7, 5, 0, { dead: true });
+    for (const e of [caster, near, far, enemy, player, pet, corpse]) grid.insert(e);
+
+    const found = findNearbyAllies(grid, caster, 40);
+    expect(found.map((e) => e.id)).toEqual([1, 2]);
+  });
+
+  it('returns matches in ascending entity-id order regardless of grid insertion or bucket order, so per-ally rng draws and max-hp tie-breaks stay stable', () => {
+    const grid = new SpatialGrid();
+    // Insert out of id order, and spread across distinct grid cells (cellSize
+    // 32), so bucket-iteration order alone would not happen to match id order.
+    const c = mob(5, 0, 0);
+    const b = mob(3, -40, 0);
+    const a = mob(9, 40, 0);
+    for (const e of [a, b, c]) grid.insert(e);
+
+    const found = findNearbyAllies(grid, c, 100);
+    expect(found.map((e) => e.id)).toEqual([3, 5, 9]);
+  });
+
+  it('applies the caller predicate on top of the faction/radius filter', () => {
+    const grid = new SpatialGrid();
+    const caster = mob(1, 0, 0, { hp: 100, maxHp: 100 });
+    const wounded = mob(2, 5, 0, { hp: 30, maxHp: 100 });
+    const healthy = mob(3, 5, 0, { hp: 100, maxHp: 100 });
+    for (const e of [caster, wounded, healthy]) grid.insert(e);
+
+    const found = findNearbyAllies(grid, caster, 40, (ally) => ally.hp < ally.maxHp);
+    expect(found.map((e) => e.id)).toEqual([2]);
+  });
+
+  it('lets the predicate exclude the caster itself (channelHeal protectee pick)', () => {
+    const grid = new SpatialGrid();
+    const caster = mob(1, 0, 0, { maxHp: 500 });
+    const boss = mob(2, 5, 0, { maxHp: 9000 });
+    const add = mob(3, 5, 0, { maxHp: 200 });
+    for (const e of [caster, boss, add]) grid.insert(e);
+
+    const candidates = findNearbyAllies(grid, caster, 40, (ally) => ally.id !== caster.id);
+    const protectee = candidates.reduce<Entity | null>(
+      (best, ally) => (!best || ally.maxHp > best.maxHp ? ally : best),
+      null,
+    );
+    expect(protectee?.id).toBe(2);
+  });
+
+  it('excludes allies outside the radius', () => {
+    const grid = new SpatialGrid();
+    const caster = mob(1, 0, 0);
+    const justInside = mob(2, 39, 0);
+    const justOutside = mob(3, 41, 0);
+    for (const e of [caster, justInside, justOutside]) grid.insert(e);
+
+    const found = findNearbyAllies(grid, caster, 40);
+    expect(found.map((e) => e.id)).toEqual([1, 2]);
+  });
+});

--- a/tests/mob_nearby_allies.test.ts
+++ b/tests/mob_nearby_allies.test.ts
@@ -31,6 +31,20 @@ describe('findNearbyAllies', () => {
 
     const found = findNearbyAllies(grid, caster, 40);
     expect(found.map((e) => e.id)).toEqual([1, 2]);
+
+    const all = [caster, near, far, enemy, player, pet, corpse];
+    const bruteForce = all
+      .filter(
+        (e) =>
+          e.kind === 'mob' &&
+          !e.dead &&
+          e.hostile === caster.hostile &&
+          e.ownerId == null &&
+          Math.hypot(e.pos.x - caster.pos.x, e.pos.z - caster.pos.z) <= 40,
+      )
+      .map((e) => e.id)
+      .sort((x, y) => x - y);
+    expect(found.map((e) => e.id)).toEqual(bruteForce);
   });
 
   it('returns matches in ascending entity-id order regardless of grid insertion or bucket order, so per-ally rng draws and max-hp tie-breaks stay stable', () => {
@@ -72,14 +86,15 @@ describe('findNearbyAllies', () => {
     expect(protectee?.id).toBe(2);
   });
 
-  it('excludes allies outside the radius', () => {
+  it('excludes allies outside the radius, and includes one exactly on the boundary', () => {
     const grid = new SpatialGrid();
     const caster = mob(1, 0, 0);
     const justInside = mob(2, 39, 0);
+    const onBoundary = mob(4, 40, 0);
     const justOutside = mob(3, 41, 0);
-    for (const e of [caster, justInside, justOutside]) grid.insert(e);
+    for (const e of [caster, justInside, onBoundary, justOutside]) grid.insert(e);
 
     const found = findNearbyAllies(grid, caster, 40);
-    expect(found.map((e) => e.id)).toEqual([1, 2]);
+    expect(found.map((e) => e.id)).toEqual([1, 2, 4]);
   });
 });


### PR DESCRIPTION
## Summary
- Five mob support mechanics in `updateBossMechanics` (Mend, Ward, the channeled
  protectee heal, Rally, and War Cadence) each ran a full linear scan over every
  entity in the world to find same-faction allies within radius, instead of using
  the `SpatialGrid.forEachInRadius` index that `interaction.ts`, `targeting.ts`, and
  the pull/leash logic already use for the same kind of query.
- Extracts the shared same-faction ally scan into a new pure sibling module,
  `findNearbyAllies(grid, mob, radius, predicate)` (`src/sim/mob/nearby_allies.ts`),
  and swaps all five call sites to it. Each mechanic keeps its own extra filter
  (wounded-only for Mend, exclude-self for the channeled heal's protectee pick) as
  the `predicate` argument; the shared kind/dead/owner/faction checks move into the
  helper once instead of being duplicated five times.
- Byte-identical relocation: same entities included/excluded per mechanic, no RNG
  draws or emit ordering touched, only the scan strategy changes from O(total
  entities) to O(nearby entities via the grid).

## Why
Each block is timer-gated per mob, but with several scripted mobs active in a
zone at once, staggered timers mean at least one of these fires most ticks, each
doing a full-world scan. It's the same waste pattern the two most recent merged
perf commits (party-frame projection caching, snapshot-timer caching) fixed, just
not yet applied to these five blocks.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run tests/mob_nearby_allies.test.ts` (new: grid-vs-brute-force
      parity, predicate composition, exclude-self protectee pick, radius boundary)
- [x] `npx vitest run tests/spatial.test.ts tests/architecture.test.ts`
- [x] `npx vitest run tests/mob_mend_ally.test.ts tests/mob_ward_allies.test.ts
      tests/mob_rally.test.ts tests/mob_warcry.test.ts tests/nythraxis_priest_heal.test.ts
      tests/nythraxis_raid.test.ts tests/delves.test.ts tests/world_boss.test.ts`
  (existing mechanic-behavior tests, all still pass unmodified, confirming the move
  is behavior-preserving)
- [x] `npm test` (full suite): 16480 passed, 1 unrelated pre-existing flake
      (`tests/fixes.test.ts` Varkas Boneguard despawn timer, a `testTimeout` under
      core contention; passes in isolation, unaffected by this diff)
- [x] `npm run ci:changed` (Biome on changed files): clean, no errors
- [x] `npm run build`

## Diagram
```mermaid
flowchart LR
    subgraph before["Before: 5x O(total entities)"]
        M1["mendAlly scan"] --> E1[("this.entities.values()")]
        W1["wardAllies scan"] --> E1
        C1["channelHeal protectee scan"] --> E1
        R1["rally scan"] --> E1
        WC1["warcry scan"] --> E1
    end
    subgraph after["After: 5x O(nearby entities)"]
        M2["mendAlly"] --> F["findNearbyAllies(grid, mob, radius, predicate)"]
        W2["wardAllies"] --> F
        C2["channelHeal protectee"] --> F
        R2["rally"] --> F
        WC2["warcry"] --> F
        F --> G[("SpatialGrid.forEachInRadius")]
    end
```
