### PR TITLE
fix(ui): require Shift to clear action bar slots

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -226,6 +226,10 @@ import {
 } from './frame_pos_reset';
 import { gatherDeniedLineKey, gatherDowngradeLineKey } from './gathering_view';
 import { isSelfOnlyAbility } from './hud/action_bar/ability_self_only';
+import {
+  handleShiftClearContextMenu,
+  handleShiftClearKeydown,
+} from './hud/action_bar/action_bar_clear';
 import { ActionBarController } from './hud/action_bar/action_bar_controller';
 import {
   ACTION_BAR_ABILITY_SLOTS,
@@ -5726,15 +5730,10 @@ export class Hud {
           this.hideTooltip();
         };
         btn.addEventListener('contextmenu', (e) => {
-          if (!e.shiftKey) return;
-          e.preventDefault();
-          clearSlot();
+          handleShiftClearContextMenu(e, clearSlot);
         });
         btn.addEventListener('keydown', (e) => {
-          if (!e.shiftKey || (e.key !== 'Delete' && e.key !== 'Backspace')) return;
-          e.preventDefault();
-          e.stopPropagation();
-          clearSlot();
+          handleShiftClearKeydown(e, clearSlot);
         });
         btn.addEventListener('dragstart', (e) => {
           const action = this.actionForSlot(slot);
@@ -5803,29 +5802,29 @@ export class Hud {
           this.clearActionDropTargets();
         });
         this.bindMobileActionDrag(btn, slot);
-        // right-click clears the slot so a full bar can make room for new spells
-        btn.addEventListener('contextmenu', (e) => {
-          e.preventDefault();
-          if (this.hotbarActions[slot - 1] === null) return;
-          this.hotbarActions = clearHotbarSlot(this.hotbarActions, slot - 1);
-          this.saveSlotMap();
-          this.hideTooltip();
-        });
       } else {
         // Slot 0 (Attack). Right-click removes the Attack toggle from the bar
         // (Interface option showAttackButton -> off), freeing the slot and its key
-        // for a normal action; right-click again clears whatever was dropped in.
-        // The Options toggle restores Attack at any time.
+        // for a normal action. The Options toggle restores Attack at any time.
         btn.draggable = true;
-        btn.addEventListener('contextmenu', (e) => {
-          e.preventDefault();
-          if (this.attackSlotIsAttack()) {
-            this.optionsHooks?.settings.set('showAttackButton', false);
-          } else if (this.attackSlotAction !== null) {
-            this.attackSlotAction = null;
-            this.saveAttackSlotAction();
-          }
+        const clearAttackSlotAction = () => {
+          if (this.attackSlotAction === null) return;
+          this.attackSlotAction = null;
+          this.saveAttackSlotAction();
           this.hideTooltip();
+        };
+        btn.addEventListener('contextmenu', (e) => {
+          if (this.attackSlotIsAttack()) {
+            e.preventDefault();
+            this.optionsHooks?.settings.set('showAttackButton', false);
+            this.hideTooltip();
+            return;
+          }
+          handleShiftClearContextMenu(e, clearAttackSlotAction);
+        });
+        btn.addEventListener('keydown', (e) => {
+          if (this.attackSlotIsAttack()) return;
+          handleShiftClearKeydown(e, clearAttackSlotAction);
         });
         btn.addEventListener('dragstart', (e) => {
           const action = this.actionForSlot(0);

--- a/src/ui/hud/action_bar/action_bar_clear.ts
+++ b/src/ui/hud/action_bar/action_bar_clear.ts
@@ -1,0 +1,20 @@
+type ClearContextMenuEvent = Pick<MouseEvent, 'shiftKey' | 'preventDefault'>;
+type ClearKeyEvent = Pick<KeyboardEvent, 'shiftKey' | 'key' | 'preventDefault' | 'stopPropagation'>;
+
+export function handleShiftClearContextMenu(
+  event: ClearContextMenuEvent,
+  clear: () => void,
+): boolean {
+  if (!event.shiftKey) return false;
+  event.preventDefault();
+  clear();
+  return true;
+}
+
+export function handleShiftClearKeydown(event: ClearKeyEvent, clear: () => void): boolean {
+  if (!event.shiftKey || (event.key !== 'Delete' && event.key !== 'Backspace')) return false;
+  event.preventDefault();
+  event.stopPropagation();
+  clear();
+  return true;
+}

--- a/tests/action_bar_clear.test.ts
+++ b/tests/action_bar_clear.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  handleShiftClearContextMenu,
+  handleShiftClearKeydown,
+} from '../src/ui/hud/action_bar/action_bar_clear';
+
+describe('action-bar clear gestures', () => {
+  it('leaves a slot unchanged on an ordinary right-click', () => {
+    const preventDefault = vi.fn();
+    const clear = vi.fn();
+
+    expect(handleShiftClearContextMenu({ shiftKey: false, preventDefault }, clear)).toBe(false);
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(clear).not.toHaveBeenCalled();
+  });
+
+  it('clears a slot and suppresses the menu on Shift-right-click', () => {
+    const preventDefault = vi.fn();
+    const clear = vi.fn();
+
+    expect(handleShiftClearContextMenu({ shiftKey: true, preventDefault }, clear)).toBe(true);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it.each(['Delete', 'Backspace'])('clears a slot on Shift-%s', (key) => {
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+    const clear = vi.fn();
+
+    expect(
+      handleShiftClearKeydown({ shiftKey: true, key, preventDefault, stopPropagation }, clear),
+    ).toBe(true);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(stopPropagation).toHaveBeenCalledOnce();
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it('ignores unmodified and unrelated key presses', () => {
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+    const clear = vi.fn();
+
+    expect(
+      handleShiftClearKeydown(
+        { shiftKey: false, key: 'Delete', preventDefault, stopPropagation },
+        clear,
+      ),
+    ).toBe(false);
+    expect(
+      handleShiftClearKeydown(
+        { shiftKey: true, key: 'Enter', preventDefault, stopPropagation },
+        clear,
+      ),
+    ).toBe(false);
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(stopPropagation).not.toHaveBeenCalled();
+    expect(clear).not.toHaveBeenCalled();
+  });
+});

--- a/tests/action_bar_hud_facade.test.ts
+++ b/tests/action_bar_hud_facade.test.ts
@@ -13,6 +13,31 @@ vi.mock('../src/render/characters/portrait', () => ({
 afterEach(() => vi.unstubAllGlobals());
 
 describe('Hud action-bar facade', () => {
+  it('routes both configurable slot paths through the Shift-only clear gesture', () => {
+    const source = readFileSync(new URL('../src/ui/hud.ts', import.meta.url), 'utf8');
+    const buildStart = source.indexOf('private buildActionBar(): void');
+    const configurableStart = source.indexOf('if (slot >= 1) {', buildStart);
+    const attackSlotStart = source.indexOf('// Slot 0 (Attack).', configurableStart);
+    const configurableSlots = source.slice(configurableStart, attackSlotStart);
+
+    expect(configurableSlots.match(/btn\.addEventListener\('contextmenu'/g)).toHaveLength(1);
+    expect(configurableSlots).toContain('handleShiftClearContextMenu(e, clearSlot)');
+    expect(configurableSlots).toContain(
+      'this.hotbarActions = clearHotbarSlot(this.hotbarActions, slot - 1);',
+    );
+    expect(configurableSlots).toContain('this.saveSlotMap();');
+
+    const actionBarBuild = source.slice(
+      buildStart,
+      source.indexOf('private buildCastBar()', buildStart),
+    );
+    expect(actionBarBuild.match(/handleShiftClearContextMenu\(/g)).toHaveLength(2);
+    expect(actionBarBuild.match(/handleShiftClearKeydown\(/g)).toHaveLength(2);
+    expect(actionBarBuild).toContain('handleShiftClearContextMenu(e, clearAttackSlotAction);');
+    expect(actionBarBuild).toContain('this.attackSlotAction = null;');
+    expect(actionBarBuild).toContain('this.saveAttackSlotAction();');
+  });
+
   it('checks drag eligibility before normal-bar and configurable slot 0 drops', () => {
     const source = readFileSync(new URL('../src/ui/hud.ts', import.meta.url), 'utf8');
     expect(source.match(/actionBarController\.isAssignableAction\(/g)).toHaveLength(4);


### PR DESCRIPTION
Remove the duplicate unmodified context-menu handler that cleared configured slots on an ordinary right-click. Apply the same guarded gesture to the configurable first slot and add regression coverage.

<!--
Thanks for contributing to World of ClaudeCraft!

New here? The contributing guide is available in your language:
https://github.com/levy-street/world-of-claudecraft/blob/main/CONTRIBUTING.md

Filling this out helps reviewers understand and merge your work faster. Anything
that doesn't apply to your change, feel free to delete or mark as N/A.
-->

## Summary

<!-- What does this PR change, and why? Link the motivation or design if there is one. -->

## Related issues

<!-- e.g. "Closes #123" or "Part of #456". Remove this section if it doesn't apply. -->

## Type of change

<!-- Check all that apply. -->

- [ ] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

<!-- The commands you ran and the manual steps you walked through. Be specific. -->

- Commands:
- Manual steps:

## Screenshots / recordings

<!--
If this PR changes anything a player or operator sees (HUD, windows, tooltips,
mobile controls, admin dashboard), please add before/after screenshots or a
short clip, on desktop and mobile where relevant. Remove this section for non-UI
changes.
-->

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [ ] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings follow the contributor policy.** Every user-facing
      string is a `t()` key added to the matching English catalog. I did not edit locale
      overlays, except for the five required non-Latin fills when the M16 wordy-copy
      rule applies (see `src/ui/CLAUDE.md`).
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [ ] N/A. This PR adds no player-visible strings.

### Hygiene

- [ ] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [ ] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

> Commit messages and PR titles use [Conventional Commits](https://www.conventionalcommits.org/)
> with a required scope (`feat(talents): ...`, `fix(net): ...`).

---

A complete checklist and a green CI run (tests, typecheck, and builds) are what
we look for before merging. Smaller, focused PRs land faster than large ones, and
reviewers may suggest changes, which is a normal and friendly part of the
process. Thank you for helping build World of ClaudeCraft. Questions? Join us on
[Discord](https://discord.com/invite/worldofclaudecraft).
