### PR TITLE
fix(server): refresh the Arena window immediately after queue/leave

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -4735,10 +4735,19 @@ export class GameServer {
                   ? 'yumi5'
                   : '1v1';
         sim.arenaQueueJoin(pid, fmt);
+        // ARENA_WIRE_HZ throttles the `arena` self key to once per 10s (the
+        // #940 perf fix for the uncached arenaLadder() sort), so without this
+        // the Arena window would keep showing the stale Queue button for up to
+        // 10s after the player just clicked it. Force the next snapshot to
+        // carry fresh arenaInfo, same reset used at the spectate transitions.
+        session.lastArenaWireTick = -ARENA_WIRE_INTERVAL_TICKS;
         break;
       }
       case 'arena_leave':
         sim.arenaQueueLeave(pid);
+        // Same staleness fix as arena_queue above: surface the cleared queue
+        // state immediately instead of on the next throttled tick.
+        session.lastArenaWireTick = -ARENA_WIRE_INTERVAL_TICKS;
         break;
       case 'arena_augment': {
         if (typeof msg.augment === 'string' && msg.augment.length <= 64)
@@ -6467,6 +6476,11 @@ export class GameServer {
               // a sim-driven change to a heavy self field (loot, level-up, quest
               // credit, ...) refreshes those fields on the next snapshot
               if (HEAVY_SELF_EVENTS.has(ev.type)) session.selfHeavyDirty = true;
+              // A match concluding (win, loss, draw, or forfeit) changes rating
+              // and standings on the throttled `arena` self key (ARENA_WIRE_HZ):
+              // force it fresh next snapshot instead of leaving the Arena
+              // window showing the pre-match rating for up to 10s.
+              if (ev.type === 'arenaEnd') session.lastArenaWireTick = -ARENA_WIRE_INTERVAL_TICKS;
               // remember the last person to whisper us, for /r reply (the
               // recipient copy of a whisper has no `to`; the sender echo does)
               if (

--- a/tests/arena_online.test.ts
+++ b/tests/arena_online.test.ts
@@ -204,4 +204,71 @@ describe('arena: online integration (GameServer)', () => {
     expect(victorSave?.[2].honor).toBe(RANKED_ARENA_WIN_HONOR['1v1']);
     expect(victorSave?.[2].lifetimeHonor).toBe(RANKED_ARENA_WIN_HONOR['1v1']);
   });
+
+  // Regression coverage for the stale Arena window: ARENA_WIRE_HZ throttles the
+  // `arena` self key to once per 200 ticks (10s), a real perf fix (#940) for the
+  // uncached arenaLadder() sort. A queue join/leave must still surface on the
+  // very next snapshot rather than waiting out that window, or the window keeps
+  // showing "Queue" after the player already queued (and vice versa on leave).
+  function snapsWithArenaKey(fc: FakeClient, fromIndex: number): any[] {
+    return fc.sent
+      .slice(fromIndex)
+      .filter((msg: any) => msg.t === 'snap' && Object.hasOwn(msg.self, 'arena'));
+  }
+
+  it('refreshes the arena self key on the very next tick after arena_queue/arena_leave, not after the 10s throttle', () => {
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 40, 'Quick', 'warrior');
+    teleport(server.sim, session.pid, 0, -40);
+
+    // A fresh join always ships arena on its first snapshot (lastArenaWireTick
+    // starts negative); consume that grace before probing the steady-state gate.
+    advance(server);
+    const first = lastSnap(fc);
+    expect(first.self.arena).toBeTruthy();
+    expect(first.self.arena.queued).toBe(false);
+
+    const beforeQueue = fc.sent.length;
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'arena_queue', format: '1v1' }));
+    advance(server); // a single tick: far short of the 200-tick (10s) throttle window
+    const queueUpdates = snapsWithArenaKey(fc, beforeQueue);
+    expect(queueUpdates.length).toBeGreaterThan(0);
+    expect(queueUpdates[queueUpdates.length - 1].self.arena.queued).toBe(true);
+
+    const beforeLeave = fc.sent.length;
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'arena_leave' }));
+    advance(server);
+    const leaveUpdates = snapsWithArenaKey(fc, beforeLeave);
+    expect(leaveUpdates.length).toBeGreaterThan(0);
+    expect(leaveUpdates[leaveUpdates.length - 1].self.arena.queued).toBe(false);
+  });
+
+  it('refreshes the arena self key on the very next tick after a match concludes (arenaEnd), not after the 10s throttle', async () => {
+    const fcA = fakeWs();
+    const fcB = fakeWs();
+    const sa = joinServer(server, fcA, 41, 'Loser', 'warrior');
+    const sb = joinServer(server, fcB, 42, 'Winner', 'mage');
+    teleport(server.sim, sa.pid, 0, -40);
+    teleport(server.sim, sb.pid, 4, -40);
+    server.handleMessage(sa, JSON.stringify({ t: 'cmd', cmd: 'arena_queue' }));
+    server.handleMessage(sb, JSON.stringify({ t: 'cmd', cmd: 'arena_queue' }));
+    for (let i = 0; i < 20 * 6; i++) advance(server);
+    expect(server.sim.arenaMatchFor(sa.pid)?.state).toBe('active');
+
+    // Run well past the throttle window so lastArenaWireTick sits in a settled
+    // steady state (not still inside the queue command's own forced-fresh grace).
+    for (let i = 0; i < 200; i++) advance(server);
+    const priorArenaSnaps = snapsWithArenaKey(fcB, 0);
+    const ratingBefore =
+      priorArenaSnaps[priorArenaSnaps.length - 1].self.arena.standings['1v1'].rating;
+
+    const before = fcB.sent.length;
+    await server.leave(sa, 'disconnect'); // forfeit win for sb: sim.arenaResolveDesertion emits arenaEnd
+    advance(server); // one tick later: routes the arenaEnd event, then broadcasts
+
+    const updates = snapsWithArenaKey(fcB, before);
+    expect(updates.length).toBeGreaterThan(0);
+    const updated = updates[updates.length - 1].self.arena;
+    expect(updated.standings['1v1'].rating).toBeGreaterThan(ratingBefore);
+  });
 });


