### PR TITLE
fix(render): derive dungeon wall visuals from collider geometry (rift phantom walls)

### DIFF
--- a/src/render/dungeon.ts
+++ b/src/render/dungeon.ts
@@ -46,6 +46,7 @@ import {
   placeMarshTombs,
   placeMarshWallDressing,
 } from './delve_marsh_dressing';
+import { rectShellWallSegments, stubFaceSegments } from './dungeon_wall_segments';
 import { sharedUniforms } from './gfx';
 import { buildInfernalDecor, ensureInfernalDecorAssets } from './rift_decor';
 import { radialGlowTexture } from './textures';
@@ -1716,43 +1717,48 @@ export class DungeonInteriors {
       return;
     }
     const bannerEvery = variant === 'crypt' ? 4 : 3;
-    const wallX = layout.wallX ?? DUNGEON_WALL_X;
-    const endWallHw = layout.endWallHw ?? DUNGEON_END_WALL_HW;
+    // Exact collider-run coverage (see dungeon_wall_segments.ts): each side/end
+    // run is split into equal segments and one module is scaled to each span,
+    // so the drawn shell always matches the collision shell (the legacy fixed
+    // 8u grid left visual corner gaps whenever endWallHw was not module-aligned,
+    // which a rift's arbitrary wallX + 1 almost never is).
+    const shell = rectShellWallSegments(layout, DUNGEON_WALL_X, DUNGEON_END_WALL_HW);
     for (const side of [-1, 1]) {
       const target = arenaWalls
         ? side < 0
           ? arenaWalls.left.placements
           : arenaWalls.right.placements
         : p;
-      const ry = side < 0 ? Math.PI / 2 : -Math.PI / 2; // detail + banners face the room
+      const segments = side < 0 ? shell.left : shell.right;
       let i = 0;
-      for (let z = layout.zMin; z <= layout.zMax + 2; z += 8, i++) {
-        const kind = this.wallKind(variant, hash2(side * 13.7, z));
-        target.add(kind, side * wallX, 0, z, ry, MODULE_SCALE);
+      for (const seg of segments) {
+        const kind = this.wallKind(variant, hash2(side * 13.7, seg.z));
+        target.add(kind, seg.x, 0, seg.z, seg.ry, [seg.halfLength / 2, MODULE_SCALE, MODULE_SCALE]);
         if (i % bannerEvery === 2 && kind !== 'wall_archedwindow_gated') {
           target.add(
-            this.bannerKind(variant, hash2(z, side * 7.3)),
-            side * wallX,
+            this.bannerKind(variant, hash2(seg.z, side * 7.3)),
+            seg.x,
             0,
-            z,
-            ry,
+            seg.z,
+            seg.ry,
             MODULE_SCALE,
           );
         }
+        i++;
       }
     }
     for (const end of [
-      { z: layout.zMin, ry: 0 },
-      { z: layout.zMax, ry: Math.PI },
+      { segments: shell.front, atMin: true },
+      { segments: shell.back, atMin: false },
     ]) {
       const target = arenaWalls
-        ? end.z === layout.zMin
+        ? end.atMin
           ? arenaWalls.front.placements
           : arenaWalls.back.placements
         : p;
-      for (let x = -endWallHw + 4; x <= endWallHw - 4; x += 8) {
-        const kind = this.wallKind(variant, hash2(x, end.z * 3.1));
-        target.add(kind, x, 0, end.z, end.ry, MODULE_SCALE);
+      for (const seg of end.segments) {
+        const kind = this.wallKind(variant, hash2(seg.x, seg.z * 3.1));
+        target.add(kind, seg.x, 0, seg.z, seg.ry, [seg.halfLength / 2, MODULE_SCALE, MODULE_SCALE]);
       }
     }
     // back wall banners flank the boss dais
@@ -2014,21 +2020,36 @@ export class DungeonInteriors {
       }
       return;
     }
-    const archZ = new Set<number>();
+    // Derive every pier face from the stub's own collider OBB
+    // (dungeon_wall_segments.ts). The legacy branch hardcoded the classic
+    // crypt/sanctum geometry (cap at |x| 6, faces spanning |x| 5..23), which a
+    // parameterized rift waist (passage half 7 to 8.5, piers out to a variable
+    // wallX) turned into a phantom wall panel INSIDE the open passage plus an
+    // uncovered invisible collider strip beyond |x| 23. Evaluated at the
+    // classic stub geometry (hw 9 around |x| 14) these segments reproduce the
+    // old faces exactly.
+    const archAt = new Map<number, number>();
     for (const s of stubs) {
-      const sign = s.x < 0 ? -1 : 1;
-      // passage-facing cap (length 2*hd along z)
-      p.add('wall', sign * 6, 0, s.z, Math.PI / 2, [s.hd / 2, MODULE_SCALE, MODULE_SCALE]);
-      // front/back faces, two 9u modules from |x| 5..23, flush inside the OBB
-      for (const fz of [s.z - s.hd + 1, s.z + s.hd - 1]) {
-        const ry = fz < s.z ? 0 : Math.PI;
-        p.add('wall_pillar', sign * 9.5, 0, fz, ry, [2.25, MODULE_SCALE, MODULE_SCALE]);
-        p.add('wall', sign * 18.5, 0, fz, ry, [2.25, MODULE_SCALE, MODULE_SCALE]);
+      const faces = stubFaceSegments(s);
+      for (const seg of faces.caps) {
+        p.add('wall', seg.x, 0, seg.z, seg.ry, [seg.halfLength / 2, MODULE_SCALE, MODULE_SCALE]);
       }
-      archZ.add(s.z);
+      let i = 0;
+      for (const seg of faces.faces) {
+        // Alternate the classic pillar-then-wall reading along each face.
+        const kind = i % 2 === 0 ? 'wall_pillar' : 'wall';
+        p.add(kind, seg.x, 0, seg.z, seg.ry, [seg.halfLength / 2, MODULE_SCALE, MODULE_SCALE]);
+        i++;
+      }
+      const prior = archAt.get(s.z);
+      archAt.set(s.z, prior === undefined ? faces.innerFaceX : Math.min(prior, faces.innerFaceX));
     }
     if (variant === 'sanctum' || variant === 'temple') {
-      for (const z of archZ) p.add('arch', 0, 0, z, 0, [2.6, 1.9, 2.0]);
+      // The arch module spans ~10.4u; only span passages it actually fits
+      // (classic half-5 aisles). A wider rift passage gets no floating arch.
+      for (const [z, innerFaceX] of archAt) {
+        if (innerFaceX <= 5.5) p.add('arch', 0, 0, z, 0, [2.6, 1.9, 2.0]);
+      }
     }
   }
 

--- a/src/render/dungeon_wall_segments.ts
+++ b/src/render/dungeon_wall_segments.ts
@@ -1,0 +1,147 @@
+// Pure wall-face segment math for parameterized dungeon layouts (procedural
+// rift halls and the classic interiors that share their shape). Derives every
+// RENDERED wall face from the same DungeonLayout fields layoutColliders()
+// turns into collision OBBs, so the drawn walls and the solid walls can never
+// drift apart.
+//
+// Why this module exists: the renderer used to place the rectangular shell by
+// stepping a fixed 8u module grid (leaving up to an 8u visual gap at end-wall
+// corners whenever endWallHw is not module-aligned, which a rift's arbitrary
+// wallX + 1 almost never is), and drew chamber-waist stubs with HARDCODED
+// classic-dungeon coordinates (pier faces spanning |x| 5..23, passage cap at
+// |x| = 6). Rift waists are generated with a passage half-width of 7 to 8.5
+// and piers reaching a variable wallX, so every rift waist rendered a wall
+// panel INSIDE the open passage (a "phantom wall" the player must run
+// through to reach the next chamber) plus an invisible collider strip beyond
+// |x| 23 that no wall was drawn for. Deriving the faces from each stub's own
+// collider fields reproduces the classic interiors (whose stubs are exactly
+// hw 9 around |x| 14 with a half-5 passage) and fixes every parameterized
+// layout at once. The polygon-shell path already works this way
+// (polygonWallSegments); this module extends the idea to the rectangular
+// shell and the stub piers.
+//
+// Render-layer sibling (not sim): only the renderer consumes these placements.
+// It imports types from src/sim/dungeon_layout, never three.js, so a Vitest
+// can sweep it directly against layoutColliders (tests/rift_wall_render_parity).
+import type { DungeonLayout, WallStub } from '../sim/dungeon_layout';
+
+export interface WallFaceSegment {
+  x: number;
+  z: number;
+  /** Euler-Y for the module (the renderer passes it straight to Placements). */
+  ry: number;
+  /** Half-length of the face span this segment covers, along the run axis. */
+  halfLength: number;
+}
+
+/** One KayKit wall module at room scale spans 8u (4u model x MODULE_SCALE 2).
+ * Runs are split into equal segments no longer than this, then each module is
+ * scaled to its exact segment span (the polygonWallSegments approach), so a
+ * run always reads as individual wall modules yet covers its collider exactly. */
+export const WALL_MODULE_SPAN = 8;
+
+function splitRun(x0: number, z0: number, x1: number, z1: number, ry: number): WallFaceSegment[] {
+  const dx = x1 - x0;
+  const dz = z1 - z0;
+  const len = Math.hypot(dx, dz);
+  if (len < 1e-6) return [];
+  const segCount = Math.max(1, Math.ceil(len / WALL_MODULE_SPAN));
+  const out: WallFaceSegment[] = [];
+  for (let s = 0; s < segCount; s++) {
+    const midT = (s + 0.5) / segCount;
+    out.push({
+      x: x0 + dx * midT,
+      z: z0 + dz * midT,
+      ry,
+      halfLength: len / segCount / 2,
+    });
+  }
+  return out;
+}
+
+export interface RectShellSegments {
+  /** Keyed by side sign so the renderer can route arena wall placements. */
+  left: WallFaceSegment[];
+  right: WallFaceSegment[];
+  front: WallFaceSegment[];
+  back: WallFaceSegment[];
+}
+
+/** Wall-face segments for a rectangular shell, spanning EXACTLY the collider
+ * runs layoutColliders() builds: side walls at +-wallX over sideWallZ +-
+ * sideWallHd, end walls at zMin/zMax over +-endWallHw. Module ry matches the
+ * legacy fixed-grid loops (side detail faces the room; ends face inward). */
+export function rectShellWallSegments(
+  layout: Pick<DungeonLayout, 'wallX' | 'endWallHw' | 'sideWallZ' | 'sideWallHd' | 'zMin' | 'zMax'>,
+  defaultWallX: number,
+  defaultEndWallHw: number,
+): RectShellSegments {
+  const wallX = layout.wallX ?? defaultWallX;
+  const endWallHw = layout.endWallHw ?? defaultEndWallHw;
+  return {
+    left: splitRun(
+      -wallX,
+      layout.sideWallZ - layout.sideWallHd,
+      -wallX,
+      layout.sideWallZ + layout.sideWallHd,
+      Math.PI / 2,
+    ),
+    right: splitRun(
+      wallX,
+      layout.sideWallZ - layout.sideWallHd,
+      wallX,
+      layout.sideWallZ + layout.sideWallHd,
+      -Math.PI / 2,
+    ),
+    front: splitRun(-endWallHw, layout.zMin, endWallHw, layout.zMin, 0),
+    back: splitRun(-endWallHw, layout.zMax, endWallHw, layout.zMax, Math.PI),
+  };
+}
+
+export interface StubFaceSegments {
+  /** Both x-end cap slabs (visible surfaces flush with the collider faces).
+   * The centre-facing cap matters for waist piers; the outer cap closes the
+   * free-standing wall fins (a flush waist pier's outer cap merges invisibly
+   * into the side wall mass, still collider-backed). */
+  caps: WallFaceSegment[];
+  /** Front/back pier faces (toward zMin / toward zMax). */
+  faces: WallFaceSegment[];
+  /** The pier's centre-side collider face |x|, for arch-fit decisions. */
+  innerFaceX: number;
+}
+
+/** Wall-face segments wrapping one stub OBB (x, z, hw, hd), derived from the
+ * stub's own collider fields the way the Bell Niche delve already renders its
+ * piers: each slab centreline sits 1u inside the collider face (the module's
+ * half-thickness) so the visible surface lands exactly ON the face and the
+ * player stands flush instead of clipping in. Handles both stub kinds the
+ * rift generator emits: side-wall-flush waist pairs AND free-standing wall
+ * fins, which is why all four faces are covered. */
+export function stubFaceSegments(s: WallStub): StubFaceSegments {
+  const sign = s.x < 0 ? -1 : 1;
+  const innerFaceX = s.x - sign * s.hw;
+  const outerFaceX = s.x + sign * s.hw;
+  const caps: WallFaceSegment[] = [
+    // centreline 1u inside the pier from each x face
+    ...splitRun(
+      innerFaceX + sign,
+      s.z - s.hd,
+      innerFaceX + sign,
+      s.z + s.hd,
+      sign < 0 ? Math.PI / 2 : -Math.PI / 2,
+    ),
+    ...splitRun(
+      outerFaceX - sign,
+      s.z - s.hd,
+      outerFaceX - sign,
+      s.z + s.hd,
+      sign < 0 ? -Math.PI / 2 : Math.PI / 2,
+    ),
+  ];
+  const faces: WallFaceSegment[] = [];
+  for (const front of [true, false]) {
+    const fz = front ? s.z - (s.hd - 1) : s.z + (s.hd - 1);
+    faces.push(...splitRun(s.x - s.hw, fz, s.x + s.hw, fz, front ? 0 : Math.PI));
+  }
+  return { caps, faces, innerFaceX: Math.abs(innerFaceX) };
+}

--- a/tests/rift_wall_render_parity.test.ts
+++ b/tests/rift_wall_render_parity.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from 'vitest';
+import {
+  rectShellWallSegments,
+  stubFaceSegments,
+  type WallFaceSegment,
+} from '../src/render/dungeon_wall_segments';
+import type { Collider } from '../src/sim/colliders';
+import { polygonWallSegments } from '../src/sim/delve_litany_layout';
+import { DUNGEON_END_WALL_HW, DUNGEON_WALL_X, layoutColliders } from '../src/sim/dungeon_layout';
+import { RIFT_RANK_BASE_LEVEL } from '../src/sim/rift/ranks';
+import { generateRiftFloor, generateRiftPlan, isSetPieceSeed } from '../src/sim/rift/rift_gen';
+
+// Every rendered wall face must sit ON collision, and every wall collider must
+// be visually covered. The renderer used to hardcode the classic-dungeon stub
+// geometry (passage cap at |x| 6, pier faces spanning |x| 5..23) while rift
+// waists are generated with a passage half-width of 7 to 8.5 and piers out to
+// a variable wallX: every rift waist drew a phantom wall panel INSIDE the open
+// passage (the "run through a wall to reach the next chamber" playtest bug)
+// plus an uncovered invisible collider strip beyond |x| 23. The end walls also
+// tiled a fixed 8u grid that left visual corner gaps for any endWallHw not
+// module-aligned (a rift's is wallX + 1). This sweep pins the shared-segment
+// replacement across seeds, ranks, and floors.
+
+/** The rendered module is 2u thick around its centreline (KayKit 1u half
+ * thickness x MODULE_SCALE 2); segment centrelines sit on or 1u inside the
+ * collider centreline, so a 1.2u inflation covers every legal offset. */
+const FACE_TOLERANCE = 1.2;
+const SAMPLE_STEP = 1;
+
+function obbContains(c: Collider, x: number, z: number, tol: number): boolean {
+  if (c.type !== 'obb') return false;
+  const rot = c.rot ?? 0;
+  const dx = x - c.x;
+  const dz = z - c.z;
+  // colliders.ts rotY convention: local +x maps to world (cos rot, -sin rot).
+  const u = dx * Math.cos(rot) - dz * Math.sin(rot);
+  const v = dx * Math.sin(rot) + dz * Math.cos(rot);
+  return Math.abs(u) <= c.hw + tol && Math.abs(v) <= c.hd + tol;
+}
+
+/** Sample points along a face segment's centreline, ends inset slightly so a
+ * corner sample never falls just past an adjacent run's collider end. */
+function segmentSamples(seg: WallFaceSegment): Array<{ x: number; z: number }> {
+  // ry aligns the module's local +x with the run axis: world (cos ry, -sin ry).
+  const ax = Math.cos(seg.ry);
+  const az = -Math.sin(seg.ry);
+  const half = Math.max(0, seg.halfLength - 0.15);
+  const out: Array<{ x: number; z: number }> = [];
+  const count = Math.max(2, Math.ceil((half * 2) / SAMPLE_STEP) + 1);
+  for (let i = 0; i < count; i++) {
+    const t = -half + (i * (half * 2)) / (count - 1);
+    out.push({ x: seg.x + ax * t, z: seg.z + az * t });
+  }
+  return out;
+}
+
+function coveredBySegments(
+  segments: readonly WallFaceSegment[],
+  x: number,
+  z: number,
+  tol: number,
+): boolean {
+  return segments.some((seg) => {
+    const ax = Math.cos(seg.ry);
+    const az = -Math.sin(seg.ry);
+    const dx = x - seg.x;
+    const dz = z - seg.z;
+    const along = dx * ax + dz * az;
+    const across = dx * az * -1 + dz * ax; // perpendicular in the run plane
+    return Math.abs(along) <= seg.halfLength + 0.15 && Math.abs(across) <= tol;
+  });
+}
+
+interface SweptFloor {
+  seed: number;
+  baseLevel: number;
+  floorIndex: number;
+  floor: ReturnType<typeof generateRiftFloor>;
+  colliders: Collider[];
+}
+
+function sweepFloors(): SweptFloor[] {
+  const out: SweptFloor[] = [];
+  const ranks = Object.values(RIFT_RANK_BASE_LEVEL);
+  let seed = 1;
+  let procedural = 0;
+  while (procedural < 25 && seed < 500) {
+    if (!isSetPieceSeed(seed)) {
+      procedural++;
+      for (const baseLevel of ranks) {
+        const plan = generateRiftPlan(seed, baseLevel);
+        for (const floorIndex of [0, plan.floorCount - 1]) {
+          const floor = generateRiftFloor(seed, baseLevel, floorIndex, null);
+          out.push({
+            seed,
+            baseLevel,
+            floorIndex,
+            floor,
+            colliders: layoutColliders(floor.layout),
+          });
+        }
+      }
+    }
+    seed++;
+  }
+  return out;
+}
+
+const SWEPT = sweepFloors();
+
+describe('rift wall render/collision parity', () => {
+  it('sweeps a non-vacuous mix of rectangular, polygon, and stub floors', () => {
+    expect(SWEPT.length).toBeGreaterThan(100);
+    expect(SWEPT.some((f) => f.floor.layout.shellPolygon)).toBe(true);
+    expect(SWEPT.some((f) => !f.floor.layout.shellPolygon)).toBe(true);
+    expect(SWEPT.some((f) => f.floor.layout.stubs.length > 0)).toBe(true);
+  });
+
+  it('every rendered shell and stub wall segment sits on a collider (no phantom walls)', () => {
+    for (const { seed, baseLevel, floorIndex, floor, colliders } of SWEPT) {
+      const layout = floor.layout;
+      const segments: WallFaceSegment[] = [];
+      if (layout.shellPolygon) {
+        // The renderer walks the delve segmenter for polygon shells; its split
+        // pitch differs from the collision segmenter, so pin coverage here too.
+        for (const seg of polygonWallSegments(layout.shellPolygon)) {
+          segments.push({ x: seg.x, z: seg.z, ry: seg.rot, halfLength: seg.halfLength });
+        }
+      } else {
+        const shell = rectShellWallSegments(layout, DUNGEON_WALL_X, DUNGEON_END_WALL_HW);
+        segments.push(...shell.left, ...shell.right, ...shell.front, ...shell.back);
+      }
+      for (const s of layout.stubs) {
+        const faces = stubFaceSegments(s);
+        segments.push(...faces.caps, ...faces.faces);
+      }
+      for (const seg of segments) {
+        for (const p of segmentSamples(seg)) {
+          const onCollider = colliders.some((c) => obbContains(c, p.x, p.z, FACE_TOLERANCE));
+          expect(
+            onCollider,
+            `phantom wall segment at (${p.x.toFixed(1)}, ${p.z.toFixed(1)}) ` +
+              `seed ${seed} L${baseLevel} floor ${floorIndex}`,
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('every rectangular wall collider run is visually covered (no invisible walls)', () => {
+    for (const { seed, baseLevel, floorIndex, floor } of SWEPT) {
+      const layout = floor.layout;
+      if (layout.shellPolygon) continue;
+      const shell = rectShellWallSegments(layout, DUNGEON_WALL_X, DUNGEON_END_WALL_HW);
+      const wallX = layout.wallX ?? DUNGEON_WALL_X;
+      const endWallHw = layout.endWallHw ?? DUNGEON_END_WALL_HW;
+      const label = (what: string, x: number, z: number) =>
+        `invisible wall: ${what} uncovered at (${x.toFixed(1)}, ${z.toFixed(1)}) ` +
+        `seed ${seed} L${baseLevel} floor ${floorIndex}`;
+      for (const [sideSegs, sx] of [
+        [shell.left, -wallX],
+        [shell.right, wallX],
+      ] as const) {
+        const z0 = layout.sideWallZ - layout.sideWallHd;
+        const z1 = layout.sideWallZ + layout.sideWallHd;
+        for (let z = z0 + 0.2; z <= z1 - 0.2; z += SAMPLE_STEP) {
+          expect(coveredBySegments(sideSegs, sx, z, 0.5), label('side wall', sx, z)).toBe(true);
+        }
+      }
+      for (const [endSegs, ez] of [
+        [shell.front, layout.zMin],
+        [shell.back, layout.zMax],
+      ] as const) {
+        for (let x = -endWallHw + 0.2; x <= endWallHw - 0.2; x += SAMPLE_STEP) {
+          expect(coveredBySegments(endSegs, x, ez, 0.5), label('end wall', x, ez)).toBe(true);
+        }
+      }
+      for (const s of layout.stubs) {
+        const faces = stubFaceSegments(s);
+        const sign = s.x < 0 ? -1 : 1;
+        const innerX = s.x - sign * s.hw;
+        const outerX = s.x + sign * s.hw;
+        for (let z = s.z - s.hd + 0.2; z <= s.z + s.hd - 0.2; z += SAMPLE_STEP) {
+          expect(
+            coveredBySegments(faces.caps, innerX + sign, z, 0.5),
+            label('stub inner cap', innerX, z),
+          ).toBe(true);
+          expect(
+            coveredBySegments(faces.caps, outerX - sign, z, 0.5),
+            label('stub outer cap', outerX, z),
+          ).toBe(true);
+        }
+        for (const fz of [s.z - (s.hd - 1), s.z + (s.hd - 1)]) {
+          for (let x = s.x - s.hw + 0.2; x <= s.x + s.hw - 0.2; x += SAMPLE_STEP) {
+            expect(coveredBySegments(faces.faces, x, fz, 0.5), label('stub face', x, fz)).toBe(
+              true,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it('no wall segment intrudes into a waist passage (the run-through-the-doorway bug)', () => {
+    let waists = 0;
+    for (const { seed, baseLevel, floorIndex, floor } of SWEPT) {
+      const layout = floor.layout;
+      if (layout.shellPolygon || layout.stubs.length === 0) continue;
+      const wallX = layout.wallX ?? DUNGEON_WALL_X;
+      const shell = rectShellWallSegments(layout, DUNGEON_WALL_X, DUNGEON_END_WALL_HW);
+      const segments: WallFaceSegment[] = [
+        ...shell.left,
+        ...shell.right,
+        ...shell.front,
+        ...shell.back,
+      ];
+      for (const s of layout.stubs) {
+        const faces = stubFaceSegments(s);
+        segments.push(...faces.caps, ...faces.faces);
+      }
+      // True waists are the side-wall-flush mirrored pairs (the generator also
+      // emits free-standing wall fins, which have no passage of their own).
+      const flush = layout.stubs.filter((s) => Math.abs(s.x) + s.hw >= wallX - 0.6);
+      for (const s of flush) {
+        if (s.x >= 0) continue;
+        const mirror = flush.find((m) => m.z === s.z && m.x > 0);
+        if (!mirror) continue;
+        waists++;
+        const passageHalf = Math.min(Math.abs(s.x) - s.hw, Math.abs(mirror.x) - mirror.hw);
+        for (const seg of segments) {
+          for (const p of segmentSamples(seg)) {
+            const inPassage = Math.abs(p.x) < passageHalf - 0.2 && Math.abs(p.z - s.z) < s.hd - 0.2;
+            expect(
+              inPassage,
+              `wall segment inside the waist passage at (${p.x.toFixed(1)}, ${p.z.toFixed(1)}) ` +
+                `seed ${seed} L${baseLevel} floor ${floorIndex}`,
+            ).toBe(false);
+          }
+        }
+      }
+    }
+    expect(waists).toBeGreaterThan(0);
+  });
+
+  it('stub wall segments never enter the walkable centre aisle', () => {
+    // Both stub kinds (waist piers, wall fins) keep their inner collider face
+    // at |x| >= 7 (AISLE_HALF 5.5 plus the generator margins). The legacy
+    // renderer ignored the stub fields entirely and drew hardcoded panels from
+    // |x| 5 inward across the aisle; pin that every stub-derived segment stays
+    // outside the spine so that class of phantom wall cannot return.
+    let checked = 0;
+    for (const { seed, baseLevel, floorIndex, floor } of SWEPT) {
+      for (const s of floor.layout.stubs) {
+        expect(Math.abs(s.x) - s.hw).toBeGreaterThanOrEqual(7);
+        const faces = stubFaceSegments(s);
+        for (const seg of [...faces.caps, ...faces.faces]) {
+          for (const p of segmentSamples(seg)) {
+            expect(
+              Math.abs(p.x) >= 6.5,
+              `stub segment in the aisle at (${p.x.toFixed(1)}, ${p.z.toFixed(1)}) ` +
+                `seed ${seed} L${baseLevel} floor ${floorIndex}`,
+            ).toBe(true);
+          }
+        }
+        checked++;
+      }
+    }
+    expect(checked).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Problem

Rift playtests keep reporting phantom walls: wall panels you run straight through, the occasional wall that really blocks, and the mechanic to progress to the next chamber apparently generated inside a wall. The round-2 wall fix (illusion walls emptied + the displacement guard) was real but addressed a different, smaller class: the big one survived because it is not a collision bug at all.

## Root cause

The renderer's rectangular-shell and stub wall placement never derived from the layout's collider fields:

- **Stub piers were hardcoded to the classic crypt/sanctum geometry** (passage cap at |x| 6, two faces spanning |x| 5..23) for every stub, in every dungeon. Rift waist piers are parameterized (passage half-width 7 to 8.5, piers out to a variable wallX up to ~38), so every rift waist drew a wall panel INSIDE the open passage: the wall you are forced to run through to reach the next chamber. The collider strip beyond |x| 23 rendered nothing: an invisible wall.
- **The generator's free-standing wall fins** (the second `stubs.push` site in `rift_gen.ts`) were worse: their panels rendered at those same hardcoded coordinates regardless of the fin's true position (fins sit anywhere from |x| 8 to 34). Every fin produced mid-room phantom panels plus one invisible collider block where the fin actually stands. A single floor can carry 8+ fins (seed 8, C, floor 0), which is why walls felt phantom everywhere while one wall still "kind of did something".
- **End walls tiled a fixed 8u grid** from `-endWallHw+4` to `endWallHw-4`, leaving a visual corner gap up to 8u whenever endWallHw is not module-aligned. A rift's endWallHw is `wallX + 1`, so almost every rift end wall had an open-looking corner that blocks movement.

The wall-solidity suite never caught this because it verifies collision only; nothing compared what the renderer draws against what the sim collides.

## Fix

New pure module `src/render/dungeon_wall_segments.ts` computes exact wall-face segments from the same `DungeonLayout` fields `layoutColliders()` collides:

- shell runs are split into equal spans with one module scaled per span (the approach `placePolygonWalls`/`polygonWallSegments` already uses),
- stub piers are wrapped from their own OBB fields (the Bell Niche delve precedent, generalized to all four faces so free-standing fins are closed).

`placeWalls`/`placeStubs` become thin consumers. Evaluated at the classic dungeons' stub geometry the segments reproduce the old faces, and the classic interiors' own 4u end-wall corner gaps get covered as a bonus. The sanctum/temple passage arch is now placed only where it actually spans the passage (classic half-5 aisles), instead of floating in a wider rift doorway.

**Collision is untouched**: `layoutColliders` and all sim behavior are byte-identical, so no parity goldens and no rift digest re-mints.

## Tests

`tests/rift_wall_render_parity.test.ts` sweeps 25 procedural seeds x 4 ranks x first/boss floors (200 floors):

1. every rendered shell/stub segment must sit on a collider (no phantom walls),
2. every rectangular collider run must be visually covered end to end (no invisible walls),
3. no segment may intrude into a waist passage (the exact run-through-the-doorway bug; the legacy cap at |x| 6 vs rift passages of 7+ fails this),
4. stub segments must stay out of the walkable centre aisle,
5. polygon shells: the delve segmenter the renderer walks is pinned against the collision segmenter's coverage (they split at different pitches, 6 vs 8).

Full rift suite (8 files, 146 tests) green; `tsc --noEmit` clean.

## Follow-ups (deliberately out of scope)

- `ClientWorld.riftFloor` is rebuilt only from the per-player `riftState` event with no snapshot field: a lost event (reconnect/black-holed drop) leaves a stale floor descriptor with no self-heal. Worth mirroring through the self snapshot like `delveRun`.
- The two polygon segmenters (`polygonWallSegments` pitch 6, `polygonWallColliders` pitch 8) are duplicate logic; consolidating changes collision micro-behavior, so it was left alone and is now pinned by test 5.