### PR TITLE
fix(server): resync own talents after /unspectate

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -1548,6 +1548,11 @@ export class GameServer {
     moderator.lastArenaWireTick = -ARENA_WIRE_INTERVAL_TICKS;
     moderator.lastDfWireTick = -DF_WIRE_INTERVAL_TICKS;
     moderator.sentEnts.clear();
+    // force the heavy self block (tal/inv/equip/bags/...) to re-run next
+    // snapshot: it is gated on meta.wireRev vs session.lastWireRev, and that
+    // comparison is keyed to whichever entity's meta is being wired, so
+    // without this the target's heavy fields can silently fail to resend.
+    moderator.selfHeavyDirty = true;
     this.send(moderator, { t: 'spectate', name: target.name });
     this.sendSystemNotice(moderator, `Now spectating ${target.name}.`);
   }
@@ -1572,6 +1577,10 @@ export class GameServer {
     moderator.lastArenaWireTick = -ARENA_WIRE_INTERVAL_TICKS;
     moderator.lastDfWireTick = -DF_WIRE_INTERVAL_TICKS;
     moderator.sentEnts.clear();
+    // same as enterSpectate: force the heavy self block to re-run so the
+    // moderator's OWN talents/inventory/equip/etc. resend immediately
+    // instead of staying stuck on the spectated target's last-sent values.
+    moderator.selfHeavyDirty = true;
     this.send(moderator, { t: 'spectate', name: null });
     if (announce) this.sendSystemNotice(moderator, 'Stopped spectating.');
   }

--- a/tests/moderation_game.test.ts
+++ b/tests/moderation_game.test.ts
@@ -60,6 +60,7 @@ type TestFrame = {
     nm: string;
     ack: number;
     party: { members: { pid: number; x: number; z: number }[] };
+    tal?: { alloc: { spec: string | null; rows: Record<number, string> } };
   };
 };
 
@@ -783,5 +784,46 @@ describe('moderator spectate integration', () => {
 
     command(server, moderator, '/unspectate');
     expect(server.sim.petOf(moderator.pid, true)?.name).toBe('Tracker');
+  });
+
+  // Regression for the /spectate talent-reset bug: the heavy self block
+  // (tal/inv/equip/...) is gated on meta.wireRev vs session.lastWireRev, a
+  // comparison keyed to whichever entity's meta is currently being wired.
+  // Neither talent allocation bumps wireRev here (both start at the sim
+  // default, 0), so without forcing selfHeavyDirty on enter/exit, the
+  // moderator's own 'tal' field silently fails to resend after /unspectate
+  // and the client stays mirrored on the spectated target's talents.
+  it('resends the moderator own talents (not the spectated target) after /unspectate', () => {
+    const server = new GameServer();
+    const moderatorWs = fakeWs();
+    const moderator = joined(
+      server.join(moderatorWs, 1, 101, 'Watcher', 'mage', null, false, {
+        isAdmin: true,
+        adminPermissions: MOD_PERMS,
+      }),
+    );
+    const suspect = joined(server.join(fakeWs(), 2, 102, 'Suspect', 'mage', null));
+    const moderatorMeta = server.sim.meta(moderator.pid);
+    const suspectMeta = server.sim.meta(suspect.pid);
+    if (!moderatorMeta || !suspectMeta) throw new Error('meta missing');
+    moderatorMeta.talents = { spec: 'arcane', rows: { 5: 'arc_r5_arcane_focus' } };
+    suspectMeta.talents = { spec: 'fire', rows: { 5: 'fir_r5_imp_fireball' } };
+
+    // first snapshot as self establishes session.lastWireRev at the
+    // moderator's own (unbumped) wireRev.
+    internals(server).broadcastSnapshots();
+
+    command(server, moderator, '/spectate Suspect');
+    moderatorWs.send.mockClear();
+    internals(server).broadcastSnapshots();
+    const spectateSnap = frames(moderatorWs).find((frame) => frame.t === 'snap');
+    expect(spectateSnap?.self?.tal?.alloc).toEqual(suspectMeta.talents);
+
+    command(server, moderator, '/unspectate');
+    moderatorWs.send.mockClear();
+    internals(server).broadcastSnapshots();
+    const restoredSnap = frames(moderatorWs).find((frame) => frame.t === 'snap');
+    if (!restoredSnap?.self) throw new Error('restored snapshot missing');
+    expect(restoredSnap.self.tal?.alloc).toEqual(moderatorMeta.talents);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes a bug where using `/spectate` on another player can swap the moderator's own action-bar/talents to the spectated target's for a window after `/unspectate`, until the staggered self-refresh backstop or a manual loadout re-select forces a resync.
- Root cause: the heavy self-snapshot block (`tal`/`inv`/`equip`/`bags`/...) in `selfWireJson` is gated on `meta.wireRev !== session.lastWireRev`. During spectate the `meta` passed in belongs to whichever entity is currently anchored (the target while spectating, the moderator again after `/unspectate`), but the gate variable (`session.lastWireRev`) lives on the moderator's own session. If the two wireRev values happen to coincide (e.g. neither player's talents changed since login, both default to `0`), the heavy block is skipped entirely on enter AND exit, so the moderator's client keeps mirroring the spectated target's talent allocation after returning to their own body.
- Fix: force `selfHeavyDirty = true` in both `enterSpectate` and `exitSpectate` (`server/game.ts`), the same pattern already used at login and by `resyncQuests`, so the heavy block always re-runs on the very next snapshot regardless of wireRev coincidence.
- Note (per review): the wire-level gap is bounded even without this fix, since the heavy gate has a staggered backstop (`(tickCount + pid) % HEAVY_SELF_REFRESH_TICKS`, about 2 seconds) that resends the correct talents on its own. The fix is still worth having: it closes that 2-second window where a foreign talent kit is live on the moderator's client, and it's needed on the enter side regardless so the spectate view populates immediately instead of waiting on the backstop.

## Test plan
- [x] Added a regression test in `tests/moderation_game.test.ts` that reproduces the exact wireRev-coincidence bug (both talent allocations pinned so the test fails deterministically without the fix, confirmed locally by reverting the fix) and asserts the moderator's own `tal.alloc` is resent (not the spectated target's) immediately after `/unspectate`.
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run tests/moderation_game.test.ts tests/moderation_service.test.ts tests/moderation_commands.test.ts tests/snapshots.test.ts tests/architecture.test.ts tests/command_schema.test.ts` all green.
- [x] `npx @biomejs/biome check` on changed files clean (whole-repo check is pre-existing debt per CLAUDE.md, not touched here).
- No screenshots: this is a server-only wire-sync fix, no `src/render`/`src/ui`/`src/styles` changes.

```mermaid
sequenceDiagram
    participant Client as Moderator client
    participant Server as GameServer
    participant Target as Spectated player meta

    Client->>Server: /spectate "Suspect"
    Server->>Server: enterSpectate (BEFORE: no selfHeavyDirty force)
    Server-->>Client: self snapshot built from Target meta (tal = Target's talents)
    Client->>Server: /unspectate
    Server->>Server: exitSpectate (BEFORE: no selfHeavyDirty force)
    Note over Server: meta.wireRev (own) == session.lastWireRev (stale, from Target)<br/>heavy block SKIPPED
    Server-->>Client: self snapshot omits 'tal' -> client stays on Target's talents (BUG)

    Note over Server: AFTER fix: selfHeavyDirty=true set in both enterSpectate and exitSpectate
    Server-->>Client: heavy block always re-runs next snapshot -> own 'tal' resent correctly
```

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>