### PR TITLE
feat(dungeons): scale normal Wildheart Basin to the Sanctum calibration and punish early boss pulls

### DIFF
--- a/docs/prd/wildheart-basin-open-field-dungeon.md
+++ b/docs/prd/wildheart-basin-open-field-dungeon.md
@@ -269,6 +269,40 @@ portal membrane is turquoise and animated. A warm limestone fallback handles pre
 `HEROIC_DUNGEON_TUNING.wildheart_basin` pins Heroic mobs to level 22, names
 `wildheart_high_priest` as final boss, and awards one Heroic Mark per eligible participant.
 
+### 8.1 Normal retune (follow-up)
+
+The dungeon shipped with a Heroic record but NO `NORMAL_DUNGEON_TUNING` record, so Normal mode ran
+the raw base templates. Measured on the shared reference warrior (level-20 prot, 2861 armor,
+Defensive Stance) its trash swung 26 to 32 and Zulgar 35, against normal Gravewyrm Sanctum's 103 to
+112 and 200 to 301: roughly 3.5x under on trash and 6 to 8x under on the boss, for the same endgame
+loot band. `NORMAL_DUNGEON_TUNING.wildheart_basin` ports the Sanctum calibration (doubled health,
+trash floored at 100 and the boss at 200), with two roster-forced departures:
+
+- a third band at 150 for `wildheart_beastmaster`, a rare ccImmune pack leader that spawns twice and
+  out-presses trash without being a second Zulgar;
+- `rangedDamageMultiplierByMob`, a new knob on `NormalDungeonTuning`. Half this roster (Stalker x6,
+  Hexcaller x4) is a `petSpell` caster, and a caster stands at spell range and casts instead of
+  swinging, so `damageMultiplierByMob` (which moves `dmgBase`/`dmgPerLevel`, i.e. melee) is inert
+  for it. Its nuke is rolled from the base table and multiplied by `petDamageMult`, which returns a
+  flat 1 for any mob with no owner, so no pre-existing knob could reach it. The new factor stamps
+  `Entity.rangedDamageMult`, applied at the fire site after the rng draw. Normal only: Heroic keeps
+  its shipped calibration untouched, and therefore still carries the same inert-caster gap.
+
+Floors, literals, live-spawn wiring, and the Heroic transform are pinned by
+`tests/wildheart_normal_tuning.test.ts`.
+
+### 8.2 Premature boss pull
+
+`DungeonDef.bossChainPull` (opt-in, live only here) makes aggroing Zulgar while any of the route is
+still alive send every living mob in the instance at the puller at once. The two open routes make
+running past every pack to the shrine trivial in a way a corridor dungeon prevents by geometry, so
+this restores the cost of skipping trash. The mechanic is self-gating: it pulls whatever is still
+alive, so a group that cleared the route finds nothing to pull and fights the boss alone. Pulled
+mobs anchor their leash on the puller rather than on where they stood, because the route is about
+180 yards end to end against a 70-yard dungeon leash and a self-anchored mob would evade home before
+reaching the shrine. Draws no rng, so the parity goldens are unaffected. Implementation in
+`src/sim/instances/boss_chain_pull.ts`, pinned by `tests/wildheart_boss_chain_pull.test.ts`.
+
 Zulgar drops three new epic weapons: Wildheart Tuskblade, Hexwood Staff of the Basin, and
 Fangknife of Zulgar.
 

--- a/src/sim/content/dungeon_difficulty.ts
+++ b/src/sim/content/dungeon_difficulty.ts
@@ -80,6 +80,17 @@ export interface NormalDungeonTuning {
   // factor. Keys must be a subset of damageMultiplierByMob (pinned by
   // tests/gravewyrm_normal_tuning.test.ts).
   mechanicDamageMultiplierByMob?: Record<string, number>;
+  // Optional per-mob multiplier for a mob's RANGED petSpell nuke. Needed
+  // because damageMultiplierByMob moves dmgBase/dmgPerLevel, which is MELEE
+  // only, while a petSpell caster stands at spell range and casts instead of
+  // swinging (mob/combat_profile.ts updateCasterCombat: "the chase-arm melee
+  // probes are dead in practice"). For such a mob the melee factor is inert and
+  // this is the factor that actually prices it. Rolled damage is unmitigated by
+  // armor, so its floor is measured on the raw hit, not the tank's intake.
+  // Keys must be a subset of damageMultiplierByMob, and every key must name a
+  // template that actually HAS a petSpell (pinned by
+  // tests/wildheart_normal_tuning.test.ts).
+  rangedDamageMultiplierByMob?: Record<string, number>;
 }
 
 // Fresh-group retune (v0.30), pressure pass (2026-07-26): the first v0.30
@@ -140,6 +151,54 @@ export const NORMAL_DUNGEON_TUNING: Record<string, NormalDungeonTuning> = {
     damageMultiplierByMob: {
       nythraxis_scourge_of_thornpeak: 5,
       nythraxis_skeleton_warrior: 5,
+    },
+  },
+  // Wildheart Basin shipped with a heroic record but NO normal one, so its
+  // normal mode ran the raw base templates: trash swung 26-32 post-mitigation
+  // on the reference warrior and Zulgar 35, against the Sanctum's 103-112 and
+  // 200-301. That is 3.5x under on trash and 6-8x under on the boss, for a
+  // dungeon whose loot and level sit in the same endgame band. This record puts
+  // normal Wildheart on the SANCTUM NORMAL calibration: the same DOUBLED health
+  // and the same reference warrior (level-20 prot, 2861 armor, Defensive
+  // Stance), floored per band at trash 100 / boss 200.
+  //
+  // Two Wildheart-specific departures from the Sanctum table, both forced by
+  // the roster rather than chosen:
+  // 1. A third band at 150 for wildheart_beastmaster. It is a rare, ccImmune
+  //    pack-leader that spawns TWICE and carries warcry + wardAllies + stomp,
+  //    so it out-presses trash, but it is not the final boss and must not read
+  //    as a third Zulgar. Nythraxis set the same precedent (its own 600/300
+  //    bands rather than the five-man 500/250).
+  // 2. rangedDamageMultiplierByMob for the two petSpell casters. HALF the
+  //    20-spawn roster (stalker x6, hexcaller x4) is a ranged caster that never
+  //    melees, so its damageMultiplierByMob factor is inert and its real output
+  //    is a petSpell nuke no other knob reaches. Priced to the same 100 minimum
+  //    hit as trash melee: unmitigated by armor and landable on any group
+  //    member, which is what makes them the priority kill the content brief
+  //    calls for. Their melee factors are still solved to the 100 floor so a
+  //    caster cornered in melee range (the chase arm) is on-model too.
+  //
+  // Mechanics ride each mob's own melee factor with NO override, which is the
+  // Sanctum default: Zulgar's Wildheart Pulse lands 170-243 raw every 9s
+  // against Korgath's Shuddering Stomp at 190-285 every 12s, and the
+  // beastmaster's Beast Pit Quake 88-130. Support scales on mechanicHealMult
+  // (= healthMultiplier), so the hexcaller's Ancestral Sap heals 72-100 and
+  // Thickhide Ward absorbs 140, both keeping pace with the doubled pools.
+  // Pinned by tests/wildheart_normal_tuning.test.ts.
+  wildheart_basin: {
+    id: 'wildheart_basin',
+    difficulty: 'normal',
+    healthMultiplier: 2.0,
+    damageMultiplierByMob: {
+      wildheart_stalker: 3.7,
+      wildheart_ravager: 3.15,
+      wildheart_hexcaller: 3.9,
+      wildheart_beastmaster: 4.2,
+      wildheart_high_priest: 5.65,
+    },
+    rangedDamageMultiplierByMob: {
+      wildheart_stalker: 2.7,
+      wildheart_hexcaller: 2.5,
     },
   },
 };

