### PR TITLE
fix(deeds): floor proficiency display and heal the stranded Old Salt band

### DIFF
--- a/src/sim/CLAUDE.md
+++ b/src/sim/CLAUDE.md
@@ -127,8 +127,10 @@ legality), `cooldown_persist.ts` (cooldown save/load), `tab_target.ts`/`assist.t
 `vendor_stack.ts`, `loot_master.ts`, `aura_classify.ts` (buff-vs-debuff, shared with the
 HUD), `resurrection.ts` (sickness rules shared by every death site), and the combat
 leaves `spell_resist.ts`/`ranged_shot.ts`/`aura_stacking.ts`/`aura_cancel.ts`/
-`exclusive_aura.ts`/`form_swing.ts`, and `jail.ts` (moderation-jail cage layout, gate
-teleport, visitor spot; the jail SYSTEM logic stays on `Sim`). A leaf is any `src/sim`
+`exclusive_aura.ts`/`form_swing.ts`, `jail.ts` (moderation-jail cage layout, gate
+teleport, visitor spot; the jail SYSTEM logic stays on `Sim`), and
+`professions/proficiency_display_heal.ts` (the one-time gathering-proficiency
+display-band heal applied at character load). A leaf is any `src/sim`
 file with no `sim_context` import.
 
 ## The SimContext seam (final shape)

--- a/src/sim/professions/proficiency_display_heal.ts
+++ b/src/sim/professions/proficiency_display_heal.ts
@@ -1,0 +1,47 @@
+// One-time heal for gathering proficiencies stranded by the pre-fix
+// character-sheet rounding (issue 2339). The sheet formatted the raw value
+// with round-half-up while every threshold reader (the proficiency bands and
+// the 100/200 gathering deeds) compares the raw value with >=, so a player at
+// 99.5 to 99.99 read "Fishing: 100" with Old Salt still locked, took the
+// readout at its word, and stopped fishing with the deed stranded.
+//
+// The heal bumps any value inside the half-point display band below a band
+// threshold ([threshold - 0.5, threshold), exactly the values the old sheet
+// showed as that threshold) up to the threshold, so the join-time deed retro
+// pass (the sim.ts addPlayer tail) grants the matching deeds on that same
+// join. Only band thresholds heal: they are the deed milestones and the
+// catch-table boundaries; a mid-band schedule breakpoint (150) has no reader
+// and stays untouched. Applied once per character behind
+// CharacterState.proficiencyDisplayHealApplied (the masteryResetApplied
+// idiom): blobs written by post-fix code floor on the sheet instead, so a
+// live 99.5 correctly reads 99 and is never healed.
+//
+// Pure leaf (no SimContext, no rng, Vitest-importable directly), mutating
+// the record in place, the applyMasteryReset shape.
+import { GATHERING_PROFESSION_IDS, GATHERING_PROFESSIONS } from '../content/professions';
+import type { GatheringProficiency } from './gathering';
+import { PROFICIENCY_BAND_THRESHOLDS } from './proficiency_bands';
+
+// Half a display point: the pre-fix sheet's round-half-up showed a threshold
+// for any raw value at or above threshold - 0.5.
+export const DISPLAY_HEAL_BAND = 0.5;
+
+/** Bumps every proficiency the pre-fix sheet displayed as a crossed band
+ *  threshold up to that threshold, capped at the profession's maxSkill
+ *  ladder (a threshold above the cap never applies). Returns whether any
+ *  value changed. */
+export function healDisplayRoundedProficiency(proficiency: GatheringProficiency): boolean {
+  let healed = false;
+  for (const id of GATHERING_PROFESSION_IDS) {
+    const cap = GATHERING_PROFESSIONS[id].maxSkill;
+    for (const threshold of PROFICIENCY_BAND_THRESHOLDS) {
+      if (threshold === 0 || threshold > cap) continue;
+      const v = proficiency[id];
+      if (v >= threshold - DISPLAY_HEAL_BAND && v < threshold) {
+        proficiency[id] = threshold;
+        healed = true;
+      }
+    }
+  }
+  return healed;
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -331,6 +331,7 @@ import {
   placeMobileStationForPlayer,
 } from './professions/mobile_station';
 import { updateProfNudges } from './professions/prof_nudges';
+import { healDisplayRoundedProficiency } from './professions/proficiency_display_heal';
 import { type SalvageResult, salvageItem as salvageItemImpl } from './professions/salvage';
 import { normalizeTierMailOnLoad, updateTierMail } from './professions/tier_mail';
 import { grandfatherKnownRecipes, resolveTrain, type TrainResult } from './professions/training';
@@ -1411,6 +1412,15 @@ export interface CharacterState {
   // true is serialized unconditionally (any blob written by curve-era code
   // has the reset applied), so it can never re-fire.
   masteryResetApplied?: boolean;
+  // Proficiency display heal already applied (issue 2339; JSONB, the
+  // masteryResetApplied idiom): absent/false on a save written while the
+  // character sheet still ROUNDED its Gathering rows triggers the one-time
+  // healDisplayRoundedProficiency on load (a value the old sheet displayed
+  // as a crossed band threshold, 99.5 to 99.99 reading "100", bumps to that
+  // threshold so the join retro pass grants the stranded 100/200 gathering
+  // deeds), then LITERAL true is serialized unconditionally so it can never
+  // re-fire on the floored post-fix display.
+  proficiencyDisplayHealApplied?: boolean;
   townFocus?: Record<string, number>;
   // Active-archetype state (#1129, superseded scope; JSONB, back-compat: absent on
   // older saves loads as emptyArchetypeState, see normalizeArchetypeState).
@@ -2360,6 +2370,17 @@ export class Sim {
         applyMasteryReset(meta.craftSkills, meta.gatheringProficiency);
         meta.pendingMasteryResetNotice = true;
       }
+      // The one-time proficiency display heal (issue 2339), after the
+      // mastery-reset branch so it sees the values this character actually
+      // keeps: a save written while the character sheet rounded its
+      // Gathering rows can hold a proficiency the old readout showed as a
+      // crossed band threshold (99.5 to 99.99 read "100") while the
+      // threshold deeds, comparing the raw value with >=, stayed locked.
+      // Bump exactly those values to the threshold once; the deed retro
+      // pass below then grants the stranded deeds on this same join.
+      if (s.proficiencyDisplayHealApplied !== true) {
+        healDisplayRoundedProficiency(meta.gatheringProficiency);
+      }
       meta.mailWelcomed = s.mailWelcomed === true;
       meta.guildLetterSent = s.guildLetterSent === true;
       // Work-order cooldowns: clamp every stored availableAt to
@@ -3025,6 +3046,11 @@ export class Sim {
       // serializes unconditionally. There is deliberately NO PlayerMeta
       // mirror: the parity sampler must see zero new fields.
       masteryResetApplied: true,
+      // LITERAL true for the same reason: any blob written by post-fix code
+      // was loaded through the heal branch (or born past the cut), and the
+      // floored display makes the heal unrepeatable by design. No PlayerMeta
+      // mirror here either.
+      proficiencyDisplayHealApplied: true,
       archetype: { ...meta.archetype, attunedPairs: [...meta.archetype.attunedPairs] },
       delveMarks: meta.delveMarks,
       delveClears: { ...meta.delveClears },

--- a/src/ui/char_window.ts
+++ b/src/ui/char_window.ts
@@ -284,7 +284,7 @@ export class CharWindow {
         const icon = imageUrl
           ? `<img class="char-gather-icon" src="${esc(imageUrl)}" alt="" draggable="false">`
           : '';
-        return `<span class="char-gather-row">${icon}<span>${esc(t(key))}: <b>${formatNumber(r.value, { maximumFractionDigits: 0 })}</b></span></span>`;
+        return `<span class="char-gather-row">${icon}<span>${esc(t(key))}: <b>${formatNumber(r.displayValue, { maximumFractionDigits: 0 })}</b></span></span>`;
       })
       .join('');
     return `<div class="char-progression"><div class="cp-title">${esc(t('hudChrome.gathering.title'))}</div><div class="char-stats cp-stats">${items}</div></div>`;

--- a/src/ui/gathering_view.ts
+++ b/src/ui/gathering_view.ts
@@ -143,10 +143,16 @@ export function gatherDowngradeLineKey(lost: 'mark' | 'find'): TranslationKey {
 }
 
 /** One row of the gathering-proficiency display: a profession id plus its
- *  current point value, in the fixed GATHERING_PROFESSION_IDS order. */
+ *  current point value, in the fixed GATHERING_PROFESSION_IDS order. `value`
+ *  is the raw, possibly fractional proficiency (the repaint-signature input,
+ *  full granularity); `displayValue` floors it for readouts, the
+ *  buildSkillBar convention (issue 2339): a fractional value never rounds a
+ *  threshold forward, so 99.5 reads 99, not a fake crossed 100 while the
+ *  100-proficiency deed is still locked. */
 export interface GatheringProficiencyRow {
   professionId: GatheringProfessionId;
   value: number;
+  displayValue: number;
 }
 
 /** Builds the proficiency display rows from IWorldProfessions#professionsState,
@@ -156,6 +162,6 @@ export function buildGatheringProficiencyRows(world: IWorld): GatheringProficien
   return GATHERING_PROFESSION_IDS.map((professionId) => {
     const raw = bySkill.get(professionId);
     const value = typeof raw === 'number' && Number.isFinite(raw) ? Math.max(0, raw) : 0;
-    return { professionId, value };
+    return { professionId, value, displayValue: Math.floor(value) };
   });
 }

--- a/tests/char_window.test.ts
+++ b/tests/char_window.test.ts
@@ -174,6 +174,73 @@ describe('char_window: profession art placements', () => {
     expect(root.querySelector('.char-archetype-title-crest')).toBeNull();
     expect(root.innerHTML).not.toContain('/ui/professions/archetype_bombardier.webp');
   });
+
+  it('floors a fractional gathering proficiency in the rendered row (issue 2339)', () => {
+    // The sheet must never claim an uncrossed threshold: the deed evaluator
+    // and the band ladder compare the raw value with >=, so 99.5 renders 99
+    // (the professions-window floor convention), never a rounded 100.
+    let canvasContext: unknown;
+    canvasContext = new Proxy(
+      {},
+      {
+        get: () => () => canvasContext,
+        set: () => true,
+      },
+    );
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(canvasContext as never);
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue(
+      'data:image/png;base64,stub',
+    );
+    const root = document.createElement('div');
+    const world = {
+      cfg: { playerClass: 'warrior' },
+      player: { name: 'Aurelia', level: 60, skin: 0 },
+      equipment: {},
+      honor: 0,
+      archetypeTitle: null,
+      hobbyCraft: 'jewelcrafting',
+      professionsState: {
+        skills: [
+          { professionId: 'mining', skill: 99.75, maxSkill: 100 },
+          { professionId: 'logging', skill: 12, maxSkill: 100 },
+          { professionId: 'herbalism', skill: 100, maxSkill: 100 },
+          { professionId: 'fishing', skill: 99.5, maxSkill: 200 },
+        ],
+      },
+    };
+    const win = new CharWindow({
+      root: () => root,
+      world: () => world as never,
+      closeOthers: vi.fn(),
+      hideTooltip: vi.fn(),
+      captureFocus: () => null,
+      restoreFocus: vi.fn(),
+      slotName: (slot) => slot,
+      statCellHtml: () => '',
+      statTooltipHtml: () => '',
+      talentSummaryHtml: () => '',
+      progressionHtml: () => '',
+      unequip: vi.fn(),
+      beginUnequipDrag: vi.fn(),
+      endUnequipDrag: vi.fn(),
+      renderPreview: vi.fn(),
+      renderSkinPicker: vi.fn(),
+      openPlayerCard: vi.fn(),
+      openPrestige: vi.fn(),
+      openDeeds: vi.fn(),
+      dragState: new ItemDragState(),
+      renderBags: vi.fn(),
+      showError: vi.fn(),
+      itemIcon: () => '',
+      moneyHtml: () => '',
+      itemTooltip: () => '',
+      attachTooltip: vi.fn(),
+    });
+
+    win.render();
+    const values = [...root.querySelectorAll('.char-gather-row b')].map((b) => b.textContent);
+    expect(values).toEqual(['99', '12', '100', '99']);
+  });
 });
 
 describe('char_window: paperdoll core + HUD-owned preview boundary', () => {

--- a/tests/gathering_view.test.ts
+++ b/tests/gathering_view.test.ts
@@ -192,11 +192,27 @@ describe('buildGatheringProficiencyRows', () => {
     const world = makeWorld({ proficiency: { mining: 12, logging: 4, herbalism: 0 } });
     const rows = buildGatheringProficiencyRows(world);
     expect(rows).toEqual([
-      { professionId: 'mining', value: 12 },
-      { professionId: 'logging', value: 4 },
-      { professionId: 'herbalism', value: 0 },
-      { professionId: 'fishing', value: 0 },
+      { professionId: 'mining', value: 12, displayValue: 12 },
+      { professionId: 'logging', value: 4, displayValue: 4 },
+      { professionId: 'herbalism', value: 0, displayValue: 0 },
+      { professionId: 'fishing', value: 0, displayValue: 0 },
     ]);
+  });
+
+  it('display-floors a fractional proficiency, never rounding a threshold forward', () => {
+    // The character sheet must never read "100" while the raw value (which
+    // the deed evaluator and the band ladder compare with >=) is still 99.5
+    // (issue 2339, the Old Salt strand): the readout floors, the buildSkillBar
+    // convention, while `value` keeps the exact fraction for the repaint
+    // signature.
+    const world = makeWorld({ proficiency: { mining: 99.75, fishing: 99.5 } });
+    const rows = buildGatheringProficiencyRows(world);
+    const fishing = rows.find((r) => r.professionId === 'fishing');
+    expect(fishing?.value).toBe(99.5);
+    expect(fishing?.displayValue).toBe(99);
+    const mining = rows.find((r) => r.professionId === 'mining');
+    expect(mining?.value).toBe(99.75);
+    expect(mining?.displayValue).toBe(99);
   });
 
   it('defaults an absent or malformed entry to 0, never throwing', () => {

--- a/tests/mastery_reset_rehearsal.test.ts
+++ b/tests/mastery_reset_rehearsal.test.ts
@@ -14,12 +14,15 @@
 // forced true (the no-reset baseline). Baseline vs actual isolates EXACTLY
 // the reset's effect; input vs actual is then classified row by row against
 // the documented allowlist (two maps zeroed, legacy professions mirror
-// zeroed, flag added true, load-time cap clamps on the two maps) plus the
+// zeroed, flags added true, load-time cap clamps on the two maps, the
+// one-time proficiency display heal of issue 2339) plus the
 // default fills the no-reset baseline also produces. Anything else fails
 // with a printed per-key diff.
 import fs from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { CRAFT_RING, GATHERING_PROFESSIONS } from '../src/sim/content/professions';
+import { PROFICIENCY_BAND_THRESHOLDS } from '../src/sim/professions/proficiency_bands';
+import { DISPLAY_HEAL_BAND } from '../src/sim/professions/proficiency_display_heal';
 import { type CharacterState, Sim } from '../src/sim/sim';
 
 type Blob = Record<string, unknown>;
@@ -88,6 +91,19 @@ function capFor(path: string): number | null {
   return null;
 }
 
+// The one-time proficiency display heal (issue 2339): a gathering leaf inside
+// the half-point display band below a band threshold bumps to that threshold
+// on load, once per character (proficiencyDisplayHealApplied). A documented
+// deploy delta on any blob saved before the heal shipped.
+function isDisplayHealDelta(before: unknown, after: unknown): boolean {
+  if (typeof before !== 'number' || typeof after !== 'number') return false;
+  return (
+    PROFICIENCY_BAND_THRESHOLDS.some((t) => t !== 0 && after === t) &&
+    before >= after - DISPLAY_HEAL_BAND &&
+    before < after
+  );
+}
+
 interface RehearsalResult {
   applied: boolean;
   violations: string[];
@@ -134,13 +150,23 @@ function rehearse(state: CharacterState, seed: number, playerClass = 'warrior'):
   };
   flatten(baseline, '');
   for (const row of deployDelta) {
-    if (row.path === 'masteryResetApplied' && row.before === undefined && row.after === true) {
-      continue; // the flag lands true
+    if (
+      (row.path === 'masteryResetApplied' || row.path === 'proficiencyDisplayHealApplied') &&
+      row.before === undefined &&
+      row.after === true
+    ) {
+      continue; // the one-time flags land true
     }
     const root = skillMapRoot(row.path);
     if (root !== null && !wasApplied && row.after === 0) continue; // zeroed by the reset
     if (root !== null && typeof row.before === 'number' && row.after === capFor(row.path)) {
       continue; // the documented load-time cap clamp
+    }
+    if (
+      (root === 'gatheringProficiency' || root === 'professions') &&
+      isDisplayHealDelta(row.before, row.after)
+    ) {
+      continue; // the one-time display heal (issue 2339)
     }
     if (
       row.before === undefined &&

--- a/tests/mastery_reset_rehearsal.test.ts
+++ b/tests/mastery_reset_rehearsal.test.ts
@@ -94,11 +94,16 @@ function capFor(path: string): number | null {
 // The one-time proficiency display heal (issue 2339): a gathering leaf inside
 // the half-point display band below a band threshold bumps to that threshold
 // on load, once per character (proficiencyDisplayHealApplied). A documented
-// deploy delta on any blob saved before the heal shipped.
-function isDisplayHealDelta(before: unknown, after: unknown): boolean {
+// deploy delta on any blob saved before the heal shipped. Cap-bounded like
+// the production guard: a threshold above the profession's maxSkill never
+// classifies, so the classifier stays exactly as strict as the heal even if
+// pointed at un-normalized rows.
+function isDisplayHealDelta(path: string, before: unknown, after: unknown): boolean {
   if (typeof before !== 'number' || typeof after !== 'number') return false;
+  const cap = capFor(path);
   return (
     PROFICIENCY_BAND_THRESHOLDS.some((t) => t !== 0 && after === t) &&
+    (cap === null || after <= cap) &&
     before >= after - DISPLAY_HEAL_BAND &&
     before < after
   );
@@ -164,7 +169,7 @@ function rehearse(state: CharacterState, seed: number, playerClass = 'warrior'):
     }
     if (
       (root === 'gatheringProficiency' || root === 'professions') &&
-      isDisplayHealDelta(row.before, row.after)
+      isDisplayHealDelta(row.path, row.before, row.after)
     ) {
       continue; // the one-time display heal (issue 2339)
     }
@@ -279,6 +284,31 @@ function buildCorpus(): { id: string; state: CharacterState }[] {
   const overCapApplied = clone(overCap) as Blob;
   overCapApplied.masteryResetApplied = true;
 
+  // A stranded display-band row (issue 2339): the reset long applied, the
+  // heal flag absent, fishing parked at 99.5 (the value the pre-fix sheet
+  // read as "100"). Stabilized first so its deeds/renown already match a
+  // character that once stood at the healed value, then the strand and the
+  // missing flag re-imposed, so the sweep must classify exactly the heal
+  // bump (99.5 to 100 on both gathering keys) plus the flag rows; this is
+  // the row that keeps the isDisplayHealDelta allowlist arm live.
+  const strandedBase = stabilize(
+    (() => {
+      const b = clone(modern) as Blob;
+      (b.gatheringProficiency as Record<string, number>).fishing = 99.5;
+      (b.professions as Record<string, number>).fishing = 99.5;
+      // Absent during stabilization so the heal fires there: the stabilized
+      // deeds/renown then include prog_fishing_100, the state a real
+      // stranded character reaches on its first post-fix login.
+      delete b.proficiencyDisplayHealApplied;
+      return b as unknown as CharacterState;
+    })(),
+    52,
+  );
+  const stranded = clone(strandedBase) as Blob;
+  (stranded.gatheringProficiency as Record<string, number>).fishing = 99.5;
+  (stranded.professions as Record<string, number>).fishing = 99.5;
+  delete stranded.proficiencyDisplayHealApplied;
+
   // A sparse pre-12b row. Its deeds carry the grants a real character with
   // these skills already received the first time it logged in after the Book
   // of Deeds shipped (the skill-proof retro inferences), so the reset cannot
@@ -307,6 +337,7 @@ function buildCorpus(): { id: string; state: CharacterState }[] {
     { id: 'over-cap-already-applied', state: overCapApplied as unknown as CharacterState },
     { id: 'minimal-fresh-shape', state: minimal },
     { id: 'already-applied', state: modernApplied as unknown as CharacterState },
+    { id: 'stranded-display-band', state: stranded as unknown as CharacterState },
   ];
 }
 
@@ -325,6 +356,7 @@ describe('mastery reset rehearsal (the committed synthetic corpus)', () => {
     expect(byId.get('minimal-fresh-shape')?.applied).toBe(true);
     expect(byId.get('over-cap-already-applied')?.applied).toBe(false);
     expect(byId.get('already-applied')?.applied).toBe(false);
+    expect(byId.get('stranded-display-band')?.applied).toBe(false);
   });
 });
 

--- a/tests/profession_surface_refresh.test.ts
+++ b/tests/profession_surface_refresh.test.ts
@@ -29,6 +29,7 @@ function gathering(values: Partial<Record<string, number>> = {}): GatheringProfi
   return GATHERING_PROFESSION_IDS.map((professionId) => ({
     professionId,
     value: values[professionId] ?? 0,
+    displayValue: Math.floor(values[professionId] ?? 0),
   }));
 }
 

--- a/tests/professions_mastery_reset.test.ts
+++ b/tests/professions_mastery_reset.test.ts
@@ -450,11 +450,14 @@ describe('re-crossing the 75/100 thresholds after the reset', () => {
 });
 
 describe('parity: zero new sampled PlayerMeta fields', () => {
-  it('samplePlayerMeta(fresh meta) contains neither reset key', () => {
+  it('samplePlayerMeta(fresh meta) contains no one-time load-flag key', () => {
     const sim = makeSim();
     const pid = sim.addPlayer('warrior', 'Sampled');
     const sample = samplePlayerMeta(metaOf(sim, pid)) as Record<string, unknown>;
     expect(Object.keys(sample)).not.toContain('pendingMasteryResetNotice');
     expect(Object.keys(sample)).not.toContain('masteryResetApplied');
+    // The proficiency display heal (issue 2339) follows the same contract:
+    // CharacterState-only, serialized as literal true, no PlayerMeta mirror.
+    expect(Object.keys(sample)).not.toContain('proficiencyDisplayHealApplied');
   });
 });

--- a/tests/proficiency_display_heal.test.ts
+++ b/tests/proficiency_display_heal.test.ts
@@ -1,0 +1,178 @@
+// The one-time gathering-proficiency display heal (issue 2339): the pre-fix
+// character sheet rounded its Gathering rows half-up while the deed evaluator
+// and the band ladder compare the raw value with >=, so a raw 99.5 read
+// "Fishing: 100" with Old Salt still locked. The heal bumps exactly the
+// display band [threshold - 0.5, threshold) to the threshold on load, once
+// per character (CharacterState.proficiencyDisplayHealApplied, the
+// masteryResetApplied idiom), and the join-time retro pass then grants the
+// stranded deeds silently.
+import { describe, expect, it } from 'vitest';
+import { DEEDS } from '../src/sim/content/deeds';
+import { emptyGatheringProficiency } from '../src/sim/professions/gathering';
+import {
+  DISPLAY_HEAL_BAND,
+  healDisplayRoundedProficiency,
+} from '../src/sim/professions/proficiency_display_heal';
+import { type CharacterState, Sim } from '../src/sim/sim';
+import type { SimEvent } from '../src/sim/types';
+
+function makeSim(seed = 42): Sim {
+  return new Sim({ seed, playerClass: 'warrior', autoEquip: false });
+}
+
+function deedEvents(evs: SimEvent[]): Extract<SimEvent, { type: 'deedUnlocked' }>[] {
+  return evs.filter((ev): ev is Extract<SimEvent, { type: 'deedUnlocked' }> => {
+    return ev.type === 'deedUnlocked';
+  });
+}
+
+// A pre-fix save in the stranded display band: the old sheet read both rows
+// as "100" while the raw values were still below the deed threshold.
+function strandedState(): CharacterState {
+  return {
+    level: 12,
+    xp: 0,
+    copper: 0,
+    hp: 100,
+    resource: 0,
+    pos: { x: 2, z: -2 },
+    facing: 0,
+    equipment: {},
+    inventory: [],
+    questLog: [],
+    questsDone: [],
+    gatheringProficiency: { fishing: 99.5, mining: 99.75 },
+    // A curve-era blob (Professions 2.0): without this flag the one-time
+    // mastery reset zeroes the skill maps at load, BEFORE the heal and the
+    // retro sweep run (the tests/deeds.test.ts veteranState precedent).
+    masteryResetApplied: true,
+  };
+}
+
+describe('healDisplayRoundedProficiency', () => {
+  it('pins the display band to half a point, the Intl round-half-up width', () => {
+    // The pre-fix sheet (formatNumber, maximumFractionDigits 0) showed a
+    // threshold for any raw value at or above threshold - 0.5; the heal band
+    // must match that display band exactly, no wider.
+    expect(DISPLAY_HEAL_BAND).toBe(0.5);
+  });
+
+  it('bumps a value the old sheet displayed as a crossed threshold', () => {
+    const prof = emptyGatheringProficiency();
+    prof.fishing = 99.5;
+    prof.mining = 99.75;
+    expect(healDisplayRoundedProficiency(prof)).toBe(true);
+    expect(prof.fishing).toBe(100);
+    expect(prof.mining).toBe(100);
+  });
+
+  it('leaves values below the display band and exact thresholds alone', () => {
+    const prof = emptyGatheringProficiency();
+    prof.fishing = 99.25; // displayed 99: the sheet never claimed the crossing
+    prof.mining = 100; // already exactly at the threshold
+    prof.logging = 42.5; // fractional, but no band threshold within half a point
+    expect(healDisplayRoundedProficiency(prof)).toBe(false);
+    expect(prof.fishing).toBe(99.25);
+    expect(prof.mining).toBe(100);
+    expect(prof.logging).toBe(42.5);
+  });
+
+  it('heals the fishing 200 band edge, including the float-drift tail', () => {
+    const prof = emptyGatheringProficiency();
+    prof.fishing = 199.99; // the 0.02-per-catch climb, displayed as 200
+    expect(healDisplayRoundedProficiency(prof)).toBe(true);
+    expect(prof.fishing).toBe(200);
+  });
+
+  it('ignores the mid-band gain-schedule breakpoint: 150 is not a threshold', () => {
+    // 150 halves the fishing gain but nothing reads it with >=: a 149.5
+    // displayed "150" claimed nothing a deed or band grants, so no heal.
+    const prof = emptyGatheringProficiency();
+    prof.fishing = 149.5;
+    expect(healDisplayRoundedProficiency(prof)).toBe(false);
+    expect(prof.fishing).toBe(149.5);
+  });
+
+  it('never heals past a profession cap, even on a malformed over-cap record', () => {
+    // Load normalize clamps over-cap values before the heal ever runs; the
+    // pure function still refuses the 200 threshold for a 100-cap profession
+    // so a malformed record can never be healed ABOVE its cap.
+    const prof = emptyGatheringProficiency();
+    prof.mining = 199.6;
+    expect(healDisplayRoundedProficiency(prof)).toBe(false);
+    expect(prof.mining).toBe(199.6);
+  });
+});
+
+describe('the one-time heal on load', () => {
+  it('heals a pre-fix save and grants the stranded deeds on the same join', () => {
+    const sim = makeSim();
+    const pid = sim.addPlayer('warrior', 'Stranded', { state: strandedState() });
+    const meta = sim.players.get(pid)!;
+    expect(meta.gatheringProficiency.fishing).toBe(100);
+    expect(meta.gatheringProficiency.mining).toBe(100);
+    expect(meta.deedsEarned.has('prog_fishing_100')).toBe(true);
+    expect(meta.deedsEarned.has('prog_mining_100')).toBe(true);
+    expect(meta.deedsEarned.has('prog_master_angler')).toBe(false); // 100 < 200
+    // Renown accounting stays exact: the running total equals the catalog
+    // sum over the earned set, Old Salt's 10 included.
+    const catalogSum = [...meta.deedsEarned.keys()].reduce((n, id) => n + DEEDS[id].renown, 0);
+    expect(meta.renown).toBe(catalogSum);
+    expect(DEEDS.prog_fishing_100.renown).toBe(10);
+    // The join events drain retro-flagged on the next tick: the silent Book
+    // summary, never the live unlock banner.
+    const evs = deedEvents(sim.tick());
+    const oldSalt = evs.find((ev) => ev.deedId === 'prog_fishing_100');
+    expect(oldSalt?.retro).toBe(true);
+    expect(oldSalt?.pid).toBe(pid);
+  });
+
+  it('serializes the heal flag as literal true with the healed values', () => {
+    const sim = makeSim();
+    const pid = sim.addPlayer('warrior', 'Stranded', { state: strandedState() });
+    const saved = sim.serializeCharacter(pid);
+    expect(saved?.proficiencyDisplayHealApplied).toBe(true);
+    expect(saved?.gatheringProficiency?.fishing).toBe(100);
+    expect(saved?.gatheringProficiency?.mining).toBe(100);
+  });
+
+  it('never re-heals a post-fix save: 99.5 under the floored display stays 99.5', () => {
+    const sim = makeSim();
+    const pid = sim.addPlayer('warrior', 'Honest', {
+      state: { ...strandedState(), proficiencyDisplayHealApplied: true },
+    });
+    const meta = sim.players.get(pid)!;
+    expect(meta.gatheringProficiency.fishing).toBe(99.5);
+    expect(meta.gatheringProficiency.mining).toBe(99.75);
+    expect(meta.deedsEarned.has('prog_fishing_100')).toBe(false);
+    expect(meta.deedsEarned.has('prog_mining_100')).toBe(false);
+  });
+
+  it('a raw value at or past the threshold grants on join with or without the heal', () => {
+    // The granting-path acceptance check from issue 2339: the join retro
+    // pass compares the raw value with >=, so a genuine 100+ earns Old Salt
+    // at the next login regardless of the heal branch.
+    const sim = makeSim();
+    const pid = sim.addPlayer('warrior', 'Veteran', {
+      state: {
+        ...strandedState(),
+        gatheringProficiency: { fishing: 123.4 },
+        proficiencyDisplayHealApplied: true,
+      },
+    });
+    const meta = sim.players.get(pid)!;
+    expect(meta.gatheringProficiency.fishing).toBe(123.4);
+    expect(meta.deedsEarned.has('prog_fishing_100')).toBe(true);
+  });
+
+  it('heals the 200 band edge to the cap and grants both fishing deeds', () => {
+    const sim = makeSim();
+    const pid = sim.addPlayer('warrior', 'Angler', {
+      state: { ...strandedState(), gatheringProficiency: { fishing: 199.5 } },
+    });
+    const meta = sim.players.get(pid)!;
+    expect(meta.gatheringProficiency.fishing).toBe(200);
+    expect(meta.deedsEarned.has('prog_fishing_100')).toBe(true);
+    expect(meta.deedsEarned.has('prog_master_angler')).toBe(true);
+  });
+});

--- a/tests/proficiency_display_heal.test.ts
+++ b/tests/proficiency_display_heal.test.ts
@@ -77,6 +77,17 @@ describe('healDisplayRoundedProficiency', () => {
     expect(prof.logging).toBe(42.5);
   });
 
+  it('heals every gathering profession: the logging and herbalism edges too', () => {
+    // The loop covers all four professions, never just the two the issue
+    // named: a regression narrowing it to mining/fishing must red here.
+    const prof = emptyGatheringProficiency();
+    prof.logging = 99.5;
+    prof.herbalism = 99.75;
+    expect(healDisplayRoundedProficiency(prof)).toBe(true);
+    expect(prof.logging).toBe(100);
+    expect(prof.herbalism).toBe(100);
+  });
+
   it('heals the fishing 200 band edge, including the float-drift tail', () => {
     const prof = emptyGatheringProficiency();
     prof.fishing = 199.99; // the 0.02-per-catch climb, displayed as 200
@@ -174,5 +185,32 @@ describe('the one-time heal on load', () => {
     expect(meta.gatheringProficiency.fishing).toBe(200);
     expect(meta.deedsEarned.has('prog_fishing_100')).toBe(true);
     expect(meta.deedsEarned.has('prog_master_angler')).toBe(true);
+  });
+
+  it('a pre-curve save (neither flag) is zeroed by the reset, never healed or granted', () => {
+    // The load-order invariant: the mastery reset runs BEFORE the heal, so
+    // the heal must not resurrect a value the curve migration wipes.
+    const state = strandedState();
+    delete state.masteryResetApplied;
+    const sim = makeSim();
+    const pid = sim.addPlayer('warrior', 'PreCurve', { state });
+    const meta = sim.players.get(pid)!;
+    expect(meta.gatheringProficiency.fishing).toBe(0);
+    expect(meta.gatheringProficiency.mining).toBe(0);
+    expect(meta.deedsEarned.has('prog_fishing_100')).toBe(false);
+    expect(meta.deedsEarned.has('prog_mining_100')).toBe(false);
+  });
+
+  it('heals a legacy professions-key-only save shape', () => {
+    // Old blobs carry only the pre-rename `professions` key; the load
+    // normalize folds it into gatheringProficiency BEFORE the heal runs.
+    const state = strandedState();
+    delete state.gatheringProficiency;
+    state.professions = { fishing: 99.5 };
+    const sim = makeSim();
+    const pid = sim.addPlayer('warrior', 'Legacy', { state });
+    const meta = sim.players.get(pid)!;
+    expect(meta.gatheringProficiency.fishing).toBe(100);
+    expect(meta.deedsEarned.has('prog_fishing_100')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the Old Salt strand: the character sheet's Gathering rows rounded the raw proficiency half-up while the deed evaluator and the proficiency band ladder compare the raw value with `>=`. A raw fishing value of 99.5 rendered as "Fishing: 100" with Old Salt (Reach 100 Fishing) still locked, so players took the readout at its word, stopped fishing, and stayed stranded half a point short of the deed.

Two parts:

1. **Display honesty.** `buildGatheringProficiencyRows` (the pure core behind the character sheet's Gathering section) now returns a floored `displayValue` alongside the raw `value`, and the char window renders that, matching the floor convention the Professions window already uses (`buildSkillBar`). The sheet can no longer claim an uncrossed threshold; the raw value stays on the row for the repaint signature, so repaint granularity is unchanged.

2. **A one-time heal for already-stranded characters.** Saves written before this fix get a load-time heal (`proficiencyDisplayHealApplied`, following the `masteryResetApplied` one-time-flag idiom): any gathering proficiency inside the half-point display band below a band threshold (`[99.5, 100)` and `[199.5, 200)`, exactly the values the old sheet displayed as that threshold) bumps to the threshold, capped at the profession's `maxSkill`. The existing join-time deed retro pass then grants the stranded deeds silently (`retro: true`, the Book summary, no banner), the renown lands, and the server-side `character_deeds` reconcile and Steam mirror pick it up through their existing idempotent replay. So everyone who already "reached 100 Fishing" per their character sheet receives Old Salt on their next login, and their sheet keeps reading 100 (now truthfully). The same heal covers the mining/logging/herbalism 100 deeds and Master Angler at 200.

Post-fix characters are never healed: the flag serializes as literal true, and under the floored display a live 99.5 correctly reads 99 and earns the deed on the catch that crosses 100 (below 100 the gain steps are 1 and 0.5, so the raw value lands on exactly 100).

The granting path itself was verified sound end to end (drain marks the deed sweep, `>=` comparison, full retro evaluation on every join across all three hosts), and the acceptance test pins that a raw value at or past the threshold grants on join with or without the heal.

### Who is covered, and when

- **Raw proficiency at or past 100 (say, a true 102):** already covered by the existing join-time retro pass in the deployed build; such a character receives Old Salt at their next login even without this PR. The new test pins that case (a save at fishing 123.4 earns the deed on join with the heal flag already set), so the PR proves that path rather than assuming it. Characters that already hold the deed are untouched: grants are idempotent and deeds never re-fire.
- **Raw proficiency in [99.5, 100), the stranded band:** covered by this PR's heal. The old sheet told these players they were at 100, so they stopped one catch short and no login could ever grant them the deed. On their first post-deploy login they heal to a true 100 and earn Old Salt with its 10 Renown in that same join.
- **Post-fix characters:** never healed (the flag serializes as literal true); under the floored display a live 99.5 reads 99 and earns the deed on the catch that crosses 100 (below 100 the gain steps are 1 and 0.5, so the raw value lands on exactly 100).

### Why the Book shows "0% of players" for Old Salt

Investigated alongside the fix because it looks alarming next to an earned deed: the rarity line is `earned / totalEligible` from the `character_deeds` aggregate (every level 5+ character with a finished save on a non-banned account, cross-realm, no activity window; served through a 5-minute TTL cache) and renders with at most one decimal place, so any deed held by fewer than 0.05% of eligible characters truthfully displays "0%". Old Salt shipped on 2026-07-22 and this very bug stranded nearly everyone who "finished" fishing at raw 99.5, so its earner count is genuinely near zero; the handful of players who fished past the phantom cap ARE counted (live grants mirror into `character_deeds` at grant time, retro grants replay at every join). No rarity-side change is needed: the percentage climbs on its own after deploy as stranded players log in, earn, and get counted. If a flat "0%" on ultra-rare deeds ever feels wrong, a "<0.1%" floor on the rarity line is a one-line cosmetic follow-up, deliberately not part of this PR.

## Related issues

Closes #2339

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npm run gate` (full pre-merge gate, green)
  - `npx vitest run tests/proficiency_display_heal.test.ts` (new: heal module contract + Sim load integration: heal, flag round-trip, retro-flagged deed grants, exact renown accounting, never-re-heal negative, raw-past-threshold acceptance case)
  - `npx vitest run tests/gathering_view.test.ts tests/char_window.test.ts tests/profession_surface_refresh.test.ts` (display floor pinned in the pure core and in the rendered jsdom row)
  - `npx vitest run tests/mastery_reset_rehearsal.test.ts tests/professions_mastery_reset.test.ts tests/deeds.test.ts tests/deeds_content.test.ts tests/deeds_reconcile.test.ts tests/professions_gathering.test.ts tests/professions_skill_caps.test.ts tests/professions_fishing.test.ts tests/parity` (blast radius, all green; the blob-diff rehearsal allowlist learned the two documented deltas: the new one-time flag and the display-heal bump)
- Manual steps: verified the deed catalog untouched (no trigger edits, design rule 9) and that the heal band matches the Intl round-half-up display band exactly.

## Screenshots / recordings

The only visual delta is the Gathering row number itself: a raw 99.5 that used to render "Fishing: 100" now renders "Fishing: 99" until the raw value truly crosses 100 (pre-fix strands instead keep reading 100 because the heal lifts them to a true 100).

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no layout, control, or style change; one number in an existing row renders through the same markup.
- ~Accessible.~ N/A: no new or edited UI surface.

### Localization (i18n)

- [x] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
