### PR TITLE
fix(social): recheck instance position on every Vale Cup/Yumi queue prune

### DIFF
--- a/src/sim/social/vale_cup.ts
+++ b/src/sim/social/vale_cup.ts
@@ -564,8 +564,10 @@ export function vcupSetRole(ctx: SimContext, role: SportRole, pid?: number): voi
   queued.unit.roles[id] = normalizeRole(role, queued.bracket);
 }
 
-// Drop units whose members died, vanished, or got seated elsewhere (arena
-// matchmaker prune pattern).
+// Drop units whose members died, vanished, got seated elsewhere, or walked
+// into a dungeon/instance while queued (arena matchmaker prune pattern,
+// issue #1600's x-band recheck: the bout would return them inside fully
+// restored otherwise).
 export function vcupPruneQueue(ctx: SimContext, bracket: VcBracket): void {
   const match = ctx.vcup.match;
   ctx.vcup.queues[bracket] = ctx.vcup.queues[bracket].filter((unit) =>
@@ -573,6 +575,7 @@ export function vcupPruneQueue(ctx: SimContext, bracket: VcBracket): void {
       const e = ctx.entities.get(id);
       if (!e || e.dead) return false;
       if (ctx.arenaMatches.has(id)) return false;
+      if (e.pos.x > DUNGEON_X_THRESHOLD) return false;
       return !(match && vcupTeamOf(match, id));
     }),
   );

--- a/src/sim/social/yumi.ts
+++ b/src/sim/social/yumi.ts
@@ -23,7 +23,7 @@
 // touches the shared sim stream, so existing golden traces stay byte-identical.
 
 import { YUMI_TEMPLATE_ID } from '../content/yumi';
-import { MOBS, YUMI_MAZE_SLOT_COUNT, yumiMazeOrigin } from '../data';
+import { DUNGEON_X_THRESHOLD, MOBS, YUMI_MAZE_SLOT_COUNT, yumiMazeOrigin } from '../data';
 import { createMob } from '../entity';
 import { Rng } from '../rng';
 import type { ArenaMatch, ArenaQueueUnit, ArenaReturnPools } from '../sim';
