### PR TITLE
test(professions): Phase 11 QA, fishing coverage pins and the S3 scan-list fix

### DIFF
--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -394,6 +394,41 @@ surfaces are covered before/after). QA probe-first: the extraction commit 62ee26
 move-not-rewrite, band-1 liveness at proficiency 150, and the live GameServer gprof round
 trip suite.
 
+Phase 11 QA (2026-07-20): PASS with fixes, zero blocking. Verified off the merge
+15c9794db9 into release/v0.29.0 (QA diff = the PR #2197 commits first-parent across the
+83b929398 sync, whose only cargo was the Discord invite-rotation revert). Method:
+validation matrix green at the untouched tip first (the matrix suites plus tests/parity,
+925 tests, tsc clean), one Explore context load, then an adversarial-verify Workflow (3
+packet audits + the 5 dispatch-matrix reviewers; every nontrivial finding retried by two
+independent skeptics under distinct lenses; all audits delivered structured output first
+try) plus a correctness probe suite run and deleted in-tree (band boundaries live at
+99/100/199/200, startFishing deny arms, codfather full-bags, col_glimmerfin off a real
+fished koi, nonzero persistence round trips). The extraction stopping rule never
+triggered: move-not-rewrite confirmed at line level, draw order and observable behavior
+unchanged, the two sanctioned additions (fishingResult emit, grant queue) draw-free after
+the single roll. The one guard regression found and fixed: the S3 drift guard's scan list
+was not extended to src/sim/professions/fishing.ts, so the three relocated literals whose
+only emitters now live there (no-bite, rare catch, face-fishable-water) had silently lost
+reword-drift protection (matchers unchanged, zero runtime impact; the guard now reds on a
+reword, mutation-verified). Coverage closed test-first, each pin mutation-verified: the
+band-2 top-band liveness literal (B2_SEQ_4242, diverging from the band-1 walk exactly
+where band 2 lands the koi and band 1 an empty hook), the codfather over-capacity
+force-add (the quest soft-lock defense), col_glimmerfin on the fished path, the
+startFishing deny arms plus the fixed 5 s zero-draw cast start, negative band input, the
+NONZERO fishing persistence round trip (every prior fixture carried fishing 0), and the
+ACCEPTED rollback caveat pin (a stripped-key reload re-zeroes fishing only, the other
+three professions survive). Cleanup: the data.ts FISHING_RARE_ID / FISHING_TABLES
+re-export arm, left consumer-less by the extraction, dropped. Deferred with reasons: a
+char_window DOM-level gathering test (the undefined-key skip arm is unreachable by
+construction: rows come from the fixed client-side GATHERING_PROFESSION_IDS list, and the
+label-map tripwire plus the wheel-window DOM pins cover the reachable arm), a
+vale-fallback cast test (unreachable via zoneAt: ZONES is exactly the three tabled zones,
+clamped at the strip ends), the SWIM_DEPTH deep-water alias now at four copies
+(extraction chore candidate, drift note in state.md), gathering accrual past maxSkill
+(pre-existing semantics shared with node harvests across all four professions; the wheel
+UI clamps via the Phase 5 above-cap saturation pin), and the catchLine unknown-item
+fallback arm (defensive, unreachable today).
+
 ### Phase 12: Base tool tier gating
 - [ ] Nodes carry tiers; tool tier + skill gate node and corpse-material access
 - [ ] The 15 existing tools change outcomes; stale no-op test pin replaced

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -892,6 +892,24 @@ tables, i18n key namespaces, files created)
   touching reviewed prose trips the full-gate i18n semantic-regression
   pins). catchLine's English carries no trailing period while gatherLine
   has one (deliberate; the five overlay fills match their English source).
