### PR TITLE
fix(auth): require full scope for WebSocket and admin access

### DIFF
--- a/server/account.ts
+++ b/server/account.ts
@@ -24,7 +24,6 @@ import {
   accountAndScopeForToken,
   accountById,
   accountByUnsubscribeToken,
-  accountForToken,
   accountMailTarget,
   accountTwoFactorEnabled,
   backfillAccountEmailIfEmpty,
@@ -631,7 +630,6 @@ function useRuntime(): AccountGameHooks {
 
 const REAL_ACCOUNT_DB = {
   accountAndScopeForToken,
-  accountForToken,
   moderationStatusForAccount,
   createCompanionToken,
   listCompanionTokens,
@@ -697,12 +695,12 @@ const activeGuard: Middleware = async (ctx, next) => {
  * Logout gate (mirrors the legacy /api/account/logout arm): any bearer token that
  * still maps to an account may proceed, with NO scope or moderation gate, so a
  * banned/suspended/deactivated account can still sign out this device. A missing
- * token 401s DB-free; a present-but-unknown token 401s after the accountForToken
- * lookup, exactly as the legacy arm did.
+ * token 401s DB-free; a present-but-unknown token 401s after the scoped lookup,
+ * exactly as the legacy arm did.
  */
 const logoutGuard: Middleware = async (ctx, next) => {
   const token = bearerToken(ctx.req);
-  if (token === null || (await accountDb.accountForToken(token)) === null) {
+  if (token === null || (await accountDb.accountAndScopeForToken(token)) === null) {
     json(ctx.res, 401, NOT_AUTHENTICATED);
     return;
   }

--- a/server/admin.ts
+++ b/server/admin.ts
@@ -50,8 +50,8 @@ import {
 } from './chat_filter_db';
 import { currentDailyRewardDay } from './daily_rewards';
 import {
+  accountAndScopeForToken,
   accountById,
-  accountForToken,
   accountMailTarget,
   findAccount,
   isAdminAccount,
@@ -275,8 +275,9 @@ interface AdminIdentity {
 async function adminIdentity(req: http.IncomingMessage): Promise<AdminIdentity | null> {
   const m = /^Bearer ([a-f0-9]{64})$/.exec(req.headers.authorization ?? '');
   if (!m) return null;
-  const accountId = await accountForToken(m[1]);
-  if (accountId === null) return null;
+  const account = await accountAndScopeForToken(m[1]);
+  if (account === null || account.scope !== 'full') return null;
+  const accountId = account.accountId;
   const staff = await adminRolesForAccount(accountId);
   if (staff === null) return null;
   return {
@@ -1051,15 +1052,15 @@ export async function handleAdminApi(
 //    internal throw). The happy + guard paths never reach withErrors.
 //
 //  - AUTH is the legacy-body admin gate (createRequireAdmin), mirroring
-//    adminIdentity(req) EXACTLY (v0.22.0 staff roles): bearer -> accountForToken ->
-//    staff_db.adminRolesForAccount (fail closed; no roles means not staff), a
+//    adminIdentity(req) EXACTLY (v0.22.0 staff roles): bearer -> scoped token
+//    resolver (full required) -> staff_db.adminRolesForAccount (fail closed), a
 //    uniform 401 { ...error: 'admin authentication required' } on any failure, then
 //    the CENTRAL AUTHORIZATION gate: the route's declared permission resolves from
 //    ADMIN_ROUTE_PERMISSIONS (server/admin_routes.ts) against the concrete request
 //    path, fail-closed (unmapped -> 404 'unknown admin endpoint' / 405; missing
 //    permission -> 403), mirroring the legacy handleAdminApi preamble byte-for-byte.
-//    NO read-only-scope 403 and NO moderation gate (legacy admin auth applies
-//    neither). Mounted on every route except login (anonymous by design).
+//    Read-scope tokens receive the same uniform 401 as every other invalid admin
+//    credential. No moderation gate applies. Mounted on every route except login.
 //    requireAdmin runs BEFORE the :id / :action decode, so an unauthenticated
 //    malformed request 401s exactly as legacy did (auth precedes route/method).
 //
@@ -1224,7 +1225,7 @@ function makeRealAdminDb() {
     moderationQueue,
     moderationReportsForAccount,
     muteAccountChat,
-    accountForToken,
+    accountAndScopeForToken,
     accountMailTarget,
     findAccount,
     // Target-account staff check (the "admin accounts cannot be suspended / banned /
@@ -1289,7 +1290,7 @@ export function resetAdminDbForTests(): void {
   adminDbOverride = undefined;
 }
 
-// The admin-auth gate reads its two db functions (accountForToken,
+// The admin-auth gate reads its two db functions (accountAndScopeForToken and
 // adminRolesForAccount) off the active bundle, so a setAdminDbForTests fake drives
 // it too. AdminDb is a superset of AdminAuthDb, so the getter is assignable.
 const requireAdmin = createRequireAdmin((): AdminAuthDb => adminDb());

--- a/server/admin.ts
+++ b/server/admin.ts
@@ -106,9 +106,10 @@ import {
 } from './staff_db';
 import { PgUserAssetsDb } from './user_assets_db';
 
-// Admin API: everything under /admin/api/*. Auth is a bearer token whose
-// account has at least one staff role (accounts.admin_roles; is_admin stays
-// the derived "is staff" flag): the admin.* hostname is routing, not security.
+// Admin API: everything under /admin/api/*. Auth is an exact full-scope bearer
+// token whose account has at least one staff role (accounts.admin_roles;
+// is_admin stays the derived "is staff" flag): the admin.* hostname is routing,
+// not security.
 // Authorization is per route: every route is declared with a permission in
 // admin_routes.ts and gated centrally in handleAdminApi before any handler
 // runs, so a route absent from that table can never execute.

--- a/server/db.ts
+++ b/server/db.ts
@@ -178,6 +178,24 @@ const LIFETIME_XP_EXPR = "((state->>'lifetimeXp')::bigint)";
 export const ELIGIBLE_ACCOUNT_SQL =
   'a.banned_at IS NULL AND (a.suspended_until IS NULL OR a.suspended_until <= now())';
 
+// Additive scope-domain hardening for auth_tokens. NOT VALID avoids a table
+// scan and tolerates any historical bad rows during deploy, while PostgreSQL
+// still enforces the constraint for every new or updated row. Runtime token
+// decoding independently fails closed on historical values outside this set.
+// Exported so the opt-in real-Postgres migration test executes this exact DDL.
+export const AUTH_TOKENS_SCOPE_CONSTRAINT_SQL = `DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'auth_tokens_scope_check'
+      AND conrelid = 'auth_tokens'::regclass
+  ) THEN
+    ALTER TABLE auth_tokens
+      ADD CONSTRAINT auth_tokens_scope_check CHECK (scope IN ('full', 'read')) NOT VALID;
+  END IF;
+END $$;`;
+
 export const SCHEMA = `
 CREATE TABLE IF NOT EXISTS accounts (
   id SERIAL PRIMARY KEY,
@@ -200,18 +218,7 @@ CREATE INDEX IF NOT EXISTS auth_tokens_account ON auth_tokens(account_id);
 -- token in the account portal so a user can revoke a specific one.
 ALTER TABLE auth_tokens ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT 'full';
 ALTER TABLE auth_tokens ADD COLUMN IF NOT EXISTS label TEXT;
-DO $$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1
-    FROM pg_constraint
-    WHERE conname = 'auth_tokens_scope_check'
-      AND conrelid = 'auth_tokens'::regclass
-  ) THEN
-    ALTER TABLE auth_tokens
-      ADD CONSTRAINT auth_tokens_scope_check CHECK (scope IN ('full', 'read')) NOT VALID;
-  END IF;
-END $$;
+${AUTH_TOKENS_SCOPE_CONSTRAINT_SQL}
 CREATE TABLE IF NOT EXISTS characters (
   id SERIAL PRIMARY KEY,
   account_id INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,

--- a/server/db.ts
+++ b/server/db.ts
@@ -200,6 +200,18 @@ CREATE INDEX IF NOT EXISTS auth_tokens_account ON auth_tokens(account_id);
 -- token in the account portal so a user can revoke a specific one.
 ALTER TABLE auth_tokens ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT 'full';
 ALTER TABLE auth_tokens ADD COLUMN IF NOT EXISTS label TEXT;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'auth_tokens_scope_check'
+      AND conrelid = 'auth_tokens'::regclass
+  ) THEN
+    ALTER TABLE auth_tokens
+      ADD CONSTRAINT auth_tokens_scope_check CHECK (scope IN ('full', 'read')) NOT VALID;
+  END IF;
+END $$;
 CREATE TABLE IF NOT EXISTS characters (
   id SERIAL PRIMARY KEY,
   account_id INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
@@ -1492,18 +1504,10 @@ export async function saveToken(
   );
 }
 
-export async function accountForToken(token: string): Promise<number | null> {
-  const res = await pool.query(
-    'SELECT account_id FROM auth_tokens WHERE token = $1 AND expires_at > now()',
-    [token],
-  );
-  return res.rows[0]?.account_id ?? null;
-}
-
-// Account + scope for a live token. Mirrors accountForToken but also returns the
-// token's scope so read routes can accept 'read'|'full' while mutating routes
-// (via bearerActiveAccount) reject anything that is not 'full'. Old tokens
-// predating the scope column read as 'full' via the column default.
+// Account + scope for a live token. Every caller receives the authority context:
+// read routes may accept both scopes, while mutation and privileged boundaries
+// require exact full scope. Unknown database values fail closed instead of being
+// promoted to full authority.
 export async function accountAndScopeForToken(
   token: string,
 ): Promise<{ accountId: number; scope: TokenScope } | null> {
@@ -1513,7 +1517,8 @@ export async function accountAndScopeForToken(
   );
   const row = res.rows[0];
   if (!row) return null;
-  return { accountId: row.account_id, scope: row.scope === 'read' ? 'read' : 'full' };
+  if (row.scope !== 'full' && row.scope !== 'read') return null;
+  return { accountId: row.account_id, scope: row.scope };
 }
 
 export interface AccountInfoRow {

--- a/server/desktop_login.ts
+++ b/server/desktop_login.ts
@@ -70,7 +70,7 @@ export function desktopLoginCodeCountForTest(): number {
 // Shapes are structural subsets of the real functions on purpose.
 //
 // Scope fix: the create leg no longer resolves its own bearer (the
-// original deps carried the scope-blind accountForToken, which let a read-scope
+// original deps carried a scope-blind identity resolver, which let a read-scope
 // companion/OAuth token mint a handoff code that exchange then traded for a
 // FULL session, a scope escalation). Both serving paths now authenticate with
 // the full-session resolver BEFORE calling issueDesktopLoginCode: the legacy

--- a/server/desktop_login_routes.ts
+++ b/server/desktop_login_routes.ts
@@ -18,7 +18,7 @@
 // - Scope fix (maintainer-resolved fork): create authenticates via
 //   the shared createActiveGuard (full active session; a read-scope
 //   companion/OAuth token answers 403 'this token is read-only'), where the
-//   original handler used the scope-blind accountForToken, letting a read token
+//   original handler used a scope-blind identity resolver, letting a read token
 //   escalate to the full session exchange mints. The legacy arm carries the
 //   mirror fix (bearerActiveAccount before issueDesktopLoginCode); the
 //   desktopLoginCreateFullScope known deviation records the contract change.

--- a/server/http/middleware/require_admin.ts
+++ b/server/http/middleware/require_admin.ts
@@ -53,6 +53,7 @@
 
 import { type AdminPermission, permissionsForRoles } from '../../admin_permissions';
 import { adminPathKnown, permissionForAdminRoute } from '../../admin_routes';
+import type { TokenScope } from '../../db';
 import { json } from '../../http_util';
 import { num } from '../schema';
 import type { Ctx, Middleware, Next, RouteMeta } from '../types';
@@ -88,11 +89,12 @@ export interface AdminIdentity {
 /**
  * The two db reads the admin gate needs, bundled so a unit test can inject a fake
  * with no Postgres. The shape mirrors the real server exports the legacy
- * adminIdentity(req) resolver calls (db.accountForToken, staff_db.adminRolesForAccount).
+ * adminIdentity(req) resolver calls (the scoped token resolver and
+ * staff_db.adminRolesForAccount).
  */
 export interface AdminAuthDb {
-  /** Account id for a live bearer token, or null (mirrors db.accountForToken). */
-  accountForToken(token: string): Promise<number | null>;
+  /** Account id and authority for a live bearer token, or null. */
+  accountAndScopeForToken(token: string): Promise<{ accountId: number; scope: TokenScope } | null>;
   /** Staff username + roles, or null when not staff (mirrors staff_db.adminRolesForAccount). */
   adminRolesForAccount(accountId: number): Promise<{ username: string; roles: string[] } | null>;
 }
@@ -109,9 +111,14 @@ export function createRequireAdmin(getDb: () => AdminAuthDb): Middleware {
   return async (ctx: Ctx, next: Next) => {
     const token = bearerToken(ctx.req);
     const db = getDb();
-    const accountId = token === null ? null : await db.accountForToken(token);
-    const staff = accountId === null ? null : await db.adminRolesForAccount(accountId);
-    if (accountId === null || staff === null) {
+    const account = token === null ? null : await db.accountAndScopeForToken(token);
+    if (account === null || account.scope !== 'full') {
+      json(ctx.res, 401, ADMIN_AUTH_REQUIRED);
+      return;
+    }
+    const accountId = account.accountId;
+    const staff = await db.adminRolesForAccount(accountId);
+    if (staff === null) {
       json(ctx.res, 401, ADMIN_AUTH_REQUIRED);
       return;
     }
@@ -151,12 +158,7 @@ export function createRequireAdmin(getDb: () => AdminAuthDb): Middleware {
       return;
     }
 
-    // NOMINAL stamp, not the token's real scope: the legacy gate never scope-checks
-    // an admin bearer (accountForToken ignores the scope column, so a read-scope
-    // companion token of a staff account passes too, parity-first). Today's admin
-    // handlers read only ctxAccountId; do NOT trust ctx.account.scope downstream of
-    // requireAdmin for a scope decision without resolving the token's actual scope.
-    ctx.account = { accountId, scope: 'full' };
+    ctx.account = { accountId, scope: account.scope };
     ctx.state.set(ADMIN_IDENTITY, identity);
     await next();
   };

--- a/server/http/middleware/require_admin.ts
+++ b/server/http/middleware/require_admin.ts
@@ -4,10 +4,11 @@
 //
 //  - createRequireAdmin(getDb): the admin-auth gate. It mirrors the legacy
 //    adminIdentity(req) resolver EXACTLY (server/admin.ts): resolve the 64-hex
-//    bearer, look up the account, require at least one staff role
-//    (staff_db.adminRolesForAccount, fail closed; roles are re-read on every
-//    request so a dashboard revocation applies to the next call). On ANY failure
-//    (absent/bad token, unknown account, non-staff account) it writes the legacy
+//    bearer, require its exact scope to be 'full', then require at least one
+//    staff role (staff_db.adminRolesForAccount, fail closed; roles are re-read
+//    on every request so a dashboard revocation applies to the next call). On
+//    ANY failure
+//    (absent/bad/read token, unknown account, non-staff account) it writes the legacy
 //    admin envelope body { success: false, data: null, error: 'admin authentication
 //    required' } at 401 and short-circuits (no next()), so the no-auth admin goldens
 //    replay byte-identically. A missing/malformed bearer 401s WITHOUT a DB call.
@@ -23,8 +24,8 @@
 //    ('any' admits any staff account). On success it sets ctx.account (admin
 //    tokens are full-scope), stashes the resolved AdminIdentity on ctx.state for
 //    the handlers (/me, staff-role writes), and calls next(). The gate applies NO
-//    read-only-scope 403 and NO moderation gate (staff is trusted operator
-//    authority), preserving the legacy gate byte-for-byte.
+//    separate read-only-scope 403 and NO moderation gate (staff is trusted operator
+//    authority). Read tokens use the same uniform 401 as other invalid credentials.
 //
 //  - requireAdminTarget(kind): the admin-scope :id loader. It decodes the :id param
 //    with num({ int, min: 1 }) BEFORE any DB call (a non-numeric / non-positive id

--- a/server/main.ts
+++ b/server/main.ts
@@ -95,7 +95,6 @@ import {
   type ArenaLeaderRow,
   accountAndScopeForToken,
   accountById,
-  accountForToken,
   acquireCharacterLease,
   bankBonusFactsForAccount,
   type CharacterRow,
@@ -985,7 +984,8 @@ async function bearerAccount(req: http.IncomingMessage): Promise<number | null> 
   const auth = req.headers.authorization ?? '';
   const m = /^Bearer ([a-f0-9]{64})$/.exec(auth);
   if (!m) return null;
-  return accountForToken(m[1]);
+  const info = await accountAndScopeForToken(m[1]);
+  return info?.accountId ?? null;
 }
 
 // Account + token scope for the bearer (or null when unauthenticated). The scope
@@ -1452,7 +1452,7 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       // via exchange, so create requires a full active session too
       // (bearerActiveAccount: read and companion tokens answer 403 'this token
       // is read-only'), where the pre-fix handler resolved the scope-blind
-      // accountForToken. Mirrored on
+      // identity-only token resolver. Mirrored on
       // the RouteDef twin (server/desktop_login_routes.ts); the
       // desktopLoginCreateFullScope known deviation records the change.
       const accountId = await bearerActiveAccount(req, res);
@@ -2025,7 +2025,7 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
     }
     if (req.method === 'POST' && url === '/api/account/logout') {
       const callerToken = bearerToken(req);
-      if (!callerToken || (await accountForToken(callerToken)) === null)
+      if (!callerToken || (await accountAndScopeForToken(callerToken)) === null)
         return json(res, 401, { error: 'not authenticated', code: 'auth.required' });
       return handleAccountLogout(res, callerToken);
     }
@@ -2959,7 +2959,7 @@ export async function startServer(): Promise<http.Server> {
   const wss = new WebSocketServer({ noServer: true, maxPayload: WS_MAX_PAYLOAD_BYTES });
   const wsAuth = createWsAuth({
     game,
-    accountForToken,
+    accountAndScopeForToken,
     moderationStatusForAccount,
     getCharacter,
     chatMuteStatusForAccount,

--- a/server/maps_routes.ts
+++ b/server/maps_routes.ts
@@ -24,7 +24,7 @@
 
 import type * as http from 'node:http';
 import { parsePageParams } from './admin';
-import { accountAndScopeForToken, accountForToken, moderationStatusForAccount, pool } from './db';
+import { accountAndScopeForToken, moderationStatusForAccount, pool } from './db';
 import { ctxAccountId } from './http/context';
 import { createActiveGuard, createReadGuard } from './http/middleware/bearer_active_guard';
 import { MAP_MUTATION_POLICY, PUBLIC_READ_POLICY, rateLimit } from './http/middleware/rate_limit';
@@ -212,7 +212,7 @@ export async function mapSetPublishedCore(
 // mirrors the legacy lane: BEFORE auth, 413 + Connection: close, no body read.
 // ---------------------------------------------------------------------------
 
-const REAL_GUARD_DB = { accountAndScopeForToken, accountForToken, moderationStatusForAccount };
+const REAL_GUARD_DB = { accountAndScopeForToken, moderationStatusForAccount };
 let guardDbBundle = REAL_GUARD_DB;
 
 /** Override the bearer-guard db reads with fakes (test-only). */
@@ -250,7 +250,8 @@ const VIEWER_ACCOUNT = 'maps_viewer_account';
 const BEARER_PATTERN = /^Bearer ([a-f0-9]{64})$/;
 const optionalViewerGuard: Middleware = async (ctx, next) => {
   const m = BEARER_PATTERN.exec(ctx.req.headers.authorization ?? '');
-  const accountId = m ? await guardDbBundle.accountForToken(m[1]) : null;
+  const info = m ? await guardDbBundle.accountAndScopeForToken(m[1]) : null;
+  const accountId = info?.accountId ?? null;
   if (accountId === null && !publicReadRateLimited(ctx.req).allowed) {
     json(ctx.res, 429, RATE_LIMITED);
     return;

--- a/server/perf_report.ts
+++ b/server/perf_report.ts
@@ -1,6 +1,6 @@
 import type * as http from 'node:http';
 import {
-  accountForToken,
+  accountAndScopeForToken,
   type ClientPerfReportInsert,
   getCharacter,
   insertClientPerfReport,
@@ -272,7 +272,8 @@ function rawSummary(value: unknown, devTraceAllowed = false): Record<string, unk
 async function authenticatedAccountId(req: http.IncomingMessage): Promise<number | null> {
   const m = /^Bearer ([a-f0-9]{64})$/.exec(req.headers.authorization ?? '');
   if (!m) return null;
-  return accountForToken(m[1]);
+  const info = await accountAndScopeForToken(m[1]);
+  return info?.scope === 'full' ? info.accountId : null;
 }
 
 async function authenticatedCharacterId(

--- a/server/ws_auth.ts
+++ b/server/ws_auth.ts
@@ -21,6 +21,7 @@ import type {
   AccountCosmetics,
   AccountModerationStatus,
   CharacterRow,
+  TokenScope,
 } from './db';
 import type { GameServer } from './game';
 
@@ -69,7 +70,9 @@ function rejectHandshake(ws: WebSocket, error: string): void {
 
 export interface WsAuthDeps {
   game: GameServer;
-  accountForToken: (token: string) => Promise<number | null>;
+  accountAndScopeForToken: (
+    token: string,
+  ) => Promise<{ accountId: number; scope: TokenScope } | null>;
   moderationStatusForAccount: (accountId: number) => Promise<AccountModerationStatus>;
   getCharacter: (accountId: number, characterId: number) => Promise<CharacterRow | null>;
   chatMuteStatusForAccount: (accountId: number) => Promise<AccountChatMuteStatus>;
@@ -134,7 +137,7 @@ export interface WsAuthHandlers {
 export function createWsAuth(deps: WsAuthDeps): WsAuthHandlers {
   const {
     game,
-    accountForToken,
+    accountAndScopeForToken,
     moderationStatusForAccount,
     getCharacter,
     chatMuteStatusForAccount,
@@ -245,11 +248,12 @@ export function createWsAuth(deps: WsAuthDeps): WsAuthHandlers {
     // strings, booleans, and unknown future versions stay on the legacy wire.
     const timerWireVersion: 1 | typeof STABLE_TIMER_WIRE_VERSION =
       msg.timerWire === STABLE_TIMER_WIRE_VERSION ? STABLE_TIMER_WIRE_VERSION : 1;
-    const accountId = await accountForToken(token);
-    if (accountId === null || !Number.isFinite(characterId)) {
+    const account = await accountAndScopeForToken(token);
+    if (account === null || account.scope !== 'full' || !Number.isFinite(characterId)) {
       rejectHandshake(ws, WS_AUTH_ERROR.notAuthenticated);
       return;
     }
+    const accountId = account.accountId;
     const status = await moderationStatusForAccount(accountId);
     if (status.locked) {
       rejectHandshake(ws, status.message);

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -9,7 +9,7 @@ vi.mock('../server/db', () => ({
   findAccount: vi.fn(),
   touchLogin: vi.fn(),
   saveToken: vi.fn(),
-  accountForToken: vi.fn(),
+  accountAndScopeForToken: vi.fn(),
   isAdminAccount: vi.fn(),
   accountMailTarget: vi.fn(async () => null),
   accountById: vi.fn(),
@@ -116,8 +116,8 @@ import {
   updateFilterConfig,
 } from '../server/chat_filter_db';
 import {
+  accountAndScopeForToken,
   accountById,
-  accountForToken,
   accountMailTarget,
   findAccount,
   isAdminAccount,
@@ -144,6 +144,7 @@ import {
 } from '../server/staff_db';
 
 const VALID_TOKEN = 'a'.repeat(64);
+const fullToken = (accountId: number) => ({ accountId, scope: 'full' as const });
 
 function fakeReq(opts: { method?: string; url?: string; token?: string; body?: unknown } = {}) {
   const req = new EventEmitter() as EventEmitter & {
@@ -260,7 +261,7 @@ describe('admin api auth', () => {
   });
 
   it('rejects a valid token whose account is not an admin', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(false);
     const res = fakeRes();
 
@@ -270,8 +271,27 @@ describe('admin api auth', () => {
     expect(isAdminAccount).toHaveBeenCalledWith(7);
   });
 
+  it('rejects a staff read token before resolving roles or serving the handler', async () => {
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'read' });
+    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    vi.mocked(adminRolesForAccount).mockClear();
+    const res = fakeRes();
+
+    await handleAdminApi(fakeReq({ token: VALID_TOKEN }), res, fakeGame);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({
+      success: false,
+      data: null,
+      error: 'admin authentication required',
+    });
+    expect(adminRolesForAccount).not.toHaveBeenCalled();
+    expect(isAdminAccount).not.toHaveBeenCalled();
+    expect(overviewCounts).not.toHaveBeenCalled();
+  });
+
   it('serves the overview to an admin token and includes live server stats', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(overviewCounts).mockResolvedValue({
       accounts: 10,
@@ -310,7 +330,7 @@ describe('admin api auth', () => {
   });
 
   it('serves fresh counts to a later cold request instead of a stale snapshot', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     // A different stub body than the other overview test: without the
     // beforeEach cache reset, whichever overview test runs second would be
@@ -352,7 +372,7 @@ describe('admin api auth', () => {
     // proves both dispatch arms read the one injected canonicalPlayersCap source, and
     // reds if the legacy arm ever omits playersCap (the objectContaining "serves the
     // overview" case would stay green on such an omission).
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(overviewCounts).mockResolvedValue({
       accounts: 1,
@@ -384,7 +404,7 @@ describe('admin api auth', () => {
   });
 
   it('serves persistent online history with cleaned range parameters', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(onlineHistory).mockResolvedValue({
       range: '7d',
@@ -417,7 +437,7 @@ describe('admin api auth', () => {
   });
 
   it('serves live suspicious players to an authenticated admin', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     fakeGame.suspiciousPlayers.mockReturnValue([
       {
@@ -454,7 +474,7 @@ describe('admin api auth', () => {
   });
 
   it('serves detection calibration histograms to an authenticated admin', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     fakeGame.detectionCalibration.mockReturnValue({
       schemaVersion: 1,
@@ -520,7 +540,7 @@ describe('admin api auth', () => {
   });
 
   it('rejects non-GET methods on data endpoints', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     const res = fakeRes();
     await handleAdminApi(
@@ -533,7 +553,7 @@ describe('admin api auth', () => {
   });
 
   it('returns 404 for unknown admin endpoints', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     const res = fakeRes();
 
@@ -543,7 +563,7 @@ describe('admin api auth', () => {
   });
 
   it('passes pagination and search through to the accounts query', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(listAccounts).mockResolvedValue({ rows: [], total: 0, page: 2, limit: 50 });
     const res = fakeRes();
@@ -559,7 +579,7 @@ describe('admin api auth', () => {
   });
 
   it('passes pagination, search, and sorting through to the characters query', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(listCharacters).mockResolvedValue({ rows: [], total: 0, page: 3, limit: 50 });
     const res = fakeRes();
@@ -578,7 +598,7 @@ describe('admin api auth', () => {
   });
 
   it('serves shared IPs with their current block state', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(listSharedIps).mockResolvedValue({
       rows: [
@@ -612,7 +632,7 @@ describe('admin api auth', () => {
   });
 
   it('serves online shared IPs from memory without querying session history', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     fakeGame.liveSharedIps.mockReturnValue([
       {
@@ -655,7 +675,7 @@ describe('admin api auth', () => {
   });
 
   it('serves grouped IP associations with normalized pagination', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(associationsForIp).mockResolvedValue({
       ip: '203.0.113.7',
@@ -697,7 +717,7 @@ describe('admin api auth', () => {
   });
 
   it('rejects an invalid IP association lookup', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     const res = fakeRes();
 
@@ -712,7 +732,7 @@ describe('admin api auth', () => {
   });
 
   it('serves the moderation queue to admins with online account context', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(moderationQueue).mockResolvedValue([
       {
@@ -742,7 +762,7 @@ describe('admin api auth', () => {
   });
 
   it('serves perf summaries and raw rows through existing admin auth', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(clientPerfSummary).mockResolvedValue({
       hours: 24,
@@ -792,7 +812,7 @@ describe('admin api auth', () => {
   });
 
   it('loads moderation account detail with open reports', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(accountDetail).mockResolvedValue({
       id: 9,
@@ -830,7 +850,7 @@ describe('admin api auth', () => {
   });
 
   it('includes the in-memory online state in account detail without another query', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(accountDetail).mockResolvedValue({
       id: 9,
@@ -867,7 +887,7 @@ describe('admin api auth', () => {
   });
 
   it('ignores an open report', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(ignoreReport).mockResolvedValue(true);
     const res = fakeRes();
@@ -888,7 +908,7 @@ describe('admin api auth', () => {
   });
 
   it('suspends and disconnects an account', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     vi.mocked(moderateAccount).mockResolvedValue();
     const res = fakeRes();
@@ -917,7 +937,7 @@ describe('admin api auth', () => {
   });
 
   it('bans and disconnects an account', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     vi.mocked(moderateAccount).mockResolvedValue();
     const res = fakeRes();
@@ -945,7 +965,7 @@ describe('admin api auth', () => {
   });
 
   it('mutes account chat and sends a live warning without disconnecting', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     vi.mocked(muteAccountChat).mockResolvedValue();
     const res = fakeRes();
@@ -974,7 +994,7 @@ describe('admin api auth', () => {
   });
 
   it('unbans without disconnecting the account', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(moderateAccount).mockResolvedValue();
     const res = fakeRes();
@@ -1002,7 +1022,7 @@ describe('admin api auth', () => {
   });
 
   it('unsuspends without disconnecting the account', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(moderateAccount).mockResolvedValue();
     const res = fakeRes();
@@ -1031,7 +1051,7 @@ describe('admin api auth', () => {
   });
 
   it('rejects suspending or banning admin accounts', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValueOnce(true).mockResolvedValueOnce(true);
     const res = fakeRes();
 
@@ -1053,7 +1073,7 @@ describe('admin api auth', () => {
   });
 
   it('forces a character rename and disconnects that account', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(forceCharacterRename).mockResolvedValue({ accountId: 9 });
     const res = fakeRes();
@@ -1084,7 +1104,7 @@ describe('admin api auth', () => {
 
 describe('admin api chat filter', () => {
   beforeEach(() => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
   });
 
@@ -1211,7 +1231,7 @@ describe('admin api chat filter', () => {
   });
 
   it('lifts a mute and syncs the live session', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(liftAccountChatMute).mockResolvedValue();
     const res = fakeRes();
 
@@ -1336,7 +1356,7 @@ describe('escapeLike', () => {
 
 describe('blocked-ips admin route', () => {
   beforeEach(() => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(isAdminAccount).mockResolvedValue(true);
   });
 
@@ -1428,7 +1448,7 @@ describe('blocked-ips admin route', () => {
 
 describe('admin api password reset', () => {
   const actAs = (roles: string[], accountId = 7) => {
-    vi.mocked(accountForToken).mockResolvedValue(accountId);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(accountId));
     vi.mocked(adminRolesForAccount).mockResolvedValue({ username: 'operator', roles });
   };
   const targetExists = () =>
@@ -1563,7 +1583,7 @@ describe('admin api password reset', () => {
 
 describe('admin api permissions', () => {
   const actAs = (roles: string[], accountId = 7) => {
-    vi.mocked(accountForToken).mockResolvedValue(accountId);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(accountId));
     vi.mocked(adminRolesForAccount).mockResolvedValue({ username: 'operator', roles });
   };
 
@@ -1706,7 +1726,7 @@ describe('admin api permissions', () => {
     expect(res.body.error).toBe('you cannot change your own roles');
 
     // Superadmin target: refused even for another superadmin actor.
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(adminRolesForAccount).mockImplementation(async (id: number) =>
       id === 7
         ? { username: 'operator', roles: ['superadmin'] }
@@ -1721,7 +1741,7 @@ describe('admin api permissions', () => {
   });
 
   it('applies a valid role change through the audited writer', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(adminRolesForAccount).mockImplementation(async (id: number) =>
       id === 7 ? { username: 'operator', roles: ['superadmin'] } : null,
     );
@@ -1834,7 +1854,7 @@ describe('staff role change live effects', () => {
     fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/staff/roles', body });
 
   const actorAndTarget = () => {
-    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
     vi.mocked(adminRolesForAccount).mockImplementation(async (id: number) =>
       id === 7
         ? { username: 'operator', roles: ['superadmin'] }

--- a/tests/antibot_config_api.test.ts
+++ b/tests/antibot_config_api.test.ts
@@ -12,7 +12,7 @@ vi.mock('../server/db', () => ({
   findAccount: vi.fn(),
   touchLogin: vi.fn(),
   saveToken: vi.fn(),
-  accountForToken: vi.fn(),
+  accountAndScopeForToken: vi.fn(),
   isAdminAccount: vi.fn(),
   accountMailTarget: vi.fn(async () => null),
 }));
@@ -38,7 +38,7 @@ import {
   saveAntibotConfigChange,
 } from '../server/antibot_config_db';
 import type { ConfigField } from '../server/bot_detector/contract';
-import { accountForToken, isAdminAccount } from '../server/db';
+import { accountAndScopeForToken, isAdminAccount } from '../server/db';
 import { adminRolesForAccount } from '../server/staff_db';
 
 const VALID_TOKEN = 'a'.repeat(64);
@@ -126,7 +126,7 @@ async function settle(res: FakeResponse): Promise<void> {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(accountForToken).mockResolvedValue(7);
+  vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 7, scope: 'full' });
   vi.mocked(isAdminAccount).mockResolvedValue(true);
   vi.mocked(adminRolesForAccount).mockResolvedValue({
     username: 'admin',
@@ -146,7 +146,9 @@ describe('GET /admin/api/antibot-config', () => {
     await handleAdminApi(fakeReq(), res, game);
     expect(res.statusCode).toBe(200);
     expect(res.body.data?.updatedAt).toBe('2026-07-04T00:00:00.000Z');
-    expect((res.body.data?.fields as ConfigField[])[0].id).toBe('gate.kick_score');
+    expect((res.body.data?.fields as ConfigField[] | undefined)?.[0]?.id).toBe(
+      'gate.kick_score',
+    );
   });
 });
 
@@ -173,7 +175,7 @@ describe('POST /admin/api/antibot-config', () => {
       7,
       'Tune after calibration',
     );
-    expect((res.body.data?.fields as ConfigField[])[0].value).toBe(1.5);
+    expect((res.body.data?.fields as ConfigField[] | undefined)?.[0]?.value).toBe(1.5);
     expect(res.body.data?.updatedAt).toBe('2026-07-04T00:00:01.000Z');
   });
 

--- a/tests/antibot_config_api.test.ts
+++ b/tests/antibot_config_api.test.ts
@@ -146,9 +146,7 @@ describe('GET /admin/api/antibot-config', () => {
     await handleAdminApi(fakeReq(), res, game);
     expect(res.statusCode).toBe(200);
     expect(res.body.data?.updatedAt).toBe('2026-07-04T00:00:00.000Z');
-    expect((res.body.data?.fields as ConfigField[] | undefined)?.[0]?.id).toBe(
-      'gate.kick_score',
-    );
+    expect((res.body.data?.fields as ConfigField[] | undefined)?.[0]?.id).toBe('gate.kick_score');
   });
 });
 

--- a/tests/auth_token_scope_constraint_integration.test.ts
+++ b/tests/auth_token_scope_constraint_integration.test.ts
@@ -1,0 +1,94 @@
+// Opt-in real-Postgres coverage for the additive auth-token scope constraint.
+// The default suite stays DB-free; set TEST_DATABASE_URL to execute the exact
+// production DDL against an isolated schema.
+
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const DB_URL = process.env.TEST_DATABASE_URL;
+const SCHEMA_NAME = 'auth_token_scope_constraint_integration_test';
+const describeDb = DB_URL ? describe : describe.skip;
+
+if (DB_URL) process.env.DATABASE_URL = DB_URL;
+
+describeDb('auth token scope constraint (real Postgres)', () => {
+  let pool: Pool;
+  let constraintSql: string;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DB_URL, max: 2 });
+    await pool.query(`DROP SCHEMA IF EXISTS ${SCHEMA_NAME} CASCADE`);
+    await pool.query(`CREATE SCHEMA ${SCHEMA_NAME}`);
+    const db = await pool.connect();
+    try {
+      await db.query(`SET search_path TO ${SCHEMA_NAME}`);
+      await db.query(`
+        CREATE TABLE accounts (id INT PRIMARY KEY);
+        CREATE TABLE auth_tokens (
+          token TEXT PRIMARY KEY,
+          account_id INT NOT NULL REFERENCES accounts(id),
+          expires_at TIMESTAMPTZ NOT NULL,
+          scope TEXT NOT NULL DEFAULT 'full'
+        );
+        INSERT INTO accounts VALUES (1);
+        INSERT INTO auth_tokens (token, account_id, expires_at, scope)
+        VALUES ('historical-invalid', 1, now() + interval '1 day', 'legacy');
+      `);
+      const dbModule = await import('../server/db');
+      constraintSql = dbModule.AUTH_TOKENS_SCOPE_CONSTRAINT_SQL;
+      await db.query(constraintSql);
+      await db.query(constraintSql);
+    } finally {
+      db.release();
+    }
+  });
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS ${SCHEMA_NAME} CASCADE`);
+    await pool.end();
+  });
+
+  async function scopedQuery(text: string, values: unknown[] = []) {
+    const db = await pool.connect();
+    try {
+      await db.query(`SET search_path TO ${SCHEMA_NAME}`);
+      return await db.query(text, values);
+    } finally {
+      db.release();
+    }
+  }
+
+  it('is idempotent and leaves the constraint unvalidated for historical rows', async () => {
+    const result = await scopedQuery(
+      `SELECT convalidated
+         FROM pg_constraint
+        WHERE conname = 'auth_tokens_scope_check'
+          AND conrelid = 'auth_tokens'::regclass`,
+    );
+    expect(result.rows).toEqual([{ convalidated: false }]);
+    const historical = await scopedQuery(
+      "SELECT scope FROM auth_tokens WHERE token = 'historical-invalid'",
+    );
+    expect(historical.rows).toEqual([{ scope: 'legacy' }]);
+  });
+
+  it.each(['full', 'read'])('accepts a new %s token', async (scope) => {
+    await expect(
+      scopedQuery(
+        `INSERT INTO auth_tokens (token, account_id, expires_at, scope)
+         VALUES ($1, 1, now() + interval '1 day', $2)`,
+        [`valid-${scope}`, scope],
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it('rejects a new token outside the closed scope vocabulary', async () => {
+    await expect(
+      scopedQuery(
+        `INSERT INTO auth_tokens (token, account_id, expires_at, scope)
+         VALUES ('new-invalid', 1, now() + interval '1 day', 'write')`,
+      ),
+    ).rejects.toMatchObject({ code: '23514' });
+  });
+});

--- a/tests/character_lease_ws.test.ts
+++ b/tests/character_lease_ws.test.ts
@@ -63,7 +63,7 @@ function makeDeps(opts: { joinResult?: any; hasSession?: boolean; acquireResult?
   };
   const deps: any = {
     game,
-    accountForToken: vi.fn(async () => 1),
+    accountAndScopeForToken: vi.fn(async () => ({ accountId: 1, scope: 'full' as const })),
     moderationStatusForAccount: vi.fn(async () => ({ locked: false, chatStrikes: 0 })),
     getCharacter: vi.fn(async () => character),
     chatMuteStatusForAccount: vi.fn(async () => ({ mutedUntil: null, reason: null })),
@@ -119,8 +119,8 @@ describe('ws auth character load lease', () => {
   });
 
   it('acquires with the AUTHENTICATED account id, never the client-sent character id', async () => {
-    // Distinct fixtures: getCharacter yields character 7, accountForToken yields
-    // account 1, so a positional swap of the two args cannot pass unnoticed.
+    // Distinct fixtures: getCharacter yields character 7, the scoped token lookup
+    // yields account 1, so a positional swap of the two args cannot pass unnoticed.
     const { deps, acquireSpy, joinSpy } = makeDeps();
     const { ws } = fakeWs();
 

--- a/tests/companion_read_api.test.ts
+++ b/tests/companion_read_api.test.ts
@@ -60,8 +60,8 @@ describe('migration is additive; old tokens read full', () => {
   });
 });
 
-describe('token identity lookups retain authority context', () => {
-  it('has no production resolver that erases token scope', () => {
+describe('legacy scope-blind resolver removal', () => {
+  it('has no production reference to the removed accountForToken helper', () => {
     const offenders = serverTypeScriptFiles(SERVER_DIR)
       .filter((file) => /\baccountForToken\b/.test(stripComments(readFileSync(file, 'utf8'))))
       .map((file) => file.slice(SERVER_DIR.length + 1))

--- a/tests/companion_read_api.test.ts
+++ b/tests/companion_read_api.test.ts
@@ -5,7 +5,7 @@
 // is additive with old tokens reading 'full'. main.ts cannot be imported (it
 // boots a server + connects to Postgres on import), so the route coverage is
 // verified structurally rather than over a live socket.
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
@@ -16,6 +16,19 @@ process.env.DATABASE_URL ||= 'postgres://test:test@localhost:5432/test';
 const { scopeAllowsMutation, scopeAllowsRead, SCHEMA } = await import('../server/db');
 
 const MAIN = readFileSync(join(__dirname, '..', 'server', 'main.ts'), 'utf8');
+const SERVER_DIR = join(__dirname, '..', 'server');
+
+function serverTypeScriptFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return serverTypeScriptFiles(path);
+    return entry.isFile() && entry.name.endsWith('.ts') ? [path] : [];
+  });
+}
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+}
 
 describe('token scope policy', () => {
   it('only a full token may mutate', () => {
@@ -39,6 +52,21 @@ describe('migration is additive; old tokens read full', () => {
     // The DEFAULT 'full' on the additive column is what makes every token that
     // predates the scope column read back as a full session.
     expect(SCHEMA).toContain("scope TEXT NOT NULL DEFAULT 'full'");
+  });
+  it('rejects new token rows whose scope is outside the closed scope vocabulary', () => {
+    expect(SCHEMA).toMatch(
+      /CONSTRAINT auth_tokens_scope_check CHECK \(scope IN \('full', 'read'\)\) NOT VALID/,
+    );
+  });
+});
+
+describe('token identity lookups retain authority context', () => {
+  it('has no production resolver that erases token scope', () => {
+    const offenders = serverTypeScriptFiles(SERVER_DIR)
+      .filter((file) => /\baccountForToken\b/.test(stripComments(readFileSync(file, 'utf8'))))
+      .map((file) => file.slice(SERVER_DIR.length + 1))
+      .sort();
+    expect(offenders).toEqual([]);
   });
 });
 

--- a/tests/perf_report.test.ts
+++ b/tests/perf_report.test.ts
@@ -2,12 +2,12 @@ import { EventEmitter } from 'node:events';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../server/db', () => ({
-  accountForToken: vi.fn(),
+  accountAndScopeForToken: vi.fn(),
   getCharacter: vi.fn(),
   insertClientPerfReport: vi.fn(async () => {}),
 }));
 
-import { accountForToken, getCharacter, insertClientPerfReport } from '../server/db';
+import { accountAndScopeForToken, getCharacter, insertClientPerfReport } from '../server/db';
 import { handlePerfReport, perfReportInternalsForTest } from '../server/perf_report';
 import { resetRateLimitClock, setRateLimitClock } from '../server/ratelimit';
 
@@ -59,7 +59,7 @@ beforeEach(() => {
 
 describe('perf report ingestion', () => {
   it('sanitizes and stores a bounded report with authenticated account context', async () => {
-    vi.mocked(accountForToken).mockResolvedValue(10);
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 10, scope: 'full' });
     vi.mocked(getCharacter).mockResolvedValue({ id: 55 } as any);
     const res = fakeRes();
 
@@ -121,6 +121,31 @@ describe('perf report ingestion', () => {
         osFamily: 'macos',
         viewportBucket: 'large-1440x900',
         rawSummary: { truncated: true },
+      }),
+    );
+  });
+
+  it('stores a read-token report anonymously without resolving its character', async () => {
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({ accountId: 10, scope: 'read' });
+    const res = fakeRes();
+
+    await handlePerfReport(
+      fakeReq(
+        {
+          sessionId: 'read-token-report',
+          characterId: 55,
+        },
+        { token: VALID_TOKEN },
+      ),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(getCharacter).not.toHaveBeenCalled();
+    expect(insertClientPerfReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: null,
+        characterId: null,
       }),
     );
   });

--- a/tests/server/account.test.ts
+++ b/tests/server/account.test.ts
@@ -334,16 +334,19 @@ describe('activeGuard', () => {
 
 describe('logoutGuard', () => {
   it('401s a missing Authorization header with NO db read', async () => {
-    const accountForToken = vi.fn(async () => 7);
-    setAccountDbForTests({ accountForToken });
+    const accountAndScopeForToken = vi.fn(async () => ({
+      accountId: 7,
+      scope: 'full' as const,
+    }));
+    setAccountDbForTests({ accountAndScopeForToken });
     const r = await runChain([logoutGuard], fakeCtx({}));
     expect(r).toMatchObject({ reached: false, status: 401 });
     expect(r.body).toEqual({ error: 'not authenticated', code: 'auth.required' });
-    expect(accountForToken).not.toHaveBeenCalled();
+    expect(accountAndScopeForToken).not.toHaveBeenCalled();
   });
 
-  it('401s a present-but-unknown token (accountForToken -> null)', async () => {
-    setAccountDbForTests({ accountForToken: async () => null });
+  it('401s a present-but-unknown token (scoped lookup -> null)', async () => {
+    setAccountDbForTests({ accountAndScopeForToken: async () => null });
     const r = await runChain([logoutGuard], fakeCtx({ headers: { authorization: BEARER } }));
     expect(r).toMatchObject({ reached: false, status: 401 });
     expect(r.body).toEqual({ error: 'not authenticated', code: 'auth.required' });
@@ -353,7 +356,10 @@ describe('logoutGuard', () => {
     // A read-only OR locked account still logs out: the guard never reads the scope
     // or the moderation status, unlike activeGuard.
     const moderationStatusForAccount = vi.fn(async () => modStatus({ locked: true }));
-    setAccountDbForTests({ accountForToken: async () => 7, moderationStatusForAccount });
+    setAccountDbForTests({
+      accountAndScopeForToken: async () => ({ accountId: 7, scope: 'read' }),
+      moderationStatusForAccount,
+    });
     const r = await runChain([logoutGuard], fakeCtx({ headers: { authorization: BEARER } }));
     expect(r.reached).toBe(true);
     expect(moderationStatusForAccount).not.toHaveBeenCalled();

--- a/tests/server/admin.test.ts
+++ b/tests/server/admin.test.ts
@@ -8,8 +8,8 @@
 // pins:
 //  - the FROZEN envelope contract (a success body, an error body, a data:{ ok:true }
 //    body) and that surface 'admin' + meta.envelope 'admin' select serializeAdmin;
-//  - the requireAdmin gate: db-free 401 on a missing bearer, 401 on a non-admin, and
-//    a valid admin reaches the handler (no read-only-scope 403, no moderation gate);
+//  - the requireAdmin gate: db-free 401 on a missing bearer, 401 on a read token or
+//    non-admin, and a valid full-scope admin reaches the handler;
 //  - the admin.login limiter: its own in-handler rateLimited (429), the 401 bad-cred
 //    and 403 no-admin-access shapes, all anonymous (no requireAdmin);
 //  - the operator :id loader: a valid id reaches the handler, a NaN id 422s;
@@ -61,6 +61,7 @@ const BEARER = `Bearer ${'a'.repeat(64)}`;
 // The admin caller the gate resolves the bearer to; isAdminAccount(id) returns true
 // ONLY for this id, so a moderation target (a different id) reads as a non-admin.
 const ADMIN_ACCOUNT_ID = 7;
+const fullToken = (accountId = ADMIN_ACCOUNT_ID) => ({ accountId, scope: 'full' as const });
 // The admin-login per-minute ceiling (server/admin.ts ADMIN_LOGIN_MAX_PER_MINUTE).
 const ADMIN_LOGIN_MAX = 10;
 // A frozen instant so a limiter drain sits inside one 60s window.
@@ -92,7 +93,7 @@ const allowedRateLimit = (): ReturnType<NonNullable<AdminDbBundle['rateLimited']
 // target reads as a normal account). Extra reads are layered per test.
 function authedAdminDb(overrides: DbOverrides = {}): void {
   setDb({
-    accountForToken: async () => ADMIN_ACCOUNT_ID,
+    accountAndScopeForToken: async () => fullToken(),
     adminRolesForAccount: async (id: number) =>
       id === ADMIN_ACCOUNT_ID ? { username: 'op', roles: ['superadmin'] } : null,
     isAdminAccount: async (id: number) => id === ADMIN_ACCOUNT_ID,
@@ -279,19 +280,22 @@ describe('admin envelope contract (frozen)', () => {
 
 describe('requireAdmin gate', () => {
   it('401s a missing bearer DB-free with the legacy admin body', async () => {
-    const accountForToken = vi.fn(async () => ADMIN_ACCOUNT_ID);
+    const accountAndScopeForToken = vi.fn(async () => fullToken());
     const adminRolesForAccount = vi.fn(async () => ({ username: 'op', roles: ['superadmin'] }));
-    setDb({ accountForToken, adminRolesForAccount });
+    setDb({ accountAndScopeForToken, adminRolesForAccount });
     installAdminRuntime();
     const r = await runRoute('GET', '/admin/api/overview');
     expect(r.status).toBe(401);
     expect(r.body).toEqual({ success: false, data: null, error: 'admin authentication required' });
     // A missing bearer never reaches the token lookup.
-    expect(accountForToken).not.toHaveBeenCalled();
+    expect(accountAndScopeForToken).not.toHaveBeenCalled();
   });
 
   it('401s a valid bearer whose account is NOT staff (no roles)', async () => {
-    setDb({ accountForToken: async () => 42, adminRolesForAccount: async () => null });
+    setDb({
+      accountAndScopeForToken: async () => fullToken(42),
+      adminRolesForAccount: async () => null,
+    });
     installAdminRuntime();
     const r = await runRoute('GET', '/admin/api/overview', { headers: { authorization: BEARER } });
     expect(r.status).toBe(401);
@@ -300,13 +304,34 @@ describe('requireAdmin gate', () => {
 
   it('401s a bearer that resolves to no account', async () => {
     setDb({
-      accountForToken: async () => null,
+      accountAndScopeForToken: async () => null,
       adminRolesForAccount: async () => ({ username: 'op', roles: ['superadmin'] }),
     });
     installAdminRuntime();
     const r = await runRoute('GET', '/admin/api/overview', { headers: { authorization: BEARER } });
     expect(r.status).toBe(401);
     expect(r.body).toEqual({ success: false, data: null, error: 'admin authentication required' });
+  });
+
+  it('401s a staff read token before role resolution or the handler', async () => {
+    const adminRolesForAccount = vi.fn(async () => ({ username: 'op', roles: ['superadmin'] }));
+    setDb({
+      accountAndScopeForToken: async () => ({
+        accountId: ADMIN_ACCOUNT_ID,
+        scope: 'read' as const,
+      }),
+      adminRolesForAccount,
+    });
+    installAdminRuntime();
+
+    const r = await runRoute('GET', '/admin/api/overview', {
+      headers: { authorization: BEARER },
+    });
+
+    expect(r.status).toBe(401);
+    expect(r.body).toEqual({ success: false, data: null, error: 'admin authentication required' });
+    expect(r.reached).toBe(false);
+    expect(adminRolesForAccount).not.toHaveBeenCalled();
   });
 
   it('lets a valid admin through to the handler', async () => {
@@ -2160,7 +2185,7 @@ describe('reset-password RouteDef handler (accounts.password)', () => {
     // The actor holds accounts.password via the plain admin role, but the target
     // reads as staff (isAdminAccount true), so the reset is refused.
     setDb({
-      accountForToken: async () => ADMIN_ACCOUNT_ID,
+      accountAndScopeForToken: async () => fullToken(),
       adminRolesForAccount: async (id: number) =>
         id === ADMIN_ACCOUNT_ID ? { username: 'op', roles: ['admin'] } : null,
       isAdminAccount: async () => true,
@@ -2185,7 +2210,7 @@ describe('reset-password RouteDef handler (accounts.password)', () => {
   it('is denied 403 by the central gate for a moderator (accounts.password not held)', async () => {
     const deps = resetDeps();
     setDb({
-      accountForToken: async () => ADMIN_ACCOUNT_ID,
+      accountAndScopeForToken: async () => fullToken(),
       adminRolesForAccount: async () => ({ username: 'op', roles: ['moderator'] }),
       ...deps,
     });
@@ -2245,7 +2270,7 @@ describe('account flair (AI mark + streamer links)', () => {
     const setAccountAiFlag = vi.fn(async () => {});
     const setAccountStreamerFlair = vi.fn(async () => {});
     setDb({
-      accountForToken: async () => ADMIN_ACCOUNT_ID,
+      accountAndScopeForToken: async () => fullToken(),
       adminRolesForAccount: async () => ({ username: 'op', roles: ['viewer'] }),
       setAccountAiFlag,
       setAccountStreamerFlair,
@@ -2282,7 +2307,7 @@ describe('account flair (AI mark + streamer links)', () => {
     // The REAL setAccountAiFlag runs (not overridden), so the transaction and its
     // audit row are the ones production issues.
     setDb({
-      accountForToken: async () => ADMIN_ACCOUNT_ID,
+      accountAndScopeForToken: async () => fullToken(),
       adminRolesForAccount: async () => ({ username: 'op', roles: ['moderator'] }),
       loadAccountFlair,
     });
@@ -2311,7 +2336,7 @@ describe('account flair (AI mark + streamer links)', () => {
   it('audits an AI-mark write with no reason (non-punitive: a reason is optional)', async () => {
     const db = recordingPoolClient();
     setDb({
-      accountForToken: async () => ADMIN_ACCOUNT_ID,
+      accountAndScopeForToken: async () => fullToken(),
       adminRolesForAccount: async () => ({ username: 'op', roles: ['moderator'] }),
       loadAccountFlair: async () => LIVE_FLAIR,
     });
@@ -2389,7 +2414,7 @@ describe('account flair (AI mark + streamer links)', () => {
     const db = recordingPoolClient();
     const loadAccountFlair = vi.fn(async () => LIVE_FLAIR);
     setDb({
-      accountForToken: async () => ADMIN_ACCOUNT_ID,
+      accountAndScopeForToken: async () => fullToken(),
       adminRolesForAccount: async () => ({ username: 'op', roles: ['moderator'] }),
       loadAccountFlair,
     });
@@ -2419,7 +2444,7 @@ describe('account flair (AI mark + streamer links)', () => {
       links: { twitch: 'https://twitch.tv/someone', youtube: 'https://youtu.be/abc' },
     };
     setDb({
-      accountForToken: async () => ADMIN_ACCOUNT_ID,
+      accountAndScopeForToken: async () => fullToken(),
       adminRolesForAccount: async () => ({ username: 'op', roles: ['moderator'] }),
       loadAccountFlair: async () => live,
     });
@@ -2465,7 +2490,7 @@ describe('account flair (AI mark + streamer links)', () => {
     // The row after the flag is switched off: links intact, flag down.
     const flagOff: AccountFlair = { ai: false, streamer: false, links: storedLinks };
     setDb({
-      accountForToken: async () => ADMIN_ACCOUNT_ID,
+      accountAndScopeForToken: async () => fullToken(),
       adminRolesForAccount: async () => ({ username: 'op', roles: ['moderator'] }),
       loadAccountFlair: async () => flagOff,
     });
@@ -2503,7 +2528,7 @@ describe('account flair (AI mark + streamer links)', () => {
     const links = { twitch: 'https://twitch.tv/someone' };
     const already: AccountFlair = { ai: false, streamer: true, links };
     setDb({
-      accountForToken: async () => ADMIN_ACCOUNT_ID,
+      accountAndScopeForToken: async () => fullToken(),
       adminRolesForAccount: async () => ({ username: 'op', roles: ['moderator'] }),
       loadAccountFlair: async () => already,
     });
@@ -2533,7 +2558,7 @@ describe('account flair (AI mark + streamer links)', () => {
   it('leaves the stored links ALONE when the body omits the links key', async () => {
     const db = recordingPoolClient();
     setDb({
-      accountForToken: async () => ADMIN_ACCOUNT_ID,
+      accountAndScopeForToken: async () => fullToken(),
       adminRolesForAccount: async () => ({ username: 'op', roles: ['moderator'] }),
       loadAccountFlair: async () => ({ ai: false, streamer: false, links: {} }),
     });
@@ -2556,7 +2581,7 @@ describe('account flair (AI mark + streamer links)', () => {
   it('clears the links only on an EXPLICIT empty bag', async () => {
     const db = recordingPoolClient();
     setDb({
-      accountForToken: async () => ADMIN_ACCOUNT_ID,
+      accountAndScopeForToken: async () => fullToken(),
       adminRolesForAccount: async () => ({ username: 'op', roles: ['moderator'] }),
       loadAccountFlair: async () => ({ ai: false, streamer: true, links: {} }),
     });
@@ -2574,7 +2599,7 @@ describe('account flair (AI mark + streamer links)', () => {
 
   it('surfaces a db failure as a 400 without pushing anything live', async () => {
     setDb({
-      accountForToken: async () => ADMIN_ACCOUNT_ID,
+      accountAndScopeForToken: async () => fullToken(),
       adminRolesForAccount: async () => ({ username: 'op', roles: ['moderator'] }),
       setAccountAiFlag: async () => {
         throw new Error('boom');

--- a/tests/server/admin_overview_cache_arms.test.ts
+++ b/tests/server/admin_overview_cache_arms.test.ts
@@ -18,7 +18,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../server/db', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../server/db')>();
-  return { ...actual, accountForToken: vi.fn() };
+  return {
+    ...actual,
+    accountForToken: vi.fn(),
+    accountAndScopeForToken: vi.fn(),
+  };
 });
 vi.mock('../../server/staff_db', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../server/staff_db')>();
@@ -39,7 +43,7 @@ import {
   resetOverviewCacheForTests,
   setOverviewCacheForTests,
 } from '../../server/admin_overview_cache';
-import { accountForToken } from '../../server/db';
+import { accountAndScopeForToken, accountForToken } from '../../server/db';
 import { compose } from '../../server/http/compose';
 import { withErrors } from '../../server/http/middleware/with_errors';
 import type { Method, Middleware } from '../../server/http/types';
@@ -182,6 +186,10 @@ beforeEach(() => {
     now: () => nowMs,
   });
   vi.mocked(accountForToken).mockResolvedValue(ADMIN_ACCOUNT_ID);
+  vi.mocked(accountAndScopeForToken).mockResolvedValue({
+    accountId: ADMIN_ACCOUNT_ID,
+    scope: 'full',
+  });
   vi.mocked(adminRolesForAccount).mockResolvedValue({ username: 'op', roles: ['superadmin'] });
   configureAdminRuntime({ adminStats: vi.fn(() => ROUTE_STATS) } as unknown as AdminRuntime);
 });
@@ -194,6 +202,27 @@ afterEach(() => {
 });
 
 describe('admin overview cache arm parity', () => {
+  it('both arms reject a staff read token before staff or overview reads', async () => {
+    vi.mocked(accountAndScopeForToken).mockResolvedValue({
+      accountId: ADMIN_ACCOUNT_ID,
+      scope: 'read',
+    });
+    vi.mocked(adminRolesForAccount).mockClear();
+
+    const legacy = await runLegacyOverview();
+    const routed = await runRouteOverview();
+
+    const body = {
+      success: false,
+      data: null,
+      error: 'admin authentication required',
+    };
+    expect(legacy).toEqual({ status: 401, body });
+    expect(routed).toEqual({ status: 401, body });
+    expect(adminRolesForAccount).not.toHaveBeenCalled();
+    expect(calls).toBe(0);
+  });
+
   it('both arms share the singleton: two requests inside the TTL, one refresh', async () => {
     const legacy = await runLegacyOverview();
     const routed = await runRouteOverview();

--- a/tests/server/admin_overview_cache_arms.test.ts
+++ b/tests/server/admin_overview_cache_arms.test.ts
@@ -20,7 +20,6 @@ vi.mock('../../server/db', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../server/db')>();
   return {
     ...actual,
-    accountForToken: vi.fn(),
     accountAndScopeForToken: vi.fn(),
   };
 });
@@ -43,7 +42,7 @@ import {
   resetOverviewCacheForTests,
   setOverviewCacheForTests,
 } from '../../server/admin_overview_cache';
-import { accountAndScopeForToken, accountForToken } from '../../server/db';
+import { accountAndScopeForToken } from '../../server/db';
 import { compose } from '../../server/http/compose';
 import { withErrors } from '../../server/http/middleware/with_errors';
 import type { Method, Middleware } from '../../server/http/types';
@@ -185,7 +184,6 @@ beforeEach(() => {
     },
     now: () => nowMs,
   });
-  vi.mocked(accountForToken).mockResolvedValue(ADMIN_ACCOUNT_ID);
   vi.mocked(accountAndScopeForToken).mockResolvedValue({
     accountId: ADMIN_ACCOUNT_ID,
     scope: 'full',

--- a/tests/server/http/ownership_coverage.test.ts
+++ b/tests/server/http/ownership_coverage.test.ts
@@ -319,7 +319,10 @@ const ADMIN_VALIDATION_FAILED = { success: false, data: null, error: 'validation
 // so the gate's fail-closed staff check is the one that must refuse it.
 function installNonAdminDb(): void {
   setAdminDbForTests({
-    accountForToken: async () => NON_ADMIN_ACCOUNT_ID,
+    accountAndScopeForToken: async () => ({
+      accountId: NON_ADMIN_ACCOUNT_ID,
+      scope: 'full' as const,
+    }),
     adminRolesForAccount: async () => null,
   });
 }
@@ -329,9 +332,29 @@ function installNonAdminDb(): void {
 // operator identity.
 function installAdminDb(): void {
   setAdminDbForTests({
-    accountForToken: async () => CALLER_ACCOUNT_ID,
+    accountAndScopeForToken: async () => ({
+      accountId: CALLER_ACCOUNT_ID,
+      scope: 'full' as const,
+    }),
     adminRolesForAccount: async () => ({ username: 'op', roles: ['superadmin'] }),
   });
+}
+
+// Install a staff-owned read token. The token must be denied before the role
+// resolver is consulted, regardless of which protected admin route was matched.
+function installReadAdminDb() {
+  const adminRolesForAccount = vi.fn(async () => ({
+    username: 'op',
+    roles: ['superadmin'],
+  }));
+  setAdminDbForTests({
+    accountAndScopeForToken: async () => ({
+      accountId: CALLER_ACCOUNT_ID,
+      scope: 'read' as const,
+    }),
+    adminRolesForAccount,
+  });
+  return { adminRolesForAccount };
 }
 
 // Run a route's chain UNDER withErrors (surface 'admin'), so requireAdminTarget's
@@ -518,7 +541,7 @@ describe('admin auth-mounting sweep: every non-login admin route 401s an unauthe
   for (const route of authedAdminRoutes) {
     it(`refuses an unauthenticated ${route.method} ${route.path} with the legacy admin 401 before the handler`, async () => {
       // No authorization header at all: the gate must 401 db-free (bearerToken is
-      // null, so accountForToken is never consulted) and short-circuit the chain.
+      // null, so accountAndScopeForToken is never consulted) and short-circuit the chain.
       const ctx = fakeCtx({
         method: route.method,
         url: concretePath(route.path),
@@ -553,6 +576,37 @@ describe('admin auth-mounting sweep: every non-login admin route 401s an unauthe
     expect(handler).toHaveBeenCalledTimes(1);
     expect(res.statusCode).not.toBe(401);
   });
+});
+
+describe('admin scope sweep: every non-login admin route rejects a read token', () => {
+  beforeEach(() => {
+    configureAdminRuntime({} as AdminRuntime);
+  });
+
+  afterEach(() => {
+    resetAdminDbForTests();
+    resetAdminRuntimeForTests();
+    vi.restoreAllMocks();
+  });
+
+  for (const route of authedAdminRoutes) {
+    it(`refuses a read-scoped ${route.method} ${route.path} before roles or the handler`, async () => {
+      const { adminRolesForAccount } = installReadAdminDb();
+      const ctx = fakeCtx({
+        method: route.method,
+        url: concretePath(route.path),
+        headers: { authorization: `Bearer ${VALID_TOKEN}` },
+        params: { id: REQUESTED_ID, action: 'suspend' },
+      });
+
+      const { res, handler } = await runRouteWithErrors(route, ctx);
+
+      expect(res.statusCode).toBe(401);
+      expect(handler).not.toHaveBeenCalled();
+      expect(adminRolesForAccount).not.toHaveBeenCalled();
+      expect(JSON.parse(res.body)).toEqual(ADMIN_AUTH_REQUIRED);
+    });
+  }
 });
 
 // -------------------------------------------------------------------------

--- a/tests/server/maps_routes.test.ts
+++ b/tests/server/maps_routes.test.ts
@@ -471,7 +471,9 @@ describe('the optional-auth public :id read', () => {
   it('resolves a presented bearer to the viewer account (owner sees a private map)', async () => {
     const getMapForViewer = vi.fn(async () => mapRecord());
     fakeService({ getMapForViewer });
-    setMapsGuardDbForTests({ accountForToken: async () => CALLER });
+    setMapsGuardDbForTests({
+      accountAndScopeForToken: async () => ({ accountId: CALLER, scope: 'read' }),
+    });
     const res = await runRoute('GET', '/api/maps/:id', {
       headers: { authorization: BEARER },
       params: { id: '5' },

--- a/tests/server/reports_telemetry.test.ts
+++ b/tests/server/reports_telemetry.test.ts
@@ -14,7 +14,7 @@
 // server/db.ts builds a pg Pool at module load and throws if DATABASE_URL is unset;
 // reports.ts (via perf_report.ts) imports it, so set a dummy URL. The pool never
 // connects: insertClientPerfReport / recordSitePresence are vi.fn fakes, and the
-// happy-path requests carry no bearer so perf-report's accountForToken / getCharacter
+// happy-path requests carry no bearer so perf-report's scoped lookup / getCharacter
 // reads are never reached.
 process.env.DATABASE_URL ||= 'postgres://test:test@127.0.0.1:5433/wocc_phase15_telemetry';
 
@@ -30,7 +30,7 @@ import { routes } from '../../server/reports';
 import { type FakeRes, fakeCtx } from './helpers';
 
 // perf-report self-reads its body and, for an authed caller only, reads
-// accountForToken / getCharacter; our happy-path requests carry no bearer, so only
+// accountAndScopeForToken / getCharacter; our happy-path requests carry no bearer, so only
 // insertClientPerfReport is reached. Replace it with a fake; the ...actual spread
 // keeps every other db export real.
 vi.mock('../../server/db', async (importActual) => {

--- a/tests/server/ws_auth.test.ts
+++ b/tests/server/ws_auth.test.ts
@@ -160,6 +160,33 @@ describe('createWsAuth: authenticateWebSocket reject paths', () => {
     expectSendThenClose(ws, errorFrame('not authenticated'));
   });
 
+  it('3b. rejects a read-scoped token before any account-bound lookup', async () => {
+    const { ws, game, deps, req } = setup();
+    const accountAndScopeForToken = vi.fn(async () => ({
+      accountId: 1,
+      scope: 'read' as const,
+    }));
+    Object.assign(deps, { accountAndScopeForToken });
+    // A staff result makes this test decisive for the privileged escalation too:
+    // the scope gate must run before the staff lookup can confer permissions.
+    deps.adminRolesForAccount = vi.fn(async () => ({
+      username: 'staff',
+      roles: ['superadmin'],
+    }));
+
+    await createWsAuth(deps).authenticateWebSocket(asWs(ws), authRaw(), req);
+
+    expectSendThenClose(ws, errorFrame('not authenticated'));
+    expect(accountAndScopeForToken).toHaveBeenCalledWith('tok');
+    expect(deps.moderationStatusForAccount).not.toHaveBeenCalled();
+    expect(deps.getCharacter).not.toHaveBeenCalled();
+    expect(deps.adminRolesForAccount).not.toHaveBeenCalled();
+    expect(deps.loadAccountCosmetics).not.toHaveBeenCalled();
+    expect(deps.acquireCharacterLease).not.toHaveBeenCalled();
+    expect(deps.bankBonusForAccount).not.toHaveBeenCalled();
+    expect(game.join).not.toHaveBeenCalled();
+  });
+
   it('4. rejects a non-finite character with "not authenticated"', async () => {
     const { ws, deps, req } = setup();
     // account resolves fine here; the branch is forced via a non-numeric character.

--- a/tests/server/ws_auth.test.ts
+++ b/tests/server/ws_auth.test.ts
@@ -70,7 +70,10 @@ function setup() {
   };
   const deps: WsAuthDeps = {
     game: game as unknown as WsAuthDeps['game'],
-    accountForToken: vi.fn(async () => 1 as number | null),
+    accountAndScopeForToken: vi.fn(async () => ({
+      accountId: 1,
+      scope: 'full' as const,
+    })),
     moderationStatusForAccount: vi.fn(async () => modStatus()),
     getCharacter: vi.fn(async () => baseChar() as CharacterRow | null),
     chatMuteStatusForAccount: vi.fn(async () => ({
@@ -154,7 +157,7 @@ describe('createWsAuth: authenticateWebSocket reject paths', () => {
 
   it('3. rejects a null account with "not authenticated"', async () => {
     const { ws, deps, req } = setup();
-    deps.accountForToken = vi.fn(async () => null);
+    deps.accountAndScopeForToken = vi.fn(async () => null);
     const { authenticateWebSocket } = createWsAuth(deps);
     await authenticateWebSocket(asWs(ws), authRaw({ character: 1 }), req);
     expectSendThenClose(ws, errorFrame('not authenticated'));
@@ -166,7 +169,7 @@ describe('createWsAuth: authenticateWebSocket reject paths', () => {
       accountId: 1,
       scope: 'read' as const,
     }));
-    Object.assign(deps, { accountAndScopeForToken });
+    deps.accountAndScopeForToken = accountAndScopeForToken;
     // A staff result makes this test decisive for the privileged escalation too:
     // the scope gate must run before the staff lookup can confer permissions.
     deps.adminRolesForAccount = vi.fn(async () => ({
@@ -190,7 +193,10 @@ describe('createWsAuth: authenticateWebSocket reject paths', () => {
   it('4. rejects a non-finite character with "not authenticated"', async () => {
     const { ws, deps, req } = setup();
     // account resolves fine here; the branch is forced via a non-numeric character.
-    deps.accountForToken = vi.fn(async () => 1);
+    deps.accountAndScopeForToken = vi.fn(async () => ({
+      accountId: 1,
+      scope: 'full' as const,
+    }));
     const { authenticateWebSocket } = createWsAuth(deps);
     await authenticateWebSocket(asWs(ws), authRaw({ character: 'abc' }), req);
     expectSendThenClose(ws, errorFrame('not authenticated'));
@@ -895,7 +901,7 @@ describe('createWsAuth: onConnection', () => {
     // reject, never swallow: the character_lease_ws pin requires that). The caller
     // must convert the escaped rejection into the client's classified retry path
     // instead of leaving an unhandled rejection that hangs the client.
-    deps.accountForToken = vi.fn(async () => {
+    deps.accountAndScopeForToken = vi.fn(async () => {
       throw new Error('db down');
     });
     // Model an OPEN socket so the caller sends the classified error frame.
@@ -917,7 +923,7 @@ describe('createWsAuth: onConnection', () => {
 
   it('logs but sends no frame when the socket already closed during a rejected handshake', async () => {
     const { ws, deps, req } = setup();
-    deps.accountForToken = vi.fn(async () => {
+    deps.accountAndScopeForToken = vi.fn(async () => {
       throw new Error('db down');
     });
     // Socket already closed (readyState CLOSED, not OPEN): the caller must not

--- a/tests/token_scope_db.test.ts
+++ b/tests/token_scope_db.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMock = vi.hoisted(() => {
+  process.env.DATABASE_URL ??= 'postgres://test/test';
+  return { query: vi.fn() };
+});
+
+vi.mock('pg', () => ({
+  Pool: vi.fn(function Pool() {
+    return { query: dbMock.query };
+  }),
+}));
+
+import { accountAndScopeForToken } from '../server/db';
+
+beforeEach(() => {
+  dbMock.query.mockReset();
+});
+
+describe('accountAndScopeForToken', () => {
+  it.each([
+    ['full', { accountId: 7, scope: 'full' }],
+    ['read', { accountId: 7, scope: 'read' }],
+    ['write', null],
+    ['FULL', null],
+    [null, null],
+  ])('decodes database scope %j fail closed', async (scope, expected) => {
+    dbMock.query.mockResolvedValueOnce({
+      rows: [{ account_id: 7, scope }],
+    });
+
+    await expect(accountAndScopeForToken('a'.repeat(64))).resolves.toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Summary

- Require an exact `full` token scope before WebSocket world entry, before any character, staff-role, lease, or game lookup.
- Apply the same exact `full` requirement to both the RouteDef and legacy admin API authentication paths, returning the existing uniform 401 before role resolution.
- Remove the shared scope-blind token resolver. Safe read and logout consumers now resolve scope explicitly, while unknown persisted scope values fail closed.
- Add an additive `NOT VALID` PostgreSQL constraint that blocks new invalid scope values without scanning or rejecting historical rows during deployment.
- Add cross-boundary regression coverage for player and staff read tokens, all protected admin routes, fail-closed scope decoding, and the database constraint.

### Deployment

Stop and recreate every game or realm container during deployment. Do not leave an old container serving during a rolling overlap. Active and linkdead sessions keep their authority in process memory after the handshake, so replacing the process is what closes that residual window. A normal single-container Docker recreate is sufficient and will disconnect players so they reconnect through the fixed handshake.

The constraint is intentionally `NOT VALID`: it immediately governs new and updated rows, while runtime decoding rejects any historical value other than exact `full` or `read`. Existing rows can be inventoried and the constraint validated separately.

## Related issues

Closes #1835

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run` over 13 scope, WebSocket, admin, account, maps, and perf-report files: 600 passed, 4 opt-in PostgreSQL tests skipped without `TEST_DATABASE_URL`.
  - `npm run check:types`: TypeScript and Svelte checks passed with zero diagnostics.
  - `npm run test:browser`: 66 passed.
  - `npm run security:gate`: passed with zero unapproved high findings.
  - Changed-file Biome check, `git diff --check`, server build, environment build, and client production build: passed.
  - Three independent security, correctness, and migration reviews: no blocking findings.
- Manual steps:
  - Audited every former `accountForToken` call and confirmed there are no production references to the removed helper.
  - Confirmed read-scope rejection happens before downstream WebSocket and admin lookups.

`npm run gate` reached the full 18,014-test suite with 17,970 passed and 41 skipped. It stopped on three unrelated local-host failures: two existing `deploy_watchdog` timeout cases on macOS and one asset-inventory race that passed 56/56 in isolation. The focused security matrix and every downstream browser, type, malware, and build step are green.

---

## Checklist

### Quality

- [ ] **The full gate passes.** The change-specific matrix and downstream checks pass; the unrelated local failures are recorded above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** N/A, no UI changes.
- [ ] **Accessible.** N/A, no UI changes.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I did not hand-edit generated files.
