### PR TITLE
feat(claudium): use service-controlled WOC discount

### DIFF
--- a/docs/claudium-store.md
+++ b/docs/claudium-store.md
@@ -39,8 +39,9 @@ These names match the economy service implementation. Do not place Stripe secret
 IDs in the game-client repository.
 
 SOL, USDC, and WOC amounts must continue to be quoted by the economy service from the USD value.
-The WOC rail should return the existing service-computed 20 percent discount. The game client
-displays the returned quote and does not calculate token prices or discounts. All three native
+The WOC rail should return the service-controlled discount (20 percent by default). Operators can
+change that base discount in the internal dashboard without rebuilding the game. The game client
+displays the returned discount and quote and does not calculate token prices. All three native
 rails flow through the same native quote, confirm, and purchase endpoints proxied by the game
 server (`server/claudium_proxy.ts`); the economy service decides which rails are offered via its
 native rails response (`rails.sol`, `rails.usdc`, `rails.woc`), so enabling or disabling USDC is

--- a/server/claudium_proxy.ts
+++ b/server/claudium_proxy.ts
@@ -41,6 +41,7 @@ export interface ClaudiumNativePriceResult {
   rail: ClaudiumNativeRail;
   claudium: number | null;
   amountBase: string | null;
+  discountBps: number | null;
   reason?: string;
 }
 
