### PR TITLE
fix(sim): make normal Sanctum clearable for fresh level-20 groups; nerf heroic boss adds 40%

### DIFF
--- a/scripts/sanctum_fresh_montecarlo.ts
+++ b/scripts/sanctum_fresh_montecarlo.ts
@@ -1,0 +1,690 @@
+// Monte Carlo: NORMAL Gravewyrm Sanctum vs a FRESH level-20 group (the
+// clearability companion to scripts/healing_montecarlo.ts, which benches
+// best-in-slot groups vs heroics). Drives the REAL Sim: freshly-capped tanks
+// (quest greens/blues, no epics, no heroic variants) against normal-Sanctum
+// transformed mobs, one seeded Sim per run, so variance comes from real
+// crit/miss/dodge/parry rolls.
+//
+// Three benches:
+//   A) intake: per-hit damage distribution and DTPS on each committed tank
+//      (prot warrior, protection paladin, feral druid) from every Sanctum
+//      encounter shape, both sides pinned to full HP so the distribution is
+//      not censored by death, enrage, or summon thresholds
+//   B) survival: fresh tank + fresh healer + a modeled fresh-DPS drain runs
+//      the real fight (enrage fires, Velkhar's add waves spawn tuned at his
+//      66%/33% thresholds): cleared-vs-tank-death outcomes
+//   C) solo ceiling (economy guard): DTPS on a best-in-slot max-EHP warrior,
+//      compared against the ~140 hps self-heal ceiling of the strongest solo
+//      archetype, so the retune provably keeps solo boss-farming dead
+//
+// Run: npx tsx scripts/sanctum_fresh_montecarlo.ts [--runs N] [--quick]
+// Writes tmp/sanctum_mc/report.json and prints the digest tables.
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { defaultBuild, validateAllocation } from '../src/sim/content/talents';
+import { ITEMS, MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import { canEquipItem } from '../src/sim/equipment_rules';
+import {
+  applyDungeonMobTuning,
+  mobTemplateForDungeonDifficulty,
+} from '../src/sim/instances/difficulty';
+import { Sim } from '../src/sim/sim';
+import {
+  type Entity,
+  type EquipSlot,
+  type ItemDef,
+  MAX_LEVEL,
+  MELEE_RANGE,
+} from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
+import {
+  applyTankRaidBuffs,
+  cast,
+  face,
+  HEALER_SPECS,
+  healTick,
+  round1,
+  type Spec,
+  summarize,
+  teleport,
+} from './healing_montecarlo';
+
+function must<T>(value: T | undefined | null, label = 'expected value'): T {
+  if (value === undefined || value === null) throw new Error(`must: ${label} was missing`);
+  return value;
+}
+
+// ---------------------------------------------------------------- CLI / knobs
+
+const args = process.argv.slice(2);
+const QUICK = args.includes('--quick');
+const runsFlag = args.indexOf('--runs');
+const RUNS = runsFlag >= 0 ? Number(args[runsFlag + 1]) : QUICK ? 2 : 8;
+const INTAKE_SECONDS = QUICK ? 20 : 60;
+const SURVIVAL_CAP_SECONDS = QUICK ? 60 : 240;
+const BASE_SEED = 424200;
+
+const SANCTUM = 'gravewyrm_sanctum';
+const ARENA = { x: -2000, z: 3000 };
+
+// Three fresh level-20 damage dealers focus-killing alongside the tank. A
+// best-in-slot fire mage sustains ~233 dps (healing MC raid bench); fresh
+// greens/blues players land well under half that.
+const GROUP_DPS = 240;
+// The strongest solo archetype's sustained self-heal (the solo economy line
+// documented in tests/gravewyrm_normal_tuning.test.ts).
+const SOLO_SELF_HEAL_CEILING = 140;
+
+// ------------------------------------------------------------------- specs
+
+const TANK_SPECS: Spec[] = [
+  {
+    key: 'prot_warrior',
+    cls: 'warrior',
+    kind: 'tank',
+    talents: {
+      spec: 'prot',
+      rows: {
+        5: 'war_row_double_charge',
+        8: 'war_row_second_wind',
+        11: 'war_row_piercing_howl',
+        14: 'war_row_anger_management',
+        17: 'war_row_avatar',
+        20: 'war_row_colossal_might',
+      },
+    },
+    setup: ['defensive_stance'],
+  },
+  {
+    key: 'protection_paladin',
+    cls: 'paladin',
+    kind: 'tank',
+    talents: {
+      spec: 'protection',
+      rows: {
+        5: 'pal_r5_crusaders_zeal',
+        8: 'pal_r8_consecrated_ground',
+        11: 'pal_r11_guardians_favor',
+        14: 'pal_r14_righteous_cause',
+        17: 'pal_r17_ardent_defender',
+        20: 'pal_r20_avenging_wrath',
+      },
+    },
+    setup: [],
+  },
+  {
+    key: 'feral_druid',
+    cls: 'druid',
+    kind: 'tank',
+    talents: {
+      spec: 'feral',
+      rows: {
+        5: 'dru_r5_ferocity',
+        8: 'dru_r8_brutal_bash',
+        11: 'dru_r11_furor',
+        14: 'dru_r14_savage_fury',
+        17: 'dru_r17_survival_of_the_fittest',
+        20: 'dru_r20_berserk',
+      },
+    },
+    setup: ['bear_form'],
+  },
+];
+
+// Fresh healer for the survival bench: restoration shaman, the strongest
+// sustain healer (healing MC bench A), re-geared to the fresh tier below.
+const FRESH_HEALER = must(
+  HEALER_SPECS.find((s) => s.key === 'restoration_shaman'),
+  'restoration_shaman spec',
+);
+
+// -------------------------------------------------------------------- gear
+
+// 'fresh': what a freshly-capped 20 can wear out of questing and normal
+// leveling drops: no epics, no legendaries, no heroic-minted variants.
+// 'bis': everything, the healing MC best-in-slot tier (solo ceiling bench).
+type KitTier = 'fresh' | 'bis';
+
+function tierAllows(tier: KitTier, item: ItemDef): boolean {
+  if (tier === 'bis') return true;
+  if (item.quality === 'epic' || item.quality === 'legendary') return false;
+  if (item.id.startsWith('heroic_')) return false;
+  return true;
+}
+
+function statScore(item: ItemDef, spec: Spec): number {
+  const s = item.stats ?? {};
+  const weapon = item.weapon ? (item.weapon.min + item.weapon.max) / 2 / item.weapon.speed : 0;
+  if (spec.kind === 'healer')
+    return (
+      weapon + (s.int ?? 0) * 5.4 + (s.spi ?? 0) * 4.4 + (s.sta ?? 0) * 0.8 + (s.armor ?? 0) * 0.004
+    );
+  // Tank: max-EHP pick (stamina first, armor as tiebreak), the same weighting
+  // that reproduces the floors-test reference warrior at the 'bis' tier.
+  return (s.sta ?? 0) * 100 + (s.armor ?? 0) * 0.1 + weapon * 0.01;
+}
+
+const ARMOR_SLOTS: EquipSlot[] = [
+  'helmet',
+  'neck',
+  'shoulder',
+  'chest',
+  'waist',
+  'legs',
+  'gloves',
+  'feet',
+];
+
+function equipCandidates(spec: Spec, tier: KitTier, filter: (item: ItemDef) => boolean): ItemDef[] {
+  return Object.values(ITEMS)
+    .filter(
+      (item) =>
+        (item.kind === 'weapon' || item.kind === 'armor' || item.kind === 'held_offhand') &&
+        canEquipItem(spec.cls, item) &&
+        tierAllows(tier, item) &&
+        filter(item),
+    )
+    .sort((a, b) => statScore(b, spec) - statScore(a, spec));
+}
+
+function give(sim: Sim, pid: number, itemId: string, slot?: EquipSlot) {
+  sim.addItem(itemId, 1, pid);
+  if (slot) sim.equipItemToSlot(itemId, slot, pid);
+  else sim.equipItem(itemId, pid);
+}
+
+function equipTier(sim: Sim, pid: number, spec: Spec, tier: KitTier) {
+  for (const slot of ARMOR_SLOTS) {
+    const item = equipCandidates(spec, tier, (i) => i.slot === slot)[0];
+    if (item) give(sim, pid, item.id);
+  }
+  const rings = equipCandidates(spec, tier, (i) => i.slot === 'ring').slice(0, 2);
+  if (rings[0]) give(sim, pid, rings[0].id, 'ring1');
+  if (rings[1]) give(sim, pid, rings[1].id, 'ring2');
+  const twoHand = equipCandidates(
+    spec,
+    tier,
+    (i) => i.slot === 'mainhand' && i.kind === 'weapon' && i.weapon?.hand === 'twohand',
+  )[0];
+  const oneHand = equipCandidates(
+    spec,
+    tier,
+    (i) => i.slot === 'mainhand' && i.kind === 'weapon' && i.weapon?.hand !== 'twohand',
+  )[0];
+  const offhand = equipCandidates(spec, tier, (i) => i.slot === 'offhand')[0];
+  const comboScore =
+    (oneHand ? statScore(oneHand, spec) : 0) + (offhand ? statScore(offhand, spec) : 0);
+  const twoHandScore = twoHand ? statScore(twoHand, spec) : 0;
+  if (comboScore >= twoHandScore) {
+    if (oneHand) give(sim, pid, oneHand.id);
+    if (offhand) give(sim, pid, offhand.id);
+  } else if (twoHand) {
+    give(sim, pid, twoHand.id);
+  }
+}
+
+function ensureTalents(sim: Sim, pid: number, spec: Spec) {
+  const check = validateAllocation(spec.cls, spec.talents, MAX_LEVEL);
+  if (!check.ok) console.warn(`invalid talents for ${spec.key}: ${check.reason}`);
+  if (!sim.applyTalents(spec.talents, pid)) {
+    console.warn(`applyTalents rejected build for ${spec.key}, using default`);
+    sim.applyTalents(defaultBuild(spec.cls, MAX_LEVEL), pid);
+  }
+}
+
+function addTierPlayer(sim: Sim, spec: Spec, name: string, tier: KitTier): number {
+  const pid = sim.addPlayer(spec.cls, name);
+  sim.setPlayerLevel(MAX_LEVEL, pid);
+  ensureTalents(sim, pid, spec);
+  equipTier(sim, pid, spec, tier);
+  return pid;
+}
+
+// --------------------------------------------------------------- sim helpers
+
+type SimInner = { addEntity(e: Entity): void };
+
+function spawnNormalMob(
+  sim: Sim,
+  mobId: string,
+  at: { x: number; z: number },
+  level?: number,
+): Entity {
+  const template = mobTemplateForDungeonDifficulty(MOBS[mobId], SANCTUM, 'normal');
+  const mob = createMob(sim.nextId++, template, level ?? template.maxLevel, {
+    x: at.x,
+    y: groundHeight(at.x, at.z, sim.cfg.seed),
+    z: at.z,
+  });
+  mob.hostile = true;
+  // Entity-level stamping: mechanic (stomp / Grave Inferno) multipliers live
+  // on the ENTITY; without this boss mechanics fire at base damage.
+  applyDungeonMobTuning(mob, SANCTUM, 'normal');
+  (sim as unknown as SimInner).addEntity(mob);
+  return mob;
+}
+
+function engage(mob: Entity, tank: Entity) {
+  mob.inCombat = true;
+  mob.aiState = 'attack';
+  pinThreat(mob, tank);
+}
+
+function pinThreat(mob: Entity, tank: Entity) {
+  mob.aggroTargetId = tank.id;
+  mob.threat.set(tank.id, 1e9);
+}
+
+function sweepForeignMobs(sim: Sim, keep: Set<number>) {
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || keep.has(e.id) || e.dead) continue;
+    const dx = e.pos.x - ARENA.x;
+    const dz = e.pos.z - ARENA.z;
+    if (dx * dx + dz * dz < 150 * 150) {
+      e.hp = 0;
+      e.dead = true;
+      // Bench kills bypass handleDeath, so park the in-place respawn
+      // (mob/locomotion.ts revives a dead overworld mob when respawnTimer
+      // runs out) the same way handleDeath does for scheduler-owned mobs.
+      e.respawnTimer = Infinity;
+    }
+  }
+}
+
+type TankSetup = { pid: number; tank: Entity };
+
+function setupTank(sim: Sim, spec: Spec, tier: KitTier, buffed: boolean): TankSetup {
+  const pid = addTierPlayer(sim, spec, 'Tank', tier);
+  teleport(sim, pid, ARENA.x, ARENA.z);
+  const tank = must(sim.entities.get(pid), `tank entity ${pid}`);
+  for (const ability of spec.setup ?? []) cast(sim, pid, pid, ability);
+  sim.tick();
+  sim.tick();
+  if (buffed) applyTankRaidBuffs(sim, pid);
+  tank.hp = tank.maxHp;
+  return { pid, tank };
+}
+
+// -------------------------------------------------------------- encounters
+
+type EncounterMob = { mobId: string; level?: number };
+type Encounter = { key: string; mobs: EncounterMob[]; note?: string };
+
+const ENCOUNTERS: Encounter[] = [
+  {
+    key: 'trash_2boneguard_1drakonid',
+    mobs: [
+      { mobId: 'sanctum_boneguard' },
+      { mobId: 'sanctum_boneguard' },
+      { mobId: 'sanctum_drakonid' },
+    ],
+    note: 'the standard three-elite pull, drakonid at its level-20 max roll',
+  },
+  {
+    key: 'adds_3bonewalkers',
+    mobs: [
+      { mobId: 'raised_bonewalker' },
+      { mobId: 'raised_bonewalker' },
+      { mobId: 'raised_bonewalker' },
+    ],
+    note: "one of Velkhar's summon waves, alone",
+  },
+  { key: 'midboss_korgath', mobs: [{ mobId: 'korgath_the_bound' }] },
+  { key: 'midboss_velkhar', mobs: [{ mobId: 'grand_necromancer_velkhar' }] },
+  {
+    key: 'velkhar_plus_3adds',
+    mobs: [
+      { mobId: 'grand_necromancer_velkhar' },
+      { mobId: 'raised_bonewalker' },
+      { mobId: 'raised_bonewalker' },
+      { mobId: 'raised_bonewalker' },
+    ],
+    note: 'the mid-fight steady state while a wave is up',
+  },
+  { key: 'boss_korzul', mobs: [{ mobId: 'korzul_the_gravewyrm' }] },
+];
+
+function spawnEncounter(sim: Sim, encounter: Encounter, tank: Entity): Entity[] {
+  const mobs: Entity[] = [];
+  encounter.mobs.forEach((em, i) => {
+    const angle = (Math.PI * 2 * i) / 6;
+    const mob = spawnNormalMob(
+      sim,
+      em.mobId,
+      {
+        x: ARENA.x + Math.sin(angle) * (MELEE_RANGE - 1),
+        z: ARENA.z + Math.cos(angle) * (MELEE_RANGE - 1),
+      },
+      em.level,
+    );
+    engage(mob, tank);
+    mobs.push(mob);
+  });
+  face(tank, mobs[0]);
+  return mobs;
+}
+
+// ------------------------------------------------------------------ bench A
+
+type IntakeRun = {
+  dtps: number;
+  hits: number[];
+  crits: number;
+  avoided: number;
+  byAbility: Record<string, { count: number; total: number; max: number }>;
+  tankArmor: number;
+  tankMaxHp: number;
+};
+
+function runIntake(spec: Spec, encounter: Encounter, seed: number, tier: KitTier): IntakeRun {
+  const sim = new Sim({ seed, playerClass: 'warrior', noPlayer: true });
+  const { pid, tank } = setupTank(sim, spec, tier, tier === 'bis');
+  const mobs = spawnEncounter(sim, encounter, tank);
+  const keep = new Set(mobs.map((m) => m.id));
+  const hits: number[] = [];
+  let crits = 0;
+  let avoided = 0;
+  const byAbility: IntakeRun['byAbility'] = {};
+  const ticks = INTAKE_SECONDS * 20;
+  for (let tick = 0; tick < ticks; tick++) {
+    tank.hp = tank.maxHp; // immortal probe: the full distribution, uncensored
+    for (const mob of mobs) {
+      if (mob.dead) continue;
+      mob.hp = mob.maxHp; // pinned: no enrage, no summon thresholds, no death
+      pinThreat(mob, tank);
+    }
+    sim.startAutoAttack(pid);
+    const events = sim.tick();
+    for (const event of events) {
+      if (event.type !== 'damage' || event.targetId !== pid) continue;
+      if (event.kind === 'hit') {
+        hits.push(event.amount);
+        if (event.crit) crits++;
+        const label = event.ability ?? 'melee';
+        let slot = byAbility[label];
+        if (!slot) {
+          slot = { count: 0, total: 0, max: 0 };
+          byAbility[label] = slot;
+        }
+        slot.count++;
+        slot.total += event.amount;
+        slot.max = Math.max(slot.max, event.amount);
+      } else {
+        avoided++;
+      }
+    }
+    if (tick % 40 === 0) sweepForeignMobs(sim, keep);
+  }
+  return {
+    dtps: hits.reduce((a, b) => a + b, 0) / INTAKE_SECONDS,
+    hits,
+    crits,
+    avoided,
+    byAbility,
+    tankArmor: tank.stats.armor,
+    tankMaxHp: tank.maxHp,
+  };
+}
+
+// ------------------------------------------------------------------ bench B
+
+type SurvivalRun = {
+  cleared: boolean;
+  tankDeathSeconds: number | null;
+  clearSeconds: number | null;
+  healerOomSeconds: number | null;
+  minTankHpFrac: number;
+};
+
+// Velkhar's real fight summons tuned waves at 66%/33%. Standalone arena
+// spawns sit in no instance, so the sim's own spawnBossAdds path would mint
+// UNTUNED adds; the bench pre-fires his thresholds and spawns the waves
+// itself through the normal-Sanctum transform.
+function runSurvival(spec: Spec, encounter: Encounter, seed: number): SurvivalRun {
+  const sim = new Sim({ seed, playerClass: 'warrior', noPlayer: true });
+  const { pid: tankPid, tank } = setupTank(sim, spec, 'fresh', false);
+  const healerPid = addTierPlayer(sim, FRESH_HEALER, 'Healer', 'fresh');
+  teleport(sim, healerPid, ARENA.x + 20, ARENA.z + 20);
+  const healer = must(sim.entities.get(healerPid), `healer entity ${healerPid}`);
+  const mobs = spawnEncounter(sim, encounter, tank);
+  const keep = new Set(mobs.map((m) => m.id));
+  const velkhar = mobs.find((m) => m.templateId === 'grand_necromancer_velkhar');
+  if (velkhar) velkhar.firedSummons = 2; // bench owns the waves (see above)
+  const waveThresholds = velkhar ? [0.66, 0.33] : [];
+  let wavesFired = 0;
+  let tankDeath: number | null = null;
+  let cleared: number | null = null;
+  let healerOom: number | null = null;
+  let minTankHpFrac = 1;
+  const ticks = SURVIVAL_CAP_SECONDS * 20;
+  for (let tick = 0; tick < ticks; tick++) {
+    // The modeled DPS drain focus-kills adds first, then the pull in order.
+    const alive = mobs.filter((m) => !m.dead);
+    if (alive.length === 0) {
+      cleared = tick / 20;
+      break;
+    }
+    const adds = alive.filter((m) => m.templateId === 'raised_bonewalker');
+    const killTarget = adds[0] ?? alive[0];
+    killTarget.hp -= GROUP_DPS / 20;
+    if (killTarget.hp <= 0) {
+      killTarget.hp = 0;
+      killTarget.dead = true;
+      // Park the in-place respawn; without this the arena "corpse" revives
+      // at full health ~25s later and the encounter never clears.
+      killTarget.respawnTimer = Infinity;
+    }
+    if (velkhar && !velkhar.dead && wavesFired < waveThresholds.length) {
+      const frac = velkhar.hp / Math.max(1, velkhar.maxHp);
+      if (frac <= waveThresholds[wavesFired]) {
+        wavesFired++;
+        for (let k = 0; k < 3; k++) {
+          const ang = (k / 3) * Math.PI * 2 + 0.7;
+          const add = spawnNormalMob(sim, 'raised_bonewalker', {
+            x: velkhar.pos.x + Math.sin(ang) * 3.5,
+            z: velkhar.pos.z + Math.cos(ang) * 3.5,
+          });
+          engage(add, tank);
+          mobs.push(add);
+          keep.add(add.id);
+        }
+      }
+    }
+    for (const mob of mobs) if (!mob.dead) pinThreat(mob, tank);
+    sim.startAutoAttack(tankPid);
+    if (tank.hp < tank.maxHp) {
+      healTick(sim, healerPid, tank, FRESH_HEALER, FRESH_HEALER.healPriority ?? []);
+    }
+    if (healerOom === null && !healer.castingAbility && healer.resource < 25) {
+      healerOom = tick / 20;
+    }
+    const events = sim.tick();
+    for (const event of events) {
+      if (event.type === 'death' && event.entityId === tankPid) tankDeath = tick / 20;
+    }
+    if (process.env.DEBUG_SURVIVAL && tick % 100 === 0) {
+      const aliveNow = mobs.filter((m) => !m.dead);
+      console.log(
+        `  dbg t=${(tick / 20).toFixed(0)}s alive=${aliveNow.length} ` +
+          `firstHp=${aliveNow[0] ? Math.round(aliveNow[0].hp) : 0} ` +
+          `tankHp=${Math.round(tank.hp)}/${tank.maxHp} mana=${Math.round(healer.resource)} ` +
+          `healerDead=${healer.dead}`,
+      );
+    }
+    minTankHpFrac = Math.min(minTankHpFrac, Math.max(0, tank.hp) / tank.maxHp);
+    if (tankDeath !== null) break;
+    if (tick % 40 === 0) sweepForeignMobs(sim, keep);
+  }
+  return {
+    cleared: cleared !== null,
+    tankDeathSeconds: tankDeath,
+    clearSeconds: cleared,
+    healerOomSeconds: healerOom,
+    minTankHpFrac: round1(minTankHpFrac * 100) / 100,
+  };
+}
+
+// -------------------------------------------------------------------- main
+
+function main() {
+  const startedAt = Date.now();
+  console.log(
+    `sanctum fresh monte carlo: runs=${RUNS} intake=${INTAKE_SECONDS}s ` +
+      `survivalCap=${SURVIVAL_CAP_SECONDS}s groupDps=${GROUP_DPS}`,
+  );
+
+  // Tank profiles at both tiers.
+  const profiles: Record<string, Record<string, unknown>> = {};
+  for (const spec of TANK_SPECS) {
+    for (const tier of ['fresh', 'bis'] as KitTier[]) {
+      const sim = new Sim({ seed: BASE_SEED, playerClass: 'warrior', noPlayer: true });
+      const { tank } = setupTank(sim, spec, tier, false);
+      profiles[`${spec.key}__${tier}`] = {
+        maxHp: tank.maxHp,
+        armor: tank.stats.armor,
+        sta: tank.stats.sta,
+      };
+      console.log(
+        `P ${spec.key.padEnd(20)} ${tier.padEnd(5)} hp ${String(tank.maxHp).padStart(5)} ` +
+          `armor ${String(tank.stats.armor).padStart(5)}`,
+      );
+    }
+  }
+
+  // Bench A: fresh-tank intake per encounter.
+  const intake: Record<string, Record<string, unknown>> = {};
+  for (const spec of TANK_SPECS) {
+    for (const encounter of ENCOUNTERS) {
+      const runs: IntakeRun[] = [];
+      for (let r = 0; r < RUNS; r++) {
+        runs.push(runIntake(spec, encounter, BASE_SEED + r * 104729, 'fresh'));
+      }
+      const pool = runs[0].tankMaxHp;
+      const allHits = runs.flatMap((r) => r.hits);
+      const hitStats = summarize(allHits);
+      const maxHit = allHits.length ? Math.max(...allHits) : 0;
+      const dtps = summarize(runs.map((r) => r.dtps));
+      const totalSwings = runs.reduce((a, r) => a + r.hits.length + r.avoided, 0);
+      const avoidedPct = round1(
+        (100 * runs.reduce((a, r) => a + r.avoided, 0)) / Math.max(1, totalSwings),
+      );
+      const byAbility: Record<string, { count: number; mean: number; max: number }> = {};
+      for (const run of runs) {
+        for (const [label, slot] of Object.entries(run.byAbility)) {
+          let agg = byAbility[label];
+          if (!agg) {
+            agg = { count: 0, mean: 0, max: 0 };
+            byAbility[label] = agg;
+          }
+          agg.count += slot.count;
+          agg.mean += slot.total;
+          agg.max = Math.max(agg.max, slot.max);
+        }
+      }
+      for (const agg of Object.values(byAbility)) {
+        agg.mean = round1(agg.mean / Math.max(1, agg.count));
+      }
+      intake[`${spec.key}__${encounter.key}`] = {
+        pool,
+        tankArmor: runs[0].tankArmor,
+        hit: hitStats,
+        maxHit,
+        meanHitPctOfPool: round1((100 * hitStats.mean) / pool),
+        maxHitPctOfPool: round1((100 * maxHit) / pool),
+        dtps,
+        avoidedPct,
+        byAbility,
+        note: encounter.note,
+      };
+      console.log(
+        `A ${spec.key.padEnd(20)} ${encounter.key.padEnd(28)} hit p50 ${String(hitStats.p50).padStart(4)} ` +
+          `(${round1((100 * hitStats.p50) / pool)}% pool) max ${String(maxHit).padStart(4)} ` +
+          `(${round1((100 * maxHit) / pool)}%) dtps ${dtps.p50.toFixed(0).padStart(4)} avoid ${avoidedPct}%`,
+      );
+    }
+  }
+
+  // Bench B: survival (fresh tank + fresh resto shaman + modeled group dps).
+  const survivalEncounters = ENCOUNTERS.filter((e) =>
+    ['trash_2boneguard_1drakonid', 'midboss_korgath', 'midboss_velkhar', 'boss_korzul'].includes(
+      e.key,
+    ),
+  );
+  const survival: Record<string, Record<string, unknown>> = {};
+  for (const spec of TANK_SPECS) {
+    for (const encounter of survivalEncounters) {
+      const runs: SurvivalRun[] = [];
+      for (let r = 0; r < RUNS; r++) {
+        runs.push(runSurvival(spec, encounter, BASE_SEED + r * 15485863));
+      }
+      const clearedPct = round1((100 * runs.filter((r) => r.cleared).length) / runs.length);
+      const deaths = runs.filter((r) => r.tankDeathSeconds !== null);
+      const deathTimes = summarize(deaths.map((r) => must(r.tankDeathSeconds, 'tankDeathSeconds')));
+      const clearTimes = summarize(
+        runs.filter((r) => r.clearSeconds !== null).map((r) => must(r.clearSeconds, 'clear')),
+      );
+      const minHp = summarize(runs.map((r) => r.minTankHpFrac * 100));
+      survival[`${spec.key}__${encounter.key}`] = {
+        clearedPct,
+        tankDeaths: deaths.length,
+        tankDeathSeconds: deathTimes,
+        clearSeconds: clearTimes,
+        minTankHpPct: minHp,
+      };
+      console.log(
+        `B ${spec.key.padEnd(20)} ${encounter.key.padEnd(28)} cleared ${String(clearedPct).padStart(5)}% ` +
+          `deaths ${deaths.length}/${runs.length} clear p50 ${clearTimes.p50}s minHp p10 ${minHp.p10}%`,
+      );
+    }
+  }
+
+  // Bench C: solo ceiling on the best-in-slot warrior (economy guard).
+  const solo: Record<string, Record<string, unknown>> = {};
+  const soloEncounters = ENCOUNTERS.filter((e) =>
+    ['trash_2boneguard_1drakonid', 'midboss_korgath', 'midboss_velkhar', 'boss_korzul'].includes(
+      e.key,
+    ),
+  );
+  for (const encounter of soloEncounters) {
+    const runs: IntakeRun[] = [];
+    for (let r = 0; r < RUNS; r++) {
+      runs.push(runIntake(TANK_SPECS[0], encounter, BASE_SEED + r * 32452843, 'bis'));
+    }
+    const dtps = summarize(runs.map((r) => r.dtps));
+    solo[encounter.key] = {
+      pool: runs[0].tankMaxHp,
+      tankArmor: runs[0].tankArmor,
+      dtps,
+      soloSelfHealCeiling: SOLO_SELF_HEAL_CEILING,
+      soloDies: dtps.p10 > SOLO_SELF_HEAL_CEILING,
+    };
+    console.log(
+      `C ${encounter.key.padEnd(28)} bis-warrior dtps p50 ${dtps.p50.toFixed(0).padStart(4)} ` +
+        `(p10 ${dtps.p10.toFixed(0)}) vs solo self-heal ${SOLO_SELF_HEAL_CEILING} hps -> ` +
+        `${dtps.p10 > SOLO_SELF_HEAL_CEILING ? 'solo still dies' : 'SOLOABLE'}`,
+    );
+  }
+
+  const report = {
+    generated: new Date().toISOString(),
+    config: {
+      runs: RUNS,
+      intakeSeconds: INTAKE_SECONDS,
+      survivalCapSeconds: SURVIVAL_CAP_SECONDS,
+      groupDps: GROUP_DPS,
+      baseSeed: BASE_SEED,
+    },
+    profiles,
+    intake,
+    survival,
+    solo,
+  };
+  mkdirSync('tmp/sanctum_mc', { recursive: true });
+  writeFileSync('tmp/sanctum_mc/report.json', JSON.stringify(report, null, 2));
+  console.log(
+    `wrote tmp/sanctum_mc/report.json in ${Math.round((Date.now() - startedAt) / 1000)}s`,
+  );
+}
+
+if (process.argv[1]?.includes('sanctum_fresh_montecarlo.ts')) main();

