### PR TITLE
fix(game): clear stale meters:KeyZ from the v0.24.0 repair signature

### DIFF
--- a/src/game/keybinds_repair.ts
+++ b/src/game/keybinds_repair.ts
@@ -20,6 +20,17 @@
 // action-bar slots and strafe is dead. Dropping the four keys re-seeds strafe to
 // Q/E and slot10/slot11 to Minus/Equal, the current defaults.
 //
+// The same v0.24.0 window (#1792) also shipped Damage Meters defaulting to
+// KeyZ, so a profile matching the rest of Signature A typically also persisted
+// meters: ['KeyZ', null]. meters now defaults to Shift+KeyH, but the stored
+// KeyZ sticks like the other four, and it is processed before Sheathe/
+// Unsheathe Weapon in BIND_ACTIONS: it claims KeyZ first, so the load-time
+// uniqueness sweep silently evicts sheathe's untouched KeyZ default down to
+// unbound. Signature A therefore also drops meters when it resolves to KeyZ
+// with an empty secondary, re-seeding meters to Shift+KeyH and freeing KeyZ
+// back to sheathe. A meters:KeyZ value seen WITHOUT the rest of the signature
+// is a deliberate remap and is left alone (see the test for that case).
+//
 // Signature B, the targetFriendly/meters KeyH collision: both used to default to
 // KeyH, and the uniqueness sweep handed KeyH to Target Nearest Friendly
 // (Targeting precedes Interface), so the next save() persisted Damage Meters as
