### PR TITLE
fix(auth): localize the 2FA recovery-codes download file

### DIFF
--- a/tests/two_factor_setup.test.ts
+++ b/tests/two_factor_setup.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { t } from '../src/ui/i18n';
+import { afterEach, describe, expect, it } from 'vitest';
+import { en, ensureLocaleLoaded, fr_FR, setLanguage, t } from '../src/ui/i18n';
 import {
   classifyAuthCode,
   formatRecoveryCodesFile,
@@ -77,5 +77,26 @@ describe('formatRecoveryCodesFile', () => {
     );
     expect(lines[3]).toBe(t('hudChrome.account.recoveryCodesFileHint'));
     expect(lines[4]).toBe(t('hudChrome.account.recoveryCodesFileWarn'));
+  });
+
+  afterEach(() => setLanguage('en'));
+
+  it('follows the active locale, not a decoupled English literal', async () => {
+    // Non-vacuous floor: fr_FR genuinely differs from English for this key, so a test that
+    // still hardcoded the English literals (rather than calling t()) would fail here even
+    // though the earlier default-locale assertions would still pass.
+    expect(fr_FR.hudChrome.account.recoveryCodesFileWarn).not.toBe(
+      en.hudChrome.account.recoveryCodesFileWarn,
+    );
+
+    await ensureLocaleLoaded('fr_FR');
+    setLanguage('fr_FR');
+
+    const lines = formatRecoveryCodesFile(['aaaa-bbbb'], 'Aelwyn').split('\n');
+    expect(lines[0]).toBe(
+      fr_FR.hudChrome.account.recoveryCodesFileHeader.replace('{brand}', 'World of ClaudeCraft'),
+    );
+    expect(lines[3]).toBe(fr_FR.hudChrome.account.recoveryCodesFileHint);
+    expect(lines[4]).toBe(fr_FR.hudChrome.account.recoveryCodesFileWarn);
   });
 });


### PR DESCRIPTION
## Summary

The 2FA recovery-codes file — the backup a player downloads after enabling two-factor auth and is told to keep safe and read again only in an account-lockout emergency (no authenticator access) — was built entirely from raw English string literals in `formatRecoveryCodesFile()`, bypassing `t()` completely. The sibling status message on the exact same account screen already goes through `t('hudChrome.account.twoFactorEnabledMsg')`. Two other raw-English modules in this codebase each carry an explicit "stays English by design" comment justifying their exception (a downstream re-render layer localizes the real strings, or the values are dev-only ids); `two_factor_setup.ts` has no such comment and no downstream localization pass, so this was a genuine gap, not an intentional exception. A non-English player who enables 2FA gets an untranslated backup file for exactly the emergency where clear-language instructions matter most.

```mermaid
flowchart TD
    subgraph before["Before"]
        A["formatRecoveryCodesFile()"] --> B["'${brand} recovery codes'<br/>'Account: ${username}'<br/>'Each code can be used once...'<br/>'Keep this file somewhere safe...'"]
        B --> C["Blob download: always English"]
    end
    subgraph after["After"]
        D["formatRecoveryCodesFile()"] --> E["t(recoveryCodesFileHeader, {brand})<br/>t(recoveryCodesFileAccount, {username})<br/>t(recoveryCodesFileHint)<br/>t(recoveryCodesFileWarn)"]
        E --> F["Blob download: localized to player's language"]
    end
    G["sibling on same screen, already correct:<br/>t('hudChrome.account.twoFactorEnabledMsg')"] -.mirrors.-> E
```

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx tsc --noEmit`, `npx @biomejs/biome check --write` on all touched source/locale files, `npm run i18n:gen`, `npx vitest run tests/two_factor_setup.test.ts`, plus `tests/i18n_completeness.test.ts`, `tests/i18n_status_registry.test.ts`, `tests/localization_coverage.test.ts`, `tests/localization_fixes.test.ts`, `npm run gate`.
- New test asserts the generated file's four prose lines come from the real `t()`-resolved strings, not the old raw literals; confirmed it fails pre-fix (untracked-key error) and passes post-fix. 9/9 in `tests/two_factor_setup.test.ts`; the i18n guard/completeness suites all pass.

## Screenshots / recordings

N/A. This changes the text content of a downloaded `.txt` file, not any rendered pixel. Verified via the new `t()`-output assertion test rather than a screenshot.

---

## Checklist

### Quality
- [x] The full gate passes. Added a decisive test pinning the `t()`-resolved file content.

### Cross-platform
- [x] N/A. Same pure formatting/catalog layer feeds desktop and mobile identically; no layout involved.

### Localization (i18n)
- [x] **New player-visible strings follow the contributor policy.** Added four English-only keys under the existing `hudChrome.account.*` namespace, next to `twoFactorEnabledMsg`.
- [x] Two of the four new values are "wordy" under the M16 rule, so this change also ships their required non-Latin fills (`ja_JP`, `ko_KR`, `ru_RU`, `zh_CN`, `zh_TW`) in the same commit, reusing terminology already established in those locale files (recovery code(s), authenticator app, Account). I did not touch any other locale overlay.
- [x] Confirmed `tests/localization_fixes.test.ts` (S3 guard) passes.

### Hygiene
- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files (regenerated via `npm run i18n:gen`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
