### PR TITLE
docs(professions-2): the 2026-07-20 timing and economy restructure (phases 12b and 14b)

### DIFF
--- a/docs/professions-2/README.md
+++ b/docs/professions-2/README.md
@@ -50,8 +50,10 @@ starter prompt.
 | 10 | [Recipe ladders and materials content](phase-10-recipe-ladders.md) | [QA](phase-10-qa.md) |
 | 11 | [Fishing joins the framework](phase-11-fishing.md) | [QA](phase-11-qa.md) |
 | 12 | [Base tool tier gating](phase-12-tool-gating.md) | [QA](phase-12-qa.md) |
+| 12b | [Gathering rhythm](phase-12b-gathering-rhythm.md) | [QA](phase-12b-qa.md) |
 | 13 | [Enchanting reachable](phase-13-enchanting.md) | [QA](phase-13-qa.md) |
 | 14 | [Attunement quests and nudges](phase-14-attunement-quests.md) | [QA](phase-14-qa.md) |
+| 14b | [Commissions and the Maker's Bond](phase-14b-commissions-binding.md) | [QA](phase-14b-qa.md) |
 | 15 | [Deeds, tuning, and polish](phase-15-deeds-polish.md) | [Final QA + teardown](phase-15-qa.md) |
 
 Waves for orientation: phases 1 to 7 are the fun kernel (visibility, truth,
@@ -64,7 +66,11 @@ stands in until the Phase 8 masters land), celebrate a masterwork, trade
 it) before wave one begins. Ordering relief: Phase 6 depends on Phases 2
 and 4, NOT on Phase 5, so it may run ahead of the wheel window if the
 design-language rollout stalls Phase 5 (the state.md OPEN item).
