### PR TITLE
docs(professions-2): the 2026-07-20 mastery and provenance amendments (phases 12c and 12d)

### DIFF
--- a/docs/professions-2/README.md
+++ b/docs/professions-2/README.md
@@ -51,6 +51,8 @@ starter prompt.
 | 11 | [Fishing joins the framework](phase-11-fishing.md) | [QA](phase-11-qa.md) |
 | 12 | [Base tool tier gating](phase-12-tool-gating.md) | [QA](phase-12-qa.md) |
 | 12b | [Gathering rhythm](phase-12b-gathering-rhythm.md) | [QA](phase-12b-qa.md) |
+| 12c | [The Mastery Curve](phase-12c-mastery-curve.md) | [QA](phase-12c-qa.md) |
+| 12d | [Provenance and the harvest loop](phase-12d-provenance-stacking.md) | [QA](phase-12d-qa.md) |
 | 13 | [Enchanting reachable](phase-13-enchanting.md) | [QA](phase-13-qa.md) |
 | 14 | [Attunement quests and nudges](phase-14-attunement-quests.md) | [QA](phase-14-qa.md) |
 | 14b | [Commissions and the Maker's Bond](phase-14b-commissions-binding.md) | [QA](phase-14b-qa.md) |
@@ -72,5 +74,7 @@ tracked on epic #1866, not in this packet; salvage wiring moved INTO
 Phase 13 by the 2026-07-17 design-review amendments recorded in state.md,
 and the 2026-07-20 timing and economy amendments inserted Phases 12b
 (Gathering rhythm) and 14b (Commissions and the Maker's Bond) without
-renumbering; the state.md amendments block is the authority for both
-passes.
+renumbering; the SECOND 2026-07-20 block (mastery and provenance)
+inserted Phases 12c (The Mastery Curve) and 12d (Provenance and the
+harvest loop) after the 12b QA; the state.md amendments blocks are the
+authority for all three passes.

--- a/docs/professions-2/implementation-plan.md
+++ b/docs/professions-2/implementation-plan.md
@@ -101,8 +101,10 @@ landed. Therefore every UI phase in this packet:
 
 Phases 1 to 7 are the fun kernel; 8 to 15 are wave one (the 2026-07-20
 timing and economy amendments inserted Phases 12b and 14b without
-renumbering; the remaining order is 12, 12b, 13, 14, 14b, 15, and the
-state.md amendments block is the authority for their rulings). End of Phase 7 is
+renumbering, and the SECOND 2026-07-20 block, mastery and provenance,
+inserted 12c and 12d after the 12b QA; the remaining order is 12c, 12d,
+13, 14, 14b, 15, and the state.md amendments blocks are the authority for
+their rulings). End of Phase 7 is
 the vertical-slice checkpoint (see README). Phase 6 depends on Phases 2 and
 4, not on Phase 5, and may run ahead of the wheel window if the
 design-language rollout stalls Phase 5. The 2026-07-17 design-review
@@ -128,6 +130,8 @@ Phase 1.
 | 11 | Fishing joins the framework | Fishing proficiency + catch rarity ladder feeding cooking | sim, content, ui |
 | 12 | Base tool tier gating | Node tiers; tool tier + skill gates; tools matter; effects stay parked | sim, content, tests |
 | 12b | Gathering rhythm | Gather cast scaled by tool tier and band; the fishing bite minigame with rod synergy; placeholder cues; the pin-cost appendix | sim, ui, tests |
+| 12c | The Mastery Curve | The four-state curve replaces the free floor; enforced per-profession caps as content data; the one-time skill reset with its keep ledger; the shared action throttle; quality-tiered enchanting gains | sim, content, ui, tests |
+| 12d | Provenance and the harvest loop | Identical-payload material stacking (bags and bank); Gathered by copy, bag marker, downgrade notice; one interact loots AND harvests with a decoupled corpse lifecycle; mail attachment expiry; #2139 and the rename signer sweep | sim, ui, server, tests |
 | 13 | Enchanting reachable | Disenchant, enchant-apply, and salvage on IWorld/wire/UI in both hosts; typed reagents with same-phase consumers; the bind-on-trade primitive | world_api, net, server, ui, content |
 | 14 | Attunement quests and nudges | Lore quests, work orders, and tier mail at the masters; nudges; celebration; the learnable-at-a-master hint | content, sim, ui |
 | 14b | Commissions and the Maker's Bond | Opt-in commission crafts bind on first trade; master unbind gold sink; resolves #1298 semantics | sim, world_api, net, server, ui |

--- a/docs/professions-2/phase-12c-mastery-curve.md
+++ b/docs/professions-2/phase-12c-mastery-curve.md
@@ -1,0 +1,312 @@
+# Phase 12c: The Mastery Curve
+
+Profession pacing becomes real. Today the sim has NO skill cap anywhere (300 is a display
+constant in `professions_view.ts` plus display-only `maxSkill` content rows), and the tier-0
+"free floor" in `tierProgressMultiplier` grants full gain on the cheapest recipes forever, so a
+player can spam any skillReq-0 recipe from 0 to 300 in about 30 minutes of throttled crafting;
+fishing caps in about 35. Live community reports confirm both halves: players are asking
+whether common recipes are the intended path to 300, and a dormant craft shows the inverted
+display where the basic recipe reads Full skill gain while every higher recipe reads No skill
+gain. The locked pacing ruling ("fast early, slow top; scarcity, materials and adventure, is
+the clock") finally gets its mechanism: the four-state gray-out curve, enforced per-profession
+caps as content data, and a ONE-TIME reset of skill values earned under the placeholder rules,
+keeping everything players own and know.
+
+Approved by the 2026-07-20 mastery and provenance amendments (state.md is the authority; every
+number below is a maintainer-approved number recorded there). Tracked as issue #2235. This
+phase must land BEFORE Phase 13: enchanting inherits the throttle scope and the quality-tiered
+gain model on its first reachable day, so nothing ships fast and gets nerfed later. The curve,
+the caps, and the reset ship in the SAME deploy: nobody levels under the new curve and then
+gets reset, and nobody resets into the old curve.
+
+## Context pointers
+
+- `docs/professions-2/state.md`: the 2026-07-20 mastery and provenance amendments block (the
+  authority), the updated Tuning targets (curve constants, caps, time-to-master targets), and
+  the resolved OPEN items this phase implements (q_prof_hobby_switch xpReward 0).
+- `docs/professions-2/progress.md`: phase status and the phase-start commit record.
+- `docs/professions-2/implementation-plan.md`: team workflow and the review dispatch matrix.
+- `src/sim/professions/wheel.ts`: `gainCraftSkill` (additive-only, unclamped: the craft-side
+  clamp choke point), `tierForSkill`, `tierProgressMultiplier` (the free floor to retire:
+  `recipeTier <= 0` returns 1 unconditionally), `REDUCED_TIER_MULTIPLIER`,
+  `normalizeCraftSkills` (accepts any finite value: the load-side clamp and reset site).
+- `src/sim/professions/archetype.ts`: `craftSkillGainMultiplier` (the ONE gain composition,
+  consumed by crafting.ts AND the crafting view, so the difficulty label cannot diverge) and
+  `archetypeCeilingFor` (majors unlimited, hobby and pre-archetype rare, dormant common).
+- `src/sim/professions/gathering.ts`: `queueGatheringGrant` / `drainGatheringGrants` (the
+  gathering gain path: flat 1 per harvest today, `Math.max(0, current + amount)`, never reads
+  maxSkill) and `normalizeGatheringProficiency` (the second load-side site, including the
+  legacy `professions` fallback shape).
+- `src/sim/professions/fishing.ts`: the per-catch grant and `fishingBandFor` over the shared
+  `proficiency_bands.ts` thresholds.
+- `src/sim/professions/crafting.ts`: `CRAFT_SKILL_GAIN`, the craft throttle
+  (`CRAFT_THROTTLE_WINDOW_SECONDS` / `CRAFT_THROTTLE_MAX_PER_WINDOW` in
+  `src/sim/content/professions.ts`, enforced in the resolve path): the window the enchanting
+  and salvage actions join.
+- `src/sim/professions/enchanting.ts` and `salvage.ts`: `ENCHANTING_SKILL_GAIN` (flat 1,
+  unmultiplied, no throttle today) and the salvage resolver; sim-complete, unwired until
+  Phase 13, which is exactly why the pacing machinery lands NOW.
+- `src/sim/professions/battlefield_xp.ts`: `BATTLEFIELD_XP_TRICKLE` gains through
+  `gainCraftSkill`, so the cap clamp covers it automatically; observe, do not retune.
+- `src/sim/content/professions.ts`: the four gathering `maxSkill: 300` display rows that
+  become enforced per-profession cap data (and the craft-side rows this phase adds).
+- `src/sim/sim.ts`: `CharacterState` (craftSkills, gatheringProficiency, the persisted
+  one-shot flag idiom: `recipesGrandfathered` in `src/sim/professions/training.ts` and the
+  `guildLetterSent` mailWelcomed shape are the precedents).
+- `src/sim/professions/guild_letter.ts` and `src/sim/content/letters.ts`: the authored-letter
+  infrastructure the reset notice letter rides (`mailAuthoredLetter` SimContext callback;
+  letters register in TWO ui registries with a coverage count pin, see the Phase 7 entry).
+- `src/ui/professions_view.ts`: `CRAFT_MAX_SKILL`, `buildSkillBar`, `craftNextUnlock` (the
+  unreachable-carrot state to fix: it returns the max state only at 300 today).
+- `src/ui/crafting_view.ts`: `CraftDifficulty` (three states today; becomes the four classic
+  states from the SAME shared multiplier).
+- Pins this phase re-points (full list in the Pin-cost appendix): tests/professions_view.test.ts,
+  tests/professions_skill.test.ts, tests/archetype_ceiling.test.ts, tests/crafting_view.test.ts,
+  the maxSkill fixture files, and the parity goldens whose digests carry skill values.
+
+## Starter Prompt
+
+```
+This is Phase 12c of the Professions 2.0 feature: The Mastery Curve.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: replace the free floor with the four-state gray-out curve, enforce per-profession skill
+caps as content data, extend the craft throttle to enchanting and salvage, make enchanting
+gains quality-tiered with a soft ceiling, and run the one-time skill reset, all in one deploy.
+
+STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
+- Run git status; the tree must be clean; stop if dirty with work you did not create.
+- Memory scan (MEMORY.md index): node25-breaks-jsdom-gate (gate under Node 24),
+  combo-recipes-broken-online (the #2033 stub trap), i18n-semantic-regressions-gate-trap
+  (reworded prose re-pins), the professions packet entries.
+- Record the phase-start commit in docs/professions-2/progress.md Notes.
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly): spawn one Explore agent to read
+and summarize: docs/professions-2/state.md (the mastery amendments block and the updated
+Tuning targets), docs/professions-2/progress.md, this phase file, src/sim/professions/wheel.ts,
+archetype.ts (craftSkillGainMultiplier + archetypeCeilingFor), gathering.ts (grant drain +
+normalize + the node-tier data), fishing.ts, crafting.ts (gain + throttle), enchanting.ts,
+salvage.ts, battlefield_xp.ts, content/professions.ts (maxSkill rows, throttle constants),
+the CharacterState persistence and one-shot flag idiom in sim.ts and training.ts
+(recipesGrandfathered) and guild_letter.ts (guildLetterSent, mailAuthoredLetter),
+src/ui/professions_view.ts and crafting_view.ts, and the CLAUDE.md files for src/sim/,
+src/sim/professions/, src/ui/, and tests/. The summary must return: every call site of
+gainCraftSkill and queueGatheringGrant; the exact throttle mechanism and its constants; the
+one-shot flag idiom end to end (persist, normalize, serialize); the authored-letter
+registration recipe including both ui registries and the count pin; and the full list of
+tests pinning 300, maxSkill fixtures, gain values, or the three-state difficulty.
+
+STEP 2 - EXECUTE. Suggested slices (sim curve, caps + reset, throttle + enchanting, ui),
+sequential or lightly parallel; the sim curve slice lands first since everything reads it.
+
+Slice A, the curve:
+- tierProgressMultiplier becomes the four-state curve for EVERY recipe tier INCLUDING 0:
+  full (1.0) at or above capability, REDUCED_TIER_MULTIPLIER (0.5) one tier below,
+  a new MINIMAL_TIER_MULTIPLIER (0.25) two below, zero three or more below. The free-floor
+  early return is deleted; the function comment re-teaches the classic
+  orange/yellow/green/gray reading. Deterministic fractional gains; NEVER a skill-up roll
+  (a roll would insert an Rng draw into every craft and re-roll every golden; see the
+  determinism stopping rule).
+- craftSkillGainMultiplier composes unchanged (archetype ceiling zero for above-ceiling
+  recipes stays EXACTLY as is for crafting); the dormant/hobby/major identity outcomes
+  this produces are the approved design (dormant plateaus on commons, hobby reaches about
+  100 with a green crawl to cap, majors master).
+- Gathering: per-harvest gain becomes node-tier-relative with the same four-state shape:
+  a node of tier T grants full gain while the player's proficiency is below the band that
+  tier is meant to carry, then decays by the same 1 / 0.5 / 0.25 / 0 ladder as proficiency
+  outgrows it, so t1 nodes gray out and Thornpeak t3 nodes are what finish mining, logging,
+  and herbalism (adventure is the clock). Fishing: per-catch gain becomes band-relative
+  and FRACTIONAL at the top (band-appropriate catches carry full value early, decaying so
+  that proficiency 200 is a thousands-of-catches journey; junk catches stop granting once
+  band 0 is outgrown). Exact fractions and boundaries are yours within these shapes; land
+  every one as a NAMED exported constant, pinned, beside the Phase 12b rhythm finals in
+  state.md Tuning targets.
+Slice B, caps and the reset:
+- Caps as content data: every profession record carries an enforced maxSkill: the nine
+  crafts and enchanting 125; mining, logging, herbalism 100; fishing 200 (the approved
+  numbers; they end where content ends and rise with future zones by data edit).
+- Clamp at ALL FOUR arms: gainCraftSkill (covers crafting, enchanting, battlefield
+  trickle), the gathering drain, normalizeCraftSkills, and normalizeGatheringProficiency
+  (including the legacy fallback shape). Missing any arm is a defect: divergent behavior
+  between crafting and gathering, or over-cap saves leaking through.
+- At cap, ACTIONS STILL WORK: crafts still resolve and still proc masterwork, harvests
+  still yield, catches still land; only skill gain stops. Pin this.
+- The ONE-TIME reset: at load-time normalize, a character without the new persisted
+  one-shot flag has BOTH maps (craftSkills, gatheringProficiency) zeroed and the flag set
+  (the recipesGrandfathered / mailWelcomed idiom exactly: optional CharacterState boolean,
+  normalize default, serialized unconditionally). Fires exactly once across relog,
+  reconnect, restart, and later deploys. NOTHING else changes: the keep list (all items,
+  bank, gold, tools, knownRecipes, recipesGrandfathered, attunements and switch history,
+  deeds and renown, character level and XP, quests, mail) is a LEDGER in this phase's
+  notes, one row each marked reset / kept / derived, and QA pins it row by row.
+- The reset notice: a one-time authored system letter through mailAuthoredLetter (the
+  Phase 7 infra: content row in letters.ts, BOTH ui letter registries, the coverage count
+  pin) telling the player what reset and what they keep. English only; the letter body is
+  entity-i18n content like every authored letter.
+- The re-crossing audit: enumerate EVERY observer of the two skill maps (deed triggers at
+  proficiency 100 and craft 75, celebrations, letters, anything threshold-keyed) and pin
+  that each no-ops on a SECOND crossing after reset: no duplicate deed grant, renown, or
+  mail. The deed system's already-earned check should make these silent no-ops; "should"
+  becomes a test here.
+- The staging rehearsal (release evidence, not CI): against a copy of the production
+  database, run the reset and diff every character blob before and after; assert the ONLY
+  deltas anywhere are the two zeroed maps plus the flag. Record the evidence in
+  progress.md Notes; the deploy does not ship without it.
+Slice C, throttle scope and enchanting:
+- The 10-per-60s craft throttle becomes a SHARED action window: crafting, disenchant,
+  enchant-apply, and salvage all draw from one budget (rename or wrap the existing
+  window seam; never a second parallel window). The enchanting/salvage arms are testable
+  now even though Phase 13 wires the commands.
+- Enchanting gains become quality-tiered with the SOFT ceiling: the effective gain tier is
+  min(the disenchanted item's quality tier or the applied enchant's tier, the archetype
+  ceiling), then the same four-state curve against the player's enchanting capability
+  tier. Rarer input always grants at least as much; an epic disenchant NEVER grants zero
+  merely for sitting above a pre-archetype ceiling (unlike crafting's hard above-ceiling
+  zero, which stays). ENCHANTING_SKILL_GAIN stops being a flat unmultiplied 1.
+- q_prof_hobby_switch xpReward becomes 0 (stays repeatable; the resolved OPEN item; the
+  quest's job is the switching service, not an XP faucet).
+- Battlefield trickle: no retune; verify the cap clamp covers it and record its relative
+  share under the new curve in the phase notes for the Phase 15 review.
+Slice D, UI and copy:
+- crafting_view difficulty becomes the FOUR classic states from the same shared
+  multiplier (full / reduced / minimal / none), colored orange / yellow / green / gray;
+  information-add, preset-identical.
+- professions_view: CRAFT_MAX_SKILL retires in favor of the per-profession content cap;
+  buildSkillBar and the pips derive from it; craftNextUnlock gains a cap-aware mastered
+  state ("Mastered, for now" copy) instead of advertising an unreachable next tier
+  forever; the gathering rows read their content caps (100 / 100 / 100 / 200).
+- Every new player string is an English-only t() key in the matching catalog module; any
+  new sim-emitted denial or notice is a text-free stable id plus matcher, and the S3 scan
+  list (tests/localization_fixes.test.ts) is extended for any new sim module in the same
+  change (this trap has fired on every sim extraction in packet history).
+- npm run wiki:content regenerated (guide freshness gate); the guide prose full rewrite
+  stays Phase 15, touch only what the curve makes factually false.
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Determinism: the curve and caps are pure arithmetic; ZERO new Rng draws anywhere. All
+  goldens stay byte-identical EXCEPT the ones the Pin-cost appendix names (skill values in
+  their digests shift under the new gain arithmetic).
+- One sim, three hosts: constants and curve live in src/sim/; both hosts read the same
+  content caps; the offline host needs nothing for the reset (characters do not persist
+  there) but must run the same curve.
+- Server authority: the reset, clamps, and gains resolve server-side online; the client
+  never decides.
+- IWorld: no new members expected (caps ride professionsState / content); if one becomes
+  necessary, facet + both worlds + parity pin in the same change.
+- i18n: English-only keys; stable ids + matchers for sim text; M16 handling per the house
+  rules; the reset letter follows the authored-letter recipe completely.
+- Prime directive: nothing breaks. The reset touches EXACTLY two maps and one flag; the
+  blob-diff rehearsal is the proof, not a claim.
+
+Out of scope (do NOT do in this phase):
+- Wiring enchanting/salvage commands to players (Phase 13 owns the seam; this phase lands
+  the pacing machinery they inherit).
+- The identical-signer stacking, provenance copy, unified loot-harvest, and mail expiry
+  work (Phase 12d).
+- Recipe or node content additions; deed additions (Phase 15); work orders (Phase 14).
+- Any masterwork constant change (the current constants are FINAL per the amendments; they
+  already harmonize with the 125 cap).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+- npx tsc --noEmit; npx vitest run tests/architecture.test.ts (sim purity + determinism).
+- The touched-suite sweep: tests/professions_skill.test.ts, tests/professions_view.test.ts,
+  tests/crafting_view.test.ts, tests/archetype_ceiling.test.ts,
+  tests/professions_crafting.test.ts, tests/professions_gathering.test.ts,
+  tests/professions_fishing.test.ts, tests/gathering_rhythm.test.ts,
+  tests/professions_enchanting.test.ts, plus every new suite (reset, clamps, re-crossing,
+  throttle scope).
+- Parity: npx vitest run tests/snapshots.test.ts tests/world_api_parity.test.ts; regen ONLY
+  the goldens the appendix names, each in its own reviewed commit.
+- i18n: npm run i18n:gen then npx vitest run tests/i18n_completeness.test.ts
+  tests/localization_fixes.test.ts.
+- npm run wiki:content + tests/guide.test.ts freshness.
+- npm run ci:changed; scoped biome on touched files.
+- Spawn review agents per the Review Dispatch Matrix (architecture-reviewer and
+  test-coverage-auditor always match here; migration-safety for the reset flag;
+  qa-checklist at the end). COVERAGE, not filtering; resume truncated agents.
+
+STEP 4 - COMMIT CADENCE (explicit paths, bodies, Conventional Commits):
+- feat(professions): the four-state mastery curve replaces the free floor
+- feat(professions): enforced per-profession skill caps as content data
+- feat(professions): the one-time skill reset with the keep ledger
+- feat(professions): shared action throttle and quality-tiered enchanting gains
+- feat(ui): four-state difficulty colors and the cap-aware mastered state
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] No recipe grants full gain forever: the free floor is gone; the four-state curve is
+      pinned at every boundary for crafting, gathering, fishing, and enchanting.
+- [ ] Every profession cap is enforced at gain time and load time; over-cap saves clamp
+      down; at cap, crafting still procs masterwork and harvests still yield.
+- [ ] The reset fires exactly once per character (relog, reconnect, restart, second deploy
+      all pinned); the keep/reset ledger is fully pinned; the blob-diff rehearsal evidence
+      is recorded.
+- [ ] Re-crossing any skill threshold after reset double-grants nothing.
+- [ ] Crafting, disenchant, enchant-apply, and salvage share one throttle window.
+- [ ] Enchanting gains are quality-tiered with the soft ceiling: rarer input never grants
+      less, and never zero above a pre-archetype ceiling.
+- [ ] q_prof_hobby_switch grants 0 XP and stays repeatable.
+- [ ] The reset notice letter arrives exactly once, through the authored-letter infra,
+      with both registries and the count pin updated.
+- [ ] The crafting window shows four difficulty states; the professions window shows the
+      real caps and the mastered state; no unreachable next-tier carrot remains.
+- [ ] Zero new Rng draws; goldens byte-identical outside the appendix list.
+- [ ] All validation rows green; every deliberate re-pin matches the Pin-cost appendix.
+
+STEP 6 - DOC UPDATES + MEMORY: update progress.md (status row, checklist, phase-start
+commit, the rehearsal evidence) and state.md (Current phase pointer; the New surfaces
+Phase 12c entry with the final constant names, the flag name, the letter id, the i18n
+namespaces; Tuning targets updated from placeholders to as-landed finals). Record genuine
+surprises to Claude Code memory.
+
+STEP 7 - FINAL RESPONSE FORMAT: phase status; files touched; validation results per
+command; review verdicts; deferrals; one line for the Phase 12c QA handoff naming the
+phase-start commit.
+
+STOPPING RULES:
+- Stop if any part of the design would require a new Rng draw in the sim (a skill-up
+  proc roll, a random reset order): the deterministic-fractions ruling is locked.
+- Stop if the reset would need to touch ANY state beyond the two skill maps and the flag.
+- Stop if a cap value would need to differ from the resolved numbers (125 / 100 / 200);
+  that is a state.md amendment, not an implementation choice.
+- Stop if the blob-diff rehearsal shows any unexplained delta; do not ship around it.
+```
+
+## Pin-cost appendix (inventoried 2026-07-20 against release/v0.29.0, 475f1e584)
+
+The CLOSED, pre-briefed list of deliberate re-pins and regens. Anything OUTSIDE this list
+that reds is a defect to fix, not a cost to absorb. Re-inventory this list if any later
+phase lands before 12c starts (the rule from the 12b appendix experience).
+
+- tests/professions_view.test.ts: the CRAFT_MAX_SKILL 300 literal, the 12-pip count, the
+  132/300 fill fraction, and the over-cap 450 saturation arms all re-pin to the
+  per-profession cap model (over-cap display saturation becomes impossible by
+  construction after the clamp; that arm becomes a clamp pin).
+- maxSkill: 300 fixture rows re-pin to the resolved caps in:
+  tests/professions_window_focus.test.ts, tests/professions_gathering.test.ts,
+  tests/professions_contracts.test.ts, tests/snapshots.test.ts,
+  tests/gathering_view.test.ts, tests/professions_fishing.test.ts.
+- tests/professions_skill.test.ts: the tierProgressMultiplier table re-pins from the
+  three-state to the four-state ladder (the tier-0 rows change value by design).
+- tests/crafting_view.test.ts: the CraftDifficulty three-state pins become four-state.
+- tests/archetype_ceiling.test.ts: unchanged for crafting (the hard ceiling stays); gains
+  arms for the enchanting soft-ceiling min() behavior.
+- tests/gathering_rhythm.test.ts and tests/professions_gathering.test.ts: gain-per-harvest
+  pins re-pin to the node-tier-relative values; the band constants themselves are
+  UNCHANGED (12b finals stand).
+- tests/professions_fishing.test.ts: accrual arms re-pin to the band-relative fractional
+  gains; the one-draw contract, bite constants, and table literals are UNCHANGED.
+- Parity goldens: professions_craft and professions_gather regenerate (their digests carry
+  craftSkills / gatheringProficiency values that shift under the new arithmetic); each
+  regen lands in its own reviewed commit with a byte-diff note. Every OTHER golden stays
+  byte-identical (zero new draws, zero new fields); a third regenerating golden is a
+  defect.
+- tests/profession_attunement_quests.test.ts: the q_prof_hobby_switch xpReward pin
+  re-pins to 0.
+- The letter registries' coverage count pin extends by one for the reset notice letter.
+- NEW suites this phase adds (not re-pins, listed for the QA twin): the reset one-shot
+  suite, the keep-ledger row pins, the re-crossing suite, the four-arm clamp suite, the
+  shared-throttle suite, and the enchanting soft-ceiling suite.

--- a/docs/professions-2/phase-12c-qa.md
+++ b/docs/professions-2/phase-12c-qa.md
@@ -1,0 +1,82 @@
+# Phase 12c QA: Verify The Mastery Curve
+
+Audits the Phase 12c diff: the four-state curve with the free floor gone, the enforced
+per-profession caps at all four clamp arms, the one-time reset with its keep ledger, the
+shared action throttle, the enchanting soft ceiling, and the pin-cost appendix discipline.
+
+## QA Starter Prompt
+
+```
+This is Phase 12c QA of the Professions 2.0 feature: verify The Mastery Curve.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: audit the Phase 12c diff for correctness, missing tests, determinism, three-host
+parity, i18n completeness, and the reset's perfection guarantee.
+
+STEP 0 - PRE-FLIGHT: run git status; the tree must be clean; stop if dirty with work you
+did not create. Memory scan (MEMORY.md index): node25-breaks-jsdom-gate (gate under
+Node 24), combo-recipes-broken-online (the #2033 stub trap), the professions packet
+entries, big-diff-reviewer-turn-budgets (hard tool budgets + report-first for every
+spawned reviewer).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly): spawn one Explore agent to
+read and summarize: docs/professions-2/state.md (the mastery amendments block and the
+as-landed Phase 12c surfaces entry), docs/professions-2/progress.md,
+docs/professions-2/phase-12c-mastery-curve.md including its Pin-cost appendix, and the
+output of git diff <phase-start>..HEAD (the phase-start commit is in progress.md). The
+summary must return: the deliverable groups and acceptance criteria; the actual constant
+names, flag name, and letter id that landed; every file the diff touched; the appendix
+list verbatim; and the validation rows for the change type.
+
+STEP 2 - QA AUDIT: spawn parallel agents, each given ONLY the Explore summary, each with
+a hard 30-tool-call budget and report-first framing:
+- Correctness agent: verify every acceptance criterion against real code; run the phase's
+  validation commands; exercise REAL behavior: level a craft through all four curve
+  states, hit a cap and keep crafting (masterwork still procs), load an over-cap save
+  (clamps), load a pre-reset save twice (reset fires once).
+- Reset-perfection agent: the keep/reset ledger row by row against the code; the one-shot
+  flag across relog, reconnect, restart, and a second normalize pass; the re-crossing
+  suite (deeds at proficiency 100 and craft 75, celebrations, letters: no double grant);
+  the blob-diff rehearsal evidence in progress.md (recorded, complete, zero unexplained
+  deltas); the legacy gatheringProficiency fallback shape resets correctly.
+- Curve and pacing agent: the four-state boundaries at every edge (24/25, 49/50, the
+  three-below zero), the archetype interplay (dormant plateaus on commons, hobby green
+  crawl, majors full), the gathering node-tier decay and fishing fractional gains against
+  the recorded constants, the shared throttle across all four action types (spam one,
+  starve the others), the enchanting soft ceiling min() arms (epic above pre-archetype
+  ceiling grants the ceiling rate, never zero, never less than a rare).
+- Pin-quality agent (test-coverage-auditor emphasis): every re-pin matches the appendix;
+  nothing outside the appendix was weakened; mutation-test the decisive new pins (flip a
+  clamp arm off, the suite must red; restore the free floor, the suite must red); the two
+  regenerated goldens are exactly the appendix's two.
+Also spawn review agents per the Review Dispatch Matrix (architecture-reviewer,
+migration-safety for the reset flag, test-coverage-auditor, qa-checklist). COVERAGE, not
+filtering; resume truncated agents.
+
+PHASE-SPECIFIC QA EMPHASIS (probe directly, not just by reading):
+- Determinism: assert ZERO new Rng draws (the draw-count pins and the untouched goldens
+  are the tooth); any golden regen beyond professions_craft and professions_gather is a
+  BLOCKING finding.
+- The offline host runs the same curve (no persistence there, so no reset arm; verify the
+  flag logic is inert for fresh characters and costs nothing).
+- i18n: the reset letter, the mastered-state copy, and the four difficulty labels are
+  English-only keys; any new sim module joined the S3 scan list; run the i18n rows.
+- The one-deploy rule: curve, caps, and reset are in this one diff; if any half was
+  deferred, stop and surface it (shipping them apart is a design violation, not a
+  scheduling choice).
+- Battlefield trickle share note recorded in the phase notes for Phase 15.
+
+STEP 3 - FIX: apply every BLOCKING and SHOULD-FIX finding test-first; rerun failed rows
+until green; commit with explicit paths, Conventional Commits with a body.
+
+STEP 4 - UPDATE DOCS + MEMORY: update progress.md with the QA row and verdict; correct
+state.md if the recorded Phase 12c surfaces drifted; append the QA post-inventory block
+to the phase file's appendix (the 12b precedent); record surprises to memory.
+
+STEP 5 - FINAL RESPONSE FORMAT: verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; findings by
+severity, fixed versus deferred; the deferral list with reasons; a one-line handoff to
+Phase 12d.
+
+STOPPING RULES: stop if a BLOCKING finding cannot be fixed without changing a locked
+decision or a resolved cap number in state.md; stop if the blob-diff rehearsal evidence
+is missing or shows unexplained deltas (the reset does not ship on vibes).
+```

--- a/docs/professions-2/phase-12d-provenance-stacking.md
+++ b/docs/professions-2/phase-12d-provenance-stacking.md
@@ -45,6 +45,33 @@ that also breaks the self-signed reagent discount and Battlefield Experience att
 - `src/sim/interaction.ts`: corpse loot and harvest resolution, the claim-once rule
   (`harvestClaimedBy`), the focus picker, town focus (the tfocus wire key), and the corpse
   despawn/respawn lifecycle this phase decouples.
+- VERIFIED MECHANICS (2026-07-20 read-only pass at the 12b QA tip; STEP 1 re-confirms at
+  the phase tip; symbols only per the anchor rule):
+  - The interact key never harvests: `interactKey` routes through `tryNearbyInteraction`
+    to `lootCorpse` only; harvest is reachable only through the loot window
+    (`LootWindowController.openCorpse`), which opens on BOTH click buttons and renders
+    Take All plus the component picker.
+  - The lifecycle coupling is real: a FULL loot runs `pruneCorpseLoot`, which empties the
+    corpse, flips `lootable` false, and clamps `corpseTimer` low, so the respawn gate in
+    the mob locomotion tick (`respawnTimer` elapsed AND (`corpseTimer` elapsed OR not
+    lootable)) fires fast, and BOTH harvest entry points close even when
+    `harvestClaimedBy` is still null: loot destroys harvestability. A harvest-only corpse
+    keeps `lootable` true, so respawn defers until `corpseTimer` runs out (bounded by
+    CORPSE_DURATION and the template respawnSeconds): the lingering-corpse report is
+    literally correct. A PARTIAL loot leaves the corpse lootable and harvestable.
+  - `harvestCorpse` touches only `harvestClaimedBy`, never loot state or timers; a
+    full-bags harvest denial returns WITHOUT consuming the claim.
+  - Town focus is not broken, it is illegible: authoritative `townFocus` can only be set
+    inside the town circle, is consumed passively inside `harvestCorpse`
+    (`applyFocusTierBonus` shifts tier by floor(points / 5) capped at +2, so under 5
+    points does nothing; `applyFocusBonus` adds 10 percent yield per point that rounding
+    can eat at low tiers), and the picker opens with an EMPTY selection: town focus is
+    neither a picker default nor an auto-selector today.
+  - Combined-press hazards for Slice C: the two resolvers have independent claim state
+    and DIFFERENT capacity gates (loot checks per slot via `canAddItem`; harvest reserves
+    max-tier quantity up front via `fitsAll`), so ordering decides starvation; and the
+    loot half's prune destroys the harvest target, so the harvest half must resolve
+    BEFORE, or atomically with, the loot prune.
 - `src/sim/mail/post_office.ts`: `MAIL_POSTAGE`, `MAIL_MAX_ATTACHMENTS`, and the
   expiresAt-Infinity-while-attachments-remain rule this phase replaces.
 - `server/characters.ts`: `rekeyMarketSeller` / `rekeyMailOwner`, the rename hooks the signer
@@ -83,18 +110,17 @@ STEP 0 - PRE-FLIGHT:
 
 STEP 1 - LOAD CONTEXT AND VERIFY THE LIFECYCLE (do NOT read planning docs directly): spawn
 one Explore agent to read and summarize: docs/professions-2/state.md (the provenance
-rulings), this phase file, src/sim/bags.ts, src/sim/bank.ts, the addItemInstance and
-removeItem paths in src/sim/sim.ts, src/sim/social/trade.ts, src/sim/interaction.ts and
-src/sim/professions/gathering.ts (the corpse loot/harvest resolvers, claim-once, the focus
-picker and town focus end to end), src/sim/mail/post_office.ts, server/characters.ts (the
-rename rekey hooks), src/ui/item_instance_tooltip.ts, and the CLAUDE.md files for sim,
-professions, ui, server, and tests. The summary MUST return, verified against code, the
-CORPSE LIFECYCLE STATE MACHINE: what removes a corpse (loot completion, timers), whether a
-looted corpse remains harvestable today, whether an unlooted-but-harvested corpse delays
-respawn, where despawn and respawn scheduling live, and what the town focus actually does
-and why a player would perceive it as not working. Record that state machine in this phase
-file's as-landed block BEFORE designing the unified flow; the community claims are
-symptoms, the code is the truth.
+rulings), this phase file INCLUDING its VERIFIED MECHANICS block, src/sim/bags.ts,
+src/sim/bank.ts, the addItemInstance and removeItem paths in src/sim/sim.ts,
+src/sim/social/trade.ts, src/sim/interaction.ts and src/sim/professions/gathering.ts (the
+corpse loot/harvest resolvers, claim-once, the focus picker and town focus end to end),
+src/sim/mail/post_office.ts, server/characters.ts (the rename rekey hooks),
+src/ui/item_instance_tooltip.ts, and the CLAUDE.md files for sim, professions, ui,
+server, and tests. The summary MUST RE-CONFIRM the VERIFIED MECHANICS block against the
+phase tip (the prune-on-full-loot arm, the respawn gate condition, the harvest-only
+deferral, the town-focus consumption sites, the empty picker pre-selection, and the two
+capacity-gate shapes); record any drift in the as-landed block BEFORE designing the
+unified flow. The community claims are symptoms; the code is the truth.
 
 STEP 2 - EXECUTE. Suggested slices: merge rule first (everything else composes with it),
 then provenance UI, then the unified interact, then mail, with the two bug fixes as their
@@ -132,14 +158,22 @@ Slice C, the unified interact:
   authoritative in both hosts; the claim-once rule and the hcb claim mirror are untouched.
 - Composition rule: a harvest denial (tool tier, capacity) NEVER blocks the loot half, and
   vice versa; each half reports its own outcome; capacity pre-checks run per half.
-- Lifecycle decoupling per the verified state machine: a looted corpse stays harvestable
-  until claimed or timed out; a harvested corpse loots normally; neither half strands the
-  corpse; respawn scheduling is explicitly NOT hostage to manual cleanup (if the verified
-  machine shows respawn gated on corpse removal, fix the gating; if it does not, pin the
-  actual behavior and correct the town-focus legibility instead).
-- Town focus: whatever the verification found, the player-visible behavior becomes
-  legible: the picker shows the active town focus as the default selection, and the
-  unified press uses it.
+- Ordering inside the unified press (from the verified hazards): the harvest half
+  resolves BEFORE, or atomically with, the loot half's prune (loot-first destroys the
+  harvest target); each half runs its own capacity gate (loot per-slot canAddItem,
+  harvest up-front fitsAll) and reports its own outcome, and a harvest denial leaves the
+  claim unconsumed exactly as today.
+- Lifecycle decoupling against the verified state machine: an UNCLAIMED fully-looted
+  corpse stays harvestable for a short grace window instead of closing both entry points
+  (the pruneCorpseLoot lootable flip and timer clamp must stop hiding an unclaimed
+  harvest); a harvest-only corpse no longer defers respawn for the full decay window
+  (the respawn gate stops treating a still-lootable-but-harvested corpse as
+  must-preserve once its loot is gone or claimed); neither half ever strands the corpse,
+  and respawn is never hostage to manual cleanup. Pin the resulting machine in full.
+- Town focus becomes legible: the picker opens with the active town focus PRE-SELECTED
+  (today it opens empty), the unified press uses that selection, and the sub-5-point
+  dead zone (tier shift is floor(points / 5)) plus the in-town-only setter get surfaced
+  in the focus UI copy so the passive bonus reads as real.
 Slice D, mail expiry:
 - Letters with attachments get a 30-day expiry (ticks-derived, never wall clock in sim
   logic) with ONE return-to-sender cycle before deletion; system-authored mail (the Guild

--- a/docs/professions-2/phase-12d-provenance-stacking.md
+++ b/docs/professions-2/phase-12d-provenance-stacking.md
@@ -1,0 +1,238 @@
+# Phase 12d: Provenance and the harvest loop
+
+Three community-confirmed pain points in the corpse-to-bag pipeline, fixed as one coherent
+phase. First, signed items confuse and punish: a gathered rare-roll item renders "Crafted by
+{name}" (one makersMark key serves every signer source), shows no marker in the bag grid, and
+never stacks, not with plain copies and not even with copies signed by the SAME player (no
+payload-equality compare exists anywhere), so high-proficiency gathering eats bag slots fast.
+Second, looting fights harvesting: the interact key takes gold and kill loot only, harvesting
+needs a per-corpse right-click and picker, players report the town focus not visibly working,
+a looted corpse becoming unharvestable, and harvested-but-unlooted corpses lingering. Third,
+the mailbox is a free infinite warehouse (30c posts three stacks, letters with attachments
+never expire), strictly better than the bank expansion ladder it hollows out.
+
+Approved by the 2026-07-20 mastery and provenance amendments (state.md is the authority).
+Tracked as issue #2236. Runs after Phase 12c and before Phase 13 (disenchanting mints a second
+instanced-item family, so the stacking and marker work must precede it). Two companion BUG
+fixes land with or ahead of this phase and are verified by it: #2139 (the corpse focus-harvest
+bag overflow: `fitsAll` counts stack top-up room while `addItemInstance` needs a fresh slot;
+the node-side twin was fixed in `harvestNode`, the reference policy) and the force-rename
+instance-signer sweep (`server/characters.ts` re-keys the market and mailbox on rename but
+never rewrites `ItemInstancePayload.signer` strings in character state: a moderation leak
+that also breaks the self-signed reagent discount and Battlefield Experience attribution).
+
+## Context pointers
+
+- `docs/professions-2/state.md`: the mastery and provenance amendments block (the authority)
+  and the Tuning targets mail-expiry row.
+- `docs/professions-2/progress.md`: phase status and the phase-start commit record.
+- `src/sim/bags.ts`: `stackSizeOf` (`UNSTACKED_KINDS`, `DEFAULT_STACK`), `addStacked` and
+  `countFit` (the #1165 never-merge-into-an-instanced-slot rule this phase relaxes for
+  byte-equal payloads), `canAddItem` / `fitsAll`.
+- `src/sim/sim.ts`: `Sim.addItemInstance` (always pushes a fresh count-1 slot today; the
+  third merge point) and `removeEnchantableItem` / the end-backward `removeItem` consumption
+  order every counted-stack change must keep correct.
+- `src/sim/bank.ts`: `moveBetweenContainers` (the instanced one-indivisible-unit arm; the
+  fourth merge point, so same-signer stacks merge on DEPOSIT too).
+- `src/sim/types.ts`: `ItemInstancePayload` (signer / charges / rolled / enchant / boundTo);
+  payload equality must treat EVERY field, so an enchanted or bound copy never merges with a
+  merely-signed one.
+- `src/sim/social/trade.ts`: instanced-copy re-grant (payload preserved); counted instanced
+  stacks must round-trip trade in both directions (extend the tests/trade.test.ts pins).
+- `src/sim/professions/gathering.ts`: `harvestNode` (the signed-grant loop and the full-bag
+  fallback to an UNSIGNED top-up, "the truncation contract wins over signing": the silent
+  downgrade this phase makes visible) and `resolveHarvest` (`isSignableMaterialRarity`).
+- `src/sim/interaction.ts`: corpse loot and harvest resolution, the claim-once rule
+  (`harvestClaimedBy`), the focus picker, town focus (the tfocus wire key), and the corpse
+  despawn/respawn lifecycle this phase decouples.
+- `src/sim/mail/post_office.ts`: `MAIL_POSTAGE`, `MAIL_MAX_ATTACHMENTS`, and the
+  expiresAt-Infinity-while-attachments-remain rule this phase replaces.
+- `server/characters.ts`: `rekeyMarketSeller` / `rekeyMailOwner`, the rename hooks the signer
+  sweep joins.
+- `src/ui/item_instance_tooltip.ts` (`instanceMakersMarkLine`) and
+  `src/ui/i18n.catalog/hud_chrome.ts` (`makersMark`): the one-key copy bug ("Crafted by" on
+  gathered items) and where the Gathered by variant lands.
+- `src/sim/professions/battlefield_xp.ts` and `crafting.ts`: the two live signer consumers
+  (attribution compares `instance.signer` to the observer name; the self-signed discount
+  counts own-signed instances); the rename sweep and any merge change must keep both correct.
+- The wire: instanced slots ride the inv payload; a counted instanced stack changes the
+  count-1 assumption, so tests/snapshots.test.ts and the trade/bank suites are in scope.
+
+## Starter Prompt
+
+```
+This is Phase 12d of the Professions 2.0 feature: Provenance and the harvest loop.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: identical-payload material stacking (bags and bank), honest provenance (Gathered by, a
+bag-grid marker, the downgrade notice), one interact press that loots AND harvests with a
+decoupled corpse lifecycle and a verified town focus, mail attachment expiry, and the two
+companion bug fixes.
+
+STEP 0 - PRE-FLIGHT:
+- Sync with the LATEST release branch FIRST: git fetch origin "+refs/heads/release/*:refs/remotes/origin/release/*"; pick
+  the newest by version sort (git branch -r --list "origin/release/*" | sort -V | tail -1). If this phase
+  starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
+  that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
+  before proceeding. Never base work on main or an older release branch than the newest.
+- Phase 12c must be LANDED (the reset and curve precede any inventory-shape change so the
+  blob-diff rehearsal baseline stays clean); verify its surfaces entry in state.md.
+- Run git status; the tree must be clean; stop if dirty with work you did not create.
+- Memory scan (MEMORY.md index): node25-breaks-jsdom-gate, combo-recipes-broken-online (the
+  #2033 stub trap), the professions packet entries.
+- Record the phase-start commit in docs/professions-2/progress.md Notes.
+
+STEP 1 - LOAD CONTEXT AND VERIFY THE LIFECYCLE (do NOT read planning docs directly): spawn
+one Explore agent to read and summarize: docs/professions-2/state.md (the provenance
+rulings), this phase file, src/sim/bags.ts, src/sim/bank.ts, the addItemInstance and
+removeItem paths in src/sim/sim.ts, src/sim/social/trade.ts, src/sim/interaction.ts and
+src/sim/professions/gathering.ts (the corpse loot/harvest resolvers, claim-once, the focus
+picker and town focus end to end), src/sim/mail/post_office.ts, server/characters.ts (the
+rename rekey hooks), src/ui/item_instance_tooltip.ts, and the CLAUDE.md files for sim,
+professions, ui, server, and tests. The summary MUST return, verified against code, the
+CORPSE LIFECYCLE STATE MACHINE: what removes a corpse (loot completion, timers), whether a
+looted corpse remains harvestable today, whether an unlooted-but-harvested corpse delays
+respawn, where despawn and respawn scheduling live, and what the town focus actually does
+and why a player would perceive it as not working. Record that state machine in this phase
+file's as-landed block BEFORE designing the unified flow; the community claims are
+symptoms, the code is the truth.
+
+STEP 2 - EXECUTE. Suggested slices: merge rule first (everything else composes with it),
+then provenance UI, then the unified interact, then mail, with the two bug fixes as their
+own commits (they may also land as standalone PRs ahead of the phase; verify rather than
+re-fix if so).
+
+Slice A, the identical-payload merge:
+- Two slots merge iff same itemId AND byte-equal instance payloads (every
+  ItemInstancePayload field participates; signer-only copies from the same gatherer merge,
+  a signed copy never merges with a plain one, an enchanted or boundTo copy never merges
+  with a merely-signed one) AND the stack cap holds. Equipment kinds (UNSTACKED_KINDS)
+  stay one-per-slot regardless.
+- All four merge points move together: countFit, addStacked, Sim.addItemInstance, and the
+  moveBetweenContainers bank arm (deposits merge same-payload stacks too, the maintainer's
+  explicit ask). The capacity pre-checks must model the merge identically or #2139-class
+  overflow bugs return.
+- The count-1-instanced-slot assumption dies here: audit EVERY consumer of instanced slots
+  (trade offer/remove/grant, removeItem end-backward consumption, enchant consumption,
+  bank moves, the wire inv encoding, save/load, vendor sell) for count handling. This is
+  the phase's riskiest edge: budget tests accordingly (partial-stack trades, splitting,
+  merging on both sides of a trade, wire round trips of counted instanced stacks).
+Slice B, provenance:
+- A "Gathered by {name}" i18n key beside makersMark; provenance resolved by item kind
+  (gathered material kinds read Gathered by; crafted outputs keep Crafted by; NO new
+  payload field, the eqi identity key and parity pins stay untouched).
+- A bag-grid marker on instanced slots (a slot-corner glyph or border; information-add,
+  preset-identical, works on mobile where the tooltip needs a long-press).
+- The full-bag signed-yield downgrade (harvestNode's unsigned fallback) emits a text-free
+  personal SimEvent rendered via a new hudChrome key ("the find was too big for your bags"
+  wording is yours); extend the S3 scan list if a new sim module appears.
+Slice C, the unified interact:
+- One interact press on an eligible corpse loots AND harvests: kill loot resolves as
+  today, then the harvest resolves using the player's focus selection with the town focus
+  as the default (the right-click picker remains for per-corpse overrides). Server
+  authoritative in both hosts; the claim-once rule and the hcb claim mirror are untouched.
+- Composition rule: a harvest denial (tool tier, capacity) NEVER blocks the loot half, and
+  vice versa; each half reports its own outcome; capacity pre-checks run per half.
+- Lifecycle decoupling per the verified state machine: a looted corpse stays harvestable
+  until claimed or timed out; a harvested corpse loots normally; neither half strands the
+  corpse; respawn scheduling is explicitly NOT hostage to manual cleanup (if the verified
+  machine shows respawn gated on corpse removal, fix the gating; if it does not, pin the
+  actual behavior and correct the town-focus legibility instead).
+- Town focus: whatever the verification found, the player-visible behavior becomes
+  legible: the picker shows the active town focus as the default selection, and the
+  unified press uses it.
+Slice D, mail expiry:
+- Letters with attachments get a 30-day expiry (ticks-derived, never wall clock in sim
+  logic) with ONE return-to-sender cycle before deletion; system-authored mail (the Guild
+  letters, the 12c reset notice, future work-order and tier mail) is exempt by
+  construction (the authored-letter class, not an id list). Existing mailed stockpiles
+  start their clock at the deploy, not retroactively expired.
+- The expiry sweep rides the existing PostOffice update cadence; escrowed attachments
+  return through the normal delivery path (a full mailbox holds the letter, never
+  destroys it).
+Companion fixes (own commits; verify-not-refix if the standalone PRs landed):
+- #2139: the corpse focus-harvest capacity pre-gate models signed instances as fresh
+  slots (the harvestNode policy is the reference).
+- The rename signer sweep: a force-rename (and sanctioned rename) rewrites signer strings
+  in the character's stored instances and live meta, beside rekeyMarketSeller and
+  rekeyMailOwner; the self-signed discount and battlefield attribution follow the new
+  name; old tooltips show the new name everywhere including eqi inspect.
+
+INVARIANTS THIS PHASE MUST KEEP:
+- Determinism: zero new Rng draws; the merge rule and lifecycle changes are pure
+  bookkeeping; goldens stay byte-identical except any the as-landed block pre-briefs.
+- Server authority: every merge, claim, grant, and expiry resolves server-side.
+- IWorld both worlds: any new read or event lands on a facet, live in BOTH hosts,
+  parity-pinned in the same change; the wire inv change round-trips counted instanced
+  stacks.
+- i18n: English-only keys; text-free stable-id events with matchers; the S3 scan list
+  extended for any new sim module.
+- Prime directive: nothing breaks. Plain-stack behavior, equipment slots, trade of
+  non-instanced goods, and market/mail instance refusals are byte-identical; existing
+  mailed attachments are never silently destroyed.
+
+Out of scope (do NOT do in this phase):
+- Market listing of instanced items (wave 2; the refusals stay).
+- Any change to what GETS signed (the rarity and rare-event rules stand).
+- Batch-loot or area-loot mechanics beyond the single-corpse unified press.
+- Per-corpse quantity or specimen-rate tuning (the gland-to-pristine ratio report is a
+  Phase 15 faucet-review row, recorded there).
+
+STEP 3 - VALIDATION + MULTI-AGENT REVIEW:
+- npx tsc --noEmit; npx vitest run tests/architecture.test.ts.
+- The inventory sweep: tests/bags.test.ts (or the bags suites found in STEP 1),
+  tests/bank.test.ts, tests/item_instance.test.ts, tests/trade.test.ts,
+  tests/snapshots.test.ts, tests/corpse_harvest_sim.test.ts,
+  tests/gather_rare_events.test.ts, tests/interactions.test.ts plus every new suite.
+- i18n rows: npm run i18n:gen then npx vitest run tests/i18n_completeness.test.ts
+  tests/localization_fixes.test.ts.
+- ui/render row: the mobile guard trio plus screenshots of the bag marker and the unified
+  loot toast (pr-screenshots skill) under docs/screenshots.
+- npm run ci:changed; scoped biome on touched files.
+- Spawn review agents per the Review Dispatch Matrix (architecture-reviewer,
+  cross-platform-sync for the wire change, privacy-security-review for the rename sweep,
+  frontend-seam-reviewer for the marker, qa-checklist). COVERAGE, not filtering.
+
+STEP 4 - COMMIT CADENCE (explicit paths, bodies, Conventional Commits):
+- feat(sim): identical-payload stacking across bags, bank, and trade
+- feat(ui): gathered-by provenance, the instanced-slot marker, the downgrade notice
+- feat(sim): one interact loots and harvests; the corpse lifecycle decoupled
+- feat(sim): mail attachment expiry with the return cycle
+- fix(sim): corpse focus-harvest capacity models signed instances (#2139)
+- fix(server): rename sweeps instance signer strings
+
+STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
+- [ ] Two same-signer gathered materials merge in bags and via bank deposit; a signed and
+      a plain copy still do not; enchanted and bound copies never merge with
+      merely-signed; equipment never stacks.
+- [ ] Counted instanced stacks round-trip trade (both directions), bank moves, save/load,
+      and the wire, payloads intact, both hosts.
+- [ ] Gathered signed items read Gathered by; crafted keep Crafted by; instanced slots
+      show the marker on desktop and mobile; the full-bag downgrade emits its notice.
+- [ ] One interact press grants kill loot AND the focused harvest; a denial of either
+      half never blocks the other; the picker still overrides per corpse; town focus is
+      the visible default.
+- [ ] The verified corpse lifecycle is recorded in the as-landed block and pinned: no
+      loot-then-cannot-harvest, no harvest-then-stranded-corpse, respawn never hostage to
+      manual cleanup.
+- [ ] Mail attachments expire per the model; the return cycle works; system mail never
+      expires; pre-existing mail starts its clock at deploy.
+- [ ] #2139 fixed and pinned at the exact overflow seed class; the rename sweep fixed and
+      pinned (market, mail, AND signer strings all follow a rename).
+- [ ] Zero new Rng draws; goldens byte-identical outside any pre-briefed list.
+- [ ] All validation rows green; screenshots committed.
+
+STEP 6 - DOC UPDATES + MEMORY: update progress.md (status row, checklist, phase-start
+commit) and state.md (New surfaces: the merge-rule symbols, the new keys and events, the
+expiry constants, the verified lifecycle summary; any rollback caveat for counted
+instanced stacks under old code, the mailWelcomed class). Record surprises to memory.
+
+STEP 7 - FINAL RESPONSE FORMAT: phase status; files touched; validation results; review
+verdicts; deferrals; one line for the Phase 12d QA handoff naming the phase-start commit.
+
+STOPPING RULES:
+- Stop if payload-equality merging cannot be made safe for any consumer of instanced
+  slots without redesigning that consumer; surface the consumer instead of forcing it.
+- Stop if the verified lifecycle contradicts this phase file's premises in a way that
+  changes the design (record the truth in the as-landed block and ask).
+- Stop if mail expiry would destroy any item without the return cycle having run.
+```

