### PR TITLE
fix(input): match gamepad look-pitch direction to mouse and touch

### DIFF
--- a/src/game/gamepad_map.ts
+++ b/src/game/gamepad_map.ts
@@ -263,7 +263,7 @@ export function stickToLook(
 ): LookDelta {
   const v = applyRadialDeadzone(x, y, dz);
   if (v.x === 0 && v.y === 0) return { yaw: 0, pitch: 0 };
-  const pitchSign = invertY ? 1 : -1;
+  const pitchSign = invertY ? -1 : 1;
   return { yaw: -v.x * speed * dt, pitch: pitchSign * v.y * speed * dt };
 }
 

--- a/tests/gamepad_map.test.ts
+++ b/tests/gamepad_map.test.ts
@@ -91,6 +91,16 @@ describe('stickToLook', () => {
     const inverted = stickToLook(0, -1, 0.2, 2, true, 0.016);
     expect(Math.sign(normal.pitch)).toBe(-Math.sign(inverted.pitch));
   });
+
+  it('pushing the stick up (y < 0) with invertY off looks up, matching mouse/touch (negative pitch delta)', () => {
+    // camPitch accumulates this delta directly (Input.applyGamepadLook); the
+    // renderer raises the camera and tilts the view DOWN as camPitch increases
+    // (see the eyeY + sin(pitch)*dist orbit in renderer.ts), so "look up" means
+    // a negative delta here, the same sign mouse's lookPitchSign and touch's
+    // touchPitchSign both apply by default for a physically-up input.
+    const up = stickToLook(0, -1, 0.2, 2, false, 0.016);
+    expect(up.pitch).toBeLessThan(0);
+  });
 });
 
 describe('risingEdges', () => {


### PR DESCRIPTION
## Summary

`stickToLook`'s pitch sign was the opposite of the convention every other look input uses. With gamepad Invert Y off (the default, matching mouse and touch's own default), pushing the right stick up made the camera look **down**, and pushing it down looked **up** — backwards. Mouse (`lookPitchSign`) and touch (`touchPitchSign`) both use `on ? -1 : 1` for the identical "moved up -> look up" semantic; gamepad used `invertY ? 1 : -1`, the inverse. The function's own doc comment even stated the intended behavior ("pushing up looks up unless invertY") while the implementation contradicted it. The only way for a gamepad player to get the intuitive feel was to turn Invert Y **on**, which then falsely reported as "inverted" in the settings UI.

The existing test only pinned that `invertY` flips the sign *relative to* the non-inverted case, never the absolute direction, so it passed even with the sign backwards.

```mermaid
flowchart LR
    A["Right stick pushed up\n(W3C convention: y = -1)"] --> B{"invertY = false (default)"}
    subgraph before["Before"]
        B -->|"pitchSign = invertY ? 1 : -1  =>  -1"| C1["pitch = -1 * -1 = +0.0384\n(positive => camera looks DOWN)"]
    end
    subgraph after["After"]
        B -->|"pitchSign = invertY ? -1 : 1  =>  +1"| C2["pitch = 1 * -1 = -0.0384\n(negative => camera looks UP,\nmatches mouse/touch's on?-1:1)"]
    end
```

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/gamepad_map.test.ts`, `npx tsc --noEmit`, `npx @biomejs/biome check --write` on changed files, plus `tests/gamepad.test.ts`, `tests/move_input.test.ts`, `tests/options_view.test.ts`, `tests/options_window.test.ts` (118 tests total).
- New test pins the absolute pitch direction (`stickToLook(0, -1, dz, speed, false, dt).pitch` must be negative for a stick-up input with Invert Y off), confirmed failing pre-fix (`expected 0.032 to be less than 0`) and passing post-fix. The existing relative-flip test ("inverts pitch when invertY is set") still passes unchanged.

## Screenshots / recordings

N/A. Input-only change with no visual UI; verified via a new absolute-direction unit test on the pure `stickToLook` function, no coordinator touched.

---

## Checklist

### Quality
- [x] The full gate passes. Added a decisive test pinning the absolute (not just relative) look direction so this sign can't silently flip back.

### Cross-platform
- [x] N/A. Gamepad input is desktop/console-controller only; the fix is in the shared pure `gamepad_map.ts` module used identically everywhere gamepad input is read.

### Localization (i18n)
- [x] N/A. This PR adds no player-visible strings.

### Hygiene
- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
