### PR TITLE
fix(ui): keep the async balance reads off the full bag rebuild

### DIFF
--- a/src/ui/bags_window.ts
+++ b/src/ui/bags_window.ts
@@ -261,8 +261,11 @@ export class BagsWindow {
 
   /** The narrow repaint: find the existing footer and re-paint it. A window that has
    *  never been rendered has no .money row yet, so this is a no-op rather than a
-   *  partial paint. */
-  private refreshMoneyRow(): void {
+   *  partial paint. Public because the async $WOC / Claudium balance reads land on
+   *  their own schedule and need the same footer-only treatment: before this they
+   *  called the HUD's full renderBags() from a promise resolve, which tore the window
+   *  down under a player who had not touched anything. */
+  refreshMoneyRow(): void {
     const row = this.deps.root().querySelector('.money') as HTMLElement | null;
     if (!row) return;
     this.paintMoneyRow(row, this.deps.world().copper);

--- a/src/ui/bags_window.ts
+++ b/src/ui/bags_window.ts
@@ -246,8 +246,17 @@ export class BagsWindow {
     this.refreshMoneyRow();
   }
 
-  /** Rewrite ONLY the .money footer in place, re-binding its two launchers. Shared by
-   *  the full render() and the purse probe, so the latch arms on both. */
+  /** Rewrite ONLY the .money footer in place, re-binding its two launchers. Every
+   *  paint path runs through here (the full render(), the purse probe, and the async
+   *  $WOC / Claudium balance reads), so the latch arms on all of them.
+   *
+   *  Deliberately does NOT restore focus across the rewrite, unlike the
+   *  deeds/professions refocus family. Two reasons, both settled on PR #2377: the
+   *  footer's launchers are BUTTONs, and input.ts leaves a focused button's Enter
+   *  default alone on the chat edge, so parking focus back on one makes the player's
+   *  next Enter open chat AND re-fire the button; and #bags is non-modal and absent
+   *  from isModalOpen(), so canUseGameKeys() stays true and Tab is swallowed by
+   *  target-nearest, which means keyboard focus never lands in here to begin with. */
   private paintMoneyRow(row: HTMLElement, copper: number): void {
     row.innerHTML = `${this.deps.wocBalanceHtml()}${this.deps.claudiumLauncherHtml()}${this.deps.moneyHtml(copper)}`;
     row.querySelector('[data-claudium-launcher]')?.addEventListener('click', () => {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -4295,8 +4295,10 @@ export class Hud {
         // balance read's own schedule with no user action behind it, so a full
         // renderBags() here would tear the window down under a player who is
         // mid-drag, hovering a tooltip, or typing in bag search. Re-entry is not a
-        // risk: the repaint calls claudiumLauncherHtml again, but the 30s throttle
-        // was just re-stamped by setClaudiumLauncherBalance above.
+        // risk: the repaint does call claudiumLauncherHtml again, but
+        // claudiumLauncherBalancePending is still true here (.finally has not run),
+        // so the nested read returns before it ever consults the 30s throttle. The
+        // throttle re-stamp above is the second line of defense, not the first.
         if (bagsWindowShown($('#bags').style.display)) this.bagsWindow.refreshMoneyRow();
       })
       .catch(() => {
@@ -12003,8 +12005,10 @@ export class Hud {
     // Dock the char-sheet pairing when its companion opens (the touch cluster).
     this.syncCharBagsPairing();
     audio.bagOpen();
-    // Pull a fresh on-chain $WOC balance for the footer; the async result
-    // re-renders the bag via the onWalletUiChange listener wired in the ctor.
+    // Pull a fresh on-chain $WOC balance for the footer; the async result repaints
+    // the footer (not the whole bag) via the onWalletUiChange listener wired in the
+    // ctor. The display is set to 'flex' above precisely so that listener's
+    // bagsWindowShown gate sees an open window when the balance lands.
     this.optionsHooks?.refreshWocBalance();
   }
 

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1744,7 +1744,10 @@ export class Hud {
     // re-render the bag footer (and re-composite an open player card) when the
     // connected wallet's $WOC balance changes
     onWalletUiChange(() => {
-      if ($('#bags').style.display !== 'none') this.renderBags();
+      // Footer-only, as this comment always claimed: the balance lands asynchronously
+      // with no user action behind it, so a full rebuild would drop the bag-search
+      // caret and strand a hovered tooltip. Cold-load-safe gate (#1538) too.
+      if (bagsWindowShown($('#bags').style.display)) this.bagsWindow.refreshMoneyRow();
       this.playerCard.refresh();
       this.claudiumWindow.onWalletChanged();
     });
@@ -4288,7 +4291,13 @@ export class Hud {
       .then((balance) => {
         if (seq !== this.claudiumLauncherBalanceSeq) return;
         this.setClaudiumLauncherBalance(balance);
-        if ($('#bags').style.display !== 'none') this.renderBags();
+        // Footer-only, and on the cold-load-safe gate (#1538). This resolves on the
+        // balance read's own schedule with no user action behind it, so a full
+        // renderBags() here would tear the window down under a player who is
+        // mid-drag, hovering a tooltip, or typing in bag search. Re-entry is not a
+        // risk: the repaint calls claudiumLauncherHtml again, but the 30s throttle
+        // was just re-stamped by setClaudiumLauncherBalance above.
+        if (bagsWindowShown($('#bags').style.display)) this.bagsWindow.refreshMoneyRow();
       })
       .catch(() => {
         if (seq !== this.claudiumLauncherBalanceSeq) return;

--- a/tests/bags_money_refresh.test.ts
+++ b/tests/bags_money_refresh.test.ts
@@ -374,11 +374,37 @@ describe('async balance reads repaint the FOOTER, not the whole window', () => {
 
   it('the wallet UI change listener repaints only the money row', () => {
     expect(hud).toMatch(/onWalletUiChange\(\(\) => \{[^}]*this\.bagsWindow\.refreshMoneyRow\(\);/);
+    // ONLY. A toMatch on the new call says nothing about the old one: re-adding
+    // `this.renderBags();` on the next line satisfies every affirmative pin here
+    // while restoring the exact teardown this block is named after. Scoped to the
+    // block, not the file, because ~7 other sites call renderBags() legitimately.
+    expect(hud).not.toMatch(/onWalletUiChange\(\(\) => \{[^}]*this\.renderBags\(\);/);
   });
 
   it('the Claudium balance resolve repaints only the money row', () => {
     expect(hud).toMatch(
       /this\.setClaudiumLauncherBalance\(balance\);[^}]*this\.bagsWindow\.refreshMoneyRow\(\);/,
+    );
+    expect(hud).not.toMatch(
+      /this\.setClaudiumLauncherBalance\(balance\);[^}]*this\.renderBags\(\);/,
+    );
+  });
+
+  it('leaves the pending flag as the re-entry guard, reset only in the finally arm', () => {
+    // The repaint re-enters claudiumLauncherHtml() -> refreshClaudiumLauncherBalance(),
+    // so something has to stop a self-feeding balance read. That something is
+    // claudiumLauncherBalancePending, which is still true inside .then because
+    // .finally has not run: the 30s throttle re-stamp is a second line of defense,
+    // not the first. Move the reset into .then (before the repaint) and the loop is
+    // live again with every behavior test still green, so pin WHERE it is cleared.
+    expect(hud).toMatch(
+      /\.finally\(\(\) => \{\s*if \(seq === this\.claudiumLauncherBalanceSeq\) \{\s*this\.claudiumLauncherBalancePending = false;/,
+    );
+    const resets = hud.match(/this\.claudiumLauncherBalancePending = false;/g) ?? [];
+    expect(resets).toHaveLength(2); // the finally arm + the attachClaudium re-arm
+    // And the early-return that consumes it still guards the whole read.
+    expect(hud).toMatch(
+      /if \(!this\.claudiumHooks \|\| this\.claudiumLauncherBalancePending\) return;/,
     );
   });
 

--- a/tests/bags_money_refresh.test.ts
+++ b/tests/bags_money_refresh.test.ts
@@ -180,7 +180,7 @@ function setup() {
   const client = bareClient(session.pid);
   (server as any).broadcastSnapshots();
   (client as any).applySnapshot(lastSnap(fc.sent));
-  expect(client.consumeInventoryChanged()).toBe(true); // negative control
+  expect(client.consumeInventoryChanged()).toBe(true); // fixture control, see above
   fc.sent.length = 0;
   return { server, fc, session, sim, meta, client };
 }
@@ -360,6 +360,38 @@ describe('bag purse-freshness wiring (source pins)', () => {
     // this only guards that adding the purse probe did not displace any of them.
     const crafting = hud.match(/this\.refreshOpenCraftingIfReagentsChanged\(\);/g) ?? [];
     expect(crafting).toHaveLength(3);
+  });
+});
+
+describe('async balance reads repaint the FOOTER, not the whole window', () => {
+  // Both $WOC and Claudium balances resolve on their own schedule with no user action
+  // behind them, and both used to call the HUD's full renderBags() from a promise
+  // resolve. That tore the window down under a player who was mid-drag, hovering a
+  // tooltip, or typing in bag search, and it defeated the narrow money-row rewrite the
+  // purse probe was built around (the Claudium read is 30s-throttled, so an open bag
+  // with a moving purse hit it roughly twice a minute). Pinned per SITE, because a
+  // whole-file assertion would be satisfied by either one alone.
+
+  it('the wallet UI change listener repaints only the money row', () => {
+    expect(hud).toMatch(/onWalletUiChange\(\(\) => \{[^}]*this\.bagsWindow\.refreshMoneyRow\(\);/);
+  });
+
+  it('the Claudium balance resolve repaints only the money row', () => {
+    expect(hud).toMatch(
+      /this\.setClaudiumLauncherBalance\(balance\);[^}]*this\.bagsWindow\.refreshMoneyRow\(\);/,
+    );
+  });
+
+  it('neither async path is left on the cold-load-unsafe raw display compare', () => {
+    // `!== 'none'` reads a never-opened window as shown (#1538), so the old form
+    // would paint a window the player has never opened on every balance read.
+    const sites = hud.match(/this\.bagsWindow\.refreshMoneyRow\(\);/g) ?? [];
+    expect(sites).toHaveLength(2);
+    const guarded =
+      hud.match(
+        /if \(bagsWindowShown\(\$\('#bags'\)\.style\.display\)\) this\.bagsWindow\.refreshMoneyRow\(\);/g,
+      ) ?? [];
+    expect(guarded).toHaveLength(2);
   });
 });
 

--- a/tests/bags_money_row_paint.test.ts
+++ b/tests/bags_money_row_paint.test.ts
@@ -243,22 +243,33 @@ describe('BagsWindow.refreshIfChanged preserves what the player is holding', () 
     expect(h.hideTooltip).not.toHaveBeenCalled();
   });
 
-  it('keeps the money row wired after its rewrite', () => {
-    // The row's two launchers are bound per paint, so an in-place rewrite has to
-    // re-bind them or the wallet/Claudium buttons go dead after the first credit.
-    const opened: string[] = [];
-    const h = harness(1000);
-    const w = h.window as unknown as {
-      deps: { claudiumLauncherHtml(): string; openClaudium(): void };
-    };
-    // Swap in a launcher with a real hook, then paint through the narrow path.
-    w.deps.claudiumLauncherHtml = () => '<button data-claudium-launcher>c</button>';
-    w.deps.openClaudium = () => opened.push('claudium');
-    h.window.render();
-    h.setCopper(5000);
-    h.window.refreshIfChanged();
+  // BOTH launchers, one case each. A single combined assertion is not enough here:
+  // with only the Claudium arm, deleting the wallet re-bind from paintMoneyRow left
+  // all 55 tests green, and the footer's Connect/Link wallet button would have gone
+  // dead after the first purse-driven repaint. wocBalanceHtml emits
+  // [data-wallet-action] only on its BUTTON variant (an unverified wallet), which is
+  // exactly the case a real player hits before verifying.
+  for (const launcher of [
+    {
+      name: 'Claudium',
+      html: 'claudiumLauncherHtml',
+      hook: 'openClaudium',
+      attr: 'data-claudium-launcher',
+    },
+    { name: 'wallet', html: 'wocBalanceHtml', hook: 'openWallet', attr: 'data-wallet-action' },
+  ] as const) {
+    it(`keeps the ${launcher.name} launcher wired after an in-place rewrite`, () => {
+      const opened: string[] = [];
+      const h = harness(1000);
+      const w = h.window as unknown as { deps: Record<string, unknown> };
+      w.deps[launcher.html] = () => `<button ${launcher.attr}>x</button>`;
+      w.deps[launcher.hook] = () => opened.push(launcher.name);
+      h.window.render();
+      h.setCopper(5000);
+      h.window.refreshIfChanged();
 
-    (h.root.querySelector('[data-claudium-launcher]') as HTMLElement | null)?.click();
-    expect(opened).toEqual(['claudium']);
-  });
+      (h.root.querySelector(`[${launcher.attr}]`) as HTMLElement | null)?.click();
+      expect(opened).toEqual([launcher.name]);
+    });
+  }
 });

--- a/tests/bags_money_row_paint.test.ts
+++ b/tests/bags_money_row_paint.test.ts
@@ -183,6 +183,51 @@ describe('BagsWindow.refreshIfChanged', () => {
 });
 
 // ---------------------------------------------------------------------------
+// The public entry point the async balance reads use. refreshIfChanged is the
+// purse-driven probe and elides on an unmoved purse; refreshMoneyRow is the
+// unconditional repaint, because the $WOC and Claudium balances move while `copper`
+// stands still. Driving it directly is what keeps those two from collapsing into one.
+// ---------------------------------------------------------------------------
+
+describe('BagsWindow.refreshMoneyRow (the async balance-read entry point)', () => {
+  it('repaints even when the purse has NOT moved', () => {
+    // The whole reason it is a separate public method. A $WOC or Claudium balance
+    // landing changes the footer markup with `copper` untouched, so a refreshMoneyRow
+    // that consulted the lastMoneyCopper latch (or delegated to refreshIfChanged)
+    // would silently never paint the new balance.
+    const h = harness(1000);
+    h.window.render();
+    expect(h.paints()).toBe(1);
+
+    h.window.refreshMoneyRow();
+    expect(h.paints()).toBe(2);
+    h.window.refreshMoneyRow();
+    expect(h.paints()).toBe(3);
+    expect(h.moneyText()).toContain('1000'); // and it repaints the CURRENT purse
+  });
+
+  it('re-arms the latch, so it never leaves a paint owed to the purse probe', () => {
+    const h = harness(1000);
+    h.window.render();
+    h.setCopper(5000);
+    h.window.refreshMoneyRow(); // paints 5000 off the balance read's own schedule
+    expect(h.paints()).toBe(2);
+    h.window.refreshIfChanged(); // the purse probe now has nothing left to do
+    expect(h.paints()).toBe(2);
+    expect(h.moneyText()).toContain('5000');
+  });
+
+  it('is a no-op on a window that has never rendered (no .money row yet)', () => {
+    // Both call sites fire from a promise resolve, so this can land before the
+    // player has ever opened the bag. It must not throw and must not half-paint.
+    const h = harness(1000);
+    expect(() => h.window.refreshMoneyRow()).not.toThrow();
+    expect(h.paints()).toBe(0);
+    expect(h.root.querySelector('.money')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // What the refresh must not disturb. These are the reason it is a narrow .money
 // rewrite rather than renderBags(): this edge fires with no user action behind it.
 // ---------------------------------------------------------------------------
@@ -268,8 +313,42 @@ describe('BagsWindow.refreshIfChanged preserves what the player is holding', () 
       h.setCopper(5000);
       h.window.refreshIfChanged();
 
+      // Prove the click lands on a FRESH node. Without this the arm passes off the
+      // binding render() already did, so a refreshIfChanged stubbed to a no-op would
+      // stay green; two paints means the in-place rewrite the title claims really ran.
+      expect(h.paints()).toBe(2);
       (h.root.querySelector(`[${launcher.attr}]`) as HTMLElement | null)?.click();
       expect(opened).toEqual([launcher.name]);
     });
   }
+
+  it('deliberately does NOT restore focus onto the rewritten launcher (PR #2377 ruling)', () => {
+    // Tempting to copy the deeds/professions "refocus the role-equivalent control"
+    // family here, since the rewrite really does drop focus to <body>. Do not: it was
+    // ruled out on PR #2377 and both reasons still hold.
+    //  - Each footer control is a BUTTON, and src/game/input.ts cancels Enter's
+    //    default on the chat edge only when `tag !== 'button'`, on the stated grounds
+    //    that a button's own Enter activation is a real default action too. Parking
+    //    focus back on one makes the player's next Enter (meaning "open chat") ALSO
+    //    open the Claudium store or re-fire the wallet connect flow.
+    //  - #bags is non-modal and absent from Hud.isModalOpen(), so canUseGameKeys()
+    //    stays true and input.ts preventDefaults Tab for target-nearest. Keyboard
+    //    focus cannot reach this footer at all, so there is no WCAG 2.4.3 debt to pay
+    //    off here, only the Enter hazard to buy.
+    // Pinned so the next reader finds the ruling instead of re-deriving the family.
+    const h = harness(1000);
+    const w = h.window as unknown as { deps: Record<string, unknown> };
+    w.deps.claudiumLauncherHtml = () => '<button data-claudium-launcher>c</button>';
+    h.window.render();
+    const before = h.root.querySelector('[data-claudium-launcher]') as HTMLElement;
+    before.focus();
+    expect(document.activeElement).toBe(before);
+
+    h.setCopper(5000);
+    h.window.refreshIfChanged();
+
+    // The rewrite happened (fresh node), and focus was left where the browser put it.
+    expect(h.root.querySelector('[data-claudium-launcher]')).not.toBe(before);
+    expect(document.activeElement).toBe(document.body);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #2380 (issue #2373), closing two findings from the post-merge seam review.

#2380 deliberately made the purse probe repaint only the bag `.money` footer rather than calling
`renderBags()`, because that edge fires from a server credit or a coin-only mob loot with **no
user action behind it**, and a full rebuild drops the bag-search caret, strands the hovered row's
listeners and breaks an armed touch drag.

Two async paths still defeated that guarantee:

- `onWalletUiChange` did `if ($('#bags').style.display !== 'none') this.renderBags();` on the
  `$WOC` balance landing. Its own comment already said "re-render the bag footer", which is what
  it now actually does.
- The Claudium balance resolve did the same. That one is reached *through the money-row paint
  itself*: `paintMoneyRow` calls `claudiumLauncherHtml()`, whose second statement is
  `refreshClaudiumLauncherBalance()`. It is 30s-throttled, so an open bag with a moving purse
  (farming, questing) hit the full teardown roughly twice a minute.

Both now call `BagsWindow.refreshMoneyRow()` behind the cold-load-safe `bagsWindowShown` gate
(#1538), the same gate #2380 introduced elsewhere. Re-entry is not a risk: the repaint calls
`claudiumLauncherHtml` again, but `setClaudiumLauncherBalance` re-stamps the throttle first.

It also closes a real coverage hole in #2380: the launcher re-bind test stubbed only the Claudium
button, so **deleting the wallet re-bind from `paintMoneyRow` left all 55 tests green** while the
footer's Connect/Link wallet button would have gone dead after the first purse-driven repaint.
That matters for real players, since `wocBalanceHtml` emits `[data-wallet-action]` only on its
button variant (an unverified wallet). Both launchers now get a case.

## Related issues

Follow-up to #2380 / #2373. No issue of its own.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run` over the bags, hud-perf, painter-host, focus-manager, architecture,
  crafting and snapshots suites (12 files, 358 passed); `npx tsc --noEmit`;
  `npx @biomejs/biome ci <changed files>`; `npm run gate`.
- Mutation-verified, each killed:
  - reverting the wallet path to `renderBags()` -> 2 red
  - reverting the Claudium path to `renderBags()` -> 2 red
  - deleting the wallet re-bind -> 1 red (this **survived** before this PR)
  - deleting the Claudium re-bind -> 1 red

## Screenshots / recordings

N/A. No visual change: this narrows *how* an already-correct footer repaints, so the rendered
markup is identical.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [x] **Tested on desktop and mobile.** No layout change. The repaint is strictly narrower than
      before, and the jsdom suite pins focus and caret survival, which is the mobile
      keyboard-dismissal case.
- [x] **Accessible.** Pinned not to move focus.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.
