### PR TITLE
fix(ui): sum trade offer ceiling across all bag slots, not just one

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -499,6 +499,7 @@ import { TOOLTIP_PEEK_MS, TouchPeekGuard } from './touch_peek';
 import { bindTouchDoubleTap, bindTouchTap, CLICK_SUPPRESS_MS, TAP_SLOP_PX } from './touch_tap';
 import { buildTownFocusView, stepTownFocus } from './town_focus_view';
 import { renderTownFocusWindow } from './town_focus_window';
+import { tradeOfferCeiling } from './trade_view';
 import { TutorialOverlay } from './tutorial';
 import { svgIcon } from './ui_icons';
 import { getUiScale } from './ui_scale';
@@ -13912,7 +13913,7 @@ export class Hud {
   addItemToTrade(itemId: string): void {
     if (!this.tradeOpen || this.stagedTrade.items.length >= 6) return;
     const existing = this.stagedTrade.items.find((s) => s.itemId === itemId);
-    const have = this.sim.inventory.find((s) => s.itemId === itemId)?.count ?? 0;
+    const have = tradeOfferCeiling(this.sim.inventory, itemId);
     if (existing) {
       if (existing.count < have) existing.count++;
     } else {

--- a/src/ui/trade_view.ts
+++ b/src/ui/trade_view.ts
@@ -1,0 +1,23 @@
+// Pure view-core for the Trade window (#trade-window). Currently owns only
+// the offer stepper's ceiling: how many of one item id the player may stage
+// into a trade offer.
+//
+// addItemToTrade (hud.ts) used to read the FIRST matching bag slot's count
+// (Array.find) as that ceiling, so a fungible item split across multiple bag
+// stacks (bags.ts's DEFAULT_STACK caps a stack at 20, so anything held above
+// that lives in 2+ InvSlot entries) could never be offered past whichever
+// single slot the search happened to land on, even though the player held
+// more and the sim's own countItem/offerableCount (src/sim/sim.ts,
+// src/sim/social/trade.ts) already validate the offer against the SUMMED
+// total. market_window.ts's bagCount() and mailbox_window.ts's
+// ownedCountFor() already sum every matching slot for this same question;
+// tradeOfferCeiling gives the trade window the same total.
+//
+// DOM/Three-free (registered in tests/architecture.test.ts UI_PURE_CORES).
+import type { InvSlot } from '../sim/types';
+
+/** Total held count of `itemId` across every bag slot: the trade offer
+ *  stepper's ceiling. */
+export function tradeOfferCeiling(inventory: InvSlot[], itemId: string): number {
+  return inventory.filter((s) => s.itemId === itemId).reduce((n, s) => n + s.count, 0);
+}

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -243,6 +243,7 @@ const UI_PURE_CORES = [
   'src/ui/chat_bubble_style.ts',
   'src/game/ui_effects_profile.ts',
   'src/game/ui_tier_knobs.ts',
+  'src/ui/trade_view.ts',
 ].map((rel) => join(repoRoot, rel));
 
 // Pure logic cores that live in src/render (the painter half is Three-side):

--- a/tests/trade_view.test.ts
+++ b/tests/trade_view.test.ts
@@ -1,0 +1,43 @@
+// Pure view-core tests for the Trade window (src/ui/trade_view.ts).
+//
+// Reproduces the reported bug: a fungible item split across multiple bag
+// slots (bags.ts's DEFAULT_STACK caps a stack at 20, so 45 held units land
+// in 3 slots: 20 + 20 + 5) must offer up to the TOTAL held, not just
+// whichever single slot the old Array.find()-based lookup happened to hit.
+
+import { describe, expect, it } from 'vitest';
+import type { InvSlot } from '../src/sim/types';
+import { tradeOfferCeiling } from '../src/ui/trade_view';
+
+describe('tradeOfferCeiling (trade offer stepper cap)', () => {
+  it('sums an item split across multiple bag slots instead of capping at one slot', () => {
+    const inventory: InvSlot[] = [
+      { itemId: 'mat_linen_cloth', count: 20 },
+      { itemId: 'mat_linen_cloth', count: 20 },
+      { itemId: 'mat_linen_cloth', count: 5 },
+    ];
+    // The old addItemToTrade used `.find(...)?.count ?? 0`, which would have
+    // returned 20 here (the first matching slot), not the true total of 45.
+    expect(tradeOfferCeiling(inventory, 'mat_linen_cloth')).toBe(45);
+  });
+
+  it('is unaffected by other item ids in the same bag', () => {
+    const inventory: InvSlot[] = [
+      { itemId: 'mat_linen_cloth', count: 20 },
+      { itemId: 'mat_wool_cloth', count: 12 },
+      { itemId: 'mat_linen_cloth', count: 5 },
+    ];
+    expect(tradeOfferCeiling(inventory, 'mat_linen_cloth')).toBe(25);
+    expect(tradeOfferCeiling(inventory, 'mat_wool_cloth')).toBe(12);
+  });
+
+  it('returns the single slot count unchanged when the item is not split', () => {
+    const inventory: InvSlot[] = [{ itemId: 'mat_linen_cloth', count: 7 }];
+    expect(tradeOfferCeiling(inventory, 'mat_linen_cloth')).toBe(7);
+  });
+
+  it('returns 0 when the item is not held at all', () => {
+    const inventory: InvSlot[] = [{ itemId: 'mat_linen_cloth', count: 20 }];
+    expect(tradeOfferCeiling(inventory, 'mat_wool_cloth')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

The trade window's offer-quantity stepper (`addItemToTrade` in `src/ui/hud.ts`) computed
the max quantity a player can offer with
`this.sim.inventory.find((s) => s.itemId === itemId)?.count ?? 0`, which returns only the
FIRST matching bag slot's count, not the total held. Since stacks cap at 20
(`DEFAULT_STACK` in `src/sim/bags.ts`), any item held above 20 units necessarily splits
across multiple slots, and the stepper undercounted it. The sibling "how much do I own"
helpers in the market and mailbox windows already sum across every matching slot; the
trade window was the one outlier still using `.find()`. Server-side, `sim.ts`'s
`countItem()` and `trade.ts`'s `offerableCount()` both already sum across slots, so the UI
cap was strictly more restrictive than what the server would actually accept.

## Related issues

N/A (found via an independent UAT sweep against release/v0.31.0).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx tsc --noEmit`, `npx vitest run tests/trade_view.test.ts tests/architecture.test.ts tests/bags_window.test.ts tests/bags_window_use_routing.test.ts tests/trade.test.ts tests/social.test.ts`, `npx @biomejs/biome check --write` on touched files
- Manual steps: added a test with an item split 20+20+5 across three bag slots and
  asserted the offer ceiling is 45, not 20. Confirmed it fails against the old `.find()`
  logic and passes with the new sum-across-slots helper.

```mermaid
flowchart TD
    A["Player holds 45 of an item,\nsplit 20+20+5 across 3 bag slots\n(stacks cap at 20)"] --> B["addItemToTrade computes offer ceiling"]
    B -->|"before fix: inventory.find()"| C["Returns FIRST matching slot's count\nceiling = 20 (undercounts by 25)"]
    B -.->|"fix: tradeOfferCeiling()"| D["Sums count across every matching slot\nceiling = 45 (matches what the server accepts)"]
```

## Checklist

### Quality

- [x] Targeted tests (listed above) plus `tsc --noEmit` and `biome check` on touched
      files are green. Did not run the full `npm run gate`; relying on targeted tests plus CI.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, logic-only fix in a pure-core helper, no visual
      change to the trade window.
- ~~Accessible.~~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] Regenerated i18n status files via `npm run i18n:gen` for the pre-push guard; no
      hand edits to generated files.
- [x] New pure-core module (`src/ui/trade_view.ts`) registered in `tests/architecture.test.ts`'s `UI_PURE_CORES` allowlist, per this repo's frontend seam.
