### PR TITLE
fix(sim): reject a town-focus allocation key that names no component family

### DIFF
--- a/src/sim/interaction.ts
+++ b/src/sim/interaction.ts
@@ -321,11 +321,15 @@ export function harvestCorpse(
   // than being re-argued away.
   //
   // This also covers the DERIVED pick, not just an explicit one: an omitted
-  // `components` resolves through meta.townFocus, and set_town_focus does not
-  // validate that a key is a real component tag (#2511), so a persisted
-  // `{ claw: 5 }` makes the plain interact press take this arm too. Refusing
-  // is the better outcome there as well: the corpse survives for a pick that
-  // can pay out, instead of being burned by a focus the player cannot see.
+  // `components` resolves through meta.townFocus, so a persisted `{ claw: 5 }`
+  // makes the plain interact press take this arm too. Refusing is the better
+  // outcome there as well: the corpse survives for a pick that can pay out,
+  // instead of being burned by a focus the player cannot see. #2511 has since
+  // closed the route that could WRITE such a focus (set_town_focus rejects a
+  // key outside HARVEST_COMPONENT_ITEMS, and the load arm drops one an older
+  // save carries), so this arm is now defense in depth on the derived pick
+  // rather than a reachable path; tests/corpse_harvest_sim.test.ts still
+  // drives it by poking meta directly, which is what a pre-#2511 save was.
   if (forfeitsEveryMappedYield(componentTags ?? [], chosen)) {
     ctx.error(meta.entityId, 'Nothing you selected can be harvested from that corpse.');
     return;

--- a/src/sim/professions/focus.ts
+++ b/src/sim/professions/focus.ts
@@ -12,7 +12,7 @@
 // passed in as a plain boolean, so this module never reaches into world state.
 
 import type { ZoneDef } from '../types';
-import { HARVEST_TIERS, type HarvestTier } from './gathering';
+import { HARVEST_COMPONENT_ITEMS, HARVEST_TIERS, type HarvestTier } from './gathering';
 
 /** Total focus points a player may allocate across every component type at once. */
 export const FOCUS_POINT_BUDGET = 10;
@@ -37,6 +37,41 @@ export const FOCUS_YIELD_BONUS_PER_POINT = 0.1;
 export type FocusAllocation = Readonly<Record<string, number>>;
 
 export const EMPTY_FOCUS_ALLOCATION: FocusAllocation = {};
+
+/**
+ * The component families a town-focus allocation may name (#2511).
+ *
+ * Exactly the families HARVEST_COMPONENT_ITEMS maps to an item, in content
+ * order, which is also every row the focus panel offers: src/ui/town_focus_view.ts
+ * re-exports THIS constant rather than deriving the same list a second time,
+ * so the panel cannot come to offer a family the validator below rejects. It
+ * is defined here, in the sim, because the sim is the authority on what it
+ * will accept.
+ *
+ * Deliberately NARROWER than the corpse tag vocabulary, which also carries
+ * claw, tusk, gills and horn. Those are real tags on shipped mobs, but no item
+ * maps to them and focus spent on one is not merely inert: the
+ * omitted-components harvest default derives its pick from this allocation
+ * (src/sim/interaction.ts), so a persisted `{ gills: 1 }` would make every
+ * plain interact press on a murloc take the #2509 all-forfeit refusal. Keeping
+ * the unmapped families out of the allocation is what makes that unreachable
+ * rather than merely unlikely.
+ */
+export const TOWN_FOCUS_COMPONENTS: readonly string[] = Object.keys(HARVEST_COMPONENT_ITEMS);
+
+// A Set, NOT a truthy `HARVEST_COMPONENT_ITEMS[key]` lookup. The map is a
+// plain object literal, so `constructor`, `toString`, `hasOwnProperty` and
+// `valueOf` all read back truthy off Object.prototype and would sail through a
+// lookup check. Those four arrive as real own keys (the server's wire loop
+// copies entries onto a fresh object; only `__proto__` is swallowed there, by
+// the prototype setter), so the difference between the two forms is the bug
+// itself, not a style preference.
+const TOWN_FOCUS_COMPONENT_SET: ReadonlySet<string> = new Set(TOWN_FOCUS_COMPONENTS);
+
+/** Does `componentType` name a real, item-mapped component family? */
+export function isTownFocusComponent(componentType: string): boolean {
+  return TOWN_FOCUS_COMPONENT_SET.has(componentType);
+}
 
 /** Points currently allocated to `componentType`, or 0 if unfocused. */
 function pointsFor(focus: FocusAllocation, componentType: string): number {
@@ -102,9 +137,10 @@ export interface SetTownFocusResult {
  * Validates and resolves a town-focus allocation request. `isInTown` is a
  * plain boolean the caller (Sim) computes from the player's current
  * position/zone; this module makes no world-state decisions of its own.
- * Rejects: not in town, negative/non-integer points, or a total exceeding
- * FOCUS_POINT_BUDGET. On rejection the previous allocation is returned
- * unchanged (the persistent state is untouched).
+ * Rejects: not in town, negative/non-integer points, a key that does not name
+ * a real component family, or a total exceeding FOCUS_POINT_BUDGET. On
+ * rejection the previous allocation is returned unchanged (the persistent
+ * state is untouched).
  */
 export function setTownFocus(
   previous: FocusAllocation,
@@ -118,7 +154,32 @@ export function setTownFocus(
       return { ok: false, allocation: previous, reason: 'invalid_allocation' };
     }
     if (points > 0) total += points;
-    if (!componentType) return { ok: false, allocation: previous, reason: 'invalid_allocation' };
+    // #2511: the key has to name a real family, whatever its point value.
+    // Every surviving key used to be copied into the allocation and persisted
+    // with the character, so a hand-crafted frame could park arbitrary strings
+    // (a 16 KiB one, or `constructor`) in a save and keep them there.
+    //
+    // This WIDENS the empty-string check it replaces rather than adding a
+    // behavior mode: '' was already rejected right here, and '' is just the
+    // degenerate unknown key. Rejecting outright, over silently dropping the
+    // unknown entries, is the rule the three checks around it already follow,
+    // and unlike the #2504 harvest pick it costs the player nothing: no
+    // single-use resource is consumed, retrying is free, and a partial accept
+    // would leave the panel showing a point the server had thrown away. An
+    // ALL-unknown allocation is that same rule with no boundary exception:
+    // rejected, previous allocation untouched.
+    //
+    // A zero-valued unknown key is rejected too, though the commit loop below
+    // would have dropped it anyway: `{ '': 0 }` was already rejected, one rule
+    // reads the same at every value, and no shipped client can send one
+    // (stepTownFocus deletes a component when it reaches zero).
+    //
+    // Precedence, since two rejections can apply at once: this returns from
+    // inside the entry loop and the budget test runs after it, so
+    // `{ leather: 999 }` is invalid_allocation, never over_budget.
+    if (!isTownFocusComponent(componentType)) {
+      return { ok: false, allocation: previous, reason: 'invalid_allocation' };
+    }
   }
   if (total > FOCUS_POINT_BUDGET) {
     return { ok: false, allocation: previous, reason: 'over_budget' };
@@ -128,6 +189,46 @@ export function setTownFocus(
     if (points > 0) allocation[componentType] = points;
   }
   return { ok: true, allocation };
+}
+
+/**
+ * Rebuild a persisted allocation into the shape setTownFocus commits: known
+ * families only, each mapped to a positive integer (#2511 back-compat).
+ *
+ * The command boundary above cannot repair a save that already carries junk,
+ * and that junk is not inert once loaded: it is mirrored to the client in the
+ * `tfocus` snapshot field, summed by the townFocusPoints deed meter, and read
+ * by the omitted-components harvest default. Dropping it costs the player
+ * nothing to feel, which is why this is silent and unconditional: focus points
+ * are freely re-allocatable and an unknown family never bought anything (the
+ * opposite of the bank's never-destroy-an-item rule).
+ *
+ * Leaving unknown keys inert instead would be worse than it sounds, because it
+ * would LOCK the character out of its own panel. The allocation is mirrored to
+ * the client, the panel seeds its draft from that mirror, stepTownFocus
+ * spreads the whole draft forward on every +/-, and Save posts it back, so the
+ * unknown key rides along into a request the command boundary now rejects,
+ * with no control anywhere that could delete it.
+ *
+ * Same normalize-on-load shape as professions/tier_mail.ts
+ * normalizeTierMailOnLoad and cadence.ts clampCadenceOnLoad, and it keeps the
+ * sim.ts load arm thin. A total over FOCUS_POINT_BUDGET is deliberately NOT
+ * re-checked here: a budget lowered by later tuning must not silently delete a
+ * legitimate allocation, and the next set_town_focus re-validates the whole
+ * request against the current budget anyway.
+ */
+export function normalizeTownFocusOnLoad(
+  saved: Readonly<Record<string, number>> | undefined | null,
+): Record<string, number> {
+  const allocation: Record<string, number> = {};
+  if (!saved) return allocation;
+  for (const [componentType, points] of Object.entries(saved)) {
+    if (!isTownFocusComponent(componentType)) continue;
+    if (typeof points === 'number' && Number.isInteger(points) && points > 0) {
+      allocation[componentType] = points;
+    }
+  }
+  return allocation;
 }
 
 // Re-spec cost model (#1144): re-aiming an existing town-focus allocation

--- a/src/sim/professions/focus.ts
+++ b/src/sim/professions/focus.ts
@@ -11,8 +11,15 @@
 // is evaluated by the caller (Sim, which knows the player's zone/position) and
 // passed in as a plain boolean, so this module never reaches into world state.
 
+// HARVEST_COMPONENT_ITEMS comes from the content leaf, not through
+// gathering.ts's compatibility re-export: it is read at MODULE-EVALUATION time
+// below (Object.keys, then new Set), so routing it through a sibling would
+// turn any future gathering -> focus edge into an import-time TDZ
+// ReferenceError on all three hosts rather than a subtle bug. HARVEST_TIERS is
+// only ever read inside a function body, so it keeps the sibling import.
+import { HARVEST_COMPONENT_ITEMS } from '../content/professions';
 import type { ZoneDef } from '../types';
-import { HARVEST_COMPONENT_ITEMS, HARVEST_TIERS, type HarvestTier } from './gathering';
+import { HARVEST_TIERS, type HarvestTier } from './gathering';
 
 /** Total focus points a player may allocate across every component type at once. */
 export const FOCUS_POINT_BUDGET = 10;
@@ -56,8 +63,21 @@ export const EMPTY_FOCUS_ALLOCATION: FocusAllocation = {};
  * plain interact press on a murloc take the #2509 all-forfeit refusal. Keeping
  * the unmapped families out of the allocation is what makes that unreachable
  * rather than merely unlikely.
+ *
+ * Being derived from content, this is a live-save contract and not just a
+ * table: renaming or retiring a HARVEST_COMPONENT_ITEMS key silently drops
+ * every existing character's points under the old key the next time they load
+ * (normalizeTownFocusOnLoad below), with no log and no refund. That is
+ * acceptable because focus points are a free, freely re-allocatable budget
+ * with no spent-points ledger, but it means such a rename is a save mutation,
+ * not a data edit. Frozen so the guarantee in the paragraph above is a real
+ * one: `Object.keys` hands back a live mutable array, and the Set is
+ * snapshotted at module init, so a push through a cast would leave the panel
+ * offering a row the validator refuses.
  */
-export const TOWN_FOCUS_COMPONENTS: readonly string[] = Object.keys(HARVEST_COMPONENT_ITEMS);
+export const TOWN_FOCUS_COMPONENTS: readonly string[] = Object.freeze(
+  Object.keys(HARVEST_COMPONENT_ITEMS),
+);
 
 // A Set, NOT a truthy `HARVEST_COMPONENT_ITEMS[key]` lookup. The map is a
 // plain object literal, so `constructor`, `toString`, `hasOwnProperty` and
@@ -159,6 +179,15 @@ export function setTownFocus(
     // with the character, so a hand-crafted frame could park arbitrary strings
     // (a 16 KiB one, or `constructor`) in a save and keep them there.
     //
+    // Scope of the whole-request rule below: the KEY channel. The value
+    // channel does not follow it, because server/game.ts pre-filters entries
+    // on `typeof v === 'number'` before this function ever sees them, so a
+    // non-number value arrives as an absent entry rather than as a rejection.
+    // Left alone deliberately: it is pre-existing, self-affecting, and
+    // unreachable from the shipped client, and changing it means moving a
+    // decision into the server dispatch, which is the opposite of where this
+    // fix argues validation belongs.
+    //
     // This WIDENS the empty-string check it replaces rather than adding a
     // behavior mode: '' was already rejected right here, and '' is just the
     // degenerate unknown key. Rejecting outright, over silently dropping the
@@ -195,6 +224,11 @@ export function setTownFocus(
  * Rebuild a persisted allocation into the shape setTownFocus commits: known
  * families only, each mapped to a positive integer (#2511 back-compat).
  *
+ * This is the whole population, not most of it: the only other writer of
+ * meta.townFocus is the validated setTownFocus commit, and a build change is a
+ * process restart, so no live character can be holding junk written by an
+ * older binary once this arm has run.
+ *
  * The command boundary above cannot repair a save that already carries junk,
  * and that junk is not inert once loaded: it is mirrored to the client in the
  * `tfocus` snapshot field, summed by the townFocusPoints deed meter, and read
@@ -212,13 +246,33 @@ export function setTownFocus(
  *
  * Same normalize-on-load shape as professions/tier_mail.ts
  * normalizeTierMailOnLoad and cadence.ts clampCadenceOnLoad, and it keeps the
- * sim.ts load arm thin. A total over FOCUS_POINT_BUDGET is deliberately NOT
- * re-checked here: a budget lowered by later tuning must not silently delete a
- * legitimate allocation, and the next set_town_focus re-validates the whole
- * request against the current budget anyway.
+ * sim.ts load arm thin. Unlike cadence, it needs no serialize-side
+ * counterpart: the fixed point holds by construction because the only writers
+ * of meta.townFocus are the fresh init, this arm, and the validated
+ * setTownFocus commit. Re-derive that if a fourth writer ever appears.
+ *
+ * A total over FOCUS_POINT_BUDGET is deliberately NOT re-checked here: a
+ * budget lowered by later tuning must not silently delete a legitimate
+ * allocation, and the next set_town_focus re-validates the whole request
+ * against the current budget anyway. The consequence, stated rather than
+ * discovered later: a save that somehow carries `{ hide: 40 }` keeps paying
+ * the uncapped applyFocusBonus yield on it. Unreachable through the command
+ * boundary, which caps the total at FOCUS_POINT_BUDGET and always did, even
+ * when it was counting unknown keys toward it.
+ *
+ * One stated behavior change for an affected character, not a side effect:
+ * dropping a real-but-unmapped corpse tag (claw/tusk/gills/horn) changes the
+ * DERIVED harvest pick from that single tag to the empty pick, so a plain
+ * interact press that used to hit the #2509 all-forfeit refusal and draw
+ * nothing now spreads and draws. That is the corpse paying out instead of
+ * refusing, it is deterministic and identical on all three hosts, and no
+ * parity scenario allocates a town focus.
+ *
+ * Takes `unknown` values on purpose: this reads a JSONB blob, so the runtime
+ * type guard below is load-bearing rather than decorative.
  */
 export function normalizeTownFocusOnLoad(
-  saved: Readonly<Record<string, number>> | undefined | null,
+  saved: Readonly<Record<string, unknown>> | undefined | null,
 ): Record<string, number> {
   const allocation: Record<string, number> = {};
   if (!saved) return allocation;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2448,7 +2448,11 @@ export class Sim {
       meta.delveMarks = s.delveMarks ?? 0;
       meta.delveClears = { ...(s.delveClears ?? {}) };
       meta.companionUpgrades = { ...(s.companionUpgrades ?? {}) };
-      meta.townFocus = { ...(s.townFocus ?? {}) };
+      // Known component families at positive integer points only: a save that
+      // predates the #2511 key check (or a corrupt one) self-heals here rather
+      // than riding back out through the panel into a request the command
+      // boundary now rejects.
+      meta.townFocus = professionsFocus.normalizeTownFocusOnLoad(s.townFocus);
       if (s.delveLoreUnlocked) for (const id of s.delveLoreUnlocked) meta.delveLoreUnlocked.add(id);
       if (s.delveDaily) {
         meta.delveDaily = {

--- a/src/ui/town_focus_view.ts
+++ b/src/ui/town_focus_view.ts
@@ -7,7 +7,7 @@
 // can give one back) and the remaining-point count. Rendering lives in
 // town_focus_window.ts.
 
-import { HARVEST_COMPONENT_ITEMS } from '../sim/professions/gathering';
+import { TOWN_FOCUS_COMPONENTS } from '../sim/professions/focus';
 
 export interface TownFocusRow {
   component: string;
@@ -26,7 +26,10 @@ export interface TownFocusView {
 }
 
 // Every currently-harvestable component type (#1140/#1142), stable order.
-export const TOWN_FOCUS_COMPONENTS: readonly string[] = Object.keys(HARVEST_COMPONENT_ITEMS);
+// Re-exported from the sim rather than derived here a second time (#2511):
+// this is the exact set setTownFocus accepts, so a row the panel offers can
+// never be a key the command boundary rejects.
+export { TOWN_FOCUS_COMPONENTS };
 
 export function buildTownFocusView(
   allocation: Readonly<Record<string, number>>,

--- a/src/ui/town_focus_view.ts
+++ b/src/ui/town_focus_view.ts
@@ -84,14 +84,30 @@ export function townFocusRenderSig(view: TownFocusView): string {
   return `${view.inTown ? 1 : 0}/${view.budget}/${view.remaining}/${rows}`;
 }
 
-/** Applies a single +1/-1 step to `component`, clamped at 0 and at the budget. */
+/**
+ * Applies a single +1/-1 step to `component`, clamped at 0 and at the budget.
+ *
+ * Built from TOWN_FOCUS_COMPONENTS rather than by spreading `allocation`
+ * forward (#2511), so the payload the panel posts is a function of the rows it
+ * actually draws. A spread carried any key buildTownFocusView never rendered
+ * into every Save, where the command boundary now rejects the whole request
+ * and the panel offers no control that could remove it. The sim closes that
+ * from its own side by dropping unknown keys on load; this keeps the view core
+ * from emitting a model it does not render in the first place. Inert for every
+ * legitimate allocation, because both the row list and the budget sum here
+ * already read TOWN_FOCUS_COMPONENTS and nothing else.
+ */
 export function stepTownFocus(
   allocation: Readonly<Record<string, number>>,
   component: string,
   delta: 1 | -1,
   budget: number,
 ): Record<string, number> {
-  const next: Record<string, number> = { ...allocation };
+  const next: Record<string, number> = {};
+  for (const c of TOWN_FOCUS_COMPONENTS) {
+    const points = Math.max(0, allocation[c] ?? 0);
+    if (points > 0) next[c] = points;
+  }
   const current = Math.max(0, next[component] ?? 0);
   const totalSpent = TOWN_FOCUS_COMPONENTS.reduce((sum, c) => sum + Math.max(0, next[c] ?? 0), 0);
   if (delta > 0 && totalSpent >= budget) return next;

--- a/src/ui/town_focus_view.ts
+++ b/src/ui/town_focus_view.ts
@@ -7,7 +7,7 @@
 // can give one back) and the remaining-point count. Rendering lives in
 // town_focus_window.ts.
 
-import { TOWN_FOCUS_COMPONENTS } from '../sim/professions/focus';
+import { isTownFocusComponent, TOWN_FOCUS_COMPONENTS } from '../sim/professions/focus';
 
 export interface TownFocusRow {
   component: string;
@@ -96,6 +96,12 @@ export function townFocusRenderSig(view: TownFocusView): string {
  * from emitting a model it does not render in the first place. Inert for every
  * legitimate allocation, because both the row list and the budget sum here
  * already read TOWN_FOCUS_COMPONENTS and nothing else.
+ *
+ * `component` is filtered too, not just the allocation carried forward, or the
+ * one key the caller names would be the single way back around the projection.
+ * The panel only ever steps a row it drew, so this is unreachable from the
+ * shipped client; it is here so the guarantee above holds for the function
+ * rather than for its current caller.
  */
 export function stepTownFocus(
   allocation: Readonly<Record<string, number>>,
@@ -108,6 +114,7 @@ export function stepTownFocus(
     const points = Math.max(0, allocation[c] ?? 0);
     if (points > 0) next[c] = points;
   }
+  if (!isTownFocusComponent(component)) return next;
   const current = Math.max(0, next[component] ?? 0);
   const totalSpent = TOWN_FOCUS_COMPONENTS.reduce((sum, c) => sum + Math.max(0, next[c] ?? 0), 0);
   if (delta > 0 && totalSpent >= budget) return next;

--- a/tests/corpse_harvest_sim.test.ts
+++ b/tests/corpse_harvest_sim.test.ts
@@ -2687,9 +2687,11 @@ describe('a pick of nothing but unmapped families is refused, claim intact (#250
   });
 
   it('refuses the DERIVED pick too, when a persisted town focus names only unmapped families', () => {
-    // set_town_focus does not validate that a key is a real component tag
-    // (#2511) and the allocation persists into the save, so an omitted
-    // `components` can resolve to an all-unmapped pick with no client involved.
+    // An omitted `components` resolves to the persisted town focus, so it can
+    // be an all-unmapped pick with no client involved. #2511 has since closed
+    // the write route (set_town_focus rejects an unmapped key and the load arm
+    // drops one an older save carries), so the direct meta poke below stands
+    // in for exactly that: a save written before the key check existed.
     // Pre-fix that burned the corpse on a plain interact press, with no picker
     // open and no line printed. The refusal covers this path for the same
     // reason it covers the explicit one: the yield is still being forfeited.

--- a/tests/deeds.test.ts
+++ b/tests/deeds.test.ts
@@ -1220,7 +1220,10 @@ describe('meter triggers (negative then positive per resolver)', () => {
           meta.townFocus = {};
         },
         at: () => {
-          meta.townFocus = { forge: 1 };
+          // A real component family: since #2511 no reachable path can put a
+          // key like 'forge' in an allocation, so a fixture using one would
+          // pin a shape the game cannot produce.
+          meta.townFocus = { hide: 1 };
         },
       },
       {

--- a/tests/focus.test.ts
+++ b/tests/focus.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { HARVEST_COMPONENT_ITEMS } from '../src/sim/content/professions';
 import { ZONES } from '../src/sim/data';
 import {
   applyFocusBonus,
@@ -7,10 +8,14 @@ import {
   EMPTY_FOCUS_ALLOCATION,
   FOCUS_POINT_BUDGET,
   isInTownZone,
+  isTownFocusComponent,
+  normalizeTownFocusOnLoad,
   POINTS_PER_TIER_BONUS,
   RESPEC_TIER_CONFIG,
   setTownFocus,
+  TOWN_FOCUS_COMPONENTS,
 } from '../src/sim/professions/focus';
+import { TOWN_FOCUS_COMPONENTS as PANEL_COMPONENTS } from '../src/ui/town_focus_view';
 
 const ZONE1 = ZONES[0];
 
@@ -114,6 +119,189 @@ describe('setTownFocus: gated on town, budget-capped, rejects leave prior state 
     const result = setTownFocus({}, { hide: 3, fang: 0 }, true);
     expect(result.ok).toBe(true);
     expect(result.allocation).toEqual({ hide: 3 });
+  });
+});
+
+// #2511: the allocation's point VALUES were validated but its KEYS were not
+// (only an empty string was refused), so every surviving key was copied into
+// the returned allocation, stored on PlayerMeta.townFocus, saved, and reloaded.
+// A hand-crafted set_town_focus frame could therefore park arbitrary strings in
+// a character save and keep them there across sessions.
+//
+// The ruling, and the reason it is REJECT rather than drop-the-unknown-keys:
+// the check widens the empty-string refusal that already sat on this exact
+// line, so it is the same shape and the same reason code rather than a new
+// partial-accept mode. Nothing is consumed by a refused request, so retrying is
+// free (unlike the #2504 harvest pick, where a single-use corpse was at stake
+// and "ignored entirely" was therefore the kinder rule).
+describe('setTownFocus rejects a key that is not a real component family (#2511)', () => {
+  const PREVIOUS = { hide: 2 } as const;
+
+  function rejects(requested: Record<string, number>): void {
+    const result = setTownFocus(PREVIOUS, requested, true);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('invalid_allocation');
+    // The whole point of the issue: nothing from the request reaches the
+    // allocation that gets persisted.
+    expect(result.allocation).toEqual(PREVIOUS);
+  }
+
+  it('refuses the issue frame, and the previous allocation survives it', () => {
+    rejects({ not_a_real_tag: 5 });
+  });
+
+  it('refuses a real tag vocabulary word that no harvest item maps', () => {
+    // claw/tusk/gills/horn are carried by shipped mobs but map to no item. They
+    // are the narrow-vs-wide allowlist call: allowed here, a persisted
+    // `{ gills: 1 }` would make the omitted-components harvest default derive
+    // an all-unmapped pick and take the #2509 refusal on every plain interact
+    // press (tests/corpse_harvest_sim.test.ts measures that on old_greyjaw).
+    for (const tag of ['claw', 'tusk', 'gills', 'horn']) rejects({ [tag]: 3 });
+  });
+
+  it('refuses an unknown key sitting beside a perfectly good one', () => {
+    rejects({ hide: 3, not_a_real_tag: 1 });
+  });
+
+  it('refuses an ALL-unknown allocation too: one rule, no boundary exception', () => {
+    rejects({ not_a_real_tag: 1, another_fake: 2 });
+  });
+
+  it('still refuses the empty-string key this check subsumes', () => {
+    // The pre-#2511 body rejected '' explicitly. Deleting that line in favor of
+    // the allowlist must not quietly re-open it, and nothing else covered it.
+    rejects({ '': 3 });
+    rejects({ '': 0 });
+  });
+
+  it('refuses an inherited Object.prototype name, which a truthy map lookup would accept', () => {
+    // The reason the allowlist is a Set and not `!!HARVEST_COMPONENT_ITEMS[k]`:
+    // the map is a plain object literal, so all four of these read back truthy
+    // off the prototype. They reach the sim as real own keys (the server's wire
+    // loop copies entries onto a fresh object), unlike `__proto__`, which that
+    // same loop swallows through the prototype setter.
+    for (const name of ['constructor', 'toString', 'hasOwnProperty', 'valueOf']) {
+      expect(!!(HARVEST_COMPONENT_ITEMS as Record<string, unknown>)[name]).toBe(true);
+      expect(isTownFocusComponent(name)).toBe(false);
+      rejects({ [name]: 1 });
+    }
+  });
+
+  it('refuses the numeric-string keys an array payload decays to', () => {
+    // server/game.ts admits any `typeof msg.allocation === 'object'`, and
+    // Object.entries([7]) is [['0', 7]].
+    rejects(Object.fromEntries(Object.entries([7, 3])));
+  });
+
+  it('refuses a zero-valued unknown key, though the commit loop would have dropped it', () => {
+    // Stated because it IS a widening past the security bug: `{ hide: 3,
+    // junk: 0 }` was accepted before. One rule reading the same at every value
+    // is worth more than the exception, and no shipped client can send this
+    // (stepTownFocus deletes a component when it reaches zero).
+    rejects({ hide: 3, junk: 0 });
+  });
+
+  it('answers invalid_allocation, not over_budget, when a bad key is also over budget', () => {
+    // Precedence is decided, not incidental: the key check returns from inside
+    // the entry loop and the budget test runs after it. Pinned so a future
+    // reorder has to argue with a test.
+    const result = setTownFocus(PREVIOUS, { leather: FOCUS_POINT_BUDGET + 999 }, true);
+    expect(result.reason).toBe('invalid_allocation');
+    // Contrast, same shape and the same over-budget total on a REAL family, so
+    // this pin cannot pass by answering invalid_allocation to everything.
+    expect(setTownFocus(PREVIOUS, { hide: FOCUS_POINT_BUDGET + 999 }, true).reason).toBe(
+      'over_budget',
+    );
+  });
+
+  it('answers not_in_town first: the town gate still outranks a bad key', () => {
+    const result = setTownFocus(PREVIOUS, { not_a_real_tag: 5 }, false);
+    expect(result.reason).toBe('not_in_town');
+    expect(result.allocation).toEqual(PREVIOUS);
+  });
+
+  it('accepts every component the shipped panel can offer', () => {
+    // The contract that matters to a real player, and the reason the allowlist
+    // has ONE definition (src/ui/town_focus_view.ts re-exports the sim's):
+    // no row the panel renders can be a key the command boundary refuses.
+    // Driven from the PANEL's export against the real validator, so a future
+    // change that re-derives the list separately has to red this rather than
+    // compare a constant with itself.
+    expect(PANEL_COMPONENTS.length).toBeGreaterThan(1);
+    expect([...PANEL_COMPONENTS]).toEqual([...TOWN_FOCUS_COMPONENTS]);
+    for (const component of PANEL_COMPONENTS) {
+      expect(isTownFocusComponent(component)).toBe(true);
+      const result = setTownFocus({}, { [component]: 1 }, true);
+      expect(result.ok, component).toBe(true);
+      expect(result.allocation).toEqual({ [component]: 1 });
+    }
+    // A full-budget spread over real families still commits unchanged, and a
+    // budget-exact re-spec off a previous allocation is untouched.
+    const spread = { hide: 4, fang: 3, silk: 3 };
+    expect(setTownFocus({ meat: 10 }, spread, true)).toEqual({ ok: true, allocation: spread });
+  });
+
+  it('has no key the allowlist admits that the item table does not map', () => {
+    // The other direction, so the allowlist cannot quietly widen: every member
+    // maps to a real harvest item, which is what makes focus on it do anything.
+    for (const component of TOWN_FOCUS_COMPONENTS) {
+      expect(HARVEST_COMPONENT_ITEMS[component], component).toBeTruthy();
+    }
+    expect(isTownFocusComponent('__proto__')).toBe(false);
+  });
+});
+
+describe('normalizeTownFocusOnLoad: an older save self-heals (#2511)', () => {
+  it('drops unknown keys and keeps the real ones, at their points', () => {
+    expect(normalizeTownFocusOnLoad({ hide: 4, eastbrook: 4, fang: 2 })).toEqual({
+      hide: 4,
+      fang: 2,
+    });
+  });
+
+  it('drops every key when the whole saved allocation is junk', () => {
+    expect(normalizeTownFocusOnLoad({ eastbrook: 4, claw: 1 })).toEqual({});
+  });
+
+  it('returns a fresh empty allocation for a missing or empty save', () => {
+    expect(normalizeTownFocusOnLoad(undefined)).toEqual({});
+    expect(normalizeTownFocusOnLoad(null)).toEqual({});
+    expect(normalizeTownFocusOnLoad({})).toEqual({});
+  });
+
+  it('normalizes to the shape setTownFocus commits: positive integers only', () => {
+    const loaded = normalizeTownFocusOnLoad({
+      hide: 0,
+      fang: -2,
+      silk: 1.5,
+      meat: Number.NaN,
+      cloth: 3,
+    } as Record<string, number>);
+    expect(loaded).toEqual({ cloth: 3 });
+  });
+
+  it('leaves an over-budget total alone: only the command boundary owns the budget', () => {
+    // Deliberate. A budget lowered by later tuning must not silently delete a
+    // legitimate allocation, and the next set_town_focus re-validates the whole
+    // request anyway.
+    const saved = { hide: FOCUS_POINT_BUDGET, fang: FOCUS_POINT_BUDGET };
+    expect(normalizeTownFocusOnLoad(saved)).toEqual(saved);
+  });
+
+  it('copies rather than aliases, so a later edit cannot write back into the save', () => {
+    const saved = { hide: 4 };
+    const loaded = normalizeTownFocusOnLoad(saved);
+    loaded.hide = 9;
+    expect(saved.hide).toBe(4);
+  });
+
+  it('never returns a key setTownFocus would then refuse', () => {
+    // The two halves of the fix agree by construction, pinned by driving both.
+    const junked = { hide: 3, eastbrook: 4, '': 1, constructor: 2, gills: 5 };
+    const loaded = normalizeTownFocusOnLoad(junked);
+    expect(setTownFocus({}, loaded, true).ok).toBe(true);
+    // ...and the raw save would NOT have been accepted, so this is not vacuous.
+    expect(setTownFocus({}, junked, true).ok).toBe(false);
   });
 });
 

--- a/tests/focus.test.ts
+++ b/tests/focus.test.ts
@@ -185,6 +185,10 @@ describe('setTownFocus rejects a key that is not a real component family (#2511)
       expect(isTownFocusComponent(name)).toBe(false);
       rejects({ [name]: 1 });
     }
+    // `__proto__` never reaches the sim as an own key (the server's copy loop
+    // assigns through the prototype setter, which ignores a number), so it gets
+    // the allowlist assertion without a request arm.
+    expect(isTownFocusComponent('__proto__')).toBe(false);
   });
 
   it('refuses the numeric-string keys an array payload decays to', () => {
@@ -205,8 +209,15 @@ describe('setTownFocus rejects a key that is not a real component family (#2511)
     // Precedence is decided, not incidental: the key check returns from inside
     // the entry loop and the budget test runs after it. Pinned so a future
     // reorder has to argue with a test.
-    const result = setTownFocus(PREVIOUS, { leather: FOCUS_POINT_BUDGET + 999 }, true);
+    const result = setTownFocus(PREVIOUS, { not_a_real_tag: FOCUS_POINT_BUDGET + 999 }, true);
     expect(result.reason).toBe('invalid_allocation');
+    expect(result.allocation).toEqual(PREVIOUS);
+    // The bad key AFTER a real one that already blew the budget. A separate arm:
+    // the first case only proves the key check beats the post-loop budget test,
+    // while this one also proves it is not sitting below the `total +=`
+    // accumulation for an earlier entry. A reorder can break one without the
+    // other, and a single-key fixture cannot tell those two edits apart.
+    rejects({ hide: FOCUS_POINT_BUDGET + 999, not_a_real_tag: 1 });
     // Contrast, same shape and the same over-budget total on a REAL family, so
     // this pin cannot pass by answering invalid_allocation to everything.
     expect(setTownFocus(PREVIOUS, { hide: FOCUS_POINT_BUDGET + 999 }, true).reason).toBe(
@@ -220,15 +231,43 @@ describe('setTownFocus rejects a key that is not a real component family (#2511)
     expect(result.allocation).toEqual(PREVIOUS);
   });
 
+  it('is exactly the six item-mapped families, and the panel exports that same binding', () => {
+    // Pinned to LITERALS, not re-derived. `Object.keys(HARVEST_COMPONENT_ITEMS)`
+    // compared against a constant DEFINED as that expression is a constant
+    // self-comparison: it holds however the item map changes, so it cannot
+    // catch the allowlist silently widening or shrinking, and `venomSac` would
+    // otherwise never be named anywhere in this suite.
+    expect([...TOWN_FOCUS_COMPONENTS]).toEqual([
+      'hide',
+      'fang',
+      'silk',
+      'venomSac',
+      'meat',
+      'cloth',
+    ]);
+    // And each really is a mapped family, pinned by item id rather than by
+    // truthiness, so widening the item map cannot quietly widen the allowlist
+    // without this line moving too.
+    expect({ ...HARVEST_COMPONENT_ITEMS }).toEqual({
+      hide: 'rough_hide',
+      fang: 'wolf_fang',
+      silk: 'spider_silk',
+      venomSac: 'venom_gland',
+      meat: 'game_meat',
+      cloth: 'homespun_cloth',
+    });
+    // ONE definition, stated as the identity it is: the panel re-exports the
+    // sim's binding (src/ui/town_focus_view.ts), so this reds the moment the UI
+    // derives its own list at all, faithfully or not. A structural toEqual
+    // would not: a faithful re-derivation would still pass.
+    expect(PANEL_COMPONENTS).toBe(TOWN_FOCUS_COMPONENTS);
+  });
+
   it('accepts every component the shipped panel can offer', () => {
-    // The contract that matters to a real player, and the reason the allowlist
-    // has ONE definition (src/ui/town_focus_view.ts re-exports the sim's):
-    // no row the panel renders can be a key the command boundary refuses.
-    // Driven from the PANEL's export against the real validator, so a future
-    // change that re-derives the list separately has to red this rather than
-    // compare a constant with itself.
-    expect(PANEL_COMPONENTS.length).toBeGreaterThan(1);
-    expect([...PANEL_COMPONENTS]).toEqual([...TOWN_FOCUS_COMPONENTS]);
+    // The contract that matters to a real player: no row the panel renders can
+    // be a key the command boundary refuses. Driven from the PANEL's export
+    // through the REAL validator, which is the non-self-referential half (the
+    // membership itself is pinned against literals in the test above).
     for (const component of PANEL_COMPONENTS) {
       expect(isTownFocusComponent(component)).toBe(true);
       const result = setTownFocus({}, { [component]: 1 }, true);
@@ -239,15 +278,6 @@ describe('setTownFocus rejects a key that is not a real component family (#2511)
     // budget-exact re-spec off a previous allocation is untouched.
     const spread = { hide: 4, fang: 3, silk: 3 };
     expect(setTownFocus({ meat: 10 }, spread, true)).toEqual({ ok: true, allocation: spread });
-  });
-
-  it('has no key the allowlist admits that the item table does not map', () => {
-    // The other direction, so the allowlist cannot quietly widen: every member
-    // maps to a real harvest item, which is what makes focus on it do anything.
-    for (const component of TOWN_FOCUS_COMPONENTS) {
-      expect(HARVEST_COMPONENT_ITEMS[component], component).toBeTruthy();
-    }
-    expect(isTownFocusComponent('__proto__')).toBe(false);
   });
 });
 
@@ -267,6 +297,12 @@ describe('normalizeTownFocusOnLoad: an older save self-heals (#2511)', () => {
     expect(normalizeTownFocusOnLoad(undefined)).toEqual({});
     expect(normalizeTownFocusOnLoad(null)).toEqual({});
     expect(normalizeTownFocusOnLoad({})).toEqual({});
+    // FRESH is the load-bearing word, and toEqual({}) alone does not say it: a
+    // shared EMPTY_FOCUS_ALLOCATION on the early-return path would pass that
+    // and alias one mutable object across every character loaded without a
+    // townFocus.
+    expect(normalizeTownFocusOnLoad(undefined)).not.toBe(normalizeTownFocusOnLoad(undefined));
+    expect(normalizeTownFocusOnLoad(undefined)).not.toBe(EMPTY_FOCUS_ALLOCATION);
   });
 
   it('normalizes to the shape setTownFocus commits: positive integers only', () => {
@@ -295,13 +331,36 @@ describe('normalizeTownFocusOnLoad: an older save self-heals (#2511)', () => {
     expect(saved.hide).toBe(4);
   });
 
-  it('never returns a key setTownFocus would then refuse', () => {
-    // The two halves of the fix agree by construction, pinned by driving both.
-    const junked = { hide: 3, eastbrook: 4, '': 1, constructor: 2, gills: 5 };
+  it('never returns anything setTownFocus would then refuse', () => {
+    // The two halves of the fix agree, pinned by driving both. The fixture
+    // carries a bad VALUE as well as bad keys, which is the second, independent
+    // pin on the value dimension: drop the integer or positivity guard and
+    // `silk: 1.5` / `fang: -2` survive into an allocation setTownFocus rejects,
+    // so this reds through a completely different path than the exact-shape
+    // assertion above.
+    const junked = { hide: 3, eastbrook: 4, '': 1, constructor: 2, gills: 5, silk: 1.5, fang: -2 };
     const loaded = normalizeTownFocusOnLoad(junked);
+    expect(loaded).toEqual({ hide: 3 });
     expect(setTownFocus({}, loaded, true).ok).toBe(true);
     // ...and the raw save would NOT have been accepted, so this is not vacuous.
     expect(setTownFocus({}, junked, true).ok).toBe(false);
+  });
+
+  it('leaves a committed allocation untouched through a load: the round trip is a fixed point', () => {
+    // The other composition, and the one nothing else pins. The commit loop
+    // keeps any `points > 0` with no integer re-check, while this normalizer
+    // also demands Number.isInteger; they agree only because the boundary
+    // already rejected non-integers upstream. Driven over every family so a
+    // future divergence in either loop's value predicate has to red here.
+    for (const component of TOWN_FOCUS_COMPONENTS) {
+      const committed = setTownFocus({}, { [component]: FOCUS_POINT_BUDGET }, true);
+      expect(committed.ok, component).toBe(true);
+      expect(normalizeTownFocusOnLoad(committed.allocation), component).toEqual(
+        committed.allocation,
+      );
+    }
+    const spread = setTownFocus({}, { hide: 4, fang: 3, silk: 3 }, true);
+    expect(normalizeTownFocusOnLoad(spread.allocation)).toEqual(spread.allocation);
   });
 });
 

--- a/tests/talent_save_migration_v026.test.ts
+++ b/tests/talent_save_migration_v026.test.ts
@@ -118,6 +118,14 @@ describe('v0.26 Talents V2 production save migration', () => {
     // synthetic q_fixture_done, pinning that done-history survives unknown ids.
     expect(first.questLog).toEqual(fixture.state.questLog);
     expect(first.questsDone).toEqual(fixture.state.questsDone);
+    // Same shape one field over (#2511): the fixture's townFocus is
+    // `{ eastbrook: 4 }`, a key that names no component family, and the load
+    // arm drops it so it cannot ride back out through the panel into a request
+    // the command boundary now rejects. Not vacuous, the fixture really does
+    // carry it, and the pure migration above still preserves it verbatim: the
+    // drop belongs to the load arm alone.
+    expect(fixture.state.townFocus).toEqual({ eastbrook: 4 });
+    expect(first.townFocus).toEqual({});
     expect(first.skin).toBe(3);
     expect(first.cooldowns).toEqual(fixture.state.cooldowns);
 

--- a/tests/town_focus_repaint_gate.test.ts
+++ b/tests/town_focus_repaint_gate.test.ts
@@ -66,6 +66,10 @@ describe('townFocusRenderSig', () => {
     const ids = Object.keys(HARVEST_COMPONENT_ITEMS);
     expect(ids.length).toBeGreaterThan(1);
     for (const id of ids) expect(id).not.toMatch(/[:|/]/);
+    // Since #2511 the panel re-exports the sim's single definition rather than
+    // deriving its own, so this line no longer proves two derivations agree,
+    // only that the one definition is still the content table's key order. The
+    // membership itself is pinned against literals in tests/focus.test.ts.
     expect([...TOWN_FOCUS_COMPONENTS]).toEqual(ids);
     // The painter's focus keys share ONE flat namespace with the two singleton
     // keys, so a component literally named `save` or `close` would route the

--- a/tests/town_focus_sim.test.ts
+++ b/tests/town_focus_sim.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 vi.mock('../server/db', () => ({
   pool: { query: vi.fn(async () => ({ rows: [] })) },
   saveCharacterState: vi.fn(async () => {}),
+  saveCharacterAndMarketState: vi.fn(async () => {}),
   openPlaySession: vi.fn(async () => 1),
   touchCharacterLogin: vi.fn(async () => {}),
   closePlaySession: vi.fn(async () => {}),
@@ -114,15 +115,19 @@ describe('an unknown allocation key never reaches the character save (#2511)', (
   });
 
   it('survives the save/load round trip as the rejection, not as stored junk', () => {
+    // Seeded with a real allocation FIRST so the round trip carries a value:
+    // an all-empty version of this would be {} equalling {} at all three
+    // checkpoints, which the unfixed load arm satisfies just as well.
     const { sim, internals, a } = setup();
+    sim.setTownFocus({ hide: 4 }, a);
     sim.setTownFocus({ hide: 4, not_a_real_tag: 5 }, a);
-    expect(internals.players.get(a)?.townFocus).toEqual({});
+    expect(internals.players.get(a)?.townFocus).toEqual({ hide: 4 });
     const state = sim.serializeCharacter(a);
-    expect(state?.townFocus).toEqual({});
+    expect(state?.townFocus).toEqual({ hide: 4 });
 
     const reloaded = new Sim({ seed: 21, playerClass: 'warrior', noPlayer: true });
     const b = reloaded.addPlayer('warrior', 'Alpha', { state: state ?? undefined });
-    expect((reloaded as unknown as SimInternals).players.get(b)?.townFocus).toEqual({});
+    expect((reloaded as unknown as SimInternals).players.get(b)?.townFocus).toEqual({ hide: 4 });
   });
 
   it('drops an unknown key an OLDER save already carries, and re-saves without it', () => {
@@ -143,11 +148,18 @@ describe('an unknown allocation key never reaches the character save (#2511)', (
   });
 
   it('unlocks the panel a junked save would otherwise have jammed shut', () => {
-    // Why the load arm is load-bearing rather than tidy-up. The panel seeds its
-    // draft from the stored allocation and stepTownFocus spreads that whole
-    // draft forward on every +/-, so without the drop the unknown key would
-    // ride back into the next Save and be refused, with no control anywhere
-    // that could delete it: the character could never change focus again.
+    // Why the load arm is load-bearing rather than tidy-up. A client seeds its
+    // draft from the stored allocation and carries that whole draft forward on
+    // every +/-, so without the drop the unknown key rides back into the next
+    // Save and is refused, with no control anywhere that could delete it: the
+    // character could never change focus again.
+    //
+    // Posts a RAW spread of the stored allocation on purpose, NOT stepTownFocus.
+    // The shipped view core now projects its output onto TOWN_FOCUS_COMPONENTS,
+    // which would strip the junk client-side and make this test pass with the
+    // load arm deleted. This drives the sim's own guarantee instead, which is
+    // the one that has to hold for any client, including a cached older bundle
+    // that still spreads.
     const { sim, a } = setup();
     const junked = { ...sim.serializeCharacter(a)!, townFocus: { hide: 3, eastbrook: 4 } };
     const reloaded = new Sim({ seed: 21, playerClass: 'warrior', noPlayer: true });
@@ -159,11 +171,26 @@ describe('an unknown allocation key never reaches the character save (#2511)', (
     reloaded.tick();
     reloaded.drainEvents();
 
-    // Exactly what the panel posts: the draft it was seeded with, plus a step.
-    const draft = stepTownFocus(reloaded.townFocusFor(b), 'hide', 1, FOCUS_POINT_BUDGET);
-    reloaded.setTownFocus(draft, b);
+    reloaded.setTownFocus({ ...reloaded.townFocusFor(b), hide: 4 }, b);
     expect(internals.players.get(b)?.townFocus).toEqual({ hide: 4 });
     expect(errorsOf(reloaded)).toEqual([]);
+  });
+
+  it('has the panel post only rows it renders, so a stale draft cannot jam it either', () => {
+    // The client half of the same guarantee (stepTownFocus projects onto
+    // TOWN_FOCUS_COMPONENTS instead of spreading its input), driven against the
+    // real Sim rather than as a view-core unit: a draft carrying a key the
+    // panel never drew still commits.
+    const { sim, internals, a } = setup();
+    const stale = { hide: 2, eastbrook: 4, constructor: 1 };
+    const draft = stepTownFocus(stale, 'hide', 1, FOCUS_POINT_BUDGET);
+    expect(draft).toEqual({ hide: 3 });
+    sim.setTownFocus(draft, a);
+    expect(internals.players.get(a)?.townFocus).toEqual({ hide: 3 });
+    expect(errorsOf(sim)).toEqual([]);
+    // A decrement to zero still removes the row, and still emits nothing junk.
+    expect(stepTownFocus(stale, 'hide', -1, FOCUS_POINT_BUDGET)).toEqual({ hide: 1 });
+    expect(stepTownFocus({ hide: 1, eastbrook: 4 }, 'hide', -1, FOCUS_POINT_BUDGET)).toEqual({});
   });
 
   it('stops a junk-only save from paying out the first-focus-point deed', () => {
@@ -309,13 +336,14 @@ describe('harvestCorpse omitted-components town-focus default', () => {
 });
 
 // The #2511 fix sits at the SIM boundary, not in server/game.ts, and this is
-// the pin that says so on purpose: the offline browser Sim and the headless RL
-// env reach setTownFocus through IWorld without ever passing the server's
-// dispatch switch, so validating keys there would have left both hosts open.
-// If a future change starts filtering on the server too, this test is the one
-// to re-argue rather than quietly delete.
-describe('the server forwards a set_town_focus allocation verbatim (#2511)', () => {
-  it('passes the unknown key straight through to the sim, which is what refuses it', () => {
+// the pin that says so on purpose: the offline browser Sim reaches
+// setTownFocus through IWorld without ever passing the server's dispatch
+// switch, so validating keys there would have left that host open. (The
+// headless RL env is NOT a second reason: it exposes no town-focus action at
+// all, and never loads a CharacterState.) If a future change starts filtering
+// on the server too, this test is the one to re-argue rather than delete.
+describe('the server forwards a set_town_focus allocation key verbatim (#2511)', () => {
+  it('passes the unknown key straight through, unfiltered', () => {
     const server = new GameServer();
     const session = server.join(
       { readyState: 1, send: () => {} } as never,
@@ -340,5 +368,27 @@ describe('the server forwards a set_town_focus allocation verbatim (#2511)', () 
       0,
     );
     expect(spy).toHaveBeenCalledWith({ hide: 4, not_a_real_tag: 5 }, session.pid);
+
+    // "Verbatim" is true of the KEY channel only, which is the channel #2511 is
+    // about. The dispatch does pre-filter VALUES on `typeof v === 'number'`, so
+    // a non-numeric value arrives at the sim as an absent entry rather than as
+    // a rejection: a silent partial accept the key rule deliberately does not
+    // have. Pinned rather than left implicit, because the source comment in
+    // professions/focus.ts scopes its whole-request rule against exactly this,
+    // and closing it means moving a decision into the dispatch, which is the
+    // opposite of what this describe argues.
+    spy.mockClear();
+    const stringValued = JSON.stringify({
+      t: 'cmd',
+      cmd: 'set_town_focus',
+      allocation: { hide: 4, fang: 'x' },
+    });
+    (server as unknown as { dispatchMessage: (...a: unknown[]) => void }).dispatchMessage(
+      session,
+      JSON.parse(stringValued),
+      stringValued,
+      0,
+    );
+    expect(spy).toHaveBeenCalledWith({ hide: 4 }, session.pid);
   });
 });

--- a/tests/town_focus_sim.test.ts
+++ b/tests/town_focus_sim.test.ts
@@ -191,6 +191,15 @@ describe('an unknown allocation key never reaches the character save (#2511)', (
     // A decrement to zero still removes the row, and still emits nothing junk.
     expect(stepTownFocus(stale, 'hide', -1, FOCUS_POINT_BUDGET)).toEqual({ hide: 1 });
     expect(stepTownFocus({ hide: 1, eastbrook: 4 }, 'hide', -1, FOCUS_POINT_BUDGET)).toEqual({});
+    // Stepping a component that is not a real family is a no-op, in both
+    // directions. Without this the named key would be the one way back around
+    // the projection, since it is written after the carried-forward rows.
+    expect(stepTownFocus({ hide: 2 }, 'eastbrook', 1, FOCUS_POINT_BUDGET)).toEqual({ hide: 2 });
+    expect(stepTownFocus({ hide: 2 }, 'constructor', 1, FOCUS_POINT_BUDGET)).toEqual({ hide: 2 });
+    expect(stepTownFocus({}, 'not_a_real_tag', 1, FOCUS_POINT_BUDGET)).toEqual({});
+    expect(stepTownFocus({ hide: 2, gills: 3 }, 'gills', -1, FOCUS_POINT_BUDGET)).toEqual({
+      hide: 2,
+    });
   });
 
   it('stops a junk-only save from paying out the first-focus-point deed', () => {

--- a/tests/town_focus_sim.test.ts
+++ b/tests/town_focus_sim.test.ts
@@ -1,10 +1,35 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the db layer so no Postgres is needed. Only the command-dispatch hop is
+// under test here (the #2511 wire pin at the bottom of this file); everything
+// else drives a bare Sim.
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  touchCharacterLogin: vi.fn(async () => {}),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
+  loadAccountFlair: vi.fn(async () => ({ ai: false, streamer: false, links: {} })),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  setAccountWeaponSkinLoadout: vi.fn(async () => ({
+    completedQuestIds: [],
+    mechChromaIds: [],
+    weaponSkinIds: [],
+    weaponSkinLoadout: {},
+  })),
+}));
+
+import { GameServer } from '../server/game';
 import { MOBS, ZONES } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
-import { POINTS_PER_TIER_BONUS } from '../src/sim/professions/focus';
+import { FOCUS_POINT_BUDGET, POINTS_PER_TIER_BONUS } from '../src/sim/professions/focus';
 import type { PlayerMeta } from '../src/sim/sim';
 import { Sim } from '../src/sim/sim';
 import type { Entity } from '../src/sim/types';
+import { stepTownFocus } from '../src/ui/town_focus_view';
 
 // #1143: persistent, town-set focus allocation, applied on top of the #1142
 // per-corpse harvest roll. Two properties matter end-to-end:
@@ -63,6 +88,103 @@ describe('setTownFocus: gated on standing in the town hub', () => {
     const { sim, internals, a } = setup();
     sim.setTownFocus({ hide: 999 }, a);
     expect(internals.players.get(a)?.townFocus).toEqual({});
+  });
+});
+
+// #2511, the persistence half: the pure validator now refuses an unknown key
+// (tests/focus.test.ts owns that rule), and the load arm drops one an older
+// save already carries. These drive the real Sim end to end, because the whole
+// harm of the issue was in what reached PlayerMeta.townFocus and survived a
+// save/load round trip.
+describe('an unknown allocation key never reaches the character save (#2511)', () => {
+  function errorsOf(sim: Sim): string[] {
+    return sim
+      .drainEvents()
+      .filter((e): e is Extract<typeof e, { type: 'error' }> => e.type === 'error')
+      .map((e) => e.text);
+  }
+
+  it('refuses the issue frame in town, leaving the stored allocation untouched', () => {
+    const { sim, internals, a } = setup();
+    sim.setTownFocus({ hide: 4 }, a);
+    sim.drainEvents();
+    sim.setTownFocus({ not_a_real_tag: 5 }, a);
+    expect(internals.players.get(a)?.townFocus).toEqual({ hide: 4 });
+    expect(errorsOf(sim)).toEqual(['Invalid focus allocation.']);
+  });
+
+  it('survives the save/load round trip as the rejection, not as stored junk', () => {
+    const { sim, internals, a } = setup();
+    sim.setTownFocus({ hide: 4, not_a_real_tag: 5 }, a);
+    expect(internals.players.get(a)?.townFocus).toEqual({});
+    const state = sim.serializeCharacter(a);
+    expect(state?.townFocus).toEqual({});
+
+    const reloaded = new Sim({ seed: 21, playerClass: 'warrior', noPlayer: true });
+    const b = reloaded.addPlayer('warrior', 'Alpha', { state: state ?? undefined });
+    expect((reloaded as unknown as SimInternals).players.get(b)?.townFocus).toEqual({});
+  });
+
+  it('drops an unknown key an OLDER save already carries, and re-saves without it', () => {
+    // Back-compat, the leg the command boundary cannot reach. The junk here is
+    // the exact shape shipped in tests/fixtures/v025_warrior_character.json.
+    const { sim, a } = setup();
+    const state = sim.serializeCharacter(a);
+    expect(state).not.toBeNull();
+    const junked = { ...state!, townFocus: { hide: 3, eastbrook: 4, gills: 1 } };
+
+    const reloaded = new Sim({ seed: 21, playerClass: 'warrior', noPlayer: true });
+    const b = reloaded.addPlayer('warrior', 'Alpha', { state: junked });
+    const meta = (reloaded as unknown as SimInternals).players.get(b);
+    expect(meta?.townFocus).toEqual({ hide: 3 });
+    // The legitimate points are kept, and the junk does not come back out of
+    // the next serialize either.
+    expect(reloaded.serializeCharacter(b)?.townFocus).toEqual({ hide: 3 });
+  });
+
+  it('unlocks the panel a junked save would otherwise have jammed shut', () => {
+    // Why the load arm is load-bearing rather than tidy-up. The panel seeds its
+    // draft from the stored allocation and stepTownFocus spreads that whole
+    // draft forward on every +/-, so without the drop the unknown key would
+    // ride back into the next Save and be refused, with no control anywhere
+    // that could delete it: the character could never change focus again.
+    const { sim, a } = setup();
+    const junked = { ...sim.serializeCharacter(a)!, townFocus: { hide: 3, eastbrook: 4 } };
+    const reloaded = new Sim({ seed: 21, playerClass: 'warrior', noPlayer: true });
+    const b = reloaded.addPlayer('warrior', 'Alpha', { state: junked });
+    const internals = reloaded as unknown as SimInternals;
+    const e = internals.entities.get(b)!;
+    e.pos = { x: ZONE1.hub.x, y: 0, z: ZONE1.hub.z };
+    e.prevPos = { ...e.pos };
+    reloaded.tick();
+    reloaded.drainEvents();
+
+    // Exactly what the panel posts: the draft it was seeded with, plus a step.
+    const draft = stepTownFocus(reloaded.townFocusFor(b), 'hide', 1, FOCUS_POINT_BUDGET);
+    reloaded.setTownFocus(draft, b);
+    expect(internals.players.get(b)?.townFocus).toEqual({ hide: 4 });
+    expect(errorsOf(reloaded)).toEqual([]);
+  });
+
+  it('stops a junk-only save from paying out the first-focus-point deed', () => {
+    // townFocusPoints sums the allocation blind, so before the drop a single
+    // fabricated key earned soc_civic_duty with no real focus allocated.
+    const { sim, a } = setup();
+    const junked = { ...sim.serializeCharacter(a)!, townFocus: { eastbrook: 4 } };
+    const reloaded = new Sim({ seed: 21, playerClass: 'warrior', noPlayer: true });
+    const b = reloaded.addPlayer('warrior', 'Alpha', { state: junked });
+    for (let i = 0; i < 5; i++) reloaded.tick();
+    const earned = () =>
+      (reloaded as unknown as SimInternals).players.get(b)!.deedsEarned.has('soc_civic_duty');
+    expect(earned()).toBe(false);
+
+    // Not vacuous: one real point in town earns it on the same rig.
+    const e = (reloaded as unknown as SimInternals).entities.get(b)!;
+    e.pos = { x: ZONE1.hub.x, y: 0, z: ZONE1.hub.z };
+    e.prevPos = { ...e.pos };
+    reloaded.setTownFocus({ hide: 1 }, b);
+    for (let i = 0; i < 5; i++) reloaded.tick();
+    expect(earned()).toBe(true);
   });
 });
 
@@ -183,5 +305,40 @@ describe('harvestCorpse omitted-components town-focus default', () => {
     const explicitFang = harvestWith({ hide: POINTS_PER_TIER_BONUS }, ['fang']);
     expect(explicitFang.fang).toBeGreaterThanOrEqual(1);
     expect(explicitFang.hide).toBe(0);
+  });
+});
+
+// The #2511 fix sits at the SIM boundary, not in server/game.ts, and this is
+// the pin that says so on purpose: the offline browser Sim and the headless RL
+// env reach setTownFocus through IWorld without ever passing the server's
+// dispatch switch, so validating keys there would have left both hosts open.
+// If a future change starts filtering on the server too, this test is the one
+// to re-argue rather than quietly delete.
+describe('the server forwards a set_town_focus allocation verbatim (#2511)', () => {
+  it('passes the unknown key straight through to the sim, which is what refuses it', () => {
+    const server = new GameServer();
+    const session = server.join(
+      { readyState: 1, send: () => {} } as never,
+      97,
+      97,
+      'Alpha',
+      'warrior',
+      null,
+    );
+    if ('error' in session) throw new Error(session.error);
+    session.blockListLoaded = true;
+    const raw = JSON.stringify({
+      t: 'cmd',
+      cmd: 'set_town_focus',
+      allocation: { hide: 4, not_a_real_tag: 5 },
+    });
+    const spy = vi.spyOn(server.sim, 'setTownFocus').mockImplementation(() => {});
+    (server as unknown as { dispatchMessage: (...a: unknown[]) => void }).dispatchMessage(
+      session,
+      JSON.parse(raw),
+      raw,
+      0,
+    );
+    expect(spy).toHaveBeenCalledWith({ hide: 4, not_a_real_tag: 5 }, session.pid);
   });
 });


### PR DESCRIPTION
## Summary

`set_town_focus` validated the allocation's point values and refused an empty-string key, but
never checked that a key named a real component family. Every surviving key was copied into
`PlayerMeta.townFocus`, saved with the character, and reloaded, so a hand-crafted frame could park
arbitrary strings in a save and keep them there across sessions.

The issue left four calls open. All four are decided here, and pinned:

| Question | Decision | Why |
|---|---|---|
| Reject vs drop the unknown keys | **Reject the whole request** (`invalid_allocation`) | It widens the empty-string key refusal that already sat on that exact line, so it is the same shape and the same reason code rather than a new partial-accept mode. Unlike the #2504 harvest pick, nothing is consumed: retrying is free, and a partial accept would leave the panel showing a point the server threw away. |
| The all-invalid case | Also rejected | One rule, no boundary exception. |
| Which allowlist | The item-mapped families (`Object.keys(HARVEST_COMPONENT_ITEMS)`), not the wider tag vocabulary | This is the #2509 interaction the issue flagged. Allowing `claw`/`tusk`/`gills`/`horn` would let a persisted `{ gills: 1 }` make the omitted-components harvest default derive an all-unmapped pick, so every plain interact press on a murloc would take the #2509 all-forfeit refusal. |
| Existing saves | **Clean on load** | Not tidy-up: the panel seeds its draft from the stored allocation and carries it forward on every step, so without the drop a junked save rides back into every Save and the character is locked out of its own allocation for good, with no control that could clear it. Follows the `normalizeTierMailOnLoad` / `clampCadenceOnLoad` precedent one line up in the same load arm. |

Two implementation details that are load-bearing rather than stylistic:

- The allowlist is a `Set`, not a truthy lookup on the item map. `constructor`, `toString`,
  `hasOwnProperty` and `valueOf` all read back truthy off `Object.prototype` and reach the sim as
  real own keys, so a lookup form would have accepted all four. (`__proto__` does not: the
  server's copy loop assigns through the prototype setter, which ignores a number.)
- The fix is at the **sim boundary**, not `server/game.ts`, because the offline browser Sim reaches
  `setTownFocus` through `IWorld` without passing the server dispatch. A test pins that the server
  still forwards the key verbatim. (The headless RL env is not a second reason: it exposes no
  town-focus action at all.)

The list of families now has one definition, in the sim, which `src/ui/town_focus_view.ts`
re-exports, so a row the panel offers can never be a key the command boundary refuses.
`stepTownFocus` also projects its output onto the rendered rows instead of spreading its input, so
the view core cannot emit a key it does not draw.

### Deliberately not changed

- **The value channel.** `server/game.ts` pre-filters entries on `typeof v === 'number'`, so
  `{"hide":"3"}` reaches the sim as `{}` and silently clears the player's focus. Pre-existing,
  self-affecting, unreachable from the shipped client, and closing it means moving a decision into
  the server dispatch, which is the opposite of where this fix argues validation belongs. Scoped
  out in the source comment and pinned by a test so it is documented rather than implicit.
- **A server-side entry-count cap.** Nothing persists now and the WS frame cap bounds the request.

### Stated consequences

- For a character whose save carries a real-but-unmapped corpse tag, dropping it changes the
  derived harvest pick from that tag to the empty pick, so a plain interact press that used to hit
  the #2509 refusal and draw nothing now spreads and draws. That is the corpse paying out instead
  of refusing; it is deterministic and identical on all three hosts, and no parity scenario
  allocates a town focus.
- An already-earned `soc_civic_duty` is not revoked. Deeds are cosmetic-only and un-granting is
  worse.
- Ops note: `tests/fixtures/v025_warrior_character.json` really carries `"townFocus": {"eastbrook": 4}`,
  which suggests the shape occurred in a real save (a zone name, so likely an old client bug rather
  than an exploit). A read-only count of `characters.state->'townFocus'` keys outside the six
  families would say whether the load arm is a formality or about to rewrite real rows.

## Related issues

Closes #2511. Sibling of #2504 (PR #2508) and #2509 (PR #2515) in the unvalidated-client-component-tag
class. Based off `release/v0.31.0`, so the keyword will not auto-close it; closing by hand on merge.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npm run gate` (release tier, on a `release/**` base): green.
  - `npx tsc --noEmit`: clean. `npm run ci:changed`: clean.
  - Mutation matrix, **10 of 10 caught**: command check removed 10 red, load normalize removed 4,
    `Set` swapped for a truthy map lookup 2, allowlist widened to the unmapped tags 4, key check
    moved after the budget test 1, normalize keeping non-positive/non-integer values 2, normalize
    aliasing the save 9, the panel re-deriving the list *faithfully* 1, `stepTownFocus` spreading
    again 1, normalize returning a shared empty object 1.
- Manual steps: none. The defect is only reachable from a hand-crafted wire frame, and the shipped
  panel cannot produce an unknown key either before or after this change, so there is nothing a
  player-visible walkthrough would show.

Back-compat is pinned against the real shipped v0.25 production-shaped fixture rather than a
synthetic one: the load arm drops its `eastbrook` key while `migrateCharacterTalentsV2` still
preserves it verbatim, and the fixture's sha256 pin is untouched.

Reviewed by seven read-only agents (qa-checklist, privacy-security-review, migration-safety,
cross-platform-sync, architecture-reviewer, frontend-seam-reviewer, test-coverage-auditor): zero
blocking findings, and every should-fix and nit applied in the second commit.

## Screenshots / recordings

N/A. No visual change: the panel renders the same rows, and the rejection reuses an existing toast.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green, with decisive tests for the changed
      behavior and a mutation matrix recorded above.

### Cross-platform

- ~[ ] Tested on desktop and mobile.~ N/A, no visual or layout change.
- ~[ ] Accessible.~ N/A, no UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The unknown-key rejection reuses the existing
      `error.townFocusInvalid` toast, which already has every locale fill, so there is no catalog
      churn and no `pending` row.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any
      production path.
- [x] No generated file hand-edited.
