### PR TITLE
fix(sim): normal Sanctum pressure pass, hp-gated Grave Inferno priced for melee

### DIFF
--- a/scripts/sanctum_fresh_montecarlo.ts
+++ b/scripts/sanctum_fresh_montecarlo.ts
@@ -72,6 +72,12 @@ const ARENA = { x: -2000, z: 3000 };
 // best-in-slot fire mage sustains ~233 dps (healing MC raid bench); fresh
 // greens/blues players land well under half that.
 const GROUP_DPS = 240;
+// Three-player composition (2026-07-26): tank + healer + ONE dps at the same
+// modeled 80 per head (the tank's own swings are real sim damage on top).
+// The 2026-07-26 pressure pass exists because a real fresh 3-man cleared the
+// first v0.30 floors without pressure; this bench keeps that composition
+// honest instead of only pricing the 5-man drain.
+const GROUP_DPS_3MAN = 80;
 // The strongest solo archetype's sustained self-heal (the solo economy line
 // documented in tests/gravewyrm_normal_tuning.test.ts).
 const SOLO_SELF_HEAL_CEILING = 140;
@@ -441,7 +447,12 @@ type SurvivalRun = {
 // spawns sit in no instance, so the sim's own spawnBossAdds path would mint
 // UNTUNED adds; the bench pre-fires his thresholds and spawns the waves
 // itself through the normal-Sanctum transform.
-function runSurvival(spec: Spec, encounter: Encounter, seed: number): SurvivalRun {
+function runSurvival(
+  spec: Spec,
+  encounter: Encounter,
+  seed: number,
+  groupDps: number = GROUP_DPS,
+): SurvivalRun {
   const sim = new Sim({ seed, playerClass: 'warrior', noPlayer: true });
   const { pid: tankPid, tank } = setupTank(sim, spec, 'fresh', false);
   const healerPid = addTierPlayer(sim, FRESH_HEALER, 'Healer', 'fresh');
@@ -467,7 +478,7 @@ function runSurvival(spec: Spec, encounter: Encounter, seed: number): SurvivalRu
     }
     const adds = alive.filter((m) => m.templateId === 'raised_bonewalker');
     const killTarget = adds[0] ?? alive[0];
-    killTarget.hp -= GROUP_DPS / 20;
+    killTarget.hp -= groupDps / 20;
     if (killTarget.hp <= 0) {
       killTarget.hp = 0;
       killTarget.dead = true;
@@ -492,6 +503,30 @@ function runSurvival(spec: Spec, encounter: Encounter, seed: number): SurvivalRu
       }
     }
     for (const mob of mobs) if (!mob.dead) pinThreat(mob, tank);
+    // Grave Inferno counterplay: the intended play is to walk out of the
+    // true-radius ring while the boss channels (he is rooted and not
+    // meleeing), so the bench tank does exactly that, at RUN speed from
+    // melee range, which usually costs the small first pulse; the mobs walk
+    // the tank back into contact after. Standing the full channel is the
+    // failure case the mechanic multiplier exists to punish, not the
+    // survival baseline.
+    const channeler = mobs.find((m) => !m.dead && m.infernoRemaining > 0);
+    if (channeler) {
+      const ring = (MOBS[channeler.templateId]?.infernoChannel?.radius ?? 14) + 2;
+      const dx = tank.pos.x - channeler.pos.x;
+      const dz = tank.pos.z - channeler.pos.z;
+      const d = Math.hypot(dx, dz);
+      if (d < ring) {
+        const out = Math.min(ring, d + 7 / 20); // player RUN_SPEED per tick
+        const scale = out / Math.max(0.5, d);
+        tank.pos = {
+          x: channeler.pos.x + dx * scale,
+          y: tank.pos.y,
+          z: channeler.pos.z + dz * scale,
+        };
+        tank.prevPos = { ...tank.pos };
+      }
+    }
     sim.startAutoAttack(tankPid);
     if (tank.hp < tank.maxHp) {
       healTick(sim, healerPid, tank, FRESH_HEALER, FRESH_HEALER.healPriority ?? []);
@@ -612,30 +647,39 @@ function main() {
     ),
   );
   const survival: Record<string, Record<string, unknown>> = {};
-  for (const spec of TANK_SPECS) {
-    for (const encounter of survivalEncounters) {
-      const runs: SurvivalRun[] = [];
-      for (let r = 0; r < RUNS; r++) {
-        runs.push(runSurvival(spec, encounter, BASE_SEED + r * 15485863));
+  const survival3man: Record<string, Record<string, unknown>> = {};
+  const comps: { label: string; dps: number; into: Record<string, Record<string, unknown>> }[] = [
+    { label: 'B ', dps: GROUP_DPS, into: survival },
+    { label: 'B3', dps: GROUP_DPS_3MAN, into: survival3man },
+  ];
+  for (const comp of comps) {
+    for (const spec of TANK_SPECS) {
+      for (const encounter of survivalEncounters) {
+        const runs: SurvivalRun[] = [];
+        for (let r = 0; r < RUNS; r++) {
+          runs.push(runSurvival(spec, encounter, BASE_SEED + r * 15485863, comp.dps));
+        }
+        const clearedPct = round1((100 * runs.filter((r) => r.cleared).length) / runs.length);
+        const deaths = runs.filter((r) => r.tankDeathSeconds !== null);
+        const deathTimes = summarize(
+          deaths.map((r) => must(r.tankDeathSeconds, 'tankDeathSeconds')),
+        );
+        const clearTimes = summarize(
+          runs.filter((r) => r.clearSeconds !== null).map((r) => must(r.clearSeconds, 'clear')),
+        );
+        const minHp = summarize(runs.map((r) => r.minTankHpFrac * 100));
+        comp.into[`${spec.key}__${encounter.key}`] = {
+          clearedPct,
+          tankDeaths: deaths.length,
+          tankDeathSeconds: deathTimes,
+          clearSeconds: clearTimes,
+          minTankHpPct: minHp,
+        };
+        console.log(
+          `${comp.label} ${spec.key.padEnd(20)} ${encounter.key.padEnd(28)} cleared ${String(clearedPct).padStart(5)}% ` +
+            `deaths ${deaths.length}/${runs.length} clear p50 ${clearTimes.p50}s minHp p10 ${minHp.p10}%`,
+        );
       }
-      const clearedPct = round1((100 * runs.filter((r) => r.cleared).length) / runs.length);
-      const deaths = runs.filter((r) => r.tankDeathSeconds !== null);
-      const deathTimes = summarize(deaths.map((r) => must(r.tankDeathSeconds, 'tankDeathSeconds')));
-      const clearTimes = summarize(
-        runs.filter((r) => r.clearSeconds !== null).map((r) => must(r.clearSeconds, 'clear')),
-      );
-      const minHp = summarize(runs.map((r) => r.minTankHpFrac * 100));
-      survival[`${spec.key}__${encounter.key}`] = {
-        clearedPct,
-        tankDeaths: deaths.length,
-        tankDeathSeconds: deathTimes,
-        clearSeconds: clearTimes,
-        minTankHpPct: minHp,
-      };
-      console.log(
-        `B ${spec.key.padEnd(20)} ${encounter.key.padEnd(28)} cleared ${String(clearedPct).padStart(5)}% ` +
-          `deaths ${deaths.length}/${runs.length} clear p50 ${clearTimes.p50}s minHp p10 ${minHp.p10}%`,
-      );
     }
   }
 
@@ -673,11 +717,13 @@ function main() {
       intakeSeconds: INTAKE_SECONDS,
       survivalCapSeconds: SURVIVAL_CAP_SECONDS,
       groupDps: GROUP_DPS,
+      groupDps3man: GROUP_DPS_3MAN,
       baseSeed: BASE_SEED,
     },
     profiles,
     intake,
     survival,
+    survival3man,
     solo,
   };
   mkdirSync('tmp/sanctum_mc', { recursive: true });

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -1228,6 +1228,7 @@ function blankEntity(id: number): Entity {
     infernoTimer: 0,
     infernoRemaining: 0,
     infernoPulsesFired: 0,
+    infernoGatesFired: 0,
     yelledEngage: false,
     stoneskinTimer: 0,
     terrifyTimer: 0,

--- a/src/sim/content/dungeon_difficulty.ts
+++ b/src/sim/content/dungeon_difficulty.ts
@@ -66,34 +66,50 @@ export interface HeroicDungeonTuning {
 // Unlike the heroic table this one is PER MOB, because the floor-style targets
 // below need different factors for trash, non-elite adds (no 1.5x elite swing
 // multiplier), and bosses. The per-mob factor also drives mechanicDamageMult,
-// so a boss's aoePulse/stomp scale with its own melee (../instances/difficulty.ts).
+// so a boss's aoePulse/stomp scale with its own melee (../instances/difficulty.ts),
+// UNLESS the mob has a mechanicDamageMultiplierByMob override: that decouples an
+// AVOIDABLE telegraphed mechanic from the unavoidable tank-swing calibration, so
+// a skill check can stay lethal while melee intake is priced for the fresh tank.
 export interface NormalDungeonTuning {
   id: string;
   difficulty: Extract<DungeonDifficulty, 'normal'>;
   healthMultiplier: number;
   damageMultiplierByMob: Record<string, number>;
+  // Optional per-mob override for mechanicDamageMult only (aoePulse, stomp,
+  // infernoChannel); a mob absent here falls back to its damageMultiplierByMob
+  // factor. Keys must be a subset of damageMultiplierByMob (pinned by
+  // tests/gravewyrm_normal_tuning.test.ts).
+  mechanicDamageMultiplierByMob?: Record<string, number>;
 }
 
-// Fresh-group retune (v0.30): normal Sanctum is the fresh-20 group dungeon,
-// and the v0.29 economy floors (trash 200 / bosses 420 / adds 150 on the
-// max-mitigation reference warrior) landed 22-54% of a freshly-capped tank's
-// pool PER SWING (quest greens/blues: 1371-1752 hp, 1439-2361 armor across
-// the three committed tanks); the Monte Carlo survival bench
-// (scripts/sanctum_fresh_montecarlo.ts) showed 0% clears and a tank death in
-// every run even against single bosses with a healer. New calibration: the
-// minimum non-crit swing on the same reference warrior (level-20 prot in the
-// max-armor kit, 2861 armor, Defensive Stance) lands at least 90 (trash),
-// 200 (bosses; Korgath/Korzul land ~245, Velkhar sits at the 200 line
-// because he swings at 2.0s and layers his summon waves on top), and 50
-// (Velkhar's non-elite bonewalker waves, which spawn three at a time and are
-// wave pressure, not extra bosses). That prices a boss swing at ~25% of the
-// fresh tank pool (~20.5% for Velkhar), the same audience-pool share the
-// heroic and Nythraxis calibrations use, with tanks crit-immune since
-// v0.29.1 so there is no spike tail above the 1.25x roll cap; an add swing
-// is ~5-7%. The DOUBLED health stays: the economy lever is clear time, not
-// lethality. Pinned by
-// tests/gravewyrm_normal_tuning.test.ts, which also pins the heroic transform
-// literals so a base-template edit cannot slip through unnoticed.
+// Fresh-group retune (v0.30), pressure pass (2026-07-26): the first v0.30
+// calibration (trash 90 / bosses 200 / adds 50 floors) fixed the unclearable
+// v0.29 economy floors, but overshot soft: a fresh THREE-player group cleared
+// the dungeon without pressure, because its Monte Carlo bench modeled the
+// worst-case healer (autopilot, no cooldowns) and priced the floors so that
+// worst case barely survived. This pass raises the minimum non-crit swing on
+// the reference warrior (level-20 prot in the max-armor kit, 2861 armor,
+// Defensive Stance) to at least 100 (trash, lands 103+) and 200 (bosses:
+// Korgath 301 / Korzul 280, ~29-31% of a fresh tank pool per average swing;
+// Velkhar is UNCHANGED at the 200 line, ~21%, because he was already the
+// peak fight: he swings at 2.0s and layers his summon waves on top for a
+// ~305 dtps wave-window peak), with the summoned bonewalkers still at 50
+// (wave pressure, not extra bosses). Korgath and Korzul rise to MEET
+// Velkhar: boss dtps on a fresh tank now runs ~179-193, pressed above a
+// fresh healer's sustain so the tank loses ground without cooldowns; tanks
+// are crit-immune since v0.29.1, so no swing can spike past the 1.25x roll
+// cap (~38% of pool). Korzul's melee sits below Korgath's per-multiplier
+// because he also carries the guaranteed inferno channel (the 50% hp gate)
+// on top of his 30% enrage.
+// Korzul additionally carries a mechanicDamageMultiplierByMob override: his
+// Grave Inferno channel is fully avoidable (rooted boss, no melee during it,
+// true-radius telegraph), so it prices at 15x, lethal to a ~1000hp fresh
+// melee pool that stands all four pulses (1050-1350 raw) while pulse one
+// stays a scratch; his melee stays on the tank calibration above. The
+// DOUBLED health stays: the economy lever is clear time, not lethality.
+// Pinned by tests/gravewyrm_normal_tuning.test.ts, which also pins the
+// heroic transform literals so a base-template edit cannot slip through
+// unnoticed.
 //
 // Normal Nythraxis gets the same treatment (2x health, boss floor 600,
 // skeleton waves floor 300, both landing at their level-20 spawns): the boss
@@ -106,12 +122,15 @@ export const NORMAL_DUNGEON_TUNING: Record<string, NormalDungeonTuning> = {
     difficulty: 'normal',
     healthMultiplier: 2.0,
     damageMultiplierByMob: {
-      sanctum_boneguard: 3.4,
-      sanctum_drakonid: 3.3,
+      sanctum_boneguard: 3.8,
+      sanctum_drakonid: 3.7,
       raised_bonewalker: 3.75,
-      korgath_the_bound: 7.75,
+      korgath_the_bound: 9.5,
       grand_necromancer_velkhar: 6.6,
-      korzul_the_gravewyrm: 7.5,
+      korzul_the_gravewyrm: 8.5,
+    },
+    mechanicDamageMultiplierByMob: {
+      korzul_the_gravewyrm: 15,
     },
   },
   nythraxis_boss_arena: {
@@ -177,8 +196,8 @@ export const HEROIC_DUNGEON_TUNING: Record<string, HeroicDungeonTuning> = {
     // (v0.30), the summoned floor drops from 250 to 150.
     addDamageMultiplier: 8.55,
     // The Sanctum bosses must out-hit their retuned NORMAL selves (normal
-    // floors them at 200-247 post-mitigation since the v0.30 fresh-group
-    // retune): 19x lands 652-708, comfortably above.
+    // floors them at 200-301 post-mitigation since the v0.30 fresh-group
+    // pressure pass): 19x lands 652-708, comfortably above.
     damageMultiplierByMob: {
       korgath_the_bound: 19,
       grand_necromancer_velkhar: 19,

--- a/src/sim/content/dungeons.ts
+++ b/src/sim/content/dungeons.ts
@@ -495,6 +495,10 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
     // Geddon-style stationary channel: 8s rooted, no melee, four escalating
     // fire pulses (base x1/2/3/4 x the per-mob mechanic multiplier), 14yd.
     // Moving out at the windup eats the small first pulse or nothing.
+    // The 50% hp gate (2026-07-26) guarantees the channel fires once per kill
+    // on BOTH difficulties: a group out-pacing the 30s cadence used to skip
+    // the mechanic entirely. One gate only, and it lands before the 30% enrage
+    // so the burn phase never stacks on enraged melee.
     infernoChannel: {
       every: 30,
       duration: 8,
@@ -504,6 +508,7 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
       radius: 14,
       name: 'Grave Inferno',
       school: 'fire',
+      atHpPct: [0.5],
     },
     enrage: { belowHpPct: 0.3, dmgMult: 1.5, hasteMult: 1.3 },
     loot: [

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -140,6 +140,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     infernoTimer: 0,
     infernoRemaining: 0,
     infernoPulsesFired: 0,
+    infernoGatesFired: 0,
     yelledEngage: false,
     stoneskinTimer: 0,
     terrifyTimer: 0,

--- a/src/sim/instances/difficulty.ts
+++ b/src/sim/instances/difficulty.ts
@@ -97,12 +97,14 @@ export function applyDungeonMobTuning(
 ): void {
   if (difficulty !== 'heroic') {
     // Normal retunes: the mob's own melee factor drives its mechanics too, so
-    // an aoePulse/stomp keeps pace with the swing it lands between. Heals from
-    // support mobs keep pace with the doubled health pool.
+    // an aoePulse/stomp keeps pace with the swing it lands between, unless the
+    // tuning carries a mechanicDamageMultiplierByMob override (an avoidable
+    // telegraphed mechanic priced independently of the tank-swing floor).
+    // Heals from support mobs keep pace with the doubled health pool.
     const normal = NORMAL_DUNGEON_TUNING[dungeonId];
     const dmgMult = normal?.damageMultiplierByMob[mob.templateId];
     if (normal && dmgMult !== undefined) {
-      mob.mechanicDamageMult = dmgMult;
+      mob.mechanicDamageMult = normal.mechanicDamageMultiplierByMob?.[mob.templateId] ?? dmgMult;
       mob.mechanicHealMult = normal.healthMultiplier;
     }
     return;

--- a/src/sim/mob/lifecycle.ts
+++ b/src/sim/mob/lifecycle.ts
@@ -87,6 +87,12 @@ export function respawnMob(ctx: SimContext, mob: Entity): void {
   mob.healedThisPull = false;
   mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
   mob.terrifyTimer = MOBS[mob.templateId]?.terrify?.every ?? 0;
+  // A mid-flight inferno channel dies with the life; the cadence reseeds and
+  // the hp gates re-arm alongside firedSummons above.
+  mob.infernoTimer = MOBS[mob.templateId]?.infernoChannel?.every ?? 0;
+  mob.infernoRemaining = 0;
+  mob.infernoPulsesFired = 0;
+  mob.infernoGatesFired = 0;
   // Charge resets READY (cooldown 0), not telegraphed: a fresh life opens with it.
   resetMobCharge(mob);
   mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;

--- a/src/sim/mob/locomotion.ts
+++ b/src/sim/mob/locomotion.ts
@@ -44,6 +44,7 @@ import {
   type Entity,
   LEASH_DISTANCE,
   MELEE_RANGE,
+  type MobTemplate,
   NYTHRAXIS_ADD_ID,
   NYTHRAXIS_BOSS_ID,
   SISTER_NHALIA_BOSS_ID,
@@ -490,18 +491,42 @@ function updateInfernoChannel(ctx: SimContext, mob: Entity): boolean {
   }
   if (mob.infernoRemaining <= 0) {
     mob.infernoPulsesFired = 0;
+    // A gate crossed DURING this channel was served by it: consume it now so
+    // the cadence path in runMobAttackMechanics cannot chain a back-to-back
+    // channel off a threshold the players already burned through.
+    consumeCrossedInfernoGates(mob, inferno);
     return false; // channel over: the boss acts normally again this tick
   }
   return true;
 }
 
+// Consume every infernoChannel.atHpPct threshold the mob's current hp has
+// crossed (mirroring the summonAdds firedSummons walk); returns whether any
+// was consumed this call. Pure counter bookkeeping: no rng, no events.
+function consumeCrossedInfernoGates(
+  mob: Entity,
+  inferno: NonNullable<MobTemplate['infernoChannel']>,
+): boolean {
+  const gates = inferno.atHpPct;
+  if (!gates) return false;
+  const hpFrac = mob.hp / Math.max(1, mob.maxHp);
+  let crossed = false;
+  while (mob.infernoGatesFired < gates.length && hpFrac <= gates[mob.infernoGatesFired]) {
+    mob.infernoGatesFired++;
+    crossed = true;
+  }
+  return crossed;
+}
+
 function runMobAttackMechanics(ctx: SimContext, mob: Entity): void {
   // Grave Inferno cadence: melee-gated like every other boss mechanic. At
   // zero the channel arms and updateInfernoChannel owns subsequent ticks.
+  // An atHpPct gate arms it immediately regardless of the cadence (and
+  // reseeds the cadence), so a fast kill still meets the burn phase.
   const inferno = MOBS[mob.templateId]?.infernoChannel;
   if (inferno && mob.infernoRemaining <= 0) {
     mob.infernoTimer -= DT;
-    if (mob.infernoTimer <= 0) {
+    if (consumeCrossedInfernoGates(mob, inferno) || mob.infernoTimer <= 0) {
       mob.infernoTimer = inferno.every;
       mob.infernoRemaining = inferno.duration;
       mob.infernoPulsesFired = 0;
@@ -777,6 +802,12 @@ export function resetEvadingMob(ctx: SimContext, mob: Entity): void {
   mob.healedThisPull = false;
   mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
   mob.terrifyTimer = MOBS[mob.templateId]?.terrify?.every ?? 0;
+  // A mid-flight inferno channel dies with the pull; the cadence reseeds and
+  // the hp gates re-arm alongside firedSummons above.
+  mob.infernoTimer = MOBS[mob.templateId]?.infernoChannel?.every ?? 0;
+  mob.infernoRemaining = 0;
+  mob.infernoPulsesFired = 0;
+  mob.infernoGatesFired = 0;
   // Charge resets READY (cooldown 0), not telegraphed: the next pull opens with it.
   resetMobCharge(mob);
   mob.aoeSlowTimer = MOBS[mob.templateId]?.aoeSlow?.every ?? 0;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1147,6 +1147,11 @@ export interface MobTemplate {
   // firing `pulses` evenly-spaced unmitigated AoE pulses whose damage
   // ESCALATES per pulse (pulse k rolls range(min, max) x k, then the
   // per-entity mechanicDamageMult). Uninterruptible: pair with ccImmune.
+  // Optional atHpPct thresholds (mirroring summonAdds) ALSO arm the channel
+  // the first time hp falls to each fraction, so every group sees the burn
+  // phase even when the boss dies inside the first cadence window; a
+  // threshold crossed while a channel is already live is served by that
+  // channel (no back-to-back re-arm).
   infernoChannel?: {
     every: number;
     duration: number;
@@ -1156,6 +1161,7 @@ export interface MobTemplate {
     radius: number;
     name: string;
     school?: string;
+    atHpPct?: number[];
   };
   // Boss mechanic: a periodic telegraphed HARDCAST. Unlike the instant aoePulse,
   // the mob shows a real cast bar (the entity casting fields carry castId) for
@@ -2951,6 +2957,7 @@ export interface Entity {
   infernoTimer: number; // infernoChannel cadence countdown
   infernoRemaining: number; // seconds left in a live inferno channel (0 = not channeling)
   infernoPulsesFired: number; // pulses already fired this channel
+  infernoGatesFired: number; // infernoChannel.atHpPct thresholds already consumed
   yelledEngage: boolean; // engage bark fired this pull (reset on evade/respawn)
   stoneskinTimer: number; // periodic self-absorb barrier countdown
   terrifyTimer: number; // Banshee's Wail fear-pulse countdown

--- a/tests/grave_inferno.test.ts
+++ b/tests/grave_inferno.test.ts
@@ -74,6 +74,11 @@ describe('Grave Inferno (Korzul channel)', () => {
       radius: 14,
       name: 'Grave Inferno',
       school: 'fire',
+      // 2026-07-26: one 50% hp gate, so the channel fires at least once per
+      // kill on both difficulties even when the group out-paces the 30s
+      // cadence; it sits above the 30% enrage so the burn phase never stacks
+      // on enraged melee.
+      atHpPct: [0.5],
     });
   });
 
@@ -151,5 +156,57 @@ describe('Grave Inferno (Korzul channel)', () => {
     for (let i = 0; i < tankHits.length; i++) {
       expect(tankHits[i].event.amount).toBe(nakedHits[i].event.amount);
     }
+  });
+});
+
+describe('Grave Inferno 50% hp gate', () => {
+  it('arms the channel immediately at 50%, then the cadence reseeds from the gate', () => {
+    const { sim, boss, tank } = setup(15);
+    const before = run(sim, 5, [tank]);
+    expect(infernoHits(before, boss.id)).toHaveLength(0); // cadence alone: first channel at 30s
+    boss.hp = boss.maxHp * 0.49;
+    const rows = run(sim, 42, [tank]);
+    const hits = infernoHits(rows, boss.id);
+    // The gate channel fires all four pulses right away (first pulse ~2s
+    // after the gate is consumed on the next engaged melee tick), long
+    // before the 30s cadence would have...
+    const gateChannel = hits.filter((h) => h.at < 20);
+    expect(gateChannel).toHaveLength(4);
+    expect(hits[0].at).toBeGreaterThan(5);
+    expect(hits[0].at).toBeLessThan(10);
+    gateChannel.forEach((h, i) => {
+      const k = i + 1;
+      expect(h.event.amount).toBeGreaterThanOrEqual(7 * k * 15);
+      expect(h.event.amount).toBeLessThanOrEqual(9 * k * 15);
+    });
+    // ...and the cadence reseeds from the gate arm (the countdown freezes
+    // while a channel is live, so the follow-up lands ~38s later), rather
+    // than a second gate-fired channel chaining instantly.
+    expect(hits.length).toBeGreaterThan(4);
+    expect(hits[4].at - hits[0].at).toBeGreaterThan(25);
+  });
+
+  it('a gate crossed during a live channel is served by it, never chained back-to-back', () => {
+    const { sim, boss, tank } = setup(15);
+    boss.infernoTimer = 0.1; // force a cadence channel on the first tick
+    run(sim, 3, [tank]);
+    boss.hp = boss.maxHp * 0.45; // cross the gate MID-channel
+    const rows = run(sim, 22, [tank]);
+    const hits = infernoHits(rows, boss.id);
+    // Only the pulses of the one live channel: the mid-channel gate is
+    // consumed by it instead of instantly re-arming a second 8s root.
+    expect(hits.length).toBeLessThanOrEqual(4);
+    expect(hits.length).toBeGreaterThan(0);
+  });
+
+  it('the gate fires once: hp hovering across the line does not re-arm', () => {
+    const { sim, boss, tank } = setup(15);
+    boss.hp = boss.maxHp * 0.49;
+    run(sim, 12, [tank]); // gate channel runs to completion
+    boss.hp = boss.maxHp * 0.8; // "heal" back over the line...
+    run(sim, 2, [tank]);
+    boss.hp = boss.maxHp * 0.49; // ...and cross it again
+    const rows = run(sim, 12, [tank]);
+    expect(infernoHits(rows, boss.id)).toHaveLength(0); // consumed; only the cadence remains
   });
 });

--- a/tests/gravewyrm_normal_tuning.test.ts
+++ b/tests/gravewyrm_normal_tuning.test.ts
@@ -1,15 +1,16 @@
 // Gravewyrm Sanctum NORMAL retune: the v0.29 economy floors (200 trash / 420
 // bosses / 150 adds) made normal Sanctum unclearable for its actual audience,
-// freshly-capped groups: bosses landed 41-54% of a fresh tank's pool PER
-// SWING and the Monte Carlo survival bench
-// (scripts/sanctum_fresh_montecarlo.ts) recorded a tank death in every run,
-// even against lone bosses with a healer. v0.30 keeps the DOUBLED health (the
-// anti-solo economy lever is clear time) and re-floors damage for the fresh
-// group instead, with boss mechanics scaled by the same per-mob factor.
-// Heroic reads the same base templates on its OWN calibration
-// (tests/heroic_difficulty_floors.test.ts), so this file also pins the heroic
-// transform literals: a base-template edit cannot slip through either
-// difficulty unnoticed.
+// freshly-capped groups. v0.30 keeps the DOUBLED health (the anti-solo
+// economy lever is clear time) and re-floors damage for the fresh group
+// instead; the 2026-07-26 pressure pass then raised the floors again after a
+// fresh THREE-player group cleared the first calibration without pressure
+// (its bench had priced the floors so a worst-case autopilot healer barely
+// survived). Boss mechanics scale by the same per-mob factor unless
+// mechanicDamageMultiplierByMob overrides one (Korzul's avoidable Grave
+// Inferno prices off the tank-swing line). Heroic reads the same base
+// templates on its OWN calibration (tests/heroic_difficulty_floors.test.ts),
+// so this file also pins the heroic transform literals: a base-template edit
+// cannot slip through either difficulty unnoticed.
 //
 // Reference warrior (the "fully geared" mitigation ceiling): level-20 prot
 // warrior in the max-armor kit (full heroic plate + shield, prot mastery),
@@ -35,20 +36,24 @@ import { armorReduction } from '../src/sim/types';
 const SANCTUM = 'gravewyrm_sanctum';
 const REF_ARMOR = 2861; // max-armor BiS prot warrior, level 20 (see header)
 const DEFENSIVE_STANCE_TAKEN = 0.9; // dealDamage: Defensive Stance takes 10% less
-// v0.30 fresh-group retune: normal Sanctum serves freshly-capped groups in
-// quest greens/blues (1371-1752 hp / 1439-2361 armor across the three
-// committed tanks), for whom even the 200/420 floors meant 21-24% (trash) and
-// 41-54% (bosses) of the pool per swing. Trash 90; bosses 200 (Korgath and
-// Korzul land ~245, an average swing of ~25% of the fresh pool, the same
-// audience-pool share the heroic and Nythraxis boss calibrations use; tanks
-// are crit-immune since v0.29.1 so there is no spike tail above the 1.25x
-// roll cap. Velkhar sits at the 200 line, ~20.5%, because he swings at 2.0s
-// and layers his bonewalker waves on top); and the summoned bonewalkers 50
-// (three spawn at once: wave pressure, not extra bosses). The DOUBLED health
-// stays. Accepted trade (2026-07-25): a best-in-slot self-healing tank can
-// out-heal these bosses again, so clear TIME, not lethality, is what keeps
-// solo farming unprofitable.
-const TRASH_FLOOR = 90;
+// v0.30 pressure pass (2026-07-26): normal Sanctum serves freshly-capped
+// groups in quest greens/blues (1371-1752 hp / 1439-2361 armor across the
+// three committed tanks). The first v0.30 floors (90/200/50) let a fresh
+// 3-man clear without pressure, so Korgath and Korzul rise to MEET Velkhar,
+// the existing peak fight (Korgath 301 / Korzul 280 on the 200 boss floor,
+// ~29-31% of a fresh tank pool per average swing; Velkhar is UNCHANGED at
+// the 200 line, ~21%, because he swings at 2.0s and layers his bonewalker
+// waves on top) and trash rises to 100 (lands 103+). Boss dtps on a fresh
+// tank runs ~179-193, pressed above a fresh healer's sustain so the tank
+// loses ground without cooldowns; tanks are crit-immune since v0.29.1 so no
+// swing spikes past the 1.25x roll cap. Korzul's melee multiplier sits below
+// Korgath's because he also carries the gate-guaranteed inferno channel on
+// top of his 30% enrage. The summoned bonewalkers stay
+// at 50 (three spawn at once: wave pressure, not extra bosses), and the
+// DOUBLED health stays. Solo note: a best-in-slot self-healing tank still
+// out-heals these floors, so clear TIME is what keeps solo farming
+// unprofitable.
+const TRASH_FLOOR = 100;
 const BOSS_FLOOR = 200;
 const ADD_FLOOR = 50;
 
@@ -92,18 +97,28 @@ describe('normal Gravewyrm Sanctum tuning data', () => {
       if (summoned) spawnIds.add(summoned);
     }
     expect([...spawnIds].sort()).toEqual(Object.keys(tuning.damageMultiplierByMob).sort());
+    // The mechanic override map may only re-price mobs the melee map covers.
+    for (const id of Object.keys(tuning.mechanicDamageMultiplierByMob ?? {})) {
+      expect(tuning.damageMultiplierByMob, `${id} missing a melee factor`).toHaveProperty(id);
+    }
   });
 
   it('pins the retune multipliers to exact literals', () => {
     const tuning = sanctumTuning();
     expect(tuning.healthMultiplier).toBe(2.0);
     expect(tuning.damageMultiplierByMob).toEqual({
-      sanctum_boneguard: 3.4,
-      sanctum_drakonid: 3.3,
+      sanctum_boneguard: 3.8,
+      sanctum_drakonid: 3.7,
       raised_bonewalker: 3.75,
-      korgath_the_bound: 7.75,
+      korgath_the_bound: 9.5,
       grand_necromancer_velkhar: 6.6,
-      korzul_the_gravewyrm: 7.5,
+      korzul_the_gravewyrm: 8.5,
+    });
+    // Korzul's avoidable Grave Inferno prices off the tank-swing line: 15x
+    // makes standing all four pulses (raw 1050-1350) lethal to a ~1000hp
+    // fresh melee pool while his melee stays on the boss calibration above.
+    expect(tuning.mechanicDamageMultiplierByMob).toEqual({
+      korzul_the_gravewyrm: 15,
     });
   });
 });
@@ -132,7 +147,7 @@ describe('normal Gravewyrm Sanctum melee floors vs the reference warrior', () =>
     }
   });
 
-  it('every trash swing lands for at least 90 at every spawnable level', () => {
+  it('every trash swing lands for at least 100 at every spawnable level', () => {
     for (const id of TRASH_IDS) {
       const { minLevel, maxLevel } = MOBS[id];
       for (let level = minLevel; level <= maxLevel; level++) {
@@ -158,16 +173,23 @@ describe('normal Gravewyrm Sanctum melee floors vs the reference warrior', () =>
 });
 
 describe('normal Gravewyrm Sanctum mechanic scaling', () => {
-  it('spawned normal mobs carry the per-mob mechanic multiplier', () => {
+  it('spawned normal mobs carry the per-mob mechanic multiplier, override first', () => {
     const tuning = sanctumTuning();
     for (const id of [...TRASH_IDS, ...BOSS_IDS]) {
       const mob = createMob(1, MOBS[id], MOBS[id].minLevel, { x: 0, y: 0, z: 0 });
       applyDungeonMobTuning(mob, SANCTUM, 'normal');
-      expect(mob.mechanicDamageMult, id).toBe(tuning.damageMultiplierByMob[id]);
+      const expected =
+        tuning.mechanicDamageMultiplierByMob?.[id] ?? tuning.damageMultiplierByMob[id];
+      expect(mob.mechanicDamageMult, id).toBe(expected);
     }
+    // The one live override, asserted concretely: Korzul's entity mechanics
+    // run at 15x while his melee template transform stays at 8.5x.
+    const korzul = createMob(1, MOBS.korzul_the_gravewyrm, 20, { x: 0, y: 0, z: 0 });
+    applyDungeonMobTuning(korzul, SANCTUM, 'normal');
+    expect(korzul.mechanicDamageMult).toBe(15);
   });
 
-  it('scales Korzul Grave Inferno and Korgath stomp with their melee factors', () => {
+  it('scales Grave Inferno by the mechanic override and Korgath stomp by his melee factor', () => {
     const tuning = sanctumTuning();
     // Korzul's aoePulse is GONE (2026-07): Grave Inferno replaced it, a
     // stationary 8s channel with four escalating avoidable pulses.
@@ -179,11 +201,13 @@ describe('normal Gravewyrm Sanctum mechanic scaling', () => {
     if (!inferno || korgathStomp?.min === undefined || korgathStomp.max === undefined) return;
     // Raw (unmitigated) mechanic damage after the per-mob multiplier: the
     // FOURTH (largest) inferno pulse on normal, and the stomp band.
-    const mult = tuning.damageMultiplierByMob.korzul_the_gravewyrm;
-    expect(inferno.min * inferno.pulses * mult).toBe(210);
-    expect(inferno.max * inferno.pulses * mult).toBe(270);
-    expect(korgathStomp.min * tuning.damageMultiplierByMob.korgath_the_bound).toBe(155);
-    expect(korgathStomp.max * tuning.damageMultiplierByMob.korgath_the_bound).toBe(232.5);
+    const mult = tuning.mechanicDamageMultiplierByMob?.korzul_the_gravewyrm;
+    expect(mult).toBe(15);
+    if (mult === undefined) return;
+    expect(inferno.min * inferno.pulses * mult).toBe(420);
+    expect(inferno.max * inferno.pulses * mult).toBe(540);
+    expect(korgathStomp.min * tuning.damageMultiplierByMob.korgath_the_bound).toBe(190);
+    expect(korgathStomp.max * tuning.damageMultiplierByMob.korgath_the_bound).toBe(285);
   });
 
   it('leaves untuned normal dungeons untouched', () => {


### PR DESCRIPTION
## Why

A real fresh 3-man cleared normal Gravewyrm Sanctum on the #2378 tuning without any real pressure. Two root causes:

1. The Monte Carlo bench that validated #2378 modeled the worst-case healer (lone fresh resto shaman on autopilot: no cooldowns, no CC, no movement) and priced the floors so that worst case barely survived. Real groups outperform that floor by a wide margin, so the calibration was a ceiling for the bench and a walk for players.
2. Korzul's signature mechanic never fired. Grave Inferno was cadence-only (every 30s, first cast at 30s) and normal groups kill him in 15 to 26 seconds, so the burn phase was dead content at any reasonable group dps. The bench never saw it either.

## What

Three commits, normal Sanctum only (heroic numbers untouched; the one shared piece is the template-level hp gate, which guarantees heroic groups also meet the channel).

**1. Grave Inferno hp gate (feat)**. `infernoChannel` gains optional `atHpPct` thresholds mirroring `summonAdds`; Korzul carries `[0.5]`. Crossing the gate arms the channel immediately (melee-gated like the cadence, which reseeds from the arm), a threshold crossed while a channel is live is served by that channel (no back-to-back 8s roots), and gates re-arm on evade and respawn. This also closes a pre-existing reset gap: a leashed or respawned Korzul previously kept mid-flight channel state. The gate sits above his 30% enrage so the burn phase never stacks on enraged melee. The gate walk draws no rng and pulses draw exactly one roll each, so the stream stays stable; parity is green.

**2. Pressure retune plus mechanic decoupling (fix)**. Korgath and Korzul rise to MEET Velkhar, the existing peak fight. New `NormalDungeonTuning.mechanicDamageMultiplierByMob` lets an avoidable telegraphed mechanic price independently of the unavoidable tank-swing line.

| Mob | Mult before | Mult after | Ref-warrior min swing | Fresh-tank dtps |
|---|---|---|---|---|
| sanctum_boneguard | 3.4 | 3.8 | 92 to 103 | 73 to 81 |
| sanctum_drakonid | 3.3 | 3.7 | 100 to 112 | 81 to 91 |
| raised_bonewalker | 3.75 | 3.75 (unchanged) | 50 | 42 |
| korgath_the_bound | 7.75 | 9.5 | 245 to 301 | 157 to 193 |
| grand_necromancer_velkhar | 6.6 | 6.6 (unchanged) | 200 | 179 (wave peak ~305) |
| korzul_the_gravewyrm | 7.5 | 8.5 melee, 15 mechanics | 247 to 280 | 171 to 193 |

Korzul's melee sits below Korgath's because he also carries the now-guaranteed channel plus his enrage. His Grave Inferno at 15x: pulse one 105 to 135 raw (a scratch, ~10% of a fresh melee pool), the full four-pulse channel 1050 to 1350 raw, lethal to every fresh melee dps pool in the game (760 to 1112 hp) and 60 to 98% of a fresh tank pool. It is fully avoidable: rooted boss, no melee during the channel, true-radius telegraph ring.

**3. Bench upgrade (test)**. Survival now runs both compositions (5-man drain at 240 group dps, and the weakest 3-man: tank plus autopilot healer plus one 80 dps player), and the bench tank plays the inferno as intended, walking out of the ring at run speed (usually eating the small first pulse) instead of standing all four.

## Monte Carlo (8 seeds, scripts/sanctum_fresh_montecarlo.ts)

5-man autopilot survival, clears across the three fresh tanks (prot warrior, prot paladin, feral druid):

| Encounter | #2378 v2 band | This PR |
|---|---|---|
| Trash pull | 100% | 100% |
| Korgath | 100% | 87.5 to 100% (minHp p10 0.1 to 5.8%) |
| Velkhar | 62.5 to 87.5% | 62.5 to 87.5% (unchanged fight) |
| Korzul | 75 to 100% | 75 to 87.5%, now WITH a guaranteed burn phase per kill |

Weakest 3-man comp: trash 12.5 to 75%, bosses 0 to 50% clears. A 3-man now has to bring real dps or heals beyond the floor comp; that is the intended new pressure.

Calibration notes from the iteration, disclosed: Korzul at 9.25x melee stacked with the guaranteed inferno collapsed the bear-tank comp to 12.5% autopilot clears, so his melee settled at 8.5x (the gate counts as pressure). Velkhar at 7.0x dropped the paladin comp to 37.5%, so he reverted to live 6.6x.

## Solo economy

Unchanged in stance and disclosed: a best-in-slot self-healing tank out-heals boss intake (dtps p50 102 to 132 vs the 140 self-heal ceiling), and the trash pull is now borderline (141 p50 vs 140). Clear time (55.9k instance hp, doubled health kept) plus the 300s instance recycle carry the anti-solo economics, as accepted on #2378.

## Test plan

- [x] tests/grave_inferno.test.ts: 3 new gate tests (immediate arm at 50%, cadence reseed, mid-channel gate served by the live channel, no re-arm on hp hover)
- [x] tests/gravewyrm_normal_tuning.test.ts: floors 100/200/50, literal pins for both maps, mechanic override subset rule, entity stamping (Korzul mechanics 15x, melee 8.5x)
- [x] Affected suites green: gravewyrm_normal_tuning, grave_inferno, heroic_difficulty_floors, dungeon_difficulty, boss_add_leash, dungeons, nythraxis_raid, gravewyrm_farm_exploit, architecture, localization_fixes, parity
- [x] Full gate: 20,085 passed, 2 failed in tests/deploy_watchdog.test.ts, confirmed identical on the untouched release/v0.30.0 tip (the documented macOS env flake)
- [x] tsc clean, biome clean on changed files
- [x] Fresh architecture review (determinism, draw order, three-host parity): pass, no blocking findings
