### PR TITLE
feat(rift): B-rank heroic scaling, flat S-23 levels, C-only citadel

### DIFF
--- a/src/sim/deeds.ts
+++ b/src/sim/deeds.ts
@@ -96,17 +96,19 @@ export const GROUND_PICKUP_PROVING_QUESTS: readonly string[] = [
 ];
 
 // The highest level any giantslayer-creditable mob can ever spawn at: S-rank
-// rift floors run mobs up to 25 (rift/ranks.ts RIFT_MAX_MOB_LEVEL), heroic
-// instances pin every mob to 22 (content/dungeon_difficulty.ts), and nothing
-// else exceeds the player cap itself (dummies, the world boss, and owned pets
-// are excluded from the killing-blow credit). cmb_giantslayer needs a blow
-// five levels up, so past this ceiling minus five the deed is permanently out
-// of reach for the character; at 25 the deed is legitimately earnable at the
-// level-20 cap inside an S-rank rift, so capped characters no longer receive
-// the stranded retro-grant. PINNED: shipping a higher-level creditable mob is
-// a conscious re-decision of the stranded threshold (the content-integrity
-// test cross-checks the ceiling against the real tables).
-export const MAX_CREDITABLE_MOB_LEVEL = 25;
+// rift floors now hold a flat level 23 (rift/ranks.ts RIFT_MAX_MOB_LEVEL),
+// heroic instances pin every mob to 22 (content/dungeon_difficulty.ts), and
+// nothing else exceeds the player cap itself (dummies, the world boss, and
+// owned pets are excluded from the killing-blow credit). cmb_giantslayer needs
+// a blow five levels up, so past this ceiling minus five (23 - 5 = 18) the
+// deed is permanently out of reach; a capped player (20) is at level 20 which
+// is above 18, so the deed IS permanently stranded in rifts for capped
+// characters and the retro auto-heal DOES fire. Giantslayer is no longer
+// earnable inside S-rank rifts (maintainer-accepted in v0.23.0 rank retune).
+// PINNED: shipping a higher-level creditable mob is a conscious re-decision of
+// the stranded threshold (the content-integrity test cross-checks the ceiling
+// against the real tables).
+export const MAX_CREDITABLE_MOB_LEVEL = 23;
 
 // Dungeon final bosses whose kill credit bumps deedStats.dungeonClears (keys
 // '<dungeonId>' and '<dungeonId>:heroic') and the dungeonFinalBossKills

--- a/src/sim/rift/ranks.ts
+++ b/src/sim/rift/ranks.ts
@@ -25,24 +25,27 @@ export function riftRankForBaseLevel(baseLevel: number): RiftTier {
   return 'C';
 }
 
-// Mob levels by rank. C/B ramp from their baseLevel and stay inside the classic
-// fairness cap (22, two above the level-20 player cap, matching the heroic
-// dungeon pin). A holds the same 22 cap and gets its bite from the heroic stat
-// transform below. S is the exception by design: its floors start at 23 and
-// ramp to 25, so an S-rank rift is the one place mobs above the heroic pin
-// exist (and the one place the Giantslayer +5-level kill is legitimately
-// earnable at the level cap).
+// Mob levels by rank. C ramps from its baseLevel (20) and stays inside the
+// classic fairness cap (22, two above the level-20 player cap, matching the
+// heroic dungeon pin). B, A, and S all hold the 22 cap; their additional
+// difficulty comes from the heroic stat transform below. S is additionally
+// nudged to flat 23 on every floor, one step above the fairness cap, to
+// signal that S-rank is the hardest tier while keeping its mobs at a level
+// where the heroic stat transform does the heavy lifting. Giantslayer (+5-level
+// kill) is no longer earnable inside S-rank rifts as a result (the maintainer
+// explicitly accepted this in v0.23.0 rank retune).
 export const RIFT_LEVEL_CAP = 22;
-export const RIFT_S_LEVEL_MIN = 23;
-/** The highest level any rift mob can spawn at (the S-rank ceiling). Also the
+export const RIFT_S_LEVEL = 23;
+/** The highest level any rift mob can spawn at (flat S-rank level). Also the
  * game-wide creditable-mob ceiling pinned by deeds (MAX_CREDITABLE_MOB_LEVEL). */
-export const RIFT_MAX_MOB_LEVEL = 25;
+export const RIFT_MAX_MOB_LEVEL = 23;
 
-/** Mob level for a floor: baseLevel + floorIndex under the rank's cap. */
+/** Mob level for a floor: C ramps baseLevel + floorIndex under cap 22;
+ * B and A hold a flat 22; S holds a flat 23 on every floor. */
 export function riftFloorLevel(baseLevel: number, floorIndex: number): number {
   const rounded = Math.round(baseLevel);
   if (riftRankForBaseLevel(rounded) === 'S') {
-    return Math.max(1, Math.min(RIFT_MAX_MOB_LEVEL, RIFT_S_LEVEL_MIN + floorIndex));
+    return RIFT_S_LEVEL;
   }
   return Math.max(1, Math.min(RIFT_LEVEL_CAP, rounded + floorIndex));
 }
