### PR TITLE
fix(net): mirror the prestige event's rank the instant it lands

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -2090,6 +2090,7 @@ export class ClientWorld implements IWorld {
         this.applyEnchantResultEvent(ev as SimEvent);
         this.applySalvageResultEvent(ev as SimEvent);
         this.applyChatFlairEvent(ev as SimEvent);
+        this.applyPrestigeEvent(ev as SimEvent);
         this.eventQueue.push(ev as SimEvent);
       }
       return;
@@ -3963,6 +3964,19 @@ export class ClientWorld implements IWorld {
     if (ev.type !== 'chat' || !ev.flair) return;
     // never trust the wire: re-sanitize the links, same as the identity decode
     this.rememberFlair(ev.from, ev.flair.ai === true, normalizeStreamerLinks(ev.flair.links));
+  }
+  // Mirror the authoritative prestige rank into this.prestigeRank the moment
+  // the event lands (issue #2137). The self snapshot's `prk` field is the
+  // convergence arm (same pattern as applyCraftResultEvent above), but the
+  // server sends this tick's `events` frame BEFORE the next `snap` frame that
+  // carries the bumped rank: without this immediacy arm, an already-open
+  // character sheet's renderCharIfOpen() (triggered by this very event) reads
+  // the STALE prestigeRank still on the mirror, so the sheet freezes one rank
+  // behind the chat line's "Prestige Rank N" until an unrelated repaint (or
+  // the next snapshot) catches it up.
+  private applyPrestigeEvent(ev: SimEvent): void {
+    if (ev.type !== 'prestige') return;
+    this.prestigeRank = ev.rank;
   }
   // --- IWorldMarket: World Market browse/list/buy/cancel/collect command sends
   // (snake_case wire strings). marketInfo is a snapshot read (mirror field above). ---

