### PR TITLE
fix(sim): raise airborne pass-over lift to match grounded stride height

### DIFF
--- a/src/sim/colliders.ts
+++ b/src/sim/colliders.ts
@@ -203,8 +203,22 @@ export function colliderTopAt(c: Collider, x: number, z: number): number {
  * passable while airborne: the mantle assist. A jump whose apex falls short of
  * a crate rim by up to this much still carries the body over, and the support
  * snap in the movement kernel then seats the feet on the top (the vault).
+ *
+ * It is pinned to the grounded stride band (`MAX_STEP_HEIGHT` in
+ * `physics/character.ts`; the equality is pinned by
+ * `tests/physics_character.test.ts`) rather than tuned on its own, for two
+ * reasons. An airborne body must never lose ground a grounded stride crosses
+ * for free, and this ONE number is read by BOTH halves of the tick: the
+ * horizontal gates (`passesOver` here, `blocksAt` in the solver) and the
+ * vertical support query (`floorHeightAt`'s `maxY` in `player_motion.ts`).
+ * They must move together, or the horizontal pass admits a top the landing
+ * snap then refuses to seat and the body tunnels into the prop. It also
+ * leaves the traversal ladder gapless: `LEDGE_GRAB_MIN` is the same 0.9, so
+ * every standable top is either vaulted or grabbed, never a mid-air wall.
+ * The literal lives here (not imported) because `physics/` imports this
+ * module, never the reverse.
  */
-export const MANTLE_REACH = 0.7;
+export const MANTLE_REACH = 0.9;
 /** Float slack when comparing feet height against a collider top. */
 const MOVE_TOP_EPS = 1e-3;
 // How much of the body radius must overlap a standable top before it supports

--- a/src/sim/physics/CLAUDE.md
+++ b/src/sim/physics/CLAUDE.md
@@ -54,6 +54,16 @@ general 3D solver and exact rather than approximate for this content.
   `MANTLE_REACH` lift only when airborne over a standable top, mirroring
   `colliders.ts` `passesOver`, so a jump that falls just short of a rim still
   carries over. Grounded climbing goes through `steppableAt` alone.
+- **One allowance, read by both halves of the tick.** `MANTLE_REACH`
+  (`colliders.ts`) is the SINGLE number the horizontal gates (`blocksAt` here,
+  `passesOver` there) and the vertical support query (`floorHeightAt`'s `maxY`
+  in `player_motion.ts`) both read, and it is pinned equal to
+  `MAX_STEP_HEIGHT`. Never raise one arm alone: a top the horizontal pass
+  admits but the landing snap will not seat is a top the body tunnels into,
+  landing on the terrain INSIDE the prop and getting ejected sideways by
+  depenetration on the next grounded tick. The equality with `MAX_STEP_HEIGHT`
+  (and so with `LEDGE_GRAB_MIN`) is what keeps the ladder in `ledge.ts`
+  gapless, and is pinned by `tests/physics_character.test.ts`.
 - **Every step-up is headroom-gated** (`isClear`): climbing must never push a
   body into a wall.
 - **The solver runs the open world; interiors share its traversal queries.**

--- a/src/sim/physics/character.ts
+++ b/src/sim/physics/character.ts
@@ -205,7 +205,12 @@ function blocksAt(
 ): boolean {
   if (params.ignoreFences && c.type === 'obb' && c.isFence) return false;
   if (c.moveTopY === undefined) return true; // full height: buildings, trees, walls
-  const lift = !params.grounded && c.standable === true ? MANTLE_REACH : 0;
+  // The airborne pass-over lift must never regress below what a grounded stride
+  // already permits (params.stepHeight), or an obstacle whose top sits between
+  // MANTLE_REACH and the stride band would newly wall the body off mid-air even
+  // though the identical geometry is a non-event when walked into on the ground.
+  const lift =
+    !params.grounded && c.standable === true ? Math.max(MANTLE_REACH, params.stepHeight) : 0;
   return colliderTopAt(c, x, z) > feetY + lift + TOP_EPS;
 }
 

--- a/src/sim/physics/character.ts
+++ b/src/sim/physics/character.ts
@@ -189,7 +189,11 @@ function supportFromCandidates(x: number, z: number, r: number, maxY: number): n
  * `MANTLE_REACH` allowance `colliders.ts` grants the legacy sweep): a jump
  * that falls just short of a crate rim still carries over it, and the vertical
  * pass then seats the body on top. Grounded bodies get no lift; they climb
- * only through step-up, which has its own, stricter gate.
+ * only through step-up, which has its own, stricter gate. `MANTLE_REACH` is
+ * pinned to the same height as the grounded stride band (`MAX_STEP_HEIGHT`),
+ * so leaving the ground never costs a body a top it could have strided over,
+ * and the ONE constant keeps this gate and the vertical support query
+ * (`floorHeightAt` in `player_motion.ts`) admitting exactly the same tops.
  *
  * Sloped tops are sampled at the body's own position: a body standing on a
  * canopy's fabric is ON the surface there, and must not be treated as inside
@@ -205,12 +209,7 @@ function blocksAt(
 ): boolean {
   if (params.ignoreFences && c.type === 'obb' && c.isFence) return false;
   if (c.moveTopY === undefined) return true; // full height: buildings, trees, walls
-  // The airborne pass-over lift must never regress below what a grounded stride
-  // already permits (params.stepHeight), or an obstacle whose top sits between
-  // MANTLE_REACH and the stride band would newly wall the body off mid-air even
-  // though the identical geometry is a non-event when walked into on the ground.
-  const lift =
-    !params.grounded && c.standable === true ? Math.max(MANTLE_REACH, params.stepHeight) : 0;
+  const lift = !params.grounded && c.standable === true ? MANTLE_REACH : 0;
   return colliderTopAt(c, x, z) > feetY + lift + TOP_EPS;
 }
 

--- a/src/sim/physics/ledge.ts
+++ b/src/sim/physics/ledge.ts
@@ -8,6 +8,10 @@
 //   up to LEDGE_GRAB_MAX       a jump GRABS it and climbs up           (climb)
 //   above that                 it is a wall
 //
+// The first three rungs meet with no gap on purpose: MANTLE_REACH equals
+// MAX_STEP_HEIGHT equals LEDGE_GRAB_MIN, so no standable top is ever a wall to
+// an airborne body that a grounded body would have strided straight over.
+//
 // Everything here is a pure query against the same extruded-2D collider set
 // and heightfield the solver uses, so a climb can only ever start onto a
 // surface the body could legitimately stand on: a standable prop top (crate,

--- a/tests/physics_character.test.ts
+++ b/tests/physics_character.test.ts
@@ -24,6 +24,7 @@ import {
   physicsStats,
   resetPhysicsStats,
 } from '../src/sim/physics';
+import { LEDGE_GRAB_MIN } from '../src/sim/physics/ledge';
 import { GRAVITY, JUMP_VELOCITY } from '../src/sim/player_motion';
 import { Sim } from '../src/sim/sim';
 import type { WorldContent } from '../src/sim/types';
@@ -123,40 +124,6 @@ function findStrideableStone(): { x: number; z: number; scale: number } | undefi
       const cz = c.z ?? 0;
       if (Math.hypot(cx - d.x, cz - d.z) <= 0.25) return false; // the stone itself
       if (cz < d.z - 3 || cz > d.z + 2) return false; // outside the walk
-      const reach = (c.type === 'circle' ? c.r : Math.hypot(c.hw, c.hd)) + 0.6;
-      return Math.abs(cx - d.x) < reach;
-    });
-    if (blocksCorridor) continue;
-    return { x: d.x, z: d.z, scale: d.scale };
-  }
-  return undefined;
-}
-
-// A collidable stone whose TRUE climb from the approach footing sits strictly
-// above MANTLE_REACH but still within MAX_STEP_HEIGHT: the band a grounded
-// stride freely crosses but that a naive airborne mantle allowance would wall
-// off, since MANTLE_REACH < MAX_STEP_HEIGHT.
-function findLadderBandStone(): { x: number; z: number; scale: number } | undefined {
-  for (const d of generateDecorations(SEED)) {
-    if (d.kind !== 'rock' || d.scale < ROCK_COLLIDER_MIN_SCALE) continue;
-    if (Math.abs(d.x) > 160) continue;
-    const top = groundHeight(d.x, d.z, SEED) + rockHeight(d.x, d.z, d.scale, SEED);
-    const climb = top - groundHeight(d.x, d.z - 1.2, SEED);
-    if (climb <= MANTLE_REACH || climb > MAX_STEP_HEIGHT) continue;
-    let clean = true;
-    for (let t = -2.6; t <= 1.6 && clean; t += 0.4) {
-      const z = d.z + t;
-      if (terrainSteepnessAt(d.x, z, SEED) > 0.4) clean = false;
-      if (terrainHeight(d.x, z, SEED) < WATER_LEVEL + 2) clean = false;
-    }
-    if (!clean) continue;
-    const near: ReturnType<typeof queryOpenWorldColliders> = [];
-    queryOpenWorldColliders(SEED, d.x - 5, d.z - 5, d.x + 5, d.z + 5, near);
-    const blocksCorridor = near.some((c) => {
-      const cx = c.x ?? 0;
-      const cz = c.z ?? 0;
-      if (Math.hypot(cx - d.x, cz - d.z) <= 0.25) return false;
-      if (cz < d.z - 3 || cz > d.z + 2) return false;
       const reach = (c.type === 'circle' ? c.r : Math.hypot(c.hw, c.hd)) + 0.6;
       return Math.abs(cx - d.x) < reach;
     });
@@ -351,20 +318,47 @@ describe('step up: walking over low obstacles', () => {
     expect(out.stepped).toBe(0);
   });
 
-  it('does not wall off an airborne body against a stride-band obstacle', () => {
-    // A body that leaves the ground must not lose ground it could freely
-    // stride over: an obstacle whose top sits within MAX_STEP_HEIGHT of the
-    // feet is never a wall for an airborne body either, even though the
-    // legacy MANTLE_REACH lift alone (0.7yd) is smaller than the stride
-    // band (0.9yd) and would otherwise block it as a new mid-air wall.
-    setActiveWorldContent(null);
-    const stone = findLadderBandStone();
-    expect(stone).toBeDefined();
-    if (!stone) return;
-    const g = groundHeight(stone.x, stone.z - 2, SEED);
-    moveCharacter(params({ grounded: false }), stone.x, g, stone.z - 2, 0, 4, out);
-    expect(out.blocked).toBe(false);
-    expect(out.z).toBeGreaterThan(stone.z - 2);
+  it('pins the airborne allowance to the grounded stride band', () => {
+    // One number, three consumers: the horizontal gates (blocksAt here,
+    // passesOver in colliders.ts) and the vertical support query in
+    // player_motion.ts all read MANTLE_REACH. Holding it equal to the stride
+    // band means leaving the ground never costs a body a top it could have
+    // strided over, and holding it equal to LEDGE_GRAB_MIN leaves no band
+    // between "vault over it" and "grab it" for a top to be a wall in.
+    expect(MANTLE_REACH).toBe(MAX_STEP_HEIGHT);
+    expect(LEDGE_GRAB_MIN).toBe(MAX_STEP_HEIGHT);
+  });
+
+  it('admits exactly the airborne tops the landing pass can seat', () => {
+    // The pass-over gate and the landing snap must agree on every top. A top
+    // the horizontal solver waves through but floorHeightAt refuses is a top
+    // the body tunnels INTO: it lands on the terrain inside the prop and gets
+    // ejected sideways the next grounded tick. So both arms are asserted, on
+    // both sides of the allowance, at a realistic per-tick displacement.
+    const cz = SPOT.z + 2;
+    setActiveWorldContent(world({ crates: [[SPOT.x, cz]] }));
+    const g = groundHeight(SPOT.x, cz, SEED);
+    const top = g + campCrateShape(SPOT.x, cz, 0).top;
+    // Feet just INSIDE the allowance: crosses, and lands on the crate top.
+    const inBand = top - MANTLE_REACH + 0.02;
+    let px = SPOT.x;
+    let pz = SPOT.z;
+    for (let i = 0; i < 20 && pz < cz; i++) {
+      moveCharacter(params({ grounded: false }), px, inBand, pz, 0, 0.35, out);
+      expect(out.blocked).toBe(false);
+      px = out.x;
+      pz = out.z;
+    }
+    expect(pz).toBeGreaterThanOrEqual(cz);
+    expect(floorHeightAt(SEED, px, pz, R, inBand + MANTLE_REACH)).toBeCloseTo(top, 6);
+    // Feet just OUTSIDE it: still a wall, and the landing pass agrees by
+    // refusing the same top. This is the negative arm the allowance needs:
+    // raising the horizontal gate alone would turn this into a tunnel.
+    const below = top - MANTLE_REACH - 0.05;
+    moveCharacter(params({ grounded: false }), SPOT.x, below, SPOT.z, 0, 4, out);
+    expect(out.blocked).toBe(true);
+    expect(out.z).toBeLessThan(cz);
+    expect(floorHeightAt(SEED, SPOT.x, cz, R, below + MANTLE_REACH)).toBeLessThan(top);
   });
 
   it('never steps onto something taller than the step height', () => {

--- a/tests/physics_character.test.ts
+++ b/tests/physics_character.test.ts
@@ -132,6 +132,40 @@ function findStrideableStone(): { x: number; z: number; scale: number } | undefi
   return undefined;
 }
 
+// A collidable stone whose TRUE climb from the approach footing sits strictly
+// above MANTLE_REACH but still within MAX_STEP_HEIGHT: the band a grounded
+// stride freely crosses but that a naive airborne mantle allowance would wall
+// off, since MANTLE_REACH < MAX_STEP_HEIGHT.
+function findLadderBandStone(): { x: number; z: number; scale: number } | undefined {
+  for (const d of generateDecorations(SEED)) {
+    if (d.kind !== 'rock' || d.scale < ROCK_COLLIDER_MIN_SCALE) continue;
+    if (Math.abs(d.x) > 160) continue;
+    const top = groundHeight(d.x, d.z, SEED) + rockHeight(d.x, d.z, d.scale, SEED);
+    const climb = top - groundHeight(d.x, d.z - 1.2, SEED);
+    if (climb <= MANTLE_REACH || climb > MAX_STEP_HEIGHT) continue;
+    let clean = true;
+    for (let t = -2.6; t <= 1.6 && clean; t += 0.4) {
+      const z = d.z + t;
+      if (terrainSteepnessAt(d.x, z, SEED) > 0.4) clean = false;
+      if (terrainHeight(d.x, z, SEED) < WATER_LEVEL + 2) clean = false;
+    }
+    if (!clean) continue;
+    const near: ReturnType<typeof queryOpenWorldColliders> = [];
+    queryOpenWorldColliders(SEED, d.x - 5, d.z - 5, d.x + 5, d.z + 5, near);
+    const blocksCorridor = near.some((c) => {
+      const cx = c.x ?? 0;
+      const cz = c.z ?? 0;
+      if (Math.hypot(cx - d.x, cz - d.z) <= 0.25) return false;
+      if (cz < d.z - 3 || cz > d.z + 2) return false;
+      const reach = (c.type === 'circle' ? c.r : Math.hypot(c.hw, c.hd)) + 0.6;
+      return Math.abs(cx - d.x) < reach;
+    });
+    if (blocksCorridor) continue;
+    return { x: d.x, z: d.z, scale: d.scale };
+  }
+  return undefined;
+}
+
 function findSteepFace(): { x: number; z: number } | undefined {
   for (let z = -60; z <= 200; z += 7) {
     for (let x = -130; x >= -184; x -= 0.25) {
@@ -315,6 +349,22 @@ describe('step up: walking over low obstacles', () => {
     const g = groundHeight(stone.x, stone.z, SEED);
     moveCharacter(params({ grounded: false }), stone.x, g, stone.z - 2, 0, 4, out);
     expect(out.stepped).toBe(0);
+  });
+
+  it('does not wall off an airborne body against a stride-band obstacle', () => {
+    // A body that leaves the ground must not lose ground it could freely
+    // stride over: an obstacle whose top sits within MAX_STEP_HEIGHT of the
+    // feet is never a wall for an airborne body either, even though the
+    // legacy MANTLE_REACH lift alone (0.7yd) is smaller than the stride
+    // band (0.9yd) and would otherwise block it as a new mid-air wall.
+    setActiveWorldContent(null);
+    const stone = findLadderBandStone();
+    expect(stone).toBeDefined();
+    if (!stone) return;
+    const g = groundHeight(stone.x, stone.z - 2, SEED);
+    moveCharacter(params({ grounded: false }), stone.x, g, stone.z - 2, 0, 4, out);
+    expect(out.blocked).toBe(false);
+    expect(out.z).toBeGreaterThan(stone.z - 2);
   });
 
   it('never steps onto something taller than the step height', () => {


### PR DESCRIPTION
## Summary
- The traversal ladder had a hole: a grounded body strides over anything up to `MAX_STEP_HEIGHT` (0.9 yd), an airborne body was only granted `MANTLE_REACH` (0.7 yd) of standable pass-over, and `LEDGE_GRAB_MIN` starts at 0.9. Any standable top in the (0.7, 0.9] yd band above the feet was therefore a mid-air wall: not vaultable, not grabbable, and a non-event on the ground.
- Fix: raise `MANTLE_REACH` (`src/sim/colliders.ts`) to 0.9. That is the ONE constant both halves of the tick read, the horizontal gates (`blocksAt`, `passesOver`/`moverHeight`) and the vertical support query (`floorHeightAt`'s `maxY` in `player_motion.ts`), so pass-over and landing support admit exactly the same tops and the open-world and instanced arms stay in step. The vault band now abuts `LEDGE_GRAB_MIN` exactly, leaving the ladder gapless.
- Raising the horizontal gate ALONE (the first revision of this PR) is the bug it must not be: the body passes the face, `floorHeightAt` refuses the top, and it lands on the terrain inside the prop before depenetration ejects it sideways. `src/sim/physics/CLAUDE.md` now spells that rule out.

## Test plan
- [x] `npx vitest run tests/physics_character.test.ts` (27 passed), including the new decisive pair: an airborne crossing at tick-sized displacement that must end SUPPORTED on the top, and the negative arm just below the allowance that must still block. Plus a pin on `MANTLE_REACH === MAX_STEP_HEIGHT === LEDGE_GRAB_MIN`.
- [x] `npx vitest run tests/parkour.test.ts tests/climb.test.ts tests/player_motion.test.ts tests/town_collision.test.ts tests/physics_audit_world.test.ts tests/architecture.test.ts`
- [x] `npx vitest run tests/parity` (golden trace unmoved)
- [x] `npx tsc --noEmit`

Found during a systematic v0.32.0 release-notes bug audit.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
