### PR TITLE
fix(render): solid base under the beacon stair so the blocked volume reads as masonry

### DIFF
--- a/src/render/gale_features.ts
+++ b/src/render/gale_features.ts
@@ -2,8 +2,7 @@
 // head (a body of stacked crenellated KayKit tower drums under the blue
 // cap, with a slowly turning light, the realm's landmark from anywhere on
 // the downs, plus the grey stone stair the sim's beaconSpiralLift makes
-// walkable, hugging the column up to the C balcony, on the masonry plinth
-// that fills the volume the same lift field walls off), the stilt piers and
+// walkable, hugging the column up to the C balcony), the stilt piers and
 // boardwalk of Wickharbor's harbor (drawn from the SAME sim/gale_harbor.ts
 // decks the player walks, with steep ramps drawn as stepped stairs), and
 // the ribs of old hulls half-buried on the Wreckfields. Same contract as the sibling
@@ -117,10 +116,8 @@ export function buildGaleFeatures(seed: number): GaleFeaturesView {
     {
       const s = BEACON_SPIRAL;
       const stone = mat(0x8f959c, 0.95);
-      const baseStone = mat(0x7c828a, 0.95); // a shade darker so the treads read on it
       const iron = mat(0x4b4f56, 0.8);
       const slabs: THREE.BufferGeometry[] = [];
-      const piers: THREE.BufferGeometry[] = [];
       const rails: THREE.BufferGeometry[] = [];
       const deckAt = (x: number, z: number): number =>
         terrainHeight(x, z, seed) + beaconSpiralLift(x, z);
@@ -130,29 +127,6 @@ export function buildGaleFeatures(seed: number): GaleFeaturesView {
         g.rotateY(yaw);
         g.translate(x, h - 0.18, z);
         slabs.push(g.toNonIndexed());
-      };
-      // The masonry the climb rides on. beaconSpiralLift is a single-valued
-      // heightfield, so the ground under an elevated tread IS that tread's
-      // height: the whole column of air below a balcony is walled off by the
-      // climb gate. Left undrawn it is an invisible wall (a player on the lawn
-      // beside the tower is stopped by the upper balcony's rim 19yd overhead).
-      // Fill that volume with stone, lawn up into the tread above, so the
-      // blocked mass reads as the tower's plinth. Purely additive geometry:
-      // nothing walkable changes, and it is built unconditionally because this
-      // is the SHAPE OF THE COLLISION, never a graphics tier's richness.
-      const pier = (a: number, outR: number, w: number): void => {
-        const innerR = s.coreR - 0.4; // bite into the column face, never a hairline gap
-        const midR = (innerR + outR) / 2;
-        const x = s.x + Math.sin(a) * midR;
-        const z = s.z + Math.cos(a) * midR;
-        const top = deckAt(x, z) - 0.3; // up INTO the tread, so no faces are coplanar
-        const bot = terrainHeight(x, z, seed) - 0.6; // sunk under the lawn
-        const height = top - bot;
-        if (height < 0.5) return; // the stair foot: the treads already meet the lawn
-        const g = new THREE.BoxGeometry(w, height, outR - innerR);
-        g.rotateY(a);
-        g.translate(x, bot + height / 2, z);
-        piers.push(g.toNonIndexed());
       };
       // whether an unwrapped angle sits on a balcony (wide band) or a flight
       const onBalcony = (a: number): boolean =>
@@ -167,9 +141,13 @@ export function buildGaleFeatures(seed: number): GaleFeaturesView {
         const outR = balc ? s.balconyOut : s.stairOut;
         const midR = (s.coreR + outR) / 2;
         const a = s.a0 + rel;
-        const w = balc ? 0.95 : 0.62;
-        slab(s.x + Math.sin(a) * midR, s.z + Math.cos(a) * midR, w, outR - s.coreR, a);
-        pier(a, outR, w);
+        slab(
+          s.x + Math.sin(a) * midR,
+          s.z + Math.cos(a) * midR,
+          balc ? 0.95 : 0.62,
+          outR - s.coreR,
+          a,
+        );
       }
       // the handrail: posts along the outer edge, and a continuous helical
       // double rail sampled finely so it runs DIAGONALLY up the flights and
@@ -224,7 +202,6 @@ export function buildGaleFeatures(seed: number): GaleFeaturesView {
           );
         }
       }
-      group.add(mergeBoxes(piers, baseStone));
       group.add(mergeBoxes(slabs, stone));
       group.add(mergeBoxes(rails, iron));
     }

--- a/src/render/gale_features.ts
+++ b/src/render/gale_features.ts
@@ -2,7 +2,8 @@
 // head (a body of stacked crenellated KayKit tower drums under the blue
 // cap, with a slowly turning light, the realm's landmark from anywhere on
 // the downs, plus the grey stone stair the sim's beaconSpiralLift makes
-// walkable, hugging the column up to the C balcony), the stilt piers and
+// walkable, hugging the column up to the C balcony, on the masonry plinth
+// that fills the volume the same lift field walls off), the stilt piers and
 // boardwalk of Wickharbor's harbor (drawn from the SAME sim/gale_harbor.ts
 // decks the player walks, with steep ramps drawn as stepped stairs), and
 // the ribs of old hulls half-buried on the Wreckfields. Same contract as the sibling
@@ -116,8 +117,10 @@ export function buildGaleFeatures(seed: number): GaleFeaturesView {
     {
       const s = BEACON_SPIRAL;
       const stone = mat(0x8f959c, 0.95);
+      const baseStone = mat(0x7c828a, 0.95); // a shade darker so the treads read on it
       const iron = mat(0x4b4f56, 0.8);
       const slabs: THREE.BufferGeometry[] = [];
+      const piers: THREE.BufferGeometry[] = [];
       const rails: THREE.BufferGeometry[] = [];
       const deckAt = (x: number, z: number): number =>
         terrainHeight(x, z, seed) + beaconSpiralLift(x, z);
@@ -127,6 +130,29 @@ export function buildGaleFeatures(seed: number): GaleFeaturesView {
         g.rotateY(yaw);
         g.translate(x, h - 0.18, z);
         slabs.push(g.toNonIndexed());
+      };
+      // The masonry the climb rides on. beaconSpiralLift is a single-valued
+      // heightfield, so the ground under an elevated tread IS that tread's
+      // height: the whole column of air below a balcony is walled off by the
+      // climb gate. Left undrawn it is an invisible wall (a player on the lawn
+      // beside the tower is stopped by the upper balcony's rim 19yd overhead).
+      // Fill that volume with stone, lawn up into the tread above, so the
+      // blocked mass reads as the tower's plinth. Purely additive geometry:
+      // nothing walkable changes, and it is built unconditionally because this
+      // is the SHAPE OF THE COLLISION, never a graphics tier's richness.
+      const pier = (a: number, outR: number, w: number): void => {
+        const innerR = s.coreR - 0.4; // bite into the column face, never a hairline gap
+        const midR = (innerR + outR) / 2;
+        const x = s.x + Math.sin(a) * midR;
+        const z = s.z + Math.cos(a) * midR;
+        const top = deckAt(x, z) - 0.3; // up INTO the tread, so no faces are coplanar
+        const bot = terrainHeight(x, z, seed) - 0.6; // sunk under the lawn
+        const height = top - bot;
+        if (height < 0.5) return; // the stair foot: the treads already meet the lawn
+        const g = new THREE.BoxGeometry(w, height, outR - innerR);
+        g.rotateY(a);
+        g.translate(x, bot + height / 2, z);
+        piers.push(g.toNonIndexed());
       };
       // whether an unwrapped angle sits on a balcony (wide band) or a flight
       const onBalcony = (a: number): boolean =>
@@ -141,13 +167,9 @@ export function buildGaleFeatures(seed: number): GaleFeaturesView {
         const outR = balc ? s.balconyOut : s.stairOut;
         const midR = (s.coreR + outR) / 2;
         const a = s.a0 + rel;
-        slab(
-          s.x + Math.sin(a) * midR,
-          s.z + Math.cos(a) * midR,
-          balc ? 0.95 : 0.62,
-          outR - s.coreR,
-          a,
-        );
+        const w = balc ? 0.95 : 0.62;
+        slab(s.x + Math.sin(a) * midR, s.z + Math.cos(a) * midR, w, outR - s.coreR, a);
+        pier(a, outR, w);
       }
       // the handrail: posts along the outer edge, and a continuous helical
       // double rail sampled finely so it runs DIAGONALLY up the flights and
@@ -202,6 +224,7 @@ export function buildGaleFeatures(seed: number): GaleFeaturesView {
           );
         }
       }
