### PR TITLE
fix(sim): collapse a repeated pid in a master-loot assignment

### DIFF
--- a/src/sim/loot/loot_roll.ts
+++ b/src/sim/loot/loot_roll.ts
@@ -595,8 +595,18 @@ export function assignMasterLoot(
   const roll = ctx.pendingLootRolls.get(rollId);
   if (!roll || roll.masterLooter === undefined) return;
   if (r.meta.entityId !== roll.masterLooter) return; // only the master looter decides
-  // Keep only still-eligible targets; ignore anyone no longer a candidate.
-  const targets = targetPids.filter((p) => roll.candidates.includes(p));
+  // Keep only still-eligible targets, each counted once; ignore anyone no longer
+  // a candidate. The pid list is client-supplied (the masterAssign wire case
+  // checks that pids is a non-empty array of numbers and nothing about the
+  // values), and a pid named twice would send that player two lootRoll prompts,
+  // print their reveal line twice, and can put one player in tiedWinners twice,
+  // drawing a tie-break ctx.rng.int the honest single-candidate case never draws.
+  // What is load-bearing is deduping BEFORE the length tests below, so [X, X]
+  // takes the direct-grant arm exactly like [X] instead of converting to a
+  // one-player need/greed roll (the dedupe and the filter commute, so their
+  // relative order is not). Set iterates in first-seen order, which preserves the
+  // caller's prompt and reveal order.
+  const targets = [...new Set(targetPids)].filter((p) => roll.candidates.includes(p));
   if (targets.length === 0) return; // nothing valid selected: leave the prompt open
   if (targets.length === 1) {
     // The target can have logged out during the up-to-5min curate window

--- a/src/sim/rng.ts
+++ b/src/sim/rng.ts
@@ -1,6 +1,8 @@
-// A per-draw observer (parity harness only). When installed, it is called with
-// every value `next()` produces, in draw order. Pure bookkeeping: it MUST NOT
-// draw rng or branch simulation behavior.
+// A per-draw observer (tests only: the parity harness, plus any test pinning
+// what a code path costs in draws). When installed, it is called with every
+// value `next()` produces, in draw order. Every other method (`range`, `int`,
+// `chance`, `pick`) funnels through `next()`, so it sees those too. Pure
+// bookkeeping: it MUST NOT draw rng or branch simulation behavior.
 export type RngObserver = (value: number) => void;
 
 // Deterministic seeded RNG (mulberry32) — all sim randomness must flow through this.
@@ -13,8 +15,8 @@ export class Rng {
     this.s = seed >>> 0;
     if (this.s === 0) this.s = 0x9e3779b9;
   }
-  // Parity-harness seam: install (or clear, with null) a per-draw observer. Off
-  // by default; the observer never affects the returned value or the state `s`.
+  // Test seam: install (or clear, with null) a per-draw observer. Off by
+  // default; the observer never affects the returned value or the state `s`.
   setObserver(observer: RngObserver | null): void {
     this.observer = observer;
   }

--- a/tests/loot_master_sim.test.ts
+++ b/tests/loot_master_sim.test.ts
@@ -288,3 +288,271 @@ describe('master loot', () => {
     expect(sim.events.filter((e) => e.type === 'lootRoll').length).toBeGreaterThan(0);
   });
 });
