### PR TITLE
test(helpers): walk every source-scan guard to any depth, through one shared walk

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -69,10 +69,11 @@ use the `tests/server/helpers/` fakes (see Map), not a bespoke GameServer rig.
   never its own `readdirSync`.** A single-level read is a defect, not a style choice: the
   day the scanned root grows a subdirectory, everything inside leaves the scan and the
   guard stays green over a quietly smaller surface (#2485, then #2489 three times over).
-  Every scan root in the repo is flat today, so no assertion over the real tree can tell a
-  recursive walk from a flat one: pin the recursion with a `mkdtemp` fixture that drives
-  the guard's OWN producer, and keep the vacuity floor near the real count (a floor sitting
-  under it is what lets a moved file hide).
+  Apart from `src/ui`, every scan root is flat today, so no assertion over the real tree
+  can tell a recursive walk from a flat one: pin the recursion with a `mkdtemp` fixture
+  that drives the guard's OWN producer, and keep the vacuity floor near the real count (a
+  floor sitting under it is what lets a moved file hide). Where the root IS deep, a
+  file-count floor over the real tree pins it directly, as `mobile_window_coverage` does.
 - `tests/parity/` is the golden-trace gate: ANY sim behavior change turns it red by
   design. Read `tests/parity/CLAUDE.md` first; regenerate only deliberately via
   `UPDATE_PARITY=1 npx vitest run tests/parity`, in its own reviewed commit.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -31,7 +31,8 @@ Subdirectories (plus one shared fixture):
   `npm run test:browser`) for WebKit/Safari CSS, axe, target-size; never a bare `vitest run`.
 - `progression/`: mirrors `src/sim/progression/` (unit tests for the extracted modules).
 - `helpers/` + `util/`: shared cross-suite utilities (`fake_dom.ts`, the reusable
-  hand-rolled fake DOM for controller suites, `i18n_determinism.ts`, `alloc_probe.ts`).
+  hand-rolled fake DOM for controller suites, `i18n_determinism.ts`, `ts_files_under.ts`,
+  `alloc_probe.ts`).
 - `global_setup.ts`: runs on every vitest invocation (`vite.config.ts` `test.globalSetup`);
   mints the SFX Studio temp root (`WOC_SFX_STUDIO_TEST_ROOT`).
 
@@ -64,6 +65,14 @@ transport (see `social_system.test.ts`) rather than mocking. REST/RouteDef endpo
 use the `tests/server/helpers/` fakes (see Map), not a bespoke GameServer rig.
 
 ## Coverage & guards
+- **A guard that scans a directory of sources walks it with `helpers/ts_files_under.ts`,
+  never its own `readdirSync`.** A single-level read is a defect, not a style choice: the
+  day the scanned root grows a subdirectory, everything inside leaves the scan and the
+  guard stays green over a quietly smaller surface (#2485, then #2489 three times over).
+  Every scan root in the repo is flat today, so no assertion over the real tree can tell a
+  recursive walk from a flat one: pin the recursion with a `mkdtemp` fixture that drives
+  the guard's OWN producer, and keep the vacuity floor near the real count (a floor sitting
+  under it is what lets a moved file hide).
 - `tests/parity/` is the golden-trace gate: ANY sim behavior change turns it red by
   design. Read `tests/parity/CLAUDE.md` first; regenerate only deliberately via
   `UPDATE_PARITY=1 npx vitest run tests/parity`, in its own reviewed commit.

--- a/tests/helpers/ts_files_under.test.ts
+++ b/tests/helpers/ts_files_under.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -76,9 +76,35 @@ describe('tsFilesUnder', () => {
     const found = tsFilesUnder(root);
     expect(found.map((f) => f.file)).toEqual(['kept.ts']);
     // `full` is what every consumer hands to readFileSync, so a label-only
-    // return would break them all; bind that it is absolute and correct.
+    // return would break them all. Read the file rather than re-deriving the
+    // path with the same path.join the walk used, which would compare the
+    // implementation to itself.
     expect(path.isAbsolute(found[0].full)).toBe(true);
-    expect(found[0].full).toBe(path.join(root, 'kept.ts'));
+    expect(readFileSync(found[0].full, 'utf8')).toBe('export const kept = true;\n');
+  });
+
+  it('descends a symlinked DIRECTORY (a Dirent reads false for that too)', () => {
+    // The other half of the symlink decision, and the more expensive one to get
+    // wrong: `entry.isDirectory()` is lstat-based, so taking it at face value
+    // drops an entire linked subtree rather than a single file, silently.
+    write('real/inside.ts');
+    write('real/deeper/lower.ts');
+    symlinkSync(path.join(root, 'real'), path.join(root, 'linked_dir'));
+    expect(tsFilesUnder(root).map((f) => f.file)).toEqual([
+      'linked_dir/deeper/lower.ts',
+      'linked_dir/inside.ts',
+      'real/deeper/lower.ts',
+      'real/inside.ts',
+    ]);
+  });
+
+  it('walks a DIRECTORY named like a source file instead of returning it', () => {
+    // The shape the hand-rolled walk exists for, per this module's own note:
+    // readdirSync's `recursive: true` emits directory entries into its result,
+    // so `namespace.ts` would come back as a file and reach the consumer's
+    // readFileSync as an EISDIR crash. Nothing else pins that reasoning.
+    write('namespace.ts/child.ts');
+    expect(tsFilesUnder(root).map((f) => f.file)).toEqual(['namespace.ts/child.ts']);
   });
 
   it('follows a symlinked .ts file (a Dirent reads false for one)', () => {

--- a/tests/helpers/ts_files_under.test.ts
+++ b/tests/helpers/ts_files_under.test.ts
@@ -1,0 +1,98 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { tsFilesUnder } from './ts_files_under';
+
+// The paired test for the shared source walk. It matters more than a helper
+// test usually would: every scan root in the repo is FLAT today, so a
+// consumer's own assertions read identically whether this walk descends or
+// stops at the top level, and a regression to a flat read would leave four
+// guards quietly covering less with every suite still green (#2485, #2489).
+// Only a fixture tree can tell the two apart, so the contract is pinned here,
+// once, rather than restated in each consumer.
+
+describe('tsFilesUnder', () => {
+  let root = '';
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'woc-ts-files-under-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const write = (relative: string, body = 'export const x = 1;\n'): void => {
+    const full = path.join(root, ...relative.split('/'));
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, body);
+  };
+
+  it('finds .ts files at every depth, labeled relative to the root', () => {
+    write('top.ts');
+    write('one/mid.ts');
+    write('one/two/three/deep.ts');
+    // Three levels, not two: a walk with any depth cap fails here rather than
+    // passing on a shallower fixture.
+    expect(tsFilesUnder(root).map((f) => f.file)).toEqual([
+      'one/mid.ts',
+      'one/two/three/deep.ts',
+      'top.ts',
+    ]);
+  });
+
+  it('labels with forward slashes, so same-named files in two directories stay distinct', () => {
+    write('a/dupe.ts');
+    write('b/dupe.ts');
+    const labels = tsFilesUnder(root).map((f) => f.file);
+    // Bare names would collide, and a per-file count map keyed on them would
+    // silently merge two files into one row.
+    expect(labels).toEqual(['a/dupe.ts', 'b/dupe.ts']);
+    expect(new Set(labels).size).toBe(2);
+  });
+
+  it('sorts within each directory, so the order does not depend on the filesystem', () => {
+    // Written in an order that is neither sorted nor reversed, so a walk
+    // returning raw readdir order would have to be lucky to pass. CI is ext4
+    // (readdir in hash order) and a dev checkout is APFS (byte-lexicographic),
+    // so an unsorted walk pins a list that holds on one machine only.
+    write('zulu.ts');
+    write('alpha.ts');
+    write('mike/zulu.ts');
+    write('mike/alpha.ts');
+    expect(tsFilesUnder(root).map((f) => f.file)).toEqual([
+      'alpha.ts',
+      'mike/alpha.ts',
+      'mike/zulu.ts',
+      'zulu.ts',
+    ]);
+  });
+
+  it('returns only .ts files, and a full path that reads back', () => {
+    write('kept.ts', 'export const kept = true;\n');
+    write('notes.md', 'ctx.addItem(itemId, 1, pid);\n');
+    write('data.json', '{}\n');
+    const found = tsFilesUnder(root);
+    expect(found.map((f) => f.file)).toEqual(['kept.ts']);
+    // `full` is what every consumer hands to readFileSync, so a label-only
+    // return would break them all; bind that it is absolute and correct.
+    expect(path.isAbsolute(found[0].full)).toBe(true);
+    expect(found[0].full).toBe(path.join(root, 'kept.ts'));
+  });
+
+  it('follows a symlinked .ts file (a Dirent reads false for one)', () => {
+    // The arm no consumer fixture can reach, and the reason there is no
+    // `entry.isFile()` gate: Dirent is lstat-based, so gating on it drops a
+    // symlinked module that the flat `readdirSync().filter()` this replaces
+    // would have read. That is the same silent narrowing the walk exists to
+    // fix, arriving one door over, and only this case holds the line.
+    write('real/module.ts');
+    symlinkSync(path.join(root, 'real', 'module.ts'), path.join(root, 'linked.ts'));
+    expect(tsFilesUnder(root).map((f) => f.file)).toEqual(['linked.ts', 'real/module.ts']);
+  });
+
+  it('is empty for an empty root rather than throwing', () => {
+    expect(tsFilesUnder(root)).toEqual([]);
+  });
+});

