### PR TITLE
fix(game): corpse picker honors loot rights so a stranger's kill cannot shadow a node

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -41,6 +41,7 @@ import {
   jailGateTeleport,
 } from '../src/sim/jail';
 import type { PickAction } from '../src/sim/lockpick';
+import { lootHasGoneFfa } from '../src/sim/loot/loot_ffa';
 import { sanitizeMarketQuery } from '../src/sim/market_query';
 import { parseMoveInputFrame } from '../src/sim/move_input';
 import {
@@ -1034,6 +1035,11 @@ function dynamicFields(e: Entity, includeAuras = true): Record<string, unknown> 
   // corpse harvest claim (single-use, first-come): the online corpse picker
   // must stop offering a corpse another player already harvested
   if (e.harvestClaimedBy !== null) out.hcb = e.harvestClaimedBy;
+  // loot owner-lock lapse (FFA): the online corpse picker must offer a
+  // stranger's aged-out corpse again for a deliberate manual loot, the same
+  // reliability contract hcb gives harvest claims. Flips once per corpse, so
+  // the per-entity dyn cache re-serializes exactly one changed record.
+  if (e.kind === 'mob' && e.lootable && lootHasGoneFfa(e.lootFfaTimer)) out.ffa = 1;
   if (e.ownerId !== null) out.own = e.ownerId;
   if (e.overheadEmoteId) {
     out.emo = e.overheadEmoteId;

--- a/src/game/corpse_loot_availability.ts
+++ b/src/game/corpse_loot_availability.ts
@@ -1,27 +1,75 @@
 import { MOBS } from '../sim/data';
+import { hasSharedLootRights, lootHasGoneFfa } from '../sim/loot/loot_ffa';
 import type { Entity } from '../sim/types';
 
 /** Resolve the exact corpse content the local player can open in the loot popup.
+ *  Answers "may I OPEN this corpse", not "does it have contents": the arms
+ *  mirror the sim's authoritative corpseLootRights + lootCorpse loop
+ *  (src/sim/interaction.ts) via the sim's own pure predicates, so a stranger's
+ *  owner-locked kill no longer captures the interact press (and its denial
+ *  toast) away from whatever sits under it.
  *  `harvestStateReliable` is true on every production path (no caller passes
  *  it: offline is sim-local truth, online
  *  mirrors harvestClaimedBy via the hcb wire key). The parameter is a
  *  deliberately retained seam for a transport that cannot mirror harvest
  *  claims; its false arm stays pinned in tests/corpse_loot_availability.test.ts
  *  and tests/interactions.test.ts (positional third argument), so do not
- *  remove it as dead plumbing without sweeping those pins. */
-export function corpseLootAvailability(mob: Entity, playerId: number, harvestStateReliable = true) {
+ *  remove it as dead plumbing without sweeping those pins.
+ *  `partyMemberIds` is the LOCAL player's party roster (pids, self included;
+ *  null when solo): party membership is symmetric, so it stands in for the
+ *  tapper's party exactly when that grants anything (the tapper being in MY
+ *  party). Offline entities carry the real tappedById / lootFfaTimer and the
+ *  roster is the bot party; online both ride the wire (tap, ffa keys), so the
+ *  same code serves both hosts unchanged. */
+export function corpseLootAvailability(
+  mob: Entity,
+  playerId: number,
+  harvestStateReliable = true,
+  partyMemberIds: readonly number[] | null = null,
+) {
   const componentTags = MOBS[mob.templateId]?.componentTags;
   const harvestable =
     harvestStateReliable && !!componentTags?.length && mob.harvestClaimedBy === null;
+  const tappedById = mob.tappedById ?? null;
+  const tapperParty =
+    tappedById !== null && partyMemberIds?.includes(tappedById) ? partyMemberIds : null;
+  const sharedRights = hasSharedLootRights(
+    playerId,
+    tappedById,
+    tapperParty,
+    lootHasGoneFfa(mob.lootFfaTimer ?? Number.POSITIVE_INFINITY),
+  );
+  // Exactly what THIS viewer could take, the three arms of the sim's lootCorpse
+  // loop: personal slots naming me, open-to-all slots, and plain (tap-owned)
+  // slots only with shared rights.
   const visibleItems = mob.loot
-    ? mob.loot.items.filter((slot) => !slot.personalFor || slot.personalFor.includes(playerId))
+    ? mob.loot.items.filter((slot) =>
+        slot.personalFor
+          ? slot.personalFor.includes(playerId)
+          : slot.openToAll
+            ? slot.count > 0
+            : sharedRights && slot.count > 0,
+      )
     : [];
-  const hasLoot = !!mob.loot && (mob.loot.copper > 0 || visibleItems.length > 0);
+  // Copper is part of the shared (tap-owned) pool: without shared rights the
+  // popup must not advertise it.
+  const visibleCopper = sharedRights && mob.loot ? mob.loot.copper : 0;
+  const hasLoot = !!mob.loot && (visibleCopper > 0 || visibleItems.length > 0);
   return {
     componentTags,
     harvestable,
     visibleItems,
+    visibleCopper,
     hasLoot,
     canOpen: hasLoot || harvestable,
   };
+}
+
+/** The local party roster in the shape `corpseLootAvailability` consumes (pids,
+ *  self included; null when solo). Structural parameter so both hosts' partyInfo
+ *  (IWorldParty) satisfy it without a world_api import here. */
+export function localPartyMemberIds(
+  partyInfo: { members: readonly { pid: number }[] } | null | undefined,
+): number[] | null {
+  return partyInfo ? partyInfo.members.map((m) => m.pid) : null;
 }

--- a/src/game/interactions.ts
+++ b/src/game/interactions.ts
@@ -2,7 +2,7 @@ import { dist2d, type Entity, INTERACT_RANGE } from '../sim/types';
 import { t } from '../ui/i18n';
 import { tSim } from '../ui/sim_i18n';
 import type { IWorld } from '../world_api';
-import { corpseLootAvailability } from './corpse_loot_availability';
+import { corpseLootAvailability, localPartyMemberIds } from './corpse_loot_availability';
 import type { HoverCursorKind } from './cursors';
 import type { InteractionOutcome } from './interaction_autorun';
 
@@ -12,6 +12,9 @@ export interface PickInteractionWorld {
   entities: IWorld['entities'];
   duelInfo?: IWorld['duelInfo'];
   arenaInfo?: IWorld['arenaInfo'];
+  // Local party roster for the corpse rights check; optional so party-less
+  // fixtures stay valid.
+  partyInfo?: IWorld['partyInfo'];
   targetEntity(id: number | null): void;
   enterDungeon(dungeonId: string): InteractionOutcome;
   leaveDungeon(): InteractionOutcome;
@@ -119,6 +122,7 @@ export function shouldApproachPickedEntity(
   entity: Entity,
   didInteract: boolean,
   harvestStateReliable = true,
+  partyMemberIds: readonly number[] | null = null,
 ): boolean {
   if (didInteract || player.dead || entity.id === player.id) return false;
   const d = dist2d(player.pos, entity.pos);
@@ -127,7 +131,7 @@ export function shouldApproachPickedEntity(
       entity.kind === 'mob' &&
       entity.lootable &&
       d > INTERACT_RANGE + 1 &&
-      corpseLootAvailability(entity, player.id, harvestStateReliable).canOpen
+      corpseLootAvailability(entity, player.id, harvestStateReliable, partyMemberIds).canOpen
     );
   }
   if (entity.kind === 'object') return d > INTERACT_RANGE;
@@ -177,8 +181,12 @@ export function handlePickedEntity(
       }
       if (d <= INTERACT_RANGE + 1) {
         if (
-          !corpseLootAvailability(e, world.playerId ?? world.player.id, harvestStateReliable)
-            .canOpen
+          !corpseLootAvailability(
+            e,
+            world.playerId ?? world.player.id,
+            harvestStateReliable,
+            localPartyMemberIds(world.partyInfo),
+          ).canOpen
         )
           return false;
         hud.openLoot(id, screenX, screenY);
@@ -247,8 +255,12 @@ export function handlePickedEntity(
       const d = dist2d(world.player.pos, e.pos);
       if (d <= INTERACT_RANGE + 1) {
         if (
-          !corpseLootAvailability(e, world.playerId ?? world.player.id, harvestStateReliable)
-            .canOpen
+          !corpseLootAvailability(
+            e,
+            world.playerId ?? world.player.id,
+            harvestStateReliable,
+            localPartyMemberIds(world.partyInfo),
+          ).canOpen
         )
           return false;
         hud.openLoot(id, screenX, screenY);

--- a/src/game/nearby_interaction.ts
+++ b/src/game/nearby_interaction.ts
@@ -1,11 +1,14 @@
 import { dist2d, type Entity, type GatherNodeDef, INTERACT_RANGE } from '../sim/types';
-import { corpseLootAvailability } from './corpse_loot_availability';
+import { corpseLootAvailability, localPartyMemberIds } from './corpse_loot_availability';
 import { type GatherNodeToolGate, handleGatherNodeInteract } from './gather_node_interact';
 import type { InteractionOutcome } from './interaction_autorun';
 
 export interface NearbyInteractionWorld {
   player: Entity;
   playerId?: number;
+  // Local party roster for the corpse rights check (IWorld.partyInfo satisfies
+  // this structurally); optional so party-less fixtures stay valid.
+  partyInfo?: { members: readonly { pid: number }[] } | null;
   entities: ReadonlyMap<number, Entity>;
   lootCorpse(id: number): InteractionOutcome;
   // Fire-and-forget half of the unified corpse press; omitting the
@@ -47,6 +50,7 @@ export function tryNearbyInteraction(
 ): InteractionOutcome {
   const player = world.player;
   const playerId = world.playerId ?? player.id;
+  const partyIds = localPartyMemberIds(world.partyInfo);
   let bestCorpse: number | null = null;
   let bestCorpseDistance = INTERACT_RANGE;
   let bestObject: number | null = null;
@@ -79,7 +83,7 @@ export function tryNearbyInteraction(
       entity.kind === 'mob' &&
       entity.dead &&
       entity.lootable &&
-      corpseLootAvailability(entity, playerId, harvestStateReliable).canOpen &&
+      corpseLootAvailability(entity, playerId, harvestStateReliable, partyIds).canOpen &&
       distance < bestCorpseDistance
     ) {
       bestCorpse = entity.id;
@@ -114,7 +118,7 @@ export function tryNearbyInteraction(
     // Each half is gated on the availability predicate so a claimed or
     // emptied half is never dispatched (no denial-toast spam); the server
     // still revalidates both authoritatively.
-    const availability = corpseLootAvailability(corpse, playerId, harvestStateReliable);
+    const availability = corpseLootAvailability(corpse, playerId, harvestStateReliable, partyIds);
     if (availability.harvestable) world.harvestCorpse(bestCorpse);
     if (availability.hasLoot) return world.lootCorpse(bestCorpse);
     return availability.harvestable;

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ import {
 } from './game/click_move';
 import { clientEnvBits, installPageStateTracking, pageStateBits } from './game/client_env';
 import { getClientSeed } from './game/client_seed';
+import { localPartyMemberIds } from './game/corpse_loot_availability';
 import { shouldClearAutorunOnDeath } from './game/death_input_reset';
 import { initDesktopDownload } from './game/desktop_download';
 import { initDesktopShellIntegration } from './game/desktop_shell_integration';
@@ -2615,7 +2616,13 @@ async function startGame(
       // regular click handler still performs target/interact behavior.
       if (
         isClickMoveButton &&
-        shouldApproachPickedEntity(world.player, e, didInteractImmediately)
+        shouldApproachPickedEntity(
+          world.player,
+          e,
+          didInteractImmediately,
+          true,
+          localPartyMemberIds(world.partyInfo),
+        )
       ) {
         const target = resolvedClickMoveTarget({ x: e.pos.x, z: e.pos.z });
         input.setClickMoveTarget(target, 3.5, e.id, clickMovePathTo(target));

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -2432,6 +2432,12 @@ export class ClientWorld implements IWorld {
       // corpse harvest claim: unconditional so a record without hcb (unclaimed,
       // or a respawn that cleared the claim) resets any stale mirrored pid
       e.harvestClaimedBy = typeof w.hcb === 'number' ? w.hcb : null;
+      // loot owner-lock lapse: flag present means lapsed (mirror as already
+      // counted down), absent means the lock still holds or never started;
+      // unconditional so a respawned record resets any stale lapse (same
+      // contract as hcb above). The server owns the countdown; the client only
+      // ever needs the boolean.
+      e.lootFfaTimer = w.ffa ? 0 : Infinity;
       e.ownerId = w.own ?? null;
       e.petMode = w.pm ?? 'defensive';
       e.petTauntTimer = w.pt ?? 0;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1,5 +1,5 @@
 import { audio } from '../game/audio';
-import { corpseLootAvailability } from '../game/corpse_loot_availability';
+import { corpseLootAvailability, localPartyMemberIds } from '../game/corpse_loot_availability';
 import type { GamepadKind } from '../game/gamepad_map';
 import { InstanceMusicController } from '../game/instance_music';
 import { type Keybinds, keyCapLabel } from '../game/keybinds';
@@ -1608,7 +1608,13 @@ export class Hud {
       element: $('#loot-window'),
       document,
       world: () => this.sim,
-      corpseAvailability: (mob) => corpseLootAvailability(mob, this.sim.playerId),
+      corpseAvailability: (mob) =>
+        corpseLootAvailability(
+          mob,
+          this.sim.playerId,
+          true,
+          localPartyMemberIds(this.sim.partyInfo),
+        ),
       closeTransient: () => this.closeOtherWindows('#loot-window'),
       hideTooltip: () => this.hideTooltip(),
       entityName: entityDisplayName,

--- a/src/ui/hud/loot/loot_window_controller.ts
+++ b/src/ui/hud/loot/loot_window_controller.ts
@@ -54,7 +54,7 @@ export class LootWindowController {
     const world = this.deps.world();
     const mob = world.entities.get(mobId);
     if (!mob) return;
-    const { componentTags, harvestable, visibleItems, hasLoot, canOpen } =
+    const { componentTags, harvestable, visibleItems, visibleCopper, hasLoot, canOpen } =
       this.deps.corpseAvailability(mob);
     if (!canOpen) return;
 
@@ -62,8 +62,10 @@ export class LootWindowController {
     this.mobId = mobId;
     this.chestId = null;
     let html = this.titleHtml(this.deps.entityName(mob));
-    if (mob.loot && mob.loot.copper > 0) {
-      html += `<div class="loot-item"><img class="item-icon q-common" src="${this.deps.coinIconUrl()}" alt="" draggable="false"><span>${this.deps.money(mob.loot.copper)}</span></div>`;
+    // visibleCopper, not mob.loot.copper: coin is shared (tap-owned) loot, so
+    // the popup must not advertise a stranger's copper the take would deny.
+    if (visibleCopper > 0) {
+      html += `<div class="loot-item"><img class="item-icon q-common" src="${this.deps.coinIconUrl()}" alt="" draggable="false"><span>${this.deps.money(visibleCopper)}</span></div>`;
     }
     html += visibleItems.map((stack) => this.itemRowHtml(stack)).join('');
     this.deps.element.innerHTML = html;

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -2033,7 +2033,7 @@ describe('client HTML shell', () => {
     expect(mainTs).not.toContain('online === null');
     expect(mainTs).toContain('const interactionOutcome = handlePickedEntity(');
     expect(mainTs).toContain(
-      'isClickMoveButton &&\n        shouldApproachPickedEntity(world.player, e, didInteractImmediately)',
+      'isClickMoveButton &&\n        shouldApproachPickedEntity(\n          world.player,\n          e,\n          didInteractImmediately,\n          true,\n          localPartyMemberIds(world.partyInfo),\n        )',
     );
     expect(mainTs).toContain(
       'stopAutorunForInteraction(interactionOutcome, input, mobileControls);',

--- a/tests/corpse_harvest_sim.test.ts
+++ b/tests/corpse_harvest_sim.test.ts
@@ -1122,6 +1122,40 @@ describe('corpse harvest claim over the live broadcast (delta + interest scope)'
     expect(cleared.harvestClaimedBy).toBeNull();
     expect(corpseLootAvailability(cleared, sb.pid).harvestable).toBe(true);
   });
+
+  it('an owner-lock lapse after first sight rides a lite delta record and reopens the picker', () => {
+    // The `ffa` key flips once per corpse INSIDE dynamicFields, the same
+    // cached-record path as hcb, so the flip must invalidate the per-entity
+    // dyn cache and reach a viewer who already saw the locked corpse.
+    const { server, fcB, sa, sb, mob } = liveSetup();
+    mob.lootable = true;
+    mob.tappedById = sa.pid;
+    mob.harvestClaimedBy = sa.pid; // harvest arm closed: canOpen isolates loot rights
+    mob.lootFfaTimer = 60;
+    mob.loot = { copper: 10, items: [{ itemId: 'wolf_fang', count: 1 }] };
+
+    broadcast(server);
+    const client = bareClient(sb.pid);
+    (client as any).applySnapshot(lastSnap(fcB.sent));
+    const locked = client.entities.get(mob.id)!;
+    expect(locked.lootFfaTimer).toBe(Infinity);
+    expect(corpseLootAvailability(locked, sb.pid).canOpen).toBe(false);
+
+    // The lock lapses AFTER Bravo has seen the corpse: the next broadcast must
+    // carry ffa:1 as a dyn-only lite record (identity already sent).
+    mob.lootFfaTimer = 0;
+    server.sim.tick();
+    broadcast(server);
+    const snap = lastSnap(fcB.sent);
+    const rec = snap.ents.find((e: any) => e.id === mob.id);
+    expect(rec.ffa).toBe(1);
+    expect(rec).not.toHaveProperty('nm'); // lite record: no identity resend
+
+    (client as any).applySnapshot(snap);
+    const lapsed = client.entities.get(mob.id)!;
+    expect(corpseLootAvailability(lapsed, sb.pid).canOpen).toBe(true);
+    expect(corpseLootAvailability(lapsed, sb.pid).hasLoot).toBe(true);
+  });
 });
 
 // The omitted-components town-focus default depends on an ABSENT

--- a/tests/corpse_loot_availability.test.ts
+++ b/tests/corpse_loot_availability.test.ts
@@ -102,3 +102,92 @@ describe('corpseLootAvailability', () => {
     expect(result.canOpen).toBe(false);
   });
 });
+
+// Loot RIGHTS, not just loot existence: the arms mirror the sim's
+// corpseLootRights + lootCorpse loop (src/sim/interaction.ts). ME = 1 views;
+// STRANGER = 9 tapped. `harvestClaimedBy: 9` keeps the harvest arm closed so
+// each case isolates the loot half; the harvest+loot split case is at the end.
+describe('corpseLootAvailability loot rights matrix', () => {
+  const ME = 1;
+  const STRANGER = 9;
+  const FRESH = 60; // owner-lock still counting
+  const LAPSED = 0; // owner-lock lapsed: loot has gone FFA
+
+  const tapped = (overrides: Partial<Entity>) =>
+    corpse({ harvestClaimedBy: STRANGER, tappedById: STRANGER, lootFfaTimer: FRESH, ...overrides });
+  const plainLoot = () => ({ copper: 0, items: [{ itemId: 'wolf_fang', count: 1 }] });
+
+  it('my own tap opens', () => {
+    const result = corpseLootAvailability(tapped({ tappedById: ME, loot: plainLoot() }), ME);
+    expect(result.hasLoot).toBe(true);
+    expect(result.canOpen).toBe(true);
+    expect(result.visibleItems).toHaveLength(1);
+  });
+
+  it("the tapper being in my party opens (my roster stands in for the tapper's)", () => {
+    const result = corpseLootAvailability(tapped({ loot: plainLoot() }), ME, true, [ME, STRANGER]);
+    expect(result.hasLoot).toBe(true);
+    expect(result.canOpen).toBe(true);
+  });
+
+  it('a fresh stranger tap is CLOSED: loot exists but I have no rights', () => {
+    const result = corpseLootAvailability(tapped({ loot: plainLoot() }), ME);
+    expect(result.hasLoot).toBe(false);
+    expect(result.visibleItems).toEqual([]);
+    expect(result.canOpen).toBe(false);
+  });
+
+  it('a stranger tap OPENS once the owner-lock lapses (FFA)', () => {
+    const result = corpseLootAvailability(tapped({ lootFfaTimer: LAPSED, loot: plainLoot() }), ME);
+    expect(result.hasLoot).toBe(true);
+    expect(result.canOpen).toBe(true);
+  });
+
+  it('a personal slot naming me opens a fresh stranger tap (personal arm ignores the lock)', () => {
+    const result = corpseLootAvailability(
+      tapped({
+        loot: { copper: 0, items: [{ itemId: 'wolf_fang', count: 1, personalFor: [ME] }] },
+      }),
+      ME,
+    );
+    expect(result.hasLoot).toBe(true);
+    expect(result.canOpen).toBe(true);
+    expect(result.visibleItems).toHaveLength(1);
+  });
+
+  it('an open-to-all slot opens a fresh stranger tap (passed-roll arm ignores the lock)', () => {
+    const result = corpseLootAvailability(
+      tapped({
+        loot: { copper: 0, items: [{ itemId: 'wolf_fang', count: 1, openToAll: true }] },
+      }),
+      ME,
+    );
+    expect(result.hasLoot).toBe(true);
+    expect(result.canOpen).toBe(true);
+  });
+
+  it('copper-only stranger corpse: closed fresh, open after the lapse, coin hidden while denied', () => {
+    const fresh = corpseLootAvailability(tapped({ loot: { copper: 25, items: [] } }), ME);
+    expect(fresh.hasLoot).toBe(false);
+    expect(fresh.visibleCopper).toBe(0);
+    expect(fresh.canOpen).toBe(false);
+
+    const lapsed = corpseLootAvailability(
+      tapped({ lootFfaTimer: LAPSED, loot: { copper: 25, items: [] } }),
+      ME,
+    );
+    expect(lapsed.hasLoot).toBe(true);
+    expect(lapsed.visibleCopper).toBe(25);
+    expect(lapsed.canOpen).toBe(true);
+  });
+
+  it('harvestable stranger corpse with rights-less loot: harvest half open, loot half closed', () => {
+    const result = corpseLootAvailability(
+      tapped({ templateId: 'forest_wolf', harvestClaimedBy: null, loot: plainLoot() }),
+      ME,
+    );
+    expect(result.harvestable).toBe(true);
+    expect(result.hasLoot).toBe(false);
+    expect(result.canOpen).toBe(true);
+  });
+});

--- a/tests/corpse_loot_rights.test.ts
+++ b/tests/corpse_loot_rights.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from 'vitest';
+import { corpseLootAvailability } from '../src/game/corpse_loot_availability';
+import { tryNearbyInteraction } from '../src/game/nearby_interaction';
+import { LOOT_FFA_DELAY } from '../src/sim/loot/loot_ffa';
+import type { Entity } from '../src/sim/types';
+
+// A corpse you have no right to loot must not shadow the resource node under
+// it. The interact picker gives corpses absolute priority, and the old
+// availability predicate answered "does loot EXIST", not "may I take it", so a
+// stranger's unlooted kill sitting on a gather node captured every interact
+// press into a denied lootCorpse ("You don't have permission to loot that")
+// for the full LOOT_FFA_DELAY owner-lock. These suites pin the rights-aware
+// predicate: the press must fall through to the node while the owner-lock
+// holds, and the corpse must come back once the lock lapses (mirrored online
+// via the ffa wire key, tests/snapshots.test.ts).
+
+const ME = 1;
+const STRANGER = 9;
+
+function corpse(overrides: Partial<Entity>): Entity {
+  return {
+    id: 2,
+    kind: 'mob',
+    // forest_wolf carries componentTags: harvestable when unclaimed.
+    templateId: 'forest_wolf',
+    dead: true,
+    lootable: true,
+    loot: null,
+    tappedById: null,
+    lootFfaTimer: Infinity,
+    harvestClaimedBy: null,
+    pos: { x: 1, y: 0, z: 0 },
+    ...overrides,
+  } as Entity;
+}
+
+function player(): Entity {
+  return { id: ME, kind: 'player', dead: false, ghost: false, pos: { x: 0, y: 0, z: 0 } } as Entity;
+}
+
+const NODE = { id: 'copper_node_1', pos: { x: 2, y: 0, z: 0 }, type: 'ore', tier: 1 } as const;
+
+function rig(e: Entity, partyInfo: { members: { pid: number }[] } | null = null) {
+  const lootCorpse = vi.fn(() => true as const);
+  const harvestCorpse = vi.fn();
+  const harvestNode = vi.fn(() => true as const);
+  const world = {
+    player: player(),
+    playerId: ME,
+    partyInfo,
+    entities: new Map([[e.id, e]]),
+    lootCorpse,
+    harvestCorpse,
+    delveInteract: () => false as const,
+    enterDungeon: () => false as const,
+    leaveDungeon: () => false as const,
+    pickUpObject: () => false as const,
+    nodeHarvestableByMe: () => true,
+    harvestNode,
+  } as unknown as Parameters<typeof tryNearbyInteraction>[0];
+  const hud = {
+    openMailbox: () => {},
+    openQuestDialog: () => {},
+    openDelveBoard: () => {},
+    showError: vi.fn(),
+  } as unknown as Parameters<typeof tryNearbyInteraction>[1] & {
+    showError: ReturnType<typeof vi.fn>;
+  };
+  const press = () => tryNearbyInteraction(world, hud, [NODE], null, 'far', 'notReady', 'nothing');
+  return { world, hud, press, lootCorpse, harvestCorpse, harvestNode };
+}
+
+// Loot only the STRANGER may take: tapped by them, owner-lock still counting.
+const strangerLoot = () => ({
+  copper: 12,
+  items: [{ itemId: 'wolf_fang', count: 1 }],
+});
+
+describe('the reported bug: a rights-less corpse must not shadow the node', () => {
+  it('a fresh stranger-tapped corpse with plain loot yields the press to the node (no denied lootCorpse)', () => {
+    const { press, lootCorpse, harvestCorpse, harvestNode, hud } = rig(
+      corpse({
+        // harvestClaimedBy set: nothing harvestable either, a pure loot corpse.
+        harvestClaimedBy: STRANGER,
+        tappedById: STRANGER,
+        lootFfaTimer: LOOT_FFA_DELAY,
+        loot: strangerLoot(),
+      }),
+    );
+
+    expect(press()).toBe(true);
+    expect(harvestNode).toHaveBeenCalledWith(NODE.id);
+    expect(lootCorpse).not.toHaveBeenCalled();
+    expect(harvestCorpse).not.toHaveBeenCalled();
+    expect(hud.showError).not.toHaveBeenCalled();
+  });
+
+  it('a copper-only stranger corpse also yields to the node', () => {
+    const { press, lootCorpse, harvestNode } = rig(
+      corpse({
+        harvestClaimedBy: STRANGER,
+        tappedById: STRANGER,
+        lootFfaTimer: LOOT_FFA_DELAY,
+        loot: { copper: 30, items: [] },
+      }),
+    );
+
+    expect(press()).toBe(true);
+    expect(harvestNode).toHaveBeenCalledWith(NODE.id);
+    expect(lootCorpse).not.toHaveBeenCalled();
+  });
+});
+
+describe('deliberately preserved corpse-priority arms', () => {
+  it("the presser's own tap still loots first", () => {
+    const { press, lootCorpse, harvestNode } = rig(
+      corpse({
+        harvestClaimedBy: STRANGER,
+        tappedById: ME,
+        lootFfaTimer: LOOT_FFA_DELAY,
+        loot: strangerLoot(),
+      }),
+    );
+
+    expect(press()).toBe(true);
+    expect(lootCorpse).toHaveBeenCalledWith(2);
+    expect(harvestNode).not.toHaveBeenCalled();
+  });
+
+  it("a party member's tap still loots first (my party stands in for the tapper's)", () => {
+    const { press, lootCorpse, harvestNode } = rig(
+      corpse({
+        harvestClaimedBy: STRANGER,
+        tappedById: STRANGER,
+        lootFfaTimer: LOOT_FFA_DELAY,
+        loot: strangerLoot(),
+      }),
+      { members: [{ pid: ME }, { pid: STRANGER }] },
+    );
+
+    expect(press()).toBe(true);
+    expect(lootCorpse).toHaveBeenCalledWith(2);
+    expect(harvestNode).not.toHaveBeenCalled();
+  });
+
+  it('an FFA-lapsed stranger corpse is offered again (the documented deliberate-press take)', () => {
+    const { press, lootCorpse, harvestNode } = rig(
+      corpse({
+        harvestClaimedBy: STRANGER,
+        tappedById: STRANGER,
+        lootFfaTimer: 0,
+        loot: strangerLoot(),
+      }),
+    );
+
+    expect(press()).toBe(true);
+    expect(lootCorpse).toHaveBeenCalledWith(2);
+    expect(harvestNode).not.toHaveBeenCalled();
+  });
+
+  it('a HARVESTABLE unclaimed stranger corpse still takes priority, harvest half only', () => {
+    const { press, lootCorpse, harvestCorpse, harvestNode, hud } = rig(
+      corpse({
+        harvestClaimedBy: null,
+        tappedById: STRANGER,
+        lootFfaTimer: LOOT_FFA_DELAY,
+        loot: strangerLoot(),
+      }),
+    );
+
+    expect(press()).toBe(true);
+    expect(harvestCorpse).toHaveBeenCalledWith(2);
+    expect(lootCorpse).not.toHaveBeenCalled();
+    expect(harvestNode).not.toHaveBeenCalled();
+    expect(hud.showError).not.toHaveBeenCalled();
+  });
+
+  it('a personal drop naming me keeps the corpse first even on a stranger tap', () => {
+    const { press, lootCorpse, harvestNode } = rig(
+      corpse({
+        harvestClaimedBy: STRANGER,
+        tappedById: STRANGER,
+        lootFfaTimer: LOOT_FFA_DELAY,
+        loot: { copper: 0, items: [{ itemId: 'wolf_fang', count: 1, personalFor: [ME] }] },
+      }),
+    );
+
+    expect(press()).toBe(true);
+    expect(lootCorpse).toHaveBeenCalledWith(2);
+    expect(harvestNode).not.toHaveBeenCalled();
+  });
+
+  it('a party roster WITHOUT the tapper grants nothing (stranger party)', () => {
+    const { press, lootCorpse, harvestNode } = rig(
+      corpse({
+        harvestClaimedBy: STRANGER,
+        tappedById: STRANGER,
+        lootFfaTimer: LOOT_FFA_DELAY,
+        loot: strangerLoot(),
+      }),
+      { members: [{ pid: ME }, { pid: 5 }] },
+    );
+
+    expect(press()).toBe(true);
+    expect(harvestNode).toHaveBeenCalledWith(NODE.id);
+    expect(lootCorpse).not.toHaveBeenCalled();
+  });
+});
+
+describe('corpseLootAvailability partyMemberIds arm (direct)', () => {
+  const freshStranger = () =>
+    corpse({
+      harvestClaimedBy: STRANGER,
+      tappedById: STRANGER,
+      lootFfaTimer: LOOT_FFA_DELAY,
+      loot: strangerLoot(),
+    });
+
+  it('grants shared rights when the tapper is in the given party roster', () => {
+    const withParty = corpseLootAvailability(freshStranger(), ME, true, [ME, STRANGER]);
+    expect(withParty.hasLoot).toBe(true);
+    expect(withParty.canOpen).toBe(true);
+  });
+
+  it('denies when the roster is absent or does not contain the tapper', () => {
+    for (const roster of [null, [ME, 5]] as const) {
+      const result = corpseLootAvailability(freshStranger(), ME, true, roster);
+      expect(result.hasLoot, `roster ${JSON.stringify(roster)}`).toBe(false);
+      expect(result.canOpen, `roster ${JSON.stringify(roster)}`).toBe(false);
+    }
+  });
+});

--- a/tests/loot_window_controller.test.ts
+++ b/tests/loot_window_controller.test.ts
@@ -152,6 +152,7 @@ describe('LootWindowController', () => {
       componentTags: undefined,
       harvestable: false,
       visibleItems: [],
+      visibleCopper: 0,
       hasLoot: false,
       canOpen: false,
     }));
@@ -162,6 +163,34 @@ describe('LootWindowController', () => {
     expect(corpseAvailability).toHaveBeenCalledWith(mob);
     expect(test.closeTransient).not.toHaveBeenCalled();
     expect(test.element.style.display).not.toBe('block');
+  });
+
+  it("hides a stranger's owner-locked copper and shared items, listing only my personal drop", () => {
+    // Tapped by 9, owner-lock still counting: viewer 7 has no shared rights, so
+    // the coin row and the plain slot must not be advertised (the take would
+    // deny them); only the personal slot naming 7 renders.
+    const mob = entity(15, {
+      kind: 'mob',
+      templateId: harvestMobId,
+      tappedById: 9,
+      lootFfaTimer: 60,
+      harvestClaimedBy: 9,
+      loot: {
+        copper: 25,
+        items: [
+          { itemId: itemIds[0], count: 1 },
+          { itemId: itemIds[1], count: 1, personalFor: [7] },
+        ],
+      },
+    });
+    const test = harness([mob]);
+
+    test.controller.openCorpse(15, 400, 300);
+
+    expect(test.element.style.display).toBe('block');
+    expect(test.element.innerHTML).not.toContain('money:25');
+    expect(test.element.innerHTML).not.toContain(`data-item="${itemIds[0]}"`);
+    expect(test.element.innerHTML).toContain(`data-item="${itemIds[1]}"`);
   });
 
   it('passes the selected harvest components through the IWorld seam', () => {

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -25,6 +25,7 @@ vi.mock('../server/db', () => ({
 
 import { saveCharacterState } from '../server/db';
 import { type ClientSession, GameServer, wireEntity } from '../server/game';
+import { corpseLootAvailability } from '../src/game/corpse_loot_availability';
 import { ClientWorld } from '../src/net/online';
 import { mechHeldWeaponOverride, visualKeyFor } from '../src/render/characters/manifest';
 import { COMBO_RECIPES } from '../src/sim/content/recipes';
@@ -577,6 +578,70 @@ describe('corpse harvest claim over the wire', () => {
     mob.harvestClaimedBy = null;
     (client as any).applySnapshot({ t: 'snap', ents: [wireEntity(mob)] });
     expect(client.entities.get(mob.id)!.harvestClaimedBy).toBeNull();
+  });
+});
+
+// Loot owner-lock lapse (FFA) over the wire. The rights-aware corpse picker
+// (src/game/corpse_loot_availability.ts) reads mob.lootFfaTimer; offline the
+// Sim entity carries the real countdown, so online the LAPSE must ride the
+// sparse terse key `ffa` or a stranger's aged-out corpse stays unofferable
+// forever (the old hardcoded Infinity mirror). Same pin shape as the hcb suite
+// above: the REAL server emit into the REAL client mirror.
+describe('loot FFA lapse over the wire', () => {
+  const TAPPER = 42;
+
+  function strangerCorpse(id: number, lootFfaTimer: number): ReturnType<typeof createMob> {
+    const template = MOBS.forest_wolf;
+    const mob = createMob(id, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+    mob.dead = true;
+    mob.lootable = true;
+    mob.tappedById = TAPPER;
+    // claimed: keeps the harvest arm closed so canOpen isolates loot rights
+    mob.harvestClaimedBy = TAPPER;
+    mob.lootFfaTimer = lootFfaTimer;
+    mob.loot = { copper: 10, items: [{ itemId: 'wolf_fang', count: 1 }] };
+    return mob;
+  }
+
+  it('a fresh owner-locked corpse stays sparse (no ffa key) and unofferable to a stranger', () => {
+    const w = wireEntity(strangerCorpse(9101, 60));
+    // Absent, not `ffa: 0`: a still-locked corpse's record must be byte-unchanged
+    // by this feature, so the per-entity delta cache keeps eliding it.
+    expect(w).not.toHaveProperty('ffa');
+
+    const client = bareClient(1);
+    (client as any).applySnapshot({ t: 'snap', ents: [w] });
+    const mirrored = client.entities.get(9101)!;
+    expect(mirrored.lootFfaTimer).toBe(Infinity);
+    expect(corpseLootAvailability(mirrored, 1).canOpen).toBe(false);
+  });
+
+  it('the lapse rides ffa:1, mirrors as lapsed, and reopens the picker for a stranger', () => {
+    const w = wireEntity(strangerCorpse(9102, 0));
+    expect(w.ffa).toBe(1);
+
+    const client = bareClient(1);
+    (client as any).applySnapshot({ t: 'snap', ents: [w] });
+    const mirrored = client.entities.get(9102)!;
+    expect(corpseLootAvailability(mirrored, 1).canOpen).toBe(true);
+    expect(corpseLootAvailability(mirrored, 1).hasLoot).toBe(true);
+  });
+
+  it('a record without the flag resets a stale mirrored lapse (respawn reuses the id)', () => {
+    const client = bareClient(1);
+    (client as any).applySnapshot({ t: 'snap', ents: [wireEntity(strangerCorpse(9103, 0))] });
+    expect(corpseLootAvailability(client.entities.get(9103)!, 1).canOpen).toBe(true);
+
+    (client as any).applySnapshot({ t: 'snap', ents: [wireEntity(strangerCorpse(9103, 60))] });
+    expect(client.entities.get(9103)!.lootFfaTimer).toBe(Infinity);
+    expect(corpseLootAvailability(client.entities.get(9103)!, 1).canOpen).toBe(false);
+  });
+
+  it('never emits ffa for a non-lootable entity even with a lapsed timer', () => {
+    const template = MOBS.forest_wolf;
+    const alive = createMob(9104, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+    alive.lootFfaTimer = 0;
+    expect(wireEntity(alive)).not.toHaveProperty('ffa');
   });
 });
 


### PR DESCRIPTION
## Summary

A corpse you have no right to loot no longer shadows the resource node under it.

Player-visible symptom: kill a mob on top of a gather node and walk away without looting; every other player pressing interact at the node gets "You don't have permission to loot that" on every press and cannot harvest the node for a full 60 seconds, and after that the press "succeeds" by taking the stranger's loot, which was the only way to free the node.

Root cause, three parts that compound:

- The interact picker (`tryNearbyInteraction`) gives corpses absolute priority: when an "openable" corpse is in range it dispatches loot and returns, so the node branch is never reached.
- "Openable" came from `corpseLootAvailability`, which answered "does loot EXIST" (copper or visible slots), never "may I take it". The server broadcasts every corpse's `lootList` to all nearby clients, so a stranger's kill looked lootable to everyone, while the sim's authoritative gate (`corpseLootRights` in `src/sim/interaction.ts`) correctly denied the take with the reported toast.
- The online mirror hardcoded `lootFfaTimer: Infinity`, so the client could never know when the 60s owner-lock (`LOOT_FFA_DELAY`) lapses.

The fix follows the repo's own precedent: harvest claims are already mirrored on the wire (`hcb`) precisely so "the online corpse picker must stop offering a corpse another player already harvested" (comment in `wireEntity`). Loot rights now get the same treatment:

1. **Wire:** `wireEntity` emits a sparse `ffa: 1` for a dead lootable mob whose owner-lock has lapsed (`lootHasGoneFfa`), inside the same cached `dynamicFields` path as `hcb` (it flips once per corpse, so exactly one changed record re-serializes). `ClientWorld.applyWire` mirrors it unconditionally: present means lapsed (`lootFfaTimer = 0`), absent resets to `Infinity` (same stale-reset contract as `hcb`).
2. **Rights-aware availability:** `corpseLootAvailability` now mirrors the sim's own arms via the sim's own pure predicates (`hasSharedLootRights` + `lootHasGoneFfa` from `src/sim/loot/loot_ffa.ts`): shared (tap-owned) loot needs shared rights, `personalFor` slots naming the viewer and `openToAll` slots open regardless. The local party roster is threaded in from the callers; it stands in for the tapper's party exactly when that grants anything (the tapper being in my party), since party membership is symmetric. The module runs unchanged in both hosts: offline entities carry the real `tappedById`/`lootFfaTimer` and the bot party, online the mirrored `tap`/`ffa` keys and the mirrored roster. The loot popup also stops advertising copper and shared slots the take would deny (`visibleCopper` + rights-filtered `visibleItems`).
3. **Picker behavior falls out:** a rights-less corpse stops being `bestCorpse`, so the press reaches the node.

Deliberately preserved (each pinned by a test):

- A HARVESTABLE unclaimed corpse still takes priority for any player (harvest is first-come), dispatching only its harvest half.
- A party member's kill still loots.
- An FFA-lapsed stranger corpse is offered again (the lapse is now mirrored), keeping the documented "a deliberate click may take a stranger's corpse once its owner-lock lapses" behavior.
- The walk-by autoloot path (`autoLootForParty`, `honorFfa = false`) and the sim's authoritative gate are untouched; the picker's priority order is unchanged.

One intentional UX delta: pressing interact next to ONLY a rights-less corpse (no node, nothing else in range) now yields the "Nothing to interact with" outcome instead of the permission toast. That matches the picker's documented design (each half of the unified press is gated on availability so denials are never dispatched), and a deliberate click after the FFA lapse still loots.

## Type of change

- [x] Bug fix

## How was this tested?

Red before, green after: the new reproduction suite (`tests/corpse_loot_rights.test.ts`) drives `tryNearbyInteraction` with a fresh stranger-tapped corpse with plain loot in range of a gather node; before the fix the press dispatched `lootCorpse` (5 of its cases failed), after it dispatches `harvestNode` with no error, and all preserved arms pass.

- Commands:
  - `npx vitest run tests/corpse_loot_rights.test.ts` (new: node-shadow reproduction, preserved priority arms, party-roster arm)
  - `npx vitest run tests/corpse_loot_availability.test.ts` (new rights matrix: own tap, tapper-in-party, stranger fresh/lapsed, personalFor, openToAll, copper-only, harvest-half split; existing `harvestStateReliable` false-arm pins untouched and passing)
  - `npx vitest run tests/snapshots.test.ts` (new: `ffa` emit exactly when lapsed on a dead lootable mob, sparse when locked or non-lootable, real-server-emit into real-client-mirror, stale reset)
  - `npx vitest run tests/corpse_harvest_sim.test.ts` (new: the lapse landing after first sight rides a lite delta record through the live broadcast path and reopens the picker)
  - `npx vitest run tests/interactions.test.ts tests/gather_open_gate.test.ts tests/corpse_lifecycle.test.ts tests/loot_window_controller.test.ts tests/client_shell.test.ts tests/loot_ffa_sim.test.ts tests/weapon_stow.test.ts tests/architecture.test.ts tests/localization_fixes.test.ts tests/world_api_parity.test.ts` (all green)
  - `npm run gate`: every step green up to the full-suite vitest step, which failed ONLY on the two known sandbox-environment flakes in `tests/deploy_watchdog.test.ts` ("abandons a hung docker inspect/restart", fake-docker timing; they fail identically on a pristine release branch in this sandbox and pass in CI). Per the documented procedure I then ran the three remaining checks directly:
    - `npm test -- --maxWorkers=6 --exclude tests/deploy_watchdog.test.ts`: green (1499 files passed, 18602 tests passed, exit 0)
    - `npx tsc --noEmit`: clean
    - `npm run build`: green (all five entries)
- Manual steps (in place of screenshots; this is interaction-priority behavior, no visual layout change): two clients online (`npm run server`, `npm run dev`, two browser sessions), player A kills a mob on a gather node and leaves it unlooted, player B presses interact at the node: B harvests the node immediately, no permission toast; after 60 seconds B's press offers the corpse again (FFA).

## Screenshots / recordings

N/A: non-visual interaction-priority change (no layout/DOM styling change); manual two-client verification above.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI layout change; the interact press path is shared across desktop/mobile/gamepad and covered by the picker tests.
- ~Accessible.~ N/A: no UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

Generated with [Claude Code](https://claude.com/claude-code)
