### PR TITLE
fix(render): rebuild far-LOD character material on skin change

### DIFF
--- a/src/render/characters/assets.ts
+++ b/src/render/characters/assets.ts
@@ -1013,14 +1013,25 @@ export function applyMaterials(
   });
 }
 
+/** Tint (and, since the materials are keyed 1:1 with `isBody`, skin) the far
+ *  LOD's baked source materials. `isBody` mirrors applyMaterials' own gate: a
+ *  skin/emissive atlas only ever replaces the character's own body texture,
+ *  never a baked-in weapon's (the far mesh includes the class default weapon
+ *  geometry too, see PreparedVisual.idleSrcMats), so the override is applied
+ *  per material rather than uniformly across the whole baked set. */
 export function tintedFarMaterials(
   def: VisualDef,
   entityColor: number,
   srcMats: THREE.Material[],
+  isBody: boolean[],
+  skinTex: THREE.Texture | null = null,
+  emisTex: THREE.Texture | null = null,
 ): THREE.Material[] {
   const tint = tintFor(def, entityColor);
   const strength = def.tintStrength ?? DEFAULT_TINT_STRENGTH;
-  return srcMats.map((m) => tintedMaterial(m, tint, strength));
+  return srcMats.map((m, i) =>
+    tintedMaterial(m, tint, strength, isBody[i] ? skinTex : null, isBody[i] ? emisTex : null),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -1040,6 +1051,10 @@ export interface PreparedVisual {
   idleGeo: THREE.BufferGeometry | null;
   /** source materials aligned with idleGeo groups */
   idleSrcMats: THREE.Material[];
+  /** parallel to idleSrcMats: whether that material belongs to the
+   *  character's own body (vs. a baked-in weapon), the same distinction
+   *  applyMaterials uses to gate the skin/emissive override */
+  idleSrcIsBody: boolean[];
   /** click-capsule radius in world units (from measured XZ body extents —
    *  long/wide creatures like wolves need far more than a humanoid sliver) */
   clickRadius: number;
@@ -1132,7 +1147,7 @@ export function prepareVisual(key: string): PreparedVisual {
     .multiply(new THREE.Matrix4().makeRotationY(def.yaw ?? 0))
     .multiply(new THREE.Matrix4().makeScale(normScale, normScale, normScale));
 
-  const { geo, mats } = bakeStaticPose(temp, norm);
+  const { geo, mats, isBody } = bakeStaticPose(temp, norm);
 
   const prep: PreparedVisual = {
     key,
@@ -1142,6 +1157,7 @@ export function prepareVisual(key: string): PreparedVisual {
     clips,
     idleGeo: geo,
     idleSrcMats: mats,
+    idleSrcIsBody: isBody,
     clickRadius,
   };
   prepared.set(key, prep);
@@ -1163,9 +1179,10 @@ function meshChainVisible(o: THREE.Object3D, stopAt: THREE.Object3D): boolean {
 function bakeStaticPose(
   root: THREE.Object3D,
   norm: THREE.Matrix4,
-): { geo: THREE.BufferGeometry | null; mats: THREE.Material[] } {
+): { geo: THREE.BufferGeometry | null; mats: THREE.Material[]; isBody: boolean[] } {
   const geos: THREE.BufferGeometry[] = [];
   const mats: THREE.Material[] = [];
+  const isBody: boolean[] = [];
   const v = new THREE.Vector3();
   const full = new THREE.Matrix4();
 
@@ -1205,9 +1222,10 @@ function bakeStaticPose(
     geos.push(out);
     // GLTFLoader emits one Mesh per primitive — materials are never arrays here
     mats.push(Array.isArray(mesh.material) ? mesh.material[0] : mesh.material);
+    isBody.push(!!mesh.userData.bodyMesh);
   });
 
-  if (geos.length === 0) return { geo: null, mats: [] };
+  if (geos.length === 0) return { geo: null, mats: [], isBody: [] };
   // uv presence must agree for merging — drop uvs entirely if any geo lacks them
   const allHaveUv = geos.every((g) => g.getAttribute('uv'));
   if (!allHaveUv) for (const g of geos) g.deleteAttribute('uv');
@@ -1216,5 +1234,5 @@ function bakeStaticPose(
     geo.clearGroups();
     geo.addGroup(0, geo.index ? geo.index.count : geo.getAttribute('position').count, 0);
   }
-  return { geo, mats };
+  return { geo, mats, isBody };
 }

--- a/src/render/characters/visual.ts
+++ b/src/render/characters/visual.ts
@@ -403,11 +403,20 @@ export class CharacterVisual {
       this.casters.push(mesh);
     });
 
-    // far LOD + shadow proxy share the baked idle-pose geometry per key
+    // far LOD + shadow proxy share the baked idle-pose geometry per key. Skin
+    // aware from the start (see applySkinMaterials): a character that spawns
+    // already wearing a non-default skin must not LOD out to the embedded one.
     if (prep.idleGeo) {
       this.farMesh = new THREE.Mesh(
         prep.idleGeo,
-        tintedFarMaterials(prep.def, entityColor, prep.idleSrcMats),
+        tintedFarMaterials(
+          prep.def,
+          entityColor,
+          prep.idleSrcMats,
+          prep.idleSrcIsBody,
+          skinTexture(key, skinIndex),
+          skinEmissiveTexture(key, skinIndex),
+        ),
       );
       this.farMaterials = this.farMesh.material;
       this.farMesh.visible = false;
@@ -1024,6 +1033,20 @@ export class CharacterVisual {
         mesh.name === 'class_halo' ? (this.haloBaseMaterial ?? mesh.material) : mesh.material;
       this.originalMaterials.set(mesh, original);
     });
+    // The far LOD mesh is a separate baked geometry (see the constructor):
+    // it needs its own skin-aware material rebuild or a distant player LOD
+    // pop reverts to the model's embedded default skin.
+    if (this.farMesh) {
+      const prep = prepareVisual(this.key);
+      this.farMaterials = tintedFarMaterials(
+        this.def,
+        this.entityColor,
+        prep.idleSrcMats,
+        prep.idleSrcIsBody,
+        skinTexture(this.key, skinIndex),
+        skinEmissiveTexture(this.key, skinIndex),
+      );
+    }
     this.applyVisualMaterials();
   }
 

--- a/tests/character_far_mesh_skin.test.ts
+++ b/tests/character_far_mesh_skin.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+// Bug: the far-LOD baked character mesh ignored the player's selected body
+// skin. tintedFarMaterials() baked this.farMaterials once in the
+// CharacterVisual constructor with no skin/emissive texture ever passed, and
+// setSkin() only rebuilt the near rig (applySkinMaterials only touched
+// this.model). A player wearing a non-default body skin visibly popped back
+// to the model's embedded default texture the instant the renderer's
+// distance LOD switched them onto the far mesh (~58-75yd band, see
+// showsStaticFarMesh in renderer.ts). This test drives the real
+// construction + setSkin path (mocked GLTF/texture loader only) and
+// compares the near-rig body mesh's texture against the far-mesh's texture
+// after a skin swap.
+import * as THREE from 'three';
+import { describe, expect, it, vi } from 'vitest';
+
+// player_paladin has no `show` allowlist (so a plain, non-skinned stub mesh
+// stays visible through assembleModel's accessory filter) and a real
+// alternate skin at index 1, matching the production data this bug hit.
+const VISUAL_KEY = 'player_paladin';
+
+function stubGltf() {
+  const scene = new THREE.Group();
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 2, 1), new THREE.MeshStandardMaterial());
+  mesh.name = 'body';
+  scene.add(mesh);
+  return { scene, animations: [new THREE.AnimationClip('Idle', 1, [])] };
+}
+
+describe('far-LOD mesh follows the selected body skin', () => {
+  it('rebuilds the far-mesh material from the current skin after setSkin', async () => {
+    vi.resetModules();
+    vi.doMock('../src/render/assets/loader', () => ({
+      loadGltf: vi.fn(() => Promise.resolve(stubGltf())),
+      loadHdr: vi.fn(() => new Promise(() => undefined)),
+      // Tag each loaded texture with the URL it came from so the test can
+      // tell the alternate-skin atlas apart from the embedded default.
+      loadTexture: vi.fn((url: string) =>
+        Promise.resolve(Object.assign(new THREE.Texture(), { name: url })),
+      ),
+      releaseGltf: vi.fn(),
+    }));
+    const { charactersReady, prepareVisual } = await import('../src/render/characters/assets');
+    await charactersReady();
+    const { CharacterVisual } = await import('../src/render/characters/visual');
+    const { SKINS } = await import('../src/render/characters/manifest');
+
+    const altSkinUrl = SKINS[VISUAL_KEY]?.[1];
+    expect(altSkinUrl).toBeTruthy();
+
+    const visual = new CharacterVisual(VISUAL_KEY, 0xffffff, 0);
+    visual.setSkin(1);
+
+    // Near rig: the equipped body mesh must show the alternate atlas.
+    let nearMap: THREE.Texture | null = null;
+    visual.root.traverse((o) => {
+      const mesh = o as THREE.Mesh;
+      if (mesh.isMesh && mesh.userData.bodyMesh) {
+        nearMap = (mesh.material as THREE.MeshStandardMaterial).map;
+      }
+    });
+    expect(nearMap).not.toBeNull();
+    expect((nearMap as unknown as THREE.Texture).name).toBe(altSkinUrl);
+
+    // Far LOD mesh: baked once per key, found by its shared (memoized)
+    // geometry. The shadow-only proxy mesh shares that SAME geometry (see
+    // the constructor), so match on the tinted-material array shape too:
+    // tintedFarMaterials always returns an array, while the shadow proxy's
+    // singleton shadowOnlyMat() is a lone, non-array material.
+    const prep = prepareVisual(VISUAL_KEY);
+    let farMaterial: THREE.Material | THREE.Material[] | undefined;
+    visual.root.traverse((o) => {
+      const mesh = o as THREE.Mesh;
+      if (mesh.isMesh && mesh.geometry === prep.idleGeo && Array.isArray(mesh.material)) {
+        farMaterial = mesh.material;
+      }
+    });
+    expect(farMaterial).toBeDefined();
+    const farMats = Array.isArray(farMaterial) ? farMaterial : [farMaterial];
+    expect(farMats.length).toBeGreaterThan(0);
+    const farMap = (farMats[0] as THREE.MeshStandardMaterial).map;
+
+    // This is the bug: the far mesh must match the near rig's selected skin,
+    // not the model's embedded default texture (map === null).
+    expect(farMap).not.toBeNull();
+    expect((farMap as unknown as THREE.Texture).name).toBe(altSkinUrl);
+
+    vi.doUnmock('../src/render/assets/loader');
+    vi.resetModules();
+  });
+});


### PR DESCRIPTION
## Summary

The far-LOD baked character mesh (used when the renderer switches a distant
entity to its cheap, static idle-pose proxy, roughly 58 to 75yd out) ignored
the player's selected body skin.

`tintedFarMaterials()` bakes `this.farMaterials` once, in the
`CharacterVisual` constructor, from the model's raw source materials, and
never received a skin or emissive texture at all. `setSkin()` (via
`applySkinMaterials()`) only rebuilt the near rig's materials on `this.model`;
it never touched `this.farMesh`. The result: a player wearing a non-default
body skin visibly popped back to the model's embedded default texture the
instant they crossed into the far LOD band.

### Fix

`tintedFarMaterials()` now accepts the same optional skin/emissive textures
`applyMaterials()` already does, gated per material by a new parallel
`isBody` flag on `PreparedVisual` (the far mesh's baked geometry also
includes the class's default weapon, via the same idle-pose bake, so the
skin override must only touch the body materials, exactly like
`applyMaterials()`'s existing `bodyMesh` gate: applying it uniformly would
have re-textured the baked-in weapon with the body atlas, a new bug).

Both the constructor (so a character that spawns already wearing a
non-default skin starts correct) and `applySkinMaterials()` (the `setSkin()`
path) now rebuild `this.farMaterials` from the current skin before handing
off to the existing ghost/shadowform/soul-rend overlay pass in
`applyVisualMaterials()`.

## Related issues

N/A (found by code audit, no existing issue).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/character_far_mesh_skin.test.ts tests/character_halo.test.ts tests/character_visual_fail_soft.test.ts tests/character_visual_pool_policy.test.ts tests/character_uv_dequantize.test.ts tests/architecture.test.ts tests/preview_appearance.test.ts tests/gfx.test.ts tests/visual_manifest.test.ts tests/char_skin_window.test.ts`
    -> 10 files, 109 tests, all passing.
  - `npx tsc --noEmit` -> clean, no errors.
  - `npx @biomejs/biome check --write src/render/characters/assets.ts src/render/characters/visual.ts tests/character_far_mesh_skin.test.ts` -> no errors, no format diffs (the pre-existing unrelated warnings it reported are outside the lines this PR touches).
- Manual steps:
  - Added `tests/character_far_mesh_skin.test.ts`, a jsdom test that drives the real construction + `setSkin()` code path (mocked GLTF/texture loader only, same pattern as `character_halo.test.ts`): it confirms the test fails for the right reason on the pre-fix code (far mesh's material `.map` stays `null` after `setSkin(1)`, while the near rig correctly shows the alternate atlas), then passes after the fix.

## Screenshots

Skipped, with reason: the far-LOD mesh only ever renders for *other* entities,
never the local player's own model (`renderer.ts` unconditionally forces
`v.isFar = false` for `isSelf`). Reproducing this live requires viewing a
second, custom-skinned player character from beyond the LOD threshold
(~58-75yd), which the offline single-player screenshot harness has no
reliable, scriptable way to stage (no other skinned player entity exists in
that mode at the needed distance). Rather than manufacture a misleading
capture, this PR relies on the jsdom unit test above, which exercises the
actual production code path deterministically.

## Root cause / fix flow

```mermaid
flowchart TD
    subgraph before["Before: far mesh baked once, blind to skin"]
        A1["CharacterVisual constructor"] --> A2["applyMaterials(model, skinTex) -- near rig OK"]
        A1 --> A3["tintedFarMaterials(def, color, idleSrcMats) -- no skin arg"]
        A3 --> A4["farMaterials baked with embedded default texture"]
        A5["setSkin(idx) -> applySkinMaterials(idx)"] --> A2b["applyMaterials(model, skinTex) -- near rig updates"]
        A5 -.->|"farMesh never touched"| A4
        A4 --> A6["LOD switch shows farMesh: default skin, not the player's pick"]
    end
    subgraph after["After: far mesh rebuilt from current skin"]
        B1["CharacterVisual constructor"] --> B2["applyMaterials(model, skinTex) -- near rig"]
        B1 --> B3["tintedFarMaterials(def, color, idleSrcMats, isBody, skinTex, emisTex)"]
        B3 --> B4["farMaterials: body mats get skinTex, weapon mats stay untouched"]
        B5["setSkin(idx) -> applySkinMaterials(idx)"] --> B2b["applyMaterials(model, skinTex) -- near rig"]
        B5 --> B3b["tintedFarMaterials(..., isBody, skinTex, emisTex) rebuilds farMaterials"]
        B3b --> B4b["applyVisualMaterials() applies farMaterials to farMesh, plus any overlay"]
        B4b --> B6["LOD switch shows farMesh matching the player's selected skin"]
    end
```

---

## Checklist

### Quality

- [x] **The full gate passes.** Ran the targeted `tsc`/`vitest`/`biome` commands above (green); did not run the full `npm run gate` since other agents are running concurrently on this machine and the task asked for a narrow, targeted verification pass.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A: no HUD/DOM surface touched; this is a Three.js material-baking fix with no CSS/layout/touch-target implications. Covered instead by the deterministic jsdom unit test.
- ~~Accessible.~~ N/A: no UI added or edited.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
