### PR TITLE
fix(auth): disconnect live sessions on password change or reset

### DIFF
--- a/server/account.ts
+++ b/server/account.ts
@@ -97,6 +97,17 @@ export interface AccountGameHooks {
   disconnectAccount(accountId: number, reason: string): void;
 }
 
+// The narrower hook a credential-change handler needs: just the live-WS
+// teardown, not the online-character check the deactivate flow uses.
+type DisconnectHook = Pick<AccountGameHooks, 'disconnectAccount'>;
+
+// Disconnect reason for the live-WS kick a password change/reset forces. Byte-
+// identical to admin.ts's IP_BLOCK_KICK_MESSAGE, which the client already
+// localizes (api_error_i18n.ts): reusing the exact literal needs no new i18n
+// work and matches the same "credentials changed, an open socket is no longer
+// trustworthy" posture as the admin-initiated reset-password handlers.
+const CREDENTIAL_CHANGE_KICK_MESSAGE = 'Connection to the server was lost.';
+
 // GET /api/account: whoami; re-validates a stored token on reload + feeds the
 // portal header. characterCount is account-wide (every realm), matching the
 // account-wide nature of this self-service portal.
@@ -124,12 +135,16 @@ export async function handleAccountWhoami(
 // POST /api/account/password: re-verify current, then revoke every OTHER token
 // so a password change signs out other devices while keeping this one alive.
 // callerToken is resolved by main.ts; it must never be null here (validated up
-// the stack) so the revoke below can never accidentally nuke this session.
+// the stack) so the revoke below can never accidentally nuke this session. Token
+// revocation alone does not close an already-open WS (an attacker who is
+// already in-world stays connected), so we also force-disconnect any live
+// session for the account, mirroring handleAccountDeactivate below.
 export async function handleAccountChangePassword(
   req: http.IncomingMessage,
   res: http.ServerResponse,
   accountId: number,
   callerToken: string,
+  hooks: DisconnectHook,
 ): Promise<void> {
   if (!rateLimited(req).allowed) return json(res, 429, { error: 'too many attempts, slow down' });
   const body = await readBody(req);
@@ -160,6 +175,7 @@ export async function handleAccountChangePassword(
   }
   await updatePasswordHash(accountId, await hashPassword(next));
   await revokeTokensExcept(accountId, callerToken);
+  hooks.disconnectAccount(accountId, CREDENTIAL_CHANGE_KICK_MESSAGE);
   // Best-effort security notice; never blocks the password change on mail state.
   emailPasswordChanged(acct);
   return json(res, 200, { ok: true });
@@ -198,10 +214,15 @@ export async function handleAccountPasswordForgot(
 // Unauthenticated: complete a reset with the emailed token + a new password. The
 // token is validated, the new password applied, and every session revoked, all in
 // one atomic DB call. Invalid and expired tokens return the same 400 so neither a
-// bad guess nor an old link reveals anything.
+// bad guess nor an old link reveals anything. Revoking tokens alone does not close
+// an already-open WS (this reset exists precisely because the account may be
+// recovering from a compromise, and a compromised session may already be
+// in-world), so we also force-disconnect any live session for the account right
+// after the reset lands, mirroring handleAccountDeactivate below.
 export async function handleAccountPasswordReset(
   req: http.IncomingMessage,
   res: http.ServerResponse,
+  hooks: DisconnectHook,
 ): Promise<void> {
   if (!rateLimited(req).allowed) return json(res, 429, { error: 'too many attempts, slow down' });
   const body = await readBody(req);
@@ -216,6 +237,7 @@ export async function handleAccountPasswordReset(
   }
   const applied = await consumePasswordResetRequest(hashEmailToken(raw), await hashPassword(next));
   if (!applied) return json(res, 400, { error: 'invalid or expired link' });
+  hooks.disconnectAccount(applied.accountId, CREDENTIAL_CHANGE_KICK_MESSAGE);
   // Best-effort "your password changed" notice; never blocks the reset on mail state.
   const target = await accountMailTarget(applied.accountId);
   if (target) emailPasswordChanged(target);
@@ -727,7 +749,13 @@ async function passwordHandler(ctx: Ctx): Promise<void> {
     json(ctx.res, 401, NOT_AUTHENTICATED);
     return;
   }
-  return handleAccountChangePassword(ctx.req, ctx.res, ctxAccountId(ctx), callerToken);
+  return handleAccountChangePassword(
+    ctx.req,
+    ctx.res,
+    ctxAccountId(ctx),
+    callerToken,
+    useRuntime(),
+  );
 }
 
 /** POST /api/account/logout: revoke this device's bearer token. */

--- a/server/account.ts
+++ b/server/account.ts
@@ -93,8 +93,12 @@ const PASSWORD_RESET_TTL_HOURS = 1;
 export interface AccountGameHooks {
   /** True when any of the account's characters is currently in a live session. */
   anyCharacterOnline(characterIds: number[]): boolean;
-  /** Close any established socket for the account right after deactivation. */
-  disconnectAccount(accountId: number, reason: string): void;
+  /**
+   * Close any established socket for the account. Pass exceptToken (the
+   * caller's own bearer token) to spare the session that just made the
+   * request; omit it to kick every live session unconditionally.
+   */
+  disconnectAccount(accountId: number, reason: string, exceptToken?: string): void;
 }
 
 // The narrower hook a credential-change handler needs: just the live-WS
@@ -137,8 +141,11 @@ export async function handleAccountWhoami(
 // callerToken is resolved by main.ts; it must never be null here (validated up
 // the stack) so the revoke below can never accidentally nuke this session. Token
 // revocation alone does not close an already-open WS (an attacker who is
-// already in-world stays connected), so we also force-disconnect any live
-// session for the account, mirroring handleAccountDeactivate below.
+// already in-world stays connected), so we also force-disconnect any OTHER live
+// session for the account, mirroring handleAccountDeactivate below but passing
+// callerToken as the exception so the caller's own live session (if any, e.g.
+// changing password from the in-game HUD account panel) is spared exactly like
+// its token is.
 export async function handleAccountChangePassword(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -175,7 +182,7 @@ export async function handleAccountChangePassword(
   }
   await updatePasswordHash(accountId, await hashPassword(next));
   await revokeTokensExcept(accountId, callerToken);
-  hooks.disconnectAccount(accountId, CREDENTIAL_CHANGE_KICK_MESSAGE);
+  hooks.disconnectAccount(accountId, CREDENTIAL_CHANGE_KICK_MESSAGE, callerToken);
   // Best-effort security notice; never blocks the password change on mail state.
   emailPasswordChanged(acct);
   return json(res, 200, { ok: true });

--- a/server/account.ts
+++ b/server/account.ts
@@ -93,12 +93,8 @@ const PASSWORD_RESET_TTL_HOURS = 1;
 export interface AccountGameHooks {
   /** True when any of the account's characters is currently in a live session. */
   anyCharacterOnline(characterIds: number[]): boolean;
-  /**
-   * Close any established socket for the account. Pass exceptToken (the
-   * caller's own bearer token) to spare the session that just made the
-   * request; omit it to kick every live session unconditionally.
-   */
-  disconnectAccount(accountId: number, reason: string, exceptToken?: string): void;
+  /** Close any established socket for the account, unconditionally. */
+  disconnectAccount(accountId: number, reason: string): void;
 }
 
 // The narrower hook a credential-change handler needs: just the live-WS
@@ -141,11 +137,15 @@ export async function handleAccountWhoami(
 // callerToken is resolved by main.ts; it must never be null here (validated up
 // the stack) so the revoke below can never accidentally nuke this session. Token
 // revocation alone does not close an already-open WS (an attacker who is
-// already in-world stays connected), so we also force-disconnect any OTHER live
-// session for the account, mirroring handleAccountDeactivate below but passing
-// callerToken as the exception so the caller's own live session (if any, e.g.
-// changing password from the in-game HUD account panel) is spared exactly like
-// its token is.
+// already in-world stays connected), so we also force-disconnect every live
+// session for the account, mirroring handleAccountDeactivate below. This
+// deliberately does NOT try to spare the caller's own live session: a bearer
+// token is a reusable wire credential, not a per-socket identity, so a stolen
+// token could authenticate an attacker's live session too, and an exemption
+// keyed on token equality could just as easily spare the attacker instead of
+// the legitimate device. Any of the account's own other tabs simply
+// reconnects with the fresh credentials, the same as password reset already
+// requires.
 export async function handleAccountChangePassword(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -182,7 +182,7 @@ export async function handleAccountChangePassword(
   }
   await updatePasswordHash(accountId, await hashPassword(next));
   await revokeTokensExcept(accountId, callerToken);
-  hooks.disconnectAccount(accountId, CREDENTIAL_CHANGE_KICK_MESSAGE, callerToken);
+  hooks.disconnectAccount(accountId, CREDENTIAL_CHANGE_KICK_MESSAGE);
   // Best-effort security notice; never blocks the password change on mail state.
   emailPasswordChanged(acct);
   return json(res, 200, { ok: true });

--- a/server/game.ts
+++ b/server/game.ts
@@ -659,6 +659,10 @@ const ADMIN_LOCATION_POI_RADIUS = 32;
 export interface ClientSession {
   ws: WebSocket;
   accountId: number;
+  // The bearer token this session authenticated (or last resumed) with. Lets a
+  // credential-change kick exempt the caller's own live session (disconnectAccount's
+  // exceptToken) instead of force-closing the socket that just made the request.
+  authToken: string;
   accountCosmetics: AccountCosmetics;
   // Operator-set account flair (AI mark + streamer links), loaded at join and kept
   // current by applyAccountFlairLive. Held on the SESSION, not just the entity,
@@ -2806,6 +2810,10 @@ export class GameServer {
         // passed through from the join handler's DB read. Untrusted at rest, so
         // it is re-validated here before it reaches the client.
         hotbarLayout?: ActionBarLayout | null;
+        // The bearer token this handshake authenticated with (ws_auth.ts). Stashed
+        // on the session so disconnectAccount can exempt this exact session from an
+        // account-wide kick (see ClientSession.authToken).
+        authToken?: string;
       } = {},
   ): ClientSession | { error: string } {
     // Anti-bot: cap simultaneous online characters per account. Accounts can
@@ -2888,6 +2896,7 @@ export class GameServer {
     const session: ClientSession = {
       ws,
       accountId,
+      authToken: meta.authToken ?? '',
       accountCosmetics,
       // Loaded right below by refreshAccountFlair; an account with no flair (every
       // ordinary player) keeps these empty values and never touches the wire.
@@ -3070,6 +3079,10 @@ export class GameServer {
     session.linkdead = false;
     session.graceUntil = 0;
     session.awaitingPong = false;
+    // A resume authenticates with a fresh bearer token; keep authToken current so a
+    // later credential-change exemption matches the token this socket is actually
+    // holding, not a stale one from the original join.
+    if (meta.authToken !== undefined) session.authToken = meta.authToken;
     const sessionIp = meta.ip ?? '';
     if (sessionIp !== session.ip) {
       this.releaseIpSession(session.ip);
@@ -3876,9 +3889,15 @@ export class GameServer {
     return state ? state.level : null;
   }
 
-  disconnectAccount(accountId: number, reason: string): void {
+  // Force-close every live session for the account, except one: pass exceptToken
+  // (the caller's own bearer token) to spare the session that just made the
+  // request (self-service password change) while still kicking every other live
+  // session for the account. Omit it (moderation, deactivation, password reset)
+  // to kick unconditionally.
+  disconnectAccount(accountId: number, reason: string, exceptToken?: string): void {
     for (const session of [...this.clients.values()]) {
       if (session.accountId !== accountId) continue;
+      if (exceptToken !== undefined && session.authToken === exceptToken) continue;
       void this.kickSession(session, reason, 'moderation action');
     }
   }

--- a/server/game.ts
+++ b/server/game.ts
@@ -659,10 +659,6 @@ const ADMIN_LOCATION_POI_RADIUS = 32;
 export interface ClientSession {
   ws: WebSocket;
   accountId: number;
-  // The bearer token this session authenticated (or last resumed) with. Lets a
-  // credential-change kick exempt the caller's own live session (disconnectAccount's
-  // exceptToken) instead of force-closing the socket that just made the request.
-  authToken: string;
   accountCosmetics: AccountCosmetics;
   // Operator-set account flair (AI mark + streamer links), loaded at join and kept
   // current by applyAccountFlairLive. Held on the SESSION, not just the entity,
@@ -2810,10 +2806,6 @@ export class GameServer {
         // passed through from the join handler's DB read. Untrusted at rest, so
         // it is re-validated here before it reaches the client.
         hotbarLayout?: ActionBarLayout | null;
-        // The bearer token this handshake authenticated with (ws_auth.ts). Stashed
-        // on the session so disconnectAccount can exempt this exact session from an
-        // account-wide kick (see ClientSession.authToken).
-        authToken?: string;
       } = {},
   ): ClientSession | { error: string } {
     // Anti-bot: cap simultaneous online characters per account. Accounts can
@@ -2896,7 +2888,6 @@ export class GameServer {
     const session: ClientSession = {
       ws,
       accountId,
-      authToken: meta.authToken ?? '',
       accountCosmetics,
       // Loaded right below by refreshAccountFlair; an account with no flair (every
       // ordinary player) keeps these empty values and never touches the wire.
@@ -3079,10 +3070,6 @@ export class GameServer {
     session.linkdead = false;
     session.graceUntil = 0;
     session.awaitingPong = false;
-    // A resume authenticates with a fresh bearer token; keep authToken current so a
-    // later credential-change exemption matches the token this socket is actually
-    // holding, not a stale one from the original join.
-    if (meta.authToken !== undefined) session.authToken = meta.authToken;
     const sessionIp = meta.ip ?? '';
     if (sessionIp !== session.ip) {
       this.releaseIpSession(session.ip);
@@ -3889,15 +3876,16 @@ export class GameServer {
     return state ? state.level : null;
   }
 
-  // Force-close every live session for the account, except one: pass exceptToken
-  // (the caller's own bearer token) to spare the session that just made the
-  // request (self-service password change) while still kicking every other live
-  // session for the account. Omit it (moderation, deactivation, password reset)
-  // to kick unconditionally.
-  disconnectAccount(accountId: number, reason: string, exceptToken?: string): void {
+  // Force-close every live session for the account. A bearer token is a reusable
+  // wire credential, not a per-socket identity: an earlier revision tried to spare
+  // the caller's own session by comparing the live socket's auth token against the
+  // request's bearer token, but a stolen/shared token authenticates identically on
+  // both, so that comparison could just as easily spare an attacker's connection.
+  // Kick unconditionally; a legitimate caller's own other tab reconnects with the
+  // fresh credentials the same as any other client would.
+  disconnectAccount(accountId: number, reason: string): void {
     for (const session of [...this.clients.values()]) {
       if (session.accountId !== accountId) continue;
-      if (exceptToken !== undefined && session.authToken === exceptToken) continue;
       void this.kickSession(session, reason, 'moderation action');
     }
   }

--- a/server/main.ts
+++ b/server/main.ts
@@ -2538,7 +2538,8 @@ configureAccountRuntime({
     [...liveGame().clients.values()].some(
       (s) => s.characterId != null && characterIds.includes(s.characterId),
     ),
-  disconnectAccount: (id, reason) => liveGame().disconnectAccount(id, reason),
+  disconnectAccount: (id, reason, exceptToken) =>
+    liveGame().disconnectAccount(id, reason, exceptToken),
 });
 
 // Inject the one main.ts-local singleton the ported wallet handlers

--- a/server/main.ts
+++ b/server/main.ts
@@ -2019,7 +2019,9 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       const callerToken = bearerToken(req);
       if (!callerToken)
         return json(res, 401, { error: 'not authenticated', code: 'auth.required' });
-      return handleAccountChangePassword(req, res, accountId, callerToken);
+      return handleAccountChangePassword(req, res, accountId, callerToken, {
+        disconnectAccount: (id, reason) => liveGame().disconnectAccount(id, reason),
+      });
     }
     // Password reset is for users who are locked out, so both routes are
     // unauthenticated (rate-limited + web-login guarded above, and each handler is
@@ -2028,7 +2030,9 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       return handleAccountPasswordForgot(req, res);
     }
     if (req.method === 'POST' && url === '/api/account/password/reset') {
-      return handleAccountPasswordReset(req, res);
+      return handleAccountPasswordReset(req, res, {
+        disconnectAccount: (id, reason) => liveGame().disconnectAccount(id, reason),
+      });
     }
     if (req.method === 'POST' && url === '/api/account/logout') {
       const callerToken = bearerToken(req);

--- a/server/main.ts
+++ b/server/main.ts
@@ -2020,7 +2020,8 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       if (!callerToken)
         return json(res, 401, { error: 'not authenticated', code: 'auth.required' });
       return handleAccountChangePassword(req, res, accountId, callerToken, {
-        disconnectAccount: (id, reason) => liveGame().disconnectAccount(id, reason),
+        disconnectAccount: (id, reason, exceptToken) =>
+          liveGame().disconnectAccount(id, reason, exceptToken),
       });
     }
     // Password reset is for users who are locked out, so both routes are

--- a/server/main.ts
+++ b/server/main.ts
@@ -2020,8 +2020,7 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       if (!callerToken)
         return json(res, 401, { error: 'not authenticated', code: 'auth.required' });
       return handleAccountChangePassword(req, res, accountId, callerToken, {
-        disconnectAccount: (id, reason, exceptToken) =>
-          liveGame().disconnectAccount(id, reason, exceptToken),
+        disconnectAccount: (id, reason) => liveGame().disconnectAccount(id, reason),
       });
     }
     // Password reset is for users who are locked out, so both routes are
@@ -2538,8 +2537,7 @@ configureAccountRuntime({
     [...liveGame().clients.values()].some(
       (s) => s.characterId != null && characterIds.includes(s.characterId),
     ),
-  disconnectAccount: (id, reason, exceptToken) =>
-    liveGame().disconnectAccount(id, reason, exceptToken),
+  disconnectAccount: (id, reason) => liveGame().disconnectAccount(id, reason),
 });
 
 // Inject the one main.ts-local singleton the ported wallet handlers

--- a/server/ws_auth.ts
+++ b/server/ws_auth.ts
@@ -311,6 +311,10 @@ export function createWsAuth(deps: WsAuthDeps): WsAuthHandlers {
       reason: chatMute.reason,
       chatStrikes: status.chatStrikes,
       accountCosmetics,
+      // Stashed so a self-service password change can exempt this exact live
+      // session from the account-wide kick (GameServer.disconnectAccount's
+      // exceptToken); see ClientSession.authToken.
+      authToken: token,
       isAdmin,
       adminPermissions,
       clientSeed,

--- a/server/ws_auth.ts
+++ b/server/ws_auth.ts
@@ -311,10 +311,6 @@ export function createWsAuth(deps: WsAuthDeps): WsAuthHandlers {
       reason: chatMute.reason,
       chatStrikes: status.chatStrikes,
       accountCosmetics,
-      // Stashed so a self-service password change can exempt this exact live
-      // session from the account-wide kick (GameServer.disconnectAccount's
-      // exceptToken); see ClientSession.authToken.
-      authToken: token,
       isAdmin,
       adminPermissions,
       clientSeed,

--- a/tests/account_server.test.ts
+++ b/tests/account_server.test.ts
@@ -212,6 +212,7 @@ describe('handleAccountChangePassword', () => {
       res,
       1,
       'tokA',
+      noHooks,
     );
     expect(parse(res).status).toBe(401);
     expect(writes.some((w) => w.sql.includes('UPDATE accounts SET password_hash'))).toBe(false);
@@ -223,6 +224,7 @@ describe('handleAccountChangePassword', () => {
       res,
       1,
       'tokA',
+      noHooks,
     );
     expect(parse(res).status).toBe(400);
   });
@@ -233,6 +235,7 @@ describe('handleAccountChangePassword', () => {
       res,
       1,
       'tokA',
+      noHooks,
     );
     const { status, data } = parse(res);
     expect(status).toBe(400);
@@ -245,6 +248,7 @@ describe('handleAccountChangePassword', () => {
       res,
       1,
       'tokA',
+      noHooks,
     );
     expect(parse(res).status).toBe(200);
     expect(writes.some((w) => w.sql.includes('UPDATE accounts SET password_hash'))).toBe(true);
@@ -253,6 +257,36 @@ describe('handleAccountChangePassword', () => {
     // The "<> $2" (keep caller) variant, with the caller token as a param.
     expect(revoke!.sql).toContain('token <>');
     expect(revoke!.params).toContain('tokA');
+  });
+  // Token revocation alone does not close an already-open WS: an attacker who
+  // phished the password and is already in-world would otherwise keep playing
+  // on the victim's character after the victim locks them out. A successful
+  // change must also force-disconnect any live session for the account.
+  it('force-disconnects any live WS session for the account on a successful change', async () => {
+    const disconnectAccount = vi.fn();
+    const res = makeRes();
+    await handleAccountChangePassword(
+      makeReq({ current: CORRECT_PW, next: 'brandnew1' }, '198.51.100.93'),
+      res,
+      1,
+      'tokA',
+      { disconnectAccount },
+    );
+    expect(parse(res).status).toBe(200);
+    expect(disconnectAccount).toHaveBeenCalledWith(1, expect.any(String));
+  });
+  it('does not disconnect anyone when the change is rejected (wrong current password)', async () => {
+    const disconnectAccount = vi.fn();
+    const res = makeRes();
+    await handleAccountChangePassword(
+      makeReq({ current: 'wrong', next: 'brandnew1' }, '198.51.100.94'),
+      res,
+      1,
+      'tokA',
+      { disconnectAccount },
+    );
+    expect(parse(res).status).toBe(401);
+    expect(disconnectAccount).not.toHaveBeenCalled();
   });
 });
 
@@ -348,6 +382,7 @@ describe('account portal rate limiting (429)', () => {
         last,
         1,
         'tokA',
+        noHooks,
       );
     }
     expect(parse(last).status).toBe(429);
@@ -386,6 +421,7 @@ describe('account portal auth-failure accounting', () => {
       res,
       1,
       'tokA',
+      noHooks,
     );
     expect(parse(res).status).toBe(200);
   });

--- a/tests/account_server.test.ts
+++ b/tests/account_server.test.ts
@@ -262,7 +262,7 @@ describe('handleAccountChangePassword', () => {
   // phished the password and is already in-world would otherwise keep playing
   // on the victim's character after the victim locks them out. A successful
   // change must also force-disconnect any live session for the account.
-  it('force-disconnects any OTHER live WS session for the account, exempting the caller', async () => {
+  it('force-disconnects every live WS session for the account, unconditionally', async () => {
     const disconnectAccount = vi.fn();
     const res = makeRes();
     await handleAccountChangePassword(
@@ -273,11 +273,13 @@ describe('handleAccountChangePassword', () => {
       { disconnectAccount },
     );
     expect(parse(res).status).toBe(200);
-    // The caller's own token is passed through as the kick exception, so
-    // GameServer.disconnectAccount can spare the session that just made this
-    // request instead of yanking the player mid-session for rotating their own
-    // password (finding 1 on the original PR review).
-    expect(disconnectAccount).toHaveBeenCalledWith(1, expect.any(String), 'tokA');
+    // No exception token: a bearer token is a reusable wire credential, not a
+    // per-socket identity, so exempting a live session by token equality could
+    // just as easily spare an attacker's session sharing a stolen token as the
+    // legitimate caller's. disconnectAccount always kicks every live session for
+    // the account (a review finding on the original PR).
+    expect(disconnectAccount).toHaveBeenCalledWith(1, expect.any(String));
+    expect(disconnectAccount.mock.calls[0]).toHaveLength(2);
   });
   it('does not disconnect anyone when the change is rejected (wrong current password)', async () => {
     const disconnectAccount = vi.fn();

--- a/tests/account_server.test.ts
+++ b/tests/account_server.test.ts
@@ -262,7 +262,7 @@ describe('handleAccountChangePassword', () => {
   // phished the password and is already in-world would otherwise keep playing
   // on the victim's character after the victim locks them out. A successful
   // change must also force-disconnect any live session for the account.
-  it('force-disconnects any live WS session for the account on a successful change', async () => {
+  it('force-disconnects any OTHER live WS session for the account, exempting the caller', async () => {
     const disconnectAccount = vi.fn();
     const res = makeRes();
     await handleAccountChangePassword(
@@ -273,7 +273,11 @@ describe('handleAccountChangePassword', () => {
       { disconnectAccount },
     );
     expect(parse(res).status).toBe(200);
-    expect(disconnectAccount).toHaveBeenCalledWith(1, expect.any(String));
+    // The caller's own token is passed through as the kick exception, so
+    // GameServer.disconnectAccount can spare the session that just made this
+    // request instead of yanking the player mid-session for rotating their own
+    // password (finding 1 on the original PR review).
+    expect(disconnectAccount).toHaveBeenCalledWith(1, expect.any(String), 'tokA');
   });
   it('does not disconnect anyone when the change is rejected (wrong current password)', async () => {
     const disconnectAccount = vi.fn();

--- a/tests/linkdead.test.ts
+++ b/tests/linkdead.test.ts
@@ -240,6 +240,33 @@ describe('linkdead grace lifecycle', () => {
     expect(server.clients.size).toBe(0);
   });
 
+  it('exempts the caller session from an account-wide kick via exceptToken, but kicks a second session', async () => {
+    const server = new GameServer();
+    const wsSelf = fakeWs();
+    const wsOther = fakeWs();
+    // Both sessions join as GM (isGm=true): MAX_ACTIVE_SESSIONS_PER_ACCOUNT caps an
+    // account at one LIVE session, and GMs are the one exemption, which is the
+    // simplest way to get two simultaneous live sessions for one account in this test.
+    const selfSession = expectJoined(
+      server.join(wsSelf, 11, 101, 'Caller', 'warrior', null, true, { authToken: 'tokA' }),
+    );
+    const otherSession = expectJoined(
+      server.join(wsOther, 11, 102, 'Other', 'warrior', null, true, { authToken: 'tokB' }),
+    );
+
+    server.disconnectAccount(11, 'credential change', 'tokA');
+    await vi.waitFor(() => {
+      expect(otherSession.left).toBe(true);
+    });
+
+    // The exempted session (its own password-change request) survives.
+    expect(selfSession.left).toBe(false);
+    expect(server.clients.has(selfSession.pid)).toBe(true);
+    // Every other live session for the account is still kicked.
+    expect(otherSession.left).toBe(true);
+    expect(server.clients.has(otherSession.pid)).toBe(false);
+  });
+
   it('fully logs the character out when the grace window expires', async () => {
     closePlaySession.mockClear();
     const server = new GameServer();

--- a/tests/linkdead.test.ts
+++ b/tests/linkdead.test.ts
@@ -240,31 +240,33 @@ describe('linkdead grace lifecycle', () => {
     expect(server.clients.size).toBe(0);
   });
 
-  it('exempts the caller session from an account-wide kick via exceptToken, but kicks a second session', async () => {
+  it('disconnectAccount kicks every live session for the account unconditionally, even one authenticated with the same stolen bearer token', async () => {
     const server = new GameServer();
-    const wsSelf = fakeWs();
-    const wsOther = fakeWs();
+    const wsVictim = fakeWs();
+    const wsAttacker = fakeWs();
     // Both sessions join as GM (isGm=true): MAX_ACTIVE_SESSIONS_PER_ACCOUNT caps an
     // account at one LIVE session, and GMs are the one exemption, which is the
-    // simplest way to get two simultaneous live sessions for one account in this test.
-    const selfSession = expectJoined(
-      server.join(wsSelf, 11, 101, 'Caller', 'warrior', null, true, { authToken: 'tokA' }),
+    // simplest way to get two simultaneous live sessions for one account in this
+    // test. A bearer token is a reusable wire credential, not a per-socket identity,
+    // so an attacker holding a stolen/shared token can authenticate their own live
+    // session with it; disconnectAccount must not spare either session by token
+    // equality (a prior revision did exactly that, and it could just as easily have
+    // spared the attacker's session instead of the victim's own).
+    const victimSession = expectJoined(
+      server.join(wsVictim, 11, 101, 'Victim', 'warrior', null, true),
     );
-    const otherSession = expectJoined(
-      server.join(wsOther, 11, 102, 'Other', 'warrior', null, true, { authToken: 'tokB' }),
+    const attackerSession = expectJoined(
+      server.join(wsAttacker, 11, 102, 'Attacker', 'warrior', null, true),
     );
 
-    server.disconnectAccount(11, 'credential change', 'tokA');
+    server.disconnectAccount(11, 'credential change');
     await vi.waitFor(() => {
-      expect(otherSession.left).toBe(true);
+      expect(victimSession.left).toBe(true);
+      expect(attackerSession.left).toBe(true);
     });
 
-    // The exempted session (its own password-change request) survives.
-    expect(selfSession.left).toBe(false);
-    expect(server.clients.has(selfSession.pid)).toBe(true);
-    // Every other live session for the account is still kicked.
-    expect(otherSession.left).toBe(true);
-    expect(server.clients.has(otherSession.pid)).toBe(false);
+    expect(server.clients.has(victimSession.pid)).toBe(false);
+    expect(server.clients.has(attackerSession.pid)).toBe(false);
   });
 
   it('fully logs the character out when the grace window expires', async () => {

--- a/tests/password_reset_server.test.ts
+++ b/tests/password_reset_server.test.ts
@@ -66,6 +66,10 @@ function routeQuery(sql: string, params: any[]) {
 
 const hasInsert = () => writes.some((w) => w.sql.includes('INSERT INTO password_reset_requests'));
 
+// No-op live-session hook for tests that don't care about the post-reset
+// disconnect (its own behavior is covered by the dedicated tests below).
+const noHooks = { disconnectAccount: () => {} };
+
 beforeEach(() => {
   accountRow = {
     id: 1,
@@ -120,6 +124,7 @@ describe('handleAccountPasswordReset', () => {
     await handleAccountPasswordReset(
       makeReq({ token: 'a'.repeat(64), next: 'brandnew1' }, '203.0.113.25'),
       res,
+      noHooks,
     );
     expect(parse(res).status).toBe(200);
     expect(writes.some((w) => w.sql.includes('UPDATE accounts SET password_hash'))).toBe(true);
@@ -135,6 +140,7 @@ describe('handleAccountPasswordReset', () => {
     await handleAccountPasswordReset(
       makeReq({ token: 'b'.repeat(64), next: 'brandnew1' }, '203.0.113.26'),
       res,
+      noHooks,
     );
     const { status, data } = parse(res);
     expect(status).toBe(400);
@@ -144,7 +150,7 @@ describe('handleAccountPasswordReset', () => {
 
   it('rejects a missing token (400) before touching the database', async () => {
     const res = makeRes();
-    await handleAccountPasswordReset(makeReq({ next: 'brandnew1' }, '203.0.113.27'), res);
+    await handleAccountPasswordReset(makeReq({ next: 'brandnew1' }, '203.0.113.27'), res, noHooks);
     expect(parse(res).status).toBe(400);
     expect(writes.some((w) => w.sql.includes('UPDATE password_reset_requests'))).toBe(false);
   });
@@ -154,6 +160,7 @@ describe('handleAccountPasswordReset', () => {
     await handleAccountPasswordReset(
       makeReq({ token: 'c'.repeat(64), next: 'abc' }, '203.0.113.28'),
       res,
+      noHooks,
     );
     expect(parse(res).status).toBe(400);
   });
@@ -163,6 +170,7 @@ describe('handleAccountPasswordReset', () => {
     await handleAccountPasswordReset(
       makeReq({ token: 'd'.repeat(64), next: 'a'.repeat(1000) }, '203.0.113.29'),
       res,
+      noHooks,
     );
     expect(parse(res).status).toBe(400);
     // The length gate runs before hashing/consume, so no account row is touched.
@@ -175,8 +183,39 @@ describe('handleAccountPasswordReset', () => {
     await handleAccountPasswordReset(
       makeReq({ token: 'a'.repeat(64), next: 'brandnew1' }, '203.0.113.30'),
       res,
+      noHooks,
     );
     expect(parse(res).status).toBe(200);
     expect(emailMock.passwordChanged).toHaveBeenCalledTimes(1);
+  });
+
+  // Token revocation alone does not close an already-open WS: this reset exists
+  // specifically for a compromised account, so an attacker's already-joined
+  // session must not survive it. A successful reset must force-disconnect any
+  // live session for the account the claimed token resolved to.
+  it('force-disconnects any live WS session for the account on a successful reset', async () => {
+    resetClaim = { account_id: 42 };
+    const disconnectAccount = vi.fn();
+    const res = makeRes();
+    await handleAccountPasswordReset(
+      makeReq({ token: 'a'.repeat(64), next: 'brandnew1' }, '203.0.113.31'),
+      res,
+      { disconnectAccount },
+    );
+    expect(parse(res).status).toBe(200);
+    expect(disconnectAccount).toHaveBeenCalledWith(42, expect.any(String));
+  });
+
+  it('does not disconnect anyone when the token is invalid or expired', async () => {
+    resetClaim = null;
+    const disconnectAccount = vi.fn();
+    const res = makeRes();
+    await handleAccountPasswordReset(
+      makeReq({ token: 'e'.repeat(64), next: 'brandnew1' }, '203.0.113.32'),
+      res,
+      { disconnectAccount },
+    );
+    expect(parse(res).status).toBe(400);
+    expect(disconnectAccount).not.toHaveBeenCalled();
   });
 });

--- a/tests/server/account.test.ts
+++ b/tests/server/account.test.ts
@@ -40,6 +40,7 @@ import {
   listCharacters,
   revokeTokensExcept,
   setAccountDeactivated,
+  updatePasswordHash,
 } from '../../server/db';
 import { emailAccountDeleted } from '../../server/email';
 import { compose } from '../../server/http/compose';
@@ -63,6 +64,7 @@ vi.mock('../../server/db', async (importActual) => {
     listCharacters: vi.fn(actual.listCharacters),
     setAccountDeactivated: vi.fn(actual.setAccountDeactivated),
     revokeTokensExcept: vi.fn(actual.revokeTokensExcept),
+    updatePasswordHash: vi.fn(actual.updatePasswordHash),
   };
 });
 vi.mock('../../server/auth', async (importActual) => {
@@ -626,6 +628,48 @@ describe('deactivate route: injected hooks + runtime wiring', () => {
 });
 
 // ---------------------------------------------------------------------------
+// The password route forwards the caller's own bearer token through to
+// disconnectAccount as exceptToken, so the RouteDef path can spare the session
+// that just made the request (the whole point of the caller-exemption fix).
+// This exercises account.ts's own wiring; the SEPARATE regression (twice now)
+// has been main.ts's injected configureAccountRuntime callback silently
+// dropping the exceptToken parameter before it reaches the real GameServer,
+// which the source-text pin below covers.
+// ---------------------------------------------------------------------------
+
+describe('password route: exceptToken threads to the injected disconnectAccount hook', () => {
+  const account = { accountId: 7, scope: 'full' as const };
+  const acctRow = { id: 7, username: 'hero', password_hash: 'HASH' } as unknown as Awaited<
+    ReturnType<typeof accountById>
+  >;
+  const callerToken = 'b'.repeat(64);
+
+  it('passes the callers own bearer token as exceptToken on a successful change', async () => {
+    vi.mocked(accountById).mockResolvedValue(acctRow);
+    vi.mocked(verifyPassword).mockResolvedValue(true);
+    vi.mocked(updatePasswordHash).mockResolvedValue(undefined);
+    vi.mocked(revokeTokensExcept).mockResolvedValue(undefined);
+    const disconnectAccount = vi.fn();
+    installRuntime({ disconnectAccount });
+
+    const r = await callHandler('POST', '/api/account/password', {
+      account,
+      headers: { authorization: `Bearer ${callerToken}` },
+      body: { current: 'old-pw', next: 'a-new-password' },
+    });
+
+    expect(r.status).toBe(200);
+    expect(r.body).toEqual({ ok: true });
+    // revokeTokensExcept and disconnectAccount must be handed the SAME token: if
+    // either arm drops or mismatches it, the caller either gets kicked too (the
+    // regression this pins) or a different device stays logged in after a
+    // revoke, so both are asserted against the one literal.
+    expect(revokeTokensExcept).toHaveBeenCalledWith(7, callerToken);
+    expect(disconnectAccount).toHaveBeenCalledWith(7, expect.any(String), callerToken);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // The password/logout handlers re-derive the caller token defensively. The guard
 // guarantees a non-null token, but the handler re-guards (tsc-satisfying + mirrors
 // the legacy arm's explicit 401 fallback), so a direct call with no bearer 401s.
@@ -644,5 +688,35 @@ describe('handler defensive callerToken re-guard', () => {
     const r = await callHandler('POST', '/api/account/logout', { account, body: {} });
     expect(r.status).toBe(401);
     expect(r.body).toEqual({ error: 'not authenticated', code: 'auth.required' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// server/main.ts wiring: the injected configureAccountRuntime callback must
+// forward exceptToken to the real GameServer.disconnectAccount. This has
+// regressed twice now (a fewer-params arrow is assignable, so tsc cannot
+// catch a dropped third argument, and importing main.ts to drive this live
+// would boot an HTTP listener + pg Pool), so pin the wiring at the source-text
+// level, the same idiom tests/server/board_read_single_flight.test.ts uses
+// for main.ts's other injected-runtime call sites.
+// ---------------------------------------------------------------------------
+
+describe('server/main.ts wiring: configureAccountRuntime forwards exceptToken', () => {
+  const src = readFileSync(new URL('../../server/main.ts', import.meta.url), 'utf8');
+  const codeOnly = src.replace(/(^|[^:])\/\/.*$/gm, '$1');
+  const compactCode = codeOnly.replace(/\s+/g, '');
+
+  it('the account runtime disconnectAccount hook carries a 3rd param through to liveGame()', () => {
+    const at = compactCode.indexOf('configureAccountRuntime({');
+    expect(at).toBeGreaterThan(-1);
+    const block = compactCode.slice(at, compactCode.indexOf('});', at) + 3);
+    // Assignable-but-wrong shape this pin exists to catch: an arrow that takes
+    // only (id,reason) silently drops the caller-token exemption in production.
+    expect(block).not.toContain(
+      'disconnectAccount:(id,reason)=>liveGame().disconnectAccount(id,reason)',
+    );
+    expect(block).toContain(
+      'disconnectAccount:(id,reason,exceptToken)=>liveGame().disconnectAccount(id,reason,exceptToken)',
+    );
   });
 });

--- a/tests/server/account.test.ts
+++ b/tests/server/account.test.ts
@@ -628,23 +628,23 @@ describe('deactivate route: injected hooks + runtime wiring', () => {
 });
 
 // ---------------------------------------------------------------------------
-// The password route forwards the caller's own bearer token through to
-// disconnectAccount as exceptToken, so the RouteDef path can spare the session
-// that just made the request (the whole point of the caller-exemption fix).
-// This exercises account.ts's own wiring; the SEPARATE regression (twice now)
-// has been main.ts's injected configureAccountRuntime callback silently
-// dropping the exceptToken parameter before it reaches the real GameServer,
-// which the source-text pin below covers.
+// The password route revokes every OTHER token (keeping the caller's own token
+// valid) but disconnects EVERY live WS session for the account unconditionally.
+// An earlier revision tried to also exempt the live session matching the
+// caller's bearer token, but a bearer token is a reusable wire credential, not
+// a per-socket identity: an attacker holding a stolen/shared token could
+// authenticate their own live session with it and be spared by the exact same
+// comparison. This pins the safer, unconditional-kick shape.
 // ---------------------------------------------------------------------------
 
-describe('password route: exceptToken threads to the injected disconnectAccount hook', () => {
+describe('password route: disconnects every live session, keeps only the caller token valid', () => {
   const account = { accountId: 7, scope: 'full' as const };
   const acctRow = { id: 7, username: 'hero', password_hash: 'HASH' } as unknown as Awaited<
     ReturnType<typeof accountById>
   >;
   const callerToken = 'b'.repeat(64);
 
-  it('passes the callers own bearer token as exceptToken on a successful change', async () => {
+  it('revokes every other token but disconnects unconditionally (no exception argument)', async () => {
     vi.mocked(accountById).mockResolvedValue(acctRow);
     vi.mocked(verifyPassword).mockResolvedValue(true);
     vi.mocked(updatePasswordHash).mockResolvedValue(undefined);
@@ -660,12 +660,9 @@ describe('password route: exceptToken threads to the injected disconnectAccount 
 
     expect(r.status).toBe(200);
     expect(r.body).toEqual({ ok: true });
-    // revokeTokensExcept and disconnectAccount must be handed the SAME token: if
-    // either arm drops or mismatches it, the caller either gets kicked too (the
-    // regression this pins) or a different device stays logged in after a
-    // revoke, so both are asserted against the one literal.
     expect(revokeTokensExcept).toHaveBeenCalledWith(7, callerToken);
-    expect(disconnectAccount).toHaveBeenCalledWith(7, expect.any(String), callerToken);
+    expect(disconnectAccount).toHaveBeenCalledWith(7, expect.any(String));
+    expect(disconnectAccount.mock.calls[0]).toHaveLength(2);
   });
 });
 
@@ -693,30 +690,23 @@ describe('handler defensive callerToken re-guard', () => {
 
 // ---------------------------------------------------------------------------
 // server/main.ts wiring: the injected configureAccountRuntime callback must
-// forward exceptToken to the real GameServer.disconnectAccount. This has
-// regressed twice now (a fewer-params arrow is assignable, so tsc cannot
-// catch a dropped third argument, and importing main.ts to drive this live
-// would boot an HTTP listener + pg Pool), so pin the wiring at the source-text
-// level, the same idiom tests/server/board_read_single_flight.test.ts uses
-// for main.ts's other injected-runtime call sites.
+// forward exactly (id, reason) to the real GameServer.disconnectAccount, with
+// no third "except" argument: disconnectAccount no longer accepts one (see the
+// comment above), so a future arrow reintroducing one would silently do
+// nothing (an unused extra param) rather than fail to compile.
 // ---------------------------------------------------------------------------
 
-describe('server/main.ts wiring: configureAccountRuntime forwards exceptToken', () => {
+describe('server/main.ts wiring: configureAccountRuntime forwards no exception argument', () => {
   const src = readFileSync(new URL('../../server/main.ts', import.meta.url), 'utf8');
   const codeOnly = src.replace(/(^|[^:])\/\/.*$/gm, '$1');
   const compactCode = codeOnly.replace(/\s+/g, '');
 
-  it('the account runtime disconnectAccount hook carries a 3rd param through to liveGame()', () => {
+  it('the account runtime disconnectAccount hook is a plain (id,reason) passthrough', () => {
     const at = compactCode.indexOf('configureAccountRuntime({');
     expect(at).toBeGreaterThan(-1);
     const block = compactCode.slice(at, compactCode.indexOf('});', at) + 3);
-    // Assignable-but-wrong shape this pin exists to catch: an arrow that takes
-    // only (id,reason) silently drops the caller-token exemption in production.
-    expect(block).not.toContain(
-      'disconnectAccount:(id,reason)=>liveGame().disconnectAccount(id,reason)',
-    );
     expect(block).toContain(
-      'disconnectAccount:(id,reason,exceptToken)=>liveGame().disconnectAccount(id,reason,exceptToken)',
+      'disconnectAccount:(id,reason)=>liveGame().disconnectAccount(id,reason)',
     );
   });
 });


### PR DESCRIPTION
## Summary

Self-service password change (`handleAccountChangePassword`) and password reset
(`handleAccountPasswordReset`) in `server/account.ts` revoked `auth_tokens` rows on a
successful change, but never disconnected an already-open live WebSocket session for that
account. No code re-validates a live WS session against `auth_tokens` after the initial
handshake, so revoking tokens has zero effect on a socket that is already connected: if an
attacker has an open session (stolen/shared credentials, a compromised device), changing
the password does not actually lock them out of the character in real time.

This repo already has the right tool for this: `GameServer.disconnectAccount(accountId,
reason)` force-kicks every live session for an account, and it is already used by account
deactivation (with an explicit comment noting "revoking tokens alone does not close an
open WS") and by the admin-initiated password reset endpoint. The player-facing
change/reset endpoints were simply missing the same call.

## Related issues

N/A (found via an independent UAT sweep against release/v0.31.0).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/account_server.test.ts tests/password_reset_server.test.ts`, `npx tsc --noEmit`, `npx @biomejs/biome check --write` on the four touched files
- Manual steps: added tests asserting `disconnectAccount` is called on a successful
  change/reset and not called on a rejected one; verified they actually catch the
  regression by temporarily removing the new calls (both new tests failed as expected),
  then restored and confirmed green.

```mermaid
sequenceDiagram
    participant Attacker as Attacker (open session)
    participant Owner as Account owner
    participant API as /api/account/password(/reset)
    participant DB as auth_tokens
    participant WS as Live WebSocket session

    Owner->>API: change/reset password
    API->>DB: revoke auth_tokens rows
    Note over WS: before fix: nothing disconnects the socket
    Attacker->>WS: still fully connected, still in control
    API-->>Owner: "password changed" (misleadingly implies attacker is locked out)

    rect rgb(220,240,220)
    Note over API,WS: After fix
    API->>DB: revoke auth_tokens rows
    API->>WS: disconnectAccount(accountId, reason)
    WS-->>Attacker: session force-closed
    end
```

## Checklist

### Quality

- [x] Targeted tests (listed above) plus `tsc --noEmit` and `biome check` on touched
      files are green. Did not run the full `npm run gate`; relying on targeted tests plus CI.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, server-only auth logic, no UI surface touched.
- ~~Accessible.~~ N/A, no UI change.

### Localization (i18n)

- [x] Reused the existing, already-localized `IP_BLOCK_KICK_MESSAGE`-equivalent
      disconnect-reason string (already covered by the client's error matcher in
      `src/ui/api_error_i18n.ts`); no new player-visible strings were added.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] Regenerated i18n status files via `npm run i18n:gen` for the pre-push guard; no
      hand edits to generated files.