+
+// #2505. The pid list reaching assignMasterLoot is client-supplied and the
+// masterAssign wire case validates that pids is a non-empty array of numbers
+// and nothing about the values, so a hand-crafted frame can name the same
+// eligible candidate twice. Every case below runs the repeat against the
+// equivalent duplicate-free request on the SAME seed: the repeat must be
+// indistinguishable in bags, chat, prompts, and rng stream position.
+describe('a repeated pid in a master-loot assignment (#2505)', () => {
+  // Every rng draw `fn` spends, counted through the parity harness's own
+  // observer seam. A no-new-draws guard, NOT the determinism arm: the extra
+  // tie-break int a doubled candidate list buys is spent at RESOLUTION, which
+  // these windows do not reach, so both arms legitimately read the same here.
+  // The determinism arm is the stream-position case at the end of this block.
+  function countDraws(sim: Sim, fn: () => void): number {
+    let draws = 0;
+    const rng = (sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } }).rng;
+    rng.setObserver(() => {
+      draws++;
+    });
+    try {
+      fn();
+    } finally {
+      rng.setObserver(null);
+    }
+    return draws;
+  }
+
+  // The next `n` values off the shared world rng. Two worlds that ran
+  // equivalent requests from the same seed sit at the same stream position, so
+  // their drains match value for value; a world that spent one extra draw is
+  // offset by one and every later value differs.
+  function drainStream(sim: Sim, n: number): number[] {
+    const rng = (sim as unknown as { rng: { next: () => number } }).rng;
+    return Array.from({ length: n }, () => rng.next());
+  }
+
+  // A three-member party (a=leader=master looter) on a corpse holding PREMIUM,
+  // with the master-loot prompt already open and the event log cleared.
+  function openMasterRoll() {
+    const sim = makeSim();
+    const { a, b, mob } = partyOnCorpse(sim, PREMIUM);
+    const c = sim.addPlayer('rogue', 'Cara');
+    sim.partyInvite(c, a);
+    sim.partyAccept(c);
+    teleportTo(sim, 21, 21, c); // within loot range of the corpse
+    sim.setPartyLootMaster(true, 0, 'uncommon', a);
+    sim.lootCorpse(mob.id, a);
+    const prompt = sim.events.find((e) => e.type === 'masterLoot')!;
+    const rollId = prompt.rollId;
+    const { expiresAt, candidates } = prompt as {
+      expiresAt: number;
+      candidates: { pid: number }[];
+    };
+    sim.events.length = 0;
+    return { sim, a, b, c, mob, rollId, expiresAt, candidates };
+  }
+
+  // Runs one assignment and reports everything an observer could tell the two
+  // requests apart by: bags, chat, prompts, and draws.
+  function assign(pids: (ids: { a: number; b: number; c: number }) => number[]) {
+    const world = openMasterRoll();
+    const { sim, a, b, c, rollId } = world;
+    const draws = countDraws(sim, () => sim.assignMasterLoot(rollId, pids({ a, b, c }), a));
+    return {
+      ...world,
+      draws,
+      prompts: sim.events
+        .filter((e) => e.type === 'lootRoll' && e.rollId === rollId)
+        .map((e) => e.pid as number),
+      lines: sim.events.filter((e) => e.type === 'loot').map((e) => `${e.pid}|${e.text}`),
+      bags: [sim.countItem(PREMIUM, a), sim.countItem(PREMIUM, b), sim.countItem(PREMIUM, c)],
+    };
+  }
+
+  it('grants [X, X] exactly like [X], with the same chat and the same draw count', () => {
+    const dup = assign(({ b }) => [b, b]);
+    const once = assign(({ b }) => [b]);
+
+    // Not a vacuous comparison of two empty bags: the control really granted.
+    expect(once.bags).toEqual([0, 1, 0]);
+    expect(dup.bags).toEqual(once.bags);
+    // Chat compared verbatim, per recipient: the duplicate used to print the
+    // named player's line twice once the roll it wrongly opened resolved.
+    expect(dup.lines).toEqual(once.lines);
+    expect(dup.lines.filter((line) => line.includes('assigned'))).toHaveLength(3); // one per member
+    expect(dup.draws).toBe(0); // a direct grant draws nothing, and neither does the repeat
+    expect(once.draws).toBe(0);
+  });
+
+  it('takes the direct-grant arm for [X, X], not a one-player need/greed roll', () => {
+    // The deliberate behavior change the dedupe buys, pinned so it is a
+    // decision rather than a side effect: deduping BEFORE the length tests is
+    // what keeps [X, X] on the single-target arm. A dedupe placed after them
+    // would still convert the roll, prompt the player, and wait out the timer
+    // for a "contest" of one.
+    const dup = assign(({ b }) => [b, b]);
+    expect(dup.prompts).toEqual([]);
+    expect(dup.sim.activeLootRolls(dup.b)).toHaveLength(0);
+    expect(dup.sim.lootRollGroupStatus(dup.b)).toHaveLength(0); // the roll is gone, not reopened
+    // The three above are all absences, which "dropped on the floor" satisfies
+    // just as well. This is the one that says the item actually went somewhere.
+    expect(dup.bags).toEqual([0, 1, 0]);
+  });
+
+  it('rolls [X, X, Y] among X and Y once each, resolving when both have answered', () => {
+    const dup = assign(({ b, c }) => [b, b, c]);
+    const once = assign(({ b, c }) => [b, c]);
+
+    expect(once.prompts).toEqual([once.b, once.c]);
+    expect(dup.prompts).toEqual([dup.b, dup.c]); // one prompt each, not two for b
+
+    // The decisive arm: resolveLootRoll fires on `choices.size >= candidates.length`,
+    // so a candidate list still holding the repeat would sit at 2 of 3 answered
+    // and hang until the 60s timeout instead of resolving here.
+    const dupDraws = countDraws(dup.sim, () => {
+      dup.sim.submitLootRoll(dup.rollId, 'need', dup.b);
+      dup.sim.submitLootRoll(dup.rollId, 'need', dup.c);
+    });
+    const onceDraws = countDraws(once.sim, () => {
+      once.sim.submitLootRoll(once.rollId, 'need', once.b);
+      once.sim.submitLootRoll(once.rollId, 'need', once.c);
+    });
+
+    // A literal, not just an equality that could hold at zero: two needers cost
+    // exactly two rolls on this seed (no tie, so no tie-break int). The repeat
+    // used to add a third entry, hence a third reveal line and a tie-break draw.
+    expect(onceDraws).toBe(2);
+    expect(dupDraws).toBe(onceDraws);
+    expect(dup.sim.countItem(PREMIUM, dup.b) + dup.sim.countItem(PREMIUM, dup.c)).toBe(1);
+    expect([dup.sim.countItem(PREMIUM, dup.b), dup.sim.countItem(PREMIUM, dup.c)]).toEqual([
+      once.sim.countItem(PREMIUM, once.b),
+      once.sim.countItem(PREMIUM, once.c),
+    ]);
+
+    // Exactly one reveal line per contender per party member (3 members, 2
+    // contenders), and Bert's appears once, not twice.
+    const reveals = dup.sim.events.flatMap((e) =>
+      e.type === 'loot' && e.text.includes('Need Roll') ? [e.text] : [],
+    );
+    expect(reveals).toHaveLength(6);
+    expect(reveals.filter((text) => text.includes('Bert'))).toHaveLength(3);
+  });
+
+  it('keeps request order for a duplicate-free list, and first-seen order for a repeat', () => {
+    // Order decides prompt (and therefore reveal) order, so the dedupe must not
+    // sort or re-seat: the trailing copy of c does not move c behind b.
+    const plain = assign(({ b, c }) => [c, b]);
+    expect(plain.prompts).toEqual([plain.c, plain.b]);
+    const repeat = assign(({ b, c }) => [c, b, c]);
+    expect(repeat.prompts).toEqual([repeat.c, repeat.b]);
+
+    // Both expectations above are reversals of the roster: c joined the party
+    // after b, so roll.candidates runs b then c. Pinning that makes the two
+    // toEqual calls real order assertions rather than pairs that would also
+    // hold if the dedupe sorted, or rebuilt the list from roll.candidates.
+    expect(plain.c).toBeGreaterThan(plain.b);
+    expect(repeat.prompts).not.toEqual([repeat.b, repeat.c]);
+  });
+
+  it('ignores a repeat of a pid that is not a candidate at all', () => {
+    const world = openMasterRoll();
+    const draws = countDraws(world.sim, () =>
+      world.sim.assignMasterLoot(world.rollId, [99999, 99999], world.a),
+    );
+    // Deduping must not turn a rejected selection into an accepted one: an
+    // ineligible pid named twice is still an empty selection.
+    expect(draws).toBe(0);
+    expect(world.sim.events.filter((e) => e.type === 'lootRoll')).toHaveLength(0);
+    expect(world.sim.countItem(PREMIUM, world.b)).toBe(0);
+
+    // The prompt SURVIVED, rather than being quietly consumed. Nothing above
+    // can tell those apart: activeLootRolls hides a curate-phase master roll by
+    // design, so an empty reconcile surface is what a deleted roll looks like
+    // too. A valid assignment landing afterwards is the proof it was still open.
+    expect(world.sim.activeLootRolls(world.b)).toHaveLength(0); // curate phase, so not a prompt
+    world.sim.assignMasterLoot(world.rollId, [world.b], world.a);
+    expect(world.sim.countItem(PREMIUM, world.b)).toBe(1);
+  });
+
+  it('drops only the ineligible copy when a repeat and a stranger share a request', () => {
+    // The dedupe and the eligibility filter have to compose: a request mixing a
+    // repeated candidate with a pid that was never a candidate keeps one copy
+    // of the first and none of the second, so it is the single-target grant.
+    const mixed = assign(({ b }) => [b, b, 99999]);
+    expect(mixed.prompts).toEqual([]);
+    expect(mixed.bags).toEqual([0, 1, 0]);
+  });
+
+  it('lets the master looter assign a repeat of themselves', () => {
+    // The looter is an eligible candidate like any other, so [A, A] from A is a
+    // plain self-assignment, not a special case. Pinned because it is the one
+    // shape where the deduped pid is also the pid passing the ownership check.
+    const self = assign(({ a }) => [a, a]);
+    expect(self.prompts).toEqual([]);
+    expect(self.bags).toEqual([1, 0, 0]);
+  });
+
+  it('opens the master roll with a candidate roster that has no repeat', () => {
+    // Load-bearing for everything above: the dedupe only covers the pid list the
+    // CLIENT sends. If roll.candidates could itself carry a repeat (it cannot
+    // today: party.members is uniqueness-guarded at join, and lootRecipientIds
+    // is built from it) the identical doubled prompt, doubled reveal, and
+    // tie-break draw would come back through the other door.
+    const pids = openMasterRoll().candidates.map((cand) => cand.pid);
+    expect(pids).toHaveLength(3); // the whole party, so the check has something to catch
+    expect(new Set(pids).size).toBe(3);
+  });
+
+  it('routes a departed [X, X] target down the same fallback [X] takes', () => {
+    // The dedupe newly steers a repeat into the single-target arm, and that arm
+    // has its own guard: a target who logged out during the up-to-5min curate
+    // window would silently destroy the item, so it converts to need/greed over
+    // the FULL candidate list instead. Pinned because "[X, X] behaves exactly
+    // like [X]" has to hold on this branch too, not just the happy path.
+    const run = (pids: (ids: { b: number }) => number[]) => {
+      const world = openMasterRoll();
+      world.sim.entities.delete(world.b); // gone from the world, still on the roll
+      world.sim.assignMasterLoot(world.rollId, pids({ b: world.b }), world.a);
+      return {
+        ...world,
+        prompts: world.sim.events
+          .filter((e) => e.type === 'lootRoll' && e.rollId === world.rollId)
+          .map((e) => e.pid as number),
+      };
+    };
+    const dup = run(({ b }) => [b, b]);
+    const once = run(({ b }) => [b]);
+
+    // The full roster, not the named target: the fallback deliberately widens.
+    expect(once.prompts).toEqual([once.a, once.b, once.c]);
+    expect(dup.prompts).toEqual(once.prompts);
+    expect(dup.sim.countItem(PREMIUM, dup.a)).toBe(0); // nothing granted on this arm
+  });
+
+  // The determinism arm. The duplicate's extra draw is a tie-break ctx.rng.int
+  // spent when the roll RESOLVES, so no assertion taken at assignment time can
+  // see it: reaching it means ticking the roll past its deadline. Counting
+  // draws across ticks is not usable (world simulation draws too), so this
+  // compares where the shared stream ENDS UP instead, which is the property
+  // that actually matters: a repeat must not shift the world's draw sequence.
+  it('leaves the world rng stream exactly where [X] leaves it', () => {
+    const run = (pids: (ids: { b: number; c: number }) => number[]) => {
+      const world = openMasterRoll();
+      world.sim.assignMasterLoot(world.rollId, pids({ b: world.b, c: world.c }), world.a);
+      // Whatever the assignment opened (nothing, on the fixed single-target
+      // arm), answer it and run out every deadline it could be waiting on.
+      world.sim.submitLootRoll(world.rollId, 'need', world.b);
+      world.sim.time = world.expiresAt - 0.5;
+      for (let i = 0; i < 40; i++) world.sim.tick();
+      return { world, stream: drainStream(world.sim, 4) };
+    };
+    const dup = run(({ b }) => [b, b]);
+    const once = run(({ b }) => [b]);
+    expect(dup.stream).toEqual(once.stream);
+
+    // Sensitivity, so the equality above is not just two worlds that never
+    // diverge: a genuinely different request DOES move the stream, which is
+    // what the duplicate used to do (an extra reveal entry and a tie-break int
+    // for a player tied with itself).
+    const other = run(({ b, c }) => [b, c]);
+    expect(other.stream).not.toEqual(once.stream);
+    expect(new Set(once.stream).size).toBe(4); // a real drain, not four repeats of one value
+
+    // And the plain determinism floor: the same request on the same seed twice
+    // is the same world, so the repeat run reproduces its own stream too.
+    expect(run(({ b }) => [b, b]).stream).toEqual(dup.stream);
+  });
+});

