### PR TITLE
fix(server): atomically persist character and escrow state after market and mail mutations

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -230,6 +230,12 @@ const LOCKPICK_ACTIONS = new Set<PickAction>(['hardSet', 'set', 'steady', 'ease'
 const LEAVE_SAVE_MAX_ATTEMPTS = 5;
 const LEAVE_SAVE_RETRY_BASE_MS = 250;
 const LEAVE_SAVE_RETRY_MAX_MS = 4000;
+// How long an escrow-mutating market/mail command waits before its prompt
+// atomic save (scheduleEscrowSave) actually runs. Short enough to close the
+// crash window between it and a restart, long enough that a burst of commands
+// from one character (a few quick mail takes, list-then-cancel) coalesces
+// into a single write instead of one per command.
+const ESCROW_SAVE_DEBOUNCE_MS = 500;
 // Usage notices for the two PLAYER chat-suppression tiers. Kept as constants
 // because the S3 localization guard scans sendChatNotice literals, and
 // src/ui/server_i18n.ts carries the matching rules. (A "mute" is the ADMIN
@@ -1242,6 +1248,9 @@ export class GameServer {
   private socialPosTimer = 0;
   private saveAllInFlight: Promise<void> | null = null;
   private readonly characterSaveQueues = new Map<number, Promise<void>>();
+  // Debounce timers for the prompt atomic escrow save (scheduleEscrowSave),
+  // one per character id currently awaiting its coalesced write.
+  private readonly escrowSaveTimers = new Map<number, NodeJS.Timeout>();
   // Weapon-skin loadouts are whole-record replacements in their dedicated paid
   // state row. Keep one FIFO per account so rapid apply/detach commands cannot
   // commit on separate pool clients in reverse order and resurrect stale state.
@@ -1942,6 +1951,42 @@ export class GameServer {
     }
   }
 
+  // Market buy/list/cancel and mail send/take each mutate BOTH the acting
+  // character's own state (bags/copper) and the shared market/mail world_state
+  // blob in the same command. flushPeriodicSaves above persists those two
+  // pieces as INDEPENDENT unsynchronized 30s writes (saveAll, then saveMarket/
+  // saveMail), so a crash between them can restore the character and the
+  // escrow from different instants: a market_buy whose buyer character save
+  // (item granted, copper deducted) lands before the market blob write that
+  // removes the listing resurrects the listing after restart (item
+  // duplicated, seller's proceeds lost); mail_take has the mirror coin/item-
+  // dupe window. The leave path was already made atomic for exactly this
+  // reason (saveCharacterOnLeave -> saveCharacter(withMarket:true), which
+  // writes both through saveCharacterAndMarketState in one transaction).
+  // Call this right after such a command so that SAME atomic write runs
+  // promptly for the acting character instead of only ever riding the
+  // unsynchronized 30s pair (kept as the fallback for the everyday case).
+  // Debounced per character, and fire-and-forget like every other save call
+  // in this file: a burst of commands from one character (a few quick mail
+  // takes, list-then-cancel) coalesces into a single write, and a slow or
+  // failed save never blocks the command's own dispatch.
+  private scheduleEscrowSave(session: ClientSession): void {
+    const characterId = session.characterId;
+    const pending = this.escrowSaveTimers.get(characterId);
+    if (pending) clearTimeout(pending);
+    this.escrowSaveTimers.set(
+      characterId,
+      setTimeout(() => {
+        this.escrowSaveTimers.delete(characterId);
+        const live = this.sessionsByCharacterId.get(characterId);
+        if (!live || live.left) return; // logged off before the debounce fired
+        void this.saveCharacter(live, { withMarket: true }).catch((err) =>
+          console.error(`escrow save failed for ${live.name}:`, err),
+        );
+      }, ESCROW_SAVE_DEBOUNCE_MS),
+    );
+  }
+
   private enforceJailStates(): void {
     for (const session of this.clients.values()) {
       this.applyModeratorJailGate(session);
@@ -2033,6 +2078,8 @@ export class GameServer {
     if (this.playtimeInterval) clearInterval(this.playtimeInterval);
     if (this.dailyRewardActivityInterval) clearInterval(this.dailyRewardActivityInterval);
     if (this.keepaliveInterval) clearInterval(this.keepaliveInterval);
+    for (const timer of this.escrowSaveTimers.values()) clearTimeout(timer);
+    this.escrowSaveTimers.clear();
   }
 
   // Grant playtime reward points to each online account that has been ACTIVE (gave
@@ -2947,6 +2994,15 @@ export class GameServer {
     if (session.jailVisit) this.exitJailVisit(session, false);
     session.left = true;
     this.clients.delete(session.pid);
+    // The leave-flush below (saveCharacterOnLeave) already runs the same
+    // atomic character+market+mail write; drop any still-pending debounced
+    // escrow save for this character so it never fires a redundant write
+    // against a session that is already gone.
+    const escrowTimer = this.escrowSaveTimers.get(session.characterId);
+    if (escrowTimer) {
+      clearTimeout(escrowTimer);
+      this.escrowSaveTimers.delete(session.characterId);
+    }
     this.botDetector.releaseTrackingContext(session.botTrackingContext);
     this.releaseIpSession(session.ip);
     void this.recordOnlineSnapshot();
@@ -4666,13 +4722,22 @@ export class GameServer {
           Number.isFinite(msg.price)
         ) {
           sim.marketList(msg.item, msg.count, msg.price, pid);
+          // Escrows the listed goods out of this character's bags into the
+          // shared market blob: flush both promptly (see scheduleEscrowSave).
+          this.scheduleEscrowSave(session);
         }
         break;
       case 'market_buy':
-        if (typeof msg.id === 'number') sim.marketBuy(msg.id, pid);
+        if (typeof msg.id === 'number') {
+          sim.marketBuy(msg.id, pid);
+          this.scheduleEscrowSave(session);
+        }
         break;
       case 'market_cancel':
-        if (typeof msg.id === 'number') sim.marketCancel(msg.id, pid);
+        if (typeof msg.id === 'number') {
+          sim.marketCancel(msg.id, pid);
+          this.scheduleEscrowSave(session);
+        }
         break;
       case 'market_collect':
         sim.marketCollect(pid);
@@ -4734,6 +4799,9 @@ export class GameServer {
             items,
             pid,
           );
+          // Escrows coin/items out of the sender's bags into the shared mail
+          // blob: flush both promptly (see scheduleEscrowSave).
+          this.scheduleEscrowSave(session);
           break;
         }
         // Offline recipient: resolve against the character DB (realm-scoped),
@@ -4770,13 +4838,17 @@ export class GameServer {
               items,
               pid,
             );
+            this.scheduleEscrowSave(session);
             session.selfHeavyDirty = true;
           })
           .catch((err) => console.error('mail send resolve failed:', err));
         break;
       }
       case 'mail_take':
-        if (typeof msg.id === 'number') sim.mailTake(msg.id, pid);
+        if (typeof msg.id === 'number') {
+          sim.mailTake(msg.id, pid);
+          this.scheduleEscrowSave(session);
+        }
         break;
       case 'mail_delete':
         if (typeof msg.id === 'number') sim.mailDelete(msg.id, pid);

--- a/tests/escrow_atomic_save.test.ts
+++ b/tests/escrow_atomic_save.test.ts
@@ -1,0 +1,273 @@
+// The 30s autosave persists character state (server/game.ts saveAll) and the
+// market/mail world_state blobs (saveMarket/saveMail) as two INDEPENDENT
+// fire-and-forget writes (flushPeriodicSaves). A crash between them tears an
+// escrow-mutating command in half: market_buy's buyer character save (item
+// granted, copper deducted) can commit before the market blob write that
+// removes the listing, so a restart resurrects the listing (item duplicated,
+// seller's proceeds lost); mail_take has the mirror coin/item-dupe window.
+//
+// The fix schedules the ALREADY atomic saveCharacterAndMarketState (the same
+// writer the leave path uses, see saveCharacterOnLeave) for the acting
+// character right after any escrow-mutating market/mail command, debounced
+// per character so a burst of commands coalesces into one write, instead of
+// relying only on the unsynchronized 30s pair.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  saveCharacterAndMarketState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+}));
+
+import { saveCharacterAndMarketState } from '../server/db';
+import { type ClientSession, GameServer } from '../server/game';
+
+interface Joined {
+  session: ClientSession;
+  sent: unknown[];
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: private sim/server internals are reached via a cast in tests.
+type AnyServer = any;
+
+function join(server: AnyServer, id: number, name: string): Joined {
+  const sent: unknown[] = [];
+  const ws = { readyState: 1, send: (p: string) => sent.push(JSON.parse(p)) };
+  const session = server.join(ws, id, id, name, 'warrior', null);
+  if ('error' in session) throw new Error(session.error);
+  session.blockListLoaded = true;
+  return { session, sent };
+}
+
+function send(server: AnyServer, session: ClientSession, msg: Record<string, unknown>): void {
+  server.handleMessage(session, JSON.stringify({ t: 'cmd', ...msg }));
+}
+
+function bringMerchantToPlayer(sim: AnyServer, pid: number): void {
+  const merchant = sim.entities.get(sim.market.merchantIds[0]);
+  const p = sim.entities.get(pid);
+  merchant.pos = { ...p.pos };
+  merchant.prevPos = { ...merchant.pos };
+}
+
+function moveToMailbox(sim: AnyServer, pid: number): void {
+  const box = sim.entities.get(sim.postOffice.mailboxIds[0]);
+  const p = sim.entities.get(pid);
+  p.pos = { ...box.pos };
+  p.prevPos = { ...p.pos };
+}
+
+function bookLetter(sim: AnyServer, recipientName: string, id: number, copper: number): void {
+  sim.postOffice.mail.push({
+    id,
+    recipientKey: recipientName,
+    recipientName,
+    senderName: 'Postmaster',
+    kind: 'system',
+    subject: 'Coin',
+    body: '',
+    copper,
+    items: [],
+    deliverAt: 0,
+    expiresAt: Infinity,
+    read: false,
+    announced: false,
+  });
+}
+
+// The Merchant seeds house stock at world creation, so a fresh listing is
+// never index 0: find it by seller instead (never house stock).
+function listingBySeller(sim: AnyServer, characterId: number): { id: number } | undefined {
+  return sim.market.marketListings.find(
+    (l: { house: boolean; sellerKey: string }) => !l.house && l.sellerKey === String(characterId),
+  );
+}
+
+function savesFor(characterId: number): unknown[][] {
+  return vi.mocked(saveCharacterAndMarketState).mock.calls.filter((c) => c[0] === characterId);
+}
+
+// Fires every currently-pending timer (the escrow debounce, nothing else: these
+// tests never call server.start(), so no interval loop is running) and lets the
+// resulting save promise chain settle.
+async function runEscrowTimers(): Promise<void> {
+  await vi.runOnlyPendingTimersAsync();
+  await vi.waitFor(() => {
+    expect(vi.mocked(saveCharacterAndMarketState).mock.calls.length).toBeGreaterThan(0);
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(saveCharacterAndMarketState).mockClear();
+});
+
+describe('escrow-mutating commands schedule a prompt atomic character+market/mail save', () => {
+  it('market_list schedules an atomic save for the lister', async () => {
+    vi.useFakeTimers();
+    try {
+      const server = new GameServer();
+      const seller = join(server, 1, 'Lister');
+      const sim = server.sim as AnyServer;
+      bringMerchantToPlayer(sim, seller.session.pid);
+      sim.addItem('wolf_fang', 1, seller.session.pid);
+
+      send(server, seller.session, { cmd: 'market_list', item: 'wolf_fang', count: 1, price: 100 });
+      expect(listingBySeller(sim, seller.session.characterId)).toBeDefined();
+      expect(saveCharacterAndMarketState).not.toHaveBeenCalled();
+
+      await runEscrowTimers();
+      expect(savesFor(seller.session.characterId).length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('market_buy schedules an atomic save for the buyer, off the hot dispatch path', async () => {
+    vi.useFakeTimers();
+    try {
+      const server = new GameServer();
+      const seller = join(server, 1, 'Seller');
+      const buyer = join(server, 2, 'Buyer');
+      const sim = server.sim as AnyServer;
+      bringMerchantToPlayer(sim, seller.session.pid);
+      bringMerchantToPlayer(sim, buyer.session.pid);
+      sim.addItem('wolf_fang', 1, seller.session.pid);
+      sim.players.get(buyer.session.pid).copper = 1000;
+
+      send(server, seller.session, { cmd: 'market_list', item: 'wolf_fang', count: 1, price: 100 });
+      const listing = listingBySeller(sim, seller.session.characterId);
+      if (!listing) throw new Error('listing not found');
+
+      send(server, buyer.session, { cmd: 'market_buy', id: listing.id });
+
+      // The buy itself resolves synchronously inside the authoritative Sim...
+      const buyerMeta = sim.players.get(buyer.session.pid);
+      expect(buyerMeta.copper).toBe(900);
+      expect(buyerMeta.inventory.some((s: { itemId: string }) => s.itemId === 'wolf_fang')).toBe(
+        true,
+      );
+      // ...but the atomic escrow save must not run inline on the hot dispatch
+      // path: it is scheduled (fire-and-forget), matching every other save
+      // call in this file.
+      expect(saveCharacterAndMarketState).not.toHaveBeenCalled();
+
+      await runEscrowTimers();
+      expect(savesFor(buyer.session.characterId).length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('market_cancel schedules an atomic save for the canceller', async () => {
+    vi.useFakeTimers();
+    try {
+      const server = new GameServer();
+      const seller = join(server, 1, 'Canceller');
+      const sim = server.sim as AnyServer;
+      bringMerchantToPlayer(sim, seller.session.pid);
+      sim.addItem('wolf_fang', 1, seller.session.pid);
+      send(server, seller.session, { cmd: 'market_list', item: 'wolf_fang', count: 1, price: 100 });
+      await runEscrowTimers(); // drain the market_list save first
+      vi.mocked(saveCharacterAndMarketState).mockClear();
+
+      const listing = listingBySeller(sim, seller.session.characterId);
+      if (!listing) throw new Error('listing not found');
+      send(server, seller.session, { cmd: 'market_cancel', id: listing.id });
+      expect(listingBySeller(sim, seller.session.characterId)).toBeUndefined();
+      expect(saveCharacterAndMarketState).not.toHaveBeenCalled();
+
+      await runEscrowTimers();
+      expect(savesFor(seller.session.characterId).length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('mail_send schedules an atomic save for the sender', async () => {
+    vi.useFakeTimers();
+    try {
+      const server = new GameServer();
+      const alice = join(server, 1, 'Alice');
+      const bob = join(server, 2, 'Bob');
+      const sim = server.sim as AnyServer;
+      const aliceMeta = sim.players.get(alice.session.pid);
+      aliceMeta.copper = 10_000;
+      moveToMailbox(sim, alice.session.pid);
+
+      send(server, alice.session, {
+        cmd: 'mail_send',
+        to: 'Bob',
+        subject: 'Hi',
+        body: 'there',
+        copper: 0,
+        items: [],
+      });
+      expect(aliceMeta.copper).toBe(10_000 - 30); // MAIL_POSTAGE taken: the send resolved
+      expect(saveCharacterAndMarketState).not.toHaveBeenCalled();
+
+      await runEscrowTimers();
+      expect(savesFor(alice.session.characterId).length).toBe(1);
+      // Bob (the recipient) took no action of his own: no save scheduled for him.
+      expect(savesFor(bob.session.characterId).length).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('mail_take schedules an atomic save for the taker (mirrors market_buy)', async () => {
+    vi.useFakeTimers();
+    try {
+      const server = new GameServer();
+      const taker = join(server, 1, 'Taker');
+      const sim = server.sim as AnyServer;
+      const meta = sim.players.get(taker.session.pid);
+      bookLetter(sim, meta.name, 9001, 50);
+      moveToMailbox(sim, taker.session.pid);
+
+      send(server, taker.session, { cmd: 'mail_take', id: 9001 });
+      expect(meta.copper).toBe(50);
+      expect(saveCharacterAndMarketState).not.toHaveBeenCalled();
+
+      await runEscrowTimers();
+      expect(savesFor(taker.session.characterId).length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('coalesces a burst of escrow commands from one character into a single debounced save', async () => {
+    vi.useFakeTimers();
+    try {
+      const server = new GameServer();
+      const taker = join(server, 1, 'Burst');
+      const sim = server.sim as AnyServer;
+      const meta = sim.players.get(taker.session.pid);
+      bookLetter(sim, meta.name, 9101, 10);
+      bookLetter(sim, meta.name, 9102, 10);
+      bookLetter(sim, meta.name, 9103, 10);
+      moveToMailbox(sim, taker.session.pid);
+
+      // Three takes back to back, all inside one debounce window: each
+      // re-arms the same per-character timer instead of scheduling a new one.
+      send(server, taker.session, { cmd: 'mail_take', id: 9101 });
+      send(server, taker.session, { cmd: 'mail_take', id: 9102 });
+      send(server, taker.session, { cmd: 'mail_take', id: 9103 });
+      expect(meta.copper).toBe(30);
+
+      await runEscrowTimers();
+      // A separate (non-debounced) implementation would have queued three
+      // pending timers here and this would read 3.
+      expect(savesFor(taker.session.characterId).length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Market and mail commands mutate two pieces of persisted state in the same command: the acting character's own bags and copper, and the shared market/mail `world_state` blob. Today those two halves are only ever written by the 30s autosave, which fires them as three independent fire-and-forget calls:

```ts
// server/game.ts, flushPeriodicSaves
void this.saveAll('autosave');
void this.saveMarket();
void this.saveMail();
```

Nothing synchronizes them, so a crash or a hard restart in between can bring the world back with the character and the escrow taken from different instants. The two cases that hurt:

- **`market_buy`.** If the buyer's character save (item granted, copper deducted) commits and the market blob write does not, the listing comes back after the restart. The item is duplicated and the seller's proceeds are gone.
- **`mail_take`.** The mirror window: the letter's coin and items land in the taker's bags, the mail blob still holds the letter, and taking it again after the restart duplicates them.

The repo already has the right primitive for this. `saveCharacterAndMarketState` (`server/db.ts`) writes the character row and both `world_state` keys inside one Postgres transaction, and the leave path already routes through it via `saveCharacterOnLeave` -> `saveCharacter(session, { withMarket: true })` for exactly this reason. The gap is that a player who never logs out never gets that atomic write.

This change calls that same atomic write promptly after each escrow-mutating command (`market_list`, `market_buy`, `market_cancel`, `mail_send` on both the online and offline-recipient branches, and `mail_take`), instead of only when the player happens to leave.

Two details worth calling out:

- **Debounced 500ms per character**, so a burst from one player (a few quick mail takes, a list followed by a cancel) coalesces into a single write rather than one write per command.
- **Fire-and-forget**, matching every other save call in `game.ts`. The command's own dispatch is never blocked by a slow or failed save, so the 20 Hz loop is untouched.

The 30s cadence stays exactly as it is, as the fallback for everything else. The pending timer is cleared in `leave()` (the leave flush already performs the same atomic write, so the debounced one would be redundant) and in `stop()`.

## Related issues

None that I found; I ran into this reading the persistence path.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/escrow_atomic_save.test.ts` (new, 6 cases, all pass)
  - `npx vitest run tests/save_character_and_market.test.ts tests/professions_market.test.ts tests/character_lease.test.ts tests/mail.test.ts tests/market.test.ts` (71 pass, the existing coverage around the same writer and the leave path)
  - `npx tsc --noEmit` (clean) and `npx @biomejs/biome check server/game.ts tests/escrow_atomic_save.test.ts` (clean)
  - `npx vitest run` (full suite)
- Manual steps: N/A, this is a persistence-timing change with no player-visible surface. The new tests drive the real `GameServer` and the real `Sim` through the actual command path (`handleMessage`) rather than mocking the seam.

I confirmed the new tests are decisive rather than tautological: against an unmodified `server/game.ts` all 6 fail (`expected 0 to be greater than 0`, no atomic write is ever scheduled), and all 6 pass with the change.

One caveat on the full suite, since I would rather flag it than quietly tick the box. I develop on Windows, and a full `npx vitest run` on an **unmodified** checkout of `release/v0.29.0` already fails 11 files / 25 tests here for environment reasons (the SFX studio suites want FFmpeg, `static_sfx_serving` hits `EPERM` on a Windows rename, `new_endpoint` gets a null status from its `tsc` spawn, plus `asset_pipeline` and `prod_cpu_monitor`). With this change applied the run is 9 files / 23 tests, a strict subset of that same baseline, so the change introduces no new failures and adds 6 passing tests. Nothing in the remaining set touches `server/`, the market, mail, or persistence. Your Linux CI should be the real verdict here.

The new `tests/escrow_atomic_save.test.ts` pins:

- each of `market_list`, `market_buy`, `market_cancel`, `mail_send`, `mail_take` schedules an atomic save for the acting character;
- the save does not run inline on the hot dispatch path (it is still pending immediately after the command resolves);
- a recipient who took no action of their own gets no save scheduled;
- a burst of three `mail_take`s inside one debounce window coalesces into exactly one write (a non-debounced implementation reads 3 here).

## Screenshots / recordings

N/A, no player-visible or operator-visible surface changes.

---

## Checklist

### Quality

- [x] **The full gate passes.** Typecheck, Biome, and the whole test suite are green apart from the pre-existing Windows-environment failures described above, which reproduce identically on an unmodified base branch. I added decisive tests for the changed behavior (verified failing without the fix) and recorded the commands above.
