### PR TITLE
docs(events): seasonal events and retention PRD and build handoff

### DIFF
--- a/docs/prd/seasonal-events-and-retention-handoff.md
+++ b/docs/prd/seasonal-events-and-retention-handoff.md
@@ -1,0 +1,322 @@
+# Implementation Handoff: Seasonal Events and Retention (Amberfall Harvest Fair + Weekly Calendar)
+
+| | |
+|---|---|
+| **Status** | BLOCKED pending the Levy portfolio and schedule decision. PR A (S1, S2) has no zone dependency but is not authorized merely because it is technically independent. Fair slices (S3 to S8) are additionally blocked on PR #2321 (feature/procedural-dungeons, the Amberfall zone) and go through a PBE round before any release. |
+| **Portfolio lane** | Proposed fourth approval candidate, the support layer after a new tentpole. This is not Levy approval. |
+| **Dispatch gate** | Levy approves the civil-time policy, fixture schedule, and this portfolio slot. Scheduler/calendar go first; recipes and extra games are cut before the fair meter, derby, lantern launch, or anti-FOMO contract. |
+| **Source PRD** | `docs/prd/seasonal-events-and-retention.md` (implementation notes + File plan inside are verified and binding) |
+| **Scope** | The season/fixture window scheduler, the weekly calendar surface, the fair (stalls, turn-in meter, derby, lantern launch, games, deeds, skins, recipes). NO calendar HUD window (separate UI PRD), NO vanity-pet system (deferred), NO Vale Cup exhibition (cut; the Cup gets a fixture day). |
+| **Verified against** | 2026-07-25: origin/release/v0.30.0 (c1a7f42f1) and, for Amberfall anchors only, origin/feature/procedural-dungeons (0084f3dad). Revalidate every anchor against the active release branch before implementation; trust symbols, not line numbers. |
+| **Executor routing** | Claude uses `extract-and-test` and `qa-checklist`; Codex uses `$woc-extract-and-test` and `$woc-qa`. Persistence work requires database-performance and persistence review; render/UI and sim reviews follow the changed surface. No slice depends on a named model. |
+
+---
+
+## 0. Ground rules for every implementation prompt
+
+1. `src/sim/` never imports from `render/`, `ui/`, `game/`, `net/`, or any DOM/Three
+   API. Guarded by `tests/architecture.test.ts`.
+2. All sim randomness goes through `Rng` (`ctx.rng`). Never `Math.random`, `Date.now`,
+   `performance.now` in sim logic. Windows are host-supplied civil-time inputs
+   or deterministic sim-tick fallback; the sim NEVER reads a clock.
+3. Every player-visible string is i18n: sim/server emit stable keys or English
+   literals with matcher entries (`src/ui/sim_i18n.ts`, S3 guard
+   `tests/localization_fixes.test.ts`); UI strings are `t()` keys in
+   `src/ui/i18n.catalog/`. M16: new wordy English values need their five non-Latin
+   fills (zh_CN, zh_TW, ja_JP, ko_KR, ru_RU) in the same change. Every NEW item id
+   needs an English row; maintainers fill remaining overlays before release.
+4. **Anti-FOMO hard rules (from the PRD, non-negotiable):** rewards are cosmetic,
+   social, or convenience only, never player power (docs/design/deeds.md rule 1).
+   No streaks, no daily checklists, no expiring currencies; everything returns every
+   fair, forever. Tallies and meters accumulate or reset without ever deleting player
+   progress; missing a window costs fun, never an item.
+5. **Agents are first-class players:** every activity is a channel, a turn-in, or a
+   published-schedule appointment. No reflex gates anywhere (the gourd roll is one
+   seeded draw by design).
+6. TypeScript strict, ESM, 2-space indent. No em dashes, en dashes, or emojis
+   anywhere. Conventional Commits with scope, e.g. `feat(events): ...`.
+7. Anchor completion on the slice's acceptance commands, not on "looks done".
+8. Seasonal state is realm-owned: one live object on `Sim`, one
+   `world_state` row `seasonal:<realm>`, never `PlayerMeta`, character blobs,
+   or one database call per activity.
+
+## 1. Shared design constants (defined once in S1; everyone else imports)
+
+```ts
+// src/sim/events/season_schedule.ts (new module, behind SimContext)
+export const FAIR_WINDOW_DAYS = 14;          // two-week fair (tuning)
+export const FAIR_CADENCE_WEEKS = 8;         // recurrence (tuning; open question 1)
+export const FAIR_SCHEDULE_VERSION = 1;
+export const FAIR_FIRST_OPEN_LOCAL = '2026-09-18T20:00:00'; // realm-local proposal, tuning
+export const LANTERN_LAUNCH_HOUR = 20;       // realm-local civil 20:00 (tuning)
+export const LANTERN_CHANNEL_SEC = 3;        // freely interruptible
+export const FAIR_METER_THRESHOLDS = [300, 800, 1500] as const; // turn-ins (tuning)
+export const OFFLINE_FAIR_CADENCE_TICKS = 8 * 7 * 24 * 3600 * 20; // tick fallback
+export const OFFLINE_FAIR_WINDOW_TICKS = 14 * 24 * 3600 * 20;
+export const SEASONAL_SAVE_VERSION = 1;
+export const FAIR_METER_CAP = FAIR_METER_THRESHOLDS[2];
+
+export interface SeasonalRealmSave {
+  version: typeof SEASONAL_SAVE_VERSION;
+  fairId: string; // derived from opening instant + schedule version + realm TZ
+  meter: number;  // finite integer, clamped to 0..FAIR_METER_CAP
+}
+```
+
+Advance recurrence by `FAIR_CADENCE_WEEKS` as calendar weeks in the configured
+realm time zone, not as elapsed milliseconds. Convert each civil opening through
+the same DST policy as `server/raid_reset.ts`, then construct `fairId` as
+`v<FAIR_SCHEDULE_VERSION>:<realmTimeZone>:<openingEpochMs>`. Any
+anchor or cadence change increments `FAIR_SCHEDULE_VERSION`.
+
+Deed tuning (S4/S5/S7/S8): Renown quantized 5/10/25/50; luck deeds and the launch
+deed at zero Renown; capstone title "Lanternlight" (tuning). Turn-ins pay standard
+work-order copper, unchanged (the payout fraction is an economy constant).
+
+## 2. Verified hook-point map (re-find every anchor before editing)
+
+All rows verified on origin/release/v0.30.0 except the Amberfall rows (branch only).
+
+| Concern | Anchor |
+|---|---|
+| Cadence primitive | `src/sim/professions/cadence.ts`: `WORK_ORDER_CADENCE_TICKS = 36000` (:14), `CadenceMap` (:35), `isCadenceBlocked` (:39), `armCadence` (:46), `serializeCadence` (:100, persisted and clamped on load). Consumers via `repeatCadenceTicks`: zone1/zone2/zone3 records + `src/sim/quests/quest_commands.ts`. There is NO daily-quest system; this is the reuse target. |
+| Host civil time | `server/raid_reset.ts`: 03:00 realm-zone boundary, `nextRaidResetMs` (:115), `isSupportedTimeZone` (:30). Fair windows reuse host-computed civil inputs, but seasonal state does NOT use per-character `meta.raidLockouts`. |
+| Realm JSONB store | `server/db.ts`: `world_state` table (:596), generic `loadWorldState` / `saveWorldState` (:3404), realm-key wrappers `market:<realm>` and `mail:<realm>` (:3464 onward). Seasonal adds typed wrappers for exactly one `seasonal:<realm>` row. |
+| Save cadence | `server/game.ts`: `createSerialWriter` market writer near :1370; `flushPeriodicSaves` 30-second cadence :2059. Seasonal adds a dirty, coalesced writer with at most one in-flight and one trailing save; no turn-in query. |
+| Boot and shutdown | `server/main.ts`: boot constructs the live game after schema setup near :2814; shutdown stops the game and drains market/mail near :3095. Seasonal load completes before listen, and its writer drains before pool close. |
+| Shared realm wire | `server/game.ts`: `maybeRaw` near :5742 and `realmReadoutJson` use near :5871 build and stringify viewer-identical state once per broadcast pass. Seasonal uses this shared path, not per-session `maybe()`. |
+| Fishing | `src/sim/professions/fishing.ts`: `startFishing` (:124), `completeFishing` (:211, ONE table draw; capacity gates after the roll :255 so draw order never depends on bags; Vale-table fallback :223), `fishingCatchGain` (:92), rare precedent `the_codfather` (:39), `onFishCaughtForDeeds` call (:284). |
+| Deeds | Content `src/sim/content/deeds.ts`: `DEED_ORDER` (:2228) APPEND-ONLY (contract header :6). Evaluator `src/sim/deeds.ts`: `onFishCaughtForDeeds` (:1792), `onNpcTalkedForDeeds` (:1765), `onCupMatchEndForDeeds` (:1699) as meter/flag templates. Contract doc: `docs/design/deeds.md`. |
+| Skins | `src/sim/content/skins.ts`: `EVENT_SKIN_TOKEN_ID = 'event_skin_token'` (:17), `rollSkinRank(unitRoll)` (:28), `EVENT_SKIN_TIERS` (:45, ":38 placeholder mapping onto existing alt skins" is the comment S8 replaces). |
+| Card duel | `src/sim/social/card_duel.ts` + `card_duel_queue.ts` (`createCardDuelQueue` :8, `joinCardDuelQueue` :16, `tryPairCardDuel` :44); `src/sim/content/card_master.ts` `CARD_MASTER_NPC_ID` (:6). Only the fair desk placement is new. |
+| Mail | `src/sim/content/letters.ts`: `LetterDef` (:17), `QUEST_LETTERS` (:90) as the record template; delivery via `src/sim/mail/post_office.ts` (PostOffice, letterId client localization). |
+| Noticeboards | `src/sim/content/noticeboards.ts`: `NOTICEBOARDS` (:29, one Eastbrook board), `noticeboardDefByEntityId` (:32). Town Focus is an interaction precedent only; seasonal persistence and shared wire use the rows above. |
+| Content merge | `src/sim/data.ts` imports content modules (zone3 at :109; amberfall at branch data.ts:43). New content modules merge here. |
+| Amberfall (branch #2321 ONLY) | `src/sim/content/amberfall.ts`: hub Lanternmere (:34), Great Mere POI (:48), NPCs `reeve_ottoline` (:223), `waywatcher_sorrel` (:233), `ferrymaster_caddow` (:244), `orchardist_pomeline` (:255), existing `stalls:` prop records (:543). Fair placements are ADDITIVE to this file. |
+| SimContext seam | `src/sim/sim_context.ts`; new system modules take `ctx: SimContext`, backing state lives on `Sim` as a live ctx view (`src/sim/CLAUDE.md`). |
+| IWorld | `src/world_api.ts` + per-facet files in `src/world_api/` (e.g. `daily_rewards.ts` as a facet template); parity pin `tests/world_api_parity.test.ts`. |
+| ClientWorld | `src/net/online.ts` `applySnapshot` self/global mirrors (tfocus pattern :2973). |
+| Server tick pin | `SIM_LAP_PHASES` `server/game.ts:334` (pinned by `tests/server/tick_perf_capture.test.ts`); a new named sim phase must be added to the array or its timing drops. |
+| Parity goldens | `tests/parity/scenarios.ts`; `UPDATE_PARITY=1 npx vitest run tests/parity` regenerates; never regenerate to hide a diff. |
+| Wardstone channel precedent | `src/sim/interaction.ts` (:472 area, `nythraxis_ward_channel`): the readable ground-object channel pattern for stalls and lanterns. |
+
+## 3. Slices
+
+Dependency order: S1 -> S2 (PR A, ships first, release-branch base) ; S3 -> S4 -> (S5,
+S6, S7 in any order) -> S8. S3 onward stack on #2321 and follow the PRD's PR B/C/D
+staging: S3+S4 = PR B, S5+S6 = PR C, S7+S8 = PR D.
+S2, S4, S6, and S8 close their PR boundaries. Each closeout carries that
+PR's Deeds and pins, English catalog and any M16 work, sim matcher rows, wiki
+regeneration, credits/provenance, and
+`npx vitest run tests/deeds_content.test.ts tests/localization_fixes.test.ts tests/guide.test.ts && npm run wiki:content`.
+
+### S1. Season/fixture scheduler and realm-save lifecycle
+- Goal: one small SimContext module resolving "what is open now" deterministically,
+  plus the complete versioned realm-save lifecycle it depends on.
+- Files: NEW `src/sim/events/season_schedule.ts` + `tests/season_schedule.test.ts`;
+  NEW `tests/server/seasonal_persistence.test.ts`; MODIFIED `src/sim/sim.ts`
+  (tick call + one live seasonal realm object), `server/db.ts` (typed
+  `seasonalStateKey(realm)`, `loadSeasonalState`, `saveSeasonalState` over
+  `world_state`), `server/game.ts` (host civil-time input beside raid reset,
+  dirty/coalesced serial writer, periodic and boundary flushes; SIM_LAP_PHASES
+  pin if named; aggregate save-age/failure diagnostics), `server/main.ts`
+  (load before listen, shutdown drain).
+- Derived window shape, never persisted:
+```ts
+export interface SeasonWindowState {
+  fairOpen: boolean;
+  fairId: string;
+  fairClosesAtMs: number | null;    // host-derived; null offline
+  nextFairOpensAtMs: number | null;
+  fixtureDayId: FixtureDayId | null; // resolved from host civil-day input
+  nextLanternLaunchAtMs: number | null; // null outside a fair window
+}
+```
+  Host mode computes instants and a stable `fairId` from the opening instant,
+  schedule version, and realm time zone, then hands those values to the sim.
+  Offline mode uses `OFFLINE_FAIR_CADENCE_TICKS` (pending Levy open question 4).
+- Persist only `SeasonalRealmSave { version, fairId, meter }`. Sanitize on load:
+  reject unknown shapes, normalize meter to a finite integer in
+  `0..FAIR_METER_CAP`, retain it only when the loaded `fairId` matches the
+  host-derived current fair, otherwise reset once into the current fair.
+- Writer contract: mark dirty on mutations; at most one database write in flight
+  and one trailing write for newer state; autosave may flush dirty state; fair
+  boundaries and thresholds request a flush; failure leaves dirty state for retry;
+  shutdown drains. A turn-in never calls `saveSeasonalState` directly.
+- Tests FIRST: same seed + host inputs produce identical windows; offline boundaries
+  land on exact ticks; same-fair restart preserves meter; next-fair and downtime
+  reconciliation reset once; corrupt/non-finite/out-of-range documents sanitize;
+  realms use distinct keys; writer queue stays bounded; failure retries; shutdown
+  drains; save-age/failure diagnostics expose no payload; architecture proves no
+  sim clock read. Pin exactly one zero-or-one-row boot read and writes only on
+  dirty autosave, boundary, threshold, or shutdown triggers. Independent malformed
+  cases cover unknown version, missing/invalid `fairId`, missing meter, negative,
+  fractional, above-cap, NaN, and Infinity. Fixed vectors cover the anchor, two
+  recurrence cycles, a DST transition, exact boundaries, and a schedule-version change.
+- Acceptance: `npx vitest run tests/season_schedule.test.ts tests/server/seasonal_persistence.test.ts tests/architecture.test.ts && npx vitest run tests/parity`
+
+### S2. Calendar data table + market day + noticeboard/letter surface (completes PR A)
+- Goal: the published weekly rhythm and its minimal v1 surface.
+- Files: NEW `src/sim/content/event_calendar.ts` (fixture-day table: Tuesday reset,
+  Wednesday Vale Cup, Friday market day, Saturday Ferrywalk placeholder, Sunday
+  featured Hunt; days tuning; merged by `data.ts`); MODIFIED `season_schedule.ts`
+  (market-day cadence clear: on the Friday boundary, clear work-order `CadenceMap`
+  keys so every order is freshly available; NO payout change),
+  `src/sim/content/noticeboards.ts` (calendar notice content),
+  `src/sim/content/letters.ts` (fair-open letter record), character state
+  serialization (`lastFairLetterId`, `lastMarketRefreshId`) with lazy reconcile
+  on character load and an online-character boundary update, `src/ui/sim_i18n.ts`
+  matcher entries for any sim-emitted lines. Never scan the character table.
+- Reused: CadenceMap, NOTICEBOARDS, LetterDef/PostOffice. NEW: the data table only.
+- Tests FIRST: cadence keys clear exactly once per market boundary; a character
+  offline at the boundary reconciles on next load; an online character updates at
+  the boundary; fixture resolution is pure; fair letter delivers once per `fairId`;
+  no boundary-wide character query occurs.
+- Acceptance: `npx vitest run tests/season_schedule.test.ts tests/server/seasonal_persistence.test.ts tests/localization_fixes.test.ts && npx vitest run tests/parity`
+
+### S3. Realm-shared fair meter (seam slice: IWorld, wire, mirror, parity)
+- Goal: the persisted realm meter plumbed through all three hosts. Buildable against
+  the release base, but merges as part of PR B.
+- Files: MODIFIED `src/sim/events/season_schedule.ts` (meter mutations + threshold tier
+  on the S1 live realm state),
+  `src/world_api.ts` + NEW facet `src/world_api/seasonal.ts`
+  (`seasonalInfo: { fairOpen: boolean; meter: number; meterTier: 0 | 1 | 2 | 3; fixtureDayId: string | null }`),
+  `server/game.ts` (S1 dirty writer integration plus shared snapshot readout),
+  `src/net/online.ts` (mirror), `tests/server/seasonal_persistence.test.ts`,
+  `tests/world_api_parity.test.ts` + `tests/snapshots.test.ts` pins.
+- Meter wire field sketch (global, not self-only; serialize once through the realm
+  readout memo because every client renders the same town):
+```ts
+// server snapshot: fair: { o: 0|1, m: number, t: 0|1|2|3 }
+// server: maybeRaw('fair', realmReadoutJson(... seasonalInfo ...))
+// online.ts applySnapshot: if (s.fair) this.seasonal = decodeFair(s.fair);
+```
+- Reused: `realmReadoutJson` + `maybeRaw`, world_api facet layout, S1 realm save.
+  NEW: meter state only (resets each fair, gates nothing).
+- Tests FIRST: offline Sim and ClientWorld expose identical `seasonalInfo`; meter
+  survives same-fair save/load; values clamp to `0..FAIR_METER_CAP`; threshold
+  crossings dirty and flush once; 100 turn-ins issue zero immediate queries and
+  coalesce to one eventual save; fresh joins receive current state; unchanged state
+  is elided; viewer-identical state stringifies once per broadcast pass; two realms
+  remain isolated; parity scenario untouched (no new rng draws).
+- Acceptance: `npx vitest run tests/server/seasonal_persistence.test.ts tests/world_api_parity.test.ts tests/snapshots.test.ts && npx vitest run tests/parity`
+
+### S4. Fair core: stalls, provisioning turn-ins, fair quests, NPC placements (with S3 = PR B)
+- Goal: the fair exists in Lanternmere.
+- Files: NEW `src/sim/content/harvest_fair.ts` (stall ground objects with
+  wardstone-style channels and cosmetic zero-stat flavor buffs; Reeve Ottoline's
+  provisioning order on the `repeatCadenceTicks` work-order pattern feeding the S3
+  meter; fair quests; merged by `data.ts`); MODIFIED `src/sim/content/amberfall.ts`
+  (stall props + fair NPC placements, ADDITIVE only), `src/sim/content/deeds.ts`
+  (append fair deeds), `src/ui/sim_i18n.ts` + catalog + five non-Latin prose fills.
+  NEW `tests/harvest_fair.test.ts` owns fair interaction behavior.
+- Reused: interaction channel machinery, work-order cadence, existing fish/meat/
+  produce item ids for turn-ins (NO new turn-in items). NEW: content records only.
+- Tests FIRST: stall channel grants the flavor aura with zero stat effect; turn-in
+  increments the realm meter and pays standard copper; turn-ins refused outside the
+  window but nothing is lost; deeds append after every existing DEED_ORDER entry.
+- Acceptance: `npx vitest run tests/harvest_fair.test.ts tests/deeds_content.test.ts tests/localization_fixes.test.ts tests/architecture.test.ts && npx vitest run tests/parity`
+
+### S5. Fishing derby: catch-table row, tally, Caddow's book
+- Goal: Mere catches count toward a lifetime derby tally during fairs.
+- Files: MODIFIED `src/sim/professions/fishing.ts` (one fair-only table row per band:
+  the Amberjack Gleamer, no-sell trophy; row weight active only while `fairOpen`),
+  `harvest_fair.ts` (Caddow derby-book interaction at the jetty),
+  `src/sim/content/deeds.ts` (derby deeds on the tally meter), deeds evaluator hook
+  beside `onFishCaughtForDeeds`.
+- Reused: the single-table-draw contract, `the_codfather` rare precedent, deed
+  meters. NEW: one item id (English row plus maintainer release fill) + persisted lifetime tally.
+- Tests FIRST: draw order identical whether or not the fair is open EXCEPT the fair
+  row (pin the one-draw contract); tally accumulates across two simulated fair
+  windows and never resets; Gleamer is no-sell; derby deed fires at thresholds.
+- Acceptance: `npx vitest run tests/professions_fishing.test.ts tests/deeds_content.test.ts && npx vitest run tests/parity` (expect NO golden churn; see gotcha G3)
+
+### S6. Lantern launch + meter-tiered town dressing (render; with S5 = PR C)
+- Goal: the fair's screenshot moment plus the town visibly dressing up.
+- Files: NEW `src/render/fair_dressing.ts` (meter-tiered props: bunting, jetty
+  lantern strings, feast table; lantern-launch choreography on the festival-gold VFX
+  palette the Vale Cup and deed bursts use); MODIFIED `harvest_fair.ts` (the 3 s
+  lantern channel + launch attendance deed, published instants from
+  `nextLanternLaunchAtMs`), English Gleamer item row from S5, wiki regeneration,
+  credits/provenance for PR C assets; renderer composes the new module (never a method bank).
+- Reused: VFX palette, channel machinery, S3 meter tier via IWorld. NEW: render
+  module + launch deed.
+- Tests FIRST (sim side): channel completes in 3 s, freely interruptible with no
+  penalty; attendance deed grants once per launch; absence costs nothing. Render
+  side: `npm run build` + screenshot evidence per the headless screenshot workflow.
+- Acceptance: `npx vitest run tests/harvest_fair.test.ts tests/deeds_content.test.ts tests/architecture.test.ts && npm run wiki:content && npm run build`; committed screenshots under `docs/screenshots/`.
+
+### S7. Fairground games: card tent desk + gourd roll
+- Goal: two games, both trivially agent-completable.
+- Files: MODIFIED `src/sim/content/card_master.ts` (fair desk placement, queue and
+  duel logic UNCHANGED), `harvest_fair.ts` (gourd-roll stall: one channel + one
+  seeded `ctx.rng` draw, `rollSkinRank` precedent, emote-line outcomes),
+  `src/sim/content/deeds.ts` (fair-wins meter deed + zero-Renown luck deed).
+- Reused: card_duel + card_duel_queue modules wholesale, rng draw pattern. NEW:
+  placements and two deed records.
+- Tests FIRST in `tests/harvest_fair.test.ts`: fair desk pairs players through the existing queue; gourd roll is one
+  draw (parity-safe, inside fair-only code path); luck deed at 0 Renown; card-win
+  deed ticks only on fair-desk wins.
+- Acceptance: `npx vitest run tests/harvest_fair.test.ts tests/deeds_content.test.ts && npx vitest run tests/parity`
+
+### S8. Skins, recipes (decision-gated), remaining deeds, locale fills (with S7 = PR D)
+- Goal: the reward tail. Recipes ship ONLY if Levy approves parity consumables
+  (open question 2); the lantern charm ships as a skin variant (question 3 decided v1).
+- Files: MODIFIED `src/sim/content/skins.ts` (real fair event skins replacing the
+  placeholder `EVENT_SKIN_TIERS` mapping, earned via the fair token),
+  `src/sim/content/recipes.ts` (IF approved: 1-2 recipes reusing existing output
+  item ids at exact parity), `deeds.ts` (capstone title "Lanternlight" + border
+  slug), English rows for every new item id and M16 prose fills (five non-Latin),
+  `CREDITS.md` for any new art, `npm run wiki:content` regen.
+  NEW `tests/fair_rewards.test.ts` and `scripts/harvest_fair_agent.mjs`.
+- Reused: EVENT_SKIN_TOKEN_ID, rollSkinRank, skin-select machinery, existing output
+  item ids. NEW: fair token + skin item records (the i18n bill; budget the fill as
+  its own task per `i18n-locale-fill`).
+- Tests FIRST in `tests/fair_rewards.test.ts`: token drops only from fair activities; skins learnable across
+  successive fairs (nothing expires); recipe outputs bit-identical to existing
+  consumables; deed set complete and append-only.
+- Acceptance: `npx vitest run tests/fair_rewards.test.ts tests/harvest_fair.test.ts tests/deeds_content.test.ts tests/i18n_completeness.test.ts tests/localization_fixes.test.ts tests/guide.test.ts && node scripts/harvest_fair_agent.mjs && npm run gate`
+
+## 4. Gotchas (read before every slice)
+
+- **G1, determinism is the whole point.** No wall clock in sim, ever: windows arrive
+  as host-supplied epoch ms (server) or tick cadence (offline). If a slice needs "is
+  the fair open", it reads `SeasonWindowState`, never computes a date.
+- **G2, SIM_LAP_PHASES is pinned.** Any new named phase in the server tick must be
+  added to the array at `server/game.ts:334` or `tests/server/tick_perf_capture.test.ts`
+  documents the dropped timing. Prefer folding the scheduler into an existing phase.
+- **G3, parity goldens.** Any new `ctx.rng` draw on a shared code path (the fishing
+  table draw especially) shifts draw order and reds every golden. Fair-only draws
+  live inside fair-only branches; the S5 test pins this. If a golden reds, fix the
+  code, never `UPDATE_PARITY=1` an existing scenario.
+- **G4, the item-i18n bill.** Every NEW item id costs an English catalog row plus a
+  maintainer-owned release overlay fill. Mitigation is designed in: turn-ins and
+  recipe outputs REUSE existing item ids; the only new items are the trophy fish,
+  the fair token, and the skin records (S5/S8). Do not add others casually.
+- **G5, deeds are append-only.** `DEED_ORDER` derives from table order; new deeds go
+  at the end of `src/sim/content/deeds.ts`, never inserted, and land in the same
+  change as their content per `docs/design/deeds.md`.
+- **G6, graphics fairness for fair dressing.** Meter-tier props, bunting, and the
+  lantern launch are cosmetic; every graphics preset may shed their richness but the
+  fair must confer zero gameplay information or advantage at any tier
+  (`docs/design/graphics-settings-fairness.md`).
+- **G7, worktree discipline.** Other sessions carry uncommitted WIP; build each slice
+  in a fresh worktree off the active release branch (fair slices off the #2321
+  branch until it merges), branch `feature/seasonal-s<N>-<slug>`.
+- **G8, realm state is one row and one writer.** Key exactly `seasonal:<realm>`;
+  one live object on Sim; at most one write in flight plus one trailing dirty write.
+  No per-turn-in query, no PlayerMeta copy, no derived timestamp in the save.
+- **G9, boundaries do not scan characters.** Fair letters and Friday refreshes use
+  per-character last-seen ids, lazy reconciliation on load, and an online-only
+  boundary pass. Never query every character when a window changes.
+- **G10, shared wire is serialized once.** Viewer-identical seasonal state uses
+  `realmReadoutJson` + `maybeRaw`; a `maybe('fair', value)` call inside each session
+  loop reintroduces avoidable stringify cost and is not acceptable.
+
+## 5. Agent dispatch template (for later; do not dispatch yet)
+
+Give one implementation owner the slice outcome, acceptance commands, relevant files,
+section 0 ground rules (including the anti-FOMO rules verbatim), section 1 constants,
+the applicable hook-map rows and gotchas. Require a diff summary, exact command
+results, fails-before evidence for any bug-shaped test, and a clean handoff. Run the
+`/qa` gate before merging each slice; S8 ends with the combined `npm run gate`.

--- a/docs/prd/seasonal-events-and-retention-handoff.md
+++ b/docs/prd/seasonal-events-and-retention-handoff.md
@@ -18,7 +18,8 @@
    API. Guarded by `tests/architecture.test.ts`.
 2. All sim randomness goes through `Rng` (`ctx.rng`). Never `Math.random`, `Date.now`,
    `performance.now` in sim logic. Windows are host-supplied civil-time inputs
-   or deterministic sim-tick fallback; the sim NEVER reads a clock.
+   online; offline fair content is controlled by a host-provided flag set at
+   world creation and defaulting OFF. The sim NEVER reads a clock.
 3. Every player-visible string is i18n: sim/server emit stable keys or English
    literals with matcher entries (`src/ui/sim_i18n.ts`, S3 guard
    `tests/localization_fixes.test.ts`); UI strings are `t()` keys in
@@ -51,8 +52,6 @@ export const FAIR_FIRST_OPEN_LOCAL = '2026-09-18T20:00:00'; // realm-local propo
 export const LANTERN_LAUNCH_HOUR = 20;       // realm-local civil 20:00 (tuning)
 export const LANTERN_CHANNEL_SEC = 3;        // freely interruptible
 export const FAIR_METER_THRESHOLDS = [300, 800, 1500] as const; // turn-ins (tuning)
-export const OFFLINE_FAIR_CADENCE_TICKS = 8 * 7 * 24 * 3600 * 20; // tick fallback
-export const OFFLINE_FAIR_WINDOW_TICKS = 14 * 24 * 3600 * 20;
 export const SEASONAL_SAVE_VERSION = 1;
 export const FAIR_METER_CAP = FAIR_METER_THRESHOLDS[2];
 
@@ -79,26 +78,26 @@ All rows verified on origin/release/v0.30.0 except the Amberfall rows (branch on
 
 | Concern | Anchor |
 |---|---|
-| Cadence primitive | `src/sim/professions/cadence.ts`: `WORK_ORDER_CADENCE_TICKS = 36000` (:14), `CadenceMap` (:35), `isCadenceBlocked` (:39), `armCadence` (:46), `serializeCadence` (:100, persisted and clamped on load). Consumers via `repeatCadenceTicks`: zone1/zone2/zone3 records + `src/sim/quests/quest_commands.ts`. There is NO daily-quest system; this is the reuse target. |
-| Host civil time | `server/raid_reset.ts`: 03:00 realm-zone boundary, `nextRaidResetMs` (:115), `isSupportedTimeZone` (:30). Fair windows reuse host-computed civil inputs, but seasonal state does NOT use per-character `meta.raidLockouts`. |
-| Realm JSONB store | `server/db.ts`: `world_state` table (:596), generic `loadWorldState` / `saveWorldState` (:3404), realm-key wrappers `market:<realm>` and `mail:<realm>` (:3464 onward). Seasonal adds typed wrappers for exactly one `seasonal:<realm>` row. |
-| Save cadence | `server/game.ts`: `createSerialWriter` market writer near :1370; `flushPeriodicSaves` 30-second cadence :2059. Seasonal adds a dirty, coalesced writer with at most one in-flight and one trailing save; no turn-in query. |
-| Boot and shutdown | `server/main.ts`: boot constructs the live game after schema setup near :2814; shutdown stops the game and drains market/mail near :3095. Seasonal load completes before listen, and its writer drains before pool close. |
-| Shared realm wire | `server/game.ts`: `maybeRaw` near :5742 and `realmReadoutJson` use near :5871 build and stringify viewer-identical state once per broadcast pass. Seasonal uses this shared path, not per-session `maybe()`. |
-| Fishing | `src/sim/professions/fishing.ts`: `startFishing` (:124), `completeFishing` (:211, ONE table draw; capacity gates after the roll :255 so draw order never depends on bags; Vale-table fallback :223), `fishingCatchGain` (:92), rare precedent `the_codfather` (:39), `onFishCaughtForDeeds` call (:284). |
-| Deeds | Content `src/sim/content/deeds.ts`: `DEED_ORDER` (:2228) APPEND-ONLY (contract header :6). Evaluator `src/sim/deeds.ts`: `onFishCaughtForDeeds` (:1792), `onNpcTalkedForDeeds` (:1765), `onCupMatchEndForDeeds` (:1699) as meter/flag templates. Contract doc: `docs/design/deeds.md`. |
-| Skins | `src/sim/content/skins.ts`: `EVENT_SKIN_TOKEN_ID = 'event_skin_token'` (:17), `rollSkinRank(unitRoll)` (:28), `EVENT_SKIN_TIERS` (:45, ":38 placeholder mapping onto existing alt skins" is the comment S8 replaces). |
-| Card duel | `src/sim/social/card_duel.ts` + `card_duel_queue.ts` (`createCardDuelQueue` :8, `joinCardDuelQueue` :16, `tryPairCardDuel` :44); `src/sim/content/card_master.ts` `CARD_MASTER_NPC_ID` (:6). Only the fair desk placement is new. |
-| Mail | `src/sim/content/letters.ts`: `LetterDef` (:17), `QUEST_LETTERS` (:90) as the record template; delivery via `src/sim/mail/post_office.ts` (PostOffice, letterId client localization). |
-| Noticeboards | `src/sim/content/noticeboards.ts`: `NOTICEBOARDS` (:29, one Eastbrook board), `noticeboardDefByEntityId` (:32). Town Focus is an interaction precedent only; seasonal persistence and shared wire use the rows above. |
-| Content merge | `src/sim/data.ts` imports content modules (zone3 at :109; amberfall at branch data.ts:43). New content modules merge here. |
-| Amberfall (branch #2321 ONLY) | `src/sim/content/amberfall.ts`: hub Lanternmere (:34), Great Mere POI (:48), NPCs `reeve_ottoline` (:223), `waywatcher_sorrel` (:233), `ferrymaster_caddow` (:244), `orchardist_pomeline` (:255), existing `stalls:` prop records (:543). Fair placements are ADDITIVE to this file. |
+| Cadence primitive | `src/sim/professions/cadence.ts`: `WORK_ORDER_CADENCE_TICKS = 36000`, `CadenceMap`, `isCadenceBlocked`, `armCadence`, and `serializeCadence`. Consumers use `repeatCadenceTicks` in the zone quest records and `src/sim/quests/quest_commands.ts`. At 20 Hz the cadence is 30 minutes, so it remains a provisioning-order precedent and is never cleared for market day. |
+| Host civil time | `server/raid_reset.ts`: `nextRaidResetMs` and `isSupportedTimeZone`. Fair windows reuse host-computed civil inputs, but seasonal state does NOT use per-character `meta.raidLockouts`. |
+| Realm JSONB store | `server/db.ts`: `world_state`, `loadWorldState`, `saveWorldState`, and the realm-key wrappers for `market:<realm>` and `mail:<realm>`. Seasonal adds typed wrappers for exactly one `seasonal:<realm>` row. |
+| Save cadence | `server/game.ts`: `createSerialWriter` and `flushPeriodicSaves`. Seasonal adds a dirty, coalesced writer with at most one in-flight and one trailing save; no turn-in query. |
+| Boot and shutdown | `server/main.ts`: the schema setup, game construction, and shutdown lifecycle. Seasonal load completes before listen, and its writer drains before pool close. |
+| Shared realm wire | `server/realm_readout_memo.ts` exports `realmReadoutJson`; `server/game.ts` imports it and combines its memoized readout with `maybeRaw`. Seasonal uses this shared path, not per-session `maybe()`. |
+| Fishing | `src/sim/professions/fishing.ts`: `startFishing`, `completeFishing`, `fishingCatchGain`, rare precedent `the_codfather`, and the `onFishCaughtForDeeds` call. `completeFishing` keeps one table draw, with capacity gates after the roll so draw order never depends on bags. |
+| Deeds | Content `src/sim/content/deeds.ts`: append-only `DEED_ORDER`. Evaluator `src/sim/deeds.ts`: `onFishCaughtForDeeds`, `onNpcTalkedForDeeds`, and `onCupMatchEndForDeeds` as meter and flag templates. Contract doc: `docs/design/deeds.md`. |
+| Skins | `src/sim/content/skins.ts`: `EVENT_SKIN_TOKEN_ID`, `rollSkinRank`, and `EVENT_SKIN_TIERS`. The placeholder mapping comment identifies what S8 replaces. |
+| Card duel | `src/sim/social/card_duel.ts` + `card_duel_queue.ts`: `createCardDuelQueue`, `joinCardDuelQueue`, and `tryPairCardDuel`; `src/sim/content/card_master.ts`: `CARD_MASTER_NPC_ID`. Only the fair desk placement is new. |
+| Mail | `src/sim/content/letters.ts`: `LetterDef` and `QUEST_LETTERS` as the record template; delivery via `src/sim/mail/post_office.ts` and `PostOffice`, with letterId client localization. |
+| Noticeboards | `src/sim/content/noticeboards.ts`: `NOTICEBOARDS` and `noticeboardDefByEntityId`. Town Focus is an interaction precedent only; seasonal persistence and shared wire use the rows above. |
+| Content merge | `src/sim/data.ts` imports the zone content modules. New content modules merge here. |
+| Amberfall (branch #2321 ONLY) | `src/sim/content/amberfall.ts`: Lanternmere, the Great Mere POI, `reeve_ottoline`, `waywatcher_sorrel`, `ferrymaster_caddow`, `orchardist_pomeline`, and the existing `stalls` prop records. Fair placements are ADDITIVE to this file. |
 | SimContext seam | `src/sim/sim_context.ts`; new system modules take `ctx: SimContext`, backing state lives on `Sim` as a live ctx view (`src/sim/CLAUDE.md`). |
 | IWorld | `src/world_api.ts` + per-facet files in `src/world_api/` (e.g. `daily_rewards.ts` as a facet template); parity pin `tests/world_api_parity.test.ts`. |
-| ClientWorld | `src/net/online.ts` `applySnapshot` self/global mirrors (tfocus pattern :2973). |
-| Server tick pin | `SIM_LAP_PHASES` `server/game.ts:334` (pinned by `tests/server/tick_perf_capture.test.ts`); a new named sim phase must be added to the array or its timing drops. |
+| ClientWorld | `src/net/online.ts`: `applySnapshot` self and global mirrors. |
+| Server tick pin | `server/game.ts`: `SIM_LAP_PHASES`, pinned by `tests/server/tick_perf_capture.test.ts`. A new named sim phase must be added to the array or its timing drops. |
 | Parity goldens | `tests/parity/scenarios.ts`; `UPDATE_PARITY=1 npx vitest run tests/parity` regenerates; never regenerate to hide a diff. |
-| Wardstone channel precedent | `src/sim/interaction.ts` (:472 area, `nythraxis_ward_channel`): the readable ground-object channel pattern for stalls and lanterns. |
+| Wardstone channel precedent | `src/sim/interaction.ts`: `nythraxis_ward_channel`, the readable ground-object channel pattern for stalls and lanterns. |
 
 ## 3. Slices
 
@@ -134,7 +133,10 @@ export interface SeasonWindowState {
 ```
   Host mode computes instants and a stable `fairId` from the opening instant,
   schedule version, and realm time zone, then hands those values to the sim.
-  Offline mode uses `OFFLINE_FAIR_CADENCE_TICKS` (pending Levy open question 4).
+  Offline mode receives a host-provided `offlineFairEnabled` flag at world
+  creation. It defaults OFF. When explicitly enabled, fair content is always
+  open with a stable offline `fairId`; no calendar progression or wall-clock
+  read occurs.
 - Persist only `SeasonalRealmSave { version, fairId, meter }`. Sanitize on load:
   reject unknown shapes, normalize meter to a finite integer in
   `0..FAIR_METER_CAP`, retain it only when the loaded `fairId` matches the
@@ -143,35 +145,42 @@ export interface SeasonWindowState {
   and one trailing write for newer state; autosave may flush dirty state; fair
   boundaries and thresholds request a flush; failure leaves dirty state for retry;
   shutdown drains. A turn-in never calls `saveSeasonalState` directly.
-- Tests FIRST: same seed + host inputs produce identical windows; offline boundaries
-  land on exact ticks; same-fair restart preserves meter; next-fair and downtime
-  reconciliation reset once; corrupt/non-finite/out-of-range documents sanitize;
-  realms use distinct keys; writer queue stays bounded; failure retries; shutdown
-  drains; save-age/failure diagnostics expose no payload; architecture proves no
-  sim clock read. Pin exactly one zero-or-one-row boot read and writes only on
-  dirty autosave, boundary, threshold, or shutdown triggers. Independent malformed
-  cases cover unknown version, missing/invalid `fairId`, missing meter, negative,
-  fractional, above-cap, NaN, and Infinity. Fixed vectors cover the anchor, two
-  recurrence cycles, a DST transition, exact boundaries, and a schedule-version change.
+- Tests FIRST: same seed + host inputs produce identical windows; offline worlds
+  default to fair content OFF and enable it only through the world-creation flag;
+  same-fair restart preserves meter; next-fair and downtime reconciliation reset
+  once; corrupt/non-finite/out-of-range documents sanitize; realms use distinct
+  keys; writer queue stays bounded; failure retries; shutdown drains;
+  save-age/failure diagnostics expose no payload; architecture proves no sim clock
+  read. Pin exactly one zero-or-one-row boot read and writes only on dirty autosave,
+  boundary, threshold, or shutdown triggers. Independent malformed cases cover
+  unknown version, missing/invalid `fairId`, missing meter, negative, fractional,
+  above-cap, NaN, and Infinity. Fixed vectors cover the anchor, two recurrence
+  cycles, a DST transition, exact boundaries, and a schedule-version change.
 - Acceptance: `npx vitest run tests/season_schedule.test.ts tests/server/seasonal_persistence.test.ts tests/architecture.test.ts && npx vitest run tests/parity`
 
 ### S2. Calendar data table + market day + noticeboard/letter surface (completes PR A)
 - Goal: the published weekly rhythm and its minimal v1 surface.
 - Files: NEW `src/sim/content/event_calendar.ts` (fixture-day table: Tuesday reset,
-  Wednesday Vale Cup, Friday market day, Saturday Ferrywalk placeholder, Sunday
-  featured Hunt; days tuning; merged by `data.ts`); MODIFIED `season_schedule.ts`
-  (market-day cadence clear: on the Friday boundary, clear work-order `CadenceMap`
-  keys so every order is freshly available; NO payout change),
+  Wednesday Vale Cup, Friday market day, Saturday Ferrywalk placeholder once its
+  proposed PRD lands, Sunday featured Hunt placeholder once its proposed PRD lands;
+  days tuning; merged by `data.ts`). Friday market day defines one visiting peddler
+  as a normal vendor NPC with one stall and an inventory of existing item ids. The
+  fixture-day gate spawns both NPC and stall while open and despawns both when
+  closed; it never mutates work-order cadence or payout state. MODIFIED
   `src/sim/content/noticeboards.ts` (calendar notice content),
   `src/sim/content/letters.ts` (fair-open letter record), character state
-  serialization (`lastFairLetterId`, `lastMarketRefreshId`) with lazy reconcile
-  on character load and an online-character boundary update, `src/ui/sim_i18n.ts`
-  matcher entries for any sim-emitted lines. Never scan the character table.
-- Reused: CadenceMap, NOTICEBOARDS, LetterDef/PostOffice. NEW: the data table only.
-- Tests FIRST: cadence keys clear exactly once per market boundary; a character
-  offline at the boundary reconciles on next load; an online character updates at
-  the boundary; fixture resolution is pure; fair letter delivers once per `fairId`;
-  no boundary-wide character query occurs.
+  serialization (`lastFairLetterId`) with lazy reconcile on character load and an
+  online-character boundary update, `src/ui/sim_i18n.ts` matcher entries for any
+  sim-emitted lines. Never scan the character table.
+- Reused: normal NPC definitions, vendor inventory and interaction machinery,
+  existing item ids, NOTICEBOARDS, and LetterDef/PostOffice. NEW: the fixture table,
+  one peddler NPC definition, and one stall placement only.
+- Tests FIRST: the peddler NPC and stall exist only while the Friday gate is open;
+  vendor interaction uses the existing machinery; every stock item id already
+  exists; work-order `CadenceMap` state is unchanged at both Friday boundaries;
+  fixture resolution is pure; fair letter delivers once per `fairId`; a character
+  offline at the fair boundary reconciles on next load; no boundary-wide character
+  query occurs.
 - Acceptance: `npx vitest run tests/season_schedule.test.ts tests/server/seasonal_persistence.test.ts tests/localization_fixes.test.ts && npx vitest run tests/parity`
 
 ### S3. Realm-shared fair meter (seam slice: IWorld, wire, mirror, parity)
@@ -188,11 +197,13 @@ export interface SeasonWindowState {
   readout memo because every client renders the same town):
 ```ts
 // server snapshot: fair: { o: 0|1, m: number, t: 0|1|2|3 }
+// server/game.ts imports realmReadoutJson from server/realm_readout_memo.ts
 // server: maybeRaw('fair', realmReadoutJson(... seasonalInfo ...))
 // online.ts applySnapshot: if (s.fair) this.seasonal = decodeFair(s.fair);
 ```
-- Reused: `realmReadoutJson` + `maybeRaw`, world_api facet layout, S1 realm save.
-  NEW: meter state only (resets each fair, gates nothing).
+- Reused: `realmReadoutJson` from `server/realm_readout_memo.ts`, `maybeRaw` in
+  `server/game.ts`, world_api facet layout, and the S1 realm save. NEW: meter
+  state only (resets each fair, gates nothing).
 - Tests FIRST: offline Sim and ClientWorld expose identical `seasonalInfo`; meter
   survives same-fair save/load; values clamp to `0..FAIR_METER_CAP`; threshold
   crossings dirty and flush once; 100 turn-ins issue zero immediate queries and
@@ -226,9 +237,11 @@ export interface SeasonWindowState {
   beside `onFishCaughtForDeeds`.
 - Reused: the single-table-draw contract, `the_codfather` rare precedent, deed
   meters. NEW: one item id (English row plus maintainer release fill) + persisted lifetime tally.
-- Tests FIRST: draw order identical whether or not the fair is open EXCEPT the fair
-  row (pin the one-draw contract); tally accumulates across two simulated fair
-  windows and never resets; Gleamer is no-sell; derby deed fires at thresholds.
+- Tests FIRST: default offline worlds keep fair content OFF. On every path exercised
+  by a parity scenario, fishing has no new draw AND no changed outcome. Separate
+  opt-in fair tests pin the existing one-draw contract while exercising the fair
+  row; tally accumulates across two simulated fair windows and never resets;
+  Gleamer is no-sell; derby deed fires at thresholds.
 - Acceptance: `npx vitest run tests/professions_fishing.test.ts tests/deeds_content.test.ts && npx vitest run tests/parity` (expect NO golden churn; see gotcha G3)
 
 ### S6. Lantern launch + meter-tiered town dressing (render; with S5 = PR C)
@@ -279,15 +292,18 @@ export interface SeasonWindowState {
 
 ## 4. Gotchas (read before every slice)
 
-- **G1, determinism is the whole point.** No wall clock in sim, ever: windows arrive
-  as host-supplied epoch ms (server) or tick cadence (offline). If a slice needs "is
-  the fair open", it reads `SeasonWindowState`, never computes a date.
+- **G1, determinism is the whole point.** No wall clock in sim, ever: online windows
+  arrive as host-supplied epoch ms. Offline fair content reads only the
+  world-creation opt-in flag, default OFF. If a slice needs "is the fair open", it
+  reads `SeasonWindowState`, never computes a date.
 - **G2, SIM_LAP_PHASES is pinned.** Any new named phase in the server tick must be
-  added to the array at `server/game.ts:334` or `tests/server/tick_perf_capture.test.ts`
-  documents the dropped timing. Prefer folding the scheduler into an existing phase.
-- **G3, parity goldens.** Any new `ctx.rng` draw on a shared code path (the fishing
-  table draw especially) shifts draw order and reds every golden. Fair-only draws
-  live inside fair-only branches; the S5 test pins this. If a golden reds, fix the
+  added to `SIM_LAP_PHASES` in `server/game.ts` or
+  `tests/server/tick_perf_capture.test.ts` documents the dropped timing. Prefer
+  folding the scheduler into an existing phase.
+- **G3, parity goldens.** The fair-only fishing invariant is no new draw AND no
+  changed outcome on any path a parity scenario exercises. Offline worlds default
+  to fair content OFF, so offline goldens never shift. The S5 tests pin both the
+  default path and the separate host-opt-in fair path. If a golden reds, fix the
   code, never `UPDATE_PARITY=1` an existing scenario.
 - **G4, the item-i18n bill.** Every NEW item id costs an English catalog row plus a
   maintainer-owned release overlay fill. Mitigation is designed in: turn-ins and
@@ -306,12 +322,14 @@ export interface SeasonWindowState {
 - **G8, realm state is one row and one writer.** Key exactly `seasonal:<realm>`;
   one live object on Sim; at most one write in flight plus one trailing dirty write.
   No per-turn-in query, no PlayerMeta copy, no derived timestamp in the save.
-- **G9, boundaries do not scan characters.** Fair letters and Friday refreshes use
-  per-character last-seen ids, lazy reconciliation on load, and an online-only
-  boundary pass. Never query every character when a window changes.
+- **G9, boundaries do not scan characters.** Fair letters use per-character
+  last-seen ids, lazy reconciliation on load, and an online-only boundary pass.
+  The Friday peddler NPC and stall are derived from the fixture gate and have no
+  per-character refresh state. Never query every character when a window changes.
 - **G10, shared wire is serialized once.** Viewer-identical seasonal state uses
-  `realmReadoutJson` + `maybeRaw`; a `maybe('fair', value)` call inside each session
-  loop reintroduces avoidable stringify cost and is not acceptable.
+  `realmReadoutJson` from `server/realm_readout_memo.ts` plus `maybeRaw` in
+  `server/game.ts`; a `maybe('fair', value)` call inside each session loop
+  reintroduces avoidable stringify cost and is not acceptable.
 
 ## 5. Agent dispatch template (for later; do not dispatch yet)
 

--- a/docs/prd/seasonal-events-and-retention-handoff.md
+++ b/docs/prd/seasonal-events-and-retention-handoff.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-| **Status** | BLOCKED pending the Levy portfolio and schedule decision. PR A (S1, S2) has no zone dependency but is not authorized merely because it is technically independent. Fair slices (S3 to S8) are additionally blocked on PR #2321 (feature/procedural-dungeons, the Amberfall zone) and go through a PBE round before any release. |
+| **Status** | READY FOR THE LEVY CONVERSATION. The Amberfall zone content landed in `release/v0.33.0` at `src/sim/content/amberfall.ts`, merged through `src/sim/data.ts` into the `ZONES` table. PR A (S1, S2) is technically independent but is not authorized. Dispatch still requires Levy's portfolio, schedule, and civil-time decisions, plus a commitment to a PBE round for fair slices S3 to S8. |
 | **Portfolio lane** | Proposed fourth approval candidate, the support layer after a new tentpole. This is not Levy approval. |
-| **Dispatch gate** | Levy approves the civil-time policy, fixture schedule, and this portfolio slot. Scheduler/calendar go first; recipes and extra games are cut before the fair meter, derby, lantern launch, or anti-FOMO contract. |
+| **Dispatch gate** | Levy approves the civil-time policy, fixture schedule, and this portfolio slot, and commits the fair slices to a PBE round. Scheduler/calendar go first; recipes and extra games are cut before the fair meter, derby, lantern launch, or anti-FOMO contract. |
 | **Source PRD** | `docs/prd/seasonal-events-and-retention.md` (implementation notes + File plan inside are verified and binding) |
 | **Scope** | The season/fixture window scheduler, the weekly calendar surface, the fair (stalls, turn-in meter, derby, lantern launch, games, deeds, skins, recipes). NO calendar HUD window (separate UI PRD), NO vanity-pet system (deferred), NO Vale Cup exhibition (cut; the Cup gets a fixture day). |
-| **Verified against** | 2026-07-25: origin/release/v0.30.0 (c1a7f42f1) and, for Amberfall anchors only, origin/feature/procedural-dungeons (0084f3dad). Revalidate every anchor against the active release branch before implementation; trust symbols, not line numbers. |
+| **Verified against** | 2026-07-25: origin/release/v0.30.0 (c1a7f42f1) for non-zone machinery. Amberfall was reverified on `release/v0.33.0` at `src/sim/content/amberfall.ts`, merged through `src/sim/data.ts` into the `ZONES` table. Revalidate every anchor against the active release branch before implementation; trust symbols, not line numbers. |
 | **Executor routing** | Claude uses `extract-and-test` and `qa-checklist`; Codex uses `$woc-extract-and-test` and `$woc-qa`. Persistence work requires database-performance and persistence review; render/UI and sim reviews follow the changed surface. No slice depends on a named model. |
 
 ---
@@ -74,7 +74,9 @@ work-order copper, unchanged (the payout fraction is an economy constant).
 
 ## 2. Verified hook-point map (re-find every anchor before editing)
 
-All rows verified on origin/release/v0.30.0 except the Amberfall rows (branch only).
+All non-zone rows were verified on `origin/release/v0.30.0`. The Amberfall rows were
+reverified on `release/v0.33.0` at `src/sim/content/amberfall.ts`, merged through
+`src/sim/data.ts` into the `ZONES` table.
 
 | Concern | Anchor |
 |---|---|
@@ -91,7 +93,7 @@ All rows verified on origin/release/v0.30.0 except the Amberfall rows (branch on
 | Mail | `src/sim/content/letters.ts`: `LetterDef` and `QUEST_LETTERS` as the record template; delivery via `src/sim/mail/post_office.ts` and `PostOffice`, with letterId client localization. |
 | Noticeboards | `src/sim/content/noticeboards.ts`: `NOTICEBOARDS` and `noticeboardDefByEntityId`. Town Focus is an interaction precedent only; seasonal persistence and shared wire use the rows above. |
 | Content merge | `src/sim/data.ts` imports the zone content modules. New content modules merge here. |
-| Amberfall (branch #2321 ONLY) | `src/sim/content/amberfall.ts`: Lanternmere, the Great Mere POI, `reeve_ottoline`, `waywatcher_sorrel`, `ferrymaster_caddow`, `orchardist_pomeline`, and the existing `stalls` prop records. Fair placements are ADDITIVE to this file. |
+| Amberfall (`release/v0.33.0`) | `src/sim/content/amberfall.ts`, merged through `src/sim/data.ts` into the `ZONES` table: Lanternmere, the Great Mere POI, `reeve_ottoline`, `waywatcher_sorrel`, `ferrymaster_caddow`, `orchardist_pomeline`, and the existing `stalls` prop records. Fair placements are ADDITIVE to this file. |
 | SimContext seam | `src/sim/sim_context.ts`; new system modules take `ctx: SimContext`, backing state lives on `Sim` as a live ctx view (`src/sim/CLAUDE.md`). |
 | IWorld | `src/world_api.ts` + per-facet files in `src/world_api/` (e.g. `daily_rewards.ts` as a facet template); parity pin `tests/world_api_parity.test.ts`. |
 | ClientWorld | `src/net/online.ts`: `applySnapshot` self and global mirrors. |
@@ -102,7 +104,9 @@ All rows verified on origin/release/v0.30.0 except the Amberfall rows (branch on
 ## 3. Slices
 
 Dependency order: S1 -> S2 (PR A, ships first, release-branch base) ; S3 -> S4 -> (S5,
-S6, S7 in any order) -> S8. S3 onward stack on #2321 and follow the PRD's PR B/C/D
+S6, S7 in any order) -> S8. The zone dependency for S3 onward is satisfied in
+`release/v0.33.0` at `src/sim/content/amberfall.ts`, merged through
+`src/sim/data.ts` into the `ZONES` table. These slices follow the PRD's PR B/C/D
 staging: S3+S4 = PR B, S5+S6 = PR C, S7+S8 = PR D.
 S2, S4, S6, and S8 close their PR boundaries. Each closeout carries that
 PR's Deeds and pins, English catalog and any M16 work, sim matcher rows, wiki
@@ -317,8 +321,10 @@ export interface SeasonWindowState {
   fair must confer zero gameplay information or advantage at any tier
   (`docs/design/graphics-settings-fairness.md`).
 - **G7, worktree discipline.** Other sessions carry uncommitted WIP; build each slice
-  in a fresh worktree off the active release branch (fair slices off the #2321
-  branch until it merges), branch `feature/seasonal-s<N>-<slug>`.
+  in a fresh worktree off the active release branch. The fair zone content is already
+  present in `release/v0.33.0` at `src/sim/content/amberfall.ts`, merged through
+  `src/sim/data.ts` into the `ZONES` table. Use branch
+  `feature/seasonal-s<N>-<slug>`.
 - **G8, realm state is one row and one writer.** Key exactly `seasonal:<realm>`;
   one live object on Sim; at most one write in flight plus one trailing dirty write.
   No per-turn-in query, no PlayerMeta copy, no derived timestamp in the save.

--- a/docs/prd/seasonal-events-and-retention.md
+++ b/docs/prd/seasonal-events-and-retention.md
@@ -1,9 +1,12 @@
 # PRD: Seasonal events and retention, the Amberfall Harvest Fair and the weekly calendar
 
-Status: DRAFT pass 1 (2026-07-25), for discussion with Levy. Numbers
-marked (tuning) are proposals. The retention program the maintainer asked
-for: cosmetic, social, and convenience rewards only; no daily-chore
-psychology; agent-completable; a village fair, not a battle pass.
+Status: READY FOR THE LEVY CONVERSATION. The Amberfall zone content landed in
+`release/v0.33.0` at `src/sim/content/amberfall.ts`, merged through
+`src/sim/data.ts` into the `ZONES` table. Dispatch still requires Levy to approve
+the schedule, civil-time policy, and portfolio slot, plus a commitment to a PBE
+round for the fair. Numbers marked (tuning) are proposals. The retention program
+the maintainer asked for: cosmetic, social, and convenience rewards only; no
+daily-chore psychology; agent-completable; a village fair, not a battle pass.
 
 ## One-line pitch
 
@@ -22,8 +25,11 @@ moment worth coming back for, and missing either costs only the fun.
   enter through a later slice.
 - First schedule cut: recipes and additional fairground games go before the meter, derby,
   lantern launch, or anti-FOMO rules.
-- Next-stage gate: Levy approves the schedule and civil-time policy. Fair slices also wait
-  for PR #2321 and require PBE. The proposed portfolio position is not approval.
+- Next-stage gate: the Amberfall zone content landed in `release/v0.33.0` at
+  `src/sim/content/amberfall.ts`, merged through `src/sim/data.ts` into the `ZONES`
+  table. Levy still must approve the schedule, civil-time policy, and portfolio slot,
+  and the fair still requires a committed PBE round. The proposed portfolio position
+  is not approval.
 
 ## Why retention content, and the anti-FOMO stance
 
@@ -44,11 +50,12 @@ than a lockout timer," never "a punishment for logging out." Hard rules:
 ## The Amberfall Harvest Fair
 
 A two-week window in Lanternmere and on the Great Mere, recurring every 8
-real weeks (tuning). Hard dependency: the Amberfall zone ships only on the
-new-realms branch (PR #2321, feature/procedural-dungeons); the fair stacks
-on it and must not contradict the authored zone (Lanternmere, the Great
-Mere, the Gilded Orchard, Harvest Hollow, and the resident cast: Reeve
-Ottoline, Ferrymaster Caddow, Orchardist Pomeline, Waywatcher Sorrel).
+real weeks (tuning). The Amberfall zone dependency is satisfied: its content
+landed in `release/v0.33.0` at `src/sim/content/amberfall.ts`, merged through
+`src/sim/data.ts` into the `ZONES` table. The fair stacks on that authored zone
+and must not contradict Lanternmere, the Great Mere, the Gilded Orchard,
+Harvest Hollow, or the resident cast: Reeve Ottoline, Ferrymaster Caddow,
+Orchardist Pomeline, and Waywatcher Sorrel.
 
 ### Fairground stalls
 
@@ -152,10 +159,12 @@ HUD window is a flagged dependency for a separate UI PRD.
 
 ## Implementation notes: verified existing machinery, reused
 
-All verified on origin/release/v0.30.0 by reading each module:
+All non-zone machinery verified on `origin/release/v0.30.0` by reading each module.
+The Amberfall zone anchor was reverified on `release/v0.33.0`:
 
-- Amberfall zone: src/sim/content/amberfall.ts (the #2321 branch only),
-  hub, lakes, props, NPCs, and quest chains as cited throughout.
+- Amberfall zone: `src/sim/content/amberfall.ts`, merged through
+  `src/sim/data.ts` into the `ZONES` table on `release/v0.33.0`, with the hub,
+  lakes, props, NPCs, and quest chains cited throughout.
 - Repeatable-quest cadence: src/sim/professions/cadence.ts (CadenceMap,
   WORK_ORDER_CADENCE_TICKS, persisted and clamped on load) driving zone1's
   work orders via repeatCadenceTicks. There is NO per-day daily-quest
@@ -261,8 +270,10 @@ authorization.
    versioned seasonal realm save and full server lifecycle, calendar data,
    gate-driven visiting peddler stall, lazy per-character letter reconciliation,
    noticeboard surface, shared wire seam, and tests.
-2. PR B (needs #2321): fair core: stalls, turn-in meter, fair quests and
-   NPC placements, fair deeds, English catalog rows, and M16 fills.
+2. PR B (Amberfall zone dependency satisfied in `release/v0.33.0` at
+   `src/sim/content/amberfall.ts`, merged through `src/sim/data.ts` into the
+   `ZONES` table): fair core: stalls, turn-in meter, fair quests and NPC
+   placements, fair deeds, English catalog rows, and M16 fills.
 3. PR C: derby plus lantern launch, their deeds, VFX, screenshot evidence.
 4. PR D: games, skins, recipes (if approved), remaining deeds and titles.
 
@@ -325,8 +336,9 @@ Files MODIFIED:
   placeholder tiers), `src/sim/content/card_master.ts` (fair desk
   placement), `src/sim/content/letters.ts`, `src/sim/content/deeds.ts`
   (append) + `tests/deeds_content` pins.
-- `src/sim/content/amberfall.ts` (branch #2321 file): stall props and
-  fair NPC placements only, additive.
+- `src/sim/content/amberfall.ts` on `release/v0.33.0`, merged through
+  `src/sim/data.ts` into the `ZONES` table: stall props and fair NPC placements
+  only, additive.
 - `src/ui/sim_i18n.ts` (event text keys), `src/ui/i18n.catalog/` +
   English item rows plus five non-Latin overlays for M16 prose, regenerated
   resolved files; noticeboard content record; `CREDITS.md` for any new

--- a/docs/prd/seasonal-events-and-retention.md
+++ b/docs/prd/seasonal-events-and-retention.md
@@ -1,0 +1,338 @@
+# PRD: Seasonal events and retention, the Amberfall Harvest Fair and the weekly calendar
+
+Status: DRAFT pass 1 (2026-07-25), for discussion with Levy. Numbers
+marked (tuning) are proposals. The retention program the maintainer asked
+for: cosmetic, social, and convenience rewards only; no daily-chore
+psychology; agent-completable; a village fair, not a battle pass.
+
+## One-line pitch
+
+A recurring two-week harvest fair in Lanternmere on the Great Mere, plus
+a published weekly fixture calendar: every week has a shape, every fair a
+moment worth coming back for, and missing either costs only the fun.
+
+## Portfolio alignment
+
+- Proposed lane: fourth approval candidate, the support layer after a new tentpole, not
+  yet Levy-approved.
+- Protected identity: a published weekly rhythm, one shared fair meter, the fishing derby,
+  and the lantern launch, all without FOMO.
+- Scope rail: scheduler and calendar ship before fair content. Fair core ships before extra
+  games, skins, or recipes. No streak, expiring currency, missable reward, or power gain may
+  enter through a later slice.
+- First schedule cut: recipes and additional fairground games go before the meter, derby,
+  lantern launch, or anti-FOMO rules.
+- Next-stage gate: Levy approves the schedule and civil-time policy. Fair slices also wait
+  for PR #2321 and require PBE. The proposed portfolio position is not approval.
+
+## Why retention content, and the anti-FOMO stance
+
+Retention here means "there is a reason to log in this week that is warmer
+than a lockout timer," never "a punishment for logging out." Hard rules:
+
+- Rewards are cosmetic (skins, titles, deed borders), social (a shared
+  spectacle, a realm meter), or convenience (a recipe at parity with
+  existing ones). Never player power (docs/design/deeds.md rule 1).
+- No streaks, no daily checklists, no expiring currencies. Everything
+  returns every fair, forever: missing one costs fun, never an item.
+- Agents are first-class players: every activity is a channel, a turn-in,
+  or a published-schedule appointment. No reflex gates anywhere.
+- Classic feel: stalls, lanterns, a derby, a town feast. Lanternmere runs
+  on harvest labor, lamp tallow, and ferry lanterns; the fair is that
+  town on its best week.
+
+## The Amberfall Harvest Fair
+
+A two-week window in Lanternmere and on the Great Mere, recurring every 8
+real weeks (tuning). Hard dependency: the Amberfall zone ships only on the
+new-realms branch (PR #2321, feature/procedural-dungeons); the fair stacks
+on it and must not contradict the authored zone (Lanternmere, the Great
+Mere, the Gilded Orchard, Harvest Hollow, and the resident cast: Reeve
+Ottoline, Ferrymaster Caddow, Orchardist Pomeline, Waywatcher Sorrel).
+
+### Fairground stalls
+
+Six to eight fair stalls dress the market square and spill down to the
+ferry jetty, reusing the ZonePropsDef stall records the town already has
+two of. Each interactive stall is a ground-object interact with a short
+readable channel (wardstone-style precedent, src/sim/interaction.ts): the
+cider press, the sap-taffy kettle, the lantern dip, the produce table.
+Channels grant purely cosmetic flavor buffs (a cider-warmth glow), zero
+stats.
+
+### The Great Mere fishing derby
+
+Fishing is a full gathering profession (src/sim/professions/fishing.ts:
+bite minigame, one-draw rng contract, proficiency catch bands, per-zone
+tables), so the derby builds directly on it. During the fair, Mere
+catches also count toward a personal derby tally and derby deeds;
+Ferrymaster Caddow keeps the derby book at the jetty. One fair-only table
+row per band adds the Amberjack Gleamer, a no-sell trophy fish used only
+by the turn-in meter and derby deeds. Prizes are titles and a skin
+unlock, never gear; the tally accumulates for life across fairs, so the
+derby changes what a catch counts for, never what fishing yields, and no
+single window is make-or-break.
+
+### The lantern launch
+
+The fair's signature social beat. On three published evenings per window
+(opening night, middle weekend, closing night, realm-local 20:00, tuning),
+Caddow's ferry crews stage a lantern launch: every player on the north
+shore channels a fair lantern (3 s, freely interruptible) and releases it
+onto the Mere, one shared render moment on the festival-gold VFX palette
+the Vale Cup and deed bursts already use, deliberately the screenshot
+every fair produces: the town relighting the water the Meredark chain
+darkened. Attendance grants a deed; absence costs nothing.
+
+### The harvest turn-in meter
+
+The whole-realm progress bar. Reeve Ottoline posts a fair provisioning
+order: players turn in harvest goods (existing fish, meat, and produce
+item ids where possible) on the repeatable work-order pattern
+(repeatCadenceTicks, WORK_ORDER_CADENCE_TICKS precedent in zone1's
+q_prof_workorder_* records) at standard work-order copper. Every turn-in
+also feeds one realm-shared fair meter with three thresholds; as it fills,
+Lanternmere visibly dresses up (bunting, jetty lantern strings, a feast
+table by the well), cosmetic props only. The meter resets each fair and
+gates nothing; it exists so the realm decorates its own town.
+
+### Fairground games
+
+Two games, both reusing shipped systems (a Vale Cup exhibition was cut:
+the Cup belongs to the Sowfield pitch; it gets a fixture day instead):
+
+- The card tent: the Card Master (src/sim/content/card_master.ts) travels
+  to the fair. A fair-side Card Duel desk reuses the matchmaking queue and
+  duel logic (src/sim/social/card_duel.ts, card_duel_queue.ts) unchanged;
+  only the desk placement is new. Fair wins tick a deed meter.
+- The gourd roll: a stall lane game, one ground-object channel plus one
+  seeded Rng draw (rollSkinRank precedent, src/sim/content/skins.ts), a
+  pure luck flavor game with emote-line outcomes and a zero-Renown luck
+  deed. Deliberately not skill-based, so trivially agent-completable.
+
+## The weekly calendar
+
+Scheduling plus a minimal surface, no new gameplay: a published weekly
+rhythm so a returning player knows what is on today (days all tuning):
+
+- Tuesday: reset day (existing 3 AM raid-lockout reset, unchanged).
+- Wednesday: Vale Cup match day (the fixture book Groundskeeper Bram
+  already keeps in fiction becomes a published day).
+- Friday: market day: work-order cadence windows clear at open so every
+  order is freshly available, plus a cosmetics-only visiting peddler
+  stall. No payout changes (the payout fraction is an economy constant).
+- Saturday: the low-tide Ferrywalk assault (the weekly event specced in
+  docs/prd/farshore-odyssey-raid.md), once that PRD lands.
+- Sunday: a featured Hunt window for the Pale Huntsman
+  (docs/prd/pale-huntsman-worldboss.md). His Hunt rides its own short
+  cadence all week; Sunday is the calendar-featured ride, not the only one.
+
+Nothing here is exclusive or expiring; a fixture day is when a thing
+reliably happens, not the only time it can. The v1 surface is the
+noticeboard interaction plus a Ravenpost letter at fair open; a calendar
+HUD window is a flagged dependency for a separate UI PRD.
+
+## Rewards and deeds
+
+- Titles and deeds, authored in the same change as their content per the
+  deeds contract (append-only DEED_ORDER): derby deeds, the launch deed, a
+  fair set with a capstone title ("Lanternlight", tuning) and a border
+  slug. Renown quantized 5/10/25/50; luck deeds at zero Renown.
+- Festival cosmetics via the shipped skin-select machinery: fair clothes
+  as event skins from a fair token, replacing the dev-placeholder tiers
+  skins.ts says await real event skins. A lantern charm ships v1 as a
+  skin variant; a follower "shoulder pet" needs a vanity-pet system that
+  does not exist, flagged NEW, deferred.
+- One or two fair recipes producing convenience consumables at exact
+  parity with existing outputs (recipes.ts precedent of reusing existing
+  item ids). Learned at the fair, craftable year-round after. FLAG for
+  Levy: cut these if even parity consumables read as power.
+
+## Implementation notes: verified existing machinery, reused
+
+All verified on origin/release/v0.30.0 by reading each module:
+
+- Amberfall zone: src/sim/content/amberfall.ts (the #2321 branch only),
+  hub, lakes, props, NPCs, and quest chains as cited throughout.
+- Repeatable-quest cadence: src/sim/professions/cadence.ts (CadenceMap,
+  WORK_ORDER_CADENCE_TICKS, persisted and clamped on load) driving zone1's
+  work orders via repeatCadenceTicks. There is NO per-day daily-quest
+  system in sim; this cadence primitive is the reuse target.
+- Daily reset: server/raid_reset.ts computes realm-local civil boundaries.
+  Seasonal code reuses that host-input boundary discipline, but NOT
+  per-character `meta.raidLockouts`; the fair is realm-owned state.
+- Noticeboards: src/sim/content/noticeboards.ts (one Eastbrook board under
+  WorldContent authority). Town Focus is an interaction precedent only, not
+  the persistence or shared-wire shape for the seasonal realm state.
+- Realm persistence: server/db.ts owns the `world_state` JSONB store and
+  realm-scoped `market:<realm>` / `mail:<realm>` wrappers. Seasonal state uses
+  one `seasonal:<realm>` row and its own validated load/save wrappers.
+- Shared wire: server/game.ts `realmReadoutJson` plus `maybeRaw` builds and
+  stringifies viewer-identical state once per broadcast pass. Seasonal state
+  uses that path, not a per-session `maybe()` stringify.
+- Deeds: src/sim/content/deeds.ts + evaluator src/sim/deeds.ts (meters,
+  flags, retro grants, onFishCaughtForDeeds); contract docs/design/deeds.md.
+- Fishing: full profession as cited above (rare precedent the_codfather).
+- Vale Cup: src/sim/content/vale_cup.ts + social/vale_cup.ts (fixtures,
+  bots, festival-gold VFX). Fiesta, checked as requested, is a 2v2 arena
+  format (social/fiesta.ts), not a seasonal event; nothing here uses it.
+- Mail: src/sim/content/letters.ts + the PostOffice, letterId client
+  localization; the fair-open letter reuses it.
+- Skins: src/sim/content/skins.ts event token + rank roll.
+
+## Genuinely NEW pieces, flagged
+
+1. The seasonal/fixture window scheduler: one small SimContext module
+   (src/sim/events/season_schedule.ts) deriving open windows from host-supplied
+   civil-time inputs; offline gets a deterministic sim-tick fallback cadence.
+2. The seasonal realm save: one versioned `SeasonalRealmSave` in
+   `world_state` under `seasonal:<realm>`, with boot load, coalesced save,
+   shutdown drain, validation, and boundary reconciliation. The live object
+   exists once on `Sim`, never in `PlayerMeta` or character blobs.
+3. The realm-shared fair meter: one field in that save plus a small shared
+   wire field and its ClientWorld mirror (IWorld extension first).
+4. The lantern-launch choreography and meter-tiered town props (render
+   side, VFX reuse).
+5. Fair catch-table row, stall ground objects, quests, deeds, skins: all
+   pure content in existing tables.
+
+## Realm persistence and lifecycle contract
+
+`SeasonalRealmSave` is a versioned, realm-owned document. Persist the minimum
+mutable state: `{ version, fairId, meter }` plus future explicitly versioned
+seasonal counters. `meter` is a finite non-negative integer saturated at the
+final threshold, 1500 in the proposed tuning. `fairId` is derived from the fair
+opening instant, schedule version, and realm time zone. Do not persist derived
+open/close/fixture timestamps; recompute them from host inputs at boot.
+
+The v1 schedule proposal is version 1, first opening 2026-09-18 20:00 in
+each realm's configured civil time, then every 8 calendar weeks. Calendar-week
+arithmetic uses the realm time zone and the same DST conversion policy as raid
+reset, never an elapsed-millisecond interval. The stable id is
+`v<version>:<realmTimeZone>:<openingEpochMs>`; any anchor or cadence change
+increments the schedule version.
+
+Load once before the server accepts traffic. Sanitize unknown versions,
+non-finite values, negative values, and values above the cap. Reconcile the
+loaded `fairId` against the host-derived current fair: retain the meter for the
+same fair, reset it for the next fair, and choose the correct current window
+after downtime. Corrupt or impossible documents fall back to an empty current
+fair and log a bounded diagnostic.
+
+Save through one serial/coalescing writer in `GameServer`: at most one seasonal
+write in flight and one trailing write for newer dirty state. The 30-second
+autosave may flush dirty state, but turn-ins never call the database directly.
+Also flush on fair boundaries and meter thresholds, then drain the writer on
+shutdown before the pool closes. Failed writes leave state dirty for retry.
+Expose aggregate save age, dirty revision, and last-failure status through the
+existing internal performance/health surface without realm payload contents.
+
+Fair-open letters and Friday work-order refreshes are per-character effects,
+not realm scans. Store `lastFairLetterId` and `lastMarketRefreshId` on each
+character, reconcile lazily when that character loads, and update online
+characters at the boundary. Never scan the character table at a seasonal
+boundary.
+
+## i18n scope, priced honestly
+
+Prose-heavy. Fair quest and letter prose needs the five non-Latin locales
+(zh_CN, zh_TW, ja_JP, ko_KR, ru_RU) in the same change per the M16 gate.
+Every NEW item id (trophy fish, fair token, recipes, skin items) needs an
+English catalog row in its contributor PR and a maintainer-owned overlay fill
+before release, which is why the design reuses existing item ids where it can. Deed text
+re-localizes client-side; sim-emitted event text ships as stable keys via
+the sim_i18n matcher in the same change (S3 guard). Budget the locale
+fill as its own task per content PR.
+
+## Staged PR plan and rollout
+
+Per the contribution process: conversation with Levy on this PRD first,
+then the staged order below, then a PBE round for the fair before any
+release. Calendar PR A is technically independent and may land ahead of
+the fair only after Levy selects this portfolio slot; independence is not
+authorization.
+
+1. PR A (no Amberfall dependency, first within this program): the scheduler module,
+   versioned seasonal realm save and full server lifecycle, calendar data,
+   lazy per-character market/letter reconciliation, noticeboard surface,
+   shared wire seam, and tests.
+2. PR B (needs #2321): fair core: stalls, turn-in meter, fair quests and
+   NPC placements, fair deeds, English catalog rows, and M16 fills.
+3. PR C: derby plus lantern launch, their deeds, VFX, screenshot evidence.
+4. PR D: games, skins, recipes (if approved), remaining deeds and titles.
+
+## Acceptance criteria
+
+- Determinism: no wall clock or Math.random in sim; windows host-supplied
+  or tick-derived; architecture and parity tests green.
+- Three hosts: identical behavior offline, online, headless; IWorld
+  extended before any render/ui consumption; meter mirrored in ClientWorld.
+- Persistence: same-fair restarts preserve the meter; next-fair and downtime
+  reconciliation reset exactly once; two realms never share state; malformed
+  saves sanitize; failed writes retry; the writer queue stays bounded.
+- Database cadence: zero queries per turn-in, one realm-row read at boot, and
+  coalesced writes only at autosave, boundary, threshold, or shutdown flushes.
+- Operations: seasonal save age and failure state are observable without
+  exposing saved payloads or player data.
+- Shared wire: one stringify per changed realm readout, fresh joins receive the
+  current value, and unchanged state emits no repeated payload.
+- Agent-completable end to end: every reward reachable via channels,
+  turn-ins, and scheduled attendance; no reflex gates (bot run as proof).
+- Zero power: no stat, gold-positive, or combat-time reward anywhere;
+  graphics-fairness rule holds for all fair dressing.
+- i18n gates green at PR tier; maintainers complete remaining overlays before
+  the release-tier gate.
+
+## File plan (build reference)
+
+Files ADDED:
+- `src/sim/events/season_schedule.ts` behind SimContext (the window
+  scheduler) + `tests/season_schedule.test.ts`.
+- `tests/server/seasonal_persistence.test.ts`: realm isolation, boot/load,
+  coalescing, retry, shutdown drain, query count, and boundary reconciliation.
+- `src/sim/content/harvest_fair.ts`: fair quests, stall ground objects,
+  the provisioning order records, derby table row, fair token/skin item
+  records, and the fair-open letter (merged by `data.ts`).
+- `src/render/fair_dressing.ts` (meter-tiered town props, lantern-launch
+  choreography on the festival-gold VFX palette).
+- The calendar data table (inside `season_schedule.ts` or a sibling
+  `src/sim/content/event_calendar.ts`).
+
+Files MODIFIED:
+- `src/sim/sim.ts` (scheduler tick, one live `SeasonalRealmState`) and
+  `server/game.ts` (SIM_LAP_PHASES decision, host civil-time input, seasonal
+  dirty/coalesced writer, load/save lifecycle, `realmReadoutJson` + `maybeRaw`).
+- `server/db.ts` (typed `seasonalStateKey`, `loadSeasonalState`, and
+  `saveSeasonalState` wrappers over `world_state`) and `server/main.ts` (load
+  before listen, shutdown drain before pool close).
+- Character state serialization for `lastFairLetterId` and
+  `lastMarketRefreshId`, reconciled lazily on character load and for online
+  characters at boundaries, with no database-wide character scan.
+- `src/world_api/` facet for the meter + open-window state, both worlds
+  (`src/net/online.ts` mirror), `tests/world_api_parity.test.ts` pins.
+- `tests/snapshots.test.ts` pins for fresh-join delivery and unchanged shared
+  payload elision.
+- `src/sim/professions/fishing.ts` zone table (the Amberjack Gleamer
+  row), `src/sim/content/skins.ts` (event skins replacing the
+  placeholder tiers), `src/sim/content/card_master.ts` (fair desk
+  placement), `src/sim/content/letters.ts`, `src/sim/content/deeds.ts`
+  (append) + `tests/deeds_content` pins.
+- `src/sim/content/amberfall.ts` (branch #2321 file): stall props and
+  fair NPC placements only, additive.
+- `src/ui/sim_i18n.ts` (event text keys), `src/ui/i18n.catalog/` +
+  English item rows plus five non-Latin overlays for M16 prose, regenerated
+  resolved files; noticeboard content record; `CREDITS.md` for any new
+  art; guide regen.
+
+## Open questions for Levy
+
+1. Fair schedule: approve the v1 proposal (first open 2026-09-18 20:00
+   realm-local, then every 8 calendar weeks), or choose an annual autumn
+   anchor (more classic, much less retention surface)?
+2. Fair recipes at convenience parity: acceptable, or cut crafting to zero?
+3. Lantern follower cosmetic: fund a small vanity-pet system later, or is
+   the skin-variant version the permanent answer?
+4. Offline worlds: fair always-on, or the tick-cadence fallback windows?
+5. The Sunday Hunt slot: confirm featuring the Pale Huntsman's ride on the
+   calendar (his PRD gives the Hunt its own 3-hour cadence (tuning); the
+   calendar entry is presentation, not a schedule change).

--- a/docs/prd/seasonal-events-and-retention.md
+++ b/docs/prd/seasonal-events-and-retention.md
@@ -118,14 +118,16 @@ rhythm so a returning player knows what is on today (days all tuning):
 - Tuesday: reset day (existing 3 AM raid-lockout reset, unchanged).
 - Wednesday: Vale Cup match day (the fixture book Groundskeeper Bram
   already keeps in fiction becomes a published day).
-- Friday: market day: work-order cadence windows clear at open so every
-  order is freshly available, plus a cosmetics-only visiting peddler
-  stall. No payout changes (the payout fraction is an economy constant).
-- Saturday: the low-tide Ferrywalk assault (the weekly event specced in
-  docs/prd/farshore-odyssey-raid.md), once that PRD lands.
-- Sunday: a featured Hunt window for the Pale Huntsman
-  (docs/prd/pale-huntsman-worldboss.md). His Hunt rides its own short
-  cadence all week; Sunday is the calendar-featured ride, not the only one.
+- Friday: market day: one visiting peddler NPC and one stall exist only
+  while the Friday calendar gate is open. The peddler is a normal vendor
+  definition with a vendor inventory, and the same gate that drives fixture
+  days spawns and despawns both NPC and stall. Stock reuses existing item ids
+  to avoid a new i18n bill.
+- Saturday: the low-tide Ferrywalk assault, once the proposed Farshore
+  Odyssey raid PRD lands.
+- Sunday: a featured Hunt window for the Pale Huntsman, once the proposed
+  worldboss PRD lands. That PRD proposes a short Hunt cadence all week;
+  Sunday is the calendar-featured ride, not the only one.
 
 Nothing here is exclusive or expiring; a fixture day is when a thing
 reliably happens, not the only time it can. The v1 surface is the
@@ -167,9 +169,10 @@ All verified on origin/release/v0.30.0 by reading each module:
 - Realm persistence: server/db.ts owns the `world_state` JSONB store and
   realm-scoped `market:<realm>` / `mail:<realm>` wrappers. Seasonal state uses
   one `seasonal:<realm>` row and its own validated load/save wrappers.
-- Shared wire: server/game.ts `realmReadoutJson` plus `maybeRaw` builds and
-  stringifies viewer-identical state once per broadcast pass. Seasonal state
-  uses that path, not a per-session `maybe()` stringify.
+- Shared wire: `server/realm_readout_memo.ts` exports `realmReadoutJson`;
+  `server/game.ts` imports it and combines its memoized readout with `maybeRaw`
+  so viewer-identical state is built and stringified once per broadcast pass.
+  Seasonal state uses that path, not a per-session `maybe()` stringify.
 - Deeds: src/sim/content/deeds.ts + evaluator src/sim/deeds.ts (meters,
   flags, retro grants, onFishCaughtForDeeds); contract docs/design/deeds.md.
 - Fishing: full profession as cited above (rare precedent the_codfather).
@@ -184,7 +187,8 @@ All verified on origin/release/v0.30.0 by reading each module:
 
 1. The seasonal/fixture window scheduler: one small SimContext module
    (src/sim/events/season_schedule.ts) deriving open windows from host-supplied
-   civil-time inputs; offline gets a deterministic sim-tick fallback cadence.
+   civil-time inputs. Offline worlds never read wall clock and expose fair
+   content only when a host-provided world-creation flag opts in, default OFF.
 2. The seasonal realm save: one versioned `SeasonalRealmSave` in
    `world_state` under `seasonal:<realm>`, with boot load, coalesced save,
    shutdown drain, validation, and boundary reconciliation. The live object
@@ -227,10 +231,11 @@ shutdown before the pool closes. Failed writes leave state dirty for retry.
 Expose aggregate save age, dirty revision, and last-failure status through the
 existing internal performance/health surface without realm payload contents.
 
-Fair-open letters and Friday work-order refreshes are per-character effects,
-not realm scans. Store `lastFairLetterId` and `lastMarketRefreshId` on each
-character, reconcile lazily when that character loads, and update online
-characters at the boundary. Never scan the character table at a seasonal
+Fair-open letters are per-character effects, not realm scans. Store
+`lastFairLetterId` on each character, reconcile lazily when that character
+loads, and update online characters at the boundary. The Friday peddler NPC
+and stall are derived directly from the calendar gate and carry no
+per-character refresh state. Never scan the character table at a seasonal
 boundary.
 
 ## i18n scope, priced honestly
@@ -254,8 +259,8 @@ authorization.
 
 1. PR A (no Amberfall dependency, first within this program): the scheduler module,
    versioned seasonal realm save and full server lifecycle, calendar data,
-   lazy per-character market/letter reconciliation, noticeboard surface,
-   shared wire seam, and tests.
+   gate-driven visiting peddler stall, lazy per-character letter reconciliation,
+   noticeboard surface, shared wire seam, and tests.
 2. PR B (needs #2321): fair core: stalls, turn-in meter, fair quests and
    NPC placements, fair deeds, English catalog rows, and M16 fills.
 3. PR C: derby plus lantern launch, their deeds, VFX, screenshot evidence.
@@ -263,9 +268,10 @@ authorization.
 
 ## Acceptance criteria
 
-- Determinism: no wall clock or Math.random in sim; windows host-supplied
-  or tick-derived; architecture and parity tests green.
-- Three hosts: identical behavior offline, online, headless; IWorld
+- Determinism: no wall clock or Math.random in sim; online windows are
+  host-supplied, and offline fair content is controlled only by the
+  host-provided world-creation flag; architecture and parity tests green.
+- Three hosts: behavior is identical for identical host inputs; IWorld
   extended before any render/ui consumption; meter mirrored in ClientWorld.
 - Persistence: same-fair restarts preserve the meter; next-fair and downtime
   reconciliation reset exactly once; two realms never share state; malformed
@@ -296,18 +302,20 @@ Files ADDED:
 - `src/render/fair_dressing.ts` (meter-tiered town props, lantern-launch
   choreography on the festival-gold VFX palette).
 - The calendar data table (inside `season_schedule.ts` or a sibling
-  `src/sim/content/event_calendar.ts`).
+  `src/sim/content/event_calendar.ts`), including the gate-driven peddler
+  NPC, existing-id vendor stock, and stall placement.
 
 Files MODIFIED:
 - `src/sim/sim.ts` (scheduler tick, one live `SeasonalRealmState`) and
   `server/game.ts` (SIM_LAP_PHASES decision, host civil-time input, seasonal
-  dirty/coalesced writer, load/save lifecycle, `realmReadoutJson` + `maybeRaw`).
+  dirty/coalesced writer, load/save lifecycle, and `maybeRaw` integration with
+  `realmReadoutJson` from `server/realm_readout_memo.ts`).
 - `server/db.ts` (typed `seasonalStateKey`, `loadSeasonalState`, and
   `saveSeasonalState` wrappers over `world_state`) and `server/main.ts` (load
   before listen, shutdown drain before pool close).
-- Character state serialization for `lastFairLetterId` and
-  `lastMarketRefreshId`, reconciled lazily on character load and for online
-  characters at boundaries, with no database-wide character scan.
+- Character state serialization for `lastFairLetterId`, reconciled lazily on
+  character load and for online characters at boundaries, with no
+  database-wide character scan.
 - `src/world_api/` facet for the meter + open-window state, both worlds
   (`src/net/online.ts` mirror), `tests/world_api_parity.test.ts` pins.
 - `tests/snapshots.test.ts` pins for fresh-join delivery and unchanged shared
@@ -332,7 +340,10 @@ Files MODIFIED:
 2. Fair recipes at convenience parity: acceptable, or cut crafting to zero?
 3. Lantern follower cosmetic: fund a small vanity-pet system later, or is
    the skin-variant version the permanent answer?
-4. Offline worlds: fair always-on, or the tick-cadence fallback windows?
-5. The Sunday Hunt slot: confirm featuring the Pale Huntsman's ride on the
-   calendar (his PRD gives the Hunt its own 3-hour cadence (tuning); the
-   calendar entry is presentation, not a schedule change).
+4. Resolved: offline worlds never read wall clock. A host-provided flag at
+   world creation opts into always-on fair content and defaults OFF. Offline
+   parity goldens therefore never shift.
+5. The Sunday Hunt slot: once the proposed Pale Huntsman worldboss PRD
+   lands, confirm featuring its ride on the calendar. That PRD proposes a
+   3-hour Hunt cadence (tuning); the calendar entry is presentation, not a
+   schedule change.


### PR DESCRIPTION
## Summary

PRD plus build handoff for the retention program: the Amberfall Harvest Fair and a published weekly fixture calendar. Docs only, two files, opened to start the design conversation.

Two halves with different dependencies. The weekly calendar (Vale Cup match day, market day that refreshes work orders, the low-tide and Hunt fixtures) needs NO new zones and could build first: it is scheduling plus a noticeboard surface. The fair (stalls, a Great Mere fishing derby on the real fishing profession, a lantern launch, a realm-wide harvest meter that cosmetically dresses Lanternmere) stacks on PR #2321.

Hard rules stated up front because they are the point: rewards are cosmetic, social, or convenience only, nothing expires, no streaks, no daily-chore psychology; missing a week costs only the fun. Everything is agent-completable. The handoff verified the shipped machinery it reuses (work-order cadence, realm-local reset, fishing, deeds, event skins, Card Duel) and flags exactly one new system, the seasonal window scheduler.

## Testing

Docs only, no code or content changes. Copy scan clean.