### PR TITLE
fix(net): converge the bag money row on a money-only change

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -2775,7 +2775,15 @@ export class ClientWorld implements IWorld {
       // inv/buyback/equip are delta-guarded (a missing field keeps the prior mirror).
       // Terse keys (inv/buyback/equip/copper) and the per-field guards are unchanged by
       // the move; the offline counterpart is src/sim/items.ts.
-      this.copper = s.copper ?? 0;
+      // A money-only delta carries no inventory echo at all (a proceeds-only market
+      // collect, a trainer fee, a bank slot buy all move meta.copper and nothing else),
+      // so without this the bag money row and vendor affordability sat stale until the
+      // window was reopened (#2373). DIFF against the prior mirror, never a presence
+      // test: copper rides EVERY self-frame, so `s.copper !== undefined` would raise the
+      // flag at 20 Hz and rebuild the bags under the player's cursor continuously.
+      const copper = s.copper ?? 0;
+      if (copper !== this.copper) this.invChanged = true;
+      this.copper = copper;
       if (s.inv !== undefined) {
         this.inventory = s.inv;
         this.invChanged = true;

--- a/src/ui/bags_view.ts
+++ b/src/ui/bags_view.ts
@@ -171,6 +171,19 @@ export function bagsWindowShown(display: string): boolean {
   return display !== 'none' && display !== '';
 }
 
+/** Whether a SHOWN bag window's money row is painting a stale purse (issue #2373).
+ *  The money row is the only thing inside #bags that reads copper (neither
+ *  buildBagGrid nor buildBagBar sees it), and several credits reach no bags arm in
+ *  either host: online a money-only snapshot carries no inventory delta at all, and
+ *  offline a trainer fee, a settled Vale Cup bet or delve copper emit no event the
+ *  bags listen to. The window has to be SHOWN before the purse is compared, so a
+ *  hidden or never-opened window costs one string compare and never reaches a
+ *  painter. `lastPainted` is the purse as of the last paint; the -1 cold sentinel a
+ *  caller starts from can never equal a real purse, which is never negative. */
+export function bagsMoneyRowStale(display: string, copper: number, lastPainted: number): boolean {
+  return bagsWindowShown(display) && copper !== lastPainted;
+}
+
 /** What the shift+right-click destroy affordance on a bag item does. 'discard' opens
  *  the destroy prompt, 'discardBlocked' rejects a protected item with feedback, 'none'
  *  means the destroy affordance is inert. A plain right-click (no shift) now runs the

--- a/src/ui/bags_window.ts
+++ b/src/ui/bags_window.ts
@@ -42,6 +42,7 @@ import {
   bagQualityKey,
   bagShiftLinks,
   bagStackIndex,
+  bagsMoneyRowStale,
   bagTooltipHintKey,
   bankDepositOpensPrompt,
   buildBagBar,
@@ -218,7 +219,54 @@ export class BagsWindow {
   // (vendor / mobile), where a null restore is a safe no-op.
   private openerFocus: HTMLElement | null = null;
 
+  // The purse as of the last money-row paint (issue #2373), re-armed by every paint
+  // whatever caused it. -1 is the cold sentinel: a real purse is never negative, so
+  // a window shown without a paint would always converge on the first probe.
+  private lastMoneyCopper = -1;
+
   constructor(private readonly deps: BagsWindowDeps) {}
+
+  /**
+   * Repaint the money row when the purse moved, the staleness contract this window
+   * owns (issue #2373). Joins the refreshIfChanged family the HUD's slow band drives
+   * (bank / mailbox / market / social / deeds / professions / calendar), so the
+   * coordinator stays a one-line consumer.
+   *
+   * Deliberately NOT a full render(): nothing else inside #bags reads copper, and a
+   * rebuild would tear down the hovered row's tooltip, the bag-search caret and an
+   * armed touch drag. This edge fires from a server credit or a coin-only mob loot
+   * with no user action behind it, so unlike the user-initiated paint paths it must
+   * not move anything the player is holding. Same reason refreshGrid() exists for
+   * live search.
+   */
+  refreshIfChanged(): void {
+    const el = this.deps.root();
+    if (!bagsMoneyRowStale(el.style.display, this.deps.world().copper, this.lastMoneyCopper))
+      return;
+    this.refreshMoneyRow();
+  }
+
+  /** Rewrite ONLY the .money footer in place, re-binding its two launchers. Shared by
+   *  the full render() and the purse probe, so the latch arms on both. */
+  private paintMoneyRow(row: HTMLElement, copper: number): void {
+    row.innerHTML = `${this.deps.wocBalanceHtml()}${this.deps.claudiumLauncherHtml()}${this.deps.moneyHtml(copper)}`;
+    row.querySelector('[data-claudium-launcher]')?.addEventListener('click', () => {
+      this.deps.openClaudium();
+    });
+    row.querySelector('[data-wallet-action]')?.addEventListener('click', () => {
+      this.deps.openWallet();
+    });
+    this.lastMoneyCopper = copper;
+  }
+
+  /** The narrow repaint: find the existing footer and re-paint it. A window that has
+   *  never been rendered has no .money row yet, so this is a no-op rather than a
+   *  partial paint. */
+  private refreshMoneyRow(): void {
+    const row = this.deps.root().querySelector('.money') as HTMLElement | null;
+    if (!row) return;
+    this.paintMoneyRow(row, this.deps.world().copper);
+  }
 
   /** Record the element that opened the window, so close() can return focus to it.
    *  Called by the HUD's toggleBags on the keyboard/minimap open path. */
@@ -270,14 +318,8 @@ export class BagsWindow {
     grid.scrollTop = prevScrollTop;
     const moneyRow = document.createElement('div');
     moneyRow.className = 'money';
-    moneyRow.innerHTML = `${this.deps.wocBalanceHtml()}${this.deps.claudiumLauncherHtml()}${this.deps.moneyHtml(world.copper)}`;
     el.appendChild(moneyRow);
-    moneyRow.querySelector('[data-claudium-launcher]')?.addEventListener('click', () => {
-      this.deps.openClaudium();
-    });
-    moneyRow.querySelector('[data-wallet-action]')?.addEventListener('click', () => {
-      this.deps.openWallet();
-    });
+    this.paintMoneyRow(moneyRow, world.copper);
     el.querySelector('[data-close]')?.addEventListener('click', () => {
       // On touch the vendor / bank clusters hide their LEFT panel's own x-btn, so
       // this bags x-btn is the whole cluster's single close control: it closes the

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -7734,6 +7734,12 @@ export class Hud {
     if (slowHud && this.mailboxWindow.isOpen) this.mailboxWindow.refreshIfChanged();
     // The bank closes itself when the bank mirror goes null (left the banker).
     if (slowHud && this.bankWindow.isOpen) this.bankWindow.refreshIfChanged();
+    // The bag money row is a cold painter, and several copper credits reach no bags
+    // arm in EITHER host (a trainer fee, a settled Vale Cup bet, delve and lockpick
+    // copper), so this is the backstop that converges them all (#2373). Online the
+    // ClientWorld purse diff gets there first via onInventoryChanged. The window owns
+    // the latch and repaints only its .money footer, never the whole grid.
+    if (slowHud) this.bagsWindow.refreshIfChanged();
     if (slowHud && this.deedsWindow.isOpen) this.deedsWindow.refreshIfChanged();
     if (slowHud) this.refreshOpenProfessionSurfacesIfChanged();
     if (slowHud && this.professionsWindow.isOpen) this.professionsWindow.refreshIfChanged();
@@ -11996,7 +12002,11 @@ export class Hud {
   // Called when an authoritative inventory delta lands (online snapshots
   // carry inventory separately from the event frames that normally redraw).
   onInventoryChanged(): void {
-    if ($('#bags').style.display !== 'none') this.renderBags();
+    // Cold-load-safe gate (#1538): a never-opened window's inline display is '', which
+    // the raw `!== 'none'` form reads as shown. That mattered little while only
+    // inventory deltas landed here, but every money-only credit now routes through
+    // this hook (#2373), so a hidden window would be rebuilt on each one.
+    if (bagsWindowShown($('#bags').style.display)) this.renderBags();
     if (this.openVendorNpcId !== null) this.renderVendor();
     this.renderCharIfOpen();
     // The crafting window rides this hook too (#2375): it is the online

--- a/tests/bags_money_refresh.test.ts
+++ b/tests/bags_money_refresh.test.ts
@@ -1,0 +1,378 @@
+// Bag money-row freshness on a MONEY-ONLY change (issue #2373: collecting
+// auction proceeds at the Merchant left the gold in the bag window stale until
+// the player closed and reopened it).
+//
+// The defect is a missing convergence edge, not a missing button handler:
+//  - the sim's proceeds arm moves ONLY meta.copper (src/sim/market.ts), so the
+//    player's inventory is byte-identical;
+//  - `copper` rides every self-frame in the server's UNCONDITIONAL base object
+//    while `inv` is serialize-diffed, so a money-only frame carries no `inv`;
+//  - ClientWorld therefore mirrored the new copper while raising NO
+//    inventory-changed flag, and Hud.onInventoryChanged() (the one authoritative
+//    online path to renderBags) never ran.
+// The bag money row is a cold painter with no signature of its own, so nothing
+// else converged it. That is the whole bug, and it is the same hole behind the
+// trainer fee, the bank slot buy, and a settled Vale Cup bet.
+//
+// This file owns the WIRE half, driven through a REAL GameServer and a real
+// ClientWorld: a proceeds-only collect must raise the flag from the copper delta
+// alone (red before the fix), an unchanged purse must not raise it (which is what
+// forces a diff rather than an `s.copper !== undefined` presence test, and with it a
+// 20 Hz repaint), the pre-existing inventory arm must still flag, and the spectate
+// anchor ruling is pinned so it cannot drift silently.
+//
+// The other two halves live where they can be EXECUTED rather than pattern-matched:
+// the pure staleness decision is a truth table on bagsMoneyRowStale in
+// tests/bags_view.test.ts, and the painter (including everything the refresh must
+// not disturb) is driven against the real BagsWindow in
+// tests/bags_money_row_paint.test.ts. Only the call-site wiring is pinned as source
+// text here, and only where a unit test genuinely cannot reach.
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the db layer so no Postgres is needed; the wire path is under test.
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  saveCharacterAndMarketState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  setAccountWeaponSkinLoadout: vi.fn(async () => ({
+    completedQuestIds: [],
+    mechChromaIds: [],
+    weaponSkinIds: [],
+    weaponSkinLoadout: {},
+  })),
+  loadAccountFlair: vi.fn(async () => ({ ai: false, streamer: false, links: {} })),
+}));
+
+import { type ClientSession, GameServer } from '../server/game';
+import { ClientWorld } from '../src/net/online';
+import type { Entity, PlayerClass } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
+
+const PROCEEDS = 54321;
+
+interface FakeClient {
+  sent: any[];
+  ws: any;
+}
+
+function fakeWs(): FakeClient {
+  const sent: any[] = [];
+  return { sent, ws: { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) } };
+}
+
+function lastSnap(sent: any[]): any {
+  for (let i = sent.length - 1; i >= 0; i--) {
+    if (sent[i].t === 'snap') return sent[i];
+  }
+  return null;
+}
+
+function joinServer(
+  server: GameServer,
+  fc: FakeClient,
+  characterId: number,
+  name = 'Fernando',
+): ClientSession {
+  const session = server.join(fc.ws, characterId, characterId, name, 'warrior', null, false, {});
+  if ('error' in session) throw new Error(session.error);
+  session.blockListLoaded = true;
+  return session;
+}
+
+// A ClientWorld without the WebSocket plumbing, to drive applySnapshot directly
+// (the tests/snapshots.test.ts idiom, copied per the repo's house pattern).
+function bareClient(pid: number, playerClass: PlayerClass = 'warrior'): ClientWorld {
+  const c: any = Object.create(ClientWorld.prototype);
+  c.cfg = { seed: 20061, playerClass };
+  c.entities = new Map();
+  c.playerId = pid;
+  c.ownPlayerId = pid;
+  c.ownPlayerClass = playerClass;
+  c.spectating = null;
+  c.cupInfo = null;
+  c.lastVcupRemainder = null;
+  c.lastVcupShared = null;
+  c.sportRole = null;
+  c.moveInput = {};
+  c.inventory = [];
+  c.vendorBuyback = [];
+  c.equipment = {};
+  c.accountCosmetics = { completedQuestIds: [], mechChromaIds: [] };
+  c.copper = 0;
+  c.honor = 0;
+  c.lifetimeHonor = 0;
+  c.xp = 0;
+  c.known = [];
+  c.questLog = new Map();
+  c.questsDone = new Set();
+  c.pendingQuestCommands = new Map();
+  c.partyInfo = null;
+  c.selectedDungeonDifficulty = 'normal';
+  c.tradeInfo = null;
+  c.duelInfo = null;
+  c.lastSnapAt = 0;
+  c.snapInterval = 50;
+  c.serverTickHz = null;
+  c.missingSince = new Map();
+  c.pendingFacingDelta = 0;
+  c.connected = true;
+  c.eventQueue = [];
+  c.mouselookFacing = null;
+  c.lastInputSentAt = 0;
+  c.lastInputSig = '';
+  c.inputSeq = 0;
+  c.pendingInputSeqSentAt = new Map();
+  c.ackedInputSeq = 0;
+  c.inputEchoSamples = [];
+  c.spectateFacingPending = false;
+  c.pendingSpectateFacing = null;
+  c.nodeCooldowns = new Map();
+  return c;
+}
+
+function merchant(sim: any): Entity {
+  for (const e of sim.entities.values()) if (e.templateId === 'the_merchant') return e;
+  throw new Error('the Merchant was not spawned');
+}
+
+/** Stand the player on the Merchant so marketCollect's proximity gate passes. */
+function standAtMerchant(sim: any, pid: number): void {
+  const m = merchant(sim);
+  const e = sim.entities.get(pid);
+  e.pos.x = m.pos.x;
+  e.pos.z = m.pos.z;
+  e.pos.y = groundHeight(e.pos.x, e.pos.z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+/**
+ * A player parked at the Merchant with PROCEEDS waiting in their collection box
+ * and one snapshot already mirrored, so the next broadcast is a true delta.
+ * The priming consume is a FIXTURE control, not a negative control: the first full
+ * snapshot always carries inv/buyback/bags, so it reports true with or without the
+ * fix. Its job is to prove the flag mechanism itself works (and to clear the flag),
+ * so a later read is attributable to the copper arm alone.
+ */
+function setup() {
+  const server = new GameServer();
+  const fc = fakeWs();
+  const session = joinServer(server, fc, 7301);
+  const sim = (server as any).sim;
+  const meta = sim.players.get(session.pid);
+  standAtMerchant(sim, session.pid);
+  // Seed the seller's collection box with sale proceeds and NO items: the
+  // money-only shape the issue reports.
+  sim.market.marketCollections.set(String(meta.characterId ?? meta.entityId), {
+    copper: PROCEEDS,
+    items: [],
+  });
+
+  const client = bareClient(session.pid);
+  (server as any).broadcastSnapshots();
+  (client as any).applySnapshot(lastSnap(fc.sent));
+  expect(client.consumeInventoryChanged()).toBe(true); // negative control
+  fc.sent.length = 0;
+  return { server, fc, session, sim, meta, client };
+}
+
+/** Collect, broadcast, and return the resulting delta snapshot. */
+function collect(server: GameServer, fc: FakeClient, session: ClientSession): any {
+  server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'market_collect' }));
+  (server as any).broadcastSnapshots();
+  return lastSnap(fc.sent);
+}
+
+describe('bag money-row freshness on a money-only delta (#2373)', () => {
+  it('raises the inventory-changed flag from the copper delta alone', () => {
+    const { server, fc, session, meta, client } = setup();
+    const copperBefore = meta.copper;
+    const invBefore = JSON.stringify(meta.inventory);
+
+    const snap = collect(server, fc, session);
+
+    // The sim really did credit the purse...
+    expect(meta.copper).toBe(copperBefore + PROCEEDS);
+    // ...and really did leave the inventory untouched, which is WHY the wire
+    // carries no inv echo. Assert both, so a future content change that starts
+    // handing out an item here fails loudly here instead of silently making the
+    // flag assertion below pass for the wrong reason.
+    expect(JSON.stringify(meta.inventory)).toBe(invBefore);
+    expect('inv' in snap.self).toBe(false);
+    // `bags` and `buyback` raise the same flag from the same heavy-gated cluster,
+    // so name them too: without this, a future wire change that started shipping
+    // either one would keep the assertion below green for the wrong reason.
+    expect('bags' in snap.self).toBe(false);
+    expect('buyback' in snap.self).toBe(false);
+    expect(snap.self.copper).toBe(copperBefore + PROCEEDS);
+
+    (client as any).applySnapshot(snap);
+    expect(client.copper).toBe(copperBefore + PROCEEDS);
+    // The bug in one assertion. consumeInventoryChanged() is what src/main.ts
+    // gates hud.onInventoryChanged() on, and onInventoryChanged is the only
+    // authoritative online path that repaints the bag money row.
+    // NOTE: this read is DESTRUCTIVE (it clears the flag), so call it once.
+    expect(client.consumeInventoryChanged()).toBe(true);
+  });
+
+  it('stays quiet when the purse did NOT move (no 20 Hz repaint)', () => {
+    const { server, fc, session, client } = setup();
+    const snap = collect(server, fc, session);
+    (client as any).applySnapshot(snap);
+    expect(client.consumeInventoryChanged()).toBe(true);
+
+    // A second broadcast with no further money movement. A fix written as
+    // `if (s.copper !== undefined) this.invChanged = true` would pass the test
+    // above and fire here on EVERY snapshot, tearing down the bags, the vendor,
+    // the char sheet and the crafting probe twice a tick under the player's
+    // cursor. Diffing against the prior mirror is what keeps this false.
+    fc.sent.length = 0;
+    (server as any).broadcastSnapshots();
+    const quiet = lastSnap(fc.sent);
+    expect(quiet.self.copper).toBe(client.copper); // copper still rides the frame
+    (client as any).applySnapshot(quiet);
+    expect(client.consumeInventoryChanged()).toBe(false);
+  });
+
+  it('still flags an inventory-bearing delta (the pre-existing arm is intact)', () => {
+    // Guards against a fix that swapped the inv/buyback/bags flag writes for a
+    // copper-only one: an item collect must keep converging as it always did.
+    const { server, fc, session, sim, meta, client } = setup();
+    sim.market.marketCollections.set(String(meta.characterId ?? meta.entityId), {
+      copper: 0,
+      items: [{ itemId: 'worn_sword', count: 1 }],
+    });
+
+    const snap = collect(server, fc, session);
+    expect('inv' in snap.self).toBe(true);
+    (client as any).applySnapshot(snap);
+    expect(client.inventory.some((s) => s.itemId === 'worn_sword')).toBe(true);
+    expect(client.consumeInventoryChanged()).toBe(true);
+  });
+});
+
+describe('the spectate anchor (a ruling, pinned so it cannot drift silently)', () => {
+  // While spectating, the server builds the whole self block from the SPECTATED
+  // player's meta, and the client's self decode has no spectate branch. So the
+  // viewer's purse mirror follows their target. That is pre-existing and is exactly
+  // what `inv` has always done (the spectator's bag already lists the target's
+  // items), which is why the purse is deliberately NOT special-cased: guarding only
+  // copper would leave the window showing the target's ITEMS beside the viewer's own
+  // GOLD, which is worse than either coherent answer. What this fix changes is only
+  // that the row now converges promptly instead of holding a stale number.
+  it('follows the spectated player, exactly as the inventory mirror already does', () => {
+    const server = new GameServer();
+    const targetFc = fakeWs();
+    const target = joinServer(server, targetFc, 8801, 'Target');
+    const viewerFc = fakeWs();
+    const viewer = joinServer(server, viewerFc, 8802, 'Viewer');
+    const sim = (server as any).sim;
+    const targetMeta = sim.players.get(target.pid);
+
+    (viewer as any).spectating = {
+      characterId: 8801,
+      name: 'Target',
+      savedPos: { ...sim.entities.get(viewer.pid).pos },
+      priorGm: false,
+      stowedPet: null,
+    };
+
+    const client = bareClient(viewer.pid);
+    (server as any).broadcastSnapshots();
+    (client as any).applySnapshot(lastSnap(viewerFc.sent));
+    client.consumeInventoryChanged();
+
+    // The target earns money the viewer had nothing to do with.
+    viewerFc.sent.length = 0;
+    targetMeta.copper += 777;
+    (server as any).broadcastSnapshots();
+    const snap = lastSnap(viewerFc.sent);
+
+    expect(snap.self.copper).toBe(targetMeta.copper);
+    // Attributable to the copper arm alone: without this, a future wire change that
+    // started shipping inv on this frame would keep the flag assertion green for the
+    // wrong reason.
+    expect('inv' in snap.self).toBe(false);
+    (client as any).applySnapshot(snap);
+    expect(client.copper).toBe(targetMeta.copper);
+    expect(client.consumeInventoryChanged()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wiring. The pure staleness decision is a truth table in tests/bags_view.test.ts
+// and the painter behavior is driven for real in tests/bags_money_row_paint.test.ts,
+// so what is left here is only WHERE the call sites live: code paths a unit test
+// cannot execute (the per-frame update band, the online delta hook). Pinned against
+// comment-stripped source, so prose alone can never satisfy a pin.
+// ---------------------------------------------------------------------------
+
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const hud = stripComments(readFileSync(path.resolve(process.cwd(), 'src/ui/hud.ts'), 'utf8'));
+
+describe('bag purse-freshness wiring (source pins)', () => {
+  it('drives the window probe from the SLOW band, never per frame', () => {
+    // Pin the gate INLINE with the call rather than slicing a region: a region
+    // ending at the next painter runs past the block's closing brace, so a call
+    // hoisted just outside it would still sit inside the slice and pass. Requiring
+    // the `if (slowHud)` prefix on the one and only occurrence cannot be dodged
+    // that way: hoisting it to per-frame drops the prefix and reds this.
+    // Heads-up for a future tidier: the slow-band siblings read `slowHud && X.isOpen`,
+    // but this one is deliberately bare. BagsWindow.refreshIfChanged self-gates on the
+    // window's own display through bagsMoneyRowStale, so an isOpen term here would be
+    // a second gate for the same fact. Adding one is not wrong, but update this pin
+    // deliberately rather than to make the line look like its neighbours.
+    const calls = hud.match(/this\.bagsWindow\.refreshIfChanged\(\);/g) ?? [];
+    expect(calls).toHaveLength(1);
+    expect(hud).toMatch(/if \(slowHud\) this\.bagsWindow\.refreshIfChanged\(\);/);
+  });
+
+  it('the online authoritative delta repaints the bags through the cold-safe gate', () => {
+    // This is the edge that makes the ONLINE half of the fix visible: the copper
+    // diff raises the flag, main.ts calls this hook, and this line repaints. Pin
+    // the cold-load-safe form too (issue #1538): every money-only credit now routes
+    // through here, so the raw `!== 'none'` compare would rebuild a window the
+    // player has never opened on each one.
+    expect(hud).toMatch(
+      /onInventoryChanged\(\): void \{[^}]*if \(bagsWindowShown\(\$\('#bags'\)\.style\.display\)\) this\.renderBags\(\);/,
+    );
+  });
+
+  it('keeps BOTH crafting reagent edges it is layered beside', () => {
+    // The two staleness probes are independent. Deleting a crafting edge on the
+    // theory that the purse diff now covers staleness would regress issue #2375.
+    // Count rather than merely match: the crafting probe has to keep ALL THREE of
+    // its call sites (the slow band, the online delta hook, and the vendor
+    // buyAndRefresh closure), and a bare toMatch would stay green with two of them
+    // removed. The behavior itself is pinned in tests/crafting_reagent_refresh.test.ts;
+    // this only guards that adding the purse probe did not displace any of them.
+    const crafting = hud.match(/this\.refreshOpenCraftingIfReagentsChanged\(\);/g) ?? [];
+    expect(crafting).toHaveLength(3);
+  });
+});
+
+describe('ClientWorld purse decode (source pin)', () => {
+  const online = stripComments(
+    readFileSync(path.resolve(process.cwd(), 'src/net/online.ts'), 'utf8'),
+  );
+
+  it('diffs the purse against the prior mirror rather than testing presence', () => {
+    // The behavior is proven by the runtime tests above; this pin names the FORM,
+    // because the presence-test mistake is silent (it passes the flag test and only
+    // shows up as a continuous repaint in a real client).
+    expect(online).toContain('if (copper !== this.copper) this.invChanged = true;');
+    expect(online).not.toMatch(/if \(s\.copper !== undefined\) this\.invChanged = true;/);
+  });
+});

--- a/tests/bags_money_row_paint.test.ts
+++ b/tests/bags_money_row_paint.test.ts
@@ -1,0 +1,264 @@
+// @vitest-environment jsdom
+// The bag money row's own staleness refresh (issue #2373), driven against the REAL
+// BagsWindow painter in jsdom (the bags_window_instance_marker.test.ts idiom).
+//
+// The pure decision behind it (bagsMoneyRowStale) is a truth table in
+// bags_view.test.ts; what this file pins is the painter half, and above all what the
+// refresh must NOT disturb. Every other bags repaint path is user-initiated (a click,
+// a keystroke) and hides the tooltip first. This one fires from a server credit or a
+// coin-only mob loot with no user action behind it, so a full render() here would
+// yank the bag-search caret mid-word, strand a hovered tooltip and drop an armed
+// touch drag. Hence a narrow .money rewrite, and hence these assertions.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { InvSlot } from '../src/sim/types';
+import { BagsWindow, type BagsWindowDeps } from '../src/ui/bags_window';
+import { ItemDragState } from '../src/ui/item_drag_state';
+import type { IWorld } from '../src/world_api';
+
+const SWORD: InvSlot[] = [{ itemId: 'sword', count: 1 }];
+
+interface Harness {
+  window: BagsWindow;
+  root: HTMLElement;
+  setCopper(next: number): void;
+  moneyText(): string;
+  hideTooltip: ReturnType<typeof vi.fn>;
+  /** How many times the money row has been PAINTED. Counted through the moneyHtml
+   *  dep, which every paint calls exactly once. A marker attribute on the .money
+   *  element cannot serve here: innerHTML replaces the row's children, not the row,
+   *  so a marker survives a repaint and an elision assertion built on it would pass
+   *  even with the latch removed entirely. */
+  paints(): number;
+}
+
+function harness(startCopper = 1000, inventory: InvSlot[] = SWORD): Harness {
+  const root = document.createElement('div');
+  root.style.display = 'flex';
+  document.body.appendChild(root);
+  let copper = startCopper;
+  let paints = 0;
+  const noop = (): void => {};
+  const hideTooltip = vi.fn();
+  const deps: BagsWindowDeps = {
+    itemIcon: () => '<span class="item-icon"></span>',
+    // Echo the purse so an assertion can see WHICH value was painted, not merely
+    // that something repainted, and count the paints for the elision assertions.
+    moneyHtml: (c: number) => {
+      paints++;
+      return `<span class="coin-amount">${c}</span>`;
+    },
+    itemTooltip: () => '',
+    attachTooltip: noop,
+    root: () => root,
+    world: () =>
+      ({
+        inventory,
+        bags: [null, null, null, null],
+        bagCapacity: 16,
+        get copper() {
+          return copper;
+        },
+      }) as unknown as IWorld,
+    wocBalanceHtml: () => '',
+    claudiumLauncherHtml: () => '',
+    openClaudium: noop,
+    openWallet: noop,
+    hideTooltip,
+    consumePeek: () => false,
+    cancelPetFeed: noop,
+    captureFocus: () => null,
+    restoreFocus: noop,
+    renderCharIfOpen: noop,
+    vendorOpen: () => false,
+    tradeOpen: () => false,
+    isMarketSell: () => false,
+    isMailAttach: () => false,
+    isBankOpen: () => false,
+    pendingPetFeed: () => false,
+    closeVendor: noop,
+    closeBank: noop,
+    onClosed: noop,
+    addItemToTrade: noop,
+    stageMarketSell: noop,
+    stageMailParcel: noop,
+    insertItemChatLink: noop,
+    showError: noop,
+    setPendingPetFeed: noop,
+    resetPetBarSig: noop,
+    isHotbarItemId: () => false,
+    useGatherTool: () => false,
+    setDragAction: noop,
+    clearActionDropTargets: noop,
+    dragState: new ItemDragState(),
+    isTouchHud: () => false,
+    markEquipDropTargets: noop,
+    dropOnEquipSlot: noop,
+    openItemActionMenu: noop,
+  };
+  return {
+    window: new BagsWindow(deps),
+    root,
+    setCopper: (next) => {
+      copper = next;
+    },
+    moneyText: () => root.querySelector('.money')?.textContent ?? '',
+    hideTooltip,
+    paints: () => paints,
+  };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('BagsWindow.refreshIfChanged', () => {
+  it('repaints the money row when the purse moves (the issue #2373 repro)', () => {
+    const h = harness(1000);
+    h.window.render();
+    expect(h.moneyText()).toContain('1000');
+
+    // The auctioneer pays out: proceeds land with no inventory change at all.
+    h.setCopper(55321);
+    h.window.refreshIfChanged();
+    expect(h.moneyText()).toContain('55321');
+  });
+
+  it('elides when the purse has not moved', () => {
+    const h = harness(1000);
+    h.window.render();
+    expect(h.paints()).toBe(1);
+    // An elided probe must not rewrite the row at all, or the 500ms band would
+    // churn the footer twice a second forever.
+    h.window.refreshIfChanged();
+    h.window.refreshIfChanged();
+    expect(h.paints()).toBe(1);
+    expect(h.moneyText()).toContain('1000');
+  });
+
+  it('paints nothing while the window is HIDDEN, then converges when it reopens', () => {
+    const h = harness(1000);
+    h.window.render();
+    h.root.style.display = 'none';
+    h.setCopper(7777);
+    h.window.refreshIfChanged();
+    expect(h.moneyText()).toContain('1000'); // still the pre-credit purse
+
+    // Reopening rebuilds the whole window, which is what actually converges it.
+    h.root.style.display = 'flex';
+    h.window.render();
+    expect(h.moneyText()).toContain('7777');
+  });
+
+  it('paints nothing on a never-opened window (cold display "", issue #1538)', () => {
+    const h = harness(1000);
+    h.window.render();
+    h.root.style.display = ''; // the cold-load value the .window CSS rule hides
+    h.setCopper(4242);
+    h.window.refreshIfChanged();
+    expect(h.moneyText()).toContain('1000');
+  });
+
+  it('re-arms the latch on a full render, so no probe owes a second paint', () => {
+    const h = harness(1000);
+    h.setCopper(9000);
+    h.window.render(); // arms at 9000
+    expect(h.paints()).toBe(1);
+    h.window.refreshIfChanged();
+    expect(h.paints()).toBe(1);
+  });
+
+  it('re-arms the latch on its OWN paint, so one credit paints exactly once', () => {
+    // Without this the latch would stay at the -1 cold sentinel and every probe
+    // would repaint: a 2 Hz rewrite of the footer for the rest of the session.
+    const h = harness(1000);
+    h.window.render();
+    h.setCopper(5000);
+    h.window.refreshIfChanged();
+    expect(h.paints()).toBe(2);
+    h.window.refreshIfChanged();
+    h.window.refreshIfChanged();
+    expect(h.paints()).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// What the refresh must not disturb. These are the reason it is a narrow .money
+// rewrite rather than renderBags(): this edge fires with no user action behind it.
+// ---------------------------------------------------------------------------
+
+describe('BagsWindow.refreshIfChanged preserves what the player is holding', () => {
+  it('does not rebuild the grid (a hovered row keeps its identity and listeners)', () => {
+    const h = harness(1000);
+    h.window.render();
+    const grid = h.root.querySelector('.bag-grid');
+    const cell = grid?.firstElementChild;
+    expect(grid).not.toBeNull();
+    expect(cell).not.toBeNull();
+
+    h.setCopper(5000);
+    h.window.refreshIfChanged();
+
+    // Same NODES, not merely equal markup: a rebuild would drop the tooltip and
+    // drag listeners bound to the old cell, which is the #2375-adjacent hazard.
+    expect(h.root.querySelector('.bag-grid')).toBe(grid);
+    expect(h.root.querySelector('.bag-grid')?.firstElementChild).toBe(cell);
+  });
+
+  it('keeps focus and the caret in the bag-search box mid-word', () => {
+    const h = harness(1000);
+    h.window.render();
+    const search = h.root.querySelector('.bag-search') as HTMLInputElement | null;
+    expect(search, 'the filter bar renders whenever the bag has items').not.toBeNull();
+    const box = search as HTMLInputElement;
+    box.value = 'swo';
+    box.focus();
+    box.setSelectionRange(2, 2);
+    expect(document.activeElement).toBe(box);
+
+    // A coin-only mob loot lands while the player is typing.
+    h.setCopper(1007);
+    h.window.refreshIfChanged();
+
+    expect(h.root.querySelector('.bag-search')).toBe(box); // never re-created
+    expect(document.activeElement).toBe(box);
+    expect(box.value).toBe('swo');
+    expect(box.selectionStart).toBe(2);
+    expect(h.moneyText()).toContain('1007');
+  });
+
+  it('never reaches for hideTooltip on this path', () => {
+    // Scope note: this guards against ADDING a hideTooltip() to the refresh path,
+    // it does not catch a regression to a full render(). render() does not call
+    // hideTooltip either (only close() and the click/drag handlers do), so the
+    // full-rebuild tooltip hazard is really the loss of the hovered row's LISTENERS,
+    // and that is what the grid node-identity assertion above pins.
+    // The click/drag paths dismiss the tooltip deliberately because the player just
+    // acted. This edge has no user action behind it, so it must stay hands-off.
+    const h = harness(1000);
+    h.window.render();
+    h.hideTooltip.mockClear();
+    h.setCopper(5000);
+    h.window.refreshIfChanged();
+    expect(h.hideTooltip).not.toHaveBeenCalled();
+  });
+
+  it('keeps the money row wired after its rewrite', () => {
+    // The row's two launchers are bound per paint, so an in-place rewrite has to
+    // re-bind them or the wallet/Claudium buttons go dead after the first credit.
+    const opened: string[] = [];
+    const h = harness(1000);
+    const w = h.window as unknown as {
+      deps: { claudiumLauncherHtml(): string; openClaudium(): void };
+    };
+    // Swap in a launcher with a real hook, then paint through the narrow path.
+    w.deps.claudiumLauncherHtml = () => '<button data-claudium-launcher>c</button>';
+    w.deps.openClaudium = () => opened.push('claudium');
+    h.window.render();
+    h.setCopper(5000);
+    h.window.refreshIfChanged();
+
+    (h.root.querySelector('[data-claudium-launcher]') as HTMLElement | null)?.click();
+    expect(opened).toEqual(['claudium']);
+  });
+});

--- a/tests/bags_view.test.ts
+++ b/tests/bags_view.test.ts
@@ -8,6 +8,7 @@ import {
   bagQualityKey,
   bagShiftLinks,
   bagStackIndex,
+  bagsMoneyRowStale,
   bagsWindowShown,
   bagTooltipHintKey,
   bankDepositOpensPrompt,
@@ -409,5 +410,48 @@ describe('ClientWorld-vs-Sim parity', () => {
     const cliInv = JSON.parse(JSON.stringify(simInv)) as InvSlot[];
     const filter = { ...DEFAULT_BAG_FILTER, sort: 'quality' as const };
     expect(buildBagGrid(simInv, lookup, filter)).toEqual(buildBagGrid(cliInv, lookup, filter));
+  });
+});
+
+// The purse-staleness decision behind the bag money row (issue #2373). This is the
+// whole polarity of the fix in one pure predicate, which is the point: driven as a
+// truth table here, an inverted gate or an inverted diff cannot survive, where a
+// source-text pin on the call site would match the negated form just as happily.
+describe('bagsMoneyRowStale', () => {
+  it('is TRUE only when a shown window is painting a purse that moved', () => {
+    // The issue's repro: the window is up, the auctioneer just paid out.
+    expect(bagsMoneyRowStale('flex', 5000, 1000)).toBe(true);
+  });
+
+  it('is FALSE when the purse did not move (no repaint under the player)', () => {
+    // Load-bearing: this runs on the 500ms band, so a predicate that ignored the
+    // purse would rebuild the money row twice a second forever.
+    expect(bagsMoneyRowStale('flex', 5000, 5000)).toBe(false);
+  });
+
+  it('is FALSE for a hidden window even when the purse moved', () => {
+    expect(bagsMoneyRowStale('none', 5000, 1000)).toBe(false);
+  });
+
+  it('is FALSE for a never-opened window, whose cold display is empty (issue #1538)', () => {
+    // The raw `!== 'none'` form that the older bags call sites copy reads '' as
+    // shown, which would paint a window the player has never opened.
+    expect(bagsMoneyRowStale('', 5000, 1000)).toBe(false);
+  });
+
+  it('converges from the -1 cold sentinel, which no real purse can equal', () => {
+    // A window shown without a paint behind it must not be left stale, and a
+    // zero-copper player must still arm rather than compare equal by accident.
+    expect(bagsMoneyRowStale('flex', 0, -1)).toBe(true);
+  });
+
+  it('fires on a DEBIT as well as a credit (a trainer fee, a vendor buy)', () => {
+    // `!==`, not `>`: money leaving the purse goes just as stale as money arriving.
+    expect(bagsMoneyRowStale('flex', 1000, 5000)).toBe(true);
+  });
+
+  it('is not pinned to the current shown value', () => {
+    // Mirrors bagsWindowShown's own contract: guard the hidden values, not 'flex'.
+    expect(bagsMoneyRowStale('block', 5000, 1000)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Collecting auction proceeds at the Merchant left the gold in the bag window stale until the
player closed and reopened it (#2373). Same class as #2375 (the crafting window going stale on a
bag change), which is why that fix's shape is reused here.

The defect is a missing convergence edge, not a missing button handler. Three links, each
confirmed by driving a real `GameServer` rather than by reading:

1. A proceeds-only collect moves **only** `meta.copper` (`src/sim/market.ts`), so the player's
   inventory is byte-identical.
2. On the wire, `copper` rides the server's unconditional self block (`server/game.ts`) while
   `inv` is serialize-diffed, so a money-only frame carries fresh gold and **no `inv` key at
   all**.
3. `ClientWorld` mirrored the new copper without raising its inventory-changed flag:

   ```ts
   this.copper = s.copper ?? 0;                                    // no flag
   if (s.inv !== undefined) { this.inventory = s.inv; this.invChanged = true; }
   ```

   So `consumeInventoryChanged()` stayed false, `Hud.onInventoryChanged()` never ran, and the
   bag money row (a cold painter with no staleness contract of its own) was never repainted.

Two halves:

**The wire half** (`src/net/online.ts`) diffs the purse against the prior mirror before
assigning it, raising the existing flag on a real move. This routes every money-only delta
through the repaint fan-out that already exists, and closes the whole online class at once:
market collect, bank slot purchase, mail coin, trainer fee, Vale Cup payout, delve and lockpick
copper. Diffing rather than testing presence is load-bearing: `copper` rides **every** self
frame, so `s.copper !== undefined` would raise the flag at 20 Hz and rebuild the bags under the
player's cursor continuously. A test pins exactly that.

**The window half** gives the bags their own staleness contract, for the credits that reach no
bags arm in *either* host (a trainer fee, a settled Vale Cup bet, delve copper):

- `bagsMoneyRowStale(display, copper, lastPainted)` in `src/ui/bags_view.ts`, the bags pure core
  that is already registered in `UI_PURE_CORES`. Putting the whole polarity in one pure
  predicate is what makes it testable as a truth table.
- `BagsWindow.refreshIfChanged()` owning its own latch, joining the eight-member
  `refreshIfChanged` family the slow band already drives (bank, mailbox, market, social, deeds,
  professions, calendar), so `hud.ts` stays a one-line consumer rather than growing another
  private probe.
- The repaint is a narrow `.money` rewrite, **not** a full `render()`. Nothing else inside
  `#bags` reads copper, and unlike every other bags repaint path this edge fires from a server
  credit or a coin-only mob loot with no user action behind it. A full rebuild would drop the
  bag-search caret mid-word, strand a hovered tooltip and break an armed touch drag. This is the
  same reason `refreshGrid()` already exists for live search.
- `onInventoryChanged` now uses the cold-load-safe `bagsWindowShown` gate instead of the raw
  `!== 'none'` compare, which reads a never-opened window as shown (#1538). That was harmless
  while only inventory deltas landed there; every money move routes through it now.

No wire change, no new delta key, no `IWorld` surface change, no parity-pin edit: `copper` was
already a pinned data member on both worlds.

### Scope, stated precisely

Not folded in, deliberately:

- **The other purse-reading windows.** `renderTrain` and `renderUnbind` read `this.sim.copper`
  for affordability and have no purse edge in either host; the vendor gets one for free online
  (it rides `onInventoryChanged`) but not offline. Separate windows, separate contracts, worth
  their own change.
- **The delta-guarded sibling scalars.** To be accurate about *why*: `xp`/`lxp`/`rxp`/`prk` ride
  the unconditional self block and move on every kill, so wiring them to this flag would tear
  down the bags and vendor continuously during combat. But `honor`/`lhonor`/`renown`/`dmarks`
  are `maybe()` delta-guarded and reach the client only when they actually changed, so that
  argument does *not* apply to them; they are a genuinely analogous cold-painter gap (marks
  shop, delve board, deeds window) and deserve a follow-up rather than being smuggled in here.
- **#2137** (character window prestige) stays open. It is a different window with its own edge.

One ruling worth surfacing: while spectating, the server builds the self block from the
spectated player's meta, so the viewer's purse mirror follows their target. That is pre-existing
and is exactly what `inv` has always done (a spectator's bag already lists the target's items).
The purse is deliberately not special-cased, because guarding only copper would show the
target's items beside the viewer's own gold, which is worse than either coherent answer. What
changes here is only that the row converges promptly instead of holding a stale number. Pinned
by a test so it cannot drift silently.

## Related issues

Closes #2373. Sibling of #2375 (merged). Does not address #2137, which stays open.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/bags_money_refresh.test.ts tests/bags_money_row_paint.test.ts
    tests/bags_view.test.ts` (the three layers, 55 tests)
  - a 16-file regression sweep across bags, hud perf budget, painter host, snapshots,
    architecture, parity, market, bank and crafting: 730 passed
  - `npx tsc --noEmit`, `npx @biomejs/biome ci <changed files>`, `npm run gate`
- Coverage is split so each layer is **executed**, not pattern-matched:
  - `tests/bags_view.test.ts` drives `bagsMoneyRowStale` as a truth table (shown+moved, shown+
    same, hidden, cold-load `''`, the `-1` sentinel, a debit, a non-`flex` shown value).
  - `tests/bags_money_row_paint.test.ts` drives the real `BagsWindow` in jsdom: the repro, the
    elision, hidden and never-opened windows, latch re-arming, and what the refresh must not
    disturb (grid node identity, focus, caret, tooltip, and the money row's own listeners).
  - `tests/bags_money_refresh.test.ts` drives a real `GameServer` + `ClientWorld` through
    `{ t: 'cmd', cmd: 'market_collect' }` and asserts the wire shape the server actually sends
    (`self.copper` fresh; `inv`, `bags` and `buyback` all absent) before asserting the flag.
- Every assertion was mutation-verified. Eight mutations, each killed: inverting the shown gate
  (10 tests red), inverting the purse diff (7), hoisting the probe to per-frame (1), swapping the
  narrow rewrite for a full rebuild (2), reverting the online diff (4), the wrong presence-test
  fix (2), removing the `onInventoryChanged` repaint (1), removing the latch re-arm (3).
- A test asserting only "a market collect repaints the bags" was deliberately **not** written:
  it passes today via the generic `loot` event arm and would prove nothing.

## Screenshots / recordings

N/A, and deliberately so. This changes **when** the money row repaints, not what it renders: the
markup is byte-identical before and after. A static before/after pair cannot show the difference
(both frames look correct, or both stale, purely by capture timing), so the convergence is
evidenced by the executed tests above instead.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [x] **Tested on desktop and mobile.** No layout or styling change. The refresh is narrower
      than the paths it replaces, and the jsdom suite pins that it preserves focus and the
      caret, which is the mobile-keyboard-dismissal case.
- [x] **Accessible.** No UI structure or ARIA change; the refresh is pinned not to move focus.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
