### PR TITLE
fix(admin): support unknown IP associations

### DIFF
--- a/server/admin.ts
+++ b/server/admin.ts
@@ -15,6 +15,7 @@ import {
   registrationsByDay,
   sessionsByDay,
 } from './admin_db';
+import { cleanIpAssociationLookup } from './admin_ip_association';
 import { readOverviewCounts } from './admin_overview_cache';
 import {
   type AdminPermission,
@@ -757,9 +758,11 @@ export async function handleAdminApi(
 
     if (req.method === 'POST' && path === '/admin/api/blocked-ips') {
       const body = await readBody(req);
+      const cleanedIp = cleanIp(body.ip);
+      if (!cleanedIp) return fail(res, 400, 'a valid IP address is required');
       try {
         const ip = await addBlockedIp({
-          ip: body.ip,
+          ip: cleanedIp,
           reason: body.reason,
           createdByAccountId: accountId,
           expiresAt: body.expiresAt,
@@ -932,18 +935,20 @@ export async function handleAdminApi(
       });
     }
     if (path === '/admin/api/ip-associations') {
-      const ip = cleanIp(url.searchParams.get('ip'));
+      const ip = cleanIpAssociationLookup(url.searchParams.get('ip'));
       if (!ip) return fail(res, 400, 'a valid IP address is required');
       const { page, limit } = parsePageParams(url.searchParams);
       const associations = await associationsForIp(ip, page, limit);
       const onlineAccountIds = game.liveAccountIds();
+      const blockableIp = cleanIp(ip);
       return ok(res, {
         ...associations,
         accounts: associations.accounts.map((account) => ({
           ...account,
           online: onlineAccountIds.has(account.accountId),
         })),
-        blocked: game.isIpBlocked(ip),
+        blocked: blockableIp ? game.isIpBlocked(blockableIp) : false,
+        blockable: Boolean(blockableIp),
       });
     }
     if (path === '/admin/api/moderation/queue') {
@@ -1576,21 +1581,23 @@ async function sharedIpsHandler(ctx: Ctx): Promise<void> {
   });
 }
 
-/** GET /admin/api/ip-associations: accounts tied to one IP, with live online flags. */
+/** GET /admin/api/ip-associations: accounts tied to one stored IP marker, with live flags. */
 async function ipAssociationsHandler(ctx: Ctx): Promise<void> {
   const rt = useAdminRuntime();
-  const ip = adminDb().cleanIp(ctx.url.searchParams.get('ip'));
+  const ip = cleanIpAssociationLookup(ctx.url.searchParams.get('ip'));
   if (!ip) return fail(ctx.res, 400, 'a valid IP address is required');
   const { page, limit } = parsePageParams(ctx.url.searchParams);
   const associations = await adminDb().associationsForIp(ip, page, limit);
   const onlineAccountIds = rt.liveAccountIds();
+  const blockableIp = adminDb().cleanIp(ip);
   ok(ctx.res, {
     ...associations,
     accounts: associations.accounts.map((account) => ({
       ...account,
       online: onlineAccountIds.has(account.accountId),
     })),
-    blocked: rt.isIpBlocked(ip),
+    blocked: blockableIp ? rt.isIpBlocked(blockableIp) : false,
+    blockable: Boolean(blockableIp),
   });
 }
 
@@ -1603,9 +1610,11 @@ async function blockedIpsGetHandler(ctx: Ctx): Promise<void> {
 async function blockedIpsPostHandler(ctx: Ctx): Promise<void> {
   const rt = useAdminRuntime();
   const body = await readBody(ctx.req);
+  const cleanedIp = adminDb().cleanIp(body.ip);
+  if (!cleanedIp) return fail(ctx.res, 400, 'a valid IP address is required');
   try {
     const ip = await adminDb().addBlockedIp({
-      ip: body.ip,
+      ip: cleanedIp,
       reason: body.reason,
       createdByAccountId: ctxAccountId(ctx),
       expiresAt: body.expiresAt,

--- a/server/admin_ip_association.ts
+++ b/server/admin_ip_association.ts
@@ -1,0 +1,11 @@
+import { cleanIp } from './ip_block';
+
+export const UNKNOWN_IP_ASSOCIATION = 'unknown';
+
+// Association reads may need to investigate the exact marker persisted when no
+// client address was available. Mutation paths deliberately keep using cleanIp
+// directly, so this marker can never become a block-list entry.
+export function cleanIpAssociationLookup(value: unknown): string {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return cleanIp(text) || (text === UNKNOWN_IP_ASSOCIATION ? text : '');
+}

--- a/src/admin/pages/IpAssociations.svelte
+++ b/src/admin/pages/IpAssociations.svelte
@@ -115,7 +115,7 @@
   <PageHeader
     title={t('ipAssociations.title', { ip })}
     badge={data?.blocked ? blockedBadge : undefined}
-    actions={data && auth.can('ipblocks.manage') ? pageActions : undefined}
+    actions={data?.blockable && auth.can('ipblocks.manage') ? pageActions : undefined}
   />
 
   <a class="back-link" href={routeHref({ page: 'shared-ips' })} onclick={back}>{t('ipAssociations.back')}</a>

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -236,6 +236,7 @@ export interface Paginated<T> {
 export interface IpAssociationsData {
   ip: string;
   blocked: boolean;
+  blockable: boolean;
   accounts: {
     accountId: number;
     username: string;

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -713,7 +713,40 @@ describe('admin api auth', () => {
     expect(associationsForIp).toHaveBeenCalledWith('203.0.113.7', 2, 50);
     expect(res.statusCode).toBe(200);
     expect(res.body.data.blocked).toBe(true);
+    expect(res.body.data.blockable).toBe(true);
     expect(res.body.data.accounts[0].online).toBe(true);
+  });
+
+  it('serves associations for the stored unknown marker without checking the block list', async () => {
+    vi.mocked(accountAndScopeForToken).mockResolvedValue(fullToken(7));
+    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    vi.mocked(associationsForIp).mockResolvedValue({
+      ip: 'unknown',
+      accounts: [],
+      total: 0,
+      page: 1,
+      limit: 25,
+    });
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({ token: VALID_TOKEN, url: '/admin/api/ip-associations?ip=unknown' }),
+      res,
+      fakeGame,
+    );
+
+    expect(associationsForIp).toHaveBeenCalledWith('unknown', 1, 25);
+    expect(fakeGame.isIpBlocked).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toEqual({
+      ip: 'unknown',
+      accounts: [],
+      total: 0,
+      page: 1,
+      limit: 25,
+      blocked: false,
+      blockable: false,
+    });
   });
 
   it('rejects an invalid IP association lookup', async () => {
@@ -1392,6 +1425,26 @@ describe('blocked-ips admin route', () => {
       fakeGame,
     );
     expect(res.statusCode).toBe(400);
+    expect(fakeGame.disconnectByIp).not.toHaveBeenCalled();
+  });
+
+  it('refuses to block unknown before the write boundary', async () => {
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({
+        method: 'POST',
+        token: VALID_TOKEN,
+        url: '/admin/api/blocked-ips',
+        body: { ip: 'unknown' },
+      }),
+      res,
+      fakeGame,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(addBlockedIp).not.toHaveBeenCalled();
+    expect(fakeGame.reloadBlockedIps).not.toHaveBeenCalled();
     expect(fakeGame.disconnectByIp).not.toHaveBeenCalled();
   });
 

--- a/tests/admin/ip_associations.test.ts
+++ b/tests/admin/ip_associations.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const data = {
   ip: '203.0.113.7',
   blocked: true,
+  blockable: true,
   total: 2,
   page: 1,
   limit: 25,
@@ -155,5 +156,16 @@ describe('IP associations', () => {
       reason: 'investigation',
       expiresAt: expect.any(String),
     });
+  });
+
+  it('does not offer block actions for the stored unknown marker', async () => {
+    currentData = { ...data, ip: 'unknown', blocked: false, blockable: false };
+    render(IpAssociations, { ip: 'unknown' });
+
+    expect(await screen.findByText('alice')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: t('ipAssociations.blockAction') }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: t('blockedIps.unblock') })).not.toBeInTheDocument();
   });
 });

--- a/tests/admin_ip_association.test.ts
+++ b/tests/admin_ip_association.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { cleanIpAssociationLookup, UNKNOWN_IP_ASSOCIATION } from '../server/admin_ip_association';
+
+describe('admin IP association lookup', () => {
+  it('accepts canonical IP addresses and the exact stored unknown marker', () => {
+    expect(cleanIpAssociationLookup(' ::ffff:203.0.113.7 ')).toBe('203.0.113.7');
+    expect(cleanIpAssociationLookup(` ${UNKNOWN_IP_ASSOCIATION} `)).toBe('unknown');
+  });
+
+  it('rejects arbitrary non-IP metadata and marker variants', () => {
+    expect(cleanIpAssociationLookup('not-an-ip')).toBe('');
+    expect(cleanIpAssociationLookup('UNKNOWN')).toBe('');
+    expect(cleanIpAssociationLookup('unknown:proxy')).toBe('');
+    expect(cleanIpAssociationLookup('')).toBe('');
+    expect(cleanIpAssociationLookup(null)).toBe('');
+  });
+});

--- a/tests/server/admin.test.ts
+++ b/tests/server/admin.test.ts
@@ -1195,6 +1195,40 @@ describe('migrated read handlers (QA gate parity coverage)', () => {
         page: 1,
         limit: 25,
         blocked: true,
+        blockable: true,
+      },
+      error: null,
+    });
+  });
+
+  it('ip-associations reads the stored unknown marker without treating it as blockable', async () => {
+    const associationsForIp = vi.fn(async (ip: string, page: number, limit: number) => ({
+      ip,
+      accounts: [{ accountId: 20 }],
+      total: 1,
+      page,
+      limit,
+    }));
+    authedAdminDb({ associationsForIp });
+    const rt = installAdminRuntime();
+
+    const r = await runRoute('GET', '/admin/api/ip-associations', {
+      url: '/admin/api/ip-associations?ip=unknown&page=1&limit=25',
+      headers: { authorization: BEARER },
+    });
+
+    expect(associationsForIp).toHaveBeenCalledWith('unknown', 1, 25);
+    expect(rt.isIpBlocked).not.toHaveBeenCalled();
+    expect(r.body).toEqual({
+      success: true,
+      data: {
+        ip: 'unknown',
+        accounts: [{ accountId: 20, online: false }],
+        total: 1,
+        page: 1,
+        limit: 25,
+        blocked: false,
+        blockable: false,
       },
       error: null,
     });
@@ -1975,7 +2009,7 @@ describe('catch -> 400 err.message remap (legacy prose passthrough, per write ha
       const r = await runRoute('POST', c.path, {
         headers: { authorization: BEARER },
         params: c.params,
-        body: {},
+        body: c.label === 'blocked-ips add' ? { ip: '9.9.9.9' } : {},
       });
       expect(r.status).toBe(400);
       expect(r.body).toEqual({ success: false, data: null, error: `${c.label} exploded` });
@@ -2073,14 +2107,32 @@ describe('remaining legacy guard negatives (re-verification audit)', () => {
   });
 
   it('400s a blocked-ips add when addBlockedIp rejects the ip (falsy), no reload and no kick', async () => {
-    authedAdminDb({ addBlockedIp: async () => '' });
+    const addBlockedIp = vi.fn(async () => '');
+    authedAdminDb({ cleanIp: () => '9.9.9.9', addBlockedIp });
     const rt = installAdminRuntime();
     const r = await runRoute('POST', '/admin/api/blocked-ips', {
       headers: { authorization: BEARER },
-      body: { ip: 'not-an-ip' },
+      body: { ip: '9.9.9.9' },
     });
     expect(r.status).toBe(400);
     expect(r.body).toEqual({ success: false, data: null, error: 'a valid IP address is required' });
+    expect(addBlockedIp).toHaveBeenCalledWith(expect.objectContaining({ ip: '9.9.9.9' }));
+    expect(rt.reloadBlockedIps).not.toHaveBeenCalled();
+    expect(rt.disconnectByIp).not.toHaveBeenCalled();
+  });
+
+  it('400s a blocked-ips add for unknown before the write boundary', async () => {
+    const addBlockedIp = vi.fn(async () => 'unknown');
+    authedAdminDb({ addBlockedIp });
+    const rt = installAdminRuntime();
+
+    const r = await runRoute('POST', '/admin/api/blocked-ips', {
+      headers: { authorization: BEARER },
+      body: { ip: 'unknown' },
+    });
+
+    expect(r.status).toBe(400);
+    expect(addBlockedIp).not.toHaveBeenCalled();
     expect(rt.reloadBlockedIps).not.toHaveBeenCalled();
     expect(rt.disconnectByIp).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Allow administrators to inspect accounts associated with the stored `unknown` IP marker from the Shared IPs dashboard.

The lookup accepts `unknown` only on the read path. IP block mutations continue to require a valid canonical IP address, and the dashboard hides Block and Unblock actions when the association is not blockable.

Both the retained legacy dispatcher and the RouteDef dispatcher implement the same behavior.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run gate`
  - `npx vitest run tests/admin_ip_association.test.ts tests/server/admin.test.ts tests/admin.test.ts`
  - `npx vitest run tests/admin/ip_associations.test.ts`
  - `npx tsc --noEmit`
- Results:
  - 18,612 unit tests passed
  - 66 browser tests passed
  - TypeScript and Svelte checks passed
  - Environment, server, and client builds passed
- PostgreSQL validation:
  - Tested on PostgreSQL 16 with 100,000 accounts and 440,000 sessions
  - Included 40,000 `unknown` sessions associated with 40 accounts
  - Main association query completed in approximately 16 to 19 ms
  - Character detail query completed in approximately 7 to 11 ms
- Manual steps:
  - Tested against an environment containing forged `unknown` entries
  - Open Shared IPs and select `unknown`
  - Confirm the associated accounts load successfully
  - Confirm Block and Unblock actions are absent
  - Open a normal IP and confirm its block actions remain available

## Screenshots / recordings

<img width="1752" height="1117" alt="Screenshot from 2026-07-23 13-44-04" src="https://github.com/user-attachments/assets/1eb31803-2152-4841-b76f-2e6dcaa52085" />

<img width="1737" height="1109" alt="image" src="https://github.com/user-attachments/assets/509e7283-f868-4b2e-b083-8d2b1886469f" />

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [x] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font.
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion`.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.