### PR TITLE
fix(game): cancel pending chat long-press timer on blur and hide

### DIFF
--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -414,6 +414,7 @@ export class MobileControls {
       this.releaseCamera();
       this.releaseSwipeLook();
       this.touchOwners.releaseAll();
+      this.cancelChatPress();
     });
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'hidden') {
@@ -421,6 +422,7 @@ export class MobileControls {
         this.releaseCamera();
         this.releaseSwipeLook();
         this.touchOwners.releaseAll();
+        this.cancelChatPress();
       }
     });
 
@@ -658,17 +660,11 @@ export class MobileControls {
   private bindChatButton(id: string): void {
     const button = document.getElementById(id);
     if (!button) return;
-    const cancel = () => {
-      if (this.chatPressTimer !== null) {
-        clearTimeout(this.chatPressTimer);
-        this.chatPressTimer = null;
-      }
-    };
     button.addEventListener('pointerdown', (e) => {
       if (!this.active) return;
       e.preventDefault();
       this.chatLongFired = false;
-      cancel();
+      this.cancelChatPress();
       this.chatPressTimer = setTimeout(() => {
         this.chatLongFired = true;
         this.chatPressTimer = null;
@@ -678,11 +674,25 @@ export class MobileControls {
     button.addEventListener('pointerup', (e) => {
       if (!this.active) return;
       e.preventDefault();
-      cancel();
+      this.cancelChatPress();
       if (!this.chatLongFired) this.tapChat();
     });
-    button.addEventListener('pointercancel', cancel);
-    button.addEventListener('pointerleave', cancel);
+    button.addEventListener('pointercancel', () => this.cancelChatPress());
+    button.addEventListener('pointerleave', () => this.cancelChatPress());
+  }
+
+  /** Cancel a pending chat long-press timer (a tap or drag off the button, or the
+   *  gesture being interrupted before it completes) so it can never fire blind
+   *  after the fact. Only touches chatLongFired while the timer is still pending
+   *  (it is already false there); once the timer has fired, chatPressTimer is
+   *  already null and this is a no-op, so a completed long press is never
+   *  reopened as a tap by a later release. */
+  private cancelChatPress(): void {
+    if (this.chatPressTimer !== null) {
+      clearTimeout(this.chatPressTimer);
+      this.chatPressTimer = null;
+      this.chatLongFired = false;
+    }
   }
 
   /** Toggle the read-only chat-log peek. Opening a peek closes the full chat first (so a

--- a/tests/mobile_controls.test.ts
+++ b/tests/mobile_controls.test.ts
@@ -452,6 +452,7 @@ function installMobileControlDom(): {
   emoteButton: FakeElement;
   discordButton: FakeElement;
   donateButton: FakeElement;
+  chatButton: FakeElement;
   windowTarget: EventTarget;
 } {
   const autorunTarget = new FakeElement();
@@ -476,6 +477,7 @@ function installMobileControlDom(): {
     ['mobile-emote', new FakeElement()],
     ['mobile-discord', new FakeElement()],
     ['mobile-donate', new FakeElement()],
+    ['mobile-chat', new FakeElement()],
     // The chat composer, so exitChatReply (value clear + blur) is exercised in the
     // fake DOM: the setActive draft-survival test reads its .value.
     ['chat-input', new FakeElement()],
@@ -514,6 +516,7 @@ function installMobileControlDom(): {
     emoteButton: elements.get('mobile-emote')!,
     discordButton: elements.get('mobile-discord')!,
     donateButton: elements.get('mobile-donate')!,
+    chatButton: elements.get('mobile-chat')!,
     windowTarget,
   };
 }
@@ -2014,6 +2017,73 @@ describe('MobileControls pointer lifecycle', () => {
       }),
     );
     expect(lookActive).toEqual([true, false, false]);
+  });
+});
+
+describe('MobileControls chat button long-press', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const noopInput = () =>
+    ({
+      setTouchMove: () => {},
+      clearTouchMove: () => {},
+      setTouchLook: () => {},
+      setTouchLookVector: () => {},
+      applyTouchLookDelta: () => {},
+      zoomBy: () => {},
+    }) as unknown as Input;
+
+  it('toggles the log peek on an uninterrupted long press, and releasing afterward does not also open the composer', () => {
+    vi.useFakeTimers();
+    const { chatButton } = installMobileControlDom();
+    const chatOpens: string[] = [];
+    const callbacks = { ...mobileCallbacks(), onChatOpen: () => chatOpens.push('open') };
+    new MobileControls(noopInput(), callbacks).start();
+
+    chatButton.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1 }));
+    vi.advanceTimersByTime(CHAT_LONG_PRESS_MS);
+    expect(document.body.classList.contains('mobile-chatlog-peek')).toBe(true);
+
+    chatButton.dispatchEvent(pointerEvent('pointerup', { pointerId: 1 }));
+    expect(document.body.classList.contains('mobile-chatlog-peek')).toBe(true);
+    expect(chatOpens).toEqual([]);
+  });
+
+  it('cancels a pending long press on window blur so it never fires blind once the timer elapses', () => {
+    vi.useFakeTimers();
+    const { chatButton, windowTarget } = installMobileControlDom();
+    const chatOpens: string[] = [];
+    const callbacks = { ...mobileCallbacks(), onChatOpen: () => chatOpens.push('open') };
+    new MobileControls(noopInput(), callbacks).start();
+
+    chatButton.dispatchEvent(pointerEvent('pointerdown', { pointerId: 2 }));
+    // Interrupt well before the long-press threshold elapses, as an app/tab
+    // switch mid-gesture would.
+    vi.advanceTimersByTime(CHAT_LONG_PRESS_MS - 100);
+    (windowTarget as unknown as EventTarget).dispatchEvent(new Event('blur'));
+
+    // Advance well past the original deadline: without the fix the backgrounded
+    // setTimeout would still fire here and toggle the peek blind.
+    vi.advanceTimersByTime(CHAT_LONG_PRESS_MS);
+    expect(document.body.classList.contains('mobile-chatlog-peek')).toBe(false);
+    expect(chatOpens).toEqual([]);
+  });
+
+  it('cancels a pending long press when the tab is hidden (visibilitychange) so it never fires blind once the timer elapses', () => {
+    vi.useFakeTimers();
+    const { chatButton } = installMobileControlDom();
+    new MobileControls(noopInput(), mobileCallbacks()).start();
+
+    chatButton.dispatchEvent(pointerEvent('pointerdown', { pointerId: 3 }));
+    vi.advanceTimersByTime(CHAT_LONG_PRESS_MS - 100);
+
+    (document as unknown as { visibilityState: string }).visibilityState = 'hidden';
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    vi.advanceTimersByTime(CHAT_LONG_PRESS_MS);
+    expect(document.body.classList.contains('mobile-chatlog-peek')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- The mobile chat button's long-press timer (`chatPressTimer`) was only cleared on `pointerup`/`pointercancel`/`pointerleave`.
- The window `blur` and `document.visibilitychange` handlers already released the move joystick, camera joystick, and swipe-look touch ownership on tab/app switch, but never touched this timer, so a long-press started right before a player switched apps kept running in the background and toggled the chat log peek blind once it elapsed or the app resumed - even though the player never intended to complete the gesture.
- Extracted the inline `cancel` closure in `bindChatButton` into a private `cancelChatPress()` method and call it from the blur and visibilitychange handlers too, alongside the other touch-release calls already there, mirroring this repo's existing pinch-zoom release-tracking pattern.

This is a background-timer lifecycle fix with no visual/DOM effect, so no screenshots are attached.

## Test plan

- [x] `tests/mobile_controls.test.ts` - new cases: an uninterrupted long press still works, a pending long press is canceled on blur, and on visibilitychange (confirmed each fails against the pre-fix code for the expected reason)
- [x] `npx tsc --noEmit` clean
- [x] `npm run gate`
