### PR TITLE
test(guide): pin LEVEL_CAP and ZONE_TEASERS against the sim source of truth

### DIFF
--- a/tests/guide_level_cap_drift.test.ts
+++ b/tests/guide_level_cap_drift.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { LEVEL_CAP, ZONE_TEASERS } from '../src/guide/data';
+import { ZONES } from '../src/sim/data';
+import { MAX_LEVEL } from '../src/sim/types';
+
+// LEVEL_CAP and ZONE_TEASERS in src/guide/data.ts are hand-duplicated literals,
+// not derived from the sim (see the comment atop that file): LEVEL_CAP mirrors
+// MAX_LEVEL and each ZONE_TEASERS entry mirrors a ZoneDef.levelRange, matched by
+// biome id ('vale'/'marsh'/'peaks'). Five guide surfaces (home, progression, faq,
+// combat, and the SEO JSON-LD in head.ts) render the hand copy directly, so a sim
+// level or zone band change would silently strand the guide showing a stale cap
+// or band until a human noticed, the same way CLASS_CHIPS drifted before
+// class_colors.test.ts pinned it. This suite is that same guard for LEVEL_CAP and
+// ZONE_TEASERS: any future drift between the two copies fails CI immediately.
+
+// ZONE_TEASERS ids ('vale'/'marsh'/'peaks') are guide-side biome labels, not sim
+// ZoneDef ids, and ZoneDef.biome is NOT unique: both eastbrook_vale (levelRange
+// [1, 7]) and farshore_isle (levelRange [3, 7]) declare biome 'vale'. Resolving a
+// teaser by ZONES.find(z => z.biome === id) would silently pick whichever zone
+// happens to come first in the ZONES array, so this map pins each teaser to the
+// explicit ZoneDef.id it is documenting instead of leaning on array order.
+const TEASER_ZONE_ID: Record<string, string> = {
+  vale: 'eastbrook_vale',
+  marsh: 'mirefen_marsh',
+  peaks: 'thornpeak_heights',
+  dusk: 'veiled_hollow',
+  ember: 'drakelands',
+  frost: 'frostveil',
+  amber: 'amberfall',
+  fen: 'willowfen',
+};
+
+describe('guide level cap and zone band freshness', () => {
+  it('LEVEL_CAP matches the sim MAX_LEVEL', () => {
+    expect(LEVEL_CAP).toBe(MAX_LEVEL);
+  });
+
+  it('every ZONE_TEASERS entry maps to a real sim zone id, with no duplicate ids', () => {
+    // ZONE_TEASERS is a curated subset for the landing page (see the comment atop
+    // src/guide/data.ts), not a full roster, so this checks each teaser resolves to a
+    // real ZoneDef rather than requiring the reverse (every sim zone has a teaser).
+    const zoneIds = new Set<string>(ZONES.map((z) => z.id));
+    const ids = ZONE_TEASERS.map((z) => z.id);
+    expect(new Set(ids).size, 'ZONE_TEASERS ids must be unique').toBe(ids.length);
+    for (const id of ids) {
+      const zoneId = TEASER_ZONE_ID[id];
+      expect(zoneId, `ZONE_TEASERS id "${id}" has no entry in TEASER_ZONE_ID`).toBeDefined();
+      expect(
+        zoneIds.has(zoneId),
+        `TEASER_ZONE_ID["${id}"] = "${zoneId}" has no matching sim ZoneDef.id`,
+      ).toBe(true);
+    }
+  });
+
+  it('ZONE_TEASERS level bands match each ZoneDef.levelRange', () => {
+    for (const teaser of ZONE_TEASERS) {
+      const zoneId = TEASER_ZONE_ID[teaser.id];
+      const zone = ZONES.find((z) => z.id === zoneId);
+      expect(zone, `no sim zone found for guide teaser "${teaser.id}" (${zoneId})`).toBeDefined();
+      expect([teaser.min, teaser.max], `level band for "${teaser.id}"`).toEqual(zone?.levelRange);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`src/guide/data.ts` hand-duplicates two pieces of sim truth as literals:

- `LEVEL_CAP` mirrors `MAX_LEVEL` (`src/sim/types.ts`)
- each `ZONE_TEASERS` entry mirrors a `ZoneDef.levelRange` (`src/sim/data.ts`, matched by biome id: `vale`/`marsh`/`peaks`)

Five guide surfaces read the hand copy directly and would silently go stale on any sim-side change: `src/guide/pages/home.ts` (zone cards + FAQ answer), `src/guide/pages/progression.ts`, `src/guide/pages/faq.ts`, `src/guide/pages/combat.ts`, and the SEO JSON-LD in `src/guide/head.ts`. Only `src/guide/pages/world.ts` correctly sources the generator output (`GUIDE_ZONES` from `src/guide/content.generated.ts`). Nothing compared the hand copy to the sim, unlike the sibling `CLASS_CHIPS` table in the same file, which this repo has already been burned by drifting before and which `tests/class_colors.test.ts` now pins.

This PR adds the equivalent freshness guard for `LEVEL_CAP`/`ZONE_TEASERS`: a new pin test, `tests/guide_level_cap_drift.test.ts`, that imports `MAX_LEVEL` and `ZONES` from `src/sim/` and asserts they equal the guide's hand copy. The current values already agree (`LEVEL_CAP` is 20, matching `MAX_LEVEL`; each zone band matches its `ZoneDef.levelRange`), so this is a coverage-only change: no production code or behavior changes. Per the recommended fix approach, the larger refactor to have all five guide surfaces consume the generator output directly is intentionally out of scope here.

## Related issues

N/A (no existing issue; found by a fresh code audit).

## Type of change

- [x] Bug fix (missing regression coverage that allowed silent drift)
- [x] Tests

## How was this tested?

Commands run from the worktree root:

- `npx tsc --noEmit` -- clean, no errors.
- `npx vitest run tests/guide_level_cap_drift.test.ts` -- 3 passed.
- `npx vitest run tests/guide_level_cap_drift.test.ts tests/class_colors.test.ts tests/guide.test.ts` -- 90 passed, confirming the new test coexists cleanly with the existing guide and class-color pin suites.
- `npx vitest run tests/architecture.test.ts` -- 33 passed (sim purity/determinism guard, unaffected but plausibly touched by an import from `src/sim/`).
- `npx @biomejs/biome check --write tests/guide_level_cap_drift.test.ts` -- formatted, no further diffs on re-check.

Test-first verification that the guard actually catches drift (not just a trivially-true assertion): temporarily changed `LEVEL_CAP` to `25` and re-ran the suite, saw `LEVEL_CAP matches the sim MAX_LEVEL` fail with `expected 25 to be 20`; separately changed the marsh zone's `max` from `13` to `12` and saw `ZONE_TEASERS level bands match each ZoneDef.levelRange` fail with `expected [ 6, 12 ] to deeply equal [ 6, 13 ]`. Reverted both before committing (confirmed via `git diff --stat` showing only the new test file).

## Screenshots / recordings

N/A. This change adds test coverage only; it does not alter any rendered guide page, HUD, or player-visible output. The guide currently renders the correct cap and zone bands both before and after this PR, so there is no honest before/after visual to capture.

```mermaid
flowchart TD
    subgraph sim["src/sim/ (source of truth)"]
        ML["MAX_LEVEL"]
        Z1["ZONE1_ZONE.levelRange [1,7]"]
        Z2["ZONE2_ZONE.levelRange [6,13]"]
        Z3["ZONE3_ZONE.levelRange [13,20]"]
    end

    subgraph gen["src/guide/content.generated.ts"]
        GZ["GUIDE_ZONES (derived via scripts/wiki generator)"]
    end

    subgraph hand["src/guide/data.ts (hand literals)"]
        LC["LEVEL_CAP = 20"]
        ZT["ZONE_TEASERS [vale, marsh, peaks]"]
    end

    ML -.->|npm run wiki:content| GZ
    Z1 -.-> GZ
    Z2 -.-> GZ
    Z3 -.-> GZ

    GZ --> World["src/guide/pages/world.ts (correct)"]

    LC --> Home["home.ts"]
    LC --> Progression["progression.ts"]
    LC --> Faq["faq.ts"]
    LC --> Combat["combat.ts"]
    LC --> Head["head.ts SEO JSON-LD"]
    ZT --> Home
    ZT --> Progression

    ML -. "NEW: pinned by" .-> Guard["tests/guide_level_cap_drift.test.ts"]
    Z1 -. "NEW: pinned by" .-> Guard
    Z2 -. "NEW: pinned by" .-> Guard
    Z3 -. "NEW: pinned by" .-> Guard
    Guard -. "asserts equality against" .-> LC
    Guard -. "asserts equality against" .-> ZT

    style hand fill:#3a2020
    style Guard fill:#204a30
```

The five hand-literal-consuming pages (top row) had no path back to the sim's `MAX_LEVEL`/`ZoneDef.levelRange` before this change; only `world.ts` did, via the generator. The new test closes that gap by asserting the hand copy and the sim agree, without touching the five pages themselves.

---

## Checklist

### Quality

- [x] **The full gate passes.** Ran the targeted subset described above (full `npm run gate` was not run, to keep this narrow while other agents share the machine); typecheck, the new test, and related existing suites are all green.

### Cross-platform

- ~~Tested on desktop and mobile.~~ N/A, no rendered UI changed.
- ~~Accessible.~~ N/A, no UI changed.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled anywhere.
- [x] I didn't hand-edit any generated file.
