### PR TITLE
test(professions): walk the grant-site sweep recursively, and pin it per file

### DIFF
--- a/tests/professions_silent_loot.test.ts
+++ b/tests/professions_silent_loot.test.ts
@@ -524,10 +524,13 @@ describe('every professions grant site is accounted for (#2430)', () => {
     );
     for (const entry of entries) {
       const full = path.join(root, entry.name);
+      // The file arm is deliberately NOT gated on `entry.isFile()`. A Dirent
+      // reports lstat, so that check reads false for a symlink, and the flat
+      // read this replaces would have followed one: gating on it would narrow
+      // coverage in the very way #2485 is about, one door over. Anything named
+      // `.ts` that is not a directory gets read.
       if (entry.isDirectory()) out.push(...tsFilesUnder(full, `${prefix}${entry.name}/`));
-      else if (entry.isFile() && entry.name.endsWith('.ts')) {
-        out.push({ file: `${prefix}${entry.name}`, full });
-      }
+      else if (entry.name.endsWith('.ts')) out.push({ file: `${prefix}${entry.name}`, full });
     }
     return out;
   };
@@ -580,14 +583,16 @@ describe('every professions grant site is accounted for (#2430)', () => {
 
   // The two rules the sweeps below enforce, as functions of a site list, so the
   // recursion case can put a nested grant to the REAL predicates rather than to
-  // a restatement of them that could drift out of agreement with these.
-  const grantsKeepingTheHubLine = (all: GrantSite[]): GrantSite[] =>
+  // a restatement of them that could drift out of agreement with these. Named
+  // for what they RETURN, the violations: a documented no-result-event grant
+  // keeps the hub line legitimately, so it is not in the first list.
+  const unaccountedLineGrants = (all: GrantSite[]): GrantSite[] =>
     all.filter(
       (s) =>
         !s.call.includes('callerLogs: true') &&
         !NO_RESULT_EVENT_GRANTS.some((marker) => s.call.includes(marker)),
     );
-  const grantsKeepingTheHubCue = (all: GrantSite[]): GrantSite[] =>
+  const unaccountedCueGrants = (all: GrantSite[]): GrantSite[] =>
     all.filter((s) => s.call.includes('callerLogs: true') && !s.call.includes('silent: true'));
 
   const describeSites = (all: GrantSite[]): string[] => all.map((s) => `${s.file}: ${s.call}`);
@@ -596,12 +601,16 @@ describe('every professions grant site is accounted for (#2430)', () => {
     // A regex that stopped matching would make the sweep below green while
     // checking nothing, so bind both the count and the shape. Per FILE, not as
     // one total: the floor this replaces (>= 19, against a real 22) left slack
-    // for up to three sites to leave the sweep unnoticed, and a module split
-    // into a subdirectory takes its whole file's worth out at once (#2485).
-    const byFile: Record<string, number> = {};
-    for (const site of sites) byFile[site.file] = (byFile[site.file] ?? 0) + 1;
+    // for up to three sites to leave the sweep unnoticed. The map and the
+    // recursion cover different halves of #2485: a file that MOVES loses its
+    // row here even under a flat read, while a file that is BORN in a new
+    // subdirectory has no row to lose, and only the walk can find it.
+    // Counted through a Map, so a source file named `__proto__.ts` lands as a
+    // row rather than vanishing into an object literal's prototype.
+    const byFile = new Map<string, number>();
+    for (const site of sites) byFile.set(site.file, (byFile.get(site.file) ?? 0) + 1);
     expect(
-      byFile,
+      Object.fromEntries(byFile),
       'grant sites per file: a NEW grant sets silent + callerLogs (or joins NO_RESULT_EVENT_GRANTS), and THEN bumps its number here; a number that dropped means a grant left the sweep',
     ).toEqual(EXPECTED_GRANT_SITES);
     // Bound to the CALL and to its identity, not just the file: `.some(file ===
@@ -652,7 +661,7 @@ describe('every professions grant site is accounted for (#2430)', () => {
 
   it('every grant either stands its hub line down or is a named no-result-event grant', () => {
     expect(
-      describeSites(grantsKeepingTheHubLine(sites)),
+      describeSites(unaccountedLineGrants(sites)),
       'a professions grant that neither sets callerLogs nor is a documented no-result-event grant',
     ).toEqual([]);
   });
@@ -674,7 +683,7 @@ describe('every professions grant site is accounted for (#2430)', () => {
     // stack one per slot today. This is the forward guard for the day one does
     // not: the same grant reached by a different route must sound the same.
     expect(
-      describeSites(grantsKeepingTheHubCue(sites)),
+      describeSites(unaccountedCueGrants(sites)),
       'a professions grant that elides the hub line but still plays the generic hub ding',
     ).toEqual([]);
   });
@@ -688,7 +697,7 @@ describe('every professions grant site is accounted for (#2430)', () => {
     // the real predicates, so the recursion is pinned rather than eyeballed.
     const fixture = mkdtempSync(path.join(tmpdir(), 'woc-grant-scan-'));
     try {
-      mkdirSync(path.join(fixture, 'nested', 'deeper'), { recursive: true });
+      mkdirSync(path.join(fixture, 'nested', 'deeper', 'deepest'), { recursive: true });
       writeFileSync(
         path.join(fixture, 'top.ts'),
         'ctx.addItem(itemId, 1, pid, { silent: true, callerLogs: true });\n',
@@ -696,13 +705,35 @@ describe('every professions grant site is accounted for (#2430)', () => {
       // One nested violation per sweep: a bare grant (keeps the hub LINE) and a
       // line-only grant (keeps the hub CUE, the #2458 half). One file each, so a
       // walk that descended but mislabeled would show up as a wrong file name.
+      // The line-only grant sits THREE levels down, so a walk with any depth
+      // cap fails here rather than passing on a two-level fixture.
       writeFileSync(
         path.join(fixture, 'nested', 'bare.ts'),
         'ctx.addItemInstance(itemId, payload, pid);\n',
       );
+      // Split between the key and its value, which is what makes `flatten`
+      // load-bearing: on raw text this call does not contain the literal
+      // `callerLogs: true`, so a regression that stopped normalizing would
+      // report it as a line violation instead of a cue one.
       writeFileSync(
-        path.join(fixture, 'nested', 'deeper', 'line_only.ts'),
-        'ctx.addItem(itemId, 1, pid, {\n  callerLogs: true,\n});\n',
+        path.join(fixture, 'nested', 'deeper', 'deepest', 'line_only.ts'),
+        'ctx.addItem(itemId, 1, pid, {\n  callerLogs:\n    true,\n});\n',
+      );
+      // The flag present ONLY as a comment INSIDE the call's own parentheses,
+      // which is what makes `codeOnly` load-bearing: commenting a trailing
+      // option out in place is the idiomatic way to disable it, and without the
+      // strip the balanced-paren capture would read those words as the flag.
+      writeFileSync(
+        path.join(fixture, 'nested', 'commented_out.ts'),
+        'ctx.addItem(itemId, 1, pid, {\n  // callerLogs: true,\n});\n',
+      );
+      // A documented no-result-event grant: bare, but carrying an exclusion
+      // marker. It is the only fixture file the line sweep must NOT report, so
+      // the exclusion conjunct is exercised here and not only by the real
+      // tree's one codfather grant.
+      writeFileSync(
+        path.join(fixture, 'nested', 'documented.ts'),
+        'ctx.addItem(THE_CODFATHER_ITEM_ID, 1, pid);\n',
       );
       // Grant-shaped prose in a non-source sibling. Nothing in the real tree
       // exercises the extension filter (src/sim/professions/CLAUDE.md holds no
@@ -723,20 +754,49 @@ describe('every professions grant site is accounted for (#2430)', () => {
       // hash order on the ext4 CI runner), and nothing is swept twice.
       expect(found.map((s) => s.file)).toEqual([
         'nested/bare.ts',
-        'nested/deeper/line_only.ts',
+        'nested/commented_out.ts',
+        'nested/deeper/deepest/line_only.ts',
+        'nested/documented.ts',
         'top.ts',
       ]);
-      // ... and both sweeps really do fire on them.
-      expect(grantsKeepingTheHubLine(found).map((s) => s.file)).toEqual(['nested/bare.ts']);
-      expect(grantsKeepingTheHubCue(found).map((s) => s.file)).toEqual([
-        'nested/deeper/line_only.ts',
+      // ... and both sweeps really do fire on them. documented.ts is absent
+      // from the line list because of its marker, and top.ts from both because
+      // it carries the pair, so a predicate that flagged everything, one that
+      // flagged nothing, and one that lost the exclusion arm all fail here.
+      expect(unaccountedLineGrants(found).map((s) => s.file)).toEqual([
+        'nested/bare.ts',
+        'nested/commented_out.ts',
       ]);
-      // The flagged top-level grant is the negative control: the sweeps clear
-      // it, so a predicate that flagged everything could not fake this case.
+      expect(unaccountedCueGrants(found).map((s) => s.file)).toEqual([
+        'nested/deeper/deepest/line_only.ts',
+      ]);
+      // The balanced-paren capture reaches the opts object at top level too, so
+      // a walk that took only the first argument could not pass the sweeps by
+      // reading every call as unflagged.
       expect(found.find((s) => s.file === 'top.ts')?.call).toContain('callerLogs: true');
     } finally {
       rmSync(fixture, { recursive: true, force: true });
     }
+  });
+
+  it('the sweep reads the tree through ONE walker (no second, flat producer)', () => {
+    // The case above pins the WALKER; nothing can pin that `sites` still goes
+    // through it, because src/sim/professions is flat, so an inline flat read
+    // here would return the identical list today and every assertion in this
+    // file would stay green. The only mechanical guard is that this file owns
+    // exactly one directory read, which is grantSitesUnder's. Comments are
+    // stripped first, or the prose above explaining the old single-level
+    // readdirSync would count as a second one.
+    const own = codeOnly(
+      readFileSync(path.resolve(process.cwd(), 'tests/professions_silent_loot.test.ts'), 'utf8'),
+    );
+    // Assembled from halves so the needle does not match itself and read as the
+    // second call site it exists to forbid.
+    const needle = `readdir${'Sync('}`;
+    expect(
+      own.split(needle).length - 1,
+      'this file should read a directory in exactly one place (tsFilesUnder); a second reader can go flat while the first stays recursive',
+    ).toBe(1);
   });
 
   it('the exclusion list has no stale entries', () => {

--- a/tests/professions_silent_loot.test.ts
+++ b/tests/professions_silent_loot.test.ts
@@ -704,11 +704,23 @@ describe('every professions grant site is accounted for (#2430)', () => {
         path.join(fixture, 'nested', 'deeper', 'line_only.ts'),
         'ctx.addItem(itemId, 1, pid, {\n  callerLogs: true,\n});\n',
       );
+      // Grant-shaped prose in a non-source sibling. Nothing in the real tree
+      // exercises the extension filter (src/sim/professions/CLAUDE.md holds no
+      // grant text), so without this the filter could be deleted and every
+      // other case here would stay green.
+      writeFileSync(
+        path.join(fixture, 'nested', 'notes.md'),
+        'The old call read ctx.addItem(itemId, 1, pid);\n',
+      );
 
       const found = grantSitesUnder(fixture);
       // Discovered at every depth, labeled by relative path with forward
       // slashes: bare names would collide across subdirectories, and a label
       // that dropped the directory would make EXPECTED_GRANT_SITES ambiguous.
+      // The list is exact and ORDERED on purpose, which is three pins in one:
+      // notes.md is absent (the .ts filter holds), the depth-first name sort
+      // holds (readdir order is byte-lexicographic on a dev APFS checkout and
+      // hash order on the ext4 CI runner), and nothing is swept twice.
       expect(found.map((s) => s.file)).toEqual([
         'nested/bare.ts',
         'nested/deeper/line_only.ts',

--- a/tests/professions_silent_loot.test.ts
+++ b/tests/professions_silent_loot.test.ts
@@ -1,4 +1,5 @@
-import { readdirSync, readFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { ALL_RECIPES } from '../src/sim/content/recipes';
@@ -438,6 +439,29 @@ describe('every professions grant site is accounted for (#2430)', () => {
   // old double-log by omission.
   const dir = path.resolve(process.cwd(), 'src/sim/professions');
 
+  // The per-file grant counts as they stand. The floor this replaces
+  // (`sites.length >= 19`) sat three under the real 22, so up to three sites
+  // could leave the sweep and be absorbed silently: splitting one module into a
+  // folder, or deleting a call, is exactly how a shipped grant would go quiet
+  // while every test here stayed green (#2485). Per file, a disappearance or a
+  // relocation reads as a diff instead. Adding a grant is a deliberate act
+  // already (it has to set its flags); bump its number here in the same change.
+  //
+  // What this map does NOT claim: the scan matches `ctx.addItem`/
+  // `ctx.addItemInstance` call TEXT, so a grant routed through a destructured
+  // `const { addItem } = ctx` or a module-local helper contributes no row and
+  // no count drift. Nothing in src/sim/professions does that today. Recursion
+  // widens which FILES are read, not which call shapes are recognized.
+  const EXPECTED_GRANT_SITES: Record<string, number> = {
+    'commission.ts': 1,
+    'crafting.ts': 6,
+    'enchanting.ts': 4,
+    'fishing.ts': 2,
+    'gathering.ts': 2,
+    'salvage.ts': 1,
+    'interaction.ts:harvestCorpse': 6,
+  };
+
   // Sites that deliberately carry NEITHER flag, keyed by a stable substring of
   // the call itself. A grant belongs here ONLY when no result event follows it,
   // because eliding the hub line for it would make the grant invisible.
@@ -475,6 +499,50 @@ describe('every professions grant site is accounted for (#2430)', () => {
     return calls;
   };
 
+  // Whitespace-normalized ONCE, here, so every pin below reads the same shape.
+  // The two sweeps used to disagree: one matched `callerLogs: true` on raw
+  // call text and the other normalized first, so a formatter that wrapped an
+  // opts object between a key and its value would have blinded one of them
+  // (in the safe direction, but for a reason nobody could see from the
+  // assertion). Comments are already gone by this point (codeOnly above).
+  const flatten = (call: string) => call.replace(/\s+/g, ' ');
+
+  /** Every .ts file under `root`, RECURSIVELY, labeled by its path relative to
+   *  `root` with forward slashes (so a top-level file keeps its bare name and
+   *  the per-file pins below go on resolving). The single-level `readdirSync`
+   *  this replaces read one directory deep, so the day src/sim/professions grew
+   *  a subdirectory every grant inside it would have left both sweeps below
+   *  while they stayed green, covering less than the day before (#2485).
+   *  Entries are sorted by name, so the label list is the same on the ext4 CI
+   *  runner (readdir in hash order) as on a dev APFS checkout. The label idiom
+   *  is tests/i18n_admin_catalog.test.ts's walk, which recursed for the same
+   *  reason: a flat read misses what a subdirectory holds. */
+  const tsFilesUnder = (root: string, prefix = ''): Array<{ file: string; full: string }> => {
+    const out: Array<{ file: string; full: string }> = [];
+    const entries = readdirSync(root, { withFileTypes: true }).sort((a, b) =>
+      a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+    );
+    for (const entry of entries) {
+      const full = path.join(root, entry.name);
+      if (entry.isDirectory()) out.push(...tsFilesUnder(full, `${prefix}${entry.name}/`));
+      else if (entry.isFile() && entry.name.endsWith('.ts')) {
+        out.push({ file: `${prefix}${entry.name}`, full });
+      }
+    }
+    return out;
+  };
+
+  /** Every grant call under `root`, each tagged with the relative file it came
+   *  from. Takes a directory rather than closing over `dir`, so the fixture
+   *  case below drives the exact scanner the sweep uses, not a restatement. */
+  const grantSitesUnder = (root: string): Array<{ file: string; call: string }> =>
+    tsFilesUnder(root).flatMap(({ file, full }) =>
+      grantCalls(codeOnly(readFileSync(full, 'utf8'))).map((call) => ({
+        file,
+        call: flatten(call),
+      })),
+    );
+
   /** The brace-balanced body of the named top-level function in `source`. */
   const functionBody = (source: string, signature: string): string => {
     const at = source.indexOf(signature);
@@ -500,32 +568,42 @@ describe('every professions grant site is accounted for (#2430)', () => {
     'export function harvestCorpse(',
   );
 
-  // Whitespace-normalized ONCE, here, so every pin below reads the same shape.
-  // The two sweeps used to disagree: one matched `callerLogs: true` on raw
-  // call text and the other normalized first, so a formatter that wrapped an
-  // opts object between a key and its value would have blinded one of them
-  // (in the safe direction, but for a reason nobody could see from the
-  // assertion). Comments are already gone by this point (codeOnly above).
-  const flatten = (call: string) => call.replace(/\s+/g, ' ');
-  const sites = [
-    ...readdirSync(dir)
-      .filter((f) => f.endsWith('.ts'))
-      .flatMap((file) =>
-        grantCalls(codeOnly(readFileSync(path.join(dir, file), 'utf8'))).map((call) => ({
-          file,
-          call: flatten(call),
-        })),
-      ),
+  type GrantSite = { file: string; call: string };
+
+  const sites: GrantSite[] = [
+    ...grantSitesUnder(dir),
     ...grantCalls(harvestBody).map((call) => ({
       file: 'interaction.ts:harvestCorpse',
       call: flatten(call),
     })),
   ];
 
+  // The two rules the sweeps below enforce, as functions of a site list, so the
+  // recursion case can put a nested grant to the REAL predicates rather than to
+  // a restatement of them that could drift out of agreement with these.
+  const grantsKeepingTheHubLine = (all: GrantSite[]): GrantSite[] =>
+    all.filter(
+      (s) =>
+        !s.call.includes('callerLogs: true') &&
+        !NO_RESULT_EVENT_GRANTS.some((marker) => s.call.includes(marker)),
+    );
+  const grantsKeepingTheHubCue = (all: GrantSite[]): GrantSite[] =>
+    all.filter((s) => s.call.includes('callerLogs: true') && !s.call.includes('silent: true'));
+
+  const describeSites = (all: GrantSite[]): string[] => all.map((s) => `${s.file}: ${s.call}`);
+
   it('the scanner actually finds the grant sites (never passes vacuously)', () => {
     // A regex that stopped matching would make the sweep below green while
-    // checking nothing, so bind both the count and the shape.
-    expect(sites.length).toBeGreaterThanOrEqual(19);
+    // checking nothing, so bind both the count and the shape. Per FILE, not as
+    // one total: the floor this replaces (>= 19, against a real 22) left slack
+    // for up to three sites to leave the sweep unnoticed, and a module split
+    // into a subdirectory takes its whole file's worth out at once (#2485).
+    const byFile: Record<string, number> = {};
+    for (const site of sites) byFile[site.file] = (byFile[site.file] ?? 0) + 1;
+    expect(
+      byFile,
+      'grant sites per file: a NEW grant sets silent + callerLogs (or joins NO_RESULT_EVENT_GRANTS), and THEN bumps its number here; a number that dropped means a grant left the sweep',
+    ).toEqual(EXPECTED_GRANT_SITES);
     // Bound to the CALL and to its identity, not just the file: `.some(file ===
     // ...)` alone stays green if commission.ts keeps some other grant while the
     // unbind peel moves out of src/sim/professions and off the sweep entirely,
@@ -554,13 +632,13 @@ describe('every professions grant site is accounted for (#2430)', () => {
     const harvestSites = sites.filter((s) => s.file === 'interaction.ts:harvestCorpse');
     expect(harvestSites).toHaveLength(6);
     // BOTH flags. The shared cue sweep below now asks for `silent` everywhere
-    // too (#2458 retired the one site that owned the line without the cue), so
-    // this is no longer the only place `silent` is checked. It stays because it
-    // binds what the shared sweep cannot: the COUNT, six, and with it the
-    // harvestCorpse slice itself. One harvest command grants several DISTINCT
-    // items, so a site that kept `callerLogs` but lost `silent` would give one
-    // harvest several cues rather than one stray ding (#2457 acceptance
-    // criterion 3).
+    // too (#2458 retired the one site that owned the line without the cue), and
+    // EXPECTED_GRANT_SITES now carries the count of six as well, so neither is
+    // this pin's alone any more. It stays because the count belongs HERE, next
+    // to the boundary checks it interprets: six is what says the slice found
+    // the whole function. One harvest command grants several DISTINCT items, so
+    // a site that kept `callerLogs` but lost `silent` would give one harvest
+    // several cues rather than one stray ding (#2457 acceptance criterion 3).
     for (const site of harvestSites) {
       expect(site.call, site.call).toContain('silent: true');
       expect(site.call, site.call).toContain('callerLogs: true');
@@ -573,13 +651,8 @@ describe('every professions grant site is accounted for (#2430)', () => {
   });
 
   it('every grant either stands its hub line down or is a named no-result-event grant', () => {
-    const unaccounted = sites.filter(
-      (s) =>
-        !s.call.includes('callerLogs: true') &&
-        !NO_RESULT_EVENT_GRANTS.some((marker) => s.call.includes(marker)),
-    );
     expect(
-      unaccounted.map((s) => `${s.file}: ${s.call}`),
+      describeSites(grantsKeepingTheHubLine(sites)),
       'a professions grant that neither sets callerLogs nor is a documented no-result-event grant',
     ).toEqual([]);
   });
@@ -600,13 +673,58 @@ describe('every professions grant site is accounted for (#2430)', () => {
     // the same item) was invisible only because commission-eligible kinds all
     // stack one per slot today. This is the forward guard for the day one does
     // not: the same grant reached by a different route must sound the same.
-    const lineOnlySites = sites.filter(
-      (s) => s.call.includes('callerLogs: true') && !s.call.includes('silent: true'),
-    );
     expect(
-      lineOnlySites.map((s) => `${s.file}: ${s.call}`),
+      describeSites(grantsKeepingTheHubCue(sites)),
       'a professions grant that elides the hub line but still plays the generic hub ding',
     ).toEqual([]);
+  });
+
+  it('the scan descends, so a grant in a SUBDIRECTORY faces both sweeps (#2485)', () => {
+    // src/sim/professions is flat today, so nothing above can tell a recursive
+    // walk from the single-level one it replaces: both sweeps would go on
+    // passing if the walk quietly stopped at the top level again, while a
+    // module split into a folder took its grants out of coverage. Drive the
+    // real scanner over a fixture tree instead, and put its nested grants to
+    // the real predicates, so the recursion is pinned rather than eyeballed.
+    const fixture = mkdtempSync(path.join(tmpdir(), 'woc-grant-scan-'));
+    try {
+      mkdirSync(path.join(fixture, 'nested', 'deeper'), { recursive: true });
+      writeFileSync(
+        path.join(fixture, 'top.ts'),
+        'ctx.addItem(itemId, 1, pid, { silent: true, callerLogs: true });\n',
+      );
+      // One nested violation per sweep: a bare grant (keeps the hub LINE) and a
+      // line-only grant (keeps the hub CUE, the #2458 half). One file each, so a
+      // walk that descended but mislabeled would show up as a wrong file name.
+      writeFileSync(
+        path.join(fixture, 'nested', 'bare.ts'),
+        'ctx.addItemInstance(itemId, payload, pid);\n',
+      );
+      writeFileSync(
+        path.join(fixture, 'nested', 'deeper', 'line_only.ts'),
+        'ctx.addItem(itemId, 1, pid, {\n  callerLogs: true,\n});\n',
+      );
+
+      const found = grantSitesUnder(fixture);
+      // Discovered at every depth, labeled by relative path with forward
+      // slashes: bare names would collide across subdirectories, and a label
+      // that dropped the directory would make EXPECTED_GRANT_SITES ambiguous.
+      expect(found.map((s) => s.file)).toEqual([
+        'nested/bare.ts',
+        'nested/deeper/line_only.ts',
+        'top.ts',
+      ]);
+      // ... and both sweeps really do fire on them.
+      expect(grantsKeepingTheHubLine(found).map((s) => s.file)).toEqual(['nested/bare.ts']);
+      expect(grantsKeepingTheHubCue(found).map((s) => s.file)).toEqual([
+        'nested/deeper/line_only.ts',
+      ]);
+      // The flagged top-level grant is the negative control: the sweeps clear
+      // it, so a predicate that flagged everything could not fake this case.
+      expect(found.find((s) => s.file === 'top.ts')?.call).toContain('callerLogs: true');
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
   });
 
   it('the exclusion list has no stale entries', () => {


### PR DESCRIPTION
## Summary

`tests/professions_silent_loot.test.ts` enumerated every professions grant site by reading
`src/sim/professions/` one directory deep. The day that directory grows a subdirectory, every
`ctx.addItem` / `ctx.addItemInstance` inside it leaves the sweep, and the file stays green while
covering less than it did the day before. Two guards ride on that site list and would go quiet
together: the `callerLogs` hub-line sweep (#2430) and the `silent` hub-cue sweep (#2458), the
latter deliberately having no exclusion list precisely so a new site cannot pass without making a
choice.

The site-count assertion could not catch it either: `sites.length >= 19` against a real 22 left
room for a small module to move into a folder and be absorbed.

This is test-only. No production code changes.

What changed:

- The walk descends. Each site is labeled by its path relative to the professions root, joined
  with forward slashes, so a top-level file keeps its bare name (`commission.ts`, `salvage.ts`)
  and the existing per-file pins go on resolving unchanged. Entries are sorted by name, so the
  label list is the same on the ext4 CI runner as on an APFS dev checkout. The label idiom is the
  one in `tests/i18n_admin_catalog.test.ts`, which recursed for the same reason.
- The floor becomes a per-file count map (`EXPECTED_GRANT_SITES`, 22 sites across 7 labels), so a
  grant that disappears or relocates reads as a diff instead of being absorbed by slack. The
  failure message names the obligation: set both flags (or join `NO_RESULT_EVENT_GRANTS`), then
  bump the number.
- The two sweep rules are now named predicates, so the new case can put a nested grant to the
  real predicates rather than to a restatement of them.
- A new case, `the scan descends, so a grant in a SUBDIRECTORY faces both sweeps (#2485)`, drives
  the real scanner over a `mkdtemp` fixture tree and puts its grants to the real predicates, so
  the recursion is guarded permanently rather than checked by hand once. The tree carries a bare
  grant one level down, a line-only grant three levels down, a documented no-result-event grant, a
  grant whose flag exists only as a comment inside its own parentheses, a fully flagged top-level
  grant, and a `notes.md` full of grant-shaped prose. The label assertion is exact and ordered on
  purpose: it covers the label scheme, the extension filter, and the name sort that keeps the ext4
  CI runner agreeing with an APFS dev checkout.
- Two helpers that had no teeth now have them. `codeOnly` and `flatten` were both deletable with
  everything green, because no real call exercises either (no swept comment holds a flag, and no
  swept call splits one across lines). The fixture now exercises both.
- One more case pins that this file owns exactly one directory read. Nothing else can: the
  professions root is flat, so a second, flat producer would return the identical list today and
  every other assertion would stay green.

The comment block also drops a claim it can no longer make: recursion widens which files are read,
not which call shapes are recognized. A grant routed through a destructured `const { addItem } =
ctx` or a module-local helper still contributes no row. Nothing in `src/sim/professions` does that
today.

## Related issues

Closes #2485.

## Type of change

- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/professions_silent_loot.test.ts` (23 passed, was 21)
  - `npm run gate` (green)
- Every new pin was mutation-checked, not eyeballed. Each of these turns the suite red on its
  own, and nothing else in the file catches them: no recursion, a depth cap, a dropped path
  prefix, `codeOnly` as the identity, `flatten` as the identity, the exclusion conjunct forced
  true, an `isFile()`-only extension filter, and a second flat directory read added beside the
  walker.
- Manual steps (the issue's acceptance criterion 2, done for real and reverted):
  - Added `src/sim/professions/probe_subdir/probe.ts` with a flag-free `ctx.addItem(...)`. The
    suite went red on two cases, naming `probe_subdir/probe.ts`: the per-file count map and the
    hub-line sweep.
  - Changed the same probe to `{ callerLogs: true }` only. The suite went red on the hub-cue
    sweep (#2458), again naming the nested path.
  - Ran the pre-change single-level scanner over the same tree: it still reported 16 professions
    sites and never saw the probe, so the recursion is what catches it.
  - Deleted the probe directory; the suite is green again.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [x] N/A. Test-only change with no UI surface. The walk builds its labels with forward slashes
      explicitly rather than relying on the platform separator, so a nested label is identical on
      Windows.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
