### PR TITLE
fix(mage): break roots on self-cast Chronomancy Temporal Barrier

### DIFF
--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -2205,7 +2205,10 @@ export function runEffects(
         break;
       }
       case 'breakRoots': {
-        removeRootAuras(ctx, p);
+        // Self-cast only: a personal barrier laid on a friendly TARGET (the
+        // Chronomancy Temporal Barrier can shield an ally) must not cleanse
+        // the caster's own root just because they cast the spell.
+        if (!target || target === p) removeRootAuras(ctx, p);
         break;
       }
       case 'breakControl': {

--- a/src/sim/content/choice_rows_classic.ts
+++ b/src/sim/content/choice_rows_classic.ts
@@ -127,6 +127,11 @@ export const MAGE_CHOICE_ROWS: ClassChoiceRows = {
             ability: [
               { ability: 'ice_barrier', addEffects: [{ type: 'breakRoots' }] },
               { ability: 'blazing_barrier', addEffects: [{ type: 'breakRoots' }] },
+              // Chronomancy's shield fills the same personal-barrier slot (see
+              // PERSONAL_BARRIER_IDS) and can also be cast on an ally: the
+              // breakRoots dispatch case gates on a self-cast so a ward laid
+              // on an ally never cleanses the caster's own root.
+              { ability: 'temporal_barrier', addEffects: [{ type: 'breakRoots' }] },
             ],
           },
         },

--- a/tests/mage_choice_rows.test.ts
+++ b/tests/mage_choice_rows.test.ts
@@ -186,6 +186,7 @@ describe('mage choice rows (owner tree)', () => {
     expect(option?.effect.ability).toEqual([
       { ability: 'ice_barrier', addEffects: [{ type: 'breakRoots' }] },
       { ability: 'blazing_barrier', addEffects: [{ type: 'breakRoots' }] },
+      { ability: 'temporal_barrier', addEffects: [{ type: 'breakRoots' }] },
     ]);
 
     applyControl(sim, p, mob.id, 'slow');
@@ -209,6 +210,19 @@ describe('mage choice rows (owner tree)', () => {
 
     expect(p.auras.some((aura) => aura.kind === 'root')).toBe(false);
     expect(p.auras.some((aura) => aura.id === 'blazing_barrier')).toBe(true);
+  });
+
+  it('Shifting Ward breaks roots when an Arcane mage casts Temporal Barrier on themselves', () => {
+    const { sim, p } = rig({ 8: 'mag_r8_temporal_rift' }, 20, 'arcane');
+    const mob = addTargetMob(sim);
+    applyControl(sim, p, mob.id, 'root');
+
+    // No friendly override and the current target is the hostile mob, so
+    // resolveFriendlyTarget falls back to self: this is a self-cast.
+    sim.castAbility('temporal_barrier');
+
+    expect(p.auras.some((aura) => aura.kind === 'root')).toBe(false);
+    expect(p.auras.some((aura) => aura.id === 'temporal_barrier')).toBe(true);
   });
 
   it('Shifting Ward does not self-cleanse an Arcane mage shielding an ally', () => {


### PR DESCRIPTION
## Summary

The mage row-8 choice-row talent Shifting Ward ("Casting your personal barrier breaks roots affecting you") only wired its `breakRoots` effect onto `ice_barrier` (Frost) and `blazing_barrier` (Fire). It omitted `temporal_barrier` (Chronomancy/Arcane), even though `PERSONAL_BARRIER_IDS` (`src/sim/combat/fire_mage.ts`) explicitly documents all three as filling the same personal-barrier slot and every sibling row talent (Warded, the shared proc hooks) already keys off that shared slot. As a result, an Arcane mage picking Shifting Ward and casting their own personal barrier while rooted never broke the root: the talent silently no-op'd for one of the three specs.

Fix:
1. Added the third `{ ability: 'temporal_barrier', addEffects: [{ type: 'breakRoots' }] }` entry to the Shifting Ward `effect.ability` array in `src/sim/content/choice_rows_classic.ts`, matching the `ice_barrier`/`blazing_barrier` entries.
2. `temporal_barrier` (unlike the other two) is `targetType: 'friendly'` and can be cast on an ally, not just the caster. The existing `breakRoots` dispatch case in `src/sim/combat/effect_dispatch.ts` unconditionally cleared root auras off the *caster*, which would have made an ally-cast Temporal Barrier incorrectly cleanse the caster's own root too. Gated the case on `!target || target === p` (self-cast only) so an ally-targeted cast leaves the caster's root untouched, matching the existing pinned expectation that Shifting Ward "does not self-cleanse an Arcane mage shielding an ally."

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/mage_choice_rows.test.ts` (added a new failing test reproducing the self-cast Arcane case, confirmed it failed for the right reason before the fix, then confirmed all 33 tests pass after the fix, including the updated catalog-pin assertion and the pre-existing ally-cast non-cleanse test)
  - `npx vitest run tests/combat_effect_dispatch.test.ts tests/architecture.test.ts tests/world_api_parity.test.ts` (344 tests passed)
  - `npx vitest run tests/parity` (186 passed, 1 pre-existing skip, confirming no determinism/golden-trace drift from the dispatch change)
  - `npx tsc --noEmit` (clean)
  - `npx @biomejs/biome check --write src/sim/content/choice_rows_classic.ts src/sim/combat/effect_dispatch.ts tests/mage_choice_rows.test.ts` (no diffs on the changed lines; two pre-existing unrelated warnings elsewhere in `effect_dispatch.ts` left untouched per repo policy on whole-file debt)
- Manual steps: none (sim-only logic change, not visually observable; screenshots skipped per task scope)

## Checklist

### Quality
- [x] **The full gate passes** for the touched behavior: targeted `tsc`, the new/updated Vitest suite, `tests/architecture.test.ts`, `tests/world_api_parity.test.ts`, and `tests/parity` all green (full `npm run gate` left to CI per task scope to avoid contending with concurrent worktree agents on this machine).

### Cross-platform
- ~~Tested on desktop and mobile.~~ N/A: sim-only logic, no UI surface.
- ~~Accessible.~~ N/A: no UI change.

### Localization (i18n)
- [x] N/A. This PR adds no player-visible strings (the talent's description text and dispatch gating are unchanged).

### Hygiene
- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

## Root cause

```mermaid
flowchart TD
    subgraph before["Before: temporal_barrier missing from the wiring"]
        A1[Shifting Ward talent] -->|addEffects breakRoots| B1[ice_barrier]
        A1 -->|addEffects breakRoots| C1[blazing_barrier]
        A1 -.->|not wired| D1[temporal_barrier]
        D1 --> E1[Arcane mage casts own shield while rooted]
        E1 --> F1[No breakRoots effect on ability: root never clears]
    end

    subgraph after["After: wired, but gated on self-cast"]
        A2[Shifting Ward talent] -->|addEffects breakRoots| B2[ice_barrier]
        A2 -->|addEffects breakRoots| C2[blazing_barrier]
        A2 -->|addEffects breakRoots| D2[temporal_barrier]
        D2 --> G2{cast target}
        G2 -->|self or no target| H2[removeRootAuras on caster: root clears]
        G2 -->|friendly ally| I2[skip: caster's own root stays, matches pinned ally test]
    end
