### PR TITLE
fix(ui): localize the trade-accept-race deny error string

### DIFF
--- a/scripts/i18n_blocked_seed.mjs
+++ b/scripts/i18n_blocked_seed.mjs
@@ -322,7 +322,6 @@ export const V07_SLASH = [
   'Quest log (5): Aki.',
   'Spellbook (5): Aki.',
   'Target: Aki (level 5 Aki) — Aki.',
-  'That player is already trading.',
   'Threat is only tracked on enemies; Aki is not one.',
   'Threat on Aki (5): Aki.',
   'Time played this session: Aki.',

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -11833,6 +11833,7 @@ export class Hud {
       'Finish your trade before queueing.': 'hud.errors.arenaQueueTrading',
       'You cannot queue from inside an instance.': 'hud.errors.arenaQueueInstance',
       'A trade is already in progress.': 'hud.errors.tradeInProgress',
+      'That player is already trading.': 'hud.errors.tradeAlreadyTrading',
       'Target is too far away to trade.': 'hud.errors.tradeTooFar',
       'The trade request has expired.': 'hud.errors.tradeExpired',
       'Trade failed: items or money no longer available.': 'hud.errors.tradeFailed',

--- a/src/ui/i18n.catalog/hud.ts
+++ b/src/ui/i18n.catalog/hud.ts
@@ -380,6 +380,7 @@ const hudStringsEn = {
       arenaQueueTrading: 'Finish your trade before queueing.',
       arenaQueueInstance: 'You cannot queue from inside an instance.',
       tradeInProgress: 'A trade is already in progress.',
+      tradeAlreadyTrading: 'That player is already trading.',
       tradeTooFar: 'Target is too far away to trade.',
       tradeExpired: 'The trade request has expired.',
       tradeFailed: 'Trade failed: items or money no longer available.',

--- a/src/ui/i18n.catalog/translation_keys.generated.ts
+++ b/src/ui/i18n.catalog/translation_keys.generated.ts
@@ -5623,6 +5623,7 @@ export type TranslationKeyFlat =
   | 'hud.errors.targetMustDodge'
   | 'hud.errors.targetTooFar'
   | 'hud.errors.tooClose'
+  | 'hud.errors.tradeAlreadyTrading'
   | 'hud.errors.tradeBound'
   | 'hud.errors.tradeExpired'
   | 'hud.errors.tradeFailed'

--- a/src/ui/i18n.locales/ja_JP.ts
+++ b/src/ui/i18n.locales/ja_JP.ts
@@ -1998,6 +1998,7 @@ export const ja_JP: Partial<Record<TranslationKey, string>> = {
   'hud.errors.arenaQueueTrading': '取引を終えてからキューに入ってください。',
   'hud.errors.arenaQueueInstance': 'インスタンス内からキューには入れません。',
   'hud.errors.tradeInProgress': 'すでに取引が進行中です。',
+  'hud.errors.tradeAlreadyTrading': 'そのプレイヤーはすでに取引中です。',
   'hud.errors.tradeTooFar': '対象が遠すぎて取引できません。',
   'hud.errors.tradeExpired': '取引リクエストは期限切れです。',
   'hud.errors.tradeFailed': '取引失敗: アイテムまたは所持金が利用できません。',

--- a/src/ui/i18n.locales/ko_KR.ts
+++ b/src/ui/i18n.locales/ko_KR.ts
@@ -1983,6 +1983,7 @@ export const ko_KR: Partial<Record<TranslationKey, string>> = {
   'hud.errors.arenaQueueTrading': '거래를 끝낸 뒤 대기열에 들어가세요.',
   'hud.errors.arenaQueueInstance': '인스턴스 안에서는 대기열에 들어갈 수 없습니다.',
   'hud.errors.tradeInProgress': '이미 거래가 진행 중입니다.',
+  'hud.errors.tradeAlreadyTrading': '그 플레이어는 이미 거래 중입니다.',
   'hud.errors.tradeTooFar': '대상이 너무 멀어 거래할 수 없습니다.',
   'hud.errors.tradeExpired': '거래 요청이 만료되었습니다.',
   'hud.errors.tradeFailed': '거래 실패: 아이템이나 돈을 더 이상 사용할 수 없습니다.',

--- a/src/ui/i18n.locales/ru_RU.ts
+++ b/src/ui/i18n.locales/ru_RU.ts
@@ -2020,6 +2020,7 @@ export const ru_RU: Partial<Record<TranslationKey, string>> = {
   'hud.errors.arenaQueueTrading': 'Завершите обмен перед постановкой в очередь.',
   'hud.errors.arenaQueueInstance': 'Нельзя вставать в очередь из подземелья.',
   'hud.errors.tradeInProgress': 'Обмен уже идет.',
+  'hud.errors.tradeAlreadyTrading': 'Этот игрок уже торгует.',
   'hud.errors.tradeTooFar': 'Цель слишком далеко для обмена.',
   'hud.errors.tradeExpired': 'Запрос обмена истек.',
   'hud.errors.tradeFailed': 'Обмен не удался: предметы или деньги больше недоступны.',

--- a/src/ui/i18n.locales/zh_CN.ts
+++ b/src/ui/i18n.locales/zh_CN.ts
@@ -1905,6 +1905,7 @@ export const zh_CN: Partial<Record<TranslationKey, string>> = {
   'hud.errors.arenaQueueTrading': '请先完成交易再加入队列。',
   'hud.errors.arenaQueueInstance': '你不能在副本内加入队列。',
   'hud.errors.tradeInProgress': '已有交易正在进行。',
+  'hud.errors.tradeAlreadyTrading': '该玩家已在交易中。',
   'hud.errors.tradeTooFar': '目标太远，无法交易。',
   'hud.errors.tradeExpired': '交易请求已过期。',
   'hud.errors.tradeFailed': '交易失败：物品或金钱已不可用。',

--- a/src/ui/i18n.locales/zh_TW.ts
+++ b/src/ui/i18n.locales/zh_TW.ts
@@ -1907,6 +1907,7 @@ export const zh_TW: Partial<Record<TranslationKey, string>> = {
   'hud.errors.arenaQueueTrading': '請先完成交易再加入佇列。',
   'hud.errors.arenaQueueInstance': '你不能在副本內加入佇列。',
   'hud.errors.tradeInProgress': '已有交易正在進行。',
+  'hud.errors.tradeAlreadyTrading': '該玩家已在交易中。',
   'hud.errors.tradeTooFar': '目標太遠，無法交易。',
   'hud.errors.tradeExpired': '交易請求已過期。',
   'hud.errors.tradeFailed': '交易失敗：物品或金錢已不可用。',

--- a/src/ui/i18n.resolved.generated/cs_CZ.ts
+++ b/src/ui/i18n.resolved.generated/cs_CZ.ts
@@ -6473,6 +6473,7 @@ export const cs_CZ: EnTranslations = {
       "arenaQueueTrading": "Před zařazením do fronty dokonči obchod.",
       "arenaQueueInstance": "Z instance se nemůžeš zařadit do fronty.",
       "tradeInProgress": "Obchod už probíhá.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Cíl je příliš daleko pro obchod.",
       "tradeExpired": "Žádost o obchod vypršela.",
       "tradeFailed": "Obchod selhal: předměty nebo peníze už nejsou dostupné.",

--- a/src/ui/i18n.resolved.generated/da_DK.ts
+++ b/src/ui/i18n.resolved.generated/da_DK.ts
@@ -6473,6 +6473,7 @@ export const da_DK: EnTranslations = {
       "arenaQueueTrading": "Afslut din handel, før du stiller dig i kø.",
       "arenaQueueInstance": "Du kan ikke stille dig i kø inde fra en instans.",
       "tradeInProgress": "En handel er allerede i gang.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Målet er for langt væk til at handle.",
       "tradeExpired": "Handelsanmodningen er udløbet.",
       "tradeFailed": "Handel mislykkedes: genstande eller penge er ikke længere tilgængelige.",

--- a/src/ui/i18n.resolved.generated/de_DE.ts
+++ b/src/ui/i18n.resolved.generated/de_DE.ts
@@ -6473,6 +6473,7 @@ export const de_DE: EnTranslations = {
       "arenaQueueTrading": "Beendet Euren Handel, bevor Ihr Euch anmeldet.",
       "arenaQueueInstance": "Aus einer Instanz heraus könnt Ihr Euch nicht anmelden.",
       "tradeInProgress": "Es läuft bereits ein Handel.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Das Ziel ist zu weit entfernt zum Handeln.",
       "tradeExpired": "Die Handelsanfrage ist abgelaufen.",
       "tradeFailed": "Handel fehlgeschlagen: Gegenstände oder Geld sind nicht mehr verfügbar.",

--- a/src/ui/i18n.resolved.generated/en.ts
+++ b/src/ui/i18n.resolved.generated/en.ts
@@ -6473,6 +6473,7 @@ export const en: EnTranslations = {
       "arenaQueueTrading": "Finish your trade before queueing.",
       "arenaQueueInstance": "You cannot queue from inside an instance.",
       "tradeInProgress": "A trade is already in progress.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Target is too far away to trade.",
       "tradeExpired": "The trade request has expired.",
       "tradeFailed": "Trade failed: items or money no longer available.",

--- a/src/ui/i18n.resolved.generated/en_CA.ts
+++ b/src/ui/i18n.resolved.generated/en_CA.ts
@@ -6473,6 +6473,7 @@ export const en_CA: EnTranslations = {
       "arenaQueueTrading": "Finish your trade before queueing.",
       "arenaQueueInstance": "You cannot queue from inside an instance.",
       "tradeInProgress": "A trade is already in progress.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Target is too far away to trade.",
       "tradeExpired": "The trade request has expired.",
       "tradeFailed": "Trade failed: items or money no longer available.",

--- a/src/ui/i18n.resolved.generated/en_XA.ts
+++ b/src/ui/i18n.resolved.generated/en_XA.ts
@@ -6473,6 +6473,7 @@ export const en_XA: EnTranslations = {
       "arenaQueueTrading": "[Ƒíñíšĥ ýóúŕ ţŕáðé ƀéƒóŕé ɋúéúéíñĝ.]",
       "arenaQueueInstance": "[Ýóú çáññóţ ɋúéúé ƒŕóɱ íñšíðé áñ íñšţáñçé.]",
       "tradeInProgress": "[Á ţŕáðé íš áļŕéáðý íñ þŕóĝŕéšš.]",
+      "tradeAlreadyTrading": "[Ţĥáţ þļáýéŕ íš áļŕéáðý ţŕáðíñĝ.]",
       "tradeTooFar": "[Ţáŕĝéţ íš ţóó ƒáŕ áŵáý ţó ţŕáðé.]",
       "tradeExpired": "[Ţĥé ţŕáðé ŕéɋúéšţ ĥáš éẋþíŕéð.]",
       "tradeFailed": "[Ţŕáðé ƒáíļéð: íţéɱš óŕ ɱóñéý ñó ļóñĝéŕ áʋáíļáƀļé.]",

--- a/src/ui/i18n.resolved.generated/es.ts
+++ b/src/ui/i18n.resolved.generated/es.ts
@@ -6473,6 +6473,7 @@ export const es: EnTranslations = {
       "arenaQueueTrading": "Termina tu comercio antes de entrar en cola.",
       "arenaQueueInstance": "No puedes entrar en cola desde una instancia.",
       "tradeInProgress": "Ya hay un comercio en curso.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "El objetivo está demasiado lejos para comerciar.",
       "tradeExpired": "La solicitud de comercio ha expirado.",
       "tradeFailed": "Comercio fallido: los objetos o el dinero ya no están disponibles.",

--- a/src/ui/i18n.resolved.generated/es_ES.ts
+++ b/src/ui/i18n.resolved.generated/es_ES.ts
@@ -6473,6 +6473,7 @@ export const es_ES: EnTranslations = {
       "arenaQueueTrading": "Termina tu comercio antes de entrar en cola.",
       "arenaQueueInstance": "No puedes entrar en cola desde una instancia.",
       "tradeInProgress": "Ya hay un comercio en curso.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "El objetivo está demasiado lejos para comerciar.",
       "tradeExpired": "La solicitud de comercio ha expirado.",
       "tradeFailed": "Comercio fallido: los objetos o el dinero ya no están disponibles.",

--- a/src/ui/i18n.resolved.generated/fr_CA.ts
+++ b/src/ui/i18n.resolved.generated/fr_CA.ts
@@ -6473,6 +6473,7 @@ export const fr_CA: EnTranslations = {
       "arenaQueueTrading": "Terminez votre échange avant de rejoindre la file.",
       "arenaQueueInstance": "Vous ne pouvez pas rejoindre la file depuis une instance.",
       "tradeInProgress": "Un échange est déjà en cours.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "La cible est trop éloignée pour échanger.",
       "tradeExpired": "La demande d'échange a expiré.",
       "tradeFailed": "Échange échoué : objets ou argent indisponibles.",

--- a/src/ui/i18n.resolved.generated/fr_FR.ts
+++ b/src/ui/i18n.resolved.generated/fr_FR.ts
@@ -6473,6 +6473,7 @@ export const fr_FR: EnTranslations = {
       "arenaQueueTrading": "Terminez votre échange avant de rejoindre la file.",
       "arenaQueueInstance": "Vous ne pouvez pas rejoindre la file depuis une instance.",
       "tradeInProgress": "Un échange est déjà en cours.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "La cible est trop éloignée pour échanger.",
       "tradeExpired": "La demande d'échange a expiré.",
       "tradeFailed": "Échange échoué : objets ou argent indisponibles.",

--- a/src/ui/i18n.resolved.generated/id_ID.ts
+++ b/src/ui/i18n.resolved.generated/id_ID.ts
@@ -6473,6 +6473,7 @@ export const id_ID: EnTranslations = {
       "arenaQueueTrading": "Selesaikan dulu perdaganganmu sebelum antre.",
       "arenaQueueInstance": "Kamu tidak bisa antre dari dalam instance.",
       "tradeInProgress": "Perdagangan sudah berlangsung.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Sasaran terlalu jauh untuk berdagang.",
       "tradeExpired": "Permintaan perdagangan telah kedaluwarsa.",
       "tradeFailed": "Perdagangan gagal: barang atau uang sudah tidak tersedia.",

--- a/src/ui/i18n.resolved.generated/it_IT.ts
+++ b/src/ui/i18n.resolved.generated/it_IT.ts
@@ -6473,6 +6473,7 @@ export const it_IT: EnTranslations = {
       "arenaQueueTrading": "Termina lo scambio prima di metterti in coda.",
       "arenaQueueInstance": "Non puoi metterti in coda da dentro un'istanza.",
       "tradeInProgress": "Uno scambio è già in corso.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Il bersaglio è troppo lontano per commerciare.",
       "tradeExpired": "La richiesta di scambio è scaduta.",
       "tradeFailed": "Scambio fallito: oggetti o denaro non più disponibili.",

--- a/src/ui/i18n.resolved.generated/ja_JP.ts
+++ b/src/ui/i18n.resolved.generated/ja_JP.ts
@@ -6473,6 +6473,7 @@ export const ja_JP: EnTranslations = {
       "arenaQueueTrading": "取引を終えてからキューに入ってください。",
       "arenaQueueInstance": "インスタンス内からキューには入れません。",
       "tradeInProgress": "すでに取引が進行中です。",
+      "tradeAlreadyTrading": "そのプレイヤーはすでに取引中です。",
       "tradeTooFar": "対象が遠すぎて取引できません。",
       "tradeExpired": "取引リクエストは期限切れです。",
       "tradeFailed": "取引失敗: アイテムまたは所持金が利用できません。",

--- a/src/ui/i18n.resolved.generated/ko_KR.ts
+++ b/src/ui/i18n.resolved.generated/ko_KR.ts
@@ -6473,6 +6473,7 @@ export const ko_KR: EnTranslations = {
       "arenaQueueTrading": "거래를 끝낸 뒤 대기열에 들어가세요.",
       "arenaQueueInstance": "인스턴스 안에서는 대기열에 들어갈 수 없습니다.",
       "tradeInProgress": "이미 거래가 진행 중입니다.",
+      "tradeAlreadyTrading": "그 플레이어는 이미 거래 중입니다.",
       "tradeTooFar": "대상이 너무 멀어 거래할 수 없습니다.",
       "tradeExpired": "거래 요청이 만료되었습니다.",
       "tradeFailed": "거래 실패: 아이템이나 돈을 더 이상 사용할 수 없습니다.",

--- a/src/ui/i18n.resolved.generated/nl_NL.ts
+++ b/src/ui/i18n.resolved.generated/nl_NL.ts
@@ -6473,6 +6473,7 @@ export const nl_NL: EnTranslations = {
       "arenaQueueTrading": "Rond je ruil af voordat je in de wachtrij gaat.",
       "arenaQueueInstance": "Je kunt niet in de wachtrij gaan vanuit een instantie.",
       "tradeInProgress": "Er is al een ruil aan de gang.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Het doelwit is te ver weg om mee te ruilen.",
       "tradeExpired": "Het ruilverzoek is verlopen.",
       "tradeFailed": "Ruil mislukt: voorwerpen of geld niet langer beschikbaar.",

--- a/src/ui/i18n.resolved.generated/pending.ts
+++ b/src/ui/i18n.resolved.generated/pending.ts
@@ -9,25 +9,55 @@
 // Reproducibility is checked by tests/i18n_resolved_equivalence.test.ts.
 
 export const pending: Record<string, readonly string[]> = {
-  "es": [],
-  "es_ES": [],
-  "fr_FR": [],
-  "fr_CA": [],
+  "es": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "es_ES": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "fr_FR": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "fr_CA": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
   "en_CA": [],
-  "it_IT": [],
-  "de_DE": [],
+  "it_IT": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "de_DE": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
   "zh_CN": [],
   "zh_TW": [],
   "ko_KR": [],
   "ja_JP": [],
-  "pt_BR": [],
+  "pt_BR": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
   "ru_RU": [],
-  "cs_CZ": [],
-  "nl_NL": [],
-  "pl_PL": [],
-  "id_ID": [],
-  "tr_TR": [],
-  "sv_SE": [],
-  "vi_VN": [],
-  "da_DK": []
+  "cs_CZ": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "nl_NL": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "pl_PL": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "id_ID": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "tr_TR": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "sv_SE": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "vi_VN": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "da_DK": [
+    "hud.errors.tradeAlreadyTrading"
+  ]
 };

--- a/src/ui/i18n.resolved.generated/pl_PL.ts
+++ b/src/ui/i18n.resolved.generated/pl_PL.ts
@@ -6473,6 +6473,7 @@ export const pl_PL: EnTranslations = {
       "arenaQueueTrading": "Zakończ wymianę przed dołączeniem do kolejki.",
       "arenaQueueInstance": "Nie możesz dołączyć do kolejki będąc wewnątrz instancji.",
       "tradeInProgress": "Wymiana już trwa.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Cel jest zbyt daleko, by handlować.",
       "tradeExpired": "Prośba o wymianę wygasła.",
       "tradeFailed": "Wymiana nieudana: przedmioty lub pieniądze są już niedostępne.",

--- a/src/ui/i18n.resolved.generated/pt_BR.ts
+++ b/src/ui/i18n.resolved.generated/pt_BR.ts
@@ -6473,6 +6473,7 @@ export const pt_BR: EnTranslations = {
       "arenaQueueTrading": "Termine sua troca antes de entrar na fila.",
       "arenaQueueInstance": "Você não pode entrar na fila dentro de uma instância.",
       "tradeInProgress": "Já há uma troca em andamento.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "O alvo está longe demais para trocar.",
       "tradeExpired": "A solicitação de troca expirou.",
       "tradeFailed": "Troca falhou: itens ou dinheiro não estão mais disponíveis.",

--- a/src/ui/i18n.resolved.generated/ru_RU.ts
+++ b/src/ui/i18n.resolved.generated/ru_RU.ts
@@ -6473,6 +6473,7 @@ export const ru_RU: EnTranslations = {
       "arenaQueueTrading": "Завершите обмен перед постановкой в очередь.",
       "arenaQueueInstance": "Нельзя вставать в очередь из подземелья.",
       "tradeInProgress": "Обмен уже идет.",
+      "tradeAlreadyTrading": "Этот игрок уже торгует.",
       "tradeTooFar": "Цель слишком далеко для обмена.",
       "tradeExpired": "Запрос обмена истек.",
       "tradeFailed": "Обмен не удался: предметы или деньги больше недоступны.",

--- a/src/ui/i18n.resolved.generated/sv_SE.ts
+++ b/src/ui/i18n.resolved.generated/sv_SE.ts
@@ -6473,6 +6473,7 @@ export const sv_SE: EnTranslations = {
       "arenaQueueTrading": "Avsluta din handel innan du köar.",
       "arenaQueueInstance": "Du kan inte köa inifrån en instans.",
       "tradeInProgress": "En handel pågår redan.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Målet är för långt bort för att handla.",
       "tradeExpired": "Handelsförfrågan har gått ut.",
       "tradeFailed": "Handeln misslyckades: föremål eller pengar är inte längre tillgängliga.",

--- a/src/ui/i18n.resolved.generated/tr_TR.ts
+++ b/src/ui/i18n.resolved.generated/tr_TR.ts
@@ -6473,6 +6473,7 @@ export const tr_TR: EnTranslations = {
       "arenaQueueTrading": "Sıraya girmeden önce takasını bitir.",
       "arenaQueueInstance": "Bir zindanın içinden sıraya giremezsin.",
       "tradeInProgress": "Zaten devam eden bir takas var.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Hedef takas için çok uzakta.",
       "tradeExpired": "Takas isteğinin süresi doldu.",
       "tradeFailed": "Takas başarısız: eşyalar ya da para artık mevcut değil.",

--- a/src/ui/i18n.resolved.generated/vi_VN.ts
+++ b/src/ui/i18n.resolved.generated/vi_VN.ts
@@ -6473,6 +6473,7 @@ export const vi_VN: EnTranslations = {
       "arenaQueueTrading": "Hãy hoàn tất giao dịch trước khi xếp hàng.",
       "arenaQueueInstance": "Bạn không thể xếp hàng khi đang ở trong hầm ngục.",
       "tradeInProgress": "Một giao dịch đang diễn ra.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Mục tiêu ở quá xa để giao dịch.",
       "tradeExpired": "Yêu cầu giao dịch đã hết hạn.",
       "tradeFailed": "Giao dịch thất bại: vật phẩm hoặc tiền không còn khả dụng.",

--- a/src/ui/i18n.resolved.generated/zh_CN.ts
+++ b/src/ui/i18n.resolved.generated/zh_CN.ts
@@ -6473,6 +6473,7 @@ export const zh_CN: EnTranslations = {
       "arenaQueueTrading": "请先完成交易再加入队列。",
       "arenaQueueInstance": "你不能在副本内加入队列。",
       "tradeInProgress": "已有交易正在进行。",
+      "tradeAlreadyTrading": "该玩家已在交易中。",
       "tradeTooFar": "目标太远，无法交易。",
       "tradeExpired": "交易请求已过期。",
       "tradeFailed": "交易失败：物品或金钱已不可用。",

--- a/src/ui/i18n.resolved.generated/zh_TW.ts
+++ b/src/ui/i18n.resolved.generated/zh_TW.ts
@@ -6473,6 +6473,7 @@ export const zh_TW: EnTranslations = {
       "arenaQueueTrading": "請先完成交易再加入佇列。",
       "arenaQueueInstance": "你不能在副本內加入佇列。",
       "tradeInProgress": "已有交易正在進行。",
+      "tradeAlreadyTrading": "該玩家已在交易中。",
       "tradeTooFar": "目標太遠，無法交易。",
       "tradeExpired": "交易請求已過期。",
       "tradeFailed": "交易失敗：物品或金錢已不可用。",

--- a/tests/localization_fixes.test.ts
+++ b/tests/localization_fixes.test.ts
@@ -6,6 +6,8 @@ import { resolveReportTarget } from '../server/report_target';
 import { DICT as adminDICT, classLabel, setAdminLanguage } from '../src/admin/i18n';
 import { DELVE_MOBS } from '../src/sim/content/delves/mobs';
 import { ABILITIES, ITEMS } from '../src/sim/data';
+import { Sim } from '../src/sim/sim';
+import type { SimEvent } from '../src/sim/types';
 import { itemDisplayName } from '../src/ui/entity_i18n';
 import { Hud } from '../src/ui/hud';
 import {
@@ -1241,6 +1243,41 @@ describe('S3: every sim.ts emit is recognized (drift guard)', () => {
     }
     setLanguage('en');
     expect(leaks, 'unregistered sim emit strings (add a key/RULE to sim_i18n.ts)').toEqual([]);
+  });
+
+  // BUG #12 regression: the trade-accept-race deny path ('That player is already
+  // trading.', emitted from src/sim/social/trade.ts's tradeAccept when a second
+  // invitee accepts a stale invite while the inviter is already trading someone
+  // else) was miscategorized into the V07_SLASH allowlist, a backstop meant for
+  // undated slash-command diagnostics, not trade errors. That let it bypass
+  // candidateStrings() (and so s3_registered above) despite carrying no real
+  // hud.errors key, unlike its sibling 'A trade is already in progress.'. Drive
+  // the real race through the real Sim to prove the exact string still ships,
+  // then check it against the same exact-map extraction s3_registered itself
+  // uses, so this fails for the true reason (no key), not a stand-in.
+  it('the real trade-accept-race deny text has its own hud.errors key, not a V07_SLASH leak', () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    const a = sim.addPlayer('warrior', 'Anna');
+    const b = sim.addPlayer('mage', 'Bert');
+    const c = sim.addPlayer('warrior', 'Cara');
+    sim.tradeRequest(b, a);
+    sim.tradeRequest(c, a);
+    sim.tradeAccept(b);
+    sim.events.length = 0;
+    sim.tradeAccept(c);
+    const err = sim.events.find(
+      (e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error',
+    );
+    expect(err?.text).toBe('That player is already trading.');
+
+    expect(
+      arms.localizeErrorText.exact.has('That player is already trading.'),
+      'That player is already trading. must be a real hud.errors EXACT key, matching its sibling A trade is already in progress.',
+    ).toBe(true);
+    expect(
+      ALLOW_V07_SLASH.has('That player is already trading.'),
+      'That player is already trading. must not be parked in the V07_SLASH slash-command backstop allowlist',
+    ).toBe(false);
   });
 
   it('the src/sim/social glob still reaches its modules and feeds the corpus', () => {


### PR DESCRIPTION
## Summary

The trade-accept-race deny path (`tradeAccept` in `src/sim/social/trade.ts`, the guard that
stops a second, stale invite acceptance from hijacking a player who is already trading someone
else) emits `'That player is already trading.'`. That string had no `hud.errors` key and no
matcher `RULE`, so it shipped as raw, unlocalized English to every non-English client.

It only passed the S3 i18n drift guard because it was miscategorized into `V07_SLASH`
(`scripts/i18n_blocked_seed.mjs`), an allowlist reserved for the undated v0.7 slash-command /
diagnostic surface (`/target`, `/xp`, `/auto`, ...) that ships English as a documented backstop.
This string is not a slash-command diagnostic, it is a normal trade error with a perfectly good
sibling pattern already in place: `'A trade is already in progress.'` -> `hud.errors.tradeInProgress`.

**Fix:** give the string its own real key (`hud.errors.tradeAlreadyTrading`), add the matching
`EXACT` entry to `hud.ts`'s `localizeErrorText`, and remove it from the `V07_SLASH` allowlist so
the drift guard actually enforces it going forward. Added the five non-Latin overlay fills
(`zh_CN`, `zh_TW`, `ja_JP`, `ko_KR`, `ru_RU`) the M16 wordy-copy rule requires for a new catalog
value of this length; the maintainer fills the remaining locales at release per the usual policy.

`src/sim/social/trade.ts` itself is untouched: this is purely the client-side localization
plumbing for an existing, already-correct sim behavior (the race-deny logic is unchanged).

```mermaid
flowchart TD
    subgraph sim["src/sim/social/trade.ts (unchanged)"]
        A["tradeAccept(): second invitee accepts\na stale invite while the inviter\nis already trading someone else"]
        A --> B["ctx.error(pid, 'That player is already trading.')"]
    end
    B --> C{"src/ui/hud.ts\nlocalizeErrorText(text)"}
    C -->|"BEFORE: no EXACT entry\nfor this string"| D["falls through to raw text\nships as English in every locale"]
    C -->|"AFTER: EXACT entry added\n'That player is already trading.' -> hud.errors.tradeAlreadyTrading"| E["t('hud.errors.tradeAlreadyTrading')\nrenders in the player's language"]

    subgraph guard["S3 drift guard (tests/localization_fixes.test.ts)"]
        F["candidateStrings() skips anything\nin the V07_SLASH allowlist"]
    end
    B -.->|"BEFORE: string sat in V07_SLASH\n(scripts/i18n_blocked_seed.mjs),\nso the guard never checked it"| F
    B -.->|"AFTER: removed from V07_SLASH,\nso the guard now requires\na real key/RULE"| F
```

## Related issues

N/A (found by fresh code audit, no existing issue).

## Type of change

- [x] Bug fix

## How was this tested?

Commands run from `/home/jegoh/worktrees/wt-trade-race-i18n`:

- `npm run i18n:gen` (regenerates `src/ui/i18n.status.json`, the resolved bundles, and the flat
  `TranslationKey` union after the catalog/overlay edits; never hand-edited).
- `npx vitest run tests/localization_fixes.test.ts` -> 40 passed, 3 skipped (release-tier only).
  Includes a new regression test, `'the real trade-accept-race deny text has its own hud.errors
  key, not a V07_SLASH leak'`, that drives the actual multi-invite-hijack race through a real
  `Sim` (three players, a stale trade invite race, exactly the path in `trade.ts`), asserts the
  real emitted text, then checks it against the same exact-key extraction the `s3_registered`
  guard itself uses. Confirmed it fails before the fix (no `hud.errors` key found) and passes
  after.
- `npx vitest run tests/i18n_completeness.test.ts` -> 8 passed (M16 non-Latin completeness guard).
- `npx vitest run tests/i18n_resolved_equivalence.test.ts` -> 7 passed (generated-artifact
  freshness/determinism, once the regenerated files were staged).
- `npx vitest run tests/fixes.test.ts tests/trade.test.ts tests/trade_view.test.ts
  tests/architecture.test.ts tests/world_api_parity.test.ts` -> all passed (existing trade-race
  behavior, sim/DOM boundary, and `IWorld` parity all unaffected).
- `npx tsc --noEmit` -> clean.
- `npx @biomejs/biome check --write` on every hand-edited file -> exit 0, no format diffs (only
  pre-existing `noExplicitAny` warnings elsewhere in the test file, not touched by this change).

## Screenshots / recordings

Skipped. Reproducing this bug's visible symptom needs three concurrent player sessions against
the live server (one inviter, one who accepts first, one who races a stale invite in behind
them) with the client set to a non-English locale, all timed to hit the exact race window. That
is not something the offline single-player capture flow (`npm run dev` + one controlled
character) can drive, and staging it through raw WebSocket messages well enough to trust the
screenshot would risk showing something other than the real client code path. The new
`Sim`-driven regression test exercises the exact same race and the exact same string, which is
the reliable way to prove this one.

---

## Checklist

### Quality

- [x] **The full gate passes.** Ran the targeted subset above (this machine has sibling agents
      running concurrently, so the full `npm run gate` was intentionally not run here); tests,
      typecheck, and biome are all green on every changed file.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A: no HUD layout, DOM, or CSS changed, only which
  translation key an existing toast string resolves through.
- ~~Accessible.~~ N/A: same toast surface, same ARIA/focus behavior; only the rendered text
  changes per locale.

### Localization (i18n)

- [x] **New player-visible strings follow the contributor policy.** Added
      `hud.errors.tradeAlreadyTrading` to `src/ui/i18n.catalog/hud.ts` (English) and the matching
      `EXACT` entry in `hud.ts`. Did not edit any locale overlay except the five required
      non-Latin fills (`zh_CN`, `zh_TW`, `ja_JP`, `ko_KR`, `ru_RU`) since the M16 wordy-copy rule
      applies to this string.
- [x] Numbers, money, dates, units, and percents go through the i18n formatters. N/A: this string
      has no interpolated values.
- [x] Player-facing text emitted from `src/sim/` or `server/` is re-localized at the client
      boundary in this same change, and `npx vitest run tests/localization_fixes.test.ts` passes.
- [ ] N/A. This PR adds no player-visible strings. (It does: see above.)

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in
      any production path.
- [x] I didn't hand-edit generated files. `src/ui/i18n.resolved.generated/*`,
      `src/ui/i18n.catalog/translation_keys.generated.ts`, and `src/ui/i18n.status.json` were all
      produced by `npm run i18n:gen`; `src/ui/i18n.status.json` is gitignored and not committed.
