### PR TITLE
fix(sim): stop a same-tick reciprocal lethal duel hit from killing a duelist

### DIFF
--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -481,12 +481,16 @@ export function dealDamage(
     }
   }
 
-  // duels end at 1 hp, nobody dies
+  // duels end at 1 hp, nobody dies. A duel that already ended earlier THIS
+  // SAME tick (endDuel defers the ctx.duels delete to tick-tail, see
+  // social/duel.ts) still matches here on purpose: a reciprocal lethal hit
+  // against the other duelist, resolving later in the same tick, must be
+  // clamped too instead of producing a real death on a simultaneous double-kill.
   const duel = target.kind === 'player' ? ctx.duels.get(target.id) : undefined;
   if (
     guardianWardRestore === 0 &&
     duel &&
-    duel.state === 'active' &&
+    (duel.state === 'active' || duel.endedTick === ctx.tickCount) &&
     sourcePlayer &&
     (sourcePlayer.id === duel.a || sourcePlayer.id === duel.b)
   ) {

--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -486,11 +486,16 @@ export function dealDamage(
   // social/duel.ts) still matches here on purpose: a reciprocal lethal hit
   // against the other duelist, resolving later in the same tick, must be
   // clamped too instead of producing a real death on a simultaneous double-kill.
+  // Keyed purely on lifetime (still live, or ended this very tick) rather than
+  // `duel.state === 'active'`: state is never flipped when a duel ends, so an
+  // ended entry that outlives its own tick (only reachable today via
+  // Sim.removePlayer ending a duel outside a tick) would otherwise still clamp
+  // for one extra tick.
   const duel = target.kind === 'player' ? ctx.duels.get(target.id) : undefined;
   if (
     guardianWardRestore === 0 &&
     duel &&
-    (duel.state === 'active' || duel.endedTick === ctx.tickCount) &&
+    (duel.endedTick === undefined || duel.endedTick === ctx.tickCount) &&
     sourcePlayer &&
     (sourcePlayer.id === duel.a || sourcePlayer.id === duel.b)
   ) {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -834,6 +834,12 @@ export interface DuelState {
   b: number;
   state: 'countdown' | 'active';
   timer: number; // countdown remaining / elapsed
+  // Tick number endDuel() set this on, or undefined while the duel is live.
+  // The entry is kept in `ctx.duels` (instead of being deleted synchronously)
+  // until updateDuels() purges it at tick-tail, so a reciprocal lethal hit
+  // resolving later in the SAME tick still finds it and gets clamped too:
+  // duels never produce a real death, even on a simultaneous double-kill.
+  endedTick?: number;
 }
 
 // GroundAoE type moved to entity_roster.ts (the ground-AoE drain's home); imported above.
@@ -8306,6 +8312,7 @@ export class Sim {
       const duel = this.duels.get(attackerPlayer.id);
       if (
         duel &&
+        duel.endedTick === undefined &&
         duel.state === 'active' &&
         ((duel.a === attackerPlayer.id && duel.b === target.id) ||
           (duel.b === attackerPlayer.id && duel.a === target.id))

--- a/src/sim/social/arena.ts
+++ b/src/sim/social/arena.ts
@@ -38,6 +38,7 @@ import {
   emptyMoveInput,
 } from '../types';
 import { clearCooldownsPreservingUnstuck } from '../unstuck_cooldown';
+import { duelFor } from './duel';
 
 // Deep-copy the CC diminishing-return map so a snapshot never shares mutable
 // state objects with the live entity (values are re-derived each restore).
@@ -131,7 +132,7 @@ export function arenaQueueJoin(
     ctx.error(id, 'You cannot queue for the arena while dead.');
     return;
   }
-  if (ctx.duels.has(id)) {
+  if (duelFor(ctx, id) !== null) {
     ctx.error(id, 'You cannot queue while dueling.');
     return;
   }
@@ -214,7 +215,7 @@ export function arenaQueueJoin(
         ctx.error(id, `${mMeta.name} is already in an arena match.`);
         return;
       }
-      if (ctx.duels.has(mPid)) {
+      if (duelFor(ctx, mPid) !== null) {
         ctx.error(id, `${mMeta.name} cannot queue while dueling.`);
         return;
       }
@@ -285,7 +286,7 @@ export function arenaQueueJoin(
       ctx.error(id, `${mMeta.name} is already in an arena match.`);
       return;
     }
-    if (ctx.duels.has(mPid)) {
+    if (duelFor(ctx, mPid) !== null) {
       ctx.error(id, `${mMeta.name} cannot queue while dueling.`);
       return;
     }

--- a/src/sim/social/duel.ts
+++ b/src/sim/social/duel.ts
@@ -30,7 +30,7 @@ export function duelRequest(ctx: SimContext, targetPid: number, pid?: number): v
     ctx.error(r.meta.entityId, 'You cannot duel in Nythraxis Raid Arena.');
     return;
   }
-  if (ctx.duels.has(r.meta.entityId) || ctx.duels.has(targetPid)) {
+  if (duelFor(ctx, r.meta.entityId) || duelFor(ctx, targetPid)) {
     ctx.error(r.meta.entityId, 'A duel is already in progress.');
     return;
   }
@@ -77,7 +77,7 @@ export function duelAccept(ctx: SimContext, pid?: number): void {
     ctx.error(r.meta.entityId, 'You cannot duel in Nythraxis Raid Arena.');
     return;
   }
-  if (ctx.duels.has(invite.fromPid) || ctx.duels.has(r.meta.entityId)) {
+  if (duelFor(ctx, invite.fromPid) || duelFor(ctx, r.meta.entityId)) {
     ctx.error(r.meta.entityId, 'A duel is already in progress.');
     return;
   }

--- a/src/sim/social/duel.ts
+++ b/src/sim/social/duel.ts
@@ -114,6 +114,10 @@ export function updateDuels(ctx: SimContext): void {
   for (const duel of ctx.duels.values()) {
     if (seen.has(duel)) continue;
     seen.add(duel);
+    // Already ended (either by an earlier same-tick lethal hit or a stale
+    // entry awaiting purge): nothing left to evaluate, just fall through to
+    // the purge sweep below.
+    if (duel.endedTick !== undefined) continue;
     const ea = ctx.entities.get(duel.a);
     const eb = ctx.entities.get(duel.b);
     if (!ea || !eb) {
@@ -146,12 +150,24 @@ export function updateDuels(ctx: SimContext): void {
       endDuel(ctx, duel, duel.a);
     }
   }
+  // Purge every duel endDuel() marked ended (this tick or, in the rare case
+  // it was ended outside a tick entirely, an earlier one) now that combat for
+  // this tick has fully resolved. Deferring the delete out of endDuel() is
+  // what lets a reciprocal lethal hit landing later in the SAME tick still
+  // find the duel and get clamped instead of producing a real death.
+  for (const [pid, duel] of ctx.duels) {
+    if (duel.endedTick !== undefined) ctx.duels.delete(pid);
+  }
 }
 
 // winnerPid null = draw/cancelled
 export function endDuel(ctx: SimContext, duel: DuelState, winnerPid: number | null): void {
-  ctx.duels.delete(duel.a);
-  ctx.duels.delete(duel.b);
+  // Idempotent: a same-tick reciprocal lethal hit re-enters here after the
+  // first hit already ended this same duel (the damage-clamp lookup in
+  // combat/damage.ts still matches it via endedTick). Only the first call
+  // performs the actual teardown and stat/emit side effects.
+  if (duel.endedTick !== undefined) return;
+  duel.endedTick = ctx.tickCount;
   const aMeta = ctx.players.get(duel.a);
   const bMeta = ctx.players.get(duel.b);
   const ea = ctx.entities.get(duel.a);
@@ -181,5 +197,10 @@ export function endDuel(ctx: SimContext, duel: DuelState, winnerPid: number | nu
 }
 
 export function duelFor(ctx: SimContext, pid: number): DuelState | null {
-  return ctx.duels.get(pid) ?? null;
+  const duel = ctx.duels.get(pid);
+  // An ended duel lingers in ctx.duels until updateDuels() purges it at
+  // tick-tail (see endDuel above); every consumer except the damage-clamp
+  // lookup in combat/damage.ts must keep seeing it as gone the instant it
+  // ends, matching the old synchronous-delete behavior.
+  return duel && duel.endedTick === undefined ? duel : null;
 }

--- a/src/sim/social/vale_cup.ts
+++ b/src/sim/social/vale_cup.ts
@@ -82,6 +82,7 @@ import {
   isArenaQueued,
   snapshotArenaReturnPools,
 } from './arena';
+import { duelFor } from './duel';
 
 // ---------------------------------------------------------------------------
 // Tuning constants (fiesta style: all at the top).
@@ -446,7 +447,7 @@ export function vcupQueueJoin(
     ctx.error(id, 'You cannot queue for the arena while dead.');
     return;
   }
-  if (ctx.duels.has(id)) {
+  if (duelFor(ctx, id) !== null) {
     ctx.error(id, 'You cannot queue while dueling.');
     return;
   }
@@ -506,7 +507,7 @@ export function vcupQueueJoin(
       ctx.error(id, `${mMeta.name} is already in the arena queue.`);
       return;
     }
-    if (ctx.duels.has(mPid)) {
+    if (duelFor(ctx, mPid) !== null) {
       ctx.error(id, `${mMeta.name} cannot queue while dueling.`);
       return;
     }

--- a/src/sim/social/vale_cup_bots.ts
+++ b/src/sim/social/vale_cup_bots.ts
@@ -35,6 +35,7 @@ import {
   vcPracticeOrigin,
 } from '../vale_cup_layout';
 import { isArenaQueued } from './arena';
+import { duelFor } from './duel';
 import * as valeCupMod from './vale_cup';
 import {
   VC_BACKFILL_WAIT,
@@ -214,7 +215,7 @@ export function startValeCupPractice(sim: Sim, bracket: VcBracket, pid?: number)
     ctx.error(id, 'You cannot queue for the arena while dead.');
     return;
   }
-  if (ctx.duels.has(id)) {
+  if (duelFor(ctx, id) !== null) {
     ctx.error(id, 'You cannot queue while dueling.');
     return;
   }

--- a/tests/deeds.test.ts
+++ b/tests/deeds.test.ts
@@ -1515,7 +1515,11 @@ describe('site wiring (real modules, not direct bumps)', () => {
     const clamped = victim.hp - 1;
     dealDamage(sim.ctx, attacker, victim, victim.hp + 500, true, 'physical', null, 'hit');
     expect(victim.hp).toBe(1);
-    expect(sim.ctx.duels.has(a)).toBe(false);
+    // The duel is over the instant the finisher lands, but the map entry
+    // itself lingers until updateDuels() purges it at tick-tail (see
+    // src/sim/social/duel.ts); duelFor() is the purge-order-independent way
+    // to observe "the duel has ended" from outside duel.ts.
+    expect(duelMod.duelFor(sim.ctx, a)).toBeNull();
     expect(metaA.deedStats.counters.damageDealt).toBe(10 + clamped);
     expect(metaA.deedStats.counters.crits).toBe(1);
   });

--- a/tests/duel.test.ts
+++ b/tests/duel.test.ts
@@ -91,7 +91,7 @@ describe('duel: non-lethal cleanup', () => {
     (sim as any).applyAura(eb, opponentDot(ea.id));
     (sim as any).dealDamage(ea, eb, eb.hp + 1000, false, 'physical', 'Finisher', 'hit');
 
-    expect((sim as any).duels.has(b)).toBe(false); // duel is over
+    expect(sim.duelFor(b)).toBeNull(); // duel is over
     expect(eb.dead).toBe(false);
     expect(eb.hp).toBe(1);
 
@@ -120,6 +120,44 @@ describe('duel: non-lethal cleanup', () => {
 
     for (let i = 0; i < 20 * 3; i++) sim.tick();
     expect(eb.dead).toBe(false);
+  });
+});
+
+describe('duel: same-tick reciprocal lethal hits', () => {
+  it('does not let a real death slip through when both duelists land a lethal hit in the same tick', () => {
+    const { sim, a, b } = startedDuel();
+    const ea = sim.entities.get(a)!;
+    const eb = sim.entities.get(b)!;
+    (sim as any).drainEvents();
+
+    // Aleph's blow lands first and ends the duel via the 1-HP guard. Before
+    // the duel entry is purged, Bet's own lethal blow against Aleph resolves
+    // in the SAME tick (the real projectile-resolution path can produce this
+    // when both attacks land in one tick). Neither hit may produce a real
+    // death: duels never kill.
+    (sim as any).dealDamage(ea, eb, eb.hp + 1000, false, 'physical', 'Finisher', 'hit');
+    (sim as any).dealDamage(eb, ea, ea.hp + 1000, false, 'physical', 'Finisher', 'hit');
+
+    expect(eb.dead).toBe(false);
+    expect(eb.hp).toBe(1);
+    expect(ea.dead).toBe(false);
+    expect(ea.hp).toBe(1);
+    expect(sim.duelFor(a)).toBeNull();
+    expect(sim.duelFor(b)).toBeNull();
+
+    // Only the first lethal hit should have resolved the duel: the deed
+    // ledgers and the duelEnd broadcast must not double-count the reciprocal
+    // hit that landed against an already-ended bout.
+    const aMeta = sim.players.get(a)!;
+    const bMeta = sim.players.get(b)!;
+    expect(aMeta.deedStats.counters.duelsWon ?? 0).toBe(1);
+    expect(bMeta.deedStats.counters.duelsLost ?? 0).toBe(1);
+    expect(bMeta.deedStats.counters.duelsWon ?? 0).toBe(0);
+    expect(aMeta.deedStats.counters.duelsLost ?? 0).toBe(0);
+    const duelEndEvents = ((sim as any).events as { type: string }[]).filter(
+      (e) => e.type === 'duelEnd',
+    );
+    expect(duelEndEvents.length).toBe(1);
   });
 });
 
@@ -154,7 +192,7 @@ describe('duel: PvP combat affordances', () => {
 
     (sim as any).dealDamage(pet, eb, eb.hp + 1000, false, 'physical', 'Pet Bite', 'hit');
 
-    expect((sim as any).duels.has(b)).toBe(false);
+    expect(sim.duelFor(b)).toBeNull();
     expect(eb.dead).toBe(false);
     expect(eb.hp).toBe(1);
   });

--- a/tests/duel_module.test.ts
+++ b/tests/duel_module.test.ts
@@ -69,18 +69,24 @@ describe('duel module: endDuel resolution', () => {
     expect(end).toBeTruthy();
     expect(end.winnerName).toBe('Aleph');
     expect(end.loserName).toBe('Bet');
-    expect(sim.duels.has(a)).toBe(false);
-    expect(sim.duels.has(b)).toBe(false);
+    // endDuel() marks the entry ended (endedTick) but defers the actual
+    // ctx.duels delete to updateDuels()'s tick-tail purge, so a same-tick
+    // reciprocal lethal hit can still find and clamp it; duelFor() is the
+    // purge-order-independent way to observe "the duel has ended" from
+    // outside duel.ts.
+    expect(duel.duelFor(sim.ctx, a)).toBeNull();
+    expect(duel.duelFor(sim.ctx, b)).toBeNull();
   });
 
   it('a draw resolution (null winner) ends the bout with no duelEnd, just a notice', () => {
-    const { sim, d } = seatedDuel();
+    const { sim, a, b, d } = seatedDuel();
     sim.drainEvents();
     duel.endDuel(sim.ctx, d, null);
     const ev = sim.drainEvents();
     expect(ev.some((e: any) => e.type === 'duelEnd')).toBe(false);
     const endedLogs = ev.filter((e: any) => e.type === 'log' && e.text === 'The duel has ended.');
     expect(endedLogs.length).toBe(2); // one to each combatant
-    expect(sim.duels.size).toBe(0);
+    expect(duel.duelFor(sim.ctx, a)).toBeNull();
+    expect(duel.duelFor(sim.ctx, b)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

The duels-end-at-1hp-nobody-dies guarantee was a one-shot `Map` lookup: `endDuel`
deleted the duel entry for both pids the instant the first lethal hit resolved
inside `dealDamage`'s 1-HP guard. If a second, independently lethal hit against
the OTHER duelist resolved later in the SAME tick (the real projectile-resolution
path, or two auto-attack swings, can both land in one 20 Hz tick), the second
`ctx.duels.get(target.id)` lookup missed (the entry was already gone) and fell
through to a real death, breaking the "duels never kill" invariant.

Fix: `endDuel` (`src/sim/social/duel.ts`) no longer deletes the duel from
`ctx.duels` synchronously. It marks the duel with `endedTick = ctx.tickCount`
instead (mirroring Arena's `match.defeated` same-tick tracking) and is now
idempotent, so a reciprocal call for the second hit is a no-op after the first.
`updateDuels()` purges every ended duel from `ctx.duels` at tick-tail, once
combat for the tick has fully resolved. The damage-clamp lookup in
`combat/damage.ts` now also matches a duel whose `endedTick` equals the
current tick, so the second hit still gets clamped to 1 HP instead of killing.
Every OTHER consumer of the duel map (`duelFor()`, and the `isHostileTo` duel
check in `sim.ts`) keeps treating an ended duel as gone immediately, preserving
their prior synchronous-delete behavior.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npx vitest run tests/duel.test.ts` (new regression test + all 6 existing
    duel tests pass; three existing assertions that checked `sim.duels.has(...)`
    immediately after a direct `dealDamage` call were updated to
    `sim.duelFor(...)` since that's the public, purge-order-independent way to
    observe "the duel is over" from outside `duel.ts`)
  - `npx vitest run tests/arena.test.ts tests/social.test.ts tests/social_system.test.ts tests/architecture.test.ts tests/world_api_parity.test.ts tests/sim.test.ts tests/combat.test.ts`
    (610 tests passed)
  - `npx vitest run tests/parity` (186 passed, 1 pre-existing skip; golden-trace
    rng draw order is unaffected since the fix adds no new rng draws)
  - `npm run i18n:gen && npx vitest run tests/localization_fixes.test.ts` (39
    passed, 3 pre-existing skips; no new player-facing strings, no generated
    file diff)
  - `npx @biomejs/biome check src/sim/combat/damage.ts src/sim/sim.ts src/sim/social/duel.ts` (clean)
- Manual steps: none (sim-only logic bug, covered by the new deterministic
  Vitest regression test that reproduces the bug via the real `dealDamage`
  code path, not a mock).

New test added: `tests/duel.test.ts`, "does not let a real death slip through
when both duelists land a lethal hit in the same tick". It first fails against
the unfixed code (`ea.dead` was `true`), confirmed before applying the fix.

## Checklist

### Quality

- [x] **The full gate passes.** Targeted `tsc`, the new/updated duel test, and
      the broader sim/social/architecture/parity/i18n suites listed above are
      green. `npm run gate` was not run in full (kept narrow per the task's
      instructions since other agents are running concurrently on shared files
      in sibling worktrees); the touched-file scope is small and localized.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A: sim-only server/headless logic, no UI.
- ~~Accessible.~~ N/A: no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files. `npm run i18n:gen` was run to confirm
      no generated-file diff results from this change.
