### PR TITLE
fix(sim): ignore a corpse-harvest component tag the corpse does not carry

### DIFF
--- a/src/sim/interaction.ts
+++ b/src/sim/interaction.ts
@@ -222,10 +222,11 @@ export function autoLootForParty(ctx: SimContext, mobId: number, triggerPid: num
  * #1142 semantics: empty or covering every tagged component spreads across
  * every tag (the #1141 behavior); picking fewer concentrates the effort for
  * a higher tier per component, per resolveCorpseFocusHarvest in
- * professions/gathering.ts. Repeats in that array are collapsed before any of
- * it is read (#2474, effectiveFocusComponents): a family is harvested at most
- * once per corpse, so `['hide','hide']` is exactly `['hide']` here and in the
- * pre-claim capacity gate below.
+ * professions/gathering.ts. That array is sanitized before any of it is read
+ * (effectiveFocusComponents): repeats collapse (#2474) and tags this corpse
+ * does not carry drop out (#2504), so `['hide','hide']` and `['hide','junk']`
+ * are both exactly `['hide']` here and in the pre-claim capacity gate below,
+ * and a pick of nothing but junk is exactly the empty pick (it spreads).
  */
 export function harvestCorpse(
   ctx: SimContext,

--- a/src/sim/professions/gathering.ts
+++ b/src/sim/professions/gathering.ts
@@ -771,9 +771,12 @@ export interface FocusHarvestYield {
  *     raw count it padded the pick past the `>= taggedComponents.length` spread
  *     threshold, so `['hide','junk']` on a two-tag corpse spread across every
  *     family at bonus 0 where `['hide']` concentrates on hide (#2504).
- * After the narrowing that second test can only ever be an equality (`picked`
- * is a deduped subset of the tags); it stays `>=` as the plain statement of
- * "the pick covers every tagged component".
+ * After the narrowing that second test can only ever be an equality: `picked`
+ * is a deduped subset of the tags, so it can exceed their count only if the
+ * tags themselves repeat, which tests/mob_component_tags.test.ts forbids. That
+ * cross-file pin is what makes the `>` half unreachable; the comparator stays
+ * `>=` as the plain statement of "the pick covers every tagged component", and
+ * degrades safely rather than silently if the pin ever loosens.
  *
  * Consequence, decided rather than inherited: a pick whose entries are ALL
  * invalid sanitizes to the empty pick, so it spreads, exactly as sending no
@@ -783,16 +786,24 @@ export interface FocusHarvestYield {
  * to the #1141 default instead of burning a single-use corpse for nothing.
  * This supersedes the narrower #2474 knock-on (an all-junk pick yielded
  * nothing), which was itself only ever true BELOW the threshold: above it, the
- * same frame already spread.
+ * same frame already spread. Scope, so the sentence above is not read as more
+ * than it is: this covers a tag the corpse does not CARRY. A tag it carries
+ * that HARVEST_COMPONENT_ITEMS does not map (claw, tusk, gills, horn) still
+ * spends the claim for nothing, is reachable from the shipped picker, and is
+ * tracked separately as #2509.
  *
  * First occurrence wins (Set iteration is insertion-ordered) and the narrowing
  * preserves that order, so tag ORDER is untouched: it is the order the yields,
  * the grants and the harvestResult ledger entries land in (#2457). Same
  * order-preserving idiom the picker's own view-core (`corpseHarvestView`)
- * already applied to the tags it renders, which is why no shipped client can
- * produce either shape in the first place.
- * `taggedComponents` needs no dedupe of its own; content uniqueness is pinned
- * by tests/mob_component_tags.test.ts.
+ * already applied to the tags it renders, which is why no CURRENT shipped
+ * client produces either shape. "Current" is load-bearing and not hedging: a
+ * cached desktop or native bundle whose content predates a retag can still
+ * name a tag this server no longer carries, which is the realistic path to the
+ * junk shape and the reason the ruling above is decided the way it is.
+ * `taggedComponents` needs no dedupe of its own: content uniqueness is pinned
+ * by tests/mob_component_tags.test.ts, the same cross-file pin the `>=`
+ * argument above leans on.
  */
 export function effectiveFocusComponents(
   taggedComponents: readonly string[],

--- a/src/sim/professions/gathering.ts
+++ b/src/sim/professions/gathering.ts
@@ -757,20 +757,40 @@ export interface FocusHarvestYield {
  * roll will yield WITHOUT drawing rng (a refused command must not shift the
  * world's draw order).
  *
- * The pick is a SET of families: a repeated tag counts ONCE, whatever the
- * caller passed (#2474). `chosen` reaches here straight off the wire
- * (server/game.ts forwards the client's `components` array after a type filter
- * only), and a corpse is single-use, so a repeat that survived would let one
- * hand-crafted frame farm the same family several times from one claim: two
- * tier rolls, two grants, and on a rare-or-better roll two signed yields. The
- * dedupe runs BEFORE either length test, so a repeat can neither reach the
- * filter arm twice nor pad `chosen.length` past the spread threshold and pull
- * in tags the caller never asked for. First occurrence wins (Set iteration is
- * insertion-ordered), so tag ORDER is untouched: it is the order the yields,
+ * `chosen` reaches here straight off the wire (server/game.ts forwards the
+ * client's `components` array after a type filter only), so it is SANITIZED
+ * first and only then interpreted: deduped to a set (#2474), then narrowed to
+ * the tags this corpse actually carries (#2504). BOTH length tests below read
+ * that sanitized set, never the raw array, which is what stops a padded frame
+ * from switching arms:
+ *   - A repeated tag counts ONCE. A corpse is single-use, so a repeat that
+ *     survived would let one hand-crafted frame farm the same family several
+ *     times off one claim: two tier rolls, two grants, and on a rare-or-better
+ *     roll two signed yields (#2474).
+ *   - A tag the corpse does not carry counts for NOTHING. Measured against the
+ *     raw count it padded the pick past the `>= taggedComponents.length` spread
+ *     threshold, so `['hide','junk']` on a two-tag corpse spread across every
+ *     family at bonus 0 where `['hide']` concentrates on hide (#2504).
+ * After the narrowing that second test can only ever be an equality (`picked`
+ * is a deduped subset of the tags); it stays `>=` as the plain statement of
+ * "the pick covers every tagged component".
+ *
+ * Consequence, decided rather than inherited: a pick whose entries are ALL
+ * invalid sanitizes to the empty pick, so it spreads, exactly as sending no
+ * selection at all does. "Ignored entirely" is then one rule applied
+ * uniformly, a junk tag is never the difference between two outcomes, and a
+ * client whose tag vocabulary has drifted from the server's content degrades
+ * to the #1141 default instead of burning a single-use corpse for nothing.
+ * This supersedes the narrower #2474 knock-on (an all-junk pick yielded
+ * nothing), which was itself only ever true BELOW the threshold: above it, the
+ * same frame already spread.
+ *
+ * First occurrence wins (Set iteration is insertion-ordered) and the narrowing
+ * preserves that order, so tag ORDER is untouched: it is the order the yields,
  * the grants and the harvestResult ledger entries land in (#2457). Same
  * order-preserving idiom the picker's own view-core (`corpseHarvestView`)
  * already applied to the tags it renders, which is why no shipped client can
- * produce the repeat in the first place.
+ * produce either shape in the first place.
  * `taggedComponents` needs no dedupe of its own; content uniqueness is pinned
  * by tests/mob_component_tags.test.ts.
  */
@@ -778,10 +798,10 @@ export function effectiveFocusComponents(
   taggedComponents: readonly string[],
   chosen: readonly string[],
 ): readonly string[] {
-  const picked = [...new Set(chosen)];
+  const picked = [...new Set(chosen)].filter((c) => taggedComponents.includes(c));
   return picked.length === 0 || picked.length >= taggedComponents.length
     ? taggedComponents
-    : picked.filter((c) => taggedComponents.includes(c));
+    : picked;
 }
 
 /**
@@ -800,7 +820,9 @@ export function effectiveFocusComponents(
  *
  * Backward compatibility: an empty `chosen` (no selection made) or a `chosen`
  * that covers every tagged component both default to spreading across all of
- * `taggedComponents`, matching the single-harvest behavior from #1141.
+ * `taggedComponents`, matching the single-harvest behavior from #1141. A
+ * `chosen` naming only tags this corpse does not carry sanitizes to the empty
+ * pick, and spreads for that same reason (#2504); see effectiveFocusComponents.
  *
  * Pure: draws only from the passed-in `Rng`, one draw per yielded component,
  * in `effectiveChosen` order.

--- a/tests/corpse_harvest_sim.test.ts
+++ b/tests/corpse_harvest_sim.test.ts
@@ -1332,6 +1332,11 @@ describe('an invalid component tag is ignored entirely (#2504)', () => {
   // already dropped by the old filter. Both are here, at two different widths,
   // and `tags` is pinned per row so a content retag cannot slide a row onto the
   // other arm while the table still claims to cover both.
+  // `absent` is the item id of every family the pick did NOT name, so a row can
+  // assert the harm directly (a spread grants them). Two rows have an empty
+  // `absent` because the only family they leave out (claw, tusk) maps to no
+  // item at all; for those, `spreadDraws` is what separates the arms, and the
+  // test below pins it live rather than trusting the label.
   const CASES: {
     templateId: string;
     padded: string[];
@@ -1339,6 +1344,8 @@ describe('an invalid component tag is ignored entirely (#2504)', () => {
     tags: string[];
     arm: string;
     draws: number;
+    spreadDraws: number;
+    absent: string[];
   }[] = [
     {
       templateId: 'forest_wolf',
@@ -1347,6 +1354,8 @@ describe('an invalid component tag is ignored entirely (#2504)', () => {
       tags: ['hide', 'fang'],
       arm: 'padded past the threshold',
       draws: 2,
+      spreadDraws: 4,
+      absent: ['wolf_fang'],
     },
     {
       templateId: 'old_greyjaw',
@@ -1355,6 +1364,8 @@ describe('an invalid component tag is ignored entirely (#2504)', () => {
       tags: ['hide', 'fang', 'claw'],
       arm: 'padded past the threshold',
       draws: 4,
+      spreadDraws: 5,
+      absent: [],
     },
     {
       templateId: 'wild_boar',
@@ -1363,6 +1374,8 @@ describe('an invalid component tag is ignored entirely (#2504)', () => {
       tags: ['hide', 'tusk', 'meat'],
       arm: 'padded past the threshold',
       draws: 4,
+      spreadDraws: 5,
+      absent: [],
     },
     {
       templateId: 'wild_boar',
@@ -1371,6 +1384,8 @@ describe('an invalid component tag is ignored entirely (#2504)', () => {
       tags: ['hide', 'tusk', 'meat'],
       arm: 'under the threshold',
       draws: 2,
+      spreadDraws: 5,
+      absent: ['game_meat'],
     },
   ];
 
@@ -1390,6 +1405,25 @@ describe('an invalid component tag is ignored entirely (#2504)', () => {
           ? 'padded past the threshold'
           : 'under the threshold';
       expect(arm, `${c.templateId} ${JSON.stringify(c.padded)} arm`).toBe(c.arm);
+      // Every `absent` id really is a family the pick leaves out, and really is
+      // mapped to an item (an unmapped one could never show up in a count, so
+      // asserting its absence would prove nothing).
+      for (const itemId of c.absent) {
+        const family = Object.keys(HARVEST_COMPONENT_ITEMS).find(
+          (k) => HARVEST_COMPONENT_ITEMS[k] === itemId,
+        );
+        expect(family, `${itemId} maps to a family`).toBeDefined();
+        expect(c.tags, `${c.templateId} ${family} is on the corpse`).toContain(family);
+        expect(c.stripped, `${c.templateId} ${family} is not named`).not.toContain(family);
+      }
+      // And the spread really does cost a different number of draws than the
+      // junk-free pick, live off the same corpse, so the per-row `draws` literal
+      // in the next test is a decisive arm separator and not a coincidence.
+      // This is what carries the two rows whose left-out family maps to no item.
+      expect(harvestWith(c.templateId, [], 5).draws, `${c.templateId} spread draws`).toBe(
+        c.spreadDraws,
+      );
+      expect(c.draws, `${c.templateId} concentrate vs spread`).not.toBe(c.spreadDraws);
     }
     expect(CASES.map((c) => c.arm)).toContain('padded past the threshold');
     expect(CASES.map((c) => c.arm)).toContain('under the threshold');
@@ -1414,6 +1448,16 @@ describe('an invalid component tag is ignored entirely (#2504)', () => {
         // ... and the claim is still spent exactly once, by the harvester.
         expect(padded.claimedBy, `${label} claim`).toBe(stripped.claimedBy);
         expect(padded.claimedBy, `${label} claim is the harvester`).not.toBeNull();
+        // The harm, stated absolutely per row rather than only as an equality:
+        // a family the caller never named is not in the bags at all. A spread
+        // would put it there, which is precisely what the junk used to buy.
+        const inv = padded.inventory as { itemId: string; count: number }[];
+        for (const itemId of c.absent) {
+          expect(
+            inv.filter((s) => s.itemId === itemId).reduce((n, s) => n + s.count, 0),
+            `${label} ${itemId} never named`,
+          ).toBe(0);
+        }
       }
     }
   });
@@ -1488,42 +1532,50 @@ describe('an invalid component tag is ignored entirely (#2504)', () => {
     expect(inv.filter((s) => s.itemId === 'wolf_fang').reduce((n, s) => n + s.count, 0)).toBe(4);
   });
 
+  const HIDE_STACK = stackSizeOf(ITEMS.rough_hide);
+  // What the pre-claim gate reserves per component: the most one can roll,
+  // harvestTierQuantity('legendary'). A literal, because WHERE that boundary
+  // sits is the whole subject of the two tests below; a rig that only ever
+  // proves "something fit" would pass on a gate reserving 3, or 1, or nothing.
+  const RESERVED_PER_FAMILY = 6;
+
+  // One rig for both capacity tests: zero free SLOTS, and a rough_hide stack
+  // with exactly `room` units of headroom. That is the only bag shape where
+  // "reserves one family" and "reserves the whole spread" can be told apart,
+  // since a second family (wolf_fang) needs a free slot and there is none.
+  const gateRig = (components: string[], room: number) => {
+    const { sim, internals, a, mob } = setup(5);
+    const m = internals.players.get(a)!;
+    fillBags(sim, internals, a);
+    m.inventory[0] = { itemId: 'rough_hide', count: HIDE_STACK - room };
+    sim.drainEvents();
+    let draws = 0;
+    const rng = (sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } }).rng;
+    rng.setObserver(() => {
+      draws++;
+    });
+    sim.harvestCorpse(mob.id, components, a);
+    rng.setObserver(null);
+    return {
+      claimedBy: mob.harvestClaimedBy,
+      hides: sim.countItem('rough_hide', a),
+      fangs: sim.countItem('wolf_fang', a),
+      draws,
+      errors: sim
+        .drainEvents()
+        .filter((e): e is Extract<typeof e, { type: 'error' }> => e.type === 'error')
+        .map((e) => e.text),
+    };
+  };
+
   it('the pre-claim capacity gate reserves the junk-free pick, not the padded one', () => {
     // The gate and the roll read the same helper, so they move together for
     // free, but the boundary they share MOVES here and only a bag sized between
-    // the old and new reservations can see it. The gate reserves the most each
-    // component can roll (6 rough_hide, the legendary tier quantity), so
-    // pre-fix ['hide','junk'] asked for two families' worth on a two-tag corpse
-    // and a bag with room for exactly one REFUSED it, while accepting the
-    // identical ['hide'].
-    const stack = stackSizeOf(ITEMS.rough_hide);
-    const rig = (components: string[]) => {
-      const { sim, internals, a, mob } = setup(5);
-      const m = internals.players.get(a)!;
-      fillBags(sim, internals, a);
-      // Zero free slots, and stack room for exactly one family's top roll.
-      m.inventory[0] = { itemId: 'rough_hide', count: stack - 6 };
-      sim.drainEvents();
-      let draws = 0;
-      const rng = (sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } })
-        .rng;
-      rng.setObserver(() => {
-        draws++;
-      });
-      sim.harvestCorpse(mob.id, components, a);
-      rng.setObserver(null);
-      return {
-        claimedBy: mob.harvestClaimedBy,
-        hides: sim.countItem('rough_hide', a),
-        draws,
-        errors: sim
-          .drainEvents()
-          .filter((e): e is Extract<typeof e, { type: 'error' }> => e.type === 'error')
-          .map((e) => e.text),
-      };
-    };
-    const padded = rig(['hide', 'junk']);
-    const stripped = rig(['hide']);
+    // the old and new reservations can see it. Pre-fix ['hide','junk'] asked
+    // for two families' worth on a two-tag corpse, so a bag with room for
+    // exactly one REFUSED it while accepting the identical ['hide'].
+    const padded = gateRig(['hide', 'junk'], RESERVED_PER_FAMILY);
+    const stripped = gateRig(['hide'], RESERVED_PER_FAMILY);
     // The single pick has always fit here, so this is the decisive half: the
     // padded pick has to reach the same harvested state, not the refusal it
     // used to get. Absolute values, not just equality, so both sides cannot be
@@ -1534,49 +1586,45 @@ describe('an invalid component tag is ignored entirely (#2504)', () => {
     expect(padded.claimedBy).toBe(stripped.claimedBy);
     expect(padded.draws).toBe(stripped.draws);
     expect(padded.hides).toBe(stripped.hides);
-    expect(padded.hides).toBe(stack - 6 + 3);
+    expect(padded.hides).toBe(HIDE_STACK - RESERVED_PER_FAMILY + 3);
     expect(padded.errors).toEqual([]);
+    // ONE unit less of room refuses both, which is what pins the reservation to
+    // 6 rather than merely "an amount that happened to fit". Without this half
+    // the accept side above would also pass a sanitize that dropped the VALID
+    // tag along with the junk and so reserved nothing at all.
+    const tightPadded = gateRig(['hide', 'junk'], RESERVED_PER_FAMILY - 1);
+    const tightStripped = gateRig(['hide'], RESERVED_PER_FAMILY - 1);
+    expect(tightStripped.claimedBy).toBeNull();
+    expect(tightStripped.draws).toBe(0);
+    expect(tightStripped.errors).toEqual(['Your bags are full.']);
+    expect(tightPadded.claimedBy).toBeNull();
+    expect(tightPadded.draws).toBe(0);
+    expect(tightPadded.errors).toEqual(['Your bags are full.']);
+    expect(tightPadded.hides).toBe(HIDE_STACK - RESERVED_PER_FAMILY + 1);
   });
 
-  it('...and an all-junk pick now reserves the whole spread, so a full bag refuses it', () => {
+  it('...and an all-junk pick reserves the whole SPREAD, not one family', () => {
     // The other side of the same moved boundary, and the one that changes a
-    // REFUSAL rather than a grant. Pre-fix an all-junk pick reserved nothing,
-    // sailed through the gate, spent the single-use claim and granted nothing;
-    // it now reserves what it will actually roll, so the same full bag refuses
-    // it and leaves the corpse for the next harvester, exactly as the empty
-    // pick always did. `claimedBy` is the decisive line: pre-fix it was spent.
-    const rig = (components: string[]) => {
-      const { sim, internals, a, mob } = setup(5);
-      fillBags(sim, internals, a);
-      sim.drainEvents();
-      let draws = 0;
-      const rng = (sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } })
-        .rng;
-      rng.setObserver(() => {
-        draws++;
-      });
-      sim.harvestCorpse(mob.id, components, a);
-      rng.setObserver(null);
-      return {
-        claimedBy: mob.harvestClaimedBy,
-        hides: sim.countItem('rough_hide', a),
-        fangs: sim.countItem('wolf_fang', a),
-        draws,
-        errors: sim
-          .drainEvents()
-          .filter((e): e is Extract<typeof e, { type: 'error' }> => e.type === 'error')
-          .map((e) => e.text),
-      };
-    };
-    const junk = rig(['junk']);
-    const empty = rig([]);
+    // REFUSAL rather than a grant. Run at the bag shape that can actually tell
+    // the two reservations apart: room for exactly ONE family. A gate that
+    // reserved one family for an all-junk pick would ACCEPT here, because
+    // ['hide'] does on the identical rig (the discriminator line below); the
+    // spread additionally needs a free slot for wolf_fang and there is none.
+    // A totally full bag would refuse under either reservation and prove
+    // nothing.
+    const junk = gateRig(['junk'], RESERVED_PER_FAMILY);
+    const oneFamily = gateRig(['hide'], RESERVED_PER_FAMILY);
+    expect(oneFamily.claimedBy).not.toBeNull();
+    expect(oneFamily.draws).toBe(2);
     expect(junk.claimedBy).toBeNull();
     expect(junk.draws).toBe(0);
-    expect(junk.hides).toBe(0);
+    expect(junk.hides).toBe(HIDE_STACK - RESERVED_PER_FAMILY);
     expect(junk.fangs).toBe(0);
     expect(junk.errors).toEqual(['Your bags are full.']);
-    // Same world as the empty pick, which is the contract: an all-junk pick is
-    // the empty pick, refusal included.
+    // Same world as the empty pick, refusal included: an all-junk pick IS the
+    // empty pick. Pre-fix it reserved nothing, sailed through the gate, and
+    // spent the single-use claim for zero yield.
+    const empty = gateRig([], RESERVED_PER_FAMILY);
     expect(junk.claimedBy).toBe(empty.claimedBy);
     expect(junk.errors).toEqual(empty.errors);
     expect(junk.draws).toBe(empty.draws);
@@ -1587,9 +1635,22 @@ describe('an invalid component tag is ignored entirely (#2504)', () => {
     // shift the world's draw order for everyone else. This change moved what
     // the capacity gate reserves, which is one of these arms, so every arm is
     // re-run with a junk-bearing pick and with an all-junk pick.
+    // Zero draws alone does NOT establish a refusal, which is exactly the trap
+    // this fix closes: pre-fix, the full-bags arm with an all-junk pick was not
+    // refused at all. It reserved nothing, passed the gate, SPENT the single-use
+    // claim, granted nothing, emitted no harvestResult (that event is gated on
+    // `granted.length > 0`) and clamped corpseTimer to 4, all while drawing zero
+    // rng and yielding zero items. So every arm also pins the claim and the
+    // corpse timer: an unspent claim on an untouched corpse is what "refused"
+    // actually means here.
     const refusals: {
       label: string;
       arrange: (rig: ReturnType<typeof setup>) => number;
+      // The pid that issues the command; defaults to the rig's player A.
+      pid?: (rig: ReturnType<typeof setup>) => number;
+      // Who owns the claim afterwards. Null everywhere except the arm that is
+      // refused BECAUSE someone else already holds it.
+      claimAfter?: (rig: ReturnType<typeof setup>) => number | null;
     }[] = [
       {
         label: 'full bags (the pre-claim capacity gate)',
@@ -1611,6 +1672,7 @@ describe('an invalid component tag is ignored entirely (#2504)', () => {
           mob.harvestClaimedBy = b;
           return mob.id;
         },
+        claimAfter: ({ b }) => b,
       },
       {
         label: 'the harvester is dead',
@@ -1644,6 +1706,18 @@ describe('an invalid component tag is ignored entirely (#2504)', () => {
         label: 'the target id is not an entity at all',
         arrange: () => 4242,
       },
+      {
+        // The two early returns the #2474 sweep this is modelled on left out.
+        // "Every arm" has to mean every arm, so the non-mob entity and the
+        // unresolvable caller are both here.
+        label: 'the target id is an entity but not a mob',
+        arrange: ({ a }) => a,
+      },
+      {
+        label: 'the acting pid resolves to no player',
+        arrange: ({ mob }) => mob.id,
+        pid: () => 987654,
+      },
     ];
     for (const arm of refusals) {
       for (const components of [['hide', 'junk'], ['junk'], ['junk', 'zzz']]) {
@@ -1656,14 +1730,41 @@ describe('an invalid component tag is ignored entirely (#2504)', () => {
         rng.setObserver(() => {
           draws++;
         });
-        rig.sim.harvestCorpse(mobId, components, rig.a);
+        rig.sim.harvestCorpse(mobId, components, arm.pid ? arm.pid(rig) : rig.a);
         rng.setObserver(null);
         const label = `${arm.label} ${JSON.stringify(components)}`;
         expect(draws, `${label} draws`).toBe(0);
         expect(rig.sim.countItem('rough_hide', rig.a), `${label} yield`).toBe(0);
         expect(rig.sim.countItem('wolf_fang', rig.a), `${label} fang yield`).toBe(0);
+        // The lines that make "refused" mean something: the claim is not spent
+        // and the corpse is left exactly as it was found, so the next harvester
+        // can still take it. Skipped only where the target is not a corpse at
+        // all (no entity, or a player entity), which have nothing to assert.
+        const target = rig.internals.entities.get(mobId);
+        if (target?.kind === 'mob') {
+          expect(target.harvestClaimedBy, `${label} claim`).toBe(
+            arm.claimAfter ? arm.claimAfter(rig) : null,
+          );
+          expect(target.corpseTimer, `${label} corpse timer`).toBe(9999);
+        }
       }
     }
+    // Positive control for the observer itself: every expectation above is
+    // zero, so a mis-wired setObserver would make the whole sweep vacuous. The
+    // SAME wiring on an accepted command has to read a nonzero count, and the
+    // accepted command has to actually land (claim spent, corpse consumed).
+    const ok = setup(5);
+    let okDraws = 0;
+    const okRng = (ok.sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } })
+      .rng;
+    okRng.setObserver(() => {
+      okDraws++;
+    });
+    ok.sim.harvestCorpse(ok.mob.id, ['hide', 'junk'], ok.a);
+    okRng.setObserver(null);
+    expect(okDraws).toBe(2);
+    expect(ok.mob.harvestClaimedBy).toBe(ok.a);
+    expect(ok.mob.corpseTimer).not.toBe(9999);
   });
 });
 
@@ -2340,7 +2441,10 @@ describe('an invalid component tag over the wire, through a real GameServer (#25
     expect(padded.raw).toContain('["hide","not_a_real_tag"]');
     // Not a vacuous comparison of two empty bags: the harvest actually yielded,
     // and it yielded only the family the frame named.
-    expect(once.hides).toBeGreaterThan(0);
+    // A literal, not just "more than zero": GameServer pins a constant
+    // WORLD_SEED and neither run ticks, so this value is knowable and a
+    // regression that changed the yield would still clear a > 0 floor.
+    expect(once.hides).toBe(2);
     expect(once.fangs).toBe(0);
     expect(padded.hides).toBe(once.hides);
     expect(padded.fangs).toBe(0);

--- a/tests/corpse_harvest_sim.test.ts
+++ b/tests/corpse_harvest_sim.test.ts
@@ -1289,6 +1289,384 @@ describe('a repeated component tag harvests the family once (#2474)', () => {
   });
 });
 
+// #2504: an entry naming no tag on the corpse is dropped before either length
+// test, so it can no longer pad the pick past the `>= taggedComponents.length`
+// spread threshold. Pre-fix, ['hide','junk'] on a two-tag corpse harvested BOTH
+// families at bonus 0 (a family the caller never named), byte-identical to the
+// empty pick; ['hide'] concentrated on hide. Same class as #2474 one step over.
+describe('an invalid component tag is ignored entirely (#2504)', () => {
+  // Same seed, same corpse template, one command each: the padded pick must
+  // land the stripped pick's world, exactly.
+  function harvestWith(
+    templateId: string,
+    components: string[],
+    seed: number,
+  ): { inventory: unknown; events: unknown; draws: number; claimedBy: number | null } {
+    const { sim, internals, a } = setup(seed);
+    const template = MOBS[templateId];
+    const corpse = createMob(7754, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+    corpse.dead = true;
+    corpse.aiState = 'dead';
+    corpse.corpseTimer = 9999;
+    corpse.respawnTimer = 9999;
+    internals.entities.set(corpse.id, corpse);
+    sim.drainEvents();
+    let draws = 0;
+    const rng = (sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } }).rng;
+    rng.setObserver(() => {
+      draws++;
+    });
+    sim.harvestCorpse(corpse.id, components, a);
+    rng.setObserver(null);
+    return {
+      inventory: structuredClone(internals.players.get(a)!.inventory),
+      events: sim.drainEvents(),
+      draws,
+      claimedBy: corpse.harvestClaimedBy,
+    };
+  }
+
+  // Which ARM a row exercises is decided by the deduped pick's raw length
+  // against the corpse's tag COUNT, not by the template: at or above the count
+  // the junk used to flip the whole command to spread, below it the junk was
+  // already dropped by the old filter. Both are here, at two different widths,
+  // and `tags` is pinned per row so a content retag cannot slide a row onto the
+  // other arm while the table still claims to cover both.
+  const CASES: {
+    templateId: string;
+    padded: string[];
+    stripped: string[];
+    tags: string[];
+    arm: string;
+    draws: number;
+  }[] = [
+    {
+      templateId: 'forest_wolf',
+      padded: ['hide', 'junk'],
+      stripped: ['hide'],
+      tags: ['hide', 'fang'],
+      arm: 'padded past the threshold',
+      draws: 2,
+    },
+    {
+      templateId: 'old_greyjaw',
+      padded: ['hide', 'fang', 'junk'],
+      stripped: ['hide', 'fang'],
+      tags: ['hide', 'fang', 'claw'],
+      arm: 'padded past the threshold',
+      draws: 4,
+    },
+    {
+      templateId: 'wild_boar',
+      padded: ['meat', 'junk', 'hide'],
+      stripped: ['meat', 'hide'],
+      tags: ['hide', 'tusk', 'meat'],
+      arm: 'padded past the threshold',
+      draws: 4,
+    },
+    {
+      templateId: 'wild_boar',
+      padded: ['hide', 'junk'],
+      stripped: ['hide'],
+      tags: ['hide', 'tusk', 'meat'],
+      arm: 'under the threshold',
+      draws: 2,
+    },
+  ];
+
+  it('covers both arms for real: each row is the corpse shape it claims to be', () => {
+    for (const c of CASES) {
+      expect(MOBS[c.templateId].componentTags, `${c.templateId} tags`).toEqual(c.tags);
+      for (const tag of c.stripped) {
+        expect(c.tags, `${c.templateId} ${tag} is on the corpse`).toContain(tag);
+      }
+      for (const tag of c.padded.filter((t) => !c.stripped.includes(t))) {
+        expect(c.tags, `${c.templateId} ${tag} is NOT on the corpse`).not.toContain(tag);
+      }
+      // The pre-#2504 test: the RAW deduped count, junk included, against the
+      // corpse's tag count.
+      const arm =
+        new Set(c.padded).size >= c.tags.length
+          ? 'padded past the threshold'
+          : 'under the threshold';
+      expect(arm, `${c.templateId} ${JSON.stringify(c.padded)} arm`).toBe(c.arm);
+    }
+    expect(CASES.map((c) => c.arm)).toContain('padded past the threshold');
+    expect(CASES.map((c) => c.arm)).toContain('under the threshold');
+  });
+
+  it('grants exactly what the junk-free pick grants, on the same seed, on both arms', () => {
+    for (const c of CASES) {
+      for (const seed of [2, 5, 11]) {
+        const label = `${c.templateId} ${JSON.stringify(c.padded)} (${c.arm}) @${seed}`;
+        const padded = harvestWith(c.templateId, c.padded, seed);
+        const stripped = harvestWith(c.templateId, c.stripped, seed);
+        // The whole observable result of the command: what landed in the bags,
+        // every event it emitted (the harvestResult ledger included), and how
+        // much rng it spent doing it.
+        expect(padded.inventory, `${label} inventory`).toEqual(stripped.inventory);
+        expect(padded.events, `${label} events`).toEqual(stripped.events);
+        expect(padded.draws, `${label} draws`).toEqual(stripped.draws);
+        // An absolute floor under that equality, per row, so a mis-wired
+        // observer reading 0 on both sides cannot pass: one mapped family costs
+        // one tier roll plus one rarity roll.
+        expect(stripped.draws, `${label} junk-free draws`).toBe(c.draws);
+        // ... and the claim is still spent exactly once, by the harvester.
+        expect(padded.claimedBy, `${label} claim`).toBe(stripped.claimedBy);
+        expect(padded.claimedBy, `${label} claim is the harvester`).not.toBeNull();
+      }
+    }
+  });
+
+  it('the issue case in absolute counts: junk no longer buys a family never named', () => {
+    // The reproduction the issue files, on the corpse it files it against.
+    // Pre-fix this command came back with 2 rough_hide and 4 wolf_fang off 4
+    // draws, byte-identical to the empty pick; the fang line is the harm (a
+    // family the caller never named) and the specimen line is the cost (the
+    // concentration bonus a one-family pick earns, spent on spreading instead).
+    const { sim, internals, a } = setup(5);
+    expect(MOBS.forest_wolf.componentTags).toEqual(['hide', 'fang']);
+    const corpse = createMob(7753, MOBS.forest_wolf, MOBS.forest_wolf.maxLevel, {
+      x: 0,
+      y: 0,
+      z: 0,
+    });
+    corpse.dead = true;
+    corpse.aiState = 'dead';
+    corpse.corpseTimer = 9999;
+    corpse.respawnTimer = 9999;
+    internals.entities.set(corpse.id, corpse);
+    sim.drainEvents();
+    let draws = 0;
+    const rng = (sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } }).rng;
+    rng.setObserver(() => {
+      draws++;
+    });
+    sim.harvestCorpse(corpse.id, ['hide', 'junk'], a);
+    rng.setObserver(null);
+    expect(sim.countItem('rough_hide', a)).toBe(3);
+    expect(sim.countItem('wolf_fang', a)).toBe(0);
+    expect(sim.countItem('pristine_hide', a)).toBe(1);
+    expect(draws).toBe(2);
+    // Read off the ledger the client actually prints, too: the junk string
+    // reaches no grant of its own and leaves no entry behind.
+    const result = sim
+      .drainEvents()
+      .filter((e): e is Extract<typeof e, { type: 'harvestResult' }> => e.type === 'harvestResult');
+    expect(result).toHaveLength(1);
+    expect(result[0].yields.map((y) => y.itemId).sort()).toEqual(['pristine_hide', 'rough_hide']);
+    expect(result[0].yields.find((y) => y.itemId === 'rough_hide')?.qty).toBe(3);
+  });
+
+  it('an ALL-junk pick spreads, exactly as the empty pick does (the settled ruling)', () => {
+    // The ordering consequence the issue asked to settle: with the filter ahead
+    // of the length tests, a pick naming nothing on the corpse reaches the
+    // `length === 0` arm. Ruled for spreading. Pre-fix this command spent the
+    // claim and granted NOTHING, which is the outcome being retired.
+    for (const templateId of ['forest_wolf', 'wild_boar']) {
+      for (const seed of [2, 5, 11]) {
+        for (const pick of [['junk'], ['junk', 'zzz'], ['junk', 'zzz', 'qqq']]) {
+          const label = `${templateId} ${JSON.stringify(pick)} @${seed}`;
+          const junk = harvestWith(templateId, pick, seed);
+          const empty = harvestWith(templateId, [], seed);
+          expect(junk.inventory, `${label} inventory`).toEqual(empty.inventory);
+          expect(junk.events, `${label} events`).toEqual(empty.events);
+          expect(junk.draws, `${label} draws`).toEqual(empty.draws);
+          expect(junk.claimedBy, `${label} claim`).toBe(empty.claimedBy);
+        }
+      }
+    }
+    // Absolutes under the equality, so two identically-empty harvests cannot
+    // pass it: the wolf spread costs 4 draws (two mapped families, a tier roll
+    // and a rarity roll each) and really lands both families. Pre-fix the same
+    // command drew 0 and granted 0.
+    const junk = harvestWith('forest_wolf', ['junk'], 5);
+    expect(junk.draws).toBe(4);
+    expect(junk.claimedBy).not.toBeNull();
+    const inv = junk.inventory as { itemId: string; count: number }[];
+    expect(inv.filter((s) => s.itemId === 'rough_hide').reduce((n, s) => n + s.count, 0)).toBe(2);
+    expect(inv.filter((s) => s.itemId === 'wolf_fang').reduce((n, s) => n + s.count, 0)).toBe(4);
+  });
+
+  it('the pre-claim capacity gate reserves the junk-free pick, not the padded one', () => {
+    // The gate and the roll read the same helper, so they move together for
+    // free, but the boundary they share MOVES here and only a bag sized between
+    // the old and new reservations can see it. The gate reserves the most each
+    // component can roll (6 rough_hide, the legendary tier quantity), so
+    // pre-fix ['hide','junk'] asked for two families' worth on a two-tag corpse
+    // and a bag with room for exactly one REFUSED it, while accepting the
+    // identical ['hide'].
+    const stack = stackSizeOf(ITEMS.rough_hide);
+    const rig = (components: string[]) => {
+      const { sim, internals, a, mob } = setup(5);
+      const m = internals.players.get(a)!;
+      fillBags(sim, internals, a);
+      // Zero free slots, and stack room for exactly one family's top roll.
+      m.inventory[0] = { itemId: 'rough_hide', count: stack - 6 };
+      sim.drainEvents();
+      let draws = 0;
+      const rng = (sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } })
+        .rng;
+      rng.setObserver(() => {
+        draws++;
+      });
+      sim.harvestCorpse(mob.id, components, a);
+      rng.setObserver(null);
+      return {
+        claimedBy: mob.harvestClaimedBy,
+        hides: sim.countItem('rough_hide', a),
+        draws,
+        errors: sim
+          .drainEvents()
+          .filter((e): e is Extract<typeof e, { type: 'error' }> => e.type === 'error')
+          .map((e) => e.text),
+      };
+    };
+    const padded = rig(['hide', 'junk']);
+    const stripped = rig(['hide']);
+    // The single pick has always fit here, so this is the decisive half: the
+    // padded pick has to reach the same harvested state, not the refusal it
+    // used to get. Absolute values, not just equality, so both sides cannot be
+    // wrong together.
+    expect(stripped.claimedBy).not.toBeNull();
+    expect(stripped.draws).toBe(2);
+    expect(stripped.errors).toEqual([]);
+    expect(padded.claimedBy).toBe(stripped.claimedBy);
+    expect(padded.draws).toBe(stripped.draws);
+    expect(padded.hides).toBe(stripped.hides);
+    expect(padded.hides).toBe(stack - 6 + 3);
+    expect(padded.errors).toEqual([]);
+  });
+
+  it('...and an all-junk pick now reserves the whole spread, so a full bag refuses it', () => {
+    // The other side of the same moved boundary, and the one that changes a
+    // REFUSAL rather than a grant. Pre-fix an all-junk pick reserved nothing,
+    // sailed through the gate, spent the single-use claim and granted nothing;
+    // it now reserves what it will actually roll, so the same full bag refuses
+    // it and leaves the corpse for the next harvester, exactly as the empty
+    // pick always did. `claimedBy` is the decisive line: pre-fix it was spent.
+    const rig = (components: string[]) => {
+      const { sim, internals, a, mob } = setup(5);
+      fillBags(sim, internals, a);
+      sim.drainEvents();
+      let draws = 0;
+      const rng = (sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } })
+        .rng;
+      rng.setObserver(() => {
+        draws++;
+      });
+      sim.harvestCorpse(mob.id, components, a);
+      rng.setObserver(null);
+      return {
+        claimedBy: mob.harvestClaimedBy,
+        hides: sim.countItem('rough_hide', a),
+        fangs: sim.countItem('wolf_fang', a),
+        draws,
+        errors: sim
+          .drainEvents()
+          .filter((e): e is Extract<typeof e, { type: 'error' }> => e.type === 'error')
+          .map((e) => e.text),
+      };
+    };
+    const junk = rig(['junk']);
+    const empty = rig([]);
+    expect(junk.claimedBy).toBeNull();
+    expect(junk.draws).toBe(0);
+    expect(junk.hides).toBe(0);
+    expect(junk.fangs).toBe(0);
+    expect(junk.errors).toEqual(['Your bags are full.']);
+    // Same world as the empty pick, which is the contract: an all-junk pick is
+    // the empty pick, refusal included.
+    expect(junk.claimedBy).toBe(empty.claimedBy);
+    expect(junk.errors).toEqual(empty.errors);
+    expect(junk.draws).toBe(empty.draws);
+  });
+
+  it('draws NO rng when refused, on every refusal arm, junk in the pick or not', () => {
+    // The determinism contract the issue names last: a refused command must not
+    // shift the world's draw order for everyone else. This change moved what
+    // the capacity gate reserves, which is one of these arms, so every arm is
+    // re-run with a junk-bearing pick and with an all-junk pick.
+    const refusals: {
+      label: string;
+      arrange: (rig: ReturnType<typeof setup>) => number;
+    }[] = [
+      {
+        label: 'full bags (the pre-claim capacity gate)',
+        arrange: ({ sim, internals, a, mob }) => {
+          fillBags(sim, internals, a);
+          return mob.id;
+        },
+      },
+      {
+        label: 'too far away',
+        arrange: ({ internals, a, mob }) => {
+          internals.entities.get(a)!.pos = { x: 500, y: 0, z: 0 };
+          return mob.id;
+        },
+      },
+      {
+        label: 'the corpse is already claimed',
+        arrange: ({ mob, b }) => {
+          mob.harvestClaimedBy = b;
+          return mob.id;
+        },
+      },
+      {
+        label: 'the harvester is dead',
+        arrange: ({ internals, a, mob }) => {
+          internals.entities.get(a)!.dead = true;
+          return mob.id;
+        },
+      },
+      {
+        label: 'the corpse carries no component tags',
+        arrange: ({ internals }) => {
+          const template = MOBS.warlock_imp;
+          const corpse = createMob(7752, template, template.maxLevel, { x: 0, y: 0, z: 0 });
+          corpse.dead = true;
+          corpse.aiState = 'dead';
+          corpse.corpseTimer = 9999;
+          corpse.respawnTimer = 9999;
+          internals.entities.set(corpse.id, corpse);
+          return corpse.id;
+        },
+      },
+      {
+        label: 'the target mob is still alive',
+        arrange: ({ mob }) => {
+          mob.dead = false;
+          mob.aiState = 'idle';
+          return mob.id;
+        },
+      },
+      {
+        label: 'the target id is not an entity at all',
+        arrange: () => 4242,
+      },
+    ];
+    for (const arm of refusals) {
+      for (const components of [['hide', 'junk'], ['junk'], ['junk', 'zzz']]) {
+        const rig = setup(5);
+        const mobId = arm.arrange(rig);
+        let draws = 0;
+        const rng = (
+          rig.sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } }
+        ).rng;
+        rng.setObserver(() => {
+          draws++;
+        });
+        rig.sim.harvestCorpse(mobId, components, rig.a);
+        rng.setObserver(null);
+        const label = `${arm.label} ${JSON.stringify(components)}`;
+        expect(draws, `${label} draws`).toBe(0);
+        expect(rig.sim.countItem('rough_hide', rig.a), `${label} yield`).toBe(0);
+        expect(rig.sim.countItem('wolf_fang', rig.a), `${label} fang yield`).toBe(0);
+      }
+    }
+  });
+});
+
 // Corpse premium-arm tool gating (Professions 2.0): the plain
 // component grant is NEVER gated (the bare-hands floor); only the
 // signed/specimen upgrade of a signable rarity roll checks the best owned
@@ -1896,5 +2274,104 @@ describe('a repeated component tag over the wire, through a real GameServer (#24
     const spy = vi.spyOn(server.sim, 'harvestCorpse').mockImplementation(() => {});
     (server as any).dispatchMessage(session, JSON.parse(raw), raw, 0);
     expect(spy).toHaveBeenCalledWith(4242, ['hide', 'hide'], session.pid);
+  });
+});
+
+// Two servers, one command each: GameServer pins a constant WORLD_SEED and
+// neither run ticks, so the two worlds are byte-identical at harvest time and
+// any difference in the result is the pick.
+describe('an invalid component tag over the wire, through a real GameServer (#2504)', () => {
+  function serverHarvest(components: string[]): {
+    raw: string;
+    inventory: { itemId: string; count: number; instance?: unknown }[];
+    hides: number;
+    fangs: number;
+    draws: number;
+    claimedBy: number | null;
+  } {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 95, 'Alpha');
+    const internals = server.sim as unknown as SimInternals;
+    const self = internals.entities.get(session.pid)!;
+    self.pos = { x: 0, y: 0, z: 0 };
+    self.prevPos = { x: 0, y: 0, z: 0 };
+    // forest_wolf tags hide/fang: two tags, so a two-entry pick CLEARS
+    // `>= tagged.length` and lands on the arm the junk string used to flip to
+    // spread. A three-tag corpse would never reach it, and this test would pass
+    // on either body.
+    const template = MOBS.forest_wolf;
+    const mobId = Math.max(...internals.entities.keys()) + 1;
+    const mob = createMob(mobId, template, template.maxLevel, { x: 2, y: 0, z: 0 });
+    mob.dead = true;
+    mob.aiState = 'dead';
+    mob.corpseTimer = 9999;
+    mob.respawnTimer = 9999;
+    internals.entities.set(mob.id, mob);
+    // A hand-built frame, the untrusted shape the issue reproduces with, parsed
+    // and dispatched exactly as a socket message is. `t: 'cmd'` is the real
+    // envelope (ClientWorld.rawCmd); without it the dispatcher drops the frame
+    // as a protocol anomaly and the test would pass on an unharvested corpse.
+    const raw = JSON.stringify({ t: 'cmd', cmd: 'harvestCorpse', id: mobId, components });
+    let draws = 0;
+    const rng = (
+      server.sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } }
+    ).rng;
+    rng.setObserver(() => {
+      draws++;
+    });
+    (server as any).dispatchMessage(session, JSON.parse(raw), raw, 0);
+    rng.setObserver(null);
+    return {
+      raw,
+      inventory: structuredClone(internals.players.get(session.pid)!.inventory),
+      hides: server.sim.countItem('rough_hide', session.pid),
+      fangs: server.sim.countItem('wolf_fang', session.pid),
+      draws,
+      claimedBy: mob.harvestClaimedBy,
+    };
+  }
+
+  it('lands the same bags the junk-free tag lands, and spends the claim once', () => {
+    const padded = serverHarvest(['hide', 'not_a_real_tag']);
+    const once = serverHarvest(['hide']);
+    // The frame really carried the junk: the assertion below is about the sim
+    // dropping it, not about the payload never arriving.
+    expect(padded.raw).toContain('["hide","not_a_real_tag"]');
+    // Not a vacuous comparison of two empty bags: the harvest actually yielded,
+    // and it yielded only the family the frame named.
+    expect(once.hides).toBeGreaterThan(0);
+    expect(once.fangs).toBe(0);
+    expect(padded.hides).toBe(once.hides);
+    expect(padded.fangs).toBe(0);
+    expect(padded.inventory).toEqual(once.inventory);
+    expect(padded.claimedBy).not.toBeNull();
+    expect(padded.claimedBy).toBe(once.claimedBy);
+    // The most decisive pin available over the wire, and the one the bags alone
+    // cannot make: rolls are what the padded pick actually spent. One family
+    // costs two draws (tier roll plus rarity roll); the padded pick used to
+    // spread and cost four, so this is a literal, not an equality that could
+    // hold at any value.
+    expect(padded.draws).toBe(2);
+    expect(once.draws).toBe(2);
+  });
+
+  it('forwards the junk verbatim: the SIM boundary is what closes it, not the server', () => {
+    // Deliberate, and the reason the fix lives in effectiveFocusComponents: the
+    // offline Sim and the headless env call the same command without ever
+    // passing through server/game.ts, so validating tags here would have left
+    // both hosts open. If a future change starts filtering on the server too,
+    // this test is the one that should be re-argued, not quietly deleted.
+    const server = new GameServer();
+    const session = joinServer(server, fakeWs(), 96, 'Alpha');
+    const raw = JSON.stringify({
+      t: 'cmd',
+      cmd: 'harvestCorpse',
+      id: 4242,
+      components: ['hide', 'not_a_real_tag'],
+    });
+    const spy = vi.spyOn(server.sim, 'harvestCorpse').mockImplementation(() => {});
+    (server as any).dispatchMessage(session, JSON.parse(raw), raw, 0);
+    expect(spy).toHaveBeenCalledWith(4242, ['hide', 'not_a_real_tag'], session.pid);
   });
 });

--- a/tests/gathering.test.ts
+++ b/tests/gathering.test.ts
@@ -275,15 +275,22 @@ describe('effectiveFocusComponents collapses a repeated tag (#2474)', () => {
     expect(effectiveFocusComponents(['hide', 'fang'], ['hide'])).toEqual(['hide']);
   });
 
-  it('a pick of repeated JUNK harvests nothing, as a single junk tag already did', () => {
+  it('a pick of repeated JUNK lands wherever a single junk tag lands', () => {
     // The knock-on the padding fix carries, pinned so it reads as intended
     // rather than as a side effect: repeats of a tag that is not on the corpse
-    // also used to clear the threshold and spread the whole corpse. One junk
-    // tag has always yielded nothing (the arm above it), so collapsing the
-    // repeat is what makes the two agree.
+    // also used to clear the threshold and spread the whole corpse, while one
+    // junk tag stayed under it and yielded nothing. The pre-#2474 body really
+    // did split the same intent by how many junk strings the frame carried:
     expect(legacyEffective(['hide', 'fang'], ['zzz', 'zzz'])).toEqual(['hide', 'fang']);
-    expect(effectiveFocusComponents(['hide', 'fang'], ['zzz', 'zzz'])).toEqual([]);
-    expect(effectiveFocusComponents(['hide', 'fang'], ['zzz'])).toEqual([]);
+    expect(legacyEffective(['hide', 'fang'], ['zzz'])).toEqual([]);
+    // Making the two agree is #2474's business and still holds. WHICH value
+    // they agree on is #2504's: an invalid tag is now dropped before either
+    // length test, so an all-junk pick is the empty pick, and the empty pick
+    // spreads (the #1141 default). Superseded, not quietly deleted: both lines
+    // read `.toEqual([])` until #2504, and the argument for the move lives on
+    // effectiveFocusComponents beside the ruling itself.
+    expect(effectiveFocusComponents(['hide', 'fang'], ['zzz', 'zzz'])).toEqual(['hide', 'fang']);
+    expect(effectiveFocusComponents(['hide', 'fang'], ['zzz'])).toEqual(['hide', 'fang']);
   });
 
   it('keeps first-occurrence ORDER, the order yields, grants and ledger entries land in', () => {
@@ -298,18 +305,32 @@ describe('effectiveFocusComponents collapses a repeated tag (#2474)', () => {
     ]);
   });
 
-  it('is identical to the pre-#2474 result for EVERY duplicate-free pick', () => {
+  it('is identical to the pre-#2474 result for EVERY duplicate-free pick naming a real tag', () => {
     // The no-regression half of the acceptance criteria, swept rather than
-    // sampled: every subset of a four-tag corpse, in two orders, plus the
-    // off-corpse tag and the empty pick. A dedupe that touched a
+    // sampled: every subset of a four-tag corpse, in two orders, plus a pick
+    // padded with an off-corpse tag and the empty pick. A dedupe that touched a
     // duplicate-free array at all would fail here.
     const picks = subsets(TAGS).flatMap((s) => [s, [...s].reverse()]);
-    picks.push(['hide', 'not_a_real_tag'], ['not_a_real_tag'], []);
+    picks.push(['hide', 'not_a_real_tag'], []);
     for (const pick of picks) {
       expect(effectiveFocusComponents(TAGS, pick), `pick ${JSON.stringify(pick)}`).toEqual(
         legacyEffective(TAGS, pick),
       );
     }
+    // The one pick that left this sweep, carved out in the open rather than
+    // dropped: #2504 ruled that a pick naming nothing the corpse carries IS the
+    // empty pick, so it spreads where the pre-#2474 body yielded nothing.
+    // Asserted right here, at the sweep it came out of, so the carve-out cannot
+    // pass unread.
+    expect(legacyEffective(TAGS, ['not_a_real_tag'])).toEqual([]);
+    expect(effectiveFocusComponents(TAGS, ['not_a_real_tag'])).toEqual(TAGS);
+    // And this fixture's blind spot, which is why #2504 sweeps narrower corpses
+    // in its own describe below: a two-entry pick can only reach the spread
+    // threshold on a corpse with two tags or fewer, so on these four tags
+    // `['hide','not_a_real_tag']` stays on the filter arm in BOTH bodies and
+    // the padding class #2504 closes is invisible from here.
+    expect(effectiveFocusComponents(TAGS, ['hide', 'not_a_real_tag'])).toEqual(['hide']);
+    expect(legacyEffective(['hide', 'fang'], ['hide', 'not_a_real_tag'])).toEqual(['hide', 'fang']);
   });
 
   it('makes a repeated pick draw and yield EXACTLY what its deduped twin does', () => {
@@ -347,6 +368,223 @@ describe('effectiveFocusComponents collapses a repeated tag (#2474)', () => {
   });
 
   function drawCount(tagged: string[], chosen: string[], seed: number): number {
+    const rng = new Rng(seed);
+    let draws = 0;
+    rng.setObserver(() => {
+      draws++;
+    });
+    resolveCorpseFocusHarvest(tagged, chosen, rng);
+    return draws;
+  }
+});
+
+// #2504: the focus pick is a set of THIS corpse's families. `chosen` arrives
+// straight off the wire (server/game.ts type-filters the array and forwards it),
+// so an entry naming no tag on the corpse is a client-supplied value the sim
+// must not act on. Measured against the raw count it still padded the pick past
+// the `>= taggedComponents.length` spread threshold, so a caller who named one
+// real family plus one junk string harvested the WHOLE corpse at bonus 0,
+// including a family they never named. Same shape as #2474 one step over: an
+// unsanitized array deciding which arm runs, through `.length`.
+describe('effectiveFocusComponents drops a tag the corpse does not carry (#2504)', () => {
+  // The pre-#2504 body, verbatim (the #2474 dedupe, filtering AFTER both length
+  // tests), kept as an independent reference so every claim below compares
+  // against real prior behavior rather than against the function under test.
+  function legacy2503(tagged: readonly string[], chosen: readonly string[]): readonly string[] {
+    const picked = [...new Set(chosen)];
+    return picked.length === 0 || picked.length >= tagged.length
+      ? tagged
+      : picked.filter((c) => tagged.includes(c));
+  }
+
+  function subsets<T>(items: readonly T[]): T[][] {
+    return items.reduce<T[][]>((acc, item) => acc.concat(acc.map((s) => [...s, item])), [[]]);
+  }
+
+  // Corpse widths chosen for their ARMS, not for variety: a two-entry pick
+  // clears `>= tagged.length` on WOLF and stays under it on BOAR, so the two
+  // rows are the padding arm and the filter arm of the same function. WOLF and
+  // BOAR mirror real content (forest_wolf, wild_boar); tests/mob_component_tags
+  // and the sim-level #2504 cases pin them against MOBS.
+  const SOLO = ['hide'];
+  const WOLF = ['hide', 'fang'];
+  const BOAR = ['hide', 'tusk', 'meat'];
+  const WIDE = ['hide', 'fang', 'claw', 'horn'];
+  const CORPSES = [SOLO, WOLF, BOAR, WIDE];
+  const JUNK = ['junk', 'zzz', 'not_a_real_tag'];
+
+  it('the issue case: one junk entry no longer spreads a one-family pick', () => {
+    // forest_wolf's two tags, the corpse the issue reproduces on. The fang line
+    // is the decisive one: it is the family the caller never named, and the
+    // whole harm is that it used to be granted anyway, at the zero
+    // concentration bonus a real two-tag pick earns.
+    expect(legacy2503(WOLF, ['hide', 'junk'])).toEqual(['hide', 'fang']);
+    expect(effectiveFocusComponents(WOLF, ['hide', 'junk'])).toEqual(['hide']);
+    expect(effectiveFocusComponents(WOLF, ['hide'])).toEqual(['hide']);
+    // Same frame one tag map over, so the pin is not a property of 'hide'.
+    expect(effectiveFocusComponents(WOLF, ['fang', 'junk'])).toEqual(['fang']);
+  });
+
+  it('junk is INERT: a pick means exactly what the same pick without junk means', () => {
+    // The contract as one property, and the general statement the case above is
+    // a single instance of. Swept over every corpse width, every subset of its
+    // tags, every subset of three junk strings, and three placements of that
+    // junk (before, after, interleaved), so neither pick length nor pick order
+    // can leave junk load-bearing anywhere.
+    for (const tags of CORPSES) {
+      for (const valid of subsets(tags)) {
+        const expected = effectiveFocusComponents(tags, valid);
+        for (const junk of subsets(JUNK)) {
+          const placements = [
+            [...valid, ...junk],
+            [...junk, ...valid],
+            valid
+              .flatMap((v, i) => (junk[i] === undefined ? [v] : [junk[i], v]))
+              .concat(junk.slice(valid.length)),
+          ];
+          for (const pick of placements) {
+            const label = `tags ${JSON.stringify(tags)} pick ${JSON.stringify(pick)}`;
+            expect(effectiveFocusComponents(tags, pick), label).toEqual(expected);
+          }
+        }
+      }
+    }
+    // Not a sweep of vacuous equalities: the property covers both arms, and
+    // these are the two values it is holding fixed on the corpse that has both.
+    expect(effectiveFocusComponents(WOLF, ['hide'])).toEqual(['hide']);
+    expect(effectiveFocusComponents(WOLF, [])).toEqual(['hide', 'fang']);
+  });
+
+  it('an all-junk pick IS the empty pick, at every junk length (the settled ruling)', () => {
+    // The ordering consequence the issue asked to settle before fixing:
+    // filtering ahead of the length tests sends an all-invalid pick to the
+    // `length === 0` arm. Ruled for spreading, and pinned here. "Ignored
+    // entirely" is then one rule with no exception at the boundary, a junk
+    // string is never the difference between two outcomes, and a client whose
+    // tag vocabulary has drifted from the server's content degrades to the
+    // #1141 default instead of burning a single-use corpse for nothing.
+    //
+    // What it supersedes, shown rather than described: the pre-#2504 body split
+    // the same intent by junk COUNT, spreading at or above the threshold and
+    // yielding nothing below it. There was no coherent prior behavior to keep.
+    expect(legacy2503(WOLF, ['junk'])).toEqual([]);
+    expect(legacy2503(WOLF, ['junk', 'zzz'])).toEqual(['hide', 'fang']);
+    for (const tags of CORPSES) {
+      for (const pick of [['junk'], ['junk', 'zzz'], ['junk', 'zzz', 'qqq'], ['junk', 'junk']]) {
+        const label = `tags ${JSON.stringify(tags)} pick ${JSON.stringify(pick)}`;
+        expect(effectiveFocusComponents(tags, pick), label).toEqual(tags);
+        expect(effectiveFocusComponents(tags, pick), `${label} vs empty`).toEqual(
+          effectiveFocusComponents(tags, []),
+        );
+      }
+    }
+  });
+
+  it('never returns anything the corpse does not carry, on any pick', () => {
+    // The invariant that survives every arm: whatever comes back is a subset of
+    // the corpse's own tags, so a junk string can never reach the grant loop as
+    // an unmapped component.
+    for (const tags of CORPSES) {
+      for (const junk of subsets(JUNK)) {
+        for (const valid of subsets(tags)) {
+          const out = effectiveFocusComponents(tags, [...valid, ...junk]);
+          expect(
+            out.filter((c) => !tags.includes(c)),
+            JSON.stringify([tags, valid, junk]),
+          ).toEqual([]);
+        }
+      }
+    }
+  });
+
+  it('is idempotent: feeding a result back in returns it unchanged', () => {
+    // The sanitize is a fixed point, which is what lets the pre-claim capacity
+    // gate and the roll call it independently and always agree.
+    for (const tags of CORPSES) {
+      for (const junk of subsets(JUNK)) {
+        for (const valid of subsets(tags)) {
+          const once = effectiveFocusComponents(tags, [...valid, ...junk]);
+          expect(effectiveFocusComponents(tags, once), JSON.stringify([tags, valid, junk])).toEqual(
+            once,
+          );
+        }
+      }
+    }
+  });
+
+  it('keeps first-occurrence ORDER once the junk is gone', () => {
+    // Order is load-bearing (#2457): pick order is yield order is chat-line
+    // order. Dropping an entry from the middle must close the gap, not reorder
+    // what is left.
+    expect(effectiveFocusComponents(WIDE, ['fang', 'junk', 'hide'])).toEqual(['fang', 'hide']);
+    expect(effectiveFocusComponents(WIDE, ['junk', 'horn', 'zzz', 'claw'])).toEqual([
+      'horn',
+      'claw',
+    ]);
+    // A pick that covers every tag still spreads in CONTENT order, not pick
+    // order, exactly as it did before this change.
+    expect(effectiveFocusComponents(WOLF, ['fang', 'hide'])).toEqual(['hide', 'fang']);
+    expect(effectiveFocusComponents(WOLF, ['fang', 'hide', 'junk'])).toEqual(['hide', 'fang']);
+  });
+
+  it('composes with the #2474 dedupe: repeats and junk in the same frame', () => {
+    // Both sanitizers run before both length tests, so a frame carrying both
+    // shapes collapses to the same one family, and neither shape can pad the
+    // other past the threshold.
+    expect(legacy2503(WOLF, ['hide', 'hide', 'junk'])).toEqual(['hide', 'fang']);
+    expect(effectiveFocusComponents(WOLF, ['hide', 'hide', 'junk'])).toEqual(['hide']);
+    expect(effectiveFocusComponents(WOLF, ['junk', 'hide', 'junk', 'hide'])).toEqual(['hide']);
+    expect(effectiveFocusComponents(BOAR, ['meat', 'junk', 'meat', 'hide'])).toEqual([
+      'meat',
+      'hide',
+    ]);
+  });
+
+  it('leaves every duplicate-free pick of REAL tags exactly where #2474 left it', () => {
+    // The no-regression half of the acceptance criteria, swept on the corpse
+    // widths that actually have a spread threshold to cross (the #2474 sweep
+    // runs on four tags, where a short pick can never reach it). Every subset of
+    // every corpse, in both orders: if this fix moved anything other than the
+    // junk-bearing picks, it fails here.
+    for (const tags of CORPSES) {
+      for (const pick of subsets(tags).flatMap((s) => [s, [...s].reverse()])) {
+        const label = `tags ${JSON.stringify(tags)} pick ${JSON.stringify(pick)}`;
+        expect(effectiveFocusComponents(tags, pick), label).toEqual(legacy2503(tags, pick));
+      }
+    }
+  });
+
+  it('makes a junk-padded pick draw and yield EXACTLY what its stripped twin does', () => {
+    // End of the pure path: same seed, same yields, same number of draws. The
+    // draw count is the decisive half, since spreading is what a padded pick
+    // used to spend its extra rolls on.
+    const pairs: [readonly string[], string[], string[]][] = [
+      [WOLF, ['hide', 'junk'], ['hide']],
+      [WOLF, ['junk', 'hide'], ['hide']],
+      [WOLF, ['hide', 'junk', 'zzz'], ['hide']],
+      [BOAR, ['meat', 'hide', 'junk'], ['meat', 'hide']],
+      [WOLF, ['junk', 'zzz'], []],
+    ];
+    for (const [tags, padded, stripped] of pairs) {
+      for (let seed = 1; seed <= 20; seed++) {
+        const label = `${JSON.stringify(tags)} ${JSON.stringify(padded)} @${seed}`;
+        expect(resolveCorpseFocusHarvest(tags, padded, new Rng(seed)), label).toEqual(
+          resolveCorpseFocusHarvest(tags, stripped, new Rng(seed)),
+        );
+        expect(drawCount(tags, padded, seed), `${label} draws`).toBe(
+          drawCount(tags, stripped, seed),
+        );
+      }
+    }
+    // Absolute literals under those equalities, so two equal-but-wrong counts
+    // cannot pass: one family costs one tier roll, the wolf spread costs two.
+    // The padded pick used to cost two here; the all-junk pick used to cost 0.
+    expect(drawCount(WOLF, ['hide', 'junk'], 3)).toBe(1);
+    expect(drawCount(WOLF, ['hide'], 3)).toBe(1);
+    expect(drawCount(WOLF, ['junk', 'zzz'], 3)).toBe(2);
+  });
+
+  function drawCount(tagged: readonly string[], chosen: string[], seed: number): number {
     const rng = new Rng(seed);
     let draws = 0;
     rng.setObserver(() => {


### PR DESCRIPTION
## Summary

`effectiveFocusComponents` (`src/sim/professions/gathering.ts`) compared the corpse-harvest
focus pick's **raw** length against the corpse's tag count before filtering out tags the corpse
does not carry, so an unrecognized string still counted toward the "covers every tagged
component" test. A pick naming one real family plus one junk string therefore cleared the
`>= taggedComponents.length` spread threshold and harvested the **whole** corpse at bonus 0,
including a family the caller never named, where the same pick without the junk concentrated.

Measured against a real `Sim` (`forest_wolf`, tags `hide`/`fang`, seed 5):

| pick | before | after |
|---|---|---|
| `["hide"]` | `rough_hide` 3, `pristine_hide` 1, 2 draws | unchanged |
| `["hide","junk"]` | `rough_hide` 2, `wolf_fang` 4, 4 draws | `rough_hide` 3, `pristine_hide` 1, 2 draws |
| `["junk"]` | nothing, claim spent, 0 draws | `rough_hide` 2, `wolf_fang` 4, 4 draws |
| `[]` | `rough_hide` 2, `wolf_fang` 4, 4 draws | unchanged |

The fix moves the narrowing ahead of both length tests, next to the #2474 dedupe: `chosen` is
sanitized first (deduped, then narrowed to this corpse's tags) and only then interpreted. It is
one line of behavior change.

### The ordering ruling the issue asked to settle

With filter-first, a pick naming **nothing** the corpse carries reaches the `length === 0` arm.
Settled for **spreading**, and pinned both as a pure unit and against a real `Sim`:

- "An invalid tag is ignored entirely" then holds as one rule with no exception at the boundary,
  and a junk string is never the difference between two outcomes.
- There was no coherent prior behavior to preserve. The pre-fix body split the same intent by
  junk **count**: `["junk"]` on a two-tag corpse yielded nothing, `["junk","zzz"]` on the same
  corpse already spread. This supersedes the narrower #2474 knock-on, which inherited the value
  from the below-threshold arm rather than arguing it.
- A client whose tag vocabulary has drifted from the server's content (a cached desktop or
  native bundle) degrades to the #1141 default instead of burning a single-use corpse for
  nothing.

Not a security escalation: the spread result is byte-identical to the empty `components: []`
array any client can already send by unchecking every box in the picker (the loot window says so
in as many words), so no capability, item, or rng draw is gained. Byte-identical to an explicit
`[]`, note, **not** to omitting `components`, which still resolves to the town-focus subset and
can concentrate; an all-junk pick lands on `bonus = 0`, the lowest-yield arm, so it can never
out-yield an honest pick. The sharper arm is the issue case itself: `["hide","junk"]` now
concentrates at `bonus = 1` where it spread at `bonus = 0`, which is a strictly better result
than the old code gave a malformed frame. That is still not a new capability, because `["hide"]`
alone already produced exactly it, and the ceiling is unchanged: the maximum bonus is
`taggedComponents.length - 1`, reached by naming exactly one real tag, before and after. Junk can
never drive the effective set below one element at a nonzero bonus, since size 0 falls to the
spread arm.

The fix lives at the **sim** boundary, not `server/game.ts`, because the
offline `Sim` and the headless RL env never pass through server dispatch; a test pins that the
server still forwards the junk verbatim, so a future server-side filter has to be argued rather
than added quietly.

### The capacity gate moves with it

The pre-claim capacity gate and the roll read the same helper, so they stay in agreement for
free, but what the gate **reserves** changes in both directions, and only a bag sized between
the old and new reservations can see it. Both boundaries get a case:

- A bag with room for exactly one family refused `["hide","junk"]` (it reserved two families'
  worth) while accepting the identical `["hide"]`. It now accepts both.
- An all-junk pick reserved **nothing**, sailed through the gate, spent the single-use claim and
  granted nothing. It now reserves the spread it will actually roll, so a full bag refuses it and
  leaves the corpse for the next harvester, exactly as the empty pick always did.

### Tests

Two pins from #2474 were **re-argued in place**, not deleted, as the issue required:

- `a pick of repeated JUNK ...` now shows the pre-#2474 body splitting the same intent by junk
  count, then pins the value #2504 chose.
- The `EVERY duplicate-free pick` sweep keeps every subset and the padded pick; the one entry
  that left it is asserted right there, beside a note that this four-tag fixture can never reach
  the spread threshold from a short pick, which is why the padding class was invisible from it.

New coverage: a junk-is-inert property swept over four corpse widths x every tag subset x every
junk subset x three junk placements; the all-junk ruling at every junk length; idempotence; the
subset invariant; order preservation; composition with the #2474 dedupe; draw-count literals;
the sim-level both-arms matrix over three seeds; the issue's reproduction in absolute counts;
both capacity-gate boundaries; the "refused command draws no rng" contract re-run on every
refusal arm with a junk-bearing and an all-junk pick; and the whole thing over the wire through
a real `GameServer`.

Reverting only the one-line fix turns **16** of these red. The three that stay green are the
no-regression sweep, the fixture-honesty check, and the subset invariant, all of which are meant
to hold on both bodies.

### Second commit: making the pins decisive

A coverage audit found three assertions that outran what they proved, all fixed in
`test(sim): make the corpse-harvest refusal and gate pins decisive`:

- The refusal sweep asserted only "zero draws, zero items", which does not establish a refusal.
  Pre-fix, a full-bags all-junk pick was **accepted**: it reserved nothing, passed the gate, spent
  the single-use claim, granted nothing and emitted no ledger, all while drawing zero rng. That is
  the exact class this PR closes and it was invisible inside the test. It now pins the claim owner
  and the corpse timer per arm, adds the two early returns the sweep never covered (a non-mob
  target, an unresolvable pid), and carries a positive control so a mis-wired rng observer cannot
  make the whole sweep vacuous. This is why the revert count went from 15 to 16.
- Both capacity-gate cases ran on bag shapes that could not see what they claimed. The accept side
  now also refuses one unit below the reservation, pinning it to the legendary tier quantity rather
  than to "an amount that fit"; the all-junk case moved off a totally full bag (which refuses under
  any reservation) onto a bag with room for exactly one family, the only shape where reserving one
  family and reserving the whole spread diverge.
- Plus per-row absolute absence pins, a live spread-draw-count pin so each row's `draws` literal is
  a real arm separator, and the wire test's knowable literal in place of "greater than zero".

## Related issues

Closes #2504. Sibling of #2472/#2473/#2474, all found in the same corpse-harvest boundary.

Two same-class findings surfaced during review were filed rather than folded in, to keep this diff
to the one line the issue names:

- #2509: picking only a **valid but unmapped** family (`claw`, `tusk`, `gills`, `horn`) still spends
  the claim for nothing, and unlike a junk string that one IS reachable from the shipped picker.
  The source comment now scopes its own rationale so it does not read as covering that case.
- #2511: `set_town_focus` accepts and persists arbitrary client-supplied allocation keys.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npm run gate` in an isolated worktree: **PASS, all 11 steps green**.
  - `npx vitest run tests/gathering.test.ts tests/corpse_harvest_sim.test.ts` (106 tests).
  - Mutation check: reverted the one-line fix in isolation, confirmed 16 tests go red, restored.
  - Reviewed by the repo's `architecture-reviewer`, `test-coverage-auditor`, `qa-checklist` and
    `privacy-security-review` agents: 0 blocking. Every should-fix and nit they raised is applied
    here, except the two that were genuinely out of scope, which are filed as #2509 and #2511.
- Manual steps: behavior measured against a real `Sim` before and after (the table above), and
  against a real `GameServer` dispatching a hand-built `{"t":"cmd","cmd":"harvestCorpse",...}`
  frame, which is the untrusted shape the issue reproduces with.

## Screenshots / recordings

N/A. No player-visible surface changes: no shipped client can produce the pick shape this fixes
(`corpseHarvestView` builds the picker's checkboxes from the corpse's own tags, and the submit
handler reads their values), so the picker renders and submits exactly as before.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green, with decisive tests for the changed
      behavior and the manual measurements recorded above.

### Cross-platform

- ~~Tested on desktop and mobile~~ N/A, no UI surface.
- ~~Accessible~~ N/A, no UI surface.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The only text near the diff
      ("Your bags are full.") is a pre-existing sim error already handled by the client matcher.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not touched.
- [x] No generated files hand-edited.
