### PR TITLE
test(parity): make the master_loot coverage assertions decisive

### DIFF
--- a/tests/parity/CLAUDE.md
+++ b/tests/parity/CLAUDE.md
@@ -87,8 +87,13 @@ confirmed each):
   same change.
 - **Transient Sim-owned collections are not sampled directly.** `arenaMatches`,
   `delveRuns`, `marketListings`/`marketCollections`, `instances`, `groundAoEs`,
-  `pendingMobRespawns` are pinned only via their entity/event/`PlayerMeta`
-  projection. Extracting one of these should add a scenario that drives it (the
+  `pendingMobRespawns`, `pendingLootRolls` are pinned only via their
+  entity/event/`PlayerMeta` projection. `pendingLootRolls` is the sharpest case:
+  a roll's `choices` map is wiped by `convertMasterRollToNeedGreed` and deleted by
+  `resolveLootRoll`, so a mid-window write to it that draws no rng leaves the whole
+  trace byte-identical. `master_loot` reaches around that with a `rec.notes`
+  readout (its refused curate-phase votes assert `choices.size === 0`); anything
+  else that must pin an unresolved roll needs the same trick. Extracting one of these should add a scenario that drives it (the
   precedents: `market_round_trip`, `bank_round_trip`, `dungeon_instances`) or sample
   the collection directly.
 - **Construction-time draws + ambient world mobs.** The `Rng` is born inside the Sim

--- a/tests/parity/coverage.test.ts
+++ b/tests/parity/coverage.test.ts
@@ -359,22 +359,36 @@ describe('coverage: each scenario fires its subsystem', () => {
     expect(rollIds.length).toBe(3);
     expect(prompts.length).toBe(3);
     expect([...new Set(prompts.map((e) => e.pid))]).toEqual([a]);
-    expect(prompts[0].candidates.map((cand: { pid: number }) => cand.pid)).toEqual([a, b, c, d]);
+    // Every prompt's roster, not just the first: a candidate set that went wrong on
+    // only the second or third drop would hide behind a first-member-only check.
+    for (const prompt of prompts) {
+      expect(prompt.candidates.map((cand: { pid: number }) => cand.pid)).toEqual([a, b, c, d]);
+    }
 
-    // Arms 1 + 2: two direct grants, each announced to all four members exactly
-    // once. A duplicate pid that failed to dedupe would either double c's line or
-    // convert the roll instead of granting it, so both counts below are decisive.
-    const assigned = evs.filter((e) => e.type === 'loot' && / assigned /.test(text(e)));
-    expect(assigned.length).toBe(8); // 2 grants x 4 party members
-    expect([...new Set(assigned.map((e) => e.pid))].sort((x, y) => x - y)).toEqual([a, b, c, d]);
-    // Where the three copies ended up: b and c took one each by direct grant and
-    // one of them took a second by winning the contest below, while the master
-    // looter kept none and the low roller (d) won nothing.
+    // Arms 1 + 2: two direct grants, announced PER GRANTEE to all four members
+    // exactly once. Naming the grantee is what makes this decisive: a plain count
+    // of 8 assign lines survives both a redistribution of the two grants and a
+    // duplicate pid printed twice to half the party.
+    const assignedTo = (name: string) =>
+      byPid(
+        evs
+          .filter(
+            (e) =>
+              e.type === 'loot' && text(e) === `Aaa assigned [[i:greyjaw_hide_boots]] to ${name}.`,
+          )
+          .map((e) => e.pid as number),
+      );
+    expect(assignedTo('Bbb')).toEqual(byPid([a, b, c, d]));
+    expect(assignedTo('Ccc')).toEqual(byPid([a, b, c, d]));
+    expect(evs.filter((e) => e.type === 'loot' && / assigned /.test(text(e))).length).toBe(8);
+    // Where the three copies ended up, per player rather than in aggregate: a sum
+    // plus a max is satisfied by a materially wrong distribution (both grants to c
+    // with b winning the contest reads identically), so pin each holder.
     const held = (pid: number) => sim.countItem('greyjaw_hide_boots', pid) as number;
-    expect(held(a)).toBe(0);
-    expect(held(d)).toBe(0);
-    expect(held(b) + held(c)).toBe(3);
-    expect(Math.max(held(b), held(c))).toBe(2);
+    expect(held(a)).toBe(0); // the master looter assigned all three away
+    expect(held(b)).toBe(1); // direct grant only
+    expect(held(c)).toBe(2); // direct grant + the contest win below
+    expect(held(d)).toBe(0); // rolled below the tie, so won nothing
     // The deduped assignment never reopened as a roll.
     expect(evs.some((e) => e.type === 'lootRoll' && e.rollId === rollIds[1])).toBe(false);
 
@@ -384,14 +398,22 @@ describe('coverage: each scenario fires its subsystem', () => {
     expect(converted.map((e) => e.pid).sort((x, y) => x - y)).toEqual([b, c, d]);
 
     // The three need rolls TIED at the top, which is the only thing that makes
-    // resolveLootRoll draw its tie-break int, and a winner was announced.
+    // resolveLootRoll draw its tie-break int. Pinned to the literal numbers the
+    // scenario comment documents, so that when a future stream change dissolves
+    // the tie the failure names the seed's actual rolls instead of just reporting
+    // that some count moved.
     const needRolls = evs
       .filter((e) => e.type === 'loot' && e.pid === a && /^Need Roll - /.test(text(e)))
       .map((e) => Number(/^Need Roll - (\d+)/.exec(text(e))?.[1]));
-    expect(needRolls.length).toBe(3);
-    const top = Math.max(...needRolls);
-    expect(needRolls.filter((n) => n === top).length).toBeGreaterThan(1);
-    expect(evs.some((e) => e.type === 'loot' && e.pid === a && / wins /.test(text(e)))).toBe(true);
+    expect(needRolls).toEqual([97, 97, 43]); // b and c tie at the top, d below
+    // The tie-break picked c, and that outcome is the one observable effect of the
+    // master-loot-only draw, so it is pinned by name and by winning roll.
+    expect(
+      evs.filter(
+        (e) =>
+          e.type === 'loot' && text(e) === `Ccc wins [[i:greyjaw_hide_boots]] (${needRolls[1]})`,
+      ).length,
+    ).toBe(4); // announced once to each party member
 
     // The golden's draw-order log across an assignment and a resolution: opening
     // the rolls and all three assignments draw NOTHING, and the resolution draws
@@ -401,13 +423,22 @@ describe('coverage: each scenario fires its subsystem', () => {
       if (!f) throw new Error(`no frame ${label}`);
       return f;
     };
+    // Absolute, not just relative: setup draws nothing at all and the whole
+    // scenario spends exactly the four master-loot draws, which is the property
+    // that makes this scenario a near-pure instrument for the slice. A delta-only
+    // check would not notice setup or the trailing ticks starting to draw.
+    expect(frame('master-rolls-open').rng.draws).toBe(0);
+    expect(trace.draws).toBe(4);
     expect(frame('assigned-converted').rng.draws - frame('master-rolls-open').rng.draws).toBe(0);
     expect(frame('roll-resolved').rng.draws - frame('assigned-converted').rng.draws).toBe(4);
-    // The refused curate-phase vote in particular bailed before its draw and
-    // moved no player or entity state (the three counted votes above are the
-    // other half of that: the refusal did not consume d's answer).
-    expect(frame('curate-phase-vote-refused').rng.draws).toBe(frame('master-rolls-open').rng.draws);
-    expect(frame('curate-phase-vote-refused').state).toBe(frame('master-rolls-open').state);
+    // The two refused curate-phase votes bailed before any draw...
+    expect(frame('curate-phase-vote-refused').rng.draws).toBe(0);
+    // ...and, the half the draw log cannot see, neither was RECORDED. A guard that
+    // admitted a vote but drew nothing (a 'pass', or a 'need' whose draw moved)
+    // leaves draws, digests and every sampled field identical, because
+    // convertMasterRollToNeedGreed wipes `choices` moments later and
+    // pendingLootRolls is never sampled. This is the only assertion that sees it.
+    expect(rec.notes.refusedChoiceCount).toBe(0);
   });
 
   it('entity_roster: despawn branches drop, delayed drain runs, ghost release + healer resurrect', () => {

--- a/tests/parity/scenarios.ts
+++ b/tests/parity/scenarios.ts
@@ -1513,8 +1513,8 @@ function l1LootDistribution(): Scenario {
 }
 
 // Master loot: a 4-member party on master loot over a corpse carrying three
-// copies of a threshold-meeting drop, driving every arm the master-loot slice
-// owns AND both places master loot reaches the shared rng stream (#2523: nothing
+// copies of a threshold-meeting drop, driving the three assignment arms below
+// AND both places master loot reaches the shared rng stream (#2523: nothing
 // in this file used to touch assignMasterLoot / setPartyLootMaster at all, so a
 // reordered master-loot draw was invisible to the draw-order digest):
 //  - DIRECT GRANT: a single assigned target takes the item, drawing NOTHING;
@@ -1538,6 +1538,12 @@ function l1LootDistribution(): Scenario {
 // that the WHOLE scenario
 // draws exactly four times, all four of them master-loot draws, so its draw
 // digest is a near-pure instrument for this slice.
+// NOT driven here, and all zero-draw, so they would need a state-side pin rather
+// than a draw delta (tests/loot_master_sim.test.ts covers each directly): the
+// empty-target refusal that leaves the prompt open (#2526), the rejection of a
+// caller who is not the master looter, the departed-single-target convert, the
+// MASTER_LOOT_TIMEOUT convert in resolveLootRoll, removePlayerFromLootRolls's
+// master-looter convert, and setPartyLootMaster's non-leader error arm.
 function masterLoot(): Scenario {
   return {
     name: 'master_loot',
@@ -1599,7 +1605,20 @@ function masterLoot(): Scenario {
       // by submitLootRoll's master-loot guard, and refused BEFORE the int(1,100)
       // draw. This frame pins that the attempt costs zero draws, so hoisting that
       // draw above the guard (the classic early-bail reorder) reddens the gate.
-      if (rollIds[2] !== undefined) sim.submitLootRoll(rollIds[2], 'need', d);
+      // BOTH choice kinds are tried: a 'need' would draw if the guard let it
+      // through (so the rng stream detects that), but a 'pass' never draws at any
+      // callsite, so nothing in the trace would notice a guard that admitted one.
+      // The recorded choice count below is what covers that second arm; it is read
+      // from pendingLootRolls, which the trace deliberately never samples.
+      if (rollIds[2] !== undefined) {
+        sim.submitLootRoll(rollIds[2], 'need', d);
+        sim.submitLootRoll(rollIds[2], 'pass', b);
+        const pending = (sim as any).pendingLootRolls as Map<
+          number,
+          { choices: Map<number, unknown> }
+        >;
+        rec.notes.refusedChoiceCount = pending.get(rollIds[2])?.choices.size ?? -1;
+      }
       rec.snapshot('curate-phase-vote-refused');
       // Arm 1: one target -> direct grant to b. No rng draw.
       if (rollIds[0] !== undefined) sim.assignMasterLoot(rollIds[0], [b], a);


### PR DESCRIPTION
## Summary

Follow-up to #2561 (issue #2523). A pin-quality audit of the `master_loot` coverage test found
three assertions that either could not fail, or could pass while the behavior they describe was
wrong. In every case the committed golden did catch the regression, but `coverage.test.ts` is meant
to be the independent detector, and it was not. This makes it one.

No scenario behavior changes, so **the golden is untouched**: the added refused vote draws nothing
and records nothing, and `rec.notes` never enters the trace.

### The three real gaps

1. **The distribution pin was satisfiable by a wrong distribution.** `held(b) + held(c) === 3` plus
   `Math.max(held(b), held(c)) === 2` reads identically when both direct grants land on `c` and `b`
   wins the contest. Now pinned per player (`held(b) === 1`, `held(c) === 2`), and the tie-break
   winner is pinned by name and winning roll.
2. **The two grants were pinned only in aggregate.** A bare count of 8 assign lines survives a
   redistribution of the two grants. Now pinned per grantee name, so a wrong *announcement* and a
   wrong *grant* fail different assertions (verified with a mutation pair below).
3. **The refusal was pinned only through the rng stream, which cannot see it.** A guard that admits
   a curate-phase vote without drawing leaves draws, digests and every sampled field identical,
   because `convertMasterRollToNeedGreed` wipes `choices` moments later and `pendingLootRolls` is
   never sampled. The scenario now also submits a `'pass'` (which never draws at any callsite) and
   records the refused roll's choice count through `rec.notes`; the frame-state equality assertion
   that replaced nothing is deleted.

Also: the tie is pinned to its literal rolls (`[97, 97, 43]`) so a future stream change fails with
the numbers visible; draw counts are asserted absolutely (`trace.draws === 4`) and not only as
deltas, which is what actually pins the scenario comment's "near-pure instrument" claim; all three
prompts' candidate rosters are checked instead of the first; the scenario comment's "every arm the
master-loot slice owns" is narrowed to the arms actually driven, with the six undriven zero-draw
arms named; and `pendingLootRolls` joins the harness's documented list of unsampled transient
collections in `tests/parity/CLAUDE.md`, with the reason it is the sharpest case.

## Related issues

Follow-up to #2561 / #2523. No new issue filed.

## Type of change

- [x] Tests

## How was this tested?

- Commands: `npx vitest run tests/parity` (green, golden unchanged), `npx tsc --noEmit` (clean),
  `npm run gate` (PASS 11/11).
- Manual steps: each new assertion was mutation-proven in an isolated worktree, and each mutation
  reverted:
  1. **Tie-break picks the other tied winner** (same draw count): before this PR the coverage test
     was GREEN and only the golden went red. Now `held(b)` fails.
  2. **Guard admits a curate-phase vote but draws nothing**: the golden stays GREEN (draws 4,
     `drawDigest` byte-identical, all state digests identical). Only the new
     `rec.notes.refusedChoiceCount` assertion catches it. This is the gap the rng log structurally
     cannot see.
  3. **Announcement names the wrong player, grant correct**: caught by `assignedTo('Bbb')`.
  4. **Grant lands on the wrong player, announcement correct**: caught by `held(b)`. Together with 3,
     label and identity fail separately rather than coinciding.

One correction to the audit that prompted this: its suggested fix for gap 1 was
`expect(held(b)).toBe(1); expect(held(c)).toBe(2)` alone, which does **not** discriminate the
both-grants-to-c case it was meant to kill (that mutation produces exactly `b=1, c=2`). Pinning the
grantee names and the tie-break winner is what actually separates them, and that is what landed.

## Screenshots / recordings

N/A, no player-visible or operator-visible surface changes.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green, and every new assertion is mutation-proven.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. The asserted English (`assigned`, `Need Roll -`,
      `wins`) are existing pinned localization anchors in `src/ui/hud.ts` / `src/ui/sim_i18n.ts`.

### Hygiene

- [x] No secrets or `.env` committed; no generated file hand-edited (the golden is unchanged).
