### PR TITLE
fix(content): give Mistcaller's Fang the dagger flag so Backstab works

### DIFF
--- a/src/sim/content/heroic_loot.ts
+++ b/src/sim/content/heroic_loot.ts
@@ -141,7 +141,7 @@ export const HEROIC_ITEMS: Record<string, ItemDef> = {
     slot: 'mainhand',
     quality: 'epic',
     requiredLevel: 20,
-    weapon: { min: 22, max: 36, speed: 1.8 },
+    weapon: { min: 22, max: 36, speed: 1.8, dagger: true },
     stats: { agi: 13, sta: 9 },
     critRating: FIVE_MAN_WEAPON_RATING,
     sellValue: 15000,

--- a/tests/weapon_skins.test.ts
+++ b/tests/weapon_skins.test.ts
@@ -139,6 +139,19 @@ describe('weapon type classification', () => {
     }
   });
 
+  it('every dagger-classified weapon carries the dagger gameplay flag', () => {
+    // The reverse of the check above: an item skinned as a dagger must also set
+    // weapon.dagger, the flag Backstab/Ambush (weaponStrike + requiresBehind) gate
+    // on in casting_lifecycle. Without it the item renders as a dagger but the
+    // positional rogue abilities reject it with "You must wield a dagger." This
+    // pins that the two dagger notions never drift apart (regression: mistcallers_fang).
+    for (const id of weaponIds) {
+      if (weaponTypeForItem(id) !== 'dagger') continue;
+      const def = ITEMS[id];
+      expect(def.kind === 'weapon' && def.weapon.dagger === true, id).toBe(true);
+    }
+  });
+
   it('heroic variants resolve through their base row', () => {
     expect(weaponTypeForItem('heroic_fang_of_korzul')).toBe('dagger');
     expect(weaponTypeForItem('heroic_staff_of_velkhar')).toBe('staff');


### PR DESCRIPTION
## Summary

Mistcaller's Fang (epic main-hand dagger, heroic Sunken Bastion drop from Vael the Mistcaller) could not be used with **Backstab** or **Ambush**: rogues equipping it were rejected with "You must wield a dagger."

Root cause is a content data omission. There are two independent "dagger" notions:

- `WEAPON_TYPE_BY_ITEM` in `weapon_skin_rules.ts` classifies the item as `'dagger'` (drives the visual skin/model). This was set correctly.
- `weapon.dagger` on the item def is the **gameplay flag** that Backstab/Ambush gate on (`weaponStrike` + `requiresBehind` in `casting_lifecycle.ts`). This was **missing**.

So the item rendered and read as a dagger everywhere in the UI but the positional rogue abilities rejected it. It was the only one of the 26 dagger-classified weapons missing the flag.

## Related issues

N/A (reported in-game by players unable to Backstab with the drop).

## Type of change

- [x] Bug fix
- [x] Tests

## Fix

- `src/sim/content/heroic_loot.ts`: add `dagger: true` to `mistcallers_fang`'s weapon block.
- `tests/weapon_skins.test.ts`: pin the **reverse-direction** invariant, every dagger-classified weapon must carry the `weapon.dagger` gameplay flag. The suite already checked the forward direction (`flag -> skin type`) but not this one, which is exactly why the drift slipped through. The new test fails on `mistcallers_fang` before the fix and passes after.

## How was this tested?

- Commands:
  - `npx vitest run tests/weapon_skins.test.ts` (44 passed; the new test red before the fix, green after)
  - `npm run gate` (green except two pre-existing, environment-specific `deploy_watchdog.test.ts` timing failures that reproduce on pristine `release/v0.29.0` with this change stashed, and are unrelated to this content change)
- Manual steps: verified `mistcallers_fang` was the only skin-classified dagger missing the flag by scanning all 26 dagger rows against their item defs.

## Screenshots / recordings

N/A (no visual change; the tooltip already displayed it as a dagger).