### PR TITLE
fix(ui): let a resized window's body follow the new height

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -556,6 +556,45 @@
     }
   }
 
+  /* ---------- resized-window fill ---------- */
+  /* A window the user has dragged to a size (.window-sized, stamped by
+     src/ui/window_resize.ts once a corner drag engages) owns an explicit
+     width/height. Its scrolling body has to follow that box, and a body authored
+     with a viewport-relative cap does not: .lb-body's 56vh keeps its old height
+     inside the taller window, so the board stays truncated behind its own
+     scrollbar while a dead band opens under it (issue: leaderboard resize).
+
+     So the ONE child marked .window-fill absorbs whatever height the drag left
+     over and scrolls inside it, while the chrome around it (the sticky header, a
+     tab strip) keeps its intrinsic size. Windows with no .window-fill child are
+     left entirely alone (the shell's own overflow-y still handles their
+     overflow), and an unsized window is unaffected, so this costs nothing until a
+     drag actually engages.
+
+     The host window must be a flex COLUMN, which per the window-frame family
+     (#mailbox-window, #social-window) means it opens with an inline display:flex:
+     `.window` is opened by an inline style.display and no stylesheet display can
+     override that. A window adopting .window-fill opts into that pattern too.
+
+     It lives here in @layer components rather than beside the other window-shell
+     rules in layout.css because it has to OUTRANK the per-window body caps, and
+     those are authored in this layer: layout sits below components, so a
+     max-height reset there would silently lose. */
+  .window.window-sized > .window-fill {
+    flex: 1 1 auto;
+    /* A floor, NOT the usual min-height:0. The item still shrinks far below its
+       content height (that is what makes it scroll inside the window instead of
+       pushing the window into its own scroll), but at WINDOW_MIN_HEIGHT the chrome
+       above it (a title that wraps at 220px wide, plus a tab strip) can already
+       exceed the content box; min-height:0 would then collapse the body to nothing
+       and hide it outright. Roughly two rows, so the window's own overflow-y takes
+       the remainder and the content stays reachable. */
+    min-height: 48px;
+    /* The window height is the budget now; a leftover vh cap would re-open the
+       dead band this rule exists to close. */
+    max-height: none;
+  }
+
   /* ---------- windows ---------- */
   #quest-dialog {
     width: 440px;
@@ -1532,6 +1571,15 @@
   #daily-rewards-window {
     width: 480px;
   }
+  /* The leaderboard is a flex COLUMN window (the #mailbox-window / #social-window
+     family): the painter opens it with an inline display:flex, and .lb-body carries
+     .window-fill, so once the user drags the window to a size the board takes the
+     leftover height instead of staying pinned to its 56vh cap. flex-direction is
+     unconditional because the inline display:flex is; with the shell default (row)
+     the header, tabs and board would lay out side by side. */
+  #leaderboard-window {
+    flex-direction: column;
+  }
   #daily-rewards-window {
     top: 24px;
     width: min(1040px, calc(100vw - 40px));
@@ -2335,11 +2383,12 @@
     text-align: right;
     color: #ffe27a;
   }
