### PR TITLE
fix(loot): set lootable for harvestable corpses whose loot table rolls empty

### DIFF
--- a/src/sim/loot/loot_roll.ts
+++ b/src/sim/loot/loot_roll.ts
@@ -315,6 +315,14 @@ export function rollLoot(
     mob.lootable = true;
     // start the owner-lock countdown: after LOOT_FFA_DELAY the tap opens to all.
     mob.lootFfaTimer = LOOT_FFA_DELAY;
+  } else if (isHarvestableCorpse(template.componentTags)) {
+    // The regular loot table rolled empty (chance-based entries, no guaranteed
+    // copper/item), but the corpse still owes a harvest. isHarvestableCorpse is
+    // the single source of truth pruneCorpseLoot already uses to re-derive
+    // lootable once existing loot empties out (#2513); this mirrors that here
+    // so a zero-loot kill isn't permanently un-lootable before pruneCorpseLoot
+    // ever runs. mob.loot stays null: no copper/items to show, just the harvest.
+    mob.lootable = true;
   }
 }
 

--- a/tests/loot_roll.test.ts
+++ b/tests/loot_roll.test.ts
@@ -130,6 +130,44 @@ describe('loot_roll: rollLoot producer (drop-rate determinism)', () => {
   });
 });
 
+describe('loot_roll: rollLoot sets lootable for a harvestable corpse with empty loot', () => {
+  // Regression test: a mob template whose loot table is entirely chance-based
+  // (no guaranteed copper/item) but carries componentTags mapping to a real
+  // harvest item must still end up lootable=true after rollLoot, so
+  // corpseInteractionAvailability offers the harvest interaction. Before the
+  // fix, rollLoot only set mob.lootable inside `if (copper > 0 || items.length
+  // > 0)`, leaving it false (the baseEntity default) whenever every chance
+  // roll failed, even though isHarvestableCorpse(componentTags) is true.
+  const TEMPLATE_ID = 'test_harvest_only_empty_loot';
+
+  it('sets mob.lootable = true even when every chance-based loot entry fails to roll', () => {
+    (MOBS as Record<string, (typeof MOBS)['forest_wolf']>)[TEMPLATE_ID] = {
+      ...MOBS.forest_wolf,
+      id: TEMPLATE_ID,
+      // No guaranteed { copper, chance: 1 } entry: every entry is chance-based.
+      loot: [{ itemId: 'wolf_fang', chance: 0.45 }],
+      componentTags: ['hide'],
+    };
+    try {
+      const sim = makeSim(1);
+      const pid = sim.addPlayer('warrior', 'Looter');
+      const meta = playerMeta(sim, pid);
+      const template = MOBS[TEMPLATE_ID];
+      expect(isHarvestableCorpse(template.componentTags)).toBe(true);
+      const mob = createMob(-1, template, template.minLevel, { x: 0, y: 0, z: 0 });
+      // Force every chance-based roll to fail, so the regular loot table
+      // produces zero copper and zero items.
+      const chanceSpy = vi.spyOn(sim.ctx.rng, 'chance').mockReturnValue(false);
+      rollLoot(sim.ctx, mob, meta);
+      chanceSpy.mockRestore();
+      expect(mob.loot).toBeNull();
+      expect(mob.lootable).toBe(true);
+    } finally {
+      delete (MOBS as Record<string, unknown>)[TEMPLATE_ID];
+    }
+  });
+});
+
 describe('loot_roll: pickRollGroupWinner (cross-group fall-forward)', () => {
   it('returns the plain partition winner when nothing in the group was awarded yet', () => {
     const group: LootEntry[] = [


### PR DESCRIPTION
## Summary
- rollLoot only set `mob.lootable = true` inside the `copper > 0 || items.length > 0` guard, so a mob whose loot table is entirely chance-based (no guaranteed copper/item entry) could leave a kill with `loot = null` and `lootable` stuck at its false default, even when the template's `componentTags` map to a real harvest item.
- `corpseInteractionAvailability` gates on `mob.lootable` before ever consulting `isHarvestableCorpse`, so such a corpse would never offer the harvest interaction for that kill.
- Fix mirrors the `isHarvestableCorpse`-driven `lootable` derivation that `pruneCorpseLoot` already performs (#2513) at the `rollLoot` call site, so both paths agree on when a corpse still owes a harvest.
- Currently unreachable with shipped content (every `componentTags`-bearing template also carries a guaranteed copper entry), but the path itself was wrong and would silently break harvest availability the moment a template is authored without one.

## Test plan
- [x] `npx vitest run tests/loot_roll.test.ts` (34 passed, including a new regression test that fails on the old code and passes after the fix)
- [x] `npx tsc --noEmit`

Found during a systematic v0.32.0 release-notes bug audit.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>