### PR TITLE
fix(admin): revoke session tokens when banning or suspending an account

### DIFF
--- a/server/admin.ts
+++ b/server/admin.ts
@@ -476,6 +476,12 @@ export async function handleAdminApi(
         if (action === 'suspend' || action === 'ban') {
           const statusText =
             action === 'ban' ? 'This account has been banned.' : 'This account is suspended.';
+          // Every device is signed out here too, mirroring the reset-password arm
+          // above: revoke all tokens then disconnect the live socket (revocation
+          // alone leaves an already-open connection intact). Otherwise a token
+          // issued before the sanction stays valid in auth_tokens and regains
+          // access with no re-authentication once the sanction is lifted or expires.
+          await revokeTokensExcept(targetAccountId, null);
           game.disconnectAccount(targetAccountId, statusText);
           // Notify the affected account of the moderation action. Best-effort and
           // fully isolated: a mail-target lookup or send failure must never turn a
@@ -1657,6 +1663,12 @@ async function moderateActionHandler(ctx: Ctx): Promise<void> {
     if (action === 'suspend' || action === 'ban') {
       const statusText =
         action === 'ban' ? 'This account has been banned.' : 'This account is suspended.';
+      // Every device is signed out here too, mirroring resetPasswordHandler: revoke
+      // all tokens then disconnect the live socket (revocation alone leaves an
+      // already-open connection intact). Otherwise a token issued before the
+      // sanction stays valid in auth_tokens and regains access with no
+      // re-authentication the moment the sanction is lifted or expires.
+      await adminDb().revokeTokensExcept(targetAccountId, null);
       rt.disconnectAccount(targetAccountId, statusText);
       // Notify the affected account of the moderation action. Best-effort and fully
       // isolated: a mail-target lookup or send failure must never turn a successful

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -940,6 +940,7 @@ describe('admin api auth', () => {
       expiresAt,
     });
     expect(fakeGame.disconnectAccount).toHaveBeenCalledWith(9, 'This account is suspended.');
+    expect(revokeTokensExcept).toHaveBeenCalledWith(9, null);
   });
 
   it('bans and disconnects an account', async () => {
@@ -968,6 +969,7 @@ describe('admin api auth', () => {
       expiresAt: undefined,
     });
     expect(fakeGame.disconnectAccount).toHaveBeenCalledWith(9, 'This account has been banned.');
+    expect(revokeTokensExcept).toHaveBeenCalledWith(9, null);
   });
 
   it('mutes account chat and sends a live warning without disconnecting', async () => {
@@ -1025,6 +1027,7 @@ describe('admin api auth', () => {
       expiresAt: undefined,
     });
     expect(fakeGame.disconnectAccount).not.toHaveBeenCalled();
+    expect(revokeTokensExcept).not.toHaveBeenCalled();
   });
 
   it('unsuspends without disconnecting the account', async () => {
@@ -1054,6 +1057,7 @@ describe('admin api auth', () => {
     });
     expect(fakeGame.disconnectAccount).not.toHaveBeenCalled();
     expect(accountMailTarget).not.toHaveBeenCalled();
+    expect(revokeTokensExcept).not.toHaveBeenCalled();
   });
 
   it('rejects suspending or banning admin accounts', async () => {

--- a/tests/server/admin.test.ts
+++ b/tests/server/admin.test.ts
@@ -516,7 +516,8 @@ describe('operator :id loader + enum :action', () => {
   for (const action of ['suspend', 'unsuspend', 'ban', 'unban'] as const) {
     it(`decodes the valid action "${action}" and reaches moderateAccount`, async () => {
       const moderateAccount = vi.fn(async () => {});
-      authedAdminDb({ moderateAccount, accountMailTarget: async () => null });
+      const revokeTokensExcept = vi.fn(async () => {});
+      authedAdminDb({ moderateAccount, accountMailTarget: async () => null, revokeTokensExcept });
       installAdminRuntime();
       const r = await runRoute('POST', '/admin/api/moderation/accounts/:id/:action', {
         headers: { authorization: BEARER },
@@ -528,6 +529,13 @@ describe('operator :id loader + enum :action', () => {
       expect(moderateAccount).toHaveBeenCalledWith(
         expect.objectContaining({ accountId: 5, adminAccountId: ADMIN_ACCOUNT_ID, action }),
       );
+      // suspend/ban sign the target out of every device (mirrors reset-password);
+      // unsuspend/unban are non-punitive reversals and must never touch tokens.
+      if (action === 'suspend' || action === 'ban') {
+        expect(revokeTokensExcept).toHaveBeenCalledWith(5, null);
+      } else {
+        expect(revokeTokensExcept).not.toHaveBeenCalled();
+      }
     });
   }
 
@@ -648,11 +656,13 @@ describe('game.* side effects preserved', () => {
 
   it('a suspend disconnects the target account and fires the best-effort mail', async () => {
     const emailSecurityIncident = vi.fn();
+    const revokeTokensExcept = vi.fn(async () => {});
     authedAdminDb({
       moderateAccount: async () => {},
       accountMailTarget: async () =>
         ({ id: 5, username: 'x', email: 'x@y.z', locale: 'en', marketing_opt_in: false }) as never,
       emailSecurityIncident,
+      revokeTokensExcept,
     });
     const rt = installAdminRuntime();
     const r = await runRoute('POST', '/admin/api/moderation/accounts/:id/:action', {
@@ -661,6 +671,7 @@ describe('game.* side effects preserved', () => {
       body: { reason: 'griefing' },
     });
     expect(r.status).toBe(200);
+    expect(revokeTokensExcept).toHaveBeenCalledWith(5, null);
     expect(rt.disconnectAccount).toHaveBeenCalledWith(5, 'This account is suspended.');
   });
 
@@ -815,6 +826,7 @@ describe('game.* side effects preserved', () => {
       accountMailTarget: async () => {
         throw new Error('mail db down');
       },
+      revokeTokensExcept: vi.fn(async () => {}),
     });
     const rt = installAdminRuntime();
     // The email is fired as a void .then().catch(), so the 200 is written synchronously
@@ -1410,6 +1422,7 @@ describe('migrated write handlers + side effects (QA gate parity coverage)', () 
       moderateAccount: async () => {},
       accountMailTarget: async () => target,
       emailSecurityIncident,
+      revokeTokensExcept: vi.fn(async () => {}),
     });
     installAdminRuntime();
     const r = await runRoute('POST', '/admin/api/moderation/accounts/:id/:action', {
@@ -1431,6 +1444,7 @@ describe('migrated write handlers + side effects (QA gate parity coverage)', () 
       moderateAccount: async () => {},
       accountMailTarget: async () => target,
       emailSecurityIncident,
+      revokeTokensExcept: vi.fn(async () => {}),
     });
     installAdminRuntime();
     await runRoute('POST', '/admin/api/moderation/accounts/:id/:action', {
@@ -2024,6 +2038,7 @@ describe('remaining legacy guard negatives (re-verification audit)', () => {
       moderateAccount: async () => {},
       accountMailTarget: async () => target,
       emailSecurityIncident,
+      revokeTokensExcept: vi.fn(async () => {}),
     });
     installAdminRuntime();
     await runRoute('POST', '/admin/api/moderation/accounts/:id/:action', {


### PR DESCRIPTION
## Summary

Admin ban/suspend kicks the account's live WebSocket session but never revokes its `auth_tokens` rows, unlike every other account-locking flow in this codebase (admin reset-password, self-service deactivate, self-service password-change), which all explicitly revoke tokens before disconnecting. This is not exploitable while the ban/suspension is active, since every route re-checks moderation status live per request. The gap surfaces later: any bearer token issued before the sanction (a session token lives up to 7 days, a companion/OAuth read token up to 90) stays a live row the whole time, and the moment staff reverse the action (unban/unsuspend) or a timed suspension simply expires, that stale pre-ban token silently regains full access with no re-authentication.

`server/admin.ts` runs a documented dual dispatch structure: a legacy inline handler ladder (`handleAdminApi`, kept live behind `API_DISPATCH=legacy` as a rollback arm) and a migrated `RouteDef` handler (`moderateActionHandler`). Both had the identical gap and both needed the fix, otherwise flipping the rollback flag would silently restore the bug.

```mermaid
sequenceDiagram
    participant Admin
    participant Handler as moderateActionHandler / handleAdminApi (ban arm)
    participant DB as moderateAccount (banned_at/suspended_until)
    participant Tokens as auth_tokens
    participant Socket as live WebSocket session

    rect rgb(255, 230, 230)
    Note over Admin,Socket: Before
    Admin->>Handler: ban / suspend account
    Handler->>DB: moderateAccount(...)
    Handler->>Socket: disconnectAccount(...)
    Note right of Tokens: never touched - pre-ban token stays valid
    end

    rect rgb(230, 255, 230)
    Note over Admin,Socket: After (both dispatch arms)
    Admin->>Handler: ban / suspend account
    Handler->>DB: moderateAccount(...)
    Handler->>Tokens: revokeTokensExcept(accountId, null)
    Handler->>Socket: disconnectAccount(...)
    Note right of Tokens: mirrors resetPasswordHandler's own sequence
    end
```

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx tsc --noEmit`, `npx @biomejs/biome check --write server/admin.ts tests/admin.test.ts tests/server/admin.test.ts`, `npx vitest run tests/admin.test.ts tests/server/admin.test.ts`, plus a wider regression sweep (`admin_routes`, `moderation_db`, `moderation_service`, `daily_rewards_controls`, `moderation_actions`, `leaderboard_moderation`, `http/parity`, `http/path_pattern`, `http/router`), `npm run gate`.
- Extended the existing `'suspends and disconnects an account'` / `'bans and disconnects an account'` specs (both the legacy-arm `tests/admin.test.ts` and the migrated-arm `tests/server/admin.test.ts`) with `revokeTokensExcept` assertions, plus negative assertions that unban/unsuspend never call it. Confirmed both failed (0 calls) against the original code, pass after the fix. 197/197 in the two admin test files, 237/237 across the wider sweep.
- Related, out-of-scope finding surfaced during review and left unfixed: the in-game moderator chat commands `/ban`/`/suspend` (`server/moderation_service.ts`) call the same `moderateAccount` DB function and disconnect but have the identical missing-revocation gap. Flagging for a possible follow-up PR.

## Screenshots / recordings

N/A. Server-only account-moderation fix, no player-visible UI.

---

## Checklist

### Quality
- [x] The full gate passes. Added decisive tests pinning that ban/suspend revoke tokens and unban/unsuspend do not, across both live dispatch arms.

### Cross-platform
- [x] N/A. Server-only change.

### Localization (i18n)
- [x] N/A. This PR adds no player-visible strings.

### Hygiene
- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