--- a/tests/loot_roll_wire.test.ts
+++ b/tests/loot_roll_wire.test.ts
@@ -95,3 +95,162 @@ describe('loot roll self-snapshot parity', () => {
     expect(client.activeLootRolls().map((p) => p.itemId)).toContain('greyjaw_hide_boots');
   });
 });
+
+// #2505 over the wire. `pids` is a client-supplied array the authoritative
+// server acts on per element, and no shipped client sends a repeat (the loot
+// window's checkbox list builds unique pids), so the only way in is a
+// hand-crafted frame. This drives exactly that frame through a REAL GameServer
+// into the REAL sim, because the wire is where the untrusted value enters and a
+// fix that only held for a direct sim call would not close it.
+//
+// One server per request, and none of them tick: GameServer pins a constant
+// WORLD_SEED (asserted below, not assumed), so two runs generate the identical
+// world and any difference in the result is the pid list.
+describe('a repeated pid in a masterAssign frame, through a real GameServer (#2505)', () => {
+  // A hand-built frame, the untrusted shape the issue reproduces with, parsed
+  // and dispatched exactly as a socket message is. `t: 'cmd'` is the real
+  // envelope (ClientWorld.rawCmd); without it the dispatcher drops the frame as
+  // a protocol anomaly and a test would pass on a command that never ran.
+  function sendCmd(server: GameServer, session: any, frame: Record<string, unknown>): string {
+    const raw = JSON.stringify({ t: 'cmd', ...frame });
+    (server as any).dispatchMessage(session, JSON.parse(raw), raw, 0);
+    return raw;
+  }
+
+  function serverAssign(pids: (ids: { a: number; b: number }) => number[]) {
+    const server = new GameServer();
+    const sa = server.join(fakeWs().ws as any, 11, 11, 'Aaa', 'warrior', null) as any;
+    const sb = server.join(fakeWs().ws as any, 12, 12, 'Bbb', 'mage', null) as any;
+    sa.blockListLoaded = true;
+    sb.blockListLoaded = true;
+    const a = sa.pid as number;
+    const b = sb.pid as number;
+    const sim = server.sim;
+    // The premise behind comparing two separate servers: GameServer pins a
+    // constant WORLD_SEED, so both runs generate the identical world and any
+    // difference in the result is the pid list. A literal, not the imported
+    // constant, so an env-derived or per-instance seed would fail here rather
+    // than silently turn every dup-vs-once comparison into a coincidence.
+    expect(sim.cfg.seed).toBe(20061);
+    for (const [pid, x] of [
+      [a, 20],
+      [b, 21],
+    ] as const) {
+      const e = sim.entities.get(pid)!;
+      e.pos = { x, y: 0, z: 20 };
+      e.prevPos = { ...e.pos };
+    }
+    sim.partyInvite(b, a);
+    sim.partyAccept(b);
+    sim.setPartyLootMaster(true, 0, 'uncommon', a);
+
+    // A world-unique corpse id: the server sim is a full generated world, so a
+    // hand-picked literal could collide with a real entity.
+    const mobId = [...sim.entities.keys()].reduce((max, k) => (k > max ? k : max), 0) + 1;
+    const mob = createMob(mobId, MOBS.forest_wolf, 2, { x: 20, y: 0, z: 22 });
+    mob.dead = true;
+    mob.lootable = true;
+    mob.tappedById = a;
+    mob.loot = { copper: 0, items: [{ itemId: 'greyjaw_hide_boots', count: 1 }] };
+    sim.entities.set(mob.id, mob);
+    sim.lootCorpse(mob.id, a);
+    const rollId = sim.events.find((e) => e.type === 'masterLoot')!.rollId;
+    sim.events.length = 0;
+
+    const rng = (sim as unknown as { rng: { setObserver: (o: (() => void) | null) => void } }).rng;
+    const countDraws = (fn: () => void): number => {
+      let draws = 0;
+      rng.setObserver(() => {
+        draws++;
+      });
+      try {
+        fn();
+      } finally {
+        rng.setObserver(null);
+      }
+      return draws;
+    };
+
+    let raw = '';
+    const draws = countDraws(() => {
+      raw = sendCmd(server, sa, { cmd: 'masterAssign', rollId, pids: pids({ a, b }) });
+    });
+    return {
+      a,
+      b,
+      raw,
+      draws,
+      // Answer the roll (if one opened) over the wire too, and report what that
+      // costs: one ctx.rng.int(1, 100) per non-pass choice.
+      answerDraws: (choices: ('need' | 'greed' | 'pass')[]) =>
+        countDraws(() => {
+          for (const [i, session] of [sa, sb].entries())
+            sendCmd(server, session, { cmd: 'lootRoll', rollId, choice: choices[i] });
+        }),
+      inventory: structuredClone(
+        (sim as unknown as { players: Map<number, { inventory: any[] }> }).players.get(b)!
+          .inventory,
+      ),
+      boots: [sim.countItem('greyjaw_hide_boots', a), sim.countItem('greyjaw_hide_boots', b)],
+      prompts: sim.events
+        .filter((e) => e.type === 'lootRoll' && e.rollId === rollId)
+        .map((e) => e.pid as number),
+    };
+  }
+
+  it('lands the same bags [X] lands, with the same prompts and the same draw count', () => {
+    const dup = serverAssign(({ b }) => [b, b]);
+    const once = serverAssign(({ b }) => [b]);
+
+    // The frame really carried the repeat, and named the pid the control names:
+    // the assertions below are about the sim collapsing it, not about the
+    // payload never arriving or the two runs assigning to different players.
+    const dupPids = JSON.parse(dup.raw).pids as number[];
+    const oncePids = JSON.parse(once.raw).pids as number[];
+    expect(oncePids).toHaveLength(1);
+    expect(dupPids).toEqual([oncePids[0], oncePids[0]]);
+    // Not a vacuous comparison of two empty bags: the control really granted.
+    expect(once.boots).toEqual([0, 1]);
+    expect(dup.boots).toEqual(once.boots);
+    expect(dup.inventory).toEqual(once.inventory);
+    // The repeat must not convert the assignment into a need/greed roll, and
+    // must not buy the extra tie-break draw a doubled candidate list can.
+    expect(dup.prompts).toEqual([]);
+    expect(once.prompts).toEqual([]);
+    expect(dup.draws).toBe(0);
+    expect(once.draws).toBe(0);
+  });
+
+  it('rolls a two-target wire assignment among both, in request order', () => {
+    // The positive control for this file's two instruments. Every assertion in
+    // the test above reads empty or zero, so a prompts extractor pointed at the
+    // wrong rollId, an event log drained by something else, or an observer
+    // wired to anything other than the rng the sim draws from would report the
+    // very same thing and this file would stay green. This run forces both
+    // instruments to a non-empty, non-zero reading, and covers the multi-target
+    // arm and first-seen order over the wire at the same time (the test above
+    // only reaches the single-target arm).
+    const both = serverAssign(({ a, b }) => [b, a]);
+    expect(both.prompts).toEqual([both.b, both.a]);
+    expect(both.b).toBeGreaterThan(both.a); // request order, reversed from the roster
+    expect(both.boots).toEqual([0, 0]); // a roll opened, so nothing is granted yet
+    // Two needers, one ctx.rng.int(1, 100) each: a literal the zeros above
+    // cannot supply, and the anchor that proves the observer intercepts.
+    expect(both.answerDraws(['need', 'need'])).toBe(2);
+  });
+
+  it('forwards the repeat verbatim: the SIM boundary is what closes it, not the server', () => {
+    // Deliberate, and the reason the fix lives in assignMasterLoot: the offline
+    // Sim reaches the same command through IWorld (loot_roll_controller.ts ->
+    // Sim.assignMasterLoot) without ever passing through server/game.ts, so
+    // sanitizing here would have left that host open. If a future change starts
+    // deduping on the server too, this test is the one that should be
+    // re-argued, not quietly deleted.
+    const server = new GameServer();
+    const session = server.join(fakeWs().ws as any, 13, 13, 'Ccc', 'warrior', null) as any;
+    session.blockListLoaded = true;
+    const spy = vi.spyOn(server.sim, 'assignMasterLoot').mockImplementation(() => {});
+    sendCmd(server, session, { cmd: 'masterAssign', rollId: 4242, pids: [7, 7] });
+    expect(spy).toHaveBeenCalledWith(4242, [7, 7], session.pid);
+  });
+});


