### PR TITLE
feat(admin): open account detail from the Overview online players table

### DIFF
--- a/src/admin/components/OnlineTable.svelte
+++ b/src/admin/components/OnlineTable.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import type { LivePlayer } from '../types';
   import { classLabel, zoneLabel, t } from '../i18n';
-  import { fmtDuration } from '../format';
+  import { fmtDuration, fmtNumber } from '../format';
+  import AccountLink from './AccountLink.svelte';
   import LocationCell from './LocationCell.svelte';
 
   // Live players table (refreshed every 5s by Overview). Ported from renderOnlineTable.
@@ -36,7 +37,7 @@
           <td class="num">{p.hp}/{p.maxHp}</td>
           <td class="num">{fmtDuration(p.sessionSeconds)}</td>
           <td class="num">{t('common.ago', { value: fmtDuration(p.lastSaveSecondsAgo) })}</td>
-          <td class="num">{p.accountId}</td>
+          <td class="num"><AccountLink accountId={p.accountId} label={fmtNumber(p.accountId)} /></td>
         </tr>
       {/each}
     </tbody>

--- a/tests/admin/online_table.test.ts
+++ b/tests/admin/online_table.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import './_setup';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const accountModalOpen = vi.fn();
+
+vi.mock('../../src/admin/account_modal', () => ({
+  getAccountModalController: () => ({
+    open: accountModalOpen,
+    close: vi.fn(),
+  }),
+}));
+
+import OnlineTable from '../../src/admin/components/OnlineTable.svelte';
+import { t } from '../../src/admin/i18n';
+import type { LivePlayer } from '../../src/admin/types';
+
+const players: LivePlayer[] = [
+  {
+    pid: 1,
+    accountId: 77,
+    characterId: 42,
+    name: 'Aragorn',
+    class: 'warrior',
+    level: 60,
+    hp: 90,
+    maxHp: 100,
+    x: 12,
+    z: 34,
+    zone: 'greenhollow',
+    sessionSeconds: 600,
+    lastSaveSecondsAgo: 5,
+    moveSpeedMultiplier: 1,
+    runSpeed: 7,
+    swimming: false,
+    auras: [],
+  },
+];
+
+beforeEach(() => {
+  accountModalOpen.mockReset();
+});
+
+describe('OnlineTable', () => {
+  it('renders the player row with the account column as an account link', () => {
+    render(OnlineTable, { players });
+    expect(screen.getByText('Aragorn')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '77' })).toBeInTheDocument();
+  });
+
+  it('opens the account detail modal when the account link is clicked', async () => {
+    render(OnlineTable, { players });
+    await fireEvent.click(screen.getByRole('button', { name: '77' }));
+    expect(accountModalOpen).toHaveBeenCalledWith(77, undefined);
+  });
+
+  it('shows the empty message for no players', () => {
+    render(OnlineTable, { players: [] });
+    expect(screen.getByText(t('online.empty'))).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# feat(admin): open account detail from the Overview online players table

## Summary

**QOL for mod team**

The online players list on the admin Overview page showed each player's account id as
plain text, so moderators had no way to reach the account detail from there and had to
go through the Characters page instead. The account cell now renders the shared
AccountLink component, which opens the same AccountModal account-detail dialog
(status, notes, moderation actions) used by the Characters, Accounts, IP associations,
moderation history, and live evidence pages.

No new permission surface: GET /admin/api/online and GET /admin/api/accounts/:id are
both gated on accounts.read in server/admin_routes.ts, so any operator who can see a
row in this table can already read the account behind it. The id also goes through
fmtNumber now, matching the Accounts page id column.

## Type of change

- [x] Feature: new functionality

## How was this tested?

- Commands:
  - `npx vitest run tests/admin/online_table.test.ts` (new component test: row render
    with the account link, click opens the modal with the right account id, empty state)
  - `npm run gate` green (all 11 steps)
  - `npm run check:admin` (svelte-check, 0 errors) and `npx tsc --noEmit`
- Manual steps: ran the local stack (dev DB, `npm run server`, `npm run dev`), granted
  a test account the moderator role via `scripts/grant_admin.mjs`, kept one player
  connected to the server, then clicked the account id in the Overview online table on
  desktop (1440x900) and a phone-sized portrait viewport (390x844): the account detail
  modal opens with the expected account.

## Screenshots / recordings

<img width="1737" height="1116" alt="image" src="https://github.com/user-attachments/assets/17d4660e-fb5b-4822-9551-8574f4624bfa" />

<img width="1737" height="1116" alt="image" src="https://github.com/user-attachments/assets/3657b721-02a6-46ce-a8f0-769bd77f0089" />

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [x] **Tested on desktop and mobile.** Verified on a desktop and on a phone-sized
      viewport (the table keeps the pre-existing sideways page scroll on phones; the
      link is reachable there).
- [x] **Accessible.** The account cell is a real button (`.btn-link`) with
      `aria-haspopup="dialog"`, keyboard-operable with visible focus, same as the
      existing AccountLink usages.

### Localization (i18n)

- [x] Numbers, money, dates, units, and percents go through the i18n formatters
      (the account id now renders via `fmtNumber`).
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
