### PR TITLE
fix(sim): grant the full rolled quantity on a signed corpse harvest

### DIFF
--- a/src/sim/bags.ts
+++ b/src/sim/bags.ts
@@ -137,6 +137,22 @@ export function canGrantItemInstance(
   return countFit(inventory, capacity, itemId, 1, instance) >= 1;
 }
 
+/** How many of a `count`-unit instanced grant actually fit: the same
+ *  countFit room model canGrantItemInstance boolean-gates, surfaced as a
+ *  number. A signed-grant call site that owns a rolled quantity larger than
+ *  one (the corpse-harvest signed grant, mirroring the node-harvest signed
+ *  grant's own countFit call) uses this to size its addItemInstance call
+ *  instead of truncating an available multi-unit fit down to one. */
+export function fitForItemInstance(
+  inventory: readonly InvSlot[],
+  capacity: number,
+  itemId: string,
+  count: number,
+  instance: ItemInstancePayload,
+): number {
+  return countFit(inventory, capacity, itemId, count, instance);
+}
+
 /** True when all `count` copies fit. */
 export function canAddItem(
   inventory: readonly InvSlot[],

--- a/src/sim/interaction.ts
+++ b/src/sim/interaction.ts
@@ -23,7 +23,7 @@
 // `src/sim`-pure: no DOM/Three/render-ui-game-net imports, no Math.random/Date.now
 // (enforced by tests/architecture.test.ts).
 
-import { bagCapacity, canGrantItemInstance, fitsAll } from './bags';
+import { bagCapacity, canGrantItemInstance, fitForItemInstance, fitsAll } from './bags';
 import { type NoticeboardDef, noticeboardDefByEntityId } from './content/noticeboards';
 import { HARVEST_COMPONENT_SPECIMENS, monsterMaterialTierFor } from './content/professions';
 import { ITEMS, MOBS, QUESTS, SPIRIT_HEALER_NPC_ID } from './data';
@@ -365,20 +365,33 @@ export function harvestCorpse(
   // pure extras. A signed instance merges into a byte-equal same-signer stack
   // (identical-payload stacking; never a plain stack, #1165), so
   // this gate accepts same-signer stack room OR a genuinely free slot
-  // (canGrantItemInstance, the countFit model harvestNode's signed grants
-  // share, #2139); with neither the signed-family grant falls back to the
-  // plain fungible top-up (the signature truncates, the yield does not) while
-  // a specimen truncates outright, the same truncation contract harvestNode's
-  // signed grants follow. Each downgrade tells the player via the text-free
-  // personal gatherDowngrade event, at most ONCE per harvest command (the
-  // toolDeniedEmitted idiom); the mark-lost arm runs first, so when both a
-  // signature and a jackpot are lost the single event reports the mark.
+  // (fitForItemInstance, the countFit model harvestNode's signed grants
+  // share, #2139) sized to the FULL rolled quantity, not a one-unit probe:
+  // any nonzero fit grants that many signed units (a full rolled qty when the
+  // bags have room for all of it, a partial one otherwise), mirroring
+  // harvestNode's own countFit-sized addItemInstance call so a multi-unit
+  // signable roll is never truncated to a single unit when it does not have
+  // to be. Only a genuine zero-room miss falls back to the plain fungible
+  // top-up at the full rolled quantity (the signature is lost, the yield is
+  // not); a specimen truncates outright, the same one-unit truncation
+  // contract harvestNode's signed grants follow. Each downgrade tells the
+  // player via the text-free personal gatherDowngrade event, at most ONCE per
+  // harvest command (the toolDeniedEmitted idiom); the mark-lost arm runs
+  // first, so when both a signature and a jackpot are lost the single event
+  // reports the mark.
   let downgradeEmitted = false;
   for (const grant of signedGrants) {
     if (grant.specimen) continue;
     const payload = { signer: meta.name };
-    if (canGrantItemInstance(meta.inventory, bagCapacity(meta.bags), grant.itemId, payload)) {
-      ctx.addItemInstance(grant.itemId, payload, meta.entityId);
+    const fit = fitForItemInstance(
+      meta.inventory,
+      bagCapacity(meta.bags),
+      grant.itemId,
+      grant.plainQty,
+      payload,
+    );
+    if (fit > 0) {
+      ctx.addItemInstance(grant.itemId, payload, meta.entityId, fit);
     } else {
       ctx.addItem(grant.itemId, grant.plainQty, meta.entityId);
       if (!downgradeEmitted) {

--- a/tests/corpse_harvest_sim.test.ts
+++ b/tests/corpse_harvest_sim.test.ts
@@ -336,7 +336,32 @@ describe('signed Pristine specimens (#1145)', () => {
     const slot = meta.inventory.find((s) => s.itemId === 'wolf_fang');
     expect(slot).toBeDefined();
     expect(slot?.instance?.signer).toBe('Alpha');
-    expect(sim.countItem('wolf_fang', a)).toBe(1);
+    // Seed 5's fang roll lands tier 3 (harvestTierQuantity), and roomy bags
+    // fit the whole thing: the signature truncates only when the bags force
+    // it to, never the rolled quantity itself (#2139's own contract).
+    expect(sim.countItem('wolf_fang', a)).toBe(3);
+  });
+
+  it('an empty-bag signed grant lands the FULL rolled quantity, never truncated to one (seed 5)', () => {
+    // Regression pin: the unfixed code called addItemInstance with no count
+    // argument (defaulting to 1) even though grant.plainQty (the rolled tier
+    // quantity, harvestTierQuantity) sat right there, silently discarding the
+    // rest of a multi-unit signable roll. Empty bags have room for the whole
+    // roll, so the fixed grant must land as one signed stack at the full
+    // rolled count, not a single unit.
+    const { sim, internals, a, mob } = setup(5);
+    const meta = internals.players.get(a)!;
+    // A fresh character's starting kit leaves the bags nearly empty (roomy,
+    // not necessarily zero items): plenty of free slots for a 3-unit roll.
+    expect(bagCapacity(meta.bags) - meta.inventory.length).toBeGreaterThan(3);
+    sim.harvestCorpse(mob.id, ['fang'], a);
+    const signedSlots = meta.inventory.filter(
+      (s) => s.itemId === 'wolf_fang' && s.instance?.signer === 'Alpha',
+    );
+    // Exactly one signed stack, not several single-unit slots.
+    expect(signedSlots).toHaveLength(1);
+    expect(signedSlots[0].count).toBe(3);
+    expect(sim.countItem('wolf_fang', a)).toBe(3);
   });
 
   it('every other specimen family grants its own jackpot beside the plain component (seed 5)', () => {
@@ -395,7 +420,9 @@ describe('signed Pristine specimens (#1145)', () => {
     const slot = meta.inventory.find((s) => s.itemId === 'homespun_cloth');
     expect(slot).toBeDefined();
     expect(slot?.instance?.signer).toBe('Alpha');
-    expect(sim.countItem('homespun_cloth', a)).toBe(1);
+    // Seed 5's cloth roll lands tier 2 (harvestTierQuantity) against this
+    // corpse and focus, and roomy bags fit the whole thing.
+    expect(sim.countItem('homespun_cloth', a)).toBe(2);
   });
 
   it('a slot-full signed-family harvest falls back to the plain stack, never over capacity (seed 5)', () => {
@@ -613,10 +640,13 @@ describe('corpse signed-guard capacity vs merge room (#2139)', () => {
   });
 
   it('a slot-full bag with a same-signer stack WITH room keeps the signature: the grant merges (seed 5)', () => {
-    // Seed 5's fang roll clears the signable floor (pre-verified above). Slot
-    // 0 is the plain partial stack the pre-gate reserves against (and the
-    // would-be fallback target); slot 1 is the byte-equal same-signer stack
-    // whose room the merge-aware guard must accept with zero free slots.
+    // Seed 5's fang roll clears the signable floor at tier 3 (pre-verified
+    // above: harvestTierQuantity rolls a 3-unit yield). Slot 0 is the plain
+    // partial stack the pre-gate reserves against (and the would-be fallback
+    // target); slot 1 is the byte-equal same-signer stack whose room the
+    // merge-aware guard must accept with zero free slots, and which has room
+    // for the FULL rolled quantity (stackSizeOf(wolf_fang) - 3 existing is
+    // far more than the 3-unit roll).
     const { sim, internals, a, mob } = setup(5);
     fillBags(sim, internals, a);
     const m = internals.players.get(a)!;
@@ -627,12 +657,14 @@ describe('corpse signed-guard capacity vs merge room (#2139)', () => {
     sim.drainEvents();
     sim.harvestCorpse(mob.id, ['fang'], a);
     expect(mob.harvestClaimedBy).toBe(a);
-    // The signed grant merged into the same-signer stack: one unit, no new
-    // slot, no overflow, and the plain stack was never topped up.
+    // The signed grant merged into the same-signer stack: no new slot, no
+    // overflow, and the plain stack was never topped up.
     expect(m.inventory.length).toBe(cap);
     const signed = m.inventory.find((s) => s.itemId === 'wolf_fang' && s.instance);
     expect(signed?.instance?.signer).toBe('Alpha');
-    expect(signed?.count).toBe(4);
+    // The full 3-unit roll merged in on top of the seeded 3 (the signature
+    // truncates only when the bags force it to, never the rolled quantity).
+    expect(signed?.count).toBe(6);
     const plain = m.inventory.find((s) => s.itemId === 'wolf_fang' && !s.instance);
     expect(plain?.count).toBe(1);
     // The signature survived: no downgrade notice fires.


### PR DESCRIPTION
## Summary

When a specimen-less harvestable component family (`wolf_fang`, `homespun_cloth`) rolls a signable (rare-or-better) material rarity on a corpse harvest, the success path granted the signed instance via `ctx.addItemInstance(...)` with no explicit count, which defaults to 1, instead of the full rolled tier quantity already computed and sitting in `grant.plainQty`. The code's own comment two lines above states the intended contract: "the signature truncates, the yield does not" — the implementation did the opposite. The gate used, `canGrantItemInstance`, only ever test-fit a single unit, so it structurally couldn't surface a higher count. The sibling node-harvest path (`gathering.ts`'s `harvestNode`) already does this correctly.

The higher-tier (better) the harvest roll, the more material was silently lost whenever bag room was available (the common case) — the "premium" signed outcome ended up strictly worse in raw yield than an unsigned plain grant of the same roll.

```mermaid
flowchart TD
    subgraph before["Before"]
        A1["Corpse harvest rolls tier qty (e.g. 3) + signable rarity"] --> B1{"canGrantItemInstance\n(boolean, tests only 1 unit)"}
        B1 -->|"true"| C1["addItemInstance(itemId, payload, pid)\ncount defaults to 1"]
        C1 --> D1["2 of 3 rolled units silently destroyed"]
    end
    subgraph after["After"]
        A2["Corpse harvest rolls tier qty (e.g. 3) + signable rarity"] --> B2["fitForItemInstance\n(bags.ts, wraps countFit)"]
        B2 -->|"fit = 3 (full qty fits)"| C2["addItemInstance(itemId, payload, pid, fit)"]
        C2 --> D2["full rolled quantity granted, signed\n(mirrors gathering.ts's harvestNode)"]
    end
```

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/corpse_harvest_sim.test.ts`, `npx tsc --noEmit`, `npx @biomejs/biome check --write` on changed files, plus a broad regression sweep across `tests/bags.test.ts`, `tests/gather_rare_events.test.ts`, `tests/gather_node_harvest.test.ts`, `tests/gather_open_gate.test.ts`, `tests/interaction.test.ts`, `tests/harvest_component_materials.test.ts`, `tests/item_instance.test.ts`, `tests/nearby_interaction.test.ts`, `tests/professions_capacity.test.ts`, `tests/town_focus_sim.test.ts`, and `tests/gathering_rhythm.test.ts`.
- Determined the true pinned quantities by instrumenting the real code path against the exact seeds already pinned in the test suite (fang seed 5 actually rolls tier qty 3, cloth seed 5 rolls tier qty 2), corrected the two pinned assertions (previously `toBe(1)`, silently accepting the bug) plus a third knock-on pin in a merge test, and added a new empty-bag regression case. All 42 tests in the file pass; confirmed the corrected assertions fail against the pre-fix code with the exact truncated values.

## Screenshots / recordings

N/A. Sim-only loot/harvest logic change, no player-visible UI.

---

## Checklist

### Quality
- [x] The full gate passes. Corrected pinned assertions were verified against the pre-fix code first (red), then against the fix (green), rather than guessed.

### Cross-platform
- [x] N/A. Sim-only change, identical behavior on every host (offline/server/RL env) by construction.

### Localization (i18n)
- [x] N/A. This PR adds no player-visible strings.

### Hygiene
- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
