### PR TITLE
refactor(ui): extract the rebuild-refocus idiom into a shared focus_restore module

### DIFF
--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -51,6 +51,14 @@ mobile portrait *and* landscape before calling UI work done.
     `Hud` drives through `windowFocus(rootSel)`. The trap intercepts Tab ONLY when focus is
     already inside (Tab is the game's target-nearest key; an unconditional trap would hijack
     it). Esc stays with the single `closeAll` dispatcher, not the manager.
+  - **Focus across a REBUILD is the other half, and a different module:** a painter that wipes
+    its own subtree carries the focused control's identity across with `captureFocusKey` /
+    `restoreFirstEnabled` (`src/ui/focus_restore.ts`), never a hand-rolled `activeElement`
+    read. The helper owns the narrowing, the containment check (the `data-focus-key` namespace
+    is shared across windows, so an unguarded read steals focus from another one) and the
+    disabled skip; the caller owns only its own degradation ladder. A guard in
+    `tests/focus_restore.test.ts` refuses any `src/ui` module that touches the attribute
+    without importing it.
   - **Visible focus that never animates away:** every outline-based `:focus-visible` ring is
     steady and drawn from a token / system color, never a raw hex, never transitioned off.
   - **Skip links** ("Skip to Main HUD" / "Skip to Chat") are the first focusable elements;

