### PR TITLE
test(css): make the four src/styles scans state their depth, and mean it

### DIFF
--- a/src/styles/CLAUDE.md
+++ b/src/styles/CLAUDE.md
@@ -31,9 +31,21 @@ the cascade); `tests/per_entry_css_wiring.test.ts` pins the flat names and
 completeness is guarded by `tests/css_corpus.test.ts` (the ten-dash
 `/* ---------- name ---------- */` banner manifest; a four-dash fence is NOT a boundary, so
 authoring one silently drops the section from the corpus; corpus = the inline `<style>`
-UNION `src/styles/*.css`), and `tests/css_value_validity.test.ts` globs every module for
+UNION `src/styles/*.css`), and `tests/css_value_validity.test.ts` walks every module for
 malformed declarations (e.g. a stray token after `var()`, which makes the whole declaration
 silently drop in the browser).
+
+## This directory is FLAT, and two guards enforce it
+Every sheet sits at the top level, because that is what ships: the `index.css` barrel, the
+modules it `@import`s, and the two per-entry `.extra.css`. **A subdirectory here hard-fails
+`tests/css_corpus.test.ts` and `tests/mobile_window_coverage.test.ts` at module load**, with
+a message naming the directory, and that is deliberate. Those two guards CREDIT what they
+read (a section still exists; a window has a mobile rule), so a sheet parked in a subfolder,
+which no entry loads, would let a rule that never reaches a browser count as shipping. The
+two guards whose miss would instead be a silent pass, `tests/css_value_validity.test.ts` and
+`tests/focus_visible_guard.test.ts`, walk to any depth. If you have a real reason to nest,
+re-make the decision at those reads (the reasoning is written there) rather than deleting
+the throw (#2499, #2502).
 
 ## Where new CSS lands (the seam) + the mobile-coverage invariant
 - **New feature-window body rules:** a new ten-dash banner section in `components.css`

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -31,8 +31,9 @@ Subdirectories (plus one shared fixture):
   `npm run test:browser`) for WebKit/Safari CSS, axe, target-size; never a bare `vitest run`.
 - `progression/`: mirrors `src/sim/progression/` (unit tests for the extracted modules).
 - `helpers/` + `util/`: shared cross-suite utilities (`fake_dom.ts`, the reusable
-  hand-rolled fake DOM for controller suites, `i18n_determinism.ts`, `ts_files_under.ts`,
-  `alloc_probe.ts`).
+  hand-rolled fake DOM for controller suites, `i18n_determinism.ts`, `ts_files_under.ts`
+  and `css_tree_under.ts`, the two source walks, `scan_guard_self_audit.ts`, the pin that
+  keeps a guard from re-growing its own directory read, `alloc_probe.ts`).
 - `global_setup.ts`: runs on every vitest invocation (`vite.config.ts` `test.globalSetup`);
   mints the SFX Studio temp root (`WOC_SFX_STUDIO_TEST_ROOT`).
 
@@ -76,15 +77,19 @@ use the `tests/server/helpers/` fakes (see Map), not a bespoke GameServer rig.
   vacuity floor near the real count (a floor sitting under it is what lets a moved file
   hide, and `it.each` over an empty list registers no cases at all). Where the root IS
   deep, a file-count floor over the real tree pins it directly, as
-  `mobile_window_coverage` does.
+  `mobile_window_coverage` does. Add `expectScansOnlyThroughSharedWalkers(import.meta.url,
+  [...])` (`helpers/scan_guard_self_audit.ts`) too: the fixture pins the producer, that pins
+  that no second reader was hand-rolled beside it, which over a flat root nothing else can.
 - **A scan that stays single-level BY DECISION says so where the read is, and checks its
   own premise.** The `src/styles` case: a guard that models the sheets an entry LOADS
   (`css_corpus`'s section corpus, `mobile_window_coverage`'s mobile-rule text) must not
