### PR TITLE
fix(render): self-heal zero-weight animation latches that T-pose characters

### DIFF
--- a/src/render/characters/CLAUDE.md
+++ b/src/render/characters/CLAUDE.md
@@ -99,6 +99,13 @@ live in `manifest.ts`), falling back to `mob_bandit`; NPCs to `NPC_KEYS`. Forms
 - Death/revive are **edge-triggered locally** from `s.dead` (clamped one-shot);
   `flourish` plays on respawn. One-shots clamp on the last frame, see the
   T-pose-pop comment in `playOneShot`.
+- **Never leave the rig at zero weight.** A SkinnedMesh renders BIND pose (the
+  T-pose) whenever the mixer's scheduled actions sum below 1, and the base-state
+  fade only runs on an EDGE, so a partner-less `fadeIn` sticks for as long as a
+  held state (strafe/cast/walk) lasts. Start every clip through `beginAction`
+  (crossfade only when the outgoing action still drives the rig, else snap to
+  full weight); the per-frame `scanAnimRepair` watchdog (`anim_state.ts`) is the
+  backstop that re-drives the base pose after 3 starved frames.
 
 ## Adding things (module-first: where NEW work lands, and its test)
 - **New family/key:** a declarative `VisualDef` in `VISUALS` (existing `ClipMap`
@@ -111,7 +118,10 @@ live in `manifest.ts`), falling back to `mob_bandit`; NPCs to `NPC_KEYS`. Forms
   then have the renderer set the new flag. New pose LOGIC goes in the pure
   `anim_state.ts` half a Vitest imports directly, never inline in `visual.ts`.
 - **Tests:** `tests/visual_manifest.test.ts` pins the `VISUALS`/clip contract,
-  `tests/visual_anim_state.test.ts` the pose selection. Fix bugs test-first:
+  `tests/character_clipmaps.test.ts` gates every ClipMap name against the clips
+  actually in the shipped GLB (both graphics tiers), `tests/character_anim_state.test.ts`
+  the pure pose/watchdog math, `tests/character_tpose_repair.test.ts` the live
+  mixer weights across death, respawn and repeated swings. Fix bugs test-first:
   reproduce there (or in `tests/rig_merge.test.ts` for merge math), then the
   smallest change that turns it green.
 

--- a/src/render/characters/anim_state.ts
+++ b/src/render/characters/anim_state.ts
@@ -90,6 +90,83 @@ export function waterContactFrameMode(
   return contactSeen ? 'track' : 'seed';
 }
 
