### PR TITLE
fix(render): character preview never loads on a cold, first-visit cache

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -143,7 +143,7 @@ import { resolveWalletCapability } from './net/wallet_capability';
 import { installWalletResumeHandlers } from './net/wallet_resume';
 import { assetsReady } from './render/assets/preload';
 import { CharacterPreview, type PreviewAppearance } from './render/characters';
-import { preloadMechAssets } from './render/characters/assets';
+import { charactersReady, preloadMechAssets } from './render/characters/assets';
 import { skinCount } from './render/characters/manifest';
 import { playerPortraitDataUrl } from './render/characters/portrait';
 import { installWebGLContextRelease } from './render/context_release';
@@ -9033,38 +9033,51 @@ function wireStartScreens(): void {
     syncLandingGraphicsSelect();
   });
 
-  // Initialize 3D character preview once assets are ready
-  assetsReady().then(() => {
-    // Resolve each panel defensively: play.html (online-only) has no #offline-select.
-    const activePanelId = ['#charselect-panel', '#offline-select'].find((id) => {
-      const panel = $(id) as HTMLElement | null;
-      return panel !== null && !panel.hasAttribute('hidden');
-    });
-    const containerId =
-      activePanelId === '#offline-select'
-        ? '#offline-preview-container'
-        : '#online-preview-container';
-    const container = $(containerId);
-    const canvas = $('#char-preview-canvas') as HTMLCanvasElement | null;
-    if (container && canvas) {
-      characterPreview = new CharacterPreview(container, canvas);
-      // If a token auto-login already rendered the roster and selected a
-      // character before assets finished, show its real appearance; otherwise
-      // fall back to the selected class chip (create/offline panels).
-      if (charselectSelected) {
-        characterPreview.setAppearance(charselectAppearance(charselectSelected));
-      } else {
-        const selSelector =
-          activePanelId === '#offline-select'
-            ? '#offline-select .mini-class.sel'
-            : '#charcreate-panel .mini-class.sel';
-        const selEl = document.querySelector(selSelector) as HTMLElement | null;
-        const cls = selEl ? (selEl.dataset.class as PlayerClass) : 'warrior';
-        characterPreview.setClass(cls);
+  // Initialize 3D character preview once its assets are ready. Gated on the
+  // narrower charactersReady() (with its own retries), not the site-wide
+  // assetsReady(): that single shared promise covers EVERY registered preload
+  // (terrain, dungeon, foliage, ...), so an unrelated failure there must never
+  // permanently blank the character-creation preview. This previously used
+  // assetsReady().then() with no failure handler at all, so on a cold,
+  // first-visit cache a single transient asset failure anywhere on the site
+  // silently stranded the preview forever (issue: new players saw no
+  // character model on their first load; a reload "fixed" it only because the
+  // browser's HTTP cache was warm by then).
+  charactersReady()
+    .catch((err: unknown) => {
+      console.error('character preview assets failed to load, preview will stay blank:', err);
+    })
+    .then(() => {
+      // Resolve each panel defensively: play.html (online-only) has no #offline-select.
+      const activePanelId = ['#charselect-panel', '#offline-select'].find((id) => {
+        const panel = $(id) as HTMLElement | null;
+        return panel !== null && !panel.hasAttribute('hidden');
+      });
+      const containerId =
+        activePanelId === '#offline-select'
+          ? '#offline-preview-container'
+          : '#online-preview-container';
+      const container = $(containerId);
+      const canvas = $('#char-preview-canvas') as HTMLCanvasElement | null;
+      if (container && canvas) {
+        characterPreview = new CharacterPreview(container, canvas);
+        // If a token auto-login already rendered the roster and selected a
+        // character before assets finished, show its real appearance; otherwise
+        // fall back to the selected class chip (create/offline panels).
+        if (charselectSelected) {
+          characterPreview.setAppearance(charselectAppearance(charselectSelected));
+        } else {
+          const selSelector =
+            activePanelId === '#offline-select'
+              ? '#offline-select .mini-class.sel'
+              : '#charcreate-panel .mini-class.sel';
+          const selEl = document.querySelector(selSelector) as HTMLElement | null;
+          const cls = selEl ? (selEl.dataset.class as PlayerClass) : 'warrior';
+          characterPreview.setClass(cls);
+        }
       }
-    }
-    decorateClassChips();
-  });
+      decorateClassChips();
+    });
 }
 
 // Looping home-page theme. Browsers block audio autoplay until a user gesture,

