### PR TITLE
fix(server): retire password_reset_requests, email_change_requests, and email_log from unbounded growth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,18 @@ WIKI_URL=http://localhost:8080/wiki/index.php/Main_Page
 # read-invisible to them.
 #PLAYER_ACTIVITY_RETENTION_DAYS=400
 
+# How many days of password-reset / email-change request rows to keep after
+# creation (default 30 each; 0 = keep forever). Requesting a new reset or email
+# change supersedes (deletes) any still-pending row for the same account, but
+# that only bounds duplicate PENDING rows: a consumed or abandoned-and-expired
+# one is untouched by it, so these two keys are what actually age the tables.
+#PASSWORD_RESET_REQUEST_RETENTION_DAYS=30
+#EMAIL_CHANGE_REQUEST_RETENTION_DAYS=30
+
+# How many days of the outbound-email audit trail (email_log: every send
+# attempt, success or failure) to keep (default 90; 0 = keep forever).
+#EMAIL_LOG_RETENTION_DAYS=90
+
 # UTC hour (0-23) the nightly retention sweep runs (default 5). Unlike the
 # retention keys, an explicit 0 here is a live value: it moves the sweep to
 # 00:00 UTC.

--- a/server/db.ts
+++ b/server/db.ts
@@ -374,6 +374,11 @@ CREATE TABLE IF NOT EXISTS email_change_requests (
 );
 CREATE INDEX IF NOT EXISTS email_change_requests_token ON email_change_requests(token_hash);
 CREATE INDEX IF NOT EXISTS email_change_requests_account ON email_change_requests(account_id);
+-- Retention: the per-account supersede DELETE in createEmailChangeRequest below
+-- removes only a duplicate still-PENDING row, never a consumed or abandoned one,
+-- so it does not bound this table's growth. pruneEmailChangeRequestsBatch (the
+-- EMAIL_CHANGE_REQUEST_RETENTION_DAYS sweep table) is what ages rows out.
+CREATE INDEX IF NOT EXISTS email_change_requests_created ON email_change_requests(created_at);
 -- Pending self-service password resets. Same posture as email_change_requests:
 -- only the SHA-256 of the token is stored (a DB leak cannot be replayed into a
 -- takeover), each row is single-use (consumed_at) and time-boxed (expires_at).
@@ -388,8 +393,15 @@ CREATE TABLE IF NOT EXISTS password_reset_requests (
 );
 CREATE INDEX IF NOT EXISTS password_reset_requests_token ON password_reset_requests(token_hash);
 CREATE INDEX IF NOT EXISTS password_reset_requests_account ON password_reset_requests(account_id);
+-- Retention: same caveat as email_change_requests above, mirrored here. The
+-- per-account supersede DELETE in createPasswordResetRequest below only removes
+-- a duplicate still-PENDING row; prunePasswordResetRequestsBatch
+-- (PASSWORD_RESET_REQUEST_RETENTION_DAYS) is what ages rows out.
+CREATE INDEX IF NOT EXISTS password_reset_requests_created ON password_reset_requests(created_at);
 -- Audit trail for every outbound email attempt (success or failure). Doubles as
