### PR TITLE
fix(ui): scope options window Reset to Defaults to the open sub-view

### DIFF
--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -403,9 +403,25 @@ export class Settings {
     return v as GameSettings[K];
   }
 
-  reset(): void {
-    for (const key of NUMERIC_KEYS) this.values[key] = SETTING_RANGES[key].def;
-    for (const key of BOOL_KEYS) this.values[key] = BOOL_SETTINGS[key].def;
+  /** Restore defaults. With no `keys`, every setting resets (the historical
+   *  behavior). With `keys`, only those keys reset, so a caller that owns just
+   *  one sub-view (e.g. the options window's per-panel footer) can offer a
+   *  "Reset to Defaults" that does not silently wipe settings the player
+   *  never saw (issue 2341). */
+  reset(keys?: readonly (keyof GameSettings)[]): void {
+    if (!keys) {
+      for (const key of NUMERIC_KEYS) this.values[key] = SETTING_RANGES[key].def;
+      for (const key of BOOL_KEYS) this.values[key] = BOOL_SETTINGS[key].def;
+      this.save();
+      return;
+    }
+    for (const key of keys) {
+      if ((BOOL_KEYS as readonly string[]).includes(key as string)) {
+        this.values[key as BoolSettingKey] = BOOL_SETTINGS[key as BoolSettingKey].def;
+      } else if ((NUMERIC_KEYS as readonly string[]).includes(key as string)) {
+        this.values[key as NumericSettingKey] = SETTING_RANGES[key as NumericSettingKey].def;
+      }
+    }
     this.save();
   }
 }

--- a/src/ui/options_view.ts
+++ b/src/ui/options_view.ts
@@ -484,6 +484,21 @@ export function buildInterfaceControls(s: OptionsSettingsSource): OptionsControl
   ];
 }
 
+/** Keys of the controls in `controls` that write a GameSettings value: sliders,
+ *  toggles, boolToggles and choices all carry a `key`. NoteControl (a display-only
+ *  line) and MusicToggleControl (reads the live MusicDirector, not a stored
+ *  setting) carry no key and are skipped. Used to scope a sub-view's "Reset to
+ *  Defaults" button to only the settings that view actually renders, instead of
+ *  resetting the whole GameSettings object (issue 2341). */
+export function optionsControlKeys(controls: OptionsControl[]): string[] {
+  const keys = new Set<string>();
+  for (const c of controls) {
+    if (c.control === 'note' || c.control === 'musicToggle') continue;
+    keys.add(c.key);
+  }
+  return [...keys];
+}
+
 /** The interface controls that belong to `tab`, in declaration order. The
  *  painter calls this per tab; the completeness test partitions the full list
  *  through it (union across INTERFACE_TAB_ORDER equals the full list, no dupes). */