+// ---------------------------------------------------------------------------
+// Zero-weight watchdog
+//
+// A three.js SkinnedMesh renders BIND POSE (arms out: the T-pose) whenever the
+// summed effective weight of the mixer's scheduled actions drops below 1, since
+// the PropertyMixer blends the deficit back toward the bind transform. The
+// state machine in visual.ts only re-drives the rig on a base-state EDGE, so a
+// transient that leaves NOTHING driving it (a partner-less fade-in, an action
+// stopped out from under `current`, a one-shot whose `finished` never arrived)
+// sticks for as long as the state is held, and strafing, casting and walking
+// are all held states. These helpers decide, from the live mixer weights alone,
+// when the rig must be re-driven.
+// ---------------------------------------------------------------------------
+
+/** One action's live contribution to the accumulated pose. */
+export interface AnimActionWeight {
+  /** The mixer still schedules this action, so its weight reaches the pose
+   *  (three's `AnimationAction.isScheduled()`, NOT `isRunning()`: a clamped
+   *  one-shot is paused, hence not running, yet still holds the rig at full
+   *  weight; and a stopped action keeps a stale non-zero effective weight). */
+  scheduled: boolean;
+  /** Weight after fades and `enabled` (three's `getEffectiveWeight()`). */
+  effectiveWeight: number;
+}
+
+/** Below this summed weight the rig is visibly blending toward bind pose. */
+export const POSE_DRIVE_MIN_WEIGHT = 0.05;
+
+/** Consecutive starved frames tolerated before the repair fires. Rides out the
+ *  frames a legitimate crossfade can spend near zero without letting a real
+ *  latch persist longer than a blink. */
+export const ANIM_REPAIR_FRAMES = 3;
+
+export interface AnimRepairScan {
+  /** consecutive starved frames after this one (0 once driven, or once repaired) */
+  starvedFrames: number;
+  /** re-drive the base pose on this frame */
+  repair: boolean;
+}
+
+/** Does this one action still hold the rig off bind pose? */
+export function drivesPose(action: AnimActionWeight | null | undefined): boolean {
+  return !!action && action.scheduled && action.effectiveWeight >= POSE_DRIVE_MIN_WEIGHT;
+}
+
+/**
+ * Is the rig blending toward bind pose with nothing left to bring it back?
+ * A crossfade sums to ~1 and a clamped one-shot holds ~1, so neither trips it;
+ * a rig with no actions at all (the clip-less prop rigs) has no pose to repair.
+ */
+export function needsAnimRepair(
+  actions: readonly AnimActionWeight[],
+  deadLocked: boolean,
+): boolean {
+  if (deadLocked || actions.length === 0) return false;
+  let total = 0;
+  for (const action of actions) {
+    if (action.scheduled) total += action.effectiveWeight;
+    if (total >= POSE_DRIVE_MIN_WEIGHT) return false;
+  }
+  return true;
+}
+
+/** One frame of the watchdog: the debounce counter folded with the decision. */
+export function scanAnimRepair(
+  starvedFrames: number,
+  actions: readonly AnimActionWeight[],
+  deadLocked: boolean,
+): AnimRepairScan {
+  if (!needsAnimRepair(actions, deadLocked)) return { starvedFrames: 0, repair: false };
+  const starved = starvedFrames + 1;
+  if (starved < ANIM_REPAIR_FRAMES) return { starvedFrames: starved, repair: false };
+  // Re-arm: a repair that did not take (a rig with no base action to drive)
+  // must be retried rather than latch the counter above the threshold.
+  return { starvedFrames: 0, repair: true };
+}
+
 export function desiredBaseState(s: AnimState, hasWalkBackClip: boolean): BaseState {
   if (s.swimming) return 'swim';
   if (s.airborne) return 'jump';

--- a/src/render/characters/manifest.ts
+++ b/src/render/characters/manifest.ts
@@ -953,7 +953,10 @@ export const VISUALS: Record<string, VisualDef> = {
   mob_stag: {
     url: `${CREATURES}/stag.glb`,
     height: 1.9,
-    clips: animal(['Attack_Headbutt', 'Attack']),
+    // Attack_Kick, not 'Attack': the rig ships no clip by that name, so every
+    // second swing in the rotation resolved to nothing and played no animation
+    // at all (the repainted siblings below always had it right).
+    clips: animal(['Attack_Headbutt', 'Attack_Kick']),
     tint: 'entity',
     tintStrength: 0.35,
   },

--- a/src/render/characters/visual.ts
+++ b/src/render/characters/visual.ts
@@ -11,12 +11,15 @@ import { GFX } from '../gfx';
 import { createWeaponVfx, WEAPON_VFX, type WeaponVfxHandle } from '../weapon_vfx';
 import { weaponVfxTuningFor } from '../weapon_vfx_tuning';
 import {
+  type AnimActionWeight,
   type AnimState,
   advanceSwimBlend,
   type BaseState,
   desiredBaseState,
+  drivesPose,
   locomotionTimeScale,
   pickProxyHeight,
+  scanAnimRepair,
 } from './anim_state';
 import {
   applyMaterials,
@@ -123,6 +126,16 @@ const MOONKIN_TINT = new THREE.Color(0x9d6bff);
 // dark enough that the body still shades and the flames read against it.
 const METAMORPH_TINT = new THREE.Color(0x4f2170);
 
+/** The live mixer facts the pure watchdog decides on (see anim_state.ts). */
+function readActionWeight(a: THREE.AnimationAction, into?: AnimActionWeight): AnimActionWeight {
+  const scheduled = a.isScheduled();
+  const effectiveWeight = a.getEffectiveWeight();
+  if (!into) return { scheduled, effectiveWeight };
+  into.scheduled = scheduled;
+  into.effectiveWeight = effectiveWeight;
+  return into;
+}
+
 // shared invisible click capsule — raycaster ignores `visible`, render doesn't
 let clickGeoSingleton: THREE.CylinderGeometry | null = null;
 function clickGeo(): THREE.CylinderGeometry {
@@ -213,6 +226,11 @@ export class CharacterVisual {
   private currentIsOneShot = false;
   private currentOneShotIsEmote = false;
   private deadLock = false;
+  /** consecutive frames with no action driving the pose (the T-pose watchdog) */
+  private starvedFrames = 0;
+  /** Per-frame scratch view of every action's mixer weight, refilled in place:
+   *  a fresh array per rig per frame would be real GC churn at raid rig counts. */
+  private readonly weightScan: AnimActionWeight[] = [];
   private wasDead = false;
   private initialized = false;
   private attackIdx = 0;
@@ -391,6 +409,15 @@ export class CharacterVisual {
         if (this.baseState === 'spin') this.current.timeScale = SPIN_ATTACK_TIMESCALE;
       }
     }
+
+    // Zero-weight watchdog. The fades above only run on a base-state EDGE, so
+    // any transient that leaves NO action driving the rig keeps it in bind pose
+    // (the T-pose) for as long as the state is held, and strafe/cast/walk are
+    // all held states. Re-drive the base pose instead of waiting for the next
+    // edge. Debounced, so a legitimate crossfade can never trip it.
+    const scan = scanAnimRepair(this.starvedFrames, this.readActionWeights(), this.deadLock);
+    this.starvedFrames = scan.starvedFrames;
+    if (scan.repair) this.repairPose();
 
     if (s.spinning && !s.dead) {
       this.spinAngle = (this.spinAngle + dt * SPIN_RATE) % (Math.PI * 2);
@@ -1126,7 +1153,35 @@ export class CharacterVisual {
   // -------------------------------------------------------------------------
 
   private desiredBase(s: AnimState): BaseState {
-    return desiredBaseState(s, !!this.def.clips.walkBack);
+    // Whether the LOADED rig has the clip, not whether the ClipMap names one:
+    // every player ClipMap names walkBack, but baseAction() silently falls back
+    // to walk when the GLB lacks it, and the machine would then hold a state
+    // nothing is playing.
+    return desiredBaseState(s, !!this.action(this.def.clips.walkBack));
+  }
+
+  /** Refill the weight scratch from the live mixer (see `weightScan`). */
+  private readActionWeights(): AnimActionWeight[] {
+    const scan = this.weightScan;
+    let i = 0;
+    for (const a of this.actions.values()) {
+      const slot = scan[i];
+      if (slot) readActionWeight(a, slot);
+      else scan.push(readActionWeight(a));
+      i++;
+    }
+    return scan;
+  }
+
+  /** Nothing is driving the rig (see `needsAnimRepair`): drop the stale handle
+   *  so fadeTo cannot early-return on it, release the one-shot latch a missed
+   *  `finished` may have left set, and re-drive the base state. beginAction
+   *  snaps rather than fades, since there is no live pose to blend from. */
+  private repairPose(): void {
+    this.currentIsOneShot = false;
+    this.currentOneShotIsEmote = false;
+    this.current = null;
+    this.fadeTo(this.baseAction(), FADE, false);
   }
 
   private effectMaterial<T extends THREE.Material | THREE.Material[]>(material: T): T {
@@ -1279,11 +1334,32 @@ export class CharacterVisual {
     next.setLoop(oneShot || this.isOnce(next) ? THREE.LoopOnce : THREE.LoopRepeat, Infinity);
     next.clampWhenFinished = true;
     next.timeScale = 1;
-    if (prev && prev !== next) prev.fadeOut(fade);
-    next.fadeIn(fade).play();
+    this.beginAction(next, prev, fade);
     this.current = next;
     this.currentIsOneShot = oneShot;
     this.currentOneShotIsEmote = false;
+  }
+
+  /**
+   * Start `next`, crossfading out of `prev` while it still drives the rig.
+   * With no outgoing partner (nothing active, the same clip re-triggered, or a
+   * `current` that was stopped out from under us) a fadeIn would ramp the ONLY
+   * contributing action up from zero, and the mixer blends that whole deficit
+   * toward BIND pose: a T-pose for the length of the fade. Snap to full weight
+   * in that case, since there is no live pose to blend from anyway.
+   */
+  private beginAction(
+    next: THREE.AnimationAction,
+    prev: THREE.AnimationAction | null,
+    fade: number,
+  ): void {
+    if (prev && prev !== next && drivesPose(readActionWeight(prev))) {
+      prev.fadeOut(fade);
+      next.fadeIn(fade).play();
+      return;
+    }
+    next.setEffectiveWeight(1);
+    next.play();
   }
 
   /** sit-down transitions play once, then hand off to the sit-idle loop */
@@ -1300,7 +1376,10 @@ export class CharacterVisual {
     const a = this.action(name);
     if (!a) return;
     const prev = this.current;
-    if (prev === a) a.stop();
+    // reset (not stop) restarts the clip in place: stopping the clip that is
+    // ALREADY driving the rig, then fading it back in from zero with no
+    // outgoing partner, T-poses the rig for the whole fade on every same-clip
+    // re-trigger (a repeated swing, a re-fired emote, the sheathe gesture).
     a.reset();
     const repeatCount = Math.max(1, Math.floor(repeats));
     a.setLoop(repeatCount === 1 ? THREE.LoopOnce : THREE.LoopRepeat, repeatCount);
@@ -1309,8 +1388,7 @@ export class CharacterVisual {
     // whole 0.18s hand-off fade (a visible T-pose pop after every swing)
     a.clampWhenFinished = true;
     a.timeScale = timeScale;
-    if (prev && prev !== a) prev.fadeOut(ONESHOT_FADE);
-    a.fadeIn(ONESHOT_FADE).play();
+    this.beginAction(a, prev, ONESHOT_FADE);
     this.current = a;
     this.currentIsOneShot = true;
     this.currentOneShotIsEmote = emoteId !== null;
@@ -1341,7 +1419,18 @@ export class CharacterVisual {
     // runs on every enterDeath path including the created-already-dead snapshot.
     this.clickProxy.scale.y = pickProxyHeight(this.height, this.clickRadius, true);
     const death = this.action(this.def.clips.death);
-    if (!death) return;
+    if (!death) {
+      // No death clip: the corpse holds whatever pose was driving it. dead-lock
+      // freezes the zero-weight watchdog, so leave the machine on something
+      // real, or the rig sits in bind pose until it revives (and revive() would
+      // inherit a stale `current` it can neither fade out of nor blend from).
+      if (!drivesPose(this.current ? readActionWeight(this.current) : null)) {
+        this.baseState = 'idle';
+        this.current = null;
+        this.fadeTo(this.baseAction(), ONESHOT_FADE, false);
+      }
+      return;
+    }
     const prev = this.current;
     death.reset();
     death.setLoop(THREE.LoopOnce, 1);
@@ -1356,27 +1445,32 @@ export class CharacterVisual {
       this.mixer.update(0);
       return;
     }
-    if (prev && prev !== death) prev.fadeOut(ONESHOT_FADE);
-    death.fadeIn(ONESHOT_FADE).play();
+    this.beginAction(death, prev, ONESHOT_FADE);
     this.current = death;
   }
 
   private revive(): void {
     this.deadLock = false;
     this.baseState = 'idle';
+    // Release the one-shot latch: a `finished` that never arrived (the rig was
+    // throttled, or the clip was cut) would otherwise leave every later base
+    // change committing its state while silently skipping its fade.
+    this.currentIsOneShot = false;
     this.currentOneShotIsEmote = false;
     // Restore the upright pick capsule (the corpse-flatten from enterDeath).
     this.clickProxy.scale.y = pickProxyHeight(this.height, this.clickRadius, false);
+    // The clamped death pose stays the OUTGOING partner of the fade below (a
+    // paused action still fades out). Stopping it first, or clearing `current`,
+    // left the incoming clip ramping up from zero with nothing else driving the
+    // rig: bind pose (the T-pose) for the whole fade, on every single respawn.
     const death = this.action(this.def.clips.death);
-    if (death) death.stop();
-    const flourish = this.action(this.def.clips.flourish);
-    if (flourish) {
-      // skeletons claw back out of the ground; bosses taunt
-      this.current = null;
-      this.playOneShot(this.def.clips.flourish!, 1);
-    } else {
-      this.fadeTo(this.action(this.def.clips.idle), 0.2, false);
+    if (death && death !== this.current) death.stop();
+    const flourishClip = this.def.clips.flourish;
+    if (flourishClip && this.action(flourishClip)) {
+      this.playOneShot(flourishClip, 1); // skeletons claw out of the ground; bosses taunt
+      return;
     }
+    this.fadeTo(this.action(this.def.clips.idle), 0.2, false);
   }
 }
 

--- a/tests/character_anim_state.test.ts
+++ b/tests/character_anim_state.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ANIM_REPAIR_FRAMES,
+  type AnimActionWeight,
+  type AnimState,
+  desiredBaseState,
+  drivesPose,
+  locomotionTimeScale,
+  needsAnimRepair,
+  scanAnimRepair,
+} from '../src/render/characters/anim_state';
+
+// A three.js SkinnedMesh renders BIND POSE (arms out, the T-pose) whenever the
+// summed effective weight of the mixer's scheduled actions is below 1: the
+// PropertyMixer blends the deficit back toward the bind transform. These
+// helpers are the pure half of the watchdog that catches a rig left with no
+// action driving it at all.
+
+const driving = (effectiveWeight: number): AnimActionWeight => ({
+  scheduled: true,
+  effectiveWeight,
+});
+/** stop()ped actions keep a stale effective weight; the mixer ignores them */
+const stopped = (effectiveWeight: number): AnimActionWeight => ({
+  scheduled: false,
+  effectiveWeight,
+});
+
+const anim = (over: Partial<AnimState> = {}): AnimState => ({
+  speed: 0,
+  moving: false,
+  running: false,
+  airborne: false,
+  backwards: false,
+  dead: false,
+  casting: false,
+  swimming: false,
+  sitting: false,
+  ...over,
+});
+
+describe('drivesPose', () => {
+  it('accepts a scheduled action at full weight', () => {
+    expect(drivesPose(driving(1))).toBe(true);
+  });
+
+  it('rejects a stopped action even though its last weight is stale at full', () => {
+    expect(drivesPose(stopped(1))).toBe(false);
+  });
+
+  it('rejects a scheduled action whose fade-out has completed', () => {
+    expect(drivesPose(driving(0))).toBe(false);
+    expect(drivesPose(driving(0.01))).toBe(false);
+  });
+
+  it('rejects nothing at all', () => {
+    expect(drivesPose(null)).toBe(false);
+  });
+});
+
+describe('needsAnimRepair', () => {
+  it('flags a rig whose only action was stopped (bind pose with no way back)', () => {
+    expect(needsAnimRepair([stopped(1), stopped(0)], false)).toBe(true);
+  });
+
+  it('flags a rig whose actions all faded out to zero', () => {
+    expect(needsAnimRepair([driving(0), driving(0)], false)).toBe(true);
+  });
+
+  it('does not flag a normal crossfade, whose halves still sum to one', () => {
+    expect(needsAnimRepair([driving(0.6), driving(0.4)], false)).toBe(false);
+  });
+
+  it('does not flag the first frame of a partnered fade-in', () => {
+    expect(needsAnimRepair([driving(0.93), driving(0.07)], false)).toBe(false);
+  });
+
+  it('does not flag a clamped-hold one-shot (a statue at full weight, not a T-pose)', () => {
+    // A finished LoopOnce action with clampWhenFinished is PAUSED, so three's
+    // isRunning() is false, yet it still accumulates at weight 1. The predicate
+    // must key off scheduling + weight, never off isRunning().
+    expect(needsAnimRepair([driving(1), stopped(0)], false)).toBe(false);
+  });
+
+  it('does not flag a dead-locked rig (the death clip clamps by design)', () => {
+    expect(needsAnimRepair([stopped(1)], true)).toBe(false);
+    // the same rig, alive, is starved: dead-lock is what suppresses it
+    expect(needsAnimRepair([stopped(1)], false)).toBe(true);
+  });
+
+  it('does not flag a rig that has no actions at all (clip-less prop rigs)', () => {
+    expect(needsAnimRepair([], false)).toBe(false);
+  });
+});
+
+describe('scanAnimRepair', () => {
+  it('does not repair on the first starved frame (a legitimate fade-in starts at zero)', () => {
+    const scan = scanAnimRepair(0, [driving(0)], false);
+    expect(scan.starvedFrames).toBe(1);
+    expect(scan.repair).toBe(false);
+  });
+
+  it('repairs on the third consecutive starved frame, not before', () => {
+    expect(ANIM_REPAIR_FRAMES).toBe(3);
+    const first = scanAnimRepair(0, [driving(0)], false);
+    const second = scanAnimRepair(first.starvedFrames, [driving(0)], false);
+    const third = scanAnimRepair(second.starvedFrames, [driving(0)], false);
+    expect([first.repair, second.repair, third.repair]).toEqual([false, false, true]);
+    expect([first.starvedFrames, second.starvedFrames]).toEqual([1, 2]);
+  });
+
+  it('forgets a starved run interrupted by a driven frame', () => {
+    const first = scanAnimRepair(0, [driving(0)], false);
+    const second = scanAnimRepair(first.starvedFrames, [driving(0)], false);
+    const driven = scanAnimRepair(second.starvedFrames, [driving(1)], false);
+    const third = scanAnimRepair(driven.starvedFrames, [driving(0)], false);
+    const fourth = scanAnimRepair(third.starvedFrames, [driving(0)], false);
+    expect([driven.repair, third.repair, fourth.repair]).toEqual([false, false, false]);
+  });
+
+  it('re-arms after a repair so a rig that is still starved is driven again', () => {
+    const scan = scanAnimRepair(ANIM_REPAIR_FRAMES - 1, [driving(0)], false);
+    expect(scan.repair).toBe(true);
+    expect(scan.starvedFrames).toBe(0);
+  });
+
+  it('resets the counter as soon as an action drives the pose again', () => {
+    const starved = scanAnimRepair(ANIM_REPAIR_FRAMES - 1, [driving(1)], false);
+    expect(starved.starvedFrames).toBe(0);
+    expect(starved.repair).toBe(false);
+  });
+
+  it('never repairs a dead-locked rig, however long it holds', () => {
+    let starvedFrames = 0;
+    for (let i = 0; i < ANIM_REPAIR_FRAMES * 3; i++) {
+      const scan = scanAnimRepair(starvedFrames, [stopped(1)], true);
+      starvedFrames = scan.starvedFrames;
+      expect(scan.repair).toBe(false);
+    }
+    expect(starvedFrames).toBe(0);
+  });
+
+  it('never repairs a crossfading rig, however long it runs', () => {
+    let starvedFrames = 0;
+    for (let i = 0; i < ANIM_REPAIR_FRAMES * 3; i++) {
+      const scan = scanAnimRepair(starvedFrames, [driving(0.5), driving(0.5)], false);
+      starvedFrames = scan.starvedFrames;
+      expect(scan.repair).toBe(false);
+    }
+  });
+});
+
+describe('desiredBaseState', () => {
+  it('never asks for walkBack when the loaded rig has no such action', () => {
+    // The mixer falls back to the plain walk action when walkBack is missing
+    // (baseAction), so a state machine that still believes it is in walkBack
+    // desyncs from what is actually playing.
+    const backwards = anim({ moving: true, backwards: true });
+    expect(desiredBaseState(backwards, false)).toBe('walk');
+    expect(desiredBaseState({ ...backwards, running: true }, false)).toBe('run');
+  });
+
+  it('asks for walkBack when the rig really has the clip', () => {
+    expect(desiredBaseState(anim({ moving: true, backwards: true }), true)).toBe('walkBack');
+  });
+
+  it('keeps the forward clip for a rig that backpedals by reversing it', () => {
+    expect(
+      desiredBaseState(anim({ moving: true, backwards: true, reverseBackpedal: true }), true),
+    ).toBe('walk');
+  });
+
+  it('keeps the documented precedence over locomotion', () => {
+    const moving = { moving: true, backwards: true };
+    expect(desiredBaseState(anim({ ...moving, swimming: true }), true)).toBe('swim');
+    expect(desiredBaseState(anim({ ...moving, airborne: true }), true)).toBe('jump');
+    expect(desiredBaseState(anim({ ...moving, spinning: true }), true)).toBe('spin');
+    expect(desiredBaseState(anim({ ...moving, casting: true }), true)).toBe('cast');
+    expect(desiredBaseState(anim({ ...moving, sitting: true }), true)).toBe('sit');
+    expect(desiredBaseState(anim(), true)).toBe('idle');
+  });
+});
+
+describe('locomotionTimeScale', () => {
+  it('matches foot speed against the walk reference, clamped', () => {
+    expect(locomotionTimeScale('walk', { speed: 2.2, backwards: false })).toBeCloseTo(1);
+    expect(locomotionTimeScale('walk', { speed: 0.1, backwards: false })).toBeCloseTo(0.6);
+    expect(locomotionTimeScale('walk', { speed: 99, backwards: false })).toBeCloseTo(1.8);
+  });
+
+  it('matches foot speed against the run reference, clamped', () => {
+    expect(locomotionTimeScale('run', { speed: 7, backwards: false })).toBeCloseTo(1);
+    expect(locomotionTimeScale('run', { speed: 99, backwards: false })).toBeCloseTo(1.6);
+  });
+
+  it('returns null for every non-locomotion pose', () => {
+    for (const state of ['idle', 'cast', 'spin', 'swim', 'sit', 'jump'] as const) {
+      expect(locomotionTimeScale(state, { speed: 4, backwards: false }), state).toBeNull();
+    }
+  });
+
+  it('reverses the forward clip only for a backpedalling reverse rig', () => {
+    const back = { speed: 2.2, backwards: true, reverseBackpedal: true };
+    expect(locomotionTimeScale('walk', back)).toBeCloseTo(-1);
+    // an authored walkBack clip plays FORWARD; only the reversed fallback negates
+    expect(locomotionTimeScale('walkBack', back)).toBeCloseTo(1);
+    expect(locomotionTimeScale('walk', { ...back, backwards: false })).toBeCloseTo(1);
+  });
+});

--- a/tests/character_clipmaps.test.ts
+++ b/tests/character_clipmaps.test.ts
@@ -1,0 +1,218 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  type ClipMap,
+  VISUALS,
+  type VisualDef,
+  visualAssetUrlForGraphics,
+} from '../src/render/characters/manifest';
+
+// A clip name the shipped GLB does not carry fails SILENTLY at every layer:
+// baseAction() falls back, fadeTo()/playOneShot() return early, and the
+// prepareVisual far-LOD bake falls back to BIND POSE (the T-pose) when the idle
+// clip is the one missing. Nothing else in CI compares the ClipMaps against the
+// GLBs actually served out of public/, so a rename in an asset update ships a
+// rig that quietly stops animating. This is that gate.
+
+const GLB_MAGIC = 0x46546c67; // 'glTF'
+const CHUNK_JSON = 0x4e4f534a; // 'JSON'
+
+/** Minimal glTF-binary reader: 12-byte header, then chunks; the JSON chunk
+ *  carries the animation list. Deliberately dependency-free, so the gate cannot
+ *  be fooled by (or fail with) whatever the runtime loader stack does. */
+function glbAnimationNames(publicPath: string): string[] {
+  const buf = readFileSync(publicPath);
+  expect(buf.length, `${publicPath} is not a GLB`).toBeGreaterThan(12);
+  expect(buf.readUInt32LE(0), `${publicPath} magic`).toBe(GLB_MAGIC);
+  let offset = 12;
+  while (offset + 8 <= buf.length) {
+    const length = buf.readUInt32LE(offset);
+    const type = buf.readUInt32LE(offset + 4);
+    if (type === CHUNK_JSON) {
+      const json = JSON.parse(buf.toString('utf8', offset + 8, offset + 8 + length)) as {
+        animations?: { name?: string }[];
+      };
+      return (json.animations ?? []).map((a) => a.name ?? '');
+    }
+    offset += 8 + length + ((4 - (length % 4)) % 4); // chunks are 4-byte aligned
+  }
+  throw new Error(`${publicPath} has no JSON chunk`);
+}
+
+function publicPath(url: string): string {
+  return fileURLToPath(new URL(`../public/${url}`, import.meta.url));
+}
+
+const namesByUrl = new Map<string, string[]>();
+function animationNamesOf(url: string): string[] {
+  const hit = namesByUrl.get(url);
+  if (hit) return hit;
+  const names = glbAnimationNames(publicPath(url));
+  namesByUrl.set(url, names);
+  return names;
+}
+
+/**
+ * Every clip name the rig can resolve, both graphics tiers: placement swaps the
+ * body GLB through visualAssetUrlForGraphics (LOW_URL_ALIAS), so a clip present
+ * only on the standard-materials body would T-pose the low tier alone.
+ */
+function loadedClipNames(def: VisualDef, standardMaterials: boolean): Set<string> {
+  const urls = [
+    visualAssetUrlForGraphics(def.url, standardMaterials),
+    ...(def.animUrls ?? []).map((url) => visualAssetUrlForGraphics(url, standardMaterials)),
+  ];
+  const names = new Set<string>();
+  for (const url of urls) for (const name of animationNamesOf(url)) names.add(name);
+  return names;
+}
+
+/** Names visual.ts binds one-for-one; a missing one silently does nothing. */
+function requiredClipNames(clips: ClipMap): string[] {
+  return [
+    clips.idle,
+    clips.walk,
+    clips.run,
+    clips.death,
+    clips.cast,
+    clips.sitDown,
+    clips.sitIdle,
+    clips.swim,
+    clips.jump,
+    clips.walkBack,
+    clips.flourish,
+    clips.stow,
+    ...clips.attack,
+    ...(clips.hit ?? []),
+    ...Object.values(clips.attackByAbility ?? {}),
+    ...Object.values(clips.attackByHand ?? {}),
+  ].filter((name): name is string => !!name);
+}
+
+/** Emote specs are a fallback CHAIN (firstLoadedEmoteClip), so one is enough. */
+function emoteChains(clips: ClipMap): [string, readonly string[]][] {
+  return Object.entries(clips.emote ?? {}).map(([id, spec]) => [id, spec.clips]);
+}
+
+// Every field the gate knows how to check. A new ClipMap field must be added to
+// requiredClipNames (or to this list, if it names no clip), or the gate would
+// silently stop covering it.
+const COVERED_CLIP_FIELDS = new Set<keyof ClipMap>([
+  'idle',
+  'walk',
+  'run',
+  'death',
+  'cast',
+  'sitDown',
+  'sitIdle',
+  'swim',
+  'jump',
+  'walkBack',
+  'flourish',
+  'stow',
+  'attack',
+  'hit',
+  'attackByAbility',
+  'attackByHand',
+  'emote',
+]);
+
+/**
+ * Rigs whose GLB deliberately ships NO animation clips: the prop-lane mounts
+ * that bob procedurally instead (src/render/mount_visuals.ts) and static set
+ * dressing. They borrow an animated sibling's ClipMap purely to satisfy the
+ * type and resolve no action at all at runtime, so there is no pose to lose.
+ * The gate still pins that each one is genuinely clip-LESS, so a rig that
+ * silently loses its clips in an asset update is not waved through here.
+ */
+const CLIPLESS_RIGS = new Set([
+  'mount_stalkglider_snail',
+  'mount_aether_hover_cycle',
+  'mob_glimmerwisp',
+  'mob_duskwisp',
+  'mob_spider_egg_sac',
+]);
+
+/** mob_yumi_cat is a single-clip objective prop: its ClipMap names the one real
+ *  clip for `hit` and parks every other required field on this sentinel. */
+const SENTINEL_CLIP_NAME = 'None';
+
+const rigs = Object.entries(VISUALS).filter(([key]) => !CLIPLESS_RIGS.has(key));
+const tiers: [string, boolean][] = [
+  ['standard materials', true],
+  ['low graphics', false],
+];
+
+describe('character ClipMaps match the shipped GLBs', () => {
+  it('covers every visual key in the manifest', () => {
+    expect(rigs.length).toBeGreaterThan(50);
+    expect(rigs.length).toBe(Object.keys(VISUALS).length - CLIPLESS_RIGS.size);
+    for (const [key, def] of rigs) {
+      expect(existsSync(publicPath(def.url)), `${key}: ${def.url} is missing`).toBe(true);
+      for (const url of def.animUrls ?? []) {
+        expect(existsSync(publicPath(url)), `${key}: ${url} is missing`).toBe(true);
+      }
+    }
+  });
+
+  it('checks every ClipMap field (a new field must join the gate)', () => {
+    for (const [key, def] of rigs) {
+      const unknown = Object.keys(def.clips).filter(
+        (field) => !COVERED_CLIP_FIELDS.has(field as keyof ClipMap),
+      );
+      expect(unknown, `${key} has ClipMap fields the gate does not check`).toEqual([]);
+    }
+  });
+
+  it('keeps the clip-less exemptions honest (those GLBs really carry no clips)', () => {
+    for (const key of CLIPLESS_RIGS) {
+      const def = VISUALS[key];
+      expect(def, `${key} is exempted but no longer in the manifest`).toBeDefined();
+      expect(animationNamesOf(def.url), `${key} now ships clips: drop the exemption`).toEqual([]);
+    }
+    // the sentinel really is a name no rig ships
+    const yumi = VISUALS.mob_yumi_cat;
+    expect(yumi.clips.idle).toBe(SENTINEL_CLIP_NAME);
+    expect(animationNamesOf(yumi.url)).not.toContain(SENTINEL_CLIP_NAME);
+  });
+
+  for (const [tierName, standardMaterials] of tiers) {
+    it(`resolves every named clip out of the GLB on ${tierName}`, () => {
+      const missing: string[] = [];
+      for (const [key, def] of rigs) {
+        const loaded = loadedClipNames(def, standardMaterials);
+        for (const name of new Set(requiredClipNames(def.clips))) {
+          if (name === SENTINEL_CLIP_NAME) continue;
+          if (!loaded.has(name)) missing.push(`${key}: ${name}`);
+        }
+      }
+      expect(missing).toEqual([]);
+    });
+
+    it(`leaves every overhead emote at least one clip on ${tierName}`, () => {
+      const empty: string[] = [];
+      for (const [key, def] of rigs) {
+        const loaded = loadedClipNames(def, standardMaterials);
+        for (const [id, chain] of emoteChains(def.clips)) {
+          if (!chain.some((name) => loaded.has(name))) empty.push(`${key}: ${id}`);
+        }
+      }
+      expect(empty).toEqual([]);
+    });
+  }
+
+  it('bakes the far-LOD proxy from a real idle pose, never bind pose', () => {
+    // prepareVisual poses a throwaway clone on clips.idle before baking the
+    // static far mesh; with no idle clip resolved it bakes the BIND pose, and
+    // every rig that crosses the far band flashes a T-pose.
+    const bindPosed: string[] = [];
+    for (const [key, def] of rigs) {
+      if (def.clips.idle === SENTINEL_CLIP_NAME) continue; // a clip-less prop either way
+      for (const [, standardMaterials] of tiers) {
+        if (!loadedClipNames(def, standardMaterials).has(def.clips.idle)) bindPosed.push(key);
+      }
+    }
+    expect([...new Set(bindPosed)]).toEqual([]);
+  });
+});

--- a/tests/character_tpose_repair.test.ts
+++ b/tests/character_tpose_repair.test.ts
@@ -1,0 +1,147 @@
+import * as THREE from 'three';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AnimState } from '../src/render/characters/anim_state';
+import { ANIM_REPAIR_FRAMES, POSE_DRIVE_MIN_WEIGHT } from '../src/render/characters/anim_state';
+import type { CharacterVisual } from '../src/render/characters/visual';
+import type { Entity } from '../src/sim/types';
+
+// A three.js SkinnedMesh renders BIND POSE (the T-pose) whenever the summed
+// effective weight of the mixer's scheduled actions falls short of 1: the
+// PropertyMixer blends the deficit back toward the bind transform. Every case
+// below drives a REAL CharacterVisual through a real AnimationMixer and asserts
+// on that sum, which is the quantity players see as a T-pose.
+
+const FRAME = 1 / 60;
+
+const dummyEntity = {
+  kind: 'mob',
+  id: 1,
+  templateId: 'training_dummy',
+  color: 0xffffff,
+  skin: 0,
+  mainhandItemId: null,
+} as unknown as Entity;
+
+const anim = (over: Partial<AnimState> = {}): AnimState => ({
+  speed: 0,
+  moving: false,
+  running: false,
+  airborne: false,
+  backwards: false,
+  dead: false,
+  casting: false,
+  swimming: false,
+  sitting: false,
+  ...over,
+});
+
+/** The training dummy's whole ClipMap, as a minimally real GLB. */
+function stubGltf() {
+  const scene = new THREE.Group();
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 2, 1), new THREE.MeshStandardMaterial());
+  mesh.name = 'body';
+  scene.add(mesh);
+  const clip = (name: string) => new THREE.AnimationClip(name, 1, []);
+  return { scene, animations: ['Idle', 'Walk', 'Run', 'Attack', 'Hit', 'Death'].map(clip) };
+}
+
+/** The mixer state the visual keeps private; reading it is the only way to
+ *  measure the bind-pose deficit that the bug renders as a T-pose. */
+type MixerPeek = { actions: Map<string, THREE.AnimationAction> };
+
+function poseWeight(visual: CharacterVisual): number {
+  const actions = (visual as unknown as MixerPeek).actions;
+  let total = 0;
+  for (const action of actions.values()) {
+    if (action.isScheduled()) total += action.getEffectiveWeight();
+  }
+  return total;
+}
+
+async function makeVisual(): Promise<CharacterVisual> {
+  vi.resetModules();
+  vi.doMock('../src/render/assets/loader', () => ({
+    loadGltf: vi.fn(() => Promise.resolve(stubGltf())),
+    loadHdr: vi.fn(() => new Promise(() => undefined)),
+    loadTexture: vi.fn(() => new Promise(() => undefined)),
+    releaseGltf: vi.fn(),
+  }));
+  const { preloadTrainingDummyAssets } = await import('../src/render/characters/assets');
+  await preloadTrainingDummyAssets();
+  const { createCharacterVisual } = await import('../src/render/characters/index');
+  const visual = createCharacterVisual(dummyEntity);
+  if (!visual) throw new Error('test harness failed to build a CharacterVisual');
+  return visual;
+}
+
+describe('CharacterVisual keeps something driving the rig', () => {
+  let visual: CharacterVisual;
+
+  beforeEach(async () => {
+    visual = await makeVisual();
+    visual.update(FRAME, anim(), true);
+  });
+
+  it('starts and stays driven while a held state runs', () => {
+    for (let i = 0; i < 10; i++) visual.update(FRAME, anim({ moving: true, speed: 2 }), true);
+    expect(poseWeight(visual)).toBeGreaterThan(1 - POSE_DRIVE_MIN_WEIGHT);
+  });
+
+  it('re-drives a rig that was left with no action at all, within the debounce window', () => {
+    // The whole H1 class in one shape: something stopped every action while a
+    // HELD state (strafe/cast/walk) was running, so no base-state edge is ever
+    // coming to repair it. Nothing else in the machine can recover from this.
+    const actions = (visual as unknown as MixerPeek).actions;
+    for (const action of actions.values()) action.stop();
+    expect(poseWeight(visual)).toBe(0);
+
+    for (let i = 0; i < ANIM_REPAIR_FRAMES; i++) {
+      visual.update(FRAME, anim({ moving: true, speed: 2 }), true);
+    }
+    expect(poseWeight(visual)).toBeGreaterThan(1 - POSE_DRIVE_MIN_WEIGHT);
+  });
+
+  it('does not wait for the mixer to catch up when the rig is throttled', () => {
+    const actions = (visual as unknown as MixerPeek).actions;
+    for (const action of actions.values()) action.stop();
+    for (let i = 0; i < ANIM_REPAIR_FRAMES; i++) visual.update(FRAME, anim(), false);
+    expect(poseWeight(visual)).toBeGreaterThan(1 - POSE_DRIVE_MIN_WEIGHT);
+  });
+
+  it('never blends toward bind pose across death and respawn (the rez T-pose)', () => {
+    const weights: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      visual.update(FRAME, anim({ dead: true }), true);
+      weights.push(poseWeight(visual));
+    }
+    // ...and back up, standing still: with no base-state edge on the revive
+    // frame, revive()'s own hand-off is the only thing driving the rig, and it
+    // must hand the incoming clip an outgoing partner (the clamped death pose).
+    for (let i = 0; i < 6; i++) {
+      visual.update(FRAME, anim(), true);
+      weights.push(poseWeight(visual));
+    }
+    expect(Math.min(...weights)).toBeGreaterThan(1 - POSE_DRIVE_MIN_WEIGHT);
+  });
+
+  it('never blends toward bind pose when the same swing clip re-triggers', () => {
+    const weights: number[] = [];
+    for (let swing = 0; swing < 3; swing++) {
+      visual.playAttack();
+      for (let i = 0; i < 4; i++) {
+        visual.update(FRAME, anim(), true);
+        weights.push(poseWeight(visual));
+      }
+    }
+    expect(Math.min(...weights)).toBeGreaterThan(1 - POSE_DRIVE_MIN_WEIGHT);
+  });
+
+  it('leaves a dead rig on a real pose when its rig ships no death clip', () => {
+    // dead-lock freezes the watchdog, so enterDeath is the only repair there is.
+    const actions = (visual as unknown as MixerPeek).actions;
+    actions.delete('Death');
+    for (const action of actions.values()) action.stop();
+    visual.update(FRAME, anim({ dead: true }), true);
+    expect(poseWeight(visual)).toBeGreaterThan(1 - POSE_DRIVE_MIN_WEIGHT);
+  });
+});


### PR DESCRIPTION
## Summary
Player reports (PBE2, screenshots): the local player intermittently renders in a T-pose while strafing, while casting, and sometimes while walking; one report suspected a correlation with dying and taking The Keeper's Toll. The suspicion was right.

Mechanism: a three.js SkinnedMesh renders bind pose (the T-pose) whenever the summed effective weight of the mixer's scheduled actions falls short of 1. The CharacterVisual state machine only re-drives the rig on a base-state EDGE, so any transient that left nothing driving the rig stuck for as long as the state was held, and strafe, cast, and walk are all held states (this is why it "sometimes" fixed itself: the next state change healed it). Measured pre-fix weights on real mixers: 0.083 on the first frame after every respawn (revive stopped the death clip, then faded idle in with no partner: the Keeper's Toll correlation, firing on every rez), 0.167 after a repeated same-clip swing, 0 for a latched or corpse-without-death-clip rig.

Fix, per the characters module convention (pure decision half + thin consumer):
- anim_state.ts gains a pure zero-weight watchdog (drivesPose, needsAnimRepair, scanAnimRepair): three consecutive starved frames with no scheduled action carrying weight, and not dead-locked, means re-drive the base pose. Crossfades sum to ~1 and clamped one-shots hold ~1, so neither trips it. It keys on isScheduled, not isRunning (a clamped one-shot is paused but still drives the rig; a stopped action keeps a stale weight).
- visual.ts routes clip starts through beginAction, which crossfades only when the outgoing action still drives the rig and otherwise snaps to full weight (fading in from zero with no partner WAS the T-pose). Closes the same-clip re-trigger, the respawn hand-off, and the no-death-clip bail. revive() clears the one-shot latch a missed finished event could leave set. desiredBase now asks whether the LOADED rig has walkBack, not whether the ClipMap names it.
- tests/character_clipmaps.test.ts is a new CI gate: every ClipMap name in the manifest must exist in the shipped GLB (parsed straight from the container, both graphics tiers, 145 rigs). It found mob_stag naming a clip (Attack) its GLB does not ship, so every second stag swing played no animation: fixed to Attack_Kick (all sibling stag repaints already used it). Clip-less prop rigs and the sentinel-name rig are pinned allowlists. No player rig had a phantom name.

Follow-ups deliberately not in this PR: the visual pool does not reset animation state for pooled mob rigs (the watchdog now covers the zero-weight half); pendingDt catch-up can pop a fade; the far-mesh band flip on cast/target change (0bd4ddaa9) is a visible pose discontinuity on other players but cannot T-pose (no player rig bakes a bind-pose far mesh, per the new gate); a same-action one-shot can freeze a statue at full weight (warrior spin), out of the T-pose class.

## Test plan
- [x] tests/character_anim_state.test.ts (new, 26): watchdog predicate against stopped-with-stale-weight, faded-out, crossfade, clamped-hold, dead-lock, empty-rig, debounce/re-arm sequences; desiredBaseState and locomotionTimeScale coverage (previously untested)
- [x] tests/character_tpose_repair.test.ts (new, 6): drives a real CharacterVisual through a real AnimationMixer and asserts summed pose weight: forced latch heals within the window, heals while update-throttled, death to respawn never dips, repeated swing never dips, corpse without a death clip, healthy-path control. 5 of 6 fail against the pre-fix code with the exact weights above
- [x] tests/character_clipmaps.test.ts (new, 8): the GLB clip gate, self-checking that new ClipMap fields must join it
- [x] 23 files / 257 tests green across the character/render suites (visual_manifest, character_visual_fail_soft, weapon_stow, mob_locomotion, crowd_lod, rig_merge, architecture, and friends)
- [x] npx tsc --noEmit clean; biome clean on changed files
- [ ] PBE2 check: rez at a graveyard and hold a strafe immediately; repeat-swing a training dummy; confirm stags actually kick