### PR TITLE
fix(ui): give the vendor window non-trapping focus capture and return

### DIFF
--- a/src/ui/focus_manager.ts
+++ b/src/ui/focus_manager.ts
@@ -76,6 +76,14 @@ export interface FocusTrapHandle {
    * recorded opener (the old restoreFocus behavior).
    */
   release(returnFocus?: boolean): void;
+  /**
+   * The element recorded as this trap's opener (what release() would restore focus
+   * to). Exposed so a successor window opened FROM WITHIN the trapped window (e.g.
+   * quest dialog -> vendor) can hand its own opener chain forward instead of
+   * capturing an element inside the trap's own subtree, which is about to be
+   * hidden and would fail canFocus by the time the successor closes.
+   */
+  opener(): HTMLElement | null;
 }
 
 interface TrapState {
@@ -158,6 +166,7 @@ export class FocusManager {
         if (this.stack.length === 0) this.stopListening();
         if (returnFocus) this.restore(state.opener);
       },
+      opener: () => state.opener,
     };
   }
 

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1803,8 +1803,8 @@ export class Hud {
       itemTooltip: (item, instance?: ItemInstancePayload) => this.itemTooltip(item, true, instance),
       attachTooltip: (element, html) => this.attachTooltip(element, html),
       openChronicles: () => this.openDeeds('chronicle'),
-      openVendor: (npcId) => this.openVendor(npcId),
-      openHeroicVendor: (npcId) => this.openHeroicVendor(npcId),
+      openVendor: (npcId, opener) => this.openVendor(npcId, opener),
+      openHeroicVendor: (npcId, opener) => this.openHeroicVendor(npcId, opener),
       openTrain: (npcId) => this.openTrain(npcId),
       openUnbind: (npcId) => this.openUnbind(npcId),
       openMarket: () => this.openMarket(),
@@ -12702,7 +12702,14 @@ export class Hud {
   // Vendor
   // -------------------------------------------------------------------------
 
-  openVendor(npcId: number): void {
+  // opener: the element to return focus to on close. Reachable from the quest
+  // dialog's "Browse Goods" route, which hides #quest-dialog (display:none)
+  // BEFORE calling this, so document.activeElement would already be
+  // disconnected from layout by the time activeFocusable() ran here; the
+  // caller must capture it beforehand and hand it in. Omitted (not merely
+  // null) falls back to activeFocusable() for any other opener whose element
+  // is still visible/connected at call time.
+  openVendor(npcId: number, opener?: HTMLElement | null): void {
     this.closeOtherWindows(['#vendor-window', '#bags']);
     // The bags companion is exclusive (see openBank): close the bank cluster
     // through the painter so onBankClosed clears body.bank-open before the
@@ -12712,7 +12719,7 @@ export class Hud {
     // Non-trapping focus capture/return (WCAG 2.4.3), matching the bank
     // companion: NOT windowFocus, which would install a Tab trap and break
     // the vendor + bags cluster.
-    this.vendorOpenerFocus = this.focusManager.activeFocusable();
+    this.vendorOpenerFocus = opener !== undefined ? opener : this.focusManager.activeFocusable();
     this.openVendorNpcId = npcId;
     document.body.classList.add('vendor-open');
     this.renderVendor();
@@ -12764,7 +12771,9 @@ export class Hud {
     );
   }
 
-  openHeroicVendor(npcId: number): void {
+  // opener: see openVendor's comment; same handoff need for the Heroic
+  // Quartermaster route out of the quest dialog.
+  openHeroicVendor(npcId: number, opener?: HTMLElement | null): void {
     this.closeOtherWindows('#vendor-window');
     // The bags companion is exclusive (see openBank): close the bank cluster
     // through the painter so onBankClosed clears body.bank-open before the
@@ -12774,7 +12783,7 @@ export class Hud {
     // Non-trapping focus capture/return (WCAG 2.4.3), matching the bank
     // companion: NOT windowFocus, which would install a Tab trap and break
     // the vendor + bags cluster.
-    this.vendorOpenerFocus = this.focusManager.activeFocusable();
+    this.vendorOpenerFocus = opener !== undefined ? opener : this.focusManager.activeFocusable();
     this.openHeroicVendorNpcId = npcId;
     this.renderHeroicVendor();
   }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -12819,6 +12819,13 @@ export class Hud {
   }
 
   closeVendor(): void {
+    // Guard, matching closeHeroicVendor: closeManagedWindow('vendor-window') calls both
+    // close methods unconditionally since either tenant can hold the shared container, so
+    // this must be a no-op when the copper vendor isn't the one open. Otherwise this still
+    // ran when only the heroic tenant was open, clearing the shared vendorOpenerFocus (and
+    // firing hideTooltip/mobile-bags teardown) before closeHeroicVendor got a chance to
+    // restore it, dropping the WCAG 2.4.3 focus return on the Esc/generic close path.
+    if (this.openVendorNpcId === null) return;
     const closeMobileBags =
       document.body.classList.contains('mobile-touch') && $('#bags').style.display !== 'none';
     $('#vendor-window').style.display = 'none';

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1384,6 +1384,12 @@ export class Hud {
     startRace: () => this.sim.mountRaceStart(),
     cancelRace: () => this.sim.mountRaceCancel(),
   });
+  // Non-trapping focus capture/return for the shared #vendor-window container
+  // (the bank companion shape, NOT windowFocus's Tab trap: vendor is a bags
+  // companion, not modal). One field covers both tenants (the copper vendor
+  // and the Heroic Quartermaster), since they share the container and are
+  // mutually exclusive.
+  private vendorOpenerFocus: HTMLElement | null = null;
   private openTrainNpcId: number | null = null;
   // Learn flights + confirmed-grant overlay for the train window (issue
   // #2342): begin on click (the double-submit guard), resolve on the
@@ -12703,6 +12709,10 @@ export class Hud {
     // vendor pairing takes over.
     if (this.bankWindowOpen) this.closeBank();
     this.openHeroicVendorNpcId = null; // the marks shop shares the container
+    // Non-trapping focus capture/return (WCAG 2.4.3), matching the bank
+    // companion: NOT windowFocus, which would install a Tab trap and break
+    // the vendor + bags cluster.
+    this.vendorOpenerFocus = this.focusManager.activeFocusable();
     this.openVendorNpcId = npcId;
     document.body.classList.add('vendor-open');
     this.renderVendor();
@@ -12761,6 +12771,10 @@ export class Hud {
     // marks shop takes the container.
     if (this.bankWindowOpen) this.closeBank();
     this.openVendorNpcId = null; // shares the container with the copper vendor
+    // Non-trapping focus capture/return (WCAG 2.4.3), matching the bank
+    // companion: NOT windowFocus, which would install a Tab trap and break
+    // the vendor + bags cluster.
+    this.vendorOpenerFocus = this.focusManager.activeFocusable();
     this.openHeroicVendorNpcId = npcId;
     this.renderHeroicVendor();
   }
@@ -12790,6 +12804,9 @@ export class Hud {
     $('#vendor-window').style.display = 'none';
     this.openHeroicVendorNpcId = null;
     this.hideTooltip();
+    // Return focus to the opener (WCAG 2.4.3); mirrors closeVendor below.
+    this.focusManager.restore(this.vendorOpenerFocus);
+    this.vendorOpenerFocus = null;
   }
 
   closeVendor(): void {
@@ -12799,6 +12816,10 @@ export class Hud {
     this.openVendorNpcId = null;
     document.body.classList.remove('vendor-open'); // bags (if still open) re-centres
     this.hideTooltip();
+    // Return focus to the opener (WCAG 2.4.3); non-trapping, matching the bank
+    // companion (no Tab trap was ever installed for vendor).
+    this.focusManager.restore(this.vendorOpenerFocus);
+    this.vendorOpenerFocus = null;
     if (closeMobileBags) {
       // Mirror BagsWindow.close()'s teardown backstop: a discard/sell prompt may hold
       // #bags inert (installPromptDialog) and this mobile path hides the grid without

--- a/src/ui/hud/quest/quest_dialog_controller.ts
+++ b/src/ui/hud/quest/quest_dialog_controller.ts
@@ -53,10 +53,13 @@ export interface QuestDialogControllerDeps {
   itemTooltip(item: ItemDef): string;
   attachTooltip(element: HTMLElement, html: () => string): void;
   openChronicles(): void;
-  // opener: the pre-close active element, handed in because bindRoute hides
-  // #quest-dialog (display:none) before calling this; an activeFocusable()
-  // read taken afterward would find nothing focusable and the WCAG 2.4.3
-  // return-to-opener chain would silently drop to <body>.
+  // opener: this dialog's own trap opener (the element that opened the quest
+  // dialog, e.g. the world interact prompt), handed in because bindRoute hides
+  // #quest-dialog (display:none) before calling this; the in-dialog button that
+  // was clicked would itself be inside the now-hidden subtree by close time,
+  // and an activeFocusable() read taken afterward would find nothing focusable
+  // either way, so the WCAG 2.4.3 return-to-opener chain would silently drop
+  // to <body> without an explicit, still-live element handed in.
   openVendor(npcId: number, opener?: HTMLElement | null): void;
   openHeroicVendor(npcId: number, opener?: HTMLElement | null): void;
   openTrain(npcId: number): void;
@@ -608,14 +611,17 @@ export class QuestDialogController {
 
   private bindRoute(selector: string, open: (opener: HTMLElement | null) => void): void {
     this.deps.element.querySelector(selector)?.addEventListener('click', () => {
-      // Capture the still-connected, still-visible active element BEFORE
-      // close(false) hides #quest-dialog: once hidden, its subtree fails
-      // FocusManager.canFocus (getClientRects().length === 0), so a capture
-      // taken after the hide would always resolve to null. See openVendor's
-      // deps comment for why the successor window needs this handed in.
-      const active = this.deps.document.activeElement;
-      const opener =
-        active instanceof HTMLElement && active !== this.deps.document.body ? active : null;
+      // Hand the successor window this dialog's OWN trap opener, not the active
+      // element inside #quest-dialog: close(false) hides the dialog, and by the
+      // time the successor closes, an in-dialog button lives inside a
+      // display:none subtree and fails FocusManager.canFocus (getClientRects()
+      // is empty), so the return-to-opener chain would silently drop to <body>.
+      // The trap's own opener (what focused the dialog before it opened) is a
+      // sibling element outside the dialog, so it stays live and visible after
+      // close(false), the same way openBank()'s live side-rail button does. See
+      // openVendor's deps comment for why the successor window needs this
+      // handed in explicitly rather than reading activeFocusable() itself.
+      const opener = this.trap?.opener() ?? null;
       this.close(false);
       open(opener);
     });

--- a/src/ui/hud/quest/quest_dialog_controller.ts
+++ b/src/ui/hud/quest/quest_dialog_controller.ts
@@ -53,8 +53,12 @@ export interface QuestDialogControllerDeps {
   itemTooltip(item: ItemDef): string;
   attachTooltip(element: HTMLElement, html: () => string): void;
   openChronicles(): void;
-  openVendor(npcId: number): void;
-  openHeroicVendor(npcId: number): void;
+  // opener: the pre-close active element, handed in because bindRoute hides
+  // #quest-dialog (display:none) before calling this; an activeFocusable()
+  // read taken afterward would find nothing focusable and the WCAG 2.4.3
+  // return-to-opener chain would silently drop to <body>.
+  openVendor(npcId: number, opener?: HTMLElement | null): void;
+  openHeroicVendor(npcId: number, opener?: HTMLElement | null): void;
   openTrain(npcId: number): void;
   openUnbind(npcId: number): void;
   openMarket(): void;
@@ -393,8 +397,8 @@ export class QuestDialogController {
         item.disabled = true;
       });
     });
-    this.bindRoute('[data-vendor]', () => this.deps.openVendor(npc.id));
-    this.bindRoute('[data-heroic-shop]', () => this.deps.openHeroicVendor(npc.id));
+    this.bindRoute('[data-vendor]', (opener) => this.deps.openVendor(npc.id, opener));
+    this.bindRoute('[data-heroic-shop]', (opener) => this.deps.openHeroicVendor(npc.id, opener));
     this.bindRoute('[data-train]', () => this.deps.openTrain(npc.id));
     this.bindRoute('[data-unbind]', () => this.deps.openUnbind(npc.id));
     this.bindRoute('[data-market]', this.deps.openMarket);
@@ -602,10 +606,18 @@ export class QuestDialogController {
     );
   }
 
-  private bindRoute(selector: string, open: () => void): void {
+  private bindRoute(selector: string, open: (opener: HTMLElement | null) => void): void {
     this.deps.element.querySelector(selector)?.addEventListener('click', () => {
+      // Capture the still-connected, still-visible active element BEFORE
+      // close(false) hides #quest-dialog: once hidden, its subtree fails
+      // FocusManager.canFocus (getClientRects().length === 0), so a capture
+      // taken after the hide would always resolve to null. See openVendor's
+      // deps comment for why the successor window needs this handed in.
+      const active = this.deps.document.activeElement;
+      const opener =
+        active instanceof HTMLElement && active !== this.deps.document.body ? active : null;
       this.close(false);
-      open();
+      open(opener);
     });
   }
 

--- a/tests/bank_window.test.ts
+++ b/tests/bank_window.test.ts
@@ -197,7 +197,7 @@ describe('bank_window: hud.ts wiring', () => {
       /openBank\(\): void \{[\s\S]{0,600}?if \(this\.vendorOpen\) this\.closeVendor\(\);[\s\S]{0,600}?classList\.add\('bank-open'\)/,
     );
     expect(hud).toMatch(
-      /openVendor\(npcId: number\): void \{[\s\S]{0,600}?if \(this\.bankWindowOpen\) this\.closeBank\(\);/,
+      /openVendor\(npcId: number, opener\?: HTMLElement \| null\): void \{[\s\S]{0,600}?if \(this\.bankWindowOpen\) this\.closeBank\(\);/,
     );
   });
 
@@ -208,7 +208,7 @@ describe('bank_window: hud.ts wiring', () => {
     // arms need their own wiring or the two windows overlap and the mobile
     // cluster-close precedence strands the bank at half-width with its x-btn hidden.
     expect(hud).toMatch(
-      /openHeroicVendor\(npcId: number\): void \{[\s\S]{0,600}?if \(this\.bankWindowOpen\) this\.closeBank\(\);/,
+      /openHeroicVendor\(npcId: number, opener\?: HTMLElement \| null\): void \{[\s\S]{0,600}?if \(this\.bankWindowOpen\) this\.closeBank\(\);/,
     );
     expect(hud).toMatch(
       /openBank\(\): void \{[\s\S]{0,600}?if \(this\.openHeroicVendorNpcId !== null\) this\.closeHeroicVendor\(\);[\s\S]{0,600}?classList\.add\('bank-open'\)/,

--- a/tests/delve_board_controller.test.ts
+++ b/tests/delve_board_controller.test.ts
@@ -49,7 +49,7 @@ function makeHarness(validNpc = true) {
   } as unknown as IWorld;
   const focusFirst = vi.fn();
   const release = vi.fn();
-  const trap: FocusTrapHandle = { focusFirst, release };
+  const trap: FocusTrapHandle = { focusFirst, release, opener: vi.fn(() => null) };
   const openFocusTrap = vi.fn(() => trap);
   const closeOtherWindows = vi.fn();
   const hideTooltip = vi.fn();

--- a/tests/lockpick_controller.test.ts
+++ b/tests/lockpick_controller.test.ts
@@ -38,7 +38,7 @@ function harness(initialState: LockpickView | null = null) {
   const keyboard = new FakeWindow(1280, 720);
   const focusFirst = vi.fn();
   const release = vi.fn();
-  const trap: FocusTrapHandle = { focusFirst, release };
+  const trap: FocusTrapHandle = { focusFirst, release, opener: vi.fn(() => null) };
   const openFocusTrap = vi.fn(() => trap);
   const engage = vi.fn();
   const act = vi.fn();

--- a/tests/lockpick_managed_close.test.ts
+++ b/tests/lockpick_managed_close.test.ts
@@ -80,7 +80,7 @@ function harness(initial: LockpickView | null, host: 'online' | 'offline' = 'onl
     '<div id="lockpick-panel" class="window panel" style="display:none"></div>';
   const panel = document.getElementById('lockpick-panel') as HTMLElement;
   const release = vi.fn();
-  const trap: FocusTrapHandle = { focusFirst: vi.fn(), release };
+  const trap: FocusTrapHandle = { focusFirst: vi.fn(), release, opener: vi.fn(() => null) };
   // Two spies for ATTRIBUTION only. Production wires the dep as
   // `hideTooltip: () => this.hideTooltip()` where the controller is built, so in the client
   // these ARE one call; splitting them here lets a case say which caller owed the hide, and

--- a/tests/mobile_more_dialog.test.ts
+++ b/tests/mobile_more_dialog.test.ts
@@ -16,7 +16,7 @@ describe('MobileMoreDialogController', () => {
     const dialog = element();
     const focusFirst = vi.fn();
     const release = vi.fn();
-    const handle = { focusFirst, release } satisfies FocusTrapHandle;
+    const handle = { focusFirst, release, opener: vi.fn(() => null) } satisfies FocusTrapHandle;
     const open = vi.fn((_options: FocusTrapOptions) => handle);
     const controller = new MobileMoreDialogController({ open } as Pick<FocusManager, 'open'>, {
       trigger: () => trigger,
@@ -47,7 +47,11 @@ describe('MobileMoreDialogController', () => {
     const trigger = element();
     const dialog = element();
     const release = vi.fn();
-    const handle = { focusFirst: vi.fn(), release } satisfies FocusTrapHandle;
+    const handle = {
+      focusFirst: vi.fn(),
+      release,
+      opener: vi.fn(() => null),
+    } satisfies FocusTrapHandle;
     const controller = new MobileMoreDialogController(
       { open: vi.fn((_options: FocusTrapOptions) => handle) },
       { trigger: () => trigger, dialog: () => dialog },

--- a/tests/player_card_controller.test.ts
+++ b/tests/player_card_controller.test.ts
@@ -71,7 +71,7 @@ function harness() {
   const captureCloseup = vi.fn(async () => document.createElement('canvas'));
   const focusFirst = vi.fn();
   const release = vi.fn();
-  const trap: FocusTrapHandle = { focusFirst, release };
+  const trap: FocusTrapHandle = { focusFirst, release, opener: vi.fn(() => null) };
   const options = {
     refreshBalance: vi.fn(),
     showWallet: vi.fn(() => true),

--- a/tests/quest_dialog_controller.test.ts
+++ b/tests/quest_dialog_controller.test.ts
@@ -352,8 +352,10 @@ describe('QuestDialogController', () => {
     vendorNpc.vendorItems = ['minor_healing_potion'];
     const vendor = harness(vendorNpc);
     vendor.controller.open(vendorNpc.id);
-    vendor.element.querySelector<HTMLButtonElement>('[data-vendor]')?.click();
-    expect(vendor.openVendor).toHaveBeenCalledWith(vendorNpc.id);
+    const vendorButton = vendor.element.querySelector<HTMLButtonElement>('[data-vendor]');
+    vendorButton?.focus();
+    vendorButton?.click();
+    expect(vendor.openVendor).toHaveBeenCalledWith(vendorNpc.id, vendorButton);
     expect(vendor.release).toHaveBeenCalledWith(false);
 
     const marketId = Object.values(NPCS).find((definition) => definition.market)?.id;
@@ -367,8 +369,10 @@ describe('QuestDialogController', () => {
 
     const heroic = harness(npc(42, heroicId));
     heroic.controller.open(42);
-    heroic.element.querySelector<HTMLButtonElement>('[data-heroic-shop]')?.click();
-    expect(heroic.openHeroicVendor).toHaveBeenCalledWith(42);
+    const heroicButton = heroic.element.querySelector<HTMLButtonElement>('[data-heroic-shop]');
+    heroicButton?.focus();
+    heroicButton?.click();
+    expect(heroic.openHeroicVendor).toHaveBeenCalledWith(42, heroicButton);
 
     const boardNpcId = DELVES.collapsed_reliquary.boardNpcId;
     const board = harness(npc(43, boardNpcId));
@@ -385,6 +389,35 @@ describe('QuestDialogController', () => {
     cardMaster.controller.open(45);
     cardMaster.element.querySelector<HTMLButtonElement>('[data-card-duel]')?.click();
     expect(cardMaster.openCardDuel).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures the opener BEFORE hiding the dialog, so a successor window can restore focus (WCAG 2.4.3)', () => {
+    // Regression for the review finding on PR #2619: bindRoute used to call
+    // close(false) (which sets #quest-dialog to display:none) BEFORE calling
+    // open(), so a capture taken inside openVendor via
+    // FocusManager.activeFocusable() would always see a disconnected,
+    // display:none ancestor and resolve to null. The real fix is that
+    // QuestDialogController itself reads document.activeElement while the
+    // dialog (and the clicked button) is still visible, and hands that
+    // element to openVendor/openHeroicVendor directly, so the successor
+    // window's own focusManager.restore() has something to return to.
+    const vendorNpc = npc(50, ordinaryNpcId());
+    vendorNpc.vendorItems = ['minor_healing_potion'];
+    const test = harness(vendorNpc);
+    test.controller.open(vendorNpc.id);
+    const vendorButton = test.element.querySelector<HTMLButtonElement>('[data-vendor]');
+    expect(vendorButton).not.toBeNull();
+    vendorButton?.focus();
+    expect(test.document.activeElement).toBe(vendorButton);
+
+    vendorButton?.click();
+
+    // The dialog is hidden by the time openVendor is invoked...
+    expect(test.element.style.display).toBe('none');
+    // ...but openVendor still received the live button reference, captured
+    // before the hide, not null.
+    expect(test.openVendor).toHaveBeenCalledWith(vendorNpc.id, vendorButton);
+    expect(test.openVendor.mock.calls[0][1]).not.toBeNull();
   });
 
   it('a station master offers the Train option and routes it to openTrain', () => {

--- a/tests/quest_dialog_controller.test.ts
+++ b/tests/quest_dialog_controller.test.ts
@@ -71,7 +71,15 @@ function harness(entity = npc(10, ordinaryNpcId()), questState = 'available') {
   } as unknown as IWorld;
   const release = vi.fn();
   const focusFirst = vi.fn();
-  const trap: FocusTrapHandle = { release, focusFirst };
+  // The element the dialog's OWN focus trap recorded as ITS opener (e.g. the
+  // world interact prompt that opened the quest dialog): stays connected and
+  // visible outside #quest-dialog, unlike a button inside the dialog, which
+  // close(false) hides before a successor window's restore() would run.
+  const trapOpener = document.createElement('button');
+  trapOpener.id = 'world-interact-prompt';
+  document.body.appendChild(trapOpener);
+  const trapOpenerFn = vi.fn(() => trapOpener as HTMLElement | null);
+  const trap: FocusTrapHandle = { release, focusFirst, opener: trapOpenerFn };
   const voice = {
     play: vi.fn(),
     isPlaying: vi.fn(() => true),
@@ -139,6 +147,8 @@ function harness(entity = npc(10, ordinaryNpcId()), questState = 'available') {
     reportTelemetry,
     release,
     focusFirst,
+    trapOpener,
+    trapOpenerFn,
     voice,
     openChronicles,
     openVendor,
@@ -355,7 +365,7 @@ describe('QuestDialogController', () => {
     const vendorButton = vendor.element.querySelector<HTMLButtonElement>('[data-vendor]');
     vendorButton?.focus();
     vendorButton?.click();
-    expect(vendor.openVendor).toHaveBeenCalledWith(vendorNpc.id, vendorButton);
+    expect(vendor.openVendor).toHaveBeenCalledWith(vendorNpc.id, vendor.trapOpener);
     expect(vendor.release).toHaveBeenCalledWith(false);
 
     const marketId = Object.values(NPCS).find((definition) => definition.market)?.id;
@@ -372,7 +382,7 @@ describe('QuestDialogController', () => {
     const heroicButton = heroic.element.querySelector<HTMLButtonElement>('[data-heroic-shop]');
     heroicButton?.focus();
     heroicButton?.click();
-    expect(heroic.openHeroicVendor).toHaveBeenCalledWith(42, heroicButton);
+    expect(heroic.openHeroicVendor).toHaveBeenCalledWith(42, heroic.trapOpener);
 
     const boardNpcId = DELVES.collapsed_reliquary.boardNpcId;
     const board = harness(npc(43, boardNpcId));
@@ -391,16 +401,18 @@ describe('QuestDialogController', () => {
     expect(cardMaster.openCardDuel).toHaveBeenCalledTimes(1);
   });
 
-  it('captures the opener BEFORE hiding the dialog, so a successor window can restore focus (WCAG 2.4.3)', () => {
-    // Regression for the review finding on PR #2619: bindRoute used to call
-    // close(false) (which sets #quest-dialog to display:none) BEFORE calling
-    // open(), so a capture taken inside openVendor via
-    // FocusManager.activeFocusable() would always see a disconnected,
-    // display:none ancestor and resolve to null. The real fix is that
-    // QuestDialogController itself reads document.activeElement while the
-    // dialog (and the clicked button) is still visible, and hands that
-    // element to openVendor/openHeroicVendor directly, so the successor
-    // window's own focusManager.restore() has something to return to.
+  it("hands the successor window the DIALOG TRAP's own opener, not the in-dialog button (WCAG 2.4.3)", () => {
+    // Regression for the second review finding on PR #2619: the first fix
+    // captured document.activeElement (the in-dialog gossip button) BEFORE
+    // close(false) hid #quest-dialog, but that button still lives INSIDE the
+    // dialog's own subtree, so by the time the successor window's
+    // focusManager.restore() runs later (after close(false) has taken
+    // effect), the button fails FocusManager.canFocus (display:none ancestor,
+    // getClientRects().length === 0) and focus still falls to <body>. The
+    // real fix hands the successor the quest dialog's OWN trap opener
+    // instead: a sibling element outside the dialog (e.g. the world interact
+    // prompt) that stays connected and visible for the whole time the vendor
+    // window is open, exactly like openBank()'s live side-rail button.
     const vendorNpc = npc(50, ordinaryNpcId());
     vendorNpc.vendorItems = ['minor_healing_potion'];
     const test = harness(vendorNpc);
@@ -414,10 +426,19 @@ describe('QuestDialogController', () => {
 
     // The dialog is hidden by the time openVendor is invoked...
     expect(test.element.style.display).toBe('none');
-    // ...but openVendor still received the live button reference, captured
-    // before the hide, not null.
-    expect(test.openVendor).toHaveBeenCalledWith(vendorNpc.id, vendorButton);
-    expect(test.openVendor.mock.calls[0][1]).not.toBeNull();
+    // ...openVendor received the trap's OWN opener, read from the trap
+    // handle rather than document.activeElement...
+    expect(test.trapOpenerFn).toHaveBeenCalled();
+    expect(test.openVendor).toHaveBeenCalledWith(vendorNpc.id, test.trapOpener);
+    // ...and, unlike the in-dialog button, that element sits OUTSIDE the
+    // hidden #quest-dialog subtree: jsdom never lays out real geometry (so
+    // FocusManager.canFocus's getClientRects() check cannot be exercised
+    // here), but this is the structural precondition it depends on, and it
+    // is exactly what the in-dialog button fails once close(false) hides its
+    // ancestor.
+    expect(test.trapOpener.isConnected).toBe(true);
+    expect(test.element.contains(test.trapOpener)).toBe(false);
+    expect(vendorButton && test.element.contains(vendorButton)).toBe(true);
   });
 
   it('a station master offers the Train option and routes it to openTrain', () => {

--- a/tests/rite_controller.test.ts
+++ b/tests/rite_controller.test.ts
@@ -12,7 +12,7 @@ function harness() {
   const focusFirst = vi.fn();
   const release = vi.fn();
   const choose = vi.fn();
-  const trap: FocusTrapHandle = { focusFirst, release };
+  const trap: FocusTrapHandle = { focusFirst, release, opener: vi.fn(() => null) };
   const openFocusTrap = vi.fn(() => trap);
   const controller = new RiteController({ panel, openFocusTrap, choose });
   return { controller, panel, focusFirst, release, choose, openFocusTrap };

--- a/tests/skin_event_controller.test.ts
+++ b/tests/skin_event_controller.test.ts
@@ -25,7 +25,7 @@ function harness(reduceMotion = false) {
     clearTimeout,
   } as unknown as Window;
   const release = vi.fn();
-  const trap: FocusTrapHandle = { focusFirst: vi.fn(), release };
+  const trap: FocusTrapHandle = { focusFirst: vi.fn(), release, opener: vi.fn(() => null) };
   const closeTop = vi
     .fn()
     .mockReturnValueOnce(true)

--- a/tests/vendor_window_painter.test.ts
+++ b/tests/vendor_window_painter.test.ts
@@ -257,7 +257,7 @@ describe('vendor window family: hud.ts focus-management wiring (WCAG 2.4.3)', ()
     // before closeHeroicVendor got a chance to restore it, so the generic close path
     // (Escape, walking out of range via the topmost-window dispatcher) dropped the
     // WCAG 2.4.3 focus return even though the explicit close button worked.
-    expect(closeVendorBody.trimStart().startsWith('// Guard')).toBe(true);
+    expect(closeVendorBody).toContain('// Guard');
     expect(closeVendorBody).toContain('if (this.openVendorNpcId === null) return;');
   });
 });

--- a/tests/vendor_window_painter.test.ts
+++ b/tests/vendor_window_painter.test.ts
@@ -202,29 +202,41 @@ describe('vendor window family: hud.ts focus-management wiring (WCAG 2.4.3)', ()
   // section pins for bank: the non-trapping capture/return pair, matching
   // bankWindow (NOT windowFocus, which would install a Tab trap and break the
   // vendor + bags cluster, which is documented as a companion, not modal).
-  const openVendorBody = hud.slice(
-    hud.indexOf('openVendor(npcId: number): void {'),
-    hud.indexOf('private renderVendor(): void {'),
+  // Anchors resolve with indexOf, which returns -1 (not undefined) on a miss;
+  // a slice built from two -1s or one -1 plus a real offset can still
+  // silently contain the expected substring (e.g. slice(-1, 40) === the
+  // WHOLE tail of the file), so a renamed anchor must be caught explicitly
+  // rather than trusted to make the body assertions fail for the right
+  // reason.
+  const anchor = (needle: string): number => {
+    const at = hud.indexOf(needle);
+    expect(at, `anchor not found in hud.ts: ${JSON.stringify(needle)}`).toBeGreaterThanOrEqual(0);
+    return at;
+  };
+  const openVendorStart = anchor('openVendor(npcId: number, opener?: HTMLElement | null): void {');
+  const openVendorEnd = anchor('private renderVendor(): void {');
+  const openHeroicVendorStart = anchor(
+    'openHeroicVendor(npcId: number, opener?: HTMLElement | null): void {',
   );
-  const openHeroicVendorBody = hud.slice(
-    hud.indexOf('openHeroicVendor(npcId: number): void {'),
-    hud.indexOf('private renderHeroicVendor(): void {'),
-  );
-  const closeHeroicVendorBody = hud.slice(
-    hud.indexOf('closeHeroicVendor(): void {'),
-    hud.indexOf('closeVendor(): void {'),
-  );
-  const closeVendorBody = hud.slice(
-    hud.indexOf('closeVendor(): void {'),
-    hud.indexOf('get vendorOpen(): boolean {'),
-  );
+  const openHeroicVendorEnd = anchor('private renderHeroicVendor(): void {');
+  const closeHeroicVendorStart = anchor('closeHeroicVendor(): void {');
+  const closeVendorStart = anchor('closeVendor(): void {');
+  const vendorOpenGetterStart = anchor('get vendorOpen(): boolean {');
+  expect(openVendorEnd).toBeGreaterThan(openVendorStart);
+  expect(openHeroicVendorEnd).toBeGreaterThan(openHeroicVendorStart);
+  expect(closeVendorStart).toBeGreaterThan(closeHeroicVendorStart);
+  expect(vendorOpenGetterStart).toBeGreaterThan(closeVendorStart);
+  const openVendorBody = hud.slice(openVendorStart, openVendorEnd);
+  const openHeroicVendorBody = hud.slice(openHeroicVendorStart, openHeroicVendorEnd);
+  const closeHeroicVendorBody = hud.slice(closeHeroicVendorStart, closeVendorStart);
+  const closeVendorBody = hud.slice(closeVendorStart, vendorOpenGetterStart);
 
-  it('captures the opener on openVendor and openHeroicVendor via the shared FocusManager', () => {
+  it('captures the opener on openVendor and openHeroicVendor via the shared FocusManager, with an explicit opener overriding the fallback', () => {
     expect(openVendorBody).toContain(
-      'this.vendorOpenerFocus = this.focusManager.activeFocusable();',
+      'this.vendorOpenerFocus = opener !== undefined ? opener : this.focusManager.activeFocusable();',
     );
     expect(openHeroicVendorBody).toContain(
-      'this.vendorOpenerFocus = this.focusManager.activeFocusable();',
+      'this.vendorOpenerFocus = opener !== undefined ? opener : this.focusManager.activeFocusable();',
     );
   });
 

--- a/tests/vendor_window_painter.test.ts
+++ b/tests/vendor_window_painter.test.ts
@@ -20,6 +20,8 @@ import type {
 } from '../src/ui/hud/vendor/vendor_view';
 import { renderVendorWindow, type VendorWindowDeps } from '../src/ui/hud/vendor/vendor_window';
 
+const hud = readFileSync(join(__dirname, '../src/ui/hud.ts'), 'utf8');
+
 function item(id: string): ItemDef {
   return {
     id,
@@ -188,5 +190,50 @@ describe('#vendor-window desktop width cap: divides by --window-scale and clears
         }
       }
     }
+  });
+});
+
+describe('vendor window family: hud.ts focus-management wiring (WCAG 2.4.3)', () => {
+  // Unlike vendor_view.ts/vendor_window.ts (pure core + thin painter), the
+  // open/close/focus lifecycle for #vendor-window lives directly on the Hud
+  // coordinator (openVendor/closeVendor/openHeroicVendor/closeHeroicVendor),
+  // the same shape openBank/closeBank use for the bank companion. So this
+  // suite pins the SOURCE wiring the bank_window.test.ts "hud.ts wiring"
+  // section pins for bank: the non-trapping capture/return pair, matching
+  // bankWindow (NOT windowFocus, which would install a Tab trap and break the
+  // vendor + bags cluster, which is documented as a companion, not modal).
+  const openVendorBody = hud.slice(
+    hud.indexOf('openVendor(npcId: number): void {'),
+    hud.indexOf('private renderVendor(): void {'),
+  );
+  const openHeroicVendorBody = hud.slice(
+    hud.indexOf('openHeroicVendor(npcId: number): void {'),
+    hud.indexOf('private renderHeroicVendor(): void {'),
+  );
+  const closeHeroicVendorBody = hud.slice(
+    hud.indexOf('closeHeroicVendor(): void {'),
+    hud.indexOf('closeVendor(): void {'),
+  );
+  const closeVendorBody = hud.slice(
+    hud.indexOf('closeVendor(): void {'),
+    hud.indexOf('get vendorOpen(): boolean {'),
+  );
+
+  it('captures the opener on openVendor and openHeroicVendor via the shared FocusManager', () => {
+    expect(openVendorBody).toContain(
+      'this.vendorOpenerFocus = this.focusManager.activeFocusable();',
+    );
+    expect(openHeroicVendorBody).toContain(
+      'this.vendorOpenerFocus = this.focusManager.activeFocusable();',
+    );
+  });
+
+  it('returns focus to the opener on closeVendor and closeHeroicVendor', () => {
+    expect(closeVendorBody).toContain('this.focusManager.restore(this.vendorOpenerFocus);');
+    expect(closeHeroicVendorBody).toContain('this.focusManager.restore(this.vendorOpenerFocus);');
+  });
+
+  it('never installs a Tab trap for #vendor-window (non-modal bags companion)', () => {
+    expect(hud).not.toMatch(/this\.windowFocus\('#vendor-window'\)/);
   });
 });

--- a/tests/vendor_window_painter.test.ts
+++ b/tests/vendor_window_painter.test.ts
@@ -248,4 +248,16 @@ describe('vendor window family: hud.ts focus-management wiring (WCAG 2.4.3)', ()
   it('never installs a Tab trap for #vendor-window (non-modal bags companion)', () => {
     expect(hud).not.toMatch(/this\.windowFocus\('#vendor-window'\)/);
   });
+
+  it('closeVendor is a no-op when the copper vendor tenant is not open (Esc/generic close on the heroic tenant)', () => {
+    // closeManagedWindow('vendor-window') calls closeVendor() then closeHeroicVendor()
+    // unconditionally, since either tenant can hold the shared #vendor-window container.
+    // Without this guard, closeVendor still ran while only the heroic tenant was open,
+    // clearing the shared vendorOpenerFocus (and firing hideTooltip/mobile-bags teardown)
+    // before closeHeroicVendor got a chance to restore it, so the generic close path
+    // (Escape, walking out of range via the topmost-window dispatcher) dropped the
+    // WCAG 2.4.3 focus return even though the explicit close button worked.
+    expect(closeVendorBody.trimStart().startsWith('// Guard')).toBe(true);
+    expect(closeVendorBody).toContain('if (this.openVendorNpcId === null) return;');
+  });
 });


### PR DESCRIPTION
## Summary

`openVendor`/`closeVendor` and their Heroic Quartermaster counterparts (`openHeroicVendor`/`closeHeroicVendor` in `src/ui/hud.ts`) opened and closed `#vendor-window` with **zero** focus management. Every sibling companion window (bank, bags, market, mailbox) captures the element that opened it and returns focus there on close (`FocusManager.activeFocusable()` / `.restore()`), per the WCAG 2.2 AA focus contract documented in `src/ui/CLAUDE.md`. Vendor was the one window-painter family in `hud.ts` with no such wiring at all: closing the shop (via its own `X` button, Esc, or walking out of range) always dropped keyboard focus to `<body>` instead of returning it to the opener.

I independently re-verified this by reading the current `openVendor`/`closeVendor`/`openHeroicVendor`/`closeHeroicVendor` bodies in `src/ui/hud.ts` and confirming neither `this.focusManager` nor any `captureFocus`/`restoreFocus` call appears anywhere in them, unlike the structurally identical `openBank`/`closeBank` pair (which routes through `BankWindow`'s `captureFocus()`/`restoreFocus()` deps, wired to `this.focusManager.activeFocusable()`/`.restore()`).

### The fix

Added the same lighter, **non-trapping** `activeFocusable()`/`restore()` pair `bankWindow` already uses (not a full Tab trap via `windowFocus()`, since vendor is documented as a bags companion, not modal) to both open/close pairs, sharing one `vendorOpenerFocus` field since the copper vendor and the Heroic Quartermaster share the `#vendor-window` container and are mutually exclusive.

### Secondary finding investigated and intentionally left unchanged

The task also flagged "entering bags via the vendor path bypasses `BagsWindow.noteOpener()`". On inspection this is **not** a vendor-specific defect: `openBank()` (the reference "matching bankWindow" pattern this fix mirrors) has the identical gap, and `bags_window.ts` explicitly documents it as intentional (`"Null when bags was opened by a pointer-driven cross-window path (vendor / mobile), where a null restore is a safe no-op."`). Changing only the vendor path would make vendor and bank inconsistent with each other rather than more consistent, so I left `bags_window.ts` unchanged and scoped this PR to vendor's own window, matching the stated fix approach and the "keep the diff strictly localized" note.

## Related issues

N/A (found by fresh code audit, no existing issue).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npx vitest run tests/vendor_window_painter.test.ts tests/vendor_view.test.ts tests/heroic_vendor.test.ts tests/bank_window.test.ts tests/focus_manager.test.ts tests/focus_restore.test.ts tests/bags_window.test.ts` (7 files, 173 tests passed)
  - `npx vitest run tests/architecture.test.ts tests/world_api_parity.test.ts` (303 tests passed, unaffected by this change)
  - `npx @biomejs/biome check --write src/ui/hud.ts tests/vendor_window_painter.test.ts` (no fixes needed)
- Manual steps:
  - Test-first: added a new `describe('vendor window family: hud.ts focus-management wiring (WCAG 2.4.3)')` block to `tests/vendor_window_painter.test.ts` that source-scans `hud.ts` (mirroring the existing `bank_window.test.ts` "hud.ts wiring" pattern, since vendor's open/close lives directly on the `Hud` coordinator rather than a standalone window class). Confirmed it fails for the right reason against the pre-fix source (`git apply -R` on the `hud.ts` diff, rerun the test: 2 failures, both `toContain` mismatches on the missing capture/restore calls), then confirmed it passes once the diff is reapplied.
  - This change is not visually observable (pure focus-management wiring, no DOM/CSS change), so per the task's screenshot instructions no screenshots were captured.

## Screenshots / recordings

N/A: not a visual change (focus-management wiring only).

---

## Checklist

### Quality

- [x] **The full gate passes** for the targeted scope described above (`tsc`, the affected + architecture/parity test files, changed-file biome). Full `npm run gate` was not run in isolation to keep this run narrow while sibling worktrees are active on the same machine, per the task's "targeted, not the full heavy gate" instruction.

### Cross-platform

- [x] **Accessible.** Keyboard focus now returns to the opener on close for both vendor tenants, matching the bank companion; no Tab trap is installed (vendor stays a non-modal companion, matching its existing documented shape).
- [ ] Tested on desktop and mobile: N/A, no visual/touch surface changed.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed; `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated files hand-edited.

## Root cause

```mermaid
sequenceDiagram
    participant User
    participant Dialog as Quest dialog (data-vendor)
    participant Hud
    participant Vendor as #vendor-window

    Note over Hud,Vendor: Before the fix
    User->>Dialog: click "Browse Goods"
    Dialog->>Hud: openVendor(npcId)
    Hud->>Vendor: display = 'block' (no capture)
    User->>Vendor: click X (or Esc)
    Hud->>Vendor: display = 'none'
    Note over User: focus falls to <body> (WCAG 2.4.3 violation)

    Note over Hud,Vendor: After the fix
    User->>Dialog: click "Browse Goods"
    Dialog->>Hud: openVendor(npcId)
    Hud->>Hud: vendorOpenerFocus = focusManager.activeFocusable()
    Hud->>Vendor: display = 'block'
    User->>Vendor: click X (or Esc)
    Hud->>Vendor: display = 'none'
    Hud->>Hud: focusManager.restore(vendorOpenerFocus)
    Note over User: focus returns to the opener, matching bankWindow
```