-Wave 2+ work (market instance carriage, commissions, Jack of All Trades,
-monster proficiency, battlefield experience) is tracked on epic #1866, not
-in this packet; salvage wiring moved INTO Phase 13 by the 2026-07-17
-design-review amendments recorded in state.md.
+Wave 2+ work (market instance carriage, the commission ORDER workflow,
+Jack of All Trades, monster proficiency, battlefield experience) is
+tracked on epic #1866, not in this packet; salvage wiring moved INTO
+Phase 13 by the 2026-07-17 design-review amendments recorded in state.md,
+and the 2026-07-20 timing and economy amendments inserted Phases 12b
+(Gathering rhythm) and 14b (Commissions and the Maker's Bond) without
+renumbering; the state.md amendments block is the authority for both
+passes.

--- a/docs/professions-2/implementation-plan.md
+++ b/docs/professions-2/implementation-plan.md
@@ -1,9 +1,10 @@
 # Professions 2.0: implementation plan
 
 The canonical workflow and phase index. Each phase is a fresh Claude Code
-session running its own starter prompt from `phase-NN-*.md`; each is followed
-by its QA session (`phase-NN-qa.md`). Locked decisions live in `state.md`;
-the vision lives in `brainstorm.md`.
+session running its own starter prompt from its phase file (`phase-NN-*.md`,
+or `phase-NNb-*.md` for the inserted 12b/14b phases); each is followed
+by its QA session (the matching `-qa.md` twin). Locked decisions live in
+`state.md`; the vision lives in `brainstorm.md`.
 
 ## Team workflow (every phase)
 
@@ -129,13 +130,15 @@ Phase 1.
 | 12b | Gathering rhythm | Gather cast scaled by tool tier and band; the fishing bite minigame with rod synergy; placeholder cues; the pin-cost appendix | sim, ui, tests |
 | 13 | Enchanting reachable | Disenchant, enchant-apply, and salvage on IWorld/wire/UI in both hosts; typed reagents with same-phase consumers; the bind-on-trade primitive | world_api, net, server, ui, content |
 | 14 | Attunement quests and nudges | Lore quests, work orders, and tier mail at the masters; nudges; celebration; the learnable-at-a-master hint | content, sim, ui |
-| 14b | Commissions and the Maker's Bond | Opt-in commission crafts bind on first trade; master unbind gold sink; resolves #1298 semantics | sim, server, ui |
+| 14b | Commissions and the Maker's Bond | Opt-in commission crafts bind on first trade; master unbind gold sink; resolves #1298 semantics | sim, world_api, net, server, ui |
 | 15 | Deeds, tuning, and polish | Universal profession deeds, economy tuning, the SFX completion sweep, wiki rewrite, final gate | content, docs, tests |
 
-Wave 2+ (NOT this packet, tracked on epic #1866): market/mail instance
-carriage (#1146), the commission ORDER workflow of #1298, Jack of All
-Trades (#1296), monster-harvest proficiency, battlefield experience
-expansion, item biographies, tool effects, jewelcrafting/inscription
-depth. (Salvage wiring left this list on 2026-07-17; it joins Phase 13.
-The binding enforcement half of #1298 left it on 2026-07-20; it is
-Phase 14b, issue #2207.)
+Wave 2+ (NOT this packet; epic #1866 is the umbrella for the packet AND
+its follow-ups, so wave-2 items live there beside the in-packet
+sub-issues): market/mail instance carriage (the closed #1146's scope,
+re-homed to a named follow-up when picked up), the commission ORDER
+workflow of #1298, Jack of All Trades (#1296), monster-harvest
+proficiency, battlefield experience expansion, item biographies, tool
+effects, jewelcrafting/inscription depth. (Salvage wiring left this list
+on 2026-07-17; it joins Phase 13. The binding enforcement half of #1298
+left it on 2026-07-20; it is Phase 14b, issue #2207.)

--- a/docs/professions-2/implementation-plan.md
+++ b/docs/professions-2/implementation-plan.md
@@ -98,7 +98,10 @@ landed. Therefore every UI phase in this packet:
 
 ## Phase summary
 
-Phases 1 to 7 are the fun kernel; 8 to 15 are wave one. End of Phase 7 is
+Phases 1 to 7 are the fun kernel; 8 to 15 are wave one (the 2026-07-20
+timing and economy amendments inserted Phases 12b and 14b without
+renumbering; the remaining order is 12, 12b, 13, 14, 14b, 15, and the
+state.md amendments block is the authority for their rulings). End of Phase 7 is
 the vertical-slice checkpoint (see README). Phase 6 depends on Phases 2 and
 4, not on Phase 5, and may run ahead of the wheel window if the
 design-language rollout stalls Phase 5. The 2026-07-17 design-review
@@ -123,12 +126,16 @@ Phase 1.
 | 10 | Recipe ladders and materials (ultracode) | Six deep crafts' tier ladders + material families + economy invariant tests + the materialTierBonus wire | content, sim, tests |
 | 11 | Fishing joins the framework | Fishing proficiency + catch rarity ladder feeding cooking | sim, content, ui |
 | 12 | Base tool tier gating | Node tiers; tool tier + skill gates; tools matter; effects stay parked | sim, content, tests |
-| 13 | Enchanting reachable | Disenchant, enchant-apply, and salvage on IWorld/wire/UI in both hosts | world_api, net, server, ui |
-| 14 | Attunement quests and nudges | Lore quests, work orders, and tier mail at the masters; nudges; celebration | content, sim, ui |
-| 15 | Deeds, tuning, and polish | Universal profession deeds, economy tuning, wiki rewrite, final gate | content, docs, tests |
+| 12b | Gathering rhythm | Gather cast scaled by tool tier and band; the fishing bite minigame with rod synergy; placeholder cues; the pin-cost appendix | sim, ui, tests |
+| 13 | Enchanting reachable | Disenchant, enchant-apply, and salvage on IWorld/wire/UI in both hosts; typed reagents with same-phase consumers; the bind-on-trade primitive | world_api, net, server, ui, content |
+| 14 | Attunement quests and nudges | Lore quests, work orders, and tier mail at the masters; nudges; celebration; the learnable-at-a-master hint | content, sim, ui |
+| 14b | Commissions and the Maker's Bond | Opt-in commission crafts bind on first trade; master unbind gold sink; resolves #1298 semantics | sim, server, ui |
+| 15 | Deeds, tuning, and polish | Universal profession deeds, economy tuning, the SFX completion sweep, wiki rewrite, final gate | content, docs, tests |
 
 Wave 2+ (NOT this packet, tracked on epic #1866): market/mail instance
-carriage (#1146), commissions and boundTo (#1298), Jack of All Trades
-(#1296), monster-harvest proficiency, battlefield experience expansion,
-item biographies, tool effects, jewelcrafting/inscription depth. (Salvage
-wiring left this list on 2026-07-17; it joins Phase 13.)
+carriage (#1146), the commission ORDER workflow of #1298, Jack of All
+Trades (#1296), monster-harvest proficiency, battlefield experience
+expansion, item biographies, tool effects, jewelcrafting/inscription
+depth. (Salvage wiring left this list on 2026-07-17; it joins Phase 13.
+The binding enforcement half of #1298 left it on 2026-07-20; it is
+Phase 14b, issue #2207.)

--- a/docs/professions-2/phase-12-qa.md
+++ b/docs/professions-2/phase-12-qa.md
@@ -74,6 +74,10 @@ Dead code and cleanup agent:
   with the rest of src/sim/professions/.
 
 PHASE-SPECIFIC QA EMPHASIS (probe these specifically):
+- Phase 12 ships NO speed or timing change (the 2026-07-20 amendments): harvests stay
+  instant and the fishing cast stays the fixed 5 s. If the diff contains any cast, duration,
+  or bite mechanic, that is scope creep into Phase 12b, a BLOCKING finding; conversely, do
+  not flag the absence of speed mechanics as a gap.
 - The lockout-prevention invariant on EVERY pre-phase node: enumerate the node defs that
   existed before Phase 12 and prove each one still resolves as bare-hands harvestable; any
   single gated pre-phase node is a BLOCKING finding.

--- a/docs/professions-2/phase-12-qa.md
+++ b/docs/professions-2/phase-12-qa.md
@@ -114,7 +114,8 @@ STEP 4 - UPDATE DOCS + MEMORY:
 STEP 5 - FINAL RESPONSE FORMAT:
 End your turn with: QA verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL), counts of BLOCKING /
 SHOULD-FIX / NICE-TO-HAVE found and fixed, deferred items, and a one-line handoff for the
-Phase 13 implementation session.
+Phase 12b implementation session (Gathering rhythm follows Phase 12 in the restructured
+order).
 
 STOPPING RULES:
 - Stop and surface to the user if any BLOCKING item cannot be fixed without changing the phase

--- a/docs/professions-2/phase-12-tool-gating.md
+++ b/docs/professions-2/phase-12-tool-gating.md
@@ -8,6 +8,13 @@ paths and gives the existing tool items and six tool recipes a real purpose. It 
 because it depends on the node materials (Phase 4), recipe ladders (Phase 10), and fishing catch
 ladder (Phase 11) all being in place, while tool effects and charges stay parked for wave 2+.
 
+Forward note (2026-07-20 timing and economy amendments): Phase 12 stays PURE ACCESS GATING.
+Gathering speed and timing land in Phase 12b (phase-12b-gathering-rhythm.md, issue #2206),
+where tool tiers above a node's requirement shorten the new gather cast and rods additionally
+shorten the fishing bite delay and widen its reaction window. Do not add any speed, cast, or
+timing mechanic in this phase; the tier fields and rod band gates authored here are exactly
+what 12b composes with.
+
 ## Context pointers
 
 - `docs/professions-2/state.md`: locked decisions (tool effects PARKED; prime directive), the
@@ -164,6 +171,8 @@ Out of scope (do NOT do in this phase):
 - Tool effects, charges, and recharge (parked for wave 2+; the pure modules stay dormant).
 - Crafted tool recipe additions or recipe ladder changes (Phase 10 owns recipe content).
 - An equip UI or tool slots (owned-best semantics only).
+- ANY speed or timing mechanic: no gather cast, no harvest duration, no bite delay. Phase 12b
+  owns gathering rhythm; this phase is pure access gating (the 2026-07-20 amendments).
 
 STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
 - Run the state.md sim row: `npx tsc --noEmit`, then

--- a/docs/professions-2/phase-12b-gathering-rhythm.md
+++ b/docs/professions-2/phase-12b-gathering-rhythm.md
@@ -208,7 +208,9 @@ STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
       requirement and proficiency band, floored; completion re-validates range, respawn,
       and capacity; moving cancels free.
 - [ ] All eleven exemption sites (plus the two new-cast joins) route through the shared
-      predicate; no site compares raw cast-id literals anymore.
+      predicate for the fishing/gather semantics; DEMON_HEAL_CAST_ID folds in only at sites
+      where its behavior was already byte-identical (per the sim deliverable), and any site
+      where it stays ad hoc is listed in state.md.
 - [ ] Fishing draws the hidden bite delay exactly once per cast; the bite fires a text-free
       personal SimEvent; the catch lands only on a pole re-press inside the
       server-authoritative window; a miss costs nothing but the cast.
@@ -272,10 +274,12 @@ that reds is a defect in the change, not an accepted cost.
   fishing" with remaining/total seconds, pinned LITERALLY in `tests/casting_command.test.ts`
   ("special-cases the fishing sentinel"). Under the bite model the readout must stay honest
   without leaking the bite time (e.g. no meaningful countdown during the waiting phase).
-  THREE coupled traps: (a) the current literal carries a grandfathered em dash exempted as a
-  v0.7 backstop via ALLOW_V07_SLASH in tests/localization_fixes.test.ts; any reword must drop
-  the em dash per the repo rule; (b) the readout is status-registry-backed English (not a t()
-  catalog key), so a reword updates src/ui/i18n.status.json via the scan, not a catalog; (c)
+  THREE coupled traps: (a) the current literal carries a grandfathered em dash that predates
+  the repo no-dash rule (the readout itself is an ALLOW_V07_SLASH English-backstop surface in
+  tests/localization_fixes.test.ts, an i18n exemption, NOT a dash exemption); any reword must
+  drop the em dash per the repo rule; (b) the readout is status-registry-backed English (not
+  a t() catalog key), so a reword updates src/ui/i18n.status.json via the scan, not a
+  catalog; (c)
   the localization_fixes probe substituter deliberately avoids desyncing the fishing/overpower
   backstop forms that share "total/remaining"; keep that coupling intact.
 - Parity: `professions_gather` (tests/parity/scenarios.ts, golden
@@ -285,10 +289,11 @@ that reds is a defect in the change, not an accepted cost.
   be RE-HUNTED against the new drive shape. Own reviewed commit.
 - Parity: the two fishing-cancel scenarios (`c4a_casting_lifecycle`, snapshot label
   "warlock-fishing-cancel", and `fiesta_midcast_kill`, label "midcast-fishcancel") BYPASS
-  startFishing (the drive assigns castingAbility/castRemaining/castTotal directly), so they
-  do NOT regen from the bite-delay draw; they only move if the cancel semantics or the
-  assigned fields change. Verify rather than regen; their checkpoint samples pin the
-  castTotal 5 shape the drive itself assigns.
+  startFishing (the drive assigns the casting fields directly: c4a sets
+  castingAbility/castRemaining/castTotal, fiesta sets only castingAbility and castRemaining
+  and leaves castTotal at its prior value), so they do NOT regen from the bite-delay draw;
+  they only move if the cancel semantics or the assigned fields change. Verify rather than
+  regen; whatever field shape each drive assigns is what its checkpoint samples pin.
 - Parity storage decision (make it EXPLICITLY, before coding): the digest harness
   (tests/parity/trace.ts) samples entities and player meta through exclude lists then
   canonicalizes with omitDefaults, so a new field ESCAPES all 56 goldens only while its value

--- a/docs/professions-2/phase-12b-gathering-rhythm.md
+++ b/docs/professions-2/phase-12b-gathering-rhythm.md
@@ -1,0 +1,317 @@
+# Phase 12b: Gathering rhythm
+
+Gathering gains action time and fishing gains a catch moment. A short gather cast (base about
+2.5 s) replaces the instant node harvest, sped up by owning a tool tier above the node's
+requirement (Phase 12's tiers) and modestly by proficiency band, floored around 1.5 s. Fishing
+replaces its fixed 5 s cast with a bite minigame: one hidden seeded delay, a private bite signal,
+and a generous server-authoritative reaction window answered by re-pressing the pole. It is its
+own slice because it is pure rhythm-and-feedback work over the Phase 11 fishing module and the
+Phase 12 tool tiers, it deliberately re-pins a known, pre-briefed set of timing tests (see the
+Pin-cost appendix below), and none of the content phases depend on it. Approved by the
+2026-07-20 timing and economy amendments (state.md is the authority); tracked as issue #2206.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: the 2026-07-20 timing and economy amendments block (the
+  authority for this phase's rulings), locked decisions, and the validation matrix.
+- `docs/professions-2/progress.md`: the Phase 12b status row and deliverable checklist.
+- The Pin-cost appendix at the bottom of THIS file: every test and golden this phase deliberately
+  re-pins, inventoried against the release/v0.29.0 tree. Read it before touching any test.
+- `src/sim/professions/fishing.ts`: `startFishing` (fixed `FISHING_CAST_TIME` cast, zero draws)
+  and `completeFishing` (the single table draw, the codfather early return, the capacity gate).
+- `src/sim/types.ts`: `FISHING_CAST_ID` (the literal `'fishing'` riding `castingAbility`),
+  `FISHING_CAST_TIME`, `DEMON_HEAL_CAST_ID` (a second non-ability cast sentinel handled ad hoc
+  at some of the same choke points), the `fishingResult` and `gatherResult` SimEvent shapes.
+- `src/sim/combat/casting_lifecycle.ts`: `updateCasting` (the silence and school-lockout
+  exemptions, the fishing completion arm routing to `ctx.completeFishing`) and `castAbility`
+  (the blink-through exclusion and the spell-queue exclusion).
+- `src/sim/combat/effect_dispatch.ts` (`runEffects`, the interrupt-immunity arm),
+  `src/sim/combat/damage.ts` (`dealDamage`, the cancel-not-pushback arm), `src/sim/items.ts`
+  (`useItem`: the rod re-entry branch and the busy guard where the reel re-press lands),
+  `src/sim/social/chat_readouts.ts` (`castingReadout`, the /cast fishing line),
+  `src/render/cast_bar.ts` (`castBarState`), `src/ui/hud.ts` (`castDisplayName`).
+- `src/sim/professions/gathering.ts`: `harvestNode` (today grants synchronously inside the
+  command; draws and grants move to cast completion) and `resolveHarvest`.
+- `src/sim/delves/lockpick_controller.ts`: `armLockpickStep` / `tickLockpickTimeout`, the
+  server-authoritative tick-deadline precedent the bite reaction window follows
+  (`stepDeadlineTick` on the session state, deadlines in sim ticks, the client never reports
+  the timeout).
+- `src/sim/professions/tools.ts` (`gatherToolTier`, `canGatherTier`) and the Phase 12 node
+  tiers and rod band gating this phase composes with.
+- The SFX pipeline for the placeholder cues: `scripts/sfx/ui_sfx.mjs` (deterministic local
+  synthesis, keys match the `ui_*` pattern), `npm run sfx:manifest`, `npm run sfx:check`, the
+  routing recipe in `src/game/CLAUDE.md`, and the help-wanted issue #2208 that lists every
+  placeholder slot for the sound engineer.
+- Local conventions: `src/sim/CLAUDE.md`, `src/sim/professions/CLAUDE.md`, `src/ui/CLAUDE.md`,
+  `tests/CLAUDE.md`.
+
+## Starter Prompt
+
+```
+This is Phase 12b of the Professions 2.0 feature: Gathering rhythm.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: give gathering a short tool-and-proficiency-scaled cast and replace the fixed fishing
+cast with a hidden-delay bite minigame, without leaking the bite time to clients and while
+re-pinning exactly the pre-briefed test set in this file's Pin-cost appendix.
+
+STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
+- Run git status; the checkout must be clean (a concurrent session may share it). Record the
+  phase-start commit in docs/professions-2/progress.md Notes.
+- Memory scan (MEMORY.md index): node25-breaks-jsdom-gate (gate under Node 24),
+  combo-recipes-broken-online (the 2033 stub trap), design-language-program (today's tokens
+  only), and any professions packet entries.
+- Phase 12 must be LANDED (this phase reads its node tiers and rod bands). If it is not, stop.
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize: docs/professions-2/state.md (the 2026-07-20
+amendments block), docs/professions-2/progress.md, this phase file INCLUDING the Pin-cost
+appendix, src/sim/professions/fishing.ts, src/sim/professions/gathering.ts (harvestNode),
+src/sim/combat/casting_lifecycle.ts, src/sim/combat/effect_dispatch.ts (the interrupt arm),
+src/sim/combat/damage.ts (the fishing cancel arm), src/sim/items.ts (useItem),
+src/sim/delves/lockpick_controller.ts (the stepDeadlineTick precedent),
+src/sim/social/chat_readouts.ts (castingReadout), src/render/cast_bar.ts, the hud.ts
+castDisplayName helper, src/sim/professions/tools.ts, and the CLAUDE.md files for sim,
+professions, ui, and tests. The summary must return: every FISHING_CAST_ID comparison site
+(expect eleven exemption sites plus the definition and the cast origin), the exact
+draw-order contracts of startFishing/completeFishing today, how harvestNode grants today
+(synchronous in the command; only the skill point rides the pendingGatherGrants queue), the
+lockpick deadline mechanism, the castRem/castTot wire behavior, and the Pin-cost appendix
+verbatim.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
+The sim agent lands first (predicate + gather cast + bite model); ui/render and tests agents
+follow against its result. Each agent gets ONLY the Explore summary.
+
+Agent sim deliverables:
+- A shared non-spell-cast predicate (a pure function in src/sim/, e.g. isNonSpellCast(castId))
+  consolidating the eleven scattered FISHING_CAST_ID exemption comparisons; the new gather
+  cast id joins it. DEMON_HEAL_CAST_ID is handled ad hoc at some of the same choke points:
+  fold it in ONLY where its current behavior is byte-identical to the fishing/gather
+  semantics; never change its behavior in this phase.
+- The gather cast: interacting with a node starts a cast (a new GATHER_CAST_ID sentinel on
+  castingAbility, base about 2.5 s), validated up front exactly as harvestNode validates
+  today. Duration shortens per owned tool tier ABOVE the node's Phase 12 requirement and
+  modestly by proficiency band, floored around 1.5 s; exact numbers are yours, as named
+  exported constants recorded in state.md tuning targets. Completion (the casting_lifecycle
+  arm) re-validates range, node respawn state, and capacity, then runs the existing resolve
+  (rarity and rare-event draws stay a completion-time pair, so denial-draws-zero survives).
+  Moving cancels like any cast (cancelCast in player_motion is generic; verify, do not add a
+  special case). NOTE the SimContext-callback trap: a new completion callback needs the five
+  sites (interface, createSimContext, Sim binding, both test stub hosts, and the pinned
+  callback-name list in tests/sim_context.test.ts).
+- The bite minigame: startFishing keeps its deny arms and cast start but draws ONE seeded
+  bite delay (roughly 3 to 8 s; exact numbers and curve are yours, named constants). The
+  delay NEVER rides castRemaining/castTotal (they are broadcast per entity in dynamicFields;
+  a modified client could read the bite time): store it in hidden state and read the Pin-cost
+  appendix's storage-decision brief BEFORE choosing where. At the bite tick, emit a text-free
+  personal SimEvent (the fishingResult idiom) that drives the bobber VFX and cue, and arm a
+  server-authoritative reaction deadline in sim ticks (the lockpick stepDeadlineTick
+  precedent; the client never reports the timeout). Re-pressing the fishing pole inside the
+  window lands the catch through the existing completeFishing table draw; the re-press rides
+  the existing useItem dispatch (it lands in the current "You are busy" branch in
+  src/sim/items.ts useItem; the wire command census does not change). A miss is "it got
+  away": the cast ends, a personal line renders, recast immediately, no other loss.
+- Rod synergy: better rods (gatherToolTier over the fishing profession, composing with the
+  Phase 12 band gating) shorten the average bite delay and widen the reaction window; named
+  constants, pinned.
+- Server authority: bite timing, the deadline, and the catch resolve server-side; online the
+  client only sends the re-press command.
+
+Agent ui/render deliverables:
+- The gather cast bar label (the castDisplayName sentinel map in hud.ts and the castBarState
+  fishing flag in src/render/cast_bar.ts generalize over the shared predicate; a new
+  abilityUi.cast key for gathering, English-only).
+- Bobber bite feedback: a visible bite state on the fishing bobber VFX plus the cue, so the
+  moment is never sound-only (accessibility); the reaction window is attention, not
+  reflexes: generous by default.
+- Cue routing with PLACEHOLDER clips: gather cast/strike, a rare-strike variant keyed off
+  gatherResult rarity/rareEvent, fish cast, bite, reel. Placeholders are SANCTIONED:
+  deterministic local synthesis (scripts/sfx/ui_sfx.mjs cue() specs, ui_* keys), routed per
+  the src/game/CLAUDE.md recipe (the bite cue is timing/affordance so it rides the
+  always-audible play() arm, never playFeedback()), npm run sfx:manifest, npm run sfx:check
+  green, catalog rows marked PLACEHOLDER for the sound engineer, and issue #2208 references
+  them. No second cue on grant lines the loot hub already covers (the Phase 4 double-log
+  trap).
+- The /cast readout for fishing stays honest without leaking the bite time (see the appendix
+  row for the readout literal, its em-dash trap, and the status-registry coupling).
+- Every new player string is an English-only t() key; sim-origin lines ship their matcher
+  rule or ride text-free id events in the SAME change (fishing.ts and gathering.ts are on
+  the S3 scan list; the guard reds otherwise).
+
+Agent tests deliverables:
+- Execute the Pin-cost appendix: every listed pin is re-pinned deliberately, in its own
+  reviewed commit where the appendix says so (parity golden regens especially); nothing
+  outside the appendix list may weaken.
+- New coverage: the bite-delay draw contract (draw count per cast/miss/land/codfather as you
+  land them), the hidden-state invariant (the bite delay appears in NO wire snapshot field),
+  the deadline boundary (re-press at the deadline tick vs one past it), rod synergy arms,
+  gather cast duration arms (tool tier above requirement, band scaling, the floor),
+  completion re-validation arms (node respawned away, bags filled mid-cast, walked out of
+  range), a same-seed determinism pin for both loops, and a live GameServer round trip for
+  the bite-and-reel flow.
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Determinism: all randomness through Rng; the bite delay is ONE draw at a fixed position;
+  gather draws stay at completion in their existing order; deadlines derive from ticks,
+  never wall clock.
+- Anti-cheat: the bite delay and deadline are never readable from any broadcast field;
+  server authority for every outcome.
+- IWorld both worlds: any new read or command lands on a facet, implemented LIVE in BOTH
+  Sim and ClientWorld, parity-pinned in the same change (the 2033 stub trap).
+- i18n: English-only catalog keys; the S3 guard stays green (fishing.ts and gathering.ts
+  are on its scan list).
+- Fairness: the cast bar, bobber, and bite cue are graphics-preset-identical; the bite is
+  never sound-only.
+- Prime directive: nothing existing breaks. Every node, corpse pull, and catch reachable
+  before this phase stays reachable; the only change is WHEN the resolve happens and the
+  fishing wait becoming interactive. Tool effects/charges stay PARKED.
+
+Out of scope (do NOT do in this phase):
+- Tool effects, charges, recharge (parked, wave 2+).
+- AFK-style repeated-attempt loops or any auto-recast.
+- New fishing or gathering content (tables, nodes, items).
+- The corpse-harvest interaction (instant today, stays instant this phase).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+- npx tsc --noEmit; npx vitest run tests/professions_fishing.test.ts
+  tests/gather_node_harvest.test.ts tests/professions_gathering.test.ts
+  tests/gather_node_interact.test.ts tests/gather_open_gate.test.ts
+  tests/gather_node_online.test.ts tests/gather_rare_events.test.ts tests/sim.test.ts
+  tests/casting_command.test.ts tests/architecture.test.ts tests/sim_context.test.ts
+- Parity: npx vitest run tests/parity (regens ONLY per the appendix, each in its own
+  reviewed commit).
+- net/wire row: npx vitest run tests/snapshots.test.ts tests/env_protocol.test.ts
+  tests/bandwidth.test.ts tests/world_api_parity.test.ts
+- i18n row: npm run i18n:gen then npx vitest run tests/i18n_completeness.test.ts
+  tests/localization_fixes.test.ts
+- SFX: npm run sfx:manifest && npm run sfx:check
+- npm run ci:changed; scoped biome on touched files.
+Then spawn review agents per the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md (expect architecture-reviewer,
+cross-platform-sync, frontend-seam-reviewer, and qa-checklist to match). Prompt each for
+COVERAGE, not filtering. Resume truncated agents; never act on a truncated report.
+
+STEP 4 - COMMIT CADENCE (explicit paths, never git add -A, every commit carries a body):
+- refactor(sim): extract the shared non-spell-cast predicate
+- feat(professions): the gather cast bar
+- feat(professions): the fishing bite minigame
+- test(sim): re-pin the appendix set; regen the appendix goldens (own commit per regen)
+- feat(ui): cast labels, bobber bite feedback, placeholder cues
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] A node harvest runs a visible cast; duration responds to tool tier above the node
+      requirement and proficiency band, floored; completion re-validates range, respawn,
+      and capacity; moving cancels free.
+- [ ] All eleven exemption sites (plus the two new-cast joins) route through the shared
+      predicate; no site compares raw cast-id literals anymore.
+- [ ] Fishing draws the hidden bite delay exactly once per cast; the bite fires a text-free
+      personal SimEvent; the catch lands only on a pole re-press inside the
+      server-authoritative window; a miss costs nothing but the cast.
+- [ ] The bite delay appears in no broadcast wire field, pinned by test.
+- [ ] Rods shorten average bite delay and widen the window, pinned.
+- [ ] Every Pin-cost appendix row is executed exactly as briefed; no unlisted pin weakened.
+- [ ] Placeholder cues pass sfx:check, are marked PLACEHOLDER in the catalog, and #2208
+      lists them.
+- [ ] The validation rows above are green in both hosts.
+
+STEP 6 - DOC UPDATES + MEMORY:
+Update docs/professions-2/progress.md (status row, checklist, phase-start commit) and
+docs/professions-2/state.md (New surfaces per phase: the predicate name and its consumer
+count, GATHER_CAST_ID, the bite-state storage choice actually made and its golden
+consequence, the named timing constants into Tuning targets, the new i18n keys and cue
+keys). Record surprises to memory.
+
+STEP 7 - FINAL RESPONSE FORMAT:
+Phase status; files touched; validation results per command; review verdicts; the appendix
+execution report (each row: re-pinned as briefed / deviation with reason); deferrals; one
+line for the Phase 12b QA handoff naming the phase-start commit.
+
+STOPPING RULES:
+- Stop if the bite delay cannot stay hidden without a new broadcast field; that is a design
+  contradiction to surface, not a wire change to make.
+- Stop if any pin OUTSIDE the appendix list would need weakening; the appendix is the
+  complete pre-briefed cost, so an unlisted red means the design or the appendix is wrong.
+- Stop if Phase 12's rod bands cannot express the synergy without redesign.
+```
+
+## Pin-cost appendix (inventoried 2026-07-20 against release/v0.29.0, 35c85b312)
+
+Every test, literal, and golden this phase is EXPECTED to move, so the implementer re-pins
+deliberately instead of discovering the blast radius mid-flight. Anything outside this list
+that reds is a defect in the change, not an accepted cost.
+
+- `tests/professions_fishing.test.ts`, describe "fishing one-draw rng contract (pin 2)": the
+  one-draw-per-cast contract ("draws exactly one rng value per normal cast, including the
+  no-bite outcome") and its bags-full sibling re-pin to the new draw contract (the bite-delay
+  draw at startFishing plus the table draw at the reel). The codfather zero-draw pin
+  ("codfather branch: zero draws, ...") re-pins to whichever codfather handling lands (keeping
+  the codfather cast bite-roll-free preserves zero-draw; rolling unconditionally makes it one
+  draw; either is fine, pin what ships and note it in state.md).
+- Same file, describe "fishing determinism (pin 1)" and "fishing band selection liveness
+  (pin 6)": the band-0/band-1/band-2 LITERAL seed-4242 catch sequences and the 30-catch
+  same-seed pin re-record under the new draw order. TRAP (Phase 11 QA): a literal band
+  sequence is only decisive if it contains a draw inside a band-DISCRIMINATING window; hunt
+  the divergence index before sizing the new literals.
+- Same file, describe "startFishing arms through the extracted module path (pin 10)": the
+  "fixed 5 s cast and draws no rng" pin inverts (the cast start now draws the bite delay);
+  the five deny arms keep their exact error literals and must stay zero-draw-and-no-castStart.
+- Same file, describe "fishing over the live server (pin 8)": the live GameServer round trip
+  waits out the fixed 5 s cast wall-clock-ticked; its wait arithmetic changes under the bite
+  model (drive the bite deterministically by seed, do not sleep).
+- `tests/sim.test.ts`, inside describe "food, drink, vendor" (there is no fishing-named
+  describe): "starts a five-second fishing cast near and facing Mirror Lake" pins
+  castTotal/castRemaining at the FISHING_CAST_TIME literal, plus the "rolls the fishing catch
+  table only when the cast completes" and "rejects fishing away from fishable water"
+  siblings; all re-pin to the new cast shape.
+- The /cast readout: `castingReadout` in `src/sim/social/chat_readouts.ts` prints "You are
+  fishing" with remaining/total seconds, pinned LITERALLY in `tests/casting_command.test.ts`
+  ("special-cases the fishing sentinel"). Under the bite model the readout must stay honest
+  without leaking the bite time (e.g. no meaningful countdown during the waiting phase).
+  THREE coupled traps: (a) the current literal carries a grandfathered em dash exempted as a
+  v0.7 backstop via ALLOW_V07_SLASH in tests/localization_fixes.test.ts; any reword must drop
+  the em dash per the repo rule; (b) the readout is status-registry-backed English (not a t()
+  catalog key), so a reword updates src/ui/i18n.status.json via the scan, not a catalog; (c)
+  the localization_fixes probe substituter deliberately avoids desyncing the fishing/overpower
+  backstop forms that share "total/remaining"; keep that coupling intact.
+- Parity: `professions_gather` (tests/parity/scenarios.ts, golden
+  tests/parity/golden/professions_gather.json) snapshots immediately after SYNCHRONOUS
+  harvestNode calls; the gather cast defers draws and grants to completion, so this golden
+  REGENERATES and its HUNTED seed 3 (chosen for a rare-event window inside 100 harvests) must
+  be RE-HUNTED against the new drive shape. Own reviewed commit.
+- Parity: the two fishing-cancel scenarios (`c4a_casting_lifecycle`, snapshot label
+  "warlock-fishing-cancel", and `fiesta_midcast_kill`, label "midcast-fishcancel") BYPASS
+  startFishing (the drive assigns castingAbility/castRemaining/castTotal directly), so they
+  do NOT regen from the bite-delay draw; they only move if the cancel semantics or the
+  assigned fields change. Verify rather than regen; their checkpoint samples pin the
+  castTotal 5 shape the drive itself assigns.
+- Parity storage decision (make it EXPLICITLY, before coding): the digest harness
+  (tests/parity/trace.ts) samples entities and player meta through exclude lists then
+  canonicalizes with omitDefaults, so a new field ESCAPES all 56 goldens only while its value
+  is inert (0, false, '', null, empty array) at every sampled frame; {} is deliberately NOT
+  inert, and any nonzero sampled value (a stored bite tick, a pending node id) forces a full
+  56-golden regen (the Phase 8/9 precedent; deliberate, own commit). The alternatives: (a) a
+  PlayerMeta/Entity field that is nonzero only mid-cast and cleared after may stay inert at
+  every existing checkpoint, but any future scenario sampling mid-cast regens; (b) a
+  module-local pid-keyed map escapes the digest entirely but pins weaker (parity cannot see
+  desync in it) and needs its own cleanup discipline (player eviction); (c) extending
+  ENTITY_EXCLUDE/META_EXCLUDE is itself a re-pin (tests/parity/harness.test.ts pins exact
+  membership). Pick one, record the choice and its consequence in state.md.
+- `tests/gather_node_harvest.test.ts`: "a player near a node receives the material item on
+  harvest" (tolerates one tick today; a 2.5 s cast is ~50 ticks, so the drive changes), "a
+  harvest grants the matching gathering profession one point of skill", "spends exactly two
+  rng draws on a granted harvest and none on any denial path" (the pair moves to completion
+  time), and both gatherResult emission pins. `tests/professions_gathering.test.ts` "a queued
+  grant only takes effect once sim.tick() runs" survives (the queue mechanism is untouched).
+  The interact/deny/online arms in tests/gather_node_interact.test.ts,
+  tests/gather_open_gate.test.ts, and tests/gather_node_online.test.ts gate the new cast
+  start and re-validation; extend, do not orphan.
+- SimContext: a new completion callback (e.g. completeGatherCast) needs the five-site append
+  (interface, createSimContext passthrough, Sim binding, the two test stub hosts) plus the
+  pinned callback-name list in tests/sim_context.test.ts (the Phase 7 trap).
+- The wire: castRem/castTot ride dynamicFields only while castingAbility is set; the gather
+  cast reuses that shape for free. Do NOT add any bite field beside them.

--- a/docs/professions-2/phase-12b-qa.md
+++ b/docs/professions-2/phase-12b-qa.md
@@ -1,0 +1,97 @@
+# Phase 12b QA: Verify Gathering rhythm
+
+Audit the Phase 12b implementation (the gather cast, the fishing bite minigame, rod synergy,
+cue routing) for correctness, missing tests, dead code, determinism, three-host parity, i18n
+completeness, and, uniquely for this phase, faithful execution of the phase file's Pin-cost
+appendix.
+
+## QA Starter Prompt
+
+```
+This is Phase 12b QA of the Professions 2.0 feature: verify Gathering rhythm.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: audit the Phase 12b diff for correctness, missing tests, dead code, determinism,
+three-host parity, and i18n completeness, and verify every Pin-cost appendix row was executed
+as briefed, then fix what the audit finds.
+
+STEP 0 - PRE-FLIGHT:
+- Run git status; the checkout must be clean (a concurrent session may share it). Stop if
+  dirty with work you did not create.
+- Memory scan (MEMORY.md index): node25-breaks-jsdom-gate (gate under Node 24),
+  combo-recipes-broken-online (the 2033 stub trap), and the professions packet entries.
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize: docs/professions-2/state.md (the 2026-07-20
+amendments block and the Phase 12b surfaces entry), docs/professions-2/progress.md,
+docs/professions-2/phase-12b-gathering-rhythm.md INCLUDING the Pin-cost appendix verbatim,
+and the git diff against the phase-start commit recorded in progress.md Notes (plus
+--name-only for the file list). The summary must return: every deliverable and acceptance
+criterion, the appendix rows with their briefed dispositions, the bite-state storage choice
+the implementation actually made (and its recorded golden consequence), the shared
+predicate's name and consumer list, and the validation command set.
+
+STEP 2 - QA AUDIT (three parallel agents on the Explore summary; prompt each for COVERAGE,
+not filtering; resume truncated agents, never act on a truncated report):
+
+Correctness agent:
+- Verify every deliverable and acceptance criterion against the real code.
+- Run the phase's validation commands and record each result.
+- Exercise the REAL behavior in the offline sim: a bare gather cast at base speed, a faster
+  cast with a higher-tier tool, the floor, a cancel by moving, completion denial after the
+  node respawn state changes mid-cast and after bags fill mid-cast; a fishing cast through
+  bite and reel inside the window, a miss one tick past the deadline, an immediate recast,
+  rod synergy on both the delay and the window; the codfather branch as pinned.
+- Prove the anti-cheat invariant with a probe, not a read: walk every broadcast snapshot
+  field for a mid-cast angler (a live GameServer round trip) and show nothing correlates
+  with the bite tick; castRem/castTot must not count down to the bite.
+- Verify both hosts surface the same lines and cues (liveness, not member shape).
+
+Appendix-fidelity agent (this phase's special role):
+- Take the Pin-cost appendix row by row and verify each was executed exactly as briefed:
+  the re-pinned draw contracts, the re-recorded band literals (and that each new literal
+  contains a draw inside a band-DISCRIMINATING window), the sim.test and casting_command
+  re-pins, the readout reword traps (no em dash, status-registry update, the substituter
+  coupling intact), the professions_gather golden regen with a RE-HUNTED seed whose
+  rare-event window still fires, the two fishing-cancel parity scenarios verified-not-regened,
+  the bite-state storage decision recorded in state.md with its golden consequence, and the
+  five-site SimContext append with its pinned name list.
+- Any pin moved that the appendix does NOT list, or any appendix row skipped without a
+  recorded deviation, is a BLOCKING finding.
+
+Test coverage and cleanup agent:
+- Find untested paths: the deadline boundary tick, re-press outside the window, re-press
+  with the wrong item, simultaneous damage-cancel and bite, gather completion re-validation
+  arms, the hidden-state cleanup on player eviction (if the module-local map was chosen),
+  determinism (same seed, same bite and catch sequence).
+- Verify no orphaned pins from the old fixed-cast model survive; verify the placeholder cue
+  rows are marked PLACEHOLDER, pass sfx:check, and are all listed on issue #2208.
+- Dead code, sim purity (architecture.test.ts), unused imports, leftover debug.
+
+PHASE-SPECIFIC QA EMPHASIS:
+- The hidden bite delay: prove it is unreadable from the wire, not just untested.
+- The appendix contract: the phase promised a CLOSED set of re-pins; hold it to that.
+- Fairness and accessibility: the bite moment must be visible (bobber) as well as audible,
+  identical across graphics presets; the window generous.
+- Prime directive: everything gatherable/catchable before the phase remains so; only the
+  rhythm changed.
+
+Multi-agent review dispatch: apply the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md over the phase diff, plus qa-checklist (the
+phase-completion gate). Prompt each for COVERAGE, not filtering.
+
+STEP 3 - FIX: apply every BLOCKING and SHOULD-FIX finding; rerun the touched validation
+rows; commit with explicit paths (never git add -A), Conventional Commits with a body.
+
+STEP 4 - UPDATE DOCS + MEMORY: update docs/professions-2/progress.md (QA row and verdict)
+and state.md (drift found, storage-choice corrections); record surprises to memory.
+
+STEP 5 - FINAL RESPONSE FORMAT: verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; counts by
+severity, fixed vs deferred; the appendix-fidelity report; deferrals with reasons; a
+one-line handoff for the Phase 13 session.
+
+STOPPING RULES:
+- Stop if the audit finds the bite delay readable from any broadcast field; that is a
+  design breach, not a test gap.
+- Stop if fixing a finding would weaken a pin outside the appendix set.
+- Stop if the tree is dirty with work you did not create.
+```

--- a/docs/professions-2/phase-12b-qa.md
+++ b/docs/professions-2/phase-12b-qa.md
@@ -37,8 +37,9 @@ Correctness agent:
 - Verify every deliverable and acceptance criterion against the real code.
 - Run the phase's validation commands and record each result.
 - Exercise the REAL behavior in the offline sim: a bare gather cast at base speed, a faster
-  cast with a higher-tier tool, the floor, a cancel by moving, completion denial after the
-  node respawn state changes mid-cast and after bags fill mid-cast; a fishing cast through
+  cast with a higher-tier tool, a faster cast at a higher proficiency band, the floor, a
+  cancel by moving, completion denial after the node respawn state changes mid-cast, after
+  bags fill mid-cast, and after walking out of range mid-cast; a fishing cast through
   bite and reel inside the window, a miss one tick past the deadline, an immediate recast,
   rod synergy on both the delay and the window; the codfather branch as pinned.
 - Prove the anti-cheat invariant with a probe, not a read: walk every broadcast snapshot

--- a/docs/professions-2/phase-13-enchanting.md
+++ b/docs/professions-2/phase-13-enchanting.md
@@ -10,6 +10,13 @@ over finished sim surfaces, independent of the content phases around it. Salvage
 2026-07-17 amendment: this phase builds the exact machinery it needs, so obsolete crafted gear
 gets a wave-one destination instead of waiting for wave 2.
 
+The 2026-07-20 timing and economy amendments (state.md is the authority) grow the phase by a
+content half: TYPED disenchant reagents on a hybrid model (the universal rarity ladder stays;
+rare and above ALSO yield a type-keyed secondary material), every typed material shipping WITH
+at least one consumer recipe in the same phase (the wolf_fang no-dead-materials rule), and the
+bind-on-trade PRIMITIVE, landed here applied to those typed reagents as its first live consumer
+(never a dormant stub, the 2033 lesson) so Phase 14b can extend it to commissioned gear.
+
 ## Context pointers
 
 - `docs/professions-2/state.md`: locked decisions, the validation matrix, and the key-surfaces row
@@ -33,6 +40,17 @@ gets a wave-one destination instead of waiting for wave 2.
   toasts, i18n rules; the Phase 5 professions wheel window module for skill visibility.
 - Pins: `tests/world_api_parity.test.ts`, `tests/snapshots.test.ts` (`ALL_DELTA_KEYS` +
   `TERSE_TO_IWORLD`), `tests/professions_enchanting.test.ts`.
+- Typed-reagent anchors (the 2026-07-20 amendments): the universal ladder is
+  `DISENCHANT_MATERIAL_BY_QUALITY` in `src/sim/professions/enchanting.ts` (arcane_dust at
+  common/uncommon, arcane_essence at rare, arcane_shard at epic/legendary; note the shipped
+  two-tier enchant table with the shard-consuming Greater tier, #1950); the armor type key is
+  `ArmorType` (`'cloth' | 'leather' | 'mail'`, `src/sim/types.ts`); the weapon kind key is the
+  sim-side `WEAPON_TYPE_BY_ITEM` map (`src/sim/content/weapon_skin_rules.ts`,
+  `ItemWeaponType`). `ItemInstancePayload.boundTo` (`src/sim/types.ts`) persists and rides
+  trade payloads but NOTHING enforces it before this phase; the trade gate to extend is
+  `tradeSetOffer` in `src/sim/social/trade.ts` (today it drops only def-level
+  quest/soulbound slots). The heroic epic faucet for sink sizing is
+  `src/sim/content/heroic_loot.ts` (every heroic final boss drops TWO tradeable epics).
 
 ## Starter Prompt
 
@@ -41,7 +59,8 @@ This is Phase 13 of the Professions 2.0 feature: Enchanting reachable.
 Model: Opus 4.8, xhigh effort. Harness: Claude Code.
 Goal: make the finished enchanting and salvage sims (disenchant, enchant application, salvage)
 reachable by players in both hosts, from the bags UI through IWorld, the wire, and server
-dispatch.
+dispatch; and land the 2026-07-20 content half: typed disenchant reagents (hybrid model) with
+same-phase consumer recipes, plus the bind-on-trade primitive applied to those reagents.
 
 STEP 0 - PRE-FLIGHT:
 Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
@@ -92,6 +111,34 @@ Agent seam deliverables:
 - Update the parity pin in tests/world_api_parity.test.ts and the ALL_DELTA_KEYS +
   TERSE_TO_IWORLD pins in tests/snapshots.test.ts in the same change.
 
+Agent content deliverables (the 2026-07-20 typed-reagent amendments):
+- The HYBRID reagent model: the universal rarity ladder
+  (DISENCHANT_MATERIAL_BY_QUALITY: dust/essence/shard) stays exactly as shipped for every
+  quality; disenchanting a RARE OR ABOVE piece ADDITIONALLY yields one type-keyed secondary
+  material. Armor keys off the existing ArmorType (cloth/leather/mail: three materials);
+  weapons key off the sim-side weapon-kind taxonomy (WEAPON_TYPE_BY_ITEM /
+  ItemWeaponType), bucketed to a small material set (exact bucketing is yours EXCEPT
+  staves and wands, whose bucket assignment is a FLAGGED maintainer decision: surface it,
+  do not default it). Cooking and alchemy are deliberately excluded from the typed family
+  on both sides: their outputs never disenchant and their recipes are not the sanctioned
+  consumers.
+- NO DEAD MATERIALS (the wolf_fang rule): every typed material ships WITH at least one
+  consumer recipe in this same phase (enchanting recipes or deep-craft recipes consuming
+  it); a typed material with zero consumers is a blocking review finding, not a follow-up.
+- The bind-on-trade PRIMITIVE: the trade-gate enforcement arm that refuses to trade an
+  instance whose boundTo is already set (beside the def-level soulbound drop in
+  tradeSetOffer, with a localized deny id), plus the stamp-on-first-trade mechanism,
+  applied HERE to the typed rare+ reagents (they are minted as instances that bind to the
+  first trade recipient). This is the primitive's first LIVE consumer (never a dormant
+  stub, the 2033 lesson); Phase 14b extends the same primitive to commissioned gear, so
+  keep the enforcement arm and the stamp generic over the instance payload, never
+  reagent-specific.
+- Sink-sizing tuning note for state.md: the epic glut this phase drains has a measured
+  faucet: every heroic final boss drops TWO tradeable epics
+  (src/sim/content/heroic_loot.ts). Size the typed-reagent yields and the Greater-tier
+  shard costs against that faucet in the tuning targets; final numbers stay maintainer
+  calls.
+
 Agent ui deliverables:
 - Bags context action Disenchant, shown on eligible items only, behind a confirm dialog (this is
   destructive). A masterwork or signed instance gets an explicit stronger warning before
@@ -117,6 +164,11 @@ Agent tests deliverables:
 - UI tests: context-action eligibility, the confirm path, and the signed/masterwork warning
   path; pure view logic lands DOM-free and Node-tested per the UI pure-core rules.
 - Keep tests/professions_enchanting.test.ts green without weakening existing pins.
+- Typed-reagent arms (the 2026-07-20 amendments): the hybrid yield split at the rare
+  boundary (rare yields the secondary, uncommon does not), the ArmorType and weapon-kind
+  keying per bucket, the no-dead-materials referential pin (every typed material id has a
+  consumer recipe), and the bind-on-trade arms (first trade stamps, second trade refused,
+  deny id localized) offline and over a live GameServer.
 
 INVARIANTS THIS PHASE MUST KEEP:
 - Determinism: all sim randomness goes through Rng; never Math.random, Date.now, or
@@ -132,8 +184,11 @@ INVARIANTS THIS PHASE MUST KEEP:
 
 Out of scope (do NOT do in this phase):
 - Batch or salvage-all UI (wave 2 polish; single-item salvage only this phase).
-- Enchanting recipe or content depth.
+- Enchanting content depth BEYOND the typed reagents and their same-phase consumer recipes
+  (the 2026-07-20 amendment scopes those IN; anything past no-dead-materials stays out).
 - Tool-enchant reframing (wave 2+).
+- Commission binding of crafted gear (Phase 14b extends the primitive; this phase only
+  lands it against the typed reagents).
 
 STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
 - Run the state.md net/wire row: npx vitest run tests/snapshots.test.ts
@@ -169,6 +224,14 @@ STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
 - [ ] The new IWorld members are live in BOTH worlds; parity and snapshot pins updated in the
       same change.
 - [ ] The enchanting skill shows in the wheel window.
+- [ ] Rare+ disenchants yield the type-keyed secondary material beside the unchanged
+      universal ladder; sub-rare disenchants are byte-identical to today.
+- [ ] Every typed material has at least one consumer recipe in this phase, pinned by a
+      referential test (the wolf_fang rule).
+- [ ] The staves/wands bucket assignment is surfaced as a flagged maintainer decision, not
+      defaulted.
+- [ ] The bind-on-trade primitive is LIVE against the typed rare+ reagents: first trade
+      stamps boundTo, a second trade is refused with a localized deny id, both hosts.
 - [ ] All validation rows above are green; the mobile screenshot is committed.
 
 STEP 6 - DOC UPDATES + MEMORY: update docs/professions-2/progress.md (phase 13 checklist, status,

--- a/docs/professions-2/phase-13-qa.md
+++ b/docs/professions-2/phase-13-qa.md
@@ -75,7 +75,11 @@ PHASE-SPECIFIC QA EMPHASIS (probe these directly, not just by reading):
   boundTo), attempt the onward trade (refused, localized deny id, both hosts), and verify
   the enforcement arm is generic over the instance payload (Phase 14b extends it to gear:
   grep for reagent-specific conditionals in the gate and flag any). Verify mail and market
-  still refuse the instanced reagents (the face-to-face construction).
+  still refuse the instanced reagents (the face-to-face construction: the fungible-only
+  counting in the PostOffice mailSend/mailSendResolved paths and market.ts marketList).
+- The exclusions held: no cooking- or alchemy-keyed typed material exists, and no cooking
+  or alchemy recipe consumes a typed reagent (the deliberate both-sides exclusion); the
+  sink-sizing note landed in state.md's Tuning targets.
 
 STEP 3 - FIX: apply every BLOCKING and SHOULD-FIX finding; rerun the failed validation rows
 until green; commit with explicit paths (never git add -A), Conventional Commits with a body.

--- a/docs/professions-2/phase-13-qa.md
+++ b/docs/professions-2/phase-13-qa.md
@@ -1,7 +1,9 @@
 # Phase 13 QA: Verify Enchanting reachable
 
 Audits the Phase 13 diff: enchanting AND salvage reachable in both hosts, replay-safe
-destruction, live `ClientWorld` result mirroring, and complete tests and i18n for this phase.
+destruction, live `ClientWorld` result mirroring, complete tests and i18n for this phase, plus
+the 2026-07-20 content half (typed disenchant reagents with same-phase consumers, and the
+bind-on-trade primitive live against them).
 
 ## QA Starter Prompt
 
@@ -63,6 +65,17 @@ PHASE-SPECIFIC QA EMPHASIS (probe these directly, not just by reading):
 - Prime directive spot check: no existing bags, trade, equip, or bank flow changed behavior
   unless the player invokes the new actions; salvage carries the same replay-safety and
   warning guarantees as disenchant (probe it with the same duplicate/race protocol).
+- Typed reagents (the 2026-07-20 amendments): disenchant a rare and an uncommon of EACH
+  armor type and at least one weapon per bucket; prove the hybrid split (secondary at rare+,
+  none below) and that a sub-rare disenchant is byte-identical to pre-phase output. Run the
+  no-dead-materials referential pin and mutation-check it (a typed material stripped of its
+  consumer must red). Confirm the staves/wands bucket was flagged to the maintainer, not
+  silently defaulted (check state.md OPEN items or the resolved decision row).
+- Bind-on-trade, probed live: trade a typed rare+ reagent to a second player (stamps
+  boundTo), attempt the onward trade (refused, localized deny id, both hosts), and verify
+  the enforcement arm is generic over the instance payload (Phase 14b extends it to gear:
+  grep for reagent-specific conditionals in the gate and flag any). Verify mail and market
+  still refuse the instanced reagents (the face-to-face construction).
 
 STEP 3 - FIX: apply every BLOCKING and SHOULD-FIX finding; rerun the failed validation rows
 until green; commit with explicit paths (never git add -A), Conventional Commits with a body.

--- a/docs/professions-2/phase-14-attunement-quests.md
+++ b/docs/professions-2/phase-14-attunement-quests.md
@@ -131,9 +131,10 @@ Agent ui deliverables:
   re-localizes through the sim_i18n matcher; the deed hook is left for Phase 15.
 - The "learnable at a master" hint row (the 2026-07-20 amendment): the crafting window,
   which lists known recipes only since Phase 9, gains one discoverability line per craft
-  section telling the player MORE recipes are taught at that craft's master (resolve the
-  master and station via the shared train_view.ts viewer predicates and
-  stationTypeForCraft; never a second knownness rule). Untrained ladders exist but are
+  section telling the player MORE recipes are taught at that craft's master (resolve
+  knownness via the shared train_view.ts viewer predicates and the station via the
+  sim-side stationTypeForCraft in src/sim/professions/stations.ts; never a second
+  knownness rule). Untrained ladders exist but are
   invisible today; this row routes players to them. Today's tokens, English-only t() key,
   both hosts, graphics-preset-identical; render it only when the viewer actually has
   unlearned trainer recipes for that craft (no noise for a fully-trained craft).

--- a/docs/professions-2/phase-14-attunement-quests.md
+++ b/docs/professions-2/phase-14-attunement-quests.md
@@ -5,7 +5,11 @@ all four wave-one archetypes, honest switching costs through repeatable make-ame
 masters' recurring pull (cadence-capped work-order quests and tier-crossing congratulation
 mail, the 2026-07-17 amendment), and
 the legibility layer (trend nudges that complete #1295, a pre-commit preview that explains
-everything, and the attunement celebration). It is its own slice because it is the first phase
+everything, and the attunement celebration). The 2026-07-20 amendments add one more legibility
+row: the crafting window gains a "learnable at a master" discoverability hint, because the
+Phase 9 known-recipes-only filter made the untrained ladders invisible from the window players
+actually live in, and the phase that makes masters prominent is the right one to route players
+to them. It is its own slice because it is the first phase
 where the PR 2039 quest machinery, the Phase 7 trend classifier, and the Phase 8 masters meet in
 player-facing content: every hook it fills already exists, and nothing later depends on it except
 the Phase 15 deed pass.
@@ -125,6 +129,14 @@ Agent ui deliverables:
   picture (majors, hobby, dormancy, return cost) is visible pre-commit in both hosts.
 - Attunement celebration: banner plus title grant plus an id-based zone broadcast that
   re-localizes through the sim_i18n matcher; the deed hook is left for Phase 15.
+- The "learnable at a master" hint row (the 2026-07-20 amendment): the crafting window,
+  which lists known recipes only since Phase 9, gains one discoverability line per craft
+  section telling the player MORE recipes are taught at that craft's master (resolve the
+  master and station via the shared train_view.ts viewer predicates and
+  stationTypeForCraft; never a second knownness rule). Untrained ladders exist but are
+  invisible today; this row routes players to them. Today's tokens, English-only t() key,
+  both hosts, graphics-preset-identical; render it only when the viewer actually has
+  unlearned trainer recipes for that craft (no noise for a fully-trained craft).
 
 Agent tests deliverables:
 - Extend tests/profession_attunement_quests.test.ts and tests/prof_intro_quest.test.ts:
@@ -206,6 +218,9 @@ STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
 - [ ] Crossing a major-craft tier delivers exactly one congratulation mail from the
       archetype's master; re-crossings, hobby crossings, and unattuned characters deliver
       none.
+- [ ] The crafting window shows the "learnable at a master" hint exactly when the viewer
+      has unlearned trainer recipes for that craft, naming the right master or station, in
+      both hosts, through the shared viewer predicates.
 - [ ] q_archetype_acceptance and q_prof_make_amends are fully retired: no content rows,
       i18n keys, locale fills, tests, or questIds references remain.
 - [ ] Players attuned via 2039's intro quest keep their state; mid-quest placeholder

--- a/docs/professions-2/phase-14-qa.md
+++ b/docs/professions-2/phase-14-qa.md
@@ -26,7 +26,9 @@ Spawn an Explore agent to read and summarize:
 - the git diff against the Phase 14 start commit recorded in progress.md Notes
   (git diff <phase-start>..HEAD, plus --name-only for the file list)
 The summary must return: every deliverable and acceptance criterion, the full list of files
-touched, the STEP 3 validation command set from the phase file, and any deferrals the
+touched, the STEP 3 validation command set from the phase file, every row of the
+"Phase-specific QA emphasis" section at the bottom of THIS file (the audit agents receive
+only the summary, so the emphasis rows must ride in it), and any deferrals the
 implementation session recorded.
 
 STEP 2 - QA AUDIT:
@@ -48,7 +50,9 @@ Agent Correctness deliverables:
   character through nudge, master, lore quest, attunement, one cheap switch, and an
   escalating amends repeat; confirm selection validation rejects a pair outside the
   whitelist and that outcomes resolve server-side online.
-- Probe the phase-specific emphasis list:
+- Probe the phase-specific emphasis list (INCLUDING every row of the "Phase-specific QA
+  emphasis" section at the bottom of this file: the work orders, the tier-crossing mail,
+  and the learnable-at-a-master hint):
   - Quest availability matrix: at each of the four masters, verify offer/deny in every
     identity state (unattuned, attuned to the matching pair, attuned to a wrong pair,
     mid-quest, repeat make-amends), in both hosts.
@@ -95,7 +99,9 @@ recorded there. Record surprises to Claude Code memory.
 STEP 5 - FINAL RESPONSE FORMAT:
 Verdict: PASS / PASS-WITH-FOLLOWUPS / FAIL. Counts: findings by severity, findings fixed,
 tests added, tests removed. Deferrals with issue links. Validation results (each command,
-pass or fail). One line handoff for Phase 15 (deed hook location and any tuning notes).
+pass or fail). One line handoff for Phase 14b (Commissions and the Maker's Bond follows
+Phase 14 in the restructured order; pass along the deed hook location and any tuning notes
+for Phase 15 as well).
 
 STOPPING RULES:
 - Stop if the audit finds that 2039's selection whitelist cannot express a quest's target
@@ -121,6 +127,7 @@ STOPPING RULES:
   unattuned characters, and repeated loads deliver none.
 - The "learnable at a master" hint (the 2026-07-20 amendment): shown exactly when the
   viewer has unlearned trainer recipes for the craft, absent for a fully-trained craft,
-  naming the master via the shared train_view.ts predicates (grep the hint's data source:
-  a second knownness rule beside isRecipeKnownForViewer is a finding); identical offline
-  and online, and across graphics presets.
+  naming the right master or station (the master via the shared train_view.ts predicates,
+  the station via the sim-side stationTypeForCraft; a second knownness rule beside
+  isRecipeKnownForViewer is a finding); identical offline and online, and across graphics
+  presets.

--- a/docs/professions-2/phase-14-qa.md
+++ b/docs/professions-2/phase-14-qa.md
@@ -119,3 +119,8 @@ STOPPING RULES:
 - Tier-crossing mail (the 2026-07-17 amendment): exactly one letter per tier per major
   craft, from the archetype's anchor master; re-crossings, hobby and dormant crossings,
   unattuned characters, and repeated loads deliver none.
+- The "learnable at a master" hint (the 2026-07-20 amendment): shown exactly when the
+  viewer has unlearned trainer recipes for the craft, absent for a fully-trained craft,
+  naming the master via the shared train_view.ts predicates (grep the hint's data source:
+  a second knownness rule beside isRecipeKnownForViewer is a finding); identical offline
+  and online, and across graphics presets.

--- a/docs/professions-2/phase-14b-commissions-binding.md
+++ b/docs/professions-2/phase-14b-commissions-binding.md
@@ -27,10 +27,11 @@ which links #1298.
 - `src/sim/social/trade.ts`: `tradeSetOffer` (the def-level gate that silently drops quest and
   soulbound slots; instance-aware counting via ctx.countItem) and the two-phase
   `tradeConfirm` (removeOffer both sides then grantOffer both sides, the Phase 3 QA fix).
-- `src/sim/mail/post_office.ts` (`sendMail`: attachments validate against countFungibleItem,
-  so instances never mail) and `src/sim/market.ts` (`marketList`: same fungible-only rule,
-  the #1146 wave-2 note). These make first delivery face-to-face BY CONSTRUCTION; verify, do
-  not rebuild.
+- `src/sim/mail/post_office.ts` (the PostOffice `mailSend` / `mailSendResolved` paths:
+  attachments validate against countFungibleItem, so instances never mail) and
+  `src/sim/market.ts` (`marketList`: same fungible-only rule; real instance carriage is the
+  closed #1146's scope, re-homed to a named follow-up when picked up). These make first
+  delivery face-to-face BY CONSTRUCTION; verify, do not rebuild.
 - `src/sim/professions/training.ts`: `TRAINING_FEE_BY_TIER` and the `resolveTrain` deny-order
   shape, the master gold-sink service precedent the unbind service follows.
 - `src/sim/professions/crafting.ts` and `masterwork.ts`: the craft resolver the commission
@@ -70,7 +71,8 @@ STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
 Spawn one Explore agent to read and summarize: docs/professions-2/state.md (the 2026-07-20
 amendments block, the resolved decision rows, the Phase 13 surfaces entry),
 docs/professions-2/progress.md, this phase file, src/sim/social/trade.ts (tradeSetOffer and
-the two-phase tradeConfirm), src/sim/mail/post_office.ts sendMail and src/sim/market.ts
+the two-phase tradeConfirm), the PostOffice mailSend/mailSendResolved paths in
+src/sim/mail/post_office.ts and src/sim/market.ts
 marketList (the fungible-only refusals), src/sim/types.ts ItemInstancePayload,
 src/sim/professions/training.ts (the fee and deny-order precedent), the Phase 13 bind-on-trade
 enforcement arm as landed, src/sim/professions/crafting.ts, server/game.ts dispatch, and the
@@ -146,7 +148,8 @@ Out of scope (do NOT do in this phase):
 - The commission ORDER workflow (open/accept/deliver/cancel UI and state; #1298 stays open
   for it).
 - Recipient-tied required materials (needs order-time escrow, per #1298's notes).
-- Market surfacing of boundTo (#1146, wave 2).
+- Market surfacing of boundTo and instance carriage (the closed #1146's scope; re-homes to a
+  named follow-up when picked up, wave 2).
 - Any binding of NON-commission output (opt-in only).
 
 STEP 3 - VALIDATION + MULTI-AGENT REVIEW:

--- a/docs/professions-2/phase-14b-commissions-binding.md
+++ b/docs/professions-2/phase-14b-commissions-binding.md
@@ -1,0 +1,202 @@
+# Phase 14b: Commissions and the Maker's Bond
+
+Crafted goods gain a way to be made FOR someone. An opt-in commission craft binds to its
+recipient on FIRST trade: the crafter hands the piece over face to face, the trade gate stamps
+`boundTo`, and from then on the same gate that blocks def-level soulbound items refuses to pass
+it on; a master NPC unbinds for gold. This resolves the enforcement semantics #1298 left open
+(the full commission ORDER workflow, open/accept/deliver, stays layered on top later) and gives
+the bind-on-trade primitive Phase 13 lands (first applied to the typed disenchant reagents) its
+second consumer. It is its own slice because it is a small, sharply bounded trade-gate and
+service change over surfaces that all exist: `boundTo` already persists and rides trade
+payloads, mail and the market already refuse instanced items (so first delivery is
+face-to-face by construction), and the masters already run gold-sink services. Approved by the
+2026-07-20 timing and economy amendments (state.md is the authority); tracked as issue #2207,
+which links #1298.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: the 2026-07-20 timing and economy amendments block (the
+  authority), the OPEN items rows for this phase's three flagged maintainer decisions, and the
+  locked economy pillars (crafted below the raid floor; NPCs only sink gold).
+- `docs/professions-2/progress.md`: the Phase 14b status row and checklist.
+- `docs/professions-2/phase-13-enchanting.md`: the bind-on-trade PRIMITIVE this phase extends
+  (landed there against the typed disenchant reagents; never re-implement it).
+- `src/sim/types.ts`: `ItemInstancePayload.boundTo` (persists in saves via the inventory
+  clone path, pinned by tests/bank.test.ts and tests/item_instance.test.ts; rides trade
+  payloads intact, pinned in tests/trade.test.ts; NOTHING enforces it before Phase 13).
+- `src/sim/social/trade.ts`: `tradeSetOffer` (the def-level gate that silently drops quest and
+  soulbound slots; instance-aware counting via ctx.countItem) and the two-phase
+  `tradeConfirm` (removeOffer both sides then grantOffer both sides, the Phase 3 QA fix).
+- `src/sim/mail/post_office.ts` (`sendMail`: attachments validate against countFungibleItem,
+  so instances never mail) and `src/sim/market.ts` (`marketList`: same fungible-only rule,
+  the #1146 wave-2 note). These make first delivery face-to-face BY CONSTRUCTION; verify, do
+  not rebuild.
+- `src/sim/professions/training.ts`: `TRAINING_FEE_BY_TIER` and the `resolveTrain` deny-order
+  shape, the master gold-sink service precedent the unbind service follows.
+- `src/sim/professions/crafting.ts` and `masterwork.ts`: the craft resolver the commission
+  opt-in joins; the maker's mark (signer) and masterwork markers the bond composes with.
+- `server/game.ts`: command dispatch (the unbind command re-validates server-side).
+- The armory/identity wire strips instance payloads including boundTo (server/game.ts, pinned
+  in tests/snapshots.test.ts): keep that data-minimization intact.
+- Local conventions: `src/sim/CLAUDE.md`, `src/sim/professions/CLAUDE.md`, `src/ui/CLAUDE.md`,
+  `tests/CLAUDE.md`.
+
+## Starter Prompt
+
+```
+This is Phase 14b of the Professions 2.0 feature: Commissions and the Maker's Bond.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: opt-in commission crafts that bind to the recipient on first trade, enforced in the
+trade gate beside the def-level soulbound rule, with a master unbind service as a gold sink.
+
+STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
+- Run git status; the checkout must be clean. Record the phase-start commit in
+  docs/professions-2/progress.md Notes.
+- Memory scan (MEMORY.md index): node25-breaks-jsdom-gate, combo-recipes-broken-online (the
+  2033 stub trap), design-language-program, the professions packet entries.
+- THE THREE FLAGGED MAINTAINER DECISIONS MUST BE RESOLVED IN STATE.MD BEFORE CODING:
+  character-vs-account binding, which item classes may opt in, and unbind pricing. If any is
+  still an OPEN item, stop and ask; never decide them silently (they are flagged, not
+  defaulted).
+- Phase 13 must be LANDED (it owns the bind-on-trade primitive). Verify its trade-gate arm
+  exists (grep the enforcement site it recorded in state.md); if absent, stop.
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize: docs/professions-2/state.md (the 2026-07-20
+amendments block, the resolved decision rows, the Phase 13 surfaces entry),
+docs/professions-2/progress.md, this phase file, src/sim/social/trade.ts (tradeSetOffer and
+the two-phase tradeConfirm), src/sim/mail/post_office.ts sendMail and src/sim/market.ts
+marketList (the fungible-only refusals), src/sim/types.ts ItemInstancePayload,
+src/sim/professions/training.ts (the fee and deny-order precedent), the Phase 13 bind-on-trade
+enforcement arm as landed, src/sim/professions/crafting.ts, server/game.ts dispatch, and the
+CLAUDE.md files for sim, professions, ui, server, and tests. The summary must return: the
+exact trade-gate shape and where the def-level soulbound check sits, the Phase 13 primitive's
+symbols and pins, how boundTo persists and travels today, the master service dispatch
+pattern, and the three resolved maintainer decisions verbatim.
+
+STEP 2 - CHOOSE ORCHESTRATION + EXECUTE: sim agent first (opt-in + gate arm + unbind),
+then ui and tests agents in parallel against the landed seam.
+
+Agent sim deliverables:
+- Commission opt-in at craft time: an explicit flag on the craft command (facet + wire; the
+  crafting window sends it only when the player chose it) stamping the output instance with
+  the commission marker (an additive ItemInstancePayload field or the Phase 13 shape,
+  whichever the primitive established; never a parallel mechanism).
+- Bind on first trade: when a commissioned, not-yet-bound instance transfers through
+  tradeConfirm, stamp boundTo = the receiving character per the resolved binding-scope
+  decision. The refusal arm for an ALREADY-bound instance rides the Phase 13 primitive in
+  tradeSetOffer, beside the def-level soulbound drop, with a localized deny id (never a
+  silent drop for this case: the player must learn WHY, unlike the legacy silent soulbound
+  skip; if you make the soulbound skip loud too, that is a separate deliberate decision, do
+  not bundle it).
+- The bound holder can still equip, use, bank, and vendor the piece per the resolved
+  decisions; only onward TRADE is refused (and mail/market were never possible for
+  instances; verify with a pin, do not rebuild).
+- Master unbind service: a command on the station masters (the resolveTrain shape: pure
+  resolver, deny order, fee charged exactly once on success, server-validated, replay-safe),
+  clearing boundTo for the resolved price. Gold sink only; no item mutation beyond the field
+  clear; signer and masterwork markers survive unbind, pinned.
+- Save/load: the new marker is additive JSONB with normalize-on-load defaults; old saves
+  load clean; the rollback caveat (old code strips unknown instance fields on round trip)
+  is recorded in state.md if it applies (the mailWelcomed class).
+
+Agent ui deliverables:
+- The commission opt-in control in the crafting window (off by default, per-craft, today's
+  tokens; visible only for the opted-in item classes per the resolved decision).
+- Tooltip lines: commissioned-unbound ("Commission piece: binds to the first recipient") and
+  bound ("Bound to {name}") on the item-instance tooltip module
+  (src/ui/item_instance_tooltip.ts composes with the seal and maker's mark lines).
+- The unbind dialog at the master (vendor/train window family), showing the fee before
+  confirm; deny toasts localized.
+- Every player string is an English-only t() key; trade/unbind deny ids ship their render
+  keys in the SAME change (text-free id events, the craftResult/trainResult precedent).
+
+Agent tests deliverables:
+- Gate arms: first trade stamps the right character; the second trade is refused with the
+  deny id; a non-commission instance is untouched; unbind restores tradeability; re-binding
+  on the next trade after unbind (per the resolved semantics); replay/duplicate safety on
+  the unbind fee.
+- Persistence: the marker and boundTo survive save/load and the trade payload round trip
+  (extend tests/trade.test.ts and tests/item_instance.test.ts pins).
+- The mail/market face-to-face construction pin: a commissioned instance cannot be mailed
+  or listed (assert the EXISTING refusal covers it; if either path has a fungible-count
+  hole for the new marker, that is a finding, not a new system).
+- Both hosts: the live GameServer trade round trip with the bound refusal, and the
+  ClientWorld mirror of whatever read the UI consumes (LIVE, the 2033 stub trap).
+- A same-seed determinism pin if any new sim state affects the tick.
+
+INVARIANTS THIS PHASE MUST KEEP:
+- The locked pillars: crafted power below the raid floor (binding is a trade rule, never a
+  stat change); masterwork stays the celebrated ceiling; NPCs only sink gold.
+- Server authority: the stamp, the refusal, and the unbind resolve server-side; the client
+  never decides.
+- Determinism: no new rng; no wall-clock anywhere in sim logic.
+- IWorld both worlds, parity-pinned, live.
+- i18n: English-only keys; stable deny ids; the S3 guard green.
+- Prime directive: nothing existing breaks. Non-commission trades are byte-identical; the
+  standing wire invariant holds (no wire command ingests a client-supplied
+  ItemInstancePayload; the stamp is minted server-side).
+
+Out of scope (do NOT do in this phase):
+- The commission ORDER workflow (open/accept/deliver/cancel UI and state; #1298 stays open
+  for it).
+- Recipient-tied required materials (needs order-time escrow, per #1298's notes).
+- Market surfacing of boundTo (#1146, wave 2).
+- Any binding of NON-commission output (opt-in only).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+- npx tsc --noEmit; npx vitest run tests/trade.test.ts tests/item_instance.test.ts
+  tests/bank.test.ts tests/professions_crafting.test.ts tests/architecture.test.ts plus
+  every new suite.
+- net/wire row: npx vitest run tests/snapshots.test.ts tests/env_protocol.test.ts
+  tests/bandwidth.test.ts tests/world_api_parity.test.ts.
+- i18n row: npm run i18n:gen then npx vitest run tests/i18n_completeness.test.ts
+  tests/localization_fixes.test.ts.
+- ui/render row: the mobile guard trio plus a screenshot of the opt-in control and the
+  bound tooltip (pr-screenshots skill) under docs/screenshots.
+- npm run ci:changed; scoped biome on touched files.
+Then spawn review agents per the Review Dispatch Matrix (expect cross-platform-sync,
+architecture-reviewer, privacy-security-review for the trade/server surface,
+frontend-seam-reviewer, and qa-checklist). COVERAGE, not filtering; resume truncated
+agents.
+
+STEP 4 - COMMIT CADENCE (explicit paths, bodies, Conventional Commits):
+- feat(professions): commission opt-in and the maker's bond stamp
+- feat(professions): bind-on-first-trade enforcement and the master unbind service
+- feat(ui): commission control, bound tooltips, unbind dialog
+- test(sim): gate arms, persistence, and live-server coverage
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] A crafter opts a craft into commission mode; the instance carries the marker in both
+      hosts; non-opted crafts are byte-identical to today.
+- [ ] The first successful trade stamps boundTo per the resolved binding scope; a second
+      trade is refused with a localized deny id in both hosts.
+- [ ] A commissioned instance cannot be mailed or market-listed (existing refusals pinned
+      against the new marker).
+- [ ] The master unbind service charges the resolved fee exactly once, replay-safe, and
+      restores tradeability; signer and masterwork markers survive.
+- [ ] The three maintainer decisions are implemented exactly as resolved in state.md and
+      surfaced in the PR body.
+- [ ] Save/load and trade payload round trips carry the new field; old saves load clean.
+- [ ] All validation rows green; screenshots committed.
+
+STEP 6 - DOC UPDATES + MEMORY: update progress.md (status row, checklist, phase-start
+commit) and state.md (New surfaces: the marker field, the deny ids, the unbind command and
+fee constant, the i18n namespaces; any rollback caveat). Record surprises to memory.
+
+STEP 7 - FINAL RESPONSE FORMAT: phase status; files touched; validation results; review
+verdicts; deferrals; one line for the Phase 14b QA handoff naming the phase-start commit.
+
+STOPPING RULES:
+- Stop if any of the three flagged maintainer decisions is unresolved in state.md; never
+  default them.
+- Stop if the Phase 13 primitive did not land or landed with a shape this phase cannot
+  extend without redesign.
+- Stop if enforcing the bond would require making the legacy silent soulbound drop loud as
+  a side effect; surface that as its own decision.
+```

--- a/docs/professions-2/phase-14b-qa.md
+++ b/docs/professions-2/phase-14b-qa.md
@@ -1,0 +1,89 @@
+# Phase 14b QA: Verify Commissions and the Maker's Bond
+
+Audit the Phase 14b diff (commission opt-in, bind on first trade, the master unbind service)
+for correctness, missing tests, dead code, determinism, three-host parity, and i18n
+completeness, with special weight on trade-gate abuse paths and the flagged maintainer
+decisions having been implemented exactly as resolved.
+
+## QA Starter Prompt
+
+```
+This is Phase 14b QA of the Professions 2.0 feature: verify Commissions and the Maker's Bond.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: audit the Phase 14b diff for correctness, missing tests, dead code, determinism,
+three-host parity, and i18n completeness, then fix what the audit finds.
+
+STEP 0 - PRE-FLIGHT:
+- Run git status; the checkout must be clean; stop if dirty with work you did not create.
+- Memory scan (MEMORY.md index): node25-breaks-jsdom-gate, combo-recipes-broken-online (the
+  2033 stub trap), the professions packet entries.
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly):
+Spawn one Explore agent to read and summarize: docs/professions-2/state.md (the 2026-07-20
+amendments block, the three resolved decisions, the Phase 13 and 14b surfaces entries),
+docs/professions-2/progress.md, docs/professions-2/phase-14b-commissions-binding.md, and
+the git diff against the phase-start commit in progress.md Notes. The summary must return:
+every deliverable and acceptance criterion, the marker field and deny ids as landed, the
+unbind command and fee constant, the three resolved maintainer decisions verbatim, and the
+validation command set.
+
+STEP 2 - QA AUDIT (three parallel agents on the Explore summary; COVERAGE, not filtering;
+resume truncated agents):
+
+Correctness agent:
+- Verify every deliverable and acceptance criterion against the real code.
+- Run the phase's validation commands and record results.
+- Exercise the REAL behavior offline and over a live GameServer: opt-in craft, first trade
+  stamps, second trade refused with the localized line, unbind at the master for the exact
+  fee, tradeable again, signer and masterwork intact throughout.
+- Abuse probes (drive them, do not read them): replay/duplicate the unbind command (one fee,
+  one clear); race the first trade against a concurrent trade of the same instance; a
+  crafted-then-banked-then-traded piece; vendor sell and buyback of a bound piece (buyback
+  re-grants a plain copy today, pre-existing: confirm no NEW hole); trade the piece back to
+  the crafter (per the resolved semantics); a mixed offer of bound and unbound copies of the
+  same itemId (the Phase 3 same-itemId cross-contamination class: prove slot-accurate
+  refusal).
+- Verify the three maintainer decisions were implemented exactly as state.md resolved them,
+  not defaulted.
+
+Test coverage agent:
+- Find untested arms: every deny path, unbind of a never-bound piece, the mail/market
+  refusal pinned against the new marker, ClientWorld liveness for whatever read the UI
+  consumes, save/load with and without the marker, the rollback caveat pin if state.md
+  recorded one.
+- Verify pins are decisive (mutation-check the gate arm: flipping the enforcement off must
+  red a test).
+
+Dead code and cleanup agent:
+- Unused imports/types, sim purity, no wall-clock, no leftover debug.
+- Verify the standing wire invariant: no wire command ingests a client-supplied
+  ItemInstancePayload (the stamp is server-minted); the armory/identity wire still strips
+  boundTo.
+
+PHASE-SPECIFIC QA EMPHASIS:
+- The trade gate is the security surface: every refusal must be server-side; a hand-crafted
+  client command must not skip the stamp or the refusal.
+- The legacy silent soulbound drop must be behaviorally unchanged unless state.md records a
+  deliberate decision otherwise.
+- Prime directive: non-commission trades are byte-identical to pre-phase behavior, pinned.
+
+Multi-agent review dispatch: apply the Review Dispatch Matrix in
+docs/professions-2/implementation-plan.md over the phase diff (privacy-security-review
+matches: trade/server surface), plus qa-checklist. COVERAGE, not filtering.
+
+STEP 3 - FIX: apply every BLOCKING and SHOULD-FIX finding; rerun touched rows; commit with
+explicit paths, Conventional Commits with a body.
+
+STEP 4 - UPDATE DOCS + MEMORY: progress.md QA row and verdict; state.md drift corrections;
+memory for surprises.
+
+STEP 5 - FINAL RESPONSE FORMAT: verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; counts by
+severity, fixed vs deferred; deferrals with reasons; a one-line handoff for the Phase 15
+session (Phase 15's burn-down and SFX sweep close the packet).
+
+STOPPING RULES:
+- Stop if any abuse probe lands a bound item in another player's hands without the unbind
+  service; that is a BLOCKING security finding to fix, not to document.
+- Stop if a fix would require changing one of the three resolved maintainer decisions.
+- Stop if the tree is dirty with work you did not create.
+```

--- a/docs/professions-2/phase-14b-qa.md
+++ b/docs/professions-2/phase-14b-qa.md
@@ -38,10 +38,12 @@ Correctness agent:
   fee, tradeable again, signer and masterwork intact throughout.
 - Abuse probes (drive them, do not read them): replay/duplicate the unbind command (one fee,
   one clear); race the first trade against a concurrent trade of the same instance; a
-  crafted-then-banked-then-traded piece; vendor sell and buyback of a bound piece (buyback
+  crafted-then-banked-then-traded piece; the bound holder equipping and using the piece
+  (binding restricts onward trade only); vendor sell and buyback of a bound piece (buyback
   re-grants a plain copy today, pre-existing: confirm no NEW hole); trade the piece back to
-  the crafter (per the resolved semantics); a mixed offer of bound and unbound copies of the
-  same itemId (the Phase 3 same-itemId cross-contamination class: prove slot-accurate
+  the crafter (per the resolved semantics); after an unbind, the NEXT trade re-binding to
+  its new recipient per the resolved semantics; a mixed offer of bound and unbound copies of
+  the same itemId (the Phase 3 same-itemId cross-contamination class: prove slot-accurate
   refusal).
 - Verify the three maintainer decisions were implemented exactly as state.md resolved them,
   not defaulted.

--- a/docs/professions-2/phase-15-deeds-polish.md
+++ b/docs/professions-2/phase-15-deeds-polish.md
@@ -171,7 +171,8 @@ INVARIANTS THIS PHASE MUST KEEP:
   ItemDef players may hold; no hand-edits to generated files.
 
 Out of scope (do NOT do in this phase):
-- Anything wave 2: market/mail instance carriage (#1146), the commission ORDER workflow
+- Anything wave 2: market/mail instance carriage (the closed #1146's scope, re-homed to a
+  named follow-up when picked up), the commission ORDER workflow
   (#1298; the binding primitive and the Maker's Bond landed in Phases 13 and 14b),
   Jack of All Trades (#1296), monster-harvest proficiency, batch salvage UI (single-item
   salvage landed in Phase 13), battlefield experience

--- a/docs/professions-2/phase-15-deeds-polish.md
+++ b/docs/professions-2/phase-15-deeds-polish.md
@@ -4,7 +4,11 @@ This phase closes the Professions 2.0 packet. It registers the basic universal p
 (cosmetic only, per the locked decision in `state.md`), replaces the placeholder tuning targets
 with the maintainer's final numbers in named constants, rewrites the `/wiki` professions page so
 the guide describes the system that actually shipped, finishes the `asset-manifest.json` designer
-handoff, and then runs the whole-feature QA matrix plus the release gate. It is its own slice
+handoff, and then runs the whole-feature QA matrix plus the release gate. The 2026-07-20
+amendments add the profession SFX completion sweep (the placeholder clips Phase 12b sanctioned
+are replaced or explicitly re-filed on the help-wanted issue #2208), require the rare-fish deed
+to celebrate through the Phase 12b bite moment, and point the legacy junk-recipe burn-down at
+the Phase 13 typed-reagent consumers. It is its own slice
 because every earlier phase must be landed before deeds can trigger on real behavior, tuning can
 be judged against the live system, and the wiki can tell the truth.
 
@@ -27,6 +31,10 @@ be judged against the live system, and the wiki can tell the truth.
   throttle constants in the crafting resolver path.
 - `src/guide/pages/professions.ts` plus the wiki content generator (`npm run wiki:content`,
   freshness-gated by `tests/guide.test.ts`); conventions in `src/guide/CLAUDE.md`.
+- The 2026-07-20 additions: issue #2208 (the profession sound slot list and per-clip pipeline
+  checklist), the PLACEHOLDER-marked catalog rows in `scripts/sfx/` from Phase 12b, the
+  `LEGACY_GOLD_POSITIVE_RECIPE_IDS` burn-down list in `tests/recipe_economy.test.ts`, and the
+  Phase 13 typed-reagent consumer recipes (the no-dead-materials referential pin).
 - Local conventions: `src/sim/CLAUDE.md`, `src/guide/CLAUDE.md`, `tests/CLAUDE.md`.
 
 ## Starter Prompt
@@ -69,10 +77,10 @@ is generated and freshness-gated; the current asset-manifest slot list; and the 
 matrix rows for deeds content, content-only, i18n keys added, and full-stack changes.
 
 STEP 2 - CHOOSE ORCHESTRATION + EXECUTE:
-Fan out three parallel agents (deeds, tuning, guide); each gets ONLY the Explore summary, never
-the planning docs. Their file sets are disjoint, so no worktree isolation is needed; if any
-overlap appears, serialize that overlap. After all three land, the main session runs the QA
-matrix (see STEP 3).
+Fan out four parallel agents (deeds, tuning, guide, polish); each gets ONLY the Explore
+summary, never the planning docs. Their file sets are disjoint, so no worktree isolation is
+needed; if any overlap appears, serialize that overlap. After all four land, the main session
+runs the QA matrix (see STEP 3).
 
 Agent deeds deliverables:
 - Register the basic universal profession deeds in src/sim/content/deeds.ts with triggers wired
@@ -80,7 +88,10 @@ Agent deeds deliverables:
   milestones (rare tier), the Specialist deed at the 75-skill specialization threshold, and
   the rare-find deeds for the Phase 4 event flavors (pristine vein, ancient heartwood,
   moonlit bloom) plus the Phase 10 perfect specimen. The rare fish deed already exists: verify
-  it, do not duplicate it.
+  it, do not duplicate it; and per the 2026-07-20 amendment, verify it celebrates THROUGH the
+  Phase 12b bite moment (the col_glimmerfin credit lands on the reeled catch, so the deed
+  banner follows the bite-and-reel beat rather than a silent timer; the scripted playthrough
+  drives the bite flow, not a direct grant).
 - Notability through the deeds pipeline (the 2026-07-17 ruling): first attunement and first
   masterwork carry TITLE rewards and marquee-tier renown (>= 25) so the existing pipeline
   fires in full: nameplate title, banner, fireworks gate, celebration sound,
@@ -106,9 +117,14 @@ Agent tuning deliverables:
   final value in the matching test.
 - Faucet-vs-sink review (the 2026-07-17 amendment): with live data, weigh the material and
   gold faucets (gathering, work-order rewards, quest gold) against the sinks (consumables,
-  crafting inputs, salvage and disenchant destruction, training and craft fees) and record
-  the balance with evidence in the phase notes; revisit the commissions (#1298) wave
-  assignment with that evidence and file the follow-up on epic #1866.
+  crafting inputs, salvage and disenchant destruction, the typed-reagent demand, training,
+  craft, and unbind fees) and record the balance with evidence in the phase notes.
+- The legacy junk-recipe burn-down (the 2026-07-20 amendment): work through
+  LEGACY_GOLD_POSITIVE_RECIPE_IDS (tests/recipe_economy.test.ts pins it three ways as a
+  burn-down target) and CROSS-CHECK each candidate fix against the Phase 13 typed-reagent
+  consumers: a legacy recipe reworked to consume a typed material closes two flags at once
+  (the gold-positive violation and a no-dead-materials consumer), so prefer that shape where
+  it fits before plain price nerfs. Maintainer numbers only; never invent balance values.
 
 Agent guide deliverables:
 - Rewrite the guide/wiki professions page (src/guide/pages/professions.ts) to describe the
@@ -119,6 +135,20 @@ Agent guide deliverables:
   guide.* prose keys added English-only.
 - Final asset-manifest.json pass: append every id that shipped procedurally across the packet,
   with purpose, size, format, and replacement notes.
+
+Agent polish deliverables (the 2026-07-20 SFX completion sweep):
+- Sweep every profession sound slot on issue #2208: the Phase 12b placeholder cues (gather
+  cast/strike, the rare-strike variant, fish cast/bite/reel), craft success, and the five
+  missing station ambiences beside amb_forge. For each slot, either a real clip replaces the
+  placeholder (the full per-clip checklist on #2208: catalog row, asset, sfx:manifest,
+  routing, gain map, sfx:check, docs row, CREDITS.md licensing for recordings) or the slot is
+  explicitly re-filed on #2208 with a note; the packet does not close with an UNTRACKED
+  placeholder.
+- Per-craft success variants where the sound engineer delivered them (the craftResult payload
+  already carries what a variant sting needs); never a second cue on grant lines the loot hub
+  owns (the Phase 4 double-log trap).
+- End state: no catalog row for a profession cue is still marked PLACEHOLDER, or every
+  remaining one is listed on #2208 with the maintainer's sign-off recorded in progress.md.
 
 Then, in the main session: run docs/professions-2/qa-checklist.md end to end, recording evidence
 (test name, command output, or screenshot path) per row; then npm run gate under Node 24; then
@@ -141,7 +171,8 @@ INVARIANTS THIS PHASE MUST KEEP:
   ItemDef players may hold; no hand-edits to generated files.
 
 Out of scope (do NOT do in this phase):
-- Anything wave 2: market/mail instance carriage (#1146), commissions and boundTo (#1298),
+- Anything wave 2: market/mail instance carriage (#1146), the commission ORDER workflow
+  (#1298; the binding primitive and the Maker's Bond landed in Phases 13 and 14b),
   Jack of All Trades (#1296), monster-harvest proficiency, batch salvage UI (single-item
   salvage landed in Phase 13), battlefield experience
   expansion, item biographies, tool effects (parked and dormant), jewelcrafting or inscription
@@ -183,8 +214,13 @@ STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
       the rare fish, and every rare-find deed all unlock).
 - [ ] First attunement and first masterwork deeds carry titles and marquee-tier renown; the
       scripted playthrough proves the nameplate title, banner, and marquee broadcast fire.
-- [ ] The faucet-vs-sink review is recorded with evidence and the commissions follow-up
-      filed on epic #1866.
+- [ ] The faucet-vs-sink review is recorded with evidence in the phase notes.
+- [ ] The legacy burn-down list shrank or every surviving member has a recorded maintainer
+      disposition; candidates were cross-checked against the typed-reagent consumers first.
+- [ ] Every profession sound slot on #2208 is either replaced (sfx:check green, licensing
+      recorded) or explicitly re-filed; no untracked PLACEHOLDER catalog row remains.
+- [ ] The rare-fish deed celebrates through the bite-and-reel flow in the scripted
+      playthrough (no direct-grant shortcut).
 - [ ] tests/deeds_content.test.ts pins the catalog append-only; all pre-packet deeds unchanged.
 - [ ] Every tuning constant is named, exported, pinned, and matches the maintainer's numbers.
 - [ ] The wiki professions page describes the shipped system; npm run wiki:content freshness

--- a/docs/professions-2/phase-15-qa.md
+++ b/docs/professions-2/phase-15-qa.md
@@ -15,6 +15,13 @@ final audit of the entire Professions 2.0 packet, ending with the teardown offer
 - Spot-check the rewritten wiki professions page against the real sim code: every claim the
   page makes must be true of the shipped system, and the teardown offer must follow the house
   rule exactly.
+- The 2026-07-20 additions: the SFX completion sweep is accountable (scan the sfx catalogs
+  for PLACEHOLDER rows; each one found must be listed on issue #2208 with a recorded
+  maintainer sign-off, and each replaced clip must pass npm run sfx:check with its
+  CREDITS.md licensing row); the rare-fish deed unlocks through the REAL bite-and-reel flow
+  in the scripted playthrough; the legacy burn-down disposition
+  (LEGACY_GOLD_POSITIVE_RECIPE_IDS) is recorded per member with the typed-reagent
+  cross-check applied first.
 
 ## QA Starter Prompt
 

--- a/docs/professions-2/phase-15-qa.md
+++ b/docs/professions-2/phase-15-qa.md
@@ -17,9 +17,10 @@ final audit of the entire Professions 2.0 packet, ending with the teardown offer
   rule exactly.
 - The 2026-07-20 additions: the SFX completion sweep is accountable (scan the sfx catalogs
   for PLACEHOLDER rows; each one found must be listed on issue #2208 with a recorded
-  maintainer sign-off, and each replaced clip must pass npm run sfx:check with its
-  CREDITS.md licensing row); the rare-fish deed unlocks through the REAL bite-and-reel flow
-  in the scripted playthrough; the legacy burn-down disposition
+  maintainer sign-off; each replaced clip must pass npm run sfx:check, with a CREDITS.md
+  licensing row when it is an original recording, matching the phase file's
+  recordings-only licensing scope); the rare-fish deed unlocks through the REAL
+  bite-and-reel flow in the scripted playthrough; the legacy burn-down disposition
   (LEGACY_GOLD_POSITIVE_RECIPE_IDS) is recorded per member with the typed-reagent
   cross-check applied first.
 
@@ -53,7 +54,9 @@ the state.md targets; the guide page's generated-data feeds; the validation comm
 phase; and any deferral or open item the implementation session left.
 
 STEP 2 - QA AUDIT:
-Fan out three parallel audit agents; each gets ONLY the Explore summary. Prompt every agent for
+Fan out three parallel audit agents; each gets ONLY the Explore summary (which must include
+every row of the "Phase-specific QA emphasis" section at the top of this file; those rows are
+audit obligations, not commentary). Prompt every agent for
 COVERAGE, not filtering: report every gap with confidence and severity; filtering happens in
 the fix pass. If any agent's output comes back truncated, re-prompt that agent to resume and
 finish its report before acting on it.

--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -26,15 +26,19 @@ Update this file at the end of every implementation and QA session. Statuses:
 | 9 | Station presence and recipe training | complete | 2026-07-19 | 2026-07-19 |
 | 9 QA | Verify station presence and training | complete | 2026-07-19 | 2026-07-19 |
 | 10 | Recipe ladders and materials content | complete | 2026-07-19 | 2026-07-19 |
-| 10 QA | Verify recipe ladders and materials | not started | | |
-| 11 | Fishing joins the framework | built (draft PR #2197 retargeted to release/v0.29.0) | 2026-07-20 | 2026-07-20 |
-| 11 QA | Verify fishing framework | not started | | |
+| 10 QA | Verify recipe ladders and materials | complete | 2026-07-19 | 2026-07-19 |
+| 11 | Fishing joins the framework | complete (PR #2197 merged into release/v0.29.0) | 2026-07-20 | 2026-07-20 |
+| 11 QA | Verify fishing framework | complete (PR #2199 merged) | 2026-07-20 | 2026-07-20 |
 | 12 | Base tool tier gating | not started | | |
 | 12 QA | Verify tool tier gating | not started | | |
+| 12b | Gathering rhythm | not started | | |
+| 12b QA | Verify gathering rhythm | not started | | |
 | 13 | Enchanting reachable | not started | | |
 | 13 QA | Verify enchanting reachable | not started | | |
 | 14 | Attunement quests and nudges | not started | | |
 | 14 QA | Verify attunement quests and nudges | not started | | |
+| 14b | Commissions and the Maker's Bond | not started | | |
+| 14b QA | Verify commissions and the Maker's Bond | not started | | |
 | 15 | Deeds, tuning, and polish | not started | | |
 | 15 QA | Final integration QA and packet teardown | not started | | |
 
@@ -434,9 +438,19 @@ fallback arm (defensive, unreachable today).
 - [ ] The 15 existing tools change outcomes; stale no-op test pin replaced
 - [ ] Tool effects remain parked (explicitly out of scope)
 
+### Phase 12b: Gathering rhythm
+- [ ] Gather cast (tool-tier and band scaled, floored); completion re-validates; move cancels free
+- [ ] The shared non-spell-cast predicate consolidates the eleven cast-id exemption sites
+- [ ] Fishing bite minigame: hidden seeded delay, private bite SimEvent, server-authoritative reaction window, reel via pole re-press, miss costs nothing
+- [ ] Rod synergy: shorter average delay, wider window (composes with Phase 12 bands)
+- [ ] Placeholder cues routed and PLACEHOLDER-marked (sfx:check green, listed on #2208)
+- [ ] Every Pin-cost appendix row executed as briefed; no unlisted pin weakened
+
 ### Phase 13: Enchanting reachable
 - [ ] Disenchant + enchant-apply + salvage on IWorld, wire commands, bags context UI, both hosts
 - [ ] Enchanting skill visible in the wheel window
+- [ ] Typed disenchant reagents (hybrid): rare+ adds the type-keyed secondary; every typed material has a same-phase consumer (the wolf_fang rule); staves/wands bucket flagged
+- [ ] Bind-on-trade primitive live against the typed rare+ reagents (generic enforcement arm for Phase 14b)
 
 ### Phase 14: Attunement quests and nudges
 - [ ] Acceptance lore quests at the masters for all four wave-one archetypes
@@ -444,16 +458,41 @@ fallback arm (defensive, unreachable today).
 - [ ] Trend nudges (chat first, Guild letter voice); attunement summary explains everything before commit
 - [ ] Work-order quests per master (cadence-capped) and one-shot-per-tier master mail
 - [ ] Title celebration on attunement
+- [ ] The crafting-window "learnable at a master" hint (shown exactly when unlearned trainer recipes exist, via the shared viewer predicates)
+
+### Phase 14b: Commissions and the Maker's Bond
+- [ ] Commission opt-in at craft; the marker rides the instance in both hosts
+- [ ] First trade stamps boundTo; onward trades refused beside the def-level soulbound gate, localized deny id
+- [ ] Master unbind service: resolved fee, replay-safe, signer and masterwork markers survive
+- [ ] The three flagged maintainer decisions implemented exactly as resolved in state.md
+- [ ] Mail/market face-to-face construction pinned against the new marker
 
 ### Phase 15: Deeds, tuning, and polish
-- [ ] Universal profession deeds incl. titles + marquee renown on first attunement and first masterwork, the Specialist deed, and the rare-find deeds (plus the rare fish, verified)
-- [ ] Economy tuning targets applied (#1301 fee/throttle, training fees, teach tiers, work orders, masterwork bounds); faucet-vs-sink review recorded
+- [ ] Universal profession deeds incl. titles + marquee renown on first attunement and first masterwork, the Specialist deed, and the rare-find deeds (plus the rare fish, verified to celebrate through the Phase 12b bite moment)
+- [ ] Economy tuning targets applied (#1301 fee/throttle, training fees, teach tiers, work orders, masterwork bounds, unbind fee); faucet-vs-sink review recorded
+- [ ] Legacy junk-recipe burn-down dispositioned, cross-checked against the typed-reagent consumers first
+- [ ] Profession SFX completion sweep over #2208: placeholders replaced or explicitly re-filed, station ambiences, per-craft success variants
 - [ ] Guide/wiki professions page rewritten; asset manifest final
 - [ ] Whole-feature qa-checklist.md matrix green; packet teardown offered
 
 ## Notes
 
 (append per-phase notes, deferrals, and surprises here as sessions complete)
+
+2026-07-20 timing and economy amendments: a second maintainer-approved
+amendment pass (community feedback on gathering feel and the crafted-goods
+economy) restructured the remaining packet to 12, 12b, 13, 14, 14b, 15.
+state.md records the rulings under "2026-07-20 timing and economy
+amendments" (the authority block); the new phase files
+(phase-12b-gathering-rhythm.md, phase-14b-commissions-binding.md, both
+with QA twins) and the amended Phase 12/13/14/15 files (each swept with
+its QA twin in the same pass) carry the deliverable wording. Epic #1866
+gained sub-issues #2206 (12b), #2207 (14b, linking #1298), and #2208 (the
+profession SFX help-wanted list); #2051 and #2053 closed against their
+landing PRs in the same sweep. The Phase 12b file introduces the Pin-cost
+appendix pattern: the phase pre-briefs its complete deliberate re-pin and
+golden-regen list, inventoried against the release/v0.29.0 tree, so QA
+audits appendix fidelity instead of discovering the blast radius.
 
 2026-07-17 design-review amendments: a maintainer design review (the
 response to the external Codex review) amended the packet between Phases 2

--- a/docs/professions-2/qa-checklist.md
+++ b/docs/professions-2/qa-checklist.md
@@ -17,15 +17,18 @@ or screenshot path), not vibes.
 
 ## Determinism
 - [ ] All new randomness (masterwork proc, rare gather events, node rarity,
-      fishing catches) draws through `Rng` with pinned draw-order tests; no
+      fishing catches, the Phase 12b hidden bite delay) draws through `Rng`
+      with pinned draw-order tests; no
       `Math.random` / `Date.now` / `performance.now` anywhere in `src/sim/`.
 - [ ] `npx vitest run tests/architecture.test.ts` green.
 - [ ] Same-seed determinism test covers a full gather-craft-masterwork sequence.
 
 ## Server authority
 - [ ] Every new command (train recipe, disenchant, enchant apply, salvage,
-      quest advance) validates server-side; the client never decides craft
-      outcomes, masterwork procs, harvest rewards, or quest credit.
+      quest advance, the Phase 14b commission opt-in and master unbind)
+      validates server-side; the client never decides craft
+      outcomes, masterwork procs, harvest rewards, quest credit, the
+      Phase 12b bite deadline, or a bind-on-trade stamp.
 - [ ] Invalid or replayed commands cannot duplicate rewards, recipes, or skill.
 
 ## Persistence

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -4,13 +4,13 @@ The ONLY file every session must trust. Update it at the end of every phase.
 
 ## Current phase
 
-Phase 1 (Ring and identity foundations) and its QA: complete
-(2026-07-17, PASS, zero blocking; fixes and drift notes below). Phase 2
-(Masterwork model): complete (2026-07-17, branch
-feature/professions-2-phase-02-masterwork; six reviewers, zero blocking;
-landed surfaces and drift notes below). Phase 2 QA: complete
-(2026-07-17, PASS, zero blocking; coverage pins, retirement cleanup, and
-QA drift notes below). Next: Phase 3 (phase-03-parity-bug-fixes.md).
+Phases 1 through 11 and all their QA sessions: complete (per-phase records
+under "New surfaces per phase" below and in progress.md). v0.28.0 SHIPPED
+with Phases 1 through 10 aboard; Phase 11 (fishing) and its QA merged into
+release/v0.29.0. The 2026-07-20 timing and economy amendments restructured
+the remaining plan to 12, 12b, 13, 14, 14b, 15 (see the amendments block
+under Locked design decisions). Next: Phase 12 (phase-12-tool-gating.md,
+issue #2057).
 
 ## Locked design decisions
 
@@ -70,6 +70,9 @@ QA drift notes below). Next: Phase 3 (phase-03-parity-bug-fixes.md).
   src/sim/professions/tools.ts stay dormant; do not wire, do not delete.
 - Wave 2+ excluded from this packet (see implementation-plan.md); EXCEPTION
   2026-07-17: salvage wiring moved INTO Phase 13 (see the amendments below).
+  EXCEPTION 2026-07-20: the binding enforcement half of commissions (#1298)
+  moved INTO the packet as Phase 14b; the commission ORDER workflow stays
+  wave 2 on #1298.
 - 2026-07-17 design-review amendments (maintainer-approved; the response to
   the external Codex review). Each binds its owning phase file, which
   carries the full deliverable wording:
@@ -122,6 +125,79 @@ QA drift notes below). Next: Phase 3 (phase-03-parity-bug-fixes.md).
     professions; a cosmetic Specialist deed lands at the 75-skill
     threshold; a faucet-vs-sink review runs in the tuning pass. Still
     basic, universal, cosmetic-only, append-only.
+- 2026-07-20 timing and economy amendments (maintainer-approved; this block
+  is the authority, on the 2026-07-17 template). The restructure INSERTS
+  Phases 12b and 14b without renumbering anything; the remaining order is
+  12, 12b, 13, 14, 14b, 15. Epic #1866 sub-issues: #2206 (Gathering
+  rhythm), #2207 (Commissions and the Maker's Bond), #2208 (the profession
+  SFX help-wanted list). Each ruling binds its owning phase file, which
+  carries the full deliverable wording:
+  - NEW Phase 12b, Gathering rhythm (#2206,
+    phase-12b-gathering-rhythm.md + QA twin): gathering gains ACTION TIME.
+    A gather cast (base about 2.5 s, shortened per owned tool tier above
+    the node's Phase 12 requirement and modestly by proficiency band,
+    floor about 1.5 s) rides the fishing cast-id template behind a new
+    shared non-spell-cast predicate consolidating the eleven scattered
+    FISHING_CAST_ID exemption sites; completion re-validates range,
+    respawn, and capacity. The FIXED 5 s FISHING CAST IS SUPERSEDED by the
+    bite minigame: ONE hidden seeded delay drawn at startFishing (roughly
+    3 to 8 s, exact numbers the implementer's call), never readable from
+    castRemaining/castTotal or any broadcast field, a text-free personal
+    bite SimEvent (bobber VFX + cue), a generous server-authoritative
+    tick-deadline reaction window (the lockpick stepDeadlineTick
+    precedent), reel = re-pressing the pole on the existing useItem
+    dispatch (command census unchanged), and a miss costs nothing but the
+    cast. Rods shorten the average bite delay and widen the window,
+    composing with Phase 12's band gating. SHIPPING NOTE: v0.29.0 ships
+    the fixed 5 s cast as-is; the bite model replaces it only when 12b
+    lands. The phase file carries a Pin-cost appendix: the CLOSED,
+    pre-briefed list of deliberate re-pins and golden regens (anything
+    outside it that reds is a defect, not a cost).
+  - Phase 12 (amended): stays PURE ACCESS GATING; forward notes only
+    (speed lands in 12b, rods gain bite synergy in 12b).
+  - Phase 13 (amended): typed disenchant reagents on the HYBRID model:
+    the universal rarity ladder (DISENCHANT_MATERIAL_BY_QUALITY
+    dust/essence/shard) stays for every quality, and RARE OR ABOVE
+    additionally yields a type-keyed secondary material keyed off the
+    existing ArmorType (cloth/leather/mail) and the sim-side weapon-kind
+    taxonomy (WEAPON_TYPE_BY_ITEM); the staves/wands bucket is a FLAGGED
+    maintainer decision; cooking and alchemy are deliberately excluded on
+    both sides. Every typed material ships WITH at least one consumer
+    recipe in the same phase (the wolf_fang no-dead-materials rule). The
+    bind-on-trade PRIMITIVE lands in this phase applied to the typed
+    rare+ reagents as its first LIVE consumer (never a dormant stub, the
+    2033 lesson); the enforcement arm stays generic so Phase 14b extends
+    it. Sink sizing notes the measured faucet: every heroic final boss
+    drops TWO tradeable epics (src/sim/content/heroic_loot.ts).
+  - Phase 14 (amended): the crafting window gains the "learnable at a
+    master" discoverability hint row (the Phase 9 known-recipes-only
+    filter made the untrained ladders invisible; the hint resolves
+    through the shared train_view.ts viewer predicates, never a second
+    knownness rule, and renders only when unlearned trainer recipes
+    exist for that craft).
+  - NEW Phase 14b, Commissions and the Maker's Bond (#2207,
+    phase-14b-commissions-binding.md + QA twin): opt-in commission
+    crafts bind to the recipient on FIRST trade, enforced in the same
+    trade gate that blocks def-level soulbound items; mail and market
+    already refuse instanced items, so first delivery is face-to-face by
+    construction; a master unbind service clears the bond for gold (a
+    real sink on the resolveTrain service shape). Resolves the
+    enforcement semantics of #1298 (which stays open as the parent for
+    the full commission ORDER workflow). THREE maintainer decisions stay
+    FLAGGED, never defaulted, and must be resolved before the phase
+    runs: character-vs-account binding, which item classes may opt in,
+    and unbind pricing (see OPEN items).
+  - Phase 15 (amended): the profession SFX completion sweep over #2208
+    (every Phase 12b PLACEHOLDER clip replaced or explicitly re-filed;
+    the five missing station ambiences beside amb_forge; per-craft
+    success variants where delivered); the rare-fish deed celebrates
+    through the Phase 12b bite moment; the legacy junk-recipe burn-down
+    (LEGACY_GOLD_POSITIVE_RECIPE_IDS) cross-checks candidates against
+    the Phase 13 typed-reagent consumers before plain price nerfs.
+  - SFX placeholders are SANCTIONED across the packet: generated with
+    the deterministic local synthesis pipeline (scripts/sfx/ui_sfx.mjs
+    cue specs), passing npm run sfx:check, catalog rows marked
+    PLACEHOLDER for the sound engineer, all tracked on #2208.
 
 ## Non-negotiable constraints
 
@@ -911,7 +987,16 @@ tables, i18n key namespaces, files created)
   semantics across all four professions; the wheel UI clamps display via
   the Phase 5 above-cap saturation pin).
 - Phase 13: (planned) disenchantItem/applyEnchant/salvageItem IWorld
-  members + wire commands.
+  members + wire commands; plus, per the 2026-07-20 amendments, the typed
+  disenchant reagents (hybrid model, same-phase consumers) and the
+  bind-on-trade primitive applied to them.
+- Phase 12b: (planned) the shared non-spell-cast predicate, the gather
+  cast, the fishing bite minigame, rod synergy, placeholder cues; the
+  Pin-cost appendix in phase-12b-gathering-rhythm.md is the pre-briefed
+  re-pin list.
+- Phase 14b: (planned) the commission marker, bind-on-first-trade
+  enforcement, the master unbind service; blocked on the three flagged
+  maintainer decisions in OPEN items.
 
 ## Tuning targets (placeholders until Phase 15 tunes against live data)
 
@@ -932,6 +1017,16 @@ tables, i18n key namespaces, files created)
 - Work-order quests (Phase 14): reward numbers need MAINTAINER numbers
   before Phase 14 runs (never gold-positive against the input vendor value;
   the cadence cap reuses the nudge cadence pattern). Flagged in OPEN items.
+- Gathering rhythm (Phase 12b): gather cast base about 2.5 s, floor about
+  1.5 s, per-tool-tier and per-band reductions; bite delay roughly 3 to
+  8 s with the rod synergy deltas. Exact numbers are the implementer's
+  call within these shapes, landed as named exported constants and pinned;
+  record the finals here when 12b lands.
+- Unbind service fee (Phase 14b): a MAINTAINER number (see OPEN items);
+  never invented.
+- Typed-reagent yields and consumer costs (Phase 13): sized against the
+  measured heroic faucet (two tradeable epics per heroic final boss);
+  final numbers are maintainer calls in the Phase 15 tuning pass.
 
 ## OPEN items
 
@@ -979,3 +1074,16 @@ tables, i18n key namespaces, files created)
   note, intended). Flagged 2026-07-17 for a maintainer call; if masterworks
   should credit the bumped tier, that is a deliberate design change for a
   tuning phase, never a QA fix.
+- Phase 14b maintainer decisions (2026-07-20, FLAGGED, must be resolved
+  here before phase-14b-commissions-binding.md runs): (a) does the Maker's
+  Bond bind to the CHARACTER or the ACCOUNT; (b) which item classes may
+  opt into commission crafting; (c) the unbind service price (flat, or
+  scaled by item tier). The phase's STEP 0 stops if any row is still open.
+- Staves/wands typed-reagent bucket (2026-07-20, FLAGGED, Phase 13): which
+  type-keyed secondary material family staff and wand disenchants feed
+  (the sim-side weapon taxonomy has them as their own kinds; cloth-adjacent
+  is arguable). Resolve before or during the Phase 13 PR review.
+- The letter-to-Haldren dead-end (Phase 7 QA): an unattuned player who
+  follows the Guild letter before q_prof_intro is available hits a dialog
+  dead-end; options recorded in progress.md Notes; the fix naturally rides
+  Phase 14's master quest work. Still open.

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -986,14 +986,14 @@ tables, i18n key namespaces, files created)
   accrual has no maxSkill cap on the drain path (shared, pre-existing
   semantics across all four professions; the wheel UI clamps display via
   the Phase 5 above-cap saturation pin).
-- Phase 13: (planned) disenchantItem/applyEnchant/salvageItem IWorld
-  members + wire commands; plus, per the 2026-07-20 amendments, the typed
-  disenchant reagents (hybrid model, same-phase consumers) and the
-  bind-on-trade primitive applied to them.
 - Phase 12b: (planned) the shared non-spell-cast predicate, the gather
   cast, the fishing bite minigame, rod synergy, placeholder cues; the
   Pin-cost appendix in phase-12b-gathering-rhythm.md is the pre-briefed
   re-pin list.
+- Phase 13: (planned) disenchantItem/applyEnchant/salvageItem IWorld
+  members + wire commands; plus, per the 2026-07-20 amendments, the typed
+  disenchant reagents (hybrid model, same-phase consumers) and the
+  bind-on-trade primitive applied to them.
 - Phase 14b: (planned) the commission marker, bind-on-first-trade
   enforcement, the master unbind service; blocked on the three flagged
   maintainer decisions in OPEN items.


### PR DESCRIPTION
## Summary

Executes the maintainer-approved 2026-07-20 timing and economy amendments as a packet docs
restructure (the second amendment pass, on the 2026-07-17 design-review precedent of PR #2084).
No gameplay code changes; docs/professions-2/ only.

What changes:

- NEW phase files phase-12b-gathering-rhythm.md and phase-14b-commissions-binding.md, each with
  its QA twin. Phase 12b adds the gather cast (tool-tier and proficiency scaled) and the fishing
  bite minigame (hidden seeded delay, private bite SimEvent, server-authoritative reaction
  window, reel via pole re-press, rod synergy), with a Pin-cost appendix inventoried against the
  release/v0.29.0 tree pre-briefing every deliberate re-pin and golden regen. Phase 14b adds
  opt-in commission crafts that bind to the recipient on first trade, a master unbind gold sink,
  and resolves the #1298 enforcement semantics; its three maintainer decision points stay
  flagged, never defaulted.
- AMENDED phases 12, 13, 14, and 15, each with its QA twin swept in the same pass (the
  amend-the-twin rule): Phase 12 stays pure access gating (forward notes only); Phase 13 gains
  the hybrid typed disenchant reagents with same-phase consumers (the wolf_fang rule), the
  bind-on-trade primitive applied to those reagents as its first live consumer, and the
  heroic-glut sink-sizing note; Phase 14 gains the crafting-window learnable-at-a-master hint;
  Phase 15 gains the SFX completion sweep over #2208, the bite-moment rare-fish deed check, and
  the typed-reagent cross-check on the legacy burn-down.
- state.md gains the dated "2026-07-20 timing and economy amendments" authority block (on the
  2026-07-17 template), the fixed-5s-fishing-cast supersession note (v0.29.0 ships the fixed
  cast; the bite model replaces it when 12b lands), the phase-order insertion (12, 12b, 13, 14,
  14b, 15), the new OPEN items and tuning-target shapes, and a current-phase header brought up
  to reality. implementation-plan.md and progress.md gain the 12b/14b rows; the stale Phase 10
  QA and Phase 11 status rows are corrected to their merged reality.

The remaining phase order is 12, 12b, 13, 14, 14b, 15. Nothing is renumbered, no locked pillar
moves. Verified by a five-reader adversarial consistency pass (cross-file contradictions, QA
twin fidelity, code and test anchors against the tree, issue-reference states, style and
approved-plan fidelity).

## Related issues

Part of #1866. The restructure's issue sweep (same session) created sub-issues #2206 (Phase
12b), #2207 (Phase 14b, linking #1298), and #2208 (the profession SFX help-wanted list), and
closed #2051 and #2053 against their landing PRs.

## Type of change

- [x] Documentation

## How was this tested?

- Commands: `npm run gate` under Node 24 at the branch head: green through i18n gen and
  freshness, malware scan, changed-files biome, SFX conformance, and the full vitest suite; the
  one red is the documented pre-existing environmental armory browser failure on this machine
  (tests/browser/armory_mobile_layout.browser.test.ts, reproduces on untouched release tips; PR
  CI is the arbiter), after which the gate tail (`npm run check:types`, `npm run build:env`,
  `npm run build:server`, `npm run build`) was finished manually, all green.
- Manual steps: five-agent adversarial consistency Workflow over the diff; every cited code and
  test anchor verified against the tree at HEAD; every cited issue number verified against
  GitHub state via gh.

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green (see above for the one documented
      environmental browser red and the manually completed tail). Docs-only change; no behavior
      to test.

### Cross-platform

- N/A. Docs-only.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in
      any production path.
- [x] I didn't hand-edit generated files.
