### PR TITLE
fix(auth): harden scope regression guards

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -138,6 +138,10 @@ curl -fsS -X POST -H "x-woc-deploy-secret: <RESTART_COUNTDOWN_SECRET>" \
 sudo docker compose stop game
 #    On an older checkout whose compose file has no stop_grace_period, pass the
 #    window explicitly: sudo docker compose stop -t 60 game
+#    This normal stop followed by up -d --build replaces the process. It also
+#    terminates authenticated and linkdead sessions held in process memory, so an
+#    auth rollout needs no separate session cleanup. Do not leave an old game
+#    process serving alongside the rebuilt one.
 
 # 6. Rebuild and start. (`sudo docker compose build game` before step 4 shortens the
 #    outage: the image is then ready the moment the countdown ends.)

--- a/server/db.ts
+++ b/server/db.ts
@@ -1514,7 +1514,8 @@ export async function saveToken(
 // Account + scope for a live token. Every caller receives the authority context:
 // read routes may accept both scopes, while mutation and privileged boundaries
 // require exact full scope. Unknown database values fail closed instead of being
-// promoted to full authority.
+// promoted to full authority. Such a historical token also cannot authenticate
+// its own logout; account-level revocation remains available to clear the row.
 export async function accountAndScopeForToken(
   token: string,
 ): Promise<{ accountId: number; scope: TokenScope } | null> {

--- a/tests/companion_read_api.test.ts
+++ b/tests/companion_read_api.test.ts
@@ -7,6 +7,7 @@
 // verified structurally rather than over a live socket.
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 // db.ts builds a pg Pool at import; give it a dummy URL (no connection is made
@@ -28,6 +29,46 @@ function serverTypeScriptFiles(dir: string): string[] {
 
 function stripComments(source: string): string {
   return source.replace(/^\s*\/\/.*$/gm, '');
+}
+
+type BearerAccountUse = {
+  kind: 'declaration' | 'call' | 'reference';
+  enclosingIf: string | null;
+};
+
+function bearerAccountUses(source: string): BearerAccountUse[] {
+  const sourceFile = ts.createSourceFile(
+    'resolver-scan.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const uses: BearerAccountUse[] = [];
+
+  function enclosingIf(node: ts.Node): string | null {
+    for (let current = node.parent; current; current = current.parent) {
+      if (ts.isIfStatement(current)) return current.expression.getText(sourceFile);
+    }
+    return null;
+  }
+
+  function visit(node: ts.Node): void {
+    if (ts.isIdentifier(node) && node.text === 'bearerAccount') {
+      const parent = node.parent;
+      if (ts.isFunctionDeclaration(parent) && parent.name === node) {
+        uses.push({ kind: 'declaration', enclosingIf: null });
+      } else if (ts.isCallExpression(parent) && parent.expression === node) {
+        uses.push({ kind: 'call', enclosingIf: enclosingIf(parent) });
+      } else {
+        uses.push({ kind: 'reference', enclosingIf: enclosingIf(node) });
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return uses;
 }
 
 describe('token scope policy', () => {
@@ -95,11 +136,12 @@ describe('legacy scope-blind resolver removal', () => {
 });
 
 describe('scope-blind bearerAccount remains confined to read routes', () => {
-  const READ_ROUTE_ANCHORS = [
-    "if (req.method === 'GET' && url === '/api/realms') {",
-    "if (req.method === 'GET' && url === '/api/search') {",
-    "if (req.method === 'GET' && mapIdMatch) {",
+  const READ_ROUTE_CONDITIONS = [
+    "req.method === 'GET' && url === '/api/realms'",
+    "req.method === 'GET' && url === '/api/search'",
+    "req.method === 'GET' && mapIdMatch",
   ];
+  const READ_ROUTE_ANCHORS = READ_ROUTE_CONDITIONS.map((condition) => `if (${condition}) {`);
 
   it('is called exactly once by each of its three permitted read routes', () => {
     const count = (MAIN.match(/bearerAccount\(req\)/g) ?? []).length;
@@ -115,6 +157,13 @@ describe('scope-blind bearerAccount remains confined to read routes', () => {
     expect(uses).toEqual([
       { kind: 'declaration', enclosingIf: null },
       { kind: 'reference', enclosingIf: null },
+    ]);
+  });
+
+  it('has no aliases and owns each call lexically inside a permitted GET branch', () => {
+    expect(bearerAccountUses(MAIN)).toEqual([
+      { kind: 'declaration', enclosingIf: null },
+      ...READ_ROUTE_CONDITIONS.map((enclosingIf) => ({ kind: 'call', enclosingIf })),
     ]);
   });
 

--- a/tests/companion_read_api.test.ts
+++ b/tests/companion_read_api.test.ts
@@ -106,6 +106,18 @@ describe('scope-blind bearerAccount remains confined to read routes', () => {
     expect(count).toBe(READ_ROUTE_ANCHORS.length);
   });
 
+  it('classifies an indirect alias as an unexpected resolver reference', () => {
+    const uses = bearerAccountUses(`
+      async function bearerAccount(req: unknown): Promise<null> { return null; }
+      const lookup = bearerAccount;
+      await lookup(req);
+    `);
+    expect(uses).toEqual([
+      { kind: 'declaration', enclosingIf: null },
+      { kind: 'reference', enclosingIf: null },
+    ]);
+  });
+
   for (const anchor of READ_ROUTE_ANCHORS) {
     it(`gates: ${anchor}`, () => {
       const idx = MAIN.indexOf(anchor);

--- a/tests/companion_read_api.test.ts
+++ b/tests/companion_read_api.test.ts
@@ -27,7 +27,7 @@ function serverTypeScriptFiles(dir: string): string[] {
 }
 
 function stripComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
 }
 
 describe('token scope policy', () => {

--- a/tests/companion_read_api.test.ts
+++ b/tests/companion_read_api.test.ts
@@ -59,20 +59,27 @@ describe('migration is additive; old tokens read full', () => {
     );
   });
   it('adds the scope column before installing the constraint that references it', () => {
+    const authTokensTable = SCHEMA.indexOf('CREATE TABLE IF NOT EXISTS auth_tokens (');
     const scopeColumn = SCHEMA.indexOf(
       "ALTER TABLE auth_tokens ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT 'full'",
     );
     const scopeConstraint = SCHEMA.indexOf('ADD CONSTRAINT auth_tokens_scope_check');
+    expect(authTokensTable).toBeGreaterThanOrEqual(0);
     expect(scopeColumn).toBeGreaterThanOrEqual(0);
     expect(scopeConstraint).toBeGreaterThanOrEqual(0);
+    expect(authTokensTable).toBeLessThan(scopeColumn);
     expect(scopeColumn).toBeLessThan(scopeConstraint);
   });
 });
 
 describe('legacy scope-blind resolver removal', () => {
-  it('strips prose comments without hiding code after a URL-like string', () => {
+  it('strips standalone prose comments without hiding code-like string contents', () => {
     const codeAfterUrl = "const base = 'http://localhost'; accountForToken(token);";
     expect(stripComments(codeAfterUrl)).toContain('accountForToken(token)');
+
+    const codeBetweenBlockMarkers =
+      "const open = '/*'; accountForToken(token); const close = '*/';";
+    expect(stripComments(codeBetweenBlockMarkers)).toContain('accountForToken(token)');
 
     const proseOnly = '// accountForToken was removed\nconst safe = true;';
     expect(stripComments(proseOnly)).not.toContain('accountForToken');

--- a/tests/companion_read_api.test.ts
+++ b/tests/companion_read_api.test.ts
@@ -58,9 +58,26 @@ describe('migration is additive; old tokens read full', () => {
       /CONSTRAINT auth_tokens_scope_check CHECK \(scope IN \('full', 'read'\)\) NOT VALID/,
     );
   });
+  it('adds the scope column before installing the constraint that references it', () => {
+    const scopeColumn = SCHEMA.indexOf(
+      "ALTER TABLE auth_tokens ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT 'full'",
+    );
+    const scopeConstraint = SCHEMA.indexOf('ADD CONSTRAINT auth_tokens_scope_check');
+    expect(scopeColumn).toBeGreaterThanOrEqual(0);
+    expect(scopeConstraint).toBeGreaterThanOrEqual(0);
+    expect(scopeColumn).toBeLessThan(scopeConstraint);
+  });
 });
 
 describe('legacy scope-blind resolver removal', () => {
+  it('strips prose comments without hiding code after a URL-like string', () => {
+    const codeAfterUrl = "const base = 'http://localhost'; accountForToken(token);";
+    expect(stripComments(codeAfterUrl)).toContain('accountForToken(token)');
+
+    const proseOnly = '// accountForToken was removed\nconst safe = true;';
+    expect(stripComments(proseOnly)).not.toContain('accountForToken');
+  });
+
   it('has no production reference to the removed accountForToken helper', () => {
     const offenders = serverTypeScriptFiles(SERVER_DIR)
       .filter((file) => /\baccountForToken\b/.test(stripComments(readFileSync(file, 'utf8'))))
@@ -68,6 +85,27 @@ describe('legacy scope-blind resolver removal', () => {
       .sort();
     expect(offenders).toEqual([]);
   });
+});
+
+describe('scope-blind bearerAccount remains confined to read routes', () => {
+  const READ_ROUTE_ANCHORS = [
+    "if (req.method === 'GET' && url === '/api/realms') {",
+    "if (req.method === 'GET' && url === '/api/search') {",
+    "if (req.method === 'GET' && mapIdMatch) {",
+  ];
+
+  it('is called exactly once by each of its three permitted read routes', () => {
+    const count = (MAIN.match(/bearerAccount\(req\)/g) ?? []).length;
+    expect(count).toBe(READ_ROUTE_ANCHORS.length);
+  });
+
+  for (const anchor of READ_ROUTE_ANCHORS) {
+    it(`gates: ${anchor}`, () => {
+      const idx = MAIN.indexOf(anchor);
+      expect(idx, `anchor not found: ${anchor}`).toBeGreaterThanOrEqual(0);
+      expect(MAIN.slice(idx, idx + 500)).toContain('bearerAccount(req)');
+    });
+  }
 });
 
 describe('every mutating / owner-action route funnels through bearerActiveAccount', () => {

--- a/tests/companion_read_api.test.ts
+++ b/tests/companion_read_api.test.ts
@@ -27,7 +27,7 @@ function serverTypeScriptFiles(dir: string): string[] {
 }
 
 function stripComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  return source.replace(/^\s*\/\/.*$/gm, '');
 }
 
 describe('token scope policy', () => {


### PR DESCRIPTION
## Summary

Follows up on FernandoX7's post-merge review of #2282.

- Pins the deliberately scope-blind `bearerAccount(req)` helper to its three read-only GET routes. The guard now parses `server/main.ts` with TypeScript, rejects aliases and other indirect references, and proves each direct call is lexically owned by an approved GET condition.
- Pins fresh-database DDL order as `auth_tokens` table creation, scope column addition, then installation of the scope constraint.
- Makes the removed-resolver scan fail noisy without allowing `http://` or block-comment markers inside string literals to hide a production reference.
- Documents that malformed historical scope values cannot authenticate their own logout, while account-level revocation remains available.
- Documents that the normal Docker stop and rebuild flow replaces the process and clears both active and linkdead in-memory sessions. No separate session cleanup step is needed.

The parent fix intentionally accepts read-token performance reports anonymously, with `accountId` and `characterId` set to `null`. This follow-up does not change that behavior or any other runtime authorization behavior from #2282.

## Related issues

- Follow-up to #2282
- Part of #1835
- Addresses [FernandoX7's post-merge review](https://github.com/levy-street/world-of-claudecraft/pull/2282#pullrequestreview-4750261203)

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/companion_read_api.test.ts tests/token_scope_db.test.ts`: 45 tests passed.
  - `npx tsc --noEmit`: passed.
  - `npx biome check tests/companion_read_api.test.ts`: passed.
  - `npm run gate`: all 11 steps passed, including 18,102 full-suite tests, 66 browser tests, TypeScript and Svelte checks, the malware gate, and production builds. On macOS, the existing watchdog timeout cases used a temporary GNU `timeout` compatible shim to match Linux and CI behavior.
  - `npm audit`: reported 17 existing transitive advisories (10 high and 7 moderate). This branch does not change dependencies or the lockfile.
- Manual steps:
  - Confirmed the release base remained at the merged #2282 tip before push.
  - Confirmed the final diff contains only `DEPLOY.md`, `server/db.ts`, and `tests/companion_read_api.test.ts`.
  - Ran independent correctness, migration/test, and security reviews. The final security review approved the AST guard and found no authorization bypass.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** N/A, no UI changes.
- [ ] **Accessible.** N/A, no UI changes.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
