### PR TITLE
fix(ui): preserve options menu back navigation

### DIFF
--- a/src/ui/options_window.ts
+++ b/src/ui/options_window.ts
@@ -381,7 +381,7 @@ export class OptionsWindow {
    *  sub-view in place if it is open, so the button glyphs switch to the newly
    *  detected brand without the player reopening the panel. A no-op otherwise. */
   refreshControllerLabels(): void {
-    if (this.isOpen && this.view === 'controller') this.renderController();
+    if (this.isOpen && this.view === 'controller') this.render();
   }
 
   // -------------------------------------------------------------------------
@@ -908,7 +908,7 @@ export class OptionsWindow {
               // Success: rebuild the panel in the new language (re-creates this picker
               // at the now-active locale).
               if (this.isOpen && this.view === 'interface') {
-                this.renderInterface();
+                this.render();
                 // Return keyboard focus to the fresh picker trigger so it isn't lost to <body>.
                 this.deps.focusFirstInteractive(this.deps.root(), '.set-lang-select .ui-dd-btn');
               }
@@ -964,7 +964,7 @@ export class OptionsWindow {
       btn.addEventListener('click', () => {
         audio.click();
         theme.setPreset(id);
-        this.renderInterface(); // refresh active state + custom pickers
+        this.render(); // refresh active state + custom pickers
       });
       seg.appendChild(btn);
     }
@@ -986,7 +986,7 @@ export class OptionsWindow {
     reset.addEventListener('click', () => {
       audio.click();
       theme.resetCustom();
-      this.renderInterface();
+      this.render();
     });
     customRow.append(customName, reset);
     body.appendChild(customRow);
@@ -1047,7 +1047,7 @@ export class OptionsWindow {
     body.setAttribute('role', 'tabpanel');
     wireTabStrip(el, 'opt-tab', (id, focusFollow) => {
       this.interfaceTab = id as InterfaceTab;
-      this.renderInterface();
+      this.render();
       if (focusFollow) focusActiveTab(this.deps.root(), 'opt-tab', 'on');
     });
 
@@ -1063,7 +1063,7 @@ export class OptionsWindow {
         interfaceControlsForTab(buildInterfaceControls(this.settingsSource(hooks)), tab),
         hooks,
         (focusKey) => {
-          this.renderInterface();
+          this.render();
           if (focusKey)
             this.deps
               .root()
@@ -1429,7 +1429,7 @@ export class OptionsWindow {
     const hooks = this.deps.options();
     const body = this.settingsViewShell(t('hudChrome.controller.title'));
     const controls = hooks ? buildControllerControls(this.settingsSource(hooks)) : [];
-    if (hooks) this.applyControls(body, controls, hooks, () => this.renderController());
+    if (hooks) this.applyControls(body, controls, hooks, () => this.render());
 
     const note = document.createElement('div');
     note.className = 'set-note';
@@ -1475,7 +1475,7 @@ export class OptionsWindow {
       reset.addEventListener('click', () => {
         audio.click();
         hooks.gamepad.reset();
-        this.renderController();
+        this.render();
       });
       body.appendChild(reset);
     }

--- a/src/ui/options_window.ts
+++ b/src/ui/options_window.ts
@@ -830,7 +830,7 @@ export class OptionsWindow {
           nativeShell: isNativeAppShell(),
         })
       : [];
-    if (hooks) this.applyControls(body, controls, hooks, () => this.renderGraphics());
+    if (hooks) this.applyControls(body, controls, hooks, () => this.render());
     const el = this.deps.root();
     const note = document.createElement('div');
     note.className = 'set-note';
@@ -859,7 +859,7 @@ export class OptionsWindow {
     const hooks = this.deps.options();
     const body = this.settingsViewShell(t('hud.options.audio'));
     const controls = hooks ? buildAudioControls(this.settingsSource(hooks)) : [];
-    if (hooks) this.applyControls(body, controls, hooks, () => this.renderAudio());
+    if (hooks) this.applyControls(body, controls, hooks, () => this.render());
     this.settingsViewFooter(controls);
   }
 
@@ -1522,7 +1522,7 @@ export class OptionsWindow {
       else hooks.onSettingChange(key, hooks.settings.set(key, next));
       sync();
       // Attack Move reveals/hides its rebindable key row, so redraw the panel.
-      if (key === 'attackMove') this.renderKeybinds();
+      if (key === 'attackMove') this.render();
     });
     row.append(name, toggle);
     parent.appendChild(row);
@@ -1657,7 +1657,7 @@ export class OptionsWindow {
       this.capturingKey = null;
       this.keybindNote = t('hud.options.keybindReset');
       this.deps.refreshKeybindLabels();
-      this.renderKeybinds();
+      this.render();
     });
     const back = document.createElement('button');
     back.className = 'btn';
@@ -1673,7 +1673,7 @@ export class OptionsWindow {
     const name = this.actionDisplayName(actionId, fallbackLabel);
     this.capturingKey = { action: actionId, index };
     this.keybindNote = t('hud.options.keybindCapture', { action: name });
-    this.renderKeybinds();
+    this.render();
     hooks.captureKey((code) => {
       this.capturingKey = null;
       if (code === null) {
@@ -1691,7 +1691,7 @@ export class OptionsWindow {
         this.keybindNote = t('hud.options.keybindReserved', { key: keyLabel(code) });
       }
       // re-render only if the menu is still open (player may have closed it)
-      if (this.isOpen) this.renderKeybinds();
+      if (this.isOpen) this.render();
     });
   }
 }

--- a/tests/options_window.test.ts
+++ b/tests/options_window.test.ts
@@ -182,6 +182,27 @@ describe('options_window: controller rebuild routing', () => {
     expect(painter.match(/this\.renderController\(\)/g) ?? []).toHaveLength(1);
     expect(painter).toContain("if (this.isOpen && this.view === 'controller') this.render();");
   });
+
+  it('keeps every settings sub-view rebuild behind render()', () => {
+    const renderDispatcher = painter.slice(
+      painter.indexOf('private render(): void {'),
+      painter.indexOf('private renderMain(): void {'),
+    );
+    for (const [view, renderer] of [
+      ['graphics', 'renderGraphics'],
+      ['audio', 'renderAudio'],
+      ['keybinds', 'renderKeybinds'],
+    ]) {
+      expect(painter.match(new RegExp(`this\\.${renderer}\\(\\)`, 'g')) ?? []).toHaveLength(1);
+      expect(renderDispatcher).toMatch(new RegExp(`case '${view}':\\s*this\\.${renderer}\\(\\);`));
+    }
+    expect(painter).toContain("if (key === 'attackMove') this.render();");
+    expect(painter).toMatch(/this\.deps\.keybinds\(\)\.reset\(\);[\s\S]{0,300}?this\.render\(\);/);
+    expect(painter).toMatch(
+      /this\.keybindNote = t\('hud\.options\.keybindCapture',[\s\S]{0,200}?this\.render\(\);\s*hooks\.captureKey/,
+    );
+    expect(painter).toContain('if (this.isOpen) this.render();');
+  });
 });
 
 // The exact control-dispatch wiring. The pure value coercion is unit-tested in

--- a/tests/options_window.test.ts
+++ b/tests/options_window.test.ts
@@ -121,8 +121,11 @@ describe('options_window: interface tab split', () => {
     // selecting a tab updates the session tab then re-renders the whole view
     expect(painter).toContain('this.interfaceTab = id as InterfaceTab;');
     expect(painter).toMatch(
-      /wireTabStrip\(el, 'opt-tab', \(id, focusFollow\) => \{\s*this\.interfaceTab = id as InterfaceTab;\s*this\.renderInterface\(\);/,
+      /wireTabStrip\(el, 'opt-tab', \(id, focusFollow\) => \{\s*this\.interfaceTab = id as InterfaceTab;\s*this\.render\(\);/,
     );
+    // render() is the only allowed caller because it rewires the title Back
+    // control after renderInterface() replaces the subtree.
+    expect(painter.match(/this\.renderInterface\(\)/g) ?? []).toHaveLength(1);
     // the panel body is the tabpanel the strip points at
     expect(painter).toContain("panelId: 'interface-tabpanel',");
     expect(painter).toContain("body.setAttribute('role', 'tabpanel');");
@@ -171,6 +174,13 @@ describe('options_window: interface tab split', () => {
     for (const sig of ['toggle(): void {', 'close(): void {', 'private goBack(): void {']) {
       expect(methodBody(sig), `${sig} must not touch interfaceTab`).not.toContain('interfaceTab');
     }
+  });
+});
+
+describe('options_window: controller rebuild routing', () => {
+  it('keeps render() as the only renderController caller so Back is rewired', () => {
+    expect(painter.match(/this\.renderController\(\)/g) ?? []).toHaveLength(1);
+    expect(painter).toContain("if (this.isOpen && this.view === 'controller') this.render();");
   });
 });
 
@@ -225,7 +235,7 @@ describe('options_window: changeLanguage hardening (PR #730)', () => {
     );
     expect(lang).toContain('.changeLanguage(selected');
     // success re-renders the panel; failure reverts the dropdown in place
-    expect(lang).toContain('this.renderInterface()');
+    expect(lang).toContain('this.render()');
     expect(lang).toContain('this.deps.setDropdownValue(dropdown, getLanguage())');
     // the trigger never gets stuck disabled on a throw
     expect(lang).toContain('.catch(');

--- a/tests/options_window_navigation.test.ts
+++ b/tests/options_window_navigation.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/game/app_viewport', () => ({ syncAppViewport: vi.fn() }));
+vi.mock('../src/game/audio', () => ({ audio: { click: vi.fn() } }));
+vi.mock('../src/game/music', () => ({
+  music: { pauseForMenu: vi.fn(), resumeFromMenu: vi.fn() },
+}));
+vi.mock('../src/ui/app_version', () => ({
+  appVersionInfo: () => ({ version: 'test', build: 'test' }),
+}));
+
+import { OptionsWindow, type OptionsWindowDeps } from '../src/ui/options_window';
+
+interface OptionsWindowTestAccess {
+  view: 'interface' | 'controller';
+  opened: boolean;
+  render(): void;
+}
+
+function mountView(view: OptionsWindowTestAccess['view']): {
+  root: HTMLElement;
+  window: OptionsWindow;
+  focusFirstInteractive: ReturnType<typeof vi.fn>;
+} {
+  const root = document.createElement('section');
+  root.style.display = 'block';
+  document.body.appendChild(root);
+  const focusFirstInteractive = vi.fn();
+  const deps = {
+    root: () => root,
+    world: () => ({}),
+    options: () => null,
+    bugReport: () => null,
+    keybinds: () => ({}),
+    slotActionName: () => null,
+    refreshKeybindLabels: vi.fn(),
+    buildDropdown: () => document.createElement('div'),
+    setDropdownValue: vi.fn(),
+    focusFirstInteractive,
+    closeOthers: vi.fn(),
+    hideTooltip: vi.fn(),
+    captureFocus: () => null,
+    restoreFocus: vi.fn(),
+    log: vi.fn(),
+    resetChatWindow: vi.fn(),
+    resetUnitFrames: vi.fn(),
+    getChatTimestamps: () => false,
+    setChatTimestamps: vi.fn(),
+    getChatClock: () => 'local',
+    setChatClock: vi.fn(),
+  } as unknown as OptionsWindowDeps;
+  const window = new OptionsWindow(deps);
+  const access = window as unknown as OptionsWindowTestAccess;
+  access.view = view;
+  access.opened = true;
+  access.render();
+  return { root, window, focusFirstInteractive };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('options window interface navigation', () => {
+  it('keeps the title-bar Back button wired after switching tabs', () => {
+    const { root, focusFirstInteractive } = mountView('interface');
+
+    const initialBack = root.querySelector<HTMLButtonElement>('[data-back]');
+    const frames = root.querySelector<HTMLButtonElement>('[data-tab="frames"]');
+    if (!initialBack || !frames) throw new Error('Interface navigation controls were not rendered');
+    frames.click();
+    const rebuiltBack = root.querySelector<HTMLButtonElement>('[data-back]');
+    if (!rebuiltBack) throw new Error('Interface Back control was not rebuilt');
+    expect(root.querySelector('[data-tab="frames"]')?.getAttribute('aria-selected')).toBe('true');
+    expect(rebuiltBack).not.toBe(initialBack);
+
+    rebuiltBack.click();
+
+    expect(root.querySelector('[role="tablist"]')).toBeNull();
+    expect(focusFirstInteractive).toHaveBeenCalledWith(root);
+  });
+
+  it('keeps the title-bar Back button wired after controller labels refresh', () => {
+    const { root, window, focusFirstInteractive } = mountView('controller');
+
+    const initialBack = root.querySelector<HTMLButtonElement>('[data-back]');
+    if (!initialBack) throw new Error('Controller Back control was not rendered');
+    window.refreshControllerLabels();
+    const rebuiltBack = root.querySelector<HTMLButtonElement>('[data-back]');
+    if (!rebuiltBack) throw new Error('Controller Back control was not rebuilt');
+    expect(rebuiltBack).not.toBe(initialBack);
+
+    rebuiltBack.click();
+
+    expect(root.querySelector('.opt-list')).not.toBeNull();
+    expect(focusFirstInteractive).toHaveBeenCalledWith(root);
+  });
+
+  it('does not rebuild controller labels while the options window is closed', () => {
+    const { root, window } = mountView('controller');
+    const initialBack = root.querySelector<HTMLButtonElement>('[data-back]');
+    if (!initialBack) throw new Error('Controller Back control was not rendered');
+    (window as unknown as OptionsWindowTestAccess).opened = false;
+
+    window.refreshControllerLabels();
+
+    expect(root.querySelector('[data-back]')).toBe(initialBack);
+  });
+
+  it('does not rebuild a non-controller view when controller labels refresh', () => {
+    const { root, window } = mountView('interface');
+    const initialBack = root.querySelector<HTMLButtonElement>('[data-back]');
+    if (!initialBack) throw new Error('Interface Back control was not rendered');
+
+    window.refreshControllerLabels();
+
+    expect(root.querySelector('[data-back]')).toBe(initialBack);
+  });
+});

--- a/tests/options_window_navigation.test.ts
+++ b/tests/options_window_navigation.test.ts
@@ -6,6 +6,10 @@ vi.mock('../src/game/audio', () => ({ audio: { click: vi.fn() } }));
 vi.mock('../src/game/music', () => ({
   music: { pauseForMenu: vi.fn(), resumeFromMenu: vi.fn() },
 }));
+vi.mock('../src/game/mobile_controls', () => ({
+  isNativeAppShell: () => false,
+  useTouchInterface: () => false,
+}));
 vi.mock('../src/ui/app_version', () => ({
   appVersionInfo: () => ({ version: 'test', build: 'test' }),
 }));
@@ -13,12 +17,15 @@ vi.mock('../src/ui/app_version', () => ({
 import { OptionsWindow, type OptionsWindowDeps } from '../src/ui/options_window';
 
 interface OptionsWindowTestAccess {
-  view: 'interface' | 'controller';
+  view: 'interface' | 'controller' | 'graphics';
   opened: boolean;
   render(): void;
 }
 
-function mountView(view: OptionsWindowTestAccess['view']): {
+function mountView(
+  view: OptionsWindowTestAccess['view'],
+  optionsHooks: object | null = null,
+): {
   root: HTMLElement;
   window: OptionsWindow;
   focusFirstInteractive: ReturnType<typeof vi.fn>;
@@ -30,7 +37,7 @@ function mountView(view: OptionsWindowTestAccess['view']): {
   const deps = {
     root: () => root,
     world: () => ({}),
-    options: () => null,
+    options: () => optionsHooks,
     bugReport: () => null,
     keybinds: () => ({}),
     slotActionName: () => null,
@@ -116,5 +123,31 @@ describe('options window interface navigation', () => {
     window.refreshControllerLabels();
 
     expect(root.querySelector('[data-back]')).toBe(initialBack);
+  });
+
+  it('keeps the title-bar Back button wired after selecting a graphics preset', () => {
+    const onSettingChange = vi.fn();
+    const optionsHooks = {
+      perfOverlay: { setPlacement: vi.fn() },
+      settings: {
+        get: vi.fn((key: string) => (key === 'graphicsPreset' ? 3 : 0)),
+      },
+      onSettingChange,
+    };
+    const { root, focusFirstInteractive } = mountView('graphics', optionsHooks);
+
+    const initialBack = root.querySelector<HTMLButtonElement>('[data-back]');
+    const low = root.querySelector<HTMLButtonElement>('.set-choice button[data-value="1"]');
+    if (!initialBack || !low) throw new Error('Graphics navigation controls were not rendered');
+    low.click();
+    const rebuiltBack = root.querySelector<HTMLButtonElement>('[data-back]');
+    if (!rebuiltBack) throw new Error('Graphics Back control was not rebuilt');
+    expect(onSettingChange).toHaveBeenCalledWith('graphicsPreset', 1);
+    expect(rebuiltBack).not.toBe(initialBack);
+
+    rebuiltBack.click();
+
+    expect(root.querySelector('.opt-list')).not.toBeNull();
+    expect(focusFirstInteractive).toHaveBeenCalledWith(root);
   });
 });


### PR DESCRIPTION
## Summary

Fixes title-bar Back becoming inert after an options sub-view rebuild.

Interface, Controller, Graphics, Audio, and Keybinds had internal paths that rebuilt their
panels directly. That replaced the Back button after the central `render()` dispatcher had
attached its listener. All sub-view rebuilds now route through `render()`, so every freshly
created title control is wired consistently.

jsdom regression tests cover an Interface tab switch, a Controller label refresh, and a real
Graphics LOW preset selection. They prove that the Back node was replaced and verify that it
returns to the Game Menu. Source guards keep every sub-renderer behind the dispatcher and pin
the remaining Keybinds rebuild triggers.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/options_window_navigation.test.ts tests/options_window.test.ts tests/options_view.test.ts tests/tab_strip_painter.test.ts tests/tab_strip_view.test.ts` (91 tests passed)
  - `npx tsc --noEmit` (passed)
  - `npx @biomejs/biome check src/ui/options_window.ts tests/options_window.test.ts tests/options_window_navigation.test.ts` (passed)
  - `npm run ci:changed` (passed with existing repository warnings)
  - `git diff --check` (passed)
  - `npm run gate` (reached the full Vitest stage; 1,798 files and 23,322 tests passed, but the stage remains red on this Windows host with unrelated path-separator, symlink-permission, temporary-file lock, and child-process failures: 17 files / 54 tests)
- Manual steps:
  - Opened Game Menu, entered Interface, switched tabs, and activated the title-bar Back arrow.
  - Confirmed the Game Menu is restored after the tab-triggered panel rebuild.

## Screenshots / recordings

N/A. The fix changes event wiring only and does not alter rendered UI or layout.

---

## Checklist

### Quality

- [ ] **The full gate passes.** The scoped tests and typecheck pass. The full gate is
      documented above because unrelated Windows-specific failures prevent a green local run.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Desktop Interface behavior was manually verified. No
      visual, sizing, or touch-target rules changed.
- [x] **Accessible.** Existing localized button semantics and focus handoff are preserved; the
      fix restores activation after subtree rebuilds and keeps keyboard tab focus restoration.

### Localization (i18n)

- [ ] **New player-visible strings follow the contributor policy.**
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters.
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at the client
      boundary in this same change.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in
      any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