--- a/src/ui/options_window.ts
+++ b/src/ui/options_window.ts
@@ -70,6 +70,7 @@ import {
   type OptionsControl,
   type OptionsPanelId,
   type OptionsSettingsSource,
+  optionsControlKeys,
   type SliderControl,
   type SliderFmt,
   sliderDispatchValue,
@@ -769,19 +770,23 @@ export class OptionsWindow {
     return body;
   }
 
-  private settingsViewFooter(): void {
+  // `controls` is the sub-view's own declarative control list (as built for
+  // this render pass): Reset to Defaults scopes to exactly the setting keys
+  // that view renders (issue 2341), rather than wiping the whole GameSettings
+  // object. NoteControl/MusicToggleControl carry no key and are filtered out
+  // by optionsControlKeys.
+  private settingsViewFooter(controls: OptionsControl[]): void {
     const el = this.deps.root();
+    const keys = optionsControlKeys(controls) as (keyof GameSettings)[];
     const reset = document.createElement('button');
     reset.className = 'btn';
     reset.textContent = t('hud.options.resetToDefaults');
     reset.addEventListener('click', () => {
       audio.click();
-      this.deps.options()?.settings.reset();
-      // re-apply every setting to its subsystem, then redraw the view
-      const all = this.deps.options()?.settings.all();
-      if (all)
-        for (const k of Object.keys(all) as (keyof GameSettings)[])
-          this.deps.options()?.onSettingChange(k, all[k]);
+      const hooks = this.deps.options();
+      hooks?.settings.reset(keys);
+      // re-apply only this view's settings to their subsystem, then redraw
+      for (const k of keys) hooks?.onSettingChange(k, hooks.settings.get(k));
       this.render();
     });
     const back = document.createElement('button');
@@ -800,13 +805,13 @@ export class OptionsWindow {
   private renderGraphics(): void {
     const hooks = this.deps.options();
     const body = this.settingsViewShell(t('hud.options.graphics'));
-    if (hooks) {
-      const controls = buildGraphicsControls(this.settingsSource(hooks), {
-        touch: useTouchInterface(),
-        nativeShell: isNativeAppShell(),
-      });
-      this.applyControls(body, controls, hooks, () => this.renderGraphics());
-    }
+    const controls = hooks
+      ? buildGraphicsControls(this.settingsSource(hooks), {
+          touch: useTouchInterface(),
+          nativeShell: isNativeAppShell(),
+        })
+      : [];
+    if (hooks) this.applyControls(body, controls, hooks, () => this.renderGraphics());
     const el = this.deps.root();
     const note = document.createElement('div');
     note.className = 'set-note';
@@ -824,7 +829,7 @@ export class OptionsWindow {
       location.reload();
     });
     el.append(reloadNote, reload);
-    this.settingsViewFooter();
+    this.settingsViewFooter(controls);
   }
 
   // -------------------------------------------------------------------------
@@ -834,11 +839,9 @@ export class OptionsWindow {
   private renderAudio(): void {
     const hooks = this.deps.options();
     const body = this.settingsViewShell(t('hud.options.audio'));
-    if (hooks)
-      this.applyControls(body, buildAudioControls(this.settingsSource(hooks)), hooks, () =>
-        this.renderAudio(),
-      );
-    this.settingsViewFooter();
+    const controls = hooks ? buildAudioControls(this.settingsSource(hooks)) : [];
+    if (hooks) this.applyControls(body, controls, hooks, () => this.renderAudio());
+    this.settingsViewFooter(controls);
   }
 
   // -------------------------------------------------------------------------
@@ -1385,10 +1388,8 @@ export class OptionsWindow {
   private renderController(): void {
     const hooks = this.deps.options();
     const body = this.settingsViewShell(t('hudChrome.controller.title'));
-    if (hooks)
-      this.applyControls(body, buildControllerControls(this.settingsSource(hooks)), hooks, () =>
-        this.renderController(),
-      );
+    const controls = hooks ? buildControllerControls(this.settingsSource(hooks)) : [];
+    if (hooks) this.applyControls(body, controls, hooks, () => this.renderController());
 
     const note = document.createElement('div');
     note.className = 'set-note';
@@ -1438,7 +1439,7 @@ export class OptionsWindow {
       });
       body.appendChild(reset);
     }
-    this.settingsViewFooter();
+    this.settingsViewFooter(controls);
   }
 
   // -------------------------------------------------------------------------

--- a/tests/options_view.test.ts
+++ b/tests/options_view.test.ts
@@ -14,6 +14,7 @@ import {
   interfaceControlsForTab,
   type OptionsControl,
   type OptionsSettingsSource,
+  optionsControlKeys,
   sliderDispatchValue,
   toggleIsOn,
   toggleNextValue,
@@ -258,6 +259,49 @@ describe('options_view: controller dispatch matrix (cluster 5)', () => {
       control: 'slider',
       fmt: 'oneDecimal',
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// optionsControlKeys: scopes a sub-view's "Reset to Defaults" to only the
+// setting keys it actually renders (issue 2341: resetting Audio must not wipe
+// Graphics/Controller/Interface too).
+// ---------------------------------------------------------------------------
+describe('options_view: optionsControlKeys (issue 2341 scoped reset)', () => {
+  it('extracts the setting key from every keyed control, in order, deduped', () => {
+    const controls = buildControllerControls(makeSource());
+    expect(optionsControlKeys(controls)).toEqual([
+      'gamepadEnabled',
+      'gamepadInvertY',
+      'gamepadStickDeadzone',
+      'gamepadCameraSpeed',
+      'gamepadVibration',
+    ]);
+  });
+
+  it('drops NoteControl and MusicToggleControl, which carry no setting key', () => {
+    const controls = buildAudioControls(makeSource());
+    // buildAudioControls includes the bespoke musicToggle marker alongside the
+    // real setting-backed sliders/toggles.
+    expect(controls.some((c) => c.control === 'musicToggle')).toBe(true);
+    const keys = optionsControlKeys(controls);
+    expect(keys).not.toContain('musicToggle');
+    expect(keys).toEqual([
+      'sfxVolume',
+      'musicVolume',
+      'voiceVolume',
+      'voiceEnabled',
+      'footstepSfx',
+      'interfaceSfx',
+      'clickFeedback',
+    ]);
+
+    const graphics = buildGraphicsControls(makeSource(), { touch: false, nativeShell: false });
+    expect(graphics.some((c) => c.control === 'note')).toBe(true);
+    expect(optionsControlKeys(graphics)).not.toContain(undefined);
+    expect(optionsControlKeys(graphics).length).toBe(
+      graphics.filter((c) => c.control !== 'note').length,
+    );
   });
 });
 

--- a/tests/options_window.test.ts
+++ b/tests/options_window.test.ts
@@ -415,3 +415,43 @@ describe('options_window: settings shows the running version (#1541)', () => {
     expect(body.indexOf("'opt-version'")).toBeGreaterThan(body.indexOf('el.appendChild(list)'));
   });
 });
+
+// Reset to Defaults is scoped per sub-view (#2341): each of Graphics/Audio/Controller
+// must feed its OWN just-built controls list into the shared footer, and the footer
+// must reset/re-apply only the keys those controls carry, never a bare full reset.
+// settings.test.ts and options_view.test.ts already unit-test reset(keys) and
+// optionsControlKeys() in isolation; this pins the WIRING between them so a future
+// footer/call-site edit that quietly reverts to the old shared-state bug (e.g. a
+// call site passing the wrong controls list, or the footer falling back to a bare
+// settings.reset()) fails a test instead of shipping silently.
+describe('options_window: Reset to Defaults is scoped per sub-view (#2341)', () => {
+  it('settingsViewFooter derives keys from its controls param and resets/re-applies only those', () => {
+    const footer = painter.slice(
+      painter.indexOf('settingsViewFooter(controls: OptionsControl[]): void {'),
+    );
+    const body = footer.slice(0, footer.indexOf('\n  }\n'));
+    expect(body).toContain('const keys = optionsControlKeys(controls)');
+    // the reset call is scoped, never the bare no-arg full reset
+    expect(body).toContain('hooks?.settings.reset(keys)');
+    expect(body).not.toMatch(/settings\.reset\(\)/);
+    // re-apply loop walks only the scoped keys, never settings.all()
+    expect(body).toContain('for (const k of keys)');
+    expect(body).not.toContain('settings.all()');
+  });
+
+  it.each([
+    ['renderGraphics', 'buildGraphicsControls'],
+    ['renderAudio', 'buildAudioControls'],
+    ['renderController', 'buildControllerControls'],
+  ])(
+    '%s builds its own controls and passes that same list into settingsViewFooter',
+    (method, builder) => {
+      const start = painter.indexOf(`private ${method}(): void {`);
+      expect(start).toBeGreaterThan(-1);
+      const rest = painter.slice(start);
+      const body = rest.slice(0, rest.indexOf('\n  }\n'));
+      expect(body).toContain(builder);
+      expect(body).toContain('this.settingsViewFooter(controls)');
+    },
+  );
+});

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -226,6 +226,46 @@ describe('Settings', () => {
     expect(s.get('mobileCameraJoystick')).toBe(false);
   });
 
+  // Issue 2341: the Esc options menu's Graphics/Audio/Controller sub-views each
+  // have a "Reset to Defaults" button, but they used to share the same no-arg
+  // reset(), which wiped EVERY setting (all panels), not just the ones the
+  // player was looking at. reset(keys) scopes the restore to only the keys
+  // passed, so a sub-view can reset itself without touching the rest.
+  it('reset(keys) restores only the given keys, leaving out-of-scope settings untouched', () => {
+    const s = new Settings();
+    // In-scope for this call: one numeric key and one bool key.
+    s.set('sfxVolume', 0.1);
+    s.set('voiceEnabled', false);
+    // Out of scope: settings a different sub-view owns (graphics + interface).
+    s.set('graphicsPreset', 4);
+    s.set('uiScale', 1.3);
+    s.set('reduceMotion', true);
+
+    s.reset(['sfxVolume', 'voiceEnabled']);
+
+    expect(s.get('sfxVolume')).toBe(SETTING_RANGES.sfxVolume.def);
+    expect(s.get('voiceEnabled')).toBe(true); // BOOL_SETTINGS.voiceEnabled.def
+    // Untouched: these custom values must survive a reset scoped elsewhere.
+    expect(s.get('graphicsPreset')).toBe(4);
+    expect(s.get('uiScale')).toBe(1.3);
+    expect(s.get('reduceMotion')).toBe(true);
+
+    // The scoped restore also persists, like the full reset does.
+    expect(new Settings().get('sfxVolume')).toBe(SETTING_RANGES.sfxVolume.def);
+    expect(new Settings().get('graphicsPreset')).toBe(4);
+  });
+
+  it('reset() with no arguments still does a full reset (other callers keep their behavior)', () => {
+    const s = new Settings();
+    s.set('sfxVolume', 0.1);
+    s.set('graphicsPreset', 4);
+    s.set('reduceMotion', true);
+    s.reset();
+    expect(s.get('sfxVolume')).toBe(SETTING_RANGES.sfxVolume.def);
+    expect(s.get('graphicsPreset')).toBe(SETTING_RANGES.graphicsPreset.def);
+    expect(s.get('reduceMotion')).toBe(false);
+  });
+
   it('action button scale defaults to 1.0 and clamps to its slider bounds', () => {
     const s = new Settings();
     expect(s.get('actionButtonScale')).toBe(1);


### PR DESCRIPTION
## Summary

- The Esc options menu's Graphics, Audio, and Controller sub-views shared one footer whose "Reset to Defaults" button called `Settings.reset()` with no arguments, which restored **every** key in `GameSettings`, silently wiping the player's graphics preset, controller sensitivity, and every Interface/Frames/Chat/Combat preference no matter which tab they were looking at (#2341).
- `Settings.reset()` now accepts an optional `keys` array and only restores those when provided; the no-arg full reset is preserved for backward compatibility (confirmed it is otherwise unused elsewhere in `src/`).
- Each sub-view now passes its own already-built `OptionsControl[]` into `settingsViewFooter()`, which derives the in-scope setting keys via a new `optionsControlKeys()` helper (filtering out `NoteControl`/`MusicToggleControl`, which carry no setting key) and re-applies only those keys after the scoped reset.

## Diagram

```mermaid
sequenceDiagram
    participant Player
    participant Footer as settingsViewFooter (Audio tab)
    participant Settings

    rect rgb(60, 20, 20)
    Note over Player,Settings: Before
    Player->>Footer: click Reset to Defaults
    Footer->>Settings: reset()
    Settings-->>Footer: every GameSettings key restored
    Footer-->>Player: Graphics, Controller, Interface all silently reverted too
    end

    rect rgb(20, 50, 20)
    Note over Player,Settings: After
    Player->>Footer: click Reset to Defaults
    Footer->>Footer: optionsControlKeys(audioControls)
    Footer->>Settings: reset(scopedKeys)
    Settings-->>Footer: only Audio keys restored
    Footer-->>Player: Graphics, Controller, Interface untouched
    end
```

## Screenshots

Desktop, Esc menu Audio tab before/after clicking Reset while a Graphics preference is non-default (see attached).

## Test plan

- [x] `tests/settings.test.ts` - new scoped-reset case, plus a case confirming the no-arg full reset is unchanged
- [x] `tests/options_view.test.ts` - new coverage for `optionsControlKeys()`
- [x] `npx tsc --noEmit` clean
- [x] `npm run gate`
