### PR TITLE
feat(server): persist action bar layouts on the character

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -9,6 +9,7 @@ import { LEADERBOARD_MAX } from '../src/sim/leaderboard_page';
 import { sanitizeRemovedZone1Content } from '../src/sim/removed_zone1_content';
 import type { CharacterState, MailSave, MarketSave } from '../src/sim/sim';
 import type { ArenaFormat, PlayerClass } from '../src/sim/types';
+import type { ActionBarLayout } from '../src/world_api/action_bar';
 import { APPLE_AUTH_SCHEMA } from './apple_auth_db';
 import type { BankBonusFacts } from './bank_entitlements';
 import { seedChatFilterDefaults } from './chat_filter_db';
@@ -216,6 +217,14 @@ ALTER TABLE characters ADD COLUMN IF NOT EXISTS realm TEXT NOT NULL DEFAULT '${R
 -- "last seen" readout on offline guild-roster rows. Nullable: a character that
 -- has never entered the world since this column was added reads NULL.
 ALTER TABLE characters ADD COLUMN IF NOT EXISTS last_login TIMESTAMPTZ;
+-- Per-character action-bar layout (JSONB). This is client PRESENTATION state (a
+-- remap over learned abilities + item shortcuts), NOT deterministic gameplay
+-- state, so it lives in its own additive column rather than the sim-owned state
+-- blob: keeping it out of CharacterState leaves sim serialization byte-identical
+-- and the offline Sim host-agnostic. Nullable/absent until the character first
+-- saves one; the server treats the value as opaque and re-validates its bounds
+-- (sanitizeActionBarLayout) on both read and write.
+ALTER TABLE characters ADD COLUMN IF NOT EXISTS hotbar_layout JSONB;
 -- Max-Level XP Overflow leaderboard: indexed lifetime-XP sort key. The first
 -- index serves the realm-scoped in-game panel; the second serves the global
 -- (cross-realm) home-page board. Both are expression indexes on the bare
@@ -2449,6 +2458,9 @@ export interface CharacterRow {
   force_rename: boolean;
   last_played?: Date | string | null;
   playtime_seconds?: string | number | null;
+  // Per-character action-bar layout (own JSONB column, not the sim state blob).
+  // Opaque to the server beyond bounds validation; only the join path selects it.
+  hotbar_layout?: ActionBarLayout | null;
 }
 
 // The account's "top" character on this realm (highest level, then lifetime XP),
@@ -2502,10 +2514,24 @@ export async function getCharacter(
   characterId: number,
 ): Promise<CharacterRow | null> {
   const res = await pool.query(
-    'SELECT id, account_id, name, class, level, state, is_gm, force_rename FROM characters WHERE id = $1 AND account_id = $2 AND realm = $3',
+    'SELECT id, account_id, name, class, level, state, is_gm, force_rename, hotbar_layout FROM characters WHERE id = $1 AND account_id = $2 AND realm = $3',
     [characterId, accountId, REALM],
   );
   return res.rows[0] ?? null;
+}
+
+/** Persist a character's action-bar layout in its dedicated JSONB column. The
+ *  layout is already sanitized/bounded by the caller (server-side, untrusted
+ *  client input); stored as an opaque document, replaced whole (last write wins).
+ *  Parameterized: characterId is $1, the JSON document is $2. */
+export async function setCharacterHotbarLayout(
+  characterId: number,
+  layout: ActionBarLayout,
+): Promise<void> {
+  await pool.query('UPDATE characters SET hotbar_layout = $2::jsonb WHERE id = $1', [
+    characterId,
+    JSON.stringify(layout),
+  ]);
 }
 
 // Active character names on this realm for the public character sitemap, ranked

--- a/server/game.ts
+++ b/server/game.ts
@@ -86,6 +86,7 @@ import {
   type VcSharedCupInfo,
   type VcViewerReadout,
 } from '../src/world_api';
+import { type ActionBarLayout, sanitizeActionBarLayout } from '../src/world_api/action_bar';
 import { recordOnlineSample } from './admin_db';
 import { offensiveName } from './auth';
 import { recordBankOp } from './bank_ledger';
@@ -130,6 +131,7 @@ import {
   saveMailState,
   saveMarketState,
   setAccountWeaponSkinLoadout,
+  setCharacterHotbarLayout,
   touchCharacterLogin,
   walletForAccount,
 } from './db';
@@ -717,6 +719,12 @@ export interface ClientSession {
     priorGm: boolean;
     stowedPet: PetState | null;
   } | null;
+  // The character's stored action-bar layout as loaded at join (already
+  // bounds-validated), or null when the character has never saved one. Sent to
+  // the owning client exactly once via the `hbl` self field (self-scoped: never
+  // an entity/broadcast field), then frozen; subsequent client saves persist to
+  // the DB and never re-echo here. null wires as an explicit "seed from local".
+  initialHotbarLayout: ActionBarLayout | null;
 }
 
 interface SentEntityVersions {
@@ -1283,6 +1291,10 @@ export class GameServer {
   // state row. Keep one FIFO per account so rapid apply/detach commands cannot
   // commit on separate pool clients in reverse order and resurrect stale state.
   private readonly weaponSkinLoadoutSaveQueues = new Map<number, Promise<void>>();
+  // Action-bar layout is a whole-record replacement in its own character column.
+  // One FIFO per character so a burst of debounced client saves cannot commit on
+  // separate pool clients in reverse order and persist a stale layout.
+  private readonly hotbarLayoutSaveQueues = new Map<number, Promise<void>>();
   // Serializes every write of the single global Market blob (the 30s autosave
   // and the leave-path combined save). Both serialize the whole market; without
   // a queue their transactions could commit out of capture order and persist an
@@ -2573,6 +2585,23 @@ export class GameServer {
     });
   }
 
