### PR TITLE
fix(ios): prevent world-entry WebContent kills on 4 GB iPhones

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		504EC31A1FED79650016851F /* AppViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3191FED79650016851F /* AppViewController.swift */; };
 		504EC3201FED79650016851F /* NativeAppUpdatePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC31F1FED79650016851F /* NativeAppUpdatePlugin.swift */; };
+		504EC3D2DEC0DE0016851F02 /* NativeDeviceInfoPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3D1DEC0DE0016851F01 /* NativeDeviceInfoPlugin.swift */; };
 		504EC3221FED79650016851F /* NativeAppleAuthPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3211FED79650016851F /* NativeAppleAuthPlugin.swift */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
 /* End PBXBuildFile section */
@@ -33,6 +34,7 @@
 		504EC3131FED79650016851F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		504EC3191FED79650016851F /* AppViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewController.swift; sourceTree = "<group>"; };
 		504EC31F1FED79650016851F /* NativeAppUpdatePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAppUpdatePlugin.swift; sourceTree = "<group>"; };
+		504EC3D1DEC0DE0016851F01 /* NativeDeviceInfoPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeDeviceInfoPlugin.swift; sourceTree = "<group>"; };
 		504EC3211FED79650016851F /* NativeAppleAuthPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAppleAuthPlugin.swift; sourceTree = "<group>"; };
 		504EC3231FED79650016851F /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
@@ -76,6 +78,7 @@
 				504EC3191FED79650016851F /* AppViewController.swift */,
 				504EC3090FED79650016851F /* NativeAttestationPlugin.swift */,
 				504EC31F1FED79650016851F /* NativeAppUpdatePlugin.swift */,
+				504EC3D1DEC0DE0016851F01 /* NativeDeviceInfoPlugin.swift */,
 				504EC3211FED79650016851F /* NativeAppleAuthPlugin.swift */,
 				504EC3231FED79650016851F /* App.entitlements */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
@@ -173,6 +176,7 @@
 				504EC31A1FED79650016851F /* AppViewController.swift in Sources */,
 				504EC3091FED79650016851F /* NativeAttestationPlugin.swift in Sources */,
 				504EC3201FED79650016851F /* NativeAppUpdatePlugin.swift in Sources */,
