### PR TITLE
fix(professions): learning-coupled craft XP and vendor pricing consistency

### DIFF
--- a/docs/design/professions.md
+++ b/docs/design/professions.md
@@ -143,6 +143,17 @@ Gathering XP (`gatherActionXp`) deliberately keeps the plain level band:
 nodes cannot be vendor-fed, harvesting is movement- and respawn-paced like
 mob grinding, and it stays a post-launch watch rather than a coupling.
 
+The economy invariant carries a discount-aware arm for the same report:
+the listed-count "no recipe vendors above its input value" rule prices the
+naive craft, but a specialized crafter consumes discounted counts (the
+`requiredReagentCountFor` composition), so a fully-vendor-fed recipe can
+flip gold-positive while the listed arm passes (the Kilnscale Mantle did:
+listed 520 against a 470 vendor-back, but cheapest achievable consumption
+300). Every fully-vendor-fed recipe (membership derived from the NPC
+vendor tables and pinned) must vendor strictly below its CHEAPEST
+achievable input, specialized plus self-signed, enforced in
+`tests/recipe_economy.test.ts`.
+
 ### Provenance and instance stacking
 Two slots merge only when itemId matches AND the instance payload is
 byte-equal (`canStackInstancePayloads`,

--- a/docs/design/professions.md
+++ b/docs/design/professions.md
@@ -136,14 +136,14 @@ the level-20 character cap (gray for skillReq 75+ would need capability
 past the 125 cap), so the skill journey is the dimension that makes every
 recipe's lifetime character-XP contribution finite: craft skill is
 additive-only and hard-capped, so a recipe that no longer teaches pays
-nothing, and a vendor-fed recipe cannot be an unbounded stationary XP farm
-(the Kilnscale Mantle report; pinned end to end by
-`tests/professions_craft_xp.test.ts`, the boundedness sweep included).
+nothing, and a vendor-fed recipe's character XP stays bounded like every
+other's (pinned end to end by `tests/professions_craft_xp.test.ts`, the
+boundedness sweep included).
 Gathering XP (`gatherActionXp`) deliberately keeps the plain level band:
 nodes cannot be vendor-fed, harvesting is movement- and respawn-paced like
 mob grinding, and it stays a post-launch watch rather than a coupling.
 
-The economy invariant carries a discount-aware arm for the same report:
+The economy invariant carries a discount-aware arm as well:
 the listed-count "no recipe vendors above its input value" rule prices the
 naive craft, but a specialized crafter consumes discounted counts (the
 `requiredReagentCountFor` composition), so a fully-vendor-fed recipe can

--- a/docs/design/professions.md
+++ b/docs/design/professions.md
@@ -124,6 +124,25 @@ the single load-time reader of PRE-reset skill values and must keep running
 before `applyMasteryReset`. Tool effects/charges/recharge stay PARKED as
 dormant pure modules in `tools.ts`: do not wire, do not delete.
 
+Character XP from crafting is LEARNING XP: the level-banded curve
+(`craftActionXp`, `src/sim/professions/profession_xp.ts`) scaled at the
+grant site (`resolveCraftForRecipe`, `src/sim/professions/crafting.ts`) by
+the skill the craft actually taught, the applied post-clamp
+`gainCraftSkill` delta. The shared `craftSkillGainMultiplier` also returns
+0 outright at the craft's content cap, which keeps the crafting window's
+difficulty label, the skill grant, and the XP grant in lockstep. The
+character-level green/gray falloff alone cannot bound a level-20 recipe at
+the level-20 character cap (gray for skillReq 75+ would need capability
+past the 125 cap), so the skill journey is the dimension that makes every
+recipe's lifetime character-XP contribution finite: craft skill is
+additive-only and hard-capped, so a recipe that no longer teaches pays
+nothing, and a vendor-fed recipe cannot be an unbounded stationary XP farm
+(the Kilnscale Mantle report; pinned end to end by
+`tests/professions_craft_xp.test.ts`, the boundedness sweep included).
+Gathering XP (`gatherActionXp`) deliberately keeps the plain level band:
+nodes cannot be vendor-fed, harvesting is movement- and respawn-paced like
+mob grinding, and it stays a post-launch watch rather than a coupling.
+
 ### Provenance and instance stacking
 Two slots merge only when itemId matches AND the instance payload is
 byte-equal (`canStackInstancePayloads`,

--- a/src/sim/content/items.ts
+++ b/src/sim/content/items.ts
@@ -1197,7 +1197,13 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     slot: 'shoulder',
     quality: 'rare',
     stats: { armor: 78, int: 6, spi: 4 },
-    sellValue: 470,
+    // Economy invariant, discount-aware arm: both reagents are vendor-stocked
+    // at the forge, and a specialized crafter holding a self-signed ore
+    // consumes as little as 4 ore + 3 flux = 300c, so the old 470 vendor-back
+    // printed copper at zero risk. Re-priced below that cheapest achievable
+    // input (the v0.29.0 output-re-price precedent); the vendor-loop bound is
+    // pinned by tests/recipe_economy.test.ts.
+    sellValue: 280,
   },
   // --- Hollow Crypt rewards (rare/blue) ---
   // Item-level showcase: these rares are NORMALIZED to the stat budget their item

--- a/src/sim/content/items.ts
+++ b/src/sim/content/items.ts
@@ -1200,7 +1200,7 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     // Economy invariant, discount-aware arm: both reagents are vendor-stocked
     // at the forge, and a specialized crafter holding a self-signed ore
     // consumes as little as 4 ore + 3 flux = 300c, so the old 470 vendor-back
-    // printed copper at zero risk. Re-priced below that cheapest achievable
+    // sat gold-positive. Re-priced below that cheapest achievable
     // input (the v0.29.0 output-re-price precedent); the vendor-loop bound is
     // pinned by tests/recipe_economy.test.ts.
     sellValue: 280,

