### PR TITLE
fix(sim): correct misleading mail expiry comment on the bags-full branch

### DIFF
--- a/src/sim/mail/post_office.ts
+++ b/src/sim/mail/post_office.ts
@@ -476,8 +476,12 @@ export class PostOffice {
       m.read = true;
     }
     if (kept.length > 0) {
-      // Attachments remain: the expiry clock stays paused (Infinity) and the
-      // player is told to make room, exactly as the Merchant's collect does.
+      // Attachments remain: expiresAt is untouched here, so the letter's
+      // existing clock keeps running. That is Infinity for system/npc mail
+      // (their by-construction exemption, see the book() comment below), but a
+      // player parcel's real MAIL_ATTACHMENT_EXPIRY_SECONDS deadline still
+      // ticks and can still trip returnToSender. The player is told to make
+      // room, exactly as the Merchant's collect does.
       this.ctx.error(meta.entityId, 'Your bags are full.');
       return;
     }

--- a/tests/mail_expiry.test.ts
+++ b/tests/mail_expiry.test.ts
@@ -366,7 +366,7 @@ describe('a full sender mailbox', () => {
 });
 
 describe('a full-bags player parcel keeps its real deadline', () => {
-  it('does not pause the attachment clock: an old sentAt is still eligible for return-to-sender', () => {
+  it('does not pause the attachment clock: an elapsed expiresAt is still eligible for return-to-sender', () => {
     // Regression pin: a comment on the mailTake bags-full branch used to claim
     // the expiry clock stays paused (Infinity) whenever a letter is kept for
     // lack of room, but that is only true for system/npc mail. A player
@@ -395,8 +395,8 @@ describe('a full-bags player parcel keeps its real deadline', () => {
     // branch, unlike system/npc mail.
     expect(Number.isFinite(raw.expiresAt)).toBe(true);
 
-    // An old sentAt (the real deadline already elapsed) is still swept into
-    // the return-to-sender flight, exactly as any other unclaimed parcel.
+    // An elapsed expiresAt (the real deadline already reached) is still swept
+    // into the return-to-sender flight, exactly as any other unclaimed parcel.
     raw.expiresAt = sim.time;
     tickFor(sim, 2);
     expect(raw.returned).toBe(true);

--- a/tests/mail_expiry.test.ts
+++ b/tests/mail_expiry.test.ts
@@ -365,6 +365,46 @@ describe('a full sender mailbox', () => {
   });
 });
 
+describe('a full-bags player parcel keeps its real deadline', () => {
+  it('does not pause the attachment clock: an old sentAt is still eligible for return-to-sender', () => {
+    // Regression pin: a comment on the mailTake bags-full branch used to claim
+    // the expiry clock stays paused (Infinity) whenever a letter is kept for
+    // lack of room, but that is only true for system/npc mail. A player
+    // parcel's real MAIL_ATTACHMENT_EXPIRY_SECONDS deadline is untouched by
+    // that branch and keeps ticking, so it can still fly home to its sender.
+    const { sim, bob, raw } = setupParcel();
+    tickFor(sim, MAIL_DELIVERY_SECONDS + 2);
+    moveToMailbox(sim, bob);
+
+    // Fill Bob's bags so the attached stack cannot fit.
+    const bobMeta = sim.meta(bob);
+    if (!bobMeta) throw new Error('no meta');
+    bobMeta.bags = [null, null, null, null];
+    bobMeta.inventory = Array.from({ length: 16 }, () => ({ itemId: 'roasted_boar', count: 20 }));
+
+    const gift = sim.mailInfoFor(bob)?.messages.find((m) => m.subject === 'Parcel');
+    if (!gift) throw new Error('parcel not delivered');
+    sim.drainEvents();
+    sim.mailTake(gift.id, bob);
+    const events = sim.drainEvents();
+    expect(events.some((e) => e.type === 'error' && e.text === 'Your bags are full.')).toBe(true);
+    // The coin collected but the stack stayed attached, kept on the letter.
+    expect(raw.items).toEqual([{ itemId: 'roasted_boar', count: 2 }]);
+
+    // NOT Infinity: a player parcel's clock is never paused by the bags-full
+    // branch, unlike system/npc mail.
+    expect(Number.isFinite(raw.expiresAt)).toBe(true);
+
+    // An old sentAt (the real deadline already elapsed) is still swept into
+    // the return-to-sender flight, exactly as any other unclaimed parcel.
+    raw.expiresAt = sim.time;
+    tickFor(sim, 2);
+    expect(raw.returned).toBe(true);
+    expect(raw.items).toEqual([{ itemId: 'roasted_boar', count: 2 }]);
+    expect(raw.copper).toBe(0); // already collected before the bags-full branch
+  });
+});
+
 describe('taking a returned letter', () => {
   it('hands the attachments back and starts the standard emptied clock', () => {
     const { sim, alice, aliceMeta, raw } = setupParcel();


### PR DESCRIPTION
## Summary

`PostOffice.mailTake` has a branch that runs when a kept attachment stack
does not fit in the recipient's bags (`kept.length > 0`). The comment on
that branch claimed:

> Attachments remain: the expiry clock stays paused (Infinity) and the
> player is told to make room, exactly as the Merchant's collect does.

That is only true for system and npc mail. `expiresAt` is simply left
untouched by this branch, and for a **player** parcel that field holds a
real, ticking `MAIL_ATTACHMENT_EXPIRY_SECONDS` (30 sim-day) deadline set at
send/return time, not `Infinity`. An unclaimed player parcel kept because
the recipient's bags are full is therefore still eligible to be swept into
`returnToSender` once that deadline elapses, exactly like any other
unclaimed parcel. The accurate explanation for the `Infinity` exemption is
already present a few lines below, in the `book()` helper's comment
(`"System and npc parcels get NO clock at all while loaded..."`).

This is a doc-only issue: there is no behavior bug, but a maintainer
reading only the bags-full branch's comment could ship a real bug (for
example, skipping the return-to-sender sweep for a kept player parcel) by
trusting the stale claim.

### Fix

- Corrected the comment on the `kept.length > 0` branch in
  `src/sim/mail/post_office.ts` to state that `expiresAt` is left as-is,
  that this means `Infinity` for system/npc mail but the real, ticking
  attachment deadline for player mail, and to point at the `book()`
  comment for the by-construction exemption. No functional code change.
- Added a regression test in `tests/mail_expiry.test.ts` that fills a
  recipient's bags, takes a delivered player parcel (leaving the item
  stack attached because it doesn't fit), asserts `expiresAt` is finite
  (not `Infinity`), then forces the deadline to have elapsed and confirms
  the parcel is still returned to its sender. This pins the real behavior
  the comment used to misdescribe.

## Related issues

N/A. Found during a fresh code audit; no existing issue.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

(Filed as "Bug fix" per the task: a misleading comment that could cause a
future real bug. The code itself needed no behavior change.)

## How was this tested?

- Commands:
  - `npx vitest run tests/mail_expiry.test.ts` (12 tests passed, including
    the new regression test, both before and after the comment edit, since
    the underlying behavior was already correct)
  - `npx vitest run tests/mail_expiry.test.ts tests/mail.test.ts tests/mail_block.test.ts`
    (33 tests passed)
  - `npx vitest run tests/architecture.test.ts` (33 tests passed; confirms
    `src/sim/` purity invariants still hold)
  - `npx tsc --noEmit` (no errors)
  - `npx @biomejs/biome check --write src/sim/mail/post_office.ts tests/mail_expiry.test.ts`
    (no issues, no fixes needed)
- Manual steps: none (sim/server-only logic, not visually observable).

```mermaid
flowchart TD
    A[mailTake: recipient collects a letter] --> B{Does the attached\nstack fit in bags?}
    B -->|Yes| C[addItem; letter emptied;\nstarts the 14-day emptied clock]
    B -->|No, kept.length > 0| D[stack stays attached to the letter\nexpiresAt left UNTOUCHED]
    D --> E{Letter kind?}
    E -->|system / npc| F[expiresAt was Infinity:\nby-construction exemption, see book]
    E -->|player| G[expiresAt is the real ticking\nMAIL_ATTACHMENT_EXPIRY_SECONDS deadline]
    G --> H[deadline elapses ->\nreturnToSender still fires]
    F -.->|old comment wrongly implied\nthis path too| H
    style F fill:#cfe8ff
    style G fill:#ffe3b3
    style H fill:#c9f7c9
```

## Screenshots / recordings

N/A. This change is doc-only sim logic (a code comment plus a test),
not visually observable.

---

## Checklist

### Quality

- [x] **The full gate passes.** Ran the targeted subset above (tsc,
      biome on changed files, the mail and architecture test suites) rather
      than the full `npm run gate`, per the narrow-verification instruction
      for this task (other agents were running concurrently on the same
      machine). I added a decisive regression test for the behavior the
      stale comment misdescribed.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A: sim-only logic change, no UI.
- ~~Accessible.~~ N/A: no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS`
      is not enabled in any production path.
- [x] I didn't hand-edit generated files.
