### PR TITLE
fix(sound): fix cracking sound when entering the world on Android

### DIFF
--- a/src/game/landing_theme.ts
+++ b/src/game/landing_theme.ts
@@ -1,0 +1,76 @@
+// Routes the landing-page theme element through a dedicated AudioContext.
+//
+// Why: on Android (reported on a Pixel 9a, Chrome), opening the FIRST WebAudio
+// output stream while an HTMLAudioElement is already playing as a bare media
+// stream forces an audio-output reconfiguration that emits a loud crack in the
+// in-flight playback. The game opens its sfx/music AudioContexts at world entry,
+// exactly while the landing theme is still playing, so entering the world
+// cracked audibly. Verified on-device: a context opened during bare-media
+// playback cracks; any later context, or a context opened first, is clean.
+// Routing the theme through WebAudio from the start means the low-latency
+// output path opens WITH the theme, so the world-entry inits land in the
+// already-clean "additional context" case.
+//
+// The element keeps owning volume/mute/pause (the fade-out and the mute toggle
+// in main.ts are untouched); this module only provides the graph routing and
+// the "play only once the routed context is running" gate. When WebAudio is
+// unavailable or wiring throws, prepare() resolves anyway and the caller's
+// plain element playback proceeds exactly as before.
+
+interface MediaSourceLike {
+  connect(node: unknown): unknown;
+}
+
+export interface ThemeAudioContextLike {
+  readonly destination: unknown;
+  resume(): Promise<void>;
+  createMediaElementSource(el: HTMLAudioElement): MediaSourceLike;
+}
+
+export interface LandingThemeAudio {
+  /** Wire the element into the dedicated context (first call only), then
+   *  resolve once that context is running, so the caller may start playback.
+   *  Resolves immediately when WebAudio is unavailable (plain playback).
+   *  Rejects only when the routed context cannot start yet (autoplay still
+   *  blocked); the caller's existing gesture retry handles that. */
+  prepare(el: HTMLAudioElement): Promise<void>;
+}
+
+function defaultContextFactory(): ThemeAudioContextLike {
+  return new AudioContext();
+}
+
+export function createLandingThemeAudio(
+  makeContext: () => ThemeAudioContextLike = defaultContextFactory,
+): LandingThemeAudio {
+  let ctx: ThemeAudioContextLike | null = null;
+  let unavailable = false;
+  let wiredEl: HTMLAudioElement | null = null;
+  return {
+    prepare(el: HTMLAudioElement): Promise<void> {
+      if (unavailable) return Promise.resolve();
+      if (!ctx) {
+        try {
+          ctx = makeContext();
+        } catch {
+          unavailable = true;
+          return Promise.resolve();
+        }
+      }
+      if (wiredEl !== el) {
+        try {
+          ctx.createMediaElementSource(el).connect(ctx.destination);
+          wiredEl = el;
+        } catch {
+          // Wiring failed (already-wired element, stubbed context, ...): leave
+          // the element on plain playback. The context, if it opened, opened
+          // BEFORE the element plays, which is the clean ordering anyway.
+        }
+      }
+      // Routed (or plain with a live context): wait for running so routed
+      // playback is never swallowed by a suspended graph. A rejection keeps
+      // the caller's gesture retry armed.
+      return ctx.resume();
+    },
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,7 @@ import { Keybinds } from './game/keybinds';
 import { newKeyboardTurnState, stepKeyboardTurnFacing } from './game/keyboard_turn_facing';
 import { applyMobileKeyboardViewport } from './game/keyboard_viewport_applier';
 import { shouldUseStaticBackdrop } from './game/landing_backdrop';
+import { createLandingThemeAudio } from './game/landing_theme';
 import {
   interfaceModeFromSetting,
   isPhoneTouchDevice,
@@ -348,6 +349,7 @@ let homepageMusic: HTMLAudioElement | null = null;
 let homepageMusicStarted = false;
 let homepageMusicMuted = readHomepageMusicMuted();
 let removeHomepageMusicGestureListeners: (() => void) | null = null;
+const landingThemeAudio = createLandingThemeAudio();
 
 function isNativeRuntime(): boolean {
   if (NATIVE_APP) return true;
@@ -5856,8 +5858,12 @@ function syncHomepageMusicToggle(): void {
 function playHomepageMusic(): void {
   const el = homepageMusic;
   if (!el || homepageMusicMuted || homepageMusicStarted) return;
-  void el
-    .play()
+  // Route the theme through its dedicated AudioContext BEFORE it plays: a bare
+  // media stream playing when the world-entry inits open the first game
+  // AudioContext cracks audibly on Android (see src/game/landing_theme.ts).
+  void landingThemeAudio
+    .prepare(el)
+    .then(() => el.play())
     .then(() => {
       homepageMusicStarted = true;
       removeHomepageMusicGestureListeners?.();

--- a/tests/landing_theme.test.ts
+++ b/tests/landing_theme.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { createLandingThemeAudio, type ThemeAudioContextLike } from '../src/game/landing_theme';
+
+interface FakeContextOptions {
+  resume?: () => Promise<void>;
+  wireThrows?: boolean;
+}
+
+function makeFakeContext(opts: FakeContextOptions = {}) {
+  const connected: unknown[] = [];
+  const wired: HTMLAudioElement[] = [];
+  const ctx: ThemeAudioContextLike = {
+    destination: { id: 'destination' },
+    resume: opts.resume ?? (() => Promise.resolve()),
+    createMediaElementSource(el: HTMLAudioElement) {
+      if (opts.wireThrows) throw new Error('already wired');
+      wired.push(el);
+      return {
+        connect(node: unknown) {
+          connected.push(node);
+          return node;
+        },
+      };
+    },
+  };
+  return { ctx, connected, wired };
+}
+
+const el = () => ({ tag: 'audio' }) as unknown as HTMLAudioElement;
+
+describe('landing theme WebAudio routing', () => {
+  it('creates one context and wires the element into it exactly once', async () => {
+    const fake = makeFakeContext();
+    let created = 0;
+    const theme = createLandingThemeAudio(() => {
+      created++;
+      return fake.ctx;
+    });
+    const element = el();
+    await theme.prepare(element);
+    await theme.prepare(element);
+    expect(created).toBe(1);
+    expect(fake.wired).toEqual([element]);
+    expect(fake.connected).toEqual([fake.ctx.destination]);
+  });
+
+  it('resolves only after the routed context resumes, so playback is never routed into a suspended graph', async () => {
+    let release: () => void = () => {};
+    const fake = makeFakeContext({
+      resume: () => new Promise<void>((resolve) => (release = resolve)),
+    });
+    const theme = createLandingThemeAudio(() => fake.ctx);
+    let ready = false;
+    const pending = theme.prepare(el()).then(() => (ready = true));
+    await Promise.resolve();
+    expect(ready).toBe(false);
+    release();
+    await pending;
+    expect(ready).toBe(true);
+  });
+
+  it('rejects while autoplay still blocks the context, keeping the caller gesture retry armed', async () => {
+    let calls = 0;
+    const fake = makeFakeContext({
+      resume: () => {
+        calls++;
+        return calls === 1 ? Promise.reject(new Error('blocked')) : Promise.resolve();
+      },
+    });
+    const theme = createLandingThemeAudio(() => fake.ctx);
+    const element = el();
+    await expect(theme.prepare(element)).rejects.toThrow('blocked');
+    await expect(theme.prepare(element)).resolves.toBeUndefined();
+    expect(fake.wired).toEqual([element]); // wired once, not re-wired by the retry
+  });
+
+  it('falls back to plain playback when the context factory throws (Node, stubbed browsers)', async () => {
+    let created = 0;
+    const theme = createLandingThemeAudio(() => {
+      created++;
+      throw new Error('no AudioContext');
+    });
+    await expect(theme.prepare(el())).resolves.toBeUndefined();
+    await expect(theme.prepare(el())).resolves.toBeUndefined();
+    expect(created).toBe(1); // failure latches; no per-gesture creation storm
+  });
+
+  it('still resolves via resume when element wiring throws, leaving plain playback intact', async () => {
+    const fake = makeFakeContext({ wireThrows: true });
+    const theme = createLandingThemeAudio(() => fake.ctx);
+    await expect(theme.prepare(el())).resolves.toBeUndefined();
+    expect(fake.wired).toEqual([]);
+  });
+
+  it('imports cleanly and defaults without touching AudioContext until prepare()', () => {
+    // Constructing with the default factory must not throw under plain Node
+    // (no AudioContext global); creation is deferred to the first prepare().
+    expect(() => createLandingThemeAudio()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Entering the world on Android (reported on a Pixel 9a, Chrome) played a loud crack. The crack always landed exactly at the audio init moment: right after the landscape preflight in the online flow, and right before it in the offline flow, which is precisely where the two flows differ in when they run `audio.init(); music.init(); sfx.init()`.

Root cause, isolated with an on-device probe page: the landing-page theme is a bare `HTMLAudioElement` media stream that is still playing when world entry opens the game's first WebAudio `AudioContext`s. On Android, opening the first low-latency WebAudio output stream while a bare media stream is playing forces an audio-output reconfiguration that audibly cracks the in-flight playback. The probe confirmed the exact boundary: a context opened during bare-media playback cracks; a context opened before the media starts, or any additional context after the first, is clean.

Fix: route the landing theme through its own dedicated `AudioContext` from the first play (the same `createMediaElementSource` pattern `src/game/music.ts` already uses for the zone/combat streams). The low-latency output path then opens together with the theme, so the world-entry inits land in the verified-clean "additional context" case and nothing is left on the bare media path to glitch.

- New `src/game/landing_theme.ts`: `createLandingThemeAudio()` factory. `prepare(el)` lazily creates the dedicated context and wires the element exactly once, resolves only when the context is running (so playback is never swallowed by a suspended graph), rejects while autoplay still blocks (the existing gesture retry stays armed), and falls back to plain element playback when WebAudio is unavailable.
- `src/main.ts`: `playHomepageMusic()` now awaits `prepare(el)` before `el.play()`. The fade-out at game start and the mute toggle are untouched.
- New `tests/landing_theme.test.ts`: 6 unit tests over the factory (wire-once, resume gating, autoplay-blocked retry, factory-throw and wire-throw fallbacks, clean import under plain Node).

## Related issues

N/A (reported directly by a player on device; no existing upstream issue found for this symptom).

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run gate` (full CI-equivalent gate) green.
  - `npx vitest run tests/landing_theme.test.ts tests/game_audio.test.ts tests/music_tracks.test.ts tests/architecture.test.ts` green (46 tests).
  - `npx tsc --noEmit` clean; `npx @biomejs/biome check` clean on the touched files.
- Manual steps:
  - Reproduced the original bug on a Pixel 9a (Chrome): loud crack at world entry, before the landscape prompt offline and after it online, matching the differing init order of the two flows.
  - Isolated the mechanism with a temporary on-device probe page: opening one `AudioContext` while a bare media element plays cracks; a second context, or contexts opened before the media, do not. The probe also validated the fix shape (theme routed through a context, then full game init on top: no crack).
  - Verified the fixed build on the same Pixel 9a end to end: character select with theme playing, Enter World, landscape prompt: no crack, in-game audio correct.
  - Desktop browser run with a WebAudio output tap (sample-level discontinuity detector): theme routes through its dedicated context (`createMediaElementSource` wired once), still plays and fades out once in-game, mute toggle works, game sfx/music contexts carry signal with zero discontinuities.

## Screenshots / recordings

N/A (audio-only change, no visual surface).

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [x] **Tested on desktop and mobile.** Verified on desktop (Chrome, instrumented run) and on a real Pixel 9a in portrait and landscape across the world-entry flow. No touch-target or input changes.
- [ ] ~Accessible.~ N/A: no UI added or edited.

### Localization (i18n)

- [ ] ~New player-visible strings follow the contributor policy.~
- [ ] ~Numbers, money, dates, units, and percents go through the i18n formatters.~
- [ ] ~Player-facing text emitted from `src/sim/` or `server/` is re-localized at the client boundary.~
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
