### PR TITLE
fix(economy): thread crafted-item provenance through trade and market

### DIFF
--- a/src/sim/bags.ts
+++ b/src/sim/bags.ts
@@ -182,15 +182,21 @@ export function canAddItem(
  *  mail claim, vendor buyback), payload-aware on both arms (#2139: the
  *  pre-check must model the grant identically or the overflow class re-opens):
  *  with `instance` absent this is canAddItem, with it canGrantItemInstance.
- *  Its grant twin is item_instance_transfer.ts grantCopies. */
+ *  Also threads the plain-stack `craftedRecipeId` marker: a caller granting a
+ *  crafted plain stack must pre-check with the same marker `grantCopies`
+ *  grants with, or the fit check can see room in a marker-free stack that the
+ *  actual grant (keyed on the marker by addStacked) cannot merge into,
+ *  overfilling the recipient's bags past the modelled cap. Its grant twin is
+ *  item_instance_transfer.ts grantCopies. */
 export function canGrantCopies(
   inventory: readonly InvSlot[],
   capacity: number,
   itemId: string,
   count: number,
   instance?: ItemInstancePayload,
+  craftedRecipeId?: string,
 ): boolean {
-  return countFit(inventory, capacity, itemId, count, instance) >= count;
+  return countFit(inventory, capacity, itemId, count, instance, craftedRecipeId) >= count;
 }
 
 /** True when EVERY add in the batch fits together (simulated cumulatively on a

--- a/src/sim/bank.ts
+++ b/src/sim/bank.ts
@@ -113,6 +113,11 @@ export function moveBetweenContainers(
 
   const want = count === undefined ? slot.count : Math.floor(count);
   if (!(want > 0) || want > slot.count) return { moved: 0, refusal: 'invalid' };
+  // Thread the plain-stack craftedRecipeId marker (bags.ts InvSlot.craftedRecipeId)
+  // into BOTH the fit check and the grant: without it a bank deposit/withdraw round
+  // trip strips the marker (addStacked/countFit key their merge on it), silently
+  // laundering a crafted item's disenchant-gate provenance into a plain drop, the
+  // same class of bug the trade/market fix closed.
   if (countFit(dest, destCapacity, slot.itemId, want, undefined, slot.craftedRecipeId) < want) {
     return { moved: 0, refusal: 'no_fit' };
   }

--- a/src/sim/item_instance_transfer.ts
+++ b/src/sim/item_instance_transfer.ts
@@ -124,16 +124,26 @@ export function removeMatchingInstance(
  *  every current source row is destroyed after the grant, a surviving source
  *  (a future instanced house listing, which never depletes) must never alias
  *  one payload object into every buyer's bags. Capacity is the caller's
- *  pre-check (bags.ts canGrantCopies, this function's twin). */
+ *  pre-check (bags.ts canGrantCopies, this function's twin).
+ *
+ *  `craftedRecipeId` (bags.ts InvSlot.craftedRecipeId, professions/crafting.ts)
+ *  is the PLAIN-STACK provenance marker, orthogonal to `instance`: a row on
+ *  the market/mail book carries one or the other, never both (an instanced
+ *  copy is escrowed through marketListInstance/its own pipe; a plain crafted
+ *  stack through marketList/mailSendResolved). It is a no-op on the instanced
+ *  arm and threaded into the plain grant otherwise, so a market/mail round
+ *  trip never launders a crafted item's provenance and reopens the disenchant
+ *  anti-farming gate (professions/enchanting.ts isCraftedDisenchantVictim). */
 export function grantCopies(
   ctx: SimContext,
   pid: number,
   itemId: string,
   count: number,
   instance?: ItemInstancePayload,
+  craftedRecipeId?: string,
 ): void {
   if (instance) ctx.addItemInstance(itemId, cloneItemInstancePayload(instance), pid, count);
-  else ctx.addItem(itemId, count, pid);
+  else ctx.addItem(itemId, count, pid, { craftedRecipeId });
 }
 
 /** Rebuild a persisted exchange-escrow slot (market collection item, mail

--- a/src/sim/items.ts
+++ b/src/sim/items.ts
@@ -60,7 +60,11 @@ interface EquippedInventoryUnit {
   craftedRecipeId: string | undefined;
 }
 
-interface VendorRemovedUnit {
+// Exported for social/trade.ts and market.ts (BUG #9): the trade swap and the
+// World Market escrow both need the same per-unit craftedRecipeId tracking a
+// vendor sell/buyback already had, so they reuse this shape and the walk
+// below instead of duplicating it.
+export interface VendorRemovedUnit {
   instance: ItemInstancePayload | undefined;
   craftedRecipeId: string | undefined;
 }
@@ -215,7 +219,14 @@ export function removePreferFungible(
   return consumed;
 }
 
-function removeVendorSellUnits(
+// Per-unit removal that reports each removed unit's ItemInstancePayload AND
+// its plain-stack craftedRecipeId marker (bags.ts InvSlot.craftedRecipeId),
+// walking plain (non-instanced) slots first, then instanced ones, both
+// highest-index-first (the same order removeFungibleItem/removeItem use, so
+// a caller switching from those to this is a behavior-preserving swap). The
+// optional `skip` predicate spares any instanced copy it matches, same
+// contract as removePreferFungible's.
+export function removeVendorSellUnits(
   ctx: SimContext,
   itemId: string,
   count: number,

--- a/src/sim/mail/post_office.ts
+++ b/src/sim/mail/post_office.ts
@@ -479,7 +479,13 @@ export class PostOffice {
         if (escrowed) parcels.push({ itemId: s.itemId, count: 1, instance: escrowed });
       } else {
         const count = Math.floor(s.count);
-        const consumed = removeVendorSellUnits(this.ctx, s.itemId, count, meta.entityId, () => true);
+        const consumed = removeVendorSellUnits(
+          this.ctx,
+          s.itemId,
+          count,
+          meta.entityId,
+          () => true,
+        );
         const byRecipe = new Map<string | undefined, number>();
         for (const unit of consumed) {
           byRecipe.set(unit.craftedRecipeId, (byRecipe.get(unit.craftedRecipeId) ?? 0) + 1);
@@ -544,7 +550,16 @@ export class PostOffice {
       // addItemInstance so its payload survives delivery; a plain parcel
       // threads its craftedRecipeId marker through so a mailed crafted item
       // keeps its provenance on arrival, the same as the market fix.
-      if (canGrantCopies(meta.inventory, bagCapacity(meta.bags), s.itemId, s.count, s.instance)) {
+      if (
+        canGrantCopies(
+          meta.inventory,
+          bagCapacity(meta.bags),
+          s.itemId,
+          s.count,
+          s.instance,
+          s.craftedRecipeId,
+        )
+      ) {
         grantCopies(this.ctx, meta.entityId, s.itemId, s.count, s.instance, s.craftedRecipeId);
       } else {
         kept.push(s);

--- a/src/sim/mail/post_office.ts
+++ b/src/sim/mail/post_office.ts
@@ -33,6 +33,7 @@ import {
   removeMatchingInstance,
   sanitizeEscrowSlot,
 } from '../item_instance_transfer';
+import { removeVendorSellUnits } from '../items';
 import type { PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
 import {
@@ -457,11 +458,19 @@ export class PostOffice {
       this.result(meta.entityId, 'recipientBoxFull');
       return;
     }
-    // Escrow: coin and goods leave the sender now, ride with the raven. A plain
-    // entry removes fungible stock only (an instanced copy is never consumed as
-    // a plain stack member); an instanced entry escrows the ACTUAL matching
-    // copy, whose payload (removeMatchingInstance's contract, never the wire
-    // needle) is what the letter carries.
+    // Escrow: coin and goods leave the sender now, ride with the raven. An
+    // instanced entry escrows the ACTUAL matching copy, whose payload
+    // (removeMatchingInstance's contract, never the wire needle) is what the
+    // letter carries. A plain entry escrows via removeVendorSellUnits (the
+    // trade/market walk) with a `skip` that spares every instanced copy
+    // (matching the countFungibleItem check above, so an instanced copy is
+    // never consumed as a plain stack member), so the escrow reports each
+    // removed unit's plain-stack craftedRecipeId marker (bags.ts
+    // InvSlot.craftedRecipeId): otherwise a mailed crafted item lands at the
+    // recipient with no marker, laundering the disenchant-gate provenance the
+    // same way the trade/market fix closed. A single plain entry can legitimately
+    // span two provenance buckets (the market's boundstone_helm case), so it
+    // splits into one parcel per bucket rather than merging them.
     meta.copper -= coin + MAIL_POSTAGE;
     const parcels: InvSlot[] = [];
     for (const s of items) {
@@ -469,8 +478,19 @@ export class PostOffice {
         const escrowed = removeMatchingInstance(this.ctx, s.itemId, s.instance, meta.entityId);
         if (escrowed) parcels.push({ itemId: s.itemId, count: 1, instance: escrowed });
       } else {
-        this.ctx.removeFungibleItem(s.itemId, Math.floor(s.count), meta.entityId);
-        parcels.push({ itemId: s.itemId, count: Math.floor(s.count) });
+        const count = Math.floor(s.count);
+        const consumed = removeVendorSellUnits(this.ctx, s.itemId, count, meta.entityId, () => true);
+        const byRecipe = new Map<string | undefined, number>();
+        for (const unit of consumed) {
+          byRecipe.set(unit.craftedRecipeId, (byRecipe.get(unit.craftedRecipeId) ?? 0) + 1);
+        }
+        for (const [craftedRecipeId, bucketCount] of byRecipe) {
+          parcels.push({
+            itemId: s.itemId,
+            count: bucketCount,
+            ...(craftedRecipeId === undefined ? {} : { craftedRecipeId }),
+          });
+        }
       }
     }
     this.book({
@@ -521,9 +541,11 @@ export class PostOffice {
     for (const s of m.items) {
       // The shared payload-aware pair (bags.ts canGrantCopies + grantCopies):
       // an instanced parcel needs instanced room and lands through
-      // addItemInstance so its payload survives delivery.
+      // addItemInstance so its payload survives delivery; a plain parcel
+      // threads its craftedRecipeId marker through so a mailed crafted item
+      // keeps its provenance on arrival, the same as the market fix.
       if (canGrantCopies(meta.inventory, bagCapacity(meta.bags), s.itemId, s.count, s.instance)) {
-        grantCopies(this.ctx, meta.entityId, s.itemId, s.count, s.instance);
+        grantCopies(this.ctx, meta.entityId, s.itemId, s.count, s.instance, s.craftedRecipeId);
       } else {
         kept.push(s);
       }
@@ -785,9 +807,15 @@ export class PostOffice {
       // edit): dormant, recoverable data, exactly like market listings.
       // sanitizeEscrowSlot preserves an instanced parcel's payload and clamps
       // its count to the identical-payload merge cap (the character-load rule).
+      // A plain parcel's craftedRecipeId marker rides alongside it (dropped by
+      // sanitizeEscrowSlot, which is instance-only), so a mail restart never
+      // strips a crafted item's provenance out of an in-flight attachment.
       const items = (m.items ?? [])
         .filter((s) => s && typeof s.itemId === 'string')
-        .map((s) => sanitizeEscrowSlot(s, instancedCountCap(ITEMS[s.itemId], s.instance)));
+        .map((s) => ({
+          ...sanitizeEscrowSlot(s, instancedCountCap(ITEMS[s.itemId], s.instance)),
+          ...(typeof s.craftedRecipeId === 'string' ? { craftedRecipeId: s.craftedRecipeId } : {}),
+        }));
       const kind: MailKind = m.kind === 'player' || m.kind === 'npc' ? m.kind : 'system';
       const recipientName = String(m.recipientName ?? m.recipientKey);
       const senderName = String(m.senderName ?? '?');

--- a/src/sim/market.ts
+++ b/src/sim/market.ts
@@ -549,6 +549,7 @@ export class Market {
         listing.itemId,
         listing.count,
         listing.instance,
+        listing.craftedRecipeId,
       )
     ) {
       this.ctx.error(meta.entityId, 'Your bags are full.');
@@ -607,6 +608,7 @@ export class Market {
         listing.itemId,
         listing.count,
         listing.instance,
+        listing.craftedRecipeId,
       )
     ) {
       this.ctx.error(meta.entityId, 'Your bags are full.');
@@ -661,7 +663,16 @@ export class Market {
     // arms so a returned instanced listing keeps its payload here too.
     const kept: typeof col.items = [];
     for (const s of col.items) {
-      if (canGrantCopies(meta.inventory, bagCapacity(meta.bags), s.itemId, s.count, s.instance)) {
+      if (
+        canGrantCopies(
+          meta.inventory,
+          bagCapacity(meta.bags),
+          s.itemId,
+          s.count,
+          s.instance,
+          s.craftedRecipeId,
+        )
+      ) {
         grantCopies(this.ctx, meta.entityId, s.itemId, s.count, s.instance, s.craftedRecipeId);
       } else {
         kept.push(s);

--- a/src/sim/market.ts
+++ b/src/sim/market.ts
@@ -351,10 +351,41 @@ export class Market {
     // (recipes.ts: boundstone_helm, gravewyrm_gauntlets), so this groups the
     // removed units by marker and lists each bucket as its own row rather than
     // merging them, keeping every listing's craftedRecipeId exact for every
-    // unit in it. The ask splits proportionally by bucket size (remainder on
-    // the last bucket) so the rows this call creates always sum to `ask`
-    // exactly; in the ordinary single-bucket case that is just `ask` on the
-    // one row, unchanged from before.
+    // unit in it. The ask splits so every row gets at least MARKET_MIN_PRICE
+    // and the rows this call creates always sum to `ask` exactly; in the
+    // ordinary single-bucket case that is just `ask` on the one row, unchanged
+    // from before.
+    // Preview the bucket split BEFORE escrowing anything: the market only
+    // ever sells fungible (non-instanced) stock here (countFungibleItem
+    // gated `want` above), so this walks the same plain-slot,
+    // highest-index-first order removeVendorSellUnits uses, without
+    // mutating, purely to learn how many distinct craftedRecipeId buckets
+    // the removal will produce. Both the MARKET_MAX_LISTINGS and
+    // MARKET_MIN_PRICE-per-row invariants must hold for the split BEFORE any
+    // item leaves the seller's bag (#2605 review: a dual-provenance stack
+    // could otherwise push the seller over the listing cap, or price a
+    // bucket at 0 copper and hand the item away for free).
+    const previewByRecipe = new Map<string | undefined, number>();
+    let previewLeft = want;
+    for (let i = meta.inventory.length - 1; i >= 0 && previewLeft > 0; i--) {
+      const s = meta.inventory[i];
+      if (s.itemId !== itemId || s.instance) continue;
+      const take = Math.min(s.count, previewLeft);
+      previewByRecipe.set(s.craftedRecipeId, (previewByRecipe.get(s.craftedRecipeId) ?? 0) + take);
+      previewLeft -= take;
+    }
+    const bucketCountPreview = previewByRecipe.size;
+    if (mine + bucketCountPreview > MARKET_MAX_LISTINGS) {
+      this.ctx.error(
+        meta.entityId,
+        `You may keep at most ${MARKET_MAX_LISTINGS} goods on the market at once.`,
+      );
+      return;
+    }
+    if (ask < bucketCountPreview) {
+      this.ctx.error(meta.entityId, 'Name a price of at least 1 copper.');
+      return;
+    }
     const units = removeVendorSellUnits(this.ctx, itemId, want, meta.entityId, () => true);
     const byRecipe = new Map<string | undefined, number>();
     for (const unit of units) {
@@ -363,8 +394,17 @@ export class Market {
     const buckets = [...byRecipe.entries()];
     let priceLeft = ask;
     buckets.forEach(([craftedRecipeId, bucketCount], i) => {
+      const remainingBuckets = buckets.length - i;
       const bucketPrice =
-        i === buckets.length - 1 ? priceLeft : Math.floor((ask * bucketCount) / want);
+        i === buckets.length - 1
+          ? priceLeft
+          : Math.max(
+              MARKET_MIN_PRICE,
+              Math.min(
+                priceLeft - (remainingBuckets - 1) * MARKET_MIN_PRICE,
+                Math.floor((ask * bucketCount) / want),
+              ),
+            );
       priceLeft -= bucketPrice;
       this.marketListings.push({
         id: this.nextListingId++,

--- a/src/sim/market.ts
+++ b/src/sim/market.ts
@@ -20,6 +20,7 @@ import {
   removeMatchingInstance,
   sanitizeEscrowSlot,
 } from './item_instance_transfer';
+import { removeVendorSellUnits } from './items';
 import { planListingIds, playerListingIdFloor } from './market_listing_ids';
 import {
   MARKET_PAGE_SIZE,
@@ -111,6 +112,15 @@ export interface MarketListing {
    *  for the plain fungible listings, whose rows stay byte-identical. Wire
    *  browse rows carry only its publicInstanceView projection. */
   instance?: ItemInstancePayload;
+  // Recipe id that crafted every unit in this stack (bags.ts InvSlot.craftedRecipeId,
+  // professions/crafting.ts), when the seller's stock carried one. Absent for a
+  // plain, never-crafted stack (and always absent on an instanced row: `instance`
+  // and `craftedRecipeId` are mutually exclusive, one row is either a single
+  // instanced copy or a plain fungible stack). Threaded through buy/cancel/collect
+  // (BUG #9) so a market round trip never launders a crafted item's provenance
+  // and reopens the disenchant anti-farming gate
+  // (professions/enchanting.ts isCraftedDisenchantVictim).
+  craftedRecipeId?: string;
 }
 
 // Gold + items awaiting pickup at the Merchant (sale proceeds, expired
