### PR TITLE
fix(ui): refresh the character sheet's prestige rank the moment you prestige

### DIFF
--- a/src/sim/progression/xp.ts
+++ b/src/sim/progression/xp.ts
@@ -76,5 +76,6 @@ export function prestige(ctx: SimContext, pid?: number): boolean {
     text: `You have prestiged! Prestige Rank ${r.meta.prestigeRank}.`,
     color: '#ffd100',
   });
+  ctx.emit({ type: 'prestige', pid: r.e.id, rank: r.meta.prestigeRank });
   return true;
 }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -3073,6 +3073,10 @@ export type SimEvent = { pid?: number } & (
   | { type: 'xp'; amount: number; rested?: number }
   | { type: 'honor'; amount: number; reason: HonorReason }
   | { type: 'levelup'; level: number }
+  // opt-in post-cap rank reset (always personal: emitted with pid). The rank
+  // itself rides every self snapshot, so this exists to tell an open character
+  // sheet WHEN to repaint, the same job the honor event does for the Honor row.
+  | { type: 'prestige'; rank: number }
   // post-cap cosmetic progression (Max-Level XP Overflow): crossing a virtual
   // level past the cap (milestone unlocks ride the deedUnlocked event since
   // the milestone unification; the legacy milestoneUnlocked emit is gone)

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -8648,6 +8648,14 @@ export class Hud {
           }
           break;
         }
