### PR TITLE
Phase 14b QA: verify Commissions and the Maker's Bond

### DIFF
--- a/docs/professions-2/progress.md
+++ b/docs/professions-2/progress.md
@@ -39,10 +39,10 @@ Update this file at the end of every implementation and QA session. Statuses:
 | 12d QA | Verify provenance and the harvest loop | complete (PASS, zero blocking) | 2026-07-21 | 2026-07-21 |
 | 13 | Enchanting reachable | complete (PR #2269 merged into release/v0.29.0) | 2026-07-21 | 2026-07-21 |
 | 13 QA | Verify enchanting reachable | complete (PASS, zero blocking) | 2026-07-21 | 2026-07-21 |
-| 14 | Attunement quests and nudges | complete (PR pending review) | 2026-07-21 | 2026-07-21 |
-| 14 QA | Verify attunement quests and nudges | not started | | |
-| 14b | Commissions and the Maker's Bond | complete (PR pending review) | 2026-07-21 | 2026-07-21 |
-| 14b QA | Verify commissions and the Maker's Bond | not started | | |
+| 14 | Attunement quests and nudges | complete (PR #2280 merged into release/v0.29.0) | 2026-07-21 | 2026-07-21 |
+| 14 QA | Verify attunement quests and nudges | complete (PASS with followups, PR #2286 merged into release/v0.29.0) | 2026-07-21 | 2026-07-21 |
+| 14b | Commissions and the Maker's Bond | complete (PR #2293 merged into release/v0.29.0) | 2026-07-21 | 2026-07-21 |
+| 14b QA | Verify commissions and the Maker's Bond | complete (PASS, zero blocking) | 2026-07-21 | 2026-07-21 |
 | 15 | Deeds, tuning, and polish | not started | | |
 | 15 QA | Final integration QA and packet teardown | not started | | |
 
@@ -1440,3 +1440,41 @@ Census moves: commands 163/172, IWORLD_MEMBERS 260 (71/189). Out of
 scope kept out: the ORDER workflow (#1298 stays open), recipient-tied
 materials, market instance carriage, non-commission binding, and the
 pre-existing vendor-sell laundering class. Close #2207 by hand at merge.
+
+Phase 14b QA (2026-07-21): PASS, zero blocking. QA diff
+cb2f026243..065763a02 (the PR #2293 merge's clean phase-only range on
+the release/v0.29.0 tip; the wider phase-start range holds a non-phase
+release sync); fix branch fix/professions-2-phase-14b-qa. Every
+deliverable, STEP 5 acceptance criterion, and the three RESOLVED
+maintainer decisions verified against real code, exactly as recorded
+(character presence-only binding, equipment-only kinds, the
+2500/10000/40000 ladder with both clamps). All validation rows green.
+Fan-out: an 11-agent Workflow (correctness, coverage, dead code, the
+four matrix reviewers, qa-checklist, then two live abuse-probe agents
+and an exclusive mutation pass). Abuse probes ALL PASS, driven for
+real, offline and over a live GameServer: unbind replay (one fee),
+craft-bank-trade, bound equip/use, vendor wash (pre-existing class
+recorded, no NEW hole), trade-back-to-crafter refusal, re-bind after
+unbind, mixed-offer slot accuracy, tampered flags, same-tick stamp
+race (no unbound window), payload smuggling through craft/trade/unbind
+extra fields (all inert), cross-player unbind targeting. Mutation
+pass: 8/8 gate-arm checks red. Fixes landed: the unbindItem fee debit
+moved AFTER the defensive unreachable guard (removes the theoretical
+charge-without-clear failure mode; behavior unchanged); new coverage,
+all mutation-checked where behavioral: bound-holder lifecycle
+(equip/unequip byte-intact round trip red against a boundTo-dropping
+unequip; equipped pieces sit outside the bags-only unbind scan; bank
+round trip; vendor sell allowed), mixed bound+unbound same-itemId
+equipment offer, deny-order discrimination pairs, the exact
+STATION_RADIUS boundary (float-exact, a <= to < regression reds), the
+active-mobile-station exclusion, wire type guards (non-boolean
+commission, smuggled payload fields, non-string unbind ids), a
+tool-kind tamper arm, unbind_window_hud.test.ts source pins (reason-to-
+key pairings, single-surface, the ONE-SHOT craftCommissionOptIn delete,
+clear-on-close, both HTML entries), and the gossip [data-unbind] route.
+Deferred by scope: the vendor buyback-plain wash (pre-existing Phase 13
+class; note the fee ladder now gives it fresh economic value, a Phase
+15 tuning-evidence input); the inline #ffd100 tooltip literal (matches
+the pre-existing masterworkSeal/soulbound convention, family-wide
+cleanup if ever); unbind rides the global command flood throttle
+(deny order makes replay free, accepted).

--- a/docs/professions-2/state.md
+++ b/docs/professions-2/state.md
@@ -1707,6 +1707,26 @@ tables, i18n key namespaces, files created)
   stackSize 1) and addItemInstance has no capacity guard there; the
   commissioned masterwork multi-copy remainder mints unsigned armed
   copies (mirrors the plain remainder; synthetic-recipe tested).
+- Phase 14b QA (2026-07-21, QA diff cb2f026243..065763a02, fix branch
+  fix/professions-2-phase-14b-qa): PASS, zero blocking; every surface
+  above verified holding in code, the three RESOLVED decisions landed
+  exactly, all abuse probes (offline + live wire, incl. same-tick stamp
+  race and payload smuggling) PASS, 8/8 mutation checks red. QA
+  hardening: unbindItem now debits the fee AFTER the defensive
+  unreachable slot guard (no reachable behavior change; a diverging
+  future refactor fails to a no-op instead of a charge-without-clear).
+  QA coverage additions: bound-holder lifecycle pins (equip/unequip
+  byte-intact, mutation-proven; the unbind scan is bags-only so an
+  equipped bound piece resolves unbind_not_bound; bank round trip;
+  vendor sell allowed), mixed bound+unbound same-itemId equipment
+  offer, deny-order discrimination pairs, the exact STATION_RADIUS
+  boundary, the active-mobile-station exclusion, wire type guards,
+  a tool-kind tamper arm, hud source pins (unbind_window_hud.test.ts:
+  the ONE-SHOT craftCommissionOptIn delete is the load-bearing line, a
+  has() regression would arm every later craft), and the gossip
+  [data-unbind] route. The vendor buyback-plain wash stays open by
+  scope; flagged as a Phase 15 tuning-evidence input (the fee ladder
+  gives the zero-cost wash fresh economic value).
 
 ## Tuning targets (placeholders until Phase 15 tunes against live data)
 

--- a/src/sim/professions/commission.ts
+++ b/src/sim/professions/commission.ts
@@ -159,11 +159,15 @@ export function unbindItem(ctx: SimContext, itemId: string, pid?: number): Unbin
   const meta = r.meta;
   const result = resolveUnbind(meta, r.e.pos, itemId);
   if (!result.ok) return result;
-  meta.copper -= result.fee;
   const slotIdx = firstBoundSlotIndex(meta, itemId);
   const slot = meta.inventory[slotIdx];
-  const instance = slot.instance;
-  if (instance === undefined) return result; // unreachable: the resolver found it bound
+  const instance = slot?.instance;
+  // Unreachable: the resolver found a bound slot on this same meta within the
+  // same synchronous call. Guarded BEFORE the charge below so that, were a
+  // future refactor ever to let the resolver and the mutation diverge, the
+  // failure mode is a no-op, never a fee charged with nothing cleared.
+  if (instance === undefined) return result;
+  meta.copper -= result.fee;
   if (slot.count === 1) {
     delete instance.boundTo;
   } else {

--- a/src/sim/professions/crafting.ts
+++ b/src/sim/professions/crafting.ts
@@ -125,7 +125,10 @@ export interface CraftResult {
   // was honored, i.e. the output is an eligible equipment kind and every
   // granted copy was minted armed with bindOnTrade (commission.ts). Absent
   // when the flag was not set AND when it was silently ignored for an
-  // ineligible output kind.
+  // ineligible output kind. Sim-internal: this field is NOT projected into
+  // CraftResultView (world_api/professions.ts) or the craftResult SimEvent,
+  // so no UI may consume it (the honored-vs-ignored pins are its consumer);
+  // the player-visible commission fact is the payload's bindOnTrade arm.
   commission?: boolean;
   // Present only when !ok: a stable reason code, not player-facing prose (the
   // caller renders/localizes the denial).

--- a/tests/professions_p14b_commissions.test.ts
+++ b/tests/professions_p14b_commissions.test.ts
@@ -35,7 +35,7 @@ vi.mock('../server/db', () => ({
 
 import { type ClientSession, GameServer } from '../server/game';
 import { ClientWorld } from '../src/net/online';
-import { STATIONS } from '../src/sim/content/professions';
+import { STATION_RADIUS, STATIONS } from '../src/sim/content/professions';
 import { ALL_RECIPES } from '../src/sim/content/recipes';
 import { ITEMS } from '../src/sim/data';
 import {
@@ -51,7 +51,7 @@ import { isAtAnyStation } from '../src/sim/professions/stations';
 import type { ProfessionRecipeRecord } from '../src/sim/professions/types';
 import { Sim } from '../src/sim/sim';
 import * as tradeMod from '../src/sim/social/trade';
-import type { InvSlot, ItemDef, ItemInstancePayload, SimEvent } from '../src/sim/types';
+import type { EquipSlot, InvSlot, ItemDef, ItemInstancePayload, SimEvent } from '../src/sim/types';
 
 const SWORD_RECIPE = 'recipe_eastbrook_arming_sword';
 const SWORD = 'eastbrook_arming_sword'; // weapon, common quality
@@ -330,6 +330,45 @@ describe('commission opt-in at craft time', () => {
       copies += slot.count;
     }
     expect(copies).toBe(2);
+  });
+
+  it('the flag is silently ignored for a TOOL output kind too (synthetic tool recipe)', () => {
+    // The potion arm above proves one ineligible kind; this pins a second,
+    // structurally different one (tool rides the same plain-fungible grant),
+    // comparing the tampered craft byte-for-byte against a plain craft.
+    const QA_TOOL = 'qa_p14b_prospect_pick';
+    (ITEMS as Record<string, ItemDef>)[QA_TOOL] = {
+      id: QA_TOOL,
+      name: 'QA Prospect Pick',
+      kind: 'tool',
+      quality: 'common',
+      sellValue: 1,
+    } as unknown as ItemDef;
+    const recipe = {
+      id: 'qa_recipe_p14b_pick',
+      professionId: recipeOf(SWORD_RECIPE).professionId,
+      resultItemId: QA_TOOL,
+      resultCount: 1,
+      reagents: [{ itemId: 'linen_scrap', count: 1 }],
+      skillReq: 0,
+      level: 1,
+      itemLevelBudget: 1,
+    } as unknown as ProfessionRecipeRecord;
+    const runCraft = (commission: boolean) => {
+      const sim = makeSim();
+      const pid = sim.playerId;
+      sim.addItem('linen_scrap', 1, pid);
+      const result = resolveCraftForRecipe(sim.ctx, pid, recipe, commission);
+      return { result, slots: slotsOf(sim, pid, QA_TOOL) };
+    };
+    const plain = runCraft(false);
+    const tampered = runCraft(true);
+    expect(plain.result.ok).toBe(true);
+    expect(tampered.result.ok).toBe(true);
+    expect(tampered.result.commission).toBeUndefined();
+    expect(tampered.slots).toEqual(plain.slots);
+    expect(tampered.slots).toHaveLength(1);
+    expect(tampered.slots[0].instance).toBeUndefined();
   });
 });
 
@@ -951,5 +990,279 @@ describe('live GameServer: commission craft, bound trade refusal, unbind over th
     expect(results[0].ok).toBe(false);
     expect(results[0].reason).toBe('unbind_out_of_range');
     expect(server.sim.players.get(st.pid)!.copper).toBe(10000);
+  });
+
+  it('wire type guards: non-boolean commission never arms, smuggled payloads are inert, non-string unbind ids drop', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const st = joinServer(server, fc, 804, 'Tamper');
+    placeAt(server, st.pid, { x: 0, z: 150 });
+    for (const reagent of recipeOf(SWORD_RECIPE).reagents) {
+      server.sim.addItem(reagent.itemId, reagent.count * 3, st.pid);
+    }
+
+    // A truthy-but-not-true commission value reads as false at the strict
+    // dispatch guard: both crafts grant the plain pre-phase fungible stack.
+    cmd(server, st, { cmd: 'craft_item', recipe: SWORD_RECIPE, commission: 'true' });
+    cmd(server, st, { cmd: 'craft_item', recipe: SWORD_RECIPE, commission: 1 });
+    routeTick(server);
+    const plain = serverSlots(server, st.pid, SWORD);
+    expect(plain.reduce((n, s) => n + s.count, 0)).toBe(2);
+    for (const slot of plain) expect(slot.instance).toBeUndefined();
+
+    // A genuine opt-in carrying smuggled payload fields mints EXACTLY the
+    // server-built arm: no wire command ingests an ItemInstancePayload.
+    cmd(server, st, {
+      cmd: 'craft_item',
+      recipe: SWORD_RECIPE,
+      commission: true,
+      instance: { boundTo: 999, signer: 'Hax' },
+      payload: { boundTo: 999 },
+      boundTo: 999,
+    });
+    routeTick(server);
+    const armed = serverSlots(server, st.pid, SWORD).filter((s) => s.instance !== undefined);
+    expect(armed).toHaveLength(1);
+    expect(armed[0].instance).toEqual({ bindOnTrade: true });
+
+    // Non-string unbind ids are dropped at the dispatch type guard: no
+    // event, no charge, the bound copy untouched.
+    server.sim.ctx.addItemInstance(SWORD, { bindOnTrade: true, boundTo: st.pid }, st.pid);
+    placeAt(server, st.pid, STATIONS[0].pos);
+    server.sim.players.get(st.pid)!.copper = 10000;
+    const from = fc.sent.length;
+    cmd(server, st, { cmd: 'unbind_item', item: 123 });
+    cmd(server, st, { cmd: 'unbind_item' });
+    routeTick(server);
+    expect(eventsFor(fc.sent, 'unbindResult', from)).toHaveLength(0);
+    expect(server.sim.players.get(st.pid)!.copper).toBe(10000);
+    const stillBound = serverSlots(server, st.pid, SWORD).filter(
+      (s) => s.instance?.boundTo !== undefined,
+    );
+    expect(stillBound).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. The bound holder keeps every non-trade right (binding restricts trade
+//     ONLY: equip, unequip, bank, and vendor all stay open, payload intact).
+// ---------------------------------------------------------------------------
+describe('bound holder lifecycle: every non-trade right survives the bond', () => {
+  // Expectation literals are built FRESH per assertion: addItemInstance can
+  // store the minted payload by reference, so comparing against the same
+  // object we handed it would be a self-comparison a field-dropping mutation
+  // could never red (mutation-checked: an unequip that deletes boundTo must
+  // fail the round-trip pin below).
+  function expectedBound(pid: number): ItemInstancePayload {
+    return { bindOnTrade: true, boundTo: pid, signer: 'Ayla' };
+  }
+
+  function mintBound(sim: Sim, pid: number): void {
+    sim.ctx.addItemInstance(SWORD, { bindOnTrade: true, boundTo: pid, signer: 'Ayla' }, pid);
+  }
+
+  it('equip and unequip round-trip the bound payload byte-intact: unequip is never a free unbind', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = sim.players.get(pid)!;
+    mintBound(sim, pid);
+    sim.equipItem(SWORD, pid);
+    const wornSlot = (Object.entries(meta.equipment).find(([, id]) => id === SWORD) ?? [])[0] as
+      | EquipSlot
+      | undefined;
+    expect(wornSlot, 'the bound sword equipped (binding restricts trade only)').toBeTruthy();
+    expect(slotsOf(sim, pid, SWORD)).toHaveLength(0);
+    expect(meta.equipmentInstance?.[wornSlot!]).toEqual(expectedBound(pid));
+    expect(sim.unequipItem(wornSlot!, pid)).toBe(true);
+    const back = slotsOf(sim, pid, SWORD);
+    expect(back).toHaveLength(1);
+    // Byte-intact: boundTo AND the arm both survive, so unequipping is never
+    // a fee-free unbind and the piece re-refuses its next trade.
+    expect(back[0].instance).toEqual(expectedBound(pid));
+  });
+
+  it('an EQUIPPED bound piece is outside the unbind scan: the service reads bags only', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = sim.players.get(pid)!;
+    mintBound(sim, pid);
+    sim.equipItem(SWORD, pid);
+    setCopper(sim, pid, 50000);
+    const result = resolveUnbind(meta, STATIONS[0].pos, SWORD);
+    expect(result).toMatchObject({ ok: false, reason: 'unbind_not_bound' });
+    expect(copperOf(sim, pid)).toBe(50000);
+  });
+
+  it('a bound piece banks and withdraws byte-intact', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = sim.players.get(pid)!;
+    // Stand on a banker (the pooled-bank gate needs one in reach).
+    const banker = [...sim.entities.values()].find(
+      (e) => e.kind === 'npc' && e.templateId === 'bursar_fernando',
+    );
+    expect(banker, 'the Eastbrook bursar is spawned').toBeTruthy();
+    const p = sim.entities.get(pid)!;
+    p.pos = { ...banker!.pos };
+    p.prevPos = { ...p.pos };
+    sim.rebucket(p);
+    mintBound(sim, pid);
+    const invIdx = meta.inventory.findIndex((s) => s.itemId === SWORD);
+    sim.bankDeposit(invIdx, 1, pid);
+    expect(slotsOf(sim, pid, SWORD)).toHaveLength(0);
+    const bankIdx = meta.bank.inventory.findIndex((s) => s.itemId === SWORD);
+    expect(bankIdx).toBeGreaterThan(-1);
+    expect(meta.bank.inventory[bankIdx].instance).toEqual(expectedBound(pid));
+    sim.bankWithdraw(bankIdx, 1, pid);
+    const back = slotsOf(sim, pid, SWORD);
+    expect(back).toHaveLength(1);
+    expect(back[0].instance).toEqual(expectedBound(pid));
+  });
+
+  it('vendor sell of a bound piece is allowed: the bond gates trade, never the vendor', () => {
+    // The equipment-kind sibling of the Phase 13 bound-reagent sell pin
+    // (professions_p13_bound_surfaces.test.ts); the buyback-laundering class
+    // stays open in scope elsewhere, this pins only the deliverable: selling
+    // is never refused by the bond.
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes');
+    expect(wilkes, 'Trader Wilkes is spawned').toBeTruthy();
+    const p = sim.entities.get(pid)!;
+    p.pos = { ...wilkes!.pos };
+    p.prevPos = { ...p.pos };
+    sim.rebucket(p);
+    mintBound(sim, pid);
+    const before = copperOf(sim, pid);
+    sim.sellItem(SWORD, 1, pid);
+    expect(errorTexts(sim.drainEvents())).toHaveLength(0);
+    expect(slotsOf(sim, pid, SWORD)).toHaveLength(0);
+    expect(copperOf(sim, pid)).toBe(before + ITEMS[SWORD].sellValue!);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. Trade-gate slot accuracy: mixed bound and unbound copies of the SAME
+//     item id (the Phase 3 same-itemId cross-contamination class, now pinned
+//     on a commission equipment kind, not only the Phase 13 reagent).
+// ---------------------------------------------------------------------------
+describe('mixed bound + unbound copies of one equipment itemId trade slot-accurately', () => {
+  it('the offer clamps to the unbound count and completing it moves ONLY the free copy', () => {
+    const { sim, a, b } = makeTradeSim();
+    sim.ctx.addItemInstance(SWORD, { bindOnTrade: true, boundTo: a }, a);
+    sim.addItem(SWORD, 1, a);
+    tradeMod.tradeRequest(sim.ctx, b, a);
+    tradeMod.tradeAccept(sim.ctx, b);
+    sim.drainEvents();
+
+    // Offering BOTH copies is refused down to the one unbound copy.
+    tradeMod.tradeSetOffer(sim.ctx, [{ itemId: SWORD, count: 2 }], 0, a);
+    expect(errorTexts(sim.drainEvents())).toContain(BOUND_DENY);
+
+    tradeMod.tradeSetOffer(sim.ctx, [{ itemId: SWORD, count: 1 }], 0, a);
+    tradeMod.tradeConfirm(sim.ctx, a);
+    tradeMod.tradeConfirm(sim.ctx, b);
+    expect(errorTexts(sim.drainEvents())).toEqual([]);
+
+    // Slot accuracy: the PLAIN copy moved (arriving unbound: nothing armed
+    // it), the bound copy never left the offerer.
+    const received = slotsOf(sim, b, SWORD);
+    expect(received).toHaveLength(1);
+    expect(received[0].instance).toBeUndefined();
+    const kept = slotsOf(sim, a, SWORD);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].instance?.boundTo).toBe(a);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 13. Deny-order discrimination and the station gate's edges (QA arms: the
+//     pairwise orders section 5 leaves open, the exact-radius boundary, and
+//     the mobile-station exclusion).
+// ---------------------------------------------------------------------------
+describe('unbind deny-order discrimination and station-gate edges', () => {
+  it('out_of_range beats cannot_afford when both fail at once', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = sim.players.get(pid)!;
+    sim.ctx.addItemInstance(SWORD, { bindOnTrade: true, boundTo: pid }, pid);
+    standInWilds(sim, pid);
+    setCopper(sim, pid, 0);
+    const result = resolveUnbind(meta, sim.ctx.entities.get(pid)!.pos, SWORD);
+    expect(result).toMatchObject({ ok: false, reason: 'unbind_out_of_range', fee: 2500 });
+  });
+
+  it('not_eligible beats not_bound: an ineligible id with zero bound copies reports eligibility', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = sim.players.get(pid)!;
+    sim.addItem(POTION, 1, pid);
+    setCopper(sim, pid, 50000);
+    const result = resolveUnbind(meta, STATIONS[0].pos, POTION);
+    expect(result).toMatchObject({ ok: false, reason: 'unbind_not_eligible' });
+  });
+
+  it('unbind_not_bound covers the zero-copies-held arm too', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = sim.players.get(pid)!;
+    setCopper(sim, pid, 50000);
+    const result = resolveUnbind(meta, STATIONS[0].pos, SWORD);
+    expect(result).toMatchObject({ ok: false, reason: 'unbind_not_bound' });
+  });
+
+  it('isAtAnyStation includes the EXACT radius boundary and excludes just beyond', () => {
+    // Boundary suites tick AT the boundary: STATION_RADIUS and the forge x
+    // are float-exact integers, so distance == radius lands precisely on the
+    // <= comparison; an off-by-one regression to < reds the first arm.
+    const forge = STATIONS[0];
+    const atEdge = { x: forge.pos.x + STATION_RADIUS, z: forge.pos.z };
+    const strictlyInsideAny = STATIONS.some((st) => {
+      const dx = atEdge.x - st.pos.x;
+      const dz = atEdge.z - st.pos.z;
+      return dx * dx + dz * dz < STATION_RADIUS * STATION_RADIUS;
+    });
+    expect(strictlyInsideAny, 'the edge probe sits on the boundary, not inside a neighbor').toBe(
+      false,
+    );
+    expect(isAtAnyStation(atEdge)).toBe(true);
+
+    const beyond = [
+      { dx: 1, dz: 0 },
+      { dx: -1, dz: 0 },
+      { dx: 0, dz: 1 },
+      { dx: 0, dz: -1 },
+    ]
+      .map((d) => ({
+        x: forge.pos.x + d.dx * (STATION_RADIUS + 0.5),
+        z: forge.pos.z + d.dz * (STATION_RADIUS + 0.5),
+      }))
+      .find((pos) =>
+        STATIONS.every((st) => {
+          const dx = pos.x - st.pos.x;
+          const dz = pos.z - st.pos.z;
+          return dx * dx + dz * dz > STATION_RADIUS * STATION_RADIUS;
+        }),
+      );
+    expect(beyond, 'a just-beyond probe position clear of every station').toBeDefined();
+    expect(isAtAnyStation(beyond!)).toBe(false);
+  });
+
+  it('an ACTIVE mobile station under the player never satisfies the unbind gate', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = sim.players.get(pid)!;
+    const p = sim.ctx.entities.get(pid)!;
+    p.pos.x = 0;
+    p.pos.z = 150;
+    expect(isAtAnyStation(p.pos)).toBe(false);
+    meta.craftSkills.alchemy = 75; // specialized: mobile placement is gated on it
+    setCopper(sim, pid, 50000);
+    sim.placeMobileStation('alchemy', pid);
+    expect(meta.mobileStation?.craftId).toBe('alchemy');
+    sim.ctx.addItemInstance(SWORD, { bindOnTrade: true, boundTo: pid }, pid);
+    const result = resolveUnbind(meta, p.pos, SWORD);
+    expect(result).toMatchObject({ ok: false, reason: 'unbind_out_of_range' });
+    expect(copperOf(sim, pid)).toBe(50000);
   });
 });

--- a/tests/quest_dialog_controller.test.ts
+++ b/tests/quest_dialog_controller.test.ts
@@ -356,6 +356,31 @@ describe('QuestDialogController', () => {
     expect(plain.element.querySelector('[data-train]')).toBeNull();
   });
 
+  it('a station master offers the Unbind service and routes it to openUnbind (Phase 14b)', () => {
+    // Every station master offers the Maker's Bond unbind service beside
+    // training (the same isStationMasterNpc gate); the click routes the NPC
+    // ENTITY id to deps.openUnbind and releases the dialog.
+    const master = harness(npc(48, STATIONS[0].masterNpcId));
+    master.controller.open(48);
+    const button = master.element.querySelector<HTMLButtonElement>('[data-unbind]');
+    expect(button).not.toBeNull();
+    expect(button?.getAttribute('aria-label')).toBeTruthy();
+    button?.click();
+    expect(master.openUnbind).toHaveBeenCalledWith(48);
+    expect(master.release).toHaveBeenCalledWith(false);
+  });
+
+  it('a non-master NPC renders no Unbind option (Phase 14b)', () => {
+    const masters = new Set(STATIONS.map((station) => station.masterNpcId));
+    const plainId = Object.values(NPCS).find(
+      (definition) => !definition.banker && !masters.has(definition.id),
+    )?.id;
+    if (!plainId) throw new Error('non-master NPC fixture not found');
+    const plain = harness(npc(49, plainId));
+    plain.controller.open(49);
+    expect(plain.element.querySelector('[data-unbind]')).toBeNull();
+  });
+
   it('closes stale gossip when the authoritative NPC disappears', () => {
     const test = harness();
     test.controller.open(test.entity.id);

--- a/tests/unbind_window_hud.test.ts
+++ b/tests/unbind_window_hud.test.ts
@@ -1,0 +1,134 @@
+// Source pins over the Hud's Phase 14b Maker's Bond integration (the
+// train_window_hud.test.ts style: the wiring lives in the hud.ts coordinator,
+// so these pin the load-bearing snippets instead of booting the whole Hud):
+//  - the unbindResult event arm logs exactly one localized line per outcome,
+//    with NO banner/toast/audio (the trainResult single-surface rule), maps
+//    every deny reason to ITS OWN key, and repaints the unbind window + bags
+//    (the single-copy unbind clears boundTo in place with no loot event);
+//  - the commission opt-in is a ONE-SHOT per-craft Set: onCraft consumes via
+//    delete (a regression to has() would arm EVERY later craft), the checkbox
+//    reads via has, and closing the crafting window clears every armed row;
+//  - the unbind window wires gossip -> openUnbind and the fee-confirm dialog
+//    to the IWorld seam (sim.unbindItem), never deciding the outcome locally;
+//  - both HTML entries declare the #unbind-window container.
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const hudSource = readFileSync(resolve(__dirname, '../src/ui/hud.ts'), 'utf8');
+
+function unbindResultArm(): string {
+  const start = hudSource.indexOf("case 'unbindResult': {");
+  // The arm sits between trainResult and masterwork in drainEvents; slicing
+  // to the NEXT case keeps the single-surface pins scoped to this arm alone
+  // (a future arm inserted between them must update this anchor).
+  const end = hudSource.indexOf("case 'masterwork': {", start);
+  expect(start, 'unbindResult case arm present in handleEvents').toBeGreaterThan(-1);
+  expect(end, 'unbindResult arm precedes the masterwork arm').toBeGreaterThan(start);
+  return hudSource.slice(start, end);
+}
+
+describe('hud.ts unbindResult event arm (source pins)', () => {
+  it('logs the unbound line on ok and maps the deny reasons to unbind keys', () => {
+    const arm = unbindResultArm();
+    expect(arm).toContain("t('hudChrome.unbind.unbound'");
+    for (const key of [
+      'hudChrome.unbind.notEligible',
+      'hudChrome.unbind.notBound',
+      'hudChrome.unbind.cannotAfford',
+      'hudChrome.unbind.outOfRange',
+    ]) {
+      expect(arm, key).toContain(key);
+    }
+    for (const reason of ['unbind_not_eligible', 'unbind_not_bound', 'unbind_cannot_afford']) {
+      expect(arm, reason).toContain(reason);
+    }
+  });
+
+  it('pairs each deny reason with ITS OWN key (a key swap in the chain must fail here)', () => {
+    // Presence pins alone cannot catch two keys swapped inside the ternary
+    // chain, so pin each reason-to-key pairing. unbind_out_of_range is
+    // deliberately the fallback arm (its literal never appears in hud.ts), so
+    // its pairing is pinned as the else branch of the cannotAfford arm.
+    const arm = unbindResultArm();
+    expect(arm).toMatch(/'unbind_not_eligible'\s*\?\s*'hudChrome\.unbind\.notEligible'/);
+    expect(arm).toMatch(/'unbind_not_bound'\s*\?\s*'hudChrome\.unbind\.notBound'/);
+    expect(arm).toMatch(
+      /'unbind_cannot_afford'\s*\?\s*'hudChrome\.unbind\.cannotAfford'\s*:\s*'hudChrome\.unbind\.outOfRange'/,
+    );
+  });
+
+  it('derives the item name from static content and formats the fee locally (text-free event)', () => {
+    const arm = unbindResultArm();
+    expect(arm).toContain('ITEMS[ev.itemId]');
+    expect(arm).toContain('itemDisplayName');
+    expect(arm).toContain('formatLocalizedMoney(ev.fee)');
+  });
+
+  it('stays single-surface: chat log only, no banner, toast, or audio cue in the arm', () => {
+    const arm = unbindResultArm();
+    expect(arm.match(/this\.log\(/g)?.length, 'exactly the ok + deny log call sites').toBe(2);
+    expect(arm).not.toMatch(/showBanner|showToast|this\.audio|playSfx|playCue|celebrat/i);
+  });
+
+  it('renders nothing for a reason-less deny (the silent malformed-item-id arm)', () => {
+    const arm = unbindResultArm();
+    expect(arm).toContain('else if (ev.reason)');
+  });
+
+  it('repaints the open unbind window AND the open bags (no loot event repaints for us)', () => {
+    const arm = unbindResultArm();
+    expect(arm).toContain('this.renderUnbind();');
+    expect(arm).toContain('this.renderBags();');
+    expect(arm).toContain("$('#unbind-window').style.display === 'block'");
+    expect(arm).toContain("$('#bags').style.display !== 'none'");
+  });
+});
+
+describe('hud.ts commission opt-in state contract (source pins)', () => {
+  it('onCraft consumes the opt-in as a ONE-SHOT delete, never a persistent read', () => {
+    // The load-bearing line: delete() both reads AND clears the armed flag,
+    // so the checkbox arms exactly one craft. A regression to has() would
+    // silently arm every subsequent craft of that recipe and no sim-side pin
+    // could catch it (the sim honors whatever flag arrives).
+    expect(hudSource).toContain('const commission = this.craftCommissionOptIn.delete(recipeId);');
+    expect(hudSource).toContain('this.sim.craftItem(recipeId, commission);');
+  });
+
+  it('the checkbox paints from has() and toggles through add/delete', () => {
+    expect(hudSource).toContain(
+      'commissionChecked: (recipeId) => this.craftCommissionOptIn.has(recipeId)',
+    );
+    expect(hudSource).toContain('if (on) this.craftCommissionOptIn.add(recipeId);');
+    expect(hudSource).toContain('else this.craftCommissionOptIn.delete(recipeId);');
+  });
+
+  it('closing the crafting window drops every armed checkbox (the off-by-default rule)', () => {
+    const start = hudSource.indexOf('closeCrafting(): void {');
+    expect(start).toBeGreaterThan(-1);
+    const arm = hudSource.slice(start, start + 600);
+    expect(arm).toContain('this.craftCommissionOptIn.clear();');
+  });
+});
+
+describe('hud.ts unbind window wiring (source pins)', () => {
+  it('gossip routes to openUnbind and the confirm dialog sends the command to the seam', () => {
+    expect(hudSource).toContain('openUnbind: (npcId) => this.openUnbind(npcId)');
+    expect(hudSource).toContain("this.closeOtherWindows('#unbind-window')");
+    expect(hudSource).toContain("t('hudChrome.unbind.confirmTitle')");
+    expect(hudSource).toContain('() => this.sim.unbindItem(itemId),');
+  });
+});
+
+describe('#unbind-window container exists in both HTML entries', () => {
+  it('index.html and play.html both declare the unbind window panel', () => {
+    for (const entry of ['index.html', 'play.html']) {
+      const html = readFileSync(resolve(__dirname, '..', entry), 'utf8');
+      expect(html, entry).toContain('id="unbind-window"');
+      const tag = html.match(/<div[^>]*id="unbind-window"[^>]*>/)?.[0] ?? '';
+      expect(tag, `${entry} unbind window is a .window.panel container`).toMatch(
+        /class="[^"]*window[^"]*panel[^"]*"/,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 14b QA of Professions 2.0: the audit-and-fix pass over Commissions and the Maker's Bond (PR #2293, clean phase diff cb2f026243..065763a02), per docs/professions-2/phase-14b-qa.md.

**Verdict: PASS, zero blocking.** Every deliverable, STEP 5 acceptance criterion, and the three RESOLVED maintainer decisions verified against real code exactly as state.md records them (character presence-only binding; equipment-only opt-in kinds; the 2500/10000/40000 fee ladder, clamp-to-last above and the recorded clamp-to-first-below interpretation, still flagged for maintainer review). Abuse probes were driven for real, offline and over a live in-process GameServer, and all pass: unbind replay (one fee, one clear), craft-bank-trade, bound equip/use, vendor wash (pre-existing class, no NEW hole), trade-back-to-crafter refusal, re-bind after unbind, mixed-offer slot accuracy, tampered flags on ineligible kinds, same-tick stamp race (no unbound window), payload smuggling through craft/trade/unbind extra fields (all inert), and cross-player unbind targeting. A mutation pass proved 8/8 landed gate-arm pins decisive.

What this PR changes:

- **fix(sim), hardening only**: `unbindItem` debits the fee AFTER the defensive unreachable slot guard, so a future resolver/mutation divergence fails to a no-op instead of a charge-without-clear. No reachable behavior change. Also documents that `CraftResult.commission` is sim-internal (never projected into `CraftResultView` or the `craftResult` event).
- **test(professions-2)**: the audit's coverage gaps, mutation-checked where behavioral: bound-holder lifecycle (equip/unequip round-trips the payload byte-intact, proven red against a boundTo-dropping unequip; the unbind scan is bags-only; bank round trip; vendor sell allowed), the mixed bound+unbound same-itemId equipment offer (slot-accurate refusal), deny-order discrimination pairs, the exact STATION_RADIUS boundary (float-exact), the active-mobile-station exclusion, wire type guards (non-boolean commission, smuggled payload fields, non-string unbind ids), a tool-kind tamper arm, `tests/unbind_window_hud.test.ts` source pins over the hud.ts glue (reason-to-key pairings, single-surface rule, the ONE-SHOT `craftCommissionOptIn` delete, clear-on-close, both HTML entries), and the gossip `[data-unbind]` route.
- **docs(professions-2)**: the QA notes block and verdict in progress.md (plus table rows caught up with merged PRs 2280/2286/2293) and the QA entry in state.md.

Deferred by scope (recorded, not fixed): the vendor buyback-plain wash (pre-existing Phase 13 class; the fee ladder now gives the zero-cost wash fresh economic value, flagged as a Phase 15 tuning-evidence input); the inline `#ffd100` tooltip literal (matches the pre-existing masterworkSeal/soulbound convention); unbind riding the global command flood throttle (deny order makes replay free).

## Related issues

Part of #1866. Phase 14b build was #2207 (closed at merge); #1298 (order workflow) stays open by scope.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation

## How was this tested?

- Commands: `npm run gate` under Node 24: PASS, all 11 steps green (GATE_EXIT=0). Touched-suite sweep: `npx vitest run` over the 14 adjacent suites (609 passed, 3 skipped); `npx tsc --noEmit` clean; scoped biome on changed files; python byte scan of added diff lines for em/en dashes and emoji (clean).
- Manual steps: 11-agent audit fan-out (correctness, coverage, dead-code, privacy-security-review, cross-platform-sync, architecture-reviewer, frontend-seam-reviewer, qa-checklist, two live abuse-probe agents, one exclusive mutation-verification pass). Mutation checks applied and reverted one at a time; the two NEW behavioral pins were additionally mutation-proven (a boundTo-dropping unequip and a `<=` to `<` station-radius regression each red exactly their pin).

## Screenshots / recordings

N/A: no visual change (tests, docs, and a behavior-preserving sim hardening only). The Phase 14b build PR carries the phase's before/after shots.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive tests for changed behavior and recorded any manual checks above.

https://claude.ai/code/session_01ENdVuwie8VwghmW5btqaR8
