### PR TITLE
fix(professions): Phase 14 QA, close the banked-amends escalation dodge and the coverage arms

### DIFF
--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -1374,3 +1374,47 @@ in-memory nudge cadence restart reset, and the letterId derivation.
 Deferred: nothing. #1295's arms are complete (issue already closed);
 #2058's quests arm lands here (close by hand at merge if the maintainer
 agrees the stations parent is satisfied by Phases 8+9+14).
+
+Phase 14 QA (2026-07-21): PASS with followups, one real fix. QA diff
+8b7bd4596..3219f69cd (build phase-start to the PR #2280 merge, the
+release/v0.29.0 tip); fix branch fix/professions-2-phase-14-qa. Every
+deliverable and STEP 5 acceptance criterion verified against real code;
+validation rows green (tsc, the content and sim matrix rows, the 2039
+attunement suites, the S3 guard with all four new sim modules plus
+quest_commands.ts on the scan list, i18n completeness, wiki:content and
+i18n:gen freshness, ci:changed, parity goldens unchanged). Fan-out:
+STEP 1 context loader, a 10-agent audit Workflow (correctness, test
+coverage, dead code, plus architecture, cross-platform-sync,
+frontend-seam, migration-safety, privacy-security,
+database-performance, qa-checklist), then 5 parallel test writers; the
+correctness agent walked a live offline Sim through nudge, attune,
+celebration, cheap switch, escalating amends, whitelist rejection, and
+a real repeated work-order turn-in at the exact boundary tick.
+- REAL FIX (sim, test-first): the amends escalation could be dodged by
+  banking. resolvedCounts is stamped at accept and turn-in never
+  re-resolves it, and new-pair attunes are free (switchCount stays 0),
+  so a player with three pairs in history could hold both open amends
+  quests at counts [5] and turn the second in after the first return
+  raised switchCount, paying 5 where a fresh accept resolves 8. The
+  shared computeQuestState now hides every OTHER attunePair-effect
+  quest while one is active (one pending identity transition at a
+  time), on both hosts and the server accept gate alike.
+- Coverage arms closed test-first by the audit: the online cprof
+  UNBLOCK arm (a lapsed window empties cadenceBlockedQuests on a set
+  SHRINK re-emit, end to end into the bareClient mirror), a second full
+  work-order accept-and-turn-in cycle, cadence load-clamp and arm
+  boundaries, the single-cadence-constant catalog pin (a second
+  repeatCadenceTicks value would silently mis-clamp on tick-reset
+  load), tier-mail over-cap and skill-drop re-cross negatives, the
+  above-threshold trend nudge (deliberate lower-bar semantics), the
+  optimistic-state cadence and busy-gate cases, the mid-quest 'active'
+  matrix arm, the HUD render sink for all four text-free events (raw
+  pairId can never leak to chat), and tutorial Esc reachability.
+- Deferred to #2285 (all cosmetic/hygiene): the veteran first-tier
+  tutorial baseline decision, a work-order cooldown legibility line,
+  tier-mail unknown-key load hardening, serialize-time cadence pruning.
+- Verified-not-refixed accepted consequences: zone celebration
+  broadcast noise (the masterworkZone precedent), the in-memory nudge
+  cadence restart reset, the v0.29.0 rollback key-drop caveat, the
+  non-wave-one no-return-path pin, and the ClientWorld no-op legacy
+  members awaiting Phase 15 retirement.

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -1612,7 +1612,19 @@ tables, i18n key namespaces, files created)
   acceptArchetypeQuest/switchArchetype (no UI caller, ClientWorld
   no-ops) do not celebrate or baseline-arm; they stay on the Phase 15
   retirement list. #1295's described arms are complete (the issue was
