### PR TITLE
fix(ui): gate the Town Focus repaint on a signature, and keep keyboard focus

### DIFF
--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -83,10 +83,11 @@ Per-frame HUD code (anything reached from `Hud.update()`) holds these:
   `HOT_PAINTERS` / `CANVAS_PAINTERS`, not every module `update()` touches. `Hud.update()` also
   polls about half the `*_window.ts` painters (`spellbook_window.tickOpen()` runs every frame
   while open; arena / dungeon_finder / vale_cup / card_duel `render()` on the 250ms band; the
-  rest get `refreshIfChanged()` on the 500ms band). MOST of those rebuild behind their own
-  invalidation signature, which no per-file scan can see, and `town_focus_window` does not:
-  it repaints on the open check alone, which is the standing proof that the signature guard is
-  a convention rather than something enforced.
+  rest get `refreshIfChanged()` on the 500ms band). Those rebuild behind their own invalidation
+  signature, which no per-file scan can see: it lives either inside the window module or on the
+  `Hud` method that polls it (`refreshOpenTownFocusIfChanged`). `town_focus_window` was the
+  standing counter-example until #2500 gave it one; a window polled from `update()` with no
+  signature is a defect, not a style choice.
   **WHICH windows those are is now a registry**, not folklore: `tests/hud_update_drive.test.ts`
   holds a row per call `Hud.update()` EVALUATES, with its cadence band, the exact condition text
   gating it, what it repaints, and (for a window) the source line its invalidation guard is

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -505,7 +505,7 @@ import type { PresetId, ThemeKnob, ThemeState } from './theme';
 import { SharedTooltipOwner } from './tooltip_owner';
 import { TOOLTIP_PEEK_MS, TouchPeekGuard } from './touch_peek';
 import { bindTouchDoubleTap, bindTouchTap, CLICK_SUPPRESS_MS, TAP_SLOP_PX } from './touch_tap';
-import { buildTownFocusView, stepTownFocus } from './town_focus_view';
+import { buildTownFocusView, stepTownFocus, townFocusRenderSig } from './town_focus_view';
 import { renderTownFocusWindow } from './town_focus_window';
 import { TutorialOverlay } from './tutorial';
 import { svgIcon } from './ui_icons';
