### PR TITLE
fix(game): release pinch-zoom tracking on blur/visibilitychange

### DIFF
--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -412,14 +412,14 @@ export class MobileControls {
     window.addEventListener('blur', () => {
       this.releaseMove();
       this.releaseCamera();
-      this.releaseSwipeLook();
+      this.releasePinch();
       this.touchOwners.releaseAll();
     });
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'hidden') {
         this.releaseMove();
         this.releaseCamera();
-        this.releaseSwipeLook();
+        this.releasePinch();
         this.touchOwners.releaseAll();
       }
     });

--- a/tests/mobile_controls.test.ts
+++ b/tests/mobile_controls.test.ts
@@ -2015,6 +2015,68 @@ describe('MobileControls pointer lifecycle', () => {
     );
     expect(lookActive).toEqual([true, false, false]);
   });
+
+  it('window blur mid-pinch clears the pinch tracking so a later single-finger swipe still works (Android app pinch-stuck bug)', () => {
+    const { canvas, windowTarget } = installMobileControlDom();
+    const lookActive: boolean[] = [];
+    const input = {
+      setTouchMove: () => {},
+      clearTouchMove: () => {},
+      setTouchLook: (active: boolean) => lookActive.push(active),
+      setTouchLookVector: () => {},
+      applyTouchLookDelta: () => {},
+      zoomBy: () => {},
+    } as unknown as Input;
+
+    new MobileControls(input, mobileCallbacks()).start();
+
+    // Two fingers land on the canvas: a pinch-zoom gesture starts.
+    canvas.dispatchEvent(
+      pointerEvent('pointerdown', {
+        pointerId: 61,
+        pointerType: 'touch',
+        clientX: 100,
+        clientY: 100,
+      }),
+    );
+    canvas.dispatchEvent(
+      pointerEvent('pointerdown', {
+        pointerId: 62,
+        pointerType: 'touch',
+        clientX: 200,
+        clientY: 100,
+      }),
+    );
+
+    // The app loses focus mid-gesture (e.g. a native Android sheet/dialog
+    // triggered by the interact/loot button) without ever delivering
+    // pointerup/pointercancel for either finger.
+    (windowTarget as unknown as EventTarget).dispatchEvent(new Event('blur'));
+
+    // A fresh single-finger swipe afterward must work normally: the stale
+    // two-finger pinch state must not still be guarding swipe-look.
+    canvas.dispatchEvent(
+      pointerEvent('pointerdown', {
+        pointerId: 63,
+        pointerType: 'touch',
+        clientX: 150,
+        clientY: 150,
+      }),
+    );
+    canvas.dispatchEvent(
+      pointerEvent('pointermove', {
+        pointerId: 63,
+        pointerType: 'touch',
+        clientX: 166,
+        clientY: 150,
+      }),
+    );
+
+    // releaseCamera's unconditional setTouchLook(false) fires first (existing
+    // blur behavior); the fix under test is that the third finger's swipe
+    // still activates afterward instead of being blocked by stale pinch state.
+    expect(lookActive).toEqual([false, true]);
+  });
 });
 
 describe('MobileControls chrome idle-fade lifecycle', () => {


### PR DESCRIPTION
## Summary

Fixes a reported Android bug where the mobile pinch-zoom gesture gets stuck ("I keep getting stuck pinch zooming in the android app on my s25 ultra. It seems to happen when running up to a body and looting with the interact button. Logging out and back in resolves.") reported in the community bug-reports channel.

Root cause: `window`'s `blur` handler and the `visibilitychange`-hidden handler in `src/game/mobile_controls.ts` release the move joystick, camera joystick, and swipe-look drag, but never called `releasePinch()`. If a two-finger pinch-zoom gesture is interrupted by a focus loss mid-gesture (e.g. a native Android sheet/dialog surfacing while looting a corpse via the interact button) without a `pointerup`/`pointercancel` ever reaching the canvas for those fingers, `pinchPointers`/`pinchPrevDist` stay stale. The next single-finger touch is then blocked by `onSwipeLookDown`'s `this.pinchPointers.size > 1` guard, which reads to the player as the camera/zoom permanently "stuck" until they log out and back in (which reconstructs the whole client and its `MobileControls` instance).

```mermaid
sequenceDiagram
    participant F1 as Finger 1
    participant F2 as Finger 2
    participant MC as MobileControls
    participant OS as Android WebView

    F1->>MC: pointerdown (canvas)
    F2->>MC: pointerdown (canvas)
    MC->>MC: pinchPointers.size == 2, pinchPrevDist set
    Note over OS: Interact button loots corpse,<br/>native sheet/dialog steals focus
    OS->>MC: window "blur" (no pointerup/pointercancel for F1/F2)
    rect rgb(255, 220, 220)
    Note over MC: BEFORE FIX: releasePinch() never called<br/>pinchPointers stays {F1, F2} forever
    end
    F1->>MC: new touch: pointerdown (canvas)
    MC->>MC: onSwipeLookDown: pinchPointers.size > 1 -> blocked
    Note over MC: Camera swipe/zoom reads as permanently stuck
```

Fix: route both the `blur` and `visibilitychange`-hidden handlers through `releasePinch()` (which already covers `releaseSwipeLook()` internally, so the separate `releaseSwipeLook()` calls are removed to avoid double-calling), matching the same cleanup-on-focus-loss pattern already used for the move joystick and camera joystick.

## Related issues

Reported verbally in the World of ClaudeCraft Discord `#bug-reports` channel by a player testing the Android app on a Samsung Galaxy S25 Ultra; no GitHub issue was filed for it prior to this PR.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/mobile_controls.test.ts`, `npx tsc --noEmit`, `npx @biomejs/biome check src/game/mobile_controls.ts tests/mobile_controls.test.ts`, `npm run gate` (all 11 steps green).
- Manual steps: added a failing-first Vitest repro (`window blur mid-pinch clears the pinch tracking so a later single-finger swipe still works (Android app pinch-stuck bug)`) that simulates a two-finger pinch start followed by a `blur` event with no matching `pointerup`/`pointercancel`, then asserts a subsequent single-finger swipe still activates camera look. Confirmed it failed before the fix (swipe-look blocked by stale `pinchPointers`) and passes after.

## Screenshots / recordings

N/A. This is a pure event-handler cleanup fix with no visual or DOM change; nothing to see in a screenshot, and the bug is a touch-input state bug that isn't visually distinguishable from a normal, working camera.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. Added a decisive regression test for the fixed behavior.

### Cross-platform

- [x] **Tested on desktop and mobile.** Change is scoped to `src/game/mobile_controls.ts`'s touch-only pinch/blur handling; verified via the mobile-controls Vitest suite (touch pointer event simulation). No desktop-facing behavior change (desktop never touches this code path).
- [ ] ~~Accessible~~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)