### PR TITLE
fix(sim): arena fight start keeps a valid countdown target

### DIFF
--- a/src/sim/sim_context.ts
+++ b/src/sim/sim_context.ts
@@ -334,6 +334,8 @@ export interface SimContextCallbacks {
   updateFiestaActive(match: ArenaMatch): void;
   fiestaRestoreChar(meta: PlayerMeta, e: Entity): void;
   clearFiestaAugments(meta: PlayerMeta, e: Entity): void;
+  // Deliberately narrower than the module function, which also takes
+  // keepValidTargetPids (fight-start target retention); no ctx caller needs it.
   readyArenaFighter(e: Entity, opts: { clearPrep: boolean }): void;
   resetForArena(e: Entity): void;
   isArenaTeamWiped(match: ArenaMatch, team: 'A' | 'B'): boolean;

--- a/src/sim/social/arena.ts
+++ b/src/sim/social/arena.ts
@@ -4,6 +4,9 @@
 // order, the matchmaking guard loops, the ~28-field fighter reset, and the
 // player-facing emit literals are preserved EXACTLY (the parity gate's full-state
 // trace + rng draw-order log proves it).
+// Post-move sanctioned deviation: readyArenaFighter's targetId reset is
+// conditional at the countdown-end call site (keepValidTargetPids); see the
+// comment at that field.
 //
 // Arena/duel state stays on Sim and is reached through SimContext live views
 // (`arenaMatches` from E1; `arenaQueue1v1`/`arenaQueue2v2`/`arenaQueueFiesta`/
@@ -911,6 +914,9 @@ export function readyArenaFighter(
   // keepValidTargetPids, so a selection made during prep survives the gates
   // opening iff it points at a current fighter of this match. Every other
   // reset (match creation, Fiesta/Yumi respawns) still clears the selection.
+  // Retention is by player pid only (a Protect Yumi cat familiar is
+  // deliberately out of scope), and a kept target can never be dead: every
+  // kept pid is a fighter revived by this same countdown-end loop.
   e.targetId =
     e.targetId !== null && opts.keepValidTargetPids?.includes(e.targetId) ? e.targetId : null;
   e.autoAttack = false;

--- a/src/sim/social/arena.ts
+++ b/src/sim/social/arena.ts
@@ -561,7 +561,9 @@ export function updateArena(ctx: SimContext): void {
       if (match.timer <= 0) {
         match.state = 'active';
         match.timer = 0;
-        for (const e of fighters) readyArenaFighter(ctx, e, { clearPrep: false });
+        const matchPids = arenaAllPids(match);
+        for (const e of fighters)
+          readyArenaFighter(ctx, e, { clearPrep: false, keepValidTargetPids: matchPids });
         for (const mPid of arenaAllPids(match)) {
           ctx.emit({
             type: 'log',
@@ -884,7 +886,11 @@ export function resetForArena(ctx: SimContext, e: Entity): void {
   readyArenaFighter(ctx, e, { clearPrep: true });
 }
 
-export function readyArenaFighter(ctx: SimContext, e: Entity, opts: { clearPrep: boolean }): void {
+export function readyArenaFighter(
+  ctx: SimContext,
+  e: Entity,
+  opts: { clearPrep: boolean; keepValidTargetPids?: readonly number[] },
+): void {
   e.dead = false;
   if (opts.clearPrep) {
     // Arena is a clean competitive slate: unlike the overworld/delve death paths it
@@ -900,7 +906,13 @@ export function readyArenaFighter(ctx: SimContext, e: Entity, opts: { clearPrep:
     recalcPlayerStats(e, meta.cls, meta.equipment, ctx.playerMods(meta), meta.equipmentInstance);
   e.hp = e.maxHp;
   e.resource = e.resourceType === 'mana' ? e.maxResource : e.resourceType === 'energy' ? 100 : 0;
-  e.targetId = null;
+  // Target retention is a separate concern from clearPrep (clean slate vs
+  // fight-start top-off): only the countdown-end call site passes
+  // keepValidTargetPids, so a selection made during prep survives the gates
+  // opening iff it points at a current fighter of this match. Every other
+  // reset (match creation, Fiesta/Yumi respawns) still clears the selection.
+  e.targetId =
+    e.targetId !== null && opts.keepValidTargetPids?.includes(e.targetId) ? e.targetId : null;
   e.autoAttack = false;
   // Drop any held movement intent so a fighter placed/respawned into the arena does
   // not drift from a stale forward/back flag with no key held (issue 1651); bots

--- a/tests/arena.test.ts
+++ b/tests/arena.test.ts
@@ -221,6 +221,17 @@ describe('arena: a full bout', () => {
     expect(sim.entities.get(a)!.autoAttack).toBe(false);
   });
 
+  it('a self-target made during the countdown also survives the fight-start reset', () => {
+    const { sim, a } = queueDuo();
+    sim.targetEntity(a, a);
+    expect(sim.entities.get(a)!.targetId).toBe(a);
+
+    startBout(sim);
+
+    expect(sim.arenaMatchFor(a)!.state).toBe('active');
+    expect(sim.entities.get(a)!.targetId).toBe(a);
+  });
+
   it('resets a target pointing outside the match to null at fight start', () => {
     const { sim, a } = queueDuo();
     const outsider = sim.addPlayer('rogue', 'Gimel');

--- a/tests/arena.test.ts
+++ b/tests/arena.test.ts
@@ -207,6 +207,73 @@ describe('arena: a full bout', () => {
     expect(sim.entities.get(a)!.targetId).toBe(b);
   });
 
+  it('keeps an opponent targeted during the countdown across the fight-start reset', () => {
+    const { sim, a, b } = queueDuo();
+    expect(sim.arenaMatchFor(a)!.state).toBe('countdown');
+    sim.targetEntity(b, a);
+    expect(sim.entities.get(a)!.targetId).toBe(b);
+
+    startBout(sim);
+
+    expect(sim.arenaMatchFor(a)!.state).toBe('active');
+    expect(sim.entities.get(a)!.targetId).toBe(b);
+    // only the selection persists: auto-attack still starts off at the gates
+    expect(sim.entities.get(a)!.autoAttack).toBe(false);
+  });
+
+  it('resets a target pointing outside the match to null at fight start', () => {
+    const { sim, a } = queueDuo();
+    const outsider = sim.addPlayer('rogue', 'Gimel');
+    expect(sim.arenaMatchFor(a)!.state).toBe('countdown');
+    sim.entities.get(a)!.targetId = outsider;
+
+    startBout(sim);
+
+    expect(sim.arenaMatchFor(a)!.state).toBe('active');
+    expect(sim.entities.get(a)!.targetId).toBe(null);
+  });
+
+  it('a fighter with no target during the countdown still starts the fight untargeted', () => {
+    const { sim, a } = queueDuo();
+    expect(sim.entities.get(a)!.targetId).toBe(null);
+
+    startBout(sim);
+
+    expect(sim.arenaMatchFor(a)!.state).toBe('active');
+    expect(sim.entities.get(a)!.targetId).toBe(null);
+  });
+
+  it('the match-creation reset still clears a target carried into the arena', () => {
+    const { sim, a } = queueDuo('warrior', 'mage', (sim, a, b) => {
+      sim.entities.get(a)!.targetId = b;
+    });
+    expect(sim.arenaMatchFor(a)!.state).toBe('countdown');
+    expect(sim.entities.get(a)!.targetId).toBe(null);
+  });
+
+  it('a 2v2 teammate target survives the fight-start reset', () => {
+    const sim = makeWorld();
+    const classes: PlayerClass[] = ['warrior', 'mage', 'rogue', 'priest'];
+    const names = ['Aleph', 'Bet', 'Gimel', 'Dalet'];
+    const pids = classes.map((cls, i) => sim.addPlayer(cls, names[i]));
+    pids.forEach((pid, i) => {
+      teleport(sim, pid, i * 3, -40);
+    });
+    for (const pid of pids) sim.arenaQueueJoin(pid, '2v2');
+    sim.tick(); // matchmake seats the four solos into one 2v2 match
+    const match = sim.arenaMatchFor(pids[0])!;
+    expect(match.format).toBe('2v2');
+    expect(match.state).toBe('countdown');
+    const [me, mate] = match.teamA;
+    sim.targetEntity(mate, me);
+    expect(sim.entities.get(me)!.targetId).toBe(mate);
+
+    startBout(sim);
+
+    expect(match.state).toBe('active');
+    expect(sim.entities.get(me)!.targetId).toBe(mate);
+  });
+
   it('does not cancel auto-attack when retargeting an active arena opponent', () => {
     const { sim, a, b } = queueDuo();
     startBout(sim);

--- a/tests/fiesta.test.ts
+++ b/tests/fiesta.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { Sim } from '../src/sim/sim';
-import { groundHeight } from '../src/sim/world';
+import {
+  AUGMENTS,
+  AUGMENTS_BY_ID,
+  eligibleAugments,
+  tierForWave,
+} from '../src/sim/content/augments';
 import { arenaOrigin } from '../src/sim/data';
-import { AUGMENTS, AUGMENTS_BY_ID, eligibleAugments, tierForWave } from '../src/sim/content/augments';
+import { Sim } from '../src/sim/sim';
 import type { PlayerClass } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
 
 function makeWorld() {
   return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
@@ -11,7 +16,8 @@ function makeWorld() {
 
 function teleport(sim: Sim, pid: number, x: number, z: number) {
   const e = sim.entities.get(pid)!;
-  e.pos.x = x; e.pos.z = z;
+  e.pos.x = x;
+  e.pos.z = z;
   e.pos.y = groundHeight(x, z, sim.cfg.seed);
   e.prevPos = { ...e.pos };
   (sim as any).rebucket(e);
@@ -22,8 +28,12 @@ function teleport(sim: Sim, pid: number, x: number, z: number) {
 function startFiesta(classes: PlayerClass[] = ['warrior', 'mage', 'rogue', 'priest']) {
   const sim = makeWorld();
   const pids = classes.map((c, i) => sim.addPlayer(c, `P${i}`));
-  pids.forEach((p, i) => teleport(sim, p, i * 4, -40));
-  pids.forEach((p) => sim.arenaQueueJoin(p, 'fiesta'));
+  pids.forEach((p, i) => {
+    teleport(sim, p, i * 4, -40);
+  });
+  pids.forEach((p) => {
+    sim.arenaQueueJoin(p, 'fiesta');
+  });
   sim.tick(); // matchmake
   for (let i = 0; i < 20 * 8; i++) {
     sim.tick();
@@ -69,11 +79,39 @@ describe('fiesta: scoring & respawn', () => {
     expect(victim.dead).toBe(true);
 
     // The victim should NOT be permanently eliminated — they revive on their timer.
+    // The respawn reset is a clean slate: a held selection does not survive it
+    // (only the countdown-end fight-start reset retains a valid target).
+    victim.targetId = killerPid;
     const downedFor = match.fiesta!.respawn.get(victimPid)!;
     for (let i = 0; i < Math.ceil(downedFor * 20) + 5; i++) sim.tick();
     expect(match.fiesta!.respawn.has(victimPid)).toBe(false);
     expect(sim.entities.get(victimPid)!.dead).toBe(false);
     expect(sim.entities.get(victimPid)!.hp).toBeGreaterThan(0);
+    expect(sim.entities.get(victimPid)!.targetId).toBe(null);
+  });
+
+  it('keeps a cross-team target selected during the countdown when the fiesta goes live', () => {
+    const sim = makeWorld();
+    const classes: PlayerClass[] = ['warrior', 'mage', 'rogue', 'priest'];
+    const pids = classes.map((c, i) => sim.addPlayer(c, `P${i}`));
+    pids.forEach((p, i) => {
+      teleport(sim, p, i * 4, -40);
+    });
+    pids.forEach((p) => {
+      sim.arenaQueueJoin(p, 'fiesta');
+    });
+    sim.tick(); // matchmake
+    const match = sim.arenaMatchFor(pids[0])!;
+    expect(match.state).toBe('countdown');
+    const me = match.teamA[0];
+    const opp = match.teamB[0];
+    sim.targetEntity(opp, me);
+    expect(sim.entities.get(me)!.targetId).toBe(opp);
+
+    for (let i = 0; i < 20 * 8 && match.state !== 'active'; i++) sim.tick();
+
+    expect(match.state).toBe('active');
+    expect(sim.entities.get(me)!.targetId).toBe(opp);
   });
 
   it('respawn timers grow with each death', () => {
@@ -186,11 +224,17 @@ describe('fiesta: augments', () => {
 
   it('standardizes every fighter to level 20 with a balanced build, restoring after', () => {
     const sim = new Sim({ seed: 5, playerClass: 'warrior', noPlayer: true });
-    const pids = (['warrior', 'mage', 'rogue', 'priest'] as const).map((c, i) => sim.addPlayer(c, `P${i}`));
+    const pids = (['warrior', 'mage', 'rogue', 'priest'] as const).map((c, i) =>
+      sim.addPlayer(c, `P${i}`),
+    );
     // Pretend everyone walked in at level 8.
     for (const p of pids) sim.setPlayerLevel(8, p);
-    pids.forEach((p) => teleport(sim, p, pids.indexOf(p) * 4, -40));
-    pids.forEach((p) => sim.arenaQueueJoin(p, 'fiesta'));
+    pids.forEach((p) => {
+      teleport(sim, p, pids.indexOf(p) * 4, -40);
+    });
+    pids.forEach((p) => {
+      sim.arenaQueueJoin(p, 'fiesta');
+    });
     sim.tick();
     for (const p of pids) expect(sim.entities.get(p)!.level).toBe(20);
     // Persistence safety: serialize must report the ORIGINAL level, not 20.
@@ -274,7 +318,10 @@ describe('fiesta: offline practice vs bots', () => {
     const run = () => {
       const sim = new Sim({ seed: 11, playerClass: 'mage' });
       sim.startFiestaPractice();
-      for (let i = 0; i < 20 * 30; i++) { sim.updateFiestaBots(); sim.tick(); }
+      for (let i = 0; i < 20 * 30; i++) {
+        sim.updateFiestaBots();
+        sim.tick();
+      }
       const m = sim.arenaMatchFor(sim.playerId);
       return m?.fiesta ? [m.fiesta.scoreA, m.fiesta.scoreB] : null;
     };
@@ -292,7 +339,17 @@ describe('fiesta: augment catalog integrity', () => {
   });
 
   it('every class can be offered three augments at every tier', () => {
-    const classes: PlayerClass[] = ['warrior', 'paladin', 'hunter', 'rogue', 'priest', 'shaman', 'mage', 'warlock', 'druid'];
+    const classes: PlayerClass[] = [
+      'warrior',
+      'paladin',
+      'hunter',
+      'rogue',
+      'priest',
+      'shaman',
+      'mage',
+      'warlock',
+      'druid',
+    ];
     for (const cls of classes) {
       for (const tier of ['silver', 'gold', 'prismatic'] as const) {
         // role null is the worst case (healer-only augments excluded)


### PR DESCRIPTION
## Summary

A fighter who targets their opponent during the arena countdown (the normal prep) is deselected at the exact moment the bout goes live and has to re-click their opponent under pressure. The 'Fight!' transition runs the same `readyArenaFighter` reset used at match creation, and that reset unconditionally set `e.targetId = null`, so the fight-start top-off (heal to full, clear auto-attack) also threw away the selection made during prep.

The fix separates the two concerns instead of keying off the existing `clearPrep` flag: `readyArenaFighter` gains an explicit `keepValidTargetPids?: readonly number[]` option, and only the countdown-end call site passes it (the `arenaAllPids(match)` set, threaded from the match at the call rather than a global lookup). Semantics, stated plainly:

- A selection made during the countdown survives the 'Fight!' transition iff it points at a current fighter of this match (opponent, 2v2 teammate, or self). Retention is by player pid only; a Protect Yumi cat familiar is deliberately out of scope.
- Anything else (an entity outside the match, a stale id, no target) resets to null exactly as today.
- The match-creation reset (`resetForArena`) and the Fiesta/Yumi respawn resets are untouched and still clear the target: a fresh teleport-in rightly starts untargeted.
- Auto-attack still starts off at the gates; only the selection persists, matching classic gates-open behavior.
- The shared countdown-end call site also serves Fiesta and Protect Yumi bouts, so their fight-start moment retains valid targets the same way (pinned by a fiesta test).

No rng draws, draw-order, tick-phase, or wire changes (`targetId` already ships on the existing wire fields, so the online host inherits the fix from the shared sim with no client edit). The parity goldens (`arena_1v1`, `arena_2v2_wipe`, the fiesta scenarios) pass unchanged; to be explicit, they stay green because no parity scenario targets during the countdown, not because the new branch is traced, so the behavior is pinned by the vitest suite instead. The module header records the sanctioned deviation from the file's move-not-rewrite parity claim, and the `SimContext` callback signature deliberately stays `{ clearPrep: boolean }` (documented at the declaration) since no ctx caller needs the new option.

Reviewed before submission by fresh `qa-checklist` and `architecture-reviewer` agents: zero blocking findings; their polish items (fiesta/respawn/self-target test arms, the header addendum, the seam-signature note) are addressed in the second commit.

## Type of change

- [x] Bug fix

## How was this tested?

Test-first: the retention tests were written before the fix and were red against the base (`targetId` came back `null` after the transition), then green after.

- Commands:
  - `npx vitest run tests/arena.test.ts` (49 passed; new tests: countdown opponent target survives the transition, self-target survives, out-of-match target resets to null, no-target stays none, match-creation reset still clears a carried-in target, 2v2 teammate target survives, auto-attack still off at fight start)
  - `npx vitest run tests/fiesta.test.ts` (19 passed; new arms: fiesta countdown target survives the fiesta fight start, the fiesta respawn reset still clears a held selection)
  - `npx vitest run tests/architecture.test.ts tests/parity/parity.test.ts tests/world_api_parity.test.ts tests/localization_fixes.test.ts tests/sim_context.test.ts tests/arena_module.test.ts tests/arena_respawn_intent.test.ts tests/yumi_match.test.ts` all green, parity goldens unchanged
  - `npm run gate`: the i18n gen + freshness, malware scan, changed-files biome, and sfx steps pass; the vitest step aborts on `tests/deploy_watchdog.test.ts`, a known sandbox flake in this environment (it fails identically on the pristine release/v0.30.0 base, no relation to this diff). Per that playbook: full `npx vitest run` excluding only that file is green (1569 files, 19660 tests), then `npx tsc --noEmit` clean and `npm run build` green, both run directly on the final tree.
- Manual steps: temporal behavior, verified through the offline sim tests above, which drive the real `Sim` through queue, countdown, and fight start; in-game the equivalent check is two clients (or one client plus a queued opponent), target the opponent while the countdown runs, and observe the target frame survive the 'Fight!' moment instead of clearing.

## Screenshots / recordings

N/A: sim + tests only, nothing visual changes (the target frame simply no longer clears at fight start).

---

## Checklist

### Quality

- [x] **The full gate passes.** Green except the pre-existing `deploy_watchdog` sandbox flake documented above; every other gate step, the full remaining suite, `tsc`, and all builds are green. Decisive tests added for the changed behavior.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A: no UI change.
- ~Accessible.~ N/A: no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
