### PR TITLE
feat(settings): make Attack button and attack-on-cast per-character

### DIFF
--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -339,6 +339,42 @@ const STORE_KEY = 'woc_settings';
 const NUMERIC_KEYS = Object.keys(SETTING_RANGES) as NumericSettingKey[];
 const BOOL_KEYS = Object.keys(BOOL_SETTINGS) as BoolSettingKey[];
 
+// Two action-bar preferences that a player wants set per CHARACTER, not device-
+// wide: a mage that drops the Attack button and turns off attack-on-cast should
+// not force those choices on a paladin (issue: character-level combat settings).
+// These keep the same names/defs in BOOL_SETTINGS above (so the options UI and
+// every get/set call site are untouched), but once a character context is known
+// (Settings.setCharacter, wired from startGame) they resolve to a per-character
+// localStorage entry keyed like the per-character action bar (actionBarSlotMapKey:
+// `woc_hotbar_${playerClass}_${playerName}`), migrating the player's existing
+// GLOBAL value in on first read so nobody's setup visibly changes on upgrade.
+export const PER_CHARACTER_BOOL_KEYS = [
+  'showAttackButton',
+  'startAttackOnAbilityUse',
+] as const satisfies readonly BoolSettingKey[];
+
+type PerCharacterBoolKey = (typeof PER_CHARACTER_BOOL_KEYS)[number];
+const PER_CHARACTER_BOOL_SET: ReadonlySet<string> = new Set(PER_CHARACTER_BOOL_KEYS);
+
+function isPerCharacterBoolKey(key: string): key is PerCharacterBoolKey {
+  return PER_CHARACTER_BOOL_SET.has(key);
+}
+
+// Mirrors action_bar_layout_sync.actionBarSlotMapKey's `woc_hotbar_${cls}_${name}`
+// convention so a character's per-slot settings sit alongside its per-slot bar.
+export function perCharacterSettingKey(
+  key: PerCharacterBoolKey,
+  playerClass: string,
+  playerName: string,
+): string {
+  return `woc_setting_${key}_${playerClass}_${playerName}`;
+}
+
+export interface CharacterContext {
+  playerClass: string;
+  playerName: string;
+}
+
 function clampNumeric(key: NumericSettingKey, v: number): number {
   const r = SETTING_RANGES[key];
   if (!Number.isFinite(v)) return r.def;
@@ -357,6 +393,11 @@ export function clickMoveButtonLabel(value: number): string {
 
 export class Settings {
   private values: GameSettings;
+  // The character these per-character keys resolve against, or null on the
+  // character-select / landing screens (and for the many standalone
+  // `new Settings()` reads of purely-global keys), where they fall back to the
+  // global blob exactly as before.
+  private character: CharacterContext | null = null;
 
   constructor() {
     this.values = this.load();
@@ -384,13 +425,94 @@ export class Settings {
 
   private save(): void {
     try {
-      localStorage.setItem(STORE_KEY, JSON.stringify(this.values));
+      // Never let the active character's per-character values overwrite the
+      // global blob: that blob is the migration SEED for characters logging in
+      // for the first time, and clobbering it would leak one character's Attack
+      // preferences onto every not-yet-migrated character. Once a character is
+      // bound we preserve whatever the blob already stored for those keys.
+      const toStore = this.character
+        ? { ...this.values, ...this.storedGlobalPerCharacterKeys() }
+        : this.values;
+      localStorage.setItem(STORE_KEY, JSON.stringify(toStore));
+    } catch {
+      /* storage unavailable */
+    }
+  }
+
+  /** The values the global blob currently holds for the per-character keys (the
+   *  original seed), used to keep save() from overwriting them once a character
+   *  is bound. Falls back to the def when the blob has no explicit value. */
+  private storedGlobalPerCharacterKeys(): Partial<Record<PerCharacterBoolKey, boolean>> {
+    let stored: unknown = null;
+    try {
+      stored = JSON.parse(localStorage.getItem(STORE_KEY) ?? 'null');
+    } catch {
+      /* corrupt */
+    }
+    const raw = stored && typeof stored === 'object' ? (stored as Record<string, unknown>) : {};
+    const out: Partial<Record<PerCharacterBoolKey, boolean>> = {};
+    for (const key of PER_CHARACTER_BOOL_KEYS) {
+      out[key] = typeof raw[key] === 'boolean' ? (raw[key] as boolean) : BOOL_SETTINGS[key].def;
+    }
+    return out;
+  }
+
+  /**
+   * Bind this Settings to a character so the per-character keys (Attack button /
+   * attack-on-cast) resolve to that character's own entry. Called once per world
+   * entry from startGame. On first read for a character with nothing stored the
+   * getter migrates in the value the global blob currently holds, so a returning
+   * player keeps whatever they had before the split.
+   */
+  setCharacter(playerClass: string, playerName: string): void {
+    this.character = { playerClass, playerName };
+    // Fold the resolved per-character values into the in-memory snapshot so
+    // all()/get() reflect this character immediately (and migrate-on-first-read
+    // is persisted right away).
+    for (const key of PER_CHARACTER_BOOL_KEYS) {
+      this.values[key] = this.readPerCharacterBool(key);
+    }
+  }
+
+  /** Read a per-character bool from storage, migrating the global value in the
+   *  first time nothing is stored for this character. Requires this.character. */
+  private readPerCharacterBool(key: PerCharacterBoolKey): boolean {
+    const ctx = this.character;
+    if (!ctx) return this.values[key];
+    const storeKey = perCharacterSettingKey(key, ctx.playerClass, ctx.playerName);
+    let stored: string | null = null;
+    try {
+      stored = localStorage.getItem(storeKey);
+    } catch {
+      /* storage unavailable */
+    }
+    if (stored === 'true') return true;
+    if (stored === 'false') return false;
+    // No per-character value yet: seed from the player's current GLOBAL value
+    // (this.values already holds it from load()) and persist so the choice is
+    // now this character's own going forward.
+    const migrated = this.values[key];
+    this.writePerCharacterBool(key, migrated);
+    return migrated;
+  }
+
+  private writePerCharacterBool(key: PerCharacterBoolKey, value: boolean): void {
+    const ctx = this.character;
+    if (!ctx) return;
+    try {
+      localStorage.setItem(
+        perCharacterSettingKey(key, ctx.playerClass, ctx.playerName),
+        value ? 'true' : 'false',
+      );
     } catch {
       /* storage unavailable */
     }
   }
 
   get<K extends keyof GameSettings>(key: K): GameSettings[K] {
+    if (this.character && isPerCharacterBoolKey(key)) {
+      return this.readPerCharacterBool(key) as GameSettings[K];
+    }
     return this.values[key];
   }
 
@@ -405,6 +527,13 @@ export class Settings {
     if ((BOOL_KEYS as readonly string[]).includes(key)) {
       const v = !!value;
       (this.values as Record<string, unknown>)[key] = v;
+      // Per-character keys with a bound character persist to that character's
+      // own entry (the global blob is left as the migration seed only); without
+      // a character they fall through to the global save() below unchanged.
+      if (this.character && isPerCharacterBoolKey(key)) {
+        this.writePerCharacterBool(key, v);
+        return v as GameSettings[K];
+      }
       this.save();
       return v as GameSettings[K];
     }
@@ -424,11 +553,24 @@ export class Settings {
       for (const key of NUMERIC_KEYS) this.values[key] = SETTING_RANGES[key].def;
       for (const key of BOOL_KEYS) this.values[key] = BOOL_SETTINGS[key].def;
       this.save();
+      // A bound character's per-character keys reset to their def in that
+      // character's own entry too, so "Reset to Defaults" is honored there.
+      if (this.character) {
+        for (const key of PER_CHARACTER_BOOL_KEYS) {
+          this.writePerCharacterBool(key, BOOL_SETTINGS[key].def);
+        }
+      }
       return;
     }
     for (const key of keys) {
       if ((BOOL_KEYS as readonly string[]).includes(key as string)) {
         this.values[key as BoolSettingKey] = BOOL_SETTINGS[key as BoolSettingKey].def;
+        if (this.character && isPerCharacterBoolKey(key as string)) {
+          this.writePerCharacterBool(
+            key as PerCharacterBoolKey,
+            BOOL_SETTINGS[key as BoolSettingKey].def,
+          );
+        }
       } else if ((NUMERIC_KEYS as readonly string[]).includes(key as string)) {
         this.values[key as NumericSettingKey] = SETTING_RANGES[key as NumericSettingKey].def;
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -993,6 +993,13 @@ async function startGame(
 
   const keybinds = new Keybinds(keybindScope);
   const settings = new Settings();
+  // Bind the per-character settings (Attack button / attack-on-cast) to THIS
+  // character so a mage and a paladin keep independent choices; keyed by
+  // class+name like the per-character action bar. First read for a character
+  // migrates in the player's existing global value, so nothing changes on
+  // upgrade. Must run before applySetting fans the stored values out below and
+  // before the HUD reads them.
+  settings.setCharacter(world.cfg.playerClass, world.player.name);
   // First-run graphics default: until a device default has been applied (the dedicated
   // graphicsDefaultApplied marker, NOT the graphicsPreset key, which save() def-fills the moment
   // any unrelated setting is stored), probe the device (GPU name, memory, cores, touch) and

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   clickMoveButtonLabel,
   normalizeClickMoveButton,
+  perCharacterSettingKey,
   SETTING_RANGES,
   Settings,
 } from '../src/game/settings';
@@ -374,5 +375,130 @@ describe('click-to-move mouse button setting', () => {
     expect(normalizeClickMoveButton(2)).toBe(2);
     expect(clickMoveButtonLabel(0)).toBe('Left Click');
     expect(clickMoveButtonLabel(2)).toBe('Right Click');
+  });
+});
+
+// The Attack button and attack-on-cast toggles are PER-CHARACTER: a mage that
+// drops the Attack button and turns off attack-on-cast must not force those on a
+// paladin. They keep the same keys/defs in BOOL_SETTINGS, but once a character
+// context is bound (Settings.setCharacter, wired from startGame) they resolve to
+// a per-character localStorage entry keyed by class+name like the action bar.
+describe('per-character combat settings (Attack button / attack-on-cast)', () => {
+  it('lets two characters hold independent values that persist across sessions', () => {
+    const mage = new Settings();
+    mage.setCharacter('mage', 'Gandalf');
+    // The mage drops the Attack button and turns off attack-on-cast.
+    mage.set('showAttackButton', false);
+    mage.set('startAttackOnAbilityUse', false);
+    expect(mage.get('showAttackButton')).toBe(false);
+    expect(mage.get('startAttackOnAbilityUse')).toBe(false);
+
+    // The paladin, bound on the same device, keeps the classic defaults and can
+    // set its own value without disturbing the mage's.
+    const paladin = new Settings();
+    paladin.setCharacter('paladin', 'Uther');
+    expect(paladin.get('showAttackButton')).toBe(true);
+    expect(paladin.get('startAttackOnAbilityUse')).toBe(true);
+    paladin.set('showAttackButton', true);
+
+    // A fresh session for each reads back its OWN stored value.
+    const mageAgain = new Settings();
+    mageAgain.setCharacter('mage', 'Gandalf');
+    expect(mageAgain.get('showAttackButton')).toBe(false);
+    expect(mageAgain.get('startAttackOnAbilityUse')).toBe(false);
+
+    const paladinAgain = new Settings();
+    paladinAgain.setCharacter('paladin', 'Uther');
+    expect(paladinAgain.get('showAttackButton')).toBe(true);
+    expect(paladinAgain.get('startAttackOnAbilityUse')).toBe(true);
+  });
+
+  it('keys per-character storage by class+name and leaves the global blob out of it', () => {
+    const s = new Settings();
+    s.setCharacter('mage', 'Gandalf');
+    s.set('showAttackButton', false);
+    expect(
+      localStorage.getItem(perCharacterSettingKey('showAttackButton', 'mage', 'Gandalf')),
+    ).toBe('false');
+    // Same-named characters of a different class do not collide.
+    expect(
+      localStorage.getItem(perCharacterSettingKey('showAttackButton', 'paladin', 'Gandalf')),
+    ).toBeNull();
+  });
+
+  it('migrates the existing GLOBAL value into each character on first read (no visible change on upgrade)', () => {
+    // A returning player had turned the Attack button OFF globally before the split.
+    localStorage.setItem(
+      'woc_settings',
+      JSON.stringify({ showAttackButton: false, startAttackOnAbilityUse: false }),
+    );
+
+    // First time each character is bound with nothing stored yet, it inherits the
+    // player's current global value, so their setup does not visibly change.
+    const mage = new Settings();
+    mage.setCharacter('mage', 'Gandalf');
+    expect(mage.get('showAttackButton')).toBe(false);
+    expect(mage.get('startAttackOnAbilityUse')).toBe(false);
+
+    const paladin = new Settings();
+    paladin.setCharacter('paladin', 'Uther');
+    expect(paladin.get('showAttackButton')).toBe(false);
+    expect(paladin.get('startAttackOnAbilityUse')).toBe(false);
+
+    // After migration each character owns its value: flipping the paladin on does
+    // not change the mage.
+    paladin.set('showAttackButton', true);
+    const mageAgain = new Settings();
+    mageAgain.setCharacter('mage', 'Gandalf');
+    expect(mageAgain.get('showAttackButton')).toBe(false);
+  });
+
+  it('does not leak one character onto a not-yet-migrated character via the global blob', () => {
+    // The global seed starts at the defaults (on). The mage plays first, turns the
+    // Attack button off, and also changes an unrelated GLOBAL setting (which calls
+    // save()). That save must NOT rewrite the blob's showAttackButton to the mage's
+    // off, or a paladin logging in later would wrongly inherit off.
+    const mage = new Settings();
+    mage.setCharacter('mage', 'Gandalf');
+    mage.set('showAttackButton', false);
+    mage.set('sfxVolume', 0.3); // unrelated global write -> save()
+
+    const paladin = new Settings();
+    paladin.setCharacter('paladin', 'Uther');
+    expect(paladin.get('showAttackButton')).toBe(true); // still the original global seed
+  });
+
+  it('without a bound character, resolves to the global blob exactly as before', () => {
+    const s = new Settings();
+    expect(s.get('showAttackButton')).toBe(true);
+    s.set('showAttackButton', false);
+    // Stored on the global blob (no per-character context), read back by a fresh instance.
+    expect(new Settings().get('showAttackButton')).toBe(false);
+  });
+
+  it("reset() restores the bound character's per-character keys to their defaults", () => {
+    const mage = new Settings();
+    mage.setCharacter('mage', 'Gandalf');
+    mage.set('showAttackButton', false);
+    mage.set('startAttackOnAbilityUse', false);
+    mage.reset();
+    expect(mage.get('showAttackButton')).toBe(true);
+    expect(mage.get('startAttackOnAbilityUse')).toBe(true);
+    // The restore persists for the next session too.
+    const mageAgain = new Settings();
+    mageAgain.setCharacter('mage', 'Gandalf');
+    expect(mageAgain.get('showAttackButton')).toBe(true);
+    expect(mageAgain.get('startAttackOnAbilityUse')).toBe(true);
+  });
+
+  it('scoped reset(keys) restores a per-character key on the bound character', () => {
+    const mage = new Settings();
+    mage.setCharacter('mage', 'Gandalf');
+    mage.set('showAttackButton', false);
+    mage.reset(['showAttackButton']);
+    expect(mage.get('showAttackButton')).toBe(true);
+    const next = new Settings();
+    next.setCharacter('mage', 'Gandalf');
+    expect(next.get('showAttackButton')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

The **Attack button** (`showAttackButton` — whether the Attack toggle occupies action-bar slot 0) and **attack-on-cast** (`startAttackOnAbilityUse`) settings were stored device-wide in the global `woc_settings` blob. That made them shared across every character, while the action-bar *layout* is already per-character.

The result: a mage that drops the Attack button and turns off attack-on-cast forced those same choices onto a paladin. Switching characters meant re-toggling both in Options every single time.

This makes those two settings **per-character**, keyed by class + name exactly the way the per-character action bar already is (`actionBarSlotMapKey` → `woc_hotbar_${class}_${name}`). Everything else stays global.

**Migration:** the first time a character reads either setting with nothing stored, the player's existing global value is migrated in and persisted. So on upgrade nothing visibly changes — each character starts where the player already was, then remembers independently from there. "Reset to Defaults" is honored per character too.

The setting **names are unchanged**, so every existing call site — the Options toggles, the HUD reads (`attackSlotIsAttack`, cast-time auto-attack), and the right-click-to-remove path — is untouched. Only the storage resolution changes underneath, in `Settings`.

## Related issues

N/A — surfaced from player feedback (switching between a mage and a paladin repeatedly re-toggling these).

## Type of change

- [x] Feature: new functionality
- [x] Tests

## How was this tested?

- Commands (run locally, Node 24):
  - `npx tsc --noEmit` — clean
  - `npm run build:env`, `npm run build:server`, `npm run build` — all pass
  - `npx vitest run tests/settings.test.ts` — 35/35 pass (7 new cases: two characters holding independent values; per-character keying leaves the global blob out; migration of the existing global value on first read; no cross-character leak via the blob; unbound fallback to the global blob; per-character reset and scoped reset)
  - `node scripts/gate.mjs` — all steps green **except** 2 pre-existing failures in `tests/deploy_watchdog.test.ts` (`docker inspect`/`docker restart` time out). Those are environmental — they need a running Docker daemon, are unrelated to this change, and fail identically on clean `main` with this change stashed. Everything else in the full vitest suite passes (20,222 passed / 51 skipped).
- Manual steps: N/A — this is a storage-layer change with no visual difference; the HUD renders identically and simply reads a per-character value.

## Screenshots / recordings

None — no visual change. The Attack button and its behavior look and work exactly as before; only *which* stored value they resolve to changes (per character vs global).

## Checklist

### Quality

- [x] Added decisive tests for the changed behavior (`tests/settings.test.ts`).
- [x] `npm run gate` is green apart from the two pre-existing, unrelated `deploy_watchdog` docker tests noted above (no Docker in my build env; they pass on clean `main`).

### Localization (i18n)

- [x] N/A — no new player-visible strings; setting labels are unchanged.

### Hygiene

- [x] No secrets or `.env` committed; no generated files hand-edited.
