### PR TITLE
fix(sim): derive CLIMB_MIN_OVERHEAD from the vault ceiling constants

### DIFF
--- a/src/sim/climb.ts
+++ b/src/sim/climb.ts
@@ -17,10 +17,11 @@
 // Pure sim: no rng, no wall clock. `Sim.updatePlayerMovement` runs the driver
 // in its short-circuit chain and the renderer reads the same state to pose it.
 
-import { supportHeightAt } from './colliders';
+import { MANTLE_REACH, supportHeightAt } from './colliders';
 import { isRooted, isStunned } from './combat/cc';
 import { PLAYER_BODY_RADIUS } from './pathfind';
 import { findLedgeGrab, LEDGE_GRAB_MAX, LEDGE_GRAB_MIN } from './physics/ledge';
+import { GRAVITY, JUMP_VELOCITY } from './player_motion';
 import { DT, type Entity, type LedgeClimb } from './types';
 import { groundHeight } from './world';
 
@@ -45,13 +46,19 @@ const CLIMB_MAX_RISE_SPEED = 2.5;
 /**
  * The pull-up is for lips ABOVE YOUR HEAD: a ledge lower than this over the
  * floor the body is jumping from is silent-vault territory (the mantle
- * covers rises up to jump apex + MANTLE_REACH, about 1.83 from flat ground),
- * so a hop onto a crate or a bench never plays the full-body climb. Measured
- * against the floor DIRECTLY BENEATH the body at grab time, so chained
- * parkour (crate to canopy) also stays a quick vault while a ground-level
- * jump at the same canopy is a real climb.
+ * covers rises up to jump apex + MANTLE_REACH from flat ground), so a hop
+ * onto a crate or a bench never plays the full-body climb. Measured against
+ * the floor DIRECTLY BENEATH the body at grab time, so chained parkour
+ * (crate to canopy) also stays a quick vault while a ground-level jump at
+ * the same canopy is a real climb.
+ *
+ * Derived, not hand-tuned: it must always equal the true vault ceiling, or a
+ * band of lips the mantle can already reach gets forced into the scripted
+ * climb instead (this drifted once already, when MANTLE_REACH moved and this
+ * literal did not).
  */
