### PR TITLE
fix(auth): surface Discord desktop login failures instead of a dead button

### DIFF
--- a/src/discord_login_start.ts
+++ b/src/discord_login_start.ts
@@ -1,0 +1,42 @@
+// Decides how a "Login with Discord" click starts the OAuth flow, split out of
+// wireStartScreens() in main.ts so the entry point is unit-testable and a future
+// change cannot silently reintroduce a dead button (issue #1988).
+//
+// Three surfaces, three outcomes:
+//   - Web build: a full-page redirect to Discord (startWebOAuth), handled inside
+//     startDiscordOAuth('login') which itself branches for NATIVE_APP.
+//   - Desktop shell with the preload bridge: open the OS browser to finish OAuth.
+//     openBrowserLogin() can reject (IPC failure, browser refused to open), so we
+//     attach a catch and surface a localized error instead of a silent no-op.
+//   - Desktop shell WITHOUT the bridge (older/broken preload): an in-app redirect
+//     to discord.com is blocked by the Electron navigation guard, which looks like
+//     a dead button, so we report the error rather than attempt it.
+
+export type DiscordLoginStartOutcome = 'browser-bridge' | 'web-redirect' | 'no-bridge-error';
+
+export interface DiscordLoginStartBridge {
+  openBrowserLogin(): Promise<void>;
+}
+
+export interface DiscordLoginStartDeps {
+  desktopApp: boolean;
+  bridge: DiscordLoginStartBridge | null;
+  startWebOAuth(): void;
+  openBrowserFailed(error: unknown): void;
+  bridgeUnavailable(): void;
+}
+
+export function startDiscordLogin(deps: DiscordLoginStartDeps): DiscordLoginStartOutcome {
+  if (deps.desktopApp) {
+    if (deps.bridge) {
+      void deps.bridge.openBrowserLogin().catch((error) => {
+        deps.openBrowserFailed(error);
+      });
+      return 'browser-bridge';
+    }
+    deps.bridgeUnavailable();
+    return 'no-bridge-error';
+  }
+  deps.startWebOAuth();
+  return 'web-redirect';
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@
 // index.html and play.html both bootstrap through this module, so this one import
 // styles both game entries; admin/guide use their own entries and inline CSS.
 import './styles/index.css';
+import { startDiscordLogin } from './discord_login_start';
 import { syncAppViewport as syncAppViewportShared } from './game/app_viewport';
 import { audio } from './game/audio';
 import { AutoLoot } from './game/autoloot';
@@ -8715,12 +8716,22 @@ function wireStartScreens(): void {
       // off-origin and the navigation guard blocks it. Route it to the external browser via
       // the preload bridge; the /desktop-login page finishes OAuth and deep-links a one-time
       // code back in (onLoginCode -> completeDesktopAppLogin). The web build redirects in place.
-      const bridge = DESKTOP_APP ? desktopBridge() : null;
-      if (bridge) {
-        void bridge.openBrowserLogin();
-        return;
-      }
-      startDiscordOAuth('login');
+      // openBrowserLogin() can reject, and a desktop shell with no bridge would otherwise fall
+      // into an in-app redirect the nav guard drops, so both paths surface a localized error
+      // instead of a silent dead button (issue #1988).
+      startDiscordLogin({
+        desktopApp: DESKTOP_APP,
+        bridge: DESKTOP_APP ? desktopBridge() : null,
+        startWebOAuth: () => startDiscordOAuth('login'),
+        openBrowserFailed: (error) => {
+          console.error('[discord] could not open browser login', error);
+          flashDiscordError();
+        },
+        bridgeUnavailable: () => {
+          console.error('[discord] desktop login bridge unavailable');
+          flashDiscordError();
+        },
+      });
     });
   }
   if (discordOrDivider && NATIVE_APP && isNativeIos()) discordOrDivider.hidden = false;

