### PR TITLE
fix(scripts): give the market shot's filler listings their own id band

### DIFF
--- a/scripts/lib/market_filler_listings.d.mts
+++ b/scripts/lib/market_filler_listings.d.mts
@@ -1,0 +1,38 @@
+// Hand-written types for market_filler_listings.mjs (scripts/CLAUDE.md: a module a
+// type-checked Vitest imports carries a .d.mts next to the .mjs). The export set here
+// is pinned against the runtime module by tests/market_filler_listings.test.ts.
+
+// One filler row, shaped exactly like `MarketListing` in src/sim/market.ts.
+export interface FillerListing {
+  id: number;
+  sellerKey: string;
+  sellerName: string;
+  itemId: string;
+  count: number;
+  price: number;
+  expiresAt: number;
+  house: false;
+}
+
+export interface FillerListingInput {
+  // How many filler rows to build.
+  count: number;
+  // Ids the book already holds, so the band is floored past them.
+  takenIds?: Iterable<unknown>;
+  // The sim clock the rows expire against (`sim.time`). Required, so a caller
+  // cannot seed a block that the next market sweep silently culls.
+  now: number;
+}
+
+export interface ListingIdSummary {
+  total: number;
+  unique: number;
+  // Ids that are not positive safe integers (the #2475 failure: every row `NaN`).
+  unusable: number;
+  duplicated: number;
+}
+
+export declare const MARKET_FILLER_LISTING_ID_BASE: number;
+export declare function fillerListingIdBase(takenIds?: Iterable<unknown>): number;
+export declare function buildFillerListings(input: FillerListingInput): FillerListing[];
+export declare function summarizeListingIds(ids: Iterable<unknown>): ListingIdSummary;

--- a/scripts/lib/market_filler_listings.mjs
+++ b/scripts/lib/market_filler_listings.mjs
@@ -1,0 +1,110 @@
+// Filler World Market listings for the dev evidence scripts: a block of cheap
+// other-seller rows pushed straight into the sim's listing book so one
+// screenshot can show a market busy enough to page, without 200 real sellers.
+//
+// Why the ids need an allocator of their own (#2475): the listing-id counter is
+// `private nextListingId` on `Market` and `Sim` exposes nothing equivalent, so a
+// script cannot read it. `scripts/market_listing_count_shot.mjs` used to try
+// (`let id = sim.nextListingId`), read `undefined`, and stamp every one of its
+// 200 rows with `NaN`, one unusable id shared by the whole block, which is the
+// duplicate-id state #2463 was filed about. So the fillers take a band of their
+// own, far above the player band the sim issues from (see
+// `MARKET_PLAYER_LISTING_ID_BASE` in `src/sim/market_listing_ids.ts`), floored
+// past whatever the book already holds.
+//
+// Pure Node: no puppeteer, no DOM, no `src/` import (scripts never import the TS
+// sources raw). A Vitest imports it directly (`tests/market_filler_listings.test.ts`)
+// and the shot script builds its rows here, then hands them to `page.evaluate`.
+
+// The first id handed to a filler row. The sim starts the PLAYER band at 1000 and
+// walks it one listing at a time, so a band three orders of magnitude further out
+// cannot be reached by any number of listings a screenshot session can place.
+export const MARKET_FILLER_LISTING_ID_BASE = 1_000_000;
+
+// The filler block is one cheap stack of a common trash item repeated. Browse sorts
+// by item NAME and only then by price, so what buries the seller's own goods is the
+// filler item's name sorting ahead of theirs ("Bone Fragments" before "Cracked Wolf
+// Fang"), not the asking price. That buried state is what the evidence shot captures.
+const FILLER_ITEM_ID = 'bone_fragments';
+const FILLER_PRICE_BASE = 40; // copper, a plausible trash-item ask
+const FILLER_PRICE_SPREAD = 30; // rows cycle through base..base+spread-1 so prices vary
+const FILLER_SECONDS_LEFT = 1000; // sim-seconds, long enough to outlive any capture
+
+// A usable listing id: a positive safe integer. Mirrors `isListingId` in
+// `src/sim/market_listing_ids.ts` (a `.mjs` script helper cannot import the TS
+// source); `tests/market_filler_listings.test.ts` pins the two against each other
+// so the copy cannot drift.
+//
+// Filtering before the comparison below is load-bearing, and not only for `NaN`
+// (which a bare `>=` happens to reject on its own). A fractional id would give a
+// fractional band, and a NUMERIC STRING is the nasty one: `'1000001' >= 1000000`
+// coerces to true, then `'1000001' + 1` CONCATENATES to `'10000011'` and every row
+// gets a string id no `l.id === listingId` lookup in the sim can ever match, which
+// is the same unreachable-row failure as #2475 wearing a different mask.
+function isUsableId(v) {
+  return typeof v === 'number' && Number.isSafeInteger(v) && v >= 1;
+}
+
+// The first id the filler block may take: at or past the reserved base, and past
+// every id the book already holds, so the block collides with nothing already
+// there and leaves the sim's own counter (which sits far below) free to keep
+// issuing real listing ids for the rest of the session.
+export function fillerListingIdBase(takenIds = []) {
+  let base = MARKET_FILLER_LISTING_ID_BASE;
+  for (const id of takenIds) if (isUsableId(id) && id >= base) base = id + 1;
+  return base;
+}
+
+// Build `count` filler rows shaped exactly like a `MarketListing`
+// (`src/sim/market.ts`), ready to push onto `sim.marketListings`. `takenIds` is
+// the book's current ids and `now` is `sim.time`, both read out of the page first
+// so the rows can be built here in Node where a Vitest can pin them. `now` is
+// required rather than defaulted: rows expire at `now + FILLER_SECONDS_LEFT`, so a
+// caller that forgot it would seed a block the next market sweep culls, and the
+// capture would show an empty market with nothing raised anywhere.
+export function buildFillerListings({ count, takenIds = [], now }) {
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new Error(`buildFillerListings: count must be a non-negative safe integer, got ${count}`);
+  }
+  if (!Number.isFinite(now)) {
+    throw new Error(`buildFillerListings: now must be a finite sim time, got ${now}`);
+  }
+  const base = fillerListingIdBase(takenIds);
+  // Saturation is unreachable from a real book, but a band running off the end of the
+  // safe-integer range would mint ids this module's own predicate rejects. Fail loudly
+  // instead. Parenthesized deliberately: `base + count - 1` evaluates the sum FIRST,
+  // and near the ceiling that sum rounds up before the subtraction brings it back
+  // under, so the guard would clear a band whose last row is still 2 ** 53.
+  const last = base + (count - 1);
+  if (count > 0 && !Number.isSafeInteger(last)) {
+    throw new Error(`buildFillerListings: id band ${base}..${last} is not representable`);
+  }
+  const rows = [];
+  for (let i = 0; i < count; i++) {
+    rows.push({
+      id: base + i,
+      sellerKey: `Trader${i}`,
+      sellerName: `Trader${i}`,
+      itemId: FILLER_ITEM_ID,
+      count: 1,
+      price: FILLER_PRICE_BASE + (i % FILLER_PRICE_SPREAD),
+      expiresAt: now + FILLER_SECONDS_LEFT,
+      house: false,
+    });
+  }
+  return rows;
+}
+
+// The health of a set of listing ids, so a script that seeds the book can print
+// the same verdict the Vitest asserts: every row reachable by its own id. This is
+// #2475's acceptance criterion made executable, which is why it lives beside the
+// allocator instead of being inlined in the one script that prints it.
+export function summarizeListingIds(ids) {
+  const all = [...ids];
+  return {
+    total: all.length,
+    unique: new Set(all).size,
+    unusable: all.filter((id) => !isUsableId(id)).length,
+    duplicated: all.length - new Set(all).size,
+  };
+}