+      group.add(mergeBoxes(piers, baseStone));
       group.add(mergeBoxes(slabs, stone));
       group.add(mergeBoxes(rails, iron));
     }

--- a/src/sim/beacon_spiral.ts
+++ b/src/sim/beacon_spiral.ts
@@ -10,8 +10,16 @@
 // so the deck the player stands on is exactly the deck they see. The
 // tower's own column is an unwalkable core plug (a sheer terrain riser the
 // climb gate refuses), which is also what keeps players from walking
-// through the lighthouse at ground level. Pure leaf: deterministic, no
-// SimContext, tested directly by tests/beacon_spiral.test.ts.
+// through the lighthouse at ground level.
+//
+// Because the lift IS the ground (groundHeight is single-valued), every yard
+// of walkable deck also blocks the ground beneath it: the footprint is a
+// wall at ground level, not a canopy to walk under. So the walkable envelope
+// is kept to ONE radius, stairOut, matching the drawn treads, and the
+// balconies' wider deck slabs are a cosmetic overhang only. Keep it that
+// way: widening the lift past the drawn stair puts an invisible wall out on
+// the open lawn. Pure leaf: deterministic, no SimContext, tested directly by
+// tests/beacon_spiral.test.ts and tests/beacon_stair_base.test.ts.
 
 export const BEACON_SPIRAL = {
   x: 498,
@@ -20,7 +28,12 @@ export const BEACON_SPIRAL = {
   coreR: 2.9,
   /** the plug's sheer height (never stood on, only refused) */
   coreH: 45,
-  /** stair outer radius; the inner edge is the column itself (coreR) */
+  /** The WALKABLE outer radius of the whole climb, flights and balconies
+   * alike; the inner edge is the column itself (coreR). groundHeight is
+   * single-valued, so every yard of this radius also walls off the ground
+   * ring beneath it: keep the collision envelope on the drawn treads
+   * (render/gale_features.ts builds them out to exactly this radius) and the
+   * lawn outside stays open. */
   stairOut: 6.5,
   /** where the stair leaves the lawn (radians, atan2(dx, dz) convention) */
   a0: 2.4,
@@ -36,7 +49,11 @@ export const BEACON_SPIRAL = {
   balcony1End: Math.PI * 2 * 0.42,
   flight2End: Math.PI * 2 * 0.76,
   balcony2End: Math.PI * 2 * 0.94,
-  /** balcony outer radius (both balconies reach wider than the stair) */
+  /** RENDER ONLY. The balcony deck slabs are drawn out to here, overhanging
+   * the walkable stair by 0.7yd: a cosmetic lip under the handrail that
+   * nobody stands on. Widening the LIFT to this radius is what put an
+   * unwalkable ring around the tower under open sky (a player on the lawn
+   * at (505, 305) was stopped by the upper balcony's rim 19yd overhead). */
   balconyOut: 7.2,
 } as const;
 
@@ -71,7 +88,7 @@ export function beaconSpiralLift(x: number, z: number): number {
   const s = BEACON_SPIRAL;
   const dx = x - s.x;
   const dz = z - s.z;
-  const gate = s.balconyOut + 0.6;
+  const gate = s.stairOut + 0.6;
   const d2 = dx * dx + dz * dz;
   if (d2 >= gate * gate) return 0;
   const d = Math.sqrt(d2);
@@ -80,8 +97,9 @@ export function beaconSpiralLift(x: number, z: number): number {
   let a = Math.atan2(dx, dz) - s.a0;
   a = ((a % (Math.PI * 2)) + Math.PI * 2) % (Math.PI * 2);
   if (a > s.balcony2End) return 0; // the mouth over the stair foot
-  const onBalcony =
-    (a > s.flight1End && a <= s.balcony1End) || (a > s.flight2End && a <= s.balcony2End);
-  if (d > (onBalcony ? s.balconyOut : s.stairOut)) return 0;
+  // ONE walkable radius for flights and balconies alike: the balconies are
+  // drawn wider (balconyOut) but that lip is cosmetic, so the ground ring
+  // around the tower is not walled off by a deck nobody can reach.
+  if (d > s.stairOut) return 0;
   return beaconDeckHeightAt(a);
 }

--- a/src/sim/beacon_spiral.ts
+++ b/src/sim/beacon_spiral.ts
@@ -10,16 +10,8 @@
 // so the deck the player stands on is exactly the deck they see. The
 // tower's own column is an unwalkable core plug (a sheer terrain riser the
 // climb gate refuses), which is also what keeps players from walking
-// through the lighthouse at ground level.
-//
-// Because the lift IS the ground (groundHeight is single-valued), every yard
-// of walkable deck also blocks the ground beneath it: the footprint is a
-// wall at ground level, not a canopy to walk under. So the walkable envelope
-// is kept to ONE radius, stairOut, matching the drawn treads, and the
-// balconies' wider deck slabs are a cosmetic overhang only. Keep it that
-// way: widening the lift past the drawn stair puts an invisible wall out on
-// the open lawn. Pure leaf: deterministic, no SimContext, tested directly by
-// tests/beacon_spiral.test.ts and tests/beacon_stair_base.test.ts.
+// through the lighthouse at ground level. Pure leaf: deterministic, no
+// SimContext, tested directly by tests/beacon_spiral.test.ts.
 
 export const BEACON_SPIRAL = {
   x: 498,
@@ -28,12 +20,7 @@ export const BEACON_SPIRAL = {
   coreR: 2.9,
   /** the plug's sheer height (never stood on, only refused) */
   coreH: 45,
-  /** The WALKABLE outer radius of the whole climb, flights and balconies
-   * alike; the inner edge is the column itself (coreR). groundHeight is
-   * single-valued, so every yard of this radius also walls off the ground
-   * ring beneath it: keep the collision envelope on the drawn treads
-   * (render/gale_features.ts builds them out to exactly this radius) and the
-   * lawn outside stays open. */
+  /** stair outer radius; the inner edge is the column itself (coreR) */
   stairOut: 6.5,
   /** where the stair leaves the lawn (radians, atan2(dx, dz) convention) */
   a0: 2.4,
@@ -49,11 +36,7 @@ export const BEACON_SPIRAL = {
   balcony1End: Math.PI * 2 * 0.42,
   flight2End: Math.PI * 2 * 0.76,
   balcony2End: Math.PI * 2 * 0.94,
-  /** RENDER ONLY. The balcony deck slabs are drawn out to here, overhanging
-   * the walkable stair by 0.7yd: a cosmetic lip under the handrail that
-   * nobody stands on. Widening the LIFT to this radius is what put an
-   * unwalkable ring around the tower under open sky (a player on the lawn
-   * at (505, 305) was stopped by the upper balcony's rim 19yd overhead). */
+  /** balcony outer radius (both balconies reach wider than the stair) */
   balconyOut: 7.2,
 } as const;
 
@@ -88,7 +71,7 @@ export function beaconSpiralLift(x: number, z: number): number {
   const s = BEACON_SPIRAL;
   const dx = x - s.x;
   const dz = z - s.z;
-  const gate = s.stairOut + 0.6;
+  const gate = s.balconyOut + 0.6;
   const d2 = dx * dx + dz * dz;
   if (d2 >= gate * gate) return 0;
   const d = Math.sqrt(d2);
@@ -97,9 +80,8 @@ export function beaconSpiralLift(x: number, z: number): number {
   let a = Math.atan2(dx, dz) - s.a0;
   a = ((a % (Math.PI * 2)) + Math.PI * 2) % (Math.PI * 2);
   if (a > s.balcony2End) return 0; // the mouth over the stair foot
-  // ONE walkable radius for flights and balconies alike: the balconies are
-  // drawn wider (balconyOut) but that lip is cosmetic, so the ground ring
-  // around the tower is not walled off by a deck nobody can reach.
-  if (d > s.stairOut) return 0;
+  const onBalcony =
+    (a > s.flight1End && a <= s.balcony1End) || (a > s.flight2End && a <= s.balcony2End);
+  if (d > (onBalcony ? s.balconyOut : s.stairOut)) return 0;
   return beaconDeckHeightAt(a);
 }

--- a/src/sim/content/galecrest.ts
+++ b/src/sim/content/galecrest.ts
@@ -641,7 +641,14 @@ export const GALECREST_PROPS: ZonePropsDef = {
     [432, 361], // the square's fire, in the lee of the market hall
     [196, 434], // the Windway's waycamp
     [455, 363], // the dockers' brazier behind the boardwalk
-    [498, 313], // Keeper Bram's brazier at the Beacon's foot
+    // Keeper Bram's brazier at the Beacon's foot: out on the lawn at d 8.5
+    // from the tower axis, clear of the spiral stair's footprint. Anywhere
+    // inside beaconSpiralLift's reach the brazier would sit UNDER the raised
+    // stair (props seat on terrainHeight, the stair on groundHeight), buried
+    // in the plinth masonry, and its collider (which has no height) would
+    // pinch the flight it stands beneath. It also stays off the stair-foot
+    // approach, which comes in around bearing 116 to 138 degrees.
+    [498, 316.5],
     [362, 633], // Salvager Edda's camp above the Wreckfields
   ],
   tents: [

--- a/tests/beacon_stair_base.test.ts
+++ b/tests/beacon_stair_base.test.ts
@@ -1,153 +1,187 @@
-// The Old Beacon's invisible wall (player report: stopped on the open lawn at
+// The Old Beacon's ground ring (player report: stopped on the open lawn at
 // (505, 305) with nothing on screen in the way). beaconSpiralLift is a
-// single-valued heightfield, so the ground under the upper balcony IS the
-// balcony's deck: the whole column of air below its rim is walled off by the
-// player climb gate, and the renderer drew only the deck slab 19yd overhead.
-// These pin the SIM side of that diagnosis (the wall is the lift rim, not a
-// collider and not terrain steepness, and every walled cell sits inside
-// balconyOut under deck2) and then assert the RENDER fix: the blocked volume
-// is solid stone on screen, while the stair-foot mouth stays open air.
+// single-valued heightfield, so every yard of walkable deck also walls off the
+// ground beneath it. The balconies used to lift out to balconyOut 7.2 while
+// the treads are only drawn to stairOut 6.5, so the outer 0.7yd was an
+// unwalkable ring under open sky. The lift now stops at the drawn tread
+// radius: these pin that the ring is walkable at every bearing, that the wall
+// begins only at the drawn envelope, that Keeper Bram's balcony spot is still
+// deck, and that no campfire sits inside the footprint.
 
-import * as THREE from 'three';
 import { describe, expect, it } from 'vitest';
-import { buildGaleFeatures } from '../src/render/gale_features';
 import { BEACON_SPIRAL, beaconSpiralLift } from '../src/sim/beacon_spiral';
 import { isBlocked } from '../src/sim/colliders';
 import { GALECREST_PROPS } from '../src/sim/content/galecrest';
 import { PLAYER_BODY_RADIUS, PLAYER_MAX_CLIMB_SLOPE } from '../src/sim/pathfind';
 import { rideSteepnessAt } from '../src/sim/ride_height';
+import { Sim } from '../src/sim/sim';
 import { groundHeight, terrainHeight } from '../src/sim/world';
 
 const SEED = 20061;
 const S = BEACON_SPIRAL;
 const SPOT = { x: 505, z: 305 }; // the reported spot, open lawn beside the tower
-const RUN_STEP = 0.35; // one 20Hz tick of run
+const BRAM_DECK = { x: 503, z: 309 }; // Keeper Bram's authored post on the upper balcony
+const DT = 1 / 20;
+const RUN_SPEED = 7;
 
 const at = (bearing: number, r: number): { x: number; z: number } => ({
   x: S.x + Math.sin(bearing) * r,
   z: S.z + Math.cos(bearing) * r,
 });
+const axisD = (x: number, z: number): number => Math.hypot(x - S.x, z - S.z);
 const spotBearing = Math.atan2(SPOT.x - S.x, SPOT.z - S.z);
-const spotR = Math.hypot(SPOT.x - S.x, SPOT.z - S.z);
+const spotR = axisD(SPOT.x, SPOT.z);
 
-let built: ReturnType<typeof buildGaleFeatures> | null = null;
-const galeFeatures = (): ReturnType<typeof buildGaleFeatures> => {
-  built ??= buildGaleFeatures(SEED);
-  return built;
+// The player movement gate (player_motion.ts): an uphill step is refused when
+// the step itself or its destination gradient beats the climb limit. Replicated
+// rather than imported so a walk can be probed without driving a whole Sim.
+const climbRefused = (px: number, pz: number, nx: number, nz: number): boolean => {
+  const r0 = groundHeight(px, pz, SEED);
+  const r1 = groundHeight(nx, nz, SEED);
+  if (r1 <= r0) return false;
+  const run = Math.hypot(nx - px, nz - pz);
+  return (
+    (r1 - r0) / run > PLAYER_MAX_CLIMB_SLOPE ||
+    rideSteepnessAt(nx, nz, SEED) > PLAYER_MAX_CLIMB_SLOPE
+  );
+};
+const stepRefused = (px: number, pz: number, nx: number, nz: number): boolean =>
+  isBlocked(SEED, nx, nz, PLAYER_BODY_RADIUS) || climbRefused(px, pz, nx, nz);
+
+// Walk a straight line, returning where it stopped (null = never stopped).
+const walk = (
+  x0: number,
+  z0: number,
+  dirX: number,
+  dirZ: number,
+  ticks: number,
+  refuse = stepRefused,
+): { x: number; z: number; stoppedAt: number | null; closest: number } => {
+  let px = x0;
+  let pz = z0;
+  let closest = axisD(px, pz);
+  for (let t = 0; t < ticks; t++) {
+    const nx = px + dirX * RUN_SPEED * DT;
+    const nz = pz + dirZ * RUN_SPEED * DT;
+    if (refuse(px, pz, nx, nz)) return { x: px, z: pz, stoppedAt: axisD(nx, nz), closest };
+    px = nx;
+    pz = nz;
+    closest = Math.min(closest, axisD(px, pz));
+  }
+  return { x: px, z: pz, stoppedAt: null, closest };
 };
 
-describe('the Old Beacon stair base', () => {
-  it('the reported spot is open lawn a step or two outside the upper balcony rim', () => {
+describe('the Old Beacon ground ring', () => {
+  it('the reported spot is open lawn, blocked by nothing', () => {
     expect(spotR).toBeCloseTo(7.616, 3);
-    expect(spotR).toBeGreaterThan(S.balconyOut);
-    expect(spotR - S.balconyOut).toBeLessThan(2 * RUN_STEP);
     expect(beaconSpiralLift(SPOT.x, SPOT.z)).toBe(0);
+    expect(groundHeight(SPOT.x, SPOT.z, SEED)).toBeCloseTo(terrainHeight(SPOT.x, SPOT.z, SEED), 5);
     expect(isBlocked(SEED, SPOT.x, SPOT.z, PLAYER_BODY_RADIUS)).toBe(false);
     expect(rideSteepnessAt(SPOT.x, SPOT.z, SEED)).toBeLessThan(PLAYER_MAX_CLIMB_SLOPE);
   });
 
-  it('the wall is the lift rim alone: no collider, no terrain steepness', () => {
-    const outside = at(spotBearing, S.balconyOut + 0.05);
-    const inside = at(spotBearing, S.balconyOut - 0.05);
-    expect(beaconSpiralLift(outside.x, outside.z)).toBe(0);
-    expect(beaconSpiralLift(inside.x, inside.z)).toBeCloseTo(S.deck2, 5);
+  it('walks the reported path past the tower without stopping', () => {
+    // due north and due south along x=505, grazing the tower at d 7.0: both
+    // used to stop dead at d 7.17 against the upper balcony's rim
+    const north = walk(SPOT.x, 298, 0, 1, 80);
+    expect(north.stoppedAt, 'northbound stop').toBeNull();
+    expect(north.z).toBeGreaterThan(312);
+    expect(north.closest).toBeLessThan(S.balconyOut);
 
-    const rise = groundHeight(inside.x, inside.z, SEED) - groundHeight(outside.x, outside.z, SEED);
-    expect(rise).toBeCloseTo(S.deck2, 2);
-    expect(rise / 0.1).toBeGreaterThan(PLAYER_MAX_CLIMB_SLOPE);
-
-    for (const p of [outside, inside]) {
-      expect(isBlocked(SEED, p.x, p.z, PLAYER_BODY_RADIUS)).toBe(false);
-      expect(rideSteepnessAt(p.x, p.z, SEED)).toBeLessThan(PLAYER_MAX_CLIMB_SLOPE);
-    }
-    const terrainStep = Math.abs(
-      terrainHeight(inside.x, inside.z, SEED) - terrainHeight(outside.x, outside.z, SEED),
-    );
-    expect(terrainStep).toBeLessThan(0.05);
+    const south = walk(SPOT.x, 312, 0, -1, 80);
+    expect(south.stoppedAt, 'southbound stop').toBeNull();
+    expect(south.z).toBeLessThan(298);
+    expect(south.closest).toBeLessThan(S.balconyOut);
   });
 
-  it('every walled cell sits inside balconyOut and under deck2', () => {
+  it('a real player (the live kernel through Sim.tick) walks the ring past the tower', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', autoEquip: true });
+    const p = sim.player;
+    p.pos.x = SPOT.x;
+    p.pos.z = 298;
+    p.pos.y = groundHeight(p.pos.x, p.pos.z, SEED);
+    p.prevPos = { ...p.pos };
+    const goal = { x: SPOT.x, z: 314 };
+    let closest = axisD(p.pos.x, p.pos.z);
+    for (let i = 0; i < 20 * 12; i++) {
+      p.facing = Math.atan2(goal.x - p.pos.x, goal.z - p.pos.z);
+      sim.moveInput.forward = true;
+      sim.tick();
+      closest = Math.min(closest, axisD(p.pos.x, p.pos.z));
+      if (Math.hypot(p.pos.x - goal.x, p.pos.z - goal.z) < 0.7) break;
+    }
+    sim.moveInput.forward = false;
+    expect(p.pos.z, 'walked past the tower').toBeGreaterThan(312);
+    expect(closest, 'grazed inside the old balcony rim').toBeLessThan(S.balconyOut);
+  });
+
+  it('the whole ground ring outside the drawn treads is open at every bearing', () => {
+    for (let i = 0; i < 360; i++) {
+      const bearing = (i / 360) * Math.PI * 2;
+      for (let r = S.stairOut + 0.05; r <= 7.6001; r += 0.05) {
+        const p = at(bearing, r);
+        expect(beaconSpiralLift(p.x, p.z), `lift at bearing ${i}, r ${r.toFixed(2)}`).toBe(0);
+      }
+      // and a tangential lawn walk at the old rim radius meets no terrain wall
+      // (props like the brazier are real visible obstacles, so the climb gate
+      // alone is what this sweep is about)
+      const graze = at(bearing, S.balconyOut);
+      const pass = walk(graze.x, graze.z, Math.cos(bearing), -Math.sin(bearing), 24, climbRefused);
+      expect(pass.stoppedAt, `tangential walk at bearing ${i}`).toBeNull();
+    }
+  });
+
+  it('the wall begins only at the drawn tread envelope', () => {
     let widest = 0;
-    let tallest = 0;
     for (let i = 0; i < 720; i++) {
       const bearing = (i / 720) * Math.PI * 2;
       for (let r = S.coreR + 0.05; r <= S.balconyOut + 1.2; r += 0.02) {
         const p = at(bearing, r);
-        const lift = beaconSpiralLift(p.x, p.z);
-        if (lift <= 0) continue;
-        if (r > widest) widest = r;
-        if (lift > tallest) tallest = lift;
+        if (beaconSpiralLift(p.x, p.z) > 0) widest = Math.max(widest, r);
       }
     }
-    expect(widest).toBeLessThanOrEqual(S.balconyOut);
-    expect(tallest).toBeCloseTo(S.deck2, 5);
+    // the renderer builds the treads to exactly stairOut, so collision and the
+    // drawn stair share one edge; balconyOut is a cosmetic overhang only
+    expect(widest).toBeGreaterThan(S.stairOut - 0.05);
+    expect(widest).toBeLessThanOrEqual(S.stairOut);
+    expect(S.balconyOut).toBeGreaterThan(S.stairOut);
+
+    // and the refusal there is the lift alone: no collider, no terrain steepness
+    const inside = at(spotBearing, S.stairOut - 0.05);
+    const outside = at(spotBearing, S.stairOut + 0.05);
+    expect(beaconSpiralLift(inside.x, inside.z)).toBeCloseTo(S.deck2, 5);
+    expect(beaconSpiralLift(outside.x, outside.z)).toBe(0);
+    for (const p of [inside, outside]) {
+      expect(isBlocked(SEED, p.x, p.z, PLAYER_BODY_RADIUS)).toBe(false);
+      expect(rideSteepnessAt(p.x, p.z, SEED)).toBeLessThan(PLAYER_MAX_CLIMB_SLOPE);
+    }
+    expect(
+      Math.abs(terrainHeight(inside.x, inside.z, SEED) - terrainHeight(outside.x, outside.z, SEED)),
+    ).toBeLessThan(0.05);
+  });
+
+  it("keeps Keeper Bram's post on the upper balcony deck", () => {
+    expect(axisD(BRAM_DECK.x, BRAM_DECK.z)).toBeCloseTo(5.099, 3);
+    expect(beaconSpiralLift(BRAM_DECK.x, BRAM_DECK.z)).toBe(S.deck2);
+    // with real clearance inboard of the walkable edge, not riding it
+    expect(S.stairOut - axisD(BRAM_DECK.x, BRAM_DECK.z)).toBeGreaterThan(1);
   });
 
   it('keeps every nearby campfire out of the stair footprint', () => {
-    const near = GALECREST_PROPS.campfires.filter(([x, z]) => Math.hypot(x - S.x, z - S.z) < 12);
+    const near = GALECREST_PROPS.campfires.filter(([x, z]) => axisD(x, z) < 12);
     expect(near.length).toBeGreaterThan(0);
     for (const [x, z] of near) {
-      const d = Math.hypot(x - S.x, z - S.z);
       // props seat on terrainHeight while the stair rides groundHeight, so a
-      // campfire inside the lift footprint is buried in the plinth AND its
+      // campfire inside the lift footprint is buried under the deck AND its
       // height-less collider pinches the flight overhead
       expect(beaconSpiralLift(x, z), `campfire (${x}, ${z}) under the stair`).toBe(0);
       expect(groundHeight(x, z, SEED)).toBeCloseTo(terrainHeight(x, z, SEED), 5);
-      expect(d, `campfire (${x}, ${z}) inside the lift gate`).toBeGreaterThan(S.balconyOut + 0.6);
+      expect(axisD(x, z), `campfire (${x}, ${z}) inside the lift gate`).toBeGreaterThan(
+        S.stairOut + 0.6,
+      );
       // and off the stair-foot approach, which the mouth leaves open
       const bearing = ((Math.atan2(x - S.x, z - S.z) * 180) / Math.PI + 360) % 360;
       expect(bearing < 116 || bearing > 138, `campfire (${x}, ${z}) in the mouth`).toBe(true);
     }
-  });
-
-  it('draws the blocked volume as solid stone from the lawn up', () => {
-    const view = galeFeatures();
-    const lawnY = terrainHeight(SPOT.x, SPOT.z, SEED);
-    const inward = new THREE.Vector3(S.x - SPOT.x, 0, S.z - SPOT.z).normalize();
-    for (const eye of [0.6, 1.4, 6, 12, 17, 18.5]) {
-      const ray = new THREE.Raycaster(new THREE.Vector3(SPOT.x, lawnY + eye, SPOT.z), inward, 0, 4);
-      const hits = ray.intersectObject(view.group, true);
-      expect(hits.length, `masonry at eye ${eye}`).toBeGreaterThan(0);
-      expect(hits[0].distance, `rim face at eye ${eye}`).toBeCloseTo(spotR - S.balconyOut, 1);
-    }
-  });
-
-  it('never draws masonry wider than the rim that blocks the step', () => {
-    const view = galeFeatures();
-    let widest = 0;
-    for (let i = 0; i < 360; i++) {
-      const bearing = (i / 360) * Math.PI * 2;
-      const o = at(bearing, 12);
-      const ray = new THREE.Raycaster(
-        new THREE.Vector3(o.x, terrainHeight(o.x, o.z, SEED) + 1, o.z),
-        new THREE.Vector3(S.x - o.x, 0, S.z - o.z).normalize(),
-        0,
-        12 - S.coreR,
-      );
-      const hits = ray.intersectObject(view.group, true);
-      if (hits.length) widest = Math.max(widest, 12 - hits[0].distance);
-    }
-    expect(widest).toBeGreaterThan(S.balconyOut - 0.1);
-    expect(widest).toBeLessThan(S.balconyOut + 0.1);
-  });
-
-  it('leaves the stair-foot mouth open air, so the approach is unchanged', () => {
-    const view = galeFeatures();
-    const mouthBearing = S.a0 + (S.balcony2End + Math.PI * 2) / 2;
-    const start = at(mouthBearing, S.balconyOut + 0.6);
-    const end = at(mouthBearing, S.coreR + 0.4);
-    expect(beaconSpiralLift(start.x, start.z)).toBe(0);
-    expect(beaconSpiralLift(end.x, end.z)).toBe(0);
-
-    const lawnY = terrainHeight(start.x, start.z, SEED);
-    const inward = new THREE.Vector3(S.x - start.x, 0, S.z - start.z).normalize();
-    const reach = S.balconyOut + 0.6 - (S.coreR + 0.4);
-    const ray = new THREE.Raycaster(
-      new THREE.Vector3(start.x, lawnY + 1.4, start.z),
-      inward,
-      0,
-      reach,
-    );
-    expect(ray.intersectObject(view.group, true).length).toBe(0);
   });
 });

--- a/tests/beacon_stair_base.test.ts
+++ b/tests/beacon_stair_base.test.ts
@@ -1,187 +1,153 @@
-// The Old Beacon's ground ring (player report: stopped on the open lawn at
+// The Old Beacon's invisible wall (player report: stopped on the open lawn at
 // (505, 305) with nothing on screen in the way). beaconSpiralLift is a
-// single-valued heightfield, so every yard of walkable deck also walls off the
-// ground beneath it. The balconies used to lift out to balconyOut 7.2 while
-// the treads are only drawn to stairOut 6.5, so the outer 0.7yd was an
-// unwalkable ring under open sky. The lift now stops at the drawn tread
-// radius: these pin that the ring is walkable at every bearing, that the wall
-// begins only at the drawn envelope, that Keeper Bram's balcony spot is still
-// deck, and that no campfire sits inside the footprint.
+// single-valued heightfield, so the ground under the upper balcony IS the
+// balcony's deck: the whole column of air below its rim is walled off by the
+// player climb gate, and the renderer drew only the deck slab 19yd overhead.
+// These pin the SIM side of that diagnosis (the wall is the lift rim, not a
+// collider and not terrain steepness, and every walled cell sits inside
+// balconyOut under deck2) and then assert the RENDER fix: the blocked volume
+// is solid stone on screen, while the stair-foot mouth stays open air.
 
+import * as THREE from 'three';
 import { describe, expect, it } from 'vitest';
+import { buildGaleFeatures } from '../src/render/gale_features';
 import { BEACON_SPIRAL, beaconSpiralLift } from '../src/sim/beacon_spiral';
 import { isBlocked } from '../src/sim/colliders';
 import { GALECREST_PROPS } from '../src/sim/content/galecrest';
 import { PLAYER_BODY_RADIUS, PLAYER_MAX_CLIMB_SLOPE } from '../src/sim/pathfind';
 import { rideSteepnessAt } from '../src/sim/ride_height';
-import { Sim } from '../src/sim/sim';
 import { groundHeight, terrainHeight } from '../src/sim/world';
 
 const SEED = 20061;
 const S = BEACON_SPIRAL;
 const SPOT = { x: 505, z: 305 }; // the reported spot, open lawn beside the tower
-const BRAM_DECK = { x: 503, z: 309 }; // Keeper Bram's authored post on the upper balcony
-const DT = 1 / 20;
-const RUN_SPEED = 7;
+const RUN_STEP = 0.35; // one 20Hz tick of run
 
 const at = (bearing: number, r: number): { x: number; z: number } => ({
   x: S.x + Math.sin(bearing) * r,
   z: S.z + Math.cos(bearing) * r,
 });
-const axisD = (x: number, z: number): number => Math.hypot(x - S.x, z - S.z);
 const spotBearing = Math.atan2(SPOT.x - S.x, SPOT.z - S.z);
-const spotR = axisD(SPOT.x, SPOT.z);
+const spotR = Math.hypot(SPOT.x - S.x, SPOT.z - S.z);
 
-// The player movement gate (player_motion.ts): an uphill step is refused when
-// the step itself or its destination gradient beats the climb limit. Replicated
-// rather than imported so a walk can be probed without driving a whole Sim.
-const climbRefused = (px: number, pz: number, nx: number, nz: number): boolean => {
-  const r0 = groundHeight(px, pz, SEED);
-  const r1 = groundHeight(nx, nz, SEED);
-  if (r1 <= r0) return false;
-  const run = Math.hypot(nx - px, nz - pz);
-  return (
-    (r1 - r0) / run > PLAYER_MAX_CLIMB_SLOPE ||
-    rideSteepnessAt(nx, nz, SEED) > PLAYER_MAX_CLIMB_SLOPE
-  );
-};
-const stepRefused = (px: number, pz: number, nx: number, nz: number): boolean =>
-  isBlocked(SEED, nx, nz, PLAYER_BODY_RADIUS) || climbRefused(px, pz, nx, nz);
-
-// Walk a straight line, returning where it stopped (null = never stopped).
-const walk = (
-  x0: number,
-  z0: number,
-  dirX: number,
-  dirZ: number,
-  ticks: number,
-  refuse = stepRefused,
-): { x: number; z: number; stoppedAt: number | null; closest: number } => {
-  let px = x0;
-  let pz = z0;
-  let closest = axisD(px, pz);
-  for (let t = 0; t < ticks; t++) {
-    const nx = px + dirX * RUN_SPEED * DT;
-    const nz = pz + dirZ * RUN_SPEED * DT;
-    if (refuse(px, pz, nx, nz)) return { x: px, z: pz, stoppedAt: axisD(nx, nz), closest };
-    px = nx;
-    pz = nz;
-    closest = Math.min(closest, axisD(px, pz));
-  }
-  return { x: px, z: pz, stoppedAt: null, closest };
+let built: ReturnType<typeof buildGaleFeatures> | null = null;
+const galeFeatures = (): ReturnType<typeof buildGaleFeatures> => {
+  built ??= buildGaleFeatures(SEED);
+  return built;
 };
 
-describe('the Old Beacon ground ring', () => {
-  it('the reported spot is open lawn, blocked by nothing', () => {
+describe('the Old Beacon stair base', () => {
+  it('the reported spot is open lawn a step or two outside the upper balcony rim', () => {
     expect(spotR).toBeCloseTo(7.616, 3);
+    expect(spotR).toBeGreaterThan(S.balconyOut);
+    expect(spotR - S.balconyOut).toBeLessThan(2 * RUN_STEP);
     expect(beaconSpiralLift(SPOT.x, SPOT.z)).toBe(0);
-    expect(groundHeight(SPOT.x, SPOT.z, SEED)).toBeCloseTo(terrainHeight(SPOT.x, SPOT.z, SEED), 5);
     expect(isBlocked(SEED, SPOT.x, SPOT.z, PLAYER_BODY_RADIUS)).toBe(false);
     expect(rideSteepnessAt(SPOT.x, SPOT.z, SEED)).toBeLessThan(PLAYER_MAX_CLIMB_SLOPE);
   });
 
-  it('walks the reported path past the tower without stopping', () => {
-    // due north and due south along x=505, grazing the tower at d 7.0: both
-    // used to stop dead at d 7.17 against the upper balcony's rim
-    const north = walk(SPOT.x, 298, 0, 1, 80);
-    expect(north.stoppedAt, 'northbound stop').toBeNull();
-    expect(north.z).toBeGreaterThan(312);
-    expect(north.closest).toBeLessThan(S.balconyOut);
+  it('the wall is the lift rim alone: no collider, no terrain steepness', () => {
+    const outside = at(spotBearing, S.balconyOut + 0.05);
+    const inside = at(spotBearing, S.balconyOut - 0.05);
+    expect(beaconSpiralLift(outside.x, outside.z)).toBe(0);
+    expect(beaconSpiralLift(inside.x, inside.z)).toBeCloseTo(S.deck2, 5);
 
-    const south = walk(SPOT.x, 312, 0, -1, 80);
-    expect(south.stoppedAt, 'southbound stop').toBeNull();
-    expect(south.z).toBeLessThan(298);
-    expect(south.closest).toBeLessThan(S.balconyOut);
-  });
+    const rise = groundHeight(inside.x, inside.z, SEED) - groundHeight(outside.x, outside.z, SEED);
+    expect(rise).toBeCloseTo(S.deck2, 2);
+    expect(rise / 0.1).toBeGreaterThan(PLAYER_MAX_CLIMB_SLOPE);
 
-  it('a real player (the live kernel through Sim.tick) walks the ring past the tower', () => {
-    const sim = new Sim({ seed: SEED, playerClass: 'warrior', autoEquip: true });
-    const p = sim.player;
-    p.pos.x = SPOT.x;
-    p.pos.z = 298;
-    p.pos.y = groundHeight(p.pos.x, p.pos.z, SEED);
-    p.prevPos = { ...p.pos };
-    const goal = { x: SPOT.x, z: 314 };
-    let closest = axisD(p.pos.x, p.pos.z);
-    for (let i = 0; i < 20 * 12; i++) {
-      p.facing = Math.atan2(goal.x - p.pos.x, goal.z - p.pos.z);
-      sim.moveInput.forward = true;
-      sim.tick();
-      closest = Math.min(closest, axisD(p.pos.x, p.pos.z));
-      if (Math.hypot(p.pos.x - goal.x, p.pos.z - goal.z) < 0.7) break;
+    for (const p of [outside, inside]) {
+      expect(isBlocked(SEED, p.x, p.z, PLAYER_BODY_RADIUS)).toBe(false);
+      expect(rideSteepnessAt(p.x, p.z, SEED)).toBeLessThan(PLAYER_MAX_CLIMB_SLOPE);
     }
-    sim.moveInput.forward = false;
-    expect(p.pos.z, 'walked past the tower').toBeGreaterThan(312);
-    expect(closest, 'grazed inside the old balcony rim').toBeLessThan(S.balconyOut);
+    const terrainStep = Math.abs(
+      terrainHeight(inside.x, inside.z, SEED) - terrainHeight(outside.x, outside.z, SEED),
+    );
+    expect(terrainStep).toBeLessThan(0.05);
   });
 
-  it('the whole ground ring outside the drawn treads is open at every bearing', () => {
-    for (let i = 0; i < 360; i++) {
-      const bearing = (i / 360) * Math.PI * 2;
-      for (let r = S.stairOut + 0.05; r <= 7.6001; r += 0.05) {
-        const p = at(bearing, r);
-        expect(beaconSpiralLift(p.x, p.z), `lift at bearing ${i}, r ${r.toFixed(2)}`).toBe(0);
-      }
-      // and a tangential lawn walk at the old rim radius meets no terrain wall
-      // (props like the brazier are real visible obstacles, so the climb gate
-      // alone is what this sweep is about)
-      const graze = at(bearing, S.balconyOut);
-      const pass = walk(graze.x, graze.z, Math.cos(bearing), -Math.sin(bearing), 24, climbRefused);
-      expect(pass.stoppedAt, `tangential walk at bearing ${i}`).toBeNull();
-    }
-  });
-
-  it('the wall begins only at the drawn tread envelope', () => {
+  it('every walled cell sits inside balconyOut and under deck2', () => {
     let widest = 0;
+    let tallest = 0;
     for (let i = 0; i < 720; i++) {
       const bearing = (i / 720) * Math.PI * 2;
       for (let r = S.coreR + 0.05; r <= S.balconyOut + 1.2; r += 0.02) {
         const p = at(bearing, r);
-        if (beaconSpiralLift(p.x, p.z) > 0) widest = Math.max(widest, r);
+        const lift = beaconSpiralLift(p.x, p.z);
+        if (lift <= 0) continue;
+        if (r > widest) widest = r;
+        if (lift > tallest) tallest = lift;
       }
     }
-    // the renderer builds the treads to exactly stairOut, so collision and the
-    // drawn stair share one edge; balconyOut is a cosmetic overhang only
-    expect(widest).toBeGreaterThan(S.stairOut - 0.05);
-    expect(widest).toBeLessThanOrEqual(S.stairOut);
-    expect(S.balconyOut).toBeGreaterThan(S.stairOut);
-
-    // and the refusal there is the lift alone: no collider, no terrain steepness
-    const inside = at(spotBearing, S.stairOut - 0.05);
-    const outside = at(spotBearing, S.stairOut + 0.05);
-    expect(beaconSpiralLift(inside.x, inside.z)).toBeCloseTo(S.deck2, 5);
-    expect(beaconSpiralLift(outside.x, outside.z)).toBe(0);
-    for (const p of [inside, outside]) {
-      expect(isBlocked(SEED, p.x, p.z, PLAYER_BODY_RADIUS)).toBe(false);
-      expect(rideSteepnessAt(p.x, p.z, SEED)).toBeLessThan(PLAYER_MAX_CLIMB_SLOPE);
-    }
-    expect(
-      Math.abs(terrainHeight(inside.x, inside.z, SEED) - terrainHeight(outside.x, outside.z, SEED)),
-    ).toBeLessThan(0.05);
-  });
-
-  it("keeps Keeper Bram's post on the upper balcony deck", () => {
-    expect(axisD(BRAM_DECK.x, BRAM_DECK.z)).toBeCloseTo(5.099, 3);
-    expect(beaconSpiralLift(BRAM_DECK.x, BRAM_DECK.z)).toBe(S.deck2);
-    // with real clearance inboard of the walkable edge, not riding it
-    expect(S.stairOut - axisD(BRAM_DECK.x, BRAM_DECK.z)).toBeGreaterThan(1);
+    expect(widest).toBeLessThanOrEqual(S.balconyOut);
+    expect(tallest).toBeCloseTo(S.deck2, 5);
   });
 
   it('keeps every nearby campfire out of the stair footprint', () => {
-    const near = GALECREST_PROPS.campfires.filter(([x, z]) => axisD(x, z) < 12);
+    const near = GALECREST_PROPS.campfires.filter(([x, z]) => Math.hypot(x - S.x, z - S.z) < 12);
     expect(near.length).toBeGreaterThan(0);
     for (const [x, z] of near) {
+      const d = Math.hypot(x - S.x, z - S.z);
       // props seat on terrainHeight while the stair rides groundHeight, so a
-      // campfire inside the lift footprint is buried under the deck AND its
+      // campfire inside the lift footprint is buried in the plinth AND its
       // height-less collider pinches the flight overhead
       expect(beaconSpiralLift(x, z), `campfire (${x}, ${z}) under the stair`).toBe(0);
       expect(groundHeight(x, z, SEED)).toBeCloseTo(terrainHeight(x, z, SEED), 5);
-      expect(axisD(x, z), `campfire (${x}, ${z}) inside the lift gate`).toBeGreaterThan(
-        S.stairOut + 0.6,
-      );
+      expect(d, `campfire (${x}, ${z}) inside the lift gate`).toBeGreaterThan(S.balconyOut + 0.6);
       // and off the stair-foot approach, which the mouth leaves open
       const bearing = ((Math.atan2(x - S.x, z - S.z) * 180) / Math.PI + 360) % 360;
       expect(bearing < 116 || bearing > 138, `campfire (${x}, ${z}) in the mouth`).toBe(true);
     }
+  });
+
+  it('draws the blocked volume as solid stone from the lawn up', () => {
+    const view = galeFeatures();
+    const lawnY = terrainHeight(SPOT.x, SPOT.z, SEED);
+    const inward = new THREE.Vector3(S.x - SPOT.x, 0, S.z - SPOT.z).normalize();
+    for (const eye of [0.6, 1.4, 6, 12, 17, 18.5]) {
+      const ray = new THREE.Raycaster(new THREE.Vector3(SPOT.x, lawnY + eye, SPOT.z), inward, 0, 4);
+      const hits = ray.intersectObject(view.group, true);
+      expect(hits.length, `masonry at eye ${eye}`).toBeGreaterThan(0);
+      expect(hits[0].distance, `rim face at eye ${eye}`).toBeCloseTo(spotR - S.balconyOut, 1);
+    }
+  });
+
+  it('never draws masonry wider than the rim that blocks the step', () => {
+    const view = galeFeatures();
+    let widest = 0;
+    for (let i = 0; i < 360; i++) {
+      const bearing = (i / 360) * Math.PI * 2;
+      const o = at(bearing, 12);
+      const ray = new THREE.Raycaster(
+        new THREE.Vector3(o.x, terrainHeight(o.x, o.z, SEED) + 1, o.z),
+        new THREE.Vector3(S.x - o.x, 0, S.z - o.z).normalize(),
+        0,
+        12 - S.coreR,
+      );
+      const hits = ray.intersectObject(view.group, true);
+      if (hits.length) widest = Math.max(widest, 12 - hits[0].distance);
+    }
+    expect(widest).toBeGreaterThan(S.balconyOut - 0.1);
+    expect(widest).toBeLessThan(S.balconyOut + 0.1);
+  });
+
+  it('leaves the stair-foot mouth open air, so the approach is unchanged', () => {
+    const view = galeFeatures();
+    const mouthBearing = S.a0 + (S.balcony2End + Math.PI * 2) / 2;
+    const start = at(mouthBearing, S.balconyOut + 0.6);
+    const end = at(mouthBearing, S.coreR + 0.4);
+    expect(beaconSpiralLift(start.x, start.z)).toBe(0);
+    expect(beaconSpiralLift(end.x, end.z)).toBe(0);
+
+    const lawnY = terrainHeight(start.x, start.z, SEED);
+    const inward = new THREE.Vector3(S.x - start.x, 0, S.z - start.z).normalize();
+    const reach = S.balconyOut + 0.6 - (S.coreR + 0.4);
+    const ray = new THREE.Raycaster(
+      new THREE.Vector3(start.x, lawnY + 1.4, start.z),
+      inward,
+      0,
+      reach,
+    );
+    expect(ray.intersectObject(view.group, true).length).toBe(0);
   });
 });

--- a/tests/beacon_stair_base.test.ts
+++ b/tests/beacon_stair_base.test.ts
@@ -1,0 +1,153 @@
+// The Old Beacon's invisible wall (player report: stopped on the open lawn at
+// (505, 305) with nothing on screen in the way). beaconSpiralLift is a
+// single-valued heightfield, so the ground under the upper balcony IS the
+// balcony's deck: the whole column of air below its rim is walled off by the
+// player climb gate, and the renderer drew only the deck slab 19yd overhead.
+// These pin the SIM side of that diagnosis (the wall is the lift rim, not a
+// collider and not terrain steepness, and every walled cell sits inside
+// balconyOut under deck2) and then assert the RENDER fix: the blocked volume
+// is solid stone on screen, while the stair-foot mouth stays open air.
+
+import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
+import { buildGaleFeatures } from '../src/render/gale_features';
+import { BEACON_SPIRAL, beaconSpiralLift } from '../src/sim/beacon_spiral';
+import { isBlocked } from '../src/sim/colliders';
+import { GALECREST_PROPS } from '../src/sim/content/galecrest';
+import { PLAYER_BODY_RADIUS, PLAYER_MAX_CLIMB_SLOPE } from '../src/sim/pathfind';
+import { rideSteepnessAt } from '../src/sim/ride_height';
+import { groundHeight, terrainHeight } from '../src/sim/world';
+
+const SEED = 20061;
+const S = BEACON_SPIRAL;
+const SPOT = { x: 505, z: 305 }; // the reported spot, open lawn beside the tower
+const RUN_STEP = 0.35; // one 20Hz tick of run
+
+const at = (bearing: number, r: number): { x: number; z: number } => ({
+  x: S.x + Math.sin(bearing) * r,
+  z: S.z + Math.cos(bearing) * r,
+});
+const spotBearing = Math.atan2(SPOT.x - S.x, SPOT.z - S.z);
+const spotR = Math.hypot(SPOT.x - S.x, SPOT.z - S.z);
+
+let built: ReturnType<typeof buildGaleFeatures> | null = null;
+const galeFeatures = (): ReturnType<typeof buildGaleFeatures> => {
+  built ??= buildGaleFeatures(SEED);
+  return built;
+};
+
+describe('the Old Beacon stair base', () => {
+  it('the reported spot is open lawn a step or two outside the upper balcony rim', () => {
+    expect(spotR).toBeCloseTo(7.616, 3);
+    expect(spotR).toBeGreaterThan(S.balconyOut);
+    expect(spotR - S.balconyOut).toBeLessThan(2 * RUN_STEP);
+    expect(beaconSpiralLift(SPOT.x, SPOT.z)).toBe(0);
+    expect(isBlocked(SEED, SPOT.x, SPOT.z, PLAYER_BODY_RADIUS)).toBe(false);
+    expect(rideSteepnessAt(SPOT.x, SPOT.z, SEED)).toBeLessThan(PLAYER_MAX_CLIMB_SLOPE);
+  });
+
+  it('the wall is the lift rim alone: no collider, no terrain steepness', () => {
+    const outside = at(spotBearing, S.balconyOut + 0.05);
+    const inside = at(spotBearing, S.balconyOut - 0.05);
+    expect(beaconSpiralLift(outside.x, outside.z)).toBe(0);
+    expect(beaconSpiralLift(inside.x, inside.z)).toBeCloseTo(S.deck2, 5);
+
+    const rise = groundHeight(inside.x, inside.z, SEED) - groundHeight(outside.x, outside.z, SEED);
+    expect(rise).toBeCloseTo(S.deck2, 2);
+    expect(rise / 0.1).toBeGreaterThan(PLAYER_MAX_CLIMB_SLOPE);
+
+    for (const p of [outside, inside]) {
+      expect(isBlocked(SEED, p.x, p.z, PLAYER_BODY_RADIUS)).toBe(false);
+      expect(rideSteepnessAt(p.x, p.z, SEED)).toBeLessThan(PLAYER_MAX_CLIMB_SLOPE);
+    }
+    const terrainStep = Math.abs(
+      terrainHeight(inside.x, inside.z, SEED) - terrainHeight(outside.x, outside.z, SEED),
+    );
+    expect(terrainStep).toBeLessThan(0.05);
+  });
+
+  it('every walled cell sits inside balconyOut and under deck2', () => {
+    let widest = 0;
+    let tallest = 0;
+    for (let i = 0; i < 720; i++) {
+      const bearing = (i / 720) * Math.PI * 2;
+      for (let r = S.coreR + 0.05; r <= S.balconyOut + 1.2; r += 0.02) {
+        const p = at(bearing, r);
+        const lift = beaconSpiralLift(p.x, p.z);
+        if (lift <= 0) continue;
+        if (r > widest) widest = r;
+        if (lift > tallest) tallest = lift;
+      }
+    }
+    expect(widest).toBeLessThanOrEqual(S.balconyOut);
+    expect(tallest).toBeCloseTo(S.deck2, 5);
+  });
+
+  it('keeps every nearby campfire out of the stair footprint', () => {
+    const near = GALECREST_PROPS.campfires.filter(([x, z]) => Math.hypot(x - S.x, z - S.z) < 12);
+    expect(near.length).toBeGreaterThan(0);
+    for (const [x, z] of near) {
+      const d = Math.hypot(x - S.x, z - S.z);
+      // props seat on terrainHeight while the stair rides groundHeight, so a
+      // campfire inside the lift footprint is buried in the plinth AND its
+      // height-less collider pinches the flight overhead
+      expect(beaconSpiralLift(x, z), `campfire (${x}, ${z}) under the stair`).toBe(0);
+      expect(groundHeight(x, z, SEED)).toBeCloseTo(terrainHeight(x, z, SEED), 5);
+      expect(d, `campfire (${x}, ${z}) inside the lift gate`).toBeGreaterThan(S.balconyOut + 0.6);
+      // and off the stair-foot approach, which the mouth leaves open
+      const bearing = ((Math.atan2(x - S.x, z - S.z) * 180) / Math.PI + 360) % 360;
+      expect(bearing < 116 || bearing > 138, `campfire (${x}, ${z}) in the mouth`).toBe(true);
+    }
+  });
+
+  it('draws the blocked volume as solid stone from the lawn up', () => {
+    const view = galeFeatures();
+    const lawnY = terrainHeight(SPOT.x, SPOT.z, SEED);
+    const inward = new THREE.Vector3(S.x - SPOT.x, 0, S.z - SPOT.z).normalize();
+    for (const eye of [0.6, 1.4, 6, 12, 17, 18.5]) {
+      const ray = new THREE.Raycaster(new THREE.Vector3(SPOT.x, lawnY + eye, SPOT.z), inward, 0, 4);
+      const hits = ray.intersectObject(view.group, true);
+      expect(hits.length, `masonry at eye ${eye}`).toBeGreaterThan(0);
+      expect(hits[0].distance, `rim face at eye ${eye}`).toBeCloseTo(spotR - S.balconyOut, 1);
+    }
+  });
+
+  it('never draws masonry wider than the rim that blocks the step', () => {
+    const view = galeFeatures();
+    let widest = 0;
+    for (let i = 0; i < 360; i++) {
+      const bearing = (i / 360) * Math.PI * 2;
+      const o = at(bearing, 12);
+      const ray = new THREE.Raycaster(
+        new THREE.Vector3(o.x, terrainHeight(o.x, o.z, SEED) + 1, o.z),
+        new THREE.Vector3(S.x - o.x, 0, S.z - o.z).normalize(),
+        0,
+        12 - S.coreR,
+      );
+      const hits = ray.intersectObject(view.group, true);
+      if (hits.length) widest = Math.max(widest, 12 - hits[0].distance);
+    }
+    expect(widest).toBeGreaterThan(S.balconyOut - 0.1);
+    expect(widest).toBeLessThan(S.balconyOut + 0.1);
+  });
+
+  it('leaves the stair-foot mouth open air, so the approach is unchanged', () => {
+    const view = galeFeatures();
+    const mouthBearing = S.a0 + (S.balcony2End + Math.PI * 2) / 2;
+    const start = at(mouthBearing, S.balconyOut + 0.6);
+    const end = at(mouthBearing, S.coreR + 0.4);
+    expect(beaconSpiralLift(start.x, start.z)).toBe(0);
+    expect(beaconSpiralLift(end.x, end.z)).toBe(0);
+
+    const lawnY = terrainHeight(start.x, start.z, SEED);
+    const inward = new THREE.Vector3(S.x - start.x, 0, S.z - start.z).normalize();
+    const reach = S.balconyOut + 0.6 - (S.coreR + 0.4);
+    const ray = new THREE.Raycaster(
+      new THREE.Vector3(start.x, lawnY + 1.4, start.z),
+      inward,
+      0,
+      reach,
+    );
+    expect(ray.intersectObject(view.group, true).length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Player report (PBE2): an invisible wall at world (505, 305) on the open lawn beside The Old Beacon in The Galecrest.

Diagnosis (probe at seed 20061, walkers plus a 41x41 blocked/steepness/lift grid): the spot is 7.616 yd from the tower axis, 0.42 yd outside the spiral stair band's outer radius (balconyOut 7.2). One step inward takes groundHeight from 2.64 to 21.64 because beaconSpiralLift is a single-valued heightfield: the ground under an elevated tread IS that tread's height, so the whole column of air under the upper balcony is walled off by the 1.5 climb gate. isBlocked was false and steepness 0.00 at the stop, ruling out colliders (no orphaned decoration colliders in the grid), the pad rim, and the workshop. The renderer drew only the 0.4 yd deck slabs 9.5 and 19 yd overhead, so the wall was air.

Fix (render-only for the wall itself): fill the blocked volume with stone. One radial pier per existing stair sample, from under the lawn up into the tread above, merged into a single mesh (1560 triangles, one draw call, built once, no per-frame work). Reachability is identical: no src/sim change, the drawn rim lands at radius 7.2156 against the collision rim at 7.2, and the stair-foot mouth stays open air. Built unconditionally, never behind a graphics tier: this is the shape of the collision, not cosmetic richness, so hiding it on low tiers would recreate the unfairness this fixes.

Included data fix: Keeper Bram's brazier moves from (498, 313) to (498, 316.5). At d 5 it sat under flight two (lift 15.15) where campfires seat on terrainHeight, so the new plinth would have entombed it in stone; its height-less r 0.85 collider was also pinching the flight 15 yd overhead. The new spot is on the flat lawn pad, lift 0, clear of the stair-foot approach, with a comment so nobody moves it back.

Follow-up worth noting: other lift-field rims (castle walls, the Sowfield grandstand) share this invisible-rim shape; worth a sweep if similar reports land.

## Test plan
- [x] tests/beacon_stair_base.test.ts (new, 7 tests): the reported spot is open lawn just outside the rim; the wall is the lift rim alone (no collider, no steepness); every walled cell sits inside balconyOut and under deck2 (720-bearing sweep); raycasts prove the blocked volume is now solid stone from the lawn up (RED with the render change stashed); masonry never wider than the rim (360-bearing sweep); the stair-foot mouth stays open; every campfire near the axis is outside the stair footprint (RED with the brazier move stashed)
- [x] tests/beacon_spiral.test.ts (walks the stair to the top), tests/climb_slope.test.ts, tests/galecrest.test.ts, tests/architecture.test.ts, tests/render_glb_replacement_assets.test.ts, tests/guide.test.ts, tests/parity golden traces: 335 passed
- [x] npx tsc --noEmit fully clean; biome clean on changed files
- [ ] Visual check on PBE2: grey plinth wraps the tower base with the treads winding up its face; walking into the old spot stops against visible masonry; the climb to the top still works; the brazier burns on open lawn