### PR TITLE
fix(sim): collapse a repeated corpse-harvest component tag to one

### DIFF
--- a/src/sim/interaction.ts
+++ b/src/sim/interaction.ts
@@ -222,7 +222,10 @@ export function autoLootForParty(ctx: SimContext, mobId: number, triggerPid: num
  * #1142 semantics: empty or covering every tagged component spreads across
  * every tag (the #1141 behavior); picking fewer concentrates the effort for
  * a higher tier per component, per resolveCorpseFocusHarvest in
- * professions/gathering.ts.
+ * professions/gathering.ts. Repeats in that array are collapsed before any of
+ * it is read (#2474, effectiveFocusComponents): a family is harvested at most
+ * once per corpse, so `['hide','hide']` is exactly `['hide']` here and in the
+ * pre-claim capacity gate below.
  */
 export function harvestCorpse(
   ctx: SimContext,

--- a/src/sim/professions/gathering.ts
+++ b/src/sim/professions/gathering.ts
@@ -756,14 +756,32 @@ export interface FocusHarvestYield {
  * capacity gate (src/sim/interaction.ts), which must see exactly the set the
  * roll will yield WITHOUT drawing rng (a refused command must not shift the
  * world's draw order).
+ *
+ * The pick is a SET of families: a repeated tag counts ONCE, whatever the
+ * caller passed (#2474). `chosen` reaches here straight off the wire
+ * (server/game.ts forwards the client's `components` array after a type filter
+ * only), and a corpse is single-use, so a repeat that survived would let one
+ * hand-crafted frame farm the same family several times from one claim: two
+ * tier rolls, two grants, and on a rare-or-better roll two signed yields. The
+ * dedupe runs BEFORE either length test, so a repeat can neither reach the
+ * filter arm twice nor pad `chosen.length` past the spread threshold and pull
+ * in tags the caller never asked for. First occurrence wins (Set iteration is
+ * insertion-ordered), so tag ORDER is untouched: it is the order the yields,
+ * the grants and the harvestResult ledger entries land in (#2457). Same
+ * order-preserving idiom the picker's own view-core already applied to the tags
+ * it renders (src/ui/hud/loot/corpse_harvest_view.ts), which is why no shipped
+ * client can produce the repeat in the first place.
+ * `taggedComponents` needs no dedupe of its own; content uniqueness is pinned
+ * by tests/mob_component_tags.test.ts.
  */
 export function effectiveFocusComponents(
   taggedComponents: readonly string[],
   chosen: readonly string[],
 ): readonly string[] {
-  return chosen.length === 0 || chosen.length >= taggedComponents.length
+  const picked = [...new Set(chosen)];
+  return picked.length === 0 || picked.length >= taggedComponents.length
     ? taggedComponents
-    : chosen.filter((c) => taggedComponents.includes(c));
+    : picked.filter((c) => taggedComponents.includes(c));
 }
 
 /**

--- a/src/sim/professions/gathering.ts
+++ b/src/sim/professions/gathering.ts
@@ -768,9 +768,9 @@ export interface FocusHarvestYield {
  * in tags the caller never asked for. First occurrence wins (Set iteration is
  * insertion-ordered), so tag ORDER is untouched: it is the order the yields,
  * the grants and the harvestResult ledger entries land in (#2457). Same
- * order-preserving idiom the picker's own view-core already applied to the tags
- * it renders (src/ui/hud/loot/corpse_harvest_view.ts), which is why no shipped
- * client can produce the repeat in the first place.
+ * order-preserving idiom the picker's own view-core (`corpseHarvestView`)
+ * already applied to the tags it renders, which is why no shipped client can
+ * produce the repeat in the first place.
  * `taggedComponents` needs no dedupe of its own; content uniqueness is pinned
  * by tests/mob_component_tags.test.ts.
  */

--- a/tests/corpse_harvest_sim.test.ts
+++ b/tests/corpse_harvest_sim.test.ts
@@ -928,6 +928,165 @@ describe('a signed specimen-less grant carries its rolled quantity (#2473)', () 
   });
 });
 
+// #2474: a corpse is single-use, so the family a repeated tag names must be
+// harvested ONCE however many times the frame repeats it. The pick reaches the
+// sim straight off the wire (server/game.ts type-filters `components` and
+// forwards it), and before the dedupe a hand-crafted ['hide','hide'] rolled,
+// granted and logged the hide family twice off one claim, signed Pristine Hides
+// included. Driven end to end here (rolls, grants, ledger, claim, lifecycle),
+// not just at the pure boundary in tests/gathering.test.ts.
+describe('a repeated component tag harvests the family once (#2474)', () => {
+  // Same seed, same corpse template, one command each: the duplicated pick must
+  // land the deduped pick's world, exactly.
+  function harvestWith(
+    templateId: string,
+    components: string[],
+    seed: number,
+  ): { inventory: unknown; events: unknown; draws: number; claimedBy: number | null } {
+    const { sim, internals, a } = setup(seed);
+    const template = MOBS[templateId];
+    const corpse = createMob(7774, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+    corpse.dead = true;
+    corpse.aiState = 'dead';
+    corpse.corpseTimer = 9999;
+    corpse.respawnTimer = 9999;
+    internals.entities.set(corpse.id, corpse);
+    sim.drainEvents();
+    let draws = 0;
+    const rng = (sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } }).rng;
+    rng.setObserver(() => {
+      draws++;
+    });
+    sim.harvestCorpse(corpse.id, components, a);
+    rng.setObserver(null);
+    return {
+      inventory: structuredClone(internals.players.get(a)!.inventory),
+      events: sim.drainEvents(),
+      draws,
+      claimedBy: corpse.harvestClaimedBy,
+    };
+  }
+
+  // wild_boar tags hide/tusk/meat: three tags, so a two-entry pick stays under
+  // the spread threshold and lands on the arm that used to hand the duplicate
+  // straight through. old_greyjaw (hide/fang/claw) is the same arm one tag map
+  // over. forest_wolf tags hide/fang: two tags, so ['hide','hide'] used to
+  // clear `>= tagged.length` and spread onto fang instead.
+  const CASES: { templateId: string; tag: string; arm: string }[] = [
+    { templateId: 'wild_boar', tag: 'hide', arm: 'concentrate' },
+    { templateId: 'wild_boar', tag: 'meat', arm: 'concentrate' },
+    { templateId: 'old_greyjaw', tag: 'fang', arm: 'concentrate' },
+    { templateId: 'forest_wolf', tag: 'hide', arm: 'spread threshold' },
+    { templateId: 'forest_wolf', tag: 'fang', arm: 'spread threshold' },
+  ];
+
+  it('grants exactly what the single tag grants, on the same seed, on both arms', () => {
+    for (const c of CASES) {
+      for (const seed of [2, 5, 11]) {
+        const label = `${c.templateId} ${c.tag} (${c.arm}) @${seed}`;
+        const dup = harvestWith(c.templateId, [c.tag, c.tag], seed);
+        const once = harvestWith(c.templateId, [c.tag], seed);
+        // The whole observable result of the command: what landed in the bags,
+        // every event it emitted (the harvestResult ledger included), and how
+        // much rng it spent doing it.
+        expect(dup.inventory, `${label} inventory`).toEqual(once.inventory);
+        expect(dup.events, `${label} events`).toEqual(once.events);
+        expect(dup.draws, `${label} draws`).toEqual(once.draws);
+        // ... and the claim is still spent exactly once, by the harvester.
+        expect(dup.claimedBy, `${label} claim`).toBe(once.claimedBy);
+        expect(dup.claimedBy, `${label} claim is the harvester`).not.toBeNull();
+      }
+    }
+  });
+
+  it('rolls and grants the family ONE time, not once per repeat (seed 5, absolute counts)', () => {
+    // The equality above would also pass if both sides were wrong together, so
+    // the doubled quantities are pinned to literals here. Seed 5 clears the
+    // signable floor on the first rarity roll, which is what made the old
+    // duplicate hand out a second signed Pristine Hide off a single corpse.
+    const { sim, internals, a } = setup(5);
+    const template = MOBS.wild_boar;
+    const corpse = createMob(7773, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+    corpse.dead = true;
+    corpse.aiState = 'dead';
+    corpse.corpseTimer = 9999;
+    corpse.respawnTimer = 9999;
+    internals.entities.set(corpse.id, corpse);
+    expect(template.componentTags).toEqual(['hide', 'tusk', 'meat']);
+    sim.drainEvents();
+    sim.harvestCorpse(corpse.id, ['hide', 'hide'], a);
+    // Two draws is one family's worth (tier roll + rarity roll); four was the
+    // bug. Read off the ledger the client actually prints, which carries one
+    // entry per distinct granted item.
+    const result = sim
+      .drainEvents()
+      .filter((e): e is Extract<typeof e, { type: 'harvestResult' }> => e.type === 'harvestResult');
+    expect(result).toHaveLength(1);
+    expect(result[0].yields.map((y) => y.itemId).sort()).toEqual(['pristine_hide', 'rough_hide']);
+    expect(result[0].yields.filter((y) => y.itemId === 'rough_hide')).toHaveLength(1);
+    expect(sim.countItem('rough_hide', a)).toBe(4);
+    expect(sim.countItem('pristine_hide', a)).toBe(1);
+    const meta = internals.players.get(a)!;
+    expect(meta.inventory.filter((s) => s.itemId === 'pristine_hide')).toHaveLength(1);
+    // Nothing from the tags the caller never named.
+    expect(sim.countItem('game_meat', a)).toBe(0);
+  });
+
+  it('a repeat cannot pull in a tag the caller never asked for (spread threshold, seed 5)', () => {
+    // forest_wolf tags hide and fang, so ['hide','hide'] used to clear
+    // `chosen.length >= tagged.length` and spread across BOTH families at the
+    // zero concentration bonus a real two-tag pick earns. The fang line is the
+    // decisive one: a dedupe that ran after the length test would still grant it.
+    const { sim, mob, a } = setup(5);
+    expect(MOBS.forest_wolf.componentTags).toEqual(['hide', 'fang']);
+    sim.harvestCorpse(mob.id, ['hide', 'hide'], a);
+    expect(sim.countItem('rough_hide', a)).toBeGreaterThan(0);
+    expect(sim.countItem('wolf_fang', a)).toBe(0);
+  });
+
+  it('a repeat inside a MULTI-family pick collapses only its own family', () => {
+    // The mixed case: the other tags in the same frame must still be harvested,
+    // in the order they were named. wild_boar's tusk maps to no item, so hide
+    // and meat are the two that land.
+    const { sim, internals, a } = setup(5);
+    const template = MOBS.wild_boar;
+    const corpse = createMob(7772, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+    corpse.dead = true;
+    corpse.aiState = 'dead';
+    corpse.corpseTimer = 9999;
+    corpse.respawnTimer = 9999;
+    internals.entities.set(corpse.id, corpse);
+    sim.drainEvents();
+    sim.harvestCorpse(corpse.id, ['meat', 'hide', 'meat'], a);
+    const result = sim
+      .drainEvents()
+      .filter((e): e is Extract<typeof e, { type: 'harvestResult' }> => e.type === 'harvestResult');
+    expect(result).toHaveLength(1);
+    // Ledger order follows the pick's first-occurrence order, meat before hide,
+    // which is also the chat-line order the player reads (#2457).
+    expect(result[0].yields.map((y) => y.itemId)).toEqual(['game_meat', 'rough_hide']);
+    expect(
+      internals.players.get(a)!.inventory.filter((s) => s.itemId === 'game_meat'),
+    ).toHaveLength(1);
+  });
+
+  it('leaves the corpse lifecycle exactly where a single-tag harvest leaves it', () => {
+    // The claim is single-use whatever the frame said: the repeat spends it
+    // once, the corpse is denied to everyone after, and the harvested-corpse
+    // timer clamp is the same one the deduped pick produces.
+    const { sim, mob, a, b } = setup(11);
+    const once = setup(11);
+    sim.harvestCorpse(mob.id, ['hide', 'hide'], a);
+    once.sim.harvestCorpse(once.mob.id, ['hide'], once.a);
+    expect(mob.harvestClaimedBy).toBe(a);
+    expect(mob.corpseTimer).toBe(once.mob.corpseTimer);
+    expect(mob.lootable).toBe(once.mob.lootable);
+    // A second command, repeated tag or not, is denied against the same corpse.
+    sim.harvestCorpse(mob.id, ['hide', 'hide'], b);
+    expect(mob.harvestClaimedBy).toBe(a);
+  });
+});
+
 // Corpse premium-arm tool gating (Professions 2.0): the plain
 // component grant is NEVER gated (the bare-hands floor); only the
 // signed/specimen upgrade of a signable rarity roll checks the best owned
@@ -1436,5 +1595,87 @@ describe('harvestCorpse omitted components over the wire', () => {
     const spy = vi.spyOn(server.sim, 'harvestCorpse').mockImplementation(() => {});
     (server as any).dispatchMessage(session, JSON.parse(raw), raw, 0);
     expect(spy).toHaveBeenCalledWith(4242, ['hide'], session.pid);
+  });
+});
+
+// #2474 over the wire. The `components` array is a client-supplied value the
+// authoritative server acts on, and no shipped client sends a repeat (the loot
+// window's picker and the interact key both build unique tags), so the only way
+// in is a hand-crafted frame. This drives exactly that frame through a REAL
+// GameServer into the REAL sim, because the wire is where the untrusted value
+// enters and a fix that only held for a direct sim call would not close it.
+// Two servers, one command each: GameServer pins a constant WORLD_SEED and
+// neither run ticks, so the two worlds are byte-identical at harvest time and
+// any difference in the result is the pick.
+describe('a repeated component tag over the wire, through a real GameServer (#2474)', () => {
+  function serverHarvest(components: string[]): {
+    raw: string;
+    inventory: { itemId: string; count: number; instance?: unknown }[];
+    hides: number;
+    claimedBy: number | null;
+  } {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 93, 'Alpha');
+    const internals = server.sim as unknown as SimInternals;
+    const self = internals.entities.get(session.pid)!;
+    self.pos = { x: 0, y: 0, z: 0 };
+    self.prevPos = { x: 0, y: 0, z: 0 };
+    // wild_boar tags hide/tusk/meat: three tags, so a two-entry pick stays
+    // under the spread threshold and lands on the arm that used to hand the
+    // repeat through to the roll loop.
+    const template = MOBS.wild_boar;
+    const mobId = Math.max(...internals.entities.keys()) + 1;
+    const mob = createMob(mobId, template, template.maxLevel, { x: 2, y: 0, z: 0 });
+    mob.dead = true;
+    mob.aiState = 'dead';
+    mob.corpseTimer = 9999;
+    mob.respawnTimer = 9999;
+    internals.entities.set(mob.id, mob);
+    // A hand-built frame, the untrusted shape the issue reproduces with, parsed
+    // and dispatched exactly as a socket message is. `t: 'cmd'` is the real
+    // envelope (ClientWorld.rawCmd); without it the dispatcher drops the frame
+    // as a protocol anomaly and the test would pass on an unharvested corpse.
+    const raw = JSON.stringify({ t: 'cmd', cmd: 'harvestCorpse', id: mobId, components });
+    (server as any).dispatchMessage(session, JSON.parse(raw), raw, 0);
+    return {
+      raw,
+      inventory: structuredClone(internals.players.get(session.pid)!.inventory),
+      hides: server.sim.countItem('rough_hide', session.pid),
+      claimedBy: mob.harvestClaimedBy,
+    };
+  }
+
+  it('lands the same bags a single tag lands, and spends the claim once', () => {
+    const dup = serverHarvest(['hide', 'hide']);
+    const once = serverHarvest(['hide']);
+    // The frame really carried the repeat: the assertion below is about the
+    // sim collapsing it, not about the payload never arriving.
+    expect(dup.raw).toContain('["hide","hide"]');
+    // Not a vacuous comparison of two empty bags: the harvest actually yielded.
+    expect(once.hides).toBeGreaterThan(0);
+    expect(dup.hides).toBe(once.hides);
+    expect(dup.inventory).toEqual(once.inventory);
+    expect(dup.claimedBy).not.toBeNull();
+    expect(dup.claimedBy).toBe(once.claimedBy);
+  });
+
+  it('forwards the repeat verbatim: the SIM boundary is what closes it, not the server', () => {
+    // Deliberate, and the reason the fix lives in effectiveFocusComponents: the
+    // offline Sim and the headless env call the same command without ever
+    // passing through server/game.ts, so sanitizing here would have left both
+    // hosts open. If a future change starts deduping on the server too, this
+    // test is the one that should be re-argued, not quietly deleted.
+    const server = new GameServer();
+    const session = joinServer(server, fakeWs(), 94, 'Alpha');
+    const raw = JSON.stringify({
+      t: 'cmd',
+      cmd: 'harvestCorpse',
+      id: 4242,
+      components: ['hide', 'hide'],
+    });
+    const spy = vi.spyOn(server.sim, 'harvestCorpse').mockImplementation(() => {});
+    (server as any).dispatchMessage(session, JSON.parse(raw), raw, 0);
+    expect(spy).toHaveBeenCalledWith(4242, ['hide', 'hide'], session.pid);
   });
 });

--- a/tests/corpse_harvest_sim.test.ts
+++ b/tests/corpse_harvest_sim.test.ts
@@ -1141,6 +1141,12 @@ describe('a repeated component tag harvests the family once (#2474)', () => {
     // no loot, so the harvest takes the collapse arm and clamps the timer to 4.
     expect(mob.corpseTimer).toBe(4);
     expect(mob.corpseTimer).toBe(once.mob.corpseTimer);
+    // `lootable` is pinned against the arm that decides it rather than against
+    // the twin: this corpse has no loot, so it takes the collapse arm and ends
+    // false. Compared to the twin alone the line would hold even if the command
+    // never ran, since a createMob corpse starts out unlootable.
+    expect(mob.loot).toBeNull();
+    expect(mob.lootable).toBe(false);
     expect(mob.lootable).toBe(once.mob.lootable);
     // A second command, repeated tag or not, is denied against the same corpse.
     sim.harvestCorpse(mob.id, ['hide', 'hide'], b);
@@ -1245,6 +1251,21 @@ describe('a repeated component tag harvests the family once (#2474)', () => {
           internals.entities.set(corpse.id, corpse);
           return corpse.id;
         },
+      },
+      {
+        // The sixth early return, and the only one that refuses SILENTLY (no
+        // error text): the target is not a dead mob. "Every arm" has to mean
+        // every arm, so the live mob and the unknown id are both here.
+        label: 'the target mob is still alive',
+        arrange: ({ mob }) => {
+          mob.dead = false;
+          mob.aiState = 'idle';
+          return mob.id;
+        },
+      },
+      {
+        label: 'the target id is not an entity at all',
+        arrange: () => 4242,
       },
     ];
     for (const arm of refusals) {

--- a/tests/corpse_harvest_sim.test.ts
+++ b/tests/corpse_harvest_sim.test.ts
@@ -1612,6 +1612,7 @@ describe('a repeated component tag over the wire, through a real GameServer (#24
     raw: string;
     inventory: { itemId: string; count: number; instance?: unknown }[];
     hides: number;
+    draws: number;
     claimedBy: number | null;
   } {
     const server = new GameServer();
@@ -1637,11 +1638,20 @@ describe('a repeated component tag over the wire, through a real GameServer (#24
     // envelope (ClientWorld.rawCmd); without it the dispatcher drops the frame
     // as a protocol anomaly and the test would pass on an unharvested corpse.
     const raw = JSON.stringify({ t: 'cmd', cmd: 'harvestCorpse', id: mobId, components });
+    let draws = 0;
+    const rng = (
+      server.sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } }
+    ).rng;
+    rng.setObserver(() => {
+      draws++;
+    });
     (server as any).dispatchMessage(session, JSON.parse(raw), raw, 0);
+    rng.setObserver(null);
     return {
       raw,
       inventory: structuredClone(internals.players.get(session.pid)!.inventory),
       hides: server.sim.countItem('rough_hide', session.pid),
+      draws,
       claimedBy: mob.harvestClaimedBy,
     };
   }
@@ -1658,6 +1668,13 @@ describe('a repeated component tag over the wire, through a real GameServer (#24
     expect(dup.inventory).toEqual(once.inventory);
     expect(dup.claimedBy).not.toBeNull();
     expect(dup.claimedBy).toBe(once.claimedBy);
+    // The most decisive pin available over the wire, and the one the bags
+    // alone cannot make: rolls are what a doubled harvest actually spent. One
+    // family costs two draws (tier roll plus rarity roll); the repeat used to
+    // cost four, so this is a literal, not an equality that could hold at any
+    // value.
+    expect(dup.draws).toBe(2);
+    expect(once.draws).toBe(2);
   });
 
   it('forwards the repeat verbatim: the SIM boundary is what closes it, not the server', () => {

--- a/tests/corpse_harvest_sim.test.ts
+++ b/tests/corpse_harvest_sim.test.ts
@@ -1085,6 +1085,126 @@ describe('a repeated component tag harvests the family once (#2474)', () => {
     sim.harvestCorpse(mob.id, ['hide', 'hide'], b);
     expect(mob.harvestClaimedBy).toBe(a);
   });
+
+  it('reserves ONE family of stack room, so a repeat no longer over-reserves the gate', () => {
+    // The boundary this fix actually MOVES, and the reason the pre-claim gate
+    // and the roll have to agree: the gate reserves the most a component can
+    // roll, so the duplicated pick used to ask for two families' worth (12
+    // rough_hide, 2 x the legendary tier quantity) where one was ever granted.
+    // A bag holding room for exactly one family therefore refused the repeat
+    // outright while accepting the identical single-tag pick. Both now behave
+    // the same, which is the whole contract.
+    const stack = stackSizeOf(ITEMS.rough_hide);
+    const rig = (components: string[]) => {
+      const { sim, internals, a } = setup(5);
+      const template = MOBS.wild_boar;
+      const corpse = createMob(7771, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+      corpse.dead = true;
+      corpse.aiState = 'dead';
+      corpse.corpseTimer = 9999;
+      corpse.respawnTimer = 9999;
+      internals.entities.set(corpse.id, corpse);
+      const m = internals.players.get(a)!;
+      fillBags(sim, internals, a);
+      // Zero free slots, and stack room for exactly one family's top roll.
+      m.inventory[0] = { itemId: 'rough_hide', count: stack - 6 };
+      let draws = 0;
+      const rng = (sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } })
+        .rng;
+      rng.setObserver(() => {
+        draws++;
+      });
+      sim.harvestCorpse(corpse.id, components, a);
+      rng.setObserver(null);
+      return {
+        claimedBy: corpse.harvestClaimedBy,
+        hides: sim.countItem('rough_hide', a),
+        draws,
+      };
+    };
+    const dup = rig(['hide', 'hide']);
+    const once = rig(['hide']);
+    // The single pick has always fit here, so this is the decisive half: the
+    // repeat has to reach the same harvested state, not the refusal it used to
+    // get. Absolute values, not just equality, so both sides cannot be wrong.
+    expect(once.claimedBy).not.toBeNull();
+    expect(once.draws).toBe(2);
+    expect(dup.claimedBy).toBe(once.claimedBy);
+    expect(dup.draws).toBe(once.draws);
+    expect(dup.hides).toBe(once.hides);
+    expect(dup.hides).toBe(stack - 6 + 4);
+  });
+
+  it('draws NO rng when refused, on every refusal arm, repeat or not', () => {
+    // A refused command must not shift the world's draw order for everyone
+    // else. Both source comments state that as a hard determinism contract and
+    // nothing pinned it, and this change is what moved the gate that decides
+    // one of these arms, so it is pinned here across all five.
+    const refusals: {
+      label: string;
+      arrange: (rig: ReturnType<typeof setup>) => number;
+    }[] = [
+      {
+        label: 'full bags (the pre-claim capacity gate)',
+        arrange: ({ sim, internals, a, mob }) => {
+          fillBags(sim, internals, a);
+          return mob.id;
+        },
+      },
+      {
+        label: 'too far away',
+        arrange: ({ internals, a, mob }) => {
+          internals.entities.get(a)!.pos = { x: 500, y: 0, z: 0 };
+          return mob.id;
+        },
+      },
+      {
+        label: 'the corpse is already claimed',
+        arrange: ({ mob, b }) => {
+          mob.harvestClaimedBy = b;
+          return mob.id;
+        },
+      },
+      {
+        label: 'the harvester is dead',
+        arrange: ({ internals, a, mob }) => {
+          internals.entities.get(a)!.dead = true;
+          return mob.id;
+        },
+      },
+      {
+        label: 'the corpse carries no component tags',
+        arrange: ({ internals }) => {
+          const template = MOBS.warlock_imp;
+          const corpse = createMob(7770, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+          corpse.dead = true;
+          corpse.aiState = 'dead';
+          corpse.corpseTimer = 9999;
+          corpse.respawnTimer = 9999;
+          internals.entities.set(corpse.id, corpse);
+          return corpse.id;
+        },
+      },
+    ];
+    for (const arm of refusals) {
+      for (const components of [['hide', 'hide'], ['hide']]) {
+        const rig = setup(5);
+        const mobId = arm.arrange(rig);
+        let draws = 0;
+        const rng = (
+          rig.sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } }
+        ).rng;
+        rng.setObserver(() => {
+          draws++;
+        });
+        rig.sim.harvestCorpse(mobId, components, rig.a);
+        rng.setObserver(null);
+        const label = `${arm.label} ${JSON.stringify(components)}`;
+        expect(draws, `${label} draws`).toBe(0);
+        expect(rig.sim.countItem('rough_hide', rig.a), `${label} yield`).toBe(0);
+      }
+    }
+  });
 });
 
 // Corpse premium-arm tool gating (Professions 2.0): the plain

--- a/tests/corpse_harvest_sim.test.ts
+++ b/tests/corpse_harvest_sim.test.ts
@@ -972,13 +972,30 @@ describe('a repeated component tag harvests the family once (#2474)', () => {
   // straight through. old_greyjaw (hide/fang/claw) is the same arm one tag map
   // over. forest_wolf tags hide/fang: two tags, so ['hide','hide'] used to
   // clear `>= tagged.length` and spread onto fang instead.
-  const CASES: { templateId: string; tag: string; arm: string }[] = [
-    { templateId: 'wild_boar', tag: 'hide', arm: 'concentrate' },
-    { templateId: 'wild_boar', tag: 'meat', arm: 'concentrate' },
-    { templateId: 'old_greyjaw', tag: 'fang', arm: 'concentrate' },
-    { templateId: 'forest_wolf', tag: 'hide', arm: 'spread threshold' },
-    { templateId: 'forest_wolf', tag: 'fang', arm: 'spread threshold' },
+  // `tags` is pinned per row, not just described: the arm a row exercises is
+  // decided by the corpse's tag COUNT against the two-entry pick, so a content
+  // retag would slide a row onto the other arm while the table still claimed to
+  // cover both. Pinning the tags here is what keeps the matrix honest.
+  const CASES: { templateId: string; tag: string; arm: string; tags: string[] }[] = [
+    { templateId: 'wild_boar', tag: 'hide', arm: 'concentrate', tags: ['hide', 'tusk', 'meat'] },
+    { templateId: 'wild_boar', tag: 'meat', arm: 'concentrate', tags: ['hide', 'tusk', 'meat'] },
+    { templateId: 'old_greyjaw', tag: 'fang', arm: 'concentrate', tags: ['hide', 'fang', 'claw'] },
+    { templateId: 'forest_wolf', tag: 'hide', arm: 'spread threshold', tags: ['hide', 'fang'] },
+    { templateId: 'forest_wolf', tag: 'fang', arm: 'spread threshold', tags: ['hide', 'fang'] },
   ];
+
+  it('covers both arms for real: each row is the corpse shape it claims to be', () => {
+    for (const c of CASES) {
+      expect(MOBS[c.templateId].componentTags, `${c.templateId} tags`).toEqual(c.tags);
+      expect(c.tags, `${c.templateId} ${c.tag} is on the corpse`).toContain(c.tag);
+      // A two-entry pick is under the spread threshold only while the corpse
+      // carries MORE than two tags; at exactly two it clears `>= tagged.length`.
+      const arm = c.tags.length > 2 ? 'concentrate' : 'spread threshold';
+      expect(arm, `${c.templateId} ${c.tag} arm`).toBe(c.arm);
+    }
+    expect(CASES.map((c) => c.arm)).toContain('concentrate');
+    expect(CASES.map((c) => c.arm)).toContain('spread threshold');
+  });
 
   it('grants exactly what the single tag grants, on the same seed, on both arms', () => {
     for (const c of CASES) {
@@ -992,6 +1009,10 @@ describe('a repeated component tag harvests the family once (#2474)', () => {
         expect(dup.inventory, `${label} inventory`).toEqual(once.inventory);
         expect(dup.events, `${label} events`).toEqual(once.events);
         expect(dup.draws, `${label} draws`).toEqual(once.draws);
+        // An absolute floor under that equality, so a mis-wired observer
+        // reading 0 on both sides cannot pass: one mapped family costs exactly
+        // one tier roll plus one rarity roll, on every row.
+        expect(once.draws, `${label} single-pick draws`).toBe(2);
         // ... and the claim is still spent exactly once, by the harvester.
         expect(dup.claimedBy, `${label} claim`).toBe(once.claimedBy);
         expect(dup.claimedBy, `${label} claim is the harvester`).not.toBeNull();
@@ -999,11 +1020,42 @@ describe('a repeated component tag harvests the family once (#2474)', () => {
     }
   });
 
+  it('never mints a second signed Pristine Hide off one claim (seed 11, the issue case)', () => {
+    // The headline harm the issue reports, at the one state that actually
+    // reaches it. Pre-fix, seed 11 rolled rare-or-better on BOTH of the
+    // duplicate's rarity rolls and handed out two Pristine Hides plus 6
+    // rough_hide off a single-use corpse; nothing else in this suite exercises
+    // the doubled SIGNED arm, which is the valuable half of the exploit
+    // (a non-fungible, signer-stamped item, minted twice from one claim).
+    // Post-fix the repeat lands the single tag's world exactly: no specimen,
+    // 4 hides, one claim.
+    const { sim, internals, a } = setup(11);
+    const template = MOBS.wild_boar;
+    const corpse = createMob(7769, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+    corpse.dead = true;
+    corpse.aiState = 'dead';
+    corpse.corpseTimer = 9999;
+    corpse.respawnTimer = 9999;
+    internals.entities.set(corpse.id, corpse);
+    sim.harvestCorpse(corpse.id, ['hide', 'hide'], a);
+    expect(sim.countItem('pristine_hide', a)).toBe(0);
+    expect(sim.countItem('rough_hide', a)).toBe(4);
+    // Signed instances never merge into a plain stack, so a doubled jackpot
+    // would show up as instance slots, not as a bigger count.
+    expect(
+      internals.players.get(a)!.inventory.filter((s) => s.instance?.signer === 'Alpha'),
+    ).toHaveLength(0);
+  });
+
   it('rolls and grants the family ONE time, not once per repeat (seed 5, absolute counts)', () => {
     // The equality above would also pass if both sides were wrong together, so
-    // the doubled quantities are pinned to literals here. Seed 5 clears the
-    // signable floor on the first rarity roll, which is what made the old
-    // duplicate hand out a second signed Pristine Hide off a single corpse.
+    // the quantities are pinned to literals here. At this seed the deduped
+    // single roll clears the signable floor, so the specimen below is the
+    // ORDINARY one-family jackpot, not a doubled one: pre-fix the same command
+    // rolled twice at a lower concentration bonus and came back with 8 plain
+    // hides and no specimen at all. Both numbers move under a revert, which is
+    // what makes them decisive. The doubled-specimen state has its own case
+    // above, at the seed that actually reaches it.
     const { sim, internals, a } = setup(5);
     const template = MOBS.wild_boar;
     const corpse = createMob(7773, template, template.maxLevel, { x: 0, y: 0, z: 0 });
@@ -1023,7 +1075,11 @@ describe('a repeated component tag harvests the family once (#2474)', () => {
       .filter((e): e is Extract<typeof e, { type: 'harvestResult' }> => e.type === 'harvestResult');
     expect(result).toHaveLength(1);
     expect(result[0].yields.map((y) => y.itemId).sort()).toEqual(['pristine_hide', 'rough_hide']);
-    expect(result[0].yields.filter((y) => y.itemId === 'rough_hide')).toHaveLength(1);
+    // The QUANTITY on that entry, not its count: recordHarvestYield merges
+    // same-item grants, so the doubled harvest also produced exactly one
+    // rough_hide row, just carrying 8 instead of 4. Only the number can tell
+    // the two apart.
+    expect(result[0].yields.find((y) => y.itemId === 'rough_hide')?.qty).toBe(4);
     expect(sim.countItem('rough_hide', a)).toBe(4);
     expect(sim.countItem('pristine_hide', a)).toBe(1);
     const meta = internals.players.get(a)!;
@@ -1076,9 +1132,14 @@ describe('a repeated component tag harvests the family once (#2474)', () => {
     // timer clamp is the same one the deduped pick produces.
     const { sim, mob, a, b } = setup(11);
     const once = setup(11);
+    expect(mob.corpseTimer).toBe(9999);
     sim.harvestCorpse(mob.id, ['hide', 'hide'], a);
     once.sim.harvestCorpse(once.mob.id, ['hide'], once.a);
     expect(mob.harvestClaimedBy).toBe(a);
+    // Literals, not only the twin comparison: two runs of the same post-fix
+    // path move together, so an equality alone cannot fail. This corpse carries
+    // no loot, so the harvest takes the collapse arm and clamps the timer to 4.
+    expect(mob.corpseTimer).toBe(4);
     expect(mob.corpseTimer).toBe(once.mob.corpseTimer);
     expect(mob.lootable).toBe(once.mob.lootable);
     // A second command, repeated tag or not, is denied against the same corpse.

--- a/tests/gathering.test.ts
+++ b/tests/gathering.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  effectiveFocusComponents,
   harvestTierQuantity,
   isHarvestableCorpse,
   resolveCorpseFocusHarvest,
@@ -228,4 +229,130 @@ describe('harvestTierQuantity', () => {
     expect(harvestTierQuantity('epic')).toBe(5);
     expect(harvestTierQuantity('legendary')).toBe(6);
   });
+});
+
+// #2474: the focus pick is a SET of component families. `chosen` arrives
+// straight off the wire (server/game.ts type-filters the array and forwards it),
+// so a repeated tag is a client-supplied value the authoritative sim must not
+// act on twice: a corpse is single-use, and a repeat that survived harvested the
+// same family once per repeat off one claim.
+describe('effectiveFocusComponents collapses a repeated tag (#2474)', () => {
+  const TAGS = ['hide', 'fang', 'claw', 'horn'];
+
+  // The pre-#2474 body, verbatim, kept as an independent reference so the
+  // "unchanged for a duplicate-free pick" sweep below compares against real
+  // prior behavior rather than against the function under test.
+  function legacyEffective(
+    tagged: readonly string[],
+    chosen: readonly string[],
+  ): readonly string[] {
+    return chosen.length === 0 || chosen.length >= tagged.length
+      ? tagged
+      : chosen.filter((c) => tagged.includes(c));
+  }
+
+  function subsets<T>(items: readonly T[]): T[][] {
+    return items.reduce<T[][]>((acc, item) => acc.concat(acc.map((s) => [...s, item])), [[]]);
+  }
+
+  it('a repeat on the CONCENTRATE arm harvests the family once, not once per repeat', () => {
+    // The plain doubling: 2 raw entries against 4 tags stays under the spread
+    // threshold, so the old filter arm handed back ['hide','hide'] and the
+    // command rolled, granted and logged the hide family twice.
+    expect(legacyEffective(TAGS, ['hide', 'hide'])).toEqual(['hide', 'hide']);
+    expect(effectiveFocusComponents(TAGS, ['hide', 'hide'])).toEqual(['hide']);
+    expect(effectiveFocusComponents(TAGS, ['hide', 'hide', 'hide', 'hide'])).toEqual(['hide']);
+  });
+
+  it('a repeat can no longer pad the pick past the SPREAD threshold', () => {
+    // The second, quieter half of the same bug: `chosen.length` was the raw
+    // count, so on a two-tag corpse ['hide','hide'] cleared `>= tagged.length`
+    // and spread across every tag, harvesting fang the caller never asked for
+    // (and at bonus 0 instead of the concentration bonus a real one-tag pick
+    // earns). Both halves are decided by the dedupe running BEFORE the tests.
+    expect(legacyEffective(['hide', 'fang'], ['hide', 'hide'])).toEqual(['hide', 'fang']);
+    expect(effectiveFocusComponents(['hide', 'fang'], ['hide', 'hide'])).toEqual(['hide']);
+    expect(effectiveFocusComponents(['hide', 'fang'], ['hide'])).toEqual(['hide']);
+  });
+
+  it('a pick of repeated JUNK harvests nothing, as a single junk tag already did', () => {
+    // The knock-on the padding fix carries, pinned so it reads as intended
+    // rather than as a side effect: repeats of a tag that is not on the corpse
+    // also used to clear the threshold and spread the whole corpse. One junk
+    // tag has always yielded nothing (the arm above it), so collapsing the
+    // repeat is what makes the two agree.
+    expect(legacyEffective(['hide', 'fang'], ['zzz', 'zzz'])).toEqual(['hide', 'fang']);
+    expect(effectiveFocusComponents(['hide', 'fang'], ['zzz', 'zzz'])).toEqual([]);
+    expect(effectiveFocusComponents(['hide', 'fang'], ['zzz'])).toEqual([]);
+  });
+
+  it('keeps first-occurrence ORDER, the order yields, grants and ledger entries land in', () => {
+    // Order is load-bearing (#2457): tag order is yield order is chat-line
+    // order. A dedupe that sorted, or that kept the LAST occurrence, would
+    // silently reorder the harvest ledger.
+    expect(effectiveFocusComponents(TAGS, ['fang', 'hide', 'fang'])).toEqual(['fang', 'hide']);
+    expect(effectiveFocusComponents(TAGS, ['claw', 'hide', 'claw', 'fang'])).toEqual([
+      'claw',
+      'hide',
+      'fang',
+    ]);
+  });
+
+  it('is identical to the pre-#2474 result for EVERY duplicate-free pick', () => {
+    // The no-regression half of the acceptance criteria, swept rather than
+    // sampled: every subset of a four-tag corpse, in two orders, plus the
+    // off-corpse tag and the empty pick. A dedupe that touched a
+    // duplicate-free array at all would fail here.
+    const picks = subsets(TAGS).flatMap((s) => [s, [...s].reverse()]);
+    picks.push(['hide', 'not_a_real_tag'], ['not_a_real_tag'], []);
+    for (const pick of picks) {
+      expect(effectiveFocusComponents(TAGS, pick), `pick ${JSON.stringify(pick)}`).toEqual(
+        legacyEffective(TAGS, pick),
+      );
+    }
+  });
+
+  it('makes a repeated pick draw and yield EXACTLY what its deduped twin does', () => {
+    // End of the pure path: same seed, same yields, same number of draws. The
+    // draw count is the decisive half, since the rolls are what a doubled
+    // harvest spent twice.
+    const pairs: [string[], string[]][] = [
+      [['hide', 'hide'], ['hide']],
+      [
+        ['hide', 'hide', 'fang'],
+        ['hide', 'fang'],
+      ],
+      [
+        ['fang', 'hide', 'fang'],
+        ['fang', 'hide'],
+      ],
+      [
+        ['hide', 'fang', 'hide', 'claw', 'horn'],
+        ['hide', 'fang', 'claw', 'horn'],
+      ],
+    ];
+    for (const [dup, deduped] of pairs) {
+      for (let seed = 1; seed <= 20; seed++) {
+        const label = `${JSON.stringify(dup)} @${seed}`;
+        expect(resolveCorpseFocusHarvest(TAGS, dup, new Rng(seed)), label).toEqual(
+          resolveCorpseFocusHarvest(TAGS, deduped, new Rng(seed)),
+        );
+        expect(drawCount(TAGS, dup, seed), `${label} draws`).toBe(drawCount(TAGS, deduped, seed));
+      }
+    }
+    // And the count is genuinely the one a single family costs, so the
+    // comparison above is not two equal-but-wrong numbers.
+    expect(drawCount(TAGS, ['hide', 'hide'], 3)).toBe(1);
+    expect(drawCount(TAGS, ['hide', 'fang'], 3)).toBe(2);
+  });
+
+  function drawCount(tagged: string[], chosen: string[], seed: number): number {
+    const rng = new Rng(seed);
+    let draws = 0;
+    rng.setObserver(() => {
+      draws++;
+    });
+    resolveCorpseFocusHarvest(tagged, chosen, rng);
+    return draws;
+  }
 });

--- a/tests/harvest_yields.test.ts
+++ b/tests/harvest_yields.test.ts
@@ -5,7 +5,9 @@
 //
 // Pinned directly rather than only through harvestCorpse because the merge arm
 // is not reachable from shipped content: no mob today tags two components that
-// map to the same item id. The rule exists because the command boundary's own
+// map to the same item id, and since #2474 a repeated tag in the request cannot
+// reach it either (effectiveFocusComponents collapses the pick to a set before
+// anything rolls). The rule exists because the command boundary's own
 // pre-claim capacity gate already folds that case when it reserves stack room
 // (interaction.ts `wanted.find((w) => w.itemId === wantedItemId)`), so a ledger
 // that disagreed would reserve one stack and then print two lines for it.


### PR DESCRIPTION
## Summary

`harvestCorpse` acted on the client's `components` array without ever asking whether a tag
appeared twice, so a hand-crafted frame carrying `['hide','hide']` harvested the hide family
once per repeat off a corpse that is single-use by design: two tier rolls, two grants, and on a
rare-or-better roll two signed Pristine Hides. `effectiveFocusComponents` returned
`chosen.filter(...)` verbatim and `server/game.ts` forwards the wire array after a
`typeof c === 'string'` filter only.

The pick is a set of component families, so it is deduplicated now, before anything reads it:

```ts
const picked = [...new Set(chosen)];
return picked.length === 0 || picked.length >= taggedComponents.length
  ? taggedComponents
  : picked.filter((c) => taggedComponents.includes(c));
```

Running the dedupe **before both length tests** is what makes it complete. The repeat escaped
through two different arms:

| corpse tags | frame | before | after |
|---|---|---|---|
| `['hide','tusk','meat']` (wild_boar) | `['hide','hide']` | filter arm keeps both copies: 4 draws, two `rough_hide` grants, two shots at the jackpot | `['hide']`: 2 draws, one grant |
| `['hide','fang']` (forest_wolf) | `['hide','hide']` | raw length 2 clears `>= tagged.length`, so the concentrate request becomes a full spread and harvests `fang` the caller never named, at bonus 0 | `['hide']`: no fang, bonus 1 |

A dedupe placed after the length test would have closed only the first row.

First occurrence wins, so tag order is untouched. That order is load-bearing: it is the order
the yields, the grants and the `harvestResult` ledger entries land in (#2457).

**Fixed at the sim boundary, not on the server.** The offline `Sim` and the headless RL env call
the same command without passing through `server/game.ts` at all, so sanitizing the wire would
have left both hosts open. A test pins that the server still forwards the repeat verbatim, so a
future server-side dedupe has to be argued rather than added quietly.

### One knock-on worth calling out

A frame of repeated *invalid* tags (`['bogus','bogus']` on a two-tag corpse) used to clear the
same threshold and spread the whole corpse. It now harvests nothing, with the claim still spent,
which is exactly what a single `['bogus']` has always done. Pinned rather than left implicit.

`taggedComponents` needs no dedupe of its own: content uniqueness is already pinned by
`tests/mob_component_tags.test.ts`.

## Related issues

Closes #2474. Found while implementing #2457 (PR #2472); predates it and is untouched by it.
Sibling of #2496 (#2473), the other bug that report turned up.

Review of this PR turned up three things that are deliberately NOT fixed here, each filed
instead of widening the diff:

- **#2504**, the same class one step over: a distinct INVALID tag still pads a pick past the
  spread threshold, so `['hide','junk']` spreads where `['hide']` concentrates. Closing it
  changes behavior for an input this issue did not cover, and would require re-arguing the
  duplicate-free sweep entry that currently locks it in.
- **#2505**, `masterAssign` forwards duplicate pids, double-prompting one player and drawing an
  extra roll. Same shape, different command. The item is still granted once.
- **#2506**, `tests/gathering.test.ts` has carried two byte-identical copies of the same two
  describe blocks since before this branch.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npm run gate` (release tier, branch is off `release/v0.31.0`)
  - `npx vitest run tests/gathering.test.ts tests/corpse_harvest_sim.test.ts tests/harvest_yields.test.ts`
  - `npx tsc --noEmit`
- Manual steps: mutation-checked the fix. Replacing `[...new Set(chosen)]` with `[...chosen]`
  fails **12** of the new cases, reproduced independently by two reviewers. The rest are the
  pins meant to hold either way: the duplicate-free sweep, the zero-draw refusal contract, the
  corpse-lifecycle forward guard, the case-table shape pin, and the server-passthrough scope pin.
  Those are not counted as bug coverage.

### What the new tests pin

`effectiveFocusComponents` had **no direct coverage at all** before this, so the pure cases carry
a verbatim copy of the pre-fix body as an independent reference and assert what it used to return
beside what it returns now. A sweep over every duplicate-free subset of a four-tag corpse, in both
orders, asserts the two still agree everywhere else.

Through the offline `Sim`, the duplicated pick is compared against its single tag on the same
seed across both arms and three corpse templates, on bags, events, rng draw count and claim, with
seed-5 quantities pinned to literals so the pair cannot be equal and wrong together. The wire case
drives a hand-built frame through a real `GameServer` into the real sim and pins the draw count to
two (one family's tier roll plus its rarity roll) against the four the repeat used to cost.

Two cases are worth calling out because they cover things the first pass missed:

- **The capacity gate**, which is the boundary this change actually moves. The pre-claim gate
  reserves the most a component can roll, so the repeat used to ask for two families' worth of
  stack room (12 hides) where one was ever granted. A bag with room for exactly one family
  therefore **refused** the repeat outright while accepting the identical single-tag pick.
- **The doubled signed specimen at seed 11**, the issue's headline harm. Pre-fix that seed rolled
  rare-or-better on both of the duplicate's rarity rolls and minted **two** signer-stamped
  Pristine Hides off one single-use claim. Nothing reached that state before; it asserts on
  instance slots, so a doubled jackpot cannot hide behind a stack count.

Also pinned: a refused `harvestCorpse` draws zero rng, swept over all seven refusal arms. Two
source comments state that as a determinism contract and nothing measured it.

No parity golden moves: no parity scenario drives `harvestCorpse`. `origin/release/v0.31.0` was
merged in after it moved ahead (PR #2501, zero file overlap with this diff), so CI runs on a tip
that includes the release head.

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~Tested on desktop and mobile.~ Sim-only change, no UI surface.
- ~Accessible.~ No UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
