### PR TITLE
fix(sim): return bounced mail by stable sender id, not display name

### DIFF
--- a/src/sim/mail/post_office.ts
+++ b/src/sim/mail/post_office.ts
@@ -48,6 +48,13 @@ export interface MailMessage {
   recipientKey: string; // stable recipient identity (character id string); market sellerKey convention
   recipientName: string; // display name at send time (rekeyed on rename)
   senderName: string; // display name; player names splice verbatim, letter senders localize by letterId
+  // Stable sender identity (the market sellerKey convention), captured at send
+  // time for player mail only. A rename never changes this, unlike senderName,
+  // so returnToSender re-keys the flight home by THIS field: the sender's
+  // display name can drift after send (a rename between send and expiry), but
+  // their stable id never does. Absent on system/npc mail (never returned) and
+  // on any letter persisted before this field existed.
+  senderKey?: string;
   kind: MailKind;
   letterId?: string; // authored-letter id: the client localizes subject/body/sender through it
   subject: string;
@@ -76,6 +83,7 @@ export interface MailSave {
     recipientKey: string;
     recipientName: string;
     senderName: string;
+    senderKey?: string;
     kind: MailKind;
     letterId?: string;
     subject: string;
@@ -166,17 +174,25 @@ export class PostOffice {
   // Expiry return flight: the unclaimed parcel flies home IN PLACE, deliberately
   // not as a send: MAIL_MAX_PER_RECIPIENT is a send-time gate, so a full sender
   // box still holds the returned letter rather than destroying it. Re-keys the
-  // letter onto the sender's name bucket (the loadMail soulbound-return
-  // precedent; the key folds onto the stable character id via rekeyMailOwner)
-  // and swaps the names so the letter honestly shows who it came back from.
+  // letter onto the sender's STABLE id (senderKey, the market sellerKey
+  // convention), never their display name: a sender who renames between send
+  // and expiry must still be reachable, so a name would silently orphan the
+  // parcel (or hand it to whoever later claims the vacated name). Falls back to
+  // senderName only for a letter persisted before senderKey existed. Also
+  // swaps the names so the letter honestly shows who it came back from, and
+  // carries the OLD recipientKey forward as the new senderKey: recipientKey is
+  // always stable-id by construction (booked that way, or by a prior return),
+  // so a letter that bounces back and forth stays stable-id-keyed on both ends.
   private returnToSender(m: MailMessage, now: number): void {
     // Move the delivered-and-unread contribution out of the old bucket
     // (exactly what the index counts; the rekeyMailOwner shape).
     if (!m.read && now >= m.deliverAt) this.indexDec(m.recipientKey);
-    const home = m.senderName;
+    const homeKey = m.senderKey ?? m.senderName;
+    const homeName = m.senderName;
+    m.senderKey = m.recipientKey;
     m.senderName = m.recipientName;
-    m.recipientKey = home;
-    m.recipientName = home;
+    m.recipientKey = homeKey;
+    m.recipientName = homeName;
     m.returned = true;
     m.read = false;
     // A fresh flight: the normal delivery path lands and announces the return.
@@ -406,6 +422,7 @@ export class PostOffice {
       recipientKey: recipient.key,
       recipientName: recipient.name,
       senderName: meta.name,
+      senderKey: this.mailKeyFor(meta),
       kind: 'player',
       subject: cleanSubject,
       body: cleanBody,
@@ -560,6 +577,7 @@ export class PostOffice {
     recipientKey: string;
     recipientName: string;
     senderName: string;
+    senderKey?: string;
     kind: MailKind;
     letterId?: string;
     subject: string;
@@ -582,6 +600,7 @@ export class PostOffice {
       recipientKey: opts.recipientKey,
       recipientName: opts.recipientName,
       senderName: opts.senderName,
+      senderKey: opts.senderKey,
       kind: opts.kind,
       letterId: opts.letterId,
       subject: opts.subject,
@@ -660,6 +679,7 @@ export class PostOffice {
         recipientKey: m.recipientKey,
         recipientName: m.recipientName,
         senderName: m.senderName,
+        senderKey: m.senderKey,
         kind: m.kind,
         letterId: m.letterId,
         subject: m.subject,
@@ -698,6 +718,7 @@ export class PostOffice {
       const kind: MailKind = m.kind === 'player' || m.kind === 'npc' ? m.kind : 'system';
       const recipientName = String(m.recipientName ?? m.recipientKey);
       const senderName = String(m.senderName ?? '?');
+      const senderKey = typeof m.senderKey === 'string' ? m.senderKey : undefined;
       const subject = String(m.subject ?? '');
       const body = String(m.body ?? '');
       const retainedItems: InvSlot[] = [];
@@ -746,6 +767,7 @@ export class PostOffice {
         recipientKey: m.recipientKey,
         recipientName,
         senderName,
+        senderKey,
         kind,
         letterId: typeof m.letterId === 'string' ? m.letterId : undefined,
         subject,

--- a/tests/mail_expiry.test.ts
+++ b/tests/mail_expiry.test.ts
@@ -77,7 +77,7 @@ describe('the attachment window at send', () => {
 
 describe('the return flight', () => {
   it('returns the unclaimed parcel AT the expiry boundary, through the normal delivery path', () => {
-    const { sim, alice, bob, raw } = setupParcel();
+    const { sim, alice, bob, aliceMeta, raw } = setupParcel();
     tickFor(sim, MAIL_DELIVERY_SECONDS + 2);
     expect(raw.announced).toBe(true);
     const bobKey = raw.recipientKey;
@@ -102,8 +102,9 @@ describe('the return flight', () => {
     tickFor(sim, 1); // the boundary sweep: now === expiresAt exactly
     expect(sim.time).toBe(boundary);
     expect(raw.returned).toBe(true);
-    // Re-keyed onto the sender's name bucket, the names swapped honestly.
-    expect(raw.recipientKey).toBe('Alice');
+    // Re-keyed onto the sender's stable id (never their mutable name), the
+    // display names swapped honestly.
+    expect(raw.recipientKey).toBe(sim.postOffice.mailKeyFor(aliceMeta));
     expect(raw.recipientName).toBe('Alice');
     expect(raw.senderName).toBe('Bob');
     // Attachments ride home intact and the letter flies fresh.
@@ -135,8 +136,53 @@ describe('the return flight', () => {
     expect(back?.read).toBe(false);
   });
 
+  it('still reaches the sender by stable id if they renamed while the parcel was in flight', () => {
+    // Regression for the data-loss bug: the return flight used to re-key onto
+    // the sender's DISPLAY NAME captured at send time. If the sender renamed
+    // before the still-unclaimed parcel expired, the return could never find
+    // them again (belongsTo/mailInfoFor match on the stable id or the CURRENT
+    // name, neither of which is the stale pre-rename name), orphaning the
+    // coin and items forever.
+    const { sim, alice, aliceMeta, raw } = setupParcel();
+
+    // Alice is renamed while her still-unclaimed parcel to Bob is in flight.
+    // rekeyMailOwner migrates Alice's OWN inbox (e.g. her welcome letter, which
+    // is keyed by her own stable id already) but must leave the Parcel letter
+    // alone: Alice is only its SENDER, never its recipient, exactly like the
+    // real rename flow (server/characters.ts calls rekeyMailOwner with the
+    // renaming character's own stable key, which never matches a letter she
+    // only sent).
+    const recipientKeyBeforeRename = raw.recipientKey;
+    sim.rekeyMailOwner(alice, 'Alice', 'Alicia');
+    expect(raw.recipientKey).toBe(recipientKeyBeforeRename);
+    aliceMeta.name = 'Alicia';
+
+    // Bob never claims it; the parcel expires and flies home.
+    tickFor(sim, MAIL_DELIVERY_SECONDS + 2);
+    raw.expiresAt = sim.time;
+    tickFor(sim, 2); // the return cycle runs
+    expect(raw.returned).toBe(true);
+
+    // The return flight lands; the renamed Alice must still be able to see and
+    // collect it.
+    tickFor(sim, MAIL_DELIVERY_SECONDS + 2);
+    moveToMailbox(sim, alice);
+    const info = sim.mailInfoFor(alice);
+    const back = info?.messages.find((m) => m.subject === 'Parcel');
+    expect(back).toBeDefined();
+    expect(back?.copper).toBe(500);
+    expect(back?.items).toEqual([{ itemId: 'roasted_boar', count: 2 }]);
+
+    const coinBefore = aliceMeta.copper;
+    if (back) sim.mailTake(back.id, alice);
+    expect(aliceMeta.copper).toBe(coinBefore + 500);
+    expect(sim.countItem('roasted_boar', alice)).toBe(2);
+  });
+
   it('never deletes an un-returned parcel: expiry without the flag always bounces', () => {
-    const { sim, raw } = setupParcel();
+    const { sim, bob, raw } = setupParcel();
+    const bobMeta = sim.meta(bob);
+    if (!bobMeta) throw new Error('no meta');
     tickFor(sim, MAIL_DELIVERY_SECONDS + 2);
     const id = raw.id;
 
@@ -156,8 +202,9 @@ describe('the return flight', () => {
     expect(raw.returned).toBe(true);
     expect(raw.items).toEqual([{ itemId: 'roasted_boar', count: 2 }]);
     expect(raw.copper).toBe(500);
-    // It bounced back the other way: recipient and sender swapped again.
-    expect(raw.recipientKey).toBe('Bob');
+    // It bounced back the other way: recipient and sender swapped again, still
+    // keyed by the stable id on both legs.
+    expect(raw.recipientKey).toBe(sim.postOffice.mailKeyFor(bobMeta));
     expect(raw.senderName).toBe('Alice');
   });
 
@@ -306,7 +353,7 @@ describe('a full sender mailbox', () => {
     raw.expiresAt = sim.time;
     tickFor(sim, 2);
     expect(raw.returned).toBe(true);
-    expect(raw.recipientKey).toBe('Alice');
+    expect(raw.recipientKey).toBe(sim.postOffice.mailKeyFor(aliceMeta));
     tickFor(sim, MAIL_DELIVERY_SECONDS + 2);
     moveToMailbox(sim, alice);
     const info = sim.mailInfoFor(alice);


### PR DESCRIPTION
## Summary

Expired/undeliverable mail return-to-sender logic (`returnToSender()` in
`src/sim/mail/post_office.ts`) re-keyed a bounced parcel using the sender's plain display
NAME (`m.senderName`), with no stable sender identifier stored on the mail record at all.
If the sender renamed their character between sending the mail and it expiring, the
returned parcel could no longer be matched to its rightful owner: `belongsTo()` and
`mailInfoFor()` only match by stable id or the character's *current* name, so the parcel
was permanently orphaned (or, worse, could be picked up by whoever later reclaimed the
vacated name).

## Related issues

N/A (found via an independent UAT sweep against release/v0.31.0).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/mail_expiry.test.ts tests/mail.test.ts tests/professions_bind_on_trade_surfaces.test.ts tests/professions_trend.test.ts tests/retired_heroic_items.test.ts tests/deeds_content.test.ts tests/architecture.test.ts tests/world_api_parity.test.ts`, `npx tsc --noEmit`, `npx @biomejs/biome check --write`
- Manual steps: added a test that sends a parcel, renames the sender, forces
  expiry/return, and asserts the renamed sender can still retrieve the coin/items.
  Confirmed it fails against the pre-fix code (the parcel is orphaned) and passes with the
  new stable-id keying. Updated three pre-existing assertions that had pinned the old
  buggy name-keyed behavior to instead assert the correct stable-id key.

```mermaid
flowchart TD
    A["Player sends mail, then renames\ntheir character before it expires"] --> B["Mail expires, returnToSender() runs"]
    B -->|"before fix"| C["Re-keys the return using\nm.senderName (the OLD, stale name)"]
    C --> D["belongsTo()/mailInfoFor() match by\nstable id or CURRENT name only\n-> parcel is orphaned, item/coin lost\n(or hijacked if the old name is reclaimed)"]
    B -.->|fix| E["Mail record now carries a senderKey\n(same stable-id convention as market.ts's\nsellerKey), set at send time"]
    E --> F["returnToSender() re-keys using\nsenderKey (falls back to senderName only\nfor pre-fix persisted mail)"]
    F --> G["Renamed sender still owns\nand can retrieve the returned parcel"]
```

## Checklist

### Quality

- [x] Targeted tests (listed above) plus `tsc --noEmit` and `biome check` on touched
      files are green. Did not run the full `npm run gate`; relying on targeted tests plus CI.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, sim/mail logic only, no UI surface touched.
- ~~Accessible.~~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] Regenerated i18n status files via `npm run i18n:gen` for the pre-push guard; no
      hand edits to generated files.