-  /* Players / Guilds tab bar above the board. */
+  /* Players / Guilds tab bar above the board. No margin-top: the window is a flex
+     column, so this margin would ADD to .panel-title's 8px margin-bottom instead of
+     collapsing with it the way it did under block flow, doubling the gap. */
   .lb-tabs {
     display: flex;
     gap: 6px;
-    margin-top: 8px;
   }
   .lb-tab {
     flex: 1;

--- a/src/ui/leaderboard_window.ts
+++ b/src/ui/leaderboard_window.ts
@@ -110,8 +110,14 @@ export class LeaderboardWindow {
     else this.playerPage = value;
   }
 
+  // Open is an inline display:flex, not display:block: the window is a flex COLUMN
+  // (see #leaderboard-window in src/styles/components.css) so that .lb-body, marked
+  // .window-fill, can absorb the leftover height once the user drags the window to a
+  // size. A stylesheet display can never override the inline one, so the open value
+  // itself has to carry it, the way #mailbox-window does. Closed is still 'none', and
+  // every render guard below compares against this same value.
   get isOpen(): boolean {
-    return this.deps.root().style.display === 'block';
+    return this.deps.root().style.display === 'flex';
   }
 
   /** Open if closed, close if open (the minimap / menu leaderboard button). */
@@ -130,14 +136,14 @@ export class LeaderboardWindow {
     this.deedsPage = 0;
     this.devPage = 0;
     this.dailyPage = 0;
-    this.deps.root().style.display = 'block';
+    this.deps.root().style.display = 'flex';
     this.deps.onVisibilityChange?.();
     void this.render('open');
   }
 
   close(): void {
     const el = this.deps.root();
-    if (el.style.display !== 'block') {
+    if (el.style.display !== 'flex') {
       this.openerFocus = null;
       return;
     }
@@ -197,7 +203,7 @@ export class LeaderboardWindow {
     }
     // A newer render may own the body now, or the panel may have been closed,
     // while the fetch was in flight.
-    if (seq !== this.renderSeq || el.style.display !== 'block') return;
+    if (seq !== this.renderSeq || el.style.display !== 'flex') return;
     const body = el.querySelector('.lb-body');
     if (!body) return;
 
@@ -254,7 +260,7 @@ export class LeaderboardWindow {
     } catch {
       result = null;
     }
-    if (seq !== this.renderSeq || el.style.display !== 'block') return;
+    if (seq !== this.renderSeq || el.style.display !== 'flex') return;
     const body = el.querySelector('.lb-body');
     if (!body) return;
 
@@ -301,7 +307,7 @@ export class LeaderboardWindow {
     } catch {
       result = null;
     }
-    if (seq !== this.renderSeq || el.style.display !== 'block') return;
+    if (seq !== this.renderSeq || el.style.display !== 'flex') return;
     const body = el.querySelector('.lb-body');
     if (!body) return;
 
@@ -351,7 +357,7 @@ export class LeaderboardWindow {
     } catch {
       result = null;
     }
-    if (seq !== this.renderSeq || el.style.display !== 'block') return;
+    if (seq !== this.renderSeq || el.style.display !== 'flex') return;
     const body = el.querySelector('.lb-body');
     if (!body) return;
 
@@ -392,7 +398,7 @@ export class LeaderboardWindow {
     } catch {
       result = null;
     }
-    if (seq !== this.renderSeq || el.style.display !== 'block') return;
+    if (seq !== this.renderSeq || el.style.display !== 'flex') return;
     const body = el.querySelector('.lb-body');
     if (!body) return;
     if (result === null) {
@@ -438,8 +444,13 @@ export class LeaderboardWindow {
 
   // The in-flight state carries aria-busy + role=status (the lazy-load a11y
   // contract) so a screen reader announces the pending board.
+  //
+  // window-fill marks this as the child that absorbs the leftover height once the
+  // user drags the window to a size (the resized-window fill contract in
+  // src/styles/components.css). It is emitted here, not stamped once at open,
+  // because every render() rebuilds the window's innerHTML from scratch.
   private loadingBodyHtml(): string {
-    return `<div class="lb-body" id="lb-body-panel" role="tabpanel"><div class="lb-loading" role="status" aria-busy="true">${esc(t('game.leaderboard.loading'))}</div></div>`;
+    return `<div class="lb-body window-fill" id="lb-body-panel" role="tabpanel"><div class="lb-loading" role="status" aria-busy="true">${esc(t('game.leaderboard.loading'))}</div></div>`;
   }
 
   // The Players / Guilds / Daily tab bar. A WAI-ARIA role=tablist with roving

--- a/src/ui/window_resize.ts
+++ b/src/ui/window_resize.ts
@@ -166,6 +166,12 @@ export function installWindowResize(deps: WindowResizeDeps): () => void {
     session.startY = ev.clientY;
     session.engaged = true;
     el.classList.add('window-resizing');
+    // From here the window owns an explicit width/height, so its content must
+    // follow that box instead of the viewport-relative cap it was authored with.
+    // Unlike window-resizing this is permanent for the session: it drives the
+    // .window-fill contract in src/styles/components.css, and it lives on the
+    // window element, so it survives the innerHTML rebuilds the painters do.
+    el.classList.add('window-sized');
     // Opts the window into the viewport-resize re-clamp pass hud.ts runs.
     el.dataset.windowMoved = '1';
     try {

--- a/tests/browser/window_resize_fill.browser.test.ts
+++ b/tests/browser/window_resize_fill.browser.test.ts
@@ -1,0 +1,226 @@
+// Layout regression coverage for the resized-window fill contract, driven through
+// the REAL painter, the REAL resize controller, and the REAL stylesheet in a real
+// browser. A CSS text pin cannot catch this class of bug: every rule involved was
+// individually valid before the fix, and the defect only appeared in the computed
+// box geometry.
+//
+// The bug: dragging the leaderboard window taller grew the window but not the
+// board. .lb-body kept its authored 56vh cap, so the extra height became a dead
+// band under the list while the list itself stayed truncated behind its own
+// scrollbar. The fix marks .lb-body as the .window-fill child of a flex-column
+// window and drops that cap once window_resize.ts stamps .window-sized.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { page as browserPage } from 'vitest/browser';
+import { LeaderboardWindow } from '../../src/ui/leaderboard_window';
+import { installWindowResize } from '../../src/ui/window_resize';
+import { RESIZE_ENGAGE_SLOP } from '../../src/ui/window_resize_core';
+import type { LeaderboardEntry, LeaderboardPage } from '../../src/world_api';
+import { cleanup, host, stubDeps } from './_harness';
+
+// Tall enough that the board overflows its 56vh cap (so the cap is actually
+// binding, which is the precondition for the bug) and the shell's 85vh clamp
+// still leaves real room to grow into.
+const VIEWPORT = { width: 1200, height: 1000 };
+// The window's own frame under the body: --window-pad plus the 1px border. The
+// dead band the bug produced was an order of magnitude larger than this.
+const WINDOW_FRAME_BELOW_BODY = 16;
+
+let teardownResize: (() => void) | null = null;
+
+beforeEach(async () => {
+  await browserPage.viewport(VIEWPORT.width, VIEWPORT.height);
+  document.documentElement.style.setProperty('--app-vw', `${VIEWPORT.width}px`);
+  document.documentElement.style.setProperty('--app-vh', `${VIEWPORT.height}px`);
+  document.documentElement.style.setProperty('--ui-scale', '1');
+});
+
+afterEach(() => {
+  teardownResize?.();
+  teardownResize = null;
+  cleanup();
+  document.documentElement.style.removeProperty('--app-vw');
+  document.documentElement.style.removeProperty('--app-vh');
+  document.documentElement.style.removeProperty('--ui-scale');
+});
+
+function entry(rank: number): LeaderboardEntry {
+  return {
+    rank,
+    name: `Chronicler${rank}`,
+    cls: 'warrior',
+    level: 60,
+    virtualLevel: 12,
+    lifetimeXp: 5_000_000 - rank,
+    prestigeRank: 0,
+    title: null,
+  };
+}
+
+// A full 50-row page: more rows than the 56vh cap can show, so the board is
+// scrolling inside its own cap before the drag.
+function fullPage(): LeaderboardPage {
+  const leaders = Array.from({ length: 50 }, (_, i) => entry(i + 1));
+  return {
+    leaders,
+    page: 0,
+    pageCount: 2,
+    total: 100,
+    pageSize: 50,
+  } as unknown as LeaderboardPage;
+}
+
+async function openLeaderboard(): Promise<HTMLElement> {
+  const root = host('leaderboard-window');
+  root.style.display = 'none'; // toggle() opens it
+  const win = new LeaderboardWindow(
+    stubDeps({
+      root: () => root,
+      world: () =>
+        ({
+          realm: 'Claudemoon',
+          player: { name: 'Chronicler1', level: 60 },
+          lifetimeXp: 5_000_000,
+          leaderboard: () => Promise.resolve(fullPage()),
+        }) as never,
+      captureFocus: () => null,
+      showDevBadges: () => true,
+    }),
+  );
+  win.toggle();
+  await win.render();
+  return root;
+}
+
+// Installs the real controller and drags the SE grip by (dx, dy) author px, the
+// same pointerdown / past-the-slop / move / up sequence a mouse produces.
+function dragCorner(el: HTMLElement, dx: number, dy: number): void {
+  teardownResize = installWindowResize({
+    getScale: () => 1,
+    // What Hud.setWindowPixelPosition does: convert the centering transform into
+    // pixel left/top before the first size write.
+    pinWindow: (target, rect) => {
+      target.style.left = `${rect.left}px`;
+      target.style.top = `${rect.top}px`;
+      target.style.transform = 'none';
+    },
+    isCoarsePointer: () => false,
+  });
+  const rect = el.getBoundingClientRect();
+  const x = rect.left + el.clientLeft + el.clientWidth - 4;
+  const y = rect.top + el.clientTop + el.clientHeight - 4;
+  const fire = (type: string, cx: number, cy: number, buttons: number): void => {
+    const ev = new PointerEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      clientX: cx,
+      clientY: cy,
+      pointerId: 1,
+      pointerType: 'mouse',
+      button: 0,
+      buttons,
+    });
+    (type === 'pointerdown' ? el : document).dispatchEvent(ev);
+  };
+  fire('pointerdown', x, y, 1);
+  fire('pointermove', x + RESIZE_ENGAGE_SLOP, y + RESIZE_ENGAGE_SLOP, 1);
+  fire('pointermove', x + dx, y + dy, 1);
+  fire('pointerup', x + dx, y + dy, 0);
+}
+
+function boxes(root: HTMLElement): {
+  win: DOMRect;
+  body: DOMRect;
+  bodyEl: HTMLElement;
+} {
+  const bodyEl = root.querySelector<HTMLElement>('.lb-body');
+  if (!bodyEl) throw new Error('the leaderboard body never rendered');
+  return { win: root.getBoundingClientRect(), body: bodyEl.getBoundingClientRect(), bodyEl };
+}
+
+describe('leaderboard window resize', () => {
+  it('grows the board with the window instead of leaving a dead band under it', async () => {
+    const root = await openLeaderboard();
+    const before = boxes(root);
+    // Precondition: the authored 56vh cap is binding, so the board is already
+    // scrolling. Without this the test could pass on a board that simply fits.
+    expect(before.body.height).toBeCloseTo(VIEWPORT.height * 0.56, 0);
+    expect(before.bodyEl.scrollHeight).toBeGreaterThan(before.bodyEl.clientHeight);
+
+    dragCorner(root, 0, 400);
+
+    const after = boxes(root);
+    expect(root.classList.contains('window-sized')).toBe(true);
+    const grewBy = after.win.height - before.win.height;
+    // The drag has room to grow into (the shell's 85vh clamp is well above the
+    // 56vh-capped starting height), or the assertions below prove nothing.
+    expect(grewBy).toBeGreaterThan(50);
+    // THE BUG: the board used to keep its 56vh height, so every pixel the window
+    // gained became empty space under the list.
+    expect(after.body.height - before.body.height).toBeCloseTo(grewBy, 0);
+    expect(after.win.bottom - after.body.bottom).toBeLessThanOrEqual(WINDOW_FRAME_BELOW_BODY);
+    // And the board scrolls INSIDE the window, rather than pushing the window
+    // into its own scroll.
+    expect(after.bodyEl.scrollHeight).toBeGreaterThan(after.bodyEl.clientHeight);
+    expect(root.scrollHeight).toBeLessThanOrEqual(root.clientHeight);
+  });
+
+  it('shows more rows after the drag, not just a taller box', async () => {
+    const root = await openLeaderboard();
+    const rowHeight =
+      root.querySelector<HTMLElement>('.lb-row')?.getBoundingClientRect().height ?? 0;
+    expect(rowHeight).toBeGreaterThan(0);
+    const visibleBefore = Math.floor(boxes(root).bodyEl.clientHeight / rowHeight);
+
+    dragCorner(root, 0, 400);
+
+    const visibleAfter = Math.floor(boxes(root).bodyEl.clientHeight / rowHeight);
+    expect(visibleAfter).toBeGreaterThan(visibleBefore);
+  });
+
+  it('shrinks the board back down with the window', async () => {
+    const root = await openLeaderboard();
+    const before = boxes(root);
+
+    dragCorner(root, 0, -300);
+
+    const after = boxes(root);
+    expect(after.win.height).toBeLessThan(before.win.height);
+    expect(after.body.height).toBeLessThan(before.body.height);
+    expect(after.win.bottom - after.body.bottom).toBeLessThanOrEqual(WINDOW_FRAME_BELOW_BODY);
+    expect(root.scrollHeight).toBeLessThanOrEqual(root.clientHeight);
+  });
+
+  it('keeps the fill through a tab switch, which rebuilds the whole window', async () => {
+    const root = await openLeaderboard();
+    dragCorner(root, 0, 400);
+    const sized = boxes(root);
+
+    root.querySelector<HTMLButtonElement>('[data-leaderboard-tab="guilds"]')?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const rebuilt = boxes(root);
+    // render() replaces the window's innerHTML, so the marker has to be re-emitted
+    // by the painter rather than stamped once at open.
+    expect(rebuilt.bodyEl.classList.contains('window-fill')).toBe(true);
+    expect(rebuilt.win.height).toBeCloseTo(sized.win.height, 0);
+    expect(rebuilt.win.bottom - rebuilt.body.bottom).toBeLessThanOrEqual(WINDOW_FRAME_BELOW_BODY);
+  });
+
+  it('leaves an untouched window on its authored layout', async () => {
+    const root = await openLeaderboard();
+    const title = root.querySelector<HTMLElement>('.panel-title')?.getBoundingClientRect();
+    const tabs = root.querySelector<HTMLElement>('.lb-tabs')?.getBoundingClientRect();
+    const { body, bodyEl } = boxes(root);
+    if (!title || !tabs) throw new Error('the window chrome never rendered');
+    expect(root.classList.contains('window-sized')).toBe(false);
+    // The flex column must not re-open the gaps that block flow collapsed: 8px
+    // under the header (.panel-title's margin-bottom, NOT it plus .lb-tabs' old
+    // margin-top) and 8px under the tab strip (.lb-body's margin-top).
+    expect(tabs.top - title.bottom).toBeCloseTo(8, 0);
+    expect(body.top - tabs.bottom).toBeCloseTo(8, 0);
+    // And the authored cap still governs an unsized window.
+    expect(bodyEl.clientHeight).toBeLessThanOrEqual(Math.round(VIEWPORT.height * 0.56));
+  });
+});

--- a/tests/leaderboard_window.test.ts
+++ b/tests/leaderboard_window.test.ts
@@ -85,7 +85,7 @@ describe('leaderboard_window: async + page wiring contracts (the painter half)',
     // close() hides the window without clearing innerHTML, and a newer render
     // (tab switch, page change) owns the shared body; a late-resolving fetch
     // must bail on either rather than repaint stale rows.
-    expect(code).toContain("if (seq !== this.renderSeq || el.style.display !== 'block') return;");
+    expect(code).toContain("if (seq !== this.renderSeq || el.style.display !== 'flex') return;");
   });
 
   it('stamps a render epoch and bails every stale board response against it', () => {
@@ -148,6 +148,22 @@ describe('leaderboard_window: guild board tab (Players / Guilds)', () => {
     expect(code).toContain('aria-label="${esc(t(\'hudChrome.leaderboard.tabsLabel\'))}"');
   });
 
+  it('opens as a flex column and re-emits window-fill on the board body every render', () => {
+    // The board must follow the window box once the user drags the window to a
+    // size, instead of staying pinned to .lb-body's authored 56vh cap (which left
+    // a dead band under a truncated board). That needs two halves, both here:
+    //
+    // 1. the window is the flex COLUMN container. A stylesheet display can never
+    //    beat the inline one the painter writes, so the open value itself carries
+    //    it (the #mailbox-window family); 'block' would silently kill the fill.
+    expect(code).toContain("this.deps.root().style.display = 'flex';");
+    expect(code).toContain("return this.deps.root().style.display === 'flex';");
+    // 2. .lb-body is the marked fill child. render() rebuilds the window's whole
+    //    innerHTML on every open, tab switch and page change, so the class has to
+    //    come from the emitted HTML, not a one-time stamp at open.
+    expect(code).toContain('<div class="lb-body window-fill" id="lb-body-panel" role="tabpanel">');
+  });
+
   it('drives keyboard tab nav through the shared roving core and refocuses the active tab', () => {
     // Arrow/Home/End routed through the tested rovingTarget core (not bespoke math).
     expect(code).toContain("rovingTarget(ke.key, i, tabs.length, 'horizontal')");
@@ -200,7 +216,7 @@ describe('leaderboard_window: developers board tab', () => {
 
   it('guards against painting the dev board into a window closed or superseded mid-fetch', () => {
     expect(code).toMatch(
-      /renderDevBoard[\s\S]{0,400}if \(seq !== this\.renderSeq \|\| el\.style\.display !== 'block'\) return;/,
+      /renderDevBoard[\s\S]{0,400}if \(seq !== this\.renderSeq \|\| el\.style\.display !== 'flex'\) return;/,
     );
   });
 
@@ -285,7 +301,7 @@ describe('leaderboard_window: Renown (deeds) board tab', () => {
 
   it('guards against painting the Renown board into a window closed or superseded mid-fetch', () => {
     expect(code).toMatch(
-      /renderDeedsBoard\([\s\S]{0,500}if \(seq !== this\.renderSeq \|\| el\.style\.display !== 'block'\) return;/,
+      /renderDeedsBoard\([\s\S]{0,500}if \(seq !== this\.renderSeq \|\| el\.style\.display !== 'flex'\) return;/,
     );
   });
 });

--- a/tests/leaderboard_window_stale.test.ts
+++ b/tests/leaderboard_window_stale.test.ts
@@ -15,9 +15,10 @@ function lbEl(): HTMLElement {
   const el = document.createElement('div');
   el.id = 'leaderboard-window';
   el.className = 'window panel';
-  // The async board render bails unless the window reads as open (display:block);
+  // The async board render bails unless the window reads as open (display:flex, the
+  // flex-column open value the window-fill contract needs);
   // set it so render() completes its error-state paint deterministically.
-  el.style.display = 'block';
+  el.style.display = 'flex';
   return el;
 }
 

--- a/tests/window_fill_css.test.ts
+++ b/tests/window_fill_css.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// Load-bearing CSS pins for the resized-window fill contract: the half of the
+// leaderboard resize fix that lives in the stylesheet. Dragging a window taller
+// used to leave a dead band under the board while the board itself stayed
+// truncated, because .lb-body kept its authored 56vh cap inside the now-taller
+// window. The contract is: window_resize.ts stamps .window-sized, the window is a
+// flex column, and the one child marked .window-fill absorbs the leftover height.
+//
+// Pinned against a WHITESPACE-NORMALIZED view so a biome re-wrap never breaks a
+// pin, only a real value change does (the perf_nudge_css.test.ts convention).
+const norm = (css: string): string =>
+  css
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\s+/g, ' ')
+    .replace(/\( /g, '(')
+    .replace(/ \)/g, ')');
+
+const rawComponents = readFileSync(
+  new URL('../src/styles/components.css', import.meta.url),
+  'utf8',
+);
+const components = norm(rawComponents);
+
+describe('resized-window fill CSS', () => {
+  it('owns a ten-dash section banner so the corpus guard sees it', () => {
+    // css_corpus.test.ts treats ONLY ten-dash fences as section boundaries; a
+    // four-dash banner would silently drop the section from the corpus.
+    expect(rawComponents).toContain('/* ---------- resized-window fill ---------- */');
+  });
+
+  it('lets the marked child absorb the leftover height of a sized window', () => {
+    expect(components).toContain(
+      '.window.window-sized > .window-fill { flex: 1 1 auto; min-height: 48px; max-height: none; }',
+    );
+  });
+
+  it('drops the authored viewport cap ONLY once the window carries an explicit size', () => {
+    // max-height: none is the whole point (without it the body stops at 56vh
+    // inside a taller window and the dead band comes back), but it must not apply
+    // to an unsized window, whose height is still content-driven: a bare
+    // `.window-fill { max-height: none }` would let the board run to the shell's
+    // 85vh clamp the moment the window opens.
+    expect(components).not.toMatch(/(?<!\.window-sized > )\.window-fill \{[^}]*max-height: none/);
+  });
+
+  it('keeps the board capped at 56vh until then', () => {
+    expect(components).toContain(
+      '.lb-body { margin-top: 8px; max-height: 56vh; overflow-y: auto; }',
+    );
+  });
+
+  it('makes the leaderboard window a flex column so the fill has a column to fill', () => {
+    // The painter opens it with an inline display:flex (pinned in
+    // leaderboard_window.test.ts); with the shell default (row) the header, tabs
+    // and board would lay out side by side instead.
+    expect(components).toContain('#leaderboard-window { flex-direction: column; }');
+  });
+
+  it('drops the tab strip margin that block-flow used to collapse', () => {
+    // Under block flow .panel-title's 8px margin-bottom collapsed with .lb-tabs'
+    // 8px margin-top into one 8px gap. Flex does not collapse margins, so keeping
+    // both would double the gap under the header.
+    expect(components).toContain('.lb-tabs { display: flex; gap: 6px; }');
+    expect(components).not.toMatch(/\.lb-tabs \{[^}]*margin-top/);
+  });
+});

--- a/tests/window_resize.test.ts
+++ b/tests/window_resize.test.ts
@@ -227,6 +227,11 @@ describe('installWindowResize tap safety', () => {
       expect(el.style).toEqual({});
       expect(el.dataset).toEqual({});
       expect(el.classList.contains('window-resizing')).toBe(false);
+      // No explicit size was written, so the window must NOT claim the sized
+      // contract either: .window-sized drops the body's authored viewport cap
+      // (see the resized-window fill block in src/styles/components.css), and a
+      // bare tap doing that would reflow a window nobody actually resized.
+      expect(el.classList.contains('window-sized')).toBe(false);
     } finally {
       restore();
     }
@@ -247,6 +252,23 @@ describe('installWindowResize tap safety', () => {
       fire('pointerup', {});
       expect(el.classList.contains('window-resizing')).toBe(false);
       expect(el.style.width).toBe('430px');
+    } finally {
+      restore();
+    }
+  });
+
+  it('stamps window-sized at engage and keeps it after the drag ends', () => {
+    const { el, fire, restore } = setup();
+    try {
+      fire('pointerdown', { clientX: CORNER.x, clientY: CORNER.y });
+      fire('pointermove', { clientX: CORNER.x + RESIZE_ENGAGE_SLOP, clientY: CORNER.y });
+      expect(el.classList.contains('window-sized')).toBe(true);
+      fire('pointerup', {});
+      // Unlike window-resizing (a live-drag cursor/selection flag), window-sized is
+      // permanent: the inline width/height outlive the drag, so the body has to keep
+      // following the window box for the rest of the session.
+      expect(el.classList.contains('window-sized')).toBe(true);
+      expect(el.classList.contains('window-resizing')).toBe(false);
     } finally {
       restore();
     }


### PR DESCRIPTION
## Summary

Resizing the leaderboard window grew the window but not the board. `.lb-body` is
authored with `max-height: 56vh`, a cap tied to the viewport rather than to the
window, so every pixel the drag added became an empty band under the list while
the list itself stayed truncated behind its own scrollbar. Measured on a
1000x1000 viewport: dragging the window from 676px to 826px tall left the board
at 560px and opened a 164px dead band.

The window shell is a general seam (`src/ui/window_resize.ts` gives every movable
`.window.panel` the same corner grip), so the fix lands there rather than as a
one-off:

- `window_resize.ts` stamps `.window-sized` on a window once a corner drag
  engages. Unlike the existing `.window-resizing` flag this is permanent for the
  session, because the inline width/height it announces are.
- A new `resized-window fill` block in `src/styles/components.css` gives the one
  child marked `.window-fill` the leftover height of a sized window and drops its
  authored viewport cap. Windows with no `.window-fill` child are untouched, and
  an unsized window is unaffected, so the contract costs nothing until a drag
  actually engages.
- The leaderboard opts in: `.lb-body` carries `window-fill`, and the painter opens
  the window with an inline `display: flex` so the shell is the flex column the
  fill needs. That is the `#mailbox-window` / `#social-window` pattern already
  documented in `components.css`: a stylesheet `display` can never override the
  inline one a painter writes, so the open value itself has to carry it. `.lb-tabs`
  drops its `margin-top`, which block flow used to collapse into `.panel-title`'s
  `margin-bottom` and flex would have doubled.

The board now takes the height the drag gives it, keeps scrolling inside the
window instead of pushing the window into its own scroll, and follows the window
back down when it is shrunk.

Two edges worth naming:

- At `WINDOW_MIN_HEIGHT` (140px) the chrome above the board (a title that wraps at
  220px wide plus the tab strip) already exceeds the content box. The fill floors
  at 48px rather than the usual `min-height: 0` so the board can never collapse to
  nothing; the window's own overflow takes the remainder.
- `.dr-body` (Daily Rewards, `62vh`) and `.cl-body` (Claudium) are the same shape
  and look like the same bug, but both windows open with `display: block` and
  would each need their own flex-column switch, screenshots and tests. Left out of
  scope here rather than bundled in blind; the mechanism they would use is now in
  place.

## Related issues

N/A

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npm run gate` (green)
  - `npx vitest run --config vitest.browser.config.ts tests/browser/window_resize_fill.browser.test.ts`
- New coverage:
  - `tests/browser/window_resize_fill.browser.test.ts`: the decisive one. Drives
    the real painter, the real `installWindowResize` controller and the real
    stylesheet in Chromium, and asserts the computed geometry: the board grows by
    exactly what the window grew, the band under it stays within the window frame,
    the board keeps scrolling inside the window, more rows become visible, the
    board shrinks back, the fill survives the innerHTML rebuild a tab switch does,
    and an untouched window keeps its authored 8px/8px gaps and 56vh cap. Teeth
    verified: reverting any single half of the fix (the `window-fill` marker, the
    flex open value, or `max-height: none`) fails 3 of the 5 tests, and restoring
    `.lb-tabs`' `margin-top` fails the authored-layout one (16px vs 8px).
  - `tests/window_resize.test.ts`: `.window-sized` is stamped at engage and
    survives pointerup, and a sub-slop tap never stamps it.
  - `tests/window_fill_css.test.ts`: pins the fill rule, that `max-height: none` is
    scoped to `.window-sized` only, and that the leaderboard's flex column and the
    dropped tab margin stay.
  - `tests/leaderboard_window.test.ts`: pins the flex open value and the
    re-emitted `window-fill` marker.
- Manual steps: offline world at 1000x1000, opened the leaderboard, padded the
  board past its cap, dragged the SE grip taller / shorter / wider, switched tabs
  while sized, and dragged to the 220x140 minimum. Repeated at 844x390 with
  `body.mobile-touch` to confirm the sheet layout is unchanged.

## Screenshots / recordings

<!-- Upload the three PNGs from tmp/ here; they are deliberately not committed. -->

**Desktop before** 

<img width="1000" height="1000" alt="lb-resize-before" src="https://github.com/user-attachments/assets/a081ba30-9acb-4d29-ba3d-7cc325d46add" />

1000x1000, window dragged from 676px to 826px tall): the board stops mid-row at 560px and a 164px dead band fills the rest of the window.



**Desktop after** 

<img width="1000" height="1000" alt="lb-resize-after" src="https://github.com/user-attachments/assets/b9aae395-5e88-4166-b002-1c1270e4e7bb" />

the board is 710px and runs to the window's padding. No dead band, no truncated row.


**Mobile after**: 

<img width="844" height="390" alt="lb-mobile-after" src="https://github.com/user-attachments/assets/dfb556bf-f753-4867-ad28-40152f387927" />


the sheet is unchanged. The window is a flex column here
too, and the authored 8px/8px gaps and the 56vh body scroll (218px at this
viewport) behave exactly as before.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [x] **Tested on desktop and mobile.** Verified at 1000x1000 desktop and at
      844x390 landscape with `body.mobile-touch`. No touch target or font size
      changed.
- [x] **Accessible.** No change to the tablist, roving tabindex, `aria-controls`,
      the labelled tabpanel or the focus-return path; the `#lb-body-panel` id and
      `role="tabpanel"` are unchanged and still pinned.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.
