### PR TITLE
fix(render): stop deck railings crossing walkway junctions

### DIFF
--- a/src/render/deck_render.ts
+++ b/src/render/deck_render.ts
@@ -3,6 +3,8 @@
 // post geometry: level runs as long plank courses on stilts, steep
 // two-anchor ramps as stepped stair treads, handrails on the stairs (and,
 // when railAll is set, along every deck edge: the bridge-and-pier look).
+// Rails stop short where two decks of the batch join (deckRailRuns), so a
+// walkway the decks share never ends up fenced off across its mouth.
 // Callers merge the returned arrays with their own materials, so the
 // harbor and the jungle walkways each keep their own wood tones. Extracted
 // from render/gale_features.ts when the Palmreach walkways became the
@@ -34,6 +36,70 @@ export function beamBetween(
 export interface DeckWood {
   planks: THREE.BufferGeometry[];
   posts: THREE.BufferGeometry[];
+}
+
+/** One rail post position along a deck edge (`along` re-samples its height). */
+export interface DeckRailPoint {
+  x: number;
+  z: number;
+  along: number;
+}
+
+/**
+ * A rail point this close to another deck's walkable rectangle counts as
+ * standing in the junction. Decks that join share an anchor and overlap only
+ * roughly, so the neighbour's rail can sit a little OUTSIDE the rectangle and
+ * still fence its mouth (at the Palmreach lagoon T the boardwalk's far-side
+ * rail misses the pier rect by 0.38).
+ */
+const RAIL_JUNCTION_MARGIN = 0.55;
+
+/** Point inside a deck's walkable rectangle (rotated rect), grown by `margin`. */
+function deckContains(deck: GaleDeckDef, x: number, z: number, margin: number): boolean {
+  const dx = x - deck.x;
+  const dz = z - deck.z;
+  const dirx = Math.sin(deck.rot);
+  const dirz = Math.cos(deck.rot);
+  const along = dx * dirx + dz * dirz;
+  const across = dx * dirz - dz * dirx;
+  return Math.abs(along) <= deck.hl + margin && Math.abs(across) <= deck.hw + margin;
+}
+
+/**
+ * The rail post positions along one edge of `deck`, split into runs.
+ *
+ * Decks meet flush by design (a pier off a boardwalk, a stair into the deck it
+ * climbs to), so an edge run laid over the deck's whole length walls off the
+ * walkway they share. A point standing on ANOTHER deck of the same batch is
+ * dropped and ENDS its run, so the rail bars stop at the junction instead of
+ * stretching across the gap. Pure and cheap: batches are a handful of decks.
+ */
+export function deckRailRuns(
+  deck: GaleDeckDef,
+  side: number,
+  batch: readonly GaleDeckDef[],
+): DeckRailPoint[][] {
+  const dirx = Math.sin(deck.rot);
+  const dirz = Math.cos(deck.rot);
+  const pxu = dirz; // unit across (perp) axis
+  const pzu = -dirx;
+  const runs: DeckRailPoint[][] = [];
+  let run: DeckRailPoint[] = [];
+  for (let along = -deck.hl + 0.4; along <= deck.hl - 0.2; along += 1.4) {
+    const x = deck.x + dirx * along + pxu * (deck.hw - 0.12) * side;
+    const z = deck.z + dirz * along + pzu * (deck.hw - 0.12) * side;
+    const junction = batch.some(
+      (other) => other !== deck && deckContains(other, x, z, RAIL_JUNCTION_MARGIN),
+    );
+    if (junction) {
+      if (run.length > 0) runs.push(run);
+      run = [];
+      continue;
+    }
+    run.push({ x, z, along });
+  }
+  if (run.length > 0) runs.push(run);
+  return runs;
 }
 
 export function buildDeckWood(
@@ -84,27 +150,27 @@ export function buildDeckWood(
         g.translate(px, (top + bed - 0.4) / 2 + 0.2, pz);
         posts.push(g.toNonIndexed());
       }
-      // stairs always get a handrail; railAll rails the level runs too
+      // stairs always get a handrail; railAll rails the level runs too. Runs
+      // break where another deck of the batch joins, so no rail fences off a
+      // shared walkway (the lagoon T, the pool stair, the harbor stair feet).
       if (stair || opts.railAll) {
-        const railPts: THREE.Vector3[] = [];
-        for (let along = -d.hl + 0.4; along <= d.hl - 0.2; along += 1.4) {
-          const px = d.x + dirx * along + pxu * (d.hw - 0.12) * side;
-          const pz = d.z + dirz * along + pzu * (d.hw - 0.12) * side;
-          const y = yAt(along);
-          railPts.push(new THREE.Vector3(px, y, pz));
-          const g = new THREE.BoxGeometry(0.14, 1.06, 0.14);
-          g.translate(px, y + 0.5, pz);
-          posts.push(g.toNonIndexed());
-        }
-        for (let i = 0; i + 1 < railPts.length; i++) {
-          for (const lift of [0.98, 0.54]) {
-            beamBetween(
-              posts,
-              new THREE.Vector3(railPts[i].x, railPts[i].y + lift, railPts[i].z),
-              new THREE.Vector3(railPts[i + 1].x, railPts[i + 1].y + lift, railPts[i + 1].z),
-              0.08,
-              0.1,
-            );
+        for (const run of deckRailRuns(d, side, decks)) {
+          const railPts = run.map((p) => new THREE.Vector3(p.x, yAt(p.along), p.z));
+          for (const pt of railPts) {
+            const g = new THREE.BoxGeometry(0.14, 1.06, 0.14);
+            g.translate(pt.x, pt.y + 0.5, pt.z);
+            posts.push(g.toNonIndexed());
+          }
+          for (let i = 0; i + 1 < railPts.length; i++) {
+            for (const lift of [0.98, 0.54]) {
+              beamBetween(
+                posts,
+                new THREE.Vector3(railPts[i].x, railPts[i].y + lift, railPts[i].z),
+                new THREE.Vector3(railPts[i + 1].x, railPts[i + 1].y + lift, railPts[i + 1].z),
+                0.08,
+                0.1,
+              );
+            }
           }
         }
       }

--- a/tests/deck_railings.test.ts
+++ b/tests/deck_railings.test.ts
@@ -1,0 +1,134 @@
+// The shared plank-walkway builder (src/render/deck_render.ts) rails every
+// deck edge over the deck's whole length. Where two decks JOIN (the Palmreach
+// lagoon boardwalk meeting its pier at a T, the jungle-pool stair running into
+// its platform, the harbor stairs landing on the boardwalk) that laid a fence
+// straight across the walkway the player is meant to walk: at world
+// (-309, 947) the boardwalk's rails ran across the mouth of the pier.
+//
+// The rule pinned here: a rail post never stands on ANOTHER deck of the same
+// build batch, and dropping one breaks the rail run rather than stretching a
+// bar across the junction. Every other rail is untouched.
+import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
+import { buildDeckWood, deckRailRuns } from '../src/render/deck_render';
+import { GALE_HARBOR_DECKS, type GaleDeckDef } from '../src/sim/gale_harbor';
+import { REACH_DECKS } from '../src/sim/reach_decks';
+import { terrainHeight, WATER_LEVEL } from '../src/sim/world';
+
+const SEED = 20061;
+// the lagoon sits on level shore: a flat world keeps the decks level, so the
+// rails under test are the railAll runs, not stair handrails
+const FLAT_GROUND = 2;
+const flat = (): number => FLAT_GROUND;
+
+interface RailPost {
+  x: number;
+  z: number;
+}
+
+/** Rail posts are the only 0.14 x 1.06 x 0.14 boxes the builder emits. */
+function railPosts(geoms: readonly THREE.BufferGeometry[]): RailPost[] {
+  const found: RailPost[] = [];
+  const size = new THREE.Vector3();
+  const center = new THREE.Vector3();
+  for (const g of geoms) {
+    g.computeBoundingBox();
+    const bb = g.boundingBox;
+    if (!bb) continue;
+    bb.getSize(size);
+    if (Math.abs(size.x - 0.14) > 1e-3) continue;
+    if (Math.abs(size.z - 0.14) > 1e-3) continue;
+    if (Math.abs(size.y - 1.06) > 1e-3) continue;
+    bb.getCenter(center);
+    found.push({ x: center.x, z: center.z });
+  }
+  return found;
+}
+
+/** Point in a deck's walkable rectangle (rotated rect, the groundHeight one). */
+function onDeck(deck: GaleDeckDef, x: number, z: number): boolean {
+  const dx = x - deck.x;
+  const dz = z - deck.z;
+  const dirx = Math.sin(deck.rot);
+  const dirz = Math.cos(deck.rot);
+  const along = dx * dirx + dz * dirz;
+  const across = dx * dirz - dz * dirx;
+  return Math.abs(along) <= deck.hl && Math.abs(across) <= deck.hw;
+}
+
+function straddling(decks: readonly GaleDeckDef[], posts: readonly RailPost[]): string[] {
+  return posts
+    .filter((p) => decks.filter((d) => onDeck(d, p.x, p.z)).length > 1)
+    .map((p) => `rail post@${p.x.toFixed(2)},${p.z.toFixed(2)}`);
+}
+
+const key = (p: RailPost): string => `${p.x.toFixed(4)},${p.z.toFixed(4)}`;
+
+describe('deck railings at walkway junctions', () => {
+  it('stands no rail post on a neighbouring deck of the same batch', () => {
+    const { posts } = buildDeckWood(REACH_DECKS, flat, 0, { railAll: true });
+    expect(straddling(REACH_DECKS, railPosts(posts))).toEqual([]);
+  });
+
+  it('leaves the lagoon pier railed on both long edges out over the water', () => {
+    const pier = REACH_DECKS[3];
+    const { posts } = buildDeckWood(REACH_DECKS, flat, 0, { railAll: true });
+    const seaward = railPosts(posts).filter((p) => p.x > -300 && onDeck(pier, p.x, p.z));
+    const north = seaward.filter((p) => p.z > pier.z);
+    const south = seaward.filter((p) => p.z < pier.z);
+    expect(north.length, 'north edge rail posts').toBeGreaterThanOrEqual(8);
+    expect(south.length, 'south edge rail posts').toBeGreaterThanOrEqual(8);
+  });
+
+  it('rails a lone deck exactly as it rails it inside the batch', () => {
+    // the Emerald Run bridge touches no other deck: batch or alone, same rails
+    const bridge = REACH_DECKS[0];
+    const alone = railPosts(buildDeckWood([bridge], flat, 0, { railAll: true }).posts);
+    const inBatch = railPosts(buildDeckWood(REACH_DECKS, flat, 0, { railAll: true }).posts).filter(
+      (p) => onDeck(bridge, p.x, p.z),
+    );
+    expect(alone.length, 'the lone bridge is fully railed').toBeGreaterThanOrEqual(20);
+    expect(inBatch.map(key).sort()).toEqual(alone.map(key).sort());
+  });
+
+  it('ends the rail run at the junction instead of spanning it', () => {
+    const boardwalk = REACH_DECKS[2];
+    const pier = REACH_DECKS[3];
+    for (const side of [1, -1]) {
+      const runs = deckRailRuns(boardwalk, side, REACH_DECKS);
+      expect(runs.length, `edge ${side} splits at the pier mouth`).toBeGreaterThanOrEqual(2);
+      expect(runs.flat().filter((p) => onDeck(pier, p.x, p.z))).toEqual([]);
+      for (const run of runs) {
+        for (let i = 0; i + 1 < run.length; i++) {
+          const gap = run[i + 1].along - run[i].along;
+          expect(gap, `gap inside a rail run on edge ${side}`).toBeLessThan(1.5);
+        }
+      }
+    }
+  });
+
+  it('draws no rail bar stretched across the junction gap', () => {
+    // the lagoon pair is axis aligned, so a rail bar's bounding box IS its span
+    const { posts } = buildDeckWood([REACH_DECKS[2], REACH_DECKS[3]], flat, 0, { railAll: true });
+    const size = new THREE.Vector3();
+    const spans: number[] = [];
+    for (const g of posts) {
+      g.computeBoundingBox();
+      const bb = g.boundingBox;
+      if (!bb) continue;
+      bb.getSize(size);
+      if (Math.abs(size.y - 0.1) > 1e-6) continue; // the two flat rail bars
+      spans.push(Math.max(size.x, size.z));
+    }
+    expect(spans.length, 'the lagoon decks keep their rail bars').toBeGreaterThanOrEqual(20);
+    expect(Math.max(...spans), 'longest rail bar').toBeLessThan(1.5);
+  });
+
+  it('keeps the harbor stair handrails, none of them on the boardwalk', () => {
+    const terrain = (x: number, z: number): number => terrainHeight(x, z, SEED);
+    const { posts } = buildDeckWood(GALE_HARBOR_DECKS, terrain, WATER_LEVEL, { bollards: true });
+    const rails = railPosts(posts);
+    expect(rails.length, 'the bluff stairs keep their handrails').toBeGreaterThanOrEqual(12);
+    expect(straddling(GALE_HARBOR_DECKS, rails)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Player report (PBE2): a stray railing renders across the mouth of the pond bridge at world (-309, 947) in The Palmreach.

Root cause: buildDeckWood (src/render/deck_render.ts) railed both long edges of every deck over the deck's full length with no junction awareness. The lagoon bridge is two GaleDeckDef walkways meeting in a T at a shared anchor (src/sim/reach_decks.ts): the shore boardwalk's rails ran straight across the pier's mouth, and the pier's rails ran back across the boardwalk, reading as a stray fence in front of the bridge.

Fix: rail posts now come from deckRailRuns, a pure generator that drops any rail point standing inside another deck of the same build batch (rotated rect test with a 0.55 yd margin) and ends the rail run there, so a rail bar is never stretched across the junction. Rails away from junctions, lone decks, and stair handrails produce positionally identical geometry to before.

Render only: walkable deck surfaces, colliders, and all sim paths are untouched. The same bug class is also cleaned up at the Palmreach jungle-pool platform and stair and at the Wickharbor bluff stair feet (a few posts disappear where those decks join; remaining handrails stay contiguous).

## Test plan
- [x] tests/deck_railings.test.ts (new): no rail post stands on another deck of its batch (failed before the fix with the exact stray posts at the lagoon T); the pier keeps at least 8 posts per edge seaward of the junction; an isolated deck rails identically alone and in a batch; runs split at junctions and no rail bar longer than 1.5 yd spans a gap; harbor stair handrails intact
- [x] tests/gale_harbor.test.ts, tests/reach_palms_cliffs.test.ts, tests/architecture.test.ts green
- [x] npx tsc --noEmit clean; biome clean on changed files
- [ ] Visual check on PBE2 at (-309, 947): bridge mouth open, side railings intact