### PR TITLE
fix(sim): recompute corpseInstanceId from corpsePos on ghost relog

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2849,6 +2849,12 @@ export class Sim {
       player.corpsePos = savedState.corpsePos
         ? this.groundPos(savedState.corpsePos.x, savedState.corpsePos.z)
         : null;
+      // Instance ids are boot-local (recreated on every claim), so recompute
+      // from the restored position via the same helper the death path uses
+      // (spirit.ts releasePlayerSpirit) rather than persisting the raw id: a
+      // relog within a still-live claim recovers the corpse's instance
+      // binding, while a stale or reset claim correctly resolves to null.
+      player.corpseInstanceId = player.corpsePos ? this.instanceClaimIdAt(player.corpsePos) : null;
       player.hp = player.maxHp;
     } else if (savedState?.dead && !isArenaPos(savedState.pos.x) && !isDelvePos(savedState.pos.x)) {
       // Auto-release-on-logout: a character saved dead but UNRELEASED resumes as

--- a/tests/ghost_dead_gate.test.ts
+++ b/tests/ghost_dead_gate.test.ts
@@ -357,6 +357,41 @@ describe('auto-release-on-logout: save/load of a dead-unreleased character', () 
     expect(healerInRange(sim2, e2.pos, SPIRIT_HEALER_RANGE)).toBe(true);
   });
 
+  it('a released-ghost save inside a live dungeon claim recomputes corpseInstanceId on relog', () => {
+    const sim = makeSim();
+    sim.setPlayerLevel(10);
+    const p = sim.player as AnyEntity;
+    sim.enterDungeon('hollow_crypt');
+    expect(p.pos.x).toBeGreaterThan(DUNGEON_X_THRESHOLD);
+    // Die deeper inside the instance, then release: the normal death path
+    // (spirit.ts releasePlayerSpirit) stamps corpseInstanceId from the live
+    // claim so a fallen party member's corpse still counts for loot/XP.
+    p.pos = { x: p.pos.x, y: p.pos.y, z: p.pos.z + 30 };
+    p.prevPos = { ...p.pos };
+    sim.rebucket(p);
+    p.hp = 0;
+    p.dead = true;
+    sim.releaseSpirit();
+    const inst = (sim.instances as any[]).find(
+      (i) => i.dungeonId === 'hollow_crypt' && i.partyKey !== null,
+    );
+    expect(p.corpseInstanceId).toBe(inst.exitId);
+
+    // A relog within the SAME server session (the common case: the process
+    // does not restart, so the party's instance claim is still live) must not
+    // lose the corpse's instance binding, or a reconnecting downed member is
+    // permanently excluded from loot/XP/Heroic Mark credit for that corpse.
+    const state = sim.serializeCharacter(sim.playerId)!;
+    sim.removePlayer(sim.playerId);
+    const pid2 = sim.addPlayer('warrior', 'Reloger', { state });
+    const e2 = sim.entities.get(pid2) as AnyEntity;
+
+    expect(e2.dead).toBe(true);
+    expect(e2.ghost).toBe(true);
+    expect(e2.corpsePos).toBeTruthy();
+    expect(e2.corpseInstanceId).toBe(inst.exitId);
+  });
+
   it('an alive save still loads alive and unchanged', () => {
     const sim = makeSim();
     sim.setPlayerLevel(10);


### PR DESCRIPTION
## Summary

`corpsePos` is persisted and restored across a relog, but `corpseInstanceId` was
not: `addPlayer`'s ghost-resume branch restored `player.corpsePos` from the saved
state but left `player.corpseInstanceId` at its default `null`.

The fallen-members-still-count invariant (a downed party member's corpse still
counts for loot/XP/Heroic Mark eligibility while their body lies inside a live
dungeon or raid claim) is implemented in `combat/damage.ts` and `sim.ts` by
comparing `entity.corpseInstanceId` against the live instance claim's `exitId`.
With `corpseInstanceId` stuck at `null` after a relog, that comparison always
fails for a reconnected member, so their corpse position is silently discarded
in favor of their out-of-range ghost/graveyard position, permanently excluding
them from credit for kills in the instance they died in, even while their
party's claim is still live and their party is still fighting inside it.

The fix recomputes `corpseInstanceId` from the restored `corpsePos` in
`addPlayer`'s ghost-resume branch, using the same `instanceClaimIdAt` helper
`releasePlayerSpirit` (`src/sim/spirit.ts`) already uses at the moment of
death. Instance ids are boot-local (an instance's exit entity is recreated on
every claim), so this recomputes the binding rather than raw-persisting the
id: a relog inside a still-live claim recovers the binding, and a relog after
the claim has actually been freed correctly resolves to `null` (no stale
match against a recycled slot).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/ghost_dead_gate.test.ts` (new regression test added; confirmed it failed with `expected null to be <exitId>` before the fix, and passes after)
  - `npx vitest run tests/dungeons.test.ts` (78 passed, including the existing direct-death `corpseInstanceId` pins)
  - `npx vitest run tests/spirit.test.ts tests/persistence_round_trip.test.ts tests/parity/ tests/persisted_position_escape.test.ts` (220 passed, 1 pre-existing skip)
  - `npx vitest run tests/architecture.test.ts tests/world_api_parity.test.ts` (303 passed)
  - `npx tsc --noEmit` (clean)
  - `npx @biomejs/biome check --write src/sim/sim.ts tests/ghost_dead_gate.test.ts` (no format diffs remaining; only pre-existing lint warnings, no errors)
- Manual steps: none (sim/server-only logic, not visually observable).

```mermaid
flowchart TD
    A[Player dies inside a dungeon or raid instance] --> B[releasePlayerSpirit]
    B --> C["corpsePos = death spot
corpseInstanceId = instanceClaimIdAt(pos)"]
    C --> D[Player disconnects: character serialized with corpsePos + ghost = true]
    D --> E[Player reconnects: addPlayer ghost-resume branch]
    E --> F[corpsePos restored from saved state]
    F --> G{corpseInstanceId restored too?}
    G -- "Before fix: left null" --> H["Fallen-member checks compare
corpseInstanceId vs live claim exitId;
null never matches, falls back to the
out-of-range graveyard position"]
    H --> I[Excluded from loot / XP / Heroic Marks]
    G -- "After fix: instanceClaimIdAt(corpsePos)" --> J[corpseInstanceId matches the live claim exitId]
    J --> K[Corpse recognized as inside the instance]
    K --> L[Still credited for loot / XP / Heroic Marks]
```

## Checklist

### Quality

- [x] **The full gate passes.** Ran the targeted equivalent above (`npm run gate`
      was not run in full to keep this narrow while sibling agents share the
      machine); I added a decisive regression test for the changed behavior.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A: sim/server-only logic change, no UI surface.
- ~~Accessible.~~ N/A: no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit any generated file.
