### PR TITLE
fix(market): include zero/missing bagSlots as a selectable bag capacity

### DIFF
--- a/src/sim/market_query.ts
+++ b/src/sim/market_query.ts
@@ -47,19 +47,23 @@ export type MarketBagSizeFilter = 'all' | `${number}`;
 // capacity no other bag has adds its browse option automatically, in ascending order,
 // with no code and no locale change: the option label reuses the already-translated
 // `itemUi.tooltip.bagSlots` template, which takes the number as a value.
-export const MARKET_BAG_SIZE_FILTERS: readonly MarketBagSizeFilter[] = [
-  'all',
-  ...[
-    ...new Set(
-      Object.values(ITEMS)
-        .filter((item) => item.kind === 'bag')
-        .map((item) => item.bagSlots ?? 0)
-        .filter((slots) => slots > 0),
-    ),
-  ]
-    .sort((a, b) => a - b)
-    .map((slots) => `${slots}` as const),
-];
+//
+// A bag with bagSlots 0, or with bagSlots omitted entirely (defaulted to 0 below), is a
+// legitimate distinct capacity, not noise to drop: excluding it here would still let the
+// bag match under itemType 'bag' + subtype 'all' (itemMatchesSubtype short-circuits on
+// 'all'), but no specific-capacity button could ever reach it. So every distinct value,
+// including 0, gets its own option.
+export function deriveBagSizeFilters(items: readonly ItemDef[]): readonly MarketBagSizeFilter[] {
+  return [
+    'all',
+    ...[...new Set(items.filter((item) => item.kind === 'bag').map((item) => item.bagSlots ?? 0))]
+      .sort((a, b) => a - b)
+      .map((slots) => `${slots}` as const),
+  ];
+}
+export const MARKET_BAG_SIZE_FILTERS: readonly MarketBagSizeFilter[] = deriveBagSizeFilters(
+  Object.values(ITEMS),
+);
 // Bound to the content union both ways on purpose: `satisfies` rejects an option that is not
 // a real ArmorType, and the Exclude assertion below reddens tsc if ArmorType ever gains a class
 // with no option here (which would silently make that whole armor class unbrowsable).

--- a/tests/market_filters.test.ts
+++ b/tests/market_filters.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { ITEMS } from '../src/sim/data';
-import { type MarketQuery, marketItemMatches, sanitizeMarketQuery } from '../src/sim/market_query';
+import {
+  deriveBagSizeFilters,
+  type MarketQuery,
+  marketItemMatches,
+  sanitizeMarketQuery,
+} from '../src/sim/market_query';
+import type { ItemDef } from '../src/sim/types';
 import {
   MARKET_ARMOR_CLASS_FILTERS,
   MARKET_ARMOR_TYPE_FILTERS,
@@ -213,6 +219,36 @@ describe('World Market filters', () => {
     // catalog-side bagSlots typo moves the derivation and its mirror in lockstep, and it
     // is deliberately the one place a new bag capacity has to be acknowledged by a human.
     expect([...MARKET_BAG_SIZE_FILTERS]).toEqual(['all', '6', '8', '10', '12', '14']);
+  });
+
+  it('keeps a zero or missing bagSlots value as its own selectable option, not just under all', () => {
+    // A bagSlots of 0, or an absent bagSlots field entirely (defaulted to 0), used to be
+    // dropped by a `slots > 0` filter: the bag still matched itemType 'bag' + subtype
+    // 'all', but no specific-capacity button could ever reach it. Both cases must now
+    // surface a '0' option alongside the regular capacities.
+    const zeroSlotBag = {
+      id: 'zero_slot_bag',
+      name: 'Zero Slot Bag',
+      kind: 'bag',
+      quality: 'common',
+      bagSlots: 0,
+    } as ItemDef;
+    const missingSlotBag = {
+      id: 'missing_slot_bag',
+      name: 'Missing Slot Bag',
+      kind: 'bag',
+      quality: 'common',
+    } as ItemDef;
+    const normalBag = {
+      id: 'normal_bag',
+      name: 'Normal Bag',
+      kind: 'bag',
+      quality: 'common',
+      bagSlots: 6,
+    } as ItemDef;
+
+    expect(deriveBagSizeFilters([zeroSlotBag, normalBag])).toEqual(['all', '0', '6']);
+    expect(deriveBagSizeFilters([missingSlotBag, normalBag])).toEqual(['all', '0', '6']);
   });
 
   it('narrows bags by exact capacity, and every catalog bag is reachable by one size', () => {


### PR DESCRIPTION
## Summary
- MARKET_BAG_SIZE_FILTERS dropped any bag with bagSlots 0, or bagSlots missing entirely, from the World Market capacity subtype options via a `slots > 0` filter. The bag still matched itemType 'bag' + subtype 'all', but no specific-capacity button could ever reach it.
- Extracted the derivation into an exported `deriveBagSizeFilters` pure function and removed the `slots > 0` filter so every distinct capacity value, including 0, gets its own selectable option.

## Test plan
- [x] npx vitest run tests/market_filters.test.ts
- [x] npx tsc --noEmit

Found during a systematic v0.32.0 release-notes bug audit.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>