### PR TITLE
test(ui): name which windows Hud.update() drives, with band and invalidation guard

### DIFF
--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -86,10 +86,24 @@ Per-frame HUD code (anything reached from `Hud.update()`) holds these:
   rest get `refreshIfChanged()` on the 500ms band). MOST of those rebuild behind their own
   invalidation signature, which no per-file scan can see, and `town_focus_window` does not:
   it repaints on the open check alone, which is the standing proof that the signature guard is
-  a convention rather than something enforced. So a window on a poll is held to the
-  write-elision standard by review, not by the gate: give it a signature guard and keep it,
-  and if you add a genuinely per-frame write path, route it through the facet and move the
-  module into `HOT_PAINTERS`.
+  a convention rather than something enforced.
+  **WHICH windows those are is now a registry**, not folklore: `tests/hud_update_drive.test.ts`
+  holds a row per call `Hud.update()` makes, with its cadence band, the exact condition text
+  gating it, what it repaints, and (for a window) the source line its invalidation guard is
+  spelled on, diffed BOTH ways against a TypeScript AST walk of the real method. Adding,
+  removing, re-banding or re-gating a call in `update()` fails it, and so does deleting a
+  guard it names. Three things it does not do, so nothing here is read as more than it is: it
+  sees `update()`'s own body only (a repaint added inside an already-registered private method
+  is invisible to it), a guard proof catches DELETION and not a guard neutered while its field
+  survives, and the band it records is the CALL SITE's, not any further self-throttling the
+  callee adds. So a window on a poll is now NAMED by the gate and still held to the
+  write-elision standard by review: give it a signature guard and keep it, and if you add a
+  genuinely per-frame write path, route it through the facet and move the module into
+  `HOT_PAINTERS`. A module that arms its own repeating driver owes the same care INSIDE the
+  callback, which is a contract nothing scans yet: `lockpick_window` re-resolved three element
+  refs on a 100ms tick until #2498, and the fix had to re-resolve them per board REBUILD
+  rather than once at construction, because `renderBoard` replaces that subtree on a signature
+  the clock does not restart on (`tests/lockpick_timer_repaint.test.ts` pins both halves).
 - **Allocation-light cores.** A per-frame view-core returns a REUSED, preallocated container +
   slots (no per-frame array/object garbage); jitter/clock stay in the painter, never the core.
   Guarded always-on by the reference-stability probe `tests/util/alloc_probe.ts`.

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -88,7 +88,7 @@ Per-frame HUD code (anything reached from `Hud.update()`) holds these:
   it repaints on the open check alone, which is the standing proof that the signature guard is
   a convention rather than something enforced.
   **WHICH windows those are is now a registry**, not folklore: `tests/hud_update_drive.test.ts`
-  holds a row per call `Hud.update()` makes, with its cadence band, the exact condition text
+  holds a row per call `Hud.update()` EVALUATES, with its cadence band, the exact condition text
   gating it, what it repaints, and (for a window) the source line its invalidation guard is
   spelled on, diffed BOTH ways against a TypeScript AST walk of the real method. Adding,
   removing, re-banding or re-gating a call in `update()` fails it, and so does deleting a