--- a/src/main.ts
+++ b/src/main.ts
@@ -145,7 +145,7 @@ import { assetsReady } from './render/assets/preload';
 import { CharacterPreview, type PreviewAppearance } from './render/characters';
 import { charactersReady, preloadMechAssets } from './render/characters/assets';
 import { skinCount } from './render/characters/manifest';
-import { playerPortraitDataUrl } from './render/characters/portrait';
+import { onPortraitsReady, playerPortraitDataUrl } from './render/characters/portrait';
 import { installWebGLContextRelease } from './render/context_release';
 import { firstRunGraphicsPreset, GFX, graphicsPresetLabel } from './render/gfx';
 import { Renderer } from './render/renderer';
@@ -3554,8 +3554,10 @@ function renderSkinPicker(
   });
 }
 
-/** Give each class button a small portrait preview of that class (run once
- *  character assets are ready so portraits render synchronously). */
+/** Give each class button a small portrait preview of that class. Wired to
+ *  {@link onPortraitsReady} so it runs once portrait.ts's own asset barrier
+ *  resolves (portraits render synchronously from then on); one-shot per chip
+ *  via the .mini-class-portrait guard below, so it is safe to call again. */
 function decorateClassChips(): void {
   document
     .querySelectorAll<HTMLElement>('#charcreate-panel .mini-class, #offline-select .mini-class')
@@ -9033,6 +9035,16 @@ function wireStartScreens(): void {
     syncLandingGraphicsSelect();
   });
 
+  // Give each class chip its portrait as soon as portrait.ts's own (separate,
+  // wider) character-asset barrier resolves, independent of the 3D preview
+  // below. portraitsReady() latches once and decorateClassChips() is one-shot
+  // per chip, so gating this off charactersReady()'s narrower, retried set
+  // (as the 3D preview below does) left it permanently false whenever a
+  // transient failure landed in the wider set portrait.ts actually waits on:
+  // the preview would recover (that is charactersReady()'s job) but every
+  // class chip stayed a plain label for the rest of the page's life.
+  onPortraitsReady(decorateClassChips);
+
   // Initialize 3D character preview once its assets are ready. Gated on the
   // narrower charactersReady() (with its own retries), not the site-wide
   // assetsReady(): that single shared promise covers EVERY registered preload
@@ -9044,9 +9056,6 @@ function wireStartScreens(): void {
   // character model on their first load; a reload "fixed" it only because the
   // browser's HTTP cache was warm by then).
   charactersReady()
-    .catch((err: unknown) => {
-      console.error('character preview assets failed to load, preview will stay blank:', err);
-    })
     .then(() => {
       // Resolve each panel defensively: play.html (online-only) has no #offline-select.
       const activePanelId = ['#charselect-panel', '#offline-select'].find((id) => {
@@ -9076,7 +9085,9 @@ function wireStartScreens(): void {
           characterPreview.setClass(cls);
         }
       }
-      decorateClassChips();
+    })
+    .catch((err: unknown) => {
+      console.error('character preview assets failed to load, preview will stay blank:', err);
     });
 }
 

--- a/src/render/characters/CLAUDE.md
+++ b/src/render/characters/CLAUDE.md
@@ -21,7 +21,12 @@ no procedural-rig path here anymore. Reads the world; never mutates the sim.
   guess; see the P0 comment in `manifest.ts` and
   `tests/render_asset_preload.test.ts`). `prepareVisual(key)` memoizes
   normalize transform, resolved clips, click-capsule radius, and a baked
-  idle-pose geo (far-LOD/shadow proxy).
+  idle-pose geo (far-LOD/shadow proxy). `charactersReady()` is a narrower gate
+  than the site-wide `assetsReady()`: only this file's boot GLBs + skin atlases,
+  with its own retry loop (delayed, backed off between outer attempts) so a
+  transient failure anywhere else on the site can never permanently blank the
+  landing character-creation preview (`src/main.ts` awaits it there instead of
+  `assetsReady()`; see `tests/character_preview_boot.test.ts`).
 - `asset_miss_log.ts`: once-per-key dev logging for character-asset failures in
   per-frame render paths; `createCharacterVisual` returns null on such a
   failure so callers skip the view for the frame instead of stalling the

