### PR TITLE
fix(drakelands): seal the last keep flank collision traps

### DIFF
--- a/src/render/castle_features.ts
+++ b/src/render/castle_features.ts
@@ -160,6 +160,10 @@ export function buildCastleFeatures(): CastleFeaturesView {
 
   // stone slab helper: the visible floor caps and stair masses
   const slabMat = surfaceMat({ color: 0x8a7568, roughness: 0.95 });
+  // the solid wedge masses (the wall flights and the ward's stair cuts) are
+  // hand-wound triangle soups, so they draw both faces
+  const wedgeMat = surfaceMat({ color: 0x8a7568, roughness: 0.95 });
+  wedgeMat.side = THREE.DoubleSide;
   const capMat = surfaceMat({ color: 0x97826f, roughness: 0.9 });
   const slab = (
     cx: number,
@@ -334,16 +338,44 @@ export function buildCastleFeatures(): CastleFeaturesView {
     }
   }
 
-  // ---- the ward: a foundation-block retaining edge with two stone stair
-  // cuts, so the keep terrace reads as built masonry, not a dirt shelf ----
+  // ---- the ward: a SOLID PLINTH from the bailey floor to the terrace, faced
+  // with foundation blocks and cut by two stone stairs, so the keep terrace
+  // reads as built masonry, not a dirt shelf ----
+  //
+  // The plinth is load-bearing, not dressing. The terrain mesh deliberately
+  // leaves the terrace out (render/terrain_mesh_height.ts: its 0.7yd retaining
+  // blend is far narrower than the vertex lattice, so a meshed terrace smeared
+  // its faces out over the bailey and buried anyone walking along them). This
+  // mass IS the terrace the player stands on, exactly like the wall-walk cap
+  // slabs are the walk: its top sits at the ward height groundHeight reports.
   {
     const w = CASTLE.ward;
     const rise = w.h - padY;
     const fScale = rise / 2; // foundation piece is 2 units tall
-    const edges: { x0: number; z0: number; x1: number; z1: number }[] = [
-      { x0: w.x0, z0: w.z0, x1: w.x0, z1: w.z1 }, // west edge
-      { x0: w.x0, z0: w.z1, x1: w.x1, z1: w.z1 }, // south edge (stair cuts)
-      { x0: w.x1, z0: w.z0, x1: w.x1, z1: w.z1 }, // east edge
+    /** kcas_foundation is 2.2 units square in plan */
+    const fHalf = (2.2 * fScale) / 2;
+    // the terrace mass. Sunk below the flat mesh at its foot so the two never
+    // z-fight, and pulled a hair inside the rect so the block facing wins.
+    {
+      const inset = 0.05;
+      const mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(w.x1 - w.x0 - inset * 2, rise + 0.4, w.z1 - w.z0 - inset * 2),
+        slabMat,
+      );
+      mesh.position.set((w.x0 + w.x1) / 2, w.h - (rise + 0.4) / 2, (w.z0 + w.z1) / 2);
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+      group.add(mesh);
+    }
+    // The retaining facing, on all four sides. Each block is offset INWARD by
+    // its own half depth so its outer face lands on the rect line: the sim's
+    // cliff. Straddling the line (the old placement) put 1.4yd of stonework
+    // over bailey floor the player walks on, and they walked into it.
+    const edges: { x0: number; z0: number; x1: number; z1: number; cuts?: boolean }[] = [
+      { x0: w.x0 + fHalf, z0: w.z0, x1: w.x0 + fHalf, z1: w.z1 }, // west edge
+      { x0: w.x1 - fHalf, z0: w.z0, x1: w.x1 - fHalf, z1: w.z1 }, // east edge
+      { x0: w.x0, z0: w.z0 + fHalf, x1: w.x1, z1: w.z0 + fHalf }, // north edge
+      { x0: w.x0, z0: w.z1 - fHalf, x1: w.x1, z1: w.z1 - fHalf, cuts: true }, // south
     ];
     const stepGap = (v: number): boolean =>
       WARD_STEPS.some((cut) => v > cut.x0 - 1.4 && v < cut.x1 + 1.4);
@@ -354,7 +386,7 @@ export function buildCastleFeatures(): CastleFeaturesView {
         const t = i / n;
         const x = e.x0 + (e.x1 - e.x0) * t;
         const z = e.z0 + (e.z1 - e.z0) * t;
-        if (e.z0 === e.z1 && stepGap(x)) continue; // part at the stair cuts
+        if (e.cuts && stepGap(x)) continue; // part at the stair cuts
         put('kcasFoundation', {
           x,
           y: padY,
@@ -364,7 +396,9 @@ export function buildCastleFeatures(): CastleFeaturesView {
         });
       }
     }
-    // the stair cuts: wide stone steps down from the terrace
+    // the stair cuts: wide stone steps down from the terrace, over a solid
+    // wedge whose TOP is the ramp surface castlePadTarget authors (the mesh
+    // leaves the cuts out with the rest of the ward, so this carries them)
     for (const cut of WARD_STEPS) {
       const cx = (cut.x0 + cut.x1) / 2;
       put('kcasStairsWide', {
@@ -374,20 +408,48 @@ export function buildCastleFeatures(): CastleFeaturesView {
         rot: Math.PI,
         s: 0.62,
       });
-      // sloped mass under the walk surface so the cut reads solid
-      const mesh = new THREE.Mesh(
-        new THREE.BoxGeometry(cut.x1 - cut.x0, 1.0, WARD_STEP_RUN + 0.8),
-        slabMat,
-      );
-      mesh.position.set(cx, padY + rise / 2 - 0.2, w.z1 + WARD_STEP_RUN / 2);
-      mesh.rotation.x = Math.atan2(rise, WARD_STEP_RUN);
+      const z0 = w.z1;
+      const z1 = w.z1 + WARD_STEP_RUN;
+      const base = padY - 0.4;
+      const v: number[] = [];
+      const quad = (
+        p0: [number, number, number],
+        p1: [number, number, number],
+        p2: [number, number, number],
+        p3: [number, number, number],
+      ): void => {
+        v.push(...p0, ...p1, ...p2, ...p0, ...p2, ...p3);
+      };
+      // top (the ramp: w.h at the terrace edge down to padY at the run's end)
+      quad([cut.x0, w.h, z0], [cut.x1, w.h, z0], [cut.x1, padY, z1], [cut.x0, padY, z1]);
+      for (const [sx, dir] of [
+        [cut.x0, -1],
+        [cut.x1, 1],
+      ] as const) {
+        const side: [number, number, number][] = [
+          [sx, w.h, z0],
+          [sx, base, z0],
+          [sx, base, z1],
+          [sx, padY, z1],
+        ];
+        if (dir < 0) quad(side[0], side[1], side[2], side[3]);
+        else quad(side[3], side[2], side[1], side[0]);
+      }
+      quad([cut.x0, w.h, z0], [cut.x0, base, z0], [cut.x1, base, z0], [cut.x1, w.h, z0]);
+      const geo = new THREE.BufferGeometry();
+      geo.setAttribute('position', new THREE.BufferAttribute(new Float32Array(v), 3));
+      geo.computeVertexNormals();
+      const mesh = new THREE.Mesh(geo, wedgeMat);
       mesh.castShadow = true;
       mesh.receiveShadow = true;
       group.add(mesh);
     }
-    // terrace floor trim: large tiles along the ward's south rim
+    // terrace paving: the same large tiles the bailey court is laid with, so
+    // the plinth top reads as the keep's paved yard rather than bare stone
     for (let x = w.x0 + 3.5; x < w.x1 - 1; x += M) {
-      put('kcasFloorLarge', { x, y: w.h + 0.02, z: w.z1 - 3, rot: 0 });
+      for (let z = w.z0 + 3.5; z < w.z1 - 1; z += M) {
+        put('kcasFloorLarge', { x, y: w.h + 0.02, z, rot: 0 });
+      }
     }
   }
 
@@ -563,8 +625,6 @@ export function buildCastleFeatures(): CastleFeaturesView {
   // ---- the stair flights: SOLID wedge piers from their footing to the
   // sloped surface (the lift terrain is invisible, so the mass itself must
   // read as built masonry), with a stone tread at each bailey foot ----
-  const wedgeMat = slabMat.clone();
-  wedgeMat.side = THREE.DoubleSide;
   for (const rmp of CASTLE_RAMPS) {
     const baseY = rmp.h0 <= padY + 0.1 || rmp.h1 <= padY + 0.1 ? padY - 0.4 : CASTLE.walkAbs - 0.6;
     // 8 corners: along the run a0 -> a1, surface h0 -> h1, flat base

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -12,7 +12,7 @@ import {
 } from '../sim/data';
 import { fbm2 } from '../sim/rng';
 import type { BiomeId, ZoneDef } from '../sim/types';
-import { roadDistance, terrainHeight, WATER_LEVEL, zoneBiomeAt } from '../sim/world';
+import { roadDistance, WATER_LEVEL, zoneBiomeAt } from '../sim/world';
 import { loadTexture } from './assets/loader';
 import { registerPreload } from './assets/preload';
 import { type ChunkGrid, type GroundPendingAt, orderCellsForEntry } from './chunk_residency_core';
@@ -27,6 +27,7 @@ import {
   fillChunkVertexRow,
 } from './terrain_chunk_build';
 import { terrainChunkPool } from './terrain_chunk_pool';
+import { meshTerrainHeight } from './terrain_mesh_height';
 import {
   chunkIntersectsRegion,
   normalTexelBounds,
@@ -53,7 +54,7 @@ import { groundDetailTexture, groundSplatMaps, macroNoiseTexture } from './textu
 // - High tier: MeshStandardMaterial + splat shading (grass/dirt/rock/sand
 //   weights precomputed per vertex from slope/height/roadDistance into a vec4
 //   attribute) over the biome vertex-color tint, plus a world-space macro
-//   normal map baked from terrainHeight.
+//   normal map baked from the mesh height view (terrain_mesh_height.ts).
 // - Low tier: the legacy vertex-color Lambert look, still chunked for culling.
 
 const CHUNK_SIZE = 60;
@@ -145,7 +146,7 @@ const WALL_LOD_RIM_MARGIN = 40;
 // Macro relief only needs to carry broad slopes: vertex normals and the four
 // tiled material normals own close detail. The atlas spans the whole expanded
 // world but is baked sparsely by zone, so keep it compact enough that entering
-// a new region never turns tens of thousands of terrainHeight samples into a
+// a new region never turns tens of thousands of height samples into a
 // second boot. At the current bounds this is roughly 3yd/texel.
 const NORMAL_TEX_W = 320;
 const NORMAL_TEX_H = 960;
@@ -216,13 +217,13 @@ async function buildChunkGeometryIdle(
 }
 
 // ---------------------------------------------------------------------------
-// Macro relief: a DataTexture normal map baked from terrainHeight in
+// Macro relief: a DataTexture normal map baked from the mesh height view in
 // strip-planar UV space — cliffs and ridges get per-pixel light response far
 // beyond the vertex density.
 // ---------------------------------------------------------------------------
 
 // Bake the normal texels [i0..i1] x [j0..j1] (inclusive) into `data`, sampling
-// the CURRENT terrainHeight. The full build and the editor's partial rebake
+// the CURRENT mesh height. The full build and the editor's partial rebake
 // share this one path so a partial rebake is byte-identical to a full one:
 // heights are sampled one texel beyond the baked rect (clamped at the texture
 // border, exactly like the full bake's clamped derivative stencil).
@@ -250,7 +251,7 @@ function bakeNormalRegion(
   for (let j = hj0; j <= hj1; j++) {
     const z = WORLD_MIN_Z + (j + 0.5) * stepZ;
     for (let i = hi0; i <= hi1; i++) {
-      heights[(j - hj0) * hw + (i - hi0)] = terrainHeight(
+      heights[(j - hj0) * hw + (i - hi0)] = meshTerrainHeight(
         -WORLD_MAX_X + (i + 0.5) * stepX,
         z,
         seed,
@@ -583,7 +584,7 @@ export interface TerrainView {
   rebuildRegion(minX: number, minZ: number, maxX: number, maxZ: number): void;
   /**
    * Editor-only: rebake the region's texels of the macro normal DataTexture
-   * from the current terrainHeight and flag it for re-upload. Byte-identical
+   * from the current mesh height and flag it for re-upload. Byte-identical
    * to a full bake over those texels. Call at stroke end, never per drag
    * sample. No-op on the Lambert tier (it has no normal map).
    */

--- a/src/render/terrain_chunk_build.ts
+++ b/src/render/terrain_chunk_build.ts
@@ -34,8 +34,9 @@ import {
 } from '../sim/data';
 import { fbm2 } from '../sim/rng';
 import type { BiomeId } from '../sim/types';
-import { roadDistance, terrainHeight, WATER_LEVEL, zoneBiomeAt } from '../sim/world';
+import { roadDistance, WATER_LEVEL, zoneBiomeAt } from '../sim/world';
 import { impactCraterTerrainBlend } from './impact_terrain';
+import { meshTerrainHeight } from './terrain_mesh_height';
 
 const SKIRT_DROP = 0.3;
 const SLOPE_EPS = 1.5; // matches the legacy color pass so tints don't shift
@@ -309,9 +310,9 @@ function lerpSplat(w: [number, number, number, number], layer: 0 | 1 | 2 | 3, t:
 // One terrain sample: height, analytic normal, legacy tint color and splat
 // weights. Both tiers use the color; only the splat tier consumes weights.
 function sampleVertex(x: number, z: number, seed: number, lowShade: boolean): VertexSample {
-  const h = terrainHeight(x, z, seed);
-  const hx = terrainHeight(x + SLOPE_EPS, z, seed) - terrainHeight(x - SLOPE_EPS, z, seed);
-  const hz = terrainHeight(x, z + SLOPE_EPS, seed) - terrainHeight(x, z - SLOPE_EPS, seed);
+  const h = meshTerrainHeight(x, z, seed);
+  const hx = meshTerrainHeight(x + SLOPE_EPS, z, seed) - meshTerrainHeight(x - SLOPE_EPS, z, seed);
+  const hz = meshTerrainHeight(x, z + SLOPE_EPS, seed) - meshTerrainHeight(x, z - SLOPE_EPS, seed);
   const slope = Math.sqrt(hx * hx + hz * hz) / (2 * SLOPE_EPS);
   const invLen = 1 / Math.hypot(hx / (2 * SLOPE_EPS), 1, hz / (2 * SLOPE_EPS));
   const normal: [number, number, number] = [

--- a/src/render/terrain_mesh_height.ts
+++ b/src/render/terrain_mesh_height.ts
@@ -1,0 +1,30 @@
+// The height the TERRAIN MESH is built from.
+//
+// The chunk generator samples a vertex lattice (1.2yd at the densest LOD band,
+// 3.0yd on the low tier) and draws flat triangles between the samples, so it
+// can only carry features WIDER than that lattice. Anything sharper renders as
+// a smeared ramp while the sim keeps the exact cliff, and the two surfaces
+// disagree: a player standing at the sim height either floats over the drawn
+// ground or sinks into it.
+//
+// The castle's built masses already avoid this: the curtain walls, bastions
+// and stair flights live in castleLift, which groundHeight adds and
+// terrainHeight does not, and render/castle_features.ts draws each one with a
+// visible cap so nobody stands on air. The Last Keep's inner ward was the one
+// exception, a 2.6yd terrace with a 0.7yd retaining blend baked into
+// terrainHeight; its faces smeared up to 1.7yd out over the bailey and buried
+// anyone walking along them (player report: characters sinking into the ground
+// on the keep's east and west faces).
+//
+// So the mesh subtracts the ward terrace and castle_features.ts draws it as
+// masonry. This is a RENDER view only: groundHeight, the climb gate, the
+// steepness field, and every collision path still see the exact terrace.
+import { castlePadWeight, wardTerraceRise } from '../sim/castle_layout';
+import { terrainHeight } from '../sim/world';
+
+export function meshTerrainHeight(x: number, z: number, seed: number): number {
+  const rise = wardTerraceRise(x, z);
+  const h = terrainHeight(x, z, seed);
+  // exactly the contribution applyCastlePad added: target lerped in by weight
+  return rise > 0 ? h - rise * castlePadWeight(x, z) : h;
+}

--- a/src/sim/castle_layout.ts
+++ b/src/sim/castle_layout.ts
@@ -284,29 +284,49 @@ export function castleClear(x: number, z: number): boolean {
 const LAST_SPRING = { x: 456, z: 1988 } as const;
 
 /**
- * The local pad TARGET height: the inner ward terrace inside its rect
- * (with the two stair cuts ramping its south edge down), the bailey floor
- * everywhere else inside the pad.
+ * The inner ward terrace's rise above the bailey floor: the full 2.6 inside
+ * its rect, blended down over WARD_EDGE_BLEND at the retaining edge, and
+ * ramping back down over WARD_STEP_RUN inside the two stair cuts. Zero
+ * everywhere else.
+ *
+ * Split out because the RENDER has to subtract it. The retaining blend is
+ * 0.7yd, far narrower than the terrain mesh's vertex lattice (1.2yd at the
+ * densest LOD band, 3.0yd on the low tier), so a mesh built straight off
+ * terrainHeight smears this cliff into a ramp that climbs up to 1.7yd above
+ * the bailey floor the sim actually stands players on: they sink into the
+ * drawn ground along the ward's faces. The terrace is therefore drawn as a
+ * built mass instead (render/castle_features.ts) over a flat mesh, the same
+ * way the curtain walls, bastions and stair flights already are. See
+ * render/terrain_mesh_height.ts.
  */
-export function castlePadTarget(x: number, z: number): number {
+export function wardTerraceRise(x: number, z: number): number {
   const w = CASTLE.ward;
-  if (x < w.x0 || x > w.x1 || z < w.z0 || z > w.z1 + WARD_STEP_RUN) return CASTLE.pad.h;
+  if (x < w.x0 || x > w.x1 || z < w.z0 || z > w.z1 + WARD_STEP_RUN) return 0;
   const rise = CASTLE.ward.h - CASTLE.pad.h;
   if (z <= w.z1) {
     // the terrace proper; a narrow blend at the rect edge keeps the riser
     // sheer enough to refuse the climb gate but not a numeric wall
     const edge = Math.min(x - w.x0, w.x1 - x, z - w.z0);
-    return CASTLE.pad.h + rise * Math.min(1, edge / WARD_EDGE_BLEND);
+    return rise * Math.min(1, edge / WARD_EDGE_BLEND);
   }
   // south of the terrace edge: bailey, except inside a stair cut where the
   // surface ramps down over WARD_STEP_RUN
   for (const cut of WARD_STEPS) {
     if (x >= cut.x0 && x <= cut.x1) {
       const t = (z - w.z1) / WARD_STEP_RUN;
-      return CASTLE.pad.h + rise * (1 - Math.min(1, t));
+      return rise * (1 - Math.min(1, t));
     }
   }
-  return CASTLE.pad.h;
+  return 0;
+}
+
+/**
+ * The local pad TARGET height: the inner ward terrace inside its rect
+ * (with the two stair cuts ramping its south edge down), the bailey floor
+ * everywhere else inside the pad.
+ */
+export function castlePadTarget(x: number, z: number): number {
+  return CASTLE.pad.h + wardTerraceRise(x, z);
 }
 
 /** The graded pad weight: level grounds, gentle skirt back to the waste. */

--- a/src/sim/castle_layout.ts
+++ b/src/sim/castle_layout.ts
@@ -14,6 +14,7 @@
 // bailey sits at padH and the inner ward, the keep's raised terrace,
 // 2.6 above it behind a retaining edge with two stair cuts. Pure leaf:
 // deterministic, no rng, no SimContext.
+import type { BlockerDef } from './types';
 
 export const CASTLE = {
   // the graded grounds (terrain levels to the local pad target; the skirt
@@ -39,6 +40,12 @@ export const CASTLE = {
   /** mid-wall tower half-width */
   midTowerHw: 2.8,
 } as const;
+
+/** The ward's retaining edge blend: how far inside the ward rect the terrace
+ *  reaches full height. Sheer enough for the climb gate to refuse it, but not
+ *  a numeric wall. Anything that must MEET the edge (the alley flight's mass)
+ *  has to reach the far side of this band or it leaves a crack. */
+export const WARD_EDGE_BLEND = 0.7;
 
 // The three ways in. Every opening is a gap in the wall riser; spans are in
 // the wall's run coordinate (z for the west/east walls, x for north/south).
@@ -138,8 +145,19 @@ export const CASTLE_RAMPS: readonly CastleRamp[] = [
   // ...and its flat landing, bridging the flight top onto the SW bastion
   { axis: 'z', b0: 361.0, b1: 363.6, a0: 2058.6, a1: 2069, h0: CASTLE.walkAbs, h1: CASTLE.walkAbs },
   // the alley flight: squeezed between the north wall and the ward's
-  // retaining edge, climbing east to the NE walk
-  { axis: 'x', b0: 1989.0, b1: 1991.3, a0: 414, a1: 433.6, h0: 6, h1: CASTLE.walkAbs },
+  // retaining edge, climbing east to the NE walk. The band runs THROUGH the
+  // ward's retaining blend (the overlap rule above): stopping at the rect line
+  // left a sliver of bailey floor between the stair mass and the terrace that
+  // a walker fell up to 6.8yd into and could not climb out of.
+  {
+    axis: 'x',
+    b0: 1989.0,
+    b1: CASTLE.ward.z0 + WARD_EDGE_BLEND,
+    a0: 414,
+    a1: 433.6,
+    h0: 6,
+    h1: CASTLE.walkAbs,
+  },
   // the watch flight: the far wall-walk itself climbs to the SE chamber
   {
     axis: 'x',
@@ -193,6 +211,26 @@ export const CASTLE_BUILDINGS: readonly CastleBuilding[] = [
   { key: 'hexrBarracks', x: 400, z: 2063, rot: 0, scale: 7.5, r: 6, h: 12.5 },
   { key: 'hexrChurch', x: 413, z: 2060, rot: -Math.PI / 2, scale: 7.5, r: 5.5, h: 12.5 },
   { key: 'hexrTavern', x: 421, z: 2043, rot: Math.PI, scale: 7.5, r: 5.5, h: 10.5 },
+] as const;
+
+// The keep and the great hall stand 1.2yd apart on the ward terrace, closer
+// than a player body can use. Their collision circles are INSCRIBED in square
+// meshes, so that slot's floor sits inside both rendered buildings: a player
+// who squeezed in stood under the stonework (it reads as being underground)
+// with barely room to turn around. Two invisible blocker walls close the neck
+// at the point where the gap is still wide enough to stand in, so the slot can
+// never be entered from either end. The terrace east of the keep (2.4yd clear)
+// stays the way around to the ward's north yard.
+//
+// Same idiom as JAIL_BLOCKERS: fence-width, camera-ghost, never jumpable, and
+// pure static data (no rng, no tick-order effect). Merged into the built-in
+// world's blockers in data.ts, so all three hosts collide identically.
+export const CASTLE_BLOCKERS: readonly BlockerDef[] = [
+  // the slot's north mouth: from inside the great hall's circle to inside the
+  // keep's, so neither end can be walked around
+  { x1: 410.2, z1: 2003.9, x2: 412.6, z2: 2003.9 },
+  // the slot's south mouth
+  { x1: 410.2, z1: 2006.1, x2: 412.6, z2: 2006.1 },
 ] as const;
 
 // Ember crystals of varying sizes around the grounds and approach (drawn by
@@ -258,7 +296,7 @@ export function castlePadTarget(x: number, z: number): number {
     // the terrace proper; a narrow blend at the rect edge keeps the riser
     // sheer enough to refuse the climb gate but not a numeric wall
     const edge = Math.min(x - w.x0, w.x1 - x, z - w.z0);
-    return CASTLE.pad.h + rise * Math.min(1, edge / 0.7);
+    return CASTLE.pad.h + rise * Math.min(1, edge / WARD_EDGE_BLEND);
   }
   // south of the terrace edge: bailey, except inside a stair cut where the
   // surface ramps down over WARD_STEP_RUN

--- a/src/sim/data.ts
+++ b/src/sim/data.ts
@@ -27,6 +27,7 @@ import type {
 
 export type { FishingEntry } from './content/items';
 
+import { CASTLE_BLOCKERS } from './castle_layout';
 import {
   AMBERFALL_CAMPS,
   AMBERFALL_ITEMS,
@@ -707,7 +708,9 @@ export const BUILTIN_WORLD: WorldContent = {
     noticeboards: NOTICEBOARDS,
     graveyards: OVERWORLD_GRAVEYARDS,
   },
-  blockers: JAIL_BLOCKERS,
+  // invisible collision walls: the moderation cage plus the Last Keep's
+  // sealed building slot (castle_layout.ts CASTLE_BLOCKERS)
+  blockers: [...JAIL_BLOCKERS, ...CASTLE_BLOCKERS],
   terrainEdits: JAIL_TERRAIN_EDITS,
 };
 

--- a/tests/last_keep_face_sink.test.ts
+++ b/tests/last_keep_face_sink.test.ts
@@ -1,0 +1,221 @@
+// A character standing on the Last Keep's grounds must stand on the ground it
+// SEES. The reported break (maintainer, on the castle's east and west faces):
+// run a character along them and it sinks into the terrain.
+//
+// Mechanism: the terrain chunk mesh samples a vertex lattice (1.2yd at the
+// densest LOD band, 3.0yd on the low tier) and draws flat triangles between
+// samples, so it can only carry features WIDER than that lattice. Every other
+// built mass in the castle already respects that (the curtain walls, bastions
+// and stair flights live in castleLift, which terrainHeight excludes and
+// castle_features.ts draws), but the inner ward's 2.6yd terrace sat in
+// terrainHeight behind a 0.7yd retaining blend. The mesh smeared that cliff
+// into a ramp spilling out over the bailey, so the drawn ground stood up to
+// 1.73yd ABOVE the floor the sim puts the player's feet on, along both faces.
+//
+// The gate below is lattice-independent: over the graded castle grounds the
+// mesh height view must be exactly FLAT, and a constant field interpolates
+// exactly at any spacing and any phase, so no LOD band can reintroduce a sink.
+// The lattice replication then measures the thing a player actually sees.
+import type * as THREE from 'three';
+import { describe, expect, it, vi } from 'vitest';
+import { meshTerrainHeight } from '../src/render/terrain_mesh_height';
+import {
+  CASTLE,
+  castleLift,
+  castlePadWeight,
+  WARD_STEP_RUN,
+  WARD_STEPS,
+  wardTerraceRise,
+} from '../src/sim/castle_layout';
+import { WORLD_MAX_X, WORLD_MIN_Z } from '../src/sim/data';
+import { groundHeight } from '../src/sim/world';
+
+const SEED = 20061;
+// render/terrain.ts: CHUNK_SIZE and every LOD_BANDS spacing, high and low tier
+const CHUNK_SIZE = 60;
+const SPACINGS = [1.2, 1.6, 2.6, 3.0, 4.4, 6.5];
+/** the graded castle grounds: the walls plus a margin, all at pad weight 1 */
+const GROUNDS = { x0: 350, x1: 444, z0: 1982, z1: 2078 };
+
+/**
+ * The drawn terrain surface at (x, z): the chunk mesh's triangle, rebuilt from
+ * the same lattice and the same diagonal choice as fillChunkVertexRow /
+ * fillChunkIndexRow in render/terrain_chunk_build.ts.
+ */
+function meshSurface(x: number, z: number, spacing: number, originX: number): number {
+  const cx = Math.floor((x - originX) / CHUNK_SIZE);
+  const cz = Math.floor((z - WORLD_MIN_Z) / CHUNK_SIZE);
+  const x0 = originX + cx * CHUNK_SIZE;
+  const z0 = WORLD_MIN_Z + cz * CHUNK_SIZE;
+  const n = Math.max(4, Math.round(CHUNK_SIZE / spacing));
+  const step = CHUNK_SIZE / n;
+  const i = Math.min(n - 1, Math.floor((x - x0) / step));
+  const j = Math.min(n - 1, Math.floor((z - z0) / step));
+  const vx = x0 + i * step;
+  const vz = z0 + j * step;
+  const ha = meshTerrainHeight(vx, vz, SEED);
+  const hb = meshTerrainHeight(vx + step, vz, SEED);
+  const hc = meshTerrainHeight(vx, vz + step, SEED);
+  const hd = meshTerrainHeight(vx + step, vz + step, SEED);
+  const u = (x - vx) / step;
+  const v = (z - vz) / step;
+  if (Math.abs(hb - hc) <= Math.abs(ha - hd)) {
+    // b-c diagonal: triangles either side of u + v = 1
+    return u + v <= 1
+      ? ha + (hb - ha) * u + (hc - ha) * v
+      : hd + (hc - hd) * (1 - u) + (hb - hd) * (1 - v);
+  }
+  // a-d diagonal: triangles either side of v = u
+  return v <= u ? ha + (hb - ha) * u + (hd - hb) * v : ha + (hc - ha) * v + (hd - hc) * u;
+}
+
+/** Sample points over a rect. */
+function grid(r: { x0: number; x1: number; z0: number; z1: number }, s: number) {
+  const out: { x: number; z: number }[] = [];
+  for (let x = r.x0; x <= r.x1 + 1e-9; x += s) {
+    for (let z = r.z0; z <= r.z1 + 1e-9; z += s) out.push({ x, z });
+  }
+  return out;
+}
+
+describe('the Last Keep is drawn on the ground the sim stands players on', () => {
+  it('keeps the terrain mesh view exactly flat over the graded castle grounds', () => {
+    // The one property that makes the mesh lattice-proof. Any feature left in
+    // here that is narrower than a vertex cell comes back as a sink.
+    for (const p of grid(GROUNDS, 0.25)) {
+      if (castlePadWeight(p.x, p.z) !== 1) continue;
+      expect(
+        Math.abs(meshTerrainHeight(p.x, p.z, SEED) - CASTLE.pad.h),
+        `mesh height view at (${p.x.toFixed(2)}, ${p.z.toFixed(2)})`,
+      ).toBeLessThan(1e-4);
+    }
+  });
+
+  it('never draws ground above a player standing on the keep flanks, at any LOD', () => {
+    // The east and west faces the report names, plus the north and south rims,
+    // swept at every LOD band spacing and at two lattice phases (the real
+    // chunk anchor and a half-cell offset), so no vertex alignment hides it.
+    const faces = [
+      { name: 'west face', x0: 393, x1: 403, z0: 1990, z1: 2020 },
+      { name: 'east face', x0: 428, x1: 438, z0: 1990, z1: 2020 },
+      { name: 'north rim', x0: 396, x1: 435, z0: 1986, z1: 1996 },
+      { name: 'south rim', x0: 396, x1: 435, z0: 2014, z1: 2024 },
+    ];
+    for (const face of faces) {
+      for (const spacing of SPACINGS) {
+        for (const originX of [-WORLD_MAX_X, -WORLD_MAX_X + CHUNK_SIZE / 2]) {
+          for (const p of grid(face, 0.5)) {
+            if (castlePadWeight(p.x, p.z) !== 1) continue;
+            const drawn = meshSurface(p.x, p.z, spacing, originX);
+            expect(
+              drawn - groundHeight(p.x, p.z, SEED),
+              `${face.name} sink at (${p.x.toFixed(1)}, ${p.z.toFixed(1)}) spacing ${spacing}`,
+            ).toBeLessThan(0.02);
+          }
+        }
+      }
+    }
+  });
+
+  it('leaves nobody standing on air: every gap under the feet is authored masonry', () => {
+    // Where the mesh sits BELOW the sim ground, a built mass has to be drawn
+    // there. castleLift is the curtain walls, bastions and stair flights;
+    // wardTerraceRise is the ward plinth castle_features.ts now builds.
+    for (const p of grid(GROUNDS, 0.25)) {
+      if (castlePadWeight(p.x, p.z) !== 1) continue;
+      const gap = groundHeight(p.x, p.z, SEED) - meshTerrainHeight(p.x, p.z, SEED);
+      if (gap <= 0.05) continue;
+      const built = castleLift(p.x, p.z) > 0 || wardTerraceRise(p.x, p.z) > 0;
+      expect(
+        built,
+        `unbuilt ${gap.toFixed(2)}yd gap at (${p.x.toFixed(2)}, ${p.z.toFixed(2)})`,
+      ).toBe(true);
+    }
+  });
+
+  it('pins the ward mass the render draws to the terrace the sim walks', () => {
+    // castle_features.ts builds the plinth, its facing blocks and its stair
+    // wedges from exactly these numbers, so they cannot drift apart.
+    const w = CASTLE.ward;
+    expect(wardTerraceRise(415, 2005), 'full height well inside the rect').toBeCloseTo(2.6, 6);
+    expect(CASTLE.ward.h - CASTLE.pad.h, 'the terrace stands 2.6 over the bailey').toBeCloseTo(
+      2.6,
+      6,
+    );
+    expect(groundHeight(415, 2005, SEED), 'the sim terrace').toBeCloseTo(8.6, 6);
+    // zero on every rect line, so the drawn facing sits on the sim's cliff
+    for (const p of [
+      { x: w.x0, z: 2005 },
+      { x: w.x1, z: 2005 },
+      { x: 415, z: w.z0 },
+      { x: 393, z: 2005 },
+      { x: 438, z: 2005 },
+    ]) {
+      expect(wardTerraceRise(p.x, p.z), `ward rise at (${p.x}, ${p.z})`).toBe(0);
+    }
+    // the two stair cuts ramp the terrace down to the bailey over their run
+    for (const cut of WARD_STEPS) {
+      const cx = (cut.x0 + cut.x1) / 2;
+      expect(wardTerraceRise(cx, w.z1), 'cut starts at terrace height').toBeCloseTo(2.6, 6);
+      expect(wardTerraceRise(cx, w.z1 + WARD_STEP_RUN / 2), 'half way down').toBeCloseTo(1.3, 6);
+      expect(wardTerraceRise(cx, w.z1 + WARD_STEP_RUN), 'lands on the bailey').toBeCloseTo(0, 6);
+      // and the rise is gentle enough for the mesh-free wedge to read as stairs
+      expect(2.6 / WARD_STEP_RUN, 'stair run').toBeLessThan(1);
+    }
+  });
+
+  it('builds a solid ward mass whose top is the terrace height, not a dirt shelf', async () => {
+    // The mesh no longer carries the terrace, so castle_features.ts MUST: this
+    // is what a player on the ward now stands on. Asset loads never resolve, so
+    // only the analytic masses land in the group, which is exactly what we want
+    // to measure.
+    vi.resetModules();
+    vi.doMock('../src/render/assets/loader', () => ({
+      loadGltf: vi.fn(() => new Promise(() => {})),
+      loadHdr: vi.fn(() => new Promise(() => {})),
+      loadTexture: vi.fn(() => new Promise(() => {})),
+      releaseGltf: vi.fn(),
+    }));
+    const { buildCastleFeatures } = await import('../src/render/castle_features');
+    const w = CASTLE.ward;
+    const view = buildCastleFeatures();
+    const boxes = view.group.children
+      .filter((c): c is THREE.Mesh => (c as THREE.Mesh).isMesh)
+      .map((mesh) => {
+        mesh.geometry.computeBoundingBox();
+        return (mesh.geometry.boundingBox as THREE.Box3)
+          .clone()
+          .applyMatrix4(
+            mesh.matrixWorld.clone().compose(mesh.position, mesh.quaternion, mesh.scale),
+          );
+      });
+    // the terrace mass: the one that spans most of the ward rect in both axes
+    const plinth = boxes.find(
+      (b) => b.max.x - b.min.x > (w.x1 - w.x0) * 0.9 && b.max.z - b.min.z > (w.z1 - w.z0) * 0.9,
+    );
+    expect(plinth, 'a ward-sized mass must be drawn under the terrace').toBeTruthy();
+    if (!plinth) return;
+    expect(plinth.max.y, 'its top IS the terrace the sim walks').toBeCloseTo(CASTLE.ward.h, 4);
+    expect(plinth.min.y, 'and it reaches below the bailey floor it stands on').toBeLessThan(
+      CASTLE.pad.h,
+    );
+    // it may not overhang the rect: that ground is walkable bailey
+    expect(plinth.min.x).toBeGreaterThanOrEqual(w.x0 - 1e-6);
+    expect(plinth.max.x).toBeLessThanOrEqual(w.x1 + 1e-6);
+    expect(plinth.min.z).toBeGreaterThanOrEqual(w.z0 - 1e-6);
+    expect(plinth.max.z).toBeLessThanOrEqual(w.z1 + 1e-6);
+    // and the two stair cuts get their own wedges reaching the terrace top
+    for (const cut of WARD_STEPS) {
+      const wedge = boxes.find(
+        (b) =>
+          b.min.x >= cut.x0 - 1e-6 &&
+          b.max.x <= cut.x1 + 1e-6 &&
+          b.min.z >= w.z1 - 1e-6 &&
+          Math.abs(b.max.y - CASTLE.ward.h) < 1e-4,
+      );
+      expect(wedge, `a stair wedge for the cut at x ${cut.x0}..${cut.x1}`).toBeTruthy();
+      expect(wedge?.max.z, 'running out to the bailey').toBeCloseTo(w.z1 + WARD_STEP_RUN, 4);
+    }
+    vi.doUnmock('../src/render/assets/loader');
+  });
+});

--- a/tests/last_keep_flank_traps.test.ts
+++ b/tests/last_keep_flank_traps.test.ts
@@ -1,0 +1,351 @@
+// The Last Keep's flanks must never wedge a player. Two authored defects put
+// standable ground into cracks a body cannot turn around in, both beside the
+// keep (player reports: "VERY easy to fall in-between the cracks or get stuck
+// underground", one death with the corpse left in the gap):
+//   NORTH FLANK: the alley flight's mass stopped at z 1991.3 while the ward's
+//   retaining edge starts at 1991.4, leaving a sliver of BAILEY floor under the
+//   stair, up to 6.8yd below the tread beside it. Falling in put the player
+//   between the drawn stair wedge and the terrace, which reads as underground.
+//   WEST FLANK: the keep and the great hall stand 1.2yd apart on the terrace,
+//   a corridor narrower than a player can use, and its floor is inside both
+//   rendered building masses (the circle colliders are inscribed in square
+//   meshes, so the mesh corners overhang walkable ground).
+// The regression gate is a REACHABLE-WEDGE scan: every spot a player can walk
+// or fall to must sit in a corridor at least a body diameter plus margin wide,
+// counting static colliders and unclimbable risers as walls.
+import { describe, expect, it } from 'vitest';
+import { CASTLE, CASTLE_RAMPS } from '../src/sim/castle_layout';
+import { isBlocked, resolveMovement } from '../src/sim/colliders';
+import { PLAYER_BODY_RADIUS, PLAYER_MAX_CLIMB_SLOPE } from '../src/sim/pathfind';
+import { rideSteepnessAt } from '../src/sim/ride_height';
+import { Sim } from '../src/sim/sim';
+import { groundHeight } from '../src/sim/world';
+
+// the live world seed: the reports are seed-pinned castle geometry
+const SEED = 20061;
+
+// the ward and both of its flanks, out to the curtain walls on either side
+const RECT = { x0: 394, x1: 440, z0: 1986, z1: 2024 };
+const TICK_STEP = 0.35; // one movement tick of run at RUN_SPEED 7
+const FINE = 0.1; // corridor-width sampling
+const WALL_RISE = 1.5; // ground this much higher within reach is a wall face
+const LOOK = 1.5; // how far to look for the facing wall
+const MIN_CORRIDOR = 1.4; // player diameter 1.0 plus a 0.4 margin
+
+interface Wedge {
+  x0: number;
+  x1: number;
+  z0: number;
+  z1: number;
+  width: number;
+  samples: number;
+}
+
+/**
+ * Ground a player can stand on and actually get to (walking in or dropping in
+ * from anywhere in the rect), whose free corridor is narrower than a body.
+ * Reachability runs the real gates: the climb limit, the standing-steepness
+ * limit, and the collider slide, on a one-tick lattice.
+ */
+function reachableWedges(): Wedge[] {
+  const gnx = Math.round((RECT.x1 - RECT.x0) / TICK_STEP) + 1;
+  const gnz = Math.round((RECT.z1 - RECT.z0) / TICK_STEP) + 1;
+  const gh = new Float64Array(gnx * gnz);
+  const gsteep = new Float64Array(gnx * gnz);
+  const gstand = new Uint8Array(gnx * gnz);
+  for (let i = 0; i < gnx; i++) {
+    for (let j = 0; j < gnz; j++) {
+      const x = RECT.x0 + i * TICK_STEP;
+      const z = RECT.z0 + j * TICK_STEP;
+      const k = i * gnz + j;
+      gh[k] = groundHeight(x, z, SEED);
+      gsteep[k] = rideSteepnessAt(x, z, SEED);
+      gstand[k] =
+        gsteep[k] <= PLAYER_MAX_CLIMB_SLOPE && !isBlocked(SEED, x, z, PLAYER_BODY_RADIUS) ? 1 : 0;
+    }
+  }
+  const neigh = [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+    [1, 1],
+    [1, -1],
+    [-1, 1],
+    [-1, -1],
+  ] as const;
+  // seed from the rect rim (open bailey and open waste on every side), then
+  // flood along every legal one-tick step
+  const reached = new Uint8Array(gnx * gnz);
+  const queue: number[] = [];
+  for (let i = 0; i < gnx; i++) {
+    for (let j = 0; j < gnz; j++) {
+      const k = i * gnz + j;
+      if (!gstand[k] || (i > 0 && j > 0 && i < gnx - 1 && j < gnz - 1)) continue;
+      reached[k] = 1;
+      queue.push(k);
+    }
+  }
+  for (let qi = 0; qi < queue.length; qi++) {
+    const k = queue[qi];
+    const i = Math.floor(k / gnz);
+    const j = k % gnz;
+    for (const [di, dj] of neigh) {
+      const ni = i + di;
+      const nj = j + dj;
+      if (ni < 0 || nj < 0 || ni >= gnx || nj >= gnz) continue;
+      const nk = ni * gnz + nj;
+      if (reached[nk] || !gstand[nk]) continue;
+      const x = RECT.x0 + i * TICK_STEP;
+      const z = RECT.z0 + j * TICK_STEP;
+      const nx = RECT.x0 + ni * TICK_STEP;
+      const nz = RECT.z0 + nj * TICK_STEP;
+      const run = Math.hypot(nx - x, nz - z);
+      const rise = gh[nk] - gh[k];
+      if (
+        rise > 0 &&
+        (rise / run > PLAYER_MAX_CLIMB_SLOPE || gsteep[nk] > PLAYER_MAX_CLIMB_SLOPE)
+      ) {
+        continue;
+      }
+      const res = resolveMovement(SEED, x, z, nx, nz, PLAYER_BODY_RADIUS);
+      if (Math.hypot(res.x - nx, res.z - nz) > TICK_STEP * 0.5) continue;
+      reached[nk] = 1;
+      queue.push(nk);
+    }
+  }
+  const canReach = (x: number, z: number): boolean => {
+    const i = Math.round((x - RECT.x0) / TICK_STEP);
+    const j = Math.round((z - RECT.z0) / TICK_STEP);
+    for (let di = -1; di <= 1; di++) {
+      for (let dj = -1; dj <= 1; dj++) {
+        const ni = i + di;
+        const nj = j + dj;
+        if (ni < 0 || nj < 0 || ni >= gnx || nj >= gnz) continue;
+        if (reached[ni * gnz + nj]) return true;
+      }
+    }
+    return false;
+  };
+
+  // fine geometry pass: corridor width on each axis, colliders and risers both
+  const nx = Math.round((RECT.x1 - RECT.x0) / FINE) + 1;
+  const nz = Math.round((RECT.z1 - RECT.z0) / FINE) + 1;
+  const h = new Float64Array(nx * nz);
+  const wall = new Uint8Array(nx * nz);
+  const stand = new Uint8Array(nx * nz);
+  for (let i = 0; i < nx; i++) {
+    for (let j = 0; j < nz; j++) {
+      const x = RECT.x0 + i * FINE;
+      const z = RECT.z0 + j * FINE;
+      const k = i * nz + j;
+      h[k] = groundHeight(x, z, SEED);
+      wall[k] = isBlocked(SEED, x, z, PLAYER_BODY_RADIUS) ? 1 : 0;
+      stand[k] = !wall[k] && rideSteepnessAt(x, z, SEED) <= PLAYER_MAX_CLIMB_SLOPE ? 1 : 0;
+    }
+  }
+  const look = Math.round(LOOK / FINE);
+  const hits = new Map<number, number>(); // fine index -> corridor width
+  for (let i = look; i < nx - look; i++) {
+    for (let j = look; j < nz - look; j++) {
+      const k = i * nz + j;
+      if (!stand[k]) continue;
+      let width = Infinity;
+      for (const [dx, dz] of [
+        [1, 0],
+        [0, 1],
+      ] as const) {
+        let ahead = -1;
+        let behind = -1;
+        for (let n = 1; n <= look; n++) {
+          const kp = (i + dx * n) * nz + (j + dz * n);
+          const km = (i - dx * n) * nz + (j - dz * n);
+          if (ahead < 0 && (wall[kp] || h[kp] >= h[k] + WALL_RISE)) ahead = n;
+          if (behind < 0 && (wall[km] || h[km] >= h[k] + WALL_RISE)) behind = n;
+        }
+        if (ahead > 0 && behind > 0) width = Math.min(width, (ahead + behind) * FINE);
+      }
+      if (width >= MIN_CORRIDOR) continue;
+      if (!canReach(RECT.x0 + i * FINE, RECT.z0 + j * FINE)) continue;
+      hits.set(k, width);
+    }
+  }
+
+  // cluster the hits so a failure names each pocket once
+  const out: Wedge[] = [];
+  const seen = new Set<number>();
+  for (const start of hits.keys()) {
+    if (seen.has(start)) continue;
+    seen.add(start);
+    const stack = [start];
+    const w: Wedge = {
+      x0: Infinity,
+      x1: -Infinity,
+      z0: Infinity,
+      z1: -Infinity,
+      width: Infinity,
+      samples: 0,
+    };
+    while (stack.length > 0) {
+      const k = stack.pop() as number;
+      const i = Math.floor(k / nz);
+      const j = k % nz;
+      w.x0 = Math.min(w.x0, RECT.x0 + i * FINE);
+      w.x1 = Math.max(w.x1, RECT.x0 + i * FINE);
+      w.z0 = Math.min(w.z0, RECT.z0 + j * FINE);
+      w.z1 = Math.max(w.z1, RECT.z0 + j * FINE);
+      w.width = Math.min(w.width, hits.get(k) as number);
+      w.samples++;
+      for (let di = -1; di <= 1; di++) {
+        for (let dj = -1; dj <= 1; dj++) {
+          const nk = (i + di) * nz + (j + dj);
+          if (!hits.has(nk) || seen.has(nk)) continue;
+          seen.add(nk);
+          stack.push(nk);
+        }
+      }
+    }
+    out.push(w);
+  }
+  return out.sort((a, b) => b.samples - a.samples);
+}
+
+function describeWedges(list: Wedge[]): string {
+  return list
+    .map(
+      (w) =>
+        `x ${w.x0.toFixed(1)}..${w.x1.toFixed(1)} z ${w.z0.toFixed(1)}..${w.z1.toFixed(1)} ` +
+        `corridor ${w.width.toFixed(2)}yd (${w.samples} samples)`,
+    )
+    .join('; ');
+}
+
+function makeWalker(spot: { x: number; z: number }) {
+  const sim = new Sim({ seed: SEED, playerClass: 'warrior', autoEquip: true });
+  sim.setPlayerLevel(20);
+  const p = sim.player;
+  const meta = (
+    sim as unknown as { players: Map<number, { moveInput: { forward: boolean } }> }
+  ).players.get((sim as unknown as { playerId: number }).playerId);
+  if (!meta) throw new Error('no meta');
+  p.pos.x = spot.x;
+  p.pos.z = spot.z;
+  p.pos.y = groundHeight(spot.x, spot.z, SEED) + 0.05;
+  p.prevPos = { ...p.pos };
+  for (let i = 0; i < 40; i++) {
+    p.hp = p.maxHp;
+    sim.tick();
+  }
+  return { sim, p, meta };
+}
+
+interface Walker {
+  pos: { x: number; y: number; z: number };
+  facing: number;
+  hp: number;
+  maxHp: number;
+  onGround: boolean;
+}
+
+/** Drive toward a target, reporting each tick's pose to an optional watcher. */
+function pushToward(
+  sim: Sim,
+  p: Walker,
+  meta: { moveInput: { forward: boolean } },
+  target: { x: number; z: number },
+  ticks: number,
+  watch?: (p: Walker) => void,
+): boolean {
+  let arrived = false;
+  for (let i = 0; i < ticks && !arrived; i++) {
+    p.facing = Math.atan2(target.x - p.pos.x, target.z - p.pos.z);
+    meta.moveInput.forward = true;
+    p.hp = p.maxHp; // terrain question, not combat
+    sim.tick();
+    watch?.(p);
+    arrived = Math.hypot(target.x - p.pos.x, target.z - p.pos.z) < 1.2;
+  }
+  meta.moveInput.forward = false;
+  return arrived;
+}
+
+describe('the Last Keep flanks hold no wedge pockets', () => {
+  it('leaves no reachable spot in a corridor narrower than a body', () => {
+    const wedges = reachableWedges();
+    expect(wedges.length, `wedge pockets: ${describeWedges(wedges)}`).toBe(0);
+  });
+
+  it('carries the alley flight onto the ward edge with no bailey sliver under it', () => {
+    // the flight's mass must overlap the ward's retaining edge: any dip back to
+    // the bailey floor between them is the crack players fell into
+    const flight = CASTLE_RAMPS[2];
+    expect(flight.axis, 'the alley flight is the third authored ramp').toBe('x');
+    expect(flight.b1, 'the flight band must reach past the ward edge').toBeGreaterThanOrEqual(
+      CASTLE.ward.z0,
+    );
+    for (let x = 418; x <= CASTLE.ward.x1; x += 0.2) {
+      for (let z = 1991.3; z <= CASTLE.ward.z0 + 0.7; z += 0.05) {
+        expect(
+          groundHeight(x, z, SEED),
+          `sliver of bailey floor under the alley flight at (${x.toFixed(1)}, ${z.toFixed(2)})`,
+        ).toBeGreaterThan(CASTLE.pad.h + 1.2);
+      }
+    }
+  });
+
+  it('stops a walker pushed off the flight and out of the keep/hall slot', () => {
+    // pushed south off the alley flight: the walker rides the stair mass or the
+    // terrace, and never comes down onto the bailey floor beside them (the old
+    // crack), and can still walk out west into the open alley afterwards
+    {
+      const { sim, p, meta } = makeWalker({ x: 428, z: 1990.2 });
+      let crackTicks = 0;
+      pushToward(sim, p, meta, { x: 428, z: 1996 }, 20 * 8, (w) => {
+        const inBand = w.pos.z > 1991.2 && w.pos.z < CASTLE.ward.z0 + 0.9;
+        const beside = w.pos.x > 418 && w.pos.x < CASTLE.ward.x1;
+        if (w.onGround && inBand && beside && w.pos.y < CASTLE.pad.h + 1.2) crackTicks++;
+      });
+      expect(crackTicks, 'stood in the crack beside the alley flight').toBe(0);
+      expect(
+        pushToward(sim, p, meta, { x: 404, z: 1990.3 }, 20 * 20),
+        'walks out west into the open alley',
+      ).toBe(true);
+    }
+    // driven north out of the open terrace into the keep/hall slot
+    {
+      const { sim, p, meta } = makeWalker({ x: 411.6, z: 2009 });
+      pushToward(sim, p, meta, { x: 411.6, z: 1998 }, 20 * 6);
+      expect(p.pos.z, 'held south of the slot').toBeGreaterThan(2006.5);
+    }
+    // and driven south into it from the ward's north yard
+    {
+      const { sim, p, meta } = makeWalker({ x: 411.6, z: 2002 });
+      pushToward(sim, p, meta, { x: 411.6, z: 2012 }, 20 * 6);
+      expect(p.pos.z, 'held north of the slot').toBeLessThan(2003.5);
+    }
+  });
+
+  it('keeps the ward routes open: the alley flight, the ward step, the keep door', () => {
+    // the alley flight still climbs east to the NE walk
+    {
+      const { sim, p, meta } = makeWalker({ x: 416, z: 1990.2 });
+      pushToward(sim, p, meta, { x: 433, z: 1990.2 }, 20 * 12);
+      expect(p.pos.x, 'climbs the flight').toBeGreaterThan(431);
+      expect(p.pos.y, 'reaches the wall walk').toBeGreaterThan(CASTLE.walkAbs - 0.6);
+    }
+    // the west ward step still climbs the terrace
+    {
+      const { sim, p, meta } = makeWalker({ x: 405.75, z: 2026 });
+      pushToward(sim, p, meta, { x: 405.75, z: 2014 }, 20 * 12);
+      expect(p.pos.z, 'on the terrace').toBeLessThan(2016);
+      expect(p.pos.y, 'at terrace height').toBeGreaterThan(CASTLE.ward.h - 0.4);
+    }
+    // the terrace east of the keep still carries traffic to the north yard
+    {
+      const { sim, p, meta } = makeWalker({ x: 431.2, z: 2014 });
+      pushToward(sim, p, meta, { x: 431.2, z: 1995 }, 20 * 12);
+      expect(p.pos.z, 'rounds the keep to the north yard').toBeLessThan(1997);
+      expect(p.pos.y, 'stays on the terrace').toBeGreaterThan(CASTLE.ward.h - 0.4);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Player reports (Discord, screenshots): the areas flanking the Last Keep near the entrance are death traps; it is very easy to fall between the cracks or get stuck underground, and one player bricked a character stuck in ghost form (mitigated separately by the /unstuck-while-dead change already on this branch).

A reachable-wedge scan (movement-tick lattice over the ward and both flanks with the real climb, steepness, and collider gates, then a corridor-width pass) found exactly two wedge pockets, identical across seeds 20061, 42, and 7:

1. The alley-flight crack (north flank): the stair band ended at z 1991.3 while the ward rect starts at 1991.4, leaving a 0.60 yd sliver of bailey floor between the solid stair wedge and the ward's retaining edge. A walker pushed off the flight's south side fell 5 yd into the gap between the two meshes and could not climb out. This is the file's own documented failure mode ("Every band OVERLAPS its landing strip").
2. The keep/great-hall slot (west flank): the two buildings' circle colliders leave a 1.2 yd corridor whose floor is inside both rendered square meshes; a player who squeezed in stood under the stonework, reading as underground.

The reported (397, 2000) spot itself and the east trench both probe out as escapable (walkers leave 70+ yd cleanly), so they were correctly left alone: the two wedges above are what players were actually falling into.

Fix:
- CASTLE_RAMPS alley flight band now runs through the ward's retaining blend (new exported WARD_EDGE_BLEND = 0.7, which also replaces the previously duplicated magic 0.7 in castlePadTarget), so no low ground survives between the stair mass and the terrace. The flight's usable width grows slightly (2.1 to 2.3 yd).
- New CASTLE_BLOCKERS (the JAIL_BLOCKERS idiom: invisible, fence-width, camera-ghost, never jumpable) close the keep/hall slot at both mouths, overshooting into both collider circles so neither end can be walked around. Merged into BUILTIN_WORLD.blockers, so all three hosts collide identically.

Legit routes are asserted unaffected: main gate, postern, breach, barbican, garden doorway, both ward steps, all wall-walk flights, and the keep door. Post-fix the scan reports the only unreachable standable nodes are the sealed slot interior (7 nodes).

## Test plan
- [x] tests/last_keep_flank_traps.test.ts (new, 4 tests): the wedge scan finds zero reachable sub-body corridors (RED before with both pockets named); the alley flight carries onto the ward edge with no bailey sliver (RED before); a walker pushed off the flight and toward the slot is kept out (RED before: fell to y 6.0); the ward routes stay open. Each half of the fix verified load-bearing by disabling it alone
- [x] tests/last_keep_grounds.test.ts, tests/last_keep.test.ts, tests/blocker_colliders.test.ts green; plus architecture, pathfind, camp_scatter, terrain_wall_standoff, world_api_parity, sim and friends: 604 tests
- [x] npx tsc --noEmit clean; biome clean on changed files
- [ ] PBE2 check: walk the alley flight and both ward flanks; confirm the slot cannot be entered and the stair never drops you into a crack