### PR TITLE
fix(ui): let reins be placed on the action bar like any other usable item

### DIFF
--- a/src/ui/hud/action_bar/action_bar_controller.ts
+++ b/src/ui/hud/action_bar/action_bar_controller.ts
@@ -243,11 +243,16 @@ export class ActionBarController {
     // Gathering implements (#2343): the simple pole (use.type 'fishing') and
     // every gatherTool (picks, axes, sickles, tiered rods) are placeable, so
     // a keybound press works the tool exactly like the bags click.
+    // Reins: the mounts-as-items pivot routes kind 'mount' through the same
+    // useItem dispatch a potion rides (src/sim/items.ts -> summonMountItem), so
+    // reins are placeable for the same reason a potion is. Without this arm the
+    // bag drag never writes a hotbar payload and the bar cannot accept them.
     const item = ITEMS[itemId];
     return (
       item?.kind === 'food' ||
       item?.kind === 'drink' ||
       item?.kind === 'potion' ||
+      item?.kind === 'mount' ||
       item?.use?.type === 'fishing' ||
       item?.use?.type === 'gatherTool'
     );

--- a/tests/action_bar_controller.test.ts
+++ b/tests/action_bar_controller.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { ITEMS } from '../src/sim/data';
 import type { PlayerClass } from '../src/sim/types';
 import {
   ACTION_BAR_ABILITY_SLOTS,
@@ -567,5 +568,33 @@ describe('isHotbarItemId: gathering implements are placeable (#2343)', () => {
     // Regression companions: the consumable arms and the non-usable negative.
     expect(controller.isHotbarItemId('lesser_healing_potion')).toBe(true);
     expect(controller.isHotbarItemId('copper_ore')).toBe(false);
+  });
+});
+
+describe('isHotbarItemId: reins are placeable now that mounts are items', () => {
+  // The mounts-as-items pivot made every reins item usable through the same
+  // useItem dispatch a potion rides (src/sim/items.ts, kind 'mount' ->
+  // summonMountItem), and that arm's own comment states reins are used from
+  // "bags or an action-bar slot". isHotbarItemId was never widened to match, so
+  // the bag drag never wrote a hotbar payload and the bar could not accept it.
+  it('admits every kind:mount reins item in the shipped content tables', () => {
+    const { controller } = makeHarness('warrior', [], []);
+    const reins = Object.keys(ITEMS).filter((id) => ITEMS[id]?.kind === 'mount');
+    // Guard the guard: if the content tables ever stop shipping mounts this test
+    // must fail loudly rather than vacuously pass on an empty list.
+    expect(reins.length).toBeGreaterThan(0);
+    for (const id of reins) {
+      expect(controller.isHotbarItemId(id), `${id} should be hotbar placeable`).toBe(true);
+    }
+  });
+
+  it('routes a reins drag through the assignable-action path like a potion', () => {
+    const { controller } = makeHarness('warrior', [], []);
+    // isAssignableAction is what the drop target consults; a reins action must
+    // survive it exactly as a potion action does.
+    expect(controller.isAssignableAction({ type: 'item', id: 'reins_valorsteed' })).toBe(true);
+    expect(controller.isAssignableAction({ type: 'item', id: 'lesser_healing_potion' })).toBe(true);
+    // A non-usable material still must not be assignable.
+    expect(controller.isAssignableAction({ type: 'item', id: 'copper_ore' })).toBe(false);
   });
 });


### PR DESCRIPTION
Reported in play: mounts cannot be dragged onto the action bar even though they are supposed to work like potions now.

## Cause

The mounts-as-items pivot in v0.32.0 routed `kind: 'mount'` through the same `useItem` dispatch a potion rides (`src/sim/items.ts` to `summonMountItem`). That arm's own comment states reins are used from "bags or an action-bar slot".

The action bar never learned about it. `isHotbarItemId` (`src/ui/hud/action_bar/action_bar_controller.ts:242`) admitted only `food`, `drink`, `potion`, `use.type: 'fishing'` and `use.type: 'gatherTool'`. The bag drag consults that predicate before it writes the hotbar payload (`src/ui/bags_window.ts:721`), so for reins the payload was never written and the bar had nothing to accept. Reins were usable only from the bags window.

## Fix

One arm added for `kind: 'mount'`. The same predicate also gates the keybound press (`hud.ts:5891`, `hud.ts:6149`) and `isAssignableAction`, so placing and pressing both start working from this single change.

Nothing downstream needed mount-specific handling. The item-slot painter already derives `count` from the inventory and applies a cooldown only to potions, so a reins slot paints and enables correctly as-is. The sim keeps owning every gate on press: riding skill first, then dead or ghost, then combat.

## Tests

Written first, and verified decisive by reverting the source arm and re-running:

- Without the fix: `reins_valorsteed should be hotbar placeable: expected false to be true`, 2 failed.
- With the fix: 31 passed.

The first case iterates every `kind: 'mount'` item in the shipped content tables rather than pinning a single id, and asserts the list is non-empty so it cannot pass vacuously if mounts ever leave the tables. The second pins `isAssignableAction`, which is what the drop target actually consults, with a potion as the positive control and a crafting material as the negative.

## Verification

- `tests/action_bar_controller.test.ts`, `mounts`, `bags_window`, `bags_window_use_routing`, `bags_money_row_paint`, `bags_window_instance_marker`, `hud_perf_budget`: 236 passed, 4 skipped.
- `tests/architecture.test.ts`: 33 passed.
- `npx tsc --noEmit` clean; Biome clean on both changed files.

## Two adjacent findings, deliberately not fixed here

1. **`kind: 'elixir'` has the identical gap.** Elixirs are usable through `useItem` and the mobile quick bar already treats them as first-class consumables (`CONSUMABLE_KIND_ORDER`), but `isHotbarItemId` does not admit them either, so they cannot be placed on the desktop bar. That gap predates the mount work and is a separate bug; say the word and I will fix it the same way.
2. **Mobile cannot place reins.** The mobile quick bar is auto-populated from `CONSUMABLE_KIND_ORDER` (potion, elixir, food, drink) because touch has no drag gesture, and it is documented as "the bag's Consumables category made castable". Mounts are not consumables, so adding them would widen that bar's stated purpose. Mobile players can still summon from the bags window. Worth a product call rather than a silent change.