### PR TITLE
fix(sim): match the Nythraxis arena empty-instance reaper to its real footprint

### DIFF
--- a/src/sim/instances/dungeons.ts
+++ b/src/sim/instances/dungeons.ts
@@ -832,11 +832,15 @@ export function updateInstances(ctx: SimContext): void {
   if (ctx.tickCount % 20 !== 0) return; // once a second
   for (const inst of ctx.instances) {
     if (inst.partyKey === null) continue;
-    const origin = instanceOriginOf(inst);
     let occupied = false;
     for (const meta of ctx.players.values()) {
       const e = ctx.entities.get(meta.entityId);
-      if (e && instanceContains(origin, e.pos)) {
+      // instanceClaimContains, not the plain instanceContains box: the
+      // Nythraxis boss arena's authored room is wider than the generic
+      // footprint (see its carve-out above), so the narrower box let this
+      // reaper free a claim while raiders were still legitimately standing
+      // in the wide outer floor.
+      if (e && instanceClaimContains(inst, e.pos)) {
         occupied = true;
         break;
       }

--- a/tests/dungeons.test.ts
+++ b/tests/dungeons.test.ts
@@ -2285,6 +2285,25 @@ describe('dungeons: heroic Nythraxis raid arena', () => {
     expect(sim.players.get(fallen)!.raidLockouts.has('nythraxis_boss_arena:heroic')).toBe(true);
     expect(sim.countItem(HEROIC_MARK_ITEM_ID, fallen)).toBe(0);
   });
+
+  it('the empty-instance reaper never frees the arena while raiders stand in its wide outer floor', () => {
+    const { sim, raiders, inst } = raidSetup('normal');
+    const origin = instanceOriginOf(inst);
+    // NYTHRAXIS_LAYOUT (dungeon_layout.ts) authors tomb alcoves at local
+    // x = +/-210, legitimately inside the wide wallX:230/floorHalfX:228 raid
+    // room (and within instanceClaimContains's NYTHRAXIS_ROOM_RADIUS carve-out),
+    // but outside the generic 120yd box that instanceContains checks. Standing
+    // there is a real, in-fight position, not an edge case.
+    const tombX = origin.x + 210;
+    const tombZ = origin.z + 20;
+    raiders.forEach((pid) => {
+      teleport(sim, sim.entities.get(pid) as AnyEntity, tombX, tombZ);
+    });
+    inst.emptyFor = 100000; // even pre-loaded, an occupied check must reset it
+    updateInstances(sim.ctx);
+    expect(inst.partyKey).not.toBeNull();
+    expect(inst.emptyFor).toBe(0);
+  });
 });
 
 describe('dungeons: ghost corpse-run re-entry', () => {


### PR DESCRIPTION
## Summary

The Nythraxis Raid Arena's empty-instance reaper (`updateInstances` in
`src/sim/instances/dungeons.ts`, the once-a-second sweep that frees an instance claim once
nobody has been inside it for a while) checked occupancy with the generic, narrow
`instanceContains` box (`|dx| < 120 && |dz| < 250`), instead of `instanceClaimContains`,
the wider check every other membership test in this file already uses for this specific
room (a 260yd radius around the boss spawn, matching the room's authored 228yd floor half-
width and its tomb alcoves at local x = +/-210). A raid standing in a legitimate part of
the room (e.g. a tomb alcove 223yd from the boss spawn, well inside the real floor and the
claim radius) was outside the reaper's narrower box, so the claim could be silently freed
mid-fight or mid-loot: boss, adds, wardstones, and the exit would despawn and unlooted
corpses would be destroyed while the raid was still legitimately there.

## Related issues

N/A (found via an independent UAT sweep against release/v0.31.0).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/dungeons.test.ts`, a broader dungeon/Nythraxis sweep,
  `tests/architecture.test.ts`, `tests/world_api_parity.test.ts`, `tests/parity`,
  `npx tsc --noEmit`, `npx @biomejs/biome check --write` on touched files
- Manual steps: added a test placing a full raid at the authored tomb-alcove position with
  a large stale `emptyFor` value, and asserted the reaper resets it (claim survives)
  instead of freeing it. Confirmed it fails against the pre-fix narrow box and passes
  after switching to the wider, already-used-elsewhere `instanceClaimContains` check.

```mermaid
flowchart TD
    A["Raid standing in a tomb alcove\n(local x=210, 223yd from boss spawn)"] --> B{"Is this inside the instance?"}
    B -->|"instanceContains (narrow box)\nused elsewhere: instanceLockoutMetas,\ninstanceInfoAt, instanceClaimIdAt"| C["|dx|<120 -> false\n210 > 120, outside the box"]
    B -->|"instanceClaimContains (wide, room-aware)\nused everywhere EXCEPT the reaper"| D["260yd radius -> true\nmatches the authored 228yd floor + alcoves"]
    C -.->|"before fix: reaper used\nthe narrow check"| E["Reaper thinks the room is empty\nafter emptyFor timeout -> claim freed\nwhile the raid is still inside"]
    D -.->|fix| F["Reaper now uses the same wide check\nas every other membership test in the file"]
```

## Checklist

### Quality

- [x] Targeted tests (listed above) plus `tsc --noEmit` and `biome check` on touched
      files are green. Did not run the full `npm run gate`; relying on targeted tests plus CI.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, sim/instance logic only, no UI surface touched.
- ~~Accessible.~~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] Regenerated i18n status files via `npm run i18n:gen` for the pre-push guard; no
      hand edits to generated files.
