### PR TITLE
fix(sim): grant the rolled quantity on a signed corpse-harvest yield

### DIFF
--- a/docs/design/professions.md
+++ b/docs/design/professions.md
@@ -70,7 +70,9 @@ vein, ancient heartwood, moonlit bloom) on ONE shared cadence knob
 the overworld zone via `emitToZonePlayers`. Corpse harvesting grants ALL
 plain yields before any signed instance, specimens last, with rarity draws
 staying in the first loop in yield order (`harvestCorpse`,
-`src/sim/interaction.ts`; the draw order is golden-pinned). The premium arm
+`src/sim/interaction.ts`; the draw order is pinned by the corpse suites' own
+draw-count cases, not by the parity goldens, which drive no corpse harvest).
+The premium arm
 gates on `MONSTER_MATERIAL_TIERS` (every wave-one family is tier 1, so the
 gate is live but never fires yet). One interact press loots AND harvests an
 eligible corpse, client-composed with no new wire command
@@ -166,7 +168,11 @@ merge-aware `canGrantItemInstance` gate; a signed instance merges only into
 a byte-equal same-signer stack, never a plain one); with neither, the grant
 falls back to the unsigned fungible top-up (the signature truncates, the
 yield does not; pinned in `tests/gather_node_harvest.test.ts` and the corpse
-suites). Mail attachments expire after
+suites). That room is measured against the WHOLE grant rather than one copy,
+because a corpse signed component carries its rolled quantity: room for one
+unit of three refuses outright instead of spilling the remainder past
+capacity. A gathering node differs on purpose and lands a partial fit, since
+it has no reserved plain fallback to catch the rest. Mail attachments expire after
 `MAIL_ATTACHMENT_EXPIRY_SECONDS` with exactly one return-to-sender cycle
 (system and work-order mail exempt). A character rename re-keys market and
 mail but sweeps only the renamed character's own blob for instance signers
@@ -371,9 +377,12 @@ the lever is material quantities per craft.
 - Sim purity and 20 Hz determinism everywhere; all randomness through
   `ctx.rng`. Draw-count contracts are golden-pinned: gathering draws exactly
   2 per granted harvest and 0 on denial; fishing draws 1 hidden delay per
-  cast plus 1 table draw per landed reel; corpse rarity draws stay in the
-  first grant loop in yield order; unbind draws none. Any change near these
-  paths re-verifies against `tests/parity/` before touching goldens.
+  cast plus 1 table draw per landed reel; unbind draws none. The corpse rule,
+  that rarity draws stay in the first grant loop in yield order, is pinned by
+  the draw-count cases in the corpse suites instead: no parity scenario
+  harvests a corpse, so a green parity run says nothing about that path. Any
+  change near these paths re-verifies against `tests/parity/` before touching
+  goldens.
 - Adding any static NPC shifts the world-ctor entity-id counter and moves
   parity goldens: regenerate deliberately (UPDATE_PARITY=1) in its own
   reviewed commit, never hand-edit.

--- a/src/sim/bags.ts
+++ b/src/sim/bags.ts
@@ -121,20 +121,29 @@ export function countFit(
   return Math.min(count, room);
 }
 
