### PR TITLE
fix(ui): paint col-b micro-menu hover flyouts over col-a

### DIFF
--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -1813,6 +1813,16 @@
     width: 34px;
     gap: 4px;
   }
+  /* col-b hugs the screen edge, so its hover flyouts grow leftward ACROSS
+     col-a. The flyout ::before is z-index: -1 (tucked under its own button),
+     which in the shared #side-buttons stacking context also painted it under
+     col-a's buttons, clipping the label. Lift col-b into its own stacking
+     context above col-a: the flyout still paints under its own column's
+     buttons but over the neighbor column's. */
+  #side-buttons-col-b {
+    position: relative;
+    z-index: 1;
+  }
   .micro-btn {
     width: 34px;
     height: 30px;

--- a/tests/crafting_launcher.test.ts
+++ b/tests/crafting_launcher.test.ts
@@ -311,3 +311,26 @@ describe('desktop launcher behavior (jsdom)', () => {
     expect(btn.querySelector('.ui-icon')).not.toBeNull();
   });
 });
+
+describe('side rail flyout stacking (col-b hover labels over col-a)', () => {
+  // The hover flyout is a ::before at z-index: -1 so it tucks 6px under its
+  // own button. In the shared #side-buttons stacking context that also painted
+  // it under EVERY rail button, so the leftward-growing labels of col-b (the
+  // column hugging the screen edge) were clipped by col-a's buttons (v0.29.0
+  // bug: hovering the Game Menu gear showed "Game M" cut off by the Crafting
+  // tankard). Col-b must form its own stacking context above col-a: the flyout
+  // then still paints under its own column's buttons but over the neighbor's.
+  it('keeps the flyout tucked under its own button (z-index -1)', () => {
+    const flyout = /\.micro-btn::before \{([^}]*)\}/.exec(hudCss)?.[1] ?? '';
+    expect(flyout).toMatch(/z-index:\s*-1;/);
+  });
+
+  it('lifts #side-buttons-col-b into a stacking context above col-a', () => {
+    const colB = /#side-buttons-col-b \{([^}]*)\}/.exec(hudCss)?.[1] ?? '';
+    expect(colB, 'a #side-buttons-col-b rule must exist in hud.css').not.toBe('');
+    expect(colB).toMatch(/position:\s*relative;/);
+    expect(colB).toMatch(/z-index:\s*1;/);
+    // col-a must not be lifted too, or the fix cancels itself out.
+    expect(/#side-buttons-col-a \{[^}]*z-index/.test(hudCss)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
On release/v0.29.0, hovering a launcher in the desktop side rail's edge column (col-b, the one hugging the screen edge) clipped its slide-out label under the inner column's buttons: hovering the Game Menu gear showed only "Game M" cut off by the Crafting tankard.

Root cause: the hover flyout is a `.micro-btn::before` at `z-index: -1` so it tucks 6px under its own button. Since the rail was split into two columns (6ad84bc498), that negative z-index lives in the shared `#side-buttons` stacking context, so col-b's leftward-growing labels also painted under every col-a button crossing their path.

Fix: lift `#side-buttons-col-b` into its own stacking context (`position: relative; z-index: 1`). Inside that context the flyout still paints under its own column's buttons (the tuck-under design is preserved), but the whole column, flyout included, now paints over col-a.

## Test plan
- [x] New pins in `tests/crafting_launcher.test.ts` (red before the fix, green after): flyout keeps `z-index: -1`, col-b forms a stacking context, col-a is not lifted too
- [x] Verified live against the local dev stack (dev DB + server + Vite client, real login and world entry): hovering `#mm-options` (bottom of col-b) shows the full "Game Menu" label painting over col-a; `#mm-leaderboard` mid-column likewise; col-a's own `#mm-bag` flyout unaffected
- [x] `npx vitest run tests/crafting_launcher.test.ts` green (16 tests)
- [x] `npm run gate`: full suite 18322 passed; only reds are the known macOS-environmental `deploy_watchdog` pair (passes on Ubuntu CI) and a `discord_server` expectation broken by a local `.env` invite override, both unrelated and reproducible on the untouched base
- [x] `tsc --noEmit` clean, changed-files biome clean
- [x] Mobile unaffected: `body.mobile-touch #side-buttons { display: none }`