### PR TITLE
fix(sim): scale ground-AoE and Heroic Leap damage by talent/augment modifiers

### DIFF
--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -6402,6 +6402,30 @@ function scaleEffect(
       return { ...eff, mana: Math.round(eff.mana * dmgMult + flat) };
     case 'gainResource':
       return { ...eff, amount: Math.round(eff.amount * dmgMult + flat) };
+    case 'groundAoE':
+      // Rune of Power's pulse is an ally damage-done buff, not a damage roll
+      // (its authored min/max are 0/0): leave it untouched so a flat talent
+      // mod can never turn a buff zone into a damage zone.
+      return eff.allyBuffPct
+        ? eff
+        : {
+            ...eff,
+            min: Math.round(eff.min * dmgMult + flat),
+            max: Math.round(eff.max * dmgMult + flat),
+          };
+    case 'repositionToAim':
+      // Heroic Leap's landing hit is a groundAoE-shaped rider on the
+      // reposition; scale it the same way a groundAoE pulse scales.
+      return eff.landingAoe
+        ? {
+            ...eff,
+            landingAoe: {
+              ...eff.landingAoe,
+              min: Math.round(eff.landingAoe.min * dmgMult + flat),
+              max: Math.round(eff.landingAoe.max * dmgMult + flat),
+            },
+          }
+        : eff;
     default:
       return eff;
   }

--- a/tests/talent_buffpct_fixes.test.ts
+++ b/tests/talent_buffpct_fixes.test.ts
@@ -110,4 +110,77 @@ describe('talent buffPct resolver fixes', () => {
     expect(effect.dmgMult).toBeCloseTo(1.15, 6);
     expect(effect.flat ?? 0).toBe(0);
   });
+
+  // scaleEffect had no case for 'groundAoE' or 'repositionToAim', so a global
+  // damage modifier (e.g. the Fiesta arena augments, aug_bloodhunter's
+  // +18%/+18%) silently no-opped on Consecration, Earthquake, Blizzard,
+  // Meteor, and Heroic Leap's landing hit while every directDamage ability
+  // scaled correctly. These pin the fix against the same global mult a
+  // directDamage ability already applies.
+  it('Consecration groundAoE damage scales with the global spell damage modifier, same factor as a directDamage ability', () => {
+    const mods = emptyModifiers();
+    accumulateTalentEffect(mods, { global: { spellDmgPct: 0.18 } }, 1);
+
+    const exorcism = resolvedEffect('paladin', 'exorcism', 'directDamage', mods);
+    expect(exorcism.min).toBe(Math.round(46 * 1.18));
+    expect(exorcism.max).toBe(Math.round(56 * 1.18));
+
+    const consecration = resolvedEffect('paladin', 'consecration', 'groundAoE', mods);
+    expect(consecration.min).toBe(Math.round(28 * 1.18));
+    expect(consecration.max).toBe(Math.round(34 * 1.18));
+  });
+
+  it('Earthquake groundAoE damage scales with the global spell damage modifier', () => {
+    const mods = emptyModifiers();
+    accumulateTalentEffect(mods, { global: { spellDmgPct: 0.3 } }, 1);
+
+    const earthquake = resolvedEffect('shaman', 'earthquake', 'groundAoE', mods);
+    expect(earthquake.min).toBe(Math.round(13 * 1.3));
+    expect(earthquake.max).toBe(Math.round(17 * 1.3));
+  });
+
+  it('Blizzard groundAoE damage scales with the global spell damage modifier and keeps its snare/orb riders', () => {
+    const mods = emptyModifiers();
+    mods.spec = 'frost';
+    accumulateTalentEffect(mods, { global: { spellDmgPct: 0.3 } }, 1);
+
+    const blizzard = resolvedEffect('mage', 'blizzard', 'groundAoE', mods);
+    expect(blizzard.min).toBe(Math.round(12 * 1.3));
+    expect(blizzard.max).toBe(Math.round(16 * 1.3));
+    expect(blizzard.slowMult).toBe(0.6);
+    expect(blizzard.orbCdr).toBe(true);
+  });
+
+  it('Meteor groundAoE damage scales with the global spell damage modifier and keeps its ignite/delay riders', () => {
+    const mods = emptyModifiers();
+    mods.spec = 'fire';
+    accumulateTalentEffect(mods, { global: { spellDmgPct: 0.45 } }, 1);
+
+    const meteor = resolvedEffect('mage', 'meteor', 'groundAoE', mods);
+    expect(meteor.min).toBe(Math.round(90 * 1.45));
+    expect(meteor.max).toBe(Math.round(120 * 1.45));
+    expect(meteor.igniteFrac).toBe(0.4);
+    expect(meteor.delayed).toBe(true);
+  });
+
+  it('Rune of Power groundAoE ally-buff pulse (0/0 min/max) is left untouched by the global spell damage modifier', () => {
+    // Rune of Power is only reachable via the mage 20 choice row grant.
+    const mods = rowMods('mage', { 20: 'mag_r20_rune_of_power' });
+    accumulateTalentEffect(mods, { global: { spellDmgPct: 0.45 } }, 1);
+
+    const rune = resolvedEffect('mage', 'rune_of_power', 'groundAoE', mods);
+    expect(rune.min).toBe(0);
+    expect(rune.max).toBe(0);
+    expect(rune.allyBuffPct).toBe(0.1);
+  });
+
+  it('Heroic Leap landingAoe damage scales with the global melee damage modifier', () => {
+    const mods = emptyModifiers();
+    accumulateTalentEffect(mods, { global: { meleeDmgPct: 0.4 } }, 1);
+
+    const leap = resolvedEffect('warrior', 'heroic_leap', 'repositionToAim', mods);
+    expect(leap.landingAoe?.min).toBe(Math.round(24 * 1.4));
+    expect(leap.landingAoe?.max).toBe(Math.round(32 * 1.4));
+    expect(leap.landingAoe?.radius).toBe(6);
+  });
 });