+  private enqueueHotbarLayoutSave(characterId: number, layout: ActionBarLayout): void {
+    const previous = this.hotbarLayoutSaveQueues.get(characterId);
+    const run = (previous ? previous.catch(() => {}) : Promise.resolve()).then(async () => {
+      await setCharacterHotbarLayout(characterId, layout);
+    });
+    this.hotbarLayoutSaveQueues.set(characterId, run);
+    const cleanup = (): void => {
+      if (this.hotbarLayoutSaveQueues.get(characterId) === run) {
+        this.hotbarLayoutSaveQueues.delete(characterId);
+      }
+    };
+    void run.then(cleanup, (err) => {
+      console.error('failed to save hotbar layout:', err);
+      cleanup();
+    });
+  }
+
   join(
     ws: WebSocket,
     accountId: number,
@@ -2597,6 +2626,10 @@ export class GameServer {
         // the character state via addPlayer. Absent on a resume and for callers that
         // pass no meta (tests, the bot-detector overlay), which keep the saved value.
         bankBonus?: { bonusSlots: number; sources: BankBonusSource[] };
+        // The character's stored action-bar layout (characters.hotbar_layout),
+        // passed through from the join handler's DB read. Untrusted at rest, so
+        // it is re-validated here before it reaches the client.
+        hotbarLayout?: ActionBarLayout | null;
       } = {},
   ): ClientSession | { error: string } {
     // Anti-bot: cap simultaneous online characters per account. Accounts can
@@ -2724,6 +2757,8 @@ export class GameServer {
       spectating: null,
       jailed: state?.jail ?? null,
       jailVisit: null,
+      // Re-validate the stored layout (untrusted at rest) before it can wire out.
+      initialHotbarLayout: sanitizeActionBarLayout(meta.hotbarLayout),
     };
     if (session.jailed) this.teleportJailedSession(session);
     this.ipSessionCounts.set(sessionIp, (this.ipSessionCounts.get(sessionIp) ?? 0) + 1);
@@ -4163,6 +4198,15 @@ export class GameServer {
       case 'stow_weapon':
         sim.toggleWeaponStow(pid);
         break;
+      // Per-character action-bar layout upload (untrusted client input). Validate
+      // + bound the payload; a malformed/oversized layout is dropped silently
+      // (never crashes the session). A clean layout is persisted to the
+      // character's own JSONB column via the per-character FIFO save queue.
+      case 'save_hotbar_layout': {
+        const layout = sanitizeActionBarLayout(msg.layout);
+        if (layout) this.enqueueHotbarLayoutSave(session.characterId, layout);
+        break;
+      }
       // Skin-select event lock-in. The Sim re-validates the skin against the
       // rank it rolled and consumes the event token; a forged claim no-ops.
       case 'claim_event_skin':
@@ -5718,6 +5762,12 @@ export class GameServer {
         loadouts: meta.loadouts,
         activeLoadout: meta.activeLoadout,
       });
+      // IWorldActionBar login restore (self-scoped, never a broadcast/entity
+      // field): the VIEWER's own stored layout, or an explicit null meaning "the
+      // server has no copy, seed from this device". Bound to the frozen join-time
+      // value, so lastSent-diffing sends it exactly once and a later client save
+      // never round-trips back to clobber an in-flight edit.
+      maybe('hbl', session.initialHotbarLayout);
       // Vale Cup sport-kit flag ({ role } | null): while set, the client's
       // action bar rebuilds the role kit instead of the class kit. Rides the
       // wireRev-gated block because the sim bumps wireRev on BOTH the kickoff

--- a/server/ws_auth.ts
+++ b/server/ws_auth.ts
@@ -297,6 +297,9 @@ export function createWsAuth(deps: WsAuthDeps): WsAuthHandlers {
       adminPermissions,
       clientSeed,
       timerWireVersion,
+      // The character's stored action-bar layout, sent once to the owning client
+      // so it restores at login on any device (game.join re-validates it).
+      hotbarLayout: character.hotbar_layout ?? null,
     };
     // Two genuinely concurrent handshakes for one character would race to stamp
     // the lease nonce; admit only the first and refuse the rest (never queue).

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -1526,6 +1526,7 @@ export class ClientWorld implements IWorld {
   private actionBarRestoreResolved = false;
   private actionBarSaveTimer: ReturnType<typeof setTimeout> | null = null;
   private actionBarSaveLastJson: string | null = null;
+  private actionBarSavePending: ActionBarLayout | null = null;
   // Soft (cosmetic) profanity terms the server sends in `hello` and pushes via
   // `censor` frames when an admin edits the list. The HUD drains these to mask
   // chat locally when the player's filter is on. Hard words never arrive here.
@@ -1575,6 +1576,16 @@ export class ClientWorld implements IWorld {
   // resume, force a real state check and retry immediately instead of
   // waiting for a close event or the rest of the backoff delay.
   private readonly handleVisibilityChange = (): void => {
+    if (document.visibilityState === 'hidden') {
+      // Backgrounding (tab switch, tab close, phone lock) is the last reliable
+      // beat to get an in-flight debounced layout edit to the server while the
+      // socket is still open, so a "rearrange then close the tab" never strands
+      // the final edit for a second device. Bounded: a no-op unless a save is
+      // pending. A raw tab close routes through pagehide, not sendLogout, so this
+      // is what covers it.
+      this.flushActionBarLayoutSave();
+      return;
+    }
     if (document.visibilityState !== 'visible') return;
     if (this.sessionEnded) return;
     if (this.ws.readyState === WebSocket.OPEN) return;
@@ -1668,6 +1679,11 @@ export class ClientWorld implements IWorld {
   }
 
   private endSession(): void {
+    // Flush a pending layout save BEFORE teardown, while the socket is still open
+    // and `connected` is still true: close() calls this before ws.close() and
+    // sendLogout() calls it before the logout frame, so the final edit is not
+    // lost to a deliberate logout within the debounce window.
+    this.flushActionBarLayoutSave();
     this.sessionEnded = true;
     this.failPendingCommandOutcomes();
     clearInterval(this.sendTimer);
@@ -3165,11 +3181,29 @@ export class ClientWorld implements IWorld {
     const json = JSON.stringify(clean);
     if (json === this.actionBarSaveLastJson) return;
     this.actionBarSaveLastJson = json;
+    this.actionBarSavePending = clean;
     if (this.actionBarSaveTimer !== null) clearTimeout(this.actionBarSaveTimer);
-    this.actionBarSaveTimer = setTimeout(() => {
+    this.actionBarSaveTimer = setTimeout(
+      () => this.flushActionBarLayoutSave(),
+      ACTION_BAR_SAVE_DEBOUNCE_MS,
+    );
+  }
+
+  // Send any debounced-but-not-yet-sent layout NOW. Called on the debounce timer
+  // and, critically, when the session ends or the page backgrounds (endSession +
+  // the visibilitychange 'hidden' branch), so the final sub-debounce edit reaches
+  // the server before the socket goes away instead of being stranded (the local
+  // mirror would still be right on the same device, but a second device would
+  // miss it). No-op unless a save is pending.
+  private flushActionBarLayoutSave(): void {
+    if (this.actionBarSaveTimer !== null) {
+      clearTimeout(this.actionBarSaveTimer);
       this.actionBarSaveTimer = null;
-      this.cmd({ cmd: 'save_hotbar_layout', layout: clean });
-    }, ACTION_BAR_SAVE_DEBOUNCE_MS);
+    }
+    const pending = this.actionBarSavePending;
+    if (pending === null) return;
+    this.actionBarSavePending = null;
+    this.cmd({ cmd: 'save_hotbar_layout', layout: pending });
   }
   takeActionBarLayoutRestore(): ActionBarLayoutRestore | undefined {
     const restore = this.actionBarRestore;

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -108,6 +108,11 @@ import {
   type VcSharedCupInfo,
   type VcViewerReadout,
 } from '../world_api';
+import {
+  type ActionBarLayout,
+  type ActionBarLayoutRestore,
+  sanitizeActionBarLayout,
+} from '../world_api/action_bar';
 import type { MasterworkView } from '../world_api/professions';
 import { computeBackoffDelay } from './backoff';
 import { optimisticQuestState } from './quest_state_optimistic';
@@ -1032,6 +1037,10 @@ const TELEPORT_SNAP_DIST_SQ = 40 * 40;
 // genuine leaver (logout, corpse cleanup) lingers only momentarily.
 const DESPAWN_GRACE_MS = 600;
 
+// Debounce for the action-bar layout upload: coalesce a burst of drag/drop edits
+// into one wire save rather than a send per slot change (server persists it).
+const ACTION_BAR_SAVE_DEBOUNCE_MS = 1500;
+
 // Auto-reconnect backoff for an unexpectedly dropped game socket. The server
 // holds the character in-world (linkdead) for five minutes; the retry window
 // is deliberately longer, since past the grace a successful auth simply
@@ -1509,6 +1518,14 @@ export class ClientWorld implements IWorld {
   // HUD redraws on — the frame loop polls this so open panels re-render
   private invChanged = false;
   private cosmeticsChanged = false;
+  // IWorldActionBar: the login-time reconciliation, resolved once from the first
+  // self-payload (undefined until then, and again once consumed); the debounced
+  // upload state coalesces rapid layout edits into one wire save and skips a
+  // send whose serialized layout matches the last one sent.
+  private actionBarRestore: ActionBarLayoutRestore | undefined = undefined;
+  private actionBarRestoreResolved = false;
+  private actionBarSaveTimer: ReturnType<typeof setTimeout> | null = null;
+  private actionBarSaveLastJson: string | null = null;
   // Soft (cosmetic) profanity terms the server sends in `hello` and pushes via
   // `censor` frames when an admin edits the list. The HUD drains these to mask
   // chat locally when the player's filter is on. Hard words never arrive here.
@@ -2738,6 +2755,22 @@ export class ClientWorld implements IWorld {
         while (d < -Math.PI) d += 2 * Math.PI;
         this.pendingFacingDelta += d;
       }
+      // IWorldActionBar: resolve the login-time layout reconciliation exactly
+      // once, on the first self-payload this ClientWorld processes. A fresh join
+      // always carries the heavy self block, so `hbl` is present: the stored
+      // server layout (server WINS) or an explicit null (the server has no copy,
+      // so seed from local). `hbl` absent on the first payload (a resumed
+      // session's re-sync, where it was already sent once) leaves the local
+      // mirror authoritative ('noop').
+      if (!this.actionBarRestoreResolved) {
+        this.actionBarRestoreResolved = true;
+        if (s.hbl !== undefined) {
+          const clean = s.hbl === null ? null : sanitizeActionBarLayout(s.hbl);
+          this.actionBarRestore = clean ? { source: 'server', layout: clean } : { source: 'seed' };
+        } else {
+          this.actionBarRestore = { source: 'noop' };
+        }
+      }
     }
 
     // prune entities that left our interest area. An entity briefly absent from
@@ -3120,6 +3153,28 @@ export class ClientWorld implements IWorld {
       this.cosmeticsChanged = true;
     }
     this.cmd({ cmd: 'change_weapon_skin', skin: skinId, wtype: type ?? null });
+  }
+  saveActionBarLayout(layout: ActionBarLayout): void {
+    // Debounced, deduped upload of the whole layout. The controller has already
+    // written the localStorage mirror; this pushes the server copy so it
+    // restores on other devices. Rapid drags coalesce to the last layout, and an
+    // upload whose serialized form matches the last send is skipped, so a
+    // re-save during login (or an unchanged bar) never amplifies wire/db writes.
+    const clean = sanitizeActionBarLayout(layout);
+    if (!clean) return;
+    const json = JSON.stringify(clean);
+    if (json === this.actionBarSaveLastJson) return;
+    this.actionBarSaveLastJson = json;
+    if (this.actionBarSaveTimer !== null) clearTimeout(this.actionBarSaveTimer);
+    this.actionBarSaveTimer = setTimeout(() => {
+      this.actionBarSaveTimer = null;
+      this.cmd({ cmd: 'save_hotbar_layout', layout: clean });
+    }, ACTION_BAR_SAVE_DEBOUNCE_MS);
+  }
+  takeActionBarLayoutRestore(): ActionBarLayoutRestore | undefined {
+    const restore = this.actionBarRestore;
+    this.actionBarRestore = undefined; // one-shot: consumed by the HUD at world entry
+    return restore;
   }
   chat(text: string): void {
     this.cmd({ cmd: 'chat', text });

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1,5 +1,7 @@
 import type {
   AccountCosmetics,
+  ActionBarLayout,
+  ActionBarLayoutRestore,
   ActiveFrostRing,
   ActiveTemporalHourglass,
   BankBonusSource,
@@ -3001,6 +3003,20 @@ export class Sim {
 
   changeWeaponSkin(skinId: string | null, weaponType?: WeaponSkinType): void {
     this.setWeaponSkin(this.primaryId, skinId, weaponType);
+  }
+
+  // IWorldActionBar (offline arm). The action-bar layout is client presentation
+  // state, not sim state: offline, localStorage (written by the controller) is
+  // the one store, so persisting is a no-op and there is no server copy to
+  // reconcile ('noop' leaves the localStorage-loaded bars untouched). Keeping
+  // these host-agnostic no-ops here is what stops the offline Sim ever becoming
+  // aware of a persistence host.
+  saveActionBarLayout(_layout: ActionBarLayout): void {
+    // Offline: the controller already wrote localStorage; nothing else to do.
+  }
+
+  takeActionBarLayoutRestore(): ActionBarLayoutRestore | undefined {
+    return { source: 'noop' };
   }
 
   /** Z-key sheathe toggle (IWorld.toggleWeaponStow; server `stow_weapon` command).

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -225,6 +225,11 @@ import {
   ACTION_BAR_ABILITY_SLOTS_PER_ROW,
   actionBarRowForSlot,
 } from './hud/action_bar/action_bar_layout_core';
+import {
+  applyActionBarLayout,
+  captureActionBarLayout,
+  planActionBarRestore,
+} from './hud/action_bar/action_bar_layout_sync';
 import { ActionBarPainter, type ActionBarSlotElements } from './hud/action_bar/action_bar_painter';
 import {
   ABILITY_ICON_PREFIX,
@@ -950,6 +955,8 @@ export class Hud {
   // stop autorun without making Hud own Input or MobileControls.
   onResurrectAtSpiritHealer: (() => void) | null = null;
   private readonly actionBarController: ActionBarController;
+  // One-shot latch for the login-time action-bar layout reconciliation.
+  private actionBarLayoutRestored = false;
   private get hotbarActions(): HotbarAction[] {
     return this.actionBarController.actions;
   }
@@ -1417,6 +1424,10 @@ export class Hud {
         return !!match && match.team !== null;
       },
       showAttackButton: () => this.optionsHooks?.settings.get('showAttackButton') ?? true,
+      // Persistence seam: online, the ClientWorld debounces a per-character wire
+      // save; offline, Sim.saveActionBarLayout is a no-op (localStorage is the
+      // store). The controller always writes the localStorage mirror itself.
+      persistLayout: (layout) => this.sim.saveActionBarLayout(layout),
     });
     this.delveTracker = new DelveTrackerController({
       element: $('#delve-tracker'),
@@ -4964,6 +4975,30 @@ export class Hud {
     this.actionBarController.saveActions();
   }
 
+  // Runs once at world entry (polled each frame until the world resolves the
+  // decision): reconcile the device's local action-bar layout with the server
+  // copy. Offline resolves immediately to 'noop'. Online waits for the login
+  // self-payload, then either the server copy WINS (overwrite the local mirror
+  // and re-seed the controller) or the local layout seeds the first server copy.
+  private maybeRestoreActionBarLayout(): void {
+    if (this.actionBarLayoutRestored) return;
+    const restore = this.sim.takeActionBarLayoutRestore();
+    if (restore === undefined) return; // still pending (online, pre-login-payload)
+    this.actionBarLayoutRestored = true;
+    const playerClass = this.sim.cfg.playerClass;
+    const playerName = this.sim.player.name;
+    const plan = planActionBarRestore(restore, () =>
+      captureActionBarLayout(localStorage, playerClass, playerName),
+    );
+    if (plan.action === 'apply-server') {
+      applyActionBarLayout(localStorage, playerClass, playerName, plan.layout);
+      this.actionBarController.reload();
+      this.spellbookWindow.refreshHotbarControls();
+    } else if (plan.action === 'seed-local') {
+      this.sim.saveActionBarLayout(plan.layout);
+    }
+  }
+
   private addAbilityToHotbar(abilityId: string): boolean {
     return this.actionBarController.addAbility(abilityId);
   }
@@ -6853,6 +6888,7 @@ export class Hud {
     this.lootRolls.update(now);
     if (slowHud) this.updateRaidLockoutBadge();
     if (slowHud) this.refreshDailyRewardsLauncher();
+    this.maybeRestoreActionBarLayout();
     this.syncActiveHotbarForm();
     this.syncSlotMap(); // picks up newly learned abilities mid-session
 

--- a/src/ui/hud/action_bar/action_bar_controller.ts
+++ b/src/ui/hud/action_bar/action_bar_controller.ts
@@ -1,8 +1,15 @@
 import { SPORT_ABILITIES } from '../../../sim/content/vale_cup';
 import { ABILITIES, ITEMS } from '../../../sim/data';
 import type { PlayerClass } from '../../../sim/types';
+import type { ActionBarLayout } from '../../../world_api/action_bar';
 import { WARRIOR_STANCE_GROUP } from '../../stance_bar_view';
 import { ACTION_BAR_ABILITY_SLOTS } from './action_bar_layout_core';
+import {
+  actionBarFormSeededKey,
+  actionBarSlotMapKey,
+  actionBarStealthInitializedKey,
+  captureActionBarLayout,
+} from './action_bar_layout_sync';
 import {
   actionForAttackSlot,
   attackSlotStorageKey,
@@ -36,6 +43,12 @@ export interface ActionBarControllerDeps {
   hasAura(kind: string): boolean;
   isInSportMatch(): boolean;
   showAttackButton(): boolean;
+  // The persistence seam: called after a user-driven layout change (never during
+  // initial load) with the FULL captured layout. Offline it is a no-op
+  // (localStorage is the store); online the ClientWorld debounces a wire save.
+  // Optional so an offline/test controller with no server persistence just skips
+  // it and keeps its byte-identical localStorage behavior.
+  persistLayout?(layout: ActionBarLayout): void;
 }
 
 /** Owns action-bar pages, migrations, persistence, and attack-slot assignment. */
@@ -48,12 +61,34 @@ export class ActionBarController {
   private loadedFromStorage = false;
   private knownAbilityIdsAtLastSync: Set<string> | null = null;
   private attackActionState: HotbarAction = null;
+  // Suppresses the persistence seam while the controller is loading/seeding from
+  // storage: only user-driven changes after init should upload. Flipped true at
+  // the end of init()/reload().
+  private ready = false;
 
   constructor(private readonly deps: ActionBarControllerDeps) {}
 
   init(): void {
     this.loadActions();
     this.loadAttackAction();
+    this.ready = true;
+  }
+
+  /** Re-seed every bar/attack slot from storage (after the server layout has
+   *  overwritten the local mirror at login). Persistence stays suppressed while
+   *  reloading so restoring a server copy never bounces straight back up. */
+  reload(): void {
+    this.ready = false;
+    this.loadActions();
+    this.loadAttackAction();
+    this.ready = true;
+  }
+
+  private persist(): void {
+    if (!this.ready || !this.deps.persistLayout) return;
+    this.deps.persistLayout(
+      captureActionBarLayout(this.deps.storage, this.deps.playerClass, this.deps.playerName),
+    );
   }
 
   get activeForm(): HotbarForm {
@@ -216,6 +251,7 @@ export class ActionBarController {
     } catch {
       // Storage can be unavailable in private browsing modes.
     }
+    this.persist();
   }
 
   saveAttackAction(): void {
@@ -228,11 +264,11 @@ export class ActionBarController {
     } catch {
       // Storage can be unavailable in private browsing modes.
     }
+    this.persist();
   }
 
   private slotMapKey(form: HotbarForm = this.activeFormState): string {
-    const base = `woc_hotbar_${this.deps.playerClass}_${this.deps.playerName}`;
-    return form === 'normal' ? base : `${base}_${form}`;
+    return actionBarSlotMapKey(this.deps.playerClass, this.deps.playerName, form);
   }
 
   private shouldAutoPlaceOnForm(id: string, form: HotbarForm): boolean {
@@ -271,7 +307,7 @@ export class ActionBarController {
   }
 
   private formBarSeededKey(form: HotbarForm = this.activeFormState): string {
-    return `${this.slotMapKey(form)}_seeded`;
+    return actionBarFormSeededKey(this.slotMapKey(form));
   }
 
   private markFormBarSeeded(form: HotbarForm = this.activeFormState): void {
@@ -283,7 +319,7 @@ export class ActionBarController {
   }
 
   private stealthBarInitializedKey(form: HotbarForm = this.activeFormState): string {
-    return `${this.slotMapKey(form)}_blank_v1`;
+    return actionBarStealthInitializedKey(this.slotMapKey(form));
   }
 
   private loadStealthActions(

--- a/src/ui/hud/action_bar/action_bar_layout_sync.ts
+++ b/src/ui/hud/action_bar/action_bar_layout_sync.ts
@@ -1,0 +1,148 @@
+// Pure (DOM-free, host-agnostic) bridge between the localStorage key scheme the
+// ActionBarController owns and the structured ActionBarLayout wire payload. It
+// reads/writes a `Pick<Storage, ...>` handed in, so a Vitest drives it against a
+// Map-backed fake; the browser passes real localStorage. The payload MODEL and
+// its bounds validation live one layer down in `src/world_api/action_bar.ts`
+// (shared with the server); this module only maps that model to and from the
+// per-form storage keys and decides the login-time reconciliation.
+
+import {
+  ACTION_BAR_LAYOUT_FORMS,
+  type ActionBarLayout,
+  type ActionBarLayoutForm,
+  type ActionBarLayoutRestore,
+  actionBarLayoutIsEmpty,
+  sanitizeActionBarLayout,
+} from '../../../world_api/action_bar';
+import { ACTION_BAR_ABILITY_SLOTS } from './action_bar_layout_core';
+import {
+  attackSlotStorageKey,
+  encodeStoredHotbarAction,
+  type HotbarAction,
+  type HotbarStorage,
+} from './hotbar';
+
+// The one source of truth for the action-bar localStorage key scheme. The
+// controller delegates to these so the capture/apply round trip cannot drift
+// from the keys the controller actually loads.
+export function actionBarSlotMapKey(
+  playerClass: string,
+  playerName: string,
+  form: ActionBarLayoutForm,
+): string {
+  const base = `woc_hotbar_${playerClass}_${playerName}`;
+  return form === 'normal' ? base : `${base}_${form}`;
+}
+
+export function actionBarFormSeededKey(slotMapKey: string): string {
+  return `${slotMapKey}_seeded`;
+}
+
+export function actionBarStealthInitializedKey(slotMapKey: string): string {
+  return `${slotMapKey}_blank_v1`;
+}
+
+type ReadStorage = Pick<HotbarStorage, 'getItem'>;
+type WriteStorage = Pick<HotbarStorage, 'getItem' | 'setItem' | 'removeItem'>;
+
+/**
+ * Read the full per-character layout out of storage into a bounded, structured
+ * payload. Only forms that have a stored bar or attack key are included; the
+ * result is passed through sanitizeActionBarLayout so it is already in-bounds.
+ */
+export function captureActionBarLayout(
+  storage: ReadStorage,
+  playerClass: string,
+  playerName: string,
+): ActionBarLayout {
+  const forms: Record<string, unknown> = {};
+  for (const form of ACTION_BAR_LAYOUT_FORMS) {
+    const key = actionBarSlotMapKey(playerClass, playerName, form);
+    let barRaw: string | null = null;
+    let attackRaw: string | null = null;
+    try {
+      barRaw = storage.getItem(key);
+      attackRaw = storage.getItem(attackSlotStorageKey(key));
+    } catch {
+      // Storage can be unavailable in private browsing modes.
+    }
+    if (barRaw === null && attackRaw === null) continue;
+    const formLayout: Record<string, unknown> = { bar: safeParseArray(barRaw) };
+    if (attackRaw !== null) formLayout.attack = safeParse(attackRaw);
+    forms[form] = formLayout;
+  }
+  return sanitizeActionBarLayout({ v: 1, forms }) ?? { v: 1, forms: {} };
+}
+
+/**
+ * Overwrite the device's local mirror with the server layout (server wins). Only
+ * the forms present in the layout are touched; an absent form leaves the
+ * device's state alone (version-tolerant, mirroring the hotbar tail rule). Each
+ * written form also gets its seed/init markers set so the controller treats the
+ * server data as already-seeded and never auto-seeds a default kit over it.
+ */
+export function applyActionBarLayout(
+  storage: WriteStorage,
+  playerClass: string,
+  playerName: string,
+  layout: ActionBarLayout,
+): void {
+  const clean = sanitizeActionBarLayout(layout);
+  if (!clean) return;
+  for (const form of ACTION_BAR_LAYOUT_FORMS) {
+    const formLayout = clean.forms[form];
+    if (!formLayout) continue;
+    const key = actionBarSlotMapKey(playerClass, playerName, form);
+    const bar: HotbarAction[] = Array.from(
+      { length: Math.min(formLayout.bar.length, ACTION_BAR_ABILITY_SLOTS) },
+      (_, i) => formLayout.bar[i] ?? null,
+    );
+    try {
+      storage.setItem(key, JSON.stringify(bar));
+      const encodedAttack = encodeStoredHotbarAction((formLayout.attack ?? null) as HotbarAction);
+      if (encodedAttack === null) storage.removeItem(attackSlotStorageKey(key));
+      else storage.setItem(attackSlotStorageKey(key), encodedAttack);
+      storage.setItem(actionBarFormSeededKey(key), '1');
+      storage.setItem(actionBarStealthInitializedKey(key), '1');
+    } catch {
+      // Storage can be unavailable in private browsing modes.
+    }
+  }
+}
+
+// The login-time reconciliation decision, as a pure function of the server's
+// restore signal and (lazily) the device's captured local layout. This is the
+// locked merge rule: server copy present -> server wins; server copy absent ->
+// seed from a non-empty local layout; both absent -> nothing (defaults stand).
+export type ActionBarRestorePlan =
+  | { action: 'apply-server'; layout: ActionBarLayout }
+  | { action: 'seed-local'; layout: ActionBarLayout }
+  | { action: 'none' };
+
+export function planActionBarRestore(
+  restore: ActionBarLayoutRestore | undefined,
+  captureLocal: () => ActionBarLayout,
+): ActionBarRestorePlan {
+  if (!restore) return { action: 'none' };
+  if (restore.source === 'server') return { action: 'apply-server', layout: restore.layout };
+  if (restore.source === 'seed') {
+    const local = captureLocal();
+    if (actionBarLayoutIsEmpty(local)) return { action: 'none' };
+    return { action: 'seed-local', layout: local };
+  }
+  return { action: 'none' };
+}
+
+function safeParse(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function safeParseArray(raw: string | null): unknown[] {
+  if (raw === null) return [];
+  const parsed = safeParse(raw);
+  return Array.isArray(parsed) ? parsed : [];
+}

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -57,6 +57,7 @@
 //                                          union of the facets.
 // ---------------------------------------------------------------------------
 
+import type { IWorldActionBar } from './world_api/action_bar';
 import type { IWorldBank } from './world_api/bank';
 import type { IWorldCardMinigame } from './world_api/card_minigame';
 import type { IWorldChat } from './world_api/chat';
@@ -118,6 +119,13 @@ export type StableCooldownWire =
   | readonly [expiresAt: number, recoveryRate: number, acceleratedUntil: number];
 
 // --- facet aux-type + value re-exports (each travels with its facet file) ---
+export type {
+  ActionBarFormLayout,
+  ActionBarLayout,
+  ActionBarLayoutForm,
+  ActionBarLayoutRestore,
+  ActionBarSlotAction,
+} from './world_api/action_bar';
 export type { BankBonusSource, BankInfo } from './world_api/bank';
 export type { CardMinigameInfo } from './world_api/card_minigame';
 export { isOverheadEmoteId, OVERHEAD_EMOTES } from './world_api/chat';
@@ -237,6 +245,7 @@ export interface IWorld
     IWorldBank,
     IWorldValeCup,
     IWorldDungeonFinder,
+    IWorldActionBar,
     IWorldDeeds {}
 
 // ---------------------------------------------------------------------------
@@ -430,6 +439,9 @@ export const COMMAND_NAMES = [
   // Recipe training (Professions 2.0 Phase 9): learn a trainer-taught recipe
   // at its craft's station (Sim.trainRecipe via professions/training.ts).
   'train_recipe',
+  // Per-character action-bar layout persistence: the owning client uploads its
+  // full arranged layout (debounced) so it restores at login on any device.
+  'save_hotbar_layout',
 ] as const;
 
 // The union both the send path (`online.ts`) and the dispatch switch
@@ -498,6 +510,7 @@ export type WorldFacet =
   | 'IWorldBank'
   | 'IWorldValeCup'
   | 'IWorldDungeonFinder'
+  | 'IWorldActionBar'
   | 'IWorldDeeds';
 
 export const COMMAND_FACETS = {
@@ -683,4 +696,7 @@ export const COMMAND_FACETS = {
   // design). deedsEarned/deedStats/renown/activeTitle are snapshot reads (no
   // send, untagged).
   deed_set_title: 'IWorldDeeds',
+  // IWorldActionBar: the debounced action-bar layout upload. takeActionBarLayoutRestore
+  // is a login-time read (no send, untagged).
+  save_hotbar_layout: 'IWorldActionBar',
 } as const satisfies Partial<Record<ClientCommand, WorldFacet>>;

--- a/src/world_api/action_bar.ts
+++ b/src/world_api/action_bar.ts
@@ -1,0 +1,135 @@
+// IWorldActionBar: per-character action-bar layout persistence. The layout is
+// pure client PRESENTATION state (a remap over learned abilities + item
+// shortcuts), NOT sim gameplay state, so it never rides the deterministic
+// CharacterState. Offline it lives in localStorage exactly as before; online it
+// is persisted per character on the server and restored at login on any device.
+//
+// This module is the ONE home both the server and the client share for the wire
+// payload MODEL and its bounds validation: it is DOM-free and sim-free (only
+// plain types), so `server/game.ts` (which cannot import `src/ui/`) and the
+// client controller both import the same `sanitizeActionBarLayout`. The
+// localStorage read/write side lives in `src/ui/hud/action_bar/
+// action_bar_layout_sync.ts` (browser-only), which imports the type from here.
+
+// The six action-bar "forms" a character can arrange independently: the base
+// bar, the druid Bear/Cat/Cat-stealth kits, the rogue Stealth bar, and the Vale
+// Cup sport bar. This is the full sibling set the localStorage keys cover.
+export const ACTION_BAR_LAYOUT_FORMS = [
+  'normal',
+  'bear',
+  'cat',
+  'cat_stealth',
+  'stealth',
+  'sport',
+] as const;
+export type ActionBarLayoutForm = (typeof ACTION_BAR_LAYOUT_FORMS)[number];
+
+// Bounds for the untrusted client payload (validated server-side). The slot cap
+// is the current configurable-slot count (SAVED_LOADOUT_BAR_SLOTS, three rows);
+// a legacy shorter/longer array is tolerated up to the cap, never past it.
+export const ACTION_BAR_LAYOUT_VERSION = 1;
+export const ACTION_BAR_LAYOUT_MAX_SLOTS = 33;
+export const ACTION_BAR_LAYOUT_MAX_ID_LEN = 64;
+// Hard ceiling on distinct form keys accepted before the whole payload is
+// rejected as abusive (a legitimate client sends at most ACTION_BAR_LAYOUT_FORMS).
+export const ACTION_BAR_LAYOUT_MAX_FORM_KEYS = 16;
+
+export type ActionBarSlotAction = { type: 'ability' | 'item'; id: string };
+
+export interface ActionBarFormLayout {
+  // The configurable slots (index 0 is bar slot 1). Entries are an ability/item
+  // binding or null for an empty slot. Up to ACTION_BAR_LAYOUT_MAX_SLOTS long.
+  bar: (ActionBarSlotAction | null)[];
+  // The player-assignable Attack control binding (bar slot 0), or null/absent.
+  attack?: ActionBarSlotAction | null;
+}
+
+export interface ActionBarLayout {
+  v: number;
+  // PARTIAL by design: an absent form means "leave the device's state for that
+  // form alone" on apply (version-tolerant, mirroring the hotbar tail rule).
+  forms: Partial<Record<ActionBarLayoutForm, ActionBarFormLayout>>;
+}
+
+// How the client should reconcile its local layout with the server copy at
+// world entry (resolved once per ClientWorld from the login self-payload):
+//   - 'server': the server has a copy; it WINS (seed the controller + overwrite
+//     the local mirror).
+//   - 'seed':   the server has NO copy; the device's local layout seeds the
+//     first server copy (or, if the device has none either, defaults stand).
+//   - 'noop':   nothing to do (offline play, or a reconnect that keeps the
+//     already-authoritative local mirror).
+export type ActionBarLayoutRestore =
+  | { source: 'server'; layout: ActionBarLayout }
+  | { source: 'seed' }
+  | { source: 'noop' };
+
+export interface IWorldActionBar {
+  // Persist the full action-bar layout for this character. Offline: a no-op
+  // (localStorage, written by the controller, is the store). Online: a debounced
+  // wire save; the localStorage mirror is written by the controller as before.
+  saveActionBarLayout(layout: ActionBarLayout): void;
+  // One-shot at world entry: the login-time reconciliation decision, consumed
+  // once (subsequent calls return undefined). Returns undefined while the
+  // resolution is still pending (online, before the login self-payload arrives),
+  // so the caller polls until it resolves. Offline resolves to 'noop' at once.
+  takeActionBarLayoutRestore(): ActionBarLayoutRestore | undefined;
+}
+
+const KNOWN_FORMS = new Set<string>(ACTION_BAR_LAYOUT_FORMS);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function sanitizeSlotAction(value: unknown): ActionBarSlotAction | null {
+  if (!isPlainObject(value)) return null;
+  const type = value.type;
+  const id = value.id;
+  if (type !== 'ability' && type !== 'item') return null;
+  if (typeof id !== 'string') return null;
+  if (id.length === 0 || id.length > ACTION_BAR_LAYOUT_MAX_ID_LEN) return null;
+  return { type, id };
+}
+
+function sanitizeFormLayout(value: unknown): ActionBarFormLayout | null {
+  if (!isPlainObject(value)) return null;
+  const rawBar = value.bar;
+  if (!Array.isArray(rawBar)) return null;
+  // Reject an oversized bar outright rather than silently truncating untrusted
+  // input; a legitimate client never sends past the slot cap.
+  if (rawBar.length > ACTION_BAR_LAYOUT_MAX_SLOTS) return null;
+  const bar = rawBar.map((entry) => (entry === null ? null : sanitizeSlotAction(entry)));
+  const layout: ActionBarFormLayout = { bar };
+  if ('attack' in value) {
+    layout.attack = value.attack === null ? null : sanitizeSlotAction(value.attack);
+  }
+  return layout;
+}
+
+/**
+ * Validate + bound an untrusted action-bar layout payload. Returns a clean,
+ * in-bounds ActionBarLayout, or null when the input is fundamentally malformed
+ * (not an object, or an oversized/garbage form). Never throws: a bad payload
+ * yields null so the caller can drop it without crashing the session.
+ */
+export function sanitizeActionBarLayout(value: unknown): ActionBarLayout | null {
+  if (!isPlainObject(value)) return null;
+  const rawForms = value.forms;
+  if (!isPlainObject(rawForms)) return null;
+  const keys = Object.keys(rawForms);
+  if (keys.length > ACTION_BAR_LAYOUT_MAX_FORM_KEYS) return null;
+  const forms: Partial<Record<ActionBarLayoutForm, ActionBarFormLayout>> = {};
+  for (const key of keys) {
+    if (!KNOWN_FORMS.has(key)) continue; // ignore unknown form keys
+    const form = sanitizeFormLayout(rawForms[key]);
+    if (form === null) return null; // an oversized/garbage form rejects the payload
+    forms[key as ActionBarLayoutForm] = form;
+  }
+  return { v: ACTION_BAR_LAYOUT_VERSION, forms };
+}
+
+/** True when a layout carries no form data (nothing worth persisting/seeding). */
+export function actionBarLayoutIsEmpty(layout: ActionBarLayout): boolean {
+  return Object.keys(layout.forms).length === 0;
+}

--- a/tests/action_bar_controller.test.ts
+++ b/tests/action_bar_controller.test.ts
@@ -5,6 +5,7 @@ import {
   ActionBarController,
 } from '../src/ui/hud/action_bar/action_bar_controller';
 import type { HotbarAction } from '../src/ui/hud/action_bar/hotbar';
+import type { ActionBarLayout } from '../src/world_api/action_bar';
 
 class MemoryStorage {
   readonly values = new Map<string, string>();
@@ -464,5 +465,74 @@ describe('ActionBarController: passives never occupy an action slot', () => {
 
     expect(controller.attackAction).toBeNull();
     expect(storage.getItem(key)).toBeNull();
+  });
+});
+
+describe('ActionBarController persistence seam', () => {
+  function persistHarness(): {
+    controller: ActionBarController;
+    storage: MemoryStorage;
+    persisted: ActionBarLayout[];
+  } {
+    const storage = new MemoryStorage();
+    const persisted: ActionBarLayout[] = [];
+    const controller = new ActionBarController({
+      storage,
+      playerClass: 'warrior',
+      playerName: 'ActionbarTester',
+      knownAbilityIds: () => ['heroic_strike', 'sunder_armor'],
+      hasAura: () => false,
+      isInSportMatch: () => false,
+      showAttackButton: () => true,
+      persistLayout: (layout) => persisted.push(layout),
+    });
+    return { controller, storage, persisted };
+  }
+
+  it('does NOT persist while loading during init (only user changes upload)', () => {
+    const { controller, persisted } = persistHarness();
+    controller.init();
+    expect(persisted).toEqual([]);
+  });
+
+  it('persists the full captured layout on a user-driven save after init', () => {
+    const { controller, persisted } = persistHarness();
+    controller.init();
+    controller.replaceActions(bar('heroic_strike'));
+    controller.saveActions();
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].forms.normal?.bar[0]).toEqual({ type: 'ability', id: 'heroic_strike' });
+  });
+
+  it('does NOT persist while re-seeding from storage in reload (server-wins restore)', () => {
+    const { controller, storage, persisted } = persistHarness();
+    controller.init();
+    persisted.length = 0;
+    // Simulate a server layout landing in the mirror, then a reload.
+    storage.setItem('woc_hotbar_warrior_ActionbarTester', JSON.stringify(bar('sunder_armor')));
+    controller.reload();
+    expect(persisted).toEqual([]);
+    expect(controller.actions[0]).toEqual({ type: 'ability', id: 'sunder_armor' });
+  });
+
+  it('keeps offline localStorage behavior byte-identical when no persistLayout is wired', () => {
+    const storage = new MemoryStorage();
+    const controller = new ActionBarController({
+      storage,
+      playerClass: 'warrior',
+      playerName: 'ActionbarTester',
+      knownAbilityIds: () => ['heroic_strike'],
+      hasAura: () => false,
+      isInSportMatch: () => false,
+      showAttackButton: () => true,
+      // no persistLayout: offline arm
+    });
+    controller.init();
+    controller.replaceActions(bar('heroic_strike'));
+    expect(() => controller.saveActions()).not.toThrow();
+    expect(JSON.parse(storage.getItem('woc_hotbar_warrior_ActionbarTester') ?? 'null')[0]).toEqual({
+      type: 'ability',
+      id: 'heroic_strike',
+    });
   });
 });

--- a/tests/action_bar_layout_client.test.ts
+++ b/tests/action_bar_layout_client.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ClientWorld } from '../src/net/online';
+import type { ActionBarLayout } from '../src/world_api/action_bar';
+
+// The ClientWorld upload-coalescing contract, driven on a bare prototype instance
+// (no WebSocket plumbing) with fake timers. This pins the write-amplification
+// defenses: a burst of edits collapses to ONE wire save carrying the final
+// layout, and an unchanged re-save sends nothing.
+function bareClient(): { client: any; sent: any[] } {
+  const client: any = Object.create(ClientWorld.prototype);
+  client.actionBarSaveTimer = null;
+  client.actionBarSaveLastJson = null;
+  const sent: any[] = [];
+  client.cmd = (payload: any) => sent.push(payload);
+  return { client, sent };
+}
+
+const A: ActionBarLayout = { v: 1, forms: { normal: { bar: [{ type: 'ability', id: 'a' }] } } };
+const B: ActionBarLayout = { v: 1, forms: { normal: { bar: [{ type: 'ability', id: 'b' }] } } };
+const C: ActionBarLayout = { v: 1, forms: { normal: { bar: [{ type: 'ability', id: 'c' }] } } };
+
+describe('ClientWorld.saveActionBarLayout (debounce + dedup)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('coalesces a burst of edits into one wire save carrying the final layout', () => {
+    const { client, sent } = bareClient();
+    client.saveActionBarLayout(A);
+    client.saveActionBarLayout(B);
+    client.saveActionBarLayout(C);
+    expect(sent).toHaveLength(0); // nothing sent until the debounce elapses
+    vi.advanceTimersByTime(1600);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].cmd).toBe('save_hotbar_layout');
+    expect(sent[0].layout).toEqual(C);
+  });
+
+  it('skips a re-save whose serialized layout matches the last one sent', () => {
+    const { client, sent } = bareClient();
+    client.saveActionBarLayout(A);
+    vi.advanceTimersByTime(1600);
+    expect(sent).toHaveLength(1);
+    // Identical layout again: deduped, no timer even scheduled.
+    client.saveActionBarLayout(A);
+    vi.advanceTimersByTime(1600);
+    expect(sent).toHaveLength(1);
+    // A genuine change still uploads.
+    client.saveActionBarLayout(B);
+    vi.advanceTimersByTime(1600);
+    expect(sent).toHaveLength(2);
+    expect(sent[1].layout).toEqual(B);
+  });
+
+  it('drops a malformed layout without scheduling a send', () => {
+    const { client, sent } = bareClient();
+    client.saveActionBarLayout({ forms: 'garbage' } as unknown as ActionBarLayout);
+    vi.advanceTimersByTime(1600);
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/tests/action_bar_layout_client.test.ts
+++ b/tests/action_bar_layout_client.test.ts
@@ -10,6 +10,7 @@ function bareClient(): { client: any; sent: any[] } {
   const client: any = Object.create(ClientWorld.prototype);
   client.actionBarSaveTimer = null;
   client.actionBarSaveLastJson = null;
+  client.actionBarSavePending = null;
   const sent: any[] = [];
   client.cmd = (payload: any) => sent.push(payload);
   return { client, sent };
@@ -55,6 +56,25 @@ describe('ClientWorld.saveActionBarLayout (debounce + dedup)', () => {
     const { client, sent } = bareClient();
     client.saveActionBarLayout({ forms: 'garbage' } as unknown as ActionBarLayout);
     vi.advanceTimersByTime(1600);
+    expect(sent).toHaveLength(0);
+  });
+
+  it('flushes a pending debounced save immediately (logout / tab-close path)', () => {
+    const { client, sent } = bareClient();
+    client.saveActionBarLayout(A);
+    expect(sent).toHaveLength(0); // still inside the debounce window
+    client.flushActionBarLayoutSave();
+    expect(sent).toHaveLength(1);
+    expect(sent[0].cmd).toBe('save_hotbar_layout');
+    expect(sent[0].layout).toEqual(A);
+    // The cancelled debounce timer must not then fire a duplicate.
+    vi.advanceTimersByTime(1600);
+    expect(sent).toHaveLength(1);
+  });
+
+  it('flush with nothing pending is a no-op', () => {
+    const { client, sent } = bareClient();
+    client.flushActionBarLayoutSave();
     expect(sent).toHaveLength(0);
   });
 });

--- a/tests/action_bar_layout_persistence_game.test.ts
+++ b/tests/action_bar_layout_persistence_game.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mocked-db GameServer harness (see tests/character_lease_game.test.ts). Only the
+// db exports game.ts touches on the join / dispatch / broadcast paths are stubbed;
+// setCharacterHotbarLayout is the one this suite asserts on. The mock is hoisted
+// above the game import.
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  saveCharacterAndMarketState: vi.fn(async () => {}),
+  saveMarketState: vi.fn(async () => {}),
+  saveMailState: vi.fn(async () => {}),
+  loadMarketState: vi.fn(async () => null),
+  loadMailState: vi.fn(async () => null),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  revokeAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  insertBankLedgerRow: vi.fn(async () => {}),
+  acquireCharacterLease: vi.fn(async () => true),
+  releaseCharacterLease: vi.fn(async () => {}),
+  heartbeatCharacterLeases: vi.fn(async () => {}),
+  releaseAllCharacterLeases: vi.fn(async () => {}),
+  setCharacterHotbarLayout: vi.fn(async () => {}),
+}));
+
+import { setCharacterHotbarLayout } from '../server/db';
+import { type ClientSession, GameServer } from '../server/game';
+import type { ActionBarLayout } from '../src/world_api/action_bar';
+
+interface FakeClient {
+  sent: any[];
+  ws: { readyState: number; send: (payload: string) => void };
+}
+
+function fakeWs(): FakeClient {
+  const sent: any[] = [];
+  return { sent, ws: { readyState: 1, send: (p: string) => sent.push(JSON.parse(p)) } };
+}
+
+function lastSnap(sent: any[]): any {
+  for (let i = sent.length - 1; i >= 0; i--) {
+    if (sent[i].t === 'snap') return sent[i];
+  }
+  return null;
+}
+
+function join(
+  server: GameServer,
+  fc: FakeClient,
+  characterId: number,
+  name: string,
+  meta: Parameters<GameServer['join']>[7] = {},
+): ClientSession {
+  const s = server.join(fc.ws as any, characterId, characterId, name, 'warrior', null, false, meta);
+  if ('error' in s) throw new Error(s.error);
+  s.blockListLoaded = true;
+  return s;
+}
+
+function broadcast(server: GameServer): void {
+  (server as any).broadcastSnapshots();
+}
+
+const LAYOUT: ActionBarLayout = {
+  v: 1,
+  forms: {
+    normal: {
+      bar: [{ type: 'ability', id: 'heroic_strike' }, null],
+      attack: { type: 'item', id: 'linen_bandage' },
+    },
+    stealth: { bar: [{ type: 'ability', id: 'ambush' }], attack: null },
+  },
+};
+
+describe('action-bar layout persistence (wire round trip)', () => {
+  beforeEach(() => {
+    vi.mocked(setCharacterHotbarLayout).mockClear();
+  });
+
+  it('sends the stored layout to the owning client once, as the self `hbl` field', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    join(server, fc, 1, 'Owner', { hotbarLayout: LAYOUT });
+    broadcast(server);
+    const snap = lastSnap(fc.sent);
+    expect(snap.self.hbl).toEqual(LAYOUT);
+
+    // Second broadcast: the frozen layout is diffed against lastSent, so it is
+    // NOT re-echoed (a later save must never round-trip back and clobber edits).
+    fc.sent.length = 0;
+    broadcast(server);
+    const snap2 = lastSnap(fc.sent);
+    expect(snap2?.self).not.toHaveProperty('hbl');
+  });
+
+  it('sends an explicit null `hbl` (seed signal) when the character has no stored layout', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    join(server, fc, 5, 'Fresh');
+    broadcast(server);
+    const snap = lastSnap(fc.sent);
+    expect(snap.self).toHaveProperty('hbl');
+    expect(snap.self.hbl).toBeNull();
+  });
+
+  it("does NOT leak one player's layout to another client observing the same entity", () => {
+    const server = new GameServer();
+    const ownerFc = fakeWs();
+    const observerFc = fakeWs();
+    const owner = join(server, ownerFc, 1, 'Owner', { hotbarLayout: LAYOUT });
+    join(server, observerFc, 2, 'Observer');
+    broadcast(server);
+
+    const observerSnap = lastSnap(observerFc.sent);
+    // The observer sees the owner as an OTHER entity (snap.ents); no entity wire
+    // carries a hotbar layout, and the observer's own self.hbl is its own (null).
+    for (const ent of observerSnap.ents ?? []) {
+      expect(ent).not.toHaveProperty('hbl');
+    }
+    expect(observerSnap.self.hbl).toBeNull();
+    // Decisive: the owner's private layout appears nowhere in the observer's frame.
+    expect(JSON.stringify(observerSnap)).not.toContain('linen_bandage');
+    // The owner still receives its own layout.
+    expect(lastSnap(ownerFc.sent).self.hbl).toEqual(LAYOUT);
+    void owner;
+  });
+
+  it('serializes concurrent saves per character in FIFO order (no reordered stale write)', async () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = join(server, fc, 9, 'Ordered');
+    const first: ActionBarLayout = {
+      v: 1,
+      forms: { normal: { bar: [{ type: 'ability', id: 'first' }] } },
+    };
+    const second: ActionBarLayout = {
+      v: 1,
+      forms: { normal: { bar: [{ type: 'ability', id: 'second' }] } },
+    };
+    // Two saves dispatched back to back: the per-character FIFO queue must commit
+    // them in arrival order so the newer layout is never overwritten by the older.
+    server.handleMessage(
+      session,
+      JSON.stringify({ t: 'cmd', cmd: 'save_hotbar_layout', layout: first }),
+    );
+    server.handleMessage(
+      session,
+      JSON.stringify({ t: 'cmd', cmd: 'save_hotbar_layout', layout: second }),
+    );
+    await vi.waitFor(() => expect(vi.mocked(setCharacterHotbarLayout)).toHaveBeenCalledTimes(2));
+    const calls = vi.mocked(setCharacterHotbarLayout).mock.calls;
+    expect(calls.map((c) => c[0])).toEqual([9, 9]);
+    expect(calls[0][1]).toEqual(first);
+    expect(calls[1][1]).toEqual(second);
+  });
+
+  it('validates + enqueues a save with the exact sanitized payload on a save_hotbar_layout command', async () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = join(server, fc, 7, 'Saver');
+    server.handleMessage(
+      session,
+      JSON.stringify({ t: 'cmd', cmd: 'save_hotbar_layout', layout: LAYOUT }),
+    );
+    await vi.waitFor(() => expect(vi.mocked(setCharacterHotbarLayout)).toHaveBeenCalledTimes(1));
+    const [characterId, saved] = vi.mocked(setCharacterHotbarLayout).mock.calls[0];
+    expect(characterId).toBe(7);
+    expect(saved).toEqual(LAYOUT);
+  });
+
+  it('drops a garbage / oversized payload server-side without crashing or persisting', async () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = join(server, fc, 8, 'Abuser');
+
+    // Not an object.
+    expect(() =>
+      server.handleMessage(
+        session,
+        JSON.stringify({ t: 'cmd', cmd: 'save_hotbar_layout', layout: 'nope' }),
+      ),
+    ).not.toThrow();
+    // An oversized bar (past the slot cap) rejects the whole payload.
+    const huge = { v: 1, forms: { normal: { bar: Array.from({ length: 500 }, () => null) } } };
+    expect(() =>
+      server.handleMessage(
+        session,
+        JSON.stringify({ t: 'cmd', cmd: 'save_hotbar_layout', layout: huge }),
+      ),
+    ).not.toThrow();
+    // Missing layout entirely.
+    expect(() =>
+      server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'save_hotbar_layout' })),
+    ).not.toThrow();
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(vi.mocked(setCharacterHotbarLayout)).not.toHaveBeenCalled();
+    // The session survives: a subsequent valid command still processes.
+    server.handleMessage(
+      session,
+      JSON.stringify({ t: 'cmd', cmd: 'save_hotbar_layout', layout: LAYOUT }),
+    );
+    await vi.waitFor(() => expect(vi.mocked(setCharacterHotbarLayout)).toHaveBeenCalledTimes(1));
+  });
+});

