### PR TITLE
fix(social): stop raid departures from scrambling other members' subgroups

### DIFF
--- a/src/sim/social/party.ts
+++ b/src/sim/social/party.ts
@@ -570,6 +570,5 @@ export class PartyMachine {
       }
     }
     this.announceLooterShift(party, beforeLooter);
-    if (party.raid) this.normalizeRaidGroups(party);
   }
 }

--- a/tests/party_machine.test.ts
+++ b/tests/party_machine.test.ts
@@ -248,6 +248,51 @@ describe('PartyMachine: raid conversion + groups', () => {
     );
     expect(party.partyOf(leader)!.raid).toBe(true);
   });
+
+  it('a departure preserves every other member manually-assigned raid subgroup', () => {
+    const t = makeCtx();
+    const leader = t.addPlayer(1, 'L');
+    for (let i = 2; i <= 9; i++) t.addPlayer(i, `M${i}`);
+    const party = new PartyMachine(t.ctx);
+    // Fill a party of five, convert to raid (which lifts the cap to ten), then
+    // invite the rest so the raid ends up with 9 members total.
+    for (let i = 2; i <= 5; i++) {
+      party.partyInvite(i, leader);
+      party.partyAccept(i);
+    }
+    party.convertPartyToRaid(leader);
+    for (let i = 6; i <= 9; i++) {
+      party.partyInvite(i, leader);
+      party.partyAccept(i);
+    }
+    const p = party.partyOf(leader)!;
+    expect(p.members.length).toBe(9);
+    // Normalized on conversion: members 1-5 -> group 1 (full), 6-8 -> group 2.
+    expect(p.raidGroups.get(5)).toBe(1);
+    expect(p.raidGroups.get(6)).toBe(2);
+
+    // The leader manually swaps member 5 into group 2 and member 6 into group 1
+    // (e.g. to balance healers across subgroups for an upcoming raid mechanic).
+    party.moveRaidMember(5, 2, leader);
+    party.moveRaidMember(6, 1, leader);
+    expect(p.raidGroups.get(5)).toBe(2);
+    expect(p.raidGroups.get(6)).toBe(1);
+
+    // A totally unrelated member (9, untouched by the swap) leaves the raid.
+    party.partyLeave(9);
+
+    // Only the departing member's own slot is gone; the manual swap, and every
+    // other member's subgroup, must survive untouched.
+    expect(p.raidGroups.has(9)).toBe(false);
+    expect(p.raidGroups.get(5)).toBe(2);
+    expect(p.raidGroups.get(6)).toBe(1);
+    expect(p.raidGroups.get(1)).toBe(1);
+    expect(p.raidGroups.get(2)).toBe(1);
+    expect(p.raidGroups.get(3)).toBe(1);
+    expect(p.raidGroups.get(4)).toBe(1);
+    expect(p.raidGroups.get(7)).toBe(2);
+    expect(p.raidGroups.get(8)).toBe(2);
+  });
 });
 
 describe('PartyMachine: teardown', () => {


### PR DESCRIPTION
## Summary

`removeFromParty` (`src/sim/social/party.ts`) ended with an unconditional
`if (party.raid) this.normalizeRaidGroups(party);` on every ordinary leave or kick.
`normalizeRaidGroups` clears the entire raid-group map and reassigns every remaining
member's subgroup purely by current array index, discarding any prior manual placement
made via `moveRaidMember`. The departing member's own slot is already removed a few lines
earlier by `party.raidGroups.delete(pid)`, so the renormalize call was both redundant for
correctness and destructive for everyone else: any raid leader who had manually arranged
subgroups saw that arrangement silently scrambled every time anyone left or got kicked.

## Related issues

N/A (found via an independent UAT sweep against release/v0.31.0).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/party_machine.test.ts tests/social.test.ts tests/social_system.test.ts tests/party_command.test.ts tests/party_collapse.test.ts tests/dead_party_loot.test.ts tests/raid_lockout.test.ts tests/raid_buffs.test.ts tests/nythraxis_raid.test.ts tests/dungeon_finder.test.ts tests/snapshots.test.ts tests/parity/parity.test.ts`, `npx tsc --noEmit`, `npx @biomejs/biome check --write` on touched files
- Manual steps: added a test building a 9-member raid, manually swapping two members
  between subgroups, then having an unrelated member leave; asserted every survivor's
  subgroup (including the manually-swapped ones) is unchanged and only the departed
  member's own slot is gone. Confirmed it fails against the pre-fix code (the manual swap
  was silently undone) and passes after removing the redundant renormalize call.

```mermaid
flowchart TD
    A["Raid leader manually places members\ninto subgroups via moveRaidMember"] --> B["Any member leaves or is kicked"]
    B --> C["removeFromParty:\nraidGroups.delete(departingPid)\n(correctly removes just their slot)"]
    C --> D["Before fix: unconditional\nnormalizeRaidGroups(party) also runs"]
    D --> E["Every OTHER member's subgroup\nrecomputed by array index,\nmanual arrangement scrambled"]
    C -.->|fix| F["normalizeRaidGroups call removed\nfrom this path entirely"]
    F --> G["Every other member's subgroup\nunchanged; only the departed\nmember's slot is gone"]
```

## Checklist

### Quality

- [x] Targeted tests (listed above) plus `tsc --noEmit` and `biome check` on touched
      files are green. Did not run the full `npm run gate`; relying on targeted tests plus CI.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, sim/social logic only, no UI surface touched.
- ~~Accessible.~~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] Regenerated i18n status files via `npm run i18n:gen` for the pre-push guard; no
      hand edits to generated files.