@@ -99,7 +99,10 @@ export function pruneYumiQueue(ctx: SimContext, fmt: YumiFormat): void {
   const keep = (unit: ArenaQueueUnit) =>
     unit.pids.every((id) => {
       const e = ctx.entities.get(id);
-      return !!e && !e.dead && !ctx.arenaMatches.has(id);
+      // Drop the whole unit if any member walked into a dungeon/instance while
+      // queued: the bout would return them inside fully restored (issue #1600).
+      // Same x-band test the sibling 1v1/2v2/fiesta arena prune paths use.
+      return !!e && !e.dead && !ctx.arenaMatches.has(id) && e.pos.x <= DUNGEON_X_THRESHOLD;
     });
   if (fmt === 'yumi3') ctx.arenaQueueYumi3 = ctx.arenaQueueYumi3.filter(keep);
   else ctx.arenaQueueYumi5 = ctx.arenaQueueYumi5.filter(keep);

--- a/tests/vale_cup_match.test.ts
+++ b/tests/vale_cup_match.test.ts
@@ -114,6 +114,27 @@ describe('Vale Cup: queue guards', () => {
     expect(errorsOf(sim.drainEvents())).toContain('You cannot queue from inside an instance.');
   });
 
+  it('prunes a queued player who walked into a dungeon/instance mid-queue (issue #1600 x-band recheck)', () => {
+    // The join-time instance guard only blocks queuing FROM inside an instance
+    // (see the test above). Once queued, matchmaking itself must recheck the
+    // guard every pass, mirroring the sibling arena 1v1/2v2/fiesta queues
+    // (arena.ts matchmakeArena1v1 / pruneTeamQueue), or a player who wanders
+    // into a dungeon mid-queue stays a valid candidate and gets teleported
+    // out of the instance onto the pitch, fully restored, when the pitch pops.
+    const sim = makeWorld();
+    const inside = addAt(sim, 'warrior', 'Inside');
+    const outside = addAt(sim, 'mage', 'Outside', 4, -40);
+    sim.vcupQueueJoin(1, 'vale', 'allrounder', false, inside);
+    sim.vcupQueueJoin(1, 'mirefen', 'allrounder', false, outside);
+    // Move the queued player past the instance x-band WITHOUT enterDungeon, so
+    // the entry-dequeue path does not mask the matchmaking prune under test.
+    teleport(sim, inside, DUNGEON_X_THRESHOLD + 50, -40);
+    sim.tick();
+    expect(sim.vcup.match).toBeNull(); // no match: the pack lost its second body
+    expect(sim.cupInfoFor(inside)!.queued).toBe(false); // pruned
+    expect(sim.cupInfoFor(outside)!.queued).toBe(true); // the honest queuer waits
+  });
+
   it('rejects a missing banner nation', () => {
     const sim = makeWorld();
     const a = addAt(sim, 'warrior', 'Aleph');

--- a/tests/yumi_match.test.ts
+++ b/tests/yumi_match.test.ts
@@ -3,10 +3,10 @@
 // death (guaranteed winner, unranked), win + cleanup, and determinism.
 
 import { describe, expect, it } from 'vitest';
-import { yumiMazeOrigin } from '../src/sim/data';
+import { DUNGEON_X_THRESHOLD, yumiMazeOrigin } from '../src/sim/data';
 import { Rng } from '../src/sim/rng';
 import { Sim } from '../src/sim/sim';
-import { updateArena } from '../src/sim/social/arena';
+import { isArenaQueued, updateArena } from '../src/sim/social/arena';
 import {
   matchmakeYumiFormat,
   packYumiTeams,
@@ -155,6 +155,29 @@ describe('yumi: queue and matchmaking', () => {
       ),
     ).toBe(true);
     expect(sim.arenaQueueYumi3.length).toBe(0);
+  });
+
+  it('prunes a queued player who walked into a dungeon/instance mid-queue (issue #1600 x-band recheck)', () => {
+    // The join-time instance guard only blocks queuing FROM inside an instance;
+    // matchmaking itself must recheck the guard every pass, mirroring the
+    // sibling arena 1v1/2v2/fiesta queues (arena.ts matchmakeArena1v1 /
+    // pruneTeamQueue), or a player who wanders into a dungeon mid-queue stays a
+    // valid candidate and gets teleported out of the instance into the maze,
+    // fully restored, when the match pops.
+    const sim = makeWorld();
+    const inside = sim.addPlayer('warrior', 'Inside');
+    const outside = sim.addPlayer('mage', 'Outside');
+    teleport(sim, inside, 0, -40);
+    teleport(sim, outside, 4, -40);
+    sim.arenaQueueJoin(inside, 'yumi3');
+    sim.arenaQueueJoin(outside, 'yumi3');
+    // Move the queued player past the instance x-band WITHOUT entering a real
+    // dungeon, so the entry-dequeue path does not mask the prune under test.
+    teleport(sim, inside, DUNGEON_X_THRESHOLD + 50, -40);
+    sim.tick();
+    expect(sim.arenaMatchFor(inside)).toBeNull();
+    expect(isArenaQueued(sim.ctx, inside)).toBe(false); // pruned
+    expect(isArenaQueued(sim.ctx, outside)).toBe(true); // the honest queuer waits
   });
 
   it('packs premades and solos FIFO first-fit', () => {


### PR DESCRIPTION
## Summary

Vale Cup's and Protect Yumi's queue pruning (`vcupPruneQueue` in
`src/sim/social/vale_cup.ts`, `pruneYumiQueue` in `src/sim/social/yumi.ts`) only dropped a
queued unit for being gone or already in a match, with no recheck of their live position.
The sibling Arena queue formats already fixed exactly this class of bug for issue #1600:
`matchmakeArena1v1` and `pruneTeamQueue` in `src/sim/social/arena.ts` explicitly recheck
`e.pos.x <= DUNGEON_X_THRESHOLD` on every matchmaking pass, since a queued player who
walks into a dungeon/instance mid-queue must not stay matchable (a bout would teleport
them back outside, fully restored, from inside an instance they were mid-progress in).
Vale Cup and Yumi only checked this guard once, at join time; nothing rechecked it
afterward, so the same leak Arena already closed was still open here.

## Related issues

N/A (found via an independent UAT sweep against release/v0.31.0).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: the vale_cup/yumi/arena/gravewyrm test suite (195 tests across the affected
  files), `tests/parity` (rng draw-order check), `npx tsc --noEmit`,
  `npx @biomejs/biome check --write` on touched files
- Manual steps: added a test per queue (Vale Cup, Yumi) that queues a player, then moves
  them into a dungeon/instance x-band, and asserts the next prune pass drops them.
  Confirmed both fail against the pre-fix code (the leaked entry stayed queued) and pass
  after adding the same `DUNGEON_X_THRESHOLD` recheck Arena already uses.

```mermaid
flowchart TD
    A["Player queues for Vale Cup / Yumi"] --> B["Player walks into a dungeon/instance\nmid-queue (x > DUNGEON_X_THRESHOLD)"]
    B --> C{"Next matchmaking prune pass"}
    C -->|"Arena queues (arena.ts)"| D["Rechecks e.pos.x <= DUNGEON_X_THRESHOLD\nevery pass (fixed for #1600)\n-> player pruned"]
    C -->|"Vale Cup / Yumi (before fix)"| E["Only checks dead/already-matched\n-> stale queue entry survives"]
    E -.->|fix| F["Same x-band recheck added\nto vcupPruneQueue and pruneYumiQueue"]
```

## Checklist

### Quality

- [x] Targeted tests (listed above) plus `tsc --noEmit` and `biome check` on touched
      files are green. Did not run the full `npm run gate`; relying on targeted tests plus CI.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, sim logic only, no UI surface touched.
- ~~Accessible.~~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] Regenerated i18n status files via `npm run i18n:gen` for the pre-push guard; no
      hand edits to generated files.
