### PR TITLE
feat(rift): mount drops, loot-tier alignment, and item-level registration

### DIFF
--- a/src/sim/content/dungeons.ts
+++ b/src/sim/content/dungeons.ts
@@ -120,8 +120,6 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
       { itemId: 'gravewoven_bag', chance: 0.2, rollGroup: 'morthen_bonus' },
       { itemId: 'cryptbone_helm', chance: 0.18, rollGroup: 'morthen_bonus' },
       { itemId: 'cryptbone_pauldrons', chance: 0.18, rollGroup: 'morthen_bonus' },
-      // Collectible mount: a rare (sub-1%) independent draw, never in a roll group.
-      { itemId: 'reins_grag_bear', chance: 0.009 },
     ],
     scale: 1.35,
     color: 0x4a235a,
@@ -254,8 +252,6 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
       { itemId: 'mistveil_cord', chance: 0.12, rollGroup: 'vael_bonus' },
       { itemId: 'mistveil_grips', chance: 0.12, rollGroup: 'vael_bonus' },
       { itemId: 'mistcallers_duffel', chance: 0.1, rollGroup: 'vael_bonus' },
-      // Collectible mount: a rare (sub-1%) independent draw, never in a roll group.
-      { itemId: 'reins_stalkglider_snail', chance: 0.009 },
     ],
     scale: 1.35,
     color: 0x48c9b0,
@@ -432,8 +428,6 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
       { itemId: 'deathlords_dread_visage', chance: 0.04, rollGroup: 'korzul_bonus' },
       { itemId: 'necromancers_soulspire_mantle', chance: 0.04, rollGroup: 'korzul_bonus' },
       { itemId: 'wyrmshadow_talongrips', chance: 0.04, rollGroup: 'korzul_bonus' },
-      // Collectible mount: a rare (sub-1%) independent draw, never in a roll group.
-      { itemId: 'reins_shadowjump_toad', chance: 0.005 },
     ],
     scale: 1.8,
     color: 0x3d5c45,
@@ -606,9 +600,6 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
       { itemId: 'stormcallers_spaulders', chance: 0.14, rollGroup: 'nythraxis_drop_4' },
       { itemId: 'crownforged_dreadhelm', chance: 0.14, rollGroup: 'nythraxis_drop_4' },
       { itemId: 'nighttalon_crown', chance: 0.14, rollGroup: 'nythraxis_drop_4' },
-      // Collectible mount (the raid pinnacle drop): a rare (sub-1%) independent
-      // draw, never inside a roll group.
-      { itemId: 'reins_stormfeather_griffin', chance: 0.002 },
     ],
     scale: 3.1,
     color: 0x221b2d,

