### PR TITLE
docs(professions-2): direct the loot-window legibility fix at Phase 12d QA

### DIFF
--- a/docs/professions-2/phase-12d-qa.md
+++ b/docs/professions-2/phase-12d-qa.md
@@ -62,6 +62,17 @@ filtering; resume truncated agents.
 
 STEP 3 - FIX: apply every BLOCKING and SHOULD-FIX finding test-first; rerun failed rows
 until green; commit with explicit paths, Conventional Commits with a body.
+- DIRECTED SHOULD-FIX (user, 2026-07-21, loot-window legibility; approved wording, land
+  it in this QA pass): rename the loot window's "Take All" button to "Take Loot" (the
+  old label promised the harvest too) and add tooltips to both buttons via the shared
+  attachTooltip idiom, hover and mobile long-press alike:
+  - Take Loot: "Takes the coins and dropped items. Does not use up the harvest."
+  - Harvest: "Gathers the checked components. Each corpse can be harvested once, first
+    come. Does not take the loot."
+  Optional if the window stays uncluttered: a footer hint line "The interact key loots
+  and harvests in one press, using your town focus." The new strings are wordy (M16):
+  English catalog rows plus the five non-Latin overlay fills each. Pin the renamed
+  label and both tooltip bindings; the Harvest button id/behavior is unchanged.
 
 STEP 4 - UPDATE DOCS + MEMORY: progress.md QA row and verdict; state.md drift
 corrections; append the QA post-inventory to the phase file's as-landed block; record

--- a/docs/professions-2/phase-12d-qa.md
+++ b/docs/professions-2/phase-12d-qa.md
@@ -69,8 +69,9 @@ until green; commit with explicit paths, Conventional Commits with a body.
   - Take Loot: "Takes the coins and dropped items. Does not use up the harvest."
   - Harvest: "Gathers the checked components. Each corpse can be harvested once, first
     come. Does not take the loot."
-  Optional if the window stays uncluttered: a footer hint line "The interact key loots
-  and harvests in one press, using your town focus." The new strings are wordy (M16):
+  Plus the footer hint line (approved, not optional): "The interact key loots and
+  harvests in one press, using your town focus." on the loot window, the town-focus
+  hint-line idiom. The new strings are wordy (M16):
   English catalog rows plus the five non-Latin overlay fills each. Pin the renamed
   label and both tooltip bindings; the Harvest button id/behavior is unchanged.
 


### PR DESCRIPTION
Playtesting the merged Phase 12d unified press (PR #2264) surfaced one residual legibility gap: the loot window's Take All label reads as if it takes the harvest too. This packet amendment records the approved fix as a directed should-fix for the Phase 12d QA session, so it lands with the QA PR:

- Rename Take All to Take Loot.
- Tooltips on both buttons (hover + mobile long-press): Take Loot takes coins and drops and never uses up the harvest; Harvest gathers the checked components, once per corpse, first come, and never takes the loot.
- Optional footer hint teaching that the interact key does both in one press using town focus.
- M16: English catalog rows plus the five non-Latin overlay fills; pin the renamed label and both tooltip bindings.

Part of #1866. Docs-only, no code change.