### PR TITLE
fix(professions): deny a craft that would overfill bags

### DIFF
--- a/src/sim/professions/crafting.ts
+++ b/src/sim/professions/crafting.ts
@@ -138,7 +138,8 @@ export interface CraftResult {
     | 'combo_requirement_unmet'
     | 'recipe_not_learned'
     | 'throttled'
-    | 'station_required';
+    | 'station_required'
+    | 'bags_full';
 }
 
 /** Whether `meta` currently knows `recipe` (issue #1299): a recipe with no
@@ -348,6 +349,18 @@ export function resolveCraftForRecipe(
   }
   if (!hasRecipeMaterials(ctx, recipe, pid)) {
     return { ok: false, recipeId: recipe.id, reason: 'insufficient_materials' };
+  }
+  // Bag-space pre-gate (mirrors the same-shape checks gathering.ts/fishing.ts/
+  // items.ts vendor-buy already run before their grant): the output item id
+  // and count are both known here, before any reagent is consumed or the
+  // single masterwork rng draw happens, so a full-bag denial has zero side
+  // effect (no reagents lost, no gold sink charged, no skill gained) and
+  // cannot shift the world's rng draw order. Without this gate the grant hub
+  // (Sim.addItem/addItemInstance) never capacity-caps by design (an async
+  // award must not destroy items), so a craft with too little bag space would
+  // silently overfill the player's bags past their slot cap.
+  if (!ctx.canAddItem(recipe.resultItemId, recipe.resultCount, pid)) {
+    return { ok: false, recipeId: recipe.id, reason: 'bags_full' };
   }
   // #1301 output throttle, shared: one action window paced across
   // crafting, disenchant, enchant-apply, and salvage (action_throttle.ts),

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -3631,7 +3631,8 @@ export type SimEvent = { pid?: number } & (
         | 'combo_requirement_unmet'
         | 'recipe_not_learned'
         | 'throttled'
-        | 'station_required';
+        | 'station_required'
+        | 'bags_full';
     }
   // Enchanting profession outcomes (Professions 2.0): mirror
   // src/sim/professions/enchanting.ts DisenchantResult / ApplyEnchantResult and

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -9055,7 +9055,9 @@ export class Hud {
                           ? 'hudChrome.crafting.throttled'
                           : ev.reason === 'recipe_not_learned'
                             ? 'hudChrome.crafting.recipeNotLearned'
-                            : 'hudChrome.crafting.insufficientMaterials',
+                            : ev.reason === 'bags_full'
+                              ? 'hudChrome.crafting.bagsFull'
+                              : 'hudChrome.crafting.insufficientMaterials',
                   ),
               '#ff6b6b',
             );

--- a/src/ui/i18n.catalog/hud_chrome.ts
+++ b/src/ui/i18n.catalog/hud_chrome.ts
@@ -2448,6 +2448,7 @@ export const hudChromeStrings = {
     resultAria: 'Craft {name}',
     craftedToast: 'Crafted: {name}',
     insufficientMaterials: 'You do not have the materials for that.',
+    bagsFull: 'Your bags are too full to craft that.',
     unknownRecipe: 'That recipe does not exist.',
     comboRequirementUnmet:
       'You do not have both required crafts at the required tier for that recipe.',

--- a/src/ui/i18n.catalog/translation_keys.generated.ts
+++ b/src/ui/i18n.catalog/translation_keys.generated.ts
@@ -5398,6 +5398,7 @@ export type TranslationKeyFlat =
   | 'hudChrome.crafting.attunedZoneLine'
   | 'hudChrome.crafting.attunementPreview'
   | 'hudChrome.crafting.attunementReturnCost'
+  | 'hudChrome.crafting.bagsFull'
   | 'hudChrome.crafting.close'
   | 'hudChrome.crafting.comboMet'
   | 'hudChrome.crafting.comboNotAttuned'

--- a/src/ui/i18n.locales/ja_JP.ts
+++ b/src/ui/i18n.locales/ja_JP.ts
@@ -6324,6 +6324,7 @@ export const ja_JP: Partial<Record<TranslationKey, string>> = {
   'hudChrome.crafting.resultAria': '{name}を製作',
   'hudChrome.crafting.craftedToast': '製作しました:{name}',
   'hudChrome.crafting.insufficientMaterials': '材料が不足しています。',
+  'hudChrome.crafting.bagsFull': 'カバンがいっぱいで、それを製作できません。',
   'hudChrome.crafting.unknownRecipe': 'そのレシピは存在しません。',
   'hudChrome.crafting.comboRequires': '調律条件：{craftA} + {craftB}、ティア {tier}。',
   'hudChrome.crafting.comboMet': '準備完了。',

--- a/src/ui/i18n.locales/ko_KR.ts
+++ b/src/ui/i18n.locales/ko_KR.ts
@@ -6320,6 +6320,7 @@ export const ko_KR: Partial<Record<TranslationKey, string>> = {
   'hudChrome.crafting.resultAria': '{name} 제작',
   'hudChrome.crafting.craftedToast': '제작 완료:{name}',
   'hudChrome.crafting.insufficientMaterials': '재료가 부족합니다.',
+  'hudChrome.crafting.bagsFull': '가방이 가득 차서 그것을 제작할 수 없습니다.',
   'hudChrome.crafting.unknownRecipe': '해당 제작법이 존재하지 않습니다.',
   'hudChrome.crafting.comboRequires': '조율 조건: {craftA} + {craftB}, 티어 {tier}.',
   'hudChrome.crafting.comboMet': '준비 완료.',

--- a/src/ui/i18n.locales/ru_RU.ts
+++ b/src/ui/i18n.locales/ru_RU.ts
@@ -6435,6 +6435,7 @@ export const ru_RU: Partial<Record<TranslationKey, string>> = {
   'hudChrome.crafting.resultAria': 'Создать {name}',
   'hudChrome.crafting.craftedToast': 'Создано: {name}',
   'hudChrome.crafting.insufficientMaterials': 'У вас недостаточно материалов.',
+  'hudChrome.crafting.bagsFull': 'Ваши сумки слишком полны, чтобы изготовить это.',
   'hudChrome.crafting.unknownRecipe': 'Такого рецепта не существует.',
   'hudChrome.crafting.comboRequires': 'Настройка: {craftA} + {craftB}, ранг {tier}.',
   'hudChrome.crafting.comboMet': 'Готово.',

--- a/src/ui/i18n.locales/zh_CN.ts
+++ b/src/ui/i18n.locales/zh_CN.ts
@@ -6042,6 +6042,7 @@ export const zh_CN: Partial<Record<TranslationKey, string>> = {
   'hudChrome.crafting.resultAria': '制作{name}',
   'hudChrome.crafting.craftedToast': '已制作:{name}',
   'hudChrome.crafting.insufficientMaterials': '你没有足够的材料。',
+  'hudChrome.crafting.bagsFull': '你的背包太满，无法制作该物品。',
   'hudChrome.crafting.unknownRecipe': '该配方不存在。',
   'hudChrome.crafting.comboRequires': '调谐要求：{craftA} + {craftB}，阶级 {tier}。',
   'hudChrome.crafting.comboMet': '已就绪。',

--- a/src/ui/i18n.locales/zh_TW.ts
+++ b/src/ui/i18n.locales/zh_TW.ts
@@ -6042,6 +6042,7 @@ export const zh_TW: Partial<Record<TranslationKey, string>> = {
   'hudChrome.crafting.resultAria': '製作{name}',
   'hudChrome.crafting.craftedToast': '已製作:{name}',
   'hudChrome.crafting.insufficientMaterials': '你沒有足夠的材料。',
+  'hudChrome.crafting.bagsFull': '你的背包太滿，無法製作該物品。',
   'hudChrome.crafting.unknownRecipe': '該配方不存在。',
   'hudChrome.crafting.comboRequires': '調諧要求：{craftA} + {craftB}，階級 {tier}。',
   'hudChrome.crafting.comboMet': '已就緒。',

--- a/src/ui/i18n.resolved.generated/cs_CZ.ts
+++ b/src/ui/i18n.resolved.generated/cs_CZ.ts
@@ -2261,6 +2261,7 @@ export const cs_CZ: EnTranslations = {
       "resultAria": "Vyrobit {name}",
       "craftedToast": "Vyrobeno: {name}",
       "insufficientMaterials": "Na to nemáš materiály.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "Tento recept neexistuje.",
       "comboRequirementUnmet": "Nemáš obě požadovaná řemesla na potřebné úrovni pro tento recept.",
       "comboRequires": "Ladění: {craftA} + {craftB}, úroveň {tier}.",

--- a/src/ui/i18n.resolved.generated/da_DK.ts
+++ b/src/ui/i18n.resolved.generated/da_DK.ts
@@ -2261,6 +2261,7 @@ export const da_DK: EnTranslations = {
       "resultAria": "Håndværk {name}",
       "craftedToast": "Udformet: {name}",
       "insufficientMaterials": "Det har du ikke materialerne til.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "Den opskrift findes ikke.",
       "comboRequirementUnmet": "Du har ikke begge de krævede håndværk på det krævede niveau til den opskrift.",
       "comboRequires": "Indstilling: {craftA} + {craftB}, niveau {tier}.",

--- a/src/ui/i18n.resolved.generated/de_DE.ts
+++ b/src/ui/i18n.resolved.generated/de_DE.ts
@@ -2261,6 +2261,7 @@ export const de_DE: EnTranslations = {
       "resultAria": "Basteln {name}",
       "craftedToast": "Hergestellt: {name}",
       "insufficientMaterials": "Dafür fehlen Ihnen die Materialien.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "Dieses Rezept existiert nicht.",
       "comboRequirementUnmet": "Ihr besitzt nicht beide erforderlichen Berufe auf der nötigen Stufe für dieses Rezept.",
       "comboRequires": "Abstimmung: {craftA} + {craftB}, Stufe {tier}.",

--- a/src/ui/i18n.resolved.generated/en.ts
+++ b/src/ui/i18n.resolved.generated/en.ts
@@ -2261,6 +2261,7 @@ export const en: EnTranslations = {
       "resultAria": "Craft {name}",
       "craftedToast": "Crafted: {name}",
       "insufficientMaterials": "You do not have the materials for that.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "That recipe does not exist.",
       "comboRequirementUnmet": "You do not have both required crafts at the required tier for that recipe.",
       "comboRequires": "Attunement: {craftA} + {craftB}, tier {tier}.",

--- a/src/ui/i18n.resolved.generated/en_CA.ts
+++ b/src/ui/i18n.resolved.generated/en_CA.ts
@@ -2261,6 +2261,7 @@ export const en_CA: EnTranslations = {
       "resultAria": "Craft {name}",
       "craftedToast": "Crafted: {name}",
       "insufficientMaterials": "You do not have the materials for that.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "That recipe does not exist.",
       "comboRequirementUnmet": "You do not have both required crafts at the required tier for that recipe.",
       "comboRequires": "Attunement: {craftA} + {craftB}, tier {tier}.",

--- a/src/ui/i18n.resolved.generated/en_XA.ts
+++ b/src/ui/i18n.resolved.generated/en_XA.ts
@@ -2261,6 +2261,7 @@ export const en_XA: EnTranslations = {
       "resultAria": "[Çŕáƒţ {name}]",
       "craftedToast": "[Çŕáƒţéð: {name}]",
       "insufficientMaterials": "[Ýóú ðó ñóţ ĥáʋé ţĥé ɱáţéŕíáļš ƒóŕ ţĥáţ.]",
+      "bagsFull": "[Ýóúŕ ƀáĝš áŕé ţóó ƒúļļ ţó çŕáƒţ ţĥáţ.]",
       "unknownRecipe": "[Ţĥáţ ŕéçíþé ðóéš ñóţ éẋíšţ.]",
       "comboRequirementUnmet": "[Ýóú ðó ñóţ ĥáʋé ƀóţĥ ŕéɋúíŕéð çŕáƒţš áţ ţĥé ŕéɋúíŕéð ţíéŕ ƒóŕ ţĥáţ ŕéçíþé.]",
       "comboRequires": "[Áţţúñéɱéñţ: {craftA} + {craftB}, ţíéŕ {tier}.]",

--- a/src/ui/i18n.resolved.generated/es.ts
+++ b/src/ui/i18n.resolved.generated/es.ts
@@ -2261,6 +2261,7 @@ export const es: EnTranslations = {
       "resultAria": "Elaboración {name}",
       "craftedToast": "Elaborado: {name}",
       "insufficientMaterials": "No tienes los materiales para eso.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "Esa receta no existe.",
       "comboRequirementUnmet": "No tienes las dos profesiones requeridas al nivel necesario para esa receta.",
       "comboRequires": "Sintonización: {craftA} + {craftB}, nivel {tier}.",

--- a/src/ui/i18n.resolved.generated/es_ES.ts
+++ b/src/ui/i18n.resolved.generated/es_ES.ts
@@ -2261,6 +2261,7 @@ export const es_ES: EnTranslations = {
       "resultAria": "Elaboración {name}",
       "craftedToast": "Elaborado: {name}",
       "insufficientMaterials": "No tienes los materiales para eso.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "Esa receta no existe.",
       "comboRequirementUnmet": "No tienes las dos profesiones requeridas al nivel necesario para esa receta.",
       "comboRequires": "Sintonización: {craftA} + {craftB}, nivel {tier}.",

--- a/src/ui/i18n.resolved.generated/fr_CA.ts
+++ b/src/ui/i18n.resolved.generated/fr_CA.ts
@@ -2261,6 +2261,7 @@ export const fr_CA: EnTranslations = {
       "resultAria": "Artisanat {name}",
       "craftedToast": "Fabriqué$1 {name}",
       "insufficientMaterials": "Vous n'avez pas le matériel pour cela.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "Cette recette n'existe pas.",
       "comboRequirementUnmet": "Vous ne possédez pas les deux métiers requis au palier nécessaire pour cette recette.",
       "comboRequires": "Communion : {craftA} + {craftB}, palier {tier}.",

--- a/src/ui/i18n.resolved.generated/fr_FR.ts
+++ b/src/ui/i18n.resolved.generated/fr_FR.ts
@@ -2261,6 +2261,7 @@ export const fr_FR: EnTranslations = {
       "resultAria": "Artisanat {name}",
       "craftedToast": "Fabriqué$1 {name}",
       "insufficientMaterials": "Vous n'avez pas le matériel pour cela.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "Cette recette n'existe pas.",
       "comboRequirementUnmet": "Vous ne possédez pas les deux métiers requis au palier nécessaire pour cette recette.",
       "comboRequires": "Communion : {craftA} + {craftB}, palier {tier}.",

--- a/src/ui/i18n.resolved.generated/id_ID.ts
+++ b/src/ui/i18n.resolved.generated/id_ID.ts
@@ -2261,6 +2261,7 @@ export const id_ID: EnTranslations = {
       "resultAria": "Kerajinan {name}",
       "craftedToast": "Dibuat: {name}",
       "insufficientMaterials": "Anda tidak memiliki bahan untuk itu.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "Resep itu tidak ada.",
       "comboRequirementUnmet": "Kamu tidak memiliki kedua keahlian yang diperlukan pada tingkat yang disyaratkan untuk resep itu.",
       "comboRequires": "Penyelarasan: {craftA} + {craftB}, tingkat {tier}.",

--- a/src/ui/i18n.resolved.generated/it_IT.ts
+++ b/src/ui/i18n.resolved.generated/it_IT.ts
@@ -2261,6 +2261,7 @@ export const it_IT: EnTranslations = {
       "resultAria": "Crea {name}",
       "craftedToast": "Realizzato: {name}",
       "insufficientMaterials": "Non hai i materiali per quello.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "Quella ricetta non esiste.",
       "comboRequirementUnmet": "Non possiedi entrambe le professioni richieste al livello necessario per quella ricetta.",
       "comboRequires": "Attunement: {craftA} + {craftB}, livello {tier}.",

--- a/src/ui/i18n.resolved.generated/ja_JP.ts
+++ b/src/ui/i18n.resolved.generated/ja_JP.ts
@@ -2261,6 +2261,7 @@ export const ja_JP: EnTranslations = {
       "resultAria": "{name}を製作",
       "craftedToast": "製作しました:{name}",
       "insufficientMaterials": "材料が不足しています。",
+      "bagsFull": "カバンがいっぱいで、それを製作できません。",
       "unknownRecipe": "そのレシピは存在しません。",
       "comboRequirementUnmet": "その組み合わせレシピに必要な両方の生産スキルの熟練度に達していません。",
       "comboRequires": "調律条件：{craftA} + {craftB}、ティア {tier}。",

--- a/src/ui/i18n.resolved.generated/ko_KR.ts
+++ b/src/ui/i18n.resolved.generated/ko_KR.ts
@@ -2261,6 +2261,7 @@ export const ko_KR: EnTranslations = {
       "resultAria": "{name} 제작",
       "craftedToast": "제작 완료:{name}",
       "insufficientMaterials": "재료가 부족합니다.",
+      "bagsFull": "가방이 가득 차서 그것을 제작할 수 없습니다.",
       "unknownRecipe": "해당 제작법이 존재하지 않습니다.",
       "comboRequirementUnmet": "이 조합 제작법에 필요한 두 제작 기술의 숙련도에 도달하지 못했습니다.",
       "comboRequires": "조율 조건: {craftA} + {craftB}, 티어 {tier}.",

--- a/src/ui/i18n.resolved.generated/nl_NL.ts
+++ b/src/ui/i18n.resolved.generated/nl_NL.ts
@@ -2261,6 +2261,7 @@ export const nl_NL: EnTranslations = {
       "resultAria": "Ambacht {name}",
       "craftedToast": "Gemaakt: {name}",
       "insufficientMaterials": "Daar heb je de materialen niet voor.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "Dat recept bestaat niet.",
       "comboRequirementUnmet": "Je hebt niet beide vereiste ambachten op het vereiste niveau voor dat recept.",
       "comboRequires": "Afstemming: {craftA} + {craftB}, rang {tier}.",

--- a/src/ui/i18n.resolved.generated/pending.ts
+++ b/src/ui/i18n.resolved.generated/pending.ts
@@ -9,25 +9,55 @@
 // Reproducibility is checked by tests/i18n_resolved_equivalence.test.ts.
 
 export const pending: Record<string, readonly string[]> = {
-  "es": [],
-  "es_ES": [],
-  "fr_FR": [],
-  "fr_CA": [],
+  "es": [
+    "hudChrome.crafting.bagsFull"
+  ],
+  "es_ES": [
+    "hudChrome.crafting.bagsFull"
+  ],
+  "fr_FR": [
+    "hudChrome.crafting.bagsFull"
+  ],
+  "fr_CA": [
+    "hudChrome.crafting.bagsFull"
+  ],
   "en_CA": [],
-  "it_IT": [],
-  "de_DE": [],
+  "it_IT": [
+    "hudChrome.crafting.bagsFull"
+  ],
+  "de_DE": [
+    "hudChrome.crafting.bagsFull"
+  ],
   "zh_CN": [],
   "zh_TW": [],
   "ko_KR": [],
   "ja_JP": [],
-  "pt_BR": [],
+  "pt_BR": [
+    "hudChrome.crafting.bagsFull"
+  ],
   "ru_RU": [],
-  "cs_CZ": [],
-  "nl_NL": [],
-  "pl_PL": [],
-  "id_ID": [],
-  "tr_TR": [],
-  "sv_SE": [],
-  "vi_VN": [],
-  "da_DK": []
+  "cs_CZ": [
+    "hudChrome.crafting.bagsFull"
+  ],
+  "nl_NL": [
+    "hudChrome.crafting.bagsFull"
+  ],
+  "pl_PL": [
+    "hudChrome.crafting.bagsFull"
+  ],
+  "id_ID": [
+    "hudChrome.crafting.bagsFull"
+  ],
+  "tr_TR": [
+    "hudChrome.crafting.bagsFull"
+  ],
+  "sv_SE": [
+    "hudChrome.crafting.bagsFull"
+  ],
+  "vi_VN": [
+    "hudChrome.crafting.bagsFull"
+  ],
+  "da_DK": [
+    "hudChrome.crafting.bagsFull"
+  ]
 };

--- a/src/ui/i18n.resolved.generated/pl_PL.ts
+++ b/src/ui/i18n.resolved.generated/pl_PL.ts
@@ -2261,6 +2261,7 @@ export const pl_PL: EnTranslations = {
       "resultAria": "Craft {name}",
       "craftedToast": "Wykonane: {name}",
       "insufficientMaterials": "Nie masz na to materiałów.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "Ten przepis nie istnieje.",
       "comboRequirementUnmet": "Nie masz obu wymaganych rzemiosł na wymaganym poziomie dla tego przepisu.",
       "comboRequires": "Dostrojenie: {craftA} + {craftB}, poziom {tier}.",

--- a/src/ui/i18n.resolved.generated/pt_BR.ts
+++ b/src/ui/i18n.resolved.generated/pt_BR.ts
@@ -2261,6 +2261,7 @@ export const pt_BR: EnTranslations = {
       "resultAria": "Artesanato {name}",
       "craftedToast": "Feito: {name}",
       "insufficientMaterials": "Você não tem os materiais para isso.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "Essa receita não existe.",
       "comboRequirementUnmet": "Você não possui os dois ofícios exigidos no nível necessário para essa receita.",
       "comboRequires": "Afinidade: {craftA} + {craftB}, nível {tier}.",

--- a/src/ui/i18n.resolved.generated/ru_RU.ts
+++ b/src/ui/i18n.resolved.generated/ru_RU.ts
@@ -2261,6 +2261,7 @@ export const ru_RU: EnTranslations = {
       "resultAria": "Создать {name}",
       "craftedToast": "Создано: {name}",
       "insufficientMaterials": "У вас недостаточно материалов.",
+      "bagsFull": "Ваши сумки слишком полны, чтобы изготовить это.",
       "unknownRecipe": "Такого рецепта не существует.",
       "comboRequirementUnmet": "У вас нет обоих требуемых ремесел нужного уровня для этого рецепта.",
       "comboRequires": "Настройка: {craftA} + {craftB}, ранг {tier}.",

--- a/src/ui/i18n.resolved.generated/sv_SE.ts
+++ b/src/ui/i18n.resolved.generated/sv_SE.ts
@@ -2261,6 +2261,7 @@ export const sv_SE: EnTranslations = {
       "resultAria": "Hantverk {name}",
       "craftedToast": "Tillverkad: {name}",
       "insufficientMaterials": "Du har inte materialet för det.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "Det receptet finns inte.",
       "comboRequirementUnmet": "Du har inte båda de hantverk som krävs på den nivå receptet kräver.",
       "comboRequires": "Inriktning: {craftA} + {craftB}, nivå {tier}.",

--- a/src/ui/i18n.resolved.generated/tr_TR.ts
+++ b/src/ui/i18n.resolved.generated/tr_TR.ts
@@ -2261,6 +2261,7 @@ export const tr_TR: EnTranslations = {
       "resultAria": "{name} zanaatı",
       "craftedToast": "Hazırlanma Tarihi: {name}",
       "insufficientMaterials": "Bunun için malzemeleriniz yok.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "O tarif mevcut değil.",
       "comboRequirementUnmet": "O tarif için gereken iki zanaata da gereken kademede sahip değilsin.",
       "comboRequires": "Uyum: {craftA} + {craftB}, kademe {tier}.",

--- a/src/ui/i18n.resolved.generated/vi_VN.ts
+++ b/src/ui/i18n.resolved.generated/vi_VN.ts
@@ -2261,6 +2261,7 @@ export const vi_VN: EnTranslations = {
       "resultAria": "Thủ công {name}",
       "craftedToast": "Đã chế tác: {name}",
       "insufficientMaterials": "Bạn không có tài liệu cho việc đó.",
+      "bagsFull": "Your bags are too full to craft that.",
       "unknownRecipe": "Công thức đó không tồn tại.",
       "comboRequirementUnmet": "Bạn chưa có cả hai nghề chế tạo cần thiết ở bậc yêu cầu cho công thức đó.",
       "comboRequires": "Thụ ngộ: {craftA} + {craftB}, bậc {tier}.",

--- a/src/ui/i18n.resolved.generated/zh_CN.ts
+++ b/src/ui/i18n.resolved.generated/zh_CN.ts
@@ -2261,6 +2261,7 @@ export const zh_CN: EnTranslations = {
       "resultAria": "制作{name}",
       "craftedToast": "已制作:{name}",
       "insufficientMaterials": "你没有足够的材料。",
+      "bagsFull": "你的背包太满，无法制作该物品。",
       "unknownRecipe": "该配方不存在。",
       "comboRequirementUnmet": "你没有达到该配方所需组合的两项制造技能等级。",
       "comboRequires": "调谐要求：{craftA} + {craftB}，阶级 {tier}。",

--- a/src/ui/i18n.resolved.generated/zh_TW.ts
+++ b/src/ui/i18n.resolved.generated/zh_TW.ts
@@ -2261,6 +2261,7 @@ export const zh_TW: EnTranslations = {
       "resultAria": "製作{name}",
       "craftedToast": "已製作:{name}",
       "insufficientMaterials": "你沒有足夠的材料。",
+      "bagsFull": "你的背包太滿，無法製作該物品。",
       "unknownRecipe": "該配方不存在。",
       "comboRequirementUnmet": "你尚未達到該配方所需組合的兩項製造技能等級。",
       "comboRequires": "調諧要求：{craftA} + {craftB}，階級 {tier}。",

--- a/src/world_api/professions.ts
+++ b/src/world_api/professions.ts
@@ -71,7 +71,12 @@ export interface CraftResultView {
     // activity and type, never distance). The ui resolves
     // WHICH station from recipeById(recipeId)?.stationType (static content,
     // identical in both worlds): no station field rides the event.
-    | 'station_required';
+    | 'station_required'
+    // Denied because granting the recipe's output would overfill the
+    // player's bags: checked before any reagent is consumed or the craft's
+    // rng draw happens, so a full-bag denial has zero side effect (see
+    // src/sim/professions/crafting.ts resolveCraftForRecipe).
+    | 'bags_full';
   // Professions 2.0: true only when the masterwork effect applied to
   // this craft's output. `quality` now reports the output def's static
   // quality (outputs are deterministic; the quality roll is retired).

--- a/tests/professions_crafting.test.ts
+++ b/tests/professions_crafting.test.ts
@@ -286,6 +286,53 @@ describe('resolveCraft (#1127)', () => {
     expect(sim.countItem('eastbrook_arming_sword', pid)).toBe(0);
   });
 
+  it('denies with bags_full when granting the output would overfill the bags, consuming NOTHING (bug: crafting let bags overfill)', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const recipe = recipeById('recipe_eastbrook_arming_sword')!;
+    grantItem(sim, 'wolf_fang', 2, pid);
+    grantItem(sim, 'bone_fragments', 4, pid);
+    grantItem(sim, 'smithing_flux', 6, pid);
+    // Fill every one of the 16 backpack slots with distinct, non-stacking
+    // equipment (none of which overlaps the recipe's reagents or output), so
+    // there is zero free slot and zero same-item stack room for the crafted
+    // eastbrook_arming_sword to land in.
+    const fillerItems = [
+      'worn_sword',
+      'gnarled_staff',
+      'rusty_dagger',
+      'training_mace',
+      'rusty_hatchet',
+      'recruit_tunic',
+      'apprentice_robe',
+      'footpad_jerkin',
+      'redbrook_blade',
+      'apprentice_staff',
+      'keen_dirk',
+      'militia_vest',
+      'woven_robe',
+      'shadow_jerkin',
+      'oiled_boots',
+      'quilted_trousers',
+    ];
+    for (const itemId of fillerItems) grantItem(sim, itemId, 1, pid);
+    const slotsBefore = sim.inventory.length;
+
+    const result = resolveCraft((sim as any).ctx, pid, recipe.id);
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('bags_full');
+    // No reagent lost, no output granted, no gold fee charged, no skill
+    // gained, and the bag slot count never crosses the cap: a denied craft
+    // for lack of bag space is a complete no-op, exactly like every other
+    // resolveCraftForRecipe denial.
+    expect(sim.countItem('wolf_fang', pid)).toBe(2);
+    expect(sim.countItem('bone_fragments', pid)).toBe(4);
+    expect(sim.countItem('smithing_flux', pid)).toBe(6);
+    expect(sim.countItem('eastbrook_arming_sword', pid)).toBe(0);
+    expect(sim.inventory.length).toBe(slotsBefore);
+  });
+
   it('denies an unknown recipe id with no side effects', () => {
     const sim = makeSim();
     const pid = sim.playerId;


### PR DESCRIPTION
<!--
Thanks for contributing to World of ClaudeCraft!
-->

## Summary

Crafting could overfill a player's bags: reported in Discord #bug-reports by derkwan
(confirmed by maintainer Fernando), a player with only 1 free bag slot who crafted an
8-item batch ended up with "79/72" bags, 7 over capacity.

Root cause: `resolveCraftForRecipe` (`src/sim/professions/crafting.ts`) grants its output
through the shared inventory grant hub (`Sim.addItem` / `Sim.addItemInstance`), which is
documented to **never** capacity-cap by design (an async award like a loot roll or master
loot must not destroy items just because it lands late). Every other command that reaches
that hub already runs a `ctx.canAddItem` pre-check at its own command boundary before
granting: gathering (`professions/gathering.ts`), fishing (`professions/fishing.ts`), vendor
buy and interaction grants (`items.ts`, `interaction.ts`), and the market
(`market.ts`). Crafting was the one path that skipped this pre-check, so a near-full bag
plus a multi-item craft output could push the bag slot count past its cap.

## Fix

Added the same capacity pre-check crafting's sibling systems already use, in
`resolveCraftForRecipe`: after materials are confirmed to be sufficient but **before**
any reagent is consumed, the gold sink fee is charged, or the single masterwork rng draw
happens, the craft is denied with a new `bags_full` reason if `ctx.canAddItem` says the
output won't fit. This matches the existing "denies with zero side effect" contract every
other `resolveCraftForRecipe` denial already follows (no partial consumption, no gold
spent, no skill gained).

Wired `bags_full` through the full existing reason-code seam so nothing new had to be
invented:
- `CraftResult.reason` (sim)
- the `craftResult` `SimEvent` (`src/sim/types.ts`)
- `CraftResultView.reason` (`src/world_api/professions.ts`, both `Sim` and `ClientWorld`
  already mirror the same event, so no parity gap)
- the HUD deny toast (`src/ui/hud.ts`) with a new `hudChrome.crafting.bagsFull` catalog key
  (English plus the five required M16 non-Latin overlay fills: zh_CN, zh_TW, ja_JP, ko_KR,
  ru_RU)

```mermaid
flowchart TD
    A[craftItem command] --> B{Station gate}
    B -->|fail| Z1[deny: station_required]
    B -->|pass| C{Combo requirement met?}
    C -->|fail| Z2[deny: combo_requirement_unmet]
    C -->|pass| D{Recipe known?}
    D -->|fail| Z3[deny: recipe_not_learned]
    D -->|pass| E{Has required materials?}
    E -->|fail| Z4[deny: insufficient_materials]
    E -->|pass| F{"ctx.canAddItem(resultItemId, resultCount)"}
    F -->|fail, NEW gate| Z5["deny: bags_full\n(zero side effect: no reagents lost,\nno gold fee, no skill gained)"]
    F -->|pass| G{Within action throttle?}
    G -->|fail| Z6[deny: throttled]
    G -->|pass| H[Charge gold sink fee]
    H --> I[Consume reagents]
    I --> J[Draw masterwork proc roll]
    J --> K["Grant output via addItem/addItemInstance\n(hub NEVER capacity-caps by design)"]
    K --> L[Grant craft skill + XP]
```

## Related issues

Reported in Discord #bug-reports.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/professions_crafting.test.ts`, `npm run gate`
- Manual steps: N/A (sim-level fix; no UI added, only the existing deny-toast wired to a
  new reason)
- Added a regression test in `tests/professions_crafting.test.ts` that fills all 16
  backpack slots with unrelated non-stacking items, then attempts a craft whose reagents
  are fully held: asserts the craft is denied with `reason: 'bags_full'` and that no
  reagent, gold, output, or slot count changes as a result (a complete no-op, matching
  every other denial in the same function).

## Screenshots / recordings

N/A. No new UI surface: this reuses the existing craft-denial toast path with a new,
localized reason string.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green (all 11 steps). Added a decisive
      regression test for the fixed behavior.

### Cross-platform

- [ ] N/A. No new UI; the existing HUD deny-toast codepath is reused.

### Localization (i18n)

- [x] **New player-visible strings follow the contributor policy.** Added
      `hudChrome.crafting.bagsFull` to `src/ui/i18n.catalog/hud_chrome.ts` (English). Also
      added the five non-Latin M16 overlay fills (zh_CN, zh_TW, ja_JP, ko_KR, ru_RU) since
      the string is wordy English, matching the contributor rule.
- [x] N/A. No numbers/money/dates in this string.
- [x] N/A. No new player-facing text originates in `src/sim/`/`server/` outside the
      existing `craftResult` reason-code seam, which the client already re-localizes.

### Hygiene

- [x] No secrets, credentials, or `.env` committed. `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated files hand-edited; `src/ui/i18n.resolved.generated/*` and
      `src/ui/i18n.catalog/translation_keys.generated.ts` were regenerated via
      `npm run i18n:gen`, not hand-edited.