--- a/docs/professions-2/phase-12d-qa.md
+++ b/docs/professions-2/phase-12d-qa.md
@@ -1,0 +1,71 @@
+# Phase 12d QA: Verify Provenance and the harvest loop
+
+Audits the Phase 12d diff: the identical-payload merge at all four points, counted
+instanced stacks across every consumer, the provenance surfaces, the unified
+loot-and-harvest flow against the verified corpse lifecycle, mail expiry, and the two
+companion bug fixes.
+
+## QA Starter Prompt
+
+```
+This is Phase 12d QA of the Professions 2.0 feature: verify Provenance and the harvest
+loop.
+Model: Opus 4.8, xhigh effort. Harness: Claude Code.
+Goal: audit the Phase 12d diff for correctness, missing tests, determinism, three-host
+parity, i18n completeness, and inventory-integrity safety.
+
+STEP 0 - PRE-FLIGHT: run git status; the tree must be clean; stop if dirty with work you
+did not create. Memory scan (MEMORY.md index): node25-breaks-jsdom-gate, the professions
+packet entries, big-diff-reviewer-turn-budgets (hard tool budgets + report-first for
+every spawned reviewer).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly): spawn one Explore agent to
+read and summarize: docs/professions-2/state.md (the provenance rulings and the as-landed
+Phase 12d surfaces entry), docs/professions-2/progress.md,
+docs/professions-2/phase-12d-provenance-stacking.md including its as-landed lifecycle
+block, and git diff <phase-start>..HEAD. The summary must return: the deliverables and
+acceptance criteria, the merge-rule symbols as landed, the verified corpse lifecycle as
+recorded, every file touched, and the applicable validation rows.
+
+STEP 2 - QA AUDIT: spawn parallel agents, each given ONLY the Explore summary, each with
+a hard 30-tool-call budget and report-first framing:
+- Inventory-integrity agent (the hardest charter): hunt dupes and losses around counted
+  instanced stacks. Probe: partial-stack trades both directions; a trade where both sides
+  offer same-payload stacks; removeItem end-backward consumption across a mixed
+  plain/instanced inventory; enchant consumption from a counted stack; bank
+  deposit-merge and withdraw-split; vendor sell of a counted stack; save/load and wire
+  round trips; conservation must hold in every probe (count the items before and after).
+- Lifecycle agent: drive loot-then-harvest, harvest-then-loot, denial of each half
+  (tool tier, full bags), the town-focus default and picker override, claim races
+  between two players, and respawn timing against the pinned state machine; a corpse
+  that can strand or a respawn hostage to cleanup is BLOCKING.
+- Provenance agent: Gathered by versus Crafted by across every signer source (node
+  gather, corpse rare+, specimen, masterwork, enchant-carried); the marker on desktop
+  and mobile shots; the downgrade notice fires on the exact full-bag boundary and never
+  otherwise; the S3 guard.
+- Companion-fix agent: reproduce the pre-fix #2139 overflow seed class and prove it
+  fixed; force-rename a character with signed items everywhere (bags, bank, mail
+  escrow, trade-received copies, equipped eqi) and prove every signer string, the
+  self-signed discount, and battlefield attribution follow the new name.
+- Mail agent: expiry at exactly the boundary, the single return cycle, deletion only
+  after it, system-mail exemption by class (author a new system letter and prove it
+  never expires without touching an id list), pre-existing mail clocks starting at
+  deploy, and the full-mailbox return case.
+Also spawn review agents per the Review Dispatch Matrix (cross-platform-sync for the
+wire, privacy-security-review for the rename sweep, qa-checklist). COVERAGE, not
+filtering; resume truncated agents.
+
+STEP 3 - FIX: apply every BLOCKING and SHOULD-FIX finding test-first; rerun failed rows
+until green; commit with explicit paths, Conventional Commits with a body.
+
+STEP 4 - UPDATE DOCS + MEMORY: progress.md QA row and verdict; state.md drift
+corrections; append the QA post-inventory to the phase file's as-landed block; record
+surprises to memory.
+
+STEP 5 - FINAL RESPONSE FORMAT: verdict PASS / PASS-WITH-FOLLOWUPS / FAIL; findings by
+severity, fixed versus deferred; deferrals with reasons; a one-line handoff to Phase 13.
+
+STOPPING RULES: stop if any probe shows item duplication or loss (conservation is
+non-negotiable); stop if a fix would require re-opening a locked provenance ruling; stop
+if the tree is dirty with work you did not create.
+```