-/** True when ONE copy of an instanced grant fits: room in a byte-equal
- *  mergeable stack (identical-payload stacking) OR a free slot.
- *  The signed-grant guards (corpse focus-harvest, node harvest) consume this
- *  so a slot-full bag holding a same-payload stack with room keeps the
+/** True when ALL `count` copies of an instanced grant fit (one by default):
+ *  room in a byte-equal mergeable stack (identical-payload stacking) plus free
+ *  slots. The corpse focus-harvest signed guards consume this (harvestNode's
+ *  signed batch reads countFit directly for the same model) so a slot-full bag
+ *  holding a same-payload stack with room keeps the
  *  signature instead of downgrading to the plain fungible fallback (#2139:
  *  every capacity pre-check must model the merge identically, or a guard
- *  that disagrees with addStacked re-opens the overflow class). */
+ *  that disagrees with addStacked re-opens the overflow class). Counting the
+ *  WHOLE grant is what keeps that promise for a multi-unit signed yield
+ *  (#2473): a stack with room for one of three units must refuse, or the
+ *  remaining two push a fresh slot past capacity. The plain twin is
+ *  canAddItem, same all-or-nothing shape. A `count` of 0 answers true (nothing
+ *  is always grantable) and addItemInstance early-returns on it, so a caller
+ *  that can legitimately reach 0 owns that check itself; no shipped grant can
+ *  (a harvest quantity floors at 1). */
 export function canGrantItemInstance(
   inventory: readonly InvSlot[],
   capacity: number,
   itemId: string,
   instance: ItemInstancePayload,
+  count = 1,
 ): boolean {
-  return countFit(inventory, capacity, itemId, 1, instance) >= 1;
+  return countFit(inventory, capacity, itemId, count, instance) >= count;
 }
 
 /** True when all `count` copies fit. */

--- a/src/sim/interaction.ts
+++ b/src/sim/interaction.ts
@@ -322,7 +322,9 @@ export function harvestCorpse(
   // the slot reserved for a LATER family's plain stack and push the uncapped
   // plain grant past capacity). The rarity rolls stay in this first loop, in
   // yield order, so the draw sequence is byte-identical to the single-pass
-  // shape (pinned by the parity goldens); only the grants are reordered.
+  // shape (pinned by the draw-count cases in tests/corpse_harvest_sim.test.ts
+  // and tests/corpse_harvest_result_event.test.ts, NOT by the parity goldens:
+  // no parity scenario drives harvestCorpse); only the grants are reordered.
   // `rarity` rides along purely so the deferred grants below can record their
   // ledger entry with the roll that produced them (#2457): the line color is
   // the ROLLED material rarity, and by the time a signed grant lands its own
@@ -345,7 +347,9 @@ export function harvestCorpse(
     const qty = focusedHarvestQuantity(tier, y.component, meta.townFocus);
     const rarity = rollCorpseMaterialRarity(ctx.rng);
     // The rarity roll above MUST stay exactly where it is (one roll per yield,
-    // in yield order: the draw sequence is pinned by the parity goldens). The
+    // in yield order: the draw sequence is pinned by the corpse suites' own
+    // draw-count cases, one per arm, since no parity scenario harvests a
+    // corpse). The
     // premium-arm denial below happens strictly AFTER the roll and
     // draws no rng: a denied family downgrades to the plain fungible grant it
     // gets on a common roll today (a specimen family keeps its plain component
@@ -387,29 +391,74 @@ export function harvestCorpse(
   // pre-gate-reserved stack room, so they outrank the specimens, which are
   // pure extras. A signed instance merges into a byte-equal same-signer stack
   // (identical-payload stacking; never a plain stack, #1165), so
-  // this gate accepts same-signer stack room OR a genuinely free slot
+  // this gate accepts same-signer stack room plus genuinely free slots
   // (canGrantItemInstance, the countFit model harvestNode's signed grants
-  // share, #2139); with neither the signed-family grant falls back to the
+  // share, #2139), measured against the FULL grant: one unit for a specimen,
+  // the whole rolled quantity for a signed component (#2473). Without room for
+  // all of it the signed-family grant falls back to the
   // plain fungible top-up (the signature truncates, the yield does not) while
   // a specimen truncates outright, the same truncation contract harvestNode's
   // signed grants follow. Each downgrade tells the player via the text-free
   // personal gatherDowngrade event, at most ONCE per harvest command (the
   // toolDeniedEmitted idiom); the mark-lost arm runs first, so when both a
   // signature and a jackpot are lost the single event reports the mark.
+  // All-or-nothing is a deliberate divergence from harvestNode, whose signed
+  // batch lands a PARTIAL fit and lets the rest of the yield go: a corpse
+  // downgrade is an UNCAPPED plain grant of the whole rolled quantity into
+  // pre-gate-reserved room, so refusing the signature here costs the player no
+  // units and keeps the harvest at one ledger entry (one chat line) per item.
+  //
+  // #2473, the one behavior this quantity fix trades away, deliberately: with
+  // PARTIAL same-signer merge room the counted grant spills into a fresh slot
+  // where the one-unit grant it replaces merged for free, so on a corpse that
+  // also procs a specimen (forest_wolf tags hide AND fang) the last free slot
+  // can go to the component instead of the jackpot, which then truncates with
+  // its lost: 'find' notice. The component wins that slot for one reason only,
+  // stated plainly because it is easy to get wrong: this loop runs FIRST. It is
+  // NOT holding a claim on the slot. The pre-gate reserves room for a PLAIN add
+  // (every `wanted` entry carries no instance) and a signed instance can never
+  // spend plain-stack room (#1165), so the free slot taken here is unreserved
+  // room, the same unreserved room the specimen wanted.
+  // Refusing the signature whenever a jackpot is pending was measured across
+  // corpse templates, bag shapes, seeds and focus picks: it saves the specimen
+  // in every case that truncates and costs no yield, but it refuses tens of
+  // signatures for each specimen saved, because most bags have plain-stack room
+  // the fallback would have used anyway. Paying that much for a rare extra is
+  // the worse trade, so the simple rule stands. BOTH states are pinned in
+  // tests/corpse_harvest_sim.test.ts: the one where holding back would change
+  // nothing, and the one where it would have saved the jackpot. The real cure
+  // is a specimen reservation in the pre-gate, wider than this issue.
   let downgradeEmitted = false;
   for (const grant of signedGrants) {
     if (grant.specimen) continue;
     const payload = { signer: meta.name };
-    if (canGrantItemInstance(meta.inventory, bagCapacity(meta.bags), grant.itemId, payload)) {
-      // The explicit count 1 is the shipped default spelled out so the opts
-      // argument can follow it; the units granted are unchanged.
-      ctx.addItemInstance(grant.itemId, payload, meta.entityId, 1, {
+    if (
+      canGrantItemInstance(
+        meta.inventory,
+        bagCapacity(meta.bags),
+        grant.itemId,
+        payload,
+        grant.plainQty,
+      )
+    ) {
+      // The whole rolled quantity, stamped (#2473): on a specimen-less family
+      // the component ITSELF is the signed grant, so the signature and the
+      // yield ride one call and a hardcoded count of 1 dropped the rest of the
+      // roll on the floor, leaving the premium arm smaller than the plain
+      // fallback right below it. The guard counts the WHOLE quantity for the
+      // same reason (#2139): a same-signer stack with room for one of three
+      // units must refuse rather than let the other two push a fresh slot past
+      // capacity. Mergeable signer payloads stack, so the whole roll costs at
+      // most ONE slot; that is one more than the single-unit grant it replaces
+      // spent whenever partial merge room let that one unit land for free,
+      // which is what the jackpot hold-back above accounts for.
+      ctx.addItemInstance(grant.itemId, payload, meta.entityId, grant.plainQty, {
         silent: true,
         callerLogs: true,
       });
       recordHarvestYield(granted, {
         itemId: grant.itemId,
-        qty: 1,
+        qty: grant.plainQty,
         rarity: grant.rarity,
         kind: 'signed',
       });
@@ -434,7 +483,9 @@ export function harvestCorpse(
     if (!grant.specimen) continue;
     const payload = { signer: meta.name };
     if (canGrantItemInstance(meta.inventory, bagCapacity(meta.bags), grant.itemId, payload)) {
-      // Explicit count 1 for the opts argument, see the matching call above.
+      // Exactly one unit, deliberately: the specimen is a jackpot, not a
+      // quantity, so it never carries the component's rolled count the way the
+      // signed grant above does. The guard's count defaults to that same 1.
       ctx.addItemInstance(grant.itemId, payload, meta.entityId, 1, {
         silent: true,
         callerLogs: true,

--- a/src/sim/professions/CLAUDE.md
+++ b/src/sim/professions/CLAUDE.md
@@ -120,7 +120,13 @@ hosts, plus the pinned callback-name list in `tests/sim_context.test.ts`.
   signed instance merges only into a byte-equal same-signer stack, never a
   plain one); with neither it falls back to the unsigned fungible top-up
   (the signature truncates, the yield does not; pinned in
-  `tests/gather_node_harvest.test.ts`).
+  `tests/gather_node_harvest.test.ts`). The room is measured against the WHOLE
+  grant, not one copy: a corpse signed component carries its rolled quantity
+  (#2473), so a stack with room for one of three units refuses rather than
+  spilling the rest past capacity (#2139). All-or-nothing there, deliberately
+  unlike `harvestNode`, whose signed batch lands a PARTIAL fit: a corpse
+  downgrade is an uncapped plain grant of the full roll, so refusing costs no
+  yield. Pinned on both sides of the boundary in `tests/corpse_harvest_sim.test.ts`.
 - The economy invariant: no recipe vendors above its input value, enforced
   for EVERY recipe by `tests/recipe_economy.test.ts` (the exception list is
   empty). Author new recipes against it; the full economy model lives in

--- a/tests/bags.test.ts
+++ b/tests/bags.test.ts
@@ -8,6 +8,7 @@ import {
   BAG_SOCKETS,
   bagCapacity,
   canAddItem,
+  canGrantItemInstance,
   consumeOneScratch,
   countFit,
   fitsAll,
@@ -114,6 +115,25 @@ describe('stack sizes and stacking math', () => {
     expect(inv[0].count).toBe(20);
     // At the cap the full stack offers zero room and a fresh add needs a slot.
     expect(countFit(inv, 1, 'baked_bread', 1, { signer: 'Ana' })).toBe(0);
+  });
+
+  it('canGrantItemInstance is all-or-nothing across the whole requested count (#2473)', () => {
+    // The signed-grant guard the corpse harvest reads. Its default is one copy,
+    // but a multi-unit signed yield must ask about ALL its units: a slot-full
+    // bag whose same-signer stack has room for one of three has to refuse, or
+    // the other two push a fresh slot past capacity (#2139, the class this
+    // guard exists to close).
+    const signer = { signer: 'Ana' };
+    const inv: InvSlot[] = [{ itemId: 'baked_bread', count: 19, instance: { signer: 'Ana' } }];
+    // Capacity 1: zero free slots, exactly one unit of merge room.
+    expect(canGrantItemInstance(inv, 1, 'baked_bread', signer)).toBe(true);
+    expect(canGrantItemInstance(inv, 1, 'baked_bread', signer, 1)).toBe(true);
+    expect(canGrantItemInstance(inv, 1, 'baked_bread', signer, 2)).toBe(false);
+    expect(canGrantItemInstance(inv, 1, 'baked_bread', signer, 3)).toBe(false);
+    // One free slot absorbs a whole fresh stack, so the same counts now pass.
+    expect(canGrantItemInstance(inv, 2, 'baked_bread', signer, 3)).toBe(true);
+    // A differently-signed grant sees neither the merge room nor a shortcut.
+    expect(canGrantItemInstance(inv, 1, 'baked_bread', { signer: 'Bru' }, 1)).toBe(false);
   });
 
   it('a charge-bearing payload gets one unit per fresh slot and never tops up its twin', () => {

--- a/tests/corpse_harvest_result_event.test.ts
+++ b/tests/corpse_harvest_result_event.test.ts
@@ -177,16 +177,32 @@ describe('one harvestResult per harvest command (#2457)', () => {
     // signed row's fang lands as an instance.
     expect(arms[0].loots).toHaveLength(2);
     expect(arms[2].loots).toHaveLength(3);
+    // The signed row's multi-unit grant is ONE batched call, so it is one loot
+    // event and one cue (#2473). A regression that looped the grant per unit
+    // would keep the site-count sweep in tests/professions_silent_loot.test.ts
+    // green while quietly firing a burst here.
+    expect(arms[1].loots).toHaveLength(2);
   });
 
   it('reports quantities that match what actually landed in the bags', () => {
     // A ledger that drifted from the grants would print a line for units the
     // player never received. Checked against the inventory, not the roll.
-    const { sim, a, mob } = setup(3);
-    const { results } = harvest(sim, mob.id, undefined, a);
-    for (const y of results[0].yields) {
-      expect(sim.countItem(y.itemId, a)).toBe(y.qty);
+    // Driven on the plain roll AND on the signed arm, whose entry carries the
+    // rolled quantity of its own (#2473): a count passed to addItemInstance
+    // that disagreed with the recorded one would otherwise go unseen.
+    const seen: HarvestResultEvent['yields'] = [];
+    for (const seed of [3, 30]) {
+      const { sim, a, mob } = setup(seed);
+      const { results } = harvest(sim, mob.id, undefined, a);
+      expect(results[0].yields.length, `seed ${seed}`).toBeGreaterThan(0);
+      for (const y of results[0].yields) {
+        expect(sim.countItem(y.itemId, a), `seed ${seed} ${y.itemId}`).toBe(y.qty);
+        seen.push(y);
+      }
     }
+    // Never vacuous on the arm this case was widened for: seed 30 must really
+    // have reached the multi-unit signed grant.
+    expect(seen.some((y) => y.kind === 'signed' && y.qty > 1)).toBe(true);
   });
 
   it('adds no rng draw: the event is composed from grants that already happened', () => {
@@ -222,7 +238,9 @@ describe('the four grant arms each report themselves (#2457)', () => {
     const { results } = harvest(sim, mob.id, undefined, a);
     expect(results[0].yields).toEqual([
       { itemId: 'rough_hide', qty: 1, rarity: 'common', kind: 'plain' },
-      { itemId: 'wolf_fang', qty: 1, rarity: 'rare', kind: 'signed' },
+      // The signed entry carries the roll's own quantity (#2473), which is what
+      // makes the client's quantity key reachable on this arm at all.
+      { itemId: 'wolf_fang', qty: 4, rarity: 'rare', kind: 'signed' },
     ]);
     // The arm identity: a signed instance really did land, stamped with the
     // harvester's name, so 'signed' is not just a label on a plain grant.
@@ -253,7 +271,9 @@ describe('the four grant arms each report themselves (#2457)', () => {
     const { results } = harvest(sim, mob.id, undefined, a);
     expect(results[0].yields).toEqual([
       { itemId: 'rough_hide', qty: 2, rarity: 'rare', kind: 'plain' },
-      { itemId: 'wolf_fang', qty: 1, rarity: 'rare', kind: 'signed' },
+      { itemId: 'wolf_fang', qty: 2, rarity: 'rare', kind: 'signed' },
+      // The specimen stays exactly one whatever the component rolled (#2473):
+      // it is a jackpot, not a quantity.
       { itemId: 'pristine_hide', qty: 1, rarity: 'rare', kind: 'specimen' },
     ]);
   });

--- a/tests/corpse_harvest_sim.test.ts
+++ b/tests/corpse_harvest_sim.test.ts
@@ -336,7 +336,8 @@ describe('signed Pristine specimens (#1145)', () => {
     const slot = meta.inventory.find((s) => s.itemId === 'wolf_fang');
     expect(slot).toBeDefined();
     expect(slot?.instance?.signer).toBe('Alpha');
-    expect(sim.countItem('wolf_fang', a)).toBe(1);
+    // The whole rolled quantity, stamped (#2473), not a single token unit.
+    expect(sim.countItem('wolf_fang', a)).toBe(3);
   });
 
   it('every other specimen family grants its own jackpot beside the plain component (seed 5)', () => {
@@ -395,7 +396,10 @@ describe('signed Pristine specimens (#1145)', () => {
     const slot = meta.inventory.find((s) => s.itemId === 'homespun_cloth');
     expect(slot).toBeDefined();
     expect(slot?.instance?.signer).toBe('Alpha');
-    expect(sim.countItem('homespun_cloth', a)).toBe(1);
+    // This corpse's own rolled quantity (#2473): the bandit's cloth tier rolls
+    // two where the wolf's fang rolls three at the same seed, so the count
+    // tracks the ROLL rather than any constant the arm could hardcode.
+    expect(sim.countItem('homespun_cloth', a)).toBe(2);
   });
 
   it('a slot-full signed-family harvest falls back to the plain stack, never over capacity (seed 5)', () => {
@@ -627,12 +631,14 @@ describe('corpse signed-guard capacity vs merge room (#2139)', () => {
     sim.drainEvents();
     sim.harvestCorpse(mob.id, ['fang'], a);
     expect(mob.harvestClaimedBy).toBe(a);
-    // The signed grant merged into the same-signer stack: one unit, no new
-    // slot, no overflow, and the plain stack was never topped up.
+    // The signed grant merged into the same-signer stack: no new slot, no
+    // overflow, and the plain stack was never topped up. The stack absorbs the
+    // whole three-unit roll (#2473) because seventeen units of merge room
+    // cover it; the partial-room case is its own pin below.
     expect(m.inventory.length).toBe(cap);
     const signed = m.inventory.find((s) => s.itemId === 'wolf_fang' && s.instance);
     expect(signed?.instance?.signer).toBe('Alpha');
-    expect(signed?.count).toBe(4);
+    expect(signed?.count).toBe(6);
     const plain = m.inventory.find((s) => s.itemId === 'wolf_fang' && !s.instance);
     expect(plain?.count).toBe(1);
     // The signature survived: no downgrade notice fires.
@@ -686,6 +692,239 @@ describe('corpse signed-guard capacity vs merge room (#2139)', () => {
     // The plain component still arrived through its reserved top-up room.
     expect(sim.countItem('rough_hide', a)).toBeGreaterThan(1);
     expect(sim.drainEvents().filter((e) => e.type === 'gatherDowngrade')).toHaveLength(0);
+  });
+});
+
+// #2473: on a specimen-less family the component ITSELF is the signed grant,
+// so the signature and the yield ride one call. That call used to pass a
+// hardcoded count of 1 while the downgrade fallback right beneath it granted
+// the whole rolled quantity, so a rare roll was a yield LOSS and a fuller bag
+// was a yield GAIN. The premium arm must never be the smaller grant: it lands
+// the rolled quantity signed, or it does not land signed at all.
+describe('a signed specimen-less grant carries its rolled quantity (#2473)', () => {
+  it('draws no rng of its own: the count comes from the tier roll already taken', () => {
+    // The draw pin ON the arm the change touched. The sibling cases in
+    // tests/corpse_harvest_result_event.test.ts cover the plain and specimen
+    // paths; a counted grant that re-rolled anything per unit would show up
+    // here as more than the one tier roll plus one rarity roll.
+    const { sim, a, mob } = setup(5);
+    let draws = 0;
+    sim.rng.setObserver(() => draws++);
+    try {
+      sim.harvestCorpse(mob.id, ['fang'], a);
+    } finally {
+      sim.rng.setObserver(null);
+    }
+    // Never vacuous: this seed really does reach the multi-unit signed arm.
+    expect(sim.countItem('wolf_fang', a)).toBe(3);
+    expect(draws).toBe(2);
+  });
+
+  it('grants exactly the units its own downgrade fallback would, signed (seed 5, fang)', () => {
+    // Same seed, same corpse, same roll: the ONLY difference between the two
+    // runs is whether the bags can hold the instance. Rolling rare must not
+    // cost the player units, so the two counts have to agree.
+    const roomy = setup(5);
+    roomy.sim.harvestCorpse(roomy.mob.id, ['fang'], roomy.a);
+    const signedSlot = roomy.internals.players
+      .get(roomy.a)!
+      .inventory.find((s) => s.itemId === 'wolf_fang');
+    // The premium arm really is the one under test: the units landed stamped.
+    expect(signedSlot?.instance?.signer).toBe('Alpha');
+    const signedQty = roomy.sim.countItem('wolf_fang', roomy.a);
+
+    const full = setup(5);
+    fillBags(full.sim, full.internals, full.a);
+    const m = full.internals.players.get(full.a)!;
+    m.inventory[0] = { itemId: 'wolf_fang', count: 1 };
+    expect(m.inventory.length).toBe(bagCapacity(m.bags));
+    full.sim.harvestCorpse(full.mob.id, ['fang'], full.a);
+    expect(m.inventory.some((s) => s.itemId === 'wolf_fang' && s.instance)).toBe(false);
+    // Minus the unit seeded into the partial stack the fallback tops up.
+    const downgradedQty = full.sim.countItem('wolf_fang', full.a) - 1;
+
+    expect(signedQty).toBe(downgradedQty);
+    // Bound to the roll's own tier quantity too, so a future change that made
+    // BOTH arms grant one unit could not pass the equality above alone.
+    expect(downgradedQty).toBe(3);
+  });
+
+  it('grants the whole rolled quantity into ONE signed slot, never a unit per slot (seed 5)', () => {
+    // A mergeable signer payload stacks (#1165), so three units are one slot,
+    // not three: the counted grant must not cost the player bag space that a
+    // plain grant of the same size would not.
+    const { sim, internals, a, mob } = setup(5);
+    const m = internals.players.get(a)!;
+    const before = m.inventory.length;
+    sim.drainEvents();
+    sim.harvestCorpse(mob.id, ['fang'], a);
+    const signed = m.inventory.filter((s) => s.itemId === 'wolf_fang');
+    expect(signed).toHaveLength(1);
+    expect(signed[0].count).toBe(3);
+    expect(m.inventory.length).toBe(before + 1);
+    // The slot's count is the ledger's count is the roll: bound to the event
+    // rather than to the literal alone, so a change that moved the grant and
+    // the report together could not pass by agreeing with itself.
+    const result = sim
+      .drainEvents()
+      .find((e): e is Extract<typeof e, { type: 'harvestResult' }> => e.type === 'harvestResult');
+    expect(result?.yields).toEqual([
+      { itemId: 'wolf_fang', qty: signed[0].count, rarity: 'rare', kind: 'signed' },
+    ]);
+  });
+
+  it('the cloth family carries its rolled quantity the same way (seed 5)', () => {
+    // The second specimen-less family, so the fix is the ARM's behavior and not
+    // a fang-shaped special case. Its roll is TWO where the fang above is
+    // three, which is what proves the count is read off the roll.
+    const { sim, internals, a } = setup(5);
+    const template = MOBS.vale_bandit;
+    const corpse = createMob(7775, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+    corpse.dead = true;
+    corpse.aiState = 'dead';
+    corpse.corpseTimer = 9999;
+    corpse.respawnTimer = 9999;
+    internals.entities.set(corpse.id, corpse);
+    sim.harvestCorpse(corpse.id, ['cloth'], a);
+    const slot = internals.players.get(a)!.inventory.find((s) => s.itemId === 'homespun_cloth');
+    expect(slot?.instance?.signer).toBe('Alpha');
+    expect(slot?.count).toBe(2);
+    // The two families really do land on different counts, so neither literal
+    // can be a constant the arm hardcoded.
+    const fang = setup(5);
+    fang.sim.harvestCorpse(fang.mob.id, ['fang'], fang.a);
+    expect(fang.sim.countItem('wolf_fang', fang.a)).not.toBe(slot?.count);
+  });
+
+  it('refuses the signature when only PART of the rolled quantity fits, never overflowing', () => {
+    // The state a "grant plainQty whenever ONE copy fits" fix would break, and
+    // the reason the guard counts the WHOLE quantity: zero free slots and a
+    // same-signer stack with room for exactly one unit LESS than the roll. Two
+    // units would merge and the third would push a fresh slot past capacity
+    // (#2139), so the grant takes the plain fallback and its mark-lost toast
+    // instead. The signature truncates, the yield does not: the same contract
+    // the zero-merge-room boundary above follows.
+    //
+    // Seeded ONE short of the roll on purpose. At any looser distance a guard
+    // that asked for `plainQty - 1` (or for a hardcoded 2) would refuse here
+    // too and the case could not tell it from the real one; at exactly
+    // plainQty - 1 that guard accepts, merges two, opens a slot, and overflows
+    // the bag to 17 of 16. The accept side of the same boundary is the case
+    // below.
+    const { sim, internals, a, mob } = setup(5);
+    fillBags(sim, internals, a);
+    const m = internals.players.get(a)!;
+    const cap = bagCapacity(m.bags);
+    const stack = stackSizeOf(ITEMS.wolf_fang);
+    m.inventory[0] = { itemId: 'wolf_fang', count: 1 };
+    m.inventory[1] = { itemId: 'wolf_fang', count: stack - 2, instance: { signer: 'Alpha' } };
+    expect(m.inventory.length).toBe(cap);
+    sim.drainEvents();
+    sim.harvestCorpse(mob.id, ['fang'], a);
+    expect(mob.harvestClaimedBy).toBe(a);
+    expect(m.inventory.length).toBe(cap);
+    // Untouched: a partially-landed signed grant is not a thing.
+    expect(m.inventory[1].count).toBe(stack - 2);
+    // The yield still arrived WHOLE, through the plain stack's reserved room.
+    expect(m.inventory[0].count).toBe(4);
+    expect(sim.drainEvents().filter((e) => e.type === 'gatherDowngrade')).toEqual([
+      { type: 'gatherDowngrade', pid: a, surface: 'corpse', lost: 'mark' },
+    ]);
+  });
+
+  it('takes the signature when the merge room EXACTLY covers the roll (seed 5)', () => {
+    // The accept side of the same boundary, one unit up from the case above:
+    // room for exactly three against a three-unit roll. A guard that asked for
+    // one unit more than the roll would refuse here and quietly cost players
+    // signatures they earned, which no other case in the suite can see.
+    const { sim, internals, a, mob } = setup(5);
+    fillBags(sim, internals, a);
+    const m = internals.players.get(a)!;
+    const cap = bagCapacity(m.bags);
+    const stack = stackSizeOf(ITEMS.wolf_fang);
+    m.inventory[0] = { itemId: 'wolf_fang', count: 1 };
+    m.inventory[1] = { itemId: 'wolf_fang', count: stack - 3, instance: { signer: 'Alpha' } };
+    expect(m.inventory.length).toBe(cap);
+    sim.drainEvents();
+    sim.harvestCorpse(mob.id, ['fang'], a);
+    expect(m.inventory.length).toBe(cap);
+    // The whole roll merged into the same-signer stack, filling it exactly.
+    expect(m.inventory[1].count).toBe(stack);
+    expect(m.inventory[1].instance?.signer).toBe('Alpha');
+    // The plain stack was never touched: the signature took the whole yield.
+    expect(m.inventory[0].count).toBe(1);
+    expect(sim.drainEvents().filter((e) => e.type === 'gatherDowngrade')).toHaveLength(0);
+  });
+
+  it('a partial-merge spill can cost a pending specimen its slot, deliberately (seed 11)', () => {
+    // The one behavior #2473 trades away, pinned so it stays a decision. With
+    // partial same-signer merge room the counted grant needs a fresh slot
+    // where the one-unit grant it replaced merged for free, so on a corpse
+    // that procs a specimen too the last free slot goes to the component and
+    // the jackpot truncates with its lost: 'find' notice. The component wins
+    // that slot because its loop runs first, not because it holds a claim on
+    // it: the pre-gate reserves PLAIN room, which a signed instance can never
+    // spend. THIS bag has no plain fang stack, so refusing the signature would
+    // route the fallback's uncapped addItem to the same slot and lose the mark
+    // for nothing. The sibling case below is the other half, where refusing
+    // WOULD have saved the jackpot and the trade is still taken.
+    const stack = stackSizeOf(ITEMS.wolf_fang);
+    const { sim, internals, a, mob } = setup(11);
+    const m = internals.players.get(a)!;
+    const cap = bagCapacity(m.bags);
+    // Exactly ONE free slot, and a same-signer fang stack one unit short of
+    // the roll, so the signed grant merges what it can and spills.
+    fillBags(sim, internals, a);
+    m.inventory[0] = { itemId: 'rough_hide', count: 14 };
+    m.inventory[1] = { itemId: 'wolf_fang', count: stack - 1, instance: { signer: 'Alpha' } };
+    m.inventory.pop();
+    expect(m.inventory.length).toBe(cap - 1);
+    sim.drainEvents();
+    sim.harvestCorpse(mob.id, undefined, a);
+    const events = sim.drainEvents();
+    // The signature landed whole, across the filled stack and the free slot.
+    expect(m.inventory.length).toBe(cap);
+    expect(sim.countItem('wolf_fang', a)).toBe(stack - 1 + 2);
+    expect(m.inventory.every((s) => s.itemId !== 'wolf_fang' || !!s.instance)).toBe(true);
+    // ... and the jackpot had nowhere left to go, so it truncated and said so.
+    expect(m.inventory.some((s) => s.itemId === 'pristine_hide')).toBe(false);
+    expect(events.filter((e) => e.type === 'gatherDowngrade')).toEqual([
+      { type: 'gatherDowngrade', pid: a, surface: 'corpse', lost: 'find' },
+    ]);
+  });
+
+  it('and it costs the specimen even when a plain stack could have taken the yield', () => {
+    // The refuting half of the case above, and the one the trade is actually
+    // argued on: the same spill, but with a PLAIN fang stack holding room for
+    // the whole roll. Refusing the signature here would have parked the yield
+    // in that stack for free and left the slot to the jackpot, so this is the
+    // state where holding back would genuinely have saved a Pristine Hide. It
+    // is still not held back, because a rule that refuses whenever a jackpot
+    // is pending costs tens of signatures for each specimen it saves. Pinning
+    // the losing side too, so the trade cannot be mistaken for an oversight.
+    const stack = stackSizeOf(ITEMS.wolf_fang);
+    const { sim, internals, a, mob } = setup(11);
+    const m = internals.players.get(a)!;
+    const cap = bagCapacity(m.bags);
+    fillBags(sim, internals, a);
+    m.inventory[0] = { itemId: 'rough_hide', count: 14 };
+    m.inventory[1] = { itemId: 'wolf_fang', count: 14 };
+    m.inventory[2] = { itemId: 'wolf_fang', count: stack - 1, instance: { signer: 'Alpha' } };
+    m.inventory.pop();
+    expect(m.inventory.length).toBe(cap - 1);
+    sim.drainEvents();
+    sim.harvestCorpse(mob.id, undefined, a);
+    const events = sim.drainEvents();
+    // The signature took the free slot: the plain stack it could have merged
+    // into on the downgrade arm is untouched.
+    expect(m.inventory.length).toBe(cap);
+    expect(m.inventory[1].count).toBe(14);
+    expect(m.inventory[2].count).toBe(stack);
+    // ... and the jackpot paid for it.
+    expect(m.inventory.some((s) => s.itemId === 'pristine_hide')).toBe(false);
+    expect(events.filter((e) => e.type === 'gatherDowngrade')).toEqual([
+      { type: 'gatherDowngrade', pid: a, surface: 'corpse', lost: 'find' },
+    ]);
   });
 });
 

--- a/tests/professions_single_line_grants.test.ts
+++ b/tests/professions_single_line_grants.test.ts
@@ -554,6 +554,24 @@ describe('a corpse harvest prints one line per DISTINCT granted item (#2457)', (
     expect(signed).toEqual([`You harvest: [${itemDisplayName(ITEMS[FANG])}].`]);
   });
 
+  it('a MULTI-UNIT signed component takes the quantity line, like its plain twin', () => {
+    // A signed corpse yield carries the roll's own quantity (#2473), so the
+    // signed-plus-quantity combination is reachable for the first time: before
+    // it, that arm could only ever land one unit. The ruling above is unchanged
+    // (a signed line reads exactly like a plain one), but the key choice now
+    // has to survive a count, and a line that dropped it would under-report
+    // what the player just received.
+    const hud = makeHud();
+    hud.handleEvents(harvestBurst([{ itemId: FANG, qty: 3, rarity: 'rare', kind: 'signed' }]));
+    const signed = lines(hud);
+    document.body.replaceChildren();
+    mountBags();
+    const plainHud = makeHud();
+    plainHud.handleEvents(harvestBurst([{ itemId: FANG, qty: 3, rarity: 'rare', kind: 'plain' }]));
+    expect(signed).toEqual(lines(plainHud));
+    expect(signed).toEqual([`You harvest: [${itemDisplayName(ITEMS[FANG])}] x3.`]);
+  });
+
   it('each line paints from its ROLLED rarity while the link paints from the item def', () => {
     // The gatherResult rule, and the arm no source-text pin can settle. Rough
     // Hide is a COMMON item granted at every roll, so a rare roll must color


### PR DESCRIPTION
## Summary

On a corpse-harvest family with no Pristine specimen (`fang`, `cloth`) the component
itself is the signed grant, so the signature and the yield ride one call. That call
passed a hardcoded count of 1 while the full-bag downgrade arm right beneath it granted
the whole rolled `plainQty`, so a rare-or-better roll was a yield LOSS and fuller bags
were a yield GAIN. On seed 5 with `['fang']`: one signed Cracked Wolf Fang with roomy
bags, three plain ones when the instance slot was refused.

The signed grant now carries the rolled quantity, stamped. A mergeable signer payload
stacks (#1165), so those units land in the same single slot the one-unit grant used.

Two things that came out of the fix and are worth calling out:

- **The capacity guard now counts the whole grant.** `canGrantItemInstance` asked
  whether ONE copy fits. Passing `plainQty` behind that gate re-opens the #2139 overflow
  class: with zero free slots and a same-signer stack with room for one of three units,
  one unit merges and the other two push a fresh slot past capacity. The guard takes a
  `count` (default 1, so the specimen arm is unchanged) and asks whether all of them fit,
  the same all-or-nothing shape its plain twin `canAddItem` already has.
- **All-or-nothing is a deliberate divergence from `harvestNode`**, whose signed batch
  lands a partial fit and drops the rest. A corpse downgrade is an uncapped plain grant of
  the full rolled quantity into pre-gate-reserved room, so refusing the signature costs
  the player no units and keeps the harvest at one ledger entry, and so one chat line, per
  item. A partial fit would need a split signed-plus-plain line for one component.

No rng draw moves or is added, the grant order is untouched, and the Pristine specimen
stays deliberately at one unit. Signed units sit outside the fungible pool (they cannot be
listed on the market or mailed, #1165), which is unchanged in kind by this fix: it is the
pre-existing meaning of the signature, now applied to the units that were previously
dropped rather than to one of them.

### One trade, pinned rather than left to chance

With partial same-signer merge room the counted grant needs a fresh slot where the one-unit
grant it replaces merged for free. On a corpse that also procs a specimen (`forest_wolf`
tags `hide` AND `fang`) that can hand the last free slot to the component, so the jackpot
truncates with its `lost: 'find'` notice. Measured on seed 11, not theorised.

The component wins that slot because its loop runs first, not because it has a claim on it:
the pre-gate reserves room for a PLAIN add, and a signed instance can never spend
plain-stack room (#1165), so the slot it takes is unreserved room the specimen wanted.

I implemented the alternative (hold those slots back whenever a jackpot is pending) and
measured it rather than guessing. It saves the specimen in every case that truncates and
costs no yield, but it refuses tens of signatures for each specimen it saves, because most
bags have plain-stack room the fallback would have used anyway. That is the worse trade, so
the simple rule stands. Curing it properly means reserving specimen room in the pre-gate,
which is wider than this issue.

Both states are pinned so this cannot be mistaken for an oversight: the bag where holding
back would change nothing, and the bag where it genuinely would have saved the Pristine
Hide. Easy to revisit if you want the other trade.

## Related issues

Closes #2473. Found while implementing #2457 (PR #2472).

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npm run gate` (green: i18n freshness, malware scan, biome on changed files, SFX
    conformance, full vitest suite, `tsc`, all five builds)
  - `npx vitest run tests/corpse_harvest_sim.test.ts tests/corpse_harvest_result_event.test.ts tests/bags.test.ts tests/professions_single_line_grants.test.ts`
- Manual steps: none beyond the suites. The change is server-authoritative sim math with
  no new player-visible string; the client's quantity line key (`harvestLineQty`) already
  covered a multi-unit yield and is now pinned on the signed arm through the real HUD.

New coverage:

- the premium arm against its OWN downgrade fallback on the same roll (seed 5, `fang`):
  same units either way, bound to the rolled tier quantity
- the whole quantity lands in ONE signed slot, not a slot per unit, with the slot count
  bound to the ledger entry so the two cannot drift together
- the `cloth` family, which rolls a different quantity at the same seed (asserted to
  differ), so the count is read off the roll rather than a constant
- both sides of the guard's boundary: merge room exactly ONE under the roll refuses and
  keeps the bag at capacity, merge room exactly AT the roll signs. Seeded at the boundary
  on purpose. A looser distance cannot tell `plainQty` from `plainQty - 1`, and I verified
  by mutation that `plainQty - 1` overflows the bag to 17 slots of 16 while the earlier,
  looser version of this test stayed green
- the specimen-truncation trade above (seed 11)
- one batched `loot` event for a multi-unit signed grant, so a per-unit-loop regression
  cannot fire a burst of cues
- a draw-count pin on the signed arm itself, where the "adds no rng" claim is made
- `canGrantItemInstance` as a unit, on both sides of the count boundary
- the newly reachable signed-plus-quantity chat line, on rendered text
- the ledger-versus-bags pin widened to the signed arm

Pins that recorded the one-unit behavior move with the fix (`corpse_harvest_sim` seeds 5,
`corpse_harvest_result_event` seeds 30 and 11).

Docs: the signing slot policy in `src/sim/professions/CLAUDE.md` and
`docs/design/professions.md` both stated the one-copy rule, so both now say the room is
measured against the whole grant and note the deliberate divergence from `harvestNode`.

Also corrected: two comments above the roll loop and two lines in
`docs/design/professions.md` said the corpse draw order was "pinned by the parity goldens".
No parity scenario drives `harvestCorpse` (verified: zero hits in `tests/parity/`), so a
green parity run said nothing about this path, which is exactly the class of change those
comments promised was protected. They now point at the corpse suites' own draw-count cases,
which do guard it, and this PR adds one for the signed arm specifically. Adding a real
`professions_corpse` parity scenario would be the stronger fix and needs a golden
re-record, so it belongs in its own change.

## Screenshots / recordings

No layout or style change: the harvest line already rendered a quantity, and the only
difference a player sees is the number in it. The bot's `corpse harvest lines desktop`
capture below shows it anyway, and it is a clean demonstration of the fix: the last line
reads `You harvest: [Cracked Wolf Fang] x3.` painted rare-blue, where that same rare roll
used to grant a single unit. The link inside it stays common-white, since the item did not
get rarer, only the roll.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A, no UI change.
- ~Accessible.~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.
