### PR TITLE
test(professions): Phase 12 QA, base tool tier gating

### DIFF
--- a/docs/professions-2/phase-12b-gathering-rhythm.md
+++ b/docs/professions-2/phase-12b-gathering-rhythm.md
@@ -245,7 +245,10 @@ STOPPING RULES:
 
 Every test, literal, and golden this phase is EXPECTED to move, so the implementer re-pins
 deliberately instead of discovering the blast radius mid-flight. Anything outside this list
-that reds is a defect in the change, not an accepted cost.
+that reds is a defect in the change, not an accepted cost. Re-inventoried by the Phase 12
+QA session against the Phase 12 merge (a57e43b78) plus the QA PR's own pins: the last
+three rows below cover the pins that landed AFTER the original inventory point and keep
+this list closed.
 
 - `tests/professions_fishing.test.ts`, describe "fishing one-draw rng contract (pin 2)": the
   one-draw-per-cast contract ("draws exactly one rng value per normal cast, including the
@@ -320,3 +323,25 @@ that reds is a defect in the change, not an accepted cost.
   pinned callback-name list in tests/sim_context.test.ts (the Phase 7 trap).
 - The wire: castRem/castTot ride dynamicFields only while castingAbility is set; the gather
   cast reuses that shape for free. Do NOT add any bite field beside them.
+- (post-inventory, Phase 12 + its QA) `tests/professions_fishing.test.ts`, describe
+  "fishing band tool cap (Professions 2.0 Phase 12)": the five literal-sequence arms (the
+  three rod-cap arms, the pole-only proficiency-0 byte-identity walk, and the QA's "a high
+  rod never buys bands" proficiency-arm pin) re-record under the new draw order exactly
+  like pins 1 and 6, same band-discriminating-window trap; and "useItem on each new rod
+  starts the standard fishing cast" pins the cast start at FISHING_CAST_ID with the
+  castStart emit, so it re-pins to the new bite cast-start shape.
+- (post-inventory, Phase 12 + its QA) `tests/professions_tools.test.ts`, describe
+  "sim-level node access gating (Professions 2.0 Phase 12)": the deny, unlock, owned-best,
+  requiredTier-3, and herbalism arms drive harvestNode synchronously with exact
+  gatherDenied shapes and a zero-draw deny pin; extend them to the new cast entry point
+  (extend, do not orphan), and the deny-is-rng-free property must hold at cast START (a
+  denied attempt draws nothing and starts no cast).
+- (post-inventory, Phase 12 + its QA) `tests/gather_node_harvest.test.ts`, describes
+  "node tool gate ordering (Phase 12)" and "Phase 12 determinism (same seed, same drive)":
+  the deny-order pins (respawn before tool gate, tool gate before bags-full) and the
+  hot-path exactly-two-draws pin re-home to the cast-completion shape; the determinism
+  drive re-shapes under the cast, and its fishDraws liveness pin (completeFishing called
+  directly, bypassing startFishing, exactly one table draw) survives only while the reel
+  keeps its single draw, re-pin consciously if that draw moves. The corpse premium-arm
+  suite (tests/corpse_harvest_sim.test.ts) is OUTSIDE this phase's blast radius: 12b adds
+  no corpse timing.

--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -449,6 +449,39 @@ IWorld member; parity goldens byte-identical. Deferred: rod-synergy and cap visi
 node hover tooltip is desktop-pointer-only (mobile reads the minimap lock tint + denial
 toast).
 
+Phase 12 QA (2026-07-20): PASS with fixes, zero blocking. Verified off the merge a57e43b78
+into release/v0.29.0 (QA diff = the PR #2217 commits c139db6d5..4fa130aedf first-parent
+across the 59f9c42d2 sync, whose only cargo was the market landscape PR #2107, clean
+release-merge-audit on record). Method: validation matrix green at the untouched tip first
+(tsc plus the seventeen phase-touched suites), one Explore context load, then an
+adversarial-verify Workflow (three packet audits plus the four dispatch-matrix reviewers;
+every BLOCKING or SHOULD-FIX finding retried by two independent skeptics under
+code-verification and impact lenses; all seven audits delivered structured output first
+try), with a correctness probe suite driven through the real Sim and deleted in-tree
+(bare-hands tier-1 success, rng-free t2/t3 denies with exact event shapes, pick unlocks,
+per-profession owned-best, the herbalism arm, corpse deny and restore via withTier with
+identical claims and draws, silent band caps with and without rods, useItem rod casts,
+both-host denial liveness). Two SHOULD-FIX decisiveness holes fixed test-first with
+mutation verification: the fishing band min() proficiency arm was one-arm-only (a tier-3
+rod at band-0 proficiency now pins band 0; the pre-fix suite passed with the min collapsed
+to the rod arm), and requiredTier was never pinned at any value other than 2 (an
+owned-but-short iron pick at a tier-3 vein now pins requiredTier 3). Also landed: the
+herbalism deny/unlock arm through the real harvestNode, the corpse
+granted-with-tool-at-raised-tier arm, the FIRST-failing-family pin on the corpse deny
+event (asymmetric raised tiers both ways at the pre-hunted seed 11), a draw-count liveness
+pin on the determinism drive's fishing arm, withTier absent-component restore hygiene, and
+the gate-order comment correction in gather_node_interact.ts (the client pre-gate
+deliberately reports the lock before readiness while the sim checks respawn first; both
+orders were already pinned, the comment claimed they matched). Verified clean: the PR body
+references all five screenshot pairs, wiki:content regenerates no diff, no scope-creep
+timing mechanic, the parked tool-effect half has zero callers, rods stocked at the literal
+trader_wilkes. Deferred with reasons: the main.ts gate-wiring source pin (rename-fragile
+idiom; the sim/server deny is the authoritative backstop, so a dropped wire only costs the
+pre-gate line), the items.ts isGatherToolUse consistency swap (zero behavior change), the
+toolTierUnmet key composition duplication (two copies, below the rule of three), the
+hover-tooltip listener-logic test and the *_tooltip.ts painter-scan naming, and the
+minimap per-build tool-tier memo allocation. Drift notes in state.md.
+
 ### Phase 12b: Gathering rhythm
 - [ ] Gather cast (tool-tier and band scaled, floored); completion re-validates; move cancels free
 - [ ] The shared non-spell-cast predicate consolidates the eleven cast-id exemption sites

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -1019,6 +1019,26 @@ tables, i18n key namespaces, files created)
   parity goldens byte-identical (nodes are content, not entities); the
   tools.ts gating trio now has live callers while the effect/recharge
   half stays PARKED with zero callers.
+  Phase 12 QA drift notes (2026-07-20): the corpse deny event's
+  requiredTier is the FIRST failing family in yield order (now pinned
+  both ways at seed 11); for a future corpse mixing tiers the single
+  toast can advertise a lower tier than the highest needed, revisit when
+  a tier-2+ family is authored. bestOwnedAnyGatherToolTier spans ALL
+  gathering professions, so a fishing rod re-opens a raised-tier corpse
+  premium pull (proven live in QA; inert through shipped content;
+  maintainer design call whether rods should count as skinning tools
+  when tier-2+ corpse families arrive). In normal play the client
+  pre-gate short-circuits before harvestNode, so the sim gatherDenied
+  fires mainly online and under direct drives; the sim gate is the
+  authoritative backstop, deliberate. Spectator sessions receive the
+  spectated player's gatherDenied toast (the generic personal-event
+  contract, inherited, not Phase 12-specific). The client pre-gate
+  checks the tool gate BEFORE readiness while the sim checks respawn
+  first; deliberate divergence, both orders pinned, documented at
+  decideGatherNodeAction. RELEASE-NOTES AWARENESS for v0.29.0: the
+  silent band cap applies retroactively to existing high-proficiency
+  rod-less anglers the moment the release ships (band 0 until they buy
+  the 60c/150c rods at trader_wilkes; 12b adds the visibility UX).
 - Phase 12b: (planned) the shared non-spell-cast predicate, the gather
   cast, the fishing bite minigame, rod synergy, placeholder cues; the
   Pin-cost appendix in phase-12b-gathering-rhythm.md is the pre-briefed

