### PR TITLE
fix(render): mesh the terrain cells no zone rectangle owns

### DIFF
--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -18,7 +18,13 @@ import { registerPreload } from './assets/preload';
 import { GFX } from './gfx';
 import { idleSlot } from './idle_queue';
 import { impactCraterTerrainBlend } from './impact_terrain';
-import { chunkIntersectsRegion, normalTexelBounds } from './terrain_region_core';
+import {
+  chunkIntersectsRegion,
+  normalTexelBounds,
+  owningRectIndex,
+  type TexelBounds,
+  type WorldRect,
+} from './terrain_region_core';
 import { groundDetailTexture, groundSplatMaps, macroNoiseTexture } from './textures';
 
 // Chunked terrain across the whole 360x1080 zone strip.
@@ -1253,12 +1259,38 @@ export function buildTerrain(seed: number, priorityPoint?: { x: number; z: numbe
     return false;
   };
 
+  // The zone rectangles do NOT tile the world box. Three kinds of cell fall
+  // outside every one of them: the whole quadrant west of Eastbrook Vale (no
+  // realm sits at x < -180 for z -180..180), the centre column north of
+  // Frostveil, and the grid's last row, which overhangs WORLD_MAX_Z and so
+  // carries the northern 20yd of the Drakelands rim. Those cells still hold
+  // ground a player reaches on foot: the tongue of land running south out of
+  // the Willowfen border around (-195, 161) sits 1.6yd ABOVE the waterline.
+  // Leaving them unowned meant no zone's build ever meshed them, so that
+  // ground rendered as a hole you could see (and fall) through.
+  const zoneRects: WorldRect[] = ZONES.map((zone) => ({
+    minX: zone.xMin ?? STRIP_MIN_X,
+    maxX: zone.xMax ?? STRIP_MAX_X,
+    minZ: zone.zMin,
+    maxZ: zone.zMax,
+  }));
+  const insideAnyZone = (x: number, z: number): boolean =>
+    zoneRects.some((r) => x >= r.minX && x < r.maxX && z >= r.minZ && z < r.maxZ);
+
   const bandIndexAt = (cx: number, cz: number): number => {
     const x0 = -WORLD_MAX_X + cx * CHUNK_SIZE;
     const z0 = WORLD_MIN_Z + cz * CHUNK_SIZE;
-    if (wallChunkAt(x0, z0, CHUNK_SIZE)) return 0;
     const centerX = x0 + CHUNK_SIZE / 2;
     const centerZ = z0 + CHUNK_SIZE / 2;
+    // Cells outside every realm (see zoneRects) are open sea floor and the
+    // outer face of the rim: no quest, camp, or road ever lands there, and the
+    // sim drowns a player who swims out. They take the coarsest band whatever
+    // wallChunkAt says, so the gap fill costs a handful of merged super-chunks
+    // instead of a dense grid over water nobody stands on. Checked BEFORE the
+    // wall promotion, which would otherwise hand the empty south-west quadrant
+    // the 1.2u spacing meant for the terraced inter-zone walls.
+    if (!insideAnyZone(centerX, centerZ)) return bands.length - 1;
+    if (wallChunkAt(x0, z0, CHUNK_SIZE)) return 0;
     let hubDist = Infinity;
     for (const zn of ZONES) {
       hubDist = Math.min(hubDist, Math.hypot(centerX - zn.hub.x, centerZ - zn.hub.z));
@@ -1345,22 +1377,13 @@ export function buildTerrain(seed: number, priorityPoint?: { x: number; z: numbe
   // renderer rebuildTerrain) stops adding chunks instead of building on a
   // setTimeout chain for the rest of the session.
   let cancelled = false;
-  const cellOwnerId = (cx: number, cz: number): string | null => {
+  // Every cell of the grid gets exactly one owner: the zone containing it,
+  // else (the gap cells described at zoneRects) the nearest zone rectangle.
+  // See owningRectIndex for why nearest-rect and not zoneAt's z-band clamp.
+  const cellOwnerId = (cx: number, cz: number): string => {
     const x = -WORLD_MAX_X + (cx + 0.5) * CHUNK_SIZE;
     const z = WORLD_MIN_Z + (cz + 0.5) * CHUNK_SIZE;
-    // zoneAt deliberately clamps gaps/out-of-bounds positions to the nearest
-    // playable zone. Terrain ownership must not: otherwise asking for one
-    // column can accidentally materialize chunks in an empty neighbouring
-    // column merely because that zone is the fallback for the same z band.
-    return (
-      ZONES.find(
-        (candidate) =>
-          z >= candidate.zMin &&
-          z < candidate.zMax &&
-          x >= (candidate.xMin ?? STRIP_MIN_X) &&
-          x < (candidate.xMax ?? STRIP_MAX_X),
-      )?.id ?? null
-    );
+    return ZONES[owningRectIndex(x, z, zoneRects)].id;
   };
   const zoneCells = (zone: ZoneDef): [number, number][] => {
     const out: [number, number][] = [];
@@ -1376,12 +1399,12 @@ export function buildTerrain(seed: number, priorityPoint?: { x: number; z: numbe
   // timeout still forces progress under sustained load, so a later gating
   // caller awaiting the same shared task is never starved indefinitely.
   const yieldIdle = (): Promise<void> => idleSlot(IDLE_BUILD_TIMEOUT_MS);
-  const normalBoundsFor = (zone: ZoneDef) =>
+  const normalTexelsOver = (minX: number, minZ: number, maxX: number, maxZ: number) =>
     normalTexelBounds(
-      zone.xMin ?? STRIP_MIN_X,
-      zone.zMin,
-      zone.xMax ?? STRIP_MAX_X,
-      zone.zMax,
+      minX,
+      minZ,
+      maxX,
+      maxZ,
       -WORLD_MAX_X,
       WORLD_MIN_Z,
       WORLD_MAX_X * 2,
@@ -1390,6 +1413,29 @@ export function buildTerrain(seed: number, priorityPoint?: { x: number; z: numbe
       NORMAL_TEX_H,
       1,
     );
+  // The macro normal texels this zone's build must bake: its own rectangle,
+  // plus one region per owned cell lying outside it (the gap cells above).
+  // An unbaked texel stays flat, so without the extra regions the macro relief
+  // would stop dead at the realm border. Region-per-cell rather than one
+  // bounding box over rect + cells: the gap west of Eastbrook Vale is as wide
+  // as the realm itself, and a bbox would re-bake that whole empty quadrant.
+  const normalRegionsFor = (zone: ZoneDef, cells: readonly [number, number][]): TexelBounds[] => {
+    const minX = zone.xMin ?? STRIP_MIN_X;
+    const maxX = zone.xMax ?? STRIP_MAX_X;
+    const regions: TexelBounds[] = [];
+    const zoneBounds = normalTexelsOver(minX, zone.zMin, maxX, zone.zMax);
+    if (zoneBounds) regions.push(zoneBounds);
+    for (const [cx, cz] of cells) {
+      const x0 = -WORLD_MAX_X + cx * CHUNK_SIZE;
+      const z0 = WORLD_MIN_Z + cz * CHUNK_SIZE;
+      const inside =
+        x0 >= minX && x0 + CHUNK_SIZE <= maxX && z0 >= zone.zMin && z0 + CHUNK_SIZE <= zone.zMax;
+      if (inside) continue; // already covered by zoneBounds
+      const cellBounds = normalTexelsOver(x0, z0, x0 + CHUNK_SIZE, z0 + CHUNK_SIZE);
+      if (cellBounds) regions.push(cellBounds);
+    }
+    return regions;
+  };
   const ensureZone = (
     zone: ZoneDef,
     onProgress?: (done: number, total: number) => void,
@@ -1433,26 +1479,29 @@ export function buildTerrain(seed: number, priorityPoint?: { x: number; z: numbe
           cells.push(...nearby, ...rest);
         }
       }
-      const normalBounds = normalTex ? normalBoundsFor(zone) : null;
+      const normalRegions = normalTex ? normalRegionsFor(zone, cells) : [];
       const rowsPerSlice = 12;
-      const normalSlices = normalBounds
-        ? Math.ceil((normalBounds.j1 - normalBounds.j0 + 1) / rowsPerSlice)
-        : 0;
+      const normalSlices = normalRegions.reduce(
+        (slices, region) => slices + Math.ceil((region.j1 - region.j0 + 1) / rowsPerSlice),
+        0,
+      );
       const total = Math.max(1, normalSlices + cells.length);
       let done = 0;
-      if (normalTex && normalBounds) {
-        for (let j = normalBounds.j0; j <= normalBounds.j1; j += rowsPerSlice) {
-          if (cancelled) return;
-          bakeNormalRegion(
-            normalTex.image.data as Uint8Array,
-            seed,
-            normalBounds.i0,
-            normalBounds.i1,
-            j,
-            Math.min(normalBounds.j1, j + rowsPerSlice - 1),
-          );
-          onProgress?.(++done, total);
-          await yieldSlice();
+      if (normalTex && normalRegions.length > 0) {
+        for (const region of normalRegions) {
+          for (let j = region.j0; j <= region.j1; j += rowsPerSlice) {
+            if (cancelled) return;
+            bakeNormalRegion(
+              normalTex.image.data as Uint8Array,
+              seed,
+              region.i0,
+              region.i1,
+              j,
+              Math.min(region.j1, j + rowsPerSlice - 1),
+            );
+            onProgress?.(++done, total);
+            await yieldSlice();
+          }
         }
         normalTex.needsUpdate = true;
       }

--- a/src/render/terrain_region_core.ts
+++ b/src/render/terrain_region_core.ts
@@ -1,10 +1,53 @@
-// PURE (unit-tested, Three-free): region selection math for the map editor's
-// partial terrain rebuilds. terrain.ts stores each chunk's build inputs
-// (x0, z0, size, spacing) and uses these helpers to decide which chunk
-// geometries a sculpt region invalidates and which texel rows of the baked
-// macro normal DataTexture go stale. Registered in RENDER_PURE_CORES
+// PURE (unit-tested, Three-free): region selection math for terrain chunk
+// ownership and the map editor's partial terrain rebuilds. terrain.ts stores
+// each chunk's build inputs (x0, z0, size, spacing) and uses these helpers to
+// decide which zone builds a given chunk cell, which chunk geometries a sculpt
+// region invalidates, and which texel rows of the baked macro normal
+// DataTexture go stale. Registered in RENDER_PURE_CORES
 // (tests/architecture.test.ts): no three/game/net/i18n imports, no DOM, no
 // nondeterminism.
+
+/** An axis-aligned world-space footprint (a zone rectangle, a chunk cell). */
+export interface WorldRect {
+  minX: number;
+  minZ: number;
+  maxX: number;
+  maxZ: number;
+}
+
+/** Axis-aligned XZ distance from a point to a rect. 0 when the point is inside. */
+export function rectDistance(x: number, z: number, rect: WorldRect): number {
+  const dx = Math.max(rect.minX - x, 0, x - rect.maxX);
+  const dz = Math.max(rect.minZ - z, 0, z - rect.maxZ);
+  return Math.hypot(dx, dz);
+}
+
+// Which rect owns the point (x, z)? The CONTAINING rect wins, half-open on the
+// max edges so two abutting rects never both claim a shared border. When no
+// rect contains it (the zone rectangles do not tile the world box: nothing
+// sits west of Eastbrook Vale, nothing north of Frostveil in the centre
+// column, and the chunk grid overhangs WORLD_MAX_Z by a row) ownership falls
+// back to the geometrically NEAREST rect, ties resolved to the lowest index.
+//
+// Nearest-rect, not a z-band clamp like zoneAt's: a z-band fallback would hand
+// a whole empty column to whichever zone merely shares its latitude, while the
+// nearest rect is always one the gap actually abuts. Exactly one rect wins
+// either way, so a caller enumerating cells per rect covers the whole grid and
+// never builds a cell twice. Returns -1 only for an empty rect list.
+export function owningRectIndex(x: number, z: number, rects: readonly WorldRect[]): number {
+  let nearest = -1;
+  let nearestDistance = Number.POSITIVE_INFINITY;
+  for (let i = 0; i < rects.length; i++) {
+    const rect = rects[i];
+    if (x >= rect.minX && x < rect.maxX && z >= rect.minZ && z < rect.maxZ) return i;
+    const distance = rectDistance(x, z, rect);
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearest = i;
+    }
+  }
+  return nearest;
+}
 
 // Does the chunk footprint [x0, x0+size] x [z0, z0+size] intersect the edit
 // region? INCLUSIVE on borders: a chunk whose edge merely touches the region

--- a/tests/terrain_region_core.test.ts
+++ b/tests/terrain_region_core.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { chunkIntersectsRegion, normalTexelBounds } from '../src/render/terrain_region_core';
+import {
+  chunkIntersectsRegion,
+  normalTexelBounds,
+  owningRectIndex,
+  rectDistance,
+  type WorldRect,
+} from '../src/render/terrain_region_core';
 import {
   advanceWaterSchedule,
   shoreDepthAt,
@@ -128,6 +134,68 @@ describe('normalTexelBounds (macro normal partial rebake)', () => {
     const b = normalTexelBounds(-10, 5, 5, 8, 0, 0, W, D, TEX_W, TEX_H, 1);
     expect(b).not.toBeNull();
     expect(b?.i0).toBe(0);
+  });
+});
+
+describe('owningRectIndex (terrain chunk cell -> building zone)', () => {
+  // Three rects laid out like the real world's south end: a centre strip, an
+  // east wing beside it, and a west wing one band NORTH of them, leaving the
+  // south-west corner covered by nobody.
+  const STRIP: WorldRect = { minX: -180, maxX: 180, minZ: -180, maxZ: 180 };
+  const EAST: WorldRect = { minX: 180, maxX: 540, minZ: -180, maxZ: 180 };
+  const WEST_NORTH: WorldRect = { minX: -540, maxX: -180, minZ: 180, maxZ: 700 };
+  const RECTS = [STRIP, EAST, WEST_NORTH];
+
+  it('returns the containing rect', () => {
+    expect(owningRectIndex(0, 0, RECTS)).toBe(0);
+    expect(owningRectIndex(300, -100, RECTS)).toBe(1);
+    expect(owningRectIndex(-300, 400, RECTS)).toBe(2);
+  });
+
+  it('resolves a shared border to exactly one rect (half-open on max)', () => {
+    // x = 180 is STRIP's max edge and EAST's min edge: EAST takes it, and no
+    // point is ever claimed twice.
+    expect(owningRectIndex(180, 0, RECTS)).toBe(1);
+    expect(owningRectIndex(179.999, 0, RECTS)).toBe(0);
+  });
+
+  it('gives an uncovered cell to the nearest rect, not to a z-band neighbour', () => {
+    // The real bug: (-210, 150) is the chunk cell holding the dry ground south
+    // of the Willowfen border, inside no rect at all. It must still be built.
+    // Nearest here is a tie (30 west of STRIP, 30 south of WEST_NORTH), broken
+    // to the lower index.
+    expect(owningRectIndex(-210, 150, RECTS)).toBe(0);
+    // Deep in the gap the west wing is unambiguously nearer than the strip,
+    // so a z-band clamp (which would say "strip, same latitude") is wrong.
+    expect(owningRectIndex(-510, 150, RECTS)).toBe(2);
+    // ...and low in the gap the strip is nearer than the west wing.
+    expect(owningRectIndex(-210, -150, RECTS)).toBe(0);
+  });
+
+  it('gives a cell past a rect edge back to that rect', () => {
+    // The chunk grid overhangs the world box by up to one row; the overhanging
+    // cell centres sit just outside the northmost rect and must build with it.
+    expect(owningRectIndex(-300, 720, RECTS)).toBe(2);
+  });
+
+  it('reports -1 for an empty rect list', () => {
+    expect(owningRectIndex(0, 0, [])).toBe(-1);
+  });
+});
+
+describe('rectDistance', () => {
+  const R: WorldRect = { minX: -10, maxX: 10, minZ: -10, maxZ: 10 };
+
+  it('is zero inside and on the border', () => {
+    expect(rectDistance(0, 0, R)).toBe(0);
+    expect(rectDistance(10, 10, R)).toBe(0);
+    expect(rectDistance(-10, 4, R)).toBe(0);
+  });
+
+  it('measures the axis gap outside, and the corner diagonal past a corner', () => {
+    expect(rectDistance(13, 0, R)).toBeCloseTo(3, 10);
+    expect(rectDistance(0, -14, R)).toBeCloseTo(4, 10);
+    expect(rectDistance(13, 14, R)).toBeCloseTo(5, 10); // 3-4-5
   });
 });
 

--- a/tests/terrain_streaming.test.ts
+++ b/tests/terrain_streaming.test.ts
@@ -180,3 +180,108 @@ describe('progressive terrain build', () => {
     expect(earlyClosest).toBeCloseTo(overallClosest, 5);
   });
 });
+
+// The world seed src/main.ts fixes; the gap geometry below is stated in its
+// terms, so the height pin and the build share one world.
+const WORLD_SEED = 20061;
+
+// The zone rectangles do not tile the world box (nothing sits west of
+// Eastbrook Vale for z -180..180, nothing north of Frostveil in the centre
+// column, and the chunk grid overhangs WORLD_MAX_Z by a row). Cells in those
+// gaps used to belong to no zone, so no zone's build ever meshed them: the
+// ground there rendered as a hole you saw and fell through. Standing at
+// (-195, 161) the terrain is 1.6yd ABOVE the waterline, i.e. walkable ground a
+// player reaches on foot from the Willowfen border.
+describe('terrain covers the whole world, gaps between zone rectangles included', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // A point is covered when some built chunk's XZ footprint contains it.
+  const coversPoint = (group: THREE.Object3D, x: number, z: number): boolean =>
+    group.children.some((mesh) => {
+      const box = new THREE.Box3().setFromObject(mesh);
+      return x >= box.min.x && x <= box.max.x && z >= box.min.z && z <= box.max.z;
+    });
+
+  it('meshes the walkable ground at (-195, 161), in the gap west of Eastbrook Vale', async () => {
+    vi.resetModules();
+    mockEmptyAssetLoads();
+    const { buildTerrain } = await import('../src/render/terrain');
+    const { ZONES } = await import('../src/sim/data');
+    const { terrainHeight, WATER_LEVEL } = await import('../src/sim/world');
+
+    // Pin the premise on the shipped world seed: this really is dry land, not
+    // seabed under the water plane, so a missing chunk here is ground the
+    // player walks onto and falls through.
+    expect(terrainHeight(-195, 161, WORLD_SEED)).toBeGreaterThan(WATER_LEVEL);
+
+    const terrain = buildTerrain(WORLD_SEED);
+    // The two realms the gap abuts, which is what the renderer's streaming
+    // horizon prepares from either side of the border.
+    for (const id of ['eastbrook_vale', 'willowfen']) {
+      const zone = ZONES.find((candidate) => candidate.id === id);
+      if (!zone) throw new Error(`missing zone ${id}`);
+      const task = terrain.ensureZone(zone);
+      await vi.runAllTimersAsync();
+      await task;
+    }
+
+    expect(coversPoint(terrain.group, -195, 161)).toBe(true);
+    terrain.cancelStreaming();
+  });
+
+  it('leaves no uncovered cell anywhere once every zone is built', async () => {
+    vi.resetModules();
+    mockEmptyAssetLoads();
+    const { buildTerrain } = await import('../src/render/terrain');
+    const { ZONES, WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_Z } = await import('../src/sim/data');
+
+    const terrain = buildTerrain(WORLD_SEED);
+    for (const zone of ZONES) {
+      const task = terrain.ensureZone(zone);
+      await vi.runAllTimersAsync();
+      await task;
+    }
+
+    // Sample every 60u chunk cell's centre across the whole world box. Before
+    // the gap-cell fix this found 96 uncovered cells (the south-west quadrant,
+    // the centre column north of Frostveil, and the overhanging north row).
+    const CHUNK = 60;
+    const uncovered: [number, number][] = [];
+    for (let z = WORLD_MIN_Z + CHUNK / 2; z < WORLD_MAX_Z; z += CHUNK) {
+      for (let x = -WORLD_MAX_X + CHUNK / 2; x < WORLD_MAX_X; x += CHUNK) {
+        if (!coversPoint(terrain.group, x, z)) uncovered.push([x, z]);
+      }
+    }
+    expect(uncovered).toEqual([]);
+    terrain.cancelStreaming();
+  });
+
+  it('builds every cell exactly once across all zones', async () => {
+    vi.resetModules();
+    mockEmptyAssetLoads();
+    const { buildTerrain } = await import('../src/render/terrain');
+    const { ZONES } = await import('../src/sim/data');
+
+    // Nearest-rect ownership must stay single-owner: a cell claimed by two
+    // zones would mesh twice and z-fight, which is the failure mode a plain
+    // "nearest zone" fallback in each zone's own loop would have.
+    const terrain = buildTerrain(WORLD_SEED);
+    for (const zone of ZONES) {
+      const task = terrain.ensureZone(zone);
+      await vi.runAllTimersAsync();
+      await task;
+    }
+
+    const footprints = terrain.group.children.map((mesh) => {
+      const box = new THREE.Box3().setFromObject(mesh);
+      return `${box.min.x.toFixed(2)},${box.min.z.toFixed(2)},${box.max.x.toFixed(2)},${box.max.z.toFixed(2)}`;
+    });
+    expect(new Set(footprints).size).toBe(footprints.length);
+    terrain.cancelStreaming();
+  });
+});


### PR DESCRIPTION
Targets `feature/procedural-dungeons` (the #1584 branch), where this was reported: at Eastbrook Vale (-195, 161) there is no ground and you can see through the map.

## The bug

Not a texture problem. There is no terrain mesh there at all, so you see the water plane and the fog through the hole, and drop through the floor.

`buildTerrain` enumerates chunk cells per zone, and `cellOwnerId` returned `null` for any 60u cell whose centre fell inside no zone rectangle. The zone rectangles do not tile the world box, so 96 of the 792 cells were owned by nobody and no zone's build ever meshed them:

| Gap | Cells | Why |
|---|---|---|
| Quadrant west of Eastbrook Vale, x -540..-180 by z -180..180 | 36 | Farshore Isle covers the +x side at that latitude, nothing covers -x |
| Centre column north of Frostveil, z 1960..2400 | 42 | Amberfall and Drakelands flank it, nothing fills it |
| The grid's last row, z 2400..2420 | 18 | The cell grid overhangs `WORLD_MAX_Z`, so the northern 20yd of the Drakelands rim was unowned |

These are not all open sea. `terrainHeight(-195, 161, 20061)` is **+1.6**, dry ground 6yd above the waterline, reached on foot by walking south out of the Willowfen border: z 180 to 145 descends smoothly with no wall and no deep water in between. That is exactly where the report came from.

## The fix

`cellOwnerId` falls back to the geometrically nearest zone rectangle (`owningRectIndex`, added to the `terrain_region_core` pure core) instead of returning `null`.

Deliberately nearest-rect and NOT `zoneAt`'s z-band clamp, which was the original reason the function returned `null`: a z-band fallback would hand a whole empty column to whichever realm merely shares its latitude. The nearest rectangle is always one the gap actually abuts, and exactly one zone wins either way, so no cell is ever meshed twice.

Two supporting changes:

- `bandIndexAt` gives out-of-realm cells the coarsest LOD band BEFORE the `wallChunkAt` promotion, so they merge into 2x2 super-chunks instead of taking the 1.2u spacing meant for the terraced inter-zone walls. That lands the boot zone at +12 meshes / +16% verts (Eastbrook Vale 36 to 48 meshes, 16.2k to 18.8k verts) rather than +18 / +35%, and every added chunk is fog-cullable far field.
- The macro normal bake now covers each zone's gap cells too, one region per cell rather than one bounding box over rect plus cells (a bbox would rebake the whole empty quadrant). Unbaked texels stay flat, so without this the macro relief stopped dead at the realm border.

## Verification

Before/after captured in the same worktree, same spot, same seed 20061, same camera, HUD hidden, with only the two source files swapped between arms. BEFORE: grass tufts and a fern hang in mid-air over open water (foliage is placed world-wide from `terrainHeight`, so it renders where no chunk exists, which is why they float). AFTER: continuous textured ground, tufts sit on it, seamless into the Willowfen bank.

Also checked the strip edge at x = -178 (no seam) and deeper into the gap at (-260, 100), where the seabed now renders under open water and the sim's existing "the open sea saps your strength" guard behaves as designed.

## Test plan

- [x] `tests/terrain_streaming.test.ts`: the point at (-195, 161) is covered by a chunk; a whole-world cell sweep reports zero uncovered centres (78 before the fix); every cell is built exactly once (no duplicate footprints, so no z-fighting from double ownership)
- [x] `tests/terrain_region_core.test.ts`: unit cover for `owningRectIndex` and `rectDistance`, including the half-open border rule, the nearest-rect tie break, and the past-the-edge overhang case
- [x] Both new end-to-end tests confirmed RED on the base commit and GREEN with the fix
- [x] `tsc --noEmit` clean, biome clean on all four changed files
- [x] `tests/architecture.test.ts` plus the eight other terrain suites green (`terrain_window_seams`, `terrain_edit_index`, `map_terrain`, `terrain_rim_earlyout`, `terrain_wall_standoff`, `terrain_escape`)
- [ ] Not run here: full `npm run gate`

## Note on a pre-existing failure

`tests/world_edge_coast.test.ts` ("no sheer face rises straight out of the shore on the named margins") fails on this branch. It is NOT from this change: I reverted just the two source files to the base commit in a clean worktree and it fails identically there. Flagging it for whoever owns the Palmreach coast work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)