### PR TITLE
fix(market): keep the Merchant house stock and player listing ids in separate bands

### DIFF
--- a/src/sim/CLAUDE.md
+++ b/src/sim/CLAUDE.md
@@ -124,6 +124,8 @@ legality), `cooldown_persist.ts` (cooldown save/load), `tab_target.ts`/`assist.t
 `mob/scan_counters.ts` (the per-tick mob scan-visit tally the server reads post-tick),
 `lockpick.ts` (the minigame core behind `delves/lockpick_controller.ts`), `map_doc.ts`
 (the custom-map document/validator), `geometry2d.ts`, `market_query.ts`,
+`market_listing_ids.ts` (the World Market's id allocator: the reserved house band plus
+the load-time reissue that keeps one row per id),
 `vendor_stack.ts`, `loot_master.ts`, `aura_classify.ts` (buff-vs-debuff, shared with the
 HUD), `resurrection.ts` (sickness rules shared by every death site), and the combat
 leaves `spell_resist.ts`/`ranged_shot.ts`/`aura_stacking.ts`/`aura_cancel.ts`/
@@ -218,7 +220,7 @@ persistence (`serializeCharacter`/`addPlayer`), the shared entry points above, a
   `localizeLootText` arm: `parseSimMoney` reverses the `"Ng Ns Nc"` fragment back to copper,
   then the i18n `formatMoney` formats it. Don't reach for the i18n `formatMoney`/`formatNumber`
   here, and don't hand-format with a separator a locale would change.
-- **Dev-channel text stays English.** The sim's only non-player text is a couple of
+- **Dev-channel text stays English.** The sim's only non-player text is a few
   `console.warn` diagnostics (no user-surfaced `throw`s); they are never matched. If a
   string would ever feed both a diagnostic log and a player-visible `SimEvent`, split it
   so only the player arm (`error`/`notice`) is registered in `sim_i18n.ts`.

--- a/src/sim/market.ts
+++ b/src/sim/market.ts
@@ -576,7 +576,12 @@ export class Market {
 
   loadMarket(save: MarketSave | null | undefined): void {
     if (!save) return;
-    const saved = save.listings ?? [];
+    // Drop the rows that carry no item id at all BEFORE planning, so the plan
+    // describes exactly what gets pushed: no planned id is burned on a row that
+    // never lands, and `remapped` counts only reissues the book actually took.
+    // (A listing whose item id is merely no longer in ITEMS is a different case
+    // and is KEPT; see the loop below.)
+    const saved = (save.listings ?? []).filter((l) => l && typeof l.itemId === 'string');
     // Settle the id counter and reissue any collision BEFORE a single row is
     // pushed back. The house band is already in the book (seeded by the ctor)
     // and is sized by the CURRENT stock table, so a save written under a smaller
@@ -587,7 +592,7 @@ export class Market {
     // loads the market before any client connects (server/main.ts).
     const plan = planListingIds({
       taken: this.marketListings.map((l) => l.id),
-      saved: saved.map((l) => l?.id),
+      saved: saved.map((l) => l.id),
       from: this.nextListingId,
       savedNext: save.nextListingId,
     });
@@ -599,7 +604,6 @@ export class Market {
       // dormant, recoverable data (the owner can reclaim it into bags, exactly
       // as the character load path keeps unknown ids verbatim); a re-added or
       // corrected id rehydrates it. Display/buy paths already guard on ITEMS[id].
-      if (!l || typeof l.itemId !== 'string') continue;
       if (!ITEMS[l.itemId])
         console.warn(`market: keeping listing with unknown item id ${l.itemId}`);
       this.marketListings.push({

--- a/src/sim/market.ts
+++ b/src/sim/market.ts
@@ -11,6 +11,7 @@
 
 import { ITEMS } from './data';
 import { formatMoney } from './format_money';
+import { planListingIds, playerListingIdFloor } from './market_listing_ids';
 import {
   MARKET_PAGE_SIZE,
   type MarketQuery,
@@ -208,6 +209,11 @@ export class Market {
       // here would renumber every row after it, so a client holding a browse list
       // across a server restart could click Buy on a row that now means a different
       // item. Appending leaves every existing id pointing at the same goods.
+      // (Growing this table is otherwise content-safe now: the counter is floored
+      // to the reserved player base below, so no id this build issues a player
+      // listing can ever be reached by stock, and an id a pre-#2463 build issued
+      // below that base is reissued by the load path in the same boot the table
+      // grows over it. See market_listing_ids.ts, #2463.)
       { itemId: 'linen_pouch', count: 1, price: 250 },
       { itemId: 'travelers_knapsack', count: 1, price: 2000 },
     ];
@@ -224,6 +230,11 @@ export class Market {
         house: true,
       });
     }
+    // Reserve the whole low band for house stock before a player listing can be
+    // issued an id. House rows are reseeded from this counter every boot and are
+    // never persisted, so without the floor a grown stock table reissues ids an
+    // older build already handed to persisted player listings (#2463).
+    this.nextListingId = playerListingIdFloor(this.marketListings.map((l) => l.id));
   }
 
   // List a stack from your bags for sale. The goods are escrowed (pulled from
@@ -565,7 +576,23 @@ export class Market {
 
   loadMarket(save: MarketSave | null | undefined): void {
     if (!save) return;
-    for (const l of save.listings ?? []) {
+    const saved = save.listings ?? [];
+    // Settle the id counter and reissue any collision BEFORE a single row is
+    // pushed back. The house band is already in the book (seeded by the ctor)
+    // and is sized by the CURRENT stock table, so a save written under a smaller
+    // table can carry an id that now names a house row. Replaying it verbatim
+    // would put two rows in the book under one id, and every id-resolving call
+    // site (marketBuy/marketCancel/the wire) would resolve to the house row that
+    // sits earlier in the array (#2463). Boot order makes this safe: the server
+    // loads the market before any client connects (server/main.ts).
+    const plan = planListingIds({
+      taken: this.marketListings.map((l) => l.id),
+      saved: saved.map((l) => l?.id),
+      from: this.nextListingId,
+      savedNext: save.nextListingId,
+    });
+    for (let i = 0; i < saved.length; i++) {
+      const l = saved[i];
       // Keep a listing whose item id is no longer in ITEMS (a content rename,
       // retirement, or typo). Dropping it would silently destroy every escrowed
       // copy on the next restart and never refund the seller. An unknown id is
@@ -576,7 +603,7 @@ export class Market {
       if (!ITEMS[l.itemId])
         console.warn(`market: keeping listing with unknown item id ${l.itemId}`);
       this.marketListings.push({
-        id: l.id,
+        id: plan.ids[i],
         sellerKey: String(l.sellerKey ?? ''),
         sellerName: String(l.sellerName ?? l.sellerKey ?? '?'),
         itemId: l.itemId,
@@ -603,8 +630,16 @@ export class Market {
           .map((s) => ({ itemId: s.itemId, count: Math.max(1, s.count | 0) })),
       });
     }
-    const maxId = this.marketListings.reduce((m, l) => Math.max(m, l.id + 1), 1);
-    this.nextListingId = Math.max(this.nextListingId, save.nextListingId ?? 1, maxId);
+    this.nextListingId = plan.nextListingId;
+    if (plan.remapped > 0) {
+      // Dev-channel only: a boot-time repair the operator should see in the log.
+      // The count covers all three reissue causes (taken by the house band,
+      // duplicated inside the save, or malformed), so the log never sends an
+      // operator after the wrong hypothesis on a corrupt blob.
+      console.warn(
+        `market: reissued ${plan.remapped} persisted listing id(s) that collided or were malformed`,
+      );
+    }
     this.reclaimSoulboundListings();
   }
 

--- a/src/sim/market_listing_ids.ts
+++ b/src/sim/market_listing_ids.ts
@@ -1,0 +1,104 @@
+// The World Market's listing-id allocator: the pure core that keeps the
+// Merchant's standing house stock and persisted player listings in two
+// non-overlapping id bands.
+//
+// Why this exists (#2463): house rows are reseeded from the SAME counter on
+// every boot and are never persisted, while player listings are pushed back
+// from the save carrying the ids an OLDER build issued them. Every time the
+// stock table grows, the reseeded house band swallows ids that build had
+// already handed to real player listings, and because the house rows are pushed
+// first, `findIndex((l) => l.id === listingId)` resolves the duplicate to the
+// house row: the owner cannot reclaim their goods ("That is not your listing")
+// and a buyer gets the house item at the house price without the row ever being
+// consumed, so the purchase repeats and the seller is never paid.
+//
+// Two complementary rules, both pure and both tested directly:
+//  - `playerListingIdFloor` reserves a whole low band for house stock, so
+//    growing the Merchant's stock table can never reach the player band again.
+//  - `planListingIds` settles the counter BEFORE the load pushes anything back
+//    and reissues any persisted id the book has already taken, which repairs a
+//    save that an earlier stock batch already armed.
+//
+// `src/sim`-pure: no imports at all, no rng, no clock. A Vitest imports it
+// directly (`tests/market_listing_ids.test.ts`).
+
+// The first id the counter hands to a PLAYER listing on a fresh world. Every id
+// below it belongs to the reseeded house band, which is a couple of dozen rows
+// today and may grow into the whole reserved span without ever reaching a
+// persisted player id.
+export const MARKET_PLAYER_LISTING_ID_BASE = 1000;
+
+// A usable listing id: a positive safe integer. Anything else a persisted row
+// can carry (missing, null, fractional, NaN, Infinity, past the safe-integer
+// range, or a numeric string) is treated as NO id and gets reissued: the
+// id-resolving call sites match with `===`, so such a row would be unreachable
+// for its owner and would poison the counter through `Math.max`.
+export function isListingId(v: unknown): v is number {
+  return typeof v === 'number' && Number.isSafeInteger(v) && v >= 1;
+}
+
+// The counter to resume from once the house band is seeded: at or past the
+// reserved base, and past every seeded row, so the player band starts at
+// MARKET_PLAYER_LISTING_ID_BASE on a fresh world and still clears the stock
+// table in the (unreached) case where it ever outgrows the reserved span.
+export function playerListingIdFloor(seededIds: Iterable<number>): number {
+  let floor = MARKET_PLAYER_LISTING_ID_BASE;
+  for (const id of seededIds) if (isListingId(id) && id >= floor) floor = id + 1;
+  return floor;
+}
+
+export interface ListingIdPlanInput {
+  // Ids already in the book when the save is replayed (the reseeded house band).
+  taken: Iterable<number>;
+  // The persisted listing ids in save order; any entry may be malformed.
+  saved: readonly unknown[];
+  // The counter as it stands before the replay (post-seed, so already floored).
+  from: number;
+  // The counter the save carries: honoured when it is ahead, never trusted alone.
+  savedNext: unknown;
+}
+
+export interface ListingIdPlan {
+  // The id to push each persisted listing back with, index-aligned with `saved`
+  // (a row the caller skips simply leaves its planned id unused).
+  ids: number[];
+  // The counter the market resumes issuing from.
+  nextListingId: number;
+  // How many persisted ids had to be reissued; 0 on a healthy save.
+  remapped: number;
+}
+
+// Decide the id every persisted listing is replayed under, keeping the whole
+// book collision-free. A healthy save keeps every id verbatim and reports
+// `remapped: 0`.
+export function planListingIds(input: ListingIdPlanInput): ListingIdPlan {
+  const used = new Set<number>();
+  for (const id of input.taken) if (isListingId(id)) used.add(id);
+
+  // Settle the counter FIRST, past everything the book already holds AND
+  // everything the save carries. Doing this before a single id is handed out is
+  // what stops a reissued id from landing on a persisted id further down the
+  // same save (the old code advanced the counter only AFTER the push loop, so
+  // it could not have reissued anything safely).
+  let next = isListingId(input.from) ? input.from : 1;
+  for (const id of used) if (id >= next) next = id + 1;
+  if (isListingId(input.savedNext) && input.savedNext > next) next = input.savedNext;
+  for (const id of input.saved) if (isListingId(id) && id >= next) next = id + 1;
+
+  const ids: number[] = [];
+  let remapped = 0;
+  for (const id of input.saved) {
+    if (isListingId(id) && !used.has(id)) {
+      used.add(id);
+      ids.push(id);
+      continue;
+    }
+    // Taken by the house band, duplicated inside the save, or malformed: hand
+    // out a fresh id from the settled counter.
+    used.add(next);
+    ids.push(next);
+    next++;
+    remapped++;
+  }
+  return { ids, nextListingId: next, remapped };
+}

--- a/tests/market.test.ts
+++ b/tests/market.test.ts
@@ -608,7 +608,11 @@ describe('the World Market — the Merchant', () => {
     expect(house.length).toBeGreaterThan(0);
     // every seeded row sits below the base, with room for the table to grow
     expect(Math.max(...house.map((l) => l.id))).toBeLessThan(MARKET_PLAYER_LISTING_ID_BASE);
-    expect(house.length).toBeLessThan(MARKET_PLAYER_LISTING_ID_BASE);
+    // and the room is real, not one row's worth: the stock table can grow to ten
+    // times its current size and still not reach the player band. "Below the
+    // base" alone would hold just as well with a base of house.length + 1, which
+    // is the state #2463 was filed about.
+    expect(house.length * 10).toBeLessThan(MARKET_PLAYER_LISTING_ID_BASE);
 
     const seller = sim.addPlayer('warrior', 'Seller');
     standAtMerchant(sim, seller);
@@ -741,6 +745,27 @@ describe('the World Market — the Merchant', () => {
     expect(sim.marketListings.filter((l) => l.house).length).toBe(houseIds.length);
   });
 
+  it('burns no listing ids on save rows it cannot replay at all', () => {
+    // A row with no usable item id is dropped, so it must not consume a planned
+    // id on the way out: the id plan has to describe what actually lands in the
+    // book, or the boot log reports reissues for rows nobody ever sees and the
+    // counter skips ids for no reason.
+    const sim = makeWorld();
+    const before = sim.serializeMarket().nextListingId;
+    sim.loadMarket({
+      listings: [
+        // malformed id AND no item id: unusable on both counts
+        { id: Number.NaN, sellerKey: '12', sellerName: 'Seller', count: 1, price: 10 },
+        null,
+      ],
+      collections: [],
+      nextListingId: 1,
+    } as never);
+
+    expect(sim.marketListings.filter((l) => !l.house).length).toBe(0);
+    expect(sim.serializeMarket().nextListingId).toBe(before);
+  });
+
   it('keeps listings and collection items whose item id is no longer known', () => {
     // A content edit (rename/retire/typo of an item id) must NOT vaporize every
     // in-flight copy of that item sitting on the market at the next restart.
@@ -749,7 +774,10 @@ describe('the World Market — the Merchant', () => {
     const save = {
       listings: [
         {
-          id: 7,
+          // A player-band id, so this case stays about the unknown ITEM id: an
+          // id inside the reseeded house band would also be reissued by the
+          // #2463 repair, which is a different test's charter.
+          id: 1007,
           sellerKey: '12',
           sellerName: 'Seller',
           itemId: 'retired_relic', // not in ITEMS
@@ -768,7 +796,7 @@ describe('the World Market — the Merchant', () => {
           ],
         },
       ],
-      nextListingId: 8,
+      nextListingId: 1008,
     };
 
     const sim = makeWorld();
@@ -840,10 +868,13 @@ describe('World Market: a now-soulbound listing is returned to the seller', () =
     // A save from BEFORE heroic_mark became soulbound can still hold a listing of
     // it (the list-time gate only blocks NEW listings). loadMarket must not keep a
     // soulbound item on the market; it returns it to the seller's collection.
+    // Player-band ids (>= MARKET_PLAYER_LISTING_ID_BASE): ids inside the
+    // reseeded house band would be reissued by the #2463 repair, which would
+    // leave this case quietly testing the reclaim over a renumbered book.
     const save = {
       listings: [
         {
-          id: 1,
+          id: 1001,
           sellerKey,
           sellerName: 'Ada',
           itemId: 'heroic_mark',
@@ -852,7 +883,7 @@ describe('World Market: a now-soulbound listing is returned to the seller', () =
           secondsLeft: 1000,
         },
         {
-          id: 2,
+          id: 1002,
           sellerKey,
           sellerName: 'Ada',
           itemId: 'wolf_fang',
@@ -862,7 +893,7 @@ describe('World Market: a now-soulbound listing is returned to the seller', () =
         },
       ],
       collections: [],
-      nextListingId: 3,
+      nextListingId: 1003,
     };
     sim.market.loadMarket(save as never);
 

--- a/tests/market.test.ts
+++ b/tests/market.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { ITEMS } from '../src/sim/data';
+import { MARKET_PLAYER_LISTING_ID_BASE } from '../src/sim/market_listing_ids';
 import type { MarketQuery } from '../src/sim/market_query';
 import { Sim } from '../src/sim/sim';
 import type { Entity } from '../src/sim/types';
@@ -592,6 +593,152 @@ describe('the World Market — the Merchant', () => {
     sim2.marketList('bone_fragments', 1, 50, seller2);
     const ids = sim2.marketListings.map((l) => l.id);
     expect(new Set(ids).size).toBe(ids.length); // no id collisions
+  });
+
+  // ---------------------------------------------------------------------------
+  // Listing-id bands (#2463). House stock is reseeded from the id counter every
+  // boot and is never persisted; player listings are replayed from the save with
+  // the ids an OLDER build issued them. Growing the stock table therefore used to
+  // reissue ids the save still held, and the duplicate resolved to the house row.
+  // ---------------------------------------------------------------------------
+
+  it('reserves the low id band for house stock so growing it cannot reach player ids', () => {
+    const sim = makeWorld();
+    const house = sim.marketListings.filter((l) => l.house);
+    expect(house.length).toBeGreaterThan(0);
+    // every seeded row sits below the base, with room for the table to grow
+    expect(Math.max(...house.map((l) => l.id))).toBeLessThan(MARKET_PLAYER_LISTING_ID_BASE);
+    expect(house.length).toBeLessThan(MARKET_PLAYER_LISTING_ID_BASE);
+
+    const seller = sim.addPlayer('warrior', 'Seller');
+    standAtMerchant(sim, seller);
+    sim.addItem('wolf_fang', 2, seller);
+    sim.marketList('wolf_fang', 1, 100, seller);
+    sim.marketList('wolf_fang', 1, 120, seller);
+
+    const mine = sim.marketListings.filter((l) => !l.house);
+    expect(mine.length).toBe(2);
+    expect(mine.every((l) => l.id >= MARKET_PLAYER_LISTING_ID_BASE)).toBe(true);
+  });
+
+  it('replays a healthy save with its listing ids untouched and resumes past it', () => {
+    const sim = makeWorld();
+    const row = (id: number) => ({
+      id,
+      sellerKey: 'legacy',
+      sellerName: 'Legacy',
+      itemId: 'wolf_fang',
+      count: 1,
+      price: 100,
+      secondsLeft: 600,
+    });
+    // Off-sequence ids, the shape a live save takes once sales and expiries have
+    // punched holes in it. They matter: an id the counter would have handed out
+    // anyway cannot tell "kept verbatim" apart from "renumbered off the counter".
+    sim.loadMarket({ listings: [row(1000), row(1007)], collections: [], nextListingId: 1008 });
+
+    // no gratuitous renumbering: only a real collision reissues an id
+    expect(sim.marketListings.filter((l) => !l.house).map((l) => l.id)).toEqual([1000, 1007]);
+
+    // and the counter resumed past the whole save, so the next listing cannot reuse one
+    const seller = sim.addPlayer('warrior', 'Seller');
+    standAtMerchant(sim, seller);
+    sim.addItem('wolf_fang', 1, seller);
+    sim.marketList('wolf_fang', 1, 50, seller);
+    const fresh = sim.marketListings.find((l) => l.sellerKey === marketSellerKey(seller))!;
+    expect(fresh.id).toBeGreaterThanOrEqual(1008);
+    const ids = sim.marketListings.map((l) => l.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('reissues a persisted listing id the reseeded house band has taken', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    const buyer = sim.addPlayer('mage', 'Buyer');
+    standAtMerchant(sim, seller);
+    standAtMerchant(sim, buyer);
+    sim.players.get(buyer)!.copper = 1000;
+
+    // A save written by a build whose stock table was smaller: this id was a
+    // real player listing then and names a house row now.
+    const houseIds = sim.marketListings.filter((l) => l.house).map((l) => l.id);
+    const collidingId = houseIds[houseIds.length - 1];
+    sim.loadMarket({
+      listings: [
+        {
+          id: collidingId,
+          sellerKey: marketSellerKey(seller),
+          sellerName: 'Seller',
+          itemId: 'wolf_fang',
+          count: 2,
+          price: 300,
+          secondsLeft: 600,
+        },
+      ],
+      collections: [],
+      nextListingId: collidingId + 1,
+    });
+
+    const ids = sim.marketListings.map((l) => l.id);
+    expect(new Set(ids).size).toBe(ids.length); // one row per id
+    const mine = sim.marketListings.find(
+      (l) => !l.house && l.sellerKey === marketSellerKey(seller),
+    );
+    expect(mine).toBeTruthy();
+    expect(mine!.id).not.toBe(collidingId);
+    expect(mine!.id).toBeGreaterThanOrEqual(MARKET_PLAYER_LISTING_ID_BASE);
+    // the id-resolving call sites now land on the PLAYER row, not a house row
+    expect(sim.marketListings[sim.marketListings.findIndex((l) => l.id === mine!.id)].house).toBe(
+      false,
+    );
+    // and the house row that owns the old id is untouched
+    expect(sim.marketListings.filter((l) => l.house).length).toBe(houseIds.length);
+    expect(sim.marketListings.find((l) => l.id === collidingId)!.house).toBe(true);
+
+    // buying the player row hands over the player's goods, consumes the row, and
+    // pays the seller (the house arm paid no one and never depleted)
+    sim.marketBuy(mine!.id, buyer);
+    expect(sim.countItem('wolf_fang', buyer)).toBe(2);
+    expect(copperOf(sim, buyer)).toBe(700);
+    expect(sim.marketListings.some((l) => l.id === mine!.id)).toBe(false);
+    expect(sim.marketInfoFor(seller)!.collectionCopper).toBe(285); // 300 - 5%
+  });
+
+  it('lets the owner reclaim a listing whose saved id the house band had taken', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    standAtMerchant(sim, seller);
+
+    const houseIds = sim.marketListings.filter((l) => l.house).map((l) => l.id);
+    const collidingId = houseIds[houseIds.length - 1];
+    sim.loadMarket({
+      listings: [
+        {
+          id: collidingId,
+          sellerKey: marketSellerKey(seller),
+          sellerName: 'Seller',
+          itemId: 'wolf_fang',
+          count: 2,
+          price: 300,
+          secondsLeft: 600,
+        },
+      ],
+      collections: [],
+      nextListingId: collidingId + 1,
+    });
+
+    const mine = sim.marketListings.find(
+      (l) => !l.house && l.sellerKey === marketSellerKey(seller),
+    )!;
+    expect(sim.marketInfoFor(seller)!.myListingCount).toBe(1);
+    sim.events.length = 0;
+
+    sim.marketCancel(mine.id, seller);
+
+    expect(errorsSince(sim)).toEqual([]); // no "That is not your listing"
+    expect(sim.countItem('wolf_fang', seller)).toBe(2); // escrow came back
+    expect(sim.marketListings.some((l) => l.id === mine.id)).toBe(false);
+    expect(sim.marketListings.filter((l) => l.house).length).toBe(houseIds.length);
   });
 
   it('keeps listings and collection items whose item id is no longer known', () => {

--- a/tests/market_listing_ids.test.ts
+++ b/tests/market_listing_ids.test.ts
@@ -9,6 +9,19 @@ import {
   playerListingIdFloor,
 } from '../src/sim/market_listing_ids';
 
+describe('MARKET_PLAYER_LISTING_ID_BASE', () => {
+  it('is pinned to its literal value', () => {
+    // Deliberately a literal, not a self-comparison: every OTHER assertion in
+    // this file and in tests/market.test.ts is written against the constant, so
+    // shrinking it would leave all of them green while destroying the headroom
+    // the band exists to provide (at base 24 the 23-row stock table already sits
+    // flush against the first player id, re-arming #2463 on the next stock row).
+    // Raising it is fine on its own, but it moves where every future player id
+    // lands, so it should be a deliberate edit rather than a silent one.
+    expect(MARKET_PLAYER_LISTING_ID_BASE).toBe(1000);
+  });
+});
+
 describe('isListingId', () => {
   it('accepts only positive safe integers', () => {
     expect(isListingId(1)).toBe(true);

--- a/tests/market_listing_ids.test.ts
+++ b/tests/market_listing_ids.test.ts
@@ -1,0 +1,153 @@
+// The World Market's listing-id allocator (src/sim/market_listing_ids.ts), the
+// pure core behind the house-band / player-band split (#2463). Tested directly:
+// no Sim, no clock, no rng.
+import { describe, expect, it } from 'vitest';
+import {
+  isListingId,
+  MARKET_PLAYER_LISTING_ID_BASE,
+  planListingIds,
+  playerListingIdFloor,
+} from '../src/sim/market_listing_ids';
+
+describe('isListingId', () => {
+  it('accepts only positive safe integers', () => {
+    expect(isListingId(1)).toBe(true);
+    expect(isListingId(1000)).toBe(true);
+    expect(isListingId(Number.MAX_SAFE_INTEGER)).toBe(true);
+
+    expect(isListingId(0)).toBe(false);
+    expect(isListingId(-1)).toBe(false);
+    expect(isListingId(1.5)).toBe(false);
+    expect(isListingId(NaN)).toBe(false);
+    expect(isListingId(Infinity)).toBe(false);
+    expect(isListingId(Number.MAX_SAFE_INTEGER + 1)).toBe(false);
+    expect(isListingId('7')).toBe(false);
+    expect(isListingId(null)).toBe(false);
+    expect(isListingId(undefined)).toBe(false);
+  });
+});
+
+describe('playerListingIdFloor', () => {
+  it('starts the player band at the reserved base, whatever the house band holds', () => {
+    expect(playerListingIdFloor([])).toBe(MARKET_PLAYER_LISTING_ID_BASE);
+    expect(playerListingIdFloor([1, 2, 3])).toBe(MARKET_PLAYER_LISTING_ID_BASE);
+    // the whole reserved span is the Merchant's to grow into
+    expect(playerListingIdFloor([MARKET_PLAYER_LISTING_ID_BASE - 1])).toBe(
+      MARKET_PLAYER_LISTING_ID_BASE,
+    );
+    // boundary: a seeded row ON the base pushes the floor past it, never onto it
+    expect(playerListingIdFloor([MARKET_PLAYER_LISTING_ID_BASE])).toBe(
+      MARKET_PLAYER_LISTING_ID_BASE + 1,
+    );
+  });
+
+  it('clears a house band that outgrew the reserved base', () => {
+    const past = MARKET_PLAYER_LISTING_ID_BASE + 40;
+    expect(playerListingIdFloor([1, past, 2])).toBe(past + 1);
+  });
+
+  it('ignores malformed seeded ids instead of poisoning the floor', () => {
+    expect(playerListingIdFloor([NaN, Infinity, -5, 0] as number[])).toBe(
+      MARKET_PLAYER_LISTING_ID_BASE,
+    );
+  });
+});
+
+describe('planListingIds', () => {
+  it('keeps a healthy save verbatim and settles the counter past it', () => {
+    const plan = planListingIds({
+      taken: [1, 2, 3],
+      saved: [1001, 1002],
+      from: 1000,
+      savedNext: 1003,
+    });
+    expect(plan.ids).toEqual([1001, 1002]);
+    expect(plan.remapped).toBe(0);
+    expect(plan.nextListingId).toBe(1003);
+  });
+
+  it('reissues a persisted id the house band has already taken', () => {
+    // the #2463 shape: the save was written when the stock table was smaller,
+    // so id 7 was a player listing then and names a house row now.
+    const plan = planListingIds({
+      taken: [1, 2, 3, 4, 5, 6, 7],
+      saved: [7],
+      from: 1000,
+      savedNext: 8,
+    });
+    expect(plan.ids).toEqual([1000]);
+    expect(plan.remapped).toBe(1);
+    expect(plan.nextListingId).toBe(1001);
+  });
+
+  it('never hands a reissued id to a row a later save entry keeps verbatim', () => {
+    // The counter must be settled BEFORE the first id is handed out: advancing
+    // it only as rows are pushed (the old order) would reissue the colliding 2
+    // as 4 and collide head-on with the 4 further down the same save.
+    const plan = planListingIds({ taken: [1, 2, 3], saved: [2, 4], from: 4, savedNext: 4 });
+    expect(plan.ids).toEqual([5, 4]);
+    expect(new Set(plan.ids).size).toBe(plan.ids.length);
+    expect(plan.remapped).toBe(1);
+    expect(plan.nextListingId).toBe(6);
+  });
+
+  it('breaks up ids duplicated inside one save', () => {
+    const plan = planListingIds({
+      taken: [],
+      saved: [1001, 1001, 1001],
+      from: 1000,
+      savedNext: 1002,
+    });
+    expect(plan.ids).toEqual([1001, 1002, 1003]);
+    expect(plan.remapped).toBe(2);
+    expect(plan.nextListingId).toBe(1004);
+  });
+
+  it('reissues every malformed id and stays index-aligned with the save', () => {
+    const saved = [undefined, null, 0, -3, 2.5, NaN, Infinity, '1001', Number.MAX_SAFE_INTEGER + 1];
+    const plan = planListingIds({ taken: [1], saved, from: 1000, savedNext: 1000 });
+    expect(plan.ids.length).toBe(saved.length); // one planned id per save row
+    expect(plan.ids).toEqual([1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008]);
+    expect(plan.remapped).toBe(saved.length);
+    expect(plan.nextListingId).toBe(1009);
+  });
+
+  it('honours a saved counter that runs ahead of every id', () => {
+    const plan = planListingIds({ taken: [1], saved: [1001], from: 1000, savedNext: 5000 });
+    expect(plan.ids).toEqual([1001]);
+    expect(plan.nextListingId).toBe(5000); // the next id issued is 5000
+  });
+
+  it('ignores a malformed or stale saved counter instead of walking backwards', () => {
+    for (const savedNext of [undefined, null, NaN, -1, 0, 'lots', 2]) {
+      const plan = planListingIds({ taken: [1, 2, 3], saved: [1001], from: 1000, savedNext });
+      expect(plan.ids).toEqual([1001]);
+      expect(plan.nextListingId).toBe(1002); // past the book and past the save
+    }
+  });
+
+  it('settles past an id the book holds ON the counter, never onto it', () => {
+    // boundary: `from` equal to a taken id must still advance, or the first
+    // reissued row lands on the house row that already owns that id.
+    const plan = planListingIds({ taken: [1000], saved: [null], from: 1000, savedNext: 0 });
+    expect(plan.ids).toEqual([1001]);
+    expect(plan.nextListingId).toBe(1002);
+  });
+
+  it('settles past the book even when the incoming counter lags behind it', () => {
+    const plan = planListingIds({ taken: [1, 2, 3, 4], saved: [], from: 1, savedNext: 1 });
+    expect(plan.ids).toEqual([]);
+    expect(plan.remapped).toBe(0);
+    expect(plan.nextListingId).toBe(5);
+  });
+
+  it('leaves no two rows sharing an id across a mixed, hostile save', () => {
+    const taken = [1, 2, 3, 4, 5];
+    const saved = [3, 3, 1002, undefined, 1002, 5, 1001];
+    const plan = planListingIds({ taken, saved, from: 1000, savedNext: 7 });
+    const all = [...taken, ...plan.ids];
+    expect(new Set(all).size).toBe(all.length);
+    expect(plan.ids.every((id) => Number.isSafeInteger(id) && id >= 1)).toBe(true);
+    expect(Math.max(...plan.ids)).toBeLessThan(plan.nextListingId);
+  });
+});

--- a/tests/retired_heroic_items.test.ts
+++ b/tests/retired_heroic_items.test.ts
@@ -205,7 +205,10 @@ describe('retired heroic items: the four ids v0.25.0 orphaned resolve again', ()
     const marketSave: MarketSave = {
       listings: [
         {
-          id: 7,
+          // A player-band id (>= MARKET_PLAYER_LISTING_ID_BASE), so the round-trip
+          // below stays strict: an id inside the reseeded house band would be
+          // reissued at load by the #2463 repair, which is not this test's charter.
+          id: 1007,
           sellerKey: 'legacy-seller',
           sellerName: 'Legacy Seller',
           itemId: 'soulrend_diadem',
@@ -221,7 +224,7 @@ describe('retired heroic items: the four ids v0.25.0 orphaned resolve again', ()
           items: [{ itemId: 'soulforged_warplate', count: 1 }],
         },
       ],
-      nextListingId: 8,
+      nextListingId: 1008,
     };
     const mailSave: MailSave = {
       mail: [


### PR DESCRIPTION
## Summary

The Merchant's standing house stock and players' persisted listings share one listing-id
namespace, but only one of the two is persisted. `seedHouseListings()` runs in the `Market`
constructor and allocates from `nextListingId = 1`, so the house rows always occupy a dense band
starting at 1, resized on every boot by whatever the current binary's stock table says.
`loadMarket()` then pushes persisted player listings back verbatim, after the house rows are
already in the book. Every time the stock table has grown (5 rows, then 13, then 21, now 23), the
house band swallowed ids an earlier build had handed to real player listings, and
`findIndex((l) => l.id === listingId)` resolved the duplicate to the house row that sits first:

- the owner got "That is not your listing" and could not reclaim their goods until the listing
  expired, and
- a buyer got the house item at the house price, with the row never consumed and the seller never
  paid, repeatable without limit.

Both halves the issue asks for are here, and they are complements rather than alternatives:

1. **Reserve a house band.** After seeding, the counter is floored at `MARKET_PLAYER_LISTING_ID_BASE`
   (1000), so no id this build issues a player listing can ever be reached by stock growth. The
   floor is derived from the seeded ids, not the array length, so it still clears the table if the
   stock ever outgrows the reserved span.
2. **Remap on load.** `loadMarket` settles the counter *before* it replays a single row, then
   reissues any persisted id the book has already taken. This repairs saves the earlier stock
   batches already armed, which the floor alone cannot do. The same pass reissues ids duplicated
   inside one save and malformed ids (missing, `NaN`, fractional, out of safe-integer range), which
   previously flowed straight through and could poison the counter via `Math.max`.

The policy lives in a new pure leaf, `src/sim/market_listing_ids.ts` (no imports, no rng, no clock),
so it is unit-testable directly; `market.ts` stays a thin consumer. The plan is built over only the
rows the load can actually replay: a save row carrying no item id at all is dropped before planning,
so it never burns a planned id and never inflates the reissue count the boot warning reports.

A healthy save still replays byte-identical: only a real collision reissues an id, which is pinned.
The repair is invisible to players because `server/main.ts` awaits `game.loadMarket()` before
`game.start()` and `server.listen(...)`, so no socket exists when an id moves. Rollback is clean
too: a blob written by this build carries ids at 1000 and up, which the pre-fix `loadMarket` accepts
without collision (its house band tops out at 23).

`server/market_backfill.ts` is deliberately untouched. `mergeMarketSaves` can still mint ids in the
low band when merging a pre-fix blob, and the load-path remap repairs exactly that at the next boot;
post-fix blobs persist a counter at 1000 or above, so the merge lands in the player band by
construction.

### Known limit (unchanged from before this PR)

`planListingIds` saturates if a hand-corrupted blob carries `nextListingId` or a listing id within a
few of `Number.MAX_SAFE_INTEGER`. Ids increment by exactly one per listing, so nothing reachable
gets there; the previous code fed the same mint site with no validation at all, so this is strictly
better, not a new limit. Happy to file a follow-up if you want an input ceiling in the leaf.

### Noticed in passing, filed separately

`scripts/market_listing_count_shot.mjs` reads and writes `sim.nextListingId`, which does not exist on
`Sim` (the counter is private on `Market`), so its 200 filler listings all get `id: NaN`. Dev-only
and pre-existing, and the file carries pre-existing Biome format and `organizeImports` errors, so
touching it here would have pulled a whole-file reformat into a sim fix. Filed as #2475.

## Related issues

Closes #2463. Follow-up filed: #2475.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run gate` (PR tier), all 11 steps green.
  - `npx vitest run tests/market_listing_ids.test.ts tests/market.test.ts tests/retired_heroic_items.test.ts`
  - Guard suites: `tests/architecture.test.ts`, `tests/localization_fixes.test.ts`,
    `tests/world_api_parity.test.ts`, `tests/guide.test.ts`, `tests/parity`,
    `tests/server/market_backfill.test.ts`, `tests/market_db.test.ts`,
    `tests/save_character_and_market.test.ts`, `tests/professions_market.test.ts`,
    `tests/migrate_old_cragmaw_pelt.test.ts`.