--- a/tests/helpers/ts_files_under.ts
+++ b/tests/helpers/ts_files_under.ts
@@ -1,0 +1,62 @@
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+
+// The shared recursive source walk for guards that scan a directory of .ts
+// files. It exists because the single-level `readdirSync(dir).filter(...)` it
+// replaces was a silent-coverage bug four times over: #2485 in the professions
+// grant sweep, then #2489 in the forbidden-login scan, the S3 emit drift guard,
+// and the mobile window scrape. In every case a module moved into a
+// subdirectory would leave the scan while the guard stayed green, covering less
+// than the day before with no diff for a reviewer to notice.
+//
+// ONE argument, and it is meant to stay that way. A caller that wants less
+// filters the returned list. A caller that wants a genuinely different corpus
+// (another extension, absolute paths, a hashed record) hand-rolls its own walk
+// and keeps it local: the point of this module is one contract shared by the
+// guards that want exactly this one, not a walker framework with a knob per
+// caller. The concrete case that stays OUT is
+// tests/mobile_window_coverage.test.ts's src/styles read, which models the
+// sheets an entry actually loads rather than the files on disk.
+
+/** One source file found by {@link tsFilesUnder}. */
+export interface TsSourceFile {
+  /** Path relative to the scan root, joined with forward slashes at every depth. */
+  readonly file: string;
+  /** Absolute path, for `readFileSync`. */
+  readonly full: string;
+}
+
+/**
+ * Every `.ts` file under `root`, RECURSIVELY, sorted by name within each
+ * directory.
+ *
+ * The sort matters: readdir returns byte-lexicographic order on a dev APFS
+ * checkout and hash order on the ext4 CI runner, so an unsorted walk pins a
+ * label list that only holds on one of them.
+ *
+ * The file arm is deliberately NOT gated on `entry.isFile()`. A `Dirent`
+ * reports lstat, so that check reads false for a symlink, while the flat reads
+ * this replaces followed one: gating on it would narrow coverage in exactly the
+ * way this module exists to stop. Anything named `.ts` that is not a directory
+ * gets returned.
+ *
+ * Walks by hand rather than through `readdirSync`'s `recursive: true`, which
+ * emits directory entries into its own result (so a directory named `x.ts`
+ * reaches `readFileSync` and throws EISDIR), returns platform-separator paths,
+ * and does not sort.
+ */
+export function tsFilesUnder(root: string): TsSourceFile[] {
+  const walk = (dir: string, prefix: string): TsSourceFile[] => {
+    const out: TsSourceFile[] = [];
+    const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+      a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+    );
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) out.push(...walk(full, `${prefix}${entry.name}/`));
+      else if (entry.name.endsWith('.ts')) out.push({ file: `${prefix}${entry.name}`, full });
+    }
+    return out;
+  };
+  return walk(root, '');
+}