-  credit a sheet parked in a subfolder, so it filters to the top level and THROWS on
-  `cssTreeUnder(...).dirs`, from the same read, naming the directory. A guard whose miss
-  is a silent pass (`css_value_validity`, `focus_visible_guard`) recurses instead. Either
-  way the reasoning is written at the read, and a subdirectory fails loudly rather than
-  narrowing the scan (#2499, #2502).
+  credit a sheet parked in a subfolder, so it REFUSES rather than filtering: it throws on
+  `cssTreeUnder(...).dirs`, from the same read, naming the directory. (Refusing, not
+  filtering, is the point. A filter would keep the guard green over a surface that quietly
+  stopped matching the ruling behind it.) A guard whose miss is a silent pass
+  (`css_value_validity`, `focus_visible_guard`) recurses instead. Either way the reasoning
+  is written at the read, and a subdirectory fails loudly rather than narrowing the scan
+  (#2499, #2502).
 - `tests/parity/` is the golden-trace gate: ANY sim behavior change turns it red by
   design. Read `tests/parity/CLAUDE.md` first; regenerate only deliberately via
   `UPDATE_PARITY=1 npx vitest run tests/parity`, in its own reviewed commit.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -65,15 +65,26 @@ transport (see `social_system.test.ts`) rather than mocking. REST/RouteDef endpo
 use the `tests/server/helpers/` fakes (see Map), not a bespoke GameServer rig.
 
 ## Coverage & guards
-- **A guard that scans a directory of sources walks it with `helpers/ts_files_under.ts`,
-  never its own `readdirSync`.** A single-level read is a defect, not a style choice: the
+- **A guard that scans a directory of sources walks it with a shared walker, never its own
+  `readdirSync`:** `helpers/ts_files_under.ts` for `.ts`, `helpers/css_tree_under.ts` for
+  the `src/styles` sheets. A single-level read is a defect, not a style choice: the
   day the scanned root grows a subdirectory, everything inside leaves the scan and the
-  guard stays green over a quietly smaller surface (#2485, then #2489 three times over).
-  Apart from `src/ui`, every scan root is flat today, so no assertion over the real tree
-  can tell a recursive walk from a flat one: pin the recursion with a `mkdtemp` fixture
-  that drives the guard's OWN producer, and keep the vacuity floor near the real count (a
-  floor sitting under it is what lets a moved file hide). Where the root IS deep, a
-  file-count floor over the real tree pins it directly, as `mobile_window_coverage` does.
+  guard stays green over a quietly smaller surface (#2485, then #2489 three times over,
+  then #2502 four more). Apart from `src/ui`, every scan root is flat today, so no
+  assertion over the real tree can tell a recursive walk from a flat one: pin the
+  recursion with a `mkdtemp` fixture that drives the guard's OWN producer, and keep the
+  vacuity floor near the real count (a floor sitting under it is what lets a moved file
+  hide, and `it.each` over an empty list registers no cases at all). Where the root IS
+  deep, a file-count floor over the real tree pins it directly, as
+  `mobile_window_coverage` does.
+- **A scan that stays single-level BY DECISION says so where the read is, and checks its
+  own premise.** The `src/styles` case: a guard that models the sheets an entry LOADS
+  (`css_corpus`'s section corpus, `mobile_window_coverage`'s mobile-rule text) must not
+  credit a sheet parked in a subfolder, so it filters to the top level and THROWS on
+  `cssTreeUnder(...).dirs`, from the same read, naming the directory. A guard whose miss
+  is a silent pass (`css_value_validity`, `focus_visible_guard`) recurses instead. Either
+  way the reasoning is written at the read, and a subdirectory fails loudly rather than
+  narrowing the scan (#2499, #2502).
 - `tests/parity/` is the golden-trace gate: ANY sim behavior change turns it red by
   design. Read `tests/parity/CLAUDE.md` first; regenerate only deliberately via
   `UPDATE_PARITY=1 npx vitest run tests/parity`, in its own reviewed commit.

--- a/tests/css_corpus.test.ts
+++ b/tests/css_corpus.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { cssTreeUnder } from './helpers/css_tree_under';
+import { expectScansOnlyThroughSharedWalkers } from './helpers/scan_guard_self_audit';
 
 // Section-by-section completeness guard for the game-HUD CSS, the floor the CSS
 // extraction regresses against. That extraction relocates CSS section by
@@ -359,6 +360,14 @@ describe('css_corpus src/styles read is flat BY RULING, and refuses instead of n
 
   afterEach(() => {
     rmSync(root, { recursive: true, force: true });
+  });
+
+  it('is the only reader of src/styles in this file', () => {
+    // The collapse of the two independently-flat reads into one STYLE_SHEETS is
+    // the part of this guard that nothing else can pin: a re-added reader in the
+    // brace-balance case would return the same 10 sheets today, every assertion
+    // would stay green, and the two would be free to drift apart again.
+    expectScansOnlyThroughSharedWalkers(import.meta.url, ['css_tree_under']);
   });
 
   it('reads the top-level sheets of a flat root', () => {

--- a/tests/css_corpus.test.ts
+++ b/tests/css_corpus.test.ts
@@ -1,7 +1,9 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cssTreeUnder } from './helpers/css_tree_under';
 
 // Section-by-section completeness guard for the game-HUD CSS, the floor the CSS
 // extraction regresses against. That extraction relocates CSS section by
@@ -13,14 +15,21 @@ import { describe, expect, it } from 'vitest';
 // banner comment /* ---------- name ---------- */, and the guard asserts that the
 // full set of those section names still exists somewhere in the corpus.
 //
-// THE CORPUS IS A UNION: both entries' inline <style> text UNION the contents of
-// src/styles/*.css. Today src/styles/ does not exist, so the union is just the
-// two inline blocks. That union is the whole point: when the extraction moves a section
-// out of an inline block and into a src/styles module keyed on the SAME ten-dash
+// THE CORPUS IS A UNION: both entries' inline <style> text UNION the src/styles
+// sheets. That union is the whole point: when the extraction moves a section out of
+// an inline block and into a src/styles module keyed on the SAME ten-dash
 // marker, the section leaves the inline block but reappears in the module, so the
 // union stays complete and this guard stays green. A section that vanishes from
 // BOTH the inline blocks and src/styles fails the guard, which is exactly the
 // "a rule was dropped during extraction" regression we want to catch.
+//
+// The extraction is now COMPLETE, so today the union is lopsided: both inline
+// <style> blocks are comment-only (pinned by tests/per_entry_css_wiring.test.ts) and
+// carry no ten-dash banner, so every pinned section below is accounted for by
+// src/styles alone. The union side stays because it is what makes the guard
+// indifferent to WHERE a section lives, which is the property being guarded, but it
+// means the src/styles read below is now the whole corpus rather than a supplement
+// to it.
 //
 // TWO TRAPS this guard is built to avoid (both are silent false greens):
 //   1. Vacuous marker pattern. V16 authored the banners with exactly ten dashes.
@@ -59,17 +68,45 @@ function inlineStyleCss(entryFile: string): string {
   return parts.join('\n');
 }
 
-// Every CSS module already migrated into src/styles/. None exist yet and the
-// directory itself is absent, so glob it and tolerate a missing dir. This is the
-// extension seam: as the extraction moves sections out of the inline blocks, they land
-// here and the union below picks them up with no edit to this guard.
-function extractedStyleCss(): string {
-  if (!existsSync(stylesDir)) return '';
-  const parts: string[] = [''];
-  for (const name of readdirSync(stylesDir).sort()) {
-    if (name.endsWith('.css')) parts.push(readFileSync(join(stylesDir, name), 'utf8'));
+// The src/styles sheets, read ONCE for this whole file: the union corpus below and
+// the per-file brace balance at the bottom both consume this list, so neither can
+// drift from the other and the file owns exactly one directory reader.
+//
+// This read stays FLAT deliberately, the same ruling #2499 made for
+// tests/mobile_window_coverage.test.ts and for the same reason: the corpus CREDITS
+// a pinned section to whatever text it finds, so a sheet parked in a subfolder
+// (component-local, experimental, half-migrated) would let a section that no entry
+// loads count as still shipping. That is a false green, which is strictly worse than
+// the narrowed scan recursing would fix. Only the top level ships: the index.css
+// barrel, the 7 modules it @imports, and the two .extra.css that a <link> pulls in
+// per entry (pinned by tests/per_entry_css_wiring.test.ts).
+//
+// The premise is CHECKED rather than asserted in prose (#2502): the day a sheet
+// lands in a subdirectory this throws, HERE, next to the reasoning, so the choice
+// gets re-made deliberately instead of quietly meaning something else. `dirs` comes
+// out of the same walk as the files, so checking it costs no second read, and it
+// sees a SYMLINKED subdirectory that a `Dirent.isDirectory()` test reads as a file.
+// A missing or renamed src/styles now throws out of the walk too: this used to fall
+// back to an empty corpus, and while that fails the completeness assertion loudly
+// today, the teeth case below would pass over the empty corpus vacuously.
+function styleSheets(root = stylesDir): { file: string; css: string }[] {
+  const tree = cssTreeUnder(root);
+  if (tree.dirs.length > 0) {
+    throw new Error(
+      `src/styles gained a subdirectory (${tree.dirs.join(', ')}): re-read the note above styleSheets()`,
+    );
   }
-  return parts.join('\n');
+  return tree.files.map(({ file, full }) => ({ file, css: readFileSync(full, 'utf8') }));
+}
+
+const STYLE_SHEETS = styleSheets();
+
+// Every CSS module migrated into src/styles/, concatenated. This is the extension
+// seam: a section moved out of an inline block lands here and the union below picks
+// it up with no edit to this guard, as long as it lands at the top level, where the
+// entries load it from.
+function extractedStyleCss(): string {
+  return ['', ...STYLE_SHEETS.map((sheet) => sheet.css)].join('\n');
 }
 
 // The whole game-HUD CSS corpus: both entries' inline <style> UNION src/styles.
@@ -269,14 +306,21 @@ function braceBalance(css: string): number {
 
 describe('css_corpus per-file brace balance', () => {
   it('balances every src/styles module exactly', () => {
-    expect(existsSync(stylesDir)).toBe(true);
-    const files = readdirSync(stylesDir)
-      .sort()
-      .filter((name) => name.endsWith('.css'));
-    expect(files.length).toBeGreaterThan(0);
-    for (const name of files) {
-      const css = readFileSync(join(stylesDir, name), 'utf8');
-      expect(braceBalance(css), `src/styles/${name} must have balanced braces`).toBe(0);
+    // Consumes the ONE read at the top of the file (this used to be a second,
+    // separately-flat readdirSync, so the two could drift, #2502).
+    //
+    // The vacuity floor sits at the live module count, 10, which an empty OR a
+    // truncated scan cannot clear: the `> 0` floor it replaces was satisfied by a
+    // single sheet, so a walk that lost the other nine, or that returned only the
+    // one file whose name survived a filter typo, passed while checking almost
+    // nothing. The names pin that the 10 are the real modules.
+    const names = STYLE_SHEETS.map((sheet) => sheet.file);
+    expect(names.length).toBeGreaterThanOrEqual(10);
+    expect(names).toEqual(
+      expect.arrayContaining(['index.css', 'components.css', 'hud.mobile.css', 'tokens.css']),
+    );
+    for (const { file, css } of STYLE_SHEETS) {
+      expect(braceBalance(css), `src/styles/${file} must have balanced braces`).toBe(0);
     }
   });
 
@@ -290,5 +334,70 @@ describe('css_corpus per-file brace balance', () => {
     expect(braceBalance('.a { color: red;')).toBe(1);
     expect(braceBalance('.a { color: red; } }')).toBe(-1);
     expect(braceBalance('.a { content: "}"; } /* } */ .b { color: blue; }')).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The flat-read premise, pinned. src/styles is flat today, so nothing asserted
+// over the real tree can tell this reader from one that quietly stopped at the
+// top level: only a fixture root can, and it has to drive styleSheets() itself
+// rather than the shared walk (helpers/css_tree_under.test.ts owns that).
+// ---------------------------------------------------------------------------
+
+describe('css_corpus src/styles read is flat BY RULING, and refuses instead of narrowing', () => {
+  let root = '';
+
+  const write = (relative: string, body: string): void => {
+    const full = join(root, ...relative.split('/'));
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(full, body);
+  };
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'woc-css-corpus-styles-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('reads the top-level sheets of a flat root', () => {
+    // The other polarity of the two refusals below: without this, a reader that
+    // threw unconditionally would pass them both.
+    write('a.css', '/* ---------- alpha ---------- */\n.a { color: red; }\n');
+    write('b.css', '.b { color: blue; }\n');
+    expect(styleSheets(root).map((sheet) => sheet.file)).toEqual(['a.css', 'b.css']);
+    expect(
+      sectionNames(
+        styleSheets(root)
+          .map((sheet) => sheet.css)
+          .join('\n'),
+      ),
+    ).toEqual(['alpha']);
+  });
+
+  it('throws when a sheet lands in a subdirectory, naming it', () => {
+    write('a.css', '.a { color: red; }\n');
+    write('nested/sunk.css', '/* ---------- sunk ---------- */\n.s { color: red; }\n');
+    // The failure the ruling is worth having: a section (or a brace bug) inside a
+    // sheet no entry loads must not read as covered, and the day one appears the
+    // decision gets re-made here rather than silently meaning something else.
+    expect(() => styleSheets(root)).toThrow(/gained a subdirectory \(nested\)/);
+  });
+
+  it('throws for a subdirectory that holds no sheet at all', () => {
+    write('a.css', '.a { color: red; }\n');
+    mkdirSync(join(root, 'experimental'), { recursive: true });
+    // Keyed on the DIRECTORY, not on finding a .css inside it, so the choice is
+    // re-made when the shape changes rather than on the later day something lands.
+    expect(() => styleSheets(root)).toThrow(/gained a subdirectory \(experimental\)/);
+  });
+
+  it('throws for a missing root instead of reporting an empty corpus', () => {
+    // The hole this replaces: `if (!existsSync(stylesDir)) return ''` answered a
+    // moved or renamed src/styles with an empty corpus. The completeness assertion
+    // would go red on that today, but the dropped-section teeth case above passes
+    // over an empty corpus vacuously, so the read is the place to fail.
+    expect(() => styleSheets(join(root, 'no_such_dir'))).toThrow(/ENOENT/);
   });
 });

--- a/tests/css_value_validity.test.ts
+++ b/tests/css_value_validity.test.ts
@@ -15,6 +15,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { cssTreeUnder } from './helpers/css_tree_under';
+import { expectScansOnlyThroughSharedWalkers } from './helpers/scan_guard_self_audit';
 
 const STYLES_DIR = fileURLToPath(new URL('../src/styles/', import.meta.url));
 
@@ -66,6 +67,14 @@ describe('src/styles CSS value validity', () => {
       expect(hits, `malformed color value(s) in ${file}: ${hits.join(' | ')}`).toEqual([]);
     },
   );
+
+  it('reads src/styles through the shared walker, with no flat reader beside it', () => {
+    // The fixture above pins the PRODUCER; this pins that nothing else in the
+    // file opens the directory. A second reader hand-rolled beside it would
+    // return the same 10 sheets today, so no assertion here could notice it, and
+    // the two could then drift apart exactly as css_corpus's pair did.
+    expectScansOnlyThroughSharedWalkers(import.meta.url, ['css_tree_under']);
+  });
 
   it("scans a module in a SUBDIRECTORY, through this guard's own producer", () => {
     // The recursion pin. src/styles is flat today, so this is the only thing that

--- a/tests/css_value_validity.test.ts
+++ b/tests/css_value_validity.test.ts
@@ -1,19 +1,38 @@
-// Health guard for the extracted CSS modules (src/styles/*.css). Lightning CSS passes
+// Health guard for the extracted CSS modules (src/styles). Lightning CSS passes
 // var() through unresolved, so a malformed color value like `color: var(--x) b0` (a
 // dangling 8-digit-hex alpha left over from tokenizing a literal hex into a var) builds
 // clean and only fails silently in the browser, where the whole declaration is dropped
 // and the element falls back to inherited color. The .se-preview-hint rule shipped that
 // bug from its original feature commit. This scans every module for that bug class so it
-// cannot recur, and auto-covers any module added later (it globs the directory).
-import { readdirSync, readFileSync } from 'node:fs';
+// cannot recur, and auto-covers any module added later at ANY DEPTH: it walks the
+// directory recursively (helpers/css_tree_under.ts), because a miss here is a silent
+// pass, and the single-level read this replaces would have let a sheet moved one folder
+// down leave the scan with no failure and no diff (#2502). The header used to promise
+// that auto-coverage while the read stopped at the top level.
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { cssTreeUnder } from './helpers/css_tree_under';
 
-const dir = new URL('../src/styles/', import.meta.url);
-const files = readdirSync(dir).filter((f) => f.endsWith('.css'));
-const read = (f: string) => readFileSync(new URL(f, dir), 'utf8').replace(/\r\n/g, '\n');
+const STYLES_DIR = fileURLToPath(new URL('../src/styles/', import.meta.url));
+
+// Every module this guard scans, keyed by its path relative to src/styles.
+// Parameterized on the root so the recursion case below can drive this exact
+// producer over a fixture tree: the real tree is flat, so no assertion over it
+// can tell a recursive walk from a single-level one.
+function sheets(root = STYLES_DIR): { file: string; css: string }[] {
+  return cssTreeUnder(root).files.map(({ file, full }) => ({
+    file,
+    css: readFileSync(full, 'utf8').replace(/\r\n/g, '\n'),
+  }));
+}
+
+const SHEETS = sheets();
 const stripComments = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, '');
 
-describe('src/styles/*.css value validity', () => {
+describe('src/styles CSS value validity', () => {
   // The single-value color longhands take exactly one color, so a var() followed by
   // another value token is always invalid. Limited to the strictly-single-value
   // longhands: border-color (1 to 4 colors), fill/stroke (SVG paint accepts url() + a
@@ -23,11 +42,52 @@ describe('src/styles/*.css value validity', () => {
   const malformedColor =
     /(?:^|[\s;{])(?:color|background-color|outline-color|caret-color|text-decoration-color|column-rule-color|border-top-color|border-right-color|border-bottom-color|border-left-color):\s*var\([^)]*\)\s+[^;}\s]/gi;
 
-  it.each(files)('%s has no single-color longhand with a stray token after var()', (file) => {
-    const hits = stripComments(read(file)).match(malformedColor) ?? [];
-    expect(
-      hits,
-      `malformed color value(s) in ${file}: ${hits.map((h) => h.trim()).join(' | ')}`,
-    ).toEqual([]);
+  const malformedIn = (css: string): string[] =>
+    (stripComments(css).match(malformedColor) ?? []).map((hit) => hit.trim());
+
+  it('scans every shipping module (the floor an empty or truncated walk cannot clear)', () => {
+    // Without this the file has NO vacuity pin at all: `it.each([])` registers zero
+    // cases, so an empty list passes the whole file green. The floor sits at the live
+    // module count (10: the index.css barrel, the 7 it @imports, and the two
+    // per-entry .extra.css), so losing a single sheet, a whole subtree, or the
+    // extension filter fails here rather than covering less quietly. The names pin
+    // that the 10 are the real modules and not 10 of something else.
+    const names = SHEETS.map((s) => s.file);
+    expect(names.length).toBeGreaterThanOrEqual(10);
+    expect(names).toEqual(
+      expect.arrayContaining(['index.css', 'index.extra.css', 'play.extra.css', 'tokens.css']),
+    );
+  });
+
+  it.each(SHEETS)(
+    '$file has no single-color longhand with a stray token after var()',
+    ({ file, css }) => {
+      const hits = malformedIn(css);
+      expect(hits, `malformed color value(s) in ${file}: ${hits.join(' | ')}`).toEqual([]);
+    },
+  );
+
+  it("scans a module in a SUBDIRECTORY, through this guard's own producer", () => {
+    // The recursion pin. src/styles is flat today, so this is the only thing that
+    // can tell the walk descends; it drives `sheets()` itself, not the shared walk
+    // (helpers/css_tree_under.test.ts already owns that), so a consumer that
+    // recursed and then filtered back to the top level would fail here.
+    const root = mkdtempSync(path.join(tmpdir(), 'woc-css-value-validity-'));
+    try {
+      mkdirSync(path.join(root, 'nested', 'deeper'), { recursive: true });
+      writeFileSync(path.join(root, 'top.css'), '.ok { color: var(--color-text); }\n');
+      writeFileSync(
+        path.join(root, 'nested', 'deeper', 'sunk.css'),
+        '.se-preview-hint { color: var(--color-text) b0; }\n',
+      );
+      const scanned = sheets(root);
+      expect(scanned.map((s) => s.file)).toEqual(['nested/deeper/sunk.css', 'top.css']);
+      // And the nested sheet reaches the real assertion, not just the file list:
+      // this is the hit the `it.each` case above would report as an offender.
+      expect(malformedIn(scanned[0].css)).toEqual(['color: var(--color-text) b']);
+      expect(malformedIn(scanned[1].css)).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/focus_visible_guard.test.ts
+++ b/tests/focus_visible_guard.test.ts
@@ -2,7 +2,8 @@
 //
 // The carried "FB lesson": a visible :focus-visible ring must NEVER be
 // animated, blurred, transitioned, or filtered away. This Node guard scans the extracted
-// stylesheets (src/styles/*.css) and asserts, for every :focus-visible rule block, that the
+// stylesheets (every .css under src/styles, at any depth) and asserts, for every
+// :focus-visible rule block, that the
 // block declares no transition / animation / filter / backdrop-filter / blur (which would
 // fade, slide, or smear the ring), and that no rule anywhere animates the `outline` property
 // from a base rule (which would animate the ring indirectly). It also pins, for
@@ -20,9 +21,12 @@
 // via npm run test:browser): it keyboard-focuses each shell control and asserts a present,
 // steady focus indicator (box-shadow, outline, or border-color), complementing this scan.
 
-import { readdirSync, readFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { cssTreeUnder } from './helpers/css_tree_under';
 
 const STYLES_DIR = fileURLToPath(new URL('../src/styles/', import.meta.url));
 
@@ -31,11 +35,19 @@ function stripComments(css: string): string {
   return css.replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
-function cssFiles(): { name: string; css: string }[] {
-  return readdirSync(STYLES_DIR)
-    .filter((f) => f.endsWith('.css'))
-    .sort()
-    .map((name) => ({ name, css: stripComments(readFileSync(STYLES_DIR + name, 'utf8')) }));
+// Every stylesheet the a11y scan covers, at ANY depth (helpers/css_tree_under.ts).
+// The single-level read this replaces would have stopped enforcing the steady-ring
+// rule for whatever landed in a subdirectory, with no failure and no diff to notice
+// it by (#2502): a miss here is a silent pass, so depth is the safe direction, and
+// a sheet that never ships cannot false-GREEN a scan that only looks for offenders.
+// The root is a parameter so the recursion case can drive this exact reader over a
+// fixture tree; src/styles is flat today, so nothing over the real tree can tell a
+// recursive walk from a single-level one.
+function cssFiles(root = STYLES_DIR): { name: string; css: string }[] {
+  return cssTreeUnder(root).files.map(({ file, full }) => ({
+    name: file,
+    css: stripComments(readFileSync(full, 'utf8')),
+  }));
 }
 
 // Every :focus-visible rule block in a stylesheet, as { selector, body } pairs. The
@@ -87,6 +99,22 @@ const RING_TRANSITION = /transition(?:-property)?\s*:[^;}]*\b(outline|all)\b/i;
 const RING_ANIMATION = /\banimation\s*:/i;
 const BLUR_FN = /\bblur\s*\(/i;
 
+// Every :focus-visible block in `sheets` whose drawn ring is moved, smeared, or faded.
+// Named so the recursion case can run the real offender scan over a fixture tree
+// instead of re-deriving a weaker version of it.
+function unsteadyRingOffenders(sheets: { name: string; css: string }[]): string[] {
+  const offenders: string[] = [];
+  for (const { name, css } of sheets) {
+    for (const { selector, body } of focusVisibleBlocks(css)) {
+      if (!drawsOutlineRing(body)) continue; // outline:none emphasis has no ring to destroy
+      if (RING_TRANSITION.test(body) || RING_ANIMATION.test(body) || BLUR_FN.test(body)) {
+        offenders.push(`${name}: ${selector} { ${body.trim().replace(/\s+/g, ' ')} }`);
+      }
+    }
+  }
+  return offenders;
+}
+
 describe(':focus-visible ring is steady and visible (the FB lesson)', () => {
   const files = cssFiles();
 
@@ -95,19 +123,41 @@ describe(':focus-visible ring is steady and visible (the FB lesson)', () => {
     // There are dozens of :focus-visible rules across the chrome; pin a floor so an
     // accidental rename/refactor that stops matching is caught instead of passing empty.
     expect(total).toBeGreaterThan(10);
+    // And a floor on the FILES, near the real count (10: the index.css barrel, the 7
+    // it @imports, and the two per-entry .extra.css). The block floor above cannot
+    // tell a full scan from one that lost a sheet or a whole subtree, since
+    // components.css alone clears it.
+    expect(files.length).toBeGreaterThanOrEqual(10);
   });
 
   it('never animates / blurs / transitions the drawn outline ring on any :focus-visible block', () => {
-    const offenders: string[] = [];
-    for (const { name, css } of files) {
-      for (const { selector, body } of focusVisibleBlocks(css)) {
-        if (!drawsOutlineRing(body)) continue; // outline:none emphasis has no ring to destroy
-        if (RING_TRANSITION.test(body) || RING_ANIMATION.test(body) || BLUR_FN.test(body)) {
-          offenders.push(`${name}: ${selector} { ${body.trim().replace(/\s+/g, ' ')} }`);
-        }
-      }
-    }
+    const offenders = unsteadyRingOffenders(files);
     expect(offenders, `animated/blurred focus rings:\n${offenders.join('\n')}`).toEqual([]);
+  });
+
+  it("scans a stylesheet in a SUBDIRECTORY, through this guard's own reader", () => {
+    // The recursion pin, driving cssFiles + the real offender scan rather than the
+    // shared walk (helpers/css_tree_under.test.ts owns that): a reader that recursed
+    // and then filtered back to the top level would fail here.
+    const root = mkdtempSync(path.join(tmpdir(), 'woc-focus-visible-guard-'));
+    try {
+      mkdirSync(path.join(root, 'nested', 'deeper'), { recursive: true });
+      writeFileSync(
+        path.join(root, 'steady.css'),
+        '.a:focus-visible { outline: 2px solid red; }\n',
+      );
+      writeFileSync(
+        path.join(root, 'nested', 'deeper', 'sunk.css'),
+        '.b:focus-visible { outline: 2px solid red; animation: pulse 1s infinite; }\n',
+      );
+      expect(cssFiles(root).map((f) => f.name)).toEqual(['nested/deeper/sunk.css', 'steady.css']);
+      // The nested sheet reaches the real assertion, and the flat sibling stays clean,
+      // so this fails for the depth rather than for scanning anything at all.
+      expect(unsteadyRingOffenders(cssFiles(root))).toHaveLength(1);
+      expect(unsteadyRingOffenders(cssFiles(root))[0]).toContain('nested/deeper/sunk.css');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('never transitions the outline property from a base rule (indirect ring animation)', () => {

--- a/tests/focus_visible_guard.test.ts
+++ b/tests/focus_visible_guard.test.ts
@@ -27,6 +27,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { cssTreeUnder } from './helpers/css_tree_under';
+import { expectScansOnlyThroughSharedWalkers } from './helpers/scan_guard_self_audit';
 
 const STYLES_DIR = fileURLToPath(new URL('../src/styles/', import.meta.url));
 
@@ -133,6 +134,12 @@ describe(':focus-visible ring is steady and visible (the FB lesson)', () => {
   it('never animates / blurs / transitions the drawn outline ring on any :focus-visible block', () => {
     const offenders = unsteadyRingOffenders(files);
     expect(offenders, `animated/blurred focus rings:\n${offenders.join('\n')}`).toEqual([]);
+  });
+
+  it('reads src/styles through the shared walker, with no flat reader beside it', () => {
+    // The fixture below pins the READER; this pins that nothing else in the file
+    // opens the directory, which no assertion over today's flat tree could tell.
+    expectScansOnlyThroughSharedWalkers(import.meta.url, ['css_tree_under']);
   });
 
   it("scans a stylesheet in a SUBDIRECTORY, through this guard's own reader", () => {

--- a/tests/helpers/css_tree_under.test.ts
+++ b/tests/helpers/css_tree_under.test.ts
@@ -1,0 +1,157 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cssTreeUnder } from './css_tree_under';
+
+// The paired test for the shared stylesheet walk, and it carries the same weight
+// as helpers/ts_files_under.test.ts: `src/styles` is FLAT today, so every
+// consumer's assertions over the real tree read identically whether this walk
+// descends or stops at the top level. Only a fixture tree can tell the two
+// apart, so the contract is pinned here once instead of restated in each guard.
+//
+// `dirs` is pinned as hard as `files`: two consumers are flat by ruling (#2499)
+// and refuse on a subdirectory, so a `dirs` that missed one would turn a loud
+// refusal back into the silent narrowing this module exists to stop.
+
+describe('cssTreeUnder', () => {
+  let root = '';
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'woc-css-tree-under-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const write = (relative: string, body = '.a { color: red; }\n'): void => {
+    const full = path.join(root, ...relative.split('/'));
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, body);
+  };
+
+  it('finds .css files at every depth, labeled relative to the root', () => {
+    write('top.css');
+    write('one/mid.css');
+    write('one/two/three/deep.css');
+    // Three levels, not two: a walk with any depth cap fails here rather than
+    // passing on a shallower fixture.
+    expect(cssTreeUnder(root).files.map((f) => f.file)).toEqual([
+      'one/mid.css',
+      'one/two/three/deep.css',
+      'top.css',
+    ]);
+  });
+
+  it('reports every subdirectory at every depth, holding a sheet or not', () => {
+    write('one/two/deep.css');
+    mkdirSync(path.join(root, 'empty'), { recursive: true });
+    // `empty` holds no stylesheet and still counts: the flat consumers refuse the
+    // day the directory appears, not the later day a .css lands inside it, so a
+    // `dirs` derived from the file list would let the decision go quiet in
+    // between.
+    expect(cssTreeUnder(root).dirs).toEqual(['empty', 'one', 'one/two']);
+  });
+
+  it('reports no subdirectory for a flat root, so the flat consumers stay green', () => {
+    write('a.css');
+    write('b.css');
+    const tree = cssTreeUnder(root);
+    // The other polarity of the case above: a `dirs` that reported something for
+    // a flat tree would make every flat consumer throw on the real src/styles,
+    // which no assertion over today's tree could distinguish from a real refusal.
+    expect(tree.dirs).toEqual([]);
+    expect(tree.files.map((f) => f.file)).toEqual(['a.css', 'b.css']);
+  });
+
+  it('labels with forward slashes, so same-named sheets in two directories stay distinct', () => {
+    write('a/dupe.css');
+    write('b/dupe.css');
+    const labels = cssTreeUnder(root).files.map((f) => f.file);
+    // Bare names would collide, and a per-file offender message keyed on them
+    // would name the wrong sheet.
+    expect(labels).toEqual(['a/dupe.css', 'b/dupe.css']);
+    expect(new Set(labels).size).toBe(2);
+  });
+
+  it('sorts within each directory, so the order does not depend on the filesystem', () => {
+    // Written in an order that is neither sorted nor reversed, so a walk
+    // returning raw readdir order would have to be lucky to pass. CI is ext4
+    // (readdir in hash order) and a dev checkout is APFS (byte-lexicographic),
+    // so an unsorted walk pins a list that holds on one machine only.
+    write('zulu.css');
+    write('alpha.css');
+    write('mike/zulu.css');
+    write('mike/alpha.css');
+    expect(cssTreeUnder(root).files.map((f) => f.file)).toEqual([
+      'alpha.css',
+      'mike/alpha.css',
+      'mike/zulu.css',
+      'zulu.css',
+    ]);
+  });
+
+  it('returns only .css files, and a full path that reads back', () => {
+    write('kept.css', '.kept { color: red; }\n');
+    write('notes.md', '.a { color: var(--x) b0; }\n');
+    write('tokens.scss', '.b { outline: none; }\n');
+    const found = cssTreeUnder(root).files;
+    expect(found.map((f) => f.file)).toEqual(['kept.css']);
+    // `full` is what every consumer hands to readFileSync, so a label-only
+    // return would break them all. Read the file rather than re-deriving the
+    // path with the same path.join the walk used, which would compare the
+    // implementation to itself.
+    expect(path.isAbsolute(found[0].full)).toBe(true);
+    expect(readFileSync(found[0].full, 'utf8')).toBe('.kept { color: red; }\n');
+  });
+
+  it('descends a symlinked DIRECTORY and reports it in dirs (a Dirent reads false for one)', () => {
+    // The expensive half of the symlink decision: `entry.isDirectory()` is
+    // lstat-based, so taking it at face value drops an entire linked subtree
+    // silently AND leaves the flat consumers' premise check blind to the one
+    // subdirectory shape a hand-rolled `isDirectory()` test cannot see.
+    write('real/inside.css');
+    write('real/deeper/lower.css');
+    symlinkSync(path.join(root, 'real'), path.join(root, 'linked_dir'));
+    const tree = cssTreeUnder(root);
+    expect(tree.files.map((f) => f.file)).toEqual([
+      'linked_dir/deeper/lower.css',
+      'linked_dir/inside.css',
+      'real/deeper/lower.css',
+      'real/inside.css',
+    ]);
+    expect(tree.dirs).toEqual(['linked_dir', 'linked_dir/deeper', 'real', 'real/deeper']);
+  });
+
+  it('walks a DIRECTORY named like a stylesheet instead of returning it', () => {
+    // The shape the hand-rolled walk exists for: readdirSync's `recursive: true`
+    // emits directory entries into its result, so `theme.css` would come back as
+    // a file and reach the consumer's readFileSync as an EISDIR crash.
+    write('theme.css/child.css');
+    const tree = cssTreeUnder(root);
+    expect(tree.files.map((f) => f.file)).toEqual(['theme.css/child.css']);
+    expect(tree.dirs).toEqual(['theme.css']);
+  });
+
+  it('follows a symlinked .css file (a Dirent reads false for one)', () => {
+    // The arm no consumer fixture can reach, and the reason there is no
+    // `entry.isFile()` gate: Dirent is lstat-based, so gating on it drops a
+    // symlinked sheet that the flat `readdirSync().filter()` this replaces would
+    // have read. That is the same silent narrowing arriving one door over, and
+    // only this case holds the line.
+    write('real/module.css');
+    symlinkSync(path.join(root, 'real', 'module.css'), path.join(root, 'linked.css'));
+    expect(cssTreeUnder(root).files.map((f) => f.file)).toEqual(['linked.css', 'real/module.css']);
+  });
+
+  it('is empty for an empty root rather than throwing', () => {
+    expect(cssTreeUnder(root)).toEqual({ files: [], dirs: [] });
+  });
+
+  it('throws for a missing root rather than reporting an empty tree', () => {
+    // Load-bearing for css_corpus, which used to answer a missing src/styles
+    // with an empty corpus that its teeth case then passed over vacuously.
+    expect(() => cssTreeUnder(path.join(root, 'no_such_dir'))).toThrow(/ENOENT/);
+  });
+});

--- a/tests/helpers/css_tree_under.test.ts
+++ b/tests/helpers/css_tree_under.test.ts
@@ -80,6 +80,13 @@ describe('cssTreeUnder', () => {
     // returning raw readdir order would have to be lucky to pass. CI is ext4
     // (readdir in hash order) and a dev checkout is APFS (byte-lexicographic),
     // so an unsorted walk pins a list that holds on one machine only.
+    //
+    // Which means this case is decisive on CI and NOT on a macOS checkout:
+    // APFS hands back byte-lexicographic order, so deleting the sort still
+    // passes locally, on this fixture or any other. Short of stubbing the fs
+    // there is no local fixture that fails, and the failure a missing sort
+    // causes is a cross-platform flake rather than a silent narrowing, so the
+    // case is kept and its reach written down instead of overstated.
     write('zulu.css');
     write('alpha.css');
     write('mike/zulu.css');
@@ -143,6 +150,21 @@ describe('cssTreeUnder', () => {
     write('real/module.css');
     symlinkSync(path.join(root, 'real', 'module.css'), path.join(root, 'linked.css'));
     expect(cssTreeUnder(root).files.map((f) => f.file)).toEqual(['linked.css', 'real/module.css']);
+  });
+
+  it('returns a BROKEN symlink named .css instead of dropping it from the scan', () => {
+    // The arm behind `throwIfNoEntry: false`, and the reason it is written that
+    // way: a dangling link resolves to neither a file nor a directory, so it
+    // comes back as a file and the consumer's own readFileSync fails loudly.
+    // Drop the option and statSync throws instead, which turns every guard's
+    // failure mode from "this one sheet is broken" into "the walk died", with
+    // nothing red to say the contract changed.
+    write('real/module.css');
+    symlinkSync(path.join(root, 'real', 'gone.css'), path.join(root, 'dangling.css'));
+    expect(cssTreeUnder(root).files.map((f) => f.file)).toEqual([
+      'dangling.css',
+      'real/module.css',
+    ]);
   });
 
   it('is empty for an empty root rather than throwing', () => {

--- a/tests/helpers/css_tree_under.ts
+++ b/tests/helpers/css_tree_under.ts
@@ -1,0 +1,89 @@
+import { readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+// The shared walk for the guards that scan a directory of STYLESHEETS, the
+// counterpart to helpers/ts_files_under.ts for `src/styles`. It is a separate
+// module rather than an extension knob on that one because that module's header
+// rules it so: one contract per corpus, and a caller wanting another extension
+// keeps its own walk. Five readers over `src/styles` wanted the same one
+// (#2502), so this is that one walk shared by them, not a walker framework.
+//
+// Unlike the .ts walk it returns the SUBDIRECTORIES alongside the files, because
+// the `src/styles` readers split two ways (the ruling in #2499). A guard whose
+// miss is a silent PASS (a malformed value that the browser drops, an animated
+// focus ring, an unbalanced brace) wants every sheet at any depth. A guard that
+// models the sheets an entry actually LOADS stays flat on purpose: crediting a
+// sheet parked in a subfolder, which no entry imports, would be a false green.
+// The flat ones still have to NOTICE a subdirectory rather than quietly covering
+// less, and `dirs` lets each check that premise off the same read it already
+// does, so no file needs a second directory reader. Deriving it from a `Dirent`
+// instead (`entries.some((e) => e.isDirectory())`) misses a symlinked directory,
+// which is the same silent narrowing arriving one door over.
+
+/** One stylesheet found by {@link cssTreeUnder}. */
+export interface CssSourceFile {
+  /** Path relative to the scan root, joined with forward slashes at every depth. */
+  readonly file: string;
+  /** Absolute path, for `readFileSync`. */
+  readonly full: string;
+}
+
+/** Everything {@link cssTreeUnder} found under one root. */
+export interface CssTree {
+  /** Every `.css` file at any depth, sorted by name within each directory. */
+  readonly files: CssSourceFile[];
+  /**
+   * Every subdirectory at any depth, relative to the root and forward-slashed.
+   * A directory is listed whether or not it holds a stylesheet, so a
+   * flat-by-design consumer refuses the day the directory grows one, not the
+   * later day a `.css` lands inside it.
+   */
+  readonly dirs: string[];
+}
+
+/**
+ * Every `.css` file under `root`, RECURSIVELY, plus every subdirectory it
+ * passed through, sorted by name within each directory.
+ *
+ * The sort matters: readdir returns byte-lexicographic order on a dev APFS
+ * checkout and hash order on the ext4 CI runner, so an unsorted walk pins a
+ * label list that only holds on one of them.
+ *
+ * Symlinks are followed on BOTH arms, for the reasons written out in
+ * helpers/ts_files_under.ts: a `Dirent` reports lstat, so `isFile()` and
+ * `isDirectory()` both read false for one, and taking either at face value drops
+ * a linked sheet or a whole linked subtree silently. A symlink is resolved once
+ * and treated as whatever it points at; a broken one resolves to neither and, if
+ * it is named `.css`, is still returned so the consumer's own read fails loudly
+ * rather than the file leaving the scan. A symlink CYCLE recurses until the
+ * stack ends, which is loud in the same way.
+ *
+ * Walks by hand rather than through `readdirSync`'s `recursive: true`, which
+ * emits directory entries into its own result (so a directory named `x.css`
+ * reaches `readFileSync` and throws EISDIR), returns platform-separator paths,
+ * and does not sort.
+ */
+export function cssTreeUnder(root: string): CssTree {
+  const files: CssSourceFile[] = [];
+  const dirs: string[] = [];
+  const walk = (dir: string, prefix: string): void => {
+    const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+      a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+    );
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      const isDir =
+        entry.isDirectory() ||
+        (entry.isSymbolicLink() &&
+          (statSync(full, { throwIfNoEntry: false })?.isDirectory() ?? false));
+      if (isDir) {
+        dirs.push(`${prefix}${entry.name}`);
+        walk(full, `${prefix}${entry.name}/`);
+      } else if (entry.name.endsWith('.css')) {
+        files.push({ file: `${prefix}${entry.name}`, full });
+      }
+    }
+  };
+  walk(root, '');
+  return { files, dirs };
+}

--- a/tests/helpers/scan_guard_self_audit.test.ts
+++ b/tests/helpers/scan_guard_self_audit.test.ts
@@ -1,0 +1,101 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { expectScansOnlyThroughSharedWalkers } from './scan_guard_self_audit';
+
+// A guard's own helper is the classic unpinned arm: production source never
+// exercises it, so `codeOnly`, an extension filter, or a whole banned-spelling
+// list can be deleted with every suite still green (#2499). Only a synthetic
+// source file reaches these arms, so each one gets one here.
+
+describe('expectScansOnlyThroughSharedWalkers', () => {
+  let root = '';
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'woc-scan-guard-self-audit-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const guard = (body: string): string => {
+    const file = path.join(root, 'fake_guard.test.ts');
+    writeFileSync(file, body);
+    return pathToFileURL(file).href;
+  };
+
+  const clean = [
+    "import { cssTreeUnder } from './helpers/css_tree_under';",
+    "const files = cssTreeUnder('/x').files;",
+  ].join('\n');
+
+  it('passes a guard that reads only through the named walker', () => {
+    expect(() =>
+      expectScansOnlyThroughSharedWalkers(guard(clean), ['css_tree_under']),
+    ).not.toThrow();
+  });
+
+  it.each([
+    ['readdirSync', "const own = readdirSync('/x');"],
+    ['opendirSync', "const own = opendirSync('/x');"],
+    ['globSync', "const own = globSync('/x/*.css');"],
+    ['readdir', "const own = await readdir('/x');"],
+    ['opendir', "const own = await opendir('/x');"],
+  ])('fails on a hand-rolled %s beside the walker', (spelling, line) => {
+    // One case per spelling: a list that bans only `readdirSync` bans only
+    // `readdirSync`, and every other row here rebuilds the same flat read with
+    // that count still at zero.
+    expect(() =>
+      expectScansOnlyThroughSharedWalkers(guard(`${clean}\n${line}`), ['css_tree_under']),
+    ).toThrow(new RegExp(`reads a directory itself via ${spelling}\\(`));
+  });
+
+  it('fails when the walker import is gone, even though the module name is still written', () => {
+    // The trap this helper exists to survive: a needle written whole matches its
+    // own assertion line, so a `toContain('helpers/css_tree_under')` pin passes
+    // with the import deleted. Here the bare name appears in the file and the
+    // check still fails, because it wants the IMPORT STATEMENT shape.
+    const body = ["const walker = 'helpers/css_tree_under';", 'const files = walk(walker);'].join(
+      '\n',
+    );
+    expect(() => expectScansOnlyThroughSharedWalkers(guard(body), ['css_tree_under'])).toThrow(
+      /no longer imports helpers\/css_tree_under/,
+    );
+  });
+
+  it('checks every walker it is given, not just the first', () => {
+    const body = ["import { tsFilesUnder } from './helpers/ts_files_under';"].join('\n');
+    expect(() =>
+      expectScansOnlyThroughSharedWalkers(guard(body), ['ts_files_under', 'css_tree_under']),
+    ).toThrow(/no longer imports helpers\/css_tree_under/);
+  });
+
+  it('ignores a directory read that is only mentioned in a comment', () => {
+    // Prose about the flat `readdirSync` a guard NO LONGER makes is exactly what
+    // these files are full of after the fix, so a strip-free scan would fail
+    // every one of them.
+    const body = [
+      '/* this used to be a second, separately-flat readdirSync(dir) */',
+      '// and a line comment mentioning readdirSync(dir) too',
+      clean,
+    ].join('\n');
+    expect(() =>
+      expectScansOnlyThroughSharedWalkers(guard(body), ['css_tree_under']),
+    ).not.toThrow();
+  });
+
+  it('does not let a URL swallow the rest of its line while stripping comments', () => {
+    // The shipped bug this strip is written against (#2499): a `[^:]` guard is
+    // what keeps `https://` from reading as a line comment and deleting the live
+    // code after it, which would hide a hand-rolled read on that same line.
+    const body = [clean, "const doc = 'https://example.com'; const own = readdirSync('/x');"].join(
+      '\n',
+    );
+    expect(() => expectScansOnlyThroughSharedWalkers(guard(body), ['css_tree_under'])).toThrow(
+      /reads a directory itself via readdirSync\(/,
+    );
+  });
+});

--- a/tests/helpers/scan_guard_self_audit.ts
+++ b/tests/helpers/scan_guard_self_audit.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { expect } from 'vitest';
+
+// The mechanical half of the shared-walker rule in tests/CLAUDE.md: a guard that
+// scans a directory of sources reads it through helpers/ts_files_under.ts or
+// helpers/css_tree_under.ts, never its own directory call.
+//
+// A behavior test cannot cover that. Every scan root in this repo is flat or
+// nearly so, so a producer built on a hand-rolled read returns the same list as
+// the shared walk today, and the guard's own assertions cannot tell them apart:
+// the drift only shows up the day something moves down a level, which is the
+// silent narrowing the rule exists to stop (#2485, #2489, #2502). So the pin is a
+// source scan of the guard file itself.
+//
+// It lives here rather than being copied per guard because the two ways to write
+// it wrong are both easy to re-derive. FIRST, a needle written whole matches its
+// own assertion line, so the pin passes with the import deleted; that is why the
+// walker check below is a regex for the IMPORT STATEMENT shape, which a call
+// site's bare `'css_tree_under'` argument cannot satisfy, rather than a substring
+// the caller has to remember to split. SECOND, banning one spelling bans one
+// spelling: `opendirSync`, `globSync`, and `fs.promises.readdir` all rebuild a
+// hand-rolled walk with a `readdirSync` count still at zero.
+
+/** Every way this repo could open a directory, all of them equally banned in a guard. */
+const DIRECTORY_READS = ['readdirSync(', 'opendirSync(', 'globSync(', 'readdir(', 'opendir('];
+
+/**
+ * Assert that the test file at `sourceUrl` (pass `import.meta.url`) contains no
+ * directory read of its own, and imports each walker in `walkerModules` (bare
+ * module names under `helpers/`, e.g. `'css_tree_under'`).
+ *
+ * Comments are stripped first, so prose about a `readdirSync` this file no longer
+ * makes cannot fail the pin. The line-comment strip keeps a `://` in a URL from
+ * eating the rest of its line, which is a live bug this repo has already shipped
+ * once in a comment stripper (#2499, the steam forbidden-login scan).
+ */
+export function expectScansOnlyThroughSharedWalkers(
+  sourceUrl: string,
+  walkerModules: string[],
+): void {
+  const name = fileURLToPath(sourceUrl).split('/').pop() ?? sourceUrl;
+  const code = readFileSync(fileURLToPath(sourceUrl), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+  for (const spelling of DIRECTORY_READS) {
+    expect(
+      code.split(spelling).length - 1,
+      `${name} reads a directory itself via ${spelling}: use the shared walker instead`,
+    ).toBe(0);
+  }
+  for (const walker of walkerModules) {
+    expect(
+      new RegExp(`from\\s+'\\.\\/helpers\\/${walker}'`).test(code),
+      `${name} no longer imports helpers/${walker}`,
+    ).toBe(true);
+  }
+}

--- a/tests/helpers/ts_files_under.ts
+++ b/tests/helpers/ts_files_under.ts
@@ -11,12 +11,14 @@ import path from 'node:path';
 //
 // ONE argument, and it is meant to stay that way. A caller that wants less
 // filters the returned list. A caller that wants a genuinely different corpus
-// (another extension, absolute paths, a hashed record) hand-rolls its own walk
-// and keeps it local: the point of this module is one contract shared by the
-// guards that want exactly this one, not a walker framework with a knob per
-// caller. The concrete case that stays OUT is
-// tests/mobile_window_coverage.test.ts's src/styles read, which models the
-// sheets an entry actually loads rather than the files on disk.
+// (another extension, absolute paths, a hashed record) writes its own walk
+// rather than growing a knob here: the point of this module is one contract
+// shared by the guards that want exactly this one, not a walker framework with a
+// knob per caller. The concrete case that stayed OUT and then earned a sibling is
+// the `src/styles` stylesheet corpus, now helpers/css_tree_under.ts (#2502): five
+// readers over that one directory wanted the same walk, and it has to report the
+// SUBDIRECTORIES as well, because two of them are single-level by ruling (#2499)
+// and refuse rather than narrow. Sibling, still not a knob.
 
 /** One source file found by {@link tsFilesUnder}. */
 export interface TsSourceFile {

--- a/tests/mobile_window_coverage.test.ts
+++ b/tests/mobile_window_coverage.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { cssTreeUnder } from './helpers/css_tree_under';
+import { expectScansOnlyThroughSharedWalkers } from './helpers/scan_guard_self_audit';
 import { tsFilesUnder } from './helpers/ts_files_under';
 
 // Phase 5 mobile-HUD-parity coverage guard.
@@ -123,8 +124,10 @@ const MOBILE_WINDOW_EXCEPTIONS: Record<string, string> = {
 // by a flat read is a silent PASS, which is the bug #2489 is about; a src/styles
 // module missed here makes its windows read as unclassified and turns the
 // coverage assertion RED, which needs no depth fix to be noticed.
-function stylesText(): string {
-  const dir = fileURLToPath(new URL(STYLES_DIR, import.meta.url));
+// Takes a root, like dynamicWindowIds above, so the refusal below is reachable
+// from a fixture: src/styles is flat, so nothing asserted over the real tree can
+// tell this read from one that quietly stopped meaning anything.
+function stylesText(dir: string = fileURLToPath(new URL(STYLES_DIR, import.meta.url))): string {
   const tree = cssTreeUnder(dir);
   // The premise, checked rather than asserted in prose: the reasoning above
   // holds only while every sheet sits at the top level. The day one lands in a
@@ -286,19 +289,30 @@ describe('mobile window coverage (Phase 5 parity)', () => {
     // walk, and stylesText's src/styles read goes through the .css walk, whose
     // subdirectory report is what keeps that read single-level BY DECISION (see
     // its comment) rather than by a `Dirent` test blind to a symlinked folder.
-    const own = readFileSync(
-      fileURLToPath(new URL('mobile_window_coverage.test.ts', import.meta.url)),
-      'utf8',
-    )
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/(^|[^:])\/\/.*$/gm, '$1');
-    // Needle assembled from halves so it does not match itself.
-    expect(own.split(`readdir${'Sync('}`).length - 1).toBe(0);
-    // Needles split for the same reason as the one above: written whole they
-    // would match their own assertion line, so this passed even with the import
-    // gone.
-    expect(own).toContain(`helpers/ts_files${'_under'}`);
-    expect(own).toContain(`helpers/css_tree${'_under'}`);
+    expectScansOnlyThroughSharedWalkers(import.meta.url, ['ts_files_under', 'css_tree_under']);
+  });
+
+  it('stylesText refuses a src/styles subdirectory rather than reading past it', () => {
+    // The refusal was unreachable while stylesText hardcoded its root: the arm
+    // the #2499 ruling rests on, never once executed by the suite.
+    const fixture = mkdtempSync(path.join(tmpdir(), 'woc-mobile-styles-'));
+    try {
+      writeFileSync(
+        path.join(fixture, 'hud.mobile.css'),
+        'body.mobile-touch #bags-window { left: 0; }\n',
+      );
+      // Flat first, so a stylesText that threw unconditionally could not pass
+      // this pair, and so the read is shown to work at a fixture root at all.
+      expect(stylesText(fixture)).toContain('#bags-window');
+      mkdirSync(path.join(fixture, 'experimental'), { recursive: true });
+      writeFileSync(
+        path.join(fixture, 'experimental', 'parked.css'),
+        'body.mobile-touch #parked-window { left: 0; }\n',
+      );
+      expect(() => stylesText(fixture)).toThrow(/gained a subdirectory \(experimental\)/);
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
   });
 
   it('every window is either sheeted on mobile or an explicit exception', () => {

--- a/tests/mobile_window_coverage.test.ts
+++ b/tests/mobile_window_coverage.test.ts
@@ -1,8 +1,9 @@
-import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { cssTreeUnder } from './helpers/css_tree_under';
 import { tsFilesUnder } from './helpers/ts_files_under';
 
 // Phase 5 mobile-HUD-parity coverage guard.
@@ -124,19 +125,22 @@ const MOBILE_WINDOW_EXCEPTIONS: Record<string, string> = {
 // coverage assertion RED, which needs no depth fix to be noticed.
 function stylesText(): string {
   const dir = fileURLToPath(new URL(STYLES_DIR, import.meta.url));
-  const entries = readdirSync(dir, { withFileTypes: true });
+  const tree = cssTreeUnder(dir);
   // The premise, checked rather than asserted in prose: the reasoning above
   // holds only while every sheet sits at the top level. The day one lands in a
   // subdirectory this throws here, where the comment explaining the decision
   // is, so the choice gets re-made deliberately instead of quietly meaning
   // something else. Derived from the SAME read as the file list, so this file
-  // still owns exactly one directory reader.
-  if (entries.some((e) => e.isDirectory())) {
-    throw new Error('src/styles gained a subdirectory: re-read the note above stylesText()');
+  // still owns exactly one directory read (and no reader of its own: the shared
+  // walk reports the subdirectories, which the hand-rolled `e.isDirectory()`
+  // this replaces could not see through a SYMLINKED one, #2502).
+  if (tree.dirs.length > 0) {
+    throw new Error(
+      `src/styles gained a subdirectory (${tree.dirs.join(', ')}): re-read the note above stylesText()`,
+    );
   }
-  const files = entries.map((e) => e.name).filter((f) => f.endsWith('.css'));
-  return files
-    .map((f) => readFileSync(`${dir}/${f}`, 'utf8').replace(/\/\*[\s\S]*?\*\//g, ''))
+  return tree.files
+    .map(({ full }) => readFileSync(full, 'utf8').replace(/\/\*[\s\S]*?\*\//g, ''))
     .join('\n');
 }
 
@@ -272,14 +276,16 @@ describe('mobile window coverage (Phase 5 parity)', () => {
     }
   });
 
-  it('the scrape reads src/ui through the shared walker, with no flat reader beside it', () => {
+  it('both scans read through the shared walkers, with no flat reader beside them', () => {
     // The fixture pins the SCRAPER, and the file-count floor above pins that the
     // real scrape reaches the whole tree. This closes the remaining gap: a
     // second producer built on its own flat read would return the same window
     // IDS today, since every window-minting module is at the top level, so the
-    // ids and windowClassFiles pins would not notice it. Exactly one directory
-    // read is left in this file: stylesText's, single-level by design (see its
-    // comment).
+    // ids and windowClassFiles pins would not notice it. NO hand-rolled
+    // directory read is left in this file: src/ui goes through the recursive .ts
+    // walk, and stylesText's src/styles read goes through the .css walk, whose
+    // subdirectory report is what keeps that read single-level BY DECISION (see
+    // its comment) rather than by a `Dirent` test blind to a symlinked folder.
     const own = readFileSync(
       fileURLToPath(new URL('mobile_window_coverage.test.ts', import.meta.url)),
       'utf8',
@@ -287,10 +293,12 @@ describe('mobile window coverage (Phase 5 parity)', () => {
       .replace(/\/\*[\s\S]*?\*\//g, '')
       .replace(/(^|[^:])\/\/.*$/gm, '$1');
     // Needle assembled from halves so it does not match itself.
-    expect(own.split(`readdir${'Sync('}`).length - 1).toBe(1);
-    // Needle split for the same reason as the one above: written whole it would
-    // match its own assertion line, so this passed even with the import gone.
+    expect(own.split(`readdir${'Sync('}`).length - 1).toBe(0);
+    // Needles split for the same reason as the one above: written whole they
+    // would match their own assertion line, so this passed even with the import
+    // gone.
     expect(own).toContain(`helpers/ts_files${'_under'}`);
+    expect(own).toContain(`helpers/css_tree${'_under'}`);
   });
 
   it('every window is either sheeted on mobile or an explicit exception', () => {


### PR DESCRIPTION
## Summary

#2499 settled how a source-scan guard reads a directory, and it settled the `src/styles`
question specifically: `stylesText()` in `tests/mobile_window_coverage.test.ts` stays
single-level because it models the sheets an entry actually loads, and it throws if that
directory ever grows a subdirectory so the choice gets re-made instead of quietly meaning
something else. Four more readers over the same directory never got either treatment, and
two of them promised auto-coverage they did not deliver.

Each of the four now either recurses or refuses, with the reasoning written where the read
is. The split is by failure direction, which is the part that was invisible before:

- **A miss is a silent pass, so it recurses.** `tests/css_value_validity.test.ts` (a
  malformed `var()` value the browser drops silently) and `tests/focus_visible_guard.test.ts`
  (an animated or blurred focus ring) only ever look for offenders, so a sheet that ships
  to nobody cannot false-green them and depth is the safe direction. Both headers claimed
  this already; now the code does it.
- **A miss would be a false GREEN, so it refuses.** `tests/css_corpus.test.ts` credits a
  pinned section to whatever text it finds, so recursing would let a section parked in a
  subfolder count as still shipping. It keeps #2499's ruling and throws on any
  subdirectory, naming it.

Supporting changes:

- New shared walk `tests/helpers/css_tree_under.ts` with a paired test. It returns the
  subdirectories alongside the files, which the `.ts` walk has no use for: the flat-by-ruling
  readers check that premise off the same read, so no file needs a second directory reader,
  and unlike a `Dirent` test it sees a symlinked directory. It is a sibling module rather
  than an extension knob on `ts_files_under.ts`, which is what that module's own header
  rules; its header is updated to point here.
- New `tests/helpers/scan_guard_self_audit.ts`: the "exactly one directory read" half of the
  criterion, which no behavior test can cover while the root is flat. It was a hand-rolled
  pin in one guard and is now shared by four, because both ways to write it wrong are easy
  to re-derive: a needle written whole matches its own assertion line and passes with the
  import deleted (so the walker check wants the import STATEMENT shape, which a call site's
  bare argument cannot fake), and banning `readdirSync` bans `readdirSync` (so `opendirSync`,
  `globSync` and the promises spellings are banned beside it).
- `tests/css_corpus.test.ts` collapses its two separate single-level reads into one, so the
  corpus and the brace balance cannot drift apart, and drops `if (!existsSync(stylesDir))
  return ''`.
- `tests/mobile_window_coverage.test.ts` (outside the issue's scope, adjacent hardening, its
  own commits so it can be dropped): the #2499 ruling stands and only the mechanism changes.
  Its premise check was `entries.some((e) => e.isDirectory())`, and a `Dirent` reports lstat,
  so a SYMLINKED subdirectory read as a file: the one shape that could still narrow that scan
  with the throw silent. Its `stylesText()` also hardcoded its root, so that throw had never
  once executed in the suite; it now takes a root and a fixture drives both polarities.
- `tests/CLAUDE.md` records the rule and the split, since four readers each answering it
  differently is what the invisible reasoning produced. `src/styles/CLAUDE.md` gets the fact
  a CSS author actually needs: this directory is flat, a subdirectory hard-fails two suites
  at module load, and here is which reads recurse and why.

One correction to the issue text, since it changes nothing about the fix but should not be
carried forward as fact: the `existsSync` fallback's downstream effect today is a LOUD red,
not a silent pass. The extraction finished, both inline `<style>` blocks are comment-only,
so an empty `src/styles` corpus fails the completeness assertion on all 69 pinned sections.
The genuinely silent arm is the dropped-section teeth case, which passes over an empty
corpus vacuously. The read is still the right place to fail, so the fallback is gone.

Vacuity pins, per the acceptance criteria:

- `tests/css_value_validity.test.ts` had NONE, and `it.each` over an empty list registers
  zero cases, so an empty walk passed the whole file. It gains a floor at the live module
  count with the barrel and both per-entry sheets named.
- `tests/css_corpus.test.ts`'s `expect(files.length).toBeGreaterThan(0)` is replaced by the
  same floor plus names: one surviving sheet satisfied the old one.

No production behavior changes: every file touched is under `tests/`.

## Related issues

Closes #2502. Follows #2485, #2489, #2499 (same class).

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation

## How was this tested?

- Commands: `npm run gate` (green), `npx vitest run tests/css_corpus.test.ts
  tests/css_value_validity.test.ts tests/focus_visible_guard.test.ts
  tests/mobile_window_coverage.test.ts tests/helpers/ tests/per_entry_css_wiring.test.ts
  tests/styles_extraction.test.ts`.
- Manual steps: the acceptance criterion, done and reverted. Added
  `src/styles/probe_nested/probe.css` carrying one offense per guard (a malformed
  `color: var(--color-text) b0`, a `:focus-visible` block with `outline` plus `animation`,
  and an unterminated block), then ran the four suites.
  - **Before** (the four guards at `d87f0c1a4`): `tests/css_corpus.test.ts`,
    `tests/css_value_validity.test.ts` and `tests/focus_visible_guard.test.ts` all passed,
    22 tests green over a sheet none of them read. Only `tests/mobile_window_coverage.test.ts`
    refused, which is the #2499 treatment working.
  - **After**: all four fail. `css_corpus` and `mobile_window_coverage` throw
    `src/styles gained a subdirectory (probe_nested)` at the read; `css_value_validity`
    reports `malformed color value(s) in probe_nested/probe.css`; `focus_visible_guard`
    reports the animated ring.
  - Probe removed, tree clean.
- Each recursive guard also carries a `mkdtemp` fixture that drives its OWN producer over a
  nested tree (the shared walk's paired test is separate), since `src/styles` is flat, so no
  assertion over the real tree can tell a recursive walk from a single-level one. Both
  flat-by-ruling reads are pinned the same way: fixture cases covering a nested sheet, an
  EMPTY subdirectory, and a missing root, each keyed on the message text, plus a flat-root
  case so a reader that threw unconditionally would not pass them.
- Mutation-checked, since a pin over a flat tree proves little on its own: making the walk
  stop descending, making it stop reporting subdirectories, dropping one real sheet, and
  re-adding a hand-rolled `readdirSync` beside the shared one each turn the expected guards
  red.

Applied from review (a fresh `test-coverage-auditor` and the `qa-checklist` gate, both run
against the diff, both landed in this PR rather than as follow-ups): the unreachable
`stylesText` refusal, the missing one-read pins, the `src/styles/CLAUDE.md` silence, the
`tests/CLAUDE.md` helpers map and its "filters to the top level" wording (they refuse, they
do not filter), the uncovered broken-symlink arm, and the sort case's real reach (it is
decisive on the ext4 CI runner, not on an APFS checkout, and now says so).

## Screenshots / recordings

N/A, test-only change.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green.

### Cross-platform

- ~Tested on desktop and mobile~ N/A, no UI change.
- ~Accessible~ N/A, no UI change (the focus-ring guard's coverage widens, but no rule moves).

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled
      in any production path.
- [x] I didn't hand-edit generated files.
