### PR TITLE
fix: Repair the assignable Attack action and duplicated auto-attack option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "electron-builder": "^26.15.6",
         "esbuild": "^0.28.1",
         "ffmpeg-static": "^5.3.0",
-        "ffprobe-static": "^3.1.0",
+        "ffprobe-static": "npm:@ffprobe-installer/ffprobe@^2.1.2",
         "jsdom": "^29.1.1",
         "lightningcss": "1.32.0",
         "playwright": "1.61.1",
@@ -2916,6 +2916,124 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@ffprobe-installer/darwin-arm64": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/darwin-arm64/-/darwin-arm64-5.0.1.tgz",
+      "integrity": "sha512-vwNCNjokH8hfkbl6m95zICHwkSzhEvDC3GVBcUp5HX8+4wsX10SP3B+bGur7XUzTIZ4cQpgJmEIAx6TUwRepMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "LGPL-2.1",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ffprobe-installer/darwin-x64": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/darwin-x64/-/darwin-x64-5.1.0.tgz",
+      "integrity": "sha512-J+YGscZMpQclFg31O4cfVRGmDpkVsQ2fZujoUdMAAYcP0NtqpC49Hs3SWJpBdsGB4VeqOt5TTm1vSZQzs1NkhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ffprobe-installer/linux-arm": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-arm/-/linux-arm-5.2.0.tgz",
+      "integrity": "sha512-PF5HqEhCY7WTWHtLDYbA/+rLS+rhslWvyBlAG1Fk8VzVlnRdl93o6hy7DE2kJgxWQbFaR3ZktPQGEzfkrmQHvQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffprobe-installer/linux-arm64": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-arm64/-/linux-arm64-5.2.0.tgz",
+      "integrity": "sha512-X1VvWtlLs6ScP73biVLuHD5ohKJKsMTa0vafCESOen4mOoNeLAYbxOVxDWAdFz9cpZgRiloFj5QD6nDj8E28yQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffprobe-installer/linux-ia32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-ia32/-/linux-ia32-5.2.0.tgz",
+      "integrity": "sha512-TFVK5sasXyXhbIG7LtPRDmtkrkOsInwKcL43iEvEw+D9vCS2rc//mn9/0Q+BR0UoJEiMK4+ApYr/3LLVUBPOCQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffprobe-installer/linux-x64": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-x64/-/linux-x64-5.2.0.tgz",
+      "integrity": "sha512-D3UeqTLYPNs7pBWPLUYGehPdRVqU8eACox4OZy3pZUZatxye2YKlvBwEfaLdL1v2Z4FOAlLUhms0kY8m8kqSRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffprobe-installer/win32-ia32": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/win32-ia32/-/win32-ia32-5.1.0.tgz",
+      "integrity": "sha512-5O3vOoNRxmut0/Nu9vSazTdSHasrr+zPT2B3Hm7kjmO3QVFcIfVImS6ReQnZeSy8JPJOqXts5kX5x/3KOX54XQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "GPL-3.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@ffprobe-installer/win32-x64": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/win32-x64/-/win32-x64-5.1.0.tgz",
+      "integrity": "sha512-jMGYeAgkrdn4e2vvYt/qakgHRE3CPju4bn5TmdPfoAm1BlX1mY9cyMd8gf5vSzI8gH8Zq5WQAyAkmekX/8TSTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "GPL-3.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@gltf-transform/cli": {
       "version": "4.4.1",
@@ -10128,11 +10246,25 @@
       }
     },
     "node_modules/ffprobe-static": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ffprobe-static/-/ffprobe-static-3.1.0.tgz",
-      "integrity": "sha512-Dvpa9uhVMOYivhHKWLGDoa512J751qN1WZAIO+Xw4L/mrUSPxS4DApzSUDbCFE/LUq2+xYnznEahTd63AqBSpA==",
+      "name": "@ffprobe-installer/ffprobe",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/ffprobe/-/ffprobe-2.1.2.tgz",
+      "integrity": "sha512-ZNvwk4f2magF42Zji2Ese16SMj9BS7Fui4kRjg6gTYTxY3gWZNpg85n4MIfQyI9nimHg4x/gT6FVkp/bBDuBwg==",
       "dev": true,
-      "license": "MIT"
+      "license": "LGPL-2.1",
+      "engines": {
+        "node": ">=14.21.2"
+      },
+      "optionalDependencies": {
+        "@ffprobe-installer/darwin-arm64": "5.0.1",
+        "@ffprobe-installer/darwin-x64": "5.1.0",
+        "@ffprobe-installer/linux-arm": "5.2.0",
+        "@ffprobe-installer/linux-arm64": "5.2.0",
+        "@ffprobe-installer/linux-ia32": "5.2.0",
+        "@ffprobe-installer/linux-x64": "5.2.0",
+        "@ffprobe-installer/win32-ia32": "5.1.0",
+        "@ffprobe-installer/win32-x64": "5.1.0"
+      }
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "electron-builder": "^26.15.6",
     "esbuild": "^0.28.1",
     "ffmpeg-static": "^5.3.0",
