### PR TITLE
fix(palmreach): unfreeze the jungle-pool walkway crossing

### DIFF
--- a/src/sim/world.ts
+++ b/src/sim/world.ts
@@ -32,7 +32,7 @@ import {
   emberLinkDistanceNorm,
   emberNearestOnLink,
 } from './ember_lava_layout';
-import { galeDeckSurface } from './gale_harbor';
+import { GALE_DECK_FREEBOARD, galeDeckSurface } from './gale_harbor';
 import { reachDeckClear, reachDeckSurface } from './reach_decks';
 import { fbm2, hash2, noise2 } from './rng';
 import type { BiomeId, HeightStamp, ZoneDef } from './types';
@@ -3033,6 +3033,119 @@ function applyLakeShoreGrading(x: number, z: number, h: number): number {
   return gradeShoreBand(h, w);
 }
 
+// ---------------------------------------------------------------------------
+// The Palmreach jungle-pool walkway's bed: the two places the terrain under
+// the viewing platform (sim/reach_decks.ts) has to be shaped for the walkway
+// to behave, the rim it crosses and the sand it lands on.
+// ---------------------------------------------------------------------------
+
+// The Palmreach jungle pool's east rim, where the viewing platform and the
+// stair that lands on it cross it (sim/reach_decks.ts). The rim climbs at
+// almost exactly the movement climb limit (PLAYER_MAX_CLIMB_SLOPE, 1.5), and
+// the platform's LEVEL plank plane covers the handful of 1-yard cells that tip
+// over it. That pairing is not a slow spot, it is a permanent freeze: the
+// movement kernel takes the player's own steepness from the TERRAIN under the
+// planks (rideSteepnessAt defers to the memoized terrain view on dry ground),
+// so a player standing there counts as standing on unwalkable ground and loses
+// all steering; but BOTH escapes from unwalkable ground read groundHeight,
+// which over a level deck is a dead-flat plane, so terrainDownhill finds no
+// downhill to slide along and terrainWallStandoff finds no wall to be pushed
+// off. Nothing ever moves the player again (reported stuck at -373, 1003).
+//
+// Ease the rim's face where the walkway crosses it so no cell the planks cover
+// reaches the limit, with margin. Only the face moves: everything at or above
+// `top` is untouched (including both deck anchors, so every plank plane stays
+// exactly where it was), and the pool floor below the face simply lifts by the
+// rise the face gives up. Bbox-guarded, so the rest of the world never pays.
+const REACH_POOL_RIM_EASE = {
+  // the early-out box around the crossing
+  x1: -379,
+  x2: -367,
+  z1: 993,
+  z2: 1012,
+  // the crest line the walkway crosses, as a capsule (the rim runs as an arc
+  // of the declared jungle pool at -380, 1000)
+  ax: -371.5,
+  az: 998.4,
+  bx: -374.9,
+  bz: 1006.2,
+  full: 3.4, // full weight within this far of the crest line
+  fade: 7.0, // and none past this
+  // the rim face itself, in finished heights: `drop` yards below `top`
+  top: -5.35,
+  drop: 1.6,
+  // the face keeps this much of its rise, so this much of its gradient
+  scale: 0.62,
+};
+
+function applyReachPoolRimEase(x: number, z: number, h: number): number {
+  const e = REACH_POOL_RIM_EASE;
+  if (x < e.x1 || x > e.x2 || z < e.z1 || z > e.z2) return h;
+  const y = h - e.top;
+  if (y >= 0) return h; // the shelf above the rim, and both deck anchors, never move
+  const sx = e.bx - e.ax;
+  const sz = e.bz - e.az;
+  const t = Math.min(1, Math.max(0, ((x - e.ax) * sx + (z - e.az) * sz) / (sx * sx + sz * sz)));
+  const d = Math.hypot(x - (e.ax + sx * t), z - (e.az + sz * t));
+  const w = 1 - smoothstep(e.full, e.fade, d);
+  if (w === 0) return h;
+  // monotone and continuous at both ends of the face (y = 0 maps to 0, and the
+  // ground below the face rides up by exactly the rise the face gave up), so
+  // wet stays wet, dry stays dry, and no step opens anywhere along the blend
+  const eased = y < -e.drop ? y + e.drop * (1 - e.scale) : y * e.scale;
+  return h + (eased - y) * w;
+}
+
+// The sand tie-in at the platform's landward end. The plank plane is set by the
+// deck freeboard (GALE_DECK_FREEBOARD over the waterline), not by the shore, so
+// it rides about a yard proud of the flat beach behind it: the whole landward
+// end reads as a knee-high plinth the climb gate refuses, and a player who
+// walks off the deck onto the strand can never step back on. Drift the sand up
+// against the deck's end so the walkway is a path in BOTH directions, one deck
+// lift below the planks (the height the deck's own bed sits at, so the boards
+// meet the sand instead of hanging over it). Raises only, so the beach is never
+// carved, and its reach stops well short of the shared deck anchor at
+// (-368, 1000): both plank planes are anchored there and must not move.
+const REACH_POOL_DECK_TIE_IN = {
+  x1: -377,
+  x2: -363,
+  z1: 1002,
+  z2: 1015,
+  x: -369.5,
+  z: 1008.6,
+  full: 2.6, // sand at the tie-in height within this far of the end
+  fade: 6.0, // easing back to the natural strand by here
+};
+
+function applyReachPoolDeckTieIn(x: number, z: number, h: number): number {
+  const t = REACH_POOL_DECK_TIE_IN;
+  if (x < t.x1 || x > t.x2 || z < t.z1 || z > t.z2) return h;
+  // the platform is freeboard-seated, so its planks (and this tie-in with them)
+  // sit a fixed height over the waterline wherever the shore happens to be.
+  // WATER_LEVEL, not waterLevel(): dockSurfaceHeight seats every deck on the
+  // constant, so the sand has to answer to the same line the planks do.
+  const target = WATER_LEVEL + GALE_DECK_FREEBOARD;
+  if (h >= target) return h;
+  const w = 1 - smoothstep(t.full, t.fade, Math.hypot(x - t.x, z - t.z));
+  if (w === 0) return h;
+  return h + (target - h) * w;
+}
+
+// One shared early-out over both shapers' boxes: this runs for every terrain
+// sample in the world, so the rest of it never pays for more than four compares.
+const REACH_POOL_BED_BOX = {
+  x1: Math.min(REACH_POOL_RIM_EASE.x1, REACH_POOL_DECK_TIE_IN.x1),
+  x2: Math.max(REACH_POOL_RIM_EASE.x2, REACH_POOL_DECK_TIE_IN.x2),
+  z1: Math.min(REACH_POOL_RIM_EASE.z1, REACH_POOL_DECK_TIE_IN.z1),
+  z2: Math.max(REACH_POOL_RIM_EASE.z2, REACH_POOL_DECK_TIE_IN.z2),
+};
+
+function applyReachPoolWalkwayBed(x: number, z: number, h: number): number {
+  const b = REACH_POOL_BED_BOX;
+  if (x < b.x1 || x > b.x2 || z < b.z1 || z > b.z2) return h;
+  return applyReachPoolDeckTieIn(x, z, applyReachPoolRimEase(x, z, h));
+}
+
 // Ground height including instanced dungeon floors (flat, far off-world), the
 // walkable Vale Cup grandstand lift, raised docks, and custom-map sculpt edits.
 export function groundHeight(x: number, z: number, seed: number): number {
@@ -3075,6 +3188,12 @@ export function terrainHeight(x: number, z: number, seed: number): number {
   // sea shave runs late in the unpadded chain and was clipping the castle's
   // seaward corner; the castle plateau must win everywhere inside its walls).
   h = applyCastlePad(x, z, h);
+  // The Palmreach jungle-pool walkway's bed, over the FINISHED height: the
+  // deck surfaces the movement kernel walks are anchored to this function, so
+  // the rim the planks cover and the sand they land on have to be shaped here,
+  // after the shore grading that forms them (see REACH_POOL_RIM_EASE for the freeze
+  // it closes and REACH_POOL_DECK_TIE_IN for the one-way edge it closes).
+  h = applyReachPoolWalkwayBed(x, z, h);
   // Level pads under the Evergarden's modeled flower beds, applied over the
   // FINISHED height (the garden seam reshapes the lawn per position, so an
   // early flatten would drift apart again): each bed ensemble sits flush on

--- a/tests/emerald_deck_escape.test.ts
+++ b/tests/emerald_deck_escape.test.ts
@@ -1,0 +1,373 @@
+// The Palmreach jungle-pool walkway (sim/reach_decks.ts indices 4 and 5: the
+// viewing platform off the pool's east rim and the stair climbing the tangle
+// side behind it) must never wedge a player: walking on, off, up, down, or
+// stepping over an edge always leaves a way out.
+//
+// The reported bug was a total freeze at (-373, 1003), standing on the
+// platform. A deck's plank plane is walkable raised ground (world.ts
+// groundHeight takes the max of terrain and the deck surface), but the
+// movement kernel reads two DIFFERENT surfaces when it decides whether the
+// player is on unwalkable ground: rideSteepnessAt defers to the memoized
+// TERRAIN steepness on dry land (so the pool rim buried under the planks
+// stripped all steering), while terrainDownhill and terrainWallStandoff read
+// groundHeight, which over a LEVEL deck is a dead-flat plane (so there was no
+// downhill to slide along and no wall to be pushed off). The player was
+// frozen for good. The pool rim is eased under the walkway so no cell the
+// planks cover reaches the climb limit.
+
+import { describe, expect, it } from 'vitest';
+import { resolveMovement } from '../src/sim/colliders';
+import { GALE_DECK_FREEBOARD, galeDeckSurfaceAt } from '../src/sim/gale_harbor';
+import { PLAYER_MAX_CLIMB_SLOPE } from '../src/sim/pathfind';
+import { type PlayerMotionDeps, stepPlayerMotion } from '../src/sim/player_motion';
+import { REACH_DECKS, reachDeckSurface } from '../src/sim/reach_decks';
+import { Sim } from '../src/sim/sim';
+import type { Entity, MoveInput } from '../src/sim/types';
+import { groundHeight, terrainHeight, terrainSteepness, WATER_LEVEL } from '../src/sim/world';
+
+// The shipped seed: the report is seed-pinned world geometry.
+const SEED = 20061;
+// The viewing platform and its stair; the rest of REACH_DECKS is elsewhere.
+const PLATFORM = REACH_DECKS[4];
+const STAIR = REACH_DECKS[5];
+
+// The scanned rect: the whole walkway complex plus the pool rim, the beach
+// apron below it, and the tangle-side bank the stair climbs.
+const RECT = { x1: -382, x2: -356, z1: 988, z2: 1014 };
+
+const terrain = (x: number, z: number): number => terrainHeight(x, z, SEED);
+
+// --- a walker on the shared movement kernel --------------------------------
+// player_motion.ts is the one kernel the offline Sim, the authoritative
+// server, and the client self-predictor all run, so a probe driven through it
+// is exactly what a real player's body does. Driving it directly (rather than
+// a whole Sim tick) keeps the exhaustive sweep below fast enough to cover the
+// rect at half-yard spacing.
+
+const deps: PlayerMotionDeps = {
+  seed: SEED,
+  moveSpeedMult: () => 1,
+  resolveMove: (fx, fz, nx, nz, r, _e, ignoreFences) =>
+    resolveMovement(SEED, fx, fz, nx, nz, r, ignoreFences),
+  resolvedAbility: () => null,
+  cancelCast: () => {},
+  standUp: () => {},
+  dealDamage: () => {},
+};
+
+const NO_INPUT: MoveInput = {
+  forward: false,
+  back: false,
+  strafeLeft: false,
+  strafeRight: false,
+  turnLeft: false,
+  turnRight: false,
+  jump: false,
+};
+
+let walkerBody: Entity | null = null;
+function bodyForWalking(): Entity {
+  if (!walkerBody) {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', autoEquip: true });
+    sim.setPlayerLevel(20);
+    walkerBody = sim.player;
+  }
+  return walkerBody;
+}
+
+function standAt(p: Entity, x: number, z: number): void {
+  p.pos.x = x;
+  p.pos.z = z;
+  p.pos.y = groundHeight(x, z, SEED);
+  p.prevPos = { ...p.pos };
+  p.vx = 0;
+  p.vy = 0;
+  p.vz = 0;
+  p.onGround = true;
+  p.jumping = false;
+  p.fallStartY = p.pos.y;
+  p.auras.length = 0;
+}
+
+/** How far a player starting at (x, z) gets, over `azimuths` fixed headings. */
+function escapeDistance(
+  x: number,
+  z: number,
+  azimuths: number,
+  ticks: number,
+  want: number,
+): number {
+  const p = bodyForWalking();
+  const inp: MoveInput = { ...NO_INPUT, forward: true };
+  let best = 0;
+  for (let k = 0; k < azimuths; k++) {
+    standAt(p, x, z);
+    const facing = (k * 2 * Math.PI) / azimuths;
+    for (let i = 0; i < ticks; i++) {
+      p.facing = facing;
+      p.prevPos = { ...p.pos };
+      stepPlayerMotion(deps, p, inp);
+    }
+    best = Math.max(best, Math.hypot(p.pos.x - x, p.pos.z - z));
+    if (best > want) break; // an escape is an escape; stop paying for the rest
+  }
+  return best;
+}
+
+// A spot escapes when some heading walks the player clear of the complex. 12
+// yards is well past the widest deck (the stair is 14.6 long by 3.6 wide), so
+// clearing it means the player left the walkway, not shuffled along it.
+const ESCAPE_YARDS = 12;
+
+/** Coarse sweep first, then a long 24-heading confirmation on the survivors. */
+function isWedge(x: number, z: number): boolean {
+  if (escapeDistance(x, z, 8, 120, ESCAPE_YARDS) > ESCAPE_YARDS) return false;
+  return escapeDistance(x, z, 24, 400, ESCAPE_YARDS) <= ESCAPE_YARDS;
+}
+
+function scanWedges(step: number): { x: number; z: number }[] {
+  const found: { x: number; z: number }[] = [];
+  for (let z = RECT.z1; z <= RECT.z2 + 1e-9; z += step) {
+    for (let x = RECT.x1; x <= RECT.x2 + 1e-9; x += step) {
+      if (isWedge(x, z)) found.push({ x, z });
+    }
+  }
+  return found;
+}
+
+// --- a walker on the real Sim ----------------------------------------------
+
+function makeSimWalker(spot: { x: number; z: number }) {
+  const sim = new Sim({ seed: SEED, playerClass: 'warrior', autoEquip: true });
+  sim.setPlayerLevel(20);
+  const p = sim.player;
+  const meta = (
+    sim as unknown as { players: Map<number, { moveInput: { forward: boolean } }> }
+  ).players.get((sim as unknown as { playerId: number }).playerId)!;
+  p.pos.x = spot.x;
+  p.pos.z = spot.z;
+  p.pos.y = groundHeight(spot.x, spot.z, SEED) + 0.05;
+  p.prevPos = { ...p.pos };
+  for (let i = 0; i < 20; i++) sim.tick();
+  return { sim, p, meta };
+}
+
+/** Steers a live player through the waypoints, the way a real player walks. */
+function walkRoute(
+  start: { x: number; z: number },
+  waypoints: { x: number; z: number }[],
+): { completed: boolean; reached: number; stalledAt: { x: number; z: number } } {
+  const { sim, p, meta } = makeSimWalker(start);
+  let wp = 0;
+  for (let i = 0; i < 20 * 120 && wp < waypoints.length; i++) {
+    const t = waypoints[wp];
+    p.facing = Math.atan2(t.x - p.pos.x, t.z - p.pos.z);
+    meta.moveInput.forward = true;
+    // the question is terrain, not combat: the walker heals through the local
+    // wildlife so a mob pile-up never reads as a walkway trap
+    p.hp = p.maxHp;
+    (p as unknown as { dead: boolean }).dead = false;
+    sim.tick();
+    if (Math.hypot(t.x - p.pos.x, t.z - p.pos.z) < 2) wp++;
+  }
+  meta.moveInput.forward = false;
+  return {
+    completed: wp >= waypoints.length,
+    reached: wp,
+    stalledAt: { x: p.pos.x, z: p.pos.z },
+  };
+}
+
+// The clifftop path above the stair, down the treads, across the platform,
+// off onto the beach and out to the open strand.
+const CLIFFTOP = { x: -358.5, z: 992.5 };
+const DOWN_ROUTE = [
+  { x: -361, z: 994.4 },
+  { x: -364, z: 996.9 },
+  { x: -368, z: 1000.2 },
+  { x: -371.4, z: 1002.9 },
+  { x: -372, z: 1004 },
+  { x: -370.8, z: 1006.6 },
+  { x: -369, z: 1010 },
+  { x: -368, z: 1014 },
+];
+const BEACH = DOWN_ROUTE[DOWN_ROUTE.length - 1];
+const UP_ROUTE = [...DOWN_ROUTE].slice(0, -1).reverse().concat([CLIFFTOP]);
+
+// --- edge step-offs ---------------------------------------------------------
+// Every point 0.3yd outside a deck's rectangle, all the way round both decks:
+// where a player who walks through the (cosmetic) railing lands.
+function edgeStepOffs(): { x: number; z: number; label: string }[] {
+  const out: { x: number; z: number; label: string }[] = [];
+  for (const [i, d] of [PLATFORM, STAIR].entries()) {
+    const name = i === 0 ? 'platform' : 'stair';
+    const dirx = Math.sin(d.rot);
+    const dirz = Math.cos(d.rot);
+    const pad = 0.3;
+    for (let a = -d.hl; a <= d.hl + 1e-9; a += d.hl / 4) {
+      for (const side of [1, -1]) {
+        out.push({
+          x: d.x + dirx * a + dirz * (d.hw + pad) * side,
+          z: d.z + dirz * a - dirx * (d.hw + pad) * side,
+          label: `${name} side ${side > 0 ? '+' : '-'} at along ${a.toFixed(1)}`,
+        });
+      }
+    }
+    for (const end of [1, -1]) {
+      for (let w = -d.hw; w <= d.hw + 1e-9; w += d.hw) {
+        out.push({
+          x: d.x + dirx * (d.hl + pad) * end + dirz * w,
+          z: d.z + dirz * (d.hl + pad) * end - dirx * w,
+          label: `${name} end ${end > 0 ? '+' : '-'} at across ${w.toFixed(1)}`,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+describe('the Palmreach jungle-pool walkway keeps no one', () => {
+  it('is pointed at the jungle-pool platform and its stair', () => {
+    // everything below reads REACH_DECKS by index; pin which records those are
+    // so a reordered or retuned list cannot quietly aim this suite elsewhere
+    expect({ x: PLATFORM.x, z: PLATFORM.z, hl: PLATFORM.hl, hw: PLATFORM.hw }).toEqual({
+      x: -372,
+      z: 1004,
+      hl: 4.5,
+      hw: 2.2,
+    });
+    expect(PLATFORM.ax2, 'the platform is the LEVEL deck (one anchor)').toBeUndefined();
+    expect({ x: STAIR.x, z: STAIR.z, ax2: STAIR.ax2, az2: STAIR.az2 }).toEqual({
+      x: -366.69,
+      z: 998.99,
+      ax2: -361,
+      az2: 994,
+    });
+    // both decks hang off the same shore root, which is what makes their
+    // planes meet at the junction; the bed shaping must never move it
+    expect({ ax: PLATFORM.ax, az: PLATFORM.az }).toEqual({ ax: STAIR.ax, az: STAIR.az });
+  });
+
+  it('leaves both plank planes exactly where they were seated', () => {
+    // The bed shaping under the walkway is deliberately confined BELOW the
+    // deck anchors: the platform is freeboard-seated and the stair ramps from
+    // that same plane up to the tangle-side bank. If a future terrain touch
+    // lifts either anchor, both walkway surfaces move and every clearance
+    // measured here goes stale.
+    // the ground at both anchors, unchanged
+    expect(terrain(PLATFORM.ax, PLATFORM.az)).toBeCloseTo(-4.05, 2);
+    expect(terrain(-361, 994)).toBeCloseTo(2.64, 2);
+    // the shore root sits below the freeboard line, so the platform is seated
+    // on the freeboard, not on the shore: that is what makes its plane level
+    expect(terrain(PLATFORM.ax, PLATFORM.az)).toBeLessThan(WATER_LEVEL + GALE_DECK_FREEBOARD);
+    // and so the planes themselves are where every clearance here assumes
+    expect(galeDeckSurfaceAt(PLATFORM, 0, terrain, WATER_LEVEL)).toBeCloseTo(-3.61, 2);
+    expect(galeDeckSurfaceAt(STAIR, -STAIR.hl, terrain, WATER_LEVEL)).toBeCloseTo(-3.61, 2);
+    expect(galeDeckSurfaceAt(STAIR, STAIR.hl, terrain, WATER_LEVEL)).toBeCloseTo(2.98, 2);
+  });
+
+  it('ties the platform into the sand a player can step back up', () => {
+    // The plank plane is set by the deck freeboard, not the shore, so without
+    // the sand tie-in the whole landward end is a knee-high plinth: a player
+    // could walk off onto the strand and never step back on (a one-way deck).
+    // One tick of run climbs RUN_SPEED * DT * MAX_CLIMB_SLOPE = 0.525yd.
+    const oneTickClimb = 7 * (1 / 20) * PLAYER_MAX_CLIMB_SLOPE;
+    const dirx = Math.sin(PLATFORM.rot);
+    const dirz = Math.cos(PLATFORM.rot);
+    for (let w = -PLATFORM.hw; w <= PLATFORM.hw + 1e-9; w += PLATFORM.hw / 2) {
+      const ox = PLATFORM.x + dirx * (PLATFORM.hl + 0.3) + dirz * w;
+      const oz = PLATFORM.z + dirz * (PLATFORM.hl + 0.3) - dirx * w;
+      const ix = PLATFORM.x + dirx * (PLATFORM.hl - 0.05) + dirz * w;
+      const iz = PLATFORM.z + dirz * (PLATFORM.hl - 0.05) - dirx * w;
+      const lip = reachDeckSurface(ix, iz, terrain, WATER_LEVEL) - groundHeight(ox, oz, SEED);
+      expect(lip, `landward end at across ${w.toFixed(1)}`).toBeLessThan(oneTickClimb);
+    }
+  });
+
+  it('covers no ground the movement kernel calls unwalkable', () => {
+    // The wedge's precondition, as data: a LEVEL plank plane over a terrain
+    // cell steeper than the climb limit freezes a player outright (no
+    // steering, and neither the downhill slide nor the wall standoff can see
+    // past the flat planks). The 1-yd cells are exactly the cells the
+    // memoized steepness view (terrainSteepnessAt) quantizes to.
+    const over: string[] = [];
+    for (const d of [PLATFORM, STAIR]) {
+      const reach = Math.ceil(d.hl + d.hw) + 1;
+      for (let cx = Math.floor(d.x - reach); cx <= Math.ceil(d.x + reach); cx++) {
+        for (let cz = Math.floor(d.z - reach); cz <= Math.ceil(d.z + reach); cz++) {
+          const steep = terrainSteepness(cx, cz, SEED);
+          if (steep <= PLAYER_MAX_CLIMB_SLOPE) continue;
+          // does any point that rounds into this cell stand on planks?
+          let covered = false;
+          for (let sx = cx - 0.5; sx <= cx + 0.5 + 1e-9 && !covered; sx += 0.25) {
+            for (let sz = cz - 0.5; sz <= cz + 0.5 + 1e-9; sz += 0.25) {
+              if (reachDeckSurface(sx, sz, terrain, WATER_LEVEL) !== -Infinity) {
+                covered = true;
+                break;
+              }
+            }
+          }
+          if (covered) over.push(`cell (${cx}, ${cz}) steepness ${steep.toFixed(3)}`);
+        }
+      }
+    }
+    expect(over).toEqual([]);
+  });
+
+  it('leaves no wedge anywhere over the walkway, the rim, or the beach', {
+    timeout: 180_000,
+  }, () => {
+    const wedges = scanWedges(0.75);
+    expect(wedges.map((w) => `(${w.x.toFixed(2)}, ${w.z.toFixed(2)})`)).toEqual([]);
+  });
+
+  it('frees the exact spot the player reported standing on', () => {
+    // (-373, 1003) and the platform cells around it: the report's coordinates
+    // land between scan samples, so pin the reported spot itself too.
+    for (const spot of [
+      { x: -373, z: 1003 },
+      { x: -373, z: 1003.75 },
+      { x: -373.75, z: 1004.5 },
+      { x: -372.5, z: 1004 },
+    ]) {
+      expect(
+        escapeDistance(spot.x, spot.z, 24, 400, ESCAPE_YARDS),
+        `stuck at (${spot.x}, ${spot.z})`,
+      ).toBeGreaterThan(ESCAPE_YARDS);
+    }
+  });
+
+  it('walks the clifftop down the stair, over the platform and out to the beach', {
+    timeout: 90_000,
+  }, () => {
+    const down = walkRoute(CLIFFTOP, DOWN_ROUTE);
+    expect(down.completed, `stalled at (${down.stalledAt.x}, ${down.stalledAt.z})`).toBe(true);
+  });
+
+  it('walks the beach back up the stair to the clifftop', { timeout: 90_000 }, () => {
+    const up = walkRoute(BEACH, UP_ROUTE);
+    expect(up.completed, `stalled at (${up.stalledAt.x}, ${up.stalledAt.z})`).toBe(true);
+  });
+
+  it('lets a player who steps over any railing walk away from where they land', {
+    timeout: 180_000,
+  }, () => {
+    const p = bodyForWalking();
+    const trapped: string[] = [];
+    for (const spot of edgeStepOffs()) {
+      // land first: a step off an edge is a drop, so settle where it ends
+      standAt(p, spot.x, spot.z);
+      p.pos.y = Math.max(p.pos.y, groundHeight(spot.x, spot.z, SEED) + 0.05);
+      for (let i = 0; i < 60; i++) {
+        p.facing = 0;
+        p.prevPos = { ...p.pos };
+        stepPlayerMotion(deps, p, NO_INPUT);
+      }
+      const landed = { x: p.pos.x, z: p.pos.z };
+      if (escapeDistance(landed.x, landed.z, 24, 400, ESCAPE_YARDS) <= ESCAPE_YARDS) {
+        trapped.push(`${spot.label}: landed (${landed.x.toFixed(2)}, ${landed.z.toFixed(2)})`);
+      }
+    }
+    expect(trapped).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Player report (PBE2): players get stuck on the walkway at world (-373, 1003) in The Palmreach (the stair down the jungle cliff to the railed viewing platform at the pool).

Root cause: a movement-kernel blind spot, not deck geometry. The pool's east rim climbs at almost exactly the climb limit, and two 1-yd terrain cells UNDER the level platform planks tip over it (steepness 1.586 and 1.542 vs the 1.5 gate). The kernel takes standing-steepness from the TERRAIN under the planks (rideSteepnessAt defers to the terrain view on dry ground), so a player on those cells counts as standing on unwalkable ground and loses all steering; but both escape mechanisms read groundHeight, which over a level deck is a dead-flat plane, so the downhill slide finds no slope and the wall standoff finds no wall. Every escape disarms at once: a 24-heading, 400-tick probe moved the player 0.00 yd. The platform's landward end also had a 0.56 to 1.05 yd lip onto the sand, making the deck one-way (you could hop off but never climb back on).

Fix (src/sim/world.ts only; the deck records are untouched because the rim crest runs through the platform's middle, so no anchor retune could clear it): two bbox-guarded, lift-only terrain shapers in the finished-height family, applyReachPoolRimEase (eases the rim face where the walkway crosses so no plank-covered cell reaches the limit; everything at or above the rim shelf is untouched, so both deck anchors and both plank planes are bit-identical) and applyReachPoolDeckTieIn (drifts the landing sand up to one deck lift under the planks; the landward lip drops to 0.34 yd, under the one-tick climb). Total footprint x -379..-366, z 993..1013.5, max +1.15 yd, zero samples changed elsewhere in the zone. No colliders added; railings stay cosmetic, matching every other walkway.

Checked and ruled out: the pool is already a declared, swimmable lake (no dry-basin trap); the stair's top meets the clifftop flush; no under-deck pocket exists (groundHeight is single-valued).

Parity: no golden drift (182 passed), so no re-mint was needed.

Known follow-ups (out of scope, documented in the test): the same latent kernel asymmetry exists under two Wickharbor harbor decks (they slide rather than freeze, since those decks sit on non-flat ground); a general fix belongs in ride_height.ts and has a much wider blast radius. Terrain moved up to 1.15 yd near the platform, so reeds and the visible shoreline shift slightly there.

## Test plan
- [x] tests/emerald_deck_escape.test.ts (new, 9 tests, RED-first 5 of 6 pre-fix): deck-record and plank-plane identity pins (proves the walkway itself did not move); no plank-covered terrain cell at or over the climb gate (the data guard for this bug class on REACH_DECKS); landward lip under one tick's climb; a 0.75 yd wedge sweep over the whole complex finds zero inescapable cells (found the 2 freezes before); the reported spot escapes; route walkers complete clifftop to beach AND beach to clifftop on a real Sim; step-offs over every deck edge land on escapable ground
- [x] tests/parity golden gate green (no drift); tests/reach_palms_cliffs.test.ts, tests/climb_slope.test.ts, tests/terrain_escape.test.ts, terrain seam/chunk suites, gale_harbor, water suites, sim, architecture: 237 passed
- [x] npx tsc --noEmit clean; biome clean on changed files
- [x] In-game before/after screenshots attached below