--- a/scripts/market_listing_count_shot.mjs
+++ b/scripts/market_listing_count_shot.mjs
@@ -6,10 +6,12 @@
 // seller's listings are always wired (the "Reclaim" rows on page 1).
 //
 // Run with max graphics: GFX=ultra. Toggle which build you screenshot with
-// LABEL=before|after (purely cosmetic — affects only the output filenames).
-import puppeteer from 'puppeteer-core';
+// LABEL=before|after (purely cosmetic, it only affects the output filenames).
 import fs from 'node:fs';
+import puppeteer from 'puppeteer-core';
 import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+import { enterOfflineGame } from './enter_offline_game.mjs';
+import { buildFillerListings, summarizeListingIds } from './lib/market_filler_listings.mjs';
 
 const GFX = process.env.GFX ?? 'ultra';
 const LABEL = process.env.LABEL ?? 'after';
@@ -25,49 +27,61 @@ const browser = await puppeteer.launch({
   defaultViewport: { width: 1600, height: 1000 },
 });
 const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
 await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
-const tap = (sel) => page.evaluate((s) => document.querySelector(s)?.click(), sel);
-await page.waitForSelector('#btn-offline', { timeout: 30000 });
-await tap('#btn-offline');
-await wait(300);
-await page.evaluate(() => {
-  document.querySelector('#char-name').value = 'Strider';
-  document.querySelector('#offline-select .mini-class[data-class="warrior"]')?.click();
+// The shared entry flow (scripts/CLAUDE.md): it drives Play Offline, the name, the
+// class card, and Enter World, then dismisses the intro cinematic, the tutorial, and
+// the camera prompt. None of those may appear in a capture, and the intro sets #ui to
+// display:none outright, which zeroes the window clip taken below.
+await enterOfflineGame(page, { charClass: 'warrior', charName: 'Strider', settleMs: 2500 });
+
+// Stand the player on the Merchant and list all 12 of their slots.
+const seeded = await page.evaluate(() => {
+  const { sim } = window.__game;
+  const merch = [...sim.entities.values()].find((e) => e.templateId === 'the_merchant');
+  const pe = sim.player;
+  pe.pos = sim.groundPos(merch.pos.x, merch.pos.z);
+  pe.prevPos = { ...pe.pos };
+
+  sim.addItem('wolf_fang', 12, sim.playerId);
+  for (let i = 0; i < 12; i++) sim.marketList('wolf_fang', 1, 200 + i, sim.playerId);
+  // The filler ids are allocated out in Node, so hand back what the book already
+  // holds plus the clock their expiry is measured against.
+  return { takenIds: sim.marketListings.map((l) => l.id), now: sim.time };
 });
-await tap('#btn-start-offline');
-await page.waitForFunction(() => window.__game?.hud && window.__game?.sim, { timeout: 30000 });
-await wait(1500);
 
-// Stand the player on the Merchant, list all 12 of their slots, then flood the
-// market with 200 cheaper other-seller listings that sort first.
-const setup = await page.evaluate(() => {
-  const { sim, hud } = window.__game;
-  const me = [...sim.players.keys()][0];
-  let merch = null;
-  for (const e of sim.entities.values()) if (e.templateId === 'the_merchant') merch = e;
-  const pe = sim.entities.get(me);
-  pe.pos.x = merch.pos.x; pe.pos.z = merch.pos.z; pe.prevPos = { ...pe.pos };
-
-  sim.addItem('wolf_fang', 12, me);
-  for (let i = 0; i < 12; i++) sim.marketList('wolf_fang', 1, 200 + i, me);
-
-  let id = sim.nextListingId;
-  for (let i = 0; i < 200; i++) {
-    sim.marketListings.push({
-      id: id++, sellerKey: `Trader${i}`, sellerName: `Trader${i}`,
-      itemId: 'bone_fragments', count: 1, price: 40 + (i % 30), expiresAt: sim.time + 1000, house: false,
-    });
-  }
-  sim.nextListingId = id;
-  const info = sim.marketInfoFor(me);
+// Flood the market with 200 other-seller listings. Browse sorts by item name and
+// only then by price, so a filler item whose name sorts ahead of the seller's own
+// goods is what pushes those goods out of the wire window. The rows take their ids
+// from the filler band's own allocator: the sim's listing-id counter is private to
+// Market, so a script must never try to read one off Sim (#2475).
+const fillers = buildFillerListings({ count: 200, takenIds: seeded.takenIds, now: seeded.now });
+const setup = await page.evaluate((rows) => {
+  const { sim } = window.__game;
+  sim.marketListings.push(...rows);
+  const info = sim.marketInfoFor(sim.playerId);
   return {
     total: sim.marketListings.length,
     myListingCount: info.myListingCount,
     wired: info.listings.length,
     mineWired: info.listings.filter((l) => l.mine).length,
+    bookIds: sim.marketListings.map((l) => l.id),
   };
-});
-console.log(`[${LABEL}]`, JSON.stringify(setup));
+}, fillers);
+// Report the id health of the whole seeded book alongside the counts: every row has
+// to stay reachable by its own id or the market cannot resolve a buy or a reclaim
+// against it (#2475 left all 200 filler rows sharing one unusable NaN).
+const { bookIds, ...counts } = setup;
+const ids = summarizeListingIds(bookIds);
+console.log(`[${LABEL}]`, JSON.stringify({ ...counts, ids }));
+// The seeded book is a precondition of the capture, not part of what the shot
+// compares, so it holds for LABEL=before and LABEL=after alike and can be checked
+// outright. Still write the PNGs (they are the evidence of whatever went wrong), but
+// do not let an unattended rerun report success on a book #2475 would recognize.
+if (ids.unusable > 0 || ids.duplicated > 0 || counts.total <= 120) {
+  console.error(`[${LABEL}] seeded book is unfit for capture:`, JSON.stringify({ ...counts, ids }));
+  process.exitCode = 1;
+}
 
 // Open the market and capture the Browse tab (page 1).
 await page.evaluate(() => window.__game.hud.openMarket());
@@ -75,12 +89,30 @@ await wait(600);
 const clip = await page.evaluate(() => {
   const el = document.querySelector('#market-window');
   const r = el.getBoundingClientRect();
-  return { x: Math.round(r.x), y: Math.round(r.y), width: Math.round(r.width), height: Math.round(r.height) };
+  return {
+    x: Math.round(r.x),
+    y: Math.round(r.y),
+    width: Math.round(r.width),
+    height: Math.round(r.height),
+  };
 });
 await page.screenshot({ path: `${OUT}/${LABEL}_browse.png`, clip });
 
-// Switch to the Sell tab where the "X / 12 listing slots" note lives.
-await page.evaluate(() => { const h = window.__game.hud; h.marketTab = 'sell'; h.renderMarket(); });
+// Switch to the Sell tab where the "X / 12 listing slots" note lives. The tab state
+// is private to the market window, so click the real tab button (the idiom of
+// scripts/localization_e2e.mjs) instead of poking at the HUD. Wait for the button and
+// then for its aria-pressed to flip, rather than sleeping: the clip below is the one
+// computed on Browse, so a click that quietly missed would write a second Browse
+// capture into the file named `_sell`, which is the failure mode the vanished
+// hud.marketTab hook this replaces at least used to announce by throwing.
+const SELL_TAB = '#market-window [data-tab="sell"]';
+await page.waitForSelector(SELL_TAB, { timeout: 10000 });
+await page.evaluate((sel) => document.querySelector(sel).click(), SELL_TAB);
+await page.waitForFunction(
+  (sel) => document.querySelector(sel)?.getAttribute('aria-pressed') === 'true',
+  { timeout: 10000 },
+  SELL_TAB,
+);
 await wait(400);
 await page.screenshot({ path: `${OUT}/${LABEL}_sell.png`, clip });
 

--- a/tests/market_filler_listings.test.ts
+++ b/tests/market_filler_listings.test.ts
@@ -1,0 +1,367 @@
+// The filler-listing allocator the World Market evidence scripts seed their busy
+// market from (scripts/lib/market_filler_listings.mjs), the pure core behind
+// #2475. Tested directly, plus one integration case over a real Sim that pins the
+// claim the band exists to make: nothing the sim issues later in the same session
+// can reuse a filler id.
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import type { FillerListingInput } from '../scripts/lib/market_filler_listings.mjs';
+import * as fillerModule from '../scripts/lib/market_filler_listings.mjs';
+import {
+  buildFillerListings,
+  fillerListingIdBase,
+  MARKET_FILLER_LISTING_ID_BASE,
+  summarizeListingIds,
+} from '../scripts/lib/market_filler_listings.mjs';
+import { ITEMS } from '../src/sim/data';
+import { isListingId, MARKET_PLAYER_LISTING_ID_BASE } from '../src/sim/market_listing_ids';
+import { Sim } from '../src/sim/sim';
+import type { Entity } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const SHOT_SCRIPT = 'scripts/market_listing_count_shot.mjs';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function merchant(sim: Sim): Entity {
+  for (const e of sim.entities.values()) if (e.templateId === 'the_merchant') return e;
+  throw new Error('the Merchant was not spawned');
+}
+
+// stand a player right on the Merchant so the proximity gate passes
+function standAtMerchant(sim: Sim, pid: number) {
+  const m = merchant(sim);
+  const e = sim.entities.get(pid)!;
+  e.pos.x = m.pos.x;
+  e.pos.z = m.pos.z;
+  e.pos.y = groundHeight(e.pos.x, e.pos.z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function bookIds(sim: Sim): number[] {
+  return sim.marketListings.map((l) => l.id);
+}
+
+// Everything the script mentions in prose is irrelevant to these pins; only the
+// code is. Full-line comments are stripped (a trailing `//` strip would eat the
+// `http://` inside the script's own URL template).
+function codeOf(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/^[ \t]*\/\/.*$/gm, ' ');
+}
+
+describe('MARKET_FILLER_LISTING_ID_BASE', () => {
+  it('is pinned to its literal value, far above the band the sim issues from', () => {
+    // Deliberately a literal: every other assertion here is written against the
+    // constant, so lowering it to MARKET_PLAYER_LISTING_ID_BASE + 1 would leave
+    // them all green while destroying the entire point of the band.
+    expect(MARKET_FILLER_LISTING_ID_BASE).toBe(1_000_000);
+
+    // And the headroom is a magnitude, not an inequality. The sim walks the player
+    // band one listing at a time from MARKET_PLAYER_LISTING_ID_BASE, so "above the
+    // player base" would also be satisfied by a base of 1001, which a scripted
+    // list-and-cancel loop could reach inside a single session.
+    expect(MARKET_PLAYER_LISTING_ID_BASE * 100).toBeLessThanOrEqual(MARKET_FILLER_LISTING_ID_BASE);
+  });
+});
+
+describe('fillerListingIdBase', () => {
+  it('starts at the reserved base whatever the sim has already issued', () => {
+    expect(fillerListingIdBase([])).toBe(MARKET_FILLER_LISTING_ID_BASE);
+    // the real shape of a seeded book: the 23-row house band plus a dozen player
+    // listings, all of it far below the filler band
+    expect(fillerListingIdBase([1, 2, 3, 23, 1000, 1011])).toBe(MARKET_FILLER_LISTING_ID_BASE);
+    expect(fillerListingIdBase([MARKET_FILLER_LISTING_ID_BASE - 1])).toBe(
+      MARKET_FILLER_LISTING_ID_BASE,
+    );
+  });
+
+  it('steps past an id sitting ON the base, never onto it', () => {
+    expect(fillerListingIdBase([MARKET_FILLER_LISTING_ID_BASE])).toBe(
+      MARKET_FILLER_LISTING_ID_BASE + 1,
+    );
+  });
+
+  it('clears a book that already holds ids inside the filler band', () => {
+    // the re-entrant case: the same page ran a filler pass already
+    const past = MARKET_FILLER_LISTING_ID_BASE + 199;
+    expect(fillerListingIdBase([1, past, 1000])).toBe(past + 1);
+  });
+
+  it('ignores malformed ids instead of poisoning the base', () => {
+    const malformed = [NaN, Infinity, -Infinity, -1, 0, 1.5, '1000001', null, undefined, {}];
+    expect(fillerListingIdBase(malformed as number[])).toBe(MARKET_FILLER_LISTING_ID_BASE);
+
+    // The three shapes above that a bare `id >= base` comparison would let through,
+    // asserted one at a time so trimming the table cannot leave the filter unpinned.
+    // A numeric string is the worst of them: `'1000001' >= 1_000_000` coerces to true
+    // and `'1000001' + 1` then CONCATENATES to '10000011', so every row would carry a
+    // string id that no `l.id === listingId` lookup in the sim can ever match, which
+    // is #2475's unreachable-row failure by another route.
+    for (const v of [Infinity, '1000001', MARKET_FILLER_LISTING_ID_BASE + 0.5]) {
+      expect(fillerListingIdBase([v] as unknown as number[])).toBe(MARKET_FILLER_LISTING_ID_BASE);
+    }
+  });
+
+  it('still honours a real high id mixed in with malformed ones', () => {
+    const past = MARKET_FILLER_LISTING_ID_BASE + 7;
+    expect(fillerListingIdBase([NaN, past, Infinity] as number[])).toBe(past + 1);
+  });
+});
+
+describe('buildFillerListings', () => {
+  it('gives all 200 rows distinct, usable, contiguous ids', () => {
+    const rows = buildFillerListings({ count: 200, takenIds: [1, 23, 1000, 1011], now: 0 });
+    expect(rows.length).toBe(200);
+    const ids = rows.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.every((id) => Number.isSafeInteger(id) && id >= 1)).toBe(true);
+    expect(Math.min(...ids)).toBe(MARKET_FILLER_LISTING_ID_BASE);
+    expect(Math.max(...ids)).toBe(MARKET_FILLER_LISTING_ID_BASE + 199);
+  });
+
+  it('shapes every row like a live player listing', () => {
+    const rows = buildFillerListings({ count: 4, now: 12_345 });
+    expect(rows.every((r) => r.house === false)).toBe(true);
+    expect(rows.every((r) => r.count === 1)).toBe(true);
+    expect(rows.every((r) => r.price >= 1 && Number.isSafeInteger(r.price))).toBe(true);
+    // distinct sellers, so the block models a busy market rather than one seller
+    // sitting on the 12-listing cap
+    expect(new Set(rows.map((r) => r.sellerKey)).size).toBe(rows.length);
+    expect(rows.every((r) => r.sellerName === r.sellerKey)).toBe(true);
+    // Expiry is anchored to the sim clock the caller read out of the page, pinned to
+    // the exact lifetime: a units slip (seconds read as ticks, say) would leave every
+    // row expiring inside the seconds the capture takes, and the market sweep would
+    // empty the book before the screenshot with nothing raised.
+    expect(rows[0].expiresAt).toBe(12_345 + 1000);
+    expect(rows.every((r) => r.expiresAt === rows[0].expiresAt)).toBe(true);
+  });
+
+  it('fills with a real item whose name sorts ahead of the goods being buried', () => {
+    const [row] = buildFillerListings({ count: 1, now: 0 });
+    // An id absent from ITEMS is filtered out of the browse list entirely
+    // (marketItemMatches), so the shot would capture an empty market.
+    const filler = ITEMS[row.itemId];
+    expect(filler).toBeDefined();
+    // Browse sorts by item NAME first and only then by price, so the filler name
+    // is what pushes the seller's own wolf fangs past the wire limit, which is
+    // the state the evidence shot exists to capture.
+    expect(filler.name.localeCompare(ITEMS.wolf_fang.name)).toBeLessThan(0);
+  });
+
+  it('varies the asking price across the block', () => {
+    const prices = buildFillerListings({ count: 200, now: 0 }).map((r) => r.price);
+    expect(new Set(prices).size).toBeGreaterThan(1);
+  });
+
+  it('builds nothing for a count of zero', () => {
+    expect(buildFillerListings({ count: 0, now: 0 })).toEqual([]);
+  });
+
+  it('refuses a count that is not a non-negative safe integer', () => {
+    for (const count of [-1, 1.5, NaN, Infinity, Number.MAX_SAFE_INTEGER + 1, undefined, '200']) {
+      expect(() => buildFillerListings({ count, now: 0 } as unknown as FillerListingInput)).toThrow(
+        /non-negative safe integer/,
+      );
+    }
+  });
+
+  it('refuses a non-finite sim clock, and an omitted one', () => {
+    for (const now of [NaN, Infinity, -Infinity]) {
+      expect(() => buildFillerListings({ count: 1, now })).toThrow(/finite sim time/);
+    }
+    // Omitted rather than defaulted to 0: at a default of 0 the rows expire at the
+    // fixed lifetime, so a caller in a session past that point would seed a block the
+    // next market sweep culls and capture an empty market with nothing raised.
+    expect(() => buildFillerListings({ count: 1 } as unknown as FillerListingInput)).toThrow(
+      /finite sim time/,
+    );
+  });
+
+  it('refuses a band that would run off the safe-integer range', () => {
+    // Unreachable from a real book, but a band past the ceiling would mint ids this
+    // module's own predicate rejects, which is the failure it exists to prevent.
+    expect(() =>
+      buildFillerListings({ count: 5, takenIds: [Number.MAX_SAFE_INTEGER], now: 0 }),
+    ).toThrow(/not representable/);
+
+    // The rounding arm: with the guard written `base + count - 1` the sum is formed
+    // FIRST and rounds up past the ceiling, then the subtraction brings it back to
+    // exactly MAX_SAFE_INTEGER, so the guard passed and the loop still emitted 2 ** 53.
+    const near = Number.MAX_SAFE_INTEGER - 4;
+    expect(() => buildFillerListings({ count: 5, takenIds: [near], now: 0 })).toThrow(
+      /not representable/,
+    );
+  });
+});
+
+describe('summarizeListingIds', () => {
+  it('reports a healthy book as healthy', () => {
+    expect(summarizeListingIds([1, 23, 1000, 1_000_000])).toEqual({
+      total: 4,
+      unique: 4,
+      unusable: 0,
+      duplicated: 0,
+    });
+  });
+
+  it('reports the #2475 book: 200 rows, one unusable id between them', () => {
+    const ids = Array.from({ length: 200 }, () => NaN);
+    expect(summarizeListingIds(ids)).toEqual({
+      total: 200,
+      unique: 1, // a Set collapses every NaN into one
+      unusable: 200,
+      duplicated: 199,
+    });
+  });
+
+  it('counts a plain duplicate without calling it unusable', () => {
+    expect(summarizeListingIds([1000, 1000, 1001])).toEqual({
+      total: 3,
+      unique: 2,
+      unusable: 0,
+      duplicated: 1,
+    });
+  });
+
+  it('agrees with the isListingId predicate in the sim on every id shape', () => {
+    // The script layer cannot import the TS source, so the predicate is copied.
+    // This pins the copy against the original so it cannot drift.
+    const table = [
+      1,
+      23,
+      1000,
+      MARKET_FILLER_LISTING_ID_BASE,
+      Number.MAX_SAFE_INTEGER,
+      0,
+      -1,
+      1.5,
+      NaN,
+      Infinity,
+      -Infinity,
+      Number.MAX_SAFE_INTEGER + 1,
+      '7',
+      null,
+      undefined,
+      {},
+    ];
+    for (const v of table) {
+      expect(summarizeListingIds([v]).unusable).toBe(isListingId(v) ? 0 : 1);
+    }
+  });
+});
+
+describe('the filler band against a real Sim', () => {
+  it('leaves every row in the book reachable by its own id', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Strider');
+    standAtMerchant(sim, seller);
+    sim.addItem('wolf_fang', 12, seller);
+    for (let i = 0; i < 12; i++) sim.marketList('wolf_fang', 1, 200 + i, seller);
+    expect(sim.marketInfoFor(seller)?.myListingCount).toBe(12);
+
+    const before = sim.marketListings.length;
+    sim.marketListings.push(
+      ...buildFillerListings({ count: 200, takenIds: bookIds(sim), now: sim.time }),
+    );
+    // The block really landed: without this the two health assertions below also hold
+    // over the 35-row pre-push book, so a filler pass contributing nothing would pass.
+    expect(sim.marketListings.length).toBe(before + 200);
+
+    const health = summarizeListingIds(bookIds(sim));
+    expect(health.total).toBe(sim.marketListings.length);
+    expect(health.unusable).toBe(0);
+    expect(health.duplicated).toBe(0);
+    // And none of the 200 is attributed to the viewer, or the Sell caption the whole
+    // capture exists to show would read 212 / 12 instead of 12 / 12.
+    expect(sim.marketInfoFor(seller)?.myListingCount).toBe(12);
+  });
+
+  it('cannot be reused by a listing the sim issues afterwards', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Strider');
+    standAtMerchant(sim, seller);
+    sim.addItem('wolf_fang', 12, seller);
+    for (let i = 0; i < 12; i++) sim.marketList('wolf_fang', 1, 200 + i, seller);
+
+    const fillers = buildFillerListings({ count: 200, takenIds: bookIds(sim), now: sim.time });
+    sim.marketListings.push(...fillers);
+    const fillerIds = new Set(fillers.map((r) => r.id));
+
+    // a second seller, because the first is sitting on the 12-listing cap
+    const other = sim.addPlayer('warrior', 'Bystander');
+    standAtMerchant(sim, other);
+    sim.addItem('wolf_fang', 1, other);
+    sim.marketList('wolf_fang', 1, 500, other);
+
+    const issued = sim.marketListings.find((l) => l.sellerName === 'Bystander');
+    expect(issued).toBeDefined();
+    // The counter was untouched by the push: pushing onto the book does not feed
+    // the allocator (only loadMarket does, and that is server-only), so the sim
+    // keeps issuing from the player band far below the filler band.
+    expect(issued?.id).toBeLessThan(MARKET_FILLER_LISTING_ID_BASE);
+    expect(fillerIds.has(issued?.id as number)).toBe(false);
+    expect(summarizeListingIds(bookIds(sim)).duplicated).toBe(0);
+  });
+
+  it('exposes no listing-id counter for a script to read off Sim', () => {
+    // #2475's ruling: the counter stays `private` on Market and the fix belongs in
+    // the script. The broken script read `sim.nextListingId`, got undefined, and
+    // stamped NaN on all 200 rows. If a public counter is ever added here, this
+    // goes red so the band above can be reconsidered rather than silently orphaned.
+    const sim = makeWorld();
+    // Typed as `number` so the increment below compiles; at runtime the property is
+    // absent, which is exactly the claim.
+    let counter = (sim as unknown as Record<string, number>).nextListingId;
+    expect(counter).toBeUndefined();
+    // Routed through the real property rather than asserted of NaN directly, so this
+    // goes red the moment Sim grows a readable counter instead of staying vacuous.
+    expect(Number.isNaN(counter++)).toBe(true);
+  });
+});
+
+describe('the evidence script and its declared types', () => {
+  it('allocates through the shared helper and never off the sim', () => {
+    const code = codeOf(readFileSync(join(ROOT, SHOT_SCRIPT), 'utf8'));
+    // positive first, so the negative below cannot be satisfied by deleting the
+    // filler block outright
+    expect(code).toContain("from './lib/market_filler_listings.mjs'");
+    expect(code).toContain('buildFillerListings(');
+    expect(code).toContain('summarizeListingIds(');
+    expect(code).not.toMatch(/nextListingId/);
+  });
+
+  it('keeps the shared entry flow and the real Sell tab button', () => {
+    // The same rot class as #2475, and the other two defects this change fixed: a dev
+    // script naming a member that no longer exists. Hand-rolling the entry flow leaves
+    // the intro cinematic up, and it sets #ui to display:none, which zeroes the window
+    // clip; `hud.marketTab` / `hud.renderMarket()` went away with the market window
+    // extraction and threw in-page, aborting before the Sell capture.
+    const code = codeOf(readFileSync(join(ROOT, SHOT_SCRIPT), 'utf8'));
+    expect(code).toContain('enterOfflineGame(page');
+    expect(code).toContain('[data-tab="sell"]');
+    expect(code).not.toMatch(/marketTab|renderMarket\(/);
+  });
+
+  it('declares every runtime export in the hand-written .d.mts', () => {
+    const dts = readFileSync(join(ROOT, 'scripts/lib/market_filler_listings.d.mts'), 'utf8');
+    const names = Object.keys(fillerModule).sort();
+    expect(names).toEqual([
+      'MARKET_FILLER_LISTING_ID_BASE',
+      'buildFillerListings',
+      'fillerListingIdBase',
+      'summarizeListingIds',
+    ]);
+    // Anchored at line start: unanchored, a commented-out `// export declare ...`
+    // satisfies the match. Compared as a SET so the sweep runs both ways, and a
+    // declaration left behind by a rename fails too.
+    const declared = [...dts.matchAll(/^export declare (?:function|const) (\w+)/gm)]
+      .map((m) => m[1])
+      .sort();
+    expect(declared).toEqual(names);
+  });
+});


### PR DESCRIPTION
## Summary

`scripts/market_listing_count_shot.mjs` seeded its 200 filler World Market listings from
`sim.nextListingId`. That member does not exist: the counter is `private nextListingId` on `Market`
(`src/sim/market.ts`) and `Sim` exposes no equivalent, so `let id = sim.nextListingId` read
`undefined`, `id++` yielded `NaN`, and all 200 rows landed with `id: NaN`. Since `NaN !== NaN`, not
one of them was reachable by the `findIndex((l) => l.id === listingId)` lookups every buy and
reclaim path uses, and the write-back left a stray `nextListingId` property on `Sim` that nothing
reads.

Per the issue's ruling the counter stays `private` on `Market` and the fix lands in the script
layer. The allocation moves into a new pure Node helper, `scripts/lib/market_filler_listings.mjs`,
which hands the block a reserved band from 1,000,000: three orders of magnitude above the player
band the sim walks one listing at a time, floored past whatever the book already holds, and with
malformed ids filtered out before that floor is taken. The filter is load-bearing in a way worth
naming: a numeric-string id passes a bare `>=` by coercion and then **concatenates** rather than
adds (`'1000001' + 1` is `'10000011'`), which would hand every row a string id no listing lookup
can resolve, the same unreachable-row failure wearing a different mask.

### Two further defects in the same file

The issue notes the captures the script produces "are still the ones it advertises". That premise
did not hold: on today's tree the script cannot produce any capture. Both causes sit in the one file
the issue scopes, and both had to go before the acceptance criteria were checkable at all.

- **It hand-rolled the pre-game entry flow** instead of the shared `enterOfflineGame` helper that
  `scripts/CLAUDE.md` mandates for offline shot scripts, so it dismissed none of the three overlays
  that must never appear in a capture. The first-spawn intro sets `#ui` to `display:none`, which
  zeroes the `#market-window` clip. Run as-is it never even boots the world: it dies at
  `waitForFunction(() => window.__game...)` because the class card is clicked before it renders and
  `#char-name` never gets its `input` event.
- **It switched tabs through `hud.marketTab` / `hud.renderMarket()`**, neither of which exists any
  more; the tab state has been `private tab` on `MarketWindow` since the market window was extracted
  to `src/ui/market_window.ts`. That threw inside `page.evaluate` and aborted the run before the
  Sell capture. It now waits for the real `[data-tab="sell"]` button and then for its `aria-pressed`
  to flip (the `scripts/localization_e2e.mjs` idiom) rather than sleeping past a click that may have
  missed, because the clip is the one computed on Browse and a silent miss would write a second
  Browse capture into the file named `_sell`.

The script also prints the id health of the book it seeded and fails its exit code if that book is
unfit to photograph, so an unattended rerun cannot report success on exactly the state the evidence
exists to disprove. That check sits on the seeding precondition, not on the before/after axis, so it
holds for `LABEL=before` and `LABEL=after` alike.

## Related issues

Closes #2475. (A PR based on a release branch never fires the keyword, which only works against the
default branch, so this one needs closing by hand.)

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [x] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - `npm run gate`: **PASS, all 11 steps green**, run on this exact tip after rebasing onto
    `origin/release/v0.31.0` (`ae9e0bdad`).
  - `npx vitest run tests/market_filler_listings.test.ts`: 24 passing.
  - `npx tsc --noEmit`: clean.
  - `npx @biomejs/biome ci scripts/market_listing_count_shot.mjs`: exit 0, acceptance criterion 3.
    The file carried pre-existing format and `organizeImports` errors, so the diff includes the
    whole-file reformat the issue anticipated.
