### PR TITLE
test(professions): Phase 12b QA, verify Gathering rhythm

### DIFF
--- a/docs/professions-2/phase-12b-gathering-rhythm.md
+++ b/docs/professions-2/phase-12b-gathering-rhythm.md
@@ -55,6 +55,13 @@ full surfaces record is state.md's Phase 12b entry):
   of scope; the latter is a pure ClientWorld ncd-mirror suite); the online
   castStart-wire-shape and completion-grant arms live in gather_node_harvest's live
   GameServer describe, and the interact-starts-a-cast arm in gather_node_interact.test.ts.
+- Predicate-consumer precision (QA wording correction, 2026-07-20): of the eleven
+  exemption sites, SEVEN consume the isNonSpellCast boolean directly (casting_lifecycle
+  silence/lockout/blink-through/spell-queue, effect_dispatch interrupt immunity, damage
+  cancel-not-pushback, items useItem busy guard) and FOUR are id-discriminating by
+  construction, comparing the sentinels individually beside it (casting_lifecycle
+  completion routing, castingReadout, castBarState, castDisplayName). The Starter
+  Prompt's "all eleven route through the shared predicate" reads as the former only.
 
 ## Context pointers
 
@@ -391,3 +398,18 @@ this list closed.
   keeps its single draw, re-pin consciously if that draw moves. The corpse premium-arm
   suite (tests/corpse_harvest_sim.test.ts) is OUTSIDE this phase's blast radius: 12b adds
   no corpse timing.
+- (post-inventory, Phase 12b QA, 2026-07-20) The QA pass added pins inside this
+  appendix's blast radius (the standing re-inventory rule; all additive, nothing
+  weakened, every one mutation-verified): tests/gathering_rhythm.test.ts gained the
+  deadline-tick no-miss arm (the tick phase runs AT the deadline and must not miss; a
+  `>` to `>=` flip previously survived the suite), a cast-end-clears describe pinning
+  cancelCast (with the stale-deadline instant-reel scenario), arena reset, fiesta down,
+  and the defensive session-cap end, the useItem busy-guard gather arm, and same-draw
+  rod-synergy literals (seed 4242 first cast: bare 127 / tier-2 107 / tier-3 87 ticks,
+  decisive on the reduction in both directions); tests/game_audio.test.ts gained the six
+  cue ROUTING pins (five feedback-gated, fishBite on the always-audible arm);
+  tests/cast_bar.test.ts pins fishing fill 1 under broadcast decay plus the gather
+  honest fill; tests/gather_event_i18n.test.ts re-tightened the fishingResult arm to
+  exactly one cue (exact-set form); tests/sim.test.ts re-pinned castTotal/castRemaining/
+  castStart.time to the literal 15 (constant-self-comparison removal); and
+  tests/gather_node_interact.test.ts pinned the 2.5 s base-duration literal.