+        // The rank itself already rides every self snapshot; the open character
+        // sheet is only repainted on an explicit trigger, so without this it
+        // keeps showing the pre-prestige rank until closed and reopened. Same
+        // job the 'honor' case below does for the sheet's Honor balance.
+        case 'prestige': {
+          this.renderCharIfOpen();
+          break;
+        }
         case 'honor': {
           const amount = formatNumber(ev.amount, { maximumFractionDigits: 0 });
           const honorMessage = t('hudChrome.warfare.honorGain', {

--- a/tests/parity/golden/g1b_xp_prestige.json
+++ b/tests/parity/golden/g1b_xp_prestige.json
@@ -769,7 +769,7 @@
       "time": 3,
       "nextId": 416,
       "state": "87876dad",
-      "events": "430e2101",
+      "events": "f92c18e2",
       "rng": {
         "draws": 75,
         "digest": "cc652885"

--- a/tests/prestige_ui.test.ts
+++ b/tests/prestige_ui.test.ts
@@ -1,0 +1,21 @@
+// Source-scan guard for the prestige repaint wiring (the honor_ui.test.ts shape).
+// prk rides every self snapshot, so the character sheet always has the new rank
+// in hand; it just never repainted on prestige, leaving the open window showing
+// the previous rank until it was closed and reopened. Node-only: reads the file
+// as text, no DOM.
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const hud = readFileSync(new URL('../src/ui/hud.ts', import.meta.url), 'utf8');
+
+describe('prestige character-sheet refresh', () => {
+  it('repaints the open character sheet when a prestige event lands', () => {
+    const start = hud.indexOf("case 'prestige': {");
+    expect(start, "the hud's prestige event case").toBeGreaterThan(-1);
+    const end = hud.indexOf("case 'honor': {", start);
+    const handler = hud.slice(start, end);
+
+    expect(handler).toContain('this.renderCharIfOpen()');
+  });
+});

--- a/tests/xp.test.ts
+++ b/tests/xp.test.ts
@@ -312,6 +312,30 @@ describe('prestige', () => {
     expect(sim.prestige()).toBe(false);
     expect(sim.prestigeRank).toBe(0);
   });
+
+  // The rank rides every self snapshot, so the client always HAS the new value;
+  // what the character sheet lacked was a signal telling it when to repaint.
+  // This event is that signal (the 'honor' precedent), so a successful prestige
+  // must emit exactly one carrying the new rank, and a refused one must emit none.
+  it('emits a personal prestige event carrying the new rank', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(MAX_LEVEL);
+    sim.grantXp(800_000);
+    sim.drainEvents();
+
+    expect(sim.prestige()).toBe(true);
+    const events = sim.drainEvents().filter((e) => e.type === 'prestige');
+    expect(events).toEqual([{ type: 'prestige', pid: sim.playerId, rank: 1 }]);
+  });
+
+  it('emits no prestige event when the gate refuses', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(10);
+    sim.drainEvents();
+
+    expect(sim.prestige()).toBe(false);
+    expect(sim.drainEvents().filter((e) => e.type === 'prestige')).toEqual([]);
+  });
 });
 
 describe('prestige anti-abuse gate (server-locked rank)', () => {


### PR DESCRIPTION
## Summary

Fixes the character window showing the old prestige rank after prestiging, exactly as reported: the chat line announces the new rank while the open window still reads the previous one, and it only catches up once the window is closed and reopened.

The interesting part is that **the data was never wrong**. `prk` rides every self snapshot unconditionally (it sits in the `Object.assign` block of `selfWireJson`, outside the `heavyDue` gate), and `ClientWorld` decodes it on every self-frame. So by the time the chat line lands, the client already holds the new rank. `'prestige'` being in `HEAVY_SELF_CMDS` is also unrelated: that only refreshes the genuinely heavy fields (`inv`, `bags`, `equip`, `deeds`, `tal`, ...), and `prk` is not one of them.

What was missing is the signal telling the open sheet to repaint. `CharWindow.render()` runs only on explicit triggers, currently: open/toggle, `onInventoryChanged`, `onCosmeticsChanged`, an Honor award, and relocalize. Prestige's only client-visible signal was a generic `log` event, which the HUD appends to chat and never acts on further. Since `render()` rebuilds the panel from live `IWorld` state, reopening the window shows the right value immediately, which is precisely the reporter's workaround.

So this gives prestige its own `SimEvent`, the way `honor` and `levelup` already have one, and repaints the sheet on it:

```ts
case 'prestige': {
  this.renderCharIfOpen();
  break;
}
```

Why an event rather than the smaller alternatives:

- **It covers offline and online through one path.** The sim emits it in both hosts, and the server already forwards `pid`-tagged events to the acting player's session only, so there is no separate online-only plumbing and no cross-player leakage.
- **It avoids sniffing the log text.** Matching on the English `"You have prestiged!"` string would work today and quietly break the moment that line is localized.
- **It matches the codebase's own stated shape.** The `SimEvent` union is documented as exhaustively typed, and the `honor` case is the exact precedent (it repaints the sheet's Honor balance for the same reason).

Worth noting the same gap exists for `levelup` and `virtualLevelUp`, which also do not repaint an open sheet. I left those alone to keep this scoped to the reported bug, but happy to follow up if you want them covered.

## Related issues

Closes #2137

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/xp.test.ts tests/prestige_ui.test.ts tests/honor_ui.test.ts tests/snapshots.test.ts tests/architecture.test.ts` (209 pass)
  - `npx vitest run tests/parity` (183 pass)
  - `npx tsc --noEmit` (clean), `npx @biomejs/biome check` on the changed files (no errors, no format diff)
  - `npx vitest run` (full suite)

One note on the full suite, since I would rather flag it than quietly tick the box. I develop on Windows, and a full run on an unmodified checkout of `release/v0.29.0` already fails 11 files / 25 tests here for environment reasons (the SFX studio suites want FFmpeg, `static_sfx_serving` hits `EPERM` on a Windows rename, `new_endpoint` gets a null status from its `tsc` spawn, plus `asset_pipeline` and `prod_cpu_monitor`). With this change applied the run is also 11 files / 25 tests, and the difference against that baseline is two files that swap in and out (`ai_review`, `deploy_watchdog`); both pass in isolation on this branch, so they are I/O timeouts under a loaded parallel run rather than anything to do with this change. Nothing in the failing set touches `src/sim/`, `src/ui/`, or the parity gate. Your Linux CI should be the real verdict.
- Manual steps: at the cap with a full prestige bar, open the character window and prestige. Before: chat says rank N+1, the window still reads N until reopened. After: the window updates in place with the chat line.

Tests added, both verified decisive (they fail without the fix):

- `tests/xp.test.ts`: a successful prestige emits exactly one `prestige` event carrying the new rank, and a gate-refused prestige emits none.
- `tests/prestige_ui.test.ts`: the HUD's `prestige` case repaints the sheet (the `honor_ui.test.ts` source-contract shape).

### On the golden trace

The second commit regenerates one golden with `UPDATE_PARITY=1`, kept separate per `tests/parity/CLAUDE.md`. It is a one-line diff in `g1b_xp_prestige.json`: the `events` digest at the `prestige-accept` label, which now folds the added event. `state` (`87876dad`), `rng.draws` (75) and `rng.digest` are byte-identical, which is the point: the new emit changes no world state and draws no randomness.

## Screenshots / recordings

N/A. The window's layout and styling are untouched; the only difference is that the rank number it already had access to now appears without a reopen.

---

## Checklist

### Quality

- [x] **The full gate passes.** Typecheck, Biome, the parity gate and the touched suites are green. I added decisive tests for the changed behavior and recorded the manual steps above.