### PR DESCRIPTION
## Summary

The `masterAssign` wire case validates that `msg.pids` is a non-empty array of numbers and nothing about the values, so a hand-crafted frame could name one eligible candidate twice. `assignMasterLoot` kept both copies, which gave that player two `lootRoll` prompts, printed their reveal line twice, and could leave `tiedWinners` holding one player twice, buying a tie-break `ctx.rng.int` the honest single-candidate case never draws.

The fix is one line in `src/sim/loot/loot_roll.ts`: dedupe with a `Set` **before** the length tests, so `[X, X]` takes the direct-grant arm exactly like `[X]` rather than converting to a single-player need/greed roll. `Set` iterates in first-seen order, which is what decides prompt and reveal order. Deduping before the length tests is the load-bearing part; the dedupe and the eligibility filter commute, so their relative order is not.

Fixed at the sim boundary rather than in `server/game.ts`, for the same reason #2474 was (PR #2503): the offline `Sim` reaches the same command through `IWorld` (`loot_roll_controller.ts` -> `Sim.assignMasterLoot`) without ever passing through the server dispatch, so a server-side fix would have left that host open. A test pins that the server still forwards the repeat verbatim, so adding a second sanitizer later has to be argued rather than added quietly.

**Behavior change, deliberate and pinned:** `[X, X]` is now a direct grant, not a one-player need/greed roll. The issue flagged this as worth pinning explicitly, and it has its own test.