@@ -293,6 +294,7 @@ export async function claudiumNativePrice(
     rail?: ClaudiumNativeRail;
     claudium?: number;
     amountBase?: string | null;
+    discountBps?: number | null;
     reason?: string;
   }>({
     method: 'GET',
@@ -305,6 +307,13 @@ export async function claudiumNativePrice(
         ? data.claudium
         : null,
     amountBase: typeof data?.amountBase === 'string' ? data.amountBase : null,
+    discountBps:
+      typeof data?.discountBps === 'number' &&
+      Number.isInteger(data.discountBps) &&
+      data.discountBps >= 0 &&
+      data.discountBps <= 9000
+        ? data.discountBps
+        : null,
     reason: data?.reason ?? (data ? undefined : 'unavailable'),
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -214,7 +214,7 @@ import { deleteCharButtonHtml } from './ui/char_delete_button';
 import { loadCharselectNews } from './ui/charselect_news';
 import { ChatCommandMenu } from './ui/chat_command_menu';
 import { CLASS_DETAILS, SIGNATURE_ABILITIES } from './ui/class_details_data';
-import { claudiumBalanceAddress } from './ui/claudium_view';
+import { claudiumBalanceAddress, currentWocDiscountBps } from './ui/claudium_view';
 import { ensureDeedLocalesLoaded } from './ui/deed_i18n';
 import { isDevGuiCommand } from './ui/dev_command_view';
 import { devTierByIndex, devTierDisplayName } from './ui/dev_tier';
@@ -2315,6 +2315,7 @@ async function startGame(
             balance,
             skus,
             nativeRails,
+            wocDiscountBps: null,
             walletBalances: {
               solLamports: null,
               usdcBaseUnits: null,
@@ -2360,14 +2361,17 @@ async function startGame(
               solAmountBase: nativeAmountBase('sol', row.sku, sol?.amountBase),
               usdcAmountBase: nativeAmountBase('usdc', row.sku, usdc?.amountBase),
               wocAmountBase: nativeAmountBase('woc', row.sku, woc?.amountBase),
+              wocDiscountBps: woc?.discountBps ?? null,
             };
           }),
         );
+        const wocDiscountBps = currentWocDiscountBps(nativePrices);
         return {
           available: true,
           balance,
           skus,
           nativeRails,
+          wocDiscountBps,
           walletBalances: {
             solLamports: solBalance.lamports,
             usdcBaseUnits: usdcBalance.amountBase,

--- a/src/net/economy_sdk.ts
+++ b/src/net/economy_sdk.ts
@@ -85,6 +85,7 @@ export interface ClaudiumNativePrice {
   rail: ClaudiumNativeRail;
   claudium: number | null;
   amountBase: string | null;
+  discountBps: number | null;
   reason?: string;
 }
 
@@ -294,13 +295,25 @@ export class EconomyClient {
     return this.get('/api/claudium/native/rails', OFF_NATIVE_RAILS);
   }
 
-  nativePrice(rail: ClaudiumNativeRail, sku: string): Promise<ClaudiumNativePrice> {
-    return this.get(`/api/claudium/native/price/${rail}?sku=${encodeURIComponent(sku)}`, {
-      rail,
-      claudium: null,
-      amountBase: null,
-      reason: 'unavailable',
-    });
+  async nativePrice(rail: ClaudiumNativeRail, sku: string): Promise<ClaudiumNativePrice> {
+    const price = await this.get(
+      `/api/claudium/native/price/${rail}?sku=${encodeURIComponent(sku)}`,
+      {
+        rail,
+        claudium: null,
+        amountBase: null,
+        discountBps: null,
+        reason: 'unavailable',
+      },
+    );
+    const discountBps =
+      Number.isInteger(price.discountBps) &&
+      price.discountBps !== null &&
+      price.discountBps >= 0 &&
+      price.discountBps <= 9000
+        ? price.discountBps
+        : null;
+    return { ...price, discountBps };
   }
 
   solBalance(owner: string): Promise<ClaudiumSolBalance> {

--- a/src/ui/claudium_view.ts
+++ b/src/ui/claudium_view.ts
@@ -31,6 +31,7 @@ export interface ClaudiumNativeSkuPriceInput {
   solAmountBase?: string | null;
   usdcAmountBase?: string | null;
   wocAmountBase?: string | null;
+  wocDiscountBps?: number | null;
 }
 
 /** The raw inputs, all sourced from the service via the SDK. */
@@ -38,6 +39,7 @@ export interface ClaudiumViewInput {
   /** Integer Claudium balance, or null when the service is off. */
   balance: number | null;
   skus: readonly ClaudiumSkuInput[];
+  wocDiscountBps?: number | null;
   nativeRails?: Partial<Record<'sol' | 'usdc' | 'woc', boolean>>;
   walletBalances?: ClaudiumWalletBalancesInput;
   nativePrices?: readonly ClaudiumNativeSkuPriceInput[];
@@ -76,6 +78,7 @@ export interface ClaudiumView {
   hasBalance: boolean;
   /** The integer balance to render, or null in the disabled state. */
   balance: number | null;
+  wocDiscountBps: number | null;
   walletBalances: ClaudiumWalletBalancesInput;
   buyRows: ClaudiumBuyRow[];
   rails: ClaudiumRailAvailability;
@@ -97,6 +100,27 @@ export function claudiumBalanceAddress(
   linkedWalletPubkey: string | null,
 ): string | null {
   return connectedAddress ?? linkedWalletPubkey;
+}
+
+/** Select the current service-owned $WOC discount when fetched SKU prices agree. */
+export function currentWocDiscountBps(
+  nativePrices: readonly ClaudiumNativeSkuPriceInput[],
+): number | null {
+  let current: number | null = null;
+  for (const row of nativePrices) {
+    const value = row.wocDiscountBps;
+    if (
+      !Number.isInteger(value) ||
+      value === null ||
+      value === undefined ||
+      value < 0 ||
+      value > 9000
+    )
+      return null;
+    if (current !== null && current !== value) return null;
+    current = value;
+  }
+  return current;
 }
 
 function affordable(balance: string | null | undefined, cost: string | null | undefined): boolean {
@@ -122,6 +146,7 @@ export function buildClaudiumView(input: ClaudiumViewInput): ClaudiumView {
       disabled: true,
       hasBalance: false,
       balance: null,
+      wocDiscountBps: null,
       walletBalances: { solLamports: null, usdcBaseUnits: null, wocBaseUnits: null },
       buyRows: [],
       rails: { stripe: false, sol: false, usdc: false, woc: false },
@@ -166,6 +191,7 @@ export function buildClaudiumView(input: ClaudiumViewInput): ClaudiumView {
     disabled: false,
     hasBalance: true,
     balance,
+    wocDiscountBps: input.wocDiscountBps ?? null,
     walletBalances,
     buyRows,
     rails: { stripe, sol, usdc, woc },

--- a/src/ui/claudium_window.ts
+++ b/src/ui/claudium_window.ts
@@ -25,6 +25,8 @@ export interface ClaudiumSnapshot {
   available?: boolean;
   balance: number | null;
   skus: readonly ClaudiumSkuInput[];
+  /** Current service-computed $WOC discount, in basis points. */
+  wocDiscountBps?: number | null;
   nativeRails?: Partial<Record<'sol' | 'usdc' | 'woc', boolean>>;
   walletBalances?: {
     solLamports: string | null;
@@ -367,6 +369,18 @@ export class ClaudiumWindow {
     const solSel = this.selectedRail === 'sol' ? ' aria-pressed="true"' : ' aria-pressed="false"';
     const usdcSel = this.selectedRail === 'usdc' ? ' aria-pressed="true"' : ' aria-pressed="false"';
     const wocSel = this.selectedRail === 'woc' ? ' aria-pressed="true"' : ' aria-pressed="false"';
+    const wocDiscount =
+      Number.isInteger(view.wocDiscountBps) &&
+      (view.wocDiscountBps ?? -1) >= 0 &&
+      (view.wocDiscountBps ?? 10_000) <= 9000
+        ? `<span class="cl-rail-discount">${esc(
+            t('hudChrome.claudium.railWocDiscount', {
+              percent: formatNumber((view.wocDiscountBps ?? 0) / 100, {
+                maximumFractionDigits: 2,
+              }),
+            }),
+          )}</span>`
+        : '';
     const railPicker =
       `<div class="cl-rails" role="group" aria-label="${esc(t('hudChrome.claudium.railLabel'))}">` +
       `<button type="button" class="cl-rail" data-rail="stripe"${stripeSel} ${view.rails.stripe && !pending ? '' : 'disabled'}>` +
@@ -376,7 +390,7 @@ export class ClaudiumWindow {
       `<button type="button" class="cl-rail cl-rail-woc" data-rail="woc"${wocSel} ${view.rails.woc && !pending ? '' : 'disabled'}>` +
       this.railIconHtml('woc') +
       `<span>${esc(t('hudChrome.claudium.railWoc'))}</span>` +
-      `<span class="cl-rail-discount">${esc(t('hudChrome.claudium.railWocDiscount'))}</span>` +
+      wocDiscount +
       `</button>` +
       `<button type="button" class="cl-rail" data-rail="usdc"${usdcSel} ${view.rails.usdc && !pending ? '' : 'disabled'}>` +
       this.railIconHtml('usdc') +

--- a/src/ui/i18n.catalog/hud_chrome.ts
+++ b/src/ui/i18n.catalog/hud_chrome.ts
@@ -238,7 +238,7 @@ export const hudChromeStrings = {
     railSol: 'SOL',
     railUsdc: 'USDC',
     railWoc: 'WOC',
-    railWocDiscount: '20% off',
+    railWocDiscount: '{percent}% off',
     railWocUnavailable: 'WOC pricing is unavailable right now.',
     railNativeUnavailable: 'Crypto off.',
     amountLabel: 'Amount',

--- a/src/ui/i18n.locales/cs_CZ.ts
+++ b/src/ui/i18n.locales/cs_CZ.ts
@@ -8223,7 +8223,7 @@ export const cs_CZ: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': 'Karta',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': 'Sleva 20 %',
+  'hudChrome.claudium.railWocDiscount': 'Sleva {percent} %',
   'hudChrome.claudium.railWocUnavailable': 'Cena ve WOC nyní není dostupná.',
   'hudChrome.claudium.showAmounts': 'Zobrazit všechny nabídky Claudium',
   'hudChrome.claudium.skuRow': '{claudium} Claudium za {usd}',

--- a/src/ui/i18n.locales/da_DK.ts
+++ b/src/ui/i18n.locales/da_DK.ts
@@ -8290,7 +8290,7 @@ export const da_DK: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': 'Kort',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': '20% rabat',
+  'hudChrome.claudium.railWocDiscount': '{percent}% rabat',
   'hudChrome.claudium.railWocUnavailable': 'WOC-priser er ikke tilgængelige lige nu.',
   'hudChrome.claudium.showAmounts': 'Vis alle Claudium-beløb',
   'hudChrome.claudium.skuRow': '{usd} til {claudium} Claudium',

--- a/src/ui/i18n.locales/de_DE.ts
+++ b/src/ui/i18n.locales/de_DE.ts
@@ -8334,7 +8334,7 @@ export const de_DE: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': 'Karte',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': '20% Rabatt',
+  'hudChrome.claudium.railWocDiscount': '{percent}% Rabatt',
   'hudChrome.claudium.railWocUnavailable': 'WOC-Preise sind derzeit nicht verfügbar.',
   'hudChrome.claudium.showAmounts': 'Alle Claudium-Mengen anzeigen',
   'hudChrome.claudium.skuRow': '{claudium} Claudium für {usd}',

--- a/src/ui/i18n.locales/es.ts
+++ b/src/ui/i18n.locales/es.ts
@@ -8248,7 +8248,7 @@ export const es: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': 'Tarjeta',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': '20 % de descuento',
+  'hudChrome.claudium.railWocDiscount': '{percent} % de descuento',
   'hudChrome.claudium.railWocUnavailable':
     'Los precios en WOC no están disponibles en este momento.',
   'hudChrome.claudium.showAmounts': 'Mostrar todas las cantidades de Claudium',

--- a/src/ui/i18n.locales/fr_FR.ts
+++ b/src/ui/i18n.locales/fr_FR.ts
@@ -1259,7 +1259,7 @@ export const fr_FR: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': 'Carte',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': '20 % de réduction',
+  'hudChrome.claudium.railWocDiscount': '{percent} % de réduction',
   'hudChrome.claudium.railWocUnavailable': 'Les prix en WOC sont indisponibles pour le moment.',
   'hudChrome.claudium.showAmounts': 'Afficher tous les montants de Claudium',
   'hudChrome.claudium.skuRow': '{claudium} Claudium pour {usd}',

--- a/src/ui/i18n.locales/id_ID.ts
+++ b/src/ui/i18n.locales/id_ID.ts
@@ -8276,7 +8276,7 @@ export const id_ID: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': 'Kartu',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': 'Diskon 20%.',
+  'hudChrome.claudium.railWocDiscount': 'Diskon {percent}%.',
   'hudChrome.claudium.railWocUnavailable': 'Harga WOC tidak tersedia saat ini.',
   'hudChrome.claudium.showAmounts': 'Tampilkan semua jumlah Claudium',
   'hudChrome.claudium.skuRow': '{usd} untuk {claudium} Claudium',

--- a/src/ui/i18n.locales/it_IT.ts
+++ b/src/ui/i18n.locales/it_IT.ts
@@ -8380,7 +8380,7 @@ export const it_IT: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': 'Carta',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': '20% di sconto',
+  'hudChrome.claudium.railWocDiscount': '{percent}% di sconto',
   'hudChrome.claudium.railWocUnavailable': 'I prezzi WOC non sono disponibili al momento.',
   'hudChrome.claudium.showAmounts': 'Mostra tutti gli importi di Claudium',
   'hudChrome.claudium.skuRow': '{usd} per {claudium} Claudium',

--- a/src/ui/i18n.locales/ja_JP.ts
+++ b/src/ui/i18n.locales/ja_JP.ts
@@ -421,7 +421,7 @@ export const ja_JP: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': 'カード',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': '20%オフ',
+  'hudChrome.claudium.railWocDiscount': '{percent}%オフ',
   'hudChrome.claudium.solBalance': 'SOL：{amount}',
   'hudChrome.claudium.wocBalance': 'WOC：{amount}',
   'hudChrome.claudium.railWocUnavailable': 'WOC価格は現在利用できません。',

--- a/src/ui/i18n.locales/ko_KR.ts
+++ b/src/ui/i18n.locales/ko_KR.ts
@@ -426,7 +426,7 @@ export const ko_KR: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': '카드',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': '20% 할인',
+  'hudChrome.claudium.railWocDiscount': '{percent}% 할인',
   'hudChrome.claudium.solBalance': 'SOL: {amount}',
   'hudChrome.claudium.wocBalance': 'WOC: {amount}',
   'hudChrome.claudium.railWocUnavailable': '현재 WOC 가격을 이용할 수 없습니다.',

--- a/src/ui/i18n.locales/nl_NL.ts
+++ b/src/ui/i18n.locales/nl_NL.ts
@@ -8356,7 +8356,7 @@ export const nl_NL: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': 'Kaart',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': '20% korting',
+  'hudChrome.claudium.railWocDiscount': '{percent}% korting',
   'hudChrome.claudium.railWocUnavailable': 'WOC-prijzen zijn momenteel niet beschikbaar.',
   'hudChrome.claudium.showAmounts': 'Toon alle Claudium-bedragen',
   'hudChrome.claudium.skuRow': '{usd} voor {claudium} Claudium',

--- a/src/ui/i18n.locales/pl_PL.ts
+++ b/src/ui/i18n.locales/pl_PL.ts
@@ -8320,7 +8320,7 @@ export const pl_PL: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': 'Karta',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': '20% zniżki',
+  'hudChrome.claudium.railWocDiscount': '{percent}% zniżki',
   'hudChrome.claudium.railWocUnavailable': 'Ceny WOC są obecnie niedostępne.',
   'hudChrome.claudium.showAmounts': 'Pokaż wszystkie ilości Claudium',
   'hudChrome.claudium.skuRow': '{usd} dla {claudium} Claudium',

--- a/src/ui/i18n.locales/pt_BR.ts
+++ b/src/ui/i18n.locales/pt_BR.ts
@@ -8226,7 +8226,7 @@ export const pt_BR: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': 'Cartão',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': '20% de desconto',
+  'hudChrome.claudium.railWocDiscount': '{percent}% de desconto',
   'hudChrome.claudium.railWocUnavailable': 'O preço do WOC não está disponível no momento.',
   'hudChrome.claudium.showAmounts': 'Mostrar todos os valores de Claudium',
   'hudChrome.claudium.skuRow': '{claudium} Claudium por {usd}',

--- a/src/ui/i18n.locales/ru_RU.ts
+++ b/src/ui/i18n.locales/ru_RU.ts
@@ -421,7 +421,7 @@ export const ru_RU: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': 'Карта',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': 'Скидка 20%',
+  'hudChrome.claudium.railWocDiscount': 'Скидка {percent}%',
   'hudChrome.claudium.solBalance': 'SOL: {amount}',
   'hudChrome.claudium.wocBalance': 'WOC: {amount}',
   'hudChrome.claudium.railWocUnavailable': 'Цена WOC сейчас недоступна.',

--- a/src/ui/i18n.locales/sv_SE.ts
+++ b/src/ui/i18n.locales/sv_SE.ts
@@ -8134,7 +8134,7 @@ export const sv_SE: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': 'Kort',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': '20% rabatt',
+  'hudChrome.claudium.railWocDiscount': '{percent}% rabatt',
   'hudChrome.claudium.railWocUnavailable': 'WOC-priser är inte tillgängliga just nu.',
   'hudChrome.claudium.showAmounts': 'Visa alla Claudium-belopp',
   'hudChrome.claudium.skuRow': '{usd} för {claudium} Claudium',

--- a/src/ui/i18n.locales/tr_TR.ts
+++ b/src/ui/i18n.locales/tr_TR.ts
@@ -8111,7 +8111,7 @@ export const tr_TR: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': 'Kart',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': '%20 indirim',
+  'hudChrome.claudium.railWocDiscount': '%{percent} indirim',
   'hudChrome.claudium.railWocUnavailable': 'WOC fiyatlandırması şu anda mevcut değil.',
   'hudChrome.claudium.showAmounts': 'Tüm Claudium miktarlarını göster',
   'hudChrome.claudium.skuRow': '{claudium} Claudium için {usd}',

--- a/src/ui/i18n.locales/vi_VN.ts
+++ b/src/ui/i18n.locales/vi_VN.ts
@@ -8223,7 +8223,7 @@ export const vi_VN: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': 'Thẻ',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': 'Giảm 20%',
+  'hudChrome.claudium.railWocDiscount': 'Giảm {percent}%',
   'hudChrome.claudium.railWocUnavailable': 'Giá WOC hiện không có sẵn.',
   'hudChrome.claudium.showAmounts': 'Hiển thị tất cả số lượng Claudium',
   'hudChrome.claudium.skuRow': '{usd} đổi lấy {claudium} Claudium',

--- a/src/ui/i18n.locales/zh_CN.ts
+++ b/src/ui/i18n.locales/zh_CN.ts
@@ -421,7 +421,7 @@ export const zh_CN: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': '银行卡',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': '优惠 20%',
+  'hudChrome.claudium.railWocDiscount': '优惠 {percent}%',
   'hudChrome.claudium.solBalance': 'SOL：{amount}',
   'hudChrome.claudium.wocBalance': 'WOC：{amount}',
   'hudChrome.claudium.railWocUnavailable': 'WOC 定价暂时不可用。',

--- a/src/ui/i18n.locales/zh_TW.ts
+++ b/src/ui/i18n.locales/zh_TW.ts
@@ -421,7 +421,7 @@ export const zh_TW: Partial<Record<TranslationKey, string>> = {
   'hudChrome.claudium.railSol': 'SOL',
   'hudChrome.claudium.railStripe': '信用卡',
   'hudChrome.claudium.railWoc': 'WOC',
-  'hudChrome.claudium.railWocDiscount': '優惠 20%',
+  'hudChrome.claudium.railWocDiscount': '優惠 {percent}%',
   'hudChrome.claudium.solBalance': 'SOL：{amount}',
   'hudChrome.claudium.wocBalance': 'WOC：{amount}',
   'hudChrome.claudium.railWocUnavailable': 'WOC 定價目前無法使用。',

--- a/src/ui/i18n.resolved.generated/cs_CZ.ts
+++ b/src/ui/i18n.resolved.generated/cs_CZ.ts
@@ -666,7 +666,7 @@ export const cs_CZ: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "Sleva 20 %",
+      "railWocDiscount": "Sleva {percent} %",
       "railWocUnavailable": "Cena ve WOC nyní není dostupná.",
       "railNativeUnavailable": "SOL/WOC nedostupné",
       "amountLabel": "Množství",

--- a/src/ui/i18n.resolved.generated/da_DK.ts
+++ b/src/ui/i18n.resolved.generated/da_DK.ts
@@ -666,7 +666,7 @@ export const da_DK: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "20% rabat",
+      "railWocDiscount": "{percent}% rabat",
       "railWocUnavailable": "WOC-priser er ikke tilgængelige lige nu.",
       "railNativeUnavailable": "SOL/WOC er slået fra.",
       "amountLabel": "Beløb",

--- a/src/ui/i18n.resolved.generated/de_DE.ts
+++ b/src/ui/i18n.resolved.generated/de_DE.ts
@@ -666,7 +666,7 @@ export const de_DE: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "20% Rabatt",
+      "railWocDiscount": "{percent}% Rabatt",
       "railWocUnavailable": "WOC-Preise sind derzeit nicht verfügbar.",
       "railNativeUnavailable": "SOL/WOC deaktiviert.",
       "amountLabel": "Menge",

--- a/src/ui/i18n.resolved.generated/en.ts
+++ b/src/ui/i18n.resolved.generated/en.ts
@@ -666,7 +666,7 @@ export const en: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "20% off",
+      "railWocDiscount": "{percent}% off",
       "railWocUnavailable": "WOC pricing is unavailable right now.",
       "railNativeUnavailable": "Crypto off.",
       "amountLabel": "Amount",

--- a/src/ui/i18n.resolved.generated/en_CA.ts
+++ b/src/ui/i18n.resolved.generated/en_CA.ts
@@ -666,7 +666,7 @@ export const en_CA: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "20% off",
+      "railWocDiscount": "{percent}% off",
       "railWocUnavailable": "WOC pricing is unavailable right now.",
       "railNativeUnavailable": "Crypto off.",
       "amountLabel": "Amount",

--- a/src/ui/i18n.resolved.generated/en_XA.ts
+++ b/src/ui/i18n.resolved.generated/en_XA.ts
@@ -666,7 +666,7 @@ export const en_XA: EnTranslations = {
       "railSol": "[ŠÓĻ]",
       "railUsdc": "[ÚŠÐÇ]",
       "railWoc": "[ŴÓÇ]",
-      "railWocDiscount": "[20% óƒƒ]",
+      "railWocDiscount": "[{percent}% óƒƒ]",
       "railWocUnavailable": "[ŴÓÇ þŕíçíñĝ íš úñáʋáíļáƀļé ŕíĝĥţ ñóŵ.]",
       "railNativeUnavailable": "[Çŕýþţó óƒƒ.]",
       "amountLabel": "[Áɱóúñţ]",

--- a/src/ui/i18n.resolved.generated/es.ts
+++ b/src/ui/i18n.resolved.generated/es.ts
@@ -666,7 +666,7 @@ export const es: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "20 % de descuento",
+      "railWocDiscount": "{percent} % de descuento",
       "railWocUnavailable": "Los precios en WOC no están disponibles en este momento.",
       "railNativeUnavailable": "SOL/WOC no disponible.",
       "amountLabel": "Cantidad",

--- a/src/ui/i18n.resolved.generated/es_ES.ts
+++ b/src/ui/i18n.resolved.generated/es_ES.ts
@@ -666,7 +666,7 @@ export const es_ES: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "20 % de descuento",
+      "railWocDiscount": "{percent} % de descuento",
       "railWocUnavailable": "Los precios en WOC no están disponibles en este momento.",
       "railNativeUnavailable": "SOL/WOC no disponible.",
       "amountLabel": "Cantidad",

--- a/src/ui/i18n.resolved.generated/fr_CA.ts
+++ b/src/ui/i18n.resolved.generated/fr_CA.ts
@@ -666,7 +666,7 @@ export const fr_CA: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "20 % de réduction",
+      "railWocDiscount": "{percent} % de réduction",
       "railWocUnavailable": "Les prix en WOC sont indisponibles pour le moment.",
       "railNativeUnavailable": "SOL/WOC désactivé.",
       "amountLabel": "Montant",

--- a/src/ui/i18n.resolved.generated/fr_FR.ts
+++ b/src/ui/i18n.resolved.generated/fr_FR.ts
@@ -666,7 +666,7 @@ export const fr_FR: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "20 % de réduction",
+      "railWocDiscount": "{percent} % de réduction",
       "railWocUnavailable": "Les prix en WOC sont indisponibles pour le moment.",
       "railNativeUnavailable": "SOL/WOC désactivé.",
       "amountLabel": "Montant",

--- a/src/ui/i18n.resolved.generated/id_ID.ts
+++ b/src/ui/i18n.resolved.generated/id_ID.ts
@@ -666,7 +666,7 @@ export const id_ID: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "Diskon 20%.",
+      "railWocDiscount": "Diskon {percent}%.",
       "railWocUnavailable": "Harga WOC tidak tersedia saat ini.",
       "railNativeUnavailable": "SOL/WOC tidak tersedia.",
       "amountLabel": "Jumlah",

--- a/src/ui/i18n.resolved.generated/it_IT.ts
+++ b/src/ui/i18n.resolved.generated/it_IT.ts
@@ -666,7 +666,7 @@ export const it_IT: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "20% di sconto",
+      "railWocDiscount": "{percent}% di sconto",
       "railWocUnavailable": "I prezzi WOC non sono disponibili al momento.",
       "railNativeUnavailable": "SOL/WOC non disponibile.",
       "amountLabel": "Quantità",

--- a/src/ui/i18n.resolved.generated/ja_JP.ts
+++ b/src/ui/i18n.resolved.generated/ja_JP.ts
@@ -666,7 +666,7 @@ export const ja_JP: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "20%オフ",
+      "railWocDiscount": "{percent}%オフ",
       "railWocUnavailable": "WOC価格は現在利用できません。",
       "railNativeUnavailable": "SOL/WOCは利用不可",
       "amountLabel": "数量",

--- a/src/ui/i18n.resolved.generated/ko_KR.ts
+++ b/src/ui/i18n.resolved.generated/ko_KR.ts
@@ -666,7 +666,7 @@ export const ko_KR: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "20% 할인",
+      "railWocDiscount": "{percent}% 할인",
       "railWocUnavailable": "현재 WOC 가격을 이용할 수 없습니다.",
       "railNativeUnavailable": "SOL/WOC 사용 불가",
       "amountLabel": "수량",

--- a/src/ui/i18n.resolved.generated/nl_NL.ts
+++ b/src/ui/i18n.resolved.generated/nl_NL.ts
@@ -666,7 +666,7 @@ export const nl_NL: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "20% korting",
+      "railWocDiscount": "{percent}% korting",
       "railWocUnavailable": "WOC-prijzen zijn momenteel niet beschikbaar.",
       "railNativeUnavailable": "SOL/WOC staat uit.",
       "amountLabel": "Hoeveelheid",

--- a/src/ui/i18n.resolved.generated/pl_PL.ts
+++ b/src/ui/i18n.resolved.generated/pl_PL.ts
@@ -666,7 +666,7 @@ export const pl_PL: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "20% zniżki",
+      "railWocDiscount": "{percent}% zniżki",
       "railWocUnavailable": "Ceny WOC są obecnie niedostępne.",
       "railNativeUnavailable": "SOL/WOC są obecnie niedostępne.",
       "amountLabel": "Kwota",

--- a/src/ui/i18n.resolved.generated/pt_BR.ts
+++ b/src/ui/i18n.resolved.generated/pt_BR.ts
@@ -666,7 +666,7 @@ export const pt_BR: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "20% de desconto",
+      "railWocDiscount": "{percent}% de desconto",
       "railWocUnavailable": "O preço do WOC não está disponível no momento.",
       "railNativeUnavailable": "SOL/WOC indisponível.",
       "amountLabel": "Quantia",

--- a/src/ui/i18n.resolved.generated/ru_RU.ts
+++ b/src/ui/i18n.resolved.generated/ru_RU.ts
@@ -666,7 +666,7 @@ export const ru_RU: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "Скидка 20%",
+      "railWocDiscount": "Скидка {percent}%",
       "railWocUnavailable": "Цена WOC сейчас недоступна.",
       "railNativeUnavailable": "SOL/WOC недоступны",
       "amountLabel": "Количество",

--- a/src/ui/i18n.resolved.generated/sv_SE.ts
+++ b/src/ui/i18n.resolved.generated/sv_SE.ts
@@ -666,7 +666,7 @@ export const sv_SE: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "20% rabatt",
+      "railWocDiscount": "{percent}% rabatt",
       "railWocUnavailable": "WOC-priser är inte tillgängliga just nu.",
       "railNativeUnavailable": "SOL/WOC är avstängt.",
       "amountLabel": "Belopp",

--- a/src/ui/i18n.resolved.generated/tr_TR.ts
+++ b/src/ui/i18n.resolved.generated/tr_TR.ts
@@ -666,7 +666,7 @@ export const tr_TR: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "%20 indirim",
+      "railWocDiscount": "%{percent} indirim",
       "railWocUnavailable": "WOC fiyatlandırması şu anda mevcut değil.",
       "railNativeUnavailable": "SOL/WOC şu anda kullanılamıyor.",
       "amountLabel": "Miktar",

--- a/src/ui/i18n.resolved.generated/vi_VN.ts
+++ b/src/ui/i18n.resolved.generated/vi_VN.ts
@@ -666,7 +666,7 @@ export const vi_VN: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "Giảm 20%",
+      "railWocDiscount": "Giảm {percent}%",
       "railWocUnavailable": "Giá WOC hiện không có sẵn.",
       "railNativeUnavailable": "SOL/WOC hiện không khả dụng.",
       "amountLabel": "Số lượng",

--- a/src/ui/i18n.resolved.generated/zh_CN.ts
+++ b/src/ui/i18n.resolved.generated/zh_CN.ts
@@ -666,7 +666,7 @@ export const zh_CN: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "优惠 20%",
+      "railWocDiscount": "优惠 {percent}%",
       "railWocUnavailable": "WOC 定价暂时不可用。",
       "railNativeUnavailable": "SOL/WOC 不可用",
       "amountLabel": "数量",

--- a/src/ui/i18n.resolved.generated/zh_TW.ts
+++ b/src/ui/i18n.resolved.generated/zh_TW.ts
@@ -666,7 +666,7 @@ export const zh_TW: EnTranslations = {
       "railSol": "SOL",
       "railUsdc": "USDC",
       "railWoc": "WOC",
-      "railWocDiscount": "優惠 20%",
+      "railWocDiscount": "優惠 {percent}%",
       "railWocUnavailable": "WOC 定價目前無法使用。",
       "railNativeUnavailable": "SOL/WOC 無法使用",
       "amountLabel": "數量",

--- a/tests/claudium_view.test.ts
+++ b/tests/claudium_view.test.ts
@@ -3,6 +3,7 @@ import {
   buildClaudiumView,
   type ClaudiumViewInput,
   claudiumBalanceAddress,
+  currentWocDiscountBps,
 } from '../src/ui/claudium_view';
 
 // The pure Claudium view core is DOM/i18n/net-free, so it drives directly here.
@@ -219,5 +220,37 @@ describe('claudiumBalanceAddress (which wallet funds the affordability reads)', 
 
   it('returns null with neither wallet, so the caller performs no balance read', () => {
     expect(claudiumBalanceAddress(null, null)).toBeNull();
+  });
+});
+
+describe('currentWocDiscountBps (service price aggregation)', () => {
+  it('selects the authoritative discount when every fetched $WOC price row agrees', () => {
+    expect(
+      currentWocDiscountBps([
+        { sku: 's1', wocDiscountBps: 5000 },
+        { sku: 's10', wocDiscountBps: 5000 },
+      ]),
+    ).toBe(5000);
+  });
+
+  it('fails closed when no fetched price row contains a valid discount', () => {
+    expect(currentWocDiscountBps([])).toBeNull();
+    expect(
+      currentWocDiscountBps([
+        { sku: 's1', wocDiscountBps: null },
+        { sku: 's10', wocDiscountBps: 5000 },
+      ]),
+    ).toBeNull();
+    expect(currentWocDiscountBps([{ sku: 's1', wocDiscountBps: -1 }])).toBeNull();
+    expect(currentWocDiscountBps([{ sku: 's10', wocDiscountBps: 9001 }])).toBeNull();
+  });
+
+  it('fails closed when fetched price rows span different policy revisions', () => {
+    expect(
+      currentWocDiscountBps([
+        { sku: 's1', wocDiscountBps: 2000 },
+        { sku: 's10', wocDiscountBps: 5000 },
+      ]),
+    ).toBeNull();
   });
 });

--- a/tests/claudium_window.test.ts
+++ b/tests/claudium_window.test.ts
@@ -240,6 +240,7 @@ function nativeSnapshot(): ClaudiumSnapshot {
   return {
     balance: 500,
     skus: [{ sku: 'claudium_500', usd: 4.99, claudium: 500 }],
+    wocDiscountBps: 5000,
     nativeRails: { sol: true, usdc: true, woc: true },
     walletBalances: {
       solLamports: '1000000000',
@@ -298,6 +299,7 @@ describe('ClaudiumWindow refresh stability', () => {
     expect(html).toContain('src="/claudium/icons/solana-icon.webp"');
     expect(html).toContain('src="/claudium/icons/usdc-icon.webp"');
     expect(html).toContain('USDC: 12.35');
+    expect(html).toContain('50% off');
 
     root.body.rail('usdc').click();
     expect(root.body.innerHTML).toContain('4.99 USDC');
@@ -306,6 +308,25 @@ describe('ClaudiumWindow refresh stability', () => {
     root.body.sku().click();
     await flushMicrotasks();
     expect(buys).toEqual([{ rail: 'usdc', sku: 'claudium_500' }]);
+  });
+
+  it('renders the current service-provided $WOC discount instead of a bundled percentage', async () => {
+    vi.stubGlobal('document', fakeDocument);
+    const root = new FakeRoot();
+    root.style.display = 'block';
+    const window = new ClaudiumWindow({
+      root: () => asHtml(root),
+      closeOthers: () => {},
+      captureFocus: () => null,
+      restoreFocus: () => {},
+      snapshot: () => Promise.resolve({ ...nativeSnapshot(), wocDiscountBps: 2000 }),
+      buy: () => Promise.resolve(),
+    });
+
+    await window.render();
+
+    expect(root.body.innerHTML).toContain('20% off');
+    expect(root.body.innerHTML).not.toContain('50% off');
   });
 
   it('renders the wallet connection card and routes its action from the Claudium panel', async () => {

--- a/tests/economy_sdk.test.ts
+++ b/tests/economy_sdk.test.ts
@@ -212,6 +212,61 @@ describe('EconomyClient pack snapshot', () => {
   });
 });
 
+describe('EconomyClient native price', () => {
+  it('preserves the service-provided $WOC discount for the store badge', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              rail: 'woc',
+              claudium: 500,
+              amountBase: '4000000',
+              discountBps: 5000,
+            }),
+            { status: 200 },
+          ),
+      ),
+    );
+
+    const price = await new EconomyClient({
+      token: () => 'token',
+      base: 'https://game.example',
+    }).nativePrice('woc', 'claudium_500');
+
+    expect(price.discountBps).toBe(5000);
+  });
+
+  it.each([-1, 9001, 2000.5, Number.NaN])(
+    'fails closed when the service returns malformed discount basis points: %s',
+    async (discountBps) => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(
+          async () =>
+            new Response(
+              JSON.stringify({
+                rail: 'woc',
+                claudium: 500,
+                amountBase: '4000000',
+                discountBps,
+              }),
+              { status: 200 },
+            ),
+        ),
+      );
+
+      const price = await new EconomyClient({
+        token: () => 'token',
+        base: 'https://game.example',
+      }).nativePrice('woc', 'claudium_500');
+
+      expect(price.discountBps).toBeNull();
+    },
+  );
+});
+
 describe('startClaudiumPurchase', () => {
   it('signs and confirms a service-built USDC transaction through Wallet Standard', async () => {
     const client = new EconomyClient({ token: () => 'token', base: 'https://game.example' });

--- a/tests/server/claudium.test.ts
+++ b/tests/server/claudium.test.ts
@@ -851,9 +851,17 @@ describe('Claudium economy-service transport contract', () => {
     vi.stubEnv('WOC_ECONOMY_INTERNAL_SECRET', 'test-secret');
     const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
       Promise.resolve(
-        new Response(JSON.stringify({ rail: 'sol', claudium: 13_000, amountBase: '9999000' }), {
-          status: 200,
-        }),
+        new Response(
+          JSON.stringify({
+            rail: 'sol',
+            claudium: 13_000,
+            amountBase: '9999000',
+            discountBps: 0,
+          }),
+          {
+            status: 200,
+          },
+        ),
       ),
     );
     vi.stubGlobal('fetch', fetchMock);
@@ -872,10 +880,48 @@ describe('Claudium economy-service transport contract', () => {
       rail: 'sol',
       claudium: 13_000,
       amountBase: '9999000',
+      discountBps: 0,
     });
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
       'https://economy.example/v1/claudium/native/price/sol?sku=claudium_13000',
     );
+  });
+
+  it('passes the authoritative $WOC discount through to the game client', async () => {
+    vi.stubEnv('WOC_ECONOMY_SERVICE_URL', 'https://economy.example/v1/claudium/');
+    vi.stubEnv('WOC_ECONOMY_INTERNAL_SECRET', 'test-secret');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              rail: 'woc',
+              claudium: 500,
+              amountBase: '4000000',
+              discountBps: 5000,
+            }),
+            { status: 200 },
+          ),
+      ),
+    );
+    const res = new FakeRes();
+
+    await handleClaudiumApi(
+      makeReq({
+        method: 'GET',
+        url: '/api/claudium/native/price/woc?sku=claudium_500',
+      }),
+      res as never,
+      7,
+    );
+
+    expect(responseJson(res)).toEqual({
+      rail: 'woc',
+      claudium: 500,
+      amountBase: '4000000',
+      discountBps: 5000,
+    });
   });
 
   it('maps history responses to the economy SDK ledger-entry shape', async () => {


### PR DESCRIPTION
## Summary

- Read the authoritative WOC discount from economy-service native price responses.
- Render the localized Claudium WOC discount badge dynamically instead of bundling a fixed percentage.
- Fail closed when discount data is missing, malformed, stale-mixed, or inconsistent across SKUs.
- Document the service-owned policy and add proxy, SDK, aggregation, and window regression coverage.

## Type of change

- [x] Feature
- [x] Tests
- [x] Documentation

## Testing

- `npx vitest run tests/claudium_view.test.ts tests/claudium_window.test.ts tests/economy_sdk.test.ts tests/server/claudium.test.ts` (80 passed)
- `npm run check:types`
- `npm run build:env`
- `npm run build:server`
- `npm run build`
- Pre-push QA floor (72 passed, 3 skipped; typecheck, guard tests, lint, copy rules green)
- Manual local game, economy service, and dashboard validation completed.

`npm run gate` reached 20,599 passing tests and stopped on six failures outside this diff. An isolated single-worker retry left three reproducible release-branch/environment failures: two macOS watchdog timeout assertions and one Discord invite URL environment expectation. The AI review timeout and two load-sensitive watchdog cases passed on retry.

## Screenshots

No layout change. The existing badge now renders the percentage supplied by the economy service and is hidden when a consistent value is unavailable.

## Checklist

- [x] Branch rebased onto the latest `release/v0.31.0`
- [x] Focused security review completed with no blocker
- [x] Cross-platform review completed with no blocker
- [x] Localization sources and generated artifacts regenerated and verified clean
- [x] Production client and server builds pass