--- a/src/sim/content/dungeon_difficulty.ts
+++ b/src/sim/content/dungeon_difficulty.ts
@@ -74,15 +74,21 @@ export interface NormalDungeonTuning {
   damageMultiplierByMob: Record<string, number>;
 }
 
-// Economy retune (v0.29): soloable normal Sanctum runs were printing up to 6
-// gold per clear. Calibration target: every mob's health DOUBLES, and the
-// minimum non-crit swing lands at least 300 (trash) / 600 (bosses) on the
-// maximum-mitigation reference warrior: level-20 prot in the max-armor kit
-// (full heroic plate + shield, prot mastery), 2861 armor, in Defensive Stance
-// (takes 10% less), i.e. only ~37-38% of a raw swing gets through. Solving the
-// floor per mob at its minimum spawn level gives the ladder below; the
-// non-elite raised_bonewalker needs roughly double the trash factor because it
-// lacks the 1.5x elite swing multiplier. Pinned by
+// Fresh-group retune (v0.30): normal Sanctum is the fresh-20 group dungeon,
+// and the v0.29 economy floors (trash 200 / bosses 420 / adds 150 on the
+// max-mitigation reference warrior) landed 22-54% of a freshly-capped tank's
+// pool PER SWING (quest greens/blues: 1371-1752 hp, 1439-2361 armor across
+// the three committed tanks); the Monte Carlo survival bench
+// (scripts/sanctum_fresh_montecarlo.ts) showed 0% clears and a tank death in
+// every run even against single bosses with a healer. New calibration: the
+// minimum non-crit swing on the same reference warrior (level-20 prot in the
+// max-armor kit, 2861 armor, Defensive Stance) lands at least 90 (trash),
+// 150 (bosses; Korgath/Korzul reach ~173, Velkhar sits at the 150 line
+// because he swings at 2.0s and layers his summon waves on top), and 50
+// (Velkhar's non-elite bonewalker waves, which spawn three at a time and are
+// wave pressure, not extra bosses). That prices a boss swing at ~15-22% and
+// an add swing at ~5-7% of a fresh tank pool. The DOUBLED health stays: the
+// economy lever is clear time, not lethality. Pinned by
 // tests/gravewyrm_normal_tuning.test.ts, which also pins the heroic transform
 // literals so a base-template edit cannot slip through unnoticed.
 //
