### PR TITLE
fix(ui): re-localize the signature-gated surfaces on a language switch

### DIFF
--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -359,6 +359,29 @@ expected and fine at PR tier.
 **non-release builds only**, and **hard-fails a pending key on a release build**
 (`isReleaseBuild()` = `I18N_RELEASE=1` or `import.meta.env.PROD`).
 
+**A runtime language switch does not reload the page: a surface with a REPAINT SIGNATURE
+must be in the fan-out.** `changeLanguage` (`main.ts`) re-localizes the static shell and
+dispatches `woc:languagechange`; `Hud.refreshLocalizedDynamicUi()` repaints the dynamic
+surfaces. Which of the two elision idioms a module uses decides whether it needs an arm there:
+- a **write-elision facet** (`PainterHostWriters`) compares the RESOLVED string it is about to
+  write, so a locale change moves the comparison and the write happens by itself. Nothing to do.
+- a **repaint signature** (`lastSig` and its family) compares a digest of the DATA (ids, counts,
+  positions, booleans). That is text-independent BY DESIGN, so `setLanguage` alone can never
+  move it and the surface keeps the old locale until its data happens to change. It needs an arm.
+
+Give such a module a `relocalize()` that is **self-gated on its own open check** (the fan-out
+calls it unconditionally), forces exactly one rebuild, and leaves the signature **re-latched to
+the current state, never cleared**: a cleared signature buys a second rebuild on the next poll,
+which lands after any draft restore and undoes it. If the rebuild destroys live typed input
+(a compose form, a typeahead, a booking form), carry it across with
+`form_draft.ts` (`captureFormDraft` / `restoreFormDraft`). Two mistakes to avoid, both of which
+this repo has shipped: a `render()` whose signature check is INSIDE it is a silent no-op from
+the fan-out (`card_duel_window.ts`), and an arm that calls a method the callee's own signature
+swallows is present and inert (`delve_tracker_controller.ts`, #2529). Both halves are pinned by
+`tests/language_fanout_registry.test.ts`, which enumerates the fan-out and sweeps `src/ui` for
+signature-gated modules, so a new one cannot land without the question being answered; the
+per-surface behavior lives in `tests/language_fanout_relocalize.test.ts`.
+
 **Contributor workflow (add a player-visible string): add ENGLISH ONLY.**
 1. Add the key to `en` (the matching `i18n.catalog/<domain>.ts` module) and render it through
    `t()`. **Never edit the `i18n.locales/<lang>.ts` overlays, and never put English / a

--- a/src/ui/calendar_window.ts
+++ b/src/ui/calendar_window.ts
@@ -19,6 +19,7 @@ import {
 } from './calendar_view';
 import { markDialogRoot } from './dialog_root';
 import { esc } from './esc';
+import { captureFormDraft, restoreFormDraft } from './form_draft';
 import { formatDateTime, formatNumber, type TranslationKey, t } from './i18n';
 import { svgIcon } from './ui_icons';
 
@@ -121,14 +122,45 @@ export class CalendarWindow {
     this.lastSig = '';
   }
 
+  // The repaint signature: the visible month, the selected day, and the guild-event
+  // mirror. Every member is an id, a number or a date string, so a language switch
+  // alone can never move it, which is why relocalize() exists below.
+  private sig(): string {
+    const guild = this.deps.world().socialInfo?.guild ?? null;
+    return JSON.stringify([this.year, this.month, this.selectedIso, guild?.events ?? []]);
+  }
+
   // Slow-band refresh: repaint when the guild-event mirror changes.
   refreshIfChanged(): void {
     if (!this.opened) return;
-    const guild = this.deps.world().socialInfo?.guild ?? null;
-    const sig = JSON.stringify([this.year, this.month, this.selectedIso, guild?.events ?? []]);
+    const sig = this.sig();
     if (sig === this.lastSig) return;
     this.lastSig = sig;
     this.render();
+  }
+
+  /**
+   * Re-localize after an in-game language switch (the Hud's woc:languagechange
+   * fan-out). Self-gated on the open flag so the fan-out can call it
+   * unconditionally.
+   *
+   * A bare render() would repaint in the new locale and wipe the guild-event
+   * booking form, which renderDayPane emits with empty inputs, so the draft is
+   * carried across the rebuild.
+   *
+   * The signature is RE-LATCHED rather than cleared. Clearing it is what the
+   * window's own interactive paths do, and each of those pays one extra rebuild
+   * on the next slow tick; here that second rebuild would land after the restore
+   * and wipe the draft again. The render below already painted the current data,
+   * so latching the current signature is what makes refreshIfChanged correct.
+   */
+  relocalize(): void {
+    if (!this.opened) return;
+    const root = this.deps.root();
+    const draft = captureFormDraft(root);
+    this.render();
+    restoreFormDraft(root, draft);
+    this.lastSig = this.sig();
   }
 
   private guildEvents(): GuildEventInfo[] {

--- a/src/ui/form_draft.ts
+++ b/src/ui/form_draft.ts
@@ -22,8 +22,13 @@
 // FOCUS IS RESTORED ONLY IF IT WAS ALREADY INSIDE THIS ROOT. The language picker
 // lives in the Options window, so at the moment of a switch the player is
 // normally focused there; re-focusing a mailbox field would yank the caret out
-// from under them. Capturing the caret is still worth it because the two windows
-// CAN both be open (opening a window no longer closes its siblings).
+// from under them. Capturing it is still worth it because the two windows CAN
+// both be open (opening a window no longer closes its siblings), and focus is
+// tracked for ANY control under the root, not only the text fields: these
+// windows install a Tab trap that only arms while `root.contains(activeElement)`
+// (see focus_manager.ts), so a rebuild that dropped focus to `<body>` would let
+// the next Tab walk straight out of the window. The spellbook already restores
+// focus by selector across its own rebuild for the same reason.
 
 /** The `<input>` types whose `.value` is the text a player typed. A checkbox or
  *  radio carries its state in `.checked`, and a file/color/range input has no
@@ -34,11 +39,15 @@ type DraftField = HTMLInputElement | HTMLTextAreaElement;
 
 /** A window's live text, captured before a rebuild and written back after it. */
 export interface FormDraft {
-  /** Field key (`#id` or `[data-field="..."]`) to the value it held. */
+  /** Field key (`[id="..."]` or `[data-*="..."]`) to the value it held. */
   readonly values: ReadonlyMap<string, string>;
-  /** The key of the field that held focus, or null when focus was elsewhere. */
+  /**
+   * The key of the element that held focus, or null when focus was outside this
+   * root. NOT limited to the text fields in `values`: a focused button matters
+   * too, because losing it disarms the window's Tab trap.
+   */
   readonly focusKey: string | null;
-  /** The caret/selection of the focused field, when it exposes one. */
+  /** The caret/selection, when the focused element was a text field exposing one. */
   readonly selection: readonly [start: number, end: number] | null;
 }
 
@@ -48,12 +57,48 @@ function isDraftField(el: Element): el is DraftField {
   return TEXT_INPUT_TYPES.has((el as HTMLInputElement).type);
 }
 
-/** The selector that finds this field again in the rebuilt DOM, or null when it
- *  carries no stable identity to find it by. */
-function draftKey(el: DraftField): string | null {
-  if (el.id) return `#${el.id}`;
-  const field = el.dataset.field;
-  return field ? `[data-field="${field}"]` : null;
+/**
+ * The selector that finds this element again in the rebuilt DOM, or null when it
+ * carries no stable identity to find it by.
+ *
+ * Falls back to the first `data-*` attribute, which is how every window in this
+ * repo identifies its controls (`data-tab`, `data-cal-day`, `data-play`,
+ * `data-close`, `data-act`). An element with none of the three is skipped rather
+ * than guessed at: a wrong restore is worse than none.
+ */
+function elementKey(el: Element): string | null {
+  if (el.id) return `[id="${escapeSelectorString(el.id)}"]`;
+  for (const attr of el.attributes) {
+    if (attr.name.startsWith('data-'))
+      return `[${attr.name}="${escapeSelectorString(attr.value)}"]`;
+  }
+  return null;
+}
+
+/**
+ * Escape a value for use inside a quoted CSS attribute-selector string.
+ *
+ * The id key is written `[id="..."]` rather than `#...` on purpose. A leading
+ * digit is a legal HTML id and an ILLEGAL CSS identifier, so `#2fa` makes
+ * querySelector throw SyntaxError, and that throw would unwind out of the
+ * window's relocalize and out of the whole language fan-out, taking every
+ * later surface with it. A quoted attribute selector accepts any value, so the
+ * only escaping left is the two characters that would end the string early.
+ * (`CSS.escape` would solve the identifier form, but it is absent in the test
+ * DOM, and a fix that only holds in a browser is not a fix.)
+ */
+function escapeSelectorString(value: string): string {
+  return value.replace(/[\\"]/g, '\\$&');
+}
+
+/** `querySelector` that cannot throw: an unmatchable key skips its restore
+ *  rather than unwinding the caller. Belt for the escaping above. */
+function findByKey(root: ParentNode, key: string): Element | null {
+  try {
+    return root.querySelector(key);
+  } catch {
+    return null;
+  }
 }
 
 /** `selectionStart`/`setSelectionRange` throw on a number input in Chromium and
@@ -76,22 +121,22 @@ function readSelection(el: DraftField): readonly [number, number] | null {
  */
 export function captureFormDraft(root: ParentNode): FormDraft {
   const values = new Map<string, string>();
-  const active = typeof document === 'undefined' ? null : document.activeElement;
-  let focusKey: string | null = null;
-  let selection: readonly [number, number] | null = null;
   for (const el of root.querySelectorAll('input, textarea')) {
     if (!isDraftField(el)) continue;
-    const key = draftKey(el);
+    const key = elementKey(el);
     // First writer wins: a duplicate id restores through one querySelector
     // anyway, so recording the later one would write the wrong value back.
     if (key === null || values.has(key)) continue;
     values.set(key, el.value);
-    if (el === active) {
-      focusKey = key;
-      selection = readSelection(el);
-    }
   }
-  return { values, focusKey, selection };
+  const active = typeof document === 'undefined' ? null : document.activeElement;
+  const focused =
+    active !== null && active !== document.body && root.contains(active) ? active : null;
+  return {
+    values,
+    focusKey: focused ? elementKey(focused) : null,
+    selection: focused && isDraftField(focused) ? readSelection(focused) : null,
+  };
 }
 
 /**
@@ -100,14 +145,14 @@ export function captureFormDraft(root: ParentNode): FormDraft {
  */
 export function restoreFormDraft(root: ParentNode, draft: FormDraft): void {
   for (const [key, value] of draft.values) {
-    const el = root.querySelector(key);
+    const el = findByKey(root, key);
     if (el && isDraftField(el)) el.value = value;
   }
   if (draft.focusKey === null) return;
-  const target = root.querySelector(draft.focusKey);
-  if (!target || !isDraftField(target)) return;
+  const target = findByKey(root, draft.focusKey);
+  if (!(target instanceof HTMLElement)) return;
   target.focus();
-  if (draft.selection === null) return;
+  if (draft.selection === null || !isDraftField(target)) return;
   try {
     target.setSelectionRange(draft.selection[0], draft.selection[1]);
   } catch {

--- a/src/ui/form_draft.ts
+++ b/src/ui/form_draft.ts
@@ -1,0 +1,116 @@
+// Preserve what a player has TYPED across a forced window rebuild.
+//
+// The `woc:languagechange` fan-out (Hud.refreshLocalizedDynamicUi) forces one
+// full repaint of every open window so its t() text lands in the new locale.
+// Three of those windows build their text fields with innerHTML and emit them
+// empty every time (the calendar's guild-event booking form, the mailbox Send
+// tab, the social window's typeahead and guild billboard), so the repaint that
+// fixes the language would wipe a half-written letter. Those windows capture the
+// live values first, rebuild, and write them back.
+//
+// This is the same hazard the mailbox already ruled on for a different trigger:
+// attaching a parcel used to run the full render and wiped the compose form
+// (#1695), which is why stageParcel repaints only the parcels row. A language
+// switch cannot narrow that way, since every label in the window is what moved.
+//
+// KEYED ON THE FIELD'S OWN IDENTITY, its `id` or its `data-field`, never its
+// position. A rebuild in another language reorders nothing, but the social
+// window's footer markup differs per tab, and an index-keyed restore would put a
+// half-typed guild name into the friend field the moment a tab was involved. A
+// field carrying neither key is skipped rather than guessed at.
+//
+// FOCUS IS RESTORED ONLY IF IT WAS ALREADY INSIDE THIS ROOT. The language picker
+// lives in the Options window, so at the moment of a switch the player is
+// normally focused there; re-focusing a mailbox field would yank the caret out
+// from under them. Capturing the caret is still worth it because the two windows
+// CAN both be open (opening a window no longer closes its siblings).
+
+/** The `<input>` types whose `.value` is the text a player typed. A checkbox or
+ *  radio carries its state in `.checked`, and a file/color/range input has no
+ *  draft to lose, so none of them belong in a draft. */
+const TEXT_INPUT_TYPES = new Set(['text', 'search', 'email', 'tel', 'url', 'number']);
+
+type DraftField = HTMLInputElement | HTMLTextAreaElement;
+
+/** A window's live text, captured before a rebuild and written back after it. */
+export interface FormDraft {
+  /** Field key (`#id` or `[data-field="..."]`) to the value it held. */
+  readonly values: ReadonlyMap<string, string>;
+  /** The key of the field that held focus, or null when focus was elsewhere. */
+  readonly focusKey: string | null;
+  /** The caret/selection of the focused field, when it exposes one. */
+  readonly selection: readonly [start: number, end: number] | null;
+}
+
+function isDraftField(el: Element): el is DraftField {
+  if (el.tagName === 'TEXTAREA') return true;
+  if (el.tagName !== 'INPUT') return false;
+  return TEXT_INPUT_TYPES.has((el as HTMLInputElement).type);
+}
+
+/** The selector that finds this field again in the rebuilt DOM, or null when it
+ *  carries no stable identity to find it by. */
+function draftKey(el: DraftField): string | null {
+  if (el.id) return `#${el.id}`;
+  const field = el.dataset.field;
+  return field ? `[data-field="${field}"]` : null;
+}
+
+/** `selectionStart`/`setSelectionRange` throw on a number input in Chromium and
+ *  Firefox (the spec forbids a selection on a non-text input), and the coin
+ *  fields and the calendar's hour field are exactly that. Losing the caret is
+ *  acceptable there; throwing out of a language switch is not. */
+function readSelection(el: DraftField): readonly [number, number] | null {
+  try {
+    const { selectionStart, selectionEnd } = el;
+    if (selectionStart === null || selectionEnd === null) return null;
+    return [selectionStart, selectionEnd];
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Snapshot every text field under `root`, plus the caret, if focus is currently
+ * inside `root`.
+ */
+export function captureFormDraft(root: ParentNode): FormDraft {
+  const values = new Map<string, string>();
+  const active = typeof document === 'undefined' ? null : document.activeElement;
+  let focusKey: string | null = null;
+  let selection: readonly [number, number] | null = null;
+  for (const el of root.querySelectorAll('input, textarea')) {
+    if (!isDraftField(el)) continue;
+    const key = draftKey(el);
+    // First writer wins: a duplicate id restores through one querySelector
+    // anyway, so recording the later one would write the wrong value back.
+    if (key === null || values.has(key)) continue;
+    values.set(key, el.value);
+    if (el === active) {
+      focusKey = key;
+      selection = readSelection(el);
+    }
+  }
+  return { values, focusKey, selection };
+}
+
+/**
+ * Write a captured draft back into the rebuilt DOM. Fields the rebuild dropped
+ * (a tab switched, a form went read-only) are skipped, never recreated.
+ */
+export function restoreFormDraft(root: ParentNode, draft: FormDraft): void {
+  for (const [key, value] of draft.values) {
+    const el = root.querySelector(key);
+    if (el && isDraftField(el)) el.value = value;
+  }
+  if (draft.focusKey === null) return;
+  const target = root.querySelector(draft.focusKey);
+  if (!target || !isDraftField(target)) return;
+  target.focus();
+  if (draft.selection === null) return;
+  try {
+    target.setSelectionRange(draft.selection[0], draft.selection[1]);
+  } catch {
+    // A number input refuses a selection range; the value is already restored.
+  }
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -5033,7 +5033,10 @@ export class Hud {
     });
     this.refreshKeybindLabels();
     this.updateQuestTracker();
-    this.updateDelveTracker();
+    // NOT updateDelveTracker(): the tracker's own signature is ids + numbers, so
+    // a plain update() early-returns here and re-emits nothing. relocalize()
+    // clears it for exactly one rebuild (#2529).
+    this.delveTracker.relocalize();
     // The keyed-pool party rows reuse their DOM, so a rebuild never re-runs t() on
     // their badge tooltips / leave label; re-localize them in place on a switch.
     this.partyFramesPainter.relocalize();
@@ -5086,6 +5089,20 @@ export class Hud {
     this.vcupBriefing.relocalize();
     this.vcupCharge.relocalize();
     this.questDialog.relocalize();
+    // Same text-independent-sig contract, one surface at a time (#2529). Every
+    // one of these was rebuilding only when its own data moved, so an open one
+    // kept the previous locale until the player happened to change something.
+    // Each relocalize() is self-gated on its own window being open.
+    this.calendarWindow.relocalize();
+    this.mailboxWindow.relocalize();
+    this.socialWindow.relocalize();
+    this.cardDuelWindow.relocalize();
+    this.spellbookWindow.relocalize();
+    this.lockpickController.relocalize();
+    this.tutorial.relocalize(this.sim, this.keybinds);
+    // The ring latches its page indicator on the page/count pair; dropping the
+    // latch relabels it on the next paint (mobile layouts only build the ring).
+    this.mobileActionRingPainter?.relocalize();
   }
 
   // Prefers the live resolved entry when the player already knows it (rank +

--- a/src/ui/hud/action_bar/mobile_action_ring_painter.ts
+++ b/src/ui/hud/action_bar/mobile_action_ring_painter.ts
@@ -50,6 +50,17 @@ export class MobileActionRingPainter {
    *  rebuild + write entirely on an unchanged page). The toggle's aria-label is
    *  the static "Switch action page" action name (its purpose never changes);
    *  the indicator span shows the dynamic "Page X of Y" text. */
+  /** Re-localize after an in-game language switch (the Hud's woc:languagechange
+   *  fan-out). Both elided writes above are keyed on the page/count pair, which
+   *  is two integers, so a switch alone never moves them and the ring would keep
+   *  the old locale's "Page X of Y" and toggle name. Dropping the latch makes the
+   *  NEXT paint rewrite both, the same in-place shape the party rows use (there
+   *  is no state to paint from here: the descriptor arrives per call). */
+  relocalize(): void {
+    this.lastPage = -1;
+    this.lastPageCount = -1;
+  }
+
   paint(
     state: ActionBarState,
     page: number,

--- a/src/ui/hud/action_bar/mobile_action_ring_painter.ts
+++ b/src/ui/hud/action_bar/mobile_action_ring_painter.ts
@@ -50,17 +50,6 @@ export class MobileActionRingPainter {
    *  rebuild + write entirely on an unchanged page). The toggle's aria-label is
    *  the static "Switch action page" action name (its purpose never changes);
    *  the indicator span shows the dynamic "Page X of Y" text. */
-  /** Re-localize after an in-game language switch (the Hud's woc:languagechange
-   *  fan-out). Both elided writes above are keyed on the page/count pair, which
-   *  is two integers, so a switch alone never moves them and the ring would keep
-   *  the old locale's "Page X of Y" and toggle name. Dropping the latch makes the
-   *  NEXT paint rewrite both, the same in-place shape the party rows use (there
-   *  is no state to paint from here: the descriptor arrives per call). */
-  relocalize(): void {
-    this.lastPage = -1;
-    this.lastPageCount = -1;
-  }
-
   paint(
     state: ActionBarState,
     page: number,
@@ -98,5 +87,17 @@ export class MobileActionRingPainter {
         this.t(PAGE_TOGGLE_ARIA_KEY),
       );
     }
+  }
+
+  /** Re-localize after an in-game language switch (the Hud's woc:languagechange
+   *  fan-out). Both writes at the end of paint() are keyed on the page/count
+   *  pair, which is two integers, so a switch alone never moves them and the ring
+   *  would keep the old locale's "Page X of Y" and toggle name. Dropping the
+   *  latch makes the NEXT paint rewrite both, the same in-place shape the party
+   *  rows use; there is nothing to repaint from here, since the page and count
+   *  arrive per call rather than being retained. */
+  relocalize(): void {
+    this.lastPage = -1;
+    this.lastPageCount = -1;
   }
 }

--- a/src/ui/hud/delve/delve_tracker_controller.ts
+++ b/src/ui/hud/delve/delve_tracker_controller.ts
@@ -30,8 +30,19 @@ export class DelveTrackerController {
 
   constructor(private readonly deps: DelveTrackerControllerDeps) {}
 
-  invalidate(): void {
+  /**
+   * Re-localize after an in-game language switch (the Hud's woc:languagechange
+   * fan-out). Every member of the signature below is an id, a number or a
+   * boolean, so setLanguage alone never moves it and a plain update() from the
+   * fan-out early-returns with the old locale still on screen. Clearing forces
+   * exactly one rebuild, which re-latches the signature in the same call.
+   *
+   * Needs no open check: update() paints only while a delve run exists and
+   * clears the strip when it does not.
+   */
+  relocalize(): void {
     this.lastSignature = '';
+    this.update();
   }
 
   update(): void {

--- a/src/ui/hud/delve/lockpick_controller.ts
+++ b/src/ui/hud/delve/lockpick_controller.ts
@@ -64,6 +64,12 @@ export class LockpickController {
     this.window.repaintIfChanged();
   }
 
+  /** Re-localize the open lock board after an in-game language switch (the Hud's
+   *  woc:languagechange fan-out). Self-gated inside the window. */
+  relocalize(): void {
+    this.window.relocalize();
+  }
+
   end(outcome: 'success' | 'fail' | 'abandoned', tier?: LootTier): void {
     const summary =
       outcome === 'success'

--- a/src/ui/hud/delve/lockpick_window.ts
+++ b/src/ui/hud/delve/lockpick_window.ts
@@ -170,6 +170,24 @@ export class LockpickWindow {
     this.syncTimer();
   }
 
+  /**
+   * Re-localize after an in-game language switch (the Hud's woc:languagechange
+   * fan-out). Self-gated on the panel being up with a live session, so the
+   * fan-out can call it unconditionally.
+   *
+   * lockpickRenderSig is rows, columns, tries and the pick position, all
+   * numbers, so a switch alone never moves it and the per-frame
+   * repaintIfChanged above would leave the board's labels in the old locale.
+   * Clearing forces exactly one renderBoard, which re-latches the signature in
+   * the same call.
+   */
+  relocalize(): void {
+    if (this.panel()?.style.display !== 'block') return;
+    if (!this.deps.getState()) return;
+    this.lastSig = '';
+    this.repaintIfChanged();
+  }
+
   /** Refill the per-page clock whenever the timed move changes (a new pin, try,
    * page, or session); stop it when the lock ends. State-driven so a correct move
    * ALWAYS rewinds the clock to full, regardless of how/when events were drained. */

--- a/src/ui/hud/delve/lockpick_window.ts
+++ b/src/ui/hud/delve/lockpick_window.ts
@@ -72,6 +72,14 @@ export class LockpickWindow {
   private timerInterval: number | null = null;
   private lastSig = '';
   private lastTimerKey = '';
+  // The ante selector's own inputs, retained only so a language switch can
+  // repaint it (see renderAnte); null whenever the selector is not what the
+  // panel is showing.
+  private ante: { objectId: number; coffer: boolean } | null = null;
+  // The live clock's deadline, retained so a rebuild that does NOT restart the
+  // clock can still paint the bar at where the clock actually is (see
+  // relocalize); null whenever no clock is running.
+  private timerDeadline: { end: number; seconds: number } | null = null;
   // The countdown's element refs, and the urgent-class latch that rides with them.
   //
   // RESOLVED PER BOARD PAINT, not once at construction, and that distinction is the whole
@@ -98,6 +106,12 @@ export class LockpickWindow {
   renderAnte(objectId: number, coffer: boolean): void {
     const el = this.panel();
     if (!el) return;
+    // Retained so relocalize() can repaint this half of the panel. The ante
+    // selector is the state where getState() is still null (the player opened
+    // the chest and has not picked an ante yet), so the board path below cannot
+    // reach it, and a language switch spent staring at the selector would
+    // otherwise leave every one of its labels in the old locale.
+    this.ante = { objectId, coffer };
     this.lastSig = '';
     const buttons = anteOptions(coffer)
       .map(
@@ -172,20 +186,36 @@ export class LockpickWindow {
 
   /**
    * Re-localize after an in-game language switch (the Hud's woc:languagechange
-   * fan-out). Self-gated on the panel being up with a live session, so the
-   * fan-out can call it unconditionally.
+   * fan-out). Self-gated on the panel being up, so the fan-out can call it
+   * unconditionally.
    *
-   * lockpickRenderSig is rows, columns, tries and the pick position, all
-   * numbers, so a switch alone never moves it and the per-frame
-   * repaintIfChanged above would leave the board's labels in the old locale.
-   * Clearing forces exactly one renderBoard, which re-latches the signature in
-   * the same call.
+   * BOTH halves of the panel need it, and they need different treatment.
+   * The board's lockpickRenderSig is rows, columns, tries and the pick position,
+   * all numbers, so a switch alone never moves it and the per-frame
+   * repaintIfChanged above would leave the board in the old locale; clearing
+   * forces exactly one renderBoard, which re-latches the signature in the same
+   * call. The ante selector has no signature and no driver at all: it is painted
+   * once by openAnte and sits there until the player chooses, so it repaints
+   * straight from its retained inputs.
    */
   relocalize(): void {
     if (this.panel()?.style.display !== 'block') return;
-    if (!this.deps.getState()) return;
+    if (!this.deps.getState()) {
+      if (this.ante) this.renderAnte(this.ante.objectId, this.ante.coffer);
+      return;
+    }
     this.lastSig = '';
     this.repaintIfChanged();
+    // renderBoard re-emits the countdown at width:100% and the full-duration
+    // label, and syncTimer correctly does NOT restart the clock (the timer key
+    // did not move), so without this the bar would read a full budget until the
+    // running interval's next tick. That is up to 100 ms of a TIMED minigame
+    // showing the wrong remaining time, which is not something a cosmetic
+    // repaint is allowed to do.
+    const clock = this.timerDeadline;
+    if (clock) {
+      this.paintTimer(Math.max(0, (clock.end - performance.now()) / 1000), clock.seconds);
+    }
   }
 
   /** Refill the per-page clock whenever the timed move changes (a new pin, try,
@@ -220,6 +250,10 @@ export class LockpickWindow {
       return;
     }
     this.lastSig = lockpickRenderSig(view);
+    // The board markup replaces the ante selector's, so the retained selector
+    // inputs stop being what the panel shows here (a stale pair would let a
+    // relocalize repaint the selector back over a live board).
+    this.ante = null;
     const m = lockpickBoardModel(view);
     const rowH = (r: number): string => `${(r / Math.max(1, m.h - 1)) * 100}%`;
     // Tumbler tracks: one brass column per lock column. Only lit wards (open /
@@ -343,6 +377,7 @@ export class LockpickWindow {
       this.timerInterval = null;
     }
     const end = performance.now() + seconds * 1000;
+    this.timerDeadline = { end, seconds };
     this.paintTimer(seconds, seconds);
     this.timerInterval = window.setInterval(() => {
       if (gen !== this.timerGen) return; // superseded by a newer clock
@@ -355,6 +390,7 @@ export class LockpickWindow {
   /** Stop the clock and invalidate any in-flight callback. */
   stopTimer(): void {
     this.timerGen++;
+    this.timerDeadline = null;
     if (this.timerInterval !== null) {
       clearInterval(this.timerInterval);
       this.timerInterval = null;
@@ -385,5 +421,6 @@ export class LockpickWindow {
     this.forgetTimerEls();
     this.lastSig = '';
     this.lastTimerKey = '';
+    this.ante = null;
   }
 }

--- a/src/ui/mailbox_window.ts
+++ b/src/ui/mailbox_window.ts
@@ -18,6 +18,7 @@ import type { IWorld } from '../world_api';
 import { markDialogRoot } from './dialog_root';
 import { itemDisplayName, tEntity } from './entity_i18n';
 import { esc } from './esc';
+import { captureFormDraft, restoreFormDraft } from './form_draft';
 import { formatMoney, formatNumber, t } from './i18n';
 import { QUALITY_COLOR } from './icons';
 import {
@@ -220,10 +221,46 @@ export class MailboxWindow {
       return;
     }
     if (this.tab === 'send') return; // typed inputs: rebuilt only on actions
-    const sig = JSON.stringify([this.tab, this.openedId, info.messages, info.unread]);
+    const sig = this.sig(info);
     if (sig === this.lastSig) return;
     this.lastSig = sig;
     this.render();
+  }
+
+  // The inbox repaint signature: the tab, the open letter, and the mail mirror.
+  // Ids and counts only, so a language switch alone can never move it, which is
+  // why relocalize() exists below.
+  private sig(info: NonNullable<IWorld['mailInfo']>): string {
+    return JSON.stringify([this.tab, this.openedId, info.messages, info.unread]);
+  }
+
+  /**
+   * Re-localize after an in-game language switch (the Hud's woc:languagechange
+   * fan-out). Self-gated on the open flag so the fan-out can call it
+   * unconditionally.
+   *
+   * The Send tab is the reason this cannot be a bare render(): renderSend
+   * rebuilds the form via innerHTML with an empty recipient, subject, body and
+   * zeroed coin fields, so the repaint that fixes the language would wipe a
+   * half-written letter. That is the same loss #1695 fixed for the parcel path,
+   * where the answer was to repaint less; a language switch cannot narrow that
+   * way, since every label in the window is what moved, so the draft is carried
+   * across the rebuild instead. The suggestion list needs no extra handling:
+   * renderSend clears the pending search and its timer itself.
+   *
+   * The signature is RE-LATCHED, not cleared, so the next slow tick early-returns
+   * instead of rebuilding a second time over the restored draft. It is skipped
+   * when the mail mirror is absent, since the sig is built from it and
+   * refreshIfChanged returns before reading it in that state.
+   */
+  relocalize(): void {
+    if (!this.opened) return;
+    const root = this.deps.root();
+    const draft = captureFormDraft(root);
+    this.render();
+    restoreFormDraft(root, draft);
+    const info = this.deps.world().mailInfo;
+    if (info) this.lastSig = this.sig(info);
   }
 
   private senderLabel(row: MailInboxRow): string {

--- a/src/ui/mailbox_window.ts
+++ b/src/ui/mailbox_window.ts
@@ -257,7 +257,7 @@ export class MailboxWindow {
     if (!this.opened) return;
     const root = this.deps.root();
     const draft = captureFormDraft(root);
-    this.render();
+    this.render({ revealBags: false });
     restoreFormDraft(root, draft);
     const info = this.deps.world().mailInfo;
     if (info) this.lastSig = this.sig(info);
@@ -273,7 +273,17 @@ export class MailboxWindow {
     return row.subject.length > 0 ? row.subject : t('hudChrome.mailbox.noSubject');
   }
 
-  render(): void {
+  /**
+   * Full rebuild of the window chrome plus its current tab.
+   *
+   * `revealBags` exists for the language fan-out and is the one thing a caller
+   * ever needs to turn off: the Send tab's paint normally REVEALS the bags
+   * window so parcels can be clicked straight onto the letter, and a language
+   * switch must not re-open a bags window the player deliberately closed. It is
+   * an argument rather than a mode flag on the instance so the decision is
+   * visible at the call site that makes it.
+   */
+  render({ revealBags = true }: { revealBags?: boolean } = {}): void {
     const el = this.deps.root();
     this.deps.hideTooltip();
     markDialogRoot(el, { label: t('hudChrome.mailbox.title') });
@@ -304,10 +314,10 @@ export class MailboxWindow {
         (this.deps.root().querySelector(`[data-tab="${next}"]`) as HTMLElement | null)?.focus();
       });
     });
-    this.renderContent();
+    this.renderContent(revealBags);
   }
 
-  private renderContent(): void {
+  private renderContent(revealBags: boolean): void {
     const body = this.deps.root().querySelector<HTMLElement>('#mailbox-body');
     if (!body) return;
     const view = buildMailboxView({
@@ -324,7 +334,7 @@ export class MailboxWindow {
       this.renderInbox(body, view.body);
       return;
     }
-    this.renderSend(body, view.body);
+    this.renderSend(body, view.body, revealBags);
   }
 
   private renderInbox(body: HTMLElement, view: MailInboxBody): void {
@@ -451,7 +461,7 @@ export class MailboxWindow {
     }
   }
 
-  private renderSend(body: HTMLElement, view: MailSendBody): void {
+  private renderSend(body: HTMLElement, view: MailSendBody, revealBags: boolean): void {
     window.clearTimeout(this.recipientSuggestTimer);
     this.recipientSuggest = { items: [], index: -1 };
     body.innerHTML =
@@ -480,7 +490,11 @@ export class MailboxWindow {
       `</div>`;
     this.renderParcels();
     // Bags ride alongside so parcels can be clicked straight onto the letter.
-    this.deps.syncBags(true);
+    // NOT on the relocalize path (revealBags false): syncBags(true) REVEALS the
+    // bags window, and a language switch must not re-open one the player closed.
+    // The fan-out re-renders an open bags window on its own arm, so an open one
+    // still lands in the new locale.
+    if (revealBags) this.deps.syncBags(true);
     // The coin inputs seed "0": select it on focus so typing replaces the value
     // (clicking into gold and typing 1 must mean 1g, not the 10 you get by
     // appending). The once-only mouseup swallow keeps the click-to-focus gesture

--- a/src/ui/social_window.ts
+++ b/src/ui/social_window.ts
@@ -27,6 +27,7 @@ import { deedTitleText } from './deed_i18n';
 import { markDialogRoot } from './dialog_root';
 import { classDisplayName } from './entity_i18n';
 import { esc } from './esc';
+import { captureFormDraft, restoreFormDraft } from './form_draft';
 import { loadGuildHideOffline, saveGuildHideOffline } from './guild_hide_offline';
 import { formatDateTime, formatNumber, t, tPlural } from './i18n';
 import { localizeZone } from './server_i18n';
@@ -196,6 +197,39 @@ export class SocialWindow {
         this.refreshList();
       }
     }
+  }
+
+  /**
+   * Re-localize after an in-game language switch (the Hud's woc:languagechange
+   * fan-out). Self-gated on isOpen so the fan-out can call it unconditionally.
+   *
+   * A full render() is what this needs and refreshList() is not a substitute:
+   * the panel title, the five tab labels and the footer's placeholders and
+   * button labels are all emitted by render(), which refreshList never reaches
+   * (it swaps `.soc-body` only). Three things have to survive that rebuild:
+   *   - the half-typed name in the tab's typeahead, emitted with no value;
+   *   - the guild billboard draft. refreshList protects it by reading the live
+   *     input, but render() destroys `.soc-body` BEFORE calling refreshList, so
+   *     by then there is nothing left to read. Capture happens first here.
+   *   - `this.suggest`, which render() strands: it destroys the `.soc-suggest`
+   *     listbox and leaves the field populated, so ArrowDown/Enter would act on
+   *     items no longer on screen. The pending search is dropped with the DOM
+   *     that showed it.
+   *
+   * Both signatures are RE-LATCHED rather than cleared: render() does not touch
+   * them, and clearing would buy a second full rebuild on the next slow tick
+   * that would wipe the draft this just restored.
+   */
+  relocalize(): void {
+    if (!this.isOpen) return;
+    const el = this.deps.root();
+    const draft = captureFormDraft(el);
+    window.clearTimeout(this.suggestTimer);
+    this.suggest = { field: '', items: [], index: -1 };
+    this.render();
+    restoreFormDraft(el, draft);
+    this.lastStruct = this.structSig();
+    this.lastContent = this.contentSig();
   }
 
   private structSig(): string {

--- a/src/ui/spellbook_window.ts
+++ b/src/ui/spellbook_window.ts
@@ -273,6 +273,22 @@ export class SpellbookWindow {
     this.refreshHotbarControlsIfChanged();
   }
 
+  /**
+   * Re-localize after an in-game language switch (the Hud's woc:languagechange
+   * fan-out). Self-gated on isOpen so the fan-out can call it unconditionally.
+   *
+   * tickOpen only rebuilds when a resolved ability's id, rank, cost, cast time
+   * or cooldown moved, and the hotbar toggles elide their accessible names on
+   * the on-bar state, all of it text-independent, so an open spellbook would
+   * otherwise keep the old locale until the player learned something. Goes
+   * through the scroll- and focus-preserving path for the same reason it exists:
+   * the list rebuild is an innerHTML write on the scroll container.
+   */
+  relocalize(): void {
+    if (!this.isOpen) return;
+    this.rerenderPreservingView();
+  }
+
   // render() rebuilds the list via innerHTML, and the window root is the scroll
   // container, so a mid-session rebuild would jump the scroll to top and drop the
   // keyboard user's focus. Preserve both across the talent-driven rebuild: capture

--- a/src/ui/tutorial.ts
+++ b/src/ui/tutorial.ts
@@ -163,6 +163,11 @@ export class TutorialOverlay {
    */
   relocalize(world: IWorld, keybinds: Keybinds): void {
     if (this.completed || !this.engaged || this.step === null) return;
+    // The same defense update() and isFreshCharacter take: player is typed as an
+    // Entity but is absent in the online pre-snapshot window, and renderPanel
+    // reads player.name. A throw here would unwind the whole fan-out and skip
+    // every arm after this one.
+    if (!world.player) return;
     this.renderPanel(world, keybinds);
   }
 

--- a/src/ui/tutorial.ts
+++ b/src/ui/tutorial.ts
@@ -151,6 +151,21 @@ export class TutorialOverlay {
     this.updateArrow(world, renderer);
   }
 
+  /**
+   * Re-localize after an in-game language switch (the Hud's woc:languagechange
+   * fan-out). Self-gated on there being a card on screen, so the fan-out can
+   * call it unconditionally.
+   *
+   * update() repaints only when the STEP changes or Interface Mode flips, so a
+   * card that is already up would keep its old-locale copy for the whole step.
+   * Takes the world and keybinds the same way update() does, since the card's
+   * copy interpolates the live keybind labels and the player's name.
+   */
+  relocalize(world: IWorld, keybinds: Keybinds): void {
+    if (this.completed || !this.engaged || this.step === null) return;
+    this.renderPanel(world, keybinds);
+  }
+
   // ---- internals --------------------------------------------------------
 
   private findEntity(world: IWorld, kind: string, templateId: string) {

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -1040,6 +1040,7 @@ const UI_DOM_MODULES = [
   'src/ui/discord_widget.ts',
   'src/ui/entry_guard_banner.ts',
   'src/ui/focus_manager.ts',
+  'src/ui/form_draft.ts',
   'src/ui/gather_node_tooltip.ts',
   'src/ui/gpu_notice_toast.ts',
   'src/ui/hud.ts',

--- a/tests/form_draft.test.ts
+++ b/tests/form_draft.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+
+// The draft carrier three windows use to survive the woc:languagechange rebuild
+// (#2529). The windows' own arms in language_fanout_relocalize.test.ts prove the
+// happy path end to end; what is pinned here is the behavior at the edges, where
+// getting it wrong is silent: a key that is not stable, a field whose `.value` is
+// not its state, a focus restore that fires when focus was somewhere else, and a
+// number input that throws on a selection range.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { captureFormDraft, restoreFormDraft } from '../src/ui/form_draft';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+function mount(html: string): HTMLElement {
+  const root = document.createElement('div');
+  root.innerHTML = html;
+  document.body.appendChild(root);
+  return root;
+}
+
+describe('form_draft: what it carries', () => {
+  it('captures text inputs and textareas by id and by data-field', () => {
+    const root = mount(
+      '<input id="a" type="text"><textarea id="b"></textarea><input data-field="c">',
+    );
+    (root.querySelector<HTMLInputElement>('#a') as HTMLInputElement).value = 'one';
+    (root.querySelector<HTMLTextAreaElement>('#b') as HTMLTextAreaElement).value = 'two';
+    (root.querySelector<HTMLInputElement>('[data-field="c"]') as HTMLInputElement).value = 'three';
+    const draft = captureFormDraft(root);
+
+    // The rebuild: same fields, all emitted empty, exactly as innerHTML does it.
+    root.innerHTML = '<input id="a" type="text"><textarea id="b"></textarea><input data-field="c">';
+    restoreFormDraft(root, draft);
+
+    expect(root.querySelector<HTMLInputElement>('#a')?.value).toBe('one');
+    expect(root.querySelector<HTMLTextAreaElement>('#b')?.value).toBe('two');
+    expect(root.querySelector<HTMLInputElement>('[data-field="c"]')?.value).toBe('three');
+  });
+
+  it('prefers the id when a field carries both, so one key finds it again', () => {
+    const root = mount('<input id="a" data-field="other">');
+    (root.querySelector<HTMLInputElement>('#a') as HTMLInputElement).value = 'kept';
+    const draft = captureFormDraft(root);
+    expect([...draft.values.keys()]).toEqual(['#a']);
+  });
+
+  it('skips a field with no stable key rather than guessing at its position', () => {
+    const root = mount('<input type="text"><input id="a" type="text">');
+    root.querySelectorAll('input')[0].value = 'anonymous';
+    (root.querySelector<HTMLInputElement>('#a') as HTMLInputElement).value = 'named';
+    const draft = captureFormDraft(root);
+    expect([...draft.values.keys()]).toEqual(['#a']);
+
+    // Rebuilt in the OTHER order: an index-keyed restore would put "named" into
+    // the anonymous field. Keying on identity cannot.
+    root.innerHTML = '<input id="a" type="text"><input type="text">';
+    restoreFormDraft(root, draft);
+    expect(root.querySelector<HTMLInputElement>('#a')?.value).toBe('named');
+    expect(root.querySelectorAll('input')[1].value).toBe('');
+  });
+
+  it('leaves a checkbox alone: its state is .checked, not .value', () => {
+    const root = mount('<input id="a" type="checkbox" value="on">');
+    const box = root.querySelector<HTMLInputElement>('#a') as HTMLInputElement;
+    box.checked = true;
+    const draft = captureFormDraft(root);
+    expect(draft.values.size).toBe(0);
+  });
+
+  it('carries a number input, which the coin and hour fields are', () => {
+    const root = mount('<input id="g" type="number" value="0">');
+    (root.querySelector<HTMLInputElement>('#g') as HTMLInputElement).value = '42';
+    const draft = captureFormDraft(root);
+    root.innerHTML = '<input id="g" type="number" value="0">';
+    restoreFormDraft(root, draft);
+    expect(root.querySelector<HTMLInputElement>('#g')?.value).toBe('42');
+  });
+
+  it('records the first of two fields sharing a key, the one a restore would find', () => {
+    const root = mount('<input id="dup" type="text"><input id="dup" type="text">');
+    const inputs = root.querySelectorAll<HTMLInputElement>('input');
+    inputs[0].value = 'first';
+    inputs[1].value = 'second';
+    expect(captureFormDraft(root).values.get('#dup')).toBe('first');
+  });
+
+  it('drops a field the rebuild did not bring back rather than recreating it', () => {
+    const root = mount('<input id="a" type="text">');
+    (root.querySelector<HTMLInputElement>('#a') as HTMLInputElement).value = 'gone';
+    const draft = captureFormDraft(root);
+    root.innerHTML = '<div>read only now</div>';
+    expect(() => restoreFormDraft(root, draft)).not.toThrow();
+    expect(root.querySelector('#a')).toBeNull();
+  });
+});
+
+describe('form_draft: focus', () => {
+  it('restores focus and the caret when focus was inside the root', () => {
+    const root = mount('<input id="a" type="text">');
+    const input = root.querySelector<HTMLInputElement>('#a') as HTMLInputElement;
+    input.value = 'Mirabel';
+    input.focus();
+    input.setSelectionRange(3, 5);
+    const draft = captureFormDraft(root);
+    expect(draft.focusKey).toBe('#a');
+
+    root.innerHTML = '<input id="a" type="text">';
+    restoreFormDraft(root, draft);
+    const rebuilt = root.querySelector<HTMLInputElement>('#a') as HTMLInputElement;
+    expect(document.activeElement).toBe(rebuilt);
+    expect([rebuilt.selectionStart, rebuilt.selectionEnd]).toEqual([3, 5]);
+  });
+
+  it('does NOT steal focus when the player was typing somewhere else', () => {
+    // The live case: the language picker is in the Options window, so at the
+    // moment of the switch focus is over there, and yanking the caret into a
+    // mailbox field would be worse than the stale label.
+    const root = mount('<input id="a" type="text">');
+    (root.querySelector<HTMLInputElement>('#a') as HTMLInputElement).value = 'draft';
+    const elsewhere = document.createElement('input');
+    document.body.appendChild(elsewhere);
+    elsewhere.focus();
+
+    const draft = captureFormDraft(root);
+    expect(draft.focusKey).toBeNull();
+    root.innerHTML = '<input id="a" type="text">';
+    restoreFormDraft(root, draft);
+
+    expect(root.querySelector<HTMLInputElement>('#a')?.value).toBe('draft');
+    expect(document.activeElement).toBe(elsewhere);
+  });
+
+  it('survives a focused number input, whose selection range the DOM refuses', () => {
+    const root = mount('<input id="g" type="number" value="0">');
+    const input = root.querySelector<HTMLInputElement>('#g') as HTMLInputElement;
+    input.value = '9';
+    input.focus();
+    // Chromium and Firefox throw InvalidStateError on both of these for a
+    // number input; jsdom reports null instead, so force the throwing shape.
+    Object.defineProperty(input, 'selectionStart', {
+      get() {
+        throw new DOMException('not a text input', 'InvalidStateError');
+      },
+    });
+    const draft = captureFormDraft(root);
+    expect(draft.focusKey).toBe('#g');
+    expect(draft.selection).toBeNull();
+
+    root.innerHTML = '<input id="g" type="number" value="0">';
+    const rebuilt = root.querySelector<HTMLInputElement>('#g') as HTMLInputElement;
+    rebuilt.setSelectionRange = () => {
+      throw new DOMException('not a text input', 'InvalidStateError');
+    };
+    expect(() => restoreFormDraft(root, { ...draft, selection: [0, 1] })).not.toThrow();
+    expect(rebuilt.value).toBe('9');
+  });
+});

--- a/tests/form_draft.test.ts
+++ b/tests/form_draft.test.ts
@@ -44,7 +44,7 @@ describe('form_draft: what it carries', () => {
     const root = mount('<input id="a" data-field="other">');
     (root.querySelector<HTMLInputElement>('#a') as HTMLInputElement).value = 'kept';
     const draft = captureFormDraft(root);
-    expect([...draft.values.keys()]).toEqual(['#a']);
+    expect([...draft.values.keys()]).toEqual(['[id="a"]']);
   });
 
   it('skips a field with no stable key rather than guessing at its position', () => {
@@ -52,7 +52,7 @@ describe('form_draft: what it carries', () => {
     root.querySelectorAll('input')[0].value = 'anonymous';
     (root.querySelector<HTMLInputElement>('#a') as HTMLInputElement).value = 'named';
     const draft = captureFormDraft(root);
-    expect([...draft.values.keys()]).toEqual(['#a']);
+    expect([...draft.values.keys()]).toEqual(['[id="a"]']);
 
     // Rebuilt in the OTHER order: an index-keyed restore would put "named" into
     // the anonymous field. Keying on identity cannot.
@@ -84,7 +84,38 @@ describe('form_draft: what it carries', () => {
     const inputs = root.querySelectorAll<HTMLInputElement>('input');
     inputs[0].value = 'first';
     inputs[1].value = 'second';
-    expect(captureFormDraft(root).values.get('#dup')).toBe('first');
+    expect(captureFormDraft(root).values.get('[id="dup"]')).toBe('first');
+  });
+
+  it('survives an id and a data-field that are not legal CSS identifiers', () => {
+    // A leading digit is a legal HTML id and an ILLEGAL CSS identifier, so an
+    // unescaped `#2fa` makes querySelector throw SyntaxError, and that throw
+    // would unwind out of relocalize and take the rest of the language fan-out
+    // with it. Same for a quote or a bracket inside a data-field value.
+    const root = mount('<input id="2fa" type="text"><input data-field=\'a"b]c\' type="text">');
+    (root.querySelector<HTMLInputElement>('input') as HTMLInputElement).value = 'code';
+    (root.querySelectorAll<HTMLInputElement>('input')[1] as HTMLInputElement).value = 'odd';
+    const draft = captureFormDraft(root);
+    expect(draft.values.size).toBe(2);
+
+    root.innerHTML = '<input id="2fa" type="text"><input data-field=\'a"b]c\' type="text">';
+    expect(() => restoreFormDraft(root, draft)).not.toThrow();
+    const rebuilt = root.querySelectorAll<HTMLInputElement>('input');
+    expect(rebuilt[0].value).toBe('code');
+    expect(rebuilt[1].value).toBe('odd');
+  });
+
+  it('falls back to a data attribute of any name, including a valueless one', () => {
+    // The windows key their controls on whatever data-* they already carry
+    // (data-tab, data-cal-day, data-close), not on data-field specifically.
+    const root = mount('<button data-close>x</button><input data-cal-day="2026-07-27">');
+    (root.querySelector<HTMLInputElement>('[data-cal-day]') as HTMLInputElement).value = 'noted';
+    const draft = captureFormDraft(root);
+    expect([...draft.values.keys()]).toEqual(['[data-cal-day="2026-07-27"]']);
+
+    root.innerHTML = '<button data-close>x</button><input data-cal-day="2026-07-27">';
+    restoreFormDraft(root, draft);
+    expect(root.querySelector<HTMLInputElement>('[data-cal-day]')?.value).toBe('noted');
   });
 
   it('drops a field the rebuild did not bring back rather than recreating it', () => {
@@ -94,6 +125,17 @@ describe('form_draft: what it carries', () => {
     root.innerHTML = '<div>read only now</div>';
     expect(() => restoreFormDraft(root, draft)).not.toThrow();
     expect(root.querySelector('#a')).toBeNull();
+  });
+
+  it('does not write a value onto a DIFFERENT element that reused the key', () => {
+    const root = mount('<input id="a" type="text">');
+    (root.querySelector<HTMLInputElement>('#a') as HTMLInputElement).value = 'typed';
+    const draft = captureFormDraft(root);
+    // The rebuild turned the editable field into read-only markup under the same
+    // id (the calendar does exactly this when management rights drop).
+    root.innerHTML = '<div id="a">read only now</div>';
+    restoreFormDraft(root, draft);
+    expect(root.querySelector('#a')?.textContent).toBe('read only now');
   });
 });
 
@@ -105,13 +147,29 @@ describe('form_draft: focus', () => {
     input.focus();
     input.setSelectionRange(3, 5);
     const draft = captureFormDraft(root);
-    expect(draft.focusKey).toBe('#a');
+    expect(draft.focusKey).toBe('[id="a"]');
 
     root.innerHTML = '<input id="a" type="text">';
     restoreFormDraft(root, draft);
     const rebuilt = root.querySelector<HTMLInputElement>('#a') as HTMLInputElement;
     expect(document.activeElement).toBe(rebuilt);
     expect([rebuilt.selectionStart, rebuilt.selectionEnd]).toEqual([3, 5]);
+  });
+
+  it('restores focus to a BUTTON, not only to a text field', () => {
+    // These windows install a Tab trap that only arms while focus is inside the
+    // root, so a rebuild that dropped focus to <body> would let the next Tab
+    // walk the player straight out of an open dialog.
+    const root = mount('<button data-tab="send">Send</button><input id="a" type="text">');
+    const button = root.querySelector('button') as HTMLButtonElement;
+    button.focus();
+    const draft = captureFormDraft(root);
+    expect(draft.focusKey).toBe('[data-tab="send"]');
+    expect(draft.selection, 'a button has no caret to record').toBeNull();
+
+    root.innerHTML = '<button data-tab="send">Enviar</button><input id="a" type="text">';
+    restoreFormDraft(root, draft);
+    expect(document.activeElement).toBe(root.querySelector('button'));
   });
 
   it('does NOT steal focus when the player was typing somewhere else', () => {
@@ -133,6 +191,27 @@ describe('form_draft: focus', () => {
     expect(document.activeElement).toBe(elsewhere);
   });
 
+  it('leaves focus alone when the rebuild dropped the field that had it', () => {
+    const root = mount('<input id="a" type="text">');
+    const input = root.querySelector<HTMLInputElement>('#a') as HTMLInputElement;
+    input.focus();
+    const draft = captureFormDraft(root);
+    root.innerHTML = '<div>gone</div>';
+    expect(() => restoreFormDraft(root, draft)).not.toThrow();
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it('records no caret for a number input, the shape the DOM reports as null', () => {
+    // The everyday jsdom/browser shape for a non-text input, distinct from the
+    // throwing shape below: selectionStart simply reads null.
+    const root = mount('<input id="g" type="number" value="0">');
+    const input = root.querySelector<HTMLInputElement>('#g') as HTMLInputElement;
+    input.focus();
+    const draft = captureFormDraft(root);
+    expect(draft.focusKey).toBe('[id="g"]');
+    expect(draft.selection).toBeNull();
+  });
+
   it('survives a focused number input, whose selection range the DOM refuses', () => {
     const root = mount('<input id="g" type="number" value="0">');
     const input = root.querySelector<HTMLInputElement>('#g') as HTMLInputElement;
@@ -146,7 +225,7 @@ describe('form_draft: focus', () => {
       },
     });
     const draft = captureFormDraft(root);
-    expect(draft.focusKey).toBe('#g');
+    expect(draft.focusKey).toBe('[id="g"]');
     expect(draft.selection).toBeNull();
 
     root.innerHTML = '<input id="g" type="number" value="0">';

--- a/tests/language_fanout_registry.test.ts
+++ b/tests/language_fanout_registry.test.ts
@@ -47,6 +47,15 @@
 //   - Neither half says anything about a COLD window (rendered on open, no
 //     repaint driver at all). That is a different gap with a different answer
 //     and it is not what #2529 is about.
+//   - Half 1 registers STATEMENT-position calls. An arm added inside a callback
+//     (`queueMicrotask(() => this.foo.relocalize())`) is invisible to it, though
+//     deleting a registered arm is still caught.
+//   - The memo sweep requires the literal `private` modifier and a `this.`
+//     receiver, so a module-scoped `let lastSig` or a `#lastSig` would escape
+//     it. There is no such module in `src/ui` today; if one lands, widen
+//     MEMO_DECL rather than exempting the file.
+//   - The sweep covers `src/ui` only. A signature-gated text surface under
+//     `src/render/` would have to be caught in review.
 
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -306,16 +315,42 @@ const ANSWERED: readonly AnsweredSurface[] = [
  * guard green without fixing anything, so each one names the memo's contents
  * and says what moves it when the locale moves.
  */
-const NOT_A_LANGUAGE_GATE: Readonly<Record<string, string>> = {
-  'claudium_window.ts':
-    'paintedWalletMarkup retains the RESOLVED wallet markup and is compared against a freshly built walletConnectionHtml(), so a locale change moves both sides of the comparison and the repaint happens by itself. It is a write-elision memo, not a data signature.',
-  'daily_rewards_window.ts':
-    'paintedStoreBody / paintedStoreMarkup retain the RESOLVED store markup and the element it was written into, compared against freshly built markup in replaceStoreBody, so a locale change produces different markup and repaints. Same write-elision shape as claudium_window.',
-  'deed_tracker_painter.ts':
-    'lastChip gates only the header ARIA presence swap (aria-expanded / aria-controls / aria-haspopup), which carries no player-visible text. Every string in this painter goes through the elided writer facet, which compares resolved text, and the fan-out drives it through this.updateDeedTracker.',
-  'hud.ts':
-    'the coordinator itself. Its own signature-gated arms are individually answered inside refreshLocalizedDynamicUi, which half 1 above pins EXACTLY, so pinning its memo list here as well would only mean every unrelated hud.ts memo edit had to be re-approved in two places.',
-};
+const NOT_A_LANGUAGE_GATE: ReadonlyArray<{
+  readonly file: string;
+  /**
+   * The memos the exemption was argued about, or 'coordinator' for hud.ts. Pinned
+   * for the same reason the ANSWERED rows are: an exemption is granted about
+   * SPECIFIC fields, and a module that later grows a real data signature must
+   * not inherit an answer that was given about a different one.
+   */
+  readonly memos: readonly string[] | 'coordinator';
+  readonly reason: string;
+}> = [
+  {
+    file: 'claudium_window.ts',
+    memos: ['paintedWalletMarkup'],
+    reason:
+      'paintedWalletMarkup retains the RESOLVED wallet markup and is compared against a freshly built walletConnectionHtml(), so a locale change moves both sides of the comparison and the repaint happens by itself. It is a write-elision memo, not a data signature.',
+  },
+  {
+    file: 'daily_rewards_window.ts',
+    memos: ['paintedStoreBody', 'paintedStoreMarkup'],
+    reason:
+      'paintedStoreBody / paintedStoreMarkup retain the RESOLVED store markup and the element it was written into, compared against freshly built markup in replaceStoreBody, so a locale change produces different markup and repaints. Same write-elision shape as claudium_window.',
+  },
+  {
+    file: 'deed_tracker_painter.ts',
+    memos: ['lastChip'],
+    reason:
+      'lastChip gates only the header ARIA presence swap (aria-expanded / aria-controls / aria-haspopup), which carries no player-visible text. Every string in this painter goes through the elided writer facet, which compares resolved text, and the fan-out drives it through this.updateDeedTracker.',
+  },
+  {
+    file: 'hud.ts',
+    memos: 'coordinator',
+    reason:
+      'the coordinator itself. Its own signature-gated arms are individually answered inside refreshLocalizedDynamicUi, which half 1 above pins EXACTLY, so pinning its two dozen unrelated memos here as well would only mean every hud.ts edit had to be re-approved in two places.',
+  },
+];
 
 // ---------------------------------------------------------------------------
 
@@ -326,6 +361,14 @@ describe('language fan-out: half 1, the arms of refreshLocalizedDynamicUi', () =
     // come back short: a walk that stopped parsing part way down the body.
     expect(scan.classMembers, 'the Hud class shrank past recognition').toBeGreaterThan(600);
     expect(observedArms.length, 'the fan-out walk came back short').toBeGreaterThan(30);
+  });
+
+  it('still has a producer for the event the whole fan-out hangs off', () => {
+    // Nothing else pins this, and the entire feature is dead without it: the
+    // listener below would be green while no switch ever reached it.
+    const main = stripComments(readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8'));
+    expect(main).toContain("document.dispatchEvent(new CustomEvent('woc:languagechange'");
+    expect(main).toContain('async function changeLanguage(');
   });
 
   it('wires the fan-out to the woc:languagechange event exactly once', () => {
@@ -364,11 +407,42 @@ describe('language fan-out: half 2, every signature-gated src/ui surface is clas
     expectScansOnlyThroughSharedWalkers(import.meta.url, ['ts_files_under']);
   });
 
+  // The corpus does not currently exercise every alternate in the two matchers
+  // (no discovered module is found ONLY by `prev`, `tPlural(` or `tEntity(`), so
+  // a narrowing that dropped one would pass every corpus assertion. Pin the
+  // matchers' own contract directly instead of pretending the tree covers it.
+  it('keeps every alternate in both matchers live', () => {
+    for (const decl of [
+      '  private lastSig = 1;',
+      '  private prevSkills = 1;',
+      '  private knownIds = [];',
+      '  private paintedMarkup = 1;',
+      '  private readonly lastKey = 1;',
+    ]) {
+      expect(new RegExp(MEMO_DECL.source).test(decl), `MEMO_DECL missed ${decl}`).toBe(true);
+    }
+    for (const decl of ['  private lastsig = 1;', '  lastSig = 1;', '  private sig = 1;']) {
+      expect(new RegExp(MEMO_DECL.source).test(decl), `MEMO_DECL over-matched ${decl}`).toBe(false);
+    }
+    for (const call of ["t('a.b')", "tPlural('a.b', 2)", "tEntity({ kind: 'x' })"]) {
+      expect(EMITS_TEXT.test(call), `EMITS_TEXT missed ${call}`).toBe(true);
+    }
+    // A word ending in `t` before a paren is the over-match to stay clear of.
+    for (const call of ['arr.at(3)', 'print(x)', 'format(x)']) {
+      expect(EMITS_TEXT.test(call), `EMITS_TEXT over-matched ${call}`).toBe(false);
+    }
+  });
+
   it('swept a real corpus (non-vacuity)', () => {
+    // src/ui is the one DEEP scan root in this repo, so the floor has to sit
+    // above what a NON-recursive read returns (about 300 top-level files today)
+    // or it cannot detect the failure its own message names.
+    const corpus = tsFilesUnder(uiRoot);
+    expect(corpus.length, 'the src/ui walk came back short').toBeGreaterThan(400);
     expect(
-      tsFilesUnder(uiRoot).length,
-      'the src/ui walk came back short: it stopped recursing',
-    ).toBeGreaterThan(150);
+      corpus.filter((f) => f.file.includes('/')).length,
+      'the src/ui walk returned only top-level files: it stopped recursing',
+    ).toBeGreaterThan(50);
     expect(
       discovered.length,
       'the signature sweep found almost nothing: its memo or text matcher stopped matching',
@@ -402,7 +476,7 @@ describe('language fan-out: half 2, every signature-gated src/ui surface is clas
 
   it('classifies every discovered module exactly once', () => {
     const answered = new Set(ANSWERED.map((s) => s.file));
-    const exempt = new Set(Object.keys(NOT_A_LANGUAGE_GATE));
+    const exempt = new Set(NOT_A_LANGUAGE_GATE.map((r) => r.file));
     const unclassified = discovered
       .map((m) => m.file)
       .filter((f) => !answered.has(f) && !exempt.has(f));
@@ -416,7 +490,7 @@ describe('language fan-out: half 2, every signature-gated src/ui surface is clas
   });
 
   it('keeps no stale rows for modules the sweep no longer finds', () => {
-    const rows = [...ANSWERED.map((s) => s.file), ...Object.keys(NOT_A_LANGUAGE_GATE)];
+    const rows = [...ANSWERED.map((s) => s.file), ...NOT_A_LANGUAGE_GATE.map((r) => r.file)];
     const stale = rows.filter((f) => !discoveredByFile.has(f));
     expect(
       stale,
@@ -456,13 +530,13 @@ describe('language fan-out: half 2, every signature-gated src/ui surface is clas
   it('holds every row to a written reason', () => {
     const thin: string[] = [];
     for (const row of ANSWERED) if (row.why.length < 40) thin.push(`ANSWERED ${row.file}`);
-    for (const [file, reason] of Object.entries(NOT_A_LANGUAGE_GATE)) {
+    for (const row of NOT_A_LANGUAGE_GATE) {
       // The exemption is the cheap way out, so it costs more prose than an answer.
-      if (reason.length < 120) thin.push(`NOT_A_LANGUAGE_GATE ${file}`);
+      if (row.reason.length < 120) thin.push(`NOT_A_LANGUAGE_GATE ${row.file}`);
     }
     expect(thin, `row(s) with no real reason written:\n${thin.join('\n')}`).toEqual([]);
     expect(
-      Object.keys(NOT_A_LANGUAGE_GATE).length,
+      NOT_A_LANGUAGE_GATE.length,
       'the exemption list grew. Every entry is a memo this repo has decided cannot hold player text; adding one should be argued in review, not absorbed by a floor.',
     ).toBe(4);
   });
@@ -473,9 +547,11 @@ describe('language fan-out: half 2, every signature-gated src/ui surface is clas
     // caller is dead code that reads like a working feature.
     const armCalls = new Set(scan.sites.map((s) => s.call));
     const uncalled: string[] = [];
+    const scanned: string[] = [];
     for (const { file, full } of tsFilesUnder(uiRoot)) {
       const source = stripComments(readFileSync(full, 'utf8'));
       if (!/^\s{2}relocalize\(/m.test(source)) continue;
+      scanned.push(file);
       const cls = /export class (\w+)/.exec(source)?.[1] ?? '';
       // Map the class back to the Hud field that holds it, then look for an arm
       // on that field. A module whose relocalize is reached through a wrapper
@@ -488,6 +564,15 @@ describe('language fan-out: half 2, every signature-gated src/ui surface is clas
         [...armCalls].some((c) => c.endsWith('.relocalize') && wrapperOwns(c, cls));
       if (!credited) uncalled.push(`${file} (${cls || 'unnamed class'})`);
     }
+    // The filter above is the whole test: an empty `uncalled` proves nothing if
+    // the relocalize matcher stopped matching (a reformat, an `async`, a
+    // `public`), so floor the set it actually walked.
+    expect(
+      scanned.length,
+      'the relocalize sweep matched almost nothing: its declaration matcher stopped matching',
+    ).toBeGreaterThan(20);
+    expect(scanned).toContain('card_duel_window.ts');
+    expect(scanned).toContain('hud/delve/lockpick_window.ts');
     expect(
       uncalled,
       'src/ui module(s) exposing a relocalize() that Hud.refreshLocalizedDynamicUi never calls. Wire it into the fan-out, or delete it: an uncalled relocalize is what let four windows look answered while they were not:\n' +

--- a/tests/language_fanout_registry.test.ts
+++ b/tests/language_fanout_registry.test.ts
@@ -1,0 +1,520 @@
+// THE LANGUAGE FAN-OUT REGISTRY (#2529).
+//
+// A runtime language change does not reload the page. `changeLanguage`
+// (src/main.ts) re-localizes the static shell and then dispatches
+// `woc:languagechange`; `Hud.refreshLocalizedDynamicUi()` is the ONE hand-
+// maintained fan-out that repaints the dynamic surfaces, and a surface is
+// re-localized only if it appears in that method.
+//
+// WHY A SURFACE NEEDS TO BE IN IT. Two different elision idioms live in
+// `src/ui`, and only one of them is locale-safe:
+//   - a WRITE-ELISION facet (`PainterHostWriters`) compares the RESOLVED string
+//     it is about to write, so a locale change moves the comparison and the
+//     write happens by itself. Nothing to do.
+//   - a REPAINT SIGNATURE (`lastSig` and its family) compares a digest of the
+//     DATA: ids, counts, positions, booleans. Every one of those is
+//     text-independent by design, which is the whole point of the idiom, and it
+//     means `setLanguage` alone can never move one. A surface gated that way
+//     keeps the previous locale until its data happens to change.
+// Four windows had gone missing from the fan-out that way (calendar, mailbox,
+// social, card duel), and nothing enumerated the list, which is why they could
+// go missing quietly. Sweeping for the second idiom found five more, including
+// one, the delve tracker, whose fan-out arm was PRESENT and inert: the arm
+// called `update()`, and `update()` early-returned on its own unchanged
+// signature.
+//
+// WHAT THIS FILE HOLDS, in two halves that fail for different reasons:
+//   1. The fan-out's own call list, read off the AST and diffed BOTH WAYS
+//      against `FANOUT_ARMS`. A new arm fails until it is registered; a deleted
+//      arm fails until its row goes; a re-gated one fails because the gate text
+//      is part of the key.
+//   2. A sweep of `src/ui` for the signature idiom. Every module it finds must
+//      be either answered by a named arm from half 1 or carry a written
+//      exemption, and each one pins the memo fields it was classified on, so a
+//      NEW memo added to an already-classified module re-opens the question
+//      instead of inheriting an answer that was given about a different field.
+//
+// WHERE ITS TEETH STOP, stated rather than implied:
+//   - The sweep recognizes the `x === this.lastFoo` comparison shape. A gate
+//     written as a predicate call over retained state is invisible to it: the
+//     tutorial overlay's `tutorialNeedsRerender(this.step, next, ...)` is the
+//     live example, and it is covered instead by half 1 pinning its arm and by
+//     the behavioral test in `language_fanout_relocalize.test.ts`.
+//   - Half 1 sees `refreshLocalizedDynamicUi()`'s OWN body. An arm that calls a
+//     `Hud` method which then fails to repaint is invisible here; the delve
+//     tracker was exactly that, and what catches it is the behavioral arm, not
+//     a call list.
+//   - Neither half says anything about a COLD window (rendered on open, no
+//     repaint driver at all). That is a different gap with a different answer
+//     and it is not what #2529 is about.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { readMethodCallSites } from './helpers/method_call_sites';
+import { expectScansOnlyThroughSharedWalkers } from './helpers/scan_guard_self_audit';
+import { tsFilesUnder } from './helpers/ts_files_under';
+
+const uiRoot = fileURLToPath(new URL('../src/ui/', import.meta.url));
+const hudSource = readFileSync(new URL('../src/ui/hud.ts', import.meta.url), 'utf8');
+
+// Raw source to the parser (a `//` inside one of hud.ts's regex literals or
+// template strings truncates a line for a comment stripper, and ts.createSourceFile
+// does not throw on the broken tree, it silently loses a call site); stripped
+// source only for the text pins further down.
+const scan = readMethodCallSites('src/ui/hud.ts', hudSource, 'Hud', 'refreshLocalizedDynamicUi');
+
+function stripComments(source: string): string {
+  // The `(^|[^:])` capture keeps a `://` in a URL from eating the rest of its
+  // line, the stripper bug this repo already shipped once (#2499).
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+// --- half 1: the fan-out's arms -------------------------------------------
+
+/** `call|gate`, the same key `hud_update_drive.test.ts` uses. */
+const FANOUT_ARMS: readonly string[] = [
+  'this.syncDailyRewardsSurfaceLabels|',
+  'this.storePromoCard.relocalize|',
+  'this.refreshKeybindLabels|',
+  'this.updateQuestTracker|',
+  'this.delveTracker.relocalize|',
+  'this.partyFramesPainter.relocalize|',
+  'this.mapPainter.relocalize|',
+  'this.targetFrameMover.relocalize|',
+  'this.playerFrameMover.relocalize|',
+  'this.partyFrameMover.relocalize|',
+  'this.questlogWindow.render|this.questlogWindow.isOpen',
+  "this.renderBags|$('#bags').style.display !== 'none'",
+  "this.renderVendor|this.openVendorNpcId !== null && $('#vendor-window').style.display === 'block'",
+  "this.renderHeroicVendor|this.openHeroicVendorNpcId !== null && $('#vendor-window').style.display === 'block'",
+  "this.renderTrain|this.openTrainNpcId !== null && $('#train-window').style.display === 'block'",
+  "this.renderUnbind|this.openUnbindNpcId !== null && $('#unbind-window').style.display === 'block'",
+  'this.renderTownFocus|this.townFocusOpen',
+  'this.marketWindow.render|this.marketWindow.isOpen',
+  'this.bankWindow.render|this.bankWindow.isOpen',
+  'this.deedsWindow.render|this.deedsWindow.isOpen',
+  'this.professionsWindow.render|this.professionsWindow.isOpen',
+  'this.updateDeedTracker|',
+  'this.charWindow.renderIfOpen|',
+  'this.arenaWindow.relocalize|',
+  'this.dungeonFinderWindow.relocalize|',
+  'this.dungeonFinderProposalPopup.relocalize|',
+  'this.valeCupWindow.relocalize|',
+  'this.vcupBetting.relocalize|',
+  'this.vcupIndicator.relocalize|',
+  'this.vcupMatchHud.relocalize|',
+  'this.vcupBriefing.relocalize|',
+  'this.vcupCharge.relocalize|',
+  'this.questDialog.relocalize|',
+  'this.calendarWindow.relocalize|',
+  'this.mailboxWindow.relocalize|',
+  'this.socialWindow.relocalize|',
+  'this.cardDuelWindow.relocalize|',
+  'this.spellbookWindow.relocalize|',
+  'this.lockpickController.relocalize|',
+  'this.tutorial.relocalize|',
+  'this.mobileActionRingPainter.relocalize|',
+];
+
+const observedArms = scan.sites.map((s) => `${s.call}|${s.conditions.join(' && ')}`);
+
+// --- half 2: every signature-gated, text-bearing src/ui module -------------
+
+/**
+ * A memo field name shaped like a repaint signature. Deliberately a NAME
+ * family rather than a type: what makes one of these a language hazard is that
+ * it retains a digest of the previous paint's INPUTS, and this repo spells that
+ * `lastX` / `prevX` / `knownX` / `paintedX` everywhere it does it.
+ */
+const MEMO_DECL = /\bprivate\s+(?:readonly\s+)?((?:last|prev|known|painted)[A-Z]\w*)\b/g;
+
+/** Any call that puts player-visible text on screen. */
+const EMITS_TEXT = /\bt\(|\btPlural\(|\btEntity\(/;
+
+interface GatedModule {
+  /** Path under `src/ui/`. */
+  readonly file: string;
+  /** The memo fields the classification below was made about, sorted. */
+  readonly memos: readonly string[];
+}
+
+function discoverGatedModules(): GatedModule[] {
+  const out: GatedModule[] = [];
+  for (const { file, full } of tsFilesUnder(uiRoot)) {
+    const source = stripComments(readFileSync(full, 'utf8'));
+    if (!EMITS_TEXT.test(source)) continue;
+    const declared = [...source.matchAll(MEMO_DECL)].map((m) => m[1]);
+    // A memo is only a REPAINT gate when the module compares it. A retained
+    // value that is merely written and read back (a cached ref, a latch the
+    // painter re-reads) suppresses nothing on its own.
+    const gating = [
+      ...new Set(
+        declared.filter((memo) =>
+          new RegExp(`[!=]==\\s*this\\.${memo}\\b|this\\.${memo}\\s*[!=]==`).test(source),
+        ),
+      ),
+    ].sort();
+    if (gating.length > 0) out.push({ file, memos: gating });
+  }
+  return out;
+}
+
+const discovered = discoverGatedModules();
+const discoveredByFile = new Map(discovered.map((m) => [m.file, m]));
+
+interface AnsweredSurface extends GatedModule {
+  /** The `call` key in FANOUT_ARMS that re-localizes this module. */
+  readonly answer: string;
+  /** What the memo digests, and therefore why the locale cannot move it. */
+  readonly why: string;
+}
+
+const ANSWERED: readonly AnsweredSurface[] = [
+  {
+    file: 'arena_window.ts',
+    memos: ['lastSig'],
+    answer: 'this.arenaWindow.relocalize',
+    why: 'the offline sentinel or a JSON of bracket ids and scores',
+  },
+  {
+    file: 'bank_window.ts',
+    memos: ['lastSig'],
+    answer: 'this.bankWindow.render',
+    why: 'capacity, purchased and bonus slot counts, the next expansion cost and the stored slots. render() carries no self-gate, so the arm rebuilds',
+  },
+  {
+    file: 'calendar_window.ts',
+    memos: ['lastSig'],
+    answer: 'this.calendarWindow.relocalize',
+    why: 'the visible month, the selected day and the guild-event mirror (#2529)',
+  },
+  {
+    file: 'card_duel_window.ts',
+    memos: ['lastSig'],
+    answer: 'this.cardDuelWindow.relocalize',
+    why: 'the duel view model: state, card values, round counts (#2529)',
+  },
+  {
+    file: 'deeds_window.ts',
+    memos: ['lastSig'],
+    answer: 'this.deedsWindow.render',
+    why: 'the earned/watched deed ids and their counters',
+  },
+  {
+    file: 'dungeon_finder_proposal_popup.ts',
+    memos: ['lastRemainingText', 'lastSig'],
+    answer: 'this.dungeonFinderProposalPopup.relocalize',
+    why: 'the proposal id and roles, plus a countdown string latch',
+  },
+  {
+    file: 'dungeon_finder_window.ts',
+    memos: ['lastSig'],
+    answer: 'this.dungeonFinderWindow.relocalize',
+    why: 'the view core signature (queue state, role counts and party ids) joined with the open pane name',
+  },
+  {
+    file: 'hud/action_bar/mobile_action_ring_painter.ts',
+    memos: ['lastPage', 'lastPageCount'],
+    answer: 'this.mobileActionRingPainter.relocalize',
+    why: 'two integers gating the page indicator text and the toggle name (#2529)',
+  },
+  {
+    file: 'hud/delve/delve_tracker_controller.ts',
+    memos: ['lastSignature'],
+    answer: 'this.delveTracker.relocalize',
+    why: 'delve/tier/module ids, objective counts, affixes and marks. The arm used to call update(), which this same signature swallowed (#2529)',
+  },
+  {
+    file: 'hud/delve/lockpick_window.ts',
+    memos: ['lastSig', 'lastTimerKey', 'lastUrgent'],
+    answer: 'this.lockpickController.relocalize',
+    why: 'the board geometry and pick position; the other two are the countdown clock key and its urgent latch (#2529)',
+  },
+  {
+    file: 'hud/quest/quest_dialog_controller.ts',
+    memos: ['lastIntroHintVisible'],
+    answer: 'this.questDialog.relocalize',
+    why: 'the profession intro hint visibility latch',
+  },
+  {
+    file: 'mailbox_window.ts',
+    memos: ['lastSig'],
+    answer: 'this.mailboxWindow.relocalize',
+    why: 'the tab, the open letter id and the mail mirror (#2529)',
+  },
+  {
+    file: 'market_window.ts',
+    memos: ['lastSig'],
+    answer: 'this.marketWindow.render',
+    why: 'the listing ids, prices and the active tab; render() carries no self-gate',
+  },
+  {
+    file: 'professions_window.ts',
+    memos: ['lastSig'],
+    answer: 'this.professionsWindow.render',
+    why: 'the known professions and their skill numbers; render() carries no self-gate',
+  },
+  {
+    file: 'social_window.ts',
+    memos: ['lastContent', 'lastStruct'],
+    answer: 'this.socialWindow.relocalize',
+    why: 'the tab plus the friend/guild/raid rosters, split structural and content (#2529)',
+  },
+  {
+    file: 'spellbook_window.ts',
+    memos: ['knownIds', 'knownNums', 'lastAttackOnBar', 'lastHasFree', 'lastSlotIds'],
+    answer: 'this.spellbookWindow.relocalize',
+    why: 'the resolved ability ids and their rank/cost/cast/cooldown numbers, plus the hotbar toggle state (#2529)',
+  },
+  {
+    file: 'vale_cup_betting.ts',
+    memos: ['lastSig'],
+    answer: 'this.vcupBetting.relocalize',
+    why: 'the match id, the two nation ids, the away-palette flag and a skeleton of each team roster',
+  },
+  {
+    file: 'vale_cup_briefing.ts',
+    memos: ['lastSig'],
+    answer: 'this.vcupBriefing.relocalize',
+    why: 'the two nation ids, the away-palette flag, the local team and role, the format and a skeleton of each roster',
+  },
+  {
+    file: 'vale_cup_hud.ts',
+    memos: ['lastSig'],
+    answer: 'this.vcupMatchHud.relocalize',
+    why: 'the match id, the two nation ids, the away-palette flag and the local team, pipe-joined',
+  },
+  {
+    file: 'vale_cup_indicator.ts',
+    memos: ['lastSig'],
+    answer: 'this.vcupIndicator.relocalize',
+    why: 'a hidden sentinel or the bracket, queue position and waiting count. The clock is deliberately out of it and rides the elided setText instead',
+  },
+  {
+    file: 'vale_cup_window.ts',
+    memos: ['lastSig'],
+    answer: 'this.valeCupWindow.relocalize',
+    why: 'standing, queue state, bracket, position, queue sizes, the deserter timer, nation, role and the live match scores',
+  },
+];
+
+/**
+ * A memo the sweep finds that is NOT a language hazard, with the reason.
+ *
+ * The bar is high on purpose: an exemption is the cheapest way to make this
+ * guard green without fixing anything, so each one names the memo's contents
+ * and says what moves it when the locale moves.
+ */
+const NOT_A_LANGUAGE_GATE: Readonly<Record<string, string>> = {
+  'claudium_window.ts':
+    'paintedWalletMarkup retains the RESOLVED wallet markup and is compared against a freshly built walletConnectionHtml(), so a locale change moves both sides of the comparison and the repaint happens by itself. It is a write-elision memo, not a data signature.',
+  'daily_rewards_window.ts':
+    'paintedStoreBody / paintedStoreMarkup retain the RESOLVED store markup and the element it was written into, compared against freshly built markup in replaceStoreBody, so a locale change produces different markup and repaints. Same write-elision shape as claudium_window.',
+  'deed_tracker_painter.ts':
+    'lastChip gates only the header ARIA presence swap (aria-expanded / aria-controls / aria-haspopup), which carries no player-visible text. Every string in this painter goes through the elided writer facet, which compares resolved text, and the fan-out drives it through this.updateDeedTracker.',
+  'hud.ts':
+    'the coordinator itself. Its own signature-gated arms are individually answered inside refreshLocalizedDynamicUi, which half 1 above pins EXACTLY, so pinning its memo list here as well would only mean every unrelated hud.ts memo edit had to be re-approved in two places.',
+};
+
+// ---------------------------------------------------------------------------
+
+describe('language fan-out: half 1, the arms of refreshLocalizedDynamicUi', () => {
+  it('read a whole, real fan-out before asserting anything about it', () => {
+    // readMethodCallSites throws on a renamed class or method, so a rename is
+    // red rather than a quiet empty scan. These floors cover the other way to
+    // come back short: a walk that stopped parsing part way down the body.
+    expect(scan.classMembers, 'the Hud class shrank past recognition').toBeGreaterThan(600);
+    expect(observedArms.length, 'the fan-out walk came back short').toBeGreaterThan(30);
+  });
+
+  it('wires the fan-out to the woc:languagechange event exactly once', () => {
+    const wiring = stripComments(hudSource).match(
+      /document\.addEventListener\('woc:languagechange'/g,
+    );
+    expect(wiring, 'hud.ts no longer listens for woc:languagechange').toHaveLength(1);
+    expect(stripComments(hudSource)).toContain(
+      "document.addEventListener('woc:languagechange', () => this.refreshLocalizedDynamicUi());",
+    );
+  });
+
+  it('registers every arm the fan-out drives, and nothing it does not', () => {
+    const missing = observedArms.filter((k) => !FANOUT_ARMS.includes(k));
+    const stale = FANOUT_ARMS.filter((k) => !observedArms.includes(k));
+    expect(
+      { missing, stale },
+      'refreshLocalizedDynamicUi and this registry disagree. A NEW arm needs a row here saying what it re-localizes; a REMOVED one needs its row deleted; a RE-GATED one needs its gate text updated. That is the point of the table: a surface cannot leave the fan-out without a diff line here.',
+    ).toEqual({ missing: [], stale: [] });
+    expect(observedArms).toHaveLength(FANOUT_ARMS.length);
+  });
+
+  it('finds the call shapes a narrowed walk would lose', () => {
+    // One unconditional arm, one behind an isOpen gate, one behind a raw DOM
+    // display check, and one optional-chained call: a walk that dropped any of
+    // those families would still leave the other three healthy.
+    expect(observedArms).toContain('this.cardDuelWindow.relocalize|');
+    expect(observedArms).toContain('this.bankWindow.render|this.bankWindow.isOpen');
+    expect(observedArms).toContain("this.renderBags|$('#bags').style.display !== 'none'");
+    expect(observedArms).toContain('this.mobileActionRingPainter.relocalize|');
+  });
+});
+
+describe('language fan-out: half 2, every signature-gated src/ui surface is classified', () => {
+  it('scans src/ui only through the shared walker', () => {
+    expectScansOnlyThroughSharedWalkers(import.meta.url, ['ts_files_under']);
+  });
+
+  it('swept a real corpus (non-vacuity)', () => {
+    expect(
+      tsFilesUnder(uiRoot).length,
+      'the src/ui walk came back short: it stopped recursing',
+    ).toBeGreaterThan(150);
+    expect(
+      discovered.length,
+      'the signature sweep found almost nothing: its memo or text matcher stopped matching',
+    ).toBeGreaterThan(20);
+    // Both halves of the predicate must be load-bearing, or the sweep is really
+    // just "every module in src/ui" or "every module with a memo".
+    expect(
+      discoveredByFile.has('talents_window.ts'),
+      'talents_window.ts has t() and no repaint memo: the memo half of the predicate stopped filtering',
+    ).toBe(false);
+    expect(
+      discoveredByFile.has('party_below_target_painter.ts'),
+      'party_below_target_painter.ts has a memo and no t(): the text half of the predicate stopped filtering',
+    ).toBe(false);
+  });
+
+  it('finds every surface #2529 named, plus the ones the sweep itself turned up', () => {
+    for (const file of [
+      'calendar_window.ts',
+      'mailbox_window.ts',
+      'social_window.ts',
+      'card_duel_window.ts',
+      'spellbook_window.ts',
+      'hud/delve/delve_tracker_controller.ts',
+      'hud/delve/lockpick_window.ts',
+      'hud/action_bar/mobile_action_ring_painter.ts',
+    ]) {
+      expect(discoveredByFile.has(file), `the sweep no longer finds ${file}`).toBe(true);
+    }
+  });
+
+  it('classifies every discovered module exactly once', () => {
+    const answered = new Set(ANSWERED.map((s) => s.file));
+    const exempt = new Set(Object.keys(NOT_A_LANGUAGE_GATE));
+    const unclassified = discovered
+      .map((m) => m.file)
+      .filter((f) => !answered.has(f) && !exempt.has(f));
+    expect(
+      unclassified,
+      'unclassified signature-gated src/ui module(s). Each one repaints only when its OWN data signature moves, so a language switch leaves it in the old locale. Either give it a relocalize(), call it from Hud.refreshLocalizedDynamicUi and add an ANSWERED row, or add a NOT_A_LANGUAGE_GATE entry naming the memo and saying what moves it when the locale moves:\n' +
+        unclassified.join('\n'),
+    ).toEqual([]);
+    const both = [...answered].filter((f) => exempt.has(f));
+    expect(both, 'a module is both answered and exempt: pick one').toEqual([]);
+  });
+
+  it('keeps no stale rows for modules the sweep no longer finds', () => {
+    const rows = [...ANSWERED.map((s) => s.file), ...Object.keys(NOT_A_LANGUAGE_GATE)];
+    const stale = rows.filter((f) => !discoveredByFile.has(f));
+    expect(
+      stale,
+      'registry row(s) naming a module that no longer has a compared repaint memo. If the gate really went, delete the row (and, for an ANSWERED one, decide whether its fan-out arm is still needed):\n' +
+        stale.join('\n'),
+    ).toEqual([]);
+  });
+
+  it('pins each classification to the memo fields it was made about', () => {
+    const drift: string[] = [];
+    for (const row of ANSWERED) {
+      const found = discoveredByFile.get(row.file);
+      if (!found) continue; // reported by the stale-row test above
+      if (found.memos.join(',') !== [...row.memos].sort().join(',')) {
+        drift.push(
+          `${row.file}: registry ${row.memos.join(',')} vs source ${found.memos.join(',')}`,
+        );
+      }
+    }
+    expect(
+      drift,
+      'a classified module gained or lost a repaint memo. A NEW memo is a NEW gate and needs the language question answered about it, not inherited from the answer given about a different field:\n' +
+        drift.join('\n'),
+    ).toEqual([]);
+  });
+
+  it('answers each surface with an arm the fan-out really drives', () => {
+    const calls = new Set(scan.sites.map((s) => s.call));
+    const orphans = ANSWERED.filter((s) => !calls.has(s.answer));
+    expect(
+      orphans.map((s) => `${s.file} -> ${s.answer}`),
+      'an ANSWERED row names a call refreshLocalizedDynamicUi does not make:\n' +
+        orphans.map((s) => `${s.file} -> ${s.answer}`).join('\n'),
+    ).toEqual([]);
+  });
+
+  it('holds every row to a written reason', () => {
+    const thin: string[] = [];
+    for (const row of ANSWERED) if (row.why.length < 40) thin.push(`ANSWERED ${row.file}`);
+    for (const [file, reason] of Object.entries(NOT_A_LANGUAGE_GATE)) {
+      // The exemption is the cheap way out, so it costs more prose than an answer.
+      if (reason.length < 120) thin.push(`NOT_A_LANGUAGE_GATE ${file}`);
+    }
+    expect(thin, `row(s) with no real reason written:\n${thin.join('\n')}`).toEqual([]);
+    expect(
+      Object.keys(NOT_A_LANGUAGE_GATE).length,
+      'the exemption list grew. Every entry is a memo this repo has decided cannot hold player text; adding one should be argued in review, not absorbed by a floor.',
+    ).toBe(4);
+  });
+
+  it('gives every relocalize() in src/ui a caller in the fan-out', () => {
+    // The bug that started #2529: card_duel_window.ts already HAD a correct
+    // relocalize() and nothing in the repo ever called it. A relocalize with no
+    // caller is dead code that reads like a working feature.
+    const armCalls = new Set(scan.sites.map((s) => s.call));
+    const uncalled: string[] = [];
+    for (const { file, full } of tsFilesUnder(uiRoot)) {
+      const source = stripComments(readFileSync(full, 'utf8'));
+      if (!/^\s{2}relocalize\(/m.test(source)) continue;
+      const cls = /export class (\w+)/.exec(source)?.[1] ?? '';
+      // Map the class back to the Hud field that holds it, then look for an arm
+      // on that field. A module whose relocalize is reached through a wrapper
+      // (LockpickWindow via LockpickController) is credited by the wrapper's arm.
+      const fields = [...stripComments(hudSource).matchAll(/(\w+)\s*=\s*new (\w+)\(/g)]
+        .filter(([, , constructed]) => constructed === cls)
+        .map(([, field]) => field);
+      const credited =
+        fields.some((f) => armCalls.has(`this.${f}.relocalize`)) ||
+        [...armCalls].some((c) => c.endsWith('.relocalize') && wrapperOwns(c, cls));
+      if (!credited) uncalled.push(`${file} (${cls || 'unnamed class'})`);
+    }
+    expect(
+      uncalled,
+      'src/ui module(s) exposing a relocalize() that Hud.refreshLocalizedDynamicUi never calls. Wire it into the fan-out, or delete it: an uncalled relocalize is what let four windows look answered while they were not:\n' +
+        uncalled.join('\n'),
+    ).toEqual([]);
+  });
+});
+
+/**
+ * Whether the Hud field behind `armCall` is a controller that forwards
+ * relocalize() to `cls`. Reads the wrapper's own source rather than trusting a
+ * name, so renaming LockpickController to something else keeps working and
+ * gutting its forwarding call does not.
+ */
+function wrapperOwns(armCall: string, cls: string): boolean {
+  const field = armCall.slice('this.'.length, -'.relocalize'.length);
+  const constructed = new RegExp(`\\b${field}\\s*=\\s*new (\\w+)\\(`).exec(
+    stripComments(hudSource),
+  );
+  if (!constructed) return false;
+  for (const { full } of tsFilesUnder(uiRoot)) {
+    const source = stripComments(readFileSync(full, 'utf8'));
+    if (!new RegExp(`export class ${constructed[1]}\\b`).test(source)) continue;
+    // The wrapper must both hold one of these and forward to it.
+    return (
+      new RegExp(`:\\s*${cls}\\b|new ${cls}\\(`).test(source) && /\.relocalize\(\)/.test(source)
+    );
+  }
+  return false;
+}

--- a/tests/language_fanout_relocalize.test.ts
+++ b/tests/language_fanout_relocalize.test.ts
@@ -1,0 +1,554 @@
+// @vitest-environment jsdom
+
+// THE BUG (#2529): a runtime language change does not reload the page. It
+// dispatches `woc:languagechange`, and `Hud.refreshLocalizedDynamicUi()` forces
+// one repaint of every open surface so its t() text lands in the new locale. A
+// surface that repaints only when its OWN signature moves never gets that
+// repaint, because every one of those signatures is text-independent by design
+// (ids, counts, positions), so `setLanguage` alone can never move it.
+//
+// Nine surfaces were in that state. Each test below runs the same three beats,
+// and the middle one is what makes it a regression test rather than a
+// smoke test:
+//   1. paint in English and record what is on screen;
+//   2. switch the locale and drive the surface's ORDINARY repaint path with
+//      unchanged data. The old locale is STILL on screen: that is the bug,
+//      reproduced, and it is what fails if someone later widens a signature to
+//      cover text and deletes the relocalize as redundant;
+//   3. call relocalize() and assert the new locale is on screen AND that the two
+//      differ (a locale whose value happened to match English would make the
+//      whole arm vacuous).
+//
+// The windows carrying live typed input get a fourth beat: the draft survives.
+// A relocalize that fixed the language by wiping a half-written letter would
+// trade one bug for a worse one (`src/ui/form_draft.ts` states the contract).
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Keybinds } from '../src/game/keybinds';
+import type { Renderer } from '../src/render/renderer';
+import type { InvSlot } from '../src/sim/types';
+import { CalendarWindow, type CalendarWindowDeps } from '../src/ui/calendar_window';
+import { CardDuelWindow, type CardDuelWindowDeps } from '../src/ui/card_duel_window';
+import { DelveTrackerController } from '../src/ui/hud/delve/delve_tracker_controller';
+import { LockpickWindow } from '../src/ui/hud/delve/lockpick_window';
+import { ensureLocaleLoaded, setLanguage, type TranslationKey, t } from '../src/ui/i18n';
+import { MailboxWindow, type MailboxWindowDeps } from '../src/ui/mailbox_window';
+import { SocialWindow, type SocialWindowDeps } from '../src/ui/social_window';
+import { TutorialOverlay } from '../src/ui/tutorial';
+import type { DelveRunInfo, IWorld, LockpickView } from '../src/world_api';
+
+// A real locale, not the dev pseudo one: the pseudo-locale is a transform of
+// English and would still pass a test that never re-resolved anything.
+const OTHER = 'es';
+
+beforeAll(async () => {
+  await ensureLocaleLoaded(OTHER);
+});
+
+beforeEach(() => {
+  setLanguage('en');
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  setLanguage('en');
+  document.body.innerHTML = '';
+  localStorage.clear();
+  vi.useRealTimers();
+});
+
+/**
+ * Read one key in both locales and refuse to run if they match.
+ *
+ * Without this every assertion below could pass over a locale that fell back to
+ * English, which is exactly the state a missing translation leaves. The guard
+ * belongs in the test rather than in review: the catalogs move every release.
+ */
+function bilingual(key: TranslationKey): { en: string; other: string } {
+  setLanguage('en');
+  const english = t(key);
+  setLanguage(OTHER);
+  const other = t(key);
+  setLanguage('en');
+  expect(
+    other,
+    `${key} reads the same in ${OTHER} as in English, so it cannot witness a re-localization`,
+  ).not.toBe(english);
+  return { en: english, other };
+}
+
+function mount(id: string, display = 'none'): HTMLElement {
+  const el = document.createElement('div');
+  el.id = id;
+  el.style.display = display;
+  document.body.appendChild(el);
+  return el;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Mailbox (named by #2529)
+// ---------------------------------------------------------------------------
+
+function mailWorld(inventory: InvSlot[] = []): IWorld {
+  return {
+    inventory,
+    copper: 100_000,
+    mailInfo: { unread: 0, messages: [], postage: 30, maxAttachments: 3, deliverySeconds: 60 },
+    mailMarkRead: () => {},
+  } as unknown as IWorld;
+}
+
+function openMailbox(): { win: MailboxWindow; root: HTMLElement } {
+  const root = mount('mailbox-window');
+  const noop = (): void => {};
+  const deps: MailboxWindowDeps = {
+    itemIcon: () => '<span class="item-icon"></span>',
+    moneyHtml: () => '',
+    itemTooltip: () => '',
+    attachTooltip: noop,
+    root: () => root,
+    world: () => mailWorld(),
+    closeOthers: noop,
+    hideTooltip: noop,
+    captureFocus: () => null,
+    restoreFocus: noop,
+    showError: noop,
+    syncBags: noop,
+  };
+  const win = new MailboxWindow(deps);
+  win.open();
+  return { win, root };
+}
+
+describe('#2529 mailbox: an open Send tab re-localizes without losing the letter', () => {
+  it('keeps the old locale on its own repaint path, then relocalizes and preserves the draft', () => {
+    const label = bilingual('hudChrome.mailbox.toLabel');
+    const { win, root } = openMailbox();
+    (root.querySelector('[data-tab="send"]') as HTMLElement).click();
+    const labelText = (): string =>
+      root.querySelector('label[for="mail-to"]')?.textContent?.trim() ?? '';
+    expect(labelText()).toBe(label.en);
+
+    const field = <T extends HTMLInputElement | HTMLTextAreaElement>(id: string): T =>
+      root.querySelector<T>(`#${id}`) as T;
+    field<HTMLInputElement>('mail-to').value = 'Mira';
+    field<HTMLInputElement>('mail-subject').value = 'For you';
+    field<HTMLTextAreaElement>('mail-body').value = 'A fang from the hunt.';
+    field<HTMLInputElement>('mail-g').value = '2';
+    field<HTMLInputElement>('mail-s').value = '30';
+    field<HTMLInputElement>('mail-c').value = '7';
+
+    // THE BUG: the slow-band repaint is the only thing that ran before this fix,
+    // and on the Send tab it deliberately does nothing at all.
+    setLanguage(OTHER);
+    win.refreshIfChanged();
+    expect(labelText(), 'the send tab repainted itself: this arm no longer proves the gap').toBe(
+      label.en,
+    );
+
+    win.relocalize();
+    expect(labelText()).toBe(label.other);
+    expect(field<HTMLInputElement>('mail-to').value).toBe('Mira');
+    expect(field<HTMLInputElement>('mail-subject').value).toBe('For you');
+    expect(field<HTMLTextAreaElement>('mail-body').value).toBe('A fang from the hunt.');
+    expect(field<HTMLInputElement>('mail-g').value).toBe('2');
+    expect(field<HTMLInputElement>('mail-s').value).toBe('30');
+    expect(field<HTMLInputElement>('mail-c').value).toBe('7');
+  });
+
+  it('re-latches the inbox signature so the next slow tick does not rebuild again', () => {
+    const tab = bilingual('hudChrome.mailbox.tabSend');
+    const { win, root } = openMailbox();
+    const sendTab = (): HTMLElement => root.querySelector('[data-tab="send"]') as HTMLElement;
+    // open() clears the signature, so the first poll after it always rebuilds.
+    // Settle that here, in English, or the staleness arm below would be measuring
+    // the open path rather than the elision.
+    win.refreshIfChanged();
+    expect(sendTab().textContent).toBe(tab.en);
+
+    setLanguage(OTHER);
+    win.refreshIfChanged();
+    expect(sendTab().textContent).toBe(tab.en);
+
+    win.relocalize();
+    const rebuilt = sendTab();
+    expect(rebuilt.textContent).toBe(tab.other);
+
+    // A relocalize that CLEARED the signature instead of re-latching it would
+    // rebuild a second time here, which on the Send tab would land after the
+    // restore above and wipe the draft it just put back.
+    win.refreshIfChanged();
+    expect(sendTab(), 'the mailbox rebuilt a second time on unchanged data').toBe(rebuilt);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Calendar (named by #2529)
+// ---------------------------------------------------------------------------
+
+function calendarWorld(): IWorld {
+  return {
+    socialInfo: {
+      guild: { name: 'Ashen Vow', rank: 'leader', members: [], events: [] },
+    },
+    guildEventCreate: () => {},
+    guildEventRemove: () => {},
+  } as unknown as IWorld;
+}
+
+function openCalendar(): { win: CalendarWindow; root: HTMLElement } {
+  const root = mount('calendar-window');
+  const noop = (): void => {};
+  const deps: CalendarWindowDeps = {
+    root: () => root,
+    world: () => calendarWorld(),
+    closeOthers: noop,
+    captureFocus: () => null,
+    restoreFocus: noop,
+    showError: noop,
+  };
+  const win = new CalendarWindow(deps);
+  win.open();
+  return { win, root };
+}
+
+describe('#2529 calendar: an open month re-localizes without losing the booking draft', () => {
+  it('holds the old locale through refreshIfChanged, then relocalizes and keeps the form', () => {
+    const heading = bilingual('hudChrome.calendar.bookTitle');
+    const { win, root } = openCalendar();
+    const bookTitle = (): string =>
+      root.querySelector('.cal-form-title')?.textContent?.trim() ?? '';
+    // open() clears the signature, so the first poll after it always rebuilds.
+    // Settle that in English first, or the staleness arm below measures the open
+    // path rather than the elision.
+    win.refreshIfChanged();
+    expect(bookTitle(), 'the guild-master booking form did not render').toBe(heading.en);
+
+    const title = root.querySelector<HTMLInputElement>('#cal-ev-title') as HTMLInputElement;
+    const note = root.querySelector<HTMLInputElement>('#cal-ev-note') as HTMLInputElement;
+    const hour = root.querySelector<HTMLInputElement>('#cal-ev-hour') as HTMLInputElement;
+    title.value = 'Molten Core';
+    note.value = 'Bring fire resist';
+    hour.value = '20';
+
+    setLanguage(OTHER);
+    win.refreshIfChanged();
+    expect(bookTitle(), 'the calendar repainted itself: this arm no longer proves the gap').toBe(
+      heading.en,
+    );
+
+    win.relocalize();
+    expect(bookTitle()).toBe(heading.other);
+    expect(root.querySelector<HTMLInputElement>('#cal-ev-title')?.value).toBe('Molten Core');
+    expect(root.querySelector<HTMLInputElement>('#cal-ev-note')?.value).toBe('Bring fire resist');
+    expect(root.querySelector<HTMLInputElement>('#cal-ev-hour')?.value).toBe('20');
+
+    // Re-latched, not cleared: a second rebuild would wipe the restored draft.
+    const kept = root.querySelector('#cal-ev-title');
+    win.refreshIfChanged();
+    expect(
+      root.querySelector('#cal-ev-title'),
+      'the calendar rebuilt again on unchanged data',
+    ).toBe(kept);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Social (named by #2529)
+// ---------------------------------------------------------------------------
+
+function socialWorld(
+  search: (q: string) => Promise<{ name: string; cls: string; level: number }[]>,
+): IWorld {
+  return {
+    playerId: 7,
+    player: { id: 7, name: 'Aleron' },
+    realm: 'Ashenvale',
+    partyInfo: null,
+    socialInfo: { friends: [], ignores: [], blocks: [], guild: null },
+    searchCharacters: search,
+  } as unknown as IWorld;
+}
+
+function openSocial(
+  search: (q: string) => Promise<{ name: string; cls: string; level: number }[]> = async () => [],
+): { win: SocialWindow; root: HTMLElement } {
+  const root = mount('social-window');
+  const noop = (): void => {};
+  const deps: SocialWindowDeps = {
+    root: () => root,
+    world: () => socialWorld(search),
+    closeOthers: noop,
+    hideTooltip: noop,
+    captureFocus: () => null,
+    restoreFocus: noop,
+    showPrompt: noop,
+    startWhisper: noop,
+  };
+  const win = new SocialWindow(deps);
+  win.toggle();
+  return { win, root };
+}
+
+describe('#2529 social: an open panel re-localizes without losing the typed name', () => {
+  it('holds the old locale through refreshIfChanged, then relocalizes and keeps the draft', () => {
+    const tab = bilingual('hud.social.friendsTab');
+    const { win, root } = openSocial();
+    const firstTab = (): string => root.querySelector('.soc-tab')?.textContent?.trim() ?? '';
+    expect(firstTab()).toBe(tab.en);
+
+    const input = root.querySelector<HTMLInputElement>(
+      'input[data-field="friend"]',
+    ) as HTMLInputElement;
+    input.value = 'Mirabel';
+
+    setLanguage(OTHER);
+    win.refreshIfChanged();
+    expect(firstTab(), 'the social panel repainted itself: this arm no longer proves the gap').toBe(
+      tab.en,
+    );
+
+    win.relocalize();
+    expect(firstTab()).toBe(tab.other);
+    expect(root.querySelector<HTMLInputElement>('input[data-field="friend"]')?.value).toBe(
+      'Mirabel',
+    );
+
+    const kept = root.querySelector('input[data-field="friend"]');
+    win.refreshIfChanged();
+    expect(root.querySelector('input[data-field="friend"]'), 'the panel rebuilt again').toBe(kept);
+  });
+
+  it('drops the pending suggestion list with the listbox the rebuild destroys', async () => {
+    vi.useFakeTimers();
+    const { win, root } = openSocial(async () => [
+      { name: 'Mirabel', cls: 'mage', level: 12 },
+      { name: 'Miranda', cls: 'rogue', level: 9 },
+    ]);
+    const input = root.querySelector<HTMLInputElement>(
+      'input[data-field="friend"]',
+    ) as HTMLInputElement;
+    input.value = 'Mir';
+    input.dispatchEvent(new Event('input'));
+    await vi.advanceTimersByTimeAsync(500);
+    expect(
+      root.querySelectorAll('.soc-suggest[data-for="friend"] .soc-sugg-item').length,
+      'the typeahead never opened, so the stranded-list arm proves nothing',
+    ).toBe(2);
+
+    setLanguage(OTHER);
+    win.relocalize();
+
+    // render() destroyed the listbox. If `suggest` survived it, ArrowDown would
+    // still move a highlight through items nobody can see, and point the
+    // combobox at an element id that no longer exists.
+    const rebuilt = root.querySelector<HTMLInputElement>(
+      'input[data-field="friend"]',
+    ) as HTMLInputElement;
+    expect(rebuilt.value).toBe('Mir');
+    rebuilt.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(
+      rebuilt.getAttribute('aria-activedescendant'),
+      'a stranded suggestion list survived the relocalize rebuild',
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Card duel (named by #2529; its relocalize existed with no caller at all)
+// ---------------------------------------------------------------------------
+
+function openCardDuel(): { win: CardDuelWindow; root: HTMLElement } {
+  const root = mount('card-duel-window');
+  const noop = (): void => {};
+  const deps: CardDuelWindowDeps = {
+    root: () => root,
+    world: () =>
+      ({
+        cardMinigameInfo: { queued: false, inQueue: 0, match: null },
+        joinCardDuelQueue: noop,
+        leaveCardDuelQueue: noop,
+        forfeitCardDuel: noop,
+        playCardInDuel: noop,
+      }) as unknown as IWorld,
+    closeOthers: noop,
+    captureFocus: () => null,
+    restoreFocus: noop,
+  };
+  const win = new CardDuelWindow(deps);
+  win.toggle();
+  return { win, root };
+}
+
+describe('#2529 card duel: the orphaned relocalize is the only thing that repaints it', () => {
+  it('no-ops on a direct render() and repaints on relocalize()', () => {
+    const title = bilingual('cardDuel.title');
+    const { win, root } = openCardDuel();
+    const heading = (): string => root.querySelector('#card-duel-title')?.textContent?.trim() ?? '';
+    expect(heading()).toBe(title.en);
+
+    // The signature check lives INSIDE render(), so wiring the fan-out to
+    // render() (the shape three other windows use) would have been a silent
+    // no-op here. That is why this window needs its relocalize called.
+    setLanguage(OTHER);
+    win.render();
+    expect(heading(), 'render() rebuilt on an unchanged signature').toBe(title.en);
+
+    win.relocalize();
+    expect(heading()).toBe(title.other);
+
+    // relocalize() clears then re-latches inside the same render, so the medium
+    // band goes straight back to eliding.
+    const kept = root.querySelector('#card-duel-title');
+    win.render();
+    expect(root.querySelector('#card-duel-title'), 'the duel window rebuilt again').toBe(kept);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Delve tracker: the fan-out already CALLED it, and the call did nothing
+// ---------------------------------------------------------------------------
+
+function delveRun(): DelveRunInfo {
+  return {
+    delveId: 'collapsed_reliquary',
+    tierId: 'normal',
+    slot: 0,
+    origin: { x: 0, z: 0 },
+    moduleIndex: 0,
+    moduleCount: 2,
+    modules: ['reliquary_sunken_ossuary', 'reliquary_finale'],
+    objective: { kind: 'kill_boss', counts: [0], complete: false },
+    affixes: [],
+    completed: false,
+    exitPortalOpen: false,
+    bountiful: false,
+    rite: null,
+  } as unknown as DelveRunInfo;
+}
+
+describe('#2529 delve tracker: the fan-out arm was present but inert', () => {
+  it('ignores a plain update() after a language switch and repaints on relocalize()', () => {
+    const heading = bilingual('delveUi.tracker.title');
+    const element = mount('delve-tracker', 'block');
+    const world = { delveRun: delveRun(), delveMarks: 3 } as Pick<
+      IWorld,
+      'delveRun' | 'delveMarks'
+    >;
+    const controller = new DelveTrackerController({
+      element,
+      world: () => world,
+      delveName: () => 'Collapsed Reliquary',
+      mobName: () => 'Deacon Varric',
+      attachTooltip: () => {},
+      closeRitePanel: () => {},
+    });
+    controller.update();
+    const title = (): string => element.querySelector('.dt-header')?.textContent?.trim() ?? '';
+    expect(title()).toBe(heading.en);
+
+    // This is exactly what refreshLocalizedDynamicUi used to do: call update().
+    setLanguage(OTHER);
+    controller.update();
+    expect(title(), 'update() repainted on an unchanged signature: the arm is moot').toBe(
+      heading.en,
+    );
+
+    controller.relocalize();
+    expect(title()).toBe(heading.other);
+
+    const kept = element.querySelector('.dt-header');
+    controller.update();
+    expect(element.querySelector('.dt-header'), 'the tracker rebuilt again').toBe(kept);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Lockpick board
+// ---------------------------------------------------------------------------
+
+const LOCK_VIEW: LockpickView = {
+  sessionId: 'lp_1_0',
+  objectId: 1,
+  w: 4,
+  h: 4,
+  col: 0,
+  row: 2,
+  page: 1,
+  pageCount: 2,
+  tries: 2,
+  triesTotal: 2,
+  lootTier: 'premium',
+  allowed: ['set', 'steady', 'ease'],
+  visible: [],
+  stepTimeoutMs: 15000,
+};
+
+describe('#2529 lockpick: the open board re-localizes', () => {
+  it('ignores the per-frame repaint after a language switch and repaints on relocalize()', () => {
+    const panel = mount('lockpick-panel', 'block');
+    const win = new LockpickWindow({
+      panel: () => panel,
+      getState: () => LOCK_VIEW,
+      tierName: (tier) => tier,
+      onEngage: () => {},
+      onAction: () => {},
+      onAbort: () => {},
+      onClose: () => {},
+    });
+    win.openBoard();
+    const heading = (): string => panel.querySelector('.panel-title span')?.textContent ?? '';
+    const english = heading();
+    expect(english.length).toBeGreaterThan(0);
+
+    setLanguage(OTHER);
+    win.repaintIfChanged();
+    expect(heading(), 'the board repainted itself: this arm no longer proves the gap').toBe(
+      english,
+    );
+
+    win.relocalize();
+    const other = heading();
+    expect(other).toBe(t('lockpickUi.boardTitle', { tier: LOCK_VIEW.lootTier }));
+    expect(other, 'the board title reads the same in both locales').not.toBe(english);
+    win.stopTimer();
+  });
+});
+
+// The ninth surface, MobileActionRingPainter, is pinned in its own suite
+// (tests/mobile_action_ring_painter.test.ts), which already owns the fake
+// action-bar facet and slot descriptors this file would otherwise duplicate.
+
+// ---------------------------------------------------------------------------
+// 7. Tutorial overlay
+// ---------------------------------------------------------------------------
+
+describe('#2529 tutorial: the coachmark card re-localizes mid-step', () => {
+  it('holds the old locale through update() and repaints on relocalize()', () => {
+    const heading = bilingual('hud.tutorial.moveTitle');
+    mount('ui', 'block');
+    const world = {
+      playerId: 7,
+      player: { id: 7, level: 1, name: 'Aleron', pos: { x: 0, y: 0, z: 0 } },
+      questsDone: new Set<string>(),
+      questLog: new Map(),
+      questState: () => null,
+      entities: new Map(),
+    } as unknown as IWorld;
+    const renderer = {
+      worldToScreen: () => ({ x: 0, y: 0, behind: false }),
+    } as unknown as Renderer;
+    const keybinds = { primaryLabel: (id: string) => id.toUpperCase() } as unknown as Keybinds;
+    const overlay = new TutorialOverlay();
+    overlay.update(world, renderer, keybinds);
+    const title = (): string => document.querySelector('.tut-title')?.textContent ?? '';
+    expect(title(), 'the tutorial card never rendered: the arm proves nothing').toBe(heading.en);
+
+    setLanguage(OTHER);
+    overlay.update(world, renderer, keybinds);
+    expect(title(), 'update() repainted on an unchanged step: the arm is moot').toBe(heading.en);
+
+    overlay.relocalize(world, keybinds);
+    expect(title()).toBe(heading.other);
+  });
+});

--- a/tests/language_fanout_relocalize.test.ts
+++ b/tests/language_fanout_relocalize.test.ts
@@ -64,11 +64,14 @@ afterEach(() => {
  * English, which is exactly the state a missing translation leaves. The guard
  * belongs in the test rather than in review: the catalogs move every release.
  */
-function bilingual(key: TranslationKey): { en: string; other: string } {
+function bilingual(
+  key: TranslationKey,
+  values?: Record<string, string | number>,
+): { en: string; other: string } {
   setLanguage('en');
-  const english = t(key);
+  const english = t(key, values);
   setLanguage(OTHER);
-  const other = t(key);
+  const other = t(key, values);
   setLanguage('en');
   expect(
     other,
@@ -154,6 +157,41 @@ describe('#2529 mailbox: an open Send tab re-localizes without losing the letter
     expect(field<HTMLInputElement>('mail-g').value).toBe('2');
     expect(field<HTMLInputElement>('mail-s').value).toBe('30');
     expect(field<HTMLInputElement>('mail-c').value).toBe('7');
+  });
+
+  it('does not re-open a bags window the player closed, and keeps focus in the dialog', () => {
+    const root = mount('mailbox-window');
+    const bagsReveals: boolean[] = [];
+    const noop = (): void => {};
+    const win = new MailboxWindow({
+      itemIcon: () => '<span class="item-icon"></span>',
+      moneyHtml: () => '',
+      itemTooltip: () => '',
+      attachTooltip: noop,
+      root: () => root,
+      world: () => mailWorld(),
+      closeOthers: noop,
+      hideTooltip: noop,
+      captureFocus: () => null,
+      restoreFocus: noop,
+      showError: noop,
+      syncBags: (open) => bagsReveals.push(open),
+    });
+    win.open();
+    (root.querySelector('[data-tab="send"]') as HTMLElement).click();
+    expect(bagsReveals, 'opening the Send tab is what docks the bags window').toContain(true);
+
+    // The player closed bags; a language switch must not undo that.
+    bagsReveals.length = 0;
+    const sendTab = root.querySelector('[data-tab="send"]') as HTMLElement;
+    sendTab.focus();
+    setLanguage(OTHER);
+    win.relocalize();
+    expect(bagsReveals, 'the relocalize re-revealed the bags window').toEqual([]);
+    // Focus was on a button, not a text field: the window's Tab trap only arms
+    // while focus is inside its root, so dropping it to body would let the next
+    // Tab walk out of the dialog.
+    expect(document.activeElement).toBe(root.querySelector('[data-tab="send"]'));
   });
 
   it('re-latches the inbox signature so the next slow tick does not rebuild again', () => {
@@ -257,27 +295,32 @@ describe('#2529 calendar: an open month re-localizes without losing the booking 
 // 3. Social (named by #2529)
 // ---------------------------------------------------------------------------
 
+type CharacterHit = { name: string; cls: string; level: number };
+
 function socialWorld(
-  search: (q: string) => Promise<{ name: string; cls: string; level: number }[]>,
+  search: (q: string) => Promise<CharacterHit[]>,
+  guild: unknown = null,
 ): IWorld {
   return {
     playerId: 7,
     player: { id: 7, name: 'Aleron' },
     realm: 'Ashenvale',
     partyInfo: null,
-    socialInfo: { friends: [], ignores: [], blocks: [], guild: null },
+    socialInfo: { friends: [], ignores: [], blocks: [], guild },
     searchCharacters: search,
+    guildSetMotd: () => {},
   } as unknown as IWorld;
 }
 
 function openSocial(
-  search: (q: string) => Promise<{ name: string; cls: string; level: number }[]> = async () => [],
+  search: (q: string) => Promise<CharacterHit[]> = async () => [],
+  guild: unknown = null,
 ): { win: SocialWindow; root: HTMLElement } {
   const root = mount('social-window');
   const noop = (): void => {};
   const deps: SocialWindowDeps = {
     root: () => root,
-    world: () => socialWorld(search),
+    world: () => socialWorld(search, guild),
     closeOthers: noop,
     hideTooltip: noop,
     captureFocus: () => null,
@@ -317,6 +360,55 @@ describe('#2529 social: an open panel re-localizes without losing the typed name
     const kept = root.querySelector('input[data-field="friend"]');
     win.refreshIfChanged();
     expect(root.querySelector('input[data-field="friend"]'), 'the panel rebuilt again').toBe(kept);
+  });
+
+  it('carries the guild billboard draft, which refreshList could no longer read', () => {
+    // The subtle arm of the three: refreshList protects this draft by reading the
+    // LIVE input, but render() destroys `.soc-body` before calling refreshList, so
+    // by then there is nothing to read. relocalize has to capture first.
+    const heading = bilingual('hudChrome.social.billboard.inputLabel');
+    const { win, root } = openSocial(async () => [], {
+      name: 'Ashen Vow',
+      rank: 'leader',
+      members: [{ name: 'Aleron', cls: 'warrior', level: 60, online: true, rank: 'leader' }],
+      motd: 'Raid at eight',
+      events: [],
+    });
+    (root.querySelector('[data-tab="guild"]') as HTMLElement | null)?.click();
+    const motd = (): HTMLInputElement | null =>
+      root.querySelector<HTMLInputElement>('input[data-field="gmotd"]');
+    expect(motd(), 'the guild billboard never rendered: the arm proves nothing').not.toBeNull();
+    expect(motd()?.getAttribute('aria-label')).toBe(heading.en);
+    (motd() as HTMLInputElement).value = 'Raid at nine, bring fire resist';
+
+    setLanguage(OTHER);
+    win.relocalize();
+    expect(motd()?.getAttribute('aria-label')).toBe(heading.other);
+    expect(motd()?.value, 'the billboard draft was lost in the rebuild').toBe(
+      'Raid at nine, bring fire resist',
+    );
+  });
+
+  it('drops a search still in flight, so its results cannot land on the rebuilt DOM', async () => {
+    vi.useFakeTimers();
+    let searches = 0;
+    const { win, root } = openSocial(async () => {
+      searches++;
+      return [{ name: 'Mirabel', cls: 'mage', level: 12 }];
+    });
+    const input = root.querySelector<HTMLInputElement>(
+      'input[data-field="friend"]',
+    ) as HTMLInputElement;
+    input.value = 'Mir';
+    input.dispatchEvent(new Event('input'));
+
+    // Mid-debounce: the timer is armed and has NOT fired. relocalize must clear
+    // it, or the search resolves against a listbox that no longer exists.
+    setLanguage(OTHER);
+    win.relocalize();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(searches, 'a search armed before the relocalize still ran after it').toBe(0);
+    expect(root.querySelectorAll('.soc-suggest .soc-sugg-item')).toHaveLength(0);
   });
 
   it('drops the pending suggestion list with the listbox the rebuild destroys', async () => {
@@ -461,6 +553,27 @@ describe('#2529 delve tracker: the fan-out arm was present but inert', () => {
     controller.update();
     expect(element.querySelector('.dt-header'), 'the tracker rebuilt again').toBe(kept);
   });
+
+  it('needs no open check: with no run it clears the strip instead of painting', () => {
+    // The one relocalize in the nine with no open guard of its own. It leans on
+    // update()'s no-run arm, so that arm is what has to be pinned.
+    const element = mount('delve-tracker', 'block');
+    element.innerHTML = 'stale';
+    const closeRitePanel = vi.fn();
+    const controller = new DelveTrackerController({
+      element,
+      world: () => ({ delveRun: null, delveMarks: 0 }) as Pick<IWorld, 'delveRun' | 'delveMarks'>,
+      delveName: () => 'Collapsed Reliquary',
+      mobName: () => 'Deacon Varric',
+      attachTooltip: () => {},
+      closeRitePanel,
+    });
+    setLanguage(OTHER);
+    controller.relocalize();
+    expect(element.innerHTML).toBe('');
+    expect(element.style.display).toBe('none');
+    expect(closeRitePanel).toHaveBeenCalledWith(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -484,34 +597,115 @@ const LOCK_VIEW: LockpickView = {
   stepTimeoutMs: 15000,
 };
 
-describe('#2529 lockpick: the open board re-localizes', () => {
-  it('ignores the per-frame repaint after a language switch and repaints on relocalize()', () => {
-    const panel = mount('lockpick-panel', 'block');
-    const win = new LockpickWindow({
-      panel: () => panel,
-      getState: () => LOCK_VIEW,
-      tierName: (tier) => tier,
-      onEngage: () => {},
-      onAction: () => {},
-      onAbort: () => {},
-      onClose: () => {},
-    });
+function lockpickHarness(state: () => LockpickView | null): {
+  win: LockpickWindow;
+  panel: HTMLElement;
+} {
+  const panel = mount('lockpick-panel', 'block');
+  const win = new LockpickWindow({
+    panel: () => panel,
+    getState: state,
+    tierName: (tier) => tier,
+    onEngage: () => {},
+    onAction: () => {},
+    onAbort: () => {},
+    onClose: () => {},
+  });
+  return { win, panel };
+}
+
+describe('#2529 lockpick: both halves of the panel re-localize', () => {
+  it('ignores the per-frame repaint after a language switch and repaints the board', () => {
+    // Captured BEFORE the window is touched, so beat 3 compares against an
+    // independently read value rather than re-resolving the same t() call the
+    // painter just made (which would be a near-tautology).
+    const title = bilingual('lockpickUi.boardTitle', { tier: LOCK_VIEW.lootTier });
+    const { win, panel } = lockpickHarness(() => LOCK_VIEW);
     win.openBoard();
     const heading = (): string => panel.querySelector('.panel-title span')?.textContent ?? '';
-    const english = heading();
-    expect(english.length).toBeGreaterThan(0);
+    expect(heading()).toBe(title.en);
 
     setLanguage(OTHER);
     win.repaintIfChanged();
     expect(heading(), 'the board repainted itself: this arm no longer proves the gap').toBe(
-      english,
+      title.en,
     );
 
     win.relocalize();
-    const other = heading();
-    expect(other).toBe(t('lockpickUi.boardTitle', { tier: LOCK_VIEW.lootTier }));
-    expect(other, 'the board title reads the same in both locales').not.toBe(english);
+    expect(heading()).toBe(title.other);
+
+    // relocalize() CLEARS lastSig here and leans on repaintIfChanged to re-latch
+    // inside the same call, which is a different mechanism from the re-latching
+    // siblings and the one worth pinning: a leaked clear would rebuild the board
+    // on every frame for the rest of the attempt.
+    const kept = panel.querySelector('.panel-title span');
+    win.repaintIfChanged();
+    expect(panel.querySelector('.panel-title span'), 'the board rebuilt again').toBe(kept);
     win.stopTimer();
+  });
+
+  it('leaves the countdown reading the live remaining, not a full budget', () => {
+    // renderBoard re-emits the bar at width:100% and the full-duration label, and
+    // syncTimer deliberately does not restart the clock (the timer key did not
+    // move), so a naive relocalize would show a full timer on a TIMED minigame
+    // until the running interval's next tick.
+    vi.useFakeTimers();
+    const { win, panel } = lockpickHarness(() => LOCK_VIEW);
+    win.openBoard();
+    const bar = (): string =>
+      (panel.querySelector('#lp-timer-bar') as HTMLElement | null)?.style.width ?? '';
+    expect(bar()).toBe('100%');
+    vi.advanceTimersByTime(9_000);
+    const midAttempt = bar();
+    expect(midAttempt, 'the countdown never advanced: the arm proves nothing').not.toBe('100%');
+
+    setLanguage(OTHER);
+    win.relocalize();
+    expect(bar(), 'the rebuild snapped the countdown back to a full budget').not.toBe('100%');
+    win.stopTimer();
+  });
+
+  it('repaints the ante selector, which has no signature and no driver at all', () => {
+    // The state BEFORE a session exists: the player opened the chest and has not
+    // chosen an ante, so getState() is null and the board path cannot reach it.
+    const heading = bilingual('lockpickUi.pickTitle');
+    const { win, panel } = lockpickHarness(() => null);
+    win.renderAnte(7, false);
+    const title = (): string => panel.querySelector('.panel-title span')?.textContent ?? '';
+    expect(title()).toBe(heading.en);
+
+    setLanguage(OTHER);
+    win.repaintIfChanged();
+    expect(title(), 'something already repaints the ante selector: the arm is moot').toBe(
+      heading.en,
+    );
+
+    win.relocalize();
+    expect(title()).toBe(heading.other);
+  });
+
+  it('drops the retained ante inputs once a board has painted over them', () => {
+    // The sequence that makes a stale retention visible: the selector paints, the
+    // player picks an ante and the board replaces it, then the session ends while
+    // the panel is still up (getState() goes null again). If renderBoard had not
+    // dropped the retained pair, the relocalize below would paint a dead ante
+    // selector back over whatever the panel is showing.
+    let state: LockpickView | null = null;
+    const { win, panel } = lockpickHarness(() => state);
+    win.renderAnte(7, false);
+    expect(panel.querySelector('[data-ante]')).not.toBeNull();
+    state = LOCK_VIEW;
+    win.openBoard();
+    win.stopTimer();
+    expect(panel.querySelector('[data-ante]')).toBeNull();
+
+    state = null;
+    setLanguage(OTHER);
+    win.relocalize();
+    expect(
+      panel.querySelector('[data-ante]'),
+      'a stale retained ante repainted the selector after the session ended',
+    ).toBeNull();
   });
 });
 
@@ -523,32 +717,143 @@ describe('#2529 lockpick: the open board re-localizes', () => {
 // 7. Tutorial overlay
 // ---------------------------------------------------------------------------
 
+function tutorialWorld(over: Record<string, unknown> = {}): IWorld {
+  return {
+    playerId: 7,
+    player: { id: 7, level: 1, name: 'Aleron', pos: { x: 0, y: 0, z: 0 } },
+    questsDone: new Set<string>(),
+    questLog: new Map(),
+    questState: () => null,
+    entities: new Map(),
+    ...over,
+  } as unknown as IWorld;
+}
+
+const FAKE_RENDERER = {
+  worldToScreen: () => ({ x: 0, y: 0, behind: false }),
+} as unknown as Renderer;
+const FAKE_KEYBINDS = {
+  primaryLabel: (id: string) => id.toUpperCase(),
+} as unknown as Keybinds;
+
 describe('#2529 tutorial: the coachmark card re-localizes mid-step', () => {
   it('holds the old locale through update() and repaints on relocalize()', () => {
     const heading = bilingual('hud.tutorial.moveTitle');
     mount('ui', 'block');
-    const world = {
-      playerId: 7,
-      player: { id: 7, level: 1, name: 'Aleron', pos: { x: 0, y: 0, z: 0 } },
-      questsDone: new Set<string>(),
-      questLog: new Map(),
-      questState: () => null,
-      entities: new Map(),
-    } as unknown as IWorld;
-    const renderer = {
-      worldToScreen: () => ({ x: 0, y: 0, behind: false }),
-    } as unknown as Renderer;
-    const keybinds = { primaryLabel: (id: string) => id.toUpperCase() } as unknown as Keybinds;
+    const world = tutorialWorld();
     const overlay = new TutorialOverlay();
-    overlay.update(world, renderer, keybinds);
+    overlay.update(world, FAKE_RENDERER, FAKE_KEYBINDS);
     const title = (): string => document.querySelector('.tut-title')?.textContent ?? '';
     expect(title(), 'the tutorial card never rendered: the arm proves nothing').toBe(heading.en);
 
     setLanguage(OTHER);
-    overlay.update(world, renderer, keybinds);
+    overlay.update(world, FAKE_RENDERER, FAKE_KEYBINDS);
     expect(title(), 'update() repainted on an unchanged step: the arm is moot').toBe(heading.en);
 
-    overlay.relocalize(world, keybinds);
+    overlay.relocalize(world, FAKE_KEYBINDS);
     expect(title()).toBe(heading.other);
+
+    // The card reuses its element refs rather than rebuilding, so idempotence is
+    // pinned on the node identity plus the text staying put across a follow-up
+    // update() with the step unchanged.
+    const card = document.querySelector('.tut-card');
+    overlay.update(world, FAKE_RENDERER, FAKE_KEYBINDS);
+    expect(document.querySelector('.tut-card')).toBe(card);
+    expect(title()).toBe(heading.other);
+  });
+
+  it('paints nothing before a step exists, so the fan-out can call it unconditionally', () => {
+    mount('ui', 'block');
+    const overlay = new TutorialOverlay();
+    setLanguage(OTHER);
+    overlay.relocalize(tutorialWorld(), FAKE_KEYBINDS);
+    expect(document.querySelector('.tut-card'), 'relocalize built a card with no step').toBeNull();
+  });
+
+  it('refuses a world with no player rather than throwing out of the fan-out', () => {
+    // update() and isFreshCharacter both guard this: player is TYPED as an Entity
+    // but is absent in the online pre-snapshot window, and renderPanel reads
+    // player.name. A throw here would skip every fan-out arm after the tutorial.
+    const heading = bilingual('hud.tutorial.moveTitle');
+    mount('ui', 'block');
+    const overlay = new TutorialOverlay();
+    overlay.update(tutorialWorld(), FAKE_RENDERER, FAKE_KEYBINDS);
+    const title = (): string => document.querySelector('.tut-title')?.textContent ?? '';
+    expect(title()).toBe(heading.en);
+
+    setLanguage(OTHER);
+    expect(() => overlay.relocalize(tutorialWorld({ player: null }), FAKE_KEYBINDS)).not.toThrow();
+    expect(title(), 'it painted from a world with no player').toBe(heading.en);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. The contract every one of them states: safe to call while closed
+// ---------------------------------------------------------------------------
+
+// Every relocalize doc comment in the change claims to be self-gated so the
+// fan-out can call it unconditionally, and the fan-out does exactly that. Only
+// the spellbook proved it (in its own suite), so a dropped `if (!this.opened)
+// return;` would paint into a hidden root and leave every other assertion in
+// this file green.
+describe('#2529 a closed surface paints nothing when the fan-out reaches it', () => {
+  const cases: ReadonlyArray<[string, () => HTMLElement]> = [
+    [
+      'calendar',
+      () => {
+        const { win, root } = openCalendar();
+        win.close();
+        root.innerHTML = '';
+        win.relocalize();
+        return root;
+      },
+    ],
+    [
+      'mailbox',
+      () => {
+        const { win, root } = openMailbox();
+        win.close();
+        root.innerHTML = '';
+        win.relocalize();
+        return root;
+      },
+    ],
+    [
+      'social',
+      () => {
+        const { win, root } = openSocial();
+        win.close();
+        root.innerHTML = '';
+        win.relocalize();
+        return root;
+      },
+    ],
+    [
+      'card duel',
+      () => {
+        const { win, root } = openCardDuel();
+        win.close();
+        root.innerHTML = '';
+        win.relocalize();
+        return root;
+      },
+    ],
+    [
+      'lockpick',
+      () => {
+        const { win, panel } = lockpickHarness(() => LOCK_VIEW);
+        win.openBoard();
+        win.stopTimer();
+        panel.style.display = 'none';
+        panel.innerHTML = '';
+        win.relocalize();
+        return panel;
+      },
+    ],
+  ];
+
+  it.each(cases)('%s', (_name, run) => {
+    setLanguage(OTHER);
+    expect(run().innerHTML).toBe('');
   });
 });

--- a/tests/mobile_action_ring_painter.test.ts
+++ b/tests/mobile_action_ring_painter.test.ts
@@ -555,4 +555,58 @@ describe('Hud.buildMobileActionRing wiring (source scan)', () => {
       "(iconKey) => (iconKey === ATTACK_ICON_KEY ? '' : this.actionBarIconBg(iconKey)),",
     );
   });
+
+  // #2529: the page/count latch is two integers, so a language switch alone
+  // cannot move it and the elision above would hold the previous locale's
+  // "Page X of Y" and toggle name for as long as the player stayed on the page.
+  it('re-issues the elided indicator writes in the new locale after relocalize()', () => {
+    const { calls, writers } = recordingFacet();
+    const els = [0, 1, 2, 3, 4, 5].map((i) => slotElements(`ring${i}`));
+    const indicator = { tag: 'indicator' } as unknown as HTMLElement;
+    const toggle = { tag: 'toggle' } as unknown as HTMLElement;
+    let locale = 'en';
+    const painter = new MobileActionRingPainter(
+      writers,
+      {
+        bar: { container: { tag: 'c' } as unknown as HTMLElement, slots: els },
+        pageToggle: toggle,
+        pageIndicator: indicator,
+      },
+      (key) => `URL(${key})`,
+      (key, values) => `${locale}:${key}${values ? `|${JSON.stringify(values)}` : ''}`,
+    );
+    const pageBox = { page: 0 };
+    const view = createActionBarView({ slots: ringDescriptor(pageBox, new Map()) }, fakeDeps());
+    const indicatorWrites = (): unknown[] =>
+      calls.filter((c) => c.m === 'setText' && c.args[0] === indicator).map((c) => c.args[1]);
+    const toggleWrites = (): unknown[] =>
+      calls.filter((c) => c.m === 'setAttr' && c.args[0] === toggle).map((c) => c.args[2]);
+
+    painter.paint(view.tick(idleWorld()), 0, 2);
+    expect(indicatorWrites()).toEqual([
+      'en:hudChrome.mobile.actionPageIndicator|{"page":1,"count":2}',
+    ]);
+    expect(toggleWrites()).toEqual(['en:hudChrome.mobile.actionPageToggle']);
+
+    // The switch itself moves nothing the latch can see: this paint must elide.
+    locale = 'es';
+    painter.paint(view.tick(idleWorld()), 0, 2);
+    expect(indicatorWrites(), 'the unchanged-page paint stopped eliding').toHaveLength(1);
+
+    painter.relocalize();
+    painter.paint(view.tick(idleWorld()), 0, 2);
+    expect(indicatorWrites()).toEqual([
+      'en:hudChrome.mobile.actionPageIndicator|{"page":1,"count":2}',
+      'es:hudChrome.mobile.actionPageIndicator|{"page":1,"count":2}',
+    ]);
+    expect(toggleWrites()).toEqual([
+      'en:hudChrome.mobile.actionPageToggle',
+      'es:hudChrome.mobile.actionPageToggle',
+    ]);
+
+    // The latch is retaken by that paint, so the ring goes straight back to
+    // eliding rather than rewriting both nodes on every subsequent frame.
+    painter.paint(view.tick(idleWorld()), 0, 2);
+    expect(indicatorWrites(), 'relocalize() left the page latch cleared').toHaveLength(2);
+  });
 });

--- a/tests/spellbook_tick_repaint.test.ts
+++ b/tests/spellbook_tick_repaint.test.ts
@@ -31,11 +31,11 @@
 // quietly stopped looking at `cooldown` (or at the tail of the list) moves no other assertion
 // in this file.
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ResolvedAbility } from '../src/sim/sim';
 import { tEntity } from '../src/ui/entity_i18n';
 import type { HotbarAction } from '../src/ui/hud/action_bar/hotbar';
-import { t } from '../src/ui/i18n';
+import { ensureLocaleLoaded, setLanguage, t } from '../src/ui/i18n';
 import { SpellbookWindow, type SpellbookWindowDeps } from '../src/ui/spellbook_window';
 
 // jsdom ships no 2D canvas, so the procedural ability-icon compositor cannot run
@@ -807,5 +807,63 @@ describe('spellbook per-frame tick: the rebuild gate still watches every summary
     watch.stop();
     expect(h.toggle('charge')).toBe(before);
     expect(watch.writes, `a no-op snapshot repainted: ${watch.writes.join(', ')}`).toEqual([]);
+  });
+});
+
+// #2529: everything the gate above compares is an id or a number, so a runtime
+// language change moves none of it and an open spellbook kept the previous
+// locale until the player happened to learn or re-rank something.
+describe('spellbook: a language switch repaints through relocalize(), not through the gate', () => {
+  const OTHER = 'es';
+
+  beforeAll(async () => {
+    await ensureLocaleLoaded(OTHER);
+  });
+
+  afterEach(() => {
+    setLanguage('en');
+  });
+
+  it('holds the old locale through tickOpen and repaints on relocalize()', () => {
+    setLanguage('en');
+    const english = t('abilityUi.spellbook.title');
+    setLanguage(OTHER);
+    const other = t('abilityUi.spellbook.title');
+    expect(other, 'the spellbook title reads the same in both locales').not.toBe(english);
+    setLanguage('en');
+
+    const h = harness();
+    open(h);
+    const title = (): string =>
+      h.root.querySelector('.panel-title span')?.textContent?.trim() ?? '';
+    expect(title().startsWith(english)).toBe(true);
+
+    setLanguage(OTHER);
+    h.win.tickOpen();
+    expect(
+      title().startsWith(english),
+      'tickOpen repainted: this arm no longer proves the gap',
+    ).toBe(true);
+
+    h.win.relocalize();
+    expect(title().startsWith(other)).toBe(true);
+
+    // The rebuild re-latches every compared field, so the per-frame band goes
+    // straight back to eliding rather than repainting on every subsequent frame.
+    const settled = h.toggle('charge');
+    const watch = watchDom();
+    h.win.tickOpen();
+    watch.stop();
+    expect(h.toggle('charge')).toBe(settled);
+    expect(watch.writes, `relocalize() left the gate cleared: ${watch.writes.join(', ')}`).toEqual(
+      [],
+    );
+  });
+
+  it('refuses while the window is closed, so the fan-out can call it unconditionally', () => {
+    const h = harness();
+    setLanguage(OTHER);
+    h.win.relocalize();
+    expect(h.root.innerHTML, 'relocalize painted a closed spellbook').toBe('');
   });
 });


### PR DESCRIPTION
## Summary

A runtime language change does not reload the page. It dispatches `woc:languagechange`, and
`Hud.refreshLocalizedDynamicUi()` is the one hand-maintained fan-out that repaints the open
surfaces. A surface that rebuilds only when its **own repaint signature** moves never gets that
repaint, because every one of those signatures is a digest of ids, counts and positions, which is
the whole point of the idiom and also means `setLanguage` alone can never move one.

#2529 named four windows. Sweeping `src/ui` for the same shape found **nine**, including one the
issue could not have seen from the outside:

| Surface | State before |
|---|---|
| calendar, mailbox, social, card duel | the issue's four; `card_duel_window.relocalize()` already existed with **zero callers** |
| spellbook | rebuilds only when a resolved ability's id, rank, cost, cast time or cooldown moves |
| lockpick board | gated on board geometry and pick position |
| tutorial card | gated on the step and the Interface Mode flip |
| mobile ring page indicator | elided on the page/count integer pair |
| **delve tracker** | **its fan-out arm was already present and inert**: the arm called `update()`, and `update()` early-returned on its own unchanged signature |

Each gains a `relocalize()` that is self-gated on its own open check, forces exactly one rebuild,
and leaves its signature **re-latched to current state rather than cleared** (a cleared signature
buys a second rebuild on the next poll, which lands after any draft restore and undoes it).

**Three of them hold live typed input**, so a bare repaint would have fixed the language by wiping
a half-written letter. That is the loss #1695 already ruled on for the parcel path, where the
answer was to repaint *less*; a language switch cannot narrow that way, since every label in the
window is what moved. The new `src/ui/form_draft.ts` carries the draft across the rebuild instead,
keyed on each field's own identity rather than its position (the social footer's markup differs per
tab, so an index-keyed restore would drop a half-typed guild name into the friend field).

### Beyond the repaint itself

The review round found that several surfaces paid for the new rebuild somewhere else, and those are
fixed here too:

- the mailbox Send tab's paint **reveals** the bags window, so a language switch re-opened one the
  player had closed. The reveal is now an explicit `render({ revealBags })` argument, not a side
  effect every caller inherits.
- the lockpick board rebuild re-emitted the countdown at a full budget while the authoritative clock
  kept running, i.e. a **timed** minigame showing the wrong remaining time. It now repaints from the
  live deadline.
- the lockpick **ante selector** has no signature *and* no driver, so the first cut skipped it
  entirely and left the one screen a player sits on stale. It repaints from retained inputs, which
  are dropped whenever a board paints over them.
- the tutorial arm could throw on a world with no player, and a throw in one arm silently skips
  every arm after it.

### Focus, and the merge with #2528

`release/v0.32.0` landed the `focus_restore` seam mid-branch, with an absolute rule: a painter
carrying focus across a rebuild uses `captureFocusKey` / `restoreFirstEnabled`, never a hand-rolled
`activeElement` read. This branch takes that rule rather than sitting beside it. `form_draft` keeps
only the part the seam does not cover, the **identity**, because it needs one key that finds the
field again to write a captured *value* back and `data-focus-key` carries no value; the narrowing,
the containment check and the disabled skip come from `focus_restore`, which gains one export for
the case its own header already described as out of scope for #2528. That is a behavior gain, not
just conformance: a control the rebuild came back **disabled** can no longer take focus and silently
drop the player to `<body>`.

Focus is restored only when it was already inside the rebuilt root. The language picker lives in the
Options window, so at the moment of a switch the player is normally focused there, and re-focusing a
mailbox field would yank the caret out from under them.

## Related issues

Closes #2529.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation

## How was this tested?

- Commands:
  - `npm run gate` (release tier, since the branch is based on `release/v0.32.0`): **green**.
  - `npx vitest run tests/language_fanout_registry.test.ts tests/language_fanout_relocalize.test.ts tests/form_draft.test.ts tests/focus_restore.test.ts tests/architecture.test.ts tests/hud_update_drive.test.ts tests/hud_perf_budget.test.ts tests/mailbox_window*.test.ts tests/lockpick_*.test.ts tests/delve_tracker_controller.test.ts tests/spellbook_tick_repaint.test.ts tests/mobile_action_ring_painter.test.ts tests/social_window.test.ts tests/town_focus_repaint_gate.test.ts`
- **Mutation-tested, 16 mutations, all caught.** Every fix here was verified by reverting it and
  watching a named test go red, including a replay of the original bug: removing the card duel arm
  fails with *"exposing a relocalize() that Hud.refreshLocalizedDynamicUi never calls"*. The others
  cover a dropped fan-out arm, a bare `render()` in place of the draft-preserving relocalize, a
  cleared instead of re-latched signature, a new unclassified gated window, the delve tracker's
  inert arm, the bags reveal, the null-player guard, the ante repaint, the countdown deadline, the
  in-flight search, the stranded suggestion list, the selector escaping and the non-text focus
  restore.

## Screenshots / recordings

Not included, and I want to be explicit about the call rather than quietly drop the section. This
change adds no new visual design: the only visible difference is *which language* an
already-designed window renders in, and a before/after pair of the same window in two languages
carries less information than the per-surface tests, which switch to a real locale (`es`, not the
pseudo-locale) and assert the old language is still on screen after the ordinary repaint path before
asserting the new one lands. Happy to capture a pair if you would rather have it.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green, and every changed behavior has a decisive
      test (see the mutation results above).

### Cross-platform

- [x] **Accessible.** Focus across the forced rebuild goes through the `focus_restore` seam,
      including the disabled skip. Keyboard focus is never stolen from another open window.
- [ ] ~Tested on desktop and mobile.~ No layout, target size or font change; the mobile-specific
      surface touched is the action ring's page indicator, covered by its own suite.

### Localization (i18n)

- [x] **N/A. This PR adds no player-visible strings.** It is a pure *delivery* fix for keys that
      already existed: no catalog edit, no overlay edit, no new `pending` row, no matcher change.

### Hygiene

- [x] No secrets, no `ALLOW_DEV_COMMANDS`, no hand-edited generated files.

---

### Two things I did not do, called out for your ruling

1. **The fan-out has no failure isolation.** It is 41 bare statements, so one throwing arm silently
   skips every arm after it. I fixed the one concrete throw (the tutorial's) rather than reshaping
   the coordinator, because per-arm isolation means either 41 `try`/`catch` blocks or a table of
   thunks, and a table would empty the AST registry this issue asked for (`readMethodCallSites`
   deliberately does not descend into callbacks). Worth its own issue if you want it.
2. **Cold windows are a separate gap.** A window rendered once on open with no repaint driver at all
   (talents, inspect, leaderboard, claudium, dev command, daily rewards) is stale on a language
   switch for a different reason, with a different answer, and is out of scope here. The new guard's
   "where its teeth stop" section says so rather than implying coverage.