--- a/src/game/gather_node_interact.ts
+++ b/src/game/gather_node_interact.ts
@@ -39,9 +39,13 @@ export function decideGatherNodeAction(
 ): GatherNodeVerdict {
   const d = dist2d(playerPos, { x: nodePos.x, y: playerPos.y, z: nodePos.z });
   if (d > INTERACT_RANGE) return 'too_far';
-  // Between range and readiness, mirroring the sim's own harvestNode gate
-  // order (professions/gathering.ts): a locked node reads as locked, not as
-  // "not respawned", and the shared canGatherTier comparator decides.
+  // Deliberate divergence from the sim's authoritative order: harvestNode
+  // checks respawn readiness BEFORE the tool gate (a cooling node never emits
+  // gatherDenied; pinned in tests/gather_node_harvest.test.ts), while this
+  // pre-gate reports the lock first so a locked node reads as locked, not as
+  // "not respawned" (the tool shortfall is the durable, actionable fact; the
+  // client-order pin lives in tests/gather_node_interact.test.ts). The shared
+  // canGatherTier comparator decides both layers.
   if (toolGate && !canGatherTier(toolGate.viewerToolTier, toolGate.nodeTier)) return 'tool_tier';
   if (!ready) return 'not_ready';
   return 'harvest';

--- a/tests/corpse_harvest_sim.test.ts
+++ b/tests/corpse_harvest_sim.test.ts
@@ -533,7 +533,11 @@ describe('corpse premium-arm tool gating (Professions 2.0 Phase 12)', () => {
     try {
       body();
     } finally {
-      tiers[component] = prior;
+      // A future component absent from the table must restore to ABSENT, not
+      // to a present-but-undefined key (which would surprise the literal set
+      // pin below and any Object.keys comparison).
+      if (prior === undefined) delete tiers[component];
+      else tiers[component] = prior;
     }
   }
 
@@ -620,6 +624,32 @@ describe('corpse premium-arm tool gating (Professions 2.0 Phase 12)', () => {
     ]);
   });
 