-    "ffprobe-static": "^3.1.0",
+    "ffprobe-static": "npm:@ffprobe-installer/ffprobe@^2.1.2",
     "jsdom": "^29.1.1",
     "lightningcss": "1.32.0",
     "playwright": "1.61.1",
@@ -257,8 +257,13 @@
     }
   },
   "allowScripts": {
+    "@ffprobe-installer/darwin-arm64@5.0.1": true,
+    "@ffprobe-installer/darwin-x64@5.1.0": true,
+    "@ffprobe-installer/linux-arm@5.2.0": true,
+    "@ffprobe-installer/linux-arm64@5.2.0": true,
+    "@ffprobe-installer/linux-ia32@5.2.0": true,
+    "@ffprobe-installer/linux-x64@5.2.0": true,
     "sharp@0.34.5": true,
-    "ffmpeg-static@5.3.0": true,
-    "ffprobe-static@3.1.0": true
+    "ffmpeg-static@5.3.0": true
   }
 }

--- a/src/sim/targeting.ts
+++ b/src/sim/targeting.ts
@@ -93,16 +93,19 @@ export class Targeting {
     const r = this.ctx.resolve(pid);
     if (!r) return;
     const p = r.e;
-    let best: Entity | null = null;
-    let bestD2 = TAB_QUERY_RADIUS * TAB_QUERY_RADIUS;
-    this.ctx.grid.forEachInRadius(p.pos.x, p.pos.z, TAB_QUERY_RADIUS, (e, d2) => {
-      if (!this.isEnemyTargetCandidate(p, e)) return;
-      if (d2 < bestD2) {
-        bestD2 = d2;
-        best = e;
-      }
-    });
-    if (best) p.targetId = (best as Entity).id;
+    const candidates = this.enemyCandidates(p);
+    if (candidates.length === 0) return;
+    const { ids } = orderTabTargets(
+      candidates.map((c) => ({
+        id: c.e.id,
+        dx: c.e.pos.x - p.pos.x,
+        dz: c.e.pos.z - p.pos.z,
+        d: c.d,
+        engaged: c.e.aggroTargetId === p.id || c.e.targetId === p.id,
+      })),
+      p.facing,
+    );
+    p.targetId = ids[0];
   }
 
   private enemyCandidates(p: Entity): { e: Entity; d: number }[] {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -260,6 +260,7 @@ import {
   loadoutKnownAbilityIds,
   parseHotbarAction,
   placeAbilityOnSlot,
+  placeAttackOnSlot,
   placeItemOnSlot,
   resolveMobileHotbarDrop,
   swapHotbarSlots,
@@ -3945,10 +3946,12 @@ export class Hud {
     abilityIdByBarSlot: () =>
       this.hotbarActions.map((a) => (a && a.type === 'ability' ? a.id : null)),
     hasFreeSlot: () => this.actionBarController.hasFreeSlot(),
-    attackOnBar: () => this.attackSlotIsAttack(),
-    // Routes through the Interface showAttackButton setting, the same state the
-    // options window and the slot-0 right-click drive, so all three stay one.
-    setAttackOnBar: (on) => this.optionsHooks?.settings.set('showAttackButton', on),
+    attackOnBar: () =>
+      this.attackSlotIsAttack() ||
+      this.attackSlotAction?.type === 'attack' ||
+      this.hasAttackOnHotbar(),
+    addAttackToBar: () => this.addAttackToHotbar(),
+    removeAttackFromBar: () => this.removeAttackFromHotbar(),
     addToBar: (id) => this.addAbilityToHotbar(id),
     removeFromBar: (id) => this.removeAbilityFromHotbar(id),
     hasFormBars: () => this.classHasFormBars(),
@@ -4963,6 +4966,34 @@ export class Hud {
     return this.actionBarController.removeAbility(abilityId);
   }
 
+  private hasAttackOnHotbar(): boolean {
+    return this.actionBarController.hasAttackAction();
+  }
+
+  private addAttackToHotbar(): boolean {
+    if (this.attackSlotIsAttack() || this.attackSlotAction?.type === 'attack') return false;
+    if (this.attackSlotAction === null) {
+      this.attackSlotAction = { type: 'attack' };
+      this.saveAttackSlotAction();
+      return true;
+    }
+    return this.actionBarController.addAttack();
+  }
+
+  private removeAttackFromHotbar(): boolean {
+    if (this.attackSlotAction?.type === 'attack') {
+      this.attackSlotAction = null;
+      this.saveAttackSlotAction();
+      return true;
+    }
+    if (this.actionBarController.removeAttack()) return true;
+    if (this.attackSlotIsAttack()) {
+      this.optionsHooks?.settings.set('showAttackButton', false);
+      return true;
+    }
+    return false;
+  }
+
   private resetActiveFormBarToDefault(): void {
     this.actionBarController.resetActiveBar();
     this.spellbookWindow.refreshHotbarControls();
@@ -4982,6 +5013,10 @@ export class Hud {
 
   private attackSlotIsAttack(): boolean {
     return this.actionBarController.isAttackSlotFixed();
+  }
+
+  private slotRendersAttack(barSlot: number): boolean {
+    return this.actionBarController.slotRendersAttack(barSlot);
   }
 
   private saveAttackSlotAction(): void {
@@ -5287,6 +5322,10 @@ export class Hud {
       return;
     }
     const action = this.actionForSlot(barSlot);
+    if (action?.type === 'attack') {
+      this.activateFixedAttackSlot();
+      return;
+    }
     if (action?.type === 'ability') {
       // cast by ability id: the server validates against its own known list,
       // so the client-side slot remap never desyncs slot semantics
@@ -5405,7 +5444,7 @@ export class Hud {
   private writeDraggedAction(dt: DataTransfer | null, action: Exclude<HotbarAction, null>): void {
     if (!dt) return;
     dt.setData(HOTBAR_ACTION_MIME, encodeHotbarAction(action));
-    dt.setData('text/plain', action.id);
+    dt.setData('text/plain', action.type === 'attack' ? 'attack' : action.id);
   }
 
   private readDraggedAction(dt: DataTransfer | null): Exclude<HotbarAction, null> | null {
@@ -5480,8 +5519,12 @@ export class Hud {
         e.stopPropagation();
       });
       this.attachTooltip(btn, () => {
-        if (slot === 0 && this.attackSlotIsAttack()) {
-          return `<div class="tt-title">${esc(t('abilityUi.actionBar.attackName'))}</div><div class="tt-sub">${esc(t('abilityUi.actionBar.attackTooltip'))}</div><div class="tt-sub">${esc(t('abilityUi.actionBar.attackRemoveHint'))}</div>`;
+        if (this.slotRendersAttack(slot)) {
+          const clearHint =
+            slot === 0 && this.attackSlotIsAttack()
+              ? t('abilityUi.actionBar.attackRemoveHint')
+              : t('abilityUi.actionBar.clearHint');
+          return `<div class="tt-title">${esc(t('abilityUi.actionBar.attackName'))}</div><div class="tt-sub">${esc(t('abilityUi.actionBar.attackTooltip'))}</div><div class="tt-sub">${esc(clearHint)}</div>`;
         }
         const known = this.abilityForSlot(slot);
         const clearHint = `<div class="tt-sub">${esc(t('abilityUi.actionBar.clearHint'))}</div>`;
@@ -5566,7 +5609,9 @@ export class Hud {
           if (!this.actionBarController.isAssignableAction(action)) return;
           if (dragged.sourceIndex !== null)
             this.hotbarActions = swapHotbarSlots(this.hotbarActions, dragged.sourceIndex, slot - 1);
-          else if (
+          else if (action.type === 'attack') {
+            this.hotbarActions = placeAttackOnSlot(this.hotbarActions, slot - 1);
+          } else if (
             action.type === 'ability' &&
             this.sim.known.some((k) => k.def.id === action.id)
           ) {
@@ -5687,9 +5732,9 @@ export class Hud {
           const slotKey = `slot${i}`;
           return {
             slotIndex: i,
-            // Live accessor: slot 0 stops being the Attack toggle when the player
-            // removes it (Interface option showAttackButton off / right-click).
-            isAttack: () => i === 0 && this.attackSlotIsAttack(),
+            // Live accessor: slot 0 may be the fixed Attack toggle, and any slot
+            // can render an assigned Attack action from the spellbook.
+            isAttack: () => this.slotRendersAttack(i),
             // Raw binding presence (any assigned slot, even one whose ability is
             // unlearned or item id is unknown): the many-spells count source, kept
             // byte-identical to the former hotbarActions.filter(a => a !== null).
@@ -5841,7 +5886,8 @@ export class Hud {
           },
           ...Array.from({ length: 5 }, (_, i) => ({
             slotIndex: i + 1,
-            isAttack: () => false,
+            isAttack: () =>
+              this.slotRendersAttack(sourceSlotForMobileButton(this.mobileActionPage, i)),
             hasAction: () =>
               this.actionForSlot(sourceSlotForMobileButton(this.mobileActionPage, i)) !== null,
             ability: () => this.abilityForSlot(sourceSlotForMobileButton(this.mobileActionPage, i)),

--- a/src/ui/hud/action_bar/action_bar_controller.ts
+++ b/src/ui/hud/action_bar/action_bar_controller.ts
@@ -150,6 +150,17 @@ export class ActionBarController {
     return true;
   }
 
+  addAttack(): boolean {
+    if (this.actionState.some((action) => action?.type === 'attack')) return false;
+    const target = this.actionState.indexOf(null);
+    if (target === -1) return false;
+    const next = this.actionState.slice();
+    next[target] = { type: 'attack' };
+    this.actionState = next;
+    this.saveActions();
+    return true;
+  }
+
   hasFreeSlot(): boolean {
     return this.actionState.includes(null);
   }
@@ -158,6 +169,18 @@ export class ActionBarController {
     const target = this.actionState.findIndex(
       (action) => action?.type === 'ability' && action.id === abilityId,
     );
+    if (target === -1) return false;
+    this.actionState = clearHotbarSlot(this.actionState, target);
+    this.saveActions();
+    return true;
+  }
+
+  hasAttackAction(): boolean {
+    return this.actionState.some((action) => action?.type === 'attack');
+  }
+
+  removeAttack(): boolean {
+    const target = this.actionState.findIndex((action) => action?.type === 'attack');
     if (target === -1) return false;
     this.actionState = clearHotbarSlot(this.actionState, target);
     this.saveActions();
@@ -193,6 +216,7 @@ export class ActionBarController {
   }
 
   isAssignableAction(action: Exclude<HotbarAction, null>): boolean {
+    if (action.type === 'attack') return true;
     if (action.type === 'item') return this.isHotbarItemId(action.id);
     return (
       this.deps.knownAbilityIds().includes(action.id) && this.isAbilityPlacementAllowed(action.id)
@@ -208,6 +232,11 @@ export class ActionBarController {
       return actionForAttackSlot(this.isAttackSlotFixed(), this.attackActionState);
     }
     return this.actionState[barSlot - 1] ?? null;
+  }
+
+  slotRendersAttack(barSlot: number): boolean {
+    if (barSlot === 0) return this.isAttackSlotFixed() || this.attackActionState?.type === 'attack';
+    return this.actionState[barSlot - 1]?.type === 'attack';
   }
 
   saveActions(): void {

--- a/src/ui/hud/action_bar/hotbar.ts
+++ b/src/ui/hud/action_bar/hotbar.ts
@@ -2,7 +2,11 @@ import { computeTalentModifiers, type TalentAllocation } from '../../../sim/cont
 import { abilitiesKnownAt } from '../../../sim/data';
 import type { AbilityDef, PlayerClass } from '../../../sim/types';
 
-export type HotbarAction = { type: 'ability'; id: string } | { type: 'item'; id: string } | null;
+export type HotbarAction =
+  | { type: 'attack' }
+  | { type: 'ability'; id: string }
+  | { type: 'item'; id: string }
+  | null;
 
 export interface HotbarStorage {
   getItem(key: string): string | null;
@@ -63,6 +67,7 @@ export function parseHotbarAction(
 ): Exclude<HotbarAction, null> | null {
   if (!value || typeof value !== 'object') return null;
   const action = value as { type?: unknown; id?: unknown };
+  if (action.type === 'attack') return { type: 'attack' };
   if (typeof action.id !== 'string') return null;
   if (action.type === 'ability' && abilityExists(action.id))
     return { type: 'ability', id: action.id };
@@ -174,6 +179,22 @@ export function placeAbilityOnSlot(
   return next;
 }
 
+export function placeAttackOnSlot(
+  actions: readonly HotbarAction[],
+  targetIndex: number,
+): HotbarAction[] {
+  const next = actions.slice();
+  if (targetIndex < 0 || targetIndex >= next.length) return next;
+  const sourceIndex = next.findIndex((action) => action?.type === 'attack');
+  if (sourceIndex === targetIndex) return next;
+  if (sourceIndex !== -1) {
+    [next[sourceIndex], next[targetIndex]] = [next[targetIndex], next[sourceIndex]];
+    return next;
+  }
+  next[targetIndex] = { type: 'attack' };
+  return next;
+}
+
 export function clearHotbarSlot(
   actions: readonly HotbarAction[],
   targetIndex: number,
@@ -253,6 +274,7 @@ export function hotbarActionsEqual(
   return a.every((action, i) => {
     const other = b[i];
     if (action === null || other === null) return action === other;
+    if (action.type === 'attack' || other.type === 'attack') return action.type === other.type;
     return action.type === other.type && action.id === other.id;
   });
 }

--- a/src/ui/options_view.ts
+++ b/src/ui/options_view.ts
@@ -429,7 +429,6 @@ export function buildInterfaceControls(s: OptionsSettingsSource): OptionsControl
       disabled: !s.bool('showSecondaryActionBar'),
     }),
     boolToggle(s, 'showTargetOfTarget', 'hudChrome.options.showTargetOfTarget'),
-    boolToggle(s, 'showAttackButton', 'hudChrome.options.showAttackButton'),
     boolToggle(s, 'showDailyRewardsChest', 'hudChrome.options.showDailyRewardsChest'),
   ];
 }

--- a/src/ui/spellbook_view.ts
+++ b/src/ui/spellbook_view.ts
@@ -55,10 +55,10 @@ export interface SpellbookView {
   classId: PlayerClass;
   /** Drives the per-form "reset bar" button (only classes with form bars). */
   hasFormBars: boolean;
-  /** The pinned basic Attack row's toggle state: whether the Attack toggle
-   *  currently occupies action-bar slot 0 (the Interface showAttackButton
-   *  option). Attack is not an ability, so it rides the view beside `rows`
-   *  instead of forging a fake ResolvedAbility row. */
+  /** Whether the basic Attack action is currently available on the action bar,
+   *  either as the fixed slot-0 button or as an assigned hotbar action. Attack is
+   *  not an ability, so it rides the view beside `rows` instead of forging a fake
+   *  ResolvedAbility row. */
   attackOnBar: boolean;
   rows: SpellbookRow[];
   /** No rows rendered at all (the class kit was empty). */
@@ -76,7 +76,7 @@ export interface SpellbookInput {
   barAbilityIds: readonly string[];
   /** The action bar has at least one empty slot. */
   hasFreeSlot: boolean;
-  /** The Attack toggle currently occupies bar slot 0 (showAttackButton on). */
+  /** The Attack action is currently present on the bar. */
   attackOnBar: boolean;
   /** The class has per-form bars (druid), so the reset-bar button is shown. */
   hasFormBars: boolean;

--- a/src/ui/spellbook_window.ts
+++ b/src/ui/spellbook_window.ts
@@ -27,6 +27,7 @@ import { esc } from './esc';
 import {
   encodeHotbarAction,
   HOTBAR_ACTION_MIME,
+  type HotbarAction,
   isAbilityActionBarEligible,
 } from './hud/action_bar/hotbar';
 import { formatNumber, t } from './i18n';
@@ -59,12 +60,12 @@ export interface SpellbookWindowDeps {
   abilityIdByBarSlot(): (string | null)[];
   /** The action bar has at least one empty slot. */
   hasFreeSlot(): boolean;
-  /** The Attack toggle currently occupies bar slot 0 (showAttackButton on). */
+  /** The Attack action is currently present on the bar. */
   attackOnBar(): boolean;
-  /** Restore (true) or remove (false) the Attack toggle on bar slot 0; routes
-   *  through the same Interface showAttackButton setting the options window and
-   *  the slot's right-click use, so all three controls stay one state. */
-  setAttackOnBar(on: boolean): void;
+  /** Place the basic Attack action on the first free assignable slot. */
+  addAttackToBar(): boolean;
+  /** Remove an assigned Attack action, or hide the fixed Attack slot if present. */
+  removeAttackFromBar(): boolean;
   /** Place an ability on the first free slot; returns whether it changed. */
   addToBar(abilityId: string): boolean;
   /** Remove an ability from the bar; returns whether it changed. */
@@ -73,7 +74,7 @@ export interface SpellbookWindowDeps {
   hasFormBars(): boolean;
   /** Reset the active form bar to its default kit. */
   resetFormBar(): void;
-  setDragAction(action: { type: 'ability'; id: string } | null): void;
+  setDragAction(action: Exclude<HotbarAction, null> | null): void;
   clearActionDropTargets(): void;
 }
 
@@ -224,9 +225,9 @@ export class SpellbookWindow {
   // keybind use) without a full rebuild. Mirrors the inline refreshSpellbookHotbar
   // controls but scoped to this window's root.
   refreshHotbarControls(): void {
-    // The Attack toggle tracks the Interface showAttackButton setting, which can
-    // flip while the window is open (the options window, or a right-click on the
-    // slot-0 button itself). Same elision discipline as the ability toggles:
+    // The Attack toggle tracks whether Attack is available on the bar, either as
+    // the fixed slot-0 button or as an assigned action. Same elision discipline as
+    // the ability toggles:
     // rewrite only when the on-bar state actually flips.
     const attackBtn = this.deps.root().querySelector<HTMLButtonElement>('[data-attack-toggle]');
     if (attackBtn) {
@@ -285,10 +286,8 @@ export class SpellbookWindow {
   }
 
   // The pinned basic Attack row, first in the list (classic spellbooks lead with
-  // Attack). Attack is not an ability: its +/- toggle restores or removes the
-  // fixed Attack button on bar slot 0 through the same Interface
-  // showAttackButton setting the options window drives, so a player who
-  // right-clicked the button away can always get it back from here. Reuses the
+  // Attack). Attack is not an ability, but it is an assignable hotbar action: its
+  // +/- toggle uses the same add/remove flow as normal spell rows. Reuses the
   // existing attackName/attackTooltip keys and the add/remove aria pair; no new
   // player strings.
   private appendAttackRow(list: HTMLElement, onBar: boolean): void {
@@ -319,11 +318,26 @@ export class SpellbookWindow {
     toggle.addEventListener('click', (ev) => {
       ev.preventDefault();
       ev.stopPropagation();
-      this.deps.setAttackOnBar(!this.deps.attackOnBar());
+      const changed = this.deps.attackOnBar()
+        ? this.deps.removeAttackFromBar()
+        : this.deps.addAttackToBar();
+      if (!changed) return;
       audio.click();
       this.refreshHotbarControls();
     });
     el.appendChild(toggle);
+    el.draggable = true;
+    el.addEventListener('dragstart', (e) => {
+      const action = { type: 'attack' as const };
+      this.deps.setDragAction(action);
+      this.writeDraggedAction(e.dataTransfer, action);
+      if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move';
+      this.deps.hideTooltip();
+    });
+    el.addEventListener('dragend', () => {
+      this.deps.setDragAction(null);
+      this.deps.clearActionDropTargets();
+    });
     this.deps.attachTooltip(
       el,
       () =>
@@ -434,13 +448,10 @@ export class SpellbookWindow {
 
   // Reproduced from the exported hotbar encoder so cross-window drag state stays on
   // the HUD via the deps (mirrors bags_window).
-  private writeDraggedAction(
-    dt: DataTransfer | null,
-    action: { type: 'ability'; id: string },
-  ): void {
+  private writeDraggedAction(dt: DataTransfer | null, action: Exclude<HotbarAction, null>): void {
     if (!dt) return;
     dt.setData(HOTBAR_ACTION_MIME, encodeHotbarAction(action));
-    dt.setData('text/plain', action.id);
+    dt.setData('text/plain', action.type === 'attack' ? 'attack' : action.id);
   }
 
   private abilityName(def: AbilityDef): string {

--- a/tests/action_bar_controller.test.ts
+++ b/tests/action_bar_controller.test.ts
@@ -359,6 +359,26 @@ describe('ActionBarController attack slot', () => {
     expect(storage.getItem('woc_hotbar_warrior_ActionbarTester:s0')).toBeNull();
   });
 
+  it('assigns Attack into the normal layout and renders it as an Attack slot', () => {
+    const harness = makeHarness('warrior', ['strike'], bar('strike'));
+    harness.state.showAttackButton = false;
+    harness.controller.init();
+
+    expect(harness.controller.addAttack()).toBe(true);
+    expect(harness.controller.actionForSlot(1)).toEqual({ type: 'attack' });
+    expect(harness.controller.slotRendersAttack(1)).toBe(true);
+
+    harness.controller.replaceAttackAction({ type: 'attack' });
+    harness.controller.saveAttackAction();
+
+    const reloaded = makeHarness('warrior', ['strike'], bar(), harness.storage);
+    reloaded.state.showAttackButton = false;
+    reloaded.controller.init();
+
+    expect(reloaded.controller.actionForSlot(0)).toEqual({ type: 'attack' });
+    expect(reloaded.controller.slotRendersAttack(0)).toBe(true);
+  });
+
   it('reloads a druid form-scoped attack slot on shapeshift instead of leaking the caster slot', () => {
     const harness = makeHarness('druid', ['bear_form', 'cat_form', 'claw', 'mangle'], bar());
     harness.state.showAttackButton = false;

--- a/tests/hotbar.test.ts
+++ b/tests/hotbar.test.ts
@@ -17,6 +17,7 @@ import {
   parseHotbarActions,
   parseStoredHotbarAction,
   placeAbilityOnSlot,
+  placeAttackOnSlot,
   placeItemOnSlot,
   resolveMobileHotbarDrop,
   saveAttackSlotAction,
@@ -234,15 +235,19 @@ describe('hotbar action placement', () => {
     expect(slots).toHaveLength(barSlots);
     // ice_barrier is an overflow spell learned beyond the initial bar slots.
     expect(mageAbilities.indexOf('ice_barrier')).toBeGreaterThanOrEqual(barSlots);
-    expect(slots.some((action) => action.id === 'ice_barrier')).toBe(false);
+    expect(slots.some((action) => action?.type === 'ability' && action.id === 'ice_barrier')).toBe(
+      false,
+    );
 
     const next = placeAbilityOnSlot(slots, 'ice_barrier', targetIndex);
-    const occupied = next.filter((action) => action !== null);
+    const occupied = next.flatMap((action) => (action === null ? [] : [action]));
 
     expect(next[targetIndex]).toEqual({ type: 'ability', id: 'ice_barrier' });
     expect(next).not.toContain(displacedAbility);
     expect(occupied).toHaveLength(barSlots);
-    expect(new Set(occupied.map((action) => action!.id)).size).toBe(occupied.length);
+    expect(
+      new Set(occupied.map((action) => (action.type === 'attack' ? 'attack' : action.id))).size,
+    ).toBe(occupied.length);
     expect(slots).toEqual(mageAbilities.slice(0, barSlots).map((id) => ({ type: 'ability', id })));
   });
 });
@@ -635,6 +640,30 @@ describe('desktop attack slot behavior', () => {
     });
     saveAttackSlotAction(store, key, null);
     expect(store.getItem(key)).toBeNull();
+  });
+
+  it('round-trips Attack as an assignable persisted action', () => {
+    const store = storage();
+    const key = attackSlotStorageKey('woc_hotbar_warrior_Thorgar');
+
+    saveAttackSlotAction(store, key, { type: 'attack' });
+
+    expect(loadAttackSlotAction(store, key, abilityExists, itemExists)).toEqual({
+      type: 'attack',
+    });
+    expect(parseHotbarActions([{ type: 'attack' }], 1, abilityExists, itemExists)).toEqual([
+      { type: 'attack' },
+    ]);
+  });
+
+  it('places Attack on a target slot without duplicating it', () => {
+    const actions = [{ type: 'attack' as const }, { type: 'ability' as const, id: 'fireball' }];
+
+    expect(placeAttackOnSlot(actions, 1)).toEqual([
+      { type: 'ability', id: 'fireball' },
+      { type: 'attack' },
+    ]);
+    expect(placeAttackOnSlot([null, null], 1)).toEqual([null, { type: 'attack' }]);
   });
 
   it('rejects malformed and stale persisted actions', () => {

--- a/tests/options_view.test.ts
+++ b/tests/options_view.test.ts
@@ -302,9 +302,9 @@ describe('options_view: interface dispatch matrix (cluster 5)', () => {
       'showSecondaryActionBar',
       'showThirdActionBar',
       'showTargetOfTarget',
-      'showAttackButton',
       'showDailyRewardsChest',
     ]);
+    expect(controls.filter((c) => 'key' in c && c.key === 'showAttackButton')).toHaveLength(1);
     expect(find(controls, 'partyFrameStyle')).toMatchObject({
       control: 'choice',
       options: [

--- a/tests/parity/golden/targeting_markers.json
+++ b/tests/parity/golden/targeting_markers.json
@@ -5,7 +5,7 @@
   "ticks": 0,
   "coverage": [
     "tabTarget cycle over visible enemies via orderTabTargets + grid order (~9690)",
-    "targetNearestEnemy / enemyCandidates grid scan, engaged vs idle (~9724/9740)",
+    "targetNearestEnemy / enemyCandidates focused order, engaged vs idle (~9724/9740)",
     "targetNearestFriendly + friendlyTabTarget wrap, autoAttack never armed (~9782/9797)",
     "setMarker set/toggle-off/symbol-uniqueness + clearEntityMarker death-strip (~11956/12002)"
   ],

--- a/tests/parity/scenarios.ts
+++ b/tests/parity/scenarios.ts
@@ -3415,7 +3415,7 @@ function targetingMarkers(): Scenario {
     name: 'targeting_markers',
     coverage: [
       'tabTarget cycle over visible enemies via orderTabTargets + grid order (~9690)',
-      'targetNearestEnemy / enemyCandidates grid scan, engaged vs idle (~9724/9740)',
+      'targetNearestEnemy / enemyCandidates focused order, engaged vs idle (~9724/9740)',
       'targetNearestFriendly + friendlyTabTarget wrap, autoAttack never armed (~9782/9797)',
       'setMarker set/toggle-off/symbol-uniqueness + clearEntityMarker death-strip (~11956/12002)',
     ],

--- a/tests/spellbook_window.test.ts
+++ b/tests/spellbook_window.test.ts
@@ -78,9 +78,17 @@ describe('spellbook_window: the pinned Attack row', () => {
     expect(code).toContain("iconDataUrl('ability', 'attack')");
   });
 
-  it('routes the toggle through setAttackOnBar with aria-pressed state', () => {
-    expect(code).toContain('this.deps.setAttackOnBar(!this.deps.attackOnBar())');
+  it('routes the toggle through assignable Attack add/remove callbacks', () => {
+    expect(code).toContain('this.deps.removeAttackFromBar()');
+    expect(code).toContain('this.deps.addAttackToBar()');
     expect(code).toContain("toggle.dataset.attackToggle = '1'");
+  });
+
+  it('makes Attack draggable as a hotbar action payload', () => {
+    expect(code).toContain("const action = { type: 'attack' as const }");
+    expect(code).toContain(
+      "dt.setData('text/plain', action.type === 'attack' ? 'attack' : action.id)",
+    );
   });
 
   it('keeps the per-frame refresh syncing the Attack toggle (options can flip it)', () => {

--- a/tests/targeting.test.ts
+++ b/tests/targeting.test.ts
@@ -170,6 +170,30 @@ describe('Targeting: target selection', () => {
     expect(actor.targetId).toBe(11); // the nearer mob
   });
 
+  it('targetNearestEnemy keeps the target on an engaged fight before idle mobs', () => {
+    const t = makeCtx();
+    const actor = t.add(ent({ id: 1, kind: 'player', pos: { x: 0, y: 0, z: 0 }, facing: 0 }));
+    t.add(ent({ id: 10, hostile: true, pos: { x: 0, y: 0, z: 6 } }));
+    const engaged = t.add(
+      ent({ id: 11, hostile: true, pos: { x: 0, y: 0, z: 24 }, aggroTargetId: actor.id }),
+    );
+    const targeting = new Targeting(t.ctx);
+    targeting.targetNearestEnemy(1);
+    expect(actor.targetId).toBe(engaged.id);
+  });
+
+  it('targetNearestEnemy does not jump from a visible fight cluster to distant idle mobs', () => {
+    const t = makeCtx();
+    const actor = t.add(ent({ id: 1, kind: 'player', pos: { x: 0, y: 0, z: 0 }, facing: 0 }));
+    t.add(ent({ id: 10, hostile: true, pos: { x: 0, y: 0, z: 12 }, aggroTargetId: actor.id }));
+    const farIdle = t.add(ent({ id: 11, hostile: true, pos: { x: 0, y: 0, z: 38 } }));
+    const targeting = new Targeting(t.ctx);
+    for (let i = 0; i < 4; i++) {
+      targeting.targetNearestEnemy(1);
+      expect(actor.targetId).not.toBe(farIdle.id);
+    }
+  });
+
   it('friendlyTabTarget cycles party-mates by distance and wraps', () => {
     const t = makeCtx();
     const actor = t.add(ent({ id: 1, kind: 'player', pos: { x: 0, y: 0, z: 0 } }));


### PR DESCRIPTION
# Release v0.30.0

## Summary

This release repairs two approved community feedback items from the curated Discord channel:

- Fixed the basic Attack action so players can assign it from the spellbook/action-bar flow again.
- Removed the duplicated Show Attack Button control from Interface options.
- Updated Target Nearest Enemy so combat targeting stays focused on nearby active fights instead of jumping to distant idle mobs.

## Community PRs

No open community PRs were selected or merged in this run because `SCOPE_MAX_PR_MERGES=NONE`.

## Feedback Repairs

- Discord `1529170493549187102`: Attack could not be assigned as a spell/action. Addressed by `8f7e5a484` (`fix: make attack assignable from spellbook`).
- Discord `1529190935265542194`: Show Attack Button appeared twice in Interface options. Addressed by `8f7e5a484` (`fix: make attack assignable from spellbook`).
- Discord `1529198534866505819`: Target Nearest Enemy could select far-away mobs while the player was already fighting nearby enemies. Addressed by `c7aea4f9d` (`fix: keep enemy targeting on active fights`) and `f8f008639` (`test: refresh targeting parity label`).

## Included Commits

- `60dd797f8` `fix(sfx): use runnable ffprobe package`
- `8f7e5a484` `fix: make attack assignable from spellbook`
- `c7aea4f9d` `fix: keep enemy targeting on active fights`
- `f8f008639` `test: refresh targeting parity label`

## Verification

- Base health release-tier gate: green after base SFX tooling repair.
- Release-tier gate: green.
- Final security review: passed.
- Automated tests: `1382` files passed, `16790` tests passed, `18` skipped.
- Community PR tester verdicts: none, because no community PRs were merged. `USE_TESTERS=false`, so there was no per-PR playtest coverage to report.

## Bounced or Dropped Work

None.