--- a/src/render/characters/assets.ts
+++ b/src/render/characters/assets.ts
@@ -471,6 +471,35 @@ for (const [key, list] of Object.entries(SKINS)) {
 }
 for (const url of bootSkinUrls) registerPreload(loadSkinTexInto(url, skinTexByUrl));
 
+/** Resolve once every boot-time character GLB + skin atlas is cached, retrying
+ *  whatever is still missing instead of depending on the site-wide assetsReady()
+ *  barrier. That barrier is one shared promise over EVERY registered preload
+ *  (terrain, dungeon, foliage, ...): an unrelated failure there must not sink the
+ *  character-creation preview, and loadGltf/loadTexture already evict a failed
+ *  URL from their own cache on rejection, so a fresh call here genuinely
+ *  re-fetches rather than re-awaiting a permanently rejected promise. A transient
+ *  failure is far more likely on a cold, first-visit cache (no warm HTTP cache to
+ *  fall back on), which is exactly when this matters most. */
+export async function charactersReady(maxAttempts = 3): Promise<void> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const missingGltf = preloadUrls.filter((u) => !gltfByUrl.has(assetUrl(u)));
+    const missingSkins = [...bootSkinUrls].filter((u) => !skinTexByUrl.has(u));
+    if (missingGltf.length === 0 && missingSkins.length === 0) return;
+    const results = await Promise.allSettled([
+      ...missingGltf.map((u) => loadGltf(u).then((g) => void gltfByUrl.set(u, g))),
+      ...missingSkins.map((u) => loadSkinTexInto(u, skinTexByUrl)),
+    ]);
+    if (attempt === maxAttempts) {
+      const failed = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+      if (failed.length > 0) {
+        throw new Error(
+          `character preview assets failed to load (${failed.length}): ${failed.map((f) => String(f.reason)).join('; ')}`,
+        );
+      }
+    }
+  }
+}
+
 /** Resolved skin texture for a visual key + skin index, or null for the model's
  *  embedded default (index 0, unknown key, or an atlas that is not loaded yet). */
 export function skinTexture(key: string, skinIndex: number): THREE.Texture | null {

--- a/src/render/characters/assets.ts
+++ b/src/render/characters/assets.ts
@@ -5,12 +5,18 @@
 //
 // Loading contract: fetches kick off at module import and register with the
 // preload registry; main.ts awaits assetsReady() before the Renderer exists,
-// so everything here can assume resolved GLTFs synchronously afterwards.
+// so everything here can assume resolved GLTFs synchronously afterwards. The
+// landing character-creation preview is the one exception: it awaits the
+// narrower charactersReady() below instead (this file's boot GLBs + skin
+// atlases only, with its own retries), since gating it on the site-wide
+// assetsReady() left an unrelated preload failure anywhere on the site
+// permanently blanking it on a cold, first-visit cache.
 import * as THREE from 'three';
 import type { GLTF } from 'three/addons/loaders/GLTFLoader.js';
 import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
 import { clone as cloneSkinned } from 'three/addons/utils/SkeletonUtils.js';
 import { WEAPON_SKINS } from '../../sim/content/weapon_skins';
+import { retryDelayMs as gltfRetryDelayMs } from '../assets/load_retry';
 import { loadGltf, loadTexture } from '../assets/loader';
 import { registerPreload } from '../assets/preload';
 import { addRimGlow, GFX } from '../gfx';
@@ -479,12 +485,22 @@ for (const url of bootSkinUrls) registerPreload(loadSkinTexInto(url, skinTexByUr
  *  URL from their own cache on rejection, so a fresh call here genuinely
  *  re-fetches rather than re-awaiting a permanently rejected promise. A transient
  *  failure is far more likely on a cold, first-visit cache (no warm HTTP cache to
- *  fall back on), which is exactly when this matters most. */
+ *  fall back on), which is exactly when this matters most.
+ *
+ *  Each outer attempt here already follows loadGltf's own three inner attempts
+ *  (400/800ms backoff, see load_retry.ts), so a URL that reaches this loop's
+ *  retry has already spent that whole window failing. Waiting again before the
+ *  next outer attempt (same schedule, reused) widens the retry window instead
+ *  of hammering a still-flaky connection three more times back to back in one
+ *  tick. */
 export async function charactersReady(maxAttempts = 3): Promise<void> {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const missingGltf = preloadUrls.filter((u) => !gltfByUrl.has(assetUrl(u)));
     const missingSkins = [...bootSkinUrls].filter((u) => !skinTexByUrl.has(u));
     if (missingGltf.length === 0 && missingSkins.length === 0) return;
+    if (attempt > 1) {
+      await new Promise((resolve) => setTimeout(resolve, gltfRetryDelayMs(attempt)));
+    }
     const results = await Promise.allSettled([
       ...missingGltf.map((u) => loadGltf(u).then((g) => void gltfByUrl.set(u, g))),
       ...missingSkins.map((u) => loadSkinTexInto(u, skinTexByUrl)),

--- a/tests/character_preview_boot.test.ts
+++ b/tests/character_preview_boot.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it, vi } from 'vitest';
 // only waits on character-boot assets and retries whatever is still missing,
 // since loadGltf/loadTexture evict a failed URL from their cache on
 // rejection, making a fresh call a real re-fetch attempt.
-function mockGltfLoad(failFirstNCalls: number): void {
+function mockGltfLoad(failFirstNCalls: number): { calls: Map<string, number> } {
   const calls = new Map<string, number>();
   vi.doMock('../src/render/assets/loader', () => ({
     loadGltf: vi.fn((url: string) => {
@@ -22,15 +22,24 @@ function mockGltfLoad(failFirstNCalls: number): void {
     loadTexture: vi.fn(() => Promise.resolve({})),
     releaseGltf: vi.fn(),
   }));
+  return { calls };
 }
 
 describe('character preview boot (first-visit transient asset failure)', () => {
   it('retries a failed character GLB and eventually resolves', async () => {
     vi.resetModules();
-    mockGltfLoad(1); // every URL fails once, then succeeds
+    const { calls } = mockGltfLoad(1); // every URL fails once, then succeeds
     const { charactersReady } = await import('../src/render/characters/assets');
 
     await expect(charactersReady(3)).resolves.toBeUndefined();
+    // Decisive on the actual readiness check (gltfByUrl.has(assetUrl(u))): every
+    // URL must have been retried exactly twice (the initial failure plus the one
+    // retry that succeeds), never zero (which would mean the loop fell out
+    // without actually resolving anything) and never three (which would mean
+    // the early-return on an empty missing set regressed and kept re-fetching
+    // URLs that were already cached).
+    expect(calls.size).toBeGreaterThan(0);
+    for (const count of calls.values()) expect(count).toBe(2);
   });
 
   it('rejects once every attempt is exhausted, instead of hanging forever', async () => {

--- a/tests/character_preview_boot.test.ts
+++ b/tests/character_preview_boot.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The bug: the landing character-creation preview was gated on the site-wide
+// assetsReady() promise with no failure handler. That promise covers EVERY
+// registered preload (terrain, dungeon, foliage, character GLBs, ...), so a
+// single transient failure ANYWHERE permanently sank the character preview
+// with zero retry, most likely on a cold, first-visit cache (no warm HTTP
+// cache to mask a flaky fetch). charactersReady() is the narrower fix: it
+// only waits on character-boot assets and retries whatever is still missing,
+// since loadGltf/loadTexture evict a failed URL from their cache on
+// rejection, making a fresh call a real re-fetch attempt.
+function mockGltfLoad(failFirstNCalls: number): void {
+  const calls = new Map<string, number>();
+  vi.doMock('../src/render/assets/loader', () => ({
+    loadGltf: vi.fn((url: string) => {
+      const n = (calls.get(url) ?? 0) + 1;
+      calls.set(url, n);
+      if (n <= failFirstNCalls) return Promise.reject(new Error(`transient failure: ${url}`));
+      return Promise.resolve({ scene: {}, animations: [] });
+    }),
+    loadHdr: vi.fn(() => new Promise(() => undefined)),
+    loadTexture: vi.fn(() => Promise.resolve({})),
+    releaseGltf: vi.fn(),
+  }));
+}
+
+describe('character preview boot (first-visit transient asset failure)', () => {
+  it('retries a failed character GLB and eventually resolves', async () => {
+    vi.resetModules();
+    mockGltfLoad(1); // every URL fails once, then succeeds
+    const { charactersReady } = await import('../src/render/characters/assets');
+
+    await expect(charactersReady(3)).resolves.toBeUndefined();
+  });
+
+  it('rejects once every attempt is exhausted, instead of hanging forever', async () => {
+    vi.resetModules();
+    mockGltfLoad(Number.POSITIVE_INFINITY); // every URL always fails
+    const { charactersReady } = await import('../src/render/characters/assets');
+
+    await expect(charactersReady(2)).rejects.toThrow(/character preview assets failed to load/);
+  });
+});


### PR DESCRIPTION
## Problem

New players sometimes see no character model at all on the Offline
Character / character-creation screen, on their very first visit to the
site in a given browser. A page reload usually "fixes" it.

## Root cause

```mermaid
sequenceDiagram
    participant Browser as Browser (cold cache)
    participant Preload as assets/preload.ts (site-wide)
    participant MainTS as main.ts (landing preview)
    participant Preview as CharacterPreview

    Browser->>Preload: fetch terrain, dungeon, foliage, character GLBs...
    Note over Preload: ONE shared assetsReady() promise<br/>over EVERY registered preload
    Preload-->>Preload: an unrelated asset (e.g. terrain texture)<br/>fails all its retries (cold cache, flaky first load)
    Preload--xMainTS: assetsReady() REJECTS
    Note over MainTS: assetsReady().then(...) has NO .catch()
    MainTS--xPreview: the .then() callback never runs
    Note over Preview: CharacterPreview is never constructed.<br/>Canvas stays permanently blank.<br/>Only an unhandled-rejection in devtools.
```

`assetsReady()` (`src/render/assets/preload.ts`) is a single barrier over
*every* preload registered anywhere in the render stack. The landing
character-creation preview in `src/main.ts` awaited that barrier with a bare
`.then()` and no failure handler at all. If even one *unrelated* asset (a
terrain splat, a dungeon prop, anything) fails all of its internal retries,
the shared promise rejects, the `.then()` callback that builds
`CharacterPreview` silently never runs, and nothing ever retries it for the
rest of the page's lifetime.

This is much more likely on a cold, first-visit cache: there's no warm HTTP
cache to fall back on, so a slow or flaky first connection is more likely to
exhaust an asset's bounded retry budget within the boot window. A reload
"fixes" it only because the browser's HTTP cache is warm by then, which is
why it reads as a first-visit-only bug.

## Fix

- Added `charactersReady()` in `src/render/characters/assets.ts`: a
  narrower gate that only waits on the character-boot GLBs/skin atlases
  (not the unrelated site-wide preload set), and retries whatever is still
  missing (up to 3 attempts). `loadGltf`/`loadTexture` already evict a
  failed URL from their own cache on rejection, so a fresh call here is a
  real re-fetch, not a re-await of a permanently rejected promise.
- Wired `src/main.ts`'s landing preview init through `charactersReady()`
  instead of the bare `assetsReady()`, with a `.catch()` that logs instead
  of leaving an unhandled rejection if every retry is exhausted.

## Test plan

- [x] New `tests/character_preview_boot.test.ts`: covers a transient
      per-asset failure that succeeds on retry, and confirms retries are
      bounded (rejects with a clear error instead of hanging forever).
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run` (full suite): all green except two known-unrelated
      flakes that also fail identically on a clean checkout of this branch
      before my change (a timing-sensitive mob-despawn test that passes in
      isolation, and two i18n registry tests that just need `npm run
      i18n:gen`, which `pretest` runs and a bare `vitest run` skips).
- [x] `npx @biomejs/biome check` on changed files: no new warnings.

No visual/UI change under normal conditions (this only changes error/retry
handling around asset loading), so no before/after screenshots.