### PR TITLE
test(ui): hold a granted driver allowance to what its callback actually runs

### DIFF
--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -101,7 +101,13 @@ Per-frame HUD code (anything reached from `Hud.update()`) holds these:
   write-elision standard by review: give it a signature guard and keep it, and if you add a
   genuinely per-frame write path, route it through the facet and move the module into
   `HOT_PAINTERS`. A module that arms its own repeating driver owes the same care INSIDE the
-  callback, which is a contract nothing scans yet: `lockpick_window` re-resolved three element
+  callback, and since #2518 that is a scanned contract too: granting a driver in
+  `tests/hud_perf_budget.test.ts` now costs a `drivers` entry per call site recording the
+  cadence (pinned against the literal in the source), why the driver exists, and the EXACT
+  count of raw writes, element re-queries and IDL-property writes one tick performs. The unit
+  is not the callback body, which is empty in every live case and would have been green on the
+  defect that prompted the rule: it is the body PLUS every same-module function the tick can
+  reach (`tests/helpers/driver_callback_bodies.ts`). `lockpick_window` re-resolved three element
   refs on a 100ms tick until #2498, and the fix had to re-resolve them per board REBUILD
   rather than once at construction, because `renderBoard` replaces that subtree on a signature
   the clock does not restart on (`tests/lockpick_timer_repaint.test.ts` pins both halves).
@@ -243,9 +249,12 @@ follow the root `extract-and-test` skill for the move-not-rewrite mechanics. The
     The two contracts that hold whatever the cadence are enforced: **no forced-reflow layout
     read** and **no repeating driver of its own** (`requestAnimationFrame` /
     `requestIdleCallback`, or a `setInterval` beyond a documented, counted allowance recording
-    its cadence). A window that grows a genuinely per-frame write path moves into
-    `HOT_PAINTERS` and takes the raw-write scan with it, keeping the driver scan, which every
-    bucket runs.
+    its cadence). Granting one is not free: the allowance also declares, per call site, what
+    ONE TICK is allowed to do, counted exactly over the callback body plus every same-module
+    function it reaches (raw writes, element re-queries such as `querySelector`, and
+    IDL-property writes such as `.disabled`). A window that grows a genuinely per-frame write
+    path moves into `HOT_PAINTERS` and takes the raw-write scan with it, keeping the driver
+    scan, which every bucket runs.
   The gate sweeps all three DOM-adapter names, `*_painter.ts`, `*_window.ts` and
   `*_controller.ts`, so renaming between them sheds no contract. Two limits remain, so neither
   reads as more than it is: the scans are per FILE, so a layout read one hop away in a shared

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -107,7 +107,10 @@ Per-frame HUD code (anything reached from `Hud.update()`) holds these:
   count of raw writes, element re-queries and IDL-property writes one tick performs. The unit
   is not the callback body, which is empty in every live case and would have been green on the
   defect that prompted the rule: it is the body PLUS every same-module function the tick can
-  reach (`tests/helpers/driver_callback_bodies.ts`). `lockpick_window` re-resolved three element
+  reach (`tests/helpers/driver_callback_bodies.ts`). Its REACH is the gate's, so read it with
+  the same limit: only the three sanctioned adapter filenames are swept, so a driver in a
+  bare-named module (`reconnect_overlay.ts`, `icon_prewarm.ts`, `hud.ts`) is outside it, the
+  same way those modules are already outside the per-file painter scans. `lockpick_window` re-resolved three element
   refs on a 100ms tick until #2498, and the fix had to re-resolve them per board REBUILD
   rather than once at construction, because `renderBoard` replaces that subtree on a signature
   the clock does not restart on (`tests/lockpick_timer_repaint.test.ts` pins both halves).

--- a/src/ui/hud/CLAUDE.md
+++ b/src/ui/hud/CLAUDE.md
@@ -30,7 +30,9 @@ and performance rules.
   (`tests/hud_perf_budget.test.ts`). A `*_controller.ts` holds the same cold contract a
   `*_window.ts` does: no forced-reflow layout read and no repeating driver of its own,
   beyond a documented, counted allowance. Three carry one today
-  (`chat_geometry_controller`, `chat_window_controller`, `fiesta_controller`). Renaming
+  (`chat_geometry_controller`, `chat_window_controller`, `fiesta_controller`). A granted
+  driver also declares what one tick may do, counted over everything that tick reaches
+  (#2518), so arming a clock means saying what it repaints and how often. Renaming
   between the adapter names therefore sheds nothing, which is the point: name by role.
 - Domain tests import the owning module directly and assert behavior, not source
   line placement.

--- a/src/ui/hud/CLAUDE.md
+++ b/src/ui/hud/CLAUDE.md
@@ -30,9 +30,11 @@ and performance rules.
   (`tests/hud_perf_budget.test.ts`). A `*_controller.ts` holds the same cold contract a
   `*_window.ts` does: no forced-reflow layout read and no repeating driver of its own,
   beyond a documented, counted allowance. Three carry one today
-  (`chat_geometry_controller`, `chat_window_controller`, `fiesta_controller`). A granted
-  driver also declares what one tick may do, counted over everything that tick reaches
-  (#2518), so arming a clock means saying what it repaints and how often. Renaming
+  (`chat_geometry_controller`, `chat_window_controller`, `fiesta_controller`), all of them
+  layout reads rather than drivers. The two modules that DO arm a driver are
+  `daily_rewards_window` (two polls) and `hud/delve/lockpick_window` (the 100ms countdown),
+  and since #2518 a granted driver also declares what ONE TICK may do, counted over everything
+  that tick reaches: arming a clock means saying what it repaints and how often. Renaming
   between the adapter names therefore sheds nothing, which is the point: name by role.
 - Domain tests import the owning module directly and assert behavior, not source
   line placement.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -37,7 +37,8 @@ Subdirectories (plus one shared fixture):
   `ts.createSourceFile` walk that reports the calls a class method evaluates, each with the
   `if` chain guarding each, `test_block_calls.ts`, the `ts.createSourceFile` walk that reports
   every `describe`/`it`/`test`/`suite` call in a source tagged with the block enclosing it,
-  `alloc_probe.ts`).
+  `driver_callback_bodies.ts`, the `ts.createSourceFile` walk that resolves a repeating
+  driver's callback and every same-module body one of its ticks can reach, `alloc_probe.ts`).
 - `global_setup.ts`: runs on every vitest invocation (`vite.config.ts` `test.globalSetup`);
   mints the SFX Studio temp root (`WOC_SFX_STUDIO_TEST_ROOT`).
 
@@ -130,7 +131,14 @@ use the `tests/server/helpers/` fakes (see Map), not a bespoke GameServer rig.
   or cold, the registration-free default for a window (no forced-reflow read and no repeating
   driver of its own, at any cadence). The raw-write scan is waived for cold NOT because a
   window is cold, which this tree contradicts, but because a COUNT cannot tell a build-time
-  write from a repeated one; see the bucket 3 comment for the cadences involved.
+  write from a repeated one; see the bucket 3 comment for the cadences involved. Inside a
+  granted driver's callback it CAN, so a `driverAllow` entry now costs a `drivers` entry per
+  call site: the cadence, pinned against the source literal, plus exact counts of raw writes,
+  element re-queries and IDL-property writes over everything ONE TICK reaches
+  (`helpers/driver_callback_bodies.ts`). The unit is the callback body PLUS every same-module
+  function it calls, because a body-only scan is vacuous over this tree: all three live
+  callbacks are a guard and a method call, and the writes that motivated the rule are one hop
+  further in.
 - `hud_update_drive.test.ts` answers the cadence question that gate refuses to: one
   hand-written row per call `Hud.update()` evaluates, carrying its band
   (`frame`/`fast`/`medium`/`slow`), the exact condition text gating it, what it repaints, and

--- a/tests/helpers/driver_callback_bodies.test.ts
+++ b/tests/helpers/driver_callback_bodies.test.ts
@@ -18,15 +18,20 @@ describe('readDriverCallbacks: which call sites it finds', () => {
       setInterval(() => {}, 100);
       window.setInterval(() => {}, 200);
       requestAnimationFrame(() => {});
+      window.requestAnimationFrame(() => {});
+      requestIdleCallback(() => {});
       window.requestIdleCallback(() => {});
       clearInterval(handle);
       cancelAnimationFrame(handle);
+      cancelIdleCallback(handle);
       setTimeout(() => {}, 100);
     `);
     expect(found.map((f) => f.driver)).toEqual([
       'setInterval',
       'setInterval',
       'requestAnimationFrame',
+      'requestAnimationFrame',
+      'requestIdleCallback',
       'requestIdleCallback',
     ]);
   });
@@ -39,6 +44,24 @@ describe('readDriverCallbacks: which call sites it finds', () => {
       requestAnimationFrame(() => {});
     `);
     expect(found.map((f) => f.delayMs)).toEqual([100, 15000, null, null]);
+  });
+
+  // A cadence hoisted into a constant still resolves, which is what keeps the pin from being
+  // escapable by a one-line refactor. src/ui/reconnect_overlay.ts already writes this shape.
+  it('resolves a cadence hoisted into a module-level const', () => {
+    const found = read(`
+      const TICK_MS = 250;
+      const SLOW_MS = 30_000;
+      setInterval(render, TICK_MS);
+      setInterval(render, SLOW_MS);
+      function render(): void {}
+    `);
+    expect(found.map((f) => f.delayMs)).toEqual([250, 30000]);
+  });
+
+  it('reports the line of the driver call, so a failure can be found', () => {
+    const found = read('const a = 1;\n\nsetInterval(() => {}, 10);');
+    expect(found[0]?.line).toBe(3);
   });
 
   it('finds a driver armed anywhere in the file, not only at top level', () => {
@@ -152,6 +175,47 @@ describe('readDriverCallbacks: what one tick reaches', () => {
     expect(both[0]?.code).toContain('from B');
   });
 
+  // THE SAME-MODULE ESCAPES, each of which resolved to nothing before they were closed. All
+  // three are one keystroke away from the shape the walk already followed, which is exactly the
+  // kind of gap a gate ships with and never notices: a NEW driver written this way would pass
+  // with an empty allowance and a wholly unscanned tick.
+  it('follows a call through a local bound to `this`', () => {
+    const found = read(`
+      export class W {
+        private arm(): void {
+          const self = this;
+          setInterval(() => { self.paintTimer(); }, 100);
+        }
+        private paintTimer(): void { this.el.style.width = '1px'; }
+      }
+    `);
+    expect(found[0]?.reached).toEqual(['paintTimer']);
+    expect(found[0]?.code).toContain("style.width = '1px'");
+  });
+
+  it('follows a COMPUTED call on `this`, the escape every write family already closes', () => {
+    const found = read(`
+      export class W {
+        private arm(): void { setInterval(() => { this['paintTimer'](); }, 100); }
+        private paintTimer(): void { this.el.textContent = 'computed callee'; }
+      }
+    `);
+    expect(found[0]?.reached).toEqual(['paintTimer']);
+    expect(found[0]?.code).toContain('computed callee');
+  });
+
+  it('follows an object-literal method', () => {
+    const found = read(`
+      const ui = {
+        paint(): void { node.textContent = 'from an object literal'; },
+        fmt: () => 'x',
+      };
+      setInterval(() => { ui.paint(); }, 100);
+    `);
+    expect(found[0]?.reached).toEqual(['paint']);
+    expect(found[0]?.code).toContain('from an object literal');
+  });
+
   it('does not leave this module: a call through an injected dep is out of reach', () => {
     const found = read(`
       export class W {
@@ -159,6 +223,30 @@ describe('readDriverCallbacks: what one tick reaches', () => {
       }
     `);
     expect(found[0]?.reached).toEqual([]);
+  });
+
+  // The limits the header states, pinned as the CURRENT behavior rather than left as prose a
+  // reader has to trust. If a later change closes one of these, this test is where it is
+  // noticed, and the header paragraph moves with it.
+  it('records the stated limits: a dynamic key and a detached method reference', () => {
+    expect(
+      read(`
+        export class W {
+          private arm(): void { setInterval(() => { this[key](); }, 10); }
+          private paint(): void { this.el.textContent = 'unreachable through a dynamic key'; }
+        }
+      `)[0]?.reached,
+    ).toEqual([]);
+    expect(
+      read(`
+        export class W {
+          private arm(): void {
+            const fn = this.deps.paint;
+            setInterval(() => { fn(); }, 10);
+          }
+        }
+      `)[0]?.reached,
+    ).toEqual([]);
   });
 });
 
