### PR TITLE
fix(vendor): sell-quantity dialog cap the clicked slot, not total held

### DIFF
--- a/src/ui/bags_window.ts
+++ b/src/ui/bags_window.ts
@@ -64,6 +64,7 @@ import { MASTERWORK_SEAL_IMAGE_URL } from './profession_art';
 import { tSim } from './sim_i18n';
 import { bindTouchItemDrag } from './touch_item_drag';
 import { svgIcon, type UiIconName } from './ui_icons';
+import { totalHeldCount } from './vendor_sell_quantity';
 import { dropOnWorld } from './world_drop_target';
 
 const BAG_FILTER_KEY = 'woc_bag_filter';
@@ -1043,7 +1044,11 @@ export class BagsWindow {
     if (ev.ctrlKey || ev.metaKey) {
       this.deps.world().sellItem(slot.itemId, count);
     } else if (ev.shiftKey && count > 1) {
-      this.showSellQuantityPrompt(slot.itemId, count);
+      // The prompt's cap is every copy of this item across the whole bag, not just
+      // the ONE slot that was clicked: a stackable item's per-slot count tops out at
+      // its stackSize (commonly 20), so a player holding more sits in other slots.
+      const heldTotal = Math.max(count, totalHeldCount(this.deps.world().inventory, slot.itemId));
+      this.showSellQuantityPrompt(slot.itemId, heldTotal);
     } else {
       this.deps.world().sellItem(slot.itemId);
     }

--- a/src/ui/vendor_sell_quantity.ts
+++ b/src/ui/vendor_sell_quantity.ts
@@ -1,0 +1,18 @@
+import type { InvSlot } from '../sim/types';
+
+/** Total copies of `itemId` held across every bag slot, not just the ONE slot the
+ *  player shift-clicked. A stackable item's per-slot count is capped at its
+ *  `stackSize` (commonly 20, see `sim/bags.ts` `stackSizeOf`), so a player holding
+ *  more than one stack has the rest sitting in other slots. The sell-quantity
+ *  prompt's cap must be the total held, or a custom amount above one slot's stack
+ *  size (e.g. 100 when the player owns five stacks of 20) silently clamps down to
+ *  whatever the clicked slot alone holds, never reaching what was actually typed.
+ *  `Sim.sellItem` already walks every unbound stack (`removePreferFungible`) once
+ *  asked for more than one slot's worth; only the UI-side cap was wrong. */
+export function totalHeldCount(inventory: readonly InvSlot[], itemId: string): number {
+  let total = 0;
+  for (const slot of inventory) {
+    if (slot.itemId === itemId) total += slot.count;
+  }
+  return total;
+}

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -1490,6 +1490,24 @@ describe('food, drink, vendor', () => {
     expect(sim.countItem('wolf_fang')).toBe(0);
   });
 
+  // Regression: "Sell amount to NPC" (Discord #bug-reports, Corotexus). A custom
+  // amount typed into the sell-quantity dialog above one stack's size (wolf_fang
+  // has no explicit stackSize, so it defaults to 20, see sim/bags.ts stackSizeOf)
+  // must sell the FULL amount by pulling from every stack the player holds, not
+  // silently cap at one stack's worth.
+  it('vendor sells a custom amount greater than one stack size, drawing from every stack', () => {
+    const sim = makeSim('warrior');
+    const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    teleportTo(sim, wilkes.pos.x + 2, wilkes.pos.z);
+    sim.addItem('wolf_fang', 100); // spread across five 20-stacks
+    expect(sim.inventory.filter((s) => s.itemId === 'wolf_fang')).toHaveLength(5);
+
+    sim.sellItem('wolf_fang', 100);
+
+    expect(sim.copper).toBe(400);
+    expect(sim.countItem('wolf_fang')).toBe(0);
+  });
+
   it('vendor ignores invalid sell quantities', () => {
     const sim = makeSim('warrior');
     const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;

--- a/tests/vendor_sell_quantity.test.ts
+++ b/tests/vendor_sell_quantity.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import type { InvSlot } from '../src/sim/types';
+import { totalHeldCount } from '../src/ui/vendor_sell_quantity';
+
+// Regression for the "sell amount to NPC" bug (Discord #bug-reports, Corotexus):
+// shift+click/shift+i on a stackable item opens a sell-amount dialog whose cap was
+// the SINGLE clicked slot's count (a stack, capped at its stackSize, commonly 20),
+// not the total the player actually holds across every bag slot. Typing a custom
+// amount above one stack's worth (e.g. 100 while holding five 20-stacks) silently
+// clamped down to 20, so only 20 or the full clicked stack ever sold.
+describe('totalHeldCount', () => {
+  it('sums an item across every bag slot, not just one', () => {
+    const inventory: InvSlot[] = [
+      { itemId: 'wolf_fang', count: 20 },
+      { itemId: 'apprentice_staff', count: 1 },
+      { itemId: 'wolf_fang', count: 20 },
+      { itemId: 'wolf_fang', count: 20 },
+      { itemId: 'wolf_fang', count: 20 },
+      { itemId: 'wolf_fang', count: 20 },
+    ];
+    // 5 stacks of 20 = 100 held, well past what any single slot alone reports.
+    expect(totalHeldCount(inventory, 'wolf_fang')).toBe(100);
+  });
+
+  it('returns 0 for an item the player does not hold', () => {
+    const inventory: InvSlot[] = [{ itemId: 'wolf_fang', count: 20 }];
+    expect(totalHeldCount(inventory, 'apprentice_staff')).toBe(0);
+  });
+
+  it('matches a single slot when only one stack exists', () => {
+    const inventory: InvSlot[] = [{ itemId: 'wolf_fang', count: 7 }];
+    expect(totalHeldCount(inventory, 'wolf_fang')).toBe(7);
+  });
+});
+
+// Source-level pin: the sell-quantity prompt's cap must come from totalHeldCount
+// across the whole bag, never the clicked slot's count alone.
+describe('bags_window: sell-quantity prompt cap uses total held, not one slot', () => {
+  const painter = readFileSync(new URL('../src/ui/bags_window.ts', import.meta.url), 'utf8');
+
+  it('imports totalHeldCount from vendor_sell_quantity', () => {
+    expect(painter).toContain("import { totalHeldCount } from './vendor_sell_quantity';");
+  });
+
+  it('passes the total-held cap, not slot.count, into showSellQuantityPrompt', () => {
+    expect(painter).toContain(
+      'const heldTotal = Math.max(count, totalHeldCount(this.deps.world().inventory, slot.itemId));',
+    );
+    expect(painter).toContain('this.showSellQuantityPrompt(slot.itemId, heldTotal);');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes "Sell amount to NPC" (reported in Discord #bug-reports by Corotexus,
confirmed by Fernando): shift+click (or shift+i) on a stackable item at a
vendor opens a sell-amount dialog, but typing a custom amount above 20
(e.g. 100) silently sold only 20, or the clicked stack's full amount,
never the typed number.

**Root cause:** the sell-quantity prompt's max/cap came from the count of
the ONE bag slot the player clicked (`slot.count`), not the total copies
of that item held across every bag slot. A stackable item's per-slot
count tops out at its `stackSize` (defaults to 20, see
`src/sim/bags.ts` `stackSizeOf`), so a player holding more than one
stack (e.g. five 20-stacks of a reagent = 100 total) had the rest
sitting in other slots the dialog never accounted for. The number
input's `max` attribute (and the confirm handler's own clamp) capped
at that one slot, so a typed 100 silently came back as 20.

The sim side (`Sim.sellItem` / `items.ts sellItem`) was already correct:
it draws from every unbound stack via `removePreferFungible` and clamps
only to what the player actually has, so a large custom count already
worked end to end once it reached the sim. Only the UI-side cap was wrong.

**Fix:** added a small pure helper, `totalHeldCount` in
`src/ui/vendor_sell_quantity.ts`, that sums an item's count across the
whole inventory array. `bags_window.ts`'s `sellBagItem` now passes that
total (not the clicked slot's count) as the sell-quantity prompt's cap.

```mermaid
sequenceDiagram
    participant Player
    participant Dialog as Sell-amount dialog (bags_window.ts)
    participant Helper as totalHeldCount (vendor_sell_quantity.ts)
    participant Sim as Sim.sellItem (items.ts)
    participant Vendor as NPC vendor

    Player->>Dialog: shift+click stackable item (5x 20-stacks held)
    Dialog->>Helper: totalHeldCount(inventory, itemId)
    Helper-->>Dialog: 100 (sum across every slot, not just the clicked one)
    Dialog->>Dialog: input max = 100 (was: clicked slot's count, e.g. 20)
    Player->>Dialog: types "100", confirms
    Dialog->>Sim: world().sellItem(itemId, 100)
    Sim->>Sim: clamp to available, walk every unbound stack (removePreferFungible)
    Sim->>Vendor: sell 100 copies
    Sim-->>Player: copper credited, all 5 stacks emptied
```

## Related issues

Reported in Discord #bug-reports by Corotexus, confirmed by Fernando.
No GitHub issue number was filed for this report.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npx tsc --noEmit`
  - `npx vitest run tests/vendor_sell_quantity.test.ts tests/sim.test.ts`
  - `npm run gate` (green: i18n freshness, malware scan, changed-files biome,
    SFX check, full test suite, tsc, all builds)
- New tests:
  - `tests/vendor_sell_quantity.test.ts`: unit-tests `totalHeldCount` (sums
    across multiple slots, returns 0 for an unheld item, matches a single
    slot) plus source-level pins that `bags_window.ts` wires the total-held
    cap into the sell-quantity prompt.
  - `tests/sim.test.ts`: `vendor sells a custom amount greater than one
    stack size, drawing from every stack` reproduces the reported bug at
    the sim level (100 wolf_fang spread across five 20-stacks, sold as one
    100-count `sellItem` call, `copper` and `countItem` both confirm the
    full amount sold).

## Screenshots / recordings

N/A. This is a behavioral fix to the sell-quantity dialog's internal cap
(what number it accepts and forwards), not a layout or visual change; the
dialog looks identical before and after.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. Added decisive
      tests for the changed behavior (see above).

### Cross-platform

- [ ] ~Tested on desktop and mobile.~ No visual/layout change; the dialog's
      markup and styling are untouched.
- [x] **Accessible.** No change to focus handling, ARIA, or keyboard
      operability; the existing prompt dialog wiring (installPromptDialog)
      is reused unmodified.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS`
      is not enabled in any production path.
- [x] I didn't hand-edit generated files.