### PR DESCRIPTION
## Summary

`scaleEffect()` is the single choke point that folds a resolved ability's talent/augment damage-percent modifiers into its effect numbers. It has a `case` for every damage-shaped `AbilityEffect` type (`weaponDamage`, `directDamage`, `dot`, `aoeDamage`/`aoeHeal`, `finisherDamage`, `heal`, etc.) except `'groundAoE'` and `'repositionToAim'`, both of which fell through to `default: return eff;` **unchanged**. `groundAoE` backs Consecration (paladin), Earthquake (shaman), Blizzard (frost mage), Meteor (fire mage), and Rune of Power's ally-buff pulse (mage); `repositionToAim` backs Heroic Leap's landing hit (warrior).

This is live-reachable today, not hypothetical: several shipped Fiesta (2v2 arena) augments set exactly `effect: { global: { meleeDmgPct, spellDmgPct } }` — Bloodhunter (+18%/+18%, universal), Overdrive (+30%/+30%, universal), Apex Predator (+40% melee), Archmage (+45% spell) — picks any class can take. A paladin/shaman/frost-or-fire-mage who picks a universal augment got zero benefit on Consecration/Earthquake/Blizzard/Meteor while every other ability they own correctly scaled; a warrior picking a melee augment got zero benefit on Heroic Leap's landing damage. This directly contradicted the augment's own tooltip promise ("+18% damage of all kinds").

This is the highest-stakes fix in this UAT batch (balance-sensitive damage math across 5 abilities / 4 classes), so it got extra scrutiny: the full golden-hash-pinned parity suite (112 scenarios, including `paladin_consecration`) passes byte-identical after the fix, confirming no currently-pinned scenario exercises this code path with a nonzero `global` damage modifier — nothing needed re-pinning, this closes a pure gap rather than changing any shipped baseline number.

```mermaid
flowchart TD
    Effect["resolved AbilityEffect"] --> Switch{"scaleEffect() switch"}
    Switch -->|directDamage, dot, aoeDamage, etc| Scaled["min/max * dmgMult + flat"]
    Switch -->|"groundAoE (before)"| Default["default: return eff unchanged"]
    Switch -->|"repositionToAim (before)"| Default
    Default --> Broken["Consecration / Earthquake / Blizzard /<br/>Meteor / Heroic Leap: augment % silently ignored"]

    Switch -->|"groundAoE (after)"| Guard{"allyBuffPct set?"}
    Guard -->|yes: Rune of Power pulse| Untouched["left unscaled (0/0 by design)"]
    Guard -->|no: real damage roll| Scaled2["min/max * dmgMult + flat"]
    Switch -->|"repositionToAim (after)"| Scaled3["landingAoe.min/max * dmgMult + flat"]
```

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx tsc --noEmit`, `npx @biomejs/biome check --write` on changed files, `npx vitest run tests/talent_buffpct_fixes.test.ts`, plus a broad regression sweep (`tests/parity/parity.test.ts` — 112 golden scenarios byte-identical — `heroic_leap`, `ground_aim`, `ground_target_cast`, `frost_mage_aoe`, `fire_mage`, `mage_ground_fx`, `aldric_meteor_quest`, `combat_effect_dispatch`, `mage_choice_rows`, `mage_talent_icons`, `ability_damage`, `ability_tooltip_consistency`, `arena`, `attack_on_ability`, `aura_effect`, `entity_roster`, `fixes`, `threat`, `fire_short_fight_tuning`), `npm run gate`.
- Six new tests pin that a synthetic `global.spellDmgPct`/`meleeDmgPct` modifier scales Consecration/Earthquake/Blizzard/Meteor's `groundAoE` min/max and Heroic Leap's `landingAoe` min/max by the same factor a `directDamage` ability already correctly scales by, that Blizzard/Meteor keep their snare/orb/ignite/delay riders, and — the critical negative case — that Rune of Power's `allyBuffPct` pulse (0/0 min/max) is explicitly left untouched. All confirmed failing pre-fix, passing post-fix. 11/11 in `tests/talent_buffpct_fixes.test.ts`.

## Screenshots / recordings

N/A. Sim-only combat-math change, no player-visible UI.

---

## Checklist

### Quality
- [x] The full gate passes. Added six decisive regression tests covering all five affected abilities plus the one ability that must NOT scale; ran the full golden-hash parity suite to confirm no shipped baseline changed.

### Cross-platform
- [x] N/A. Sim-only change, identical behavior on every host (offline/server/RL env) by construction.

### Localization (i18n)
- [x] N/A. This PR adds no player-visible strings.

### Hygiene
- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