## Related issues

Closes #2505.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npm run gate` -> **PASS, all 11 steps green** (release tier, on a `release/**` branch)
  - `npx vitest run tests/loot_master_sim.test.ts tests/loot_roll_wire.test.ts` -> 28 passed
  - `npx vitest run tests/parity tests/architecture.test.ts tests/world_api_parity.test.ts` -> green
  - `npx tsc --noEmit` -> clean
- Revert check: with the dedupe reverted in place, **9 of the 13 new tests fail**. The other 4 pass by design (they guard the fix's blast radius rather than reproduce the bug): the non-candidate refusal, the candidate-roster uniqueness pin, the wire positive control, and "forwards the repeat verbatim".
- Mutation check: the pins kill every plausible partial fix, including dedupe-placed-after-the-length-tests, a sorting dedupe, rebuilding from `roll.candidates`, a last-seen-order dedupe, and moving the fix to the server.

### On the determinism assertion

The duplicate's extra draw is spent at **resolution**, so no assertion taken at assignment time can see it. Rather than count draws across ticks (world simulation draws too), the determinism test runs both worlds out past the roll deadline and compares where the shared rng stream ends up, which is the property that actually matters. It carries a sensitivity check that a genuinely different request does move the stream, so the equality is not two worlds that never diverge.

Both test files also carry a non-zero draw anchor, verified by neutering `Rng.setObserver`: without it a dead observer would report `0` everywhere and both arms would pass vacuously.

## Screenshots / recordings

N/A, no user-visible surface changes. The player-facing effect is the removal of a duplicate prompt and a duplicated chat line.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green, with decisive tests for the changed behavior.

### Cross-platform

- ~[ ] Tested on desktop and mobile.~ N/A, no UI change.
- ~[ ] Accessible.~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The `assigned [[i:...]] to ...` line the direct-grant arm now reaches is pre-existing and already matched client-side.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

## Follow-ups (filed separately, not widened into this diff)

- No parity scenario exercises master loot in any form, so the parity gate's green is vacuous for this path.
- `masterAssign` is the only array-taking wire case with no upper length bound on its array.
- A rejected assignment strands the master looter's HUD until the 5-minute timeout, because the controller deletes the row optimistically while curate-phase master rolls are excluded from both reconcile reads. Pre-existing and symmetric across hosts.