+- Phase 11 QA notes (2026-07-20, PASS with fixes, zero blocking): the S3
+  drift guard scan list now includes src/sim/professions/fishing.ts (the
+  extraction had orphaned the three fishing-only emit literals from reword
+  protection; matchers unchanged). The stranded data.ts FISHING_RARE_ID /
+  FISHING_TABLES re-export dropped (the band-0 alias comment in
+  content/items.ts now names the deeds zone-key guard as the surviving
+  consumer). New pins, all mutation-verified: band-2 liveness on the live
+  catch path, codfather over-capacity force-add (soft-lock defense),
+  col_glimmerfin off a fished koi, startFishing deny arms + fixed 5 s
+  zero-draw cast start, nonzero fishing persistence round trip, and the
+  ACCEPTED rollback caveat (stripped-key reload re-zeroes fishing only).
+  Chore candidate: the `const SWIM_DEPTH = PLAYER_SWIM_DEPTH` deep-water
+  alias now has FOUR copies (sim.ts, player_motion.ts, mob/locomotion.ts,
+  professions/fishing.ts); rule of three tripped, a shared deep-water
+  predicate is the extraction shape. Awareness note: gathering proficiency
+  accrual has no maxSkill cap on the drain path (shared, pre-existing
+  semantics across all four professions; the wheel UI clamps display via
+  the Phase 5 above-cap saturation pin).
 - Phase 13: (planned) disenchantItem/applyEnchant/salvageItem IWorld
   members + wire commands.
 

--- a/src/sim/content/items.ts
+++ b/src/sim/content/items.ts
@@ -1907,7 +1907,7 @@ export const FISHING_TABLES_BY_BAND: Record<string, FishingEntry[]>[] = [
 ];
 
 // The band-0 tables, kept under the original export name so pre-Phase-11
-// consumers (src/sim/data.ts re-export, the deeds zone-key guard) resolve
+// consumers (the deeds zone-key guard in tests/deeds_content.test.ts) resolve
 // unchanged. Identical object as FISHING_TABLES_BY_BAND[0], so its rows are the
 // shipped rows byte for byte.
 export const FISHING_TABLES: Record<string, FishingEntry[]> = FISHING_TABLES_BY_BAND[0];

--- a/src/sim/data.ts
+++ b/src/sim/data.ts
@@ -4,7 +4,7 @@
 // merges those records into the flat tables the rest of the engine consumes,
 // and owns the world-layout constants.
 