--- a/src/sim/content/wildheart.ts
+++ b/src/sim/content/wildheart.ts
@@ -273,6 +273,11 @@ export const WILDHEART_DUNGEON_DEFS: Record<string, DungeonDef> = {
     exitOffset: { x: 0, z: -10 },
     spawns: WILDHEART_SPAWN_LIST,
     interior: 'wildheart',
+    // The basin answers as one. Pulling Zulgar with any of the route still alive
+    // brings the whole cult down on you (instances/boss_chain_pull.ts): the two
+    // open routes make skipping trash to the shrine trivial otherwise, since
+    // nothing here is a corridor that has to be fought through.
+    bossChainPull: true,
     suggestedPlayers: 5,
     enterText: 'Warm rain hisses on old stone. The Wildheart Basin opens before you.',
     leaveText: 'You pass back beneath the stone fangs into the Palmreach sun.',

--- a/src/sim/instances/boss_chain_pull.ts
+++ b/src/sim/instances/boss_chain_pull.ts
@@ -1,0 +1,71 @@
+// The premature-boss-pull punish, for the dungeons that opt in via
+// DungeonDef.bossChainPull.
+//
+// Classic behavior is that a group can run past trash, pull the final boss, and
+// fight it alone. Where a dungeon marks bossChainPull, aggroing its boss instead
+// wakes EVERY mob still alive in that instance and sends all of them at the
+// puller at once. Skipping trash stops being a shortcut and becomes a wipe, so
+// the route has to be cleared on the way in.
+//
+// The mechanic is self-gating rather than carrying an explicit "is this
+// premature" test: it pulls whatever is still alive, so a group that cleared the
+// route finds nothing left to pull and the boss fight starts normally. One
+// skipped pack is still a skipped pack, and it answers the call.
+//
+// Pure entity-state mutation on the same fields aggroMob and rallyFleeingAllies
+// already set, and it draws NO rng, so the shared draw order (and the parity
+// goldens) are untouched. Runs once per boss pull: aggroMob early-returns for a
+// boss already in chase/attack, and re-arms if the boss evades and resets.
+import { DUNGEONS, MOBS } from '../data';
+import type { SimContext } from '../sim_context';
+import { addThreat } from '../threat';
+import type { Entity } from '../types';
+import { instanceAt } from './dungeons';
+
+/**
+ * Pull every living, idle mob of `boss`'s instance onto `target`.
+ *
+ * No-ops unless `boss` is a boss-flagged template standing in a claimed
+ * instance whose dungeon opted into bossChainPull. Returns the number of mobs
+ * newly pulled (0 when the route was already cleared).
+ */
+export function chainPullInstanceOnBossAggro(
+  ctx: SimContext,
+  boss: Entity,
+  target: Entity,
+): number {
+  if (!MOBS[boss.templateId]?.boss) return 0;
+  const inst = instanceAt(ctx, boss.pos);
+  if (!inst || !DUNGEONS[inst.dungeonId]?.bossChainPull) return 0;
+
+  let pulled = 0;
+  for (const id of inst.mobIds) {
+    const mob = ctx.entities.get(id);
+    if (
+      !mob ||
+      mob.id === boss.id ||
+      mob.kind !== 'mob' ||
+      mob.dead ||
+      !mob.hostile ||
+      mob.ownerId !== null ||
+      mob.aiState !== 'idle'
+    ) {
+      continue;
+    }
+    mob.aiState = 'chase';
+    mob.aggroTargetId = target.id;
+    mob.inCombat = true;
+    // Anchor the leash on the PULLER, not on the mob's own position as a social
+    // pull does. Wildheart's route is ~180 yards end to end and
+    // DUNGEON_LEASH_DISTANCE is 70, so a mob anchored where it stood would run
+    // 70 yards, hit its leash, and evade home without ever reaching the fight,
+    // which would quietly turn the whole mechanic into a no-op for the far half
+    // of the dungeon. Anchoring on the puller lets every pulled mob arrive while
+    // still keeping a real leash: it can be dragged 70 yards from the pull
+    // point, so the group cannot walk the dungeon out through the door.
+    mob.leashAnchor = { ...target.pos };
+    addThreat(mob, target.id, 1); // seed the hate table, as aggroMob does
+    pulled++;
+  }
+  return pulled;
+}

--- a/src/sim/instances/difficulty.ts
+++ b/src/sim/instances/difficulty.ts
@@ -106,6 +106,11 @@ export function applyDungeonMobTuning(
     if (normal && dmgMult !== undefined) {
       mob.mechanicDamageMult = normal.mechanicDamageMultiplierByMob?.[mob.templateId] ?? dmgMult;
       mob.mechanicHealMult = normal.healthMultiplier;
+      // A petSpell caster's nuke is rolled from the base table and cannot be
+      // reached by the template transform (melee only) or by
+      // mechanicDamageMult, so it takes its own factor or stays at 1.
+      const ranged = normal.rangedDamageMultiplierByMob?.[mob.templateId];
+      if (ranged !== undefined) mob.rangedDamageMult = ranged;
     }
     return;
   }

--- a/src/sim/instances/dungeons.ts
+++ b/src/sim/instances/dungeons.ts
@@ -858,16 +858,23 @@ export function instanceSlotAt(ctx: SimContext, pos: Vec3): number | null {
   return instanceInfoAt(ctx, pos)?.slot ?? null;
 }
 
+/** The live slot whose claim footprint contains `pos`, or null. Same envelope as
+ *  instanceInfoAt below, exposed for the callers that need the slot's own STATE
+ *  (its mobIds roster) and not just its identity: see
+ *  instances/boss_chain_pull.ts. */
+export function instanceAt(ctx: SimContext, pos: Vec3): InstanceSlot | null {
+  for (const inst of ctx.instances) {
+    if (instanceClaimContains(inst, pos)) return inst;
+  }
+  return null;
+}
+
 export function instanceInfoAt(
   ctx: SimContext,
   pos: Vec3,
 ): { slot: number; dungeonId: string } | null {
-  for (const inst of ctx.instances) {
-    if (instanceClaimContains(inst, pos)) {
-      return { slot: inst.slot, dungeonId: inst.dungeonId };
-    }
-  }
-  return null;
+  const inst = instanceAt(ctx, pos);
+  return inst ? { slot: inst.slot, dungeonId: inst.dungeonId } : null;
 }
 
 // Authoritative: is `pos` physically inside one of the two Nythraxis raid

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -436,6 +436,7 @@ export type { MailSave } from './mail/post_office';
 export type { MarketSave } from './market';
 
 import { updateSwimFatigue } from './fatigue';
+import { chainPullInstanceOnBossAggro } from './instances/boss_chain_pull';
 import {
   applyDungeonMobTuning,
   mobLevelForDungeonDifficulty,
@@ -6558,6 +6559,16 @@ export class Sim {
       mob.yelledEngage = true;
       emitMobYell(this.ctx, mob, engageYell, MOBS[mob.templateId]?.battleYells?.range);
     }
+    // Premature-boss-pull punish, for the dungeons that opt in: pulling the boss
+    // with trash still standing brings the whole instance. Gated on a
+    // player-driven pull, like the engage yell above.
+    //
+    // Deliberately BEFORE the social block: both skip a mob that is no longer
+    // idle, so whichever runs first owns the leash anchor, and only the chain
+    // pull's puller-anchored leash lets a mob from the far end of the field
+    // actually reach the fight. Reordering these two would quietly shorten the
+    // leash on every mob they both claim.
+    if (playerPull) chainPullInstanceOnBossAggro(this.ctx, mob, target);
     if (social) {
       const family = MOBS[mob.templateId]?.family;
       const pullRadius = (family && SOCIAL_PULL_RADIUS[family]) ?? DEFAULT_SOCIAL_PULL_RADIUS;
@@ -6770,9 +6781,14 @@ export class Sim {
         });
         this.enterCombat(pet, target);
       } else {
+        // rangedDamageMult is the instance-tuning factor for a HOSTILE petSpell
+        // caster (undefined, so 1, for every player pet and every untuned or
+        // heroic spawn). Applied after the rng draw like the mechanic
+        // multipliers, so the shared draw order is unchanged.
         const dmg = Math.round(
           this.rng.range(spell.min + pet.level * 0.8, spell.max + pet.level * 1.1) *
-            this.petDamageMult(pet),
+            this.petDamageMult(pet) *
+            (pet.rangedDamageMult ?? 1),
         );
         this.dealDamage(pet, target, Math.max(1, dmg), false, spell.school, spell.name, 'hit');
       }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -2546,6 +2546,15 @@ export interface DungeonDef {
    * `dungeon_layout.ts` layoutColliders.
    */
   tombDressing?: 'coffins' | 'cargo';
+  /**
+   * Opt in to the premature-boss-pull punish: aggroing this dungeon's final
+   * boss while ANY of the instance's other mobs is still alive and idle pulls
+   * every one of them onto the puller at once (instances/boss_chain_pull.ts).
+   * Absent, a boss pull behaves classically (only the boss and its own social
+   * radius). Deliberately per dungeon rather than global: it turns skipping
+   * trash from a shortcut into a wipe, which is a per-dungeon design choice.
+   */
+  bossChainPull?: boolean;
   suggestedPlayers: number;
   enterText: string;
   leaveText: string;
@@ -3342,6 +3351,18 @@ export interface Entity extends ClientMirroredEntityFields {
   // multiply by these AFTER the rng draw. undefined = 1 (normal difficulty).
   mechanicDamageMult?: number;
   mechanicHealMult?: number;
+  // Ranged petSpell scaling for a TUNED instance spawn, the third fire-time
+  // multiplier beside the two above. A hostile mob's petSpell damage is rolled
+  // from the base MOBS table and multiplied by petDamageMult, which returns a
+  // flat 1 for any mob with no owner, so NEITHER the spawn-time template
+  // transform (which only moves dmgBase/dmgPerLevel, i.e. melee) nor
+  // mechanicDamageMult can reach it. Without this a petSpell caster is immune
+  // to dungeon tuning, and since a caster stands and casts instead of meleeing
+  // (mob/combat_profile.ts updateCasterCombat) that is its ENTIRE damage
+  // output. Set from NormalDungeonTuning.rangedDamageMultiplierByMob;
+  // undefined = 1 (untuned, and every heroic spawn, which keeps its shipped
+  // calibration).
+  rangedDamageMult?: number;
   // Entity-level CC/snare immunity, the per-spawn twin of the MobTemplate
   // ccImmune/slowImmune flags (which are read from the base MOBS table, so a
   // spawn-time template transform cannot grant them). Heroic instances set

--- a/tests/wildheart_boss_chain_pull.test.ts
+++ b/tests/wildheart_boss_chain_pull.test.ts
@@ -1,0 +1,130 @@
+// The premature-boss-pull punish (src/sim/instances/boss_chain_pull.ts), opted
+// into by DungeonDef.bossChainPull and live only in the Wildheart Basin.
+//
+// The basin is an open field with two routes to the shrine, so running past
+// every pack to pull Zulgar alone is trivial there in a way it is not in a
+// corridor dungeon. With the flag on, pulling him while ANY of the route is
+// still alive sends the whole instance at the puller at once.
+
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_WORLD, DUNGEONS } from '../src/sim/data';
+import { enterDungeon } from '../src/sim/instances/dungeons';
+import { type InstanceSlot, Sim } from '../src/sim/sim';
+import type { Entity, WorldContent } from '../src/sim/types';
+
+const WILDHEART_TEST_WORLD: WorldContent = {
+  ...BUILTIN_WORLD,
+  camps: [],
+  npcs: {},
+  groundObjects: [],
+};
+
+function makeSim(seed = 91): Sim {
+  return new Sim({ seed, playerClass: 'warrior', noPlayer: true, world: WILDHEART_TEST_WORLD });
+}
+
+interface Claimed {
+  sim: Sim;
+  instance: InstanceSlot;
+  player: Entity;
+  boss: Entity;
+  others: Entity[];
+}
+
+function claim(dungeonId: string, finalBossId: string): Claimed {
+  const sim = makeSim();
+  const pid = sim.addPlayer('warrior', 'Alpha');
+  expect(enterDungeon(sim.ctx, dungeonId, pid)).toBe(true);
+  const instance = sim.instances.find((c) => c.dungeonId === dungeonId && c.partyKey !== null);
+  if (!instance) throw new Error(`${dungeonId} instance was not claimed`);
+  const player = sim.entities.get(sim.players.get(pid)!.entityId);
+  if (!player) throw new Error('player entity missing');
+  const mobs = instance.mobIds
+    .map((id) => sim.entities.get(id))
+    .filter((e): e is Entity => !!e && e.kind === 'mob');
+  const boss = mobs.find((m) => m.templateId === finalBossId);
+  if (!boss) throw new Error(`${finalBossId} did not spawn`);
+  return { sim, instance, player, boss, others: mobs.filter((m) => m.id !== boss.id) };
+}
+
+describe('Wildheart Basin premature boss pull', () => {
+  it('opts in through content, not through a hardcoded dungeon id in sim logic', () => {
+    expect(DUNGEONS.wildheart_basin.bossChainPull).toBe(true);
+    // Every other dungeon keeps classic pull behavior.
+    for (const dungeon of Object.values(DUNGEONS)) {
+      if (dungeon.id === 'wildheart_basin') continue;
+      expect(dungeon.bossChainPull, dungeon.id).toBeUndefined();
+    }
+  });
+
+  it('sends every living mob in the instance at the puller when Zulgar is pulled early', () => {
+    const { sim, player, boss, others } = claim('wildheart_basin', 'wildheart_high_priest');
+    // The whole authored route is standing: 20 spawns, so 19 besides Zulgar.
+    expect(others.length).toBe(19);
+    for (const mob of others) expect(mob.aiState).toBe('idle');
+
+    sim.aggroMob(boss, player, false);
+
+    expect(boss.aiState).toBe('chase');
+    for (const mob of others) {
+      expect(mob.aiState, mob.templateId).toBe('chase');
+      expect(mob.aggroTargetId, mob.templateId).toBe(player.id);
+      expect(mob.inCombat, mob.templateId).toBe(true);
+      // Hate table seeded, so a taunt or a heal has a baseline to work against.
+      expect(mob.threat.get(player.id), mob.templateId).toBeGreaterThan(0);
+      // Leash anchored on the PULLER, not where the mob stood: the route is
+      // ~180 yards end to end against a 70-yard dungeon leash, so a
+      // self-anchored mob would evade home before reaching the shrine and the
+      // mechanic would silently do nothing for the far half of the dungeon.
+      expect(mob.leashAnchor, mob.templateId).toEqual({ ...player.pos });
+    }
+  });
+
+  it('is a no-op once the route is cleared, so a clean clear fights the boss alone', () => {
+    const { sim, player, boss, others } = claim('wildheart_basin', 'wildheart_high_priest');
+    for (const mob of others) mob.dead = true;
+
+    sim.aggroMob(boss, player, false);
+
+    expect(boss.aiState).toBe('chase');
+    expect(boss.aggroTargetId).toBe(player.id);
+    for (const mob of others) {
+      expect(mob.aiState, mob.templateId).toBe('idle');
+      expect(mob.aggroTargetId, mob.templateId).toBeNull();
+    }
+  });
+
+  it('never fires for a mob that is not the boss', () => {
+    const { sim, player, boss, others } = claim('wildheart_basin', 'wildheart_high_priest');
+    const trash = others.find((m) => m.templateId === 'wildheart_ravager');
+    if (!trash) throw new Error('no ravager spawned');
+
+    sim.aggroMob(trash, player, false);
+
+    expect(trash.aiState).toBe('chase');
+    expect(boss.aiState).toBe('idle');
+    // Everything else stays asleep: a trash pull is still a local pull.
+    const stillIdle = others.filter((m) => m.id !== trash.id && m.aiState === 'idle');
+    expect(stillIdle.length).toBe(others.length - 1);
+  });
+
+  it('leaves a dungeon that did not opt in on classic boss-pull behavior', () => {
+    const { sim, player, boss, others } = claim('gravewyrm_sanctum', 'korzul_the_gravewyrm');
+
+    sim.aggroMob(boss, player, false);
+
+    expect(boss.aiState).toBe('chase');
+    for (const mob of others) expect(mob.aiState, mob.templateId).toBe('idle');
+  });
+
+  it('draws no rng, so the shared draw order and the parity goldens are unaffected', () => {
+    const { sim, player, boss } = claim('wildheart_basin', 'wildheart_high_priest');
+    let draws = 0;
+    sim.rng.setObserver(() => {
+      draws++;
+    });
+    sim.aggroMob(boss, player, false);
+    sim.rng.setObserver(null);
+    expect(draws).toBe(0);
+  });
+});

--- a/tests/wildheart_normal_tuning.test.ts
+++ b/tests/wildheart_normal_tuning.test.ts
@@ -1,0 +1,441 @@
+// Wildheart Basin NORMAL retune: the dungeon shipped with a heroic tuning
+// record but NO normal one, so normal mode ran the raw base templates. Against
+// the reference warrior its trash swung 26-32 and Zulgar 35, where normal
+// Gravewyrm Sanctum (the calibration this suite ports) lands 103-112 and
+// 200-301: about 3.5x under on trash and 6-8x under on the boss, in the same
+// endgame loot band. This suite pins the ported calibration.
+//
+// Reference warrior (identical to tests/gravewyrm_normal_tuning.test.ts, so the
+// two dungeons are measured on one ruler): level-20 prot warrior in the
+// max-armor kit (full heroic plate + shield, prot mastery), 2861 armor / 2762
+// hp, in Defensive Stance (takes 10% less).
+//
+// Two departures from the Sanctum table, both forced by this roster:
+//  - a third band at 150 for the rare ccImmune beastmaster, which spawns twice
+//    and out-presses trash without being the final boss;
+//  - rangedDamageMultiplierByMob, because HALF this roster is a petSpell caster
+//    that stands at spell range and never melees (mob/combat_profile.ts), so its
+//    melee factor is inert and its nuke is otherwise immune to every tuning
+//    knob. See src/sim/content/dungeon_difficulty.ts for the full rationale.
+
+import { describe, expect, it } from 'vitest';
+import {
+  NORMAL_DUNGEON_TUNING,
+  type NormalDungeonTuning,
+} from '../src/sim/content/dungeon_difficulty';
+import { BUILTIN_WORLD, DUNGEONS, MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import {
+  applyDungeonMobTuning,
+  mobTemplateForDungeonDifficulty,
+} from '../src/sim/instances/difficulty';
+import { enterDungeon } from '../src/sim/instances/dungeons';
+import { Sim } from '../src/sim/sim';
+import type { Entity } from '../src/sim/types';
+import { armorReduction } from '../src/sim/types';
+
+const BASIN = 'wildheart_basin';
+const REF_ARMOR = 2861; // max-armor BiS prot warrior, level 20 (see header)
+const DEFENSIVE_STANCE_TAKEN = 0.9; // dealDamage: Defensive Stance takes 10% less
+
+// The Sanctum floors this dungeon is being brought onto, plus the one new band.
+const TRASH_FLOOR = 100;
+const MINIBOSS_FLOOR = 150;
+const BOSS_FLOOR = 200;
+// A caster's nuke is spell damage: no armor step, and it can land on any group
+// member rather than only the tank. Floored on the same 100 line as trash melee.
+const RANGED_FLOOR = 100;
+
+const TRASH_IDS = ['wildheart_stalker', 'wildheart_ravager', 'wildheart_hexcaller'] as const;
+const MINIBOSS_IDS = ['wildheart_beastmaster'] as const;
+const BOSS_IDS = ['wildheart_high_priest'] as const;
+const CASTER_IDS = ['wildheart_stalker', 'wildheart_hexcaller'] as const;
+
+function basinTuning(): NormalDungeonTuning {
+  const tuning = NORMAL_DUNGEON_TUNING[BASIN];
+  expect(tuning).toBeTruthy();
+  return tuning;
+}
+
+// The minimum non-avoided, non-crit MELEE hit the reference warrior takes,
+// replicating the sim's rounding chain: mobSwing rounds after the armor step,
+// dealDamage rounds after the stance cut.
+function minSwingOnReferenceWarrior(mobId: string, level: number): number {
+  const template = mobTemplateForDungeonDifficulty(MOBS[mobId], BASIN, 'normal');
+  const mob = createMob(1, template, level, { x: 0, y: 0, z: 0 });
+  const afterArmor = Math.round(mob.weapon.min * (1 - armorReduction(REF_ARMOR, level)));
+  return Math.round(afterArmor * DEFENSIVE_STANCE_TAKEN);
+}
+
+// The minimum non-resisted petSpell hit on the reference warrior, replicating
+// the sim's chain (sim.ts updateRangedPetAttack): the floor of the damage band
+// scaled by rangedDamageMult and rounded, then the stance cut. NO armor step:
+// petSpell damage goes through dealDamage as spell damage.
+function minRangedHitOnReferenceWarrior(mobId: string, level: number): number {
+  const spell = MOBS[mobId].petSpell;
+  if (!spell) throw new Error(`${mobId} has no petSpell`);
+  const mult = basinTuning().rangedDamageMultiplierByMob?.[mobId] ?? 1;
+  return Math.round(Math.round((spell.min + level * 0.8) * mult) * DEFENSIVE_STANCE_TAKEN);
+}
+
+function normalMaxHp(mobId: string, level: number): number {
+  const template = mobTemplateForDungeonDifficulty(MOBS[mobId], BASIN, 'normal');
+  return createMob(1, template, level, { x: 0, y: 0, z: 0 }).maxHp;
+}
+
+describe('normal Wildheart Basin tuning data', () => {
+  it('covers every mob the basin spawns, including any boss-summoned add', () => {
+    const tuning = basinTuning();
+    const spawnIds = new Set<string>();
+    for (const spawn of DUNGEONS[BASIN].spawns) {
+      spawnIds.add(spawn.mobId);
+      const summoned = MOBS[spawn.mobId]?.summonAdds?.mobId;
+      if (summoned) spawnIds.add(summoned);
+    }
+    expect([...spawnIds].sort()).toEqual(Object.keys(tuning.damageMultiplierByMob).sort());
+  });
+
+  it('only re-prices ranged damage for mobs that have a melee factor AND a petSpell', () => {
+    const tuning = basinTuning();
+    const rangedKeys = Object.keys(tuning.rangedDamageMultiplierByMob ?? {});
+    expect(rangedKeys.sort()).toEqual([...CASTER_IDS].sort());
+    for (const id of rangedKeys) {
+      expect(tuning.damageMultiplierByMob, `${id} missing a melee factor`).toHaveProperty(id);
+      expect(MOBS[id].petSpell, `${id} has no petSpell to re-price`).toBeTruthy();
+    }
+    // The converse, so a future roster edit cannot silently leave a caster
+    // unpriced: every spawnable mob WITH a petSpell must carry a ranged factor.
+    for (const id of Object.keys(tuning.damageMultiplierByMob)) {
+      if (MOBS[id].petSpell) {
+        expect(
+          tuning.rangedDamageMultiplierByMob,
+          `${id} is a caster with no ranged factor`,
+        ).toHaveProperty(id);
+      }
+    }
+  });
+
+  it('pins the retune multipliers to exact literals', () => {
+    const tuning = basinTuning();
+    expect(tuning.healthMultiplier).toBe(2.0);
+    expect(tuning.damageMultiplierByMob).toEqual({
+      wildheart_stalker: 3.7,
+      wildheart_ravager: 3.15,
+      wildheart_hexcaller: 3.9,
+      wildheart_beastmaster: 4.2,
+      wildheart_high_priest: 5.65,
+    });
+    expect(tuning.rangedDamageMultiplierByMob).toEqual({
+      wildheart_stalker: 2.7,
+      wildheart_hexcaller: 2.5,
+    });
+    // Mechanics ride each mob's own melee factor: no avoidable-mechanic
+    // override here, unlike Korzul's Grave Inferno in the Sanctum.
+    expect(tuning.mechanicDamageMultiplierByMob).toBeUndefined();
+  });
+});
+
+describe('normal Wildheart Basin health', () => {
+  it('doubles every mob health at its level-20 spawn (pre-retune values in comments)', () => {
+    expect(normalMaxHp('wildheart_stalker', 20)).toBe(2208); // was 1104
+    expect(normalMaxHp('wildheart_ravager', 20)).toBe(2765); // was 1382
+    expect(normalMaxHp('wildheart_hexcaller', 20)).toBe(2111); // was 1056
+    expect(normalMaxHp('wildheart_beastmaster', 20)).toBe(3836); // was 1918
+    expect(normalMaxHp('wildheart_high_priest', 20)).toBe(6882); // was 3441
+  });
+
+  it('leaves Zulgar in the same pool band as Korzul, the Sanctum final boss', () => {
+    const korzul = createMob(
+      1,
+      mobTemplateForDungeonDifficulty(MOBS.korzul_the_gravewyrm, 'gravewyrm_sanctum', 'normal'),
+      20,
+      { x: 0, y: 0, z: 0 },
+    ).maxHp;
+    const zulgar = normalMaxHp('wildheart_high_priest', 20);
+    expect(zulgar).toBeGreaterThan(korzul * 0.9);
+    expect(zulgar).toBeLessThan(korzul * 1.25);
+  });
+});
+
+describe('normal Wildheart Basin melee floors vs the reference warrior', () => {
+  it('every trash swing lands for at least 100 at every spawnable level', () => {
+    for (const id of TRASH_IDS) {
+      const { minLevel, maxLevel } = MOBS[id];
+      for (let level = minLevel; level <= maxLevel; level++) {
+        expect(
+          minSwingOnReferenceWarrior(id, level),
+          `${id} at level ${level}`,
+        ).toBeGreaterThanOrEqual(TRASH_FLOOR);
+      }
+    }
+  });
+
+  it('the rare beastmaster lands above trash but below the boss line', () => {
+    for (const id of MINIBOSS_IDS) {
+      const { minLevel, maxLevel } = MOBS[id];
+      for (let level = minLevel; level <= maxLevel; level++) {
+        const swing = minSwingOnReferenceWarrior(id, level);
+        expect(swing, `${id} at level ${level}`).toBeGreaterThanOrEqual(MINIBOSS_FLOOR);
+        expect(swing, `${id} at level ${level} is not a third boss`).toBeLessThan(BOSS_FLOOR);
+      }
+    }
+  });
+
+  it('every boss swing lands for at least 200 at every spawnable level', () => {
+    for (const id of BOSS_IDS) {
+      const { minLevel, maxLevel } = MOBS[id];
+      for (let level = minLevel; level <= maxLevel; level++) {
+        expect(
+          minSwingOnReferenceWarrior(id, level),
+          `${id} at level ${level}`,
+        ).toBeGreaterThanOrEqual(BOSS_FLOOR);
+      }
+    }
+  });
+
+  it('lands the whole roster inside the Sanctum normal swing band', () => {
+    // The point of the retune: measured on one ruler, Wildheart's trash and boss
+    // now sit in the Sanctum's own post-mitigation window (103-301), where they
+    // previously sat at 26-35.
+    for (const id of [...TRASH_IDS, ...MINIBOSS_IDS, ...BOSS_IDS]) {
+      const swing = minSwingOnReferenceWarrior(id, 20);
+      expect(swing, `${id} below the Sanctum trash floor`).toBeGreaterThanOrEqual(TRASH_FLOOR);
+      expect(swing, `${id} above the Sanctum boss ceiling`).toBeLessThanOrEqual(301);
+    }
+  });
+});
+
+describe('normal Wildheart Basin ranged floors', () => {
+  it('every caster nuke lands for at least 100 at every spawnable level', () => {
+    for (const id of CASTER_IDS) {
+      const { minLevel, maxLevel } = MOBS[id];
+      for (let level = minLevel; level <= maxLevel; level++) {
+        expect(
+          minRangedHitOnReferenceWarrior(id, level),
+          `${id} at level ${level}`,
+        ).toBeGreaterThanOrEqual(RANGED_FLOOR);
+      }
+    }
+  });
+
+  it('actually reaches the live petSpell fire site, not just the tuning table', () => {
+    // The floor assertions above replicate the damage chain arithmetically, so
+    // they would still pass if nothing in the sim ever READ rangedDamageMult.
+    // This one drives the real fire path (sim.ts updateRangedPetAttack) on a mob
+    // spawned by a real normal claim and reads the damage events it emits, which
+    // is the only assertion here that fails if the fire-site wiring is removed.
+    const sim = new Sim({
+      seed: 91,
+      playerClass: 'warrior',
+      noPlayer: true,
+      world: { ...BUILTIN_WORLD, camps: [], npcs: {}, groundObjects: [] },
+    });
+    const pid = sim.addPlayer('warrior', 'Alpha');
+    expect(enterDungeon(sim.ctx, BASIN, pid)).toBe(true);
+    const instance = sim.instances.find((c) => c.dungeonId === BASIN && c.partyKey !== null);
+    if (!instance) throw new Error('basin instance was not claimed');
+    const player = sim.entities.get(sim.players.get(pid)!.entityId);
+    const hexcaller = instance.mobIds
+      .map((id) => sim.entities.get(id))
+      .find((e) => e?.templateId === 'wildheart_hexcaller');
+    if (!player || !hexcaller) throw new Error('hexcaller or player missing');
+    const spell = MOBS.wildheart_hexcaller.petSpell;
+    if (!spell) throw new Error('hexcaller lost its petSpell');
+
+    // Stand the caster next to the player so the cast is always in range, then
+    // drive the RELEASE path directly: Sunvenom Hex has a 0.7s windup, which
+    // normally releases on a later tick, and this test does not advance the sim
+    // clock. Pinning rangedWindupReleaseTick at 0 makes each call take the
+    // committed-release branch, which is the branch that rolls the damage.
+    hexcaller.pos = { ...player.pos };
+    const hits: number[] = [];
+    for (let i = 0; i < 400; i++) {
+      hexcaller.swingTimer = 0;
+      hexcaller.rangedWindupReleaseTick = 0;
+      sim.ctx.updateRangedPetAttack(hexcaller, player, spell);
+      for (const event of sim.drainEvents() as {
+        type: string;
+        ability?: string;
+        amount?: number;
+      }[]) {
+        if (event.type === 'damage' && event.ability === spell.name && (event.amount ?? 0) > 0) {
+          hits.push(event.amount as number);
+        }
+      }
+      if (hits.length >= 20) break;
+    }
+    expect(hits.length, 'the caster never landed a hex').toBeGreaterThan(0);
+    // Every landed hex clears the ranged floor, and the whole observed band sits
+    // far above the unscaled 45-63 the same spell rolls at 1x.
+    const mult = basinTuning().rangedDamageMultiplierByMob!.wildheart_hexcaller;
+    expect(Math.min(...hits)).toBeGreaterThanOrEqual(RANGED_FLOOR);
+    expect(Math.min(...hits)).toBeGreaterThan(spell.max + 20 * 1.1); // above the 1x CEILING
+    expect(Math.max(...hits)).toBeLessThanOrEqual(
+      Math.round((spell.max + 20 * 1.1) * mult), // and never above the scaled ceiling
+    );
+  });
+
+  it('was NOT reachable before this retune (the gap the ranged knob closes)', () => {
+    // With no ranged factor the identical chain lands 38-41: the casters were
+    // immune to dungeon tuning, and a caster never melees, so that WAS their
+    // whole output. This is the regression this table exists to prevent.
+    for (const id of CASTER_IDS) {
+      const spell = MOBS[id].petSpell;
+      expect(spell).toBeTruthy();
+      if (!spell) continue;
+      const untuned = Math.round(Math.round(spell.min + 20 * 0.8) * DEFENSIVE_STANCE_TAKEN);
+      expect(untuned, `${id} untuned`).toBeLessThan(RANGED_FLOOR / 2);
+    }
+  });
+});
+
+describe('normal Wildheart Basin fire-time stamping', () => {
+  it('stamps the melee factor on mechanics and the doubled pool on support heals', () => {
+    const tuning = basinTuning();
+    for (const id of Object.keys(tuning.damageMultiplierByMob)) {
+      const mob = createMob(1, MOBS[id], 20, { x: 0, y: 0, z: 0 });
+      applyDungeonMobTuning(mob, BASIN, 'normal');
+      expect(mob.mechanicDamageMult, id).toBe(tuning.damageMultiplierByMob[id]);
+      expect(mob.mechanicHealMult, id).toBe(2.0);
+    }
+  });
+
+  it('stamps rangedDamageMult on the two casters and on nobody else', () => {
+    const tuning = basinTuning();
+    for (const id of Object.keys(tuning.damageMultiplierByMob)) {
+      const mob = createMob(1, MOBS[id], 20, { x: 0, y: 0, z: 0 });
+      applyDungeonMobTuning(mob, BASIN, 'normal');
+      expect(mob.rangedDamageMult, id).toBe(tuning.rangedDamageMultiplierByMob?.[id]);
+    }
+    const ravager = createMob(1, MOBS.wildheart_ravager, 20, { x: 0, y: 0, z: 0 });
+    applyDungeonMobTuning(ravager, BASIN, 'normal');
+    expect(ravager.rangedDamageMult).toBeUndefined();
+  });
+
+  it('scales Zulgar Wildheart Pulse and the Beast Pit Quake by their melee factors', () => {
+    const tuning = basinTuning();
+    const pulse = MOBS.wildheart_high_priest.aoePulse;
+    const quake = MOBS.wildheart_beastmaster.stomp;
+    expect(pulse).toBeTruthy();
+    expect(quake?.min).toBeTruthy();
+    if (!pulse || quake?.min === undefined || quake.max === undefined) return;
+    const bossMult = tuning.damageMultiplierByMob.wildheart_high_priest;
+    const rareMult = tuning.damageMultiplierByMob.wildheart_beastmaster;
+    // Raw (unmitigated) mechanic damage after the per-mob multiplier. The boss
+    // pulse sits in the same band as Korgath's Shuddering Stomp (190-285).
+    expect(Math.round(pulse.min * bossMult)).toBe(170);
+    expect(Math.round(pulse.max * bossMult)).toBe(243);
+    expect(Math.round(quake.min * rareMult)).toBe(88);
+    expect(Math.round(quake.max * rareMult)).toBe(130);
+  });
+
+  it('scales the hexcaller heal and the beastmaster ward with the doubled pools', () => {
+    const mend = MOBS.wildheart_hexcaller.mendAlly;
+    const ward = MOBS.wildheart_beastmaster.wardAllies;
+    expect(mend).toBeTruthy();
+    expect(ward).toBeTruthy();
+    if (!mend || !ward) return;
+    const healMult = basinTuning().healthMultiplier;
+    expect(Math.round(mend.healMin * healMult)).toBe(72);
+    expect(Math.round(mend.healMax * healMult)).toBe(100);
+    expect(Math.round(ward.amount * healMult)).toBe(140);
+  });
+});
+
+describe('a really claimed normal instance spawns the retuned roster', () => {
+  // The assertions above exercise the transform and stamping functions. This one
+  // walks the live spawn path end to end, so a tuning record that is never
+  // actually reached (the failure mode that let the basin ship untuned) fails
+  // here rather than passing on the unit level.
+  it('applies the retune to every mob a normal claim spawns', () => {
+    const sim = new Sim({
+      seed: 91,
+      playerClass: 'warrior',
+      noPlayer: true,
+      world: { ...BUILTIN_WORLD, camps: [], npcs: {}, groundObjects: [] },
+    });
+    const pid = sim.addPlayer('warrior', 'Alpha');
+    expect(enterDungeon(sim.ctx, BASIN, pid)).toBe(true);
+    const instance = sim.instances.find((c) => c.dungeonId === BASIN && c.partyKey !== null);
+    if (!instance) throw new Error('basin instance was not claimed');
+    expect(instance.difficulty).toBe('normal');
+
+    const spawned = instance.mobIds
+      .map((id) => sim.entities.get(id))
+      .filter((e): e is Entity => !!e && e.kind === 'mob');
+    expect(spawned.length).toBe(20);
+
+    const tuning = basinTuning();
+    for (const mob of spawned) {
+      // Doubled pool, live.
+      expect(mob.maxHp, mob.templateId).toBe(normalMaxHp(mob.templateId, mob.level));
+      expect(mob.maxHp, mob.templateId).toBeGreaterThan(2000);
+      // Fire-time multipliers, live.
+      expect(mob.mechanicDamageMult, mob.templateId).toBe(
+        tuning.damageMultiplierByMob[mob.templateId],
+      );
+      expect(mob.mechanicHealMult, mob.templateId).toBe(2.0);
+      expect(mob.rangedDamageMult, mob.templateId).toBe(
+        tuning.rangedDamageMultiplierByMob?.[mob.templateId],
+      );
+      // Normal never re-levels: the level-22 pin is heroic-only.
+      expect(mob.level, mob.templateId).toBe(20);
+    }
+    // And the swing the tank actually feels clears the floor on a live spawn.
+    const zulgar = spawned.find((m) => m.templateId === 'wildheart_high_priest');
+    if (!zulgar) throw new Error('Zulgar did not spawn');
+    const afterArmor = Math.round(
+      zulgar.weapon.min * (1 - armorReduction(REF_ARMOR, zulgar.level)),
+    );
+    expect(Math.round(afterArmor * DEFENSIVE_STANCE_TAKEN)).toBeGreaterThanOrEqual(BOSS_FLOOR);
+  });
+});
+
+describe('heroic Wildheart Basin keeps its own shipped calibration', () => {
+  it('pins the heroic transform literals, untouched by the normal retune', () => {
+    // Base template x heroic tuning (health 4.0, damage 17.25, armor 1.2, level
+    // 22). If the normal retune had been implemented by editing base templates
+    // instead of adding a tuning record, these would redden.
+    const heroic = mobTemplateForDungeonDifficulty(MOBS.wildheart_high_priest, BASIN, 'heroic');
+    expect(heroic.minLevel).toBe(22);
+    expect(heroic.hpBase).toBeCloseTo(1880, 10);
+    expect(heroic.hpPerLevel).toBeCloseTo(216, 10);
+    expect(heroic.dmgBase).toBeCloseTo(293.25, 10);
+    expect(heroic.dmgPerLevel).toBeCloseTo(55.2, 10);
+    expect(heroic.armorPerLevel).toBeCloseTo(42, 10);
+    expect(heroic.moveSpeed).toBe(8);
+
+    const trash = mobTemplateForDungeonDifficulty(MOBS.wildheart_hexcaller, BASIN, 'heroic');
+    expect(trash.dmgBase).toBeCloseTo(189.75, 10);
+    expect(trash.hpBase).toBeCloseTo(240, 10);
+  });
+
+  it('never stamps rangedDamageMult on a heroic spawn', () => {
+    // The ranged knob is normal-only by construction (HeroicDungeonTuning has no
+    // such field), so heroic Wildheart cannot be silently re-priced by it.
+    for (const id of Object.keys(basinTuning().damageMultiplierByMob)) {
+      const mob = createMob(1, MOBS[id], 22, { x: 0, y: 0, z: 0 });
+      applyDungeonMobTuning(mob, BASIN, 'heroic');
+      expect(mob.rangedDamageMult, id).toBeUndefined();
+    }
+  });
+});
+
+describe('the ranged knob does not leak', () => {
+  it('leaves every other dungeon and a player pet unscaled', () => {
+    // A Sanctum spawn (a tuned normal dungeon with no ranged factors) and an
+    // untuned dungeon both keep rangedDamageMult undefined, so the petSpell fire
+    // site multiplies by 1 for everything except the two basin casters.
+    const boneguard = createMob(1, MOBS.sanctum_boneguard, 19, { x: 0, y: 0, z: 0 });
+    applyDungeonMobTuning(boneguard, 'gravewyrm_sanctum', 'normal');
+    expect(boneguard.rangedDamageMult).toBeUndefined();
+
+    const untuned = createMob(1, MOBS.wildheart_hexcaller, 20, { x: 0, y: 0, z: 0 });
+    applyDungeonMobTuning(untuned, 'hollow_crypt', 'normal');
+    expect(untuned.rangedDamageMult).toBeUndefined();
+
+    // A player-owned pet is never touched by instance tuning at all.
+    const pet = { ownerId: 7 } as Entity;
+    expect(pet.rangedDamageMult).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Two changes to The Wildheart Basin (`wildheart_basin`, Palmreach's open-field five-man; the repo has
no instance named "grove"):

1. **Normal mode is retuned onto the Gravewyrm Sanctum normal calibration.** It shipped with a
   Heroic tuning record but NO normal one, so normal mode ran the raw base templates.
2. **Pulling Zulgar early now brings the whole instance**, via a new opt-in `DungeonDef` flag.

## 1. Normal retune

Measured on the shared reference warrior that `tests/gravewyrm_normal_tuning.test.ts` already uses
(level-20 prot, max-armor kit, 2861 armor, Defensive Stance), normal Wildheart against normal
Sanctum:

| | Wildheart before | Sanctum normal | Wildheart after |
|---|---|---|---|
| trash min swing | 26 to 32 | 103 to 112 | 101 |
| caster min ranged hit | 38 to 41 | n/a (no casters) | 102 |
| rare miniboss | 36 | n/a | 151 |
| final boss min swing | 35 | 200 to 301 | 201 |
| final boss HP | 3,441 | 6,127 (Korzul) | 6,882 |
| trash HP | 1,056 to 1,382 | 2,199 to 2,410 | 2,111 to 2,765 |

So it was roughly 3.5x under on trash and 6 to 8x under on the boss, in the same endgame loot band.
`NORMAL_DUNGEON_TUNING.wildheart_basin` ports the Sanctum model: the same doubled health, trash
floored at 100 and the boss at 200. Two roster-forced departures:

**A third band at 150 for `wildheart_beastmaster`.** It is a rare, `ccImmune` pack leader that
spawns twice and carries warcry + wardAllies + stomp, so it out-presses trash, but it is not the
final boss and must not read as a second Zulgar. Nythraxis set the precedent for a dungeon defining
its own bands.

**A new `rangedDamageMultiplierByMob` knob.** This is the load-bearing part. Half the 20-spawn
roster (Stalker x6, Hexcaller x4) is a `petSpell` caster, and a caster stands at spell range and
casts instead of swinging (`mob/combat_profile.ts`: "the chase-arm melee probes are dead in
practice"). Its nuke is rolled from the base table and multiplied by `petDamageMult`, which returns
a flat `1` for any mob with no owner, so **neither** the template transform (which moves
`dmgBase`/`dmgPerLevel`, i.e. melee) **nor** `mechanicDamageMult` could reach it. Without this knob
half the dungeon would have stayed at ~16 dps no matter what the table said. The factor stamps a new
`Entity.rangedDamageMult`, applied at the fire site after the rng draw, and prices both casters to
the same 100 minimum hit as trash melee (unmitigated by armor and landable on any group member,
which is what makes them the priority kill the content brief asks for).

Mechanics ride each mob's own melee factor with no override, the Sanctum default: Zulgar's Wildheart
Pulse lands 170 to 243 raw every 9s against Korgath's Shuddering Stomp at 190 to 285 every 12s, and
Beast Pit Quake 88 to 130. Support scales on `mechanicHealMult`, so Ancestral Sap heals 72 to 100 and
Thickhide Ward absorbs 140.

**Heroic is deliberately untouched.** `HeroicDungeonTuning` has no ranged field, so heroic Wildheart
keeps its shipped, floor-tested calibration byte for byte. That does mean heroic still carries the
same inert-caster gap; fixing it means re-deriving the heroic floors, which belongs in its own change
rather than riding along here. Flagged, not done.

## 2. Premature boss pull

New `DungeonDef.bossChainPull`, opt-in and set only on `wildheart_basin`. Aggroing the final boss
while any of the route is still alive sends every living mob in the instance at the puller at once.
The basin's two open routes make running past every pack trivial in a way a corridor dungeon prevents
by geometry, so this restores the cost of skipping trash.

- **Self-gating**: it pulls whatever is still alive, so a group that cleared the route finds nothing
  to pull and fights the boss normally. No separate "is this premature" test to drift.
- **Leash anchored on the puller**, not on where each mob stood. The route is ~180 yards end to end
  against a 70-yard `DUNGEON_LEASH_DISTANCE`, so a self-anchored mob would run 70 yards, leash, and
  evade home without reaching the shrine, silently making the mechanic a no-op for the far half of
  the dungeon. Mobs can still only be dragged 70 yards from the pull point, so the dungeon cannot be
  walked out through the door.
- **Ordering is load-bearing** and commented as such: the chain pull runs before the existing social
  block, because both skip a non-idle mob and only the chain pull's anchor lets a distant mob arrive.
- **Draws no rng**, like `rallyFleeingAllies`, so the shared draw order and the parity goldens are
  untouched (asserted via the `Rng.setObserver` seam).
- Applies on both difficulties, which is intended: skipping trash is a wipe either way.
- Silent by design (no new player-facing string, so no i18n surface): the boss's existing engage yell
  plus 19 mobs converging is the feedback.

Behavior lives in its own module, `src/sim/instances/boss_chain_pull.ts`, behind the `SimContext`
seam, with `aggroMob` a one-line consumer. `instanceAt` was extracted in `instances/dungeons.ts` so
the module can read a slot's own `mobIds` roster instead of duplicating the claim-footprint math;
`instanceInfoAt` now delegates to it.

## Test plan

- [x] `tests/wildheart_normal_tuning.test.ts` (new, 19 tests): spawn coverage, pinned literals,
      doubled health, per-band melee floors, ranged floors, the fire-time stamping of all three
      multipliers, the heroic transform literals, and a proof the ranged floor was unreachable before
      this change. Includes an **end-to-end** case that claims a real normal instance and asserts all
      20 live spawns are retuned, so a tuning record that is never actually reached (the failure mode
      that let the basin ship untuned) cannot pass on the unit level alone.
- [x] `tests/wildheart_boss_chain_pull.test.ts` (new, 6 tests): all 19 non-boss mobs pulled with
      threat and puller-anchored leash, no-op on a cleared route, no fire for a non-boss pull, no fire
      for a dungeon that did not opt in, and zero rng draws.
- [x] Regression suites green: `dungeon_difficulty`, `gravewyrm_normal_tuning`,
      `heroic_difficulty_floors`, `wildheart`, `boss_add_leash`, `architecture`, `dungeons`,
      `nythraxis_raid`, `gravewyrm_farm_exploit`, the five `pet_*` suites (the petSpell fire site is
      shared with player pets), and the full `tests/parity` golden gate (185 passed).
- [x] `npm run gate` (PR tier): i18n gen + freshness, malware scan, changed-files biome, typecheck
      and all three builds green. The full vitest run was **22,814 passed / 1 failed**, the one
      failure being `tests/sfx_export_bundle.test.ts` timing out. That test builds the SFX bundle
      twice and takes ~88s against a 90s `testTimeout`, so it sits on the boundary and tips over
      under core contention (a second `npm run gate` was running in a sibling worktree). It passes in
      isolation, and an SFX bundle byte-determinism check has no path to sim tuning or mob aggro.
      Called out rather than papered over: if it recurs on CI it wants its own timeout bump, which is
      not this PR's business.
- [ ] Not play-tested in a live client; the numbers are derived and pinned rather than measured in a
      real group run. Worth a play-test before this ships, particularly the chain pull, which is
      intended to be a wipe and is deliberately unforgiving.
