### PR TITLE
fix(tests): exclude .worktrees/ from the vitest glob

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -382,6 +382,12 @@ export default defineConfig({
     // - agent-runtime directories may contain local worktree copies, and their tracked
     //   config or instruction files are not product test sources. Excluding them keeps a
     //   stale local worktree from duplicating tests. .venv is local Python tooling.
+    //   .worktrees/ is the repo's own gitignored convention for local linked worktrees
+    //   (see .gitignore); leaving it out of this list meant a worktree left checked out
+    //   there re-ran its whole frozen test tree on every `vitest run`, so a stale branch
+    //   snapshot inside it could fail tests/architecture.test.ts or
+    //   tests/localization_fixes.test.ts and block pre-push for reasons unrelated to the
+    //   current branch.
     // - the opt-in browser suite (vitest.browser.config.ts, npm run test:browser) must NOT
     //   leak into a bare `vitest run`: excluding its files keeps the default Node run from
     //   importing the Playwright provider or launching a browser. Cross-engine CI is P17b.
@@ -395,6 +401,7 @@ export default defineConfig({
       '**/.claude/**',
       '**/.codex/**',
       '**/.agents/**',
+      '**/.worktrees/**',
       '**/.venv/**',
       'tmp/**',
       'tests/browser/**',


### PR DESCRIPTION
## Summary
- `pre-push` / `npm run gate` could fail nondeterministically depending on what stray local state happened to sit in the repo, and the cause was hard to pin down from the failure output alone.
- Root cause: the vitest `exclude` list in `vite.config.ts` already skips `.claude/**`, `.codex/**`, and `.agents/**` so a stale linked worktree checked out under one of those does not get its frozen test tree re-run on every `vitest run` - but it missed the repo's own gitignored `.worktrees/` convention (`.gitignore` line 5: `.worktrees/`, and the `using-git-worktrees` workflow contributors are told to follow).
- Any branch with a linked worktree still checked out under `.worktrees/` at HEAD had that worktree's own `tests/architecture.test.ts` / `tests/localization_fixes.test.ts` picked up and run *again*, against whatever stale commit that worktree happened to be pinned to. A frozen worktree from a few commits back can fail those guard tests for reasons that have nothing to do with the branch you're actually pushing, so `npm run gate` and the pre-push hook fail "for various reasons" that don't reproduce on a clean checkout.
- Fix: add `.worktrees/**` to the same exclude list, mirroring the existing `.claude/**` entry.

```mermaid
flowchart TD
    A["vitest run (no path args)"] --> B{"glob tests/**/*.test.ts"}
    B --> C["repo's own tests/"]
    B --> D[".worktrees/&lt;task&gt;/tests/ (stale, gitignored)"]
    D -->|"before fix: not excluded"| E["re-runs frozen tests from an old commit"]
    E --> F["tests/architecture.test.ts or\ntests/localization_fixes.test.ts fails\nfor an unrelated reason"]
    F --> G["npm run gate / pre-push blocked"]
    D -->|"after fix: **/.worktrees/** excluded"| H["skipped, same as .claude/**"]
    C --> I["only the current branch's tests run"]
    H -.->|no longer reachable| F
```

## Test plan
- [x] `npx tsc --noEmit` - clean
- [x] `npx vitest run tests/architecture.test.ts tests/localization_fixes.test.ts` - 72 passed, 3 skipped
- [x] `npx @biomejs/biome check vite.config.ts` - no issues
- [x] Reproduced the failure mode locally: seeded a nested `.worktrees/fake/tests/broken.test.ts` with a deliberately failing test and confirmed a targeted `vitest run` no longer picks it up after the exclude is added (mirrors the existing, already-proven `.claude/**` behavior against the repo's real `.claude/worktrees/*` copies)
- [x] `git push` (pre-push QA floor: typecheck, guard tests, lint, copy rules) passed clean end to end