### PR TITLE
fix: Make fang-shaped rogue weapons count as daggers for Knifework strikes

### DIFF
--- a/src/sim/content/heroic_loot.ts
+++ b/src/sim/content/heroic_loot.ts
@@ -139,7 +139,7 @@ export const HEROIC_ITEMS: Record<string, ItemDef> = {
     slot: 'mainhand',
     quality: 'epic',
     requiredLevel: 20,
-    weapon: { min: 22, max: 36, speed: 1.8 },
+    weapon: { min: 22, max: 36, speed: 1.8, dagger: true },
     stats: { agi: 13, sta: 9 },
     critRating: FIVE_MAN_WEAPON_RATING,
     sellValue: 15000,

--- a/tests/dagger_weapon_metadata.test.ts
+++ b/tests/dagger_weapon_metadata.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { ITEMS } from '../src/sim/data';
+import { recalcPlayerStats } from '../src/sim/entity';
+import { Sim } from '../src/sim/sim';
+import type { Entity } from '../src/sim/types';
+import { terrainHeight } from '../src/sim/world';
+
+function trainingDummy(sim: Sim): Entity {
+  const target = [...sim.entities.values()].find(
+    (entity) => entity.kind === 'mob' && entity.templateId === 'training_dummy' && !entity.dead,
+  );
+  if (!target) throw new Error('training dummy not spawned');
+  return target;
+}
+
+function placeForCravenThrust(sim: Sim, player: Entity, target: Entity): void {
+  player.pos.x = target.pos.x - 1;
+  player.pos.z = target.pos.z;
+  player.pos.y = terrainHeight(player.pos.x, player.pos.z, sim.cfg.seed);
+  player.prevPos = { ...player.pos };
+  player.facing = Math.atan2(target.pos.x - player.pos.x, target.pos.z - player.pos.z);
+  target.facing = Math.PI / 2;
+}
+
+function equipMainhandForValidation(sim: Sim, itemId: string): void {
+  const meta = sim.meta(sim.playerId);
+  if (!meta) throw new Error('player metadata missing');
+  meta.equipment.mainhand = itemId;
+  delete meta.equipment.offhand;
+  recalcPlayerStats(sim.player, meta.cls, meta.equipment, meta.talentMods, meta.equipmentInstance);
+}
+
+function cravenThrustEventsWith(itemId: string) {
+  const sim = new Sim({ seed: 42, playerClass: 'rogue', autoEquip: true });
+  sim.setPlayerLevel(20);
+  const target = trainingDummy(sim);
+  placeForCravenThrust(sim, sim.player, target);
+  sim.targetEntity(target.id);
+  sim.player.resource = sim.player.maxResource;
+  equipMainhandForValidation(sim, itemId);
+
+  const startHp = target.hp;
+  sim.castAbility('backstab');
+  const events = sim.tick();
+
+  return { events, target, startHp };
+}
+
+describe('dagger-class fang weapons', () => {
+  it('lets Craven Thrust use Mistcaller Fang as a dagger-class fang weapon', () => {
+    expect(ITEMS.mistcallers_fang.weapon?.dagger).toBe(true);
+
+    const { events, target, startHp } = cravenThrustEventsWith('mistcallers_fang');
+
+    expect(
+      events.some((event) => event.type === 'error' && event.text === 'You must wield a dagger.'),
+    ).toBe(false);
+    expect(target.hp).toBeLessThan(startHp);
+  });
+
+  it('keeps non-dagger fang greatblades rejected by dagger validation', () => {
+    expect(ITEMS.direfang_greatblade.weapon?.dagger).toBeUndefined();
+
+    const { events, target, startHp } = cravenThrustEventsWith('direfang_greatblade');
+
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'error', text: 'You must wield a dagger.' }),
+    );
+    expect(target.hp).toBe(startHp);
+  });
+});


### PR DESCRIPTION
# Release v0.31.0

## Summary

This release fixes approved player feedback about rogue dagger abilities rejecting a fang weapon that should count as dagger-class.

## Feedback Repairs

- Fixes Discord feedback `1529079945861529712`: Mistcaller's Fang now carries dagger-class weapon metadata, so rogue Knifework abilities such as Craven Thrust validate it correctly.

## Community PRs

- None selected for this release. `SCOPE_MAX_PR_MERGES=NONE`.

## Verification

- Clean base release-tier gate: green.
- Release-tier gate `release-tier-0`: green.
- Final security review: pass.
- PR tester verdicts: none, because no community PRs merged and `USE_TESTERS=false`.

## Technical Notes

- Release branch: `ossbrain-release/v0.31.0`
- Base: `release/v0.28.0` at `0473be665f0e0c27e5f06a20d9c03fff3e40f0fe`
- Release commit: `08911d3ca fix(sim): mark mistcaller fang as dagger-class`
- Changed files:
  - `src/sim/content/heroic_loot.ts`
  - `tests/dagger_weapon_metadata.test.ts`

## Bounced Or Dropped Work

- No community PRs were bounced or dropped.
- Approved messages `1529170493549187102`, `1529190935265542194`, and `1529198534866505819` were already shipped in v0.30.0 via PR #2275, so they were not duplicated here.