-export const CLIMB_MIN_OVERHEAD = 1.8;
+const CLIMB_JUMP_APEX = (JUMP_VELOCITY * JUMP_VELOCITY) / (2 * GRAVITY);
+export const CLIMB_MIN_OVERHEAD = CLIMB_JUMP_APEX + MANTLE_REACH;
 
 const smooth = (t: number): number => {
   const c = Math.min(1, Math.max(0, t));

--- a/tests/climb.test.ts
+++ b/tests/climb.test.ts
@@ -229,6 +229,35 @@ describe('the climb move', () => {
     expect(p.climb).toBeNull();
   });
 
+  it('a lip inside the vault ceiling stays a silent vault, even below the stall roof ridge', () => {
+    // CLIMB_MIN_OVERHEAD must track the true vault ceiling (jump apex plus
+    // MANTLE_REACH): anything the silent vault already reaches should never
+    // be forced into the scripted climb. Probe a point partway up the stall
+    // canopy's pitched gable, well short of its 2.54 ridge, so the overhead
+    // above the floor lands inside vault reach.
+    const sz = SPOT.z + 2.2;
+    setActiveWorldContent(world({ stalls: [{ x: SPOT.x, z: sz, rot: 0, r: 1.7 }] }));
+    const bodyZ = sz - 0.6 - (R + 0.5);
+    const startY = groundHeight(SPOT.x, bodyZ, SEED) + 0.6;
+    const grab = findLedgeGrab(q(), SPOT.x, startY, bodyZ);
+    expect(grab).not.toBeNull();
+    if (!grab) return;
+    const floorY = Math.max(
+      groundHeight(SPOT.x, bodyZ, SEED),
+      supportHeightAt(SEED, SPOT.x, bodyZ, R, startY + 1e-3),
+    );
+    const overhead = grab.topY - floorY;
+    const apex = (JUMP_VELOCITY * JUMP_VELOCITY) / (2 * GRAVITY);
+    // Comfortably inside the vault ceiling, so the silent vault already
+    // carries the body up here without any scripted animation.
+    expect(overhead).toBeLessThan(apex + MANTLE_REACH);
+    expect(overhead).toBeGreaterThan(1); // clear of the step/vault floor too
+
+    const p = makeBody(SPOT.x, startY, bodyZ);
+    expect(tryStartClimb(p, SEED)).toBe(false);
+    expect(p.climb).toBeNull();
+  });
+
   it('drops the body when a stun lands mid-climb', () => {
     const cz = SPOT.z + 2.2;
     setActiveWorldContent(world({ stalls: [{ x: SPOT.x, z: cz, rot: Math.PI / 2, r: 1.7 }] }));
@@ -319,8 +348,11 @@ describe('the climb against real world geometry', () => {
     expect(crossHeight).toBeLessThanOrEqual(climbReach);
     // No dead band in the ladder: everything below the climb's above-the-head
     // floor is inside the silent vault's reach from flat ground, so gating
-    // the pull-up on tall lips never makes any height unreachable.
-    expect(CLIMB_MIN_OVERHEAD).toBeLessThanOrEqual(vaultReach);
+    // the pull-up on tall lips never makes any height unreachable. Pinned
+    // to the exact vault ceiling, not just "under it": a looser bound let
+    // CLIMB_MIN_OVERHEAD drift stale under a later MANTLE_REACH tune and
+    // still pass.
+    expect(CLIMB_MIN_OVERHEAD).toBeCloseTo(vaultReach, 6);
     // And the cross itself still earns the pull-up.
     expect(crossHeight).toBeGreaterThanOrEqual(CLIMB_MIN_OVERHEAD);
   });

--- a/tests/climb.test.ts
+++ b/tests/climb.test.ts
@@ -52,6 +52,24 @@ function findFlatSpot(): { x: number; z: number } {
 }
 
 const SPOT = findFlatSpot();
+
+// Stricter than findFlatSpot: an interior spot with a near-zero terrain grade,
+// for the one test below that reads an exact overhead value (not just whether
+// a collider is present) off a wide (dz -3..5) probe span.
+function findLevelSpot(): { x: number; z: number } {
+  for (let x = -40; x <= 40; x += 3) {
+    for (let z = -40; z <= 40; z += 3) {
+      if (terrainHeight(x, z, SEED) < WATER_LEVEL + 2) continue;
+      let ok = true;
+      for (let dz = -3; dz <= 5 && ok; dz += 1) {
+        if (terrainSteepnessAt(x, z + dz, SEED) > 0.3) ok = false;
+        if (isBlocked(SEED, x, z + dz, 2.2)) ok = false;
+      }
+      if (ok) return { x, z };
+    }
+  }
+  throw new Error('no level spot');
+}
 const q = (over: Partial<Parameters<typeof findLedgeGrab>[0]> = {}) => ({
   seed: SEED,
   radius: R,
@@ -235,16 +253,23 @@ describe('the climb move', () => {
     // be forced into the scripted climb. Probe a point partway up the stall
     // canopy's pitched gable, well short of its 2.54 ridge, so the overhead
     // above the floor lands inside vault reach.
-    const sz = SPOT.z + 2.2;
-    setActiveWorldContent(world({ stalls: [{ x: SPOT.x, z: sz, rot: 0, r: 1.7 }] }));
+    //
+    // The shared SPOT fixture (used everywhere else in this file, where only
+    // "flat enough to be collider-free" matters) can resolve to a spot with a
+    // subtle residual terrain grade that this probe is sensitive to (it reads
+    // an exact overhead value, not just presence/absence of a collider), so
+    // this one test finds its own interior, near-zero-grade spot instead.
+    const spot = findLevelSpot();
+    const sz = spot.z + 2.2;
+    setActiveWorldContent(world({ stalls: [{ x: spot.x, z: sz, rot: 0, r: 1.7 }] }));
     const bodyZ = sz - 0.6 - (R + 0.5);
-    const startY = groundHeight(SPOT.x, bodyZ, SEED) + 0.6;
-    const grab = findLedgeGrab(q(), SPOT.x, startY, bodyZ);
+    const startY = groundHeight(spot.x, bodyZ, SEED) + 0.6;
+    const grab = findLedgeGrab(q(), spot.x, startY, bodyZ);
     expect(grab).not.toBeNull();
     if (!grab) return;
     const floorY = Math.max(
-      groundHeight(SPOT.x, bodyZ, SEED),
-      supportHeightAt(SEED, SPOT.x, bodyZ, R, startY + 1e-3),
+      groundHeight(spot.x, bodyZ, SEED),
+      supportHeightAt(SEED, spot.x, bodyZ, R, startY + 1e-3),
     );
     const overhead = grab.topY - floorY;
     const apex = (JUMP_VELOCITY * JUMP_VELOCITY) / (2 * GRAVITY);
@@ -253,7 +278,7 @@ describe('the climb move', () => {
     expect(overhead).toBeLessThan(apex + MANTLE_REACH);
     expect(overhead).toBeGreaterThan(1); // clear of the step/vault floor too
 
-    const p = makeBody(SPOT.x, startY, bodyZ);
+    const p = makeBody(spot.x, startY, bodyZ);
     expect(tryStartClimb(p, SEED)).toBe(false);
     expect(p.climb).toBeNull();
   });


### PR DESCRIPTION
## Summary

`CLIMB_MIN_OVERHEAD` (the height above the floor a ledge must clear before the
scripted climb pull-up plays instead of a silent vault) was a hand-derived
literal, `1.8`, matched to an old `MANTLE_REACH` of `0.7` (vault ceiling =
jump apex + `MANTLE_REACH` ~= 1.83). PR #2545 later raised `MANTLE_REACH` to
`0.9` to fix an airborne pass-over gap (the true vault ceiling is now
`apex + MANTLE_REACH` = `2.025`), but never revisited `src/sim/climb.ts`.

That left a band, `(1.8, 2.025)`, where a ledge's overhead is already inside
the silent vault's reach (the mantle can carry the body straight over it) but
`CLIMB_MIN_OVERHEAD`'s stale threshold still forced the full scripted
pull-up. Confirmed against real content: a market-stall canopy's pitched
gable crosses this exact band partway up its slope.

## Fix

`CLIMB_MIN_OVERHEAD` is now computed from the same constants that define the
vault ceiling (`JUMP_VELOCITY`, `GRAVITY`, `MANTLE_REACH`) instead of a
hardcoded literal, so it can never drift out of sync with `MANTLE_REACH`
again. Also tightened the existing `toBeLessThanOrEqual` assertion in
`tests/climb.test.ts` (which passed even with the stale 1.8 value) to an
exact `toBeCloseTo` pin, so a future `MANTLE_REACH` tune cannot silently
reopen this gap.

No import-cycle risk: `src/sim/player_motion.ts` (source of `JUMP_VELOCITY`/
`GRAVITY`) does not import `src/sim/climb.ts`, and the only importer of
`climb.ts` is `src/sim/sim.ts`.

## Related issues

No existing issue; found by fresh code audit during a bug-discovery sweep.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How was this tested

- `npx tsc --noEmit` from the worktree root: no type errors.
- `npx vitest run tests/climb.test.ts`: added a new failing-first regression
  test (`a lip inside the vault ceiling stays a silent vault, even below the
  stall roof ridge`) that probes a point partway up the stall canopy's
  pitched gable where the overhead lands at ~1.886 (inside the stale-vs-fixed
  gap band). Confirmed it failed against the unfixed code (`tryStartClimb`
  wrongly returned `true`), then confirmed all 21 tests in the file pass
  after the fix.
- `npx vitest run tests/parkour.test.ts tests/physics_character.test.ts
  tests/player_motion.test.ts tests/architecture.test.ts`: 89 tests passed
  (no regression in the surrounding movement/physics suites).
- `npx vitest run tests/world_api_parity.test.ts`: 270 tests passed (no
  `IWorld` surface touched).
- `npx vitest run tests/parity`: 186 passed, 1 skipped (no golden-trace
  drift from the constant change).
- `npx vitest run tests/dungeon_parkour.test.ts tests/climb_slope.test.ts
  tests/town_collision.test.ts tests/physics_audit_world.test.ts`: 51 tests
  passed (other suites exercising the same collider/climb geometry).
- `npx @biomejs/biome check --write src/sim/climb.ts tests/climb.test.ts`:
  no issues, no fixes needed.

## Screenshots

Skipped. This is a low-severity change to an internal traversal-gating
constant: the visible difference is only whether a ~0.5-0.65s scripted
pull-up animation plays versus an instant silent pass-over, both ending with
the player standing in the same spot. Reliably reproducing it live requires
positioning the player within a fraction of a yard of a specific point along
a stall canopy's pitched gable AND facing within a tight tolerance; the only
teleport dev command (`/dev tp x z`) does not set facing, and mouse-driven
facing control in a scripted browser cannot hit the needed precision. A
before/after screenshot pair built any other way would not honestly capture
the two code paths, so it is omitted per the "genuinely impractical" escape
hatch rather than manufacture a misleading one. The fix is instead pinned by
the exact-value test above and the geometry check against real content.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not applicable, no public docs describe this internal constant)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published (not applicable)

## Root cause diagram

```mermaid
flowchart TD
    A["PR #2545: raise MANTLE_REACH 0.7 -> 0.9\n(fix airborne pass-over gap)"] --> B["colliders.ts MANTLE_REACH = 0.9\nvault ceiling = apex + MANTLE_REACH = 2.025"]
    A -.never touched.-> C["climb.ts CLIMB_MIN_OVERHEAD = 1.8\n(hand-derived from the OLD 0.7 mantle)"]
    B --> D{"ledge overhead vs floor"}
    C --> D
    D -->|"overhead < 1.8"| E["silent vault (mantle pass-over)\ncorrect either way"]
    D -->|"1.8 <= overhead < 2.025"| F["BUG: forced scripted climb\neven though the mantle already reaches it"]
    D -->|"overhead >= 2.025"| G["scripted climb\ncorrect either way"]

    H["FIX: CLIMB_MIN_OVERHEAD =\napex + MANTLE_REACH (derived)"] -.replaces literal 1.8.-> C
    H --> I["1.8..2.025 band collapses:\nCLIMB_MIN_OVERHEAD now equals\nthe true vault ceiling"]
```