- Manual steps:
  - `npm run dev`, then `node scripts/market_listing_count_shot.mjs`. It now runs to completion and
    writes both PNGs. Its readout is the issue's own repro check, inverted:

    ```
    [after] {"total":235,"myListingCount":12,"wired":62,"mineWired":12,
             "ids":{"total":235,"unique":235,"unusable":0,"duplicated":0}}
    ```

    235 rows = 23 house + 12 player + 200 filler, every one with a distinct usable id, where before
    the 200 filler rows shared one `NaN`. Browse page 1 shows the 12 `RECLAIM` rows above the
    `Trader<N>` fillers; Sell reads "You are using 12/12 listing slots", which is the note the whole
    script exists to capture and which had never been produced before.
  - Mutation-checked every pin: 24 separate mutations of the helper, the script, and the `.d.mts`
    each turn the suite red. Among them: all rows sharing one id, dropping the safe-integer and
    numeric-string filter, base 1,000,000 to 1,001, `>=` to `>`, dropping the `takenIds` floor,
    reverting the saturation guard to the unparenthesized `base + count - 1` (which rounds up past
    the ceiling and then back under it, clearing a band whose last row is still `2 ** 53`),
    defaulting the sim clock back to 0, an expiry units slip, a filler seller key colliding with the
    viewer's name, a nonexistent filler item, a filler item sorting after the seller's goods,
    reverting the script to read `sim.nextListingId`, reverting it to the hand-rolled entry flow,
    reverting it to `hud.marketTab`, and both `.d.mts` drift directions.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added decisive tests for the changed
      behavior and recorded the manual checks above.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A: a dev-only Node script, not part of any bundle and not a
  player-facing or operator-facing surface.
- ~~Accessible.~~ N/A: adds and edits no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The only new strings are two `throw` messages in
      the helper, which are dev-channel (a Node script throw with no catch surfacing them), and the
      filler rows' `Trader<N>` seller names, which are listing data rendered through the existing
      market painter rather than UI copy.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any
      production path.
- [x] I didn't hand-edit any generated file.

## Notes for the reviewer

- **The band is a script-side reservation, not a sim guarantee**, and that is deliberate.
  `loadMarket` is the only path that ever settles the counter from the book, and its sole callers
  are `server/game.ts` and `server/main.ts`, so it never runs in the offline browser client this
  script drives. A test pins the consequence directly: after the 200-row push, a fresh `marketList`
  still issues from the player band, well below the filler band.
- **`summarizeListingIds` has one production consumer** (the script's readout). It lives in the
  helper rather than inline so the Vitest asserts the same verdict the script prints, which is
  #2475's acceptance criterion made executable in both hosts.
- The `noNonNullAssertion` warning on the test's `standAtMerchant` helper matches the identical
  helper in `tests/market.test.ts`; CI gates errors and format diffs, not warnings.