--- a/tests/helpers/ts_files_under.ts
+++ b/tests/helpers/ts_files_under.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from 'node:fs';
+import { readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 // The shared recursive source walk for guards that scan a directory of .ts
@@ -34,11 +34,15 @@ export interface TsSourceFile {
  * checkout and hash order on the ext4 CI runner, so an unsorted walk pins a
  * label list that only holds on one of them.
  *
- * The file arm is deliberately NOT gated on `entry.isFile()`. A `Dirent`
- * reports lstat, so that check reads false for a symlink, while the flat reads
- * this replaces followed one: gating on it would narrow coverage in exactly the
- * way this module exists to stop. Anything named `.ts` that is not a directory
- * gets returned.
+ * Symlinks are followed on BOTH arms, which takes deciding rather than
+ * defaulting: a `Dirent` reports lstat, so `isFile()` and `isDirectory()` both
+ * read false for one. Gating the file arm on `isFile()` would drop a symlinked
+ * module the flat `readdirSync().filter()` reads this replace would have read,
+ * and taking `isDirectory()` at face value would drop a whole symlinked
+ * subtree. Either is the silent narrowing this module exists to stop, so a
+ * symlink is resolved once and treated as whatever it points at. A broken one
+ * resolves to neither and, if it is named `.ts`, is still returned, so the
+ * consumer's own read fails loudly rather than the file leaving the scan.
  *
  * Walks by hand rather than through `readdirSync`'s `recursive: true`, which
  * emits directory entries into its own result (so a directory named `x.ts`
@@ -53,7 +57,11 @@ export function tsFilesUnder(root: string): TsSourceFile[] {
     );
     for (const entry of entries) {
       const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) out.push(...walk(full, `${prefix}${entry.name}/`));
+      const isDir =
+        entry.isDirectory() ||
+        (entry.isSymbolicLink() &&
+          (statSync(full, { throwIfNoEntry: false })?.isDirectory() ?? false));
+      if (isDir) out.push(...walk(full, `${prefix}${entry.name}/`));
       else if (entry.name.endsWith('.ts')) out.push({ file: `${prefix}${entry.name}`, full });
     }
     return out;

--- a/tests/localization_fixes.test.ts
+++ b/tests/localization_fixes.test.ts
@@ -1219,10 +1219,13 @@ describe('S3: every sim.ts emit is recognized (drift guard)', () => {
   });
 
   it('the src/sim/social glob still reaches its modules and feeds the corpus', () => {
-    // The corpus-wide floor above cannot see this: the glob is one input among
-    // forty explicit files, so it could contribute nothing at all and the total
-    // would still clear any sane floor. These two bind the glob itself, which
-    // is the input a subdirectory (or a rename) would silently empty.
+    // These bind the GLOB, where the floor above binds the total. Measured, so
+    // the difference is on the record: the corpus is 428 with the glob and 290
+    // without it, so the 400 floor does now catch a glob that empties
+    // completely (the 80 it replaced did not, which is what let this input be
+    // the quiet one). What the floor still cannot localize is a PARTIAL loss,
+    // and it cannot say which input went missing; these can, and they are the
+    // input a subdirectory or a rename would empty.
     expect(
       socialFiles.map((f) => f.file),
       'the src/sim/social walk reaches every module in the directory',
@@ -1248,6 +1251,20 @@ describe('S3: every sim.ts emit is recognized (drift guard)', () => {
       scanEmitCandidates(socialSrc, '').length,
       'the social glob still contributes its emits to the S3 corpus',
     ).toBeGreaterThan(220);
+  });
+
+  it('the corpus reads the tree through the shared walker, with no flat reader beside it', () => {
+    // The sibling of the pins in steam_routes / mobile_window_coverage /
+    // professions_silent_loot, and the same reasoning: src/sim/social is flat,
+    // so a second producer for socialSrc built on its own flat read would join
+    // the identical text to the corpus today and nothing here would notice.
+    const own = fs
+      .readFileSync(path.resolve(process.cwd(), 'tests/localization_fixes.test.ts'), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');
+    // Both needles assembled from halves so neither matches its own line.
+    expect(own.split(`readdir${'Sync('}`).length - 1).toBe(0);
+    expect(own).toContain(`helpers/ts_files${'_under'}`);
   });
 
   it('the social glob descends, so an emit in a SUBDIRECTORY is scanned too (#2489)', () => {

--- a/tests/localization_fixes.test.ts
+++ b/tests/localization_fixes.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { resolveReportTarget } from '../server/report_target';
@@ -44,6 +45,7 @@ import {
   renderTalentManifestEntry,
   talentTranslationManifest,
 } from '../src/ui/talent_i18n';
+import { tsFilesUnder } from './helpers/ts_files_under';
 
 // Lazy locale flip: the non-en game locales are no longer statically resident. Every
 // describe below setLanguage(non-en)s and reads synchronously through t() / localizeSimText /
@@ -911,14 +913,24 @@ describe('S3: every sim.ts emit is recognized (drift guard)', () => {
   // through SimContext. Scan ALL of them alongside sim.ts so every language-agnostic sim
   // emit stays under the drift guard; they are re-localized client-side by the same
   // matchers. When a slice moves emit literals out of the monolith, append its path here.
+  // The one automatic input in a hand-curated list, and so the one whose
+  // disappearance nobody would catch by reading a diff. It walks to any depth
+  // (#2489): the single-level read this replaces would have dropped every emit
+  // in a src/sim/social subdirectory the day one appeared, leaving this guard
+  // green over a quietly smaller corpus. Takes a root rather than closing over
+  // socialDir, so the recursion case at the end of this file drives the exact
+  // producer the corpus uses, not a restatement of it.
   const socialDir = path.resolve(process.cwd(), 'src/sim/social');
-  const socialSrc = fs.existsSync(socialDir)
-    ? fs
-        .readdirSync(socialDir)
-        .filter((f) => f.endsWith('.ts'))
-        .map((f) => fs.readFileSync(path.join(socialDir, f), 'utf8'))
-        .join('\n')
-    : '';
+  const socialSourceUnder = (root: string): string =>
+    tsFilesUnder(root)
+      .map(({ full }) => fs.readFileSync(full, 'utf8'))
+      .join('\n');
+  // No existsSync fallback to ''. That arm made a MOVED or renamed
+  // src/sim/social scan NOTHING with this guard still green, which is the same
+  // silence #2489 is about wearing a different hat; a directory that is gone
+  // now throws where a reader can see it.
+  const socialFiles = tsFilesUnder(socialDir);
+  const socialSrc = socialSourceUnder(socialDir);
   const simSrc = [
     fs.readFileSync(path.resolve(process.cwd(), 'src/sim/sim.ts'), 'utf8'),
     fs.readFileSync(path.resolve(process.cwd(), 'src/sim/combat/damage.ts'), 'utf8'),
@@ -1197,13 +1209,67 @@ describe('S3: every sim.ts emit is recognized (drift guard)', () => {
   it('s3_registered: every sim.ts emit maps to a registered key/RULE (PR tier)', () => {
     setLanguage('en');
     const cands = candidateStrings();
-    expect(cands.length, 'sanity: should enumerate many emit sites').toBeGreaterThan(80);
+    expect(cands.length, 'sanity: should enumerate many emit sites').toBeGreaterThan(400);
     const leaks: string[] = [];
     for (const { type, s } of cands) {
       if (!recognized(type, s)) leaks.push(`(${type}) ${JSON.stringify(s)}`);
     }
     setLanguage('en');
     expect(leaks, 'unregistered sim emit strings (add a key/RULE to sim_i18n.ts)').toEqual([]);
+  });
+
+  it('the src/sim/social glob still reaches its modules and feeds the corpus', () => {
+    // The corpus-wide floor above cannot see this: the glob is one input among
+    // forty explicit files, so it could contribute nothing at all and the total
+    // would still clear any sane floor. These two bind the glob itself, which
+    // is the input a subdirectory (or a rename) would silently empty.
+    expect(
+      socialFiles.map((f) => f.file),
+      'the src/sim/social walk reaches every module in the directory',
+    ).toEqual([
+      'arena.ts',
+      'away.ts',
+      'card_duel.ts',
+      'card_duel_queue.ts',
+      'chat.ts',
+      'chat_readouts.ts',
+      'duel.ts',
+      'dungeon_finder.ts',
+      'fiesta.ts',
+      'fiesta_bots.ts',
+      'party.ts',
+      'ready_check.ts',
+      'trade.ts',
+      'vale_cup.ts',
+      'vale_cup_bots.ts',
+      'yumi.ts',
+    ]);
+    expect(
+      scanEmitCandidates(socialSrc, '').length,
+      'the social glob still contributes its emits to the S3 corpus',
+    ).toBeGreaterThan(220);
+  });
+
+  it('the social glob descends, so an emit in a SUBDIRECTORY is scanned too (#2489)', () => {
+    // src/sim/social is flat today, so no assertion over the real tree can tell
+    // a recursive read from the single-level one it replaces. Drive the real
+    // producer over a fixture tree and hand its output to the real scanner: a
+    // nested emit has to arrive as a candidate, or the day social grows a
+    // folder its player text leaves the drift guard unnoticed.
+    const fixture = fs.mkdtempSync(path.join(tmpdir(), 'woc-social-scan-'));
+    try {
+      fs.mkdirSync(path.join(fixture, 'cards', 'deeper'), { recursive: true });
+      fs.writeFileSync(
+        path.join(fixture, 'cards', 'deeper', 'nested_emit.ts'),
+        "export function f(ctx: Ctx, pid: number) {\n  ctx.error(pid, 'Fixture nested social emit.');\n}\n",
+      );
+      fs.writeFileSync(path.join(fixture, 'notes.md'), "ctx.error(pid, 'Not source.');\n");
+      const found = scanEmitCandidates(socialSourceUnder(fixture), '').map((c) => c.tmpl);
+      expect(found).toContain('Fixture nested social emit.');
+      expect(found).not.toContain('Not source.');
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
   });
 
   // RELEASE TIER: the same coverage across all 21 locales, and where a real matcher
@@ -1213,7 +1279,7 @@ describe('S3: every sim.ts emit is recognized (drift guard)', () => {
     's3_localized: every emit is recognized in all 21 locales and not left English where a matcher resolves it',
     () => {
       const cands = candidateStrings();
-      expect(cands.length, 'sanity: should enumerate many emit sites').toBeGreaterThan(80);
+      expect(cands.length, 'sanity: should enumerate many emit sites').toBeGreaterThan(400);
       const leaks: string[] = [];
       for (const lang of supportedLanguages) {
         setLanguage(lang);

--- a/tests/mobile_window_coverage.test.ts
+++ b/tests/mobile_window_coverage.test.ts
@@ -113,8 +113,8 @@ const MOBILE_WINDOW_EXCEPTIONS: Record<string, string> = {
 //
 // This read stays SINGLE-LEVEL on purpose, unlike the src/ui walk above (#2489).
 // It models the sheets that actually reach a browser, not the files on disk:
-// every one of these ships, the 7 via the src/styles/index.css barrel and the
-// two .extra.css via a <link> in each entry (pinned by
+// all 10 ship, as the index.css barrel itself, the 7 it imports, and the two
+// .extra.css pulled in by a <link> in each entry (pinned by
 // tests/per_entry_css_wiring.test.ts). Recursing would be worse than a no-op
 // (src/styles has no subdirectories today): it would let a component-local or
 // experimental sheet parked in a subfolder count as mobile coverage for a rule
@@ -179,7 +179,11 @@ function hasMobileRule(css: string, id: string): boolean {
 // would demand mobile CSS that nobody decided to write).
 function hasOwnSheetRule(css: string, id: string): boolean {
   const selRe = new RegExp(
-    `body\\.mobile-touch[^,{}]*#${id}(?![-a-z0-9])(?::[a-z-]+(?:\\([^)]*\\))?)*\\s*[,{]`,
+    // No id-boundary lookahead here, unlike hasMobileRule: the trailing `[,{]`
+    // already does that job, since a longer id (#beta-extended searched for as
+    // #beta) leaves `-extended` where a comma or brace has to be. Mutation
+    // showed a lookahead here is unreachable, so it is not written.
+    `body\\.mobile-touch[^,{}]*#${id}(?::[a-z-]+(?:\\([^)]*\\))?)*\\s*[,{]`,
     'g',
   );
   let m: RegExpExecArray | null;
@@ -269,11 +273,13 @@ describe('mobile window coverage (Phase 5 parity)', () => {
   });
 
   it('the scrape reads src/ui through the shared walker, with no flat reader beside it', () => {
-    // The fixture pins the SCRAPER; nothing can pin that it still reaches the
-    // real tree through the walk, because every window-minting module is at the
-    // top level, so a second inline flat read would produce the same ids today.
-    // Exactly one directory read is left in this file: stylesText's, which is
-    // single-level by design (see its comment).
+    // The fixture pins the SCRAPER, and the file-count floor above pins that the
+    // real scrape reaches the whole tree. This closes the remaining gap: a
+    // second producer built on its own flat read would return the same window
+    // IDS today, since every window-minting module is at the top level, so the
+    // ids and windowClassFiles pins would not notice it. Exactly one directory
+    // read is left in this file: stylesText's, single-level by design (see its
+    // comment).
     const own = readFileSync(
       fileURLToPath(new URL('mobile_window_coverage.test.ts', import.meta.url)),
       'utf8',
@@ -282,7 +288,9 @@ describe('mobile window coverage (Phase 5 parity)', () => {
       .replace(/(^|[^:])\/\/.*$/gm, '$1');
     // Needle assembled from halves so it does not match itself.
     expect(own.split(`readdir${'Sync('}`).length - 1).toBe(1);
-    expect(own).toContain('helpers/ts_files_under');
+    // Needle split for the same reason as the one above: written whole it would
+    // match its own assertion line, so this passed even with the import gone.
+    expect(own).toContain(`helpers/ts_files${'_under'}`);
   });
 
   it('every window is either sheeted on mobile or an explicit exception', () => {
@@ -351,5 +359,24 @@ describe('mobile window coverage (Phase 5 parity)', () => {
     expect(hasOwnSheetRule(css, 'daily-rewards-window')).toBe(true);
     expect(hasOwnSheetRule(css, 'loot-window')).toBe(false);
     expect(hasMobileRule(css, 'loot-window')).toBe(true);
+    // The real cascade happens to satisfy both controls through one plain
+    // `#id { ... }` rule, so neither of the regex's other two clauses is
+    // exercised by it: delete the pseudo-class group or the id-boundary
+    // lookahead and the two controls above still pass. Drive those arms over a
+    // fixture cascade instead.
+    const fixtureCss = [
+      'body.mobile-touch #alpha:not(.docked) { max-height: 10px; }',
+      'body.mobile-touch #beta-extended { top: 0; }',
+      'body.mobile-touch #gamma .inner { min-height: 40px; }',
+    ].join('\n');
+    // The pseudo-class group: the id is still the target, `:not(.docked)` and
+    // all, so this is an id-scoped rule.
+    expect(hasOwnSheetRule(fixtureCss, 'alpha')).toBe(true);
+    // The boundary lookahead: #beta must not match the longer #beta-extended,
+    // or a window would inherit a namesake prefix's rule and lose its exception.
+    expect(hasOwnSheetRule(fixtureCss, 'beta')).toBe(false);
+    expect(hasOwnSheetRule(fixtureCss, 'beta-extended')).toBe(true);
+    // ... and the descendant shape stays out, which is the whole distinction.
+    expect(hasOwnSheetRule(fixtureCss, 'gamma')).toBe(false);
   });
 });

--- a/tests/mobile_window_coverage.test.ts
+++ b/tests/mobile_window_coverage.test.ts
@@ -124,7 +124,17 @@ const MOBILE_WINDOW_EXCEPTIONS: Record<string, string> = {
 // coverage assertion RED, which needs no depth fix to be noticed.
 function stylesText(): string {
   const dir = fileURLToPath(new URL(STYLES_DIR, import.meta.url));
-  const files = readdirSync(dir).filter((f) => f.endsWith('.css'));
+  const entries = readdirSync(dir, { withFileTypes: true });
+  // The premise, checked rather than asserted in prose: the reasoning above
+  // holds only while every sheet sits at the top level. The day one lands in a
+  // subdirectory this throws here, where the comment explaining the decision
+  // is, so the choice gets re-made deliberately instead of quietly meaning
+  // something else. Derived from the SAME read as the file list, so this file
+  // still owns exactly one directory reader.
+  if (entries.some((e) => e.isDirectory())) {
+    throw new Error('src/styles gained a subdirectory: re-read the note above stylesText()');
+  }
+  const files = entries.map((e) => e.name).filter((f) => f.endsWith('.css'));
   return files
     .map((f) => readFileSync(`${dir}/${f}`, 'utf8').replace(/\/\*[\s\S]*?\*\//g, ''))
     .join('\n');
@@ -160,6 +170,13 @@ function hasMobileRule(css: string, id: string): boolean {
 // the comma or the brace, and the block carries a real pin property. Only the
 // exception-necessity check below uses this; hasMobileRule above stays looser on
 // purpose, because a sheeted window is usually positioned through its parts.
+// Across the 142 ids named in a body.mobile-touch selector today the two answers
+// differ for 7, every one of them an ancestor-only rule (#deed-tracker's own
+// block is a font-size, its max-height sits on .dt-list).
+// It misses `#id.state { ... }`, where a class follows the id: that reads as
+// "not id-scoped" and keeps an exception alive, which is the safe direction for
+// the only caller (a wrongly-kept exception is inert; a wrongly-dropped one
+// would demand mobile CSS that nobody decided to write).
 function hasOwnSheetRule(css: string, id: string): boolean {
   const selRe = new RegExp(
     `body\\.mobile-touch[^,{}]*#${id}(?![-a-z0-9])(?::[a-z-]+(?:\\([^)]*\\))?)*\\s*[,{]`,

--- a/tests/mobile_window_coverage.test.ts
+++ b/tests/mobile_window_coverage.test.ts
@@ -1,6 +1,9 @@
-import { readdirSync, readFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { tsFilesUnder } from './helpers/ts_files_under';
 
 // Phase 5 mobile-HUD-parity coverage guard.
 //
@@ -58,16 +61,27 @@ function windowIdsFromHtml(html: string): string[] {
 // short line-distance. Matching the id AND the window className on the same element
 // is what keeps sibling containers (#emote-wheel, #loot-rolls, #skin-event: divs in
 // the same module that are NOT .window boxes) from being mis-scraped as windows.
-function dynamicWindowIds(): { ids: string[]; scannedFiles: number; hadWindowClass: number } {
-  const dir = fileURLToPath(new URL(UI_DIR, import.meta.url));
-  const files = readdirSync(dir).filter((f) => f.endsWith('.ts'));
+// The walk goes to any depth (#2489). The single-level read this replaces was
+// pointed at exactly the directory the repo tells contributors NOT to add new
+// components to: src/ui/CLAUDE.md sends a new HUD component to
+// src/ui/hud/<domain>/, and much of the window family already lives there. Those
+// stay visible only because they paint into ids that exist in the static markup;
+// the day one mints its own `.window` root, a flat read would go blind while
+// every assertion below stayed green, which is the exact failure this closes.
+// Takes a root so the recursion case can drive the real scraper over a fixture.
+function dynamicWindowIds(dir: string = fileURLToPath(new URL(UI_DIR, import.meta.url))): {
+  ids: string[];
+  files: string[];
+  windowClassFiles: string[];
+} {
+  const sources = tsFilesUnder(dir);
   const ids = new Set<string>();
-  let hadWindowClass = 0;
+  const windowClassFiles: string[] = [];
   const idRe = /(\w+)\.id\s*=\s*['"]([a-z0-9-]+)['"]/g;
-  for (const f of files) {
-    const src = readFileSync(`${dir}/${f}`, 'utf8');
+  for (const { file, full } of sources) {
+    const src = readFileSync(full, 'utf8');
     if (!/\.className\s*=\s*['"]window(?:\s+[^'"]*)?['"]/.test(src)) continue;
-    hadWindowClass++;
+    windowClassFiles.push(file);
     for (const m of src.matchAll(idRe)) {
       const [, varName, id] = m;
       // Require the same variable to receive a `window` className nearby (within the
@@ -77,7 +91,7 @@ function dynamicWindowIds(): { ids: string[]; scannedFiles: number; hadWindowCla
       if (classRe.test(near)) ids.add(id);
     }
   }
-  return { ids: [...ids], scannedFiles: files.length, hadWindowClass };
+  return { ids: [...ids], files: sources.map((s) => s.file), windowClassFiles };
 }
 
 // Windows deliberately NOT brought into the mobile sheet pattern, each with a
@@ -91,13 +105,23 @@ const MOBILE_WINDOW_EXCEPTIONS: Record<string, string> = {
     'small centered modal (dynamic, the first-tier profession tutorial); centered and clamped by its own base #profession-tutorial rule plus the shared .window viewport clamp, with its z-index floored above the mobile sheet (96) in JS',
   'delve-rite-panel': 'in-run gameplay overlay, not a menu window that docks to a sheet',
   'lockpick-panel': 'in-run gameplay overlay, not a menu window that docks to a sheet',
-  'daily-rewards-window':
-    'sized entirely by the shared body.mobile-touch .window sheet base (max-width/max-height) plus its own .dr-body 2-column body rule; its only id-specific mobile rule is a z-index bump, so it carries no id-scoped pin of its own',
 };
 
 // A src/styles/*.css module contains a positioning/floor rule for #id on touch when
 // some `body.mobile-touch ... #id ...` selector names the id. Comments are stripped
 // so a commented id cannot spoof coverage.
+//
+// This read stays SINGLE-LEVEL on purpose, unlike the src/ui walk above (#2489).
+// It models the sheets that actually reach a browser, not the files on disk:
+// every one of these ships, the 7 via the src/styles/index.css barrel and the
+// two .extra.css via a <link> in each entry (pinned by
+// tests/per_entry_css_wiring.test.ts). Recursing would be worse than a no-op
+// (src/styles has no subdirectories today): it would let a component-local or
+// experimental sheet parked in a subfolder count as mobile coverage for a rule
+// that never loads. The failure directions differ too. A src/ui module missed
+// by a flat read is a silent PASS, which is the bug #2489 is about; a src/styles
+// module missed here makes its windows read as unclassified and turns the
+// coverage assertion RED, which needs no depth fix to be noticed.
 function stylesText(): string {
   const dir = fileURLToPath(new URL(STYLES_DIR, import.meta.url));
   const files = readdirSync(dir).filter((f) => f.endsWith('.css'));
@@ -131,6 +155,28 @@ function hasMobileRule(css: string, id: string): boolean {
   return false;
 }
 
+// A rule that targets the WINDOW ITSELF on touch, rather than something inside
+// it: the id (with any pseudo-classes) is the last thing in its selector before
+// the comma or the brace, and the block carries a real pin property. Only the
+// exception-necessity check below uses this; hasMobileRule above stays looser on
+// purpose, because a sheeted window is usually positioned through its parts.
+function hasOwnSheetRule(css: string, id: string): boolean {
+  const selRe = new RegExp(
+    `body\\.mobile-touch[^,{}]*#${id}(?![-a-z0-9])(?::[a-z-]+(?:\\([^)]*\\))?)*\\s*[,{]`,
+    'g',
+  );
+  let m: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop.
+  while ((m = selRe.exec(css)) !== null) {
+    const open = css.indexOf('{', m.index + m[0].length - 1);
+    if (open === -1) continue;
+    const close = css.indexOf('}', open + 1);
+    if (close === -1) continue;
+    if (PIN_PROP_RE.test(css.slice(open + 1, close))) return true;
+  }
+  return false;
+}
+
 describe('mobile window coverage (Phase 5 parity)', () => {
   const htmlIds = HTML_ENTRIES.flatMap((e) => windowIdsFromHtml(read(e)));
   const dyn = dynamicWindowIds();
@@ -138,13 +184,88 @@ describe('mobile window coverage (Phase 5 parity)', () => {
   const css = stylesText();
 
   it('scrapes a plausible set of window ids from both entries plus src/ui', () => {
-    // Sanity floor: the static markup carries the full HUD window family; if this
-    // collapses, the scrape regex broke and the coverage assertions are hollow.
-    expect(allIds.length).toBeGreaterThanOrEqual(20);
-    // The dynamic scrape must have inspected src/ui and found the window-creating
-    // module(s); #confirm-dialog is the one dynamic window today.
-    expect(dyn.hadWindowClass).toBeGreaterThanOrEqual(1);
-    expect(allIds).toContain('confirm-dialog');
+    // Sanity floors: the static markup carries the full HUD window family; if
+    // this collapses, the scrape regex broke and the coverage assertions are
+    // hollow. PER ENTRY, not on the union: both entries ship the same window
+    // family (37 ids each today), so a union floor stays green while one
+    // entry's scrape collapses entirely.
+    for (const entry of HTML_ENTRIES) {
+      expect(windowIdsFromHtml(read(entry)).length, entry).toBeGreaterThanOrEqual(35);
+    }
+    expect(allIds.length).toBeGreaterThanOrEqual(38);
+    // The recursion pin that lives in the REAL tree rather than a fixture: the
+    // single-level read this replaces saw 295 files, the walk sees 450, so a
+    // quiet return to a flat read cannot clear this floor.
+    expect(
+      dyn.files.length,
+      'the src/ui scrape reads the whole tree, not one level (#2489)',
+    ).toBeGreaterThanOrEqual(400);
+    // Exact, not a floor. Minting a window at runtime is a rare, deliberate act,
+    // and it is the arm the recursion widens: a fourth module joins this list in
+    // the same change that gives its window a mobile rule or an exception below.
+    expect(dyn.windowClassFiles).toEqual([
+      'dev_command_window.ts',
+      'hud.ts',
+      'profession_tutorial_window.ts',
+    ]);
+    expect([...dyn.ids].sort()).toEqual([
+      'confirm-dialog',
+      'dev-command-window',
+      'profession-tutorial',
+    ]);
+  });
+
+  it('the src/ui scrape descends, so a window minted in a SUBDIRECTORY is seen (#2489)', () => {
+    // Every window-minting module sits at the top of src/ui today, so no
+    // assertion over the real tree can tell a recursive walk from the flat one
+    // it replaces. Drive the real scraper over a fixture tree instead, in the
+    // shape the repo actually asks for: a component under a hud domain folder.
+    const fixture = mkdtempSync(path.join(tmpdir(), 'woc-ui-scrape-'));
+    try {
+      mkdirSync(path.join(fixture, 'hud', 'trade'), { recursive: true });
+      writeFileSync(
+        path.join(fixture, 'hud', 'trade', 'haggle_window.ts'),
+        "const root = document.createElement('div');\n" +
+          "root.id = 'haggle-window';\n" +
+          "root.className = 'window haggle';\n",
+      );
+      // The pairing rule has to survive the recursion: a sibling id in the same
+      // nested module that never receives a window className is NOT a window
+      // (the real tree's #emote-wheel, #loot-rolls, #skin-event are this shape).
+      writeFileSync(
+        path.join(fixture, 'hud', 'trade', 'haggle_tray.ts'),
+        "const tray = document.createElement('div');\n" +
+          "tray.id = 'haggle-tray';\n" +
+          "tray.className = 'tray';\n" +
+          "const box = document.createElement('div');\n" +
+          "box.className = 'window';\n",
+      );
+      const found = dynamicWindowIds(fixture);
+      expect(found.ids).toEqual(['haggle-window']);
+      expect(found.windowClassFiles).toEqual([
+        'hud/trade/haggle_tray.ts',
+        'hud/trade/haggle_window.ts',
+      ]);
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it('the scrape reads src/ui through the shared walker, with no flat reader beside it', () => {
+    // The fixture pins the SCRAPER; nothing can pin that it still reaches the
+    // real tree through the walk, because every window-minting module is at the
+    // top level, so a second inline flat read would produce the same ids today.
+    // Exactly one directory read is left in this file: stylesText's, which is
+    // single-level by design (see its comment).
+    const own = readFileSync(
+      fileURLToPath(new URL('mobile_window_coverage.test.ts', import.meta.url)),
+      'utf8',
+    )
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');
+    // Needle assembled from halves so it does not match itself.
+    expect(own.split(`readdir${'Sync('}`).length - 1).toBe(1);
+    expect(own).toContain('helpers/ts_files_under');
   });
 
   it('every window is either sheeted on mobile or an explicit exception', () => {
@@ -184,5 +305,34 @@ describe('mobile window coverage (Phase 5 parity)', () => {
       expect(allIds, `exception #${id} is not a scraped window id`).toContain(id);
       expect(reason.length, `exception #${id} needs a non-empty reason`).toBeGreaterThan(10);
     }
+  });
+
+  it('every exception is still NEEDED (none shadows a window that already qualifies)', () => {
+    // The sweep consults the exception map BEFORE hasMobileRule, so an entry
+    // whose window later gained a real mobile rule keeps passing while its
+    // stated reason quietly goes false, and nothing notices. That is what
+    // happened to #daily-rewards-window: it was excused for carrying "only a
+    // z-index bump" long after src/styles/hud.mobile.css gave it an id-scoped
+    // max-height, so the entry was removed rather than left to rot.
+    //
+    // This asks a STRICTER question than hasMobileRule, deliberately. That one
+    // credits a rule where the id is merely an ANCESTOR of the target, which is
+    // right for coverage (a sheeted window is usually styled through its parts)
+    // but wrong here: #loot-window is named only by `#loot-window .btn`, which
+    // gives its buttons a min-height and sheets nothing, so treating that as
+    // "already qualifies" would delete a legitimate exception. An excused
+    // window is one that carries no rule targeting the window ITSELF.
+    const shadowed = Object.keys(MOBILE_WINDOW_EXCEPTIONS).filter((id) => hasOwnSheetRule(css, id));
+    expect(
+      shadowed,
+      'these ids are excused but already carry an id-scoped body.mobile-touch rule with a real pin; drop the exception',
+    ).toEqual([]);
+    // Both controls, or the sweep above could pass by answering false to
+    // everything. #daily-rewards-window is the window whose dead exception this
+    // replaced (an id-scoped max-height); #loot-window is the one that keeps its
+    // exception, named in hud.mobile.css only through `#loot-window .btn`.
+    expect(hasOwnSheetRule(css, 'daily-rewards-window')).toBe(true);
+    expect(hasOwnSheetRule(css, 'loot-window')).toBe(false);
+    expect(hasMobileRule(css, 'loot-window')).toBe(true);
   });
 });

--- a/tests/professions_silent_loot.test.ts
+++ b/tests/professions_silent_loot.test.ts
@@ -769,9 +769,11 @@ describe('every professions grant site is accounted for (#2430)', () => {
     const needle = `readdir${'Sync('}`;
     expect(
       own.split(needle).length - 1,
-      'this file should not read a directory itself; the sweep goes through tests/helpers/ts_files_under, and a second reader could go flat while the shared one stays recursive',
+      'this file should not read a directory itself; the sweep goes through the shared walk helper, and a second reader could go flat while the shared one stays recursive',
     ).toBe(0);
-    expect(own).toContain('helpers/ts_files_under');
+    // Needle split for the same reason as the one above: written whole it would
+    // match its own assertion line, so this passed even with the import gone.
+    expect(own).toContain(`helpers/ts_files${'_under'}`);
   });
 
   it('the exclusion list has no stale entries', () => {

--- a/tests/professions_silent_loot.test.ts
+++ b/tests/professions_silent_loot.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -9,6 +9,7 @@ import { stationsOfType } from '../src/sim/professions/stations';
 import { Sim } from '../src/sim/sim';
 import type { Entity, SimEvent, StationType } from '../src/sim/types';
 import { terrainHeight } from '../src/sim/world';
+import { tsFilesUnder } from './helpers/ts_files_under';
 
 // Every grant in the game flows through the one shared inventory hub
 // (Sim.addItem/addItemInstance), which unconditionally emitted a 'loot'
@@ -507,34 +508,6 @@ describe('every professions grant site is accounted for (#2430)', () => {
   // assertion). Comments are already gone by this point (codeOnly above).
   const flatten = (call: string) => call.replace(/\s+/g, ' ');
 
-  /** Every .ts file under `root`, RECURSIVELY, labeled by its path relative to
-   *  `root` with forward slashes (so a top-level file keeps its bare name and
-   *  the per-file pins below go on resolving). The single-level `readdirSync`
-   *  this replaces read one directory deep, so the day src/sim/professions grew
-   *  a subdirectory every grant inside it would have left both sweeps below
-   *  while they stayed green, covering less than the day before (#2485).
-   *  Entries are sorted by name, so the label list is the same on the ext4 CI
-   *  runner (readdir in hash order) as on a dev APFS checkout. The label idiom
-   *  is tests/i18n_admin_catalog.test.ts's walk, which recursed for the same
-   *  reason: a flat read misses what a subdirectory holds. */
-  const tsFilesUnder = (root: string, prefix = ''): Array<{ file: string; full: string }> => {
-    const out: Array<{ file: string; full: string }> = [];
-    const entries = readdirSync(root, { withFileTypes: true }).sort((a, b) =>
-      a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
-    );
-    for (const entry of entries) {
-      const full = path.join(root, entry.name);
-      // The file arm is deliberately NOT gated on `entry.isFile()`. A Dirent
-      // reports lstat, so that check reads false for a symlink, and the flat
-      // read this replaces would have followed one: gating on it would narrow
-      // coverage in the very way #2485 is about, one door over. Anything named
-      // `.ts` that is not a directory gets read.
-      if (entry.isDirectory()) out.push(...tsFilesUnder(full, `${prefix}${entry.name}/`));
-      else if (entry.name.endsWith('.ts')) out.push({ file: `${prefix}${entry.name}`, full });
-    }
-    return out;
-  };
-
   /** Every grant call under `root`, each tagged with the relative file it came
    *  from. Takes a directory rather than closing over `dir`, so the fixture
    *  case below drives the exact scanner the sweep uses, not a restatement. */
@@ -779,24 +752,26 @@ describe('every professions grant site is accounted for (#2430)', () => {
     }
   });
 
-  it('the sweep reads the tree through ONE walker (no second, flat producer)', () => {
+  it('the sweep reads the tree through the shared walker (no flat producer beside it)', () => {
     // The case above pins the WALKER; nothing can pin that `sites` still goes
     // through it, because src/sim/professions is flat, so an inline flat read
     // here would return the identical list today and every assertion in this
-    // file would stay green. The only mechanical guard is that this file owns
-    // exactly one directory read, which is grantSitesUnder's. Comments are
-    // stripped first, or the prose above explaining the old single-level
-    // readdirSync would count as a second one.
+    // file would stay green. The mechanical guard is that this file owns NO
+    // directory read of its own: the walk lives in tests/helpers/ts_files_under
+    // with its own paired test, and #2489 put three more guards on it. Comments
+    // are stripped first, or the prose above explaining the old single-level
+    // readdirSync would count as a call site.
     const own = codeOnly(
       readFileSync(path.resolve(process.cwd(), 'tests/professions_silent_loot.test.ts'), 'utf8'),
     );
     // Assembled from halves so the needle does not match itself and read as the
-    // second call site it exists to forbid.
+    // call site it exists to forbid.
     const needle = `readdir${'Sync('}`;
     expect(
       own.split(needle).length - 1,
-      'this file should read a directory in exactly one place (tsFilesUnder); a second reader can go flat while the first stays recursive',
-    ).toBe(1);
+      'this file should not read a directory itself; the sweep goes through tests/helpers/ts_files_under, and a second reader could go flat while the shared one stays recursive',
+    ).toBe(0);
+    expect(own).toContain('helpers/ts_files_under');
   });
 
   it('the exclusion list has no stale entries', () => {

--- a/tests/server/steam_routes.test.ts
+++ b/tests/server/steam_routes.test.ts
@@ -689,7 +689,9 @@ describe('login with Steam does not exist', () => {
     );
     // Needle assembled from halves so it does not match itself.
     expect(own.split(`readdir${'Sync('}`).length - 1).toBe(0);
-    expect(own).toContain('helpers/ts_files_under');
+    // Needle split for the same reason as the one above: written whole it would
+    // match its own assertion line, so this passed even with the import gone.
+    expect(own).toContain(`helpers/ts_files${'_under'}`);
   });
 
   it('a successful link response carries no token-shaped field', async () => {

--- a/tests/server/steam_routes.test.ts
+++ b/tests/server/steam_routes.test.ts
@@ -595,7 +595,11 @@ describe('login with Steam does not exist', () => {
   // deletes from the `//` inside a URL literal to end of line, which silently
   // drops real code from the scan (server/steam/ticket.ts's PARTNER_API_HOST is
   // exactly that shape) and would take a violation sharing that line with it.
-  // Same idiom as codeOnly in tests/professions_silent_loot.test.ts.
+  // Same idiom as codeOnly in tests/professions_silent_loot.test.ts. The order
+  // trades one hazard for a rarer one: a `/*` written inside a line comment now
+  // opens a block strip that runs to the next `*/`. No file under server/steam
+  // has that shape, and the strip only ever deletes, so both hazards fail
+  // toward a quieter scan rather than a false accusation.
   const codeOnly = (source: string): string =>
     source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
 
@@ -613,10 +617,13 @@ describe('login with Steam does not exist', () => {
       tsFilesUnder(STEAM_DIR).map((f) => f.file),
       'server/steam source files: a new module joins this list and stays clear of FORBIDDEN',
     ).toEqual(STEAM_SOURCE_FILES);
-    // The strip must not eat live code: a regression that blanked the source
-    // would leave the rule below passing over nothing at all.
+    // The strip must not eat live code. Bound to the WHOLE url literal, not to
+    // the identifier: under the old line-comments-first order this line survived
+    // as `export const PARTNER_API_HOST = 'https:`, so an identifier check
+    // passed while 25 characters of real code left the scan. Only the full
+    // literal turns that revert red.
     expect(codeOnly(fs.readFileSync(path.join(STEAM_DIR, 'ticket.ts'), 'utf8'))).toContain(
-      'PARTNER_API_HOST',
+      "'https://partner.steam-api.com'",
     );
     // ... and it must still remove the prose that states the rule, or the scan
     // reports the documentation as a violation of itself.

--- a/tests/server/steam_routes.test.ts
+++ b/tests/server/steam_routes.test.ts
@@ -5,8 +5,10 @@
 process.env.DATABASE_URL ||= 'postgres://test:test@127.0.0.1:5433/wocc_steam_units';
 
 import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { tsFilesUnder } from '../helpers/ts_files_under';
 
 // Isolate the route layer: SQL boundary, upstream verification, and the
 // mirror are each mocked (the mirror has its own suite; the routes only owe
@@ -245,14 +247,17 @@ describe('POST /api/steam/link', () => {
     ['non-hex', 'z'.repeat(80)],
     ['too short', 'a'.repeat(MIN_TICKET_HEX_CHARS - 2)],
     ['too long', 'a'.repeat(MAX_TICKET_HEX_CHARS + 2)],
-  ])('rejects a %s ticket 400 steam.invalid_ticket without an upstream call', async (_name, ticket) => {
-    enableSteam();
-    await expect(handler()(linkCtx({ ticket }))).rejects.toMatchObject({
-      status: 400,
-      code: 'steam.invalid_ticket',
-    });
-    expect(verifyMock).not.toHaveBeenCalled();
-  });
+  ])(
+    'rejects a %s ticket 400 steam.invalid_ticket without an upstream call',
+    async (_name, ticket) => {
+      enableSteam();
+      await expect(handler()(linkCtx({ ticket }))).rejects.toMatchObject({
+        status: 400,
+        code: 'steam.invalid_ticket',
+      });
+      expect(verifyMock).not.toHaveBeenCalled();
+    },
+  );
 
   it('answers 503 steam.upstream when enabled but unprovisioned (no app id / key), before any upstream call', async () => {
     process.env.STEAM_ENABLED = '1';
@@ -349,18 +354,21 @@ describe('POST /api/steam/link', () => {
   it.each([
     ['account_linked' as const, 'steam.already_linked'],
     ['steam_taken' as const, 'steam.account_taken'],
-  ])('maps a displace race arm %s to its 409 (23505 re-classified behind the reclaim)', async (arm, code) => {
-    enableSteam();
-    accountForSteamIdMock.mockResolvedValue(99);
-    displaceMock.mockResolvedValue({ result: arm, displacedAccountId: null });
-    await expect(handler()(linkCtx({ ticket: GOOD_TICKET }))).rejects.toMatchObject({
-      status: 409,
-      code,
-    });
-    // A lost race wrote nothing, so no reconcile and no cache flip.
-    expect(reconcileMock).not.toHaveBeenCalled();
-    expect(onLinkChangedMock).not.toHaveBeenCalled();
-  });
+  ])(
+    'maps a displace race arm %s to its 409 (23505 re-classified behind the reclaim)',
+    async (arm, code) => {
+      enableSteam();
+      accountForSteamIdMock.mockResolvedValue(99);
+      displaceMock.mockResolvedValue({ result: arm, displacedAccountId: null });
+      await expect(handler()(linkCtx({ ticket: GOOD_TICKET }))).rejects.toMatchObject({
+        status: 409,
+        code,
+      });
+      // A lost race wrote nothing, so no reconcile and no cache flip.
+      expect(reconcileMock).not.toHaveBeenCalled();
+      expect(onLinkChangedMock).not.toHaveBeenCalled();
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -545,19 +553,136 @@ describe('ticket helpers (pure)', () => {
 // ---------------------------------------------------------------------------
 
 describe('login with Steam does not exist', () => {
-  it('no file under server/steam/ references newToken or auth_tokens (source scan)', () => {
-    const dir = path.resolve(process.cwd(), 'server/steam');
-    const files = fs.readdirSync(dir).filter((f) => f.endsWith('.ts'));
-    expect(files.length).toBeGreaterThanOrEqual(7);
-    for (const file of files) {
-      const source = fs.readFileSync(path.join(dir, file), 'utf8');
-      // The strings appear here only inside this scan and the routes module's
-      // rule comment; strip comments before asserting so documentation of the
-      // rule cannot mask a violation.
-      const code = source.replace(/\/\/[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
-      expect(code, `${file} must not mint tokens`).not.toContain('newToken');
-      expect(code, `${file} must not touch auth_tokens`).not.toContain('auth_tokens');
+  const STEAM_DIR = path.resolve(process.cwd(), 'server/steam');
+
+  // The source files the rule covers, exactly. The `>= 7` floor this replaces
+  // sat ONE under the real 8, so a module could leave the top level (deleted,
+  // renamed, or moved down into a subdirectory) and the scan would still pass
+  // over whatever was left. The #2489 shape lands squarely in that slack: a
+  // split takes the count to 7 while every file in the new folder sits outside
+  // a single-level read. A new steam module joins this list and the Layout
+  // section of server/steam/CLAUDE.md in the same change.
+  const STEAM_SOURCE_FILES = [
+    'achievement_map.ts',
+    'config.ts',
+    'index.ts',
+    'mirror.ts',
+    'routes.ts',
+    'steam_db.ts',
+    'ticket.ts',
+    'web_api.ts',
+  ];
+
+  // The credential-minting surface the steam domain may never reach for.
+  // `newToken` (server/auth.ts) only generates the random string; the MINT is
+  // `saveToken` (server/db.ts, the repo's one INSERT INTO auth_tokens) and its
+  // `createCompanionToken` wrapper, and provisioning is `createAccount`. The
+  // two-string list this replaces could not see the minimal violation
+  // `await saveToken(randomBytes(32).toString('hex'), accountId)`, which names
+  // neither string and is the established idiom elsewhere under server/.
+  const FORBIDDEN = [
+    'newToken',
+    'auth_tokens',
+    'saveToken',
+    'createCompanionToken',
+    'createAccount',
+  ];
+
+  // Source with comments removed, so the rule's own documentation cannot read
+  // as a violation of it (server/steam/routes.ts and steam_db.ts both state the
+  // rule in prose, naming the forbidden strings). BLOCK comments first, then
+  // line comments guarded by a leading non-colon: the reverse order, unguarded,
+  // deletes from the `//` inside a URL literal to end of line, which silently
+  // drops real code from the scan (server/steam/ticket.ts's PARTNER_API_HOST is
+  // exactly that shape) and would take a violation sharing that line with it.
+  // Same idiom as codeOnly in tests/professions_silent_loot.test.ts.
+  const codeOnly = (source: string): string =>
+    source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+  // Every forbidden reference under `root`, tagged with the file it came from.
+  // Takes a root rather than closing over STEAM_DIR, so the recursion case
+  // below drives the exact scanner the rule uses, not a restatement of it.
+  const mintSitesUnder = (root: string): string[] =>
+    tsFilesUnder(root).flatMap(({ file, full }) => {
+      const code = codeOnly(fs.readFileSync(full, 'utf8'));
+      return FORBIDDEN.filter((token) => code.includes(token)).map((token) => `${file}: ${token}`);
+    });
+
+  it('the scan reads every source file under server/steam (never passes vacuously)', () => {
+    expect(
+      tsFilesUnder(STEAM_DIR).map((f) => f.file),
+      'server/steam source files: a new module joins this list and stays clear of FORBIDDEN',
+    ).toEqual(STEAM_SOURCE_FILES);
+    // The strip must not eat live code: a regression that blanked the source
+    // would leave the rule below passing over nothing at all.
+    expect(codeOnly(fs.readFileSync(path.join(STEAM_DIR, 'ticket.ts'), 'utf8'))).toContain(
+      'PARTNER_API_HOST',
+    );
+    // ... and it must still remove the prose that states the rule, or the scan
+    // reports the documentation as a violation of itself.
+    const routesSource = fs.readFileSync(path.join(STEAM_DIR, 'routes.ts'), 'utf8');
+    expect(routesSource).toContain('newToken');
+    expect(codeOnly(routesSource)).not.toContain('newToken');
+  });
+
+  it('no file under server/steam mints or touches a credential (source scan)', () => {
+    expect(
+      mintSitesUnder(STEAM_DIR),
+      'the steam domain reached for the credential surface; linking never mints a login',
+    ).toEqual([]);
+  });
+
+  it('the scan descends, so a module in a SUBDIRECTORY is covered too (#2489)', () => {
+    // server/steam is flat today, so nothing above can tell a recursive walk
+    // from the single-level one it replaces: the rule would go on passing if
+    // the read quietly went flat again, while a module in a new folder minted
+    // freely. Drive the real scanner over a fixture tree instead.
+    const fixture = fs.mkdtempSync(path.join(tmpdir(), 'woc-steam-scan-'));
+    try {
+      fs.mkdirSync(path.join(fixture, 'nested', 'deeper'), { recursive: true });
+      fs.writeFileSync(path.join(fixture, 'clean.ts'), 'export const ok = true;\n');
+      fs.writeFileSync(
+        path.join(fixture, 'nested', 'mints.ts'),
+        "import { newToken } from '../../auth';\n",
+      );
+      fs.writeFileSync(
+        path.join(fixture, 'nested', 'deeper', 'reads_table.ts'),
+        "export const q = 'SELECT 1 FROM auth_tokens';\n",
+      );
+      // A violation only the widened FORBIDDEN list can see, three levels down:
+      // it names neither newToken nor auth_tokens.
+      fs.writeFileSync(
+        path.join(fixture, 'nested', 'deeper', 'wrapper.ts'),
+        'export const t = await saveToken(random, accountId);\n',
+      );
+      // Documentation of the rule, nested: it must NOT read as a violation.
+      fs.writeFileSync(
+        path.join(fixture, 'nested', 'documented.ts'),
+        '// This module must never call newToken or touch auth_tokens.\n',
+      );
+      // A non-source sibling that would violate: the extension filter holds.
+      fs.writeFileSync(path.join(fixture, 'nested', 'notes.md'), 'newToken(auth_tokens)\n');
+
+      expect(mintSitesUnder(fixture)).toEqual([
+        'nested/deeper/reads_table.ts: auth_tokens',
+        'nested/deeper/wrapper.ts: saveToken',
+        'nested/mints.ts: newToken',
+      ]);
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true });
     }
+  });
+
+  it('the rule reads the tree through the shared walker, with no flat reader beside it', () => {
+    // The case above pins the WALKER; nothing can pin that the rule still goes
+    // through it, because server/steam is flat, so a second inline flat read
+    // would return the identical list today with every assertion green.
+    const own = codeOnly(
+      fs.readFileSync(path.resolve(process.cwd(), 'tests/server/steam_routes.test.ts'), 'utf8'),
+    );
+    // Needle assembled from halves so it does not match itself.
+    expect(own.split(`readdir${'Sync('}`).length - 1).toBe(0);
+    expect(own).toContain('helpers/ts_files_under');
   });
 
   it('a successful link response carries no token-shaped field', async () => {


### PR DESCRIPTION
## Summary

#2485 fixed one instance of a class: a guard that enumerates source files with a single-level
`readdirSync`, so anything in a subdirectory silently leaves coverage while the guard stays green.
This closes the three remaining instances, and the fourth thing they revealed: nobody was going to
stop the next one.

Every scan root involved is flat today, so all three recursions are zero-delta. That is exactly why
they were worth fixing now rather than after the first miss: nothing about the current tree can tell
a recursive walk from a flat one, so the bug only ever shows up as coverage that was never there.

This is test-only. No production code changes.

**The walk is now shared.** `tests/helpers/ts_files_under.ts`, one argument, no knobs. Fixing #2489
would otherwise have put the third and fourth hand-rolled copies of the same twelve lines on disk,
which is where the rule of three stops being a guideline. The helper's paired test carries the arm
no consumer can reach: a symlinked `.ts` file, which is *why* the file arm has no `entry.isFile()`
gate (a `Dirent` reports lstat, so that check reads false for a symlink the flat read would have
followed).

**`server/steam`, the forbidden-login scan.** Recursive now, and two more defects lived in the same
expression:

- The `>= 7` floor sat one under the real 8, so a module could leave the top level and the rule
  would still pass over what was left. A split takes the count to 7. It is the exact file list now.
- The comment strip ran line comments first and unguarded, so it deleted from the `//` inside
  `ticket.ts`'s `PARTNER_API_HOST` URL to end of line, dropping live code from the scan and taking
  any violation sharing that line with it. Block comments first, guarded by a leading non-colon.
- The forbidden list could not see the actual mint. `newToken` only makes the string; `saveToken`
  (the repo's one `INSERT INTO auth_tokens`), `createCompanionToken` and `createAccount` are what
  issue a credential, so `await saveToken(randomBytes(32).toString('hex'), accountId)` named neither
  forbidden string. All three are now on the list.

**`src/sim/social`, the S3 emit drift guard.** The one automatic input in an otherwise hand-curated
list of ~40 files, so also the one whose disappearance nobody would catch by reading a diff. The
`existsSync(...) : ''` fallback went with it: that arm let a moved or renamed directory scan nothing
at all, forever, green. The corpus floor sat at 80 against a real 428 (it now binds 400), and two new
cases bind the glob itself rather than the total it disappears into: its 16 files by name, and the
237 emit candidates it contributes (floor 220). Measured, not guessed: the corpus is 428 with the
glob and 290 without it, so the old floor of 80 would not have moved if the whole glob went silent,
while the new one would. The two glob-specific pins are what localize a PARTIAL loss, and what say
which input went missing.

**`src/ui`, the mobile-window scrape.** The flat read was pointed at exactly the directory the repo
tells contributors not to add components to: `src/ui/CLAUDE.md` sends a new HUD component to
`src/ui/hud/<domain>/`, and much of the window family already lives there. Those stay visible only
because they paint into static markup ids; the day one mints its own `.window` root a flat read goes
blind while every assertion stays green. Its floors were all under water too (20 against a real 40,
one window-class file against a real 3, and a scanned-file count computed and never asserted), and
they are now per-entry, exact where the recursion widens the arm, and a file-count floor that
separates the walk's 450 from the flat read's 295.

`src/styles` in that same file deliberately stays single-level, with the reason written down. It
models the sheets that actually ship, not the files on disk, so recursing would let a component-local
or experimental sheet parked in a subfolder count as mobile coverage for a rule that never loads. Its
failure direction is opposite too: a missed `src/ui` module is a silent pass, a missed stylesheet is
a loud red.

**One thing found along the way.** The exception map excused `#daily-rewards-window` for carrying
"only a z-index bump" long after `hud.mobile.css` gave it an id-scoped `max-height`, so the entry was
dead and its reason false. Removed, plus a case that keeps the map honest. That case asks a stricter
question than the coverage sweep on purpose: `hasMobileRule` credits a rule where the id is merely an
ancestor, which is right for coverage but would have deleted `#loot-window`'s legitimate exception,
since that id is named only through `#loot-window .btn` (a min-height for its buttons, sheeting
nothing).

## Related issues

Closes #2489. Follow-up to #2485 (#2488).

## Type of change

- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/server/steam_routes.test.ts tests/localization_fixes.test.ts tests/mobile_window_coverage.test.ts tests/professions_silent_loot.test.ts tests/helpers/ts_files_under.test.ts` (121 passed, 3 skipped)
  - `npm run gate` (green, all 11 steps)
- Manual steps (the issue's acceptance criterion 2, done for real and reverted). Added one violating
  file in a subdirectory of each root:
  - `server/steam/mirror/mint.ts` calling `saveToken` (a violation only the widened list can see):
    red on the file-list pin and on the mint scan.
  - `src/sim/social/cards/leak.ts` emitting an unregistered string: red on `s3_registered` naming
    the leaked string, and on the glob's file list.
  - `src/ui/hud/fixture/fixture_window.ts` minting a `.window` root: red on `windowClassFiles` and
    then on the unclassified-window sweep.
  - The pre-change flat reads over the same tree saw none of the three (`server/steam` still 8 files,
    `src/sim/social` still 16, `src/ui` still 295), so the recursion is what catches them.
  - Deleted the three probes; all suites green again.
- Every new pin was mutation-checked rather than eyeballed. Reverting the comment strip to
  line-comments-first turns the steam suite red (it did not, at first: review caught that the pin
  asked for `PARTNER_API_HOST`, which survives the broken strip inside the truncated
  `= 'https:`, so it now binds the whole url literal). Reverting the walk to single-level, capping
  its depth, or dropping the path prefix each turns the helper's own suite red.
- Floors, measured against their real values so a reviewer can see the margin: steam exactly 8
  files; social exactly 16 files and 237 emit candidates (floor 220); S3 corpus 428 (floor 400);
  `src/ui` 450 recursive against 295 flat and 374 at a one-level cap (floor 400); 37 window ids per
  entry (floor 35).

A coverage audit then found five escapes in the new pins themselves, all fixed in the last two
commits and each verified by mutation rather than by reading:

- The `toContain('helpers/ts_files_under')` half of three meta-guards was self-satisfying, since the
  needle sat in its own assertion line (and, in one file, in the failure message too). It passed
  with the import deleted. Split, like the `readdirSync` needle beside it already was.
- The walk dropped a symlinked DIRECTORY, for the same lstat reason its file arm was careful about,
  losing a whole subtree instead of one file.
- The comment-strip fix shipped unpinned: the pin asked for `PARTNER_API_HOST`, which survives the
  broken strip inside the truncated `= 'https:`, so reverting the fix left the suite green.
- Two `hasOwnSheetRule` clauses were unexercised, because the real cascade satisfies both controls
  through one plain rule. Pinning them over a fixture cascade showed the id-boundary lookahead was
  unreachable behind the trailing anchor, so it was removed rather than left looking load-bearing.
- Two comments were factually wrong, one of them made wrong by this branch (see the corrected
  corpus numbers above; the other miscounted the styles cascade as 9 sheets rather than 10).

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [x] N/A. Test-only change with no UI surface. The shared walk builds its labels with forward
      slashes explicitly rather than relying on the platform separator, and sorts within each
      directory so the label list is the same on the ext4 CI runner as on an APFS dev checkout.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The S3 guard's corpus is unchanged in content:
      the recursion is zero-delta today, so no new emit enters the drift guard.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

One formatting note: `tests/server/steam_routes.test.ts` had a pre-existing biome format error at
the base commit, so touching the file makes `ci:changed` fail on it. The reformatted `it.each`
blocks in that file's diff are that, not a drive-by refactor.