-  already closed administratively).
+  already closed administratively). Phase 14 QA addition (branch
+  fix/professions-2-phase-14-qa): computeQuestState gained the
+  one-pending-identity-transition gate: while any attunePair-effect
+  quest is active, every OTHER attunePair-effect quest reports
+  'unavailable' in both hosts (the shared function; the server accept
+  path rides questState). Closes the banked-amends escalation dodge:
+  resolvedCounts is stamped at accept and turn-in never re-resolves it,
+  and new-pair attunes leave switchCount untouched, so banking two open
+  amends quests completed the second at a stale cheaper count. Pinned in
+  tests/profession_attunement_quests.test.ts (live path, abandon reopen,
+  escalated re-resolve at 8) and tests/quest_state_optimistic.test.ts
+  (mirror arm); switchHobby and plain quests stay outside the gate. QA
+  deferrals live in #2285.
 - Phase 14b: (planned) the commission marker, bind-on-first-trade
   enforcement, the master unbind service; the three maintainer decisions
   are RESOLVED in OPEN items (character binding, equipment-only opt-in

--- a/src/sim/quests/quest_commands.ts
+++ b/src/sim/quests/quest_commands.ts
@@ -78,6 +78,18 @@ export function computeQuestState(
   ) {
     return 'unavailable';
   }
+  // One pending identity transition at a time: while any attunePair-effect
+  // quest is active, every OTHER attunePair-effect quest is unavailable.
+  // resolvedCounts is stamped at accept and turn-in never re-resolves it, so a
+  // banked second amends would complete at a stale cost after the first return
+  // raised switchCount, dodging the 5 + 3 * switchCount escalation. The gate
+  // lives here so both hosts and the server accept path share it (the quest
+  // already in the log returned 'active' above, so it never gates itself).
+  if (quest.completionEffect?.type === 'attunePair') {
+    for (const activeId of questLog.keys()) {
+      if (QUESTS[activeId]?.completionEffect?.type === 'attunePair') return 'unavailable';
+    }
+  }
   // A repeatable work order inside its cooldown window is unavailable until it
   // lapses (the turn-in armed it; the window is server-authoritative and mirrors
   // to the online client via cprof).

--- a/tests/hud_profession_events.test.ts
+++ b/tests/hud_profession_events.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+
+// The HUD render sink for the four Professions 2.0 Phase 14 text-free
+// SimEvents (profTrendNudge, profTierTutorial, attuned, attunedZone). The sim
+// emits ids and names only; handleProfessionEvent must resolve the LOCALIZED
+// archetype title and master name (never leak the raw pairId, whose '+'
+// separator is the wire spelling, not player copy) and execute exactly the
+// plan's one render action per arm: a chat line, the tutorial panel, or the
+// celebration banner family (banner + polite announcer + one achievement
+// cue). Exercised via a bare Hud prototype (the profession_tutorial_window /
+// hud_confirm_gates precedent) since handleProfessionEvent is private.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { audio } from '../src/game/audio';
+import { ARCHETYPE_PAIR_TARGETS } from '../src/sim/professions/archetype';
+import { archetypeTitleText } from '../src/ui/char_window';
+import { tEntity } from '../src/ui/entity_i18n';
+import { Hud } from '../src/ui/hud';
+import { t } from '../src/ui/i18n';
+import {
+  attunementMasterForPair,
+  type ProfessionEventInput,
+} from '../src/ui/profession_event_lines_core';
+
+// jsdom ships no matchMedia; the handler reads only `.matches` to derive the
+// reduced-motion flag. A never-matching stub keeps motion on (the desktop
+// default the attuned banner assertion below relies on).
+window.matchMedia = ((query: string) =>
+  ({ matches: false, media: query }) as MediaQueryList) as typeof window.matchMedia;
+
+interface ProfessionEventHarness {
+  log: ReturnType<typeof vi.fn>;
+  showBanner: ReturnType<typeof vi.fn>;
+  combatAnnouncer: { push: ReturnType<typeof vi.fn> };
+  openProfessionTutorial: ReturnType<typeof vi.fn>;
+  handleProfessionEvent(ev: ProfessionEventInput): void;
+}
+
+function makeHud(): ProfessionEventHarness {
+  const hud = Object.create(Hud.prototype) as unknown as ProfessionEventHarness;
+  hud.log = vi.fn();
+  hud.showBanner = vi.fn();
+  hud.combatAnnouncer = { push: vi.fn() };
+  // Instance stub shadows the private prototype method: the tierTutorial arm
+  // only has to ROUTE here; the panel itself is pinned in
+  // profession_tutorial_window.test.ts.
+  hud.openProfessionTutorial = vi.fn();
+  return hud;
+}
+
+// A wave-one pair with a seated anchor master (content/zone1.ts
+// q_prof_attune_smith), so the trendNudge master arm has a real name to
+// resolve.
+const MASTER_PAIR = 'weaponcrafting+armorcrafting';
+const MASTER_NPC_ID = 'forgemistress_darva';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Hud.handleProfessionEvent', () => {
+  it('profTrendNudge logs the localized master line: archetype title + master name, no raw pairId', () => {
+    const hud = makeHud();
+    hud.handleProfessionEvent({ type: 'profTrendNudge', pairId: MASTER_PAIR });
+
+    expect(hud.log).toHaveBeenCalledTimes(1);
+    const line = hud.log.mock.calls[0][0] as string;
+    const archetype = archetypeTitleText(MASTER_PAIR);
+    const master = tEntity({ kind: 'npc', id: MASTER_NPC_ID, field: 'name' });
+    // Guard: the entity catalog resolves a real display name, so the contains
+    // assertions below cannot be satisfied by an id-echo fallback.
+    expect(master).not.toBe(MASTER_NPC_ID);
+    expect(line).toBe(t('hudChrome.crafting.trendNudge', { archetype, master }));
+    expect(line).toContain(archetype);
+    expect(line).toContain(master);
+    // The raw pair id is wire spelling: its '+' separator never reaches chat.
+    expect(line).not.toContain(MASTER_PAIR);
+    expect(line).not.toContain('+');
+    expect(hud.showBanner).not.toHaveBeenCalled();
+    expect(hud.openProfessionTutorial).not.toHaveBeenCalled();
+  });
+
+  it('profTrendNudge falls to the noMaster line for a ring pair without a seated master', () => {
+    // Derived, not hand-picked: any ring pair outside the four wave-one
+    // archetypes has no attunement quest, hence no master to name. If a later
+    // phase seats all ten masters this find() comes up empty and the arm
+    // becomes dead code, which this guard would surface.
+    const pair = ARCHETYPE_PAIR_TARGETS.find((p) => attunementMasterForPair(p) === null);
+    expect(pair).toBeTruthy();
+
+    const hud = makeHud();
+    hud.handleProfessionEvent({ type: 'profTrendNudge', pairId: pair as string });
+
+    expect(hud.log).toHaveBeenCalledTimes(1);
+    const line = hud.log.mock.calls[0][0] as string;
+    expect(line).toBe(
+      t('hudChrome.crafting.trendNudgeNoMaster', { archetype: archetypeTitleText(pair as string) }),
+    );
+    expect(line).not.toContain('+');
+  });
+
+  it('attunedZone logs the celebrant name with the localized archetype title, never the raw pairId', () => {
+    const hud = makeHud();
+    hud.handleProfessionEvent({
+      type: 'attunedZone',
+      celebrantName: 'Torvald',
+      pairId: 'alchemy+cooking',
+    });
+
+    expect(hud.log).toHaveBeenCalledTimes(1);
+    const line = hud.log.mock.calls[0][0] as string;
+    expect(line).toContain('Torvald');
+    expect(line).toContain(archetypeTitleText('alchemy+cooking'));
+    expect(line).not.toContain('alchemy+cooking');
+    expect(line).not.toContain('+');
+    // A zone broadcast is a chat line only: no banner, no cue for recipients
+    // (the masterworkZone precedent).
+    expect(hud.showBanner).not.toHaveBeenCalled();
+  });
+
+  it('attuned fires the celebration family: banner + polite announcer + one achievement cue, localized', () => {
+    const achievement = vi.spyOn(audio, 'achievement').mockImplementation(() => {});
+    const hud = makeHud();
+    hud.handleProfessionEvent({ type: 'attuned', pairId: 'leatherworking+tailoring' });
+
+    expect(hud.showBanner).toHaveBeenCalledTimes(1);
+    const [text, motion] = hud.showBanner.mock.calls[0] as [string, boolean];
+    expect(text).toBe(
+      t('hudChrome.crafting.attunedBanner', {
+        title: archetypeTitleText('leatherworking+tailoring'),
+      }),
+    );
+    expect(text).not.toContain('+');
+    // jsdom's matchMedia never matches prefers-reduced-motion, so the plan
+    // keeps motion on; information (text, announcer, cue) is never gated.
+    expect(motion).toBe(true);
+    expect(hud.combatAnnouncer.push).toHaveBeenCalledTimes(1);
+    expect(hud.combatAnnouncer.push.mock.calls[0][0]).toBe(text);
+    expect(achievement).toHaveBeenCalledTimes(1);
+    expect(hud.log).not.toHaveBeenCalled();
+  });
+
+  it('profTierTutorial routes to openProfessionTutorial and does nothing else', () => {
+    const hud = makeHud();
+    hud.handleProfessionEvent({ type: 'profTierTutorial' });
+
+    expect(hud.openProfessionTutorial).toHaveBeenCalledTimes(1);
+    expect(hud.log).not.toHaveBeenCalled();
+    expect(hud.showBanner).not.toHaveBeenCalled();
+  });
+});
+
+// No test instantiates the full Hud event loop, so the sim-event switch wiring
+// is held by a source pin (the craft_celebration_view.test.ts precedent): all
+// four Phase 14 event types must fall through to the ONE handler above, so a
+// new arm cannot silently drop one of them.
+describe('sim-event switch routing (source pin)', () => {
+  // join(process.cwd()) rather than import.meta.url: under jsdom the module
+  // URL is not a file: scheme (the confirm_dialog_key_activation precedent).
+  const hudSource = readFileSync(join(process.cwd(), 'src/ui/hud.ts'), 'utf8');
+
+  it('all four SimEvent types route to handleProfessionEvent', () => {
+    expect(hudSource).toMatch(
+      /case 'profTrendNudge':\n\s*case 'profTierTutorial':\n\s*case 'attuned':\n\s*case 'attunedZone':(?:\n\s*\/\/[^\n]*)*\n\s*this\.handleProfessionEvent\(ev\);/,
+    );
+  });
+});

