### PR TITLE
fix(ui): localize the Fiesta augment card's aria-label

### DIFF
--- a/src/ui/hud/fiesta/fiesta_controller.ts
+++ b/src/ui/hud/fiesta/fiesta_controller.ts
@@ -255,7 +255,11 @@ export class FiestaController {
         `<span class="fa-cat cat-${category}">${esc(t(`fiesta.category.${category}` as TranslationKey))}</span>`;
       card.setAttribute(
         'aria-label',
-        `${this.augmentName(id)} (${t(`fiesta.category.${category}` as TranslationKey)}) - ${this.augmentDescription(id)}`,
+        t('fiesta.augment.cardAria', {
+          name: this.augmentName(id),
+          category: t(`fiesta.category.${category}` as TranslationKey),
+          description: this.augmentDescription(id),
+        }),
       );
       card.addEventListener('click', () => {
         this.deps.audio.click();

--- a/src/ui/i18n.catalog/index.ts
+++ b/src/ui/i18n.catalog/index.ts
@@ -1128,6 +1128,7 @@ export const en = {
     },
     augment: {
       choose: 'Choose an Augment',
+      cardAria: '{name} ({category}) - {description}',
       aug_brutality: { name: 'Brutality', desc: 'Your physical strikes hit 15% harder.' },
       aug_spellfire: { name: 'Grimfire', desc: 'Your spells deal 15% more damage.' },
       aug_toughness: { name: 'Toughness', desc: 'Gain 12% maximum health.' },

--- a/src/ui/i18n.catalog/translation_keys.generated.ts
+++ b/src/ui/i18n.catalog/translation_keys.generated.ts
@@ -3057,6 +3057,7 @@ export type TranslationKeyFlat =
   | 'fiesta.augment.aug_vampirism.name'
   | 'fiesta.augment.aug_warlords_might.desc'
   | 'fiesta.augment.aug_warlords_might.name'
+  | 'fiesta.augment.cardAria'
   | 'fiesta.augment.choose'
   | 'fiesta.banner.augmentGained'
   | 'fiesta.banner.powerup'

--- a/src/ui/i18n.resolved.generated/cs_CZ.ts
+++ b/src/ui/i18n.resolved.generated/cs_CZ.ts
@@ -5438,6 +5438,7 @@ export const cs_CZ: EnTranslations = {
     },
     "augment": {
       "choose": "Vyber vylepšení",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Brutalita",
         "desc": "Tvoje fyzické údery zasahují o 15 % tvrději."

--- a/src/ui/i18n.resolved.generated/da_DK.ts
+++ b/src/ui/i18n.resolved.generated/da_DK.ts
@@ -5438,6 +5438,7 @@ export const da_DK: EnTranslations = {
     },
     "augment": {
       "choose": "Vælg en Forstærkning",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Brutalitet",
         "desc": "Dine fysiske slag rammer 15% hårdere."

--- a/src/ui/i18n.resolved.generated/de_DE.ts
+++ b/src/ui/i18n.resolved.generated/de_DE.ts
@@ -5438,6 +5438,7 @@ export const de_DE: EnTranslations = {
     },
     "augment": {
       "choose": "Wählt eine Augmentierung",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Brutalität",
         "desc": "Eure physischen Schläge treffen 15% härter."

--- a/src/ui/i18n.resolved.generated/en.ts
+++ b/src/ui/i18n.resolved.generated/en.ts
@@ -5438,6 +5438,7 @@ export const en: EnTranslations = {
     },
     "augment": {
       "choose": "Choose an Augment",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Brutality",
         "desc": "Your physical strikes hit 15% harder."

--- a/src/ui/i18n.resolved.generated/en_CA.ts
+++ b/src/ui/i18n.resolved.generated/en_CA.ts
@@ -5438,6 +5438,7 @@ export const en_CA: EnTranslations = {
     },
     "augment": {
       "choose": "Choose an Augment",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Brutality",
         "desc": "Your physical strikes hit 15% harder."

--- a/src/ui/i18n.resolved.generated/en_XA.ts
+++ b/src/ui/i18n.resolved.generated/en_XA.ts
@@ -5438,6 +5438,7 @@ export const en_XA: EnTranslations = {
     },
     "augment": {
       "choose": "[Çĥóóšé áñ Áúĝɱéñţ]",
+      "cardAria": "[{name} ({category}) - {description}]",
       "aug_brutality": {
         "name": "[Ɓŕúţáļíţý]",
         "desc": "[Ýóúŕ þĥýšíçáļ šţŕíķéš ĥíţ 15% ĥáŕðéŕ.]"

--- a/src/ui/i18n.resolved.generated/es.ts
+++ b/src/ui/i18n.resolved.generated/es.ts
@@ -5438,6 +5438,7 @@ export const es: EnTranslations = {
     },
     "augment": {
       "choose": "Elige una mejora",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Brutalidad",
         "desc": "Tus golpes físicos pegan un 15% más fuerte."

--- a/src/ui/i18n.resolved.generated/es_ES.ts
+++ b/src/ui/i18n.resolved.generated/es_ES.ts
@@ -5438,6 +5438,7 @@ export const es_ES: EnTranslations = {
     },
     "augment": {
       "choose": "Elige una mejora",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Brutalidad",
         "desc": "Tus golpes físicos pegan un 15% más fuerte."

--- a/src/ui/i18n.resolved.generated/fr_CA.ts
+++ b/src/ui/i18n.resolved.generated/fr_CA.ts
@@ -5438,6 +5438,7 @@ export const fr_CA: EnTranslations = {
     },
     "augment": {
       "choose": "Choisissez une augmentation",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Brutalité",
         "desc": "Vos frappes physiques cognent 15% plus fort."

--- a/src/ui/i18n.resolved.generated/fr_FR.ts
+++ b/src/ui/i18n.resolved.generated/fr_FR.ts
@@ -5438,6 +5438,7 @@ export const fr_FR: EnTranslations = {
     },
     "augment": {
       "choose": "Choisissez une augmentation",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Brutalité",
         "desc": "Vos frappes physiques cognent 15% plus fort."

--- a/src/ui/i18n.resolved.generated/id_ID.ts
+++ b/src/ui/i18n.resolved.generated/id_ID.ts
@@ -5438,6 +5438,7 @@ export const id_ID: EnTranslations = {
     },
     "augment": {
       "choose": "Pilih sebuah Augment",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Kebrutalan",
         "desc": "Serangan fisikmu menghantam 15% lebih keras."

--- a/src/ui/i18n.resolved.generated/it_IT.ts
+++ b/src/ui/i18n.resolved.generated/it_IT.ts
@@ -5438,6 +5438,7 @@ export const it_IT: EnTranslations = {
     },
     "augment": {
       "choose": "Scegli un potenziamento",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Brutalità",
         "desc": "I tuoi colpi fisici infliggono il 15% di danni in più."

--- a/src/ui/i18n.resolved.generated/ja_JP.ts
+++ b/src/ui/i18n.resolved.generated/ja_JP.ts
@@ -5438,6 +5438,7 @@ export const ja_JP: EnTranslations = {
     },
     "augment": {
       "choose": "オーグメントを選択",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "蛮勇",
         "desc": "物理攻撃の威力が15%上昇する。"

--- a/src/ui/i18n.resolved.generated/ko_KR.ts
+++ b/src/ui/i18n.resolved.generated/ko_KR.ts
@@ -5438,6 +5438,7 @@ export const ko_KR: EnTranslations = {
     },
     "augment": {
       "choose": "증강 선택",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "잔혹함",
         "desc": "당신의 물리 공격이 15% 더 강하게 적중합니다."

--- a/src/ui/i18n.resolved.generated/nl_NL.ts
+++ b/src/ui/i18n.resolved.generated/nl_NL.ts
@@ -5438,6 +5438,7 @@ export const nl_NL: EnTranslations = {
     },
     "augment": {
       "choose": "Kies een Versterking",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Brutaliteit",
         "desc": "Je fysieke slagen treffen 15% harder."

--- a/src/ui/i18n.resolved.generated/pending.ts
+++ b/src/ui/i18n.resolved.generated/pending.ts
@@ -9,25 +9,65 @@
 // Reproducibility is checked by tests/i18n_resolved_equivalence.test.ts.
 
 export const pending: Record<string, readonly string[]> = {
-  "es": [],
-  "es_ES": [],
-  "fr_FR": [],
-  "fr_CA": [],
+  "es": [
+    "fiesta.augment.cardAria"
+  ],
+  "es_ES": [
+    "fiesta.augment.cardAria"
+  ],
+  "fr_FR": [
+    "fiesta.augment.cardAria"
+  ],
+  "fr_CA": [
+    "fiesta.augment.cardAria"
+  ],
   "en_CA": [],
-  "it_IT": [],
-  "de_DE": [],
-  "zh_CN": [],
-  "zh_TW": [],
-  "ko_KR": [],
-  "ja_JP": [],
-  "pt_BR": [],
-  "ru_RU": [],
-  "cs_CZ": [],
-  "nl_NL": [],
-  "pl_PL": [],
-  "id_ID": [],
-  "tr_TR": [],
-  "sv_SE": [],
-  "vi_VN": [],
-  "da_DK": []
+  "it_IT": [
+    "fiesta.augment.cardAria"
+  ],
+  "de_DE": [
+    "fiesta.augment.cardAria"
+  ],
+  "zh_CN": [
+    "fiesta.augment.cardAria"
+  ],
+  "zh_TW": [
+    "fiesta.augment.cardAria"
+  ],
+  "ko_KR": [
+    "fiesta.augment.cardAria"
+  ],
+  "ja_JP": [
+    "fiesta.augment.cardAria"
+  ],
+  "pt_BR": [
+    "fiesta.augment.cardAria"
+  ],
+  "ru_RU": [
+    "fiesta.augment.cardAria"
+  ],
+  "cs_CZ": [
+    "fiesta.augment.cardAria"
+  ],
+  "nl_NL": [
+    "fiesta.augment.cardAria"
+  ],
+  "pl_PL": [
+    "fiesta.augment.cardAria"
+  ],
+  "id_ID": [
+    "fiesta.augment.cardAria"
+  ],
+  "tr_TR": [
+    "fiesta.augment.cardAria"
+  ],
+  "sv_SE": [
+    "fiesta.augment.cardAria"
+  ],
+  "vi_VN": [
+    "fiesta.augment.cardAria"
+  ],
+  "da_DK": [
+    "fiesta.augment.cardAria"
+  ]
 };

--- a/src/ui/i18n.resolved.generated/pl_PL.ts
+++ b/src/ui/i18n.resolved.generated/pl_PL.ts
@@ -5438,6 +5438,7 @@ export const pl_PL: EnTranslations = {
     },
     "augment": {
       "choose": "Wybierz wzmocnienie",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Brutalność",
         "desc": "Twoje fizyczne uderzenia ranią o 15% mocniej."

--- a/src/ui/i18n.resolved.generated/pt_BR.ts
+++ b/src/ui/i18n.resolved.generated/pt_BR.ts
@@ -5438,6 +5438,7 @@ export const pt_BR: EnTranslations = {
     },
     "augment": {
       "choose": "Escolha um Aprimoramento",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Brutalidade",
         "desc": "Seus golpes físicos batem 15% mais forte."

--- a/src/ui/i18n.resolved.generated/ru_RU.ts
+++ b/src/ui/i18n.resolved.generated/ru_RU.ts
@@ -5438,6 +5438,7 @@ export const ru_RU: EnTranslations = {
     },
     "augment": {
       "choose": "Выберите усиление",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Жестокость",
         "desc": "Твои физические удары бьют на 15% сильнее."

--- a/src/ui/i18n.resolved.generated/sv_SE.ts
+++ b/src/ui/i18n.resolved.generated/sv_SE.ts
@@ -5438,6 +5438,7 @@ export const sv_SE: EnTranslations = {
     },
     "augment": {
       "choose": "Välj en förstärkning",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Brutalitet",
         "desc": "Dina fysiska slag träffar 15% hårdare."

--- a/src/ui/i18n.resolved.generated/tr_TR.ts
+++ b/src/ui/i18n.resolved.generated/tr_TR.ts
@@ -5438,6 +5438,7 @@ export const tr_TR: EnTranslations = {
     },
     "augment": {
       "choose": "Bir Güçlendirme Seç",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Vahşilik",
         "desc": "Fiziksel vuruşların %15 daha sert isabet eder."

--- a/src/ui/i18n.resolved.generated/vi_VN.ts
+++ b/src/ui/i18n.resolved.generated/vi_VN.ts
@@ -5438,6 +5438,7 @@ export const vi_VN: EnTranslations = {
     },
     "augment": {
       "choose": "Chọn một Cường Hóa",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "Tàn Bạo",
         "desc": "Đòn đánh vật lý của ngươi mạnh hơn 15%."

--- a/src/ui/i18n.resolved.generated/zh_CN.ts
+++ b/src/ui/i18n.resolved.generated/zh_CN.ts
@@ -5438,6 +5438,7 @@ export const zh_CN: EnTranslations = {
     },
     "augment": {
       "choose": "选择一项强化",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "残暴",
         "desc": "你的物理打击造成的伤害提高15%。"

--- a/src/ui/i18n.resolved.generated/zh_TW.ts
+++ b/src/ui/i18n.resolved.generated/zh_TW.ts
@@ -5438,6 +5438,7 @@ export const zh_TW: EnTranslations = {
     },
     "augment": {
       "choose": "選擇一項強化",
+      "cardAria": "{name} ({category}) - {description}",
       "aug_brutality": {
         "name": "殘暴",
         "desc": "你的物理打擊造成的傷害提高15%。"

--- a/tests/fiesta_controller.test.ts
+++ b/tests/fiesta_controller.test.ts
@@ -2,6 +2,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FiestaController } from '../src/ui/hud/fiesta/fiesta_controller';
+import { t } from '../src/ui/i18n';
 import type { FiestaMatchInfo, IWorld } from '../src/world_api';
 
 function match(overrides: Partial<FiestaMatchInfo> = {}): FiestaMatchInfo {
@@ -174,5 +175,32 @@ describe('FiestaController', () => {
     expect(test.audio.click).toHaveBeenCalledTimes(1);
     expect(test.augments.style.display).toBe('none');
     expect(test.augments.innerHTML).toBe('');
+  });
+
+  it('localizes each augment card aria-label through one composed t() key', () => {
+    const test = harness();
+    test.fiesta.offer = {
+      tier: 'silver',
+      wave: 1,
+      choices: ['aug_brutality', 'aug_toughness', 'aug_keen_eye'],
+    };
+
+    test.controller.update();
+
+    const cards = test.augments.querySelectorAll<HTMLButtonElement>('.fa-card');
+    const expected = [
+      { id: 'aug_brutality', category: t('fiesta.category.offense') },
+      { id: 'aug_toughness', category: t('fiesta.category.defense') },
+      { id: 'aug_keen_eye', category: t('fiesta.category.offense') },
+    ];
+    expected.forEach((augment, index) => {
+      expect(cards[index].getAttribute('aria-label')).toBe(
+        t('fiesta.augment.cardAria', {
+          name: t(`fiesta.augment.${augment.id}.name` as Parameters<typeof t>[0]),
+          category: augment.category,
+          description: t(`fiesta.augment.${augment.id}.desc` as Parameters<typeof t>[0]),
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

The Arena Fiesta augment-pick card's accessible name was built by gluing three already-localized strings together with hardcoded English punctuation (`" ("`, `") - "`) outside of any `t()` call, violating this repo's i18n rule: "Rendered text always comes from `t()`: never concat." The same file already demonstrates the correct pattern about 40 lines earlier, where the Fiesta score bar's aria-label is a single composed `t()` key with named params (`t('fiesta.score.aria', { mine, theirs, limit })`).

Player impact: a screen-reader user in any non-English locale hears the augment name, category, and description forced into English word order and punctuation regardless of the target language's grammar, during a timed in-match pick — the one voiced affordance in this flow (the visible card spans render fine via CSS layout; only the aria-label was malformed).

```mermaid
flowchart LR
    subgraph before["Before"]
        A1["augmentName(id) -> t()"] --> C1["template literal: name + \" (\" + t(category) + \") - \" + desc"]
        A2["t(fiesta.category.category)"] --> C1
        A3["augmentDescription(id) -> t()"] --> C1
        C1 --> D1["aria-label: hardcoded English glue"]
    end
    subgraph after["After"]
        B1["augmentName(id)"] --> C2["t('fiesta.augment.cardAria', { name, category, description })"]
        B2["t(fiesta.category.category)"] --> C2
        B3["augmentDescription(id)"] --> C2
        C2 --> D2["aria-label: fully localized"]
    end
    E["sibling pattern already correct:<br/>t('fiesta.score.aria', { mine, theirs, limit })"] -.mirrors.-> C2
```

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx tsc --noEmit`, `npx @biomejs/biome check --write` on changed files, `npm run i18n:gen`, `npx vitest run tests/fiesta_controller.test.ts tests/fiesta.test.ts tests/fiesta_module.test.ts tests/localization_fixes.test.ts tests/localization_coverage.test.ts`, `npm run gate`.
- New test asserts each augment card's `aria-label` equals the real `t('fiesta.augment.cardAria', ...)` output computed the same way the controller does; confirmed it fails pre-fix (untracked-key error before the catalog entry existed) and passes post-fix. 7/7 in `tests/fiesta_controller.test.ts`, 68 passed / 3 skipped across the fiesta + i18n test files.

## Screenshots / recordings

N/A. This is an accessible-name (aria-label) i18n fix with no visible pixel change — the visible card content is unchanged, only the screen-reader-only string composition changed. Verified via the new `t()`-output assertion test rather than a screenshot.

---

## Checklist

### Quality
- [x] The full gate passes. Added a decisive test pinning the exact `t()`-composed aria-label string.

### Cross-platform
- [x] N/A. Same pure formatting/catalog layer feeds both desktop and mobile identically; no layout change.

### Localization (i18n)
- [x] **New player-visible strings follow the contributor policy.** Added one English-only key (`fiesta.augment.cardAria`) to the fiesta catalog, mirroring the existing `fiesta.score.aria` entry's location and style. I did not edit locale overlays.
- [x] Confirmed `tests/localization_fixes.test.ts` (the S3 i18n guard) and `tests/localization_coverage.test.ts` pass.
- [x] N/A. Player-facing text from `src/sim/`/`server/` is unaffected.

### Hygiene
- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files (`translation_keys.generated.ts` / `i18n.resolved.generated/*` were regenerated via `npm run i18n:gen`, not hand-edited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
