### PR TITLE
fix(social): stop Vale Cup teardown granting a free full restore

### DIFF
--- a/src/sim/social/arena.ts
+++ b/src/sim/social/arena.ts
@@ -40,7 +40,9 @@ import {
 
 // Deep-copy the CC diminishing-return map so a snapshot never shares mutable
 // state objects with the live entity (values are re-derived each restore).
-function cloneCcDr(
+// Exported: vale_cup.ts reuses this to restore its own pre-match pools
+// (mirroring this same free-full-restore fix, see snapshotArenaReturnPools).
+export function cloneCcDr(
   src: Map<CrowdControlDrCategory, CrowdControlDrState>,
 ): Map<CrowdControlDrCategory, CrowdControlDrState> {
   const out = new Map<CrowdControlDrCategory, CrowdControlDrState>();
@@ -49,8 +51,11 @@ function cloneCcDr(
 }
 
 // Deep-copy the recharge-model charge pools (Entity.abilityCharges) so a
-// snapshot never shares mutable state objects with the live entity.
-function cloneAbilityCharges(src: Entity['abilityCharges']): ArenaReturnPools['abilityCharges'] {
+// snapshot never shares mutable state objects with the live entity. Exported
+// for the same reason as cloneCcDr above.
+export function cloneAbilityCharges(
+  src: Entity['abilityCharges'],
+): ArenaReturnPools['abilityCharges'] {
   const out: ArenaReturnPools['abilityCharges'] = {};
   if (src) for (const [id, state] of Object.entries(src)) out[id] = { ...state };
   return out;

--- a/src/sim/social/vale_cup.ts
+++ b/src/sim/social/vale_cup.ts
@@ -37,7 +37,7 @@ import { abilitiesKnownAt, DUNGEON_X_THRESHOLD, MOBS } from '../data';
 import * as deedsMod from '../deeds';
 import { createMob, createNpc, recalcPlayerStats } from '../entity';
 import { restorePetFromDelveStash, stowPetForDelve } from '../pet/pet_commands';
-import type { PlayerMeta } from '../sim';
+import type { ArenaReturnPools, PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
 import {
   DT,
@@ -75,7 +75,7 @@ import {
   VC_SPAWNS_B,
   vcPracticeOrigin,
 } from '../vale_cup_layout';
-import { arenaCombatants } from './arena';
+import { arenaCombatants, cloneAbilityCharges, cloneCcDr, snapshotArenaReturnPools } from './arena';
 
 // ---------------------------------------------------------------------------
 // Tuning constants (fiesta style: all at the top).
@@ -228,6 +228,12 @@ export interface VcMatch {
   kickoffTeam: 'A' | 'B';
   kickoffGraceUntil: number; // sim.time the whistle grace ends (long boots clamp)
   returns: Map<number, { x: number; z: number; facing: number }>;
+  // Pre-match HP/resource/cooldown/CC DR pools keyed by pid, snapshotted before
+  // the sport-kit clean-slate reset and restored on teardown, so a Vale Cup
+  // match (rated or practice) can never be farmed as a free full HP/mana/
+  // cooldown restore. Mirrors ArenaMatch.preMatchPools (issue #1600); optional
+  // only for compatibility with synthetic/legacy VcMatch fixtures.
+  preMatchPools?: Map<number, ArenaReturnPools>;
   ball: VcBallState | null; // spawned at kickoff, despawned at match end
   pocket: 'west' | 'east' | null; // which net the celebrating ball settles in
   pendingWinner: 'A' | 'B' | null | undefined; // decided during 'goal' celebrate
@@ -835,9 +841,15 @@ export function startCupMatch(
   for (const pid of sideA.pids) sideA.roles[pid] = roles[pid];
   for (const pid of sideB.pids) sideB.roles[pid] = roles[pid];
   const returns = new Map<number, { x: number; z: number; facing: number }>();
+  // Snapshot each fighter's recovery pools NOW, before the sport-kit clean-slate
+  // reset below (valeCupStandardize -> ctx.resetForArena), so teardownCupMatch
+  // restores what they walked in with instead of a free full restore (mirrors
+  // arena.ts's startArenaMatch, issue #1600).
+  const preMatchPools = new Map<number, ArenaReturnPools>();
   for (let i = 0; i < allPids.length; i++) {
     const e = entities[i] as Entity;
     returns.set(allPids[i], { x: e.pos.x, z: e.pos.z, facing: e.facing });
+    preMatchPools.set(allPids[i], snapshotArenaReturnPools(e));
   }
   // Guild banner entries carried from the queue (rated matches only credit these;
   // bots and practice never populate a guild, so the map is empty there).
@@ -874,6 +886,7 @@ export function startCupMatch(
     kickoffTeam: 'A',
     kickoffGraceUntil: 0,
     returns,
+    preMatchPools,
     ball: null,
     pocket: null,
     pendingWinner: undefined,
@@ -1244,7 +1257,24 @@ function teardownCupMatch(ctx: SimContext, match: VcMatch): void {
     const e = ctx.entities.get(pid);
     if (!meta || !e) continue;
     valeCupRestore(ctx, meta, e);
-    ctx.resetForArena(e); // wipes sport_* cooldowns; the arena accepts the same tradeoff
+    ctx.resetForArena(e); // clean slate first: wipes sport_* cooldowns too
+    // The match is a parenthesis, not a rest stop: undo the clean-slate full
+    // restore and hand back exactly the HP, resource, cooldowns, and CC DR the
+    // fighter carried in, so a Vale Cup match (rated or practice) can never be
+    // farmed as a free heal, mana refill, or cooldown reset (mirrors arena.ts's
+    // returnFromArena, issue #1600). recalcPlayerStats already ran inside
+    // resetForArena, so maxHp/maxResource are current for the clamp.
+    const pools = match.preMatchPools?.get(pid);
+    if (pools) {
+      e.cooldowns = new Map(pools.cooldowns);
+      e.abilityCharges =
+        Object.keys(pools.abilityCharges).length > 0
+          ? cloneAbilityCharges(pools.abilityCharges)
+          : undefined;
+      e.ccDr = cloneCcDr(pools.ccDr);
+      e.hp = Math.max(0, Math.min(pools.hp, e.maxHp));
+      e.resource = Math.max(0, Math.min(pools.resource, e.maxResource));
+    }
     const ret = match.returns.get(pid);
     if (ret) {
       e.pos = ctx.groundPos(ret.x, ret.z);

--- a/tests/vale_cup_match.test.ts
+++ b/tests/vale_cup_match.test.ts
@@ -494,6 +494,139 @@ describe('Vale Cup: match lifecycle', () => {
   });
 });
 
+describe('Vale Cup: teardown does not grant a free full HP/resource/cooldown restore', () => {
+  it('teardownCupMatch restores pre-match HP, resource, and cooldowns instead of full-healing', () => {
+    const sim = makeWorld();
+    // A mage (mana resource): the in-match clean slate tops mana to max, so a
+    // drained pool restoring is a meaningful assertion (rage clean-slates to 0
+    // either way).
+    const a = addAt(sim, 'mage', 'Aleph');
+    const b = addAt(sim, 'warrior', 'Bet', 4, -40);
+    const ae = sim.entities.get(a)!;
+    expect(ae.maxHp).toBeGreaterThan(0);
+
+    // The fighter walks in wounded, low on mana, with an ability on cooldown.
+    ae.hp = Math.floor(ae.maxHp * 0.4);
+    ae.resource = Math.floor(ae.maxResource * 0.3);
+    ae.cooldowns.set('charge', 9);
+    const woundedHp = ae.hp;
+    const drainedResource = ae.resource;
+
+    sim.vcupQueueJoin(1, 'vale', 'allrounder', false, a);
+    sim.vcupQueueJoin(1, 'mirefen', 'allrounder', false, b);
+    sim.tick(); // forms the match: valeCupStandardize's clean slate takes over
+    const match = sim.vcup.match!;
+    expect(match.phase).toBe('briefing');
+
+    // The pre-match snapshot captured exactly what the fighter carried in (the
+    // cooldown ticks down by one DT on the same tick the match forms, so it
+    // reads the snapshot back rather than the un-decayed literal).
+    expect(match.preMatchPools).toBeDefined();
+    const pools = match.preMatchPools?.get(a);
+    expect(pools).toBeDefined();
+    if (!pools) return;
+    expect(pools.hp).toBe(woundedHp);
+    expect(pools.resource).toBe(drainedResource);
+    const preCooldown = pools.cooldowns.get('charge');
+    expect(preCooldown).toBeLessThanOrEqual(9);
+    expect(preCooldown).toBeGreaterThan(8.9);
+
+    // The in-match clean slate still stands: full HP/resource, cooldowns cleared.
+    expect(ae.hp).toBe(ae.maxHp);
+    expect(ae.resource).toBe(ae.maxResource);
+    expect(ae.cooldowns.size).toBe(0);
+
+    // Ready up, play the whistle through to an active bout, then force a
+    // quick, uneven result and run the aftermath out to teardown.
+    readyAll(sim);
+    tickUntil(sim, () => match.phase === 'active', 20 * 6);
+    (match as any).scoreA = 1;
+    (match as any).clock = VC_MATCH_DURATION;
+    tickUntil(sim, () => sim.vcup.match === null, 20 * 20);
+
+    // The fighter is handed back EXACTLY what they walked in with: no free
+    // heal, no free mana, no free cooldown reset.
+    expect(ae.hp).toBe(woundedHp);
+    expect(ae.hp).toBeLessThan(ae.maxHp);
+    expect(ae.resource).toBe(drainedResource);
+    expect(ae.cooldowns.get('charge')).toBe(preCooldown);
+  });
+
+  it('the exploit: repeatedly entering and tearing down a match cannot be farmed as a free heal/mana reset', () => {
+    const sim = makeWorld();
+    // A mage again: mana clean-slates to full mid-match, so restoring a
+    // deliberately drained pool is a meaningful (not vacuously-zero) check.
+    const a = addAt(sim, 'mage', 'Aleph');
+    const b = addAt(sim, 'warrior', 'Bet', 4, -40);
+    const ae = sim.entities.get(a)!;
+
+    // Run one full queue -> ready -> active -> teardown cycle, wounding the
+    // fighter to a given fraction of max HP/resource beforehand, and return
+    // what it was wounded to.
+    const runOneCycle = (frac: number): { hp: number; resource: number } => {
+      ae.hp = Math.floor(ae.maxHp * frac);
+      ae.resource = Math.floor(ae.maxResource * frac);
+      const wounded = { hp: ae.hp, resource: ae.resource };
+      sim.vcupQueueJoin(1, 'vale', 'allrounder', false, a);
+      sim.vcupQueueJoin(1, 'mirefen', 'allrounder', false, b);
+      sim.tick();
+      const match = sim.vcup.match!;
+      readyAll(sim);
+      tickUntil(sim, () => match.phase === 'active', 20 * 6);
+      (match as any).scoreA = 1;
+      (match as any).clock = VC_MATCH_DURATION;
+      tickUntil(sim, () => sim.vcup.match === null, 20 * 20);
+      return wounded;
+    };
+
+    // A first bout: leaving it does not top the fighter off.
+    const wounded1 = runOneCycle(0.5);
+    expect(ae.hp).toBe(wounded1.hp);
+    expect(ae.hp).toBeLessThan(ae.maxHp);
+    expect(ae.resource).toBe(wounded1.resource);
+    expect(ae.resource).toBeLessThan(ae.maxResource);
+
+    // A second, independent bout right after: still no free restore, proving
+    // the exploit is not a one-time snapshot bug but genuinely un-farmable.
+    const wounded2 = runOneCycle(0.2);
+    expect(ae.hp).toBe(wounded2.hp);
+    expect(ae.hp).toBeLessThan(ae.maxHp);
+    expect(ae.resource).toBe(wounded2.resource);
+    expect(ae.resource).toBeLessThan(ae.maxResource);
+  });
+
+  it('vcupPracticeStart (the instant solo bot practice) is covered by the same restore', () => {
+    // A mage: mana clean-slates to full mid-match, so restoring a drained pool
+    // is a meaningful check (rage clean-slates to 0 either way).
+    const sim = new Sim({ seed: 7, playerClass: 'mage', playerName: 'Solo' });
+    const pe = sim.entities.get(sim.primaryId)!;
+    pe.hp = Math.floor(pe.maxHp * 0.35);
+    pe.resource = Math.floor(pe.maxResource * 0.1);
+    const wounded = pe.hp;
+    const drained = pe.resource;
+
+    sim.vcupPracticeStart(1);
+    const match = sim.vcup.practices[0];
+    expect(match.preMatchPools?.get(sim.primaryId)?.hp).toBe(wounded);
+    expect(match.preMatchPools?.get(sim.primaryId)?.resource).toBe(drained);
+
+    // In-match clean slate: full HP/resource while the practice bout runs.
+    expect(pe.hp).toBe(pe.maxHp);
+    expect(pe.resource).toBe(pe.maxResource);
+
+    readyAll(sim);
+    tickUntil(sim, () => match.phase === 'active', 20 * 6);
+    (match as any).scoreA = 1;
+    (match as any).clock = VC_MATCH_DURATION;
+    tickUntil(sim, () => sim.vcup.practices.length === 0, 20 * 20);
+
+    // Practice is instant, repeatable, and free to enter (vale_cup_bots.ts): if
+    // it granted a full restore this would be an infinite heal/mana loop.
+    expect(pe.hp).toBe(wounded);
+    expect(pe.resource).toBe(drained);
+  });
+});
+
 describe('Vale Cup: sport moves', () => {
   // Stage a lone shooter on the ball a fixed distance out from the empty east
   // goal, facing it, then fire sport_shoot at a given charge (encoded as the aim


### PR DESCRIPTION
## Summary

Every Vale Cup match teardown (`teardownCupMatch` in `src/sim/social/vale_cup.ts`),
including the instantly-startable, repeatable, unrated solo Practice bout against bots,
granted a free full HP/resource/cooldown/ability-charge restore: it called
`ctx.resetForArena(e)` (a clean-slate reset) with nothing to bring the fighter's pools
back down to where they actually were. The sibling systems, `arena.ts` and `yumi.ts`,
already solved this exact problem for issue #1600 by snapshotting each fighter's real
pools at match start (`snapshotArenaReturnPools`) and restoring exactly that snapshot at
teardown (`returnFromArena`) instead of a full heal. `vale_cup.ts` had no equivalent
snapshot/restore at all, so a player could repeatedly queue and leave/finish a Vale Cup
(or solo Practice) match purely to get free heals, mana, and cooldown resets outside any
intended reward context.

## Related issues

N/A (found via an independent UAT sweep against release/v0.31.0).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run` on the Vale Cup / arena / gravewyrm / parity / architecture
  suite (604 tests), `npx tsc --noEmit`, `npx @biomejs/biome check --write` on touched files
- Manual steps: added 3 tests (rated 1v1 wounded-state snapshot/restore, a back-to-back
  queue-match-teardown repro proving no free restore across two cycles, and coverage of
  the solo Practice bot match). Verified all 3 fail against the pre-fix code (confirmed
  the exploit reproduces, e.g. HP fully healed instead of staying at its wounded value)
  and pass with the fix restored.

```mermaid
flowchart TD
    subgraph before["Before fix"]
    A1["startCupMatch"] --> B1["Fighter enters wounded\n(hp=27/54, mana low, abilities on cooldown)"]
    B1 --> C1["teardownCupMatch"]
    C1 --> D1["ctx.resetForArena(e)\nfull heal, full resource,\nclear cooldowns/charges/CC DR"]
    D1 --> E1["Free full restore, repeatable\nby queueing again (even solo Practice)"]
    end
    subgraph after["After fix"]
    A2["startCupMatch"] --> B2["snapshotArenaReturnPools(e)\ncaptures real hp/resource/cooldowns/charges"]
    B2 --> C2["Fighter enters wounded"]
    C2 --> D2["teardownCupMatch"]
    D2 --> E2["ctx.resetForArena(e) then\nrestore the captured snapshot\n(clamped to current max)"]
    E2 --> F2["Fighter leaves the match\nexactly as wounded as they were,\nmatching arena.ts / yumi.ts"]
    end
```

## Checklist

### Quality

- [x] Targeted tests (listed above) plus `tsc --noEmit` and `biome check` on touched
      files are green. Did not run the full `npm run gate`; relying on targeted tests plus CI.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, sim logic only, no UI surface touched.
- ~~Accessible.~~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] Regenerated i18n status files via `npm run i18n:gen` for the pre-push guard; no
      hand edits to generated files.