--- a/tests/action_bar_layout_sync.test.ts
+++ b/tests/action_bar_layout_sync.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+import {
+  actionBarSlotMapKey,
+  applyActionBarLayout,
+  captureActionBarLayout,
+  planActionBarRestore,
+} from '../src/ui/hud/action_bar/action_bar_layout_sync';
+import { attackSlotStorageKey } from '../src/ui/hud/action_bar/hotbar';
+import {
+  ACTION_BAR_LAYOUT_MAX_ID_LEN,
+  ACTION_BAR_LAYOUT_MAX_SLOTS,
+  type ActionBarLayout,
+  actionBarLayoutIsEmpty,
+  sanitizeActionBarLayout,
+} from '../src/world_api/action_bar';
+
+class MemoryStorage {
+  readonly values = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+const CLS = 'warrior';
+const NAME = 'LayoutTester';
+
+describe('sanitizeActionBarLayout (untrusted payload bounds)', () => {
+  it('accepts a well-formed layout and normalizes the version', () => {
+    const clean = sanitizeActionBarLayout({
+      v: 99,
+      forms: { normal: { bar: [{ type: 'ability', id: 'heroic_strike' }, null], attack: null } },
+    });
+    expect(clean).not.toBeNull();
+    expect(clean?.v).toBe(1);
+    expect(clean?.forms.normal?.bar).toEqual([{ type: 'ability', id: 'heroic_strike' }, null]);
+    expect(clean?.forms.normal?.attack).toBeNull();
+  });
+
+  it('rejects a non-object payload without throwing', () => {
+    expect(sanitizeActionBarLayout(null)).toBeNull();
+    expect(sanitizeActionBarLayout(42)).toBeNull();
+    expect(sanitizeActionBarLayout('garbage')).toBeNull();
+    expect(sanitizeActionBarLayout([])).toBeNull();
+    expect(sanitizeActionBarLayout({ v: 1 })).toBeNull(); // no forms object
+  });
+
+  it('rejects a bar longer than the slot cap (oversized, not truncated)', () => {
+    const bar = Array.from({ length: ACTION_BAR_LAYOUT_MAX_SLOTS + 1 }, () => null);
+    expect(sanitizeActionBarLayout({ v: 1, forms: { normal: { bar } } })).toBeNull();
+  });
+
+  it('rejects an over-long ability id by nulling the slot, not the payload', () => {
+    const id = 'x'.repeat(ACTION_BAR_LAYOUT_MAX_ID_LEN + 1);
+    const clean = sanitizeActionBarLayout({
+      v: 1,
+      forms: { normal: { bar: [{ type: 'ability', id }] } },
+    });
+    expect(clean?.forms.normal?.bar).toEqual([null]);
+  });
+
+  it('drops unknown form keys but keeps the payload', () => {
+    const clean = sanitizeActionBarLayout({
+      v: 1,
+      forms: { normal: { bar: [] }, wat: { bar: [] }, __proto__: { bar: [] } },
+    });
+    expect(clean).not.toBeNull();
+    expect(Object.keys(clean?.forms ?? {})).toEqual(['normal']);
+  });
+
+  it('rejects a payload with an abusive number of form keys', () => {
+    const forms: Record<string, unknown> = {};
+    for (let i = 0; i < 64; i++) forms[`junk${i}`] = { bar: [] };
+    expect(sanitizeActionBarLayout({ v: 1, forms })).toBeNull();
+  });
+
+  it('nulls a garbage slot entry instead of rejecting the whole bar', () => {
+    const clean = sanitizeActionBarLayout({
+      v: 1,
+      forms: {
+        normal: { bar: [{ type: 'nope', id: 'x' }, { id: 5 }, 'string', { type: 'item' }] },
+      },
+    });
+    expect(clean?.forms.normal?.bar).toEqual([null, null, null, null]);
+  });
+
+  it('reports emptiness', () => {
+    expect(actionBarLayoutIsEmpty({ v: 1, forms: {} })).toBe(true);
+    expect(actionBarLayoutIsEmpty({ v: 1, forms: { normal: { bar: [] } } })).toBe(false);
+  });
+});
+
+describe('capture/apply round trip', () => {
+  it('captures every stored form bar plus its attack binding', () => {
+    const storage = new MemoryStorage();
+    const normalKey = actionBarSlotMapKey(CLS, NAME, 'normal');
+    const bearKey = actionBarSlotMapKey(CLS, NAME, 'bear');
+    storage.setItem(normalKey, JSON.stringify([{ type: 'ability', id: 'heroic_strike' }, null]));
+    storage.setItem(
+      attackSlotStorageKey(normalKey),
+      JSON.stringify({ type: 'item', id: 'potion' }),
+    );
+    storage.setItem(bearKey, JSON.stringify([{ type: 'ability', id: 'maul' }]));
+
+    const layout = captureActionBarLayout(storage, CLS, NAME);
+    expect(layout.forms.normal?.bar).toEqual([{ type: 'ability', id: 'heroic_strike' }, null]);
+    expect(layout.forms.normal?.attack).toEqual({ type: 'item', id: 'potion' });
+    expect(layout.forms.bear?.bar).toEqual([{ type: 'ability', id: 'maul' }]);
+    // A form with no stored key is absent (leave-alone semantics).
+    expect(layout.forms.cat).toBeUndefined();
+  });
+
+  it('applies a server layout onto a different device, overwriting the mirror and setting seed markers', () => {
+    const storage = new MemoryStorage();
+    const layout: ActionBarLayout = {
+      v: 1,
+      forms: {
+        normal: {
+          bar: [{ type: 'ability', id: 'mortal_strike' }],
+          attack: { type: 'item', id: 'potion' },
+        },
+      },
+    };
+    applyActionBarLayout(storage, CLS, NAME, layout);
+    const key = actionBarSlotMapKey(CLS, NAME, 'normal');
+    expect(JSON.parse(storage.getItem(key) ?? 'null')).toEqual([
+      { type: 'ability', id: 'mortal_strike' },
+    ]);
+    expect(JSON.parse(storage.getItem(attackSlotStorageKey(key)) ?? 'null')).toEqual({
+      type: 'item',
+      id: 'potion',
+    });
+    expect(storage.getItem(`${key}_seeded`)).toBe('1');
+    expect(storage.getItem(`${key}_blank_v1`)).toBe('1');
+  });
+
+  it('is a faithful round trip: capture(apply(L)) preserves the forms in L', () => {
+    const storage = new MemoryStorage();
+    const layout: ActionBarLayout = {
+      v: 1,
+      forms: {
+        normal: { bar: [{ type: 'ability', id: 'a' }, null, { type: 'item', id: 'b' }] },
+        stealth: { bar: [{ type: 'ability', id: 'ambush' }], attack: null },
+      },
+    };
+    applyActionBarLayout(storage, CLS, NAME, layout);
+    const captured = captureActionBarLayout(storage, CLS, NAME);
+    expect(captured.forms.normal?.bar).toEqual(layout.forms.normal?.bar);
+    expect(captured.forms.stealth?.bar).toEqual(layout.forms.stealth?.bar);
+  });
+
+  it('leaves an absent form untouched on the device (version-tolerant)', () => {
+    const storage = new MemoryStorage();
+    const catKey = actionBarSlotMapKey(CLS, NAME, 'cat');
+    storage.setItem(catKey, JSON.stringify([{ type: 'ability', id: 'shred' }]));
+    // A server layout that only knows about the normal bar must not clear cat.
+    applyActionBarLayout(storage, CLS, NAME, {
+      v: 1,
+      forms: { normal: { bar: [{ type: 'ability', id: 'wrath' }] } },
+    });
+    expect(JSON.parse(storage.getItem(catKey) ?? 'null')).toEqual([
+      { type: 'ability', id: 'shred' },
+    ]);
+  });
+});
+
+describe('planActionBarRestore (the locked merge rule)', () => {
+  const local: ActionBarLayout = {
+    v: 1,
+    forms: { normal: { bar: [{ type: 'ability', id: 'x' }] } },
+  };
+  const server: ActionBarLayout = {
+    v: 1,
+    forms: { normal: { bar: [{ type: 'ability', id: 'srv' }] } },
+  };
+
+  it('server copy present WINS over local', () => {
+    const plan = planActionBarRestore({ source: 'server', layout: server }, () => local);
+    expect(plan).toEqual({ action: 'apply-server', layout: server });
+  });
+
+  it('server copy absent seeds from a non-empty local layout', () => {
+    const plan = planActionBarRestore({ source: 'seed' }, () => local);
+    expect(plan).toEqual({ action: 'seed-local', layout: local });
+  });
+
+  it('both absent seeds nothing (defaults stand)', () => {
+    const plan = planActionBarRestore({ source: 'seed' }, () => ({ v: 1, forms: {} }));
+    expect(plan).toEqual({ action: 'none' });
+  });
+
+  it('noop / undefined restore does nothing (offline, reconnect)', () => {
+    expect(planActionBarRestore({ source: 'noop' }, () => local)).toEqual({ action: 'none' });
+    expect(planActionBarRestore(undefined, () => local)).toEqual({ action: 'none' });
+  });
+});

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -103,6 +103,13 @@ const actionBarControllerTs = readFileSync(
   new URL('../src/ui/hud/action_bar/action_bar_controller.ts', import.meta.url),
   'utf8',
 ).replace(/\r\n/g, '\n');
+// The per-form storage key scheme (incl. the `_seeded` / `_blank_v1` markers) is
+// shared with the layout-sync module so server-restore writes cannot drift from
+// the keys the controller loads.
+const actionBarLayoutSyncTs = readFileSync(
+  new URL('../src/ui/hud/action_bar/action_bar_layout_sync.ts', import.meta.url),
+  'utf8',
+).replace(/\r\n/g, '\n');
 // The Esc options menu was extracted to options_view.ts (the declarative menu
 // model) + options_window.ts (the painter); the menu guard reads the
 // model rather than the old inline hud.ts main-menu builder.
@@ -2196,7 +2203,10 @@ describe('client HTML shell', () => {
   });
 
   it('migrates a pre-existing form bar at most once via a per-form seeded marker', () => {
-    expect(actionBarControllerTs).toContain('_seeded');
+    // The `_seeded` marker suffix lives in the shared key-scheme module; the
+    // controller gates seeding on it via formBarSeededKey.
+    expect(actionBarLayoutSyncTs).toContain('_seeded');
+    expect(actionBarControllerTs).toContain('actionBarFormSeededKey(this.slotMapKey(form))');
     expect(actionBarControllerTs).toContain('shouldSeedFormBar(parsed, normalActions, false)');
   });
 

--- a/tests/command_schema.test.ts
+++ b/tests/command_schema.test.ts
@@ -29,8 +29,8 @@ const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 // stow_weapon, Dungeon Finder, inv_move, the release's Card Duel minigame
 // (card_queue_join/leave, play_card, card_forfeit), and Professions 2.0
 // Phase 8's place_mobile_station and Phase 9's train_recipe.
-const EXPECTED_SEND_COUNT = 158;
-const EXPECTED_DISPATCH_COUNT = 167;
+const EXPECTED_SEND_COUNT = 159;
+const EXPECTED_DISPATCH_COUNT = 168;
 const EXPECTED_DISPATCH_ONLY_COUNT = 9;
 
 // The chat sub-channel routing switch (server/game.ts `switch

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -2911,6 +2911,7 @@ const ALL_DELTA_KEYS = [
   'duel',
   'equip',
   'gprof',
+  'hbl',
   'honor',
   'inv',
   'lhonor',
@@ -3128,6 +3129,12 @@ function dirtyEveryDeltaField(): {
     mechChromaIds: ['amber_crimson'],
     weaponSkinIds: [],
     weaponSkinLoadout: {},
+  };
+  // Session-scoped stored action-bar layout (`hbl`, self-only): set the frozen
+  // join-time copy so the heavy self block wires it once.
+  leader.initialHotbarLayout = {
+    v: 1,
+    forms: { normal: { bar: [{ type: 'ability', id: 'heroic_strike' }], attack: null } },
   };
 
   // Player Entity fields.
@@ -3399,6 +3406,16 @@ describe('full self-state snapshot delta fixture', () => {
     expect(client.talentSpec).toBe('arms');
     expect(client.loadouts).toEqual([{ name: 'PvP', alloc: { spec: 'arms', rows: {} }, bar: [] }]);
     expect(client.activeLoadout).toBe(0);
+    // hbl -> the login action-bar restore (self-only, resolved once on the first
+    // self payload). A stored server layout arrives as a 'server' win; like tal
+    // it is asserted directly (no TERSE_TO_IWORLD rename entry).
+    expect(client.takeActionBarLayoutRestore()).toEqual({
+      source: 'server',
+      layout: {
+        v: 1,
+        forms: { normal: { bar: [{ type: 'ability', id: 'heroic_strike' }], attack: null } },
+      },
+    });
 
     // vcup + vcupb -> cupInfo (merged from both fragments; neither key alone
     // equals the full CupInfo, so both are excluded from TERSE_TO_IWORLD and
@@ -3504,9 +3521,9 @@ describe('gather node cooldown wire round trip (ncd)', () => {
 });
 
 describe('delta-key contract pins (anti-drift)', () => {
-  it('ALL_DELTA_KEYS contains exactly 50 unique keys in sorted order', () => {
-    expect(ALL_DELTA_KEYS).toHaveLength(50);
-    expect(new Set(ALL_DELTA_KEYS).size).toBe(50);
+  it('ALL_DELTA_KEYS contains exactly 51 unique keys in sorted order', () => {
+    expect(ALL_DELTA_KEYS).toHaveLength(51);
+    expect(new Set(ALL_DELTA_KEYS).size).toBe(51);
     expect([...ALL_DELTA_KEYS]).toEqual([...ALL_DELTA_KEYS].sort());
   });
 
@@ -3525,7 +3542,7 @@ describe('delta-key contract pins (anti-drift)', () => {
     expect(scraped.has('lockouts')).toBe(true); // the multi-line call IS captured
     expect(scraped.has('vcupb')).toBe(true); // the maybeRaw calls ARE captured by the widened regex
     expect(scraped.has('dfb')).toBe(true); // incl. the multi-line maybeRaw('dfb', ...) form
-    expect(scraped.size).toBe(50);
+    expect(scraped.size).toBe(51);
     expect([...scraped].sort()).toEqual([...ALL_DELTA_KEYS].sort());
   });
 

--- a/tests/world_api_parity.test.ts
+++ b/tests/world_api_parity.test.ts
@@ -38,6 +38,7 @@ import { OVERHEAD_EMOTE_IDS, type PlayerClass } from '../src/sim/types';
 // The 27 facet interfaces the W1 split produced (src/world_api/<facet>.ts), plus the
 // bank facet added in the bank-system feature and the Book of Deeds facet. Imported
 // type-only to pin each facet's runtime member array to its interface key-set below.
+import type { IWorldActionBar } from '../src/world_api/action_bar';
 import type { IWorldBank } from '../src/world_api/bank';
 import type { IWorldCardMinigame } from '../src/world_api/card_minigame';
 import type { IWorldChat } from '../src/world_api/chat';
@@ -352,6 +353,9 @@ export const IWORLD_MEMBERS = [
   { name: 'setActiveTitle', kind: 'method' },
   { name: 'deedsRarity', kind: 'method' },
   { name: 'deedsLeaderboard', kind: 'method' },
+  // IWorldActionBar: per-character action-bar layout persistence + login restore.
+  { name: 'saveActionBarLayout', kind: 'method' },
+  { name: 'takeActionBarLayoutRestore', kind: 'method' },
 ] as const satisfies readonly IWorldMember[];
 
 const DATA_MEMBERS = IWORLD_MEMBERS.filter((m) => m.kind === 'data');
@@ -458,9 +462,9 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
     // plus the release's Card Duel facet, the Professions 2.0 identity
     // surface, and Phase 8's mobile-station pair (placeMobileStation +
     // activeMobileStationCraft).
-    expect(IWORLD_MEMBERS.length).toBe(251);
+    expect(IWORLD_MEMBERS.length).toBe(253);
     expect(DATA_MEMBERS.length).toBe(68);
-    expect(METHOD_MEMBERS.length).toBe(183);
+    expect(METHOD_MEMBERS.length).toBe(185);
   });
   it('has no duplicate member names', () => {
     const names = IWORLD_MEMBERS.map((m) => m.name);
@@ -671,6 +675,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'resurrectAtCorpse',
       'resurrectAtSpiritHealer',
       'revivePet',
+      'saveActionBarLayout',
       'saveLoadout',
       'searchCharacters',
       'selectTalentRow',
@@ -693,6 +698,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'switchArchetype',
       'switchLoadout',
       'tabTarget',
+      'takeActionBarLayoutRestore',
       'talentPoints',
       'talentRole',
       'talentSpec',
@@ -941,6 +947,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'resurrectAtCorpse',
       'resurrectAtSpiritHealer',
       'revivePet',
+      'saveActionBarLayout',
       'saveLoadout',
       'searchCharacters',
       'selectTalentRow',
@@ -962,6 +969,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'switchArchetype',
       'switchLoadout',
       'tabTarget',
+      'takeActionBarLayoutRestore',
       'talentPoints',
       'targetEntity',
       'targetNearestFriendly',
@@ -1425,7 +1433,15 @@ const FACET_DEEDS = [
 ] as const satisfies readonly (keyof IWorldDeeds)[];
 type _ExhaustDeeds = AssertNever<Exclude<keyof IWorldDeeds, (typeof FACET_DEEDS)[number]>>;
 
-// The 27-facet partition, keyed by facet for legible failure messages.
+const FACET_ACTION_BAR = [
+  'saveActionBarLayout',
+  'takeActionBarLayoutRestore',
+] as const satisfies readonly (keyof IWorldActionBar)[];
+type _ExhaustActionBar = AssertNever<
+  Exclude<keyof IWorldActionBar, (typeof FACET_ACTION_BAR)[number]>
+>;
+
+// The facet partition, keyed by facet for legible failure messages.
 const FACET_MEMBER_ARRAYS: Readonly<Record<string, readonly string[]>> = {
   entityRoster: FACET_ENTITY_ROSTER,
   combat: FACET_COMBAT,
@@ -1455,11 +1471,12 @@ const FACET_MEMBER_ARRAYS: Readonly<Record<string, readonly string[]>> = {
   valeCup: FACET_VALE_CUP,
   dungeonFinder: FACET_DUNGEON_FINDER,
   deeds: FACET_DEEDS,
+  actionBar: FACET_ACTION_BAR,
 };
 
 describe('W1: aggregate IWorld member set equals the disjoint union of the 28 facets', () => {
   it('pins the facet count at 28', () => {
-    expect(Object.keys(FACET_MEMBER_ARRAYS).length).toBe(28);
+    expect(Object.keys(FACET_MEMBER_ARRAYS).length).toBe(29);
   });
 
   it('each facet array is non-empty and internally duplicate-free', () => {
@@ -1487,8 +1504,8 @@ describe('W1: aggregate IWorld member set equals the disjoint union of the 28 fa
 
   it('the union of the 28 facets equals the pinned 251-member IWORLD_MEMBERS set', () => {
     const union = Object.values(FACET_MEMBER_ARRAYS).flatMap((arr) => [...arr]);
-    expect(union.length, 'union size before dedup (catches a duplicated member)').toBe(251);
-    expect(new Set(union).size, 'union size after dedup (catches a duplicated member)').toBe(251);
+    expect(union.length, 'union size before dedup (catches a duplicated member)').toBe(253);
+    expect(new Set(union).size, 'union size after dedup (catches a duplicated member)').toBe(253);
     const sortedUnion = [...union].sort();
     const pinned = IWORLD_MEMBERS.map((m) => m.name).sort();
     expect(sortedUnion).toEqual(pinned);


### PR DESCRIPTION
## Summary

Action-bar layouts (the base bar, the druid Bear/Cat/Cat-stealth kits, the rogue
Stealth bar, the Vale Cup sport bar, and each form's Attack slot) lived only in
browser `localStorage`. A second browser, a new machine, or the desktop client
therefore seeded default bars. This adds **per-character server persistence of
the full layout, restored at login on any device.**

The layout is client *presentation* state, not deterministic gameplay state, so
it deliberately does **not** enter the sim-owned `CharacterState` (which would
make the offline `Sim` host-aware and change its serialization). Instead it:

- rides its own **additive `characters.hotbar_layout` JSONB column** (no change
  to `CharacterState`, sim serialization stays byte-identical, rollback-safe:
  old binaries ignore the column);
- reaches the owning client as a **self-scoped `hbl` login payload** (like `tal`),
  never a broadcast/entity field, so no other player receives it;
- flows through a new **`IWorldActionBar` facet** (`saveActionBarLayout`,
  `takeActionBarLayoutRestore`) implemented in both worlds: offline `Sim` keeps
  `localStorage` as the one store (no-op save), online `ClientWorld` debounces a
  `save_hotbar_layout` wire command and keeps `localStorage` as a mirror.

**Merge rule at login (locked):**

| Server copy | Local layout | Result |
|---|---|---|
| present | (any) | **server WINS** — overwrite the local mirror, re-seed the controller |
| absent | present | local layout **seeds** the first server copy |
| absent | absent | defaults stand (byte-identical to today) |

**Offline play** is byte-identical: `localStorage` remains the one store; the
`Sim` persistence arm is a no-op and never becomes host-aware.

The debounced save is **flushed when the session ends or the page backgrounds**
(`endSession()` covers logout/close; the `visibilitychange: hidden` branch covers
a raw tab close, which routes through `pagehide`, not logout), so a "rearrange
then close the tab within the debounce window" edit still reaches the server for
a second device.

**Untrusted input** is validated + bounded server-side (slot-count, id-length,
and form-key caps in `sanitizeActionBarLayout`); a malformed/oversized/garbage
payload is dropped without crashing the session, and the stored value is
re-validated on read at join. Saves are **debounced** client-side (1.5s, with a
JSON dedup) and serialized per character via a FIFO save queue server-side.

Out of scope, noted as follow-ups: **keybind profiles** and **window positions**
(same "presentation state that should follow the character" family; deliberately
not bundled to keep this diff scoped).

## Related issues

Part of #2228. That issue names two problems; this PR delivers the **cross-device
persistence** half. The **stale-bars-from-an-older-saved-build** half is already
handled in base (`applyLoadoutBar` preserves slots past a legacy snapshot's
length, pinned by `tests/hotbar.test.ts`), so #2228 should **not** be auto-closed
by this PR alone.

## Type of change

- [x] Feature: new functionality

## How was this tested?

- Commands:
  - `npm run gate` (i18n gen + malware scan + changed-files biome + full Vitest +
    `tsc` + all builds). Green except two **pre-existing, environmental**
    `deploy_watchdog.test.ts` failures (docker-watchdog timing; confirmed
    identical on a clean `main` checkout with none of these changes, and this PR
    touches nothing in that path).
  - Targeted: `npx vitest run tests/action_bar_layout_sync.test.ts
    tests/action_bar_layout_persistence_game.test.ts
    tests/action_bar_controller.test.ts tests/hotbar.test.ts
    tests/loadout_action_bar.test.ts tests/world_api_parity.test.ts
    tests/command_facets.test.ts tests/command_schema.test.ts
    tests/snapshots.test.ts tests/architecture.test.ts
    tests/localization_fixes.test.ts tests/persistence_round_trip.test.ts
    tests/client_shell.test.ts` — all green.
- New/updated tests:
  - `action_bar_layout_sync.test.ts` — payload bounds validation, capture/apply
    round trip, and the merge-rule (`planActionBarRestore`) unit cases
    (server-present wins / server-absent seeds / both-absent defaults).
  - `action_bar_layout_persistence_game.test.ts` — mocked-db `GameServer` wire
    round trip: client save validates + enqueues with the exact payload; join
    with a stored layout delivers `hbl` to the owning client; a second client
    observing the same entity receives nothing (**self-scope**); garbage/oversized
    payloads are rejected without crashing the session.
  - Controller persistence-seam tests (persist fires only on user changes, not on
    load/reload; offline no-`persistLayout` behavior byte-identical).
  - Parity/wire pins updated in `world_api_parity`, `command_schema`,
    `command_facets`, `snapshots`, and `client_shell`.
- Manual steps: **Live two-device verification was not run locally** (no Docker
  DB available here). The mocked-db suite covers every server seam at the wire
  level. The one thing worth a spot-check on a dev realm after merge is the
  merge-rule **first-sync** path (first login after ship seeding the server copy
  from an existing local layout).

## Screenshots / recordings

N/A. This change is state, not pixels; the acceptance is a localStorage-vs-server
round trip, proved by the mocked `GameServer` tests. (See the merge-rule table
above.)

---

## Checklist

### Quality

- [x] The full gate passes (see note above on the two pre-existing environmental
      `deploy_watchdog` failures, unrelated to this change). Decisive tests added
      for the new behavior.

### Cross-platform

- [x] Determinism / three-host parity preserved: the offline `Sim` stays
      host-agnostic (presentation state never enters the sim), `IWorld` parity
      pins updated in the same change.
- ~[ ] Tested on desktop and mobile.~ No visual/layout change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (`tests/localization_fixes.test.ts`
      passes).

### Hygiene

- [x] No secrets/`.env`; `ALLOW_DEV_COMMANDS` untouched.
- [x] No hand-edited generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