- Manual steps:
  - Proved the three new integration cases red first on the unfixed `market.ts`: the buyer arm
    failed on `new Set(ids).size` (23 vs 24) and the owner arm failed with the literal
    `That is not your listing.`
  - Mutation-checked the fix against the new suites: reverting `id: plan.ids[i]` to a fresh
    `nextListingId++`, dropping the post-load counter assignment, dropping the seed-time floor, and
    weakening either `>=` boundary in the leaf each turn the suite red.
  - Mutation-checked the review follow-ups too: shrinking `MARKET_PLAYER_LISTING_ID_BASE` to 24
    (the current stock-table size) reddens both the literal pin and the headroom assertion, and it
    was fully green before them; restoring the old plan-over-every-row shape reddens the new
    burned-id case.

### Tests added

- `tests/market_listing_ids.test.ts` (new): the leaf's contract, including verbatim replay of a
  healthy save, a house-band clash, ids duplicated inside one save, malformed ids, the two `>=`
  boundaries, and the settle-before-assign property (a reissued id must never land on a persisted id
  further down the same save). Plus a literal pin on `MARKET_PLAYER_LISTING_ID_BASE`: every other
  assertion in both suites is written against the constant, so without it, shrinking the base to the
  stock table's own size would keep them all green while re-arming the collision.
- `tests/market.test.ts`: five cases on the real `loadMarket` path, including the one the issue asks
  for (load a save holding an id inside the house band, then assert one row per id, `findIndex`
  resolving to the player row, the buy paying the seller and consuming the row, and the owner
  reclaiming without an error), and one that a row the load cannot replay burns no id. The house-band
  case also asserts real headroom (the stock table can grow tenfold), not just "below the base".
- `tests/retired_heroic_items.test.ts`: its market fixture moves to a player-band id so its strict
  round-trip pin stays strict; the retired-item charter is unchanged. The two `tests/market.test.ts`
  fixtures that still sat inside the house band move the same way, so they keep testing verbatim
  replay rather than quietly exercising the repair.

## Screenshots / recordings

N/A. Nothing a player or operator sees changes.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~[ ] Tested on desktop and mobile.~ N/A, no UI change.
- ~[ ] Accessible.~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The one added `console.warn` is dev-channel
      English, per the `src/sim/` rule.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.