--- a/tests/profession_attunement_quests.test.ts
+++ b/tests/profession_attunement_quests.test.ts
@@ -380,6 +380,11 @@ describe.each(MASTERS_WITH_OTHER)(
       attune(sim, other.master, other.attuneQuest, other.pair);
       expect(sim.questState(amendsQuest)).toBe('available');
       expect(sim.questState(attuneQuest)).toBe('done');
+
+      // Mid-quest: the accepted amends reports 'active' (the fifth matrix
+      // identity state), not a silent disappearance.
+      acceptAt(sim, master, amendsQuest, pair);
+      expect(sim.questState(amendsQuest)).toBe('active');
     });
   },
 );
@@ -393,5 +398,65 @@ describe('q_prof_hobby_switch reward shape (Phase 12c)', () => {
     const quest = ZONE1_QUESTS[HOBBY_QUEST];
     expect(quest.xpReward).toBe(0);
     expect(quest.repeatable).toBe(true);
+  });
+});
+
+// Phase 14 QA: one pending identity transition at a time. resolvedCounts is
+// stamped at ACCEPT (finalizeQuestAccept) and turn-in never re-resolves it, so
+// holding two attunePair quests at once lets the second complete at a stale
+// amends cost: new-pair attunes are free and leave switchCount at 0, so a
+// player with three pairs in history can bank both open amends quests at
+// counts [5] and turn the second in after the first return bumped switchCount
+// to 1, dodging the honest 5 + 3 = 8. The shared computeQuestState therefore
+// hides every OTHER attunePair-effect quest while one is active, on both hosts
+// (the online mirror shares the function; the server accept gate rides
+// questState). switchHobby quests and plain quests are outside the gate.
+describe('attunePair quests block concurrent identity transitions (Phase 14 QA)', () => {
+  const APOTHECARY_PAIR = 'alchemy+cooking';
+
+  it('hides other attune quests while one is active, and reopens them on abandon', () => {
+    const sim = makeSim();
+    unlockProfessionQuests(sim);
+
+    acceptAt(sim, SMITH_MASTER, 'q_prof_attune_smith', WEAPON_ARMOR);
+    expect(sim.questState('q_prof_attune_smith')).toBe('active');
+    expect(sim.questState('q_prof_attune_outfitter')).toBe('unavailable');
+    // The gate is identity-scoped: a plain quest (the smith's work order, no
+    // completionEffect) is untouched while the transition is pending.
+    expect(sim.questState('q_prof_workorder_forge')).toBe('available');
+
+    sim.abandonQuest('q_prof_attune_smith');
+    expect(sim.questState('q_prof_attune_outfitter')).toBe('available');
+  });
+
+  it('refuses a banked second amends so escalation can never be dodged', () => {
+    const sim = makeSim();
+    unlockProfessionQuests(sim);
+
+    // Three pairs in history at switchCount 0: new-pair attunes are free.
+    attune(sim, SMITH_MASTER, 'q_prof_attune_smith', WEAPON_ARMOR);
+    attune(sim, OUTFITTER_MASTER, 'q_prof_attune_outfitter', LEATHER_TAILOR);
+    attune(sim, 'cook_marlow', 'q_prof_attune_apothecary', APOTHECARY_PAIR);
+    expect(sim.archetypeSwitchCount).toBe(0);
+
+    // Both non-active pairs' amends are open at the cheap first-switch cost.
+    expect(sim.questState('q_prof_amends_smith')).toBe('available');
+    expect(sim.questState('q_prof_amends_outfitter')).toBe('available');
+
+    // Accepting one closes the other while the transition is pending, and the
+    // accept path refuses the bank outright.
+    acceptAt(sim, SMITH_MASTER, 'q_prof_amends_smith', WEAPON_ARMOR);
+    expect(sim.questLog.get('q_prof_amends_smith')?.resolvedCounts).toEqual([5]);
+    expect(sim.questState('q_prof_amends_outfitter')).toBe('unavailable');
+    acceptAt(sim, OUTFITTER_MASTER, 'q_prof_amends_outfitter', LEATHER_TAILOR);
+    expect(sim.questLog.has('q_prof_amends_outfitter')).toBe(false);
+
+    // Return to smith: switchCount 1; the outfitter amends reopens and a fresh
+    // accept resolves the ESCALATED count (5 + 3 * 1 = 8), the honest cost.
+    completeAndTurnInAt(sim, SMITH_MASTER, 'q_prof_amends_smith');
+    expect(sim.archetypeSwitchCount).toBe(1);
+    expect(sim.questState('q_prof_amends_outfitter')).toBe('available');
+    acceptAt(sim, OUTFITTER_MASTER, 'q_prof_amends_outfitter', LEATHER_TAILOR);
+    expect(sim.questLog.get('q_prof_amends_outfitter')?.resolvedCounts).toEqual([8]);
   });
 });

