### PR TITLE
perf(ui): gate the spellbook's per-frame path so an unchanged frame does nothing

### DIFF
--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -105,12 +105,12 @@ Per-frame HUD code (anything reached from `Hud.update()`) holds these:
   correct `lastKnownSig` its cheap branch still walked the subtree, allocated, and wrote a
   property per row on every frame. Every branch a per-frame entry point takes needs its own
   change check, so an unchanged frame does nothing at all. That module is also the worked
-  answer to "should a per-frame window move to `HOT_PAINTERS`", and it is NO here for a
-  measured reason: the full write contract is a per-FILE count and the file carries 42
-  build-time raw writes, so pinning them exactly churns on every ordinary edit and never
-  moves when a build-time write starts repeating; and the facet's writers elide through Maps
-  keyed by ELEMENT, so a window that replaces its whole row set per rebuild would strand a
-  cache entry per destroyed node. What holds a per-frame window instead is a behavioral test
+  answer to "should a per-frame window move to `HOT_PAINTERS`", and it is NO here for two
+  reasons, neither of them "windows are cold": the full write contract is a per-FILE token
+  count pinned exactly, which churns on every ordinary markup edit while saying nothing about
+  CADENCE (it cannot tell a repaint write from a build-time one in the same file), and the
+  facet's writers elide through Maps keyed by ELEMENT, so a window that replaces its whole row
+  set per rebuild would strand a cache entry per destroyed node. What holds a per-frame window instead is a behavioral test
   that drives it across repeated identical frames and asserts zero queries, reads and writes
   (`tests/spellbook_tick_repaint.test.ts`); note the READ half, since once every write is
   elided per row an ungated repaint still writes nothing and only the elision checks show up.

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -100,7 +100,21 @@ Per-frame HUD code (anything reached from `Hud.update()`) holds these:
   callee adds. So a window on a poll is now NAMED by the gate and still held to the
   write-elision standard by review: give it a signature guard and keep it, and if you add a
   genuinely per-frame write path, route it through the facet and move the module into
-  `HOT_PAINTERS`. A module that arms its own repeating driver owes the same care INSIDE the
+  `HOT_PAINTERS`. **A signature over the REBUILD does not cover the fall-through**, which is
+  the hole #2519 closed in `spellbook_window` (the one window on the frame band): behind a
+  correct `lastKnownSig` its cheap branch still walked the subtree, allocated, and wrote a
+  property per row on every frame. Every branch a per-frame entry point takes needs its own
+  change check, so an unchanged frame does nothing at all. That module is also the worked
+  answer to "should a per-frame window move to `HOT_PAINTERS`", and it is NO here for a
+  measured reason: the full write contract is a per-FILE count and the file carries 42
+  build-time raw writes, so pinning them exactly churns on every ordinary edit and never
+  moves when a build-time write starts repeating; and the facet's writers elide through Maps
+  keyed by ELEMENT, so a window that replaces its whole row set per rebuild would strand a
+  cache entry per destroyed node. What holds a per-frame window instead is a behavioral test
+  that drives it across repeated identical frames and asserts zero queries, reads and writes
+  (`tests/spellbook_tick_repaint.test.ts`); note the READ half, since once every write is
+  elided per row an ungated repaint still writes nothing and only the elision checks show up.
+  A module that arms its own repeating driver owes the same care INSIDE the
   callback, and since #2518 that is a scanned contract too: granting a driver in
   `tests/hud_perf_budget.test.ts` now costs a `drivers` entry per call site recording the
   cadence (pinned against the literal in the source), why the driver exists, and the EXACT
@@ -144,6 +158,11 @@ The contract above is the WHAT; reach for the matching one when you build a hot 
 (each names its exemplar):
 - **Resolve element refs ONCE** into a field at construction, never `$()`/`querySelector` from
   a per-frame path (a re-query every frame was a real leak; `hud.ts` caches `xpbarEl` etc.).
