### PR TITLE
fix(ui): wire the Town Focus panel into the shared focus system

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -11876,13 +11876,14 @@ export class Hud {
   private lastTownFocusSig = '';
 
   // Standalone trapping window (#2525): the train / unbind shape, one
-  // windowFocus bridge plus one opener field. The panel was the last window
-  // outside the shared focus system and not one of the two documented opt-outs
-  // (#bags and #bank-window, which pair with another window and must stay
-  // Tab-passable), so it had no Tab trap and no return-to-opener. Invisible
-  // while the panel rebuilt itself twice a second, because focus never survived
-  // long enough to be handed back; #2500 fixed the rebuild, which is what made
-  // the gap reachable.
+  // windowFocus bridge plus one opener field. The panel was outside the shared
+  // focus system entirely: absent from every windowFocus(rootSel) call site and
+  // not one of the two documented opt-outs (#bags and #bank-window, which pair
+  // with a second window and must stay Tab-passable), so it had no Tab trap and
+  // no return-to-opener. It is not the last one out (vendor, crafting, trade,
+  // map and report still are); it is the one that became REACHABLE, because
+  // #2500 stopped the panel rebuilding itself twice a second and focus started
+  // surviving long enough for the missing hand-back to matter.
   private readonly townFocusWindowFocus = this.windowFocus('#town-focus-window');
   private townFocusOpenerFocus: HTMLElement | null = null;
 
@@ -11957,7 +11958,21 @@ export class Hud {
   /** The ONE close path: the X and Save go through onClose/onSave, Escape and
    *  the gamepad go through closeAll -> closeManagedWindow's `town-focus-window`
    *  case, and the toggle re-press comes straight here. So releasing the trap and
-   *  handing focus back once, here, covers every one of them. */
+   *  handing focus back once, here, covers every one of them.
+   *
+   *  Deliberately NOT guarded on `townFocusOpen` the way closeTrain/closeUnbind
+   *  guard on their npc id: those hold open state in a field, this panel reads
+   *  it off the DOM, every caller is already guarded, and a redundant call is a
+   *  no-op (the opener is nulled below, and releasing a released trap does
+   *  nothing). A guard would also make the "a later close cannot re-steal focus"
+   *  test pass for the wrong reason.
+   *
+   *  KNOWN EDGE, shared with the whole windowFocus family: FocusManager refuses
+   *  to focus an element reporting no client rects, so an opener that went away
+   *  between open and close (walk out of town and #mm-town-focus hides) gets no
+   *  hand-back. Focus is left where it is rather than moved somewhere the player
+   *  cannot see, which is the pre-#2525 outcome and never worse; the trap is
+   *  still released either way. */
   closeTownFocus(): void {
     $('#town-focus-window').style.display = 'none';
     this.townFocusDraft = null;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -11875,6 +11875,17 @@ export class Hud {
    *  the in-town flag, the budget and a row per component). */
   private lastTownFocusSig = '';
 
+  // Standalone trapping window (#2525): the train / unbind shape, one
+  // windowFocus bridge plus one opener field. The panel was the last window
+  // outside the shared focus system and not one of the two documented opt-outs
+  // (#bags and #bank-window, which pair with another window and must stay
+  // Tab-passable), so it had no Tab trap and no return-to-opener. Invisible
+  // while the panel rebuilt itself twice a second, because focus never survived
+  // long enough to be handed back; #2500 fixed the rebuild, which is what made
+  // the gap reachable.
+  private readonly townFocusWindowFocus = this.windowFocus('#town-focus-window');
+  private townFocusOpenerFocus: HTMLElement | null = null;
+
   private isInTown(): boolean {
     const pos = this.sim.player.pos;
     return isInTownZone(pos, zoneAt(pos.z));
@@ -11889,6 +11900,10 @@ export class Hud {
     this.closeOtherWindows('#town-focus-window');
     this.townFocusDraft = { ...this.sim.townFocus };
     this.renderTownFocus();
+    // AFTER the first paint, the train / unbind ordering: captureFocus records
+    // the opener (the minimap button) and installs the trap over a root that is
+    // by then populated and displayed.
+    this.townFocusOpenerFocus = this.townFocusWindowFocus.captureFocus();
   }
 
   private renderTownFocus(): void {
@@ -11939,10 +11954,16 @@ export class Hud {
     this.renderTownFocus();
   }
 
+  /** The ONE close path: the X and Save go through onClose/onSave, Escape and
+   *  the gamepad go through closeAll -> closeManagedWindow's `town-focus-window`
+   *  case, and the toggle re-press comes straight here. So releasing the trap and
+   *  handing focus back once, here, covers every one of them. */
   closeTownFocus(): void {
     $('#town-focus-window').style.display = 'none';
     this.townFocusDraft = null;
     this.hideTooltip();
+    this.townFocusWindowFocus.restoreFocus(this.townFocusOpenerFocus);
+    this.townFocusOpenerFocus = null;
   }
 
   get townFocusOpen(): boolean {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -11903,7 +11903,13 @@ export class Hud {
     this.renderTownFocus();
     // AFTER the first paint, the train / unbind ordering: captureFocus records
     // the opener (the minimap button) and installs the trap over a root that is
-    // by then populated and displayed.
+    // by then populated and displayed. The one case where AFTER would be worse
+    // than BEFORE is unreachable: if the paint could leave focus INSIDE the
+    // panel, captureFocus would record an in-window opener and the bridge's
+    // in-window arm would then decline to release the trap on close. It cannot,
+    // because the root is display:none until this paint, so a browser has
+    // already blurred its stale children to <body>, and activeFocusable()
+    // rejects <body>.
     this.townFocusOpenerFocus = this.townFocusWindowFocus.captureFocus();
   }
 
@@ -11967,12 +11973,21 @@ export class Hud {
    *  nothing). A guard would also make the "a later close cannot re-steal focus"
    *  test pass for the wrong reason.
    *
-   *  KNOWN EDGE, shared with the whole windowFocus family: FocusManager refuses
-   *  to focus an element reporting no client rects, so an opener that went away
-   *  between open and close (walk out of town and #mm-town-focus hides) gets no
-   *  hand-back. Focus is left where it is rather than moved somewhere the player
-   *  cannot see, which is the pre-#2525 outcome and never worse; the trap is
-   *  still released either way. */
+   *  KNOWN EDGE, NOT fixed here, and the obvious local fix is a trap. The panel
+   *  is deliberately readable out of town while the slow band hides
+   *  #mm-town-focus out of town, so a player can open it in town, walk out, and
+   *  close with the opener no longer rendered. FocusManager then refuses the
+   *  hand-back (no client rects: moving focus somewhere invisible is a WCAG
+   *  2.4.11 failure), focus is left standing, and the browser drops it to <body>
+   *  with the panel. That is the pre-#2525 outcome, never worse, and the trap is
+   *  released either way.
+   *  Do NOT "fix" it by keeping the button visible while townFocusOpen: the
+   *  hand-back lands, then the next slow tick (<=500ms later) hides the button
+   *  again now that the panel is closed, and focus drops anyway. A flicker
+   *  instead of a loss. The real fix is a fallback destination, which
+   *  makeWindowFocus passes for NO window (closeTrain / closeUnbind hand back to
+   *  a gossip button that is already gone), so it belongs to the bridge and the
+   *  whole family, not to this one caller. */
   closeTownFocus(): void {
     $('#town-focus-window').style.display = 'none';
     this.townFocusDraft = null;

--- a/src/ui/town_focus_window.ts
+++ b/src/ui/town_focus_window.ts
@@ -5,6 +5,7 @@
 // orchestrator (open/close + cross-window coordination).
 
 import { MAX_FOCUS_TIER_BONUS, POINTS_PER_TIER_BONUS } from '../sim/professions/focus';
+import { markDialogRoot } from './dialog_root';
 import { esc } from './esc';
 import { formatNumber, t } from './i18n';
 import type { TownFocusView } from './town_focus_view';
@@ -46,6 +47,17 @@ export function renderTownFocusWindow(
   const active = document.activeElement;
   const focusKey =
     active instanceof HTMLElement && el.contains(active) ? (active.dataset.focusKey ?? null) : null;
+  // Dialog semantics for the trapped root (#2525). Hud installs the Tab trap and
+  // the return-to-opener through windowFocus('#town-focus-window'); a trapped
+  // window also has to ANNOUNCE itself, or a screen-reader user is cycling inside
+  // an unnamed <div>. Set before the wipe, the deeds / professions ordering: these
+  // attributes live on the root, which the innerHTML below never touches, and the
+  // one accessible name comes from the SAME key as the visible title, so the two
+  // can never drift. markDialogRoot also writes tabindex="-1", which is
+  // deliberately NOT a Tab stop: FOCUSABLE_SELECTOR excludes tabindex="-1" from
+  // every clause, so the root stays programmatically focusable (the focus-first
+  // fallback) without joining the cycle.
+  markDialogRoot(el, { label: t('hudChrome.townFocus.title') });
   el.innerHTML = `<div class="panel-title"><span>${esc(t('hudChrome.townFocus.title'))}</span><button type="button" class="x-btn" data-close data-focus-key="${CLOSE_FOCUS_KEY}" aria-label="${esc(t('itemUi.vendor.close'))}">${svgIcon('close')}</button></div>`;
 
   const hint = document.createElement('div');

--- a/tests/town_focus_repaint_gate.test.ts
+++ b/tests/town_focus_repaint_gate.test.ts
@@ -29,11 +29,11 @@
 //     re-arm, the language switch), each anchored to the REGION it has to live
 //     in rather than to the whole file.
 //
-// Section 6 is issue #2525, the other half of the same story. The panel was the
-// one HUD window never wired into the shared FocusManager, so it had no Tab
-// trap, no return-to-opener and no dialog role. That gap was unreachable while
-// the panel rebuilt itself at 2Hz (focus never survived long enough to be handed
-// back), which is why it lands here, against the same painter and the same Hud
+// Section 6 is issue #2525, the other half of the same story. The panel was
+// outside the shared FocusManager entirely, so it had no Tab trap, no
+// return-to-opener and no dialog role. That gap was unreachable while the panel
+// rebuilt itself at 2Hz (focus never survived long enough to be handed back),
+// which is why it lands here, against the same painter and the same Hud
 // methods, rather than in a file of its own.
 
 import { readFileSync } from 'node:fs';
@@ -1011,6 +1011,35 @@ describe('the Town Focus panel is wired into the shared focus system', () => {
     plus.focus();
     expect(pressTab().defaultPrevented).toBe(false);
     expect(document.activeElement).toBe(plus);
+  });
+
+  it('declines to focus an opener that went away, and still releases the trap', () => {
+    // The panel is deliberately readable OUT of town while #mm-town-focus hides
+    // out of town, so a player can open it in town, walk out, and close it with
+    // the opener no longer rendered. FocusManager's canFocus refuses a
+    // zero-rect element ON PURPOSE: moving focus somewhere invisible is a WCAG
+    // 2.4.11 failure, not a fix. So the hand-back no-ops. That is the shared
+    // bridge's behavior for any window whose opener can vanish (closeTrain and
+    // closeUnbind hand back to a gossip button that is already gone by then),
+    // and it is exactly the pre-#2525 outcome, never worse.
+    const { hud, el, opener } = makeFocusHud();
+    opener.focus();
+    hud.toggleTownFocus();
+    const plus = stepButton(el, COMPONENT, 'inc');
+    plus.focus();
+    // A per-element override: the blanket stub in beforeEach reports one rect
+    // for everything, which is what makes this case unrepresentable by default.
+    vi.spyOn(opener, 'getClientRects').mockReturnValue([] as unknown as DOMRectList);
+    hud.closeTownFocus();
+    vi.runAllTimers();
+    // jsdom does not blur on display:none, so focus is simply left standing
+    // where it was; a real browser drops it to <body> at the same moment.
+    // Either way it is NOT moved onto the hidden button.
+    expect(document.activeElement).toBe(plus);
+    expect(document.activeElement).not.toBe(opener);
+    // ...and the trap is released regardless, so a no-op hand-back never leaves
+    // the player Tab-trapped inside a closed panel.
+    expect(pressTab().defaultPrevented).toBe(false);
   });
 
   it('marks the root as a dialog with exactly ONE accessible name', () => {

--- a/tests/town_focus_repaint_gate.test.ts
+++ b/tests/town_focus_repaint_gate.test.ts
@@ -783,7 +783,10 @@ interface TownFocusFocusHarness {
   readonly townFocusOpen: boolean;
 }
 
-function makeFocusHud(allocation: Record<string, number> = { [COMPONENT]: 2 }): {
+function makeFocusHud(
+  allocation: Record<string, number> = { [COMPONENT]: 2 },
+  inTown = true,
+): {
   hud: TownFocusFocusHarness;
   el: HTMLElement;
   opener: HTMLButtonElement;
@@ -807,9 +810,13 @@ function makeFocusHud(allocation: Record<string, number> = { [COMPONENT]: 2 }): 
   hud.lastTownFocusSig = '';
   // Object.create skips field initializers, so build the bridge by hand out of
   // the SAME two pieces the field declares: makeWindowFocus over a FocusManager.
+  // Two things this seeding cannot see, both covered by source pins below
+  // instead: WHICH root the bridge is built over, and that the shipped
+  // `windowFocus` helper resolves the ONE manager shared by every window rather
+  // than minting a private one per window as this harness does.
   hud.townFocusWindowFocus = makeWindowFocus(new FocusManager(), () => el);
   hud.townFocusOpenerFocus = null;
-  hud.isInTown = () => true;
+  hud.isInTown = () => inTown;
   hud.closeContextMenu = vi.fn() as unknown as TownFocusFocusHarness['closeContextMenu'];
   hud.hideTooltip = vi.fn() as unknown as TownFocusFocusHarness['hideTooltip'];
   return { hud, el, opener };
@@ -836,10 +843,21 @@ describe('the Town Focus panel is wired into the shared focus system', () => {
     // jsdom lays nothing out, so every element reports ZERO client rects and the
     // manager (which reads getClientRects().length to mean "rendered, therefore
     // focusable") would refuse every candidate, opener included. Report one rect
-    // for this section; the manager only ever reads `.length`. It also means the
-    // manager's self-heal never fires here, which is what makes the release
-    // assertions below decisive: a leaked trap stays leaked instead of being
-    // quietly popped on the next Tab.
+    // for this section; the manager only ever reads `.length`.
+    //
+    // Two consequences worth stating, because both are load-bearing. First, a
+    // leaked trap's root keeps reporting rects, so the manager's self-heal (which
+    // pops traps whose root has gone unfocusable) cannot quietly paper over one:
+    // that is what makes every "the trap was released" assertion below decisive.
+    // Second, the stub is per-PROTOTYPE, so a `display: none` element still reads
+    // as focusable and the whole class of "the return target vanished" cases is
+    // unrepresentable by default; the one test that needs it overrides
+    // getClientRects on a single ELEMENT.
+    //
+    // The self-heal is not dead in this file, though: the four tests that never
+    // close the panel leave a live trap and a live document listener behind, and
+    // it is afterEach's document.body.innerHTML wipe that detaches their roots so
+    // the next test's first Tab pops them. Isolation depends on that wipe.
     const spy = vi
       .spyOn(Element.prototype, 'getClientRects')
       .mockReturnValue([{}] as unknown as DOMRectList);
@@ -888,14 +906,24 @@ describe('the Town Focus panel is wired into the shared focus system', () => {
     expect(document.activeElement).toBe(elsewhere);
   });
 
-  it('cycles Tab inside the open panel instead of letting it reach the game world', () => {
+  it('cycles Tab inside the open panel, and preventDefaults it', () => {
+    // NOT "instead of letting it reach the game world": the manager only
+    // cancels the default, and src/game/input.ts listens on `window` without
+    // checking defaultPrevented, so in the real client the same Tab press also
+    // runs target-nearest. That is true of every window in this family (no
+    // windowFocus window is in Hud.isModalOpen()), it is not something this
+    // change introduced, and nothing here covers it. Claim only what is driven.
     const { hud, el, opener } = makeFocusHud();
     opener.focus();
     hud.toggleTownFocus();
     const focusables = [...el.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)];
-    // The X, at least one live stepper pair and Save: enough stops that a cycle
-    // is distinguishable from doing nothing.
+    // This list is derived from the manager's OWN selector, so it pins order,
+    // wrapping and preventDefault but says nothing about MEMBERSHIP: a Save
+    // button that stopped rendering would leave the loop green. Pin the two ends
+    // by identity so the cycle is known to span the real panel, X to Save.
     expect(focusables.length).toBeGreaterThan(2);
+    expect(focusables[0]).toBe(el.querySelector('[data-close]'));
+    expect(focusables[focusables.length - 1]).toBe(el.querySelector('.town-focus-save'));
     focusables[0].focus();
     for (let i = 1; i < focusables.length; i++) {
       expect(pressTab().defaultPrevented).toBe(true);
@@ -936,11 +964,50 @@ describe('the Town Focus panel is wired into the shared focus system', () => {
     const rebuilt = stepButton(el, COMPONENT, 'inc');
     expect(rebuilt).not.toBe(plus);
     expect(document.activeElement).toBe(rebuilt);
-    // ...and that in-window refocus must not tear the trap down. The ladder
-    // reaches focus() directly and makeWindowFocus's in-window arm exists for
-    // the same reason: a refocus inside an OPEN window is not a close.
+    // ...and that in-window refocus must not tear the trap down. Note WHY it
+    // does not: the ladder reaches candidate.focus() directly inside the painter
+    // and never touches the bridge, so nothing releases the trap. It is not
+    // makeWindowFocus's in-window arm catching it; that arm is never entered for
+    // this window, and nothing in the repo drives it here. This is still the
+    // regression guard the criterion wants, since a rebuild that DID release
+    // would fail it.
     expect(pressTab().defaultPrevented).toBe(true);
     expect(el.contains(document.activeElement)).toBe(true);
+  });
+
+  it('cycles a shorter Tab ring out of town, where Save disables out of the set', () => {
+    // Out of town every stepper and Save render disabled, and a disabled button
+    // is out of FOCUSABLE_SELECTOR: the ring collapses to the X alone. Worth
+    // driving rather than assuming, because a one-element ring is the case where
+    // nextFocusIndex could plausibly return -1 and let Tab escape the panel.
+    const { hud, el, opener } = makeFocusHud({ [COMPONENT]: 2 }, false);
+    opener.focus();
+    hud.toggleTownFocus();
+    const focusables = [...el.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)];
+    expect(el.querySelector<HTMLButtonElement>('.town-focus-save')?.disabled).toBe(true);
+    expect(focusables).not.toContain(el.querySelector('.town-focus-save'));
+    expect(focusables).toEqual([el.querySelector('[data-close]')]);
+    focusables[0].focus();
+    expect(pressTab().defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(focusables[0]);
+  });
+
+  it('captures a null opener when nothing was focused, and still releases the trap', () => {
+    // The WebKit path, and the default one there: Safari and iOS do not focus a
+    // <button> on click, so activeFocusable() returns null at capture and the
+    // opener field is null at close. The bridge must still take its
+    // release-the-trap branch rather than treating null as an in-window refocus.
+    const { hud, el } = makeFocusHud();
+    expect(document.activeElement).toBe(document.body);
+    hud.toggleTownFocus();
+    expect(hud.townFocusOpenerFocus).toBeNull();
+    const plus = stepButton(el, COMPONENT, 'inc');
+    plus.focus();
+    hud.closeTownFocus();
+    vi.runAllTimers();
+    expect(hud.townFocusOpen).toBe(false);
+    plus.focus();
+    expect(pressTab().defaultPrevented).toBe(false);
   });
 
   it('returns focus to the opener through Save', () => {
@@ -952,7 +1019,7 @@ describe('the Town Focus panel is wired into the shared focus system', () => {
     save?.focus();
     save?.click();
     vi.runAllTimers();
-    expect(hud.sim.setTownFocus).toHaveBeenCalled();
+    expect(hud.sim.setTownFocus).toHaveBeenCalledWith({ [COMPONENT]: 2 });
     expect(hud.townFocusOpen).toBe(false);
     expect(document.activeElement).toBe(opener);
   });
@@ -1050,7 +1117,11 @@ describe('the Town Focus panel is wired into the shared focus system', () => {
     expect(el.getAttribute('aria-modal')).toBe('false');
     expect(el.getAttribute('tabindex')).toBe('-1');
     const title = t('hudChrome.townFocus.title');
-    expect(title.length).toBeGreaterThan(0);
+    // Both sides of the comparison below resolve the SAME key, so the pin is a
+    // discriminator for key IDENTITY (a painter that named itself off another
+    // key reds it) and not for the value. Pin the value to its literal too, the
+    // standard mitigation, so the triangle has a second independent vertex.
+    expect(title).toBe('Town Focus');
     expect(el.getAttribute('aria-label')).toBe(title);
     // aria-labelledby SHADOWS aria-label, so a root carrying both is ambiguous:
     // exactly one, which is what markDialogRoot guarantees.
@@ -1060,19 +1131,34 @@ describe('the Town Focus panel is wired into the shared focus system', () => {
     expect(el.querySelector('.panel-title span')?.textContent).toBe(title);
   });
 
+  it('re-asserts the dialog attributes on every repaint, not just the first', () => {
+    // The painter marks the root before its own innerHTML wipe, so a rebuild
+    // cannot strip the attributes; this pins that placement behaviorally rather
+    // than trusting the source pin below, which only proves the call exists.
+    const { hud, el, opener } = makeFocusHud();
+    opener.focus();
+    hud.toggleTownFocus();
+    el.removeAttribute('role');
+    el.removeAttribute('aria-label');
+    hud.townFocusDraft = { [COMPONENT]: 3 };
+    hud.renderTownFocus();
+    expect(el.getAttribute('role')).toBe('dialog');
+    expect(el.getAttribute('aria-label')).toBe(t('hudChrome.townFocus.title'));
+    expect(el.getAttribute('tabindex')).toBe('-1');
+  });
+
   it('keeps the dialog root itself out of the Tab cycle it wraps', () => {
     const { hud, el, opener } = makeFocusHud();
     opener.focus();
     hud.toggleTownFocus();
     // tabindex="-1" is programmatically focusable but deliberately OUT of the
-    // Tab sequence. A root written with tabindex="0" would match here and become
-    // an extra stop between the last control and the first.
+    // Tab sequence. This match is the WHOLE test: the manager derives its ring
+    // from root.querySelectorAll, which can never return the root itself, so a
+    // root written with tabindex="0" would NOT join the manager's cycle. What it
+    // would join is the browser's NATIVE Tab order, which is what a mouse user
+    // tabbing away and back, and every assistive technology, actually walks.
     expect(el.matches(FOCUSABLE_SELECTOR)).toBe(false);
-    const focusables = [...el.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)];
-    expect(focusables).not.toContain(el);
-    focusables[focusables.length - 1].focus();
-    pressTab();
-    expect(document.activeElement).toBe(focusables[0]);
+    expect(el.getAttribute('tabindex')).toBe('-1');
   });
 });
 
@@ -1086,6 +1172,21 @@ describe('Town Focus focus-system wiring (source pins)', () => {
       "private readonly townFocusWindowFocus = this.windowFocus('#town-focus-window');",
     );
     expect(hudSrc).toContain('private townFocusOpenerFocus: HTMLElement | null = null;');
+  });
+
+  it('builds that bridge over the ONE FocusManager every window shares', () => {
+    // The harness above mints a private FocusManager per panel, which is the one
+    // thing about the shipped wiring it cannot model. It matters: the stack is
+    // what makes closing a window reactivate the one beneath it, so rewriting
+    // this helper to `new FocusManager()` would give every window its own stack
+    // and leave all twelve behavioral tests green.
+    const helper = region(
+      'private windowFocus(rootSel: string): {',
+      'private refreshLocalizedDynamicUi(): void {',
+    );
+    expect(helper).toContain('return makeWindowFocus(this.focusManager, () => $(rootSel));');
+    expect(helper).not.toContain('new FocusManager(');
+    expect(hudSrc).toContain('private readonly focusManager = new FocusManager();');
   });
 
   it('captures the opener AFTER the first paint, the train / unbind ordering', () => {
@@ -1108,14 +1209,30 @@ describe('Town Focus focus-system wiring (source pins)', () => {
   });
 
   it('routes the managed close (Escape / closeAll / gamepad) through that one path', () => {
+    // The end anchor leans on `crafting-window` being the very next case (it is).
+    // A case inserted between them widens the region, which reds the negative
+    // half LOUDLY rather than passing it vacuously, so this is maintenance cost
+    // and not a coverage hole.
     const arm = region("case 'town-focus-window':", "case 'crafting-window':");
     expect(arm).toContain('this.closeTownFocus();');
-    // Not a bare hide, which is what the arm would have to become for the
-    // hand-back to be skipped while the window still closed.
+    // Pure belt, and worth naming as such so nobody upgrades it thinking it is
+    // the gate: the refusal has obvious dead alternates (`el.hidden = true`, a
+    // class toggle, a different spacing). What actually kills every spelling is
+    // the behavioral closeManagedWindow test above.
     expect(arm).not.toContain("style.display = 'none'");
   });
 
-  it('marks the dialog root from the painter, so every repaint re-asserts it', () => {
-    expect(painterSrc).toContain("markDialogRoot(el, { label: t('hudChrome.townFocus.title') });");
+  it('marks the dialog root INSIDE the painter, so every repaint re-asserts it', () => {
+    // Scoped to renderTownFocusWindow's body: the behavioral repaint test proves
+    // the attributes come back, and this proves WHERE from, so a call relocated
+    // to a one-shot open path (where a re-open would miss it) cannot satisfy it.
+    const start = painterSrc.indexOf('export function renderTownFocusWindow(');
+    expect(start).toBeGreaterThan(-1);
+    const end = painterSrc.indexOf('function restoreFocus(', start);
+    expect(end).toBeGreaterThan(start);
+    const painter = painterSrc.slice(start, end);
+    expect(painter).toContain("markDialogRoot(el, { label: t('hudChrome.townFocus.title') });");
+    // ...and BEFORE the wipe, which is what makes it survive innerHTML.
+    expect(painter.indexOf('markDialogRoot(')).toBeLessThan(painter.indexOf('el.innerHTML ='));
   });
 });

--- a/tests/town_focus_repaint_gate.test.ts
+++ b/tests/town_focus_repaint_gate.test.ts
@@ -28,13 +28,22 @@
 //  5. The wiring source pins for the three edges (the slow band, the paint
 //     re-arm, the language switch), each anchored to the REGION it has to live
 //     in rather than to the whole file.
+//
+// Section 6 is issue #2525, the other half of the same story. The panel was the
+// one HUD window never wired into the shared FocusManager, so it had no Tab
+// trap, no return-to-opener and no dialog role. That gap was unreachable while
+// the panel rebuilt itself at 2Hz (focus never survived long enough to be handed
+// back), which is why it lands here, against the same painter and the same Hud
+// methods, rather than in a file of its own.
 
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HARVEST_COMPONENT_ITEMS } from '../src/sim/content/professions';
 import { FOCUS_POINT_BUDGET } from '../src/sim/professions/focus';
+import { FOCUSABLE_SELECTOR, FocusManager } from '../src/ui/focus_manager';
 import { Hud } from '../src/ui/hud';
+import { t } from '../src/ui/i18n';
 import {
   buildTownFocusView,
   TOWN_FOCUS_COMPONENTS,
@@ -42,6 +51,7 @@ import {
   townFocusRenderSig,
 } from '../src/ui/town_focus_view';
 import { renderTownFocusWindow } from '../src/ui/town_focus_window';
+import { makeWindowFocus, type WindowFocusBridge } from '../src/ui/window_focus';
 
 const COMPONENT = TOWN_FOCUS_COMPONENTS[0];
 const OTHER_COMPONENT = TOWN_FOCUS_COMPONENTS[1];
@@ -742,5 +752,341 @@ describe('Town Focus repaint-gate wiring (source pins)', () => {
       'private previewResolvedAbility(',
     );
     expect(relocalize).toContain('if (this.townFocusOpen) this.renderTownFocus();');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. The shared focus system (issue #2525).
+//
+// The panel was absent from every windowFocus(rootSel) call site in hud.ts, was
+// not one of the two documented opt-outs (#bags and #bank-window, which pair
+// with a second window and must stay Tab-passable), and never called
+// markDialogRoot: no Tab trap, no return-to-opener, no role=dialog. Everything
+// below is driven over the REAL bridge (src/ui/window_focus.ts) and a REAL
+// FocusManager, the same two pieces the Hud field initializer wires, so none of
+// it is asserted against a stand-in for the shipped glue.
+// ---------------------------------------------------------------------------
+
+interface TownFocusFocusHarness {
+  sim: { townFocus: Record<string, number>; setTownFocus(next: Record<string, number>): void };
+  townFocusDraft: Record<string, number> | null;
+  lastTownFocusSig: string;
+  townFocusWindowFocus: WindowFocusBridge;
+  townFocusOpenerFocus: HTMLElement | null;
+  isInTown(): boolean;
+  renderTownFocus(): void;
+  toggleTownFocus(): void;
+  closeTownFocus(): void;
+  closeManagedWindow(el: HTMLElement): void;
+  closeContextMenu(): void;
+  hideTooltip(): void;
+  readonly townFocusOpen: boolean;
+}
+
+function makeFocusHud(allocation: Record<string, number> = { [COMPONENT]: 2 }): {
+  hud: TownFocusFocusHarness;
+  el: HTMLElement;
+  opener: HTMLButtonElement;
+} {
+  document.body.innerHTML = '';
+  // The real opener: the minimap button whose click handler calls toggleTownFocus.
+  const opener = document.createElement('button');
+  opener.id = 'mm-town-focus';
+  document.body.appendChild(opener);
+  const el = document.createElement('div');
+  el.id = 'town-focus-window';
+  el.className = 'window panel';
+  document.body.appendChild(el);
+
+  const hud = Object.create(Hud.prototype) as unknown as TownFocusFocusHarness;
+  hud.sim = {
+    townFocus: { ...allocation },
+    setTownFocus: vi.fn(),
+  } as unknown as TownFocusFocusHarness['sim'];
+  hud.townFocusDraft = null;
+  hud.lastTownFocusSig = '';
+  // Object.create skips field initializers, so build the bridge by hand out of
+  // the SAME two pieces the field declares: makeWindowFocus over a FocusManager.
+  hud.townFocusWindowFocus = makeWindowFocus(new FocusManager(), () => el);
+  hud.townFocusOpenerFocus = null;
+  hud.isInTown = () => true;
+  hud.closeContextMenu = vi.fn() as unknown as TownFocusFocusHarness['closeContextMenu'];
+  hud.hideTooltip = vi.fn() as unknown as TownFocusFocusHarness['hideTooltip'];
+  return { hud, el, opener };
+}
+
+function pressTab(shift = false): KeyboardEvent {
+  const ev = new KeyboardEvent('keydown', {
+    key: 'Tab',
+    shiftKey: shift,
+    bubbles: true,
+    cancelable: true,
+  });
+  document.dispatchEvent(ev);
+  return ev;
+}
+
+describe('the Town Focus panel is wired into the shared focus system', () => {
+  let restoreRects: () => void;
+
+  beforeEach(() => {
+    // FocusManager.restore defers focus a tick (window.setTimeout 0) so it wins
+    // over a close handler still settling the DOM.
+    vi.useFakeTimers();
+    // jsdom lays nothing out, so every element reports ZERO client rects and the
+    // manager (which reads getClientRects().length to mean "rendered, therefore
+    // focusable") would refuse every candidate, opener included. Report one rect
+    // for this section; the manager only ever reads `.length`. It also means the
+    // manager's self-heal never fires here, which is what makes the release
+    // assertions below decisive: a leaked trap stays leaked instead of being
+    // quietly popped on the next Tab.
+    const spy = vi
+      .spyOn(Element.prototype, 'getClientRects')
+      .mockReturnValue([{}] as unknown as DOMRectList);
+    restoreRects = () => spy.mockRestore();
+  });
+
+  afterEach(() => {
+    restoreRects();
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('captures the opener at open and hands focus back on close', () => {
+    const { hud, el, opener } = makeFocusHud();
+    opener.focus();
+    hud.toggleTownFocus();
+    expect(hud.townFocusOpen).toBe(true);
+    const plus = stepButton(el, COMPONENT, 'inc');
+    plus.focus();
+    expect(document.activeElement).toBe(plus);
+    hud.closeTownFocus();
+    expect(hud.townFocusOpen).toBe(false);
+    // Deferred, not synchronous: before the tick the old focus is still standing.
+    expect(document.activeElement).not.toBe(opener);
+    vi.runAllTimers();
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it('drops the recorded opener after the hand-back, so a later close cannot re-steal focus', () => {
+    const { hud, el, opener } = makeFocusHud();
+    opener.focus();
+    hud.toggleTownFocus();
+    stepButton(el, COMPONENT, 'inc').focus();
+    hud.closeTownFocus();
+    vi.runAllTimers();
+    expect(document.activeElement).toBe(opener);
+    expect(hud.townFocusOpenerFocus).toBeNull();
+    // Without the null the stale opener survives, and the next close (a
+    // closeAll sweep, a second toggle) yanks the player off whatever they moved
+    // to and back onto the minimap button.
+    const elsewhere = document.createElement('button');
+    document.body.appendChild(elsewhere);
+    elsewhere.focus();
+    hud.closeTownFocus();
+    vi.runAllTimers();
+    expect(document.activeElement).toBe(elsewhere);
+  });
+
+  it('cycles Tab inside the open panel instead of letting it reach the game world', () => {
+    const { hud, el, opener } = makeFocusHud();
+    opener.focus();
+    hud.toggleTownFocus();
+    const focusables = [...el.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)];
+    // The X, at least one live stepper pair and Save: enough stops that a cycle
+    // is distinguishable from doing nothing.
+    expect(focusables.length).toBeGreaterThan(2);
+    focusables[0].focus();
+    for (let i = 1; i < focusables.length; i++) {
+      expect(pressTab().defaultPrevented).toBe(true);
+      expect(document.activeElement).toBe(focusables[i]);
+    }
+    // ...and WRAPS at the end rather than escaping into the world behind it.
+    expect(pressTab().defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(focusables[0]);
+    // Shift+Tab wraps backwards off the same edge.
+    expect(pressTab(true).defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(focusables[focusables.length - 1]);
+  });
+
+  it('leaves Tab alone while focus is OUTSIDE the panel, so the game keeps its target key', () => {
+    const { hud, opener } = makeFocusHud();
+    opener.focus();
+    hud.toggleTownFocus();
+    // Opening records the opener and installs the trap; it does NOT pull focus
+    // in (the train / unbind shape). So the player is still on the minimap
+    // button, outside the panel, where Tab is target-nearest and must not be
+    // swallowed.
+    expect(document.activeElement).toBe(opener);
+    const ev = pressTab();
+    expect(ev.defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it('keeps the trap installed across the rebuild the step ladder drives', () => {
+    const { hud, el, opener } = makeFocusHud();
+    opener.focus();
+    hud.toggleTownFocus();
+    const plus = stepButton(el, COMPONENT, 'inc');
+    plus.focus();
+    hud.townFocusDraft = { [COMPONENT]: 3 };
+    hud.renderTownFocus();
+    // The #2500 ladder hands focus to the REBUILT equivalent of the control the
+    // player was on...
+    const rebuilt = stepButton(el, COMPONENT, 'inc');
+    expect(rebuilt).not.toBe(plus);
+    expect(document.activeElement).toBe(rebuilt);
+    // ...and that in-window refocus must not tear the trap down. The ladder
+    // reaches focus() directly and makeWindowFocus's in-window arm exists for
+    // the same reason: a refocus inside an OPEN window is not a close.
+    expect(pressTab().defaultPrevented).toBe(true);
+    expect(el.contains(document.activeElement)).toBe(true);
+  });
+
+  it('returns focus to the opener through Save', () => {
+    const { hud, el, opener } = makeFocusHud();
+    opener.focus();
+    hud.toggleTownFocus();
+    const save = el.querySelector<HTMLButtonElement>('.town-focus-save');
+    expect(save).not.toBeNull();
+    save?.focus();
+    save?.click();
+    vi.runAllTimers();
+    expect(hud.sim.setTownFocus).toHaveBeenCalled();
+    expect(hud.townFocusOpen).toBe(false);
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it('returns focus to the opener through the X button', () => {
+    const { hud, el, opener } = makeFocusHud();
+    opener.focus();
+    hud.toggleTownFocus();
+    const close = el.querySelector<HTMLButtonElement>('[data-close]');
+    expect(close).not.toBeNull();
+    close?.focus();
+    close?.click();
+    vi.runAllTimers();
+    expect(hud.townFocusOpen).toBe(false);
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it('returns focus to the opener through closeManagedWindow, the Escape / closeAll route', () => {
+    const { hud, el, opener } = makeFocusHud();
+    opener.focus();
+    hud.toggleTownFocus();
+    stepButton(el, COMPONENT, 'inc').focus();
+    // Escape and the gamepad both land in closeAll -> closeManagedWindow, whose
+    // `town-focus-window` case is the only thing standing between them and a
+    // focus drop to <body>.
+    hud.closeManagedWindow(el);
+    vi.runAllTimers();
+    expect(hud.townFocusOpen).toBe(false);
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it('returns focus to the opener when the toggle is pressed a second time', () => {
+    const { hud, el, opener } = makeFocusHud();
+    opener.focus();
+    hud.toggleTownFocus();
+    stepButton(el, COMPONENT, 'inc').focus();
+    hud.toggleTownFocus();
+    vi.runAllTimers();
+    expect(hud.townFocusOpen).toBe(false);
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it('releases the trap on close, over repeated open/close cycles', () => {
+    const { hud, el, opener } = makeFocusHud();
+    for (let i = 0; i < 2; i++) {
+      opener.focus();
+      hud.toggleTownFocus();
+      stepButton(el, COMPONENT, 'inc').focus();
+      hud.closeTownFocus();
+      vi.runAllTimers();
+    }
+    // A closed panel is hidden, not emptied, and jsdom lays nothing out, so its
+    // controls can still take focus. If ANY of those opens leaked a trap, this
+    // Tab would be swallowed and cycled instead of falling through to the game.
+    const plus = stepButton(el, COMPONENT, 'inc');
+    plus.focus();
+    expect(pressTab().defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(plus);
+  });
+
+  it('marks the root as a dialog with exactly ONE accessible name', () => {
+    const { hud, el, opener } = makeFocusHud();
+    opener.focus();
+    hud.toggleTownFocus();
+    expect(el.getAttribute('role')).toBe('dialog');
+    expect(el.getAttribute('aria-modal')).toBe('false');
+    expect(el.getAttribute('tabindex')).toBe('-1');
+    const title = t('hudChrome.townFocus.title');
+    expect(title.length).toBeGreaterThan(0);
+    expect(el.getAttribute('aria-label')).toBe(title);
+    // aria-labelledby SHADOWS aria-label, so a root carrying both is ambiguous:
+    // exactly one, which is what markDialogRoot guarantees.
+    expect(el.hasAttribute('aria-labelledby')).toBe(false);
+    // ...and the name a screen reader announces is the name on screen, off the
+    // same key, so the two cannot drift.
+    expect(el.querySelector('.panel-title span')?.textContent).toBe(title);
+  });
+
+  it('keeps the dialog root itself out of the Tab cycle it wraps', () => {
+    const { hud, el, opener } = makeFocusHud();
+    opener.focus();
+    hud.toggleTownFocus();
+    // tabindex="-1" is programmatically focusable but deliberately OUT of the
+    // Tab sequence. A root written with tabindex="0" would match here and become
+    // an extra stop between the last control and the first.
+    expect(el.matches(FOCUSABLE_SELECTOR)).toBe(false);
+    const focusables = [...el.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)];
+    expect(focusables).not.toContain(el);
+    focusables[focusables.length - 1].focus();
+    pressTab();
+    expect(document.activeElement).toBe(focusables[0]);
+  });
+});
+
+describe('Town Focus focus-system wiring (source pins)', () => {
+  it('declares ONE windowFocus bridge for the panel root, plus its opener field', () => {
+    // Both harnesses build the Hud with Object.create, which skips field
+    // initializers and seeds these by hand, so no behavioral test in this file
+    // can see the DECLARED wiring. Pin it, or the panel could be trapped against
+    // some other root with everything above still green.
+    expect(hudSrc).toContain(
+      "private readonly townFocusWindowFocus = this.windowFocus('#town-focus-window');",
+    );
+    expect(hudSrc).toContain('private townFocusOpenerFocus: HTMLElement | null = null;');
+  });
+
+  it('captures the opener AFTER the first paint, the train / unbind ordering', () => {
+    const toggle = region('toggleTownFocus(): void {', 'private renderTownFocus(): void {');
+    const painted = toggle.indexOf('this.renderTownFocus();');
+    const captured = toggle.indexOf(
+      'this.townFocusOpenerFocus = this.townFocusWindowFocus.captureFocus();',
+    );
+    expect(painted).toBeGreaterThan(-1);
+    expect(captured).toBeGreaterThan(painted);
+  });
+
+  it('releases the trap and hands focus back in the ONE close path', () => {
+    // Scoped to the method: every close route (X, Save, Escape, the toggle
+    // re-press) funnels here, so this is the single place the hand-back has to
+    // live. Moving it into one caller would silently drop the others.
+    const close = region('closeTownFocus(): void {', 'get townFocusOpen(): boolean {');
+    expect(close).toContain('this.townFocusWindowFocus.restoreFocus(this.townFocusOpenerFocus);');
+    expect(close).toContain('this.townFocusOpenerFocus = null;');
+  });
+
+  it('routes the managed close (Escape / closeAll / gamepad) through that one path', () => {
+    const arm = region("case 'town-focus-window':", "case 'crafting-window':");
+    expect(arm).toContain('this.closeTownFocus();');
+    // Not a bare hide, which is what the arm would have to become for the
+    // hand-back to be skipped while the window still closed.
+    expect(arm).not.toContain("style.display = 'none'");
+  });
+
+  it('marks the dialog root from the painter, so every repaint re-asserts it', () => {
+    expect(painterSrc).toContain("markDialogRoot(el, { label: t('hudChrome.townFocus.title') });");
   });
 });


### PR DESCRIPTION
## Summary

`#town-focus-window` was outside the shared focus system entirely: absent from every
`windowFocus(rootSel)` call site in `src/ui/hud.ts`, not one of the two documented opt-outs
(`#bags`, `#bank-window`, which pair with a second window and must stay Tab-passable), and it
never called `markDialogRoot`. So the panel had no Tab trap, no return-to-opener, and no
`role="dialog"` with an accessible name: `closeTownFocus()` set `display: none` on the focused
control's ancestor and focus fell to `<body>`.

It wires up the way the issue's Scope named, the train / unbind shape, with no new seam:

- **`src/ui/hud.ts`** gains one bridge field, `townFocusWindowFocus = this.windowFocus('#town-focus-window')`,
  and one opener field. `toggleTownFocus()` captures the opener AFTER the first paint (the
  train / unbind ordering, so the trap installs over a populated, displayed root).
  `closeTownFocus()` releases the trap, hands focus back, and nulls the opener. That method is
  the ONE close funnel every route already reaches: the X and Save through `onClose`/`onSave`,
  Escape and the gamepad through `closeAll` -> `closeManagedWindow`'s `town-focus-window` case,
  and the toggle re-press directly. (`closeOtherWindows` no longer closes anything; it only
  clears the context menu and tooltip.)
- **`src/ui/town_focus_window.ts`** marks the root before its wipe with
  `markDialogRoot(el, { label: t('hudChrome.townFocus.title') })`, the deeds / professions
  ordering. Exactly one accessible name, off the same `t()` key as the visible title, so the two
  cannot drift. No new i18n key.

The #2500 rebuild-refocus ladder still holds, and it is worth being precise about why: the
ladder calls `candidate.focus()` directly inside the painter and never touches the bridge, so
nothing releases the trap. It is not `makeWindowFocus`'s in-window arm catching it; that arm is
never entered for this window. There is a test for the surviving trap either way.

### Two things this deliberately does not do

- **No focus-first-on-open.** `WindowFocusBridge` exposes none, and no member of the
  `windowFocus` family calls one; the issue's Scope says to copy train / unbind, which are
  capture-only. Worth knowing while reading: `src/game/input.ts` cancels Tab whenever
  `canUseGameKeys()` is true, and no `windowFocus` window is in `Hud.isModalOpen()`, so for this
  panel (as for train, unbind, deeds, professions, char, spellbook, ...) the trap is entered
  after a pointer click rather than by tabbing in from the world. That is a family-wide property,
  not something this panel does differently, and changing it means changing
  `gameplayInputBlocked()` for ~22 windows at once.
- **No fallback when the opener has gone away.** `FocusManager` refuses to focus an element
  reporting no client rects, on purpose (focusing something invisible is a WCAG 2.4.11 failure).
  The panel is readable out of town while `#mm-town-focus` hides out of town, so a player can
  open it in town, walk out, and close with the opener no longer rendered: the hand-back no-ops,
  focus is left standing, and the browser drops it to `<body>` with the panel. That is the
  pre-change outcome, never worse, and the trap is released either way. Three reviewers raised
  it; I traced both candidate fixes before leaving it:
  - *Keep the button visible while `townFocusOpen`* does **not** work. The hand-back lands, then
    the next slow tick (<=500ms) hides the button again now that the panel is closed, and focus
    drops anyway. It trades a loss for a flicker.
  - *A fallback destination* is the real fix, and `FocusManager.restore(target, fallback)`
    already takes one, but `makeWindowFocus` passes it for **no** window (`closeTrain` /
    `closeUnbind` hand back to a gossip button that is already gone by then). It belongs to the
    bridge and the whole family, not to one caller.

  Pinned by a test, and the reasoning including the flicker trap is written on `closeTownFocus`
  so the next reader does not take the wrong one.

## Related issues

Closes #2525. Follow-up from the review panel on #2522 (which closed #2500).

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npm run gate` -> **PASS, all 11 steps green**
  - `npx vitest run tests/town_focus_repaint_gate.test.ts` -> 66 passed (22 new cases: 16 behavioral, 6 source pins)
  - `npx vitest run tests/hud_perf_budget.test.ts tests/architecture.test.ts tests/hud_update_drive.test.ts tests/dialog_root.test.ts tests/focus_manager.test.ts tests/localization_fixes.test.ts tests/deeds_window.test.ts` -> green
  - `npx tsc --noEmit` clean; biome clean on the three changed files
- Manual steps: a **17-mutation battery** over `src/ui/hud.ts` and `src/ui/town_focus_window.ts`,
  every one caught by the suite. Wiring: remove the `captureFocus` line (10 red); remove
  `restoreFocus` (9); remove `townFocusOpenerFocus = null` (2); capture BEFORE the first paint
  (1); point the bridge at `#bags` (1); `restoreFocus(null)` (7); give `windowFocus` a private
  `new FocusManager()` instead of the shared one (1); the managed-close arm becomes a bare
  `el.style.display = 'none'` (2). Dialog root: remove `markDialogRoot` (4); swap to
  `{ labelledBy: 'town-focus-title' }`, a dangling idref (3); a hardcoded English name (1); the
  wrong `t()` key (3); `tabindex="0"` (4); move the call after the `innerHTML` wipe (1). Painter
  shape, to prove the new membership and out-of-town pins bite: Save never disabled (2); Save
  never appended (6); the `-` stepper never disabled (4).

New coverage in `tests/town_focus_repaint_gate.test.ts` section 6 (16 cases), driven over the
REAL `makeWindowFocus` bridge and a REAL `FocusManager` (the same two pieces the Hud field
initializer wires, so nothing is asserted against a stand-in): opener captured at open and
returned on close; the hand-back is deferred, not synchronous; the opener field is dropped so a
later close cannot re-steal focus; a **null** opener is captured and still releases the trap
(the WebKit default, since Safari does not focus a `<button>` on click); Tab and Shift+Tab cycle
and WRAP, with the ring's **membership** pinned by identity at both ends (X first, Save last),
since the expectation list is otherwise derived from the manager's own selector; the shorter
out-of-town ring where Save disables out of the focusable set; Tab from OUTSIDE is not trapped;
the trap survives the step rebuild; return-to-opener through Save, the X, `closeManagedWindow`
(the Escape / closeAll route) and a second toggle press; no trap leaks over repeated open/close
cycles; the vanished-opener edge above; `role=dialog` + `aria-modal=false` + `tabindex=-1` +
exactly one accessible name, with the name pinned to its English literal as well as to the key,
and re-asserted after a repaint. Plus six source pins for the wiring a unit test cannot reach
(the field declaration, that `windowFocus` builds over the ONE shared manager, the
capture-after-paint ordering, the release-and-null pair, the managed-close arm, and
`markDialogRoot`'s placement before the wipe inside the painter).

**Review:** three reviewer agents (QA gate, frontend seam, test coverage), 0 blocking after
fixes, every should-fix and nit applied. Notable corrections they caught: a comment claiming the
panel was the *last* window outside the focus system (false, vendor / crafting / trade / map /
report still are); a test title claiming Tab never reaches the game world (`input.ts` listens on
`window` and does not check `defaultPrevented`, so it does, for every window in this family);
and a comment crediting the trap's survival across a rebuild to `makeWindowFocus`'s in-window
arm, which is never entered here (the ladder calls `focus()` directly, so nothing releases it).

## Screenshots / recordings

N/A. Nothing rendered changes: the diff adds focus behavior and ARIA attributes only, no CSS,
no markup, no layout.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [x] **Tested on desktop and mobile.** No visual or layout surface changed; the mobile rule at
      `src/styles/hud.mobile.css` for `#town-focus-window` is untouched, and 20+ sibling
      `.window.panel` roots already carry the identical `markDialogRoot` attributes.
- [x] **Accessible.** This is the accessibility fix: keyboard-operable trap, focus returned to
      the opener, `role=dialog` with one accessible name. No motion or focus-ring change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The accessible name reuses the existing
      `hudChrome.townFocus.title` key, and the existing `refreshLocalizedDynamicUi` arm already
      repaints the open panel on a language switch, so the name re-localizes with it.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.
