### PR TITLE
fix(sim): let Iron Aim boost Arcane Shot like every other ranged shot

### DIFF
--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -6439,7 +6439,12 @@ function scaleEffect(
 // mods stack on top and also tune cost / cast time / cooldown.
 function applyTalentMods(entry: KnownAbility, mods: TalentModifiers): void {
   const am = mods.abilities[entry.def.id];
-  const physical = entry.def.school === 'physical';
+  // The melee bucket also covers hunter's ranged-AP shots regardless of magic school:
+  // `scalesWith: 'ranged'` is exclusively set on hunter abilities (arcane_shot, serpent_sting,
+  // and wyvern_sting are non-physical), so this widening cannot reach any other class's
+  // melee/spell split. Without it, Marksmanship's Iron Aim ("ranged ability damage") silently
+  // never applied to Arcane Shot, the spec's arcane-school nuke.
+  const physical = entry.def.school === 'physical' || entry.def.scalesWith === 'ranged';
   const globalDmg = physical ? mods.global.meleeDmgPct : mods.global.spellDmgPct;
   const dmgMult = 1 + globalDmg + (am?.dmgPct ?? 0);
   const healMult = 1 + mods.global.healPct + (am?.dmgPct ?? 0);

--- a/tests/spec_masteries.test.ts
+++ b/tests/spec_masteries.test.ts
@@ -187,6 +187,25 @@ describe('spec masteries', () => {
     expect(effect(known('rogue', 'sinister_strike', 'combat'), 'weaponStrike').bonus).toBe(18);
   });
 
+  it('Iron Aim (Marksmanship mastery) reaches Arcane Shot, not just physical-school shots', () => {
+    // Iron Aim's tooltip promises "ranged ability damage" (not "physical"), and Hunter is
+    // the only class whose ranged-AP kit spans magic schools: Aimed Shot is school:'physical'
+    // but Arcane Shot is school:'arcane' (both scalesWith:'ranged'). applyTalentMods used to
+    // gate the mastery's global meleeDmgPct on entry.def.school === 'physical', so Arcane Shot
+    // silently never received it. masteryOnly() isolates the mastery's global meleeDmgPct=0.2
+    // from the ability-scoped spec-baseline dmgPct in spec_baselines.ts, pinning the mastery
+    // bonus alone on both shots.
+    const aimedBase = effect(known('hunter', 'aimed_shot'), 'directDamage');
+    const aimedSpecced = effect(known('hunter', 'aimed_shot', 'marksmanship'), 'directDamage');
+    expect(aimedSpecced.min).toBe(Math.round(aimedBase.min * 1.2));
+    expect(aimedSpecced.max).toBe(Math.round(aimedBase.max * 1.2));
+
+    const arcaneBase = effect(known('hunter', 'arcane_shot'), 'directDamage');
+    const arcaneSpecced = effect(known('hunter', 'arcane_shot', 'marksmanship'), 'directDamage');
+    expect(arcaneSpecced.min).toBe(Math.round(arcaneBase.min * 1.2));
+    expect(arcaneSpecced.max).toBe(Math.round(arcaneBase.max * 1.2));
+  });
+
   it('applies petDmgPct at BOTH the melee and ranged pet damage sites, not only the helper', () => {
     // Drive the actual damage sites (a regression that drops `dmg *= petDamageMult` at
     // either would still pass a helper-only assertion). Same seed + fixed rolls + an


### PR DESCRIPTION
## Summary

Hunter Marksmanship's mastery talent "Iron Aim" is described as "+20% ranged ability
damage," but `applyTalentMods` (`src/sim/content/classes.ts`) applied it via a
melee-vs-spell split gated purely on `entry.def.school === 'physical'`. Arcane Shot
(`school: 'arcane'`) is one of Marksmanship's two headline ranged nukes, so it silently
never received the mastery bonus, while Aimed Shot and Concussive Shot (both
`school: 'physical'`) did. Confirmed every hunter ability that scales as ranged
(`scalesWith: 'ranged'`) is exclusively used by the Hunter class (9 total, 3 non-physical:
Arcane Shot/arcane, Serpent Sting/nature, Wyvern Sting/nature), so widening the gate to
also include `scalesWith === 'ranged'` cannot affect any other class's melee/spell split.

## Related issues

N/A (found via an independent UAT sweep against release/v0.31.0).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: 14 targeted test files covering masteries, spec baselines, ability damage,
  and talent choice rows, plus `tests/parity` (golden trace/determinism), a full
  `npx vitest run` (20,165 tests, 2 pre-existing unrelated failures from a missing
  generated i18n file, fixed by `npm run i18n:gen`), `npx tsc --noEmit`,
  `npx @biomejs/biome check --write`
- Manual steps: added a test pinning that both Aimed Shot (physical, positive control)
  and Arcane Shot (arcane, the regression) receive the same Iron Aim multiplier.
  Confirmed it fails pre-fix (Arcane Shot unaffected) and passes after widening the gate.

```mermaid
flowchart TD
    A["Marksmanship hunter has Iron Aim\n(+20% ranged ability damage)"] --> B{"applyTalentMods gate:\nentry.def.school === 'physical'?"}
    B -->|"Aimed Shot, Concussive Shot\n(school: physical)"| C["Receives Iron Aim bonus"]
    B -->|"Arcane Shot\n(school: arcane)"| D["Before fix: silently excluded,\ndespite being a headline ranged nuke"]
    B -.->|fix| E["Gate widened to\nschool==='physical' OR scalesWith==='ranged'\n(scalesWith:'ranged' is Hunter-only,\nso no other class is affected)"]
    E --> F["Arcane Shot now receives\nthe ranged-ability-damage bonus"]
```

## Checklist

### Quality

- [x] Targeted tests (listed above) plus `tsc --noEmit` and `biome check` on touched
      files are green. Did not run the full `npm run gate`; relying on targeted tests plus CI.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, sim/talent logic only, no UI surface touched.
- ~~Accessible.~~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] Regenerated i18n status files via `npm run i18n:gen` for the pre-push guard; no
      hand edits to generated files.
