### PR TITLE
fix(ui): repaint the character sheet on prestige rank change

### DIFF
--- a/src/sim/progression/xp.ts
+++ b/src/sim/progression/xp.ts
@@ -76,5 +76,9 @@ export function prestige(ctx: SimContext, pid?: number): boolean {
     text: `You have prestiged! Prestige Rank ${r.meta.prestigeRank}.`,
     color: '#ffd100',
   });
+  // Dedicated, text-free signal (distinct from the chat 'log' line above) so
+  // the client can repaint an already-open character sheet's prestige rank
+  // immediately, instead of waiting on an unrelated repaint trigger.
+  ctx.emit({ type: 'prestige', pid: r.e.id, rank: r.meta.prestigeRank });
   return true;
 }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -3187,6 +3187,11 @@ export type SimEvent = { pid?: number } & (
   // level past the cap (milestone unlocks ride the deedUnlocked event since
   // the milestone unification; the legacy milestoneUnlocked emit is gone)
   | { type: 'virtualLevelUp'; level: number }
+  // Cosmetic prestige (prestige(), src/sim/progression/xp.ts): fired alongside
+  // the 'log' chat line so the client can repaint an already-open character
+  // sheet's prestige rank without waiting for an unrelated repaint trigger
+  // (closing/reopening the window). Text-free: the chat line is the 'log' event.
+  | { type: 'prestige'; rank: number }
   // Book of Deeds unlock (always personal: emitted with pid). Carries the deed
   // ID only, never English text; `retro` marks the on-join back-credit pass so
   // the client can batch those into one summary line instead of banner spam.

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -9007,6 +9007,15 @@ export class Hud {
           audio.levelUp();
           break;
         }
+        case 'prestige': {
+          // Keep the character sheet's prestige rank live if the sheet is open
+          // (mirrors the 'honor' case above): the chat/log line already
+          // announced the rank via the accompanying 'log' event, this just
+          // repaints an already-open sheet instead of leaving it stale until
+          // some unrelated trigger closes/reopens it.
+          this.renderCharIfOpen();
+          break;
+        }
         case 'deedUnlocked': {
           deedUnlocks.push(ev);
           break;

--- a/tests/honor_ui.test.ts
+++ b/tests/honor_ui.test.ts
@@ -32,3 +32,17 @@ describe('Honor and ranked Arena chat feedback', () => {
     expect(handler).not.toContain('this.combatLog(arenaResultLine');
   });
 });
+
+describe('prestige event repaints an already-open character sheet (issue #2137)', () => {
+  it('the prestige event case calls renderCharIfOpen, same as the honor case', () => {
+    const start = hud.indexOf("case 'prestige':");
+    const end = hud.indexOf("case 'deedUnlocked':", start);
+    const handler = hud.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    // Without this, an already-open character sheet keeps showing the stale
+    // prestige rank until something unrelated triggers a repaint (closing
+    // and reopening the window), which is the bug reported in #2137.
+    expect(handler).toContain('this.renderCharIfOpen()');
+  });
+});

--- a/tests/parity/golden/g1b_xp_prestige.json
+++ b/tests/parity/golden/g1b_xp_prestige.json
@@ -769,7 +769,7 @@
       "time": 3,
       "nextId": 416,
       "state": "87876dad",
-      "events": "430e2101",
+      "events": "f92c18e2",
       "rng": {
         "draws": 75,
         "digest": "cc652885"

--- a/tests/xp.test.ts
+++ b/tests/xp.test.ts
@@ -312,6 +312,22 @@ describe('prestige', () => {
     expect(sim.prestige()).toBe(false);
     expect(sim.prestigeRank).toBe(0);
   });
+
+  it('emits a dedicated prestige event carrying the new rank (issue #2137)', () => {
+    // Regression: the character sheet only repaints on a small explicit set of
+    // triggers, and prestige used to emit only a chat 'log' line, so an
+    // already-open sheet kept showing the stale rank. A dedicated event lets
+    // the HUD repaint the sheet the moment prestige lands.
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(MAX_LEVEL);
+    sim.grantXp(PRESTIGE_XP_PER_RANK);
+    sim.events.length = 0;
+    expect(sim.prestige()).toBe(true);
+    const prestigeEvents = sim.events.filter((e) => e.type === 'prestige');
+    expect(prestigeEvents).toHaveLength(1);
+    expect((prestigeEvents[0] as any).rank).toBe(1);
+    expect(sim.prestigeRank).toBe(1);
+  });
 });
 
 describe('prestige anti-abuse gate (server-locked rank)', () => {


### PR DESCRIPTION
## Summary

Fixes #2137: the character sheet's Prestige Rank looked stuck after prestiging.

- `prestige()` (`src/sim/progression/xp.ts`) only ever emitted a generic chat `'log'` event for the "You have prestiged!" line, and `hud.ts`'s `'log'` case never repaints the character sheet.
- The sheet only redraws on a small explicit set of triggers, so an already-open sheet kept showing the old rank until some unrelated trigger (like closing and reopening the window) forced a redraw.
- Adds a dedicated, text-free `{ type: 'prestige'; rank }` `SimEvent` emitted alongside the existing log line, and a `hud.ts` case that calls `renderCharIfOpen()`, mirroring the existing `'honor'` case that already keeps the sheet's Honor balance live the same way.
- No sim behavior, balance, or wire/parity shape changed otherwise; only the `g1b_xp_prestige` parity golden's per-tick event digest was regenerated to reflect the new event.

(A prior attempt at this same fix exists as PR #2216, but it targets the stale, unmerged `release/v0.29.0` base. This reimplements the same approach fresh against current `release/v0.30.0`.)

## Diagram

```mermaid
sequenceDiagram
    participant Sim as prestige()
    participant Hud

    rect rgb(60, 20, 20)
    Note over Sim,Hud: Before
    Sim->>Hud: emit 'log' ("Prestige Rank N")
    Hud->>Hud: append chat line only
    Note over Hud: open character sheet stays stale
    end

    rect rgb(20, 50, 20)
    Note over Sim,Hud: After
    Sim->>Hud: emit 'log' ("Prestige Rank N")
    Sim->>Hud: emit 'prestige' { rank }
    Hud->>Hud: renderCharIfOpen()
    Note over Hud: open character sheet updates immediately
    end
```

## Screenshots

To follow (reproducing requires leveling a character past the level cap and prestiging, which needs a dev-command-enabled server session).

## Test plan

- [x] `tests/xp.test.ts` - new case asserting `prestige()` emits the dedicated event with the correct rank
- [x] `tests/honor_ui.test.ts` - new coverage asserting the `'prestige'` case repaints the sheet, mirroring the existing `'honor'` case test
- [x] `tests/parity/golden/g1b_xp_prestige.json` regenerated (only the new event in the per-tick digest changed)
- [x] `npx tsc --noEmit` clean
- [x] `npm run gate`