--- a/src/ui/hud/delve/lockpick_window.ts
+++ b/src/ui/hud/delve/lockpick_window.ts
@@ -185,9 +185,11 @@ export class LockpickWindow {
     if (!el) return;
     const view = this.deps.getState();
     if (!view) {
-      // The one exit from renderBoard that leaves the subtree alone: drop the refs anyway,
-      // so the module upholds "the refs are dropped wherever they stop being current" by
-      // itself rather than relying on the caller routing onClose back into close().
+      // The one exit from renderBoard that leaves the subtree alone. Dropping the refs here
+      // is hygiene rather than behavior, like close()'s: every caller runs syncTimer() next,
+      // which stops the clock on a null state, so nothing can paint afterwards. It is here
+      // so the module upholds "the refs go wherever they stop being current" by itself
+      // rather than leaning on that ordering.
       this.forgetTimerEls();
       this.deps.onClose();
       return;
@@ -281,11 +283,12 @@ export class LockpickWindow {
   /**
    * Drop the refs when the subtree they point into is gone or replaced.
    *
-   * From `close()` this is reference hygiene rather than a behavior: `close()` stops the
-   * clock first, so nothing can paint afterwards and no test can observe the difference.
-   * From `renderAnte()` and the state-less `renderBoard()` exit it IS observable, because
-   * both leave a running interval behind, and `tests/lockpick_timer_repaint.test.ts` pins
-   * those two.
+   * From `renderAnte()` this is a real behavior and is pinned: the ante selector replaces
+   * the board's subtree and deliberately does NOT stop the clock, so stale refs would keep
+   * being painted. From `close()` and from `renderBoard()`'s state-less exit it is hygiene
+   * only, because both stop the clock (directly, or via the `syncTimer()` that follows), so
+   * nothing can paint afterwards and no test can tell the difference. Said here rather than
+   * left for the next reader to re-derive from three call sites.
    */
   private forgetTimerEls(): void {
     this.timerEls = null;

--- a/src/ui/hud/delve/lockpick_window.ts
+++ b/src/ui/hud/delve/lockpick_window.ts
@@ -56,6 +56,9 @@ export interface LockpickWindowDeps {
 }
 
 const NUM0 = { maximumFractionDigits: 0 } as const;
+// The countdown's one decimal. `toFixed(1)` rendered `12.3` in every locale, where ru_RU and
+// de want a comma; English output is byte-identical through formatNumber either way.
+const NUM1 = { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false } as const;
 
 /** The three countdown nodes `renderBoard` emits, resolved once per board paint. */
 interface TimerEls {
@@ -182,6 +185,10 @@ export class LockpickWindow {
     if (!el) return;
     const view = this.deps.getState();
     if (!view) {
+      // The one exit from renderBoard that leaves the subtree alone: drop the refs anyway,
+      // so the module upholds "the refs are dropped wherever they stop being current" by
+      // itself rather than relying on the caller routing onClose back into close().
+      this.forgetTimerEls();
       this.deps.onClose();
       return;
     }
@@ -228,7 +235,7 @@ export class LockpickWindow {
     const timerBlock =
       timerSecs != null
         ? `<div class="lp-timer" aria-label="${esc(t('lockpickUi.timerAria'))}"><div class="lp-timer-track"><div class="lp-timer-bar" id="lp-timer-bar" style="width:100%"></div></div>` +
-          `<span class="lp-timer-value" id="lp-timer-value">${esc(t('lockpickUi.seconds', { seconds: timerSecs.toFixed(1) }))}</span></div>`
+          `<span class="lp-timer-value" id="lp-timer-value">${esc(t('lockpickUi.seconds', { seconds: formatNumber(timerSecs, NUM1) }))}</span></div>`
         : '';
     el.innerHTML =
       `<div class="panel-title"><span>${esc(t('lockpickUi.boardTitle', { tier: this.deps.tierName(view.lootTier) }))}</span>` +
@@ -260,15 +267,26 @@ export class LockpickWindow {
    * per-step budget emits no timer block, so the refs go null and paintTimer writes nothing.
    */
   private cacheTimerEls(el: HTMLElement): void {
-    const bar = el.querySelector<HTMLElement>('#lp-timer-bar');
-    const value = el.querySelector<HTMLElement>('#lp-timer-value');
+    // By CLASS, not by the ids the markup also carries: this window is
+    // instance-parameterized on deps.panel, so a second panel would make the ids collide
+    // while a query scoped to the panel's own class stays correct.
+    const bar = el.querySelector<HTMLElement>('.lp-timer-bar');
+    const value = el.querySelector<HTMLElement>('.lp-timer-value');
     const wrap = el.querySelector<HTMLElement>('.lp-timer');
     this.timerEls = bar && value && wrap ? { bar, value, wrap } : null;
     // The fresh markup carries no urgent class, so the latch starts from that.
     this.lastUrgent = false;
   }
 
-  /** Drop the refs when the subtree they point into is gone or replaced. */
+  /**
+   * Drop the refs when the subtree they point into is gone or replaced.
+   *
+   * From `close()` this is reference hygiene rather than a behavior: `close()` stops the
+   * clock first, so nothing can paint afterwards and no test can observe the difference.
+   * From `renderAnte()` and the state-less `renderBoard()` exit it IS observable, because
+   * both leave a running interval behind, and `tests/lockpick_timer_repaint.test.ts` pins
+   * those two.
+   */
   private forgetTimerEls(): void {
     this.timerEls = null;
     this.lastUrgent = false;
@@ -325,7 +343,7 @@ export class LockpickWindow {
     const els = this.timerEls;
     if (!els) return;
     els.bar.style.width = `${(remaining / seconds) * 100}%`;
-    els.value.textContent = t('lockpickUi.seconds', { seconds: remaining.toFixed(1) });
+    els.value.textContent = t('lockpickUi.seconds', { seconds: formatNumber(remaining, NUM1) });
     const urgent = remaining < 3;
     if (urgent !== this.lastUrgent) {
       this.lastUrgent = urgent;

--- a/src/ui/hud/delve/lockpick_window.ts
+++ b/src/ui/hud/delve/lockpick_window.ts
@@ -57,11 +57,31 @@ export interface LockpickWindowDeps {
 
 const NUM0 = { maximumFractionDigits: 0 } as const;
 
+/** The three countdown nodes `renderBoard` emits, resolved once per board paint. */
+interface TimerEls {
+  readonly bar: HTMLElement;
+  readonly value: HTMLElement;
+  readonly wrap: HTMLElement;
+}
+
 export class LockpickWindow {
   private timerGen = 0;
   private timerInterval: number | null = null;
   private lastSig = '';
   private lastTimerKey = '';
+  // The countdown's element refs, and the urgent-class latch that rides with them.
+  //
+  // RESOLVED PER BOARD PAINT, not once at construction, and that distinction is the whole
+  // reason this is not the ordinary "cache refs in the constructor" of src/ui/CLAUDE.md.
+  // renderBoard() replaces the panel's entire subtree, and it runs on a DIFFERENT trigger
+  // than the clock does: lockpickRenderSig covers `row` and `visible.length` while
+  // lockpickTimerKey (sessionId:page:tries:col) covers neither, so moving the pick up a row
+  // or revealing fog rebuilds these three nodes WITHOUT restarting the interval. Refs taken
+  // at startTimer() would then paint into a detached subtree and the bar would freeze for the
+  // rest of the attempt. Re-resolving here, at the one innerHTML site that destroys them,
+  // keeps that correct while taking the three querySelector walks off the 10 Hz path.
+  private timerEls: TimerEls | null = null;
+  private lastUrgent = false;
 
   constructor(private readonly deps: LockpickWindowDeps) {}
 
@@ -96,6 +116,8 @@ export class LockpickWindow {
       `<button type="button" class="x-btn" data-close aria-label="${esc(t('lockpickUi.closeAria'))}">${svgIcon('close')}</button></div>` +
       `<div class="lp-blurb${coffer ? ' lp-blurb-coffer' : ''}">${esc(blurb)}</div>` +
       `<div class="lp-ante-row${coffer ? ' lp-ante-row-coffer' : ''}">${buttons}</div>`;
+    // The ante markup carries no countdown, so any refs from a previous board are stale.
+    this.forgetTimerEls();
     el.querySelectorAll('[data-ante]').forEach((btn) => {
       btn.addEventListener('click', () => {
         const ante = Number((btn as HTMLElement).dataset.ante) as Ante;
@@ -229,6 +251,27 @@ export class LockpickWindow {
     });
     el.querySelector('[data-withdraw]')?.addEventListener('click', () => this.deps.onAbort());
     el.querySelector('[data-close]')?.addEventListener('click', () => this.deps.onAbort());
+    this.cacheTimerEls(el);
+  }
+
+  /**
+   * Re-point the countdown at the nodes this paint just created. Called at the END of
+   * renderBoard, after the innerHTML write that destroyed the previous ones. A board with no
+   * per-step budget emits no timer block, so the refs go null and paintTimer writes nothing.
+   */
+  private cacheTimerEls(el: HTMLElement): void {
+    const bar = el.querySelector<HTMLElement>('#lp-timer-bar');
+    const value = el.querySelector<HTMLElement>('#lp-timer-value');
+    const wrap = el.querySelector<HTMLElement>('.lp-timer');
+    this.timerEls = bar && value && wrap ? { bar, value, wrap } : null;
+    // The fresh markup carries no urgent class, so the latch starts from that.
+    this.lastUrgent = false;
+  }
+
+  /** Drop the refs when the subtree they point into is gone or replaced. */
+  private forgetTimerEls(): void {
+    this.timerEls = null;
+    this.lastUrgent = false;
   }
 
   // --- Countdown (generation-guarded) --------------------------------------
@@ -272,19 +315,28 @@ export class LockpickWindow {
     }
   }
 
+  /**
+   * One tick of the countdown, 10x a second for the length of an attempt. Reads the refs
+   * renderBoard cached rather than re-resolving them (three querySelector subtree walks per
+   * tick before #2498). The width and the label move every tick by definition; the urgent
+   * class flips at most once per attempt, so it rides a latch instead of a blind toggle.
+   */
   private paintTimer(remaining: number, seconds: number): void {
-    const panel = this.panel();
-    const bar = panel?.querySelector<HTMLElement>('#lp-timer-bar') ?? null;
-    if (bar) bar.style.width = `${(remaining / seconds) * 100}%`;
-    const val = panel?.querySelector<HTMLElement>('#lp-timer-value') ?? null;
-    if (val) val.textContent = t('lockpickUi.seconds', { seconds: remaining.toFixed(1) });
-    const wrap = panel?.querySelector<HTMLElement>('.lp-timer') ?? null;
-    if (wrap) wrap.classList.toggle('lp-timer-urgent', remaining < 3);
+    const els = this.timerEls;
+    if (!els) return;
+    els.bar.style.width = `${(remaining / seconds) * 100}%`;
+    els.value.textContent = t('lockpickUi.seconds', { seconds: remaining.toFixed(1) });
+    const urgent = remaining < 3;
+    if (urgent !== this.lastUrgent) {
+      this.lastUrgent = urgent;
+      els.wrap.classList.toggle('lp-timer-urgent', urgent);
+    }
   }
 
   /** Tear down on panel close: stop the clock and forget the last paint. */
   close(): void {
     this.stopTimer();
+    this.forgetTimerEls();
     this.lastSig = '';
     this.lastTimerKey = '';
   }

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -34,7 +34,7 @@ Subdirectories (plus one shared fixture):
   hand-rolled fake DOM for controller suites, `i18n_determinism.ts`, `ts_files_under.ts`
   and `css_tree_under.ts`, the two source walks, `scan_guard_self_audit.ts`, the pin that
   keeps a guard from re-growing its own directory read, `method_call_sites.ts`, the
-  `ts.createSourceFile` walk that reports a class method's statement-position calls with the
+  `ts.createSourceFile` walk that reports the calls a class method evaluates, each with the
   `if` chain guarding each, `alloc_probe.ts`).
 - `global_setup.ts`: runs on every vitest invocation (`vite.config.ts` `test.globalSetup`);
   mints the SFX Studio temp root (`WOC_SFX_STUDIO_TEST_ROOT`).
@@ -121,7 +121,7 @@ use the `tests/server/helpers/` fakes (see Map), not a bespoke GameServer rig.
   window is cold, which this tree contradicts, but because a COUNT cannot tell a build-time
   write from a repeated one; see the bucket 3 comment for the cadences involved.
 - `hud_update_drive.test.ts` answers the cadence question that gate refuses to: one
-  hand-written row per call `Hud.update()` makes, carrying its band
+  hand-written row per call `Hud.update()` evaluates, carrying its band
   (`frame`/`fast`/`medium`/`slow`), the exact condition text gating it, what it repaints, and
   for a window the source line its invalidation guard is spelled on. Diffed BOTH ways against
   a `ts.createSourceFile` walk (`helpers/method_call_sites.ts`), so adding, deleting,

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -33,7 +33,9 @@ Subdirectories (plus one shared fixture):
 - `helpers/` + `util/`: shared cross-suite utilities (`fake_dom.ts`, the reusable
   hand-rolled fake DOM for controller suites, `i18n_determinism.ts`, `ts_files_under.ts`
   and `css_tree_under.ts`, the two source walks, `scan_guard_self_audit.ts`, the pin that
-  keeps a guard from re-growing its own directory read, `alloc_probe.ts`).
+  keeps a guard from re-growing its own directory read, `method_call_sites.ts`, the
+  `ts.createSourceFile` walk that reports a class method's statement-position calls with the
+  `if` chain guarding each, `alloc_probe.ts`).
 - `global_setup.ts`: runs on every vitest invocation (`vite.config.ts` `test.globalSetup`);
   mints the SFX Studio temp root (`WOC_SFX_STUDIO_TEST_ROOT`).
 
@@ -118,6 +120,15 @@ use the `tests/server/helpers/` fakes (see Map), not a bespoke GameServer rig.
   driver of its own, at any cadence). The raw-write scan is waived for cold NOT because a
   window is cold, which this tree contradicts, but because a COUNT cannot tell a build-time
   write from a repeated one; see the bucket 3 comment for the cadences involved.
+- `hud_update_drive.test.ts` answers the cadence question that gate refuses to: one
+  hand-written row per call `Hud.update()` makes, carrying its band
+  (`frame`/`fast`/`medium`/`slow`), the exact condition text gating it, what it repaints, and
+  for a window the source line its invalidation guard is spelled on. Diffed BOTH ways against
+  a `ts.createSourceFile` walk (`helpers/method_call_sites.ts`), so adding, deleting,
+  re-banding or re-gating a call in `update()` fails until the table says so, and deleting a
+  guard it names fails too. It registers the WHOLE body rather than only the windows on
+  purpose: a table naming a handful when half the family qualifies reads as a complete
+  classification and is not one. Touching `update()` means touching this file.
 - SFX gates: the `sfx_*` suites (`sfx_conform`, `sfx_studio_server_security`,
   `tests/server/static_sfx_serving`, ...) mirror `npm run sfx:check`.
 - `malware_scan.test.ts` is the release-gate backstop (signatures from `scripts/malware_scan.mjs`,

--- a/tests/helpers/method_call_sites.test.ts
+++ b/tests/helpers/method_call_sites.test.ts
@@ -36,7 +36,7 @@ const ARM_FIXTURES: ReadonlyArray<readonly [string, string, string[]]> = [
   ['isForOfStatement', 'for (const e of list) this.a();', ['this.a']],
   ['isForInStatement', 'for (const k in map) this.a();', ['this.a']],
   ['isWhileStatement', 'while (go) this.a();', ['this.a']],
-  ['isDoStatement', 'do { this.a(); } while (go);', ['this.a']],
+  ['isDoStatement', 'do { this.doOnce(); } while (go);', ['this.doOnce']],
   ['isLabeledStatement', 'outer: { this.a(); }', ['this.a']],
   [
     'isTryStatement',
@@ -73,7 +73,23 @@ const ARM_FIXTURES: ReadonlyArray<readonly [string, string, string[]]> = [
 ];
 
 /** Arms the helper matches by `SyntaxKind` rather than through a `ts.is*` guard. */
-const ROOT_ARMS = ['ThisKeyword'];
+function rootArms(helperSource: string): string[] {
+  // The `node.kind === ts.SyntaxKind.X` shape specifically, which is how a callee-chain arm
+  // gets matched without a `ts.is*` guard and so without needing a fixture. A bare
+  // `ts.SyntaxKind.X` is a different thing (an operator kind compared against
+  // `operatorToken.kind`, or a member of the ASSIGNMENT_OPS set), and those arms have their
+  // own cases below rather than an entry in this list.
+  return [
+    ...new Set([...helperSource.matchAll(/\.kind === ts\.SyntaxKind\.(\w+)/g)].map((m) => m[1])),
+  ];
+}
+
+/**
+ * The bodies every fixture shares because EVERY case exercises them: a class, a method and
+ * the `this` root. Any OTHER two arms sharing a body means one of them is not being driven,
+ * which is what let a fixture be replaced by a copy-paste and stay green.
+ */
+const STRUCTURAL_ARMS = ['isClassDeclaration', 'isMethodDeclaration', 'ThisKeyword'];
 
 describe('readMethodCallSites: statement position', () => {
   it('records the statement head and NOT the calls nested inside it', () => {
@@ -229,6 +245,9 @@ describe('readMethodCallSites: the condition chain', () => {
     expect(broken).toEqual(inline);
     expect(broken).toEqual(['sigOf(a, b) !== this.last']);
     expect(sitesIn('if (a /* why */ && b) this.render();')[0].conditions).toEqual(['a && b']);
+    // The BRACKET halves of the two padding rules, and the trailing-comma rule, match nothing
+    // in the live tree, so each could be deleted with everything green.
+    expect(normalizeCondition('rows[\n  i,\n] && f(\n  a ,\n)')).toBe('rows[i] && f(a)');
   });
 
   it('normalizeCondition leaves a URL protocol alone', () => {
@@ -299,9 +318,7 @@ describe('readMethodCallSites: refusals and counts', () => {
     expect(
       readMethodCallSites('w.ts', wrap('this.a();\nthis.b();'), 'Widget', 'update').bodyLines,
     ).toBe(4);
-    expect(readMethodCallSites('w.ts', wrap('this.a();'), 'Widget', 'update').declarationLine).toBe(
-      2,
-    );
+    expect(readMethodCallSites('w.ts', wrap('this.a();'), 'Widget', 'update').bodyLines).toBe(3);
   });
 
   it('walks a body holding regex literals with quotes and escaped slashes', () => {
@@ -347,8 +364,47 @@ describe('the fixture list covers every walker arm', () => {
       guards.length,
       'the walker stopped using ts.is* guards: re-derive this pin',
     ).toBeGreaterThan(15);
-    expect([...new Set([...guards, ...ROOT_ARMS])].sort()).toEqual(
+    expect([...new Set([...guards, ...rootArms(normalizeCondition(helper))])].sort()).toEqual(
       [...new Set(ARM_FIXTURES.map(([label]) => label))].sort(),
     );
+  });
+
+  it("gives each arm its OWN fixture body, not a copy of another arm's", () => {
+    // The label-to-body binding is otherwise decorative: swap the `isDoStatement` body for
+    // `this.a();`, keep the label, and the completeness pin above still passes while the arm
+    // goes unexercised. Same class as a matcher pinned by label rather than by identity.
+    const bodies = ARM_FIXTURES.filter(([label]) => !STRUCTURAL_ARMS.includes(label)).map(
+      ([, body]) => body,
+    );
+    expect(new Set(bodies).size, 'two arms share a fixture body: one of them is not driven').toBe(
+      bodies.length,
+    );
+    // ...and the three allowed to share are pinned by name, so the exemption cannot widen.
+    expect(
+      ARM_FIXTURES.filter(([label]) => STRUCTURAL_ARMS.includes(label)).map(([label]) => label),
+    ).toEqual(STRUCTURAL_ARMS);
+  });
+
+  it('records the right side of EVERY assignment operator it lists', () => {
+    // Eight of the nine ASSIGNMENT_OPS entries match nothing in the live tree, so the set
+    // could be cut to `=` alone with everything green, and a repaint written as
+    // `this.total += this.paintAndCount()` would leave the registry entirely.
+    const operators = ['=', '+=', '-=', '*=', '/=', '%=', '&&=', '||=', '??='];
+    for (const op of operators) {
+      expect(callsIn(`this.n ${op} this.compute();`), `the ${op} arm`).toEqual(['this.compute']);
+    }
+    // The comma arm is the same shape and equally unexercised by the live tree: without a
+    // case, deleting it loses the second call of a sequence expression silently.
+    expect(callsIn('this.a(), this.b();')).toEqual(['this.a', 'this.b']);
+    const helper = readFileSync(
+      fileURLToPath(new URL('./method_call_sites.ts', import.meta.url)),
+      'utf8',
+    );
+    const from = helper.indexOf('ASSIGNMENT_OPS = new Set');
+    const listed = helper.slice(from, helper.indexOf(']);', from));
+    expect(
+      (listed.match(/ts\.SyntaxKind\./g) ?? []).length,
+      'ASSIGNMENT_OPS grew or shrank: give every operator in it a case above',
+    ).toBe(operators.length);
   });
 });

--- a/tests/helpers/method_call_sites.test.ts
+++ b/tests/helpers/method_call_sites.test.ts
@@ -1,0 +1,286 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { normalizeCondition, readMethodCallSites } from './method_call_sites';
+
+// The paired test for the source walk `tests/hud_update_drive.test.ts` runs on.
+//
+// It exists for the reason `scan_guard_self_audit.test.ts` states: production source never
+// exercises a guard's helper into its corners, so an arm can be deleted with the whole suite
+// green (#2499, #2502). Every case below is a SYNTHETIC source, never `src/ui/hud.ts`: the
+// walker takes a string precisely so its branches can be reached from a fixture, and a test
+// that drove it over the real coordinator would only ever prove the tree it already passes on.
+//
+// The fixture list is pinned against the type guards the walker actually calls, so an arm
+// added without a case fails here rather than shipping unexercised.
+
+const wrap = (body: string, name = 'update'): string =>
+  `export class Widget {\n  ${name}(): void {\n${body}\n  }\n}\n`;
+
+const callsIn = (body: string): string[] =>
+  readMethodCallSites('w.ts', wrap(body), 'Widget', 'update').sites.map((s) => s.call);
+
+const sitesIn = (body: string) => readMethodCallSites('w.ts', wrap(body), 'Widget', 'update').sites;
+
+/**
+ * One case per walker arm. The label is the `ts.is*` guard it drives, which is what the
+ * completeness pin at the bottom matches against the helper's own source.
+ */
+const ARM_FIXTURES: ReadonlyArray<readonly [string, string, string[]]> = [
+  ['isClassDeclaration', 'this.a();', ['this.a']],
+  ['isMethodDeclaration', 'this.a();', ['this.a']],
+  ['isExpressionStatement', 'this.a();\nconst x = this.notAStatementHead();', ['this.a']],
+  ['isBlock', '{\n  this.a();\n}', ['this.a']],
+  ['isIfStatement', 'if (open) this.a();', ['this.a']],
+  ['isForStatement', 'for (let i = 0; i < 3; i++) this.a();', ['this.a']],
+  ['isForOfStatement', 'for (const e of list) this.a();', ['this.a']],
+  ['isForInStatement', 'for (const k in map) this.a();', ['this.a']],
+  ['isWhileStatement', 'while (go) this.a();', ['this.a']],
+  ['isDoStatement', 'do { this.a(); } while (go);', ['this.a']],
+  ['isLabeledStatement', 'outer: { this.a(); }', ['this.a']],
+  [
+    'isTryStatement',
+    'try { this.a(); } catch (e) { this.b(); } finally { this.c(); }',
+    ['this.a', 'this.b', 'this.c'],
+  ],
+  [
+    'isSwitchStatement',
+    'switch (k) {\n  case 1:\n    this.a();\n    break;\n  default:\n    this.b();\n}',
+    ['this.a', 'this.b'],
+  ],
+  ['isIdentifier', 'freeFunction();', ['freeFunction']],
+  ['isPropertyAccessExpression', 'this.win.render();', ['this.win.render']],
+  ['isElementAccessExpression', "this.rows['first'].paint();", ['this.rows[].paint']],
+  [
+    'isCallExpression',
+    "document.getElementById('x').classList.toggle('on');",
+    ['document.getElementById().classList.toggle'],
+  ],
+  ['isNonNullExpression', 'this.win!.render();', ['this.win.render']],
+  ['isParenthesizedExpression', '(this.win).render();', ['this.win.render']],
+  ['isAwaitExpression', 'await this.save();', ['this.save']],
+  ['isVoidExpression', 'void this.probe();', ['this.probe']],
+  // Not a `ts.is*` call in the helper (the root is matched on SyntaxKind), so it is listed
+  // in ROOT_ARMS below and pinned the same way.
+  ['ThisKeyword', 'this.a();', ['this.a']],
+];
+
+/** Arms the helper matches by `SyntaxKind` rather than through a `ts.is*` guard. */
+const ROOT_ARMS = ['ThisKeyword'];
+
+describe('readMethodCallSites: statement position', () => {
+  it('records the statement head and NOT the calls nested inside it', () => {
+    // The distinction the whole registry rests on: this is ONE drive, not two. The inner
+    // tick() is an argument the painter consumes, on the painter's cadence, not a second
+    // thing `update()` drives.
+    expect(callsIn('this.painter.paint(this.view.tick({ a: 1 }));')).toEqual([
+      'this.painter.paint',
+    ]);
+  });
+
+  it('does not descend into a callback body', () => {
+    // A one-shot the callback owns is not a per-frame drive. Recording `this.hide` here
+    // would be a lie about cadence, and it is exactly the shape `update()` contains.
+    expect(callsIn('window.setTimeout(() => this.hide(), 8000);')).toEqual(['window.setTimeout']);
+    expect(callsIn('list.forEach(function (e) {\n  this.paint(e);\n});')).toEqual(['list.forEach']);
+  });
+
+  it('ignores a statement whose head is not a call', () => {
+    expect(
+      callsIn(
+        [
+          'this.lastZone = zone.id;',
+          "this.el.innerHTML = '';",
+          'const v = this.build();',
+          'let n = 1;',
+          'return;',
+        ].join('\n'),
+      ),
+    ).toEqual([]);
+  });
+
+  it('ignores a callee that is not a plain member chain', () => {
+    // Returning nothing beats guessing a name: a registry keyed on a guess would pair the
+    // wrong row with the wrong call and read as if it had checked something.
+    expect(callsIn('(cond ? this.a : this.b)();')).toEqual([]);
+  });
+
+  it('normalizes an optional link and keeps an intermediate call visible', () => {
+    expect(callsIn("document.getElementById('x')?.classList.toggle('on', v);")).toEqual([
+      'document.getElementById().classList.toggle',
+    ]);
+    expect(callsIn('this.win?.render();')).toEqual(['this.win.render']);
+  });
+
+  it('reports 1-based lines in the WHOLE file, not in the extracted body', () => {
+    const src = wrap('\nthis.a();');
+    const [only] = readMethodCallSites('w.ts', src, 'Widget', 'update').sites;
+    expect(only.line).toBe(4);
+    expect(src.split('\n')[only.line - 1]).toContain('this.a();');
+  });
+});
+
+describe('readMethodCallSites: the condition chain', () => {
+  it('carries enclosing conditions outermost first', () => {
+    expect(sitesIn('if (slowHud) {\n  if (open) this.render();\n}')[0].conditions).toEqual([
+      'slowHud',
+      'open',
+    ]);
+  });
+
+  it('records an else arm as the negation, so the two arms never merge', () => {
+    const sites = sitesIn('if (target) {\n  this.paint();\n} else {\n  this.hide();\n}');
+    expect(sites.map((s) => [s.call, s.conditions])).toEqual([
+      ['this.paint', ['target']],
+      ['this.hide', ['!(target)']],
+    ]);
+  });
+
+  it('threads an else-if chain', () => {
+    const sites = sitesIn(
+      [
+        'if (a) {',
+        '  this.x();',
+        '} else if (b) {',
+        '  this.y();',
+        '} else {',
+        '  this.z();',
+        '}',
+      ].join('\n'),
+    );
+    expect(sites.map((s) => s.conditions)).toEqual([['a'], ['!(a)', 'b'], ['!(a)', '!(b)']]);
+  });
+
+  it('leaves a loop or try header out of the chain', () => {
+    expect(sitesIn('for (const e of list) {\n  this.paint(e);\n}')[0].conditions).toEqual([]);
+    expect(sitesIn('try {\n  this.paint();\n} catch (e) {}')[0].conditions).toEqual([]);
+  });
+
+  it('normalizes a condition biome reflowed, and strips a comment inside it', () => {
+    // biome breaks a long condition across lines the moment it grows a character, and adds a
+    // trailing comma to the argument list it broke. A key that kept either would flip on a
+    // reformat, so both are normalized away.
+    const inline = sitesIn('if (sigOf(a, b) !== this.last) this.render();')[0].conditions;
+    const broken = sitesIn(
+      'if (\n  sigOf(\n    a,\n    b,\n  ) !== this.last\n)\n  this.render();',
+    )[0].conditions;
+    expect(broken).toEqual(inline);
+    expect(broken).toEqual(['sigOf(a, b) !== this.last']);
+    expect(sitesIn('if (a /* why */ && b) this.render();')[0].conditions).toEqual(['a && b']);
+  });
+
+  it('normalizeCondition leaves a URL protocol alone', () => {
+    // The line-comment strip this repo has already shipped wrong once (#2499): a bare
+    // `//` rule eats the rest of the line starting at `https://`.
+    expect(normalizeCondition("u === 'https://example.com/a' // note")).toBe(
+      "u === 'https://example.com/a'",
+    );
+  });
+});
+
+describe('readMethodCallSites: refusals and counts', () => {
+  const missing = (fn: () => unknown, re: RegExp): void => expect(fn).toThrow(re);
+
+  it('THROWS on a missing class or method rather than returning an empty scan', () => {
+    // The load-bearing refusal. The hazard #2498 named is `update()` being extracted behind a
+    // controller, and a resolver that answered "no calls" would hand the gate a clean, empty,
+    // passing scan of nothing.
+    missing(
+      () => readMethodCallSites('w.ts', wrap('this.a();'), 'Gone', 'update'),
+      /class Gone not found/,
+    );
+    missing(
+      () => readMethodCallSites('w.ts', wrap('this.a();'), 'Widget', 'tick'),
+      /Widget\.tick\(\) not found/,
+    );
+    missing(
+      () =>
+        readMethodCallSites(
+          'w.ts',
+          'export class Widget {\n  update(): void;\n}\n',
+          'Widget',
+          'update',
+        ),
+      /has no body/,
+    );
+    // Both messages tell the reader what to do, which is the difference between a refusal and
+    // a wall.
+    missing(
+      () => readMethodCallSites('w.ts', wrap('this.a();'), 'Widget', 'tick'),
+      /renamed or extracted/,
+    );
+  });
+
+  it('counts class members exactly, template literals included', () => {
+    const src = [
+      'export class Widget {',
+      '  private a = 1;',
+      '  private b: string | null = null;',
+      '  private c = `',
+      '  width: 100%;',
+      '  height: 100%;',
+      '  `;',
+      '  private d: Map<string, number> = new Map();',
+      '  get e(): number { return 1; }',
+      '  set f(v: number) { void v; }',
+      '  constructor() {}',
+      '  update(): void { this.g(); }',
+      '  private g(): void {}',
+      '}',
+    ].join('\n');
+    // The indentation-and-regex counter this replaced read the two CSS lines inside the
+    // template literal as fields, and the `;` inside `Map<string, number>` as a member break.
+    expect(readMethodCallSites('w.ts', src, 'Widget', 'update').classMembers).toBe(9);
+  });
+
+  it('measures the body span in lines', () => {
+    expect(
+      readMethodCallSites('w.ts', wrap('this.a();\nthis.b();'), 'Widget', 'update').bodyLines,
+    ).toBe(4);
+    expect(readMethodCallSites('w.ts', wrap('this.a();'), 'Widget', 'update').declarationLine).toBe(
+      2,
+    );
+  });
+
+  it('walks a body holding regex literals with quotes and escaped slashes', () => {
+    // The case that decided this module is an AST walk rather than a lexer: `src/ui/hud.ts`
+    // holds about a hundred of these in its server-text matchers, and a hand-rolled scan has
+    // to guess regex-versus-division from the preceding token to get past them.
+    expect(
+      callsIn(
+        [
+          "const m = /^You can't do that in (Bruin|Wolf) Form\\.$/.exec(text);",
+          'const n = /^Unknown command: (.+?)\\. Try \\/.*$/.exec(text);',
+          'const ratio = a.hp / Math.max(1, a.maxHp);',
+          'this.paint(ratio, m, n);',
+        ].join('\n'),
+      ),
+    ).toEqual(['this.paint']);
+  });
+});
+
+describe('the fixture list covers every walker arm', () => {
+  it('drives each arm and gets the call it names', () => {
+    for (const [label, body, expected] of ARM_FIXTURES) {
+      expect(callsIn(body), `the ${label} arm`).toEqual(expected);
+    }
+  });
+
+  it('has a fixture for every type guard the walker calls', () => {
+    // Without this, an arm added later is pinned by nothing: every other assertion here names
+    // its own case, so a new branch simply goes unvisited (#2497's unfixtured-matcher hole,
+    // one file over). Reading the helper's OWN source is what makes the list two-directional.
+    const helper = readFileSync(
+      fileURLToPath(new URL('./method_call_sites.ts', import.meta.url)),
+      'utf8',
+    );
+    const guards = [...helper.matchAll(/ts\.is([A-Za-z]+)\(/g)].map((m) => `is${m[1]}`);
+    expect(
+      guards.length,
+      'the walker stopped using ts.is* guards: re-derive this pin',
+    ).toBeGreaterThan(15);
+    expect([...new Set([...guards, ...ROOT_ARMS])].sort()).toEqual(
+      [...new Set(ARM_FIXTURES.map(([label]) => label))].sort(),
+    );
+  });
+});

--- a/tests/helpers/method_call_sites.test.ts
+++ b/tests/helpers/method_call_sites.test.ts
@@ -29,7 +29,7 @@ const sitesIn = (body: string) => readMethodCallSites('w.ts', wrap(body), 'Widge
 const ARM_FIXTURES: ReadonlyArray<readonly [string, string, string[]]> = [
   ['isClassDeclaration', 'this.a();', ['this.a']],
   ['isMethodDeclaration', 'this.a();', ['this.a']],
-  ['isExpressionStatement', 'this.a();\nconst x = this.notAStatementHead();', ['this.a']],
+  ['isExpressionStatement', 'this.a();\nfreeFn();', ['this.a', 'freeFn']],
   ['isBlock', '{\n  this.a();\n}', ['this.a']],
   ['isIfStatement', 'if (open) this.a();', ['this.a']],
   ['isForStatement', 'for (let i = 0; i < 3; i++) this.a();', ['this.a']],
@@ -48,6 +48,11 @@ const ARM_FIXTURES: ReadonlyArray<readonly [string, string, string[]]> = [
     'switch (k) {\n  case 1:\n    this.a();\n    break;\n  default:\n    this.b();\n}',
     ['this.a', 'this.b'],
   ],
+  ['isVariableStatement', 'const v = this.build();', ['this.build']],
+  ['isReturnStatement', 'return this.build();', ['this.build']],
+  ['isThrowStatement', 'throw this.buildError();', ['this.buildError']],
+  ['isBinaryExpression', 'this.last = this.marker.mark(x);', ['this.marker.mark']],
+  ['isConditionalExpression', 'const v = ok ? this.a() : this.b();', ['this.a', 'this.b']],
   ['isIdentifier', 'freeFunction();', ['freeFunction']],
   ['isPropertyAccessExpression', 'this.win.render();', ['this.win.render']],
   ['isElementAccessExpression', "this.rows['first'].paint();", ['this.rows[].paint']],
@@ -60,6 +65,8 @@ const ARM_FIXTURES: ReadonlyArray<readonly [string, string, string[]]> = [
   ['isParenthesizedExpression', '(this.win).render();', ['this.win.render']],
   ['isAwaitExpression', 'await this.save();', ['this.save']],
   ['isVoidExpression', 'void this.probe();', ['this.probe']],
+  ['isAsExpression', 'const v = this.build() as string;', ['this.build']],
+  ['isSatisfiesExpression', 'const v = this.build() satisfies string;', ['this.build']],
   // Not a `ts.is*` call in the helper (the root is matched on SyntaxKind), so it is listed
   // in ROOT_ARMS below and pinned the same way.
   ['ThisKeyword', 'this.a();', ['this.a']],
@@ -85,16 +92,10 @@ describe('readMethodCallSites: statement position', () => {
     expect(callsIn('list.forEach(function (e) {\n  this.paint(e);\n});')).toEqual(['list.forEach']);
   });
 
-  it('ignores a statement whose head is not a call', () => {
+  it('ignores a statement that evaluates no call', () => {
     expect(
       callsIn(
-        [
-          'this.lastZone = zone.id;',
-          "this.el.innerHTML = '';",
-          'const v = this.build();',
-          'let n = 1;',
-          'return;',
-        ].join('\n'),
+        ['this.lastZone = zone.id;', "this.el.innerHTML = '';", 'let n = 1;', 'return;'].join('\n'),
       ),
     ).toEqual([]);
   });
@@ -117,6 +118,67 @@ describe('readMethodCallSites: statement position', () => {
     const [only] = readMethodCallSites('w.ts', src, 'Widget', 'update').sites;
     expect(only.line).toBe(4);
     expect(src.split('\n')[only.line - 1]).toContain('this.a();');
+  });
+});
+
+describe('readMethodCallSites: value slots', () => {
+  it('records a call the statement stores, not only one it makes for effect', () => {
+    // The hole that shipped in the first cut of this walk: `const musicState =
+    // this.instanceMusic.update({...})` in Hud.update() is a real drive, and a head-only
+    // walk saw nothing. So is `this.lastFoo = this.someWindow.render()`, which is how a
+    // repaint sneaks past a registry that only reads statement heads.
+    expect(callsIn('const music = this.music.update({ now: 1 });')).toEqual(['this.music.update']);
+    expect(callsIn('this.lastText = this.marker.mark(text);')).toEqual(['this.marker.mark']);
+    expect(callsIn('return this.win.render();')).toEqual(['this.win.render']);
+  });
+
+  it('records ONLY a call on `this` in a value slot', () => {
+    // A bare producer in a value slot is the same shape as an argument, which this walk
+    // already declines: registering `xpBarView({...})` and `zoneAt(z)` would bury the
+    // question the registry exists to answer under two dozen rows of formatters. A call on
+    // `this` in that same slot is the coordinator doing something, which IS the question.
+    expect(callsIn('const bar = xpBarView({ level: 1 });')).toEqual([]);
+    expect(callsIn('const zone = zoneAt(p.pos.z);')).toEqual([]);
+    expect(callsIn('const e = sim.entities.get(id);')).toEqual([]);
+    expect(callsIn('const t = this.fxTier();')).toEqual(['this.fxTier']);
+    // ...but a statement whose whole purpose IS the call is a side effect whatever its
+    // callee, so the effect slot keeps the wider rule.
+    expect(callsIn("document.body.classList.toggle('x', on);")).toEqual([
+      'document.body.classList.toggle',
+    ]);
+  });
+
+  it('adds a short-circuit or ternary test to the condition chain', () => {
+    // `&&` / `||` / `??` / `?:` decide WHETHER the call runs, exactly as an enclosing `if`
+    // does, so they belong in the chain rather than being flattened away. Without this,
+    // `open && this.win.render()` would register as an unconditional per-frame repaint.
+    expect(sitesIn('open && this.win.render();')[0].conditions).toEqual(['open']);
+    expect(sitesIn('cached || this.win.render();')[0].conditions).toEqual(['!(cached)']);
+    expect(sitesIn('const v = cached ?? this.win.render();')[0].conditions).toEqual([
+      'cached == null',
+    ]);
+    expect(sitesIn('if (slowHud) open && this.win.render();')[0].conditions).toEqual([
+      'slowHud',
+      'open',
+    ]);
+    const both = sitesIn('ok ? this.a() : this.b();');
+    expect(both.map((s) => [s.call, s.conditions])).toEqual([
+      ['this.a', ['ok']],
+      ['this.b', ['!(ok)']],
+    ]);
+  });
+
+  it('does not follow a call argument, a comparison operand, or a loop header', () => {
+    expect(callsIn('this.painter.paint(this.view.tick(x));')).toEqual(['this.painter.paint']);
+    expect(callsIn('const changed = this.sigOf(a) !== this.last;')).toEqual([]);
+    expect(callsIn('for (const e of this.sim.entities.values()) this.paint(e);')).toEqual([
+      'this.paint',
+    ]);
+    // An `if` header is not a gap: it is already pinned verbatim in the condition chain of
+    // everything it guards, so recording it again would double-count it.
+    expect(sitesIn('if (this.isOpen()) this.win.render();')).toEqual([
+      { call: 'this.win.render', line: 3, conditions: ['this.isOpen()'] },
+    ]);
   });
 });
 
@@ -274,7 +336,13 @@ describe('the fixture list covers every walker arm', () => {
       fileURLToPath(new URL('./method_call_sites.ts', import.meta.url)),
       'utf8',
     );
-    const guards = [...helper.matchAll(/ts\.is([A-Za-z]+)\(/g)].map((m) => `is${m[1]}`);
+    // Comments stripped FIRST: a doc comment that names a guard the walker deliberately
+    // does NOT call would otherwise demand a fixture for an arm that does not exist, and a
+    // guard mentioned only in prose would satisfy the pin with no arm behind it. This repo
+    // has shipped the un-stripped version of that pin before (#2499).
+    const guards = [...normalizeCondition(helper).matchAll(/ts\.is([A-Za-z]+)\(/g)].map(
+      (m) => `is${m[1]}`,
+    );
     expect(
       guards.length,
       'the walker stopped using ts.is* guards: re-derive this pin',

--- a/tests/helpers/method_call_sites.ts
+++ b/tests/helpers/method_call_sites.ts
@@ -1,0 +1,247 @@
+import ts from 'typescript';
+
+// The statement-level call walk a coordinator gate needs: given one TypeScript source
+// and the name of a method on a class inside it, return every call that method makes AT
+// STATEMENT POSITION, each tagged with the chain of `if` conditions that must hold for
+// it to run.
+//
+// It exists because #2498 asked a question no per-file source scan can answer: which
+// windows does `Hud.update()` actually drive, and how often? The cadence is not a
+// property of the window module, it is a property of the CALL SITE, and the call site
+// lives inside a 677-line method on a 742-member coordinator. A grep answers it wrong
+// in both directions: searching for `this.arenaWindow.render(` finds the call but not
+// the `if (mediumHud)` wrapping it, and it also finds the identical call inside
+// `openArena()`, which is an event handler and not a poll at all.
+//
+// THE UNIT IS A STATEMENT, NOT A LINE. Three distinctions carry the whole gate:
+//   - STATEMENT POSITION. `this.actionBarPainter.paint(this.actionBarView.tick(...))`
+//     is ONE drive, not two: the inner `tick` is an argument the painter consumes. A
+//     call inside a callback (`setTimeout(() => this.foo(), 8000)`) is not a drive of
+//     `update()` at all, it is a one-shot the callback owns, so the walk descends into
+//     statement containers and never into a function body.
+//   - THE CONDITION CHAIN, outermost first. `mediumHud` alone is the band; the
+//     `$('#arena-window').style.display === 'block'` nested inside it is the gate. The
+//     gate is the interesting half, and dropping either one loses the meaning.
+//   - THE `else` ARM, recorded as `!(cond)`. `update()` paints the target frame in the
+//     consequent and hides it in the alternate; a walk that merged the two would claim
+//     the frame is painted unconditionally.
+//
+// WHY THE COMPILER API AND NOT A HAND-ROLLED SCAN. The first cut of this module lexed
+// the file itself and got a working answer, and it was still the wrong instrument: it
+// had to guess regex-versus-division from the preceding token, because `src/ui/hud.ts`
+// holds about a hundred regex literals in its server-text matchers and several contain
+// an apostrophe or an escaped slash that desynchronize a naive walk. It also read 752
+// class members where the real count is 742, since a generic type argument's `;` reads
+// as a member break. Neither error is visible from a green test. `tests/
+// companion_read_api.test.ts` already parses a source file with `ts.createSourceFile`
+// and already climbs parents looking for the enclosing `if`, so the AST is this repo's
+// established answer for exactly this question and needs no new dependency.
+//
+// It takes a STRING rather than a path and knows nothing about `src/ui/hud.ts`, which
+// is what lets the paired test drive it over synthetic sources with planted shapes.
+// This repo's standing lesson about scan guards (#2499, #2502, #2497) is that a
+// producer which resolves its own input can only ever be proven against the tree it
+// already passes on.
+
+/** One statement-position call found inside a method body. */
+export interface CallSite {
+  /**
+   * The callee's member chain, written as the source writes it and rooted at whatever
+   * the statement starts with: `this.updateMinimap`, `this.spellbookWindow.tickOpen`,
+   * `document.getElementById().classList.toggle`. An intermediate call keeps its `()`
+   * so an element lookup stays distinguishable from the write made on its result; an
+   * index access becomes `[]`, and an optional `?.` link reads as a plain `.`, so the
+   * key does not move when a null check is added.
+   *
+   * Deliberately NOT restricted to `this`: `document.getElementById('x')?.classList
+   * .toggle(...)` is a raw write on the polled path just as much as a call on a field
+   * is, and a registry that only knew about `this` would hand a new repaint a free way
+   * out of the sweep.
+   */
+  readonly call: string;
+  /** 1-based line of the statement in the source file. */
+  readonly line: number;
+  /**
+   * The enclosing `if` conditions, OUTERMOST FIRST, each whitespace-normalized. An
+   * `else` arm carries its `if`'s condition wrapped as `!(cond)`. Empty means the call
+   * runs every time the method does.
+   */
+  readonly conditions: readonly string[];
+}
+
+/** What {@link readMethodCallSites} resolved out of one class method. */
+export interface MethodScan {
+  /** Every statement-position call in the method body, in source order. */
+  readonly sites: readonly CallSite[];
+  /** How many members the enclosing class declares (methods, fields, accessors). */
+  readonly classMembers: number;
+  /** Lines spanned by the method body, braces included. */
+  readonly bodyLines: number;
+  /** 1-based line the method's own declaration starts on. */
+  readonly declarationLine: number;
+}
+
+/**
+ * Reduce a condition to the ONE spelling every formatting of it shares.
+ *
+ * A registry pins these strings, so the normalization is load-bearing rather than
+ * cosmetic: biome at lineWidth 100 breaks a long condition across lines the moment it
+ * grows a character, and when it does it ALSO adds a trailing comma to the argument
+ * list it broke. A key that kept either would flip on a reformat, and a gate that flips
+ * on a reformat gets its expected value pasted over rather than read. So: comments go,
+ * whitespace runs collapse to one space, padding inside brackets goes, and a comma
+ * directly before a closing bracket goes with it.
+ */
+export function normalizeCondition(text: string): string {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1')
+    .replace(/\s+/g, ' ')
+    .replace(/([([])\s+/g, '$1')
+    .replace(/\s+([)\]])/g, '$1')
+    .replace(/\s+,/g, ',')
+    .replace(/,([)\]])/g, '$1')
+    .trim();
+}
+
+/**
+ * The callee's member chain, or `null` when the expression is not a plain member chain
+ * (a call on a parenthesized ternary, an `await`ed promise, a computed callee).
+ * Returning null rather than a best guess is deliberate: a registry keyed on a guessed
+ * name would silently pair the wrong row with the wrong call.
+ */
+function calleeChain(expr: ts.Expression, sf: ts.SourceFile): string | null {
+  if (ts.isIdentifier(expr)) return expr.text;
+  if (expr.kind === ts.SyntaxKind.ThisKeyword) return 'this';
+  if (ts.isPropertyAccessExpression(expr)) {
+    const head = calleeChain(expr.expression, sf);
+    return head === null ? null : `${head}.${expr.name.text}`;
+  }
+  if (ts.isElementAccessExpression(expr)) {
+    const head = calleeChain(expr.expression, sf);
+    return head === null ? null : `${head}[]`;
+  }
+  if (ts.isCallExpression(expr)) {
+    const head = calleeChain(expr.expression, sf);
+    return head === null ? null : `${head}()`;
+  }
+  if (ts.isNonNullExpression(expr) || ts.isParenthesizedExpression(expr)) {
+    return calleeChain(expr.expression, sf);
+  }
+  return null;
+}
+
+/** Unwrap the wrappers that can sit between a statement and the call it makes. */
+function callOf(expr: ts.Expression): ts.CallExpression | null {
+  if (ts.isCallExpression(expr)) return expr;
+  if (ts.isAwaitExpression(expr) || ts.isVoidExpression(expr)) return callOf(expr.expression);
+  return null;
+}
+
+interface Walk {
+  readonly sf: ts.SourceFile;
+  readonly out: CallSite[];
+}
+
+function lineOf(w: Walk, node: ts.Node): number {
+  return w.sf.getLineAndCharacterOfPosition(node.getStart(w.sf)).line + 1;
+}
+
+/**
+ * Visit ONE statement, carrying the conditions that guard it.
+ *
+ * Descends only through STATEMENT containers. A function or arrow body reached from an
+ * expression is a different cadence with a different owner, so it is deliberately out
+ * of reach here; a module that arms its own repeating driver is the painter gate's
+ * business (`FRAME_DRIVERS` in `tests/hud_perf_budget.test.ts`), not this walk's.
+ */
+function visitStatement(w: Walk, stmt: ts.Statement, conditions: readonly string[]): void {
+  if (ts.isBlock(stmt)) {
+    for (const inner of stmt.statements) visitStatement(w, inner, conditions);
+    return;
+  }
+  if (ts.isIfStatement(stmt)) {
+    const cond = normalizeCondition(stmt.expression.getText(w.sf));
+    visitStatement(w, stmt.thenStatement, [...conditions, cond]);
+    if (stmt.elseStatement) visitStatement(w, stmt.elseStatement, [...conditions, `!(${cond})`]);
+    return;
+  }
+  if (
+    ts.isForStatement(stmt) ||
+    ts.isForOfStatement(stmt) ||
+    ts.isForInStatement(stmt) ||
+    ts.isWhileStatement(stmt) ||
+    ts.isDoStatement(stmt) ||
+    ts.isLabeledStatement(stmt)
+  ) {
+    visitStatement(w, stmt.statement, conditions);
+    return;
+  }
+  if (ts.isTryStatement(stmt)) {
+    visitStatement(w, stmt.tryBlock, conditions);
+    if (stmt.catchClause) visitStatement(w, stmt.catchClause.block, conditions);
+    if (stmt.finallyBlock) visitStatement(w, stmt.finallyBlock, conditions);
+    return;
+  }
+  if (ts.isSwitchStatement(stmt)) {
+    for (const clause of stmt.caseBlock.clauses) {
+      for (const inner of clause.statements) visitStatement(w, inner, conditions);
+    }
+    return;
+  }
+  if (ts.isExpressionStatement(stmt)) {
+    const call = callOf(stmt.expression);
+    if (!call) return;
+    const chain = calleeChain(call.expression, w.sf);
+    if (chain === null) return;
+    w.out.push({ call: chain, line: lineOf(w, stmt), conditions: [...conditions] });
+  }
+}
+
+/**
+ * Scan `class <className>`'s `<methodName>` for its statement-position calls.
+ *
+ * Throws when the class or the method is absent. That is the point: the coordinator
+ * gate calling this exists because a future extraction could move `update()` behind a
+ * controller, and a resolver that returned an empty list for a missing method would
+ * hand that gate a clean, empty, passing scan. A rename must be a red test, never a
+ * quiet zero.
+ */
+export function readMethodCallSites(
+  fileName: string,
+  source: string,
+  className: string,
+  methodName: string,
+): MethodScan {
+  const sf = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const cls = sf.statements.find(
+    (s): s is ts.ClassDeclaration => ts.isClassDeclaration(s) && s.name?.text === className,
+  );
+  if (!cls) {
+    throw new Error(
+      `class ${className} not found in ${fileName}: it was renamed or moved. Re-point the guard at its new home rather than deleting the read.`,
+    );
+  }
+  const method = cls.members.find(
+    (m): m is ts.MethodDeclaration =>
+      ts.isMethodDeclaration(m) && m.name.getText(sf) === methodName,
+  );
+  if (!method) {
+    throw new Error(
+      `${className}.${methodName}() not found in ${fileName}: it was renamed or extracted. Re-point the guard at its new home rather than deleting the read.`,
+    );
+  }
+  if (!method.body) {
+    throw new Error(`${className}.${methodName}() has no body in ${fileName}`);
+  }
+  const w: Walk = { sf, out: [] };
+  for (const stmt of method.body.statements) visitStatement(w, stmt, []);
+  const bodyStart = sf.getLineAndCharacterOfPosition(method.body.getStart(sf)).line;
+  const bodyEnd = sf.getLineAndCharacterOfPosition(method.body.getEnd()).line;
+  return {
+    sites: w.out,
+    classMembers: cls.members.length,
+    bodyLines: bodyEnd - bodyStart + 1,
+    declarationLine: lineOf(w, method),
+  };
+}

--- a/tests/helpers/method_call_sites.ts
+++ b/tests/helpers/method_call_sites.ts
@@ -1,9 +1,8 @@
 import ts from 'typescript';
 
-// The statement-level call walk a coordinator gate needs: given one TypeScript source
-// and the name of a method on a class inside it, return every call that method makes AT
-// STATEMENT POSITION, each tagged with the chain of `if` conditions that must hold for
-// it to run.
+// The call walk a coordinator gate needs: given one TypeScript source and the name of a
+// method on a class inside it, return every call that method EVALUATES DIRECTLY, each
+// tagged with the chain of conditions that must hold for it to run.
 //
 // It exists because #2498 asked a question no per-file source scan can answer: which
 // windows does `Hud.update()` actually drive, and how often? The cadence is not a
@@ -13,15 +12,20 @@ import ts from 'typescript';
 // the `if (mediumHud)` wrapping it, and it also finds the identical call inside
 // `openArena()`, which is an event handler and not a poll at all.
 //
-// THE UNIT IS A STATEMENT, NOT A LINE. Three distinctions carry the whole gate:
-//   - STATEMENT POSITION. `this.actionBarPainter.paint(this.actionBarView.tick(...))`
-//     is ONE drive, not two: the inner `tick` is an argument the painter consumes. A
-//     call inside a callback (`setTimeout(() => this.foo(), 8000)`) is not a drive of
-//     `update()` at all, it is a one-shot the callback owns, so the walk descends into
-//     statement containers and never into a function body.
+// THE UNIT IS AN EVALUATED EXPRESSION, NOT A LINE. Three distinctions carry the gate:
+//   - WHAT THE STATEMENT EVALUATES, which is narrower than "every call in the method"
+//     and wider than "the statement head". `this.painter.paint(this.view.tick(...))` is
+//     ONE drive, not two: the inner `tick` is an argument the painter consumes. A call
+//     inside a callback (`setTimeout(() => this.foo(), 8000)`) is not a drive of
+//     `update()` at all, it is a one-shot the callback owns. But `const music =
+//     this.instanceMusic.update({...})` IS a drive, and the head-only version of this
+//     walk missed it, along with the `this.lastFoo = this.someWindow.render()` shape a
+//     repaint uses to sneak past a registry. See `visitExpression` for where the line
+//     falls and why a value slot admits only a call on `this`.
 //   - THE CONDITION CHAIN, outermost first. `mediumHud` alone is the band; the
 //     `$('#arena-window').style.display === 'block'` nested inside it is the gate. The
-//     gate is the interesting half, and dropping either one loses the meaning.
+//     gate is the interesting half, and dropping either one loses the meaning. `&&`,
+//     `||`, `??` and a ternary contribute their test the same way an `if` does.
 //   - THE `else` ARM, recorded as `!(cond)`. `update()` paints the target frame in the
 //     consequent and hides it in the alternate; a walk that merged the two would claim
 //     the frame is painted unconditionally.
@@ -131,13 +135,6 @@ function calleeChain(expr: ts.Expression, sf: ts.SourceFile): string | null {
   return null;
 }
 
-/** Unwrap the wrappers that can sit between a statement and the call it makes. */
-function callOf(expr: ts.Expression): ts.CallExpression | null {
-  if (ts.isCallExpression(expr)) return expr;
-  if (ts.isAwaitExpression(expr) || ts.isVoidExpression(expr)) return callOf(expr.expression);
-  return null;
-}
-
 interface Walk {
   readonly sf: ts.SourceFile;
   readonly out: CallSite[];
@@ -147,13 +144,119 @@ function lineOf(w: Walk, node: ts.Node): number {
   return w.sf.getLineAndCharacterOfPosition(node.getStart(w.sf)).line + 1;
 }
 
+/** The assignment operators, whose LEFT side is a write target rather than a call. */
+const ASSIGNMENT_OPS = new Set<ts.SyntaxKind>([
+  ts.SyntaxKind.EqualsToken,
+  ts.SyntaxKind.PlusEqualsToken,
+  ts.SyntaxKind.MinusEqualsToken,
+  ts.SyntaxKind.AsteriskEqualsToken,
+  ts.SyntaxKind.SlashEqualsToken,
+  ts.SyntaxKind.PercentEqualsToken,
+  ts.SyntaxKind.AmpersandAmpersandEqualsToken,
+  ts.SyntaxKind.BarBarEqualsToken,
+  ts.SyntaxKind.QuestionQuestionEqualsToken,
+]);
+
+/**
+ * Whether the expression IS the statement's purpose (`effect`) or produces a value the
+ * statement then stores (`value`): a declaration's initializer, an assignment's right side,
+ * a `return`/`throw` operand.
+ */
+type Slot = 'effect' | 'value';
+
+/**
+ * Visit one expression the statement evaluates, carrying the conditions guarding it.
+ *
+ * WHERE THE LINE IS, because "record every call in the method" and "record only the
+ * statement head" are both wrong.
+ *
+ * The walk follows the operators that decide WHETHER a call runs: `&&`, `||`, `??` and a
+ * ternary each contribute their test to the condition chain, exactly as an enclosing `if`
+ * does. It does NOT follow into a call's ARGUMENTS (`painter.paint(view.tick(x))` is one
+ * drive, not two: the tick produces the paint's input), nor into an operand of a comparison
+ * or arithmetic, nor into a function or arrow body (a different cadence with a different
+ * owner), nor into a control-flow HEADER. That last one is not a gap: an `if` or loop
+ * condition is already pinned verbatim in the condition chain of everything it guards, so
+ * recording it again would double-count it.
+ *
+ * IN A `value` SLOT ONLY A CALL ON `this` IS RECORDED, and the asymmetry is the point. A
+ * statement whose whole purpose is a call is a side effect whatever its callee, so it is
+ * recorded. A value slot is different: `const bar = xpBarView({...})` and `const zone =
+ * zoneAt(p.pos.z)` are pure producers, the same shape as the arguments this walk already
+ * declines, and registering them would bury the question the registry exists to answer under
+ * two dozen rows of formatters. `this.<anything>()` in that same slot is the coordinator
+ * doing something, which is exactly the question: `const music =
+ * this.instanceMusic.update({...})` is a real drive that a head-only walk missed, and
+ * `this.lastFoo = this.someWindow.render()` is how a repaint sneaks past one.
+ */
+function visitExpression(
+  w: Walk,
+  expr: ts.Expression,
+  conditions: readonly string[],
+  slot: Slot,
+): void {
+  if (
+    ts.isParenthesizedExpression(expr) ||
+    ts.isAwaitExpression(expr) ||
+    ts.isVoidExpression(expr) ||
+    ts.isNonNullExpression(expr) ||
+    ts.isAsExpression(expr) ||
+    ts.isSatisfiesExpression(expr)
+  ) {
+    visitExpression(w, expr.expression, conditions, slot);
+    return;
+  }
+  if (ts.isBinaryExpression(expr)) {
+    const op = expr.operatorToken.kind;
+    if (ASSIGNMENT_OPS.has(op)) {
+      visitExpression(w, expr.right, conditions, 'value');
+      return;
+    }
+    if (op === ts.SyntaxKind.CommaToken) {
+      visitExpression(w, expr.left, conditions, slot);
+      visitExpression(w, expr.right, conditions, slot);
+      return;
+    }
+    const test = normalizeCondition(expr.left.getText(w.sf));
+    if (op === ts.SyntaxKind.AmpersandAmpersandToken) {
+      visitExpression(w, expr.left, conditions, slot);
+      visitExpression(w, expr.right, [...conditions, test], slot);
+      return;
+    }
+    if (op === ts.SyntaxKind.BarBarToken) {
+      visitExpression(w, expr.left, conditions, slot);
+      visitExpression(w, expr.right, [...conditions, `!(${test})`], slot);
+      return;
+    }
+    if (op === ts.SyntaxKind.QuestionQuestionToken) {
+      visitExpression(w, expr.left, conditions, slot);
+      visitExpression(w, expr.right, [...conditions, `${test} == null`], slot);
+      return;
+    }
+    return;
+  }
+  if (ts.isConditionalExpression(expr)) {
+    const test = normalizeCondition(expr.condition.getText(w.sf));
+    visitExpression(w, expr.condition, conditions, 'value');
+    visitExpression(w, expr.whenTrue, [...conditions, test], slot);
+    visitExpression(w, expr.whenFalse, [...conditions, `!(${test})`], slot);
+    return;
+  }
+  if (!ts.isCallExpression(expr)) return;
+  const chain = calleeChain(expr.expression, w.sf);
+  if (chain === null) return;
+  if (slot === 'value' && chain !== 'this' && !chain.startsWith('this.')) return;
+  w.out.push({ call: chain, line: lineOf(w, expr), conditions: [...conditions] });
+}
+
 /**
  * Visit ONE statement, carrying the conditions that guard it.
  *
- * Descends only through STATEMENT containers. A function or arrow body reached from an
- * expression is a different cadence with a different owner, so it is deliberately out
- * of reach here; a module that arms its own repeating driver is the painter gate's
- * business (`FRAME_DRIVERS` in `tests/hud_perf_budget.test.ts`), not this walk's.
+ * Descends only through STATEMENT containers, then hands each value slot to
+ * {@link visitExpression}. A function or arrow body reached from an expression is a
+ * different cadence with a different owner, so it is deliberately out of reach here; a
+ * module that arms its own repeating driver is the painter gate's business
+ * (`FRAME_DRIVERS` in `tests/hud_perf_budget.test.ts`), not this walk's.
  */
 function visitStatement(w: Walk, stmt: ts.Statement, conditions: readonly string[]): void {
   if (ts.isBlock(stmt)) {
@@ -190,11 +293,17 @@ function visitStatement(w: Walk, stmt: ts.Statement, conditions: readonly string
     return;
   }
   if (ts.isExpressionStatement(stmt)) {
-    const call = callOf(stmt.expression);
-    if (!call) return;
-    const chain = calleeChain(call.expression, w.sf);
-    if (chain === null) return;
-    w.out.push({ call: chain, line: lineOf(w, stmt), conditions: [...conditions] });
+    visitExpression(w, stmt.expression, conditions, 'effect');
+    return;
+  }
+  if (ts.isVariableStatement(stmt)) {
+    for (const decl of stmt.declarationList.declarations) {
+      if (decl.initializer) visitExpression(w, decl.initializer, conditions, 'value');
+    }
+    return;
+  }
+  if ((ts.isReturnStatement(stmt) || ts.isThrowStatement(stmt)) && stmt.expression) {
+    visitExpression(w, stmt.expression, conditions, 'value');
   }
 }
 

--- a/tests/helpers/method_call_sites.ts
+++ b/tests/helpers/method_call_sites.ts
@@ -81,8 +81,6 @@ export interface MethodScan {
   readonly classMembers: number;
   /** Lines spanned by the method body, braces included. */
   readonly bodyLines: number;
-  /** 1-based line the method's own declaration starts on. */
-  readonly declarationLine: number;
 }
 
 /**
@@ -245,7 +243,7 @@ function visitExpression(
   if (!ts.isCallExpression(expr)) return;
   const chain = calleeChain(expr.expression, w.sf);
   if (chain === null) return;
-  if (slot === 'value' && chain !== 'this' && !chain.startsWith('this.')) return;
+  if (slot === 'value' && !chain.startsWith('this.')) return;
   w.out.push({ call: chain, line: lineOf(w, expr), conditions: [...conditions] });
 }
 
@@ -347,10 +345,5 @@ export function readMethodCallSites(
   for (const stmt of method.body.statements) visitStatement(w, stmt, []);
   const bodyStart = sf.getLineAndCharacterOfPosition(method.body.getStart(sf)).line;
   const bodyEnd = sf.getLineAndCharacterOfPosition(method.body.getEnd()).line;
-  return {
-    sites: w.out,
-    classMembers: cls.members.length,
-    bodyLines: bodyEnd - bodyStart + 1,
-    declarationLine: lineOf(w, method),
-  };
+  return { sites: w.out, classMembers: cls.members.length, bodyLines: bodyEnd - bodyStart + 1 };
 }

--- a/tests/hud_update_drive.test.ts
+++ b/tests/hud_update_drive.test.ts
@@ -1,0 +1,1421 @@
+// THE DRIVE REGISTRY for `Hud.update()` (#2498).
+//
+// WHAT QUESTION THIS ANSWERS, AND WHY THE PAINTER GATE CANNOT.
+// `tests/hud_perf_budget.test.ts` sorts every `src/ui` painter into a bucket, and its cold
+// bucket deliberately makes NO claim about cadence, because a per-module source scan cannot
+// see a driver that lives in the coordinator (#2497 recorded that gap and filed this issue as
+// the close). The premise a reader would assume is false in this tree: a `*_window.ts` is NOT
+// cold. `Hud.update()` polls about half of them. `spellbookWindow.tickOpen()` runs EVERY
+// FRAME while the window is open; arena / dungeon_finder / vale_cup / card_duel `render()` on
+// the 250 ms band behind only a display check; social / market / mailbox / bank / bags /
+// deeds / professions / calendar get `refreshIfChanged()` on the 500 ms band.
+//
+// The repo's intended pattern is POLL CHEAPLY, REBUILD ON A SIGNATURE CHANGE, and it works.
+// What was missing is that nothing said WHICH windows are on a poll, on which band, or behind
+// which guard. Drop a signature guard and a full `innerHTML` rebuild becomes a 4 Hz or
+// per-frame rebuild while every number in every gate holds. That is what this file fixes.
+//
+// WHAT IT IS. One hand-written table, `HUD_UPDATE_DRIVES`, with a row per distinct
+// (callee, band, gate) that `Hud.update()` drives, diffed BOTH WAYS against a TypeScript AST
+// walk of the real method. Adding a call to `update()` fails until it is registered; deleting
+// one fails until its row goes; moving one between bands fails; and changing the condition
+// that gates it fails, because the gate TEXT is part of the key.
+//
+// IT IS THE WHOLE BODY, NOT JUST THE WINDOWS, and that is deliberate. Scoping the table to
+// windows would repeat the mistake #2497 refused to ship (a declaration naming a handful of
+// windows when half the family qualifies reads as a complete classification and is not one),
+// and it would hand a new repaint a free way out: name it `syncFoo()` and it is not a window.
+// Every statement-position call is registered; the `surface` field is what answers the window
+// question. The cost is real and is the point: a new line in `update()` is now a diff line
+// here too.
+//
+// WHERE ITS TEETH STOP, stated rather than implied:
+//   - It sees `update()`'s OWN body. A repaint two hops down a `Hud` private method is named
+//     by the row for that method (`this.updateTradeWindow` says it rebuilds `#trade-window`),
+//     but the walk does not follow it, so a NEW repaint added inside an ALREADY-registered
+//     method is invisible here. The `surface` and `guard` fields are what a reviewer reads;
+//     the diff is what a machine enforces.
+//   - A `guard` proof is a source-text pin. It fails when the guard is DELETED, which is the
+//     criterion #2498 asked for, and it cannot tell a guard that was neutered while its field
+//     survived. The instrument for THAT is behavioral (render, poll unchanged, assert zero
+//     writes) and already exists per window in `tests/<window>.test.ts`; this table's job is
+//     to make a missing one visible, not to replace it.
+//   - Cadence here is the CALL SITE's band. A callee may throttle itself further (`meters`
+//     self-limits to 250 ms on a per-frame call), which the row's `why` records and no walk
+//     over `hud.ts` can check.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  type CallSite,
+  normalizeCondition,
+  readMethodCallSites,
+} from './helpers/method_call_sites';
+
+// --------------------------------------------------------------------------
+// The band split.
+// --------------------------------------------------------------------------
+
+/**
+ * The cadence latch that admits a call. `frame` means nothing in `update()` throttles it, so
+ * it runs at the render loop's rate; the other three are the dividers `update()` computes at
+ * its top (`fastHud` 100 ms, `mediumHud` 250 ms, `slowHud` 500 ms).
+ */
+type Band = 'frame' | 'fast' | 'medium' | 'slow';
+
+/** The divider variable each band is spelled with, in `src/ui/hud.ts`. */
+const BAND_TOKENS: ReadonlyArray<readonly [string, Band]> = [
+  ['fastHud', 'fast'],
+  ['mediumHud', 'medium'],
+  ['slowHud', 'slow'],
+];
+
+/** Split a condition on TOP-LEVEL ` && ` only, so a `&&` inside a call argument survives. */
+function splitTopLevelAnd(cond: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < cond.length; i++) {
+    const c = cond[i];
+    if (c === '(' || c === '[') depth++;
+    else if (c === ')' || c === ']') depth--;
+    else if (depth === 0 && c === '&' && cond[i + 1] === '&') {
+      parts.push(cond.slice(start, i).trim());
+      start = i + 2;
+      i++;
+    }
+  }
+  parts.push(cond.slice(start).trim());
+  return parts.filter((p) => p !== '');
+}
+
+/**
+ * Separate the cadence latch from the rest of the guard.
+ *
+ * The band token can share its condition with a real gate (`slowHud && this.bankWindow
+ * .isOpen`), so the token is removed from the condition that carries it and whatever remains
+ * joins the gate. A part holding a top-level `||` is parenthesized on the way in, because
+ * joining `!npc || dist2d(...) > 8` onto a preceding condition with a bare ` && ` would print
+ * a gate that reads as a different expression than the source it came from.
+ */
+function splitBand(conditions: readonly string[]): { band: Band; gate: string } {
+  let band: Band = 'frame';
+  const gateParts: string[] = [];
+  for (const cond of conditions) {
+    const hit = BAND_TOKENS.find(([token]) => new RegExp(`\\b${token}\\b`).test(cond));
+    if (!hit) {
+      gateParts.push(cond);
+      continue;
+    }
+    band = hit[1];
+    gateParts.push(...splitTopLevelAnd(cond).filter((part) => part !== hit[0]));
+  }
+  return {
+    band,
+    gate: gateParts
+      .map((p) => (p.includes('||') && !/^\(.*\)$/.test(p) ? `(${p})` : p))
+      .join(' && '),
+  };
+}
+
+/** The registry key: what the diff below compares in both directions. */
+const keyOf = (call: string, band: Band, gate: string): string => `${call}|${band}|${gate}`;
+
+// --------------------------------------------------------------------------
+// The registry.
+// --------------------------------------------------------------------------
+
+/**
+ * What the call repaints.
+ *
+ * `window` is the subject of #2498: a window, panel or popup container, whether the row
+ * repaints it, opens it or closes it. `chrome` is always-on HUD furniture (unit frames, bars,
+ * trackers, badges, banners, canvases, live regions), whose write contract belongs to the
+ * painter gate. `none` makes no DOM write on this path (state sync, audio, logic).
+ */
+type Surface = 'window' | 'chrome' | 'none';
+
+/**
+ * What stops a repeated poll from rebuilding.
+ *
+ * `module` and `hud` both carry a `proof`: the source line the guard is spelled on, matched
+ * whitespace-normalized against the comment-stripped module, so DELETING the guard fails this
+ * gate and reformatting it does not. `callsite` means the row's own `gate` is the whole guard.
+ * `none` is the honest record that there is not one, and it must say why.
+ */
+type Guard =
+  | { readonly kind: 'module'; readonly module: string; readonly proof: string }
+  | { readonly kind: 'hud'; readonly proof: string }
+  | { readonly kind: 'callsite' }
+  | { readonly kind: 'none'; readonly why: string };
+
+interface DriveRow {
+  /** The callee chain exactly as the AST walk reports it. */
+  readonly call: string;
+  readonly band: Band;
+  /** Every enclosing condition except the band token, outermost first. */
+  readonly gate: string;
+  /** How many statement sites share this exact key. Omitted means one. */
+  readonly sites?: number;
+  readonly surface: Surface;
+  /** Required for `surface: 'window'`, forbidden otherwise, so it cannot rot into decoration. */
+  readonly guard?: Guard;
+  /** What it repaints, in one line. */
+  readonly why: string;
+}
+
+const SIG_RETURN = 'if (sig === this.lastSig) return;';
+const VIEW_SIG_RETURN = 'if (view.sig === this.lastSig) return;';
+const VIEW_SIG_BLOCK = 'if (view.sig !== this.lastSig) {';
+
+/**
+ * Every statement-position call `Hud.update()` makes, in SOURCE ORDER, so the table reads as
+ * the method reads. Hand-written on purpose: deriving it from the walk would make the diff a
+ * tautology that can never fail.
+ */
+const HUD_UPDATE_DRIVES: readonly DriveRow[] = [
+  {
+    call: 'this.reconcileSfx',
+    band: 'fast',
+    gate: '',
+    surface: 'none',
+    why: 'prunes the mob-aggro and cast SFX bookkeeping sets; no DOM',
+  },
+  {
+    call: 'this.sweepMobIdleBarks',
+    band: 'frame',
+    gate: 'now - this.lastIdleSweepAt >= MOB_IDLE_CHECK_INTERVAL_MS',
+    surface: 'none',
+    why: 'idle bark audio on its own interval latch; no DOM',
+  },
+  {
+    call: 'this.combatAnnouncer.flush',
+    band: 'fast',
+    gate: '',
+    surface: 'chrome',
+    why: 'drains the trailing combat burst into the polite live region',
+  },
+  {
+    call: 'this.chatAnnouncer.flush',
+    band: 'fast',
+    gate: '',
+    surface: 'chrome',
+    why: 'drains the trailing chat burst into the tab-independent live region',
+  },
+  {
+    call: 'this.questDialog.updateVoice',
+    band: 'frame',
+    gate: '',
+    surface: 'none',
+    why: 'sets the gossip voice distance; audio only, no DOM',
+  },
+  {
+    call: 'this.meters.update',
+    band: 'frame',
+    gate: '',
+    surface: 'window',
+    guard: {
+      kind: 'module',
+      module: 'meters.ts',
+      proof: 'if (!this.isOpen || now - this.lastRender < 250) return;',
+    },
+    why: 'the damage/healing meters window; called per frame and self-limits to 250 ms',
+  },
+  {
+    call: 'this.lockpickController.repaintIfChanged',
+    band: 'frame',
+    gate: '',
+    surface: 'window',
+    guard: {
+      kind: 'module',
+      module: 'hud/delve/lockpick_window.ts',
+      proof: 'if (lockpickRenderSig(view) !== this.lastSig) this.renderBoard();',
+    },
+    why: 'the delve lockpick panel; a per-frame safety net behind a display check and a sig diff',
+  },
+  {
+    call: 'this.tutorial.update',
+    band: 'frame',
+    gate: '',
+    surface: 'chrome',
+    why: 'the tutorial hint overlay',
+  },
+  {
+    call: 'this.lootRolls.update',
+    band: 'frame',
+    gate: '',
+    surface: 'window',
+    guard: {
+      kind: 'none',
+      why: 'reconciles the live roll set and ticks their timers with no signature latch; cheap only because the roll maps are empty outside a group loot window',
+    },
+    why: 'the need/greed roll popups',
+  },
+  {
+    call: 'this.updateRaidLockoutBadge',
+    band: 'slow',
+    gate: '',
+    surface: 'chrome',
+    why: 'the minimap raid-lockout badge class, value-diffed',
+  },
+  {
+    call: 'this.refreshDailyRewardsLauncher',
+    band: 'slow',
+    gate: '',
+    surface: 'chrome',
+    why: 'the daily-rewards launcher button state (not the window)',
+  },
+  {
+    call: 'this.maybeRestoreActionBarLayout',
+    band: 'frame',
+    gate: '',
+    surface: 'none',
+    why: 'one-shot latch that reloads the saved action-bar layout once',
+  },
+  {
+    call: 'this.syncActiveHotbarForm',
+    band: 'frame',
+    gate: '',
+    surface: 'none',
+    why: 'action-bar controller state sync; no DOM',
+  },
+  {
+    call: 'this.syncSlotMap',
+    band: 'frame',
+    gate: '',
+    surface: 'none',
+    why: 'picks up newly learned abilities mid-session; no DOM',
+  },
+  {
+    call: 'document.getElementById().classList.toggle',
+    band: 'frame',
+    gate: '',
+    sites: 2,
+    surface: 'chrome',
+    why: 'the unspent-talent-points glow on the desktop and mobile talent buttons',
+  },
+  {
+    call: 'this.renderTownFocus',
+    band: 'slow',
+    gate: 'this.townFocusOpen',
+    surface: 'window',
+    guard: {
+      kind: 'none',
+      why: 'the standing exception (#2500): the open check is the whole gate, so the window rebuilds its DOM twice a second and restores scrollTop but not keyboard focus',
+    },
+    why: 'a full rebuild of the Town Focus window',
+  },
+  {
+    call: 'this.renderCrafting',
+    band: 'slow',
+    gate: "$('#crafting-window').style.display === 'flex' && stationTypesSignature(inRangeStationTypes(sim.stationPlacements, sim.player.pos, sim.activeMobileStationCraft)) !== this.lastCraftingStationSig",
+    surface: 'window',
+    guard: { kind: 'callsite' },
+    why: 'rebuilds the crafting window when the in-range station-type set changes',
+  },
+  {
+    call: 'this.refreshOpenCraftingIfReagentsChanged',
+    band: 'slow',
+    gate: '',
+    surface: 'window',
+    guard: {
+      kind: 'hud',
+      proof:
+        'if (craftingReagentSig(this.sim.inventory, this.sim.player.name) === this.lastCraftingReagentSig) return;',
+    },
+    why: 'the other half of the Craft gate: rebuilds the crafting window when the bags move',
+  },
+  {
+    call: 'this.playerFramePainter.paint',
+    band: 'frame',
+    gate: '',
+    surface: 'chrome',
+    why: 'the player unit frame, facet-routed',
+  },
+  {
+    call: 'this.updateLowHealthVignette',
+    band: 'frame',
+    gate: '',
+    surface: 'chrome',
+    why: 'the low-health vignette class and its two custom properties, through the elided writers',
+  },
+  {
+    call: 'this.updateLowResource',
+    band: 'frame',
+    gate: '',
+    surface: 'chrome',
+    why: 'the low-resource pulse on the player resource bar',
+  },
+  {
+    call: 'this.setDisplay',
+    band: 'frame',
+    gate: "p.resourceType === 'energy'",
+    surface: 'chrome',
+    why: 'shows the combo-point row for energy users, through the elided writer',
+  },
+  {
+    call: 'this.comboRowEl.appendChild',
+    band: 'frame',
+    gate: "p.resourceType === 'energy' && this.comboRowEl.children.length !== COMBO_PIP_COUNT",
+    surface: 'chrome',
+    why: 'lazily builds the combo pips ONCE; the child-count check is the one-shot latch',
+  },
+  {
+    call: 'this.toggleClass',
+    band: 'frame',
+    gate: "p.resourceType === 'energy'",
+    surface: 'chrome',
+    why: 'lights each combo pip, through the elided writer',
+  },
+  {
+    call: 'this.setDisplay',
+    band: 'frame',
+    gate: "!(p.resourceType === 'energy')",
+    surface: 'chrome',
+    why: 'hides the combo-point row for every other resource type',
+  },
+  {
+    call: 'this.buffBarPainter.paint',
+    band: 'frame',
+    gate: 'cadenceDue(this.lastBuffBarPaintAt, now, auraRefreshIntervalMs(fxTier))',
+    surface: 'chrome',
+    why: 'the buff row, tier-coarsened (full tiers every frame, low ~4 Hz)',
+  },
+  {
+    call: 'this.debuffBarPainter.paint',
+    band: 'frame',
+    gate: 'cadenceDue(this.lastBuffBarPaintAt, now, auraRefreshIntervalMs(fxTier))',
+    surface: 'chrome',
+    why: 'the debuff row, on the same latch as the buff row',
+  },
+  {
+    call: 'this.targetFramePainter.paint',
+    band: 'frame',
+    gate: "target && target.kind !== 'object' && nonSelfRepaintDue(targetChanged, this.lastTargetFramePaintAt, now, targetFrameNonSelfIntervalMs(fxTier))",
+    surface: 'chrome',
+    why: 'the target unit frame; a target swap bypasses the non-self throttle',
+  },
+  {
+    call: 'this.toggleClass',
+    band: 'frame',
+    gate: "target && target.kind !== 'object'",
+    sites: 3,
+    surface: 'chrome',
+    why: 'the target elite class, the boss class, and the forced-colors hostile cue',
+  },
+  {
+    call: 'this.setText',
+    band: 'frame',
+    gate: "target && target.kind !== 'object'",
+    surface: 'chrome',
+    why: 'the target elite/boss tag text',
+  },
+  {
+    call: 'this.setStyleProp',
+    band: 'frame',
+    gate: "target && target.kind !== 'object'",
+    surface: 'chrome',
+    why: 'the target name color (staff role, else hostile/friendly)',
+  },
+  {
+    call: 'this.updateTargetDiscordLine',
+    band: 'frame',
+    gate: "target && target.kind !== 'object'",
+    surface: 'chrome',
+    why: 'the Discord nickname/rank/role line under the target healthbar, signature-gated',
+  },
+  {
+    call: 'this.targetDebuffsPainter.paint',
+    band: 'frame',
+    gate: "target && target.kind !== 'object' && nonSelfRepaintDue(targetChanged, this.lastTargetDebuffsPaintAt, now, auraRefreshIntervalMs(fxTier))",
+    surface: 'chrome',
+    why: 'the target debuff strip, tier-coarsened, swap-bypassed',
+  },
+  {
+    call: 'this.targetCastBarPainter.paint',
+    band: 'frame',
+    gate: "target && target.kind !== 'object'",
+    surface: 'chrome',
+    why: 'the target/boss cast bar (a raid mechanic indicator, deliberately untiered)',
+  },
+  {
+    call: 'this.totFramePainter.paint',
+    band: 'frame',
+    gate: "target && target.kind !== 'object' && tot && tot.kind !== 'object' && nonSelfRepaintDue(totChanged, this.lastTotFramePaintAt, now, targetFrameNonSelfIntervalMs(fxTier))",
+    surface: 'chrome',
+    why: 'the target-of-target mini frame',
+  },
+  {
+    call: 'this.totFramePainter.paint',
+    band: 'frame',
+    gate: "target && target.kind !== 'object' && !(tot && tot.kind !== 'object')",
+    surface: 'chrome',
+    why: 'hides the target-of-target frame and resets its portrait gate',
+  },
+  {
+    call: 'this.targetReannounce.reset',
+    band: 'frame',
+    gate: "!(target && target.kind !== 'object') && this.lastAnnouncedTargetId !== null",
+    surface: 'none',
+    why: 'clears the re-announce marker on the no-target EDGE; the tracker keeps it off the per-frame path',
+  },
+  {
+    call: 'this.targetFramePainter.paint',
+    band: 'frame',
+    gate: "!(target && target.kind !== 'object')",
+    surface: 'chrome',
+    why: 'hides the target frame when there is no target',
+  },
+  {
+    call: 'this.totFramePainter.paint',
+    band: 'frame',
+    gate: "!(target && target.kind !== 'object')",
+    surface: 'chrome',
+    why: 'hides the target-of-target frame when there is no target',
+  },
+  {
+    call: 'this.playerCastBarPainter.paint',
+    band: 'frame',
+    gate: '',
+    surface: 'chrome',
+    why: 'the player cast bar plus the eat/drink overlay',
+  },
+  {
+    call: 'this.swingTimerPainter.paint',
+    band: 'frame',
+    gate: '',
+    surface: 'chrome',
+    why: 'the auto-attack swing timer',
+  },
+  {
+    call: 'this.procOverlayEl.classList.add',
+    band: 'frame',
+    gate: "!this.procOverlayPreviewed && this.sim.talentSpec === 'fire'",
+    surface: 'chrome',
+    why: 'the one-shot login preview of the proc bird; the latch field is the guard',
+  },
+  {
+    call: 'window.setTimeout',
+    band: 'frame',
+    gate: "!this.procOverlayPreviewed && this.sim.talentSpec === 'fire'",
+    surface: 'chrome',
+    why: 'clears that preview after 8 s; a one-shot behind the same latch, not a repeating driver',
+  },
+  {
+    call: 'this.procOverlayPainter.paintChronoCharges',
+    band: 'frame',
+    gate: "this.sim.talentSpec === 'arcane'",
+    surface: 'chrome',
+    why: 'the proc overlay driven by Aether Surge charges',
+  },
+  {
+    call: 'this.procOverlayPainter.paintFrostCharges',
+    band: 'frame',
+    gate: "!(this.sim.talentSpec === 'arcane') && this.sim.talentSpec === 'frost'",
+    surface: 'chrome',
+    why: 'the frost arm of the same overlay',
+  },
+  {
+    call: 'this.procOverlayPainter.paint',
+    band: 'frame',
+    gate: "!(this.sim.talentSpec === 'arcane') && !(this.sim.talentSpec === 'frost')",
+    surface: 'chrome',
+    why: 'the Heating Up / Hot Streak arm, the default for every other spec',
+  },
+  {
+    call: 'this.renderPetBar',
+    band: 'frame',
+    gate: '',
+    surface: 'chrome',
+    why: 'the pet bar; rebuilds its buttons behind a signature latch',
+  },
+  {
+    call: 'this.renderStanceBar',
+    band: 'frame',
+    gate: '',
+    surface: 'chrome',
+    why: 'the stance/form bar; rebuilds its buttons behind a signature latch',
+  },
+  {
+    call: 'this.flushPendingProcAuraNotes',
+    band: 'frame',
+    gate: '',
+    surface: 'chrome',
+    why: 'drains queued proc self-notes; early-outs on an empty set',
+  },
+  {
+    call: 'this.spellbookWindow.tickOpen',
+    band: 'frame',
+    gate: 'this.spellbookWindow.isOpen',
+    surface: 'window',
+    guard: {
+      kind: 'module',
+      module: 'spellbook_window.ts',
+      proof: 'if (SpellbookWindow.knownSig(this.deps.world().known) !== this.lastKnownSig) {',
+    },
+    why: 'the ONLY window on the per-frame band; the sig gates the rebuild, the fall-through hotbar-control refresh runs every frame',
+  },
+  {
+    call: 'this.actionBarPainter.paint',
+    band: 'frame',
+    gate: '',
+    surface: 'chrome',
+    why: 'the desktop action bar, facet-routed',
+  },
+  {
+    call: 'this.mobileActionRingPainter.paint',
+    band: 'frame',
+    gate: 'this.isMobileLayout() && this.mobileActionRingView && this.mobileActionRingPainter',
+    surface: 'chrome',
+    why: 'the touch action ring; desktop skips the tick and the paint entirely',
+  },
+  {
+    call: 'this.consumableBarPainter.paint',
+    band: 'frame',
+    gate: 'this.isMobileLayout() && this.consumablesOpen && this.consumableBarView && this.consumableBarPainter',
+    surface: 'chrome',
+    why: 'the touch consumables quick bar, only while the row is expanded',
+  },
+  {
+    call: 'this.xpBarPainter.paint',
+    band: 'frame',
+    gate: '',
+    surface: 'chrome',
+    why: 'the XP bar, including the max-level overflow styling',
+  },
+  {
+    call: 'this.fctPainter.step',
+    band: 'frame',
+    gate: '',
+    surface: 'chrome',
+    why: 'TTL-recycles the floating-combat-text pool; returns immediately when empty',
+  },
+  {
+    call: 'this.closeResurrectionPrompt',
+    band: 'frame',
+    gate: '!p.dead',
+    surface: 'chrome',
+    why: 'removes the resurrection prompt node once the player is alive',
+  },
+  {
+    call: 'document.body.classList.toggle',
+    band: 'frame',
+    gate: '',
+    surface: 'chrome',
+    why: 'the spirit-mode body class that drains the world to greyscale',
+  },
+  {
+    call: 'this.setDisplay',
+    band: 'frame',
+    gate: '',
+    surface: 'chrome',
+    why: 'the full-screen death overlay, through the elided writer',
+  },
+  {
+    call: 'this.setDisplay',
+    band: 'frame',
+    gate: 'ghost',
+    sites: 3,
+    surface: 'chrome',
+    why: 'the ghost prompt and its two resurrect buttons',
+  },
+  {
+    call: 'this.setDisplay',
+    band: 'frame',
+    gate: '!(ghost)',
+    surface: 'chrome',
+    why: 'hides the ghost prompt while not a ghost',
+  },
+  {
+    call: 'this.showBanner',
+    band: 'medium',
+    gate: "!inDungeon && currentZone.id !== this.lastZoneId && pastDeadBand && this.lastZoneId !== ''",
+    surface: 'chrome',
+    why: 'the zone banner on a real zone crossing; the dead-band stops border straddling from re-firing it',
+  },
+  {
+    call: 'this.log',
+    band: 'medium',
+    gate: "!inDungeon && currentZone.id !== this.lastZoneId && pastDeadBand && this.lastZoneId !== ''",
+    surface: 'chrome',
+    why: 'the zone-entry chat line',
+  },
+  {
+    call: 'this.logZoneWelcome',
+    band: 'medium',
+    gate: "!inDungeon && currentZone.id !== this.lastZoneId && pastDeadBand && this.lastZoneId !== ''",
+    surface: 'chrome',
+    why: 'the zone welcome blurb in chat',
+  },
+  {
+    call: 'this.renderer.vistaPan',
+    band: 'medium',
+    gate: "!inDungeon && currentZone.id !== this.lastZoneId && pastDeadBand && this.lastZoneId !== '' && !p.dead && !p.inCombat && !recentCombat",
+    surface: 'none',
+    why: 'the zone-entry camera sweep; a renderer call, not a HUD write',
+  },
+  {
+    call: 'this.prewarmMapBg',
+    band: 'medium',
+    gate: '!inDungeon && currentZone.id !== this.lastZoneId && pastDeadBand',
+    surface: 'none',
+    why: 'idle-schedules the new zone map background into an offscreen canvas',
+  },
+  {
+    call: 'this.showSubzone',
+    band: 'medium',
+    gate: 'subzone !== this.lastSubzone && subzone',
+    surface: 'chrome',
+    why: 'the subzone banner on a landmark crossing',
+  },
+  {
+    call: 'this.toggleClass',
+    band: 'medium',
+    gate: '',
+    surface: 'chrome',
+    why: 'the combat swords/ring on the player portrait, through the elided writer',
+  },
+  {
+    call: 'restEl.classList.toggle',
+    band: 'medium',
+    gate: 'rest.resting !== this.lastResting',
+    surface: 'chrome',
+    why: 'the resting zZz on the player portrait, behind an edge latch',
+  },
+  {
+    call: 'this.updateQuestTracker',
+    band: 'medium',
+    gate: '',
+    surface: 'chrome',
+    why: 'the quest tracker, rebuilt behind an html diff',
+  },
+  {
+    call: 'this.updateDelveTracker',
+    band: 'medium',
+    gate: '',
+    surface: 'chrome',
+    why: 'the delve tracker',
+  },
+  {
+    call: 'this.updatePartyFrames',
+    band: 'medium',
+    gate: '',
+    surface: 'window',
+    guard: { kind: 'hud', proof: 'if (sig !== this.lastLootSettingsSig) {' },
+    why: 'the party frames (a pooled painter) AND, via paintLootSettings, the loot-settings window',
+  },
+  {
+    call: 'this.updateTradeWindow',
+    band: 'medium',
+    gate: '',
+    surface: 'window',
+    guard: { kind: 'hud', proof: 'if (sig === this.lastTradeSig) return;' },
+    why: 'the trade window, rebuilt on a signature change; also auto-opens it on a trade start',
+  },
+  {
+    call: 'this.updateArenaStatus',
+    band: 'medium',
+    gate: '',
+    surface: 'chrome',
+    why: 'the arena status banner, signature-gated',
+  },
+  {
+    call: 'this.updateFiestaHud',
+    band: 'medium',
+    gate: '',
+    surface: 'chrome',
+    why: 'the fiesta score, respawn, offer and augment overlays',
+  },
+  {
+    call: 'this.yumiPainter.update',
+    band: 'medium',
+    gate: '',
+    surface: 'chrome',
+    why: 'the arena match strip, facet-routed',
+  },
+  {
+    call: 'this.vcupIndicator.update',
+    band: 'medium',
+    gate: '',
+    surface: 'chrome',
+    why: 'the Vale Cup minimap indicator button',
+  },
+  {
+    call: 'this.vcupMatchHud.update',
+    band: 'medium',
+    gate: '',
+    surface: 'chrome',
+    why: 'the Vale Cup in-match strip',
+  },
+  {
+    call: 'this.vcupBriefing.update',
+    band: 'medium',
+    gate: '',
+    surface: 'window',
+    guard: { kind: 'module', module: 'vale_cup_briefing.ts', proof: VIEW_SIG_BLOCK },
+    why: 'the Vale Cup briefing card, a self-mounting full-screen panel',
+  },
+  {
+    call: 'this.vcupBetting.update',
+    band: 'medium',
+    gate: '',
+    surface: 'window',
+    guard: { kind: 'module', module: 'vale_cup_betting.ts', proof: VIEW_SIG_BLOCK },
+    why: 'the Vale Cup betting banner and card',
+  },
+  {
+    call: 'this.updateShootCharge',
+    band: 'medium',
+    gate: '',
+    surface: 'chrome',
+    why: 'the Vale Cup shot-charge meter',
+  },
+  {
+    call: 'this.updateMapWindow',
+    band: 'medium',
+    gate: "$('#map-window').style.display === 'block'",
+    surface: 'window',
+    guard: {
+      kind: 'none',
+      why: 'the open check is the whole gate: the map canvas is re-stroked 4x/sec while the window is open, which is a canvas redraw rather than a DOM rebuild and is why it has never needed one',
+    },
+    why: 'repaints the map window canvas and its summary line',
+  },
+  {
+    call: 'this.arenaWindow.render',
+    band: 'medium',
+    gate: "$('#arena-window').style.display === 'block'",
+    surface: 'window',
+    guard: { kind: 'module', module: 'arena_window.ts', proof: VIEW_SIG_RETURN },
+    why: 'the arena queue window',
+  },
+  {
+    call: 'this.dungeonFinderWindow.render',
+    band: 'medium',
+    gate: "$('#dungeon-finder-window').style.display === 'flex'",
+    surface: 'window',
+    guard: {
+      kind: 'module',
+      module: 'dungeon_finder_window.ts',
+      proof: 'if (sig === this.lastSig) {',
+    },
+    why: 'the dungeon finder window; an unchanged sig still ticks its 1 Hz clock text',
+  },
+  {
+    call: 'this.dungeonFinderProposalPopup.render',
+    band: 'medium',
+    gate: 'this.dungeonFinderProposalPopup.isOpen',
+    surface: 'window',
+    guard: {
+      kind: 'module',
+      module: 'dungeon_finder_proposal_popup.ts',
+      proof: VIEW_SIG_BLOCK,
+    },
+    why: 'the ready-check popup; a bare-named module the painter gate does not sweep',
+  },
+  {
+    call: 'this.valeCupWindow.render',
+    band: 'medium',
+    gate: "$('#valecup-window').style.display === 'block'",
+    surface: 'window',
+    guard: { kind: 'module', module: 'vale_cup_window.ts', proof: VIEW_SIG_RETURN },
+    why: 'the Vale Cup queue window',
+  },
+  {
+    call: 'this.cardDuelWindow.toggle',
+    band: 'medium',
+    gate: 'cardDuelInMatch && !this.cardDuelWasInMatch && !this.cardDuelWindow.isOpen',
+    surface: 'window',
+    guard: { kind: 'callsite' },
+    why: 'auto-opens the card duel window on the false->true match edge',
+  },
+  {
+    call: 'this.cardDuelWindow.render',
+    band: 'medium',
+    gate: "$('#card-duel-window').style.display === 'block'",
+    surface: 'window',
+    guard: { kind: 'module', module: 'card_duel_window.ts', proof: SIG_RETURN },
+    why: 'the card duel window',
+  },
+  {
+    call: 'this.lootWindow.updateProximity',
+    band: 'medium',
+    gate: '',
+    surface: 'window',
+    guard: {
+      kind: 'none',
+      why: 'no latch field: it is close-only, gated on a non-null corpse/chest id plus a range test, and nulling the id disarms it',
+    },
+    why: 'closes the loot window when the player walks away from the corpse or chest',
+  },
+  {
+    call: 'this.closeVendor',
+    band: 'medium',
+    gate: 'this.openVendorNpcId !== null && (!npc || dist2d(p.pos, npc.pos) > 8)',
+    surface: 'window',
+    guard: { kind: 'callsite' },
+    why: 'closes the vendor window out of range',
+  },
+  {
+    call: 'this.closeHeroicVendor',
+    band: 'medium',
+    gate: 'this.openHeroicVendorNpcId !== null && (!npc || dist2d(p.pos, npc.pos) > 8)',
+    surface: 'window',
+    guard: { kind: 'callsite' },
+    why: 'closes the heroic vendor window out of range',
+  },
+  {
+    call: 'this.closeTrain',
+    band: 'medium',
+    gate: 'this.openTrainNpcId !== null && (!npc || dist2d(p.pos, npc.pos) > 8)',
+    surface: 'window',
+    guard: { kind: 'callsite' },
+    why: 'closes the trainer window out of range',
+  },
+  {
+    call: 'this.closeUnbind',
+    band: 'medium',
+    gate: 'this.openUnbindNpcId !== null && (!npc || dist2d(p.pos, npc.pos) > 8)',
+    surface: 'window',
+    guard: { kind: 'callsite' },
+    why: 'closes the unbind window out of range',
+  },
+  {
+    call: 'this.questDialog.updateProximity',
+    band: 'medium',
+    gate: '',
+    surface: 'window',
+    guard: {
+      kind: 'none',
+      why: 'no latch field: close-only, gated on a non-null npc id plus a range test',
+    },
+    why: 'closes the gossip dialog when the player walks away from the NPC',
+  },
+  {
+    call: 'this.arenaWindow.close',
+    band: 'frame',
+    gate: "inArenaMatch && !this.arenaMatchSeen && $('#arena-window').style.display === 'block'",
+    surface: 'window',
+    guard: { kind: 'callsite' },
+    why: 'gets the arena queue window out of the way when a bout starts; the seen latch makes it an edge',
+  },
+  {
+    call: 'this.valeCupWindow.close',
+    band: 'frame',
+    gate: "inVcupMatch && !this.vcupMatchSeen && $('#valecup-window').style.display === 'block'",
+    surface: 'window',
+    guard: { kind: 'callsite' },
+    why: 'the same edge close for the Vale Cup queue window',
+  },
+  {
+    call: 'this.updateMinimap',
+    band: 'fast',
+    gate: 'cadenceDue(this.lastMinimapDrawAt, now, minimapRedrawIntervalMs(fxTier))',
+    surface: 'chrome',
+    why: 'the minimap canvas redraw, the heaviest fast-band item, tier-coarsened',
+  },
+  {
+    call: 'this.updateClock',
+    band: 'fast',
+    gate: '',
+    surface: 'chrome',
+    why: 'the minimap clock text, value-diffed',
+  },
+  {
+    call: 'this.updateMinimapCoords',
+    band: 'fast',
+    gate: '',
+    surface: 'chrome',
+    why: 'the minimap coordinate readout, value-diffed',
+  },
+  {
+    call: 'this.updateCompass',
+    band: 'fast',
+    gate: '',
+    surface: 'chrome',
+    why: 'the compass marks and heading; early-outs on an unchanged facing',
+  },
+  {
+    call: 'this.socialWindow.refreshIfChanged',
+    band: 'slow',
+    gate: '',
+    surface: 'window',
+    guard: {
+      kind: 'module',
+      module: 'social_window.ts',
+      proof: 'if (struct !== this.lastStruct) {',
+    },
+    why: 'the social window; a struct change rebuilds, a content change refreshes the list only',
+  },
+  {
+    call: 'this.marketWindow.close',
+    band: 'slow',
+    gate: 'this.marketWindow.isOpen && !this.nearbyMarketNpc()',
+    surface: 'window',
+    guard: { kind: 'callsite' },
+    why: 'closes the market window when the player leaves the auctioneer',
+  },
+  {
+    call: 'this.marketWindow.refreshIfChanged',
+    band: 'slow',
+    gate: 'this.marketWindow.isOpen && !(!this.nearbyMarketNpc())',
+    surface: 'window',
+    guard: { kind: 'module', module: 'market_window.ts', proof: SIG_RETURN },
+    why: 'the market window',
+  },
+  {
+    call: 'this.mailboxWindow.refreshIfChanged',
+    band: 'slow',
+    gate: 'this.mailboxWindow.isOpen',
+    surface: 'window',
+    guard: { kind: 'module', module: 'mailbox_window.ts', proof: SIG_RETURN },
+    why: 'the mailbox window; it also closes itself when the mail mirror goes null',
+  },
+  {
+    call: 'this.bankWindow.refreshIfChanged',
+    band: 'slow',
+    gate: 'this.bankWindow.isOpen',
+    surface: 'window',
+    guard: { kind: 'module', module: 'bank_window.ts', proof: SIG_RETURN },
+    why: 'the bank window; it also closes itself when the bank mirror goes null',
+  },
+  {
+    call: 'this.bagsWindow.refreshIfChanged',
+    band: 'slow',
+    gate: '',
+    surface: 'window',
+    guard: {
+      kind: 'module',
+      module: 'bags_window.ts',
+      proof:
+        'if (!bagsMoneyRowStale(el.style.display, this.deps.world().copper, this.lastMoneyCopper)) return;',
+    },
+    why: 'DELIBERATELY has no isOpen gate: the money-footer backstop (#2373) that converges every copper credit reaching no bags arm',
+  },
+  {
+    call: 'this.deedsWindow.refreshIfChanged',
+    band: 'slow',
+    gate: 'this.deedsWindow.isOpen',
+    surface: 'window',
+    guard: { kind: 'module', module: 'deeds_window.ts', proof: SIG_RETURN },
+    why: 'the Book of Deeds window',
+  },
+  {
+    call: 'this.refreshOpenProfessionSurfacesIfChanged',
+    band: 'slow',
+    gate: '',
+    surface: 'window',
+    guard: { kind: 'hud', proof: 'if (sig === this.lastProfessionSurfaceSig) return;' },
+    why: 'repaints the character window and the crafting window when a profession number moves',
+  },
+  {
+    call: 'this.professionsWindow.refreshIfChanged',
+    band: 'slow',
+    gate: 'this.professionsWindow.isOpen',
+    surface: 'window',
+    guard: { kind: 'module', module: 'professions_window.ts', proof: SIG_RETURN },
+    why: 'the professions window',
+  },
+  {
+    call: 'this.questDialog.refreshIfChanged',
+    band: 'slow',
+    gate: '',
+    surface: 'window',
+    guard: {
+      kind: 'module',
+      module: 'hud/quest/quest_dialog_controller.ts',
+      proof: 'if (this.introHintVisibleFor(npc) !== this.lastIntroHintVisible) this.refresh();',
+    },
+    why: "the gossip dialog's intro hint row, which watches an online edge no quest event fires for",
+  },
+  {
+    call: 'this.updateDeedTracker',
+    band: 'slow',
+    gate: '',
+    surface: 'chrome',
+    why: 'the always-on deed tracker (not gated on a window)',
+  },
+  {
+    call: 'this.calendarWindow.refreshIfChanged',
+    band: 'slow',
+    gate: 'this.calendarWindow.isOpen',
+    surface: 'window',
+    guard: { kind: 'module', module: 'calendar_window.ts', proof: SIG_RETURN },
+    why: 'the guild calendar window',
+  },
+  {
+    call: 'this.updateMailIndicator',
+    band: 'slow',
+    gate: '',
+    surface: 'chrome',
+    why: 'the minimap envelope badge, value-diffed',
+  },
+  {
+    call: 'this.updateMarketIndicator',
+    band: 'slow',
+    gate: '',
+    surface: 'chrome',
+    why: 'the minimap market badge, value-diffed',
+  },
+];
+
+// --------------------------------------------------------------------------
+// The verdict path, extracted so a synthetic control can drive it.
+// --------------------------------------------------------------------------
+
+/**
+ * Both directions of the diff between the registry and the walk.
+ *
+ * Takes both sides as PARAMETERS, module constants included, so the positive control below
+ * runs the same code the real assertion does. Resolving `declared` from `HUD_UPDATE_DRIVES`
+ * inside would leave the real path unproven, which is the shape #2497 shipped twice.
+ */
+function driveProblems(declared: readonly DriveRow[], observed: readonly CallSite[]): string[] {
+  const problems: string[] = [];
+  const want = new Map<string, number>();
+  for (const row of declared) {
+    const key = keyOf(row.call, row.band, row.gate);
+    if (want.has(key)) {
+      problems.push(`${key} (registered twice: merge the rows and set sites)`);
+      continue;
+    }
+    want.set(key, row.sites ?? 1);
+  }
+  const got = new Map<string, number>();
+  for (const site of observed) {
+    const { band, gate } = splitBand(site.conditions);
+    const key = keyOf(site.call, band, gate);
+    got.set(key, (got.get(key) ?? 0) + 1);
+  }
+  for (const [key, count] of got) {
+    const expected = want.get(key);
+    if (expected === undefined) problems.push(`${key} (drives ${count}x, registered nowhere)`);
+    else if (expected !== count) {
+      problems.push(`${key} (drives ${count}x, registered as ${expected})`);
+    }
+  }
+  for (const key of want.keys()) {
+    if (!got.has(key)) problems.push(`${key} (registered, drives nothing)`);
+  }
+  return problems.sort();
+}
+
+/** The per-row shape rules, which nothing about a green diff would otherwise enforce. */
+function rowShapeProblems(declared: readonly DriveRow[]): string[] {
+  const problems: string[] = [];
+  for (const row of declared) {
+    const at = keyOf(row.call, row.band, row.gate);
+    if (!row.why.trim()) problems.push(`${at} (why is empty: say what it repaints)`);
+    if ((row.sites ?? 1) < 1) problems.push(`${at} (sites must be at least 1)`);
+    if (row.surface === 'window' && !row.guard) {
+      problems.push(`${at} (a window row must name its invalidation guard)`);
+    }
+    if (row.surface !== 'window' && row.guard) {
+      problems.push(`${at} (only a window row carries a guard, so the field cannot rot)`);
+    }
+    if (row.guard?.kind === 'none' && !row.guard.why.trim()) {
+      problems.push(`${at} (guard kind "none" must record WHY there is none)`);
+    }
+  }
+  return problems;
+}
+
+/**
+ * The guard proofs: every `module`/`hud` guard's source line must still be in its file.
+ *
+ * `read` is a parameter so the control can plant a module whose guard was deleted. Both the
+ * proof and the source are normalized the same way, so biome reflowing a guard across lines
+ * does not fail this, and deleting it does.
+ */
+function guardProblems(
+  declared: readonly DriveRow[],
+  read: (module: string) => string,
+): { problems: string[]; checked: string[] } {
+  const problems: string[] = [];
+  const checked: string[] = [];
+  for (const row of declared) {
+    const guard = row.guard;
+    if (!guard || (guard.kind !== 'module' && guard.kind !== 'hud')) continue;
+    const module = guard.kind === 'hud' ? 'hud.ts' : guard.module;
+    checked.push(`${module}: ${guard.proof}`);
+    if (!normalizeCondition(read(module)).includes(normalizeCondition(guard.proof))) {
+      problems.push(
+        `${row.call}: ${module} no longer contains its invalidation guard \`${guard.proof}\``,
+      );
+    }
+  }
+  return { problems, checked };
+}
+
+// --------------------------------------------------------------------------
+// The read.
+// --------------------------------------------------------------------------
+
+const UI_DIR = fileURLToPath(new URL('../src/ui/', import.meta.url));
+const readUi = (module: string): string => readFileSync(`${UI_DIR}${module}`, 'utf8');
+const HUD_PATH = `${UI_DIR}hud.ts`;
+const scan = readMethodCallSites(HUD_PATH, readFileSync(HUD_PATH, 'utf8'), 'Hud', 'update');
+const observedKeys = scan.sites.map((s) => {
+  const { band, gate } = splitBand(s.conditions);
+  return keyOf(s.call, band, gate);
+});
+
+describe('Hud.update() drives exactly the registered set, on the registered bands', () => {
+  // ANTI-VACUITY FIRST, because every assertion after it is an empty-collection check and an
+  // empty collection is what a narrowed walk produces. `readMethodCallSites` THROWS on a
+  // missing class or method rather than returning nothing, which is the load-bearing half:
+  // the shape risk #2498 named is an extraction behind a controller, and that must be a red
+  // test, not a quiet zero. These floors catch the other half, a walk that resolved the file
+  // but stopped part way through it.
+  it('read a whole, real Hud.update() before asserting anything about it', () => {
+    expect(
+      scan.classMembers,
+      'the Hud class shrank past recognition: re-point this gate',
+    ).toBeGreaterThan(600);
+    expect(scan.bodyLines, 'Hud.update() shrank past recognition').toBeGreaterThan(400);
+    expect(
+      scan.sites.length,
+      'the statement walk came back short: it stopped parsing',
+    ).toBeGreaterThan(100);
+    // One floor per band, because three empty bands hide behind one healthy one.
+    const perBand = new Map<Band, number>();
+    for (const site of scan.sites) {
+      const { band } = splitBand(site.conditions);
+      perBand.set(band, (perBand.get(band) ?? 0) + 1);
+    }
+    expect(perBand.get('frame') ?? 0).toBeGreaterThan(45);
+    expect(perBand.get('fast') ?? 0).toBeGreaterThan(4);
+    expect(perBand.get('medium') ?? 0).toBeGreaterThan(25);
+    expect(perBand.get('slow') ?? 0).toBeGreaterThan(15);
+  });
+
+  // NAMED POSITIVE CONTROLS, one per band and one per walker arm that a narrowing would
+  // silently empty. Each is a different failure mode: the frame-band window is the case the
+  // painter gate calls cold; the medium one carries a display-check gate; the slow one carries
+  // NO gate on purpose; and the last is the non-`this` arm, which a `this.`-only walk drops
+  // without changing any count enough to trip a floor.
+  it('finds the five call shapes that a narrowed walk would lose', () => {
+    expect(observedKeys).toContain(
+      'this.spellbookWindow.tickOpen|frame|this.spellbookWindow.isOpen',
+    );
+    expect(observedKeys).toContain(
+      "this.arenaWindow.render|medium|$('#arena-window').style.display === 'block'",
+    );
+    expect(observedKeys).toContain('this.bagsWindow.refreshIfChanged|slow|');
+    expect(observedKeys).toContain('this.updateClock|fast|');
+    expect(observedKeys).toContain('document.body.classList.toggle|frame|');
+  });
+
+  it('registers every call Hud.update() makes, and nothing it does not', () => {
+    const problems = driveProblems(HUD_UPDATE_DRIVES, scan.sites);
+    expect(
+      problems,
+      `Hud.update()'s drive list and this registry disagree. A NEW call needs a row saying what it repaints, on which band, behind which gate; a REMOVED call needs its row deleted; a MOVED one needs its band or gate updated. That is the point of the table: a repaint added to the per-frame path should cost a diff line here.\n${problems.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('keeps every row well formed', () => {
+    const problems = rowShapeProblems(HUD_UPDATE_DRIVES);
+    expect(problems, `malformed registry row(s):\n${problems.join('\n')}`).toEqual([]);
+    expect(HUD_UPDATE_DRIVES.length).toBeGreaterThan(100);
+    // A floor on the WINDOW rows specifically, so a future edit cannot answer the diff by
+    // reclassifying the whole family to chrome and keeping everything green.
+    const windows = HUD_UPDATE_DRIVES.filter((r) => r.surface === 'window');
+    expect(windows.length, 'the window rows vanished from the registry').toBeGreaterThan(25);
+    expect(windows.map((r) => r.call)).toContain('this.spellbookWindow.tickOpen');
+    expect(windows.map((r) => r.call)).toContain('this.renderTownFocus');
+  });
+
+  it('still finds every invalidation guard the window rows name', () => {
+    const { problems, checked } = guardProblems(HUD_UPDATE_DRIVES, readUi);
+    expect(
+      checked.length,
+      'the guard sweep proved nothing: no row named a source guard',
+    ).toBeGreaterThan(15);
+    expect(
+      problems,
+      `a window on a poll rebuilds only because a signature guard says nothing changed. Deleting one turns a full innerHTML rebuild into a 2 Hz (or per-frame) rebuild that moves no number in any other gate. Restore the guard, or update the row to say where it went:\n${problems.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  // The bridge to tests/hud_perf_budget.test.ts, and the honest half of it. That gate sweeps
+  // three DOM-adapter filenames; a window under a BARE name escapes it entirely, which
+  // src/ui/CLAUDE.md already records as a limit. This pins WHICH driven windows are in that
+  // hole, so the set cannot grow silently: a new bare-named module polled from update() fails
+  // here until someone either renames it into the sweep or adds it to this list on purpose.
+  it('names the driven windows the painter gate cannot see', () => {
+    const adapterName = /_(?:painter|window|controller)\.ts$/;
+    const modules = HUD_UPDATE_DRIVES.flatMap((r) =>
+      r.guard?.kind === 'module' ? [r.guard.module] : [],
+    );
+    expect(
+      modules.length,
+      'no window row names a module: the guard kinds were gutted',
+    ).toBeGreaterThan(15);
+    expect(modules.filter((m) => !adapterName.test(m)).sort()).toEqual([
+      'dungeon_finder_proposal_popup.ts',
+      'meters.ts',
+      'vale_cup_betting.ts',
+      'vale_cup_briefing.ts',
+    ]);
+  });
+});
+
+describe('the drive registry checks themselves have teeth', () => {
+  const site = (call: string, conditions: string[]): CallSite => ({ call, line: 1, conditions });
+
+  it('splits the cadence latch off the gate, and only the latch', () => {
+    expect(splitBand([])).toEqual({ band: 'frame', gate: '' });
+    expect(splitBand(['slowHud'])).toEqual({ band: 'slow', gate: '' });
+    expect(splitBand(['mediumHud', "$('#x').style.display === 'block'"])).toEqual({
+      band: 'medium',
+      gate: "$('#x').style.display === 'block'",
+    });
+    // The compound form: the token shares its condition with a real gate.
+    expect(splitBand(['slowHud && this.bankWindow.isOpen'])).toEqual({
+      band: 'slow',
+      gate: 'this.bankWindow.isOpen',
+    });
+    // A `&&` INSIDE a call argument is not a top-level separator.
+    expect(splitBand(['fastHud && cadenceDue(a && b, c)'])).toEqual({
+      band: 'fast',
+      gate: 'cadenceDue(a && b, c)',
+    });
+    // A part holding a top-level `||` is parenthesized, so the joined gate reads as the
+    // source expression rather than as a different one with the same tokens.
+    expect(splitBand(['mediumHud', 'id !== null', '!npc || far'])).toEqual({
+      band: 'medium',
+      gate: 'id !== null && (!npc || far)',
+    });
+    // ...and an already-parenthesized part is not double-wrapped.
+    expect(splitBand(['(a || b)'])).toEqual({ band: 'frame', gate: '(a || b)' });
+    // An identifier that merely CONTAINS a band token is not one.
+    expect(splitBand(['lastSlowHudAt > 0'])).toEqual({ band: 'frame', gate: 'lastSlowHudAt > 0' });
+  });
+
+  // The positive control for the diff. Everything the real assertions do is "expect an array
+  // to be empty", which a broken comparator satisfies trivially; this drives the same function
+  // over synthetic input with one planted fault of each kind and requires it to REPORT.
+  it('reports an unregistered call, an orphan row, and a count that moved', () => {
+    const declared: DriveRow[] = [
+      { call: 'this.a', band: 'slow', gate: '', surface: 'none', why: 'x' },
+      { call: 'this.gone', band: 'frame', gate: '', surface: 'none', why: 'x' },
+      { call: 'this.twice', band: 'frame', gate: '', sites: 2, surface: 'none', why: 'x' },
+    ];
+    const observed = [
+      site('this.a', ['slowHud']),
+      site('this.surprise', ['mediumHud', 'open']),
+      site('this.twice', []),
+    ];
+    expect(driveProblems(declared, observed)).toEqual([
+      'this.gone|frame| (registered, drives nothing)',
+      'this.surprise|medium|open (drives 1x, registered nowhere)',
+      'this.twice|frame| (drives 1x, registered as 2)',
+    ]);
+    // ...and it stays silent on a set that agrees, so it is not simply always noisy.
+    expect(
+      driveProblems(
+        [{ call: 'this.a', band: 'slow', gate: 'open', sites: 2, surface: 'none', why: 'x' }],
+        [site('this.a', ['slowHud', 'open']), site('this.a', ['slowHud', 'open'])],
+      ),
+    ).toEqual([]);
+    // A key registered twice is caught rather than silently taking the last write.
+    expect(
+      driveProblems(
+        [
+          { call: 'this.a', band: 'frame', gate: '', surface: 'none', why: 'x' },
+          { call: 'this.a', band: 'frame', gate: '', surface: 'none', why: 'y' },
+        ],
+        [site('this.a', [])],
+      ),
+    ).toEqual(['this.a|frame| (registered twice: merge the rows and set sites)']);
+  });
+
+  it('reports each kind of malformed row', () => {
+    expect(
+      rowShapeProblems([
+        { call: 'this.a', band: 'frame', gate: '', surface: 'window', why: 'x' },
+        {
+          call: 'this.b',
+          band: 'frame',
+          gate: '',
+          surface: 'chrome',
+          guard: { kind: 'callsite' },
+          why: 'x',
+        },
+        {
+          call: 'this.c',
+          band: 'frame',
+          gate: '',
+          surface: 'window',
+          guard: { kind: 'none', why: '  ' },
+          why: 'x',
+        },
+        { call: 'this.d', band: 'frame', gate: '', surface: 'none', why: '' },
+        { call: 'this.e', band: 'frame', gate: '', sites: 0, surface: 'none', why: 'x' },
+      ]),
+    ).toEqual([
+      'this.a|frame| (a window row must name its invalidation guard)',
+      'this.b|frame| (only a window row carries a guard, so the field cannot rot)',
+      'this.c|frame| (guard kind "none" must record WHY there is none)',
+      'this.d|frame| (why is empty: say what it repaints)',
+      'this.e|frame| (sites must be at least 1)',
+    ]);
+    expect(
+      rowShapeProblems([
+        {
+          call: 'this.ok',
+          band: 'slow',
+          gate: '',
+          surface: 'window',
+          guard: { kind: 'callsite' },
+          why: 'x',
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  it('reports a guard whose source line is gone, and tolerates a reformatted one', () => {
+    const rows: DriveRow[] = [
+      {
+        call: 'this.kept',
+        band: 'slow',
+        gate: '',
+        surface: 'window',
+        guard: {
+          kind: 'module',
+          module: 'kept_window.ts',
+          proof: 'if (sig === this.lastSig) return;',
+        },
+        why: 'x',
+      },
+      {
+        call: 'this.lost',
+        band: 'slow',
+        gate: '',
+        surface: 'window',
+        guard: {
+          kind: 'module',
+          module: 'lost_window.ts',
+          proof: 'if (sig === this.lastSig) return;',
+        },
+        why: 'x',
+      },
+    ];
+    const sources: Record<string, string> = {
+      // Reformatted across lines the way biome would, plus a comment mentioning the guard,
+      // which the strip must not accept as the guard itself.
+      'kept_window.ts': 'render() {\n  if (\n    sig === this.lastSig\n  )\n    return;\n}',
+      'lost_window.ts': '// the lastSig guard used to live here\nrender() { this.rebuild(); }',
+    };
+    const { problems, checked } = guardProblems(rows, (m) => sources[m]);
+    expect(problems).toEqual([
+      'this.lost: lost_window.ts no longer contains its invalidation guard `if (sig === this.lastSig) return;`',
+    ]);
+    expect(checked).toEqual([
+      'kept_window.ts: if (sig === this.lastSig) return;',
+      'lost_window.ts: if (sig === this.lastSig) return;',
+    ]);
+  });
+});

--- a/tests/hud_update_drive.test.ts
+++ b/tests/hud_update_drive.test.ts
@@ -1101,6 +1101,12 @@ function driveProblems(declared: readonly DriveRow[], observed: readonly CallSit
   return problems.sort();
 }
 
+/**
+ * A callee whose own name says it is a window. Case-sensitive on purpose, so the global
+ * `window.setTimeout` is not swept in with `this.arenaWindow.render`.
+ */
+const NAMES_A_WINDOW = /\.\w*(?:Window|Popup)\b/;
+
 /** The per-row shape rules, which nothing about a green diff would otherwise enforce. */
 function rowShapeProblems(declared: readonly DriveRow[]): string[] {
   const problems: string[] = [];
@@ -1116,6 +1122,16 @@ function rowShapeProblems(declared: readonly DriveRow[]): string[] {
     }
     if (row.guard?.kind === 'none' && !row.guard.why.trim()) {
       problems.push(`${at} (guard kind "none" must record WHY there is none)`);
+    }
+    // The cheapest way out of the guard requirement is to relabel the row rather than fix
+    // it, and mutation testing found exactly that: flipping card_duel_window's row to
+    // `chrome` dropped its guard with the whole suite green. A name is not proof a call
+    // touches a window, but it IS proof of what the author called it, so where the callee
+    // says window or popup the classification is not a judgment any more.
+    if (NAMES_A_WINDOW.test(row.call) && row.surface !== 'window') {
+      problems.push(
+        `${at} (a callee named Window/Popup is a window row: it cannot be relabelled ${row.surface} to shed its guard)`,
+      );
     }
   }
   return problems;
@@ -1219,10 +1235,18 @@ describe('Hud.update() drives exactly the registered set, on the registered band
     const problems = rowShapeProblems(HUD_UPDATE_DRIVES);
     expect(problems, `malformed registry row(s):\n${problems.join('\n')}`).toEqual([]);
     expect(HUD_UPDATE_DRIVES.length).toBeGreaterThan(100);
-    // A floor on the WINDOW rows specifically, so a future edit cannot answer the diff by
-    // reclassifying the whole family to chrome and keeping everything green.
+    // The surface split is pinned EXACTLY, not floored. A floor is what let mutation
+    // testing relabel one window row as chrome and shed its guard with the suite green:
+    // dropping one of thirty-odd sits comfortably above any floor worth setting. Adding a
+    // call to update() already costs a row here, so it costing a number here too is
+    // proportionate, and it forces the surface question to be answered out loud.
+    const bySurface: Record<Surface, number> = { window: 0, chrome: 0, none: 0 };
+    for (const row of HUD_UPDATE_DRIVES) bySurface[row.surface]++;
+    expect(
+      bySurface,
+      "the surface split moved. A new call needs its surface decided; a CHANGED one means a repaint was reclassified, which is the one edit that can quietly drop a window row's invalidation guard.",
+    ).toEqual({ window: 37, chrome: 67, none: 9 });
     const windows = HUD_UPDATE_DRIVES.filter((r) => r.surface === 'window');
-    expect(windows.length, 'the window rows vanished from the registry').toBeGreaterThan(25);
     expect(windows.map((r) => r.call)).toContain('this.spellbookWindow.tickOpen');
     expect(windows.map((r) => r.call)).toContain('this.renderTownFocus');
   });
@@ -1354,6 +1378,7 @@ describe('the drive registry checks themselves have teeth', () => {
         },
         { call: 'this.d', band: 'frame', gate: '', surface: 'none', why: '' },
         { call: 'this.e', band: 'frame', gate: '', sites: 0, surface: 'none', why: 'x' },
+        { call: 'this.someWindow.render', band: 'frame', gate: '', surface: 'chrome', why: 'x' },
       ]),
     ).toEqual([
       'this.a|frame| (a window row must name its invalidation guard)',
@@ -1361,7 +1386,14 @@ describe('the drive registry checks themselves have teeth', () => {
       'this.c|frame| (guard kind "none" must record WHY there is none)',
       'this.d|frame| (why is empty: say what it repaints)',
       'this.e|frame| (sites must be at least 1)',
+      'this.someWindow.render|frame| (a callee named Window/Popup is a window row: it cannot be relabelled chrome to shed its guard)',
     ]);
+    // The global `window.` object is lowercase and must not be swept in with it.
+    expect(
+      rowShapeProblems([
+        { call: 'window.setTimeout', band: 'frame', gate: '', surface: 'chrome', why: 'x' },
+      ]),
+    ).toEqual([]);
     expect(
       rowShapeProblems([
         {

--- a/tests/hud_update_drive.test.ts
+++ b/tests/hud_update_drive.test.ts
@@ -1291,14 +1291,73 @@ describe('Hud.update() drives exactly the registered set, on the registered band
     const windows = HUD_UPDATE_DRIVES.filter((r) => r.surface === 'window');
     expect(windows.map((r) => r.call)).toContain('this.spellbookWindow.tickOpen');
     expect(windows.map((r) => r.call)).toContain('this.renderTownFocus');
+    // The guard KINDS are pinned the same way and for the same reason: `kind` is otherwise a
+    // free-text opt-out, so a row could keep `surface: 'window'`, keep the counts above
+    // intact, and swap `module` for a plausible-sounding `none` while the real guard was
+    // deleted from the tree.
+    const byKind: Record<string, number> = {};
+    for (const row of HUD_UPDATE_DRIVES)
+      if (row.guard) byKind[row.guard.kind] = (byKind[row.guard.kind] ?? 0) + 1;
+    expect(byKind, 'a guard kind changed: say why in the PR, not only in the table').toEqual({
+      module: 19,
+      hud: 4,
+      callsite: 9,
+      none: 5,
+    });
+    // ...and the honest-exception list by NAME, because that is the one that should never
+    // grow quietly: every entry is a window this repo knows has no invalidation guard.
+    expect(
+      HUD_UPDATE_DRIVES.filter((r) => r.guard?.kind === 'none')
+        .map((r) => r.call)
+        .sort(),
+    ).toEqual([
+      'this.lootRolls.update',
+      'this.lootWindow.updateProximity',
+      'this.questDialog.updateProximity',
+      'this.renderTownFocus',
+      'this.updateMapWindow',
+    ]);
   });
 
   it('still finds every invalidation guard the window rows name', () => {
     const { problems, checked } = guardProblems(HUD_UPDATE_DRIVES, readUi);
+    // PINNED EXACTLY, module and proof together, and this is the assertion that carries the
+    // whole guard half of the gate. A floor here was the hole mutation testing found twice
+    // over: a window row could downgrade its guard to `kind: 'none'` with a plausible
+    // sentence, or repoint its `module` at any of the seven other files that spell the proof
+    // identically, and both left the count comfortably above any floor while a real guard was
+    // deleted from the tree. `if (sig === this.lastSig) return;` appears in seven modules, so
+    // the module a row NAMES has to be part of the pin, not just the line it looks for.
     expect(
-      checked.length,
-      'the guard sweep proved nothing: no row named a source guard',
-    ).toBeGreaterThan(15);
+      [...checked].sort(),
+      'the resolved guard list moved. A row changed which module it points at, which line it looks for, or dropped to a guard kind that names no source at all.',
+    ).toEqual(
+      [
+        'arena_window.ts: if (view.sig === this.lastSig) return;',
+        'bags_window.ts: if (!bagsMoneyRowStale(el.style.display, this.deps.world().copper, this.lastMoneyCopper)) return;',
+        'bank_window.ts: if (sig === this.lastSig) return;',
+        'calendar_window.ts: if (sig === this.lastSig) return;',
+        'card_duel_window.ts: if (sig === this.lastSig) return;',
+        'deeds_window.ts: if (sig === this.lastSig) return;',
+        'dungeon_finder_proposal_popup.ts: if (view.sig !== this.lastSig) {',
+        'dungeon_finder_window.ts: if (sig === this.lastSig) {',
+        'hud.ts: if (craftingReagentSig(this.sim.inventory, this.sim.player.name) === this.lastCraftingReagentSig) return;',
+        'hud.ts: if (sig !== this.lastLootSettingsSig) {',
+        'hud.ts: if (sig === this.lastProfessionSurfaceSig) return;',
+        'hud.ts: if (sig === this.lastTradeSig) return;',
+        'hud/delve/lockpick_window.ts: if (lockpickRenderSig(view) !== this.lastSig) this.renderBoard();',
+        'hud/quest/quest_dialog_controller.ts: if (this.introHintVisibleFor(npc) !== this.lastIntroHintVisible) this.refresh();',
+        'mailbox_window.ts: if (sig === this.lastSig) return;',
+        'market_window.ts: if (sig === this.lastSig) return;',
+        'meters.ts: if (!this.isOpen || now - this.lastRender < 250) return;',
+        'professions_window.ts: if (sig === this.lastSig) return;',
+        'social_window.ts: if (struct !== this.lastStruct) {',
+        'spellbook_window.ts: if (SpellbookWindow.knownSig(this.deps.world().known) !== this.lastKnownSig) {',
+        'vale_cup_betting.ts: if (view.sig !== this.lastSig) {',
+        'vale_cup_briefing.ts: if (view.sig !== this.lastSig) {',
+        'vale_cup_window.ts: if (view.sig === this.lastSig) return;',
+      ].sort(),
+    );
     expect(
       problems,
       `a window on a poll rebuilds only because a signature guard says nothing changed. Deleting one turns a full innerHTML rebuild into a 2 Hz (or per-frame) rebuild that moves no number in any other gate. Restore the guard, or update the row to say where it went:\n${problems.join('\n')}`,
@@ -1358,6 +1417,13 @@ describe('the drive registry checks themselves have teeth', () => {
     expect(splitBand(['(a || b)'])).toEqual({ band: 'frame', gate: '(a || b)' });
     // An identifier that merely CONTAINS a band token is not one.
     expect(splitBand(['lastSlowHudAt > 0'])).toEqual({ band: 'frame', gate: 'lastSlowHudAt > 0' });
+    // A `&&` inside a BRACKET is not a top-level separator either. No live condition in
+    // `update()` uses an index access today, so without this the bracket half of the depth
+    // counter matches nothing and could be deleted with the suite green.
+    expect(splitBand(['slowHud && rows[a && b].open'])).toEqual({
+      band: 'slow',
+      gate: 'rows[a && b].open',
+    });
   });
 
   // The positive control for the diff. Everything the real assertions do is "expect an array
@@ -1421,6 +1487,10 @@ describe('the drive registry checks themselves have teeth', () => {
         { call: 'this.d', band: 'frame', gate: '', surface: 'none', why: '' },
         { call: 'this.e', band: 'frame', gate: '', sites: 0, surface: 'none', why: 'x' },
         { call: 'this.someWindow.render', band: 'frame', gate: '', surface: 'chrome', why: 'x' },
+        // The Popup alternate matches exactly ONE live row, which already passes, so nothing
+        // else ever drives it in the reporting direction: the dead-arm shape this repo has
+        // shipped twice.
+        { call: 'this.somePopup.render', band: 'frame', gate: '', surface: 'chrome', why: 'x' },
       ]),
     ).toEqual([
       'this.a|frame| (a window row must name its invalidation guard)',
@@ -1429,11 +1499,17 @@ describe('the drive registry checks themselves have teeth', () => {
       'this.d|frame| (why is empty: say what it repaints)',
       'this.e|frame| (sites must be at least 1)',
       'this.someWindow.render|frame| (a callee named Window/Popup is a window row: it cannot be relabelled chrome to shed its guard)',
+      'this.somePopup.render|frame| (a callee named Window/Popup is a window row: it cannot be relabelled chrome to shed its guard)',
     ]);
-    // The global `window.` object is lowercase and must not be swept in with it.
+    // The three negatives that pin the rest of the matcher, none of which the positives
+    // above can reach. The global `window.` object is lowercase (so the alternation itself
+    // rejects it); `windowManager` has no leading dot before the word, which is what the
+    // `\.` anchor is for; and `windowed` continues past the word, which is what `\b` is for.
     expect(
       rowShapeProblems([
         { call: 'window.setTimeout', band: 'frame', gate: '', surface: 'chrome', why: 'x' },
+        { call: 'windowManager.tick', band: 'frame', gate: '', surface: 'chrome', why: 'x' },
+        { call: 'this.windowed.paint', band: 'frame', gate: '', surface: 'chrome', why: 'x' },
       ]),
     ).toEqual([]);
     expect(

--- a/tests/hud_update_drive.test.ts
+++ b/tests/hud_update_drive.test.ts
@@ -25,9 +25,9 @@
 // windows would repeat the mistake #2497 refused to ship (a declaration naming a handful of
 // windows when half the family qualifies reads as a complete classification and is not one),
 // and it would hand a new repaint a free way out: name it `syncFoo()` and it is not a window.
-// Every statement-position call is registered; the `surface` field is what answers the window
-// question. The cost is real and is the point: a new line in `update()` is now a diff line
-// here too.
+// Every call `update()` evaluates is registered; the `surface` field is what answers the
+// window question. The cost is real and is the point: a new line in `update()` is now a diff
+// line here too.
 //
 // WHERE ITS TEETH STOP, stated rather than implied:
 //   - It sees `update()`'s OWN body. A repaint two hops down a `Hud` private method is named
@@ -35,6 +35,12 @@
 //     but the walk does not follow it, so a NEW repaint added inside an ALREADY-registered
 //     method is invisible here. The `surface` and `guard` fields are what a reviewer reads;
 //     the diff is what a machine enforces.
+//   - In a VALUE slot (a declaration's initializer, an assignment's right side, a `return`)
+//     only a call on `this` is registered, so `const bar = xpBarView({...})` is not a row
+//     while `const music = this.instanceMusic.update({...})` is. A repaint written as a call
+//     on a LOCAL in a value slot would escape; the whole registry is about what the
+//     coordinator drives, and registering every pure producer would bury that under two
+//     dozen rows of formatters. `helpers/method_call_sites.ts` states the full rule.
 //   - A `guard` proof is a source-text pin. It fails when the guard is DELETED, which is the
 //     criterion #2498 asked for, and it cannot tell a guard that was neutered while its field
 //     survived. The instrument for THAT is behavioral (render, poll unchanged, assert zero
@@ -176,6 +182,13 @@ const VIEW_SIG_BLOCK = 'if (view.sig !== this.lastSig) {';
  */
 const HUD_UPDATE_DRIVES: readonly DriveRow[] = [
   {
+    call: 'this.fxTier',
+    band: 'frame',
+    gate: '',
+    surface: 'none',
+    why: 'reads the STATIC graphics-preset stamp that tiers several cadences below it; no DOM write',
+  },
+  {
     call: 'this.reconcileSfx',
     band: 'fast',
     gate: '',
@@ -296,6 +309,13 @@ const HUD_UPDATE_DRIVES: readonly DriveRow[] = [
     why: 'the unspent-talent-points glow on the desktop and mobile talent buttons',
   },
   {
+    call: 'this.isInTown',
+    band: 'slow',
+    gate: '',
+    surface: 'none',
+    why: 'the zone read behind the Town Focus button and the open panel gate; no DOM write',
+  },
+  {
     call: 'this.renderTownFocus',
     band: 'slow',
     gate: 'this.townFocusOpen',
@@ -388,6 +408,13 @@ const HUD_UPDATE_DRIVES: readonly DriveRow[] = [
     gate: 'cadenceDue(this.lastBuffBarPaintAt, now, auraRefreshIntervalMs(fxTier))',
     surface: 'chrome',
     why: 'the debuff row, on the same latch as the buff row',
+  },
+  {
+    call: 'this.targetReannounce.mark',
+    band: 'frame',
+    gate: "target && target.kind !== 'object' && target.id !== this.lastAnnouncedTargetId",
+    surface: 'chrome',
+    why: 'marks the target-name announcement so a same-named re-target still re-reads; its result is written straight to the target live region, deliberately NOT through the elided writer, and the id gate makes that an event write rather than a per-frame one',
   },
   {
     call: 'this.targetFramePainter.paint',
@@ -668,6 +695,13 @@ const HUD_UPDATE_DRIVES: readonly DriveRow[] = [
     gate: 'subzone !== this.lastSubzone && subzone',
     surface: 'chrome',
     why: 'the subzone banner on a landmark crossing',
+  },
+  {
+    call: 'this.instanceMusic.update',
+    band: 'medium',
+    gate: '',
+    surface: 'none',
+    why: 'the zone/combat/boss music state machine, and the source of the inCombat and atSowfield reads under it; audio only',
   },
   {
     call: 'this.toggleClass',
@@ -1155,9 +1189,17 @@ function guardProblems(
     if (!guard || (guard.kind !== 'module' && guard.kind !== 'hud')) continue;
     const module = guard.kind === 'hud' ? 'hud.ts' : guard.module;
     checked.push(`${module}: ${guard.proof}`);
-    if (!normalizeCondition(read(module)).includes(normalizeCondition(guard.proof))) {
+    // Counted, not merely present. Every proof is unique in its module today, which is what
+    // makes deleting the guard fail this; the day a second copy appears somewhere else in the
+    // file, "contains it" would stay true with the real one gone and the pin would weaken
+    // with no diff to notice. An exact count turns that into a loud failure whose fix is to
+    // choose a proof line that is still unique.
+    const hits = normalizeCondition(read(module)).split(normalizeCondition(guard.proof)).length - 1;
+    if (hits !== 1) {
       problems.push(
-        `${row.call}: ${module} no longer contains its invalidation guard \`${guard.proof}\``,
+        hits === 0
+          ? `${row.call}: ${module} no longer contains its invalidation guard \`${guard.proof}\``
+          : `${row.call}: ${module} contains \`${guard.proof}\` ${hits}x, so the pin no longer identifies one guard`,
       );
     }
   }
@@ -1245,7 +1287,7 @@ describe('Hud.update() drives exactly the registered set, on the registered band
     expect(
       bySurface,
       "the surface split moved. A new call needs its surface decided; a CHANGED one means a repaint was reclassified, which is the one edit that can quietly drop a window row's invalidation guard.",
-    ).toEqual({ window: 37, chrome: 67, none: 9 });
+    ).toEqual({ window: 37, chrome: 68, none: 12 });
     const windows = HUD_UPDATE_DRIVES.filter((r) => r.surface === 'window');
     expect(windows.map((r) => r.call)).toContain('this.spellbookWindow.tickOpen');
     expect(windows.map((r) => r.call)).toContain('this.renderTownFocus');

--- a/tests/lockpick_timer_repaint.test.ts
+++ b/tests/lockpick_timer_repaint.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+
+// The lockpick countdown's repaint contract (#2498).
+//
+// `paintTimer` runs 10 times a second for the length of an attempt, and used to re-resolve
+// all three of its element refs on every tick. That is the shape `src/ui/CLAUDE.md` bans
+// ("Resolve element refs ONCE into a field at construction, never `$()`/`querySelector` from
+// a per-frame path"), and no gate could see it: `querySelector` is not in the painter gate's
+// vocabulary, and the cold bucket's `setInterval` allowance says a module repaints on a
+// cadence without implying anything about what runs inside the callback.
+//
+// THE LITERAL FORM OF THAT RULE WOULD HAVE BROKEN THIS WINDOW, which is why the invariant is
+// pinned here rather than left to review. `renderBoard()` replaces the panel subtree, and it
+// fires on `lockpickRenderSig` (which covers `row` and `visible.length`) while the interval
+// restarts on `lockpickTimerKey` (`sessionId:page:tries:col`, covering neither). So moving
+// the pick up a row rebuilds the three countdown nodes and does NOT restart the clock. Refs
+// taken once at construction, or at `startTimer()`, would paint into a detached subtree from
+// there on and the bar would freeze for the rest of the attempt. The refs must be re-resolved
+// at the rebuild, and the case below is the one that fails if they are not.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { lockpickRenderSig, lockpickTimerKey } from '../src/ui/hud/delve/lockpick_panel';
+import { LockpickWindow } from '../src/ui/hud/delve/lockpick_window';
+import type { LockpickView } from '../src/world_api';
+
+const VIEW: LockpickView = {
+  sessionId: 'lp_1_0',
+  objectId: 1,
+  w: 4,
+  h: 4,
+  col: 0,
+  row: 2,
+  page: 1,
+  pageCount: 2,
+  tries: 2,
+  triesTotal: 2,
+  lootTier: 'premium',
+  allowed: ['set', 'up', 'down'],
+  visible: [],
+  stepTimeoutMs: 15000,
+};
+
+function harness(initial: LockpickView | null = VIEW) {
+  document.body.innerHTML = '<div id="lockpick-panel" style="display:block"></div>';
+  const panel = document.getElementById('lockpick-panel') as HTMLElement;
+  let state: LockpickView | null = initial;
+  const win = new LockpickWindow({
+    panel: () => panel,
+    getState: () => state,
+    tierName: (tier) => tier,
+    onEngage: () => {},
+    onAction: () => {},
+    onAbort: () => {},
+    onClose: () => {},
+  });
+  return {
+    win,
+    panel,
+    set(next: LockpickView | null): void {
+      state = next;
+    },
+    bar: () => panel.querySelector<HTMLElement>('#lp-timer-bar'),
+    value: () => panel.querySelector<HTMLElement>('#lp-timer-value'),
+    wrap: () => panel.querySelector<HTMLElement>('.lp-timer'),
+  };
+}
+
+/** Run the countdown interval's callback exactly `ticks` times. */
+function tick(ticks: number): void {
+  for (let i = 0; i < ticks; i++) vi.advanceTimersByTime(100);
+}
+
+describe('lockpick countdown repaint', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+
+  it('paints the bar without re-querying the panel on every tick', () => {
+    const h = harness();
+    h.win.openBoard();
+    const spy = vi.spyOn(h.panel, 'querySelector');
+    tick(5);
+    // The three walks per tick this fix removes. The refs come from the board paint, so a
+    // steady-state tick resolves nothing at all.
+    expect(spy).not.toHaveBeenCalled();
+    expect(h.bar()?.style.width).not.toBe('');
+    spy.mockRestore();
+  });
+
+  it('keeps painting the LIVE nodes after a rebuild that does not restart the clock', () => {
+    // The correctness case. A row move changes the render signature but not the timer key,
+    // so renderBoard() replaces the countdown nodes while the same interval keeps running.
+    const moved = { ...VIEW, row: 3 };
+    expect(lockpickRenderSig(moved)).not.toBe(lockpickRenderSig(VIEW));
+    expect(lockpickTimerKey(moved)).toBe(lockpickTimerKey(VIEW));
+
+    const h = harness();
+    h.win.openBoard();
+    const before = h.bar();
+    tick(20); // 2s in
+    const midWidth = before?.style.width;
+
+    h.set(moved);
+    h.win.repaintIfChanged();
+    const after = h.bar();
+    expect(after, 'the rebuild should have replaced the timer nodes').not.toBe(before);
+    expect(after?.style.width, 'a fresh board starts the bar full').toBe('100%');
+
+    tick(20); // 2 more seconds, on the SAME interval
+    expect(after?.style.width).not.toBe('100%');
+    expect(after?.style.width).not.toBe(midWidth);
+    // ...and the stale node is not being written any more.
+    expect(before?.style.width).toBe(midWidth);
+  });
+
+  it('writes the urgent class only when it flips', () => {
+    const h = harness();
+    h.win.openBoard();
+    const wrap = h.wrap() as HTMLElement;
+    const toggle = vi.spyOn(wrap.classList, 'toggle');
+    tick(20); // 13s remaining, nowhere near urgent
+    expect(toggle).not.toHaveBeenCalled();
+    expect(wrap.classList.contains('lp-timer-urgent')).toBe(false);
+
+    tick(110); // past the 3s threshold
+    expect(wrap.classList.contains('lp-timer-urgent')).toBe(true);
+    expect(toggle).toHaveBeenCalledTimes(1);
+
+    tick(10); // still urgent: no second write
+    expect(toggle).toHaveBeenCalledTimes(1);
+    toggle.mockRestore();
+  });
+
+  it('drops its refs when the ante selector replaces the board, and when the panel closes', () => {
+    const h = harness();
+    h.win.openBoard();
+    expect(h.bar()).not.toBeNull();
+
+    h.win.renderAnte(1, false);
+    expect(h.bar(), 'the ante markup carries no countdown').toBeNull();
+    // The interval is still armed here (renderAnte does not stop it), so a tick must be a
+    // no-op rather than a throw on a ref into the replaced subtree.
+    expect(() => tick(5)).not.toThrow();
+
+    h.win.close();
+    expect(() => tick(5)).not.toThrow();
+  });
+
+  it('paints nothing when the board carries no per-step budget', () => {
+    const h = harness({ ...VIEW, stepTimeoutMs: null });
+    h.win.openBoard();
+    expect(h.wrap()).toBeNull();
+    expect(() => tick(5)).not.toThrow();
+  });
+});

--- a/tests/lockpick_timer_repaint.test.ts
+++ b/tests/lockpick_timer_repaint.test.ts
@@ -35,7 +35,7 @@ const VIEW: LockpickView = {
   tries: 2,
   triesTotal: 2,
   lootTier: 'premium',
-  allowed: ['set', 'up', 'down'],
+  allowed: ['set', 'steady', 'ease'],
   visible: [],
   stepTimeoutMs: 15000,
 };
@@ -79,13 +79,39 @@ describe('lockpick countdown repaint', () => {
   it('paints the bar without re-querying the panel on every tick', () => {
     const h = harness();
     h.win.openBoard();
-    const spy = vi.spyOn(h.panel, 'querySelector');
+    // All three resolvers, not just the injected panel's: `panel()` itself falls back to
+    // `document.getElementById`, so an instance-scoped spy alone would miss a regression
+    // that re-queried through the document instead.
+    const spies = [
+      vi.spyOn(h.panel, 'querySelector'),
+      vi.spyOn(document, 'querySelector'),
+      vi.spyOn(document, 'getElementById'),
+    ];
     tick(5);
-    // The three walks per tick this fix removes. The refs come from the board paint, so a
-    // steady-state tick resolves nothing at all.
-    expect(spy).not.toHaveBeenCalled();
+    for (const spy of spies) expect(spy).not.toHaveBeenCalled();
     expect(h.bar()?.style.width).not.toBe('');
-    spy.mockRestore();
+    for (const spy of spies) spy.mockRestore();
+  });
+
+  it('re-applies the urgent class after a rebuild that happens WHILE urgent', () => {
+    // The two arms of the latch only meet here: the rebuild case above happens at 13s
+    // (never urgent) and the latch case below never rebuilds, so neither notices if
+    // cacheTimerEls stops resetting lastUrgent. It would then stay true against fresh
+    // markup that carries no urgent class, and the player loses the cue for the rest of
+    // the attempt.
+    const h = harness();
+    h.win.openBoard();
+    tick(130); // past the 3s threshold
+    expect(h.wrap()?.classList.contains('lp-timer-urgent')).toBe(true);
+
+    h.set({ ...VIEW, row: 3 });
+    h.win.repaintIfChanged();
+    expect(h.wrap()?.classList.contains('lp-timer-urgent'), 'fresh markup starts clean').toBe(
+      false,
+    );
+
+    tick(1);
+    expect(h.wrap()?.classList.contains('lp-timer-urgent')).toBe(true);
   });
 
   it('keeps painting the LIVE nodes after a rebuild that does not restart the clock', () => {
@@ -132,25 +158,44 @@ describe('lockpick countdown repaint', () => {
     toggle.mockRestore();
   });
 
-  it('drops its refs when the ante selector replaces the board, and when the panel closes', () => {
+  it('stops writing the detached nodes when the ante selector replaces the board', () => {
+    // Asserted as "the stale node stops moving", not as "nothing throws": writing into a
+    // detached subtree throws nothing at all, so the no-throw version of this passes with
+    // forgetTimerEls() deleted. renderAnte deliberately does NOT stop the interval, which
+    // is what makes this reachable.
     const h = harness();
     h.win.openBoard();
-    expect(h.bar()).not.toBeNull();
+    const stale = h.bar() as HTMLElement;
+    tick(20);
+    const frozen = stale.style.width;
+    expect(frozen).not.toBe('100%');
 
     h.win.renderAnte(1, false);
     expect(h.bar(), 'the ante markup carries no countdown').toBeNull();
-    // The interval is still armed here (renderAnte does not stop it), so a tick must be a
-    // no-op rather than a throw on a ref into the replaced subtree.
-    expect(() => tick(5)).not.toThrow();
+    tick(20);
+    expect(stale.style.width, 'the replaced node must stop being painted').toBe(frozen);
+  });
 
-    h.win.close();
-    expect(() => tick(5)).not.toThrow();
+  it('drops its refs when the board repaints with no authoritative state left', () => {
+    // renderBoard's one exit that does not touch the subtree: state went null, so it calls
+    // deps.onClose() and returns. The module drops the refs there itself rather than relying
+    // on the caller routing that back into close().
+    const h = harness();
+    h.win.openBoard();
+    const stale = h.bar() as HTMLElement;
+    tick(20);
+    const frozen = stale.style.width;
+
+    h.set(null);
+    h.win.onStep('advanced');
+    tick(20);
+    expect(stale.style.width).toBe(frozen);
   });
 
   it('paints nothing when the board carries no per-step budget', () => {
     const h = harness({ ...VIEW, stepTimeoutMs: null });
     h.win.openBoard();
-    expect(h.wrap()).toBeNull();
+    expect(h.wrap(), 'no budget means no timer block is emitted').toBeNull();
     expect(() => tick(5)).not.toThrow();
   });
 });

--- a/tests/lockpick_timer_repaint.test.ts
+++ b/tests/lockpick_timer_repaint.test.ts
@@ -138,6 +138,12 @@ describe('lockpick countdown repaint', () => {
     expect(after?.style.width).not.toBe(midWidth);
     // ...and the stale node is not being written any more.
     expect(before?.style.width).toBe(midWidth);
+    // The LABEL is half the countdown and nothing else in the repo touches #lp-timer-value.
+    // Deleting the textContent write, or reverting formatNumber back to toFixed(1), was
+    // green before this. The literal pins the one decimal `NUM1` exists for.
+    // 15s budget, 4s of ticks on the one uninterrupted interval: the rebuild resets the
+    // BAR to full markup but not the clock's end, so the label keeps counting down.
+    expect(h.value()?.textContent).toContain('11.0');
   });
 
   it('writes the urgent class only when it flips', () => {
@@ -156,6 +162,17 @@ describe('lockpick countdown repaint', () => {
     tick(10); // still urgent: no second write
     expect(toggle).toHaveBeenCalledTimes(1);
     toggle.mockRestore();
+  });
+
+  it('flips urgent at 3s, not somewhere in a ten-second band', () => {
+    // The case above samples 13s then 2s, so any threshold in (0, 13) satisfies it. This
+    // straddles the real boundary instead.
+    const h = harness();
+    h.win.openBoard();
+    tick(119); // 3.1s remaining
+    expect(h.wrap()?.classList.contains('lp-timer-urgent')).toBe(false);
+    tick(2); // 2.9s remaining
+    expect(h.wrap()?.classList.contains('lp-timer-urgent')).toBe(true);
   });
 
   it('stops writing the detached nodes when the ante selector replaces the board', () => {
@@ -229,5 +246,24 @@ describe('lockpick countdown repaint', () => {
     h.win.openBoard();
     expect(h.wrap(), 'no budget means no timer block is emitted').toBeNull();
     expect(() => tick(5)).not.toThrow();
+  });
+
+  it('goes quiet when a rebuild drops the timer block out from under a running clock', () => {
+    // The one path that reaches cacheTimerEls' null fallback with an interval still armed,
+    // and the reason the fallback is a null rather than three non-null assertions. Opening
+    // with a budget arms the clock; dropping stepTimeoutMs while moving `row` changes
+    // lockpickRenderSig (so renderBoard runs and emits no timer block) but NOT
+    // lockpickTimerKey (so syncTimer neither restarts nor stops the interval).
+    const h = harness();
+    h.win.openBoard();
+    const stale = h.bar() as HTMLElement;
+    tick(20);
+    const frozen = stale.style.width;
+
+    h.set({ ...VIEW, stepTimeoutMs: null, row: 3 });
+    h.win.repaintIfChanged();
+    expect(h.wrap(), 'the rebuilt board carries no countdown').toBeNull();
+    expect(() => tick(20)).not.toThrow();
+    expect(stale.style.width, 'the dropped node must stop being painted').toBe(frozen);
   });
 });

--- a/tests/lockpick_timer_repaint.test.ts
+++ b/tests/lockpick_timer_repaint.test.ts
@@ -176,20 +176,52 @@ describe('lockpick countdown repaint', () => {
     expect(stale.style.width, 'the replaced node must stop being painted').toBe(frozen);
   });
 
-  it('drops its refs when the board repaints with no authoritative state left', () => {
-    // renderBoard's one exit that does not touch the subtree: state went null, so it calls
-    // deps.onClose() and returns. The module drops the refs there itself rather than relying
-    // on the caller routing that back into close().
+  it('stops painting when the authoritative state goes null', () => {
+    // NAMED for what it actually pins. renderBoard's state-less exit also drops the refs,
+    // but syncTimer stops the clock on the very next line, so that teardown is reference
+    // hygiene no test can observe (same as close()'s). What IS observable, and what this
+    // holds, is that the countdown goes quiet the moment the sim says the lock is over.
     const h = harness();
     h.win.openBoard();
-    const stale = h.bar() as HTMLElement;
+    const bar = h.bar() as HTMLElement;
     tick(20);
-    const frozen = stale.style.width;
+    const frozen = bar.style.width;
 
     h.set(null);
     h.win.onStep('advanced');
     tick(20);
-    expect(stale.style.width).toBe(frozen);
+    expect(bar.style.width).toBe(frozen);
+  });
+
+  it('paints its OWN panel when a second window instance exists', () => {
+    // What the class-scoped lookup buys, and the reason it is not an id lookup: the window
+    // is instance-parameterized on deps.panel, so two instances must not fight over one
+    // pair of element ids. Without this the id-versus-class choice is unpinned either way.
+    document.body.innerHTML =
+      '<div id="lockpick-panel" style="display:block"></div><div id="second-panel" style="display:block"></div>';
+    const first = document.getElementById('lockpick-panel') as HTMLElement;
+    const second = document.getElementById('second-panel') as HTMLElement;
+    const make = (panel: HTMLElement): LockpickWindow =>
+      new LockpickWindow({
+        panel: () => panel,
+        getState: () => VIEW,
+        tierName: (tier) => tier,
+        onEngage: () => {},
+        onAction: () => {},
+        onAbort: () => {},
+        onClose: () => {},
+      });
+    const a = make(first);
+    const b = make(second);
+    a.openBoard();
+    b.openBoard();
+    tick(20);
+
+    const barA = first.querySelector<HTMLElement>('.lp-timer-bar') as HTMLElement;
+    const barB = second.querySelector<HTMLElement>('.lp-timer-bar') as HTMLElement;
+    expect(barA).not.toBe(barB);
+    expect(barA.style.width).not.toBe('100%');
+    expect(barB.style.width, 'the second instance must paint its own node').toBe(barA.style.width);
   });
 
   it('paints nothing when the board carries no per-step budget', () => {


### PR DESCRIPTION
## Summary

`tests/hud_perf_budget.test.ts` sorts every `src/ui` painter into a bucket, but its cold bucket
deliberately makes no claim about cadence, because a per-module source scan cannot see a driver
that lives in the coordinator. #2497 documented that gap and filed #2498 as the close. This is the
close.

The premise a reader would assume is false in this tree: a `*_window.ts` is not cold.
`Hud.update()` polls about half of them. `spellbookWindow.tickOpen()` runs **every frame** while
the window is open; arena / dungeon_finder / vale_cup / card_duel `render()` on the 250ms band
behind only a display check; social / market / mailbox / bank / bags / deeds / professions /
calendar get `refreshIfChanged()` on the 500ms band. The intended pattern is *poll cheaply, rebuild
on a signature change*, and it works, but nothing said which windows were on a poll or behind which
guard. Drop a signature guard and a full `innerHTML` rebuild becomes a 4Hz or per-frame rebuild
while every number in every gate holds.

**`tests/hud_update_drive.test.ts`** is a hand-written row per distinct (callee, band, gate) that
`Hud.update()` drives, diffed **both ways** against a TypeScript AST walk of the real method:

- a new call in `update()` fails until it is registered,
- a removed one fails until its row goes,
- moving one between bands fails,
- changing the condition that gates it fails, because the gate text is part of the key,
- and every window row names its invalidation guard as the source line it is spelled on, so
  deleting the guard fails here.

It registers the **whole body**, not only the windows. Scoping it to windows would repeat the
mistake #2497 refused to ship (a table naming a handful when half the family qualifies reads as a
complete classification and is not one), and it would let a repaint out by being named `syncFoo()`.
The `surface` field is what answers the window question.

The walk lives in **`tests/helpers/method_call_sites.ts`** so its branches are reachable from
synthetic sources, and it is built on `ts.createSourceFile` following `tests/companion_read_api.test.ts`.
A hand-rolled lexer was written first and was wrong twice over: `src/ui/hud.ts` holds about a
hundred regex literals whose apostrophes and escaped slashes need a regex-versus-division guess,
and a generic type argument's `;` read as a class-member break (752 members against a real 742).
Neither error shows up in a green test.

### The named defect from the issue thread

`lockpick_window.paintTimer()` ran a 100ms interval and re-resolved all three of its element refs
on every tick, plus a blind `classList.toggle` whose value flips at most once per attempt.

**The literal form of the rule it violates would have broken the window**, which is the finding
worth carrying forward. `renderBoard()` replaces the panel subtree and fires on `lockpickRenderSig`
(which covers `row` and `visible.length`); the interval restarts on `lockpickTimerKey`
(`sessionId:page:tries:col`, covering neither). So moving the pick up a row rebuilds the countdown
nodes and does **not** restart the clock. Refs cached "once at construction" would paint into a
detached subtree and the bar would freeze for the rest of the attempt. They are resolved at the end
of `renderBoard()` instead, at the one `innerHTML` site that destroys them. `tests/lockpick_timer_repaint.test.ts`
pins both halves: it fails on the old code for the re-query and the unelided toggle, and its rebuild
case fails on the naive cache-at-`startTimer` fix.

Two smaller things went with it, both flagged in review: the refs resolve by class rather than by
the ids the markup also carries (the window is instance-parameterized on `deps.panel`, so two
instances would collide, and a second instance now renders in the test), and the countdown's one
decimal goes through `formatNumber` instead of `toFixed(1)`, which had been rendering `12.3` in
every locale. English output is byte-identical; ru_RU and de now get their comma.

### Verification

35 mutations run over the branch, all caught except the two that must pass (a reformatted gate
condition, which the normalization exists to tolerate) or that are honestly unobservable (two
`forgetTimerEls()` calls whose callers stop the clock first, said so at the call site rather than
covered by a green assertion that proves nothing). Mutation testing is also what found the
registry's own hole: relabelling a window row to `chrome` dropped its guard requirement with the
suite green, so a callee named `Window`/`Popup` is now a window row by rule and the surface split
is pinned to exact counts.

Reviewers found two more, both fixed here: the walk originally recorded only a statement's *head*
call, so `const musicState = this.instanceMusic.update({...})` was a live drive with no row and
`this.lastFoo = this.someWindow.render()` was a free way past the gate; and a guard proof was
merely *found* rather than counted, so a second copy appearing later would have weakened the pin
silently.

### What it deliberately does not do, stated in the file rather than implied

- It sees `update()`'s own body. A repaint added inside an already-registered private method is
  invisible to it.
- A guard proof catches **deletion**, not a guard neutered while its field survives. The
  instrument for that is behavioral and already exists per window.
- The band is the **call site's**, not any further self-throttling the callee adds.
- In a value slot only a call on `this` is registered, so a repaint written as a call on a local
  in a value slot would escape.

## Related issues

Closes #2498. Follow-up from #2497 (which closed #2492), same lineage as #2486 -> #2491 -> #2492.

## Type of change

- [x] Bug fix
- [x] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests

## How was this tested?

- Commands:
  - `npm run gate` (release tier, on a clean `npm ci` in the worktree): green.
  - `npx vitest run tests/hud_update_drive.test.ts tests/helpers/method_call_sites.test.ts tests/lockpick_timer_repaint.test.ts`
  - `npx vitest run tests/hud_perf_budget.test.ts tests/architecture.test.ts tests/painter_host.test.ts tests/lockpick_*.test.ts`
  - `npx tsc --noEmit`, `npx @biomejs/biome check` on the touched files.
- Manual steps: 35 scripted mutations across `src/ui/hud.ts`, the registry, the walk, a window
  module's guard, and `lockpick_window.ts`, each applied, run, and reverted. Results are summarized
  above; the two expected survivors are the reformat-tolerance case and the two unobservable
  teardowns.

## Screenshots / recordings

N/A. The only player-visible delta is the lockpick countdown's decimal separator in non-English
locales (`12.3` -> `12,3` in ru_RU/de), which is a formatter fix rather than a layout change;
English output is byte-identical.

---

## Checklist

### Quality

- [x] **The full gate passes.**

### Cross-platform

- [x] ~Tested on desktop and mobile.~ N/A: no layout, CSS, or touch surface changes.
- [x] ~Accessible.~ N/A: no UI added or edited. The countdown keeps its existing `aria-label` and
      its `t()` key.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.
- [x] Numbers go through the i18n formatters: this PR moves the lockpick countdown's seconds onto
      `formatNumber`, which it had been bypassing.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any
      production path.
- [x] No generated file hand-edited.
