### PR TITLE
docs(raids): The Far Shore Voyage sailing raid PRD and build handoff

### DIFF
--- a/docs/prd/farshore-odyssey-raid-handoff.md
+++ b/docs/prd/farshore-odyssey-raid-handoff.md
@@ -2,13 +2,13 @@
 
 | | |
 |---|---|
-| **Status** | INCUBATION, DRAFT STAGE 4 PACKET, excluded from the active implementation-handoff queue. Do not start slices until Levy explicitly approves the reduced three-boss raid core, the first dungeon and raid pipelines are proven, and PR #2321 lands. Large content requires PBE. |
+| **Status** | INCUBATION, DRAFT STAGE 4 PACKET, excluded from the active implementation-handoff queue. Do not start slices until Levy explicitly approves the reduced three-boss raid core, the first dungeon and raid pipelines are proven, and the `feature/procedural-dungeons` branch (umbrella PR #1584) lands. Large content requires PBE. |
 | **Portfolio lane** | Incubation. The packet is detailed enough to execute later, but detail is not approval or dispatch priority. |
-| **Dispatch gate** | Levy approves the reduced raid core after the pipeline proof. The low-tide assault is a separately approved post-raid extension and cannot delay or share the initial raid dispatch. |
+| **Dispatch gate** | Levy approves the reduced raid core after the pipeline proof, and the `feature/procedural-dungeons` branch (umbrella PR #1584) lands. The low-tide assault is a separately approved post-raid extension and cannot delay or share the initial raid dispatch. |
 | **Source PRD** | `docs/prd/farshore-odyssey-raid.md` (whole document; its File plan section is the file inventory this handoff schedules) |
-| **Scope** | Initial raid core only: standard click-the-moored-ship entry, THREE bosses (Split Horizon, the Name-Taker, Sereva) plus the non-boss Tenfold Sail launch and the open-sail prison-hulk rescue beat, ONE raid lockout id, the Beckoning lured-state primitive, in-instance ship/sail state, the vote with an aura-only Captain mantle, heroic mode on the existing difficulty and variant machinery, loot/deeds/i18n, music/fx, and bot tuning. The weekly low-tide assault is extension X1 outside this core. NOT in scope: the pass-2 to pass-4 cuts, town-side or cross-instance state, additional wings/routes, bespoke Captain buttons, trophy moves, Farshore leveling-content changes, and any $WOC or economy hook. |
+| **Scope** | Initial raid core only: standard click-the-moored-ship entry, THREE bosses (Vessarine, the Name-Taker, Sereva) plus the non-boss Tenfold Sail launch and the open-sail prison-hulk rescue beat, ONE raid lockout id, the Beckoning lured-state primitive, in-instance ship/sail state, the vote with an aura-only Captain mantle, heroic mode on the existing difficulty and variant machinery, loot/deeds/i18n, music/fx, and bot tuning. The weekly low-tide assault is extension X1 outside this core. NOT in scope: the pass-2 to pass-4 cuts, town-side or cross-instance state, additional wings/routes, bespoke Captain buttons, trophy moves, Farshore leveling-content changes, and any $WOC or economy hook. |
 | **Verified against** | `origin/release/v0.30.0` and `origin/feature/procedural-dungeons`, 2026-07-25 (heroic anchors re-verified 2026-07-26). Revalidate every anchor against the active branch before implementation; trust symbols, not line numbers. |
-| **Executor routing** | Claude uses `extract-and-test`, `build-dungeon-kit`, `gen-3d-asset`, `gen-icon-art`, and `qa-checklist`; Codex uses the matching `$woc-*` skills. Sim, frontend, and cross-platform reviewers follow the changed surface. No slice depends on a named model. |
+| **Executor routing** | Claude uses `extract-and-test` and `qa-checklist`; Codex uses the matching `$woc-*` skills. The GLB lane uses the `image-to-glb` skill (`.claude/skills/image-to-glb/SKILL.md`) plus `docs/image-to-glb-asset-workflow.md`. Icon and kit lanes are plain authoring work with no named skill. Sim, frontend, and cross-platform reviewers follow the changed surface. No slice depends on a named model. |
 
 ## 0. Ground rules
 
@@ -16,9 +16,10 @@ Rules 1 to 6 of `docs/prd/FRONTIER_PHASE1_HANDOFF.md` section 0 apply verbatim (
 Rng-only randomness, i18n, strict TS, Conventional Commits, command-anchored acceptance).
 Deltas for this program:
 
-1. Base branch: until #2321 merges, every slice stacks on
-   `origin/feature/procedural-dungeons` (the Farshore stage lives there); after it merges,
-   on the active release branch. Never fork or edit #2321's files.
+1. Base branch: until the `feature/procedural-dungeons` branch (umbrella PR #1584) merges,
+   every slice stacks on `origin/feature/procedural-dungeons` (the Farshore stage lives
+   there); after it merges, on the active release branch. Never fork or edit files owned
+   by the dependency branch.
 2. Commit scope is `feat(voyage): ...`; branches `feature/voyage-s<N>`.
 3. Every NEW per-tick sim module gets its `SIM_LAP_PHASES` pin in `server/game.ts` in the
    SAME slice as its tick call (gotcha G1); every NEW read surface ships as a
@@ -37,7 +38,7 @@ Deltas for this program:
 export const VOYAGE_RAID_SIZE = 10;            // one crew, one ship
 export const VOYAGE_MIN_LEVEL = 20;
 export const VOYAGE_LOCKOUT_ID = 'voyage';     // the ONE raid lockout id on meta.raidLockouts (pass 3)
-export const WATCH_SWAP_SECONDS = 35;          // Split Horizon verse cadence
+export const WATCH_SWAP_SECONDS = 35;          // Vessarine verse cadence
 export const LASH_CHANNEL_SECONDS = 2;         // ally lash-to-mast channel
 export const BECKON_MAX_SECONDS = 8;           // lured walk expiry ceiling
 export const NET_RETURN_SECONDS = 8;           // walk back from the boarding nets
@@ -51,7 +52,10 @@ export const CROWN_SHATTER_HP_PCT = 0.10;      // aurora finale trigger
 Pass-2 scope cut (maintainer direction 2026-07-26): entry is the standard click-the-moored-ship
 raid gate; NO cross-instance or single-crew systems. The bell relay, Gullhaven Answers skiffs,
 previous-crew Wake Ship, and all town-side live state (hung sail, blue watchfire) are CUT.
-First-clear bell engraving remains the only open-world mutation in the raid core.
+
+**Future flourish:** A first-server-clear plaque would be realm-global persisted state,
+which conflicts with the raid's no-cross-instance-state rail. It needs its own persistence
+design, including a `server/` surface and serialize/load coverage, before it can be scheduled.
 
 Pass-3 scope cut (maintainer direction 2026-07-26): ONE raid lockout id (per-wing
 `voyage:` ids collapsed); Bells STAGED at the time (pass 4 then cut it outright, block
@@ -68,7 +72,7 @@ Pass-4 scope cut (maintainer direction 2026-07-26: lame bosses out, a 2-to-3 bos
 is fine): the Teeth crag wing and the Wake Doubles wing are CUT outright, and the entire
 two-route system dies with them, INCLUDING the previously staged Bells follow-up (its
 constants block is deleted; the route type and the per-wing counts are gone from section
-1). The raid is THREE bosses (Split Horizon, the Name-Taker, Sereva) plus the non-boss
+1). The raid is THREE bosses (Vessarine, the Name-Taker, Sereva) plus the non-boss
 Tenfold Sail launch and the open-sail prison-hulk rescue beat, which now rides the sail
 between fights instead of living in a wing: one tow-cable ground object plus a ship-record
 flag. The finale has no trophy moves at all: cosmetic ship scars only, and the rescued
@@ -138,20 +142,21 @@ sim matcher rows, wiki regen, credits/provenance for that PR's assets, and this 
 - Tests first: NEW `tests/voyage_ship.test.ts` (ten panels derive deterministically from the roster, agents and humans identically; scars persist across encounters and change no numbers; `hulkRescued` stays false until S5; no town-side or extension state exists).
 - Acceptance: `npx vitest run tests/voyage_ship.test.ts tests/deeds_content.test.ts tests/world_api_parity.test.ts tests/architecture.test.ts && npx vitest run tests/parity`.
 
-### S3. Watches, the Split Horizon verse (Boss 1, navigation half)
+### S3. Watches, Vessarine's verse (Boss 1, navigation half)
 - Goal: the raid alternates two five-player watches every 35 seconds, each seeing a disjoint information set while keeping full combat agency.
-- Files: NEW `src/sim/voyage_watches.ts` (assignment, 35 s swap timer on sim time, per-watch visibility flags); MODIFY `src/world_api/voyage.ts` (own watch + fog state), both worlds, parity pin; `server/game.ts` (interest filtering honors the watch flags server-side, never client-side).
+- Files: NEW `src/sim/voyage_watches.ts` (assignment, 35 s swap timer on sim time, per-watch visibility flags); MODIFY `src/world_api/voyage.ts` (own watch + fog state), both worlds, parity pin; `server/game.ts` (interest filtering honors the watch flags server-side before viewer-neutral payloads are cached; any field-level divergence uses a session-specific payload; the fogged route never ships).
 - Reused: snapshot interest scoping. NEW: watch split. Fairness note: the split is a MECHANIC, not a graphics tier; it is exempt from the graphics-fairness rule because both watches get actionable, complementary state by design.
-- Tests first: NEW `tests/voyage_watches.test.ts` (swap at exactly `WATCH_SWAP_SECONDS`; the two watches partition the raid 5/5; a Current Watch client snapshot omits deck-only state and vice versa; determinism across two seeded sims).
-- Acceptance: `npx vitest run tests/voyage_watches.test.ts tests/snapshots.test.ts && npx vitest run tests/parity`.
+- Review cost: per-player divergent scoping is new behavior around the `identityFields`/`dynamicFields` wire, must preserve shared-cache correctness, and needs a bandwidth glance in review.
+- Tests first: NEW `tests/voyage_watches.test.ts` (swap at exactly `WATCH_SWAP_SECONDS`; the two watches partition the raid 5/5; a Current Watch client snapshot omits deck-only state and vice versa; sequential snapshots swapping both directions clear previously visible watch state from ClientWorld; byte-level snapshots never contain the other watch's privileged fields; determinism across two seeded sims).
+- Acceptance: `npx vitest run tests/voyage_watches.test.ts tests/snapshots.test.ts tests/bandwidth.test.ts && npx vitest run tests/parity`.
 
 ### S4. The Beckoning lured state (Boss 1, chorus half)
 - Goal: the one NEW sim primitive: a state that replaces a player's movement input with a slow server-driven walk toward a point, breakable by lash interact, Siren interrupt/death, or expiry.
 - Sub-decision (blocked on Levy, open question 2): if the walk module is not funded, ship the fallback in this same slice: the Beckoning applies the existing `polymorphHex`-style incapacitate (raider stands entranced, interrupt/lash counters intact, no walk). Build the module API so both resolutions sit behind one `applyBeckon(ctx, target, source)` entry; the fallback is a config flag, not a fork.
-- Files: NEW `src/sim/beckoning.ts` (`BeckonState { targetPos, sourceId, expiresAt }`, walk driven in the module tick, `BECKON_MAX_SECONDS` ceiling, `LASH_CHANNEL_SECONDS` lash via `src/sim/interaction.ts`, net catch + `NET_RETURN_SECONDS` walk-back + soaked movement debuff, never damage); MODIFY `src/sim/sim.ts` (tick call), `server/game.ts` (SIM_LAP_PHASES pin), `src/sim/types.ts` (SimEvent variants `beckoned`/`beckonBroken`), `src/sim/content/deeds.ts` (Split Horizon rows) plus deed pins, facet read state (Beckoned walk target visible to agents), both worlds, parity pin.
+- Files: NEW `src/sim/beckoning.ts` (`BeckonState { targetPos, sourceId, expiresAt }`, walk driven in the module tick, `BECKON_MAX_SECONDS` ceiling, `LASH_CHANNEL_SECONDS` lash via `src/sim/interaction.ts`, net catch + `NET_RETURN_SECONDS` walk-back + soaked movement debuff, never damage); MODIFY `src/sim/sim.ts` (tick call), `server/game.ts` (SIM_LAP_PHASES pin), `src/sim/types.ts` (SimEvent variants `beckoned`/`beckonBroken`), `src/sim/content/deeds.ts` (Vessarine rows) plus deed pins, facet read state (Beckoned walk target visible to agents), both worlds, parity pin.
 - Reused: channel machinery for the lash, interaction.ts for the interact, aura plumbing for soaked. NEW: forced-walk movement (no precedent exists, see section 2).
 - Tests first: NEW `tests/beckoning.test.ts` (input ignored while Beckoned; lash channel breaks it; Siren interrupt OR death breaks it; expiry walks into the net, `NET_RETURN_SECONDS` return, no fall damage, no death; open-world entities can never be Beckoned; fallback flag degrades to incapacitate with the same counters).
-- Acceptance: `npx vitest run tests/beckoning.test.ts tests/mob_hex.test.ts tests/deeds_content.test.ts && npx vitest run tests/parity`; mint the Split Horizon parity scenario with `UPDATE_PARITY=1` in its own commit.
+- Acceptance: `npx vitest run tests/beckoning.test.ts tests/mob_hex.test.ts tests/deeds_content.test.ts && npx vitest run tests/parity`; mint the Vessarine parity scenario with `UPDATE_PARITY=1` in its own commit.
 
 ### S5. The open-sail hulk rescue beat (between fights, not a boss)
 - Goal: the single prison-hulk rescue riding the sail between encounters (pass 4: the Teeth encounter and the route system are cut; the rescue survives on the open sail as one tow-cable ground object plus a ship-record flag).
@@ -168,28 +173,28 @@ sim matcher rows, wiki regen, credits/provenance for that PR's assets, and this 
 - Acceptance: `npx vitest run tests/voyage_vote.test.ts tests/deeds_content.test.ts tests/world_api_parity.test.ts && npx vitest run tests/parity`.
 
 ### S7. Finale: Sereva, allied boats, deck orders (Boss 3)
-- Goal: the return-leg finale: `ORDER_CYCLE_SECONDS` orders against `DECK_POST_COUNT` fixed posts, four named NPC boats (scripted in-instance set pieces), the `CROWN_SHATTER_HP_PCT` aurora across the instance sky, and the one-time first-server-clear bell engraving (plaque precedent). Pass 3: ship scars are COSMETIC only; scar-weakened posts and wreck damage-absorbs are cut. Pass 4: no trophy moves at all; the rescued hulk captives cheer from a trailing boat (scripted set piece).
+- Goal: the return-leg finale: `ORDER_CYCLE_SECONDS` orders against `DECK_POST_COUNT` fixed posts, four named NPC boats (scripted in-instance set pieces), and the `CROWN_SHATTER_HP_PCT` aurora across the instance sky. Pass 3: ship scars are COSMETIC only; scar-weakened posts and wreck damage-absorbs are cut. Pass 4: no trophy moves at all; the rescued hulk captives cheer from a trailing boat (scripted set piece).
 - Files: MODIFY `src/sim/content/farshore_voyage.ts` (Sereva encounter: HOLD COURSE / CUT THE COIL / OPEN THE LENS order records, failure damages a known ship section, never a reflex-kill; allied boats never provide required damage; the captives' trailing cheer boat when `hulkRescued` is set), `src/sim/voyage_ship.ts` (cosmetic scar records only), `src/sim/content/deeds.ts` (Sereva first-clear rows) plus deed pins; NEW `src/render/voyage_fx.ts` (aurora, INSTANCE-ONLY, cosmetic, passes graphics fairness).
-- Reused: encounter module precedent (`src/sim/encounters/nythraxis.ts`), boss `'yell'` barks, the first-clear plaque precedent for the engraving. NEW: order/post system, fx module. CUT at pass 2: previous-crew Wake Ship, responder skiffs, hung sail, blue watchfire (single-crew assumptions).
-- Tests first: extend `tests/farshore_voyage.test.ts` (HOLD COURSE, CUT THE COIL, and OPEN THE LENS each pass independently and each damage their own mapped section on failure; scars accumulate but change no combat numbers; the trailing cheer boat appears only when `hulkRescued` is set and contributes nothing mechanical; the engraving survives serialize/load and fires exactly once per realm; the fight is completable with the NPC boats contributing zero required damage).
+- Reused: encounter module precedent (`src/sim/encounters/nythraxis.ts`) and boss `'yell'` barks. NEW: order/post system, fx module. CUT at pass 2: previous-crew Wake Ship, responder skiffs, hung sail, blue watchfire (single-crew assumptions).
+- Tests first: extend `tests/farshore_voyage.test.ts` (HOLD COURSE, CUT THE COIL, and OPEN THE LENS each pass independently and each damage their own mapped section on failure; scars accumulate but change no combat numbers; the trailing cheer boat appears only when `hulkRescued` is set and contributes nothing mechanical; the fight is completable with the NPC boats contributing zero required damage).
 - Acceptance: `npx vitest run tests/farshore_voyage.test.ts tests/deeds_content.test.ts && npx vitest run tests/parity && npm run gate` (raid-complete milestone); mint the finale parity scenario via `UPDATE_PARITY=1` in its own commit.
 
 ### S8. Loot, deeds, i18n sweep
 - Goal: finish Glasswake loot, remaining meta deeds, and contributor-owned localization without repairing obligations from earlier content slices.
-- Files: MODIFY `src/sim/content/farshore_voyage.ts` (rift-glass gear, one weapon per armor class off Sereva, gull shoulder pet for full hulk-rescue runs; numbers follow the existing level-20 stat budget rules exactly, compute the budget first), `src/sim/content/deeds.ts` (append remaining cross-program meta rows), `src/ui/sim_i18n.ts` (PR G loot/meta matcher rows only; earlier boss and quest rows already landed at their boundaries), `src/ui/i18n.catalog/items.ts` for English item names (G3), regenerated `src/ui/i18n.resolved.generated/*`, `src/ui/icons.ts` ITEM_IMAGE_IDS + `public/ui/items/mapping.json` via `gen-icon-art`, guide regen.
-- Tests first: extend `tests/deeds_content.test.ts` pins and `tests/item_level` budget checks before authoring items.
+- Files: MODIFY `src/sim/content/farshore_voyage.ts` (rift-glass gear, one weapon per armor class off Sereva, gull shoulder pet for full hulk-rescue runs; numbers follow the existing level-20 stat budget rules exactly, compute the budget first), `src/sim/content/deeds.ts` (append remaining cross-program meta rows), `src/ui/sim_i18n.ts` (PR G loot/meta matcher rows only; earlier boss and quest rows already landed at their boundaries), `src/ui/i18n.catalog/items.ts` for English item names (G3), regenerated `src/ui/i18n.resolved.generated/*`, `src/ui/icons.ts` ITEM_IMAGE_IDS + `public/ui/items/mapping.json` through plain icon authoring work, guide regen.
+- Tests first: extend `tests/deeds_content.test.ts` pins plus `tests/item_level.test.ts` and `tests/item_level_req.test.ts` budget checks before authoring items.
 - Acceptance: `npx vitest run tests/deeds_content.test.ts tests/i18n_completeness.test.ts tests/localization_fixes.test.ts tests/guide.test.ts && npm run wiki:content && npm run gate`.
 
 ### S9. Heroic mode (pass 3: launch requirement, existing machinery only)
 - Goal: heroic difficulty rides the shipped machinery end to end: the heroic flag per the dungeon_difficulty pattern, boss stats tuned by the standing heroic multipliers, loot through the heroic RAID variant tier. No heroic-only mechanics in v1: heroic is numbers and loot, per the shipped convention. Exact ilvls follow the PRD's tier-position decision.
 - Files: MODIFY `src/sim/content/dungeon_difficulty.ts` (voyage rows in `HEROIC_DUNGEON_TUNING`), `src/sim/content/heroic_variants.ts` (voyage bosses join the raid-tier list so `buildHeroicVariants` derives `heroic_<id>` items via `heroicVariantId`, the `NYTHRAXIS_RAID_BOSS_ID`/`NYTHRAXIS_RAID_LOOT_SOURCE_LEVEL` precedent in `src/sim/content/heroic_loot.ts`), `src/sim/content/farshore_voyage.ts` (heroic flag on the instance records only).
 - Reused: `DungeonDifficulty` + `isDungeonDifficulty`/`setDungeonDifficulty` (already wired in `server/game.ts`), `mobTemplateForDungeonDifficulty`/`applyDungeonMobTuning`/`HEROIC_DUNGEON_IDS` in `src/sim/instances/difficulty.ts`. NEW: nothing; content rows only.
-- Tests first: extend `tests/farshore_voyage.test.ts` (heroic entry tunes boss stats by the standing multipliers; heroic Sereva drops the `heroic_` raid-tier variants; normal drops unchanged; the heroic run shares the same single `VOYAGE_LOCKOUT_ID`); extend the item budget pins if `tests/item_level` covers variants.
+- Tests first: extend `tests/farshore_voyage.test.ts` (heroic entry tunes boss stats by the standing multipliers; heroic Sereva drops the `heroic_` raid-tier variants; normal drops unchanged; the heroic run shares the same single `VOYAGE_LOCKOUT_ID`); extend the item budget pins in `tests/item_level.test.ts` and `tests/item_level_req.test.ts` if they cover variants.
 - Acceptance: `npx vitest run tests/farshore_voyage.test.ts tests/deeds_content.test.ts && npx vitest run tests/parity`.
 
 ### S10. Music and models
 - Goal: per-boss music (plus the sail theme) and the ship/naga/prop asset kit.
-- Files: MODIFY `src/game/music.ts` (new `MusicZone` cues for the sail and each boss), `src/game/music_tracks.ts` (`ZONE_STREAM_URLS` rows), `src/game/instance_music.ts` (routing); NEW `public/audio/music/` tracks, `public/models/` GLBs via `gen-3d-asset` (Glasswake visual signature: cobalt rift-glass crown plus red sailcloth streamer on every unit), `CREDITS.md`.
+- Files: MODIFY `src/game/music.ts` (new `MusicZone` cues for the sail and each boss), `src/game/music_tracks.ts` (`ZONE_STREAM_URLS` rows), `src/game/instance_music.ts` (routing); NEW `public/audio/music/` tracks, `public/models/` GLBs via the `image-to-glb` skill (`.claude/skills/image-to-glb/SKILL.md`) plus `docs/image-to-glb-asset-workflow.md` (Glasswake visual signature: cobalt rift-glass crown plus red sailcloth streamer on every unit), `CREDITS.md`. Remaining kit work is plain authoring with no named skill.
 - Tests first: extend `tests/music.test.ts`, `tests/music_tracks.test.ts`, and `tests/instance_music.test.ts` with the exact voyage zone and boss routing rows; the media manifest regenerates via the build (never hand-edit it).
 - Acceptance: `npx vitest run tests/music.test.ts tests/music_tracks.test.ts tests/instance_music.test.ts && npm run build`; in-game listen on `npm run dev` (headless screenshot workflow for the PR evidence).
 
@@ -237,13 +242,14 @@ sim matcher rows, wiki regen, credits/provenance for that PR's assets, and this 
   without rng (the lowest-slot tie-break) or two hosts diverge; where an encounter does
   draw (loot), draw in one fixed module order per tick.
 - **G6, the stage is read-only.** `src/sim/content/farshore.ts` and the rift siege quests
-  belong to #2321; the raid adds siblings, never edits.
+  belong to the `feature/procedural-dungeons` branch (umbrella PR #1584); the raid adds
+  siblings, never edits.
 - **G7, worktree discipline.** The shared checkout carries uncommitted WIP; build each slice
   in a fresh worktree off the base branch (`feature/voyage-s<N>`) and re-merge it as it moves.
 
 ## 5. Dispatch note
 
-Do not dispatch any slice while the Status row says BLOCKED. When unblocked, hand each owner
+Do not dispatch any slice while the Status row says INCUBATION. When unblocked, hand each owner
 the slice block, section 0 rules, section 1 constants, its hook-map rows, the gotchas, and
 the acceptance commands. Require fails-before/passes-after evidence for every test written
 first, exact command output, and a `qa-checklist` pass. S1, S5, S7, S8, and S11 end with `npm run gate`.

--- a/docs/prd/farshore-odyssey-raid-handoff.md
+++ b/docs/prd/farshore-odyssey-raid-handoff.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-| **Status** | INCUBATION, DRAFT STAGE 4 PACKET, excluded from the active implementation-handoff queue. Do not start slices until Levy explicitly approves the reduced three-boss raid core, the first dungeon and raid pipelines are proven, and the `feature/procedural-dungeons` branch (umbrella PR #1584) lands. Large content requires PBE. |
-| **Portfolio lane** | Incubation. The packet is detailed enough to execute later, but detail is not approval or dispatch priority. |
-| **Dispatch gate** | Levy approves the reduced raid core after the pipeline proof, and the `feature/procedural-dungeons` branch (umbrella PR #1584) lands. The low-tide assault is a separately approved post-raid extension and cannot delay or share the initial raid dispatch. |
+| **Status** | READY FOR THE LEVY CONVERSATION, DRAFT STAGE 4 PACKET, excluded from the active implementation-handoff queue. The Farshore content in `src/sim/content/farshore.ts` landed in `release/v0.33.0`, is merged through `src/sim/data.ts`, and is placed in the `ZONES` table. Do not start slices until Levy explicitly approves the reduced three-boss raid core, the first dungeon and raid pipelines are proven, and a PBE round is committed. |
+| **Portfolio lane** | Pre-dispatch. The packet is ready for the Levy conversation, but detail is not approval or dispatch priority. |
+| **Dispatch gate** | The Farshore zone gate is satisfied in `release/v0.33.0` through `src/sim/content/farshore.ts`, its merge in `src/sim/data.ts`, and its placement in the `ZONES` table. Levy approval after the pipeline proof and a committed PBE round still gate dispatch. The low-tide assault is a separately approved post-raid extension and cannot delay or share the initial raid dispatch. |
 | **Source PRD** | `docs/prd/farshore-odyssey-raid.md` (whole document; its File plan section is the file inventory this handoff schedules) |
 | **Scope** | Initial raid core only: standard click-the-moored-ship entry, THREE bosses (Vessarine, the Name-Taker, Sereva) plus the non-boss Tenfold Sail launch and the open-sail prison-hulk rescue beat, ONE raid lockout id, the Beckoning lured-state primitive, in-instance ship/sail state, the vote with an aura-only Captain mantle, heroic mode on the existing difficulty and variant machinery, loot/deeds/i18n, music/fx, and bot tuning. The weekly low-tide assault is extension X1 outside this core. NOT in scope: the pass-2 to pass-4 cuts, town-side or cross-instance state, additional wings/routes, bespoke Captain buttons, trophy moves, Farshore leveling-content changes, and any $WOC or economy hook. |
-| **Verified against** | `origin/release/v0.30.0` and `origin/feature/procedural-dungeons`, 2026-07-25 (heroic anchors re-verified 2026-07-26). Revalidate every anchor against the active branch before implementation; trust symbols, not line numbers. |
+| **Verified against** | `origin/release/v0.30.0` for existing machinery and `origin/release/v0.33.0` for the Farshore stage, re-verified 2026-07-31 (heroic anchors re-verified 2026-07-26). Revalidate every anchor against the active branch before implementation; trust symbols, not line numbers. |
 | **Executor routing** | Claude uses `extract-and-test` and `qa-checklist`; Codex uses the matching `$woc-*` skills. The GLB lane uses the `image-to-glb` skill (`.claude/skills/image-to-glb/SKILL.md`) plus `docs/image-to-glb-asset-workflow.md`. Icon and kit lanes are plain authoring work with no named skill. Sim, frontend, and cross-platform reviewers follow the changed surface. No slice depends on a named model. |
 
 ## 0. Ground rules
@@ -16,19 +16,19 @@ Rules 1 to 6 of `docs/prd/FRONTIER_PHASE1_HANDOFF.md` section 0 apply verbatim (
 Rng-only randomness, i18n, strict TS, Conventional Commits, command-anchored acceptance).
 Deltas for this program:
 
-1. Base branch: until the `feature/procedural-dungeons` branch (umbrella PR #1584) merges,
-   every slice stacks on `origin/feature/procedural-dungeons` (the Farshore stage lives
-   there); after it merges, on the active release branch. Never fork or edit files owned
-   by the dependency branch.
-2. Commit scope is `feat(voyage): ...`; branches `feature/voyage-s<N>`.
-3. Every NEW per-tick sim module gets its `SIM_LAP_PHASES` pin in `server/game.ts` in the
+The Farshore stage in `src/sim/content/farshore.ts` landed in `release/v0.33.0`, is merged
+through `src/sim/data.ts`, and is placed in the `ZONES` table. Base every slice on the
+active release branch, and never edit the released Farshore stage.
+
+1. Commit scope is `feat(voyage): ...`; branches `feature/voyage-s<N>`.
+2. Every NEW per-tick sim module gets its `SIM_LAP_PHASES` pin in `server/game.ts` in the
    SAME slice as its tick call (gotcha G1); every NEW read surface ships as a
    `src/world_api/` facet in BOTH worlds with its `tests/world_api_parity.test.ts` pin in
    the SAME slice (G2).
-4. Agent-completable policy is a hard invariant: no mechanic may demand a reaction faster
+3. Agent-completable policy is a hard invariant: no mechanic may demand a reaction faster
    than its telegraphed timer, and every mechanic's state (watch assignment, Beckoned walk
    target, vote options, deck orders) must be readable through IWorld, never visuals.
-5. All tuning numbers in section 1 come from the PRD and are locked for PBE; do not retune
+4. All tuning numbers in section 1 come from the PRD and are locked for PBE; do not retune
    them mid-slice.
 
 ## 1. Shared design constants (defined once in S1, imported everywhere)
@@ -86,7 +86,7 @@ The boarding-net soaked debuff is a movement tax only, never damage.
 
 | Concern | Branch | Anchor (re-find before editing) |
 |---|---|---|
-| Farshore stage | procedural-dungeons | `src/sim/content/farshore.ts`: Warden Coalfast NPC, `welcomeQuestId: 'q_fs_bell_at_the_landing'`, Gullhaven prose. Read-only stage; the raid plugs in, never edits |
+| Farshore stage | release/v0.33.0 | `src/sim/content/farshore.ts`: Warden Coalfast NPC, `welcomeQuestId: 'q_fs_bell_at_the_landing'`, Gullhaven prose; merged through `src/sim/data.ts` as `FARSHORE_ZONE` in the `ZONES` table. Read-only stage; the raid plugs in, never edits |
 | Raid lockout | release/v0.30.0 | `raidLockouts: Map<string, number>` on PlayerMeta in `src/sim/sim.ts`; checked/cleared in `src/sim/instances/dungeons.ts`; `meta.raidLockouts.set(lockId, until)` precedent in `src/sim/encounters/nythraxis.ts` (pass 3: the raid uses the ONE `voyage` id, never per-wing ids) |
 | Instance entry | release/v0.30.0 | `export function enterDungeon(` in `src/sim/instances/dungeons.ts`; coverage pin `tests/dungeon_entry_clearance.test.ts` |
 | Content shape | release/v0.30.0 | `interface DungeonDef` and `interface MobTemplate` in `src/sim/types.ts`; precedent module `src/sim/content/temple.ts`; merged via `export const MOBS: Record<string, MobTemplate>` in `src/sim/data.ts` |
@@ -242,14 +242,16 @@ sim matcher rows, wiki regen, credits/provenance for that PR's assets, and this 
   without rng (the lowest-slot tie-break) or two hosts diverge; where an encounter does
   draw (loot), draw in one fixed module order per tick.
 - **G6, the stage is read-only.** `src/sim/content/farshore.ts` and the rift siege quests
-  belong to the `feature/procedural-dungeons` branch (umbrella PR #1584); the raid adds
-  siblings, never edits.
+  landed in `release/v0.33.0`, are merged through `src/sim/data.ts`, and are represented by
+  `FARSHORE_ZONE` in the `ZONES` table; the raid adds siblings, never edits.
 - **G7, worktree discipline.** The shared checkout carries uncommitted WIP; build each slice
   in a fresh worktree off the base branch (`feature/voyage-s<N>`) and re-merge it as it moves.
 
 ## 5. Dispatch note
 
-Do not dispatch any slice while the Status row says INCUBATION. When unblocked, hand each owner
-the slice block, section 0 rules, section 1 constants, its hook-map rows, the gotchas, and
-the acceptance commands. Require fails-before/passes-after evidence for every test written
-first, exact command output, and a `qa-checklist` pass. S1, S5, S7, S8, and S11 end with `npm run gate`.
+The Status row records readiness for the Levy conversation, not build authorization. Do not
+dispatch until the pipeline proof, explicit Levy approval, and committed PBE round are recorded.
+Once those gates are met, hand each owner the slice block, section 0 rules, section 1 constants,
+its hook-map rows, the gotchas, and the acceptance commands. Require fails-before/passes-after
+evidence for every test written first, exact command output, and a `qa-checklist` pass. S1, S5,
+S7, S8, and S11 end with `npm run gate`.

--- a/docs/prd/farshore-odyssey-raid-handoff.md
+++ b/docs/prd/farshore-odyssey-raid-handoff.md
@@ -1,0 +1,249 @@
+# Implementation Handoff: The Far Shore Voyage (Gullhaven sailing raid)
+
+| | |
+|---|---|
+| **Status** | INCUBATION, DRAFT STAGE 4 PACKET, excluded from the active implementation-handoff queue. Do not start slices until Levy explicitly approves the reduced three-boss raid core, the first dungeon and raid pipelines are proven, and PR #2321 lands. Large content requires PBE. |
+| **Portfolio lane** | Incubation. The packet is detailed enough to execute later, but detail is not approval or dispatch priority. |
+| **Dispatch gate** | Levy approves the reduced raid core after the pipeline proof. The low-tide assault is a separately approved post-raid extension and cannot delay or share the initial raid dispatch. |
+| **Source PRD** | `docs/prd/farshore-odyssey-raid.md` (whole document; its File plan section is the file inventory this handoff schedules) |
+| **Scope** | Initial raid core only: standard click-the-moored-ship entry, THREE bosses (Split Horizon, the Name-Taker, Sereva) plus the non-boss Tenfold Sail launch and the open-sail prison-hulk rescue beat, ONE raid lockout id, the Beckoning lured-state primitive, in-instance ship/sail state, the vote with an aura-only Captain mantle, heroic mode on the existing difficulty and variant machinery, loot/deeds/i18n, music/fx, and bot tuning. The weekly low-tide assault is extension X1 outside this core. NOT in scope: the pass-2 to pass-4 cuts, town-side or cross-instance state, additional wings/routes, bespoke Captain buttons, trophy moves, Farshore leveling-content changes, and any $WOC or economy hook. |
+| **Verified against** | `origin/release/v0.30.0` and `origin/feature/procedural-dungeons`, 2026-07-25 (heroic anchors re-verified 2026-07-26). Revalidate every anchor against the active branch before implementation; trust symbols, not line numbers. |
+| **Executor routing** | Claude uses `extract-and-test`, `build-dungeon-kit`, `gen-3d-asset`, `gen-icon-art`, and `qa-checklist`; Codex uses the matching `$woc-*` skills. Sim, frontend, and cross-platform reviewers follow the changed surface. No slice depends on a named model. |
+
+## 0. Ground rules
+
+Rules 1 to 6 of `docs/prd/FRONTIER_PHASE1_HANDOFF.md` section 0 apply verbatim (sim purity,
+Rng-only randomness, i18n, strict TS, Conventional Commits, command-anchored acceptance).
+Deltas for this program:
+
+1. Base branch: until #2321 merges, every slice stacks on
+   `origin/feature/procedural-dungeons` (the Farshore stage lives there); after it merges,
+   on the active release branch. Never fork or edit #2321's files.
+2. Commit scope is `feat(voyage): ...`; branches `feature/voyage-s<N>`.
+3. Every NEW per-tick sim module gets its `SIM_LAP_PHASES` pin in `server/game.ts` in the
+   SAME slice as its tick call (gotcha G1); every NEW read surface ships as a
+   `src/world_api/` facet in BOTH worlds with its `tests/world_api_parity.test.ts` pin in
+   the SAME slice (G2).
+4. Agent-completable policy is a hard invariant: no mechanic may demand a reaction faster
+   than its telegraphed timer, and every mechanic's state (watch assignment, Beckoned walk
+   target, vote options, deck orders) must be readable through IWorld, never visuals.
+5. All tuning numbers in section 1 come from the PRD and are locked for PBE; do not retune
+   them mid-slice.
+
+## 1. Shared design constants (defined once in S1, imported everywhere)
+
+```ts
+// src/sim/content/farshore_voyage.ts
+export const VOYAGE_RAID_SIZE = 10;            // one crew, one ship
+export const VOYAGE_MIN_LEVEL = 20;
+export const VOYAGE_LOCKOUT_ID = 'voyage';     // the ONE raid lockout id on meta.raidLockouts (pass 3)
+export const WATCH_SWAP_SECONDS = 35;          // Split Horizon verse cadence
+export const LASH_CHANNEL_SECONDS = 2;         // ally lash-to-mast channel
+export const BECKON_MAX_SECONDS = 8;           // lured walk expiry ceiling
+export const NET_RETURN_SECONDS = 8;           // walk back from the boarding nets
+export const CAPTAIN_ROUNDS = 3;               // Name-Taker elections per fight
+export const ORDER_CYCLE_SECONDS = 12;         // Sereva order cadence
+export const DECK_POST_COUNT = 10;             // fixed finale stations
+export const NAMED_BOAT_COUNT = 4;             // Coalfast, Tam, Edda, Bram
+export const CROWN_SHATTER_HP_PCT = 0.10;      // aurora finale trigger
+```
+
+Pass-2 scope cut (maintainer direction 2026-07-26): entry is the standard click-the-moored-ship
+raid gate; NO cross-instance or single-crew systems. The bell relay, Gullhaven Answers skiffs,
+previous-crew Wake Ship, and all town-side live state (hung sail, blue watchfire) are CUT.
+First-clear bell engraving remains the only open-world mutation in the raid core.
+
+Pass-3 scope cut (maintainer direction 2026-07-26): ONE raid lockout id (per-wing
+`voyage:` ids collapsed); Bells STAGED at the time (pass 4 then cut it outright, block
+deleted); Wreck Train reduced to the single prison-hulk rescue, one tow-cable ground
+object plus a ship-record flag (`TOW_CABLE_COUNT`, medicine skiff, powder barge, and the
+later low-tide cargo choice deleted from raid scope); the recorder/
+replayer (`src/sim/wake_doubles.ts`) CUT for a fixed class-to-reflection template map
+(`INSPECTION_SECONDS` deleted; the whole wing then died at pass 4); the Captain's bespoke
+command-ability kit cut (existing aura machinery only); scar-weakened posts and wreck
+damage-absorbs cut (cosmetic scars only); heroic mode ADDED as a launch requirement on
+the existing machinery (now S9).
+
+Pass-4 scope cut (maintainer direction 2026-07-26: lame bosses out, a 2-to-3 boss raid
+is fine): the Teeth crag wing and the Wake Doubles wing are CUT outright, and the entire
+two-route system dies with them, INCLUDING the previously staged Bells follow-up (its
+constants block is deleted; the route type and the per-wing counts are gone from section
+1). The raid is THREE bosses (Split Horizon, the Name-Taker, Sereva) plus the non-boss
+Tenfold Sail launch and the open-sail prison-hulk rescue beat, which now rides the sail
+between fights instead of living in a wing: one tow-cable ground object plus a ship-record
+flag. The finale has no trophy moves at all: cosmetic ship scars only, and the rescued
+captives cheer from a trailing boat inside the instance.
+
+Extension X1 is the separately approved low-tide event. It owns its event-local aid choice
+and persistence, never reads a raid-run cargo field, and cannot begin until after raid PBE.
+The boarding-net soaked debuff is a movement tax only, never damage.
+
+## 2. Verified hook-point map (branch column says where the anchor was verified)
+
+| Concern | Branch | Anchor (re-find before editing) |
+|---|---|---|
+| Farshore stage | procedural-dungeons | `src/sim/content/farshore.ts`: Warden Coalfast NPC, `welcomeQuestId: 'q_fs_bell_at_the_landing'`, Gullhaven prose. Read-only stage; the raid plugs in, never edits |
+| Raid lockout | release/v0.30.0 | `raidLockouts: Map<string, number>` on PlayerMeta in `src/sim/sim.ts`; checked/cleared in `src/sim/instances/dungeons.ts`; `meta.raidLockouts.set(lockId, until)` precedent in `src/sim/encounters/nythraxis.ts` (pass 3: the raid uses the ONE `voyage` id, never per-wing ids) |
+| Instance entry | release/v0.30.0 | `export function enterDungeon(` in `src/sim/instances/dungeons.ts`; coverage pin `tests/dungeon_entry_clearance.test.ts` |
+| Content shape | release/v0.30.0 | `interface DungeonDef` and `interface MobTemplate` in `src/sim/types.ts`; precedent module `src/sim/content/temple.ts`; merged via `export const MOBS: Record<string, MobTemplate>` in `src/sim/data.ts` |
+| polymorphHex fallback | release/v0.30.0 | `polymorphHex?: { chance; duration; name; school? }` on MobTemplate in `src/sim/types.ts`; applied in `src/sim/mob/mob_swing.ts`; test `tests/mob_hex.test.ts` |
+| SimContext seam | release/v0.30.0 | `src/sim/sim_context.ts`: `SimContextPrimitives` (readonly `rng`), `SimContextCallbacks` (`error(pid, text, reason?)`); `ctx.spawnBossAdds` precedent `src/sim/delves/drowned_litany_boss.ts` |
+| Tick phase pin | release/v0.30.0 | `export const SIM_LAP_PHASES = [` in `server/game.ts` (entries like `'worldBosses'`, `'instances'`, `'lootRolls'`) |
+| Weekly scheduler | release/v0.30.0 | `src/sim/world_boss.ts`: `WORLD_BOSSES`, `WORLD_BOSS_INTERVAL_SECONDS`, `WORLD_BOSS_LOCKOUT_PREFIX` (lockout keys ride `raidLockouts`) |
+| Heroic mode (pass 3) | release/v0.30.0 | Difficulty: `DungeonDifficulty` in `src/sim/types.ts`; `HEROIC_DUNGEON_TUNING` in `src/sim/content/dungeon_difficulty.ts`; `HEROIC_DUNGEON_IDS`, `mobTemplateForDungeonDifficulty`, `applyDungeonMobTuning` in `src/sim/instances/difficulty.ts`; `isDungeonDifficulty` + `sim.setDungeonDifficulty` wired via `case 'set_dungeon_difficulty'` in `server/game.ts`. Loot: `heroicVariantId()` (`heroic_<id>`) and `buildHeroicVariants()` in `src/sim/content/heroic_variants.ts` (`heroicOf` drives the tooltip [HEROIC] tag, never a name prefix); Nythraxis heroic raid precedent `NYTHRAXIS_RAID_BOSS_ID` + `NYTHRAXIS_RAID_LOOT_SOURCE_LEVEL` (27) in `src/sim/content/heroic_loot.ts` |
+| IWorld facets | release/v0.30.0 | `src/world_api/` directory (per-facet interfaces; `interaction.ts` exposes `interact()`; `deeds.ts` exists); pin file `tests/world_api_parity.test.ts` (facet key-sets + `COMMAND_NAMES`/`COMMAND_FACETS`) |
+| ClientWorld + wire | release/v0.30.0 | `src/net/online.ts` `applySnapshot`/`applyWire`; `function identityFields(e: Entity)` in `server/game.ts`; self-delta `maybe()` pattern (`maybe('lrollg', this.sim.lootRollGroupStatus(...))`) |
+| Group vote precedent | release/v0.30.0 | `src/sim/loot/loot_roll.ts` (finite-choice group prompt, `'lootRolls'` phase, group status on the wire) |
+| Interact verb | release/v0.30.0 | `export function interact(` in `src/sim/interaction.ts` (lash, deck posts, the hulk tow cable all route here) |
+| Channel state | release/v0.30.0 | `channeling`/`channelTimer`/`channelTicksLeft` on the entity in `src/sim/entity.ts`; cast lifecycle in `src/sim/combat/casting_lifecycle.ts` |
+| Boss barks | release/v0.30.0 | boss bark lines broadcast as `'yell'`-channel chat (`src/sim/types.ts`) |
+| Sim i18n matcher | release/v0.30.0 | `const AURA_NAME_KEY` in `src/ui/sim_i18n.ts`; English item names in `src/ui/i18n.catalog/items.ts`; release overlay ownership in root `CLAUDE.md` |
+| Icons | release/v0.30.0 | `export const ITEM_IMAGE_IDS` in `src/ui/icons.ts`; `public/ui/items/mapping.json` |
+| Music | release/v0.30.0 | `ZONE_STREAM_URLS`/`COMBAT_STREAM_URLS` in `src/game/music_tracks.ts`, keyed by `MusicZone` from `src/game/music.ts` (`musicZoneForLocation`); consumer `src/game/instance_music.ts` |
+| Parity goldens | release/v0.30.0 | `tests/parity/` per its CLAUDE.md; mint via `UPDATE_PARITY=1 npx vitest run tests/parity` in its own reviewed commit |
+| Deeds | release/v0.30.0 | `export const DEEDS: Record<string, DeedDef>` in `src/sim/content/deeds.ts`; pins `tests/deeds_content.test.ts`; facet `src/world_api/deeds.ts` |
+
+NOT verified (no precedent exists; genuinely new): a server-driven forced-walk movement
+state (searched `feared`/`forcedMove`/knockback: only a `knockbackResistance` scalar and the
+polymorphHex incapacitate exist); S4 owns it. The other two no-precedent items (bell-relay
+store, wake recorder) were cut at pass 2 and pass 3 respectively.
+
+## 3. Slices
+
+Core dependency order: S1 -> S2 -> S3 -> S4 -> S5 -> S6 -> S7 -> S8 -> S9 -> S10 ->
+S11. S6 (the vote) is independent once S2 lands. S9 (heroic) needs S7's encounters and
+S8's items. Extension X1 begins only after the core clears PBE and receives separate Levy
+approval; it is not in the core dependency chain.
+
+PR boundaries: A = S1-S2, B = S3-S4, C = S5, D = S6, E = S7, F = S8-S9,
+G = S10-S11. X1 is its own later contribution. Do not land a partial boundary. Every
+boundary that introduces a boss
+or event includes its Deeds rows and `tests/deeds_content.test.ts` pins (S8 holds only
+cross-program meta deeds); its final slice also carries English catalog and any M16 work,
+sim matcher rows, wiki regen, credits/provenance for that PR's assets, and this closeout:
+`npx vitest run tests/deeds_content.test.ts tests/localization_fixes.test.ts tests/guide.test.ts && npm run wiki:content`.
+
+### S1. Instance shell, content module, the one lockout
+- Goal: a ten-player, level-20 voyage instance you can enter from Gullhaven with the single raid lockout, no mechanics yet.
+- Arena model (the PRD's "one ship, one arena" section, binding for every later slice): the instance map holds THREE dressed copies of ONE deck collider layout at fixed grid locations (strait deck with sea-stack geometry, open-water deck, harbor deck with room for the NPC boats). Sailing between legs is a scripted whole-raid teleport to the next deck copy when the prior encounter ends (the standard party-move machinery), wrapped in departure/arrival beats. Nothing in sim space ever moves, nobody steers, players never leave the deck (rails plus boarding nets are the boundary). S1 stamps the three decks and the leg-transition teleports with placeholder dressing.
+- Files: NEW `src/sim/content/farshore_voyage.ts` (section 1 constants, DungeonDef-style records carrying the ONE `VOYAGE_LOCKOUT_ID` on `meta.raidLockouts` (pass 3: per-wing ids collapsed), the three deck stamps and leg-transition records, the three placeholder boss MobTemplates, the on-ramp quest; `temple.ts` is the shape precedent); MODIFY `src/sim/data.ts` (merge), `src/sim/instances/dungeons.ts` only if the raid-size gate needs a new guard.
+- Reused: enterDungeon flow, `raidLockouts`, dungeon clearance test harness. NEW: the content module only.
+- Tests first: NEW `tests/farshore_voyage.test.ts` (entry gated at level 20, party size cap 10, the single lockout set on the final boss kill, a run inside the lockout is loot-locked per the world-boss lockout precedent); extend `tests/dungeon_entry_clearance.test.ts` coverage.
+- Acceptance: `npx vitest run tests/farshore_voyage.test.ts tests/dungeon_entry_clearance.test.ts tests/architecture.test.ts && npx vitest run tests/parity` (untouched), then `npm run gate` once as the shell milestone.
+
+### S2. Voyage ship state + Tenfold Sail (the launch, not a boss)
+- Goal: one persistent per-run ship record (sail panels, cosmetic scars, hulk flag) that the launch ceremony fills and every later encounter reads.
+- Files: NEW `src/sim/voyage_ship.ts` (SimContext module: `VoyageShipState { panels, scars (cosmetic only, pass 3), hulkRescued: boolean }`, panel derivation from class+weapon+color), NEW `src/render/voyage_ship.ts` (ship mesh, sail compositing, called by the renderer, never a method bank); MODIFY `src/sim/sim.ts` (thin tick call), `server/game.ts` (SIM_LAP_PHASES pin), `src/sim/content/deeds.ts` (Tenfold Sail launch rows) plus deed pins; NEW `src/world_api/voyage.ts` facet (sail/ship read state) implemented in BOTH `Sim` and `src/net/online.ts`, pin in `tests/world_api_parity.test.ts`.
+- Reused: manifest read as `'yell'` barks; wire self-delta via `maybe()`. NEW: ship state module, render module, facet.
+- Tests first: NEW `tests/voyage_ship.test.ts` (ten panels derive deterministically from the roster, agents and humans identically; scars persist across encounters and change no numbers; `hulkRescued` stays false until S5; no town-side or extension state exists).
+- Acceptance: `npx vitest run tests/voyage_ship.test.ts tests/deeds_content.test.ts tests/world_api_parity.test.ts tests/architecture.test.ts && npx vitest run tests/parity`.
+
+### S3. Watches, the Split Horizon verse (Boss 1, navigation half)
+- Goal: the raid alternates two five-player watches every 35 seconds, each seeing a disjoint information set while keeping full combat agency.
+- Files: NEW `src/sim/voyage_watches.ts` (assignment, 35 s swap timer on sim time, per-watch visibility flags); MODIFY `src/world_api/voyage.ts` (own watch + fog state), both worlds, parity pin; `server/game.ts` (interest filtering honors the watch flags server-side, never client-side).
+- Reused: snapshot interest scoping. NEW: watch split. Fairness note: the split is a MECHANIC, not a graphics tier; it is exempt from the graphics-fairness rule because both watches get actionable, complementary state by design.
+- Tests first: NEW `tests/voyage_watches.test.ts` (swap at exactly `WATCH_SWAP_SECONDS`; the two watches partition the raid 5/5; a Current Watch client snapshot omits deck-only state and vice versa; determinism across two seeded sims).
+- Acceptance: `npx vitest run tests/voyage_watches.test.ts tests/snapshots.test.ts && npx vitest run tests/parity`.
+
+### S4. The Beckoning lured state (Boss 1, chorus half)
+- Goal: the one NEW sim primitive: a state that replaces a player's movement input with a slow server-driven walk toward a point, breakable by lash interact, Siren interrupt/death, or expiry.
+- Sub-decision (blocked on Levy, open question 2): if the walk module is not funded, ship the fallback in this same slice: the Beckoning applies the existing `polymorphHex`-style incapacitate (raider stands entranced, interrupt/lash counters intact, no walk). Build the module API so both resolutions sit behind one `applyBeckon(ctx, target, source)` entry; the fallback is a config flag, not a fork.
+- Files: NEW `src/sim/beckoning.ts` (`BeckonState { targetPos, sourceId, expiresAt }`, walk driven in the module tick, `BECKON_MAX_SECONDS` ceiling, `LASH_CHANNEL_SECONDS` lash via `src/sim/interaction.ts`, net catch + `NET_RETURN_SECONDS` walk-back + soaked movement debuff, never damage); MODIFY `src/sim/sim.ts` (tick call), `server/game.ts` (SIM_LAP_PHASES pin), `src/sim/types.ts` (SimEvent variants `beckoned`/`beckonBroken`), `src/sim/content/deeds.ts` (Split Horizon rows) plus deed pins, facet read state (Beckoned walk target visible to agents), both worlds, parity pin.
+- Reused: channel machinery for the lash, interaction.ts for the interact, aura plumbing for soaked. NEW: forced-walk movement (no precedent exists, see section 2).
+- Tests first: NEW `tests/beckoning.test.ts` (input ignored while Beckoned; lash channel breaks it; Siren interrupt OR death breaks it; expiry walks into the net, `NET_RETURN_SECONDS` return, no fall damage, no death; open-world entities can never be Beckoned; fallback flag degrades to incapacitate with the same counters).
+- Acceptance: `npx vitest run tests/beckoning.test.ts tests/mob_hex.test.ts tests/deeds_content.test.ts && npx vitest run tests/parity`; mint the Split Horizon parity scenario with `UPDATE_PARITY=1` in its own commit.
+
+### S5. The open-sail hulk rescue beat (between fights, not a boss)
+- Goal: the single prison-hulk rescue riding the sail between encounters (pass 4: the Teeth encounter and the route system are cut; the rescue survives on the open sail as one tow-cable ground object plus a ship-record flag).
+- Files: MODIFY `src/sim/content/farshore_voyage.ts` (the prison hulk: ONE tow-cable ground object whose `interact()` slows ship repairs for a stretch, frees the captives, and sets the ship-record flag), `src/sim/voyage_ship.ts` (`hulkRescued` persists for the run; captives transfer to a trailing rescue boat inside the instance), `src/sim/content/deeds.ts` (rescue rows, the full-rescue gull-pet feed) plus deed pins, facet, both worlds, parity pin.
+- Reused: `interact()` for the cable, ground-object patterns from temple.ts. NEW: nothing engine-side.
+- Tests first: extend `tests/farshore_voyage.test.ts` (hooking the hulk slows repairs, frees captives, sets the flag, and produces the in-instance trailing boat; skipping the hulk leaves the flag false and no boat; no town-side state or low-tide field is written; all rng draws stay inside voyage code paths).
+- Acceptance: `npx vitest run tests/farshore_voyage.test.ts tests/voyage_ship.test.ts tests/deeds_content.test.ts && npx vitest run tests/parity && npm run gate` (mid-program milestone).
+
+### S6. The vote (Boss 2, the Name-Taker's Mutiny)
+- Goal: three deterministic election rounds where the raid answers "WHO COMMANDS YOU?" from the ten crew names, majority becomes Captain, used names strike out. The Captain's mantle is EXISTING aura machinery only: enormous boss threat plus a defensive buff for the phase (pass 3: the bespoke command-ability kit is cut).
+- Files: NEW `src/sim/voyage_vote.ts` (`CAPTAIN_ROUNDS` rounds, finite clickable option set exposed in structured state, majority tally, ties and silence resolve deterministically: lowest crew-slot index wins, abstain counts nothing, no rng); MODIFY `src/sim/sim.ts` + `server/game.ts` (tick call + SIM_LAP_PHASES pin), `src/sim/content/deeds.ts` (Mutiny rows) plus deed pins, facet (options + tally + struck names), both worlds, parity pin; UI answer strip follows the loot-roll prompt pattern (`src/sim/loot/loot_roll.ts` + its wire status is the template), pure view module per the HUD recipe.
+- Reused: loot-roll group prompt shape, `/say` chat emit for the transcript, existing aura plumbing for the mantle. NEW: election module. No free-text parsing anywhere (PRD non-goal).
+- Tests first: NEW `tests/voyage_vote.test.ts` (majority elects; struck names cannot repeat; three rounds elect three different captains; tie and full-silence cases resolve identically on two seeded sims; the Captain gains the threat + defensive mantle aura for the phase only, and no new ability ids exist).
+- Acceptance: `npx vitest run tests/voyage_vote.test.ts tests/deeds_content.test.ts tests/world_api_parity.test.ts && npx vitest run tests/parity`.
+
+### S7. Finale: Sereva, allied boats, deck orders (Boss 3)
+- Goal: the return-leg finale: `ORDER_CYCLE_SECONDS` orders against `DECK_POST_COUNT` fixed posts, four named NPC boats (scripted in-instance set pieces), the `CROWN_SHATTER_HP_PCT` aurora across the instance sky, and the one-time first-server-clear bell engraving (plaque precedent). Pass 3: ship scars are COSMETIC only; scar-weakened posts and wreck damage-absorbs are cut. Pass 4: no trophy moves at all; the rescued hulk captives cheer from a trailing boat (scripted set piece).
+- Files: MODIFY `src/sim/content/farshore_voyage.ts` (Sereva encounter: HOLD COURSE / CUT THE COIL / OPEN THE LENS order records, failure damages a known ship section, never a reflex-kill; allied boats never provide required damage; the captives' trailing cheer boat when `hulkRescued` is set), `src/sim/voyage_ship.ts` (cosmetic scar records only), `src/sim/content/deeds.ts` (Sereva first-clear rows) plus deed pins; NEW `src/render/voyage_fx.ts` (aurora, INSTANCE-ONLY, cosmetic, passes graphics fairness).
+- Reused: encounter module precedent (`src/sim/encounters/nythraxis.ts`), boss `'yell'` barks, the first-clear plaque precedent for the engraving. NEW: order/post system, fx module. CUT at pass 2: previous-crew Wake Ship, responder skiffs, hung sail, blue watchfire (single-crew assumptions).
+- Tests first: extend `tests/farshore_voyage.test.ts` (HOLD COURSE, CUT THE COIL, and OPEN THE LENS each pass independently and each damage their own mapped section on failure; scars accumulate but change no combat numbers; the trailing cheer boat appears only when `hulkRescued` is set and contributes nothing mechanical; the engraving survives serialize/load and fires exactly once per realm; the fight is completable with the NPC boats contributing zero required damage).
+- Acceptance: `npx vitest run tests/farshore_voyage.test.ts tests/deeds_content.test.ts && npx vitest run tests/parity && npm run gate` (raid-complete milestone); mint the finale parity scenario via `UPDATE_PARITY=1` in its own commit.
+
+### S8. Loot, deeds, i18n sweep
+- Goal: finish Glasswake loot, remaining meta deeds, and contributor-owned localization without repairing obligations from earlier content slices.
+- Files: MODIFY `src/sim/content/farshore_voyage.ts` (rift-glass gear, one weapon per armor class off Sereva, gull shoulder pet for full hulk-rescue runs; numbers follow the existing level-20 stat budget rules exactly, compute the budget first), `src/sim/content/deeds.ts` (append remaining cross-program meta rows), `src/ui/sim_i18n.ts` (PR G loot/meta matcher rows only; earlier boss and quest rows already landed at their boundaries), `src/ui/i18n.catalog/items.ts` for English item names (G3), regenerated `src/ui/i18n.resolved.generated/*`, `src/ui/icons.ts` ITEM_IMAGE_IDS + `public/ui/items/mapping.json` via `gen-icon-art`, guide regen.
+- Tests first: extend `tests/deeds_content.test.ts` pins and `tests/item_level` budget checks before authoring items.
+- Acceptance: `npx vitest run tests/deeds_content.test.ts tests/i18n_completeness.test.ts tests/localization_fixes.test.ts tests/guide.test.ts && npm run wiki:content && npm run gate`.
+
+### S9. Heroic mode (pass 3: launch requirement, existing machinery only)
+- Goal: heroic difficulty rides the shipped machinery end to end: the heroic flag per the dungeon_difficulty pattern, boss stats tuned by the standing heroic multipliers, loot through the heroic RAID variant tier. No heroic-only mechanics in v1: heroic is numbers and loot, per the shipped convention. Exact ilvls follow the PRD's tier-position decision.
+- Files: MODIFY `src/sim/content/dungeon_difficulty.ts` (voyage rows in `HEROIC_DUNGEON_TUNING`), `src/sim/content/heroic_variants.ts` (voyage bosses join the raid-tier list so `buildHeroicVariants` derives `heroic_<id>` items via `heroicVariantId`, the `NYTHRAXIS_RAID_BOSS_ID`/`NYTHRAXIS_RAID_LOOT_SOURCE_LEVEL` precedent in `src/sim/content/heroic_loot.ts`), `src/sim/content/farshore_voyage.ts` (heroic flag on the instance records only).
+- Reused: `DungeonDifficulty` + `isDungeonDifficulty`/`setDungeonDifficulty` (already wired in `server/game.ts`), `mobTemplateForDungeonDifficulty`/`applyDungeonMobTuning`/`HEROIC_DUNGEON_IDS` in `src/sim/instances/difficulty.ts`. NEW: nothing; content rows only.
+- Tests first: extend `tests/farshore_voyage.test.ts` (heroic entry tunes boss stats by the standing multipliers; heroic Sereva drops the `heroic_` raid-tier variants; normal drops unchanged; the heroic run shares the same single `VOYAGE_LOCKOUT_ID`); extend the item budget pins if `tests/item_level` covers variants.
+- Acceptance: `npx vitest run tests/farshore_voyage.test.ts tests/deeds_content.test.ts && npx vitest run tests/parity`.
+
+### S10. Music and models
+- Goal: per-boss music (plus the sail theme) and the ship/naga/prop asset kit.
+- Files: MODIFY `src/game/music.ts` (new `MusicZone` cues for the sail and each boss), `src/game/music_tracks.ts` (`ZONE_STREAM_URLS` rows), `src/game/instance_music.ts` (routing); NEW `public/audio/music/` tracks, `public/models/` GLBs via `gen-3d-asset` (Glasswake visual signature: cobalt rift-glass crown plus red sailcloth streamer on every unit), `CREDITS.md`.
+- Tests first: extend `tests/music.test.ts`, `tests/music_tracks.test.ts`, and `tests/instance_music.test.ts` with the exact voyage zone and boss routing rows; the media manifest regenerates via the build (never hand-edit it).
+- Acceptance: `npx vitest run tests/music.test.ts tests/music_tracks.test.ts tests/instance_music.test.ts && npm run build`; in-game listen on `npm run dev` (headless screenshot workflow for the PR evidence).
+
+### S11. Bot-raid tuning pass
+- Goal: prove agent-completability end to end (normal and heroic) and tune timers only where a scripted crew fails.
+- Files: NEW `scripts/voyage_bot_raid.mjs` (drives 10 clients through a full clear on a dev server with `ALLOW_DEV_COMMANDS=1`, dev only, never production); tuning edits confined to `src/sim/content/farshore_voyage.ts` constants.
+- Tests first: the script IS the test; every encounter must clear with agents alone reading only IWorld state on the section 1 timers.
+- Acceptance: `node scripts/voyage_bot_raid.mjs`; full scripted clear recorded; `npm run gate` final milestone; then the PBE handoff per the rollout section of the PRD.
+
+## Extension X1. Low-tide assault, separate approval after raid PBE
+
+- Goal: a weekly level 3 to 7 Ferrywalk defense with villager rescues and event-local aid
+  choices. It is not part of the initial raid contribution and never reads raid-run state.
+- Gate: the raid core has shipped through PBE, Levy separately approves this extension,
+  and the extension re-verifies the Farshore zone anchors against the active release branch.
+- Files: NEW `src/sim/lowtide_assault.ts` (weekly cadence on the world-boss scheduler
+  pattern, phalanx spawns, one Siren per phalanx Beckons Gullhaven villagers only, never
+  players, rescue channel, event-local timber/oil/medicine aid choices); MODIFY
+  `src/sim/sim.ts` + `server/game.ts` (one tick call and lap pin), deeds plus pins, one event
+  read facet, both worlds, and the parity pin.
+- Reused: world-boss scheduler and S4's Beckon module villager arm. NEW: the event module.
+- Tests first: NEW `tests/lowtide_assault.test.ts` (event never scales past the 3 to 7 band;
+  villagers are Beckoned, players never are; each event-local aid choice changes the
+  defense; no raid lockout or voyage state is read; the event runs with zero raiders).
+- Acceptance: `npx vitest run tests/lowtide_assault.test.ts tests/deeds_content.test.ts tests/architecture.test.ts && npx vitest run tests/parity && npm run gate`.
+
+## 4. Gotchas (read before every slice)
+
+- **G1, SIM_LAP_PHASES is a pinned list.** Every per-tick module added here (`voyage_ship`,
+  `voyage_watches`, `beckoning`, `voyage_vote`; exactly these four in the raid core, the
+  pass-4 wing cuts add none) needs its phase entry in `server/game.ts` in the same slice
+  as its tick call or the profiler pin test reds; base lap names stay first. X1 adds
+  `lowtide_assault` only in its separately approved contribution.
+- **G2, every read surface is a three-part change.** New facet in `src/world_api/`,
+  implementation in BOTH `Sim` and `ClientWorld` (`src/net/online.ts`), and the pins in
+  `tests/world_api_parity.test.ts`. Missing any leg fails the pin or ships a behavior fork.
+- **G3, i18n ownership is split.** Contributor slices add English item-name rows and five
+  non-Latin fills for M16 prose. Maintainers fill remaining locale overlays before release.
+  Never put copied English in an overlay.
+- **G4, parity goldens.** One `ctx.rng` draw on a shared code path shifts draw order and
+  reds every golden. All voyage draws stay inside voyage-only code paths; each new
+  scenario's golden is minted with `UPDATE_PARITY=1` in its own reviewed commit; never
+  regenerate an existing golden to hide a diff.
+- **G5, deterministic draw-order discipline inside the raid too.** The vote must resolve
+  without rng (the lowest-slot tie-break) or two hosts diverge; where an encounter does
+  draw (loot), draw in one fixed module order per tick.
+- **G6, the stage is read-only.** `src/sim/content/farshore.ts` and the rift siege quests
+  belong to #2321; the raid adds siblings, never edits.
+- **G7, worktree discipline.** The shared checkout carries uncommitted WIP; build each slice
+  in a fresh worktree off the base branch (`feature/voyage-s<N>`) and re-merge it as it moves.
+
+## 5. Dispatch note
+
+Do not dispatch any slice while the Status row says BLOCKED. When unblocked, hand each owner
+the slice block, section 0 rules, section 1 constants, its hook-map rows, the gotchas, and
+the acceptance commands. Require fails-before/passes-after evidence for every test written
+first, exact command output, and a `qa-checklist` pass. S1, S5, S7, S8, and S11 end with `npm run gate`.

--- a/docs/prd/farshore-odyssey-raid.md
+++ b/docs/prd/farshore-odyssey-raid.md
@@ -1,0 +1,411 @@
+# PRD: The Far Shore Voyage, a Gullhaven sailing raid (Glasswake Covenant)
+
+Status: INCUBATION, draft pass 2 (2026-07-26) for discussion with Levy. Not scheduled
+and not eligible for Stage 5. The reduced raid core still needs an explicit Stage 3
+scope decision before its existing handoff can be dispatched.
+Depends on the Farshore zone (PR #2321, feature/procedural-dungeons) landing
+first. Supersedes the earlier Wickharbor-anchored draft. Pass-2 scope cut
+(maintainer direction): entry is the standard click-the-moored-ship raid
+gate, and every cross-instance or single-crew system is removed (bell
+relay, Gullhaven Answers, previous-crew ghost ship, town-side live state);
+the design assumes many groups raid concurrently. Pass-3 cuts (2026-07-26):
+Wreck Train reduced to the single hulk rescue, Bells route staged to a
+follow-up patch, Wake Doubles recorder replaced with class-mirror mob
+reflections, the Captain's bespoke ability kit dropped, scar/absorb finale
+bookkeeping dropped, per-wing lockouts collapsed to one. Heroic mode added
+as a launch requirement on the existing machinery. Pass-4 cut
+(2026-07-26, maintainer direction: lame bosses out, a 2-to-3 boss raid is
+fine): the Teeth crag and Wake Doubles wings are CUT outright, along with
+the entire two-route system and the staged Bells patch. The raid is THREE
+bosses (Vessarine, Szethkar, Sereva) plus the launch and the
+open-sail hulk rescue.
+
+## One-liner
+
+The game's first sailing raid: ten level-20 players crew one visible ship out of
+Gullhaven through a three-boss voyage against the Glasswake Covenant, and the
+crew's rescue and election decisions reshape that run's ship and return-leg finale
+without creating persistent per-crew world state.
+
+## Portfolio alignment
+
+- Proposed lane: incubation until the first dungeon and raid pipelines are proven, not yet
+  Levy-approved.
+- Protected identity: one crew, one visible ship, the Name-Taker election, and Sereva's
+  return-leg finale.
+- Scope rail: the pass-4 three-boss cut is the maximum initial raid. Cross-instance state,
+  town-side live state, route branches, extra wings, bespoke Captain buttons, and trophy
+  moves remain cut.
+- First schedule cut: the weekly low-tide assault becomes a separately approved post-raid
+  extension. It cannot delay or share the initial raid dispatch.
+- Next-stage gate: Hullworks and one raid prove the pipeline, Levy approves the reduced
+  raid core, and PR #2321 lands. The low-tide extension receives its own later scope
+  decision.
+
+## Why this patch
+
+Design target is shareability. Every encounter is built around one recognizable
+screenshot or chat transcript. The elected Captain and optional hulk rescue may
+change the return-leg frame without changing the world outside the instance.
+Secondary target: showcase what this game uniquely is, a deterministic sim where
+AI agents are first-class players, by giving humans and agents mechanics they
+solve together (information splits and votes).
+
+Entry is deliberately boring: the raid ship is moored at the Landing, and
+a raid group clicks it to enter the instance (the standard raid-gate plus
+dungeon-door pattern, nothing custom). Everything the raid does happens
+INSIDE the instance; the design assumes many groups run it concurrently,
+so no system below ever refers to "the" crew at sea. Endgame content
+berthed in a starter zone is still the flavor win (geared players moor at
+a level-5 dock), but it is set dressing, not machinery.
+
+Everything below is agent-completable by policy: coordination, information
+asymmetry, resource math, and positioning on readable timers. No
+human-reflex mechanics anywhere.
+
+## Setting and dependencies
+
+Stage is the existing Farshore content (nothing invented here):
+
+- Gullhaven, the island fishing town (Warden Coalfast, Bellkeeper Tam,
+  Quartermaster Edda, Mender Saul, Fisher Bram, Riftwatch Ollun).
+- The Landing, where the Ferrywalk sandbar meets the island, with its
+  watchbell (the existing q_fs_bell_at_the_landing breadcrumb).
+- The Sundered Cliffs: the siren strait.
+- The Riftfields and the breaks: the zone's existing sea-rift siege, which
+  this patch's fiction plugs into rather than replaces.
+- The Three Bells (existing quest motif): flavor only; the raid adds no
+  live town-side state (pass-2 rule: no single-crew systems).
+
+Dependency: the Farshore ships in #2321. This PRD stacks on it or follows
+it; it does not fork it.
+
+## The enemy: the Glasswake Covenant
+
+Naga-style serpent people, all names original. Doctrine, rewired to the
+Farshore's existing fiction: where the breaks tear the sea, the shallows
+fuse into rift-glass, and the Covenant harvests it. They believe the breaks
+are the sea opening its one true eye, and a crown of rift-glass will let
+their Crowned speak for it. Gullhaven thinks it has a rift problem; it has
+a rift problem AND a congregation that follows the rifts ashore. The two
+sieges explain each other.
+
+Unit archetypes:
+
+| Unit | Role | Signature mechanic |
+|---|---|---|
+| Keelgrip Bulwark | Frontline | Hooks a target to a deck post (visible cast); armored until another player breaks the chain |
+| Wakeglass Siren | Song caster | Splits information between player groups, masks cast names, projects false headings; sings the Beckoning (the faction's mind-control verb, below) |
+| Wreckstitch Diver | Salvage engineer | Repairs enemy stations, cuts the raid's tow cables, raises wreck constructs |
+| Lantern Thief | Support skirmisher | Steals one player buff into a targetable glass lantern; break the right lantern to get it back, break a decoy and an add spawns |
+| Deepchart Augur | Navigator | Draws deterministic current lanes and marks future boarding points, readable by humans and agents alike |
+
+Visual signature (every unit, every screenshot): a tall crown or back-fin of
+jagged rift-glass, cobalt blue, bound in strips of saturated red sailcloth.
+Blue rim light off the glass, red streamers off the silhouette. One crown
+plus one streamer identifies the faction at any zoom.
+
+## Post-raid extension: Low tide on the Ferrywalk
+
+This weekly event is conceptually related but is not part of the initial raid
+scope or dispatch. It receives a separate Levy decision after the raid clears
+PBE, owns its own state, and cannot require a choice or persisted field from a
+raid run.
+
+The extension stays scaled to the zone's 3 to 7 band so the starter island
+defends itself. At low tide the sandbar widens into a broad seabed road and the
+Glasswake walk it in phalanx toward the Landing. Islanders and low-level players
+defend Gullhaven. If approved, event-local aid choices may let timber build
+barricades, oil light the exposed seabed, or medicine add rescue tents. This is
+supporting content that teaches raid fiction at level 5, not a raid prerequisite.
+
+The assault also teaches the Beckoning small: one Siren walks with each
+phalanx, singing a handful of GULLHAVEN VILLAGERS (named friendly NPCs,
+never players in the open world) into a slow march toward the waterline.
+Any player of any level can grab a villager (2 s channel) to snap them
+out; every villager saved is a defense objective and feeds a small deed.
+Once the extension ships, level-5 players learn "interrupt the singer,
+grab the walker" before later meeting the raid's lash counter.
+
+(Cut at pass 2: the Bell Relay cross-lockout message system and the
+Gullhaven Answers open-world skiff event. Both assumed a single crew at
+sea and needed custom cross-instance plumbing with no precedent. The
+low-tide assault above is a separate post-raid extension, not the raid's
+open-world footprint.)
+
+## The space: one ship, one arena
+
+The entire raid is fought on the deck of the raid's own ship. The boat is
+the arena; the world moves past it. There are no islands, no landfalls,
+and no second room in v1:
+
+- Boss 1 plays out as the ship runs the Sundered Cliffs strait: sirens
+  sing from the sea stacks AROUND the boat, boarders come over the rails,
+  and the Beckoned walk happens on the deck planks.
+- The open sail is the same deck with open water around it; the hulk is
+  hooked from the rail.
+- Boss 2 is a boarding action: the Name-Taker forces the command crisis
+  on your own deck.
+- Boss 3 is the harbor mouth: Sereva coils around the hull and the town's
+  boats circle the fight.
+
+The movement model, stated plainly because it is the load-bearing
+implementation fact: nothing ever moves in sim space. The instance map
+holds THREE dressed copies of the same deck, stamped at three fixed
+locations on the one instance grid: the strait deck (real sea-stack and
+cliff geometry around it), the open-water deck, and the harbor deck
+(town backdrop, room for the NPC boats). "Sailing" between legs is a
+short scripted teleport of the whole raid to the next deck copy when the
+prior encounter ends, the exact machinery dungeons already use to move
+parties, wrapped in a departure and arrival beat. Nobody steers, there
+is no ship-driving verb, and no geometry ever moves. Players never leave
+the deck they are on: the rails and the boarding nets below are the
+arena boundary, and going overboard means the nets and a walk back up.
+
+This is a deliberate build economy: ONE deck collider layout authored
+once and stamped three times, real (static) scenery per leg instead of
+faked motion, one `interior` entry.
+The known risk is visual monotony (three fights on the same planks); the
+named mitigation, if playtest agrees, is moving Boss 2 below decks into
+the hold, a second small interior on the same ship (open question below).
+
+## The raid: three bosses, 10 players, level 20, one evening
+
+### The launch: the Tenfold Sail (not a boss)
+The group clicks the moored ship, zones in on deck, and the launch plays
+out in-instance: each raider's heraldic panel (generated from class,
+weapon silhouette, and chosen color) stitches into the ship's mainsail as
+a deckhand NPC reads the manifest. Agents get panels and manifest lines
+identically to humans. The sail takes damage and collects trophies all
+run: the before and after shots tell the run's whole story. Render-side
+compositing only, no new sim system.
+
+### Boss 1: Vessarine, First Voice of the Glasswake (the Sundered Cliffs)
+The encounter formerly labeled "the Split Horizon" now has a villain: 
+Vessarine, the siren matriarch who taught the Covenant to sing, coiled on
+the tallest sea stack, conducting. She pulls when the ship enters her
+strait, opening on a yell ("Every wreck on this coast learned my name
+before the water took them. Learn it dry."). Her Wakeglass Sirens sing
+from the broken cliff stacks around her, and the fight
+alternates between the song's two movements on a loud, readable cadence:
+
+- The Verse (navigation): the song splits the raid into two five-player
+  watches that swap every 35 seconds: the Current Watch sees safe
+  channels, hidden casts, and the true heading but not the deck; the Deck
+  Watch sees boarders, stations, and the wheel but a fogged route.
+  Everyone keeps full combat agency; success is short calls between
+  watches ("port after this cast"). The swap cadence means nobody owns
+  the caller role and everyone plays both halves.
+- The Chorus (the Beckoning, the mind-control beat): a Siren turns her
+  song on one or two raiders (long telegraphed cast, interruptible, loud
+  personal warning). A Beckoned raider loses input and walks slowly,
+  visibly, toward the rail and the sea. Three counters, all
+  coordination: interrupt the Siren mid-cast; LASH the Beckoned player
+  to the mast or a deck post (an ally channels 2 s on them with rigging
+  rope, holding them safely until the verse ends, the Odyssey image as
+  counterplay); or let them walk and fish them out of the boarding nets
+  below the rail (no death, no fall damage, an 8 second walk back and a
+  soaked movement debuff: a positioning tax, never a kill).
+
+The Beckoning is the one NEW sim primitive this raid asks for: a "lured"
+state that replaces a player's movement input with a slow server-driven
+walk toward a point, breakable by the lash interact, the Siren's death
+or interrupt, or expiry. It is agent-completable by construction (the
+state, the walk target, and the lash interact are all readable game
+state on generous timers). Fallback needing zero engine work: the
+Beckoning uses the existing polymorphHex incapacitate (the raider stands
+entranced instead of walking), losing the walk-to-the-rail image but
+keeping the interrupt/lash play. The walking version is the one that
+produces the clip of a guildmate marching overboard while nine people
+scream, so this PRD recommends funding the module.
+
+### The open sail (between fights: trash pulls and the rescue beat)
+The sail legs carry the raid's trash rhythm, because a raid night needs
+pulls between bosses: two to three boarding parties per leg, each a
+readable Glasswake squad built from the unit table (a Keelgrip anchor
+line, a Lantern Thief cutting purse, a Wreckstitch crew trying to saw
+through the rail), coming over the sides with grapnel telegraphs. Classic
+pacing: pull, reset, banter, next pull.
+
+One rescue beat also rides the sail: the prison hulk, a
+wrecked prisoner transport adrift on the route. Hooking it (one tow
+cable, a ground object interact) slows the ship's repairs for a stretch
+but frees its captives, who transfer to a trailing rescue boat inside the
+instance, cheer during the finale, and feed the full-rescue deed and the gull
+pet. No town-side or cross-instance state is created.
+
+(Pass 4, boss-count cut: the Teeth crag wing and the Wake Doubles wing
+are CUT, and with them the entire two-route system including the staged
+Bells patch. Three bosses is the raid. The hulk rescue survives here.)
+
+### Boss 2: Szethkar the Name-Taker (the boarding)
+Szethkar is the Covenant's herald, the one who collects names off stolen
+manifests for the crown, and he boards mid-sail with a Keelgrip honor
+guard: a proper villain with a ledger, not an abstraction. He opens the
+mutiny with his demand, "WHO COMMANDS YOU?", and each raider answers in
+/say with one
+of the ten crew names (clickable options in the UI, exposed in structured
+state for agents). The majority pick becomes Captain for the phase: all
+enormous boss threat plus a defensive mantle, nine defenders. The name is then
+struck and cannot repeat, so three rounds elect three different captains.
+The Captain's mantle is existing aura machinery only: enormous boss threat
+plus a defensive buff for the phase (pass 3: the bespoke command-ability
+kit is cut; the social moment is the election, not new buttons). Every
+clear produces a different transcript; agents nominate humans, humans put
+an agent in command, friends betray each other. Ties and silence resolve
+deterministically, so it cannot deadlock.
+
+### Boss 3, the finale: The Island Answers
+Boss: Sereva, Crown of the Glasswake. She rises across the strait on the
+return leg, coils around the raid's own ship in sight of the Landing, and
+begins dragging it toward the largest break.
+
+- The island answers: Coalfast, Tam, Edda, and Bram launch four named
+  boats, scripted NPC allies inside the instance (spawned set pieces, the
+  same machinery as any add wave, dressed as boats). They intercept adds
+  and carry signals; they never provide required damage. (Cut at pass 2:
+  the previous-crew ghost ship and open-world responder skiffs, which
+  assumed a single crew and cross-instance plumbing.)
+- The ship is the weapon: Sereva cycles 12-second orders (HOLD COURSE, CUT
+  THE COIL, OPEN THE LENS) against ten fixed deck posts, fully exposed in
+  game state. Failure damages a known ship section, never a reflex-kill.
+- The voyage pays off, lightly: the rescued hulk captives cheer from a
+  trailing boat. Cosmetic ship scars only; nothing mechanical carries
+  forward (pass 4: the trophy moves died with the route wings).
+- The shot: at 10 percent her rift-glass crown catches the light of the
+  break beneath her and fires it skyward; the crown shatters into a
+  colored aurora across the INSTANCE sky as the NPC boats spiral around
+  the Tenfold Sail. The frame contains this crew, their sail, the rescued
+  captives when that optional beat was completed, and the town's named boats.
+  None of it leaks outside the instance.
+
+Persistence: first server clear engraves the roster on the Landing bell
+(a one-time plaque, the existing precedent). That is the raid's entire
+open-world footprint besides the moored ship. The low-tide extension is a
+separate later feature.
+
+## Loot direction (sketch)
+
+Glasswake theme: rift-glass and wrecked-fittings gear, one weapon per armor
+class off Sereva, and a gull shoulder pet for full-rescue hulk runs.
+Numbers follow the existing level-20 stat budget rules; no numbers are
+proposed here. Naming direction, because loot is half the fantasy: items
+read like salvage with a history, in the classic register. Examples
+(names only, all original, final list at implementation): Vessarine's
+Hushing Choker, Manifest of Stolen Names, Szethkar's Ledger-Blade,
+Coilwarped Breastplate, Sereva's Shattered Facet, Gullhaven Deckhand's
+Mitts.
+
+## Character and voice (the classic-raid dressing)
+
+All of it rides the existing yell machinery and the sim_i18n matcher,
+zero new systems, priced into the i18n scope:
+
+- Every boss gets an RP pull line, two mid-fight yells keyed to their
+  signature mechanic (Vessarine sings names before each Chorus; Szethkar
+  reads the elected Captain's name off his ledger, aloud, which is the
+  transcript moment), a kill quote, and a raid-wipe quote.
+- A named deckhand, Bosun Hetta Vail, crews the ship as the raid's warm
+  voice: she reads the manifest at launch, calls the hulk sighting, and
+  gets the last line sailing home. NPC record in the content module.
+- The town boats in the finale each get one bark on arrival (Coalfast,
+  Tam, Edda, Bram), so the cavalry moment has voices, not just hulls.
+
+## Heroic mode (required at launch)
+
+Heroic rides the existing machinery end to end, nothing bespoke: the
+heroic difficulty flag on the instance (the dungeon_difficulty pattern),
+tuned-up boss stats per the standing heroic multipliers, and loot through
+the heroic RAID variant tier (heroic_variants.ts: scaled primary rating
+plus a complementary secondary, the Nythraxis heroic precedent). Exact
+ilvls fall out of the tier-position decision (open question below). No
+heroic-only mechanics in v1: heroic is numbers and loot, per the shipped
+convention.
+
+## Explicit non-goals
+
+- No new action-combat verbs; everything is tab-target, GCD, threat, mana.
+- No cross-instance or single-crew systems of any kind: nothing in the
+  zone reflects a run in progress, and no instance reads another run's
+  state. Many groups raid concurrently; the design never assumes "the"
+  crew.
+- No chat free-text parsing: every chat-integrated mechanic offers a finite
+  clickable and machine-readable answer set.
+- No WoW-derived names anywhere in the faction, bosses, or abilities.
+- No changes to the Farshore's existing 3 to 7 leveling content in the raid
+  build; the rift-siege quests stay exactly as authored. The separately
+  approved low-tide extension owns any later zone changes.
+
+## Rollout
+
+Per the contribution process: this is a large content feature, so the gate
+order is (1) a conversation with Levy on the reduced raid core, (2)
+implementation behind the Farshore dependency, (3) a PBE round for community
+testing, (4) raid release, and only then (5) a separate decision on the
+low-tide extension. i18n scope is large (faction, three bosses, ability names, bell
+quest prose) and follows the standard catalog plus overlay
+workflow, budgeted as its own task.
+
+## File plan (build reference)
+
+Files ADDED:
+- `src/sim/content/farshore_voyage.ts`: the raid's DungeonDef-style instance
+  records (ONE lockout id on `meta.raidLockouts`, pass 3: per-wing lockouts
+  collapsed; heroic difficulty flag per the dungeon_difficulty pattern),
+  the three boss MobTemplates, ground objects (deck posts, the hulk
+  cable), items (normal plus heroic variant tier), and the on-ramp quest
+  (temple.ts precedent).
+- Sim modules behind the SimContext seam, each with its own test file:
+  `src/sim/voyage_ship.ts` (ship state, trophies; sail panels derive
+  client-side from party composition, zero sim cost),
+  `src/sim/voyage_watches.ts` (Split Horizon watch split, aura-keyed,
+  client-side filtering only), `src/sim/beckoning.ts` (the lured walk
+  state, the one NEW primitive), `src/sim/voyage_vote.ts` (Name-Taker
+  election). The later low-tide extension owns `src/sim/lowtide_assault.ts`
+  only if separately approved. (Pass 2/3 cuts: bell_relay.ts, wake_doubles.ts
+  recorder, wreck_train.ts; pass 4 cut the Teeth and Wake Doubles wings
+  outright; the hulk rescue is a ground object plus a flag.)
+- `src/render/voyage_ship.ts` (ship, sail compositing, flotilla) and
+  `src/render/voyage_fx.ts` (aurora finale), called by the renderer, never
+  method banks on `renderer.ts`.
+- `public/audio/music/` tracks (sail theme plus one per boss);
+  `public/models/` ship/naga GLBs via the gen-3d-asset lanes; icons via
+  gen-icon-art.
+- Tests: `tests/farshore_voyage.test.ts` per module, one `tests/parity`
+  scenario + golden per boss.
+
+Files MODIFIED:
+- `src/sim/data.ts` (merge the new defs), `src/sim/content/deeds.ts`
+  (append rows), `src/sim/sim.ts` (tick calls for the new modules, thin),
+  `server/game.ts` (SIM_LAP_PHASES pins for each per-tick module).
+- `src/world_api/` facet(s) for sail/vote read state, implemented in
+  BOTH `Sim` and `src/net/online.ts` (ClientWorld), pins updated in
+  `tests/world_api_parity.test.ts`.
+- `src/ui/sim_i18n.ts` (matcher dicts, AURA_NAME_KEY, yells),
+  `src/ui/i18n.catalog/items.ts` for English item names, five non-Latin
+  overlays for M16 quest prose, regenerated
+  `src/ui/i18n.resolved.generated/*`.
+- `src/game/instance_music.ts` + `src/game/music_tracks.ts`,
+  `src/ui/icons.ts` (ITEM_IMAGE_IDS), `public/ui/items/mapping.json`,
+  `CREDITS.md`, `tests/deeds_content.test.ts` pins,
+  `tests/dungeon_entry_clearance.test.ts` coverage, guide regen
+  (`npm run wiki:content` + `guide.*` keys).
+
+## Open questions for Levy
+
+1. Visual monotony lever: keep all three fights on the open deck, or move
+   Boss 2 below decks into the hold (one extra small interior on the same
+   ship)? Deck-only is cheaper; the hold buys variety.
+2. The Beckoning mind control: fund the "lured" walk module (recommended,
+   it is the raid's most clippable moment and the faction's identity
+   verb), or ship the polymorphHex entrance fallback? Related taste
+   call: is losing movement control for up to ~8 seconds acceptable
+   player feel for this game, given every counter is in the raid's
+   hands? (Players are never Beckoned in the open world; only the raid
+   instance and only with the lash counter available.)
+
+## Post-raid extension question for Levy
+
+If the raid ships cleanly, decide whether the low-tide Ferrywalk assault is
+worth a separate contribution. If approved, keep it at zone level 3 to 7 and
+give it event-local aid choices; do not add raid-run persistence to fund it.

--- a/docs/prd/farshore-odyssey-raid.md
+++ b/docs/prd/farshore-odyssey-raid.md
@@ -1,11 +1,11 @@
 # PRD: The Far Shore Voyage, a Gullhaven sailing raid (Glasswake Covenant)
 
-Status: INCUBATION, draft pass 2 (2026-07-26) for discussion with Levy. Not scheduled
+Status: READY FOR THE LEVY CONVERSATION, draft pass 2 (2026-07-26). Not scheduled
 and not eligible for Stage 5. The reduced raid core still needs an explicit Stage 3
-scope decision before its existing handoff can be dispatched.
-Depends on the Farshore zone on the `feature/procedural-dungeons` branch
-(umbrella PR #1584) landing first. Supersedes the earlier Wickharbor-anchored
-draft. Pass-2 scope cut
+scope decision, pipeline proof, and a committed PBE round before its existing handoff
+can be dispatched. The Farshore zone content in `src/sim/content/farshore.ts` landed in
+`release/v0.33.0`, is merged through `src/sim/data.ts`, and is placed in the `ZONES`
+table. Supersedes the earlier Wickharbor-anchored draft. Pass-2 scope cut
 (maintainer direction): entry is the standard click-the-moored-ship raid
 gate, and every cross-instance or single-crew system is removed (bell
 relay, Gullhaven Answers, previous-crew ghost ship, town-side live state);
@@ -30,8 +30,8 @@ without creating persistent per-crew world state.
 
 ## Portfolio alignment
 
-- Proposed lane: incubation until the first dungeon and raid pipelines are proven, not yet
-  Levy-approved.
+- Proposed lane: ready for the Levy conversation, with the first dungeon and raid pipelines
+  still to be proven and no Levy approval yet.
 - Protected identity: one crew, one visible ship, the Name-Taker election, and Sereva's
   return-leg finale.
 - Scope rail: the pass-4 three-boss cut is the maximum initial raid. Cross-instance state,
@@ -39,9 +39,12 @@ without creating persistent per-crew world state.
   moves remain cut.
 - First schedule cut: the weekly low-tide assault becomes a separately approved post-raid
   extension. It cannot delay or share the initial raid dispatch.
-- Next-stage gate: Hullworks and one raid prove the pipeline, Levy approves the reduced
-  raid core, and the `feature/procedural-dungeons` branch (umbrella PR #1584) lands. The
-  low-tide extension receives its own later scope decision.
+- Satisfied zone gate: the Farshore content in `src/sim/content/farshore.ts` landed in
+  `release/v0.33.0`, is merged through `src/sim/data.ts`, and is placed in the `ZONES`
+  table.
+- Remaining next-stage gate: Hullworks and one raid prove the pipeline, Levy approves the
+  reduced raid core, and a PBE round is committed. The low-tide extension receives its own
+  later scope decision.
 
 ## Why this patch
 
@@ -78,8 +81,9 @@ Stage is the existing Farshore content (nothing invented here):
 - The Three Bells (existing quest motif): flavor only; the raid adds no
   live town-side state (pass-2 rule: no single-crew systems).
 
-Dependency: the Farshore ships on the `feature/procedural-dungeons` branch
-(umbrella PR #1584). This PRD stacks on it or follows it; it does not fork it.
+Dependency satisfied: the Farshore content in `src/sim/content/farshore.ts` landed in
+`release/v0.33.0`, is merged through `src/sim/data.ts`, and is placed in the `ZONES`
+table. This PRD builds on the released zone and does not edit it.
 
 ## The enemy: the Glasswake Covenant
 
@@ -338,11 +342,12 @@ convention.
 
 ## Rollout
 
-Per the contribution process: this is a large content feature, so the gate
-order is (1) a conversation with Levy on the reduced raid core, (2)
-implementation behind the Farshore dependency, (3) a PBE round for community
-testing, (4) raid release, and only then (5) a separate decision on the
-low-tide extension. i18n scope is large (faction, three bosses, ability names, bell
+The Farshore dependency is already satisfied in `release/v0.33.0` through
+`src/sim/content/farshore.ts`, its merge in `src/sim/data.ts`, and its placement in the
+`ZONES` table. Per the contribution process, this is a large content feature, so the
+remaining gate order is (1) a conversation with Levy on the reduced raid core, (2) a
+committed PBE round for community testing, (3) raid release, and only then (4) a separate
+decision on the low-tide extension. i18n scope is large (faction, three bosses, ability names, bell
 quest prose) and follows the standard catalog plus overlay
 workflow, budgeted as its own task.
 

--- a/docs/prd/farshore-odyssey-raid.md
+++ b/docs/prd/farshore-odyssey-raid.md
@@ -3,8 +3,9 @@
 Status: INCUBATION, draft pass 2 (2026-07-26) for discussion with Levy. Not scheduled
 and not eligible for Stage 5. The reduced raid core still needs an explicit Stage 3
 scope decision before its existing handoff can be dispatched.
-Depends on the Farshore zone (PR #2321, feature/procedural-dungeons) landing
-first. Supersedes the earlier Wickharbor-anchored draft. Pass-2 scope cut
+Depends on the Farshore zone on the `feature/procedural-dungeons` branch
+(umbrella PR #1584) landing first. Supersedes the earlier Wickharbor-anchored
+draft. Pass-2 scope cut
 (maintainer direction): entry is the standard click-the-moored-ship raid
 gate, and every cross-instance or single-crew system is removed (bell
 relay, Gullhaven Answers, previous-crew ghost ship, town-side live state);
@@ -39,8 +40,8 @@ without creating persistent per-crew world state.
 - First schedule cut: the weekly low-tide assault becomes a separately approved post-raid
   extension. It cannot delay or share the initial raid dispatch.
 - Next-stage gate: Hullworks and one raid prove the pipeline, Levy approves the reduced
-  raid core, and PR #2321 lands. The low-tide extension receives its own later scope
-  decision.
+  raid core, and the `feature/procedural-dungeons` branch (umbrella PR #1584) lands. The
+  low-tide extension receives its own later scope decision.
 
 ## Why this patch
 
@@ -77,8 +78,8 @@ Stage is the existing Farshore content (nothing invented here):
 - The Three Bells (existing quest motif): flavor only; the raid adds no
   live town-side state (pass-2 rule: no single-crew systems).
 
-Dependency: the Farshore ships in #2321. This PRD stacks on it or follows
-it; it does not fork it.
+Dependency: the Farshore ships on the `feature/procedural-dungeons` branch
+(umbrella PR #1584). This PRD stacks on it or follows it; it does not fork it.
 
 ## The enemy: the Glasswake Covenant
 
@@ -181,8 +182,7 @@ run: the before and after shots tell the run's whole story. Render-side
 compositing only, no new sim system.
 
 ### Boss 1: Vessarine, First Voice of the Glasswake (the Sundered Cliffs)
-The encounter formerly labeled "the Split Horizon" now has a villain: 
-Vessarine, the siren matriarch who taught the Covenant to sing, coiled on
+Vessarine, the siren matriarch who taught the Covenant to sing, is coiled on
 the tallest sea stack, conducting. She pulls when the ship enters her
 strait, opening on a yell ("Every wreck on this coast learned my name
 before the water took them. Learn it dry."). Her Wakeglass Sirens sing
@@ -279,10 +279,10 @@ begins dragging it toward the largest break.
   captives when that optional beat was completed, and the town's named boats.
   None of it leaks outside the instance.
 
-Persistence: first server clear engraves the roster on the Landing bell
-(a one-time plaque, the existing precedent). That is the raid's entire
-open-world footprint besides the moored ship. The low-tide extension is a
-separate later feature.
+**Future flourish:** A first-server-clear plaque would be realm-global persisted
+state, which conflicts with the raid's no-cross-instance-state rail. It needs its
+own persistence design, including a `server/` surface and serialize/load coverage,
+before it can be scheduled.
 
 ## Loot direction (sketch)
 
@@ -358,8 +358,10 @@ Files ADDED:
 - Sim modules behind the SimContext seam, each with its own test file:
   `src/sim/voyage_ship.ts` (ship state, trophies; sail panels derive
   client-side from party composition, zero sim cost),
-  `src/sim/voyage_watches.ts` (Split Horizon watch split, aura-keyed,
-  client-side filtering only), `src/sim/beckoning.ts` (the lured walk
+  `src/sim/voyage_watches.ts` (Vessarine watch split, aura-keyed; server-side
+  interest scoping honors the watch flags without putting viewer-specific fields
+  in shared cached payloads, so the fogged route never ships in the snapshot),
+  `src/sim/beckoning.ts` (the lured walk
   state, the one NEW primitive), `src/sim/voyage_vote.ts` (Name-Taker
   election). The later low-tide extension owns `src/sim/lowtide_assault.ts`
   only if separately approved. (Pass 2/3 cuts: bell_relay.ts, wake_doubles.ts
@@ -369,8 +371,10 @@ Files ADDED:
   `src/render/voyage_fx.ts` (aurora finale), called by the renderer, never
   method banks on `renderer.ts`.
 - `public/audio/music/` tracks (sail theme plus one per boss);
-  `public/models/` ship/naga GLBs via the gen-3d-asset lanes; icons via
-  gen-icon-art.
+  `public/models/` ship/naga GLBs via the `image-to-glb` skill
+  (`.claude/skills/image-to-glb/SKILL.md`) plus
+  `docs/image-to-glb-asset-workflow.md`. Icons and non-GLB kit elements are
+  plain authoring work with no named skill.
 - Tests: `tests/farshore_voyage.test.ts` per module, one `tests/parity`
   scenario + golden per boss.
 


### PR DESCRIPTION
## Summary

PRD plus build handoff for The Far Shore Voyage, a ten-player level-20 sailing raid out of Gullhaven on the Farshore island. Docs only, two files, opened to start the design conversation.

The raid is a sea voyage fought entirely on the deck of the crew's own ship (one collider layout stamped at three dressed spots on the instance map; sailing is the standard party teleport between them). Three named bosses: Vessarine, First Voice of the Glasswake, whose sirens mind-control raiders into walking toward the rail, countered by interrupting her or lashing your crewmate to the mast; Szethkar the Name-Taker, who boards mid-sail and forces the raid to elect one of its own as Captain by vote, three rounds, no repeats; and Sereva, Crown of the Glasswake, fought in the harbor mouth while the town's boats sail out. Plus the Tenfold Sail launch (the raiders' heraldry composes the mainsail) and one optional prison-hulk rescue on the open sail.

Scope discipline, because this went through four descope passes before opening: entry is a standard click-the-moored-ship raid gate, there are NO cross-instance or single-crew systems, no town-side live state, one raid lockout, heroic at launch on existing machinery, and exactly ONE new sim primitive in the whole design (the Beckoning lured-walk state, with a zero-engine fallback specced beside it). The open-world footprint is a moored ship, a one-time first-clear plaque, and a weekly low-tide event scoped as a separate extension.

The naga faction (the Glasswake Covenant) ties into the Farshore's existing rift-siege fiction and rivals the Redwake Company of the Hullworks PRD; neither blocks the other.

Depends on PR #2321 landing before any build starts; the handoff marks itself incubation-lane pending the conversation and the first dungeon proving the pipeline.

## Testing

Docs only, no code or content changes. Copy scan clean.