--- a/docs/professions-2/phase-13-enchanting.md
+++ b/docs/professions-2/phase-13-enchanting.md
@@ -17,6 +17,18 @@ at least one consumer recipe in the same phase (the wolf_fang no-dead-materials 
 bind-on-trade PRIMITIVE, landed here applied to those typed reagents as its first live consumer
 (never a dormant stub, the 2033 lesson) so Phase 14b can extend it to commissioned gear.
 
+The SECOND 2026-07-20 block (mastery and provenance; state.md is the authority) then settles
+this phase's pacing and its one flagged decision, and inserts Phases 12c and 12d ahead of it:
+- Phase 12c MUST land first: this phase inherits the shared action throttle (crafting,
+  disenchant, enchant-apply, and salvage draw from one 10-per-60s window) and the
+  quality-tiered soft-ceiling enchanting gain model already wired in the sim; this phase makes
+  the actions reachable, never re-invents their pacing.
+- The staves/wands typed-reagent bucket is RESOLVED: the WEAPON bucket, no cloth special case.
+- The typed-reagent yields are APPROVED numbers in state.md Tuning targets (dust 1 to 2,
+  essence 1 plus a secondary, exactly 1 shard per epic mapping the heroic faucet one to one).
+- Community draft PR #2134 (which wires disenchant end to end) is OUT of consideration by
+  maintainer ruling: do not absorb, rebase, or reconcile it; build on the packet's own seam.
+
 ## Context pointers
 
 - `docs/professions-2/state.md`: locked decisions, the validation matrix, and the key-surfaces row
@@ -68,6 +80,9 @@ the newest by version sort (git branch -r --list "origin/release/*" | sort -V | 
 starts a fresh branch or worktree, base it on that branch; if the feature branch already exists, merge
 that release branch into it NOW, resolve conflicts, and run the release-merge-audit skill on the merge
 before proceeding. Never base work on main or an older release branch than the newest.
+Phases 12c and 12d must be LANDED first (the second 2026-07-20 block): verify the shared
+action throttle seam and the enchanting soft-ceiling gain arm exist in the sim (grep the
+constants state.md's Phase 12c surfaces entry records); if absent, stop.
 Then run git status; the tree must be clean (a concurrent session may share this
 checkout); if it is dirty with work you did not create, stop and ask. Scan Claude Code memory
 (the MEMORY.md index) for: the node25 gate rule (run npm run gate under Node 24), combo recipes
@@ -117,11 +132,11 @@ Agent content deliverables (the 2026-07-20 typed-reagent amendments):
   quality; disenchanting a RARE OR ABOVE piece ADDITIONALLY yields one type-keyed secondary
   material. Armor keys off the existing ArmorType (cloth/leather/mail: three materials);
   weapons key off the sim-side weapon-kind taxonomy (WEAPON_TYPE_BY_ITEM /
-  ItemWeaponType), bucketed to a small material set (exact bucketing is yours EXCEPT
-  staves and wands, whose bucket assignment is a FLAGGED maintainer decision: surface it,
-  do not default it). Cooking and alchemy are deliberately excluded from the typed family
-  on both sides: their outputs never disenchant and their recipes are not the sanctioned
-  consumers.
+  ItemWeaponType), bucketed to a small material set (exact bucketing is yours; the
+  staves/wands assignment is RESOLVED per the 2026-07-20 mastery amendments: the WEAPON
+  bucket, no cloth special case). Cooking and alchemy are deliberately excluded from the
+  typed family on both sides: their outputs never disenchant and their recipes are not the
+  sanctioned consumers. Yields use the APPROVED numbers in state.md Tuning targets.
 - NO DEAD MATERIALS (the wolf_fang rule): every typed material ships WITH at least one
   consumer recipe in this same phase (enchanting recipes or deep-craft recipes consuming
   it); a typed material with zero consumers is a blocking review finding, not a follow-up.
@@ -228,8 +243,10 @@ STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
       universal ladder; sub-rare disenchants are byte-identical to today.
 - [ ] Every typed material has at least one consumer recipe in this phase, pinned by a
       referential test (the wolf_fang rule).
-- [ ] The staves/wands bucket assignment is surfaced as a flagged maintainer decision, not
-      defaulted.
+- [ ] Staves and wands disenchant in the WEAPON bucket per the resolved decision.
+- [ ] Disenchant, enchant-apply, and salvage draw from the Phase 12c shared throttle
+      window, and their gains run the quality-tiered soft-ceiling model (verify inherited
+      behavior end to end; do not re-implement it).
 - [ ] The bind-on-trade primitive is LIVE against the typed rare+ reagents: first trade
       stamps boundTo, a second trade is refused with a localized deny id, both hosts.
 - [ ] All validation rows above are green; the mobile screenshot is committed.

--- a/docs/professions-2/phase-13-qa.md
+++ b/docs/professions-2/phase-13-qa.md
@@ -69,8 +69,14 @@ PHASE-SPECIFIC QA EMPHASIS (probe these directly, not just by reading):
   armor type and at least one weapon per bucket; prove the hybrid split (secondary at rare+,
   none below) and that a sub-rare disenchant is byte-identical to pre-phase output. Run the
   no-dead-materials referential pin and mutation-check it (a typed material stripped of its
-  consumer must red). Confirm the staves/wands bucket was flagged to the maintainer, not
-  silently defaulted (check state.md OPEN items or the resolved decision row).
+  consumer must red). Confirm staves and wands landed in the WEAPON bucket per the
+  resolved decision (the 2026-07-20 mastery amendments; a cloth special case is a
+  finding), and that the yields match the APPROVED Tuning targets numbers.
+- Inherited pacing (the 2026-07-20 mastery amendments): spam disenchant against the
+  Phase 12c SHARED throttle window (crafting and disenchant starve each other; a second
+  parallel window is a finding); verify the quality-tiered soft-ceiling gains live on the
+  now-reachable actions (an epic disenchant above a pre-archetype ceiling grants the
+  ceiling rate, never zero); confirm nothing in this phase re-implemented pacing locally.
 - Bind-on-trade, probed live: trade a typed rare+ reagent to a second player (stamps
   boundTo), attempt the onward trade (refused, localized deny id, both hosts), and verify
   the enforcement arm is generic over the instance payload (Phase 14b extends it to gear:

--- a/docs/professions-2/phase-14-attunement-quests.md
+++ b/docs/professions-2/phase-14-attunement-quests.md
@@ -104,7 +104,7 @@ Agent content deliverables:
   cadence-capped craft-objective turn-in ("the master needs N of X") on QuestDef.repeatable
   plus the 2039 craft objective, consuming that master's craft materials: a recurring
   material sink with a face on it. Rewards use the RESOLVED formula in state.md Tuning
-  targets (the 2026-07-20 mastery amendments: coin = floor(0.5 * summed input vendor
+  targets (the 2026-07-20 mastery amendments: coin = floor(0.5 * summed input vendor SELL
   value) plus standard repeatable-quest XP for the level band; vendoring always pays more
   gold by construction, so the loop is never gold-optimal) and the cadence cap reuses the
   nudge cadence pattern so the loop can never become an unbounded XP or gold faucet (the

--- a/docs/professions-2/phase-14-attunement-quests.md
+++ b/docs/professions-2/phase-14-attunement-quests.md
@@ -103,11 +103,20 @@ Agent content deliverables:
 - One repeatable work-order quest per master (six total; the 2026-07-17 amendment): a
   cadence-capped craft-objective turn-in ("the master needs N of X") on QuestDef.repeatable
   plus the 2039 craft objective, consuming that master's craft materials: a recurring
-  material sink with a face on it. Rewards use the state.md work-order tuning target
-  (MAINTAINER numbers; stop and ask if they are still absent; never gold-positive against
-  the input vendor value) and the cadence cap reuses the nudge cadence pattern so the loop
-  can never become an unbounded XP or gold faucet (the q_prof_hobby_switch lesson in
-  state.md OPEN items).
+  material sink with a face on it. Rewards use the RESOLVED formula in state.md Tuning
+  targets (the 2026-07-20 mastery amendments: coin = floor(0.5 * summed input vendor
+  value) plus standard repeatable-quest XP for the level band; vendoring always pays more
+  gold by construction, so the loop is never gold-optimal) and the cadence cap reuses the
+  nudge cadence pattern so the loop can never become an unbounded XP or gold faucet (the
+  q_prof_hobby_switch lesson, resolved to 0 XP in Phase 12c).
+- Master voices (the 2026-07-20 mastery amendments; approved sketches, maintainer vetoes
+  wording in the PR review). Every quest, work order, and letter this phase writes speaks
+  in its master's voice: forgemistress_darva, a stern forge veteran, warm underneath,
+  praise earned not given; cook_marlow, jovial, feeds everyone, thinks in food metaphors;
+  weaver_ottilie, precise and quietly proud, measures twice; tinker_gizzel, manic
+  enthusiasm, tangents mid-sentence, loves volatile things slightly too much;
+  tanner_hesk, taciturn, few words, judges by hands not talk; alchemist_verane, an aloof
+  scholar with dry wit and exact warnings.
 
 Agent sim deliverables:
 - Switch cost wiring: the escalation formula resolves in the sim through the make-amends

--- a/docs/professions-2/phase-14-qa.md
+++ b/docs/professions-2/phase-14-qa.md
@@ -121,7 +121,14 @@ STOPPING RULES:
 - Work orders (the 2026-07-17 amendment): each master offers its repeatable work order; a
   loop of immediate re-turn-ins is BOUNDED by the cadence cap and never gold-positive
   against the input vendor value; the turn-in consumes the materials (a recurring sink,
-  not a faucet); probe the loop with a real repeated turn-in, not a formula read.
+  not a faucet); probe the loop with a real repeated turn-in, not a formula read. The
+  rewards implement the RESOLVED formula from state.md Tuning targets (the 2026-07-20
+  mastery amendments: coin = floor(0.5 * summed input vendor value) plus standard
+  repeatable XP); verify at least one order's arithmetic against real vendor values, and
+  verify vendoring the same materials pays strictly more.
+- Master voices (the 2026-07-20 mastery amendments): quest, work-order, and letter text
+  matches each master's approved voice sketch in the phase file; flag copy that reads
+  voice-neutral or swaps voices between masters.
 - Tier-crossing mail (the 2026-07-17 amendment): exactly one letter per tier per major
   craft, from the archetype's anchor master; re-crossings, hobby and dormant crossings,
   unattuned characters, and repeated loads deliver none.

--- a/docs/professions-2/phase-14-qa.md
+++ b/docs/professions-2/phase-14-qa.md
@@ -123,7 +123,7 @@ STOPPING RULES:
   against the input vendor value; the turn-in consumes the materials (a recurring sink,
   not a faucet); probe the loop with a real repeated turn-in, not a formula read. The
   rewards implement the RESOLVED formula from state.md Tuning targets (the 2026-07-20
-  mastery amendments: coin = floor(0.5 * summed input vendor value) plus standard
+  mastery amendments: coin = floor(0.5 * summed input vendor SELL value) plus standard
   repeatable XP); verify at least one order's arithmetic against real vendor values, and
   verify vendoring the same materials pays strictly more.
 - Master voices (the 2026-07-20 mastery amendments): quest, work-order, and letter text

--- a/docs/professions-2/phase-14b-commissions-binding.md
+++ b/docs/professions-2/phase-14b-commissions-binding.md
@@ -13,6 +13,12 @@ face-to-face by construction), and the masters already run gold-sink services. A
 2026-07-20 timing and economy amendments (state.md is the authority); tracked as issue #2207,
 which links #1298.
 
+The three flagged maintainer decisions are RESOLVED by the second 2026-07-20 block (mastery
+and provenance; the OPEN items rows carry the rationale): the Maker's Bond binds to the
+CHARACTER; opt-in item classes are equipment only (weapon, armor, held_offhand); the unbind
+fee is tier-scaled on the training-fee family (2500 / 10000 / 40000 copper by quality tier,
+clamp-to-last). STEP 0's gate is satisfied; implement exactly these.
+
 ## Context pointers
 
 - `docs/professions-2/state.md`: the 2026-07-20 timing and economy amendments block (the
@@ -60,10 +66,10 @@ STEP 0 - PRE-FLIGHT:
   docs/professions-2/progress.md Notes.
 - Memory scan (MEMORY.md index): node25-breaks-jsdom-gate, combo-recipes-broken-online (the
   2033 stub trap), design-language-program, the professions packet entries.
-- THE THREE FLAGGED MAINTAINER DECISIONS MUST BE RESOLVED IN STATE.MD BEFORE CODING:
-  character-vs-account binding, which item classes may opt in, and unbind pricing. If any is
-  still an OPEN item, stop and ask; never decide them silently (they are flagged, not
-  defaulted).
+- THE THREE MAINTAINER DECISIONS ARE RESOLVED (2026-07-20 mastery amendments; read the
+  state.md OPEN items rows verbatim): character binding, equipment-only opt-in classes,
+  the tier-scaled unbind fee ladder. Verify the rows still read RESOLVED; if any has been
+  reopened, stop and ask; never decide them silently.
 - Phase 13 must be LANDED (it owns the bind-on-trade primitive). Verify its trade-gate arm
   exists (grep the enforcement site it recorded in state.md); if absent, stop.
 

--- a/docs/professions-2/phase-14b-commissions-binding.md
+++ b/docs/professions-2/phase-14b-commissions-binding.md
@@ -22,7 +22,7 @@ clamp-to-last). STEP 0's gate is satisfied; implement exactly these.
 ## Context pointers
 
 - `docs/professions-2/state.md`: the 2026-07-20 timing and economy amendments block (the
-  authority), the OPEN items rows for this phase's three flagged maintainer decisions, and the
+  authority), the OPEN items rows RESOLVING this phase's three maintainer decisions, and the
   locked economy pillars (crafted below the raid floor; NPCs only sink gold).
 - `docs/professions-2/progress.md`: the Phase 14b status row and checklist.
 - `docs/professions-2/phase-13-enchanting.md`: the bind-on-trade PRIMITIVE this phase extends

--- a/docs/professions-2/phase-14b-qa.md
+++ b/docs/professions-2/phase-14b-qa.md
@@ -68,6 +68,11 @@ PHASE-SPECIFIC QA EMPHASIS:
 - The legacy silent soulbound drop must be behaviorally unchanged unless state.md records a
   deliberate decision otherwise.
 - Prime directive: non-commission trades are byte-identical to pre-phase behavior, pinned.
+- The three RESOLVED decisions (the 2026-07-20 mastery amendments) landed exactly as
+  recorded: the bond binds to the CHARACTER (not the account), only weapon / armor /
+  held_offhand kinds can opt in (probe a consumable and a material: the opt-in must be
+  impossible, not merely hidden), and the unbind fee ladder is 2500 / 10000 / 40000
+  copper by quality tier with clamp-to-last, charged exactly once.
 
 Multi-agent review dispatch: apply the Review Dispatch Matrix in
 docs/professions-2/implementation-plan.md over the phase diff (privacy-security-review

--- a/docs/professions-2/phase-15-deeds-polish.md
+++ b/docs/professions-2/phase-15-deeds-polish.md
@@ -12,6 +12,20 @@ the Phase 13 typed-reagent consumers. It is its own slice
 because every earlier phase must be landed before deeds can trigger on real behavior, tuning can
 be judged against the live system, and the wiki can tell the truth.
 
+The SECOND 2026-07-20 block (mastery and provenance; state.md is the authority) reshapes this
+phase in four ways. (1) Deeds grow: fishing gets its FIRST deed, prog_master_gatherer counts
+fishing, per-craft mastery deeds land at the RESOLVED caps (125 crafts, 100
+mining/logging/herbalism, 200 fishing; no record may reference 300), and the titles scheme is
+approved (Guildsworn, Masterwright, "Grandmaster {Craft}", Master Angler; wording veto in the
+PR review). (2) The tuning sheet SHRINKS: the masterwork constants, specialization perks, and
+rare-event cadence (one shared knob, no per-family split) are FINAL; the work-order formula,
+unbind ladder, typed-reagent yields, and training-fee extension are resolved in state.md
+Tuning targets; the discovery-credit item is closed; the 12c curve constants and time targets
+arrive already landed and pinned. (3) The faucet-vs-sink review gains three named rows: the
+market fee (#2156), the dust-vs-cheap-uncommon disenchant margin, and the live
+gland-to-pristine ratio report (about 250 plain glands per 5 pristine). (4) The wiki rewrite
+expands to the RuneScape-wiki bar as its OWN dedicated arm (see the guide agent below).
+
 ## Context pointers
 
 - `docs/professions-2/state.md`: locked decisions, the "Tuning targets" section (the numbers this
@@ -92,6 +106,15 @@ Agent deeds deliverables:
   Phase 12b bite moment (the col_glimmerfin credit lands on the reeled catch, so the deed
   banner follows the bite-and-reel beat rather than a silent timer; the scripted playthrough
   drives the bite flow, not a direct grant).
+- The mastery additions (the second 2026-07-20 block): fishing's FIRST deed; fix
+  prog_master_gatherer to count fishing (any 3 of 4 stays the accepted Phase 11 semantics
+  or tightens to all 4 by explicit maintainer choice in review, never silently); per-craft
+  mastery deeds at the RESOLVED caps carrying the approved titles ("Grandmaster {Craft}"
+  at craft 125, Master Angler at fishing 200); Guildsworn on first attunement and
+  Masterwright on first masterwork (these two carry the marquee-tier renown per the
+  2026-07-17 ruling). NO deed may reference skill 300; every threshold is a resolved cap
+  or below. All still cosmetic-only, append-only; deed triggers must no-op on re-crossings
+  after the Phase 12c reset (the 12c re-crossing suite is the precedent to extend).
 - Notability through the deeds pipeline (the 2026-07-17 ruling): first attunement and first
   masterwork carry TITLE rewards and marquee-tier renown (>= 25) so the existing pipeline
   fires in full: nameplate title, banner, fireworks gate, celebration sound,
@@ -106,19 +129,28 @@ Agent deeds deliverables:
 - A scripted playthrough test (Vitest driving the real Sim) that unlocks every new deed.
 
 Agent tuning deliverables:
-- Review masterwork proc bounds, training fees, teach tiers, work-order rewards, the
-  rare-event cadence, and the #1301 craft fee
-  and throttle against the state.md tuning targets, applying the maintainer's numbers. The
-  rare-event cadence review decides per FAMILY: the Phase 4 shared knob may split into
-  per-flavor cadences (vein, heartwood, bloom) with maintainer numbers if live data says
-  the families need different rhythms. If a
-  maintainer number is missing for any constant, stop and ask; never invent balance numbers.
+- Review the tuning sheet against state.md Tuning targets, applying the resolved numbers.
+  The second 2026-07-20 block settled most of it: the masterwork proc constants,
+  specialization perks, and rare-event cadence (ONE shared knob; the per-family split is
+  decided AGAINST for wave one) are FINAL and must not change; the work-order formula,
+  unbind ladder, typed-reagent yields, and the training-fee extension are resolved rows to
+  verify as-landed; the 12c curve constants, caps, and time-to-master targets arrive
+  already pinned. What remains live here: the #1301 craft fee and throttle values against
+  live data, and the time-to-master targets checked against real playthrough arithmetic
+  (materials included). If any remaining constant lacks a maintainer number, stop and ask;
+  never invent balance numbers.
 - Every constant is a NAMED export in its owning module; none inline at a call site. Pin each
   final value in the matching test.
 - Faucet-vs-sink review (the 2026-07-17 amendment): with live data, weigh the material and
   gold faucets (gathering, work-order rewards, quest gold) against the sinks (consumables,
   crafting inputs, salvage and disenchant destruction, the typed-reagent demand, training,
-  craft, and unbind fees) and record the balance with evidence in the phase notes.
+  craft, and unbind fees) and record the balance with evidence in the phase notes. Three
+  named rows from the second 2026-07-20 block: the market fee (#2156) under the higher
+  material volume the slower curve drives; the dust-vs-cheap-uncommon disenchant margin
+  (arbitrage should be a profession, not a printer; note it destroys items, so a generous
+  margin is tolerable); and the live gland-to-pristine ratio report (about 250 plain
+  glands per 5 pristine, about 8 full stacks: check the per-corpse quantity and the
+  specimen rate against how much plain volume the sinks can actually drink).
 - The legacy junk-recipe burn-down (the 2026-07-20 amendment): work through
   LEGACY_GOLD_POSITIVE_RECIPE_IDS (tests/recipe_economy.test.ts pins it three ways as a
   burn-down target) and CROSS-CHECK each candidate fix against the Phase 13 typed-reagent
@@ -126,13 +158,31 @@ Agent tuning deliverables:
   (the gold-positive violation and a no-dead-materials consumer), so prefer that shape where
   it fits before plain price nerfs. Maintainer numbers only; never invent balance values.
 
-Agent guide deliverables:
-- Rewrite the guide/wiki professions page (src/guide/pages/professions.ts) to describe the
-  SHIPPED system: archetypes and attunement, masterworks, stations and masters, training,
-  gathering and the rare events, fishing, enchanting reach, salvage, and the deeds. Recipe and station
-  data must feed the page from src/sim/ content, not hand-copied tables.
-- npm run wiki:content regenerated and the freshness gate (tests/guide.test.ts) green; any new
-  guide.* prose keys added English-only.
+Agent guide deliverables (EXPANDED to the RuneScape-wiki bar by the second 2026-07-20
+block; this is its own dedicated arm of the phase, sized accordingly):
+- The professions wiki becomes per-skill pages at genre-best detail, on one strategy:
+  GENERATE the tables, WRITE the understanding. Generated from src/sim/ content (never
+  hand-copied): full recipe tables per craft (name, skillReq, gain state at a glance,
+  materials, output, acquisition, station), gathering node lists per zone with tiers,
+  tool and rod ladders with vendor prices, band thresholds and what each band unlocks,
+  fishing tables per zone and band, and the deed list. Written prose, focused on
+  understanding: the wheel and archetype identity (majors, hobby, dormancy, make-amends),
+  attunement, the four-state Mastery Curve and its colors, the caps and the
+  more-with-new-zones promise, time-to-master expectations, provenance and signatures,
+  masterwork, the enchanting materials ladder, and the economy (market, what sells,
+  commissions once 14b lands). Page structure: one overview page, nine craft pages, four
+  gathering pages, an enchanting page, an economy page, and an FAQ seeded from the real
+  community questions (non-stacking signed items, common recipes and skill gain, loot
+  versus harvest).
+- TRANSPARENCY POLICY (resolved): publish the exact numbers, including skill
+  requirements, gain states, band thresholds, cap values, and rare-event odds; the repo
+  is public, so the wiki is the accurate source rather than a coy one. Narrative content
+  (quest stories, letter text) stays spoiler-light per the guide's existing rule.
+- i18n: every new guide.* prose key lands ENGLISH-ONLY; the locale fill is a release-time
+  batch by the maintainer. Land the guide-scoped M16 exemption alongside (the wordy-value
+  rule exists for HUD layout overflow; the guide is a document page, so scope the
+  exemption to guide.* keys, narrowly, with the gate change reviewed in this PR).
+- npm run wiki:content regenerated and the freshness gate (tests/guide.test.ts) green.
 - Final asset-manifest.json pass: append every id that shipped procedurally across the packet,
   with purpose, size, format, and replacement notes.
 
@@ -224,8 +274,17 @@ STEP 5 - ACCEPTANCE CRITERIA (do not mark complete until all check):
       playthrough (no direct-grant shortcut).
 - [ ] tests/deeds_content.test.ts pins the catalog append-only; all pre-packet deeds unchanged.
 - [ ] Every tuning constant is named, exported, pinned, and matches the maintainer's numbers.
-- [ ] The wiki professions page describes the shipped system; npm run wiki:content freshness
-      green.
+- [ ] The mastery deed additions land: fishing's first deed, prog_master_gatherer counts
+      fishing, per-craft mastery deeds at the resolved caps with the approved titles, and
+      no deed references skill 300; re-crossings after the 12c reset double-grant nothing.
+- [ ] The wiki is per-skill pages at the resolved detail bar: tables generated from
+      src/sim/ content, exact numbers published per the transparency policy, the FAQ
+      seeded from the real community questions; npm run wiki:content freshness green.
+- [ ] Every new guide.* key is English-only and the guide-scoped M16 exemption is in
+      place; the release-tier gate still hard-fails pending rows (the release fill
+      workflow is untouched).
+- [ ] The faucet review covers the three named rows (market fee, disenchant margin, the
+      gland-to-pristine ratio) with evidence.
 - [ ] asset-manifest.json lists every procedurally shipped id from the packet.
 - [ ] docs/professions-2/qa-checklist.md fully checked with evidence per row.
 - [ ] npm run gate green (Node 24 rule respected).

--- a/docs/professions-2/phase-15-qa.md
+++ b/docs/professions-2/phase-15-qa.md
@@ -23,6 +23,17 @@ final audit of the entire Professions 2.0 packet, ending with the teardown offer
   bite-and-reel flow in the scripted playthrough; the legacy burn-down disposition
   (LEGACY_GOLD_POSITIVE_RECIPE_IDS) is recorded per member with the typed-reagent
   cross-check applied first.
+- The second 2026-07-20 block (mastery and provenance): the deed additions landed
+  (fishing's deed, prog_master_gatherer counting fishing, mastery deeds at the RESOLVED
+  caps with the approved titles; grep the catalog for any 300 threshold: one hit is a
+  finding); every FINAL-marked tuning row (masterwork constants, specialization,
+  rare-event shared knob) is byte-unchanged from its recorded value; deed triggers no-op
+  on re-crossings after the 12c reset (extend the 12c suite, do not trust it); the wiki
+  hits the per-skill detail bar with generated tables (spot-check three generated numbers
+  against src/sim/ content AND three prose claims against real behavior), publishes exact
+  numbers per the transparency policy, and every new guide.* key is English-only with the
+  guide-scoped M16 exemption in place and the release-tier gate still hard-failing
+  pending rows; the faucet review's three named rows carry real evidence.
 
 ## QA Starter Prompt
 

--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -33,6 +33,10 @@ Update this file at the end of every implementation and QA session. Statuses:
 | 12 QA | Verify tool tier gating | complete (PR #2223 merged) | 2026-07-20 | 2026-07-20 |
 | 12b | Gathering rhythm | complete (PR #2226 merged into release/v0.29.0) | 2026-07-20 | 2026-07-20 |
 | 12b QA | Verify gathering rhythm | complete (PASS, zero blocking) | 2026-07-20 | 2026-07-20 |
+| 12c | The Mastery Curve | not started | | |
+| 12c QA | Verify The Mastery Curve | not started | | |
+| 12d | Provenance and the harvest loop | not started | | |
+| 12d QA | Verify provenance and the harvest loop | not started | | |
 | 13 | Enchanting reachable | not started | | |
 | 13 QA | Verify enchanting reachable | not started | | |
 | 14 | Attunement quests and nudges | not started | | |
@@ -529,11 +533,29 @@ were re-run green first-hand at the head before review dispatch.
 - [x] Placeholder cues routed and PLACEHOLDER-marked (sfx:check green, listed on #2208)
 - [x] Every Pin-cost appendix row executed as briefed; no unlisted pin weakened (two pre-briefed additive extensions outside the appendix, recorded in the as-landed block: the game_audio cue census 14 to 20 and the gather_event_i18n fishingResult cue pin)
 
+### Phase 12c: The Mastery Curve
+- [ ] The four-state curve replaces the free floor (1 / 0.5 / 0.25 / 0; every recipe tier included; zero new Rng draws)
+- [ ] Enforced per-profession caps as content data (crafts + enchanting 125, mining/logging/herbalism 100, fishing 200) at all four clamp arms
+- [ ] Gathering gains node-tier-relative; fishing gains band-relative and fractional; constants named, exported, pinned
+- [ ] The one-time reset (two maps + one flag, nothing else): keep ledger pinned, re-crossing audit green, blob-diff rehearsal evidence recorded, notice letter delivered once
+- [ ] The shared action throttle covers crafting, disenchant, enchant-apply, salvage
+- [ ] Enchanting gains quality-tiered with the soft ceiling; q_prof_hobby_switch xpReward 0
+- [ ] Four-state difficulty colors and the cap-aware mastered state in the UI
+- [ ] Pin-cost appendix executed as briefed; goldens byte-identical outside the appendix pair
+
+### Phase 12d: Provenance and the harvest loop
+- [ ] Identical-payload material stacking in bags AND through the bank move path; counted instanced stacks ride trade, wire, and removal correctly
+- [ ] Gathered by copy, the bag-grid instanced marker, and the full-bag signed-downgrade notice
+- [ ] One interact press loots AND harvests; denial of either half never blocks the other; corpse lifecycle decoupled; town focus verified and fixed or made legible
+- [ ] Mail attachment expiry (30 days, one return cycle, system mail exempt)
+- [ ] Companion fixes landed and pinned: #2139 and the force-rename signer sweep
+
 ### Phase 13: Enchanting reachable
 - [ ] Disenchant + enchant-apply + salvage on IWorld, wire commands, bags context UI, both hosts
 - [ ] Enchanting skill visible in the wheel window
-- [ ] Typed disenchant reagents (hybrid): rare+ adds the type-keyed secondary; every typed material has a same-phase consumer (the wolf_fang rule); staves/wands bucket flagged
+- [ ] Typed disenchant reagents (hybrid): rare+ adds the type-keyed secondary; every typed material has a same-phase consumer (the wolf_fang rule); staves/wands in the WEAPON bucket per the resolved decision
 - [ ] Bind-on-trade primitive live against the typed rare+ reagents (generic enforcement arm for Phase 14b)
+- [ ] Inherited 12c pacing verified: the shared throttle and quality-tiered gains govern the newly reachable actions
 
 ### Phase 14: Attunement quests and nudges
 - [ ] Acceptance lore quests at the masters for all four wave-one archetypes
@@ -552,10 +574,11 @@ were re-run green first-hand at the head before review dispatch.
 
 ### Phase 15: Deeds, tuning, and polish
 - [ ] Universal profession deeds incl. titles + marquee renown on first attunement and first masterwork, the Specialist deed, and the rare-find deeds (plus the rare fish, verified to celebrate through the Phase 12b bite moment)
-- [ ] Economy tuning targets applied (#1301 fee/throttle, training fees, teach tiers, work orders, masterwork bounds, unbind fee); faucet-vs-sink review recorded
+- [ ] Mastery deed additions: fishing's first deed, prog_master_gatherer counts fishing, per-craft mastery deeds at the resolved caps with the approved titles; no 300 reference anywhere; reset re-crossings double-grant nothing
+- [ ] Economy tuning targets applied (#1301 fee/throttle live rows; the FINAL-marked rows verified byte-unchanged); faucet-vs-sink review recorded incl. the market fee, disenchant margin, and gland-to-pristine ratio rows
 - [ ] Legacy junk-recipe burn-down dispositioned, cross-checked against the typed-reagent consumers first
 - [ ] Profession SFX completion sweep over #2208: placeholders replaced or explicitly re-filed, station ambiences, per-craft success variants
-- [ ] Guide/wiki professions page rewritten; asset manifest final
+- [ ] The wiki at the RuneScape bar: per-skill pages, tables generated from sim content, exact numbers per the transparency policy, English-only keys with the guide-scoped M16 exemption; asset manifest final
 - [ ] Whole-feature qa-checklist.md matrix green; packet teardown offered
 
 ## Notes
@@ -565,6 +588,24 @@ were re-run green first-hand at the head before review dispatch.
 2026-07-20 timing and economy amendments: a second maintainer-approved
 amendment pass (community feedback on gathering feel and the crafted-goods
 economy) restructured the remaining packet to 12, 12b, 13, 14, 14b, 15.
+
+2026-07-20 mastery and provenance amendments (the SECOND same-day block;
+state.md carries the authority rulings): the close-out brainstorm with the
+maintainer settled pacing (the four-state curve, enforced caps 125/100/200,
+the one-time skill reset with the keep ledger), provenance and stacking
+(identical-payload merge, Gathered by, the unified loot-and-harvest
+interact, mail expiry), the market ruling (gold buys materials, never
+skill), the offline-taster ruling, and resolved EVERY standing flagged
+decision except the letter-to-Haldren dead-end (which still rides Phase
+14): the three 14b decisions, the staves/wands bucket, the work-order
+formula, q_prof_hobby_switch (0 XP), masterwork discovery credit (keep
+def), master voices, the titles scheme, the rare-event shared knob, the
+specialization finals, and the training-fee extension. Phases 12c (#2235)
+and 12d (#2236) were inserted after the 12b QA; community draft PR #2134
+is out of consideration by maintainer ruling. Community inputs recorded:
+the signed Ironbark Log confusion thread, the common-recipes-to-300
+question, and the loot-versus-harvest report (its gland-to-pristine ratio
+feeds the Phase 15 faucet review).
 state.md records the rulings under "2026-07-20 timing and economy
 amendments" (the authority block); the new phase files
 (phase-12b-gathering-rhythm.md, phase-14b-commissions-binding.md, both

--- a/docs/professions-2/qa-checklist.md
+++ b/docs/professions-2/qa-checklist.md
@@ -38,6 +38,25 @@ or screenshot path), not vibes.
 - [ ] Save/load round-trip tests cover archetype history, fishing proficiency,
       known recipes, and masterwork instances.
 - [ ] All DDL (if any) is additive and idempotent under the boot advisory lock.
+- [ ] The Phase 12c one-time reset: fires exactly once per character (relog,
+      reconnect, restart, second deploy); the keep/reset ledger is fully
+      pinned; the blob-diff rehearsal evidence is on record; re-crossing any
+      threshold after reset double-grants no deed, renown, or letter.
+
+## Pacing (the Mastery Curve, Phase 12c)
+- [ ] The free floor is gone: no recipe tier grants full gain forever; the
+      four-state curve (1 / 0.5 / 0.25 / 0) is pinned at every boundary for
+      crafting, gathering, fishing, and enchanting.
+- [ ] Every per-profession cap (crafts and enchanting 125,
+      mining/logging/herbalism 100, fishing 200) is enforced at gain time and
+      load time; at cap, crafting still procs masterwork and harvests still
+      yield.
+- [ ] Crafting, disenchant, enchant-apply, and salvage share ONE throttle
+      window; no action type has a parallel budget.
+- [ ] The enchanting soft ceiling holds: rarer input never grants less skill,
+      and never zero above a pre-archetype ceiling.
+- [ ] A real playthrough spot-check lands inside the state.md time-to-master
+      target ranges (arithmetic recorded, not vibes).
 
 ## Economy invariants
 - [ ] Pinned test: no recipe's output vendors for more than its inputs.
@@ -51,6 +70,12 @@ or screenshot path), not vibes.
       is recorded with evidence.
 - [ ] The masterwork signed-reagent term counts ANY player's signature
       (buying a gatherer's signed materials works; the count-1 case works).
+- [ ] The market ruling holds: gold buys materials, never skill directly; no
+      gathered or monster material carries a vendor buyValue; fungible
+      materials remain market-listable.
+- [ ] Storage is honest (Phase 12d): identical-payload material stacks merge
+      in bags and bank; mail attachments expire per the model with system
+      mail exempt; the bank expansion ladder is the standing storage sink.
 
 ## i18n completeness
 - [ ] Every new player-visible string (window chrome, recipe rows, station

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -129,8 +129,10 @@ the remaining order is 12c, 12d, 13, 14, 14b, 15. Next: Phase 12c
     basic, universal, cosmetic-only, append-only.
 - 2026-07-20 timing and economy amendments (maintainer-approved; this block
   is the authority, on the 2026-07-17 template). The restructure INSERTS
-  Phases 12b and 14b without renumbering anything; the remaining order is
-  12, 12b, 13, 14, 14b, 15. Epic #1866 sub-issues: #2206 (Gathering
+  Phases 12b and 14b without renumbering anything; the remaining order was
+  12, 12b, 13, 14, 14b, 15 at this block's writing (superseded by the
+  second 2026-07-20 block below, which inserts 12c and 12d after the 12b
+  QA). Epic #1866 sub-issues: #2206 (Gathering
   rhythm), #2207 (Commissions and the Maker's Bond), #2208 (the profession
   SFX help-wanted list). Each ruling binds its owning phase file, which
   carries the full deliverable wording:
@@ -162,8 +164,9 @@ the remaining order is 12c, 12d, 13, 14, 14b, 15. Next: Phase 12c
     dust/essence/shard) stays for every quality, and RARE OR ABOVE
     additionally yields a type-keyed secondary material keyed off the
     existing ArmorType (cloth/leather/mail) and the sim-side weapon-kind
-    taxonomy (WEAPON_TYPE_BY_ITEM); the staves/wands bucket is a FLAGGED
-    maintainer decision; cooking and alchemy are deliberately excluded on
+    taxonomy (WEAPON_TYPE_BY_ITEM); the staves/wands bucket was FLAGGED
+    here and is RESOLVED by the second 2026-07-20 block below (the WEAPON
+    bucket); cooking and alchemy are deliberately excluded on
     both sides. Every typed material ships WITH at least one consumer
     recipe in the same phase (the wolf_fang no-dead-materials rule). The
     bind-on-trade PRIMITIVE lands in this phase applied to the typed
@@ -1266,8 +1269,9 @@ tables, i18n key namespaces, files created)
   bind-on-trade primitive applied to them; inherits the Phase 12c shared
   throttle and quality-tiered soft-ceiling gain model on day one.
 - Phase 14b: (planned) the commission marker, bind-on-first-trade
-  enforcement, the master unbind service; blocked on the three flagged
-  maintainer decisions in OPEN items.
+  enforcement, the master unbind service; the three maintainer decisions
+  are RESOLVED in OPEN items (character binding, equipment-only opt-in
+  classes, the tier-scaled unbind ladder), so STEP 0's gate is satisfied.
 
 ## Tuning targets (placeholders until Phase 15 tunes against live data)
 
@@ -1305,7 +1309,7 @@ tables, i18n key namespaces, files created)
   amendments): the cadence stays ONE shared knob; no per-family split in
   wave one; revisit with zone-expansion data.
 - Work-order quests (Phase 14), FORMULA RESOLVED (2026-07-20 mastery
-  amendments): coin reward = floor(0.5 * the summed vendor value of the
+  amendments): coin reward = floor(0.5 * the summed vendor SELL value of the
   requested materials), plus standard repeatable-quest XP for the level
   band; cadence-capped on the nudge cadence pattern. Vendoring is always
   more gold by construction, so work orders can never be the gold-optimal

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -4,13 +4,15 @@ The ONLY file every session must trust. Update it at the end of every phase.
 
 ## Current phase
 
-Phases 1 through 11 and all their QA sessions: complete (per-phase records
+Phases 1 through 12b and all their QA sessions: complete (per-phase records
 under "New surfaces per phase" below and in progress.md). v0.28.0 SHIPPED
-with Phases 1 through 10 aboard; Phase 11 (fishing) and its QA merged into
-release/v0.29.0. The 2026-07-20 timing and economy amendments restructured
-the remaining plan to 12, 12b, 13, 14, 14b, 15 (see the amendments block
-under Locked design decisions). Next: Phase 12 (phase-12-tool-gating.md,
-issue #2057).
+with Phases 1 through 10 aboard; Phases 11, 12, and 12b plus their QA
+sessions merged into release/v0.29.0 (12b QA is PR #2229). The 2026-07-20
+timing and economy amendments restructured the remaining plan to 12, 12b,
+13, 14, 14b, 15; the SECOND 2026-07-20 block (mastery and provenance, see
+Locked design decisions) inserts Phases 12c and 12d after the 12b QA, so
+the remaining order is 12c, 12d, 13, 14, 14b, 15. Next: Phase 12c
+(phase-12c-mastery-curve.md, issue #2235).
 
 ## Locked design decisions
 
@@ -198,6 +200,106 @@ issue #2057).
     the deterministic local synthesis pipeline (scripts/sfx/ui_sfx.mjs
     cue specs), passing npm run sfx:check, catalog rows marked
     PLACEHOLDER for the sound engineer, all tracked on #2208.
+- 2026-07-20 mastery and provenance amendments (maintainer-approved; the
+  SECOND 2026-07-20 block, on the same template; this block is the
+  authority). The restructure INSERTS Phases 12c and 12d after the 12b QA
+  without renumbering; the remaining order is 12c, 12d, 13, 14, 14b, 15.
+  Epic #1866 sub-issues: #2235 (The Mastery Curve), #2236 (Provenance and
+  the harvest loop). Each ruling binds its owning phase file, which carries
+  the full deliverable wording:
+  - NEW Phase 12c, The Mastery Curve (#2235, phase-12c-mastery-curve.md +
+    QA twin): the tier-0 free floor is RETIRED and the skill-gain
+    multiplier becomes the four-state curve for EVERY recipe tier (full at
+    or above capability, 0.5 one tier below, 0.25 two below, zero three or
+    more below); deterministic fractional gains, NEVER a skill-up roll.
+    Per-profession skill caps become ENFORCED content data: the nine
+    crafts and enchanting 125; mining, logging, herbalism 100; fishing
+    200 (caps end where content ends and rise with future zones by data
+    edit). Clamps land at all four arms (gainCraftSkill, the gathering
+    drain, both normalize-on-load functions); at cap, actions still work
+    (masterwork still procs, harvests still yield), only gain stops.
+    Gathering gains go node-tier-relative and fishing gains band-relative
+    and fractional (adventure is the clock; t3 nodes finish the gathering
+    trades). A ONE-TIME reset zeroes craftSkills and gatheringProficiency
+    behind a persisted one-shot flag (the recipesGrandfathered idiom);
+    players keep all items, gold, bank, knownRecipes, attunements, deeds,
+    character level, quests, and mail; a one-time authored system letter
+    explains it; the keep/reset ledger, the re-crossing audit, and a
+    production blob-diff rehearsal are release evidence. The craft
+    throttle becomes ONE shared action window covering crafting,
+    disenchant, enchant-apply, and salvage. Enchanting gains become
+    quality-tiered with a SOFT ceiling (effective gain tier = min(input
+    quality tier, archetype ceiling): rarer input never grants less, and
+    never zero above a pre-archetype ceiling; crafting's hard ceiling
+    stays). q_prof_hobby_switch xpReward becomes 0 (stays repeatable).
+    Curve, caps, and reset ship in the SAME deploy, BEFORE Phase 13.
+  - NEW Phase 12d, Provenance and the harvest loop (#2236,
+    phase-12d-provenance-stacking.md + QA twin): identical-payload
+    material stacking (byte-equal instance payloads merge, in bags AND
+    through the bank move path; equipment kinds stay one-per-slot;
+    counted instanced stacks ride trade, wire, and removal correctly);
+    provenance copy ("Gathered by {name}" for gathered signers, "Crafted
+    by {name}" stays for crafted; a visible bag-grid marker on instanced
+    slots; the full-bag signed-yield downgrade emits a player-visible
+    notice). ONE interact press loots AND harvests an eligible corpse
+    (focus selection with the town focus as default; the picker remains
+    for overrides; a denial of either half never blocks the other); the
+    corpse lifecycle decouples (looting never destroys harvestability,
+    harvesting alone never strands the corpse or the respawn); the town
+    focus behavior is verified and fixed or made legible. Mail
+    attachments expire after 30 days with one return-to-sender cycle
+    (system and work-order mail exempt); the bank is the warehouse and
+    its expansion ladder the storage gold sink. Companion bug fixes land
+    with or ahead of the phase: #2139 and the force-rename instance
+    signer sweep (renames re-key market and mail but never stored
+    signer strings: a moderation leak that also breaks the self-signed
+    discount and battlefield attribution).
+  - Market ruling, LOCKED: gold buys MATERIALS, never skill directly.
+    Fungible materials stay market-listable (gatherer income and the
+    socializer economy are the point); the curve, the shared throttle,
+    and material volume are the sanctioned brake on purchased progress.
+    No gathered or monster material ever gets a vendor buyValue.
+  - Offline host ruling: offline is a documented TASTER for professions
+    (characters do not persist there); no host-scoped pacing knob;
+    offline persistence is low priority by maintainer call.
+  - Masterwork constants are FINAL as shipped: at the 125 cap with full
+    bonuses the proc lands at its 15 percent ceiling, so at-cap crafting
+    becomes the masterwork hunt by construction; no constant changes.
+  - Phase 13 (amended): inherits the 12c shared throttle and the
+    quality-tiered soft-ceiling gain model on day one. The staves/wands
+    typed-reagent bucket is RESOLVED: the weapon bucket, no cloth special
+    case. Typed-reagent yields are APPROVED (see Tuning targets).
+    Community draft PR #2134 is OUT of consideration by maintainer
+    ruling; do not absorb, rebase, or reconcile it.
+  - Phase 14 (amended): the work-order reward FORMULA is resolved (see
+    Tuning targets; the stop-and-ask row is satisfied). Six master voice
+    sketches are approved and live in the phase file; the maintainer may
+    veto wording in the PR review.
+  - Phase 14b (amended): the three flagged decisions are RESOLVED (see
+    OPEN items): the Maker's Bond binds to the CHARACTER; opt-in classes
+    are equipment only (weapon, armor, held_offhand); the unbind fee is
+    tier-scaled on the training-fee family.
+  - Phase 15 (amended): deed additions (fishing's first deed;
+    prog_master_gatherer counts fishing; mastery deeds authored against
+    the RESOLVED caps, no reach-300 records); the titles scheme is
+    approved (Guildsworn for first attunement, Masterwright for first
+    masterwork, "Grandmaster {Craft}" per-craft at 125, Master Angler at
+    fishing 200; rare-find deeds stay renown-only; wording veto in the PR
+    review). The rare-event cadence is RESOLVED: ONE shared knob, no
+    per-family split in wave one (revisit with zone-expansion data).
+    Specialization perks are FINAL (threshold 75, materialDiscountPct
+    0.2). Masterwork discovery-deed credit is RESOLVED: keep def-quality
+    credit (item closed). The training-fee ladder EXTENDS on the 4x
+    geometric step for future tiers (tier 3 = 40000, tier 4 = 160000
+    copper; future-proofing, re-tunable when content exists). The wiki
+    rewrite expands to the RuneScape-wiki bar as its own dedicated arm:
+    per-skill pages, tables GENERATED from src/sim/ content, FULL
+    transparency on numbers (the repo is public; the wiki is the accurate
+    source), English-only keys with a guide-scoped M16 exemption (locale
+    fill stays a release-time batch). The faucet-vs-sink review gains
+    three named rows: the market fee (#2156), the dust-vs-cheap-uncommon
+    disenchant margin, and the live gland-to-pristine ratio report
+    (about 250 plain glands per 5 pristine).
 
 ## Non-negotiable constraints
 
@@ -1146,33 +1248,68 @@ tables, i18n key namespaces, files created)
   pre-existing, gatherResult/fishingResult log lines use the repo's raw
   hex log-color idiom, and the six cues stay PLACEHOLDER pending #2208
   (release-notes caveat).
+- Phase 12c: (planned) the four-state curve constants in wheel.ts, the
+  enforced per-profession maxSkill content rows and four clamp arms, the
+  node-tier and band-relative gathering/fishing gain constants, the
+  one-time reset flag and its authored notice letter, the shared action
+  throttle seam, the enchanting soft-ceiling gain arm, q_prof_hobby_switch
+  xpReward 0, and the four-state difficulty + cap-aware UI states.
+- Phase 12d: (planned) the identical-payload merge rule in bags/bank/
+  addItemInstance, the Gathered by key + bag-grid instanced marker + the
+  signed-downgrade notice event, the unified loot-and-harvest interact
+  flow with the decoupled corpse lifecycle and verified town focus, mail
+  attachment expiry with the return cycle, and the companion fixes
+  (#2139, the rename signer sweep).
 - Phase 13: (planned) disenchantItem/applyEnchant/salvageItem IWorld
   members + wire commands; plus, per the 2026-07-20 amendments, the typed
   disenchant reagents (hybrid model, same-phase consumers) and the
-  bind-on-trade primitive applied to them.
+  bind-on-trade primitive applied to them; inherits the Phase 12c shared
+  throttle and quality-tiered soft-ceiling gain model on day one.
 - Phase 14b: (planned) the commission marker, bind-on-first-trade
   enforcement, the master unbind service; blocked on the three flagged
   maintainer decisions in OPEN items.
 
 ## Tuning targets (placeholders until Phase 15 tunes against live data)
 
-- Masterwork proc: base 3 percent at recipe tier parity, +1 percent per tier
-  of skill above, +2 percent with any signed reagent (any player's
-  signature; decoupled from the quantity-discount flag per the 2026-07-17
-  amendment), +3 percent at the 75-skill specialization threshold; cap 15
-  percent. Masterwork bonus: +1 quality tier for the stat budget, never
-  above the raid floor band.
-- Training fees: common tier free (starter recipes), uncommon 25s, rare 1g.
+- Masterwork proc, FINAL (2026-07-20 mastery amendments): base 3 percent at
+  recipe tier parity, +1 percent per tier of skill above, +2 percent with
+  any signed reagent (any player's signature; decoupled from the
+  quantity-discount flag per the 2026-07-17 amendment), +3 percent at the
+  75-skill specialization threshold; cap 15 percent. Masterwork bonus: +1
+  quality tier for the stat budget, never above the raid floor band. These
+  constants harmonize with the 125 cap (at-cap, full-bonus crafting sits at
+  the ceiling) and do not change in Phase 15.
+- Training fees: common tier free (starter recipes), uncommon 25s, rare 1g;
+  RESOLVED extension for future tiers on the 4x geometric step: tier 3 =
+  40000, tier 4 = 160000 copper (future-proofing; nothing sells at those
+  tiers yet; re-tunable when zone content arrives).
+- Mastery curve and caps (Phase 12c, 2026-07-20, APPROVED): four-state gain
+  multipliers 1 / 0.5 / 0.25 / 0 by tiers below capability, every recipe
+  tier included (the free floor is retired); enforced per-profession caps:
+  nine crafts and enchanting 125, mining/logging/herbalism 100, fishing
+  200; gathering gains node-tier-relative, fishing gains band-relative and
+  fractional (exact fractions land as named exported pinned constants in
+  12c). Time-to-master TARGETS to tune against: first tier-up in 15 to 20
+  minutes; skill 50 in an evening; craft mastery (major, materials
+  included) 10 to 20 focused hours spread over days; gathering 100 in 8 to
+  12 hours; fishing 200 in 15 to 25 hours. If mastery should get longer,
+  the lever is material quantities per craft, never smaller gain numbers.
+- Mail attachment expiry (Phase 12d, 2026-07-20, APPROVED): 30 days with
+  one return-to-sender cycle; system and work-order mail exempt.
 - Teach tiers (Phase 9): the general predicate is tierForSkill(craft skill)
   >= tierForSkill(recipe skillReq); the wave-one ladder is common always,
   uncommon at 25 skill, rare at 50. Hobby crafts use the same thresholds.
 - Craft fee (#1301) and throttle: unchanged until live data.
 - Rare gather events (all three node flavors): roughly 1 per zone per 20
-  minutes, 5x yield, always signed; one shared cadence knob until Phase 15
-  tunes per family.
-- Work-order quests (Phase 14): reward numbers need MAINTAINER numbers
-  before Phase 14 runs (never gold-positive against the input vendor value;
-  the cadence cap reuses the nudge cadence pattern). Flagged in OPEN items.
+  minutes, 5x yield, always signed. RESOLVED (2026-07-20 mastery
+  amendments): the cadence stays ONE shared knob; no per-family split in
+  wave one; revisit with zone-expansion data.
+- Work-order quests (Phase 14), FORMULA RESOLVED (2026-07-20 mastery
+  amendments): coin reward = floor(0.5 * the summed vendor value of the
+  requested materials), plus standard repeatable-quest XP for the level
+  band; cadence-capped on the nudge cadence pattern. Vendoring is always
+  more gold by construction, so work orders can never be the gold-optimal
+  path; never gold-positive against the input vendor value.
 - Gathering rhythm (Phase 12b), FINALS as landed, all named exports, all
   pinned: gather cast GATHER_CAST_BASE_SEC 2.5, GATHER_CAST_FLOOR_SEC 1.5,
   GATHER_CAST_TOOL_TIER_REDUCTION_SEC 0.4 per owned tool tier ABOVE the
@@ -1185,11 +1322,18 @@ tables, i18n key namespaces, files created)
   FISH_REEL_WINDOW_ROD_BONUS_SEC 0.75 per rod tier above 1 (tick literals
   60/75/90 pinned), rod re-scanned at bite time. FISHING_SESSION_CAP_SEC 15
   (the constant cast-bar cap; FISHING_CAST_TIME retired).
-- Unbind service fee (Phase 14b): a MAINTAINER number (see OPEN items);
-  never invented.
-- Typed-reagent yields and consumer costs (Phase 13): sized against the
-  measured heroic faucet (two tradeable epics per heroic final boss);
-  final numbers are maintainer calls in the Phase 15 tuning pass.
+- Unbind service fee (Phase 14b), RESOLVED (2026-07-20 mastery
+  amendments): tier-scaled on the training-fee family by the item's
+  quality tier: uncommon 2500, rare 10000, epic 40000 copper,
+  clamp-to-last above.
+- Typed-reagent yields (Phase 13), APPROVED (2026-07-20 mastery
+  amendments): uncommon disenchants to 1 to 2 arcane_dust; rare to 1
+  arcane_essence plus 1 typed secondary; epic and legendary to exactly 1
+  arcane_shard plus 1 to 2 typed secondaries. The 1-shard-per-epic rate
+  deliberately maps shard supply one to one onto the measured heroic
+  faucet (two tradeable epics per heroic final boss); Greater-tier enchant
+  recipes price at 1 to 2 shards so the sink drinks what the faucet pours.
+  Consumer costs get the evidence check in the Phase 15 review.
 
 ## OPEN items
 
@@ -1214,38 +1358,42 @@ tables, i18n key namespaces, files created)
   the default, the 9 common recipes remain field-craftable (nothing
   breaks; combos stay field-craftable but pair-gated and are now
   trainer-taught; recorded in the Phase 9 surfaces entry).
-- Master NPC names/personalities (content flavor, Phase 8; maintainer may
-  want a naming pass).
+- Master NPC names/personalities: RESOLVED (2026-07-20 mastery
+  amendments) as six approved voice sketches recorded in
+  phase-14-attunement-quests.md (the quest and letter text inherits
+  them); the maintainer vetoes wording in the Phase 14 PR review.
 - RESOLVED (2026-07-20, Phase 11): fishing FOLDS into the gathering
   proficiency shape (a fourth GATHERING_PROFESSIONS row, no separate skill
   id); the wire rides the existing gprof/prof whole-record keys unchanged
   (ALL_DELTA_KEYS stays 49; recorded in the Phase 11 surfaces entry).
-- q_prof_hobby_switch is an unbounded repeatable 75 XP turn-in (flagged by
-  the Phase 1 QA security review): fully server-authoritative and XP-only,
-  but unlike its two self-limiting siblings it has no escalating gate, so a
-  player can ping-pong the hobby between the two candidates for 75 XP per
-  cycle. Maintainer decision (xpReward 0, or drop repeatable) in a tuning
-  phase; do not change balance numbers inside QA.
+- RESOLVED (2026-07-20 mastery amendments): q_prof_hobby_switch xpReward
+  becomes 0 and the quest STAYS repeatable (its job is the switching
+  service, not an XP faucet); implemented in Phase 12c. The original
+  flag: an unbounded repeatable 75 XP turn-in with no escalating gate
+  (Phase 1 QA security review).
 - Master-to-zone assignment (2026-07-17 default): forge, kitchens, loom,
   toolworks in Eastbrook; tannery in Fenbridge; apothecary in Highwatch.
   The maintainer may reshuffle in the Phase 8 PR review; positions are
   data-only records, so a move is cheap before Phase 9 renders them.
-- Work-order reward numbers (see Tuning targets): maintainer numbers
-  required before Phase 14 runs; never invent balance numbers.
-- Masterwork discovery-deed credit: a masterwork copy credits its DEF
-  quality toward discovery deeds, never the bumped tier (Phase 2 QA drift
-  note, intended). Flagged 2026-07-17 for a maintainer call; if masterworks
-  should credit the bumped tier, that is a deliberate design change for a
-  tuning phase, never a QA fix.
-- Phase 14b maintainer decisions (2026-07-20, FLAGGED, must be resolved
-  here before phase-14b-commissions-binding.md runs): (a) does the Maker's
-  Bond bind to the CHARACTER or the ACCOUNT; (b) which item classes may
-  opt into commission crafting; (c) the unbind service price (flat, or
-  scaled by item tier). The phase's STEP 0 stops if any row is still open.
-- Staves/wands typed-reagent bucket (2026-07-20, FLAGGED, Phase 13): which
-  type-keyed secondary material family staff and wand disenchants feed
-  (the sim-side weapon taxonomy has them as their own kinds; cloth-adjacent
-  is arguable). Resolve before or during the Phase 13 PR review.
+- RESOLVED (2026-07-20 mastery amendments): work-order rewards are a
+  FORMULA, recorded in Tuning targets (coin = floor(0.5 * summed input
+  vendor value) plus standard repeatable XP, cadence-capped); Phase 14's
+  stop-and-ask condition is satisfied.
+- RESOLVED (2026-07-20 mastery amendments): masterwork discovery-deed
+  credit stays DEF quality (the first-masterwork deed and title celebrate
+  the feat; the discovery ledger does not double-count it). Item closed;
+  no code change.
+- RESOLVED (2026-07-20 mastery amendments): the three Phase 14b
+  decisions: (a) the Maker's Bond binds to the CHARACTER (professions are
+  per-character, and character is the only identity the sim knows, so it
+  is also the only clean deterministic option); (b) opt-in item classes
+  are EQUIPMENT ONLY (weapon, armor, held_offhand: the kinds that already
+  carry instances); (c) the unbind fee is TIER-SCALED on the training-fee
+  family (2500 / 10000 / 40000 copper by quality tier, clamp-to-last).
+  Phase 14b's STEP 0 gate is satisfied.
+- RESOLVED (2026-07-20 mastery amendments): the staves/wands typed-reagent
+  bucket is the WEAPON bucket; no cloth special case (they are weapons in
+  the sim taxonomy and the special case buys nothing).
 - The letter-to-Haldren dead-end (Phase 7 QA): an unattuned player who
   follows the Guild letter before q_prof_intro is available hits a dialog
   dead-end; options recorded in progress.md Notes; the fix naturally rides


### PR DESCRIPTION
## Summary

Records the third maintainer-approved amendment pass for the Professions 2.0 program (the 2026-07-20 mastery and provenance amendments) in the docs packet, following the PR #2209 precedent. The brainstorm behind it settled profession pacing and closed every standing flagged decision but one:

- **New Phase 12c, The Mastery Curve (#2235)**: the tier-0 free floor is retired for a four-state gain curve (1 / 0.5 / 0.25 / 0), per-profession skill caps become enforced content data (crafts and enchanting 125; mining, logging, herbalism 100; fishing 200), a one-time skill reset (players keep items, recipes, attunements, deeds, gold) ships in the same deploy, the craft throttle becomes one shared action window including enchanting and salvage, and enchanting gains go quality-tiered with a soft ceiling. The phase file carries a pin-cost appendix and the reset's keep/reset ledger plus blob-diff rehearsal protocol.
- **New Phase 12d, Provenance and the harvest loop (#2236)**: identical-payload material stacking (bags and bank), "Gathered by" provenance with a bag-grid marker and the full-bag downgrade notice, one interact press that loots AND harvests with a decoupled corpse lifecycle and verified town focus, mail attachment expiry (30 days, one return cycle), and the two companion bug fixes (#2139, the force-rename signer sweep).
- **state.md** gains the authority block, updated Tuning targets (curve constants, caps, time-to-master targets, the resolved work-order formula, unbind ladder, typed-reagent yields, training-fee extension, mail expiry), and resolves the standing OPEN items: the three Phase 14b decisions, the staves/wands bucket, work-order numbers, q_prof_hobby_switch (0 XP), masterwork discovery credit, and master naming. The letter-to-Haldren dead-end stays open (rides Phase 14).
- **Downstream phases swept with their QA twins**: 13 (inherits the 12c throttle and gain model; resolved bucket; approved yields; the #2134 out-of-consideration ruling), 14 (resolved reward formula; six master voice sketches), 14b (STEP 0 gate satisfied), 15 (mastery deed additions and titles scheme, the finalized tuning sheet, three named faucet-review rows, and the wiki arm expanded to per-skill pages with generated tables, full number transparency, and English-only keys with a guide-scoped M16 exemption).
- **Status flips**: the stale state.md current-phase header (was "Next: Phase 12"), the progress.md table and checklists, implementation-plan.md order and phase-summary rows, README.md index.

The remaining order is 12c, 12d, 13, 14, 14b, 15. Docs only; no code changes.

## Related issues

Part of #1866. Adds the phase files for #2235 and #2236.

## Type of change

- [x] Documentation

## How was this tested?

- Commands: `npm run gate` under Node 24 (docs-only diff; the known environmental armory browser-test failure is expected locally, PR CI is the arbiter), plus a diff-wide scan for em dashes, en dashes, and emojis (zero hits).
- Manual steps: cross-file consistency review (phase order, issue numbers, cap values, formulas identical across state.md, phase files, QA twins, progress.md, implementation-plan.md, README.md); QA-twin sweep verified for every amended phase file; an independent reviewer agent passed over the full diff.