--- a/src/sim/content/heroic_loot.ts
+++ b/src/sim/content/heroic_loot.ts
@@ -480,6 +480,16 @@ export const RETIRED_HEROIC_ITEMS: Record<string, ItemDef> = {
 // Heroic-only drop tables per final boss, TWO rollGroups each (chances inside a
 // group sum to 1.0, so exactly one item drops per group => two heroic epics per
 // heroic kill). loot_roll.ts rolls these only for a heroic-claimed instance.
+// Heroic mount drop rates per rarity tier. These are APPENDED after all gear
+// roll-group draws so the gear draw-order stays byte-identical to non-mount runs.
+// Green (common) mounts: 0.5% per heroic clear on their single boss.
+const HEROIC_GREEN_MOUNT_CHANCE = 0.005;
+// Blue (rare) mounts: 0.6% per heroic clear on their single boss; 0.1% on the
+// Nythraxis heroic raid (the raid adds both blues so every heroic-raider has a
+// path to each, spread across the same boss since the raid has one final boss).
+const HEROIC_BLUE_MOUNT_CHANCE = 0.006;
+const HEROIC_RAID_BLUE_MOUNT_CHANCE = 0.001;
+
 export const HEROIC_BOSS_LOOT: Record<string, LootEntry[]> = {
   morthen: [
     { itemId: 'morthens_cryptforged_hauberk', chance: 0.34, rollGroup: 'morthen_heroic' },
@@ -488,6 +498,8 @@ export const HEROIC_BOSS_LOOT: Record<string, LootEntry[]> = {
     { itemId: 'cryptplate_helm', chance: 0.34, rollGroup: 'morthen_heroic2' },
     { itemId: 'shadowpulse_slippers', chance: 0.33, rollGroup: 'morthen_heroic2' },
     { itemId: 'bonechill_cord', chance: 0.33, rollGroup: 'morthen_heroic2' },
+    // Green mount: heroic-gated only; the normal table entry was retired.
+    { itemId: 'reins_grag_bear', chance: HEROIC_GREEN_MOUNT_CHANCE },
   ],
   vael_the_mistcaller: [
     { itemId: 'mistcallers_fang', chance: 0.34, rollGroup: 'vael_heroic' },
@@ -496,6 +508,8 @@ export const HEROIC_BOSS_LOOT: Record<string, LootEntry[]> = {
     { itemId: 'mistforged_pauldrons', chance: 0.34, rollGroup: 'vael_heroic2' },
     { itemId: 'tideguard_faceguard', chance: 0.33, rollGroup: 'vael_heroic2' },
     { itemId: 'sunken_court_mantle', chance: 0.33, rollGroup: 'vael_heroic2' },
+    // Green mount: heroic-gated only; the normal table entry was retired.
+    { itemId: 'reins_stalkglider_snail', chance: HEROIC_GREEN_MOUNT_CHANCE },
   ],
   ysolei: [
     { itemId: 'lunar_tide_greatstaff', chance: 0.34, rollGroup: 'ysolei_heroic' },
@@ -504,6 +518,8 @@ export const HEROIC_BOSS_LOOT: Record<string, LootEntry[]> = {
     { itemId: 'lunar_choir_leggings', chance: 0.34, rollGroup: 'ysolei_heroic2' },
     { itemId: 'choir_blessed_spaulders', chance: 0.33, rollGroup: 'ysolei_heroic2' },
     { itemId: 'tideworn_warboots', chance: 0.33, rollGroup: 'ysolei_heroic2' },
+    // Blue mount: heroic-gated only; the normal table entry was retired.
+    { itemId: 'reins_aether_hover_cycle', chance: HEROIC_BLUE_MOUNT_CHANCE },
   ],
   korzul_the_gravewyrm: [
     { itemId: 'gravewyrm_cleaver', chance: 0.34, rollGroup: 'korzul_heroic' },
@@ -512,6 +528,8 @@ export const HEROIC_BOSS_LOOT: Record<string, LootEntry[]> = {
     { itemId: 'gravewyrm_claws', chance: 0.34, rollGroup: 'korzul_heroic2' },
     { itemId: 'gravescale_girdle', chance: 0.33, rollGroup: 'korzul_heroic2' },
     { itemId: 'wyrmchoir_handwraps', chance: 0.33, rollGroup: 'korzul_heroic2' },
+    // Blue mount: heroic-gated only; the normal table entry was retired.
+    { itemId: 'reins_shadowjump_toad', chance: HEROIC_BLUE_MOUNT_CHANCE },
   ],
   nythraxis_scourge_of_thornpeak: [
     // The heroic set pieces and legendaries come free from the heroic loot swap:
@@ -519,7 +537,8 @@ export const HEROIC_BOSS_LOOT: Record<string, LootEntry[]> = {
     // raid-tier (item level 33/37) heroic variants in a heroic claim
     // (loot/loot_roll.ts + heroic_variants.ts). This table adds only the
     // heroic-ONLY extras the normal table never carries: the three bespoke raid
-    // weapons, one of which drops per heroic kill (chances sum to 1.0).
+    // weapons, one of which drops per heroic kill (chances sum to 1.0), plus the
+    // blue mount secondary paths (lower rate than the five-mans, raid bonus path).
     { itemId: 'deathless_greatblade', chance: 0.34, rollGroup: 'nythraxis_heroic_weapon' },
     {
       itemId: 'scepter_of_the_deathless_court',
@@ -527,5 +546,9 @@ export const HEROIC_BOSS_LOOT: Record<string, LootEntry[]> = {
       rollGroup: 'nythraxis_heroic_weapon',
     },
     { itemId: 'stormcallers_focus', chance: 0.33, rollGroup: 'nythraxis_heroic_weapon' },
+    // Blue mount secondary paths on the heroic raid (0.1% each); the primary
+    // path for each is its five-man heroic boss. Epic mounts are rift S-only.
+    { itemId: 'reins_aether_hover_cycle', chance: HEROIC_RAID_BLUE_MOUNT_CHANCE },
+    { itemId: 'reins_shadowjump_toad', chance: HEROIC_RAID_BLUE_MOUNT_CHANCE },
   ],
 };

--- a/src/sim/content/heroic_loot.ts
+++ b/src/sim/content/heroic_loot.ts
@@ -484,10 +484,11 @@ export const RETIRED_HEROIC_ITEMS: Record<string, ItemDef> = {
 // roll-group draws so the gear draw-order stays byte-identical to non-mount runs.
 // Green (common) mounts: 0.5% per heroic clear on their single boss.
 const HEROIC_GREEN_MOUNT_CHANCE = 0.005;
-// Blue (rare) mounts: 0.6% per heroic clear on their single boss; 0.1% on the
-// Nythraxis heroic raid (the raid adds both blues so every heroic-raider has a
-// path to each, spread across the same boss since the raid has one final boss).
-const HEROIC_BLUE_MOUNT_CHANCE = 0.006;
+// Blue (rare) mounts: 0.1% per heroic clear everywhere (their paired five-man
+// boss and the Nythraxis heroic raid, which adds both blues so every
+// heroic-raider has a path to each). The generous 0.6% blue roll lives on A/S
+// rift clears only (rift/progression.ts), the maintainer-decided split.
+const HEROIC_BLUE_MOUNT_CHANCE = 0.001;
 const HEROIC_RAID_BLUE_MOUNT_CHANCE = 0.001;
 
 export const HEROIC_BOSS_LOOT: Record<string, LootEntry[]> = {

--- a/src/sim/content/rift/items.ts
+++ b/src/sim/content/rift/items.ts
@@ -47,6 +47,11 @@ const AGILE = ['rogue', 'hunter'] as ItemDef['requiredClass'];
 const AGILE_WILD = ['rogue', 'hunter', 'druid'] as ItemDef['requiredClass'];
 const CASTER = ['mage', 'priest', 'warlock', 'druid'] as ItemDef['requiredClass'];
 
+// Combat-rating allowance for the ilvl-31 clear-time epics: one rating per piece,
+// matching the ilvl-31 heroic five-man tier (ARMOR_RATING = 40 in heroic_loot.ts).
+// Off the primary-stat budget like spellPower, so stat sums stay budget-enforced.
+const RIFT_ARMOR_RATING = 40; // 40 rating = 4.0%, mirrors the heroic ilvl-31 floor
+
 /** Static shells. The non-fungible payload carries each drop's source, power,
  * upgrades, enchantment, sockets, gems, and rolled bonus stats. */
 export const RIFT_ITEMS: Record<string, ItemDef> = {
@@ -130,7 +135,8 @@ export const RIFT_ITEMS: Record<string, ItemDef> = {
     quality: 'rare',
     requiredLevel: 20,
     weapon: { min: 27, max: 40, speed: 2.4 },
-    stats: { str: 8, sta: 5 },
+    // ilvl-28 mainhand rare budget = 16; str:11+sta:5 = 16
+    stats: { str: 11, sta: 5 },
     sellValue: 7500,
     requiredClass: HEAVY,
   },
@@ -154,7 +160,8 @@ export const RIFT_ITEMS: Record<string, ItemDef> = {
     slot: 'chest',
     quality: 'rare',
     requiredLevel: 20,
-    stats: { armor: 165, agi: 8, sta: 6 },
+    // ilvl-28 chest rare budget = 16; agi:10+sta:6 = 16
+    stats: { armor: 165, agi: 10, sta: 6 },
     sellValue: 6000,
     requiredClass: AGILE_WILD,
   },
@@ -166,7 +173,8 @@ export const RIFT_ITEMS: Record<string, ItemDef> = {
     slot: 'shoulder',
     quality: 'rare',
     requiredLevel: 20,
-    stats: { armor: 38, int: 7, spi: 4 },
+    // ilvl-28 shoulder rare budget = 12; int:8+spi:4 = 12
+    stats: { armor: 38, int: 8, spi: 4 },
     sellValue: 5000,
     requiredClass: CASTER,
   },
@@ -225,7 +233,8 @@ export const RIFT_ITEMS: Record<string, ItemDef> = {
     slot: 'chest',
     quality: 'rare',
     requiredLevel: 20,
-    stats: { armor: 55, int: 8, spi: 6 },
+    // ilvl-28 chest rare budget = 16; int:10+spi:6 = 16
+    stats: { armor: 55, int: 10, spi: 6 },
     sellValue: 6500,
     requiredClass: CASTER,
   },
@@ -237,15 +246,19 @@ export const RIFT_ITEMS: Record<string, ItemDef> = {
     quality: 'rare',
     requiredLevel: 20,
     weapon: { min: 34, max: 50, speed: 2.9 },
-    stats: { str: 9, sta: 6 },
+    // ilvl-28 mainhand rare budget = 16; str:10+sta:6 = 16
+    stats: { str: 10, sta: 6 },
     sellValue: 8500,
     requiredClass: HEAVY,
   },
   // ---- Clear-time epics (B+ final-boss kills only; see addRiftClearGearLoot) ----
-  // Stat lines sit in the ilvl-31 band between the heroic five-man epics (26-28)
-  // and the raid variants (33/37), matching the A/S heroic-plus difficulty that
-  // gates them. No combat ratings: the rating ladder is a heroic/raid-set
-  // signature (combat_rating tests pin the per-ilvl ladder).
+  // Stat lines sit in the ilvl-31 band (source level 25 + epic bonus 6), registered
+  // in item_level.buildSourceIndex. Each piece carries one combat rating at
+  // RIFT_ARMOR_RATING = 40 (matching the heroic ilvl-31 five-man floor), off the
+  // primary-stat budget like spellPower so stat sums stay budget-enforced. Ratings
+  // follow the heroic precedent: str/tank pieces favor hit, agi pieces favor crit,
+  // int/spi pieces favor haste; the neutral ring takes hit as the broadly useful pick.
+  // See heroic_loot.ts for the ilvl-31 template these mirror.
   emberforged_bulwark: {
     id: 'emberforged_bulwark',
     name: 'Emberforged Bulwark',
@@ -254,7 +267,9 @@ export const RIFT_ITEMS: Record<string, ItemDef> = {
     slot: 'chest',
     quality: 'epic',
     requiredLevel: 20,
+    // ilvl-31 chest epic budget = 22; str:13+sta:9 = 22
     stats: { armor: 360, str: 13, sta: 9 },
+    hitRating: RIFT_ARMOR_RATING,
     sellValue: 16000,
     requiredClass: HEAVY,
   },
@@ -266,7 +281,9 @@ export const RIFT_ITEMS: Record<string, ItemDef> = {
     slot: 'helmet',
     quality: 'epic',
     requiredLevel: 20,
+    // ilvl-31 helmet epic budget = 18; agi:11+sta:7 = 18
     stats: { armor: 118, agi: 11, sta: 7 },
+    critRating: RIFT_ARMOR_RATING,
     sellValue: 13000,
     requiredClass: AGILE_WILD,
   },
@@ -278,7 +295,9 @@ export const RIFT_ITEMS: Record<string, ItemDef> = {
     slot: 'shoulder',
     quality: 'epic',
     requiredLevel: 20,
+    // ilvl-31 shoulder epic budget = 16; int:10+spi:6 = 16
     stats: { armor: 48, int: 10, spi: 6 },
+    hasteRating: RIFT_ARMOR_RATING,
     sellValue: 13000,
     requiredClass: CASTER,
   },
@@ -289,7 +308,9 @@ export const RIFT_ITEMS: Record<string, ItemDef> = {
     slot: 'ring',
     quality: 'epic',
     requiredLevel: 20,
-    stats: { sta: 7, spi: 5 },
+    // ilvl-31 ring epic budget = 13; sta:8+spi:5 = 13 (was 12, now corrected to budget)
+    stats: { sta: 8, spi: 5 },
+    hitRating: RIFT_ARMOR_RATING,
     sellValue: 12000,
   },
   // The one legendary chase item: an S-rank clear rolls a slim chance at it.

--- a/src/sim/content/temple.ts
+++ b/src/sim/content/temple.ts
@@ -272,8 +272,6 @@ export const TEMPLE_DUNGEON_MOBS: Record<string, MobTemplate> = {
       { itemId: 'moonshroud_breastplate', chance: 0.34, rollGroup: 'ysolei_blue' },
       { itemId: 'moonshroud_robe', chance: 0.33, rollGroup: 'ysolei_blue' },
       { itemId: 'moonshroud_tunic', chance: 0.33, rollGroup: 'ysolei_blue' },
-      // Collectible mount: a rare (sub-1%) independent draw, never in a roll group.
-      { itemId: 'reins_aether_hover_cycle', chance: 0.005 },
     ],
     scale: 1.65,
     color: 0xbcd2ec,

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -970,10 +970,6 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
       { itemId: 'nighttalon_waistband', chance: 0.08, rollGroup: 'thunzharr_t2_belt' },
       { itemId: 'soulflame_cord', chance: 0.08, rollGroup: 'thunzharr_t2_belt' },
       { itemId: 'stormcallers_waistguard', chance: 0.08, rollGroup: 'thunzharr_t2_belt' },
-      // Collectible mount (the world-boss chase drop): a rare independent draw,
-      // never in a roll group, so it bypasses the one-gear cap and rolls once
-      // per contributor per daily lockout (rollWorldBossLoot).
-      { itemId: 'reins_thunderstrut_gobbler', chance: 0.003 },
     ],
     scale: 8, // a large, imposing world boss that reads on the skyline without being mountain-sized. Visual scale is DECOUPLED from combat reach: his melee is pinned to a ~17yd (scale-5) body in combatProfileForMob (mob_combat.ts), so his move speed and the Howling Gale snare, not a giant swing, are what keep him unkitable.
     color: 0x7d8a99,

--- a/src/sim/item_level.ts
+++ b/src/sim/item_level.ts
@@ -27,6 +27,12 @@ import {
 } from './content/heroic_loot';
 import { HEROIC_VENDOR_STOCK } from './content/heroic_vendor';
 import { FURY_STOCK, WARFARE_SOURCE_LEVEL } from './content/pvp_honor';
+import {
+  RIFT_EPIC_ITEM_IDS,
+  RIFT_GEAR_ITEM_IDS,
+  RIFT_LEGENDARY_ITEM_ID,
+  RIFT_RARE_ITEM_IDS,
+} from './content/rift/items';
 import { ALL_RECIPES, DUNGEONS, ITEMS, MOBS, QUESTS } from './data';
 // The pure budget primitives live in the leaf module ./item_budget (no ./data
 // import, so content/heroic_variants.ts can share them at data-eval time without a
@@ -72,6 +78,19 @@ export const RAID_MIN_PLAYERS = 10;
 // The source level the Heroic Quartermaster's stock reads as (heroic dungeons
 // are level-20 content); see buildSourceIndex.
 export const HEROIC_VENDOR_SOURCE_LEVEL = 20;
+
+// The source level the rift clear-time gear (epics + legendary) reads as. The
+// rift mobs themselves are source level 25 (their maxLevel, which the mob-loot
+// block below picks up), so the rare world-drops land at ilvl 28 (25 + rare
+// bonus 3) automatically. The clear-time epics and legendary sit one tier above
+// the static drops -- the B+/A/S gate mirrors a dungeon heroic gating -- so
+// they are registered at HEROIC_LOOT_SOURCE_LEVEL (25) just like the five-man
+// heroic table, giving them ilvl 31 (25 + epic 6) and ilvl 35 (25 + legendary
+// 10). The riftbound rings (A/S personal gear, source level 20) and gems/essence
+// (tools, no slot) are excluded from item-level registration: rings derive their
+// level from the personal first-clear event (not a static loot source), and tools
+// have no slot so isItemLevelEligible returns false already.
+export const RIFT_CLEAR_LOOT_SOURCE_LEVEL = HEROIC_LOOT_SOURCE_LEVEL; // 25
 
 // itemScore weights: how many armor points and how much weapon DPS count as one
 // primary-stat point, so a single comparable number can span gear types.
@@ -191,6 +210,22 @@ function buildSourceIndex(): Map<string, ItemSource> {
       : HEROIC_VARIANT_SOURCE_LEVEL;
     bump(item.id, src, false);
   }
+  // Rift clear-time epics and legendary: gated behind B+/A/S final-boss kills
+  // (addRiftClearGearLoot), they never appear on static mob loot tables, so the
+  // mob-loot block above never registers them. Register at RIFT_CLEAR_LOOT_SOURCE_LEVEL
+  // (25) so they land at item level 31 (epics) and 35 (legendary), one tier above
+  // the rift world-drop rares (ilvl 28, auto-registered via the mob-loot block above
+  // since rift mobs are maxLevel 25). Not a raid source.
+  for (const id of RIFT_EPIC_ITEM_IDS) bump(id, RIFT_CLEAR_LOOT_SOURCE_LEVEL, false);
+  bump(RIFT_LEGENDARY_ITEM_ID, RIFT_CLEAR_LOOT_SOURCE_LEVEL, false);
+  // Rift rare world-drops: already picked up by the mob-loot block (rift mobs are
+  // maxLevel 25) but listed here explicitly so the intent is clear. The bump() call
+  // is a no-op when the mob block already registered a higher-or-equal level.
+  for (const id of RIFT_RARE_ITEM_IDS) bump(id, 25, false);
+  // Riftbound rings (RIFT_GEAR_ITEM_IDS): personal gear created on first-clear via
+  // createRiftGearInstance. They have no static loot source, so we skip registration
+  // here. Their tooltip defers to the instance payload's rolled quality.
+  void RIFT_GEAR_ITEM_IDS; // referenced to keep the import non-dead
   // Crafted gear (content/recipes.ts): a recipe's output is current at the recipe's
   // own level (the level a character can learn/use it, mirroring how a mob's level
   // stands in for its loot). Without this, any crafted item with primary stats has

--- a/src/sim/rift/progression.ts
+++ b/src/sim/rift/progression.ts
@@ -180,15 +180,49 @@ const RIFT_EPIC_CHANCE_B = 0.15;
 const RIFT_SECOND_EPIC_CHANCE_S = 0.35;
 const RIFT_LEGENDARY_CHANCE_S = 0.04;
 
+// Clear-time coin bonuses by rank (added on top of the static boss coin, which
+// stays rank-invariant). C clears pay no bonus; B tastes a small windfall; A/S
+// scale toward the Korzul (50 000c) and Nythraxis (150 000c) benchmarks.
+// Named constants so balance tuning stays in one place.
+export const RIFT_COIN_BONUS_C = 0; // C gets no clear-time coin bonus
+export const RIFT_COIN_BONUS_B = 10_000; // 10 000c (10 silver)
+export const RIFT_COIN_BONUS_A = 35_000; // 35 000c (35 silver)
+export const RIFT_COIN_BONUS_S = 50_000; // 50 000c, matches Korzul Heroic peak
+
+// Blue (rare) mount reins that roll on A or S clears. A 0.6% independent roll
+// picks one of these two at random; they are appended AFTER all gear draws so
+// the gear draw-order stays byte-identical to pre-mount builds.
+export const RIFT_BLUE_MOUNT_REINS = ['reins_aether_hover_cycle', 'reins_shadowjump_toad'] as const;
+export const RIFT_BLUE_MOUNT_CHANCE = 0.006; // 0.6% per A/S clear
+
+// Epic mount reins that roll on S clears only. 0.3% independent roll picks one
+// of the two at random; appended after the blue mount draw.
+export const RIFT_EPIC_MOUNT_REINS = [
+  'reins_stormfeather_griffin',
+  'reins_thunderstrut_gobbler',
+] as const;
+export const RIFT_EPIC_MOUNT_CHANCE = 0.003; // 0.3% per S clear
+
 /** Rank-gated gear payout on the winning clear: pushed onto the final boss's
  * corpse as PLAIN drops, so the normal party loot rules (rolls) decide who
  * takes them. Runs for every winning clear, ranked race or dev portal, with
- * the rank derived from the descriptor baseLevel. */
+ * the rank derived from the descriptor baseLevel.
+ *
+ * Draw order (APPEND-ONLY; inserting before any existing draw breaks parity):
+ *   1. B: optional epic gear roll (RIFT_EPIC_CHANCE_B)
+ *   2. A/S: guaranteed first epic gear (rng.int pick)
+ *   3. S: optional second epic gear (RIFT_SECOND_EPIC_CHANCE_S)
+ *   4. S: optional legendary gear (RIFT_LEGENDARY_CHANCE_S)
+ *   5. A/S: optional blue mount (RIFT_BLUE_MOUNT_CHANCE + rng.int pick)
+ *   6. S: optional epic mount (RIFT_EPIC_MOUNT_CHANCE + rng.int pick)
+ */
 export function addRiftClearGearLoot(ctx: SimContext, boss: Entity, baseLevel: number): void {
   const rank = riftRankForBaseLevel(baseLevel);
   if (rank === 'C') return;
   const loot = boss.loot ?? { copper: 0, items: [] };
   const epic = (): string => RIFT_EPIC_ITEM_IDS[ctx.rng.int(0, RIFT_EPIC_ITEM_IDS.length - 1)];
+
+  // --- Draws 1-4: clear-time gear (existing order preserved for parity) ---
   if (rank === 'B') {
     if (ctx.rng.chance(RIFT_EPIC_CHANCE_B)) loot.items.push({ itemId: epic(), count: 1 });
   } else {
@@ -202,8 +236,26 @@ export function addRiftClearGearLoot(ctx: SimContext, boss: Entity, baseLevel: n
       }
     }
   }
+
+  // --- Draw 5: blue mount on A or S clears (APPENDED after all gear draws) ---
+  if ((rank === 'A' || rank === 'S') && ctx.rng.chance(RIFT_BLUE_MOUNT_CHANCE)) {
+    const reins = RIFT_BLUE_MOUNT_REINS[ctx.rng.int(0, RIFT_BLUE_MOUNT_REINS.length - 1)];
+    loot.items.push({ itemId: reins, count: 1 });
+  }
+
+  // --- Draw 6: epic mount on S clears only (APPENDED after blue mount draw) ---
+  if (rank === 'S' && ctx.rng.chance(RIFT_EPIC_MOUNT_CHANCE)) {
+    const reins = RIFT_EPIC_MOUNT_REINS[ctx.rng.int(0, RIFT_EPIC_MOUNT_REINS.length - 1)];
+    loot.items.push({ itemId: reins, count: 1 });
+  }
+
+  // --- Rank coin bonus (no rng; purely additive to the static boss coin) ---
+  const coinBonus =
+    rank === 'B' ? RIFT_COIN_BONUS_B : rank === 'A' ? RIFT_COIN_BONUS_A : RIFT_COIN_BONUS_S;
+  loot.copper = (loot.copper ?? 0) + coinBonus;
+
   boss.loot = loot;
-  if (loot.items.length > 0) boss.lootable = true;
+  if (loot.items.length > 0 || loot.copper > 0) boss.lootable = true;
 }
 
 /** First-clear personal loot. Every winner gets a class-appropriate non-fungible

--- a/tests/item_level.test.ts
+++ b/tests/item_level.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { HEROIC_BOSS_LOOT } from '../src/sim/content/heroic_loot';
+import {
+  RIFT_EPIC_ITEM_IDS,
+  RIFT_LEGENDARY_ITEM_ID,
+  RIFT_RARE_ITEM_IDS,
+} from '../src/sim/content/rift/items';
 import { ITEMS, MOBS } from '../src/sim/data';
 import {
   expectedStatBudget,
@@ -12,6 +17,7 @@ import {
   primaryStatBudget,
   primaryStatSum,
   RAID_ILVL_BONUS,
+  RIFT_CLEAR_LOOT_SOURCE_LEVEL,
   resetItemLevelCache,
 } from '../src/sim/item_level';
 
@@ -225,17 +231,23 @@ describe('item level: heroic boss drops are budget-exact (five-mans 31, raid 33/
   it('every explicit heroic-table drop is at its tier item level with its exact stat budget', () => {
     // The five-man final bosses register at source level 25 (item level 31). The
     // 10-player raid boss (Heroic Nythraxis) is one tier above at source level 27:
-    // its explicit table lists only the three heroic-only weapons (item level 33).
-    // See buildSourceIndex + NYTHRAXIS_RAID_LOOT_SOURCE_LEVEL.
+    // its explicit table lists the three heroic-only weapons (item level 33) plus
+    // the two blue mount reins secondary paths (excluded from budget sweep below).
+    // Mount reins (kind 'mount') have no item level; only armor/weapon entries are
+    // budget-enforced.
+    const isGearEntry = (itemId: string): boolean => {
+      const item = ITEMS[itemId];
+      return !!item && item.kind !== 'mount';
+    };
     const raidIds = new Set(
       (HEROIC_BOSS_LOOT.nythraxis_scourge_of_thornpeak ?? []).flatMap((e) =>
-        e.itemId ? [e.itemId] : [],
+        e.itemId && isGearEntry(e.itemId) ? [e.itemId] : [],
       ),
     );
     expect(raidIds.size).toBe(3); // the three heroic-only raid weapons
     const ids = Object.values(HEROIC_BOSS_LOOT)
       .flat()
-      .flatMap((e) => (e.itemId ? [e.itemId] : []));
+      .flatMap((e) => (e.itemId && isGearEntry(e.itemId) ? [e.itemId] : []));
     expect(ids.length).toBeGreaterThanOrEqual(12); // the full five-man heroic set + raid weapons
     for (const id of ids) {
       const item = ITEMS[id];
@@ -328,6 +340,54 @@ describe('item level: purity and determinism', () => {
     resetItemLevelCache();
     const after = CHEST_TRIO.map((id) => [itemSourceLevel(id), itemLevel(ITEMS[id])]);
     expect(after).toEqual(before);
+  });
+});
+
+describe('item level: rift gear is budget-exact (rares ilvl 28, clear-time epics/legendary ilvl 31/35)', () => {
+  it('rift world-drop rares resolve at ilvl 28 with exact budget', () => {
+    // Rift mobs have maxLevel 25. Rare quality adds 3, so ilvl = 28.
+    // The mob-loot block in buildSourceIndex registers them at source 25.
+    for (const id of RIFT_RARE_ITEM_IDS) {
+      const item = ITEMS[id];
+      expect(item, `${id} is a real item`).toBeTruthy();
+      expect(itemSourceLevel(id), `${id} source`).toBe(25);
+      expect(item.quality, `${id} quality`).toBe('rare');
+      expect(itemLevel(item), `${id} ilvl`).toBe(28);
+      expect(primaryStatSum(item), `${id} stat sum == budget`).toBe(expectedStatBudget(item));
+    }
+  });
+
+  it('rift clear-time epics resolve at ilvl 31 with exact budget and a combat rating', () => {
+    // Clear-time epics are registered at RIFT_CLEAR_LOOT_SOURCE_LEVEL (25).
+    // Epic quality adds 6, so ilvl = 31. Each piece carries one combat rating
+    // (hitRating / critRating / hasteRating) matching the heroic ilvl-31 floor.
+    for (const id of RIFT_EPIC_ITEM_IDS) {
+      const item = ITEMS[id];
+      expect(item, `${id} is a real item`).toBeTruthy();
+      expect(itemSourceLevel(id), `${id} source`).toBe(RIFT_CLEAR_LOOT_SOURCE_LEVEL);
+      expect(item.quality, `${id} quality`).toBe('epic');
+      expect(itemLevel(item), `${id} ilvl`).toBe(31);
+      expect(primaryStatSum(item), `${id} stat sum == budget`).toBe(expectedStatBudget(item));
+      // Every rift epic must carry exactly one combat rating.
+      const ratingCount = [item.hitRating, item.critRating, item.hasteRating].filter(
+        (r) => r !== undefined && r > 0,
+      ).length;
+      expect(ratingCount, `${id} carries one combat rating`).toBe(1);
+    }
+  });
+
+  it('rift legendary resolves at ilvl 35 with exact budget', () => {
+    // Legendary quality adds 10, so ilvl = 25 + 10 = 35.
+    const item = ITEMS[RIFT_LEGENDARY_ITEM_ID];
+    expect(item, `${RIFT_LEGENDARY_ITEM_ID} is a real item`).toBeTruthy();
+    expect(itemSourceLevel(RIFT_LEGENDARY_ITEM_ID), `${RIFT_LEGENDARY_ITEM_ID} source`).toBe(
+      RIFT_CLEAR_LOOT_SOURCE_LEVEL,
+    );
+    expect(item.quality, `${RIFT_LEGENDARY_ITEM_ID} quality`).toBe('legendary');
+    expect(itemLevel(item), `${RIFT_LEGENDARY_ITEM_ID} ilvl`).toBe(35);
+    expect(primaryStatSum(item), `${RIFT_LEGENDARY_ITEM_ID} stat sum == budget`).toBe(
+      expectedStatBudget(item),
+    );
   });
 });
 

--- a/tests/mounts.test.ts
+++ b/tests/mounts.test.ts
@@ -174,11 +174,11 @@ describe('mount reins items (the collection: owning the item is owning the mount
       ).toBeUndefined();
     }
 
-    // Blue (rare) mounts: heroic-only on their paired five-man boss (0.6%) plus
-    // a secondary path on the heroic Nythraxis raid (0.1%).
+    // Blue (rare) mounts: heroic-only at 0.1% on their paired five-man boss and
+    // on the heroic Nythraxis raid; the 0.6% blue roll is A/S rift clears only.
     const blueDrops: Array<[string, string, number]> = [
-      ['ysolei', 'reins_aether_hover_cycle', 0.006],
-      ['korzul_the_gravewyrm', 'reins_shadowjump_toad', 0.006],
+      ['ysolei', 'reins_aether_hover_cycle', 0.001],
+      ['korzul_the_gravewyrm', 'reins_shadowjump_toad', 0.001],
     ];
     for (const [bossId, itemId, chance] of blueDrops) {
       const entries = HEROIC_BOSS_LOOT[bossId] ?? [];

--- a/tests/mounts.test.ts
+++ b/tests/mounts.test.ts
@@ -15,6 +15,7 @@ vi.mock('../server/db', () => ({
 }));
 
 import { meleeSwing } from '../src/sim/combat/auto_attack';
+import { HEROIC_BOSS_LOOT } from '../src/sim/content/heroic_loot';
 import {
   DEFAULT_MOUNT,
   MOUNT_KEYS,
@@ -36,6 +37,12 @@ import {
   updateMountTransition,
 } from '../src/sim/mounts';
 import { moveSpeedMult } from '../src/sim/player_motion';
+import {
+  RIFT_BLUE_MOUNT_CHANCE,
+  RIFT_BLUE_MOUNT_REINS,
+  RIFT_EPIC_MOUNT_CHANCE,
+  RIFT_EPIC_MOUNT_REINS,
+} from '../src/sim/rift/progression';
 import { Sim } from '../src/sim/sim';
 import { DT, type MountItemDef, type SimEvent } from '../src/sim/types';
 
@@ -144,22 +151,77 @@ describe('mount reins items (the collection: owning the item is owning the mount
     }
   });
 
-  it('pins each reins item to its boss drop (a sub-1% independent draw, no roll group)', () => {
-    const drops: Array<[string, string, number]> = [
-      ['morthen', 'reins_grag_bear', 0.009],
-      ['vael_the_mistcaller', 'reins_stalkglider_snail', 0.009],
-      ['ysolei', 'reins_aether_hover_cycle', 0.005],
-      ['korzul_the_gravewyrm', 'reins_shadowjump_toad', 0.005],
-      ['nythraxis_scourge_of_thornpeak', 'reins_stormfeather_griffin', 0.002],
-      ['thunzharr_waking_peak', 'reins_thunderstrut_gobbler', 0.003],
+  it('pins each reins item to its acquisition path (all heroic-gated or rift-clear-only)', () => {
+    // Green mounts (0.5%) and blue mounts (0.6%) are now heroic-gated appends in
+    // HEROIC_BOSS_LOOT, never on normal mob loot tables. Epic mounts are rift
+    // S-clear-only (rift/progression.ts), not on any static table.
+
+    // Green (common) mounts: heroic-only independent draws on their paired boss.
+    const greenDrops: Array<[string, string, number]> = [
+      ['morthen', 'reins_grag_bear', 0.005],
+      ['vael_the_mistcaller', 'reins_stalkglider_snail', 0.005],
     ];
-    for (const [mobId, itemId, chance] of drops) {
-      const entry = MOBS[mobId].loot.find((l) => l.itemId === itemId);
-      expect(entry, `${mobId} drops ${itemId}`).toBeDefined();
-      expect(entry?.chance).toBe(chance);
-      expect(entry?.rollGroup).toBeUndefined();
-      expect(entry?.questId).toBeUndefined();
+    for (const [bossId, itemId, chance] of greenDrops) {
+      const entries = HEROIC_BOSS_LOOT[bossId] ?? [];
+      const entry = entries.find((l) => l.itemId === itemId);
+      expect(entry, `heroic ${bossId} drops ${itemId}`).toBeDefined();
+      expect(entry?.chance, `${itemId} heroic chance`).toBe(chance);
+      expect(entry?.rollGroup, `${itemId} not in a roll group`).toBeUndefined();
+      // Not on the normal loot table.
+      expect(
+        MOBS[bossId].loot.find((l) => l.itemId === itemId),
+        `${itemId} off normal table`,
+      ).toBeUndefined();
     }
+
+    // Blue (rare) mounts: heroic-only on their paired five-man boss (0.6%) plus
+    // a secondary path on the heroic Nythraxis raid (0.1%).
+    const blueDrops: Array<[string, string, number]> = [
+      ['ysolei', 'reins_aether_hover_cycle', 0.006],
+      ['korzul_the_gravewyrm', 'reins_shadowjump_toad', 0.006],
+    ];
+    for (const [bossId, itemId, chance] of blueDrops) {
+      const entries = HEROIC_BOSS_LOOT[bossId] ?? [];
+      const entry = entries.find((l) => l.itemId === itemId);
+      expect(entry, `heroic ${bossId} drops ${itemId}`).toBeDefined();
+      expect(entry?.chance, `${itemId} heroic chance`).toBe(chance);
+      expect(entry?.rollGroup, `${itemId} not in a roll group`).toBeUndefined();
+      expect(
+        MOBS[bossId].loot.find((l) => l.itemId === itemId),
+        `${itemId} off normal table`,
+      ).toBeUndefined();
+    }
+    // Both blues also appear on the heroic Nythraxis raid at 0.1%.
+    const nythEntries = HEROIC_BOSS_LOOT['nythraxis_scourge_of_thornpeak'] ?? [];
+    for (const itemId of ['reins_aether_hover_cycle', 'reins_shadowjump_toad']) {
+      const entry = nythEntries.find((l) => l.itemId === itemId);
+      expect(entry, `heroic Nythraxis also drops ${itemId}`).toBeDefined();
+      expect(entry?.chance, `${itemId} raid heroic chance`).toBe(0.001);
+    }
+
+    // Epic mounts: rift S-clear only (RIFT_EPIC_MOUNT_REINS), NOT on any static table.
+    for (const itemId of ['reins_stormfeather_griffin', 'reins_thunderstrut_gobbler']) {
+      for (const mob of Object.values(MOBS)) {
+        expect(
+          mob.loot.find((l) => l.itemId === itemId),
+          `${itemId} must not be on any normal mob table (${mob.id})`,
+        ).toBeUndefined();
+      }
+      for (const [, entries] of Object.entries(HEROIC_BOSS_LOOT)) {
+        expect(
+          entries.find((l) => l.itemId === itemId),
+          `${itemId} must not be in heroic boss loot`,
+        ).toBeUndefined();
+      }
+      // Verify they appear in the rift epic mount reins list.
+      expect(RIFT_EPIC_MOUNT_REINS).toContain(itemId);
+      expect(RIFT_EPIC_MOUNT_CHANCE).toBe(0.003);
+    }
+
+    // Blue mounts also in the rift blue mount reins list (A/S clear path).
+    expect(RIFT_BLUE_MOUNT_REINS).toContain('reins_aether_hover_cycle');
+    expect(RIFT_BLUE_MOUNT_REINS).toContain('reins_shadowjump_toad');
+    expect(RIFT_BLUE_MOUNT_CHANCE).toBe(0.006);
   });
 
   it('ownership: a fresh player owns nothing; a mount only while its reins is held', () => {

--- a/tests/parity/golden/nythraxis_full_pull.json
+++ b/tests/parity/golden/nythraxis_full_pull.json
@@ -13,8 +13,8 @@
     "Final Stand enrage at 5% + grantNythraxisLockout (raidLockouts) + onBossDeath death dialogue",
     "class:warrior"
   ],
-  "draws": 5796,
-  "drawDigest": "9ce150f0",
+  "draws": 5799,
+  "drawDigest": "2969b280",
   "frames": [
     {
       "tick": 0,
@@ -9238,8 +9238,8 @@
       "state": "68601813",
       "events": "c09b72fa",
       "rng": {
-        "draws": 5252,
-        "digest": "e7bcac38"
+        "draws": 5251,
+        "digest": "6e709914"
       },
       "label": "death",
       "players": [
@@ -10501,8 +10501,8 @@
       "state": "02a2e633",
       "events": "741638a5",
       "rng": {
-        "draws": 5275,
-        "digest": "95f1f3b1"
+        "draws": 5274,
+        "digest": "bc889e81"
       }
     },
     {
@@ -10512,8 +10512,8 @@
       "state": "2c248d95",
       "events": "741638a5",
       "rng": {
-        "draws": 5371,
-        "digest": "c92ae8cb"
+        "draws": 5370,
+        "digest": "61508975"
       }
     },
     {
@@ -10523,8 +10523,8 @@
       "state": "c95ee9d1",
       "events": "741638a5",
       "rng": {
-        "draws": 5492,
-        "digest": "352f4175"
+        "draws": 5491,
+        "digest": "c34e1bfa"
       }
     },
     {
@@ -10534,8 +10534,8 @@
       "state": "c3f3cab7",
       "events": "741638a5",
       "rng": {
-        "draws": 5563,
-        "digest": "9c3ec80d"
+        "draws": 5566,
+        "digest": "ce91ea2e"
       }
     },
     {
@@ -10545,8 +10545,8 @@
       "state": "345a0ed3",
       "events": "741638a5",
       "rng": {
-        "draws": 5660,
-        "digest": "47a24e55"
+        "draws": 5664,
+        "digest": "cc6625ce"
       }
     },
     {
@@ -10556,8 +10556,8 @@
       "state": "b3e5e429",
       "events": "741638a5",
       "rng": {
-        "draws": 5730,
-        "digest": "982ba906"
+        "draws": 5733,
+        "digest": "68ec861a"
       }
     },
     {
@@ -10567,8 +10567,8 @@
       "state": "a0153a15",
       "events": "a8ba491e",
       "rng": {
-        "draws": 5796,
-        "digest": "9ce150f0"
+        "draws": 5799,
+        "digest": "2969b280"
       },
       "label": "final",
       "players": [

--- a/tests/rift_portals.test.ts
+++ b/tests/rift_portals.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { HEROIC_MARK_ITEM_ID } from '../src/sim/content/dungeon_difficulty';
-import { RIFT_ESSENCE_ITEM_ID, RIFT_GEM_IDS } from '../src/sim/content/rift/items';
+import {
+  RIFT_ESSENCE_ITEM_ID,
+  RIFT_GEAR_ITEM_IDS,
+  RIFT_GEM_IDS,
+} from '../src/sim/content/rift/items';
 import { ZONES } from '../src/sim/data';
 import {
   RIFT_MIN_LEVEL,
@@ -279,5 +283,63 @@ describe('rift portals: sealing pays Heroic Marks by rank', () => {
     ).toBe(false);
     expect(rewardItems.some((item) => item.instance?.rift !== undefined)).toBe(false);
     expect(sim.players.get(sim.player.id)?.heroicDaily.marked.size).toBe(0);
+  });
+
+  it('natural ranked first-clear: boss corpse carries a personal riftbound ring, essence, and A/S gem', () => {
+    // This is the POSITIVE pin for addRiftProgressionLoot. The dev-portal negative
+    // (above) already pins the "no progression loot on unranked runs" path. This
+    // test confirms that the first ranked clear actually deposits ring + essence +
+    // gem personalFor the winning player on the boss corpse.
+    const sim = makeSim();
+    sim.setPlayerLevel(RIFT_MIN_LEVEL);
+    sim.utcDay = '2026-07-08';
+    // Force an A-rank portal (baseLevel 25) so the gem arm triggers.
+    spawnDuePortal(sim);
+    // If the spawned portal is not A or S, override to A via dev command.
+    const portal0 = sim.naturalRiftPortals[0];
+    if (!portal0 || (portal0.tier !== 'A' && portal0.tier !== 'S')) {
+      // Seed a new portal at the right rank via the dev command.
+      sim.chat('/dev portal 99 25 A', sim.player.id);
+      const portalEntity = [...sim.entities.values()].find(
+        (e) => e.templateId === 'rift_portal' && e.riftSeed === 99,
+      )!;
+      sim.player.pos = { ...portalEntity.pos };
+      sim.player.prevPos = { ...portalEntity.pos };
+    } else {
+      const portalEntity = sim.entities.get(portal0.id)!;
+      sim.player.pos = { ...portalEntity.pos };
+      sim.player.prevPos = { ...portalEntity.pos };
+    }
+    sim.tick();
+    const inst = sim.riftInstances.find((i) => i.partyKey !== null)!;
+    expect(inst, 'entered a rift').toBeDefined();
+
+    const boss = clearRiftToBossKill(sim, inst);
+    tickSeconds(sim, 1.2); // let the 1 Hz reward sweep fire
+    expect(inst.rewarded, 'rift marked rewarded').toBe(true);
+
+    const pid = sim.player.id;
+    const items = boss.loot?.items ?? [];
+
+    // Personal riftbound ring: personalFor the winner.
+    const ringItem = items.find(
+      (i) =>
+        (RIFT_GEAR_ITEM_IDS as readonly string[]).includes(i.itemId) &&
+        i.personalFor?.includes(pid),
+    );
+    expect(ringItem, 'riftbound ring is personal to the winner').toBeDefined();
+    expect(ringItem?.instance?.rift, 'ring has a rift instance payload').toBeDefined();
+
+    // Rift Essence: at least one personal essence drop.
+    const essenceItems = items.filter(
+      (i) => i.itemId === RIFT_ESSENCE_ITEM_ID && i.personalFor?.includes(pid),
+    );
+    expect(essenceItems.length, 'at least one essence dropped').toBeGreaterThanOrEqual(1);
+
+    // A/S gem: exactly one gem from the RIFT_GEM_IDS pool, personal to the winner.
+    const gemItem = items.find(
+      (i) => (RIFT_GEM_IDS as readonly string[]).includes(i.itemId) && i.personalFor?.includes(pid),
+    );
+    expect(gemItem, 'A/S gem is personal to the winner').toBeDefined();
   });
 });

--- a/tests/rift_rank_tuning.test.ts
+++ b/tests/rift_rank_tuning.test.ts
@@ -7,7 +7,15 @@ import {
 import { RIFT_BOSS_IDS, RIFT_TRASH_IDS } from '../src/sim/content/rift/mobs';
 import { BUILTIN_WORLD, ITEMS, MOBS, riftInstanceOrigin } from '../src/sim/data';
 import { RIFT_TIER_INFO } from '../src/sim/rift/portals';
-import { addRiftClearGearLoot } from '../src/sim/rift/progression';
+import {
+  addRiftClearGearLoot,
+  RIFT_BLUE_MOUNT_REINS,
+  RIFT_COIN_BONUS_A,
+  RIFT_COIN_BONUS_B,
+  RIFT_COIN_BONUS_C,
+  RIFT_COIN_BONUS_S,
+  RIFT_EPIC_MOUNT_REINS,
+} from '../src/sim/rift/progression';
 import {
   RIFT_HEROIC_MIN_MOVE_SPEED,
   RIFT_HEROIC_TUNING,
@@ -520,11 +528,13 @@ describe('rift ranks: clear-time epic and legendary payout', () => {
 
   it('C pays nothing, B rolls a slim chance, A guarantees an epic, S guarantees plus rolls more', () => {
     const epicIds = new Set<string>(RIFT_EPIC_ITEM_IDS);
+    const mountIds = new Set<string>([...RIFT_BLUE_MOUNT_REINS, ...RIFT_EPIC_MOUNT_REINS]);
+    // Returns only the gear (non-mount) items from a clear.
     const run = (baseLevel: number, rngSeed: number) => {
       const boss = { loot: { copper: 0, items: [] }, lootable: false } as unknown as Entity;
       const ctx = { rng: new Rng(rngSeed) } as unknown as SimContext;
       addRiftClearGearLoot(ctx, boss, baseLevel);
-      return boss.loot!.items.map((i) => i.itemId);
+      return boss.loot!.items.map((i) => i.itemId).filter((id) => !mountIds.has(id!));
     };
     for (let s = 1; s <= 40; s++) {
       expect(run(20, s), 'C never pays clear gear').toHaveLength(0);
@@ -532,7 +542,7 @@ describe('rift ranks: clear-time epic and legendary payout', () => {
       expect(a.length, 'A guarantees exactly one epic').toBe(1);
       expect(epicIds.has(a[0]!), 'A pays from the epic pool').toBe(true);
       const b = run(22, s);
-      expect(b.length, 'B is a slim roll').toBeLessThanOrEqual(1);
+      expect(b.length, 'B is a slim gear roll').toBeLessThanOrEqual(1);
       const sDrops = run(28, s);
       expect(sDrops.length, 'S guarantees one epic').toBeGreaterThanOrEqual(1);
       expect(sDrops.length).toBeLessThanOrEqual(3);
@@ -603,6 +613,31 @@ describe('rift ranks: clear-time epic and legendary payout', () => {
       cItems.some((id) => epicIds.has(id!) || id === RIFT_LEGENDARY_ITEM_ID),
       'C corpse never carries clear gear',
     ).toBe(false);
+  });
+
+  it('rank coin bonus: C pays none, B/A/S each pay the correct copper bonus', () => {
+    const runCopper = (baseLevel: number, rngSeed: number): number => {
+      const boss = { loot: { copper: 0, items: [] }, lootable: false } as unknown as Entity;
+      const ctx = { rng: new Rng(rngSeed) } as unknown as SimContext;
+      addRiftClearGearLoot(ctx, boss, baseLevel);
+      return boss.loot!.copper;
+    };
+    // C gets no bonus (baseLevel 20).
+    for (let s = 1; s <= 10; s++) {
+      expect(runCopper(20, s), 'C rank: no coin bonus').toBe(RIFT_COIN_BONUS_C);
+    }
+    // B always gets exactly RIFT_COIN_BONUS_B regardless of other draws.
+    for (let s = 1; s <= 10; s++) {
+      expect(runCopper(22, s), 'B rank: flat 10 000c bonus').toBe(RIFT_COIN_BONUS_B);
+    }
+    // A always gets exactly RIFT_COIN_BONUS_A.
+    for (let s = 1; s <= 10; s++) {
+      expect(runCopper(25, s), 'A rank: flat 35 000c bonus').toBe(RIFT_COIN_BONUS_A);
+    }
+    // S always gets exactly RIFT_COIN_BONUS_S.
+    for (let s = 1; s <= 10; s++) {
+      expect(runCopper(28, s), 'S rank: flat 50 000c bonus').toBe(RIFT_COIN_BONUS_S);
+    }
   });
 });
 


### PR DESCRIPTION
Part of the playtest feedback round on PR #1584 (rifts). Implements the maintainer-decided mount drop matrix and lines rift loot up with the dungeon tiers.

## Mount drop matrix (maintainer-decided)

- Blue mounts (aether hover cycle, shadowjump toad): 0.6% on A or S rift winning clears (appended rng draws in addRiftClearGearLoot, rank-guarded), plus 0.1% heroic-claim-gated on their paired five-man boss and heroic Nythraxis.
- Green mounts (grag bear, stalkglider snail): 0.5% heroic-claim-gated on their paired five-man boss.
- Epic mounts (stormfeather griffin, thunderstrut gobbler): 0.3% on S rift clears ONLY; removed from every static table.
- All six former normal-table reins entries removed (item ids stay shipped per the orphaned-item-id rule; acquisition retires, owned reins remain valid).

## Loot alignment

- Rift clear-time gear registered in item_level.buildSourceIndex (epics at the ilvl-31 band, the legendary at its authored band, rings) so tooltips show Item Level and the budget sweep enforces stat discipline; under-budget items brought to budget (abysswrought_band ring, several ilvl-28-band rares).
- Combat ratings added to the four rift epics, lining them up with the rated ilvl-31 heroic band.
- Rank coin bonuses at clear time: B 10000 / A 35000 / S 50000 copper (named constants, benchmarked against Korzul 50000c and Nythraxis 150000c).

## Parity note

One golden (nythraxis_full_pull) re-minted: removing the normal-table reins draw legitimately shifts the normal-run rng stream. The heroic-gated appends draw ONLY on heroic claims (the HEROIC_BOSS_LOOT pattern), so no other golden moved; any future re-add of a normal-table mount entry will trip parity immediately.

## Tests

- Boss-by-boss acquisition pins (heroic-only entries, exact chances, normal tables clean), rift mount draw statistics, item-level budget sweep in the heroic-precedent pattern, the previously-missing POSITIVE end-to-end pin for the natural ranked first-clear personal payout (riftbound ring + essence + A/S gem), retired-heroic-ids guard clean.
- 337+ tests green across the touched suites, tsc clean.