### PR TITLE
fix(server): include every realm's characters in the GDPR data export

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -2022,16 +2022,20 @@ export async function consumeRecoveryCode(accountId: number, codeHash: string): 
 }
 
 // GDPR-style data export bundle: the account's own profile plus every character
-// it owns on this realm, as plain JSON. Excludes secrets (password hash, tokens).
-// Also carries the folded retention rollups (lifetime playtime totals and the
-// account-to-IP association ledger): they are stored personal data, so a data
-// export must include them even after the raw sessions folded away.
+// it owns across every realm this deployment runs (account-wide, like
+// characterCountForAccount: the account portal is an account-wide self-service
+// surface, and a process-per-realm deployment can host the same account's
+// characters on several realm processes sharing this database), as plain JSON.
+// Excludes secrets (password hash, tokens). Also carries the folded retention
+// rollups (lifetime playtime totals and the account-to-IP association ledger):
+// they are stored personal data, so a data export must include them even after
+// the raw sessions folded away.
 export async function exportAccountData(
   accountId: number,
 ): Promise<Record<string, unknown> | null> {
   const acct = await accountById(accountId);
   if (!acct) return null;
-  const characters = await listCharacters(accountId);
+  const characters = await listCharactersAllRealms(accountId);
   const twoFactorEnabled = await accountTwoFactorEnabled(accountId);
   const playtimeTotals = await pool.query(
     `SELECT character_id, playtime_seconds, sessions, last_played
@@ -2064,6 +2068,7 @@ export async function exportAccountData(
       class: c.class,
       level: c.level,
       state: c.state,
+      realm: c.realm,
     })),
     playtimeTotals: playtimeTotals.rows,
     ipAssociations: ipAssociations.rows,
@@ -2539,6 +2544,26 @@ export async function listCharacters(accountId: number): Promise<CharacterRow[]>
       WHERE c.account_id = $1 AND c.realm = $2
       ORDER BY c.id`,
     [accountId, REALM],
+  );
+  return res.rows;
+}
+
+// Account-wide character list across every realm this deployment runs, used by
+// the GDPR export (exportAccountData below): the export is an account-wide
+// self-service surface, same as characterCountForAccount, so it must not stop
+// at this process's realm the way listCharacters above deliberately does.
+// Selects the realm column so the export can label which realm each character
+// belongs to. One query, no per-realm loop: `characters` is already indexed
+// on account_id (characters_account), so this stays a single indexed read.
+export async function listCharactersAllRealms(
+  accountId: number,
+): Promise<(CharacterRow & { realm: string })[]> {
+  const res = await pool.query(
+    `SELECT id, account_id, name, class, level, state, is_gm, force_rename, realm
+       FROM characters
+      WHERE account_id = $1
+      ORDER BY realm, id`,
+    [accountId],
   );
   return res.rows;
 }