@@ -220,6 +308,18 @@ describe('readDriverCallbacks: it refuses rather than scanning nothing', () => {
 
   it('throws when the driver is armed with no callback at all', () => {
     expect(() => read('setInterval();')).toThrow(/armed with no callback argument/);
+  });
+
+  it('scans EVERY body when the callback reference itself is ambiguous', () => {
+    const found = read(`
+      export class A { tick(): void { this.el.textContent = 'from A'; } }
+      export class B { tick(): void { this.el.innerHTML = 'from B'; } }
+      export class C { arm(): void { setInterval(this.tick, 10); } }
+    `);
+    // Both, for the same reason an ambiguous CALLEE pulls in both: picking one would silently
+    // scan the wrong tick, and over-scanning is the safe direction for a budget.
+    expect(found[0]?.code).toContain('from A');
+    expect(found[0]?.code).toContain('from B');
   });
 
   it('resolves a reference to a same-module function, and does not re-add it as its own callee', () => {

--- a/tests/helpers/driver_callback_bodies.test.ts
+++ b/tests/helpers/driver_callback_bodies.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+import { readDriverCallbacks } from './driver_callback_bodies';
+
+// The paired test for the driver-callback resolver. Synthetic sources ONLY, on purpose: the
+// consumer (tests/hud_perf_budget.test.ts) resolves its own input from src/ui, and a producer
+// that reads its own input can only ever be proven against the tree it already passes on
+// (#2497, #2499, #2502). Every shape below is one the walk has to get right for the gate on
+// top of it to mean anything.
+
+const DRIVERS = ['requestAnimationFrame', 'requestIdleCallback', 'setInterval'];
+
+const read = (source: string, stopAt: string[] = []) =>
+  readDriverCallbacks('probe.ts', source, DRIVERS, stopAt);
+
+describe('readDriverCallbacks: which call sites it finds', () => {
+  it('finds the bare and the member form of every driver, and no teardown', () => {
+    const found = read(`
+      setInterval(() => {}, 100);
+      window.setInterval(() => {}, 200);
+      requestAnimationFrame(() => {});
+      window.requestIdleCallback(() => {});
+      clearInterval(handle);
+      cancelAnimationFrame(handle);
+      setTimeout(() => {}, 100);
+    `);
+    expect(found.map((f) => f.driver)).toEqual([
+      'setInterval',
+      'setInterval',
+      'requestAnimationFrame',
+      'requestIdleCallback',
+    ]);
+  });
+
+  it('reads the cadence literal, underscores included, and null where there is none', () => {
+    const found = read(`
+      setInterval(() => {}, 100);
+      setInterval(() => {}, 15_000);
+      setInterval(() => {}, delayFromConfig);
+      requestAnimationFrame(() => {});
+    `);
+    expect(found.map((f) => f.delayMs)).toEqual([100, 15000, null, null]);
+  });
+
+  it('finds a driver armed anywhere in the file, not only at top level', () => {
+    const found = read(`
+      export class W {
+        private arm(): void {
+          if (this.live) {
+            this.iv = window.setInterval(() => this.tick(), 50);
+          }
+        }
+        private tick(): void { this.el.textContent = 'x'; }
+      }
+    `);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.delayMs).toBe(50);
+    expect(found[0]?.reached).toEqual(['tick']);
+  });
+});
+
+describe('readDriverCallbacks: what one tick reaches', () => {
+  // THE CASE THE WHOLE THING EXISTS FOR. A body-only scan of lockpick_window's clock saw a
+  // guard, a subtraction and two method calls, and every write and every re-query the issue
+  // is about sat one call away in paintTimer.
+  it('follows a call out of the callback body into a same-module method', () => {
+    const found = read(`
+      export class W {
+        private arm(): void {
+          this.iv = window.setInterval(() => {
+            if (gen !== this.gen) return;
+            this.paintTimer(remaining);
+          }, 100);
+        }
+        private paintTimer(remaining: number): void {
+          const bar = this.panel.querySelector('.bar');
+          if (bar) bar.style.width = '50%';
+        }
+        private unrelated(): void { this.el.innerHTML = 'never reached'; }
+      }
+    `);
+    expect(found[0]?.reached).toEqual(['paintTimer']);
+    expect(found[0]?.code).toContain('querySelector');
+    expect(found[0]?.code).not.toContain('never reached');
+  });
+
+  it('follows transitively, and survives a cycle', () => {
+    const found = read(`
+      export class W {
+        private arm(): void { setInterval(() => this.a(), 10); }
+        private a(): void { this.b(); }
+        private b(): void { this.a(); this.c(); }
+        private c(): void { this.el.textContent = 'deep'; }
+      }
+    `);
+    expect(found[0]?.reached).toEqual(['a', 'b', 'c']);
+    expect(found[0]?.code).toContain('deep');
+  });
+
+  it('follows a getter, because `if (this.isOpen)` runs a body', () => {
+    const found = read(`
+      export class W {
+        private arm(): void { setInterval(() => { if (this.isOpen) this.noop(); }, 10); }
+        get isOpen(): boolean { return this.root().style.display === 'block'; }
+        private noop(): void {}
+      }
+    `);
+    expect(found[0]?.reached).toEqual(['isOpen', 'noop']);
+    expect(found[0]?.code).toContain('style.display');
+  });
+
+  // The over-approximating half of the rule, and the reason it is that way: excluding nested
+  // function bodies would put every write one `forEach` away from the scan.
+  it('follows a callee named inside a nested callback', () => {
+    const found = read(`
+      export class W {
+        private arm(): void { setInterval(() => { this.paint(); }, 10); }
+        private paint(): void { this.rows.forEach(() => this.write()); }
+        private write(): void { this.el.textContent = 'inside a nested arrow'; }
+      }
+    `);
+    expect(found[0]?.reached).toEqual(['paint', 'write']);
+    expect(found[0]?.code).toContain('inside a nested arrow');
+  });
+
+  it('follows a call in an argument position and a module-level function', () => {
+    const found = read(`
+      function label(n: number): string { return String(n); }
+      const paint = (el: HTMLElement, s: string): void => { el.textContent = s; };
+      setInterval(() => { paint(node, label(1)); }, 10);
+    `);
+    expect(found[0]?.reached).toEqual(['label', 'paint']);
+    expect(found[0]?.code).toContain('el.textContent = s;');
+  });
+
+  it('pulls in EVERY body when a name is ambiguous, rather than guessing one', () => {
+    const found = read(`
+      export class A { paint(): void { this.el.textContent = 'from A'; } }
+      export class B { paint(): void { this.el.innerHTML = 'from B'; } }
+      setInterval(() => { thing.paint(); }, 10);
+    `);
+    // A bare `thing.paint()` is not a `this` call, so it is not followed at all...
+    expect(found[0]?.reached).toEqual([]);
+    const both = read(`
+      export class A { paint(): void { this.el.textContent = 'from A'; } }
+      export class B { paint(): void { this.el.innerHTML = 'from B'; } }
+      export class C { arm(): void { setInterval(() => this.paint(), 10); } }
+    `);
+    // ...but a `this.paint()` whose name matches two declarations scans both, since
+    // picking one would silently scan the wrong body.
+    expect(both[0]?.reached).toEqual(['paint']);
+    expect(both[0]?.code).toContain('from A');
+    expect(both[0]?.code).toContain('from B');
+  });
+
+  it('does not leave this module: a call through an injected dep is out of reach', () => {
+    const found = read(`
+      export class W {
+        private arm(): void { setInterval(() => { this.deps.repaint(); }, 10); }
+      }
+    `);
+    expect(found[0]?.reached).toEqual([]);
+  });
+});
+
+describe('readDriverCallbacks: the declared cut', () => {
+  it('stops at a named method and reports the cut, without cutting its siblings', () => {
+    const source = `
+      export class W {
+        private arm(): void { setInterval(() => { this.render(); this.tick(); }, 10); }
+        private render(): void { this.el.innerHTML = 'the whole window'; }
+        private tick(): void { this.el.textContent = 'the tick'; }
+      }
+    `;
+    const cut = read(source, ['render']);
+    expect(cut[0]?.reached).toEqual(['tick']);
+    expect(cut[0]?.stopped).toEqual(['render']);
+    expect(cut[0]?.code).not.toContain('the whole window');
+    expect(cut[0]?.code).toContain('the tick');
+    // Uncut, the same source reaches both, so the cut is doing the work and not the walk.
+    expect(read(source)[0]?.reached).toEqual(['render', 'tick']);
+  });
+
+  it('reports no cut for a name the callback never reaches, so a dead cut is visible', () => {
+    const found = read(
+      'export class W { arm(): void { setInterval(() => this.tick(), 10); } tick(): void {} }',
+      ['renderCurrent'],
+    );
+    expect(found[0]?.stopped).toEqual([]);
+  });
+
+  it('cuts a method reached deeper than the callback body', () => {
+    const found = read(
+      `export class W {
+         arm(): void { setInterval(() => this.a(), 10); }
+         a(): void { this.render(); }
+         render(): void { this.el.innerHTML = 'deep render'; }
+       }`,
+      ['render'],
+    );
+    expect(found[0]?.reached).toEqual(['a']);
+    expect(found[0]?.stopped).toEqual(['render']);
+    expect(found[0]?.code).not.toContain('deep render');
+  });
+});
+
+describe('readDriverCallbacks: it refuses rather than scanning nothing', () => {
+  // The standing anti-vacuity rule for a source guard: a resolver that shrugged at a shape it
+  // could not follow would hand the gate above an empty, passing scan.
+  it('throws when the callback is an unresolvable expression', () => {
+    expect(() => read('setInterval(makeTick(this), 100);')).toThrow(
+      /does not resolve to a function in this module/,
+    );
+  });
+
+  it('throws when the callback names a function that is not in this module', () => {
+    expect(() => read("import { tick } from './tick';\nsetInterval(tick, 100);")).toThrow(
+      /does not resolve to a function in this module/,
+    );
+  });
+
+  it('throws when the driver is armed with no callback at all', () => {
+    expect(() => read('setInterval();')).toThrow(/armed with no callback argument/);
+  });
+
+  it('resolves a reference to a same-module function, and does not re-add it as its own callee', () => {
+    const found = read(`
+      export class W {
+        private arm(): void { setInterval(this.tick, 100); }
+        private tick(): void { this.tick(); this.paint(); }
+        private paint(): void { this.el.textContent = 'x'; }
+      }
+    `);
+    expect(found[0]?.reached).toEqual(['paint']);
+    expect(found[0]?.code).toContain("this.el.textContent = 'x';");
+  });
+
+  it('resolves a bound reference and a module-level arrow', () => {
+    expect(
+      read(`
+        export class W {
+          private arm(): void { setInterval(this.tick.bind(this), 100); }
+          private tick(): void { this.paint(); }
+          private paint(): void {}
+        }
+      `)[0]?.reached,
+    ).toEqual(['paint']);
+    expect(
+      read('const tick = () => { node.textContent = "x"; };\nsetInterval(tick, 100);')[0]?.code,
+    ).toContain('node.textContent');
+  });
+
+  it('scans an expression-bodied arrow, not just a block', () => {
+    const found = read('setInterval(() => node.classList.toggle("on", x), 100);');
+    expect(found[0]?.code).toContain('classList.toggle');
+  });
+});

--- a/tests/helpers/driver_callback_bodies.ts
+++ b/tests/helpers/driver_callback_bodies.ts
@@ -33,15 +33,32 @@ import ts from 'typescript';
 //     put every write behind a callback the walk refuses to enter);
 //   - a property access on `this` is followed as a possible GETTER, since `if (this.isOpen)`
 //     runs `get isOpen()`'s body, `style` read and all;
+//   - a LOCAL BOUND TO `this` OR TO AN OBJECT LITERAL reads like `this` (`const self = this;
+//     self.paintTimer()`, `const ui = { paint() {} }; ui.paint()`), and the
+//     `['paintTimer']()` spelling reads as the `.paintTimer()` one, because both are the same
+//     same-module call wearing a shape a narrower walk cannot see. The computed form matters
+//     most: every matcher family in the consuming gate carries a `['computed']` arm to close
+//     exactly that escape for property writes, so leaving it open for CALLEES would let a
+//     write hop behind `this['paintTimer']()` and out of a gate that catches `el['style']`;
 //   - a name resolving to more than one body (two classes in one file with the same method
 //     name) pulls in ALL of them, since guessing between them would silently scan the wrong
 //     one.
 // Every one of those is the OVER-approximating direction: a handler registered during a tick
 // is scanned as though the tick ran it. That is the safe direction for a budget, and it is
 // the same trade the `getUiScale` proxy token in `tests/hud_perf_budget.test.ts` already
-// makes. What it does NOT reach is another MODULE: `this.deps.root()` and an imported helper
-// are out of range, exactly as the per-file scans in that gate are, and a write moved behind
-// one is invisible here. That limit is stated, not implied.
+// makes.
+//
+// WHAT IT DOES NOT REACH, stated rather than implied, because a resolver that shrugs is the
+// failure mode this file exists to avoid. FIRST, another MODULE: `this.deps.root()` and an
+// imported helper are out of range, exactly as the per-file scans in that gate are, and a
+// write moved behind one is invisible here. SECOND, a callee reached through a value this walk
+// cannot name: a method plucked into a local (`const paint = obj.paint; paint()` resolves only
+// if some same-module body happens to be named `paint`), a dynamic `this[key]()`, or a call on
+// an object handed in from outside. The asymmetry with the CALLBACK resolver is deliberate and
+// is the honest reading of the anti-vacuity rule: an unresolvable callback means the tick is
+// wholly unknown, so it THROWS; an unresolvable callee inside a known tick means one branch of
+// it is unknown, which no source walk can rule out in general, so the walk records what it can
+// and this paragraph says what it cannot.
 //
 // THE CUT, and why it is declarable. A driver whose callback calls the module's ordinary
 // full-render entry point reaches the whole module, and counting that would re-litigate the
@@ -60,13 +77,14 @@ import ts from 'typescript';
 export interface DriverCallback {
   /** The driver armed, spelled as the source spells it: `setInterval`, ... */
   readonly driver: string;
-  /** 1-based line of the driver call, for a failure message only (never pinned). */
+  /** 1-based line of the driver call. Consumed by the gate's failure messages, never pinned
+   * against the real tree (a line number rots); the paired test pins it on synthetic input. */
   readonly line: number;
   /**
-   * The cadence argument when it is a numeric literal (`100`, `15_000`), else null.
-   * `requestAnimationFrame` / `requestIdleCallback` take no delay, so they are always null.
-   * A caller pins this, which is what makes a declared cadence load-bearing rather than a
-   * comment that can drift away from the number beside it.
+   * The cadence argument as a number: a literal (`100`, `15_000`) or a module-level `const`
+   * holding one, else null. `requestAnimationFrame` / `requestIdleCallback` take no delay, so
+   * they are always null. A caller pins this, which is what makes a declared cadence
+   * load-bearing rather than a comment that can drift away from the number beside it.
    */
   readonly delayMs: number | null;
   /** Names of the same-module bodies pulled in, sorted. Empty when the tick calls nothing. */
@@ -80,21 +98,65 @@ export interface DriverCallback {
 /** Index of every named function body in one module: name -> one or more bodies. */
 type BodyIndex = ReadonlyMap<string, readonly ts.Node[]>;
 
+/** What one module offers the walk: its named bodies, its `this` aliases, its number consts. */
+interface ModuleIndex {
+  readonly bodies: BodyIndex;
+  /**
+   * Locals whose member calls are same-module code: a binding of `this` (`const self = this`)
+   * or of an object literal (`const ui = { paint() {} }`). A call on either is one this walk
+   * can resolve, and neither is a `this.` chain or a bare identifier, so without them both
+   * `self.paintTimer()` and `ui.paint()` reach nothing.
+   */
+  readonly selfLike: ReadonlySet<string>;
+  /** Module-level `const TICK_MS = 100`, so a hoisted cadence still resolves to its number. */
+  readonly numbers: ReadonlyMap<string, number>;
+}
+
 function addBody(index: Map<string, ts.Node[]>, name: string, body: ts.Node): void {
   const existing = index.get(name);
   if (existing) existing.push(body);
   else index.set(name, [body]);
 }
 
+/** A numeric literal, with `_` separators removed. `15_000` reads as 15000. */
+function numberOf(node: ts.Node): number | null {
+  if (!ts.isNumericLiteral(node)) return null;
+  const value = Number(node.text.replace(/_/g, ''));
+  return Number.isFinite(value) ? value : null;
+}
+
 /**
- * Every named function body in the file: class methods and get accessors, class properties
- * initialized to a function, module-level function declarations, and `const f = () => {}`.
- * Indexed by BARE name, because that is all a call site gives: `this.paintTimer(...)` and
- * `paintTimer(...)` both resolve here.
+ * Everything the walk needs out of one module, in one pass.
+ *
+ * BODIES: class methods and get accessors, class properties initialized to a function,
+ * module-level function declarations, and `const f = () => {}`. Indexed by BARE name, because
+ * that is all a call site gives: `this.paintTimer(...)` and `paintTimer(...)` both resolve here.
+ *
+ * THIS ALIASES: `const self = this` is a same-module call that neither a `this.` chain nor a
+ * bare identifier can see, so `self.paintTimer()` would reach nothing and a NEW driver written
+ * that way would pass with an empty allowance and an unscanned tick. Collecting the alias names
+ * closes it. Any local bound to `this` counts, wherever it is declared, which over-approximates
+ * across scopes in the safe direction: a second unrelated `self` would only pull in MORE bodies.
+ *
+ * NUMBERS: module-level `const TICK_MS = 100`, so hoisting a cadence out of the call does not
+ * turn a pinned cadence into an unpinnable `null`. `src/ui/reconnect_overlay.ts` already writes
+ * `window.setInterval(render, TICK_MS)`, so this is the live shape rather than a hypothetical.
  */
-function indexBodies(sf: ts.SourceFile): BodyIndex {
+function indexModule(sf: ts.SourceFile): ModuleIndex {
   const index = new Map<string, ts.Node[]>();
+  const selfLike = new Set<string>();
+  const numbers = new Map<string, number>();
   const visit = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const bound = node.initializer;
+      if (bound.kind === ts.SyntaxKind.ThisKeyword || ts.isObjectLiteralExpression(bound)) {
+        selfLike.add(node.name.text);
+      }
+    }
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const value = numberOf(node.initializer);
+      if (value !== null) numbers.set(node.name.text, value);
+    }
     if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
       for (const member of node.members) {
         if (
@@ -114,6 +176,22 @@ function indexBodies(sf: ts.SourceFile): BodyIndex {
         }
       }
     }
+    // An object-literal method (`const ui = { paint() { ... } }`) is a same-module body too,
+    // and `ui.paint()` is not a call on `this`, so without this arm it resolves to nothing.
+    if (ts.isObjectLiteralExpression(node)) {
+      for (const property of node.properties) {
+        if (ts.isMethodDeclaration(property) && property.body) {
+          addBody(index, property.name.getText(sf), property.body);
+        }
+        if (
+          ts.isPropertyAssignment(property) &&
+          (ts.isArrowFunction(property.initializer) ||
+            ts.isFunctionExpression(property.initializer))
+        ) {
+          addBody(index, property.name.getText(sf), property.initializer.body);
+        }
+      }
+    }
     if (ts.isFunctionDeclaration(node) && node.name && node.body) {
       addBody(index, node.name.text, node.body);
     }
@@ -126,7 +204,7 @@ function indexBodies(sf: ts.SourceFile): BodyIndex {
     ts.forEachChild(node, visit);
   };
   visit(sf);
-  return index;
+  return { bodies: index, selfLike, numbers };
 }
 
 /** The driver name this call arms, or null: `setInterval(...)` and `window.setInterval(...)`. */
@@ -151,14 +229,14 @@ function resolveCallback(
   arg: ts.Expression | undefined,
   index: BodyIndex,
   where: string,
-): { body: ts.Node; seedName: string | null } {
+): { bodies: readonly ts.Node[]; seedName: string | null } {
   if (!arg) {
     throw new Error(
       `${where}: the repeating driver was armed with no callback argument, so nothing can be scanned. A driver whose callback cannot be resolved must be a red test, never a quiet zero.`,
     );
   }
   if (ts.isArrowFunction(arg) || ts.isFunctionExpression(arg)) {
-    return { body: arg.body, seedName: null };
+    return { bodies: [arg.body], seedName: null };
   }
   // `setInterval(this.tick.bind(this), 100)` is the same callback one wrapper out.
   if (
@@ -172,48 +250,86 @@ function resolveCallback(
     ? arg.text
     : ts.isPropertyAccessExpression(arg)
       ? arg.name.text
-      : null;
+      : ts.isElementAccessExpression(arg) && ts.isStringLiteralLike(arg.argumentExpression)
+        ? arg.argumentExpression.text
+        : null;
   const bodies = name === null ? undefined : index.get(name);
   if (!name || !bodies || bodies.length === 0) {
     throw new Error(
       `${where}: the repeating driver's callback (\`${arg.getText(arg.getSourceFile())}\`) does not resolve to a function in this module, so its per-tick work cannot be scanned. Inline the callback, point it at a same-module function, or move the driver somewhere this gate can see it.`,
     );
   }
-  // A name with two bodies is scanned as both; the seed keeps the walk from re-adding it.
-  return { body: bodies[0] as ts.Node, seedName: name };
-}
-
-/** The cadence argument, when it is a plain numeric literal. `15_000` counts as 15000. */
-function delayOf(call: ts.CallExpression): number | null {
-  const arg = call.arguments[1];
-  if (!arg || !ts.isNumericLiteral(arg)) return null;
-  const value = Number(arg.text.replace(/_/g, ''));
-  return Number.isFinite(value) ? value : null;
+  // A name with two bodies is scanned as BOTH, the same rule the reachability walk follows for
+  // an ambiguous callee: picking one would silently scan the wrong tick. The seed name keeps
+  // the walk from re-adding them as a callee of themselves.
+  return { bodies, seedName: name };
 }
 
 /**
- * Every callee name the node mentions: a call on `this`, a bare call, and a property access
- * on `this` (a possible getter). Descends through nested function bodies on purpose; see the
- * reachability rule at the top of this file.
+ * The cadence argument as a number: a literal (`100`, `15_000`), or a module-level `const`
+ * holding one. Null when it is neither, and for a driver that takes no delay at all.
+ *
+ * THE CONST ARM IS NOT A CONVENIENCE. Without it the cadence pin is escapable by hoisting:
+ * `window.setInterval(render, TICK_MS)` would resolve to `null`, an entry could then declare
+ * `everyMs: null`, and re-tuning that constant would move no gate. `src/ui/reconnect_overlay.ts`
+ * already writes exactly that shape.
  */
-function calleeNames(node: ts.Node): string[] {
+function delayOf(call: ts.CallExpression, numbers: ReadonlyMap<string, number>): number | null {
+  const arg = call.arguments[1];
+  if (!arg) return null;
+  const literal = numberOf(arg);
+  if (literal !== null) return literal;
+  return ts.isIdentifier(arg) ? (numbers.get(arg.text) ?? null) : null;
+}
+
+/**
+ * Whether a member call on this expression is same-module code the walk can resolve: `this`,
+ * a local bound to it (`const self = this`), or a local bound to an object literal.
+ *
+ * Deliberately NOT "any object": `this.deps.repaint()` must stay out of reach, because `deps`
+ * is another module's surface and a same-named method here would be the wrong body entirely.
+ */
+function isSelfLike(expr: ts.Expression, selfLike: ReadonlySet<string>): boolean {
+  if (expr.kind === ts.SyntaxKind.ThisKeyword) return true;
+  return ts.isIdentifier(expr) && selfLike.has(expr.text);
+}
+
+/** The member name a `.foo` or a `['foo']` access reads, or null for a computed one. */
+function memberName(node: ts.PropertyAccessExpression | ts.ElementAccessExpression): string | null {
+  if (ts.isPropertyAccessExpression(node)) return node.name.text;
+  return ts.isStringLiteralLike(node.argumentExpression) ? node.argumentExpression.text : null;
+}
+
+/**
+ * Every callee name the node mentions: a call on `this` (or on a local bound to it), a bare
+ * call, and a property access on `this` (a possible getter). Descends through nested function
+ * bodies on purpose; see the reachability rule at the top of this file.
+ *
+ * BOTH the `.foo` and the `['foo']` spelling count, which is the same computed-access escape
+ * every matcher family in `tests/hud_perf_budget.test.ts` carries a `['computed']` arm for. A
+ * walk that saw only the dot form would let a write move behind `this['paintTimer']()` and out
+ * of a gate that catches `el['style']` one layer up.
+ */
+function calleeNames(node: ts.Node, selfLike: ReadonlySet<string>): string[] {
   const names: string[] = [];
   const visit = (n: ts.Node): void => {
     if (ts.isCallExpression(n)) {
       const callee = n.expression;
-      if (
-        ts.isPropertyAccessExpression(callee) &&
-        callee.expression.kind === ts.SyntaxKind.ThisKeyword
-      ) {
-        names.push(callee.name.text);
-      } else if (ts.isIdentifier(callee)) {
+      if (ts.isIdentifier(callee)) {
         names.push(callee.text);
+      } else if (
+        (ts.isPropertyAccessExpression(callee) || ts.isElementAccessExpression(callee)) &&
+        isSelfLike(callee.expression, selfLike)
+      ) {
+        const name = memberName(callee);
+        if (name !== null) names.push(name);
       }
     } else if (
-      ts.isPropertyAccessExpression(n) &&
-      n.expression.kind === ts.SyntaxKind.ThisKeyword
+      (ts.isPropertyAccessExpression(n) || ts.isElementAccessExpression(n)) &&
+      isSelfLike(n.expression, selfLike)
     ) {
-      names.push(n.name.text);
+      const name = memberName(n);
+      if (name !== null) names.push(name);
     }
     ts.forEachChild(n, visit);
   };
@@ -237,7 +353,7 @@ export function readDriverCallbacks(
   const sf = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
   const drivers = new Set(driverNames);
   const cuts = new Set(stopAt);
-  const index = indexBodies(sf);
+  const index = indexModule(sf);
 
   const calls: ts.CallExpression[] = [];
   const collect = (node: ts.Node): void => {
@@ -250,21 +366,22 @@ export function readDriverCallbacks(
     const driver = armedDriver(call, drivers) as string;
     const line = sf.getLineAndCharacterOfPosition(call.getStart(sf)).line + 1;
     const where = `${fileName}:${line}`;
-    const { body, seedName } = resolveCallback(call.arguments[0], index, where);
+    const resolvedCallback = resolveCallback(call.arguments[0], index.bodies, where);
+    const seedName = resolvedCallback.seedName;
 
     const seen = new Set<string>(seedName ? [seedName] : []);
     const stopped = new Set<string>();
-    const bodies: ts.Node[] = [body];
-    const queue: ts.Node[] = [body];
+    const bodies: ts.Node[] = [...resolvedCallback.bodies];
+    const queue: ts.Node[] = [...resolvedCallback.bodies];
     while (queue.length) {
       const current = queue.shift() as ts.Node;
-      for (const name of calleeNames(current)) {
+      for (const name of calleeNames(current, index.selfLike)) {
         if (cuts.has(name)) {
           stopped.add(name);
           continue;
         }
         if (seen.has(name)) continue;
-        const found = index.get(name);
+        const found = index.bodies.get(name);
         if (!found || found.length === 0) continue;
         seen.add(name);
         for (const reachedBody of found) {
@@ -277,7 +394,7 @@ export function readDriverCallbacks(
     return {
       driver,
       line,
-      delayMs: delayOf(call),
+      delayMs: delayOf(call, index.numbers),
       reached: [...seen].sort(),
       stopped: [...stopped].sort(),
       code: bodies.map((b) => b.getText(sf)).join('\n'),

--- a/tests/helpers/driver_callback_bodies.ts
+++ b/tests/helpers/driver_callback_bodies.ts
@@ -1,0 +1,286 @@
+import ts from 'typescript';
+
+// The other half of #2498's rule, and the thing a granted driver allowance was missing:
+// given one module source, resolve WHAT ACTUALLY RUNS on each tick of a repeating driver
+// it arms (`setInterval`, `requestAnimationFrame`, `requestIdleCallback`).
+//
+// WHY A CALLBACK BODY IS NOT THE ANSWER, measured rather than assumed. The obvious reading
+// of the rule is "scan the body of the callback", and over this tree that scan is VACUOUS:
+// all three live driver callbacks contain zero writes and zero queries, because each one is
+// a guard plus a call to a method. `lockpick_window`'s clock, the defect that motivated the
+// rule, reads in full as
+//
+//     window.setInterval(() => {
+//       if (gen !== this.timerGen) return;
+//       const remaining = Math.max(0, (end - performance.now()) / 1000);
+//       this.paintTimer(remaining, seconds);
+//       if (remaining <= 0) this.stopTimer();
+//     }, 100);
+//
+// and every one of the three `querySelector` walks and the unelided `classList.toggle` the
+// issue is about lived in `paintTimer`, one call away. A body-only scan would have been
+// green on the exact source that motivated writing it. So the unit here is the callback body
+// PLUS the body of every same-module function it can reach, transitively.
+//
+// THE REACHABILITY RULE, and how it deliberately differs from `method_call_sites.ts`. That
+// walk answers "what does `Hud.update()` DRIVE", so it declines call arguments (a producer
+// feeding a painter is not a second drive) and declines nested function bodies (a callback
+// registered inside `update()` runs on someone else's cadence). This walk answers a different
+// question, "what CODE does one tick execute", so it follows every callee it can see:
+//   - a call in an argument position IS evaluated on the tick, so it is followed;
+//   - a callee named inside a nested arrow IS followed, because the alternative hands anyone
+//     a one-line way out of the scan (`rows.forEach(() => this.write(el))` would otherwise
+//     put every write behind a callback the walk refuses to enter);
+//   - a property access on `this` is followed as a possible GETTER, since `if (this.isOpen)`
+//     runs `get isOpen()`'s body, `style` read and all;
+//   - a name resolving to more than one body (two classes in one file with the same method
+//     name) pulls in ALL of them, since guessing between them would silently scan the wrong
+//     one.
+// Every one of those is the OVER-approximating direction: a handler registered during a tick
+// is scanned as though the tick ran it. That is the safe direction for a budget, and it is
+// the same trade the `getUiScale` proxy token in `tests/hud_perf_budget.test.ts` already
+// makes. What it does NOT reach is another MODULE: `this.deps.root()` and an imported helper
+// are out of range, exactly as the per-file scans in that gate are, and a write moved behind
+// one is invisible here. That limit is stated, not implied.
+//
+// THE CUT, and why it is declarable. A driver whose callback calls the module's ordinary
+// full-render entry point reaches the whole module, and counting that would re-litigate the
+// question the cold bucket already settled: a COUNT over a render path fails on every
+// ordinary edit while the hazard it is meant to catch moves no count at all. So `stopAt`
+// names the methods where the walk stops, the caller records WHY next to the name, and the
+// gate fails a cut that turns out to be dead. What survives the cut is the tick's own work,
+// which is the thing the driver is actually responsible for.
+//
+// It takes a STRING rather than a path and knows about no particular module, so the paired
+// test drives it over synthetic sources with planted shapes. This repo's standing lesson
+// about scan guards (#2497, #2499, #2502) is that a producer resolving its own input can
+// only ever be proven against the tree it already passes on.
+
+/** One resolved repeating-driver call site and everything one of its ticks can reach. */
+export interface DriverCallback {
+  /** The driver armed, spelled as the source spells it: `setInterval`, ... */
+  readonly driver: string;
+  /** 1-based line of the driver call, for a failure message only (never pinned). */
+  readonly line: number;
+  /**
+   * The cadence argument when it is a numeric literal (`100`, `15_000`), else null.
+   * `requestAnimationFrame` / `requestIdleCallback` take no delay, so they are always null.
+   * A caller pins this, which is what makes a declared cadence load-bearing rather than a
+   * comment that can drift away from the number beside it.
+   */
+  readonly delayMs: number | null;
+  /** Names of the same-module bodies pulled in, sorted. Empty when the tick calls nothing. */
+  readonly reached: readonly string[];
+  /** The `stopAt` names this callback actually ran into, sorted. A cut not listed here is dead. */
+  readonly stopped: readonly string[];
+  /** The callback body plus every reached body, joined. Comments are NOT stripped. */
+  readonly code: string;
+}
+
+/** Index of every named function body in one module: name -> one or more bodies. */
+type BodyIndex = ReadonlyMap<string, readonly ts.Node[]>;
+
+function addBody(index: Map<string, ts.Node[]>, name: string, body: ts.Node): void {
+  const existing = index.get(name);
+  if (existing) existing.push(body);
+  else index.set(name, [body]);
+}
+
+/**
+ * Every named function body in the file: class methods and get accessors, class properties
+ * initialized to a function, module-level function declarations, and `const f = () => {}`.
+ * Indexed by BARE name, because that is all a call site gives: `this.paintTimer(...)` and
+ * `paintTimer(...)` both resolve here.
+ */
+function indexBodies(sf: ts.SourceFile): BodyIndex {
+  const index = new Map<string, ts.Node[]>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
+      for (const member of node.members) {
+        if (
+          (ts.isMethodDeclaration(member) ||
+            ts.isGetAccessorDeclaration(member) ||
+            ts.isSetAccessorDeclaration(member)) &&
+          member.body
+        ) {
+          addBody(index, member.name.getText(sf), member.body);
+        }
+        if (
+          ts.isPropertyDeclaration(member) &&
+          member.initializer &&
+          (ts.isArrowFunction(member.initializer) || ts.isFunctionExpression(member.initializer))
+        ) {
+          addBody(index, member.name.getText(sf), member.initializer.body);
+        }
+      }
+    }
+    if (ts.isFunctionDeclaration(node) && node.name && node.body) {
+      addBody(index, node.name.text, node.body);
+    }
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const init = node.initializer;
+      if (ts.isArrowFunction(init) || ts.isFunctionExpression(init)) {
+        addBody(index, node.name.text, init.body);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return index;
+}
+
+/** The driver name this call arms, or null: `setInterval(...)` and `window.setInterval(...)`. */
+function armedDriver(call: ts.CallExpression, drivers: ReadonlySet<string>): string | null {
+  const callee = call.expression;
+  if (ts.isIdentifier(callee)) return drivers.has(callee.text) ? callee.text : null;
+  if (ts.isPropertyAccessExpression(callee)) {
+    return drivers.has(callee.name.text) ? callee.name.text : null;
+  }
+  return null;
+}
+
+/**
+ * The callback body, plus the name it was resolved THROUGH when it came from a reference
+ * rather than an inline function (so the walk does not re-enter it as a callee of itself).
+ *
+ * Throws rather than returning null when the argument is a shape it cannot follow. That is
+ * the standing anti-vacuity rule for a source guard: a resolver that shrugged would hand the
+ * gate an empty, passing scan the day someone writes `setInterval(makeTick(this), 100)`.
+ */
+function resolveCallback(
+  arg: ts.Expression | undefined,
+  index: BodyIndex,
+  where: string,
+): { body: ts.Node; seedName: string | null } {
+  if (!arg) {
+    throw new Error(
+      `${where}: the repeating driver was armed with no callback argument, so nothing can be scanned. A driver whose callback cannot be resolved must be a red test, never a quiet zero.`,
+    );
+  }
+  if (ts.isArrowFunction(arg) || ts.isFunctionExpression(arg)) {
+    return { body: arg.body, seedName: null };
+  }
+  // `setInterval(this.tick.bind(this), 100)` is the same callback one wrapper out.
+  if (
+    ts.isCallExpression(arg) &&
+    ts.isPropertyAccessExpression(arg.expression) &&
+    arg.expression.name.text === 'bind'
+  ) {
+    return resolveCallback(arg.expression.expression, index, where);
+  }
+  const name = ts.isIdentifier(arg)
+    ? arg.text
+    : ts.isPropertyAccessExpression(arg)
+      ? arg.name.text
+      : null;
+  const bodies = name === null ? undefined : index.get(name);
+  if (!name || !bodies || bodies.length === 0) {
+    throw new Error(
+      `${where}: the repeating driver's callback (\`${arg.getText(arg.getSourceFile())}\`) does not resolve to a function in this module, so its per-tick work cannot be scanned. Inline the callback, point it at a same-module function, or move the driver somewhere this gate can see it.`,
+    );
+  }
+  // A name with two bodies is scanned as both; the seed keeps the walk from re-adding it.
+  return { body: bodies[0] as ts.Node, seedName: name };
+}
+
+/** The cadence argument, when it is a plain numeric literal. `15_000` counts as 15000. */
+function delayOf(call: ts.CallExpression): number | null {
+  const arg = call.arguments[1];
+  if (!arg || !ts.isNumericLiteral(arg)) return null;
+  const value = Number(arg.text.replace(/_/g, ''));
+  return Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Every callee name the node mentions: a call on `this`, a bare call, and a property access
+ * on `this` (a possible getter). Descends through nested function bodies on purpose; see the
+ * reachability rule at the top of this file.
+ */
+function calleeNames(node: ts.Node): string[] {
+  const names: string[] = [];
+  const visit = (n: ts.Node): void => {
+    if (ts.isCallExpression(n)) {
+      const callee = n.expression;
+      if (
+        ts.isPropertyAccessExpression(callee) &&
+        callee.expression.kind === ts.SyntaxKind.ThisKeyword
+      ) {
+        names.push(callee.name.text);
+      } else if (ts.isIdentifier(callee)) {
+        names.push(callee.text);
+      }
+    } else if (
+      ts.isPropertyAccessExpression(n) &&
+      n.expression.kind === ts.SyntaxKind.ThisKeyword
+    ) {
+      names.push(n.name.text);
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(node);
+  return names;
+}
+
+/**
+ * Resolve every repeating-driver call site in one module, with the code one of its ticks can
+ * reach.
+ *
+ * @param driverNames the driver globals to look for, e.g. `['setInterval']`.
+ * @param stopAt same-module names where the reachability walk stops.
+ */
+export function readDriverCallbacks(
+  fileName: string,
+  source: string,
+  driverNames: readonly string[],
+  stopAt: readonly string[] = [],
+): DriverCallback[] {
+  const sf = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const drivers = new Set(driverNames);
+  const cuts = new Set(stopAt);
+  const index = indexBodies(sf);
+
+  const calls: ts.CallExpression[] = [];
+  const collect = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && armedDriver(node, drivers) !== null) calls.push(node);
+    ts.forEachChild(node, collect);
+  };
+  collect(sf);
+
+  return calls.map((call) => {
+    const driver = armedDriver(call, drivers) as string;
+    const line = sf.getLineAndCharacterOfPosition(call.getStart(sf)).line + 1;
+    const where = `${fileName}:${line}`;
+    const { body, seedName } = resolveCallback(call.arguments[0], index, where);
+
+    const seen = new Set<string>(seedName ? [seedName] : []);
+    const stopped = new Set<string>();
+    const bodies: ts.Node[] = [body];
+    const queue: ts.Node[] = [body];
+    while (queue.length) {
+      const current = queue.shift() as ts.Node;
+      for (const name of calleeNames(current)) {
+        if (cuts.has(name)) {
+          stopped.add(name);
+          continue;
+        }
+        if (seen.has(name)) continue;
+        const found = index.get(name);
+        if (!found || found.length === 0) continue;
+        seen.add(name);
+        for (const reachedBody of found) {
+          bodies.push(reachedBody);
+          queue.push(reachedBody);
+        }
+      }
+    }
+    if (seedName) seen.delete(seedName);
+    return {
+      driver,
+      line,
+      delayMs: delayOf(call),
+      reached: [...seen].sort(),
+      stopped: [...stopped].sort(),
+      code: bodies.map((b) => b.getText(sf)).join('\n'),
+    };
+  });
+}

--- a/tests/hud_perf_budget.test.ts
+++ b/tests/hud_perf_budget.test.ts
@@ -105,6 +105,7 @@ import { type UnitFrameDescriptor, unitFrameView } from '../src/ui/unit_frame';
 import { type UnitFrameElements, UnitFramePainter } from '../src/ui/unit_frame_painter';
 import type { XpBarView } from '../src/ui/xp_bar';
 import { XpBarPainter } from '../src/ui/xp_bar_painter';
+import { readDriverCallbacks } from './helpers/driver_callback_bodies';
 import { assertAllocationStable } from './util/alloc_probe';
 
 // --------------------------------------------------------------------------
@@ -339,6 +340,74 @@ const FRAME_DRIVERS: ReadonlyArray<readonly [string, RegExp]> = [
   ['setInterval', /(?<![\w$])setInterval\b/g],
 ];
 
+// The element RE-QUERY vocabulary, the third matcher family and the one the tables above
+// lacked entirely. A re-query is neither a write nor a layout read, so `querySelector` was in
+// none of the three families and the gate could not see it at any cadence: `lockpick_window`
+// walked the panel subtree three times per 100ms tick until #2516 and nothing said a word.
+// A repeated query is a subtree walk whose result the module already had, which is the
+// canonical src/ui/CLAUDE.md violation ("resolve element refs ONCE into a field").
+//
+// Every arm is the MEMBER form, which is the deliberate difference from the bare-global arms
+// in FORCED_REFLOW_READS. None of these is a global (`querySelector` is always reached off a
+// node or off `document`), so there is no bare call to miss, and the member form still closes
+// the aliasing escape the getComputedStyle arm had, because an alias has to be MADE through a
+// member access (`const q = el.querySelector.bind(el)` counts on the line that makes it).
+// `.closest` is the arm that would have gone the other way: matching the NAME would count a
+// `const closest = nearestTarget(...)` in a game codebase, and this tree already declares a
+// `closest(selector)` member in src/game/touch_router.ts. `.matches` is DELIBERATELY out for
+// the same reason and a worse one: `matchMedia(...).matches` and `regex.matches` are both
+// live here, so the arm would count noise in every direction.
+// `.getElementsByClassName` / `.getElementsByTagName` match nothing in src/ui today, which is
+// exactly when to add an arm rather than after someone reaches for one; both are fixtured
+// below, since a count of zero cannot notice an arm that went dead.
+const ELEMENT_QUERIES: ReadonlyArray<readonly [string, RegExp]> = [
+  ['.querySelector', /\.querySelector\b/g],
+  ['.querySelectorAll', /\.querySelectorAll\b/g],
+  ['.getElementById', /\.getElementById\b/g],
+  ['.getElementsByClassName', /\.getElementsByClassName\b/g],
+  ['.getElementsByTagName', /\.getElementsByTagName\b/g],
+  ['.closest', /\.closest\b/g],
+  [
+    "['computed' query]",
+    /\[\s*['"](?:querySelector|querySelectorAll|getElementById|getElementsByClassName|getElementsByTagName|closest)['"]\s*\]/g,
+  ],
+];
+
+// The IDL-PROPERTY write vocabulary: a DOM mutation that goes through a typed property
+// instead of through `style` / `classList` / an attribute, so RAW_WRITES cannot see it.
+// `btn.disabled = true` is a real per-tick write one property over from `.setAttribute`.
+//
+// THIS FAMILY IS SCANNED ONLY INSIDE A DRIVER CALLBACK, and the reason is measured rather
+// than assumed. #2518 asked whether these belong in RAW_WRITES itself; over the whole tree
+// they do not, and the two halves of the answer are worth writing down.
+//   - RAW_WRITES runs over WHOLE FILES in the hot + canvas buckets, and a bare member-name
+//     matcher over a whole file counts ordinary data fields: `.value` matches the `els.value`
+//     countdown node in lockpick_window and the `o.value` of a view model, `.src` matches a
+//     manifest record, `.selected`/`.checked` match view-model booleans by the dozen in
+//     dungeon_finder_window. `.value` and `.src` are OUT of the list below for that reason,
+//     even inside a callback: an allowance that reads "this driver writes .value once" when
+//     the hit is a field named `value` documents a fiction.
+//   - Adding `.disabled` to RAW_WRITES would ALSO not have caught the case #2518 cites.
+//     `spellbook_window` is a COLD painter, and cold takes no raw-write scan at all, so the
+//     arm would have been added to a scan that never runs over the module in question. That
+//     one is #2519's, and it needs the cadence answer, not a new token.
+// Inside a driver callback the corpus is a few hundred characters and hand-checkable, which
+// is the condition #2518 named, so the collision-prone middle of the list stays out and the
+// rest is counted exactly, like every other allowance here.
+const IDL_WRITES: ReadonlyArray<readonly [string, RegExp]> = [
+  ['.disabled', /\.disabled\b/g],
+  ['.hidden', /\.hidden\b/g],
+  ['.checked', /\.checked\b/g],
+  ['.selected', /\.selected\b/g],
+  ['.readOnly', /\.readOnly\b/g],
+  ['.indeterminate', /\.indeterminate\b/g],
+  ['.srcset', /\.srcset\b/g],
+  [
+    "['computed' idl]",
+    /\[\s*['"](?:disabled|hidden|checked|selected|readOnly|indeterminate|srcset)['"]\s*\]/g,
+  ],
+];
+
 // The CANVAS_PAINTERS identity proof, which is what stops that list from being a
 // no-contract parking space for a module that would otherwise answer to the src/ui module
 // sweep in tests/architecture.test.ts. A registered canvas painter must BOTH name a 2D
@@ -387,11 +456,60 @@ const CANVAS_DRAW_ONLY = 'c.clearRect(0, 0, w, h); c.drawImage(sprite, x, y);';
 // rotting: a granted read that is later deleted fails until the number comes back down.
 type TokenAllowance = Readonly<Partial<Record<string, number>>>;
 
+// WHAT A GRANTED DRIVER ALLOWANCE COSTS, which until #2518 was nothing at all.
+//
+// A `driverAllow: { setInterval: 1 }` entry recorded that a module repaints on a cadence and
+// then implied NOTHING about what runs on that cadence: whatever the callback did was held to
+// no write rule and no query rule, at any speed. lockpick_window is the proof. Its granted
+// interval was documented right here as "the fastest module-owned driver in the bucket", and
+// inside that 100ms callback it re-resolved three element refs with `querySelector` and made
+// an unelided `classList.toggle` on every tick for the whole length of an attempt. Neither
+// was visible to anything: `querySelector` was in none of the three matcher families, and the
+// raw-write scan is waived for cold by design, because a COUNT over a whole window file
+// cannot tell a build-time write from a repeated one.
+//
+// Inside a driver callback it CAN, and that is the whole idea. The corpus is not a file, it
+// is the code one tick executes, so every write in it repeats at the cadence beside it and a
+// count means something. One entry per driver CALL SITE, in source order.
+interface DriverCallbackAllowance {
+  /** Which FRAME_DRIVERS matcher this call site arms. */
+  readonly driver: string;
+  /**
+   * The cadence, in ms, PINNED against the literal in the source (null for a driver that
+   * takes no delay, or a delay that is not a literal). This is what makes the number
+   * load-bearing instead of a comment that drifts: re-tuning a 100ms clock to 16ms fails
+   * here until the entry says so, which is the point at which someone re-reads the counts
+   * below and asks whether they are still cheap enough.
+   */
+  readonly everyMs: number | null;
+  /** What the driver is for, and what its per-tick work is allowed to be. */
+  readonly why: string;
+  /**
+   * Same-module method names where the reachability walk STOPS, each mapped to its reason.
+   *
+   * The knob exists because one shape needs it: a poll whose callback calls the module's
+   * ordinary full-render entry point reaches the entire module, and counting that would
+   * re-run the argument the cold bucket already settled, where a count over a render path
+   * churns on every ordinary edit while the hazard it is meant to catch moves no count at
+   * all. Cutting there leaves the tick's OWN work, which is what the driver is responsible
+   * for. A cut is a conscious diff line with a stated reason, like every allowance here, and
+   * a cut that turns out to be unreachable fails as dead.
+   */
+  readonly stopsAt?: Readonly<Record<string, string>>;
+  /** Counted RAW_WRITES allowance over everything the tick reaches. */
+  readonly writeAllow: TokenAllowance;
+  /** Counted ELEMENT_QUERIES allowance over everything the tick reaches. */
+  readonly queryAllow: TokenAllowance;
+  /** Counted IDL_WRITES allowance over everything the tick reaches. */
+  readonly idlAllow: TokenAllowance;
+}
+
 interface ScannedPainter {
   file: string;
   allow: TokenAllowance;
   reflowAllow: TokenAllowance;
   driverAllow?: TokenAllowance;
+  drivers?: ReadonlyArray<DriverCallbackAllowance>;
 }
 
 // BUCKET 1 of 3, the strictest: the painters held to the full write contract. Mostly
@@ -538,6 +656,7 @@ interface ColdPainter {
   file: string;
   reflowAllow: TokenAllowance;
   driverAllow: TokenAllowance;
+  drivers?: ReadonlyArray<DriverCallbackAllowance>;
 }
 
 const COLD_PAINTER_ALLOWANCES: ReadonlyArray<ColdPainter> = [
@@ -558,13 +677,70 @@ const COLD_PAINTER_ALLOWANCES: ReadonlyArray<ColdPainter> = [
   },
   // Two polls that repaint an OPEN window only: a 15s refresh of the reward state and a 30s
   // countdown tick. Page cadence rather than frame cadence, and both no-op while closed.
-  { file: 'daily_rewards_window.ts', reflowAllow: {}, driverAllow: { setInterval: 2 } },
+  {
+    file: 'daily_rewards_window.ts',
+    reflowAllow: {},
+    driverAllow: { setInterval: 2 },
+    drivers: [
+      {
+        driver: 'setInterval',
+        everyMs: 15_000,
+        why: 'the reward-state refresh: re-fetch status + history and repaint the open window. Its per-tick body is the `isOpen` guard and a call into renderCurrent, the SAME entry point an open or a tab switch takes, so the DOM cost below is the guard only.',
+        stopsAt: {
+          renderCurrent:
+            "the window's ordinary full re-render, shared with toggle() / openStore() / a tab click. Counting a render path per driver would re-run the argument the cold bucket settled (a count over a render churns on every edit and never moves when the real hazard lands); what this entry holds is that the 15s tick does nothing EXTRA on its way there.",
+        },
+        // The one `.style` is the `isOpen` getter reading `root().style.display`, not a write:
+        // this matcher counts ACCESSES, the same way the granted `.scrollTop` reads elsewhere
+        // in this file are half write-backs. It works as a change detector either way.
+        writeAllow: { '.style': 1 },
+        queryAllow: {},
+        idlAllow: {},
+      },
+      {
+        driver: 'setInterval',
+        everyMs: 30_000,
+        why: 'the countdown tick: rewrite the "ends in" labels so the open window does not show a stale time. Reaches paintCountdowns + remainingText and nothing else.',
+        // `.style` is the isOpen guard again; `.textContent` is the countdown label, which
+        // genuinely differs every tick, so it is an unelided write ON PURPOSE at 30s cadence;
+        // `.dataset` is the read of the reset timestamp off each node.
+        writeAllow: { '.style': 1, '.textContent': 1, '.dataset': 1 },
+        // ONE subtree walk per tick to find the countdown nodes. It is a re-query rather than
+        // a cached ref because the nodes are replaced by every repaint of the window; at 30s
+        // that is cheap, and the count is what makes a second one a conscious act.
+        queryAllow: { '.querySelectorAll': 1 },
+        idlAllow: {},
+      },
+    ],
+  },
   { file: 'deeds_window.ts', reflowAllow: { '.scrollTop': 2 }, driverAllow: {} },
   { file: 'dungeon_finder_window.ts', reflowAllow: { '.scrollTop': 2 }, driverAllow: {} },
   // The lockpick clock: a 100ms tick that repaints the remaining-time bar for the duration
   // of one attempt, generation-guarded and cleared on stop. The fastest module-owned driver
   // in the bucket, and the reason setInterval is counted rather than banned.
-  { file: 'hud/delve/lockpick_window.ts', reflowAllow: {}, driverAllow: { setInterval: 1 } },
+  {
+    file: 'hud/delve/lockpick_window.ts',
+    reflowAllow: {},
+    driverAllow: { setInterval: 1 },
+    drivers: [
+      {
+        driver: 'setInterval',
+        everyMs: 100,
+        why: 'the per-step countdown: repaint the remaining-time bar 10x a second for the length of one attempt, generation-guarded so a superseded clock no-ops. The fastest module-owned driver in the bucket, so it is the one whose per-tick work is worth counting most.',
+        // The three writes paintTimer makes, and each is here because it MOVES every tick or
+        // is latched so it does not. Width and label are the countdown by definition; the
+        // urgent class flips at most once per attempt and rides `lastUrgent` rather than a
+        // blind per-tick toggle. Anything beyond these three repeats 10x a second.
+        writeAllow: { '.style': 1, '.textContent': 1, '.classList': 1 },
+        // ZERO, and this is the entry the whole gate is for. Before #2516 this tick walked the
+        // panel subtree four times (three querySelector + the getElementById behind panel())
+        // to re-find nodes it already had, ten times a second. The refs are now resolved once
+        // per board rebuild, at the one innerHTML site that destroys them.
+        queryAllow: {},
+        idlAllow: {},
+      },
+    ],
+  },
   // The three controllers with real layout reads. chat_geometry measures the chat box to
   // clamp a drag or resize; chat_window fits the input and keeps the log pinned to the
   // bottom; fiesta forces one reflow to restart a CSS animation, the same documented trick
@@ -710,8 +886,118 @@ function sweepBucket(
   return { violations, scanned, observed, checked: [...checked] };
 }
 
+// What one tick of a granted driver is allowed to do. The sweep is extracted for the same
+// reason sweepBucket is: everything else about it asserts that a list is empty, which a
+// broken comparator satisfies trivially, so the positive control below drives THIS function
+// over synthetic sources with a planted violation.
+interface DriverBodySweep {
+  violations: string[];
+  /** `file#index` per callback actually scanned, in order. */
+  scanned: string[];
+  /** How many driver call sites were resolved out of real source. */
+  resolved: number;
+  /** Total matches counted, across every family. Zero means the scan read nothing. */
+  observed: number;
+  /** The matcher labels walked, so a truncated family cannot pass by asserting nothing. */
+  checked: string[];
+  /** `file: name` for every declared cut the walk actually ran into. */
+  cuts: string[];
+}
+
+interface DriverHost {
+  readonly file: string;
+  readonly drivers?: ReadonlyArray<DriverCallbackAllowance>;
+}
+
+const DRIVER_BODY_FAMILIES = [
+  ['writeAllow', RAW_WRITES],
+  ['queryAllow', ELEMENT_QUERIES],
+  ['idlAllow', IDL_WRITES],
+] as const;
+
+function sweepDriverBodies(
+  hosts: ReadonlyArray<DriverHost>,
+  read: (file: string) => string,
+): DriverBodySweep {
+  const violations: string[] = [];
+  const scanned: string[] = [];
+  const checked = new Set<string>();
+  const cuts: string[] = [];
+  let resolved = 0;
+  let observed = 0;
+  const driverNames = labelsOf(FRAME_DRIVERS);
+
+  for (const { file, drivers } of hosts) {
+    if (!drivers || drivers.length === 0) continue;
+    const source = read(file);
+    let countMismatch = false;
+    drivers.forEach((grant, index) => {
+      if (countMismatch) return;
+      // Resolved once PER ENTRY with only that entry's cuts, so one grant's declared stop
+      // cannot silently shrink a sibling grant's closure in the same module.
+      const found = readDriverCallbacks(
+        file,
+        source,
+        driverNames,
+        Object.keys(grant.stopsAt ?? {}),
+      );
+      if (found.length !== drivers.length) {
+        violations.push(
+          `${file}: ${drivers.length} driver allowance entr(ies) declared, ${found.length} driver call site(s) in the source`,
+        );
+        countMismatch = true;
+        return;
+      }
+      const callback = found[index] as (typeof found)[number];
+      resolved += 1;
+      scanned.push(`${file}#${index}`);
+      if (callback.driver !== grant.driver) {
+        violations.push(
+          `${file}#${index}: the source arms ${callback.driver}, the allowance declares ${grant.driver}`,
+        );
+      }
+      if (callback.delayMs !== grant.everyMs) {
+        violations.push(
+          `${file}#${index}: ${callback.driver} is armed every ${callback.delayMs}ms, the allowance declares ${grant.everyMs}ms`,
+        );
+      }
+      for (const name of Object.keys(grant.stopsAt ?? {})) {
+        if (callback.stopped.includes(name)) cuts.push(`${file}: ${name}`);
+        else {
+          violations.push(
+            `${file}#${index}: stopsAt names "${name}", which this callback never reaches, so the cut is dead and hides nothing`,
+          );
+        }
+      }
+      const code = stripComments(callback.code);
+      for (const [kind, matchers] of DRIVER_BODY_FAMILIES) {
+        const allow = grant[kind];
+        for (const [token, re] of matchers) {
+          const expected = allow[token] ?? 0;
+          const actual = countMatches(code, re);
+          checked.add(token);
+          observed += actual;
+          if (actual !== expected) {
+            violations.push(
+              `${file}#${index} (${callback.driver} every ${callback.delayMs}ms): ${token} appears ${actual}x on the tick, expected ${expected}`,
+            );
+          }
+        }
+      }
+    });
+  }
+  return { violations, scanned, resolved, observed, checked: [...checked], cuts };
+}
+
 const coldReflowAllowance = new Map(COLD_PAINTER_ALLOWANCES.map((c) => [c.file, c.reflowAllow]));
 const coldDriverAllowance = new Map(COLD_PAINTER_ALLOWANCES.map((c) => [c.file, c.driverAllow]));
+// Every bucket, since a driver allowance is grantable in any of them and the hot/canvas ones
+// hold a hard zero today. Ordered so the pinned scan list below reads in bucket order.
+const DRIVER_HOSTS: ReadonlyArray<DriverHost> = [
+  ...HOT_PAINTERS,
+  ...CANVAS_PAINTERS,
+  ...COLD_PAINTER_ALLOWANCES,
+];
 
 // The per-file scan for one matcher family. It RETURNS the labels it checked so the caller
 // can assert the whole family was walked: every count in the scanned buckets is expected 0
@@ -886,6 +1172,175 @@ describe('hud_perf_budget ARM 1: every src/ui painter holds its bucket contract 
     ).toEqual([]);
   });
 
+  // #2518: a granted driver allowance now costs something. The sweep above says a module
+  // repaints on a cadence; this one says what it is allowed to DO on that cadence.
+  it('a granted repeating driver does only its documented work on each tick', () => {
+    const sweep = sweepDriverBodies(DRIVER_HOSTS, painterSource);
+    expect(sweep.checked, 'the driver-body sweep skipped part of the vocabulary').toEqual([
+      ...labelsOf(RAW_WRITES),
+      ...labelsOf(ELEMENT_QUERIES),
+      ...labelsOf(IDL_WRITES),
+    ]);
+    // NON-VACUITY, and it needs three separate pins because each covers a different way this
+    // sweep could scan nothing while reporting a clean bill of health.
+    //
+    // FIRST, the call sites resolved must match the DRIVER NAMES the other sweep counted.
+    // That is the join between the two gates: FRAME_DRIVERS counts a name, this resolves a
+    // call, and a name that is not a resolvable call (an alias, a driver armed through a
+    // helper) fails here instead of quietly scanning one fewer callback.
+    const grantedDrivers = DRIVER_HOSTS.reduce(
+      (total, host) =>
+        total +
+        Object.values((host as { driverAllow?: TokenAllowance }).driverAllow ?? {}).reduce<number>(
+          (n, granted) => n + (granted ?? 0),
+          0,
+        ),
+      0,
+    );
+    expect(sweep.resolved, 'a granted driver did not resolve to a real call site').toBe(
+      grantedDrivers,
+    );
+    expect(sweep.resolved, 'the driver-body sweep resolved nothing at all').toBeGreaterThan(0);
+    // SECOND, exactly which callbacks were walked, both ways. A host list narrowed to an
+    // empty slice, or a `drivers` list quietly deleted from an entry, reports zero violations
+    // over zero callbacks and reads as a pass.
+    expect(sweep.scanned).toEqual([
+      'daily_rewards_window.ts#0',
+      'daily_rewards_window.ts#1',
+      'hud/delve/lockpick_window.ts#0',
+    ]);
+    // THIRD, the matchers must have seen real source. The positive control is the lockpick
+    // clock, whose three per-tick writes are the reason this gate exists.
+    expect(
+      sweep.observed,
+      'the driver-body sweep matched nothing at all: it read no real source, or the matchers went blind',
+    ).toBeGreaterThan(0);
+    expect(sweep.cuts, 'the one declared reachability cut stopped reaching anything').toEqual([
+      'daily_rewards_window.ts: renderCurrent',
+    ]);
+    expect(
+      sweep.violations,
+      `a repeating driver's callback runs its whole reachable body at the cadence beside it, so every write and every element re-query in there repeats with it. Cache the ref where the subtree that owns it is REBUILT, latch a class that changes at most once, or add a documented, counted entry to the module's \`drivers\` list saying what the tick does and why that is cheap enough:\n${sweep.violations.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  // THE POSITIVE CONTROL for the driver-body sweep. Same reasoning as the bucket sweep's:
+  // the real-tree assertions above are all "this list is empty", so the comparator, the
+  // family loop, the cadence pin and the dead-cut check are each exercised here over
+  // synthetic sources instead.
+  it('the driver-body sweep reports each kind of per-tick violation', () => {
+    // The shape the gate exists for, and it is the shape lockpick_window actually had: the
+    // callback body itself is clean, and the query lives one call away in a method.
+    const leaky = `
+      export class W {
+        private arm(): void {
+          this.iv = window.setInterval(() => {
+            this.paint();
+          }, 100);
+        }
+        private paint(): void {
+          const bar = this.root.querySelector('.bar');
+          if (bar) bar.style.width = '50%';
+        }
+      }`;
+    const host = (drivers: DriverCallbackAllowance[]): DriverHost[] => [
+      { file: 'leaky_window.ts', drivers },
+    ];
+    const grant = (over: Partial<DriverCallbackAllowance> = {}): DriverCallbackAllowance => ({
+      driver: 'setInterval',
+      everyMs: 100,
+      why: 'synthetic',
+      writeAllow: {},
+      queryAllow: {},
+      idlAllow: {},
+      ...over,
+    });
+    const read = () => leaky;
+
+    // A BODY-ONLY scan would report nothing here, which is exactly why this gate walks the
+    // callees: both hits are inside `paint()`, not inside the callback.
+    const unbudgeted = sweepDriverBodies(host([grant()]), read);
+    expect(unbudgeted.violations).toEqual([
+      'leaky_window.ts#0 (setInterval every 100ms): .style appears 1x on the tick, expected 0',
+      'leaky_window.ts#0 (setInterval every 100ms): .querySelector appears 1x on the tick, expected 0',
+    ]);
+    expect(unbudgeted.resolved).toBe(1);
+    expect(unbudgeted.observed).toBe(2);
+
+    // A granted allowance silences exactly those two and nothing else...
+    expect(
+      sweepDriverBodies(
+        host([grant({ writeAllow: { '.style': 1 }, queryAllow: { '.querySelector': 1 } })]),
+        read,
+      ).violations,
+    ).toEqual([]);
+
+    // ...and the count is EXACT in both directions, so a grant for a query that is later
+    // deleted fails until the number comes back down rather than rotting into a free pass.
+    expect(
+      sweepDriverBodies(
+        host([grant({ writeAllow: { '.style': 1 }, queryAllow: { '.querySelector': 2 } })]),
+        read,
+      ).violations,
+    ).toEqual([
+      'leaky_window.ts#0 (setInterval every 100ms): .querySelector appears 1x on the tick, expected 2',
+    ]);
+
+    // The declared cadence is pinned against the literal in the source, so re-tuning a clock
+    // fails until the entry that documents why the counts are cheap enough says so.
+    expect(sweepDriverBodies(host([grant({ everyMs: 1000 })]), read).violations).toContain(
+      'leaky_window.ts#0: setInterval is armed every 100ms, the allowance declares 1000ms',
+    );
+    // ...and so is WHICH driver the site arms.
+    expect(
+      sweepDriverBodies(host([grant({ driver: 'requestAnimationFrame' })]), read).violations,
+    ).toContain(
+      'leaky_window.ts#0: the source arms setInterval, the allowance declares requestAnimationFrame',
+    );
+
+    // A cut silences the method it names...
+    const cut = sweepDriverBodies(host([grant({ stopsAt: { paint: 'synthetic reason' } })]), read);
+    expect(cut.violations).toEqual([]);
+    expect(cut.cuts).toEqual(['leaky_window.ts: paint']);
+    // ...but a cut the callback never reaches is DEAD, and a dead cut is how a stale entry
+    // would sit in the table looking like it was doing something.
+    expect(
+      sweepDriverBodies(host([grant({ stopsAt: { gone: 'synthetic reason' } })]), read).violations,
+    ).toContain(
+      'leaky_window.ts#0: stopsAt names "gone", which this callback never reaches, so the cut is dead and hides nothing',
+    );
+
+    // A declaration that does not match the number of call sites in the source fails before
+    // any count is compared, in BOTH directions.
+    expect(sweepDriverBodies(host([grant(), grant()]), read).violations).toEqual([
+      'leaky_window.ts: 2 driver allowance entr(ies) declared, 1 driver call site(s) in the source',
+    ]);
+    expect(
+      sweepDriverBodies(host([grant()]), () => `${leaky}\nsetInterval(() => {}, 5);`).violations,
+    ).toEqual([
+      'leaky_window.ts: 1 driver allowance entr(ies) declared, 2 driver call site(s) in the source',
+    ]);
+
+    // An IDL write is seen too, which is the half RAW_WRITES cannot name.
+    expect(
+      sweepDriverBodies(host([grant()]), () => 'setInterval(() => { btn.disabled = true; }, 100);')
+        .violations,
+    ).toEqual([
+      'leaky_window.ts#0 (setInterval every 100ms): .disabled appears 1x on the tick, expected 0',
+    ]);
+
+    // A driver whose callback cannot be resolved REFUSES rather than scanning nothing. That
+    // is the standing anti-vacuity rule: a resolver that shrugged would hand this gate an
+    // empty, passing scan the day someone hides the callback behind a factory.
+    expect(() =>
+      sweepDriverBodies(host([grant()]), () => 'setInterval(makeTick(this), 100);'),
+    ).toThrow(/does not resolve to a function in this module/);
+
+    // A host with no `drivers` list contributes nothing, which is what makes the real-tree
+    // `scanned` pin above load-bearing rather than incidental.
+    expect(sweepDriverBodies([{ file: 'quiet_window.ts' }], read).resolved).toBe(0);
+  });
+
   // THE POSITIVE CONTROL for both sweeps above. Everything else about them is an assertion
   // that a list is empty, which a broken comparator satisfies trivially; this drives the same
   // function over synthetic sources and requires it to REPORT.
@@ -964,32 +1419,83 @@ describe('hud_perf_budget ARM 1: every src/ui painter holds its bucket contract 
       onDisk,
       cold,
       // A bad allowance key on a SCANNED entry too, so BOTH halves of the key check are
-      // driven rather than only the cold one.
+      // driven rather than only the cold one. The scanned entry ALSO grants a driver with no
+      // callback allowance behind it, which is the #2518 shape: a cadence granted and the
+      // per-tick contract skipped.
       [
-        { file: 'b_painter.ts', allow: { offsetWidth: 1 }, reflowAllow: {}, driverAllow: {} },
+        {
+          file: 'b_painter.ts',
+          allow: { offsetWidth: 1 },
+          reflowAllow: {},
+          driverAllow: { setInterval: 1 },
+        },
         { file: 'gone_painter.ts', allow: {}, reflowAllow: {}, driverAllow: {} },
       ],
       [{ file: 'b_painter.ts', allow: {}, reflowAllow: {}, driverAllow: {} }],
       [
         { file: 'c_painter.ts', reflowAllow: {}, driverAllow: {} },
-        { file: 'live_window.ts', reflowAllow: { notAToken: 1 }, driverAllow: {} },
+        {
+          file: 'live_window.ts',
+          reflowAllow: { notAToken: 1 },
+          driverAllow: {},
+          // Every predicate on a callback allowance, planted at once: an entry with no driver
+          // granted behind it, a driver name that is not a matcher label, an empty reason, a
+          // cut with no reason, and a bad allowance key.
+          drivers: [
+            {
+              driver: 'setTimeout',
+              everyMs: null,
+              why: '  ',
+              stopsAt: { render: '' },
+              writeAllow: { nope: 1 },
+              queryAllow: {},
+              idlAllow: {},
+            },
+          ],
+        },
       ],
     );
     expect(problems).toEqual([
       'gone_painter.ts (HOT_PAINTERS: not an on-disk src/ui painter)',
       'b_painter.ts (CANVAS_PAINTERS: classified twice)',
       'c_painter.ts (COLD_PAINTER_ALLOWANCES: not a cold painter, so nothing reads it)',
+      'b_painter.ts (drivers: 1 driver(s) granted by driverAllow, 0 callback allowance(s) declared)',
+      'live_window.ts (drivers: 0 driver(s) granted by driverAllow, 1 callback allowance(s) declared)',
+      'live_window.ts#0 (drivers: "setTimeout" is not a driver label)',
+      'live_window.ts#0 (drivers: the granted cadence says what it is for)',
+      'live_window.ts#0 (stopsAt: "render" cuts the walk with no reason)',
       'b_painter.ts (allow: "offsetWidth" is not a matcher label, so nothing reads it)',
       'live_window.ts (reflowAllow: "notAToken" is not a matcher label, so nothing reads it)',
+      'live_window.ts#0 (writeAllow: "nope" is not a matcher label, so nothing reads it)',
     ]);
-    // ...and it stays silent on a well-formed set, so it is not simply always noisy.
+    // ...and it stays silent on a well-formed set, so it is not simply always noisy. The
+    // well-formed driver entry keys all THREE new allowance maps with real labels, which is
+    // what keeps each of the three label sets load-bearing: point `queryAllow` at the
+    // raw-write labels and this arm goes red.
     expect(
       registrationProblems(
         onDisk,
         cold,
         [{ file: 'b_painter.ts', allow: { '.style': 1 }, reflowAllow: {}, driverAllow: {} }],
         [{ file: 'c_painter.ts', allow: {}, reflowAllow: {}, driverAllow: {} }],
-        [{ file: 'a_window.ts', reflowAllow: { '.scrollTop': 2 }, driverAllow: {} }],
+        [
+          {
+            file: 'a_window.ts',
+            reflowAllow: { '.scrollTop': 2 },
+            driverAllow: { setInterval: 1 },
+            drivers: [
+              {
+                driver: 'setInterval',
+                everyMs: 1000,
+                why: 'synthetic',
+                stopsAt: { render: 'synthetic' },
+                writeAllow: { '.style': 1 },
+                queryAllow: { '.querySelector': 1 },
+                idlAllow: { '.disabled': 1 },
+              },
+            ],
+          },
+        ],
       ),
     ).toEqual([]);
   });
@@ -1033,10 +1539,51 @@ function registrationProblems(
     // checks, is looked up, misses, and silently degrades that token back to an expected 0.
     // Today that fails loudly only by luck, because the real count then mismatches; a typo on
     // a token the file happens not to use would be invisible.
+    // #2518: a granted driver must ALSO declare what its callback does, one entry per call
+    // site. Without this the new scan would be opt-in: `driverAllow: { setInterval: 1 }` with
+    // no `drivers` list would grant the cadence and skip the per-tick contract entirely,
+    // which is precisely the permission-slip-with-no-contract shape the issue is about. The
+    // count is exact in both directions, so a deleted entry and a leftover one both fail.
+    const driverHosts: ReadonlyArray<DriverHost & { driverAllow?: TokenAllowance }> = [
+      ...hot,
+      ...canvas,
+      ...coldAllowances,
+    ];
+    const driverLabels = new Set(FRAME_DRIVERS.map(([label]) => label));
+    for (const host of driverHosts) {
+      const granted = Object.values(host.driverAllow ?? {}).reduce<number>(
+        (total, n) => total + (n ?? 0),
+        0,
+      );
+      const declaredCallbacks = host.drivers?.length ?? 0;
+      if (granted !== declaredCallbacks) {
+        problems.push(
+          `${host.file} (drivers: ${granted} driver(s) granted by driverAllow, ${declaredCallbacks} callback allowance(s) declared)`,
+        );
+      }
+      for (const [index, grant] of (host.drivers ?? []).entries()) {
+        if (!driverLabels.has(grant.driver)) {
+          problems.push(`${host.file}#${index} (drivers: "${grant.driver}" is not a driver label)`);
+        }
+        if (!grant.why.trim()) {
+          problems.push(`${host.file}#${index} (drivers: the granted cadence says what it is for)`);
+        }
+        for (const [name, reason] of Object.entries(grant.stopsAt ?? {})) {
+          if (!reason.trim()) {
+            problems.push(
+              `${host.file}#${index} (stopsAt: "${name}" cuts the walk with no reason)`,
+            );
+          }
+        }
+      }
+    }
     const known = {
       allow: new Set(RAW_WRITES.map(([label]) => label)),
       reflowAllow: new Set(FORCED_REFLOW_READS.map(([label]) => label)),
       driverAllow: new Set(FRAME_DRIVERS.map(([label]) => label)),
+      writeAllow: new Set(RAW_WRITES.map(([label]) => label)),
+      queryAllow: new Set(ELEMENT_QUERIES.map(([label]) => label)),
+      idlAllow: new Set(IDL_WRITES.map(([label]) => label)),
     };
     const declared: ReadonlyArray<readonly [string, string, TokenAllowance]> = [
       ...[...hot, ...canvas].flatMap((p) => [
@@ -1048,6 +1595,13 @@ function registrationProblems(
         ['reflowAllow', c.file, c.reflowAllow] as const,
         ['driverAllow', c.file, c.driverAllow] as const,
       ]),
+      ...driverHosts.flatMap((host) =>
+        (host.drivers ?? []).flatMap((grant, index) => [
+          ['writeAllow', `${host.file}#${index}`, grant.writeAllow] as const,
+          ['queryAllow', `${host.file}#${index}`, grant.queryAllow] as const,
+          ['idlAllow', `${host.file}#${index}`, grant.idlAllow] as const,
+        ]),
+      ),
     ];
     for (const [kind, file, allowance] of declared) {
       const labels = known[kind as keyof typeof known];
@@ -1249,6 +1803,81 @@ describe('hud_perf_budget ARM 1 (cont.): the matchers themselves', () => {
       expect(countMatches(negative, re), `${label} must not count: ${negative}`).toBe(0);
     }
 
+    // The two families #2518 added, both scanned ONLY inside a driver callback, so on the
+    // real tree every arm but two counts zero and the counts can notice nothing. Fixtures
+    // are the whole cover here, and the negatives are the point of each arm: the query arms
+    // must not fire on a longer identifier, and `.closest` must not fire on the bare word,
+    // which is why it is the one query arm matched as a MEMBER only.
+    const queries = new Map(ELEMENT_QUERIES);
+    const queryFixtures: ReadonlyArray<readonly [string, string, string]> = [
+      ['.querySelector', "root.querySelector('.bar')", 'el.querySelectorish(x)'],
+      ['.querySelectorAll', "root.querySelectorAll('[data-x]')", 'el.querySelectorAllish(x)'],
+      ['.getElementById', "document.getElementById('lockpick-panel')", 'doc.getElementByIdish(x)'],
+      ['.getElementsByClassName', "root.getElementsByClassName('lp')", 'el.getElementsByClass(x)'],
+      ['.getElementsByTagName', "root.getElementsByTagName('li')", 'el.getElementsByTag(x)'],
+      ['.closest', "target.closest('.window.panel')", 'const closest = nearestTarget(p);'],
+      ["['computed' query]", "el['querySelector']('.bar')", "el['querySelectorish']()"],
+    ];
+    for (const [label, positive, negative] of queryFixtures) {
+      const re = queries.get(label);
+      expect(re, `the ${label} arm must exist`).toBeDefined();
+      if (!re) continue;
+      expect(countMatches(positive, re), `${label} must count: ${positive}`).toBe(1);
+      expect(countMatches(negative, re), `${label} must not count: ${negative}`).toBe(0);
+    }
+    // `.querySelector` must not double-count a `querySelectorAll`, since the two arms are
+    // budgeted separately and one swallowing the other would make both numbers fiction.
+    const qs = queries.get('.querySelector');
+    expect(qs && countMatches("root.querySelectorAll('[data-x]')", qs)).toBe(0);
+    // The computed arm must cover EVERY dot arm above, the hole the raw-write computed arm
+    // shipped with twice.
+    const computedQuery = queries.get("['computed' query]");
+    for (const [label] of queryFixtures.filter(([l]) => l !== "['computed' query]")) {
+      const member = label.slice(1);
+      expect(
+        computedQuery && countMatches(`el['${member}']()`, computedQuery),
+        `the computed query arm must cover ${label}`,
+      ).toBe(1);
+    }
+    // NON-VACUITY against the live tree for the arm that motivated the family: the
+    // pre-#2516 lockpick clock re-queried its refs three times per tick, and
+    // daily_rewards' countdown poll still walks the subtree once per tick today. If the
+    // querySelectorAll arm were re-narrowed it would count 0 here and pass quietly.
+    const qsa = queries.get('.querySelectorAll');
+    expect(qsa && countMatches(painterSource('daily_rewards_window.ts'), qsa)).toBeGreaterThan(0);
+
+    const idl = new Map(IDL_WRITES);
+    const idlFixtures: ReadonlyArray<readonly [string, string, string]> = [
+      ['.disabled', 'btn.disabled = true;', 'const d = row.disabledAt;'],
+      ['.hidden', 'el.hidden = !visible;', 'const h = view.hiddenRows;'],
+      ['.checked', 'input.checked = on;', 'const c = opt.checkedAt;'],
+      ['.selected', 'opt.selected = true;', 'const s = view.selectedIndex;'],
+      ['.readOnly', 'input.readOnly = true;', 'const r = opts.readOnlyish;'],
+      ['.indeterminate', 'box.indeterminate = true;', 'const i = x.indeterminateish;'],
+      ['.srcset', 'img.srcset = urls;', 'const s = img.srcsetOf;'],
+      ["['computed' idl]", "btn['disabled'] = true;", "btn['disabledAt'] = 1;"],
+    ];
+    for (const [label, positive, negative] of idlFixtures) {
+      const re = idl.get(label);
+      expect(re, `the ${label} arm must exist`).toBeDefined();
+      if (!re) continue;
+      expect(countMatches(positive, re), `${label} must count: ${positive}`).toBe(1);
+      expect(countMatches(negative, re), `${label} must not count: ${negative}`).toBe(0);
+    }
+    const computedIdl = idl.get("['computed' idl]");
+    for (const [label] of idlFixtures.filter(([l]) => l !== "['computed' idl]")) {
+      expect(
+        computedIdl && countMatches(`el['${label.slice(1)}'] = x;`, computedIdl),
+        `the computed idl arm must cover ${label}`,
+      ).toBe(1);
+    }
+    // The two properties DELIBERATELY out of IDL_WRITES, pinned as absent rather than left
+    // to a reader to notice. Both collide with ordinary field names in this very tree
+    // (`els.value` is the lockpick countdown node), so an allowance counting them would
+    // document a fiction. If a future case needs them, this is the assertion to argue with.
+    expect(labelsOf(IDL_WRITES)).not.toContain('.value');
+    expect(labelsOf(IDL_WRITES)).not.toContain('.src');
+
     // COVERAGE OF THE FIXTURE TABLES THEMSELVES, which is the hole all three loops share:
     // each walks the FIXTURE list and looks the regex up by label, so an arm added to a family
     // without a fixture is never visited and nothing says so. The identity pins below would
@@ -1261,6 +1890,8 @@ describe('hud_perf_budget ARM 1 (cont.): the matchers themselves', () => {
     expect(new Set(writeFixtures.map(([label]) => label))).toEqual(new Set(labelsOf(RAW_WRITES)));
     expect(reflowFixtures.map(([label]) => label)).toEqual(labelsOf(FORCED_REFLOW_READS));
     expect(driverFixtures.map(([label]) => label)).toEqual(labelsOf(FRAME_DRIVERS));
+    expect(queryFixtures.map(([label]) => label)).toEqual(labelsOf(ELEMENT_QUERIES));
+    expect(idlFixtures.map(([label]) => label)).toEqual(labelsOf(IDL_WRITES));
 
     // Identity pins. Each arm is wired in by the regex OBJECT, not by its label, so a
     // weakened or dead arm cannot be swapped in behind a label that still reads right. The
@@ -1310,6 +1941,35 @@ describe('hud_perf_budget ARM 1 (cont.): the matchers themselves', () => {
       ['requestAnimationFrame', /(?<![\w$])requestAnimationFrame\b/g],
       ['requestIdleCallback', /(?<![\w$])requestIdleCallback\b/g],
       ['setInterval', /(?<![\w$])setInterval\b/g],
+    ]);
+    // The two #2518 families take the same identity pin, and they need it MORE than the
+    // others: they are scanned over driver callbacks only, so all but two of their arms
+    // count zero on the real tree and a dead arm swapped in behind a label that still reads
+    // right would be invisible to every count in the file.
+    expect(ELEMENT_QUERIES).toEqual([
+      ['.querySelector', /\.querySelector\b/g],
+      ['.querySelectorAll', /\.querySelectorAll\b/g],
+      ['.getElementById', /\.getElementById\b/g],
+      ['.getElementsByClassName', /\.getElementsByClassName\b/g],
+      ['.getElementsByTagName', /\.getElementsByTagName\b/g],
+      ['.closest', /\.closest\b/g],
+      [
+        "['computed' query]",
+        /\[\s*['"](?:querySelector|querySelectorAll|getElementById|getElementsByClassName|getElementsByTagName|closest)['"]\s*\]/g,
+      ],
+    ]);
+    expect(IDL_WRITES).toEqual([
+      ['.disabled', /\.disabled\b/g],
+      ['.hidden', /\.hidden\b/g],
+      ['.checked', /\.checked\b/g],
+      ['.selected', /\.selected\b/g],
+      ['.readOnly', /\.readOnly\b/g],
+      ['.indeterminate', /\.indeterminate\b/g],
+      ['.srcset', /\.srcset\b/g],
+      [
+        "['computed' idl]",
+        /\[\s*['"](?:disabled|hidden|checked|selected|readOnly|indeterminate|srcset)['"]\s*\]/g,
+      ],
     ]);
   });
 });

--- a/tests/hud_perf_budget.test.ts
+++ b/tests/hud_perf_budget.test.ts
@@ -343,7 +343,7 @@ const FRAME_DRIVERS: ReadonlyArray<readonly [string, RegExp]> = [
 // The element RE-QUERY vocabulary, the third matcher family and the one the tables above
 // lacked entirely. A re-query is neither a write nor a layout read, so `querySelector` was in
 // none of the three families and the gate could not see it at any cadence: `lockpick_window`
-// walked the panel subtree three times per 100ms tick until #2516 and nothing said a word.
+// walked the panel subtree three times per 100ms tick until #2498 and nothing said a word.
 // A repeated query is a subtree walk whose result the module already had, which is the
 // canonical src/ui/CLAUDE.md violation ("resolve element refs ONCE into a field").
 //
@@ -366,10 +366,12 @@ const ELEMENT_QUERIES: ReadonlyArray<readonly [string, RegExp]> = [
   ['.getElementById', /\.getElementById\b/g],
   ['.getElementsByClassName', /\.getElementsByClassName\b/g],
   ['.getElementsByTagName', /\.getElementsByTagName\b/g],
+  ['.getElementsByTagNameNS', /\.getElementsByTagNameNS\b/g],
+  ['.getElementsByName', /\.getElementsByName\b/g],
   ['.closest', /\.closest\b/g],
   [
     "['computed' query]",
-    /\[\s*['"](?:querySelector|querySelectorAll|getElementById|getElementsByClassName|getElementsByTagName|closest)['"]\s*\]/g,
+    /\[\s*['"](?:querySelector|querySelectorAll|getElementById|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getElementsByName|closest)['"]\s*\]/g,
   ],
 ];
 
@@ -402,9 +404,16 @@ const IDL_WRITES: ReadonlyArray<readonly [string, RegExp]> = [
   ['.readOnly', /\.readOnly\b/g],
   ['.indeterminate', /\.indeterminate\b/g],
   ['.srcset', /\.srcset\b/g],
+  // The two a11y-carrying IDL writes, in for a reason the collision argument above does not
+  // cover: a per-tick `ariaLabel` or `tabIndex` write is the shape that most deserves counting,
+  // since it churns the accessibility tree rather than just a pixel. `.title`, `.alt` and
+  // `.placeholder` stay OUT with `.value` and `.src`: all three are ordinary record field names
+  // in this tree (yumi_match_painter alone writes `.title` three times as data).
+  ['.ariaLabel', /\.ariaLabel\b/g],
+  ['.tabIndex', /\.tabIndex\b/g],
   [
     "['computed' idl]",
-    /\[\s*['"](?:disabled|hidden|checked|selected|readOnly|indeterminate|srcset)['"]\s*\]/g,
+    /\[\s*['"](?:disabled|hidden|checked|selected|readOnly|indeterminate|srcset|ariaLabel|tabIndex)['"]\s*\]/g,
   ],
 ];
 
@@ -502,6 +511,12 @@ interface DriverCallbackAllowance {
   readonly queryAllow: TokenAllowance;
   /** Counted IDL_WRITES allowance over everything the tick reaches. */
   readonly idlAllow: TokenAllowance;
+  /**
+   * Counted FORCED_REFLOW_READS allowance over everything the tick reaches. Separate from the
+   * per-FILE reflowAllow beside it, and not redundant with it: that one says the module makes N
+   * layout reads, this one says how many of them happen on a tick.
+   */
+  readonly reflowAllow: TokenAllowance;
 }
 
 interface ScannedPainter {
@@ -696,11 +711,12 @@ const COLD_PAINTER_ALLOWANCES: ReadonlyArray<ColdPainter> = [
         writeAllow: { '.style': 1 },
         queryAllow: {},
         idlAllow: {},
+        reflowAllow: {},
       },
       {
         driver: 'setInterval',
         everyMs: 30_000,
-        why: 'the countdown tick: rewrite the "ends in" labels so the open window does not show a stale time. Reaches paintCountdowns + remainingText and nothing else.',
+        why: 'the countdown tick: rewrite the "ends in" labels so the open window does not show a stale time. Reaches the `isOpen` guard plus paintCountdowns and its remainingText formatter.',
         // `.style` is the isOpen guard again; `.textContent` is the countdown label, which
         // genuinely differs every tick, so it is an unelided write ON PURPOSE at 30s cadence;
         // `.dataset` is the read of the reset timestamp off each node.
@@ -710,6 +726,7 @@ const COLD_PAINTER_ALLOWANCES: ReadonlyArray<ColdPainter> = [
         // that is cheap, and the count is what makes a second one a conscious act.
         queryAllow: { '.querySelectorAll': 1 },
         idlAllow: {},
+        reflowAllow: {},
       },
     ],
   },
@@ -732,12 +749,16 @@ const COLD_PAINTER_ALLOWANCES: ReadonlyArray<ColdPainter> = [
         // urgent class flips at most once per attempt and rides `lastUrgent` rather than a
         // blind per-tick toggle. Anything beyond these three repeats 10x a second.
         writeAllow: { '.style': 1, '.textContent': 1, '.classList': 1 },
-        // ZERO, and this is the entry the whole gate is for. Before #2516 this tick walked the
+        // ZERO, and this is the entry the whole gate is for. Before #2498 this tick walked the
         // panel subtree four times (three querySelector + the getElementById behind panel())
         // to re-find nodes it already had, ten times a second. The refs are now resolved once
         // per board rebuild, at the one innerHTML site that destroys them.
         queryAllow: {},
         idlAllow: {},
+        // Zero, and worth stating: the countdown writes a width but never READS one back. A
+        // layout read here would flush pending layout ten times a second, the same thrash the
+        // per-file scan bans on a redraw, only faster.
+        reflowAllow: {},
       },
     ],
   },
@@ -807,8 +828,12 @@ function countMatches(code: string, re: RegExp): number {
   return (code.match(re) ?? []).length;
 }
 
+function painterRawSource(file: string): string {
+  return readFileSync(new URL(`../src/ui/${file}`, import.meta.url), 'utf8');
+}
+
 function painterSource(file: string): string {
-  return stripComments(readFileSync(new URL(`../src/ui/${file}`, import.meta.url), 'utf8'));
+  return stripComments(painterRawSource(file));
 }
 
 // The painter half of the src/ui classification: these two suffixes are what make a module
@@ -909,10 +934,17 @@ interface DriverHost {
   readonly drivers?: ReadonlyArray<DriverCallbackAllowance>;
 }
 
+// All FOUR families, and the reflow one is here for the same reason the whole gate is. A
+// granted per-file `reflowAllow` says a module makes N layout reads and, exactly like a granted
+// driver before #2518, implies nothing about WHEN: a read granted for a rebuild can migrate
+// into a 100ms tick and move no count anywhere. It is free today, because no entry has both a
+// non-empty reflowAllow and a non-empty driverAllow, which is precisely when to add it rather
+// than after the first module that has both.
 const DRIVER_BODY_FAMILIES = [
   ['writeAllow', RAW_WRITES],
   ['queryAllow', ELEMENT_QUERIES],
   ['idlAllow', IDL_WRITES],
+  ['reflowAllow', FORCED_REFLOW_READS],
 ] as const;
 
 function sweepDriverBodies(
@@ -934,7 +966,15 @@ function sweepDriverBodies(
     drivers.forEach((grant, index) => {
       if (countMismatch) return;
       // Resolved once PER ENTRY with only that entry's cuts, so one grant's declared stop
-      // cannot silently shrink a sibling grant's closure in the same module.
+      // cannot silently shrink a sibling grant's closure in the same module. Pinned by the
+      // two-driver synthetic in the positive control, where entry #0 cuts a method entry #1
+      // must still be scanned through.
+      //
+      // The source handed in is RAW, never comment-stripped: stripComments is a regex whose
+      // `//` arm would truncate a line at a `//` inside a string or a template literal, and
+      // ts.createSourceFile does not throw on the broken tree that results, it just silently
+      // loses a call site. The parse gets real source; only the RESOLVED tick corpus is
+      // stripped, below.
       const found = readDriverCallbacks(
         file,
         source,
@@ -951,6 +991,7 @@ function sweepDriverBodies(
       const callback = found[index] as (typeof found)[number];
       resolved += 1;
       scanned.push(`${file}#${index}`);
+      const at = `${file}#${index} (${callback.driver} every ${callback.delayMs}ms, line ${callback.line})`;
       if (callback.driver !== grant.driver) {
         violations.push(
           `${file}#${index}: the source arms ${callback.driver}, the allowance declares ${grant.driver}`,
@@ -978,9 +1019,7 @@ function sweepDriverBodies(
           checked.add(token);
           observed += actual;
           if (actual !== expected) {
-            violations.push(
-              `${file}#${index} (${callback.driver} every ${callback.delayMs}ms): ${token} appears ${actual}x on the tick, expected ${expected}`,
-            );
+            violations.push(`${at}: ${token} appears ${actual}x on the tick, expected ${expected}`);
           }
         }
       }
@@ -1175,11 +1214,20 @@ describe('hud_perf_budget ARM 1: every src/ui painter holds its bucket contract 
   // #2518: a granted driver allowance now costs something. The sweep above says a module
   // repaints on a cadence; this one says what it is allowed to DO on that cadence.
   it('a granted repeating driver does only its documented work on each tick', () => {
-    const sweep = sweepDriverBodies(DRIVER_HOSTS, painterSource);
+    const sweep = sweepDriverBodies(DRIVER_HOSTS, painterRawSource);
     expect(sweep.checked, 'the driver-body sweep skipped part of the vocabulary').toEqual([
       ...labelsOf(RAW_WRITES),
       ...labelsOf(ELEMENT_QUERIES),
       ...labelsOf(IDL_WRITES),
+      ...labelsOf(FORCED_REFLOW_READS),
+    ]);
+    // ...and the family table itself is pinned, so the loop above cannot be satisfied by a
+    // table that quietly lost the family it was supposed to walk.
+    expect(DRIVER_BODY_FAMILIES.map(([kind]) => kind)).toEqual([
+      'writeAllow',
+      'queryAllow',
+      'idlAllow',
+      'reflowAllow',
     ]);
     // NON-VACUITY, and it needs three separate pins because each covers a different way this
     // sweep could scan nothing while reporting a clean bill of health.
@@ -1188,6 +1236,12 @@ describe('hud_perf_budget ARM 1: every src/ui painter holds its bucket contract 
     // That is the join between the two gates: FRAME_DRIVERS counts a name, this resolves a
     // call, and a name that is not a resolvable call (an alias, a driver armed through a
     // helper) fails here instead of quietly scanning one fewer callback.
+    // A CONSTRAINT THIS JOIN IMPOSES, stated so it is a decision rather than a trap: driverAllow
+    // counts NAME occurrences while this counts CALL SITES, so a module that mentions a driver
+    // name without calling it (`typeof requestAnimationFrame === 'function'`) would need more
+    // granted names than it has call sites and could not satisfy both halves. No such module
+    // exists in src/ui, and the strictness is what makes an unresolvable driver loud; the day
+    // one does, this is the join that gets a documented exception rather than a quiet loosening.
     const grantedDrivers = DRIVER_HOSTS.reduce(
       (total, host) =>
         total +
@@ -1215,6 +1269,18 @@ describe('hud_perf_budget ARM 1: every src/ui painter holds its bucket contract 
       sweep.observed,
       'the driver-body sweep matched nothing at all: it read no real source, or the matchers went blind',
     ).toBeGreaterThan(0);
+    // The hot and canvas buckets contribute ZERO callbacks today, so narrowing DRIVER_HOSTS to
+    // the cold bucket alone would keep every other assertion here green while a future
+    // hot-bucket driver grant went unscanned. Pinned by length, both ways.
+    expect(DRIVER_HOSTS.length).toBe(
+      HOT_PAINTERS.length + CANVAS_PAINTERS.length + COLD_PAINTER_ALLOWANCES.length,
+    );
+    expect(DRIVER_HOSTS.map((h) => h.file)).toContain('xp_bar_painter.ts');
+    expect(DRIVER_HOSTS.map((h) => h.file)).toContain('minimap_painter.ts');
+    // THE CUT REGISTRY, and it is doing more work than it looks. `stopsAt` is the one knob here
+    // that could re-open #2518 a level up (name the method that does the work, zero the budget),
+    // and this exact-list pin is what stops it being cheap: a cut added anywhere in any bucket
+    // shows up as a new row and fails until it is argued for in the diff.
     expect(sweep.cuts, 'the one declared reachability cut stopped reaching anything').toEqual([
       'daily_rewards_window.ts: renderCurrent',
     ]);
@@ -1253,6 +1319,7 @@ describe('hud_perf_budget ARM 1: every src/ui painter holds its bucket contract 
       writeAllow: {},
       queryAllow: {},
       idlAllow: {},
+      reflowAllow: {},
       ...over,
     });
     const read = () => leaky;
@@ -1261,8 +1328,8 @@ describe('hud_perf_budget ARM 1: every src/ui painter holds its bucket contract 
     // callees: both hits are inside `paint()`, not inside the callback.
     const unbudgeted = sweepDriverBodies(host([grant()]), read);
     expect(unbudgeted.violations).toEqual([
-      'leaky_window.ts#0 (setInterval every 100ms): .style appears 1x on the tick, expected 0',
-      'leaky_window.ts#0 (setInterval every 100ms): .querySelector appears 1x on the tick, expected 0',
+      'leaky_window.ts#0 (setInterval every 100ms, line 4): .style appears 1x on the tick, expected 0',
+      'leaky_window.ts#0 (setInterval every 100ms, line 4): .querySelector appears 1x on the tick, expected 0',
     ]);
     expect(unbudgeted.resolved).toBe(1);
     expect(unbudgeted.observed).toBe(2);
@@ -1283,7 +1350,7 @@ describe('hud_perf_budget ARM 1: every src/ui painter holds its bucket contract 
         read,
       ).violations,
     ).toEqual([
-      'leaky_window.ts#0 (setInterval every 100ms): .querySelector appears 1x on the tick, expected 2',
+      'leaky_window.ts#0 (setInterval every 100ms, line 4): .querySelector appears 1x on the tick, expected 2',
     ]);
 
     // The declared cadence is pinned against the literal in the source, so re-tuning a clock
@@ -1326,7 +1393,7 @@ describe('hud_perf_budget ARM 1: every src/ui painter holds its bucket contract 
       sweepDriverBodies(host([grant()]), () => 'setInterval(() => { btn.disabled = true; }, 100);')
         .violations,
     ).toEqual([
-      'leaky_window.ts#0 (setInterval every 100ms): .disabled appears 1x on the tick, expected 0',
+      'leaky_window.ts#0 (setInterval every 100ms, line 1): .disabled appears 1x on the tick, expected 0',
     ]);
 
     // A driver whose callback cannot be resolved REFUSES rather than scanning nothing. That
@@ -1335,6 +1402,87 @@ describe('hud_perf_budget ARM 1: every src/ui painter holds its bucket contract 
     expect(() =>
       sweepDriverBodies(host([grant()]), () => 'setInterval(makeTick(this), 100);'),
     ).toThrow(/does not resolve to a function in this module/);
+
+    // A layout read on a tick is reported too. On the real tree that family counts zero for
+    // every granted driver, so nothing else here would notice it going dead.
+    expect(
+      sweepDriverBodies(
+        host([grant()]),
+        () => 'setInterval(() => { void el.getBoundingClientRect(); }, 100);',
+      ).violations,
+    ).toEqual([
+      'leaky_window.ts#0 (setInterval every 100ms, line 1): .getBoundingClientRect appears 1x on the tick, expected 0',
+    ]);
+
+    // A COMMENT inside the tick is not source. The corpus is stripped before counting, so
+    // prose about a `querySelector` the module no longer makes cannot fail the budget, and a
+    // banned call cannot be smuggled past a reviewer's eye in a commented-out line either.
+    expect(
+      sweepDriverBodies(
+        host([grant()]),
+        () => 'setInterval(() => { /* querySelector */ void 0; }, 100);',
+      ).violations,
+    ).toEqual([]);
+
+    // ONE GRANT'S CUT MUST NOT SHRINK ITS SIBLING'S CLOSURE. Two call sites in one module,
+    // both reaching the same method: entry #0 cuts it, entry #1 does not, so the query inside
+    // it must still be reported against entry #1. Resolving once with the UNION of every
+    // entry's cuts would silence it, and on the real tree that shortcut is invisible because
+    // the 30s poll happens not to reach what the 15s poll cuts.
+    const twoDrivers = `
+      export class W {
+        private arm(): void {
+          setInterval(() => this.paint(), 100);
+          setInterval(() => this.paint(), 200);
+        }
+        private paint(): void { void this.root.querySelector('.bar'); }
+      }`;
+    const siblings = sweepDriverBodies(
+      [
+        {
+          file: 'two_window.ts',
+          drivers: [
+            grant({ stopsAt: { paint: 'synthetic reason' } }),
+            grant({ everyMs: 200, queryAllow: {} }),
+          ],
+        },
+      ],
+      () => twoDrivers,
+    );
+    expect(siblings.violations).toEqual([
+      'two_window.ts#1 (setInterval every 200ms, line 5): .querySelector appears 1x on the tick, expected 0',
+    ]);
+    expect(siblings.cuts).toEqual(['two_window.ts: paint']);
+
+    // The `everyMs: null` arm of the cadence comparator, which no live entry exercises: a
+    // driver with no delay argument matches null, and a null against a number reports.
+    const rafSource = 'requestAnimationFrame(() => { void el.querySelector("x"); });';
+    expect(
+      sweepDriverBodies(
+        host([
+          grant({
+            driver: 'requestAnimationFrame',
+            everyMs: null,
+            queryAllow: { '.querySelector': 1 },
+          }),
+        ]),
+        () => rafSource,
+      ).violations,
+    ).toEqual([]);
+    expect(
+      sweepDriverBodies(
+        host([
+          grant({
+            driver: 'requestAnimationFrame',
+            everyMs: 16,
+            queryAllow: { '.querySelector': 1 },
+          }),
+        ]),
+        () => rafSource,
+      ).violations,
+    ).toEqual([
+      'leaky_window.ts#0: requestAnimationFrame is armed every nullms, the allowance declares 16ms',
+    ]);
 
     // A host with no `drivers` list contributes nothing, which is what makes the real-tree
     // `scanned` pin above load-bearing rather than incidental.
@@ -1450,6 +1598,18 @@ describe('hud_perf_budget ARM 1: every src/ui painter holds its bucket contract 
               writeAllow: { nope: 1 },
               queryAllow: {},
               idlAllow: {},
+              reflowAllow: {},
+            },
+            // A setInterval grant that declares no cadence, so the counts beside it would be
+            // per nothing.
+            {
+              driver: 'setInterval',
+              everyMs: null,
+              why: 'synthetic',
+              writeAllow: {},
+              queryAllow: {},
+              idlAllow: {},
+              reflowAllow: {},
             },
           ],
         },
@@ -1460,17 +1620,18 @@ describe('hud_perf_budget ARM 1: every src/ui painter holds its bucket contract 
       'b_painter.ts (CANVAS_PAINTERS: classified twice)',
       'c_painter.ts (COLD_PAINTER_ALLOWANCES: not a cold painter, so nothing reads it)',
       'b_painter.ts (drivers: 1 driver(s) granted by driverAllow, 0 callback allowance(s) declared)',
-      'live_window.ts (drivers: 0 driver(s) granted by driverAllow, 1 callback allowance(s) declared)',
+      'live_window.ts (drivers: 0 driver(s) granted by driverAllow, 2 callback allowance(s) declared)',
       'live_window.ts#0 (drivers: "setTimeout" is not a driver label)',
       'live_window.ts#0 (drivers: the granted cadence says what it is for)',
       'live_window.ts#0 (stopsAt: "render" cuts the walk with no reason)',
+      'live_window.ts#1 (drivers: a setInterval grant must declare its cadence; hoist the delay to a literal or a module-level const so it can be pinned)',
       'b_painter.ts (allow: "offsetWidth" is not a matcher label, so nothing reads it)',
       'live_window.ts (reflowAllow: "notAToken" is not a matcher label, so nothing reads it)',
       'live_window.ts#0 (writeAllow: "nope" is not a matcher label, so nothing reads it)',
     ]);
     // ...and it stays silent on a well-formed set, so it is not simply always noisy. The
     // well-formed driver entry keys all THREE new allowance maps with real labels, which is
-    // what keeps each of the three label sets load-bearing: point `queryAllow` at the
+    // what keeps each of the four label sets load-bearing: point `queryAllow` at the
     // raw-write labels and this arm goes red.
     expect(
       registrationProblems(
@@ -1492,6 +1653,7 @@ describe('hud_perf_budget ARM 1: every src/ui painter holds its bucket contract 
                 writeAllow: { '.style': 1 },
                 queryAllow: { '.querySelector': 1 },
                 idlAllow: { '.disabled': 1 },
+                reflowAllow: { '.scrollTop': 1 },
               },
             ],
           },
@@ -1568,6 +1730,16 @@ function registrationProblems(
         if (!grant.why.trim()) {
           problems.push(`${host.file}#${index} (drivers: the granted cadence says what it is for)`);
         }
+        // A `setInterval` grant must name a cadence, because the counts beside it are per tick
+        // and a `null` would make them per nothing. `delayOf` resolves a literal OR a
+        // module-level const, so the honest way to reach null here is a delay computed at run
+        // time; that is the point at which a reviewer should be asked, not waved through.
+        // requestAnimationFrame / requestIdleCallback take no delay and are legitimately null.
+        if (grant.driver === 'setInterval' && grant.everyMs === null) {
+          problems.push(
+            `${host.file}#${index} (drivers: a setInterval grant must declare its cadence; hoist the delay to a literal or a module-level const so it can be pinned)`,
+          );
+        }
         for (const [name, reason] of Object.entries(grant.stopsAt ?? {})) {
           if (!reason.trim()) {
             problems.push(
@@ -1600,6 +1772,7 @@ function registrationProblems(
           ['writeAllow', `${host.file}#${index}`, grant.writeAllow] as const,
           ['queryAllow', `${host.file}#${index}`, grant.queryAllow] as const,
           ['idlAllow', `${host.file}#${index}`, grant.idlAllow] as const,
+          ['reflowAllow', `${host.file}#${index}`, grant.reflowAllow] as const,
         ]),
       ),
     ];
@@ -1815,6 +1988,12 @@ describe('hud_perf_budget ARM 1 (cont.): the matchers themselves', () => {
       ['.getElementById', "document.getElementById('lockpick-panel')", 'doc.getElementByIdish(x)'],
       ['.getElementsByClassName', "root.getElementsByClassName('lp')", 'el.getElementsByClass(x)'],
       ['.getElementsByTagName', "root.getElementsByTagName('li')", 'el.getElementsByTag(x)'],
+      [
+        '.getElementsByTagNameNS',
+        "root.getElementsByTagNameNS(ns, 'g')",
+        'el.getElementsByTagNS(x)',
+      ],
+      ['.getElementsByName', "document.getElementsByName('q')", 'doc.getElementsByNamed(x)'],
       ['.closest', "target.closest('.window.panel')", 'const closest = nearestTarget(p);'],
       ["['computed' query]", "el['querySelector']('.bar')", "el['querySelectorish']()"],
     ];
@@ -1840,7 +2019,7 @@ describe('hud_perf_budget ARM 1 (cont.): the matchers themselves', () => {
       ).toBe(1);
     }
     // NON-VACUITY against the live tree for the arm that motivated the family: the
-    // pre-#2516 lockpick clock re-queried its refs three times per tick, and
+    // pre-#2498 lockpick clock re-queried its refs three times per tick, and
     // daily_rewards' countdown poll still walks the subtree once per tick today. If the
     // querySelectorAll arm were re-narrowed it would count 0 here and pass quietly.
     const qsa = queries.get('.querySelectorAll');
@@ -1855,6 +2034,8 @@ describe('hud_perf_budget ARM 1 (cont.): the matchers themselves', () => {
       ['.readOnly', 'input.readOnly = true;', 'const r = opts.readOnlyish;'],
       ['.indeterminate', 'box.indeterminate = true;', 'const i = x.indeterminateish;'],
       ['.srcset', 'img.srcset = urls;', 'const s = img.srcsetOf;'],
+      ['.ariaLabel', 'btn.ariaLabel = label;', 'const a = row.ariaLabelKey;'],
+      ['.tabIndex', 'el.tabIndex = -1;', 'const t = row.tabIndexOf;'],
       ["['computed' idl]", "btn['disabled'] = true;", "btn['disabledAt'] = 1;"],
     ];
     for (const [label, positive, negative] of idlFixtures) {
@@ -1875,8 +2056,12 @@ describe('hud_perf_budget ARM 1 (cont.): the matchers themselves', () => {
     // to a reader to notice. Both collide with ordinary field names in this very tree
     // (`els.value` is the lockpick countdown node), so an allowance counting them would
     // document a fiction. If a future case needs them, this is the assertion to argue with.
-    expect(labelsOf(IDL_WRITES)).not.toContain('.value');
-    expect(labelsOf(IDL_WRITES)).not.toContain('.src');
+    for (const excluded of ['.value', '.src', '.title', '.alt', '.placeholder']) {
+      expect(labelsOf(IDL_WRITES), `${excluded} is excluded by decision`).not.toContain(excluded);
+    }
+    // `.matches` is out of the query family for the same reason, and worse: `matchMedia().matches`
+    // and a regex `.matches` are both live here.
+    expect(labelsOf(ELEMENT_QUERIES)).not.toContain('.matches');
 
     // COVERAGE OF THE FIXTURE TABLES THEMSELVES, which is the hole all three loops share:
     // each walks the FIXTURE list and looks the regex up by label, so an arm added to a family
@@ -1952,10 +2137,12 @@ describe('hud_perf_budget ARM 1 (cont.): the matchers themselves', () => {
       ['.getElementById', /\.getElementById\b/g],
       ['.getElementsByClassName', /\.getElementsByClassName\b/g],
       ['.getElementsByTagName', /\.getElementsByTagName\b/g],
+      ['.getElementsByTagNameNS', /\.getElementsByTagNameNS\b/g],
+      ['.getElementsByName', /\.getElementsByName\b/g],
       ['.closest', /\.closest\b/g],
       [
         "['computed' query]",
-        /\[\s*['"](?:querySelector|querySelectorAll|getElementById|getElementsByClassName|getElementsByTagName|closest)['"]\s*\]/g,
+        /\[\s*['"](?:querySelector|querySelectorAll|getElementById|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getElementsByName|closest)['"]\s*\]/g,
       ],
     ]);
     expect(IDL_WRITES).toEqual([
@@ -1966,9 +2153,11 @@ describe('hud_perf_budget ARM 1 (cont.): the matchers themselves', () => {
       ['.readOnly', /\.readOnly\b/g],
       ['.indeterminate', /\.indeterminate\b/g],
       ['.srcset', /\.srcset\b/g],
+      ['.ariaLabel', /\.ariaLabel\b/g],
+      ['.tabIndex', /\.tabIndex\b/g],
       [
         "['computed' idl]",
-        /\[\s*['"](?:disabled|hidden|checked|selected|readOnly|indeterminate|srcset)['"]\s*\]/g,
+        /\[\s*['"](?:disabled|hidden|checked|selected|readOnly|indeterminate|srcset|ariaLabel|tabIndex)['"]\s*\]/g,
       ],
     ]);
   });


### PR DESCRIPTION
## Summary

A `COLD_PAINTER_ALLOWANCES` entry granting `setInterval` recorded that a module repaints on a
cadence and implied **nothing** about the work on that cadence. `lockpick_window` is the proof:
its granted 100ms clock re-resolved three element refs with `querySelector` and made an unelided
`classList.toggle` on every tick, and no gate could see either one. `querySelector` was in none
of the three matcher families, and the raw-write scan is waived for the cold bucket by design.

Granting a driver now costs a `drivers` entry per call site: the cadence (pinned against the
literal in the source), why the driver exists, and the EXACT count of raw writes, element
re-queries and IDL-property writes one tick performs.

**The unit is not the callback body, and this is the finding worth reading.** A body-only scan is
what the issue describes, and over this tree it is vacuous: all three live driver callbacks
contain zero writes and zero queries, because each one is a guard plus a call to a method. Run
against the pre-#2516 `lockpick_window`, a body-only scan is **green on the exact defect that
motivated the rule**. So the corpus is the callback body PLUS every same-module function one tick
can reach, resolved through the TypeScript AST in `tests/helpers/driver_callback_bodies.ts`. Run
against that same pre-fix source, the walk reports `.querySelector` 3x and `.getElementById` 1x
against a zero allowance.

### The two open decisions, answered

**1. Do `.disabled` and the other IDL-property writes belong in `RAW_WRITES`?** No, and there are
two halves to it.

- `RAW_WRITES` runs over WHOLE FILES in the hot and canvas buckets, and a bare member-name matcher
  over a whole file counts ordinary data fields. `.value` matches the `els.value` countdown node
  in `lockpick_window`; `.selected` / `.checked` match view-model booleans by the dozen in
  `dungeon_finder_window`. `.value` and `.src` are therefore out of the new family too: an
  allowance reading "this driver writes `.value` once" when the hit is a field named `value`
  documents a fiction.
- Adding `.disabled` to `RAW_WRITES` would **also not have caught the case the issue cites**.
  `spellbook_window` is a COLD painter and cold takes no raw-write scan at all, so the arm would
  have been added to a scan that never runs over the module in question. That one is #2519's, and
  it needs the cadence answer rather than a new token.

So `IDL_WRITES` is a new family scanned ONLY inside a driver callback, where the corpus is a few
hundred characters and hand-checkable, which is the condition the issue named.

**2. What is a legitimate driver callback allowed to do?** A counted allowance, as the issue
expected, but per CALL SITE rather than per module: `daily_rewards_window` arms two intervals with
different cadences and different per-tick work, and one number for both would describe neither.

### The reachability cut

A poll whose callback calls the module's ordinary full-render entry point reaches the whole module
(the 15s `daily_rewards` poll reaches 43 methods and ~30k characters through `renderCurrent`).
Counting that would re-run the argument the cold bucket already settled: a count over a render path
churns on every ordinary edit while the hazard it is meant to catch moves no count at all. So an
entry may declare `stopsAt`, naming where the walk stops WITH its reason, and the gate fails a cut
that turns out to be dead. One cut exists today.

### The three live allowances, at their real counts

| module | cadence | writes | re-queries |
|---|---|---|---|
| `daily_rewards_window.ts` | 15s | `.style` 1 (the `isOpen` display read) | none (cut at `renderCurrent`) |
| `daily_rewards_window.ts` | 30s | `.style` 1, `.textContent` 1, `.dataset` 1 | `.querySelectorAll` 1 |
| `hud/delve/lockpick_window.ts` | 100ms | `.style` 1, `.textContent` 1, `.classList` 1 | **zero** |

Layout reads are counted per tick as a fourth family, for the same reason the gate exists: a
granted per-file reflow allowance says a module makes N layout reads and, exactly like a granted
driver before this, implies nothing about whether one of them happens on a 100ms tick. It is free
today, because no entry has both a non-empty `reflowAllow` and a non-empty `driverAllow`, which is
when to add it rather than after the first module that has both.

### What review changed

Two read-only reviewers (frontend-seam, test-coverage) returned 0 blocking, 6 should-fix and 5
notes; all are applied. The substantive ones:

- **Three same-module escapes in the reachability walk.** It followed only `this.foo()` and a bare
  `foo()`, so `const self = this; self.paint()`, `this['paint']()` and an object-literal method
  each reached NOTHING: a new driver written any of those ways would have passed with an empty
  allowance and a wholly unscanned tick. The computed form is the sharp one, since every write
  family already carries a `['computed']` arm for exactly that escape, so leaving it open for
  CALLEES would let a write hop behind `this['paintTimer']()` and out of a gate that catches
  `el['style']`.
- **The cadence pin was escapable by hoisting** the delay into a constant, a shape
  `src/ui/reconnect_overlay.ts` already uses. The resolver now reads a module-level numeric const,
  and a `setInterval` grant that still cannot name its cadence fails registration.
- **The parse now gets raw source**, not regex-stripped source: `stripComments`'s `//` arm would
  truncate a line at a `//` inside a string, and `ts.createSourceFile` does not throw on the
  broken tree that results, it silently loses a call site. Only the resolved tick corpus is
  stripped.
- I found one myself: an ambiguous callback reference scanned only the FIRST matching body while
  the comment beside it claimed it scanned both.

### Two limits, stated rather than implied

The scan reaches only the three sanctioned adapter filenames, so a driver in a bare-named module
(`reconnect_overlay.ts`, `icon_prewarm.ts`, `hud.ts`) is outside it, the same way those modules are
already outside the per-file painter scans. And it does not leave the module: a write moved behind
an injected dep or an imported helper is invisible here. Both are written down at the code rather
than left for a reader to discover.

## Related issues

Closes #2518. Follow-up from #2516 (which closed #2498). Same lineage as #2486 -> #2491 -> #2492
-> #2497 -> #2498 -> #2516.

## Type of change

- [x] Tests
- [x] Documentation

## How was this tested?

- Commands:
  - `npx vitest run tests/hud_perf_budget.test.ts tests/helpers/driver_callback_bodies.test.ts`
  - `npx tsc --noEmit`
  - `npx @biomejs/biome check tests/hud_perf_budget.test.ts tests/helpers/driver_callback_bodies.ts tests/helpers/driver_callback_bodies.test.ts`
  - `npm run gate`
- Manual steps: a 25-case mutation battery in an isolated worktree, all as expected (24 RED, plus
  one deliberate GREEN). Ten mutate the SOURCE: the pre-fix defect restored verbatim, a
  `querySelector` added to an existing driver callback, the clock re-tuned 100ms to 50ms, the
  cadence hoisted into a const and re-tuned, a `.hidden` IDL write added to the tick, a
  forced-reflow read added to the tick, a re-query hidden behind a nested arrow plus an extra
  method hop, an undeclared third `setInterval`, and the tick rewritten through `const self =
  this` (this one must stay GREEN, and is paired with a RED case that guts the alias arm while
  the source uses an alias). Fifteen mutate the GATE: the `drivers` list deleted while the
  cadence stays granted, a stale grant, the matcher-family loop truncated, the host list narrowed
  to empty, the verdict comparator flipped to `<`, the cut removed, the cut re-pointed at an
  unreachable name, a NEW cut added to zero out a budget, the resolver returning no call sites,
  the resolver shrugging at a callback it cannot follow, the walk reduced to a body-only scan,
  callee collection stopped at a nested arrow, the computed-callee arm gutted, the cadence pin
  disabled, and the setInterval-must-name-its-cadence rule disabled.

  The first `npm run gate` had exactly one red, `tests/asset_pipeline.test.ts` ENOENT on
  `public/models/sfx-studio-security-<pid>.glb`. That is a known cross-suite filesystem race
  (another suite creates and removes that temp symlink; the inventory scan stats it mid-delete);
  this diff touches no `public/models/`, asset-pipeline or SFX code, and `asset_pipeline.test.ts`
  passes alone at 56/56. The re-run was `[gate] PASS: all 11 steps green`.

## Screenshots / recordings

N/A. Tests and docs only; no runtime code and nothing a player or operator sees changes.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green, with decisive tests for the new behavior.

### Cross-platform

- ~Tested on desktop and mobile.~ N/A, no UI change.
- ~Accessible.~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any
      production path.
- [x] No generated file was hand-edited.
