### PR TITLE
fix(social): make guild leader transfer atomic

### DIFF
--- a/server/social.ts
+++ b/server/social.ts
@@ -134,6 +134,15 @@ export interface SocialDb {
   ): Promise<'ok' | 'full' | 'already_member' | 'no_guild'>;
   removeGuildMember(charId: number): Promise<void>;
   setGuildRank(charId: number, rank: GuildRank): Promise<void>;
+  // hand off the Guild Master title atomically: locks the guild row, re-checks
+  // that fromCharId is still the leader and toCharId is still a member of the
+  // SAME guild, then promotes/demotes both rows in one transaction, so two
+  // racing transfers can never both succeed and leave two Guild Masters.
+  transferGuildLeader(
+    guildId: number,
+    fromCharId: number,
+    toCharId: number,
+  ): Promise<'ok' | 'not_leader' | 'not_member' | 'no_guild'>;
   guildMembers(
     guildId: number,
   ): Promise<
@@ -845,8 +854,24 @@ export class SocialService {
       this.err(actor.characterId, `${target.name} is not in your guild.`);
       return;
     }
-    await this.db.setGuildRank(target.id, 'leader');
-    await this.db.setGuildRank(actor.characterId, 'officer');
+    const result = await this.db.transferGuildLeader(
+      membership.guildId,
+      actor.characterId,
+      target.id,
+    );
+    if (result === 'no_guild') {
+      this.err(actor.characterId, 'That guild no longer exists.');
+      return;
+    }
+    if (result === 'not_leader') {
+      // lost a race with another transfer between the checks above and here
+      this.err(actor.characterId, 'Only the Guild Master may promote a new leader.');
+      return;
+    }
+    if (result === 'not_member') {
+      this.err(actor.characterId, `${target.name} is not in your guild.`);
+      return;
+    }
     await this.broadcastGuild(membership.guildId, [
       {
         type: 'log',

--- a/server/social_db.ts
+++ b/server/social_db.ts
@@ -385,6 +385,54 @@ export class PgSocialDb implements SocialDb {
     ]);
   }
 
+  async transferGuildLeader(
+    guildId: number,
+    fromCharId: number,
+    toCharId: number,
+  ): Promise<'ok' | 'not_leader' | 'not_member' | 'no_guild'> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      // lock the guild row so a racing transfer serializes behind this one:
+      // without this, two /gleader calls can both read "actor is still
+      // leader" before either write lands, and both promotions go through.
+      const g = await client.query('SELECT id FROM guilds WHERE id = $1 FOR UPDATE', [guildId]);
+      if (g.rowCount === 0) {
+        await client.query('ROLLBACK');
+        return 'no_guild';
+      }
+      const rows = await client.query(
+        'SELECT character_id, rank FROM guild_members WHERE guild_id = $1 AND character_id IN ($2, $3)',
+        [guildId, fromCharId, toCharId],
+      );
+      const fromRow = rows.rows.find((r) => r.character_id === fromCharId);
+      const toRow = rows.rows.find((r) => r.character_id === toCharId);
+      // re-check under the lock: the actor may have lost leadership (or the
+      // target may have left) to a transfer that committed first.
+      if (!fromRow || fromRow.rank !== 'leader') {
+        await client.query('ROLLBACK');
+        return 'not_leader';
+      }
+      if (!toRow) {
+        await client.query('ROLLBACK');
+        return 'not_member';
+      }
+      await client.query("UPDATE guild_members SET rank = 'leader' WHERE character_id = $1", [
+        toCharId,
+      ]);
+      await client.query("UPDATE guild_members SET rank = 'officer' WHERE character_id = $1", [
+        fromCharId,
+      ]);
+      await client.query('COMMIT');
+      return 'ok';
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
   async setGuildMotd(guildId: number, motd: string, setBy: string): Promise<void> {
     await this.pool.query('UPDATE guilds SET motd = $2, motd_set_by = $3 WHERE id = $1', [
       guildId,

--- a/tests/social_system.test.ts
+++ b/tests/social_system.test.ts
@@ -139,6 +139,20 @@ class FakeDb implements SocialDb {
     const m = this.members.get(c);
     if (m) m.rank = rank;
   }
+  async transferGuildLeader(
+    guildId: number,
+    fromCharId: number,
+    toCharId: number,
+  ): Promise<'ok' | 'not_leader' | 'not_member' | 'no_guild'> {
+    if (!this.guilds.has(guildId)) return 'no_guild';
+    const fromM = this.members.get(fromCharId);
+    if (!fromM || fromM.guildId !== guildId || fromM.rank !== 'leader') return 'not_leader';
+    const toM = this.members.get(toCharId);
+    if (!toM || toM.guildId !== guildId) return 'not_member';
+    toM.rank = 'leader';
+    fromM.rank = 'officer';
+    return 'ok';
+  }
   private lastLogins = new Map<number, string>();
   setLastLogin(id: number, iso: string): void {
     this.lastLogins.set(id, iso);
@@ -1254,6 +1268,30 @@ describe('guild atomicity (#149)', () => {
     await h.svc.guildAccept(h.actor(2));
     expect(h.tx.errorsFor(2).join()).toMatch(/no longer exists/i);
     expect((await h.svc.snapshot(2)).guild).toBeNull();
+  });
+
+  it('two racing /gleader transfers to different targets never both succeed', async () => {
+    // Both calls read "actor is still Guild Master" before either write
+    // lands. The non-atomic flow (two independent setGuildRank writes with
+    // no lock or re-check between them) let both promotions through, so the
+    // guild ended up with two members simultaneously ranked leader.
+    h.add(3, 'Cee');
+    h.tx.setOnline(3);
+    await h.svc.guildCreate(h.actor(1), 'Iron Vanguard');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    await h.svc.guildAccept(h.actor(2));
+    await h.svc.guildInvite(h.actor(1), 'Cee');
+    await h.svc.guildAccept(h.actor(3));
+    h.tx.clear();
+
+    await Promise.all([
+      h.svc.guildTransferLeader(h.actor(1), 'Bet'),
+      h.svc.guildTransferLeader(h.actor(1), 'Cee'),
+    ]);
+
+    const guildId = (await h.db.guildMembership(1))!.guildId;
+    const leaders = (await h.db.guildMembers(guildId)).filter((m) => m.rank === 'leader');
+    expect(leaders).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Summary

`guildTransferLeader` (`/gleader`) promoted the target and demoted the actor as two independent, non-transactional `setGuildRank` writes with no lock or re-check between them. This is the same race class that `createGuildWithLeader` and `addGuildMemberAtomic` already guard against elsewhere in this file, but the leader-transfer path had no such protection.

Concretely: two concurrent `/gleader` calls from the same Guild Master (promoting two different members) can both read "actor is still leader" before either write lands, so both promotions go through. The guild ends up with two members simultaneously ranked leader, and the actor's own demote only fires once, so there is no clean single owner afterward.

**Fix:** add an atomic `SocialDb.transferGuildLeader(guildId, fromCharId, toCharId)` that mirrors `addGuildMemberAtomic`'s shape: `BEGIN`, `SELECT ... FOR UPDATE` on the guild row to serialize racing transfers, re-check under the lock that `fromCharId` is still `'leader'` and `toCharId` is still a member of the same guild, then update both rows and `COMMIT`. `guildTransferLeader` in `server/social.ts` now calls this single atomic method instead of two independent `setGuildRank` calls, and surfaces the lost-race outcomes (`not_leader`, `not_member`, `no_guild`) using the same English error text the code already used for the equivalent up-front checks (no new i18n keys needed).

## Related issues

N/A (found via code audit, no existing issue).

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/social_system.test.ts -t "two racing /gleader"` confirmed the new regression test fails against the pre-fix code (two members both ended up ranked `leader`), then passes after the fix.
  - `npx vitest run tests/social_system.test.ts` (98 tests passed, including the existing `guild atomicity (#149)` block and the happy-path `transfers leadership explicitly` test).
  - `npx tsc --noEmit` (clean).
  - `npx vitest run tests/architecture.test.ts` (33 passed, unaffected).
  - `npm run i18n:gen` then `npx vitest run tests/localization_fixes.test.ts` (39 passed, 3 skipped; the S3 guard is satisfied because the new error branches reuse existing exact English strings already present in `src/ui/server_i18n.ts`, so no catalog change was needed).
  - `npx @biomejs/biome check server/social.ts server/social_db.ts tests/social_system.test.ts` (exit 0; only pre-existing `noNonNullAssertion` style warnings shared with the rest of the file, no errors, no format diff).
- Manual steps: none (server/sim-only logic change, not visually observable).

## Screenshots / recordings

N/A. This change is server/test-only logic with no visual surface.

---

## Checklist

### Quality

- [x] **The full gate passes.** Ran the targeted subset above (`tsc`, the changed test file, `architecture.test.ts`, `localization_fixes.test.ts`, biome on changed files) rather than the full `npm run gate`, since this worktree runs alongside several sibling agents on the same machine; the change is scoped to `server/social.ts`, `server/social_db.ts`, and `tests/social_system.test.ts`.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, server-only logic.
- ~~Accessible.~~ N/A, no UI change.

### Localization (i18n)

- [x] **New player-visible strings follow the contributor policy.** No new strings: the race-lost error branches reuse existing exact English text already present (`'That guild no longer exists.'`, `'Only the Guild Master may promote a new leader.'`, `` `${target.name} is not in your guild.` ``), all already matched by `src/ui/server_i18n.ts`.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters. N/A, no such values in this change.
- [x] Player-facing text emitted from `server/` is re-localized at the client boundary; `npx vitest run tests/localization_fixes.test.ts` passes.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled anywhere.
- [x] I didn't hand-edit any generated file.