--- a/tests/profession_attunement_quests.test.ts
+++ b/tests/profession_attunement_quests.test.ts
@@ -429,6 +429,23 @@ describe('attunePair quests block concurrent identity transitions (Phase 14 QA)'
     expect(sim.questState('q_prof_attune_outfitter')).toBe('available');
   });
 
+  it('leaves switchHobby quests outside the gate (attunePair-only scope)', () => {
+    // The work-order control above has NO completionEffect, so it cannot catch
+    // a regression that broadens the gate from attunePair to any effect; the
+    // hobby switch carries the OTHER effect type and must stay offered while
+    // an identity transition is pending.
+    const sim = makeSim();
+    unlockProfessionQuests(sim);
+    attune(sim, SMITH_MASTER, 'q_prof_attune_smith', WEAPON_ARMOR);
+    attune(sim, OUTFITTER_MASTER, 'q_prof_attune_outfitter', LEATHER_TAILOR);
+
+    acceptAt(sim, SMITH_MASTER, 'q_prof_amends_smith', WEAPON_ARMOR);
+    // The gated control: a fresh attunePair quest hides while amends is active.
+    expect(sim.questState('q_prof_attune_apothecary')).toBe('unavailable');
+    // The scope boundary: the switchHobby quest is untouched by the gate.
+    expect(sim.questState(HOBBY_QUEST)).toBe('available');
+  });
+
   it('refuses a banked second amends so escalation can never be dodged', () => {
     const sim = makeSim();
     unlockProfessionQuests(sim);

--- a/tests/profession_tutorial_window.test.ts
+++ b/tests/profession_tutorial_window.test.ts
@@ -55,6 +55,55 @@ describe('renderProfessionTutorial', () => {
   });
 });
 
