### PR TITLE
fix(loot): reveal only need rolls when a need roll exists

### DIFF
--- a/src/sim/loot/loot_roll.ts
+++ b/src/sim/loot/loot_roll.ts
@@ -704,10 +704,14 @@ export function resolveLootRoll(ctx: SimContext, roll: PendingLootRoll): void {
       ctx.emit({ type: 'loot', text: `Everyone passed on [[i:${roll.itemId}]].`, pid });
     return;
   }
-  // Reveal every roll, classic-style: one loot line per need/greed roller so the
-  // whole group can audit the outcome (passes were already visible live via
-  // lootRollGroupStatus and have no number to reveal).
-  for (const entry of entries) {
+  // Reveal one loot line per CONTENDING roller only: when anyone needed, need
+  // beats greed, so the greed numbers cannot affect the outcome and revealing
+  // them is noise. Nothing is hidden that matters: every choice (need, greed,
+  // pass) was already visible live via lootRollGroupStatus while the roll was
+  // open, and the winner line below still closes the roll. With no needers the
+  // greed rolls are the contest and all of them are revealed as before (passes
+  // have no number to reveal).
+  for (const entry of contenders) {
     const rollerName =
       ctx.players.get(entry.pid)?.name ?? roll.candidateNames.get(entry.pid) ?? 'Unknown';
     for (const pid of partyMembersForRoll(roll)) {

--- a/tests/loot_roll.test.ts
+++ b/tests/loot_roll.test.ts
@@ -421,7 +421,7 @@ describe('loot_roll: group roll status + resolution broadcast (module entry)', (
     }
   });
 
-  it('broadcasts every need/greed roll to the whole party at resolution, then the winner line', () => {
+  it('reveals only the need rolls at resolution when anyone needed, then the winner line', () => {
     const { sim, a, b, c, rollId } = openRoll();
     submitLootRoll(sim.ctx, rollId, 'greed', b);
     submitLootRoll(sim.ctx, rollId, 'need', a);
@@ -433,9 +433,9 @@ describe('loot_roll: group roll status + resolution broadcast (module entry)', (
     for (const viewer of [a, b, c]) {
       const texts = lootTexts(viewer);
       const needLine = texts.find((t) => t.startsWith('Need Roll - '));
-      const greedLine = texts.find((t) => t.startsWith('Greed Roll - '));
       expect(needLine).toMatch(/^Need Roll - \d+ for \[\[i:greyjaw_hide_boots\]\] by Aaa$/);
-      expect(greedLine).toMatch(/^Greed Roll - \d+ for \[\[i:greyjaw_hide_boots\]\] by Bbb$/);
+      // A need makes the greed rolls outcome-irrelevant, so they are not revealed.
+      expect(texts.some((t) => t.startsWith('Greed Roll - '))).toBe(false);
       // Winner line still closes the roll, after the per-roller reveals.
       const winLine = texts.find((t) => t.includes(' wins '));
       expect(winLine).toMatch(/^Aaa wins \[\[i:greyjaw_hide_boots\]\] \(\d+\)$/);
@@ -445,6 +445,28 @@ describe('loot_roll: group roll status + resolution broadcast (module entry)', (
     expect(lootTexts(a).some((t) => t.includes('by Ccc'))).toBe(false);
     // Resolved roll leaves the group status.
     expect(lootRollGroupStatus(sim.ctx, a)).toHaveLength(0);
+  });
+
+  it('still reveals every greed roll to the whole party when nobody needed', () => {
+    const { sim, a, b, c, rollId } = openRoll();
+    submitLootRoll(sim.ctx, rollId, 'greed', a);
+    submitLootRoll(sim.ctx, rollId, 'greed', b);
+    submitLootRoll(sim.ctx, rollId, 'pass', c);
+    const lootTexts = (pid: number) =>
+      sim.events
+        .filter((e): e is Extract<SimEvent, { type: 'loot' }> => e.type === 'loot' && e.pid === pid)
+        .map((e) => e.text);
+    for (const viewer of [a, b, c]) {
+      const texts = lootTexts(viewer);
+      const greedLines = texts.filter((t) => t.startsWith('Greed Roll - '));
+      expect(greedLines).toHaveLength(2);
+      expect(greedLines[0]).toMatch(/^Greed Roll - \d+ for \[\[i:greyjaw_hide_boots\]\] by Aaa$/);
+      expect(greedLines[1]).toMatch(/^Greed Roll - \d+ for \[\[i:greyjaw_hide_boots\]\] by Bbb$/);
+      expect(texts.some((t) => t.startsWith('Need Roll - '))).toBe(false);
+      const winLine = texts.find((t) => t.includes(' wins '));
+      expect(winLine).toMatch(/^(Aaa|Bbb) wins \[\[i:greyjaw_hide_boots\]\] \(\d+\)$/);
+      expect(texts.indexOf(greedLines[1])).toBeLessThan(texts.indexOf(winLine as string));
+    }
   });
 
   it('hides a curate-phase master roll from the group status', () => {

--- a/tests/parity/golden/l1_loot_distribution.json
+++ b/tests/parity/golden/l1_loot_distribution.json
@@ -460,7 +460,7 @@
       "time": 0.05,
       "nextId": 419,
       "state": "dcf32892",
-      "events": "ae59d2c8",
+      "events": "be00f09c",
       "rng": {
         "draws": 3,
         "digest": "0f82d0c2"


### PR DESCRIPTION
## Summary

When a need-greed loot roll resolves, chat currently reveals every roll line, so a drop with two needers and four greeders prints six roll lines even though the greed numbers cannot matter (need beats greed). This PR reveals only the contending rolls: when at least one player rolled Need, only the Need lines are broadcast; the Greed lines are revealed only when nobody needed. The winner line is unchanged.

The reveal loop in `resolveLootRoll` (`src/sim/loot/loot_roll.ts`) previously iterated all non-pass entries; it now iterates the `contenders` set the function already computes for winner selection (needers if any exist, else greeders), so the behavioral change is that one loop. Winner selection, the everyone-passed branch, and the offline-winner fallback are untouched.

This deliberately overturns the "reveal every roll ... so the whole group can audit the outcome" intent comment: nothing auditable is lost. Every choice (need, greed, pass) is already visible to the whole group live via `lootRollGroupStatus` while the roll is open, and a greed number cannot affect the outcome once a need exists; revealing it at resolution is pure noise. The comment is rewritten to the new intent.

The parity golden `tests/parity/golden/l1_loot_distribution.json` is regenerated in its own commit per `tests/parity/CLAUDE.md`: the diff is a single line, the event-stream hash at the "after-rolls" checkpoint. The state hash and the rng record (draw count and digest) are byte-identical, which is the direct evidence that no rng draw or state behavior changed, only which loot lines are emitted.

No new player-facing text is emitted (the existing `Need Roll` / `Greed Roll` formats fire for fewer entries), so no `sim_i18n` matcher changes; the `loot.rollGreed` matcher stays reachable through the greed-only path.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/loot_roll.test.ts` (red-before proven: the new negative assertion, Greed line absent when a need exists, fails on the base branch; green after)
  - `npx vitest run tests/loot_roll.test.ts tests/loot_messaging_sim.test.ts tests/loot_roll_reconcile.test.ts tests/loot_roll_controller.test.ts tests/loot_master_sim.test.ts tests/dead_party_loot.test.ts` (75 tests green)
  - `UPDATE_PARITY=1 npx vitest run tests/parity/parity.test.ts` to mint the golden, then `npx vitest run tests/parity` green
  - `npm run gate`: every step green except the two known-flaky `tests/deploy_watchdog.test.ts` "abandons a hung docker" cases (fake-docker timing), which fail identically on a pristine `release/v0.28.0` checkout in my sandbox and are unrelated to this diff; the rest of the full suite is green (1377 files, 16697 tests passed) along with the i18n freshness, malware scan, biome, SFX conformance, `tsc`, and all five builds
- Manual steps: none needed; chat-text-only change, fully covered by the sim tests.

Test changes in `tests/loot_roll.test.ts`:
- The mixed-roll case now asserts the Need line is present AND the Greed line is absent (a decisive negative assertion, not just presence of the need line), plus the winner-line ordering.
- New greed-only case: both greed lines still revealed to every party member, no need lines, winner line last.

## Checklist

### Quality

- [x] **The full gate passes.** Green except the two pre-existing sandbox-flaky
      `deploy_watchdog` cases noted above (fail identically on a pristine base
      checkout; CI runs them fine). Decisive tests added and updated for the
      changed behavior; manual checks recorded above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: chat text only, no layout or input change.
- ~Accessible.~ N/A: no UI added or edited.

### Localization (i18n)

- [x] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings. (Existing matched formats fire for fewer entries; `loot.rollGreed` remains reachable via the greed-only path.)

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files. The parity golden was regenerated via
      `UPDATE_PARITY=1 npx vitest run tests/parity/parity.test.ts` (its sanctioned owner), in its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