+  it('an owned tier-2 tool restores the premium pull at a raised family tier (seed 5)', () => {
+    // The canHarvestMonsterMaterial SUCCESS branch with a real tool: the
+    // deny/downgrade arms above never prove a tool actually re-opens the
+    // premium pull once a family tier rises.
+    const { sim, internals, a, mob } = soloRig(5);
+    sim.addItem('mithril_mining_pick', 1, a); // any-profession owned-best covers tier 2
+    sim.drainEvents();
+    let draws = 0;
+    withTier('hide', 2, () => {
+      sim.rng.setObserver(() => draws++);
+      try {
+        sim.harvestCorpse(mob.id, ['hide'], a);
+      } finally {
+        sim.rng.setObserver(null);
+      }
+    });
+    // Same two draws as the bare-handed arms: the success branch adds none.
+    expect(draws).toBe(2);
+    expect(sim.drainEvents().some((e) => e.type === 'gatherDenied')).toBe(false);
+    const meta = internals.players.get(a)!;
+    const specimen = meta.inventory.find((s) => s.itemId === 'pristine_hide');
+    expect(specimen?.instance?.signer).toBe('Alpha');
+    expect(sim.countItem('rough_hide', a)).toBe(3);
+    expect(mob.harvestClaimedBy).toBe(a);
+  });
+
   it('at most ONE gatherDenied per harvest command, even with several denied families (seed 11)', () => {
     // Seed 11 pre-verified against soloRig: BOTH wolf families (hide and
     // fang) roll signable on an untagged harvest, so raising both tiers
@@ -649,6 +679,33 @@ describe('corpse premium-arm tool gating (Professions 2.0 Phase 12)', () => {
     expect(sim.countItem('pristine_hide', a)).toBe(0);
     expect(meta.inventory.some((s) => s.instance?.signer)).toBe(false);
     expect(mob.harvestClaimedBy).toBe(a);
+  });
+
+  it('the single event is tiered off the FIRST failing family in yield order (seed 11)', () => {
+    // hide precedes fang in the wolf's yield order, so asymmetric raised
+    // tiers discriminate FIRST from min/max/last: (hide 2, fang 3) emits 2
+    // (ruling out max and last), the mirror (hide 3, fang 2) emits 3 (ruling
+    // out min). Same pre-hunted seed-11 rig as the dedupe arm above.
+    const first = soloRig(11);
+    first.sim.drainEvents();
+    withTier('hide', 2, () => {
+      withTier('fang', 3, () => {
+        first.sim.harvestCorpse(first.mob.id, undefined, first.a);
+      });
+    });
+    expect(first.sim.drainEvents().filter((e) => e.type === 'gatherDenied')).toEqual([
+      { type: 'gatherDenied', pid: first.a, surface: 'corpse', requiredTier: 2 },
+    ]);
+    const mirror = soloRig(11);
+    mirror.sim.drainEvents();
+    withTier('hide', 3, () => {
+      withTier('fang', 2, () => {
+        mirror.sim.harvestCorpse(mirror.mob.id, undefined, mirror.a);
+      });
+    });
+    expect(mirror.sim.drainEvents().filter((e) => e.type === 'gatherDenied')).toEqual([
+      { type: 'gatherDenied', pid: mirror.a, surface: 'corpse', requiredTier: 3 },
+    ]);
   });
 });
 

