### PR TITLE
fix(sim): make takeActionBarLayoutRestore one-shot in the offline Sim

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1833,6 +1833,10 @@ export class Sim {
   // the sim runs at 20 Hz wall speed, so the interval is real hours.
   private worldBossNextAt: number[] = WORLD_BOSSES.map((b) => b.intervalSeconds);
   private worldBossEntityIds: (number | null)[] = WORLD_BOSSES.map(() => null);
+  // One-shot gate for takeActionBarLayoutRestore (IWorldActionBar): mirrors
+  // ClientWorld's null-out pattern so the offline arm honors the same
+  // consumed-once contract instead of returning the 'noop' value forever.
+  private actionBarLayoutRestoreServed = false;
 
   // Per-world key for the rift collision registry in colliders.ts. Allocated per
   // Sim INSTANCE (not per seed): two same-seed Sims in one process must never
@@ -3633,6 +3637,8 @@ export class Sim {
   }
 
   takeActionBarLayoutRestore(): ActionBarLayoutRestore | undefined {
+    if (this.actionBarLayoutRestoreServed) return undefined;
+    this.actionBarLayoutRestoreServed = true;
     return { source: 'noop' };
   }
 

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -884,3 +884,15 @@ describe('friendly targeting (#133)', () => {
     expect(sim.player.targetId).toBe(77);
   });
 });
+
+describe('action bar layout restore (IWorldActionBar, offline arm)', () => {
+  // IWorldActionBar.takeActionBarLayoutRestore is documented as one-shot at
+  // world entry: consumed once, subsequent calls return undefined. ClientWorld
+  // honors this by nulling out its stored decision; the offline Sim must match.
+  it('returns the resolved value once, then undefined on every later call', () => {
+    const sim = makeSim();
+    expect(sim.takeActionBarLayoutRestore()).toEqual({ source: 'noop' });
+    expect(sim.takeActionBarLayoutRestore()).toBeUndefined();
+    expect(sim.takeActionBarLayoutRestore()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`IWorldActionBar.takeActionBarLayoutRestore()` is documented (`src/world_api/action_bar.ts`) as one-shot at world entry: "consumed once (subsequent calls return undefined)". `ClientWorld` (`src/net/online.ts`) honors this correctly, nulling out its stored `actionBarRestore` field on the first read. The offline `Sim` (`src/sim/sim.ts`) did not: it hardcoded `return { source: 'noop' }` unconditionally, so every call, first or hundredth, returned the same value forever. This breaks the documented `IWorld` contract for the offline host.

The `world_api_parity` gate could not catch this because it only pins the presence/shape of method-kind members, not their runtime behavior, and the sole current caller (`hud.ts` `maybeRestoreActionBarLayout`) masks the bug by gating on its own local `actionBarLayoutRestored` boolean and never actually calling the method twice.

### Fix

Added a private `actionBarLayoutRestoreServed` boolean to `Sim`, mirroring `ClientWorld`'s null-out pattern: the first call still returns `{ source: 'noop' }` (unchanged offline behavior), and every subsequent call now returns `undefined`, matching both the documented contract and `ClientWorld`'s behavior.

The diff is intentionally minimal and localized to this one method (both `src/sim/sim.ts` and `src/net/online.ts` are shared with other in-flight PRs).

## Related issues

N/A (found via fresh code audit, no existing issue).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands run from the worktree root:
  - `npx vitest run tests/sim.test.ts` (97 passed, includes the new test)
  - `npx vitest run tests/snapshots.test.ts tests/world_api_parity.test.ts tests/architecture.test.ts tests/action_bar_layout_client.test.ts` (470 passed)
  - `npx tsc --noEmit` (clean)
  - `npx @biomejs/biome check --write src/sim/sim.ts tests/sim.test.ts` (0 errors, 0 format diffs; only pre-existing unrelated lint warnings in the file, not part of this change)
- Manual steps: reverted the `src/sim/sim.ts` half of the diff with `git apply -R` on a saved patch, re-ran the new test to confirm it fails for the right reason (`expected { source: 'noop' } to be undefined`), then reapplied the patch and confirmed green.

```mermaid
sequenceDiagram
    participant HUD as hud.ts (caller)
    participant Sim as Sim (offline, BEFORE fix)
    participant Client as ClientWorld (online, unaffected)

    Note over Sim: takeActionBarLayoutRestore() hardcoded<br/>return { source: 'noop' } always
    HUD->>Sim: takeActionBarLayoutRestore() #1
    Sim-->>HUD: { source: 'noop' }
    HUD->>Sim: takeActionBarLayoutRestore() #2 (hypothetical)
    Sim-->>HUD: { source: 'noop' }

    Note over Client: ClientWorld already nulls out<br/>its stored decision on first read
    HUD->>Client: takeActionBarLayoutRestore() #1
    Client-->>HUD: restore (then sets field to undefined)
    HUD->>Client: takeActionBarLayoutRestore() #2
    Client-->>HUD: undefined
```

```mermaid
sequenceDiagram
    participant HUD as hud.ts (caller)
    participant Sim as Sim (offline, AFTER fix)

    Note over Sim: private actionBarLayoutRestoreServed = false
    HUD->>Sim: takeActionBarLayoutRestore() #1
    Sim-->>HUD: { source: 'noop' } (served flag set true)
    HUD->>Sim: takeActionBarLayoutRestore() #2
    Sim-->>HUD: undefined
```

## Screenshots / recordings

N/A. This is sim-only, test-covered logic with no visual surface.

---

## Checklist

### Quality

- [x] **The full gate passes.** Targeted checks green (`tsc --noEmit`, the affected Vitest files, `biome check` on changed files). Did not run the full heavy `npm run gate` in this pass since other agents share this machine concurrently; the orchestrator's CI run covers the full gate.

### Cross-platform

- [x] N/A. Sim-only logic change, no rendered surface, nothing to test on desktop/mobile viewports.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
