### PR TITLE
fix(ui): keep the dungeon finder catalogue scrolled where the player left it

### DIFF
--- a/src/ui/dungeon_finder_window.ts
+++ b/src/ui/dungeon_finder_window.ts
@@ -165,8 +165,15 @@ export class DungeonFinderWindow {
     }
     this.lastSig = sig;
     this.deps.hideTooltip();
+    // .df-rail (not #dungeon-finder-window) is the catalogue's scroll container; it
+    // is recreated on every rebuild, so capture its scroll offset and reapply it to
+    // the fresh one, else selecting a row near the bottom snaps the list back to the
+    // top and scrolls the just-picked dungeon out of view (the bank/spellbook idiom).
+    const prevRailScrollTop = el.querySelector('.df-rail')?.scrollTop ?? 0;
     el.innerHTML = this.liveHtml(view);
     this.wire(el, view);
+    const rail = el.querySelector('.df-rail');
+    if (rail) rail.scrollTop = prevRailScrollTop;
     this.cacheClockSlots(el);
     this.lastClockText.clear();
     this.updateClocks(view.clocks);

--- a/tests/dungeon_finder_window.test.ts
+++ b/tests/dungeon_finder_window.test.ts
@@ -20,6 +20,17 @@ describe('dungeon finder window painter (source contract)', () => {
     expect(src).toContain('data-df-clock');
   });
 
+  // The rebuild at `el.innerHTML = this.liveHtml(view)` replaces the whole window
+  // subtree, so the freshly parsed .df-rail starts at scrollTop 0. Selecting a row
+  // always takes that branch (the click flips this.pane and feeds selectedId into
+  // view.sig), which is why picking a dungeon near the bottom snapped the list back
+  // to the top. Capture-before / restore-after is the same idiom bank_window,
+  // spellbook_window and crafting_window already use for their own scrollers.
+  it('preserves the catalogue rail scroll offset across a rebuild', () => {
+    expect(src).toContain("el.querySelector('.df-rail')?.scrollTop ?? 0");
+    expect(src).toContain('rail.scrollTop = prevRailScrollTop');
+  });
+
   it('owns WCAG focus: dialog root marked once on open, focus captured and restored', () => {
     expect(src).toContain("markDialogRoot(root, { labelledBy: 'dfinder-title' })");
     expect(src).toContain('this.openerFocus = this.deps.captureFocus();');


### PR DESCRIPTION
## Summary

Fixes the Dungeon Finder catalogue snapping back to the top when you pick a dungeon near the bottom of the list, which made picking several in a row tedious: the row you just selected scrolled out of view and you had to scroll back down every time.

`render()` rebuilds the whole window in one assignment:

```ts
el.innerHTML = this.liveHtml(view);
```

`.df-rail` (the catalogue's scroll container, `overflow-y: auto` in `components.css`) is part of that markup, so the rebuild throws away the node holding the player's scroll offset and parses a fresh one, which starts at `scrollTop` 0.

A row click always reaches that rebuild, for two independent reasons: it flips `this.pane` from `'list'` to `'detail'`, and `pane` is concatenated into the render signature; and `selectedActivityId` feeds `buildDungeonFinderView`'s own `sig`. So the signature skip above can never absorb a selection.

The fix captures the rail's offset before the rebuild and reapplies it to the new node. That is the same idiom `bank_window`, `spellbook_window` and `crafting_window` already use for their own scrollers, so this brings the finder in line with the rest of the HUD rather than inventing anything.

Two deliberate scoping choices:

- **`.df-rail` only.** It exists only on the catalogue tab, so the queue and board tabs are a no-op (the selector is `null` before and after).
- **`.df-detail` is left alone.** Its content becomes a different dungeon on selection, so starting that pane at the top is the correct behavior.

I did look at the in-place alternative (patch just the `active` class on the changed row instead of rebuilding). The painter is built entirely from HTML-string builders (`rowHtml`, `detailHtml`, `boardHtml`, ...), so there is no cheap seam for that without restructuring it away from its established style, and every comparable window in the repo hit the same constraint and resolved it the same way.

## Related issues

Closes #2026

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/dungeon_finder_window.test.ts tests/dungeon_finder_view.test.ts tests/bank_window.test.ts tests/spellbook_window.test.ts tests/architecture.test.ts` (152 pass)
  - `npx tsc --noEmit` (clean), `npx @biomejs/biome check` on both changed files (clean)
- Manual steps: open the Dungeon Finder on the catalogue tab, size the window so the rail scrolls, scroll down and select the second-to-last dungeon. Before: the list jumps to the top and the selected row is off screen. After: the list stays put and the selected row is still visible. Also checked the queue and board tabs (no rail, unaffected) and that the detail pane still starts at the top when you pick a different dungeon.

I added a case to `tests/dungeon_finder_window.test.ts` in that file's existing source-contract style, and confirmed it is decisive: it fails against the unmodified painter and passes with the change.

## Screenshots / recordings

Deliberately omitting stills here: the change alters no layout, spacing, or color, only the scroll offset that survives a rebuild, so a before/after pair of static screenshots would look identical. The difference is only visible in motion. Happy to attach a short clip if you would like one for the record.

---

## Checklist

### Quality

- [x] **The full gate passes.** Typecheck, Biome and the touched suites are green. I added a decisive test for the changed behavior (verified failing without the fix) and recorded the manual steps above.
