### PR TITLE
fix(combat): cap Emboldening Roar's crit buff at one instance per target

### DIFF
--- a/src/sim/combat/aura_stacking.ts
+++ b/src/sim/combat/aura_stacking.ts
@@ -17,6 +17,9 @@ export const SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS: ReadonlySet<string> = new S
   'battle_shout',
   'blessing_of_might',
   'devotion_aura',
+  // Emboldening Roar (Fury aoeAllySureCrit): two Fury warriors must not stack
+  // two separate 3-charge guaranteed-crit auras on a shared ally.
+  'emboldening_roar_crit',
   'mark_of_the_wild',
   'power_word_fortitude',
   'rallying_cry_dr',

--- a/tests/group_buff_self_stacking.test.ts
+++ b/tests/group_buff_self_stacking.test.ts
@@ -45,6 +45,33 @@ describe('Wildfang Rally never stacks with itself', () => {
   });
 });
 
+describe('Emboldening Roar never stacks its crit buff with itself', () => {
+  it('two Fury warriors casting on an overlapping ally leave exactly one 3-charge copy', () => {
+    const sim = new Sim({ seed: 2026, playerClass: 'warrior', noPlayer: true }) as AnySim;
+    const a = sim.addPlayer('warrior', 'WarriorA');
+    const b = sim.addPlayer('warrior', 'WarriorB');
+    for (const pid of [a, b]) {
+      sim.setPlayerLevel(20, pid);
+      expect(sim.setSpec('fury', pid)).toBe(true);
+    }
+    const entA = sim.entities.get(a) as Entity;
+    const entB = sim.entities.get(b) as Entity;
+    entB.pos = { ...entA.pos };
+
+    sim.castAbility('emboldening_roar', a);
+    entB.gcdRemaining = 0;
+    sim.castAbility('emboldening_roar', b);
+
+    for (const ent of [entA, entB]) {
+      const crit = ent.auras.filter((x) => x.id === 'emboldening_roar_crit');
+      expect(crit, 'one Emboldened copy').toHaveLength(1);
+      expect(crit[0].charges).toBe(3);
+      // The later cast owns the surviving copy.
+      expect(crit[0].sourceId).toBe(b);
+    }
+  });
+});
+
 describe('every group buff is exhaustion-gated or source-independent', () => {
   it('no aoeAlly buff can silently self-stack across casters', () => {
     const offenders: string[] = [];
@@ -58,6 +85,16 @@ describe('every group buff is exhaustion-gated or source-independent', () => {
           // The dispatch stamps this half as `${abilityId}_ap`.
           if (!SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS.has(`${ability.id}_ap`)) {
             offenders.push(`${ability.id} (aoeAllyAttackPower)`);
+          }
+        } else if (eff.type === 'aoeAllySureCrit') {
+          // The dispatch stamps this as `${abilityId}_crit` (Emboldening Roar).
+          if (!SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS.has(`${ability.id}_crit`)) {
+            offenders.push(`${ability.id} (aoeAllySureCrit)`);
+          }
+        } else if (eff.type === 'aoeAllyMaxHp') {
+          // The dispatch stamps this as `${abilityId}_hp` (Rallying Cry).
+          if (!SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS.has(`${ability.id}_hp`)) {
+            offenders.push(`${ability.id} (aoeAllyMaxHp)`);
           }
         }
       }


### PR DESCRIPTION
## Summary

Emboldening Roar (Fury warrior, "your next 3 abilities are guaranteed critical strikes") is not in `SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS`, so two different Fury warriors casting it on an overlapping ally stack two separate 3-charge `sure_crit` auras instead of the buff refreshing to one capped instance, unlike every other group buff of this shape (Battle Shout, Sanguine Aura, Rallying Cry, Trueshot Aura). A shared target can bank 6+ guaranteed crits from a single burst window instead of 3.

The repo's own regression test (`tests/group_buff_self_stacking.test.ts`) exists specifically to catch this class of gap, but its guard loop only checked `aoeAllyHaste`/`aoeAllyAttackPower` effect types, silently skipping `aoeAllySureCrit` (and `aoeAllyMaxHp`), which is why this shipped without failing CI.

```mermaid
sequenceDiagram
    participant W1 as Fury Warrior A
    participant W2 as Fury Warrior B
    participant T as Shared Ally

    rect rgb(255, 230, 230)
    Note over W1,T: Before: not in SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS
    W1->>T: Emboldening Roar (aura emboldening_roar_crit, 3 charges, sourceId=A)
    W2->>T: Emboldening Roar (aura emboldening_roar_crit, 3 charges, sourceId=B)
    Note right of T: sourceId differs -> no dedupe -> 2 auras stacked -> 6 guaranteed crits
    end

    rect rgb(230, 255, 230)
    Note over W1,T: After: id added to SOURCE_INDEPENDENT_GROUP_BUFF_AURA_IDS
    W1->>T: Emboldening Roar (3 charges)
    W2->>T: Emboldening Roar (replaces existing aura)
    Note right of T: source-independent dedupe -> exactly 1 aura -> 3 guaranteed crits
    end
```

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/group_buff_self_stacking.test.ts`, `npx tsc --noEmit`, `npx @biomejs/biome check --write` on changed files, `npm run gate`.
- New test reproduces two Fury warriors casting on an overlapping ally and asserts exactly one 3-charge aura survives; confirmed red before the fix, green after. The guard loop that is supposed to catch this class of bug was also extended to flag `aoeAllySureCrit`/`aoeAllyMaxHp` effects missing from the Set, so this cannot silently regress again.

## Screenshots / recordings

N/A. Sim-only combat logic change, no player-visible UI.

---

## Checklist

### Quality
- [x] The full gate passes. Added a decisive regression test that fails pre-fix and passes post-fix, plus strengthened the existing guard test.

### Cross-platform
- [x] N/A. Sim-only change, identical behavior on every host (offline/server/RL env) by construction.

### Localization (i18n)
- [x] N/A. This PR adds no player-visible strings.

### Hygiene
- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
