### PR TITLE
fix(professions): stop the Bombardier pair defaulting into a zero-content hobby

### DIFF
--- a/src/sim/professions/archetype.ts
+++ b/src/sim/professions/archetype.ts
@@ -25,7 +25,7 @@
 // server, and in the headless RL env unchanged.
 
 import { adjacentCrafts, CRAFT_RING, oppositeCraft } from '../content/professions';
-import { COMBO_RECIPES } from '../content/recipes';
+import { ALL_RECIPES, COMBO_RECIPES } from '../content/recipes';
 import type { SimContext } from '../sim_context';
 import {
   type CraftSkills,
@@ -213,8 +213,31 @@ export function hobbyCandidatesForPair(activeArchetype: string, pairedMajor: str
   return [oppositeCraft(activeArchetype).id, oppositeCraft(pairedMajor).id];
 }
 
-/** Choose the higher retained-skill hobby, with ring order as the stable tie
- * break. This is used for first attunement and old-save backfill. */
+// Craft ids with real, reachable content: at least one recipe in
+// content/recipes.ts (ALL_RECIPES) targets it, or it has an enchanting-style
+// action outside the recipe table (today, only enchanting itself, via
+// disenchanting; see professions/enchanting.ts). Jewelcrafting and
+// Inscription have neither (content/deeds.ts's prog_guildsworn comment: "no
+// live skill-gain path yet, zero recipes, no enchanting-style action"), so
+// defaulting a fresh hobby into either soft-locks the slot: no possible skill
+// gain until an unrelated hobby-switch quest moves it. Read once at module
+// load: ALL_RECIPES is a static content table, never mutated at runtime.
+const CRAFTS_WITH_CONTENT: ReadonlySet<string> = new Set([
+  ...ALL_RECIPES.map((recipe) => recipe.professionId),
+  'enchanting',
+]);
+
+function craftHasContent(craftId: string): boolean {
+  return CRAFTS_WITH_CONTENT.has(craftId);
+}
+
+/** Choose the higher retained-skill hobby; among an equal-skill (typically
+ * zero-skill) tie, prefer a candidate with real content (craftHasContent)
+ * over one with none, and only then fall back to ring order as the final
+ * stable tie break. This is used for first attunement and old-save backfill.
+ * Deliberately NOT applied in hobbyCandidatesForPair: the explicit
+ * hobby-switch quest still needs every ring-opposite candidate reachable by
+ * player choice, content or not. */
 export function defaultHobbyForPair(
   activeArchetype: string,
   pairedMajor: string,
@@ -225,6 +248,8 @@ export function defaultHobbyForPair(
   return [...candidates].sort((a, b) => {
     const skillDelta = (skills[b] ?? 0) - (skills[a] ?? 0);
     if (skillDelta !== 0) return skillDelta;
+    const contentDelta = Number(craftHasContent(b)) - Number(craftHasContent(a));
+    if (contentDelta !== 0) return contentDelta;
     return (
       CRAFT_RING.findIndex((craft) => craft.id === a) -
       CRAFT_RING.findIndex((craft) => craft.id === b)

--- a/tests/professions_archetype.test.ts
+++ b/tests/professions_archetype.test.ts
@@ -348,6 +348,24 @@ describe('defaultHobbyForPair skill preference (hobby default)', () => {
   it('returns null for a non-adjacent pair', () => {
     expect(defaultHobbyForPair('engineering', 'tailoring', {})).toBeNull();
   });
+
+  // Bug (fresh code audit, no existing issue): the ring-order tie break alone
+  // ignores content availability. The live, shipped Bombardier pair
+  // (engineering+alchemy) has ring opposites inscription (ring index 5) and
+  // enchanting (ring index 6); ring order picks inscription first, but
+  // inscription has zero recipes and no other skill-gain path
+  // (content/deeds.ts's prog_guildsworn comment: "Jewelcrafting and
+  // Inscription have no live skill-gain path yet"), so a fresh Bombardier
+  // character is defaulted into a hobby slot that can never progress until an
+  // unrelated hobby-switch quest is separately discovered. Enchanting has
+  // real content (disenchanting) and must win the tie instead.
+  it('prefers a candidate with real content over one with none, at equal (zero) skill', () => {
+    expect(defaultHobbyForPair('engineering', 'alchemy', {})).toBe('enchanting');
+  });
+
+  it('the content-availability tiebreak never overrides an actual skill preference', () => {
+    expect(defaultHobbyForPair('engineering', 'alchemy', { inscription: 5 })).toBe('inscription');
+  });
 });
 
 function ctxOf(sim: Sim) {

--- a/tests/professions_hobby_craft.test.ts
+++ b/tests/professions_hobby_craft.test.ts
@@ -45,16 +45,24 @@ describe('IWorld hobbyCraft read surface (#1294)', () => {
     expect(sim.hobbyCraft).toBeNull();
   });
 
-  it('b. completing the acceptance quest grants a hobby: the opposite craft on the ring', () => {
+  it("b. completing the acceptance quest grants a hobby: one of the pair's two ring-opposite candidates", () => {
     const sim = makeSim();
     sim.acceptArchetypeQuest(CRAFT_A);
-    expect(sim.hobbyCraft).toBe(oppositeCraft(CRAFT_A).id);
+    // CRAFT_A is engineering; acceptArchetypeQuest pairs it with its
+    // combo-aware default major, alchemy (the Bombardier pair). The two ring
+    // opposites are inscription (opposite engineering) and enchanting
+    // (opposite alchemy); inscription has zero recipes and no other
+    // skill-gain path (content/deeds.ts's prog_guildsworn comment), so
+    // defaultHobbyForPair's content-availability tiebreak picks enchanting
+    // over the plain ring-order tie break (see tests/professions_archetype.test.ts
+    // for the general rule).
+    expect(sim.hobbyCraft).toBe('enchanting');
   });
 
   it('c. switching the active archetype re-derives the deterministic default hobby for the new pair', () => {
     const sim = makeSim();
     sim.acceptArchetypeQuest(CRAFT_A);
-    expect(sim.hobbyCraft).toBe(oppositeCraft(CRAFT_A).id);
+    expect(sim.hobbyCraft).toBe('enchanting');
 
     const required = sim.archetypeAmendsRequired;
     for (let i = 0; i < required; i++) sim.advanceAmendsProgress();
@@ -64,15 +72,18 @@ describe('IWorld hobbyCraft read surface (#1294)', () => {
     // CRAFT_B is alchemy: its combo-aware default pair is alchemy+engineering,
     // whose two opposite candidates are enchanting (opposite alchemy) and
     // inscription (opposite engineering). With zero retained skill,
-    // defaultHobbyForPair tie-breaks by ring order to inscription. Pinned as
-    // literals so a change to the pair-default or hobby-default rule reddens
-    // here deliberately (see tests/professions_archetype.test.ts for the
-    // skill-preference arm).
+    // ring order alone would tie-break to inscription, but inscription has
+    // zero recipes and no other skill-gain path (content/deeds.ts's
+    // prog_guildsworn comment), so defaultHobbyForPair's content-availability
+    // tiebreak picks enchanting instead (real content via disenchanting).
+    // Pinned as literals so a change to the pair-default or hobby-default
+    // rule reddens here deliberately (see tests/professions_archetype.test.ts
+    // for the skill-preference and content-availability arms).
     const meta = (
       sim as unknown as { players: Map<number, { archetype: { pairedMajor: string } }> }
     ).players.get(sim.playerId)!;
     expect(meta.archetype.pairedMajor).toBe('engineering');
-    expect(sim.hobbyCraft).toBe('inscription');
+    expect(sim.hobbyCraft).toBe('enchanting');
   });
 
   it('d. per-pid read surface (hobbyCraftFor) matches the primary-player getter', () => {
@@ -90,8 +101,18 @@ describe('IWorld hobbyCraft read surface (#1294)', () => {
     const meta = (
       sim as unknown as { players: Map<number, { archetype: { pairedMajor: string } }> }
     ).players.get(sim.playerId)!;
+    // The real persisted hobby is passed explicitly as the 4th arg, matching
+    // every production call site (crafting.ts, combo_eligibility.ts): the
+    // 4th param's own default (the legacy single-craft getHobbyCraft
+    // fallback) is deliberately NOT the same value once the content-availability
+    // tiebreak picks a different candidate than oppositeCraft(activeArchetype).
     expect(
-      archetypeCeilingFor(sim.activeArchetype, meta.archetype.pairedMajor, hobby as string),
+      archetypeCeilingFor(
+        sim.activeArchetype,
+        meta.archetype.pairedMajor,
+        hobby as string,
+        hobby as string,
+      ),
     ).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

`defaultHobbyForPair` (`src/sim/professions/archetype.ts`) chooses a player's default hobby craft (the opposite-craft slot capped at rare) between the two ring-opposite candidates of an archetype pair. At equal (typically zero) retained skill it tie-broke purely by ring order, with no awareness of whether the winning candidate actually has any content.

For the live, shipped Bombardier pair (engineering+alchemy, granted via `q_prof_attune_bombardier`), the two candidates are inscription (ring index 5) and enchanting (ring index 6). Ring order alone always picked inscription, but inscription has zero recipes and no other skill-gain path (`content/deeds.ts`'s `prog_guildsworn` comment already documents this: "Jewelcrafting and Inscription have no live skill-gain path yet"). A fresh Bombardier character was therefore permanently defaulted into a hobby slot that can never progress, until the player separately discovered and completed the unrelated `q_prof_hobby_switch` quest to move off it.

### Fix

Added a `craftHasContent` predicate (every `professionId` referenced in `content/recipes.ts`'s `ALL_RECIPES`, plus `enchanting`, which gains skill through disenchanting outside the recipe table) and folded it into `defaultHobbyForPair`'s comparator as a tiebreak that runs after the existing skill preference and before the ring-order fallback. `hobbyCandidatesForPair` is untouched on purpose: the explicit hobby-switch quest still needs every ring-opposite candidate reachable by player choice, content or not.

```mermaid
flowchart TD
    A["defaultHobbyForPair(engineering, alchemy, skills={})"] --> B["candidates = [inscription, enchanting]"]
    B --> C{"skill(a) != skill(b)?"}
    C -- "no, both 0" --> D{"BEFORE FIX:\nring order only"}
    D --> E["inscription wins\n(ring index 5 < 6)"]
    E --> F["hobbyCraft = inscription\nzero recipes, zero skill-gain path\nSOFT-LOCKED until unrelated\nhobby-switch quest is found"]

    C -- "no, both 0" --> G{"AFTER FIX:\ncontentDelta tiebreak\n(craftHasContent)"}
    G --> H["enchanting has content\n(disenchanting), inscription does not"]
    H --> I["hobbyCraft = enchanting\nreal, immediately-progressable content"]

    style F fill:#f66,color:#000
    style I fill:#6c6,color:#000
```

## Related issues

N/A (found by fresh code audit, no existing tracked issue).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands run from the worktree root:
  - `npx tsc --noEmit` — clean.
  - `npx vitest run tests/professions_hobby_craft.test.ts tests/professions_archetype.test.ts tests/archetype_ceiling.test.ts tests/profession_attunement_quests.test.ts tests/professions_archetype_title.test.ts` — 114/114 passed.
  - `npx vitest run tests/professions*.test.ts tests/archetype_ceiling.test.ts tests/combo_eligibility.test.ts tests/profession_*.test.ts` — 1243/1243 passed (full professions surface, to confirm no pair besides the ones this fix intentionally changes regressed).
  - `npx vitest run tests/architecture.test.ts tests/world_api_parity.test.ts` — 303/303 passed (determinism/seam guards untouched).
  - `npx vitest run tests/parity/parity.test.ts tests/parity/coverage.test.ts` — 167/167 passed (golden-trace parity unaffected; the change draws zero rng).
  - `npx @biomejs/biome check --write src/sim/professions/archetype.ts tests/professions_archetype.test.ts tests/professions_hobby_craft.test.ts` — no fixes applied, no new warnings introduced (the 5 pre-existing `noNonNullAssertion` warnings reported predate this change and sit on lines this PR never touches).
- Test-first: added a new failing test in `tests/professions_archetype.test.ts` (`defaultHobbyForPair('engineering', 'alchemy', {})` expected `'enchanting'`) against the actual `defaultHobbyForPair` code path, confirmed it failed with `Received: "inscription"` before the fix, then made the smallest change (the `contentDelta` comparator term) that turned it green. Also added a companion test pinning that the content tiebreak never overrides an actual skill preference. Updated the one pre-existing pinned literal in `tests/professions_hobby_craft.test.ts` (test `c`) from `'inscription'` to `'enchanting'`, and fixed two now-divergent assertions in that same file (`b`, which coincidentally matched the legacy single-craft `oppositeCraft(activeArchetype)` fallback before this fix, and `e`, which now needs the real persisted hobby passed explicitly as the 4th `archetypeCeilingFor` argument, matching every production call site in `crafting.ts` and `combo_eligibility.ts`).
- Manually enumerated all 10 ring-adjacent archetype pairs against `craftHasContent` to confirm the fix only changes the previously-broken engineering+alchemy (Bombardier) and cooking+leatherworking pairs (the latter had the identical latent bug via jewelcrafting, just not the one named in this report), and leaves every other pair's zero-skill default unchanged, matching the existing pinned literals throughout `tests/professions_archetype.test.ts`, `tests/archetype_ceiling.test.ts`, and `tests/profession_attunement_quests.test.ts` (all of which passed unmodified).

## Screenshots / recordings

Skipped. The observable difference is a single default-value change deep in an archetype-identity state machine (which hobby craft id a fresh Bombardier character's `ArchetypeState.hobbyCraft` resolves to); a genuinely honest before/after screenshot would require driving the full in-client Bombardier quest chain (traveling to Tinker Gizzel, accepting and turning in `q_prof_attune_bombardier`) and then reading the Professions window's hobby row, which adds a lot of scripted-gameplay surface for a change with no CSS/layout/rendering component. The behavior is directly and decisively covered by the automated tests above instead (`tests/professions_hobby_craft.test.ts`, `tests/professions_archetype.test.ts`).

---

## Checklist

### Quality

- [x] Added or updated decisive tests for changed behavior (see "How was this tested?"). Ran the full relevant targeted suite green; did not run the full `npm run gate` (other agents were running concurrently on this machine, so verification was kept narrow per instructions), but `tsc`, the full professions test surface, architecture, world_api_parity, and golden-trace parity all pass.

### Cross-platform

- N/A. No UI/render/HUD surface touched; pure `src/sim/` logic change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (it changes which existing craft id a state field defaults to; no new copy).

### Hygiene

- [x] No secrets, credentials, or `.env` committed; `ALLOW_DEV_COMMANDS` not touched.
- [x] No generated files hand-edited.
