### PR TITLE
fix(professions): search all recipes for Battlefield Experience credit

### DIFF
--- a/src/sim/content/recipes.ts
+++ b/src/sim/content/recipes.ts
@@ -1368,7 +1368,10 @@ export const FIELD_RECIPES: ReadonlySet<string> = new Set(COMMON_RECIPES.map((r)
 // Reverse lookup (#1149, Battlefield Experience): the recipe whose crafting
 // produced a given result item id, so a tracked-event handler holding only an
 // item instance can resolve back to the craft (professionId) that made it.
-// First match wins: no two recipes in this table share a resultItemId today.
+// Searches ALL_RECIPES (common, tool, caster hub, combo, and ladder alike),
+// not just COMMON_RECIPES: a narrower search here silently broke attribution
+// for every recipe outside the common set. First match wins: no two recipes
+// in this table share a resultItemId today.
 export function recipeForResultItem(itemId: string): ProfessionRecipeRecord | undefined {
-  return COMMON_RECIPES.find((r) => r.resultItemId === itemId);
+  return ALL_RECIPES.find((r) => r.resultItemId === itemId);
 }

--- a/tests/professions_battlefield_xp.test.ts
+++ b/tests/professions_battlefield_xp.test.ts
@@ -445,6 +445,34 @@ describe('Battlefield Experience wired into potion-drunk (#1149)', () => {
   });
 });
 
+// Regression: recipeForResultItem (content/recipes.ts) previously searched
+// COMMON_RECIPES only, even though it is documented as a reverse lookup over
+// every recipe and ALL_RECIPES (aggregating COMMON_RECIPES, TOOL_RECIPES,
+// CASTER_HUB_RECIPES, COMBO_RECIPES, and LADDER_RECIPES) already existed in
+// the same file. That silently broke Battlefield Experience for every
+// ladder/tool/combo/caster-hub recipe, including both shipped alchemy rare
+// potions. This exercises the REAL shipped recipe_sunpetal_healing_draught
+// output (LADDER_RECIPES, genuinely quality 'rare' per profession_items.ts,
+// no quality mutation needed, unlike the def-quality fallback cases above)
+// drunk end to end through the real potion-drunk tracked event (items.ts
+// useItem), proving the lookup covers a genuine LADDER_RECIPES item.
+describe('Battlefield Experience credits a real LADDER_RECIPES output (regression)', () => {
+  it('a self-signed sunpetal healing draught (recipe_sunpetal_healing_draught, LADDER_RECIPES) drunk by its signer trickles alchemy skill', () => {
+    expect(ITEMS.sunpetal_healing_draught.quality).toBe('rare');
+    const sim = makeSim();
+    const pid = sim.playerId;
+    const meta = (sim as any).players.get(pid);
+    meta.archetype.activeArchetype = 'alchemy';
+    sim.addItemInstance('sunpetal_healing_draught', { signer: meta.name }, pid);
+    const entity = (sim as any).entities.get(pid);
+    entity.hp = 1;
+
+    sim.useItem('sunpetal_healing_draught', pid);
+
+    expect(meta.craftSkills.alchemy).toBe(BATTLEFIELD_XP_TRICKLE);
+  });
+});
+
 // #1149's re-craft/re-sign requirement: "the original crafter benefits most
 // on later improving that same item" falls out for free from signer-based
 // attribution, since a re-craft simply re-signs the instance with the new


### PR DESCRIPTION
## Summary

`recipeForResultItem`, the reverse lookup Battlefield Experience (#1149) uses to resolve "which recipe produced this crafted item" from an observed item instance, searched only `COMMON_RECIPES` (9 entries) even though `ALL_RECIPES` (aggregating common, tool, caster-hub, combo, and ladder recipes) was already defined in the same file. This function is the sole lookup `battlefieldExperienceTrickle` uses whenever a rare-or-better signed potion is drunk.

The shipped alchemy ladder's two rare potions (Sunpetal Healing/Mana Draught, both self-signed on craft) are exactly the shipped self-observation case Battlefield Experience targets, yet the lookup returned `undefined` for them every time, so the XP trickle silently returned 0. The existing test suite only exercised this via a common-recipe item with an artificially mutated quality field, never a real rare ladder recipe, which is why the gap had zero coverage.

```mermaid
flowchart LR
    subgraph before["Before"]
        A1["recipeForResultItem(itemId)"] --> B1["COMMON_RECIPES.find(...)\n(9 entries)"]
        B1 -->|"sunpetal_healing_draught\nnot in this table"| C1["undefined"]
        C1 --> D1["battlefieldExperienceTrickle\nreturns 0, silently"]
    end
    subgraph after["After"]
        A2["recipeForResultItem(itemId)"] --> B2["ALL_RECIPES.find(...)\n(common + tool + caster_hub + combo + ladder)"]
        B2 -->|"sunpetal_healing_draught\nfound in LADDER_RECIPES"| C2["recipe record"]
        C2 --> D2["battlefieldExperienceTrickle\ncredits alchemy skill"]
    end
```

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/professions_battlefield_xp.test.ts`, `npx tsc --noEmit`, `npx @biomejs/biome check --write` on changed files, plus a broader regression sweep (`professions_battlefield_xp`, `character_rename`, `professions_skill_caps`, `professions_crafting`, `professions_crafting_hub`, `professions_training`, `professions_acquisition_salvage_sink`, `recipe_economy`, `architecture`: 192 tests total).
- New regression test crafts and signs the real `sunpetal_healing_draught` output and drinks it end to end through `sim.useItem`, asserting the alchemy trickle fires (`0.25` credited). Confirmed red before the fix (`expected +0 to be 0.25`), green after. The existing synthetic-mutated-quality test continues to pass unchanged.

## Screenshots / recordings

N/A. Sim-only content-lookup logic change, no player-visible UI.

---

## Checklist

### Quality
- [x] The full gate passes. Added a regression test covering a real shipped rare ladder recipe end to end, not just the pre-existing synthetic case.

### Cross-platform
- [x] N/A. Sim-only change, identical behavior on every host (offline/server/RL env) by construction.

### Localization (i18n)
- [x] N/A. This PR adds no player-visible strings.

### Hygiene
- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