+// The Esc dispatcher reaches a managed window only through the
+// topmostOpenWindow scan (closeAll -> topmostOpenWindow -> closeManagedWindow),
+// which selects visible '.window.panel' elements by z-order. This pin drives
+// the REAL openProfessionTutorial (painter, z floor, focus trap wiring) and
+// asserts the scan finds the modal and the close case tears it down with the
+// trap released, so the one-shot can never open unreachable by Esc.
+interface EscReachHarness {
+  professionTutorialTrap: { release: (restore?: boolean) => void; focusFirst: () => void } | null;
+  windowZ: number;
+  focusManager: { open: ReturnType<typeof vi.fn> };
+  syncAnyWindowOpenState(): void;
+  hideTooltip(): void;
+  openProfessionTutorial(): void;
+  topmostOpenWindow(): HTMLElement | null;
+  closeManagedWindow(el: HTMLElement): void;
+}
+
+describe('tutorial Esc reachability (openProfessionTutorial -> topmostOpenWindow)', () => {
+  it('the open modal is the topmost scan hit, and the close case releases the trap and removes it', () => {
+    document.body.innerHTML = '';
+    const release = vi.fn();
+    const hud = Object.create(Hud.prototype) as unknown as EscReachHarness;
+    hud.professionTutorialTrap = null;
+    // The window z-band floor; bringWindowToFront increments from here before
+    // the tutorial's own 96 floor wins.
+    hud.windowZ = 50;
+    hud.focusManager = { open: vi.fn(() => ({ release, focusFirst: vi.fn() })) };
+    hud.syncAnyWindowOpenState = vi.fn();
+    hud.hideTooltip = vi.fn();
+
+    hud.openProfessionTutorial();
+    const el = document.getElementById('profession-tutorial');
+    expect(el).not.toBeNull();
+    expect(hud.focusManager.open).toHaveBeenCalledTimes(1);
+
+    // The Esc dispatcher's scan (visible '.window.panel' by z) must surface
+    // the modal, or Esc would close some other window underneath it.
+    const top = hud.topmostOpenWindow();
+    expect(top).toBe(el);
+
+    hud.closeManagedWindow(top as HTMLElement);
+    // No-arg release: restoreFocus defaults true, focus returns to the opener.
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledWith();
+    expect(hud.professionTutorialTrap).toBeNull();
+    expect(document.getElementById('profession-tutorial')).toBeNull();
+  });
+});
+
 describe('tutorial managed-window close (Esc path)', () => {
   it('releases the focus trap (returning focus) and removes the modal, not just hides it', () => {
     document.body.innerHTML = '';

--- a/tests/professions_attunement_online.test.ts
+++ b/tests/professions_attunement_online.test.ts
@@ -205,7 +205,7 @@ function workOrderMaterial(): { itemId: string; count: number } {
 }
 
 describe('work-order cadence mirror over the live GameServer wire (cprof)', () => {
-  it('an online work-order turn-in blocks the quest and mirrors cadenceBlockedQuests onto the cprof self-delta', () => {
+  it('an online work-order turn-in blocks the quest over cprof, and a lapsed window empties the mirror on a later broadcast', () => {
     const server = new GameServer();
     const fcOwner = fakeWs();
     const so = joinServer(server, fcOwner, 121, 'Worker');
@@ -238,6 +238,30 @@ describe('work-order cadence mirror over the live GameServer wire (cprof)', () =
       .map((m) => m.self!.cprof!);
     expect(cprofs.length).toBeGreaterThan(0);
     expect(cprofs[cprofs.length - 1].cadenceBlockedQuests).toContain(WORK_ORDER);
+
+    // The UNBLOCK arm (blocked -> available over the wire): lapse the window
+    // server-side by rewinding the stored availableAt to the server's CURRENT
+    // tick (isCadenceBlocked is strict-before, so a key is available exactly
+    // AT its availableAt). If the cprof diff failed to re-emit on a set
+    // SHRINK, the stale blocked frame would stay last until relog and only
+    // the blocked half above would keep this suite green.
+    meta.questCadence.set(WORK_ORDER, server.sim.tickCount);
+    expect(server.sim.questState(WORK_ORDER, so.pid)).toBe('available');
+    routeOf(server)(server.sim.tick());
+    (server as unknown as { broadcastSnapshots(): void }).broadcastSnapshots();
+    const after = fcOwner.sent
+      .filter((m) => m.t === 'snap' && m.self?.cprof)
+      .map((m) => m.self!.cprof!);
+    // A NEW cprof frame shipped for the shrink (the delta re-emits, it is not
+    // the old blocked frame still sitting last), and its blocked set no
+    // longer carries the work order.
+    expect(after.length).toBeGreaterThan(cprofs.length);
+    const lapsedFrame = after[after.length - 1];
+    expect(lapsedFrame.cadenceBlockedQuests).not.toContain(WORK_ORDER);
+    // Close the loop client-side: feed the LAST wire frame into the bare
+    // client mirror and the quest reads available again.
+    const client = bareClient({ cadenceBlockedQuests: lapsedFrame.cadenceBlockedQuests });
+    expect(client.questState(WORK_ORDER)).toBe('available');
   });
 });
 

--- a/tests/professions_nudges.test.ts
+++ b/tests/professions_nudges.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { NUDGE_CADENCE_TICKS } from '../src/sim/professions/cadence';
 import { maybeEmitTierTutorial, maybeEmitTrendNudge } from '../src/sim/professions/prof_nudges';
+import { classifyCraftTrend } from '../src/sim/professions/trend';
 import { Sim } from '../src/sim/sim';
 import type { SimContext } from '../src/sim/sim_context';
 import type { SimEvent } from '../src/sim/types';
@@ -60,6 +61,20 @@ describe('trend nudge (Professions 2.0 Phase 14)', () => {
     const { ctx, emitted } = nudgeCtx();
     expect(maybeEmitTrendNudge(meta, ctx)).toBe(true);
     expect(emitted).toHaveLength(1);
+  });
+
+  it('also fires ABOVE the Guild letter crossing threshold (deliberate lower-bar semantics)', () => {
+    // The nudge fires for ANY non-null classifyCraftTrend, crossed or not: it is
+    // a hint below AND above the letter threshold, while the Guild letter keeps
+    // its own one-shot crossing semantics. A future !crossed guard here must be
+    // a deliberate re-pin of this contract, not a drive-by tightening.
+    const sim = makeSim();
+    const meta = sim.players.get(sim.playerId)!;
+    meta.craftSkills.weaponcrafting = 60; // score 60 >= 25: the letter threshold is crossed
+    expect(classifyCraftTrend(meta.craftSkills)?.crossed).toBe(true);
+    const { ctx, emitted } = nudgeCtx();
+    expect(maybeEmitTrendNudge(meta, ctx)).toBe(true);
+    expect(emitted).toEqual([{ type: 'profTrendNudge', pid: sim.playerId, pairId: TREND_PAIR }]);
   });
 
   it('does not fire for an attuned character, an amends-history character, or a fresh one', () => {

--- a/tests/professions_quest_cadence.test.ts
+++ b/tests/professions_quest_cadence.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { QUESTS } from '../src/sim/data';
 import {
   armCadence,
   cadenceBlockedKeys,
@@ -90,6 +91,46 @@ describe('cadence.ts pure helpers', () => {
     expect(clampCadenceOnLoad(undefined, 0, WORK_ORDER_CADENCE_TICKS).size).toBe(0);
     expect(clampCadenceOnLoad(null, 0, WORK_ORDER_CADENCE_TICKS).size).toBe(0);
   });
+
+  it('clampCadenceOnLoad drops a value exactly at now, keeps one exactly at the cap', () => {
+    // The keep arm is strict (clamped > now): a window lapsing exactly on the load
+    // tick is already available, so keeping it would only delay the shrink-back-to-
+    // empty re-omission from the next save. The cap itself is a legal availableAt.
+    const clamped = clampCadenceOnLoad(
+      { atNow: 100, atCap: 100 + WORK_ORDER_CADENCE_TICKS },
+      100,
+      WORK_ORDER_CADENCE_TICKS,
+    );
+    expect(clamped.has('atNow')).toBe(false);
+    expect(clamped.get('atCap')).toBe(100 + WORK_ORDER_CADENCE_TICKS);
+  });
+
+  it('armCadence clamps a negative window to immediately elapsed and floors a fraction', () => {
+    const map = new Map<string, number>();
+    // A non-positive window must never brick a key: availableAt lands AT now,
+    // which the strict isCadenceBlocked arm treats as already available.
+    armCadence(map, 'neg', 100, -50);
+    expect(map.get('neg')).toBe(100);
+    expect(isCadenceBlocked(map, 'neg', 100)).toBe(false);
+    // Windows are whole ticks: a fractional input floors, never rounds up.
+    armCadence(map, 'frac', 100, 50.9);
+    expect(map.get('frac')).toBe(150);
+  });
+});
+
+describe('work-order cadence catalog pin', () => {
+  it('every quest with a repeatCadenceTicks uses the single WORK_ORDER_CADENCE_TICKS window', () => {
+    // clampCadenceOnLoad clamps EVERY persisted questCadence key against this one
+    // constant (the src/sim/sim.ts load arm), so a quest armed with a second,
+    // different cadence value would silently mis-clamp on a tick-reset load. This
+    // pin turns that future hazard into a loud failure directing the author to
+    // make the load clamp per-key before introducing a second window length.
+    const cadenced = Object.values(QUESTS).filter((q) => q.repeatCadenceTicks !== undefined);
+    expect(cadenced.length).toBeGreaterThan(0); // the six work orders, at minimum
+    for (const quest of cadenced) {
+      expect(quest.repeatCadenceTicks, quest.id).toBe(WORK_ORDER_CADENCE_TICKS);
+    }
+  });
 });
 
 describe('computeQuestState cadence gating', () => {
@@ -112,12 +153,17 @@ describe('work-order turn-in arms the cooldown (Sim, Phase 14)', () => {
   it('turn-in arms the window, blocks re-accept inside it, and reopens after it lapses', () => {
     const sim = makeSim();
     expect(sim.questState(WORK_ORDER)).toBe('available');
+    const meta = sim.players.get(sim.playerId)!;
+    const copperReward = QUESTS[WORK_ORDER].copperReward;
+    expect(copperReward).toBeGreaterThan(0); // a zero reward would make the payout deltas vacuous
+    const copperStart = meta.copper;
 
     turnInWorkOrder(sim);
     // Armed for WORK_ORDER_CADENCE_TICKS from the current tick.
-    const meta = sim.players.get(sim.playerId)!;
     expect(meta.questCadence.get(WORK_ORDER)).toBe(sim.tickCount + WORK_ORDER_CADENCE_TICKS);
     expect(sim.questState(WORK_ORDER)).toBe('unavailable');
+    expect(meta.copper).toBe(copperStart + copperReward);
+    expect(meta.questsDone.has(WORK_ORDER)).toBe(true);
 
     // An immediate re-accept attempt is rejected server-side (questState gates it).
     moveToNpc(sim, FORGE_MASTER);
@@ -127,6 +173,16 @@ describe('work-order turn-in arms the cooldown (Sim, Phase 14)', () => {
     // Simulate the window lapsing (advance the stored availableAt into the past).
     meta.questCadence.set(WORK_ORDER, sim.tickCount);
     expect(sim.questState(WORK_ORDER)).toBe('available');
+
+    // Second FULL cycle after the lapse: 'available' must mean a real re-accept
+    // and re-turn-in land, the reward pays out a second time, and the window
+    // re-arms from the new turn-in tick (not from the first one).
+    const secondTurnInTick = sim.tickCount;
+    turnInWorkOrder(sim);
+    expect(meta.copper).toBe(copperStart + 2 * copperReward);
+    expect(meta.questsDone.has(WORK_ORDER)).toBe(true);
+    expect(meta.questCadence.get(WORK_ORDER)).toBe(secondTurnInTick + WORK_ORDER_CADENCE_TICKS);
+    expect(sim.questState(WORK_ORDER)).toBe('unavailable');
   });
 
   it('an immediate re-turn-in loop is bounded: only the first turn-in lands, then it is blocked', () => {

--- a/tests/professions_tier_mail.test.ts
+++ b/tests/professions_tier_mail.test.ts
@@ -102,6 +102,24 @@ describe('tier-crossing master mail (Professions 2.0 Phase 14)', () => {
     expect(second.booked).toEqual([]);
   });
 
+  it('mails a SECONDARY major crossing too (both majors watched, not just the archetype)', () => {
+    // Every other crossing test raises PRIMARY (activeArchetype), so a
+    // regression that watched only that craft on the mailing path would
+    // stay green; this arm crosses pairedMajor upward and demands its letter.
+    const sim = makeSim();
+    const meta = attunedMeta(sim);
+    meta.craftSkills[PRIMARY] = tierSkill(1);
+    meta.craftSkills[SECONDARY] = tierSkill(1);
+    baselineActivePairTierMail(meta);
+
+    meta.craftSkills[SECONDARY] = tierSkill(2);
+    const { ctx, booked } = recordingCtx();
+    expect(updateTierMailFor(meta, ctx)).toBe(true);
+    expect(booked).toEqual([MASTER_TIER_LETTERS[PAIR][2]]);
+    expect(meta.tierMailSent.get(SECONDARY)).toBe(2);
+    expect(meta.tierMailSent.get(PRIMARY)).toBe(1); // untouched
+  });
+
   it('sends only the top tier letter on a multi-tier jump', () => {
     const sim = makeSim();
     const meta = attunedMeta(sim);

--- a/tests/professions_tier_mail.test.ts
+++ b/tests/professions_tier_mail.test.ts
@@ -143,6 +143,61 @@ describe('tier-crossing master mail (Professions 2.0 Phase 14)', () => {
     expect(meta.tierMailSent.get(NON_WAVE_ONE_PRIMARY)).toBe(3);
   });
 
+  it('acknowledges an over-cap tier beyond the authored 1..5 range without mailing', () => {
+    const sim = makeSim();
+    const meta = attunedMeta(sim);
+    meta.craftSkills[PRIMARY] = tierSkill(5);
+    meta.craftSkills[SECONDARY] = tierSkill(1);
+    baselineActivePairTierMail(meta); // PRIMARY acknowledged at the authored top tier
+    // Decisive precondition: the wave-one letter set really ends at tier 5.
+    expect(MASTER_TIER_LETTERS[PAIR][5]).toBeDefined();
+    expect(MASTER_TIER_LETTERS[PAIR][6]).toBeUndefined();
+
+    // An over-cap skill crossing into tier 6 has no authored letter, so nothing
+    // is booked; the acknowledgement still advances so the same crossing is
+    // never re-evaluated by a later sweep.
+    meta.craftSkills[PRIMARY] = tierSkill(6);
+    const crossing = recordingCtx();
+    expect(updateTierMailFor(meta, crossing.ctx)).toBe(false);
+    expect(crossing.booked).toEqual([]);
+    expect(meta.tierMailSent.get(PRIMARY)).toBe(6);
+
+    const after = recordingCtx();
+    expect(updateTierMailFor(meta, after.ctx)).toBe(false);
+    expect(after.booked).toEqual([]);
+  });
+
+  it('stays quiet through a skill drop and re-cross, then mails only a genuinely new tier', () => {
+    const sim = makeSim();
+    const meta = attunedMeta(sim);
+    meta.craftSkills[PRIMARY] = tierSkill(3);
+    meta.craftSkills[SECONDARY] = tierSkill(1);
+    baselineActivePairTierMail(meta); // PRIMARY acknowledged at tier 3
+
+    // A mastery reset (12c) can lower craft skills: the acknowledgement never
+    // regresses with the skill, so the earlier congratulation stands.
+    meta.craftSkills[PRIMARY] = tierSkill(1);
+    const dropped = recordingCtx();
+    expect(updateTierMailFor(meta, dropped.ctx)).toBe(false);
+    expect(dropped.booked).toEqual([]);
+    expect(meta.tierMailSent.get(PRIMARY)).toBe(3);
+
+    // Re-crossing an already-acknowledged tier delivers nothing: no duplicate
+    // congratulations for ground regained.
+    meta.craftSkills[PRIMARY] = tierSkill(3);
+    const recrossed = recordingCtx();
+    expect(updateTierMailFor(meta, recrossed.ctx)).toBe(false);
+    expect(recrossed.booked).toEqual([]);
+    expect(meta.tierMailSent.get(PRIMARY)).toBe(3);
+
+    // Only a tier never acknowledged before mails: exactly the tier-4 letter.
+    meta.craftSkills[PRIMARY] = tierSkill(4);
+    const fresh = recordingCtx();
+    expect(updateTierMailFor(meta, fresh.ctx)).toBe(true);
+    expect(fresh.booked).toEqual([MASTER_TIER_LETTERS[PAIR][4]]);
+    expect(meta.tierMailSent.get(PRIMARY)).toBe(4);
+  });
+
   it('never mails for an unattuned character, a hobby craft, or a dormant craft', () => {
     // Unattuned: activeArchetype null -> a complete no-op, tierMailSent stays empty.
     const simUnattuned = makeSim();

--- a/tests/quest_state_optimistic.test.ts
+++ b/tests/quest_state_optimistic.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { optimisticQuestState } from '../src/net/quest_state_optimistic';
+import { emptyArchetypeState } from '../src/sim/professions/archetype';
 import type { QuestProgress } from '../src/sim/types';
 
 // Issue 1667: talking to an NPC, turning in a quest that gates a follow-up quest,
@@ -55,5 +56,146 @@ describe('optimisticQuestState (issue 1667)', () => {
     expect(optimisticQuestState('q_greyjaw', questLog, questsDone, pendingQuestCommands, 5)).toBe(
       'unavailable',
     );
+  });
+});
+
+// Phase 14: the optional `withinCadence` param is the online client's mirror of
+// the server-computed work-order cooldown set (cprof), and the attunePair busy
+// gate (one pending identity transition at a time) flows through the same
+// shared computeQuestState. Both are pinned here at the optimistic seam because
+// this is the exact function the gossip dialog re-queries between a click and
+// the next snapshot.
+describe('optimisticQuestState (Phase 14: cadence + attunement busy gate)', () => {
+  const noPending = () => new Map<string, 'accept' | 'turnin'>();
+
+  it('reports a repeatable work order inside its mirrored cadence window as unavailable', () => {
+    const questLog = new Map<string, QuestProgress>();
+    const questsDone = new Set<string>(['q_prof_workorder_forge']); // repeatable: done never sticks
+    const withinCadence = new Set(['q_prof_workorder_forge']);
+
+    expect(
+      optimisticQuestState(
+        'q_prof_workorder_forge',
+        questLog,
+        questsDone,
+        noPending(),
+        5,
+        undefined,
+        withinCadence,
+      ),
+    ).toBe('unavailable');
+  });
+
+  it('keeps the work order available when the cadence set is absent or names another quest', () => {
+    const questLog = new Map<string, QuestProgress>();
+    const questsDone = new Set<string>(['q_prof_workorder_forge']);
+
+    // No mirror at all (offline shape, or an empty cprof snapshot).
+    expect(
+      optimisticQuestState('q_prof_workorder_forge', questLog, questsDone, noPending(), 5),
+    ).toBe('available');
+    // Membership must be per-quest, not mere presence of a cooldown set.
+    expect(
+      optimisticQuestState(
+        'q_prof_workorder_forge',
+        questLog,
+        questsDone,
+        noPending(),
+        5,
+        undefined,
+        new Set(['q_prof_workorder_loom']),
+      ),
+    ).toBe('available');
+  });
+
+  it('lets a mirrored cadence block win over a pending accept for the same quest', () => {
+    // A stale accept click racing the cooldown mirror must not conjure an
+    // optimistic 'active': the accept promotion only applies to an 'available'
+    // base state, and cadence resolves the base state to 'unavailable'.
+    const questLog = new Map<string, QuestProgress>();
+    const questsDone = new Set<string>(['q_prof_workorder_forge']);
+    const pendingQuestCommands = new Map<string, 'accept' | 'turnin'>([
+      ['q_prof_workorder_forge', 'accept'],
+    ]);
+
+    expect(
+      optimisticQuestState(
+        'q_prof_workorder_forge',
+        questLog,
+        questsDone,
+        pendingQuestCommands,
+        5,
+        undefined,
+        new Set(['q_prof_workorder_forge']),
+      ),
+    ).toBe('unavailable');
+  });
+
+  it('gates a second attunePair quest while another attunement is active in the mirrored log', () => {
+    // One pending identity transition at a time (Phase 14 QA fix): an active
+    // smith attunement makes the outfitter offer unavailable even though the
+    // unattuned profession state would otherwise make it a legal target.
+    const questLog = new Map<string, QuestProgress>([
+      ['q_prof_attune_smith', { questId: 'q_prof_attune_smith', counts: [0], state: 'active' }],
+    ]);
+    const questsDone = new Set<string>();
+
+    expect(
+      optimisticQuestState(
+        'q_prof_attune_outfitter',
+        questLog,
+        questsDone,
+        noPending(),
+        5,
+        emptyArchetypeState(),
+      ),
+    ).toBe('unavailable');
+    // Positive control: with no attunement in flight the same state offers it.
+    expect(
+      optimisticQuestState(
+        'q_prof_attune_outfitter',
+        new Map<string, QuestProgress>(),
+        questsDone,
+        noPending(),
+        5,
+        emptyArchetypeState(),
+      ),
+    ).toBe('available');
+  });
+
+  it('shows a ready work order with a pending turn-in as active until the cadence mirrors', () => {
+    // The reconciliation window: the turn-in command is in flight, so the quest
+    // is still in the mirrored questLog as 'ready' and the server-armed cadence
+    // has not reached cprof yet. The questLog entry resolves first ('ready'),
+    // which the pending 'turnin' promotes to 'active': display-only optimism
+    // that holds exactly until the snapshot drops the log entry, clears the
+    // pending command, and delivers the cooldown set.
+    const questLog = new Map<string, QuestProgress>([
+      [
+        'q_prof_workorder_forge',
+        { questId: 'q_prof_workorder_forge', counts: [8], state: 'ready' },
+      ],
+    ]);
+    const questsDone = new Set<string>();
+    const pendingQuestCommands = new Map<string, 'accept' | 'turnin'>([
+      ['q_prof_workorder_forge', 'turnin'],
+    ]);
+
+    expect(
+      optimisticQuestState('q_prof_workorder_forge', questLog, questsDone, pendingQuestCommands, 5),
+    ).toBe('active');
+    // Post-snapshot resolution of the same window: log entry gone, pending
+    // cleared, cadence mirrored, so the quest settles to 'unavailable'.
+    expect(
+      optimisticQuestState(
+        'q_prof_workorder_forge',
+        new Map<string, QuestProgress>(),
+        new Set<string>(['q_prof_workorder_forge']),
+        noPending(),
+        5,
+        undefined,
+        new Set(['q_prof_workorder_forge']),
+      ),
+    ).toBe('unavailable');
   });
 });


### PR DESCRIPTION
## Summary

The independent Phase 14 QA pass over the Professions 2.0 attunement quests and nudges (QA diff 8b7bd4596..3219f69cd, the PR #2280 merge). Executed per docs/professions-2/phase-14-qa.md: a 10-agent audit fan-out (correctness, test coverage, dead code, plus the six matching dispatch-matrix reviewers and qa-checklist), a live offline-Sim behavior walk (nudge, attune, celebration, cheap switch, escalating amends, whitelist rejection, repeated work-order turn-in at the exact boundary tick), then fixes applied test-first.

Verdict: PASS with followups. Zero blocking findings; one real sim fix and eleven coverage arms landed; four cosmetic/hygiene items deferred to #2285.

The fix: the amends escalation could be dodged by banking. `resolvedCounts` is stamped at accept and turn-in never re-resolves it, and new-pair attunes are free (`switchCount` stays 0), so a player with three pairs in history could hold both open amends quests at counts [5] and turn the second in after the first return raised `switchCount`, paying 5 kills where a fresh accept resolves 8. The shared `computeQuestState` now hides every OTHER attunePair-effect quest while one is active (one pending identity transition at a time). Both hosts and the server accept gate share the one function; `switchHobby` and plain quests stay outside the gate; abandon reopens the others. Reproduced with a failing test first.

Coverage arms closed (all decisive, several mutation-verified):

- The online cprof UNBLOCK arm: a lapsed work-order window empties `cadenceBlockedQuests` on a set-shrink re-emit, verified end to end into the bareClient mirror.
- A second full work-order accept-and-turn-in cycle (second payout, window re-armed from the new turn-in tick).
- Cadence boundaries: load-clamp drop-at-now / keep-at-cap, negative and fractional arm windows, plus the catalog pin that every `repeatCadenceTicks` quest uses the single `WORK_ORDER_CADENCE_TICKS` (the load clamp caps against that one constant; a second value would silently mis-clamp on a tick-reset load).
- Tier-mail negatives: the over-cap acknowledged-anyway arm and the skill-drop then re-cross cycle (no duplicate mail, then exactly the genuinely new tier's letter).
- The above-threshold trend nudge (deliberate lower-bar semantics pinned against a future `!crossed` guard).
- `optimisticQuestState` unit arms: cadence blocked/available, block-beats-pending-accept, the busy gate through the mirrored log, and the pending-turn-in reconciliation window.
- The HUD render sink for all four text-free events (localized lines with the archetype title and master or celebrant name, never a raw pairId; banner family and tutorial routing; a source pin on the four switch cases) and tutorial Esc reachability through the topmost managed-window scan.
- The mid-quest 'active' identity state in the four-master availability matrix.

Verified-not-refixed accepted consequences (recorded in state.md): the zone celebration broadcast noise (masterworkZone precedent), the in-memory nudge cadence restart reset, the v0.29.0 rollback key-drop caveat, the non-wave-one no-return-path pin, and the ClientWorld no-op legacy members awaiting Phase 15 retirement.

Docs: progress.md gains the Phase 14 QA note; state.md's Phase 14 surfaces entry records the busy gate.

## Related issues

Part of #1866. Deferrals tracked in #2285.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation

## How was this tested?

- Commands: `npx tsc --noEmit`; `npx vitest run` over the full touched set (profession_attunement_quests, professions_quest_cadence, professions_tier_mail, professions_nudges, professions_attunement_online, quest_state_optimistic, hud_profession_events, profession_tutorial_window, quest_commands, quest_credit, prof_intro_quest, quest_dialog_controller, architecture, localization_fixes, world_api_parity, i18n_completeness, progression, professions_crafting and the parity goldens via the audit agents); `npm run wiki:content` and `npm run i18n:gen` freshness (zero diff); `npm run ci:changed`; `npm run gate` under Node 24 (GATE_EXIT=0).
- Manual steps: the correctness audit walked a live offline Sim through the full identity journey (trend nudge at the cadence boundary tick, attune with selection, celebration events, cheap first switch at 5, escalating repeat at 8, out-of-whitelist rejection) and a real repeated work-order turn-in (materials consumed, immediate re-turn-in cadence-blocked, window frees exactly at the boundary tick, coin 16 vs vendor 32). The escalation-dodge exploit was reproduced with a failing test before the fix.

## Screenshots / recordings

N/A: no visual change (the one source change is a sim-side availability gate using the existing hidden-quest idiom).

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI change.
- ~Accessible.~ N/A: no UI change (the tutorial Esc-path pin covers the existing modal).

### Localization (i18n)

- [x] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings (the busy gate uses the silent-hide idiom).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files. They're regenerated by the build.
