### PR TITLE
fix(sim): same-stat elixirs replace each other instead of stacking

### DIFF
--- a/src/sim/items.ts
+++ b/src/sim/items.ts
@@ -473,11 +473,16 @@ export function useItem(ctx: SimContext, itemId: string, pid?: number): ItemUseR
   } else if (def.kind === 'elixir') {
     // Battle elixir: grant a temporary stat-buff aura. Usable in combat (classic),
     // no shared potion cooldown; re-quaffing refreshes the buff via applyAura.
+    // The aura id is keyed on the elixir's EFFECT kind, not the item, so every
+    // elixir of one stat shares one id and the same-id replacement in applyAura
+    // makes same-stat elixirs exclusive: last drunk wins (classic overwrite,
+    // weaker included). Different-kind elixirs coexist; class buffs
+    // (buff_sta_pct) and negative buff_sta debuffs ride their own ids.
     const elx = def.elixir;
     if (!elx) return;
     ctx.removeItem(itemId, 1, meta.entityId);
     ctx.applyAura(p, {
-      id: `elixir_${itemId}`,
+      id: `elixir_${elx.kind}`,
       name: elx.aura,
       kind: elx.kind,
       remaining: elx.duration,

--- a/src/sim/items.ts
+++ b/src/sim/items.ts
@@ -477,7 +477,10 @@ export function useItem(ctx: SimContext, itemId: string, pid?: number): ItemUseR
     // elixir of one stat shares one id and the same-id replacement in applyAura
     // makes same-stat elixirs exclusive: last drunk wins (classic overwrite,
     // weaker included). Different-kind elixirs coexist; class buffs
-    // (buff_sta_pct) and negative buff_sta debuffs ride their own ids.
+    // (buff_sta_pct) and negative buff_sta debuffs ride their own ids. This
+    // assumes one stat kind equals one exclusivity slot: if a guardian elixir
+    // family that should stack with battle elixirs ever lands, the id needs a
+    // family component (elixir_battle_...), not just the kind.
     const elx = def.elixir;
     if (!elx) return;
     ctx.removeItem(itemId, 1, meta.entityId);

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -5367,8 +5367,15 @@ export class Sim {
     )
       return;
     for (const existing of replacementConflicts) {
-      this.applyNonPlayerStatAura(target, target.auras[existing], -1);
+      const displaced = target.auras[existing];
+      this.applyNonPlayerStatAura(target, displaced, -1);
       target.auras.splice(existing, 1);
+      // A same-id replacement that swaps in a DIFFERENT display name (a
+      // same-stat elixir overwriting another brand) would otherwise vanish
+      // from the buff bar with no combat-log trace: emit the fade the client
+      // cannot infer. Same-name refreshes stay silent, exactly as before.
+      if (displaced.name !== aura.name)
+        this.emit({ type: 'aura', targetId: target.id, name: displaced.name, gained: false });
     }
     target.auras.push(aura);
     if (aura.kind === 'stealth') target.stealthed = true; // keep the cache live without waiting for updateAuras

--- a/tests/elixir.test.ts
+++ b/tests/elixir.test.ts
@@ -183,6 +183,33 @@ describe('same-stat elixirs are exclusive, last drunk wins', () => {
     }
   });
 
+  it('displacing a different-name elixir emits its fade event alongside the gain', () => {
+    const { sim, pid } = playerWorld();
+    drink(sim, pid, 'elixir_of_the_bear');
+    sim.drainEvents();
+    drink(sim, pid, 'elixir_of_the_serpent');
+    const evs = sim.drainEvents();
+    expect(
+      evs.some((e) => e.type === 'aura' && e.name === 'Might of the Bear' && e.gained === false),
+      'the displaced Bear aura fades visibly in the event stream',
+    ).toBe(true);
+    expect(
+      evs.some((e) => e.type === 'aura' && e.name === 'Might of the Serpent' && e.gained === true),
+    ).toBe(true);
+  });
+
+  it('a same-item refresh emits no fade event (same name stays silent)', () => {
+    const { sim, pid } = playerWorld();
+    drink(sim, pid, 'elixir_of_the_bear');
+    sim.drainEvents();
+    drink(sim, pid, 'elixir_of_the_bear');
+    const evs = sim.drainEvents();
+    expect(evs.some((e) => e.type === 'aura' && e.gained === false)).toBe(false);
+    expect(
+      evs.some((e) => e.type === 'aura' && e.name === 'Might of the Bear' && e.gained === true),
+    ).toBe(true);
+  });
+
   it('every elixir item in the catalog maps to the shared per-kind aura id', () => {
     // Content-shape pin: a future fifth stamina elixir lands in this loop
     // automatically and cannot silently reintroduce per-item stacking.

--- a/tests/elixir.test.ts
+++ b/tests/elixir.test.ts
@@ -191,6 +191,8 @@ describe('same-stat elixirs are exclusive, last drunk wins', () => {
       .filter((d) => d.elixir?.kind === 'buff_sta')
       .map((d) => d.id)
       .sort();
+    // A new stamina elixir must be added here DELIBERATELY: it inherits the
+    // shared exclusivity id automatically via the loop below.
     expect(staElixirIds).toEqual([
       'elixir_of_the_bear',
       'elixir_of_the_boar',

--- a/tests/elixir.test.ts
+++ b/tests/elixir.test.ts
@@ -1,23 +1,41 @@
 import { describe, expect, it } from 'vitest';
+import { ITEMS } from '../src/sim/data';
 import { Sim } from '../src/sim/sim';
-import { Entity } from '../src/sim/types';
+import type { Aura, Entity } from '../src/sim/types';
 
 function makeWorld() {
   return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
 }
 
+function playerWorld() {
+  const sim = makeWorld();
+  const pid = sim.addPlayer('warrior', 'Aleph');
+  sim.tick();
+  const p = sim.entities.get(pid)! as Entity;
+  return { sim, pid, p };
+}
+
+function drink(sim: Sim, pid: number, itemId: string): void {
+  sim.addItem(itemId, 1, pid);
+  sim.useItem(itemId, pid);
+}
+
+function staAuras(p: Entity): Aura[] {
+  return p.auras.filter((a) => a.kind === 'buff_sta');
+}
+
+function applyAuraOn(sim: Sim, target: Entity, aura: Aura): void {
+  (sim as unknown as { applyAura(t: Entity, a: Aura): void }).applyAura(target, aura);
+}
+
 describe('battle elixir (Elixir of the Bear)', () => {
   it('grants the stamina buff aura and raises max HP on use', () => {
-    const sim = makeWorld();
-    const pid = sim.addPlayer('warrior', 'Aleph');
-    sim.tick();
-    const p = sim.entities.get(pid)! as Entity;
+    const { sim, pid, p } = playerWorld();
     const beforeMaxHp = p.maxHp;
 
-    sim.addItem('elixir_of_the_bear', 1, pid);
-    sim.useItem('elixir_of_the_bear', pid);
+    drink(sim, pid, 'elixir_of_the_bear');
 
-    const aura = p.auras.find((a) => a.id === 'elixir_elixir_of_the_bear');
+    const aura = p.auras.find((a) => a.id === 'elixir_buff_sta');
     expect(aura, 'elixir aura applied').toBeTruthy();
     expect(aura!.kind).toBe('buff_sta');
     expect(aura!.value).toBe(12);
@@ -26,9 +44,7 @@ describe('battle elixir (Elixir of the Bear)', () => {
   });
 
   it('consumes one elixir per use', () => {
-    const sim = makeWorld();
-    const pid = sim.addPlayer('warrior', 'Aleph');
-    sim.tick();
+    const { sim, pid } = playerWorld();
 
     sim.addItem('elixir_of_the_bear', 2, pid);
     sim.useItem('elixir_of_the_bear', pid);
@@ -36,28 +52,157 @@ describe('battle elixir (Elixir of the Bear)', () => {
   });
 
   it('does nothing when the player has no elixir', () => {
-    const sim = makeWorld();
-    const pid = sim.addPlayer('warrior', 'Aleph');
-    sim.tick();
-    const p = sim.entities.get(pid)! as Entity;
+    const { sim, pid, p } = playerWorld();
 
     sim.useItem('elixir_of_the_bear', pid);
-    expect(p.auras.some((a) => a.id === 'elixir_elixir_of_the_bear')).toBe(false);
+    expect(p.auras.some((a) => a.id === 'elixir_buff_sta')).toBe(false);
   });
 
   it('re-quaffing refreshes the buff without stacking it', () => {
-    const sim = makeWorld();
-    const pid = sim.addPlayer('warrior', 'Aleph');
-    sim.tick();
-    const p = sim.entities.get(pid)! as Entity;
+    const { sim, pid, p } = playerWorld();
 
     sim.addItem('elixir_of_the_bear', 2, pid);
     sim.useItem('elixir_of_the_bear', pid);
     for (let i = 0; i < 20 * 5; i++) sim.tick(); // let it tick down ~5s
     sim.useItem('elixir_of_the_bear', pid);
 
-    const auras = p.auras.filter((a) => a.id === 'elixir_elixir_of_the_bear');
+    const auras = p.auras.filter((a) => a.id === 'elixir_buff_sta');
     expect(auras.length, 'only one elixir aura, refreshed').toBe(1);
+    expect(auras[0].value).toBe(12);
     expect(auras[0].remaining).toBeGreaterThan(890);
+  });
+});
+
+// The four stamina elixirs (Boar / Vipersear / Bear / Serpent) are one alchemy
+// ladder for one effect. Elixirs are exclusive PER BUFF KIND, last drunk wins
+// (classic overwrite semantics, weaker included): the aura id is derived from
+// the elixir's effect kind, so the ordinary same-id replacement in applyAura
+// enforces exclusivity. Class buffs (buff_sta_pct) and negative buff_sta
+// debuffs ride their own ids and are untouched.
+describe('same-stat elixirs are exclusive, last drunk wins', () => {
+  it('Bear then Serpent leaves exactly one stamina elixir aura at +12, not +24', () => {
+    const { sim, pid, p } = playerWorld();
+    const baseSta = p.stats.sta;
+    const baseMaxHp = p.maxHp;
+
+    drink(sim, pid, 'elixir_of_the_bear');
+    const oneElixirMaxHp = p.maxHp;
+    drink(sim, pid, 'elixir_of_the_serpent');
+
+    const auras = staAuras(p);
+    expect(auras.length, 'one stamina elixir aura').toBe(1);
+    expect(auras[0].id).toBe('elixir_buff_sta');
+    expect(auras[0].name).toBe('Might of the Serpent');
+    expect(p.stats.sta, 'stamina reflects one +12 elixir').toBe(baseSta + 12);
+    expect(p.maxHp, 'HP pool reflects one elixir, not two').toBe(oneElixirMaxHp);
+    expect(p.maxHp).toBeGreaterThan(baseMaxHp);
+  });
+
+  it('ladder up: Boar then Bear is one aura at +12 with Bear duration', () => {
+    const { sim, pid, p } = playerWorld();
+    const baseSta = p.stats.sta;
+
+    drink(sim, pid, 'elixir_of_the_boar');
+    for (let i = 0; i < 20 * 5; i++) sim.tick(); // tick the Boar buff down ~5s
+    drink(sim, pid, 'elixir_of_the_bear');
+
+    const auras = staAuras(p);
+    expect(auras.length).toBe(1);
+    expect(auras[0].value).toBe(12);
+    expect(auras[0].name).toBe('Might of the Bear');
+    expect(auras[0].remaining, "Bear's own 900s timer, not Boar's").toBeGreaterThan(890);
+    expect(p.stats.sta).toBe(baseSta + 12);
+  });
+
+  it('ladder down: Bear then Boar is one aura at +6 (classic overwrite, weaker wins)', () => {
+    const { sim, pid, p } = playerWorld();
+    const baseSta = p.stats.sta;
+
+    drink(sim, pid, 'elixir_of_the_bear');
+    drink(sim, pid, 'elixir_of_the_boar');
+
+    const auras = staAuras(p);
+    expect(auras.length).toBe(1);
+    expect(auras[0].value).toBe(6);
+    expect(auras[0].name).toBe('Might of the Boar');
+    expect(p.stats.sta).toBe(baseSta + 6);
+  });
+
+  it('a percent stamina class buff (Fortitude-shaped) stacks with an elixir', () => {
+    const { sim, pid, p } = playerWorld();
+    const baseSta = p.stats.sta;
+
+    drink(sim, pid, 'elixir_of_the_bear');
+    applyAuraOn(sim, p, {
+      id: 'power_word_fortitude',
+      name: 'Power Word: Fortitude',
+      kind: 'buff_sta_pct',
+      remaining: 1800,
+      duration: 1800,
+      value: 10,
+      sourceId: p.id,
+      school: 'holy',
+    } as Aura);
+
+    expect(p.auras.some((a) => a.id === 'elixir_buff_sta')).toBe(true);
+    expect(p.auras.some((a) => a.id === 'power_word_fortitude')).toBe(true);
+    expect(p.stats.sta, 'flat elixir then +10% fold').toBe(Math.round((baseSta + 12) * 1.1));
+  });
+
+  it('a negative buff_sta drain debuff and an elixir coexist in both orders', () => {
+    const drain: Omit<Aura, 'sourceId'> = {
+      id: 'enervate_test_mob',
+      name: 'Enervate',
+      kind: 'buff_sta',
+      remaining: 30,
+      duration: 30,
+      value: -5,
+      school: 'shadow',
+    } as Omit<Aura, 'sourceId'>;
+
+    // Drain first, then drink: the elixir must not displace the debuff.
+    {
+      const { sim, pid, p } = playerWorld();
+      const baseSta = p.stats.sta;
+      applyAuraOn(sim, p, { ...drain, sourceId: 999999 } as Aura);
+      drink(sim, pid, 'elixir_of_the_bear');
+      expect(p.auras.some((a) => a.id === 'enervate_test_mob')).toBe(true);
+      expect(p.auras.some((a) => a.id === 'elixir_buff_sta')).toBe(true);
+      expect(p.stats.sta).toBe(baseSta + 12 - 5);
+    }
+
+    // Drink first, then the drain lands: the debuff must not displace the elixir.
+    {
+      const { sim, pid, p } = playerWorld();
+      const baseSta = p.stats.sta;
+      drink(sim, pid, 'elixir_of_the_bear');
+      applyAuraOn(sim, p, { ...drain, sourceId: 999999 } as Aura);
+      expect(p.auras.some((a) => a.id === 'elixir_buff_sta')).toBe(true);
+      expect(p.auras.some((a) => a.id === 'enervate_test_mob')).toBe(true);
+      expect(p.stats.sta).toBe(baseSta + 12 - 5);
+    }
+  });
+
+  it('every elixir item in the catalog maps to the shared per-kind aura id', () => {
+    // Content-shape pin: a future fifth stamina elixir lands in this loop
+    // automatically and cannot silently reintroduce per-item stacking.
+    const elixirs = Object.values(ITEMS).filter((d) => d.kind === 'elixir');
+    const staElixirIds = elixirs
+      .filter((d) => d.elixir?.kind === 'buff_sta')
+      .map((d) => d.id)
+      .sort();
+    expect(staElixirIds).toEqual([
+      'elixir_of_the_bear',
+      'elixir_of_the_boar',
+      'elixir_of_the_serpent',
+      'venomfire_elixir',
+    ]);
+    for (const def of elixirs) {
+      const { sim, pid, p } = playerWorld();
+      drink(sim, pid, def.id);
+      const aura = p.auras.find((a) => a.id === `elixir_${def.elixir!.kind}`);
+      expect(aura, `${def.id} applies the shared elixir_${def.elixir!.kind} aura`).toBeTruthy();
+      expect(aura!.value, def.id).toBe(def.elixir!.value);
+    }
   });
 });

--- a/tests/items.test.ts
+++ b/tests/items.test.ts
@@ -168,7 +168,10 @@ describe('items.useItem', () => {
     sim.addItem('elixir_of_the_bear', 1, pid);
 
     items.useItem(ctx, 'elixir_of_the_bear', pid);
-    expect(p.auras.some((a) => a.id === 'elixir_elixir_of_the_bear')).toBe(true);
+    const aura = p.auras.find((a) => a.id === 'elixir_buff_sta');
+    expect(aura).toBeTruthy();
+    expect(aura!.kind).toBe('buff_sta');
+    expect(aura!.value).toBe(12);
     expect(sim.countItem('elixir_of_the_bear', pid)).toBe(0);
   });
 

--- a/tests/ladder_crafting.test.ts
+++ b/tests/ladder_crafting.test.ts
@@ -160,7 +160,7 @@ describe('crafted elixir defs and the live use path', () => {
       sim.addItem(id, 1, pid);
       sim.useItem(id, pid);
       const p = (sim as any).entities.get(pid);
-      const aura = p.auras.find((a: { id: string }) => a.id === `elixir_${id}`);
+      const aura = p.auras.find((a: { id: string }) => a.id === 'elixir_buff_sta');
       expect(aura, `${id} aura applied`).toBeTruthy();
       expect(aura.kind).toBe('buff_sta');
       expect(aura.value).toBe(expected.value);

--- a/tests/parity/golden/inventory_vendor.json
+++ b/tests/parity/golden/inventory_vendor.json
@@ -1085,7 +1085,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 416,
-      "state": "7a2cf236",
+      "state": "47b62c32",
       "events": "700fff02",
       "rng": {
         "draws": 0,
@@ -1180,7 +1180,7 @@
             },
             {
               "duration": 900,
-              "id": "elixir_elixir_of_the_bear",
+              "id": "elixir_buff_sta",
               "kind": "buff_sta",
               "name": "Might of the Bear",
               "remaining": 900,
@@ -1257,7 +1257,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 416,
-      "state": "8e0056f3",
+      "state": "ffba8687",
       "events": "5917907c",
       "rng": {
         "draws": 0,
@@ -1357,7 +1357,7 @@
             },
             {
               "duration": 900,
-              "id": "elixir_elixir_of_the_bear",
+              "id": "elixir_buff_sta",
               "kind": "buff_sta",
               "name": "Might of the Bear",
               "remaining": 900,
@@ -1434,7 +1434,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 416,
-      "state": "eb860be0",
+      "state": "1df65594",
       "events": "43fbfed4",
       "rng": {
         "draws": 0,
@@ -1540,7 +1540,7 @@
             },
             {
               "duration": 900,
-              "id": "elixir_elixir_of_the_bear",
+              "id": "elixir_buff_sta",
               "kind": "buff_sta",
               "name": "Might of the Bear",
               "remaining": 900,
@@ -1617,7 +1617,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 416,
-      "state": "dd2834f7",
+      "state": "40c47e9b",
       "events": "a5ebc92c",
       "rng": {
         "draws": 0,
@@ -1728,7 +1728,7 @@
             },
             {
               "duration": 900,
-              "id": "elixir_elixir_of_the_bear",
+              "id": "elixir_buff_sta",
               "kind": "buff_sta",
               "name": "Might of the Bear",
               "remaining": 900,
@@ -1805,7 +1805,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 416,
-      "state": "e3bba7b2",
+      "state": "1410de4e",
       "events": "6787cd59",
       "rng": {
         "draws": 0,
@@ -1912,7 +1912,7 @@
             },
             {
               "duration": 900,
-              "id": "elixir_elixir_of_the_bear",
+              "id": "elixir_buff_sta",
               "kind": "buff_sta",
               "name": "Might of the Bear",
               "remaining": 900,
@@ -1989,7 +1989,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 416,
-      "state": "e3bba7b2",
+      "state": "1410de4e",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -2096,7 +2096,7 @@
             },
             {
               "duration": 900,
-              "id": "elixir_elixir_of_the_bear",
+              "id": "elixir_buff_sta",
               "kind": "buff_sta",
               "name": "Might of the Bear",
               "remaining": 900,

--- a/tests/parity/golden/inventory_vendor.json
+++ b/tests/parity/golden/inventory_vendor.json
@@ -1257,7 +1257,183 @@
       "tick": 0,
       "time": 0,
       "nextId": 416,
-      "state": "ffba8687",
+      "state": "5e8369a7",
+      "events": "0d8a0109",
+      "rng": {
+        "draws": 0,
+        "digest": "811c9dc5"
+      },
+      "label": "quaffed-second-elixir",
+      "players": [
+        {
+          "activeLoadout": -1,
+          "archetype": {},
+          "arena2v2Rating": 1500,
+          "arenaRating": 1500,
+          "bags": [
+            null,
+            null,
+            null,
+            null
+          ],
+          "bank": {},
+          "cls": "warrior",
+          "companionUpgrades": {},
+          "copper": 710,
+          "counters": {},
+          "craftSkills": {},
+          "craftThrottle": {},
+          "deedStats": {
+            "counters": {},
+            "dungeonClears": {},
+            "itemsDiscovered": [
+              "baked_bread",
+              "cryptbone_helm",
+              "eastbrook_buckler",
+              "elixir_of_the_bear",
+              "elixir_of_the_serpent",
+              "minor_healing_potion",
+              "recruit_tunic",
+              "roadwardens_helm",
+              "spring_water",
+              "worn_sword"
+            ],
+            "visited": [
+              "quality:rare"
+            ]
+          },
+          "delveClears": {},
+          "delveDaily": {},
+          "entityId": 415,
+          "equipment": {
+            "chest": "recruit_tunic",
+            "mainhand": "worn_sword",
+            "offhand": "eastbrook_buckler"
+          },
+          "equipmentInstance": {},
+          "gatheringProficiency": {},
+          "heroicDaily": {},
+          "inventory": [
+            {
+              "count": 9,
+              "itemId": "baked_bread"
+            },
+            {
+              "count": 4,
+              "itemId": "spring_water"
+            },
+            {
+              "count": 1,
+              "itemId": "cryptbone_helm"
+            },
+            {
+              "count": 1,
+              "itemId": "roadwardens_helm"
+            }
+          ],
+          "mailWelcomed": true,
+          "nodeHarvestReadyAt": {},
+          "recipesGrandfathered": true,
+          "talents": {
+            "rows": {}
+          },
+          "townFocus": {}
+        }
+      ],
+      "entities": [
+        {
+          "aiState": "idle",
+          "attackPower": 46,
+          "auras": [
+            {
+              "duration": 3600,
+              "id": "battle_stance",
+              "kind": "battle_stance",
+              "name": "Battle Stance",
+              "remaining": 3600,
+              "school": "physical",
+              "sourceId": 415
+            },
+            {
+              "duration": 900,
+              "id": "elixir_buff_sta",
+              "kind": "buff_sta",
+              "name": "Might of the Serpent",
+              "remaining": 900,
+              "school": "nature",
+              "sourceId": 415,
+              "value": 12
+            }
+          ],
+          "blockChance": 0.05,
+          "blockValue": 6,
+          "combatTimer": 99,
+          "comboUntil": -1,
+          "critChance": 0.06,
+          "detonateTimer": "Infinity",
+          "dodgeChance": 0.06,
+          "drinking": {
+            "itemId": "spring_water",
+            "kind": "drink",
+            "manaPer2s": 8,
+            "remaining": 18
+          },
+          "eating": {
+            "hpPer2s": 7,
+            "itemId": "baked_bread",
+            "kind": "food",
+            "remaining": 18
+          },
+          "fallStartY": 1.5,
+          "fiveSecondRule": 99,
+          "hp": 220,
+          "id": 415,
+          "kind": "player",
+          "level": 1,
+          "lootFfaTimer": "Infinity",
+          "maxHp": 220,
+          "maxResource": 100,
+          "moveSpeed": 7,
+          "offhandItemId": "eastbrook_buckler",
+          "onGround": true,
+          "overpowerUntil": -1,
+          "petMode": "defensive",
+          "pos": {
+            "x": -5.125851,
+            "y": 1.5,
+            "z": 0.812357
+          },
+          "potionCooldownUntil": 120,
+          "resourceType": "rage",
+          "sitting": true,
+          "spawnPos": {
+            "x": 2,
+            "y": 1.5,
+            "z": -2
+          },
+          "spellPower": 5,
+          "stats": {
+            "agi": 20,
+            "armor": 144,
+            "int": 10,
+            "spi": 11,
+            "sta": 35,
+            "str": 23
+          },
+          "templateId": "warrior",
+          "weapon": {
+            "max": 5,
+            "min": 2,
+            "speed": 2
+          }
+        }
+      ]
+    },
+    {
+      "tick": 0,
+      "time": 0,
+      "nextId": 416,
+      "state": "4db9ec82",
       "events": "5917907c",
       "rng": {
         "draws": 0,
@@ -1291,12 +1467,16 @@
               "cryptbone_helm",
               "eastbrook_buckler",
               "elixir_of_the_bear",
+              "elixir_of_the_serpent",
               "minor_healing_potion",
               "recruit_tunic",
               "roadwardens_helm",
               "spring_water",
               "wolf_fang",
               "worn_sword"
+            ],
+            "visited": [
+              "quality:rare"
             ]
           },
           "delveClears": {},
@@ -1359,7 +1539,7 @@
               "duration": 900,
               "id": "elixir_buff_sta",
               "kind": "buff_sta",
-              "name": "Might of the Bear",
+              "name": "Might of the Serpent",
               "remaining": 900,
               "school": "nature",
               "sourceId": 415,
@@ -1434,7 +1614,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 416,
-      "state": "1df65594",
+      "state": "6666c937",
       "events": "43fbfed4",
       "rng": {
         "draws": 0,
@@ -1468,12 +1648,16 @@
               "cryptbone_helm",
               "eastbrook_buckler",
               "elixir_of_the_bear",
+              "elixir_of_the_serpent",
               "minor_healing_potion",
               "recruit_tunic",
               "roadwardens_helm",
               "spring_water",
               "wolf_fang",
               "worn_sword"
+            ],
+            "visited": [
+              "quality:rare"
             ]
           },
           "delveClears": {},
@@ -1542,7 +1726,7 @@
               "duration": 900,
               "id": "elixir_buff_sta",
               "kind": "buff_sta",
-              "name": "Might of the Bear",
+              "name": "Might of the Serpent",
               "remaining": 900,
               "school": "nature",
               "sourceId": 415,
@@ -1617,7 +1801,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 416,
-      "state": "40c47e9b",
+      "state": "561f2654",
       "events": "a5ebc92c",
       "rng": {
         "draws": 0,
@@ -1652,12 +1836,16 @@
               "cryptbone_helm",
               "eastbrook_buckler",
               "elixir_of_the_bear",
+              "elixir_of_the_serpent",
               "minor_healing_potion",
               "recruit_tunic",
               "roadwardens_helm",
               "spring_water",
               "wolf_fang",
               "worn_sword"
+            ],
+            "visited": [
+              "quality:rare"
             ]
           },
           "delveClears": {},
@@ -1730,7 +1918,7 @@
               "duration": 900,
               "id": "elixir_buff_sta",
               "kind": "buff_sta",
-              "name": "Might of the Bear",
+              "name": "Might of the Serpent",
               "remaining": 900,
               "school": "nature",
               "sourceId": 415,
@@ -1805,7 +1993,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 416,
-      "state": "1410de4e",
+      "state": "9fb63795",
       "events": "6787cd59",
       "rng": {
         "draws": 0,
@@ -1840,12 +2028,16 @@
               "cryptbone_helm",
               "eastbrook_buckler",
               "elixir_of_the_bear",
+              "elixir_of_the_serpent",
               "minor_healing_potion",
               "recruit_tunic",
               "roadwardens_helm",
               "spring_water",
               "wolf_fang",
               "worn_sword"
+            ],
+            "visited": [
+              "quality:rare"
             ]
           },
           "delveClears": {},
@@ -1914,7 +2106,7 @@
               "duration": 900,
               "id": "elixir_buff_sta",
               "kind": "buff_sta",
-              "name": "Might of the Bear",
+              "name": "Might of the Serpent",
               "remaining": 900,
               "school": "nature",
               "sourceId": 415,
@@ -1989,7 +2181,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 416,
-      "state": "1410de4e",
+      "state": "9fb63795",
       "events": "741638a5",
       "rng": {
         "draws": 0,
@@ -2024,12 +2216,16 @@
               "cryptbone_helm",
               "eastbrook_buckler",
               "elixir_of_the_bear",
+              "elixir_of_the_serpent",
               "minor_healing_potion",
               "recruit_tunic",
               "roadwardens_helm",
               "spring_water",
               "wolf_fang",
               "worn_sword"
+            ],
+            "visited": [
+              "quality:rare"
             ]
           },
           "delveClears": {},
@@ -2098,7 +2294,7 @@
               "duration": 900,
               "id": "elixir_buff_sta",
               "kind": "buff_sta",
-              "name": "Might of the Bear",
+              "name": "Might of the Serpent",
               "remaining": 900,
               "school": "nature",
               "sourceId": 415,

--- a/tests/parity/scenarios.ts
+++ b/tests/parity/scenarios.ts
@@ -3981,6 +3981,12 @@ function inventoryVendor(): Scenario {
       sim.addItem('elixir_of_the_bear', 1, buyer);
       sim.useItem('elixir_of_the_bear', buyer);
       rec.snapshot('quaffed-elixir');
+      // A second same-stat elixir pins the per-kind exclusivity path (the
+      // shared elixir_buff_sta id replaces the Bear aura, last drunk wins,
+      // plus the fade event for the displaced different-name aura).
+      sim.addItem('elixir_of_the_serpent', 1, buyer);
+      sim.useItem('elixir_of_the_serpent', buyer);
+      rec.snapshot('quaffed-second-elixir');
 
       // 5) discard one of a gray stack.
       sim.addItem('wolf_fang', 3, buyer);


### PR DESCRIPTION
## Summary

All four stamina elixirs stack today: Elixir of the Boar (+6), Vipersear Elixir (+9), Elixir of the Bear (+12), and Elixir of the Serpent (+12) all grant the `buff_sta` buff kind, but the elixir use path applied an aura with a per-item id (`elixir_<itemId>`). Four items, four distinct ids, nothing conflicts, so a player can drink all four for +39 Stamina, roughly 390 extra HP at the level-20 budget. They are authored as one alchemy ladder for one effect, not four independent buffs.

The fix derives the aura id from the elixir's EFFECT kind instead of the item: all four stamina elixirs now share `elixir_buff_sta`, so the existing same-id same-source replacement in `applyAura` enforces exclusivity with zero new machinery. Semantics, stated plainly: elixirs are exclusive per buff kind and the last drink wins, including downgrades (classic overwrite; drinking a Boar over a Bear leaves you at +6). Same-item re-drinking refreshes exactly as before. Class buffs are unaffected (a `buff_sta_pct` buff like Power Word: Fortitude still stacks with an elixir), and the mob stamina-drain debuffs (`enervate_*` / `plague_*`, negative `buff_sta` on their own ids) are neither displaced by an elixir nor displace one; both coexistences are pinned in tests, in both application orders.

One adjacent fix that review surfaced: this change creates the first same-id replacement whose displaced aura has a different display name, and `applyAura` emitted no fade event for it, so the Bear icon would vanish from the buff bar with no combat-log trace when a Serpent overwrote it. The replacement loop now emits `gained: false` for a displaced aura whose name differs from the incoming one. Same-name refreshes stay silent, so no other event stream changes (verified: no other parity golden moved).

Aura persistence: checked rather than assumed. `CharacterState` carries no aura list (the only aura-derived field is the resurrection-sickness remaining time), so elixir buffs are session-transient, no stale per-item ids can load from the database, and no migration is needed.

Determinism: the elixir path draws no rng, and the re-minted parity golden proves neutrality: across both re-mints, no pre-existing frame's rng block or events digest moved, only the sampled aura id and the folded state digests.

Two notes for the maintainer, flagged by review, deliberately not acted on here: with exclusivity in force the rare Serpent (+12/900s) is now functionally identical to the uncommon Bear (+12/900s), and Boar/Vipersear are strictly dominated while an elixir is active; the values are untouched per the no-invented-balance rule, but the ladder may deserve a differentiation pass. And "weaker wins on downgrade" is pinned as decided; the later-era "a more powerful spell is already active" protection would be a separate design call.

## Type of change

- [x] Bug fix

## How was this tested?

Test-first: the reproduction was written before the fix and failed red on the unfixed code with `expected 2 to be 1` (two stacked stamina elixir auras), going green only with the fix.

New and updated coverage in `tests/elixir.test.ts` (all asserting recalculated `stats.sta` / `maxHp` on the player entity, not just the aura list):

- Bear then Serpent: exactly one `buff_sta` elixir aura, +12 not +24, HP pool unchanged from one elixir.
- Ladder up (Boar then Bear): one aura, +12, Bear's own 900s timer.
- Ladder down (Bear then Boar): one aura, +6, pinning the decided last-wins semantics.
- Same-item refresh (Bear then Bear): one aura, +12, timer reset (pre-existing test, id updated).
- Fortitude-shaped `buff_sta_pct` aura and an elixir both apply and both contribute (`round((base + 12) * 1.1)`).
- A negative `buff_sta` drain debuff and an elixir coexist in both orders, stats reflect `+12 - 5`.
- Fade-event fidelity: displacing a different-name elixir emits its `gained: false` event; a same-item refresh emits none.
- Catalog shape pin over `ITEMS`: the exact set of four `buff_sta` elixir ids, plus a loop driving every elixir item through the live use path and asserting it lands on the shared `elixir_<kind>` id, so a future fifth stamina elixir cannot silently reintroduce the bug.

The `inventory_vendor` parity scenario now drinks a second same-stat elixir so the exclusivity path and the fade event are pinned cross-host; both golden re-mints are separate `UPDATE_PARITY=1` commits whose structural diffs show unchanged rng and event digests on all pre-existing frames.

- Commands:
  - `npx vitest run tests/elixir.test.ts tests/items.test.ts tests/ladder_crafting.test.ts tests/architecture.test.ts` (green, 64 tests)
  - `npx vitest run tests/parity` (green, 183 passed)
  - `npm run gate`: fails only at the vitest step on 2 tests in `tests/deploy_watchdog.test.ts` (docker-shim timeout assertions), a known sandbox flake independently confirmed to fail identically on the untouched base. Per the documented fallback, all three follow-ups were run directly on the final tree and are green: `npx vitest run --exclude tests/deploy_watchdog.test.ts --maxWorkers=6` (1561 files, 19520 tests passed), `npx tsc --noEmit` (clean), `npm run build` (exit 0, all five entries). Every other gate step (i18n gen + freshness, malware scan, changed-files biome, sfx conformance) passed before the vitest step.
- Manual steps: none needed beyond the automated coverage; the change is a single sim path shared by all three hosts, with no wire, IWorld, UI, or persistence surface.

## Screenshots / recordings

N/A: no visual change beyond one fewer buff icon when a second same-stat elixir is drunk (the intended fix). Icons resolve from the aura kind and names are unchanged, so the buff bar renders identically otherwise.

---

## Checklist

### Quality

- [x] **The full gate passes** modulo the pre-existing `tests/deploy_watchdog.test.ts` sandbox flake documented above; decisive tests added for all changed behavior.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI change.
- ~Accessible.~ N/A: no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. Aura display names are unchanged data; the sim i18n matcher keys on those names, and `npx vitest run tests/localization_fixes.test.ts` passes.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] No generated files hand-edited; the parity goldens were re-minted via `UPDATE_PARITY=1` in their own reviewed commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