--- a/src/ui/focus_restore.ts
+++ b/src/ui/focus_restore.ts
@@ -90,6 +90,20 @@ export function captureFocusKey(root: HTMLElement): string | null {
  * "that control does not exist in the rebuilt tree" are live at the call sites:
  * `querySelector` returns null, a `Map.get` miss and an unset optional field return
  * undefined.
+ *
+ * A bare `focus()`, deliberately NOT `focus({ preventScroll: true })`, and this is now
+ * the ONE place that decision is spelled: every hand-rolled copy already agreed on the
+ * bare call, but only town_focus_window recorded why. The reason is that a caller
+ * restores its scroll offset before calling here, and `focus()` scrolling its target
+ * into view is what lets a DEGRADED target (a rung further down the ladder, which the
+ * player may not be looking at) win over that offset. Focus must be visible (WCAG
+ * 2.4.11), and the common case cannot conflict: the control being refocused is the one
+ * the player was already on, so it is in view and `focus()` scrolls nothing.
+ *
+ * SYNCHRONOUS on purpose, unlike FocusManager.restore, which defers a tick to win
+ * against a browser's own post-close focus move. There is no competing move here: the
+ * caller has just finished rebuilding its own subtree, and deferring would let a Tab
+ * press in between land on <body>.
  */
 export function restoreFirstEnabled(
   candidates: ReadonlyArray<FocusRestoreCandidate | null | undefined>,

--- a/src/ui/focus_restore.ts
+++ b/src/ui/focus_restore.ts
@@ -1,0 +1,102 @@
+// The two mechanical halves of carrying keyboard focus across a full window rebuild.
+//
+// A painter that wipes its own subtree (`innerHTML = ''`, then a fresh createElement
+// pass) destroys every control the player could be standing on. A keyboard player who
+// pressed `+` has the button removed from under them and lands on <body>, unable to
+// press it again. About a dozen src/ui painters answer that by hand and every copy does
+// the same two things: before the wipe, remember WHICH control had focus; after it,
+// focus the rebuilt equivalent, skipping any that came back disabled (#2528).
+//
+// What stays with the CALLER is the interesting half: which fresh control is the
+// role-equivalent of the one that had focus, and what to degrade to when that one came
+// back disabled. Those ladders are genuinely per-window (mailbox_window prefers the
+// quantity input, town_focus_window walks the stepper pair outward before it leaves the
+// row) and folding them in here would mean a switch over window identities. So this
+// module owns only the parts every copy spells the same way, and the parts a copy can
+// get subtly wrong: the activeElement narrowing, the containment check, and the
+// disabled skip.
+//
+// DOM-touching by design (`document.activeElement` and the `instanceof` narrowing), so
+// this is NOT a registered pure core and NOT a UI_PAINTER_HELPERS entry either (that
+// contract bars `instanceof HTMLElement` outright). It is registered in UI_DOM_MODULES
+// in tests/architecture.test.ts, following the src/ui/dialog_root.ts precedent for a
+// small DOM-touching micro-pattern lifted out of a dozen painters. Taking the document
+// (or the already-read activeElement) as a parameter would keep it out of every list,
+// and is deliberately not done: that hands the one line each copy got wrong back to the
+// copies.
+//
+// Deliberately NOT FocusManager's focusability model. That manager's `canFocus` predicate
+// is `isConnected && getClientRects().length > 0`, which is both a forced-reflow layout
+// read (invisible to the per-file painter gate from in here) and a different question
+// from the one the callers ask: they know their candidate is attached, and what they need
+// to know is whether the rebuild disabled it. `disabled` it is, exactly as every copy
+// spelled it.
+
+/**
+ * Anything a caller can hand back focus to. Structural rather than
+ * `HTMLButtonElement`, because the two windows this was extracted from already need
+ * more than one element type: town_focus_window's ladder is all buttons, but
+ * mailbox_window's runs through the parcel's `<input type=number>` quantity field,
+ * which is the candidate it most wants to keep. `disabled` is optional so a focusable
+ * non-form node (a `tabIndex = 0` chip) is a legal candidate too, and reads as
+ * never-disabled.
+ */
+export interface FocusRestoreCandidate {
+  readonly disabled?: boolean;
+  focus(): void;
+}
+
+/**
+ * Remember the identity of the focused control inside `root`, to be handed to the
+ * caller's own resolve-and-degrade ladder after the wipe. Returns null when there is
+ * nothing to carry, which is the common case: focus is on the world, in another window,
+ * or on a control inside `root` that carries no key.
+ *
+ * `root` is the container that is ABOUT TO BE REBUILT, not necessarily the window root:
+ * mailbox_window rebuilds only its `#mail-parcels` list and passes that, so focus
+ * elsewhere in the mailbox is correctly left alone.
+ *
+ * The identity is read off `dataset.focusKey` (`data-focus-key="..."` in markup), ONE
+ * flat namespace shared by every window, which is exactly why the containment check
+ * lives HERE and not in the caller: mailbox_window keys its parcel steppers
+ * `<itemId>:<role>` and town_focus_window keys its allocation steppers
+ * `<component>:<role>`, the same shape under the same attribute name. A window that read
+ * the key without checking containment would let its own repaint pull focus out of
+ * another open window.
+ *
+ * `instanceof HTMLElement` rather than a cast: `document.activeElement` is typed
+ * `Element | null`, and the `dataset` read is only sound on an HTMLElement (an
+ * `Element` has no `dataset` at all). focus_manager.ts narrows the same way.
+ */
+export function captureFocusKey(root: HTMLElement): string | null {
+  const active = document.activeElement;
+  if (!(active instanceof HTMLElement)) return null;
+  if (!root.contains(active)) return null;
+  return active.dataset.focusKey ?? null;
+}
+
+/**
+ * Focus the first candidate that is present and not disabled, in the caller's order,
+ * and stop there. Focuses nothing when every candidate is absent or disabled.
+ *
+ * The disabled skip is the load-bearing part, and the reason a bare
+ * `candidates[0]?.focus()` will not do: the control the player just activated can
+ * legitimately come back DISABLED by the rebuild it caused (stepping the last point off
+ * a component disables its `-`, spending the last one disables every `+`), and a
+ * disabled control cannot take focus, so a caller that ignored this would silently drop
+ * focus to <body> in exactly the case the whole idiom exists for.
+ *
+ * `null` AND `undefined` are both accepted and skipped, because both spellings of
+ * "that control does not exist in the rebuilt tree" are live at the call sites:
+ * `querySelector` returns null, a `Map.get` miss and an unset optional field return
+ * undefined.
+ */
+export function restoreFirstEnabled(
+  candidates: ReadonlyArray<FocusRestoreCandidate | null | undefined>,
+): void {
+  for (const candidate of candidates) {
+    if (candidate === null || candidate === undefined || candidate.disabled) continue;
+    candidate.focus();
+    return;
+  }
+}

--- a/src/ui/focus_restore.ts
+++ b/src/ui/focus_restore.ts
@@ -3,9 +3,20 @@
 // A painter that wipes its own subtree (`innerHTML = ''`, then a fresh createElement
 // pass) destroys every control the player could be standing on. A keyboard player who
 // pressed `+` has the button removed from under them and lands on <body>, unable to
-// press it again. About a dozen src/ui painters answer that by hand and every copy does
-// the same two things: before the wipe, remember WHICH control had focus; after it,
-// focus the rebuilt equivalent, skipping any that came back disabled (#2528).
+// press it again. About a dozen src/ui painters answer that by hand, and each does the
+// same two things in outline: before the wipe, remember WHICH control had focus; after
+// it, focus the rebuilt equivalent, skipping any that came back disabled (#2528).
+//
+// "In outline" is the honest phrasing, because only the two callers of this module key
+// their controls off `data-focus-key`. The others carry a different identity entirely:
+// deeds_window a priority-ordered selector over four attributes, spellbook_window a
+// four-branch chain (two class-plus-dataset pairs, then two bare attribute markers),
+// claudium_window a discriminated union, professions_window a bare boolean, bank_window a
+// boolean plus a caret pair for its search box. Two more resolve the identity from a click
+// handler's argument and never read activeElement at all (options_window, char_window).
+// Migrating one of those means changing its rendered markup or its capture shape, not
+// swapping a call, which is why #2528 scoped this to the pair that already shares the
+// attribute.
 //
 // What stays with the CALLER is the interesting half: which fresh control is the
 // role-equivalent of the one that had focus, and what to degrade to when that one came
@@ -18,12 +29,15 @@
 //
 // DOM-touching by design (`document.activeElement` and the `instanceof` narrowing), so
 // this is NOT a registered pure core and NOT a UI_PAINTER_HELPERS entry either (that
-// contract bars `instanceof HTMLElement` outright). It is registered in UI_DOM_MODULES
-// in tests/architecture.test.ts, following the src/ui/dialog_root.ts precedent for a
-// small DOM-touching micro-pattern lifted out of a dozen painters. Taking the document
-// (or the already-read activeElement) as a parameter would keep it out of every list,
-// and is deliberately not done: that hands the one line each copy got wrong back to the
-// copies.
+// contract bars `instanceof HTMLElement` outright). It is registered in UI_DOM_MODULES in
+// tests/architecture.test.ts, the way ./focus_manager.ts is and for the same stated
+// reason. Note that registration is unavoidable rather than a choice of style: even a
+// version taking the document (or the already-read activeElement) as a PARAMETER still
+// trips UI_DOM_CONSTRUCTOR_RE on the `instanceof HTMLElement` alone, so parameterizing
+// would buy no exemption and would hand the one line each copy got wrong back to the
+// copies. (./dialog_root.ts, the other micro-pattern lifted out of a dozen painters,
+// really is unregistered, but only because it takes its element as a parameter AND does
+// no narrowing.)
 //
 // Deliberately NOT FocusManager's focusability model. That manager's `canFocus` predicate
 // is `isConnected && getClientRects().length > 0`, which is both a forced-reflow layout
@@ -38,8 +52,24 @@
  * more than one element type: town_focus_window's ladder is all buttons, but
  * mailbox_window's runs through the parcel's `<input type=number>` quantity field,
  * which is the candidate it most wants to keep. `disabled` is optional so a focusable
- * non-form node (a `tabIndex = 0` chip) is a legal candidate too, and reads as
- * never-disabled.
+ * non-form node (a `tabIndex = 0` span, which several windows paint) is a legal
+ * candidate too, and reads as never-disabled.
+ *
+ * TWO BOUNDARIES ON THE PREDICATE, both the caller's to respect:
+ * - It is the IDL `disabled` property ONLY. `aria-disabled="true"` is a live idiom in
+ *   this tree (bags_window paints deliberately focusable no-op buttons that way), and
+ *   such a node reads as ENABLED here. A caller with aria-disabled rungs has to filter
+ *   them out before it calls.
+ * - Nothing checks whether a candidate is visible or attached. Both callers rebuild and
+ *   then pass nodes from that fresh subtree, so the question does not arise; a caller
+ *   that could pass a detached or hidden node would have `focus()` no-op on it and the
+ *   walk would stop there. (This is deliberately NOT FocusManager's `canFocus`: see the
+ *   header.)
+ *
+ * `focus(): void` and not `focus(options?: FocusOptions): void` on purpose. The seam's
+ * policy is the bare call (stated on restoreFirstEnabled below), and the narrow signature
+ * is what keeps a future caller from quietly reintroducing the per-window divergence
+ * #2528 exists to end.
  */
 export interface FocusRestoreCandidate {
   readonly disabled?: boolean;
@@ -67,6 +97,12 @@ export interface FocusRestoreCandidate {
  * `instanceof HTMLElement` rather than a cast: `document.activeElement` is typed
  * `Element | null`, and the `dataset` read is only sound on an HTMLElement (an
  * `Element` has no `dataset` at all). focus_manager.ts narrows the same way.
+ *
+ * The one value this does NOT normalize: `data-focus-key=""` returns the empty string,
+ * not null, because that is what the attribute says. No caller writes an empty key today,
+ * but the two guard the result differently (`if (focusKey)` versus
+ * `if (focusKey !== null)`), so a caller that could mint one must decide which it means
+ * rather than inherit whichever its guard happens to be.
  */
 export function captureFocusKey(root: HTMLElement): string | null {
   const active = document.activeElement;

--- a/src/ui/mailbox_window.ts
+++ b/src/ui/mailbox_window.ts
@@ -777,6 +777,19 @@ export class MailboxWindow {
       // Note that the qty input and Remove are never disabled in this painter,
       // so the skip changes nothing for them: they are the two rungs the old
       // hand-rolled chain took without a disabled check.
+      // `minus` and `plus` are DEFENSIVE rungs, not reachable fallbacks, and
+      // were equally unreachable in the chain this replaced: all three stepper
+      // controls are minted together under `owned > 1` above and qty is never
+      // disabled, so qty always intercepts before them. They earn their place
+      // the day qty can be disabled, and they cost nothing meanwhile. The
+      // reachable rungs are the preferred control, qty, and Remove (the last
+      // only when the stepper vanishes because owned dropped under two).
+      // KNOWN GAP, pre-existing and not this ladder's to fix: pressing Remove
+      // itself lands on <body>, because the parcel is gone from `attachments`
+      // so every rung for that item resolves undefined (and with one parcel
+      // staged, the empty-list return above skips the restore entirely).
+      // Degrading to a surviving parcel, or to the parcels container, needs a
+      // cross-item fallback this per-item ladder does not have.
       restoreFirstEnabled([
         preferred,
         controls?.qty,

--- a/src/ui/mailbox_window.ts
+++ b/src/ui/mailbox_window.ts
@@ -18,6 +18,7 @@ import type { IWorld } from '../world_api';
 import { markDialogRoot } from './dialog_root';
 import { itemDisplayName, tEntity } from './entity_i18n';
 import { esc } from './esc';
+import { captureFocusKey, restoreFirstEnabled } from './focus_restore';
 import { formatMoney, formatNumber, t } from './i18n';
 import { QUALITY_COLOR } from './icons';
 import {
@@ -625,10 +626,11 @@ export class MailboxWindow {
     if (!parcels) return;
     // A +/- click rebuilds this whole container, which would otherwise drop
     // keyboard focus to <body>; remember which control (by item + role) had
-    // it so the rebuilt equivalent can reclaim it below.
-    const focusedEl = document.activeElement as HTMLElement | null;
-    const focusKey =
-      focusedEl && parcels.contains(focusedEl) ? (focusedEl.dataset.focusKey ?? null) : null;
+    // it so the rebuilt equivalent can reclaim it below. The shared helper
+    // (#2528) narrows activeElement and does the containment check; the
+    // container passed is the PARCEL LIST, not the window root, so focus
+    // sitting anywhere else in the mailbox is correctly left alone.
+    const focusKey = captureFocusKey(parcels);
     parcels.innerHTML = '';
     if (this.attachments.length === 0) {
       const hint = document.createElement('span');
@@ -769,14 +771,19 @@ export class MailboxWindow {
         : undefined;
       // The just-activated control (or its whole item) can vanish on rebuild
       // (disabled at a bound, or the stepper dropped once owned <= 1): fall
-      // back to the nearest still-focusable control for the same item.
-      let target: HTMLButtonElement | HTMLInputElement | undefined;
-      if (preferred && !preferred.disabled) target = preferred;
-      else if (controls?.qty) target = controls.qty;
-      else if (controls?.minus && !controls.minus.disabled) target = controls.minus;
-      else if (controls?.plus && !controls.plus.disabled) target = controls.plus;
-      else target = controls?.remove;
-      target?.focus();
+      // back to the nearest still-focusable control for the same item. This
+      // ladder is the panel's own; the shared helper (#2528) owns only the
+      // walk, skipping any candidate that is absent or came back disabled.
+      // Note that the qty input and Remove are never disabled in this painter,
+      // so the skip changes nothing for them: they are the two rungs the old
+      // hand-rolled chain took without a disabled check.
+      restoreFirstEnabled([
+        preferred,
+        controls?.qty,
+        controls?.minus,
+        controls?.plus,
+        controls?.remove,
+      ]);
     }
   }
 }

--- a/src/ui/town_focus_window.ts
+++ b/src/ui/town_focus_window.ts
@@ -157,15 +157,15 @@ export function renderTownFocusWindow(
   close?.addEventListener('click', () => deps.onClose());
   el.style.display = 'block';
   el.scrollTop = scrollTop;
-  // Scroll FIRST, then focus, and deliberately WITHOUT { preventScroll: true }.
-  // `focus()` scrolls its target into view, so this order lets a degraded
+  // Scroll FIRST, then focus. `focus()` scrolls its target into view (the
+  // helper calls it bare, and states why there), so this order lets a degraded
   // target (Save or Close, when the control the player was on came back
   // disabled) win over the restored offset. That is the wanted outcome: focus
   // must be visible (WCAG 2.4.11), and the common case cannot conflict, since
   // the control being refocused is the one the player was already looking at,
-  // so it is in view and `focus()` scrolls nothing. Reversing the two, or
-  // passing preventScroll, would trade a visible focus ring for an offset the
-  // player can no longer see the focus in.
+  // so it is in view and `focus()` scrolls nothing. Reversing the two would
+  // trade a visible focus ring for an offset the player can no longer see the
+  // focus in.
   if (focusKey !== null) restoreFocus(focusKey, steppers, save, close);
 }
 

--- a/src/ui/town_focus_window.ts
+++ b/src/ui/town_focus_window.ts
@@ -7,6 +7,7 @@
 import { MAX_FOCUS_TIER_BONUS, POINTS_PER_TIER_BONUS } from '../sim/professions/focus';
 import { markDialogRoot } from './dialog_root';
 import { esc } from './esc';
+import { captureFocusKey, restoreFirstEnabled } from './focus_restore';
 import { formatNumber, t } from './i18n';
 import type { TownFocusView } from './town_focus_view';
 import { svgIcon } from './ui_icons';
@@ -36,17 +37,13 @@ export function renderTownFocusWindow(
   // is the other half (#2500). A step click rebuilds the whole panel, which
   // would otherwise drop keyboard focus to <body> and leave a keyboard player
   // unable to press + a second time. Remember which control had it (by
-  // component + role) so the rebuilt equivalent can reclaim it below, the
-  // mailbox_window parcel-stepper idiom.
-  // `instanceof` rather than a cast: activeElement is typed Element, and the
-  // dataset read below is only sound on an HTMLElement (focus_manager.ts
-  // narrows the same way). The containment check is load-bearing, not
-  // defensive: mailbox_window keys its parcel steppers with the SAME
-  // data-focus-key attribute in the same shape, so an unguarded read would let
-  // a slow-band repaint here pull focus out of another open window.
-  const active = document.activeElement;
-  const focusKey =
-    active instanceof HTMLElement && el.contains(active) ? (active.dataset.focusKey ?? null) : null;
+  // component + role) so the rebuilt equivalent can reclaim it below.
+  // The shared helper (#2528) owns the narrowing and, importantly, the
+  // containment check, which is load-bearing rather than defensive here:
+  // mailbox_window keys its parcel steppers with the SAME data-focus-key
+  // attribute in the same shape, so an unguarded read would let a slow-band
+  // repaint here pull focus out of another open window.
+  const focusKey = captureFocusKey(el);
   // Dialog semantics for the trapped root (#2525). Hud installs the Tab trap and
   // the return-to-opener through windowFocus('#town-focus-window'); a trapped
   // window also has to ANNOUNCE itself, or a screen-reader user is cycling inside
@@ -173,15 +170,16 @@ export function renderTownFocusWindow(
 }
 
 /**
- * Hand focus back to the rebuilt equivalent of the control that had it.
+ * Resolve the rebuilt equivalent of the control that had focus and hand it back.
  *
- * The control the player just activated can legitimately come back DISABLED
- * (stepping the last point off a component disables its `-`, spending the last
- * budget point disables every `+`, and leaving town disables all of them), and
- * a disabled button cannot take focus. So this degrades along the row the
- * player is working in before it leaves it: the same stepper, then the row's
- * other stepper, then Save, then Close. Landing on Close is still keyboard
- * operation; landing on <body> is not.
+ * This is the half the shared helper deliberately does NOT own: the ladder is
+ * this panel's own. The control the player just activated can legitimately come
+ * back DISABLED (stepping the last point off a component disables its `-`,
+ * spending the last budget point disables every `+`, and leaving town disables
+ * all of them), and a disabled button cannot take focus. So the order below
+ * degrades along the row the player is working in before it leaves it: the same
+ * stepper, then the row's other stepper, then Save, then Close. Landing on
+ * Close is still keyboard operation; landing on <body> is not.
  */
 function restoreFocus(
   focusKey: string,
@@ -200,9 +198,5 @@ function restoreFocus(
   // player onto Save; every other key walks the row outward.
   const candidates: ReadonlyArray<HTMLButtonElement | null> =
     focusKey === CLOSE_FOCUS_KEY ? [close, save] : [preferred, other, save, close];
-  for (const candidate of candidates) {
-    if (candidate === null || candidate.disabled) continue;
-    candidate.focus();
-    return;
-  }
+  restoreFirstEnabled(candidates);
 }

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -1040,6 +1040,7 @@ const UI_DOM_MODULES = [
   'src/ui/discord_widget.ts',
   'src/ui/entry_guard_banner.ts',
   'src/ui/focus_manager.ts',
+  'src/ui/focus_restore.ts',
   'src/ui/gather_node_tooltip.ts',
   'src/ui/gpu_notice_toast.ts',
   'src/ui/hud.ts',

--- a/tests/focus_restore.test.ts
+++ b/tests/focus_restore.test.ts
@@ -20,8 +20,11 @@
 // captureFocusKey's whole job is `document.activeElement` plus a real
 // `instanceof HTMLElement`, and a fake document cannot pin either.
 
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { captureFocusKey, restoreFirstEnabled } from '../src/ui/focus_restore';
+import { tsFilesUnder } from './helpers/ts_files_under';
 
 afterEach(() => {
   document.body.innerHTML = '';
@@ -56,13 +59,25 @@ function restoreActiveElement(): void {
   delete (document as unknown as Record<string, unknown>).activeElement;
 }
 
-/** A candidate that records its focus() calls, for the order and stop-at-first pins. */
-function fakeCandidate(disabled?: boolean): { disabled?: boolean; focus(): void; calls: number } {
+/**
+ * A candidate that records every focus() call AND its arguments, for the order,
+ * stop-at-first and bare-call pins. The arguments matter: a real element's focus()
+ * accepts FocusOptions, so a count alone cannot tell a bare `focus()` from a
+ * `focus({ preventScroll: true })`, which is the decision the module claims to settle.
+ */
+function fakeCandidate(disabled?: boolean): {
+  disabled?: boolean;
+  focus(...args: unknown[]): void;
+  calls: number;
+  args: unknown[][];
+} {
   return {
     disabled,
     calls: 0,
-    focus() {
+    args: [],
+    focus(...args: unknown[]) {
       this.calls++;
+      this.args.push(args);
     },
   };
 }
@@ -98,6 +113,24 @@ describe('captureFocusKey', () => {
     document.body.appendChild(root);
     btn.focus();
     expect(document.activeElement).toBe(btn);
+    expect(captureFocusKey(root)).toBeNull();
+  });
+
+  it("reads the focused node's OWN key, never an ancestor's", () => {
+    // No `closest()` walk, which is right for both callers (the key sits on the focusable
+    // control itself) and needs its own case: the key-free case above uses a key-free
+    // root, so it would still pass if someone added an ancestor walk. A keyed WRAPPER
+    // around a key-free focused button is the shape that tells the two apart.
+    const root = document.createElement('div');
+    const wrapper = document.createElement('div');
+    wrapper.dataset.focusKey = 'wolf_fang:minus';
+    const btn = document.createElement('button');
+    wrapper.appendChild(btn);
+    root.appendChild(wrapper);
+    document.body.appendChild(root);
+    btn.focus();
+    expect(document.activeElement).toBe(btn);
+    expect(wrapper.dataset.focusKey).toBe('wolf_fang:minus');
     expect(captureFocusKey(root)).toBeNull();
   });
 
@@ -169,8 +202,11 @@ describe('restoreFirstEnabled', () => {
   });
 
   it('treats a candidate with no `disabled` property at all as enabled', () => {
-    // A focusable non-form node (mailbox's tabIndex = 0 item-name chip) reads
-    // `disabled === undefined`, which must not be mistaken for disabled.
+    // A focusable non-form node reads `disabled === undefined`, which must not be
+    // mistaken for disabled. A forward contract rather than a shipped rung: neither
+    // migrated caller passes one today (mailbox paints a `tabIndex = 0` item-name chip,
+    // but it is never entered into the controls map and so is never a candidate), and the
+    // optional property is what lets a caller pass one at all.
     const root = document.createElement('div');
     const chip = document.createElement('span');
     chip.tabIndex = 0;
@@ -182,14 +218,24 @@ describe('restoreFirstEnabled', () => {
   });
 
   it('focuses NOBODY when every candidate is absent or disabled', () => {
+    // The real disabled button is the WEAK half here: jsdom refuses to focus a disabled
+    // control on its own, so that arm would hold even with the skip deleted. The fake
+    // candidate is what gives this case teeth on the disabled dimension, by proving
+    // focus() was never CALLED rather than merely that it had no effect.
     const disabled = windowWithKeyedButton('inc').btn;
     disabled.disabled = true;
-    restoreFirstEnabled([null, disabled, undefined]);
+    const fake = fakeCandidate(true);
+    restoreFirstEnabled([null, disabled, undefined, fake]);
+    expect(fake.calls).toBe(0);
     expect(document.activeElement).toBe(document.body);
   });
 
-  it('focuses nothing at all on an empty candidate list', () => {
-    restoreFirstEnabled([]);
+  it('accepts an empty candidate list without throwing', () => {
+    // Titled for what it can actually catch. `document.activeElement === document.body`
+    // is already true before the call, so this case cannot see the walk or the skip; a
+    // caller whose ladder resolved to nothing (every rung absent) reaching here must not
+    // be an error, and that is the whole claim.
+    expect(() => restoreFirstEnabled([])).not.toThrow();
     expect(document.activeElement).toBe(document.body);
   });
 
@@ -208,5 +254,154 @@ describe('restoreFirstEnabled', () => {
     const rungs = [fakeCandidate(true), fakeCandidate(true), fakeCandidate(), fakeCandidate()];
     restoreFirstEnabled(rungs);
     expect(rungs.map((r) => r.calls)).toEqual([0, 0, 1, 0]);
+  });
+
+  it('calls focus() BARE, never with FocusOptions', () => {
+    // See also the module-contract scans below, which pin the same policy from the source
+    // side. This one is the behavioral half.
+    // The seam's scroll policy, which the module states as a contract: a caller restores
+    // its scroll offset and then relies on focus() scrolling a degraded target into view,
+    // so passing { preventScroll: true } here would silently break focus visibility for
+    // every caller at once. A call COUNT cannot see it, hence the recorded arguments.
+    const only = fakeCandidate();
+    restoreFirstEnabled([only]);
+    expect(only.args).toEqual([[]]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Module contract, from the source side.
+//
+// Two of this module's promises cannot be reached behaviorally, and both would fail
+// SILENTLY, which is what earns them a scan:
+//
+//  1. NO FORCED-REFLOW READ. focus_restore.ts is a shared helper on the rebuild path of
+//     two cold painters, and tests/hud_perf_budget.test.ts scans for layout reads PER
+//     FILE, with exact-count grants per painter. A getClientRects() added HERE (the
+//     tempting one: it is FocusManager.canFocus's own visibility predicate) is charged to
+//     nobody, and both painters' grants stay green. The gate's own comment says as much:
+//     "a read moved into a NEW un-named helper is still out of reach."
+//  2. NO DEFERRAL. The focus is synchronous, unlike FocusManager.restore's setTimeout(0),
+//     and town_focus_window's documented scroll-then-focus ordering depends on it.
+// ---------------------------------------------------------------------------
+
+const repoRoot = path.resolve(__dirname, '..');
+const moduleSrc = readFileSync(path.join(repoRoot, 'src/ui/focus_restore.ts'), 'utf8');
+
+/** Comment-stripped, so the header's own prose about these tokens cannot satisfy a scan. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+const moduleCode = stripComments(moduleSrc);
+
+/**
+ * The forced-reflow token names read OUT of the painter gate rather than copied, so the
+ * two lists cannot drift: a token added there is covered here the same day.
+ */
+function forcedReflowTokens(): string[] {
+  const gate = readFileSync(path.join(repoRoot, 'tests/hud_perf_budget.test.ts'), 'utf8');
+  const start = gate.indexOf('const FORCED_REFLOW_READS');
+  expect(start, 'FORCED_REFLOW_READS is no longer declared in the painter gate').toBeGreaterThan(
+    -1,
+  );
+  const end = gate.indexOf('\n];', start);
+  expect(
+    end,
+    'the FORCED_REFLOW_READS array is unterminated, so the slice is unbounded',
+  ).toBeGreaterThan(start);
+  return [...gate.slice(start, end).matchAll(/\[\s*'([^']+)'\s*,/g)].map((m) => m[1]);
+}
+
+describe('focus_restore module contract (source scans)', () => {
+  it('reads the painter gate real token list (anti-vacuity)', () => {
+    const tokens = forcedReflowTokens();
+    // Without this the scan below could pass over an empty list forever. Named literals,
+    // not a count: these two are the exact tokens the migrated painters hold grants for,
+    // plus the one this module is most likely to reach for.
+    expect(tokens.length).toBeGreaterThan(10);
+    expect(tokens).toContain('.scrollTop');
+    expect(tokens).toContain('.getBoundingClientRect');
+    expect(tokens).toContain('.getClientRects');
+  });
+
+  it('makes no forced-reflow layout read', () => {
+    const found = forcedReflowTokens().filter((token) =>
+      moduleCode.includes(token.startsWith('.') ? token : `${token}(`),
+    );
+    expect(
+      found,
+      `focus_restore.ts must make no forced-reflow read: the painter gate scans PER FILE, so a read here is charged to no painter and both migrated painters' exact-count grants stay green:\n${found.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('and that refusal really would catch one', () => {
+    // The arm that would be dead if the matcher were wrong, driven over synthetic source.
+    const planted = stripComments('function f(el) {\n  return el.getClientRects().length > 0;\n}');
+    expect(forcedReflowTokens().filter((t) => planted.includes(t))).toEqual(['.getClientRects']);
+  });
+
+  it('focuses synchronously, with no deferral of its own', () => {
+    for (const token of [
+      'setTimeout',
+      'setInterval',
+      'queueMicrotask',
+      'requestAnimationFrame',
+      'requestIdleCallback',
+      'Promise',
+      'await',
+    ]) {
+      expect(moduleCode, `focus_restore.ts must not defer: found ${token}`).not.toContain(token);
+    }
+  });
+
+  it('reaches the host ONLY for document.activeElement', () => {
+    // UI_DOM_MODULES is a blanket exemption from the architecture host scan, so nothing
+    // else stops this module from growing a second browser reach. Its whole claim to the
+    // registration is one read, so pin that it stays one read.
+    expect([...moduleCode.matchAll(/\bdocument\b/g)]).toHaveLength(1);
+    expect(moduleCode).toContain('document.activeElement');
+    for (const host of ['window.', 'navigator.', 'localStorage', 'globalThis', 'getComputedStyle'])
+      expect(moduleCode, `unexpected host reach: ${host}`).not.toContain(host);
+  });
+
+  it('never passes FocusOptions to focus()', () => {
+    expect(moduleCode).toContain('candidate.focus();');
+    expect(moduleCode).not.toContain('preventScroll');
+  });
+});
+
+describe('the data-focus-key namespace has exactly one reader', () => {
+  // The durability half of the extraction, and the answer to "what stops copy #11": any
+  // src/ui module that reads the shared focus-key attribute has to come through this
+  // helper, so it cannot hand-roll the containment check that keeps two windows with the
+  // same key from stealing focus from each other.
+  const uiFiles = tsFilesUnder(path.join(repoRoot, 'src/ui')).map((f) => ({
+    ...f,
+    code: stripComments(readFileSync(f.full, 'utf8')),
+  }));
+
+  it('sweeps a real, non-empty slice of src/ui (anti-vacuity)', () => {
+    expect(uiFiles.length).toBeGreaterThan(200);
+    expect(uiFiles.map((f) => f.file)).toContain('focus_restore.ts');
+    expect(uiFiles.map((f) => f.file)).toContain('hud/vendor/vendor_window.ts');
+  });
+
+  it('finds the readers it is supposed to find (anti-vacuity)', () => {
+    const readers = uiFiles.filter((f) => /dataset\.focusKey|data-focus-key/.test(f.code));
+    // Named literals rather than a count, so migrating a third window is not a test edit.
+    expect(readers.map((f) => f.file)).toContain('mailbox_window.ts');
+    expect(readers.map((f) => f.file)).toContain('town_focus_window.ts');
+  });
+
+  it('every module that touches the attribute goes through the helper', () => {
+    const offenders = uiFiles
+      .filter((f) => f.file !== 'focus_restore.ts')
+      .filter((f) => /dataset\.focusKey|data-focus-key/.test(f.code))
+      .filter((f) => !/from '\.{1,2}(?:\/\.\.)*\/?focus_restore'/.test(f.code))
+      .map((f) => f.file);
+    expect(
+      offenders,
+      `these src/ui modules use the shared data-focus-key namespace without importing ./focus_restore, so they hand-roll the containment check that keeps one window's repaint from stealing focus from another (#2528):\n${offenders.join('\n')}`,
+    ).toEqual([]);
   });
 });

--- a/tests/focus_restore.test.ts
+++ b/tests/focus_restore.test.ts
@@ -1,0 +1,212 @@
+// @vitest-environment jsdom
+//
+// The shared rebuild-refocus helper (#2528), extracted from about ten hand-rolled
+// copies in src/ui. Two halves, tested here against the shapes the real callers hand
+// it rather than against invented ones:
+//
+//  - captureFocusKey: the activeElement narrowing, the containment check, and the
+//    dataset read. The containment check is the acceptance criterion of the extraction:
+//    mailbox_window and town_focus_window key their steppers under the SAME
+//    `data-focus-key` attribute in the same `<id>:<role>` shape, so ONE flat namespace
+//    is shared across windows and a copy that forgot the check would let its own
+//    repaint pull focus out of the other window. That is what the cross-window case
+//    below plants.
+//  - restoreFirstEnabled: the walk and the disabled skip. Every rung the two migrated
+//    callers actually pass is represented: a button (both), an `<input type=number>`
+//    (mailbox's quantity field), a `null` hole (town focus's `querySelector` miss) and
+//    an `undefined` one (mailbox's `Map.get` / optional-field miss).
+//
+// jsdom rather than the fake-element harness tests/dialog_root.test.ts uses:
+// captureFocusKey's whole job is `document.activeElement` plus a real
+// `instanceof HTMLElement`, and a fake document cannot pin either.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { captureFocusKey, restoreFirstEnabled } from '../src/ui/focus_restore';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  restoreActiveElement();
+});
+
+/** A window root holding one keyed, focusable button. */
+function windowWithKeyedButton(key: string): { root: HTMLElement; btn: HTMLButtonElement } {
+  const root = document.createElement('div');
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.dataset.focusKey = key;
+  root.appendChild(btn);
+  document.body.appendChild(root);
+  return { root, btn };
+}
+
+// Overriding document.activeElement is the only way to reach the non-HTMLElement
+// branch: jsdom will not put focus on an element that has no focus() of its own, and
+// the point of the branch is precisely an activeElement the DOM handed back that is not
+// an HTMLElement. Restored after every test so no later case inherits the stub.
+let activeElementStubbed = false;
+function stubActiveElement(value: Element | null): void {
+  Object.defineProperty(document, 'activeElement', { get: () => value, configurable: true });
+  activeElementStubbed = true;
+}
+function restoreActiveElement(): void {
+  if (!activeElementStubbed) return;
+  activeElementStubbed = false;
+  // The own property has to be GONE, not undefined, or the native prototype getter
+  // stays shadowed and every later case reads `undefined` as its activeElement.
+  delete (document as unknown as Record<string, unknown>).activeElement;
+}
+
+/** A candidate that records its focus() calls, for the order and stop-at-first pins. */
+function fakeCandidate(disabled?: boolean): { disabled?: boolean; focus(): void; calls: number } {
+  return {
+    disabled,
+    calls: 0,
+    focus() {
+      this.calls++;
+    },
+  };
+}
+
+describe('captureFocusKey', () => {
+  it('carries the key of the focused control inside the root', () => {
+    const { root, btn } = windowWithKeyedButton('mail_wolf_fang:plus');
+    btn.focus();
+    expect(document.activeElement).toBe(btn);
+    expect(captureFocusKey(root)).toBe('mail_wolf_fang:plus');
+  });
+
+  it('refuses a keyed control in ANOTHER window, even with the identical key', () => {
+    // The extraction's acceptance criterion. Two windows, one shared key namespace:
+    // the mailbox parcel stepper and the town focus stepper really are both
+    // `<id>:<role>` under `data-focus-key`. Focus is in window B; window A repaints.
+    // A returns null, so A's ladder never runs and focus stays where the player put
+    // it. Note the key is the SAME string in both, which is what makes this a refusal
+    // by CONTAINMENT and not by key mismatch.
+    const a = windowWithKeyedButton('hide:inc');
+    const b = windowWithKeyedButton('hide:inc');
+    b.btn.focus();
+    expect(captureFocusKey(a.root)).toBeNull();
+    // ...and the window that DOES contain it still gets it, so the refusal above is
+    // not simply "this helper never returns anything in a two-window document".
+    expect(captureFocusKey(b.root)).toBe('hide:inc');
+  });
+
+  it('carries nothing when the focused control inside the root has no key', () => {
+    const root = document.createElement('div');
+    const btn = document.createElement('button');
+    root.appendChild(btn);
+    document.body.appendChild(root);
+    btn.focus();
+    expect(document.activeElement).toBe(btn);
+    expect(captureFocusKey(root)).toBeNull();
+  });
+
+  it('carries nothing when focus is on <body> (nothing in the window was focused)', () => {
+    const { root } = windowWithKeyedButton('save');
+    expect(document.activeElement).toBe(document.body);
+    expect(captureFocusKey(root)).toBeNull();
+  });
+
+  it('carries nothing when activeElement is null, as WebKit can report', () => {
+    const { root } = windowWithKeyedButton('save');
+    stubActiveElement(null);
+    expect(captureFocusKey(root)).toBeNull();
+  });
+
+  it('carries nothing from a non-HTMLElement, even one inside the root carrying a key', () => {
+    // The narrowing, and the one case a plain `as HTMLElement` cast (what most of the
+    // hand-rolled copies did, mailbox_window included) got wrong: an SVGElement is
+    // contained, is not an HTMLElement, and still answers `dataset`. So the cast would
+    // read a key here and the ladder would run off it.
+    const root = document.createElement('div');
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('data-focus-key', 'wolf_fang:remove');
+    root.appendChild(svg);
+    document.body.appendChild(root);
+    // Proof the case is the one described: contained, keyed, and NOT an HTMLElement.
+    expect(root.contains(svg)).toBe(true);
+    expect(svg.getAttribute('data-focus-key')).toBe('wolf_fang:remove');
+    expect(svg instanceof HTMLElement).toBe(false);
+    stubActiveElement(svg);
+    expect(captureFocusKey(root)).toBeNull();
+  });
+});
+
+describe('restoreFirstEnabled', () => {
+  it('focuses the first candidate when it is enabled', () => {
+    const { btn } = windowWithKeyedButton('a');
+    restoreFirstEnabled([btn]);
+    expect(document.activeElement).toBe(btn);
+  });
+
+  it('skips a candidate that came back DISABLED and takes the next one', () => {
+    // The whole reason a bare `candidates[0]?.focus()` will not do: the control the
+    // player just activated is exactly the one the rebuild can disable.
+    const first = windowWithKeyedButton('inc').btn;
+    const second = windowWithKeyedButton('dec').btn;
+    first.disabled = true;
+    restoreFirstEnabled([first, second]);
+    expect(document.activeElement).toBe(second);
+  });
+
+  it('skips null AND undefined holes, both of which the real callers pass', () => {
+    const btn = windowWithKeyedButton('save').btn;
+    restoreFirstEnabled([null, undefined, btn]);
+    expect(document.activeElement).toBe(btn);
+  });
+
+  it('focuses an <input>, the rung mailbox_window most wants to keep', () => {
+    // Not every candidate is a button: mailbox's ladder falls back to the parcel's
+    // typed quantity field, because a number input fires `change` WITHOUT blurring,
+    // so the repaint runs while the input is focused.
+    const root = document.createElement('div');
+    const qty = document.createElement('input');
+    qty.type = 'number';
+    root.appendChild(qty);
+    document.body.appendChild(root);
+    restoreFirstEnabled([qty]);
+    expect(document.activeElement).toBe(qty);
+  });
+
+  it('treats a candidate with no `disabled` property at all as enabled', () => {
+    // A focusable non-form node (mailbox's tabIndex = 0 item-name chip) reads
+    // `disabled === undefined`, which must not be mistaken for disabled.
+    const root = document.createElement('div');
+    const chip = document.createElement('span');
+    chip.tabIndex = 0;
+    root.appendChild(chip);
+    document.body.appendChild(root);
+    expect((chip as unknown as { disabled?: boolean }).disabled).toBeUndefined();
+    restoreFirstEnabled([chip]);
+    expect(document.activeElement).toBe(chip);
+  });
+
+  it('focuses NOBODY when every candidate is absent or disabled', () => {
+    const disabled = windowWithKeyedButton('inc').btn;
+    disabled.disabled = true;
+    restoreFirstEnabled([null, disabled, undefined]);
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it('focuses nothing at all on an empty candidate list', () => {
+    restoreFirstEnabled([]);
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it('stops at the first enabled candidate and never touches a later one', () => {
+    // Order is the caller's degradation ladder, so "first" has to mean first and the
+    // walk has to stop: focusing every candidate would leave the player on the LAST
+    // rung (Close) instead of the one their key resolved to.
+    const first = fakeCandidate();
+    const second = fakeCandidate();
+    restoreFirstEnabled([first, second]);
+    expect(first.calls).toBe(1);
+    expect(second.calls).toBe(0);
+  });
+
+  it('walks the ladder in the given order, skipping only the disabled rungs', () => {
+    const rungs = [fakeCandidate(true), fakeCandidate(true), fakeCandidate(), fakeCandidate()];
+    restoreFirstEnabled(rungs);
+    expect(rungs.map((r) => r.calls)).toEqual([0, 0, 1, 0]);
+  });
+});

--- a/tests/mailbox_window.test.ts
+++ b/tests/mailbox_window.test.ts
@@ -144,10 +144,14 @@ describe('mailbox_window: parcel quantity stepper (#1444, PR #1695 review)', () 
     expect(painter).toMatch(/name\.tabIndex = 0/);
   });
 
-  it('rebuilding the parcel list restores focus to the equivalent control by item + role', () => {
-    expect(painter).toContain('focusKey');
+  it('keys every parcel control by item + role, so a rebuild can refocus the equivalent', () => {
+    // Titled for what it checks: that the KEYS are written, in the shape the ladder
+    // splits on. Where focus actually LANDS is behavioral and lives in
+    // tests/mailbox_window_focus.test.ts; this file only reads source text.
     expect(painter).toMatch(/dataset\.focusKey = `\$\{slot\.itemId\}:minus`/);
     expect(painter).toMatch(/dataset\.focusKey = `\$\{slot\.itemId\}:plus`/);
+    // The qty input was missing from this list, and it is the rung the ladder prefers.
+    expect(painter).toMatch(/dataset\.focusKey = `\$\{slot\.itemId\}:qty`/);
     expect(painter).toMatch(/dataset\.focusKey = `\$\{slot\.itemId\}:remove`/);
   });
 });

--- a/tests/mailbox_window_focus.test.ts
+++ b/tests/mailbox_window_focus.test.ts
@@ -13,7 +13,15 @@
 // harness, and asserts where focus actually lands.
 //
 // The rungs, in the window's order: the same control, then the quantity input, then `-`,
-// then `+`, then Remove. Each case below lands on a different one.
+// then `+`, then Remove. Only three of the five are REACHABLE, and the extraction is what
+// made that visible rather than causing it (the old hand-rolled if/else chain had the same
+// shape). `minus`, `plus` and `qty` are created together inside the one `if (owned > 1)`
+// block in the painter, and `qty` is never disabled, so whenever the preferred control is
+// skipped and a stepper exists at all, `qty` intercepts: `-` and `+` can only ever be
+// reached AS the preferred control, never as a fallback. They stay in the array as the
+// defensive rungs they were before. The cases below cover every rung that can actually
+// win: the preferred one, `qty`, and Remove (only when the stepper vanishes between
+// renders, which needs the owned count to drop under two).
 
 import { afterEach, describe, expect, it } from 'vitest';
 import type { InvSlot } from '../src/sim/types';
@@ -32,10 +40,20 @@ function fakeWorld(inventory: InvSlot[]): IWorld {
   } as unknown as IWorld;
 }
 
-/** A real MailboxWindow on the Send tab with `itemId` staged as a parcel. */
-function stagedParcel(itemId: string, owned: number): HTMLElement {
+/**
+ * A real MailboxWindow on the Send tab with `itemId` staged as a parcel.
+ *
+ * The returned `inventory` is the LIVE array the fake world reads, so a case can shrink
+ * the owned count between renders. That is the only way to reach the Remove rung: the
+ * painter drops the whole stepper once `owned <= 1`.
+ */
+function stagedParcel(
+  itemId: string,
+  owned: number,
+): { root: HTMLElement; win: MailboxWindow; inventory: InvSlot[] } {
   const root = document.createElement('div');
   document.body.appendChild(root);
+  const inventory: InvSlot[] = [{ itemId, count: owned }];
   const noop = (): void => {};
   const deps: MailboxWindowDeps = {
     itemIcon: () => '<span class="item-icon"></span>',
@@ -43,7 +61,7 @@ function stagedParcel(itemId: string, owned: number): HTMLElement {
     itemTooltip: () => '',
     attachTooltip: noop,
     root: () => root,
-    world: () => fakeWorld([{ itemId, count: owned }]),
+    world: () => fakeWorld(inventory),
     closeOthers: noop,
     hideTooltip: noop,
     captureFocus: () => null,
@@ -55,7 +73,7 @@ function stagedParcel(itemId: string, owned: number): HTMLElement {
   win.open();
   (root.querySelector('[data-tab="send"]') as HTMLElement).click();
   win.stageParcel(itemId);
-  return root;
+  return { root, win, inventory };
 }
 
 const FANG = 'wolf_fang';
@@ -81,7 +99,7 @@ describe('the mailbox parcel list carries keyboard focus across its own rebuild'
   it('hands focus back to the rebuilt equivalent of the stepper that was pressed', () => {
     // Owned 4, staged at 4, so pressing `-` goes 4 -> 3 and `-` is still enabled on the
     // way back: the plain case, and the one that reds if the capture is dropped.
-    const root = stagedParcel(FANG, 4);
+    const { root } = stagedParcel(FANG, 4);
     const minus = control<HTMLButtonElement>(root, 'minus');
     minus.focus();
     minus.click();
@@ -92,13 +110,34 @@ describe('the mailbox parcel list carries keyboard focus across its own rebuild'
     expect(document.activeElement).not.toBe(document.body);
   });
 
+  it('hands focus back to `+` too, not just `-`', () => {
+    // The `plus` arm of the preferred-control resolution had no test anywhere: the only
+    // `+` clicks in the suite were at a ceiling where the button is disabled and so
+    // dispatches nothing. Mis-resolving this arm to Remove is silent AND destructive,
+    // since the player's next Enter would delete the parcel, which is exactly what the
+    // painter's own comment warns about. Step down to 2 of 4 first so `+` is live, and so
+    // the rebuilt `+` comes back enabled (3 < 4) rather than degrading.
+    const { root } = stagedParcel(FANG, 4);
+    control<HTMLButtonElement>(root, 'minus').click();
+    control<HTMLButtonElement>(root, 'minus').click();
+    const plus = control<HTMLButtonElement>(root, 'plus');
+    expect(plus.disabled).toBe(false);
+    plus.focus();
+    plus.click();
+    const rebuilt = control<HTMLButtonElement>(root, 'plus');
+    expect(rebuilt).not.toBe(plus);
+    expect(rebuilt.disabled).toBe(false);
+    expect(document.activeElement).toBe(rebuilt);
+    expect(document.activeElement).not.toBe(control<HTMLButtonElement>(root, 'remove'));
+  });
+
   it('degrades to the quantity input when the pressed stepper comes back DISABLED', () => {
     // Owned 2, staged at 2: pressing `-` drops the count to 1, which is the floor, so
     // the rebuilt `-` is disabled and cannot take focus. The qty input is the next rung
     // and the one that matters most: a number input fires `change` WITHOUT blurring, so
     // falling through to Remove instead would turn the player's next Enter into
     // deleting the parcel mid-adjustment.
-    const root = stagedParcel(FANG, 2);
+    const { root } = stagedParcel(FANG, 2);
     control<HTMLButtonElement>(root, 'minus').focus();
     control<HTMLButtonElement>(root, 'minus').click();
     expect(control<HTMLButtonElement>(root, 'minus').disabled).toBe(true);
@@ -106,7 +145,7 @@ describe('the mailbox parcel list carries keyboard focus across its own rebuild'
   });
 
   it('keeps the quantity input when the typed field had focus', () => {
-    const root = stagedParcel(FANG, 4);
+    const { root } = stagedParcel(FANG, 4);
     const qty = control<HTMLInputElement>(root, 'qty');
     qty.focus();
     qty.value = '2';
@@ -117,10 +156,30 @@ describe('the mailbox parcel list carries keyboard focus across its own rebuild'
     expect(document.activeElement).toBe(rebuilt);
   });
 
+  it('degrades to Remove when the whole stepper vanishes between renders', () => {
+    // The last REACHABLE rung, and the case the painter's own comment names ("the
+    // stepper dropped once owned <= 1") but nothing exercised. The player is standing on
+    // `-` when their stock of the item drops under two, so the rebuild emits no stepper
+    // at all: `-`, `+` and the qty input are all absent, not merely disabled, and Remove
+    // is the only control left for that parcel. Driven through setParcelQty, which
+    // repaints unconditionally, so the rebuild does not depend on the count changing.
+    const { root, inventory } = stagedParcel(FANG, 4);
+    const minus = control<HTMLButtonElement>(root, 'minus');
+    minus.focus();
+    inventory[0].count = 1;
+    control<HTMLInputElement>(root, 'qty').dispatchEvent(new Event('change'));
+    // The stepper really is gone, so this is the absent-rung path and not a disabled one.
+    expect(control<HTMLButtonElement>(root, 'minus')).toBeNull();
+    expect(control<HTMLInputElement>(root, 'qty')).toBeNull();
+    const remove = control<HTMLButtonElement>(root, 'remove');
+    expect(remove).not.toBeNull();
+    expect(document.activeElement).toBe(remove);
+  });
+
   it('takes focus from NOBODY when the player was not in the parcel list', () => {
     // The containment check, in the real window. Focus sits on the compose recipient
     // field, outside #mail-parcels; a parcel repaint must leave it there.
-    const root = stagedParcel(FANG, 4);
+    const { root } = stagedParcel(FANG, 4);
     const to = root.querySelector<HTMLInputElement>('#mail-to') as HTMLInputElement;
     to.focus();
     rebuildParcels(root);
@@ -136,7 +195,7 @@ describe('the mailbox parcel list carries keyboard focus across its own rebuild'
     // With the parcel list as the root this is not captured and focus stays put; with
     // the window root it is, and the repaint drags the player into a list they had
     // already left.
-    const root = stagedParcel(FANG, 4);
+    const { root } = stagedParcel(FANG, 4);
     const elsewhere = document.createElement('button');
     elsewhere.dataset.focusKey = `${FANG}:plus`;
     root.appendChild(elsewhere);
@@ -154,12 +213,15 @@ describe('the mailbox parcel list carries keyboard focus across its own rebuild'
     // allocation steppers with the SAME data-focus-key attribute in the same
     // <id>:<role> shape. Plant one of those outside the mailbox, focus it, and repaint:
     // the parcel list must not pull focus into itself.
-    const root = stagedParcel(FANG, 4);
+    const { root } = stagedParcel(FANG, 4);
     const outside = document.createElement('button');
     outside.dataset.focusKey = `${FANG}:plus`;
     document.body.appendChild(outside);
     outside.focus();
-    control<HTMLButtonElement>(root, 'plus').click();
+    rebuildParcels(root);
+    // Same proof as the case above: the rung the key names is available, so this is a
+    // refusal to capture rather than an empty ladder.
+    expect(control<HTMLButtonElement>(root, 'plus').disabled).toBe(false);
     expect(document.activeElement).toBe(outside);
   });
 });

--- a/tests/mailbox_window_focus.test.ts
+++ b/tests/mailbox_window_focus.test.ts
@@ -62,6 +62,21 @@ const FANG = 'wolf_fang';
 const control = <T extends HTMLElement>(root: HTMLElement, role: string): T =>
   root.querySelector<T>(`[data-focus-key="${FANG}:${role}"]`) as T;
 
+/**
+ * Force a parcel-list rebuild without touching focus, for the two cases that assert
+ * focus does NOT move. `-` and not `+`: the parcel is staged at its owned ceiling, so
+ * `+` comes back disabled and a disabled button dispatches no click at all, which would
+ * make these two cases pass against any implementation (the rebuild would never run).
+ */
+function rebuildParcels(root: HTMLElement): void {
+  const minus = control<HTMLButtonElement>(root, 'minus');
+  expect(minus.disabled).toBe(false);
+  const before = control<HTMLInputElement>(root, 'qty');
+  minus.click();
+  // Proof the wipe really happened: the qty input is a fresh node.
+  expect(control<HTMLInputElement>(root, 'qty')).not.toBe(before);
+}
+
 describe('the mailbox parcel list carries keyboard focus across its own rebuild', () => {
   it('hands focus back to the rebuilt equivalent of the stepper that was pressed', () => {
     // Owned 4, staged at 4, so pressing `-` goes 4 -> 3 and `-` is still enabled on the
@@ -108,8 +123,30 @@ describe('the mailbox parcel list carries keyboard focus across its own rebuild'
     const root = stagedParcel(FANG, 4);
     const to = root.querySelector<HTMLInputElement>('#mail-to') as HTMLInputElement;
     to.focus();
-    control<HTMLButtonElement>(root, 'plus').click();
+    rebuildParcels(root);
     expect(document.activeElement).toBe(to);
+  });
+
+  it('captures against the PARCEL LIST, not the whole mailbox window', () => {
+    // The root argument is a contract, not a detail: renderParcels rebuilds only
+    // #mail-parcels, so passing the window root would widen what gets captured to the
+    // whole compose form, whose nodes this repaint does not touch. The case above
+    // cannot see that (the recipient field carries no key, so both roots capture
+    // nothing), so plant a keyed control inside the window and OUTSIDE the parcel list.
+    // With the parcel list as the root this is not captured and focus stays put; with
+    // the window root it is, and the repaint drags the player into a list they had
+    // already left.
+    const root = stagedParcel(FANG, 4);
+    const elsewhere = document.createElement('button');
+    elsewhere.dataset.focusKey = `${FANG}:plus`;
+    root.appendChild(elsewhere);
+    expect(root.querySelector('#mail-parcels')?.contains(elsewhere)).toBe(false);
+    elsewhere.focus();
+    rebuildParcels(root);
+    // The rung the widened root would have resolved to really is available, so this is
+    // a refusal to capture and not just an empty ladder.
+    expect(control<HTMLButtonElement>(root, 'plus').disabled).toBe(false);
+    expect(document.activeElement).toBe(elsewhere);
   });
 
   it('never reads a focus key off a control OUTSIDE the window', () => {

--- a/tests/mailbox_window_focus.test.ts
+++ b/tests/mailbox_window_focus.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+//
+// The mailbox parcel list's rebuild-refocus ladder, behaviorally.
+//
+// renderParcels is a full wipe of #mail-parcels, and a +/- click is what triggers it, so
+// a keyboard player who pressed + had the button destroyed under them mid-adjustment.
+// The window has carried focus across that wipe since #1444, but only through source
+// pins in tests/mailbox_window.test.ts (that the focus keys are written at all), never
+// behaviorally. #2528 moved the two mechanical halves of the idiom into
+// src/ui/focus_restore.ts, and a source pin cannot tell whether that migration preserved
+// the LADDER, which is the part the window still owns. So this drives the real
+// MailboxWindow through the real stepper buttons, on the tests/mailbox_compose_preserved
+// harness, and asserts where focus actually lands.
+//
+// The rungs, in the window's order: the same control, then the quantity input, then `-`,
+// then `+`, then Remove. Each case below lands on a different one.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import type { InvSlot } from '../src/sim/types';
+import { MailboxWindow, type MailboxWindowDeps } from '../src/ui/mailbox_window';
+import type { IWorld } from '../src/world_api';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+function fakeWorld(inventory: InvSlot[]): IWorld {
+  return {
+    inventory,
+    mailInfo: { unread: 0, messages: [], postage: 30, maxAttachments: 3, deliverySeconds: 60 },
+    mailMarkRead: () => {},
+  } as unknown as IWorld;
+}
+
+/** A real MailboxWindow on the Send tab with `itemId` staged as a parcel. */
+function stagedParcel(itemId: string, owned: number): HTMLElement {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  const noop = (): void => {};
+  const deps: MailboxWindowDeps = {
+    itemIcon: () => '<span class="item-icon"></span>',
+    moneyHtml: () => '',
+    itemTooltip: () => '',
+    attachTooltip: noop,
+    root: () => root,
+    world: () => fakeWorld([{ itemId, count: owned }]),
+    closeOthers: noop,
+    hideTooltip: noop,
+    captureFocus: () => null,
+    restoreFocus: noop,
+    showError: noop,
+    syncBags: noop,
+  };
+  const win = new MailboxWindow(deps);
+  win.open();
+  (root.querySelector('[data-tab="send"]') as HTMLElement).click();
+  win.stageParcel(itemId);
+  return root;
+}
+
+const FANG = 'wolf_fang';
+const control = <T extends HTMLElement>(root: HTMLElement, role: string): T =>
+  root.querySelector<T>(`[data-focus-key="${FANG}:${role}"]`) as T;
+
+describe('the mailbox parcel list carries keyboard focus across its own rebuild', () => {
+  it('hands focus back to the rebuilt equivalent of the stepper that was pressed', () => {
+    // Owned 4, staged at 4, so pressing `-` goes 4 -> 3 and `-` is still enabled on the
+    // way back: the plain case, and the one that reds if the capture is dropped.
+    const root = stagedParcel(FANG, 4);
+    const minus = control<HTMLButtonElement>(root, 'minus');
+    minus.focus();
+    minus.click();
+    const rebuilt = control<HTMLButtonElement>(root, 'minus');
+    expect(rebuilt).not.toBe(minus); // really a fresh node, so this is a rebuild
+    expect(rebuilt.disabled).toBe(false);
+    expect(document.activeElement).toBe(rebuilt);
+    expect(document.activeElement).not.toBe(document.body);
+  });
+
+  it('degrades to the quantity input when the pressed stepper comes back DISABLED', () => {
+    // Owned 2, staged at 2: pressing `-` drops the count to 1, which is the floor, so
+    // the rebuilt `-` is disabled and cannot take focus. The qty input is the next rung
+    // and the one that matters most: a number input fires `change` WITHOUT blurring, so
+    // falling through to Remove instead would turn the player's next Enter into
+    // deleting the parcel mid-adjustment.
+    const root = stagedParcel(FANG, 2);
+    control<HTMLButtonElement>(root, 'minus').focus();
+    control<HTMLButtonElement>(root, 'minus').click();
+    expect(control<HTMLButtonElement>(root, 'minus').disabled).toBe(true);
+    expect(document.activeElement).toBe(control<HTMLInputElement>(root, 'qty'));
+  });
+
+  it('keeps the quantity input when the typed field had focus', () => {
+    const root = stagedParcel(FANG, 4);
+    const qty = control<HTMLInputElement>(root, 'qty');
+    qty.focus();
+    qty.value = '2';
+    qty.dispatchEvent(new Event('change'));
+    const rebuilt = control<HTMLInputElement>(root, 'qty');
+    expect(rebuilt).not.toBe(qty);
+    expect(rebuilt.value).toBe('2');
+    expect(document.activeElement).toBe(rebuilt);
+  });
+
+  it('takes focus from NOBODY when the player was not in the parcel list', () => {
+    // The containment check, in the real window. Focus sits on the compose recipient
+    // field, outside #mail-parcels; a parcel repaint must leave it there.
+    const root = stagedParcel(FANG, 4);
+    const to = root.querySelector<HTMLInputElement>('#mail-to') as HTMLInputElement;
+    to.focus();
+    control<HTMLButtonElement>(root, 'plus').click();
+    expect(document.activeElement).toBe(to);
+  });
+
+  it('never reads a focus key off a control OUTSIDE the window', () => {
+    // The shared namespace hazard the extraction is about: town_focus_window keys its
+    // allocation steppers with the SAME data-focus-key attribute in the same
+    // <id>:<role> shape. Plant one of those outside the mailbox, focus it, and repaint:
+    // the parcel list must not pull focus into itself.
+    const root = stagedParcel(FANG, 4);
+    const outside = document.createElement('button');
+    outside.dataset.focusKey = `${FANG}:plus`;
+    document.body.appendChild(outside);
+    outside.focus();
+    control<HTMLButtonElement>(root, 'plus').click();
+    expect(document.activeElement).toBe(outside);
+  });
+});

--- a/tests/town_focus_repaint_gate.test.ts
+++ b/tests/town_focus_repaint_gate.test.ts
@@ -1235,4 +1235,34 @@ describe('Town Focus focus-system wiring (source pins)', () => {
     // ...and BEFORE the wipe, which is what makes it survive innerHTML.
     expect(painter.indexOf('markDialogRoot(')).toBeLessThan(painter.indexOf('el.innerHTML ='));
   });
+
+  it('captures the focus key BEFORE the wipe and restores it AFTER the scroll', () => {
+    // Both halves are ordering claims the painter's own comments make and no behavioral
+    // test can see (#2528). The capture must precede the innerHTML wipe, or the control
+    // it reads is already gone; the scroll restore must precede the focus call, because
+    // the bare focus() is what lets a DEGRADED target scroll itself into view and win
+    // over the restored offset. Reversing either is silent: focus still lands somewhere.
+    //
+    // Anchored on literals verified to occur once each in the comment-stripped painter,
+    // and asserted present before they are compared, so a rename reds here instead of
+    // quietly comparing against indexOf's -1.
+    const capture = painterSrc.indexOf('captureFocusKey(el)');
+    const wipe = painterSrc.indexOf('el.innerHTML =');
+    const scroll = painterSrc.indexOf('el.scrollTop = scrollTop');
+    // The CALL, which precedes the declaration of the same name in this file.
+    const restore = painterSrc.indexOf('restoreFocus(');
+    for (const [name, at] of [
+      ['captureFocusKey(el)', capture],
+      ['el.innerHTML =', wipe],
+      ['el.scrollTop = scrollTop', scroll],
+      ['restoreFocus(', restore],
+    ] as const) {
+      expect(
+        at,
+        `${name} is no longer in the painter, so this pin cannot order it`,
+      ).toBeGreaterThan(-1);
+    }
+    expect(capture).toBeLessThan(wipe);
+    expect(scroll).toBeLessThan(restore);
+  });
 });


### PR DESCRIPTION
## Summary

The "carry keyboard focus across a full `innerHTML` rebuild" idiom was hand-rolled in
`src/ui`, and the copies disagreed on the two details that decide whether it is correct:
whether `document.activeElement` is narrowed or cast, and whether the read is contained
to the container being rebuilt. Containment is not defensive here. `mailbox_window` keys
its parcel steppers `<itemId>:<role>` and `town_focus_window` keys its allocation
steppers `<component>:<role>`, both under the same `data-focus-key` attribute, so the key
namespace is ONE flat namespace shared across windows and a copy that skipped the check
could let its own repaint pull focus out of another open window.

`src/ui/focus_restore.ts` now owns the two mechanical halves:

- `captureFocusKey(root: HTMLElement): string | null` (activeElement, `instanceof`-narrowed, contained in `root`, keyed off `dataset.focusKey`)
- `restoreFirstEnabled(candidates): void` (walk in the caller's order, skip absent and disabled, stop at the first, focus synchronously)

Each window keeps its own degradation ladder, which is the genuinely bespoke part
(`mailbox_window` prefers the quantity input, `town_focus_window` walks the stepper pair
outward before it leaves the row). Folding those in would mean a switch over window
identities.

The two callers the issue names as closest are migrated, so the helper is proven against
a button ladder and an input one rather than shipped with a single shape.

### Behavior deltas, both deliberate

1. `mailbox_window`'s capture was `document.activeElement as HTMLElement | null`, and the
   `dataset` read followed the cast. It is now a real `instanceof` narrowing. A contained,
   keyed `SVGElement` answers `dataset` and is not an `HTMLElement`, so the old cast would
   have read a key off one; `tests/focus_restore.test.ts` pins that case.
2. `mailbox_window`'s ladder took two of its rungs (the qty input and Remove) WITHOUT a
   disabled check, and they now go through one. Inert: `minus` and `plus` are the only two
   controls the painter ever disables (`src/ui/mailbox_window.ts:679,724`).

Nothing else changed at either call site, and no markup, CSS, i18n key, or rendered output
moved.

### Why `UI_DOM_MODULES` and not one of the other buckets

The module reads `document.activeElement` and uses `instanceof HTMLElement`.
`UI_PURE_CORES` is barred by `DOM_GLOBAL_RE`, and `UI_PAINTER_HELPERS` bars both outright
(`document` only to mint a detached node, no `instanceof HTMLElement`). Taking the document
or the already-read activeElement as a parameter would keep the module out of every list,
and is deliberately not done: it hands the one line each copy got wrong back to the copies.
`src/ui/dialog_root.ts` is the precedent for a small DOM-touching micro-pattern lifted out
of a dozen painters.

The module also records, in one place, the two answers the issue said were in flight: the
`instanceof` narrowing (above), and the bare `focus()` rather than
`focus({ preventScroll: true })`. Every copy already agreed on the bare call, but only
`town_focus_window` recorded why, so that reasoning now lives where the decision does.

### What the remaining copies actually need, which is more than a swap

The issue's table reads as ten copies of one idiom. Only the two migrated modules key off
`data-focus-key`; the rest are further away, and this is the useful residue of the survey:

| Module | What it really carries | Cost to migrate |
|---|---|---|
| `deeds_window` | a priority-ordered selector over `data-cat` / `data-filter` / `data-watch` / `data-title` with `:not([disabled])` baked into the selector; also distinguishes "focus was outside the root" from "inside but unkeyed" (the Close fallback), which a `string \| null` capture collapses | restore half maps; capture half needs new attributes on rendered markup |
| `spellbook_window` | a four-branch chain: TWO class-AND-dataset pairs (`.spell-hotbar-toggle` and `.spell-row`, each with `data-ability-id`), then two bare attribute markers. No ladder at all (one candidate, no degradation) | capture half needs `data-focus-key` on every row, toggle, reset and close control |
| `claudium_window` | a discriminated union (`rail` / `sku` / `wallet`), contained against a nullable `.cl-body` descendant | neither half maps |
| `options_window` | no capture half: the identity is the clicked toggle's `BoolSettingKey`, threaded as a callback argument, under `data-setting-key`. Its tab flavor is already extracted (`focusActiveTab`) | nothing for `captureFocusKey` to replace |
| `char_window` | no capture half: the `EquipSlot` argument re-derived into a DOM id, resolved from `document` | nothing for `captureFocusKey` to replace |
| `professions_window` | a bare boolean `hadFocus` with no per-control identity ("the close button is the only interactive control") | restore half maps degenerately; capture half has nothing to read |
| `bank_window` | TWO captures, neither a key: a boolean `hadFocus`, plus the search box's focus and CARET pair. Its containment test also reaches into `#prompt-stack`, which a single-root helper cannot express | neither half maps as written |
| `social_window` | draft preservation (value plus caret plus a focused flag), and one selector-keyed refocus that fires for mouse activations too | a different idiom |

So "the rest can follow incrementally" is real, but for most of them the increment includes
changing rendered markup, which is why this PR stops at the pair the issue scoped it to.

## Related issues

Closes #2528. Follow-up from the review panel on #2522.

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- Commands:
  - `npm run gate` (PR tier): PASS, all 11 steps green.
  - `npx vitest run tests/focus_restore.test.ts tests/mailbox_window_focus.test.ts tests/town_focus_repaint_gate.test.ts tests/architecture.test.ts tests/hud_perf_budget.test.ts tests/deeds_window_focus.test.ts tests/focus_manager.test.ts tests/mailbox_window.test.ts tests/mailbox_compose_preserved.test.ts`
  - A 15-mutation matrix over the three suites, **15/15 caught**: narrowing dropped to a bare
    null check, containment check removed, `dataset.focusKey` renamed, disabled skip removed,
    `return` after `focus()` removed, the `undefined` hole unskipped, each caller's capture
    root widened, each caller's `restoreFirstEnabled` call removed, the mailbox ladder
    reordered, the mailbox `plus` arm mis-resolved to Remove, `focus()` given
    `{ preventScroll: true }`, the focus deferred a tick, and the town focus capture moved
    after the wipe.
- New coverage: `tests/focus_restore.test.ts` (the helper) and `tests/mailbox_window_focus.test.ts`.
  The parcel list had never been tested behaviorally, only scraped for source text, so the
  migration would otherwise have had nothing holding its ladder. It drives the real
  `MailboxWindow` through the real stepper buttons on the `tests/mailbox_compose_preserved`
  harness.
- Manual steps: none. No rendered output changes, so no screenshots.

### What the review found, since it is the interesting part

Three domain reviewers plus five adversarial verifiers ran over this. The shipped behavior
came back clean at both call sites (one verifier reimplemented both ladders and ran all 150
combinations of stepper-present, per-control-disabled and role: zero reachable divergences).
Everything real they found was in the TESTS, and the same defect was found independently
three times:

- **Three of the new mailbox cases drove no rebuild at all.** They clicked the parcel's `+`,
  which the fixture renders disabled at the owned ceiling, and a disabled button dispatches
  no click, so `renderParcels` never ran and the cases passed against any implementation,
  including one with no containment check. The third of them was the case covering this
  extraction's own acceptance criterion. All three now go through a helper that asserts the
  button is enabled and that the wipe replaced a node. Worth stating plainly: the first
  11-mutation matrix was green THROUGH this, because other cases killed the same mutations.
  A green matrix does not certify that each case has teeth.
- **The `plus` arm of the mailbox preferred-control resolution had no test in the repo.**
  Mis-resolving it to Remove is silent and destructive (the player's next Enter deletes the
  parcel) and left every test green. Now pinned, and in the matrix as M12.
- **The bare-`focus()` contract was unpinnable against a call count**, so the fake candidate
  records arguments; the Remove rung needed a shrinking owned count to be reachable at all;
  and the disabled arm of the focus-nobody case had coinciding arms, since jsdom refuses a
  disabled element regardless.
- **Four claims in my own comments were checkable and wrong**, all corrected:
  `dialog_root.ts` is in no architecture list (it is the parameter-taking counter-example,
  not the registration precedent); a parameterized helper would still trip
  `UI_DOM_CONSTRUCTOR_RE` on the narrowing alone, so registration is unavoidable rather than
  chosen; `bank_window` carries a caret pair and not just a boolean; `spellbook_window`'s
  chain has four branches, not three.
- Two promises the header makes were unenforceable, and now have source scans: no
  forced-reflow read (the painter gate is per-FILE, so a `getClientRects()` here is charged
  to no painter and both migrated painters' exact-count grants stay green) and no deferral.
  The reflow token list is read out of the painter gate rather than copied, so the two cannot
  drift. Note that the alternative, adding the helper as a proxy token, would have BROKEN
  both painters' exact-count grants.
- A third scan refuses any `src/ui` module that touches `data-focus-key` without importing
  the helper, which is the durable answer to "what stops copy eleven".

### Known, pre-existing, not addressed here

Pressing Remove drops focus to `<body>`: the parcel is gone, so every rung for that item
resolves undefined. Faithful to the chain this replaced, and recorded in a comment at the
call site. Degrading to a surviving parcel needs a cross-item fallback this per-item ladder
does not have.

## Screenshots / recordings

N/A. No visual change: the diff moves two mechanical halves of a focus handler and adds
tests. Nothing a player sees is different, including focus behavior, which is preserved.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green, and the new behavior has decisive
      tests (mutation matrix above).

### Cross-platform

- [x] **Accessible.** Keyboard operability is the subject of the change and is unchanged:
      focus stays synchronous, stays visible, and the scroll-then-focus ordering
      `town_focus_window` documents is preserved.
- [ ] ~Tested on desktop and mobile.~ No layout, CSS or touch-target change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. `focus_restore.ts` renders no text.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is untouched.
- [x] No generated file hand-edited.
