### PR TITLE
fix(ui): close the lockpick panel through its controller on closeAll

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -2738,13 +2738,14 @@ export class Hud {
         this.closeDelveBoard();
         break;
       case 'lockpick-panel':
-        // Withdraw from a live lock, or dismiss the ante selector: the same arm the
-        // panel's own X button and its Escape handler pick (#2517). The gamepad escape
-        // arrives here (main.ts dispatchGamepadAction -> closeAll) with no DOM event for
-        // the controller's capture-phase keydown handler to intercept, so the default
-        // arm's bare hide left the 100ms countdown repainting a hidden subtree, the focus
-        // trap armed on an invisible panel, and the session live on the server.
+        // Withdraw from a live lock, else dismiss the ante selector. The reachability
+        // story and why this is not a bare hide live on LockpickController.requestClose
+        // (#2517); do not restate them here, the two copies drifted once already.
+        // The hide is this arm's own, the trade-window precedent above: the withdrawal
+        // does not close the panel, so nothing else would retire a tooltip left standing
+        // over another surface until the server answers.
         this.lockpickController.requestClose();
+        this.hideTooltip();
         break;
       case 'loot-settings-window':
         this.closeLootSettings();

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -2737,6 +2737,15 @@ export class Hud {
       case 'delve-board':
         this.closeDelveBoard();
         break;
+      case 'lockpick-panel':
+        // Withdraw from a live lock, or dismiss the ante selector: the same arm the
+        // panel's own X button and its Escape handler pick (#2517). The gamepad escape
+        // arrives here (main.ts dispatchGamepadAction -> closeAll) with no DOM event for
+        // the controller's capture-phase keydown handler to intercept, so the default
+        // arm's bare hide left the 100ms countdown repainting a hidden subtree, the focus
+        // trap armed on an invisible panel, and the session live on the server.
+        this.lockpickController.requestClose();
+        break;
       case 'loot-settings-window':
         this.closeLootSettings();
         break;

--- a/src/ui/hud/delve/lockpick_controller.ts
+++ b/src/ui/hud/delve/lockpick_controller.ts
@@ -98,6 +98,24 @@ export class LockpickController {
     this.flushEvents();
   }
 
+  /** The panel's ONE dismissal funnel: withdraw from a live lock, or just close the ante
+   *  selector when there is nothing to withdraw from. Both of the panel's own affordances
+   *  already mean exactly this (the board's X is wired to onAbort, the ante selector's to
+   *  onClose), and the capture-phase Escape handler below picks the same arm.
+   *
+   *  It is a named method rather than inline because a THIRD caller needs it and cannot
+   *  reach the handler: `Hud.closeManagedWindow`'s `lockpick-panel` case. A gamepad escape
+   *  goes `main.ts dispatchGamepadAction('escape') -> hud.closeAll()` with no DOM event for
+   *  a keydown listener to intercept, so before #2517 that path fell to the managed-window
+   *  `default:` arm (a bare `display: none`), leaving the 100ms countdown running against a
+   *  hidden subtree, the focus trap armed on an invisible panel, and the session live on the
+   *  server. Withdrawing here is what stops the clock; the trap is released when the
+   *  resulting lockpickEnd lands in `end()`, exactly as on the keyboard path. */
+  requestClose(): void {
+    if (this.deps.getState()) this.submitAbort();
+    else this.close();
+  }
+
   close(restoreFocus = true): void {
     this.deps.panel.style.display = 'none';
     this.window.close();
@@ -124,8 +142,7 @@ export class LockpickController {
       if (event.key === 'Escape') {
         event.preventDefault();
         event.stopImmediatePropagation();
-        if (live) this.submitAbort();
-        else this.close();
+        this.requestClose();
         return;
       }
       if (!live || event.repeat) return;

--- a/src/ui/hud/delve/lockpick_controller.ts
+++ b/src/ui/hud/delve/lockpick_controller.ts
@@ -26,6 +26,10 @@ export interface LockpickControllerDeps {
 export class LockpickController {
   private trap: FocusTrapHandle | null = null;
   private keyHandler: ((event: KeyboardEvent) => void) | null = null;
+  /** The session `requestClose` has already asked the server to withdraw from, so a repeat
+   *  request closes the panel instead of sending a second abort. Keyed on the id rather than
+   *  a bare flag so a fresh engage can never inherit a stale one. */
+  private withdrawnSessionId: string | null = null;
   private readonly window: LockpickWindow;
 
   constructor(private readonly deps: LockpickControllerDeps) {
@@ -99,9 +103,10 @@ export class LockpickController {
   }
 
   /** The panel's ONE dismissal funnel: withdraw from a live lock, or just close the ante
-   *  selector when there is nothing to withdraw from. Both of the panel's own affordances
-   *  already mean exactly this (the board's X is wired to onAbort, the ante selector's to
-   *  onClose), and the capture-phase Escape handler below picks the same arm.
+   *  selector when there is nothing left to withdraw from. Both of the panel's own
+   *  affordances already mean exactly this (the board's X and Withdraw are wired to onAbort,
+   *  the ante selector's X to onClose), and the capture-phase Escape handler below picks the
+   *  same arm.
    *
    *  It is a named method rather than inline because a THIRD caller needs it and cannot
    *  reach the handler: `Hud.closeManagedWindow`'s `lockpick-panel` case. A gamepad escape
@@ -109,11 +114,27 @@ export class LockpickController {
    *  a keydown listener to intercept, so before #2517 that path fell to the managed-window
    *  `default:` arm (a bare `display: none`), leaving the 100ms countdown running against a
    *  hidden subtree, the focus trap armed on an invisible panel, and the session live on the
-   *  server. Withdrawing here is what stops the clock; the trap is released when the
-   *  resulting lockpickEnd lands in `end()`, exactly as on the keyboard path. */
+   *  server, which then burned the tries out and FORFEITED the chest a withdrawal preserves.
+   *
+   *  WITHDRAW ONCE, THEN CLOSE, and the second half is not politeness about duplicate
+   *  commands. `submitAbort()` deliberately does not hide the panel: the close comes from the
+   *  authoritative lockpickEnd, which offline the sim emits and `flushEvents()` drains inside
+   *  this very call, but ONLINE is a wire command whose answer is a frame away. So online the
+   *  panel is still up when `requestClose` returns, and a caller that asks again would send a
+   *  second abort forever. `SkinEventController.open()` is exactly that caller: it sweeps
+   *  `for (i < 20 && closeTop())` to clear the stack before a roll reveal, and without the
+   *  latch it would spin all 20 iterations here and never reach the windows underneath.
+   *  Latching also unwedges the panel when the answer never comes at all:
+   *  `ClientWorld.lockpickState` is rebuilt purely from events and is not reset on reconnect,
+   *  so a stale one would otherwise leave a board that no input could dismiss. */
   requestClose(): void {
-    if (this.deps.getState()) this.submitAbort();
-    else this.close();
+    const live = this.deps.getState();
+    if (live && live.sessionId !== this.withdrawnSessionId) {
+      this.withdrawnSessionId = live.sessionId;
+      this.submitAbort();
+      return;
+    }
+    this.close();
   }
 
   close(restoreFocus = true): void {
@@ -129,6 +150,9 @@ export class LockpickController {
   }
 
   private openPanel(): void {
+    // A fresh ante selector or board is a fresh dismissal: never inherit the latch from the
+    // session before it (openAnte and openBoard are the only ways the panel is shown).
+    this.withdrawnSessionId = null;
     if (this.deps.panel.style.display !== 'block') this.trap = this.deps.openFocusTrap();
     this.deps.panel.style.display = 'block';
     this.bindKeys();

--- a/src/ui/hud/delve/lockpick_controller.ts
+++ b/src/ui/hud/delve/lockpick_controller.ts
@@ -26,9 +26,10 @@ export interface LockpickControllerDeps {
 export class LockpickController {
   private trap: FocusTrapHandle | null = null;
   private keyHandler: ((event: KeyboardEvent) => void) | null = null;
-  /** The session `requestClose` has already asked the server to withdraw from, so a repeat
-   *  request closes the panel instead of sending a second abort. Keyed on the id rather than
-   *  a bare flag so a fresh engage can never inherit a stale one. */
+  /** The session `requestClose` has already asked the server to withdraw from. A repeat
+   *  request for that same session re-sends the abort ONCE as a hedge and then closes,
+   *  rather than withdrawing and waiting forever on an answer that may never come. Keyed on
+   *  the id rather than a bare flag so a fresh engage can never inherit a stale one. */
   private withdrawnSessionId: string | null = null;
   private readonly window: LockpickWindow;
 
@@ -102,11 +103,12 @@ export class LockpickController {
     this.flushEvents();
   }
 
-  /** The panel's ONE dismissal funnel: withdraw from a live lock, or just close the ante
-   *  selector when there is nothing left to withdraw from. Both of the panel's own
-   *  affordances already mean exactly this (the board's X and Withdraw are wired to onAbort,
-   *  the ante selector's X to onClose), and the capture-phase Escape handler below picks the
-   *  same arm.
+  /** The dismissal funnel for every caller that has to CHOOSE an arm: withdraw from a live
+   *  lock, or just close the ante selector when there is nothing left to withdraw from. The
+   *  panel's own buttons do not come through here and do not need to, because each one is
+   *  bound to the arm its markup already implies (the board's X and Withdraw to onAbort, the
+   *  ante selector's X to onClose); the capture-phase Escape handler below and the HUD's
+   *  managed-window case are the callers that face either markup, and they share this.
    *
    *  It is a named method rather than inline because a THIRD caller needs it and cannot
    *  reach the handler: `Hud.closeManagedWindow`'s `lockpick-panel` case. A gamepad escape
@@ -116,17 +118,18 @@ export class LockpickController {
    *  hidden subtree, the focus trap armed on an invisible panel, and the session live on the
    *  server, which then burned the tries out and FORFEITED the chest a withdrawal preserves.
    *
-   *  WITHDRAW ONCE, THEN CLOSE, and the second half is not politeness about duplicate
-   *  commands. `submitAbort()` deliberately does not hide the panel: the close comes from the
-   *  authoritative lockpickEnd, which offline the sim emits and `flushEvents()` drains inside
-   *  this very call, but ONLINE is a wire command whose answer is a frame away. So online the
-   *  panel is still up when `requestClose` returns, and a caller that asks again would send a
-   *  second abort forever. `SkinEventController.open()` is exactly that caller: it sweeps
-   *  `for (i < 20 && closeTop())` to clear the stack before a roll reveal, and without the
-   *  latch it would spin all 20 iterations here and never reach the windows underneath.
-   *  Latching also unwedges the panel when the answer never comes at all:
+   *  WITHDRAW, THEN RE-SEND ONCE AND CLOSE. `submitAbort()` deliberately does not hide the
+   *  panel: the close comes from the authoritative lockpickEnd, which offline the sim emits
+   *  and `flushEvents()` drains inside this very call, but ONLINE is a wire command whose
+   *  answer is a frame away. So online the panel is still up when `requestClose` returns, and
+   *  a caller that asks again would withdraw forever. `SkinEventController.open()` is exactly
+   *  that caller: it sweeps `for (i < 20 && closeTop())` to clear the stack before a roll
+   *  reveal, and without the latch it would spin all 20 iterations here and never reach the
+   *  windows underneath. Latching also unwedges the panel when the answer never comes at all:
    *  `ClientWorld.lockpickState` is rebuilt purely from events and is not reset on reconnect,
-   *  so a stale one would otherwise leave a board that no input could dismiss. */
+   *  so a stale one would otherwise leave a board that no input could dismiss. The repeat arm
+   *  hedges with a second abort before it closes, because a dropped first send and one still
+   *  in flight look identical from here; see the comment on that arm for why. */
   requestClose(): void {
     const live = this.deps.getState();
     if (live && live.sessionId !== this.withdrawnSessionId) {
@@ -141,10 +144,15 @@ export class LockpickController {
     // on a closed socket with no queue and no retry. Closing without asking again in that
     // second case hides a board the server still considers live and lets the per-step clock
     // burn the tries down to lockpickFail, which is #2517's forfeited chest arriving by the
-    // other road. So ask once more, then close regardless, which is what keeps the repeat
-    // callers (the closeTop sweep) advancing. Bounded at two commands per dismissal.
-    if (live) this.submitAbort();
+    // other road. So close, then ask once more, which keeps the repeat callers (the closeTop
+    // sweep) advancing at a cost of two commands per dismissal on this path.
+    //
+    // CLOSE FIRST, and the order is load-bearing rather than tidy: submitAbort ends in
+    // flushEvents, which runs the whole Hud.handleEvents switch, and two of its arms
+    // (lockpickOffer, lockpickSession) call openPanel and put this panel back up. Closing
+    // afterwards would tear down a board the drain had just legitimately opened.
     this.close();
+    if (live) this.submitAbort();
   }
 
   close(restoreFocus = true): void {
@@ -160,13 +168,13 @@ export class LockpickController {
   }
 
   private openPanel(): void {
-    // A fresh ante selector or board is a fresh dismissal. Belt to the id keying's braces,
-    // and NO test reaches it: every ordinary re-engage already gets a different sessionId,
-    // so the comparison in requestClose alone would do. What this covers is the one case it
-    // cannot, an id COLLISION: the sim mints `lp_${objectId}_${ctx.tickCount}`, so a
-    // withdraw and a re-engage on the same chest inside one tick produce the same string,
-    // and the latch would swallow the second withdrawal, which is #2517's forfeiture again.
-    // Said here rather than pinned by a case that could only assert it vacuously.
+    // A fresh ante selector or board is a fresh dismissal. Belt to the id keying's braces:
+    // every ordinary re-engage already gets a different sessionId, so the comparison in
+    // requestClose alone would do. What this covers is the one case it cannot, an id
+    // COLLISION: the sim mints `lp_${objectId}_${ctx.tickCount}`, so a withdraw and a
+    // re-engage on the same chest inside one tick produce the same string. Without the reset
+    // that second board would take the REPEAT arm on its very first dismissal, closing
+    // optimistically instead of withdrawing and waiting for the server to confirm.
     this.withdrawnSessionId = null;
     if (this.deps.panel.style.display !== 'block') this.trap = this.deps.openFocusTrap();
     this.deps.panel.style.display = 'block';

--- a/src/ui/hud/delve/lockpick_controller.ts
+++ b/src/ui/hud/delve/lockpick_controller.ts
@@ -134,6 +134,16 @@ export class LockpickController {
       this.submitAbort();
       return;
     }
+    // A repeat request for a session we already asked to withdraw from means the answer
+    // never came, and only one of the two reasons is benign. Either the abort is still in
+    // flight (the re-send is a server-side no-op: the sim's lockpickAbort returns early once
+    // run.lockpick is null), or it was never sent at all, because ClientWorld.rawCmd DROPS
+    // on a closed socket with no queue and no retry. Closing without asking again in that
+    // second case hides a board the server still considers live and lets the per-step clock
+    // burn the tries down to lockpickFail, which is #2517's forfeited chest arriving by the
+    // other road. So ask once more, then close regardless, which is what keeps the repeat
+    // callers (the closeTop sweep) advancing. Bounded at two commands per dismissal.
+    if (live) this.submitAbort();
     this.close();
   }
 

--- a/src/ui/hud/delve/lockpick_controller.ts
+++ b/src/ui/hud/delve/lockpick_controller.ts
@@ -150,8 +150,13 @@ export class LockpickController {
   }
 
   private openPanel(): void {
-    // A fresh ante selector or board is a fresh dismissal: never inherit the latch from the
-    // session before it (openAnte and openBoard are the only ways the panel is shown).
+    // A fresh ante selector or board is a fresh dismissal. Belt to the id keying's braces,
+    // and NO test reaches it: every ordinary re-engage already gets a different sessionId,
+    // so the comparison in requestClose alone would do. What this covers is the one case it
+    // cannot, an id COLLISION: the sim mints `lp_${objectId}_${ctx.tickCount}`, so a
+    // withdraw and a re-engage on the same chest inside one tick produce the same string,
+    // and the latch would swallow the second withdrawal, which is #2517's forfeiture again.
+    // Said here rather than pinned by a case that could only assert it vacuously.
     this.withdrawnSessionId = null;
     if (this.deps.panel.style.display !== 'block') this.trap = this.deps.openFocusTrap();
     this.deps.panel.style.display = 'block';

--- a/src/ui/hud/delve/lockpick_window.ts
+++ b/src/ui/hud/delve/lockpick_window.ts
@@ -143,6 +143,13 @@ export class LockpickWindow {
    * follow the authoritative state (a new pin/try/page refills it; the lock
    * ending stops it). Driven by the lockpickStep event in both hosts. */
   onStep(result: StepResult): void {
+    // The guard repaintIfChanged already carries, and load-bearing since #2517 gave the panel
+    // a close-while-the-session-is-live path: requestClose's repeat arm closes without waiting
+    // for the server's lockpickEnd, so a lockpickStep still in flight would otherwise land
+    // here, rewrite the hidden panel's markup, and (because close() cleared lastTimerKey)
+    // restart the 100ms countdown against a subtree nobody can see. That is exactly the leak
+    // this issue is about, arriving from the other direction.
+    if (this.panel()?.style.display !== 'block') return;
     const fb = stepFeedback(result);
     // stepFeedback returns English text only for the known step results; localize
     // those via t() and leave the (empty) default unlocalized.

--- a/tests/lockpick_controller.test.ts
+++ b/tests/lockpick_controller.test.ts
@@ -137,4 +137,19 @@ describe('LockpickController', () => {
     expect(test.panel.style.display).toBe('none');
     expect(test.release).toHaveBeenCalledWith(true);
   });
+
+  it('logs a withdrawal without a banner before closing the panel', () => {
+    // end() branches three ways on outcome and only 'success' was pinned, so the colour and
+    // the no-banner half of the arm that a withdrawal actually takes were free to change.
+    // This is the arm every #2517 dismissal of a live board ends on.
+    const test = harness(liveView);
+    test.controller.openBoard();
+
+    test.controller.end('abandoned');
+
+    expect(test.showBanner, 'a withdrawal is not an achievement').not.toHaveBeenCalled();
+    expect(test.log).toHaveBeenCalledWith(expect.any(String), '#ccc');
+    expect(test.panel.style.display).toBe('none');
+    expect(test.release).toHaveBeenCalledWith(true);
+  });
 });

--- a/tests/lockpick_controller.test.ts
+++ b/tests/lockpick_controller.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { FocusTrapHandle } from '../src/ui/focus_manager';
 import { LockpickController } from '../src/ui/hud/delve/lockpick_controller';
+import { t } from '../src/ui/i18n';
 import type { LockpickView } from '../src/world_api';
 import { FakeDocument, FakeWindow } from './helpers/fake_dom';
 
@@ -148,7 +149,9 @@ describe('LockpickController', () => {
     test.controller.end('abandoned');
 
     expect(test.showBanner, 'a withdrawal is not an achievement').not.toHaveBeenCalled();
-    expect(test.log).toHaveBeenCalledWith(expect.any(String), '#ccc');
+    // The KEY, not just the colour: swapping the abandoned and fail summaries (or wiring
+    // this arm to the fail key) leaves an `expect.any(String)` version of this green.
+    expect(test.log).toHaveBeenCalledWith(t('lockpickUi.summary.abandoned'), '#ccc');
     expect(test.panel.style.display).toBe('none');
     expect(test.release).toHaveBeenCalledWith(true);
   });

--- a/tests/lockpick_managed_close.test.ts
+++ b/tests/lockpick_managed_close.test.ts
@@ -245,8 +245,13 @@ describe('lockpick panel: Hud.closeAll (the gamepad escape path)', () => {
   });
 
   it('re-arms the withdrawal for a NEW session, so the latch cannot silence a real abort', () => {
-    // The latch is keyed on sessionId rather than a bare flag for exactly this: pick one lock,
-    // withdraw, then engage another, and the second withdraw must still reach the server.
+    // Pick one lock, withdraw, engage another: the second withdraw must still reach the
+    // server, or the latch would have converted #2517's forfeiture into a subtler one.
+    //
+    // Honest about what this can and cannot separate: the id keying and openPanel's reset
+    // BOTH satisfy it, and no reachable input tells them apart (openBoard runs openPanel on
+    // every lockpickSession). It pins the behavior, not the mechanism; the reset carries its
+    // own comment saying which case it is really there for.
     const h = harness(LIVE);
     h.controller.openBoard();
     h.hud.closeAll();

--- a/tests/lockpick_managed_close.test.ts
+++ b/tests/lockpick_managed_close.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+
+// The lockpick panel's managed-window close path (#2517).
+//
+// `#lockpick-panel` is a `.window .panel`, so `Hud.closeAll()` picks it up through
+// `topmostOpenWindow()` and hands it to `closeManagedWindow`. With no `case` for its id it
+// fell to the `default:` arm, which is `el.style.display = 'none'` and nothing else: the
+// 100ms countdown interval kept firing into a hidden subtree for the rest of the attempt,
+// the focus trap stayed armed on an invisible panel, and the live session was never
+// withdrawn (the server kept burning the per-step clock on a board the player could not see).
+//
+// The keyboard Escape never showed this. `LockpickController` installs a capture-phase
+// window keydown handler that calls `stopImmediatePropagation`, so Escape is handled by the
+// controller and never reaches `src/game/input.ts`'s bubble listener at all. The GAMEPAD
+// escape is the reachable path: `dispatchGamepadAction('escape')` in `src/main.ts` calls
+// `hud.closeAll()` directly, with no DOM event for that capture handler to intercept.
+//
+// So these cases drive `closeAll()` (not a synthetic key event) over a REAL controller and a
+// REAL window, and pin that the two dismissal paths produce the same observable teardown.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FocusTrapHandle } from '../src/ui/focus_manager';
+import { Hud } from '../src/ui/hud';
+import { LockpickController } from '../src/ui/hud/delve/lockpick_controller';
+import type { LockpickView } from '../src/world_api';
+
+const LIVE: LockpickView = {
+  sessionId: 'lp_9_0',
+  objectId: 9,
+  w: 4,
+  h: 4,
+  col: 0,
+  row: 2,
+  page: 1,
+  pageCount: 2,
+  tries: 2,
+  triesTotal: 2,
+  lootTier: 'premium',
+  allowed: ['set', 'steady', 'ease'],
+  visible: [],
+  stepTimeoutMs: 15000,
+};
+
+// Only the members closeAll -> closeManagedWindow actually read; closeManagedWindow is
+// private, so the bare-prototype harness is the hud_confirm_gates / profession_tutorial
+// precedent. `windowDragController` is deliberately left undefined: the real field is
+// optional-chained, and Object.create skips field initializers.
+interface CloseAllHarness {
+  lockpickController: LockpickController;
+  lootWindow: { hasOpenChest: boolean };
+  playerCard: { isOpen: boolean };
+  emoteWheelOpen: boolean;
+  syncAnyWindowOpenState(): void;
+  hideTooltip(): void;
+  closeAll(): boolean;
+  topmostOpenWindow(): HTMLElement | null;
+}
+
+// Every controller a case builds, so afterEach can drop its capture-phase window keydown
+// listener. Without this a controller left OPEN by one case (which is exactly what the bug
+// under test does) keeps a live handler on the shared jsdom window, and its
+// stopImmediatePropagation eats the next case's Escape before the new controller sees it.
+const built: LockpickController[] = [];
+
+function harness(initial: LockpickView | null) {
+  // closeAll reads #ctx-menu and #delve-rite-panel before it ever reaches the topmost
+  // scan, and `$` returns null for a missing id, so both must exist.
+  document.body.innerHTML =
+    '<div id="ctx-menu" style="display:none"></div>' +
+    '<div id="delve-rite-panel" class="window panel" style="display:none"></div>' +
+    '<div id="lockpick-panel" class="window panel" style="display:none"></div>';
+  const panel = document.getElementById('lockpick-panel') as HTMLElement;
+  const release = vi.fn();
+  const trap: FocusTrapHandle = { focusFirst: vi.fn(), release };
+  const abort = vi.fn();
+  const hideTooltip = vi.fn();
+  let state: LockpickView | null = initial;
+  const controller = new LockpickController({
+    panel,
+    keyboardTarget: window,
+    openFocusTrap: () => trap,
+    getState: () => state,
+    engage: vi.fn(),
+    act: vi.fn(),
+    abort,
+    drainEvents: () => null,
+    handleEvents: vi.fn(),
+    showBanner: vi.fn(),
+    log: vi.fn(),
+    hideTooltip,
+  });
+  built.push(controller);
+  const hud = Object.create(Hud.prototype) as unknown as CloseAllHarness;
+  hud.lockpickController = controller;
+  hud.lootWindow = { hasOpenChest: false };
+  hud.playerCard = { isOpen: false };
+  hud.emoteWheelOpen = false;
+  hud.syncAnyWindowOpenState = vi.fn();
+  hud.hideTooltip = hideTooltip;
+  return {
+    controller,
+    hud,
+    panel,
+    release,
+    abort,
+    bar: () => panel.querySelector<HTMLElement>('.lp-timer-bar'),
+    setState(next: LockpickView | null): void {
+      state = next;
+    },
+  };
+}
+
+function tick(ticks: number): void {
+  for (let i = 0; i < ticks; i++) vi.advanceTimersByTime(100);
+}
+
+/** The observable teardown a dismissal must produce, whichever path asked for it. */
+function teardown(h: ReturnType<typeof harness>) {
+  return {
+    aborts: h.abort.mock.calls.length,
+    releases: h.release.mock.calls.length,
+    timers: vi.getTimerCount(),
+    display: h.panel.style.display,
+  };
+}
+
+describe('lockpick panel: Hud.closeAll (the gamepad escape path)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+  afterEach(() => {
+    for (const controller of built.splice(0)) controller.close(false);
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('is the topmost scan hit while the board is up', () => {
+    // If the scan did not select it, every other case below would pass vacuously by
+    // closing something else (or nothing).
+    const h = harness(LIVE);
+    h.controller.openBoard();
+    expect(h.hud.topmostOpenWindow()).toBe(h.panel);
+  });
+
+  it('withdraws from the live session and stops the 100ms countdown', () => {
+    const h = harness(LIVE);
+    h.controller.openBoard();
+    // Exactly one pending timer: the countdown startTimer armed.
+    expect(vi.getTimerCount(), 'the board arms its countdown').toBe(1);
+    const bar = h.bar() as HTMLElement;
+    tick(20);
+    const frozen = bar.style.width;
+    expect(frozen).not.toBe('100%');
+
+    expect(h.hud.closeAll(), 'closeAll reports it closed something').toBe(true);
+
+    // The server is told to withdraw, so the attempt is preserved instead of being
+    // burned down by a per-step clock the player can no longer see.
+    expect(h.abort).toHaveBeenCalledTimes(1);
+    // Asserted as "the clock is GONE", not "nothing throws": painting a detached or
+    // hidden subtree throws nothing at all, so a no-throw assertion passes with the
+    // whole fix reverted.
+    expect(vi.getTimerCount(), 'the countdown interval is cleared').toBe(0);
+    tick(20);
+    expect(bar.style.width, 'the hidden subtree stops being repainted').toBe(frozen);
+  });
+
+  it('dismisses the ante selector outright, releasing the trap and returning focus', () => {
+    // No live session to withdraw from, so this is the arm that must reach close():
+    // the trap release (and with it the WCAG 2.4.3 focus return) has no other route.
+    const h = harness(null);
+    h.controller.openAnte(9);
+    expect(h.panel.style.display).toBe('block');
+
+    expect(h.hud.closeAll()).toBe(true);
+
+    expect(h.abort, 'nothing live to abort').not.toHaveBeenCalled();
+    // release(true), the FocusManager's restoreFocus flag: focus goes back to the opener
+    // (WCAG 2.4.3). A release(false) regression, or the default arm's bare hide, fails here.
+    expect(h.release).toHaveBeenCalledTimes(1);
+    expect(h.release).toHaveBeenCalledWith(true);
+    expect(h.panel.style.display).toBe('none');
+  });
+
+  it('drops the capture-phase key handler, so a later Escape cannot re-fire on a closed panel', () => {
+    const h = harness(null);
+    h.controller.openAnte(9);
+    h.hud.closeAll();
+    h.release.mockClear();
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', cancelable: true }));
+    expect(h.release, 'the listener was removed with the panel').not.toHaveBeenCalled();
+  });
+
+  it('produces the same teardown as the Escape key, live board and ante selector alike', () => {
+    // The two paths are the same funnel or they drift: the keyboard one aborts a live
+    // session and closes an idle one, and the pad must not do something else.
+    for (const initial of [LIVE, null]) {
+      const viaKey = harness(initial);
+      if (initial) viaKey.controller.openBoard();
+      else viaKey.controller.openAnte(9);
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', cancelable: true }));
+      const keyResult = teardown(viaKey);
+      viaKey.controller.close();
+
+      const viaPad = harness(initial);
+      if (initial) viaPad.controller.openBoard();
+      else viaPad.controller.openAnte(9);
+      viaPad.hud.closeAll();
+      const padResult = teardown(viaPad);
+      viaPad.controller.close();
+
+      expect(padResult, `gamepad and keyboard must agree (live=${initial !== null})`).toEqual(
+        keyResult,
+      );
+      // Guard against both paths being vacuously identical no-ops.
+      expect(keyResult.aborts + keyResult.releases).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/lockpick_managed_close.test.ts
+++ b/tests/lockpick_managed_close.test.ts
@@ -2,7 +2,7 @@
 
 // The lockpick panel's managed-window close path (#2517).
 //
-// `#lockpick-panel` is a `.window .panel`, so `Hud.closeAll()` picks it up through
+// `#lockpick-panel` is a `.window.panel`, so `Hud.closeAll()` picks it up through
 // `topmostOpenWindow()` and hands it to `closeManagedWindow`. With no `case` for its id it
 // fell to the `default:` arm, which is `el.style.display = 'none'` and nothing else: the
 // 100ms countdown interval kept firing into a hidden subtree for the rest of the attempt,
@@ -109,8 +109,10 @@ function harness(initial: LockpickView | null, host: 'online' | 'offline' = 'onl
       pending = [];
       return out;
     },
-    // The one arm of Hud.handleEvents this path reaches: lockpickEnd -> endLockpick ->
-    // controller.end(outcome), pinned as a source fact in the registry suite.
+    // The one arm of Hud.handleEvents this path reaches, transcribed from
+    // src/ui/hud.ts's `case 'lockpickEnd': this.endLockpick(...)` -> controller.end(outcome).
+    // Transcribed, NOT pinned: no guard ties this fake to that switch, so a rewrite there
+    // would leave these cases green against a mapping the client no longer has.
     handleEvents: (events) => {
       for (const ev of events) if (ev.type === 'lockpickEnd') controller.end(ev.outcome);
     },
@@ -162,6 +164,9 @@ describe('lockpick panel: Hud.closeAll (the gamepad escape path)', () => {
   });
   afterEach(() => {
     for (const controller of built.splice(0)) controller.close(false);
+    // Not the inline mockRestore()s a failing expect would skip: a spy left on the shared
+    // jsdom window turns one red case into a cascade in every case after it.
+    vi.restoreAllMocks();
     vi.useRealTimers();
     document.body.innerHTML = '';
   });
@@ -203,6 +208,10 @@ describe('lockpick panel: Hud.closeAll (the gamepad escape path)', () => {
     expect(h.panel.style.display, 'still up until lockpickEnd lands').toBe('block');
     // The arm owes its own tooltip hide, since close() (which would have done it) has not run.
     expect(h.hudHideTooltip).toHaveBeenCalledTimes(1);
+    expect(
+      h.depsHideTooltip,
+      'close() has not run, so the controller owed no hide',
+    ).not.toHaveBeenCalled();
   });
 
   it('completes the teardown offline, inside the one closeAll call', () => {
@@ -224,7 +233,7 @@ describe('lockpick panel: Hud.closeAll (the gamepad escape path)', () => {
     expect(h.hud.topmostOpenWindow()).not.toBe(h.panel);
   });
 
-  it('withdraws once, then closes, so a repeat closeAll cannot wedge on the panel', () => {
+  it('withdraws, re-sends once, then closes, so a repeat closeAll cannot wedge on the panel', () => {
     // SkinEventController.open() sweeps `for (i < 20 && closeTop())` to clear the stack before
     // a roll reveal, and closeTop IS closeAll. Online the withdrawal leaves the panel up, so
     // without the per-session latch this spins all 20 iterations here, fires 20 aborts, and
@@ -267,6 +276,48 @@ describe('lockpick panel: Hud.closeAll (the gamepad escape path)', () => {
     h.controller.openBoard();
     h.hud.closeAll();
     expect(h.abort, 'a fresh session withdraws on its own').toHaveBeenCalledTimes(2);
+    // The count alone stopped separating the arms once the repeat arm started re-sending:
+    // both send an abort. What still tells them apart is that the FRESH arm defers the close.
+    expect(h.panel.style.display, 'a fresh session withdraws and waits, it does not close').toBe(
+      'block',
+    );
+    expect(h.release, 'and its trap survives until lockpickEnd').not.toHaveBeenCalled();
+  });
+
+  it('re-arms after a same-id re-engage, which the id keying alone cannot catch', () => {
+    // The collision openPanel's reset exists for. The sim mints
+    // `lp_${objectId}_${ctx.tickCount}`, so a withdraw and a re-engage on one chest inside a
+    // tick reuse the string. Reachable here, and NOT vacuous: without the reset the reopened
+    // board takes the repeat arm on its first dismissal and closes optimistically.
+    const h = harness(LIVE);
+    h.controller.openBoard();
+    h.hud.closeAll();
+    expect(h.abort).toHaveBeenCalledTimes(1);
+
+    // Same session id, fresh board.
+    h.controller.openBoard();
+    h.hud.closeAll();
+    expect(h.panel.style.display, 'the reopened board withdraws and waits').toBe('block');
+    expect(h.release, 'no optimistic close on a re-engaged board').not.toHaveBeenCalled();
+  });
+
+  it('routes the keyboard Escape through the same funnel, latch included', () => {
+    // The fix's central claim is that the key handler and the managed-window case share one
+    // method. Nothing pinned it: reverting bindKeys to its old inline
+    // `if (live) this.submitAbort(); else this.close();` left all cases green, because a
+    // FIRST dismissal is identical either way. The latch is what separates them, so press
+    // Escape twice and require the second press to behave like requestClose's repeat arm.
+    const h = harness(LIVE);
+    h.controller.openBoard();
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', cancelable: true }));
+    expect(h.abort).toHaveBeenCalledTimes(1);
+    expect(h.panel.style.display, 'the first Escape withdraws and waits').toBe('block');
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', cancelable: true }));
+    expect(h.abort, 'the second hedges the re-send').toHaveBeenCalledTimes(2);
+    expect(h.panel.style.display, 'and closes').toBe('none');
+    expect(h.release).toHaveBeenCalledWith(true);
   });
 
   it('dismisses the ante selector outright, releasing the trap and returning focus', () => {
@@ -299,7 +350,6 @@ describe('lockpick panel: Hud.closeAll (the gamepad escape path)', () => {
     // The registration is on the CAPTURE phase, which is what lets the controller beat
     // src/game/input.ts's bubble listener; unbinding without that flag is a silent no-op.
     expect(remove).toHaveBeenCalledWith('keydown', expect.any(Function), true);
-    remove.mockRestore();
 
     // And the behavioral half: with the panel shown again, a surviving listener WOULD act,
     // so this distinguishes "unbound" from "merely short-circuited by the display guard".
@@ -320,7 +370,6 @@ describe('lockpick panel: Hud.closeAll (the gamepad escape path)', () => {
       add.mock.calls.filter(([type]) => type === 'keydown'),
       'the reopened panel rebinds its keyboard',
     ).toHaveLength(1);
-    add.mockRestore();
   });
 
   it('produces the same teardown as the Escape key, live board and ante selector alike', () => {

--- a/tests/lockpick_managed_close.test.ts
+++ b/tests/lockpick_managed_close.test.ts
@@ -81,8 +81,10 @@ function harness(initial: LockpickView | null, host: 'online' | 'offline' = 'onl
   const panel = document.getElementById('lockpick-panel') as HTMLElement;
   const release = vi.fn();
   const trap: FocusTrapHandle = { focusFirst: vi.fn(), release };
-  // Separate spies: the Hud arm owes its own hideTooltip (the trade-window precedent) and
-  // the controller owes one from close(). One shared spy could not tell them apart.
+  // Two spies for ATTRIBUTION only. Production wires the dep as
+  // `hideTooltip: () => this.hideTooltip()` where the controller is built, so in the client
+  // these ARE one call; splitting them here lets a case say which caller owed the hide, and
+  // never claims the two can diverge.
   const hudHideTooltip = vi.fn();
   const depsHideTooltip = vi.fn();
   let state: LockpickView | null = initial;
@@ -235,8 +237,12 @@ describe('lockpick panel: Hud.closeAll (the gamepad escape path)', () => {
     expect(h.abort).toHaveBeenCalledTimes(1);
     expect(h.panel.style.display).toBe('block');
 
-    expect(h.hud.closeAll(), 'second: close').toBe(true);
-    expect(h.abort, 'no second abort for the same session').toHaveBeenCalledTimes(1);
+    expect(h.hud.closeAll(), 'second: re-send, then close').toBe(true);
+    // Two, not one and not one per iteration. ClientWorld.rawCmd drops on a closed socket
+    // with no queue and no retry, so a repeat request has to hedge that the first abort was
+    // never sent; closing on the assumption it landed would hide a live board and forfeit
+    // the chest. Closing anyway on the same pass is what bounds it at two.
+    expect(h.abort, 'one hedge re-send, not one per sweep pass').toHaveBeenCalledTimes(2);
     expect(h.panel.style.display).toBe('none');
     expect(h.release).toHaveBeenCalledWith(true);
 
@@ -303,11 +309,28 @@ describe('lockpick panel: Hud.closeAll (the gamepad escape path)', () => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', cancelable: true }));
     expect(h.release, 'no handler is left on the window').not.toHaveBeenCalled();
     expect(h.abort).not.toHaveBeenCalled();
+
+    // The FIELD was cleared alongside the unbind, which neither assertion above can see.
+    // bindKeys() early-returns on a non-null keyHandler, so dropping just the
+    // `this.keyHandler = null` line leaves the next open with no Escape and no pick hotkeys
+    // at all, while the removeEventListener spy stays perfectly green.
+    const add = vi.spyOn(window, 'addEventListener');
+    h.controller.openAnte(9);
+    expect(
+      add.mock.calls.filter(([type]) => type === 'keydown'),
+      'the reopened panel rebinds its keyboard',
+    ).toHaveLength(1);
+    add.mockRestore();
   });
 
   it('produces the same teardown as the Escape key, live board and ante selector alike', () => {
     // The two paths are the same funnel or they drift: the keyboard one aborts a live
     // session and closes an idle one, and the pad must not do something else.
+    //
+    // SCOPED to what `teardown()` reads. The paths are NOT byte-identical: the managed-window
+    // arm adds its own `this.hideTooltip()`, which the controller's keydown handler has no
+    // way to reach. That difference is deliberate (the arm owes the hide the default arm used
+    // to guarantee) and is pinned in the live case above, not here.
     for (const initial of [LIVE, null]) {
       const viaKey = harness(initial);
       if (initial) viaKey.controller.openBoard();

--- a/tests/lockpick_managed_close.test.ts
+++ b/tests/lockpick_managed_close.test.ts
@@ -19,6 +19,7 @@
 // REAL window, and pin that the two dismissal paths produce the same observable teardown.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SimEvent } from '../src/sim/types';
 import type { FocusTrapHandle } from '../src/ui/focus_manager';
 import { Hud } from '../src/ui/hud';
 import { LockpickController } from '../src/ui/hud/delve/lockpick_controller';
@@ -62,7 +63,15 @@ interface CloseAllHarness {
 // stopImmediatePropagation eats the next case's Escape before the new controller sees it.
 const built: LockpickController[] = [];
 
-function harness(initial: LockpickView | null) {
+/**
+ * @param host which IWorld the deps model, and the distinction is the whole point.
+ *   'online' (the default): `abort` only sends, so `getState()` keeps returning the live view
+ *   and the panel is still up when requestClose returns, exactly like ClientWorld waiting on
+ *   the server's lockpickEnd. 'offline': `abort` does what Sim does, emitting lockpickEnd
+ *   into the drain that `submitAbort`'s own `flushEvents()` reads, so the whole teardown
+ *   lands inside the one closeAll call.
+ */
+function harness(initial: LockpickView | null, host: 'online' | 'offline' = 'online') {
   // closeAll reads #ctx-menu and #delve-rite-panel before it ever reaches the topmost
   // scan, and `$` returns null for a missing id, so both must exist.
   document.body.innerHTML =
@@ -72,9 +81,19 @@ function harness(initial: LockpickView | null) {
   const panel = document.getElementById('lockpick-panel') as HTMLElement;
   const release = vi.fn();
   const trap: FocusTrapHandle = { focusFirst: vi.fn(), release };
-  const abort = vi.fn();
-  const hideTooltip = vi.fn();
+  // Separate spies: the Hud arm owes its own hideTooltip (the trade-window precedent) and
+  // the controller owes one from close(). One shared spy could not tell them apart.
+  const hudHideTooltip = vi.fn();
+  const depsHideTooltip = vi.fn();
   let state: LockpickView | null = initial;
+  let pending: SimEvent[] = [];
+  const abort = vi.fn(() => {
+    if (host !== 'offline') return;
+    // What src/sim/delves/lockpick_controller.ts does: ABANDON the session and emit, both
+    // synchronously, so drainEvents returns it inside the same call stack.
+    state = null;
+    pending.push({ type: 'lockpickEnd', sessionId: LIVE.sessionId, outcome: 'abandoned' });
+  });
   const controller = new LockpickController({
     panel,
     keyboardTarget: window,
@@ -83,11 +102,19 @@ function harness(initial: LockpickView | null) {
     engage: vi.fn(),
     act: vi.fn(),
     abort,
-    drainEvents: () => null,
-    handleEvents: vi.fn(),
+    drainEvents: () => {
+      const out = pending;
+      pending = [];
+      return out;
+    },
+    // The one arm of Hud.handleEvents this path reaches: lockpickEnd -> endLockpick ->
+    // controller.end(outcome), pinned as a source fact in the registry suite.
+    handleEvents: (events) => {
+      for (const ev of events) if (ev.type === 'lockpickEnd') controller.end(ev.outcome);
+    },
     showBanner: vi.fn(),
     log: vi.fn(),
-    hideTooltip,
+    hideTooltip: depsHideTooltip,
   });
   built.push(controller);
   const hud = Object.create(Hud.prototype) as unknown as CloseAllHarness;
@@ -96,13 +123,15 @@ function harness(initial: LockpickView | null) {
   hud.playerCard = { isOpen: false };
   hud.emoteWheelOpen = false;
   hud.syncAnyWindowOpenState = vi.fn();
-  hud.hideTooltip = hideTooltip;
+  hud.hideTooltip = hudHideTooltip;
   return {
     controller,
     hud,
     panel,
     release,
     abort,
+    hudHideTooltip,
+    depsHideTooltip,
     bar: () => panel.querySelector<HTMLElement>('.lp-timer-bar'),
     setState(next: LockpickView | null): void {
       state = next;
@@ -164,6 +193,69 @@ describe('lockpick panel: Hud.closeAll (the gamepad escape path)', () => {
     expect(vi.getTimerCount(), 'the countdown interval is cleared').toBe(0);
     tick(20);
     expect(bar.style.width, 'the hidden subtree stops being repainted').toBe(frozen);
+
+    // The post-condition a reader most needs, and it is deliberate rather than a shortfall:
+    // the withdrawal does NOT close. Online the panel stands and the trap stays armed until
+    // the server's lockpickEnd, which is what the offline case below drives to completion.
+    expect(h.release, 'the trap is released by end(), not by the withdraw').not.toHaveBeenCalled();
+    expect(h.panel.style.display, 'still up until lockpickEnd lands').toBe('block');
+    // The arm owes its own tooltip hide, since close() (which would have done it) has not run.
+    expect(h.hudHideTooltip).toHaveBeenCalledTimes(1);
+  });
+
+  it('completes the teardown offline, inside the one closeAll call', () => {
+    // The other host. Sim.lockpickAbort emits lockpickEnd synchronously and submitAbort's own
+    // flushEvents drains it, so end() -> close() runs before closeAll returns. Without this
+    // case every assertion in the suite describes only the online (deferred) shape.
+    const h = harness(LIVE, 'offline');
+    h.controller.openBoard();
+    expect(vi.getTimerCount()).toBe(1);
+
+    expect(h.hud.closeAll()).toBe(true);
+
+    expect(h.abort).toHaveBeenCalledTimes(1);
+    expect(h.panel.style.display, 'the round trip landed in the same stack').toBe('none');
+    expect(h.release).toHaveBeenCalledTimes(1);
+    expect(h.release).toHaveBeenCalledWith(true);
+    expect(vi.getTimerCount()).toBe(0);
+    // Nothing is left selectable, so a repeat sweep moves on to the next window.
+    expect(h.hud.topmostOpenWindow()).not.toBe(h.panel);
+  });
+
+  it('withdraws once, then closes, so a repeat closeAll cannot wedge on the panel', () => {
+    // SkinEventController.open() sweeps `for (i < 20 && closeTop())` to clear the stack before
+    // a roll reveal, and closeTop IS closeAll. Online the withdrawal leaves the panel up, so
+    // without the per-session latch this spins all 20 iterations here, fires 20 aborts, and
+    // never reaches the windows underneath. Three calls, not two: the third proves the panel
+    // has actually left the scan rather than merely stopped aborting.
+    const h = harness(LIVE);
+    h.controller.openBoard();
+
+    expect(h.hud.closeAll(), 'first: withdraw').toBe(true);
+    expect(h.abort).toHaveBeenCalledTimes(1);
+    expect(h.panel.style.display).toBe('block');
+
+    expect(h.hud.closeAll(), 'second: close').toBe(true);
+    expect(h.abort, 'no second abort for the same session').toHaveBeenCalledTimes(1);
+    expect(h.panel.style.display).toBe('none');
+    expect(h.release).toHaveBeenCalledWith(true);
+
+    expect(h.hud.topmostOpenWindow(), 'the sweep can move on').not.toBe(h.panel);
+    expect(h.hud.closeAll(), 'nothing left for this harness to close').toBe(false);
+  });
+
+  it('re-arms the withdrawal for a NEW session, so the latch cannot silence a real abort', () => {
+    // The latch is keyed on sessionId rather than a bare flag for exactly this: pick one lock,
+    // withdraw, then engage another, and the second withdraw must still reach the server.
+    const h = harness(LIVE);
+    h.controller.openBoard();
+    h.hud.closeAll();
+    expect(h.abort).toHaveBeenCalledTimes(1);
+
+    h.setState({ ...LIVE, sessionId: 'lp_9_1' });
+    h.controller.openBoard();
+    h.hud.closeAll();
+    expect(h.abort, 'a fresh session withdraws on its own').toHaveBeenCalledTimes(2);
   });
 
   it('dismisses the ante selector outright, releasing the trap and returning focus', () => {
@@ -184,13 +276,28 @@ describe('lockpick panel: Hud.closeAll (the gamepad escape path)', () => {
   });
 
   it('drops the capture-phase key handler, so a later Escape cannot re-fire on a closed panel', () => {
+    // NAMED for the listener, and it has to be probed AS the listener. The obvious version
+    // (close, dispatch Escape, assert nothing happened) is worthless: close() sets
+    // display:none BEFORE it unbinds, and the handler's own first line bails on
+    // `display !== 'block'`, so a stale listener is silent anyway and the case stays green
+    // with the whole removeEventListener block deleted.
+    const remove = vi.spyOn(window, 'removeEventListener');
     const h = harness(null);
     h.controller.openAnte(9);
     h.hud.closeAll();
-    h.release.mockClear();
+    // The registration is on the CAPTURE phase, which is what lets the controller beat
+    // src/game/input.ts's bubble listener; unbinding without that flag is a silent no-op.
+    expect(remove).toHaveBeenCalledWith('keydown', expect.any(Function), true);
+    remove.mockRestore();
 
+    // And the behavioral half: with the panel shown again, a surviving listener WOULD act,
+    // so this distinguishes "unbound" from "merely short-circuited by the display guard".
+    h.panel.style.display = 'block';
+    h.release.mockClear();
+    h.abort.mockClear();
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', cancelable: true }));
-    expect(h.release, 'the listener was removed with the panel').not.toHaveBeenCalled();
+    expect(h.release, 'no handler is left on the window').not.toHaveBeenCalled();
+    expect(h.abort).not.toHaveBeenCalled();
   });
 
   it('produces the same teardown as the Escape key, live board and ante selector alike', () => {
@@ -214,8 +321,14 @@ describe('lockpick panel: Hud.closeAll (the gamepad escape path)', () => {
       expect(padResult, `gamepad and keyboard must agree (live=${initial !== null})`).toEqual(
         keyResult,
       );
-      // Guard against both paths being vacuously identical no-ops.
-      expect(keyResult.aborts + keyResult.releases).toBeGreaterThan(0);
+      // The comparison alone is RELATIVE: both paths run the same funnel, so it survives any
+      // change made to the funnel itself, including inverting it (close a live board, abort an
+      // idle one) which keeps the two sides equal and non-empty. Pin the absolute shape too.
+      expect(keyResult, `the shape itself (live=${initial !== null})`).toEqual(
+        initial
+          ? { aborts: 1, releases: 0, timers: 0, display: 'block' }
+          : { aborts: 0, releases: 1, timers: 0, display: 'none' },
+      );
     }
   });
 });

--- a/tests/lockpick_managed_close.test.ts
+++ b/tests/lockpick_managed_close.test.ts
@@ -89,7 +89,12 @@ function harness(initial: LockpickView | null, host: 'online' | 'offline' = 'onl
   const depsHideTooltip = vi.fn();
   let state: LockpickView | null = initial;
   let pending: SimEvent[] = [];
+  const queued: SimEvent[] = [];
   const abort = vi.fn(() => {
+    if (queued.length > 0) {
+      pending.push(...queued.splice(0));
+      return;
+    }
     if (host !== 'offline') return;
     // What src/sim/delves/lockpick_controller.ts does: ABANDON the session and emit, both
     // synchronously, so drainEvents returns it inside the same call stack.
@@ -114,7 +119,12 @@ function harness(initial: LockpickView | null, host: 'online' | 'offline' = 'onl
     // Transcribed, NOT pinned: no guard ties this fake to that switch, so a rewrite there
     // would leave these cases green against a mapping the client no longer has.
     handleEvents: (events) => {
-      for (const ev of events) if (ev.type === 'lockpickEnd') controller.end(ev.outcome);
+      for (const ev of events) {
+        if (ev.type === 'lockpickEnd') controller.end(ev.outcome);
+        // hud.ts's `case 'lockpickSession': this.openLockpickBoard()`. Faithful because the
+        // repeat arm's statement ORDER depends on it: a drained event can re-open this panel.
+        if (ev.type === 'lockpickSession') controller.openBoard();
+      }
     },
     showBanner: vi.fn(),
     log: vi.fn(),
@@ -139,6 +149,10 @@ function harness(initial: LockpickView | null, host: 'online' | 'offline' = 'onl
     bar: () => panel.querySelector<HTMLElement>('.lp-timer-bar'),
     setState(next: LockpickView | null): void {
       state = next;
+    },
+    /** Make the NEXT abort's flushEvents drain carry these events. */
+    queueOnAbort(...events: SimEvent[]): void {
+      queued.push(...events);
     },
   };
 }
@@ -282,6 +296,26 @@ describe('lockpick panel: Hud.closeAll (the gamepad escape path)', () => {
       'block',
     );
     expect(h.release, 'and its trap survives until lockpickEnd').not.toHaveBeenCalled();
+  });
+
+  it("does not clobber a board that the withdrawal's own event drain re-opened", () => {
+    // Why the repeat arm closes BEFORE it re-sends. submitAbort ends in flushEvents, which
+    // runs the whole handleEvents switch, and its lockpickSession / lockpickOffer arms call
+    // openPanel. With the statements the other way round the close lands last and tears down
+    // a board the drain had just legitimately opened, leaving the player staring at nothing
+    // while the server believes a fresh lock is live.
+    const h = harness(LIVE);
+    h.controller.openBoard();
+    h.hud.closeAll(); // withdraw, latch set, panel still up (online shape)
+    expect(h.abort).toHaveBeenCalledTimes(1);
+
+    // The next abort's drain carries a fresh session, the way a re-engage would.
+    h.queueOnAbort({ type: 'lockpickSession', sessionId: 'lp_9_2' } as SimEvent);
+
+    h.hud.closeAll(); // repeat arm: close, then re-send, whose drain re-opens the board
+
+    expect(h.abort).toHaveBeenCalledTimes(2);
+    expect(h.panel.style.display, 'the re-opened board survives the dismissal').toBe('block');
   });
 
   it('re-arms after a same-id re-engage, which the id keying alone cannot catch', () => {

--- a/tests/lockpick_timer_repaint.test.ts
+++ b/tests/lockpick_timer_repaint.test.ts
@@ -241,6 +241,30 @@ describe('lockpick countdown repaint', () => {
     expect(barB.style.width, 'the second instance must paint its own node').toBe(barA.style.width);
   });
 
+  it('ignores a step that lands after the panel was closed while the session is still live', () => {
+    // #2517's repeat-dismissal arm closes the board without waiting for the server's
+    // lockpickEnd, so a lockpickStep can still arrive for a session the player has already
+    // walked away from. Without the display guard, onStep repaints the hidden panel and
+    // (because close() cleared lastTimerKey) syncTimer starts a FRESH 100ms interval on it,
+    // which is the leak the whole issue is about, re-created from the other side.
+    const h = harness();
+    h.win.openBoard();
+    const bar = h.bar() as HTMLElement;
+    tick(20);
+    const frozen = bar.style.width;
+
+    // What the controller's repeat arm does: close the window, state still live.
+    h.panel.style.display = 'none';
+    h.win.close();
+    expect(vi.getTimerCount(), 'close stops the clock').toBe(0);
+
+    h.win.onStep('advanced');
+
+    expect(vi.getTimerCount(), 'a straggler step must not re-arm the countdown').toBe(0);
+    tick(20);
+    expect(bar.style.width, 'and must not repaint the hidden subtree').toBe(frozen);
+  });
+
   it('paints nothing when the board carries no per-step budget', () => {
     const h = harness({ ...VIEW, stepTimeoutMs: null });
     h.win.openBoard();

--- a/tests/managed_window_close_registry.test.ts
+++ b/tests/managed_window_close_registry.test.ts
@@ -6,7 +6,7 @@
 // `el.style.display = 'none'` plus `hideTooltip()`. So membership in that selector is what
 // enrols a window, and a `case` is what gives it a real teardown. Nothing connected the two:
 // `#lockpick-panel` sat on the default arm for its whole life, leaking a 100ms countdown and
-// a focus trap on every Escape and every gamepad escape, and no test could notice.
+// a focus trap on every gamepad escape, and no test could notice.
 //
 // This is the connection. Every id in the family is classified exactly once, and a new
 // `.window.panel` in the markup fails the suite until its author says which bucket it is in.
@@ -48,7 +48,9 @@ const CODE_BUILT: Record<string, string> = {
 const CLOSED_BEFORE_THE_SCAN: Record<string, string> = {
   'delve-rite-panel':
     "closeAll's `$('#delve-rite-panel').style.display === 'block'` arm routes it to " +
-    'closeRitePanel -> RiteController.close(), which releases its focus trap.',
+    'closeRitePanel -> RiteController.close(), which releases its focus trap. That arm is its ' +
+    'ONLY teardown, so the ordering pin below is what defends it: move the arm under the scan ' +
+    'and the panel falls to the default hide with its trap still armed, the #2517 defect.',
 };
 
 /**
@@ -64,13 +66,20 @@ const NO_MANAGED_TEARDOWN: Record<string, string> = {
     "Hud.update()'s mediumHud band behind a display === 'block' gate, so the hide stops it, " +
     'and the mapPing / mapZoneOverride the toggle clears are re-seeded by the next open.',
   'report-window':
-    "Its X and Cancel buttons are literally `el.style.display = 'none'`. No trap, no timer; " +
-    'the panel is rebuilt by innerHTML on every open, so an in-flight submit that resolves ' +
-    'against the hidden window cannot survive into the next one.',
+    "Its X and Cancel buttons are literally `el.style.display = 'none'` and nothing else, so " +
+    'the default arm is a strict superset of its own close path. No trap, no timer; the panel ' +
+    'is rebuilt by innerHTML on every open, so an in-flight submit that resolves against the ' +
+    'hidden window cannot survive into the next one.',
 };
 
-/** The `case '<id>':` labels of the switch inside `Hud.closeManagedWindow`. */
-function readCloseManagedWindowCases(source: string): string[] {
+/**
+ * The switch inside `Hud.closeManagedWindow`: what it keys on, and its `case '<id>':` labels.
+ *
+ * The discriminant comes back too, because the case labels only mean "a window id" for as long
+ * as the switch is still keyed on one. Rewritten to switch on a class or a state enum, the
+ * labels would parse exactly the same and every diff below would compare two unrelated sets.
+ */
+function readCloseManagedWindowSwitch(source: string): { on: string; cases: string[] } {
   const file = ts.createSourceFile('hud.ts', source, ts.ScriptTarget.Latest, true);
   let method: ts.MethodDeclaration | null = null;
   const findMethod = (node: ts.Node): void => {
@@ -80,27 +89,31 @@ function readCloseManagedWindowCases(source: string): string[] {
   ts.forEachChild(file, findMethod);
   if (!method) throw new Error('closeManagedWindow not found in the source');
   // The switch this method OWNS, not one nested inside a callback it happens to contain.
-  let block: ts.CaseBlock | null = null;
+  let found: ts.SwitchStatement | null = null;
   const findSwitch = (node: ts.Node): void => {
-    if (block) return;
+    if (found) return;
     if (ts.isSwitchStatement(node)) {
-      block = node.caseBlock;
+      found = node;
       return;
     }
     ts.forEachChild(node, findSwitch);
   };
   ts.forEachChild((method as ts.MethodDeclaration).body as ts.Block, findSwitch);
-  if (!block) throw new Error('closeManagedWindow has no switch statement');
-  return (block as ts.CaseBlock).clauses
-    .filter(ts.isCaseClause)
-    .map((clause) => (ts.isStringLiteral(clause.expression) ? clause.expression.text : ''))
-    .filter((id) => id !== '');
+  if (!found) throw new Error('closeManagedWindow has no switch statement');
+  const stmt = found as ts.SwitchStatement;
+  return {
+    on: stmt.expression.getText(),
+    cases: stmt.caseBlock.clauses
+      .filter(ts.isCaseClause)
+      .map((clause) => (ts.isStringLiteral(clause.expression) ? clause.expression.text : ''))
+      .filter((id) => id !== ''),
+  };
 }
 
-/** Every `id` carrying BOTH the `window` and `panel` classes, in markup order. */
+/** Every `id` carrying BOTH the `window` and `panel` classes, whatever the tag. */
 function readPanelIds(html: string): string[] {
   const ids: string[] = [];
-  for (const tag of html.match(/<div\b[^>]*>/g) ?? []) {
+  for (const tag of html.match(/<[a-z][a-z0-9-]*\b[^>]*>/gi) ?? []) {
     const id = tag.match(/\bid="([^"]+)"/)?.[1];
     const cls = tag.match(/\bclass="([^"]+)"/)?.[1];
     if (!id || !cls) continue;
@@ -110,13 +123,20 @@ function readPanelIds(html: string): string[] {
   return ids;
 }
 
-const caseIds = readCloseManagedWindowCases(hudTs);
-const markupIds = readPanelIds(indexHtml);
+const closeSwitch = readCloseManagedWindowSwitch(hudTs);
+const caseIds = closeSwitch.cases;
+// The UNION of both game shells. tests/entry_window_parity.test.ts owns the index-vs-play
+// comparison and is where a divergence is reported; taking the union here means this registry
+// still classifies every reachable window while that guard is red, rather than silently
+// excusing a play.html-only window because index.html never mentioned it.
+const markupIds = [...new Set([...readPanelIds(indexHtml), ...readPanelIds(playHtml)])];
 
 describe('closeManagedWindow case registry', () => {
   it('reads the real switch, not a `case` label from anywhere else in the file', () => {
     // Without this the walk could be silently returning [] (or the cases of some other
     // switch) and every diff below would pass by agreeing on nothing.
+    // The labels are window ids only while the switch is still keyed on the id.
+    expect(closeSwitch.on).toBe('el.id');
     expect(caseIds).toContain('confirm-dialog');
     expect(caseIds).toContain('lockpick-panel');
     expect(caseIds.length).toBeGreaterThan(30);
@@ -124,7 +144,7 @@ describe('closeManagedWindow case registry', () => {
 
     // A synthetic source with the same shapes the real file has: a decoy case in another
     // method, one in a nested callback switch, and one inside a string and a comment.
-    const planted = readCloseManagedWindowCases(`
+    const planted = readCloseManagedWindowSwitch(`
       class Hud {
         private other(el: HTMLElement): void {
           switch (el.id) {
@@ -154,15 +174,23 @@ describe('closeManagedWindow case registry', () => {
         }
       }
     `);
-    expect(planted).toEqual(['real-one', 'real-two']);
+    expect(planted).toEqual({ on: 'el.id', cases: ['real-one', 'real-two'] });
   });
 
-  it('finds the same panel family in both game shells', () => {
-    // index.html and play.html are two entries onto the one HUD; a window that exists in
-    // only one of them is a window Escape closes differently depending on how you loaded
-    // the game.
-    expect(readPanelIds(playHtml).slice().sort()).toEqual(markupIds.slice().sort());
+  it('scrapes the real panel family out of the shells', () => {
+    // A markup change that broke the scrape would empty this set, and an empty set makes
+    // every classification below pass by having nothing to classify.
     expect(markupIds.length).toBeGreaterThan(30);
+    expect(markupIds).toContain('lockpick-panel');
+    expect(markupIds).toContain('bags');
+    // Tags other than <div> count, and extra classes and attribute order are tolerated.
+    expect(readPanelIds('<section id="a" class="window panel dev">')).toEqual(['a']);
+    expect(readPanelIds('<div class="panel window" id="b">')).toEqual(['b']);
+    // A panel that is not a window (#ctx-menu's shape) is NOT in the family: closeAll's scan
+    // is `.window.panel`, and mistaking those for members would demand cases for elements it
+    // can never hand to closeManagedWindow.
+    expect(readPanelIds('<div id="c" class="panel">')).toEqual([]);
+    expect(readPanelIds('<div id="d" class="window">')).toEqual([]);
   });
 
   it('classifies every `.window .panel` exactly once', () => {
@@ -176,6 +204,8 @@ describe('closeManagedWindow case registry', () => {
     }));
     // Named rather than counted, so the failure message says WHICH window is unclassified.
     expect(buckets.filter((b) => b.in.length === 0).map((b) => b.id)).toEqual([]);
+    // The direction people forget: an excused id that later grew a real case keeps a stale
+    // excuse, and the next reader trusts the excuse instead of the code.
     expect(
       buckets.filter((b) => b.in.length > 1).map((b) => `${b.id}: ${b.in.join(' + ')}`),
     ).toEqual([]);

--- a/tests/managed_window_close_registry.test.ts
+++ b/tests/managed_window_close_registry.test.ts
@@ -64,7 +64,7 @@ const NO_MANAGED_TEARDOWN: Record<string, string> = {
     "Hud.update()'s mediumHud band behind a display === 'block' gate, so the hide stops it, " +
     'and the mapPing / mapZoneOverride the toggle clears are re-seeded by the next open.',
   'report-window':
-    'Its X and Cancel buttons are literally `el.style.display = \'none\'`. No trap, no timer; ' +
+    "Its X and Cancel buttons are literally `el.style.display = 'none'`. No trap, no timer; " +
     'the panel is rebuilt by innerHTML on every open, so an in-flight submit that resolves ' +
     'against the hidden window cannot survive into the next one.',
 };
@@ -74,8 +74,7 @@ function readCloseManagedWindowCases(source: string): string[] {
   const file = ts.createSourceFile('hud.ts', source, ts.ScriptTarget.Latest, true);
   let method: ts.MethodDeclaration | null = null;
   const findMethod = (node: ts.Node): void => {
-    if (ts.isMethodDeclaration(node) && node.name.getText() === 'closeManagedWindow')
-      method = node;
+    if (ts.isMethodDeclaration(node) && node.name.getText() === 'closeManagedWindow') method = node;
     else ts.forEachChild(node, findMethod);
   };
   ts.forEachChild(file, findMethod);
@@ -177,9 +176,9 @@ describe('closeManagedWindow case registry', () => {
     }));
     // Named rather than counted, so the failure message says WHICH window is unclassified.
     expect(buckets.filter((b) => b.in.length === 0).map((b) => b.id)).toEqual([]);
-    expect(buckets.filter((b) => b.in.length > 1).map((b) => `${b.id}: ${b.in.join(' + ')}`)).toEqual(
-      [],
-    );
+    expect(
+      buckets.filter((b) => b.in.length > 1).map((b) => `${b.id}: ${b.in.join(' + ')}`),
+    ).toEqual([]);
   });
 
   it('keeps every case pointed at a window that still exists', () => {

--- a/tests/managed_window_close_registry.test.ts
+++ b/tests/managed_window_close_registry.test.ts
@@ -14,8 +14,8 @@
 // rather than the silent default of having forgotten.
 //
 // The case list is read with the TypeScript compiler API rather than a regex over the source
-// text. `src/ui/hud.ts` carries about a hundred regex literals in its server-text matchers,
-// several holding apostrophes and escaped slashes, and a hand-rolled scan over it has already
+// text. `src/ui/hud.ts` carries dozens of regex literals in its server-text matchers, some
+// holding an apostrophe or an escaped slash, and a hand-rolled scan over it has already
 // been wrong twice invisibly (see tests/helpers/method_call_sites.ts). A `case '...'` inside
 // one of the file's other switches, or inside a comment or a string, must not count.
 
@@ -34,7 +34,10 @@ const playHtml = readFileSync(`${root}play.html`, 'utf8');
 /**
  * `.window.panel` ids that are built in code instead of shipped in the markup, so
  * `topmostOpenWindow()` still selects them but no HTML entry lists them. Value = the module
- * that creates the element. An unlisted fourth creation site fails the count pin below.
+ * that creates the element. A fourth site written as `className = '...'` or
+ * `classList.add(...)` fails the count pin below; a panel minted through innerHTML,
+ * setAttribute('class', ...), or `className +=` is out of that scan's reach and would need
+ * its own row here.
  */
 const CODE_BUILT: Record<string, string> = {
   'confirm-dialog': 'src/ui/hud.ts (confirmDialog + inputDialog share the one id)',
@@ -51,7 +54,8 @@ const CLOSED_BEFORE_THE_SCAN: Record<string, string> = {
   'delve-rite-panel':
     "closeAll's `$('#delve-rite-panel').style.display === 'block'` arm routes it to " +
     'closeRitePanel -> RiteController.close(), which releases its focus trap. That arm is its ' +
-    'ONLY teardown, so the ordering pin below is what defends it: move the arm under the scan ' +
+    'only teardown ON THE closeAll PATH (its own X, choose(), and the delveRitePulse handler ' +
+    'close it otherwise), so the ordering pin below is what defends it: move the arm under the scan ' +
     'and the panel falls to the default hide with its trap still armed, the #2517 defect.',
 };
 
@@ -137,8 +141,8 @@ function readCloseManagedWindowSwitch(source: string): {
 function readPanelIds(html: string): string[] {
   const ids: string[] = [];
   for (const tag of html.match(/<[a-z][a-z0-9-]*\b[^>]*>/gi) ?? []) {
-    const id = tag.match(/\bid="([^"]+)"/)?.[1];
-    const cls = tag.match(/\bclass="([^"]+)"/)?.[1];
+    const id = tag.match(/\bid=("|')([^"']+)\1/)?.[2];
+    const cls = tag.match(/\bclass=("|')([^"']+)\1/)?.[2];
     if (!id || !cls) continue;
     const classes = cls.split(/\s+/);
     if (classes.includes('window') && classes.includes('panel')) ids.push(id);
@@ -247,9 +251,12 @@ describe('closeManagedWindow case registry', () => {
     // TOKEN-exact, not substring: `classes.includes(...)` and `cls.includes(...)` agree on
     // every input above and part company here.
     expect(readPanelIds('<div id="g" class="windowed paneling">')).toEqual([]);
+    // Single-quoted attributes count too: both shells use double quotes today, so without
+    // this a quote-style change would drop panels out of the family unnoticed.
+    expect(readPanelIds(`<div id='h' class='window panel'>`)).toEqual(['h']);
   });
 
-  it('classifies every `.window .panel` exactly once', () => {
+  it('classifies every `.window.panel` exactly once', () => {
     const buckets = markupIds.map((id) => ({
       id,
       in: [

--- a/tests/managed_window_close_registry.test.ts
+++ b/tests/managed_window_close_registry.test.ts
@@ -23,6 +23,8 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
+import { expectScansOnlyThroughSharedWalkers } from './helpers/scan_guard_self_audit';
+import { tsFilesUnder } from './helpers/ts_files_under';
 
 const root = fileURLToPath(new URL('..', import.meta.url));
 const hudTs = readFileSync(`${root}src/ui/hud.ts`, 'utf8');
@@ -67,9 +69,10 @@ const NO_MANAGED_TEARDOWN: Record<string, string> = {
     'and the mapPing / mapZoneOverride the toggle clears are re-seeded by the next open.',
   'report-window':
     "Its X and Cancel buttons are literally `el.style.display = 'none'` and nothing else, so " +
-    'the default arm is a strict superset of its own close path. No trap, no timer; the panel ' +
-    'is rebuilt by innerHTML on every open, so an in-flight submit that resolves against the ' +
-    'hidden window cannot survive into the next one.',
+    'the default arm is a strict superset of its own close path. No trap, no timer, and the ' +
+    'reason dropdown lives on a node the next open replaces. (Its in-flight submit closure ' +
+    'captures the PANEL, which persists, so a stale resolve can still touch a reopened ' +
+    'window: pre-existing on every close path alike, and no business of this arm.)',
 };
 
 /**
@@ -79,7 +82,14 @@ const NO_MANAGED_TEARDOWN: Record<string, string> = {
  * as the switch is still keyed on one. Rewritten to switch on a class or a state enum, the
  * labels would parse exactly the same and every diff below would compare two unrelated sets.
  */
-function readCloseManagedWindowSwitch(source: string): { on: string; cases: string[] } {
+function readCloseManagedWindowSwitch(source: string): {
+  on: string;
+  cases: string[];
+  /** Each case label mapped to its OWN statements, comments excluded by construction. */
+  bodies: Record<string, string[]>;
+  /** The `default:` arm, the premise every NO_MANAGED_TEARDOWN row leans on. */
+  fallback: string[];
+} {
   const file = ts.createSourceFile('hud.ts', source, ts.ScriptTarget.Latest, true);
   let method: ts.MethodDeclaration | null = null;
   const findMethod = (node: ts.Node): void => {
@@ -101,13 +111,26 @@ function readCloseManagedWindowSwitch(source: string): { on: string; cases: stri
   ts.forEachChild((method as ts.MethodDeclaration).body as ts.Block, findSwitch);
   if (!found) throw new Error('closeManagedWindow has no switch statement');
   const stmt = found as ts.SwitchStatement;
-  return {
-    on: stmt.expression.getText(),
-    cases: stmt.caseBlock.clauses
-      .filter(ts.isCaseClause)
-      .map((clause) => (ts.isStringLiteral(clause.expression) ? clause.expression.text : ''))
-      .filter((id) => id !== ''),
-  };
+  const cases: string[] = [];
+  const bodies: Record<string, string[]> = {};
+  let fallback: string[] = [];
+  for (const clause of stmt.caseBlock.clauses) {
+    if (ts.isDefaultClause(clause)) {
+      fallback = clause.statements.map((s) => s.getText());
+      continue;
+    }
+    // REFUSE rather than skip. Rewriting `case 'lockpick-panel':` to `case LOCKPICK_ID:`
+    // would otherwise make the id vanish from the list instead of failing the parse, and a
+    // registry whose reader can silently return less is the shape this file exists to stop.
+    if (!ts.isStringLiteral(clause.expression))
+      throw new Error(
+        `closeManagedWindow case is not a string literal: ${clause.expression.getText()}`,
+      );
+    const label = clause.expression.text;
+    cases.push(label);
+    bodies[label] = clause.statements.map((s) => s.getText());
+  }
+  return { on: stmt.expression.getText(), cases, bodies, fallback };
 }
 
 /** Every `id` carrying BOTH the `window` and `panel` classes, whatever the tag. */
@@ -122,6 +145,12 @@ function readPanelIds(html: string): string[] {
   }
   return ids;
 }
+
+// The two populations on the day this was written. They are equal by coincidence, not by
+// construction (37 cases = 34 markup panels with a case + 3 code-built; 37 markup ids = those
+// 34 + the 3 without one), so they get two names and must be bumped independently.
+const CASE_COUNT = 37;
+const MARKUP_COUNT = 37;
 
 const closeSwitch = readCloseManagedWindowSwitch(hudTs);
 const caseIds = closeSwitch.cases;
@@ -139,7 +168,9 @@ describe('closeManagedWindow case registry', () => {
     expect(closeSwitch.on).toBe('el.id');
     expect(caseIds).toContain('confirm-dialog');
     expect(caseIds).toContain('lockpick-panel');
-    expect(caseIds.length).toBeGreaterThan(30);
+    // AT the real count on the day this was written, not under it: a floor sitting below is
+    // what lets a case quietly leave (tests/CLAUDE.md). Bump it when the family grows.
+    expect(caseIds.length).toBeGreaterThanOrEqual(CASE_COUNT);
     expect(new Set(caseIds).size, 'no duplicate case labels').toBe(caseIds.length);
 
     // A synthetic source with the same shapes the real file has: a decoy case in another
@@ -174,13 +205,32 @@ describe('closeManagedWindow case registry', () => {
         }
       }
     `);
-    expect(planted).toEqual({ on: 'el.id', cases: ['real-one', 'real-two'] });
+    expect(planted.on).toBe('el.id');
+    expect(planted.cases).toEqual(['real-one', 'real-two']);
+    // Statements, not raw text: the decoy comment and string above are not in any body.
+    expect(planted.bodies['real-one']).toEqual(['this.a();', 'break;']);
+    expect(planted.fallback).toEqual(['break;']);
+
+    // A computed label must REFUSE, not quietly shrink the list.
+    expect(() =>
+      readCloseManagedWindowSwitch(`
+        class Hud {
+          private closeManagedWindow(el: HTMLElement): void {
+            switch (el.id) {
+              case LOCKPICK_PANEL_ID:
+                break;
+            }
+          }
+        }
+      `),
+    ).toThrow(/not a string literal/);
   });
 
   it('scrapes the real panel family out of the shells', () => {
     // A markup change that broke the scrape would empty this set, and an empty set makes
-    // every classification below pass by having nothing to classify.
-    expect(markupIds.length).toBeGreaterThan(30);
+    // every classification below pass by having nothing to classify. Floored AT the real
+    // count for the same reason as the case list.
+    expect(markupIds.length).toBeGreaterThanOrEqual(MARKUP_COUNT);
     expect(markupIds).toContain('lockpick-panel');
     expect(markupIds).toContain('bags');
     // Tags other than <div> count, and extra classes and attribute order are tolerated.
@@ -191,6 +241,12 @@ describe('closeManagedWindow case registry', () => {
     // can never hand to closeManagedWindow.
     expect(readPanelIds('<div id="c" class="panel">')).toEqual([]);
     expect(readPanelIds('<div id="d" class="window">')).toEqual([]);
+    // PER TAG, not a document-wide scrape: the two classes must sit on ONE element. Every
+    // decoy above is a single tag, so they cannot tell the two implementations apart.
+    expect(readPanelIds('<div id="e" class="window"><div id="f" class="panel">')).toEqual([]);
+    // TOKEN-exact, not substring: `classes.includes(...)` and `cls.includes(...)` agree on
+    // every input above and part company here.
+    expect(readPanelIds('<div id="g" class="windowed paneling">')).toEqual([]);
   });
 
   it('classifies every `.window .panel` exactly once', () => {
@@ -243,31 +299,69 @@ describe('closeManagedWindow case registry', () => {
     }
   });
 
-  it('pins the three code-built panels so a fourth has to be classified', () => {
-    // These carry no markup entry, so the markup sweep above cannot see them. An exact
-    // count (not a floor) is what makes a new one a failure instead of a silent addition.
-    const sites = [
-      ...hudTs.matchAll(/className = 'window panel'/g),
-      ...readFileSync(`${root}src/ui/profession_tutorial_window.ts`, 'utf8').matchAll(
-        /className = 'window panel'/g,
-      ),
-      ...readFileSync(`${root}src/ui/dev_command_window.ts`, 'utf8').matchAll(
-        /className = 'window panel[^']*'/g,
-      ),
-    ];
-    expect(sites).toHaveLength(4); // two share #confirm-dialog
+  it('pins the code-built panels so a fourth module has to be classified', () => {
+    // These carry no markup entry, so the shell sweep cannot see them. The claim in
+    // CODE_BUILT's doc comment is that a NEW creation site fails here, and that only holds
+    // if the scan reads the whole tree: three hard-coded readFileSync calls would miss a
+    // panel minted in src/ui/foo_window.ts entirely, leaving it unclassified AND unseen.
+    const sites: Record<string, number> = {};
+    for (const { file, full } of tsFilesUnder(`${root}src`)) {
+      const code = readFileSync(full, 'utf8')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/(^|[^:])\/\/.*$/gm, '$1');
+      // Both spellings, and extra classes tolerated in each: an exact 'window panel' regex
+      // is blind to `className = 'window panel dev-tool'`, which is how the third one is
+      // already written, and to the classList form nothing uses yet.
+      const n =
+        [...code.matchAll(/className = (['"`])([^'"`]*)\1/g)].filter(([, , cls]) => {
+          const tokens = cls.split(/\s+/);
+          return tokens.includes('window') && tokens.includes('panel');
+        }).length +
+        [...code.matchAll(/classList\.add\(([^)]*)\)/g)].filter(
+          ([, args]) => /['"`]window['"`]/.test(args) && /['"`]panel['"`]/.test(args),
+        ).length;
+      if (n > 0) sites[file] = n;
+    }
+    // EXACT, not a floor: a floor cannot notice a new module joining.
+    expect(sites).toEqual({
+      'ui/dev_command_window.ts': 1,
+      'ui/hud.ts': 2, // confirmDialog + inputDialog share the one #confirm-dialog id
+      'ui/profession_tutorial_window.ts': 1,
+    });
     for (const id of Object.keys(CODE_BUILT)) expect(caseIds).toContain(id);
+  });
+
+  it('reads the tree through the shared walker', () => {
+    // tests/CLAUDE.md's shared-walker rule. A hand-rolled readdirSync returns the same list
+    // as tsFilesUnder today and diverges the day a panel module moves down a level, which is
+    // the silent narrowing this pin exists to stop (#2485, #2489, #2502).
+    expectScansOnlyThroughSharedWalkers(import.meta.url, ['ts_files_under']);
   });
 
   it('routes #lockpick-panel through the controller, not a bare hide (#2517)', () => {
     // The regression this registry was written for. The behavioral proof lives in
     // tests/lockpick_managed_close.test.ts; this is the source-level half, so deleting the
     // case fails here even if someone also deletes that suite's harness.
-    const start = hudTs.indexOf('private closeManagedWindow(');
-    const switchBody = hudTs.slice(start, hudTs.indexOf('\n  private ', start + 1));
-    const arm = switchBody.slice(switchBody.indexOf("case 'lockpick-panel':"));
-    expect(arm.slice(0, arm.indexOf('break;'))).toContain(
+    //
+    // Over the parsed STATEMENTS, not a raw slice of the source. A slice from the label to
+    // the first `break;` swallows the arm's own comment, so the pin would be satisfiable by
+    // a comment that merely quotes the call while the call itself is gone.
+    expect(closeSwitch.bodies['lockpick-panel']).toEqual([
       'this.lockpickController.requestClose();',
-    );
+      'this.hideTooltip();',
+      'break;',
+    ]);
+  });
+
+  it('keeps the `default:` arm the bare hide the no-teardown rows assume', () => {
+    // Both NO_MANAGED_TEARDOWN rows are justified by "the default arm is a strict superset
+    // of that window's own close path". Nothing else in the repo pins what the default arm
+    // DOES, so swapping it for an el.remove(), or dropping the tooltip hide, would falsify
+    // both excuses with every other assertion here still green.
+    expect(closeSwitch.fallback).toEqual([
+      "el.style.display = 'none';",
+      'this.hideTooltip();',
+      'break;',
+    ]);
   });
 });

--- a/tests/managed_window_close_registry.test.ts
+++ b/tests/managed_window_close_registry.test.ts
@@ -336,6 +336,16 @@ describe('closeManagedWindow case registry', () => {
     // as tsFilesUnder today and diverges the day a panel module moves down a level, which is
     // the silent narrowing this pin exists to stop (#2485, #2489, #2502).
     expectScansOnlyThroughSharedWalkers(import.meta.url, ['ts_files_under']);
+    // The shared audit proves the walker is IMPORTED and that nothing reads a directory
+    // directly. It cannot see a scan that keeps the import and hard-codes its file list
+    // again, which is the exact revert this file has to survive, so count the call too.
+    // The needle is split, or this assertion line would satisfy itself (the trap
+    // helpers/scan_guard_self_audit.ts documents as its own first mistake).
+    const self = readFileSync(fileURLToPath(import.meta.url), 'utf8');
+    expect(
+      self.split(`tsFilesUnder${'('}`).length - 1,
+      'the walker is called, not just imported',
+    ).toBe(1);
   });
 
   it('routes #lockpick-panel through the controller, not a bare hide (#2517)', () => {

--- a/tests/managed_window_close_registry.test.ts
+++ b/tests/managed_window_close_registry.test.ts
@@ -1,0 +1,244 @@
+// The managed-window close registry (#2517).
+//
+// `Hud.closeAll()` reaches a window through `topmostOpenWindow()`, whose whole vocabulary is
+// the CSS selector `.window.panel`. Whatever it finds goes to `closeManagedWindow`, which
+// switches on `el.id`; anything with no `case` falls to `default:`, a bare
+// `el.style.display = 'none'` plus `hideTooltip()`. So membership in that selector is what
+// enrols a window, and a `case` is what gives it a real teardown. Nothing connected the two:
+// `#lockpick-panel` sat on the default arm for its whole life, leaking a 100ms countdown and
+// a focus trap on every Escape and every gamepad escape, and no test could notice.
+//
+// This is the connection. Every id in the family is classified exactly once, and a new
+// `.window.panel` in the markup fails the suite until its author says which bucket it is in.
+// The point is not the ids; it is that "needs no teardown" becomes a claim someone WROTE
+// rather than the silent default of having forgotten.
+//
+// The case list is read with the TypeScript compiler API rather than a regex over the source
+// text. `src/ui/hud.ts` carries about a hundred regex literals in its server-text matchers,
+// several holding apostrophes and escaped slashes, and a hand-rolled scan over it has already
+// been wrong twice invisibly (see tests/helpers/method_call_sites.ts). A `case '...'` inside
+// one of the file's other switches, or inside a comment or a string, must not count.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const hudTs = readFileSync(`${root}src/ui/hud.ts`, 'utf8');
+const indexHtml = readFileSync(`${root}index.html`, 'utf8');
+const playHtml = readFileSync(`${root}play.html`, 'utf8');
+
+/**
+ * `.window.panel` ids that are built in code instead of shipped in the markup, so
+ * `topmostOpenWindow()` still selects them but no HTML entry lists them. Value = the module
+ * that creates the element. An unlisted fourth creation site fails the count pin below.
+ */
+const CODE_BUILT: Record<string, string> = {
+  'confirm-dialog': 'src/ui/hud.ts (confirmDialog + inputDialog share the one id)',
+  'profession-tutorial': 'src/ui/profession_tutorial_window.ts',
+  'dev-command-window': 'src/ui/dev_command_window.ts',
+};
+
+/**
+ * Ids an EARLIER arm of `closeAll()` claims before the `topmostOpenWindow()` scan ever runs,
+ * so `closeManagedWindow` is unreachable for them and a `case` would be dead code. Each is
+ * checked below to really precede the scan in the source.
+ */
+const CLOSED_BEFORE_THE_SCAN: Record<string, string> = {
+  'delve-rite-panel':
+    "closeAll's `$('#delve-rite-panel').style.display === 'block'` arm routes it to " +
+    'closeRitePanel -> RiteController.close(), which releases its focus trap.',
+};
+
+/**
+ * Ids deliberately left on the `default:` arm: their own close affordance is the same bare
+ * hide, and they own no trap, no timer, and no state the next open does not re-seed. This is
+ * the "recorded as not needing one" half of the contract, and each entry is a claim its
+ * author checked, not a leftover.
+ */
+const NO_MANAGED_TEARDOWN: Record<string, string> = {
+  'map-window':
+    "#map-close's own handler is the identical hide + hideTooltip, and closeManagedWindow " +
+    'adds the same syncAnyWindowOpenState. No trap, no timer: updateMapWindow is driven by ' +
+    "Hud.update()'s mediumHud band behind a display === 'block' gate, so the hide stops it, " +
+    'and the mapPing / mapZoneOverride the toggle clears are re-seeded by the next open.',
+  'report-window':
+    'Its X and Cancel buttons are literally `el.style.display = \'none\'`. No trap, no timer; ' +
+    'the panel is rebuilt by innerHTML on every open, so an in-flight submit that resolves ' +
+    'against the hidden window cannot survive into the next one.',
+};
+
+/** The `case '<id>':` labels of the switch inside `Hud.closeManagedWindow`. */
+function readCloseManagedWindowCases(source: string): string[] {
+  const file = ts.createSourceFile('hud.ts', source, ts.ScriptTarget.Latest, true);
+  let method: ts.MethodDeclaration | null = null;
+  const findMethod = (node: ts.Node): void => {
+    if (ts.isMethodDeclaration(node) && node.name.getText() === 'closeManagedWindow')
+      method = node;
+    else ts.forEachChild(node, findMethod);
+  };
+  ts.forEachChild(file, findMethod);
+  if (!method) throw new Error('closeManagedWindow not found in the source');
+  // The switch this method OWNS, not one nested inside a callback it happens to contain.
+  let block: ts.CaseBlock | null = null;
+  const findSwitch = (node: ts.Node): void => {
+    if (block) return;
+    if (ts.isSwitchStatement(node)) {
+      block = node.caseBlock;
+      return;
+    }
+    ts.forEachChild(node, findSwitch);
+  };
+  ts.forEachChild((method as ts.MethodDeclaration).body as ts.Block, findSwitch);
+  if (!block) throw new Error('closeManagedWindow has no switch statement');
+  return (block as ts.CaseBlock).clauses
+    .filter(ts.isCaseClause)
+    .map((clause) => (ts.isStringLiteral(clause.expression) ? clause.expression.text : ''))
+    .filter((id) => id !== '');
+}
+
+/** Every `id` carrying BOTH the `window` and `panel` classes, in markup order. */
+function readPanelIds(html: string): string[] {
+  const ids: string[] = [];
+  for (const tag of html.match(/<div\b[^>]*>/g) ?? []) {
+    const id = tag.match(/\bid="([^"]+)"/)?.[1];
+    const cls = tag.match(/\bclass="([^"]+)"/)?.[1];
+    if (!id || !cls) continue;
+    const classes = cls.split(/\s+/);
+    if (classes.includes('window') && classes.includes('panel')) ids.push(id);
+  }
+  return ids;
+}
+
+const caseIds = readCloseManagedWindowCases(hudTs);
+const markupIds = readPanelIds(indexHtml);
+
+describe('closeManagedWindow case registry', () => {
+  it('reads the real switch, not a `case` label from anywhere else in the file', () => {
+    // Without this the walk could be silently returning [] (or the cases of some other
+    // switch) and every diff below would pass by agreeing on nothing.
+    expect(caseIds).toContain('confirm-dialog');
+    expect(caseIds).toContain('lockpick-panel');
+    expect(caseIds.length).toBeGreaterThan(30);
+    expect(new Set(caseIds).size, 'no duplicate case labels').toBe(caseIds.length);
+
+    // A synthetic source with the same shapes the real file has: a decoy case in another
+    // method, one in a nested callback switch, and one inside a string and a comment.
+    const planted = readCloseManagedWindowCases(`
+      class Hud {
+        private other(el: HTMLElement): void {
+          switch (el.id) {
+            case 'decoy-other-method':
+              break;
+          }
+        }
+        private closeManagedWindow(el: HTMLElement): void {
+          // case 'decoy-comment':
+          const s = "case 'decoy-string':";
+          switch (el.id) {
+            case 'real-one':
+              this.a();
+              break;
+            case 'real-two': {
+              el.addEventListener('x', () => {
+                switch (s) {
+                  case 'decoy-nested':
+                    break;
+                }
+              });
+              break;
+            }
+            default:
+              break;
+          }
+        }
+      }
+    `);
+    expect(planted).toEqual(['real-one', 'real-two']);
+  });
+
+  it('finds the same panel family in both game shells', () => {
+    // index.html and play.html are two entries onto the one HUD; a window that exists in
+    // only one of them is a window Escape closes differently depending on how you loaded
+    // the game.
+    expect(readPanelIds(playHtml).slice().sort()).toEqual(markupIds.slice().sort());
+    expect(markupIds.length).toBeGreaterThan(30);
+  });
+
+  it('classifies every `.window .panel` exactly once', () => {
+    const buckets = markupIds.map((id) => ({
+      id,
+      in: [
+        caseIds.includes(id) ? 'case' : null,
+        id in CLOSED_BEFORE_THE_SCAN ? 'closed-before-the-scan' : null,
+        id in NO_MANAGED_TEARDOWN ? 'no-teardown' : null,
+      ].filter(Boolean),
+    }));
+    // Named rather than counted, so the failure message says WHICH window is unclassified.
+    expect(buckets.filter((b) => b.in.length === 0).map((b) => b.id)).toEqual([]);
+    expect(buckets.filter((b) => b.in.length > 1).map((b) => `${b.id}: ${b.in.join(' + ')}`)).toEqual(
+      [],
+    );
+  });
+
+  it('keeps every case pointed at a window that still exists', () => {
+    // The other direction: a renamed or deleted window leaves a case that can never fire,
+    // and the next reader assumes the id is still covered.
+    const known = new Set([...markupIds, ...Object.keys(CODE_BUILT)]);
+    expect(caseIds.filter((id) => !known.has(id))).toEqual([]);
+  });
+
+  it('keeps every registry row pointed at a window that still exists', () => {
+    const live = new Set(markupIds);
+    const rows = { ...CLOSED_BEFORE_THE_SCAN, ...NO_MANAGED_TEARDOWN };
+    expect(Object.keys(rows).filter((id) => !live.has(id))).toEqual([]);
+    // A row is a claim someone made, so it has to say something. An empty or one-word
+    // reason is the same silence the default arm already gives.
+    for (const [id, reason] of Object.entries(rows)) {
+      expect(reason.length, `${id} needs a real reason`).toBeGreaterThan(60);
+    }
+  });
+
+  it('reaches the closed-before-the-scan windows from an arm that really does precede the scan', () => {
+    // The whole justification for those rows is ORDER. If the early arm moved below the
+    // topmost scan (or was deleted), they would silently fall to the default hide.
+    const body = hudTs.slice(hudTs.indexOf('  closeAll(): boolean {'));
+    const closeAll = body.slice(0, body.indexOf('\n  }'));
+    const scanAt = closeAll.indexOf('this.topmostOpenWindow()');
+    expect(scanAt).toBeGreaterThan(-1);
+    for (const id of Object.keys(CLOSED_BEFORE_THE_SCAN)) {
+      const armAt = closeAll.indexOf(`#${id}`);
+      expect(armAt, `${id} has no arm in closeAll`).toBeGreaterThan(-1);
+      expect(armAt, `${id}'s arm must run before the topmost scan`).toBeLessThan(scanAt);
+    }
+  });
+
+  it('pins the three code-built panels so a fourth has to be classified', () => {
+    // These carry no markup entry, so the markup sweep above cannot see them. An exact
+    // count (not a floor) is what makes a new one a failure instead of a silent addition.
+    const sites = [
+      ...hudTs.matchAll(/className = 'window panel'/g),
+      ...readFileSync(`${root}src/ui/profession_tutorial_window.ts`, 'utf8').matchAll(
+        /className = 'window panel'/g,
+      ),
+      ...readFileSync(`${root}src/ui/dev_command_window.ts`, 'utf8').matchAll(
+        /className = 'window panel[^']*'/g,
+      ),
+    ];
+    expect(sites).toHaveLength(4); // two share #confirm-dialog
+    for (const id of Object.keys(CODE_BUILT)) expect(caseIds).toContain(id);
+  });
+
+  it('routes #lockpick-panel through the controller, not a bare hide (#2517)', () => {
+    // The regression this registry was written for. The behavioral proof lives in
+    // tests/lockpick_managed_close.test.ts; this is the source-level half, so deleting the
+    // case fails here even if someone also deletes that suite's harness.
+    const start = hudTs.indexOf('private closeManagedWindow(');
+    const switchBody = hudTs.slice(start, hudTs.indexOf('\n  private ', start + 1));
+    const arm = switchBody.slice(switchBody.indexOf("case 'lockpick-panel':"));
+    expect(arm.slice(0, arm.indexOf('break;'))).toContain(
+      'this.lockpickController.requestClose();',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`Hud.closeAll()` picks the topmost visible `.window .panel` and hands it to
`closeManagedWindow`, which switches on `el.id`. `#lockpick-panel` had no `case`, so it landed
on `default:` (a bare `el.style.display = 'none'` plus `hideTooltip()`), and the panel's own
teardown never ran.

The keyboard Escape hid this: `LockpickController` installs a capture-phase `window` keydown
handler that calls `stopImmediatePropagation`, so Escape is served by the controller and never
reaches `closeAll()` at all. Three other paths do reach it, none of them with a DOM event for
that handler to intercept:

- `dispatchGamepadAction('escape')` in `src/main.ts` calls `hud.closeAll()` directly.
- `GamepadManager`'s virtual-cursor mode dispatches the same `'escape'` action on B / Start.
- `SkinEventController.open()` runs `closeTop()` (which is `closeAll()`) up to 20 times to
  clear stacked HUD surfaces before a skin-roll reveal.

**This is a gameplay loss, not just a leak.** Because the default arm neither withdraws nor
closes, the sim session stays live behind the hidden panel. `repaintIfChanged()` early-returns
on the hidden panel but `onStep()` does not, so each authoritative `lockpickStep` repaints the
invisible subtree and re-arms the 100ms interval, until the tries run out and the sim takes
`lockpickFail`, which sets `attemptAvailable = false` and forfeits the chest. `lockpickAbort`
explicitly preserves the attempt. So a gamepad Escape lost the chest where the keyboard Escape
kept it. On top of that the focus trap stayed armed on an invisible panel (the `FocusManager`
self-heal only pops it on the next Tab, and pops it without the WCAG 2.4.3 focus return), and
`controller.trap` stayed non-null, so the next open orphaned the old trap on the stack.

### The fix

`case 'lockpick-panel'` routes to a named `LockpickController.requestClose()`: withdraw from a
live lock, otherwise dismiss the ante selector. That is not a new rule, it is the one the panel
already implements from every other direction. The board's X and its Withdraw button are wired
to `onAbort`, the ante selector's X to `onClose`, and the Escape handler branches between them;
the two X buttons each cover one arm because the two markups are mutually exclusive with the
session state. The keydown handler now calls the same method, so the three paths cannot drift.

Withdrawing (rather than just closing) is what stops the clock synchronously in both hosts:
`stopTimer()` is the first statement of `submitAbort()`, before the command goes out. Offline the
whole chain drains in one stack (`lockpickAbort` emits `lockpickEnd`, `flushEvents` drains it,
`end()` closes and releases the trap). Online the close waits one server round-trip, exactly as
it already does for the keyboard Escape and the X button.

**The withdrawal is latched per session, and a repeat asks again before closing.** Leaving the
panel up online removed the last unconditional hide, which broke a caller: `SkinEventController`
sweeps `for (i < 20 && closeTop())` to clear the stack before a skin-roll reveal, and `closeTop`
is `closeAll`. Without a latch that sweep spins all twenty passes on this one panel and never
reaches the windows underneath. Worse, `ClientWorld.lockpickState` is rebuilt purely from events
with no snapshot field and is not reset on reconnect, so a stale one would leave a board no input
could dismiss. The repeat also re-sends the abort first, because `ClientWorld.rawCmd` drops on a
closed socket with no queue and no retry: closing on the assumption the first one landed would
hide a live board and let the per-step clock forfeit the chest, which is this same bug from the
other side. Bounded at two commands per dismissal; the sim ignores the duplicate.

Two consequences worth stating, both real behavior changes rather than defects. A second Escape
on a live online board now re-sends the withdrawal and dismisses the panel locally, instead of
doing nothing visible until the server answers. And `LockpickWindow.onStep` gained the display
guard its sibling `repaintIfChanged` already had, because closing while the session is live is
newly reachable: without it a step still in flight would rewrite the hidden panel and restart
the countdown against it, which is this issue's own leak arriving by the other road.

### The family sweep

The issue asked whether any other `.window .panel` was in the same position. All 40 were
checked (37 in the markup plus `#confirm-dialog`, `#profession-tutorial`, `#dev-command-window`
minted in code). `#lockpick-panel` was the only real gap. The other three without a `case`:

- `#delve-rite-panel` owns a focus trap and has no `case`, but `closeAll()` intercepts it in an
  arm that runs *before* the topmost scan, so `closeManagedWindow` is unreachable for it and a
  `case` would be dead code. That interception was undefended, so it is pinned now.
- `#map-window` and `#report-window` genuinely need nothing: their own close buttons are the
  same bare hide, they own no trap and no timer, and the state `toggleMap` clears is re-seeded
  by the next open.

`tests/managed_window_close_registry.test.ts` makes that a standing contract instead of a
one-off review note. Every `.window .panel` id must land in exactly one of three buckets (has a
`case`, claimed by an earlier `closeAll` arm, or explicitly recorded as needing no teardown
with a written reason), diffed both ways so a stale `case` or a stale excuse also fails. The
`case` list is read with the TypeScript compiler API rather than a regex, because `hud.ts`
carries about a hundred regex literals in its server-text matchers and a hand-rolled scan over
it has already been wrong twice invisibly (see `tests/helpers/method_call_sites.ts`).

## Related issues

Closes #2517. Found by the frontend-seam review on #2516.

## Type of change

- [x] Bug fix
- [x] Tests

## How was this tested?

- Commands:
  - `npm run gate` (green in the branch worktree).
  - `npx vitest run tests/lockpick_managed_close.test.ts tests/managed_window_close_registry.test.ts`
  - Written test-first: the new behavioral suite is red on the parent commit with the exact
    signature of the bug (`aborts: 0, timers: 1, display: none` on the pad path against
    `aborts: 1, timers: 0, display: block` on the keyboard path).
- Reviewed by four independent lenses (QA gate, presentation seam, test-coverage/pin quality,
  cross-platform parity), every finding then adversarially verified: 33 raised, 24 survived, all
  24 applied including the nits. Three of them were defects in this PR's own first cut, not in
  the code it fixes: one new test passed with the fix fully reverted, the keyboard/pad parity
  case agreed just as happily with an inverted funnel, and the registry's source pin was
  gameable by a comment quoting the call it was meant to pin.
- Mutation battery, 18/18 caught by the intended assertion:
  - Source: case deleted; case replaced by a bare hide; `requestClose` always closing; always
    aborting; the per-session latch removed; the arm's `hideTooltip()` dropped; the `default:`
    arm changed to `el.remove()`; `submitAbort` no longer stopping the clock; `close()`
    releasing with `restoreFocus = false`; the unbind losing its capture flag.
  - Registry: a `case` renamed to a window that does not exist; a `NO_MANAGED_TEARDOWN` row
    dropped; a new unclassified `.window .panel` in `index.html`; one only in `play.html`; the
    `#delve-rite-panel` arm moved below the topmost scan; a fourth code-built panel module.
  - Self-audit: the harness's listener cleanup removed; the reader filtering a computed case
    label instead of refusing; `readPanelIds` going substring instead of token-exact; the scan
    reverting to a hard-coded file list while keeping the walker import.
- Manual steps: N/A. The reachable path is a gamepad button, and the change is behavior behind
  an existing affordance with no visual surface.

## Screenshots / recordings

N/A. Nothing changes visually: the panel already disappeared, it just did not tear down.

---

## Checklist

### Quality

- [x] **The full gate passes.**

### Cross-platform

- [x] **Tested on desktop and mobile.** ~Viewport work~: no layout, CSS, or markup change. On
      touch there is no `closeAll` route at all (the mobile menu button goes straight to
      `toggleOptionsMenu`), so the lockpick panel is dismissed there by its own X, which
      already took the correct path.
- [x] **Accessible.** This is the accessibility fix: the focus trap is now released and focus
      returns to the opener on the pad path, instead of the trap being left armed on an
      invisible panel and focus dropping to `<body>`.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in
      any production path.
- [x] I didn't hand-edit generated files.
