### PR TITLE
fix(sim): stop a DoT tick from ticking twice when it breaks its own carrier's aura

### DIFF
--- a/src/sim/combat/auras.ts
+++ b/src/sim/combat/auras.ts
@@ -14,6 +14,14 @@
 // `e.auras.splice`, `c.remaining -= 2`, `a.tickTimer += ...`) are preserved exactly so
 // the parity gate's full-state trace AND rng draw-order log stay byte-identical.
 //
+// The one deliberate deviation from verbatim is updateAuras's snapshot-plus-liveness
+// walk (see the comment at the loop). It fixes a re-entrancy bug the verbatim move
+// carried over: a DoT tick's own dealDamage call splicing an aura out of this same
+// array mid-walk, which pulled the just-processed entry back under the cursor and
+// ticked it twice. It keeps the iteration ORDER, and therefore the rng draw order,
+// identical for every aura that survives its own turn: the parity gate stays green
+// with NO golden regeneration.
+//
 // CRITICAL: updateAuras carries TWO load-bearing `e.dead` guards, the top guard and
 // the post-DoT guard. A DoT tick calls ctx.dealDamage, which can kill the target
 // mid-walk; both guards stop further processing of a dead entity's auras. They MUST
@@ -194,8 +202,22 @@ export function updateAuras(ctx: SimContext, e: Entity): void {
   let statsDirty = false;
   // Talent-proc internal cooldowns age at the same cadence as auras.
   tickProcState(e, DT);
-  for (let i = e.auras.length - 1; i >= 0; i--) {
-    const a = e.auras[i];
+  // Walk a SNAPSHOT of e.auras, not the live array. A DoT tick's own
+  // ctx.dealDamage call can splice an aura out of this SAME array mid-walk
+  // (damage.ts's own backward sweeps remove a breaksOnDamage control aura, or a
+  // depleted absorb shield). A removal at an index BELOW the live cursor shifts
+  // everything above it down by one, so a live-indexed walk lands the
+  // just-processed entry back under the cursor and processes it twice: a double
+  // decrement of remaining/tickTimer and, for a DoT, a second dealDamage call in
+  // the same sim tick. The snapshot fixes the iteration ORDER once, up front,
+  // identical to the live order at that moment, so every aura still present when
+  // its turn comes is processed exactly as before. The liveness check only skips
+  // an entry a side effect already removed; it never revisits one. rng draw order
+  // is unaffected: this removes a spurious extra dealDamage, it adds none.
+  const snapshot = e.auras.slice();
+  for (let i = snapshot.length - 1; i >= 0; i--) {
+    const a = snapshot[i];
+    if (!e.auras.includes(a)) continue; // removed by an earlier entry's side effect this tick
     a.remaining -= DT;
     // charge-limited thorns (Lightning Shield): age its internal cooldown so the
     // next melee hit can reflect once it elapses. No-op for ungated thorns.
@@ -277,7 +299,17 @@ export function updateAuras(ctx: SimContext, e: Entity): void {
       }
     }
     if (a.remaining <= CAST_COMPLETE_EPS) {
-      e.auras.splice(i, 1);
+      // `i` indexes the snapshot, which no longer matches e.auras once a mid-tick
+      // removal has shifted it, so splice the aura's actual live position. The
+      // guard covers the one remaining self-removal window (an aura whose OWN
+      // side effect this iteration spliced it out): whoever removed it already
+      // emitted its fade, so the whole expiry block is skipped rather than
+      // double-emitted. Every aura reachable here today is still live, since the
+      // top-of-loop check skipped anything an EARLIER entry removed, so this is
+      // behavior-identical.
+      const liveIndex = e.auras.indexOf(a);
+      if (liveIndex < 0) continue;
+      e.auras.splice(liveIndex, 1);
       ctx.applyNonPlayerStatAura(e, a, -1);
       ctx.emit({ type: 'aura', targetId: e.id, name: a.name, gained: false });
       // A HoT that ran its FULL duration (this natural-expiry path, never a

--- a/tests/combat_auras.test.ts
+++ b/tests/combat_auras.test.ts
@@ -131,6 +131,35 @@ describe('auras: updateAuras DoT tick', () => {
     updateAuras(sim.ctx, mob);
     expect(mob.dead).toBe(true);
   });
+
+  // Re-entrancy repro: a DoT tick calls ctx.dealDamage, which runs its own
+  // backward sweeps over this SAME e.auras array and can splice a breaksOnDamage
+  // control aura (Fear and friends) or a depleted absorb shield out mid-walk.
+  // With that aura at a LOWER index than the DoT (pushed first, so the backward
+  // walk reaches the DoT before it), the removal shifts the array and a
+  // live-indexed walk lands the just-processed DoT back under the cursor: its
+  // remaining/tickTimer are decremented twice and it deals a SECOND tick of
+  // damage in the same sim tick.
+  it('a DoT tick that breaks a lower-indexed breaksOnDamage aura ages and ticks exactly once', () => {
+    const sim = makeSim();
+    const mob = spawnMob(sim, 1000);
+    const fear = aura('incapacitate', 0, { breaksOnDamage: true, remaining: 10, duration: 10 });
+    const dot = aura('dot', 50, { tickInterval: DT, remaining: 60, duration: 60 });
+    mob.auras.push(fear, dot);
+
+    const hp0 = mob.hp;
+    updateAuras(sim.ctx, mob);
+
+    // Exactly one tick: the double-tick this guards against would take 100.
+    expect(hp0 - mob.hp).toBe(50);
+    // The DoT's own damage still breaks the fear, as it should.
+    expect(mob.auras.some((a) => a.kind === 'incapacitate')).toBe(false);
+    // ...and the DoT aged by exactly one DT, not two.
+    const survivingDot = mob.auras.find((a) => a.kind === 'dot');
+    expect(survivingDot).toBeTruthy();
+    expect(survivingDot?.remaining).toBeCloseTo(60 - DT, 9);
+    expect(mob.auras.length).toBe(1);
+  });
 });
 
 describe('auras: updateAuras expiry / HoT / top guard', () => {


### PR DESCRIPTION
## Summary

`updateAuras` walks `e.auras` backward by live index:

```ts
for (let i = e.auras.length - 1; i >= 0; i--) {
  const a = e.auras[i];
```

The DoT branch inside that loop calls `ctx.dealDamage`, and `dealDamage` runs its own backward sweeps over **the same array**: it splices out a `breaksOnDamage` control aura (the Fear family) when damage lands, and it splices out an absorb shield that has just been depleted.

So a removal can happen underneath a live cursor. When the removed aura sits at a **lower** index than the DoT being processed, everything above it shifts down one, which puts the just-processed DoT back under the cursor. It is then processed a second time in the same sim tick: `remaining` and `tickTimer` are decremented twice, and the target takes a second tick of damage.

In play that means a feared target taking a DoT eats double damage on the tick that breaks the fear. It needs the two to coincide, so it is intermittent rather than constant, which is probably why it has gone unnoticed.

The fix walks an up-front snapshot, skips any entry a side effect already removed, and splices expiries at the aura's live index rather than the snapshot index.

**On determinism**, since this file's header is explicit that the extraction was a verbatim move to keep the parity trace byte-identical: the snapshot is taken in the exact order the live walk had, so every aura that survives its own turn is processed exactly as before, and the change only ever *removes* a spurious `dealDamage` call, never adds one. The parity gate is green **with no golden regeneration**, which is the proof: both the full-state trace and the rng draw-order log are unchanged. I also added a note to the file header, since the PRIME DIRECTIVE comment there would otherwise read as contradicted by this diff.

## Related issues

None open that I could find; I ran into this reading the aura tick.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/combat_auras.test.ts tests/parity tests/architecture.test.ts` (220 pass, 1 skipped)
  - `npx tsc --noEmit` (clean), `npx @biomejs/biome check` on both changed files (no errors, no format diff)
- Manual steps: N/A, the crossing case is covered directly by the new unit test against a real `Sim.ctx`.

The new test pins the exact crossing case: a `breaksOnDamage` fear pushed at a lower index than a 50-damage DoT, so the backward walk reaches the DoT first and the fear is removed beneath it. It asserts one tick of damage (50), that the fear is still broken by that damage, that the DoT aged by exactly one `DT`, and that it is the only aura left. Against the unmodified walk it reads **100 damage instead of 50**, so it reproduces the defect rather than just documenting the new shape.

## Screenshots / recordings

N/A, no visual surface.

---

## Checklist

### Quality

- [x] **The full gate passes.** Typecheck, Biome, the parity gate (no golden regeneration needed) and the aura suite are green. The added test is verified to fail against the pre-fix walk.