--- a/tests/gather_node_harvest.test.ts
+++ b/tests/gather_node_harvest.test.ts
@@ -600,12 +600,21 @@ describe('Phase 12 determinism (same seed, same drive)', () => {
       sim.entities.set(wolf.id, wolf);
       sim.harvestCorpse(wolf.id, ['hide'], pid);
       // A band-capped catch: band-1 proficiency with no rod resolves band 0.
+      // The draw count proves the arm is LIVE (completeFishing has no water
+      // gate of its own, but an early-return regression would leave it 0).
       meta.gatheringProficiency.fishing = 150;
-      completeFishing(sim.ctx, p, meta);
+      let fishDraws = 0;
+      sim.rng.setObserver(() => fishDraws++);
+      try {
+        completeFishing(sim.ctx, p, meta);
+      } finally {
+        sim.rng.setObserver(null);
+      }
       events.push(...sim.drainEvents());
       sim.tick();
       return {
         events,
+        fishDraws,
         ore: sim.countItem('iron_ore', pid),
         proficiency: { ...meta.gatheringProficiency },
         nodeReady: sim.nodeHarvestableByMeFor('ore_mirefen_t2', pid),
@@ -619,6 +628,8 @@ describe('Phase 12 determinism (same seed, same drive)', () => {
     expect(a.events.some((e) => (e as { type: string }).type === 'gatherResult')).toBe(true);
     expect(a.ore).toBeGreaterThanOrEqual(1);
     expect(a.nodeReady).toBe(false);
+    // Non-degenerate fishing arm: exactly the one band-table draw ran.
+    expect(a.fishDraws).toBe(1);
   });
 });
 

--- a/tests/professions_fishing.test.ts
+++ b/tests/professions_fishing.test.ts
@@ -536,6 +536,19 @@ describe('fishing band tool cap (Professions 2.0 Phase 12)', () => {
     expect(catchSequence(sim, meta, 18)).toEqual(B2_SEQ_4242);
   });
 
+  it('a high rod never buys bands: proficiency band 0 with the tier-3 rod stays band 0', () => {
+    const sim = makeSim(4242);
+    const meta = sim.meta(sim.playerId)!;
+    // Proficiency 0 resolves band 0 while the silverstream rod allows band 2,
+    // so the effective band must take the PROFICIENCY arm of min(profBand,
+    // allowedBand): a fresh buyer of the 150c rod cannot fish the band-2
+    // table. Every other cap test binds the rod arm or the equal case, so
+    // this is the only guard against the min() collapsing to allowedBand
+    // alone. B0 diverges from B1/B2 at index 1, so 12 casts are decisive.
+    sim.addItem('silverstream_fishing_rod', 1);
+    expect(catchSequence(sim, meta, 12)).toEqual(B0_SEQ_4242.slice(0, 12));
+  });
+
   it('a pole-only proficiency-0 angler is byte-identical to the shipped pre-phase walk', () => {
     const sim = makeSim(4242);
     const meta = sim.meta(sim.playerId)!;

--- a/tests/professions_tools.test.ts
+++ b/tests/professions_tools.test.ts
@@ -185,6 +185,40 @@ describe('sim-level node access gating (Professions 2.0 Phase 12)', () => {
     expect(sim.countItem('thorium_ore', pid)).toBeGreaterThanOrEqual(1);
   });
 
+  it('an owned tool one tier short still denies, and the event carries the real node tier (3)', () => {
+    const { sim, pid } = simAtNode(T3_ORE);
+    sim.addItem('iron_mining_pick', 1, pid); // mining tier 2 at a tier-3 vein
+    sim.drainEvents();
+    expect(sim.harvestNode(T3_ORE, pid)).toBe(false);
+    // requiredTier must be the node's tier, not a constant: every other deny
+    // pin in the suite reads 2, so this arm is the guard against a
+    // hardcoded-2 (or viewer-tier-plus-1) regression lying in the toast.
+    expect(sim.drainEvents().filter((e) => e.type === 'gatherDenied')).toEqual([
+      { type: 'gatherDenied', pid, surface: 'node', professionId: 'mining', requiredTier: 3 },
+    ]);
+  });
+
+  it('the herbalism arm denies and unlocks through the real harvestNode like the others', () => {
+    const T2_HERB = 'herb_mirefen_t2';
+    const bare = simAtNode(T2_HERB);
+    bare.sim.drainEvents();
+    expect(bare.sim.harvestNode(T2_HERB, bare.pid)).toBe(false);
+    expect(bare.sim.drainEvents().filter((e) => e.type === 'gatherDenied')).toEqual([
+      {
+        type: 'gatherDenied',
+        pid: bare.pid,
+        surface: 'node',
+        professionId: 'herbalism',
+        requiredTier: 2,
+      },
+    ]);
+    const tooled = simAtNode(T2_HERB);
+    tooled.sim.addItem('bronze_sickle', 1, tooled.pid); // herbalism tier 2
+    tooled.sim.drainEvents();
+    expect(tooled.sim.harvestNode(T2_HERB, tooled.pid)).toBe(true);
+    expect(tooled.sim.drainEvents().some((e) => e.type === 'gatherDenied')).toBe(false);
+  });
+
   it('mixed-profession bags resolve per profession: mining tier 3 never lends logging its tier', () => {
     const { sim, pid } = simAtNode(T2_WOOD);
     sim.addItem('mithril_mining_pick', 1, pid); // mining tier 3


### PR DESCRIPTION
## Summary

Phase 12 QA (Professions 2.0: Verify Base tool tier gating) over PR #2217, QA diff c139db6d5..4fa130aedf first-parent across the 59f9c42d2 release sync. Verdict: PASS with fixes, zero blocking. Seven audits (three packet audits plus the architecture / cross-platform-sync / frontend-seam / qa-checklist dispatch rows) with every BLOCKING or SHOULD-FIX finding adversarially verified by two independent skeptics, plus a live correctness probe suite driven through the real Sim (bare-hands and denied harvests, owned-best resolution, corpse deny/restore via the documented withTier seam, silent band caps, useItem rod casts, both-host denial liveness) and a fresh test-coverage audit of this PR's own diff (PASS, no blocking).

Two confirmed SHOULD-FIX decisiveness holes fixed test-first, each mutation-verified against the exact regression it guards:
- The fishing band min(profBand, allowedBand) proficiency arm was one-arm-only: the pre-fix suite stayed green with the min collapsed to the rod arm (a fresh character buying the 150c silverstream rod would have fished the band-2 table). New pin: a tier-3 rod at band-0 proficiency stays on the band-0 literal sequence.
- requiredTier was never pinned at any value other than 2: a hardcoded-2 regression passed every test while lying in the player-facing toast for tier-3 veins. New pin: an owned-but-short iron pick at a tier-3 vein denies with requiredTier 3 (also closes the owned-tool-one-tier-short boundary).

Also landed: the herbalism deny/unlock arm through the real harvestNode, the corpse granted-with-tool-at-raised-tier arm, the FIRST-failing-family pin on the corpse deny event (asymmetric raised tiers both ways at the pre-hunted seed 11), a draw-count liveness pin on the Phase 12 determinism drive's fishing arm, withTier absent-component restore hygiene, and a comment correction in gather_node_interact.ts (the client pre-gate deliberately reports the tool lock before readiness while the sim checks respawn first; both orders were already pinned, the comment claimed they matched). Docs: progress.md QA entry, state.md drift notes (first-failing-family semantics, rods counting toward the corpse any-profession owned-best with live probe evidence, the deliberate gate-order divergence, the spectator toast property, and the v0.29.0 release-notes awareness item for the retroactive silent band cap).

Deferred with reasons (recorded in progress.md): the main.ts gate-wiring source pin (rename-fragile idiom; the sim/server deny is the authoritative backstop), the items.ts isGatherToolUse consistency swap (zero behavior change), the toolTierUnmet key composition duplication (two copies, below the rule of three), the hover-tooltip listener-logic test and the *_tooltip.ts painter-scan naming, and the minimap per-build tool-tier memo allocation.

## Related issues

Part of #1866 (no issue to close: #2057 closed at the Phase 12 merge).

## Type of change

- [x] Tests
- [x] Documentation

## How was this tested?

- Commands: full `npm run gate` under Node 24 at the PR head (i18n gen + freshness, malware scan, changed-files biome, sfx check, full vitest 17221 passed / 1403 files; the browser stage red is the known environmental armory pixel failure that reproduces on untouched release tips, PR CI is the arbiter), then the gate tail manually: `npm run check:types && npm run build:env && npm run build:server && npm run build` (all green). Four mutation runs verified each new pin reds on exactly the regression it guards (min() collapsed to the rod arm, requiredTier hardcoded on both surfaces, completeFishing early return).
- Manual steps: an 11-test throwaway probe suite driven through the real headless Sim during the audit (deleted, tree clean); PR #2217 body screenshot references and wiki:content freshness verified.

## Screenshots / recordings

N/A (tests, a code comment, and packet docs only; no visual change).