### PR TITLE
docs(dungeons): The Hullworks dungeon PRD and build handoff

### DIFF
--- a/docs/prd/hullworks-dungeon-handoff.md
+++ b/docs/prd/hullworks-dungeon-handoff.md
@@ -1,0 +1,251 @@
+# Implementation Handoff: The Hullworks (five-player smuggler-shipyard dungeon)
+
+| | |
+|---|---|
+| **Status** | BLOCKED. Do not start slices until: (1) the Levy conversation on the PRD has happened (contribution process: features need a conversation first, then a PBE round); (2) the Galecrest zone PR #2321 (`feature/procedural-dungeons`) has merged, this dungeon stacks on its zone file; (3) the open question is resolved: level band 13 to 15 inside a level 20 zone (sheltered entrance pocket) OR re-band to 20. All numbers below assume 13 to 15; a re-band changes boss levels, loot ilvls, and the entrance pocket rule but no file structure. Pass 2 applied 2026-07-27 (maintainer direction: do not copy Deadmines, too long): cut from five bosses plus an optional wing to THREE (Charwick, the Hulljack, Redwake); Overseer Brack and Quartermaster Sallow cut outright along with the optional Sawpits wing; the Deadmines-style cannon-door breach replaced by the Sluiceworks flood beat, which the wrecker fiction actually earns (they drowned a hundred ships to build this one, and you drown it back); `cart_lanes.ts` and `wreck_train.ts` cut with their systems. |
+| **Portfolio lane** | Proposed first approval candidate and first dungeon build. This is not Levy approval. |
+| **Dispatch gate** | Levy selects the band and this portfolio slot, PR #2321 lands, and the PBE commitment is recorded. The pass-2 schedule cut is already applied; the protected spine is the worksite, the Charwick and Hulljack lineage, the Sluiceworks flood, and the Redwake deck finale. |
+| **Source PRD** | `docs/prd/hullworks-dungeon.md` (honor its File plan; this doc slices it) |
+| **Scope** | The full dungeon: instance shell, three bosses, the Sluiceworks flood beat, loot, heroic at launch on the existing machinery, deeds, quests, music, i18n, bot clear. Run length 20 to 30 minutes at level (tuning). PRD PR A = S1 to S4 (shell + bosses 1 to 2 lineage), PR B = S5 to S7 (flood + Redwake + heroic + loot). |
+| **Verified against** | 2026-07-25: `origin/release/v0.30.0` (all engine anchors) and `origin/feature/procedural-dungeons` (galecrest anchors); pass-2 re-slice 2026-07-27 against the pass-2 PRD (engine anchors unchanged). Re-find every symbol before editing; trust symbols, not line numbers. |
+| **Executor routing** | Claude uses `extract-and-test`, `build-dungeon-kit`, and `qa-checklist`; Codex uses `$woc-extract-and-test`, `$woc-build-dungeon-kit`, and `$woc-qa`. Sim diffs also get architecture review. |
+
+---
+
+## 0. Ground rules (deltas on FRONTIER_PHASE1_HANDOFF.md section 0, which applies verbatim)
+
+1. All of Frontier handoff section 0: sim purity, `Rng` only, i18n classification,
+   strict TS, no em/en dashes or emojis, Conventional Commits (`feat(hullworks): ...`),
+   acceptance commands over "looks done".
+2. Agent-completability is an acceptance criterion, not a style note: every interact is
+   a channel with a cast bar, every hazard has a full telegraph, no sub-second windows.
+3. Content is data-as-code in `src/sim/content/hullworks.ts`; behavior is modules behind
+   `SimContext` (`src/sim/sim_context.ts`). `sim.ts` gains only tick-call lines. The
+   Sluiceworks beat needs NO module: ground-object channels plus a door flag.
+4. Contributor slices add English ITEM name rows. Maintainers fill remaining locale
+   overlays before release. M16 quest prose needs the five non-Latin fills in the PR.
+   Boss/mechanic/aura names need `src/ui/sim_i18n.ts` matcher entries plus
+   `AURA_NAME_KEY`; NO test catches misses there, use the closeout checklists (S4, S7).
+5. Deeds are append-only: `DEED_ORDER` derives from `Object.keys(DEEDS)`
+   (`src/sim/content/deeds.ts:2228`), so new deeds go at the END of the record and ids
+   never change once shipped (`docs/design/deeds.md` authoring contract).
+6. The galecrest.ts edit stays additive and minimal: one POI, one NPC quest hook, one
+   camp-exclusion comment. It is a #2321 branch file; coordinate the base.
+
+## 1. Shared design constants (defined once in S1, imported everywhere)
+
+```ts
+// src/sim/content/hullworks.ts
+export const HULLWORKS_ID = 'hullworks';
+// S1 assigns the numeric DungeonDef index after auditing the active merged
+// registry, landed dependencies, and accepted batch handoffs. It must be unique.
+export const HULLWORKS_MIN_LEVEL = 13; // OPEN QUESTION; see header
+// Boss levels (tuning): Charwick 16, Hulljack 17, Redwake 18.
+// Entrance (tuning): work-lift head beside the Windway road, Galecrest coast south of
+// Wickharbor; propose doorPos near { x: 260, z: 452 } (Windway POI is 200,440; hub 420,360).
+// Place against real terrain and keep a 40 yd pocket clear of level-20 camps.
+```
+
+Timers (tuning, all generous by design): fuse crawl 10 s keg to keg, cut channel 1.5 s;
+Hulljack berserk 10 s, remount gap 6 s, three pilots; sluice wheel open is a
+wardstone-style channel (length tuning), one scripted crew response wave per wheel;
+Redwake phases 100/70/30, Broadside cone 90 deg. Instance x-band: origin derives from
+`index` like every dungeon (temple.ts:805 comment shows the formula, 900 + index*600).
+
+## 2. Verified hook-point map (re-find before editing)
+
+| Concern | Anchor |
+|---|---|
+| DUNGEON_DEFS registry | `src/sim/content/dungeons.ts:787`; merged at `src/sim/data.ts:432` (`DUNGEONS = { ...DUNGEON_DEFS, ...TEMPLE_DUNGEON_DEFS }`); Hullworks merges as a third spread or joins DUNGEON_DEFS |
+| DungeonDef shape | `src/sim/types.ts:2409`: id, index (unique x-band), doorPos, overworldDoor, entry, exitOffset, spawns, objects, `interior: 'crypt'|'sanctum'|'temple'|'nythraxis'`, suggestedPlayers, enterText/leaveText. A new interior key needs renderer + collider builders; S1 starts on `'crypt'` |
+| Keystone-style sealed doors | `nythraxis_crypt` def `dungeons.ts:829-864`: `objects` entry `{ templateId: 'dungeon_door', dungeonId: '<next-room-id>' }`; interact routes at `src/sim/interaction.ts:574` and `:646` to `ctx.enterDungeon`; door registry `src/sim/entity_roster.ts:125`, `src/sim/sim_context.ts:115`, spawn wiring `src/sim/instances/dungeons.ts:199`. Kill-boss-unseals = gate `ctx.enterDungeon` on the boss-kill flag, error otherwise (mirror the `crypt_keystone` gate, `src/sim/encounters/nythraxis.ts:1386`); the S5 lock gate gates on the both-wheels flood flag the same way |
+| Ground-object interact channel (sluice wheels, fuse cut) | `tryStartNythraxisWardChannel(ctx, obj, p)` called from both interaction.ts arms (before `pickUpObject`); implementation + channel/interrupt state in `src/sim/encounters/nythraxis.ts` (~1009 `lightNythraxisWardstones`, ~1121 channel mechanics). Copy the shape, not the file |
+| Boss-kit fields | `MobTemplate` at `src/sim/types.ts:1136` (`aoePulse`), examples `dungeons.ts:138` (aoePulse), `:184` (mortalStrike), `:294-295` (aoePulse + summonAdds), `:24` (charge/stun). NEW mechanics do NOT extend the kit; they live in the S3 to S6 modules keyed off template ids |
+| Entry clearance | every def comments `entry` clear of first-pack aggro; pinned by `tests/dungeon_entry_clearance.test.ts` |
+| Module tick pins | `src/sim/sim.ts` ~4505: `lap?.('<phase>')` after each phase; `server/game.ts:334` `SIM_LAP_PHASES` pins the exact emission list (append new names AFTER existing so old names stay byte-identical) |
+| Zone file (branch #2321) | `src/sim/content/galecrest.ts` (584 lines): `GALECREST_ZONE.pois` ~:42, `GALECREST_NPCS` :199 (Harbormaster Odile :213), `GALECREST_QUESTS` :255, `GALECREST_QUEST_ORDER` :437, `GALECREST_OBJECTS` :505, `GALECREST_CAMPS` :496; merged at `src/sim/data.ts:110-119` on that branch. Zone is `levelRange: [20, 20]` |
+| Deeds | `DEEDS` record `src/sim/content/deeds.ts:24`, per-boss first-kill rows follow existing dungeon rows; stat triggers via `src/sim/deeds.ts` counters (`groundObjectsLooted` pattern, `types.ts:4530`) |
+| Music | `src/game/music_tracks.ts:24-26` (`dungeon_<id>` key convention) + `src/game/instance_music.ts` (`instanceMusicDecision`, `InstanceMusicController`) |
+| Parity goldens | `tests/parity/scenarios.ts`; `UPDATE_PARITY=1 npx vitest run tests/parity` records; never regenerate to hide a diff |
+| Bot clear harness | `scripts/crypt_raid.mjs` is the template (puppeteer, needs `npm run dev` + `npm run server` + `ALLOW_DEV_COMMANDS=1`) |
+| Renderer set piece | new `src/render/hullworks_set.ts` called by the renderer (never a method bank on `renderer.ts`); interior builder keys resolve in the renderer + `src/sim/colliders.ts` interior paths (grep `interior ===`) |
+
+## 3. Slices
+
+Order: S1 -> S2 -> S3 -> S4 -> S5 -> S6 -> S7 (the S3 and S4 module work is
+independent and can run parallel, but S4 closes PR A so it lands last in it).
+PRD PR A ships S1 to S4; PR B ships S5 to S7. PBE round before any release merge.
+S4 and S7 are their PR-boundary closeouts. Each includes that PR's Deeds and
+pins, English catalog and any M16 work, sim matcher rows, wiki regeneration,
+credits/provenance, and
+`npx vitest run tests/deeds_content.test.ts tests/localization_fixes.test.ts tests/guide.test.ts && npm run wiki:content`.
+
+### S1. Instance shell, Liftworks, entrance POI, entry clearance
+- Goal: an enterable, exitable, empty-but-real dungeon: `hullworks` def (index
+  resolved from the active merged registry in this slice,
+  `interior: 'crypt'` as placeholder), internal-room def for the launched galleon deck
+  (`hullworks_deck`, `overworldDoor: false`, nythraxis_boss_arena pattern), sealed
+  `dungeon_door` objects between the boss rooms and at the lock gate to the deck (the
+  S5 flood flag unseals that one), doorPos in Galecrest.
+- Files: NEW `src/sim/content/hullworks.ts`; MODIFIED `src/sim/data.ts` (merge),
+  `src/sim/content/galecrest.ts` (ONLY: one poi `{ label: 'The Hullworks Lift', id: 'hullworks_lift' }`,
+  entrance-pocket comment on `GALECREST_CAMPS`), `tests/dungeon_entry_clearance.test.ts` pin.
+- Tests FIRST: `tests/hullworks.test.ts`: def registered in `DUNGEONS`, index unique
+  across dungeons+temple, enter at level 13 works, level 12 refused, entry point outside
+  aggro radius of the first Liftworks spawn, sealed doors refuse before their flags
+  (boss-kill doors and the lock gate).
+- Acceptance: `npx vitest run tests/hullworks.test.ts tests/dungeon_entry_clearance.test.ts tests/dungeons.test.ts tests/architecture.test.ts && npx vitest run tests/parity` (untouched).
+
+### S2. Work-crew packs + crews-stop-work readability
+- Goal: all trash as legible WORK CREWS (sawyers, rat-catchers, powder line) in
+  `DUNGEON_MOBS`-style templates inside hullworks.ts; killing a crew stops its work
+  loop. Readability is sim-cheap: crews carry a `working` aura/emote state the renderer
+  reads; on last-crew-death emit the existing ambience-quiet path (per-room ambience,
+  no new event type if an aura drop suffices).
+- Files: hullworks.ts (mob templates + spawn list, elite, level 14 to 16, hp/dmg per the
+  neighboring Sunken Bastion rows scaled by the engine curves, no invented balance).
+- Tests FIRST: extend tests/hullworks.test.ts: pack composition, elite flags, level
+  bands, XP/loot rows present, crew-death clears the working state deterministically.
+- Acceptance: `npx vitest run tests/hullworks.test.ts && npx vitest run tests/parity`.
+
+### S3. fuse_lines module + Charwick the Fusemonger
+- Goal: NEW `src/sim/fuse_lines.ts`: crawling fuses toward keg clusters, cuttable.
+  State sketch:
+  ```ts
+  interface FuseLine { id: string; targetClusterId: string; startedAt: number;
+    travelTime: number; cut: boolean; }
+  // progress = (ctx.time - startedAt) / travelTime; at >= 1 and !cut: detonate the
+  // cluster as a groundAoE. cutFuse: a 1.5 s interact channel on the fuse ground
+  // object (tryStartNythraxisWardChannel pattern in interaction.ts), sets cut.
+  ```
+  Kegs and fuse heads are `objects` rows; Charwick lights one fuse (rng cluster pick via
+  `ctx.rng`, drawn only inside the encounter), three at once below 30 pct. Flashpan is
+  an existing cone debuff row.
+- Files: NEW `src/sim/fuse_lines.ts` + `tests/fuse_lines.test.ts`; hullworks.ts;
+  interaction.ts (one `tryStartFuseCut(ctx, obj, p)` call beside the ward-channel call);
+  sim.ts tick line + SIM_LAP_PHASES append (`'fuseLines'` AFTER existing names);
+  `src/sim/content/deeds.ts` (Charwick first-kill and Dry Powder rows) plus deed
+  catalog pins.
+- Tests FIRST: uncut fuse detonates exactly at travelTime; cut fuse never does; channel
+  interrupted by damage does not cut; sub-30-pct lights exactly three; rng draws only
+  during the encounter (parity safety).
+- Acceptance: `npx vitest run tests/fuse_lines.test.ts tests/deeds_content.test.ts tests/architecture.test.ts && npx vitest run tests/parity`.
+
+### S4. rig_pilot module + the Hulljack (PR A closeout)
+- Goal: NEW `src/sim/rig_pilot.ts`: pilot/berserk/remount state machine. Rig and pilot
+  are separate entities; pilot is the priority target. States: `piloted -> berserk(10s,
+  random slow cleaves via ctx.rng) -> remount-run(6s burn window) -> piloted`, three
+  pilots total, then a fixed overload (three telegraphed aoePulse rings) and inert.
+  Grapple Claw: tank grab + 8 yd drag on existing knockback plumbing, breaks on stun or
+  pilot death.
+- Files: NEW `src/sim/rig_pilot.ts` + `tests/rig_pilot.test.ts`; hullworks.ts (rig +
+  enginewright templates, queue positions); sim.ts tick line + SIM_LAP_PHASES append
+  (`'rigPilot'`); `src/sim/content/deeds.ts` (Hulljack first-kill row) plus deed
+  catalog pins.
+- Tests FIRST: full state-machine walk (3 pilots then overload then inert); berserk
+  never targets (no threat writes); burn window is exactly the remount gap; drag breaks
+  on stun OR pilot death; deterministic under fixed seed.
+- Acceptance: `npx vitest run tests/rig_pilot.test.ts tests/deeds_content.test.ts && npx vitest run tests/parity`.
+
+### S5. The Sluiceworks flood beat (no module: ground-object channels plus a door flag)
+- Goal: the drydock's two sea-lock wheels are ground objects on opposite galleries;
+  opening each is a wardstone-style channel (ward-channel pattern, the same verb
+  machinery as the S3 fuse cut) while the party holds ONE scripted crew response wave
+  per wheel (fixed composition, no rng). Both wheels open: the lock gates part, the sea
+  comes in, and the half-built galleon lurches off her blocks and launches a season
+  early; the lock-gate `dungeon_door` to the deck unseals on the flood flag, and the
+  signature inrush audio sting event emits (`SimEvent` union in `src/sim/types.ts:1393`
+  area; the client plays the SFX). The party rides the rising water up to her deck: a
+  scripted lift, render dressing on the fixed arena; sim space never moves.
+- Files: hullworks.ts (wheel + lock-gate objects, response waves, flood flag),
+  fuse/interaction glue reused from S3 (one wheel-channel call beside the ward-channel
+  call), types.ts (one event variant), client SFX hook in the existing event handler
+  path; NEW `src/render/hullworks_set.ts` (flood + scripted-lift dressing);
+  `src/sim/content/deeds.ts` (She Never Sailed row: both wheels opened without a party
+  death during the flood beat) plus deed catalog pins.
+- Tests FIRST: deck door sealed before both wheels open, unsealed after; an opened
+  wheel refuses re-opening; each wheel spawns its response wave exactly once per
+  lockout; channel interruptible by damage; the beat draws no rng; She Never Sailed
+  triggers only when both wheels open with zero party deaths during the beat.
+- Acceptance: `npx vitest run tests/hullworks.test.ts tests/deeds_content.test.ts && npx vitest run tests/parity`.
+
+### S6. Captain Ede Redwake, three phases (rising water as a cut-safe render slice)
+- Goal: encounter module `src/sim/encounters/redwake.ts` (nythraxis.ts is the template):
+  P1 Riposte stance windows (visible stance aura; frontal attacks during it reflect a
+  cleave, positional check); P2 ALL HANDS waves (FIXED composition of surviving site
+  crew types; the cleared-wing scaling died with the wings at pass 2) plus Broadside
+  cone; P3 the flood you started reaches the gun deck: Waking-Fury-style soft-enrage
+  ramp (tuning) as the ship settles lower, death line emits the sequel-hook text via a
+  stable key. The RISING WATER is renderer-only: `src/render/hullworks_set.ts` raises
+  the water dressing on the P3 event; sim space never moves (arena is the deck
+  throughout). It is severable: if cut (open question 3), only the render slice drops.
+- Files: NEW `src/sim/encounters/redwake.ts` + `tests/redwake.test.ts`; MODIFY
+  `src/render/hullworks_set.ts` (P3 rising water); hullworks.ts (Redwake template +
+  loot hook); NEW parity scenario `hullworks_redwake` in `tests/parity/scenarios.ts`
+  (five seeded players, full three-phase kill) recorded with `UPDATE_PARITY=1` (new
+  golden only; existing goldens must stay byte-identical).
+  MODIFY `src/sim/content/deeds.ts` (Redwake first-kill and title rows) plus
+  deed catalog pins.
+- Tests FIRST: riposte reflects frontal attacks during stance, does NOT reflect
+  rear attacks during stance, and does NOT reflect frontal attacks outside stance; phase
+  thresholds exact; P2 wave composition is the fixed authored list (no wing-state
+  reads); ramp makes an infinite turtle impossible; death emits the hook line event.
+- Acceptance: `npx vitest run tests/redwake.test.ts tests/deeds_content.test.ts && npx vitest run tests/parity && npm run build`.
+
+### S7. Loot (incl. the hat), heroic, i18n sweep, music, bot clear (PR B closeout)
+- Loot: rares off bosses 1 and 2, one epic per class-armor lane off Redwake plus the
+  boarding axe; every stat sum obeys `tests/item_level` budgets (compute the budget
+  FIRST, exact numbers are authored here, tuning until then); "Redwake's Plumed Hat"
+  cosmetic epic, low drop rate (tuning, Levy question 4). Icons via `gen-icon-art`
+  (`src/ui/icons.ts` + `public/ui/items/mapping.json`); GLB props via `gen-3d-asset`;
+  `CREDITS.md`.
+- Heroic (RESOLVED 2026-07-26, maintainer direction): heroic mode ships at launch
+  on the existing machinery only: the heroic difficulty flag, standing
+  multipliers, and the automatic five-man heroic swap doing the loot (these
+  13-to-15 drops are below the swap's upgrade floor, so heroic variants generate
+  for free). No heroic-only mechanics, nothing bespoke to author.
+- Deeds: earlier slices already carry the three first-kill rows, Dry Powder, She
+  Never Sailed, and the Redwake title row. Nothing appends here (the Full Manifest
+  meta row died with the five-boss scope at pass 2).
+- Quest note: Odile's lead-in and its M16 work already landed in PR A's S4 closeout.
+- i18n sweep checklist (nothing else catches these): English item-name rows;
+  Redwake, the Sluiceworks, and PR B mechanic/aura names in the `sim_i18n.ts` matcher
+  DICTs + `AURA_NAME_KEY` (Charwick and Hulljack rows landed in PR A's S4 closeout);
+  enter/leave texts; death line; regenerated `i18n.resolved.generated/` committed.
+- Music: `dungeon_hullworks` key in `music_tracks.ts` + track file (work-shanty over the
+  Galecrest chord spine, site noise baked in); sluice inrush sting SFX from S5.
+- Bot clear: `scripts/hullworks_raid.mjs` from the `crypt_raid.mjs` template; a full
+  five-bot clear at level is the tuning acceptance (Slag Run rule: if bots cannot clear
+  it, the tuning is wrong). Guide regen: `npm run wiki:content` + `guide.*` keys.
+- Acceptance: `npx vitest run tests/item_level.test.ts tests/deeds_content.test.ts tests/localization_fixes.test.ts tests/i18n_completeness.test.ts tests/guide.test.ts && node scripts/hullworks_raid.mjs && npm run gate`; bot clear video/screenshots per the PR template.
+
+## 4. Gotchas (read before every slice)
+
+- **G1, SIM_LAP_PHASES pins the sim's emission list.** Every module that gains a
+  `lap?.('name')` in sim.ts MUST append the same name to `server/game.ts:334`, AFTER the
+  existing names (the base list stays byte-identical). Two pins land here: `fuseLines`
+  (S3) and `rigPilot` (S4). The Sluiceworks beat has no module and no pin.
+- **G2, the zone file is not yours.** galecrest.ts lives on the #2321 branch and its
+  author may still be moving it. Every edit is additive (new poi row, new quest rows,
+  comments); never re-shape existing exports. If #2321 has not merged when S1 starts,
+  stop and re-check the base with the operator.
+- **G3, parity.** New `ctx.rng` draws must live strictly inside Hullworks code paths
+  (encounter state, instance band). One new golden (`hullworks_redwake`, S6) is added;
+  if any EXISTING golden reds, the fix is the code, never `UPDATE_PARITY=1` on it.
+- **G4, i18n ownership is split.** The closeout slices (S4, S7) add English item-name
+  rows and any M16 five-locale prose fills. Maintainers fill remaining overlays before
+  release. Aura/mechanic names have NO guard test; the closeout checklists are the
+  only net.
+- **G5, deeds are forever.** Ids and `DEED_ORDER` position are persisted identity;
+  append at the end, never rename, never reorder.
+- **G6, level-band risk.** Until Levy answers open question 1, do not author loot or XP
+  rows (they are the band-sensitive parts); S1 to S6 mechanics survive a re-band.
+- **G7, interior key.** S1 ships on `interior: 'crypt'`; a bespoke shipyard interior is
+  a render/collider pair keyed off a new union member, land it with the S5 to S6
+  set-piece work or not at all. Do not block the sim slices on art.
+
+## 5. Fails-before evidence (contribution process)
+
+Each slice's tests are written FIRST and shown failing on the pre-slice tree (the
+sealed-door test fails before S1 wires the flag, the fuse test fails before S3 exists);
+put the fails-before / passes-after output in each PR body per Levy's quality bar.

--- a/docs/prd/hullworks-dungeon-handoff.md
+++ b/docs/prd/hullworks-dungeon-handoff.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-| **Status** | BLOCKED. Do not start slices until: (1) the Levy conversation on the PRD has happened (contribution process: features need a conversation first, then a PBE round); (2) the `feature/procedural-dungeons` branch (umbrella PR #1584) has landed in a release, since this dungeon stacks on its zone file; (3) the open question is resolved: level band 13 to 15 inside a level 20 zone (sheltered entrance pocket) OR re-band to 20. All numbers below assume 13 to 15; a re-band changes boss levels, loot ilvls, and the entrance pocket rule but no file structure. Pass 2 applied 2026-07-27 (maintainer direction: do not copy Deadmines, too long): cut from five bosses plus an optional wing to THREE (Charwick, the Hulljack, Redwake); Overseer Brack and Quartermaster Sallow cut outright along with the optional Sawpits wing; the Deadmines-style cannon-door breach replaced by the Sluiceworks flood beat, which the wrecker fiction actually earns (they drowned a hundred ships to build this one, and you drown it back); `cart_lanes.ts` and `wreck_train.ts` cut with their systems. |
+| **Status** | READY FOR THE LEVY CONVERSATION. The zone dependency is satisfied: `src/sim/content/galecrest.ts` landed in `release/v0.33.0`, is merged through `src/sim/data.ts`, and is placed in `ZONES`. Do not start slices until: (1) the Levy conversation on the PRD has happened and Levy has selected the band and portfolio slot; (2) the PBE round commitment is recorded; (3) the open question is resolved: level band 13 to 15 inside a level 20 zone (sheltered entrance pocket) OR re-band to 20. All numbers below assume 13 to 15; a re-band changes boss levels, loot ilvls, and the entrance pocket rule but no file structure. Pass 2 applied 2026-07-27 (maintainer direction: do not copy Deadmines, too long): cut from five bosses plus an optional wing to THREE (Charwick, the Hulljack, Redwake); Overseer Brack and Quartermaster Sallow cut outright along with the optional Sawpits wing; the Deadmines-style cannon-door breach replaced by the Sluiceworks flood beat, which the wrecker fiction actually earns (they drowned a hundred ships to build this one, and you drown it back); `cart_lanes.ts` and `wreck_train.ts` cut with their systems. |
 | **Portfolio lane** | Proposed first approval candidate and first dungeon build. This is not Levy approval. |
-| **Dispatch gate** | Levy selects the band and this portfolio slot, the `feature/procedural-dungeons` branch (umbrella PR #1584) lands in a release, and the PBE commitment is recorded. The pass-2 schedule cut is already applied; the protected spine is the worksite, the Charwick and Hulljack lineage, the Sluiceworks flood, and the Redwake deck finale. |
+| **Dispatch gate** | The zone dependency is satisfied: `src/sim/content/galecrest.ts` landed in `release/v0.33.0`, is merged through `src/sim/data.ts`, and is placed in `ZONES`. Dispatch remains gated on Levy selecting the band and this portfolio slot, resolving the open level-band question, and recording the PBE round commitment. The pass-2 schedule cut is already applied; the protected spine is the worksite, the Charwick and Hulljack lineage, the Sluiceworks flood, and the Redwake deck finale. |
 | **Source PRD** | `docs/prd/hullworks-dungeon.md` (honor its File plan; this doc slices it) |
 | **Scope** | The full dungeon: instance shell, three bosses, the Sluiceworks flood beat, loot, heroic at launch on the existing machinery, deeds, quests, music, i18n, bot clear. Run length 20 to 30 minutes at level (tuning). PRD PR A = S1 to S4 (shell + bosses 1 to 2 lineage), PR B = S5 to S7 (flood + Redwake + heroic + loot). |
-| **Verified against** | 2026-07-25: `origin/release/v0.30.0` (all engine anchors) and `origin/feature/procedural-dungeons` (galecrest anchors); pass-2 re-slice 2026-07-27 against the pass-2 PRD (engine anchors unchanged). Re-find every symbol before editing; trust symbols, not line numbers. |
+| **Verified against** | 2026-07-31: `release/v0.33.0` for `src/sim/content/galecrest.ts`, its merge through `src/sim/data.ts`, and its placement in `ZONES`; engine anchors remain from the 2026-07-25 review of `origin/release/v0.30.0`, with the pass-2 re-slice checked against the PRD on 2026-07-27. Re-find every symbol before editing; trust symbols, not line numbers. |
 | **Executor routing** | Claude uses `extract-and-test`, `build-dungeon-kit`, and `qa-checklist`; Codex uses `$woc-extract-and-test`, `$woc-build-dungeon-kit`, and `$woc-qa`. Sim diffs also get architecture review. |
 
 ---
@@ -29,9 +29,9 @@
 5. Deeds are append-only: `DEED_ORDER` derives from `Object.keys(DEEDS)` in
    `src/sim/content/deeds.ts`, so new deeds go at the END of the record and ids
    never change once shipped (`docs/design/deeds.md` authoring contract).
-6. The galecrest.ts edit stays additive and minimal: one POI, one NPC quest hook, one
-   camp-exclusion comment. It comes from the `feature/procedural-dungeons` branch
-   (umbrella PR #1584), which must land in a release before dispatch; coordinate the base.
+6. The `src/sim/content/galecrest.ts` edit stays additive and minimal: one POI, one
+   NPC quest hook, one camp-exclusion comment. The file landed in `release/v0.33.0`,
+   is merged through `src/sim/data.ts`, and is placed in `ZONES`; coordinate the base.
 
 ## 1. Shared design constants (defined once in S1, imported everywhere)
 
@@ -69,7 +69,7 @@ Redwake phases 100/70/30, Broadside cone 90 deg. Instance x-bands derive from
 | Boss-kit fields | `MobTemplate` in `src/sim/types.ts` defines fields such as `aoePulse`; `DUNGEON_MOBS` in `src/sim/content/dungeons.ts` provides examples for `aoePulse`, `mortalStrike`, `summonAdds`, charge, and stun. NEW mechanics do NOT extend the kit; they live in the S3 to S6 modules keyed off template ids |
 | Entry clearance | every def comments `entry` clear of first-pack aggro; pinned by `tests/dungeon_entry_clearance.test.ts` |
 | Module tick pins | `Sim` in `src/sim/sim.ts` emits each lap phase; `SIM_LAP_PHASES` in `server/game.ts` pins the exact emission list. Append new names AFTER existing names so old names stay byte-identical |
-| Zone file from the `feature/procedural-dungeons` branch (umbrella PR #1584) | `src/sim/content/galecrest.ts` exports `GALECREST_ZONE`, `GALECREST_NPCS`, `GALECREST_QUESTS`, `GALECREST_QUEST_ORDER`, `GALECREST_OBJECTS`, and `GALECREST_CAMPS`; the branch merges them through the exported content registries in `src/sim/data.ts`. `GALECREST_ZONE` has `levelRange: [20, 20]` |
+| Zone content landed in `release/v0.33.0` | `src/sim/content/galecrest.ts` exports `GALECREST_ZONE`, `GALECREST_NPCS`, `GALECREST_QUESTS`, `GALECREST_QUEST_ORDER`, `GALECREST_OBJECTS`, and `GALECREST_CAMPS`; `src/sim/data.ts` merges them through the exported content registries and places `GALECREST_ZONE` in `ZONES`. `GALECREST_ZONE` has `levelRange: [20, 20]` |
 | Deeds | `DEEDS` and `DEED_ORDER` in `src/sim/content/deeds.ts`; per-boss first-kill rows follow existing dungeon rows. Stat triggers use exported helpers such as `bumpDeedStat` in `src/sim/deeds.ts` |
 | Dungeon Finder | `FINDER_ACTIVITIES` and `FinderEncounter` in `src/sim/content/dungeon_finder.ts`; heroic boss drops use `HEROIC_BOSS_LOOT` in `src/sim/content/heroic_loot.ts`; `tests/dungeon_finder.test.ts` pins activity ids and level ranges |
 | Music | `ZONE_STREAM_URLS` in `src/game/music_tracks.ts`; `instanceMusicDecision` and `InstanceMusicController` in `src/game/instance_music.ts` |
@@ -251,11 +251,10 @@ credits/provenance, and
   `SIM_LAP_PHASES` in `server/game.ts`, AFTER the
   existing names (the base list stays byte-identical). Two pins land here: `fuseLines`
   (S3) and `rigPilot` (S4). The Sluiceworks beat has no module and no pin.
-- **G2, the zone file is not yours.** `src/sim/content/galecrest.ts` comes from the
-  `feature/procedural-dungeons` branch (umbrella PR #1584), and its
-  author may still be moving it. Every edit is additive (new poi row, new quest rows,
-  comments); never re-shape existing exports. If that branch has not landed in a
-  release when S1 starts, stop and re-check the base with the operator.
+- **G2, the zone file is not yours.** `src/sim/content/galecrest.ts` landed in
+  `release/v0.33.0`, is merged through `src/sim/data.ts`, and is placed in `ZONES`.
+  Every edit is additive (new poi row, new quest rows, comments); never re-shape
+  existing exports. Re-check the release base with the operator before S1 starts.
 - **G3, parity.** New `ctx.rng` draws must live strictly inside Hullworks code paths
   (encounter state, instance band). One new golden (`hullworks_redwake`, S6) is added;
   if any EXISTING golden reds, the fix is the code, never `UPDATE_PARITY=1` on it.

--- a/docs/prd/hullworks-dungeon-handoff.md
+++ b/docs/prd/hullworks-dungeon-handoff.md
@@ -2,9 +2,9 @@
 
 | | |
 |---|---|
-| **Status** | BLOCKED. Do not start slices until: (1) the Levy conversation on the PRD has happened (contribution process: features need a conversation first, then a PBE round); (2) the Galecrest zone PR #2321 (`feature/procedural-dungeons`) has merged, this dungeon stacks on its zone file; (3) the open question is resolved: level band 13 to 15 inside a level 20 zone (sheltered entrance pocket) OR re-band to 20. All numbers below assume 13 to 15; a re-band changes boss levels, loot ilvls, and the entrance pocket rule but no file structure. Pass 2 applied 2026-07-27 (maintainer direction: do not copy Deadmines, too long): cut from five bosses plus an optional wing to THREE (Charwick, the Hulljack, Redwake); Overseer Brack and Quartermaster Sallow cut outright along with the optional Sawpits wing; the Deadmines-style cannon-door breach replaced by the Sluiceworks flood beat, which the wrecker fiction actually earns (they drowned a hundred ships to build this one, and you drown it back); `cart_lanes.ts` and `wreck_train.ts` cut with their systems. |
+| **Status** | BLOCKED. Do not start slices until: (1) the Levy conversation on the PRD has happened (contribution process: features need a conversation first, then a PBE round); (2) the `feature/procedural-dungeons` branch (umbrella PR #1584) has landed in a release, since this dungeon stacks on its zone file; (3) the open question is resolved: level band 13 to 15 inside a level 20 zone (sheltered entrance pocket) OR re-band to 20. All numbers below assume 13 to 15; a re-band changes boss levels, loot ilvls, and the entrance pocket rule but no file structure. Pass 2 applied 2026-07-27 (maintainer direction: do not copy Deadmines, too long): cut from five bosses plus an optional wing to THREE (Charwick, the Hulljack, Redwake); Overseer Brack and Quartermaster Sallow cut outright along with the optional Sawpits wing; the Deadmines-style cannon-door breach replaced by the Sluiceworks flood beat, which the wrecker fiction actually earns (they drowned a hundred ships to build this one, and you drown it back); `cart_lanes.ts` and `wreck_train.ts` cut with their systems. |
 | **Portfolio lane** | Proposed first approval candidate and first dungeon build. This is not Levy approval. |
-| **Dispatch gate** | Levy selects the band and this portfolio slot, PR #2321 lands, and the PBE commitment is recorded. The pass-2 schedule cut is already applied; the protected spine is the worksite, the Charwick and Hulljack lineage, the Sluiceworks flood, and the Redwake deck finale. |
+| **Dispatch gate** | Levy selects the band and this portfolio slot, the `feature/procedural-dungeons` branch (umbrella PR #1584) lands in a release, and the PBE commitment is recorded. The pass-2 schedule cut is already applied; the protected spine is the worksite, the Charwick and Hulljack lineage, the Sluiceworks flood, and the Redwake deck finale. |
 | **Source PRD** | `docs/prd/hullworks-dungeon.md` (honor its File plan; this doc slices it) |
 | **Scope** | The full dungeon: instance shell, three bosses, the Sluiceworks flood beat, loot, heroic at launch on the existing machinery, deeds, quests, music, i18n, bot clear. Run length 20 to 30 minutes at level (tuning). PRD PR A = S1 to S4 (shell + bosses 1 to 2 lineage), PR B = S5 to S7 (flood + Redwake + heroic + loot). |
 | **Verified against** | 2026-07-25: `origin/release/v0.30.0` (all engine anchors) and `origin/feature/procedural-dungeons` (galecrest anchors); pass-2 re-slice 2026-07-27 against the pass-2 PRD (engine anchors unchanged). Re-find every symbol before editing; trust symbols, not line numbers. |
@@ -26,49 +26,56 @@
    overlays before release. M16 quest prose needs the five non-Latin fills in the PR.
    Boss/mechanic/aura names need `src/ui/sim_i18n.ts` matcher entries plus
    `AURA_NAME_KEY`; NO test catches misses there, use the closeout checklists (S4, S7).
-5. Deeds are append-only: `DEED_ORDER` derives from `Object.keys(DEEDS)`
-   (`src/sim/content/deeds.ts:2228`), so new deeds go at the END of the record and ids
+5. Deeds are append-only: `DEED_ORDER` derives from `Object.keys(DEEDS)` in
+   `src/sim/content/deeds.ts`, so new deeds go at the END of the record and ids
    never change once shipped (`docs/design/deeds.md` authoring contract).
 6. The galecrest.ts edit stays additive and minimal: one POI, one NPC quest hook, one
-   camp-exclusion comment. It is a #2321 branch file; coordinate the base.
+   camp-exclusion comment. It comes from the `feature/procedural-dungeons` branch
+   (umbrella PR #1584), which must land in a release before dispatch; coordinate the base.
 
 ## 1. Shared design constants (defined once in S1, imported everywhere)
 
 ```ts
 // src/sim/content/hullworks.ts
 export const HULLWORKS_ID = 'hullworks';
-// S1 assigns the numeric DungeonDef index after auditing the active merged
-// registry, landed dependencies, and accepted batch handoffs. It must be unique.
+export const HULLWORKS_INDEX = 6;
+export const HULLWORKS_DECK_ID = 'hullworks_deck';
+export const HULLWORKS_DECK_INDEX = 7;
+// Finder band only. DungeonDef has no level field, and physical door entry stays
+// ungated by level like every other dungeon.
 export const HULLWORKS_MIN_LEVEL = 13; // OPEN QUESTION; see header
 // Boss levels (tuning): Charwick 16, Hulljack 17, Redwake 18.
-// Entrance (tuning): work-lift head beside the Windway road, Galecrest coast south of
-// Wickharbor; propose doorPos near { x: 260, z: 452 } (Windway POI is 200,440; hub 420,360).
-// Place against real terrain and keep a 40 yd pocket clear of level-20 camps.
+// Entrance (tuning): sea cave in the lee of the Wickharbor cove, Galecrest coast.
+// Propose doorPos within x 400 to 430, z 370 to 400, near { x: 415, z: 385 }.
+// S1 verifies final placement against real terrain and keeps a 40 yd pocket clear
+// of level-20 camps.
 ```
 
 Timers (tuning, all generous by design): fuse crawl 10 s keg to keg, cut channel 1.5 s;
 Hulljack berserk 10 s, remount gap 6 s, three pilots; sluice wheel open is a
 wardstone-style channel (length tuning), one scripted crew response wave per wheel;
-Redwake phases 100/70/30, Broadside cone 90 deg. Instance x-band: origin derives from
-`index` like every dungeon (temple.ts:805 comment shows the formula, 900 + index*600).
+Redwake phases 100/70/30, Broadside cone 90 deg. Instance x-bands derive from
+`index` through `instanceOrigin` in `src/sim/data.ts`. Reserve index 6 for
+`hullworks` and index 7 for `hullworks_deck`; both must remain unique in `DUNGEONS`.
 
 ## 2. Verified hook-point map (re-find before editing)
 
 | Concern | Anchor |
 |---|---|
-| DUNGEON_DEFS registry | `src/sim/content/dungeons.ts:787`; merged at `src/sim/data.ts:432` (`DUNGEONS = { ...DUNGEON_DEFS, ...TEMPLE_DUNGEON_DEFS }`); Hullworks merges as a third spread or joins DUNGEON_DEFS |
-| DungeonDef shape | `src/sim/types.ts:2409`: id, index (unique x-band), doorPos, overworldDoor, entry, exitOffset, spawns, objects, `interior: 'crypt'|'sanctum'|'temple'|'nythraxis'`, suggestedPlayers, enterText/leaveText. A new interior key needs renderer + collider builders; S1 starts on `'crypt'` |
-| Keystone-style sealed doors | `nythraxis_crypt` def `dungeons.ts:829-864`: `objects` entry `{ templateId: 'dungeon_door', dungeonId: '<next-room-id>' }`; interact routes at `src/sim/interaction.ts:574` and `:646` to `ctx.enterDungeon`; door registry `src/sim/entity_roster.ts:125`, `src/sim/sim_context.ts:115`, spawn wiring `src/sim/instances/dungeons.ts:199`. Kill-boss-unseals = gate `ctx.enterDungeon` on the boss-kill flag, error otherwise (mirror the `crypt_keystone` gate, `src/sim/encounters/nythraxis.ts:1386`); the S5 lock gate gates on the both-wheels flood flag the same way |
-| Ground-object interact channel (sluice wheels, fuse cut) | `tryStartNythraxisWardChannel(ctx, obj, p)` called from both interaction.ts arms (before `pickUpObject`); implementation + channel/interrupt state in `src/sim/encounters/nythraxis.ts` (~1009 `lightNythraxisWardstones`, ~1121 channel mechanics). Copy the shape, not the file |
-| Boss-kit fields | `MobTemplate` at `src/sim/types.ts:1136` (`aoePulse`), examples `dungeons.ts:138` (aoePulse), `:184` (mortalStrike), `:294-295` (aoePulse + summonAdds), `:24` (charge/stun). NEW mechanics do NOT extend the kit; they live in the S3 to S6 modules keyed off template ids |
+| DUNGEON_DEFS registry | `DUNGEON_DEFS` in `src/sim/content/dungeons.ts`; merged into the exported `DUNGEONS` registry in `src/sim/data.ts` with `TEMPLE_DUNGEON_DEFS`. Hullworks merges as a third spread or joins `DUNGEON_DEFS` |
+| DungeonDef shape | `DungeonDef` in `src/sim/types.ts`: id, index (unique x-band), doorPos, overworldDoor, entry, exitOffset, spawns, objects, `interior: 'crypt'|'sanctum'|'temple'|'nythraxis'`, suggestedPlayers, enterText/leaveText. It has no level field. A new interior key needs renderer and collider builders; S1 starts on `'crypt'` |
+| Keystone-style sealed doors | `DUNGEON_DEFS` in `src/sim/content/dungeons.ts` contains the `nythraxis_crypt` object pattern. `interact` in `src/sim/interaction.ts` routes dungeon doors to `SimContext.enterDungeon`; `enterDungeon` in `src/sim/instances/dungeons.ts` owns entry rules. Kill-boss-unseals gates on the boss-kill flag, and the S5 lock gate uses the both-wheels flood flag the same way |
+| Ground-object interact channel (sluice wheels, fuse cut) | `tryStartNythraxisWardChannel`, `lightNythraxisWardstones`, and `updateNythraxisWardChannels` in `src/sim/encounters/nythraxis.ts` provide the interaction and interrupt shape. `interact` in `src/sim/interaction.ts` calls the channel helper before `pickUpObject`. Copy the shape, not the file |
+| Boss-kit fields | `MobTemplate` in `src/sim/types.ts` defines fields such as `aoePulse`; `DUNGEON_MOBS` in `src/sim/content/dungeons.ts` provides examples for `aoePulse`, `mortalStrike`, `summonAdds`, charge, and stun. NEW mechanics do NOT extend the kit; they live in the S3 to S6 modules keyed off template ids |
 | Entry clearance | every def comments `entry` clear of first-pack aggro; pinned by `tests/dungeon_entry_clearance.test.ts` |
-| Module tick pins | `src/sim/sim.ts` ~4505: `lap?.('<phase>')` after each phase; `server/game.ts:334` `SIM_LAP_PHASES` pins the exact emission list (append new names AFTER existing so old names stay byte-identical) |
-| Zone file (branch #2321) | `src/sim/content/galecrest.ts` (584 lines): `GALECREST_ZONE.pois` ~:42, `GALECREST_NPCS` :199 (Harbormaster Odile :213), `GALECREST_QUESTS` :255, `GALECREST_QUEST_ORDER` :437, `GALECREST_OBJECTS` :505, `GALECREST_CAMPS` :496; merged at `src/sim/data.ts:110-119` on that branch. Zone is `levelRange: [20, 20]` |
-| Deeds | `DEEDS` record `src/sim/content/deeds.ts:24`, per-boss first-kill rows follow existing dungeon rows; stat triggers via `src/sim/deeds.ts` counters (`groundObjectsLooted` pattern, `types.ts:4530`) |
-| Music | `src/game/music_tracks.ts:24-26` (`dungeon_<id>` key convention) + `src/game/instance_music.ts` (`instanceMusicDecision`, `InstanceMusicController`) |
+| Module tick pins | `Sim` in `src/sim/sim.ts` emits each lap phase; `SIM_LAP_PHASES` in `server/game.ts` pins the exact emission list. Append new names AFTER existing names so old names stay byte-identical |
+| Zone file from the `feature/procedural-dungeons` branch (umbrella PR #1584) | `src/sim/content/galecrest.ts` exports `GALECREST_ZONE`, `GALECREST_NPCS`, `GALECREST_QUESTS`, `GALECREST_QUEST_ORDER`, `GALECREST_OBJECTS`, and `GALECREST_CAMPS`; the branch merges them through the exported content registries in `src/sim/data.ts`. `GALECREST_ZONE` has `levelRange: [20, 20]` |
+| Deeds | `DEEDS` and `DEED_ORDER` in `src/sim/content/deeds.ts`; per-boss first-kill rows follow existing dungeon rows. Stat triggers use exported helpers such as `bumpDeedStat` in `src/sim/deeds.ts` |
+| Dungeon Finder | `FINDER_ACTIVITIES` and `FinderEncounter` in `src/sim/content/dungeon_finder.ts`; heroic boss drops use `HEROIC_BOSS_LOOT` in `src/sim/content/heroic_loot.ts`; `tests/dungeon_finder.test.ts` pins activity ids and level ranges |
+| Music | `ZONE_STREAM_URLS` in `src/game/music_tracks.ts`; `instanceMusicDecision` and `InstanceMusicController` in `src/game/instance_music.ts` |
 | Parity goldens | `tests/parity/scenarios.ts`; `UPDATE_PARITY=1 npx vitest run tests/parity` records; never regenerate to hide a diff |
 | Bot clear harness | `scripts/crypt_raid.mjs` is the template (puppeteer, needs `npm run dev` + `npm run server` + `ALLOW_DEV_COMMANDS=1`) |
-| Renderer set piece | new `src/render/hullworks_set.ts` called by the renderer (never a method bank on `renderer.ts`); interior builder keys resolve in the renderer + `src/sim/colliders.ts` interior paths (grep `interior ===`) |
+| Renderer set piece | new `src/render/hullworks_set.ts` called by `Renderer` in `src/render/renderer.ts` (never a method bank on that coordinator); collider support follows `interiorColliderFrame` in `src/sim/colliders.ts` |
 
 ## 3. Slices
 
@@ -81,20 +88,29 @@ credits/provenance, and
 `npx vitest run tests/deeds_content.test.ts tests/localization_fixes.test.ts tests/guide.test.ts && npm run wiki:content`.
 
 ### S1. Instance shell, Liftworks, entrance POI, entry clearance
-- Goal: an enterable, exitable, empty-but-real dungeon: `hullworks` def (index
-  resolved from the active merged registry in this slice,
-  `interior: 'crypt'` as placeholder), internal-room def for the launched galleon deck
-  (`hullworks_deck`, `overworldDoor: false`, nythraxis_boss_arena pattern), sealed
+- Goal: an enterable, exitable, empty-but-real dungeon: `hullworks` def
+  (`index: 6`, `interior: 'crypt'` as placeholder), internal-room def for the launched galleon deck
+  (`hullworks_deck`, index 7, `overworldDoor: false`, nythraxis_boss_arena pattern), sealed
   `dungeon_door` objects between the boss rooms and at the lock gate to the deck (the
   S5 flood flag unseals that one), doorPos in Galecrest.
 - Files: NEW `src/sim/content/hullworks.ts`; MODIFIED `src/sim/data.ts` (merge),
   `src/sim/content/galecrest.ts` (ONLY: one poi `{ label: 'The Hullworks Lift', id: 'hullworks_lift' }`,
-  entrance-pocket comment on `GALECREST_CAMPS`), `tests/dungeon_entry_clearance.test.ts` pin.
-- Tests FIRST: `tests/hullworks.test.ts`: def registered in `DUNGEONS`, index unique
-  across dungeons+temple, enter at level 13 works, level 12 refused, entry point outside
+  entrance-pocket comment on `GALECREST_CAMPS`),
+  `src/sim/content/dungeon_finder.ts` (one normal and one heroic
+  `FINDER_ACTIVITIES` row, ordered `FinderEncounter` entries, normal finder band
+  13 to 15, heroic finder band 20 to 20, and daily heroic lockout summary),
+  `src/ui/i18n.catalog/hud_chrome.ts` (the required
+  `hudChrome.finder.mech.*` copy keys),
+  `src/sim/content/heroic_loot.ts` (`HEROIC_BOSS_LOOT` rows),
+  `tests/dungeon_finder.test.ts` (pinned activity id list and level ranges in the same
+  change), and `tests/dungeon_entry_clearance.test.ts` pin.
+- Tests FIRST: `tests/hullworks.test.ts`: both defs registered in `DUNGEONS`, indexes 6
+  and 7 unique across dungeons and temple, physical door entry remains ungated by level,
+  entry point outside
   aggro radius of the first Liftworks spawn, sealed doors refuse before their flags
-  (boss-kill doors and the lock gate).
-- Acceptance: `npx vitest run tests/hullworks.test.ts tests/dungeon_entry_clearance.test.ts tests/dungeons.test.ts tests/architecture.test.ts && npx vitest run tests/parity` (untouched).
+  (boss-kill doors and the lock gate). `tests/dungeon_finder.test.ts` asserts the normal
+  finder band through its `minLevel` and `maxLevel` row and pins both new activity ids.
+- Acceptance: `npx vitest run tests/hullworks.test.ts tests/dungeon_finder.test.ts tests/dungeon_entry_clearance.test.ts tests/dungeons.test.ts tests/architecture.test.ts && npx vitest run tests/parity` (untouched).
 
 ### S2. Work-crew packs + crews-stop-work readability
 - Goal: all trash as legible WORK CREWS (sawyers, rat-catchers, powder line) in
@@ -154,8 +170,9 @@ credits/provenance, and
   per wheel (fixed composition, no rng). Both wheels open: the lock gates part, the sea
   comes in, and the half-built galleon lurches off her blocks and launches a season
   early; the lock-gate `dungeon_door` to the deck unseals on the flood flag, and the
-  signature inrush audio sting event emits (`SimEvent` union in `src/sim/types.ts:1393`
-  area; the client plays the SFX). The party rides the rising water up to her deck: a
+  signature inrush audio sting event emits (the `SimEvent` union in
+  `src/sim/types.ts`; the client plays the SFX). The party rides the rising
+  water up to her deck: a
   scripted lift, render dressing on the fixed arena; sim space never moves.
 - Files: hullworks.ts (wheel + lock-gate objects, response waves, flood flag),
   fuse/interaction glue reused from S3 (one wheel-channel call beside the ward-channel
@@ -201,9 +218,16 @@ credits/provenance, and
   `CREDITS.md`.
 - Heroic (RESOLVED 2026-07-26, maintainer direction): heroic mode ships at launch
   on the existing machinery only: the heroic difficulty flag, standing
-  multipliers, and the automatic five-man heroic swap doing the loot (these
-  13-to-15 drops are below the swap's upgrade floor, so heroic variants generate
-  for free). No heroic-only mechanics, nothing bespoke to author.
+  multipliers, and the automatic five-man heroic swap doing the loot. Qualifying
+  loot variants require no per-variant authoring, but the activity does. In the
+  same change, finalize the one normal and one heroic `FINDER_ACTIVITIES` row in
+  `src/sim/content/dungeon_finder.ts`, their ordered `FinderEncounter` entries and
+  `hudChrome.finder.mech.*` copy keys in `src/ui/i18n.catalog/hud_chrome.ts`, the
+  normal `minLevel: 13` and `maxLevel: 15` band, the heroic `minLevel: 20` and
+  `maxLevel: 20` band with its daily lockout summary, and the `HEROIC_BOSS_LOOT`
+  rows in `src/sim/content/heroic_loot.ts`. Update the
+  pinned activity id list and level ranges in `tests/dungeon_finder.test.ts` with
+  those rows. No heroic-only mechanics are added.
 - Deeds: earlier slices already carry the three first-kill rows, Dry Powder, She
   Never Sailed, and the Redwake title row. Nothing appends here (the Full Manifest
   meta row died with the five-boss scope at pass 2).
@@ -211,7 +235,8 @@ credits/provenance, and
 - i18n sweep checklist (nothing else catches these): English item-name rows;
   Redwake, the Sluiceworks, and PR B mechanic/aura names in the `sim_i18n.ts` matcher
   DICTs + `AURA_NAME_KEY` (Charwick and Hulljack rows landed in PR A's S4 closeout);
-  enter/leave texts; death line; regenerated `i18n.resolved.generated/` committed.
+  Dungeon Finder `hudChrome.finder.mech.*` copy keys; enter/leave texts; death line;
+  regenerated `i18n.resolved.generated/` committed.
 - Music: `dungeon_hullworks` key in `music_tracks.ts` + track file (work-shanty over the
   Galecrest chord spine, site noise baked in); sluice inrush sting SFX from S5.
 - Bot clear: `scripts/hullworks_raid.mjs` from the `crypt_raid.mjs` template; a full
@@ -222,13 +247,15 @@ credits/provenance, and
 ## 4. Gotchas (read before every slice)
 
 - **G1, SIM_LAP_PHASES pins the sim's emission list.** Every module that gains a
-  `lap?.('name')` in sim.ts MUST append the same name to `server/game.ts:334`, AFTER the
+  `lap?.('name')` in `Sim` at `src/sim/sim.ts` MUST append the same name to
+  `SIM_LAP_PHASES` in `server/game.ts`, AFTER the
   existing names (the base list stays byte-identical). Two pins land here: `fuseLines`
   (S3) and `rigPilot` (S4). The Sluiceworks beat has no module and no pin.
-- **G2, the zone file is not yours.** galecrest.ts lives on the #2321 branch and its
+- **G2, the zone file is not yours.** `src/sim/content/galecrest.ts` comes from the
+  `feature/procedural-dungeons` branch (umbrella PR #1584), and its
   author may still be moving it. Every edit is additive (new poi row, new quest rows,
-  comments); never re-shape existing exports. If #2321 has not merged when S1 starts,
-  stop and re-check the base with the operator.
+  comments); never re-shape existing exports. If that branch has not landed in a
+  release when S1 starts, stop and re-check the base with the operator.
 - **G3, parity.** New `ctx.rng` draws must live strictly inside Hullworks code paths
   (encounter state, instance band). One new golden (`hullworks_redwake`, S6) is added;
   if any EXISTING golden reds, the fix is the code, never `UPDATE_PARITY=1` on it.
@@ -240,6 +267,8 @@ credits/provenance, and
   append at the end, never rename, never reorder.
 - **G6, level-band risk.** Until Levy answers open question 1, do not author loot or XP
   rows (they are the band-sensitive parts); S1 to S6 mechanics survive a re-band.
+  `HULLWORKS_MIN_LEVEL` belongs only to the Finder catalogue. Do not add a level field
+  to `DungeonDef` or a level check to `enterDungeon`; physical doors stay ungated.
 - **G7, interior key.** S1 ships on `interior: 'crypt'`; a bespoke shipyard interior is
   a render/collider pair keyed off a new union member, land it with the S5 to S6
   set-piece work or not at all. Do not block the sim slices on art.

--- a/docs/prd/hullworks-dungeon.md
+++ b/docs/prd/hullworks-dungeon.md
@@ -1,8 +1,12 @@
 # PRD: The Hullworks, a five-player smuggler-shipyard dungeon
 
-Status: DRAFT pass 1 (2026-07-25), for discussion with Levy. Numbers marked
-(tuning) are proposals; engine-derived numbers follow the formulas named
-inline. Archetype: the classic "criminal syndicate digs under the coast and
+Status: READY FOR THE LEVY CONVERSATION (2026-07-31). The zone dependency
+is satisfied: `src/sim/content/galecrest.ts` landed in `release/v0.33.0`,
+is merged through `src/sim/data.ts`, and is placed in `ZONES`. The Levy
+conversation, including the band and portfolio decision, plus the PBE round
+commitment still gate dispatch. Numbers marked (tuning) are proposals;
+engine-derived numbers follow the formulas named inline. Archetype: the
+classic "criminal syndicate digs under the coast and
 builds a warship in a cave" first-story-dungeon, rebuilt with original
 fiction and this engine's primitives. Not a copy of any existing MMO
 instance: the shape (descend a worksite, reach the hidden ship) is genre
@@ -30,9 +34,11 @@ ships to build this one, and you drown it back.)
   arena); the dungeon adds no ship-physics or water-simulation system.
 - Schedule cut applied at pass 2: three bosses (Charwick, the Hulljack, Redwake), no
   optional wing, no cannon beat; Overseer Brack and Quartermaster Sallow cut outright.
-- Next-stage gate: Levy chooses the 13 to 15 or level-20 band, the
-  `feature/procedural-dungeons` branch (umbrella PR #1584) lands in a release, and the PBE
-  commitment is recorded. The proposed portfolio position is not approval.
+- Satisfied dependency: `src/sim/content/galecrest.ts` landed in
+  `release/v0.33.0`, is merged through `src/sim/data.ts`, and is placed in `ZONES`.
+- Next-stage gate: the Levy conversation resolves the 13 to 15 or level-20 band and
+  portfolio slot, and the PBE commitment is recorded. The proposed portfolio position
+  is not approval.
 
 ## Where it sits
 
@@ -47,8 +53,9 @@ ships to build this one, and you drown it back.)
   proposed door area is x 400 to 430, z 370 to 400, near the cove. S1 must
   verify final placement against the real terrain before committing the
   `doorPos`.
-- Hard dependency: the `feature/procedural-dungeons` branch (umbrella PR #1584)
-  must land in a release first. This PRD stacks on it.
+- Satisfied dependency: the Galecrest content in
+  `src/sim/content/galecrest.ts` landed in `release/v0.33.0`, is merged through
+  `src/sim/data.ts`, and is placed in `ZONES`.
 - Finder band: `HULLWORKS_MIN_LEVEL` is 13, and the normal Dungeon Finder
   activity has `minLevel: 13` and `maxLevel: 15`. Those finder rows are the
   only level enforcement surface. Physical door entry remains ungated by
@@ -261,8 +268,8 @@ Files ADDED:
 Files MODIFIED:
 - `src/sim/data.ts` (merge), `src/sim/content/deeds.ts` (append),
   `src/sim/sim.ts` (module ticks) + `server/game.ts` SIM_LAP_PHASES pins.
-- `src/sim/content/galecrest.ts`, from the `feature/procedural-dungeons`
-  branch (umbrella PR #1584): the entrance
+- `src/sim/content/galecrest.ts`, landed in `release/v0.33.0`, merged through
+  `src/sim/data.ts`, and placed in `ZONES`: the entrance
   work-lift POI, the entrance pocket kept clear of level-20 camps, and
   Odile's noticeboard quest hook; the ONLY zone-file edit, kept minimal.
 - `src/sim/content/dungeon_finder.ts` (`FINDER_ACTIVITIES` normal and heroic

--- a/docs/prd/hullworks-dungeon.md
+++ b/docs/prd/hullworks-dungeon.md
@@ -30,22 +30,29 @@ ships to build this one, and you drown it back.)
   arena); the dungeon adds no ship-physics or water-simulation system.
 - Schedule cut applied at pass 2: three bosses (Charwick, the Hulljack, Redwake), no
   optional wing, no cannon beat; Overseer Brack and Quartermaster Sallow cut outright.
-- Next-stage gate: Levy chooses the 13 to 15 or level-20 band, PR #2321 lands, and the PBE
+- Next-stage gate: Levy chooses the 13 to 15 or level-20 band, the
+  `feature/procedural-dungeons` branch (umbrella PR #1584) lands in a release, and the PBE
   commitment is recorded. The proposed portfolio position is not approval.
 
 ## Where it sits
 
 - Location: the Galecrest coast, just south of Wickharbor. The sea cave
   sits under the cliffs in the lee of the harbor cove, its work-lift head
-  tucked beside the road down from the Windway pass, so lower-level
+  tucked beside the Wickharbor cove, so lower-level
   parties reach it from Mirefen through the pass with only a short
   escorted run, the classic "dungeon mouth in a scary zone" move. The
   Company's hulls are stolen off the Wreckfields to the north, and
   Harbormaster Odile's noticeboard carries the lead-in quest: Wickharbor
-  thinks it has a salvage-theft problem, the party finds a navy.
-- Hard dependency: the Galecrest zone (#2321) must land first. This PRD
-  stacks on it.
-- Level band: minLevel 13, tuned for 14 to 16 (tuning). Bridges the gap
+  thinks it has a salvage-theft problem, the party finds a navy. The
+  proposed door area is x 400 to 430, z 370 to 400, near the cove. S1 must
+  verify final placement against the real terrain before committing the
+  `doorPos`.
+- Hard dependency: the `feature/procedural-dungeons` branch (umbrella PR #1584)
+  must land in a release first. This PRD stacks on it.
+- Finder band: `HULLWORKS_MIN_LEVEL` is 13, and the normal Dungeon Finder
+  activity has `minLevel: 13` and `maxLevel: 15`. Those finder rows are the
+  only level enforcement surface. Physical door entry remains ungated by
+  level, like every other dungeon. The band bridges the gap
   between the Sunken Bastion (~11 to 13) and the Glimmermere Temple (15 to
   16); nothing currently owns 13 to 15. OPEN QUESTION (Levy): the
   Galecrest is authored as a level 20 zone, so a 13 to 15 dungeon inside
@@ -172,9 +179,15 @@ ribs open, water you let in lapping at the berth. Three phases.
   ran for years on one good hat.
 - Heroic mode ships at launch on the existing machinery (maintainer
   direction): heroic difficulty flag, standing multipliers, and the
-  automatic five-man heroic swap doing the loot (these 13-to-15 drops are
-  below the swap's upgrade floor, so variants generate for free). No
-  heroic-only mechanics, nothing bespoke to author.
+  automatic five-man heroic swap doing the loot. The qualifying loot
+  variants generate without per-variant authoring, but heroic does not ship
+  for free as a complete activity. The same change must author one normal
+  and one heroic row in `FINDER_ACTIVITIES`, their ordered
+  `FinderEncounter` entries and `hudChrome.finder.mech.*` copy keys, the
+  normal `minLevel: 13` and `maxLevel: 15` band, the heroic `minLevel: 20`
+  and `maxLevel: 20` band with its daily lockout summary, and
+  `HEROIC_BOSS_LOOT` rows. It must also update the pinned activity id list and level ranges in
+  `tests/dungeon_finder.test.ts`. No heroic-only mechanics are added.
 
 ## Deeds (per the design/deeds.md authoring contract, same change as the
 DUNGEON_DEFS entries)
@@ -248,9 +261,16 @@ Files ADDED:
 Files MODIFIED:
 - `src/sim/data.ts` (merge), `src/sim/content/deeds.ts` (append),
   `src/sim/sim.ts` (module ticks) + `server/game.ts` SIM_LAP_PHASES pins.
-- `src/sim/content/galecrest.ts` (branch #2321 file): the entrance
+- `src/sim/content/galecrest.ts`, from the `feature/procedural-dungeons`
+  branch (umbrella PR #1584): the entrance
   work-lift POI, the entrance pocket kept clear of level-20 camps, and
   Odile's noticeboard quest hook; the ONLY zone-file edit, kept minimal.
+- `src/sim/content/dungeon_finder.ts` (`FINDER_ACTIVITIES` normal and heroic
+  rows plus ordered `FinderEncounter` entries),
+  `src/sim/content/heroic_loot.ts` (`HEROIC_BOSS_LOOT` rows), and
+  `tests/dungeon_finder.test.ts` (pinned activity ids and level ranges) in
+  the same change. Add the corresponding `hudChrome.finder.mech.*` copy
+  keys to `src/ui/i18n.catalog/hud_chrome.ts` with the finder rows.
 - `src/ui/sim_i18n.ts`, `src/ui/i18n.catalog/items.ts` for English item
   names and five non-Latin overlays for M16 quest prose, regenerated
   resolved files; `src/game/instance_music.ts` + `music_tracks.ts`;

--- a/docs/prd/hullworks-dungeon.md
+++ b/docs/prd/hullworks-dungeon.md
@@ -1,0 +1,267 @@
+# PRD: The Hullworks, a five-player smuggler-shipyard dungeon
+
+Status: DRAFT pass 1 (2026-07-25), for discussion with Levy. Numbers marked
+(tuning) are proposals; engine-derived numbers follow the formulas named
+inline. Archetype: the classic "criminal syndicate digs under the coast and
+builds a warship in a cave" first-story-dungeon, rebuilt with original
+fiction and this engine's primitives. Not a copy of any existing MMO
+instance: the shape (descend a worksite, reach the hidden ship) is genre
+furniture; the climax (flooding the drydock to launch and ruin the ship)
+and every name, faction, boss, and mechanic are original.
+
+## One-line pitch
+
+A five-player, THREE-boss dungeon at levels 13 to 15, 20 to 30 minutes:
+the party descends a salvage-works dug under the Galecrest cliffs south
+of Wickharbor, opens the sea-lock sluices to flood the Redwake Company's
+hidden drydock, launching their half-built war-galleon before she is
+ready, and kills Captain Ede Redwake on the ruined, slowly sinking deck.
+(Pass 2, maintainer direction: cut from five bosses plus an optional wing
+to three, and the Deadmines-style cannon-door breach replaced with the
+flood, which the wrecker fiction actually earns: they drowned a hundred
+ships to build this one, and you drown it back.)
+
+## Portfolio alignment
+
+- Proposed lane: first approval candidate and first dungeon build, not yet Levy-approved.
+- Protected identity: a functioning salvage site shuts down room by room, the party floods
+  the drydock to launch the ship early, and Redwake dies on the ruined unfinished deck.
+- Scope rail: the flood and the rising water stay cosmetic (render dressing on a fixed
+  arena); the dungeon adds no ship-physics or water-simulation system.
+- Schedule cut applied at pass 2: three bosses (Charwick, the Hulljack, Redwake), no
+  optional wing, no cannon beat; Overseer Brack and Quartermaster Sallow cut outright.
+- Next-stage gate: Levy chooses the 13 to 15 or level-20 band, PR #2321 lands, and the PBE
+  commitment is recorded. The proposed portfolio position is not approval.
+
+## Where it sits
+
+- Location: the Galecrest coast, just south of Wickharbor. The sea cave
+  sits under the cliffs in the lee of the harbor cove, its work-lift head
+  tucked beside the road down from the Windway pass, so lower-level
+  parties reach it from Mirefen through the pass with only a short
+  escorted run, the classic "dungeon mouth in a scary zone" move. The
+  Company's hulls are stolen off the Wreckfields to the north, and
+  Harbormaster Odile's noticeboard carries the lead-in quest: Wickharbor
+  thinks it has a salvage-theft problem, the party finds a navy.
+- Hard dependency: the Galecrest zone (#2321) must land first. This PRD
+  stacks on it.
+- Level band: minLevel 13, tuned for 14 to 16 (tuning). Bridges the gap
+  between the Sunken Bastion (~11 to 13) and the Glimmermere Temple (15 to
+  16); nothing currently owns 13 to 15. OPEN QUESTION (Levy): the
+  Galecrest is authored as a level 20 zone, so a 13 to 15 dungeon inside
+  it needs its entrance pocket kept clear of level-20 camps (as specced
+  above), OR the dungeon re-bands to 20 and becomes a heroic-adjacent
+  five-man. This doc recommends 13 to 15 with the sheltered pocket: the
+  20 band is already crowded and the leveling ladder has the hole.
+- Sequel fiction: the Redwake Company and the Glasswake Covenant (the
+  naga faction of the Farshore voyage raid PRD,
+  docs/prd/farshore-odyssey-raid.md) are natural rivals: the Covenant
+  harvests wrecks the Company manufactures, and the raid's fiction can
+  name the Company as the ones whose false beacons fed the sea its
+  ships. Loose coupling only; neither ships blocked on the other.
+
+## The faction: the Redwake Company
+
+Wreckers posing as a salvage guild. They do not find wrecks, they make
+them: false beacons on the reefs, then "salvage rights" on what drowns.
+The Hullworks is their endgame, one real warship built from a hundred
+murdered ones, enough to tax every hull on the coast. Uniform: tar-black
+oilskins with a single red-dyed sleeve (the "red wake"), instantly
+readable in a screenshot the way the Glasswake's cobalt crowns are.
+
+Trash-free-ish: not zero-trash like the Undermount raid; a leveling dungeon
+wants pulls. But every pack is a WORK CREW doing a legible job (sawyers
+ripping planks, rat-catchers, a powder line passing kegs hand to hand), and
+killing the crew visibly stops the work. The dungeon should read as a
+functioning site you are shutting down room by room, not corridors of
+guys.
+
+## Layout and flow (three bosses, one flood beat)
+
+Linear, 20 to 30 minutes at level (tuning):
+
+1. The Liftworks (descent, two crew pulls)
+2. Boss 1: Charwick the Fusemonger, in the powder magazine
+3. Boss 2: The Hulljack, in the assembly hall
+4. THE FLOOD: the Sluiceworks (story beat, not a boss)
+5. Boss 3: Captain Ede Redwake, on the deck of the launched, ruined
+   galleon
+
+Doors reuse the existing sealed-door machinery (`nythraxis_crypt`
+keystone pattern: kill the boss, the door unseals). The Sluiceworks: the
+drydock's two sea-lock wheels sit on opposite galleries; opening each is
+a wardstone-style channel while the party holds one crew response wave
+per wheel. Both wheels open, the lock gates part, the sea comes in, and
+the half-built galleon lurches off her blocks and settles, afloat and
+wrong: the ship they murdered a hundred crews for, launched a season
+early by five strangers. The inrush of water is the dungeon's signature
+audio sting, and the party rides the rising water up to her deck (a
+scripted lift, render dressing on the fixed arena).
+
+## Bosses (engine primitives only, all agent-completable)
+
+Every mechanic below is coordination, positioning on readable timers, or
+target priority. No reflex gates anywhere: every dodge has a full
+telegraph cast bar, every interact is a channel, nothing requires
+sub-second reaction. Primitive names reference the existing boss-kit
+fields in `src/sim/content/dungeons.ts` (aoePulse, cleave, summonAdds,
+knockback, manaBurn, mortalStrike and friends); anything not already in
+the kit is flagged NEW.
+
+### 1. Charwick the Fusemonger (level 16)
+Powder alchemist in a magazine stacked with kegs. The room is the fight.
+
+- Kegs are targetable ground objects. Charwick lights a crawling fuse
+  toward a random keg cluster (a visible line that advances on tick, NEW
+  ground-object state but deterministic and slow); any player can channel
+  1.5 s to cut it (interact). Uncut, the cluster detonates a large
+  groundAoE.
+- Flashpan: frontal cone blind on the tank's side (existing school/debuff
+  plumbing), tank swap or eat reduced threat uptime, party choice.
+- At 30 percent he stops lighting single fuses and lights THREE: triage,
+  cut two, soak one at range. The party picks which corner of the room
+  dies.
+- Teaching goal: interact triage under damage.
+
+### 2. The Hulljack (level 17, the walking-rig set piece)
+A salvage rig built from a crane, four wreck hulls, and spite, piloted by
+Company enginewrights. The dungeon's monster-silhouette screenshot.
+
+- The rig has one pilot at a time. Killing the PILOT (priority target,
+  low HP, on top of the rig) sends the rig BERSERK for 10 seconds
+  (random slow cleaves, no target logic), then a fresh enginewright runs
+  from the queue at the wall to re-mount, 6-second window to burn the
+  rig itself while its damage is undirected.
+- Three pilots total; after the third, the unmanned rig runs a fixed
+  overload sequence (three telegraphed aoePulse rings, then inert).
+- Grapple Claw: tank-target grab and 8-yard drag (existing knockback
+  plumbing inverted), breaks on 100 percent of a stun or the pilot's
+  death.
+- Teaching goal: add priority and burn windows.
+
+### 3. Captain Ede Redwake (level 18, on the launched galleon)
+Fought on the actual deck she never got to finish: masts scaffolded, hull
+ribs open, water you let in lapping at the berth. Three phases.
+
+- Phase 1 (100 to 70): duel on the quarterdeck. Riposte stance windows
+  (a visible stance buff during which attacking her from the front
+  reflects a cleave; attack from behind or hold, the classic positional
+  check).
+- Phase 2 (70 to 30): "ALL HANDS." She rings the ship's bell and the
+  surviving site crew swims and climbs aboard in waves; she fights amid
+  them, cleave discipline plus her Broadside cone.
+- Phase 3 (30 to 0): the flood you started reaches the gun deck; she
+  fights on as the ship settles lower (rising-water render dressing on
+  the fixed arena, cosmetic), with a Waking-Fury-style damage ramp
+  (tuning) so the fight cannot be turtled forever. Her ship is dying
+  under her feet and she knows whose fault it is.
+- Her death line sets the sequel hook: "You broke the ship. You did not
+  break the ledger."
+- Teaching goal: everything the dungeon taught, at once.
+
+## Loot (sketch, budget-gated as always)
+
+- Rares off bosses 1 and 2, ilvl per the engine's dungeon formula off
+  boss level; every stat sum obeys `tests/item_level` budgets (exact
+  numbers authored at implementation, marked (tuning) until then).
+- One epic per class-armor lane off Redwake (boss level 18: epic ilvl per
+  the engine formula), including the dungeon's signature weapon, a
+  boarding axe.
+- Meme item: "Redwake's Plumed Hat", a cosmetic epic head skin with a low
+  drop rate (tuning). The hat IS the screenshot economy; classic games
+  ran for years on one good hat.
+- Heroic mode ships at launch on the existing machinery (maintainer
+  direction): heroic difficulty flag, standing multipliers, and the
+  automatic five-man heroic swap doing the loot (these 13-to-15 drops are
+  below the swap's upgrade floor, so variants generate for free). No
+  heroic-only mechanics, nothing bespoke to author.
+
+## Deeds (per the design/deeds.md authoring contract, same change as the
+DUNGEON_DEFS entries)
+
+- Per-boss first-kill deed rows, plus:
+- "Dry Powder": kill Charwick with zero keg clusters detonated.
+- "She Never Sailed": open both sluice wheels without a party death
+  during the flood beat.
+- Redwake first kill carries the title deed (title: "the Wrecker's
+  Wrecker" (tuning)).
+
+## Audio and music
+
+- Streamed track via `src/game/instance_music.ts` + `music_tracks.ts`:
+  work-shanty rhythm section over the Galecrest theme's chord spine,
+  hammering and saw layers that thin out as wings die (implementation:
+  one track with the site-noise baked in; the "work stops" reading comes
+  from the SFX side going quiet, which the existing per-room ambience
+  already supports).
+- The sluice inrush (groaning gates, then the sea) is the one loud moment
+  the whole dungeon builds to; give it the full SFX pipeline treatment.
+
+## i18n scope (priced in, not deferred)
+
+- New ITEM NAMES require English catalog rows in the contributor PR.
+  Maintainers fill remaining locale overlays before release.
+- New quest prose: sparse-overlay rules, the five non-Latin locales
+  (zh_CN, zh_TW, ja_JP, ko_KR, ru_RU) per the M16 gate.
+- Boss/mechanic names ride the sim_i18n matcher dictionaries plus
+  AURA_NAME_KEY; no test catches misses there, so the checklist lives in
+  the staged PR plan below.
+
+## Staged PR plan
+
+1. PR A: dungeon shell, layout, crew packs, bosses 1 to 2, entrance,
+   DUNGEON_DEFS entries, deeds, quests, i18n, tests (entry clearance,
+   command schema, deed catalog pins).
+2. PR B: the flood beat, Redwake, heroic flag, loot tables, the hat,
+   music track, remaining deeds.
+3. PBE round per the contribution process before any release branch
+   merge; this PRD goes to Levy before PR A starts.
+
+## Acceptance criteria
+
+- Every mechanic passes the agent-completability review: no sub-second
+  windows, every interact is a channel with a cast bar, every hazard has
+  a full telegraph.
+- All new sim behavior lands as modules behind the SimContext seam with
+  tests; the coordinators do not grow.
+- `npm run gate` green including the i18n tiers above.
+- A full five-player clear by the in-repo bot harness (the same bar the
+  Slag Run gauntlet failed): if the bots cannot clear it at level, the
+  tuning is wrong, not the bots.
+
+## File plan (build reference)
+
+Files ADDED:
+- `src/sim/content/hullworks.ts`: instance def with sealed doors, the
+  three boss MobTemplates, work-crew packs, the two sluice-wheel ground
+  objects, items (including the hat), and the noticeboard lead-in quest.
+- Sim modules behind SimContext, with tests: `src/sim/fuse_lines.ts`
+  (Charwick's crawling fuses + cut interacts), `src/sim/rig_pilot.ts`
+  (Hulljack pilot/berserk/remount state). (Pass 2: cart_lanes.ts and
+  wreck_train.ts cut with their bosses; the sluice beat is ground-object
+  channels plus a door flag, no module.)
+- `src/render/hullworks_set.ts` for the flood dressing and rising water
+  (renderer-only spectacle on the fixed arena) and cove dressing; GLB
+  props via gen-3d-asset; one music track; `tests/hullworks.test.ts` +
+  parity scenario for Redwake.
+
+Files MODIFIED:
+- `src/sim/data.ts` (merge), `src/sim/content/deeds.ts` (append),
+  `src/sim/sim.ts` (module ticks) + `server/game.ts` SIM_LAP_PHASES pins.
+- `src/sim/content/galecrest.ts` (branch #2321 file): the entrance
+  work-lift POI, the entrance pocket kept clear of level-20 camps, and
+  Odile's noticeboard quest hook; the ONLY zone-file edit, kept minimal.
+- `src/ui/sim_i18n.ts`, `src/ui/i18n.catalog/items.ts` for English item
+  names and five non-Latin overlays for M16 quest prose, regenerated
+  resolved files; `src/game/instance_music.ts` + `music_tracks.ts`;
+  `src/ui/icons.ts` + `public/ui/items/mapping.json`; `public/ui/mobs/`
+  portraits; `CREDITS.md`; deeds/entry-clearance test pins; guide regen.
+
+## Open questions for Levy
+
+1. Level band 13 to 15 confirmed, or push to 14 to 16?
+2. Trash density: work-crew pulls as specced, or leaner toward the
+   raid's no-trash philosophy?
+3. The rising-water finale dressing: renderer-only spectacle as specced,
+   or cut for scope (the fight works without it)?
+4. Hat drop rate: properly rare (memorable) or pity-timered (kind)?


### PR DESCRIPTION
## Summary

PRD plus slice-by-slice build handoff for The Hullworks, a five-player smuggler-shipyard dungeon on the Galecrest coast south of Wickharbor. Docs only, two files, opened to start the design conversation per the contribution process (features need the conversation before serious build time).

The pitch in three lines: the Redwake Company fakes shipwrecks to "salvage" them and is building one real war-galleon out of a hundred murdered ships. The party descends their work-site (Charwick the Fusemonger, the Hulljack walking salvage rig), floods the hidden drydock through the sea-lock sluices, launching the ship a season early and ruining it, then kills Captain Ede Redwake on the settling deck. Three bosses, 20 to 30 minutes, levels 13 to 15 (the one empty band in the dungeon ladder).

Design rules baked in: every mechanic composes from existing boss-kit primitives (the two new sim modules are small and named), agent-completable throughout (no reflex gates), heroic at launch on the existing difficulty and variant machinery, deeds and i18n priced in the same change. The handoff carries a verified hook-point map (every symbol grepped against this branch and the zones branch), 7 slices, 2 staged PRs.

Open questions for the conversation are in the PRD, the main one being the level band (13 to 15 inside a level-20 zone, with a sheltered entrance pocket, vs re-banding to 20).

Depends on PR #2321 (the Galecrest zone) landing before any build starts.

## Testing

Docs only, no code or content changes. Copy scan clean (no em or en dashes, no emojis).