### PR TITLE
fix(professions): stand the loot cue down on the unbind stack peel

### DIFF
--- a/src/sim/professions/commission.ts
+++ b/src/sim/professions/commission.ts
@@ -194,17 +194,19 @@ export function unbindItem(ctx: SimContext, itemId: string, pid?: number): Unbin
     slot.count -= 1;
     const freed = cloneItemInstancePayload(instance);
     delete freed.boundTo;
-    // callerLogs, and deliberately NOT silent (#2430). This peel is an
-    // internal stack split, not an acquisition: the player already held every
-    // copy, so the hub's "You receive:" line here was the same falsehood the
-    // apply-enchant re-mint printed, stacked on top of the unbindResult line
-    // the client already logs (hudChrome.unbind.unbound, documented there as
-    // the ONE success surface). The single-copy arm above clears boundTo in
-    // place and never reaches the hub, so before this only a STACKED unbind
-    // printed two lines. `silent` stays unset because unbind has no dedicated
-    // cue of its own to protect the ding from: this is the asymmetric case the
-    // two flags are separate for.
-    ctx.addItemInstance(itemId, freed, meta.entityId, 1, { callerLogs: true });
+    // silent + callerLogs (#2430, #2458). This peel is an internal stack
+    // split, not an acquisition: the player already held every copy, so the
+    // hub's "You receive:" line here was the same falsehood the apply-enchant
+    // re-mint printed, stacked on top of the unbindResult line the client
+    // already logs (hudChrome.unbind.unbound, documented there as the ONE
+    // success surface: no toast, no sound cue). `silent` stands the hub's
+    // generic ding down for the same reason the line goes: the single-copy arm
+    // above clears boundTo in place and never reaches the hub at all, so
+    // leaving the cue on made ONE action sound different purely by how many
+    // byte-equal copies happened to share a slot. Unbind owning the cue means
+    // owning it as SILENCE (the trainResult single-surface rule), not as a cue
+    // of its own.
+    ctx.addItemInstance(itemId, freed, meta.entityId, 1, { silent: true, callerLogs: true });
   }
   return result;
 }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -6794,8 +6794,11 @@ export class Sim {
   // the caller owns the player-visible line for this grant and renders a
   // richer one off its own result event, so the hub's "You receive:" line
   // stands down instead of printing a second line for the one grant (#2430).
-  // The two stay independent by design, but no shipped caller needs them
-  // apart: a grant whose result event owns the line owns the cue too, either
+  // The two stay independent by design, but no shipped caller sets exactly one
+  // (true repo-wide today; the enforced part is professions plus corpse
+  // harvest, which tests/professions_silent_loot.test.ts sweeps, and every
+  // other grant in the game passes no opts at all). A grant whose result event
+  // owns the line owns the cue too, either
   // as a dedicated cue of its own (gather/craft/disenchant/salvage/enchant/
   // fishing/corpse harvest) or as deliberate SILENCE, which is still owning it
   // (the Maker's Bond unbind peel in professions/commission.ts, whose contract

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -6794,14 +6794,16 @@ export class Sim {
   // the caller owns the player-visible line for this grant and renders a
   // richer one off its own result event, so the hub's "You receive:" line
   // stands down instead of printing a second line for the one grant (#2430).
-  // The two are independent by design, so set exactly the halves the caller
-  // owns: a profession grant whose result event carries BOTH its own cue and
-  // its own line sets both (gather/craft/disenchant/salvage/enchant/fishing),
-  // while a caller that owns only the line sets only callerLogs (the Maker's
-  // Bond unbind peel in professions/commission.ts, which has no cue of its
-  // own). A grant with no result event behind it sets NEITHER, or it goes
-  // invisible: the once-ever Codfather quest catch (professions/fishing.ts)
-  // returns before its emit, so the hub line and ding are its only feedback.
+  // The two stay independent by design, but no shipped caller needs them
+  // apart: a grant whose result event owns the line owns the cue too, either
+  // as a dedicated cue of its own (gather/craft/disenchant/salvage/enchant/
+  // fishing/corpse harvest) or as deliberate SILENCE, which is still owning it
+  // (the Maker's Bond unbind peel in professions/commission.ts, whose contract
+  // above hudChrome.unbind.unbound is no toast and no cue at all: #2458, and
+  // tests/professions_silent_loot.test.ts sweeps for it). A grant with no
+  // result event behind it sets NEITHER, or it goes invisible: the once-ever
+  // Codfather quest catch (professions/fishing.ts) returns before its emit, so
+  // the hub line and ding are its only feedback.
   // Professions 2.0's later phases
   // add new grant sites here (Phase 4 rare-event jackpot yields, Phase 13's
   // disenchant UI wiring): pass the same opts from those too, or the new

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -6798,15 +6798,17 @@ export class Sim {
   // (true repo-wide today; the enforced part is professions plus corpse
   // harvest, which tests/professions_silent_loot.test.ts sweeps, and every
   // other grant in the game passes no opts at all). A grant whose result event
-  // owns the line owns the cue too, either
-  // as a dedicated cue of its own (gather/craft/disenchant/salvage/enchant/
-  // fishing/corpse harvest) or as deliberate SILENCE, which is still owning it
-  // (the Maker's Bond unbind peel in professions/commission.ts, whose contract
-  // above hudChrome.unbind.unbound is no toast and no cue at all: #2458, and
-  // tests/professions_silent_loot.test.ts sweeps for it). A grant with no
-  // result event behind it sets NEITHER, or it goes invisible: the once-ever
-  // Codfather quest catch (professions/fishing.ts) returns before its emit, so
-  // the hub line and ding are its only feedback.
+  // owns the line owns the cue too, in one of three ways: a dedicated cue of
+  // its own (gather/craft/disenchant/salvage/enchant/fishing), the SAME
+  // generic ding replayed by the result arm exactly once for the whole
+  // command (corpse harvest, which has never had a recording of its own, so
+  // it keeps the sound it always made and only stops stacking it: #2457), or
+  // deliberate SILENCE, which is still owning it (the Maker's Bond unbind
+  // peel in professions/commission.ts, whose contract above
+  // hudChrome.unbind.unbound is no toast and no cue at all: #2458). A grant
+  // with no result event behind it sets NEITHER, or it goes invisible: the
+  // once-ever Codfather quest catch (professions/fishing.ts) returns before
+  // its emit, so the hub line and ding are its only feedback.
   // Professions 2.0's later phases
   // add new grant sites here (Phase 4 rare-event jackpot yields, Phase 13's
   // disenchant UI wiring): pass the same opts from those too, or the new

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -3299,9 +3299,11 @@ export type SimEvent = { pid?: number } & (
   | { type: 'learnAbility'; abilityId: string; rank: number }
   // The hub grant event. Two independent stand-down flags, both set only from
   // Sim.addItem/addItemInstance's opts param (the one place either gets set):
-  // - silent: true suppresses the client's default loot AUDIO cue; a caller with
-  //   its own dedicated cue for the same grant (gathering/crafting/enchanting)
-  //   sets it so the generic ding doesn't stack on top of it.
+  // - silent: true suppresses the client's default loot AUDIO cue; a caller
+  //   that owns the cue for this grant sets it, whether it owns one of its own
+  //   (gathering/crafting/enchanting) so the generic ding doesn't stack on top
+  //   of it, or owns it as SILENCE because its result event is cue-free by
+  //   contract (the Maker's Bond unbind, #2458).
   // - callerLogs: true suppresses the client's default "You receive: X" TEXT
   //   line, because the caller owns the player-visible line for this grant and
   //   renders a richer one (rolled quality color, quantity, clickable item

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -3300,10 +3300,12 @@ export type SimEvent = { pid?: number } & (
   // The hub grant event. Two independent stand-down flags, both set only from
   // Sim.addItem/addItemInstance's opts param (the one place either gets set):
   // - silent: true suppresses the client's default loot AUDIO cue; a caller
-  //   that owns the cue for this grant sets it, whether it owns one of its own
-  //   (gathering/crafting/enchanting) so the generic ding doesn't stack on top
-  //   of it, or owns it as SILENCE because its result event is cue-free by
-  //   contract (the Maker's Bond unbind, #2458).
+  //   that owns the cue for this grant sets it, whether it owns a dedicated
+  //   one (gathering/crafting/enchanting) so the generic ding doesn't stack on
+  //   top of it, replays that same generic ding itself exactly once for a
+  //   command that grants several items (corpse harvest, #2457), or owns it as
+  //   SILENCE because its result event is cue-free by contract (the Maker's
+  //   Bond unbind, #2458).
   // - callerLogs: true suppresses the client's default "You receive: X" TEXT
   //   line, because the caller owns the player-visible line for this grant and
   //   renders a richer one (rolled quality color, quantity, clickable item

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -9159,10 +9159,12 @@ export class Hud {
             this.lootRolls.closeForItem(ev.text);
           // silent: the audio half of the same idea, and independent of it (a
           // caller can own the cue without owning the line). A professions
-          // grant sets this when it owns the cue for the same grant: either it
-          // has a dedicated one and the generic ding would stack on top, or its
-          // result event is cue-free by contract and the ding would be the only
-          // sound at all (the Maker's Bond unbind, #2458).
+          // grant sets this when it owns the cue for the same grant: it has a
+          // dedicated one and the generic ding would stack on top, or it
+          // replays that same ding itself exactly once for a whole multi-item
+          // command (the harvestResult arm below), or its result event is
+          // cue-free by contract and the ding would be the only sound at all
+          // (the Maker's Bond unbind, #2458).
           if (!ev.silent) {
             if (
               ev.text.includes('loot') ||

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -9159,8 +9159,10 @@ export class Hud {
             this.lootRolls.closeForItem(ev.text);
           // silent: the audio half of the same idea, and independent of it (a
           // caller can own the cue without owning the line). A professions
-          // grant with its own dedicated cue sets this so the generic ding
-          // doesn't stack on top of it.
+          // grant sets this when it owns the cue for the same grant: either it
+          // has a dedicated one and the generic ding would stack on top, or its
+          // result event is cue-free by contract and the ding would be the only
+          // sound at all (the Maker's Bond unbind, #2458).
           if (!ev.silent) {
             if (
               ev.text.includes('loot') ||

--- a/tests/professions_commissions.test.ts
+++ b/tests/professions_commissions.test.ts
@@ -645,12 +645,17 @@ describe('unbind service deny order and mutation', () => {
     const loot = lootEvents(sim.drainEvents());
     expect(loot).toHaveLength(1);
     expect(loot[0].callerLogs).toBe(true);
-    // NOT silent: unbind has no dedicated cue of its own, so this is the one
-    // production grant that owns the line without owning the cue. Written as
-    // an own-key check, not toBeUndefined(): the conditional-spread contract
-    // (Sim.addItem) is that an unset flag is ABSENT, and a written-undefined
-    // key would move the parity digest of every grant in the game.
-    expect(Object.hasOwn(loot[0], 'silent')).toBe(false);
+    // ...and silent (#2458). Unbind has no dedicated cue of its own, so the
+    // contract above hudChrome.unbind.unbound ("the ONE success surface: no
+    // toast, no sound cue") is NO cue at all, and the count-1 arm below never
+    // reaches the hub. Leaving the ding on here made the same action on the
+    // same item sound different purely by how many byte-equal copies shared a
+    // slot. Both the presence and the value are pinned: the conditional-spread
+    // contract (Sim.addItemInstance) is that a set flag is an OWN key valued
+    // true and an unset one is ABSENT, and a written-undefined key would move
+    // the parity digest of every grant in the game.
+    expect(Object.hasOwn(loot[0], 'silent')).toBe(true);
+    expect(loot[0].silent).toBe(true);
     const slots = slotsOf(sim, pid, QA_ITEM);
     const bound = slots.filter((s) => s.instance?.boundTo !== undefined);
     const free = slots.filter((s) => s.instance?.boundTo === undefined);
@@ -661,12 +666,14 @@ describe('unbind service deny order and mutation', () => {
     expect(free[0].instance?.bindOnTrade).toBe(true);
   });
 
-  it('a single-copy unbind reaches the hub at all, so it has no line to stand down', () => {
+  it('a single-copy unbind never reaches the hub at all, so it has nothing to stand down', () => {
     // The negative control for the pin above, and the reason the double-line
     // only ever showed on a STACK: a lone bound copy is cleared in place, so
     // no grant happens and unbindResult is the only event either way. Without
     // this, flagging the peel could read as "unbind grants are flagged" when
-    // the two arms actually differ in whether a grant exists.
+    // the two arms actually differ in whether a grant exists. It is also the
+    // sim half of #2458's "same action, same audio": zero hub events here, and
+    // a silent one on the stacked arm, is what makes the two arms agree.
     const sim = makeSim();
     const pid = sim.playerId;
     sim.ctx.addItemInstance(SWORD, { bindOnTrade: true, boundTo: pid }, pid);

--- a/tests/professions_silent_loot.test.ts
+++ b/tests/professions_silent_loot.test.ts
@@ -518,6 +518,7 @@ describe('every professions grant site is accounted for (#2430)', () => {
     expect(sites.length).toBeGreaterThanOrEqual(19);
     expect(sites.some((s) => s.file === 'commission.ts')).toBe(true);
     expect(sites.some((s) => s.call.includes('callerLogs: true'))).toBe(true);
+    expect(sites.some((s) => s.call.includes('silent: true'))).toBe(true);
     // The balanced-paren walk must capture the whole call, opts object and all,
     // or every site would read as unflagged and the exclusion list would have
     // to grow to hide it.
@@ -533,13 +534,14 @@ describe('every professions grant site is accounted for (#2430)', () => {
     // red. Bind both ends.
     const harvestSites = sites.filter((s) => s.file === 'interaction.ts:harvestCorpse');
     expect(harvestSites).toHaveLength(6);
-    // BOTH flags, and only for these six. The shared sweep below can only ask
-    // for `callerLogs`, because a caller may legitimately own the line without
-    // the cue (commission.ts's Maker's Bond unbind peel does exactly that), so
-    // `silent` would go unchecked everywhere if it were not pinned here. Corpse
-    // harvest owns both halves: its result event logs its own lines AND plays
-    // its own single cue, so a site that kept `callerLogs` but lost `silent`
-    // would give one harvest two cues (#2457 acceptance criterion 3).
+    // BOTH flags. The shared cue sweep below now asks for `silent` everywhere
+    // too (#2458 retired the one site that owned the line without the cue), so
+    // this is no longer the only place `silent` is checked. It stays because it
+    // binds what the shared sweep cannot: the COUNT, six, and with it the
+    // harvestCorpse slice itself. One harvest command grants several DISTINCT
+    // items, so a site that kept `callerLogs` but lost `silent` would give one
+    // harvest several cues rather than one stray ding (#2457 acceptance
+    // criterion 3).
     for (const site of harvestSites) {
       const call = site.call.replace(/\s+/g, ' ');
       expect(call, call).toContain('silent: true');
@@ -561,6 +563,31 @@ describe('every professions grant site is accounted for (#2430)', () => {
     expect(
       unaccounted.map((s) => `${s.file}: ${s.call.replace(/\s+/g, ' ')}`),
       'a professions grant that neither sets callerLogs nor is a documented no-result-event grant',
+    ).toEqual([]);
+  });
+
+  it('every grant that stands its line down stands its CUE down too (#2458)', () => {
+    // The two flags stay independent by design, but no production professions
+    // grant needs them apart any more. A result event either fires its own
+    // dedicated cue (craft, gather, fish, enchant, disenchant, salvage, corpse
+    // harvest) or is deliberately cue-free (unbind, the trainResult
+    // single-surface rule documented above hudChrome.unbind.unbound). Either
+    // way the hub's generic ding has to stand down, or the action plays a
+    // second cue on top of its own, or one the contract says it does not have.
+    // The unbind peel was the last holdout, and the asymmetry it created (a
+    // ding out of a stack, silence out of a lone copy, for the same action on
+    // the same item) was invisible only because commission-eligible kinds all
+    // stack one per slot today. This is the forward guard for the day one does
+    // not: the same grant reached by a different route must sound the same.
+    // Whitespace-normalized like the harvestCorpse pin above, so a future
+    // formatter wrapping one opts object across lines cannot quietly turn a
+    // real site into a non-match and empty this list for the wrong reason.
+    const lineOnlySites = sites
+      .map((s) => ({ file: s.file, call: s.call.replace(/\s+/g, ' ') }))
+      .filter((s) => s.call.includes('callerLogs: true') && !s.call.includes('silent: true'));
+    expect(
+      lineOnlySites.map((s) => `${s.file}: ${s.call}`),
+      'a professions grant that elides the hub line but still plays the generic hub ding',
     ).toEqual([]);
   });
 

--- a/tests/professions_silent_loot.test.ts
+++ b/tests/professions_silent_loot.test.ts
@@ -516,7 +516,11 @@ describe('every professions grant site is accounted for (#2430)', () => {
     // A regex that stopped matching would make the sweep below green while
     // checking nothing, so bind both the count and the shape.
     expect(sites.length).toBeGreaterThanOrEqual(19);
-    expect(sites.some((s) => s.file === 'commission.ts')).toBe(true);
+    // Bound to the CALL, not just the file: `.some(file === ...)` alone stays
+    // green if commission.ts keeps some other grant while the unbind peel moves
+    // out of src/sim/professions and off the sweep entirely. The find-then-
+    // toContain form fails on a missing site too (undefined has no substring).
+    expect(sites.find((s) => s.file === 'commission.ts')?.call).toContain('silent: true');
     expect(sites.some((s) => s.call.includes('callerLogs: true'))).toBe(true);
     expect(sites.some((s) => s.call.includes('silent: true'))).toBe(true);
     // The balanced-paren walk must capture the whole call, opts object and all,

--- a/tests/professions_silent_loot.test.ts
+++ b/tests/professions_silent_loot.test.ts
@@ -500,16 +500,26 @@ describe('every professions grant site is accounted for (#2430)', () => {
     'export function harvestCorpse(',
   );
 
+  // Whitespace-normalized ONCE, here, so every pin below reads the same shape.
+  // The two sweeps used to disagree: one matched `callerLogs: true` on raw
+  // call text and the other normalized first, so a formatter that wrapped an
+  // opts object between a key and its value would have blinded one of them
+  // (in the safe direction, but for a reason nobody could see from the
+  // assertion). Comments are already gone by this point (codeOnly above).
+  const flatten = (call: string) => call.replace(/\s+/g, ' ');
   const sites = [
     ...readdirSync(dir)
       .filter((f) => f.endsWith('.ts'))
       .flatMap((file) =>
         grantCalls(codeOnly(readFileSync(path.join(dir, file), 'utf8'))).map((call) => ({
           file,
-          call,
+          call: flatten(call),
         })),
       ),
-    ...grantCalls(harvestBody).map((call) => ({ file: 'interaction.ts:harvestCorpse', call })),
+    ...grantCalls(harvestBody).map((call) => ({
+      file: 'interaction.ts:harvestCorpse',
+      call: flatten(call),
+    })),
   ];
 
   it('the scanner actually finds the grant sites (never passes vacuously)', () => {
@@ -552,9 +562,8 @@ describe('every professions grant site is accounted for (#2430)', () => {
     // harvest several cues rather than one stray ding (#2457 acceptance
     // criterion 3).
     for (const site of harvestSites) {
-      const call = site.call.replace(/\s+/g, ' ');
-      expect(call, call).toContain('silent: true');
-      expect(call, call).toContain('callerLogs: true');
+      expect(site.call, site.call).toContain('silent: true');
+      expect(site.call, site.call).toContain('callerLogs: true');
     }
     // pickUpObject's grant is the nearest one outside the function.
     expect(harvestBody).not.toContain('objectItemId');
@@ -570,30 +579,30 @@ describe('every professions grant site is accounted for (#2430)', () => {
         !NO_RESULT_EVENT_GRANTS.some((marker) => s.call.includes(marker)),
     );
     expect(
-      unaccounted.map((s) => `${s.file}: ${s.call.replace(/\s+/g, ' ')}`),
+      unaccounted.map((s) => `${s.file}: ${s.call}`),
       'a professions grant that neither sets callerLogs nor is a documented no-result-event grant',
     ).toEqual([]);
   });
 
   it('every grant that stands its line down stands its CUE down too (#2458)', () => {
     // The two flags stay independent by design, but no production professions
-    // grant needs them apart any more. A result event either fires its own
-    // dedicated cue (craft, gather, fish, enchant, disenchant, salvage, corpse
-    // harvest) or is deliberately cue-free (unbind, the trainResult
-    // single-surface rule documented above hudChrome.unbind.unbound). Either
-    // way the hub's generic ding has to stand down, or the action plays a
-    // second cue on top of its own, or one the contract says it does not have.
+    // grant needs them apart any more. A result event owns the cue in one of
+    // three ways: it fires a dedicated one (craft, gather, fish, enchant,
+    // disenchant, salvage), it replays the SAME generic ding itself exactly
+    // once for a whole multi-item command (corpse harvest, which has never had
+    // a recording of its own, hud.ts case 'harvestResult'), or it is
+    // deliberately cue-free (unbind, the trainResult single-surface rule
+    // documented above hudChrome.unbind.unbound). All three own it, so all
+    // three need the hub's ding down, or the action plays a second cue on top
+    // of its own, or one the contract says it does not have.
     // The unbind peel was the last holdout, and the asymmetry it created (a
     // ding out of a stack, silence out of a lone copy, for the same action on
     // the same item) was invisible only because commission-eligible kinds all
     // stack one per slot today. This is the forward guard for the day one does
     // not: the same grant reached by a different route must sound the same.
-    // Whitespace-normalized like the harvestCorpse pin above, so a future
-    // formatter wrapping one opts object across lines cannot quietly turn a
-    // real site into a non-match and empty this list for the wrong reason.
-    const lineOnlySites = sites
-      .map((s) => ({ file: s.file, call: s.call.replace(/\s+/g, ' ') }))
-      .filter((s) => s.call.includes('callerLogs: true') && !s.call.includes('silent: true'));
+    const lineOnlySites = sites.filter(
+      (s) => s.call.includes('callerLogs: true') && !s.call.includes('silent: true'),
+    );
     expect(
       lineOnlySites.map((s) => `${s.file}: ${s.call}`),
       'a professions grant that elides the hub line but still plays the generic hub ding',

--- a/tests/professions_silent_loot.test.ts
+++ b/tests/professions_silent_loot.test.ts
@@ -516,11 +516,16 @@ describe('every professions grant site is accounted for (#2430)', () => {
     // A regex that stopped matching would make the sweep below green while
     // checking nothing, so bind both the count and the shape.
     expect(sites.length).toBeGreaterThanOrEqual(19);
-    // Bound to the CALL, not just the file: `.some(file === ...)` alone stays
-    // green if commission.ts keeps some other grant while the unbind peel moves
-    // out of src/sim/professions and off the sweep entirely. The find-then-
-    // toContain form fails on a missing site too (undefined has no substring).
-    expect(sites.find((s) => s.file === 'commission.ts')?.call).toContain('silent: true');
+    // Bound to the CALL and to its identity, not just the file: `.some(file ===
+    // ...)` alone stays green if commission.ts keeps some other grant while the
+    // unbind peel moves out of src/sim/professions and off the sweep entirely,
+    // and a file-scoped flag check still passes if that other grant is the one
+    // carrying the flag. The peel's own arguments are what pin the peel. The
+    // find-then-toContain form fails on a missing site too (undefined has no
+    // substring).
+    const peel = sites.find((s) => s.file === 'commission.ts')?.call;
+    expect(peel).toContain('freed, meta.entityId');
+    expect(peel).toContain('silent: true');
     expect(sites.some((s) => s.call.includes('callerLogs: true'))).toBe(true);
     expect(sites.some((s) => s.call.includes('silent: true'))).toBe(true);
     // The balanced-paren walk must capture the whole call, opts object and all,

--- a/tests/professions_single_line_grants.test.ts
+++ b/tests/professions_single_line_grants.test.ts
@@ -146,22 +146,46 @@ const professionGrant = (itemId: string, count = 1): SimEvent =>
     callerLogs: true,
   }) as SimEvent;
 
+// Every cue this file stubs, as ONE list the beforeEach installs and
+// firedCues() reads back, so the two can never cover different sets.
+const STUBBED_CUES = [
+  'lootItem',
+  'coin',
+  'gather',
+  'gatherRareTier',
+  'craftSuccess',
+  'masterwork',
+  'disenchant',
+  'salvage',
+  'enchant',
+  'fishReel',
+] as const;
+
+/** The names of every stubbed cue that actually fired, in list order. Asking
+ *  about the whole set is what makes #2458's "same action, same audio" a real
+ *  claim: naming lootItem and coin alone would miss a cue added on some other
+ *  arm later. */
+const firedCues = (): string[] =>
+  STUBBED_CUES.filter((name) => {
+    const spy = audio[name] as unknown as { mock?: { calls: unknown[] } };
+    return (spy.mock?.calls.length ?? 0) > 0;
+  });
+
+/** The exact event burst the sim emits for one successful unbind, per arm.
+ *  The stacked arm peels a copy back through the grant hub (both stand-down
+ *  flags since #2458); the lone arm clears boundTo in place, never reaches the
+ *  hub, and so has no grant event at all. That asymmetry in the BURST is the
+ *  whole reason the two arms could ever have sounded different. */
+const unbindBurst = (arm: 'stacked' | 'lone'): SimEvent[] => [
+  ...(arm === 'stacked' ? [professionGrant(SWORD, 1)] : []),
+  { type: 'unbindResult', pid: PLAYER_ID, ok: true, itemId: SWORD, fee: 2500 } as SimEvent,
+];
+
 beforeEach(() => {
   mountBags();
   // Every cue is stubbed: this file is about lines, and the cue contract has
   // its own file. The fishing arm's cue count is asserted below, though.
-  for (const name of [
-    'lootItem',
-    'coin',
-    'gather',
-    'gatherRareTier',
-    'craftSuccess',
-    'masterwork',
-    'disenchant',
-    'salvage',
-    'enchant',
-    'fishReel',
-  ] as const) {
+  for (const name of STUBBED_CUES) {
     vi.spyOn(audio, name).mockImplementation(() => {});
   }
 });
@@ -336,16 +360,7 @@ describe('one profession action prints exactly one grant line', () => {
     // stacked on top of the unbind line. A single-copy unbind clears in place
     // and never reaches the hub, so only the stacked arm ever double-logged.
     const hud = makeHud();
-    hud.handleEvents([
-      {
-        type: 'loot',
-        text: `You receive: ${ITEMS[SWORD]?.name}.`,
-        pid: PLAYER_ID,
-        silent: true,
-        callerLogs: true,
-      } as SimEvent,
-      { type: 'unbindResult', pid: PLAYER_ID, ok: true, itemId: SWORD, fee: 2500 } as SimEvent,
-    ]);
+    hud.handleEvents(unbindBurst('stacked'));
     const rendered = lines(hud);
     expect(rendered).toHaveLength(1);
     expect(rendered[0]).not.toContain('You receive');
@@ -353,28 +368,36 @@ describe('one profession action prints exactly one grant line', () => {
     // #2458: the cue stands down too. Unbind has no dedicated cue of its own,
     // so hudChrome.unbind.unbound is documented as the ONE success surface (no
     // toast, no sound cue, the trainResult rule) and the grant carries silent
-    // alongside callerLogs.
-    expect(audio.lootItem).not.toHaveBeenCalled();
-    expect(audio.coin).not.toHaveBeenCalled();
+    // alongside callerLogs. Asked across EVERY stubbed cue, not just the two
+    // the hub loot arm can reach, so a cue routed through some other arm later
+    // cannot slip in under a narrower assertion.
+    expect(firedCues()).toEqual([]);
     // The peel still moved items, so the bag mirror still repaints.
     expect(hud.renderBags).toHaveBeenCalled();
   });
 
   it('unbinding a lone copy sounds exactly like unbinding out of a stack', () => {
-    // #2458's acceptance criterion, and the only place the two arms are
-    // comparable: the count-1 arm clears boundTo in place, so its burst is the
-    // unbindResult event ALONE with no hub grant to flag. Driving it beside the
-    // stacked burst above is what makes "same action, same audio" a pin rather
-    // than a claim about one arm at a time.
-    const hud = makeHud();
-    hud.handleEvents([
-      { type: 'unbindResult', pid: PLAYER_ID, ok: true, itemId: SWORD, fee: 2500 } as SimEvent,
-    ]);
-    const rendered = lines(hud);
+    // #2458's acceptance criterion, stated as one comparison rather than two
+    // separate single-arm claims. The count-1 arm clears boundTo in place, so
+    // its burst is the unbindResult event ALONE with no hub grant to flag,
+    // which is why the two arms could ever have differed. This is a negative
+    // control, not the regression guard for the fix: it passes on the old code
+    // too. What it adds is the cross-arm equality, so the sim pin in
+    // tests/professions_commissions.test.ts stays the decisive one.
+    const stacked = makeHud();
+    stacked.handleEvents(unbindBurst('stacked'));
+    const stackedCues = firedCues();
+    vi.clearAllMocks();
+
+    const lone = makeHud();
+    lone.handleEvents(unbindBurst('lone'));
+    const loneCues = firedCues();
+
+    const rendered = lines(lone);
     expect(rendered).toHaveLength(1);
     expect(rendered[0]).toContain(itemDisplayName(ITEMS[SWORD]));
-    expect(audio.lootItem).not.toHaveBeenCalled();
-    expect(audio.coin).not.toHaveBeenCalled();
+    expect(loneCues).toEqual(stackedCues);
+    expect(loneCues).toEqual([]);
   });
 
   it('a yield-free disenchant success renders no dangling empty operand', () => {
@@ -618,6 +641,10 @@ describe('non-profession grants are untouched', () => {
     // LINE without owning the CUE, so the ding must still fire. Merging the
     // two guards into `if (!(ev.silent || ev.callerLogs))` is behaviorally the
     // regression those pins exist to stop, and it passes them; it fails here.
+    // Deliberately SYNTHETIC since #2458: no production emitter sets the two
+    // flags apart any more, so this fixture is the only thing keeping the hub's
+    // two independent guards from being collapsed into one condition. Do not
+    // delete it as unreachable.
     expect(audio.lootItem).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/professions_single_line_grants.test.ts
+++ b/tests/professions_single_line_grants.test.ts
@@ -329,7 +329,7 @@ describe('one profession action prints exactly one grant line', () => {
     ]);
   });
 
-  it('unbinding one copy out of a stack prints the unbind line only', () => {
+  it('unbinding one copy out of a stack prints the unbind line only, with no cue', () => {
     // The sweep's last grant site (commission.ts unbindItem). A bound stack of
     // byte-equal copies is SPLIT: one copy is peeled off and re-granted through
     // the hub, so the player was told they received an item they already held,
@@ -341,6 +341,7 @@ describe('one profession action prints exactly one grant line', () => {
         type: 'loot',
         text: `You receive: ${ITEMS[SWORD]?.name}.`,
         pid: PLAYER_ID,
+        silent: true,
         callerLogs: true,
       } as SimEvent,
       { type: 'unbindResult', pid: PLAYER_ID, ok: true, itemId: SWORD, fee: 2500 } as SimEvent,
@@ -349,11 +350,31 @@ describe('one profession action prints exactly one grant line', () => {
     expect(rendered).toHaveLength(1);
     expect(rendered[0]).not.toContain('You receive');
     expect(rendered[0]).toContain(itemDisplayName(ITEMS[SWORD]));
-    // The cue is deliberately NOT stood down for this one: unbind has no
-    // dedicated cue of its own, so the grant sets callerLogs without silent.
-    expect(audio.lootItem).toHaveBeenCalledTimes(1);
+    // #2458: the cue stands down too. Unbind has no dedicated cue of its own,
+    // so hudChrome.unbind.unbound is documented as the ONE success surface (no
+    // toast, no sound cue, the trainResult rule) and the grant carries silent
+    // alongside callerLogs.
+    expect(audio.lootItem).not.toHaveBeenCalled();
+    expect(audio.coin).not.toHaveBeenCalled();
     // The peel still moved items, so the bag mirror still repaints.
     expect(hud.renderBags).toHaveBeenCalled();
+  });
+
+  it('unbinding a lone copy sounds exactly like unbinding out of a stack', () => {
+    // #2458's acceptance criterion, and the only place the two arms are
+    // comparable: the count-1 arm clears boundTo in place, so its burst is the
+    // unbindResult event ALONE with no hub grant to flag. Driving it beside the
+    // stacked burst above is what makes "same action, same audio" a pin rather
+    // than a claim about one arm at a time.
+    const hud = makeHud();
+    hud.handleEvents([
+      { type: 'unbindResult', pid: PLAYER_ID, ok: true, itemId: SWORD, fee: 2500 } as SimEvent,
+    ]);
+    const rendered = lines(hud);
+    expect(rendered).toHaveLength(1);
+    expect(rendered[0]).toContain(itemDisplayName(ITEMS[SWORD]));
+    expect(audio.lootItem).not.toHaveBeenCalled();
+    expect(audio.coin).not.toHaveBeenCalled();
   });
 
   it('a yield-free disenchant success renders no dangling empty operand', () => {

--- a/tests/professions_single_line_grants.test.ts
+++ b/tests/professions_single_line_grants.test.ts
@@ -161,10 +161,18 @@ const STUBBED_CUES = [
   'fishReel',
 ] as const;
 
-/** The names of every stubbed cue that actually fired, in list order. Asking
- *  about the whole set is what makes #2458's "same action, same audio" a real
- *  claim: naming lootItem and coin alone would miss a cue added on some other
- *  arm later. */
+/** The names of every STUBBED cue that actually fired, in list order. Asking
+ *  about the whole set is what makes #2458's "same action, same audio" more
+ *  than a two-name claim: naming lootItem and coin alone would miss a cue
+ *  added on some other arm later.
+ *
+ *  Its reach stops at STUBBED_CUES, and deliberately so rather than by
+ *  oversight: a cue reached through an idiom this file does not stub
+ *  (sfx.playUi, sfx.crowdRoar, voice.play, audio.click) would fire for real
+ *  in jsdom and read as absent here. The complement that closes that is the
+ *  source pin over the whole unbindResult arm in
+ *  tests/unbind_window_hud.test.ts, which forbids every audio/sfx/voice call
+ *  in it outright. Read the two together, not this one alone. */
 const firedCues = (): string[] =>
   STUBBED_CUES.filter((name) => {
     const spy = audio[name] as unknown as { mock?: { calls: unknown[] } };
@@ -368,9 +376,12 @@ describe('one profession action prints exactly one grant line', () => {
     // #2458: the cue stands down too. Unbind has no dedicated cue of its own,
     // so hudChrome.unbind.unbound is documented as the ONE success surface (no
     // toast, no sound cue, the trainResult rule) and the grant carries silent
-    // alongside callerLogs. Asked across EVERY stubbed cue, not just the two
-    // the hub loot arm can reach, so a cue routed through some other arm later
-    // cannot slip in under a narrower assertion.
+    // alongside callerLogs. Asked across every stubbed cue, not just the two
+    // the hub loot arm can reach, so a cue routed through some OTHER arm of
+    // the burst does not slip in under a narrower assertion. What that cannot
+    // see is an unstubbed idiom, which is why the arm's own source pin in
+    // tests/unbind_window_hud.test.ts forbids the whole audio/sfx/voice
+    // receiver set rather than a cue list.
     expect(firedCues()).toEqual([]);
     // The peel still moved items, so the bag mirror still repaints.
     expect(hud.renderBags).toHaveBeenCalled();

--- a/tests/professions_single_line_grants.test.ts
+++ b/tests/professions_single_line_grants.test.ts
@@ -658,9 +658,12 @@ describe('non-profession grants are untouched', () => {
     // delete it as unreachable.
     expect(audio.lootItem).toHaveBeenCalledTimes(1);
     // Positive control for firedCues(), which the unbind symmetry pins above
-    // read as an EMPTY set. A helper that could never observe a call would make
-    // those pass vacuously; this is the one burst in the file that fires
-    // exactly one cue, so it anchors the helper against the same spies.
+    // read as an EMPTY set. A helper that could never observe a call would
+    // make those pass vacuously, so at least one burst has to read back
+    // NON-empty through the same spies, and this is the burst where that is
+    // done. (Several other cases in this file also fire exactly one cue, but
+    // they assert it per-cue with toHaveBeenCalledTimes and so anchor
+    // nothing about the helper.)
     expect(firedCues()).toEqual(['lootItem']);
   });
 });

--- a/tests/professions_single_line_grants.test.ts
+++ b/tests/professions_single_line_grants.test.ts
@@ -646,6 +646,11 @@ describe('non-profession grants are untouched', () => {
     // two independent guards from being collapsed into one condition. Do not
     // delete it as unreachable.
     expect(audio.lootItem).toHaveBeenCalledTimes(1);
+    // Positive control for firedCues(), which the unbind symmetry pins above
+    // read as an EMPTY set. A helper that could never observe a call would make
+    // those pass vacuously; this is the one burst in the file that fires
+    // exactly one cue, so it anchors the helper against the same spies.
+    expect(firedCues()).toEqual(['lootItem']);
   });
 });
 

--- a/tests/unbind_window_hud.test.ts
+++ b/tests/unbind_window_hud.test.ts
@@ -25,7 +25,17 @@ function unbindResultArm(): string {
   const end = hudSource.indexOf("case 'masterwork': {", start);
   expect(start, 'unbindResult case arm present in handleEvents').toBeGreaterThan(-1);
   expect(end, 'unbindResult arm precedes the masterwork arm').toBeGreaterThan(start);
-  return hudSource.slice(start, end);
+  // Comments stripped from the slice (`://` protocol slashes preserved), the
+  // repo's raw-source-pin idiom (the codeOnly helper in
+  // tests/professions_silent_loot.test.ts). This arm's whole subject is what
+  // it deliberately does NOT do, so the odds of a future comment NAMING a cue
+  // or a toast here are high, and it would turn the negative pins below red
+  // for the wrong reason; on the other side a commented-out key would satisfy
+  // the positive pins.
+  return hudSource
+    .slice(start, end)
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
 }
 
 describe('hud.ts unbindResult event arm (source pins)', () => {
@@ -75,16 +85,28 @@ describe('hud.ts unbindResult event arm (source pins)', () => {
   it('stays single-surface: chat log only, no banner, toast, or audio cue in the arm', () => {
     const arm = unbindResultArm();
     expect(arm.match(/this\.log\(/g)?.length, 'exactly the ok + deny log call sites').toBe(2);
-    // The audio half has to police the idioms hud.ts ACTUALLY uses, which are
-    // `audio.<cue>(` and `sfx.playUi(` (the working form is
-    // tests/professions_audio_wiring.test.ts). The alternation here used to
-    // list this.audio / playSfx / playCue / showToast, none of which occurs
-    // anywhere in hud.ts, so that half matched nothing and a real cue added to
-    // this arm would have passed the whole repo: the HUD cue pins only name
-    // lootItem and coin. #2458 made cue-free the load-bearing contract on BOTH
-    // unbind arms, so this is the guard that has to hold it.
-    expect(arm).not.toMatch(/\baudio\.\w+\(|\bsfx\.play\w*\(/);
-    expect(arm).not.toMatch(/showBanner|showToast|celebrat/i);
+    // BOTH halves police the idioms hud.ts ACTUALLY uses, because an
+    // alternation of strings the file does not contain matches nothing and
+    // waves through the exact thing it names. This pin used to list
+    // this.audio / playSfx / playCue / showToast, and all four occur ZERO
+    // times in hud.ts (showToast occurs nowhere in src/ at all), so a real
+    // cue added to this arm would have passed the whole repo: the HUD cue
+    // pins only name lootItem and coin. #2458 made cue-free the load-bearing
+    // contract on BOTH unbind arms, so this is the guard that has to hold it.
+    //
+    // Cue idioms: bind the RECEIVER, not the method, because hud.ts reaches
+    // audio through audio.<cue>( (99) and sfx.playUi( / sfx.playAt( (17) but
+    // also sfx.crowdRoar( (4), sfx.unloop( (3) and voice.play( (2), so a
+    // `sfx.play\w*` alternation still misses three live spellings. The
+    // working form is tests/professions_audio_wiring.test.ts.
+    expect(arm).not.toMatch(/\b(audio|sfx|voice)\.\w+\(/);
+    // Out-of-chat surfaces: the whole this.show<X>( family, which is what
+    // "banner or toast" means in this file. showBanner (45) and showError
+    // (21) are the live ones, and showError is BOTH halves at once, since it
+    // paints the error toast and calls audio.error() itself, so the cue pin
+    // above would not have caught it either.
+    expect(arm).not.toMatch(/\bthis\.show[A-Z]\w*\(/);
+    expect(arm).not.toMatch(/celebrat/i);
   });
 
   it('renders nothing for a reason-less deny (the silent malformed-item-id arm)', () => {

--- a/tests/unbind_window_hud.test.ts
+++ b/tests/unbind_window_hud.test.ts
@@ -85,35 +85,37 @@ describe('hud.ts unbindResult event arm (source pins)', () => {
   it('stays single-surface: chat log only, no banner, toast, or audio cue in the arm', () => {
     const arm = unbindResultArm();
     expect(arm.match(/this\.log\(/g)?.length, 'exactly the ok + deny log call sites').toBe(2);
-    // BOTH halves police the idioms hud.ts ACTUALLY uses, because an
-    // alternation of strings the file does not contain matches nothing and
-    // waves through the exact thing it names. This pin used to list
-    // this.audio / playSfx / playCue / showToast, and all four occur ZERO
-    // times in hud.ts (showToast occurs nowhere in src/ at all), so a real
-    // cue added to this arm would have passed the whole repo: the HUD cue
-    // pins only name lootItem and coin. #2458 made cue-free the load-bearing
-    // contract on BOTH unbind arms, so this is the guard that has to hold it.
+    // ALLOWLIST, not a blocklist, and that is the whole point. This pin spent
+    // two rounds losing an arms race it could not win: it began as an
+    // alternation of this.audio / playSfx / playCue / showToast, all four of
+    // which occur ZERO times in hud.ts (showToast occurs nowhere in src/ at
+    // all), so it enforced only its banner clause and a real cue added here
+    // would have passed the whole repo. Naming the live idioms instead just
+    // moved the goalposts: hud.ts reaches sound through audio.<cue>( AND
+    // sfx.playUi( / sfx.playAt( AND sfx.crowdRoar( AND sfx.unloop( AND
+    // voice.play( AND three private wrappers of its own (this.combat, an
+    // 18-use route straight onto sfx.playAt, plus playEventSfx and
+    // playAttackerSfx), and its out-of-chat surfaces are showBanner,
+    // showError (itself BOTH a toast and a cue, since it calls audio.error),
+    // showPrompt, showSelfNote, showSubzone, confirmDialog, inputDialog,
+    // combatLog, flashActionSlot. Every enumeration of that was one idiom
+    // short of the next one somebody adds.
     //
-    // Cue idioms: bind the RECEIVER, not the method, because hud.ts reaches
-    // audio through audio.<cue>( (99) and sfx.playUi( / sfx.playAt( (17) but
-    // also sfx.crowdRoar( (4), sfx.unloop( (3) and voice.play( (2), so a
-    // `sfx.play\w*` alternation still misses three live spellings. The
-    // working form is tests/professions_audio_wiring.test.ts.
-    //
-    // The three module receivers are not the whole surface either: hud.ts
-    // routes sound through three private methods of its OWN, this.combat(
-    // (18 uses, a positional wrapper straight onto sfx.playAt), plus
-    // this.playEventSfx( and this.playAttackerSfx(. A cue added to this arm
-    // through any of those never names a module, so the receiver alternation
-    // alone waves it through.
-    expect(arm).not.toMatch(/\b(audio|sfx|voice)\.\w+\(|\bthis\.(combat|play\w*Sfx)\(/);
-    // Out-of-chat surfaces: the whole this.show<X>( family, which is what
-    // "banner or toast" means in this file. showBanner (45) and showError
-    // (21) are the live ones, and showError is BOTH halves at once, since it
-    // paints the error toast and calls audio.error() itself, so the cue pin
-    // above would not have caught it either.
-    expect(arm).not.toMatch(/\bthis\.show[A-Z]\w*\(/);
-    expect(arm).not.toMatch(/celebrat/i);
+    // So enumerate what the arm IS instead. Its entire method surface is
+    // three calls, and #2458 made "one chat line and nothing else" the
+    // load-bearing contract on BOTH unbind arms, so anything a contributor
+    // adds here has to show up in this list and be argued for by name.
+    const selfCalls = [...new Set(arm.match(/\bthis\.\w+\(/g) ?? [])].sort();
+    expect(selfCalls, 'the arm calls nothing but the chat line and the two repaints').toEqual([
+      'this.log(',
+      'this.renderBags(',
+      'this.renderUnbind(',
+    ]);
+    // The allowlist cannot see a call with no `this.` receiver, which is
+    // exactly how every module-level cue is spelled, so the receiver pin
+    // stays as its complement. Between them: no bare audio/sfx/voice call,
+    // and no method of the Hud beyond the three named above.
+    expect(arm).not.toMatch(/\b(audio|sfx|voice)\.\w+\(/);
   });
 
   it('renders nothing for a reason-less deny (the silent malformed-item-id arm)', () => {

--- a/tests/unbind_window_hud.test.ts
+++ b/tests/unbind_window_hud.test.ts
@@ -99,7 +99,14 @@ describe('hud.ts unbindResult event arm (source pins)', () => {
     // also sfx.crowdRoar( (4), sfx.unloop( (3) and voice.play( (2), so a
     // `sfx.play\w*` alternation still misses three live spellings. The
     // working form is tests/professions_audio_wiring.test.ts.
-    expect(arm).not.toMatch(/\b(audio|sfx|voice)\.\w+\(/);
+    //
+    // The three module receivers are not the whole surface either: hud.ts
+    // routes sound through three private methods of its OWN, this.combat(
+    // (18 uses, a positional wrapper straight onto sfx.playAt), plus
+    // this.playEventSfx( and this.playAttackerSfx(. A cue added to this arm
+    // through any of those never names a module, so the receiver alternation
+    // alone waves it through.
+    expect(arm).not.toMatch(/\b(audio|sfx|voice)\.\w+\(|\bthis\.(combat|play\w*Sfx)\(/);
     // Out-of-chat surfaces: the whole this.show<X>( family, which is what
     // "banner or toast" means in this file. showBanner (45) and showError
     // (21) are the live ones, and showError is BOTH halves at once, since it

--- a/tests/unbind_window_hud.test.ts
+++ b/tests/unbind_window_hud.test.ts
@@ -75,7 +75,16 @@ describe('hud.ts unbindResult event arm (source pins)', () => {
   it('stays single-surface: chat log only, no banner, toast, or audio cue in the arm', () => {
     const arm = unbindResultArm();
     expect(arm.match(/this\.log\(/g)?.length, 'exactly the ok + deny log call sites').toBe(2);
-    expect(arm).not.toMatch(/showBanner|showToast|this\.audio|playSfx|playCue|celebrat/i);
+    // The audio half has to police the idioms hud.ts ACTUALLY uses, which are
+    // `audio.<cue>(` and `sfx.playUi(` (the working form is
+    // tests/professions_audio_wiring.test.ts). The alternation here used to
+    // list this.audio / playSfx / playCue / showToast, none of which occurs
+    // anywhere in hud.ts, so that half matched nothing and a real cue added to
+    // this arm would have passed the whole repo: the HUD cue pins only name
+    // lootItem and coin. #2458 made cue-free the load-bearing contract on BOTH
+    // unbind arms, so this is the guard that has to hold it.
+    expect(arm).not.toMatch(/\baudio\.\w+\(|\bsfx\.play\w*\(/);
+    expect(arm).not.toMatch(/showBanner|showToast|celebrat/i);
   });
 
   it('renders nothing for a reason-less deny (the silent malformed-item-id arm)', () => {

--- a/tests/unbind_window_hud.test.ts
+++ b/tests/unbind_window_hud.test.ts
@@ -91,15 +91,16 @@ describe('hud.ts unbindResult event arm (source pins)', () => {
     // which occur ZERO times in hud.ts (showToast occurs nowhere in src/ at
     // all), so it enforced only its banner clause and a real cue added here
     // would have passed the whole repo. Naming the live idioms instead just
-    // moved the goalposts: hud.ts reaches sound through audio.<cue>( AND
-    // sfx.playUi( / sfx.playAt( AND sfx.crowdRoar( AND sfx.unloop( AND
-    // voice.play( AND three private wrappers of its own (this.combat, an
-    // 18-use route straight onto sfx.playAt, plus playEventSfx and
-    // playAttackerSfx), and its out-of-chat surfaces are showBanner,
+    // moved the goalposts: hud.ts reaches sound through audio.<cue>(, and
+    // sfx.playUi( / playAt( / crowdRoar( / unloop( / loop( / goalHorn(, and
+    // voice.play(, and three private wrappers of its own (this.combat, a
+    // route straight onto sfx.playAt, plus playEventSfx and
+    // playAttackerSfx); its out-of-chat surfaces run to showBanner,
     // showError (itself BOTH a toast and a cue, since it calls audio.error),
     // showPrompt, showSelfNote, showSubzone, confirmDialog, inputDialog,
-    // combatLog, flashActionSlot. Every enumeration of that was one idiom
-    // short of the next one somebody adds.
+    // combatLog and flashActionSlot. Neither list is closed, and that is the
+    // point: every enumeration of them was one idiom short of the next one
+    // somebody adds.
     //
     // So enumerate what the arm IS instead. Its entire method surface is
     // three calls, and #2458 made "one chat line and nothing else" the


### PR DESCRIPTION
## Summary

Unbinding a commission piece played the generic loot ding or nothing at all depending only on
how many byte-equal copies happened to share an inventory slot.

`unbindItem` (`src/sim/professions/commission.ts`) has two arms. A lone bound copy is cleared in
place and never reaches the inventory hub, so it is silent. A bound STACK peels one copy off and
re-grants it through the hub, and that grant passed `callerLogs: true` without `silent`, so the
hub's `loot` event reached the HUD's `case 'loot'` arm with `silent` unset and `audio.lootItem()`
fired. The chat half of this was already fixed in #2452; only the cue was still asymmetric, and
`callerLogs` was set without `silent` there deliberately, to keep that change scoped to the line
defect rather than silently altering audio.

Both arms also contradicted a contract this repo writes down twice: the comment above
`hudChrome.unbind.unbound` in `src/ui/i18n.catalog/hud_chrome.ts` ("unbound is the ONE success
surface: no toast, no sound cue (the trainResult single-surface rule)"), and the matching header
on the HUD's `unbindResult` arm.

The peel now passes `silent: true` alongside `callerLogs: true`. Unbind owns its cue as
deliberate silence rather than having a cue of its own, which is still owning it, so this is the
smaller of the two resolutions the issue lays out: the alternative was to give `unbindResult` a
dedicated cue on both arms, which is a larger design change and contradicts the written contract.

Three doc comments cited this call site as the production example of a caller that owns the line
without owning the cue, so they are rewritten in the same change: the grant hub's `opts` contract
(`src/sim/sim.ts`), the `loot` SimEvent type doc (`src/sim/types.ts`), and the HUD's loot arm
(`src/ui/hud.ts`). The first of those is the repo's canonical statement of the two-flag doctrine
and, left alone, would have told the next contributor to write code the new guard rejects.

**Severity is low, and the honest reason is that no shipped GRANT path can reach the stacked
arm.** Commission eligibility is limited to `weapon`, `armor` and `held_offhand`, all of which
are in `UNSTACKED_KINDS` and therefore stack one per slot, and the only explicit `stackSize`
anywhere in `src`, `server`, `headless` or `scripts` is `heroic_mark`, a tool. The persistence
caps in `Sim` and `bank.ts` mean a hand-edited save cannot launder a count-2 bound gear slot
either. Worth being precise rather than calling it dead code: the arm itself is perfectly
reachable by anything that writes `count > 1` onto a gear slot directly, which is exactly what
`tests/professions_capacity.test.ts` does, once with a synthetic def and once with the real
shipped Eastbrook sword. What today's content cannot do is produce that slot through a grant.
So this is a forward guard and a contract correction, not a live player-visible regression: the
day anyone ships a commission-eligible def with an explicit `stackSize > 1`, the asymmetry
becomes visible with no further code change and no test failure.

Unchanged, as the issue requires: the fee, the `boundTo` clear, the stack split itself, the
`unbindResult` event, and the one chat line each arm prints.

**A cue-free unbind is not anomalous, and an earlier draft of this body claimed it was.** That
draft said a successful unbind would be the only gold spend in the game with no audio
confirmation, and offered to flip the fix the other way on that basis. The claim is false, and
the counter-example is the precedent this contract is named after: `Sim.trainRecipe` debits
`trainingFeeFor` (`src/sim/professions/training.ts`, `TRAINING_FEE_BY_TIER` topping out at
160000 copper, four times the unbind ceiling) and its HUD `trainResult` arm makes no audio call
at all. The companion upgrade (`companionUpgrade` in `src/sim/delves/runs.ts`) and the Vale Cup
stake (`src/sim/social/vale_cup.ts`) also debit copper silently, and the craft fee plays
`craftSuccess` rather than `coin`. So there is no consistency argument for giving `unbindResult`
a cue of its own, which is the alternative the issue raises and rejects: the written contract and
the neighbouring actions agree with each other. The offer to flip it is withdrawn, since it was
resting on a fact that is not true. The success still reports through the chat line, and
`Hud.log` feeds `chatAnnouncer.push`, so the screen-reader channel is untouched.

The commits after the first are review fallout, not new scope: the guards around this contract
turned out weaker than they read, twice. The `unbindResult` arm's single-surface pin matched
`showBanner`, `showToast`, `this.audio`, `playSfx`, `playCue` and `celebrat`, and four of those
six strings occur nowhere in `hud.ts`, so adding a real cue to that arm would have passed the
entire repo. Repairing the audio half then left the identical defect one line down: `showToast`
occurs nowhere in `src/` at all, while the live out-of-chat surface is the `this.show<X>(`
family, and `this.showError` is both halves at once, since it paints the error toast AND calls
`audio.error()` itself. Both halves were then rebound to the receiver rather than the method
(`audio|sfx|voice`, and the whole `this.show<X>(` family), which also picks up `sfx.crowdRoar(`,
`sfx.unloop(`, `sfx.loop(`, `sfx.goalHorn(` and `voice.play(`, live spellings a `sfx.play\w*`
alternation misses. Even that was one layer short: `hud.ts` routes sound through three private
methods of its own that never name a module (`Hud.combat`, a positional wrapper straight onto
`sfx.playAt`, plus `playEventSfx` and `playAttackerSfx`). And one layer short again: the unbind
feature opens a `confirmDialog` of its own for the fee confirm, so a modal is a perfectly
plausible thing for someone to add to the result arm, and no blocklist named it.

**So the pin is an allowlist now, which is the only version of it that stops losing this race.**
The arm's entire method surface is `this.log(` twice plus `renderUnbind()` and `renderBags()`,
which is the single-surface contract stated positively rather than as an ever-growing list of
forbidden spellings; anything added here has to appear in that list and be argued for by name.
The receiver pin stays as its complement, since a bare `audio`/`sfx`/`voice` call has no `this.`
to catch. Mutation matrix, all run: `this.confirmDialog`, `this.combatLog`,
`this.flashActionSlot`, `this.showError`, `this.combat`, bare `audio.lootItem` and bare
`voice.play` each turn it red. The arm slice strips comments now as well, which matters more
here than usual because the arm's whole subject is what it deliberately does NOT do, and a
comment naming `audio.lootItem()` and `this.showError()` correctly does not trip it.

One commit in that pass corrects the doctrine comment this PR rewrites, which is the highest
value edit of the lot, since it is the standing instruction to whoever adds the next grant site.
It sorted every grant into two buckets, a dedicated cue or deliberate silence, and filed corpse
harvest under the first.
Harvest has no cue of its own: `hud.ts case 'harvestResult'` replays the same generic
`audio.lootItem()` once for the whole command, and says so. The split is three-way, and all
three ways are still the caller owning the cue, so naming the middle one makes the argument
stronger rather than weaker.

### Tests

- `tests/professions_commissions.test.ts`: the pin that asserted `silent` was ABSENT is reworked
  to assert it is set, keeping the own-key form (the conditional-spread contract is that a set
  flag is an own key valued true and an unset one is absent, and a written-undefined key would
  move the parity digest of every grant in the game) and adding the value check. The single-copy
  negative control keeps its assertion and gains the symmetry rationale; its title read backwards
  and is corrected.
- `tests/professions_single_line_grants.test.ts`: the HUD case hand-built its `loot` event
  without `silent`, so it would have stayed GREEN while asserting the exact ding production no
  longer plays, which is the more dangerous failure mode than a red test. The fixture now carries
  `silent`, the assertion flips to "no cue", and a new sibling case drives the lone-copy burst
  (`unbindResult` alone, no hub grant) so "same action, same audio" is pinned across BOTH arms
  rather than claimed one arm at a time.
- `tests/professions_silent_loot.test.ts`: the call-site sweep required only `callerLogs`,
  justified by the unbind peel being a legitimate line-without-cue site. That justification is
  now gone, so the sweep gains a sibling requiring `silent` wherever `callerLogs` is required
  (the no-result-event exclusion list is unchanged and still covers the Codfather catch, which
  sets neither). All 22 grant sites pass it today. I mutation-tested it: reverting the one-line
  fix turns it red. The two sweeps in that file also disagreed on whitespace, the older one
  matching raw call text and the newer one normalizing first, so `sites` is normalized once at
  construction and both read the same shape. Checked by wrapping the peel's opts object across
  lines: green now, where the older sweep would have gone red for a formatting reason.
- `tests/unbind_window_hud.test.ts`: the `unbindResult` arm's single-surface pin becomes an
  allowlist over the arm's own method surface, with the receiver pin kept as its complement,
  and the arm slice strips comments. Mutation matrix above; every route that passed the
  blocklist now turns it red.

Three notes for whoever reads this next.

The tightened sweep says every professions grant that elides the hub LINE also elides the hub
CUE, which is true of every shipped site. It does NOT merge the two flags: they stay independent
in the hub by design, and the only things defending that now are synthetic fixtures the
directory scanner never sees (`tests/professions_single_line_grants.test.ts` and
`tests/professions_silent_loot.test.ts`, plus the HUD source pin in
`tests/professions_audio_wiring.test.ts`). Those are marked in place and should not be deleted as
"now unreachable". The cost of the tightening is that, unlike the line sweep beside it, it has no
`NO_RESULT_EVENT_GRANTS` escape hatch: a future professions grant that legitimately wants the
line down and the ding ON has to edit the test with a rationale. That friction is intended, so
please do not read the red as a bug. The mirror direction (`silent` with no `callerLogs`) needs
no new pin: the pre-existing line sweep already fails it.

`firedCues()` and the arm's source pin are two halves of one claim and should be read together.
`firedCues()` observes a fixed ten-name registry, so a cue reached through an idiom that file
does not stub would fire for real in jsdom and read as absent; what closes that is
`tests/unbind_window_hud.test.ts` forbidding the whole `audio|sfx|voice` receiver set in the arm
outright, rather than a cue list. Neither alone is the guard. Both doc comments now say so
instead of overclaiming.

Parity gives this arm zero coverage, by construction rather than by oversight. `eventDigest`
hashes whole event objects in emit order, so a scenario that drove a stacked unbind WOULD have
moved a golden. None does, which is the same fact as "unreachable through shipped grant paths"
seen from the other side, and it means the unit pins are the entire safety net here.

## Related issues

Closes #2458.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npm run gate` (PASS, all 11 steps green: 20471 tests, browser suite, `tsc`, all builds)
  - `npx vitest run tests/professions_commissions.test.ts tests/professions_single_line_grants.test.ts tests/professions_silent_loot.test.ts tests/professions_capacity.test.ts tests/professions_commissions_ui.test.ts tests/unbind_window_hud.test.ts`
  - Mutation check, actually run and reverted: dropping `silent: true` from `commission.ts`
    turns both the sim pin and the new sweep red, so neither passes vacuously. The sweep also
    stays red when the flag is hidden in a `//` or `/* */` comment or put behind a variable, and
    does not go falsely red when the opts object is wrapped across lines.
- Manual steps: none, because no shipped GRANT path produces a count > 1 bound gear slot (see
  above). Three existing tests drive the peel anyway by writing that slot directly: two through
  a synthetic def (`tests/professions_commissions.test.ts`'s `qa_p14b_stacked_focus` and
  `tests/professions_capacity.test.ts`'s `QA_STACK_WEAPON`) and one, `splits with a free slot`
  in the same capacity file, with the real shipped `eastbrook_arming_sword` and no synthetic def
  at all. An earlier draft of this line said "two tests, all synthetic", which contradicted the
  correct account further up this body.

## Screenshots / recordings

None, deliberately, and worth spelling out because the tooling disagrees. Touching
`src/sim/professions/commission.ts` selects three targets in `scripts/pr_shot_targets.mjs`
(`profession-grant-lines`, `crafting`, `unbind-window`), because `resolveTargets` matches on the
bare path substrings `sim/professions` and `sim/professions/commission`. All three have a
provably empty visual delta here: the only behavioral change is that one `loot` SimEvent now
carries `silent`, which gates `audio.lootItem()` alone. The chat output of both unbind arms is
byte-identical before and after, the unbind window and the crafting window are not touched, and
no CSS, DOM or render code is in the diff.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~[ ] Tested on desktop and mobile.~ N/A, no UI surface changes.
- ~[ ] Accessible.~ N/A, no UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. No key is added, and no English value is
      reworded, so there is no overlay staleness and no pending row.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.