@@ -40,6 +51,12 @@ function entryPrimary(v: unknown): string | null {
 // it keeps the current default rather than loading unbound.
 function isEmptyEntry(v: unknown): boolean {
   return Array.isArray(v) && v.every((c) => c === null || c === undefined);
+}
+
+// True when the stored entry is the v0.24.0-window meters shape: primary KeyZ,
+// empty secondary.
+function isStaleMetersKeyZ(v: unknown): boolean {
+  return Array.isArray(v) && v[0] === 'KeyZ' && (v[1] === null || v[1] === undefined);
 }
 
 // True when Target Nearest Friendly resolves to KeyH: either it is absent (so it
@@ -69,6 +86,9 @@ export function repairStoredBindings(obj: StoredBindingsBlob): StoredBindingsBlo
     delete obj.slot11;
     delete obj.strafeLeft;
     delete obj.strafeRight;
+    if (isStaleMetersKeyZ(obj.meters)) {
+      delete obj.meters;
+    }
   }
   // Signature B: meters evicted to empty while targetFriendly still holds KeyH.
   if (isEmptyEntry(obj.meters) && targetFriendlyIsKeyH(obj)) {

--- a/tests/keybinds.test.ts
+++ b/tests/keybinds.test.ts
@@ -477,6 +477,28 @@ describe('per-character scope', () => {
     expect(fresh.actionForCode('KeyE')).toBe('strafeRight');
   });
 
+  it('repairs a stale v0.24.0-window meters:KeyZ binding and its collateral Sheathe eviction', () => {
+    // The v0.24.0 overhaul window also persisted Damage Meters on KeyZ alongside
+    // the Q/E strafe signature. meters is processed before sheathe in
+    // BIND_ACTIONS, so an unrepaired stored meters:['KeyZ', null] claims KeyZ
+    // first and the load-time uniqueness sweep silently evicts Sheathe/Unsheathe
+    // Weapon's untouched default down to unbound.
+    localStorage.setItem(
+      'woc_keybinds:char:alice',
+      JSON.stringify({
+        strafeLeft: [null, null],
+        strafeRight: [null, null],
+        slot10: ['KeyQ', 'Minus'],
+        slot11: ['KeyE', 'Equal'],
+        meters: ['KeyZ', null],
+      }),
+    );
+    const fresh = new Keybinds('char:alice');
+    expect(fresh.codeAt('meters', 0)).toBe('Shift+KeyH');
+    expect(fresh.codeAt('sheathe', 0)).toBe('KeyZ');
+    expect(fresh.actionForCode('KeyZ')).toBe('sheathe');
+  });
+
   it('re-seeds an evicted meters binding to Shift+KeyH on a scoped profile', () => {
     // A profile saved while targetFriendly and meters both defaulted to KeyH
     // persisted meters as [null, null] (the sweep gave KeyH to targetFriendly).

--- a/tests/keybinds_repair.test.ts
+++ b/tests/keybinds_repair.test.ts
@@ -39,6 +39,27 @@ describe('repairStoredBindings', () => {
     expect(obj.strafeLeft).toEqual(['KeyQ']);
   });
 
+  it('also drops the v0.24.0-window meters:KeyZ leftover alongside the strafe signature', () => {
+    // The same v0.24.0 overhaul window that persisted Q/E on slot10/11 also
+    // persisted Damage Meters on KeyZ. Signature A must clear it too, or the
+    // stale KeyZ stays bound and evicts Sheathe/Unsheathe Weapon's default.
+    const obj = repairStoredBindings({
+      strafeLeft: [null, null],
+      strafeRight: [null, null],
+      slot10: ['KeyQ', 'Minus'],
+      slot11: ['KeyE', 'Equal'],
+      meters: ['KeyZ', null],
+    });
+    expect('meters' in obj).toBe(false);
+  });
+
+  it('leaves a deliberate meters:KeyZ rebind alone when the strafe signature is absent', () => {
+    // Without the rest of the v0.24.0 fingerprint, a stored meters:KeyZ is
+    // ordinary player intent (a deliberate remap), not corruption.
+    const obj = repairStoredBindings({ meters: ['KeyZ', null] });
+    expect(obj.meters).toEqual(['KeyZ', null]);
+  });
+
   it('drops an evicted meters binding when targetFriendly still holds KeyH', () => {
     // targetFriendly absent -> defaults to KeyH.
     const a = repairStoredBindings({ meters: [null, null] });


### PR DESCRIPTION
## Summary

The v0.24.0 interface-overhaul window (reverted the same day, tracked in #1792) shipped
Damage Meters defaulting to `KeyZ` alongside the well-known Q/E strafe overhaul
(`slot10`/`slot11` on Q/E, Strafe Left/Right unbound). PR #1855 replaced the original
all-five-fields-at-once migration (`d369f21c1`) with a two-signature `keybinds_repair.ts`
module, but Signature A only re-checks the four strafe-related fields (`slot10`, `slot11`,
`strafeLeft`, `strafeRight`); it never clears the fifth field from that same poisoned
profile, `meters: ['KeyZ', null]`.

Because `meters` is registered before `sheathe` in `BIND_ACTIONS`, an unrepaired stored
`meters: ['KeyZ', null]` claims `KeyZ` first during `Keybinds.load()`, and the load-time
uniqueness sweep then silently drops Sheathe/Unsheathe Weapon's own (untouched, still-default)
`KeyZ` binding to unbound. A player affected by this profile therefore permanently loses
Damage Meters on `Shift+H` (stuck on the dead bare `Z`) AND loses Sheathe/Unsheathe entirely,
with no error or indication why.

The fix extends Signature A's repair block to also delete `obj.meters` when it resolves to
primary `KeyZ` with an empty secondary, restoring parity with the original single-signature
migration this module replaced. A `meters: KeyZ` value seen without the rest of the strafe
signature is left untouched, since on its own it reads as a deliberate remap, not corruption.

## Related issues

Closes #1792

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/keybinds_repair.test.ts tests/keybinds.test.ts` (added two unit
    cases to `keybinds_repair.test.ts` and one end-to-end `Keybinds` regression case to
    `keybinds.test.ts`; confirmed both new cases failed for the expected reason before the
    fix, then passed after it; full run: 2 files, 62 tests, all green)
  - `npx vitest run tests/architecture.test.ts` (33 tests, green; `src/game/` purity/registration
    unaffected)
  - `npx vitest run tests/world_api_parity.test.ts` (270 tests, green; sanity check, this
    change does not touch `IWorld`)
  - `npx tsc --noEmit` (clean, no errors)
  - `npx @biomejs/biome check --write src/game/keybinds_repair.ts tests/keybinds_repair.test.ts tests/keybinds.test.ts`
    (no format diffs; 4 pre-existing lint warnings in unrelated, unchanged lines of
    `tests/keybinds.test.ts`, not errors)
- Manual steps: none, this is sim/test-only logic with no DOM/visual surface.

## Screenshots / recordings

N/A. This is pure local-storage repair logic with no player-visible UI change; behavior is
covered entirely by the new automated tests.

---

## Root cause

```mermaid
flowchart TD
    A["Stored profile from the v0.24.0 window:<br/>slot10=KeyQ, slot11=KeyE,<br/>strafeLeft/Right empty,<br/>meters=['KeyZ', null]"] --> B{"repairStoredBindings()"}
    B --> C["Signature A matches<br/>(slot10/11 + strafe empty)"]
    C -->|before fix| D["deletes slot10, slot11,<br/>strafeLeft, strafeRight only"]
    D --> E["obj.meters = ['KeyZ', null] survives untouched"]
    E --> F["Keybinds.load() first pass:<br/>meters (registered before sheathe)<br/>claims KeyZ from its explicit stored entry"]
    F --> G["sheathe has no stored entry,<br/>keeps its default ['KeyZ', null]"]
    G --> H["second pass: KeyZ already claimed by meters,<br/>sheathe's default KeyZ is dropped"]
    H --> I["RESULT: meters stuck on dead KeyZ,<br/>Sheathe/Unsheathe silently unbound"]

    C -->|after fix| J["also deletes obj.meters<br/>when it resolves to KeyZ + empty secondary"]
    J --> K["meters re-seeds to its current default Shift+KeyH"]
    K --> L["KeyZ stays free for sheathe's own default"]
    L --> M["RESULT: meters on Shift+KeyH,<br/>Sheathe/Unsheathe on KeyZ, both correct"]
```

## Checklist

### Quality

- [x] **The full gate passes.** Ran the targeted subset above (`tsc`, the changed-file
      biome check, the new/updated test files, plus `architecture.test.ts` and
      `world_api_parity.test.ts` as a sanity check) rather than the full `npm run gate`,
      per the task's scoped-verification instructions (other agents are running concurrently
      on this machine). All green.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, no UI surface.
- ~~Accessible.~~ N/A, no UI surface.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path.
- [x] I didn't hand-edit any generated file.
