### PR TITLE
fix(render): read mine mound offset/radius from the same per-entry fields as the collider

### DIFF
--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import type { GLTF } from 'three/addons/loaders/GLTFLoader.js';
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+import { mineMoundFootprint } from '../sim/colliders';
 import { getActiveWorldContent, WORLD_MIN_Z } from '../sim/data';
 import {
   DOCK_SECTION_LOCAL_Z,
@@ -1183,13 +1184,10 @@ export function buildProps(seed: number, delveLabel?: (delveId: string) => strin
     g.position.set(m.x, ground(m.x, m.z), m.z);
     g.rotation.y = m.rot;
     group.add(shadowed(g));
-    // mound circle behind the portal — same offset/radius as the collider
-    // (src/sim/colliders.ts), read from the same per-entry fields so the two
-    // can never drift apart again
-    const moundOffset = m.moundOffset ?? 3.4,
-      moundRadius = m.moundRadius ?? 5;
-    const mx = m.x - moundOffset * Math.sin(m.rot),
-      mz = m.z - moundOffset * Math.cos(m.rot);
+    // mound circle behind the portal, same offset/radius as the collider
+    // (src/sim/colliders.ts), via the shared mineMoundFootprint helper so the
+    // two can never drift apart again
+    const { x: mx, z: mz, r: moundRadius } = mineMoundFootprint(m);
     registerHideable(g, circleFootprint(mx, mz, moundRadius, ground(mx, mz) + moundRadius + 0.2));
   }
 

--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -1184,9 +1184,13 @@ export function buildProps(seed: number, delveLabel?: (delveId: string) => strin
     g.rotation.y = m.rot;
     group.add(shadowed(g));
     // mound circle behind the portal — same offset/radius as the collider
-    const mx = m.x - 3.4 * Math.sin(m.rot),
-      mz = m.z - 3.4 * Math.cos(m.rot);
-    registerHideable(g, circleFootprint(mx, mz, 5, ground(mx, mz) + 5.2));
+    // (src/sim/colliders.ts), read from the same per-entry fields so the two
+    // can never drift apart again
+    const moundOffset = m.moundOffset ?? 3.4,
+      moundRadius = m.moundRadius ?? 5;
+    const mx = m.x - moundOffset * Math.sin(m.rot),
+      mz = m.z - moundOffset * Math.cos(m.rot);
+    registerHideable(g, circleFootprint(mx, mz, moundRadius, ground(mx, mz) + moundRadius + 0.2));
   }
 
   // ---- fishing docks: pirate-kit platforms, moored rowboat, stone hut ------

--- a/src/sim/colliders.ts
+++ b/src/sim/colliders.ts
@@ -80,6 +80,23 @@ function rotY(lx: number, lz: number, rot: number): { x: number; z: number } {
   return { x: lx * c + lz * s, z: -lx * s + lz * c };
 }
 
+// default backward offset/radius for a mine's spoil mound behind the timber portal,
+// shared with the renderer (src/render/props.ts) so the two can't drift apart
+export const MINE_MOUND_DEFAULT_OFFSET = 3.4;
+export const MINE_MOUND_DEFAULT_RADIUS = 5;
+
+export function mineMoundFootprint(m: {
+  x: number;
+  z: number;
+  rot: number;
+  moundOffset?: number;
+  moundRadius?: number;
+}): { x: number; z: number; r: number } {
+  const r = m.moundRadius ?? MINE_MOUND_DEFAULT_RADIUS;
+  const mound = rotY(0, -(m.moundOffset ?? MINE_MOUND_DEFAULT_OFFSET), m.rot);
+  return { x: m.x + mound.x, z: m.z + mound.z, r };
+}
+
 // ---------------------------------------------------------------------------
 // Collider sets
 // ---------------------------------------------------------------------------
@@ -126,10 +143,7 @@ function staticWorldColliders(seed: number): Collider[] {
 
   // mines: mound behind the timber portal
   for (const m of PROPS.mines) {
-    const r = m.moundRadius ?? 5;
-    const mound = rotY(0, -(m.moundOffset ?? 3.4), m.rot);
-    const x = m.x + mound.x,
-      z = m.z + mound.z;
+    const { x, z, r } = mineMoundFootprint(m);
     out.push({ type: 'circle', x, z, r, cameraTopY: topY(seed, x, z, r + 0.2), camGhost: true });
   }
 

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -317,6 +317,32 @@ describe('terrain wall standoff', () => {
       }
     }
     expect(closest).toBeLessThan(2.0);
+    // Upper bound: the door-clear fix must not become an excuse to push the
+    // mound arbitrarily far back. The forward rock anchors nearest the portal
+    // (src/render/props.ts abandonedCrypt mound, local (1.75, -1.2) r 1.1 and
+    // (-1.7, -1.25) r 1.15) must stay solid, so a future offset bump can't
+    // silently turn the visible rubble into walk-through air.
+    expect(isBlocked(SEED, -153.2, 608.25, PLAYER_BODY_RADIUS)).toBe(true);
+    expect(isBlocked(SEED, -153.25, 611.7, PLAYER_BODY_RADIUS)).toBe(true);
+  });
+
+  it('keeps the OTHER mine mounds on the generic 3.4/5 default (moundOffset/moundRadius fallback)', () => {
+    // Only the Abandoned Crypt entry overrides moundOffset/moundRadius; this
+    // pins the `?? 3.4` / `?? 5` fallback arm of src/sim/colliders.ts so an
+    // edit to either default (or to the mound's rotY math) regresses these
+    // two entries silently while the crypt-only assertions above stay green.
+    const mineMoundFar = (x: number, z: number, rot: number) => ({
+      x: x - 15 * Math.sin(rot),
+      z: z - 15 * Math.cos(rot),
+    });
+    // Deeprock Burrows (88, 612, rot -2.0):
+    expect(isBlocked(SEED, 91.09, 613.41, PLAYER_BODY_RADIUS)).toBe(true); // mound center
+    const deeprockFar = mineMoundFar(88, 612, -2.0);
+    expect(isBlocked(SEED, deeprockFar.x, deeprockFar.z, PLAYER_BODY_RADIUS)).toBe(false); // far past the 5yd mound radius
+    // zone1 mine (-88, -68, rot 0.8):
+    expect(isBlocked(SEED, -90.44, -70.37, PLAYER_BODY_RADIUS)).toBe(true); // mound center
+    const zone1Far = mineMoundFar(-88, -68, 0.8);
+    expect(isBlocked(SEED, zone1Far.x, zone1Far.z, PLAYER_BODY_RADIUS)).toBe(false); // far past the 5yd mound radius
   });
 
   it('keeps the Abandoned Crypt mound collider matched to its visible rock pile', () => {


### PR DESCRIPTION
## Summary

- The Abandoned Crypt's mine-mound camera-hide footprint in `src/render/props.ts` hardcoded the old 3.4yd offset / 5yd radius constants, while `src/sim/colliders.ts` already read per-entry `m.moundOffset` / `m.moundRadius` fields for the same mound's physics collider (added specifically for the Abandoned Crypt entry in #2105).
- This meant the visible camera-hide circle could silently drift out of sync with the actual collider whenever an entry overrode those fields, breaking the "what you see is what you collide with" invariant documented in `colliders.ts`.
- Derives both values in `props.ts` from `m.moundOffset ?? 3.4` and `m.moundRadius ?? 5`, the same fallback expression the collider uses, so the two can never diverge again.
- Also pins the `?? 3.4` / `?? 5` fallback arm against Deeprock Burrows and the zone1 mine (only the Abandoned Crypt entry overrides them), and adds an upper-bound assertion on the door-clear test so the mound offset can't be pushed arbitrarily far back without also opening the forward rock anchors nearest the portal.

For the Abandoned Crypt entry itself the rendered position is numerically identical before and after (same formula, same current radius value), so this PR is about preventing future drift rather than changing today's visuals - no before/after screenshots are meaningful here.

## Test plan

- [x] `tests/fixes.test.ts` - extended door-clear test with an upper-bound assertion, plus a new test pinning the generic fallback arm for the other mine mounds
- [x] `npx tsc --noEmit` clean
- [x] `npm run gate`
