### PR TITLE
fix(ui): repaint the bag money footer only when the Claudium balance moved

### DIFF
--- a/src/ui/claudium_launcher_balance_core.ts
+++ b/src/ui/claudium_launcher_balance_core.ts
@@ -1,0 +1,156 @@
+// The Claudium launcher's balance: the number the HUD holds, the throttled read
+// that keeps it fresh, and the changed-only edge that converges whatever surface
+// displays it. Extracted from the Hud coordinator (issues #2411, #2414).
+//
+// Host-agnostic on purpose: it owns no DOM, no hooks and no clock of its own. The
+// read, the wall clock and the converge callback all ride in as deps, so the
+// throttle arithmetic, the in-flight and stale-response guards, and above all the
+// changed-only converge are executed by unit tests instead of being pattern-matched
+// as source text inside the Hud coordinator.
+//
+// Why the converge lives HERE rather than at each call site: four separate paths
+// write a balance (the launcher's own read, the WOC Store snapshot, a store spend,
+// and the Claudium window's snapshot) and only one of them ever repainted. That
+// asymmetry is both bugs at once. Routing every write through set() gives the
+// display exactly one convergence seam (#2414), and comparing before the overwrite
+// gives it the elision key the sibling purse latch in BagsWindow already had
+// (#2411): a read that lands on the value already on screen costs nothing.
+
+/** Floor between two unforced balance reads. Interactions bypass it via force. */
+export const CLAUDIUM_BALANCE_THROTTLE_MS = 30_000;
+
+export interface ClaudiumLauncherBalanceDeps {
+  /** Whether the economy hooks are attached at all (online, and the service up).
+   *  Checked BEFORE read(), so a disabled launcher never starts a request. */
+  enabled: () => boolean;
+  /** The authoritative read. Called only once every gate below has passed, so it
+   *  is never invoked speculatively. */
+  read: () => Promise<number | null>;
+  /** Converge every surface that displays the balance. Called ONLY when the value
+   *  actually moved, and always AFTER the new value is readable, so the repaint it
+   *  triggers renders the fresh number. */
+  onChanged: () => void;
+  /** Wall clock, injected rather than read here: the module stays deterministic
+   *  given its deps (the src/ui pure-core rule the architecture guard enforces), and
+   *  the throttle is driven by a test-owned clock instead of fake timers over a
+   *  captured Date.now. */
+  now: () => number;
+}
+
+export class ClaudiumLauncherBalance {
+  /** The balance as last written. null means unknown, which the launcher renders
+   *  as '--' (the same glyph the Claudium window uses for an unknown amount). */
+  private value: number | null = null;
+  /** A read is in flight. Doubles as the re-entry guard: the converge callback
+   *  repaints a surface that reads the launcher label, and reading the label calls
+   *  refresh() again, so a resolve must not be able to start a second read. */
+  private pending = false;
+  /** When the value was last written, by a read OR by a store/window write. Both
+   *  defer the next unforced read: a balance that just arrived is fresh whatever
+   *  delivered it. */
+  private lastWriteAt = 0;
+  /** Monotonic read id. A response whose id is no longer current lost a race (a
+   *  forced read overtook it, or reset() invalidated it) and is dropped. */
+  private seq = 0;
+  /** Monotonic write count, the second half of that drop rule. A read that was
+   *  already in the air when a store spend or a window snapshot wrote a balance is
+   *  answering an older question, so its response must not overwrite (and visibly
+   *  revert) the fresher number. Counted rather than folded into seq: seq gates the
+   *  in-flight release in finally, and bumping that from a write would leave pending
+   *  latched true for good. */
+  private writes = 0;
+
+  constructor(private readonly deps: ClaudiumLauncherBalanceDeps) {}
+
+  /** The current balance, or null when it is unknown. */
+  get balance(): number | null {
+    return this.value;
+  }
+
+  /**
+   * Record a balance from any source and converge the display when it MOVED.
+   *
+   * The changed compare is the whole point (#2411): a poll that returns the number
+   * already on screen must not rewrite it. The bag money footer is a cold window,
+   * not a per-frame painter, but the rewrite is not free either: it replaces the
+   * row's innerHTML and re-binds both launchers, which drops focus off whichever
+   * one had it, so a byte-identical repaint is pure cost.
+   */
+  set(next: number | null): void {
+    this.writes++;
+    const changed = next !== this.value;
+    this.value = next;
+    // Stamp BEFORE the callback, never after. onChanged repaints a surface that
+    // re-enters refresh() (painting the footer reads the launcher label), and on
+    // the write paths that are not a read resolve (a store snapshot, a store
+    // spend, the Claudium window) there is no in-flight flag to stop that nested
+    // read. The fresh stamp is what makes it a no-op, so the ordering here is
+    // load-bearing rather than cosmetic.
+    this.lastWriteAt = this.deps.now();
+    if (changed) this.deps.onChanged();
+  }
+
+  /**
+   * Back to unknown, with any in-flight read invalidated: a fresh set of economy
+   * hooks (a new session or character) must not be told the previous one's number
+   * by a response still in the air. Deliberately does NOT converge: the caller
+   * follows it with a forced read, and the surfaces this feeds are rebuilt on the
+   * way in anyway.
+   */
+  reset(): void {
+    this.value = null;
+    this.lastWriteAt = 0;
+    this.seq++;
+    this.pending = false;
+  }
+
+  /**
+   * Start a balance read, unless one is already in flight or the last write is
+   * still inside the throttle window. `force` bypasses only the throttle: a read
+   * in flight is always left to finish, since its resolve is as fresh as a
+   * duplicate would be.
+   */
+  refresh(force = false): void {
+    if (!this.deps.enabled() || this.pending) return;
+    if (!force && this.deps.now() - this.lastWriteAt < CLAUDIUM_BALANCE_THROTTLE_MS) return;
+    this.pending = true;
+    const seq = ++this.seq;
+    const writes = this.writes;
+    void this.deps
+      .read()
+      .then(
+        (balance) => {
+          if (this.overtaken(seq, writes)) return;
+          this.set(balance);
+        },
+        // The rejection arm is the SECOND argument of .then rather than a chained
+        // .catch, so an exception thrown by the converge callback above cannot land
+        // here and be reported as an unknown balance: a broken repaint is a
+        // programming error and must surface as one, not be laundered into '--'.
+        //
+        // What actually produces an unknown balance in the shipping client is the
+        // arm ABOVE, not this one: the economy SDK resolves its own fallback
+        // (available: false, balance: null) on a missing token, a non-2xx or a
+        // thrown fetch, so a failed read arrives as a resolved null. This arm is
+        // for a hooks implementation that really does reject.
+        () => {
+          if (this.overtaken(seq, writes)) return;
+          this.set(null);
+        },
+      )
+      .finally(() => {
+        // Cleared here and only here. Clearing it inside the resolve arm (before
+        // the converge callback) would re-open the self-feeding read this guard
+        // exists to stop, with every behavior test still green. Gated on seq alone:
+        // a read overtaken by a WRITE still has to release the flag it took.
+        if (seq === this.seq) this.pending = false;
+      });
+  }
+
+  /** Whether a settling read has been overtaken and must be dropped: by reset() or
+   *  a newer read (seq), or by a direct write that landed while it was in the air
+   *  (writes). Either way its answer is older than what the display already shows. */
+  private overtaken(seq: number, writes: number): boolean {
+    return seq !== this.seq || writes !== this.writes;
+  }
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -149,6 +149,7 @@ import {
   resolvePlayerSocialFlags,
   serializeIgnoreList,
 } from './chat_ignore_core';
+import { ClaudiumLauncherBalance } from './claudium_launcher_balance_core';
 import type { ClaudiumRail, ClaudiumSnapshot } from './claudium_window';
 import { ClaudiumWindow } from './claudium_window';
 import { formatClockTime } from './clock';
@@ -4073,7 +4074,7 @@ export class Hud {
     storeSnapshot: async () => {
       const snapshot = await this.claudiumHooks?.storeSnapshot();
       if (!snapshot) return { available: false, balance: null, items: [] };
-      this.setClaudiumLauncherBalance(snapshot.balance);
+      this.claudiumBalance.set(snapshot.balance);
       return {
         available: snapshot.available,
         balance: snapshot.balance,
@@ -4083,7 +4084,7 @@ export class Hud {
     spendStoreItem: async (itemId, kind, expectedCostClaudium) => {
       const result = await this.claudiumHooks?.spend(itemId, kind, expectedCostClaudium);
       if (result?.balance !== null && result?.balance !== undefined) {
-        this.setClaudiumLauncherBalance(result.balance);
+        this.claudiumBalance.set(result.balance);
       }
       return (
         result ?? {
@@ -4105,10 +4106,24 @@ export class Hud {
   // hooks are null and the window renders its clean disabled/empty state. The
   // window computes NOTHING; every number rides in through these hooks.
   private claudiumHooks: ClaudiumHooks | null = null;
-  private claudiumLauncherBalance: number | null = null;
-  private claudiumLauncherBalancePending = false;
-  private claudiumLauncherBalanceLastMs = 0;
-  private claudiumLauncherBalanceSeq = 0;
+  // The launcher's Claudium balance and its throttled read live in their own
+  // host-agnostic module (claudium_launcher_balance_core.ts). The HUD keeps only the
+  // wiring: what a read is, and what converging the display means. onChanged fires
+  // for EVERY balance write, which is what makes a store spend catch an open bag up
+  // (#2414), and ONLY when the number moved, which is what stops a poll that
+  // returned the value already on screen from rewriting the footer (#2411).
+  private readonly claudiumBalance = new ClaudiumLauncherBalance({
+    enabled: () => this.claudiumHooks !== null,
+    read: () => this.claudiumHooks?.balance() ?? Promise.resolve(null),
+    onChanged: () => {
+      // Footer-only, and on the cold-load-safe gate (#1538). A balance lands on its
+      // own schedule with no user action behind it, so a full renderBags() here
+      // would tear the window down under a player who is mid-drag, hovering a
+      // tooltip, or typing in bag search.
+      if (bagsWindowShown($('#bags').style.display)) this.bagsWindow.refreshMoneyRow();
+    },
+    now: () => Date.now(),
+  });
   private readonly claudiumWindow = new ClaudiumWindow({
     root: () => $('#claudium-window'),
     closeOthers: () => this.closeOtherWindows('#claudium-window'),
@@ -4120,7 +4135,7 @@ export class Hud {
           skus: [],
           nativeRails: { sol: false, usdc: false, woc: false },
         } satisfies ClaudiumSnapshot);
-      this.setClaudiumLauncherBalance(snapshot.balance);
+      this.claudiumBalance.set(snapshot.balance);
       return snapshot;
     },
     buy: (rail, sku) => this.claudiumHooks?.buy(rail, sku) ?? Promise.resolve(),
@@ -4298,50 +4313,11 @@ export class Hud {
 
   private claudiumLauncherHtml(): string {
     if (!this.claudiumHooks) return '';
-    this.refreshClaudiumLauncherBalance();
-    const label =
-      this.claudiumLauncherBalance === null
-        ? '--'
-        : formatNumber(this.claudiumLauncherBalance, { maximumFractionDigits: 0 });
+    this.claudiumBalance.refresh();
+    const balance = this.claudiumBalance.balance;
+    const label = balance === null ? '--' : formatNumber(balance, { maximumFractionDigits: 0 });
     const aria = t('hudChrome.claudium.open');
     return `<button type="button" class="claudium-launcher" data-claudium-launcher title="${esc(aria)}" aria-label="${esc(aria)}"><img class="claudium-coin" src="/claudium/icons/claudium_coin_64.webp" alt=""><span class="claudium-launcher-balance">${esc(label)}</span></button>`;
-  }
-
-  private setClaudiumLauncherBalance(balance: number | null): void {
-    this.claudiumLauncherBalance = balance;
-    this.claudiumLauncherBalanceLastMs = Date.now();
-  }
-
-  private refreshClaudiumLauncherBalance(force = false): void {
-    if (!this.claudiumHooks || this.claudiumLauncherBalancePending) return;
-    const now = Date.now();
-    if (!force && now - this.claudiumLauncherBalanceLastMs < 30_000) return;
-    this.claudiumLauncherBalancePending = true;
-    const seq = ++this.claudiumLauncherBalanceSeq;
-    void this.claudiumHooks
-      .balance()
-      .then((balance) => {
-        if (seq !== this.claudiumLauncherBalanceSeq) return;
-        this.setClaudiumLauncherBalance(balance);
-        // Footer-only, and on the cold-load-safe gate (#1538). This resolves on the
-        // balance read's own schedule with no user action behind it, so a full
-        // renderBags() here would tear the window down under a player who is
-        // mid-drag, hovering a tooltip, or typing in bag search. Re-entry is not a
-        // risk: the repaint does call claudiumLauncherHtml again, but
-        // claudiumLauncherBalancePending is still true here (.finally has not run),
-        // so the nested read returns before it ever consults the 30s throttle. The
-        // throttle re-stamp above is the second line of defense, not the first.
-        if (bagsWindowShown($('#bags').style.display)) this.bagsWindow.refreshMoneyRow();
-      })
-      .catch(() => {
-        if (seq !== this.claudiumLauncherBalanceSeq) return;
-        this.setClaudiumLauncherBalance(null);
-      })
-      .finally(() => {
-        if (seq === this.claudiumLauncherBalanceSeq) {
-          this.claudiumLauncherBalancePending = false;
-        }
-      });
   }
 
   // One-line aura effect summary HTML for the buff/debuff tooltip: the pure descriptor
@@ -12806,11 +12782,8 @@ export class Hud {
   attachClaudium(hooks: ClaudiumHooks): void {
     this.claudiumHooks = hooks;
     this.syncDailyRewardsSurfaceLabels();
-    this.claudiumLauncherBalance = null;
-    this.claudiumLauncherBalanceLastMs = 0;
-    this.claudiumLauncherBalanceSeq++;
-    this.claudiumLauncherBalancePending = false;
-    this.refreshClaudiumLauncherBalance(true);
+    this.claudiumBalance.reset();
+    this.claudiumBalance.refresh(true);
   }
 
   attachStorePromoCard(): void {
@@ -12844,7 +12817,7 @@ export class Hud {
   }
 
   async refreshClaudium(): Promise<void> {
-    this.refreshClaudiumLauncherBalance(true);
+    this.claudiumBalance.refresh(true);
     if (!this.claudiumWindow.isOpen) return;
     await this.claudiumWindow.render();
   }

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -168,6 +168,7 @@ const UI_PURE_CORES = [
   'src/ui/hud/vendor/train_learn_core.ts',
   'src/ui/hud/vendor/unbind_view.ts',
   'src/ui/card_duel_view.ts',
+  'src/ui/claudium_launcher_balance_core.ts',
   'src/ui/claudium_view.ts',
   'src/ui/woc_store_view.ts',
   'src/ui/wallet_connection_view.ts',

--- a/tests/bags_money_refresh.test.ts
+++ b/tests/bags_money_refresh.test.ts
@@ -381,30 +381,69 @@ describe('async balance reads repaint the FOOTER, not the whole window', () => {
     expect(hud).not.toMatch(/onWalletUiChange\(\(\) => \{[^}]*this\.renderBags\(\);/);
   });
 
-  it('the Claudium balance resolve repaints only the money row', () => {
+  // The Claudium balance itself no longer lives here to be pattern-matched. Its
+  // state, its 30s read, the in-flight and stale-response guards and the changed-only
+  // converge moved to src/ui/claudium_launcher_balance_core.ts (issues #2411, #2414),
+  // where tests/claudium_launcher_balance.test.ts EXECUTES all of them: the elision on
+  // an unchanged read, the re-entry guard on both paths (the in-flight flag inside a
+  // resolve, the stamp-before-converge ordering on a direct write), the seq drop and
+  // the throttle arithmetic. tests/bags_money_row_paint.test.ts then composes that
+  // module with the real painter and counts paints. What is left for source text is
+  // only the HUD's wiring: where the converge lands, and that nothing bypasses it.
+
+  it('the Claudium balance converge repaints only the money row', () => {
     expect(hud).toMatch(
-      /this\.setClaudiumLauncherBalance\(balance\);[^}]*this\.bagsWindow\.refreshMoneyRow\(\);/,
+      /onChanged: \(\) => \{[^}]*if \(bagsWindowShown\(\$\('#bags'\)\.style\.display\)\) this\.bagsWindow\.refreshMoneyRow\(\);/,
     );
-    expect(hud).not.toMatch(
-      /this\.setClaudiumLauncherBalance\(balance\);[^}]*this\.renderBags\(\);/,
+    // ONLY. A toMatch on the new call says nothing about the old one: re-adding
+    // `this.renderBags();` on the next line satisfies every affirmative pin here
+    // while restoring the exact teardown this block is named after.
+    expect(hud).not.toMatch(/onChanged: \(\) => \{[^}]*this\.renderBags\(\);/);
+  });
+
+  it('routes every balance write through that one converging seam (#2414)', () => {
+    // Three writes arrive without a launcher read: the WOC Store snapshot, a store
+    // spend, and the Claudium window's snapshot. Each used to update a private field
+    // and stop there, which is what left an open bag showing the pre-spend number.
+    // Counted rather than merely matched, because the regression shape is a FOURTH
+    // surface hand-wired around the seam; a new balance write goes through set() and
+    // moves this number deliberately.
+    const writes = hud.match(/this\.claudiumBalance\.set\(/g) ?? [];
+    expect(writes).toHaveLength(3);
+    // And no shadow copy survived the extraction. A balance the HUD assigned itself
+    // would render from state the converge and the changed compare never see, which
+    // is both bugs back in one line.
+    expect(hud).not.toMatch(/this\.claudiumLauncherBalance/);
+  });
+
+  it('writes the balance each of those surfaces actually reported', () => {
+    // The count above says three writers exist; it says nothing about WHAT they write.
+    // Swapping an argument for the balance already held typechecks (the getter is
+    // `number | null`) and quietly re-opens #2414 for that one surface while every
+    // other pin in this file stays green, so slice each closure and name its argument.
+    const between = (from: string, to: string): string => {
+      const start = hud.indexOf(from);
+      expect(start, `anchor missing: ${from}`).toBeGreaterThan(-1);
+      const end = hud.indexOf(to, start);
+      expect(end, `anchor missing: ${to}`).toBeGreaterThan(start);
+      return hud.slice(start, end);
+    };
+    expect(between('storeSnapshot: async () => {', 'spendStoreItem:')).toContain(
+      'this.claudiumBalance.set(snapshot.balance);',
+    );
+    expect(between('spendStoreItem: async (', 'openClaudium:')).toContain(
+      'this.claudiumBalance.set(result.balance);',
+    );
+    expect(between('new ClaudiumWindow({', 'buy: (rail, sku)')).toContain(
+      'this.claudiumBalance.set(snapshot.balance);',
     );
   });
 
-  it('leaves the pending flag as the re-entry guard, reset only in the finally arm', () => {
-    // The repaint re-enters claudiumLauncherHtml() -> refreshClaudiumLauncherBalance(),
-    // so something has to stop a self-feeding balance read. That something is
-    // claudiumLauncherBalancePending, which is still true inside .then because
-    // .finally has not run: the 30s throttle re-stamp is a second line of defense,
-    // not the first. Move the reset into .then (before the repaint) and the loop is
-    // live again with every behavior test still green, so pin WHERE it is cleared.
+  it('keeps the launcher label starting the throttled read it renders from', () => {
+    // The label paint IS the poll: nothing else drives an unforced read, so dropping
+    // this call would freeze the number at whatever the last forced read left.
     expect(hud).toMatch(
-      /\.finally\(\(\) => \{\s*if \(seq === this\.claudiumLauncherBalanceSeq\) \{\s*this\.claudiumLauncherBalancePending = false;/,
-    );
-    const resets = hud.match(/this\.claudiumLauncherBalancePending = false;/g) ?? [];
-    expect(resets).toHaveLength(2); // the finally arm + the attachClaudium re-arm
-    // And the early-return that consumes it still guards the whole read.
-    expect(hud).toMatch(
-      /if \(!this\.claudiumHooks \|\| this\.claudiumLauncherBalancePending\) return;/,
+      /claudiumLauncherHtml\(\): string \{[^}]*this\.claudiumBalance\.refresh\(\);/,
     );
   });
 

--- a/tests/bags_money_row_paint.test.ts
+++ b/tests/bags_money_row_paint.test.ts
@@ -12,7 +12,12 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { InvSlot } from '../src/sim/types';
+import { bagsWindowShown } from '../src/ui/bags_view';
 import { BagsWindow, type BagsWindowDeps } from '../src/ui/bags_window';
+import {
+  CLAUDIUM_BALANCE_THROTTLE_MS,
+  ClaudiumLauncherBalance,
+} from '../src/ui/claudium_launcher_balance_core';
 import { ItemDragState } from '../src/ui/item_drag_state';
 import type { IWorld } from '../src/world_api';
 
@@ -350,5 +355,155 @@ describe('BagsWindow.refreshIfChanged preserves what the player is holding', () 
     // The rewrite happened (fresh node), and focus was left where the browser put it.
     expect(h.root.querySelector('[data-claudium-launcher]')).not.toBe(before);
     expect(document.activeElement).toBe(document.body);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The Claudium balance, composed with the real painter (issues #2411, #2414). The
+// state machine's own truth table is tests/claudium_launcher_balance.test.ts; what
+// this block adds is the footer half, counted in PAINTS: an unchanged balance must
+// leave the row alone, a changed one must rewrite it in place, and the round trip
+// through claudiumLauncherHtml (which starts the next read) must not feed itself.
+//
+// Wired exactly as hud.ts wires it, so the two cannot drift apart silently: the
+// launcher label dep starts a read and renders the current value, and onChanged
+// repaints the money row behind the cold-load-safe gate (#1538).
+// ---------------------------------------------------------------------------
+
+interface BalanceHarness extends Harness {
+  balance: ClaudiumLauncherBalance;
+  reads(): number;
+  resolve(value: number | null): Promise<void>;
+  advance(ms: number): void;
+}
+
+function balanceHarness(startCopper = 1000): BalanceHarness {
+  const h = harness(startCopper);
+  let clock = 1_000_000;
+  let reads = 0;
+  const inflight: Array<(v: number | null) => void> = [];
+  const balance = new ClaudiumLauncherBalance({
+    enabled: () => true,
+    read: () => {
+      reads++;
+      return new Promise<number | null>((res) => inflight.push(res));
+    },
+    // The hud's gated footer repaint, verbatim.
+    onChanged: () => {
+      if (bagsWindowShown(h.root.style.display)) h.window.refreshMoneyRow();
+    },
+    now: () => clock,
+  });
+  // The hud's claudiumLauncherHtml: every paint starts a (throttled) read, then
+  // renders whatever the balance currently is.
+  const w = h.window as unknown as { deps: Record<string, unknown> };
+  w.deps.claudiumLauncherHtml = () => {
+    balance.refresh();
+    const value = balance.balance;
+    return `<button data-claudium-launcher>${value === null ? '--' : value}</button>`;
+  };
+  return {
+    ...h,
+    balance,
+    reads: () => reads,
+    // Loud when nothing is in flight: an elision case that never started the read it
+    // claims to elide would otherwise pass with no read behind it at all.
+    resolve: async (value) => {
+      const next = inflight.shift();
+      if (!next) throw new Error('settled a read that was never started');
+      next(value);
+      for (let i = 0; i < 6; i++) await Promise.resolve();
+    },
+    advance: (ms) => {
+      clock += ms;
+    },
+  };
+}
+
+describe('the Claudium balance read and the money footer', () => {
+  it('does not repaint the footer when the balance came back unchanged (#2411)', async () => {
+    const h = balanceHarness();
+    h.window.render();
+    await h.resolve(500); // the read the first paint started
+    const paintsAfterFirstBalance = h.paints();
+    expect(h.moneyText()).toContain('500');
+
+    // The poll crosses the throttle boundary again and returns the same number.
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+    h.window.refreshIfChanged(); // no purse movement, so this paints nothing itself
+    h.balance.refresh();
+    await h.resolve(500);
+    expect(h.paints()).toBe(paintsAfterFirstBalance);
+    expect(h.moneyText()).toContain('500');
+  });
+
+  it('repaints the footer in place when the balance moved', async () => {
+    const h = balanceHarness();
+    h.window.render();
+    await h.resolve(500);
+    const grid = h.root.querySelector('.bag-grid');
+    const before = h.paints();
+
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+    h.balance.refresh();
+    await h.resolve(420);
+
+    expect(h.paints()).toBe(before + 1);
+    expect(h.moneyText()).toContain('420');
+    // In place: the grid is the same node, so a hovered row keeps its listeners.
+    expect(h.root.querySelector('.bag-grid')).toBe(grid);
+  });
+
+  it('repaints the footer after a store spend, with no read involved (#2414)', () => {
+    // The WOC Store hands the post-spend balance straight to the HUD. An armory skin
+    // is an account cosmetic, so no inventory delta and no purse movement follow it:
+    // this write is the only convergence edge the open bag gets.
+    const h = balanceHarness();
+    h.window.render();
+    h.balance.set(500);
+    const before = h.paints();
+    expect(h.moneyText()).toContain('500');
+
+    h.balance.set(420); // the spend result
+    expect(h.paints()).toBe(before + 1);
+    expect(h.moneyText()).toContain('420');
+  });
+
+  it('paints nothing while the window is hidden, then converges on reopen (#1538)', async () => {
+    const h = balanceHarness();
+    h.window.render();
+    await h.resolve(500);
+    const before = h.paints();
+
+    h.root.style.display = 'none';
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+    h.balance.refresh();
+    await h.resolve(420);
+    expect(h.paints()).toBe(before); // the gate held
+
+    h.root.style.display = 'flex';
+    h.window.render();
+    expect(h.moneyText()).toContain('420');
+  });
+
+  it('does not feed itself: the repaint starts no further read', async () => {
+    // The repaint calls claudiumLauncherHtml again, which calls refresh(). Inside a
+    // resolve the in-flight flag stops it; on the store-write path the throttle stamp
+    // set() takes BEFORE it converges does. Either way the count must not run away.
+    const h = balanceHarness();
+    h.window.render();
+    expect(h.reads()).toBe(1); // the first paint's read
+    await h.resolve(500);
+    expect(h.reads()).toBe(1);
+    expect(h.paints()).toBe(2);
+
+    // Park the clock well past the throttle first, or this arm proves nothing: with a
+    // stale stamp still inside the window, a set() that stamped AFTER converging would
+    // look just as quiet as one that stamped before it. A spend a minute after the
+    // last read is also the realistic shape.
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS * 2);
+    h.balance.set(420);
+    expect(h.reads()).toBe(1);
+    expect(h.paints()).toBe(3);
   });
 });

--- a/tests/claudium_launcher_balance.test.ts
+++ b/tests/claudium_launcher_balance.test.ts
@@ -1,0 +1,512 @@
+// The Claudium launcher balance state machine (issues #2411, #2414), driven
+// directly. Before the extraction this logic sat on the Hud coordinator, which
+// nothing but src/main.ts constructs, so the only available pins were source-text
+// matches on hud.ts: they could name the SHAPE of the code but never execute it, and
+// the two bugs this file covers are both invisible to a shape pin.
+//
+//  - #2411: the read resolved and repainted whether or not the number had moved, so
+//    an open bag with a moving purse paid a byte-identical footer rewrite (innerHTML
+//    replace plus two listener re-binds, dropping focus off whichever launcher held
+//    it) every time a paint crossed the throttle boundary.
+//  - #2414: three of the four balance writes (the store snapshot, a store spend, the
+//    Claudium window snapshot) never repainted at all, so buying an armory skin left
+//    an open bag showing the pre-spend number.
+//
+// One changed-only converge inside set() fixes both, and every case below counts
+// converge calls rather than inspecting anything, so a regression to an
+// unconditional repaint (or to no repaint) is a failing count, not a prose review.
+// The footer-level proof that a converge really is a narrow money-row paint (and an
+// elided one really leaves the DOM alone) is in tests/bags_money_row_paint.test.ts.
+
+import { describe, expect, it } from 'vitest';
+import {
+  CLAUDIUM_BALANCE_THROTTLE_MS,
+  ClaudiumLauncherBalance,
+} from '../src/ui/claudium_launcher_balance_core';
+
+interface Harness {
+  balance: ClaudiumLauncherBalance;
+  /** How many times the display was told to converge. */
+  converges(): number;
+  /** How many reads were STARTED (not merely scheduled). */
+  reads(): number;
+  /** Resolve the oldest in-flight read with `value`. */
+  resolve(value: number | null): Promise<void>;
+  /** Reject the oldest in-flight read. */
+  reject(): Promise<void>;
+  advance(ms: number): void;
+  setEnabled(on: boolean): void;
+  /** Run `fn` inside the next converge callback, to exercise re-entry. */
+  onConverge(fn: () => void): void;
+}
+
+function harness(opts: { enabled?: boolean } = {}): Harness {
+  let clock = 1_000_000; // a non-zero start, so a zero stamp is never mistaken for now
+  let enabled = opts.enabled ?? true;
+  let converges = 0;
+  let reads = 0;
+  const inflight: Array<{ resolve(v: number | null): void; reject(): void }> = [];
+  let reentry: (() => void) | null = null;
+  const balance = new ClaudiumLauncherBalance({
+    enabled: () => enabled,
+    read: () => {
+      reads++;
+      return new Promise<number | null>((res, rej) => {
+        inflight.push({ resolve: res, reject: () => rej(new Error('read failed')) });
+      });
+    },
+    onChanged: () => {
+      converges++;
+      const fn = reentry;
+      reentry = null;
+      fn?.();
+    },
+    now: () => clock,
+  });
+  // Drain the whole .then -> .catch -> .finally chain, not just its first link: each
+  // link is its own microtask, and stopping early would leave `pending` set and make
+  // the next refresh look like the in-flight guard blocked it.
+  const settle = async (): Promise<void> => {
+    for (let i = 0; i < 6; i++) await Promise.resolve();
+  };
+  // Loud, not optional-chained: an elision case that never actually STARTED the read
+  // it claims to elide would otherwise pass for the wrong reason, and a gate mutation
+  // that stops the read entirely would look like a successful elision.
+  const take = (): { resolve(v: number | null): void; reject(): void } => {
+    const next = inflight.shift();
+    if (!next) throw new Error('settled a read that was never started');
+    return next;
+  };
+  return {
+    balance,
+    converges: () => converges,
+    reads: () => reads,
+    resolve: async (value) => {
+      take().resolve(value);
+      await settle();
+    },
+    reject: async () => {
+      take().reject();
+      await settle();
+    },
+    advance: (ms) => {
+      clock += ms;
+    },
+    setEnabled: (on) => {
+      enabled = on;
+    },
+    onConverge: (fn) => {
+      reentry = fn;
+    },
+  };
+}
+
+describe('a resolved read converges the display only when the number MOVED (#2411)', () => {
+  it('converges on the first balance, arriving from unknown', async () => {
+    const h = harness();
+    h.balance.refresh(true);
+    await h.resolve(500);
+    expect(h.balance.balance).toBe(500);
+    expect(h.converges()).toBe(1);
+  });
+
+  it('does NOT converge when the read returns the value already displayed', async () => {
+    const h = harness();
+    h.balance.refresh(true);
+    await h.resolve(500);
+    expect(h.converges()).toBe(1);
+
+    // The reported bug in two lines: the poll comes back with the same number.
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+    h.balance.refresh();
+    await h.resolve(500);
+    expect(h.converges()).toBe(1); // still one, not two
+    expect(h.balance.balance).toBe(500);
+
+    // And it stays elided across repeats: this is the case the 30s throttle turns
+    // into a rewrite roughly twice a minute for as long as the purse keeps moving.
+    for (let i = 0; i < 4; i++) {
+      h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+      h.balance.refresh();
+      await h.resolve(500);
+    }
+    expect(h.converges()).toBe(1);
+  });
+
+  it('converges again as soon as the number really does move', async () => {
+    const h = harness();
+    h.balance.refresh(true);
+    await h.resolve(500);
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+    h.balance.refresh();
+    await h.resolve(500); // elided
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+    h.balance.refresh();
+    await h.resolve(420); // moved
+    expect(h.converges()).toBe(2);
+    expect(h.balance.balance).toBe(420);
+  });
+
+  it('treats a repeated unknown as unchanged, and a first unknown as a move', async () => {
+    // Both directions of the null edge, because null is a real balance state here
+    // (the launcher renders it as '--'), not merely an absence.
+    const h = harness();
+    h.balance.refresh(true);
+    await h.resolve(null); // unknown -> unknown: nothing on screen changes
+    expect(h.converges()).toBe(0);
+
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+    h.balance.refresh();
+    await h.resolve(500);
+    expect(h.converges()).toBe(1);
+
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+    h.balance.refresh();
+    await h.resolve(null); // 500 -> unknown IS a visible change
+    expect(h.converges()).toBe(2);
+    expect(h.balance.balance).toBeNull();
+  });
+
+  it('exposes the new value BEFORE it converges, so the repaint paints it', async () => {
+    // Ordering, not incidental: onChanged repaints a footer that reads .balance to
+    // build the label. Converge first and the paint would render the old number and
+    // then never be asked again.
+    const h = harness();
+    const seen: Array<number | null> = [];
+    h.onConverge(() => seen.push(h.balance.balance));
+    h.balance.refresh(true);
+    await h.resolve(777);
+    expect(seen).toEqual([777]);
+  });
+});
+
+describe('every other balance write converges through the same seam (#2414)', () => {
+  // The store snapshot, a store spend and the Claudium window snapshot all write a
+  // balance the HUD learned without a launcher read. Each used to update the field
+  // and stop there, which is why an armory-skin purchase left an open bag stale.
+  it('a direct write converges when it moves the number', () => {
+    const h = harness();
+    h.balance.set(500);
+    expect(h.converges()).toBe(1);
+    h.balance.set(420); // the spend result
+    expect(h.converges()).toBe(2);
+    expect(h.balance.balance).toBe(420);
+  });
+
+  it('a direct write of the SAME number stays elided', () => {
+    // Opening the store re-reads the balance and hands it over unchanged; that must
+    // not cost a footer rewrite either.
+    const h = harness();
+    h.balance.set(500);
+    h.balance.set(500);
+    h.balance.set(500);
+    expect(h.converges()).toBe(1);
+  });
+
+  it('defers the next unforced read, since a written balance is already fresh', () => {
+    const h = harness();
+    h.balance.set(500);
+    h.balance.refresh();
+    expect(h.reads()).toBe(0);
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS - 1);
+    h.balance.refresh();
+    expect(h.reads()).toBe(0);
+    h.advance(1);
+    h.balance.refresh();
+    expect(h.reads()).toBe(1);
+  });
+});
+
+describe('the re-entry guard (a converge repaints a surface that reads the label)', () => {
+  it('a nested refresh from inside a direct write starts no read', () => {
+    // The load-bearing ordering: set() stamps the throttle BEFORE calling onChanged.
+    // On this path there is no read in flight, so the stamp is the ONLY thing
+    // standing between a converge and a self-feeding read. Move the stamp below the
+    // callback and this reds while every behavior test above stays green.
+    const h = harness();
+    h.onConverge(() => h.balance.refresh());
+    h.balance.set(500);
+    expect(h.converges()).toBe(1);
+    expect(h.reads()).toBe(0);
+  });
+
+  it('a nested refresh from inside a read resolve starts no read', async () => {
+    // Here the in-flight flag is the guard: it is still set inside .then, because
+    // .finally has not run yet. Clearing it in .then instead would re-open the loop.
+    const h = harness();
+    h.onConverge(() => h.balance.refresh(true)); // forced: only `pending` can stop it
+    h.balance.refresh(true);
+    expect(h.reads()).toBe(1);
+    await h.resolve(500);
+    expect(h.converges()).toBe(1);
+    expect(h.reads()).toBe(1);
+  });
+
+  it('releases the flag once the read settles, so the next refresh is not deadlocked', async () => {
+    const h = harness();
+    h.balance.refresh(true);
+    await h.resolve(500);
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+    h.balance.refresh();
+    expect(h.reads()).toBe(2);
+  });
+
+  it('releases the flag after a FAILED read too', async () => {
+    const h = harness();
+    h.balance.refresh(true);
+    await h.reject();
+    h.balance.refresh(true);
+    expect(h.reads()).toBe(2);
+  });
+});
+
+describe('the read gates', () => {
+  it('never reads while one is in flight, forced or not', () => {
+    const h = harness();
+    h.balance.refresh(true);
+    h.balance.refresh(true);
+    h.balance.refresh();
+    expect(h.reads()).toBe(1);
+  });
+
+  it('lets a cold unforced read through, since nothing has been written yet', () => {
+    // The boot shape: the launcher label is painted before any balance exists, and
+    // that first paint is what starts the read. A throttle measured from a zero
+    // stamp must not swallow it.
+    const h = harness();
+    h.balance.refresh();
+    expect(h.reads()).toBe(1);
+  });
+
+  it('measures the throttle from the last write, to the millisecond', async () => {
+    const h = harness();
+    h.balance.refresh(true);
+    await h.resolve(500);
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS - 1);
+    h.balance.refresh();
+    expect(h.reads()).toBe(1); // one millisecond short
+    h.advance(1);
+    h.balance.refresh();
+    expect(h.reads()).toBe(2);
+  });
+
+  it('force bypasses the throttle but not the in-flight guard', async () => {
+    const h = harness();
+    h.balance.refresh(true);
+    await h.resolve(500);
+    h.balance.refresh(); // throttled
+    expect(h.reads()).toBe(1);
+    h.balance.refresh(true); // forced through
+    expect(h.reads()).toBe(2);
+    h.balance.refresh(true); // but a read is in flight
+    expect(h.reads()).toBe(2);
+  });
+
+  it('reads nothing at all while the economy hooks are absent', async () => {
+    const h = harness({ enabled: false });
+    h.balance.refresh(true);
+    h.balance.refresh();
+    expect(h.reads()).toBe(0);
+    expect(h.converges()).toBe(0);
+    // Enabled is checked BEFORE read(), so the offline client never even builds a
+    // request it would have to discard.
+    h.setEnabled(true);
+    h.balance.refresh(true);
+    expect(h.reads()).toBe(1);
+    await h.resolve(500);
+    expect(h.converges()).toBe(1);
+  });
+
+  it('pins the throttle floor at 30s', () => {
+    expect(CLAUDIUM_BALANCE_THROTTLE_MS).toBe(30_000);
+  });
+});
+
+describe('stale responses and reset', () => {
+  it('drops a response that reset() invalidated, value and converge alike', async () => {
+    // attachClaudium re-arms for a fresh set of hooks (a new session or character).
+    // A response still in the air belongs to the old one and must not be shown.
+    const h = harness();
+    h.balance.refresh(true);
+    h.balance.reset();
+    await h.resolve(999);
+    expect(h.balance.balance).toBeNull();
+    expect(h.converges()).toBe(0);
+  });
+
+  it('drops a stale FAILURE too, rather than blanking a fresh balance', async () => {
+    const h = harness();
+    h.balance.refresh(true); // read A
+    h.balance.reset();
+    h.balance.set(500); // the fresh session's balance
+    expect(h.converges()).toBe(1);
+    await h.reject(); // A fails, late
+    expect(h.balance.balance).toBe(500);
+    expect(h.converges()).toBe(1);
+  });
+
+  it('reset() clears the value and the throttle without converging', () => {
+    const h = harness();
+    h.balance.set(500);
+    expect(h.converges()).toBe(1);
+    h.balance.reset();
+    expect(h.balance.balance).toBeNull();
+    expect(h.converges()).toBe(1); // the caller follows with a forced read
+    h.balance.refresh(); // unforced, and NOT throttled: the stamp was cleared
+    expect(h.reads()).toBe(1);
+  });
+
+  it('lets a read started after reset() through, in flight or not', async () => {
+    const h = harness();
+    h.balance.refresh(true); // read A, abandoned
+    h.balance.reset(); // clears `pending` so the new session can read at once
+    h.balance.refresh(true); // read B
+    expect(h.reads()).toBe(2);
+    await h.resolve(999); // A resolves first, and is stale
+    expect(h.balance.balance).toBeNull();
+    await h.resolve(600); // B is current
+    expect(h.balance.balance).toBe(600);
+    expect(h.converges()).toBe(1);
+  });
+
+  it('does not let a stale read release the CURRENT read in flight', async () => {
+    // The `seq === this.seq` guard on the pending clear, which only an overlapping
+    // pair can observe: A is abandoned by reset(), B is started, then A settles. If
+    // the finally arm cleared the flag unconditionally, A's settle would hand B's
+    // in-flight slot away and the next refresh would fire a third request against an
+    // endpoint that already has one open.
+    const h = harness();
+    h.balance.refresh(true); // A
+    h.balance.reset();
+    h.balance.refresh(true); // B, the current read
+    await h.resolve(999); // A settles, stale
+    h.balance.refresh(true); // forced, so only the in-flight flag can stop it
+    expect(h.reads()).toBe(2);
+  });
+});
+
+describe('a direct write overtakes a read already in the air', () => {
+  // Both halves of the drop rule matter. A store spend or a Claudium window snapshot
+  // can land while the footer paint's own read is still open, and that read is
+  // answering the pre-spend question: letting it through would repaint the fresh
+  // number and then revert it to the old one, which is #2414 back again inside the
+  // width of one request.
+  it('drops the older response instead of reverting the fresh balance', async () => {
+    const h = harness();
+    h.balance.set(500);
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+    h.balance.refresh(); // the footer paint's read, asking about 500
+    h.balance.set(300); // the spend result lands first
+    expect(h.converges()).toBe(2);
+
+    await h.resolve(500); // the pre-spend answer, now obsolete
+    expect(h.balance.balance).toBe(300);
+    expect(h.converges()).toBe(2); // no third, reverting, repaint
+  });
+
+  it('drops an overtaken FAILURE too, rather than blanking the fresh balance', async () => {
+    const h = harness();
+    h.balance.set(500);
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+    h.balance.refresh();
+    h.balance.set(300);
+    await h.reject();
+    expect(h.balance.balance).toBe(300);
+    expect(h.converges()).toBe(2);
+  });
+
+  it('still releases the in-flight flag, so the next read is not locked out', async () => {
+    const h = harness();
+    h.balance.set(500);
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+    h.balance.refresh();
+    h.balance.set(300);
+    await h.resolve(500);
+    h.balance.refresh(true);
+    expect(h.reads()).toBe(2);
+  });
+
+  it('does not drop a resolve that only its OWN write follows', async () => {
+    // The counter is captured before the request and compared before the resolve
+    // writes, so a read never invalidates itself. Without this the elision would
+    // become a total block and the balance would never update at all.
+    const h = harness();
+    h.balance.refresh(true);
+    await h.resolve(500);
+    expect(h.balance.balance).toBe(500);
+    expect(h.converges()).toBe(1);
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+    h.balance.refresh();
+    await h.resolve(420);
+    expect(h.balance.balance).toBe(420);
+    expect(h.converges()).toBe(2);
+  });
+});
+
+describe('a failed read converges the display to unknown', () => {
+  it('replaces a number nothing backs with the unknown state', async () => {
+    // A deliberate change of behavior, and the reason the converge lives in set():
+    // the field went null on a failed read before this too, so the stale number on
+    // screen survived only until some unrelated repaint flipped it to '--'. One seam
+    // means the display never disagrees with what the HUD believes.
+    const h = harness();
+    h.balance.refresh(true);
+    await h.resolve(500);
+    expect(h.converges()).toBe(1);
+
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+    h.balance.refresh();
+    await h.reject();
+    expect(h.balance.balance).toBeNull();
+    expect(h.converges()).toBe(2);
+  });
+
+  it('stays silent when the balance was already unknown', async () => {
+    const h = harness();
+    h.balance.refresh(true);
+    await h.reject();
+    expect(h.converges()).toBe(0);
+  });
+
+  it('stamps the throttle on failure, so a broken endpoint is not hammered', async () => {
+    const h = harness();
+    h.balance.refresh(true);
+    await h.reject();
+    h.balance.refresh();
+    expect(h.reads()).toBe(1);
+    h.advance(CLAUDIUM_BALANCE_THROTTLE_MS);
+    h.balance.refresh();
+    expect(h.reads()).toBe(2);
+  });
+});
+
+describe('the injected clock', () => {
+  it('reads the clock per call rather than capturing it at construction', async () => {
+    // The module takes its clock as a dep (no Date.now of its own: it is a registered
+    // src/ui pure core, and the architecture guard enforces that). Calling the dep on
+    // every gate check rather than caching a timestamp is what keeps the throttle
+    // honest under a clock that moves, which is the whole point of injecting one.
+    // Non-zero, so the blocked read below is attributable to the stamp the resolve
+    // took rather than to lastWriteAt's zero sentinel happening to equal the clock.
+    let clock = 1_000_000;
+    let reads = 0;
+    const balance = new ClaudiumLauncherBalance({
+      enabled: () => true,
+      read: () => {
+        reads++;
+        return Promise.resolve(500);
+      },
+      onChanged: () => {},
+      now: () => clock,
+    });
+    balance.refresh(true);
+    for (let i = 0; i < 6; i++) await Promise.resolve();
+    expect(reads).toBe(1);
+
+    balance.refresh(); // inside the window the resolve just stamped
+    expect(reads).toBe(1);
+    clock += CLAUDIUM_BALANCE_THROTTLE_MS;
+    balance.refresh();
+    expect(reads).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

`Hud.refreshClaudiumLauncherBalance` repainted the bag money footer on every balance resolve,
including when the read came back with the number already on screen. The read is started by
`claudiumLauncherHtml()`, which the footer paint itself calls, so an open bag with a moving purse
paid a second, byte-identical `.money` rewrite (an `innerHTML` replace plus two launcher
re-binds) every time a paint crossed the 30s throttle boundary. The sibling purse path already
had an elision key (`BagsWindow.refreshIfChanged` against its `lastMoneyCopper` latch); the
balance path had none.

The fix is the shape the issue asks for: compare before overwriting, and converge only on a real
move. Rather than bolt a fifth hand-wired arm onto the coordinator, the balance state machine
moved out of `src/ui/hud.ts` into `src/ui/claudium_launcher_balance_core.ts`, a registered
`src/ui` pure core:

- `set(next)` compares against the current value, stores it, stamps the throttle, then calls one
  injected `onChanged` **only when the number moved**. The HUD's `onChanged` is the footer-only
  repaint behind the cold-load-safe `bagsWindowShown` gate (#1538), exactly as before.
- `refresh(force)` keeps the read gates unchanged: the economy-hooks check, the in-flight guard,
  the 30s throttle, `force` bypassing the throttle only, and the monotonic read id that drops a
  response which lost its race.
- All four balance writes now route through `set()`. Three of them (the WOC Store snapshot, a
  store spend, and the Claudium window's snapshot) previously updated a private field and stopped
  there, which is the stale-after-purchase report in #2414.
- One thing the old code did not have: a read that was already in the air when a direct write
  landed is now dropped instead of overwriting it. Without that, a spend resolving while the
  footer paint's own read is open would repaint the new balance and then revert it to the
  pre-spend number, which is #2414 back again inside the width of one request.

Extracting rather than editing in place is what makes this testable at all: nothing but
`src/main.ts` constructs `Hud`, so the old behavior could only ever be pinned as source-text
matches against `hud.ts`, and both of these bugs are invisible to a shape pin. The coordinator
comes out 27 lines lighter and keeps only the wiring.

## Related issues

Closes #2411.
Closes #2414 (the single converging seam is what the issue asked for; the spend path is covered
end to end by a test).
Follows #2373 / #2380 / #2381, and keeps their rulings: footer-only, never `renderBags()`, and
no focus restore across the rewrite (the PR #2377 Enter double-fire trap).

## Type of change

- [x] Bug fix
- [x] Refactor or performance

## Performance

The change is a net reduction in work, and adds nothing to any per-frame path.

Removed:
- Every unchanged balance resolve used to cost a full footer rewrite: `row.innerHTML = ...` (three
  HTML strings built, the row's children parsed and replaced), two `querySelector` calls and two
  `addEventListener` binds, plus the focus drop that comes with replacing a focused button. Those
  are now zero.
- The Claudium top-up path in `src/main.ts` fires `hud.refreshClaudium()` up to four times per
  purchase (immediately, then at 1.5s, 4s and 8s). Once the balance settles, every one of those
  resolves used to repaint the footer; now at most one does.

Added:
- One `!==` compare per balance write. Writes are bounded by purse movement, store interaction and
  the 30s poll, never by a frame.
- One object plus its dep closures, allocated once per `Hud`.

Unchanged:
- Nothing here is reachable from `hud.update()` per frame. The only automatic driver is
  `BagsWindow.refreshIfChanged()` on the 500ms slow band, which self-gates on purse movement
  before it paints; the read gate it then reaches is the same two compares and one `Date.now()`
  the old code did.
- The 30s throttle, the single-in-flight rule and the stale-response drop all behave as before,
  pinned to the millisecond.

## Behavior note (one intended change)

A **failed** balance read now converges the footer to `--` instead of leaving the last number on
screen. Worth being precise about the path, because it is not the rejection arm: `EconomyClient`
resolves its own fallback (`available: false, balance: null`) on a missing token, a non-2xx or a
thrown fetch, so a failed read arrives as a resolved `null`. The old code already wrote that null
into the field, so the number on screen survived only until some unrelated repaint flipped it to
`--`; routing every write through one seam makes the display agree with what the HUD believes,
at the cost of showing `--` until the next successful read (at most 30s, or immediately on any
forced refresh). Documented in the module and pinned in both directions, so it is a one-line
reversal if you would rather hold the last number.

The rejection arm is now the second argument of `.then` rather than a chained `.catch`, so an
exception thrown by the converge callback can no longer land in the failure arm and be reported
as an unknown balance.

## How was this tested?

- Commands (run on the current `release/v0.30.0` tip, rebased onto #2336 after it landed
  mid-work; that commit touches `hud.ts` but nothing in the Claudium, bags or money-row paths):
  - `npm run gate` (green)
  - `npx vitest run tests/claudium_launcher_balance.test.ts tests/bags_money_row_paint.test.ts tests/bags_money_refresh.test.ts tests/architecture.test.ts`
  - every Claudium-touching suite in `tests/` (armory store, claudium view/window, WOC store
    contract, economy SDK, bags, daily rewards, mobile window layout, i18n completeness)
- Coverage added:
  - `tests/claudium_launcher_balance.test.ts`: the state machine driven directly, counting
    converges and reads. Unchanged reads elide (including across repeats), moves converge, both
    directions of the null edge, the value is readable before the converge, the read gates and the
    throttle to the millisecond, `force` semantics, stale-response drops (by `reset()` and by a
    direct write), `reset()`, and the re-entry guard on both paths. Both harnesses throw when a
    test settles a read that never started, so an elision case cannot pass with no read behind it.
  - `tests/bags_money_row_paint.test.ts`: the module composed with the real `BagsWindow` painter,
    counting **paints** as the issue asks. An unchanged balance leaves the footer untouched; a
    changed one rewrites it in place with the grid node identity intact; a store spend converges
    an open bag; a hidden window paints nothing and converges on reopen; the repaint starts no
    further read.
  - `tests/bags_money_refresh.test.ts`: the source pins move to the new wiring, keeping their
    polarity arm, and add a count pin so a future balance write cannot be hand-wired around the
    seam.
- Each new assertion was mutation-verified. Eighteen mutations, each turning at least one test
  red and each reverted byte-identical: dropping the changed gate, dropping the converge,
  swapping the stamp and the callback, converging before storing the value, clearing the
  in-flight flag in `.then` or clearing it unconditionally in `.finally`, dropping either half of
  the overtaken-response check, capturing the write counter at check time, dropping the enabled
  gate, loosening the throttle compare, a gate that stops reads outright, swapping a `set()`
  argument for the balance already held, and pointing the converge at `renderBags()` or at the
  raw `!== 'none'` display compare.
- Not covered locally: a real WOC Store purchase, which needs the online economy service and a
  funded account. The spend path is covered by test through the same closure `daily_rewards_window`
  calls.

## Screenshots / recordings

N/A. The footer renders byte-identical markup; what changes is how often it is rewritten. The one
visible difference is the failed-read `--` described above, which cannot be staged without taking
the economy service down.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green, with decisive tests for the changed
      behavior and the manual checks recorded above.

### Cross-platform

- [ ] ~**Tested on desktop and mobile.**~ Not run, and I do not think it applies: the footer's
      markup, CSS and touch targets are untouched, so there is no layout or sizing change to
      verify at either viewport. What changed is how often the row is rewritten. Say the word if
      you want a viewport pass anyway.
- [ ] ~**Accessible.**~ No UI added or edited. The launcher keeps its `aria-label` and button
      semantics; the only accessibility-adjacent effect is that a rewrite (which drops focus to
      `body`, per the #2377 ruling pinned in `tests/bags_money_row_paint.test.ts`) now happens
      strictly less often.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The `--` unknown glyph and the
      `hudChrome.claudium.open` label are unchanged, and the number still goes through
      `formatNumber`.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in
      any production path.
- [x] No generated files were hand-edited.
