### PR TITLE
fix(ui): mirror compact-tier player frame nudge in left-handed mode

### DIFF
--- a/src/styles/hud.mobile.css
+++ b/src/styles/hud.mobile.css
@@ -5035,6 +5035,15 @@
   body.mobile-touch.hud-mobile-compact #swingbar {
     left: calc(50% - 15px);
   }
+  /* Left-handed mirrors Jump (and the ring) to the left, so mirror this nudge
+     right by the same magnitude, matching the #mobile-action-ring mirror above. */
+  body.mobile-touch.hud-mobile-compact.mobile-left-handed #player-frame {
+    left: calc(50% + 15px);
+  }
+  body.mobile-touch.hud-mobile-compact.mobile-left-handed #castbar,
+  body.mobile-touch.hud-mobile-compact.mobile-left-handed #swingbar {
+    left: calc(50% + 15px);
+  }
   /* Narrowest compact phones (galaxy-s8-class 740px and below): at that width the
      centred frame's right tail (right edge ~445) runs into Jump's ring crescent
      (its circle centre sits only ~82px right of viewport centre on so narrow a
@@ -5054,6 +5063,12 @@
     body.mobile-touch.hud-mobile-compact #castbar,
     body.mobile-touch.hud-mobile-compact #swingbar {
       left: calc(50% - 44px);
+    }
+    /* Left-handed mirror of the nudge above, same magnitude, opposite side. */
+    body.mobile-touch.hud-mobile-compact.mobile-left-handed #player-frame,
+    body.mobile-touch.hud-mobile-compact.mobile-left-handed #castbar,
+    body.mobile-touch.hud-mobile-compact.mobile-left-handed #swingbar {
+      left: calc(50% + 44px);
     }
   }
   /* Tablet: a large viewport can afford a bigger, easier-to-hit cluster than

--- a/tests/mobile_swing_cast_anchor.test.ts
+++ b/tests/mobile_swing_cast_anchor.test.ts
@@ -102,4 +102,33 @@ describe('mobile swing/cast bar anchoring (issue 1577 (6))', () => {
       /hud-mobile-compact #castbar,[\s\S]{0,80}hud-mobile-compact #swingbar \{/.test(mobileCss),
     ).toBe(true);
   });
+
+  it('mirrors the compact-tier frame nudge to the right in left-handed mode', () => {
+    // Left-handed mode mirrors Jump (and the whole action ring) to the left side,
+    // so the frame's Jump-dodging nudge must flip sign too, or it drifts into the
+    // mirrored Jump crescent instead of away from it.
+    expect(
+      /hud-mobile-compact\.mobile-left-handed #player-frame \{\s*left: calc\(50% \+ 15px\);/.test(
+        mobileCss,
+      ),
+    ).toBe(true);
+    expect(
+      /hud-mobile-compact\.mobile-left-handed #castbar,\s*body\.mobile-touch\.hud-mobile-compact\.mobile-left-handed #swingbar \{\s*left: calc\(50% \+ 15px\);/.test(
+        mobileCss,
+      ),
+    ).toBe(true);
+  });
+
+  it('mirrors the narrow landscape-gated frame nudge to the right in left-handed mode', () => {
+    const landscapeStart = mobileCss.indexOf('max-width: 800px) and (orientation: landscape)');
+    expect(landscapeStart).toBeGreaterThan(-1);
+    const landscapeEnd = mobileCss.indexOf('/* Tablet:', landscapeStart);
+    expect(landscapeEnd).toBeGreaterThan(landscapeStart);
+    const landscapeBlock = mobileCss.slice(landscapeStart, landscapeEnd);
+    expect(
+      /hud-mobile-compact\.mobile-left-handed #player-frame,\s*body\.mobile-touch\.hud-mobile-compact\.mobile-left-handed #castbar,\s*body\.mobile-touch\.hud-mobile-compact\.mobile-left-handed #swingbar \{\s*left: calc\(50% \+ 44px\);/.test(
+        landscapeBlock,
+      ),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- On compact and narrow-landscape mobile HUD tiers, the player frame (plus its castbar/swingbar) is nudged left to dodge the default right-side Jump button.
- Left-handed mode mirrors Jump and the whole action ring to the left side, but the frame nudge had no left-handed counterpart, so it kept shifting left too and drifted straight into the newly-mirrored Jump crescent instead of clearing it.
- Added `.mobile-left-handed` variants for both the compact tier (`calc(50% + 15px)`) and the `max-width: 800px` landscape-gated narrow tier (`calc(50% + 44px)`) that shift the frame, castbar, and swingbar right by the same magnitude, mirroring the existing `#mobile-action-ring` left-handed pattern already in the same file.

## Test plan

- [x] `tests/mobile_swing_cast_anchor.test.ts` - new selector-presence assertions for both new left-handed mirror rules
- [x] `npx tsc --noEmit` clean
- [x] `npm run gate`
