### PR TITLE
fix(rift): interactable rate limits and placement hardening

### DIFF
--- a/src/sim/interaction.ts
+++ b/src/sim/interaction.ts
@@ -62,6 +62,8 @@ import {
 } from './types';
 import { markWorldBossLooted } from './world_boss';
 
+const LOCKPICK_OFFER_COOLDOWN = 4; // seconds between repeated rift_locked_chest offer emits per player
+
 // Shared corpse loot-rights snapshot for both the manual `lootCorpse` and the passive
 // walk-by `autoLootForParty`. The caller passes `ffaUnlocked` so the two paths can
 // diverge on the free-for-all rule: manual looting honors the FFA timer (a deliberate
@@ -456,7 +458,11 @@ export function interact(ctx: SimContext, pid?: number): void {
         }
         if (target.templateId === 'rift_locked_chest') {
           // Offer the ante selector; the pick itself runs via lockpick_engage.
-          ctx.emit({ type: 'lockpickOffer', objectId: target.id, bountiful: false, pid: p.id });
+          // Rate-limited per player so repeated F-key spam does not re-open the UI.
+          if (ctx.time >= (p.riftLockpickOfferAt ?? -Infinity) + LOCKPICK_OFFER_COOLDOWN) {
+            p.riftLockpickOfferAt = ctx.time;
+            ctx.emit({ type: 'lockpickOffer', objectId: target.id, bountiful: false, pid: p.id });
+          }
           return;
         }
         if (target.templateId === 'rift_treasure') {
@@ -529,7 +535,10 @@ export function interact(ctx: SimContext, pid?: number): void {
       return;
     }
     if (obj.templateId === 'rift_locked_chest') {
-      ctx.emit({ type: 'lockpickOffer', objectId: obj.id, bountiful: false, pid: p.id });
+      if (ctx.time >= (p.riftLockpickOfferAt ?? -Infinity) + LOCKPICK_OFFER_COOLDOWN) {
+        p.riftLockpickOfferAt = ctx.time;
+        ctx.emit({ type: 'lockpickOffer', objectId: obj.id, bountiful: false, pid: p.id });
+      }
       return;
     }
     if (obj.templateId === 'rift_treasure') {

--- a/src/sim/rift/runs.ts
+++ b/src/sim/rift/runs.ts
@@ -49,6 +49,7 @@ const SEQ_TRIGGER_RADIUS = 2.6; // walk this close to step a sequence rune
 const ORB_TRIGGER_RADIUS = 3.2;
 const ORB_NOTICE_COOLDOWN = 6; // seconds between "the orb is sealed" nudges
 const SEQ_RESET_NOTICE_COOLDOWN = 4; // seconds between "the runes go dark" reset notices
+const POOL_FULL_NOTICE_COOLDOWN = 4; // seconds between "all rifts are unstable" / "already cleared" denials on walk-in
 const BOULDER_PUSH_RADIUS = 2.0; // shove a boulder when this close and moving into it
 const PAD_RADIUS = 2.2; // a boulder counts as socketed within this of its pad
 const ICE_SLIDE_SPEED = 13; // yd/s glide across the ice (~1.85x run: frictionless momentum)
@@ -248,6 +249,7 @@ function spawnRiftFloor(ctx: SimContext, inst: RiftInstance): void {
   inst.boulderPads = [];
   inst.seqRuneIds = [];
   inst.seqStep = 0;
+  inst.seqResetAt = -Infinity;
   inst.beaconId = null;
   inst.rollerIds = [];
   inst.cacheId = null;
@@ -403,6 +405,7 @@ function freeRiftFloorEntities(ctx: SimContext, inst: RiftInstance): void {
   inst.boulderPads = [];
   inst.seqRuneIds = [];
   inst.seqStep = 0;
+  inst.seqResetAt = -Infinity;
   inst.beaconId = null;
   inst.rollerIds = [];
   inst.cacheId = null;
@@ -478,8 +481,11 @@ export function enterRift(
   if (eventId !== null) {
     const event = ctx.riftEvents.find((candidate) => candidate.eventId === eventId);
     if (!event || event.status === 'cleared' || event.status === 'collapsed') {
-      const winner = event?.firstClear?.memberNames.join(', ') || 'another party';
-      ctx.error(r.meta.entityId, `This rift has already been cleared by ${winner}.`);
+      if (ctx.time >= (r.e.riftPoolFullAt ?? -Infinity) + POOL_FULL_NOTICE_COOLDOWN) {
+        r.e.riftPoolFullAt = ctx.time;
+        const winner = event?.firstClear?.memberNames.join(', ') || 'another party';
+        ctx.error(r.meta.entityId, `This rift has already been cleared by ${winner}.`);
+      }
       return;
     }
     if (event.upgradeStatus === 'pending') event.upgradeStatus = 'fallback';
@@ -501,7 +507,10 @@ export function enterRift(
   if (!inst) {
     const free = ctx.riftInstances.find((i) => i.partyKey === null);
     if (!free) {
-      ctx.error(r.meta.entityId, 'All rifts are unstable right now. Try again soon.');
+      if (ctx.time >= (r.e.riftPoolFullAt ?? -Infinity) + POOL_FULL_NOTICE_COOLDOWN) {
+        r.e.riftPoolFullAt = ctx.time;
+        ctx.error(r.meta.entityId, 'All rifts are unstable right now. Try again soon.');
+      }
       return;
     }
     inst = free;
@@ -844,9 +853,9 @@ export function updateRiftTriggers(ctx: SimContext, p: Entity): void {
               if (rr) rr.templateId = 'rift_seq_rune';
             }
           }
-          const throttled = ctx.time < (p.riftSeqResetAt ?? -Infinity) + SEQ_RESET_NOTICE_COOLDOWN;
+          const throttled = ctx.time < inst.seqResetAt + SEQ_RESET_NOTICE_COOLDOWN;
           if (hadProgress || !throttled) {
-            p.riftSeqResetAt = ctx.time;
+            inst.seqResetAt = ctx.time;
             riftFx(ctx, rune.pos.x, rune.pos.z, 'shadow'); // the runes snuff out
             for (const pid of instancePlayerIds(ctx, inst)) {
               ctx.emit({

--- a/src/sim/rift/types.ts
+++ b/src/sim/rift/types.ts
@@ -336,6 +336,10 @@ export interface RiftInstance {
    * `lockpick` engine + the shared HUD/wire), or null. Rift-hosted, so the delve
    * lockpick controller stays untouched. */
   lockpick: LockSession | null;
+  /** Sim time of the last "the runes go dark" sequence-reset notice broadcast to
+   * this instance. Instance-level (not per-player) so N party members standing on
+   * a wrong rune together still produce only one notice per cooldown window. */
+  seqResetAt: number;
 }
 
 /** The rift as a whole (derived from the descriptor's seed + baseLevel), used for

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2047,6 +2047,7 @@ export class Sim {
         tier: null,
         portalId: null,
         rewarded: false,
+        seqResetAt: -Infinity,
       });
     }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -3045,9 +3045,15 @@ export interface Entity {
   // Sim time of the last "level too low" rift denial shown to this player, so
   // standing inside the portal trigger radius does not spam the toast per tick.
   riftDeniedAt?: number;
+  // Sim time of the last "pool full" / "event already cleared" denial shown to
+  // this player on walk-in, so a 20 Hz trigger does not spam the error toast.
+  riftPoolFullAt?: number;
   // Sim time of the last "the orb is sealed" nudge shown to this player at a
   // dormant Blood Orb (authored citadel), throttled the same way.
   riftOrbNoticeAt?: number;
+  // Sim time of the last lockpickOffer emitted to this player from a
+  // rift_locked_chest click, so repeated F-key presses don't spam the UI.
+  riftLockpickOfferAt?: number;
   // Walk-in portal grace after leaving a rift: until this sim time the player
   // does not auto-enter portals, so being returned near the entry portal can
   // never bounce them straight back in (clicking the portal still works).
@@ -3063,10 +3069,6 @@ export interface Entity {
   // Cooldown gate (sim time) between rolling-boulder knockbacks, so a single pass
   // shoves + chips once rather than every tick of overlap.
   riftRollerUntil?: number;
-  // Sim time of the last "the runes go dark" sequence-reset notice shown to this
-  // player, so standing on a wrong rune re-announces at most once per cooldown
-  // instead of every tick (rift/runs.ts).
-  riftSeqResetAt?: number;
   // Rift boss rank budget: how many entries of the template's `rankMechanics`
   // list are live on THIS spawn (C=1, B=2, A=3, S=4; rift/ranks.ts). Undefined
   // (every non-rift mob, and rift trash) suppresses nothing.

--- a/tests/rift_gen.test.ts
+++ b/tests/rift_gen.test.ts
@@ -231,10 +231,21 @@ describe('rift generator: objectives are never inside (or hidden by) a wall', ()
   // body). Every objective must clear every collider by its prop radius, and no
   // layout may carry a phantom (illusion) wall, so collider clearance IS visual
   // clearance: a rune can never render embedded in, or tucked behind, a wall.
+  // Per-kind prop clearance radii: the three values below match the explicit
+  // toClear margin the generator passes; the rest use the player body radius
+  // (BODY_R = 0.6) because they are placed on the always-clear spine or within
+  // the obstacle-free AISLE_HALF band (|x| <= 5.5) by construction.
   const PROP_R: Record<string, number> = {
     rune_pylon: 1.7,
     seq_rune: 1.5,
     treasure: 1.0,
+    chest: 0.6,
+    descent: 0.6,
+    gate: 0.6,
+    switch: 0.6,
+    boulder: 0.6,
+    boulder_pad: 0.6,
+    ice_goal: 0.6,
   };
 
   it('every interactable clears the walls by its prop radius, at every rank', () => {

--- a/tests/rift_gen.test.ts
+++ b/tests/rift_gen.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { Collider } from '../src/sim/colliders';
 import { RIFT_THEMES } from '../src/sim/content/rift/themes';
 import { DUNGEON_WALL_X } from '../src/sim/dungeon_layout';
+import { polygonContainsPoint } from '../src/sim/geometry2d';
 import {
   generateRiftFloor,
   generateRiftPlan,
@@ -239,6 +240,14 @@ describe('rift generator: objectives are never inside (or hidden by) a wall', ()
     rune_pylon: 1.7,
     seq_rune: 1.5,
     treasure: 1.0,
+    // The kinds below are placed on the always-clear centre spine (x=0) or
+    // within the obstacle-free AISLE_HALF band (|x| <= 5.5) by construction,
+    // so BODY_R (0.6) is the correct clearance check at their placement point:
+    // their visual footprint may be wider (boulder dodecahedron r=1.1, switch
+    // cylinder r=1.3, ice_goal disc r=1.7) but they are never placed near a
+    // wall. infernal_orb is authored at a fixed altar position inside the
+    // always-open citadel hall; it only appears on set-piece seeds which are
+    // skipped by the seed loop below, but is listed here for completeness.
     chest: 0.6,
     descent: 0.6,
     gate: 0.6,
@@ -246,6 +255,7 @@ describe('rift generator: objectives are never inside (or hidden by) a wall', ()
     boulder: 0.6,
     boulder_pad: 0.6,
     ice_goal: 0.6,
+    infernal_orb: 0.6,
   };
 
   it('every interactable clears the walls by its prop radius, at every rank', () => {
@@ -290,6 +300,66 @@ describe('rift generator: balance', () => {
       for (let f = 0; f < n; f++) {
         const fl = generateRiftFloor(s, 15, f);
         expect(fl.spawns.length).toBeGreaterThanOrEqual(fl.isBoss ? 3 : 4);
+      }
+    }
+  });
+});
+
+describe('rift runtime placements: exit portal and sealed cache are inside the room', () => {
+  // openExit() in runs.ts spawns two objects whose positions are computed at
+  // runtime (not by the generator): the rift exit portal and the Sealed Rift
+  // Cache. Their local positions mirror:
+  //   const chest = floor.objects.find(o => o.kind === 'chest');
+  //   const pos = chest ?? { x: 0, z: floor.layout.dais.z + 6 };
+  //   exit at (pos.x, pos.z), cache at (pos.x - 4, pos.z)
+  // Both must land inside the room polygon and clear every wall collider by
+  // at least BODY_R (0.6), across all procedural boss floors and all four
+  // rank base levels (20/22/25/28).
+
+  // Inline containment helper: polygon branch if shellPolygon is present
+  // (star-shaped room), rectangle branch otherwise. Matches the pattern from
+  // tests/rift_wall_solidity.test.ts.
+  function insideRoom(fl: ReturnType<typeof generateRiftFloor>, x: number, z: number): boolean {
+    const { layout } = fl;
+    if (layout.shellPolygon) {
+      return polygonContainsPoint(layout.shellPolygon, x, z);
+    }
+    const wx = layout.wallX ?? DUNGEON_WALL_X;
+    return Math.abs(x) < wx && z > layout.zMin && z < layout.zMax;
+  }
+
+  it('exit portal and sealed cache land inside the room at every rank', () => {
+    for (const baseLevel of [20, 22, 25, 28]) {
+      for (let s = 0; s < 60; s++) {
+        if (isSetPieceSeed(s)) continue;
+        const n = riftFloorCount(s);
+        const bossFloor = n - 1;
+        const fl = generateRiftFloor(s, baseLevel, bossFloor);
+        if (!fl.isBoss) continue; // defensive: boss is always last
+        const colliders = riftFloorColliders(s, baseLevel, bossFloor);
+        // Mirror the openExit position logic from runs.ts.
+        const chest = fl.objects.find((o) => o.kind === 'chest');
+        const pos = chest ?? { x: 0, z: fl.layout.dais.z + 6 };
+        const exitX = pos.x;
+        const exitZ = pos.z;
+        const cacheX = pos.x - 4;
+        const cacheZ = pos.z;
+        expect(
+          insideRoom(fl, exitX, exitZ),
+          `exit inside room seed ${s} base ${baseLevel} @${exitX},${exitZ}`,
+        ).toBe(true);
+        expect(
+          clears(colliders, exitX, exitZ),
+          `exit clears walls seed ${s} base ${baseLevel} @${exitX},${exitZ}`,
+        ).toBe(true);
+        expect(
+          insideRoom(fl, cacheX, cacheZ),
+          `cache inside room seed ${s} base ${baseLevel} @${cacheX},${cacheZ}`,
+        ).toBe(true);
+        expect(
+          clears(colliders, cacheX, cacheZ),
+          `cache clears walls seed ${s} base ${baseLevel} @${cacheX},${cacheZ}`,
+        ).toBe(true);
       }
     }
   });

--- a/tests/rift_rank_tuning.test.ts
+++ b/tests/rift_rank_tuning.test.ts
@@ -622,3 +622,162 @@ describe('rift exit: the way home is never anchored in water', () => {
     expect(isInWaterBody(inst.returnPos.x, inst.returnPos.z), 'return point is dry').toBe(false);
   });
 });
+
+// ---- Walk-in throttle pins ---------------------------------------------------
+// These pin the rate-limit behavior of the four repeating messages that fire on
+// the 20 Hz walk-in path without a throttle. Counting emitted messages over a
+// fixed tick window proves they stay within the cooldown cadence.
+
+describe('rift throttle: pool-full error fires at most once per cooldown window', () => {
+  it('standing in a full-pool portal emits the error once per 4 s, not every call', () => {
+    const sim = makeSim();
+    // Fill every rift slot so no free slot exists.
+    for (const inst of sim.riftInstances) {
+      inst.partyKey = 'party:occupied';
+    }
+    // A fake portal entity carrying the fields enterRift's portal-gate checks read.
+    const fakePortal = {
+      id: 9999,
+      riftSeed: SEED,
+      riftBaseLevel: 20,
+      pos: { x: 0, y: 0, z: 0 },
+    } as unknown as import('../src/sim/types').Entity;
+    sim.player.level = 20;
+    const drainPoolFull = (): number => {
+      sim.enterRift(SEED, 20, sim.player.id, undefined, fakePortal);
+      return (sim as unknown as { drainEvents(): import('../src/sim/types').SimEvent[] })
+        .drainEvents()
+        .filter(
+          (ev) =>
+            ev.type === 'error' &&
+            (ev as { text: string }).text === 'All rifts are unstable right now. Try again soon.',
+        ).length;
+    };
+    // First call: one error.
+    expect(drainPoolFull(), 'first call emits the error').toBe(1);
+    // Immediate re-call: silenced by cooldown.
+    expect(drainPoolFull(), 'immediate re-call is silenced').toBe(0);
+    // After 100 ticks (> 4 s), the cooldown has elapsed: one more error.
+    tickAlive(sim, 100);
+    expect(drainPoolFull(), 'error fires again after cooldown').toBe(1);
+  });
+});
+
+describe('rift throttle: level-denial error fires at most once per 4 s', () => {
+  it('low-level player re-entering a portal sees the denial once per cooldown', () => {
+    const sim = makeSim();
+    const fakePortal = {
+      id: 9998,
+      riftSeed: SEED,
+      riftBaseLevel: 20,
+      pos: { x: 0, y: 0, z: 0 },
+    } as unknown as import('../src/sim/types').Entity;
+    sim.player.level = 1;
+    const deny = 'Only adventurers of level 20 or higher may enter this rift.';
+    const drainDeny = (): number => {
+      sim.enterRift(SEED, 20, sim.player.id, undefined, fakePortal);
+      return (sim as unknown as { drainEvents(): import('../src/sim/types').SimEvent[] })
+        .drainEvents()
+        .filter((ev) => ev.type === 'error' && (ev as { text: string }).text === deny).length;
+    };
+    expect(drainDeny(), 'first call emits the denial').toBe(1);
+    expect(drainDeny(), 'immediate re-call is silenced').toBe(0);
+    tickAlive(sim, 100);
+    expect(drainDeny(), 'denial fires again after 4 s cooldown').toBe(1);
+  });
+});
+
+describe('rift throttle: orb-notice fires at most once per 6 s cooldown', () => {
+  it('standing at a dormant Blood Orb nudges at most once per 6 s, not every tick', () => {
+    let setPieceSeed = -1;
+    for (let s = 1; s < 400 && setPieceSeed < 0; s++) {
+      if (isSetPieceSeed(s)) setPieceSeed = s;
+    }
+    expect(setPieceSeed, 'found a set-piece seed').toBeGreaterThan(0);
+    const sim = makeSim(setPieceSeed);
+    sim.enterRift(setPieceSeed, 20, sim.player.id);
+    const inst = active(sim);
+    expect(inst.orbId, 'authored floor has an orb').not.toBeNull();
+    const orb = sim.entities.get(inst.orbId!)!;
+    sim.player.gm = true;
+    const countOrb = (ticks: number): number => {
+      let n = 0;
+      for (let i = 0; i < ticks; i++) {
+        sim.player.pos = { ...orb.pos };
+        sim.player.prevPos = { ...sim.player.pos };
+        sim.player.hp = sim.player.maxHp;
+        for (const ev of sim.tick()) {
+          if (
+            ev.type === 'log' &&
+            (ev as { text?: string }).text === 'The orb is sealed by the ritual below.'
+          )
+            n++;
+        }
+      }
+      return n;
+    };
+    // 120 ticks = 6 s: one nudge on arrival, then silence for the rest.
+    expect(countOrb(120), 'one nudge per 6 s window').toBe(1);
+    expect(countOrb(120), 'one more nudge in the next window').toBe(1);
+  });
+});
+
+describe('rift throttle: seq-reset notice is instance-level, not per-player', () => {
+  it('two party members standing on a wrong rune produce one broadcast per window', () => {
+    let seqSeed = -1;
+    for (let s = 1; s < 800 && seqSeed < 0; s++) {
+      const f = generateRiftFloor(s, 20, 0);
+      if (
+        !f.isBoss &&
+        f.puzzle.kind === 'sequence' &&
+        f.objects.filter((o) => o.kind === 'seq_rune').length >= 2
+      )
+        seqSeed = s;
+    }
+    expect(seqSeed, 'found a multi-rune sequence floor').toBeGreaterThan(0);
+    const sim = makeSim(seqSeed);
+    sim.player.level = 20;
+    // Add a second player and form a party with the primary.
+    const pid2 = sim.addPlayer('warrior', 'P2', { autoEquip: true });
+    const p2 = sim.entities.get(pid2)!;
+    p2.level = 20;
+    sim.partyInvite(pid2, sim.player.id);
+    sim.partyAccept(pid2);
+    // Both enter the rift (they share the same instance because they are in a party).
+    sim.enterRift(seqSeed, 20, sim.player.id);
+    sim.enterRift(seqSeed, 20, pid2);
+    const inst = active(sim);
+    killTrash(sim);
+    sim.player.gm = true;
+    p2.gm = true;
+    // Both stand on the SECOND rune (wrong: the sequence requires rune 0 first).
+    const wrongRune = sim.entities.get(inst.seqRuneIds[1])!;
+    const countNotices = (ticks: number): number => {
+      let n = 0;
+      for (let i = 0; i < ticks; i++) {
+        sim.player.pos = { ...wrongRune.pos };
+        sim.player.prevPos = { ...sim.player.pos };
+        p2.pos = { ...wrongRune.pos };
+        p2.prevPos = { ...p2.pos };
+        sim.player.hp = sim.player.maxHp;
+        p2.hp = p2.maxHp;
+        for (const ev of sim.tick()) {
+          if (
+            ev.type === 'log' &&
+            (ev as { text?: string }).text === 'The runes go dark. Begin again.'
+          )
+            n++;
+        }
+      }
+      return n;
+    };
+    // The instance-level stamp means exactly ONE broadcast fires per 4 s window.
+    // Each broadcast sends the log to every member: 2 players = 2 log events.
+    // With the old per-player stamp, BOTH players would trigger a broadcast on the
+    // same tick = up to 4 log events in the first tick (2 players x 2 recipients).
+    const first80 = countNotices(80);
+    expect(first80, 'one broadcast per window (2 recipients)').toBe(2);
+    const next80 = countNotices(80);
+    expect(next80, 'one broadcast in the next window').toBe(2);
+  });
+});


### PR DESCRIPTION
Part of the playtest feedback round on PR #1584 (rifts): close the remaining interactable spam paths and harden objective placement pins.

## Rate limits (the established stamp idiom, ctx.time based)

- Pool-full portal walk-in error ("All rifts are unstable right now"): was re-emitted at 20 Hz to a player standing in the portal radius; now once per 4s per player (POOL_FULL_NOTICE_COOLDOWN). The already-cleared error on the same path gets the same stamp defensively.
- Wrong-sequence rune reset notice: stamp moved from per-player to instance-level, so a party standing on wrong runes produces one notice per window instead of one per member. The progress-wipe bypass (a real reset always announces) is unchanged and pinned.
- Lockpick cache offer: short per-player cooldown on the click-bounded lockpickOffer emit.
- The two previously-implemented-but-unpinned throttles (4s level denial, 6s dormant-orb notice) now have repeat-counting tests.

## Placement hardening

- The per-kind clearance table (PROP_R) now lists every objective kind explicitly; the newly-listed kinds keep body radius 0.6 with a documented justification: they are spawned on the always-clear center spine or inside the obstacle-free aisle band, so wall clearance is guaranteed by construction (the visual-footprint radii live in the generator's placement strategy, not the sweep).
- Placement sweep extended to all four rank base levels (20/22/25/28; was baseLevel 15 only).
- New pins for the two runtime-spawned objects that had none: the Sealed Rift Cache (chest.x - 4) and the exit-portal fallback (dais.z + 6), swept across 60 seeds x 4 ranks for room containment and wall clearance.

## Notes

- No generator changes: the rift floor digest is untouched.
- Surgical diffs in runs.ts by design (a sibling branch edits other regions of the same file).
- All touched suites green, tsc clean. Residual: the runtime placement test mirrors the openExit position math; if that math moves in runs.ts the test copy must move with it.