### PR DESCRIPTION
## Summary

The online Arena window (queue/leave/rating/standings) can stay visibly stale for up to 10 seconds after a player clicks Queue or Leave. `arenaInfo` is broadcast at a fixed `ARENA_WIRE_HZ = 0.1` (once per 10s), while the two sibling "live window" queue systems, Vale Cup and Dungeon Finder, both broadcast at `2 Hz` (0.5s, 20x faster) with an explicit "keeps the window live" comment. The per-session `lastArenaWireTick` reset that forces an immediate refresh is applied on session join/resume/spectate transitions but never on the `arena_queue`/`arena_leave` command dispatch. A player who clicks Queue sees only a chat-log toast; the window itself keeps showing the stale "Queue" button (not "Cancel Queue"/position N) for up to 10s, inviting confused re-clicks.

Offline this never happens (`Sim.arenaInfo` recomputes fresh on every read) — a genuine Sim-vs-ClientWorld parity gap for the same `IWorld` member. `git log -S ARENA_WIRE_HZ` traces the 0.1 Hz throttle to an earlier perf fix (#940) protecting a real, expensive uncached per-session `arenaLadder()` sort, predating the Vale Cup/Dungeon Finder 2 Hz convention and never revisited to match it — naively raising the Hz globally would reintroduce that regression.

```mermaid
sequenceDiagram
    participant P as Player
    participant Client as Arena window (client)
    participant Server as server/game.ts

    rect rgb(255, 230, 230)
    Note over P,Server: Before
    P->>Server: dispatch arena_queue
    Server->>Server: sim.arenaQueueJoin(pid)
    Note right of Server: lastArenaWireTick untouched
    Client--xClient: window still shows "Queue" for up to 10s
    Server-->>Client: fresh arenaInfo (next scheduled 0.1 Hz tick)
    end

    rect rgb(230, 255, 230)
    Note over P,Server: After
    P->>Server: dispatch arena_queue
    Server->>Server: sim.arenaQueueJoin(pid)
    Server->>Server: lastArenaWireTick forced back (mirrors spectate-transition reset)
    Server-->>Client: fresh arenaInfo on the very next snapshot
    Client-->>P: "Cancel Queue" / position N shown immediately
    end

    Note over Server: Steady-state ARENA_WIRE_HZ = 0.1 left untouched,\nstill protects the expensive arenaLadder() sort (#940)
```

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx tsc --noEmit`, `npx @biomejs/biome check --write server/game.ts tests/arena_online.test.ts`, `npx vitest run tests/arena_online.test.ts` and the broader arena suite.
- Two new tests in `tests/arena_online.test.ts`: "refreshes the arena self key on the very next tick after arena_queue/arena_leave, not after the 10s throttle" and the equivalent for an `arenaEnd` match-conclusion event. Both confirmed failing against the original code, passing after the fix.
- `tests/arena_online.test.ts`: 6/6 pass. `tests/arena_command.test.ts`, `arena_module.test.ts`, `arena_window.test.ts`, `arena_window_view.test.ts`, `arena_respawn_intent.test.ts`, `arena_render.test.ts`, `arena_db.test.ts`, `snapshots.test.ts`: 202/202 pass. `tests/arena.test.ts`: 43/43 pass. `tests/honor_ui.test.ts`: 3/3 pass. Two unrelated timeouts (`tests/parity/coverage.test.ts`, `tests/yumi_match.test.ts`) confirmed as pre-existing environment flakes by reverting and retesting on unmodified baseline code.

## Screenshots / recordings

N/A. This is a data-refresh-cadence fix, not a layout change; the Arena window's visual appearance is unchanged, only how quickly it reflects a queue/leave/match-conclusion.

---

## Checklist

### Quality
- [x] The full gate passes. Added decisive regression tests for both trigger paths (queue/leave dispatch and match conclusion), both confirmed red before the fix, and verified the steady-state perf throttle (#940) is untouched.

### Cross-platform
- [x] N/A. Server-side wire-cadence change; identical effect on desktop and mobile clients since both consume the same `arenaInfo` IWorld member.

### Localization (i18n)
- [x] N/A. This PR adds no player-visible strings.

### Hygiene
- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
