### PR TITLE
fix(talents): ward the caster, not the enemy, on Hellglass Ward

### DIFF
--- a/src/sim/combat/talent_procs.ts
+++ b/src/sim/combat/talent_procs.ts
@@ -102,20 +102,23 @@ function fireOne(
       }
       player.resource = Math.min(player.maxResource, player.resource + response.amount);
       break;
-    case 'heal':
+    case 'heal': {
+      const recipient = response.target === 'self' ? player : subject;
       ctx.applyHeal(
         player,
-        subject,
+        recipient,
         response.amountPctSourceMaxHp !== undefined
           ? Math.round(player.maxHp * response.amountPctSourceMaxHp)
           : response.amountPctMaxHp !== undefined
-            ? Math.round(subject.maxHp * response.amountPctMaxHp)
+            ? Math.round(recipient.maxHp * response.amountPctMaxHp)
             : (response.amount ?? 0),
         def.name,
       );
       break;
-    case 'absorb':
-      ctx.applyAura(subject, {
+    }
+    case 'absorb': {
+      const recipient = response.target === 'self' ? player : subject;
+      ctx.applyAura(recipient, {
         id: def.id,
         name: def.name,
         kind: 'absorb',
@@ -123,7 +126,7 @@ function fireOne(
         duration: response.duration,
         value:
           response.amountPctMaxHp !== undefined
-            ? Math.round(subject.maxHp * response.amountPctMaxHp)
+            ? Math.round(recipient.maxHp * response.amountPctMaxHp)
             : (response.amount ?? 0),
         sourceId: player.id,
         school: def.school ?? 'holy',
@@ -131,11 +134,12 @@ function fireOne(
       ctx.emit({
         type: 'spellfx',
         sourceId: player.id,
-        targetId: subject.id,
+        targetId: recipient.id,
         school: def.school ?? 'holy',
         fx: 'wardBloom',
       });
       break;
+    }
     case 'aura':
       ctx.applyAura(player, {
         id: def.id,

--- a/src/sim/content/choice_rows_classic.ts
+++ b/src/sim/content/choice_rows_classic.ts
@@ -1913,7 +1913,17 @@ export const WARLOCK_CHOICE_ROWS: ClassChoiceRows = {
                 n: 3,
                 abilities: warlockDamagingFireOrShadowSpellAbilityIds,
               },
-              responses: [{ kind: 'absorb', amount: 90, duration: 10, name: 'Hellglass Ward' }],
+              // target: 'self': the triggering casts are hostile, so the ward
+              // must land on the warlock, never the enemy hit by the 3rd cast.
+              responses: [
+                {
+                  kind: 'absorb',
+                  amount: 90,
+                  duration: 10,
+                  name: 'Hellglass Ward',
+                  target: 'self',
+                },
+              ],
             },
           },
         },

--- a/src/sim/content/talents.ts
+++ b/src/sim/content/talents.ts
@@ -175,13 +175,26 @@ export type ProcResponse =
   // The pct-of-max-health variants (phase-2 defensive pass) override the flat
   // number when present. Most scale with the wearer; source scaling is for
   // shields whose proc owner can differ from the protected ally.
+  // target: the recipient defaults to the trigger subject (the heal target,
+  // the hit-taker, or the triggering cast's target). 'self' pins it to the
+  // proc owner instead; REQUIRED for any proc whose triggering casts are
+  // hostile (Hellglass Ward), or the response lands on the enemy. Explicit by
+  // design: the engine never infers the recipient from hostility.
   | {
       kind: 'heal';
       amount?: number;
       amountPctMaxHp?: number;
       amountPctSourceMaxHp?: number;
+      target?: 'self';
     }
-  | { kind: 'absorb'; amount?: number; amountPctMaxHp?: number; duration: number; name: string }
+  | {
+      kind: 'absorb';
+      amount?: number;
+      amountPctMaxHp?: number;
+      duration: number;
+      name: string;
+      target?: 'self';
+    }
   | {
       kind: 'echo';
       belowFrac: number;

--- a/tests/choice_rows_wave2.test.ts
+++ b/tests/choice_rows_wave2.test.ts
@@ -266,6 +266,28 @@ describe('warlock wave 2 choice rows', () => {
     expect(p.auras.some((a) => a.id === 'wlk_curse_mastery')).toBe(false);
   });
 
+  it('Hellglass Ward shields the warlock on the 3rd damaging cast, never the mob', () => {
+    const { sim, p } = rig('warlock', 20, { 20: 'wlk_r20_grimoire_of_haste' });
+    const mob = addTargetMob(sim);
+    // Hold the mob still so nothing consumes the ward while the casts settle.
+    mob.auras.push({
+      id: 'test_hold',
+      name: 'Test Hold',
+      kind: 'stun',
+      remaining: 600,
+      duration: 600,
+      value: 0,
+      sourceId: p.id,
+      school: 'shadow',
+    });
+    for (let i = 0; i < 3; i++) castAndSettle(sim, 'shadow_bolt');
+    expect(mob.dead).toBe(false);
+    expect(p.auras.some((a) => a.id === 'wlk_grimoire_of_carnage' && a.kind === 'absorb')).toBe(
+      true,
+    );
+    expect(mob.auras.some((a) => a.id === 'wlk_grimoire_of_carnage')).toBe(false);
+  });
+
   it('Deepened Hex and defensive pact hooks change live combat outcomes', () => {
     const hit = (withDot: boolean) => {
       const { sim } = rig('warlock', 20, { 14: 'wlk_r14_amplify_curse' });

--- a/tests/talent_procs.test.ts
+++ b/tests/talent_procs.test.ts
@@ -24,6 +24,26 @@ function fakePlayer(procs: ProcDef[]): { p: Entity; ctx: SimContext; events: str
     cooldowns: new Map<string, number>(),
     dead: false,
   } as unknown as Entity;
+  return withCtx(p, procs, events);
+}
+
+function fakeSubject(id: number, hostile: boolean): Entity {
+  return {
+    id,
+    kind: hostile ? 'mob' : 'player',
+    hostile,
+    hp: 300,
+    maxHp: 300,
+    auras: [] as Entity['auras'],
+    dead: false,
+  } as unknown as Entity;
+}
+
+function withCtx(
+  p: Entity,
+  procs: ProcDef[],
+  events: string[],
+): { p: Entity; ctx: SimContext; events: string[] } {
   const ctx = {
     players: new Map([[1, { cls: 'priest' }]]),
     playerMods: () => ({ procs }),
@@ -94,6 +114,95 @@ describe('talent proc engine', () => {
     tickProcState(p, 20.05); // age past the ICD
     onDamageTaken(ctx, p, 80);
     expect(events).toHaveLength(2);
+  });
+
+  it("absorb with target: 'self' wards the caster, never the live hostile cast target", () => {
+    // The Hellglass Ward shape: the triggering casts are hostile, so the cast
+    // target must NOT receive the ward. The negative assertion is the point.
+    const proc: ProcDef = {
+      id: 'test_hellglass',
+      name: 'Test Hellglass',
+      trigger: { on: 'castNth', n: 3, abilities: ['shadow_bolt'] },
+      responses: [
+        { kind: 'absorb', amount: 90, duration: 10, name: 'Test Hellglass', target: 'self' },
+      ],
+    };
+    const { p, ctx } = fakePlayer([proc]);
+    const enemy = fakeSubject(2, true);
+    for (let i = 0; i < 3; i++) onCastCompleted(ctx, p, 'shadow_bolt', enemy);
+    expect(p.auras.some((a) => a.id === 'test_hellglass' && a.kind === 'absorb')).toBe(true);
+    expect(enemy.auras).toHaveLength(0);
+  });
+
+  it("absorb with target: 'self' still lands on the caster when the 3rd cast kills", () => {
+    // Pins the onCastCompleted dead-target fallback: subject falls back to the
+    // player, and the self-targeted ward must land on the caster either way.
+    const proc: ProcDef = {
+      id: 'test_hellglass',
+      name: 'Test Hellglass',
+      trigger: { on: 'castNth', n: 3, abilities: ['shadow_bolt'] },
+      responses: [
+        { kind: 'absorb', amount: 90, duration: 10, name: 'Test Hellglass', target: 'self' },
+      ],
+    };
+    const { p, ctx } = fakePlayer([proc]);
+    const enemy = fakeSubject(2, true);
+    onCastCompleted(ctx, p, 'shadow_bolt', enemy);
+    onCastCompleted(ctx, p, 'shadow_bolt', enemy);
+    enemy.dead = true;
+    onCastCompleted(ctx, p, 'shadow_bolt', enemy);
+    expect(p.auras.some((a) => a.id === 'test_hellglass' && a.kind === 'absorb')).toBe(true);
+    expect(enemy.auras).toHaveLength(0);
+  });
+
+  it('absorb without a target field still shields the subject (the heal-target shape)', () => {
+    // Warding Refrain / Grove Covenant: a heal-triggered ward keeps landing on
+    // the friendly cast target, byte-identical to before the target field.
+    const proc: ProcDef = {
+      id: 'test_refrain',
+      name: 'Test Refrain',
+      trigger: { on: 'castNth', n: 1, abilities: ['lesser_heal'] },
+      responses: [{ kind: 'absorb', amount: 40, duration: 10, name: 'Test Refrain' }],
+    };
+    const { p, ctx } = fakePlayer([proc]);
+    const ally = fakeSubject(3, false);
+    onCastCompleted(ctx, p, 'lesser_heal', ally);
+    expect(ally.auras.some((a) => a.id === 'test_refrain' && a.kind === 'absorb')).toBe(true);
+    expect(p.auras).toHaveLength(0);
+  });
+
+  it("heal with target: 'self' heals the caster, not the subject", () => {
+    // No current talent uses this arm; it closes the same latent hazard for
+    // heal responses whose triggering casts are hostile.
+    const proc: ProcDef = {
+      id: 'test_leech',
+      name: 'Test Leech',
+      trigger: { on: 'castNth', n: 1, abilities: ['shadow_bolt'] },
+      responses: [{ kind: 'heal', amount: 25, target: 'self' }],
+    };
+    const { p, ctx } = fakePlayer([proc]);
+    p.hp = 100;
+    const enemy = fakeSubject(2, true);
+    enemy.hp = 100;
+    onCastCompleted(ctx, p, 'shadow_bolt', enemy);
+    expect(p.hp).toBe(125);
+    expect(enemy.hp).toBe(100);
+  });
+
+  it('heal without a target field still heals the subject', () => {
+    const proc: ProcDef = {
+      id: 'test_mend',
+      name: 'Test Mend',
+      trigger: { on: 'castNth', n: 1, abilities: ['lesser_heal'] },
+      responses: [{ kind: 'heal', amount: 25 }],
+    };
+    const { p, ctx } = fakePlayer([proc]);
+    p.hp = 100;
+    const ally = fakeSubject(3, false);
+    ally.hp = 100;
+    onCastCompleted(ctx, p, 'lesser_heal', ally);
+    expect(ally.hp).toBe(125);
+    expect(p.hp).toBe(100);
   });
 
   it('cooldownRefund shaves and clamps, reset clears', () => {


### PR DESCRIPTION
## Summary

The warlock choice-row talent Hellglass Ward ("Every 3rd damaging Fire or Shadow spell raises a demonic ward absorbing 90 damage for 10 sec") applied its ward to the enemy the triggering spell hit, not to the warlock. The dead-target fallback inverted it: if the 3rd cast killed the target the caster got the ward, and if the target survived, the target did.

Root cause: Hellglass rides the shared talent-proc engine (`src/sim/combat/talent_procs.ts`). A `castNth` trigger fires with the triggering cast's target as the response subject, and the `absorb` response applies its aura to that subject. That subject plumbing is correct for every other absorb proc in the game (their triggers are heals or hits taken, so the subject is a friendly or the wearer); Hellglass is the only absorb proc whose triggering abilities are hostile.

The fix makes the recipient explicit rather than inferred:

- Schema (`src/sim/content/talents.ts`): an optional `target?: 'self'` field on the `absorb` and `heal` arms of `ProcResponse`. The heal arm has the identical latent hazard (no current talent hits it); this closes the class of bug, not just the instance.
- Engine (`src/sim/combat/talent_procs.ts`): `fireOne` resolves the recipient as `response.target === 'self' ? player : subject` for both arms. Pct-of-max-HP amounts and the `wardBloom` spellfx target follow the recipient. No hostility inference, by design (offline/PvP/charm edge cases, and no implicit behavior change for future content).
- Data (`src/sim/content/choice_rows_classic.ts`): Hellglass Ward's absorb response gains `target: 'self'`. No other talent touched.

Recipient audit of all seven absorb procs (the blast radius):

| Proc | Trigger | Subject | After this PR |
|---|---|---|---|
| `pal_greater_blessing` (Afterglow Aegis) | spellCrit on heals | heal target (friendly) | unchanged |
| `pri_lingering_ward` (Warding Refrain) | castNth on Whispered Prayer | heal target (friendly) | unchanged |
| `pri_inner_fire` (Wounded Halo) | bigHitTaken | the wearer | unchanged |
| `pri_blessed_recovery` (Halo Aftershock) | spellCrit on heals | heal target (friendly) | unchanged |
| `wlk_grimoire_of_carnage` (Hellglass Ward) | castNth on damaging Fire/Shadow | the enemy (the bug) | fixed: the warlock |
| `dru_grove_covenant` (Grove Covenant) | castNth on Wildmend | heal target (friendly) | unchanged |
| `dru_survival_of_the_fittest` (Ironhide Reflex) | bigHitTaken | the wearer | unchanged |

No rng draws added, removed, or reordered (`tests/parity` green); no new `SimEvent` type or wire change; no player-visible text change (no i18n work needed, `tests/localization_fixes.test.ts` green).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npm run gate`: every step up to the full vitest suite is green (i18n gen + freshness, malware scan, changed-files biome, SFX conformance). The full suite passes 17171 tests with the only failures being the two known `tests/deploy_watchdog.test.ts` "abandons a hung docker" cases, a sandbox-environment flake: I verified they fail identically on the pristine release branch with this change stashed (CI runs them fine). Because the gate aborts at that step, I ran the later steps directly: `npx tsc --noEmit` (clean) and `npm run build` (all five entries, exit 0).
  - Test-first: the three decisive new cases were red before the fix and green after: the self-targeted ward lands on the caster with the enemy carrying no ward (live target), the self-targeted heal heals the caster, and the real Hellglass data drives a warlock `Sim` (three Gloom Bolt casts at a live mob) with the ward on the warlock and none on the mob.
  - Pinned regressions: the dead-target fallback still lands the ward on the caster, and absorb/heal responses without a `target` field still land on the subject (the heal-target shape used by the priest, paladin, and druid procs).
  - Guards: `npx vitest run tests/parity tests/architecture.test.ts tests/localization_fixes.test.ts tests/choice_rows_engine.test.ts tests/choice_rows_redesign.test.ts tests/choice_rows_unlock_guard.test.ts` and `npx tsc --noEmit`, all green.
- Manual steps: N/A (sim-only, covered by the automated cases above).

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green except the two pre-existing
      `deploy_watchdog` sandbox flakes detailed above (verified unrelated by stashing);
      `tsc` and all builds run directly and green. I added decisive tests for the
      changed behavior (red before the fix) and recorded the checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: sim-only, no UI change.
- ~Accessible.~ N/A: no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

Generated with [Claude Code](https://claude.com/claude-code)