--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -31,8 +31,8 @@ Update this file at the end of every implementation and QA session. Statuses:
 | 11 QA | Verify fishing framework | complete (PR #2199 merged) | 2026-07-20 | 2026-07-20 |
 | 12 | Base tool tier gating | complete (PR #2217 merged into release/v0.29.0) | 2026-07-20 | 2026-07-20 |
 | 12 QA | Verify tool tier gating | complete (PR #2223 merged) | 2026-07-20 | 2026-07-20 |
-| 12b | Gathering rhythm | built (PR #2226 open) | 2026-07-20 | 2026-07-20 |
-| 12b QA | Verify gathering rhythm | not started | | |
+| 12b | Gathering rhythm | complete (PR #2226 merged into release/v0.29.0) | 2026-07-20 | 2026-07-20 |
+| 12b QA | Verify gathering rhythm | complete (PASS, zero blocking) | 2026-07-20 | 2026-07-20 |
 | 13 | Enchanting reachable | not started | | |
 | 13 QA | Verify enchanting reachable | not started | | |
 | 14 | Attunement quests and nudges | not started | | |
@@ -481,6 +481,30 @@ pre-gate line), the items.ts isGatherToolUse consistency swap (zero behavior cha
 toolTierUnmet key composition duplication (two copies, below the rule of three), the
 hover-tooltip listener-logic test and the *_tooltip.ts painter-scan naming, and the
 minimap per-build tool-tier memo allocation. Drift notes in state.md.
+
+Phase 12b QA (2026-07-20): PASS, zero blocking; QA diff 26f7f40b9..8e7bc1121 audited off the
+merge 43bfcb927. Fan-out: 21-agent Workflow (3 packet audits + 6 dispatch-matrix reviewers,
+all 9 delivered schema-forced first try; every BLOCKING/SHOULD-FIX finding verified by two
+skeptics, refute + impact lenses). The Pin-cost appendix executed with ZERO violations: every
+touched test file classifies as an appendix row, a pre-cleared additive class, or pure
+additive registration; the band literals carry a discriminating draw (second discriminator at
+index 23). The anti-cheat stopping rule is NEGATIVE by live probe (every broadcast field
+walked for a mid-cast angler; no hidden key, castTot constant, castRem decay bite-independent
+across seeds). Played beats: the offline rhythm loop end to end 13/13 via CDP (gather cast
+2.5 s with real key-input move-cancel, constant fishing bar, bite line, reel-in with the
+Mirror Lake deed firing through the bite moment, got-away miss, immediate recast); the live
+GameServer bite-and-reel arm rode the correctness probe. Six skeptic-confirmed SHOULD-FIX
+regression-protection gaps (no live defects) fixed in the QA PR, all mutation-verified:
+deadline-tick no-miss arm, cancelCast/arena/fiesta/session-cap hidden-field clear pins, the
+useItem gather busy arm, the six cue routing pins (fishBite always-audible), plus literal
+re-pins (constant-self-comparison removals, rod-synergy same-draw literals 127/107/87, cast
+bar fill pins, exact reel-cue set) and the harvestNode duplicate bag-scan hoist. Docs: the
+predicate-consumer wording corrected in state.md + the phase file (7 boolean consumers, 4
+id-discriminating sites), appendix re-inventoried with the QA pins. Deferred with reasons:
+observer-bobber bite flip (owner-only by design), nameplate per-frame localize (pre-existing),
+raw hex log colors (repo idiom), placeholder cues pending #2208 (release-notes caveat), guide
+bite-minigame prose (Phase 15 rewrite), mobile fishing E2E (desktop probe + committed mobile
+shots stand; Phase 15 sweep).
 
 Phase 12b (2026-07-20): built off release/v0.29.0, phase start 26f7f40b9 (the Phase 12 QA
 merge). Seven build commits (predicate extraction, gather cast, bite minigame, ui, appendix

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -1041,11 +1041,15 @@ tables, i18n key namespaces, files created)
   the 60c/150c rods at trader_wilkes; 12b adds the visibility UX).
 - Phase 12b (built 2026-07-20, phase start 26f7f40b9): the gather cast and
   the fishing bite minigame. Shared predicate: `isNonSpellCast(castId)`
-  (src/sim/types.ts, fishing | gathering) now routes all ELEVEN cast-id
-  exemption sites (casting_lifecycle silence/lockout/completion-routing/
-  blink-through/spell-queue, effect_dispatch interrupt immunity, damage
-  cancel-not-pushback, items useItem busy guard, chat_readouts castingReadout,
-  cast_bar castBarState, hud castDisplayName). DEMON_HEAL_CAST_ID folded ONLY
+  (src/sim/types.ts, fishing | gathering) consolidates the ELEVEN cast-id
+  exemption sites: SEVEN consume the boolean directly (casting_lifecycle
+  silence/lockout/blink-through/spell-queue, effect_dispatch interrupt
+  immunity, damage cancel-not-pushback, items useItem busy guard) and FOUR
+  are id-DISCRIMINATING by construction, so they compare the sentinels
+  individually beside it (casting_lifecycle completion routing, chat_readouts
+  castingReadout, cast_bar castBarState, hud castDisplayName; QA wording
+  correction, the original entry said all eleven "route through" the
+  predicate). DEMON_HEAL_CAST_ID folded ONLY
   at the silence and lockout sites (byte-identical: it was already exempt
   there via failed ability resolution); it stays deliberately AD HOC at
   blink-through (live during its channel), spell queue (queuing works for
@@ -1123,6 +1127,25 @@ tables, i18n key namespaces, files created)
   drives re-driven through completion, coverage extended). The bobber anchor
   logic lives in the RENDER_PURE_CORES core fishing_bobber_core.ts walking
   the sim's exported FISHING_SAMPLE_DISTANCES by identity.
+  Phase 12b QA notes (2026-07-20, PASS, zero blocking): the anti-cheat
+  invariant was proven NEGATIVE live twice (a GameServer probe walked every
+  broadcast field for a mid-cast angler across ~58 pre-bite rounds: no
+  hidden key, castTot constant 15, castRem uniform DT decay carrying no
+  bite information; note castRem DOES decay on the wire toward the 15 s
+  cap, identically for every drawn delay, so the earlier "constant" phrasing
+  means bite-independent, not frozen). The appendix executed with ZERO
+  violations. Five mutation-proven pin gaps were closed in the QA PR (miss
+  boundary at the deadline tick, cancelCast/arena/fiesta/session-cap
+  hidden-field clears, the useItem gather busy arm, cue routing pins, plus
+  literal re-pins; the appendix post-inventory block lists them). The
+  played-beats probe ran the offline rhythm loop end to end 13/13,
+  including both gathering deeds and the Mirror Lake first-catch deed
+  celebrating through the new cast/bite moments. Deferred as INFO:
+  observer clients never see another angler's bobber bite flip
+  (owner-only by design), nameplate cast-label per-frame localize is
+  pre-existing, gatherResult/fishingResult log lines use the repo's raw
+  hex log-color idiom, and the six cues stay PLACEHOLDER pending #2208
+  (release-notes caveat).
 - Phase 13: (planned) disenchantItem/applyEnchant/salvageItem IWorld
   members + wire commands; plus, per the 2026-07-20 amendments, the typed
   disenchant reagents (hybrid model, same-phase consumers) and the

--- a/src/sim/professions/gathering.ts
+++ b/src/sim/professions/gathering.ts
@@ -324,9 +324,11 @@ export function harvestNode(ctx: SimContext, nodeId: string, pid?: number): bool
   // a denial never touches the respawn timer, never draws rng, and never
   // consumes anything.
   const professionId = NODE_HARVEST_TABLE[node.type].professionId;
+  // One bag scan serves both the tool gate and the cast-duration formula
+  // below (pure lookup, no rng, so hoisting it cannot shift the draw order).
+  const ownedToolTier = bestOwnedGatherToolTier(meta.inventory, professionId, ITEMS);
   if (node.tier > BARE_HANDS_TOOL_TIER) {
-    const best = bestOwnedGatherToolTier(meta.inventory, professionId, ITEMS);
-    if (!canGatherTier(best, node.tier)) {
+    if (!canGatherTier(ownedToolTier, node.tier)) {
       ctx.emit({
         type: 'gatherDenied',
         pid: meta.entityId,
@@ -352,7 +354,7 @@ export function harvestNode(ctx: SimContext, nodeId: string, pid?: number): bool
   if (p.sitting) ctx.standUp(p);
   const duration = gatherCastDurationSec(
     node.tier,
-    bestOwnedGatherToolTier(meta.inventory, professionId, ITEMS),
+    ownedToolTier,
     proficiencyBandFor(meta.gatheringProficiency[professionId]),
   );
   p.castingAbility = GATHER_CAST_ID;

--- a/tests/cast_bar.test.ts
+++ b/tests/cast_bar.test.ts
@@ -64,6 +64,24 @@ describe('overhead cast bar', () => {
     expect(unknown.label).toBe('made_up_spell');
   });
 
+  it('renders fishing as a CONSTANT full waiting bar and the gather cast as a normal fill (Phase 12b)', () => {
+    // The fishing fill is pinned at 1 REGARDLESS of the broadcast decay: the
+    // bar must carry no session-progress information (the bite is the bobber
+    // plus the cue). castRemaining 7.5 of 15 would fill 0.5 on the generic
+    // path; fishing must stay 1.
+    const fish = castBarState(
+      caster({ castingAbility: 'fishing', castRemaining: 7.5, castTotal: 15 }),
+    );
+    expect(fish.fill).toBe(1);
+    // The gather cast rides the generic filling path (public state, honest
+    // bar): 1.25 of 2.5 remaining reads as half done.
+    const gather = castBarState(
+      caster({ castingAbility: 'gathering', castRemaining: 1.25, castTotal: 2.5 }),
+    );
+    expect(gather.fishing).toBe(false);
+    expect(gather.fill).toBe(0.5);
+  });
+
   it('carries custom raid mechanic cast ids for renderer localization', () => {
     const rage = castBarState(
       caster({

--- a/tests/game_audio.test.ts
+++ b/tests/game_audio.test.ts
@@ -107,7 +107,8 @@ describe('sampled GameAudio facade', () => {
     audio.setFeedbackEnabled(false);
     expect(audio.feedbackEnabled).toBe(false);
 
-    // The interface/feedback cues fall silent (loot, level, quest, whisper, etc.).
+    // The interface/feedback cues fall silent (loot, level, quest, whisper,
+    // etc.), including five of the six Phase 12b gathering-rhythm cues.
     const feedback = [
       'coin',
       'levelUp',
@@ -119,21 +120,30 @@ describe('sampled GameAudio facade', () => {
       'arenaLoss',
       'error',
       'invitePrompt',
+      'gatherCast',
+      'gatherStrike',
+      'gatherRare',
+      'fishCast',
+      'fishReel',
     ] as const;
     for (const m of feedback) audio[m]();
     expect(sfxMock.playUi).not.toHaveBeenCalled();
 
     // Direct-affordance cues (you clicked/opened) and gameplay-timing cues (duel
-    // countdown, fiesta) are NOT gated, so they still play.
+    // countdown, fiesta, the fishing BITE that opens the live reel window) are
+    // NOT gated, so they still play. fishBite on this arm is a fairness
+    // contract: the reaction window must never be silenceable.
     audio.click();
     audio.bagOpen();
     audio.duelCountdownTick();
     audio.fiestaWave();
+    audio.fishBite();
     expect(sfxMock.playUi.mock.calls.map(([k]) => k)).toEqual([
       'ui_click',
       'ui_bag_open',
       'ui_duel_countdown',
       'ui_fiesta_wave',
+      'ui_fish_bite',
     ]);
 
     // Re-enabling restores the feedback cues.

--- a/tests/gather_event_i18n.test.ts
+++ b/tests/gather_event_i18n.test.ts
@@ -163,10 +163,11 @@ describe('hudChrome.gathering catch line (Professions 2.0 Phase 11)', () => {
     const block = source.slice(caseStart, source.indexOf('break;', caseStart));
     expect(block.includes('hudChrome.gathering.catchLine')).toBe(true);
     expect(block.includes('QUALITY_COLOR[ev.quality]')).toBe(true);
-    // Phase 12b: the reel cue rides this arm; the loot notification cue must
-    // not (the grant hub's own 'loot' event already plays it).
-    expect(block.includes('audio.fishReel()')).toBe(true);
-    expect(block.includes('audio.lootItem')).toBe(false);
+    // Phase 12b: the reel cue rides this arm and it is the ONLY cue there
+    // (the pre-12b pin excluded every cue; the exact-set form keeps the
+    // same third-cue protection while mandating the reel).
+    const cueCalls = [...block.matchAll(/audio\.(\w+)\(/g)].map((m) => m[1]);
+    expect(cueCalls).toEqual(['fishReel']);
   });
 
   it('every gathering profession id has a catalog label and both window rows', () => {

--- a/tests/gather_node_interact.test.ts
+++ b/tests/gather_node_interact.test.ts
@@ -234,7 +234,8 @@ describe('the real harvestNode behind the helper (Phase 12b cast start)', () => 
     p.prevPos = { ...p.pos };
     expect(sim.harvestNode(node.id, pid)).toBe(true);
     expect(p.castingAbility).toBe(GATHER_CAST_ID);
-    expect(p.castTotal).toBeGreaterThan(0);
+    // Fresh player, bare hands, band 0, tier-1 node: the 2.5 s base literal.
+    expect(p.castTotal).toBe(2.5);
     // The grant has NOT landed yet: it belongs to cast completion.
     expect(sim.countItem(nodeMaterialFor(node.type, node.zoneId).itemId, pid)).toBe(0);
   });

--- a/tests/gathering_rhythm.test.ts
+++ b/tests/gathering_rhythm.test.ts
@@ -32,7 +32,7 @@ vi.mock('../server/db', () => ({
 
 import { type ClientSession, GameServer } from '../server/game';
 import { bagCapacity } from '../src/sim/bags';
-import { updateCasting } from '../src/sim/combat/casting_lifecycle';
+import { cancelCast, updateCasting } from '../src/sim/combat/casting_lifecycle';
 import { runEffects } from '../src/sim/combat/effect_dispatch';
 import { GATHER_NODES } from '../src/sim/content/gather_nodes';
 import { ABILITIES, LAKE, MOBS } from '../src/sim/data';
@@ -44,6 +44,8 @@ import {
 } from '../src/sim/professions/fishing';
 import { gatherCastDurationSec, nodeMaterialFor } from '../src/sim/professions/gathering';
 import { type PlayerMeta, Sim } from '../src/sim/sim';
+import { readyArenaFighter } from '../src/sim/social/arena';
+import { fiestaDownEntity } from '../src/sim/social/fiesta';
 import {
   type Aura,
   DEMON_HEAL_CAST_ID,
@@ -226,6 +228,15 @@ describe('reel deadline boundary', () => {
     startFishing(sim.ctx, p, meta);
     sim.tickCount = p.fishBiteAtTick;
     updateCasting(sim.ctx, p, meta);
+    // AT the deadline tick the window is still open: the tick phase must NOT
+    // miss yet (kills a `>` -> `>=` regression in the miss comparison, which
+    // would steal the last valid reel tick from the player).
+    sim.tickCount = p.fishReelDeadlineTick;
+    sim.events = [];
+    updateCasting(sim.ctx, p, meta);
+    expect(sim.events).not.toContainEqual(expect.objectContaining({ type: 'fishingGotAway' }));
+    expect(p.castingAbility).toBe(FISHING_CAST_ID);
+    expect(p.fishReelDeadlineTick).toBeGreaterThan(0);
     sim.tickCount = p.fishReelDeadlineTick + 1;
     sim.events = [];
     updateCasting(sim.ctx, p, meta); // the miss fires here, before any press
@@ -772,5 +783,150 @@ describe('death clears the hidden cast state (review fix)', () => {
     expect(p.gatherCastNodeId).toBe('');
     expect(p.fishBiteAtTick).toBe(0);
     expect(p.fishReelDeadlineTick).toBe(0);
+  });
+});
+
+describe('every other cast-end path returns the hidden fields to inert (QA pins)', () => {
+  // The build pinned the death clear; these pin the remaining end paths the
+  // storage decision names (cancelCast, arena reset, fiesta down, the
+  // defensive session-cap end), each mutation-decisive: deleting the clear
+  // under test reds exactly its arm.
+  it('a fresh entity starts with all three hidden fields inert', () => {
+    const sim = makeSim(4242);
+    expect(sim.player.gatherCastNodeId).toBe('');
+    expect(sim.player.fishBiteAtTick).toBe(0);
+    expect(sim.player.fishReelDeadlineTick).toBe(0);
+  });
+
+  it('cancelCast inside the armed reel window clears both fishing fields, so the next session cannot instant-reel off a stale deadline', () => {
+    const sim = makeSim(4242);
+    const meta = mustMeta(sim, sim.playerId);
+    teleportToValeShore(sim);
+    const p = sim.player;
+    startFishing(sim.ctx, p, meta);
+    sim.tickCount = p.fishBiteAtTick;
+    updateCasting(sim.ctx, p, meta); // the bite arms the window
+    expect(p.fishReelDeadlineTick).toBeGreaterThan(sim.tickCount);
+    cancelCast(sim.ctx, p);
+    expect(p.castingAbility).toBe(null);
+    expect(p.fishBiteAtTick).toBe(0);
+    expect(p.fishReelDeadlineTick).toBe(0);
+    // Without the cancelCast clears, this recast would still see the OLD
+    // deadline armed and the immediate re-press would land a catch with no
+    // bite: the re-press must stay the busy error instead.
+    startFishing(sim.ctx, p, meta);
+    expect(p.castingAbility).toBe(FISHING_CAST_ID);
+    let draws = 0;
+    sim.rng.setObserver(() => draws++);
+    sim.events = [];
+    try {
+      startFishing(sim.ctx, p, meta);
+    } finally {
+      sim.rng.setObserver(null);
+    }
+    expect(draws).toBe(0);
+    expect(p.castingAbility).toBe(FISHING_CAST_ID);
+    expect(sim.events).toContainEqual(
+      expect.objectContaining({ type: 'error', text: 'You are busy.' }),
+    );
+  });
+
+  it('the arena fighter reset clears the hidden fields', () => {
+    const sim = makeSim(4242);
+    const meta = mustMeta(sim, sim.playerId);
+    teleportToValeShore(sim);
+    startFishing(sim.ctx, sim.player, meta);
+    expect(sim.player.fishBiteAtTick).toBeGreaterThan(0);
+    sim.player.gatherCastNodeId = NODE.id; // belt-and-braces: all three clear
+    readyArenaFighter(sim.ctx, sim.player, { clearPrep: false });
+    expect(sim.player.gatherCastNodeId).toBe('');
+    expect(sim.player.fishBiteAtTick).toBe(0);
+    expect(sim.player.fishReelDeadlineTick).toBe(0);
+  });
+
+  it('the fiesta down path clears the hidden fields', () => {
+    const sim = makeSim(4242);
+    const meta = mustMeta(sim, sim.playerId);
+    teleportToValeShore(sim);
+    startFishing(sim.ctx, sim.player, meta);
+    expect(sim.player.fishBiteAtTick).toBeGreaterThan(0);
+    sim.player.gatherCastNodeId = NODE.id;
+    fiestaDownEntity(sim.ctx, sim.player, null);
+    expect(sim.player.gatherCastNodeId).toBe('');
+    expect(sim.player.fishBiteAtTick).toBe(0);
+    expect(sim.player.fishReelDeadlineTick).toBe(0);
+  });
+
+  it('the defensive session-cap end gets away with zero draws and clears the hidden fields', () => {
+    // Unreachable in real flow (max delay + max window end well before the
+    // 15 s cap); reachable by the parity cancel drives and any future
+    // direct-assigned cast. Shape: the last DT of castRemaining expires with
+    // the bite still pending.
+    const sim = makeSim(4242);
+    const meta = mustMeta(sim, sim.playerId);
+    teleportToValeShore(sim);
+    const p = sim.player;
+    startFishing(sim.ctx, p, meta);
+    p.castRemaining = DT; // exhaust the cap on the next lifecycle tick
+    p.fishBiteAtTick = sim.tickCount + 999; // bite still pending, window unarmed
+    sim.events = [];
+    let draws = 0;
+    sim.rng.setObserver(() => draws++);
+    try {
+      updateCasting(sim.ctx, p, meta);
+    } finally {
+      sim.rng.setObserver(null);
+    }
+    expect(draws).toBe(0);
+    expect(sim.events).toContainEqual({ type: 'fishingGotAway', pid: sim.playerId });
+    expect(sim.events).toContainEqual(
+      expect.objectContaining({ type: 'castStop', success: false }),
+    );
+    expect(p.castingAbility).toBe(null);
+    expect(p.fishBiteAtTick).toBe(0);
+    expect(p.fishReelDeadlineTick).toBe(0);
+  });
+});
+
+describe('the widened useItem busy guard covers the gather cast (QA pin)', () => {
+  it('a potion press mid-gather-cast denies busy and leaves the cast untouched', () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Sipper');
+    const p = sim.entities.get(pid);
+    if (!p) throw new Error('missing entity');
+    sim.addItem('minor_mana_potion', 1, pid);
+    teleportOntoNode(sim, pid, NODE.id);
+    expect(sim.harvestNode(NODE.id, pid)).toBe(true);
+    const nodeId = p.gatherCastNodeId;
+    sim.drainEvents();
+    sim.useItem('minor_mana_potion', pid);
+    expect(sim.drainEvents()).toContainEqual(
+      expect.objectContaining({ type: 'error', text: 'You are busy.' }),
+    );
+    expect(p.castingAbility).toBe(GATHER_CAST_ID);
+    expect(p.gatherCastNodeId).toBe(nodeId);
+    expect(sim.countItem('minor_mana_potion', pid)).toBe(1);
+  });
+});
+
+describe('rod synergy is literal-pinned on one shared draw (QA pins)', () => {
+  // The same seed-4242 first draw walks all three rod arms, so these three
+  // literals pin FISH_BITE_DELAY_MIN_SEC and the 1.5 s/tier max-side
+  // reduction in BOTH directions (the sampled-bounds arms above catch only
+  // a shrink of the reduction, not a growth).
+  it('first-cast delay ticks at seed 4242: bare 127, tier-2 rod 107, tier-3 rod 87', () => {
+    for (const [rod, ticks] of [
+      [null, 127],
+      ['ironreel_fishing_rod', 107],
+      ['silverstream_fishing_rod', 87],
+    ] as [string | null, number][]) {
+      const sim = makeSim(4242);
+      const meta = mustMeta(sim, sim.playerId);
+      if (rod) sim.addItem(rod, 1);
+      teleportToValeShore(sim);
+      const p = sim.player;
+      startFishing(sim.ctx, p, meta);
+      expect(p.fishBiteAtTick - sim.tickCount, rod ?? 'bare').toBe(ticks);
+    }
   });
 });

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -14,7 +14,6 @@ import { Sim } from '../src/sim/sim';
 import {
   dist2d,
   FISHING_CAST_ID,
-  FISHING_SESSION_CAP_SEC,
   MAX_LEVEL,
   meleeMissChance,
   mobXpValue,
@@ -1181,14 +1180,17 @@ describe('food, drink, vendor', () => {
     }
     expect(draws).toBe(1);
     expect(sim.player.castingAbility).toBe(FISHING_CAST_ID);
-    expect(sim.player.castTotal).toBe(FISHING_SESSION_CAP_SEC);
-    expect(sim.player.castRemaining).toBe(FISHING_SESSION_CAP_SEC);
+    // Literal 15, not the imported constant: the broadcast session cap is a
+    // wire-visible contract, so this pin must red if the constant moves (the
+    // packet's constant-self-comparison trap).
+    expect(sim.player.castTotal).toBe(15);
+    expect(sim.player.castRemaining).toBe(15);
     expect(sim.player.channeling).toBe(false);
     expect(sim.events).toContainEqual(
       expect.objectContaining({
         type: 'castStart',
         ability: FISHING_CAST_ID,
-        time: FISHING_SESSION_CAP_SEC,
+        time: 15,
       }),
     );
   });


### PR DESCRIPTION
## Summary

Phase 12b QA of the Professions 2.0 packet: verify Gathering rhythm (the gather cast and the fishing bite minigame, PR #2226). Verdict: **PASS, zero blocking**. The Pin-cost appendix executed with zero violations, the anti-cheat stopping rule proved NEGATIVE by live probe (every broadcast field walked for a mid-cast angler: no hidden key, castTot constant 15, castRem decay bite-independent across differing drawn delays), and the offline rhythm loop played end to end 13/13 (gather cast with real key-input move-cancel, constant waiting bar, bite, reel with the Mirror Lake deed celebrating through the bite moment, got-away miss, immediate recast).

The audit fan-out (3 packet audits + 6 dispatch-matrix reviewers, every BLOCKING/SHOULD-FIX finding adversarially verified by two skeptics) found six mutation-proven regression-protection gaps, no live defects. This PR closes them:

- **Miss boundary decisiveness**: the tick phase now runs AT the reel deadline and must not miss (a `>` to `>=` flip in the miss comparison previously survived the entire suite; it would steal the last valid reel tick).
- **Hidden-field clear pins for every remaining cast-end path**: cancelCast (including the stale-deadline scenario where the next session could instant-reel with no bite), arena reset, fiesta down, and the defensive session-cap end (got-away, zero draws, fields inert).
- **Cue routing pins**: the six Phase 12b placeholder cues had census pins but no routing pins; the feedback-gating suite now proves gatherCast/gatherStrike/gatherRare/fishCast/fishReel silence with the toggle while fishBite rides the always-audible arm (the fairness contract: the reel window must never be silenceable).
- **useItem busy-guard gather arm**: a potion press mid-gather-cast denies busy and leaves the cast untouched.
- **Literal re-pins**: sim.test castTotal/castRemaining/castStart.time to the literal 15 (constant-self-comparison removal), the 2.5 s gather base literal, cast-bar fishing fill pinned at 1 under broadcast decay plus the gather honest fill, the fishingResult arm re-tightened to exactly one cue, and same-draw rod-synergy literals (seed 4242 first cast: bare 127 / tier-2 107 / tier-3 87 ticks) decisive on the delay reduction in both directions.
- **chore(sim)**: harvestNode's duplicate bag scan hoisted (pure lookup, draw order and goldens untouched).

Docs: progress.md flips the 12b row to complete and records the QA verdict; state.md corrects the predicate-consumer wording (seven sites consume the isNonSpellCast boolean, four are id-discriminating by construction) and adds the QA drift notes; the Pin-cost appendix gains the QA post-inventory block per the standing re-inventory rule. Issue #2208 got a comment naming the six shipped cue keys (ui_gather_strike was not previously named there).

Deferred with reasons (recorded in progress.md): observer-bobber bite flip (owner-only by design), nameplate per-frame cast-label localize (pre-existing), raw hex log colors (repo idiom), placeholder cues pending #2208 (release-notes caveat), guide bite-minigame prose (Phase 15 rewrite), mobile fishing E2E (desktop probe + committed mobile shots stand; Phase 15 sweep).

## Related issues

Part of #1866. (#2206 was closed at the Phase 12b merge; no issue closes here.)

## Type of change

- [x] Tests
- [x] Documentation
- [x] Refactor or performance (no behavior change)

## How was this tested?

- Commands:
  - Full validation matrix at the untouched tip 43bfcb927 BEFORE auditing (verified ground): `npx tsc --noEmit`, the 21 phase suites (409 tests), `npx vitest run tests/parity` (435), the net/wire row, the i18n row, `npm run sfx:manifest && npm run sfx:check`: all green.
  - `npm run gate` (Node 24) at the PR head: green through the full suite; the known environmental armory browser red on this machine, tail (`check:types` + all builds) finished manually green. PR CI is the arbiter.
  - Mutation verification of every new pin class: `>`-to-`>=` miss flip, cancelCast clear deletion, and fishBite-to-playFeedback each red exactly their new pin and nothing else.
- Manual steps:
  - Played-beats CDP probe over the dev client (offline world): 13/13 PASS across gather cast/cancel, fishing wait/bite/reel/miss/recast beats.
  - Live GameServer anti-cheat probe (throwaway vitest, deleted after run): walked every JSON field of every message sent for a mid-cast angler across ~58 pre-bite tick/broadcast rounds; no field correlates with the bite tick.

## Screenshots / recordings

N/A: no visual change (test, docs, and a behavior-neutral sim hoist). The Phase 12b feature screenshots live in the feature PR #2226 under docs/screenshots/professions-2-phase-12b/.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green locally except the known environmental armory browser red (tail finished manually); decisive tests added for every closed gap, mutation-verified.

### Cross-platform

- [ ] ~Tested on desktop and mobile.~ N/A: no UI change in this PR (the played-beats probe covered desktop; the feature PR carries the mobile shots).
- [ ] ~Accessible.~ N/A: no UI change.

### Localization (i18n)

- [ ] ~New player-visible strings follow the contributor policy.~ N/A. This PR adds no player-visible strings.
- [x] Player-facing text emitted from `src/sim/` is unchanged; `npx vitest run tests/localization_fixes.test.ts` passes.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