@@ -5066,6 +5066,12 @@ export class Hud {
       this.renderTrain();
     if (this.openUnbindNpcId !== null && $('#unbind-window').style.display === 'block')
       this.renderUnbind();
+    // The Town Focus signature is text-independent (the allocation, the budget
+    // and the in-town flag), so a language switch alone never moves it and the
+    // slow-band probe would leave the panel in the old locale until the player
+    // edited it. Force one rebuild with fresh t(), the arena / Vale Cup
+    // relocalize arm (#2500).
+    if (this.townFocusOpen) this.renderTownFocus();
     if (this.marketWindow.isOpen) this.marketWindow.render();
     if (this.bankWindow.isOpen) this.bankWindow.render();
     if (this.deedsWindow.isOpen) this.deedsWindow.render();
@@ -7158,7 +7164,11 @@ export class Hud {
       const inTown = this.isInTown();
       const townFocusBtn = document.getElementById('mm-town-focus');
       if (townFocusBtn) townFocusBtn.style.display = inTown ? '' : 'none';
-      if (this.townFocusOpen) this.renderTownFocus();
+      // An open panel converges on the same band, behind its own invalidation
+      // signature (#2500): the probe reads cheaply and rebuilds only when what
+      // the panel shows moves. Walking in or out of town is one of the inputs
+      // it carries, so the panel's disabled state follows the button above.
+      this.refreshOpenTownFocusIfChanged();
       // Crafting window staleness: the
       // window is a cold painter, so an open window repaints only when the
       // in-range station-type set changes (walking in/out of a station's
@@ -11838,6 +11848,11 @@ export class Hud {
 
   private townFocusDraft: Record<string, number> | null = null;
 
+  /** The signature of what the panel currently shows (#2500). `''` until the
+   *  first paint arms it, which no real signature can spell (every one carries
+   *  the in-town flag, the budget and a row per component). */
+  private lastTownFocusSig = '';
+
   private isInTown(): boolean {
     const pos = this.sim.player.pos;
     return isInTownZone(pos, zoneAt(pos.z));
@@ -11857,27 +11872,49 @@ export class Hud {
   private renderTownFocus(): void {
     const inTown = this.isInTown();
     const allocation = this.townFocusDraft ?? this.sim.townFocus;
-    renderTownFocusWindow(
-      $('#town-focus-window'),
-      buildTownFocusView(allocation, FOCUS_POINT_BUDGET, inTown),
-      {
-        onStep: (component, delta) => {
-          this.townFocusDraft = stepTownFocus(
-            this.townFocusDraft ?? this.sim.townFocus,
-            component,
-            delta,
-            FOCUS_POINT_BUDGET,
-          );
-          this.renderTownFocus();
-        },
-        onSave: () => {
-          this.sim.setTownFocus(this.townFocusDraft ?? {});
-          this.townFocusDraft = null;
-          this.closeTownFocus();
-        },
-        onClose: () => this.closeTownFocus(),
+    const view = buildTownFocusView(allocation, FOCUS_POINT_BUDGET, inTown);
+    // Re-arm the latch on EVERY paint, whatever caused it (the open, a step, a
+    // language switch), so the slow-band probe below elides against the state
+    // actually on screen rather than against the last thing the probe itself
+    // painted.
+    this.lastTownFocusSig = townFocusRenderSig(view);
+    renderTownFocusWindow($('#town-focus-window'), view, {
+      onStep: (component, delta) => {
+        this.townFocusDraft = stepTownFocus(
+          this.townFocusDraft ?? this.sim.townFocus,
+          component,
+          delta,
+          FOCUS_POINT_BUDGET,
+        );
+        this.renderTownFocus();
       },
+      onSave: () => {
+        this.sim.setTownFocus(this.townFocusDraft ?? {});
+        this.townFocusDraft = null;
+        this.closeTownFocus();
+      },
+      onClose: () => this.closeTownFocus(),
+    });
+  }
+
+  /** Slow-band staleness check for an OPEN panel (#2500). The panel used to
+   *  repaint on the open check alone, so an idle one discarded and rebuilt its
+   *  entire subtree twice a second: wasted work, and it destroyed the keyboard
+   *  user's focused control on a timer. Rebuild only when what the panel shows
+   *  actually moves (an edit to the draft, or walking in or out of town). The
+   *  open check comes FIRST so a closed panel costs nothing at all, and
+   *  renderTownFocus() owns the re-arm so every other paint cause arms it too. */
+  private refreshOpenTownFocusIfChanged(): void {
+    if (!this.townFocusOpen) return;
+    const sig = townFocusRenderSig(
+      buildTownFocusView(
+        this.townFocusDraft ?? this.sim.townFocus,
+        FOCUS_POINT_BUDGET,
+        this.isInTown(),
+      ),
     );
+    if (sig === this.lastTownFocusSig) return;
+    this.renderTownFocus();
   }
 
   closeTownFocus(): void {

--- a/src/ui/town_focus_view.ts
+++ b/src/ui/town_focus_view.ts
@@ -1,7 +1,7 @@
 // Pure, host-agnostic view model for the town-focus allocation panel (#1143).
 //
-// DOM/i18n-free so tests/town_focus_view.test.ts can drive it directly against
-// either a Sim- or ClientWorld-shaped input. Owns the one thing worth testing
+// DOM/i18n-free so tests/town_focus_repaint_gate.test.ts can drive it directly
+// against either a Sim- or ClientWorld-shaped input. Owns the one thing worth testing
 // without a DOM: turning a raw townFocus allocation + budget into per-component
 // rows (current points, whether it can still take another point, whether it
 // can give one back) and the remaining-point count. Rendering lives in
@@ -48,6 +48,37 @@ export function buildTownFocusView(
     };
   });
   return { rows, totalSpent, budget, remaining, inTown };
+}
+
+/**
+ * The compact repaint signature for an open panel (#2500).
+ *
+ * Hud polls this on the slow band and rebuilds only when it moves, the
+ * "poll cheaply, rebuild on a signature change" shape the rest of the window
+ * family already uses. Before it existed the panel discarded and rebuilt its
+ * whole subtree twice a second on the open check alone, which restored
+ * scrollTop but destroyed the keyboard user's focused control on a timer.
+ *
+ * Built from the VIEW rather than from the raw allocation so completeness is
+ * checkable by inspection: renderTownFocusWindow reads `inTown`, `budget`,
+ * `remaining` and each row's `component` / `points` / `canIncrease` /
+ * `canDecrease`, and every one of those is a term here. `totalSpent` is the
+ * one view field it deliberately omits, because nothing renders it (and
+ * `remaining` is derived from it anyway); tests/town_focus_repaint_gate.test.ts
+ * pins that set against the painter's real source, and refuses an alias that
+ * would read a field past the scan, so a future row that starts rendering
+ * another field cannot leave the gate behind.
+ *
+ * Language is deliberately NOT a term. A switch never moves the allocation, so
+ * it is converged by Hud.refreshLocalizedDynamicUi() forcing one rebuild, the
+ * same arm the arena / Vale Cup surfaces use for their text-independent
+ * signatures.
+ */
+export function townFocusRenderSig(view: TownFocusView): string {
+  const rows = view.rows
+    .map((r) => `${r.component}:${r.points}:${r.canIncrease ? 1 : 0}${r.canDecrease ? 1 : 0}`)
+    .join('|');
+  return `${view.inTown ? 1 : 0}/${view.budget}/${view.remaining}/${rows}`;
 }
 
 /** Applies a single +1/-1 step to `component`, clamped at 0 and at the budget. */

--- a/src/ui/town_focus_window.ts
+++ b/src/ui/town_focus_window.ts
@@ -16,13 +16,37 @@ export interface TownFocusWindowDeps {
   onClose(): void;
 }
 
+/** The stable identity of a focusable control, carried across the wipe below.
+ *  A stepper is keyed by component AND direction so the rebuilt equivalent is
+ *  the one the player was actually on; Save and Close are singletons. */
+type FocusRole = 'dec' | 'inc';
+const SAVE_FOCUS_KEY = 'save';
+const CLOSE_FOCUS_KEY = 'close';
+const stepFocusKey = (component: string, role: FocusRole): string => `${component}:${role}`;
+
 export function renderTownFocusWindow(
   el: HTMLElement,
   view: TownFocusView,
   deps: TownFocusWindowDeps,
 ): void {
   const scrollTop = el.scrollTop;
-  el.innerHTML = `<div class="panel-title"><span>${esc(t('hudChrome.townFocus.title'))}</span><button type="button" class="x-btn" data-close aria-label="${esc(t('itemUi.vendor.close'))}">${svgIcon('close')}</button></div>`;
+  // This is a full wipe, so every control the player could be standing on is
+  // about to be destroyed. Scroll position was already carried across; focus
+  // is the other half (#2500). A step click rebuilds the whole panel, which
+  // would otherwise drop keyboard focus to <body> and leave a keyboard player
+  // unable to press + a second time. Remember which control had it (by
+  // component + role) so the rebuilt equivalent can reclaim it below, the
+  // mailbox_window parcel-stepper idiom.
+  // `instanceof` rather than a cast: activeElement is typed Element, and the
+  // dataset read below is only sound on an HTMLElement (focus_manager.ts
+  // narrows the same way). The containment check is load-bearing, not
+  // defensive: mailbox_window keys its parcel steppers with the SAME
+  // data-focus-key attribute in the same shape, so an unguarded read would let
+  // a slow-band repaint here pull focus out of another open window.
+  const active = document.activeElement;
+  const focusKey =
+    active instanceof HTMLElement && el.contains(active) ? (active.dataset.focusKey ?? null) : null;
+  el.innerHTML = `<div class="panel-title"><span>${esc(t('hudChrome.townFocus.title'))}</span><button type="button" class="x-btn" data-close data-focus-key="${CLOSE_FOCUS_KEY}" aria-label="${esc(t('itemUi.vendor.close'))}">${svgIcon('close')}</button></div>`;
 
   const hint = document.createElement('div');
   hint.className = 'town-focus-hint';
@@ -59,6 +83,7 @@ export function renderTownFocusWindow(
   });
   el.appendChild(budget);
 
+  const steppers = new Map<string, { dec: HTMLButtonElement; inc: HTMLButtonElement }>();
   for (const row of view.rows) {
     const componentName = t(
       `hudChrome.corpseHarvest.components.${row.component}` as Parameters<typeof t>[0],
@@ -72,6 +97,7 @@ export function renderTownFocusWindow(
     dec.className = 'tf-step';
     dec.textContent = '-';
     dec.disabled = !row.canDecrease;
+    dec.dataset.focusKey = stepFocusKey(row.component, 'dec');
     dec.setAttribute(
       'aria-label',
       t('hudChrome.townFocus.decreaseAria', { component: componentName }),
@@ -83,6 +109,7 @@ export function renderTownFocusWindow(
     inc.className = 'tf-step';
     inc.textContent = '+';
     inc.disabled = !row.canIncrease;
+    inc.dataset.focusKey = stepFocusKey(row.component, 'inc');
     inc.setAttribute(
       'aria-label',
       t('hudChrome.townFocus.increaseAria', { component: componentName }),
@@ -92,6 +119,7 @@ export function renderTownFocusWindow(
     rowEl.appendChild(dec);
     rowEl.appendChild(inc);
     el.appendChild(rowEl);
+    steppers.set(row.component, { dec, inc });
   }
 
   const save = document.createElement('button');
@@ -99,10 +127,57 @@ export function renderTownFocusWindow(
   save.className = 'town-focus-save';
   save.textContent = t('hudChrome.townFocus.saveButton');
   save.disabled = !view.inTown;
+  save.dataset.focusKey = SAVE_FOCUS_KEY;
   save.addEventListener('click', () => deps.onSave());
   el.appendChild(save);
 
-  el.querySelector('[data-close]')?.addEventListener('click', () => deps.onClose());
+  const close = el.querySelector<HTMLButtonElement>('[data-close]');
+  close?.addEventListener('click', () => deps.onClose());
   el.style.display = 'block';
   el.scrollTop = scrollTop;
+  // Scroll FIRST, then focus, and deliberately WITHOUT { preventScroll: true }.
+  // `focus()` scrolls its target into view, so this order lets a degraded
+  // target (Save or Close, when the control the player was on came back
+  // disabled) win over the restored offset. That is the wanted outcome: focus
+  // must be visible (WCAG 2.4.11), and the common case cannot conflict, since
+  // the control being refocused is the one the player was already looking at,
+  // so it is in view and `focus()` scrolls nothing. Reversing the two, or
+  // passing preventScroll, would trade a visible focus ring for an offset the
+  // player can no longer see the focus in.
+  if (focusKey !== null) restoreFocus(focusKey, steppers, save, close);
+}
+
+/**
+ * Hand focus back to the rebuilt equivalent of the control that had it.
+ *
+ * The control the player just activated can legitimately come back DISABLED
+ * (stepping the last point off a component disables its `-`, spending the last
+ * budget point disables every `+`, and leaving town disables all of them), and
+ * a disabled button cannot take focus. So this degrades along the row the
+ * player is working in before it leaves it: the same stepper, then the row's
+ * other stepper, then Save, then Close. Landing on Close is still keyboard
+ * operation; landing on <body> is not.
+ */
+function restoreFocus(
+  focusKey: string,
+  steppers: ReadonlyMap<string, { dec: HTMLButtonElement; inc: HTMLButtonElement }>,
+  save: HTMLButtonElement,
+  close: HTMLButtonElement | null,
+): void {
+  const [component, role] = focusKey.split(':');
+  // `pair`, never `row`: tests/town_focus_repaint_gate.test.ts scans this file
+  // for every `row.<field>` read to prove the repaint signature covers them
+  // all, so `row` is reserved for the view row it walks.
+  const pair = steppers.get(component) ?? null;
+  const preferred = pair === null ? null : role === 'dec' ? pair.dec : pair.inc;
+  const other = pair === null ? null : role === 'dec' ? pair.inc : pair.dec;
+  // Close first for the X, so dismissing from the keyboard never jumps the
+  // player onto Save; every other key walks the row outward.
+  const candidates: ReadonlyArray<HTMLButtonElement | null> =
+    focusKey === CLOSE_FOCUS_KEY ? [close, save] : [preferred, other, save, close];
+  for (const candidate of candidates) {
+    if (candidate === null || candidate.disabled) continue;
+    candidate.focus();
+    return;
+  }
 }

--- a/tests/hud_perf_budget.test.ts
+++ b/tests/hud_perf_budget.test.ts
@@ -498,12 +498,13 @@ const CANVAS_PAINTERS: ReadonlyArray<ScannedPainter> = [
 // roughly half of them: spellbook_window's tickOpen() runs EVERY FRAME while the window is
 // open and says so in its own comments; arena, dungeon_finder, vale_cup and card_duel are
 // render()ed on the 250ms medium band behind only a display check; social, market, mailbox,
-// bank, bags, deeds, professions and calendar get refreshIfChanged() on the 500ms band;
-// crafting and loot_settings are repainted behind invalidation signatures; and town_focus is
-// repainted on the 500ms band behind an OPEN check and nothing else. The repo's INTENDED
-// window pattern is POLL CHEAPLY, REBUILD ON A SIGNATURE CHANGE, the guard lives inside the
-// module where no per-file scan can see it, and town_focus is the standing proof that this is
-// a convention rather than something anything enforces.
+// bank, bags, deeds, professions and calendar get refreshIfChanged() on the 500ms band; and
+// crafting, loot_settings and town_focus are repainted behind invalidation signatures. The
+// repo's INTENDED window pattern is POLL CHEAPLY, REBUILD ON A SIGNATURE CHANGE, and the guard
+// lives where no per-file scan can see it: inside the window module, or on the Hud method that
+// polls it. town_focus was the standing proof that this is a convention rather than something
+// anything enforces, and it held that role until #2500 gave it a signature; the enforcement is
+// now tests/hud_update_drive.test.ts, which requires a guard per driven window row by name.
 //
 // So this bucket claims nothing about cadence. What it does is hold the two contracts that
 // are true whatever the cadence turns out to be, at the same exact counts every other bucket

--- a/tests/hud_update_drive.test.ts
+++ b/tests/hud_update_drive.test.ts
@@ -316,15 +316,12 @@ const HUD_UPDATE_DRIVES: readonly DriveRow[] = [
     why: 'the zone read behind the Town Focus button and the open panel gate; no DOM write',
   },
   {
-    call: 'this.renderTownFocus',
+    call: 'this.refreshOpenTownFocusIfChanged',
     band: 'slow',
-    gate: 'this.townFocusOpen',
+    gate: '',
     surface: 'window',
-    guard: {
-      kind: 'none',
-      why: 'the standing exception (#2500): the open check is the whole gate, so the window rebuilds its DOM twice a second and restores scrollTop but not keyboard focus',
-    },
-    why: 'a full rebuild of the Town Focus window',
+    guard: { kind: 'hud', proof: 'if (sig === this.lastTownFocusSig) return;' },
+    why: 'rebuilds the Town Focus window when the allocation draft or the in-town flag moves. The standing exception of this table until #2500, when the open check was the whole gate and an idle panel rebuilt its whole subtree twice a second, restoring scrollTop but destroying keyboard focus',
   },
   {
     call: 'this.renderCrafting',
@@ -1290,7 +1287,7 @@ describe('Hud.update() drives exactly the registered set, on the registered band
     ).toEqual({ window: 37, chrome: 68, none: 12 });
     const windows = HUD_UPDATE_DRIVES.filter((r) => r.surface === 'window');
     expect(windows.map((r) => r.call)).toContain('this.spellbookWindow.tickOpen');
-    expect(windows.map((r) => r.call)).toContain('this.renderTownFocus');
+    expect(windows.map((r) => r.call)).toContain('this.refreshOpenTownFocusIfChanged');
     // The guard KINDS are pinned the same way and for the same reason: `kind` is otherwise a
     // free-text opt-out, so a row could keep `surface: 'window'`, keep the counts above
     // intact, and swap `module` for a plausible-sounding `none` while the real guard was
@@ -1300,9 +1297,9 @@ describe('Hud.update() drives exactly the registered set, on the registered band
       if (row.guard) byKind[row.guard.kind] = (byKind[row.guard.kind] ?? 0) + 1;
     expect(byKind, 'a guard kind changed: say why in the PR, not only in the table').toEqual({
       module: 19,
-      hud: 4,
+      hud: 5,
       callsite: 9,
-      none: 5,
+      none: 4,
     });
     // ...and the honest-exception list by NAME, because that is the one that should never
     // grow quietly: every entry is a window this repo knows has no invalidation guard.
@@ -1314,7 +1311,6 @@ describe('Hud.update() drives exactly the registered set, on the registered band
       'this.lootRolls.update',
       'this.lootWindow.updateProximity',
       'this.questDialog.updateProximity',
-      'this.renderTownFocus',
       'this.updateMapWindow',
     ]);
   });
@@ -1344,6 +1340,7 @@ describe('Hud.update() drives exactly the registered set, on the registered band
         'hud.ts: if (craftingReagentSig(this.sim.inventory, this.sim.player.name) === this.lastCraftingReagentSig) return;',
         'hud.ts: if (sig !== this.lastLootSettingsSig) {',
         'hud.ts: if (sig === this.lastProfessionSurfaceSig) return;',
+        'hud.ts: if (sig === this.lastTownFocusSig) return;',
         'hud.ts: if (sig === this.lastTradeSig) return;',
         'hud/delve/lockpick_window.ts: if (lockpickRenderSig(view) !== this.lastSig) this.renderBoard();',
         'hud/quest/quest_dialog_controller.ts: if (this.introHintVisibleFor(npc) !== this.lastIntroHintVisible) this.refresh();',

--- a/tests/town_focus_repaint_gate.test.ts
+++ b/tests/town_focus_repaint_gate.test.ts
@@ -1,0 +1,742 @@
+// @vitest-environment jsdom
+
+// The Town Focus repaint gate (issue #2500).
+//
+// The panel is repainted from Hud.update()'s 500ms slow band, and the whole
+// gate used to be `if (this.townFocusOpen)`. renderTownFocusWindow is a full
+// skeleton wipe (innerHTML for the title bar, then createElement/appendChild
+// for the hint block and every row), so an OPEN AND IDLE panel discarded and
+// rebuilt its entire subtree twice a second, forever. It carried scrollTop
+// across the wipe, which is itself the evidence the wipe was known to be
+// destructive; focus was the case that got missed, and a keyboard user parked
+// on a +/- stepper or Save had that element destroyed under them at 2Hz.
+//
+// Five layers are pinned here, mirroring tests/crafting_reagent_refresh.test.ts:
+//  1. townFocusRenderSig (pure): it moves on every value the painter renders
+//     and stays put on churn the painter cannot see.
+//  2. That the sig's term set really is the painter's read set, scanned out of
+//     the painter's own source, so a row that starts rendering another view
+//     field cannot silently leave the gate behind.
+//  3. The HUD probe's behavior, driven on a bare Hud prototype (the
+//     crafting_reagent_refresh precedent, since the probe is private and
+//     update() is not drivable in a unit test): cold latch, elision, the
+//     in/out-of-town edge, and that a closed panel reads nothing at all.
+//  4. The real painter in a real DOM: an unchanged poll rebuilds nothing and
+//     keyboard focus survives it, and the rebuild that DOES happen (a step)
+//     hands focus back to the rebuilt equivalent instead of dropping it to
+//     <body>.
+//  5. The wiring source pins for the three edges (the slow band, the paint
+//     re-arm, the language switch), each anchored to the REGION it has to live
+//     in rather than to the whole file.
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { HARVEST_COMPONENT_ITEMS } from '../src/sim/content/professions';
+import { FOCUS_POINT_BUDGET } from '../src/sim/professions/focus';
+import { Hud } from '../src/ui/hud';
+import {
+  buildTownFocusView,
+  TOWN_FOCUS_COMPONENTS,
+  type TownFocusView,
+  townFocusRenderSig,
+} from '../src/ui/town_focus_view';
+import { renderTownFocusWindow } from '../src/ui/town_focus_window';
+
+const COMPONENT = TOWN_FOCUS_COMPONENTS[0];
+const OTHER_COMPONENT = TOWN_FOCUS_COMPONENTS[1];
+
+/** A view built from real inputs, never hand-written, so the assertions below
+ *  keep testing what the panel is actually handed. */
+function viewOf(allocation: Record<string, number>, inTown = true): TownFocusView {
+  return buildTownFocusView(allocation, FOCUS_POINT_BUDGET, inTown);
+}
+
+// ---------------------------------------------------------------------------
+// 1. The pure signature.
+// ---------------------------------------------------------------------------
+
+describe('townFocusRenderSig', () => {
+  it('rests on component ids that carry none of its delimiters', () => {
+    // The sig packs component:points:flags rows with ':', '|' and '/'. An id
+    // carrying one could make two different allocations share a string, which
+    // is the one way a signature gate goes quietly wrong. No authored id does;
+    // this is the guard that keeps it that way, iterated over the real content
+    // table rather than over the fixtures below.
+    const ids = Object.keys(HARVEST_COMPONENT_ITEMS);
+    expect(ids.length).toBeGreaterThan(1);
+    for (const id of ids) expect(id).not.toMatch(/[:|/]/);
+    expect([...TOWN_FOCUS_COMPONENTS]).toEqual(ids);
+    // The painter's focus keys share ONE flat namespace with the two singleton
+    // keys, so a component literally named `save` or `close` would route the
+    // Save/X button's key into the stepper ladder. A different hazard from the
+    // delimiter one above, and it needs saying separately.
+    expect(ids).not.toContain('save');
+    expect(ids).not.toContain('close');
+  });
+
+  it('is never the empty string, so the cold latch cannot collide with a real panel', () => {
+    // Hud arms `lastTownFocusSig` from '' and every guard in the family leans
+    // on that sentinel being unreachable.
+    expect(townFocusRenderSig(viewOf({}))).not.toBe('');
+    expect(townFocusRenderSig(viewOf({ [COMPONENT]: FOCUS_POINT_BUDGET }, false))).not.toBe('');
+  });
+
+  it('is stable across two independently built identical views', () => {
+    expect(townFocusRenderSig(viewOf({ [COMPONENT]: 3 }))).toBe(
+      townFocusRenderSig(viewOf({ [COMPONENT]: 3 })),
+    );
+  });
+
+  it('moves when a point is spent (the panel really did change)', () => {
+    expect(townFocusRenderSig(viewOf({ [COMPONENT]: 3 }))).not.toBe(
+      townFocusRenderSig(viewOf({ [COMPONENT]: 4 })),
+    );
+  });
+
+  it('moves when the same total is spent on a DIFFERENT component', () => {
+    // remaining is identical in both, so a sig built from the budget alone
+    // would tie: the per-row terms are what separate them.
+    expect(townFocusRenderSig(viewOf({ [COMPONENT]: 2 }))).not.toBe(
+      townFocusRenderSig(viewOf({ [OTHER_COMPONENT]: 2 })),
+    );
+  });
+
+  it('moves when the player walks out of town (every control disables)', () => {
+    expect(townFocusRenderSig(viewOf({ [COMPONENT]: 2 }, false))).not.toBe(
+      townFocusRenderSig(viewOf({ [COMPONENT]: 2 }, true)),
+    );
+  });
+
+  it('stays put on allocation churn the panel cannot see', () => {
+    // Negative points clamp to 0 and an unknown key is not a row, so neither
+    // renders: a sig that stringified the raw allocation would repaint for
+    // both. Key ORDER is the same trap and is covered by the fixed component
+    // walk, asserted here rather than assumed.
+    const base = { [COMPONENT]: 2 };
+    expect(townFocusRenderSig(viewOf({ ...base, [OTHER_COMPONENT]: -4 }))).toBe(
+      townFocusRenderSig(viewOf(base)),
+    );
+    expect(townFocusRenderSig(viewOf({ ...base, not_a_component: 3 }))).toBe(
+      townFocusRenderSig(viewOf(base)),
+    );
+    expect(townFocusRenderSig(viewOf({ [OTHER_COMPONENT]: 1, [COMPONENT]: 2 }))).toBe(
+      townFocusRenderSig(viewOf({ [COMPONENT]: 2, [OTHER_COMPONENT]: 1 })),
+    );
+  });
+
+  // Per-DIMENSION negative cases: mutate one rendered field of an otherwise
+  // identical view and require the sig to move. A sig that dropped any single
+  // term would pass every whole-view assertion above and fail exactly here.
+  const MUTATIONS: ReadonlyArray<readonly [string, (v: TownFocusView) => TownFocusView]> = [
+    ['inTown', (v) => ({ ...v, inTown: !v.inTown })],
+    ['budget', (v) => ({ ...v, budget: v.budget + 1 })],
+    ['remaining', (v) => ({ ...v, remaining: v.remaining - 1 })],
+    [
+      'rows[].component',
+      (v) => ({ ...v, rows: [{ ...v.rows[0], component: 'renamed' }, ...v.rows.slice(1)] }),
+    ],
+    [
+      'rows[].points',
+      (v) => ({ ...v, rows: [{ ...v.rows[0], points: v.rows[0].points + 1 }, ...v.rows.slice(1)] }),
+    ],
+    [
+      'rows[].canIncrease',
+      (v) => ({
+        ...v,
+        rows: [{ ...v.rows[0], canIncrease: !v.rows[0].canIncrease }, ...v.rows.slice(1)],
+      }),
+    ],
+    [
+      'rows[].canDecrease',
+      (v) => ({
+        ...v,
+        rows: [{ ...v.rows[0], canDecrease: !v.rows[0].canDecrease }, ...v.rows.slice(1)],
+      }),
+    ],
+    ['rows (a row disappears)', (v) => ({ ...v, rows: v.rows.slice(1) })],
+  ];
+
+  for (const [field, mutate] of MUTATIONS) {
+    it(`moves when ${field} changes and nothing else does`, () => {
+      const base = viewOf({ [COMPONENT]: 2 });
+      expect(townFocusRenderSig(mutate(base))).not.toBe(townFocusRenderSig(base));
+    });
+  }
+
+  it('ignores totalSpent, the one view field nothing renders', () => {
+    // Stated out loud rather than left as an omission: remaining already
+    // carries it, and the completeness pin below is what keeps that true.
+    const base = viewOf({ [COMPONENT]: 2 });
+    expect(townFocusRenderSig({ ...base, totalSpent: base.totalSpent + 99 })).toBe(
+      townFocusRenderSig(base),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Completeness: the sig's terms ARE the painter's read set.
+//
+// The gate is only as good as this correspondence, and nothing else checks it:
+// a new `${view.totalSpent}` in the painter would render a number the sig does
+// not carry, and the panel would sit stale until something else moved. Scan
+// the painter's real source for what it reads off the view and off a row, and
+// require both sets to match the sig exactly.
+//
+// WHERE THIS STOPS, stated rather than implied: both scans are NAME-based, so
+// they see `view.<field>` and `row.<field>` and nothing else. Destructuring and
+// renaming the loop variable both REMOVE matches, so they fail loudly and are
+// safe; rebinding (`const v = view`) keeps the count intact and is refused
+// separately below. What escapes both is a field read off an INDEXED expression
+// (`view.rows[i].newField`), which names no receiver at all. The instrument for
+// that is the per-dimension mutation table above, which is behavioral.
+// ---------------------------------------------------------------------------
+
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const painterSrc = stripComments(
+  readFileSync(path.resolve(process.cwd(), 'src/ui/town_focus_window.ts'), 'utf8'),
+);
+const sigSrc = stripComments(
+  readFileSync(path.resolve(process.cwd(), 'src/ui/town_focus_view.ts'), 'utf8'),
+);
+
+function readsOf(src: string, receiver: string): string[] {
+  const found = new Set<string>();
+  for (const m of src.matchAll(new RegExp(`\\b${receiver}\\.([A-Za-z_][\\w]*)`, 'g')))
+    found.add(m[1]);
+  return [...found].sort();
+}
+
+/**
+ * The ONE way the read scans above can be defeated: bind the view (or a row) to
+ * another name and read the field off that. Destructuring and renaming both
+ * REMOVE matches and so fail the scans loudly, but `const v = view;` leaves the
+ * counted set untouched while a fifth field renders behind the gate.
+ */
+function aliasesOf(src: string, receiver: string): string[] {
+  return [...src.matchAll(new RegExp(`=\\s*(${receiver})\\b(?!\\.)`, 'g'))].map((m) => m[0].trim());
+}
+
+describe('the signature covers exactly what the painter renders', () => {
+  it('reads only the view fields the signature carries', () => {
+    // `rows` is the container the row terms come from, so it belongs here too.
+    expect(readsOf(painterSrc, 'view')).toEqual(['budget', 'inTown', 'remaining', 'rows']);
+  });
+
+  it('never aliases the view or a row past the scans above', () => {
+    expect(aliasesOf(painterSrc, 'view')).toEqual([]);
+    expect(aliasesOf(painterSrc, 'row')).toEqual([]);
+  });
+
+  it('and that alias refusal really would catch one', () => {
+    // Driven over synthetic source with a planted alias, because a refusal
+    // proven only against the tree it already passes on proves nothing: this is
+    // the arm that would be dead if the pattern were wrong.
+    expect(aliasesOf('const v = view;\nfoo(v.totalSpent);', 'view')).toEqual(['= view']);
+    expect(aliasesOf('let r;\nr = row;', 'row')).toEqual(['= row']);
+    // ...and does not fire on the legitimate shapes the painter really uses.
+    expect(aliasesOf('function f(view: TownFocusView) { return view.budget; }', 'view')).toEqual(
+      [],
+    );
+  });
+
+  it('reads only the row fields the signature carries', () => {
+    // File-wide, so `row` is reserved for the view row the painter walks: an
+    // unrelated local named `row` fails here and the fix is to rename it (the
+    // focus ladder's stepper pair is called `pair` for exactly this reason).
+    expect(readsOf(painterSrc, 'row')).toEqual([
+      'canDecrease',
+      'canIncrease',
+      'component',
+      'points',
+    ]);
+  });
+
+  it('the signature builder really names every one of them', () => {
+    // Guards the other direction: the scan above proves the painter reads no
+    // MORE than these, this proves the sig reads no LESS. Both are needed, and
+    // a sig term deleted while the painter kept rendering the field would show
+    // up only here and in the per-dimension mutations above.
+    //
+    // BOUNDED at the next export, not run to end of file: an unbounded slice
+    // would let any later code in the module satisfy a term the signature
+    // itself had dropped.
+    const start = sigSrc.indexOf('export function townFocusRenderSig');
+    expect(
+      start,
+      'townFocusRenderSig is no longer exported from town_focus_view.ts',
+    ).toBeGreaterThan(-1);
+    const end = sigSrc.indexOf('export function', start + 1);
+    expect(end, 'no export follows townFocusRenderSig, so the slice is unbounded').toBeGreaterThan(
+      start,
+    );
+    const sigBody = sigSrc.slice(start, end);
+    for (const term of ['view.inTown', 'view.budget', 'view.remaining', 'view.rows'])
+      expect(sigBody).toContain(term);
+    for (const term of ['r.component', 'r.points', 'r.canIncrease', 'r.canDecrease'])
+      expect(sigBody).toContain(term);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. The HUD probe, on a bare Hud prototype.
+// ---------------------------------------------------------------------------
+
+interface TownFocusProbeHarness {
+  sim: { townFocus: Record<string, number> };
+  townFocusDraft: Record<string, number> | null;
+  lastTownFocusSig: string;
+  isInTown(): boolean;
+  renderTownFocus(): void;
+  refreshOpenTownFocusIfChanged(): void;
+  readonly townFocusOpen: boolean;
+}
+
+function makeProbeHud(draft: Record<string, number> | null = {}): {
+  hud: TownFocusProbeHarness;
+  window: HTMLElement;
+  /** How many times the probe has read the allocation: the "a closed panel
+   *  costs nothing" claim is about this, not about the repaint count. */
+  allocationReads(): number;
+  townChecks(): number;
+  setInTown(next: boolean): void;
+} {
+  const hud = Object.create(Hud.prototype) as unknown as TownFocusProbeHarness;
+  let reads = 0;
+  let townChecks = 0;
+  let inTown = true;
+  hud.sim = {
+    get townFocus() {
+      reads++;
+      return {};
+    },
+  } as TownFocusProbeHarness['sim'];
+  hud.townFocusDraft = draft;
+  // Object.create skips field initializers, so seed the latch the way the real
+  // field declares it ('' until the first paint arms it).
+  hud.lastTownFocusSig = '';
+  hud.isInTown = () => {
+    townChecks++;
+    return inTown;
+  };
+  hud.renderTownFocus = vi.fn(() => {
+    hud.lastTownFocusSig = townFocusRenderSig(
+      buildTownFocusView(hud.townFocusDraft ?? {}, FOCUS_POINT_BUDGET, inTown),
+    );
+  }) as unknown as TownFocusProbeHarness['renderTownFocus'];
+  document.getElementById('town-focus-window')?.remove();
+  const el = document.createElement('div');
+  el.id = 'town-focus-window';
+  el.style.display = 'block';
+  document.body.appendChild(el);
+  return {
+    hud,
+    window: el,
+    allocationReads: () => reads,
+    townChecks: () => townChecks,
+    setInTown: (next) => {
+      inTown = next;
+    },
+  };
+}
+
+describe('refreshOpenTownFocusIfChanged', () => {
+  it('latches on the first probe, then elides an unchanged panel', () => {
+    const { hud } = makeProbeHud({ [COMPONENT]: 2 });
+    hud.refreshOpenTownFocusIfChanged();
+    expect(hud.renderTownFocus).toHaveBeenCalledTimes(1);
+    hud.refreshOpenTownFocusIfChanged();
+    hud.refreshOpenTownFocusIfChanged();
+    hud.refreshOpenTownFocusIfChanged();
+    // The whole issue: four slow ticks over an idle panel, one rebuild.
+    expect(hud.renderTownFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it('repaints when the draft moves under it', () => {
+    const { hud } = makeProbeHud({ [COMPONENT]: 2 });
+    hud.refreshOpenTownFocusIfChanged();
+    hud.townFocusDraft = { [COMPONENT]: 3 };
+    hud.refreshOpenTownFocusIfChanged();
+    expect(hud.renderTownFocus).toHaveBeenCalledTimes(2);
+  });
+
+  it('repaints when the player walks out of town (the panel disables)', () => {
+    const { hud, setInTown } = makeProbeHud({ [COMPONENT]: 2 });
+    hud.refreshOpenTownFocusIfChanged();
+    setInTown(false);
+    hud.refreshOpenTownFocusIfChanged();
+    expect(hud.renderTownFocus).toHaveBeenCalledTimes(2);
+    // ...and then settles again rather than repainting every tick out of town.
+    hud.refreshOpenTownFocusIfChanged();
+    expect(hud.renderTownFocus).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to the sim allocation when there is no draft', () => {
+    const { hud, allocationReads } = makeProbeHud(null);
+    hud.refreshOpenTownFocusIfChanged();
+    expect(hud.renderTownFocus).toHaveBeenCalledTimes(1);
+    expect(allocationReads()).toBeGreaterThan(0);
+  });
+
+  it('reads nothing at all while the panel is CLOSED', () => {
+    const { hud, window, allocationReads, townChecks } = makeProbeHud(null);
+    window.style.display = 'none';
+    hud.refreshOpenTownFocusIfChanged();
+    hud.townFocusDraft = { [COMPONENT]: 5 };
+    hud.refreshOpenTownFocusIfChanged();
+    expect(hud.renderTownFocus).not.toHaveBeenCalled();
+    // The open check must come FIRST: a guard reorder that built the signature
+    // before testing display would cost every closed player a zone check and an
+    // allocation fold per slow tick, and a repaint-count assertion alone would
+    // not notice.
+    expect(allocationReads()).toBe(0);
+    expect(townChecks()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. The real painter, the real gate, a real DOM.
+// ---------------------------------------------------------------------------
+
+interface TownFocusRenderHarness {
+  sim: { townFocus: Record<string, number>; setTownFocus(next: Record<string, number>): void };
+  townFocusDraft: Record<string, number> | null;
+  lastTownFocusSig: string;
+  isInTown(): boolean;
+  renderTownFocus(): void;
+  refreshOpenTownFocusIfChanged(): void;
+  closeTownFocus(): void;
+  hideTooltip(): void;
+}
+
+/** The real Hud methods on a bare prototype: no stubbed painter, so what these
+ *  assert is the shipped render path end to end. */
+function makeRenderHud(allocation: Record<string, number>): {
+  hud: TownFocusRenderHarness;
+  el: HTMLElement;
+  setInTown(next: boolean): void;
+} {
+  const hud = Object.create(Hud.prototype) as unknown as TownFocusRenderHarness;
+  let inTown = true;
+  hud.sim = { townFocus: {}, setTownFocus: vi.fn() } as unknown as TownFocusRenderHarness['sim'];
+  hud.townFocusDraft = { ...allocation };
+  hud.lastTownFocusSig = '';
+  hud.isInTown = () => inTown;
+  hud.closeTownFocus = vi.fn() as unknown as TownFocusRenderHarness['closeTownFocus'];
+  hud.hideTooltip = vi.fn() as unknown as TownFocusRenderHarness['hideTooltip'];
+  document.getElementById('town-focus-window')?.remove();
+  const el = document.createElement('div');
+  el.id = 'town-focus-window';
+  document.body.appendChild(el);
+  return {
+    hud,
+    el,
+    setInTown: (next) => {
+      inTown = next;
+    },
+  };
+}
+
+const stepButton = (el: HTMLElement, component: string, role: 'dec' | 'inc'): HTMLButtonElement => {
+  const btn = el.querySelector<HTMLButtonElement>(`[data-focus-key="${component}:${role}"]`);
+  expect(btn, `no ${role} stepper for ${component}`).not.toBeNull();
+  return btn as HTMLButtonElement;
+};
+
+/**
+ * Assert the subtree was NOT rebuilt: same nodes, by IDENTITY.
+ *
+ * `toEqual` is the wrong instrument and passes here for the wrong reason: it
+ * compares two node arrays STRUCTURALLY, so a full wipe followed by a
+ * byte-identical rebuild satisfies it, which is exactly the bug. Every claim
+ * about "did not repaint" in this file goes through per-node `toBe`.
+ */
+function expectSameNodes(after: readonly Element[], before: readonly Element[]): void {
+  expect(after.length).toBe(before.length);
+  expect(before.length).toBeGreaterThan(0);
+  for (let i = 0; i < before.length; i++) expect(after[i]).toBe(before[i]);
+}
+
+describe('an open Town Focus panel on the slow band', () => {
+  it('is a full wipe when it does repaint, which is why the gate matters', () => {
+    // The premise, asserted rather than assumed: the painter really does throw
+    // its subtree away. Without a gate this is what ran twice a second. It is
+    // also what makes the identity comparisons below the only honest ones: a
+    // rebuild here is structurally indistinguishable from no rebuild at all.
+    const { hud, el } = makeRenderHud({ [COMPONENT]: 2 });
+    hud.renderTownFocus();
+    const first = [...el.children];
+    hud.renderTownFocus();
+    const second = [...el.children];
+    expect(second.length).toBe(first.length);
+    for (let i = 0; i < first.length; i++) expect(second[i]).not.toBe(first[i]);
+    // ...and the structural comparison really cannot tell those two apart, so
+    // the helper above is not a stylistic preference.
+    expect(second).toEqual(first);
+  });
+
+  it('rebuilds NOTHING across repeated idle polls', () => {
+    const { hud, el } = makeRenderHud({ [COMPONENT]: 2 });
+    hud.renderTownFocus();
+    const before = [...el.querySelectorAll('*')];
+    hud.refreshOpenTownFocusIfChanged();
+    hud.refreshOpenTownFocusIfChanged();
+    hud.refreshOpenTownFocusIfChanged();
+    expectSameNodes([...el.querySelectorAll('*')], before);
+  });
+
+  it('leaves a keyboard user parked on a stepper exactly where they were', () => {
+    // The consequence the issue is really about: the element under the
+    // keyboard user was destroyed and replaced on a timer.
+    const { hud, el } = makeRenderHud({ [COMPONENT]: 2 });
+    hud.renderTownFocus();
+    const plus = stepButton(el, COMPONENT, 'inc');
+    plus.focus();
+    expect(document.activeElement).toBe(plus);
+    hud.refreshOpenTownFocusIfChanged();
+    hud.refreshOpenTownFocusIfChanged();
+    expect(document.activeElement).toBe(plus);
+    expect(plus.isConnected).toBe(true);
+  });
+
+  it('still converges the panel when the player leaves town', () => {
+    const { hud, el, setInTown } = makeRenderHud({ [COMPONENT]: 2 });
+    hud.renderTownFocus();
+    expect(stepButton(el, COMPONENT, 'inc').disabled).toBe(false);
+    setInTown(false);
+    hud.refreshOpenTownFocusIfChanged();
+    expect(stepButton(el, COMPONENT, 'inc').disabled).toBe(true);
+    expect(el.querySelector('.town-focus-not-in-town')).not.toBeNull();
+  });
+
+  it('repaints once, not twice, for one real change', () => {
+    const { hud, el } = makeRenderHud({ [COMPONENT]: 2 });
+    hud.renderTownFocus();
+    hud.townFocusDraft = { [COMPONENT]: 3 };
+    hud.refreshOpenTownFocusIfChanged();
+    const painted = [...el.querySelectorAll('*')];
+    hud.refreshOpenTownFocusIfChanged();
+    expectSameNodes([...el.querySelectorAll('*')], painted);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4b. Focus across the rebuild that DOES happen.
+// ---------------------------------------------------------------------------
+
+describe('renderTownFocusWindow carries keyboard focus across its own wipe', () => {
+  function paint(
+    view: TownFocusView,
+    onStep = vi.fn(),
+  ): { el: HTMLElement; onStep: typeof onStep } {
+    document.getElementById('town-focus-window')?.remove();
+    const el = document.createElement('div');
+    el.id = 'town-focus-window';
+    document.body.appendChild(el);
+    renderTownFocusWindow(el, view, { onStep, onSave: vi.fn(), onClose: vi.fn() });
+    return { el, onStep };
+  }
+
+  it('hands focus to the rebuilt equivalent of the stepper that was pressed', () => {
+    const { el } = paint(viewOf({ [COMPONENT]: 2 }));
+    stepButton(el, COMPONENT, 'inc').focus();
+    // The step handler repaints the panel, exactly as Hud.renderTownFocus does.
+    renderTownFocusWindow(el, viewOf({ [COMPONENT]: 3 }), {
+      onStep: vi.fn(),
+      onSave: vi.fn(),
+      onClose: vi.fn(),
+    });
+    expect(document.activeElement).toBe(stepButton(el, COMPONENT, 'inc'));
+    expect(document.activeElement).not.toBe(document.body);
+  });
+
+  it('falls back to the other stepper in the row when the pressed one comes back disabled', () => {
+    // Stepping the last point off a component disables its `-`, and a disabled
+    // button cannot take focus. Without the ladder this is where a keyboard
+    // player lands on <body> and cannot continue.
+    const { el } = paint(viewOf({ [COMPONENT]: 1 }));
+    stepButton(el, COMPONENT, 'dec').focus();
+    renderTownFocusWindow(el, viewOf({}), {
+      onStep: vi.fn(),
+      onSave: vi.fn(),
+      onClose: vi.fn(),
+    });
+    expect(stepButton(el, COMPONENT, 'dec').disabled).toBe(true);
+    expect(document.activeElement).toBe(stepButton(el, COMPONENT, 'inc'));
+  });
+
+  it('falls back past a disabled Save to Close when the whole panel disables', () => {
+    const { el } = paint(viewOf({ [COMPONENT]: 1 }));
+    stepButton(el, COMPONENT, 'dec').focus();
+    // Walking out of town disables every stepper AND Save.
+    renderTownFocusWindow(el, viewOf({ [COMPONENT]: 1 }, false), {
+      onStep: vi.fn(),
+      onSave: vi.fn(),
+      onClose: vi.fn(),
+    });
+    expect(document.activeElement).toBe(el.querySelector('[data-close]'));
+  });
+
+  it('keeps the Save button when Save had focus', () => {
+    const { el } = paint(viewOf({ [COMPONENT]: 1 }));
+    const save = el.querySelector<HTMLButtonElement>('.town-focus-save');
+    save?.focus();
+    renderTownFocusWindow(el, viewOf({ [COMPONENT]: 2 }), {
+      onStep: vi.fn(),
+      onSave: vi.fn(),
+      onClose: vi.fn(),
+    });
+    expect(document.activeElement).toBe(el.querySelector('.town-focus-save'));
+  });
+
+  it('keeps the X on Close rather than jumping the player onto Save', () => {
+    // The Close-first arm. Painted IN TOWN so Save is enabled and is a live
+    // competitor: without the arm the key falls through the stepper ladder
+    // (`steppers.get('close')` is undefined) and lands on Save, which is a
+    // destructive control to hand a player who was dismissing the panel.
+    const { el } = paint(viewOf({ [COMPONENT]: 1 }));
+    el.querySelector<HTMLButtonElement>('[data-close]')?.focus();
+    renderTownFocusWindow(el, viewOf({ [COMPONENT]: 2 }), {
+      onStep: vi.fn(),
+      onSave: vi.fn(),
+      onClose: vi.fn(),
+    });
+    expect(el.querySelector<HTMLButtonElement>('.town-focus-save')?.disabled).toBe(false);
+    expect(document.activeElement).toBe(el.querySelector('[data-close]'));
+    expect(document.activeElement).not.toBe(el.querySelector('.town-focus-save'));
+  });
+
+  it('takes focus from NOBODY when the player was not in the panel', () => {
+    // The open path: focus is on the minimap button, outside the panel, and a
+    // repaint must not steal it.
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    const { el } = paint(viewOf({ [COMPONENT]: 1 }));
+    outside.focus();
+    renderTownFocusWindow(el, viewOf({ [COMPONENT]: 2 }), {
+      onStep: vi.fn(),
+      onSave: vi.fn(),
+      onClose: vi.fn(),
+    });
+    expect(document.activeElement).toBe(outside);
+    outside.remove();
+  });
+
+  it('never reads a focus key off a control OUTSIDE the panel', () => {
+    // The containment half, which the test above cannot reach because its
+    // outside button carries no key at all. mailbox_window keys its parcel
+    // steppers with the SAME `data-focus-key` attribute in the SAME
+    // `<id>:<role>` shape, so an unguarded read would let a slow-band Town
+    // Focus repaint pull focus out of another open window.
+    const outside = document.createElement('button');
+    outside.dataset.focusKey = `${COMPONENT}:inc`;
+    document.body.appendChild(outside);
+    const { el } = paint(viewOf({ [COMPONENT]: 1 }));
+    outside.focus();
+    renderTownFocusWindow(el, viewOf({ [COMPONENT]: 2 }), {
+      onStep: vi.fn(),
+      onSave: vi.fn(),
+      onClose: vi.fn(),
+    });
+    expect(document.activeElement).toBe(outside);
+    expect(document.activeElement).not.toBe(stepButton(el, COMPONENT, 'inc'));
+    outside.remove();
+  });
+
+  it('keys every stepper by component AND direction, so no two share an identity', () => {
+    const { el } = paint(viewOf({}));
+    const keys = [...el.querySelectorAll<HTMLElement>('[data-focus-key]')].map(
+      (n) => n.dataset.focusKey,
+    );
+    expect(keys.length).toBe(TOWN_FOCUS_COMPONENTS.length * 2 + 2);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Wiring. The three call sites live in code paths a unit test cannot run
+// (the slow band of update(), the paint itself, the language fan-out), so they
+// are pinned against comment-stripped source: prose alone must never satisfy a
+// pin. Each pin is scoped to the REGION the call has to live in, so moving the
+// code somewhere that changes its meaning reds the pin.
+// ---------------------------------------------------------------------------
+
+const hudSrc = stripComments(readFileSync(path.resolve(process.cwd(), 'src/ui/hud.ts'), 'utf8'));
+
+/** Source between two unique anchors, asserted to exist so a rename fails
+ *  loudly here instead of silently slicing an empty (vacuously passing) span. */
+function region(from: string, to: string): string {
+  const start = hudSrc.indexOf(from);
+  expect(start, `anchor not found: ${from}`).toBeGreaterThan(-1);
+  const end = hudSrc.indexOf(to, start + from.length);
+  expect(end, `anchor not found after ${from}: ${to}`).toBeGreaterThan(start);
+  return hudSrc.slice(start, end);
+}
+
+describe('Town Focus repaint-gate wiring (source pins)', () => {
+  it('renderTownFocus re-arms the latch on EVERY paint, whatever caused it', () => {
+    // Scoped to the method: moving the re-arm into the probe would leave every
+    // other paint cause (the open, a step, the language switch) un-armed, so
+    // the next poll would repaint once for no reason, and a whole-file pin
+    // would not notice.
+    const render = region('private renderTownFocus(): void {', 'private refreshOpenTownFocus');
+    expect(render).toContain('this.lastTownFocusSig = townFocusRenderSig(view);');
+  });
+
+  it('the slow band drives the PROBE, never the bare painter', () => {
+    // Anchored INSIDE the `if (slowHud)` guard. The whole issue was that this
+    // line used to be the unguarded `if (this.townFocusOpen)
+    // this.renderTownFocus();`, so pin both halves: the probe is here, and the
+    // unguarded call is not.
+    //
+    // The two NEGATIVE halves are the weak ones and are deliberately kept as
+    // belt to the registry's braces: the exact-text refusal is defeated by the
+    // same call written across two lines, and the per-frame refusal only spans
+    // the ~30 lines between the divider and the slow block, so a probe moved
+    // anywhere else on the per-frame path passes it. What actually enforces the
+    // band is tests/hud_update_drive.test.ts, which diffs every call update()
+    // evaluates against an AST walk BOTH ways: mutation testing confirmed it is
+    // the gate that kills both of those, not these two lines.
+    const slowBand = region('if (slowHud) {', 'this.playerFramePainter');
+    expect(slowBand).toContain('this.refreshOpenTownFocusIfChanged();');
+    expect(slowBand).not.toContain('if (this.townFocusOpen) this.renderTownFocus();');
+    const perFrame = region('const slowHud =', 'if (slowHud) {');
+    expect(perFrame).not.toContain('refreshOpenTownFocusIfChanged');
+  });
+
+  it('declares the cold latch as the empty sentinel no real signature can spell', () => {
+    // Both harnesses build the Hud with Object.create, which skips field
+    // initializers, so they seed the latch by hand and no behavioral test in
+    // this file can see the DECLARED value. Pin the declaration itself, or
+    // changing it to a plausible-looking non-empty string would arm the panel
+    // with a signature it never painted and leave the suite green.
+    expect(hudSrc).toContain("private lastTownFocusSig = '';");
+  });
+
+  it('the probe tests the open flag before it reads anything', () => {
+    const probe = region(
+      'private refreshOpenTownFocusIfChanged(): void {',
+      'closeTownFocus(): void {',
+    );
+    expect(probe.indexOf('if (!this.townFocusOpen) return;')).toBeGreaterThan(-1);
+    expect(probe.indexOf('if (!this.townFocusOpen) return;')).toBeLessThan(
+      probe.indexOf('townFocusRenderSig'),
+    );
+    expect(probe).toContain('if (sig === this.lastTownFocusSig) return;');
+  });
+
+  it('a language switch still repaints the open panel', () => {
+    // The signature is text-independent, so the switch alone never moves it.
+    // Without this arm the gate would freeze the panel in the old locale until
+    // the player edited the allocation, which is the regression a naive gate
+    // ships. Scoped to the relocalizer, since the point is WHERE it runs.
+    const relocalize = region(
+      'private refreshLocalizedDynamicUi(): void {',
+      'private previewResolvedAbility(',
+    );
+    expect(relocalize).toContain('if (this.townFocusOpen) this.renderTownFocus();');
+  });
+});


### PR DESCRIPTION
## Summary

`src/ui/hud.ts` repainted the Town Focus panel on the 500ms `slowHud` band behind an open check
and nothing else, and `renderTownFocusWindow` is a full skeleton wipe (`innerHTML` for the title
bar, then `createElement` / `appendChild` for the hints and every row). So an open, idle panel
discarded and rebuilt its entire subtree twice a second, forever. It carried `scrollTop` across
the wipe, which is itself the evidence the wipe was known to be destructive; focus was the case
that got missed, so a keyboard player parked on a `+` / `-` stepper or on Save had that element
destroyed under them at 2Hz.

Two halves, matching the two halves of the issue:

**The invalidation gate.** A new pure `townFocusRenderSig(view)` in `src/ui/town_focus_view.ts`
(already a registered `UI_PURE_CORE`), polled from a new private
`Hud.refreshOpenTownFocusIfChanged()`, which is the shape `refreshOpenCraftingIfReagentsChanged`
already uses: the open check first so a closed panel costs nothing, then rebuild only when what
the panel shows actually moves (an edit to the draft, or walking in or out of town).
`renderTownFocus()` owns the re-arm, so every other paint cause (the open, a step, a language
switch) arms the latch too.

The signature is built from the VIEW rather than from the raw allocation, so its completeness is
checkable by inspection: the painter reads `inTown`, `budget`, `remaining` and each row's
`component` / `points` / `canIncrease` / `canDecrease`, and each is a term. A test scans the
painter's real source for its `view.*` and `row.*` reads and requires the two sets to match, so a
row that starts rendering another field cannot leave the gate behind.

**The locale arm, which a naive gate would have regressed.** Every signature in this family is
text-independent on purpose, and a language switch is fanned out through
`Hud.refreshLocalizedDynamicUi()` rather than through the sig. Town Focus was not in that fan-out
because the unconditional 500ms repaint was relocalizing it by accident. Without an arm there,
the gate would have frozen the panel in the old locale until the player edited the allocation, so
it gets one, next to the arena / Vale Cup `relocalize()` calls that exist for the same reason.

**Focus across the rebuild that does happen.** A step click still rebuilds the panel, and today
that drops keyboard focus to `<body>`, so a keyboard player cannot press `+` twice. The painter
now carries the focused control across its own wipe, keyed by component AND direction
(`data-focus-key`), the `mailbox_window` parcel-stepper idiom. The control just activated can
legitimately come back disabled (stepping the last point off a component disables its `-`,
spending the last point disables every `+`, leaving town disables all of them), so there is a
degradation ladder: the same stepper, the row's other stepper, Save, Close. Landing on Close is
still keyboard operation; landing on `<body>` is not.

`tests/hud_update_drive.test.ts` recorded Town Focus as the registry's standing `kind: 'none'`
exception and `tests/hud_perf_budget.test.ts` / `src/ui/CLAUDE.md` both called it the standing
proof that the signature guard is a convention rather than something enforced. All three are
updated: the row now names a real `kind: 'hud'` guard, the pinned guard-kind counts move
(`none` 5 to 4, `hud` 4 to 5), and the honest-exception list loses its entry.

## Related issues

Closes #2500. Surfaced by the review panel on #2497; #2498 (the drive registry) is what made the
gap enforceable.

## Deliberately not in this PR

Things the reviewers raised that are real but are their own change, filed as follow-ups rather
than smuggled in here (#2525, #2528, #2529, #2530):

- `#town-focus-window` adopts neither `FocusManager` (`windowFocus(rootSel)`) nor
  `markDialogRoot`, so it has no Tab trap, no focus-first-on-open and no return-to-opener, unlike
  the 22 sibling windows. Both reviewers reached the same conclusion independently: file it, do
  not block, because wiring the panel into the focus system is a larger change than this fix and
  wants its own tests.
- The capture-`activeElement` / `dataset.focusKey` / refocus-by-key idiom is now hand-rolled in
  about ten `src/ui` modules. The rule of three passed long ago, but an extraction worth doing is
  one that also migrates the existing callers.
- `town_focus_window.ts` interpolates raw `remaining` / `budget` / `points` numbers into `t()`
  while the tier hint two lines above goes through `formatNumber`. Pre-existing, untouched here
  (#2530).
- Four other gated windows (calendar, mailbox, social, card duel) are missing from the same
  `woc:languagechange` fan-out this PR adds Town Focus to, so they keep stale-language text on a
  runtime switch; `card_duel_window.relocalize()` is dead code nothing calls (#2529). Found while
  working out why Town Focus needed the arm at all.

Two reviewer suggestions were examined and deliberately NOT taken, with the reasoning recorded in
the code rather than left implicit: `focus({ preventScroll: true })` (and the equivalent reorder
of the `scrollTop` restore) would keep the saved offset at the cost of leaving a degraded focus
target off-screen, which trades a WCAG 2.4.11 failure for a scroll nicety; and suppressing the
focus hand-back on an involuntary repaint would drop focus to `<body>` instead, since out of town
the Close button is the only enabled control left.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npx vitest run tests/town_focus_repaint_gate.test.ts` (new suite, 44 tests)
  - `npx vitest run tests/hud_update_drive.test.ts tests/hud_perf_budget.test.ts tests/architecture.test.ts tests/town_focus_i18n.test.ts tests/town_focus_sim.test.ts tests/client_shell.test.ts`
  - `npm run gate` (green)
  - Red-before-green confirmed by stashing the three `src/ui` files and re-running the new
    suite: 34 of its tests fail against the pre-fix source.
  - Decisiveness re-confirmed after review: deleting `if (sig === this.lastTownFocusSig) return;`
    from `hud.ts` reds 6 tests, including both "did not rebuild" claims. That mattered, because
    review caught those two asserting `toEqual` over DOM node arrays, which is a STRUCTURAL
    comparison: a full wipe plus an identical rebuild satisfied it. They now go through one
    `expectSameNodes` helper doing per-node `toBe`, and the sibling test asserts out loud that
    the structural comparison really cannot tell the two apart.
  - A 25-mutation audit over the branch found three more survivors, each now killed and each
    verified by re-running the mutation: the Close-first arm of the focus ladder was entirely
    unpinned (both deleting it and reordering it to `[save, close]` passed), the
    `el.contains(active)` containment guard was unpinned (the "focus from NOBODY" test used an
    outside button with no key, so it only reached the `?? null` fallback), and the term-text pin
    sliced to end of file, so code below the signature could satisfy a term the signature had
    dropped. Two equivalent mutants (the row delimiter, and first-wins on the stepper map) are
    genuinely equivalent given a fixed row set and are recorded as such rather than "fixed".
- Manual steps: the new suite drives the real painter and the real probe on a bare `Hud`
  prototype in jsdom, so the repaint elision, the out-of-town edge and the focus ladder are
  exercised end to end rather than asserted from prose.

## Screenshots / recordings

N/A: the panel renders byte-identically. The only DOM delta is a `data-focus-key` attribute per
control, which has no visual effect; what changes is how often the subtree is replaced and where
keyboard focus lands afterwards, neither of which a screenshot can show.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green, with decisive tests for the changed
      behavior (per-dimension signature mutations, probe elision, the closed-panel zero-read
      claim, and the focus ladder including its disabled fallbacks).

### Cross-platform

- [x] **Accessible.** This is the accessibility half of the fix: a keyboard user is no longer
      evicted from the panel, on a timer or on a step.
- [ ] ~Tested on desktop and mobile.~ No layout or styling change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. It does keep the existing ones correct on a
      runtime language switch, which the new `refreshLocalizedDynamicUi` arm covers.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in
      any production path.
- [x] No generated files hand-edited.