@@ -97,12 +103,12 @@ export const NORMAL_DUNGEON_TUNING: Record<string, NormalDungeonTuning> = {
     difficulty: 'normal',
     healthMultiplier: 2.0,
     damageMultiplierByMob: {
-      sanctum_boneguard: 7.5,
-      sanctum_drakonid: 7.25,
-      raised_bonewalker: 11.25,
-      korgath_the_bound: 13.5,
-      grand_necromancer_velkhar: 14,
-      korzul_the_gravewyrm: 13,
+      sanctum_boneguard: 3.4,
+      sanctum_drakonid: 3.3,
+      raised_bonewalker: 3.75,
+      korgath_the_bound: 5.5,
+      grand_necromancer_velkhar: 5.0,
+      korzul_the_gravewyrm: 5.25,
     },
   },
   nythraxis_boss_arena: {
@@ -123,8 +129,9 @@ export const HEROIC_DUNGEON_TUNING: Record<string, HeroicDungeonTuning> = {
     level: 22,
     healthMultiplier: 3.8,
     damageMultiplier: 20,
-    // No hollow_crypt boss summons adds; kept at the half convention, inert.
-    addDamageMultiplier: 10,
+    // No hollow_crypt boss summons adds; inert, but rides the v0.30 40% add
+    // nerf with the other heroics so a future summoner starts on-model.
+    addDamageMultiplier: 6,
     armorMultiplier: 1.3,
     finalBossId: 'morthen',
     marksPerParticipant: 1,
@@ -135,9 +142,11 @@ export const HEROIC_DUNGEON_TUNING: Record<string, HeroicDungeonTuning> = {
     level: 22,
     healthMultiplier: 4.0,
     damageMultiplier: 18,
-    // Vael's drowned_thrall summons are non-elite: 16.25x lands the summoned
-    // 250 floor (adds are wave pressure, not extra bosses; 2026-07 retune).
-    addDamageMultiplier: 16.25,
+    // Vael's drowned_thrall summons are non-elite. v0.30: boss-summoned adds
+    // hit 40% softer across every heroic five-man (the 250 floor drops to
+    // 150); a tanked triple wave stacked on the boss was still overwhelming
+    // healers after the 2026-07 retune.
+    addDamageMultiplier: 9.75,
     armorMultiplier: 1.3,
     finalBossId: 'vael_the_mistcaller',
     marksPerParticipant: 1,
@@ -148,9 +157,9 @@ export const HEROIC_DUNGEON_TUNING: Record<string, HeroicDungeonTuning> = {
     level: 22,
     healthMultiplier: 5.2,
     damageMultiplier: 16.5,
-    // Ysolei's moonspawn summons are non-elite: 15.25x lands the summoned
-    // 250 floor (2026-07 retune).
-    addDamageMultiplier: 15.25,
+    // Ysolei's moonspawn summons are non-elite; 40% add nerf (v0.30), the
+    // summoned floor drops from 250 to 150.
+    addDamageMultiplier: 9.15,
     armorMultiplier: 1.25,
     finalBossId: 'ysolei',
     marksPerParticipant: 1,
@@ -161,11 +170,11 @@ export const HEROIC_DUNGEON_TUNING: Record<string, HeroicDungeonTuning> = {
     level: 22,
     healthMultiplier: 4.0,
     damageMultiplier: 15.5,
-    // Velkhar's raised_bonewalker summons are non-elite: 14.25x lands the
-    // summoned 250 floor (2026-07 retune).
-    addDamageMultiplier: 14.25,
+    // Velkhar's raised_bonewalker summons are non-elite; 40% add nerf
+    // (v0.30), the summoned floor drops from 250 to 150.
+    addDamageMultiplier: 8.55,
     // The Sanctum bosses must out-hit their retuned NORMAL selves (normal
-    // floors them at 420 post-mitigation since the 2026-07 fresh-group
+    // floors them at 150-174 post-mitigation since the v0.30 fresh-group
     // retune): 19x lands 652-708, comfortably above.
     damageMultiplierByMob: {
       korgath_the_bound: 19,

--- a/src/sim/content/dungeon_difficulty.ts
+++ b/src/sim/content/dungeon_difficulty.ts
@@ -83,12 +83,15 @@ export interface NormalDungeonTuning {
 // every run even against single bosses with a healer. New calibration: the
 // minimum non-crit swing on the same reference warrior (level-20 prot in the
 // max-armor kit, 2861 armor, Defensive Stance) lands at least 90 (trash),
-// 150 (bosses; Korgath/Korzul reach ~173, Velkhar sits at the 150 line
+// 200 (bosses; Korgath/Korzul land ~245, Velkhar sits at the 200 line
 // because he swings at 2.0s and layers his summon waves on top), and 50
 // (Velkhar's non-elite bonewalker waves, which spawn three at a time and are
-// wave pressure, not extra bosses). That prices a boss swing at ~15-22% and
-// an add swing at ~5-7% of a fresh tank pool. The DOUBLED health stays: the
-// economy lever is clear time, not lethality. Pinned by
+// wave pressure, not extra bosses). That prices a boss swing at ~25% of the
+// fresh tank pool (~20.5% for Velkhar), the same audience-pool share the
+// heroic and Nythraxis calibrations use, with tanks crit-immune since
+// v0.29.1 so there is no spike tail above the 1.25x roll cap; an add swing
+// is ~5-7%. The DOUBLED health stays: the economy lever is clear time, not
+// lethality. Pinned by
 // tests/gravewyrm_normal_tuning.test.ts, which also pins the heroic transform
 // literals so a base-template edit cannot slip through unnoticed.
 //
@@ -106,9 +109,9 @@ export const NORMAL_DUNGEON_TUNING: Record<string, NormalDungeonTuning> = {
       sanctum_boneguard: 3.4,
       sanctum_drakonid: 3.3,
       raised_bonewalker: 3.75,
-      korgath_the_bound: 5.5,
-      grand_necromancer_velkhar: 5.0,
-      korzul_the_gravewyrm: 5.25,
+      korgath_the_bound: 7.75,
+      grand_necromancer_velkhar: 6.6,
+      korzul_the_gravewyrm: 7.5,
     },
   },
   nythraxis_boss_arena: {
@@ -174,7 +177,7 @@ export const HEROIC_DUNGEON_TUNING: Record<string, HeroicDungeonTuning> = {
     // (v0.30), the summoned floor drops from 250 to 150.
     addDamageMultiplier: 8.55,
     // The Sanctum bosses must out-hit their retuned NORMAL selves (normal
-    // floors them at 150-174 post-mitigation since the v0.30 fresh-group
+    // floors them at 200-247 post-mitigation since the v0.30 fresh-group
     // retune): 19x lands 652-708, comfortably above.
     damageMultiplierByMob: {
       korgath_the_bound: 19,

--- a/tests/boss_add_leash.test.ts
+++ b/tests/boss_add_leash.test.ts
@@ -139,9 +139,10 @@ describe('heroic boss adds swing at addDamageMultiplier', () => {
     // The summoner himself carries the Sanctum boss override (see
     // damageMultiplierByMob), not the trash-wide multiplier.
     expect(boss.mechanicDamageMult).toBe(tuning.damageMultiplierByMob?.grand_necromancer_velkhar);
-    // 2026-07 retune: summoned adds floor at HALF the mob line (they are
-    // wave pressure, not extra bosses), so their multiplier now sits BELOW
-    // the trash-wide one despite the missing 1.5x elite swing multiplier.
+    // Summoned adds are wave pressure, not extra bosses: halved to the 250
+    // floor in 2026-07, then 40% softer again in v0.30 (the 150 floor), so
+    // their multiplier sits well BELOW the trash-wide one despite the
+    // missing 1.5x elite swing multiplier.
     expect(tuning.addDamageMultiplier).toBeLessThan(tuning.damageMultiplier);
   });
 
@@ -154,12 +155,12 @@ describe('heroic boss adds swing at addDamageMultiplier', () => {
     expect(adds).toHaveLength(3);
 
     // Normal Sanctum carries its own per-mob retune (fresh-group floors,
-    // see NORMAL_DUNGEON_TUNING): bonewalkers swing at 11.25x base (the 150
-    // add floor) and keep their rolled level, distinct from the heroic
-    // addDamageMultiplier path.
+    // see NORMAL_DUNGEON_TUNING): bonewalkers swing at 3.75x base (the 50
+    // add floor since the v0.30 fresh-group retune) and keep their rolled
+    // level, distinct from the heroic addDamageMultiplier path.
     const normalMult =
       NORMAL_DUNGEON_TUNING.gravewyrm_sanctum.damageMultiplierByMob.raised_bonewalker;
-    expect(normalMult).toBe(11.25);
+    expect(normalMult).toBe(3.75);
     const tmpl = MOBS.raised_bonewalker;
     const addDmg = (tmpl.dmgBase + tmpl.dmgPerLevel * (tmpl.minLevel - 1)) * normalMult;
     for (const add of adds) {

--- a/tests/dungeon_difficulty.test.ts
+++ b/tests/dungeon_difficulty.test.ts
@@ -82,9 +82,10 @@ describe('heroic tuning data contract', () => {
     // level-22 pin, and health is DOUBLED versus the previous calibration
     // (1.9/2.0/2.6/2.0/1.6 became 3.8/4.0/5.2/4.0/3.2). The ladder still
     // inverts because harder dungeons carry bigger base weapon damage.
-    // Boss-summoned add waves floor at HALF the mob line since the 2026-07
-    // retune (wave pressure, not extra bosses): their addDamageMultiplier now
-    // sits BELOW the trash value. Exact literals so an accidental retune reddens
+    // Boss-summoned add waves floor well below the mob line (wave pressure,
+    // not extra bosses): the 2026-07 retune halved them to 250, and the v0.30
+    // pass cut another 40% to the 150 floor, so addDamageMultiplier sits far
+    // BELOW the trash value. Exact literals so an accidental retune reddens
     // deliberately; the floors themselves are pinned by
     // tests/heroic_difficulty_floors.test.ts.
     expect(
@@ -95,10 +96,10 @@ describe('heroic tuning data contract', () => {
         ]),
       ),
     ).toEqual({
-      hollow_crypt: [3.8, 20, 10, 1.3],
-      sunken_bastion: [4.0, 18, 16.25, 1.3],
-      drowned_temple: [5.2, 16.5, 15.25, 1.25],
-      gravewyrm_sanctum: [4.0, 15.5, 14.25, 1.2],
+      hollow_crypt: [3.8, 20, 6, 1.3],
+      sunken_bastion: [4.0, 18, 9.75, 1.3],
+      drowned_temple: [5.2, 16.5, 9.15, 1.25],
+      gravewyrm_sanctum: [4.0, 15.5, 8.55, 1.2],
       // The raid multiplier is smaller in RELATIVE terms because normal
       // Nythraxis already lands the game's hardest hits; the heroic boss
       // floors at 1200 through the dungeon-wide value while the encounter
@@ -156,9 +157,9 @@ describe('mobTemplateForDungeonDifficulty', () => {
     const add = mobTemplateForDungeonDifficulty(SYNTHETIC, 'hollow_crypt', 'heroic', {
       summonedAdd: true,
     });
-    // hollow_crypt addDamageMultiplier is 10 (no crypt boss summons, inert).
-    expect(add.dmgBase).toBeCloseTo(200, 10);
-    expect(add.dmgPerLevel).toBeCloseTo(20, 10);
+    // hollow_crypt addDamageMultiplier is 6 (no crypt boss summons, inert).
+    expect(add.dmgBase).toBeCloseTo(120, 10);
+    expect(add.dmgPerLevel).toBeCloseTo(12, 10);
     // Health, armor, level, and the speed floor stay on the dungeon-wide tuning.
     expect(add.hpBase).toBeCloseTo(380, 10);
     expect(add.hpPerLevel).toBeCloseTo(38, 10);

--- a/tests/gravewyrm_normal_tuning.test.ts
+++ b/tests/gravewyrm_normal_tuning.test.ts
@@ -1,11 +1,15 @@
-// Gravewyrm Sanctum NORMAL retune (economy fix): soloable normal runs were
-// printing up to 6 gold per clear, so normal Sanctum doubles every mob's
-// health and raises melee so a swing lands for at least 300 (trash) / 600
-// (bosses) on the maximum-mitigation reference warrior, with boss mechanics
-// scaled by the same per-mob factor. Heroic reads the same base templates on
-// its OWN calibration (tests/heroic_difficulty_floors.test.ts), so this file
-// also pins the heroic transform literals: a base-template edit cannot slip
-// through either difficulty unnoticed.
+// Gravewyrm Sanctum NORMAL retune: the v0.29 economy floors (200 trash / 420
+// bosses / 150 adds) made normal Sanctum unclearable for its actual audience,
+// freshly-capped groups: bosses landed 41-54% of a fresh tank's pool PER
+// SWING and the Monte Carlo survival bench
+// (scripts/sanctum_fresh_montecarlo.ts) recorded a tank death in every run,
+// even against lone bosses with a healer. v0.30 keeps the DOUBLED health (the
+// anti-solo economy lever is clear time) and re-floors damage for the fresh
+// group instead, with boss mechanics scaled by the same per-mob factor.
+// Heroic reads the same base templates on its OWN calibration
+// (tests/heroic_difficulty_floors.test.ts), so this file also pins the heroic
+// transform literals: a base-template edit cannot slip through either
+// difficulty unnoticed.
 //
 // Reference warrior (the "fully geared" mitigation ceiling): level-20 prot
 // warrior in the max-armor kit (full heroic plate + shield, prot mastery),
@@ -31,15 +35,19 @@ import { armorReduction } from '../src/sim/types';
 const SANCTUM = 'gravewyrm_sanctum';
 const REF_ARMOR = 2861; // max-armor BiS prot warrior, level 20 (see header)
 const DEFENSIVE_STANCE_TAKEN = 0.9; // dealDamage: Defensive Stance takes 10% less
-// 2026-07 fresh-group retune: normal Sanctum serves freshly-capped groups in
-// quest greens/blues (a 1433-armor / 1692-hp tank), for whom the old 300/600
-// floors meant 25% and 50% of the pool per swing. Trash 200, bosses 420, and
-// Velkhar's summoned bonewalkers 150; the DOUBLED health stays (the economy
-// lever is clear time), and the solo ceiling holds: the strongest solo
-// archetype self-heals ~140 hps against a 420-floor boss's ~350+ dtps.
-const TRASH_FLOOR = 200;
-const BOSS_FLOOR = 420;
-const ADD_FLOOR = 150;
+// v0.30 fresh-group retune: normal Sanctum serves freshly-capped groups in
+// quest greens/blues (1371-1752 hp / 1439-2361 armor across the three
+// committed tanks), for whom even the 200/420 floors meant 21-24% (trash) and
+// 41-54% (bosses) of the pool per swing. Trash 90, bosses 150 (Korgath and
+// Korzul land ~173; Velkhar sits at the 150 line because he swings at 2.0s
+// and layers his bonewalker waves on top), and the summoned bonewalkers 50
+// (three spawn at once: wave pressure, not extra bosses). The DOUBLED health
+// stays. Accepted trade (2026-07-25): a best-in-slot self-healing tank can
+// out-heal a 150-floor boss again, so clear TIME, not lethality, is what
+// keeps solo farming unprofitable.
+const TRASH_FLOOR = 90;
+const BOSS_FLOOR = 150;
+const ADD_FLOOR = 50;
 
 // The dungeon's five spawn-list templates plus Velkhar's summoned add.
 const TRASH_IDS = ['sanctum_boneguard', 'sanctum_drakonid'] as const;
@@ -87,12 +95,12 @@ describe('normal Gravewyrm Sanctum tuning data', () => {
     const tuning = sanctumTuning();
     expect(tuning.healthMultiplier).toBe(2.0);
     expect(tuning.damageMultiplierByMob).toEqual({
-      sanctum_boneguard: 7.5,
-      sanctum_drakonid: 7.25,
-      raised_bonewalker: 11.25,
-      korgath_the_bound: 13.5,
-      grand_necromancer_velkhar: 14,
-      korzul_the_gravewyrm: 13,
+      sanctum_boneguard: 3.4,
+      sanctum_drakonid: 3.3,
+      raised_bonewalker: 3.75,
+      korgath_the_bound: 5.5,
+      grand_necromancer_velkhar: 5.0,
+      korzul_the_gravewyrm: 5.25,
     });
   });
 });
@@ -110,7 +118,7 @@ describe('normal Gravewyrm Sanctum health', () => {
 });
 
 describe('normal Gravewyrm Sanctum melee floors vs the reference warrior', () => {
-  it('every summoned bonewalker swing lands for at least the 150 add floor', () => {
+  it('every summoned bonewalker swing lands for at least the 50 add floor', () => {
     for (const id of ADD_IDS) {
       const { minLevel, maxLevel } = MOBS[id];
       for (let level = minLevel; level <= maxLevel; level++) {
@@ -121,7 +129,7 @@ describe('normal Gravewyrm Sanctum melee floors vs the reference warrior', () =>
     }
   });
 
-  it('every trash swing lands for at least 200 at every spawnable level', () => {
+  it('every trash swing lands for at least 90 at every spawnable level', () => {
     for (const id of TRASH_IDS) {
       const { minLevel, maxLevel } = MOBS[id];
       for (let level = minLevel; level <= maxLevel; level++) {
@@ -133,7 +141,7 @@ describe('normal Gravewyrm Sanctum melee floors vs the reference warrior', () =>
     }
   });
 
-  it('every boss swing lands for at least 420 at every spawnable level', () => {
+  it('every boss swing lands for at least 150 at every spawnable level', () => {
     for (const id of BOSS_IDS) {
       const { minLevel, maxLevel } = MOBS[id];
       for (let level = minLevel; level <= maxLevel; level++) {
@@ -169,10 +177,10 @@ describe('normal Gravewyrm Sanctum mechanic scaling', () => {
     // Raw (unmitigated) mechanic damage after the per-mob multiplier: the
     // FOURTH (largest) inferno pulse on normal, and the stomp band.
     const mult = tuning.damageMultiplierByMob.korzul_the_gravewyrm;
-    expect(inferno.min * inferno.pulses * mult).toBe(364);
-    expect(inferno.max * inferno.pulses * mult).toBe(468);
-    expect(korgathStomp.min * tuning.damageMultiplierByMob.korgath_the_bound).toBe(270);
-    expect(korgathStomp.max * tuning.damageMultiplierByMob.korgath_the_bound).toBe(405);
+    expect(inferno.min * inferno.pulses * mult).toBe(147);
+    expect(inferno.max * inferno.pulses * mult).toBe(189);
+    expect(korgathStomp.min * tuning.damageMultiplierByMob.korgath_the_bound).toBe(110);
+    expect(korgathStomp.max * tuning.damageMultiplierByMob.korgath_the_bound).toBe(165);
   });
 
   it('leaves untuned normal dungeons untouched', () => {
@@ -186,7 +194,7 @@ describe('normal Gravewyrm Sanctum mechanic scaling', () => {
 
 describe('heroic Gravewyrm Sanctum transform stays on its own calibration', () => {
   // Deliberate heroic literals: base template x heroic tuning (health 4.0,
-  // trash damage 15.5, bosses 19 via damageMultiplierByMob, adds 29, armor
+  // trash damage 15.5, bosses 19 via damageMultiplierByMob, adds 8.55, armor
   // 1.2, level 22; see tests/heroic_difficulty_floors.test.ts for the
   // floors). If a base template is edited instead of a tuning table, these
   // redden.
@@ -255,8 +263,8 @@ describe('heroic Gravewyrm Sanctum transform stays on its own calibration', () =
     const add = mobTemplateForDungeonDifficulty(MOBS.raised_bonewalker, SANCTUM, 'heroic', {
       summonedAdd: true,
     });
-    expect(add.dmgBase).toBeCloseTo(128.25, 10);
-    expect(add.dmgPerLevel).toBeCloseTo(31.35, 10);
+    expect(add.dmgBase).toBeCloseTo(76.95, 10);
+    expect(add.dmgPerLevel).toBeCloseTo(18.81, 10);
     expect(add.hpBase).toBeCloseTo(168, 10);
     expect(add.hpPerLevel).toBeCloseTo(60, 10);
     expect(add.armorPerLevel).toBeCloseTo(14.4, 10);

--- a/tests/gravewyrm_normal_tuning.test.ts
+++ b/tests/gravewyrm_normal_tuning.test.ts
@@ -38,15 +38,18 @@ const DEFENSIVE_STANCE_TAKEN = 0.9; // dealDamage: Defensive Stance takes 10% le
 // v0.30 fresh-group retune: normal Sanctum serves freshly-capped groups in
 // quest greens/blues (1371-1752 hp / 1439-2361 armor across the three
 // committed tanks), for whom even the 200/420 floors meant 21-24% (trash) and
-// 41-54% (bosses) of the pool per swing. Trash 90, bosses 150 (Korgath and
-// Korzul land ~173; Velkhar sits at the 150 line because he swings at 2.0s
-// and layers his bonewalker waves on top), and the summoned bonewalkers 50
+// 41-54% (bosses) of the pool per swing. Trash 90; bosses 200 (Korgath and
+// Korzul land ~245, an average swing of ~25% of the fresh pool, the same
+// audience-pool share the heroic and Nythraxis boss calibrations use; tanks
+// are crit-immune since v0.29.1 so there is no spike tail above the 1.25x
+// roll cap. Velkhar sits at the 200 line, ~20.5%, because he swings at 2.0s
+// and layers his bonewalker waves on top); and the summoned bonewalkers 50
 // (three spawn at once: wave pressure, not extra bosses). The DOUBLED health
 // stays. Accepted trade (2026-07-25): a best-in-slot self-healing tank can
-// out-heal a 150-floor boss again, so clear TIME, not lethality, is what
-// keeps solo farming unprofitable.
+// out-heal these bosses again, so clear TIME, not lethality, is what keeps
+// solo farming unprofitable.
 const TRASH_FLOOR = 90;
-const BOSS_FLOOR = 150;
+const BOSS_FLOOR = 200;
 const ADD_FLOOR = 50;
 
 // The dungeon's five spawn-list templates plus Velkhar's summoned add.
@@ -98,9 +101,9 @@ describe('normal Gravewyrm Sanctum tuning data', () => {
       sanctum_boneguard: 3.4,
       sanctum_drakonid: 3.3,
       raised_bonewalker: 3.75,
-      korgath_the_bound: 5.5,
-      grand_necromancer_velkhar: 5.0,
-      korzul_the_gravewyrm: 5.25,
+      korgath_the_bound: 7.75,
+      grand_necromancer_velkhar: 6.6,
+      korzul_the_gravewyrm: 7.5,
     });
   });
 });
@@ -141,7 +144,7 @@ describe('normal Gravewyrm Sanctum melee floors vs the reference warrior', () =>
     }
   });
 
-  it('every boss swing lands for at least 150 at every spawnable level', () => {
+  it('every boss swing lands for at least 200 at every spawnable level', () => {
     for (const id of BOSS_IDS) {
       const { minLevel, maxLevel } = MOBS[id];
       for (let level = minLevel; level <= maxLevel; level++) {
@@ -177,10 +180,10 @@ describe('normal Gravewyrm Sanctum mechanic scaling', () => {
     // Raw (unmitigated) mechanic damage after the per-mob multiplier: the
     // FOURTH (largest) inferno pulse on normal, and the stomp band.
     const mult = tuning.damageMultiplierByMob.korzul_the_gravewyrm;
-    expect(inferno.min * inferno.pulses * mult).toBe(147);
-    expect(inferno.max * inferno.pulses * mult).toBe(189);
-    expect(korgathStomp.min * tuning.damageMultiplierByMob.korgath_the_bound).toBe(110);
-    expect(korgathStomp.max * tuning.damageMultiplierByMob.korgath_the_bound).toBe(165);
+    expect(inferno.min * inferno.pulses * mult).toBe(210);
+    expect(inferno.max * inferno.pulses * mult).toBe(270);
+    expect(korgathStomp.min * tuning.damageMultiplierByMob.korgath_the_bound).toBe(155);
+    expect(korgathStomp.max * tuning.damageMultiplierByMob.korgath_the_bound).toBe(232.5);
   });
 
   it('leaves untuned normal dungeons untouched', () => {

--- a/tests/heroic_difficulty_floors.test.ts
+++ b/tests/heroic_difficulty_floors.test.ts
@@ -1,8 +1,10 @@
 // Heroic retune (economy pass, 2026-07): every heroic mob's health DOUBLES
-// versus the previous heroic calibration, and the minimum non-crit swing lands
-// at least 500 post-mitigation on the maximum-mitigation reference warrior
-// (see below). The Nythraxis raid joins the model: its heroic boss floors at
-// 1200, its add waves at the 500 heroic line, and NORMAL Nythraxis gets the
+// versus the previous heroic calibration, and the minimum non-crit swing of
+// every SPAWN-LIST mob lands at least 500 post-mitigation on the
+// maximum-mitigation reference warrior (see below); boss-summoned adds floor
+// at 150 since the v0.30 40% add nerf. The Nythraxis raid rides the model on
+// its own numbers: heroic boss floor 1000 (2026-07-24 nerf), encounter-script
+// add waves at the raid 250 line, and NORMAL Nythraxis gets the
 // normal-Gravewyrm treatment (2x health, boss >= 600, adds >= 300).
 //
 // Reference warrior (the "fully geared" mitigation ceiling, same as
@@ -28,10 +30,13 @@ import { armorReduction } from '../src/sim/types';
 const REF_ARMOR = 2861;
 const DEFENSIVE_STANCE_TAKEN = 0.9;
 const HEROIC_MOB_FLOOR = 500;
-// 2026-07 retune: summoned/scripted add waves floor at HALF the mob line.
-// Adds were hitting 78-89% as hard as their bosses (a tanked triple wave
-// overwhelmed the tank outright); they are wave pressure, not extra bosses.
-const SUMMONED_ADD_FLOOR = 250;
+// v0.30: five-man boss-summoned adds hit 40% softer again (the 2026-07
+// half-the-mob-line 250 floor was still overwhelming healers when a tanked
+// triple wave stacked on the boss); they are wave pressure, not extra bosses.
+// The RAID's encounter-script waves deliberately keep the old 250 line: a
+// ten-player group brings two or three healers.
+const SUMMONED_ADD_FLOOR = 150;
+const RAID_ADD_FLOOR = 250;
 // 2026-07-24 heroic Nythraxis nerf: boss floor 1200 -> 1000 (mult 7.25)
 // and the skeleton waves to 1.2x their NORMAL-mode health via the new
 // healthMultiplierByMob map. Ships with the wave-2 package; the morning
@@ -100,7 +105,7 @@ describe('heroic five-man floors', () => {
     }
   });
 
-  it('every boss-summoned add swings for at least the 250 add floor on the reference warrior', () => {
+  it('every boss-summoned add swings for at least the 150 add floor on the reference warrior', () => {
     for (const dungeonId of FIVE_MANS) {
       for (const mobId of spawnListMobIds(dungeonId)) {
         const summoned = MOBS[mobId]?.summonAdds?.mobId;
@@ -141,11 +146,11 @@ describe('heroic five-man doubled health', () => {
 });
 
 describe('Nythraxis raid floors', () => {
-  it('heroic boss swings for at least 1000, add waves for the 250 add floor', () => {
+  it('heroic boss swings for at least 1000, add waves for the raid 250 add floor', () => {
     expect(minSwing(RAID_BOSS, RAID, 'heroic')).toBeGreaterThanOrEqual(HEROIC_NYTHRAXIS_BOSS_FLOOR);
     for (const addId of RAID_HEROIC_ADDS) {
       const swing = minSwing(addId, RAID, 'heroic');
-      expect(swing, addId).toBeGreaterThanOrEqual(SUMMONED_ADD_FLOOR);
+      expect(swing, addId).toBeGreaterThanOrEqual(RAID_ADD_FLOOR);
       expect(swing, `${addId} above the mob line`).toBeLessThan(HEROIC_MOB_FLOOR);
     }
   });
@@ -190,10 +195,10 @@ describe('heroic tuning data contract', () => {
         ]),
       ),
     ).toEqual({
-      hollow_crypt: [3.8, 20, 10],
-      sunken_bastion: [4.0, 18, 16.25],
-      drowned_temple: [5.2, 16.5, 15.25],
-      gravewyrm_sanctum: [4.0, 15.5, 14.25],
+      hollow_crypt: [3.8, 20, 6],
+      sunken_bastion: [4.0, 18, 9.75],
+      drowned_temple: [5.2, 16.5, 9.15],
+      gravewyrm_sanctum: [4.0, 15.5, 8.55],
       nythraxis_boss_arena: [3.2, 7.25, 7.25],
     });
   });


### PR DESCRIPTION
## Summary

Two tuning changes for v0.30.0, both Monte Carlo validated with a new committed harness (`scripts/sanctum_fresh_montecarlo.ts`, run: `npx tsx scripts/sanctum_fresh_montecarlo.ts`):

1. **Normal Gravewyrm Sanctum is now clearable by fresh level-20 groups.** The v0.29 economy floors (calibrated on a max-mitigation heroic-geared warrior) landed 41-54% of a freshly-capped tank's pool per boss swing; the survival bench recorded a tank death in every run, even against lone bosses with a healer. Damage multipliers are re-floored for the fresh audience; the doubled health stays as the economy lever. Velkhar's bonewalker waves (the boss ads) are cut to a third.
2. **Heroic five-man boss-summoned adds hit exactly 40% softer** (`addDamageMultiplier` x0.6 in all four dungeons; the summoned floor drops 250 to 150). Nothing else in the heroics moves, and the Nythraxis raid is untouched.

## Fresh tank reference (max-EHP greens/blues, no epics, no heroic variants)

| Tank | HP | Armor |
|---|---|---|
| Prot warrior (Defensive Stance) | 1752 | 1439 |
| Protection paladin | 1688 | 1840 |
| Feral druid (bear) | 1371 | 2361 |

## Normal Sanctum: before / after (prot warrior rows; paladin and druid within 1-3 points)

Per-swing damage on the fresh tank (p50 hit, share of HP pool, DTPS), 8 seeds x 60s intake per cell:

| Encounter | Before | After |
|---|---|---|
| Trash pull (2 boneguard + drakonid) | 374/hit (21% pool), 409 dtps | 169/hit (10% pool), 186 dtps |
| Bonewalker wave x3 (boss ads) | 277/hit (16% pool), 256 dtps | 92/hit (5% pool), 85 dtps |
| Korgath | 725/hit (41% pool), 248 dtps | 417/hit (24% pool), 142 dtps |
| Velkhar | 756/hit (43% pool), 303 dtps | 356/hit (20% pool), 143 dtps |
| Velkhar + wave up | 683 dtps window | 236 dtps window |
| Korzul | 711/hit (41% pool), 226 dtps | 434/hit (25% pool), 131 dtps |

Boss swings average ~25% of the fresh pool (Velkhar ~20.5%, his waves ride on top), the same audience-pool share the heroic and Nythraxis boss calibrations use. Tanks are crit-immune (v0.29.1), so the biggest possible hit is the 1.25x roll cap: 541 (31% of pool), down from 932 (53%, and crit-free only by luck of the draw order).

Survival bench (fresh tank + fresh resto shaman + modeled 240 group DPS, real fights: enrages fire, Velkhar waves spawn at 66%/33%):

| | Before | After |
|---|---|---|
| Trash pull | 0% cleared | 100% cleared, 0 deaths |
| Korgath | 0-25% cleared | 100% cleared, 0 deaths |
| Velkhar | 0% cleared | 62.5-87.5% cleared |
| Korzul | 0-25% cleared | 75-100% cleared |

Before: the tank died in 89 of 96 runs. After: the finale bosses still kill an autopilot group sometimes, which is intended pressure. The bench healer never uses CC on the waves, the tank stands in every Grave Inferno pulse and pops zero cooldowns, and there is no second healer; real groups have all of those levers.

Multipliers (`NORMAL_DUNGEON_TUNING.gravewyrm_sanctum`): boneguard 7.5 to 3.4, drakonid 7.25 to 3.3, bonewalker 11.25 to 3.75, Korgath 13.5 to 7.75, Velkhar 14 to 6.6, Korzul 13 to 7.5. Reference-warrior floors: trash 200 to ~92, bosses 420 to 200-247, adds 150 to 50. Mechanics (Korgath stomp, Korzul Grave Inferno) ride the same per-mob factor down automatically. (Boss floors were raised from the first draft after review: with tank crit immunity there is no spike tail, so bosses take the full family-rule share.)

## Heroic five-mans: the 40% add nerf

| Dungeon | addDamageMultiplier | Note |
|---|---|---|
| sunken_bastion (Vael's thralls) | 16.25 to 9.75 | |
| drowned_temple (Ysolei's moonspawn) | 15.25 to 9.15 | |
| gravewyrm_sanctum (Velkhar's bonewalkers) | 14.25 to 8.55 | |
| hollow_crypt | 10 to 6 | inert (no summoner), kept on-model |

Add health, boss damage, trash, armor, levels: all unchanged. Raid (`nythraxis_boss_arena`) rows untouched; its encounter-script waves keep their own 250 floor via `damageMultiplierByMob`.

## Accepted trade (flagging explicitly)

The old 420 boss floor doubled as the solo lock (BiS tank took 161-212 boss DTPS, above the ~140 hps solo self-heal ceiling). After this change a best-in-slot self-healing tank archetype can out-heal normal-Sanctum bosses again (88-107 DTPS on the BiS bench, against a ~140 hps self-heal ceiling; a thinner margin than the first draft but still open). Fresh-group clearability and that solo lock cannot both hold; per the directive this PR prioritizes clearability and keeps the doubled health, so a solo clear is slow (gold/hour throttled) rather than lethal. If a harder solo lock is wanted later, it needs a different lever (per-player scaling or entry rules), not swing damage.

## Tests

- `tests/gravewyrm_normal_tuning.test.ts`: new floors (90/200/50), multiplier literals, mechanic literals, heroic bonewalker transform pins (8.55x), header rewritten.
- `tests/heroic_difficulty_floors.test.ts`: five-man summoned floor 250 to 150 with a separate raid 250 pin so the raid contract stays tight; table pins updated.
- `tests/dungeon_difficulty.test.ts`, `tests/boss_add_leash.test.ts`: literal pins and comments updated.
- New harness committed as `scripts/sanctum_fresh_montecarlo.ts` (reports land in `tmp/sanctum_mc/`, gitignored).

## Test plan

- [x] Monte Carlo before/after (8 seeds): intake, survival, solo-ceiling benches
- [x] Affected suites green (34 + 150 tests)
- [x] Full gate: 19,480 tests passed; the only red is the pre-existing `deploy_watchdog` macOS environmental flake (fails identically on the untouched tree, passes on Ubuntu CI)
- [x] `tsc` clean, all five builds emit