--- a/tests/prestige_rank_live_refresh.test.ts
+++ b/tests/prestige_rank_live_refresh.test.ts
@@ -1,0 +1,63 @@
+// Prestige rank live refresh (issue #2137, second regression): the online
+// character window kept showing the pre-prestige rank until closed and
+// reopened. #2371 (v0.30.0) added a dedicated `prestige` SimEvent and had
+// hud.ts repaint an already-open character sheet on it, but that repaint
+// reads ClientWorld.prestigeRank at the moment the event is PROCESSED. The
+// server sends this tick's `events` frame before the `snap` frame carrying
+// the bumped `prk` field (server/game.ts: routeEvents runs inside the sim
+// tick loop, broadcastSnapshots runs once after), so on the online host the
+// repaint fired against the STALE mirror and the sheet froze one rank behind
+// the chat line, exactly as reported on v0.31.0. The fix mirrors the event's
+// own `rank` into ClientWorld.prestigeRank immediately, the same "immediacy
+// arm" pattern already used for craft/masterwork/enchant/salvage results.
+import { describe, expect, it } from 'vitest';
+import { ClientWorld } from '../src/net/online';
+import type { SimEvent } from '../src/sim/types';
+
+// A ClientWorld with no constructor run (the established bareClient pattern
+// from tests/masterwork_event_mirror.test.ts / tests/snapshots.test.ts).
+// Class-field initializers do not run under Object.create, so prestigeRank
+// only comes to exist once the real event-apply path assigns it.
+function bareClient(): ClientWorld {
+  const c = Object.create(ClientWorld.prototype) as ClientWorld;
+  (c as unknown as { eventQueue: SimEvent[] }).eventQueue = [];
+  return c;
+}
+
+// Feed one event through the real wire entry point (onMessage -> the
+// 'events' branch -> applyPrestigeEvent), never by poking the field.
+function feedEvents(client: ClientWorld, list: unknown[]): void {
+  (client as unknown as { onMessage(raw: string): void }).onMessage(
+    JSON.stringify({ t: 'events', list }),
+  );
+}
+
+describe('ClientWorld prestige rank mirror', () => {
+  it('updates prestigeRank from the events frame alone, before any snap frame arrives', () => {
+    const client = bareClient();
+    // The window's initial paint reflected rank 2 (a prior snapshot); the
+    // next prestige lands rank 3 via the events frame, with no snap frame
+    // received yet (the exact ordering the bug depends on).
+    (client as unknown as { prestigeRank: number }).prestigeRank = 2;
+    feedEvents(client, [
+      { type: 'log', text: 'You have prestiged! Prestige Rank 3.', color: '#ffd100' },
+      { type: 'prestige', rank: 3 },
+    ]);
+    expect(client.prestigeRank).toBe(3);
+  });
+
+  it('is a no-op for an unrelated event (does not clobber the mirror)', () => {
+    const client = bareClient();
+    (client as unknown as { prestigeRank: number }).prestigeRank = 5;
+    feedEvents(client, [{ type: 'log', text: 'unrelated', color: '#ffd100' }]);
+    expect(client.prestigeRank).toBe(5);
+  });
+
+  it('still queues the prestige event for the HUD (chat line + repaint trigger)', () => {
+    const client = bareClient();
+    (client as unknown as { prestigeRank: number }).prestigeRank = 0;
+    feedEvents(client, [{ type: 'prestige', rank: 1 }]);
+    const drained = client.drainEvents();
+    expect(drained).toEqual([{ type: 'prestige', rank: 1 }]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2137: the character window kept showing the pre-prestige rank until closed
and reopened, even though the chat line correctly announced the new rank.

#2371 (v0.30.0) already added a dedicated `prestige` SimEvent and taught
`hud.ts` to repaint an already-open character sheet the moment that event
lands (mirroring the existing `honor` case). That repaint reads
`ClientWorld.prestigeRank` at the instant the event is processed. On the
online host the server sends this tick's `events` frame *before* the batched
`snap` frame that carries the bumped `prk` field (`server/game.ts`:
`routeEvents` runs inside the sim-tick `while` loop, `broadcastSnapshots`
runs once after the loop), so the repaint fired against the still-stale
`prestigeRank` mirror and the sheet froze one rank behind the chat line,
exactly as re-reported against v0.31.0.

**Before:**

```mermaid
sequenceDiagram
    participant Sim as Server Sim.prestige()
    participant Srv as Server broadcast
    participant Net as ClientWorld
    participant Hud as hud.ts

    Sim->>Sim: meta.prestigeRank += 1
    Sim->>Srv: emit 'log' + 'prestige' events
    Srv->>Net: {t:'events', list:[log, prestige]}  (sent first)
    Net->>Hud: drainEvents() -> case 'prestige'
    Hud->>Hud: renderCharIfOpen() reads STALE prestigeRank
    Srv->>Net: {t:'snap', prk: N}  (sent after)
    Net->>Net: this.prestigeRank = N (too late, already painted)
```

**After:**

```mermaid
sequenceDiagram
    participant Sim as Server Sim.prestige()
    participant Srv as Server broadcast
    participant Net as ClientWorld
    participant Hud as hud.ts

    Sim->>Sim: meta.prestigeRank += 1
    Sim->>Srv: emit 'log' + 'prestige' events
    Srv->>Net: {t:'events', list:[log, prestige]}
    Net->>Net: applyPrestigeEvent(ev) -> this.prestigeRank = ev.rank (immediacy arm)
    Net->>Hud: drainEvents() -> case 'prestige'
    Hud->>Hud: renderCharIfOpen() reads FRESH prestigeRank
    Srv->>Net: {t:'snap', prk: N}  (convergence arm, now redundant but harmless)
```

The fix adds `applyPrestigeEvent`, which mirrors the `prestige` event's own
`rank` field into `ClientWorld.prestigeRank` the instant the event is
received, the same "immediacy arm" pattern already used in `src/net/online.ts`
for craft/masterwork/enchant/salvage results (the self snapshot's `prk` field
stays the eventual "convergence arm").

## Related issues

Closes #2137

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/prestige_rank_live_refresh.test.ts` (new regression test)
  - `npx vitest run tests/xp.test.ts tests/honor_ui.test.ts tests/masterwork_event_mirror.test.ts tests/snapshots.test.ts tests/world_api_parity.test.ts`
  - `npx tsc --noEmit`
  - `npm run gate` (full gate, green)
- Manual steps: confirmed the new test fails (reproducing the exact ordering
  bug) when the fix is reverted, and passes with it applied.

The new test feeds a `{t:'events', list:[...]}` frame through the real
`ClientWorld.onMessage` entry point with no prior `snap` frame applied,
reproducing the exact ordering the bug depends on, and asserts
`prestigeRank` updates immediately from the event alone.

## Screenshots / recordings

N/A. This is a client-side network-message-ordering fix in `src/net/online.ts`
only: no markup, styling, or online-visible DOM changed. The character
window's HTML/CSS is identical before and after; only the timing of when its
`Prestige Rank` line becomes correct online (immediately vs. after closing
and reopening) changes, which isn't something a still screenshot can show.
The offline host was never affected (its `Sim.prestige()` mutates
`prestigeRank` synchronously before any repaint), so an offline before/after
pair would also be pixel-identical.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. Added a decisive
      regression test (`tests/prestige_rank_live_refresh.test.ts`) that fails
      without the fix and passes with it.

### Cross-platform

- [x] N/A for the desktop/mobile visual checklist (no UI/DOM change; see
      Screenshots section above).

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed. `ALLOW_DEV_COMMANDS` is not
      enabled anywhere.
- [x] No generated files hand-edited.