+				504EC3D2DEC0DE0016851F02 /* NativeDeviceInfoPlugin.swift in Sources */,
 				504EC3221FED79650016851F /* NativeAppleAuthPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/App/App/AppViewController.swift
+++ b/ios/App/App/AppViewController.swift
@@ -22,5 +22,6 @@ class AppViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(NativeAttestationPlugin())
         bridge?.registerPluginInstance(NativeAppUpdatePlugin())
         bridge?.registerPluginInstance(NativeAppleAuthPlugin())
+        bridge?.registerPluginInstance(NativeDeviceInfoPlugin())
     }
 }

--- a/ios/App/App/NativeDeviceInfoPlugin.swift
+++ b/ios/App/App/NativeDeviceInfoPlugin.swift
@@ -1,0 +1,23 @@
+import Capacitor
+import Foundation
+
+// Reports device hardware facts the WKWebView cannot observe itself. The web
+// client caches physicalMemory in localStorage so the next boot's synchronous
+// graphics-profile resolution can distinguish 4 GB-class devices (see
+// src/device_memory_hint.ts); WebKit exposes no navigator.deviceMemory on iOS.
+@objc(NativeDeviceInfoPlugin)
+public class NativeDeviceInfoPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "NativeDeviceInfoPlugin"
+    public let jsName = "NativeDeviceInfo"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "getMemoryInfo", returnType: CAPPluginReturnPromise)
+    ]
+
+    @objc func getMemoryInfo(_ call: CAPPluginCall) {
+        call.resolve([
+            "platform": "ios",
+            // UInt64 bytes fit a Double exactly for any shipping RAM size.
+            "physicalMemoryBytes": Double(ProcessInfo.processInfo.physicalMemory)
+        ])
+    }
+}

--- a/src/device_memory_hint.ts
+++ b/src/device_memory_hint.ts
@@ -1,0 +1,136 @@
+// Device-memory hint for the graphics tier resolver.
+//
+// iOS WKWebView never exposes navigator.deviceMemory, the GPU string is masked
+// to "Apple GPU", and screen metrics cannot tell a 4 GB iPhone 13 from a 6 GB
+// iPhone 12 Pro (identical 390x844@3). The only reliable memory signal is the
+// native shell's ProcessInfo.physicalMemory, which arrives over an async
+// Capacitor bridge - but src/render/gfx.ts resolves the module-load GFX profile
+// SYNCHRONOUSLY, before any plugin call can answer, and the render preload
+// sweeps key off that profile at import time. So the hint is cached here in
+// localStorage: the native shell primes it shortly after boot
+// (src/net/native_device_info.ts), and every LATER boot resolves its graphics
+// profile against the cached value.
+//
+// A second, hint-independent trigger covers the first-ever boot and any device
+// the shell cannot measure: when the world-entry crash guard applies a recovery
+// (src/game/entry_crash_guard.ts consumed in main.ts), the recovery block also
+// stamps a tight-mode marker here. One real WebContent kill during entry is
+// direct evidence the device is at its memory ceiling, so the next boots run
+// the tight profile without needing to know the RAM size. The marker expires:
+// a one-off kill on a big phone must not degrade it forever.
+//
+// ?memgb=<n> overrides the cached value for QA (the ?gfx= idiom in gfx.ts).
+//
+// Client-only wall-clock and storage access live in the thin wrappers at the
+// bottom (fail-soft, matching the entry_crash_guard idiom); everything above
+// them is pure and unit-tested.
+
+export const DEVICE_MEMORY_GB_KEY = 'woc_device_mem_gb';
+export const ENTRY_TIGHT_MODE_KEY = 'woc_entry_tight_mode';
+
+/** Devices at or below this many GB of physical RAM get the tight profile. */
+export const TIGHT_MEMORY_MAX_GB = 4;
+
+/** How long one entry-crash recovery keeps the tight profile active. */
+export const ENTRY_TIGHT_MODE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Parse a stored/override GB value; anything non-finite or absurd reads as unknown. */
+export function parseDeviceMemoryGb(raw: string | null | undefined): number | undefined {
+  if (raw === null || raw === undefined || raw === '') return undefined;
+  const value = Number(raw);
+  if (!Number.isFinite(value)) return undefined;
+  if (value <= 0 || value > 1024) return undefined;
+  return value;
+}
+
+/** Physical-memory bytes (from the native shell) to a storable GB value. */
+export function deviceMemoryGbFromBytes(bytes: number): number | undefined {
+  if (!Number.isFinite(bytes) || bytes <= 0) return undefined;
+  const gb = bytes / (1024 * 1024 * 1024);
+  if (gb > 1024) return undefined;
+  // Two decimals is plenty: jetsam budgets step in whole-GB device classes.
+  return Math.round(gb * 100) / 100;
+}
+
+/** Parse the tight-mode marker payload ({ at }); malformed reads as absent. */
+export function parseTightModeAt(raw: string | null): number | undefined {
+  if (!raw) return undefined;
+  try {
+    const value = JSON.parse(raw) as { at?: unknown } | null;
+    if (!value || typeof value.at !== 'number' || !Number.isFinite(value.at)) return undefined;
+    return value.at;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The pure tight-memory decision: a measured (or overridden) RAM size at or
+ * below the 4 GB class, OR a fresh entry-crash tight-mode marker. A marker
+ * stamped in the future (clock rollback) reads as inactive rather than pinning
+ * tight mode until the clock catches up.
+ */
+export function tightMemoryFromSignals(
+  memGb: number | undefined,
+  tightMarkerAt: number | undefined,
+  now: number,
+  windowMs: number = ENTRY_TIGHT_MODE_WINDOW_MS,
+): boolean {
+  if (memGb !== undefined && memGb <= TIGHT_MEMORY_MAX_GB) return true;
+  if (tightMarkerAt === undefined) return false;
+  const age = now - tightMarkerAt;
+  return age >= 0 && age <= windowMs;
+}
+
+// --- thin storage/clock wrappers (the impure boundary; every access fail-soft) ---
+
+function urlOverrideGb(): number | undefined {
+  try {
+    if (typeof location === 'undefined') return undefined;
+    return parseDeviceMemoryGb(new URLSearchParams(location.search).get('memgb'));
+  } catch {
+    return undefined;
+  }
+}
+
+/** The ?memgb= override when present, else the cached native measurement. */
+export function cachedDeviceMemoryGb(): number | undefined {
+  const override = urlOverrideGb();
+  if (override !== undefined) return override;
+  try {
+    return parseDeviceMemoryGb(localStorage.getItem(DEVICE_MEMORY_GB_KEY));
+  } catch {
+    return undefined;
+  }
+}
+
+/** Cache the native shell's measurement for the next boot's synchronous read. */
+export function storeDeviceMemoryGb(gb: number): void {
+  if (parseDeviceMemoryGb(String(gb)) === undefined) return;
+  try {
+    localStorage.setItem(DEVICE_MEMORY_GB_KEY, String(gb));
+  } catch {
+    // Blocked storage only loses the hint; the tier resolver falls back as before.
+  }
+}
+
+/** Stamp tight mode after an entry-crash recovery (the guard's floor has no
+ *  rung below Low; this is the rung: shed residency, not sharpness). */
+export function markEntryTightMode(now: number = Date.now()): void {
+  try {
+    localStorage.setItem(ENTRY_TIGHT_MODE_KEY, JSON.stringify({ at: now }));
+  } catch {
+    // Blocked storage: the preset step-down still applied; tight mode is bonus.
+  }
+}
+
+/** The composite signal src/render/gfx.ts reads at module load. */
+export function tightMemoryDeviceHint(now: number = Date.now()): boolean {
+  let markerAt: number | undefined;
+  try {
+    markerAt = parseTightModeAt(localStorage.getItem(ENTRY_TIGHT_MODE_KEY));
+  } catch {
+    markerAt = undefined;
+  }
+  return tightMemoryFromSignals(cachedDeviceMemoryGb(), markerAt, now);
+}

--- a/src/game/entry_crash_guard.ts
+++ b/src/game/entry_crash_guard.ts
@@ -52,6 +52,7 @@ export const ENTRY_PRESET_MIN = 1;
 export const ENTRY_PRESET_MAX = 5;
 
 export const ENTRY_CHECKPOINTS = [
+  'assets-await',
   'scene-build-start',
   'renderer-built',
   'hud-built',

--- a/src/game/entry_diagnostics.ts
+++ b/src/game/entry_diagnostics.ts
@@ -38,6 +38,8 @@ export interface EntryDiagnosticsController {
   checkpoint: (checkpoint: EntryCheckpoint, diagnostics?: EntryDiagnostics) => void;
   renderedFrame: (now: number) => void;
   markStable: (message?: string) => void;
+  suspend: () => void;
+  resume: () => void;
   stop: (message?: string) => void;
 }
 
@@ -64,12 +66,18 @@ export function createEntryDiagnosticsController(options: {
   let nextRenderCheckpointAt = 0;
   let stickyCheckpoint: EntryCheckpoint | null = null;
   let stable = false;
+  let suspended = false;
+  let activePreset = 0;
+  let lastCheckpoint: EntryCheckpoint | null = null;
+  let lastDiagnostics: EntryDiagnostics = {};
+  let stableOnResume = false;
+  let stableOnResumeMessage: string | undefined;
 
   const checkpoint = (
     nextCheckpoint: EntryCheckpoint,
     diagnostics: EntryDiagnostics = options.renderSnapshot(),
   ): void => {
-    if (!armed) return;
+    if (!armed || suspended) return;
     const resetTarget = STICKY_RESETS.get(nextCheckpoint);
     if (stickyCheckpoint && STICKY_CHECKPOINTS.has(nextCheckpoint)) return;
     if (
@@ -82,23 +90,31 @@ export function createEntryDiagnosticsController(options: {
     if (STICKY_CHECKPOINTS.has(nextCheckpoint)) stickyCheckpoint = nextCheckpoint;
     if (resetTarget === stickyCheckpoint) stickyCheckpoint = null;
     persistence.checkpoint(nextCheckpoint, wallNow(), diagnostics);
+    lastCheckpoint = nextCheckpoint;
+    lastDiagnostics = diagnostics;
     log(`[entry-diag] checkpoint=${nextCheckpoint}`, diagnostics);
   };
 
   const controller: EntryDiagnosticsController = {
     start(preset): void {
       armed = true;
+      suspended = false;
+      activePreset = preset;
       frame = 0;
       nextRenderCheckpointAt = 0;
       stickyCheckpoint = null;
       stable = false;
+      lastCheckpoint = null;
+      lastDiagnostics = {};
+      stableOnResume = false;
+      stableOnResumeMessage = undefined;
       activeController = controller;
       persistence.start(preset, wallNow());
       checkpoint('scene-build-start', options.baseSnapshot());
     },
     checkpoint,
     renderedFrame(now): void {
-      if (!armed || stable) return;
+      if (!armed || suspended || stable) return;
       frame++;
       if (frame !== 1 && now < nextRenderCheckpointAt) return;
       checkpoint(frame === 1 ? 'first-frame' : 'rendering', {
@@ -109,15 +125,44 @@ export function createEntryDiagnosticsController(options: {
     },
     markStable(message): void {
       if (!armed || stable) return;
+      if (suspended) {
+        stableOnResume = true;
+        stableOnResumeMessage = message;
+        return;
+      }
       checkpoint('runtime-stable');
       stable = true;
       if (message) log(message);
     },
+    suspend(): void {
+      if (!armed || suspended) return;
+      suspended = true;
+      persistence.clear();
+    },
+    resume(): void {
+      if (!armed || !suspended) return;
+      suspended = false;
+      persistence.start(activePreset, wallNow());
+      if (lastCheckpoint) {
+        persistence.checkpoint(lastCheckpoint, wallNow(), lastDiagnostics);
+      }
+      if (stableOnResume) {
+        const message = stableOnResumeMessage;
+        stableOnResume = false;
+        stableOnResumeMessage = undefined;
+        controller.markStable(message);
+      }
+    },
     stop(message): void {
       if (!armed) return;
       armed = false;
+      suspended = false;
       stickyCheckpoint = null;
       stable = false;
+      lastCheckpoint = null;
+      lastDiagnostics = {};
+      stableOnResume = false;
+      stableOnResumeMessage = undefined;
       if (activeController === controller) activeController = null;
       persistence.clear();
       if (message) log(message);
@@ -135,4 +180,12 @@ export function checkpointActiveEntryDiagnostics(
 
 export function stopActiveEntryDiagnostics(message?: string): void {
   activeController?.stop(message);
+}
+
+export function suspendActiveEntryDiagnostics(): void {
+  activeController?.suspend();
+}
+
+export function resumeActiveEntryDiagnostics(): void {
+  activeController?.resume();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@
 // index.html and play.html both bootstrap through this module, so this one import
 // styles both game entries; admin/guide use their own entries and inline CSS.
 import './styles/index.css';
+import { markEntryTightMode } from './device_memory_hint';
 import { startDiscordLogin } from './discord_login_start';
 import { syncAppViewport as syncAppViewportShared } from './game/app_viewport';
 import { audio } from './game/audio';
@@ -133,6 +134,7 @@ import {
   signInWithNativeApple,
 } from './net/native_apple_auth';
 import { createNativeAttestationProof } from './net/native_attestation';
+import { primeNativeDeviceMemoryHint } from './net/native_device_info';
 import {
   createNativeDiscordProof,
   installNativeDiscordUrlHandler,
@@ -404,6 +406,12 @@ applyNativeDeviceLanguage({
   languages: navigator.languages,
   language: navigator.language,
 });
+
+// Cache the native shell's physical-memory measurement for the NEXT boot's
+// synchronous graphics-profile resolution (4 GB-class devices get the tight
+// residency profile; see src/device_memory_hint.ts). Fire-and-forget: this
+// boot's profile is already resolved, and a missing bridge no-ops.
+void primeNativeDeviceMemoryHint();
 
 const SITE_URL = 'https://worldofclaudecraft.com/';
 
@@ -997,39 +1005,15 @@ async function startGame(
   // Paint the loading screen before anything can block, assetsReady may resolve
   // immediately when assets are already cached, and the scene build is synchronous.
   await nextPaint();
-  // Lazy locale flip: fetch the active locale's chunk (plus the deed locale chunk the HUD's
-  // deed surfaces read) and make both resident before the HUD renders (mountGameUi ->
-  // translatePage fans out hundreds of t() calls). It sits behind the loading screen (already
-  // painted above), so a stored non-en visitor never sees an English flash. This is now a
-  // REAL per-locale network request, so guard it: startGame is void-invoked (see the call
-  // sites) with no .catch, and English is always resident, so a failed fetch must fall back
-  // to English and keep booting rather than reject unhandled.
-  try {
-    await Promise.all([ensureLocaleLoaded(getLanguage()), ensureDeedLocalesLoaded(getLanguage())]);
-  } catch {
-    // Soft fallback: English is statically resident; boot in English (the picker can retry).
-  }
-  try {
-    await assetsReady((done, total) => setLoadingProgressRange(done, total, 0, 35));
-  } catch (err) {
-    fatalOverlay(t('loading.assetsFailed', { error: technicalErrorMessage(err) }));
-    return;
-  }
-  // Assets are the only network-bound phase the slow-connection hint can
-  // speak to; everything after this is synchronous CPU-bound scene build, so
-  // stop watching here rather than leaving it armed through hideLoadingScreen.
-  stopSlowConnectionWatch();
-  const spectateBadge = createSpectateBadge();
-  setLoadingStatus(t('loading.enteringWorld'));
-  // Let the final status + full progress bar paint before the synchronous
-  // Renderer/Hud build freezes the main thread for a beat.
-  await nextPaint();
-  mountGameUi();
-
-  const canvas = $('#game-canvas') as unknown as HTMLCanvasElement;
-  const nameplates = $('#nameplates') as HTMLDivElement;
-
-  const keybinds = new Keybinds(keybindScope);
+  // Graphics preset resolution + the entry crash probe run BEFORE the locale and
+  // asset awaits below. Those awaits are where the WebContent process actually
+  // holds its peak footprint on phone-class WebKit (the import-time preloads all
+  // resolve inside assetsReady), and a probe armed only after them missed every
+  // kill in that window: the next boot found no evidence, stepped nothing down,
+  // and the player re-crashed identically (the iPhone 13 entry-crash report).
+  // Settings and both preset writers are pure localStorage/navigator reads, so
+  // hoisting them ahead of mountGameUi is safe; everything DOM-bound (canvas
+  // lookups, the context-lost listeners) stays below, after the template mounts.
   const settings = new Settings();
   // First-run graphics default: until a device default has been applied (the dedicated
   // graphicsDefaultApplied marker, NOT the graphicsPreset key, which save() def-fills the moment
@@ -1063,38 +1047,9 @@ async function startGame(
   if (safePreset !== settings.get('graphicsPreset')) {
     settings.set('graphicsPreset', safePreset);
   }
-  // UI theming: apply the persisted theme's CSS variables to :root, then keep a
-  // hook so the Options panel can switch preset / override colours live.
-  const themeStore = new ThemeStore();
-  function applyTheme(): void {
-    const vars = themeStore.cssVars();
-    for (const name of Object.keys(vars))
-      document.documentElement.style.setProperty(name, vars[name]);
-  }
-  applyTheme();
-  // Graphics-tier HUD effects: publish the resolved effect profile (data-fx-level +
-  // the --fx-* tokens) on settings / OS reduced-motion changes only, never per
-  // frame. Driven by the STATIC graphics preset (the gfx.ts `ui` band stays
-  // governable:false): the FPS governor cannot measure compositor blur cost (the
-  // two-controller hazard). The pure resolver decides; this applier is the thin DOM
-  // consumer, mirroring applyTheme above. Motion has a single source of truth: the
-  // OS prefers-reduced-motion channel (owned by the applier) OR the in-game
-  // reduceMotion setting, both feeding the resolver's reduceMotion input; the
-  // body.reduce-motion class below stays only as the CSS hook it already is.
-  const uiEffectsApplier = new UiEffectsApplier({
-    resolve: (osReducedMotion) =>
-      resolveUiEffectsProfile({
-        presetLabel: graphicsPresetLabel(settings.get('graphicsPreset')),
-        effectsQuality: settings.get('effectsQuality'),
-        reduceMotion: osReducedMotion || settings.get('reduceMotion'),
-      }),
-  });
-  uiEffectsApplier.applyNow();
   let renderer!: Renderer;
   let rendererReady = false;
   let hud!: Hud;
-  const autoLoot = new AutoLoot();
-  const perf = createPerfMonitor(null);
   const baseEntryDiagnostics = (): EntryDiagnostics => {
     const memory = (navigator as Navigator & { deviceMemory?: number }).deviceMemory;
     return {
@@ -1129,6 +1084,7 @@ async function startGame(
       tier: stats.tier,
       constrainedMemory: GFX.constrainedMemory,
       nativeIosMemoryProfile: GFX.nativeIosMemoryProfile,
+      tightMemory: GFX.tightMemory,
       dynamicShadows: GFX.dynamicShadows,
       shadowMap: GFX.shadowMap,
       msaaSamples: GFX.msaaSamples,
@@ -1174,6 +1130,90 @@ async function startGame(
     baseSnapshot: baseEntryDiagnostics,
     renderSnapshot: renderEntryDiagnostics,
   });
+  // World-entry crash guard: persist a probe BEFORE the locale/asset awaits AND the
+  // synchronous scene build. If phone WebKit kills the WebContent process anywhere in
+  // that window (no event, no error, just a reload), the next boot finds the probe
+  // still armed and steps the graphics preset down one tier (see the recovery block
+  // in wireStartScreens). Cleared once the entry demonstrably survives, on the
+  // handled failure paths below, and whenever the page is hidden (a backgrounded
+  // eviction is NOT an entry crash).
+  entryDiagnostics.start(settings.get('graphicsPreset'));
+  // Dev-channel diagnostic (English on purpose): grep "[entry-guard]" in the WebView
+  // inspector / device console to isolate crash-at-entry causes on real hardware.
+  console.info(
+    `[entry-guard] world entry: preset=${settings.get('graphicsPreset')} ` +
+      `(${graphicsPresetLabel(settings.get('graphicsPreset'))}) native=${isNativeRuntime()}`,
+  );
+  // Name the await window in the probe: a kill during the locale/asset resolution
+  // now reads as checkpoint=assets-await instead of masquerading as a scene-build
+  // death (start() stamps scene-build-start; the real one is re-stamped below).
+  entryDiagnostics.checkpoint('assets-await', baseEntryDiagnostics());
+  // Lazy locale flip: fetch the active locale's chunk (plus the deed locale chunk the HUD's
+  // deed surfaces read) and make both resident before the HUD renders (mountGameUi ->
+  // translatePage fans out hundreds of t() calls). It sits behind the loading screen (already
+  // painted above), so a stored non-en visitor never sees an English flash. This is now a
+  // REAL per-locale network request, so guard it: startGame is void-invoked (see the call
+  // sites) with no .catch, and English is always resident, so a failed fetch must fall back
+  // to English and keep booting rather than reject unhandled.
+  try {
+    await Promise.all([ensureLocaleLoaded(getLanguage()), ensureDeedLocalesLoaded(getLanguage())]);
+  } catch {
+    // Soft fallback: English is statically resident; boot in English (the picker can retry).
+  }
+  try {
+    await assetsReady((done, total) => setLoadingProgressRange(done, total, 0, 35));
+  } catch (err) {
+    // A HANDLED failure is not a process kill, so the crash probe must not
+    // survive to cost the player a graphics tier next boot (same rule as the
+    // scene-build catch below).
+    entryDiagnostics.stop();
+    fatalOverlay(t('loading.assetsFailed', { error: technicalErrorMessage(err) }));
+    return;
+  }
+  // Assets are the only network-bound phase the slow-connection hint can
+  // speak to; everything after this is synchronous CPU-bound scene build, so
+  // stop watching here rather than leaving it armed through hideLoadingScreen.
+  stopSlowConnectionWatch();
+  const spectateBadge = createSpectateBadge();
+  setLoadingStatus(t('loading.enteringWorld'));
+  // Let the final status + full progress bar paint before the synchronous
+  // Renderer/Hud build freezes the main thread for a beat.
+  await nextPaint();
+  mountGameUi();
+
+  const canvas = $('#game-canvas') as unknown as HTMLCanvasElement;
+  const nameplates = $('#nameplates') as HTMLDivElement;
+
+  const keybinds = new Keybinds(keybindScope);
+  // UI theming: apply the persisted theme's CSS variables to :root, then keep a
+  // hook so the Options panel can switch preset / override colours live.
+  const themeStore = new ThemeStore();
+  function applyTheme(): void {
+    const vars = themeStore.cssVars();
+    for (const name of Object.keys(vars))
+      document.documentElement.style.setProperty(name, vars[name]);
+  }
+  applyTheme();
+  // Graphics-tier HUD effects: publish the resolved effect profile (data-fx-level +
+  // the --fx-* tokens) on settings / OS reduced-motion changes only, never per
+  // frame. Driven by the STATIC graphics preset (the gfx.ts `ui` band stays
+  // governable:false): the FPS governor cannot measure compositor blur cost (the
+  // two-controller hazard). The pure resolver decides; this applier is the thin DOM
+  // consumer, mirroring applyTheme above. Motion has a single source of truth: the
+  // OS prefers-reduced-motion channel (owned by the applier) OR the in-game
+  // reduceMotion setting, both feeding the resolver's reduceMotion input; the
+  // body.reduce-motion class below stays only as the CSS hook it already is.
+  const uiEffectsApplier = new UiEffectsApplier({
+    resolve: (osReducedMotion) =>
+      resolveUiEffectsProfile({
+        presetLabel: graphicsPresetLabel(settings.get('graphicsPreset')),
+        effectsQuality: settings.get('effectsQuality'),
+        reduceMotion: osReducedMotion || settings.get('reduceMotion'),
+      }),
+  });
+  uiEffectsApplier.applyNow();
+  const autoLoot = new AutoLoot();
+  const perf = createPerfMonitor(null);
   canvas.addEventListener('webglcontextlost', () => {
     entryDiagnostics.checkpoint('webgl-context-lost', {
       ...renderEntryDiagnostics(),
@@ -1185,19 +1225,9 @@ async function startGame(
     entryDiagnostics.checkpoint('webgl-context-restored');
     console.info('[entry-diag] WebGL context restored during or after world entry');
   });
-  // World-entry crash guard: persist a probe RIGHT BEFORE the synchronous scene build.
-  // If phone WebKit kills the WebContent process during the build (no event, no error,
-  // just a reload), the next boot finds the probe still armed and steps the graphics
-  // preset down one tier (see the recovery block in wireStartScreens). Cleared once the
-  // entry demonstrably survives, on the handled failure path below, and whenever the
-  // page is hidden (a backgrounded eviction is NOT an entry crash).
-  entryDiagnostics.start(settings.get('graphicsPreset'));
-  // Dev-channel diagnostic (English on purpose): grep "[entry-guard]" in the WebView
-  // inspector / device console to isolate crash-at-entry causes on real hardware.
-  console.info(
-    `[entry-guard] world entry: preset=${settings.get('graphicsPreset')} ` +
-      `(${graphicsPresetLabel(settings.get('graphicsPreset'))}) native=${isNativeRuntime()}`,
-  );
+  // The probe was armed before the locale/asset awaits above; mark that the await
+  // window ended and the synchronous scene build is what runs next.
+  entryDiagnostics.checkpoint('scene-build-start', baseEntryDiagnostics());
   try {
     setLoadingPercent(37, t('loading.enteringWorld'));
     await ensureSkyAssetsAt(world.player.pos.x, world.player.pos.z);
@@ -3920,19 +3950,26 @@ async function startGame(
     // has been materialized successfully.
     console.warn('Renderer prewarm failed', err);
   }
-  try {
-    await hud.prewarmCharacterPreview();
-  } catch (err) {
-    // The paperdoll preview is optional UI. If its secondary WebGL context
-    // cannot prewarm, opening the window can still take the normal lazy path.
-    console.warn('Character preview prewarm failed', err);
-  }
-  try {
-    await hud.prewarmArmoryPreview();
-  } catch (err) {
-    // The store is optional and online-only. A secondary-context failure must
-    // never prevent entering the world; opening it can retain the lazy path.
-    console.warn('Armory preview prewarm failed', err);
+  // Each preview prewarm mints a SECONDARY WebGL context beside the world
+  // renderer: real WebKit GPU-process residency held for a window the player
+  // may never open. The 4 GB-class tight profile skips both and keeps their
+  // documented lazy first-open path instead (the catch arms below already
+  // promise exactly that fallback).
+  if (!GFX.tightMemory) {
+    try {
+      await hud.prewarmCharacterPreview();
+    } catch (err) {
+      // The paperdoll preview is optional UI. If its secondary WebGL context
+      // cannot prewarm, opening the window can still take the normal lazy path.
+      console.warn('Character preview prewarm failed', err);
+    }
+    try {
+      await hud.prewarmArmoryPreview();
+    } catch (err) {
+      // The store is optional and online-only. A secondary-context failure must
+      // never prevent entering the world; opening it can retain the lazy path.
+      console.warn('Armory preview prewarm failed', err);
+    }
   }
   setLoadingPercent(100, t('loading.enteringWorld'));
   await nextPaint();
@@ -9425,6 +9462,13 @@ function wireStartScreens(): void {
         recoverySettings.set('graphicsPreset', entryRecovery.to);
       }
       recoverySettings.set('graphicsDefaultApplied', true);
+      // A confirmed WebContent kill during entry is direct evidence this device
+      // runs at its memory ceiling, and the preset ladder has no rung below Low.
+      // Stamp the tight-memory marker: from the NEXT module load the gfx profile
+      // and the render preload sweeps shed residency (DPR, pooled rigs, deferred
+      // cosmetic atlases/prewarms) independently of the preset. Time-limited in
+      // device_memory_hint.ts so a one-off kill cannot degrade a device forever.
+      markEntryTightMode(entryRecoveryAt);
       clearPlayMarker();
       console.warn(
         `[entry-guard] previous world entry crashed ${Math.round(entryRecovery.ageMs / 1000)}s ` +

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,9 @@ import {
 import {
   checkpointActiveEntryDiagnostics,
   createEntryDiagnosticsController,
+  resumeActiveEntryDiagnostics,
   stopActiveEntryDiagnostics,
+  suspendActiveEntryDiagnostics,
 } from './game/entry_diagnostics';
 import { GamepadManager } from './game/gamepad';
 import { GamepadBindings } from './game/gamepad_bindings';
@@ -170,7 +172,11 @@ import { assetsReady } from './render/assets/preload';
 import { CharacterPreview, type PreviewAppearance } from './render/characters';
 import { charactersReady, preloadMechAssets } from './render/characters/assets';
 import { skinCount } from './render/characters/manifest';
-import { onPortraitsReady, playerPortraitDataUrl } from './render/characters/portrait';
+import {
+  onPortraitsReady,
+  onPortraitUpdate,
+  playerPortraitDataUrl,
+} from './render/characters/portrait';
 import { installWebGLContextRelease } from './render/context_release';
 import { setDayNightPhaseOverride } from './render/day_night_clock';
 import { firstRunGraphicsPreset, GFX, graphicsPresetLabel } from './render/gfx';
@@ -308,6 +314,7 @@ import { buildPerfOverlayView, FrameMeter } from './ui/perf_overlay_model';
 import { hydratePortraits, portraitChipHtml } from './ui/portrait_chip';
 import { hideReconnectOverlay, showReconnectOverlay } from './ui/reconnect_overlay';
 import { createSpectateBadge } from './ui/spectate_badge';
+import { refreshStartSkinPickerPortraits } from './ui/start_skin_picker_portraits';
 import { refreshSteamLinkStatus, wireSteamLink } from './ui/steam_link';
 import { shouldShowStorePromo } from './ui/store_promo_card';
 import { talentRowOptionIconRef } from './ui/talent_icons';
@@ -4276,6 +4283,10 @@ function refreshOnlineSkins(cls: PlayerClass): void {
     characterPreview?.setSkin(i);
   });
 }
+
+onPortraitUpdate((visualKey, skin) => {
+  refreshStartSkinPickerPortraits(document, visualKey, skin, playerPortraitDataUrl);
+});
 
 function updatePreviewContainer(panelId: string): void {
   if (!characterPreview) return;
@@ -9576,8 +9587,12 @@ function wireStartScreens(): void {
       // A page that leaves the foreground mid-entry was not killed by a foreground
       // memory spike: a later eviction while backgrounded (or a deliberate reload,
       // which also fires pagehide) must not read as an entry crash next boot.
-      stopActiveEntryDiagnostics();
-      clearEntryProbe();
+      suspendActiveEntryDiagnostics();
+    } else {
+      // A hidden page can resume the same entry attempt. Re-arm the probe with
+      // its last durable checkpoint before the awaits or scene build continue,
+      // so a later foreground WebContent kill still advances the recovery ladder.
+      resumeActiveEntryDiagnostics();
     }
   };
   document.addEventListener('visibilitychange', restampResumeMarker);

--- a/src/net/native_device_info.ts
+++ b/src/net/native_device_info.ts
@@ -1,0 +1,39 @@
+import { deviceMemoryGbFromBytes, storeDeviceMemoryGb } from '../device_memory_hint';
+import { NATIVE_APP } from './online';
+
+// Native device-info bridge (iOS): the WKWebView cannot see the device's RAM
+// (no navigator.deviceMemory, masked GPU string), so the shell measures
+// ProcessInfo.physicalMemory and this glue caches it via device_memory_hint.ts
+// for the NEXT boot's synchronous graphics-profile resolution. Same duck-typed
+// plugin access as native_app_update.ts: a web build, an old shell, or a
+// missing plugin all no-op fail-soft.
+
+interface NativeDeviceInfoPlugin {
+  getMemoryInfo(): Promise<{ physicalMemoryBytes?: number }>;
+}
+
+function nativePlugin(): NativeDeviceInfoPlugin | null {
+  const cap = (window as unknown as { Capacitor?: { Plugins?: Record<string, unknown> } })
+    .Capacitor;
+  const plugin = cap?.Plugins?.NativeDeviceInfo;
+  if (!plugin || typeof plugin !== 'object') return null;
+  const candidate = plugin as Partial<NativeDeviceInfoPlugin>;
+  return typeof candidate.getMemoryInfo === 'function'
+    ? (candidate as NativeDeviceInfoPlugin)
+    : null;
+}
+
+/** Measure once per boot and cache; the value is stable hardware truth, so a
+ *  failed or absent bridge simply leaves the previous cache (or no hint). */
+export async function primeNativeDeviceMemoryHint(): Promise<void> {
+  if (!NATIVE_APP) return;
+  const plugin = nativePlugin();
+  if (!plugin) return;
+  try {
+    const info = await plugin.getMemoryInfo();
+    const gb = deviceMemoryGbFromBytes(Number(info?.physicalMemoryBytes));
+    if (gb !== undefined) storeDeviceMemoryGb(gb);
+  } catch {
+    // Fail-soft: the hint is an optimization, never a boot dependency.
+  }
+}

--- a/src/render/assets/loader.ts
+++ b/src/render/assets/loader.ts
@@ -125,6 +125,15 @@ export function releaseGltf(url: string): void {
   gltfCache.delete(assetUrl(url));
 }
 
+/** The texture twin of releaseGltf: drop a loadTexture entry once its pixels
+ *  have been copied into a consumer-owned surface (e.g. the VFX sprite atlas),
+ *  so the decoded source image can be garbage-collected. Pass the SAME opts the
+ *  load used - they are part of the cache key. A later loadTexture re-fetches. */
+export function releaseTexture(url: string, opts: { srgb?: boolean; repeat?: boolean } = {}): void {
+  const resolved = assetUrl(url);
+  texCache.delete(`${resolved}|${opts.srgb ? 's' : 'l'}|${opts.repeat ? 'r' : 'c'}`);
+}
+
 // One shared decode worker (created lazily): fetch + RGBE parse of an 8MB 2k
 // HDRI is over a second of pure CPU, a measured full-frame stall every time
 // zone streaming brought in a new biome's sky. Requests are matched by id;

--- a/src/render/assets/preload.ts
+++ b/src/render/assets/preload.ts
@@ -6,14 +6,32 @@ import { assetLoadStarted, recordPreloadWait } from './stats';
 const tasks: Promise<unknown>[] = [];
 
 export function registerPreload(task: Promise<unknown>): void {
-  // Observe the rejection immediately: in a host that never awaits assetsReady()
-  // (a Vitest file importing the render stack in plain Node), an import-time
-  // fetch failure must not escalate to an unhandled rejection once the event
-  // loop reaches the queued load timers. assetsReady() still receives the
-  // original rejection through Promise.allSettled on the stored task.
+  // Store a VALUE-ERASED view of the task. A settled promise pins its resolution
+  // value forever, and several registrants resolve to the live THREE.Texture they
+  // just loaded (terrain splats, water normals, the VFX sprite sheet), so keeping
+  // the original here made this append-only array a permanent retainer for ~35
+  // decoded textures - which also defeats any consumer-side release, since the
+  // registry still reaches the texture the consumer just dropped. Erasing the
+  // value keeps every settle state (and rejection reason) that assetsReady needs
+  // while retaining nothing: no drain, so repeat and concurrent callers behave
+  // exactly as they always did.
+  const erased = task.then(() => undefined);
+  // Observe the rejection immediately, on BOTH the original and the erased view:
+  // in a host that never awaits assetsReady() (a Vitest file importing the render
+  // stack in plain Node), an import-time fetch failure must not escalate to an
+  // unhandled rejection once the event loop reaches the queued load timers.
+  // These handlers create separate derived promises, so `erased` itself still
+  // rejects and assetsReady() still receives the reason via Promise.allSettled.
   task.catch(() => undefined);
-  tasks.push(task);
+  erased.catch(() => undefined);
+  tasks.push(erased);
 }
+
+/** Test-only view of the registry, so a guard can prove no task retains its
+ *  resolution value (see tests/ios_entry_memory.test.ts). */
+export const preloadInternalsForTest = {
+  tasks: (): readonly Promise<unknown>[] => tasks,
+};
 
 export async function assetsReady(
   onProgress?: (done: number, total: number) => void,

--- a/src/render/characters/assets.ts
+++ b/src/render/characters/assets.ts
@@ -484,7 +484,20 @@ for (const [key, list] of Object.entries(SKINS)) {
   if (VISUALS[key]?.lazyPreload) continue;
   for (const u of list) if (u) bootSkinUrls.add(u);
 }
-for (const url of bootSkinUrls) registerPreload(loadSkinTexInto(url, skinTexByUrl));
+// The packaged iOS shell defers the whole alternate-atlas sweep out of the boot
+// gate: ~34 1024x1024 atlases decode to well over 100 MB of RGBA inside the same
+// WebContent process whose jetsam ceiling the entry spike already presses against
+// (the iPhone 13 entry-kill report), and almost all of them are OTHER players'
+// cosmetics. skinTexture() fails soft to the embedded default and every apply
+// site heals through ensureSkinTexture() (visual.ts constructor + setSkin,
+// portrait.ts before its one-shot snapshot), so a deferred atlas costs a briefly
+// default-coloured body, never a crash or a stall. nativeIosMemoryProfile derives
+// from hints only (never the tier), so this import-time read cannot drift from
+// the live profile the way an import-time TIER read would (the farmCrate P0).
+const eagerSkinAtlases = !GFX.nativeIosMemoryProfile;
+if (eagerSkinAtlases) {
+  for (const url of bootSkinUrls) registerPreload(loadSkinTexInto(url, skinTexByUrl));
+}
 
 /** Resolve once every boot-time character GLB + skin atlas is cached, retrying
  *  whatever is still missing instead of depending on the site-wide assetsReady()
@@ -505,7 +518,11 @@ for (const url of bootSkinUrls) registerPreload(loadSkinTexInto(url, skinTexByUr
 export async function charactersReady(maxAttempts = 3): Promise<void> {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const missingGltf = preloadUrls.filter((u) => !gltfByUrl.has(assetUrl(u)));
-    const missingSkins = [...bootSkinUrls].filter((u) => !skinTexByUrl.has(u));
+    // Deferred atlases (native iOS) are not boot assets: gating the preview on
+    // them would re-create the exact entry-footprint spike the deferral removes.
+    const missingSkins = eagerSkinAtlases
+      ? [...bootSkinUrls].filter((u) => !skinTexByUrl.has(u))
+      : [];
     if (missingGltf.length === 0 && missingSkins.length === 0) return;
     if (attempt > 1) {
       await new Promise((resolve) => setTimeout(resolve, gltfRetryDelayMs(attempt)));

--- a/src/render/characters/assets.ts
+++ b/src/render/characters/assets.ts
@@ -484,17 +484,18 @@ for (const [key, list] of Object.entries(SKINS)) {
   if (VISUALS[key]?.lazyPreload) continue;
   for (const u of list) if (u) bootSkinUrls.add(u);
 }
-// The packaged iOS shell defers the whole alternate-atlas sweep out of the boot
-// gate: ~34 1024x1024 atlases decode to well over 100 MB of RGBA inside the same
-// WebContent process whose jetsam ceiling the entry spike already presses against
-// (the iPhone 13 entry-kill report), and almost all of them are OTHER players'
-// cosmetics. skinTexture() fails soft to the embedded default and every apply
-// site heals through ensureSkinTexture() (visual.ts constructor + setSkin,
-// portrait.ts before its one-shot snapshot), so a deferred atlas costs a briefly
-// default-coloured body, never a crash or a stall. nativeIosMemoryProfile derives
-// from hints only (never the tier), so this import-time read cannot drift from
-// the live profile the way an import-time TIER read would (the farmCrate P0).
-const eagerSkinAtlases = !GFX.nativeIosMemoryProfile;
+// The packaged iOS shell, plus iOS Safari after a confirmed entry kill, defers
+// the whole alternate-atlas sweep out of the boot gate: ~34 1024x1024 atlases
+// decode to well over 100 MB of RGBA inside the same WebContent process whose
+// jetsam ceiling the entry spike already presses against (the iPhone 13 report),
+// and almost all of them are OTHER players' cosmetics. skinTexture() fails soft
+// to the embedded default and every apply site heals through ensureSkinTexture()
+// (visual.ts constructor + setSkin, portrait.ts before its one-shot snapshot),
+// so a deferred atlas costs a brief fallback, never a crash or a stall. Both
+// profile hints derive from static boot signals (never the tier), so this
+// import-time read cannot drift from the live profile the way an import-time
+// TIER read would (the farmCrate P0).
+const eagerSkinAtlases = !(GFX.nativeIosMemoryProfile || GFX.tightMemory);
 if (eagerSkinAtlases) {
   for (const url of bootSkinUrls) registerPreload(loadSkinTexInto(url, skinTexByUrl));
 }

--- a/src/render/characters/portrait.ts
+++ b/src/render/characters/portrait.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import type { PlayerClass } from '../../sim/types';
 import { assetsReady } from '../assets/preload';
 import { trackWebGLContext } from '../context_release';
+import { ensureSkinTexture } from './assets';
 import { VISUALS } from './manifest';
 import { type PortraitFraming, portraitFrameParams } from './portrait_framing';
 import { CharacterVisual } from './visual';
@@ -124,6 +125,14 @@ export function visualPortraitDataUrl(
   if (cached) return cached;
   if (!assetsAreReady) return null;
 
+  // The packaged iOS shell defers the boot skin-atlas sweep (assets.ts), so a
+  // non-default skin's atlas may not be resident yet. Still render (the body
+  // falls back to the embedded default colours) but do NOT cache: the ensure
+  // kicked here resolves shortly, and the next call re-renders with the real
+  // atlas instead of pinning the wrong colours for the whole session. On eager
+  // platforms the atlas is resident and ensureSkinTexture returns null.
+  const atlasPending = ensureSkinTexture(visualKey, skin) !== null;
+
   let visual: CharacterVisual | null = null;
   try {
     ensureRig();
@@ -171,7 +180,7 @@ export function visualPortraitDataUrl(
 
     renderer!.render(scene!, camera!);
     const url = renderer!.domElement.toDataURL('image/png');
-    cache.set(key, url);
+    if (!atlasPending) cache.set(key, url);
     return url;
   } catch (err) {
     if (import.meta.env?.DEV) console.warn(`[portrait] failed for ${key}`, err);

--- a/src/render/characters/portrait.ts
+++ b/src/render/characters/portrait.ts
@@ -51,6 +51,8 @@ let mount: THREE.Group | null = null;
 
 const cache = new Map<string, string>();
 const readyListeners = new Set<() => void>();
+const updateListeners = new Set<(visualKey: string, skin: number) => void>();
+const pendingAtlases = new Map<string, Promise<void>>();
 let assetsAreReady = false;
 void assetsReady()
   .then(() => {
@@ -125,13 +127,27 @@ export function visualPortraitDataUrl(
   if (cached) return cached;
   if (!assetsAreReady) return null;
 
-  // The packaged iOS shell defers the boot skin-atlas sweep (assets.ts), so a
-  // non-default skin's atlas may not be resident yet. Still render (the body
-  // falls back to the embedded default colours) but do NOT cache: the ensure
-  // kicked here resolves shortly, and the next call re-renders with the real
-  // atlas instead of pinning the wrong colours for the whole session. On eager
-  // platforms the atlas is resident and ensureSkinTexture returns null.
-  const atlasPending = ensureSkinTexture(visualKey, skin) !== null;
+  // Tight-memory iOS hosts defer the boot skin-atlas sweep (assets.ts), so a
+  // non-default skin's atlas may not be resident yet. Do not capture the
+  // embedded default as if it were the requested chroma. Return the normal
+  // fallback and notify mounted consumers once the real atlas arrives.
+  const atlasPending = ensureSkinTexture(visualKey, skin);
+  if (atlasPending) {
+    const atlasKey = `${visualKey}:${skin}`;
+    if (!pendingAtlases.has(atlasKey)) {
+      pendingAtlases.set(atlasKey, atlasPending);
+      void atlasPending.then(
+        () => {
+          pendingAtlases.delete(atlasKey);
+          for (const cb of updateListeners) cb(visualKey, skin);
+        },
+        () => {
+          pendingAtlases.delete(atlasKey);
+        },
+      );
+    }
+    return null;
+  }
 
   let visual: CharacterVisual | null = null;
   try {
@@ -180,7 +196,7 @@ export function visualPortraitDataUrl(
 
     renderer!.render(scene!, camera!);
     const url = renderer!.domElement.toDataURL('image/png');
-    if (!atlasPending) cache.set(key, url);
+    cache.set(key, url);
     return url;
   } catch (err) {
     if (import.meta.env?.DEV) console.warn(`[portrait] failed for ${key}`, err);
@@ -198,6 +214,12 @@ export function visualPortraitDataUrl(
 export function onPortraitsReady(cb: () => void): void {
   if (assetsAreReady) cb();
   else readyListeners.add(cb);
+}
+
+/** Subscribe to newly available deferred atlases so mounted portrait consumers
+ * can replace their fallback without waiting for an unrelated repaint. */
+export function onPortraitUpdate(cb: (visualKey: string, skin: number) => void): void {
+  updateListeners.add(cb);
 }
 
 /** True once portraits can be generated synchronously. */

--- a/src/render/characters/visual.ts
+++ b/src/render/characters/visual.ts
@@ -441,6 +441,21 @@ export class CharacterVisual {
       idle.play();
       this.current = idle;
     }
+
+    // The atlas for a non-default skin may not be resident at construction: the
+    // packaged iOS shell defers the boot atlas sweep (assets.ts), so a visual
+    // born with a cosmetic skin applies the embedded default above and heals
+    // here once the atlas arrives - the same ensure + re-apply round-trip
+    // setSkin() already runs for live swaps. No-op when the atlas is resident
+    // (ensureSkinTexture returns null), so eager platforms are unchanged.
+    const pendingAtlas = ensureSkinTexture(this.key, skinIndex);
+    if (pendingAtlas) {
+      void pendingAtlas
+        .then(() => {
+          if (!this.disposed && this.skinIndex === skinIndex) this.applySkinMaterials(skinIndex);
+        })
+        .catch((err) => console.error('failed to load skin atlas:', err));
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/src/render/gfx.ts
+++ b/src/render/gfx.ts
@@ -686,11 +686,10 @@ function settingsFor(tier: GfxTier, hints?: Partial<GfxRuntimeHints>): GfxSettin
   // tier (and its density/VFX progression) while routing the packaged iOS app through the
   // bounded-residency material/world path from scene construction onward.
   const nativeIosMemoryProfile = hints?.nativeApp === true && hints.platform === 'ios';
-  // The stricter 4 GB-class rung. Gated on the native profile: the hint only exists
-  // where the native shell can measure physicalMemory (or where an entry-crash
-  // recovery stamped the marker), and the residency knobs it tightens are the ones
-  // the native profile already owns.
-  const tightMemoryProfile = nativeIosMemoryProfile && hints?.tightMemory === true;
+  // The stricter 4 GB-class rung. The native shell can measure physicalMemory,
+  // while either native WKWebView or iOS Safari can stamp the same marker after
+  // a foreground entry kill. Both WebKit hosts share the WebContent ceiling.
+  const tightMemoryProfile = hints?.platform === 'ios' && hints?.tightMemory === true;
   // Phone-class browsers live under a hard per-process memory ceiling (iOS WebKit evicts the
   // WebContent process outright); shed the largest one-shot GPU allocations there. Shadow-map
   // texels, MSAA, and DPR are cosmetic sharpness only, so this never crosses the
@@ -1150,6 +1149,7 @@ export function initGfxTier(webgl: THREE.WebGLRenderer): GfxTier {
 
 export const gfxInternalsForTest = {
   settingsFor,
+  runtimeHints,
   mobilePlatformFromNavigator,
   probeGpuRenderer,
   resetGpuRendererProbe: () => {

--- a/src/render/gfx.ts
+++ b/src/render/gfx.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { NATIVE_APP } from '../client_origin';
+import { tightMemoryDeviceHint } from '../device_memory_hint';
 import { EFFECTS_QUALITY_LOW_CUTOFF } from '../game/ui_effects_profile';
 import { FAR_ANIM_RANGE_SCALE_MAX } from './crowd_lod';
 import { isSoftwareRendererName } from './software_renderer';
@@ -62,6 +63,8 @@ export interface GfxRuntimeHints {
   gpuRenderer?: string;
   nativeApp?: boolean;
   platform?: 'ios' | 'android' | 'other';
+  /** 4 GB-class device or a fresh entry-crash marker (src/device_memory_hint.ts). */
+  tightMemory?: boolean;
   graphicsPreset?: number;
   terrainDetail?: number;
   foliageDensity?: number;
@@ -110,6 +113,16 @@ export interface GfxSettings {
   readonly constrainedMemory: boolean;
   /** Packaged iOS WKWebView profile that bounds retained GPU resources independently of FPS. */
   readonly nativeIosMemoryProfile: boolean;
+  /**
+   * The rung below nativeIosMemoryProfile for 4 GB-class devices (iPhone 13 and older
+   * non-Pro phones) and for any native-iOS device that just survived an entry-crash
+   * recovery: the WebContent jetsam ceiling there sits below the standard native
+   * profile's entry footprint, so this profile sheds RESIDENCY (DPR, pooled rigs,
+   * grass density, deferred cosmetic prewarms/preloads), never information a player
+   * acts on. Driven by src/device_memory_hint.ts; false wherever the hint is absent,
+   * which keeps every existing device on today's exact profile.
+   */
+  readonly tightMemory: boolean;
   /** Global cap for inactive skinned character rigs retained for reuse. */
   readonly maxPooledCharacterVisuals: number;
   /**
@@ -673,6 +686,11 @@ function settingsFor(tier: GfxTier, hints?: Partial<GfxRuntimeHints>): GfxSettin
   // tier (and its density/VFX progression) while routing the packaged iOS app through the
   // bounded-residency material/world path from scene construction onward.
   const nativeIosMemoryProfile = hints?.nativeApp === true && hints.platform === 'ios';
+  // The stricter 4 GB-class rung. Gated on the native profile: the hint only exists
+  // where the native shell can measure physicalMemory (or where an entry-crash
+  // recovery stamped the marker), and the residency knobs it tightens are the ones
+  // the native profile already owns.
+  const tightMemoryProfile = nativeIosMemoryProfile && hints?.tightMemory === true;
   // Phone-class browsers live under a hard per-process memory ceiling (iOS WebKit evicts the
   // WebContent process outright); shed the largest one-shot GPU allocations there. Shadow-map
   // texels, MSAA, and DPR are cosmetic sharpness only, so this never crosses the
@@ -697,15 +715,17 @@ function settingsFor(tier: GfxTier, hints?: Partial<GfxRuntimeHints>): GfxSettin
     // it ~1ms-class on real GPUs; ultra gets full-res Medium
     ao: !nativeIosMemoryProfile && (tier === 'high' || tier === 'ultra'),
     msaaSamples: (tier === 'high' || tier === 'ultra') && !constrainedMemory ? 4 : 0,
-    pixelRatioCap: nativeIosMemoryProfile
-      ? 1.25
-      : constrainedMemory
-        ? 1.48
-        : tier === 'low' || tier === 'medium'
+    pixelRatioCap: tightMemoryProfile
+      ? 1.0
+      : nativeIosMemoryProfile
+        ? 1.25
+        : constrainedMemory
           ? 1.48
-          : tier === 'high'
-            ? 1.75
-            : 2.5,
+          : tier === 'low' || tier === 'medium'
+            ? 1.48
+            : tier === 'high'
+              ? 1.75
+              : 2.5,
     // Shadows are cosmetic and duplicate the visible scene draw. Both constrained browsers and
     // the stricter native-iOS residency profile remove that duplicate pass.
     dynamicShadows: tier !== 'low' && !constrainedMemory,
@@ -727,31 +747,42 @@ function settingsFor(tier: GfxTier, hints?: Partial<GfxRuntimeHints>): GfxSettin
     // occlude world sightlines. Keep the constrained profile on the full placement
     // set and reduce only non-occluding grass below.
     leanFoliage: tier === 'low' || (tier === 'medium' && weakIntegratedGpu),
-    grassRadius: nativeIosMemoryProfile
-      ? 52
-      : tier === 'low'
-        ? 80
-        : tier === 'medium'
-          ? constrainedMemory
-            ? 62
-            : 76
-          : 82,
-    grassStep: nativeIosMemoryProfile
-      ? 2.75
-      : tier === 'low'
-        ? 2.05
-        : tier === 'medium'
-          ? constrainedMemory
-            ? 2.35
-            : 2.0
-          : 1.8,
+    // Tight memory reuses the Advanced sub-knob's lean grass values (34 / 3.8): the
+    // leanest grass the game already ships, so no new visual floor is introduced.
+    grassRadius: tightMemoryProfile
+      ? 34
+      : nativeIosMemoryProfile
+        ? 52
+        : tier === 'low'
+          ? 80
+          : tier === 'medium'
+            ? constrainedMemory
+              ? 62
+              : 76
+            : 82,
+    grassStep: tightMemoryProfile
+      ? 3.8
+      : nativeIosMemoryProfile
+        ? 2.75
+        : tier === 'low'
+          ? 2.05
+          : tier === 'medium'
+            ? constrainedMemory
+              ? 2.35
+              : 2.0
+            : 1.8,
     terrainSplat:
       !nativeIosMemoryProfile && (tier === 'medium' || tier === 'high' || tier === 'ultra'),
     windSway: true,
     maxPointLights: nativeIosMemoryProfile ? 2 : constrainedMemory ? 3 : 6,
     constrainedMemory,
     nativeIosMemoryProfile,
-    maxPooledCharacterVisuals: nativeIosMemoryProfile ? 6 : Number.POSITIVE_INFINITY,
+    tightMemory: tightMemoryProfile,
+    maxPooledCharacterVisuals: tightMemoryProfile
+      ? 4
+      : nativeIosMemoryProfile
+        ? 6
+        : Number.POSITIVE_INFINITY,
     // Extra articulated rigs are skinning + draw-call cost, so the phone-class
     // memory profiles and the low tier (which includes software GL) opt out and
     // keep the straight-to-frozen far LOD.
@@ -854,6 +885,7 @@ function runtimeHints(): GfxRuntimeHints {
     gpuRenderer: probeGpuRenderer(),
     nativeApp: NATIVE_APP,
     platform: mobilePlatformFromNavigator(nav),
+    tightMemory: tightMemoryDeviceHint(),
     graphicsPreset: storedNumericSetting('graphicsPreset'),
     terrainDetail: storedNumericSetting('terrainDetail'),
     foliageDensity: storedNumericSetting('foliageDensity'),

--- a/src/render/vfx.ts
+++ b/src/render/vfx.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { loadTexture } from './assets/loader';
+import { loadTexture, releaseTexture } from './assets/loader';
 import { registerPreload } from './assets/preload';
 import { GFX } from './gfx';
 
@@ -109,10 +109,18 @@ for (let i = 0; i < SPRITE_FILES.length; i++) {
   );
 }
 
+// The composed atlas canvas, kept module-level and reused. A SECOND Vfx in the
+// same page is real (the editor viewport's reload() builds a fresh Renderer, and
+// each Renderer owns a Vfx), and composeAtlasCanvas() releases its source
+// sprites, so recomposing would silently paint all 16 cells as fallback discs.
+// Retaining the one 1024x1024 canvas instead of 16 decoded sources is also the
+// cheaper half of that trade.
+let atlasCanvas: HTMLCanvasElement | null = null;
+
 // Compose the atlas once. Any cell whose PNG is unavailable (e.g. unit tests
 // that construct Vfx without the preload gate) falls back to a soft painted
 // disc so the system always renders something sane.
-function buildAtlasTexture(): THREE.CanvasTexture {
+function composeAtlasCanvas(): HTMLCanvasElement {
   const size = ATLAS_GRID * ATLAS_CELL;
   const canvas = document.createElement('canvas');
   canvas.width = canvas.height = size;
@@ -141,7 +149,28 @@ function buildAtlasTexture(): THREE.CanvasTexture {
       ctx.fillRect(x, y, ATLAS_CELL, ATLAS_CELL);
     }
   }
-  const tex = new THREE.CanvasTexture(canvas);
+  // The canvas now owns every cell's pixels, so the 16 source sprites (decoded
+  // RGBA, their loader cache entries, and the THREE wrappers that are never
+  // uploaded to the GPU) are dead weight from here on: ~16 MB retained for
+  // nothing, on a process whose memory ceiling is what kills world entry on
+  // 4 GB iPhones. Safe to drop because nothing recomposes this canvas (see
+  // atlasCanvas above) and no context-restore path re-reads the sources: a lost
+  // WebGL context is a dead session here, handled out of band by the entry crash
+  // guard, never re-uploaded from CPU-side copies.
+  for (let i = 0; i < SPRITE_FILES.length; i++) {
+    spriteImages[i] = null;
+    releaseTexture(`/vfx/${SPRITE_FILES[i]}.png`, { srgb: true });
+  }
+  return canvas;
+}
+
+/** A per-Vfx CanvasTexture over the one shared, already-composed atlas canvas.
+ *  A fresh texture object per instance keeps each renderer's GPU upload its own
+ *  (two live Vfx never share one texture), while the composed pixels are built
+ *  exactly once. */
+function buildAtlasTexture(): THREE.CanvasTexture {
+  atlasCanvas ??= composeAtlasCanvas();
+  const tex = new THREE.CanvasTexture(atlasCanvas);
   tex.colorSpace = THREE.SRGBColorSpace;
   tex.minFilter = THREE.LinearFilter;
   tex.magFilter = THREE.LinearFilter;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -21,7 +21,11 @@ import { castBarState, consumeBarState, mountSummonBarState } from '../render/ca
 import { CharacterPreview, type PreviewFramingName } from '../render/characters';
 import { preloadMechAssets } from '../render/characters/assets';
 import { mechHeldWeaponOverride, skinCount } from '../render/characters/manifest';
-import { onPortraitsReady, playerPortraitDataUrl } from '../render/characters/portrait';
+import {
+  onPortraitsReady,
+  onPortraitUpdate,
+  playerPortraitDataUrl,
+} from '../render/characters/portrait';
 import { currentDayNightPhase } from '../render/day_night_clock';
 import { globalDayness, skyTintForDayness } from '../render/day_night_core';
 import { isFriendlyPet, mobTooltipConColor } from '../render/reaction';
@@ -1798,6 +1802,7 @@ export class Hud {
       closeTop: () => this.closeAll(),
       hideTooltip: () => this.hideTooltip(),
       onPortraitsReady,
+      onPortraitUpdate,
       preloadMechAssets: () => {
         if (!this.mechAssetsPromise) this.mechAssetsPromise = preloadMechAssets();
         return this.mechAssetsPromise;
@@ -1886,6 +1891,31 @@ export class Hud {
       this.drawPlayerFramePortrait();
       this.targetFramePainter.invalidatePortrait();
       this.totFramePainter.invalidatePortrait();
+    });
+    onPortraitUpdate((visualKey, skin) => {
+      const playerClass = visualKey.startsWith('player_')
+        ? (visualKey.slice('player_'.length) as PlayerClass)
+        : null;
+      if (!playerClass) return;
+      if (playerClass === this.sim.cfg.playerClass && skin === (this.sim.player.skin ?? 0)) {
+        this.drawPlayerFramePortrait();
+      }
+      const target = this.targetPortraitSubject;
+      if (
+        target?.kind === 'player' &&
+        target.templateId === playerClass &&
+        (target.skin ?? 0) === skin
+      ) {
+        this.targetFramePainter.invalidatePortrait();
+      }
+      const targetOfTarget = this.totPortraitSubject;
+      if (
+        targetOfTarget?.kind === 'player' &&
+        targetOfTarget.templateId === playerClass &&
+        (targetOfTarget.skin ?? 0) === skin
+      ) {
+        this.totFramePainter.invalidatePortrait();
+      }
     });
     const mm = $('#minimap') as unknown as HTMLCanvasElement;
     this.minimapCtx = require2dContext(mm);

--- a/src/ui/hud/cosmetics/skin_event_controller.ts
+++ b/src/ui/hud/cosmetics/skin_event_controller.ts
@@ -31,6 +31,7 @@ export interface SkinEventControllerDeps {
   closeTop(): boolean;
   hideTooltip(): void;
   onPortraitsReady(callback: () => void): void;
+  onPortraitUpdate(callback: (visualKey: string, skin: number) => void): void;
   preloadMechAssets(): Promise<void>;
   preview: SkinEventPreviewPort;
   openFocusTrap(root: () => HTMLElement | null): FocusTrapHandle;
@@ -58,7 +59,9 @@ export class SkinEventController {
   private mode: SkinEventMode = 'class';
   private mechAssets: Promise<void> | null = null;
 
-  constructor(private readonly deps: SkinEventControllerDeps) {}
+  constructor(private readonly deps: SkinEventControllerDeps) {
+    this.deps.onPortraitUpdate((visualKey, skin) => this.refreshChoiceThumb(visualKey, skin));
+  }
 
   open(rank: SkinRank, options?: { mech?: boolean }): void {
     for (let index = 0; index < 20 && this.deps.closeTop(); index++) {
@@ -141,6 +144,21 @@ export class SkinEventController {
     return this.mode === 'mech'
       ? visualPortraitDataUrl('player_mech', index)
       : playerPortraitDataUrl(this.deps.world().cfg.playerClass, index);
+  }
+
+  private refreshChoiceThumb(visualKey: string, skin: number): void {
+    if (!this.element?.classList.contains('open') || this.revealTimer !== null) return;
+    const expectedKey =
+      this.mode === 'mech' ? 'player_mech' : `player_${this.deps.world().cfg.playerClass}`;
+    if (visualKey !== expectedKey) return;
+    const button = this.element.querySelector<HTMLButtonElement>(`.se-swatch[data-skin="${skin}"]`);
+    const url = button ? this.choiceThumb(skin) : null;
+    if (!button || !url || button.querySelector('img')) return;
+    const img = this.deps.document.createElement('img');
+    img.src = url;
+    img.alt = '';
+    button.textContent = '';
+    button.appendChild(img);
   }
 
   private choiceName(choice: Pick<SkinEventChoice, 'rank' | 'id'>): string {

--- a/src/ui/portrait_chip.ts
+++ b/src/ui/portrait_chip.ts
@@ -8,6 +8,7 @@
 
 import {
   onPortraitsReady,
+  onPortraitUpdate,
   type PortraitFraming,
   playerPortraitDataUrl,
   portraitsReady,
@@ -75,12 +76,17 @@ export function portraitChipHtml(opts: PortraitChipOpts): string {
 
 /** Swap any still-pending placeholder chips under `root` for the real 3D
  *  portrait. Safe to call repeatedly; a no-op until assets are ready. */
-export function hydratePortraits(root: ParentNode = document): void {
+export function hydratePortraits(
+  root: ParentNode = document,
+  onlyClass?: PlayerClass,
+  onlySkin?: number,
+): void {
   if (!portraitsReady()) return;
   root.querySelectorAll<HTMLElement>('.portrait-chip[data-portrait-pending]').forEach((chip) => {
     const cls = chip.dataset.cls as PlayerClass | undefined;
     if (!cls) return;
     const skin = Number(chip.dataset.skin ?? 0) || 0;
+    if (onlyClass && (cls !== onlyClass || skin !== onlySkin)) return;
     const framing = (chip.dataset.framing as PortraitFraming | undefined) ?? 'headshot';
     const url = playerPortraitDataUrl(cls, skin, framing);
     if (!url) return;
@@ -97,3 +103,7 @@ export function hydratePortraits(root: ParentNode = document): void {
 
 // Once the GLBs finish loading, upgrade every placeholder currently on screen.
 onPortraitsReady(() => hydratePortraits(document));
+onPortraitUpdate((visualKey, skin) => {
+  if (!visualKey.startsWith('player_')) return;
+  hydratePortraits(document, visualKey.slice('player_'.length) as PlayerClass, skin);
+});

--- a/src/ui/start_skin_picker_portraits.ts
+++ b/src/ui/start_skin_picker_portraits.ts
@@ -1,0 +1,42 @@
+import type { PlayerClass } from '../sim/types';
+
+export type StartSkinPortraitUrl = (cls: PlayerClass, skin: number) => string | null;
+
+const PICKERS = [
+  {
+    row: '#offline-skin-row',
+    selectedClass: '#offline-select .mini-class.sel',
+  },
+  {
+    row: '#online-skin-row',
+    selectedClass: '#charcreate-panel .mini-class.sel',
+  },
+] as const;
+
+/** Replace the numbered fallback for an on-demand start-screen skin portrait.
+ * The document and portrait seam are injected so main.ts only coordinates the
+ * global readiness subscription and this DOM behavior remains directly testable. */
+export function refreshStartSkinPickerPortraits(
+  document: Document,
+  visualKey: string,
+  skin: number,
+  portraitUrl: StartSkinPortraitUrl,
+): void {
+  if (!visualKey.startsWith('player_')) return;
+  const cls = visualKey.slice('player_'.length) as PlayerClass;
+  const url = portraitUrl(cls, skin);
+  if (!url) return;
+  for (const picker of PICKERS) {
+    const row = document.querySelector<HTMLElement>(picker.row);
+    const selectedClass = document.querySelector<HTMLElement>(picker.selectedClass);
+    if (!row || selectedClass?.dataset.class !== cls) continue;
+    const swatch = row.querySelector<HTMLElement>(`.skin-swatch[data-skin="${skin}"]`);
+    if (!swatch || swatch.querySelector('.skin-swatch-img')) continue;
+    const img = document.createElement('img');
+    img.src = url;
+    img.alt = '';
+    img.className = 'skin-swatch-img';
+    swatch.textContent = '';
+    swatch.appendChild(img);
+  }
+}

--- a/tests/action_bar_hud_facade.test.ts
+++ b/tests/action_bar_hud_facade.test.ts
@@ -6,6 +6,7 @@ vi.mock('../src/render/characters', () => ({ CharacterPreview: class {} }));
 vi.mock('../src/render/characters/assets', () => ({ preloadMechAssets: vi.fn() }));
 vi.mock('../src/render/characters/portrait', () => ({
   onPortraitsReady: vi.fn(),
+  onPortraitUpdate: vi.fn(),
   playerPortraitDataUrl: vi.fn(),
   visualPortraitDataUrl: vi.fn(),
 }));

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -1128,6 +1128,7 @@ const UI_DOM_MODULES = [
   'src/ui/social_window.ts',
   'src/ui/spectate_badge.ts',
   'src/ui/spellbook_window.ts',
+  'src/ui/start_skin_picker_portraits.ts',
   'src/ui/steam_link.ts',
   'src/ui/store_stack_diag.ts',
   'src/ui/talents_window.ts',

--- a/tests/chat_hud_client_seam.test.ts
+++ b/tests/chat_hud_client_seam.test.ts
@@ -10,6 +10,7 @@ vi.mock('../src/render/characters', () => ({ CharacterPreview: class {} }));
 vi.mock('../src/render/characters/assets', () => ({ preloadMechAssets: vi.fn() }));
 vi.mock('../src/render/characters/portrait', () => ({
   onPortraitsReady: vi.fn(),
+  onPortraitUpdate: vi.fn(),
   playerPortraitDataUrl: vi.fn(),
   visualPortraitDataUrl: vi.fn(),
 }));

--- a/tests/device_memory_hint.test.ts
+++ b/tests/device_memory_hint.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEVICE_MEMORY_GB_KEY,
+  deviceMemoryGbFromBytes,
+  ENTRY_TIGHT_MODE_KEY,
+  ENTRY_TIGHT_MODE_WINDOW_MS,
+  parseDeviceMemoryGb,
+  parseTightModeAt,
+  TIGHT_MEMORY_MAX_GB,
+  tightMemoryFromSignals,
+} from '../src/device_memory_hint';
+
+const NOW = 1_700_000_000_000;
+
+describe('device memory hint parsing', () => {
+  it('parses stored/override GB values and rejects junk per dimension', () => {
+    expect(parseDeviceMemoryGb('4')).toBe(4);
+    expect(parseDeviceMemoryGb('3.75')).toBe(3.75);
+    expect(parseDeviceMemoryGb(null)).toBeUndefined();
+    expect(parseDeviceMemoryGb(undefined)).toBeUndefined();
+    expect(parseDeviceMemoryGb('')).toBeUndefined();
+    expect(parseDeviceMemoryGb('lots')).toBeUndefined();
+    expect(parseDeviceMemoryGb('NaN')).toBeUndefined();
+    expect(parseDeviceMemoryGb('0')).toBeUndefined();
+    expect(parseDeviceMemoryGb('-4')).toBeUndefined();
+    expect(parseDeviceMemoryGb('2000')).toBeUndefined();
+  });
+
+  it('converts physical-memory bytes to a two-decimal GB value', () => {
+    // A real iPhone 13 reports slightly under the marketing 4 GB.
+    expect(deviceMemoryGbFromBytes(3.9 * 1024 ** 3)).toBe(3.9);
+    expect(deviceMemoryGbFromBytes(4 * 1024 ** 3)).toBe(4);
+    expect(deviceMemoryGbFromBytes(6 * 1024 ** 3)).toBe(6);
+    expect(deviceMemoryGbFromBytes(0)).toBeUndefined();
+    expect(deviceMemoryGbFromBytes(-1)).toBeUndefined();
+    expect(deviceMemoryGbFromBytes(Number.NaN)).toBeUndefined();
+    expect(deviceMemoryGbFromBytes(Number.POSITIVE_INFINITY)).toBeUndefined();
+  });
+
+  it('parses the tight-mode marker fail-soft', () => {
+    expect(parseTightModeAt(JSON.stringify({ at: NOW }))).toBe(NOW);
+    expect(parseTightModeAt(null)).toBeUndefined();
+    expect(parseTightModeAt('')).toBeUndefined();
+    expect(parseTightModeAt('{')).toBeUndefined();
+    expect(parseTightModeAt('{}')).toBeUndefined();
+    expect(parseTightModeAt(JSON.stringify({ at: 'yesterday' }))).toBeUndefined();
+    expect(parseTightModeAt(JSON.stringify({ at: Number.NaN }))).toBeUndefined();
+  });
+});
+
+describe('tight memory decision', () => {
+  it('triggers on 4 GB-class measurements and not above', () => {
+    expect(tightMemoryFromSignals(3.9, undefined, NOW)).toBe(true);
+    expect(tightMemoryFromSignals(TIGHT_MEMORY_MAX_GB, undefined, NOW)).toBe(true);
+    // The iPhone 12 Pro class (6 GB) keeps the standard native profile.
+    expect(tightMemoryFromSignals(6, undefined, NOW)).toBe(false);
+    expect(tightMemoryFromSignals(undefined, undefined, NOW)).toBe(false);
+  });
+
+  it('triggers on a fresh entry-crash marker and expires it at the window edge', () => {
+    expect(tightMemoryFromSignals(undefined, NOW, NOW)).toBe(true);
+    expect(tightMemoryFromSignals(undefined, NOW - ENTRY_TIGHT_MODE_WINDOW_MS, NOW)).toBe(true);
+    expect(tightMemoryFromSignals(undefined, NOW - ENTRY_TIGHT_MODE_WINDOW_MS - 1, NOW)).toBe(
+      false,
+    );
+    // A marker stamped in the future (clock rollback) reads inactive.
+    expect(tightMemoryFromSignals(undefined, NOW + 1, NOW)).toBe(false);
+  });
+
+  it('lets an entry-crash marker override a roomy measurement (a kill is direct evidence)', () => {
+    expect(tightMemoryFromSignals(8, NOW, NOW)).toBe(true);
+  });
+
+  it('pins the constants the recovery story is written against', () => {
+    expect(TIGHT_MEMORY_MAX_GB).toBe(4);
+    expect(ENTRY_TIGHT_MODE_WINDOW_MS).toBe(7 * 24 * 60 * 60 * 1000);
+    expect(DEVICE_MEMORY_GB_KEY).toBe('woc_device_mem_gb');
+    expect(ENTRY_TIGHT_MODE_KEY).toBe('woc_entry_tight_mode');
+  });
+});

--- a/tests/entry_diagnostics.test.ts
+++ b/tests/entry_diagnostics.test.ts
@@ -3,7 +3,9 @@ import {
   checkpointActiveEntryDiagnostics,
   createEntryDiagnosticsController,
   type EntryDiagnosticPersistence,
+  resumeActiveEntryDiagnostics,
   stopActiveEntryDiagnostics,
+  suspendActiveEntryDiagnostics,
 } from '../src/game/entry_diagnostics';
 
 function harness() {
@@ -153,6 +155,28 @@ describe('entry diagnostics controller', () => {
     controller.checkpoint('window-error');
     controller.renderedFrame(10_000);
     expect(events).toEqual(['start:2', 'scene-build-start', 'clear']);
+  });
+
+  it('clears while hidden and restores the last entry checkpoint on foreground', () => {
+    const { controller, events } = harness();
+    controller.start(2);
+    controller.checkpoint('assets-await', { phase: 'assets' });
+    suspendActiveEntryDiagnostics();
+    controller.checkpoint('renderer-built');
+    controller.renderedFrame(1_000);
+    controller.markStable();
+    resumeActiveEntryDiagnostics();
+    expect(events).toEqual([
+      'start:2',
+      'scene-build-start',
+      'assets-await',
+      'clear',
+      'start:2',
+      'assets-await',
+      'runtime-stable',
+    ]);
+    controller.markStable();
+    expect(events.at(-1)).toBe('runtime-stable');
   });
 
   it('uses wall time for persisted checkpoints rather than animation time', () => {

--- a/tests/gfx.test.ts
+++ b/tests/gfx.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import * as THREE from 'three';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DEVICE_MEMORY_GB_KEY, ENTRY_TIGHT_MODE_KEY } from '../src/device_memory_hint';
 import { NAMEPLATE_INTERVAL_LOW_SEC, nameplateIntervalSec } from '../src/game/ui_tier_knobs';
 import { FAR_ANIM_RANGE_SCALE_MAX } from '../src/render/crowd_lod';
 import {
@@ -333,7 +334,7 @@ describe('graphics tier resolution', () => {
     expect(nativeAndroid.maxPooledCharacterVisuals).toBe(Number.POSITIVE_INFINITY);
   });
 
-  it('applies the 4 GB-class tight-memory rung only with the hint, and only on native iOS', () => {
+  it('applies the 4 GB-class tight-memory rung to native iOS and recovered iOS web', () => {
     const nativeIos = {
       maxTouchPoints: 5,
       coarsePointer: true,
@@ -346,6 +347,11 @@ describe('graphics tier resolution', () => {
     const tightWeb = gfxInternalsForTest.settingsFor('medium', {
       ...nativeIos,
       nativeApp: false,
+      tightMemory: true,
+    });
+    const tightAndroid = gfxInternalsForTest.settingsFor('medium', {
+      ...nativeIos,
+      platform: 'android',
       tightMemory: true,
     });
 
@@ -368,10 +374,33 @@ describe('graphics tier resolution', () => {
     expect(standard.grassStep).toBe(2.75);
     expect(standard.maxPooledCharacterVisuals).toBe(6);
 
-    // The rung is scoped to the packaged iOS shell: the hint only exists where
-    // the native bridge measured it (or an entry crash stamped the marker).
-    expect(tightWeb.tightMemory).toBe(false);
-    expect(tightWeb.pixelRatioCap).toBeGreaterThan(1.0);
+    // A foreground entry crash also stamps the marker for iOS Safari, which
+    // shares WKWebView's WebContent memory ceiling and needs the same lower rung.
+    expect(tightWeb.tightMemory).toBe(true);
+    expect(tightWeb.pixelRatioCap).toBe(1.0);
+    expect(tightAndroid.tightMemory).toBe(false);
+  });
+
+  it('carries cached memory and recovery markers into the synchronous runtime hints', () => {
+    const originalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+    const values = new Map<string, string>([
+      [DEVICE_MEMORY_GB_KEY, '4'],
+      [ENTRY_TIGHT_MODE_KEY, JSON.stringify({ at: Date.now() })],
+    ]);
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => values.get(key) ?? null,
+        setItem: (key: string, value: string) => void values.set(key, value),
+        removeItem: (key: string) => void values.delete(key),
+      },
+    });
+    try {
+      expect(gfxInternalsForTest.runtimeHints().tightMemory).toBe(true);
+    } finally {
+      if (originalStorage) Object.defineProperty(globalThis, 'localStorage', originalStorage);
+      else delete (globalThis as { localStorage?: Storage }).localStorage;
+    }
   });
 
   it('never raises the native iOS light bound from an Advanced low-effects override', () => {

--- a/tests/gfx.test.ts
+++ b/tests/gfx.test.ts
@@ -333,6 +333,47 @@ describe('graphics tier resolution', () => {
     expect(nativeAndroid.maxPooledCharacterVisuals).toBe(Number.POSITIVE_INFINITY);
   });
 
+  it('applies the 4 GB-class tight-memory rung only with the hint, and only on native iOS', () => {
+    const nativeIos = {
+      maxTouchPoints: 5,
+      coarsePointer: true,
+      narrowViewport: true,
+      nativeApp: true,
+      platform: 'ios' as const,
+    };
+    const tight = gfxInternalsForTest.settingsFor('medium', { ...nativeIos, tightMemory: true });
+    const standard = gfxInternalsForTest.settingsFor('medium', nativeIos);
+    const tightWeb = gfxInternalsForTest.settingsFor('medium', {
+      ...nativeIos,
+      nativeApp: false,
+      tightMemory: true,
+    });
+
+    expect(tight.tightMemory).toBe(true);
+    expect(tight.pixelRatioCap).toBe(1.0);
+    // Reuses the Advanced sub-knob's lean grass values (34 / 3.8): the leanest
+    // grass the game already ships, so the rung adds no new visual floor.
+    expect(tight.grassRadius).toBe(34);
+    expect(tight.grassStep).toBe(3.8);
+    expect(tight.maxPooledCharacterVisuals).toBe(4);
+    // Collision-bearing tree/rock placement fairness holds on the tight rung too.
+    expect(tight.leanFoliage).toBe(false);
+    expect(tight.nativeIosMemoryProfile).toBe(true);
+
+    // Without the hint the standard native profile is exactly what it was: a
+    // device the shell cannot measure keeps today's behaviour, byte for byte.
+    expect(standard.tightMemory).toBe(false);
+    expect(standard.pixelRatioCap).toBe(1.25);
+    expect(standard.grassRadius).toBe(52);
+    expect(standard.grassStep).toBe(2.75);
+    expect(standard.maxPooledCharacterVisuals).toBe(6);
+
+    // The rung is scoped to the packaged iOS shell: the hint only exists where
+    // the native bridge measured it (or an entry crash stamped the marker).
+    expect(tightWeb.tightMemory).toBe(false);
+    expect(tightWeb.pixelRatioCap).toBeGreaterThan(1.0);
+  });
+
   it('never raises the native iOS light bound from an Advanced low-effects override', () => {
     const advanced = gfxInternalsForTest.settingsFor('high', {
       maxTouchPoints: 5,

--- a/tests/ios_entry_memory.test.ts
+++ b/tests/ios_entry_memory.test.ts
@@ -19,6 +19,7 @@ const mainSource = read('../src/main.ts');
 const assetsSource = read('../src/render/characters/assets.ts');
 const visualSource = read('../src/render/characters/visual.ts');
 const portraitSource = read('../src/render/characters/portrait.ts');
+const portraitChipSource = read('../src/ui/portrait_chip.ts');
 const vfxSource = read('../src/render/vfx.ts');
 
 describe('entry probe covers the await window', () => {
@@ -74,7 +75,9 @@ describe('tight-memory residency diet', () => {
 
 describe('deferred skin atlases on the packaged iOS shell', () => {
   it('gates the boot atlas sweep on the hint-stable native profile', () => {
-    expect(assetsSource).toContain('const eagerSkinAtlases = !GFX.nativeIosMemoryProfile;');
+    expect(assetsSource).toContain(
+      'const eagerSkinAtlases = !(GFX.nativeIosMemoryProfile || GFX.tightMemory);',
+    );
     // The character-preview gate must not re-await atlases the boot deferred.
     expect(assetsSource).toContain('const missingSkins = eagerSkinAtlases');
   });
@@ -84,10 +87,11 @@ describe('deferred skin atlases on the packaged iOS shell', () => {
   });
 
   it('never caches a portrait rendered while its atlas is still in flight', () => {
-    expect(portraitSource).toContain(
-      'const atlasPending = ensureSkinTexture(visualKey, skin) !== null;',
-    );
-    expect(portraitSource).toContain('if (!atlasPending) cache.set(key, url);');
+    expect(portraitSource).toContain('const atlasPending = ensureSkinTexture(visualKey, skin);');
+    expect(portraitSource).toContain('if (atlasPending) {');
+    expect(portraitSource).toContain('return null;');
+    expect(portraitChipSource).toContain('onPortraitUpdate((visualKey, skin) => {');
+    expect(mainSource).toContain('refreshStartSkinPickerPortraits(');
   });
 });
 
@@ -125,8 +129,10 @@ describe('native device-memory bridge', () => {
   it('exposes physical memory from the shell and registers the plugin', () => {
     expect(pluginSource).toContain('ProcessInfo.processInfo.physicalMemory');
     expect(pluginSource).toContain('"physicalMemoryBytes"');
+    expect(pluginSource).toContain('public let jsName = "NativeDeviceInfo"');
     expect(pluginSource).toContain('CAPPluginMethod(name: "getMemoryInfo"');
     expect(controllerSource).toContain('registerPluginInstance(NativeDeviceInfoPlugin())');
+    expect(mainSource).toContain('void primeNativeDeviceMemoryHint();');
   });
 
   it('compiles the plugin into the app target', () => {

--- a/tests/ios_entry_memory.test.ts
+++ b/tests/ios_entry_memory.test.ts
@@ -1,0 +1,185 @@
+// The 4 GB-class iOS entry-memory diet (the iPhone 13 Play-press crash).
+//
+// A WebContent process kill during world entry has no JS-observable event, so
+// most of these contracts are source pins in the entry_crash_guard.test.ts
+// idiom: they assert the load-bearing lines exist in the order the recovery
+// story depends on, and fail loudly when a refactor moves one.
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { ENTRY_CHECKPOINTS } from '../src/game/entry_crash_guard';
+import { primeNativeDeviceMemoryHint } from '../src/net/native_device_info';
+import {
+  assetsReady,
+  preloadInternalsForTest,
+  registerPreload,
+} from '../src/render/assets/preload';
+
+const read = (path: string): string => readFileSync(new URL(path, import.meta.url), 'utf8');
+const mainSource = read('../src/main.ts');
+const assetsSource = read('../src/render/characters/assets.ts');
+const visualSource = read('../src/render/characters/visual.ts');
+const portraitSource = read('../src/render/characters/portrait.ts');
+const vfxSource = read('../src/render/vfx.ts');
+
+describe('entry probe covers the await window', () => {
+  it('registers the assets-await checkpoint id', () => {
+    expect(ENTRY_CHECKPOINTS).toContain('assets-await');
+  });
+
+  it('arms the probe before the locale and asset awaits and re-stamps the build', () => {
+    const startAt = mainSource.indexOf("entryDiagnostics.start(settings.get('graphicsPreset'));");
+    const awaitCheckpointAt = mainSource.indexOf("entryDiagnostics.checkpoint('assets-await'");
+    const localeAwaitAt = mainSource.indexOf(
+      'await Promise.all([ensureLocaleLoaded(getLanguage()), ensureDeedLocalesLoaded(getLanguage())]);',
+    );
+    const assetsAwaitAt = mainSource.indexOf('await assetsReady(');
+    const sceneRestampAt = mainSource.indexOf("entryDiagnostics.checkpoint('scene-build-start'");
+    expect(startAt).toBeGreaterThan(-1);
+    expect(awaitCheckpointAt).toBeGreaterThan(startAt);
+    expect(localeAwaitAt).toBeGreaterThan(awaitCheckpointAt);
+    expect(assetsAwaitAt).toBeGreaterThan(localeAwaitAt);
+    expect(sceneRestampAt).toBeGreaterThan(assetsAwaitAt);
+  });
+
+  it('disarms the probe on the handled asset-failure path (not a process kill)', () => {
+    const assetsAwaitAt = mainSource.indexOf('await assetsReady(');
+    const stopAt = mainSource.indexOf('entryDiagnostics.stop();', assetsAwaitAt);
+    const overlayAt = mainSource.indexOf("fatalOverlay(t('loading.assetsFailed'", assetsAwaitAt);
+    expect(stopAt).toBeGreaterThan(assetsAwaitAt);
+    expect(overlayAt).toBeGreaterThan(stopAt);
+  });
+});
+
+describe('entry-crash recovery arms tight memory', () => {
+  it('stamps the tight-mode marker inside the native recovery block', () => {
+    const persistAt = mainSource.indexOf('persistEntryRecoveryLog(entryRecovery, entryRecoveryAt)');
+    const markAt = mainSource.indexOf('markEntryTightMode(entryRecoveryAt);');
+    const bannerAt = mainSource.indexOf('showEntryGuardBanner(entryRecovery.to)');
+    expect(persistAt).toBeGreaterThan(-1);
+    expect(markAt).toBeGreaterThan(persistAt);
+    expect(bannerAt).toBeGreaterThan(markAt);
+  });
+});
+
+describe('tight-memory residency diet', () => {
+  it('skips the two secondary-context preview prewarms on the tight profile', () => {
+    const gateAt = mainSource.indexOf('if (!GFX.tightMemory) {');
+    const characterPrewarmAt = mainSource.indexOf('await hud.prewarmCharacterPreview();');
+    const armoryPrewarmAt = mainSource.indexOf('await hud.prewarmArmoryPreview();');
+    expect(gateAt).toBeGreaterThan(-1);
+    expect(characterPrewarmAt).toBeGreaterThan(gateAt);
+    expect(armoryPrewarmAt).toBeGreaterThan(characterPrewarmAt);
+  });
+});
+
+describe('deferred skin atlases on the packaged iOS shell', () => {
+  it('gates the boot atlas sweep on the hint-stable native profile', () => {
+    expect(assetsSource).toContain('const eagerSkinAtlases = !GFX.nativeIosMemoryProfile;');
+    // The character-preview gate must not re-await atlases the boot deferred.
+    expect(assetsSource).toContain('const missingSkins = eagerSkinAtlases');
+  });
+
+  it('heals a deferred atlas at visual construction, not only on live swaps', () => {
+    expect(visualSource).toContain('const pendingAtlas = ensureSkinTexture(this.key, skinIndex);');
+  });
+
+  it('never caches a portrait rendered while its atlas is still in flight', () => {
+    expect(portraitSource).toContain(
+      'const atlasPending = ensureSkinTexture(visualKey, skin) !== null;',
+    );
+    expect(portraitSource).toContain('if (!atlasPending) cache.set(key, url);');
+  });
+});
+
+describe('dead sprite retention after the VFX atlas composite', () => {
+  it('releases the source sprites once the atlas canvas owns their pixels', () => {
+    expect(vfxSource).toContain('spriteImages[i] = null;');
+    expect(vfxSource).toContain('releaseTexture(`/vfx/${SPRITE_FILES[i]}.png`, { srgb: true });');
+  });
+
+  // Releasing the sources is only safe because the composed canvas is reused: a
+  // second Vfx is real (the editor viewport's reload() builds a fresh Renderer,
+  // and each Renderer owns a Vfx), and recomposing with the sources gone would
+  // paint all 16 cells as fallback discs - a silent, total loss of particle art
+  // that no existing test would catch.
+  it('composes the atlas canvas exactly once and wraps it per instance', () => {
+    // The release lives in the composer, which is called only through the ??= memo.
+    const composeAt = vfxSource.indexOf('function composeAtlasCanvas()');
+    const releaseAt = vfxSource.indexOf('spriteImages[i] = null;');
+    const buildAt = vfxSource.indexOf('function buildAtlasTexture()');
+    expect(composeAt).toBeGreaterThan(-1);
+    expect(releaseAt).toBeGreaterThan(composeAt);
+    expect(buildAt).toBeGreaterThan(releaseAt);
+    expect(vfxSource).toContain('atlasCanvas ??= composeAtlasCanvas();');
+    // Each instance still gets its OWN texture object over that shared canvas,
+    // so two live renderers never share one GPU upload.
+    expect(vfxSource).toContain('const tex = new THREE.CanvasTexture(atlasCanvas);');
+  });
+});
+
+describe('native device-memory bridge', () => {
+  const pluginSource = read('../ios/App/App/NativeDeviceInfoPlugin.swift');
+  const controllerSource = read('../ios/App/App/AppViewController.swift');
+  const pbxproj = read('../ios/App/App.xcodeproj/project.pbxproj');
+
+  it('exposes physical memory from the shell and registers the plugin', () => {
+    expect(pluginSource).toContain('ProcessInfo.processInfo.physicalMemory');
+    expect(pluginSource).toContain('"physicalMemoryBytes"');
+    expect(pluginSource).toContain('CAPPluginMethod(name: "getMemoryInfo"');
+    expect(controllerSource).toContain('registerPluginInstance(NativeDeviceInfoPlugin())');
+  });
+
+  it('compiles the plugin into the app target', () => {
+    expect(pbxproj).toContain('NativeDeviceInfoPlugin.swift in Sources');
+  });
+
+  it('no-ops fail-soft outside the native shell', async () => {
+    await expect(primeNativeDeviceMemoryHint()).resolves.toBeUndefined();
+  });
+});
+
+describe('preload registry retains no resolution values', () => {
+  // The registry is module-level and append-only by design, and two callers exist
+  // in production (portrait.ts at module import, main.ts in startGame), so the
+  // fix erases each task's VALUE rather than draining the array: repeat and
+  // concurrent callers must keep behaving exactly as they did.
+  it('never exposes a registered task resolution value', async () => {
+    const texture = { marker: 'a live THREE.Texture stands in here' };
+    registerPreload(Promise.resolve(texture));
+    registerPreload(Promise.resolve(42));
+    const seen: Array<[number, number]> = [];
+    await assetsReady((done, total) => seen.push([done, total]));
+    expect(seen.at(-1)).toEqual([2, 2]);
+    // Awaiting the stored tasks must yield undefined, not the texture: anything
+    // else means the array is still a retainer and a consumer-side release
+    // (vfx.ts dropping its sprite sources) cannot actually free the pixels.
+    const stored = preloadInternalsForTest.tasks();
+    expect(stored).toHaveLength(2);
+    await expect(Promise.all(stored)).resolves.toEqual([undefined, undefined]);
+  });
+
+  it('keeps counting progress against the full registry for a later caller', async () => {
+    registerPreload(Promise.resolve('one'));
+    registerPreload(Promise.resolve('two'));
+    const before = preloadInternalsForTest.tasks().length;
+    const first: Array<[number, number]> = [];
+    await assetsReady((done, total) => first.push([done, total]));
+    const second: Array<[number, number]> = [];
+    await assetsReady((done, total) => second.push([done, total]));
+    // Both callers see the same full denominator: nothing was drained between
+    // them (portrait.ts calls this at module import, main.ts again in startGame).
+    expect(first.at(-1)).toEqual([before, before]);
+    expect(second.at(-1)).toEqual([before, before]);
+  });
+
+  // LAST in this describe on purpose: the registry is module-level with no reset
+  // (that is the contract under test), so a rejected task registered here stays
+  // and would fail every later case in the file.
+  it('still reports every failure, on repeat calls too (no drain)', async () => {
+    registerPreload(Promise.reject(new Error('cdn fell over')));
+    await expect(assetsReady()).rejects.toThrow('asset preload failed (1)');
+    // The registry is intact, so a second caller observes the same failure
+    // rather than a silent success.
+    await expect(assetsReady()).rejects.toThrow('asset preload failed (1)');
+  });
+});

--- a/tests/native_device_info.test.ts
+++ b/tests/native_device_info.test.ts
@@ -1,0 +1,91 @@
+// The native device-memory bridge: measures ProcessInfo.physicalMemory through
+// the duck-typed Capacitor plugin and caches it for the NEXT boot's synchronous
+// graphics-profile read (src/device_memory_hint.ts). NATIVE_APP is baked from
+// VITE_NATIVE_APP at module load, so each case stubs the env and re-imports.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DEVICE_MEMORY_GB_KEY } from '../src/device_memory_hint';
+
+// The default Vitest env is plain Node, so `window`/`localStorage` are absent and
+// are stubbed here per case. Assign through an index signature rather than the
+// real DOM types: the lib types declare `window` as a full `Window`, so a bare
+// object literal is checked against that shape and fails to compile.
+const g = globalThis as unknown as Record<string, unknown>;
+const hadWindow = 'window' in globalThis;
+const hadStorage = 'localStorage' in globalThis;
+
+function stubStorage(): Map<string, string> {
+  const backing = new Map<string, string>();
+  g.localStorage = {
+    getItem: (k: string) => backing.get(k) ?? null,
+    setItem: (k: string, v: string) => void backing.set(k, v),
+    removeItem: (k: string) => void backing.delete(k),
+  };
+  return backing;
+}
+
+/** Install a fake Capacitor bridge exposing `getMemoryInfo`. */
+function stubBridge(getMemoryInfo: (() => Promise<unknown>) | null): void {
+  g.window = {
+    Capacitor: { Plugins: getMemoryInfo ? { NativeDeviceInfo: { getMemoryInfo } } : {} },
+  };
+}
+
+async function importFresh(): Promise<typeof import('../src/net/native_device_info')> {
+  vi.resetModules();
+  return import('../src/net/native_device_info');
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  if (!hadWindow) delete g.window;
+  if (!hadStorage) delete g.localStorage;
+});
+
+describe('primeNativeDeviceMemoryHint', () => {
+  it('caches the measured GB through the plugin bridge', async () => {
+    vi.stubEnv('VITE_NATIVE_APP', '1');
+    const backing = stubStorage();
+    stubBridge(async () => ({ physicalMemoryBytes: 3.9 * 1024 ** 3 }));
+    const { primeNativeDeviceMemoryHint } = await importFresh();
+    await primeNativeDeviceMemoryHint();
+    expect(backing.get(DEVICE_MEMORY_GB_KEY)).toBe('3.9');
+  });
+
+  it('stores nothing when the bridge reports garbage', async () => {
+    vi.stubEnv('VITE_NATIVE_APP', '1');
+    const backing = stubStorage();
+    stubBridge(async () => ({ physicalMemoryBytes: -1 }));
+    const { primeNativeDeviceMemoryHint } = await importFresh();
+    await primeNativeDeviceMemoryHint();
+    expect(backing.has(DEVICE_MEMORY_GB_KEY)).toBe(false);
+  });
+
+  it('no-ops fail-soft when the plugin is missing or throws', async () => {
+    vi.stubEnv('VITE_NATIVE_APP', '1');
+    const backing = stubStorage();
+    stubBridge(null);
+    const missing = await importFresh();
+    await expect(missing.primeNativeDeviceMemoryHint()).resolves.toBeUndefined();
+    stubBridge(async () => {
+      throw new Error('bridge fell over');
+    });
+    const throwing = await importFresh();
+    await expect(throwing.primeNativeDeviceMemoryHint()).resolves.toBeUndefined();
+    expect(backing.has(DEVICE_MEMORY_GB_KEY)).toBe(false);
+  });
+
+  it('never touches the bridge outside the native shell', async () => {
+    vi.stubEnv('VITE_NATIVE_APP', '');
+    const backing = stubStorage();
+    let called = 0;
+    stubBridge(async () => {
+      called++;
+      return { physicalMemoryBytes: 4 * 1024 ** 3 };
+    });
+    const { primeNativeDeviceMemoryHint } = await importFresh();
+    await primeNativeDeviceMemoryHint();
+    expect(called).toBe(0);
+    expect(backing.has(DEVICE_MEMORY_GB_KEY)).toBe(false);
+  });
+});

--- a/tests/portrait_atlas_readiness.test.ts
+++ b/tests/portrait_atlas_readiness.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const atlas = vi.hoisted(() => {
+  let resolve: () => void = () => {};
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return {
+    loaded: false,
+    promise,
+    resolve: () => {
+      atlas.loaded = true;
+      resolve();
+    },
+  };
+});
+
+const ensureSkinTexture = vi.hoisted(() => vi.fn(() => (atlas.loaded ? null : atlas.promise)));
+const CharacterVisual = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/render/assets/preload', () => ({
+  assetsReady: () => Promise.resolve(),
+}));
+vi.mock('../src/render/characters/assets', () => ({
+  ensureSkinTexture,
+}));
+vi.mock('../src/render/characters/visual', () => ({
+  CharacterVisual,
+}));
+
+import {
+  onPortraitUpdate,
+  portraitsReady,
+  visualPortraitDataUrl,
+} from '../src/render/characters/portrait';
+
+describe('deferred portrait atlas readiness', () => {
+  it('returns no false portrait and notifies consumers when the real atlas arrives', async () => {
+    await vi.waitFor(() => expect(portraitsReady()).toBe(true));
+    const updated = vi.fn();
+    onPortraitUpdate(updated);
+
+    expect(visualPortraitDataUrl('player_mage', 1)).toBeNull();
+    expect(ensureSkinTexture).toHaveBeenCalledWith('player_mage', 1);
+    expect(CharacterVisual).not.toHaveBeenCalled();
+
+    atlas.resolve();
+    await vi.waitFor(() => expect(updated).toHaveBeenCalledWith('player_mage', 1));
+  });
+});

--- a/tests/portrait_chip_defer.test.ts
+++ b/tests/portrait_chip_defer.test.ts
@@ -4,6 +4,7 @@ const portraitUrl = `data:image/png;base64,${'A'.repeat(20_000)}`;
 
 vi.mock('../src/render/characters/portrait', () => ({
   onPortraitsReady: () => undefined,
+  onPortraitUpdate: () => undefined,
   playerPortraitDataUrl: () => portraitUrl,
   portraitsReady: () => true,
 }));

--- a/tests/skin_event_controller.test.ts
+++ b/tests/skin_event_controller.test.ts
@@ -5,8 +5,9 @@ import type { FocusTrapHandle } from '../src/ui/focus_manager';
 import { SkinEventController } from '../src/ui/hud/cosmetics/skin_event_controller';
 import type { IWorld } from '../src/world_api';
 
+const playerPortraitDataUrl = vi.hoisted(() => vi.fn<() => string | null>(() => null));
 vi.mock('../src/render/characters/portrait', () => ({
-  playerPortraitDataUrl: () => null,
+  playerPortraitDataUrl,
   visualPortraitDataUrl: () => null,
 }));
 
@@ -40,6 +41,7 @@ function harness(reduceMotion = false) {
   const preview = { mount: vi.fn(), setSkin: vi.fn() };
   const showBanner = vi.fn();
   const renderBagsIfOpen = vi.fn();
+  let portraitUpdate: ((visualKey: string, skin: number) => void) | null = null;
   const controller = new SkinEventController({
     document,
     window,
@@ -51,6 +53,9 @@ function harness(reduceMotion = false) {
     closeTop,
     hideTooltip: vi.fn(),
     onPortraitsReady: vi.fn(),
+    onPortraitUpdate: (callback) => {
+      portraitUpdate = callback;
+    },
     preloadMechAssets: vi.fn(() => Promise.resolve()),
     preview,
     openFocusTrap: vi.fn(() => trap),
@@ -71,12 +76,15 @@ function harness(reduceMotion = false) {
     preview,
     showBanner,
     renderBagsIfOpen,
+    portraitUpdate: (visualKey: string, skin: number) => portraitUpdate?.(visualKey, skin),
   };
 }
 
 describe('SkinEventController', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
+    playerPortraitDataUrl.mockReset();
+    playerPortraitDataUrl.mockReturnValue(null);
   });
 
   it('closes stacked surfaces, opens a trapped wheel, and owns timed teardown', () => {
@@ -128,5 +136,18 @@ describe('SkinEventController', () => {
     expect(test.audio.cosmeticUnlock).toHaveBeenCalledTimes(1);
     expect(test.renderBagsIfOpen).toHaveBeenCalledTimes(1);
     expect(document.getElementById('skin-event')?.classList.contains('open')).toBe(false);
+  });
+
+  it('replaces a visible skin fallback when its deferred portrait becomes ready', () => {
+    const test = harness();
+    test.controller.open('rare');
+    [...test.scheduled.values()][0].callback();
+    const swatch = document.querySelector<HTMLButtonElement>('.se-swatch[data-skin="1"]');
+    expect(swatch?.querySelector('img')).toBeNull();
+
+    playerPortraitDataUrl.mockReturnValue('data:image/png;base64,ready');
+    test.portraitUpdate('player_warrior', 1);
+
+    expect(swatch?.querySelector('img')?.src).toBe('data:image/png;base64,ready');
   });
 });

--- a/tests/start_skin_picker_portraits.test.ts
+++ b/tests/start_skin_picker_portraits.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { refreshStartSkinPickerPortraits } from '../src/ui/start_skin_picker_portraits';
+
+describe('start skin picker portrait readiness', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <section id="offline-select">
+        <button class="mini-class sel" data-class="warrior"></button>
+      </section>
+      <div id="offline-skin-row">
+        <button class="skin-swatch" data-skin="1">2</button>
+      </div>
+      <section id="charcreate-panel">
+        <button class="mini-class sel" data-class="mage"></button>
+      </section>
+      <div id="online-skin-row">
+        <button class="skin-swatch" data-skin="1">2</button>
+      </div>
+    `;
+  });
+
+  it('hydrates only the picker whose selected class matches the resolved atlas', () => {
+    const portraitUrl = vi.fn(() => 'data:image/png;base64,ready');
+
+    refreshStartSkinPickerPortraits(document, 'player_warrior', 1, portraitUrl);
+
+    expect(portraitUrl).toHaveBeenCalledWith('warrior', 1);
+    expect(document.querySelector('#offline-skin-row img')?.getAttribute('src')).toBe(
+      'data:image/png;base64,ready',
+    );
+    expect(document.querySelector('#online-skin-row img')).toBeNull();
+    expect(document.querySelector('#online-skin-row .skin-swatch')?.textContent).toBe('2');
+  });
+});


### PR DESCRIPTION
## Summary

- Read physical device memory from the native iOS shell and select a tighter bounded-residency graphics profile on 4 GB devices.
- Arm entry diagnostics before asset loading, preserve them across foreground lifecycle resumes, and advance the recovery profile after confirmed foreground WebContent kills.
- Reduce entry-time texture, VFX, preview, and pooled-character residency while preserving the selected graphics tier.
- Defer alternate skin atlases on tight-memory iOS hosts and refresh every portrait consumer when an on-demand atlas becomes ready.

## Type of change

- [x] Bug fix
- [x] Performance improvement
- [x] Test coverage

## How tested

- [x] Focused iOS entry and portrait suite: 14 files, 125 tests passed.
- [x] UI extraction and architecture suite: 2 files, 34 tests passed.
- [x] `npx tsc --noEmit`
- [x] `npm run ci:changed` (exit 0, repository warnings only)
- [x] Pre-push QA floor: 72 tests passed, 3 skipped; typecheck, lint, and copy rules green.
- [ ] `npm run gate` reached the full suite. The branch-caused portrait mock failures found by that run were fixed and rerun successfully. Two unrelated local/base failures remain: `tests/discord_server.test.ts` reads the developer `.env` invite override, and `tests/texture_upload.test.ts` expects Three to lack the update-range API although the installed pinned revision 185 exposes it.

## Manual coverage

- [ ] Physical 4 GB iPhone entry reproduction was not available locally.
- [ ] Desktop and mobile browser smoke testing was not run.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Target branch is `release/v0.32.1`.
- [x] No generated artifacts or unrelated local files are included.
- [x] Final frontend and cross-platform reviews were completed; all evidence-backed findings were addressed.