-import { BASE_ITEMS, FISHING_RARE_ID, FISHING_TABLES } from './content/items';
+import { BASE_ITEMS } from './content/items';
 import type {
   CampDef,
   DelveDef,
@@ -24,7 +24,6 @@ import type {
 } from './types';
 
 export type { FishingEntry } from './content/items';
-export { FISHING_RARE_ID, FISHING_TABLES };
 
 import {
   BROTHER_HALVEN,

--- a/tests/localization_fixes.test.ts
+++ b/tests/localization_fixes.test.ts
@@ -911,6 +911,15 @@ describe('S3: every sim.ts emit is recognized (drift guard)', () => {
     // #1121: per-player node harvest command denials (dead gate, unknown node,
     // range, respawn timer, bag-full pre-check).
     fs.readFileSync(path.resolve(process.cwd(), 'src/sim/professions/gathering.ts'), 'utf8'),
+    // Professions 2.0 Phase 11: the fishing command bodies moved out of sim.ts.
+    // Three literals have their ONLY emitter occurrences here ("No fish are
+    // biting.", "A rare catch! Something gleams on your line.", "You need to
+    // face fishable water."); they are byte-identical after the move so their
+    // matchers are unchanged, but a rewording of THIS file's sites was
+    // invisible to the guard before this entry. The file's other emits
+    // (bags-full, dead/in-combat/swimming/busy) are byte-identical to literals
+    // in already-scanned files.
+    fs.readFileSync(path.resolve(process.cwd(), 'src/sim/professions/fishing.ts'), 'utf8'),
     // #2033 (PR 2039): the quest command bodies (accept/share/abandon/turn-in guards +
     // the accepted/abandoned/completed logs). The two profession-choice denials
     // ("That profession choice is not available." / "... no longer available.") have

--- a/tests/professions_fishing.test.ts
+++ b/tests/professions_fishing.test.ts
@@ -33,11 +33,12 @@ import { type ClientSession, GameServer } from '../server/game';
 import { ClientWorld } from '../src/net/online';
 import { bagCapacity } from '../src/sim/bags';
 import { FISHING_TABLES, FISHING_TABLES_BY_BAND } from '../src/sim/content/items';
-import { DEEPFEN_SHALLOWS_LAKE } from '../src/sim/data';
+import { DEEPFEN_SHALLOWS_LAKE, LAKE } from '../src/sim/data';
 import {
   completeFishing,
   FISHING_BAND_THRESHOLDS,
   fishingBandFor,
+  startFishing,
 } from '../src/sim/professions/fishing';
 import { type PlayerMeta, Sim } from '../src/sim/sim';
 import type { Entity, PlayerClass, SimEvent } from '../src/sim/types';
@@ -153,6 +154,35 @@ const B1_SEQ_4242: (string | null)[] = [
   TROUT,
 ];
 
+// The literal band-2 sequence for the SAME seed with fishing proficiency 200,
+// hand-computed from the band-2 Vale weights (trout 51 / perch 36 / weed 4 /
+// koi 3 / null 6) against the same raw rng stream. It diverges from the
+// band-0 walk at index 1 and, decisively, from the BAND-1 walk at index 16:
+// that draw lands in the 92-to-94 window where band 2 yields the koi but
+// band 1 yields an empty hook, so matching this sequence proves the live
+// path resolved FISHING_TABLES_BY_BAND[2], not a band-1 collapse (Phase 11
+// QA: the top-band wiring was previously unpinned on the live path).
+const B2_SEQ_4242: (string | null)[] = [
+  PERCH,
+  TROUT,
+  TROUT,
+  TROUT,
+  TROUT,
+  PERCH,
+  TROUT,
+  PERCH,
+  PERCH,
+  TROUT,
+  PERCH,
+  TROUT,
+  TROUT,
+  TROUT,
+  TROUT,
+  TROUT,
+  KOI,
+  PERCH,
+];
+
 function codfatherSim(): { sim: Sim; meta: PlayerMeta } {
   const sim = makeSim();
   const meta = sim.meta(sim.playerId)!;
@@ -250,6 +280,23 @@ describe('fishing one-draw rng contract (pin 2)', () => {
     sim.tick();
     expect(meta.gatheringProficiency.fishing).toBe(0);
   });
+
+  it('codfather force-lands even with full bags (over-capacity tolerated, the soft-lock defense)', () => {
+    // The codfather branch deliberately skips the capacity gate: losing the
+    // once-ever quest fish to full bags could soft-lock the quest chain. A
+    // well-meaning "consistency" change adding a canAddItem gate here would
+    // keep every other pin green while recreating the soft-lock; this pin is
+    // the tooth.
+    const { sim, meta } = codfatherSim();
+    meta.inventory = Array.from({ length: bagCapacity(meta.bags) }, () => ({
+      itemId: 'simple_fishing_pole',
+      count: 1,
+    }));
+    sim.events = [];
+    completeFishing(sim.ctx, sim.player, meta);
+    expect(sim.countItem('the_codfather')).toBe(1);
+    expect(sim.events.filter((e) => (e as { type: string }).type === 'error')).toHaveLength(0);
+  });
 });
 
 describe('fishing proficiency accrual (pin 3)', () => {
@@ -303,6 +350,8 @@ describe('fishing band function (pin 4)', () => {
     expect(fishingBandFor(200)).toBe(2);
     expect(fishingBandFor(300)).toBe(2);
     expect(fishingBandFor(Number.NaN)).toBe(0);
+    // A negative proficiency (malformed input) also falls to band 0.
+    expect(fishingBandFor(-5)).toBe(0);
   });
 });
 
@@ -432,6 +481,16 @@ describe('fishing band selection liveness (pin 6)', () => {
     // stream, so this match proves the live path actually switched tables.
     expect(catchSequence(sim, meta, 12)).toEqual(B1_SEQ_4242);
   });
+
+  it('proficiency 200 resolves the band-2 Vale table: literal sequence at seed 4242', () => {
+    const sim = makeSim(4242);
+    const meta = sim.meta(sim.playerId)!;
+    meta.gatheringProficiency.fishing = 200;
+    // The koi at index 16 sits where the band-1 table yields an empty hook
+    // (see the B2_SEQ_4242 derivation comment), so this match proves the
+    // live path resolved the TOP band, not a band-1 collapse.
+    expect(catchSequence(sim, meta, 18)).toEqual(B2_SEQ_4242);
+  });
 });
 
 describe('fishingResult event (pin 7)', () => {
@@ -529,6 +588,121 @@ describe('fishing deeds through the extracted module path (pin 9)', () => {
     sim.ctx.markDeedsDirty(meta.entityId);
     sim.tick();
     expect(meta.deedsEarned.has('prog_master_gatherer')).toBe(true);
+  });
+
+  it('a fished glimmerfin koi logs the rare-catch line and completes col_glimmerfin', () => {
+    // Acceptance criterion 3: the rare catch and its deed complete unchanged
+    // through the extracted module path. col_glimmerfin is a collectItems
+    // trigger riding the addItem collection path, so a real completeFishing
+    // koi (B0_SEQ_4242 index 21) must credit it end to end.
+    const sim = makeSim(4242);
+    const meta = sim.meta(sim.playerId)!;
+    let koiAt = -1;
+    for (let i = 0; i < 22; i++) {
+      if (castOnce(sim, meta).caught === KOI) koiAt = i;
+    }
+    expect(koiAt).toBe(21);
+    expect(sim.events).toContainEqual(
+      expect.objectContaining({
+        type: 'log',
+        text: 'A rare catch! Something gleams on your line.',
+      }),
+    );
+    sim.ctx.markDeedsDirty(meta.entityId);
+    sim.tick();
+    expect(meta.deedsEarned.has('col_glimmerfin')).toBe(true);
+  });
+});
+
+describe('startFishing arms through the extracted module path (pin 10)', () => {
+  it('all five deny arms refuse with the exact error and never start the cast', () => {
+    const sim = makeSim(4242);
+    const meta = sim.meta(sim.playerId)!;
+    const denyCase = (mutate: () => void, restore: () => void, text: string) => {
+      mutate();
+      sim.events = [];
+      startFishing(sim.ctx, sim.player, meta);
+      expect(sim.events).toContainEqual(expect.objectContaining({ type: 'error', text }));
+      // No cast ever starts on a deny (the busy arm's precondition is itself
+      // a live castingAbility, so the tooth is the absent castStart event).
+      expect(sim.events.some((e) => (e as { type: string }).type === 'castStart')).toBe(false);
+      restore();
+    };
+    denyCase(
+      () => {
+        sim.player.dead = true;
+      },
+      () => {
+        sim.player.dead = false;
+      },
+      "You can't do that while dead.",
+    );
+    denyCase(
+      () => {
+        sim.player.inCombat = true;
+      },
+      () => {
+        sim.player.inCombat = false;
+      },
+      "You can't do that while in combat.",
+    );
+    // Swimming: the vale lake center puts the player in deep water.
+    const dry = { ...sim.player.pos };
+    denyCase(
+      () => {
+        teleportTo(sim, LAKE.x, LAKE.z);
+      },
+      () => {
+        sim.player.pos = { ...dry };
+        sim.player.prevPos = { ...dry };
+      },
+      "You can't do that while swimming.",
+    );
+    denyCase(
+      () => {
+        sim.player.castingAbility = 'fishing';
+      },
+      () => {
+        sim.player.castingAbility = null;
+      },
+      'You are busy.',
+    );
+    // No fishable water: the spawn plaza facing due south is dry land for
+    // every sample distance.
+    denyCase(
+      () => {
+        sim.player.facing = Math.PI;
+      },
+      () => {},
+      'You need to face fishable water.',
+    );
+  });
+
+  it('facing the vale lake starts the fixed 5 s cast and draws no rng', () => {
+    const sim = makeSim(4242);
+    const meta = sim.meta(sim.playerId)!;
+    // South shore of the vale lake, facing the center: fishable water ahead.
+    const pz = LAKE.z - LAKE.radius - 2;
+    teleportTo(sim, LAKE.x, pz);
+    sim.player.facing = Math.atan2(0, LAKE.z - pz);
+    sim.events = [];
+    let draws = 0;
+    sim.rng.setObserver(() => draws++);
+    try {
+      startFishing(sim.ctx, sim.player, meta);
+    } finally {
+      sim.rng.setObserver(null);
+    }
+    // The cast timer is a FIXED 5 s constant (literal on purpose: comparing
+    // against the imported constant would pin nothing) and the cast start
+    // draws zero rng, preserving the draw-order contract.
+    expect(draws).toBe(0);
+    expect(sim.player.castingAbility).toBe('fishing');
+    expect(sim.player.castTotal).toBe(5);
+    expect(sim.player.castRemaining).toBe(5);
+    expect(sim.events).toContainEqual(
+      expect.objectContaining({ type: 'castStart', ability: 'fishing', time: 5 }),
+    );
   });
 });
 

--- a/tests/professions_gathering.test.ts
+++ b/tests/professions_gathering.test.ts
@@ -74,6 +74,58 @@ describe('gathering profession proficiency (#1119)', () => {
     expect(meta2.gatheringProficiency).toEqual({ mining: 7, logging: 0, herbalism: 2, fishing: 0 });
   });
 
+  it('a NONZERO fishing proficiency survives the save/load round trip (Phase 11)', () => {
+    // Every other persistence fixture in this file carries fishing:0, so a
+    // regression dropping the fishing key from serializeCharacter (or a
+    // hand-rolled normalize key list) would stay green without this pin.
+    const sim = makeSim();
+    const pid = sim.playerId;
+    sim.chat('/dev gather mining 7', pid);
+    sim.chat('/dev gather fishing 57', pid);
+    sim.tick();
+
+    const state = (sim as any).serializeCharacter(pid);
+    // The save dual-writes both the legacy and the current key.
+    expect(state.professions).toEqual({ mining: 7, logging: 0, herbalism: 0, fishing: 57 });
+    expect(state.gatheringProficiency).toEqual({
+      mining: 7,
+      logging: 0,
+      herbalism: 0,
+      fishing: 57,
+    });
+
+    const sim2 = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    const loadedPid = sim2.addPlayer('warrior', 'RoundTrip', { state });
+    const meta2 = (sim2 as any).players.get(loadedPid);
+    expect(meta2.gatheringProficiency).toEqual({
+      mining: 7,
+      logging: 0,
+      herbalism: 0,
+      fishing: 57,
+    });
+  });
+
+  it('ACCEPTED ROLLBACK CAVEAT (documented Phase 11 semantic): a pre-Phase-11 round trip re-zeroes fishing only', () => {
+    // A pre-Phase-11 loader normalizes the blob to the starter three keys, so
+    // a save written by that code path comes back WITHOUT the fishing key:
+    // accrued fishing proficiency is deliberately lost on the downgrade round
+    // trip (the mailWelcomed class; release-notes line at tag time) while the
+    // other three professions survive untouched.
+    const sim = makeSim();
+    const pid = sim.playerId;
+    sim.chat('/dev gather mining 7', pid);
+    sim.chat('/dev gather fishing 57', pid);
+    sim.tick();
+    const state = (sim as any).serializeCharacter(pid);
+    delete state.professions.fishing;
+    delete state.gatheringProficiency.fishing;
+
+    const sim2 = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    const loadedPid = sim2.addPlayer('warrior', 'RolledBack', { state });
+    const meta2 = (sim2 as any).players.get(loadedPid);
+    expect(meta2.gatheringProficiency).toEqual({ mining: 7, logging: 0, herbalism: 0, fishing: 0 });
+  });
+
   it('backward-compatible: an old save lacking the field loads with all-zero proficiency', () => {
     const sim = makeSim();
     const pid = sim.playerId;
@@ -127,6 +179,15 @@ describe('gathering profession proficiency (#1119)', () => {
       logging: 0,
       herbalism: 0,
       fishing: 0,
+    });
+    // A nonzero fishing value passes through intact (Phase 11: every other
+    // fixture in this file feeds fishing 0, which a fishing-specific drop
+    // would satisfy vacuously).
+    expect(normalizeGatheringProficiency({ fishing: 57 })).toEqual({
+      mining: 0,
+      logging: 0,
+      herbalism: 0,
+      fishing: 57,
     });
   });
 


### PR DESCRIPTION
## Summary

Phase 11 QA of the Professions 2.0 program (fishing joins the gathering framework, PR #2197 merged as 15c9794db9). The audit ran the validation matrix green at the untouched release/v0.29.0 tip first, then an adversarial-verify fan-out (3 packet audits plus the 5 dispatch-matrix reviewers, every nontrivial finding retried by two independent skeptics) and a run-and-deleted correctness probe suite. Verdict: PASS with fixes, zero blocking findings, and the extraction stopping rule never triggered (move-not-rewrite confirmed at line level; draw order and observable behavior unchanged).

What this PR lands, all test-first and mutation-verified (each new pin was proven to red on its target regression before commit):

- The S3 drift guard now scans `src/sim/professions/fishing.ts`. The extraction moved three player-facing literals (the no-bite log, the rare-catch log, the face-fishable-water error) out of `sim.ts`, and their only emitters left the guard's scan list, so a reword would have shipped English to every locale with the guard green. Matchers are unchanged and the suite stays green; a mutation reword now reds.
- Band-2 liveness pin: an 18-entry literal catch sequence at proficiency 200 that diverges from the band-1 walk exactly where band 2 lands the koi and band 1 an empty hook, so a top-band collapse can no longer pass the suite.
- Codfather over-capacity force-add pin (the quest soft-lock defense): a capacity-gate "consistency" mutation previously kept every suite green.
- `col_glimmerfin` pinned on the fished path (acceptance criterion 3 named the deed; it was proven working but unpinned).
- startFishing deny arms (all five, exact error text, no castStart) plus the fixed 5 s zero-draw cast start, and the negative band input arm.
- Nonzero fishing persistence round trip (every prior fixture carried fishing 0) and the ACCEPTED rollback caveat pin: a stripped-key reload re-zeroes fishing only while the other three professions survive.
- Cleanup: the `data.ts` `FISHING_RARE_ID` / `FISHING_TABLES` re-export arm, left consumer-less by the extraction, dropped (the band-0 alias comment now names the surviving consumer).
- Docs: the Phase 11 QA verdict in `progress.md` and the QA addendum plus drift notes in `state.md` (SWIM_DEPTH quad-copy chore candidate, uncapped-accrual awareness note, deferrals with reasons).

Deferred with written reasons (in `progress.md`): a char_window DOM-level gathering test (the undefined-key skip arm is unreachable by construction and the reachable arm is covered by the label-map tripwire plus the wheel-window DOM pins), a vale-fallback cast test (unreachable via `zoneAt`), the SWIM_DEPTH quad-copy extraction (chore candidate), and the catchLine unknown-item fallback (defensive).

## Related issues

Part of #1866.

## Type of change

- [x] Tests
- [x] Documentation
- [x] Refactor or performance (no behavior change)

## How was this tested?

- Commands: `npx vitest run tests/professions_fishing.test.ts tests/professions_gathering.test.ts tests/localization_fixes.test.ts tests/deeds.test.ts tests/architecture.test.ts` (green), `npx tsc --noEmit` (clean), three source mutations (band-2 collapse, no-bite literal reword, codfather capacity gate) each redding exactly the intended pins before revert, and the full `npm run gate` under Node 24: green through the full suite (1381 files), failing only at the known environmental armory browser pixel red on this machine (reproduces on the untouched release tip; PR CI is the arbiter), with the gate tail (`check:types`, `build:env`, `build:server`, `build`) finished manually green.
- Manual steps: adjudicated every audit finding against the real code; verified the stash list and a clean tree before each commit.

---

## Checklist

### Quality

- [x] **The full gate passes.** Green under Node 24 except the documented environmental armory browser red; tail completed manually; PR CI is the arbiter.

### Cross-platform

- N/A. No UI change (tests, one dead re-export drop, docs).

### Localization (i18n)

- [x] Player-facing text emitted from `src/sim/` or `server/` is re-localized at the client boundary in this same change, and `npx vitest run tests/localization_fixes.test.ts` passes. (This PR extends that guard's scan list; no strings changed.)
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