--- a/src/sim/content/recipes.ts
+++ b/src/sim/content/recipes.ts
@@ -366,7 +366,10 @@ export const CASTER_HUB_RECIPES: ProfessionRecipeRecord[] = [
     resultItemId: 'sootscale_mantle',
     resultCount: 1,
     // Ore stays (mail theme) plus smithing_flux volume (both sold by
-    // forgemistress_darva at the forge). Input 520 vs output 470.
+    // forgemistress_darva at the forge). Listed input 520 vs output 280:
+    // the output sits below even the cheapest specialized-plus-self-signed
+    // consumption (300, the discount-aware economy arm) so the all-vendor
+    // loop can never print copper.
     reagents: [
       { itemId: 'thorium_ore', count: 7 },
       { itemId: 'smithing_flux', count: 5 },

--- a/src/sim/professions/archetype.ts
+++ b/src/sim/professions/archetype.ts
@@ -24,12 +24,7 @@
 // imports, no Math.random/Date.now, host-agnostic so it runs offline, on the
 // server, and in the headless RL env unchanged.
 
-import {
-  adjacentCrafts,
-  CRAFT_RING,
-  craftMaxSkillFor,
-  oppositeCraft,
-} from '../content/professions';
+import { adjacentCrafts, CRAFT_RING, oppositeCraft } from '../content/professions';
 import { COMBO_RECIPES } from '../content/recipes';
 import type { SimContext } from '../sim_context';
 import {
@@ -390,7 +385,12 @@ export function craftSkillGainMultiplier(
   hobbyCraft: string | null,
   skillReq: number,
 ): number {
-  if (skillInCraft(skills, craftId) >= craftMaxSkillFor(craftId)) return 0;
+  // The cap is read off the ring record directly (not craftMaxSkillFor,
+  // which throws on an unknown id): this function was always total over
+  // arbitrary craft ids (the crafting window builds rows for any recipe
+  // def), and an unknown craft simply has no cap arm.
+  const cap = CRAFT_RING.find((c) => c.id === craftId)?.maxSkill;
+  if (cap !== undefined && skillInCraft(skills, craftId) >= cap) return 0;
   const ceilingTier = archetypeCeilingFor(activeArchetype, pairedMajor, craftId, hobbyCraft);
   const recipeTier = tierForSkill(skillReq);
   return recipeTier > ceilingTier

--- a/src/sim/professions/archetype.ts
+++ b/src/sim/professions/archetype.ts
@@ -24,10 +24,21 @@
 // imports, no Math.random/Date.now, host-agnostic so it runs offline, on the
 // server, and in the headless RL env unchanged.
 
-import { adjacentCrafts, CRAFT_RING, oppositeCraft } from '../content/professions';
+import {
+  adjacentCrafts,
+  CRAFT_RING,
+  craftMaxSkillFor,
+  oppositeCraft,
+} from '../content/professions';
 import { COMBO_RECIPES } from '../content/recipes';
 import type { SimContext } from '../sim_context';
-import { type CraftSkills, tierCapability, tierForSkill, tierProgressMultiplier } from './wheel';
+import {
+  type CraftSkills,
+  skillInCraft,
+  tierCapability,
+  tierForSkill,
+  tierProgressMultiplier,
+} from './wheel';
 
 /** A character's active-archetype progression, persisted in CharacterState. */
 export interface ArchetypeState {
@@ -363,7 +374,14 @@ export function archetypeCeilingFor(
  *  advances in the first place", wheel.ts). Below or at the ceiling, the
  *  ordinary four-state curve (full at/above raw capability, reduced one tier
  *  under, minimal two under, zero three-plus under) applies off raw
- *  capability. */
+ *  capability. At the craft's enforced content cap (craftMaxSkillFor) the
+ *  multiplier is 0 outright: gainCraftSkill's clamp already made the applied
+ *  gain zero there, and folding that arm in here keeps the window label (and
+ *  the learning-coupled character-XP grant that scales by this curve) honest
+ *  at the cap. This matters because the four-state curve alone can never
+ *  reach gray for a skillReq-75-plus recipe (gray needs capability tier
+ *  recipeTier+3, i.e. skill past the 125 cap), so without the cap arm a
+ *  maxed craft would read a nonzero gain state forever. */
 export function craftSkillGainMultiplier(
   skills: CraftSkills,
   activeArchetype: string | null,
@@ -372,6 +390,7 @@ export function craftSkillGainMultiplier(
   hobbyCraft: string | null,
   skillReq: number,
 ): number {
+  if (skillInCraft(skills, craftId) >= craftMaxSkillFor(craftId)) return 0;
   const ceilingTier = archetypeCeilingFor(activeArchetype, pairedMajor, craftId, hobbyCraft);
   const recipeTier = tierForSkill(skillReq);
   return recipeTier > ceilingTier

--- a/src/sim/professions/crafting.ts
+++ b/src/sim/professions/crafting.ts
@@ -596,13 +596,26 @@ export function resolveCraftForRecipe(
       meta.archetype.hobbyCraft,
       recipe.skillReq,
     );
+    const skillBefore = meta.craftSkills[recipe.professionId] ?? 0;
     gainCraftSkill(meta.craftSkills, recipe.professionId, CRAFT_SKILL_GAIN * multiplier);
+    const skillLearned = (meta.craftSkills[recipe.professionId] ?? 0) - skillBefore;
     recordAction(meta);
-    // Character XP for the craft (profession_xp.ts), tier-scaled and
-    // level-gated the same way gathering/kill XP are: a max-level player
-    // spamming a trivial (gray) recipe gets zero.
+    // Character XP for the craft is LEARNING XP: the level-banded curve
+    // (profession_xp.ts) scaled by the skill this craft actually taught (the
+    // applied post-clamp delta, 0..CRAFT_SKILL_GAIN). A craft that teaches
+    // nothing, gray by tier, above the archetype ceiling, or at the craft's
+    // 125 content cap, pays nothing. The character-level green/gray falloff
+    // alone cannot bound a level-20 recipe at the level-20 character cap, so
+    // the skill journey is the dimension that keeps total craft XP finite
+    // (craft skill is additive-only and hard-capped, so every recipe's
+    // lifetime XP contribution per character is a closed sum).
     const entity = ctx.entities.get(pid);
-    if (entity) ctx.grantXp(craftActionXp(recipe.level, entity.level), meta);
+    if (entity) {
+      const xp = Math.round(
+        craftActionXp(recipe.level, entity.level) * (skillLearned / CRAFT_SKILL_GAIN),
+      );
+      if (xp > 0) ctx.grantXp(xp, meta);
+    }
   }
   const result: CraftResult = {
     ok: true,

--- a/tests/crafting_view.test.ts
+++ b/tests/crafting_view.test.ts
@@ -467,6 +467,22 @@ describe('buildCraftingView difficulty and skillReq', () => {
     // a tier-3 recipe's minimal state only ever existed at the cap itself).
     expect(difficultyFor(150, { cooking: 124.5 })).toBe('full');
     expect(difficultyFor(75, { cooking: 124.5 })).toBe('reduced');
+    // Online pre-sync (empty skills mirror, identity not yet synced) the cap
+    // arm deliberately cannot fire: the label rides the ordinary curve until
+    // the first cprof snapshot lands, the same pre-existing transient every
+    // difficulty state has.
+    expect(
+      difficultyFor(
+        75,
+        {},
+        {
+          synced: false,
+          activeArchetype: null,
+          pairedMajor: null,
+          hobbyCraft: null,
+        },
+      ),
+    ).toBe('full');
   });
 
   it('pins the multiplier constants and their four-state difficulty mapping', () => {

--- a/tests/crafting_view.test.ts
+++ b/tests/crafting_view.test.ts
@@ -455,6 +455,20 @@ describe('buildCraftingView difficulty and skillReq', () => {
     expect(difficultyFor(24, { cooking: 300 })).toBe('none');
   });
 
+  it('at the craft content cap the label is none regardless of band (the learning-XP arm)', () => {
+    // The four-state curve alone can never reach gray for skillReq 75+
+    // (that needs capability past the 125 cap), so without the cap arm a
+    // maxed craft would read minimal, or even full for a tier-6 recipe,
+    // forever while the applied gain and the character-XP grant are zero.
+    expect(difficultyFor(75, { cooking: 125 })).toBe('none'); // was 'minimal'
+    expect(difficultyFor(150, { cooking: 125 })).toBe('none'); // was 'full'
+    // Just under the cap the recipe still teaches, so the band still shows
+    // (124.5 is tier 4: tier 5 begins exactly at the 125 cap, which is why
+    // a tier-3 recipe's minimal state only ever existed at the cap itself).
+    expect(difficultyFor(150, { cooking: 124.5 })).toBe('full');
+    expect(difficultyFor(75, { cooking: 124.5 })).toBe('reduced');
+  });
+
   it('pins the multiplier constants and their four-state difficulty mapping', () => {
     // Constant identity: the view compares against the SAME exported wheel.ts
     // constants the sim gain site consumes, so a curve retune moves the label

--- a/tests/crafting_view.test.ts
+++ b/tests/crafting_view.test.ts
@@ -467,18 +467,20 @@ describe('buildCraftingView difficulty and skillReq', () => {
     // a tier-3 recipe's minimal state only ever existed at the cap itself).
     expect(difficultyFor(150, { cooking: 124.5 })).toBe('full');
     expect(difficultyFor(75, { cooking: 124.5 })).toBe('reduced');
-    // Online pre-sync (empty skills mirror, identity not yet synced) the cap
-    // arm deliberately cannot fire: the label rides the ordinary curve until
-    // the first cprof snapshot lands, the same pre-existing transient every
-    // difficulty state has.
+    // Online pre-sync the skills mirror is EMPTY, and empty must never read
+    // as capped: with the majors identity the label rides the ordinary curve
+    // (full at capability 0) until the first cprof snapshot lands, the same
+    // pre-existing transient every difficulty state has. (With a NULL
+    // pre-sync identity the rare-ceiling arm reads 'none' for skillReq 75+
+    // on its own, so the majors identity is what isolates the cap arm here.)
     expect(
       difficultyFor(
         75,
         {},
         {
           synced: false,
-          activeArchetype: null,
-          pairedMajor: null,
+          activeArchetype: 'cooking',
+          pairedMajor: 'alchemy',
           hobbyCraft: null,
         },
       ),

--- a/tests/parity/golden/professions_craft.json
+++ b/tests/parity/golden/professions_craft.json
@@ -441,8 +441,8 @@
       "tick": 0,
       "time": 0,
       "nextId": 416,
-      "state": "fec08f3c",
-      "events": "c6dd8553",
+      "state": "bb62bbb0",
+      "events": "ad9c7241",
       "rng": {
         "draws": 2,
         "digest": "d6442b50"
@@ -471,7 +471,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "xpGained": 91
+            "xpGained": 24
           },
           "craftSkills": {
             "alchemy": 1,
@@ -557,7 +557,7 @@
             "itemId": "eastbrook_ritual_vestments",
             "recipeId": "recipe_eastbrook_ritual_vestments"
           },
-          "lifetimeXp": 91,
+          "lifetimeXp": 24,
           "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
@@ -565,7 +565,7 @@
             "rows": {}
           },
           "townFocus": {},
-          "xp": 91
+          "xp": 24
         }
       ],
       "entities": [
@@ -638,7 +638,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 416,
-      "state": "ea39b8bf",
+      "state": "4b90794c",
       "events": "fd5f12a8",
       "rng": {
         "draws": 3,
@@ -668,7 +668,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "xpGained": 115
+            "xpGained": 48
           },
           "craftSkills": {
             "alchemy": 2,
@@ -752,7 +752,7 @@
             "itemId": "eastbrook_ritual_vestments",
             "recipeId": "recipe_eastbrook_ritual_vestments"
           },
-          "lifetimeXp": 115,
+          "lifetimeXp": 48,
           "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
@@ -760,7 +760,7 @@
             "rows": {}
           },
           "townFocus": {},
-          "xp": 115
+          "xp": 48
         }
       ],
       "entities": [
@@ -833,7 +833,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 416,
-      "state": "ea39b8bf",
+      "state": "4b90794c",
       "events": "741638a5",
       "rng": {
         "draws": 3,
@@ -863,7 +863,7 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "xpGained": 115
+            "xpGained": 48
           },
           "craftSkills": {
             "alchemy": 2,
@@ -947,7 +947,7 @@
             "itemId": "eastbrook_ritual_vestments",
             "recipeId": "recipe_eastbrook_ritual_vestments"
           },
-          "lifetimeXp": 115,
+          "lifetimeXp": 48,
           "mailWelcomed": true,
           "nodeHarvestReadyAt": {},
           "recipesGrandfathered": true,
@@ -955,7 +955,7 @@
             "rows": {}
           },
           "townFocus": {},
-          "xp": 115
+          "xp": 48
         }
       ],
       "entities": [

--- a/tests/professions_craft_xp.test.ts
+++ b/tests/professions_craft_xp.test.ts
@@ -1,0 +1,272 @@
+// Learning-coupled craft character XP: a successful craft grants
+// character XP only in proportion to the skill it actually taught (the
+// applied post-clamp gainCraftSkill delta). A craft that teaches nothing,
+// whether gray by tier, above the archetype ceiling, or at the craft's
+// enforced 125 content cap, pays zero character XP, exactly as it already
+// pays zero skill. This closes the vendor-fed stationary XP farm (the
+// Kilnscale Mantle report): a level-20 recipe never grays by CHARACTER
+// level at the level-20 cap, so the green/gray falloff alone could not
+// bound it; the skill journey is the missing, finite dimension.
+import { describe, expect, it } from 'vitest';
+import { craftMaxSkillFor } from '../src/sim/content/professions';
+import { ALL_RECIPES, recipeById } from '../src/sim/content/recipes';
+import { resolveCraft, resolveCraftForRecipe } from '../src/sim/professions/crafting';
+import { stationsOfType } from '../src/sim/professions/stations';
+import type { ProfessionRecipeRecord } from '../src/sim/professions/types';
+import type { PlayerMeta } from '../src/sim/sim';
+import { Sim } from '../src/sim/sim';
+
+function makeSim(seed = 42) {
+  return new Sim({ seed, playerClass: 'warrior', autoEquip: false });
+}
+
+function grantItem(sim: Sim, itemId: string, count: number, pid: number) {
+  for (let i = 0; i < count; i++) sim.addItem(itemId, 1, pid);
+}
+
+function mustMeta(sim: Sim, pid: number): PlayerMeta {
+  const meta = (sim as any).players.get(pid);
+  if (!meta) throw new Error(`missing player meta ${pid}`);
+  return meta;
+}
+
+// Station-bound recipes gate on POSITION only; walk the player onto the
+// recipe's station (same harness idiom as professions_crafting.test.ts).
+function placeAtStationFor(sim: Sim, pid: number, recipe: ProfessionRecipeRecord) {
+  if (!recipe.stationType) return;
+  const station = stationsOfType(recipe.stationType)[0];
+  const entity = (sim as any).entities.get(pid);
+  entity.pos.x = station.pos.x;
+  entity.pos.z = station.pos.z;
+  entity.prevPos = { ...entity.pos };
+}
+
+// Make `active`/`paired` the character's two uncapped majors so the
+// archetype ceiling never zeroes the grant; the tests that DO exercise the
+// ceiling arm simply skip this.
+function setMajors(meta: PlayerMeta, active: string, paired: string | null) {
+  meta.archetype.activeArchetype = active;
+  meta.archetype.pairedMajor = paired;
+  meta.archetype.hobbyCraft = null;
+}
+
+const MANTLE = recipeById('recipe_sootscale_mantle')!;
+
+function grantMantleMats(sim: Sim, pid: number) {
+  grantItem(sim, 'thorium_ore', 7, pid);
+  grantItem(sim, 'smithing_flux', 5, pid);
+}
+
+describe('learning-coupled craft XP: the vendor-fed farm closes', () => {
+  it('the at-cap capstone loop grants zero XP once armorcrafting is maxed (the live exploit)', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    sim.setPlayerLevel(20);
+    const meta = mustMeta(sim, pid);
+    setMajors(meta, 'armorcrafting', 'weaponcrafting');
+    meta.craftSkills.armorcrafting = craftMaxSkillFor('armorcrafting');
+    placeAtStationFor(sim, pid, MANTLE);
+    grantMantleMats(sim, pid);
+    const before = meta.lifetimeXp;
+
+    const first = resolveCraft((sim as any).ctx, pid, MANTLE.id);
+
+    // The craft itself still works: item granted, materials consumed.
+    expect(first.ok).toBe(true);
+    expect(sim.countItem('sootscale_mantle', pid)).toBe(1);
+    // But it taught nothing, so it pays nothing: no lifetime XP, no skill.
+    expect(meta.lifetimeXp).toBe(before);
+    expect(meta.craftSkills.armorcrafting).toBe(125);
+
+    // And it stays zero on repeat: the farm has no tail.
+    grantMantleMats(sim, pid);
+    const second = resolveCraft((sim as any).ctx, pid, MANTLE.id);
+    expect(second.ok).toBe(true);
+    expect(meta.lifetimeXp).toBe(before);
+  });
+
+  it('the skillReq-150 tool chain grants zero XP at the engineering cap (the full-multiplier hole)', () => {
+    // recipe_arcanite_mining_pick is tier 6, above ANY reachable capability
+    // (cap 125 = tier 5), so the four-state curve alone reads FULL for it
+    // forever; the applied-delta coupling is what zeroes it at the cap.
+    const sim = makeSim();
+    const pid = sim.playerId;
+    sim.setPlayerLevel(20);
+    const meta = mustMeta(sim, pid);
+    setMajors(meta, 'engineering', 'armorcrafting');
+    meta.craftSkills.engineering = craftMaxSkillFor('engineering');
+    const recipe = recipeById('recipe_arcanite_mining_pick')!;
+    placeAtStationFor(sim, pid, recipe);
+    grantItem(sim, 'arcanite_bar', 2, pid);
+    grantItem(sim, 'thorium_mining_pick', 1, pid);
+    const before = meta.lifetimeXp;
+
+    const result = resolveCraft((sim as any).ctx, pid, recipe.id);
+
+    expect(result.ok).toBe(true);
+    expect(meta.lifetimeXp).toBe(before);
+    expect(meta.craftSkills.engineering).toBe(125);
+  });
+
+  it('a pre-attunement character gains neither skill nor XP from the capstone (ceiling arm)', () => {
+    // The level-1 AFK alt from the report: no archetype, so the tier-3
+    // mantle sits above the rare ceiling and must teach (and pay) nothing.
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = mustMeta(sim, pid);
+    meta.craftSkills.armorcrafting = 80;
+    placeAtStationFor(sim, pid, MANTLE);
+    grantMantleMats(sim, pid);
+    const beforeXp = meta.xp;
+    const beforeLifetime = meta.lifetimeXp;
+
+    const result = resolveCraft((sim as any).ctx, pid, MANTLE.id);
+
+    expect(result.ok).toBe(true);
+    expect(meta.xp).toBe(beforeXp);
+    expect(meta.lifetimeXp).toBe(beforeLifetime);
+    expect(meta.craftSkills.armorcrafting).toBe(80);
+  });
+});
+
+describe('learning-coupled craft XP: legitimate play keeps its grant', () => {
+  it('a capped character learning the craft keeps the full 100 XP per craft', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    sim.setPlayerLevel(20);
+    const meta = mustMeta(sim, pid);
+    setMajors(meta, 'armorcrafting', 'weaponcrafting');
+    placeAtStationFor(sim, pid, MANTLE);
+    grantMantleMats(sim, pid);
+    const before = meta.lifetimeXp;
+
+    const result = resolveCraft((sim as any).ctx, pid, MANTLE.id);
+
+    expect(result.ok).toBe(true);
+    expect(meta.lifetimeXp).toBe(before + 100);
+    expect(meta.craftSkills.armorcrafting).toBe(1);
+  });
+
+  it('an attuned low-level crafter keeps the sub-cap upscale (120 XP at level 10)', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    sim.setPlayerLevel(10);
+    const meta = mustMeta(sim, pid);
+    setMajors(meta, 'armorcrafting', 'weaponcrafting');
+    placeAtStationFor(sim, pid, MANTLE);
+    grantMantleMats(sim, pid);
+    const before = meta.xp;
+
+    const result = resolveCraft((sim as any).ctx, pid, MANTLE.id);
+
+    expect(result.ok).toBe(true);
+    expect(meta.xp).toBe(before + 120);
+    expect(meta.craftSkills.armorcrafting).toBe(1);
+  });
+
+  it('the half-gain band pays exactly half XP', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    sim.setPlayerLevel(20);
+    const meta = mustMeta(sim, pid);
+    setMajors(meta, 'armorcrafting', 'weaponcrafting');
+    meta.craftSkills.armorcrafting = 100; // capability 4 vs recipe tier 3
+    placeAtStationFor(sim, pid, MANTLE);
+    grantMantleMats(sim, pid);
+    const before = meta.lifetimeXp;
+
+    const result = resolveCraft((sim as any).ctx, pid, MANTLE.id);
+
+    expect(result.ok).toBe(true);
+    expect(meta.lifetimeXp).toBe(before + 50);
+    expect(meta.craftSkills.armorcrafting).toBe(100.5);
+  });
+
+  it('the minimal band pays a quarter (synthetic tier-1 recipe)', () => {
+    // Exercised via a synthetic recipe exactly as resolveCraftForRecipe's
+    // doc invites: no real armorcrafting recipe sits two tiers below a
+    // reachable capability while still paying at level 20.
+    const sim = makeSim();
+    const pid = sim.playerId;
+    sim.setPlayerLevel(20);
+    const meta = mustMeta(sim, pid);
+    setMajors(meta, 'armorcrafting', 'weaponcrafting');
+    meta.craftSkills.armorcrafting = 75; // capability 3 vs recipe tier 1
+    const recipe: ProfessionRecipeRecord = {
+      id: 'recipe_test_minimal_band',
+      professionId: 'armorcrafting',
+      resultItemId: 'tough_jerky',
+      resultCount: 1,
+      reagents: [{ itemId: 'spider_leg', count: 1 }],
+      skillReq: 25,
+      itemLevelBudget: 1,
+      level: 20,
+    };
+    grantItem(sim, 'spider_leg', 1, pid);
+    const before = meta.lifetimeXp;
+
+    const result = resolveCraftForRecipe((sim as any).ctx, pid, recipe);
+
+    expect(result.ok).toBe(true);
+    expect(meta.lifetimeXp).toBe(before + 25);
+    expect(meta.craftSkills.armorcrafting).toBe(75.25);
+  });
+
+  it('the final fractional skill point scales the grant (delta clamp at the cap)', () => {
+    const sim = makeSim();
+    const pid = sim.playerId;
+    sim.setPlayerLevel(20);
+    const meta = mustMeta(sim, pid);
+    setMajors(meta, 'armorcrafting', 'weaponcrafting');
+    meta.craftSkills.armorcrafting = 124.6; // half band; 0.5 gain clamps to 0.4
+    placeAtStationFor(sim, pid, MANTLE);
+    grantMantleMats(sim, pid);
+    const before = meta.lifetimeXp;
+
+    const result = resolveCraft((sim as any).ctx, pid, MANTLE.id);
+
+    expect(result.ok).toBe(true);
+    expect(meta.lifetimeXp).toBe(before + 40);
+    expect(meta.craftSkills.armorcrafting).toBe(125);
+  });
+});
+
+// The regression-proof form: EVERY recipe, current and future, must stop
+// paying character XP once its craft can no longer be taught, i.e. at the
+// craft's enforced content cap. Drives the real resolveCraft path for every
+// recipe and asserts ok === true so a new gate kind can never make this
+// suite pass vacuously.
+describe('every recipe stops paying XP at its craft cap (boundedness)', () => {
+  for (const recipe of ALL_RECIPES) {
+    it(`${recipe.id} grants zero XP at the ${recipe.professionId} cap`, () => {
+      const sim = makeSim();
+      const pid = sim.playerId;
+      sim.setPlayerLevel(20);
+      const meta = mustMeta(sim, pid);
+      const cap = craftMaxSkillFor(recipe.professionId);
+      meta.craftSkills[recipe.professionId] = cap;
+      if (recipe.comboRequirement) {
+        const { craftA, craftB, minTier } = recipe.comboRequirement;
+        setMajors(meta, craftA, craftB);
+        meta.craftSkills[craftA] = Math.max(meta.craftSkills[craftA] ?? 0, minTier * 25);
+        meta.craftSkills[craftB] = Math.max(meta.craftSkills[craftB] ?? 0, minTier * 25);
+      } else {
+        setMajors(meta, recipe.professionId, null);
+      }
+      if (recipe.acquisition && recipe.acquisition.length > 0) {
+        meta.knownRecipes.add(recipe.id);
+      }
+      placeAtStationFor(sim, pid, recipe);
+      for (const reagent of recipe.reagents) {
+        grantItem(sim, reagent.itemId, reagent.count, pid);
+      }
+      const before = meta.lifetimeXp;
+
+      const result = resolveCraft((sim as any).ctx, pid, recipe.id);
+
+      expect(result.ok).toBe(true);
+      expect(meta.lifetimeXp).toBe(before);
+      expect(meta.craftSkills[recipe.professionId]).toBe(cap);
+    });
+  }
+});

--- a/tests/professions_craft_xp.test.ts
+++ b/tests/professions_craft_xp.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it } from 'vitest';
 import { craftMaxSkillFor } from '../src/sim/content/professions';
 import { ALL_RECIPES, recipeById } from '../src/sim/content/recipes';
+import { craftSkillGainMultiplier } from '../src/sim/professions/archetype';
 import { resolveCraft, resolveCraftForRecipe } from '../src/sim/professions/crafting';
 import { stationsOfType } from '../src/sim/professions/stations';
 import type { ProfessionRecipeRecord } from '../src/sim/professions/types';
@@ -69,11 +70,18 @@ describe('learning-coupled craft XP: the vendor-fed farm closes', () => {
     grantMantleMats(sim, pid);
     const before = meta.lifetimeXp;
 
+    const throttleBefore = meta.craftThrottle.count;
+
     const first = resolveCraft((sim as any).ctx, pid, MANTLE.id);
 
-    // The craft itself still works: item granted, materials consumed.
+    // The craft itself still works: item granted, materials consumed, the
+    // shared action throttle still spent (at skill 125 the specialization
+    // discount reduces the listed 7 ore + 5 flux to 5 + 4).
     expect(first.ok).toBe(true);
     expect(sim.countItem('sootscale_mantle', pid)).toBe(1);
+    expect(sim.countItem('thorium_ore', pid)).toBe(2);
+    expect(sim.countItem('smithing_flux', pid)).toBe(1);
+    expect(meta.craftThrottle.count).toBe(throttleBefore + 1);
     // But it taught nothing, so it pays nothing: no lifetime XP, no skill.
     expect(meta.lifetimeXp).toBe(before);
     expect(meta.craftSkills.armorcrafting).toBe(125);
@@ -261,12 +269,65 @@ describe('every recipe stops paying XP at its craft cap (boundedness)', () => {
         grantItem(sim, reagent.itemId, reagent.count, pid);
       }
       const before = meta.lifetimeXp;
+      const skillBefore = meta.craftSkills[recipe.professionId];
 
       const result = resolveCraft((sim as any).ctx, pid, recipe.id);
 
       expect(result.ok).toBe(true);
       expect(meta.lifetimeXp).toBe(before);
-      expect(meta.craftSkills[recipe.professionId]).toBe(cap);
+      // Drift-proof: the skill must not MOVE across the craft (comparing to
+      // the captured pre-craft value, not to craftMaxSkillFor again, so a
+      // clamp bug cannot cancel out of both operands).
+      expect(meta.craftSkills[recipe.professionId]).toBe(skillBefore);
     });
   }
+});
+
+// Direct sim-side pin on the shared multiplier's content-cap arm: the
+// grant-site tests above cannot distinguish the cap arm from
+// gainCraftSkill's own clamp (at cap the applied delta is zero either
+// way), so the arm's own contract is pinned here, mirroring the
+// crafting_view label pin from the UI side.
+describe('craftSkillGainMultiplier content-cap arm', () => {
+  it('returns 0 at the 125 cap and the ordinary band just under it', () => {
+    const skills = { armorcrafting: 125 };
+    expect(
+      craftSkillGainMultiplier(
+        skills,
+        'armorcrafting',
+        'weaponcrafting',
+        'armorcrafting',
+        null,
+        75,
+      ),
+    ).toBe(0);
+    expect(
+      craftSkillGainMultiplier(
+        skills,
+        'armorcrafting',
+        'weaponcrafting',
+        'armorcrafting',
+        null,
+        150,
+      ),
+    ).toBe(0);
+    const under = { armorcrafting: 124.5 };
+    expect(
+      craftSkillGainMultiplier(under, 'armorcrafting', 'weaponcrafting', 'armorcrafting', null, 75),
+    ).toBe(0.5);
+    expect(
+      craftSkillGainMultiplier(
+        under,
+        'armorcrafting',
+        'weaponcrafting',
+        'armorcrafting',
+        null,
+        150,
+      ),
+    ).toBe(1);
+  });
+
+  it('stays total over an unknown craft id (no cap arm, no throw)', () => {
+    expect(craftSkillGainMultiplier({}, null, null, 'blacksmithing', null, 0)).toBe(1);
+  });
 });

--- a/tests/professions_craft_xp.test.ts
+++ b/tests/professions_craft_xp.test.ts
@@ -3,10 +3,10 @@
 // applied post-clamp gainCraftSkill delta). A craft that teaches nothing,
 // whether gray by tier, above the archetype ceiling, or at the craft's
 // enforced 125 content cap, pays zero character XP, exactly as it already
-// pays zero skill. This closes the vendor-fed stationary XP farm (the
-// Kilnscale Mantle report): a level-20 recipe never grays by CHARACTER
-// level at the level-20 cap, so the green/gray falloff alone could not
-// bound it; the skill journey is the missing, finite dimension.
+// pays zero skill. This keeps craft XP bounded for every recipe: a
+// level-20 recipe never grays by CHARACTER level at the level-20 cap, so
+// the green/gray falloff alone could not bound it; the skill journey is
+// the missing, finite dimension.
 import { describe, expect, it } from 'vitest';
 import { craftMaxSkillFor } from '../src/sim/content/professions';
 import { ALL_RECIPES, recipeById } from '../src/sim/content/recipes';
@@ -58,8 +58,8 @@ function grantMantleMats(sim: Sim, pid: number) {
   grantItem(sim, 'smithing_flux', 5, pid);
 }
 
-describe('learning-coupled craft XP: the vendor-fed farm closes', () => {
-  it('the at-cap capstone loop grants zero XP once armorcrafting is maxed (the live exploit)', () => {
+describe('learning-coupled craft XP: taught-nothing crafts pay nothing', () => {
+  it('the capstone grants zero XP once armorcrafting is maxed (the at-cap boundary)', () => {
     const sim = makeSim();
     const pid = sim.playerId;
     sim.setPlayerLevel(20);
@@ -86,7 +86,7 @@ describe('learning-coupled craft XP: the vendor-fed farm closes', () => {
     expect(meta.lifetimeXp).toBe(before);
     expect(meta.craftSkills.armorcrafting).toBe(125);
 
-    // And it stays zero on repeat: the farm has no tail.
+    // And it stays zero on repeat: the bound holds craft after craft.
     grantMantleMats(sim, pid);
     const second = resolveCraft((sim as any).ctx, pid, MANTLE.id);
     expect(second.ok).toBe(true);
@@ -117,7 +117,7 @@ describe('learning-coupled craft XP: the vendor-fed farm closes', () => {
   });
 
   it('a pre-attunement character gains neither skill nor XP from the capstone (ceiling arm)', () => {
-    // The level-1 AFK alt from the report: no archetype, so the tier-3
+    // A fresh level-1 character: no archetype, so the tier-3
     // mantle sits above the rare ceiling and must teach (and pay) nothing.
     const sim = makeSim();
     const pid = sim.playerId;

--- a/tests/recipe_economy.test.ts
+++ b/tests/recipe_economy.test.ts
@@ -87,7 +87,7 @@ describe('THE ECONOMY INVARIANT', () => {
   // the output must vendor strictly below the CHEAPEST achievable input or
   // the loop prints copper at zero risk (the Kilnscale Mantle sat exactly
   // here: listed 520 vs output 470, but specialized consumption is 5 ore +
-  // 4 flux = 420, and with a self-signed ore 4 + 3 = 300). Self-signed is
+  // 4 flux = 380, and with a self-signed ore 4 + 3 = 300). Self-signed is
   // assumed held for EVERY reagent: stricter than reality for unsignable
   // vendor staples, which is the safe direction for an invariant.
   function vendorStockedIds(): ReadonlySet<string> {
@@ -110,8 +110,20 @@ describe('THE ECONOMY INVARIANT', () => {
 
   it('every fully-vendor-fed recipe vendors strictly below its cheapest achievable input', () => {
     const stocked = vendorStockedIds();
+    // Copper-loop membership needs BOTH facts: stocked by some NPC AND
+    // carrying a copper buyValue (the FURY honor vendor's priceHonor stock
+    // is in NPCS too; honor-priced goods have no copper basis and must
+    // never classify a recipe into this arm).
     const vendorFed = ALL_RECIPES.filter((recipe) =>
-      recipe.reagents.every((reagent) => stocked.has(reagent.itemId)),
+      recipe.reagents.every((reagent) => {
+        const def = ITEMS[reagent.itemId];
+        return (
+          stocked.has(reagent.itemId) &&
+          !!def &&
+          typeof def.buyValue === 'number' &&
+          def.buyValue > 0
+        );
+      }),
     );
     // Membership pin: the vendor-fed set is exactly these six loops. A new
     // recipe (or a new vendor row) that makes another recipe fully
@@ -132,6 +144,12 @@ describe('THE ECONOMY INVARIANT', () => {
           `input ${minAchievableInputValue(recipe)} (specialized + self-signed)`,
       ).toBeLessThan(minAchievableInputValue(recipe));
     }
+    // Pin the mantle's tight bound to its literal: the protective threshold
+    // depends on the specialization discount actually firing inside
+    // requiredReagentCountFor. Self-sign alone would give 6*60 + 4*20 = 440,
+    // so without this pin a discount regression would silently widen the
+    // bound and let a 300-to-440 re-price slip through green.
+    expect(minAchievableInputValue(recipeById('recipe_sootscale_mantle')!)).toBe(300);
   });
 
   it('(a) every legacy member predates trainer acquisition (in PRE_TRAINING_RECIPE_IDS)', () => {

--- a/tests/recipe_economy.test.ts
+++ b/tests/recipe_economy.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from 'vitest';
 import { STATION_TYPE_BY_CRAFT } from '../src/sim/content/professions';
 import { ALL_RECIPES, COMBO_RECIPES, LADDER_RECIPES, recipeById } from '../src/sim/content/recipes';
 import { ITEMS, NPCS } from '../src/sim/data';
+import { requiredReagentCountFor } from '../src/sim/professions/crafting';
 import { NODE_MATERIAL_TABLE } from '../src/sim/professions/gathering';
 import { stationsOfType, stationTypeForCraft } from '../src/sim/professions/stations';
 import { PRE_TRAINING_RECIPE_IDS } from '../src/sim/professions/training';
@@ -74,6 +75,63 @@ describe('THE ECONOMY INVARIANT', () => {
     // frozen legacy ids (zero members since the economy rework completed).
     expect(checked).toBe(ALL_RECIPES.length - LEGACY_GOLD_POSITIVE_RECIPE_IDS.size);
     expect(checked).toBeGreaterThan(0);
+  });
+
+  // --- the discount-aware vendor-loop arm --------------------------------
+  // The listed-count arm above prices the NAIVE craft. A specialized crafter
+  // (skill at the craft's perk threshold, automatic for anyone deep in a
+  // craft) consumes DISCOUNTED counts, and a held self-signed instance
+  // shaves one more before the discount (requiredReagentCountFor, the same
+  // function the sim charges). For a recipe whose every reagent is
+  // NPC-vendor-stocked the whole loop is pure gold with infinite supply, so
+  // the output must vendor strictly below the CHEAPEST achievable input or
+  // the loop prints copper at zero risk (the Kilnscale Mantle sat exactly
+  // here: listed 520 vs output 470, but specialized consumption is 5 ore +
+  // 4 flux = 420, and with a self-signed ore 4 + 3 = 300). Self-signed is
+  // assumed held for EVERY reagent: stricter than reality for unsignable
+  // vendor staples, which is the safe direction for an invariant.
+  function vendorStockedIds(): ReadonlySet<string> {
+    const stocked = new Set<string>();
+    for (const npc of Object.values(NPCS)) {
+      for (const id of npc.vendorItems ?? []) stocked.add(id);
+    }
+    return stocked;
+  }
+  function minAchievableInputValue(recipe: ProfessionRecipeRecord): number {
+    // Specialized in the recipe's own craft (cap skill clears any threshold).
+    const specialized = { [recipe.professionId]: 125 };
+    let total = 0;
+    for (const reagent of recipe.reagents) {
+      const { count } = requiredReagentCountFor(true, reagent, specialized, recipe.professionId);
+      total += count * reagentUnitValue(reagent.itemId);
+    }
+    return total;
+  }
+
+  it('every fully-vendor-fed recipe vendors strictly below its cheapest achievable input', () => {
+    const stocked = vendorStockedIds();
+    const vendorFed = ALL_RECIPES.filter((recipe) =>
+      recipe.reagents.every((reagent) => stocked.has(reagent.itemId)),
+    );
+    // Membership pin: the vendor-fed set is exactly these six loops. A new
+    // recipe (or a new vendor row) that makes another recipe fully
+    // vendor-fed must be added HERE deliberately, and it then rides the
+    // cheapest-achievable-input bound below.
+    expect(vendorFed.map((recipe) => recipe.id).sort()).toEqual([
+      'recipe_ashwood_axe',
+      'recipe_goldleaf_mana_draught',
+      'recipe_goldleaf_sickle',
+      'recipe_sootscale_mantle',
+      'recipe_sunpetal_mana_draught',
+      'recipe_thorium_mining_pick',
+    ]);
+    for (const recipe of vendorFed) {
+      expect(
+        outputValue(recipe),
+        `${recipe.id}: output ${outputValue(recipe)} must be below the cheapest achievable ` +
+          `input ${minAchievableInputValue(recipe)} (specialized + self-signed)`,
+      ).toBeLessThan(minAchievableInputValue(recipe));
+    }
   });
 
   it('(a) every legacy member predates trainer acquisition (in PRE_TRAINING_RECIPE_IDS)', () => {

--- a/tests/recipe_economy.test.ts
+++ b/tests/recipe_economy.test.ts
@@ -85,7 +85,7 @@ describe('THE ECONOMY INVARIANT', () => {
   // function the sim charges). For a recipe whose every reagent is
   // NPC-vendor-stocked the whole loop is pure gold with infinite supply, so
   // the output must vendor strictly below the CHEAPEST achievable input or
-  // the loop prints copper at zero risk (the Kilnscale Mantle sat exactly
+  // the loop is gold-positive (the Kilnscale Mantle sat exactly
   // here: listed 520 vs output 470, but specialized consumption is 5 ore +
   // 4 flux = 380, and with a self-signed ore 4 + 3 = 300). Self-signed is
   // assumed held for EVERY reagent: stricter than reality for unsignable


### PR DESCRIPTION
## Summary

Craft character XP now scales with the skill a craft actually teaches: the grant multiplies the existing level-banded curve (`craftActionXp`) by the applied `gainCraftSkill` delta, and the shared `craftSkillGainMultiplier` reads zero at a craft's 125 content cap. This ties character XP from crafting to genuine craft progression, the same four-state mastery curve the crafting window's difficulty label already consumes, so the label, the skill grant, and the XP grant always agree. A side effect worth calling out: the difficulty label now correctly shows "No skill gain" at a maxed craft, where it previously showed a gain state while the applied gain was zero.

On the economy side, the Kilnscale Mantle's vendor value moves from 470 to 280 so it sits below the recipe's cheapest achievable input once the specialization material discount and the self-signed reagent reduction compose (the same output-re-price approach used for the v0.29.0 economy rework). The recipe economy invariant gains a matching discount-aware arm: every fully-vendor-stocked recipe (membership derived from the NPC vendor tables and pinned) must vendor strictly below its cheapest achievable input, priced through the real `requiredReagentCountFor`.

Design rationale for both is recorded in `docs/design/professions.md` (the learning-XP rule and the discount-aware economy arm).

No wire, persistence, or `IWorld` changes; recipes, outputs, skill gain, masterwork, and the action throttle are untouched. The parity golden for the crafting scenario was re-minted in its own commit; its rng digests and draw counts are byte-identical (state-only sample changes).

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation

## How was this tested?

- Commands: `npm run gate` (green: full vitest, tsc, biome on changed files, all builds); targeted `npx vitest run tests/professions_craft_xp.test.ts tests/recipe_economy.test.ts tests/crafting_view.test.ts tests/parity`
- New decisive coverage: `tests/professions_craft_xp.test.ts` (exact-literal pins for every band of the curve, the fractional final-skill-point case, and a sweep asserting every recipe in `ALL_RECIPES` stops granting XP at its craft cap, with `result.ok` asserted per recipe); the discount-aware vendor-pricing arm plus a literal bound pin in `tests/recipe_economy.test.ts`; cap-arm and pre-sync pins for the difficulty label in `tests/crafting_view.test.ts`
- Parity: `UPDATE_PARITY=1` re-mint of `tests/parity/golden/professions_craft.json` in its own commit, rng digests unchanged

## Screenshots / recordings

The only player-visible UI change is the crafting window's existing difficulty label showing its existing "No skill gain" text in the additional (now accurate) at-cap case; no layout, style, or new element, so no screenshots.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no layout or interaction change; an existing text label shows an existing state in one more case.
- ~Accessible.~ N/A: no UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
