### PR TITLE
fix(ui): staging a mail parcel no longer clears the typed compose form

### DIFF
--- a/src/ui/mailbox_window.ts
+++ b/src/ui/mailbox_window.ts
@@ -135,7 +135,12 @@ export class MailboxWindow {
     if (count < 1) return;
     this.attachments.push({ itemId, count });
     audio.click();
-    this.render();
+    // Targeted repaint, NOT this.render(): the full render rebuilds the send
+    // form via innerHTML with empty inputs, wiping the typed recipient,
+    // subject, body, and coin amounts the moment a parcel was attached. The
+    // stepper and remove paths already repaint this way (#1695); attach was
+    // the one parcel mutation still running the full rebuild.
+    this.renderParcels();
   }
 
   /**

--- a/tests/mailbox_compose_preserved.test.ts
+++ b/tests/mailbox_compose_preserved.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+// Staging a parcel must not clear the compose form. The bug: stageParcel (the
+// bags-window click that attaches an item) ran the FULL window render, and
+// renderSend rebuilds the whole form via innerHTML with empty inputs, so the
+// typed recipient, subject, body, and coin amounts were all wiped the moment a
+// player attached an item. The fix routes stageParcel through the targeted
+// renderParcels repaint the +/- quantity stepper already uses (#1695), which
+// only rebuilds the parcels row. Drives the REAL MailboxWindow against a jsdom
+// container (the bags_window_instance_marker idiom), through the real send-tab
+// button and the real stageParcel entry the bags window calls.
+import { afterEach, describe, expect, it } from 'vitest';
+import type { InvSlot } from '../src/sim/types';
+import { MailboxWindow, type MailboxWindowDeps } from '../src/ui/mailbox_window';
+import type { IWorld } from '../src/world_api';
+
+// Each test mounts its own window root; drop it so duplicate element ids from
+// a prior test's still-open window can never satisfy (or shadow) a lookup.
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+function fakeWorld(inventory: InvSlot[]): IWorld {
+  return {
+    inventory,
+    mailInfo: {
+      unread: 0,
+      messages: [],
+      postage: 30,
+      maxAttachments: 3,
+      deliverySeconds: 60,
+    },
+    mailMarkRead: () => {},
+  } as unknown as IWorld;
+}
+
+function openSendTab(inventory: InvSlot[]): { win: MailboxWindow; root: HTMLElement } {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  const noop = (): void => {};
+  const deps: MailboxWindowDeps = {
+    itemIcon: () => '<span class="item-icon"></span>',
+    moneyHtml: () => '',
+    itemTooltip: () => '',
+    attachTooltip: noop,
+    root: () => root,
+    world: () => fakeWorld(inventory),
+    closeOthers: noop,
+    hideTooltip: noop,
+    captureFocus: () => null,
+    restoreFocus: noop,
+    showError: noop,
+    syncBags: noop,
+  };
+  const win = new MailboxWindow(deps);
+  win.open();
+  (root.querySelector('[data-tab="send"]') as HTMLElement).click();
+  return { win, root };
+}
+
+const WOLF_FANG: InvSlot = { itemId: 'wolf_fang', count: 4 };
+
+describe('mailbox: staging a parcel preserves the typed compose form', () => {
+  it('keeps the recipient, subject, body, and coin inputs when an item is attached', () => {
+    const { win, root } = openSendTab([WOLF_FANG]);
+    const field = <T extends HTMLInputElement | HTMLTextAreaElement>(id: string) =>
+      root.querySelector<T>(`#${id}`) as T;
+    field<HTMLInputElement>('mail-to').value = 'Mira';
+    field<HTMLInputElement>('mail-subject').value = 'For you';
+    field<HTMLTextAreaElement>('mail-body').value = 'A fang from the hunt.';
+    field<HTMLInputElement>('mail-g').value = '2';
+
+    win.stageParcel('wolf_fang');
+
+    // The parcel chip landed...
+    expect(
+      root.querySelector('.mail-attachment-item, .mail-parcel-chip, #mail-parcels *'),
+    ).not.toBeNull();
+    // ...and every typed input survived the attach.
+    expect(field<HTMLInputElement>('mail-to').value).toBe('Mira');
+    expect(field<HTMLInputElement>('mail-subject').value).toBe('For you');
+    expect(field<HTMLTextAreaElement>('mail-body').value).toBe('A fang from the hunt.');
+    expect(field<HTMLInputElement>('mail-g').value).toBe('2');
+  });
+
+  it('still preserves the form when the SECOND parcel is staged (chips already present)', () => {
+    const { win, root } = openSendTab([WOLF_FANG, { itemId: 'linen_scrap', count: 2 }]);
+    const to = root.querySelector<HTMLInputElement>('#mail-to') as HTMLInputElement;
+    to.value = 'Mira';
+    win.stageParcel('wolf_fang');
+    win.stageParcel('linen_scrap');
+    expect(to.isConnected).toBe(true);
+    expect(to.value).toBe('Mira');
+  });
+});


### PR DESCRIPTION
## Summary

Typing a recipient (or subject, body, or coin amounts) in the mail Send tab and then attaching an item wiped everything typed. `stageParcel` ran the FULL mailbox render, and `renderSend` rebuilds the whole form via `innerHTML` with empty inputs.

This also explains why the bug survived an earlier fix: PR #1695 fixed the identical clobber for the +/- quantity stepper by introducing the targeted `renderParcels()` repaint, but the attach entry point kept the full rebuild. This PR routes `stageParcel` through `renderParcels()` like the stepper and remove paths, making all three parcel mutations consistent (one line plus a comment).

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/mailbox_compose_preserved.test.ts tests/mailbox_window.test.ts tests/mailbox_view.test.ts` (49 green)
  - `npx tsc --noEmit` clean; `npm run gate` green except the pre-existing environment-specific `deploy_watchdog.test.ts` timing failure that reproduces on pristine `release/v0.29.0` on this machine.
- The new regression test drives the REAL `MailboxWindow` in jsdom through the real send-tab click and the real `stageParcel` entry the bags window calls: it typed a recipient/subject/body/gold, attached an item, and failed with exactly the reported symptom (recipient wiped to `''`) before the fix; green after. A second case covers attaching when chips are already present.

## Screenshots / recordings

N/A: no visual change; the form simply keeps what was typed.