### PR TITLE
fix(ui): never tier-gate the self buff/debuff bar cadence

### DIFF
--- a/docs/design/graphics-settings-fairness.md
+++ b/docs/design/graphics-settings-fairness.md
@@ -59,9 +59,12 @@ What each knob does, and why it is gameplay-neutral:
 - Auras, `src/ui/auras_painter.ts`: on low, the visible-count cap is DEBUFF-PRIORITY. The
   player buff bar (`createAurasView('all')`) interleaves buffs and debuffs in sim-application
   order; the cap sheds BUFF overflow only (`if (!s.isDebuff && rendered >= cap) continue`), so
-  a debuff is never culled. Full tiers are byte-identical (cap is +Infinity). The aura strip
-  also coarsens its repaint cadence to about 4 Hz on low (at the human reaction floor and the
-  same rate the party frames run at on every tier).
+  a debuff is never culled. Full tiers are byte-identical (cap is +Infinity). The player's OWN
+  buff and debuff bars are never tier-gated: they repaint every frame on every preset, because
+  your own debuffs are the ACTIONABLE read named above. Only the TARGET's (non-self) debuffs
+  strip coarsens its repaint cadence to about 4 Hz on low (at the human reaction floor and the
+  same rate the party frames run at on every tier), the same non-self throttle the target frame
+  body uses.
 - Target frame, hud + `unit_frame_painter.ts`: on low, the target frame BODY (HP / level /
   portrait) refreshes at about 10 Hz; a target SWAP bypasses the throttle
   (`nonSelfRepaintDue`), and the cast bar is painted OUTSIDE the throttle (full rate, so

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1447,7 +1447,6 @@ export class Hud {
   // party frames are deliberately not stamped (party-member HP is a healer's actionable
   // signal, so it stays on the mediumHud band for every tier: see ui_tier_knobs).
   private lastMinimapDrawAt = 0;
-  private lastBuffBarPaintAt = 0;
   private lastTargetDebuffsPaintAt = 0;
   private lastTargetFramePaintAt = 0;
   private lastTargetFrameId: number | null = null;
@@ -7269,14 +7268,14 @@ export class Hud {
     // every frame (the elided writers make a no-op frame free). Buffs and debuffs render to
     // separate rows (classic layout) so a fresh debuff is never lost in a wall of long-lived
     // buffs: two view+painter instances, mode 'buffs' (#buff-bar) and 'debuffs' (#debuff-bar).
-    // The graphics tier coarsens the refresh (tick) granularity: full tiers repaint every
-    // frame (interval 0, cadenceDue always true); low coarsens to ~4Hz. The visible-count cap
-    // is applied inside the painter.
-    if (cadenceDue(this.lastBuffBarPaintAt, now, auraRefreshIntervalMs(fxTier))) {
-      this.lastBuffBarPaintAt = now;
-      this.buffBarPainter.paint(this.buffBarView.tick(p));
-      this.debuffBarPainter.paint(this.debuffBarView.tick(p));
-    }
+    // SELF/player auras are NEVER tier-gated: your own debuffs are the ACTIONABLE read named in
+    // docs/design/graphics-settings-fairness.md (there is no self-dispel, so the aura icon and
+    // its remaining duration are the only way to react to a DoT/curse/CC), so this paints every
+    // frame on every graphics preset. The visible-count cap (auraVisibleCap, still tiered) is
+    // applied inside the painter and is debuff-priority (a shed slot is always a buff, never a
+    // debuff). Only the TARGET (non-self) debuffs strip below stays on the tiered ~4Hz cadence.
+    this.buffBarPainter.paint(this.buffBarView.tick(p));
+    this.debuffBarPainter.paint(this.debuffBarView.tick(p));
 
     // target frame: the SECOND instance of the unit_frame family. The shared
     // frame (display/name/level/hp/absorb/portrait gate) goes through the family

--- a/tests/hud_update_drive.test.ts
+++ b/tests/hud_update_drive.test.ts
@@ -395,16 +395,16 @@ const HUD_UPDATE_DRIVES: readonly DriveRow[] = [
   {
     call: 'this.buffBarPainter.paint',
     band: 'frame',
-    gate: 'cadenceDue(this.lastBuffBarPaintAt, now, auraRefreshIntervalMs(fxTier))',
+    gate: '',
     surface: 'chrome',
-    why: 'the buff row, tier-coarsened (full tiers every frame, low ~4 Hz)',
+    why: 'the SELF buff row: never tier-gated, every frame on every graphics preset (the debuff row below shares this rule; only the TARGET debuffs strip is tier-coarsened)',
   },
   {
     call: 'this.debuffBarPainter.paint',
     band: 'frame',
-    gate: 'cadenceDue(this.lastBuffBarPaintAt, now, auraRefreshIntervalMs(fxTier))',
+    gate: '',
     surface: 'chrome',
-    why: 'the debuff row, on the same latch as the buff row',
+    why: 'the SELF debuff row: never tier-gated (your own debuffs are the ACTIONABLE read, docs/design/graphics-settings-fairness.md), so it paints every frame on every graphics preset, unlike the target debuffs strip',
   },
   {
     call: 'this.targetReannounce.mark',


### PR DESCRIPTION
## Summary

The player's own buff/debuff bar (`#buff-bar` / `#debuff-bar`) shared the same graphics-tier cadence gate (`cadenceDue(this.lastBuffBarPaintAt, now, auraRefreshIntervalMs(fxTier))`) as cosmetic, non-self HUD elements. On the Low graphics preset that gate coarsens to about 4 Hz, so a fresh debuff (a DoT, curse, CC, or move-out mechanic) or a duration countdown update on the player's OWN aura bar could sit stale on screen for up to 250ms before repainting.

This directly contradicts this repo's gameplay-neutral-graphics invariant (root `CLAUDE.md` and `docs/design/graphics-settings-fairness.md`), which explicitly names "your own debuffs" as ACTIONABLE information that must never be tiered, because there is no self-dispel and the aura icon is the only read a player has. The design doc itself stated the rule in one paragraph and then contradicted it two paragraphs later by describing the aura strip's repaint cadence as tiered on low, with no self/non-self distinction.

**Fix:** removed the `cadenceDue(...)` gate around `this.buffBarPainter.paint(...)` / `this.debuffBarPainter.paint(...)` in `Hud.update()` so both rows paint unconditionally, every frame, on every graphics preset (matching how the player frame already treats the SELF path). Dropped the now-dead `lastBuffBarPaintAt` timestamp field. The TARGET's (non-self) debuffs strip (`this.targetDebuffsPainter`) is untouched and keeps its existing ~4 Hz tiered cadence with its target-swap bypass, since it is not the player's own actionable information. Also corrected the fairness doc's now-inaccurate claim.

The visible-count cap on low (`auraVisibleCap`, debuff-priority) is unrelated to this bug and is left exactly as-is: it sheds buff icon overflow only, never a debuff, and hiding an icon while the aura is still active was already covered as an acceptable cosmetic shed.

## Related issues

N/A (found by a fresh code audit; no existing issue).

## Type of change

- [x] Bug fix

## How was this tested?

Commands run from the worktree root:

- `npx vitest run tests/hud_update_drive.test.ts` -- first run (with only the test's pinned rows updated to the desired `gate: ''`, before touching `hud.ts`) FAILED with `this.buffBarPainter.paint|frame| (registered, drives nothing)` / `...cadenceDue(...) (drives 1x, registered nowhere)`, confirming the AST-scanned real `Hud.update()` body still had the tiered gate. After applying the `hud.ts` fix, the same command PASSED (10/10 tests).
- `npx vitest run tests/hud_update_drive.test.ts tests/hud_perf_budget.test.ts tests/ui_tier_knobs.test.ts tests/auras_painter.test.ts tests/auras_view.test.ts tests/architecture.test.ts tests/world_api_parity.test.ts` -- 469 passed, 4 skipped, 0 failed.
- `npx tsc --noEmit` -- clean, no errors.
- `npx @biomejs/biome check --write src/ui/hud.ts tests/hud_update_drive.test.ts` -- "Checked 2 files. No fixes applied."

## Screenshots / recordings

Skipped intentionally. This bug is a per-frame repaint CADENCE/latency defect (a stale-by-up-to-250ms window on the Low preset), not a static visual state: the buff/debuff bar's DOM and styling are byte-identical before and after this change, and the icon/duration text shown at any single instant a screenshot could capture looks the same in both versions. The only observable difference is timing (how quickly a fresh debuff or duration tick appears after the sim applies it), which a still screenshot cannot represent honestly; scripting a reliable frame-timing capture was judged not worth fabricating a misleading before/after pair for this change.

```mermaid
flowchart TD
    A[Sim tick: player gains/loses an aura] --> B[Hud.update every frame]
    B --> C{Aura bar painter call}
    subgraph Before[Before: buggy]
        C --> D[cadenceDue lastBuffBarPaintAt now auraRefreshIntervalMs fxTier]
        D -->|Low preset: gate is ~250ms| E[buffBarPainter.paint / debuffBarPainter.paint SKIPPED most frames]
        E --> F[Own debuff icon and countdown lag the sim by up to 250ms]
    end
    subgraph After[After: fixed]
        C --> G[buffBarPainter.paint / debuffBarPainter.paint runs UNCONDITIONALLY]
        G --> H[Own debuff icon and countdown match the sim every frame, on every preset]
    end
    subgraph Unchanged[Unchanged: target non-self strip]
        B --> I[targetDebuffsPainter.paint]
        I --> J[nonSelfRepaintDue: still tiered ~4Hz on low, target-swap bypass]
    end
```

---

## Checklist

### Quality

- [x] Added/updated decisive tests for the changed behavior (`tests/hud_update_drive.test.ts` pinned rows, confirmed red before the fix and green after). Ran the targeted test set above rather than the full `npm run gate` (kept narrow per task instructions since other agents are running concurrently in sibling worktrees on this machine); `tsc`, biome (changed files), and the directly-relevant Vitest suites are all green.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A: no DOM/CSS/layout change, only a cadence gate removed from an existing per-frame code path; the bar's markup and styling are untouched.
- ~~Accessible.~~ N/A: no UI markup or interaction changed.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