--- a/tests/account_server.test.ts
+++ b/tests/account_server.test.ts
@@ -70,6 +70,10 @@ const parse = (res: any) => ({
 // the right rows by inspecting the SQL, and records the writes it sees.
 let accountRow: any;
 let characters: any[];
+// Rows returned for the account-wide (every realm) character read the GDPR
+// export uses: distinct from `characters` (this process's realm only) so a
+// test can prove the export is not silently dropping the other-realm rows.
+let charactersAllRealms: any[];
 let charCount: number;
 let writes: { sql: string; params: any[] }[];
 // Pending email-change row the consume UPDATE returns (null = invalid/expired).
@@ -88,6 +92,9 @@ function routeQuery(sql: string, params: any[]) {
     return { rows: [{ unsubscribe_token: params[1] ?? 'unsub-token' }] };
   if (sql.includes('FROM accounts WHERE id')) return { rows: accountRow ? [accountRow] : [] };
   if (sql.includes('COUNT(*)')) return { rows: [{ count: charCount }] };
+  // Must be checked before the generic realm-scoped branch below: this is the
+  // account-wide (every realm) read, keyed by its distinguishing ORDER BY.
+  if (sql.includes('ORDER BY realm, id')) return { rows: charactersAllRealms };
   if (sql.includes('FROM characters WHERE account_id') || sql.includes('FROM characters c')) {
     return { rows: characters };
   }
@@ -113,6 +120,7 @@ beforeEach(async () => {
     marketing_opt_in: false,
   };
   characters = [{ id: 10 }, { id: 11 }];
+  charactersAllRealms = characters;
   charCount = 2;
   pendingChange = { account_id: 1, new_email: 'new@example.com' };
   emailBackfillRows = 1;
@@ -472,6 +480,23 @@ describe('handleAccountExport', () => {
     const bundle = JSON.parse(res.body);
     expect(bundle.account).toMatchObject({ id: 1, username: 'Aelwyn' });
     expect(Array.isArray(bundle.characters)).toBe(true);
+  });
+  it('includes characters from every realm the account holds, not just this process realm', async () => {
+    // This deployment runs multiple realm processes against one shared
+    // database (server/realm.ts); an account may hold characters on several of
+    // them. The export is an account-wide self-service surface (matching
+    // characterCountForAccount / handleAccountWhoami), so it must return every
+    // realm's characters, not only the realm serving this request.
+    charactersAllRealms = [
+      { id: 10, name: 'Aelwyn', class: 'warrior', level: 12, state: {}, realm: 'ashvale' },
+      { id: 55, name: 'Faelar', class: 'druid', level: 30, state: {}, realm: 'thornreach' },
+    ];
+    const res = makeRes();
+    await handleAccountExport(makeReq({}, '198.51.100.42'), res, 1);
+    const bundle = JSON.parse(res.body);
+    const realms = bundle.characters.map((c: any) => c.realm).sort();
+    expect(realms).toEqual(['ashvale', 'thornreach']);
+    expect(bundle.characters.map((c: any) => c.id).sort()).toEqual([10, 55]);
   });
   it('404s when the account is gone', async () => {
     accountRow = null;


### PR DESCRIPTION
## Summary

The self-service GDPR account-data export (`exportAccountData` in `server/db.ts`, backing
`POST /api/account/export`) called the realm-scoped `listCharacters(accountId)`, which
filters on this process's own `REALM` constant. This deployment runs one process per
realm sharing a single `DATABASE_URL`, so one account can legitimately hold characters on
several realms; a completed export was silently missing real personal data (name, class,
level, full character state) for every character on any realm other than the one that
happened to serve the request. That's a compliance gap, not a UX nit: an export that is
supposed to be complete was not.

By contrast, `characterCountForAccount` (used by the account portal's "whoami" summary on
the same page) is already account-wide with no realm filter, so the export was
inconsistent with the repo's own existing convention for "how many characters does this
account have."

## Related issues

N/A (found via an independent UAT sweep against release/v0.31.0).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/account_server.test.ts tests/server/tunables.test.ts tests/architecture.test.ts`, `npx tsc --noEmit`, `npx @biomejs/biome check --write server/db.ts tests/account_server.test.ts`
- Manual steps: added a test seeding characters on two different realms (`ashvale`,
  `thornreach`) for one account; confirmed it fails against the old realm-scoped query
  (missing the other realm's character) and passes after switching to the account-wide query.

```mermaid
flowchart TD
    A["POST /api/account/export"] --> B["exportAccountData(accountId)"]
    B --> C["listCharacters(accountId)\nWHERE account_id = $1 AND realm = REALM"]
    C --> D["Only characters on THIS process's realm\nare included in the export"]
    D --> E["Characters on other realms:\nsilently missing from a 'complete' GDPR export"]
    B -.->|fix| F["listCharactersAllRealms(accountId)\nWHERE account_id = $1 (no realm filter)"]
    F --> G["Every character across every realm\nincluded, each tagged with its realm"]
```

## Checklist

### Quality

- [x] Targeted tests (listed above) plus `tsc --noEmit` and `biome check` on touched
      files are green. Did not run the full `npm run gate`; relying on targeted tests plus CI.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, server-only data export, no UI surface touched.
- ~~Accessible.~~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] Regenerated i18n status files via `npm run i18n:gen` for the pre-push guard; no
      hand edits to generated files.
