### PR TITLE
fix(ui): format the three Town Focus counts through the active locale

### DIFF
--- a/src/ui/town_focus_window.ts
+++ b/src/ui/town_focus_window.ts
@@ -87,11 +87,19 @@ export function renderTownFocusWindow(
     el.appendChild(notInTown);
   }
 
+  // Formatted, not spliced: t()'s interpolate() ends in a bare String(value),
+  // which is JavaScript's own fixed number-to-string spelling and never reaches
+  // Intl, so a raw number here renders the same digits for every player
+  // whatever language they picked (#2530). Same option bag as the tier hint
+  // above, which is the whole point: two adjacent lines rendering counts must
+  // not disagree about how a count is spelled. Invisible for the shipped
+  // 0..FOCUS_POINT_BUDGET range, which is exactly why it was easy to write the
+  // other way.
   const budget = document.createElement('div');
   budget.className = 'town-focus-budget';
   budget.textContent = t('hudChrome.townFocus.budgetLabel', {
-    remaining: view.remaining,
-    budget: view.budget,
+    remaining: formatNumber(view.remaining, { maximumFractionDigits: 0 }),
+    budget: formatNumber(view.budget, { maximumFractionDigits: 0 }),
   });
   el.appendChild(budget);
 
@@ -102,7 +110,12 @@ export function renderTownFocusWindow(
     );
     const rowEl = document.createElement('div');
     rowEl.className = 'town-focus-row';
-    rowEl.innerHTML = `<span class="tf-name">${esc(componentName)}</span><span class="tf-points">${row.points}</span>`;
+    // esc() as well as formatNumber, matching the name beside it: no separator
+    // any supported locale emits is HTML-special (they are U+002C, U+002E,
+    // U+00A0, U+202F), so this is a no-op today and stays one for the file's
+    // "every interpolation is escaped" rule rather than being an exception a
+    // reader has to re-derive.
+    rowEl.innerHTML = `<span class="tf-name">${esc(componentName)}</span><span class="tf-points">${esc(formatNumber(row.points, { maximumFractionDigits: 0 }))}</span>`;
 
     const dec = document.createElement('button');
     dec.type = 'button';