--- a/tests/discord_login_start.test.ts
+++ b/tests/discord_login_start.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { startDiscordLogin } from '../src/discord_login_start';
+
+// Guards the "Login with Discord" entry point (issue #1988): every surface must
+// either start the flow or surface an error, never a silent no-op.
+describe('startDiscordLogin', () => {
+  const baseDeps = () => ({
+    startWebOAuth: vi.fn(),
+    openBrowserFailed: vi.fn(),
+    bridgeUnavailable: vi.fn(),
+  });
+
+  it('web build redirects in place via startDiscordOAuth', () => {
+    const deps = baseDeps();
+    const outcome = startDiscordLogin({ desktopApp: false, bridge: null, ...deps });
+    expect(outcome).toBe('web-redirect');
+    expect(deps.startWebOAuth).toHaveBeenCalledTimes(1);
+    expect(deps.bridgeUnavailable).not.toHaveBeenCalled();
+    expect(deps.openBrowserFailed).not.toHaveBeenCalled();
+  });
+
+  it('desktop shell opens the OS browser through the preload bridge', () => {
+    const deps = baseDeps();
+    const openBrowserLogin = vi.fn().mockResolvedValue(undefined);
+    const outcome = startDiscordLogin({
+      desktopApp: true,
+      bridge: { openBrowserLogin },
+      ...deps,
+    });
+    expect(outcome).toBe('browser-bridge');
+    expect(openBrowserLogin).toHaveBeenCalledTimes(1);
+    expect(deps.startWebOAuth).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an error when the desktop bridge rejects (no silent no-op)', async () => {
+    const deps = baseDeps();
+    const failure = new Error('browser refused');
+    const openBrowserLogin = vi.fn().mockRejectedValue(failure);
+    startDiscordLogin({ desktopApp: true, bridge: { openBrowserLogin }, ...deps });
+    // The catch runs on a microtask; flush it before asserting.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(deps.openBrowserFailed).toHaveBeenCalledTimes(1);
+    expect(deps.openBrowserFailed).toHaveBeenCalledWith(failure);
+    expect(deps.bridgeUnavailable).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an error on a desktop shell with no bridge (nav guard would eat an in-app redirect)', () => {
+    const deps = baseDeps();
+    const outcome = startDiscordLogin({ desktopApp: true, bridge: null, ...deps });
+    expect(outcome).toBe('no-bridge-error');
+    expect(deps.bridgeUnavailable).toHaveBeenCalledTimes(1);
+    // Must NOT fall through to an in-app redirect that the Electron nav guard blocks.
+    expect(deps.startWebOAuth).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

On the desktop shell, clicking **Login with Discord** could do nothing at all — no popup, no redirect, no error — which is exactly the dead-button report in #1988 (seen on Windows).

Two silent-failure paths in the `#btn-login-discord` handler in `src/main.ts`:

1. `void bridge.openBrowserLogin()` had **no `.catch`**. If the IPC call rejects or the OS browser refuses to open, the rejection is swallowed and the user sees nothing.
2. When the preload bridge is missing (older/broken shell), `desktopBridge()` returns `null`, so the handler fell through to `startDiscordOAuth('login')`, whose in-app `window.location.href = discord.com/...` redirect is **blocked by the Electron navigation guard** (`will-navigate` in `electron/main.cjs`). The blocking `preventDefault()` produces no rejection, so again nothing happens.

This PR extracts the login-start decision into a small pure module, `src/discord_login_start.ts`, and routes both desktop failure modes to the existing localized login-error path (`flashDiscordError` → `hudChrome.discord.link.error`) instead of a silent no-op. The web and native redirect paths are unchanged.

No new player-visible strings are introduced; the fix reuses the existing localized Discord error copy.

## Related issues

Closes #1988

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/discord_login_start.test.ts` — 4 passed (new regression test covering all four surfaces).
  - `npx vitest run tests/discord_login_start.test.ts tests/login_parity.test.ts tests/discord_deeplink.test.ts tests/native_discord_handler.test.ts` — 24 passed.
  - `npm run check:types` — 0 errors.
  - `npm run build` (client) — built successfully.
  - `npx biome check src/discord_login_start.ts tests/discord_login_start.test.ts` — clean.
- Manual steps: traced the two silent-failure branches against `electron/main.cjs` `will-navigate` guard and `electron/preload.cjs` `openBrowserLogin` to confirm both reproduce a no-op click on the desktop shell.

The new `startDiscordLogin` unit test pins every entry point (web redirect, desktop bridge success, desktop bridge rejection, desktop no-bridge) so a future change cannot silently reintroduce a dead button.

## Screenshots / recordings

N/A — no visual change; the only user-visible effect is that a previously silent failure now shows the existing localized login-error text.

---

## Checklist

### Quality

- [x] Added a decisive regression test for the changed behavior; recorded the commands above. (Full `npm run gate` not run end-to-end in this environment; ran its constituent typecheck, client build, biome, and the relevant test suites individually — all green.)

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (reuses the existing `hudChrome.discord.link.error` copy).

### Hygiene

- [x] No secrets or `.env` committed; no generated files hand-edited.