@@ -64,16 +67,15 @@ export function riftMechanicSuppressed(mob: Entity, key: string): boolean {
   return index >= 0 && index >= limit;
 }
 
-// A- and S-rank rifts are heroic scaled: a spawn-time stat transform (the same
-// shape as instances/difficulty.ts mobTemplateForDungeonDifficulty) plus the
-// per-entity mechanicDamageMult/mechanicHealMult applied at each mechanic fire
-// site AFTER the rng draw (draw count and order stay identical across ranks).
-// The multipliers stay below the heroic five-man ladder (damage x4-5, which
-// lifts level ~10 dungeons to a level-22 challenge) because rift mobs are
-// already group-tuned at 20+ and A/S stack these on top of the rank's own
-// level lift; the first playtest round still read as too easy, so this is the
-// RAISED second calibration (A roughly doubles trash HP, S swings for double
-// damage on top of the 23-25 level lift).
+// B-, A-, and S-rank rifts are heroic scaled: a spawn-time stat transform (the
+// same shape as instances/difficulty.ts mobTemplateForDungeonDifficulty) plus
+// the per-entity mechanicDamageMult/mechanicHealMult applied at each mechanic
+// fire site AFTER the rng draw (draw count and order stay identical across
+// ranks). The shared gate riftHeroicTuningFor drives four behaviors for all
+// three ranks: the stat transform, boss-add scaling (softer addDamageMultiplier),
+// boulder lethality, and citadel exclusion (now C-only). The multipliers stay
+// below the heroic five-man ladder (damage x4-5); B is the entry rung scaled
+// proportionally between no-tuning and A.
 export interface RiftHeroicTuning {
   healthMultiplier: number;
   damageMultiplier: number;
@@ -84,6 +86,15 @@ export interface RiftHeroicTuning {
 }
 
 export const RIFT_HEROIC_TUNING: Partial<Record<RiftTier, RiftHeroicTuning>> = {
+  // B is the entry heroic tier: scaled proportionally between no-tuning and A.
+  // As with A/S, the shared gate (riftHeroicTuningFor) drives the stat transform,
+  // boss-add scaling, boulder lethality, and citadel exclusion (now C-only).
+  B: {
+    healthMultiplier: 1.5,
+    damageMultiplier: 1.35,
+    addDamageMultiplier: 1.12,
+    armorMultiplier: 1.12,
+  },
   A: {
     healthMultiplier: 1.9,
     damageMultiplier: 1.6,
@@ -98,7 +109,7 @@ export const RIFT_HEROIC_TUNING: Partial<Record<RiftTier, RiftHeroicTuning>> = {
   },
 };
 
-/** The heroic rift tuning for a descriptor baseLevel, or null (C/B). */
+/** The heroic rift tuning for a descriptor baseLevel, or null (C only). */
 export function riftHeroicTuningFor(baseLevel: number): RiftHeroicTuning | null {
   return RIFT_HEROIC_TUNING[riftRankForBaseLevel(baseLevel)] ?? null;
 }
@@ -107,7 +118,7 @@ export function riftHeroicTuningFor(baseLevel: number): RiftHeroicTuning | null 
 // same anti-kite floor heroic dungeons use (instances/difficulty.ts).
 export const RIFT_HEROIC_MIN_MOVE_SPEED = 8;
 
-/** The spawn-time stat transform for an A/S-rank rift mob. Mirrors
+/** The spawn-time stat transform for a B/A/S-rank rift mob. Mirrors
  * mobTemplateForDungeonDifficulty (stats only; levels come from
  * riftFloorLevel, and mechanics still read the base MOBS table at fire time,
  * scaled by the per-entity multipliers the spawner sets alongside this). */

--- a/src/sim/rift/rift_gen.ts
+++ b/src/sim/rift/rift_gen.ts
@@ -78,16 +78,16 @@ export function isSetPieceSeed(seed: number): boolean {
 }
 
 /** Whether this seed+rank opens the citadel. The 2-floor authored set-piece is
- * C/B content only: A and S rank dungeons are guaranteed 3+ floors, so a
- * heroic-rank portal always runs the procedural descent, even on a set-piece
- * seed. Pure over the descriptor, so every host agrees. */
+ * C content only: B, A and S rank dungeons are heroic scaled and guaranteed
+ * 3+ floors, so a heroic-rank portal always runs the procedural descent, even
+ * on a set-piece seed. Pure over the descriptor, so every host agrees. */
 export function isSetPieceRift(seed: number, baseLevel: number): boolean {
   return isSetPieceSeed(seed) && riftHeroicTuningFor(baseLevel) === null;
 }
 
 /** How many floors this rift runs (deterministic from the descriptor). The
  * authored set-piece descends from the citadel halls into the pit; every
- * procedural rift (including any A/S run) is 3 to 6 floors. `baseLevel`
+ * procedural rift (including any B/A/S run) is 3 to 6 floors. `baseLevel`
  * defaults to the C-rank baseline for legacy seed-only callers. */
 export function riftFloorCount(seed: number, baseLevel: number = RIFT_RANK_BASE_LEVEL.C): number {
   if (isSetPieceRift(seed, baseLevel)) return INFERNAL_FLOOR_COUNT;

--- a/src/sim/rift/rift_gen.ts
+++ b/src/sim/rift/rift_gen.ts
@@ -45,9 +45,9 @@ import { applyRiftUpgrade } from './upgrade';
 const MIN_FLOORS = 3;
 const MAX_FLOORS = 6;
 
-// Mob levels are rank-banded in rift/ranks.ts: C/B ramp under the classic
-// fairness cap (22), A holds 22 and gets its bite from the heroic stat
-// transform, and S-rank floors run 23 to 25 by design (re-exported here for
+// Mob levels are rank-banded in rift/ranks.ts: C ramps under the classic
+// fairness cap (22), B/A hold 22 and get their bite from the heroic stat
+// transform, and S-rank floors are a flat 23 by design (re-exported here for
 // the callers that historically read the cap off the generator).
 export { RIFT_LEVEL_CAP, RIFT_MAX_MOB_LEVEL } from './ranks';
 

--- a/src/sim/rift/runs.ts
+++ b/src/sim/rift/runs.ts
@@ -1278,7 +1278,7 @@ function tickRiftHazards(
 }
 
 // Roll one lane's boulder forward a tick and bowl over anyone it overtakes.
-// C/B ranks chip a chunk of max HP; on the heroic A/S ranks a boulder is a
+// C rank chips a chunk of max HP; on the heroic B/A/S ranks a boulder is a
 // ONE-SHOT mechanic (an unblockable killing blow), so the lane must be dodged
 // or jumped, never tanked. Lava deliberately stays damage-over-time at every
 // rank (tickRiftHazards): a burn is a mistake tax, a boulder is an execution.

--- a/src/sim/rift/runs.ts
+++ b/src/sim/rift/runs.ts
@@ -259,7 +259,7 @@ function spawnRiftFloor(ctx: SimContext, inst: RiftInstance): void {
   inst.orbId = null;
   inst.orbActive = false;
 
-  // A- and S-rank rifts are heroic scaled: a spawn-time stat transform plus the
+  // B-, A- and S-rank rifts are heroic scaled: a spawn-time stat transform plus the
   // per-entity mechanic multipliers, mirroring instances/difficulty.ts. The rank
   // derives from the descriptor's baseLevel, so every host regenerates it.
   const rank = riftRankForBaseLevel(inst.baseLevel);

--- a/tests/deeds.test.ts
+++ b/tests/deeds.test.ts
@@ -694,27 +694,32 @@ describe('retro on join', () => {
     expect(sim2.players.get(pid2)!.deedsEarned.has('exp_something_shiny')).toBe(false);
   });
 
-  it('Giantslayer never auto-heals now that S-rank rift mobs reach level 25', () => {
-    // MAX_CREDITABLE_MOB_LEVEL is the S-rank rift ceiling (25): a capped
-    // player (20) can meet a mob exactly five levels up inside an S-rank
-    // rift, so the deed is never permanently stranded and the retro heal must
-    // not fire at ANY reachable level. The live kill site stays the only path.
+  it('Giantslayer auto-heals for capped players now that S-rank is flat 23 (deed stranded)', () => {
+    // MAX_CREDITABLE_MOB_LEVEL was lowered from 25 to 23 when S-rank was
+    // re-tuned to a flat level 23 (no ramp to 25). A capped player (level 20)
+    // can never be hit by a mob five levels up (20+5=25>23), so the deed is
+    // permanently stranded and retroFallbackGrants auto-heals it at join time.
+    // Giantslayer is no longer earnable inside S-rank rifts (maintainer-accepted).
     const sim = makeSim();
     const capped = sim.addPlayer('warrior', 'Capped', {
       state: { ...veteranState(), level: 20 },
     });
-    expect(sim.players.get(capped)!.deedsEarned.has('cmb_giantslayer')).toBe(false);
+    // Auto-heal fires at join for the capped player (level 20+5=25 > 23).
+    expect(sim.players.get(capped)!.deedsEarned.has('cmb_giantslayer')).toBe(true);
+    // A level-17 player (17+5=22 <= 23) is still below the threshold: not yet stranded.
+    const notStranded = sim.addPlayer('warrior', 'NotStranded', {
+      state: { ...veteranState(), level: 17 },
+    });
+    expect(sim.players.get(notStranded)!.deedsEarned.has('cmb_giantslayer')).toBe(false);
+    // A level-18 player (18+5=23, not strictly greater) is also not stranded yet.
     const edge = sim.addPlayer('warrior', 'Edge', { state: { ...veteranState(), level: 18 } });
     expect(sim.players.get(edge)!.deedsEarned.has('cmb_giantslayer')).toBe(false);
-    const evs = deedEvents(sim.tick());
-    expect(evs.some((e) => e.deedId === 'cmb_giantslayer')).toBe(false);
-    // The live site: a killing blow on a mob five levels up (the S-rank rift
-    // ceiling against a capped player) grants it on the spot.
-    const cappedEntity = sim.entities.get(capped)!;
+    // The live kill site still grants on a killing blow five levels up (for sub-cap players).
+    const edgeEntity = sim.entities.get(edge)!;
     const wolf = [...sim.entities.values()].find((e) => e.kind === 'mob' && !e.dead)!;
-    wolf.level = cappedEntity.level + 5;
+    wolf.level = edgeEntity.level + 5;
     (sim as unknown as { dealDamage: Function }).dealDamage(
-      cappedEntity,
+      edgeEntity,
       wolf,
       wolf.hp + 10,
       false,
@@ -723,7 +728,7 @@ describe('retro on join', () => {
       'hit',
       true,
     );
-    expect(sim.players.get(capped)!.deedsEarned.has('cmb_giantslayer')).toBe(true);
+    expect(sim.players.get(edge)!.deedsEarned.has('cmb_giantslayer')).toBe(true);
   });
 
   it('the heals unlock feat_book_complete in the same join for an otherwise complete book', () => {

--- a/tests/deeds_content.test.ts
+++ b/tests/deeds_content.test.ts
@@ -240,8 +240,8 @@ describe('retro fallback proof sets stay anchored to the real tables', () => {
   it('the creditable mob-level ceiling is the S-rank rift pin', () => {
     // Giantslayer's stranded heal keys on the highest level a creditable mob
     // can ever spawn at. S-rank rift floors run mobs up to RIFT_MAX_MOB_LEVEL
-    // (the game-wide ceiling; at 25 the +5-level kill is legitimately earnable
-    // at the level-20 cap, so the stranded retro-grant no longer fires there);
+    // (the game-wide ceiling; at 23 the +5-level kill is out of reach at the
+    // level-20 cap, so capped players take the stranded retro-grant instead);
     // heroic instances pin every mob to one shared level below it; outside
     // those no spawnable template exceeds the player cap. The only templates
     // authored above the ceiling can never be credited: warlock and mage pets

--- a/tests/rift_infernal.test.ts
+++ b/tests/rift_infernal.test.ts
@@ -76,19 +76,18 @@ describe('infernal citadel: seed selection', () => {
     expect(pct).toBeLessThan(0.22);
   });
 
-  it('is C/B content: both low ranks build the same citadel; A/S run procedural', () => {
-    // The 2-floor set-piece may not headline a heroic rank: A and S dungeons
-    // are guaranteed 3+ floors, so their runs take the procedural generator
-    // even on a citadel seed (rift_gen.ts isSetPieceRift).
+  it('is C-only content: C builds the citadel; B/A/S run procedural', () => {
+    // The 2-floor set-piece gates on riftHeroicTuningFor(baseLevel) === null.
+    // B now carries the heroic transform, so B/A/S all bypass the citadel and
+    // run the procedural descent even on a set-piece seed.
     const seed = setPieceSeeds(1)[0];
-    const low = (['C', 'B'] as const).map((tier) =>
-      JSON.stringify(generateRiftFloor(seed, RIFT_TIER_INFO[tier].baseLevel, 0).layout),
-    );
-    expect(new Set(low).size).toBe(1);
-    // Only the mob level scales between the citadel ranks.
-    const cLvl = generateRiftFloor(seed, RIFT_TIER_INFO.C.baseLevel, 0).spawns[0].level;
-    const bLvl = generateRiftFloor(seed, RIFT_TIER_INFO.B.baseLevel, 0).spawns[0].level;
-    expect(bLvl).toBeGreaterThan(cLvl);
+    // C: gets the authored citadel.
+    const cFloor = generateRiftFloor(seed, RIFT_TIER_INFO.C.baseLevel, 0);
+    expect(cFloor.authored, 'C opens the citadel').toBeDefined();
+    // B on a citadel seed runs procedural 3+ (B has heroic tuning now).
+    const bFloor = generateRiftFloor(seed, RIFT_TIER_INFO.B.baseLevel, 0);
+    expect(bFloor.authored, 'B never opens the 2-floor set-piece').toBeUndefined();
+    expect(bFloor.floorCount).toBeGreaterThanOrEqual(3);
     for (const tier of ['A', 'S'] as const) {
       const floor = generateRiftFloor(seed, RIFT_TIER_INFO[tier].baseLevel, 0);
       expect(floor.authored, `${tier} never opens the 2-floor set-piece`).toBeUndefined();
@@ -97,8 +96,9 @@ describe('infernal citadel: seed selection', () => {
   });
 
   it('names the rift a Citadel and descends two floors (halls, then the pit)', () => {
+    // The citadel is C-only content: use the C-rank base level (20).
     for (const seed of setPieceSeeds(5)) {
-      const plan = generateRiftPlan(seed, 22);
+      const plan = generateRiftPlan(seed, 20);
       expect(plan.floorCount).toBe(INFERNAL_FLOOR_COUNT);
       expect(plan.floorCount).toBe(2);
       expect(plan.themeId).toBe('infernal');
@@ -162,7 +162,8 @@ describe('infernal citadel: determinism', () => {
     const before = sim.rng.next();
     const sim2 = new Sim({ seed: 7, playerClass: 'warrior' });
     buildInfernalCitadelFloor(setPieceSeeds(1)[0], 22, 22);
-    generateRiftFloor(setPieceSeeds(1)[0], 22, 0);
+    // Use C-rank (20) so the set-piece gate opens the citadel (B now has heroic tuning).
+    generateRiftFloor(setPieceSeeds(1)[0], 20, 0);
     const after = sim2.rng.next();
     expect(after).toBe(before);
   });
@@ -532,8 +533,9 @@ describe('infernal citadel: lifecycle', () => {
     seed = setPieceSeeds(1)[0];
     sim = new Sim({ seed: 99, playerClass: 'warrior', autoEquip: true, devCommands: true });
     pid = sim.player.id;
-    sim.player.level = 22;
-    sim.enterRift(seed, 22, pid);
+    // Use C-rank (baseLevel 20): the citadel is C-only content since B now has
+    // the heroic stat transform and is excluded from the set-piece by the shared gate.
+    sim.enterRift(seed, 20, pid);
   });
 
   /** Clear the halls (trash + Magus), touch the armed orb, then ride the descent
@@ -547,7 +549,7 @@ describe('infernal citadel: lifecycle', () => {
     tickSeconds(1.1); // the 1 Hz driver arms the orb and tears the descent open
     expect(i.orbActive).toBe(true);
     expect(i.descentOpen).toBe(true);
-    const floor0 = generateRiftFloor(seed, 22, 0);
+    const floor0 = generateRiftFloor(seed, 20, 0);
     const orb = floor0.objects.find((o) => o.kind === 'infernal_orb') as { x: number; z: number };
     teleport(orb.x, orb.z - 2.2);
     sim.tick();
@@ -574,7 +576,7 @@ describe('infernal citadel: lifecycle', () => {
   });
 
   it('keeps the closed gate impassable (a runtime clamp, never a collider)', () => {
-    const floor = generateRiftFloor(seed, 22, 0);
+    const floor = generateRiftFloor(seed, 20, 0);
     const gate = floor.gate as NonNullable<typeof floor.gate>;
     teleport(0, gate.z + 6); // try to stand INSIDE the temple
     sim.tick();
@@ -601,7 +603,7 @@ describe('infernal citadel: lifecycle', () => {
   });
 
   it('refuses the dormant orb, then opens the gate once the miniboss falls', () => {
-    const floor = generateRiftFloor(seed, 22, 0);
+    const floor = generateRiftFloor(seed, 20, 0);
     const orb = floor.objects.find((o) => o.kind === 'infernal_orb') as { x: number; z: number };
     const i = inst() as NonNullable<ReturnType<typeof inst>>;
     killTrash();
@@ -702,7 +704,8 @@ describe('infernal citadel: lifecycle', () => {
     const s2 = new Sim({ seed: 99, playerClass: 'warrior', autoEquip: true, devCommands: true });
     const p2 = s2.player.id;
     s2.player.level = 22;
-    s2.chat('/dev portal 5 22 A infernal', p2);
+    // Use baseLevel 20 (C-rank): the citadel is C-only since B now has heroic tuning.
+    s2.chat('/dev portal 5 20 A infernal', p2);
     const portal = [...s2.entities.values()]
       .filter((e) => e.templateId === 'rift_portal')
       .at(-1) as Entity;
@@ -760,7 +763,7 @@ describe('infernal citadel: lifecycle', () => {
 
   it('kills nothing on entry: every mob spawns clear of the walls it fights in', () => {
     const i = inst() as NonNullable<ReturnType<typeof inst>>;
-    const floor = generateRiftFloor(seed, 22, 0);
+    const floor = generateRiftFloor(seed, 20, 0);
     const colliders = layoutColliders(floor.layout);
     const o = riftInstanceOrigin(i.slot, i.floorIndex);
     expect(i.mobIds.length).toBe(floor.spawns.length);

--- a/tests/rift_mechanics.test.ts
+++ b/tests/rift_mechanics.test.ts
@@ -271,7 +271,8 @@ describe('rift mechanics: switch-gate', () => {
 });
 
 describe('rift generator: rank level bands', () => {
-  it('C/B/A floors cap mob level at 22; S-rank floors run 23 to 25', () => {
+  it('C/B/A floors cap mob level at 22; S-rank floors are flat 23', () => {
+    // S-rank is no longer a 23-25 ramp; it is a flat 23 on every floor.
     let maxNonS = 0;
     let maxS = 0;
     let minS = Infinity;
@@ -293,8 +294,9 @@ describe('rift generator: rank level bands', () => {
     }
     expect(maxNonS, 'C/B/A floors still cap mob level at 22').toBeLessThanOrEqual(22);
     expect(maxNonS, 'sanity: the 22 cap is actually reached').toBeGreaterThanOrEqual(22);
-    expect(minS, 'every S-rank mob is level 23 or higher').toBeGreaterThanOrEqual(23);
-    expect(maxS, 'S-rank depth ramps to the 25 ceiling').toBe(25);
+    expect(minS, 'every S-rank mob is level 23').toBeGreaterThanOrEqual(23);
+    // S-rank is flat 23 (no ramp to 25).
+    expect(maxS, 'S-rank is flat 23, no ramp to 25').toBe(23);
   });
 });
 

--- a/tests/rift_rank_tuning.test.ts
+++ b/tests/rift_rank_tuning.test.ts
@@ -294,6 +294,61 @@ describe('rift ranks: rank-gated summons + the boss-add level pin', () => {
       expect(add.weapon.min, 'add swings at the add multiplier').toBe(Math.round(swing * 0.8));
     }
   });
+
+  it('the heroic tuning table carries the approved literals', () => {
+    // The transform tests above assert WIRING against this table (field on the
+    // mob === field in the table), so the numbers themselves must be pinned
+    // here as literals or a silent retune of any multiplier passes every test.
+    expect(RIFT_HEROIC_TUNING).toEqual({
+      B: {
+        healthMultiplier: 1.5,
+        damageMultiplier: 1.35,
+        addDamageMultiplier: 1.12,
+        armorMultiplier: 1.12,
+      },
+      A: {
+        healthMultiplier: 1.9,
+        damageMultiplier: 1.6,
+        addDamageMultiplier: 1.25,
+        armorMultiplier: 1.25,
+      },
+      S: {
+        healthMultiplier: 2.5,
+        damageMultiplier: 2,
+        addDamageMultiplier: 1.5,
+        armorMultiplier: 1.4,
+      },
+    });
+  });
+
+  it('B-rank boss adds take the softer 1.12 multiplier (venom summons in budget)', () => {
+    const seed = seedWithFinalBoss('rift_boss_venom');
+    const b = enterAtBossFloor(seed, 22);
+    const bBoss = b.entities.get(active(b).bossId!)!;
+    b.player.gm = true; // survive the heroic boss so the summoned wave persists
+    b.player.pos = { ...bBoss.pos, z: bBoss.pos.z - 4 };
+    b.player.prevPos = { ...b.player.pos };
+    (b as unknown as { dealDamage: Function }).dealDamage(
+      b.player,
+      bBoss,
+      Math.round(bBoss.maxHp * 0.5),
+      false,
+      'physical',
+      'test',
+      'hit',
+      true,
+    );
+    tickAlive(b, 3);
+    expect(bBoss.summonedIds.length, 'B summons (venom slot 1 fits budget 2)').toBeGreaterThan(0);
+    for (const addId of bBoss.summonedIds) {
+      const add = b.entities.get(addId)!;
+      expect(add.level, 'adds match the boss level').toBe(bBoss.level);
+      expect(add.mechanicDamageMult, 'softer add multiplier, literal').toBe(1.12);
+      const t = MOBS[add.templateId];
+      const swing = t.dmgBase * 1.12 + t.dmgPerLevel * 1.12 * (add.level - 1);
+      expect(add.weapon.min, 'add swings at the softer multiplier').toBe(Math.round(swing * 0.8));
+    }
+  });
 });
 
 describe('rift ranks: A/S one-shot rolling boulder', () => {

--- a/tests/rift_rank_tuning.test.ts
+++ b/tests/rift_rank_tuning.test.ts
@@ -109,11 +109,12 @@ describe('rift ranks: derivation and level bands', () => {
     expect(RIFT_RANK_MECHANIC_BUDGET).toEqual({ C: 1, B: 2, A: 3, S: 4 });
   });
 
-  it('C ramps 20..22, B/A hold 22, S runs 23..25', () => {
+  it('C ramps 20..22, B/A hold 22, S is flat 23', () => {
     expect([0, 1, 2, 3, 5].map((i) => riftFloorLevel(20, i))).toEqual([20, 21, 22, 22, 22]);
     expect([0, 3, 5].map((i) => riftFloorLevel(22, i))).toEqual([22, 22, 22]);
     expect([0, 3, 5].map((i) => riftFloorLevel(25, i))).toEqual([22, 22, 22]);
-    expect([0, 1, 2, 3, 5].map((i) => riftFloorLevel(28, i))).toEqual([23, 24, 25, 25, 25]);
+    // S-rank mobs are flat 23 on every floor (no ramp to 25).
+    expect([0, 1, 2, 3, 5].map((i) => riftFloorLevel(28, i))).toEqual([23, 23, 23, 23, 23]);
   });
 });
 
@@ -167,16 +168,37 @@ describe('rift ranks: boss mechanic kits (content integrity)', () => {
   });
 });
 
-describe('rift ranks: A/S heroic spawn scaling', () => {
-  it('A/S trash takes the heroic stat transform + mechanic multipliers; C/B does not', () => {
-    for (const baseLevel of [20, 22]) {
+describe('rift ranks: A/S/B heroic spawn scaling', () => {
+  it('B/A/S trash takes the heroic stat transform + mechanic multipliers; C does not', () => {
+    // C is the only rank without the heroic transform.
+    for (const baseLevel of [20]) {
       const sim = makeSim();
       sim.enterRift(SEED, baseLevel, sim.player.id);
       const inst = active(sim);
       for (const id of inst.mobIds) {
         const m = sim.entities.get(id)!;
-        expect(m.mechanicDamageMult, `C/B mob ${m.templateId}`).toBeUndefined();
+        expect(m.mechanicDamageMult, `C mob ${m.templateId}`).toBeUndefined();
         expect(m.riftMechanicLimit, 'trash carries no mechanic budget').toBeUndefined();
+      }
+    }
+    // B-rank mobs DO carry the 1.5/1.35 heroic transform (new in B-rank tuning).
+    {
+      const sim = makeSim();
+      sim.enterRift(SEED, 22, sim.player.id);
+      const inst = active(sim);
+      const tuning = RIFT_HEROIC_TUNING.B!;
+      expect(inst.mobIds.length).toBeGreaterThan(0);
+      for (const id of inst.mobIds) {
+        const m = sim.entities.get(id)!;
+        const t = MOBS[m.templateId];
+        expect(m.mechanicDamageMult, `B mob ${m.templateId}`).toBe(tuning.damageMultiplier);
+        expect(m.mechanicHealMult).toBe(tuning.healthMultiplier);
+        expect(m.moveSpeed, 'anti-kite move-speed floor').toBeGreaterThanOrEqual(
+          RIFT_HEROIC_MIN_MOVE_SPEED,
+        );
+        const hm = tuning.healthMultiplier;
+        const expected = Math.round((t.hpBase * hm + t.hpPerLevel * hm * (m.level - 1)) * 2.3);
+        expect(m.maxHp, `B ${m.templateId} hp`).toBe(expected);
       }
     }
     for (const baseLevel of [25, 28]) {
@@ -212,7 +234,8 @@ describe('rift ranks: A/S heroic spawn scaling', () => {
     const s = enterAtBossFloor(seed, 28);
     const sBoss = s.entities.get(active(s).bossId!)!;
     expect(sBoss.riftMechanicLimit).toBe(4);
-    expect(sBoss.level, 'S boss reaches the 25 ceiling').toBe(25);
+    // S-rank is flat 23 on every floor (no ramp to 25).
+    expect(sBoss.level, 'S boss is flat 23').toBe(23);
   });
 });
 
@@ -296,7 +319,7 @@ describe('rift ranks: A/S one-shot rolling boulder', () => {
     sim.player.prevPos = { ...sim.player.pos };
   }
 
-  it('C chips a fraction of max hp; A executes outright (lava stays a burn)', () => {
+  it('C chips a fraction of max hp; B/A/S execute outright (lava stays a burn)', () => {
     const seed = rollerSeed();
 
     const c = makeSim(seed);
@@ -309,6 +332,17 @@ describe('rift ranks: A/S one-shot rolling boulder', () => {
     }
     expect(c.player.dead, 'a C-rank boulder is survivable').toBe(false);
     expect(c.player.hp, 'but it hurts').toBeLessThan(c.player.maxHp);
+
+    // B-rank boulders are lethal (B now has heroic tuning).
+    const b = makeSim(seed);
+    b.enterRift(seed, 22, b.player.id);
+    parkInLane(b);
+    b.player.hp = b.player.maxHp;
+    for (let i = 0; i < 20 * 30 && !b.player.dead; i++) {
+      parkInLane(b);
+      b.tick();
+    }
+    expect(b.player.dead, 'a B-rank boulder is a one-shot kill').toBe(true);
 
     const a = makeSim(seed);
     a.enterRift(seed, 25, a.player.id);
@@ -474,16 +508,22 @@ describe('rift ranks: rune-reset notice rate limit', () => {
   });
 });
 
-describe('rift ranks: A/S rifts are never shorter than 3 floors', () => {
-  it('a set-piece seed opens the 2-floor citadel at C/B but runs procedural 3+ at A/S', () => {
+describe('rift ranks: B/A/S rifts are never shorter than 3 floors', () => {
+  it('a set-piece seed opens the 2-floor citadel at C only; B/A/S run procedural 3+', () => {
+    // B now has the heroic transform, so isSetPieceRift gates on tuning !== null.
+    // The citadel is C-only content; B/A/S all run the procedural descent.
     let seed = -1;
     for (let s = 1; s < 400 && seed < 0; s++) if (isSetPieceSeed(s)) seed = s;
     expect(seed).toBeGreaterThan(0);
-    // C/B: the citadel (2 authored floors).
+    // C: the citadel (2 authored floors).
     expect(riftFloorCount(seed)).toBe(2);
     expect(riftFloorCount(seed, 20)).toBe(2);
-    expect(riftFloorCount(seed, 22)).toBe(2);
     expect(generateRiftFloor(seed, 20, 0).authored).toBe(true);
+    // B on a citadel seed now runs procedural 3+ (B has heroic tuning).
+    expect(riftFloorCount(seed, 22), 'B runs procedural').toBeGreaterThanOrEqual(3);
+    const bFloor = generateRiftFloor(seed, 22, 0);
+    expect(bFloor.authored, 'B never opens the 2-floor set-piece').toBeUndefined();
+    expect(bFloor.floorCount).toBeGreaterThanOrEqual(3);
     // A/S: guaranteed 3+ procedural floors, never the 2-floor set-piece.
     for (const baseLevel of [25, 28]) {
       expect(riftFloorCount(seed, baseLevel), `base ${baseLevel}`).toBeGreaterThanOrEqual(3);
@@ -500,11 +540,12 @@ describe('rift ranks: A/S rifts are never shorter than 3 floors', () => {
     }
   });
 
-  it('an S-rank citadel-seed run fields S-band mobs on its procedural floors', () => {
+  it('an S-rank citadel-seed run fields S-band mobs (flat 23) on its procedural floors', () => {
     let seed = -1;
     for (let s = 1; s < 400 && seed < 0; s++) if (isSetPieceSeed(s)) seed = s;
     const floor = generateRiftFloor(seed, 28, 0);
-    for (const sp of floor.spawns) expect(sp.level).toBeGreaterThanOrEqual(23);
+    // S-rank is flat 23 on every floor.
+    for (const sp of floor.spawns) expect(sp.level).toBe(23);
   });
 });
 


### PR DESCRIPTION
Part of the playtest feedback round on PR #1584 (rifts). Maintainer-approved decisions baked in.

## What

- B joins the heroic set: RIFT_HEROIC_TUNING gains a B entry (1.5x health / 1.35x damage / 1.12x softer add multiplier / 1.12x armor), below A (1.9/1.6) and S (2.5/2.0). Via the one shared gate (riftHeroicTuningFor) this also makes B boulders one-shot lethal and drops the 2-floor Infernal Citadel to C-only content (B/A/S heroic ranks always run the 3+ floor procedural descent).
- S-rank mob level is a flat 23 on every floor (was 23 to 25). The maintainer accepts the trade-off: the Giantslayer +5-level earn path inside S rifts goes away, and the deeds creditable ceiling mirror (MAX_CREDITABLE_MOB_LEVEL) follows to 23, so capped players take the stranded retro-grant again.
- Stale comments describing the pre-retune model refreshed.

## Tests

- All flipped pins preserved or tightened their predecessors (same seed sweeps, same floor indices).
- New: literal pin of the whole heroic tuning table (the transform tests assert wiring against the table, so the numbers themselves are now protected against silent retunes); B-rank boss-add test (venom boss summons within B budget, adds at boss level, 1.12 literal); B boulder lethality arm; B procedural-descent arm.
- 247 tests across the touched suites green, tsc clean, parity goldens untouched, rift floor digest unchanged (level is not part of the serialized floor shape).

## Notes for review

- The rift mob template bands (18..25) are deliberately NOT lowered: they are pricing metadata for item_level.buildSourceIndex, and the deeds ceiling test exempts rift mobs via dynamicallyLevelCapped. Spawn levels are generator-driven.