+  For a window whose nodes are REBUILT, "at construction" is wrong and re-resolving at the
+  rebuild is the fix (`lockpick_window`, above). Better still when the module mints the nodes
+  itself: COLLECT the ref as the node is created and clear the collection at the top of the
+  rebuild, which costs zero queries even on a rebuild and carries each node's key with it
+  (`spellbook_window`'s toggle list, which no longer reads `dataset` per row either).
 - **Pool + keyed-reconcile, never per-frame `innerHTML` / `createElement`.** For a per-event or
   per-entity collection (FCT, auras, party), keep a persistent node pool, reconcile a keyed list
   with minimal `insertBefore` moves, recycle departed nodes, and CAP the live count (FIFO-evict

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -4157,13 +4157,13 @@ export class Hud {
         playerSpellHasteFrac(this.sim.player),
       ),
     abilityTooltip: (known) => this.abilityTooltip(known),
-    barAbilityIds: () =>
-      this.hotbarActions.flatMap((a) => (a && a.type === 'ability' ? [a.id] : [])),
-    // Index 0 = barSlot 1 (hotbarActions' own index = barSlot-1 convention), used
-    // to derive each row's mobile action-ring page (Phase 4). Non-ability slots
-    // (empty or an item) map to null, never mistaken for an ability id.
-    abilityIdByBarSlot: () =>
-      this.hotbarActions.map((a) => (a && a.type === 'ability' ? a.id : null)),
+    // The bar's LIVE slot array (index 0 = barSlot 1, hotbarActions' own index =
+    // barSlot-1 convention), handed over as-is. It used to be two DERIVED id lists
+    // (a flatMap for the on-bar ids, a map for the per-slot ids the mobile action-
+    // ring page label reads), and the spellbook's per-frame refresh called the
+    // first one every frame the window was open, allocating 34 arrays each time.
+    // The window derives both views itself now, at render time (#2519).
+    barActions: () => this.hotbarActions,
     hasFreeSlot: () => this.actionBarController.hasFreeSlot(),
     attackOnBar: () => this.attackSlotIsAttack(),
     // Routes through the Interface showAttackButton setting, the same state the

--- a/src/ui/spellbook_window.ts
+++ b/src/ui/spellbook_window.ts
@@ -12,9 +12,31 @@
 // Ability icons resolve via iconDataUrl (the procedural ability-icon source), not
 // the PainterHost item-icon helper: that helper paints ItemDef rows, and the
 // spellbook renders abilities. It is NOT a canvas window (colors live in the
-// extracted stylesheet, no literal hex/px in TS). refreshHotbarControls
-// is the one not-cold touch: hud.update() calls it while the window is open so the
-// +/- toggles track action-bar changes without a full rebuild.
+// extracted stylesheet, no literal hex/px in TS).
+//
+// THIS IS THE ONE WINDOW Hud.update() DRIVES ON THE PER-FRAME BAND
+// (tests/hud_update_drive.test.ts records it as such), so the per-frame contract in
+// src/ui/CLAUDE.md applies to `tickOpen` and everything it reaches: refs resolved
+// once, no per-frame allocation, every repeated write elided. An unchanged frame
+// costs three primitive reads and a walk of the bar's slot array, and makes no
+// subtree query, no allocation and no DOM write at all. The two gates that buy
+// that are `lastKnownSig` (rebuild the rows only when a resolved ability's numbers
+// moved) and `takeControlChange` (repaint the +/- toggles only when the bar state
+// they render moved).
+//
+// It stays a COLD painter in tests/hud_perf_budget.test.ts rather than moving into
+// HOT_PAINTERS, and #2519 settled that on a measurement rather than a preference.
+// The full write contract is a per-FILE count, and this file carries 42 raw writes
+// (.setAttribute 12, .className 7, .textContent 6, .classList 5, .dataset 5,
+// .style 4, .innerHTML 3), every one of them a BUILD-TIME write in render() /
+// appendRow(). Pinning those at exact counts would churn on every ordinary edit
+// while moving no number when the real hazard (a build-time write starting to
+// repeat) lands, which is the argument the cold bucket already settled. The other
+// half of that contract does not fit either: the PainterHost writers elide through
+// Maps KEYED BY ELEMENT, and this window replaces its whole row set on every
+// rebuild, so routing build-time writes through the facet would strand a cache
+// entry per destroyed node. The instrument that does answer the question here is
+// behavioral, and it is tests/spellbook_tick_repaint.test.ts.
 
 import { audio } from '../game/audio';
 import { ABILITIES, CLASSES } from '../sim/data';
@@ -28,6 +50,7 @@ import {
   encodeHotbarAction,
   HOTBAR_ACTION_MIME,
   HOTBAR_ATTACK_MIME,
+  type HotbarAction,
   isAbilityActionBarEligible,
 } from './hud/action_bar/hotbar';
 import { formatNumber, t } from './i18n';
@@ -53,11 +76,19 @@ export interface SpellbookWindowDeps {
   abilitySummary(known: ResolvedAbility): string;
   /** The full ability tooltip markup (Hud-owned). */
   abilityTooltip(known: ResolvedAbility): string;
-  /** Ability ids currently on the action bar. */
-  barAbilityIds(): string[];
-  /** The hotbar's ability id per bar slot (index 0 = barSlot 1), used to derive
-   *  each row's mobile action-ring page (Phase 4, touch-only presentation). */
-  abilityIdByBarSlot(): (string | null)[];
+  /**
+   * The action bar's LIVE ability slots (index 0 = barSlot 1, Hud.hotbarActions'
+   * own convention; slot 0 is the Attack control and is not in here).
+   *
+   * Handed over as the slot array rather than as a derived id list because the
+   * per-frame change check below walks it on every frame the window is open, and
+   * has to allocate nothing while it does. The two derived views this window used
+   * to take instead (the on-bar id list, the per-slot id list the mobile page
+   * label reads) were a `flatMap` and a `map` over 33 slots, i.e. 34 and 1 fresh
+   * arrays per call, and the check called one of them 60 times a second. Both are
+   * now derived at render time, where the allocation is paid once per rebuild.
+   */
+  barActions(): readonly HotbarAction[];
   /** The action bar has at least one empty slot. */
   hasFreeSlot(): boolean;
   /** The Attack toggle currently occupies bar slot 0 (showAttackButton on). */
@@ -78,6 +109,17 @@ export interface SpellbookWindowDeps {
   clearActionDropTargets(): void;
 }
 
+/** The ability on a bar slot, or null for an empty slot or an item. */
+function slotAbilityId(action: HotbarAction): string | null {
+  return action !== null && action.type === 'ability' ? action.id : null;
+}
+
+/** One row's +/- toggle and the ability it belongs to, captured as the row is built. */
+interface RowToggle {
+  readonly abilityId: string;
+  readonly btn: HTMLButtonElement;
+}
+
 export class SpellbookWindow {
   private openerFocus: HTMLElement | null = null;
   // Signature of the resolved abilities the last render painted (id/rank/cost/
@@ -85,6 +127,31 @@ export class SpellbookWindow {
   // world.known with new numbers; comparing this per frame lets tickOpen rebuild
   // the row summaries so their cost/cast/cooldown never go stale (tooltip parity).
   private lastKnownSig = '';
+  // The +/- toggles the last render painted, COLLECTED AS THOSE ROWS ARE BUILT
+  // rather than re-queried from the tick. Before #2519 the per-frame refresh ran a
+  // querySelector for the Attack toggle plus a querySelectorAll subtree walk over
+  // every ability row, on every frame the window was open, which is the shape
+  // src/ui/CLAUDE.md bans ("resolve element refs ONCE, never querySelector from a
+  // per-frame path").
+  //
+  // Capturing at BUILD time rather than re-querying at the end of render() (the
+  // shape lockpick_window had to use, whose nodes arrive from an innerHTML string)
+  // costs zero queries even on a rebuild, and hands each row's ability id over
+  // with its node, so the refresh does not read `dataset` per row either.
+  //
+  // The refs are dropped and re-collected in render(), which is the ONLY thing
+  // that replaces these nodes: its innerHTML write destroys the whole list and
+  // appendAttackRow / appendRow rebuild it. close() deliberately does not clear
+  // them, because it only hides the root (the nodes stay attached and correct, and
+  // re-opening re-renders anyway).
+  private attackToggle: HTMLButtonElement | null = null;
+  private readonly rowToggles: RowToggle[] = [];
+  // The action-bar state those toggles were painted from. Everything the refresh
+  // writes is a function of exactly these three, so an unchanged frame has nothing
+  // to paint; see takeControlChange.
+  private lastAttackOnBar = false;
+  private lastHasFree = false;
+  private readonly lastSlotIds: (string | null)[] = [];
 
   constructor(private readonly deps: SpellbookWindowDeps) {}
 
@@ -127,17 +194,22 @@ export class SpellbookWindow {
     this.openerFocus = null;
   }
 
-  // Per-frame entry while the window is open. Rebuilds the whole list only when a
-  // resolved ability's numbers changed (a talent allocation reassigns world.known),
-  // so row summaries reflect current cost/cast/cooldown; otherwise it just does the
-  // cheap in-place +/- toggle refresh. Hover tooltips resolve live regardless (see
-  // appendRow), so this covers the always-visible row text, not the tooltip.
+  // Per-frame entry while the window is open, and the ONLY window on that band.
+  //
+  // Two gates, and NEITHER fall-through does work on an unchanged frame. The first
+  // rebuilds the whole list when a resolved ability's numbers changed (a talent
+  // allocation reassigns world.known), so row summaries reflect current
+  // cost/cast/cooldown. The second repaints the +/- toggles when the bar state they
+  // render changed. A frame where neither moved costs the two comparisons and
+  // nothing else: no subtree query, no allocation, no DOM write. Hover tooltips
+  // resolve live regardless (see appendRow), so this covers the always-visible row
+  // text, not the tooltip.
   tickOpen(): void {
     if (SpellbookWindow.knownSig(this.deps.world().known) !== this.lastKnownSig) {
       this.rerenderPreservingView();
       return;
     }
-    this.refreshHotbarControls();
+    this.refreshHotbarControlsIfChanged();
   }
 
   // render() rebuilds the list via innerHTML, and the window root is the scroll
@@ -168,6 +240,13 @@ export class SpellbookWindow {
     const el = this.deps.root();
     const world = this.deps.world();
     this.lastKnownSig = SpellbookWindow.knownSig(world.known);
+    // Drop the toggle refs BEFORE the innerHTML write below destroys their nodes,
+    // and re-latch the bar state this paint is about to render from, so the next
+    // tick compares against what actually went on screen rather than repainting a
+    // fresh list. After this call lastSlotIds / lastHasFree / lastAttackOnBar
+    // mirror the live bar, which is what the view inputs below read.
+    this.forgetToggles();
+    this.takeControlChange();
     const classId = world.cfg.playerClass;
     const cls = CLASSES[classId];
     // The kit list is the display order, but spec signatures and other talent grants are
@@ -181,10 +260,12 @@ export class SpellbookWindow {
       classId,
       abilities: [...kit, ...grantedExtra],
       known: world.known,
-      barAbilityIds: this.deps.barAbilityIds(),
-      abilityIdByBarSlot: this.deps.abilityIdByBarSlot(),
-      hasFreeSlot: this.deps.hasFreeSlot(),
-      attackOnBar: this.deps.attackOnBar(),
+      // Both bar views are derived from the one latched slot list: one allocation
+      // per rebuild, where the per-frame path pays none.
+      barAbilityIds: this.lastSlotIds.filter((id): id is string => id !== null),
+      abilityIdByBarSlot: this.lastSlotIds,
+      hasFreeSlot: this.lastHasFree,
+      attackOnBar: this.lastAttackOnBar,
       hasFormBars: this.deps.hasFormBars(),
       spec: world.talentSpec,
       level: world.player.level,
@@ -220,18 +301,87 @@ export class SpellbookWindow {
     });
   }
 
-  // In-place refresh of the per-row hotbar toggles, called from hud.update() while
-  // the window is open so the +/- state tracks action-bar changes (drag-drop,
-  // keybind use) without a full rebuild. Mirrors the inline refreshSpellbookHotbar
-  // controls but scoped to this window's root.
+  // Force the +/- toggles to match the bar as it stands right now.
+  //
+  // Public because Hud drives it after a bar change it made ITSELF and does not
+  // want to wait a frame for (the login-time action-bar layout restore, the
+  // reset-form-bar command), and because this window's own click handlers use it to
+  // reflect a toggle press immediately. Latching first is what keeps that free:
+  // the state this paint renders is recorded, so the tick that follows sees an
+  // unchanged frame and repaints nothing.
   refreshHotbarControls(): void {
+    this.takeControlChange();
+    this.paintHotbarControls();
+  }
+
+  /**
+   * The per-frame fall-through: repaint the toggles only when the bar state they
+   * render actually moved.
+   *
+   * This is the half #2519 was about. Everything paintHotbarControls writes is a
+   * function of exactly the three inputs takeControlChange reads, so a frame where
+   * none of them moved has nothing to paint, and returning here costs no subtree
+   * query, no allocation and no DOM write. Before that gate, the fall-through ran
+   * two element lookups (one of them a full subtree walk over every ability row),
+   * allocated a Set from a freshly built id list, and wrote `disabled` on every row
+   * unelided, sixty times a second for as long as the window was open.
+   */
+  private refreshHotbarControlsIfChanged(): void {
+    if (!this.takeControlChange()) return;
+    this.paintHotbarControls();
+  }
+
+  /**
+   * Read the three bar inputs the toggles render, report whether any of them
+   * moved, and latch the new values when they did.
+   *
+   * ALLOCATION-FREE on the unchanged path, which is the whole point of taking the
+   * bar as its live slot array (see `barActions`): the comparison walks that array
+   * in place against the retained copy and stops at the first difference, instead
+   * of building an id list or a joined signature string it would throw away on
+   * every frame. Only a frame that really changed pays the copy back.
+   *
+   * `hasFreeSlot` is read separately rather than derived from the slot array here,
+   * so the action bar keeps owning that rule (a slot can be occupied by an item,
+   * and the controller decides what counts as free).
+   */
+  private takeControlChange(): boolean {
+    const attackOnBar = this.deps.attackOnBar();
+    const hasFree = this.deps.hasFreeSlot();
+    const actions = this.deps.barActions();
+    if (!this.controlsMoved(attackOnBar, hasFree, actions)) return false;
+    this.lastAttackOnBar = attackOnBar;
+    this.lastHasFree = hasFree;
+    this.lastSlotIds.length = 0;
+    for (const action of actions) this.lastSlotIds.push(slotAbilityId(action));
+    return true;
+  }
+
+  private controlsMoved(
+    attackOnBar: boolean,
+    hasFree: boolean,
+    actions: readonly HotbarAction[],
+  ): boolean {
+    if (attackOnBar !== this.lastAttackOnBar) return true;
+    if (hasFree !== this.lastHasFree) return true;
+    if (actions.length !== this.lastSlotIds.length) return true;
+    for (let i = 0; i < actions.length; i++) {
+      if (slotAbilityId(actions[i]) !== this.lastSlotIds[i]) return true;
+    }
+    return false;
+  }
+
+  // In-place repaint of the hotbar toggles from the latched bar state, over the
+  // refs render() collected. Runs only behind one of the two entry points above,
+  // never on an unchanged frame.
+  private paintHotbarControls(): void {
     // The Attack toggle tracks the Interface showAttackButton setting, which can
     // flip while the window is open (the options window, or a right-click on the
     // slot-0 button itself). Same elision discipline as the ability toggles:
     // rewrite only when the on-bar state actually flips.
-    const attackBtn = this.deps.root().querySelector<HTMLButtonElement>('[data-attack-toggle]');
+    const attackBtn = this.attackToggle;
     if (attackBtn) {
-      const onBar = this.deps.attackOnBar();
+      const onBar = this.lastAttackOnBar;
       if ((attackBtn.getAttribute('aria-pressed') === 'true') !== onBar) {
         attackBtn.textContent = onBar ? '-' : '+';
         attackBtn.classList.toggle('remove', onBar);
@@ -244,45 +394,48 @@ export class SpellbookWindow {
         );
       }
     }
-    const barIds = new Set(this.deps.barAbilityIds());
-    const hasFree = this.deps.hasFreeSlot();
-    this.deps
-      .root()
-      .querySelectorAll<HTMLButtonElement>('.spell-hotbar-toggle')
-      .forEach((btn) => {
-        const id = btn.dataset.abilityId;
-        if (!id) return;
-        const onBar = barIds.has(id);
-        // Elide the toggle-state writes: this runs every frame while the window is
-        // open, but the +/- text, the remove class, and the accessible name only
-        // change when on-bar membership flips (a drag-drop / keybind use), which
-        // aria-pressed already records. Recomputing the i18n name + rewriting the
-        // attribute every frame was avoidable churn (matches the elided-writer
-        // doctrine). `disabled` stays per-frame: it also depends
-        // on hasFree, which can change without an on-bar flip.
-        if ((btn.getAttribute('aria-pressed') === 'true') !== onBar) {
-          btn.textContent = onBar ? '-' : '+';
-          btn.classList.toggle('remove', onBar);
-          btn.setAttribute('aria-pressed', onBar ? 'true' : 'false');
-          // Keep the accessible name in sync with the toggle state: a spoken
-          // action ("Add/Remove {name} to action bar"), not a bare +/- glyph.
-          // Same key pair as appendRow.
-          const def = ABILITIES[id];
-          if (def)
-            btn.setAttribute(
-              'aria-label',
-              t(
-                onBar
-                  ? 'hudChrome.spellbook.removeFromBarAria'
-                  : 'hudChrome.spellbook.addToBarAria',
-                {
-                  name: this.abilityName(def),
-                },
-              ),
-            );
-        }
-        btn.disabled = !onBar && !hasFree;
-      });
+    const hasFree = this.lastHasFree;
+    for (const { abilityId, btn } of this.rowToggles) {
+      const onBar = this.lastSlotIds.includes(abilityId);
+      // Elide the toggle-state writes per row: a repaint fires when ANY of the
+      // three inputs moved, but the +/- text, the remove class, and the accessible
+      // name only change when this row's on-bar membership flips, which
+      // aria-pressed already records. Recomputing the i18n name + rewriting the
+      // attribute for every row on every repaint was avoidable churn (matches the
+      // elided-writer doctrine).
+      if ((btn.getAttribute('aria-pressed') === 'true') !== onBar) {
+        btn.textContent = onBar ? '-' : '+';
+        btn.classList.toggle('remove', onBar);
+        btn.setAttribute('aria-pressed', onBar ? 'true' : 'false');
+        // Keep the accessible name in sync with the toggle state: a spoken
+        // action ("Add/Remove {name} to action bar"), not a bare +/- glyph.
+        // Same key pair as appendRow.
+        const def = ABILITIES[abilityId];
+        if (def)
+          btn.setAttribute(
+            'aria-label',
+            t(
+              onBar ? 'hudChrome.spellbook.removeFromBarAria' : 'hudChrome.spellbook.addToBarAria',
+              {
+                name: this.abilityName(def),
+              },
+            ),
+          );
+      }
+      // `disabled` needs its own elision rather than riding the aria-pressed
+      // branch above: it also depends on hasFree, which can change without any
+      // on-bar flip (the bar filling up disables every off-bar row's add control
+      // while no row's membership moved). Diffed against the live property so a
+      // repaint writes only the rows that actually flipped.
+      const disabled = !onBar && !hasFree;
+      if (btn.disabled !== disabled) btn.disabled = disabled;
+    }
+  }
+
+  /** Drop the toggle refs whose nodes the next render() is about to replace. */
+  private forgetToggles(): void {
+    this.attackToggle = null;
+    this.rowToggles.length = 0;
   }
 
   // The pinned basic Attack row, first in the list (classic spellbooks lead with
@@ -324,6 +477,9 @@ export class SpellbookWindow {
       audio.click();
       this.refreshHotbarControls();
     });
+    // Hold the ref the refresh repaints, instead of re-finding this node by its
+    // data-attack-toggle marker on every frame.
+    this.attackToggle = toggle;
     el.appendChild(toggle);
     // Attack drags onto the action bar like any ability row. It has no ability/item
     // id, so it cannot ride the HotbarAction path: the dragstart carries the dedicated
@@ -410,13 +566,19 @@ export class SpellbookWindow {
         ev.preventDefault();
         ev.stopPropagation();
         const id = known.def.id;
-        const changed = this.deps.barAbilityIds().includes(id)
-          ? this.deps.removeFromBar(id)
-          : this.deps.addToBar(id);
+        // Read the bar LIVE here rather than off the latched slot list: the latch
+        // is at most one frame old, and a keybind that moved this ability in that
+        // frame would otherwise send the click down the wrong branch, where
+        // addToBar reports no change and the press does nothing at all.
+        const onBar = this.deps.barActions().some((action) => slotAbilityId(action) === id);
+        const changed = onBar ? this.deps.removeFromBar(id) : this.deps.addToBar(id);
         if (!changed) return;
         audio.click();
         this.refreshHotbarControls();
       });
+      // Hold the ref (with its ability id) the refresh repaints, instead of
+      // walking the whole list for `.spell-hotbar-toggle` on every frame.
+      this.rowToggles.push({ abilityId: known.def.id, btn: toggle });
       el.appendChild(toggle);
       el.draggable = true;
       el.addEventListener('dragstart', (e) => {

--- a/src/ui/spellbook_window.ts
+++ b/src/ui/spellbook_window.ts
@@ -18,27 +18,37 @@
 // (tests/hud_update_drive.test.ts records it as such), so the per-frame contract in
 // src/ui/CLAUDE.md applies to `tickOpen` and everything it reaches: refs resolved
 // once, no per-frame allocation, every repeated write elided. An unchanged frame
-// costs two in-place comparisons and makes no subtree query, no allocation and no
+// costs two in-place comparisons and makes no element lookup, no allocation and no
 // DOM write at all. The two gates that buy that are `knownChanged` (rebuild the
 // rows only when a resolved ability's numbers moved) and `takeControlChange`
 // (repaint the +/- toggles only when the bar state they render moved). Both compare
 // retained values in place rather than through a derived id list or a joined
 // signature string: a gate that allocates to decide it has nothing to do keeps most
-// of the cost it was meant to save.
+// of the cost it was meant to save. What is NOT inside that claim, since it sits at
+// the Hud call site rather than in here: the `isOpen` check that decides whether to
+// tick at all still resolves `#spellbook` by id every frame.
 //
 // It stays a COLD painter in tests/hud_perf_budget.test.ts rather than moving into
-// HOT_PAINTERS, and #2519 settled that on a measurement rather than a preference.
-// The full write contract is a per-FILE count, and this file carries 42 raw writes
-// (.setAttribute 12, .className 7, .textContent 6, .classList 5, .dataset 5,
-// .style 4, .innerHTML 3), every one of them a BUILD-TIME write in render() /
-// appendRow(). Pinning those at exact counts would churn on every ordinary edit
-// while moving no number when the real hazard (a build-time write starting to
-// repeat) lands, which is the argument the cold bucket already settled. The other
-// half of that contract does not fit either: the PainterHost writers elide through
-// Maps KEYED BY ELEMENT, and this window replaces its whole row set on every
-// rebuild, so routing build-time writes through the facet would strand a cache
-// entry per destroyed node. The instrument that does answer the question here is
-// behavioral, and it is tests/spellbook_tick_repaint.test.ts.
+// HOT_PAINTERS, and #2519 settled that rather than leaving it open. Two reasons,
+// neither of them "windows are cold":
+//   - The hot bucket's write contract is a per-FILE token count pinned EXACTLY, and
+//     the count cannot tell CADENCE, which is the only thing #2519 was about. Most
+//     of this file's raw-write tokens are build-time writes in render() /
+//     appendAttackRow() / appendRow(), a minority are the repaint writes in
+//     paintHotbarControls, and several are not writes at all (the style.display
+//     read in isOpen, the classList.contains reads that pick a refocus target).
+//     Pinning the total makes every ordinary edit to the markup a diff line in the
+//     gate while saying nothing about which bucket a given write is in. Re-derive
+//     the numbers with the gate's own instrument (stripComments plus RAW_WRITES in
+//     tests/hud_perf_budget.test.ts) rather than from a figure quoted here, which
+//     would rot: this comment quoted one for exactly one commit before the change
+//     it describes deleted the per-row `dataset` read and falsified it.
+//   - The other half of the contract does not fit at all: the PainterHost writers
+//     elide through Maps KEYED BY ELEMENT, and this window replaces its whole row
+//     set on every rebuild, so routing its build-time writes through the facet
+//     would strand a cache entry per destroyed node.
+// The instrument that does answer a cadence question is behavioral, and it is
+// tests/spellbook_tick_repaint.test.ts.
 
 import { audio } from '../game/audio';
 import { ABILITIES, CLASSES } from '../sim/data';
@@ -179,6 +189,17 @@ export class SpellbookWindow {
    * Walks in place against the retained copy and returns at the first difference,
    * so an unchanged frame costs a bounded run of primitive comparisons and no
    * allocation at all.
+   *
+   * The length check is not redundant with the id compare below it: a set that
+   * SHRANK at the tail leaves every surviving index matching, so without it an
+   * unlearned last ability would keep its row (and its live +/- toggle) for the
+   * rest of the session.
+   *
+   * What it covers is the RESOLVED ABILITY, which is what the summary is built
+   * from, and no more. `deps.abilitySummary` also folds in live player state (the
+   * resource type, spell haste), so a change to those alone does not rebuild here.
+   * That limit predates this gate (the signature string it replaced covered the
+   * same five fields) and is left as it was.
    */
   private knownChanged(known: readonly ResolvedAbility[]): boolean {
     if (known.length !== this.knownIds.length) return true;
@@ -301,7 +322,10 @@ export class SpellbookWindow {
       abilities: [...kit, ...grantedExtra],
       known: world.known,
       // Both bar views are derived from the one latched slot list: one allocation
-      // per rebuild, where the per-frame path pays none.
+      // per rebuild, where the per-frame path pays none. abilityIdByBarSlot feeds
+      // the touch-only "Page N" chip, which appendRow emits at BUILD time and no
+      // repaint touches, so moving an ability between bar slots leaves that chip
+      // until the next rebuild. Pre-existing, and left as it was.
       barAbilityIds: this.lastSlotIds.filter((id): id is string => id !== null),
       abilityIdByBarSlot: this.lastSlotIds,
       hasFreeSlot: this.lastHasFree,

--- a/src/ui/spellbook_window.ts
+++ b/src/ui/spellbook_window.ts
@@ -18,11 +18,13 @@
 // (tests/hud_update_drive.test.ts records it as such), so the per-frame contract in
 // src/ui/CLAUDE.md applies to `tickOpen` and everything it reaches: refs resolved
 // once, no per-frame allocation, every repeated write elided. An unchanged frame
-// costs three primitive reads and a walk of the bar's slot array, and makes no
-// subtree query, no allocation and no DOM write at all. The two gates that buy
-// that are `lastKnownSig` (rebuild the rows only when a resolved ability's numbers
-// moved) and `takeControlChange` (repaint the +/- toggles only when the bar state
-// they render moved).
+// costs two in-place comparisons and makes no subtree query, no allocation and no
+// DOM write at all. The two gates that buy that are `knownChanged` (rebuild the
+// rows only when a resolved ability's numbers moved) and `takeControlChange`
+// (repaint the +/- toggles only when the bar state they render moved). Both compare
+// retained values in place rather than through a derived id list or a joined
+// signature string: a gate that allocates to decide it has nothing to do keeps most
+// of the cost it was meant to save.
 //
 // It stays a COLD painter in tests/hud_perf_budget.test.ts rather than moving into
 // HOT_PAINTERS, and #2519 settled that on a measurement rather than a preference.
@@ -122,11 +124,24 @@ interface RowToggle {
 
 export class SpellbookWindow {
   private openerFocus: HTMLElement | null = null;
-  // Signature of the resolved abilities the last render painted (id/rank/cost/
-  // cast/cooldown). Talent allocation while the window is open reassigns
-  // world.known with new numbers; comparing this per frame lets tickOpen rebuild
-  // the row summaries so their cost/cast/cooldown never go stale (tooltip parity).
-  private lastKnownSig = '';
+  // The resolved abilities the last render painted, as the fields a row summary
+  // displays: one id per ability in `knownIds`, and its rank / cost / castTime /
+  // cooldown packed four to an ability in `knownNums`. Talent allocation while the
+  // window is open reassigns world.known with new numbers; comparing this per frame
+  // lets tickOpen rebuild the row summaries so their cost/cast/cooldown never go
+  // stale (tooltip parity).
+  //
+  // Two retained arrays rather than the joined signature STRING this started as,
+  // for the same reason the bar state below is compared in place: the comparison
+  // runs on every frame the window is open, and building a signature over every
+  // known ability allocated a string of a thousand-odd characters per frame only to
+  // throw it away on the (overwhelmingly common) unchanged one. Comparing in place
+  // also stops at the first field that moved instead of always walking the whole
+  // set. Reference equality on world.known would be cheaper still and is WRONG: the
+  // online mirror rebuilds that array every snapshot, so only the VALUES tell us a
+  // talent actually changed a number.
+  private readonly knownIds: string[] = [];
+  private readonly knownNums: number[] = [];
   // The +/- toggles the last render painted, COLLECTED AS THOSE ROWS ARE BUILT
   // rather than re-queried from the tick. Before #2519 the per-frame refresh ran a
   // querySelector for the Attack toggle plus a querySelectorAll subtree walk over
@@ -155,13 +170,38 @@ export class SpellbookWindow {
 
   constructor(private readonly deps: SpellbookWindowDeps) {}
 
-  // Cheap content signature of the fields a row summary displays. Reference
-  // equality on world.known will not do: the online mirror rebuilds that array
-  // every snapshot, so only the VALUES tell us a talent actually changed a number.
-  private static knownSig(known: readonly ResolvedAbility[]): string {
-    let sig = '';
-    for (const k of known) sig += `${k.def.id}:${k.rank}:${k.cost}:${k.castTime}:${k.cooldown}|`;
-    return sig;
+  /** Number fields packed per known ability in `knownNums`: rank, cost, castTime, cooldown. */
+  private static readonly KNOWN_FIELDS = 4;
+
+  /**
+   * Did any field a row summary displays move since the last render?
+   *
+   * Walks in place against the retained copy and returns at the first difference,
+   * so an unchanged frame costs a bounded run of primitive comparisons and no
+   * allocation at all.
+   */
+  private knownChanged(known: readonly ResolvedAbility[]): boolean {
+    if (known.length !== this.knownIds.length) return true;
+    for (let i = 0; i < known.length; i++) {
+      const k = known[i];
+      if (k.def.id !== this.knownIds[i]) return true;
+      const at = i * SpellbookWindow.KNOWN_FIELDS;
+      if (k.rank !== this.knownNums[at]) return true;
+      if (k.cost !== this.knownNums[at + 1]) return true;
+      if (k.castTime !== this.knownNums[at + 2]) return true;
+      if (k.cooldown !== this.knownNums[at + 3]) return true;
+    }
+    return false;
+  }
+
+  /** Latch the resolved-ability numbers this render is painting. */
+  private captureKnown(known: readonly ResolvedAbility[]): void {
+    this.knownIds.length = 0;
+    this.knownNums.length = 0;
+    for (const k of known) {
+      this.knownIds.push(k.def.id);
+      this.knownNums.push(k.rank, k.cost, k.castTime, k.cooldown);
+    }
   }
 
   get isOpen(): boolean {
@@ -205,7 +245,7 @@ export class SpellbookWindow {
   // resolve live regardless (see appendRow), so this covers the always-visible row
   // text, not the tooltip.
   tickOpen(): void {
-    if (SpellbookWindow.knownSig(this.deps.world().known) !== this.lastKnownSig) {
+    if (this.knownChanged(this.deps.world().known)) {
       this.rerenderPreservingView();
       return;
     }
@@ -239,7 +279,7 @@ export class SpellbookWindow {
   render(): void {
     const el = this.deps.root();
     const world = this.deps.world();
-    this.lastKnownSig = SpellbookWindow.knownSig(world.known);
+    this.captureKnown(world.known);
     // Drop the toggle refs BEFORE the innerHTML write below destroys their nodes,
     // and re-latch the bar state this paint is about to render from, so the next
     // tick compares against what actually went on screen rather than repainting a

--- a/tests/browser/a11y.browser.test.ts
+++ b/tests/browser/a11y.browser.test.ts
@@ -268,7 +268,7 @@ describe('axe: spellbook window', () => {
         // (IWorld always carries a player); level 1 keeps every row locked.
         world: () =>
           ({ cfg: { playerClass: 'warrior' }, known: [], player: { level: 1 } }) as never,
-        barAbilityIds: () => [],
+        barActions: () => [],
         hasFreeSlot: () => true,
         hasFormBars: () => false,
         captureFocus: () => null,

--- a/tests/hud_perf_budget.test.ts
+++ b/tests/hud_perf_budget.test.ts
@@ -395,11 +395,12 @@ const ELEMENT_QUERIES: ReadonlyArray<readonly [string, RegExp]> = [
 //     one was #2519's, and it needed the cadence answer, not a new token. #2519 has since
 //     landed and confirmed it from the other side: the per-row `.disabled` write it was
 //     about is gone because the whole per-frame fall-through is gated now, the module STAYS
-//     cold (promoting it would pin 42 build-time raw writes at exact counts, which is the
-//     churn the cold bucket already argued against), and what holds the contract is a
-//     behavioral test that drives the open window across repeated identical frames,
-//     tests/spellbook_tick_repaint.test.ts. A token in a per-file count was never the
-//     instrument for a per-frame question.
+//     cold (promoting it would pin that file's whole raw-write vocabulary at exact counts,
+//     mostly build-time writes in its three row builders, which is the churn the cold bucket
+//     already argued against, and the count still could not tell those from the repaint
+//     writes beside them), and what holds the contract is a behavioral test that drives the
+//     open window across repeated identical frames, tests/spellbook_tick_repaint.test.ts.
+//     A token in a per-file count was never the instrument for a per-frame question.
 // Inside a driver callback the corpus is a few hundred characters and hand-checkable, which
 // is the condition #2518 named, so the collision-prone middle of the list stays out and the
 // rest is counted exactly, like every other allowance here.

--- a/tests/hud_perf_budget.test.ts
+++ b/tests/hud_perf_budget.test.ts
@@ -392,7 +392,14 @@ const ELEMENT_QUERIES: ReadonlyArray<readonly [string, RegExp]> = [
 //   - Adding `.disabled` to RAW_WRITES would ALSO not have caught the case #2518 cites.
 //     `spellbook_window` is a COLD painter, and cold takes no raw-write scan at all, so the
 //     arm would have been added to a scan that never runs over the module in question. That
-//     one is #2519's, and it needs the cadence answer, not a new token.
+//     one was #2519's, and it needed the cadence answer, not a new token. #2519 has since
+//     landed and confirmed it from the other side: the per-row `.disabled` write it was
+//     about is gone because the whole per-frame fall-through is gated now, the module STAYS
+//     cold (promoting it would pin 42 build-time raw writes at exact counts, which is the
+//     churn the cold bucket already argued against), and what holds the contract is a
+//     behavioral test that drives the open window across repeated identical frames,
+//     tests/spellbook_tick_repaint.test.ts. A token in a per-file count was never the
+//     instrument for a per-frame question.
 // Inside a driver callback the corpus is a few hundred characters and hand-checkable, which
 // is the condition #2518 named, so the collision-prone middle of the list stays out and the
 // rest is counted exactly, like every other allowance here.

--- a/tests/hud_update_drive.test.ts
+++ b/tests/hud_update_drive.test.ts
@@ -578,7 +578,7 @@ const HUD_UPDATE_DRIVES: readonly DriveRow[] = [
       module: 'spellbook_window.ts',
       proof: 'if (SpellbookWindow.knownSig(this.deps.world().known) !== this.lastKnownSig) {',
     },
-    why: 'the ONLY window on the per-frame band; the sig gates the rebuild, the fall-through hotbar-control refresh runs every frame',
+    why: 'the ONLY window on the per-frame band, and since #2519 BOTH of its halves are gated: the sig proved below gates the rebuild, and the fall-through hotbar-control refresh takes its own change check (takeControlChange) over the three bar inputs its toggles render, so an unchanged frame makes no query, no allocation and no DOM write',
   },
   {
     call: 'this.actionBarPainter.paint',

--- a/tests/hud_update_drive.test.ts
+++ b/tests/hud_update_drive.test.ts
@@ -578,7 +578,7 @@ const HUD_UPDATE_DRIVES: readonly DriveRow[] = [
       module: 'spellbook_window.ts',
       proof: 'if (this.knownChanged(this.deps.world().known)) {',
     },
-    why: 'the ONLY window on the per-frame band, and since #2519 BOTH of its halves are gated: the sig proved below gates the rebuild, and the fall-through hotbar-control refresh takes its own change check (takeControlChange) over the three bar inputs its toggles render, so an unchanged frame makes no query, no allocation and no DOM write',
+    why: 'the ONLY window on the per-frame band, and since #2519 BOTH of its halves are gated: the guard proved below (knownChanged, an in-place walk of the resolved-ability numbers, no signature string built per frame) gates the rebuild, and the fall-through hotbar-control refresh takes its own change check (takeControlChange) over the three bar inputs its toggles render, so an unchanged frame makes no lookup, no allocation and no DOM write',
   },
   {
     call: 'this.actionBarPainter.paint',

--- a/tests/hud_update_drive.test.ts
+++ b/tests/hud_update_drive.test.ts
@@ -576,7 +576,7 @@ const HUD_UPDATE_DRIVES: readonly DriveRow[] = [
     guard: {
       kind: 'module',
       module: 'spellbook_window.ts',
-      proof: 'if (SpellbookWindow.knownSig(this.deps.world().known) !== this.lastKnownSig) {',
+      proof: 'if (this.knownChanged(this.deps.world().known)) {',
     },
     why: 'the ONLY window on the per-frame band, and since #2519 BOTH of its halves are gated: the sig proved below gates the rebuild, and the fall-through hotbar-control refresh takes its own change check (takeControlChange) over the three bar inputs its toggles render, so an unchanged frame makes no query, no allocation and no DOM write',
   },
@@ -1363,7 +1363,10 @@ describe('Hud.update() drives exactly the registered set, on the registered band
         'meters.ts: if (!this.isOpen || now - this.lastRender < 250) return;',
         'professions_window.ts: if (sig === this.lastSig) return;',
         'social_window.ts: if (struct !== this.lastStruct) {',
-        'spellbook_window.ts: if (SpellbookWindow.knownSig(this.deps.world().known) !== this.lastKnownSig) {',
+        // #2519 replaced the joined signature string this used to build every frame with
+        // an in-place comparison against the retained numbers; same guard, same place, no
+        // per-frame allocation.
+        'spellbook_window.ts: if (this.knownChanged(this.deps.world().known)) {',
         'vale_cup_betting.ts: if (view.sig !== this.lastSig) {',
         'vale_cup_briefing.ts: if (view.sig !== this.lastSig) {',
         'vale_cup_window.ts: if (view.sig === this.lastSig) return;',

--- a/tests/spellbook_tick_repaint.test.ts
+++ b/tests/spellbook_tick_repaint.test.ts
@@ -1,0 +1,535 @@
+// @vitest-environment jsdom
+
+// The spellbook's per-frame repaint contract (#2519).
+//
+// `spellbook_window.tickOpen()` is the ONE window `Hud.update()` drives on the per-frame
+// band (`tests/hud_update_drive.test.ts` records it as such). Its `lastKnownSig` guard has
+// always gated the expensive half, the full `rerenderPreservingView()`. The FALL-THROUGH was
+// ungated: every frame the window was open it re-resolved the root twice, ran a
+// `querySelector` for the Attack toggle plus a `querySelectorAll` subtree walk over every
+// ability row, allocated a fresh `Set` from a freshly built id list, and wrote `disabled` on
+// every row unelided.
+//
+// NOTHING IN THE THREE SOURCE GATES COULD SEE ANY OF THAT, which is why the contract is
+// pinned behaviorally here rather than by another token. `.disabled` is an IDL property that
+// `RAW_WRITES` deliberately does not carry (#2518 measured that question and answered it),
+// `querySelector` is only counted inside a driver callback, and `spellbook_window` is a COLD
+// painter, which takes no raw-write scan at all. A count over a window FILE cannot tell a
+// build-time write from a per-frame one in any case. Driving the real window across repeated
+// identical frames can, so that is what this file does.
+//
+// WHAT IS ASSERTED, and what is not. An unchanged frame is held to zero DOM queries, zero DOM
+// writes, and exactly four dep reads, all of which return a primitive or the caller's own live
+// slot array (asserted by reference). That is the observable half of "no per-frame
+// allocation": Node cannot count allocations, so the claim rests on the window reading nothing
+// per frame that has to be built. The one remaining per-frame allocation is deliberate and
+// named where it lives: `knownSig` still concatenates a signature string, which is the rebuild
+// gate the issue calls correct.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ResolvedAbility } from '../src/sim/sim';
+import type { HotbarAction } from '../src/ui/hud/action_bar/hotbar';
+import { SpellbookWindow, type SpellbookWindowDeps } from '../src/ui/spellbook_window';
+
+// jsdom ships no 2D canvas, so the procedural ability-icon compositor cannot run
+// here; the painter only ever uses the returned string as a CSS background-image.
+vi.mock('../src/ui/icons', () => ({
+  iconDataUrl: () => 'data:,',
+}));
+
+const CLASS_ID = 'warrior';
+// Five learned, action-bar-eligible warrior abilities with no spec gate, so every one of them
+// renders a row WITH a +/- toggle. More than one on purpose: a single-row fixture cannot see a
+// per-row guard, and half the claims below are about painting one row and not its neighbours.
+const KNOWN_IDS = ['heroic_strike', 'battle_shout', 'charge', 'hamstring', 'overpower'] as const;
+
+/** A resolved ability carrying exactly the fields the window reads off it. */
+function resolved(abilityId: string, over: Partial<Record<string, number>> = {}): ResolvedAbility {
+  return {
+    def: { id: abilityId },
+    rank: 1,
+    cost: 10,
+    castTime: 0,
+    cooldown: 0,
+    ...over,
+  } as unknown as ResolvedAbility;
+}
+
+/** An ability bar slot holding `abilityId`. */
+function slot(abilityId: string): HotbarAction {
+  return { type: 'ability', id: abilityId };
+}
+
+interface Harness {
+  win: SpellbookWindow;
+  root: HTMLElement;
+  deps: SpellbookWindowDeps;
+  /** Mutable world/bar state the deps read live. */
+  state: {
+    known: ResolvedAbility[];
+    bar: HotbarAction[];
+    hasFree: boolean;
+    attackOnBar: boolean;
+  };
+  /** How many times each dep the per-frame path can reach was called. */
+  calls: Record<string, number>;
+  resetCalls(): void;
+  /** The row toggle for `abilityId`, resolved LIVE (a rebuild replaces the node). */
+  toggle(abilityId: string): HTMLButtonElement | null;
+  attackToggle(): HTMLButtonElement | null;
+}
+
+function harness(): Harness {
+  document.body.innerHTML = '<div id="spellbook" class="window panel"></div>';
+  const root = document.getElementById('spellbook') as HTMLElement;
+  const state = {
+    known: KNOWN_IDS.map((id) => resolved(id)),
+    bar: [null, null, null] as HotbarAction[],
+    hasFree: true,
+    attackOnBar: true,
+  };
+  const calls: Record<string, number> = {};
+  const count = <T>(name: string, value: T): T => {
+    calls[name] = (calls[name] ?? 0) + 1;
+    return value;
+  };
+  const noop = (): void => {};
+  const deps: SpellbookWindowDeps = {
+    root: () => count('root', root),
+    world: () =>
+      count('world', {
+        cfg: { playerClass: CLASS_ID },
+        known: state.known,
+        player: { level: 60 },
+        talentSpec: null,
+      } as never),
+    closeOthers: noop,
+    captureFocus: () => null,
+    restoreFocus: noop,
+    hideTooltip: noop,
+    attachTooltip: noop,
+    abilitySummary: () => 'summary',
+    abilityTooltip: () => '<div></div>',
+    barActions: () => count('barActions', state.bar),
+    hasFreeSlot: () => count('hasFreeSlot', state.hasFree),
+    attackOnBar: () => count('attackOnBar', state.attackOnBar),
+    setAttackOnBar: (on) => {
+      state.attackOnBar = on;
+    },
+    addToBar: (id) => {
+      const free = state.bar.indexOf(null);
+      if (free === -1) return false;
+      state.bar[free] = slot(id);
+      return true;
+    },
+    removeFromBar: (id) => {
+      const at = state.bar.findIndex((a) => a?.type === 'ability' && a.id === id);
+      if (at === -1) return false;
+      state.bar[at] = null;
+      return true;
+    },
+    hasFormBars: () => false,
+    resetFormBar: noop,
+    setDragAction: noop,
+    clearActionDropTargets: noop,
+  };
+  const win = new SpellbookWindow(deps);
+  return {
+    win,
+    root,
+    deps,
+    state,
+    calls,
+    resetCalls(): void {
+      for (const key of Object.keys(calls)) delete calls[key];
+    },
+    toggle: (abilityId) =>
+      root.querySelector<HTMLButtonElement>(`.spell-hotbar-toggle[data-ability-id="${abilityId}"]`),
+    attackToggle: () => root.querySelector<HTMLButtonElement>('[data-attack-toggle]'),
+  };
+}
+
+/**
+ * Record every DOM MUTATION, every per-node READ the repaint makes, and every element
+ * LOOKUP, at the PROTOTYPE level.
+ *
+ * Prototype-level on purpose: a spy bound to the nodes a test happens to hold would miss
+ * exactly the regression that matters, a repaint that re-resolves its own nodes and writes
+ * those instead. Style is watched through a proxy over the `style` getter rather than by
+ * naming individual properties, so a write to any CSS property counts.
+ *
+ * THE READ CHANNEL IS WHAT PINS THE GATE, and it is not redundant with the write channel.
+ * Once every write is elided per row, an UNGATED repaint still writes nothing on an
+ * unchanged frame: what it costs is the elision check itself, one `getAttribute` plus one
+ * `disabled` read for every row, sixty times a second. So "no DOM write" alone would pass
+ * with the fall-through gate deleted; "no DOM read either" is the assertion that does not.
+ */
+function watchDom(): { writes: string[]; reads: string[]; queries: string[]; stop(): void } {
+  const writes: string[] = [];
+  const reads: string[] = [];
+  const queries: string[] = [];
+  const undo: Array<() => void> = [];
+
+  const spyMethod = (target: object, name: string, into: string[]): void => {
+    const original = Reflect.get(target, name) as (...args: unknown[]) => unknown;
+    if (typeof original !== 'function') throw new Error(`watchDom: ${name} is not a method`);
+    Reflect.set(target, name, function (this: unknown, ...args: unknown[]) {
+      into.push(`${name}(${String(args[0] ?? '')})`);
+      return original.apply(this, args);
+    });
+    undo.push(() => {
+      Reflect.set(target, name, original);
+    });
+  };
+
+  const spyAccessor = (target: object, name: string, watchGet = false): void => {
+    const descriptor = Object.getOwnPropertyDescriptor(target, name);
+    const set = descriptor?.set;
+    const get = descriptor?.get;
+    if (!set) throw new Error(`watchDom: ${name} has no setter to watch`);
+    if (watchGet && !get) throw new Error(`watchDom: ${name} has no getter to watch`);
+    Object.defineProperty(target, name, {
+      ...descriptor,
+      get:
+        watchGet && get
+          ? function (this: unknown) {
+              reads.push(name);
+              return get.call(this);
+            }
+          : get,
+      set(this: unknown, value: unknown) {
+        writes.push(name);
+        set.call(this, value);
+      },
+    });
+    undo.push(() => Object.defineProperty(target, name, descriptor));
+  };
+
+  // Mutations.
+  spyMethod(Element.prototype, 'setAttribute', writes);
+  spyMethod(Element.prototype, 'removeAttribute', writes);
+  spyMethod(DOMTokenList.prototype, 'toggle', writes);
+  spyMethod(DOMTokenList.prototype, 'add', writes);
+  spyMethod(DOMTokenList.prototype, 'remove', writes);
+  spyAccessor(Node.prototype, 'textContent');
+  spyAccessor(Element.prototype, 'innerHTML');
+  spyAccessor(Element.prototype, 'className');
+  // Both halves for `disabled`: the write is the IDL mutation RAW_WRITES cannot see, and the
+  // read is the elision check an ungated repaint pays per row.
+  spyAccessor(HTMLButtonElement.prototype, 'disabled', true);
+
+  // Per-node reads the repaint makes.
+  spyMethod(Element.prototype, 'getAttribute', reads);
+  // Any CSS property write, without naming them: wrap the style object.
+  const styleDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'style');
+  const styleGet = styleDescriptor?.get;
+  if (!styleGet) throw new Error('watchDom: HTMLElement.style has no getter to wrap');
+  Object.defineProperty(HTMLElement.prototype, 'style', {
+    ...styleDescriptor,
+    get(this: HTMLElement) {
+      const real = styleGet.call(this) as CSSStyleDeclaration;
+      return new Proxy(real, {
+        get: (target, prop) => {
+          const value = Reflect.get(target, prop) as unknown;
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+        set: (target, prop, value) => {
+          writes.push(`style.${String(prop)}`);
+          return Reflect.set(target, prop, value, target);
+        },
+      });
+    },
+  });
+  undo.push(() => Object.defineProperty(HTMLElement.prototype, 'style', styleDescriptor));
+
+  // Lookups.
+  spyMethod(Element.prototype, 'querySelector', queries);
+  spyMethod(Element.prototype, 'querySelectorAll', queries);
+  spyMethod(Document.prototype, 'querySelector', queries);
+  spyMethod(Document.prototype, 'querySelectorAll', queries);
+  spyMethod(Document.prototype, 'getElementById', queries);
+
+  return {
+    writes,
+    reads,
+    queries,
+    stop(): void {
+      for (const restore of undo.reverse()) restore();
+    },
+  };
+}
+
+/** Open the window and settle it: after this the retained state matches what was painted. */
+function open(h: Harness): void {
+  h.win.toggle();
+  h.win.tickOpen();
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('spellbook per-frame tick: an unchanged frame costs nothing', () => {
+  it('makes no DOM query, no DOM read and no DOM write across repeated identical frames', () => {
+    const h = harness();
+    open(h);
+    const watch = watchDom();
+    for (let i = 0; i < 10; i++) h.win.tickOpen();
+    watch.stop();
+    expect(
+      watch.queries,
+      `element lookups on an unchanged frame: ${watch.queries.join(', ')}`,
+    ).toEqual([]);
+    expect(watch.writes, `DOM writes on an unchanged frame: ${watch.writes.join(', ')}`).toEqual(
+      [],
+    );
+    // The gate's own assertion: an ungated repaint writes nothing here either, and still
+    // pays one aria-pressed read plus one `disabled` read per row on every frame.
+    expect(watch.reads, `DOM reads on an unchanged frame: ${watch.reads.join(', ')}`).toEqual([]);
+  });
+
+  it('THE HARNESS HAS TEETH: the same watcher sees the writes a real change makes', () => {
+    // Without this the assertion above passes just as well with a broken watcher, which is
+    // the whole failure mode of a zero-expected counter.
+    const h = harness();
+    open(h);
+    const watch = watchDom();
+    // One row onto the bar AND the bar filling up, so every write channel the repaint owns
+    // moves: the flipped row's text / class / attributes, and the other rows' `disabled`.
+    h.state.bar[0] = slot('charge');
+    h.state.hasFree = false;
+    h.win.tickOpen();
+    watch.stop();
+    expect(watch.writes.length).toBeGreaterThan(0);
+    expect(watch.writes).toContain('textContent');
+    expect(watch.writes).toContain('disabled');
+    expect(watch.writes).toContain('toggle(remove)');
+    expect(watch.writes.some((w) => w.startsWith('setAttribute(aria-pressed'))).toBe(true);
+    // ...and the read channel too, so a silently-empty read watcher cannot pass the
+    // zero-read assertion above by accident.
+    expect(watch.reads).toContain('getAttribute(aria-pressed)');
+    expect(watch.reads).toContain('disabled');
+  });
+
+  it('elides `disabled` too: a pure on-bar flip writes no disabled at all', () => {
+    // `disabled` was the one write left unelided on purpose, because it depends on hasFree,
+    // which can move without an on-bar flip. It is diffed against the live property now, so a
+    // repaint driven by a membership change alone must not touch it on ANY row.
+    const h = harness();
+    open(h);
+    const watch = watchDom();
+    h.state.bar[0] = slot('charge'); // hasFree stays true, so no row's disabled value moves
+    h.win.tickOpen();
+    watch.stop();
+    expect(watch.writes.length, 'the flip itself must still paint').toBeGreaterThan(0);
+    expect(watch.writes, `disabled was rewritten: ${watch.writes.join(', ')}`).not.toContain(
+      'disabled',
+    );
+  });
+
+  it('reads only primitives and the caller-owned slot array, four dep calls a frame', () => {
+    // The observable half of "no per-frame allocation": nothing the tick reads has to be
+    // built for it. `barActions` hands back the SAME array the harness owns (the derived id
+    // lists it replaced allocated 34 arrays per call), and the other three are booleans and
+    // the world handle.
+    const h = harness();
+    open(h);
+    h.resetCalls();
+    h.win.tickOpen();
+    expect(h.calls).toEqual({ world: 1, attackOnBar: 1, hasFreeSlot: 1, barActions: 1 });
+    expect(h.deps.barActions(), 'barActions must hand back the live array, not a copy').toBe(
+      h.state.bar,
+    );
+  });
+
+  it('does not re-resolve the window root on the fall-through', () => {
+    // The issue names this too: refreshHotbarControls resolved deps.root() twice a frame, and
+    // in the real Hud that dep is a live `document.querySelector('#spellbook')`.
+    const h = harness();
+    open(h);
+    h.resetCalls();
+    for (let i = 0; i < 5; i++) h.win.tickOpen();
+    expect(h.calls.root ?? 0).toBe(0);
+  });
+});
+
+describe('spellbook per-frame tick: a changed frame paints, without walking the subtree', () => {
+  it('paints an on-bar flip without any element lookup', () => {
+    const h = harness();
+    open(h);
+    const before = h.toggle('charge') as HTMLButtonElement;
+    expect(before.getAttribute('aria-pressed')).toBe('false');
+    const watch = watchDom();
+    h.state.bar[0] = slot('charge');
+    h.win.tickOpen();
+    watch.stop();
+    expect(watch.queries, `element lookups on a repaint: ${watch.queries.join(', ')}`).toEqual([]);
+    expect(before.getAttribute('aria-pressed')).toBe('true');
+    expect(before.textContent).toBe('-');
+    expect(before.classList.contains('remove')).toBe(true);
+  });
+
+  it('writes ONLY the row that flipped, not its neighbours', () => {
+    const h = harness();
+    open(h);
+    const flipped = h.toggle('charge') as HTMLButtonElement;
+    const neighbour = h.toggle('hamstring') as HTMLButtonElement;
+    const neighbourWrites = vi.spyOn(neighbour, 'setAttribute');
+    h.state.bar[0] = slot('charge');
+    h.win.tickOpen();
+    expect(flipped.getAttribute('aria-pressed')).toBe('true');
+    expect(neighbour.getAttribute('aria-pressed')).toBe('false');
+    expect(neighbourWrites, 'an unflipped row must not be rewritten').not.toHaveBeenCalled();
+    neighbourWrites.mockRestore();
+  });
+
+  it('settles: the frame after a repaint writes nothing again', () => {
+    const h = harness();
+    open(h);
+    h.state.bar[0] = slot('charge');
+    h.win.tickOpen();
+    const watch = watchDom();
+    h.win.tickOpen();
+    h.win.tickOpen();
+    watch.stop();
+    expect(watch.writes).toEqual([]);
+    expect(watch.reads).toEqual([]);
+    expect(watch.queries).toEqual([]);
+  });
+
+  it('tracks a free-slot change with NO on-bar flip (the case `disabled` exists for)', () => {
+    // hasFree is the input that moves without any membership change: the bar filling up
+    // disables every off-bar row's add control while no row's aria-pressed moves. This is why
+    // `disabled` cannot ride the aria-pressed elision, and it is the arm a gate keyed only on
+    // the bar's contents would silently drop.
+    const h = harness();
+    open(h);
+    const off = h.toggle('charge') as HTMLButtonElement;
+    expect(off.disabled).toBe(false);
+    h.state.hasFree = false;
+    h.win.tickOpen();
+    expect(off.disabled).toBe(true);
+    h.state.hasFree = true;
+    h.win.tickOpen();
+    expect(off.disabled).toBe(false);
+  });
+
+  it('tracks the Attack toggle when only the showAttackButton setting flips', () => {
+    // The Attack row's state comes from an Interface setting, not from the bar, so it is the
+    // third independent input. The options window can flip it while the spellbook is open.
+    const h = harness();
+    open(h);
+    const attack = h.attackToggle() as HTMLButtonElement;
+    expect(attack.getAttribute('aria-pressed')).toBe('true');
+    h.state.attackOnBar = false;
+    h.win.tickOpen();
+    expect(attack.getAttribute('aria-pressed')).toBe('false');
+    expect(attack.textContent).toBe('+');
+  });
+});
+
+describe('spellbook per-frame tick: the cached refs follow the rebuild', () => {
+  it('paints the LIVE toggles after a talent-driven rebuild, not the replaced ones', () => {
+    // The lockpick lesson (#2498), in this window's shape: refs taken once and never
+    // re-collected would paint a detached subtree forever after the first rebuild. A talent
+    // allocation reassigns world.known with new numbers, which moves knownSig and rebuilds
+    // every row, while the +/- refresh keeps running on the same instance.
+    const h = harness();
+    open(h);
+    const stale = h.toggle('charge') as HTMLButtonElement;
+
+    h.state.known = KNOWN_IDS.map((id) => resolved(id, id === 'charge' ? { cost: 5 } : {}));
+    h.win.tickOpen(); // knownSig moved -> rerenderPreservingView()
+    const fresh = h.toggle('charge') as HTMLButtonElement;
+    expect(fresh, 'the rebuild should have replaced the toggle nodes').not.toBe(stale);
+
+    h.state.bar[0] = slot('charge');
+    h.win.tickOpen();
+    expect(fresh.getAttribute('aria-pressed')).toBe('true');
+    // ...and the detached node is not being written any more.
+    expect(stale.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('re-latches the bar state at the rebuild, so the next frame repaints nothing', () => {
+    const h = harness();
+    open(h);
+    h.state.bar[0] = slot('charge');
+    h.state.hasFree = false;
+    h.state.known = KNOWN_IDS.map((id) => resolved(id, id === 'charge' ? { rank: 2 } : {}));
+    h.win.tickOpen(); // rebuild, which renders the NEW bar state directly
+    expect((h.toggle('charge') as HTMLButtonElement).getAttribute('aria-pressed')).toBe('true');
+    const watch = watchDom();
+    h.win.tickOpen();
+    watch.stop();
+    expect(watch.writes, `the frame after a rebuild rewrote: ${watch.writes.join(', ')}`).toEqual(
+      [],
+    );
+    expect(watch.reads, `the frame after a rebuild re-checked: ${watch.reads.join(', ')}`).toEqual(
+      [],
+    );
+  });
+
+  it('drops the refs a rebuild orphans instead of growing them', () => {
+    // render() clears the collected refs before the innerHTML write that destroys the nodes,
+    // so a rebuild that emits FEWER eligible rows cannot leave a detached toggle behind
+    // getting painted for the rest of the session.
+    const h = harness();
+    open(h);
+    const dropped = h.toggle('hamstring') as HTMLButtonElement;
+    h.state.known = h.state.known.filter((k) => k.def.id !== 'hamstring');
+    h.win.tickOpen(); // rebuild: hamstring is now an unlearned row, with no toggle
+    expect(h.toggle('hamstring')).toBeNull();
+
+    const watch = watchDom();
+    h.state.hasFree = false;
+    h.win.tickOpen();
+    watch.stop();
+    // The live rows were repainted, the orphan was not.
+    expect(watch.writes.length).toBeGreaterThan(0);
+    expect(dropped.disabled).toBe(false);
+  });
+});
+
+describe('spellbook per-frame tick: the forced refresh Hud drives', () => {
+  it('repaints immediately after an out-of-band bar change, then settles', () => {
+    // Hud calls refreshHotbarControls() directly after a bar change it made itself (the
+    // login-time layout restore, reset-form-bar), where waiting a frame is not an option.
+    const h = harness();
+    open(h);
+    const toggle = h.toggle('charge') as HTMLButtonElement;
+    h.state.bar[0] = slot('charge');
+    h.win.refreshHotbarControls();
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+
+    const watch = watchDom();
+    h.win.tickOpen();
+    watch.stop();
+    expect(watch.writes, 'the forced refresh must latch what it painted').toEqual([]);
+    expect(watch.reads, 'the forced refresh must latch what it painted').toEqual([]);
+  });
+
+  it('routes a toggle click through the bar and reflects it without a frame', () => {
+    const h = harness();
+    open(h);
+    const toggle = h.toggle('charge') as HTMLButtonElement;
+    toggle.click();
+    expect(h.state.bar.some((a) => a?.type === 'ability' && a.id === 'charge')).toBe(true);
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+    toggle.click();
+    expect(h.state.bar.some((a) => a?.type === 'ability' && a.id === 'charge')).toBe(false);
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('reads the bar LIVE on a click, so a same-frame keybind change cannot misroute it', () => {
+    // The click branch used to read a derived id list; reading the latched copy instead would
+    // send a press down the wrong branch when the bar moved after the last tick, and
+    // addToBar-on-an-already-present-ability reports no change, so the press would do nothing.
+    const h = harness();
+    open(h);
+    const toggle = h.toggle('charge') as HTMLButtonElement;
+    // The bar changed since the last tick (a keybind drop), with no tick in between.
+    h.state.bar[2] = slot('charge');
+    toggle.click();
+    expect(h.state.bar.some((a) => a?.type === 'ability' && a.id === 'charge')).toBe(false);
+  });
+});

--- a/tests/spellbook_tick_repaint.test.ts
+++ b/tests/spellbook_tick_repaint.test.ts
@@ -18,20 +18,24 @@
 // build-time write from a per-frame one in any case. Driving the real window across repeated
 // identical frames can, so that is what this file does.
 //
-// WHAT IS ASSERTED, and what is not. An unchanged frame is held to zero DOM queries, zero DOM
-// reads, zero DOM writes, and exactly four dep reads, all of which return a primitive or the
-// caller's own live slot array (asserted by reference). That is the observable half of "no
-// per-frame allocation": Node cannot count allocations, so the claim rests on the window
-// reading nothing per frame that has to be built, and on both gates comparing retained values
-// in place instead of through a derived list or a joined signature string.
+// WHAT IS ASSERTED, and what is not. An unchanged frame is held to zero DOM lookups, zero DOM
+// reads, zero DOM writes, exactly four dep reads, and zero allocating array operations
+// (`watchAlloc` below, which sees `map`/`filter`/`flatMap`/`slice`/`concat`/`join`/`Array.from`
+// plus `@@iterator`, so `for...of`, spread and `new Set(array)` all count). Node cannot count
+// heap allocations directly, so that array watch is the honest approximation and its limit is
+// stated where it lives: a closure or a template literal built inside the tick is invisible to
+// it, which is why both comparison paths are also written as index loops a reader can check.
 //
 // The rebuild gate that got cheaper is still held to what it always covered, and per FIELD:
-// the last describe below drives one talent-shaped change at a time, because a comparison that
-// quietly stopped looking at `cooldown` moves no other assertion in this file.
+// one describe below drives one talent-shaped change at a time, because a comparison that
+// quietly stopped looking at `cooldown` (or at the tail of the list) moves no other assertion
+// in this file.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ResolvedAbility } from '../src/sim/sim';
+import { tEntity } from '../src/ui/entity_i18n';
 import type { HotbarAction } from '../src/ui/hud/action_bar/hotbar';
+import { t } from '../src/ui/i18n';
 import { SpellbookWindow, type SpellbookWindowDeps } from '../src/ui/spellbook_window';
 
 // jsdom ships no 2D canvas, so the procedural ability-icon compositor cannot run
@@ -63,6 +67,11 @@ function slot(abilityId: string): HotbarAction {
   return { type: 'ability', id: abilityId };
 }
 
+/** An ITEM bar slot. The bar holds these too, and they are not ability ids. */
+function itemSlot(itemId: string): HotbarAction {
+  return { type: 'item', id: itemId };
+}
+
 interface Harness {
   win: SpellbookWindow;
   root: HTMLElement;
@@ -87,7 +96,9 @@ function harness(): Harness {
   const root = document.getElementById('spellbook') as HTMLElement;
   const state = {
     known: KNOWN_IDS.map((id) => resolved(id)),
-    bar: [null, null, null] as HotbarAction[],
+    // Slot 3 holds an ITEM from the start, so the ability/item discrimination in
+    // slotAbilityId is exercised by every case in this file rather than by one.
+    bar: [null, null, null, itemSlot('minor_healing_potion')] as HotbarAction[],
     hasFree: true,
     attackOnBar: true,
   };
@@ -262,6 +273,50 @@ function watchDom(): { writes: string[]; reads: string[]; queries: string[]; sto
   };
 }
 
+/**
+ * Count the array operations that ALLOCATE, at the prototype level.
+ *
+ * "No per-frame allocation" is the half of the acceptance criterion Node cannot measure
+ * directly, and the assertion it replaced (that the harness's own stub hands back the
+ * harness's own array) was true by construction and could not fail for any state of the
+ * window. This can: the shapes that reintroduce the garbage are all array operations, and
+ * `Symbol.iterator` covers `for...of`, spread, and `new Set(array)`, which is the exact
+ * construct the fall-through used to run every frame.
+ *
+ * A LIMIT, stated rather than implied: it sees array work only. A closure allocated inside
+ * the tick, a boxed number, or a template literal is invisible to it, which is why the
+ * comparison paths are also written as index loops that a reader can check by eye.
+ */
+function watchAlloc(): { calls: string[]; stop(): void } {
+  const calls: string[] = [];
+  const undo: Array<() => void> = [];
+  const wrap = (target: object, key: string | symbol, label: string): void => {
+    const original = Reflect.get(target, key) as (...args: unknown[]) => unknown;
+    if (typeof original !== 'function') throw new Error(`watchAlloc: ${label} is not a method`);
+    Reflect.set(target, key, function (this: unknown, ...args: unknown[]) {
+      calls.push(label);
+      return original.apply(this, args);
+    });
+    undo.push(() => {
+      Reflect.set(target, key, original);
+    });
+  };
+  for (const name of ['map', 'filter', 'flatMap', 'slice', 'concat', 'join'] as const) {
+    wrap(Array.prototype, name, `Array#${name}`);
+  }
+  wrap(Array.prototype, Symbol.iterator, 'Array#@@iterator');
+  wrap(Array, 'from', 'Array.from');
+  return {
+    calls,
+    // An INDEX loop, not `for...of`: this teardown runs while the @@iterator spy is
+    // still installed, so iterating here would record a call of its own and the
+    // watcher would report one allocation the code under test never made.
+    stop(): void {
+      for (let i = undo.length - 1; i >= 0; i--) undo[i]();
+    },
+  };
+}
+
 /** Open the window and settle it: after this the retained state matches what was painted. */
 function open(h: Harness): void {
   h.win.toggle();
@@ -411,19 +466,29 @@ describe('spellbook per-frame tick: an unchanged frame costs nothing', () => {
     );
   });
 
-  it('reads only primitives and the caller-owned slot array, four dep calls a frame', () => {
-    // The observable half of "no per-frame allocation": nothing the tick reads has to be
-    // built for it. `barActions` hands back the SAME array the harness owns (the derived id
-    // lists it replaced allocated 34 arrays per call), and the other three are booleans and
-    // the world handle.
+  it('reads exactly four deps a frame, and allocates no array while doing it', () => {
     const h = harness();
     open(h);
     h.resetCalls();
+    const alloc = watchAlloc();
+    for (let i = 0; i < 5; i++) h.win.tickOpen();
+    alloc.stop();
+    expect(h.calls).toEqual({ world: 5, attackOnBar: 5, hasFreeSlot: 5, barActions: 5 });
+    expect(alloc.calls, `the tick allocated: ${[...new Set(alloc.calls)].join(', ')}`).toEqual([]);
+  });
+
+  it('THE ALLOC WATCHER HAS TEETH: a rebuild frame does allocate, and is seen', () => {
+    // Same failure mode as the DOM watcher: a channel only ever asserted EMPTY needs a case
+    // that fills it. render() maps the kit and filters the slot list, so a rebuild is the
+    // natural positive fixture.
+    const h = harness();
+    open(h);
+    const alloc = watchAlloc();
+    h.state.known = KNOWN_IDS.map((id) => resolved(id, id === 'charge' ? { cost: 5 } : {}));
     h.win.tickOpen();
-    expect(h.calls).toEqual({ world: 1, attackOnBar: 1, hasFreeSlot: 1, barActions: 1 });
-    expect(h.deps.barActions(), 'barActions must hand back the live array, not a copy').toBe(
-      h.state.bar,
-    );
+    alloc.stop();
+    expect(alloc.calls).toContain('Array#map');
+    expect(alloc.calls).toContain('Array#filter');
   });
 
   it('does not re-resolve the window root on the fall-through', () => {
@@ -443,6 +508,7 @@ describe('spellbook per-frame tick: a changed frame paints, without walking the 
     open(h);
     const before = h.toggle('charge') as HTMLButtonElement;
     expect(before.getAttribute('aria-pressed')).toBe('false');
+    const label = before.getAttribute('aria-label');
     const watch = watchDom();
     h.state.bar[0] = slot('charge');
     h.win.tickOpen();
@@ -451,6 +517,19 @@ describe('spellbook per-frame tick: a changed frame paints, without walking the 
     expect(before.getAttribute('aria-pressed')).toBe('true');
     expect(before.textContent).toBe('-');
     expect(before.classList.contains('remove')).toBe(true);
+    // The ACCESSIBLE NAME has to move with the state, or a screen reader announces a
+    // pressed control that still says "Add ... to action bar" (WCAG 4.1.2). Asserted as
+    // "it changed, and it now reads as the remove action", not against a literal English
+    // string, since the copy is a t() key.
+    const after = before.getAttribute('aria-label');
+    expect(after, 'the toggle kept its add-state accessible name after going on-bar').not.toBe(
+      label,
+    );
+    expect(after).toBe(
+      t('hudChrome.spellbook.removeFromBarAria', {
+        name: tEntity({ kind: 'ability', id: 'charge', field: 'name' }),
+      }),
+    );
   });
 
   it('writes ONLY the row that flipped, not its neighbours', () => {
@@ -498,6 +577,38 @@ describe('spellbook per-frame tick: a changed frame paints, without walking the 
     expect(off.disabled).toBe(false);
   });
 
+  it('ignores an ITEM moving between bar slots (it is not an ability id)', () => {
+    // The bar holds items too, and the slot reader has to discriminate. Without the type
+    // check an item id lands in the latched slot list, so every potion drag reports a bar
+    // change and repaints every row: exactly the per-event work this change removed. Worse,
+    // the day an item id collides with an ability id, that row would render as on-bar.
+    const h = harness();
+    open(h);
+    const watch = watchDom();
+    h.state.bar[3] = null;
+    h.state.bar[1] = itemSlot('minor_healing_potion');
+    h.win.tickOpen();
+    watch.stop();
+    expect(
+      watch.writes,
+      `moving an item between bar slots repainted: ${watch.writes.join(', ')}`,
+    ).toEqual([]);
+    expect(watch.reads).toEqual([]);
+  });
+
+  it('does not treat an item id as an on-bar ability', () => {
+    // The collision arm, driven directly rather than left to the id namespaces staying
+    // disjoint: an item slot whose id happens to equal an ability's must leave that
+    // ability's row reading as off-bar.
+    const h = harness();
+    open(h);
+    h.state.bar[0] = itemSlot('charge');
+    h.win.tickOpen();
+    const toggle = h.toggle('charge') as HTMLButtonElement;
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    expect(toggle.textContent).toBe('+');
+  });
+
   it('tracks the Attack toggle when only the showAttackButton setting flips', () => {
     // The Attack row's state comes from an Interface setting, not from the bar, so it is the
     // third independent input. The options window can flip it while the spellbook is open.
@@ -505,10 +616,18 @@ describe('spellbook per-frame tick: a changed frame paints, without walking the 
     open(h);
     const attack = h.attackToggle() as HTMLButtonElement;
     expect(attack.getAttribute('aria-pressed')).toBe('true');
+    expect(attack.classList.contains('remove')).toBe(true);
     h.state.attackOnBar = false;
     h.win.tickOpen();
     expect(attack.getAttribute('aria-pressed')).toBe('false');
     expect(attack.textContent).toBe('+');
+    // Its own arm of every write the row toggles get. `remove` is mobile-only styling
+    // (hud.mobile.css), so a stale class leaves a button that adds wearing the remove
+    // colors; and the accessible name is the same WCAG 4.1.2 pairing as the rows.
+    expect(attack.classList.contains('remove')).toBe(false);
+    expect(attack.getAttribute('aria-label')).toBe(
+      t('hudChrome.spellbook.addToBarAria', { name: t('abilityUi.actionBar.attackName') }),
+    );
   });
 });
 
@@ -644,6 +763,22 @@ describe('spellbook per-frame tick: the rebuild gate still watches every summary
     h.win.tickOpen();
     expect(h.toggle('charge')).not.toBe(before);
     expect(h.toggle('execute')).not.toBeNull();
+  });
+
+  it('rebuilds when the LAST known ability goes away', () => {
+    // The one case only the length check catches, and the reason it is not redundant with
+    // the id compare beside it. Drop from the TAIL and every surviving index still matches
+    // positionally, so without the length guard the comparison reports no change and the
+    // window keeps rendering an ability the player no longer has, with a live +/- toggle,
+    // for the rest of the session. Dropping from the MIDDLE shifts the ids and is caught
+    // either way, which is why that case cannot stand in for this one.
+    const h = harness();
+    open(h);
+    const last = KNOWN_IDS[KNOWN_IDS.length - 1];
+    expect(h.toggle(last), 'the fixture must start with the tail ability on screen').not.toBeNull();
+    h.state.known = h.state.known.slice(0, -1);
+    h.win.tickOpen();
+    expect(h.toggle(last), 'an unlearned tail ability kept its action-bar toggle').toBeNull();
   });
 
   it('rebuilds when the SAME numbers arrive on a different ability id', () => {

--- a/tests/spellbook_tick_repaint.test.ts
+++ b/tests/spellbook_tick_repaint.test.ts
@@ -272,6 +272,87 @@ beforeEach(() => {
   document.body.innerHTML = '';
 });
 
+describe('the DOM watcher records every channel it claims', () => {
+  // A SELF-AUDIT, and it is not ceremony. Every assertion in this file that matters is
+  // "this channel stayed EMPTY", and a count of zero cannot notice a watcher arm that
+  // records nothing: an arm the window never exercises today (querySelectorAll, className,
+  // removeAttribute, a style write) would ship dead and take the very regression it exists
+  // for with it. So each arm gets a fixture here, exercised directly, and the mutation that
+  // guts it fails HERE rather than nowhere.
+  it('records every write, read and lookup arm, on a fixture per arm', () => {
+    const watch = watchDom();
+    const el = document.createElement('div');
+    const btn = document.createElement('button');
+    el.appendChild(btn);
+    document.body.appendChild(el);
+
+    el.setAttribute('data-x', '1');
+    el.removeAttribute('data-x');
+    el.classList.add('a');
+    el.classList.remove('a');
+    el.classList.toggle('b', true);
+    el.textContent = 'text';
+    el.innerHTML = '<span></span>';
+    el.className = 'cls';
+    btn.disabled = true;
+    el.style.display = 'block';
+
+    void el.getAttribute('data-x');
+    void btn.disabled;
+
+    void el.querySelector('span');
+    void el.querySelectorAll('span');
+    void document.querySelector('div');
+    void document.querySelectorAll('div');
+    void document.getElementById('nope');
+    watch.stop();
+
+    expect(watch.writes).toEqual([
+      'setAttribute(data-x)',
+      'removeAttribute(data-x)',
+      'add(a)',
+      'remove(a)',
+      'toggle(b)',
+      'textContent',
+      'innerHTML',
+      'className',
+      'disabled',
+      'style.display',
+    ]);
+    // The `disabled` write above also goes through its getter internally in jsdom, so the
+    // read channel is asserted by membership rather than by an exact sequence.
+    expect(watch.reads).toContain('getAttribute(data-x)');
+    expect(watch.reads).toContain('disabled');
+    expect(watch.queries).toEqual([
+      'querySelector(span)',
+      'querySelectorAll(span)',
+      'querySelector(div)',
+      'querySelectorAll(div)',
+      'getElementById(nope)',
+    ]);
+  });
+
+  it('puts every prototype back, so the spies cannot leak into another test', () => {
+    const before = {
+      setAttribute: Element.prototype.setAttribute,
+      querySelectorAll: Element.prototype.querySelectorAll,
+      getAttribute: Element.prototype.getAttribute,
+      textContent: Object.getOwnPropertyDescriptor(Node.prototype, 'textContent'),
+      style: Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'style'),
+    };
+    const watch = watchDom();
+    expect(Element.prototype.setAttribute).not.toBe(before.setAttribute);
+    watch.stop();
+    expect(Element.prototype.setAttribute).toBe(before.setAttribute);
+    expect(Element.prototype.querySelectorAll).toBe(before.querySelectorAll);
+    expect(Element.prototype.getAttribute).toBe(before.getAttribute);
+    expect(Object.getOwnPropertyDescriptor(Node.prototype, 'textContent')).toEqual(
+      before.textContent,
+    );
+    expect(Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'style')).toEqual(before.style);
+  });
+});
+
 describe('spellbook per-frame tick: an unchanged frame costs nothing', () => {
   it('makes no DOM query, no DOM read and no DOM write across repeated identical frames', () => {
     const h = harness();

--- a/tests/spellbook_tick_repaint.test.ts
+++ b/tests/spellbook_tick_repaint.test.ts
@@ -19,12 +19,15 @@
 // identical frames can, so that is what this file does.
 //
 // WHAT IS ASSERTED, and what is not. An unchanged frame is held to zero DOM queries, zero DOM
-// writes, and exactly four dep reads, all of which return a primitive or the caller's own live
-// slot array (asserted by reference). That is the observable half of "no per-frame
-// allocation": Node cannot count allocations, so the claim rests on the window reading nothing
-// per frame that has to be built. The one remaining per-frame allocation is deliberate and
-// named where it lives: `knownSig` still concatenates a signature string, which is the rebuild
-// gate the issue calls correct.
+// reads, zero DOM writes, and exactly four dep reads, all of which return a primitive or the
+// caller's own live slot array (asserted by reference). That is the observable half of "no
+// per-frame allocation": Node cannot count allocations, so the claim rests on the window
+// reading nothing per frame that has to be built, and on both gates comparing retained values
+// in place instead of through a derived list or a joined signature string.
+//
+// The rebuild gate that got cheaper is still held to what it always covered, and per FIELD:
+// the last describe below drives one talent-shaped change at a time, because a comparison that
+// quietly stopped looking at `cooldown` moves no other assertion in this file.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ResolvedAbility } from '../src/sim/sim';
@@ -531,5 +534,62 @@ describe('spellbook per-frame tick: the forced refresh Hud drives', () => {
     h.state.bar[2] = slot('charge');
     toggle.click();
     expect(h.state.bar.some((a) => a?.type === 'ability' && a.id === 'charge')).toBe(false);
+  });
+});
+
+describe('spellbook per-frame tick: the rebuild gate still watches every summary field', () => {
+  // ONE case per field a row summary paints, because they are checked independently and a
+  // comparison that stopped looking at any one of them moves nothing else in this file. Each
+  // asserts node IDENTITY: a rebuild replaces the rows, and `toEqual` on the markup would
+  // pass on a wipe-and-identical-rebuild, which is the opposite of the question.
+  const FIELDS = ['rank', 'cost', 'castTime', 'cooldown'] as const;
+
+  for (const field of FIELDS) {
+    it(`rebuilds the rows when a talent moves \`${field}\` alone`, () => {
+      const h = harness();
+      open(h);
+      const before = h.toggle('charge') as HTMLButtonElement;
+      h.state.known = KNOWN_IDS.map((id) => resolved(id, id === 'charge' ? { [field]: 99 } : {}));
+      h.win.tickOpen();
+      expect(h.toggle('charge'), `a ${field} change did not rebuild the rows`).not.toBe(before);
+    });
+  }
+
+  it('rebuilds when an ability is learned or unlearned', () => {
+    const h = harness();
+    open(h);
+    const before = h.toggle('charge') as HTMLButtonElement;
+    h.state.known = [...h.state.known, resolved('execute')];
+    h.win.tickOpen();
+    expect(h.toggle('charge')).not.toBe(before);
+    expect(h.toggle('execute')).not.toBeNull();
+  });
+
+  it('rebuilds when the SAME numbers arrive on a different ability id', () => {
+    // The online mirror rebuilds world.known every snapshot, so identity says nothing; the id
+    // has to be part of the comparison or a spec swap would paint the wrong rows.
+    const h = harness();
+    open(h);
+    const before = h.toggle('charge') as HTMLButtonElement;
+    h.state.known = h.state.known.map((k) =>
+      k.def.id === 'charge' ? resolved('thunder_clap') : k,
+    );
+    h.win.tickOpen();
+    expect(h.toggle('charge')).toBeNull();
+    expect(h.toggle('thunder_clap')).not.toBeNull();
+    expect(before.isConnected, 'the old row should be detached').toBe(false);
+  });
+
+  it('CONTROL: a fresh world.known array with identical numbers rebuilds nothing', () => {
+    // The case reference equality would get wrong every frame online.
+    const h = harness();
+    open(h);
+    const before = h.toggle('charge') as HTMLButtonElement;
+    h.state.known = KNOWN_IDS.map((id) => resolved(id));
+    const watch = watchDom();
+    h.win.tickOpen();
+    watch.stop();
+    expect(h.toggle('charge')).toBe(before);
+    expect(watch.writes, `a no-op snapshot repainted: ${watch.writes.join(', ')}`).toEqual([]);
   });
 });

--- a/tests/spellbook_window.test.ts
+++ b/tests/spellbook_window.test.ts
@@ -88,9 +88,15 @@ describe('spellbook_window: the pinned Attack row', () => {
 
   it('keeps the per-frame refresh syncing the Attack toggle (options can flip it)', () => {
     // The ref is COLLECTED as appendAttackRow builds the button, not re-found by its
-    // marker on every frame (#2519); the marker itself stays, since the drag/drop path
-    // and the stylesheet both key off it. The behavior is driven in
+    // marker on every frame (#2519). The behavior is driven in
     // tests/spellbook_tick_repaint.test.ts.
+    //
+    // The `data-attack-toggle` marker stays, and its remaining readers are worth naming
+    // because none of them is in src/: the styling keys off the `.spell-hotbar-toggle`
+    // CLASS, and the drag path carries HOTBAR_ATTACK_MIME on the row, so after this
+    // change the marker is read only by scripts/spellbook_attack_shot.mjs (the Attack-row
+    // screenshot probe) and by the tests/spellbook_tick_repaint.test.ts harness. Both
+    // break silently if the dataset write is removed as dead.
     expect(code).toContain('this.attackToggle = toggle');
     expect(code).toContain('const attackBtn = this.attackToggle');
     expect(code).toContain("attackBtn.setAttribute('aria-pressed'");
@@ -123,6 +129,18 @@ describe('spellbook_window: mobile action-ring page label (Phase 4, touch-only)'
     expect(code).toContain('abilityIdByBarSlot: this.lastSlotIds');
     expect(code).toContain('this.lastSlotIds.push(slotAbilityId(action))');
     expect(code).toMatch(/slotAbilityId\(action: HotbarAction\): string \| null/);
+  });
+
+  it('takes the bar as Hud LIVE slot array, with no copy in between', () => {
+    // The per-frame change check walks whatever this dep returns, so a defensive copy on
+    // the Hud side would put a fresh 33-element array back on every frame the window is
+    // open, which is the allocation #2519 removed. Nothing behavioral can see that (a copy
+    // compares equal), so the wiring is pinned here.
+    expect(hud).toContain('barActions: () => this.hotbarActions');
+    expect(hud, 'the two allocating derived bar deps should be gone').not.toContain(
+      'barAbilityIds:',
+    );
+    expect(hud).not.toContain('abilityIdByBarSlot:');
   });
 
   it('gates the page label on both a non-null mobilePage AND touch mode', () => {
@@ -169,6 +187,20 @@ describe('spellbook_window: hud.update() refresh call site', () => {
     expect(code).toContain('this.refreshHotbarControlsIfChanged()');
     expect(code).toContain('if (!this.takeControlChange()) return');
     expect(hud).toContain('this.spellbookWindow.refreshHotbarControls();');
+    // The change check walks the slot array IN PLACE. A derived list here would allocate on
+    // every frame the window is open, and no behavioral test can see it (the derived list
+    // compares the same), so the shape is pinned: an index loop over `actions`, no map /
+    // filter / spread.
+    expect(code).toContain('for (let i = 0; i < actions.length; i++)');
+    const movedStart = code.indexOf('private controlsMoved(');
+    const movedBody = code.slice(
+      movedStart,
+      code.indexOf('private paintHotbarControls(', movedStart),
+    );
+    expect(movedStart, 'controlsMoved went missing').toBeGreaterThan(-1);
+    for (const alloc of ['.map(', '.filter(', '.flatMap(', '.concat(', 'new Set(', '...']) {
+      expect(movedBody, `controlsMoved allocates via ${alloc}`).not.toContain(alloc);
+    }
   });
 
   it('keeps the in-place refresh updating the aria-pressed + disabled state per toggle', () => {

--- a/tests/spellbook_window.test.ts
+++ b/tests/spellbook_window.test.ts
@@ -192,19 +192,23 @@ describe('spellbook_window: hud.update() refresh call site', () => {
 
 describe('spellbook_window: tooltip/summary reflect talent changes (tooltip parity)', () => {
   it('re-renders the open window only when a resolved ability number changed', () => {
-    // tickOpen compares a content signature (id/rank/cost/cast/cooldown) of
-    // world.known, not its array identity: the online mirror rebuilds that array
-    // every snapshot, so reference equality would rebuild the DOM every frame. A
-    // real change (e.g. a talent dropping Wicked Slash cost 45 -> 40) rebuilds the
-    // row summaries; an unchanged frame falls back to the cheap toggle refresh.
+    // tickOpen compares the CONTENT of world.known (id/rank/cost/cast/cooldown), not
+    // its array identity: the online mirror rebuilds that array every snapshot, so
+    // reference equality would rebuild the DOM every frame. A real change (e.g. a
+    // talent dropping Wicked Slash cost 45 -> 40) rebuilds the row summaries; an
+    // unchanged frame falls through to the gated toggle refresh.
     expect(code).toContain('tickOpen()');
-    expect(code).toContain(
-      'SpellbookWindow.knownSig(this.deps.world().known) !== this.lastKnownSig',
-    );
-    expect(code).toContain('this.lastKnownSig = SpellbookWindow.knownSig(world.known)');
-    // the signature carries the numbers a row summary paints, so a cost/cooldown
-    // change flips it (a bare id:rank would miss a same-rank talent cost cut).
-    expect(code).toMatch(/knownSig[\s\S]*k\.def\.id.*k\.rank.*k\.cost.*k\.castTime.*k\.cooldown/);
+    expect(code).toContain('if (this.knownChanged(this.deps.world().known)) {');
+    expect(code).toContain('this.captureKnown(world.known)');
+    // The comparison carries every number a row summary paints, so a cost/cooldown
+    // change flips it (a bare id/rank check would miss a same-rank talent cost cut).
+    // Field-by-field on purpose (#2519): the joined signature string this replaced
+    // was rebuilt on every frame the window was open.
+    for (const field of ['k.rank', 'k.cost', 'k.castTime', 'k.cooldown']) {
+      expect(code, `knownChanged stopped comparing ${field}`).toContain(`${field} !== this.known`);
+    }
+    expect(code).toContain('k.def.id !== this.knownIds[i]');
+    expect(code).toContain('this.knownNums.push(k.rank, k.cost, k.castTime, k.cooldown)');
   });
 
   it('preserves scroll position and keyboard focus across the talent-driven rebuild', () => {

--- a/tests/spellbook_window.test.ts
+++ b/tests/spellbook_window.test.ts
@@ -69,7 +69,10 @@ describe('spellbook_window: the pinned Attack row', () => {
     expect(code.indexOf('this.appendAttackRow(list')).toBeLessThan(
       code.indexOf('for (const row of view.rows) this.appendRow(list, row)'),
     );
-    expect(code).toContain('attackOnBar: this.deps.attackOnBar()');
+    // The Attack state reaches the view through the latch takeControlChange() fills at
+    // the top of render(), not a second deps.attackOnBar() read (#2519).
+    expect(code).toContain('attackOnBar: this.lastAttackOnBar');
+    expect(code).toContain('const attackOnBar = this.deps.attackOnBar()');
   });
 
   it('reuses the existing Attack name/tooltip keys (no new player strings)', () => {
@@ -84,7 +87,12 @@ describe('spellbook_window: the pinned Attack row', () => {
   });
 
   it('keeps the per-frame refresh syncing the Attack toggle (options can flip it)', () => {
-    expect(code).toContain("querySelector<HTMLButtonElement>('[data-attack-toggle]')");
+    // The ref is COLLECTED as appendAttackRow builds the button, not re-found by its
+    // marker on every frame (#2519); the marker itself stays, since the drag/drop path
+    // and the stylesheet both key off it. The behavior is driven in
+    // tests/spellbook_tick_repaint.test.ts.
+    expect(code).toContain('this.attackToggle = toggle');
+    expect(code).toContain('const attackBtn = this.attackToggle');
     expect(code).toContain("attackBtn.setAttribute('aria-pressed'");
   });
 });
@@ -109,8 +117,12 @@ describe('spellbook_window: the Attack row is draggable onto the action bar', ()
 });
 
 describe('spellbook_window: mobile action-ring page label (Phase 4, touch-only)', () => {
-  it('feeds abilityIdByBarSlot through to the pure view core', () => {
-    expect(code).toContain('abilityIdByBarSlot: this.deps.abilityIdByBarSlot()');
+  it('feeds the per-slot ability ids through to the pure view core', () => {
+    // Derived from the bar's live slot array at render time rather than taken as its own
+    // allocating dep, since the per-frame change check walks the same array (#2519).
+    expect(code).toContain('abilityIdByBarSlot: this.lastSlotIds');
+    expect(code).toContain('this.lastSlotIds.push(slotAbilityId(action))');
+    expect(code).toMatch(/slotAbilityId\(action: HotbarAction\): string \| null/);
   });
 
   it('gates the page label on both a non-null mobilePage AND touch mode', () => {
@@ -144,25 +156,36 @@ describe('spellbook_window: hud.update() refresh call site', () => {
   it('drives the open spellbook from hud.update() through tickOpen while displayed', () => {
     // Pin the hud.ts call site so a refactor cannot silently stop the open
     // spellbook from tracking action-bar AND talent changes. tickOpen re-renders
-    // on a resolved-numbers change, else falls back to the cheap toggle refresh.
+    // on a resolved-numbers change, else falls back to the gated toggle refresh.
     expect(hud).toContain('if (this.spellbookWindow.isOpen) this.spellbookWindow.tickOpen();');
+  });
+
+  it('gates the per-frame fall-through behind its own change check (#2519)', () => {
+    // The fall-through used to repaint unconditionally. Both entry points survive and
+    // are different contracts: tickOpen takes the gated one, and Hud keeps the forced
+    // one for the bar changes it makes itself (the login layout restore, reset-form-bar).
+    // What either one DOES is driven in tests/spellbook_tick_repaint.test.ts; these two
+    // pins only keep the per-frame call site pointed at the gated variant.
+    expect(code).toContain('this.refreshHotbarControlsIfChanged()');
+    expect(code).toContain('if (!this.takeControlChange()) return');
+    expect(hud).toContain('this.spellbookWindow.refreshHotbarControls();');
   });
 
   it('keeps the in-place refresh updating the aria-pressed + disabled state per toggle', () => {
     // The call-site guard above proves the refresh fires; this pins what it WRITES.
-    // refreshHotbarControls keys off `btn` (vs appendRow's `toggle`), so the row
+    // paintHotbarControls keys off `btn` (vs appendRow's `toggle`), so the row
     // guard does not cover this path: without these, the open spellbook's toggles
     // would stop tracking the bar (the whole reason this path is not-cold).
     expect(code).toContain("btn.setAttribute('aria-pressed'");
-    expect(code).toContain('btn.disabled = !onBar && !hasFree');
+    expect(code).toContain('const disabled = !onBar && !hasFree');
+    expect(code).toContain('if (btn.disabled !== disabled) btn.disabled = disabled');
   });
 
-  it('elides the per-frame toggle writes to on-bar flips only (this runs every frame)', () => {
-    // refreshHotbarControls fires on EVERY animation frame while the window is open, so
-    // the +/- text, the remove class, the aria-pressed, and the i18n-backed aria-label
-    // are gated on an actual on-bar membership flip (read from aria-pressed, which
-    // appendRow seeds), not rewritten unconditionally. Only `disabled` stays per-frame
-    // (it depends on hasFree). A revert to unconditional writes drops this guard.
+  it('elides the toggle writes to on-bar flips only, per row', () => {
+    // A repaint fires when any of the three bar inputs moves, so the +/- text, the
+    // remove class, the aria-pressed, and the i18n-backed aria-label are gated on an
+    // actual on-bar membership flip (read from aria-pressed, which appendRow seeds),
+    // not rewritten for every row. A revert to unconditional writes drops this guard.
     expect(code).toContain("(btn.getAttribute('aria-pressed') === 'true') !== onBar");
   });
 });

--- a/tests/spellbook_window.test.ts
+++ b/tests/spellbook_window.test.ts
@@ -136,11 +136,18 @@ describe('spellbook_window: mobile action-ring page label (Phase 4, touch-only)'
     // the Hud side would put a fresh 33-element array back on every frame the window is
     // open, which is the allocation #2519 removed. Nothing behavioral can see that (a copy
     // compares equal), so the wiring is pinned here.
-    expect(hud).toContain('barActions: () => this.hotbarActions');
-    expect(hud, 'the two allocating derived bar deps should be gone').not.toContain(
-      'barAbilityIds:',
+    //
+    // Scoped to the spellbook's own deps bag rather than the whole of hud.ts: the negative
+    // half would otherwise fire on any UNRELATED window that happens to take a dep by one
+    // of these names.
+    const bagStart = hud.indexOf('new SpellbookWindow({');
+    expect(bagStart, 'the spellbook deps bag moved or was renamed').toBeGreaterThan(-1);
+    const bag = hud.slice(bagStart, hud.indexOf('  });', bagStart));
+    expect(bag).toContain('barActions: () => this.hotbarActions');
+    expect(bag, 'the two allocating derived bar deps should be gone').not.toContain(
+      'barAbilityIds',
     );
-    expect(hud).not.toContain('abilityIdByBarSlot:');
+    expect(bag).not.toContain('abilityIdByBarSlot');
   });
 
   it('gates the page label on both a non-null mobilePage AND touch mode', () => {


### PR DESCRIPTION
## Summary

`spellbook_window.tickOpen()` is the one window `Hud.update()` drives on the per-frame band.
Its `lastKnownSig` guard covered the rebuild correctly; the fall-through did not. Every frame
the window was open, `refreshHotbarControls()` resolved the root twice, ran a `querySelector`
for the Attack toggle plus a `querySelectorAll` subtree walk over every ability row, allocated
a `Set` from a freshly built id list, and wrote `btn.disabled` on every row unelided.

Both halves of the tick are gated now, and an unchanged frame does nothing at all: no element
lookup, no DOM read, no DOM write, no allocation.

- **The toggles are collected as `render()` builds them**, rather than re-queried from the
  tick. Capturing at build time (instead of re-resolving at the end of the rebuild, the shape
  `lockpick_window` needed because its nodes arrive from an `innerHTML` string) costs zero
  lookups even on a rebuild, and carries each row's ability id with its node, so the repaint no
  longer reads `dataset` per row either. The refs are dropped at the top of `render()`, the one
  thing that replaces those nodes.
- **The fall-through takes its own change check.** Everything the repaint writes is a function
  of exactly three inputs (the Attack setting, which slots hold which ability, whether any slot
  is free), so a frame where none of them moved has nothing to paint. This is the half the
  issue calls the real fix; caching refs alone only removes the walk.
- **The bar arrives as its live slot array** (`barActions`) instead of two derived id lists, so
  the change check walks it in place and allocates nothing. The `flatMap` it replaced built 34
  arrays per call, and the tick called it 60 times a second. Both derived views are rebuilt at
  render time, where the allocation is paid once per rebuild.
- **The rebuild gate is allocation-free too.** `knownSig` concatenated a signature over every
  known ability on every frame, roughly a thousand characters built and thrown away to decide
  nothing had changed. It is now two retained arrays compared field by field, returning at the
  first difference. Semantics are unchanged and slightly tighter (an id carrying the old
  separator can no longer collide with a neighbouring field).
- `.disabled` is elided against the live property now, so a repaint driven by a membership
  change alone does not touch it on any row.

### The three things the issue asked to settle

1. **Can the fall-through ride a cheap change check?** Yes, and it is the fix. See above.
2. **Does `.disabled` belong in `RAW_WRITES`?** No, and #2518 / #2549 already answered it by
   measurement: it lives in the driver-callback-scoped `IDL_WRITES` family instead, and adding
   it to `RAW_WRITES` would not have caught this case anyway, because `spellbook_window` is a
   cold painter and cold takes no raw-write scan. The comment in `tests/hud_perf_budget.test.ts`
   that pointed at this issue is updated to record the outcome.
3. **Should the module move to `HOT_PAINTERS`?** No, for two reasons stated at the code. The
   hot bucket's write contract is a per-FILE token count pinned exactly, so it churns on every
   ordinary markup edit while saying nothing about cadence: it cannot tell a repaint write from
   a build-time one in the same file, and cadence is the only thing this issue was about. And
   the other half does not fit at all: the `PainterHost` writers elide through Maps keyed by
   ELEMENT, so a window that replaces its whole row set per rebuild would strand a cache entry
   per destroyed node. The instrument that does answer a cadence question is behavioral, and it
   is the new suite.

## Related issues

Closes #2519. Follows #2516 (the drive registry that recorded this window as per-frame) and
#2518 / #2549 (the driver-callback body gate that settled the `.disabled` question).

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- Commands:
  - `npm run gate` (green, all 11 steps)
  - `npx vitest run tests/spellbook_tick_repaint.test.ts tests/spellbook_window.test.ts tests/spellbook_view.test.ts tests/hud_update_drive.test.ts tests/hud_perf_budget.test.ts tests/client_shell.test.ts tests/architecture.test.ts`
  - `npx tsc --noEmit`
- New suite: `tests/spellbook_tick_repaint.test.ts` (jsdom) drives the real window across
  repeated identical frames and watches DOM mutations, per-node reads and element lookups at
  the PROTOTYPE level, plus an `Array.prototype` watch for allocation.
  - The READ channel is what pins the gate, and it is not redundant: once every write is elided
    per row, an ungated repaint still writes nothing on an unchanged frame, and only the elision
    checks (one `getAttribute` and one `disabled` read per row, per frame) show up.
  - Every watcher arm has its own fixture, because a channel only ever asserted EMPTY cannot
    notice an arm that records nothing, and half the arms have no live caller in this window.
- 32-case mutation battery over the change, all 32 red. It is what found the gaps below, so it
  is worth naming what it caught after the first pass looked done: the `knownChanged` length
  guard was the only detector of a TAIL unlearn and had no fixture (dropping from the middle
  shifts the ids and is caught either way); the `+/-` accessible name could stop resyncing on
  either arm with the suite green; the Attack toggle's `remove` class had no assertion; the item
  arm of the slot reader had no fixture; and the allocation claim originally rested on an
  assertion that compared the harness to itself.

## Screenshots / recordings

N/A. No rendered output changes: the same states paint the same markup, just fewer times.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green.

### Cross-platform

- [x] **Accessible.** The `+/-` accessible name and `aria-pressed` still move together on both
      the row and Attack arms, now asserted rather than assumed (WCAG 4.1.2). The mobile-only
      `remove` class is asserted on both arms too.
- [x] N/A for a viewport pass: no layout, no CSS, no rendered markup change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, no generated files hand-edited.

## Deliberately left as-is, and said so at the code

Two limits the gates do not cover, both pre-existing and both now documented where they live
rather than left for the next reader to re-derive:

- The touch-only "Page N" chip is emitted at build time, so moving an ability between bar slots
  leaves it until the next rebuild.
- The rebuild guard watches the RESOLVED ABILITY (id, rank, cost, cast, cooldown), which is what
  the row summary is built from. `abilitySummary` also folds in live player state (resource
  type, spell haste), so a change to those alone does not rebuild. The signature string this
  replaced covered exactly the same five fields.