@@ -135,6 +145,7 @@ export interface MarketSave {
     /** Additive (#1165): the escrowed payload of an instanced listing. Absent
      *  on plain rows and on every pre-payload save, which load unchanged. */
     instance?: ItemInstancePayload;
+    craftedRecipeId?: string;
   }[];
   collections: { key: string; copper: number; items: InvSlot[] }[];
   nextListingId: number;
@@ -327,16 +338,45 @@ export class Market {
       );
       return;
     }
-    this.ctx.removeFungibleItem(itemId, want, meta.entityId); // escrow (fungible-only, #1165)
-    this.marketListings.push({
-      id: this.nextListingId++,
-      sellerKey,
-      sellerName: meta.name,
-      itemId,
-      count: want,
-      price: ask,
-      expiresAt: this.ctx.time + MARKET_LISTING_DURATION,
-      house: false,
+    // Escrow per unit instead of the old blind fungible bulk-decrement, so each
+    // removed unit's craftedRecipeId marker (bags.ts InvSlot.craftedRecipeId,
+    // professions/crafting.ts) is known (BUG #9: losing it here let a crafted
+    // item launder its provenance through the World Market, reopening the
+    // disenchant anti-farming gate, professions/enchanting.ts
+    // isCraftedDisenchantVictim). The always-skip predicate is defence in
+    // depth on top of the countFungibleItem gate above: the market stays
+    // fungible-only (#1165), never touching an instanced or bound copy.
+    // A single sell request can legitimately span two provenance buckets: some
+    // content ships the same item id both crafted and drop-sourced
+    // (recipes.ts: boundstone_helm, gravewyrm_gauntlets), so this groups the
+    // removed units by marker and lists each bucket as its own row rather than
+    // merging them, keeping every listing's craftedRecipeId exact for every
+    // unit in it. The ask splits proportionally by bucket size (remainder on
+    // the last bucket) so the rows this call creates always sum to `ask`
+    // exactly; in the ordinary single-bucket case that is just `ask` on the
+    // one row, unchanged from before.
+    const units = removeVendorSellUnits(this.ctx, itemId, want, meta.entityId, () => true);
+    const byRecipe = new Map<string | undefined, number>();
+    for (const unit of units) {
+      byRecipe.set(unit.craftedRecipeId, (byRecipe.get(unit.craftedRecipeId) ?? 0) + 1);
+    }
+    const buckets = [...byRecipe.entries()];
+    let priceLeft = ask;
+    buckets.forEach(([craftedRecipeId, bucketCount], i) => {
+      const bucketPrice =
+        i === buckets.length - 1 ? priceLeft : Math.floor((ask * bucketCount) / want);
+      priceLeft -= bucketPrice;
+      this.marketListings.push({
+        id: this.nextListingId++,
+        sellerKey,
+        sellerName: meta.name,
+        itemId,
+        count: bucketCount,
+        price: bucketPrice,
+        expiresAt: this.ctx.time + MARKET_LISTING_DURATION,
+        house: false,
+        ...(craftedRecipeId === undefined ? {} : { craftedRecipeId }),
+      });
     });
     this.ctx.emit({
       type: 'loot',
@@ -475,7 +515,14 @@ export class Market {
       return;
     }
     meta.copper -= listing.price;
-    grantCopies(this.ctx, meta.entityId, listing.itemId, listing.count, listing.instance);
+    grantCopies(
+      this.ctx,
+      meta.entityId,
+      listing.itemId,
+      listing.count,
+      listing.instance,
+      listing.craftedRecipeId,
+    );
     if (!listing.house) {
       const proceeds = Math.max(0, Math.floor(listing.price * (1 - MARKET_CUT)));
       this.collectionFor(listing.sellerKey).copper += proceeds;
@@ -526,7 +573,14 @@ export class Market {
       return;
     }
     this.marketListings.splice(idx, 1);
-    grantCopies(this.ctx, meta.entityId, listing.itemId, listing.count, listing.instance);
+    grantCopies(
+      this.ctx,
+      meta.entityId,
+      listing.itemId,
+      listing.count,
+      listing.instance,
+      listing.craftedRecipeId,
+    );
     const def = ITEMS[listing.itemId];
     this.ctx.emit({
       type: 'loot',
@@ -568,7 +622,7 @@ export class Market {
     const kept: typeof col.items = [];
     for (const s of col.items) {
       if (canGrantCopies(meta.inventory, bagCapacity(meta.bags), s.itemId, s.count, s.instance)) {
-        grantCopies(this.ctx, meta.entityId, s.itemId, s.count, s.instance);
+        grantCopies(this.ctx, meta.entityId, s.itemId, s.count, s.instance, s.craftedRecipeId);
       } else {
         kept.push(s);
       }
@@ -588,12 +642,14 @@ export class Market {
       const l = this.marketListings[i];
       if (l.house || this.ctx.time < l.expiresAt) continue;
       this.marketListings.splice(i, 1);
-      // Conditional spread: a plain row must not grow an `instance: undefined`
-      // key (rows are persisted and diffed byte-for-byte).
+      // Conditional spread: a plain row must not grow an `instance: undefined`/
+      // `craftedRecipeId: undefined` key (rows are persisted and diffed
+      // byte-for-byte). instance and craftedRecipeId are mutually exclusive.
       this.collectionFor(l.sellerKey).items.push({
         itemId: l.itemId,
         count: l.count,
         ...(l.instance ? { instance: l.instance } : {}),
+        ...(l.craftedRecipeId === undefined ? {} : { craftedRecipeId: l.craftedRecipeId }),
       });
       const sellerMeta = this.metaByMarketSellerKey(l.sellerKey);
       if (sellerMeta) {
@@ -719,6 +775,7 @@ export class Market {
           // Deep-cloned (never spread): the save must not alias the live book's
           // mutable rolled/charges maps. Conditional so plain rows are unchanged.
           ...(l.instance ? { instance: cloneItemInstancePayload(l.instance) } : {}),
+          ...(l.craftedRecipeId === undefined ? {} : { craftedRecipeId: l.craftedRecipeId }),
         })),
       collections: [...this.marketCollections.entries()].map(([key, c]) => ({
         key,
@@ -785,6 +842,7 @@ export class Market {
           (Number.isFinite(l.secondsLeft) ? Math.max(0, l.secondsLeft) : MARKET_LISTING_DURATION),
         house: false,
         ...(instance ? { instance } : {}),
+        ...(typeof l.craftedRecipeId === 'string' ? { craftedRecipeId: l.craftedRecipeId } : {}),
       });
     }
     for (const c of save.collections ?? []) {
@@ -798,7 +856,12 @@ export class Market {
         // its count to the identical-payload merge cap (the character-load rule).
         items: (c.items ?? [])
           .filter((s) => s && typeof s.itemId === 'string')
-          .map((s) => sanitizeEscrowSlot(s, instancedCountCap(ITEMS[s.itemId], s.instance))),
+          .map((s) => ({
+            ...sanitizeEscrowSlot(s, instancedCountCap(ITEMS[s.itemId], s.instance)),
+            ...(typeof s.craftedRecipeId === 'string'
+              ? { craftedRecipeId: s.craftedRecipeId }
+              : {}),
+          })),
       });
     }
     this.nextListingId = plan.nextListingId;
@@ -831,6 +894,7 @@ export class Market {
         itemId: l.itemId,
         count: l.count,
         ...(l.instance ? { instance: l.instance } : {}),
+        ...(l.craftedRecipeId === undefined ? {} : { craftedRecipeId: l.craftedRecipeId }),
       });
     }
   }

--- a/src/sim/social/trade.ts
+++ b/src/sim/social/trade.ts
@@ -302,8 +302,28 @@ export function tradeConfirm(ctx: SimContext, pid?: number): void {
     for (const s of receives) {
       const plainCount = Math.min(s.count, ctx.countFungibleItem(s.itemId, giver.entityId));
       if (plainCount > 0) {
-        if (countFit(scratch, capacity, s.itemId, plainCount) < plainCount) return false;
-        addStacked(scratch, s.itemId, plainCount);
+        // grantOffer re-grants the plain units bucketed by craftedRecipeId (a
+        // marker-free stack and a crafted stack of the same itemId never merge
+        // on arrival, bags.ts addStacked keys on the marker); model that same
+        // bucket split here, walking the giver's plain slots highest-index-
+        // first (removeVendorSellUnits's order) instead of one flat
+        // marker-free countFit/addStacked call, or this capacity pre-check
+        // can see room in a stack the real grant cannot merge into and
+        // underpredict the receiver's slot usage (#2605 review).
+        const plainByRecipe = new Map<string | undefined, number>();
+        let plainLeft = plainCount;
+        for (let i = giver.inventory.length - 1; i >= 0 && plainLeft > 0; i--) {
+          const g = giver.inventory[i];
+          if (g.itemId !== s.itemId || g.instance) continue;
+          const take = Math.min(g.count, plainLeft);
+          plainByRecipe.set(g.craftedRecipeId, (plainByRecipe.get(g.craftedRecipeId) ?? 0) + take);
+          plainLeft -= take;
+        }
+        for (const [craftedRecipeId, count] of plainByRecipe) {
+          if (countFit(scratch, capacity, s.itemId, count, undefined, craftedRecipeId) < count)
+            return false;
+          addStacked(scratch, s.itemId, count, undefined, craftedRecipeId);
+        }
       }
       let remaining = s.count - plainCount;
       for (let i = giver.inventory.length - 1; i >= 0 && remaining > 0; i--) {

--- a/src/sim/social/trade.ts
+++ b/src/sim/social/trade.ts
@@ -15,7 +15,7 @@ import type { TradeInfo } from '../../world_api';
 import { addStacked, bagCapacity, countFit, removeStacked } from '../bags';
 import { RIFT_GEAR_ITEM_IDS } from '../content/rift/items';
 import { ITEMS } from '../data';
-import { removePreferFungible } from '../items';
+import { removeVendorSellUnits, type VendorRemovedUnit } from '../items';
 import type { PlayerMeta, TradeSession } from '../sim';
 import type { SimContext } from '../sim_context';
 import { dist2d, type InvSlot, type ItemInstancePayload } from '../types';
@@ -177,13 +177,21 @@ export function tradeSetOffer(
 }
 
 // Removal phase of the swap: consumes one side's offer out of their bags,
-// preserving each slot's ItemInstancePayload (enchants, signed materials,
-// rolled quality, boundTo) for grantOffer instead of re-granting plain copies.
-// removePreferFungible already reports exactly which consumed slots carried an
-// instance; grantOffer only had to route those payloads back in through
-// addItemInstance rather than discarding them, the same way discardItem never
-// needed to because a discarded item's payload does not need to reappear
-// anywhere. sellItem is NOT the same case: it records vendor buyback (items.ts
+// preserving each removed unit's ItemInstancePayload (enchants, signed
+// materials, rolled quality, boundTo) AND its plain-stack craftedRecipeId
+// marker (bags.ts InvSlot.craftedRecipeId, professions/crafting.ts) for
+// grantOffer instead of re-granting a marker-free plain copy. Losing the
+// marker let a crafted item launder its provenance across a trade: the
+// recipient's copy looked identical to a never-crafted one, so disenchanting
+// it granted full Enchanting skill and bypassed the anti-farming gate
+// (professions/enchanting.ts isCraftedDisenchantVictim) the same way an
+// untracked vendor buyback used to before items.ts's removeVendorSellUnits/
+// recordVendorBuyback started threading the marker through sell/buyback.
+// Trade reuses that exact per-unit removal instead of removePreferFungible,
+// which only ever reported the instanced remainder and bulk-decremented the
+// plain count with no record of which stack (and therefore which marker) it
+// came from.
+// sellItem is NOT the same case: it records vendor buyback (items.ts
 // sellItem), and buyback re-grants a plain copy today, so a sold instanced item
 // still loses its payload there; that is a pre-existing sibling of this bug,
 // not fixed by this change.
@@ -192,7 +200,7 @@ export function tradeSetOffer(
 // consumes just-received copies (removeItem scans highest-index-first, exactly
 // where addItemInstance pushes) and a swapped instance bounces straight back
 // to its owner, or gets spared while a plain copy crosses in its place.
-type PendingGrant = { itemId: string; plainCount: number; instances: ItemInstancePayload[] };
+type PendingGrant = { itemId: string; units: VendorRemovedUnit[] };
 
 function removeOffer(ctx: SimContext, items: InvSlot[], fromPid: number): PendingGrant[] {
   const grants: PendingGrant[] = [];
@@ -200,30 +208,44 @@ function removeOffer(ctx: SimContext, items: InvSlot[], fromPid: number): Pendin
     // A trade removal NEVER consumes a trade-locked copy. The offer
     // was already clamped to the unbound count (tradeSetOffer / offerCovered),
     // so enough unbound copies exist; the skip predicate is defence in depth so
-    // removePreferFungible's highest-index-first walk spares a bound copy even
-    // if one sits above an unbound one. Every OTHER caller passes no predicate
-    // and keeps its byte-identical behavior.
-    const instances = removePreferFungible(ctx, s.itemId, s.count, fromPid, isTradeLocked);
-    grants.push({ itemId: s.itemId, plainCount: s.count - instances.length, instances });
+    // removeVendorSellUnits's highest-index-first walk spares a bound copy even
+    // if one sits above an unbound one.
+    const units = removeVendorSellUnits(ctx, s.itemId, s.count, fromPid, isTradeLocked);
+    grants.push({ itemId: s.itemId, units });
   }
   return grants;
 }
 
 function grantOffer(ctx: SimContext, grants: PendingGrant[], toPid: number): void {
   for (const g of grants) {
-    if (g.plainCount > 0) ctx.addItem(g.itemId, g.plainCount, toPid);
-    for (const instance of g.instances) {
+    // Plain units (no instance payload) re-grant bucketed by craftedRecipeId:
+    // a marker-free stack and a crafted stack of the same itemId stay two
+    // separate stacks on arrival (bags.ts addStacked keys its merge on the
+    // marker too), instead of one addItem call washing every plain unit's
+    // provenance into whichever marker happened to be checked last.
+    const plainByRecipe = new Map<string | undefined, number>();
+    for (const unit of g.units) {
+      if (unit.instance) continue;
+      plainByRecipe.set(unit.craftedRecipeId, (plainByRecipe.get(unit.craftedRecipeId) ?? 0) + 1);
+    }
+    for (const [craftedRecipeId, count] of plainByRecipe) {
+      ctx.addItem(g.itemId, count, toPid, { craftedRecipeId });
+    }
+    for (const unit of g.units) {
+      if (!unit.instance) continue;
       // Bind-on-trade stamp: a payload armed with bindOnTrade locks
       // to the recipient the first time it changes hands. The instances here
-      // are per-unit deep clones (removeItem's contract; the final unit of a
-      // fully-consumed slot is the original, whose slot is already gone), so
-      // stamping boundTo in place is safe and never aliases a surviving stack.
-      // Generic over the payload: any future bind-on-trade good rides this same
-      // arm with nothing item-specific here.
-      if (instance.bindOnTrade === true && instance.boundTo === undefined) {
-        instance.boundTo = toPid;
+      // are per-unit deep clones (removeVendorSellUnits mirrors removeItem's
+      // contract; the final unit of a fully-consumed slot is the original,
+      // whose slot is already gone), so stamping boundTo in place is safe and
+      // never aliases a surviving stack. Generic over the payload: any future
+      // bind-on-trade good rides this same arm with nothing item-specific here.
+      if (unit.instance.bindOnTrade === true && unit.instance.boundTo === undefined) {
+        unit.instance.boundTo = toPid;
       }
-      ctx.addItemInstance(g.itemId, instance, toPid);
+      ctx.addItemInstance(g.itemId, unit.instance, toPid, 1, {
+        craftedRecipeId: unit.craftedRecipeId,
+      });
     }
   }
 }

--- a/tests/bank.test.ts
+++ b/tests/bank.test.ts
@@ -647,6 +647,34 @@ describe('moveBetweenContainers (container-agnostic guild-bank seam)', () => {
       expect(dst).toEqual([]);
     }
   });
+
+  // Review follow-up on PR #2605 (EnriqueGF, high): the bank laundered a crafted
+  // item's provenance because moveBetweenContainers dropped the plain-stack
+  // craftedRecipeId marker (bags.ts InvSlot.craftedRecipeId), the same class of bug
+  // the trade/market fix closed for those two paths. A deposit/withdraw round trip
+  // must keep the marker, and a crafted stack must never silently merge with a
+  // drop-sourced stack of the same item.
+  it('carries the craftedRecipeId marker through a deposit/withdraw round trip', () => {
+    const src: InvSlot[] = [{ itemId: 'wolf_fang', count: 3, craftedRecipeId: 'r_wolf_fang' }];
+    const dst: InvSlot[] = [];
+    expect(moveBetweenContainers(src, 0, undefined, dst, 10)).toEqual({ moved: 3 });
+    expect(src).toEqual([]);
+    expect(dst).toEqual([{ itemId: 'wolf_fang', count: 3, craftedRecipeId: 'r_wolf_fang' }]);
+    // And back the other way (withdraw is the same primitive, source/dest swapped).
+    const back: InvSlot[] = [];
+    expect(moveBetweenContainers(dst, 0, undefined, back, 10)).toEqual({ moved: 3 });
+    expect(back).toEqual([{ itemId: 'wolf_fang', count: 3, craftedRecipeId: 'r_wolf_fang' }]);
+  });
+
+  it('never merges a crafted stack into a plain stack of the same item id, or vice versa', () => {
+    const src: InvSlot[] = [{ itemId: 'wolf_fang', count: 3, craftedRecipeId: 'r_wolf_fang' }];
+    const dst: InvSlot[] = [{ itemId: 'wolf_fang', count: 5 }];
+    expect(moveBetweenContainers(src, 0, undefined, dst, 2)).toEqual({ moved: 3 });
+    expect(dst).toEqual([
+      { itemId: 'wolf_fang', count: 5 },
+      { itemId: 'wolf_fang', count: 3, craftedRecipeId: 'r_wolf_fang' },
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/item_instance_transfer.test.ts
+++ b/tests/item_instance_transfer.test.ts
@@ -161,6 +161,25 @@ describe('canGrantCopies / grantCopies: the shared exchange-pipe pair', () => {
     expect(canGrantCopies(signedStack, 1, 'pristine_hide', 1)).toBe(false);
   });
 
+  // #2605 review (Rubsey/OSSBrain): canGrantCopies must model the same
+  // craftedRecipeId bucketing grantCopies grants with, or a pre-check can see
+  // room in an existing marker-free stack the real grant (addStacked, keyed
+  // on the marker) cannot merge into, overfilling the recipient's bags past
+  // the modelled cap.
+  it('capacity: a marker-free stack is not room for a crafted-provenance grant, and the reverse', () => {
+    const plainStack: InvSlot[] = [{ itemId: 'pristine_hide', count: 1 }];
+    // One free slot short: the plain stack tops up for a marker-free grant,
+    // but a crafted-marker grant of the same itemId cannot merge into it and
+    // needs its own fresh slot.
+    expect(canGrantCopies(plainStack, 1, 'pristine_hide', 1)).toBe(true);
+    expect(canGrantCopies(plainStack, 1, 'pristine_hide', 1, undefined, 'recipe_x')).toBe(false);
+    const craftedStack: InvSlot[] = [
+      { itemId: 'pristine_hide', count: 1, craftedRecipeId: 'recipe_x' },
+    ];
+    expect(canGrantCopies(craftedStack, 1, 'pristine_hide', 1, undefined, 'recipe_x')).toBe(true);
+    expect(canGrantCopies(craftedStack, 1, 'pristine_hide', 1)).toBe(false);
+  });
+
   it('grant routes instanced copies through addItemInstance with a DEEP CLONE', () => {
     const calls: { kind: string; instance?: ItemInstancePayload }[] = [];
     const ctx = {

--- a/tests/mail.test.ts
+++ b/tests/mail.test.ts
@@ -236,6 +236,67 @@ describe('sending a letter', () => {
     sim.mailDelete(gift.id, bob);
     expect(sim.mailInfoFor(bob)?.messages.some((m) => m.id === gift.id)).toBe(false);
   });
+
+  // Review follow-up on PR #2605 (EnriqueGF, medium): mail was a third laundering
+  // channel for a crafted item's provenance marker (bags.ts InvSlot.craftedRecipeId),
+  // structurally identical to the trade and market paths the PR fixed. Escrowing via
+  // removeVendorSellUnits (instead of a blind removeFungibleItem) and re-granting with
+  // { craftedRecipeId } on mailTake must keep the marker across the flight.
+  it('carries the craftedRecipeId marker through a mailed attachment', () => {
+    const sim = makeWorld();
+    const alice = sim.addPlayer('warrior', 'Alice');
+    const bob = sim.addPlayer('mage', 'Bob');
+    const aliceMeta = sim.meta(alice);
+    const bobMeta = sim.meta(bob);
+    if (!aliceMeta || !bobMeta) throw new Error('no meta');
+    aliceMeta.copper = 10_000;
+    // One crafted copy and one plain (drop-sourced) copy of the same item id, so the
+    // escrow must keep them in separate provenance buckets rather than collapsing them.
+    sim.addItem('roasted_boar', 1, alice, { craftedRecipeId: 'r_roasted_boar' });
+    sim.addItem('roasted_boar', 1, alice);
+    moveToMailbox(sim, alice);
+    sim.mailSend(
+      'Bob',
+      'Provisions',
+      'Eat well.',
+      0,
+      [{ itemId: 'roasted_boar', count: 2 }],
+      alice,
+    );
+    expect(sim.countItem('roasted_boar', alice)).toBe(0);
+    tickFor(sim, MAIL_DELIVERY_SECONDS + 2);
+
+    moveToMailbox(sim, bob);
+    const info = sim.mailInfoFor(bob);
+    const parcel = info?.messages.find((m) => m.subject === 'Provisions');
+    if (!parcel) throw new Error('parcel not delivered');
+    // The escrow must have split the attachment into two provenance buckets.
+    expect(parcel.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          itemId: 'roasted_boar',
+          count: 1,
+          craftedRecipeId: 'r_roasted_boar',
+        }),
+        expect.objectContaining({ itemId: 'roasted_boar', count: 1 }),
+      ]),
+    );
+    expect(parcel.items.find((s) => s.craftedRecipeId !== undefined)?.craftedRecipeId).toBe(
+      'r_roasted_boar',
+    );
+
+    sim.mailTake(parcel.id, bob);
+    const bobMeta2 = sim.meta(bob);
+    if (!bobMeta2) throw new Error('no meta');
+    const crafted = bobMeta2.inventory.find(
+      (s) => s.itemId === 'roasted_boar' && s.craftedRecipeId === 'r_roasted_boar',
+    );
+    const plain = bobMeta2.inventory.find(
+      (s) => s.itemId === 'roasted_boar' && s.craftedRecipeId === undefined,
+    );
+    expect(crafted?.count).toBe(1);
+    expect(plain?.count).toBe(1);
+  });
 });
 
 describe('instanced attachments (finding 1)', () => {

--- a/tests/professions_enchant_salvage_arc.test.ts
+++ b/tests/professions_enchant_salvage_arc.test.ts
@@ -27,6 +27,7 @@ vi.mock('../server/db', () => ({
 import { type ClientSession, GameServer } from '../server/game';
 import { ClientWorld } from '../src/net/online';
 import { type PlayerMeta, Sim } from '../src/sim/sim';
+import * as tradeMod from '../src/sim/social/trade';
 import type { Entity, InvSlot, PlayerClass, SimEvent } from '../src/sim/types';
 import { terrainHeight } from '../src/sim/world';
 
@@ -249,6 +250,19 @@ function moveToVendor(sim: Sim): void {
   player.prevPos = { ...player.pos };
 }
 
+// The World Market's Merchant NPC (market.ts nearMerchant), distinct from
+// trader_wilkes above (vendor buyback only, never market: true).
+function moveToMerchant(sim: Sim, pid: number): void {
+  const merchant = [...sim.ctx.entities.values()].find((e) => e.templateId === 'the_merchant');
+  if (!merchant) throw new Error('missing the_merchant');
+  const player = sim.ctx.entities.get(pid);
+  if (!player) throw new Error(`missing player ${pid}`);
+  player.pos.x = merchant.pos.x + 2;
+  player.pos.z = merchant.pos.z;
+  player.pos.y = terrainHeight(player.pos.x, player.pos.z, sim.cfg.seed);
+  player.prevPos = { ...player.pos };
+}
+
 describe('offline Sim end-to-end (IWorld surface)', () => {
   it('crafted Eastbrook Chainmail Vest stacks yield materials but never teach Enchanting', () => {
     const sim = new Sim({ seed: 20260726, playerClass: 'warrior', autoEquip: false });
@@ -361,6 +375,121 @@ describe('offline Sim end-to-end (IWorld surface)', () => {
     expect(sim.countItem(DUST, pid)).toBeGreaterThan(dustBefore);
     expect(sim.countItem(CRAFTED_COMMON_ARMOR, pid)).toBe(0);
     expect(meta.craftSkills.enchanting).toBe(0);
+  });
+
+  // BUG #9: the same craftedRecipeId marker used to have no equivalent on
+  // PendingGrant (social/trade.ts), so a plain crafted stack re-granted to the
+  // trade recipient with no marker at all, laundering its provenance and
+  // letting the recipient disenchant it for full Enchanting skill.
+  it('crafted Eastbrook Chainmail Vest keeps provenance across a player trade before disenchant', () => {
+    const sim = new Sim({
+      seed: 20260731,
+      playerClass: 'warrior',
+      autoEquip: false,
+      noPlayer: true,
+    });
+    const seller = sim.addPlayer('warrior', 'Seller');
+    const buyer = sim.addPlayer('warrior', 'Buyer');
+    const sellerEntity = sim.ctx.entities.get(seller);
+    const buyerEntity = sim.ctx.entities.get(buyer);
+    if (!sellerEntity || !buyerEntity) throw new Error('missing trade entities');
+    buyerEntity.pos.x = sellerEntity.pos.x + 2;
+    buyerEntity.pos.z = sellerEntity.pos.z;
+
+    grantVestMaterials(sim, seller);
+    sim.craftItem(CRAFTED_COMMON_ARMOR_RECIPE, false, seller);
+    expect(metaFor(sim, seller).lastCraftResult?.ok).toBe(true);
+    expect(craftedVestSlotIndex(sim, seller)).toBeGreaterThanOrEqual(0);
+
+    tradeMod.tradeRequest(sim.ctx, buyer, seller);
+    tradeMod.tradeAccept(sim.ctx, buyer);
+    tradeMod.tradeSetOffer(sim.ctx, [{ itemId: CRAFTED_COMMON_ARMOR, count: 1 }], 0, seller);
+    tradeMod.tradeConfirm(sim.ctx, seller);
+    tradeMod.tradeConfirm(sim.ctx, buyer);
+
+    expect(sim.countItem(CRAFTED_COMMON_ARMOR, seller)).toBe(0);
+    expect(sim.countItem(CRAFTED_COMMON_ARMOR, buyer)).toBe(1);
+    const buyerSlotIndex = craftedVestSlotIndex(sim, buyer);
+    expect(buyerSlotIndex).toBeGreaterThanOrEqual(0);
+
+    sim.disenchantItem(CRAFTED_COMMON_ARMOR, buyer, buyerSlotIndex);
+    expect(sim.lastDisenchantResultFor(buyer)?.ok).toBe(true);
+    expect(metaFor(sim, buyer).craftSkills.enchanting).toBe(0);
+  });
+
+  // BUG #9's other half: MarketListing had no craftedRecipeId field either, so a
+  // crafted stack bought off the World Market re-granted to the buyer bare,
+  // with the same skill-farming consequence.
+  it('crafted Eastbrook Chainmail Vest keeps provenance across a World Market sale before disenchant', () => {
+    const sim = new Sim({
+      seed: 20260732,
+      playerClass: 'warrior',
+      autoEquip: false,
+      noPlayer: true,
+    });
+    const seller = sim.addPlayer('warrior', 'Seller');
+    const buyer = sim.addPlayer('warrior', 'Buyer');
+    moveToMerchant(sim, seller);
+    moveToMerchant(sim, buyer);
+    metaFor(sim, buyer).copper = 1000;
+
+    grantVestMaterials(sim, seller);
+    sim.craftItem(CRAFTED_COMMON_ARMOR_RECIPE, false, seller);
+    expect(metaFor(sim, seller).lastCraftResult?.ok).toBe(true);
+    expect(craftedVestSlotIndex(sim, seller)).toBeGreaterThanOrEqual(0);
+
+    sim.marketList(CRAFTED_COMMON_ARMOR, 1, 100, seller);
+    expect(sim.countItem(CRAFTED_COMMON_ARMOR, seller)).toBe(0);
+    const listing = sim.marketListings.find((l) => l.itemId === CRAFTED_COMMON_ARMOR && !l.house);
+    expect(listing).toBeDefined();
+    expect(listing?.craftedRecipeId).toBe(CRAFTED_COMMON_ARMOR_RECIPE);
+
+    sim.marketBuy(listing!.id, buyer);
+    expect(sim.countItem(CRAFTED_COMMON_ARMOR, buyer)).toBe(1);
+    const buyerSlotIndex = craftedVestSlotIndex(sim, buyer);
+    expect(buyerSlotIndex).toBeGreaterThanOrEqual(0);
+
+    sim.disenchantItem(CRAFTED_COMMON_ARMOR, buyer, buyerSlotIndex);
+    expect(sim.lastDisenchantResultFor(buyer)?.ok).toBe(true);
+    expect(metaFor(sim, buyer).craftSkills.enchanting).toBe(0);
+  });
+
+  // BUG #9 edge case the fix must not reopen: some items are BOTH craftable and
+  // drop-sourced (recipes.ts: boundstone_helm off two dungeon bosses), so a
+  // seller can hold a crafted stack and a plain (dropped) stack of the same
+  // item id at once. Listing both together must split into two listings, one
+  // per provenance, rather than merging the crafted units into a marker-free
+  // listing (which would silently launder them the same way BUG #9 did).
+  it('a sell request spanning two provenance buckets splits into two listings, prices summing to the ask', () => {
+    const sim = new Sim({
+      seed: 20260734,
+      playerClass: 'warrior',
+      autoEquip: false,
+      noPlayer: true,
+    });
+    const seller = sim.addPlayer('warrior', 'Seller');
+    moveToMerchant(sim, seller);
+    const meta = metaFor(sim, seller);
+    const BOUNDSTONE_HELM = 'boundstone_helm';
+    const BOUNDSTONE_HELM_RECIPE = 'recipe_ironbound_warplate_helm';
+    meta.inventory.push({ itemId: BOUNDSTONE_HELM, count: 1 }); // dungeon-dropped, no marker
+    meta.inventory.push({
+      itemId: BOUNDSTONE_HELM,
+      count: 1,
+      craftedRecipeId: BOUNDSTONE_HELM_RECIPE,
+    });
+
+    sim.marketList(BOUNDSTONE_HELM, 2, 101, seller);
+    expect(sim.countItem(BOUNDSTONE_HELM, seller)).toBe(0);
+    const listings = sim.marketListings.filter((l) => l.itemId === BOUNDSTONE_HELM && !l.house);
+    expect(listings).toHaveLength(2);
+    const plain = listings.find((l) => l.craftedRecipeId === undefined);
+    const crafted = listings.find((l) => l.craftedRecipeId === BOUNDSTONE_HELM_RECIPE);
+    expect(plain?.count).toBe(1);
+    expect(crafted?.count).toBe(1);
+    // No copper minted or lost by the split: the two rows' prices sum to the
+    // exact ask the seller named for the whole batch.
+    expect((plain?.price ?? 0) + (crafted?.price ?? 0)).toBe(101);
   });
 
   it('a non-crafted eligible item still gains Enchanting skill when disenchanted', () => {

--- a/tests/professions_enchant_salvage_arc.test.ts
+++ b/tests/professions_enchant_salvage_arc.test.ts
@@ -26,6 +26,7 @@ vi.mock('../server/db', () => ({
 
 import { type ClientSession, GameServer } from '../server/game';
 import { ClientWorld } from '../src/net/online';
+import { MARKET_MAX_LISTINGS } from '../src/sim/market';
 import { type PlayerMeta, Sim } from '../src/sim/sim';
 import * as tradeMod from '../src/sim/social/trade';
 import type { Entity, InvSlot, PlayerClass, SimEvent } from '../src/sim/types';
@@ -490,6 +491,76 @@ describe('offline Sim end-to-end (IWorld surface)', () => {
     // No copper minted or lost by the split: the two rows' prices sum to the
     // exact ask the seller named for the whole batch.
     expect((plain?.price ?? 0) + (crafted?.price ?? 0)).toBe(101);
+  });
+
+  // Review follow-up on #2605: the provenance split must not reopen the two
+  // per-seller invariants marketList already enforced for a single-bucket
+  // listing. A dual-provenance stack turns one sell request into two rows,
+  // so both gates must account for the split BEFORE anything leaves the bag.
+  it('refuses a dual-provenance sell that would push the seller over MARKET_MAX_LISTINGS', () => {
+    const sim = new Sim({
+      seed: 20260735,
+      playerClass: 'warrior',
+      autoEquip: false,
+      noPlayer: true,
+    });
+    const seller = sim.addPlayer('warrior', 'Seller');
+    moveToMerchant(sim, seller);
+    const meta = metaFor(sim, seller);
+    const BOUNDSTONE_HELM = 'boundstone_helm';
+    const BOUNDSTONE_HELM_RECIPE = 'recipe_ironbound_warplate_helm';
+    meta.inventory.push({ itemId: BOUNDSTONE_HELM, count: 1 });
+    meta.inventory.push({
+      itemId: BOUNDSTONE_HELM,
+      count: 1,
+      craftedRecipeId: BOUNDSTONE_HELM_RECIPE,
+    });
+    // Fill the seller up to one below the cap with unrelated single-row listings.
+    for (let i = 0; i < MARKET_MAX_LISTINGS - 1; i++) {
+      meta.inventory.push({ itemId: COMMON_WEAPON, count: 1 });
+      sim.marketList(COMMON_WEAPON, 1, 10, seller);
+    }
+    const mineBefore = sim.marketListings.filter((l) => l.sellerKey === String(seller)).length;
+    expect(mineBefore).toBe(MARKET_MAX_LISTINGS - 1);
+
+    // The dual-provenance sell would add 2 rows and land at cap + 1: refused,
+    // and neither item leaves the seller's bag.
+    sim.marketList(BOUNDSTONE_HELM, 2, 101, seller);
+    expect(sim.countItem(BOUNDSTONE_HELM, seller)).toBe(2);
+    expect(sim.marketListings.filter((l) => l.itemId === BOUNDSTONE_HELM && !l.house)).toHaveLength(
+      0,
+    );
+    expect(sim.marketListings.filter((l) => l.sellerKey === String(seller)).length).toBe(
+      mineBefore,
+    );
+  });
+
+  it('refuses a dual-provenance sell whose ask cannot give every bucket at least 1 copper', () => {
+    const sim = new Sim({
+      seed: 20260736,
+      playerClass: 'warrior',
+      autoEquip: false,
+      noPlayer: true,
+    });
+    const seller = sim.addPlayer('warrior', 'Seller');
+    moveToMerchant(sim, seller);
+    const meta = metaFor(sim, seller);
+    const BOUNDSTONE_HELM = 'boundstone_helm';
+    const BOUNDSTONE_HELM_RECIPE = 'recipe_ironbound_warplate_helm';
+    meta.inventory.push({ itemId: BOUNDSTONE_HELM, count: 1 });
+    meta.inventory.push({
+      itemId: BOUNDSTONE_HELM,
+      count: 1,
+      craftedRecipeId: BOUNDSTONE_HELM_RECIPE,
+    });
+
+    // ask=1 for a 2-bucket split cannot give both rows >= MARKET_MIN_PRICE:
+    // refused rather than pricing one row at 0 copper.
+    sim.marketList(BOUNDSTONE_HELM, 2, 1, seller);
+    expect(sim.countItem(BOUNDSTONE_HELM, seller)).toBe(2);
+    expect(sim.marketListings.filter((l) => l.itemId === BOUNDSTONE_HELM && !l.house)).toHaveLength(
+      0,
+    );
   });
 
   it('a non-crafted eligible item still gains Enchanting skill when disenchanted', () => {

--- a/tests/trade.test.ts
+++ b/tests/trade.test.ts
@@ -228,9 +228,16 @@ describe('trade module (direct, no Sim)', () => {
           if (inv[i].itemId === itemId && !inv[i].instance && inv[i].count <= 0) inv.splice(i, 1);
         }
       },
-      addItem: (itemId: string, count: number, pid?: number) => {
+      addItem: (
+        itemId: string,
+        count: number,
+        pid?: number,
+        opts?: { craftedRecipeId?: string },
+      ) => {
         const inv = players.get(pid!).inventory;
-        inv.push({ itemId, count });
+        const slot: any = { itemId, count };
+        if (opts?.craftedRecipeId !== undefined) slot.craftedRecipeId = opts.craftedRecipeId;
+        inv.push(slot);
       },
       // Merge-aware like the real Sim.addItemInstance (identical-payload
       // stacking): byte-equal mergeable payloads share a stack up
@@ -314,6 +321,37 @@ describe('trade module (direct, no Sim)', () => {
     tradeMod.tradeConfirm(ctx, 2);
 
     // Trade must be rejected, not silently overflow the receiver to 17 slots.
+    expect(players.get(2).inventory).toHaveLength(16);
+    expect(players.get(1).inventory).toHaveLength(1);
+    expect(events.some((e) => e.type === 'error' && /not enough bag space/.test(e.text))).toBe(
+      true,
+    );
+  });
+
+  // #2605 review (Rubsey/OSSBrain): fitsAfterSwap must bucket the plain
+  // (fungible) receive by craftedRecipeId, the same way grantOffer grants it,
+  // or the capacity simulation can see room in an existing marker-free stack
+  // that the real grant (addStacked, keyed on the marker) cannot merge into,
+  // underpredicting the receiver's slot usage and overflowing their bags.
+  it('rejects a trade that would push the receiver over bag capacity via a crafted-provenance plain grant', () => {
+    const receiverInv = [
+      { itemId: 'wolf_fang', count: 1 }, // marker-free plain stack (room to stack under a naive fit)
+      ...Array.from({ length: 15 }, (_, i) => ({ itemId: `filler_${i}`, count: 1 })),
+    ];
+    const { ctx, players, events } = makeInstancedTradeCtx(
+      [{ itemId: 'wolf_fang', count: 1, craftedRecipeId: 'recipe_wolf_fang' }],
+      receiverInv,
+    );
+    expect(players.get(2).inventory).toHaveLength(16);
+
+    tradeMod.tradeRequest(ctx, 2, 1);
+    tradeMod.tradeAccept(ctx, 2);
+    tradeMod.tradeSetOffer(ctx, [{ itemId: 'wolf_fang', count: 1 }], 0, 1);
+    tradeMod.tradeConfirm(ctx, 1);
+    tradeMod.tradeConfirm(ctx, 2);
+
+    // Trade must be rejected, not silently overflow the receiver to 17 slots
+    // by assuming the crafted-marker grant merges into the marker-free stack.
     expect(players.get(2).inventory).toHaveLength(16);
     expect(players.get(1).inventory).toHaveLength(1);
     expect(events.some((e) => e.type === 'error' && /not enough bag space/.test(e.text))).toBe(

--- a/tests/trade.test.ts
+++ b/tests/trade.test.ts
@@ -17,16 +17,25 @@ function makeTradeCtx() {
   const tradeInvites = new Map<number, { fromPid: number; expires: number }>();
   const partyInvites = new Map<number, { fromPid: number; expires: number }>();
   const duelInvites = new Map<number, { fromPid: number; expires: number }>();
-  const bags = new Map<number, Map<string, number>>();
   const events: any[] = [];
   let time = 0;
+  // A thin Map-like view over the player's real `inventory` array (the
+  // PlayerMeta shape), not a second, independent store: trade.ts's removal
+  // path (removeVendorSellUnits, BUG #9) walks meta.inventory directly to
+  // track each removed unit's craftedRecipeId marker, so this fake ctx has
+  // to keep the SAME one source of truth a real Sim does, or the walk finds
+  // nothing to remove. One plain (non-instanced) slot per itemId is enough
+  // for this fake's documented simplification: every held copy is fungible.
   const bag = (pid: number) => {
-    let b = bags.get(pid);
-    if (!b) {
-      b = new Map();
-      bags.set(pid, b);
-    }
-    return b;
+    const inv: { itemId: string; count: number }[] = players.get(pid)!.inventory;
+    return {
+      get: (itemId: string): number | undefined => inv.find((s) => s.itemId === itemId)?.count,
+      set: (itemId: string, count: number): void => {
+        const slot = inv.find((s) => s.itemId === itemId);
+        if (slot) slot.count = count;
+        else inv.push({ itemId, count });
+      },
+    };
   };
   const ctx = {
     get time() {


### PR DESCRIPTION
## Summary

Player trade and the World Market both re-granted a crafted item's plain copy with no `craftedRecipeId` marker, so trading an item or selling it on the World Market laundered its crafting provenance. The recipient's copy was indistinguishable from a never-crafted one, and disenchanting it granted full Enchanting skill, bypassing the already-shipped equip/buyback anti-farming gate (`professions/enchanting.ts` `isCraftedDisenchantVictim`).

Root cause: `PendingGrant` in `src/sim/social/trade.ts` had no `craftedRecipeId` field, and `removeOffer`/`grantOffer` moved items through `removePreferFungible`, which only ever reported the leftover *instanced* remainder and bulk-decremented the plain count with no record of which stack (and therefore which marker) it came from. `MarketListing` in `src/sim/market.ts` had the same gap: `marketList` escrowed via a blind `removeFungibleItem` bulk decrement and `marketBuy`/`marketCancel`/`marketCollect` re-granted with `ctx.addItem(itemId, count, pid)` and no marker at all.

Fix: both paths now reuse `items.ts`'s `removeVendorSellUnits`/`VendorRemovedUnit` per-unit removal (already used by vendor sell/buyback, which never had this bug) instead of the old bulk fungible decrement, so every removed unit's `craftedRecipeId` is known and carried through the re-grant.
- `trade.ts`: `PendingGrant` now carries the removed `VendorRemovedUnit[]`; `grantOffer` buckets the plain units by `craftedRecipeId` before re-granting (so a marker-free stack and a crafted stack of the same item id never merge into one washed stack) and passes each instanced unit's marker through `addItemInstance`.
- `market.ts`: `MarketListing` gained an optional `craftedRecipeId` field, threaded through `marketList`/`marketBuy`/`marketCancel`/`marketCollect`, the expired-listing and soulbound-reclaim return paths, and `serializeMarket`/`loadMarket` persistence. Some content ships the same item id both crafted and drop-sourced (`recipes.ts`: `boundstone_helm`, `gravewyrm_gauntlets`), so a single sell request can legitimately span two provenance buckets; `marketList` now groups the removed units by marker and creates one listing row per bucket, splitting the requested price proportionally (remainder on the last bucket) so the total across every row it creates always sums to the exact ask, never minting or losing copper.

`items.ts`'s `VendorRemovedUnit` interface and `removeVendorSellUnits` function are now exported for this reuse; `removeVendorSellUnits`'s per-unit walk order (plain slots first, then instanced, both highest-index-first) is identical to the old `removeFungibleItem`/`removeItem` order it replaces, so this is a behavior-preserving swap for every existing case, confirmed by the full parity suite staying green.

## Related issues

N/A (found by fresh code audit, no existing issue).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands run:
  - `npx tsc --noEmit` (clean)
  - `npx vitest run tests/professions_enchant_salvage_arc.test.ts` (12 passed, including 3 new regression tests: crafted item survives a player trade before disenchant, crafted item survives a World Market sale before disenchant, and a sell request spanning two provenance buckets splits into two correctly-priced listings)
  - Confirmed the 3 new tests fail for the right reason against the pre-fix code (`git apply -R` on the source diff, tests failed with "expected -1 to be greater than or equal to 0" / "expected undefined to be 'recipe_eastbrook_chain_vest'" / "expected length 2 but got 1"), then reapplied the fix and confirmed all pass again
  - `npx vitest run tests/trade.test.ts tests/market.test.ts tests/professions_market.test.ts tests/professions_commissions.test.ts tests/professions_bind_on_trade_online.test.ts tests/professions_bind_on_trade_surfaces.test.ts tests/professions_destroy_trade_races.test.ts tests/professions_typed_reagents.test.ts tests/professions_enchant_salvage_edges.test.ts tests/heroic_soulbound.test.ts tests/save_character_and_market.test.ts tests/market_db.test.ts tests/market_filler_listings.test.ts tests/market_filters.test.ts tests/market_listing_ids.test.ts tests/market_query_client.test.ts tests/market_query_game.test.ts tests/market_view.test.ts tests/market_window.test.ts tests/market_collect_indicator.test.ts tests/trade_view.test.ts` (22 files, 323 passed)
  - `npx vitest run tests/architecture.test.ts tests/world_api_parity.test.ts tests/localization_fixes.test.ts` (all green; ran `npm run i18n:gen` first since this change adds no player-visible strings and the S3 guard needs the generated status registry)
  - `npx vitest run tests/parity` (186 passed, 1 skipped; the golden-trace/rng-draw-order parity gate stays green, confirming the removal order is unchanged)
  - Full suite: `npx vitest run --max-workers=4` (1646 files, 21470 passed, 51 skipped, 0 failed)
  - `npx @biomejs/biome check --write` on every changed file (no errors, no format diffs; pre-existing `noExplicitAny`/`noNonNullAssertion` warnings in `tests/trade.test.ts`'s decoupled fake ctx are untouched style, not introduced by this change)
- Manual steps: none (sim/server logic, not UI).

Also fixed along the way: `tests/trade.test.ts`'s `makeTradeCtx()` fake previously stored bag contents in a second `Map` independent of `PlayerMeta.inventory`. Since the fix makes `removeVendorSellUnits` walk `meta.inventory` directly (the same shape a real `Sim` uses), the fake's `bag()` helper now backs onto `meta.inventory` too, so the "trade logic is decoupled" fake stays a faithful stand-in without changing any of its 16 tests' call sites.

## Screenshots / recordings

N/A. This is sim/server logic with no player-visible surface; not a visual change.

---

## Checklist

### Quality

- [x] **The full gate passes.** Ran the targeted verification above (`tsc`, the affected test suites, the full test suite, biome on changed files); did not run the full `npm run gate` release-tier build/malware-scan pipeline in this narrow pass, but every check it would run against these files passed. I added decisive regression tests for the exact laundering path (trade and market) plus the dual-provenance edge case.
- [ ] Tested on desktop and mobile. N/A, no UI surface.
- [ ] Accessible. N/A, no UI surface.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled anywhere.
- [x] I didn't hand-edit any generated file.

```mermaid
flowchart TB
    subgraph before["Before: provenance dropped"]
        C1["craftItem: plain grant carries\naddItem(..., { craftedRecipeId })"] --> S1["InvSlot { itemId, count, craftedRecipeId }"]
        S1 --> T1["trade.ts removeOffer:\nremovePreferFungible bulk-decrements\nplain count, marker NOT captured"]
        S1 --> M1["market.ts marketList:\nremoveFungibleItem bulk-decrements,\nMarketListing has no craftedRecipeId field"]
        T1 --> G1["grantOffer: addItem(itemId, plainCount)\nno marker passed"]
        M1 --> B1["marketBuy: addItem(itemId, count)\nno marker passed"]
        G1 --> R1["Recipient's InvSlot has NO craftedRecipeId"]
        B1 --> R1
        R1 --> D1["disenchantItem: isCraftedDisenchantVictim\nreturns false -> full Enchanting skill granted"]
    end

    subgraph after["After: provenance threaded"]
        C2["craftItem: same plain grant"] --> S2["InvSlot { itemId, count, craftedRecipeId }"]
        S2 --> T2["trade.ts removeOffer:\nremoveVendorSellUnits walks per-unit,\nreports craftedRecipeId for each unit"]
        S2 --> M2["market.ts marketList:\nremoveVendorSellUnits per-unit walk,\nbucketed onto MarketListing.craftedRecipeId"]
        T2 --> G2["grantOffer: addItem bucketed by\ncraftedRecipeId, marker preserved"]
        M2 --> B2["marketBuy/cancel/collect:\naddItem(itemId, count, { craftedRecipeId })"]
        G2 --> R2["Recipient's InvSlot KEEPS craftedRecipeId"]
        B2 --> R2
        R2 --> D2["disenchantItem: isCraftedDisenchantVictim\nreturns true -> no Enchanting skill, gate holds"]
    end
```
