### PR TITLE
fix(professions): stop the Bombardier pair defaulting into a zero-content hobby

### DIFF
--- a/src/sim/professions/archetype.ts
+++ b/src/sim/professions/archetype.ts
@@ -25,7 +25,7 @@
 // server, and in the headless RL env unchanged.
 
 import { adjacentCrafts, CRAFT_RING, oppositeCraft } from '../content/professions';
-import { COMBO_RECIPES } from '../content/recipes';
+import { ALL_RECIPES, COMBO_RECIPES } from '../content/recipes';
 import type { SimContext } from '../sim_context';
 import {
   type CraftSkills,
@@ -213,8 +213,31 @@ export function hobbyCandidatesForPair(activeArchetype: string, pairedMajor: str
   return [oppositeCraft(activeArchetype).id, oppositeCraft(pairedMajor).id];
 }
 
-/** Choose the higher retained-skill hobby, with ring order as the stable tie
- * break. This is used for first attunement and old-save backfill. */
+// Craft ids with real, reachable content: at least one recipe in
+// content/recipes.ts (ALL_RECIPES) targets it, or it has an enchanting-style
+// action outside the recipe table (today, only enchanting itself, via
+// disenchanting; see professions/enchanting.ts). Jewelcrafting and
+// Inscription have neither (content/deeds.ts's prog_guildsworn comment: "no
+// live skill-gain path yet, zero recipes, no enchanting-style action"), so
+// defaulting a fresh hobby into either soft-locks the slot: no possible skill
+// gain until an unrelated hobby-switch quest moves it. Read once at module
+// load: ALL_RECIPES is a static content table, never mutated at runtime.
+const CRAFTS_WITH_CONTENT: ReadonlySet<string> = new Set([
+  ...ALL_RECIPES.map((recipe) => recipe.professionId),
+  'enchanting',
+]);
+
+function craftHasContent(craftId: string): boolean {
+  return CRAFTS_WITH_CONTENT.has(craftId);
+}
+
+/** Choose the higher retained-skill hobby; among an equal-skill (typically
+ * zero-skill) tie, prefer a candidate with real content (craftHasContent)
+ * over one with none, and only then fall back to ring order as the final
+ * stable tie break. This is used for first attunement and old-save backfill.
+ * Deliberately NOT applied in hobbyCandidatesForPair: the explicit
+ * hobby-switch quest still needs every ring-opposite candidate reachable by
+ * player choice, content or not. */
 export function defaultHobbyForPair(
   activeArchetype: string,
   pairedMajor: string,
@@ -225,6 +248,8 @@ export function defaultHobbyForPair(
   return [...candidates].sort((a, b) => {
     const skillDelta = (skills[b] ?? 0) - (skills[a] ?? 0);
     if (skillDelta !== 0) return skillDelta;
+    const contentDelta = Number(craftHasContent(b)) - Number(craftHasContent(a));
+    if (contentDelta !== 0) return contentDelta;
     return (
       CRAFT_RING.findIndex((craft) => craft.id === a) -
       CRAFT_RING.findIndex((craft) => craft.id === b)

--- a/tests/professions_archetype.test.ts
+++ b/tests/professions_archetype.test.ts
@@ -348,6 +348,24 @@ describe('defaultHobbyForPair skill preference (hobby default)', () => {
   it('returns null for a non-adjacent pair', () => {
     expect(defaultHobbyForPair('engineering', 'tailoring', {})).toBeNull();
   });
+
+  // Bug (fresh code audit, no existing issue): the ring-order tie break alone
+  // ignores content availability. The live, shipped Bombardier pair
+  // (engineering+alchemy) has ring opposites inscription (ring index 5) and
+  // enchanting (ring index 6); ring order picks inscription first, but
+  // inscription has zero recipes and no other skill-gain path
+  // (content/deeds.ts's prog_guildsworn comment: "Jewelcrafting and
+  // Inscription have no live skill-gain path yet"), so a fresh Bombardier
+  // character is defaulted into a hobby slot that can never progress until an
+  // unrelated hobby-switch quest is separately discovered. Enchanting has
+  // real content (disenchanting) and must win the tie instead.
+  it('prefers a candidate with real content over one with none, at equal (zero) skill', () => {
+    expect(defaultHobbyForPair('engineering', 'alchemy', {})).toBe('enchanting');
+  });
+
+  it('the content-availability tiebreak never overrides an actual skill preference', () => {
+    expect(defaultHobbyForPair('engineering', 'alchemy', { inscription: 5 })).toBe('inscription');
+  });
 });
 
 function ctxOf(sim: Sim) {

--- a/tests/professions_hobby_craft.test.ts
+++ b/tests/professions_hobby_craft.test.ts
@@ -45,16 +45,24 @@ describe('IWorld hobbyCraft read surface (#1294)', () => {
     expect(sim.hobbyCraft).toBeNull();
   });
 
-  it('b. completing the acceptance quest grants a hobby: the opposite craft on the ring', () => {
+  it("b. completing the acceptance quest grants a hobby: one of the pair's two ring-opposite candidates", () => {
     const sim = makeSim();
     sim.acceptArchetypeQuest(CRAFT_A);
-    expect(sim.hobbyCraft).toBe(oppositeCraft(CRAFT_A).id);
+    // CRAFT_A is engineering; acceptArchetypeQuest pairs it with its
+    // combo-aware default major, alchemy (the Bombardier pair). The two ring
+    // opposites are inscription (opposite engineering) and enchanting
+    // (opposite alchemy); inscription has zero recipes and no other
+    // skill-gain path (content/deeds.ts's prog_guildsworn comment), so
+    // defaultHobbyForPair's content-availability tiebreak picks enchanting
+    // over the plain ring-order tie break (see tests/professions_archetype.test.ts
+    // for the general rule).
+    expect(sim.hobbyCraft).toBe('enchanting');
   });
 
   it('c. switching the active archetype re-derives the deterministic default hobby for the new pair', () => {
     const sim = makeSim();
     sim.acceptArchetypeQuest(CRAFT_A);
-    expect(sim.hobbyCraft).toBe(oppositeCraft(CRAFT_A).id);
+    expect(sim.hobbyCraft).toBe('enchanting');
 
     const required = sim.archetypeAmendsRequired;
     for (let i = 0; i < required; i++) sim.advanceAmendsProgress();
@@ -64,15 +72,18 @@ describe('IWorld hobbyCraft read surface (#1294)', () => {
     // CRAFT_B is alchemy: its combo-aware default pair is alchemy+engineering,
     // whose two opposite candidates are enchanting (opposite alchemy) and
     // inscription (opposite engineering). With zero retained skill,
-    // defaultHobbyForPair tie-breaks by ring order to inscription. Pinned as
-    // literals so a change to the pair-default or hobby-default rule reddens
-    // here deliberately (see tests/professions_archetype.test.ts for the
-    // skill-preference arm).
+    // ring order alone would tie-break to inscription, but inscription has
+    // zero recipes and no other skill-gain path (content/deeds.ts's
+    // prog_guildsworn comment), so defaultHobbyForPair's content-availability
+    // tiebreak picks enchanting instead (real content via disenchanting).
+    // Pinned as literals so a change to the pair-default or hobby-default
+    // rule reddens here deliberately (see tests/professions_archetype.test.ts
+    // for the skill-preference and content-availability arms).
     const meta = (
       sim as unknown as { players: Map<number, { archetype: { pairedMajor: string } }> }
     ).players.get(sim.playerId)!;
     expect(meta.archetype.pairedMajor).toBe('engineering');
-    expect(sim.hobbyCraft).toBe('inscription');
+    expect(sim.hobbyCraft).toBe('enchanting');
   });
 
   it('d. per-pid read surface (hobbyCraftFor) matches the primary-player getter', () => {
@@ -90,8 +101,18 @@ describe('IWorld hobbyCraft read surface (#1294)', () => {
     const meta = (
       sim as unknown as { players: Map<number, { archetype: { pairedMajor: string } }> }
     ).players.get(sim.playerId)!;
+    // The real persisted hobby is passed explicitly as the 4th arg, matching
+    // every production call site (crafting.ts, combo_eligibility.ts): the
+    // 4th param's own default (the legacy single-craft getHobbyCraft
+    // fallback) is deliberately NOT the same value once the content-availability
+    // tiebreak picks a different candidate than oppositeCraft(activeArchetype).
     expect(
-      archetypeCeilingFor(sim.activeArchetype, meta.archetype.pairedMajor, hobby as string),
+      archetypeCeilingFor(
+        sim.activeArchetype,
+        meta.archetype.pairedMajor,
+        hobby as string,
+        hobby as string,
+      ),
     ).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- Retarget of #2625, which accidentally merged into `release/v0.32.0` and was reverted there; this re-opens the same fix against `release/v0.33.0`.
- `defaultHobbyForPair` tie-broke a fresh hobby default by ring order alone, with no awareness of which craft actually has content. For the live, shipped Bombardier pair (engineering+alchemy), that landed a fresh character on inscription: a craft with zero recipes and no other skill-gain path, permanently soft-locking the hobby slot until the player separately discovered the unrelated hobby-switch quest.
- Adds a `craftHasContent` predicate (recipe professionIds from `content/recipes.ts` plus enchanting, which gains skill via disenchanting outside the recipe table) and folds it into `defaultHobbyForPair`'s comparator as a tiebreak between the skill preference and the ring-order fallback. `hobbyCandidatesForPair` is left untouched: the explicit hobby-switch quest still needs every ring-opposite candidate reachable by player choice, content or not.

## Test plan
- [x] `npx vitest run tests/professions_archetype.test.ts tests/professions_hobby_craft.test.ts` (47 passed)
- [x] `npm run gate` pre-push floor (guard tests, biome changed-files) green