### PR TITLE
fix(server): bound the masterAssign pids array at the raid roster size

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -52,6 +52,7 @@ import {
 } from '../src/sim/party_frame_info';
 import type { PetState, PlayerMeta } from '../src/sim/sim';
 import { MAX_CHAT_MESSAGE_LEN, Sim } from '../src/sim/sim';
+import { RAID_MAX } from '../src/sim/social/party';
 import type { VcMatch } from '../src/sim/social/vale_cup';
 import {
   parseTalentAllocation,
@@ -4610,6 +4611,17 @@ export class GameServer {
           typeof msg.rollId === 'number' &&
           Array.isArray(msg.pids) &&
           msg.pids.length > 0 &&
+          // A curate-phase roll's candidates are the tapping group's loot-eligible
+          // members, so a full raid roster is the most an honest client can check
+          // (#2524). Over cap the frame is rejected outright, the way the other
+          // capped cases here reject theirs, rather than truncated to a selection
+          // the master looter never made. Tested BEFORE the element scan so the
+          // per-element work is bounded too; the Sim re-validates every pid.
+          // Never tighten this below the honest ceiling: the reject path is
+          // silent, so a cap a real roster can exceed would not fail visibly, it
+          // would livelock the looter against the #2526 regrace (the row clears,
+          // returns after the grace, and re-sending is dropped again).
+          msg.pids.length <= RAID_MAX &&
           msg.pids.every((p: unknown) => typeof p === 'number')
         )
           sim.assignMasterLoot(msg.rollId, msg.pids, pid);

--- a/src/sim/loot/loot_roll.ts
+++ b/src/sim/loot/loot_roll.ts
@@ -653,10 +653,11 @@ export function assignMasterLoot(
   if (r.meta.entityId !== roll.masterLooter) return; // only the master looter decides
   // Keep only still-eligible targets, each counted once; ignore anyone no longer
   // a candidate. The pid list is client-supplied (the masterAssign wire case
-  // checks that pids is a non-empty array of numbers and nothing about the
-  // values), and a pid named twice would send that player two lootRoll prompts,
-  // print their reveal line twice, and can put one player in tiedWinners twice,
-  // drawing a tie-break ctx.rng.int the honest single-candidate case never draws.
+  // checks that pids is a non-empty numeric array no longer than a full raid
+  // roster, and nothing about the values), and a pid named twice would send that
+  // player two lootRoll prompts, print their reveal line twice, and can put one
+  // player in tiedWinners twice, drawing a tie-break ctx.rng.int the honest
+  // single-candidate case never draws.
   // What is load-bearing is deduping BEFORE the length tests below, so [X, X]
   // takes the direct-grant arm exactly like [X] instead of converting to a
   // one-player need/greed roll (the dedupe and the filter commute, so their

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -618,7 +618,8 @@ const DEFAULT_RAID_LOCKOUT_MS = 24 * 60 * 60 * 1000;
 // party-interact + vision delays) moved to encounters/nythraxis.ts (N1), the only
 // code that reads them. NYTHRAXIS_BOSS_ID / NYTHRAXIS_ADD_ID stay in types.ts.
 // PARTY_MAX / RAID_MIN / RAID_MAX / RAID_GROUP_MAX moved to social/party.ts (A1),
-// the only code that reads them.
+// the only code that reads them, except RAID_MAX, which server/game.ts now imports
+// as the upper length bound on the masterAssign wire case (#2524).
 // RAID_ALLOWED_DUNGEON_IDS / RAID_REQUIRED_DUNGEON_IDS moved to instances/dungeons.ts
 // (I1: read only by enterDungeon's raid gate).
 // DAMAGE_IDLE_DESPAWN_SECONDS / DAMAGE_IDLE_DESPAWN_MOB_IDS moved to entity_roster.ts

--- a/src/sim/social/party.ts
+++ b/src/sim/social/party.ts
@@ -22,10 +22,16 @@ import type { SimContext } from '../sim_context';
 import { DEFAULT_PARTY_LOOT_STRATEGIES } from '../types';
 
 // Group caps (classic 5-player party, 10-player raid as 2 subgroups of 5). Moved
-// from sim.ts with the only code that reads them; do NOT inline new numbers.
+// from sim.ts with the code that reads them; do NOT inline new numbers.
 const PARTY_MAX = 5;
 const RAID_MIN = 5;
-const RAID_MAX = 10;
+// The largest roster any group can hold, enforced at every join site below
+// (partyInvite, partyAccept, and the Dungeon Finder formation seam). The one cap
+// with a reader outside this file: it is also the honest ceiling on how many
+// players a client-supplied group-wide pid list can name, so server/game.ts
+// imports it to bound the masterAssign wire case (#2524). Raising it widens that
+// wire bound too, which is the intent.
+export const RAID_MAX = 10;
 const RAID_GROUP_MAX = 5;
 
 // One indivisible Dungeon Finder unit as the formation seam receives it: a

--- a/tests/loot_master_sim.test.ts
+++ b/tests/loot_master_sim.test.ts
@@ -465,11 +465,11 @@ describe('the master looter reconcile surface (#2526)', () => {
 });
 
 // #2505. The pid list reaching assignMasterLoot is client-supplied and the
-// masterAssign wire case validates that pids is a non-empty array of numbers
-// and nothing about the values, so a hand-crafted frame can name the same
-// eligible candidate twice. Every case below runs the repeat against the
-// equivalent duplicate-free request on the SAME seed: the repeat must be
-// indistinguishable in bags, chat, prompts, and rng stream position.
+// masterAssign wire case validates that pids is a non-empty numeric array no
+// longer than a full raid roster (#2524) and nothing about the values, so a
+// hand-crafted frame can still name the same candidate twice. Every case runs the
+// repeat against the equivalent duplicate-free request on the SAME seed: the
+// repeat must be indistinguishable in bags, chat, prompts, and rng stream position.
 describe('a repeated pid in a master-loot assignment (#2505)', () => {
   // Every rng draw `fn` spends, counted through the parity harness's own
   // observer seam. A no-new-draws guard, NOT the determinism arm: the extra
@@ -669,6 +669,46 @@ describe('a repeated pid in a master-loot assignment (#2505)', () => {
     const pids = openMasterRoll().candidates.map((cand) => cand.pid);
     expect(pids).toHaveLength(3); // the whole party, so the check has something to catch
     expect(new Set(pids).size).toBe(3);
+  });
+
+  it('opens the master roll with a roster scoped to the tapping party', () => {
+    // The other half of that invariant, and now load-bearing in a second place:
+    // server/game.ts bounds the masterAssign pid list at RAID_MAX (#2524) purely
+    // because the candidate roster is a subset of one party, which partyAccept and
+    // the finder seam both cap. A bystander standing on the corpse is the way that
+    // could quietly stop being true, so pin it with one present: a count-only
+    // assertion on an all-party fixture would pass either way.
+    const { sim, a } = openMasterRoll();
+    const bystander = sim.addPlayer('hunter', 'Nosy');
+    teleportTo(sim, 21, 21, bystander); // right on the corpse, in no party
+    expect(sim.partyOf(bystander)).toBeNull();
+
+    const rosterFor = (mobId: number) => {
+      const mob = createMob(mobId, MOBS.forest_wolf, 2, { x: 20, y: 0, z: 22 });
+      mob.dead = true;
+      mob.lootable = true;
+      mob.tappedById = a;
+      mob.loot = { copper: 0, items: [{ itemId: PREMIUM, count: 1 }] };
+      sim.entities.set(mob.id, mob);
+      sim.events.length = 0;
+      sim.lootCorpse(mob.id, a);
+      const opened = sim.events.find((e) => e.type === 'masterLoot');
+      expect(opened).toBeTruthy();
+      return (opened as { candidates: { pid: number }[] }).candidates.map((c) => c.pid);
+    };
+
+    const outside = rosterFor(990501);
+    const members = sim.partyOf(a)?.members ?? [];
+    expect(outside.length).toBeGreaterThan(1); // a real roll, not an empty one
+    expect(outside.filter((pid) => !members.includes(pid))).toEqual([]);
+    expect(outside).not.toContain(bystander);
+
+    // The control that makes it a statement about MEMBERSHIP rather than distance:
+    // nothing about where they stand changes, they simply join, and the very same
+    // corpse position now puts them on the roster.
+    sim.partyInvite(bystander, a);
+    sim.partyAccept(bystander);
+    expect(rosterFor(990502)).toContain(bystander);
   });
 
   it('routes a departed [X, X] target down the same fallback [X] takes', () => {

--- a/tests/loot_roll_wire.test.ts
+++ b/tests/loot_roll_wire.test.ts
@@ -16,6 +16,7 @@ import { GameServer } from '../server/game';
 import { ClientWorld } from '../src/net/online';
 import { MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
+import { RAID_MAX } from '../src/sim/social/party';
 
 function fakeWs() {
   const sent: any[] = [];
@@ -356,5 +357,220 @@ describe('a repeated pid in a masterAssign frame, through a real GameServer (#25
     const spy = vi.spyOn(server.sim, 'assignMasterLoot').mockImplementation(() => {});
     sendCmd(server, session, { cmd: 'masterAssign', rollId: 4242, pids: [7, 7] });
     expect(spy).toHaveBeenCalledWith(4242, [7, 7], session.pid);
+  });
+});
+
+// #2524. `masterAssign` took a client-supplied array with no upper length bound,
+// unlike the capped cases beside it: `df_roles` at 3, `df_queue` at 16,
+// `df_list_create` tags at 8, `mail_send` attachments at 3, each rejecting the
+// whole frame over cap. It was NOT the only unbounded one, so do not read this
+// block as an audit: `harvestCorpse` components, `trade_offer` items, and
+// `saveLoadout` bar all still arrive unbounded (each is filtered or sliced
+// sim-side rather than rejected at the wire). The bound here is the raid roster,
+// because a curate-phase roll's candidate list is the tapping group's
+// loot-eligible members and a group can never hold more than a full raid. These
+// drive real GameServer frames, since the dispatch is where the untrusted array
+// enters.
+describe('the masterAssign pids length cap (#2524)', () => {
+  it('is the full raid roster, ten', () => {
+    // The literal the cap resolves to. Every assertion below is written in terms of
+    // RAID_MAX, which the server imports too, so without this anchor a future edit
+    // to the roster size would move the test with the source and stop pinning any
+    // particular boundary at all.
+    expect(RAID_MAX).toBe(10);
+  });
+
+  // A real ten-member raid on a real GameServer, holding a curate-phase master-loot
+  // roll whose candidate list is the whole roster. This is the largest honest
+  // masterAssign a client can build, which is the entire argument for the cap: it is
+  // reachable in normal play, so the cap must not reject it.
+  function raidMasterRoll() {
+    const server = new GameServer();
+    const sessions: any[] = [];
+    for (let i = 0; i < RAID_MAX; i++) {
+      // A distinct account AND character id per raider: join rejects a second live
+      // session on either (MAX_ACTIVE_SESSIONS_PER_ACCOUNT is 1), and it reports
+      // that by RETURNING an error rather than throwing, which would otherwise
+      // surface here as an undefined pid several assertions later.
+      const s = server.join(fakeWs().ws as any, 30 + i, 30 + i, `Raider${i}`, 'warrior', null);
+      if ('error' in s) throw new Error(s.error);
+      (s as any).blockListLoaded = true;
+      sessions.push(s);
+    }
+    const pids = sessions.map((s) => s.pid as number);
+    const sim = server.sim;
+    const leader = pids[0];
+    // Everyone stands on the corpse (PARTY_XP_RANGE is 80 yards), so every member
+    // is loot-eligible and the roll opens with all ten as candidates.
+    for (const [i, pid] of pids.entries()) {
+      const e = sim.entities.get(pid)!;
+      e.pos = { x: 20 + i * 0.5, y: 0, z: 20 };
+      e.prevPos = { ...e.pos };
+    }
+    // Five, convert, then five more: the only route to a ten-member roster
+    // through the invite path, since convertPartyToRaid gates on RAID_MIN and
+    // partyAccept refuses past capacity. The Dungeon Finder forms one in a single
+    // step instead, through the same RAID_MAX gate (party.ts formation seam).
+    for (const pid of pids.slice(1, 5)) {
+      sim.partyInvite(pid, leader);
+      sim.partyAccept(pid);
+    }
+    sim.convertPartyToRaid(leader);
+    for (const pid of pids.slice(5)) {
+      sim.partyInvite(pid, leader);
+      sim.partyAccept(pid);
+    }
+    expect(sim.partyOf(leader)?.members).toEqual(pids);
+    sim.setPartyLootMaster(true, 0, 'uncommon', leader);
+
+    // A world-unique corpse id: the server sim is a full generated world, so a
+    // hand-picked literal could collide with a real entity.
+    const mobId = [...sim.entities.keys()].reduce((max, k) => (k > max ? k : max), 0) + 1;
+    const mob = createMob(mobId, MOBS.forest_wolf, 2, { x: 20, y: 0, z: 22 });
+    mob.dead = true;
+    mob.lootable = true;
+    mob.tappedById = leader;
+    mob.loot = { copper: 0, items: [{ itemId: 'greyjaw_hide_boots', count: 1 }] };
+    sim.entities.set(mob.id, mob);
+    sim.lootCorpse(mob.id, leader);
+    const opened = sim.events.find((e) => e.type === 'masterLoot') as any;
+    // Read before dereferencing, so a fixture that failed to open the roll says so
+    // instead of throwing a bare TypeError on the line below.
+    expect(opened).toBeTruthy();
+    // The premise: a legitimate frame really can name RAID_MAX pids.
+    expect(opened.candidates.map((c: any) => c.pid)).toEqual(pids);
+    sim.events.length = 0;
+    return { server, sim, pids, leaderSession: sessions[0], rollId: opened.rollId as number };
+  }
+
+  function promptedPids(sim: any, rollId: number): number[] {
+    return sim.events
+      .filter((e: any) => e.type === 'lootRoll' && e.rollId === rollId)
+      .map((e: any) => e.pid as number);
+  }
+
+  it('lets a full-raid assignment through: ten pids open the roll for all ten', () => {
+    const { server, sim, pids, leaderSession, rollId } = raidMasterRoll();
+    expect(pids).toHaveLength(RAID_MAX);
+    sendCmd(server, leaderSession, { cmd: 'masterAssign', rollId, pids });
+    // Every member gets the need/greed prompt, in request order: the at-cap frame
+    // reached the sim and did the whole job, not just some of it.
+    expect(promptedPids(sim, rollId)).toEqual(pids);
+    // And the same thing read off the surfaces the client mirrors: the curate
+    // prompt is gone from the looter and the roll is now live for all ten.
+    expect(sim.activeMasterLootRolls(pids[0])).toEqual([]);
+    for (const pid of pids) expect(sim.activeLootRolls(pid).map((p) => p.rollId)).toEqual([rollId]);
+  });
+
+  it('rejects one pid over the cap at the dispatch, leaving the roll assignable', () => {
+    const { server, sim, pids, leaderSession, rollId } = raidMasterRoll();
+    // A real full roster plus one repeat. Every element is a valid candidate and
+    // the sender is the master looter of an open curate-phase roll, so length is
+    // the only thing that can stop this frame.
+    const overCap = [...pids, pids[0]];
+    expect(overCap).toHaveLength(RAID_MAX + 1);
+
+    const assignSpy = vi.spyOn(sim, 'assignMasterLoot');
+    sendCmd(server, leaderSession, { cmd: 'masterAssign', rollId, pids: overCap });
+    expect(assignSpy).not.toHaveBeenCalled();
+    // Rejected at the dispatch means nothing moved in the world either: no prompts
+    // went out, and the roll is still curating on the master looter's own surface
+    // rather than resolved, converted, or dropped.
+    expect(promptedPids(sim, rollId)).toEqual([]);
+    expect(sim.activeMasterLootRolls(pids[0]).map((p) => p.rollId)).toEqual([rollId]);
+    for (const pid of pids) expect(sim.activeLootRolls(pid)).toEqual([]);
+
+    // The positive control, on the same server and the same roll and through the
+    // same spy: at cap it still lands. Without this the assertions above would all
+    // read the same way if the harness never delivered a frame at all, or if the
+    // rejection had consumed the roll.
+    sendCmd(server, leaderSession, { cmd: 'masterAssign', rollId, pids });
+    expect(assignSpy).toHaveBeenCalledWith(rollId, pids, pids[0]);
+    expect(promptedPids(sim, rollId)).toEqual(pids);
+    assignSpy.mockRestore();
+  });
+
+  it('draws the line on length alone, before any roll is looked up', () => {
+    // The boundary in isolation, with the sim stubbed out: the cap is a dispatch
+    // check, so it holds for a rollId that does not exist and pids that name nobody.
+    // Both sides of the boundary, because a pin that only shows RAID_MAX + 1 being
+    // refused cannot tell a cap of ten from a cap of one.
+    const server = new GameServer();
+    const session = server.join(fakeWs().ws as any, 14, 14, 'Ddd', 'warrior', null) as any;
+    session.blockListLoaded = true;
+    const spy = vi.spyOn(server.sim, 'assignMasterLoot').mockImplementation(() => {});
+    const atCap = Array.from({ length: RAID_MAX }, (_, i) => 7000 + i);
+
+    sendCmd(server, session, { cmd: 'masterAssign', rollId: 4243, pids: atCap });
+    expect(spy).toHaveBeenCalledWith(4243, atCap, session.pid);
+
+    spy.mockClear();
+    sendCmd(server, session, { cmd: 'masterAssign', rollId: 4243, pids: [...atCap, 7999] });
+    expect(spy).not.toHaveBeenCalled();
+
+    // The pre-existing lower bound is untouched: an empty selection is still no
+    // selection, and is still refused. So is a non-numeric element, the sibling
+    // conjunct the cap now sits in front of.
+    sendCmd(server, session, { cmd: 'masterAssign', rollId: 4243, pids: [] });
+    expect(spy).not.toHaveBeenCalled();
+    sendCmd(server, session, { cmd: 'masterAssign', rollId: 4243, pids: [7000, 'x'] });
+    expect(spy).not.toHaveBeenCalled();
+
+    // Re-arm: the three refusals above share one positive control, and it ran
+    // BEFORE them, so on its own it cannot rule out a session or spy that stopped
+    // working part way through. Send the accepted shape again, last.
+    sendCmd(server, session, { cmd: 'masterAssign', rollId: 4243, pids: atCap });
+    expect(spy).toHaveBeenCalledWith(4243, atCap, session.pid);
+    spy.mockRestore();
+  });
+
+  it('decides on length alone before reading a single element', () => {
+    // The dispatch comment claims the length test runs BEFORE the `.every` element
+    // scan, "so the per-element work is bounded too". Both orders accept and reject
+    // exactly the same frames, so no ordinary payload can tell them apart: the
+    // array itself has to be the instrument. Index getters count reads, and the
+    // frame goes straight to dispatchMessage rather than through sendCmd, because
+    // JSON.parse would flatten the getters away before the dispatch ever saw them.
+    const server = new GameServer();
+    const session = server.join(fakeWs().ws as any, 15, 15, 'Eee', 'warrior', null);
+    if ('error' in session) throw new Error(session.error);
+    (session as any).blockListLoaded = true;
+    const spy = vi.spyOn(server.sim, 'assignMasterLoot').mockImplementation(() => {});
+
+    const counting = (length: number) => {
+      let reads = 0;
+      const pids: number[] = [];
+      for (let i = 0; i < length; i++) {
+        Object.defineProperty(pids, i, {
+          enumerable: true,
+          configurable: true,
+          get: () => {
+            reads++;
+            return 7000 + i;
+          },
+        });
+      }
+      return { pids, reads: () => reads };
+    };
+    const send = (pids: number[]) =>
+      (server as any).dispatchMessage(
+        session,
+        { t: 'cmd', cmd: 'masterAssign', rollId: 4244, pids },
+        '{"t":"cmd","cmd":"masterAssign"}',
+        0,
+      );
+
+    const over = counting(RAID_MAX + 1);
+    send(over.pids);
+    expect(spy).not.toHaveBeenCalled();
+    expect(over.reads()).toBe(0);
+
+    // The instrument really counts, so the zero above is a short circuit and not a
+    // getter that never fires: at cap every element is read exactly once.
+    const at = counting(RAID_MAX);
+    send(at.pids);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(at.reads()).toBe(RAID_MAX);
+    spy.mockRestore();
   });
 });

--- a/tests/party_machine.test.ts
+++ b/tests/party_machine.test.ts
@@ -108,6 +108,37 @@ describe('PartyMachine: dungeon finder formation', () => {
     expect(formed!.members).toEqual([leader, member, solo]);
     expect(inherited).toEqual([solo]);
   });
+
+  it('refuses to form a raid one member over RAID_MAX, and forms it at RAID_MAX', () => {
+    // The formation seam is the SECOND way a roster grows (partyAccept is the
+    // other, pinned in tests/social.test.ts by an eleventh raider bouncing off a
+    // full raid). Both had to stay capped for server/game.ts to bound the
+    // masterAssign pid list at RAID_MAX (#2524): a roster the finder could push
+    // past ten would make that wire cap start rejecting honest frames, silently.
+    // Both sides of the boundary, since a refusal alone cannot tell a cap of ten
+    // from a cap of two.
+    const form = (size: number) => {
+      const t = makeCtx();
+      const pids = Array.from({ length: size }, (_, i) => t.addPlayer(i + 1, `P${i}`));
+      (t.ctx as any).entities = { has: () => true };
+      const party = new PartyMachine(t.ctx);
+      const formed = party.formDungeonFinderGroup(
+        pids.map((pid) => ({ partyId: null, leaderPid: pid, members: [pid] })),
+        { raid: true },
+      );
+      return { formed, pids, party };
+    };
+
+    const over = form(11); // RAID_MAX + 1
+    expect(over.formed).toBeNull();
+    // Refused BEFORE anything mutated: nobody is left holding a half-built group.
+    for (const pid of over.pids) expect(over.party.partyOf(pid)).toBeNull();
+
+    const at = form(10); // RAID_MAX exactly
+    expect(at.formed).not.toBeNull();
+    expect(at.formed!.members).toEqual(at.pids);
+    expect(at.formed!.raid).toBe(true);
+  });
 });
 
 describe('PartyMachine: formation', () => {


### PR DESCRIPTION
## Summary

`masterAssign` took a client-supplied array with no upper length bound, unlike the capped
cases sitting beside it in `dispatchMessage`: `df_roles` at 3, `df_queue` at 16,
`df_list_create` tags at 8, `mail_send` attachments at 3, each rejecting the whole frame
over cap rather than truncating it.

One correction to the issue's framing, which reviewers caught: `masterAssign` was **not**
the only unbounded array-taking case. `harvestCorpse` components, `trade_offer` items, and
`saveLoadout` bar all still arrive unbounded at the dispatch (each is filtered or sliced
sim-side rather than rejected at the wire). `harvestCorpse` is the same defect class and
runs its unbounded per-element `.filter()` at the dispatch itself. Those are left alone
here to keep the diff scoped, and the test block says so explicitly so nobody reads it as
a completed audit.

This adds the missing bound, sized off the real ceiling rather than a round number. A
curate-phase roll's candidates come from `partyLootCandidatesForMob`, which reads
`mob.lootRecipientIds` (or the live roster) and is therefore capped by `party.members`,
which `partyCapacity` holds at `RAID_MAX`. So a full raid roster is the most an honest
client can ever check, and `RAID_MAX` is now exported from `src/sim/social/party.ts` and
imported by the dispatch instead of a re-inlined `10`: raising the roster size widens the
wire bound with it, which is the intent.

Two decisions, both made the way the neighbouring cases already make them:

- **Over cap rejects the frame**, it does not truncate. Truncating would hand the sim a
  selection the master looter never made.
- **The rejection is silent**, with no player-visible string, no `commandOutcome`, and no
  new protocol-anomaly or drop-cause label. The frame is unreachable from any shipped
  client (the loot window builds its pid list from the roll's own candidate checkboxes),
  it is already metered by the command lane and by `WS_MAX_PAYLOAD_BYTES`, and both of
  those vocabularies are deliberately closed sets.

The length is tested **before** the `.every()` element scan, so the per-element work is
bounded too, and the sim still re-validates every pid against the roll.

Three comments asserted things this change falsifies and were corrected in the same
commit: `src/sim/loot/loot_roll.ts` and `tests/loot_master_sim.test.ts` both claimed the
wire case checks nothing but "a non-empty array of numbers", and `src/sim/sim.ts` claimed
`social/party.ts` is the only code that reads the group caps.

No sim behavior, `IWorld` surface, wire payload shape, or rng draw order changes.

## Related issues

Closes #2524. Found during the review of #2505 (PR #2521), which deliberately left the
wire case alone: the dedupe belongs at the sim boundary, and a length cap is a separate
argument.

Note that `tests/loot_roll_wire.test.ts` pins that the server forwards a repeated pid
VERBATIM. A length cap is a rejection, not a sanitize, so that pin is untouched and still
green: the cap measures the raw array, and `[7, 7]` still forwards as `[7, 7]`.

## Type of change

- [ ] Feature: new functionality
- [ ] Bug fix
- [x] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

Hardening, not a live defect fix: `WS_MAX_PAYLOAD_BYTES` (16 KiB) already bounded the array
at roughly 3k elements, and the frame is rejected outright unless the sender is the master
looter of an open curate-phase roll.

## How was this tested?

Three new tests in `tests/loot_roll_wire.test.ts`, all driving real `GameServer` frames
through `dispatchMessage`, because the dispatch is where the untrusted array enters:

1. **At cap works, end to end.** A real ten-member raid (five, convert, five more, the only
   route to a ten-member roster) holding a curate-phase master-loot roll whose candidate
   list is the whole roster. The harness asserts the roll really opened with ten candidates
   before anything else runs, so the cap is proven reachable in normal play. The ten-pid
   assignment lands and opens the need/greed roll for all ten, in request order, checked
   both on the emitted prompts and on `activeMasterLootRolls` / `activeLootRolls`.
2. **One over cap is rejected at the dispatch.** The same rig sends the full roster plus one
   repeat: `assignMasterLoot` is never called, no prompts go out, and the roll is still
   curating on the master looter's surface. The same test then sends the at-cap frame
   through the same spy as a positive control, so the refusal assertions cannot pass on a
   harness that never delivered a frame or a roll the rejection consumed.
3. **The boundary in isolation.** With the sim stubbed, exactly `RAID_MAX` pids are
   forwarded and `RAID_MAX + 1` are not, for a rollId that does not exist, plus the
   pre-existing empty-array and non-numeric-element lower bounds, and a re-armed positive
   control last so the refusals cannot pass on a spy that stopped working part way through.
   `expect(RAID_MAX).toBe(10)` anchors the literal so the test does not simply follow the
   constant wherever a future edit moves it.
4. **The length test really does run before the element scan.** Both orders accept and
   reject exactly the same frames, so the array itself is the instrument: index getters
   count reads. Over cap, zero elements are read; at cap, exactly `RAID_MAX` are, which is
   what proves the zero is a short circuit and not a getter that never fires.

Two pins were added for the invariant the cap rests on, since a roster that could exceed
`RAID_MAX` would make the cap start silently rejecting honest frames:

- `tests/party_machine.test.ts` — the Dungeon Finder formation seam refuses a raid one
  member over `RAID_MAX` (and forms one at exactly `RAID_MAX`), leaving nobody in a
  half-built group. It is the second way a roster grows; `partyAccept` was already pinned
  by the eleventh raider in `tests/social.test.ts`.
- `tests/loot_master_sim.test.ts` — an opened master roll's candidate roster is scoped to
  the tapping party, proven with a bystander standing on the corpse who is excluded, then
  included once they join and nothing else changes. That control is what makes it a
  statement about membership rather than distance.

- Commands:
  - `npm run gate` (green)
  - `npx vitest run tests/loot_roll_wire.test.ts tests/loot_master_sim.test.ts tests/loot_roll_controller.test.ts tests/command_schema.test.ts tests/architecture.test.ts tests/world_api_parity.test.ts tests/social.test.ts tests/party_machine.test.ts tests/localization_fixes.test.ts`
  - Decisiveness checked by mutation, six of them, each caught: deleting the cap fails 2 of
    the new tests; tightening it to `<= 5` fails 3; loosening it to `<= 25` fails 2; moving
    the length test after the element scan fails the ordering pin (11 reads, not 0);
    loosening the finder's raid cap to 25 fails the formation pin; unscoping the candidate
    walk from `party.members` to every player fails the roster-scoping pin.
- Manual steps: none. The over-cap frame is not reachable from any shipped client, so there
  is nothing to click; the tests build the hostile frame by hand, which is the only way in.

## Screenshots / recordings

N/A. Server-side wire validation, no player-visible surface.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [x] ~Tested on desktop and mobile.~ N/A, no UI.
- [x] ~Accessible.~ N/A, no UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files.