--- the source for any future per-account send rate limiting.
+-- the source for any future per-account send rate limiting. Retention:
+-- pruneEmailLogBatch (EMAIL_LOG_RETENTION_DAYS) ages rows out; nothing else
+-- bounds this table.
 CREATE TABLE IF NOT EXISTS email_log (
   id BIGSERIAL PRIMARY KEY,
   account_id INT REFERENCES accounts(id) ON DELETE SET NULL,
@@ -401,6 +413,9 @@ CREATE TABLE IF NOT EXISTS email_log (
   sent_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS email_log_account ON email_log(account_id, sent_at DESC);
+-- email_log_account leads on account_id, so it cannot serve pruneEmailLogBatch's
+-- account-agnostic age scan; this plain sent_at index is the one that does.
+CREATE INDEX IF NOT EXISTS email_log_sent ON email_log(sent_at);
 -- Optional TOTP two-factor auth. totp_secret holds the confirmed base32 secret
 -- (NULL until 2FA is fully enabled); totp_pending_secret holds a secret minted
 -- by setup but not yet confirmed with a live code, so a botched enrolment never
@@ -1771,7 +1786,10 @@ export async function createEmailChangeRequest(
 ): Promise<void> {
   // Invalidate any still-pending request for this account first: only the most
   // recent change link should be live (a user who re-requests supersedes the
-  // old address), and this keeps the table from accumulating dead rows.
+  // old address). This bounds duplicate PENDING rows per account, nothing more:
+  // a consumed or abandoned-and-expired row is untouched here and would grow
+  // the table forever without pruneEmailChangeRequestsBatch (the retention
+  // sweep table registered in main.ts).
   await pool.query(
     'DELETE FROM email_change_requests WHERE account_id = $1 AND consumed_at IS NULL',
     [accountId],
@@ -1831,7 +1849,10 @@ export async function createPasswordResetRequest(
   ttlHours: number,
 ): Promise<void> {
   // Invalidate any still-pending reset for this account first: only the most
-  // recent link stays live, and this keeps the table from accumulating dead rows.
+  // recent link stays live. This bounds duplicate PENDING rows per account,
+  // nothing more: a consumed or abandoned-and-expired row is untouched here
+  // and would grow the table forever without prunePasswordResetRequestsBatch
+  // (the retention sweep table registered in main.ts).
   await pool.query(
     'DELETE FROM password_reset_requests WHERE account_id = $1 AND consumed_at IS NULL',
     [accountId],
@@ -1902,6 +1923,78 @@ export async function recordEmailLog(entry: EmailLogEntry): Promise<void> {
      VALUES ($1, $2, $3, $4, $5, $6)`,
     [entry.accountId, entry.event, entry.toEmail, entry.category, entry.ok, entry.error ?? null],
   );
+}
+
+// Keeps password_reset_requests bounded. PASSWORD_RESET_REQUEST_RETENTION_DAYS=0
+// disables pruning. The per-account supersede DELETE in createPasswordResetRequest
+// above only removes a duplicate PENDING row, never a consumed or
+// abandoned-and-expired one, so this is the only thing that actually bounds the
+// table. One bounded batch per call: the caller (the retention sweep) drives
+// iteration, so each DELETE is a short autocommit statement on the default
+// statement timeout, riding password_reset_requests_created via the
+// oldest-first ORDER BY.
+export async function prunePasswordResetRequestsBatch(
+  retentionDays: number,
+  batchSize: number,
+): Promise<number> {
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) return 0;
+  const days = Math.max(1, Math.floor(retentionDays));
+  const res = await pool.query(
+    `DELETE FROM password_reset_requests
+      WHERE id IN (
+        SELECT id FROM password_reset_requests
+         WHERE created_at < now() - ($1 || ' days')::interval
+         ORDER BY created_at
+         LIMIT $2)`,
+    [String(days), Math.max(1, Math.floor(batchSize))],
+  );
+  return res.rowCount ?? 0;
+}
+
+// Keeps email_change_requests bounded. EMAIL_CHANGE_REQUEST_RETENTION_DAYS=0
+// disables pruning. Same rationale as prunePasswordResetRequestsBatch above: the
+// per-account supersede DELETE in createEmailChangeRequest only bounds duplicate
+// PENDING rows, so this is the only thing that bounds the table, riding
+// email_change_requests_created via the oldest-first ORDER BY.
+export async function pruneEmailChangeRequestsBatch(
+  retentionDays: number,
+  batchSize: number,
+): Promise<number> {
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) return 0;
+  const days = Math.max(1, Math.floor(retentionDays));
+  const res = await pool.query(
+    `DELETE FROM email_change_requests
+      WHERE id IN (
+        SELECT id FROM email_change_requests
+         WHERE created_at < now() - ($1 || ' days')::interval
+         ORDER BY created_at
+         LIMIT $2)`,
+    [String(days), Math.max(1, Math.floor(batchSize))],
+  );
+  return res.rowCount ?? 0;
+}
+
+// Keeps email_log bounded. EMAIL_LOG_RETENTION_DAYS=0 disables pruning. Nothing
+// else prunes this table (every outbound email attempt writes one row via
+// recordEmailLog and none are ever superseded), so without this the audit trail
+// grows forever. Ages on sent_at (the table has no created_at column), riding
+// email_log_sent via the oldest-first ORDER BY.
+export async function pruneEmailLogBatch(
+  retentionDays: number,
+  batchSize: number,
+): Promise<number> {
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) return 0;
+  const days = Math.max(1, Math.floor(retentionDays));
+  const res = await pool.query(
+    `DELETE FROM email_log
+      WHERE id IN (
+        SELECT id FROM email_log
+         WHERE sent_at < now() - ($1 || ' days')::interval
+         ORDER BY sent_at
+         LIMIT $2)`,
+    [String(days), Math.max(1, Math.floor(batchSize))],
+  );
+  return res.rowCount ?? 0;
 }
 
 // ── Two-factor auth (TOTP) ──────────────────────────────────────────────────

--- a/server/http/config.ts
+++ b/server/http/config.ts
@@ -119,6 +119,15 @@ export interface Config {
   // the business-metrics fact table) to keep. The snapshot reads touch only
   // today and yesterday, so any positive window is read-invisible to them.
   readonly playerActivityRetentionDays: number;
+  // How many days of password_reset_requests / email_change_requests rows to
+  // keep after creation. The per-account supersede DELETE at each create call
+  // only removes a duplicate still-PENDING row (createPasswordResetRequest /
+  // createEmailChangeRequest, server/db.ts); a consumed or abandoned-and-expired
+  // row is untouched there, so these are the only knobs that bound either table.
+  readonly passwordResetRequestRetentionDays: number;
+  readonly emailChangeRequestRetentionDays: number;
+  // How many days of email_log rows (the outbound-email audit trail) to keep.
+  readonly emailLogRetentionDays: number;
   // The two sweep knobs follow the maxPlayersPerRealm trimmed-read contract
   // instead, because for them a whitespace-derived 0 is fail-DANGEROUS: hour 0
   // moves the sweep to 00:00 UTC, next to the nightly 03:15 UTC pg_dump window
@@ -172,6 +181,9 @@ const DEFAULT_SITE_PRESENCE_RETENTION_DAYS = 90;
 const DEFAULT_PLAY_SESSION_RETENTION_DAYS = 180;
 const DEFAULT_ACCOUNT_IP_ASSOCIATION_RETENTION_DAYS = 730;
 const DEFAULT_PLAYER_ACTIVITY_RETENTION_DAYS = 400;
+const DEFAULT_PASSWORD_RESET_REQUEST_RETENTION_DAYS = 30;
+const DEFAULT_EMAIL_CHANGE_REQUEST_RETENTION_DAYS = 30;
+const DEFAULT_EMAIL_LOG_RETENTION_DAYS = 90;
 // PROVISIONAL: two hours after the nightly 03:15 UTC pg_dump window, pending real
 // traffic-curve evidence of the quietest hour; revisit when that evidence lands.
 const DEFAULT_RETENTION_SWEEP_UTC_HOUR = 5;
@@ -354,6 +366,15 @@ export function loadConfig(env: NodeJS.ProcessEnv): Config {
       env.PLAYER_ACTIVITY_RETENTION_DAYS,
       DEFAULT_PLAYER_ACTIVITY_RETENTION_DAYS,
     ),
+    passwordResetRequestRetentionDays: numberOr(
+      env.PASSWORD_RESET_REQUEST_RETENTION_DAYS,
+      DEFAULT_PASSWORD_RESET_REQUEST_RETENTION_DAYS,
+    ),
+    emailChangeRequestRetentionDays: numberOr(
+      env.EMAIL_CHANGE_REQUEST_RETENTION_DAYS,
+      DEFAULT_EMAIL_CHANGE_REQUEST_RETENTION_DAYS,
+    ),
+    emailLogRetentionDays: numberOr(env.EMAIL_LOG_RETENTION_DAYS, DEFAULT_EMAIL_LOG_RETENTION_DAYS),
     // An hour outside 0..23 is garbage, not a preference; fall back like numberOr does.
     retentionSweepUtcHour:
       Number.isInteger(sweepHourRaw) && sweepHourRaw >= 0 && sweepHourRaw <= 23

--- a/server/main.ts
+++ b/server/main.ts
@@ -129,6 +129,9 @@ import {
   primarySlugForAccount,
   pruneChatLogsBatch,
   pruneClientPerfReportsBatch,
+  pruneEmailChangeRequestsBatch,
+  pruneEmailLogBatch,
+  prunePasswordResetRequestsBatch,
   reclaimDeactivatedName,
   referralCountForAccount,
   releaseAllCharacterLeases,
@@ -3076,6 +3079,19 @@ export async function startServer(): Promise<http.Server> {
         name: 'account_ip_associations',
         pruneBatch: (n) =>
           pruneAccountIpAssociationsBatch(pool, config.accountIpAssociationRetentionDays, n),
+      },
+      {
+        name: 'password_reset_requests',
+        pruneBatch: (n) =>
+          prunePasswordResetRequestsBatch(config.passwordResetRequestRetentionDays, n),
+      },
+      {
+        name: 'email_change_requests',
+        pruneBatch: (n) => pruneEmailChangeRequestsBatch(config.emailChangeRequestRetentionDays, n),
+      },
+      {
+        name: 'email_log',
+        pruneBatch: (n) => pruneEmailLogBatch(config.emailLogRetentionDays, n),
       },
     ],
     // The fold precondition makes sample pruning lossless; skip the whole group

--- a/tests/db_retention_prune.test.ts
+++ b/tests/db_retention_prune.test.ts
@@ -32,7 +32,13 @@ vi.mock('pg', () => ({
   }),
 }));
 
-import { pruneChatLogsBatch, pruneClientPerfReportsBatch } from '../server/db';
+import {
+  pruneChatLogsBatch,
+  pruneClientPerfReportsBatch,
+  pruneEmailChangeRequestsBatch,
+  pruneEmailLogBatch,
+  prunePasswordResetRequestsBatch,
+} from '../server/db';
 
 beforeEach(() => {
   dbMock.query.mockReset();
@@ -82,6 +88,57 @@ describe('retention prune batches', () => {
     expect(params).toEqual(['90', 500]);
   });
 
+  it('password-reset-request prune deletes one bounded oldest-first batch and reports the row count', async () => {
+    dbMock.query.mockResolvedValueOnce({ rows: [], rowCount: 4 });
+
+    await expect(prunePasswordResetRequestsBatch(30, 500)).resolves.toBe(4);
+
+    const [sql, params] = dbMock.query.mock.calls[0];
+    // Same bounded shape: the age predicate rides the dedicated created_at
+    // index, oldest-first, id-subselect bounded. This is the retention story
+    // the misleading "keeps the table from accumulating dead rows" comment on
+    // the per-account supersede DELETE never actually provided: that DELETE
+    // only removes duplicate PENDING rows, never a consumed or abandoned one.
+    expect(sql).toContain('DELETE FROM password_reset_requests');
+    expect(sql).toContain('created_at <');
+    expect(sql).toContain('id IN');
+    expect(sql).toContain('ORDER BY created_at');
+    expect(sql).toContain('LIMIT $2');
+    expect(sql).toContain("($1 || ' days')::interval");
+    expect(params).toEqual(['30', 500]);
+  });
+
+  it('email-change-request prune deletes one bounded oldest-first batch and reports the row count', async () => {
+    dbMock.query.mockResolvedValueOnce({ rows: [], rowCount: 5 });
+
+    await expect(pruneEmailChangeRequestsBatch(30, 500)).resolves.toBe(5);
+
+    const [sql, params] = dbMock.query.mock.calls[0];
+    expect(sql).toContain('DELETE FROM email_change_requests');
+    expect(sql).toContain('created_at <');
+    expect(sql).toContain('id IN');
+    expect(sql).toContain('ORDER BY created_at');
+    expect(sql).toContain('LIMIT $2');
+    expect(sql).toContain("($1 || ' days')::interval");
+    expect(params).toEqual(['30', 500]);
+  });
+
+  it('email-log prune deletes one bounded oldest-first batch on sent_at and reports the row count', async () => {
+    dbMock.query.mockResolvedValueOnce({ rows: [], rowCount: 6 });
+
+    await expect(pruneEmailLogBatch(90, 500)).resolves.toBe(6);
+
+    const [sql, params] = dbMock.query.mock.calls[0];
+    // email_log ages on sent_at, not created_at: it has no created_at column.
+    expect(sql).toContain('DELETE FROM email_log');
+    expect(sql).toContain('sent_at <');
+    expect(sql).toContain('id IN');
+    expect(sql).toContain('ORDER BY sent_at');
+    expect(sql).toContain('LIMIT $2');
+    expect(sql).toContain("($1 || ' days')::interval");
+    expect(params).toEqual(['90', 500]);
+  });
+
   it('client-perf prune normalizes fractional retention days up to one full day', async () => {
     dbMock.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
 
@@ -111,22 +168,32 @@ describe('retention prune batches', () => {
     await expect(pruneChatLogsBatch(-1, 500)).resolves.toBe(0);
     await expect(pruneClientPerfReportsBatch(0, 500)).resolves.toBe(0);
     await expect(pruneClientPerfReportsBatch(-1, 500)).resolves.toBe(0);
+    await expect(prunePasswordResetRequestsBatch(0, 500)).resolves.toBe(0);
+    await expect(prunePasswordResetRequestsBatch(-1, 500)).resolves.toBe(0);
+    await expect(pruneEmailChangeRequestsBatch(0, 500)).resolves.toBe(0);
+    await expect(pruneEmailChangeRequestsBatch(-1, 500)).resolves.toBe(0);
+    await expect(pruneEmailLogBatch(0, 500)).resolves.toBe(0);
+    await expect(pruneEmailLogBatch(-1, 500)).resolves.toBe(0);
     expect(dbMock.query).not.toHaveBeenCalled();
   });
 
-  it('a zero batch size floors to LIMIT 1, never LIMIT 0, on both prunes', async () => {
+  it('a zero batch size floors to LIMIT 1, never LIMIT 0, on every prune', async () => {
     dbMock.query.mockResolvedValue({ rows: [], rowCount: 0 });
 
     await pruneChatLogsBatch(90, 0);
     await pruneClientPerfReportsBatch(14, 0);
+    await prunePasswordResetRequestsBatch(30, 0);
+    await pruneEmailChangeRequestsBatch(30, 0);
+    await pruneEmailLogBatch(90, 0);
 
     // A LIMIT 0 batch would delete nothing forever while looking healthy; the sweep
     // normalizes its tunable too, so this floor is defense in depth.
-    expect(dbMock.query.mock.calls[0][1][1]).toBe(1);
-    expect(dbMock.query.mock.calls[1][1][1]).toBe(1);
+    for (let i = 0; i < 5; i++) {
+      expect(dbMock.query.mock.calls[i][1][1]).toBe(1);
+    }
   });
 
-  it('both prunes run on the default statement timeout, never a SET LOCAL raise', async () => {
+  it('every prune runs on the default statement timeout, never a SET LOCAL raise', async () => {
     // The behavioral twin of the tunables source pin: a re-wrap in
     // runWithStatementTimeout would surface here as a SET LOCAL statement_timeout
     // control statement on the connected client.
@@ -134,6 +201,9 @@ describe('retention prune batches', () => {
 
     await pruneChatLogsBatch(30, 100);
     await pruneClientPerfReportsBatch(30, 100);
+    await prunePasswordResetRequestsBatch(30, 100);
+    await pruneEmailChangeRequestsBatch(30, 100);
+    await pruneEmailLogBatch(90, 100);
 
     const recorded = [
       ...dbMock.clientStatements,

--- a/tests/server/http/config.test.ts
+++ b/tests/server/http/config.test.ts
@@ -42,6 +42,9 @@ describe('loadConfig', () => {
     expect(cfg.playSessionRetentionDays).toBe(180);
     expect(cfg.accountIpAssociationRetentionDays).toBe(730);
     expect(cfg.playerActivityRetentionDays).toBe(400);
+    expect(cfg.passwordResetRequestRetentionDays).toBe(30);
+    expect(cfg.emailChangeRequestRetentionDays).toBe(30);
+    expect(cfg.emailLogRetentionDays).toBe(90);
     expect(cfg.retentionSweepUtcHour).toBe(5);
     expect(cfg.retentionSweepMaxRowsPerRun).toBe(50000);
     expect(cfg.requireWebLogin).toBe(false);
@@ -237,7 +240,7 @@ describe('loadConfig', () => {
     expect(loadConfig({ ...MIN_ENV, MAX_PLAYERS_PER_REALM: ' 0 ' }).maxPlayersPerRealm).toBe(0);
   });
 
-  it('reads the six retention day keys on the chat-log contract: empty is the default, whitespace is keep-forever', () => {
+  it('reads the nine retention day keys on the chat-log contract: empty is the default, whitespace is keep-forever', () => {
     const cases = [
       {
         key: 'DAILY_REWARD_EVENTS_RETENTION_DAYS',
@@ -253,6 +256,17 @@ describe('loadConfig', () => {
         dflt: 730,
       },
       { key: 'PLAYER_ACTIVITY_RETENTION_DAYS', field: 'playerActivityRetentionDays', dflt: 400 },
+      {
+        key: 'PASSWORD_RESET_REQUEST_RETENTION_DAYS',
+        field: 'passwordResetRequestRetentionDays',
+        dflt: 30,
+      },
+      {
+        key: 'EMAIL_CHANGE_REQUEST_RETENTION_DAYS',
+        field: 'emailChangeRequestRetentionDays',
+        dflt: 30,
+      },
+      { key: 'EMAIL_LOG_RETENTION_DAYS', field: 'emailLogRetentionDays', dflt: 90 },
     ] as const;
     for (const { key, field, dflt } of cases) {
       // A set value overrides the default.

--- a/tests/server/main_retention_wiring.test.ts
+++ b/tests/server/main_retention_wiring.test.ts
@@ -38,6 +38,9 @@ describe('retention sweep wiring in server/main.ts', () => {
       'prunePlaySessionsBatch(',
       'pruneAccountIpAssociationsBatch(',
       'foldOnlinePeak(',
+      'prunePasswordResetRequestsBatch(',
+      'pruneEmailChangeRequestsBatch(',
+      'pruneEmailLogBatch(',
     ]) {
       expect(preListen).not.toContain(call);
     }
@@ -74,6 +77,14 @@ describe('retention sweep wiring in server/main.ts', () => {
       'foldOnlinePeak(',
       'distinctOnlineSampleRealms(',
       'dailyRewardEventsCutoffDay(',
+      // password_reset_requests / email_change_requests / email_log used to be
+      // absent from this table list entirely: each completed reset or email
+      // change left a permanent row (the per-account supersede DELETE in db.ts
+      // only removes a duplicate PENDING row, never a consumed one), and every
+      // outbound email attempt logged forever. These three close that gap.
+      'prunePasswordResetRequestsBatch(',
+      'pruneEmailChangeRequestsBatch(',
+      'pruneEmailLogBatch(',
     ]) {
       expect(count(MAIN, call)).toBe(1);
     }
@@ -115,6 +126,13 @@ describe('retention sweep wiring in server/main.ts', () => {
     expect(MAIN).toContain(
       'pruneAccountIpAssociationsBatch(pool, config.accountIpAssociationRetentionDays, n)',
     );
+    expect(MAIN).toContain(
+      'prunePasswordResetRequestsBatch(config.passwordResetRequestRetentionDays, n)',
+    );
+    expect(MAIN).toContain(
+      'pruneEmailChangeRequestsBatch(config.emailChangeRequestRetentionDays, n)',
+    );
+    expect(MAIN).toContain('pruneEmailLogBatch(config.emailLogRetentionDays, n)');
   });
 
   it('sweeps the play-session fold before the association ager', () => {


### PR DESCRIPTION
## Summary

`password_reset_requests`, `email_change_requests`, and `email_log` are the only three unbounded per-event tables in `server/db.ts` that were missing from the nightly retention sweep (`server/retention_sweep.ts`, wired in `server/main.ts`). Every sibling table (`chat_logs`, `client_perf_reports`, `daily_reward_events`, `player_activity_daily`, `admin_site_presence_samples`, `site_presence_sessions`, `play_sessions`, `account_ip_associations`, plus the online-samples group) has a `RETENTION_DAYS` env key and a registered `pruneBatch` primitive. These three had neither.

The comment at each per-account "supersede" `DELETE` (run when a new password reset or email-change request is created) claimed it "keeps the table from accumulating dead rows." That is only true for duplicate still-PENDING rows for the same account: a row that gets consumed (a completed reset or email change), or one that is simply abandoned and expires, is never touched by that `DELETE` and stays forever. `email_log` had no pruning story of any kind: every outbound email attempt (success or failure) writes one permanent row.

### Fix
- Added `prunePasswordResetRequestsBatch`, `pruneEmailChangeRequestsBatch`, and `pruneEmailLogBatch` in `server/db.ts`, mirroring the existing `pruneClientPerfReportsBatch` shape (bounded oldest-first batch DELETE, `retentionDays <= 0` keeps rows forever).
- Registered all three as `retentionSweep.tables` entries in `server/main.ts`.
- Added `PASSWORD_RESET_REQUEST_RETENTION_DAYS` (default 30), `EMAIL_CHANGE_REQUEST_RETENTION_DAYS` (default 30), and `EMAIL_LOG_RETENTION_DAYS` (default 90) to `server/http/config.ts` and `.env.example`, following the untrimmed "0 = keep forever" contract the other six retention-day keys use.
- Added a dedicated age-column index per table (`email_change_requests_created`, `password_reset_requests_created`, `email_log_sent`) so the new batch DELETEs can ride an oldest-first `ORDER BY` instead of a per-batch full sort (`email_log`'s existing `email_log_account` index leads on `account_id`, so it can't serve an account-agnostic age scan).
- Corrected the misleading DDL and DELETE-site comments to state what the supersede DELETE actually bounds (duplicate PENDING rows only) versus what the new prune primitives bound (the table's real long-term growth).
- Extended `tests/server/main_retention_wiring.test.ts` (the wiring pin test) to cover the three new prune call sites and their config-key threading.

## Related issues

N/A (found during a fresh code audit; no existing issue).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/db_retention_prune.test.ts tests/server/main_retention_wiring.test.ts tests/server/http/config.test.ts tests/retention_sweep.test.ts tests/admin_retention_db.test.ts tests/play_session_retention.test.ts tests/play_session_retention_integration.test.ts` (130 passed, 6 skipped)
  - `npx vitest run tests/account_server.test.ts tests/password_reset_server.test.ts tests/password_reset_client.test.ts tests/email_tokens.test.ts tests/server/account.test.ts` (88 passed, unaffected)
  - `npx vitest run tests/architecture.test.ts tests/world_api_parity.test.ts` (303 passed, unaffected as expected for a server-only change)
  - `npx tsc --noEmit` (clean)
  - `npx @biomejs/biome check --write server/db.ts server/main.ts server/http/config.ts .env.example tests/db_retention_prune.test.ts tests/server/main_retention_wiring.test.ts tests/server/http/config.test.ts` (no errors, no format diffs beyond the new code)
- Manual steps: confirmed each new test failed for the right reason (missing export / missing config field / missing wiring text) before implementing the fix, then confirmed all pass after.

## Screenshots / recordings

N/A. This is sim/server-only, test-covered logic with no player- or operator-visible surface.

---

## Checklist

### Quality

- [x] **The full gate passes.** Ran the targeted suites above plus `tsc` and `biome` (not the full `npm run gate`, per the narrow-verification instruction for this batch); I added decisive tests for the new behavior and recorded the exact commands above.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, no UI surface.
- ~~Accessible.~~ N/A, no UI surface.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

## Root cause

```mermaid
flowchart TD
    subgraph before["Before: three tables missing from the sweep"]
        A1[createPasswordResetRequest] -->|DELETE pending-only<br/>for this account| A2[password_reset_requests]
        A3[createEmailChangeRequest] -->|DELETE pending-only<br/>for this account| A4[email_change_requests]
        A5[recordEmailLog] -->|INSERT, never deleted| A6[email_log]
        A2 -.not in retentionSweep.tables.-> A7[grows forever]
        A4 -.not in retentionSweep.tables.-> A7
        A6 -.not in retentionSweep.tables.-> A7
    end

    subgraph after["After: registered in the nightly sweep"]
        B1[password_reset_requests] --> B4[prunePasswordResetRequestsBatch]
        B2[email_change_requests] --> B5[pruneEmailChangeRequestsBatch]
        B3[email_log] --> B6[pruneEmailLogBatch]
        B4 --> B7[retentionSweep.tables in main.ts]
        B5 --> B7
        B6 --> B7
        B7 --> B8[nightly batched DELETE,<br/>bounded by RETENTION_DAYS env keys]
    end
```