--- a/tests/town_focus_number_format.test.ts
+++ b/tests/town_focus_number_format.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+// Town Focus spells its numbers in the active locale (issue #2530).
+//
+// The panel handed three raw numbers straight to the render sinks: two as t()
+// interpolation values for the budget line and one spliced into the row
+// template's innerHTML. t()'s interpolate() finishes with a bare String(value),
+// so none of the three ever reached Intl, two lines below a tier hint that
+// formats correctly. Root CLAUDE.md: "Numbers, money, dates, percents go
+// through formatNumber/formatMoney/formatDateTime/Intl."
+//
+// WHAT THIS FILE OWNS, stated narrowly on purpose: the three numbers the
+// painter takes off the TownFocusView. The panel paints a FOURTH, the tier
+// hint's POINTS_PER_TIER_BONUS / MAX_FOCUS_TIER_BONUS, which was already
+// formatted and is the reference this fix was written to match. It is not
+// pinned here or anywhere else, and it cannot be pinned the way these three
+// are: both are module constants imported from src/sim/professions/focus (5 and
+// 2), so no input reaches the range where a formatted and a raw number differ
+// and both arms of any assertion would coincide.
+//
+// WHY THIS FILE HAS TO BUILD AN OUT-OF-RANGE VIEW, stated up front because it
+// is the one thing a reader will question. FOCUS_POINT_BUDGET is 10, and every
+// supported locale renders 0..999 as the same ASCII digits (none uses a
+// non-Latin numbering system, and no grouping separator fires below a
+// thousand). So a case painted at the shipped budget cannot tell a formatted
+// number from a raw one: both arms of the fix coincide and the pin is dead on
+// arrival. Every view below still comes out of the REAL buildTownFocusView,
+// which takes the budget as a parameter and reads points straight off the
+// allocation, so what is synthetic is the INPUT, never the view shape.
+//
+// The third case is the same argument one level down: { maximumFractionDigits: 0 }
+// is unobservable on any integer, so a fractional input is the only way to
+// assert the option bag behaviorally instead of scraping the painter's source
+// for the literal call (which a local helper would silently kill).
+//
+// The repaint gate (tests/town_focus_repaint_gate.test.ts) owns everything else
+// about this painter and asserts nothing about rendered digits, deliberately:
+// it queries controls by data-focus-key and by class, so formatting is free to
+// change under it.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FOCUS_POINT_BUDGET } from '../src/sim/professions/focus';
+import { ensureLocaleLoaded, setLanguage, supportedLanguages } from '../src/ui/i18n';
+import { buildTownFocusView, TOWN_FOCUS_COMPONENTS } from '../src/ui/town_focus_view';
+import { renderTownFocusWindow } from '../src/ui/town_focus_window';
+
+/** Rows keep TOWN_FOCUS_COMPONENTS order, so this one owns the FIRST .tf-points. */
+const COMPONENT = TOWN_FOCUS_COMPONENTS[0];
+
+function paint(allocation: Record<string, number>, budget: number): HTMLElement {
+  document.getElementById('town-focus-window')?.remove();
+  const el = document.createElement('div');
+  el.id = 'town-focus-window';
+  document.body.appendChild(el);
+  renderTownFocusWindow(el, buildTownFocusView(allocation, budget, true), {
+    onStep: vi.fn(),
+    onSave: vi.fn(),
+    onClose: vi.fn(),
+  });
+  return el;
+}
+
+const budgetLine = (el: HTMLElement): string =>
+  el.querySelector('.town-focus-budget')?.textContent ?? '';
+
+/** The row count, alone in its own span: the one number in this panel that can
+ *  be asserted without also asserting the catalog sentence around it. */
+const rowPoints = (el: HTMLElement): string => el.querySelector('.tf-points')?.textContent ?? '';
+
+/**
+ * The numbers out of a rendered sentence, in order.
+ *
+ * Pulled out rather than asserting the sentence whole, so the pin survives a
+ * copy reword and can compare a German render against an English one. The two
+ * non-ASCII group separators the supported locales use are written as escapes
+ * on purpose: typed literally they are invisible in a diff and a reviewer
+ * cannot tell U+00A0 from a plain space. A plain space is deliberately NOT in
+ * the class, or the run would swallow the copy between two numbers.
+ *
+ * Every run has to END on a digit, which is what makes the reword claim above
+ * true rather than lucky: no locale spells a number with a trailing separator,
+ * but plenty of copy could put a period or a comma straight after {budget}, and
+ * a greedy class would absorb it and red these cases with a mismatch that has
+ * nothing to do with formatting.
+ */
+const numbersIn = (line: string): string[] =>
+  [...line.matchAll(/\d(?:[\d.,\u00A0\u202F]*\d)?/g)].map((m) => m[0]);
+
+describe('the Town Focus panel formats the numbers it takes from the view', () => {
+  // setLanguage persists to localStorage, so a non-en language left set leaks
+  // into every later case in this file. Restored here rather than at the end of
+  // each it(), which an assertion failure would skip.
+  afterEach(() => setLanguage('en'));
+
+  it('groups all three of them under a locale whose separator is not the English one', async () => {
+    // The chunk is only needed for the SENTENCE: formatNumber goes straight to
+    // Intl and never reads the catalog table, so the digits would flip either
+    // way. Awaited so the line under assertion is the one a German player sees.
+    await ensureLocaleLoaded('de_DE');
+    setLanguage('de_DE');
+    // Three DISTINCT five-digit values, one per call site, so formatting only
+    // some of them still fails here: remaining = 99999 - 12345.
+    const el = paint({ [COMPONENT]: 12_345 }, 99_999);
+
+    expect(budgetLine(el)).toContain('87.654');
+    expect(budgetLine(el)).toContain('99.999');
+    expect(rowPoints(el)).toBe('12.345');
+    // Belt, not the teeth: on the pre-fix tree the three assertions above are
+    // what red, and they abort the case before these run. They are here to say
+    // out loud that the grouped form must REPLACE the raw one rather than
+    // appear alongside it, which the toContain pair above cannot express.
+    // (There is deliberately no `rowPoints(el)).not.toBe('12345')` to match:
+    // the exact-equality assertion above already implies it, so it could never
+    // fail in either direction.)
+    expect(budgetLine(el)).not.toContain('87654');
+    expect(budgetLine(el)).not.toContain('99999');
+  });
+
+  it('groups them in English as well, where the separator is the comma', () => {
+    // Not a restatement of the case above: it is what proves the values run
+    // through the ACTIVE locale rather than through one hardcoded formatter.
+    setLanguage('en');
+    const el = paint({ [COMPONENT]: 12_345 }, 99_999);
+
+    expect(budgetLine(el)).toContain('87,654');
+    expect(budgetLine(el)).toContain('99,999');
+    expect(rowPoints(el)).toBe('12,345');
+    expect(budgetLine(el)).not.toContain('87654');
+    expect(budgetLine(el)).not.toContain('99999');
+  });
+
+  it('rounds to whole points, the same option bag as the tier hint above it', () => {
+    // formatNumber with no options keeps up to three fraction digits, so this
+    // is the case that separates `formatNumber(n, { maximumFractionDigits: 0 })`
+    // from a bare `formatNumber(n)`. 10.75 - 2.5 = 8.25 exactly (both dyadic),
+    // so there is no float slop in the expectations.
+    setLanguage('en');
+    const el = paint({ [COMPONENT]: 2.5 }, 10.75);
+
+    expect(rowPoints(el)).toBe('3');
+    // Both budget-line sites at once, exactly and in order: a substring pin
+    // would say nothing about the remaining value or about which number is
+    // which. Every arm this case exists to separate is red here (raw and bare
+    // formatNumber give ['8.25', '10.75'], a minimum-fraction bag gives
+    // ['8.00', '11.00']).
+    expect(numbersIn(budgetLine(el))).toEqual(['8', '11']);
+  });
+
+  it('leaves the range the shipped panel actually paints spelled exactly as before', () => {
+    // The other half of the claim, and the reason this fix ships no
+    // screenshots: at the real budget nothing a player sees moves, in any
+    // locale. Every supported locale, not a sample, because the one realistic
+    // way this change ever becomes visible is a locale whose default numbering
+    // system is not Latin, and adding one is exactly the change nobody would
+    // think to re-run this file for. It also catches a formatter that went
+    // further than asked (compact notation, a minimum-integer-digits pad),
+    // which the cases above cannot see.
+    //
+    // No ensureLocaleLoaded: this case asserts DIGITS only (numbersIn strips
+    // the copy, rowPoints reads a bare span), and formatNumber reads the active
+    // language straight off Intl rather than out of the catalog table, so an
+    // unloaded locale still renders its real numbers inside an English
+    // sentence. The `lang` message argument is what makes a future offender
+    // name itself.
+    const spent = 3;
+    const expected = [String(FOCUS_POINT_BUDGET - spent), String(FOCUS_POINT_BUDGET)];
+    expect(supportedLanguages.length).toBeGreaterThan(1);
+    for (const lang of supportedLanguages) {
+      setLanguage(lang);
+      const el = paint({ [COMPONENT]: spent }, FOCUS_POINT_BUDGET);
+      expect(rowPoints(el), lang).toBe(String(spent));
+      expect(numbersIn(budgetLine(el)), lang).toEqual(expected);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`src/ui/town_focus_window.ts` handed three player-visible numbers straight to their render
sinks: `view.remaining` and `view.budget` as `t('hudChrome.townFocus.budgetLabel')`
interpolation values, and `row.points` spliced into the row template's `innerHTML`. `t()`'s
`interpolate()` ends in a bare `String(value)`, so none of the three ever reached `Intl`,
two lines below a tier hint that formats correctly. Root `CLAUDE.md`: "Numbers, money, dates,
percents go through `formatNumber`/`formatMoney`/`formatDateTime`/`Intl`."

All three now go through `formatNumber(..., { maximumFractionDigits: 0 })`, the tier hint's
own option bag, and the `innerHTML` one is wrapped in `esc()` to match the component name
beside it (provably inert: the group separators across all 22 supported locales are U+002C,
U+002E, U+00A0 and U+202F, none HTML-special).

**No visible change today, and that is the point.** `FOCUS_POINT_BUDGET` is 10, and every
supported locale spells 0 to 10 with the same ASCII digits, so this is rule compliance and
future-proofing rather than a user-facing fix. It was a live counter-example sitting next to
the correct idiom in the same function, which is how the next number gets written the wrong
way.

No catalog or overlay change: `budgetLabel` already declares `{remaining}` and `{budget}`,
and `InterpolationValue` is `string | number`, so both substitute identically.

Worth stating because it explains how this survived: `tests/i18n_extra_tables.test.ts`
("locale-aware formatting is centralized") bans an ad-hoc `Intl.NumberFormat` and a bare
`.toLocaleString()`, i.e. the WRONG formatter. Neither guard can see NO formatter at all,
which is the gap this defect sat in.

### Acceptance criterion 3, the sibling harvest surfaces

Swept and already compliant, so none of them is touched:
`src/ui/hud/loot/corpse_harvest_window.ts` (paints no numbers at all),
`src/ui/hud/loot/corpse_harvest_view.ts`, `src/ui/hud/loot/loot_window_controller.ts`
(`stack.count` via `formatNumber`, coin via `Hud.moneyHtml`), `src/ui/gather_node_tooltip.ts`,
`src/ui/gather_tool_tooltip.ts`, `src/ui/grant_line_view.ts` (`grantQtyText`), and
`src/ui/gathering_view.ts` (a pure core with no rendered text).

## Related issues

Closes #2530. Follows #2522 (the repaint gate) and #2552 (the focus wiring) on the same panel.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - `npm run gate` -> **PASS, all 11 steps green** (vitest workers capped at 8).
  - `npx vitest run tests/town_focus_number_format.test.ts tests/town_focus_repaint_gate.test.ts tests/town_focus_i18n.test.ts` -> 86 passed.
  - `npx vitest run tests/architecture.test.ts tests/hud_perf_budget.test.ts tests/hud_update_drive.test.ts tests/i18n_extra_tables.test.ts tests/hud_chrome_i18n.test.ts tests/focus.test.ts tests/corpse_harvest_window.test.ts tests/corpse_harvest_view.test.ts tests/town_focus_sim.test.ts tests/guide.test.ts` -> 298 passed, 4 skipped.
  - `npx tsc --noEmit` clean; `npx @biomejs/biome check` clean on both changed files.
- New suite, `tests/town_focus_number_format.test.ts`: the three sites are pinned behaviorally,
  never by scraping the painter's source. Because an integer inside the shipped range cannot
  tell a formatted number from a raw one, the cases paint views built through the REAL
  `buildTownFocusView` from five-digit and fractional inputs (the budget is a parameter, and
  points come straight off the allocation), so what is synthetic is the input, never the view
  shape. A fourth case walks EVERY entry of `supportedLanguages` at the real budget: it is the
  executable form of the "nothing a player sees moves" claim, and it is the tripwire the day a
  locale with a non-Latin numbering system is added.
- Mutation matrix, 8/8 caught: all three sites raw (3 cases red), each site raw individually
  (3 red each), the option bag dropped everywhere (1), `minimumIntegerDigits: 2` on the row
  count (2), and a hardcoded `'en'` language argument (1). Verified the painter was restored
  byte-identical afterwards.
- The repaint gate is unaffected, as criterion 2 predicted: its `readsOf(painterSrc, 'view')`
  and `readsOf(painterSrc, 'row')` scans anchor on the receiver-dot-field token, so wrapping
  the reads in place preserves every match and introduces no alias.
- Manual steps: none. The rendered digits are byte-identical for every value the panel can
  paint, in all 22 locales, which the fourth test case asserts rather than assumes.

## Screenshots / recordings

~N/A~ deliberately, not by omission: the panel paints 0 to `FOCUS_POINT_BUDGET` (10), and every
supported locale renders that range with identical ASCII digits, so a before/after pair would be
two identical images. The "leaves the range the shipped panel actually paints spelled exactly as
before" case pins that claim across all 22 supported languages instead.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green, and the new tests are decisive
      (mutation matrix above).

### Cross-platform

- [x] ~**Tested on desktop and mobile.**~ No layout surface changes: `.tf-points` keeps
      `min-width: 1.5em` (a floor, not a cap) inside a fixed 340px panel, and every value the
      panel can paint is still at most two ASCII glyphs. No CSS change.
- [x] **Accessible.** The two stepper `aria-label`s, the dialog root, the `data-focus-key`
      values and the focus ladder are all untouched, and the repaint signature is unchanged.
      A language switch still repaints the open panel through
      `Hud.refreshLocalizedDynamicUi()`, which is what re-spells the numbers now that they are
      language-dependent (pinned by `tests/town_focus_repaint_gate.test.ts`).

### Localization (i18n)

- [x] **New player-visible strings follow the contributor policy.** None added: no catalog
      key, no overlay edit, no pending row.
- [x] Numbers, money, dates, units, and percents go through the i18n formatters. This PR is
      exactly that.
- [x] ~Player-facing text emitted from `src/sim/` or `server/`~ N/A: the change is confined to
      `src/ui/`, and the formatting deliberately stays in the painter rather than the view core,
      since `town_focus_view.ts` is i18n-free by contract and `townFocusRenderSig` is
      deliberately text-independent.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not touched.
- [x] No generated file hand-edited.
