### PR TITLE
feat(rift): one portal per zone hourly, instance binding, no race eject

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -248,12 +248,6 @@ WIKI_URL=http://localhost:8080/wiki/index.php/Main_Page
 # bots (scripts/crypt_raid.mjs etc). Never set this on a public server.
 #ALLOW_DEV_COMMANDS=1
 
-# Public test realm profile for natural Rifts. Off by default. When enabled, the
-# server restores persisted Rifts, fills eight distinct eligible regions at boot,
-# keeps one-minute replacements, uses six-hour portal lifetimes, and exposes 24
-# concurrent instance slots. This does not enable any dev command.
-#COMMUNITY_TEST_RIFTS=1
-
 # Steam account linking + achievement mirror (server/steam/). OFF by default:
 # with STEAM_ENABLED unset, every /api/steam route answers steam.disabled, the
 # mirror is inert, and no client renders link UI. When enabling, provide the

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -308,14 +308,14 @@ For off-box safety, sync the directory to S3 occasionally:
 - **Never** set `ALLOW_DEV_COMMANDS=1` in production: it enables the full
   `/dev` cheat set (the level/teleport cheats the test bots use, plus item
   grants, mob spawns, instance teleports, and the dev command GUI).
-- **Community test profile**: on a disposable public test realm, set both
-  `PROVISION_TEST_ACCOUNTS=1` and `COMMUNITY_TEST_RIFTS=1` in the host `.env`,
-  then restart the game container. The first flag gives newly created accounts
-  nine level-20 characters, one per class, with complete Warfare gear
-  and four maximum-size bags. It does not backfill existing accounts. The Rift
-  flag restores persisted events before filling eight distinct eligible regions,
-  uses six-hour portal lifetimes and one-minute replacements, and raises capacity
-  to 24 concurrent groups. Both flags are off by default and neither enables dev
+- **Community test profile**: on a disposable public test realm, set
+  `PROVISION_TEST_ACCOUNTS=1` in the host `.env`, then restart the game
+  container. The flag gives newly created accounts nine level-20 characters,
+  one per class, with complete Warfare gear and four maximum-size bags. It does
+  not backfill existing accounts. (Rift portal density no longer needs a flag:
+  every realm keeps one portal per eligible zone on an hourly rotation, so the
+  former `COMMUNITY_TEST_RIFTS` toggle is gone.) The flag is off by default and
+  does not enable dev
   commands, so keep `ALLOW_DEV_COMMANDS=0` on a public realm.
 
   For the initial community test, leave `RIFT_UPGRADER_URL` and

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,8 +87,6 @@ services:
       # heartbeat log line (tickHz, per-phase p95/max) plus over-budget stutter
       # traces. Off by default so production logs stay quiet.
       PERF_TICK_LOG: ${PERF_TICK_LOG:-}
-      # Runtime: opt-in public-test Rift population. Empty leaves normal policy on.
-      COMMUNITY_TEST_RIFTS: ${COMMUNITY_TEST_RIFTS:-}
       # Runtime: the published OTA bundle manifest POST /api/ota/updates reads
       # (server/ota_updates.ts). Empty (unset) keeps OTA dark: the endpoint
       # answers "no update" and the native apps keep their current bundle. Must

--- a/docs/design/rift-mode.md
+++ b/docs/design/rift-mode.md
@@ -7,8 +7,9 @@ content artifact and the event's atomic first-clear claim.
 
 ## Runtime flow
 
-1. `rift/portals.ts` selects an explicitly eligible new-world zone and opens a
-   deterministic C/B/A/S portal on a deterministic 2-4 hour schedule.
+1. `rift/portals.ts` keeps one deterministic C/B/A/S portal open in EVERY
+   eligible new-world zone, cycling hourly (a zone's next portal opens one
+   cycle after the previous one opened).
 2. The existing procedural generator creates the draft and remains authoritative
    for layouts, colliders, mechanics, and safe spawn points.
 3. `rift/upgrader_draft.ts` immediately builds a validated heuristic upgrade. The
@@ -16,8 +17,11 @@ content artifact and the event's atomic first-clear claim.
 4. Entry freezes the artifact (`contentLocked`) and allocates one independent
    instance per group. Every competing instance receives the same artifact hash.
 5. `rift/race.ts` performs the single-threaded check-and-write first-clear claim.
-   The winner receives race rewards; all other instances for that event are
-   notified, ejected to their saved overworld return positions, and torn down.
+   The winner receives the race rewards; every other instance keeps running and
+   completes as the race loser when its own boss falls (corpse gear ladder, no
+   first-clear extras). The first mob kill marks an instance PROGRESSED, which
+   binds its members to it WoW-raid style; unspoiled instances recycle when
+   their members regroup, so a freshly formed party shares one clean run.
 6. `rift/persistence.ts` saves portal deadlines, event history, winner metadata,
    scheduler state, and upgrade artifacts. Runtime party instances are never
    restored after a realm restart.

--- a/docs/design/rift-mode.md
+++ b/docs/design/rift-mode.md
@@ -18,10 +18,12 @@ content artifact and the event's atomic first-clear claim.
    instance per group. Every competing instance receives the same artifact hash.
 5. `rift/race.ts` performs the single-threaded check-and-write first-clear claim.
    The winner receives the race rewards; every other instance keeps running and
-   completes as the race loser when its own boss falls (corpse gear ladder, no
-   first-clear extras). The first mob kill marks an instance PROGRESSED, which
-   binds its members to it WoW-raid style; unspoiled instances recycle when
-   their members regroup, so a freshly formed party shares one clean run.
+   completes as the race loser when its own boss falls, with an egress but NO
+   completion loot (no gear ladder, no sealed cache, no first-clear extras): a
+   loser keeps only what dropped off the mobs. The first mob kill marks an
+   instance PROGRESSED, which binds its members to it WoW-raid style; unspoiled
+   instances recycle when their members regroup, so a freshly formed party
+   shares one clean run.
 6. `rift/persistence.ts` saves portal deadlines, event history, winner metadata,
    scheduler state, and upgrade artifacts. Runtime party instances are never
    restored after a realm restart.

--- a/docs/design/rift-portals.md
+++ b/docs/design/rift-portals.md
@@ -231,11 +231,13 @@ exempt from the procedural rank-mechanic budget so the citadel identity is never
 A scheduler opens ranked portals automatically. Tuning is `RIFT_TIER_INFO` plus the
 `RIFT_PORTAL_*` constants at the top of the module.
 
-- **Cadence.** First portal ~2 min after boot (so a fresh realm is not empty),
-  then one roughly every `RIFT_PORTAL_INTERVAL` (~3 hours of sim time, which is
-  real time on the 20 Hz live server); at most `RIFT_PORTAL_MAX_OPEN` (3) open
-  world-wide. Enabled by `SimConfig.riftPortals` (on for the live server and the
-  offline client; OFF by default so tests / parity / the RL env stay portal-free).
+- **Cadence.** Every eligible zone keeps one open portal: the first population
+  fills ~2 min after boot (`RIFT_PORTAL_FIRST_AT`), and each zone's next portal
+  opens `RIFT_PORTAL_ZONE_CYCLE` (1 h) after the previous one OPENED, so an
+  expired portal is replaced immediately while a first-cleared zone stays empty
+  until its boundary. Enabled by `SimConfig.riftPortals` (on for the live server
+  and the offline client; OFF by default so tests / parity / the RL env stay
+  portal-free).
 - **Determinism.** Each spawn rolls zone, rank, position and rift seed from a
   DEDICATED `Rng` derived from `(worldSeed, spawnOrdinal)`, never the shared
   stream, so adding the scheduler shifts no existing draw order.
@@ -254,15 +256,14 @@ A scheduler opens ranked portals automatically. Tuning is `RIFT_TIER_INFO` plus 
   ladder up to the S legendary), the natural-first-clear personal rings, essence
   and gems, the mount rolls, and the rank coin bonus. Dev-portal runs (tier
   null) still pay the gear ladder but no first-clear extras.
-- **Public test profile.** `COMMUNITY_TEST_RIFTS=1` is a validated, default-off
-  server flag. After persisted state loads, the server preserves open events, fills
-  to eight distinct active eligible regions, and saves the result before accepting
-  players. A transitional population can exceed eight portals when restored events
-  overlap in one region; those valid events drain normally.
-  A missing portal is replaced after 60 seconds, community portals last six hours,
-  and the instance pool grows from eight to 24 concurrent groups. Persistence load
-  or initial save failure aborts boot in this mode so an unknown saved state is
-  never overwritten. Normal scheduling and capacity remain unchanged when off.
+- **Population policy (all realms).** Every eligible zone keeps one open portal,
+  cycling hourly: a zone's next portal opens `RIFT_PORTAL_ZONE_CYCLE` (1 h) after
+  the previous one OPENED, so an uncleared portal is replaced the moment it
+  collapses while a first-cleared (sealed) zone stays empty until its boundary
+  and can never be immediately refarmed. The cadence derives from the persisted
+  event history (latest opening per zone), so restarts preserve it without extra
+  saved state. The former `COMMUNITY_TEST_RIFTS` public-test flag is gone: the
+  dense population is now the one policy on every host.
 
 ## Client sync + render
 

--- a/docs/design/rift-portals.md
+++ b/docs/design/rift-portals.md
@@ -255,7 +255,9 @@ A scheduler opens ranked portals automatically. Tuning is `RIFT_TIER_INFO` plus 
   ladder on the boss corpse (C a guaranteed themed rare + coin; B/A/S the epic
   ladder up to the S legendary), the natural-first-clear personal rings, essence
   and gems, the mount rolls, and the rank coin bonus. Dev-portal runs (tier
-  null) still pay the gear ladder but no first-clear extras.
+  null) still pay the gear ladder but no first-clear extras. A race LOSER pays
+  nothing at completion (egress only, no gear ladder, no sealed cache): losers
+  keep only what dropped off the mobs during the run.
 - **Population policy (all realms).** Every eligible zone keeps one open portal,
   cycling hourly: a zone's next portal opens `RIFT_PORTAL_ZONE_CYCLE` (1 h) after
   the previous one OPENED, so an uncleared portal is replaced the moment it

--- a/server/game.ts
+++ b/server/game.ts
@@ -51,7 +51,6 @@ import {
   partyFrameRole,
 } from '../src/sim/party_frame_info';
 import { loadRiftWorldState, serializeRiftWorldState } from '../src/sim/rift/persistence';
-import { populateCommunityRiftPortals } from '../src/sim/rift/portals';
 import type { PetState, PlayerMeta } from '../src/sim/sim';
 import { MAX_CHAT_MESSAGE_LEN, Sim } from '../src/sim/sim';
 import { RAID_MAX } from '../src/sim/social/party';
@@ -1336,10 +1335,6 @@ export interface PerfCaptureStatus {
   last: PerfCaptureResult | null;
 }
 
-export interface GameServerOptions {
-  readonly communityTestRifts?: boolean;
-}
-
 export class GameServer {
   sim: Sim;
   clients = new Map<number, ClientSession>(); // by pid
@@ -1513,10 +1508,8 @@ export class GameServer {
   private readonly ipSessionCounts = new Map<string, number>();
   private readonly riftUpgrader: RiftUpgradeCoordinator;
   private readonly riftAssets: RiftAssetCoordinator;
-  private readonly communityTestRifts: boolean;
 
-  constructor(options: GameServerOptions = {}) {
-    this.communityTestRifts = options.communityTestRifts ?? false;
+  constructor() {
     this.sim = new Sim({
       seed: WORLD_SEED,
       playerClass: 'warrior',
@@ -1527,7 +1520,6 @@ export class GameServer {
       worldBossAtBoot: true,
       // Ranked rift portals spawn on the live realm (dev/test worlds opt in).
       riftPortals: true,
-      communityRifts: this.communityTestRifts,
       lockoutNowMs: () => Date.now(),
       // Raid lockouts end at the next 3 AM (the classic daily reset) in this realm's civil
       // time zone, so the whole realm shares one predictable reset (via REALM_RESET_TZ).
@@ -3476,22 +3468,9 @@ export class GameServer {
 
   async loadRifts(): Promise<void> {
     try {
-      loadRiftWorldState(this.sim.ctx, await loadRiftState(), Date.now(), {
-        strict: this.communityTestRifts,
-      });
+      loadRiftWorldState(this.sim.ctx, await loadRiftState(), Date.now());
     } catch (err) {
       console.error('failed to load shared Rift state:', err);
-      if (this.communityTestRifts) throw err;
-      return;
-    }
-    if (!this.communityTestRifts) return;
-
-    populateCommunityRiftPortals(this.sim.ctx);
-    try {
-      await this.persistRifts();
-    } catch (err) {
-      console.error('failed to save shared Rift state:', err);
-      throw err;
     }
   }
 

--- a/server/http/config.ts
+++ b/server/http/config.ts
@@ -89,9 +89,6 @@ export interface Config {
   // Off-by-default community-realm account provisioning. When enabled, the
   // central account insert atomically creates the full level-20 test roster.
   readonly provisionTestAccounts: boolean;
-  // Public-test Rift profile. Strictly validated, read once at boot, and off by
-  // default so a typo cannot silently enable or disable the denser realm policy.
-  readonly communityTestRifts: boolean;
   readonly turnstileSecret: string;
   readonly maxWsPerIpHard: number;
   // The realm player admission cap: the WS handshake (server/ws_auth.ts) refuses a
@@ -193,7 +190,6 @@ const REQUIRE_WEB_LOGIN_ENV = 'REQUIRE_WEB_LOGIN';
 const CONTENT_TYPE_ENFORCE_ENV = 'API_CONTENT_TYPE_ENFORCE';
 const ORIGIN_CHECK_ENFORCE_ENV = 'API_ORIGIN_CHECK_ENFORCE';
 const PROVISION_TEST_ACCOUNTS_ENV = 'PROVISION_TEST_ACCOUNTS';
-const COMMUNITY_TEST_RIFTS_ENV = 'COMMUNITY_TEST_RIFTS';
 
 // The recognized boolean-flag vocabulary shared by REQUIRE_WEB_LOGIN and the two
 // API enforce flags (matches web_login_guard.ts / content_type.ts / origin_check.ts:
@@ -314,7 +310,6 @@ export function loadConfig(env: NodeJS.ProcessEnv): Config {
   validateBooleanFlag(env, CONTENT_TYPE_ENFORCE_ENV);
   validateBooleanFlag(env, ORIGIN_CHECK_ENFORCE_ENV);
   validateBooleanFlag(env, PROVISION_TEST_ACCOUNTS_ENV);
-  validateBooleanFlag(env, COMMUNITY_TEST_RIFTS_ENV);
   validatePublicOrigin(env);
   validateRealms(env);
 
@@ -331,7 +326,6 @@ export function loadConfig(env: NodeJS.ProcessEnv): Config {
     port: numberOr(env.PORT, DEFAULT_PORT),
     allowDevCommands: env.ALLOW_DEV_COMMANDS === ALLOW_DEV_COMMANDS_ON,
     provisionTestAccounts: resolveBooleanFlag(env, PROVISION_TEST_ACCOUNTS_ENV),
-    communityTestRifts: resolveBooleanFlag(env, COMMUNITY_TEST_RIFTS_ENV),
     turnstileSecret: env.TURNSTILE_SECRET ?? DEFAULT_TURNSTILE_SECRET,
     maxWsPerIpHard: numberOr(env.MAX_WS_PER_IP_HARD, DEFAULT_MAX_WS_PER_IP_HARD),
     // Trimmed so a whitespace-only value reads as unset -> the default, never as

--- a/server/main.ts
+++ b/server/main.ts
@@ -424,9 +424,7 @@ const DAILY_PRUNE_INTERVAL_MS = 24 * 3600 * 1000;
 // lazily instead of at module load.
 let gameInstance: GameServer | null = null;
 function liveGame(): GameServer {
-  gameInstance ??= new GameServer({
-    communityTestRifts: activeConfig().communityTestRifts,
-  });
+  gameInstance ??= new GameServer();
   return gameInstance;
 }
 

--- a/src/sim/data.ts
+++ b/src/sim/data.ts
@@ -1043,9 +1043,12 @@ export const RIFT_BAND_X_MIN = RIFT_X_MIN - 40;
 // only RIFT_REGION_HALF_X wide either side; 1000u of headroom keeps it clear of the
 // relocated Protect Yumi maze band (YUMI_BAND_X_MIN) that now sits past it.
 export const RIFT_BAND_X_MAX = RIFT_X_MIN + 1000;
-export const RIFT_SLOT_COUNT = 8; // normal concurrent-rift capacity
-export const COMMUNITY_RIFT_SLOT_COUNT = 24; // opt-in public-test capacity
-const RIFT_LAYOUT_SLOT_COUNT = COMMUNITY_RIFT_SLOT_COUNT;
+// Concurrent-rift capacity for every host. With one portal per eligible zone
+// and per-event instance caps enforced at entry, the bound is population, not
+// events; slots are only backing records until a group enters, so a large pool
+// costs nothing at rest.
+export const RIFT_SLOT_COUNT = 64;
+const RIFT_LAYOUT_SLOT_COUNT = RIFT_SLOT_COUNT;
 export const RIFT_MAX_FLOORS = 6; // matches rift_gen MAX_FLOORS
 const RIFT_Z0 = -1250;
 // Each FLOOR gets its own z-stacked origin within a slot, so descending builds a

--- a/src/sim/rift/persistence.ts
+++ b/src/sim/rift/persistence.ts
@@ -5,7 +5,7 @@
 import { ZONES, zoneAt } from '../data';
 import type { SimContext } from '../sim_context';
 import type { RiftTier } from '../types';
-import { RIFT_TIER_INFO, restoreNaturalRiftPortal } from './portals';
+import { RIFT_PORTAL_RETRY_DELAY, RIFT_TIER_INFO, restoreNaturalRiftPortal } from './portals';
 import { generateRiftPlan } from './rift_gen';
 import type {
   RiftAssetPipelineState,
@@ -50,11 +50,6 @@ export interface RiftWorldSavedEvent {
     duration: number;
     clearedAtMs: number;
   };
-}
-
-export interface LoadRiftWorldStateOptions {
-  /** Reject malformed state instead of tolerating it as an empty/partial save. */
-  strict?: boolean;
 }
 
 function finite(value: unknown, fallback = 0): number {
@@ -129,63 +124,13 @@ function validSavedEvent(input: unknown): input is RiftWorldSavedEvent {
   return Number.isFinite(event.seed) && Number.isFinite(event.baseLevel);
 }
 
-function validStrictSavedState(save: Partial<RiftWorldStateV1>): save is RiftWorldStateV1 {
-  if (
-    save.version !== 1 ||
-    !Number.isFinite(save.savedAtMs) ||
-    !Number.isInteger(save.spawnCount) ||
-    finite(save.spawnCount, -1) < 0 ||
-    !Number.isFinite(save.nextPortalAtMs) ||
-    !Array.isArray(save.events) ||
-    save.events.length > MAX_SAVED_EVENTS
-  ) {
-    return false;
-  }
-
-  const seen = new Set<string>();
-  for (const event of save.events) {
-    if (
-      !validSavedEvent(event) ||
-      seen.has(event.eventId) ||
-      !Number.isFinite(event.openedAtMs) ||
-      !Number.isFinite(event.expiresAtMs) ||
-      typeof event.contentId !== 'string' ||
-      typeof event.contentHash !== 'string'
-    ) {
-      return false;
-    }
-    seen.add(event.eventId);
-  }
-  return true;
-}
-
-/** Load defensively from JSONB. Returns the number of reconstructed open portals. */
-export function loadRiftWorldState(
-  ctx: SimContext,
-  input: unknown,
-  nowMs: number,
-  options: LoadRiftWorldStateOptions = {},
-): number {
-  if (input === null) return 0;
-  if (!input || typeof input !== 'object' || Array.isArray(input)) {
-    if (options.strict) throw new Error('unsupported or malformed shared Rift state');
-    return 0;
-  }
+/** Load defensively from JSONB. Returns the number of reconstructed open portals.
+ * Always tolerant: malformed or unsupported input reads as an empty save (the
+ * strict mode existed only for the retired COMMUNITY_TEST_RIFTS boot path). */
+export function loadRiftWorldState(ctx: SimContext, input: unknown, nowMs: number): number {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return 0;
   const save = input as Partial<RiftWorldStateV1>;
-  if (
-    options.strict
-      ? !validStrictSavedState(save)
-      : save.version !== 1 || !Array.isArray(save.events)
-  ) {
-    if (options.strict) throw new Error('unsupported or malformed shared Rift state');
-    return 0;
-  }
-  // The strict predicate above narrows only its ternary arm. Repeat the cheap
-  // shape guard so TypeScript and the tolerant path share one concrete array.
-  if (!Array.isArray(save.events)) {
-    if (options.strict) throw new Error('unsupported or malformed shared Rift state');
-    return 0;
-  }
+  if (save.version !== 1 || !Array.isArray(save.events)) return 0;
   const savedEvents = save.events;
 
   for (const portal of [...ctx.naturalRiftPortals]) {
@@ -277,7 +222,12 @@ export function loadRiftWorldState(
 
   const maxOrdinal = ctx.riftEvents.reduce((max, event) => Math.max(max, event.ordinal + 1), 0);
   ctx.riftPortalSpawnCount = Math.max(maxOrdinal, Math.max(0, Math.round(finite(save.spawnCount))));
+  // nextPortalAtMs predates the rotation policy, when it was the 2-4 h natural
+  // spawn deadline; today it is only the placement-failure backoff. Clamp so
+  // the first boot after the upgrade (or any oversized persisted value) can
+  // never gate every zone's spawns for hours.
   const nextAtMs = finite(save.nextPortalAtMs, nowMs);
-  ctx.riftPortalNextAt = ctx.time + Math.max(0, nextAtMs - nowMs) / 1000;
+  ctx.riftPortalNextAt =
+    ctx.time + Math.min(RIFT_PORTAL_RETRY_DELAY, Math.max(0, nextAtMs - nowMs) / 1000);
   return ctx.naturalRiftPortals.length;
 }

--- a/src/sim/rift/portals.ts
+++ b/src/sim/rift/portals.ts
@@ -4,9 +4,14 @@
 // group entering it receives an independent RiftInstance, while every instance
 // points back to the same event and races for its single first-clear claim.
 //
-// Determinism: scheduling and portal placement use streams derived only from the
-// realm seed and spawn ordinal. They never consume ctx.rng, so enabling Rifts
-// cannot perturb combat, loot, or any other pre-existing simulation stream.
+// Population policy: every eligible zone keeps one open portal, cycling hourly.
+// The zone's next portal opens RIFT_PORTAL_ZONE_CYCLE after the previous one
+// OPENED, so a collapsed portal is replaced as it expires while a first-cleared
+// (sealed) zone stays empty until its boundary and is never instantly refarmed.
+//
+// Determinism: portal placement uses streams derived only from the realm seed
+// and spawn ordinal. They never consume ctx.rng, so enabling Rifts cannot
+// perturb combat, loot, or any other pre-existing simulation stream.
 
 import { isBlocked } from '../colliders';
 import { STRIP_MAX_X, STRIP_MIN_X, WORLD_MAX_X, WORLD_MIN_X, ZONES, zoneAt } from '../data';
@@ -27,16 +32,18 @@ import {
 export const RIFT_MIN_LEVEL = 20;
 
 export const RIFT_PORTAL_FIRST_AT = 120;
-export const RIFT_PORTAL_INTERVAL_MIN = 2 * 60 * 60;
-export const RIFT_PORTAL_INTERVAL_MAX = 4 * 60 * 60;
-/** Compatibility/telemetry value: the mean of the deterministic random window. */
-export const RIFT_PORTAL_INTERVAL = (RIFT_PORTAL_INTERVAL_MIN + RIFT_PORTAL_INTERVAL_MAX) / 2;
 export const RIFT_PORTAL_LIFETIME = 60 * 60;
-export const RIFT_PORTAL_MAX_OPEN = 3;
-export const COMMUNITY_RIFT_PORTAL_TARGET = 8;
-export const COMMUNITY_RIFT_PORTAL_LIFETIME = 6 * 60 * 60;
-export const COMMUNITY_RIFT_PORTAL_REFILL_DELAY = 60;
-const RIFT_EVENT_HISTORY_LIMIT = 64;
+/** One fresh rift per eligible zone per cycle, anchored on the zone's LAST
+ * OPENING (not its close). Equal to the lifetime, so an uncleared portal is
+ * replaced the moment it collapses, while a first-cleared (sealed) zone stays
+ * empty until its next boundary and can never be immediately refarmed. */
+export const RIFT_PORTAL_ZONE_CYCLE = RIFT_PORTAL_LIFETIME;
+/** Backoff after a deterministic placement failure before rescanning zones. */
+export const RIFT_PORTAL_RETRY_DELAY = 60;
+/** Completed events retained for history AND per-zone cadence derivation
+ * (riftZoneNextOpenAt). Must stay comfortably above the eligible-zone count or
+ * a sealed zone's newest event could be trimmed and instantly refarm. */
+export const RIFT_EVENT_HISTORY_LIMIT = 64;
 
 /** Rank tuning. Rifts pay NO Heroic Marks at any rank (maintainer decision:
  * marks stay a heroic dungeon/raid currency; the rift prize is the clear-time
@@ -84,7 +91,8 @@ export interface NaturalRiftPortal {
 }
 
 interface RiftPortalSpawnOptions {
-  readonly excludedZoneIds?: ReadonlySet<string>;
+  /** Force the target zone (the per-zone scheduler); omitted picks by rng. */
+  readonly zoneId?: string;
   readonly lifetime?: number;
 }
 
@@ -92,16 +100,25 @@ function announce(ctx: SimContext, text: string, color: string): void {
   ctx.emit({ type: 'log', text, color });
 }
 
-function scheduleRng(ctx: SimContext, ordinal: number): Rng {
-  return new Rng((ctx.cfg.seed ^ Math.imul(ordinal + 1, 0x85ebca6b) ^ 0x51f15e5d) >>> 0);
-}
-
 function portalRng(ctx: SimContext, ordinal: number): Rng {
   return new Rng((ctx.cfg.seed ^ Math.imul(ordinal + 1, 0x9e3779b9) ^ 0xa341316c) >>> 0);
 }
 
-export function riftPortalDelay(ctx: SimContext, ordinal: number): number {
-  return scheduleRng(ctx, ordinal).range(RIFT_PORTAL_INTERVAL_MIN, RIFT_PORTAL_INTERVAL_MAX);
+export function eligibleRiftZones(): ZoneDef[] {
+  return ZONES.filter((zone) => zone.riftPortalEligible && zone.riftTierWeights !== undefined);
+}
+
+/** When `zoneId` may open its next portal. Derived from the event history (the
+ * zone's most recent opening plus one cycle), so a server restart preserves the
+ * cadence without any new persisted state; a zone with no recorded event is due
+ * at the world's first-spawn warmup. */
+export function riftZoneNextOpenAt(ctx: SimContext, zoneId: string): number {
+  let lastOpenedAt: number | null = null;
+  for (const event of ctx.riftEvents) {
+    if (event.zoneId !== zoneId) continue;
+    if (lastOpenedAt === null || event.openedAt > lastOpenedAt) lastOpenedAt = event.openedAt;
+  }
+  return lastOpenedAt === null ? RIFT_PORTAL_FIRST_AT : lastOpenedAt + RIFT_PORTAL_ZONE_CYCLE;
 }
 
 function contentHash(text: string): string {
@@ -170,16 +187,15 @@ export function spawnNaturalRiftPortal(
   ordinal: number,
   options?: RiftPortalSpawnOptions,
 ): boolean {
-  const eligible = ZONES.filter(
-    (zone) =>
-      zone.riftPortalEligible &&
-      zone.riftTierWeights !== undefined &&
-      !options?.excludedZoneIds?.has(zone.id),
-  );
+  const eligible = eligibleRiftZones();
   if (eligible.length === 0) return false;
 
   const rng = portalRng(ctx, ordinal);
-  const zone = eligible[rng.int(0, eligible.length - 1)];
+  const zone =
+    options?.zoneId !== undefined
+      ? (eligible.find((candidate) => candidate.id === options.zoneId) ?? null)
+      : eligible[rng.int(0, eligible.length - 1)];
+  if (zone === null) return false;
   const tier = riftTierForZone(zone, rng.next());
   const info = RIFT_TIER_INFO[tier];
   const xMin = Math.max(WORLD_MIN_X, zone.xMin ?? STRIP_MIN_X) + 25;
@@ -272,16 +288,8 @@ export function closeNaturalRiftPortal(
 ): void {
   const index = ctx.naturalRiftPortals.findIndex((portal) => portal.id === portalId);
   if (index < 0) return;
-  const coveredCommunityZonesBefore = ctx.cfg.communityRifts ? activeRiftZoneIds(ctx).size : 0;
   const portal = ctx.naturalRiftPortals[index];
   ctx.naturalRiftPortals.splice(index, 1);
-  if (
-    ctx.cfg.communityRifts &&
-    coveredCommunityZonesBefore >= COMMUNITY_RIFT_PORTAL_TARGET &&
-    activeRiftZoneIds(ctx).size < COMMUNITY_RIFT_PORTAL_TARGET
-  ) {
-    ctx.riftPortalNextAt = ctx.time + COMMUNITY_RIFT_PORTAL_REFILL_DELAY;
-  }
   if (ctx.entities.has(portal.id)) ctx.dropEntity(portal.id);
 
   const event = eventForPortal(ctx, portal);
@@ -305,54 +313,17 @@ function activeRiftZoneIds(ctx: SimContext): Set<string> {
   return new Set(ctx.naturalRiftPortals.map((portal) => portal.zoneId));
 }
 
-function spawnCommunityRiftPortal(ctx: SimContext): boolean {
-  const activeZoneIds = activeRiftZoneIds(ctx);
-  const ordinal = ctx.riftPortalSpawnCount;
-  if (
-    !spawnNaturalRiftPortal(ctx, ordinal, {
-      excludedZoneIds: activeZoneIds,
-      lifetime: COMMUNITY_RIFT_PORTAL_LIFETIME,
-    })
-  ) {
-    return false;
-  }
-  ctx.riftPortalSpawnCount += 1;
-  return true;
-}
-
-/** Reconcile the public-test population immediately after persisted state loads.
- * Existing open portals are preserved and every new portal selects a region not
- * already active. Placement failure leaves the ordinal pending for the scheduler. */
-export function populateCommunityRiftPortals(ctx: SimContext): number {
-  let spawned = 0;
-  while (activeRiftZoneIds(ctx).size < COMMUNITY_RIFT_PORTAL_TARGET) {
-    if (!spawnCommunityRiftPortal(ctx)) break;
-    spawned += 1;
-  }
-  ctx.riftPortalNextAt = ctx.time + COMMUNITY_RIFT_PORTAL_REFILL_DELAY;
-  return spawned;
-}
-
-function updateCommunityRiftPortals(ctx: SimContext): void {
-  for (let i = ctx.naturalRiftPortals.length - 1; i >= 0; i--) {
-    const portal = ctx.naturalRiftPortals[i];
-    if (ctx.time >= portal.expiresAt) closeNaturalRiftPortal(ctx, portal.id, 'collapsed');
-  }
-
-  if (activeRiftZoneIds(ctx).size >= COMMUNITY_RIFT_PORTAL_TARGET) return;
-  if (ctx.time < ctx.riftPortalNextAt) return;
-  spawnCommunityRiftPortal(ctx);
-  ctx.riftPortalNextAt = ctx.time + COMMUNITY_RIFT_PORTAL_REFILL_DELAY;
-}
-
-/** Once-per-second scheduler. A full world cap postpones the due event instead of
- * consuming it, and every successful spawn samples the next 2-4 hour deadline. */
+/** Once-per-second scheduler: every eligible zone keeps one open portal on the
+ * hourly cycle. `riftPortalNextAt` survives only as the placement-failure
+ * backoff gate (a failed ordinal re-rolls identical positions, so hammering it
+ * every second is pointless; another zone's success advances the ordinal and
+ * unwedges it). At most ONE portal spawns per pass: a spawn generates a full
+ * rift plan plus its upgrade draft (~20 ms), so when many zones fall due in the
+ * same second (fresh world, the shared hourly boundary, post-downtime restore)
+ * the fill spreads over consecutive seconds instead of blowing the 50 ms tick
+ * budget in one go. A failed zone does NOT consume the pass. */
 export function updateRiftPortals(ctx: SimContext): void {
   if (ctx.tickCount % 20 !== 10) return;
-  if (ctx.cfg.communityRifts) {
-    updateCommunityRiftPortals(ctx);
-    return;
-  }
 
   for (let i = ctx.naturalRiftPortals.length - 1; i >= 0; i--) {
     const portal = ctx.naturalRiftPortals[i];
@@ -360,12 +331,15 @@ export function updateRiftPortals(ctx: SimContext): void {
   }
 
   if (ctx.time < ctx.riftPortalNextAt) return;
-  if (ctx.naturalRiftPortals.length >= RIFT_PORTAL_MAX_OPEN) return;
-  const ordinal = ctx.riftPortalSpawnCount;
-  if (!spawnNaturalRiftPortal(ctx, ordinal)) {
-    ctx.riftPortalNextAt = ctx.time + 60;
+  const openZoneIds = activeRiftZoneIds(ctx);
+  for (const zone of eligibleRiftZones()) {
+    if (openZoneIds.has(zone.id)) continue;
+    if (ctx.time < riftZoneNextOpenAt(ctx, zone.id)) continue;
+    if (!spawnNaturalRiftPortal(ctx, ctx.riftPortalSpawnCount, { zoneId: zone.id })) {
+      ctx.riftPortalNextAt = ctx.time + RIFT_PORTAL_RETRY_DELAY;
+      continue;
+    }
+    ctx.riftPortalSpawnCount += 1;
     return;
   }
-  ctx.riftPortalSpawnCount += 1;
-  ctx.riftPortalNextAt = ctx.time + riftPortalDelay(ctx, ordinal);
 }

--- a/src/sim/rift/runs.ts
+++ b/src/sim/rift/runs.ts
@@ -1193,17 +1193,21 @@ function openExit(ctx: SimContext, inst: RiftInstance): void {
   // Beside the way home, the giga-boss leaves a SEALED reward cache: pick its lock
   // (the shared Tumbler's Path minigame) for bonus spoils. Lootable so the interact
   // scan targets it; the pick, not a grab, opens it (see interaction.ts + rift_lockpick).
-  const cache = createGroundObject(
-    ctx.nextId++,
-    '',
-    'Sealed Rift Cache',
-    ctx.groundPos(origin.x + pos.x - 4, origin.z + pos.z),
-  );
-  cache.templateId = 'rift_locked_chest';
-  cache.objectItemId = null;
-  cache.lootable = true;
-  ctx.addEntity(cache);
-  inst.cacheId = cache.id;
+  // COMPLETION loot, so race losers get the egress but no cache (maintainer
+  // decision, 2026-07-30: a loser keeps only what dropped off the mobs).
+  if (inst.outcome !== 'lost') {
+    const cache = createGroundObject(
+      ctx.nextId++,
+      '',
+      'Sealed Rift Cache',
+      ctx.groundPos(origin.x + pos.x - 4, origin.z + pos.z),
+    );
+    cache.templateId = 'rift_locked_chest';
+    cache.objectItemId = null;
+    cache.lootable = true;
+    ctx.addEntity(cache);
+    inst.cacheId = cache.id;
+  }
   for (const pid of instancePlayerIds(ctx, inst)) {
     ctx.emit({
       type: 'log',
@@ -1220,10 +1224,11 @@ function openExit(ctx: SimContext, inst: RiftInstance): void {
 
 /** Complete a run whose event was first-cleared by another group. No eject, no
  * teardown (maintainer decision, 2026-07-30): the group keeps its instance to
- * the end, the boss corpse still pays the rank-gated gear ladder, and only the
- * event's first-clear extras (rings, essence, gems, the world banner) stay
+ * the end and gets an egress, but NO completion loot of any kind. Everything a
+ * loser walks out with came off the mobs (or a mid-run treasure chest) the
+ * normal way; the gear ladder, sealed cache, and first-clear extras all stay
  * exclusive to the race winner. */
-function completeLosingRun(ctx: SimContext, inst: RiftInstance, boss: Entity | null): void {
+function completeLosingRun(ctx: SimContext, inst: RiftInstance): void {
   const event =
     inst.eventId === null
       ? null
@@ -1234,7 +1239,6 @@ function completeLosingRun(ctx: SimContext, inst: RiftInstance, boss: Entity | n
   inst.rewarded = true;
   inst.outcome = 'lost';
   inst.finishedAt = ctx.time;
-  if (boss) addRiftClearGearLoot(ctx, boss, inst.baseLevel);
   if (event && tier) {
     for (const pid of instancePlayerIds(ctx, inst)) {
       ctx.emit({
@@ -1260,7 +1264,7 @@ function completeRiftClear(ctx: SimContext, inst: RiftInstance, boss: Entity | n
   const participants = present.length > 0 ? present : [...inst.memberIds];
   const claim = claimRiftFirstClear(ctx, inst, participants);
   if (!claim.won) {
-    completeLosingRun(ctx, inst, boss);
+    completeLosingRun(ctx, inst);
     return true;
   }
 

--- a/src/sim/rift/runs.ts
+++ b/src/sim/rift/runs.ts
@@ -53,6 +53,9 @@ const ORB_TRIGGER_RADIUS = 3.2;
 const ORB_NOTICE_COOLDOWN = 6; // seconds between "the orb is sealed" nudges
 const SEQ_RESET_NOTICE_COOLDOWN = 4; // seconds between "the runes go dark" reset notices
 const POOL_FULL_NOTICE_COOLDOWN = 4; // seconds between "all rifts are unstable" / "already cleared" denials on walk-in
+// Concurrent instances one shared event may hold. The global pool (RIFT_SLOT_COUNT)
+// backs every event together; this cap keeps a single hyped portal from draining it.
+export const RIFT_EVENT_INSTANCE_CAP = 32;
 const BOULDER_PUSH_RADIUS = 2.0; // shove a boulder when this close and moving into it
 const PAD_RADIUS = 2.2; // a boulder counts as socketed within this of its pad
 const ICE_SLIDE_SPEED = 13; // yd/s glide across the ice (~1.85x run: frictionless momentum)
@@ -453,6 +456,7 @@ function freeRiftInstance(ctx: SimContext, inst: RiftInstance): void {
   inst.tier = null;
   inst.portalId = null;
   inst.rewarded = false;
+  inst.progressed = false;
   inst.bossDeathZones = [];
   if (eventId !== null) {
     const event = ctx.riftEvents.find((candidate) => candidate.eventId === eventId);
@@ -527,7 +531,19 @@ export function enterRift(
       return;
     }
   }
+  const matchesEvent = (candidate: RiftInstance): boolean =>
+    eventId !== null
+      ? candidate.eventId === eventId
+      : candidate.eventId === null && candidate.seed === seed >>> 0;
+  const liveMatch = (candidate: RiftInstance): boolean =>
+    candidate.partyKey !== null && candidate.outcome === 'active' && matchesEvent(candidate);
+
   if (eventId !== null && !deadEntry) {
+    // A resolved event denies every LIVING entrant outright. No re-entry
+    // exemption is needed: sealing or collapsing always deletes the portal
+    // entity in the same call chain, so this eventId path cannot even be
+    // reached once the event is cleared or collapsed, and mid-run groups
+    // simply keep playing inside their instance.
     const event = ctx.riftEvents.find((candidate) => candidate.eventId === eventId);
     if (!event || event.status === 'cleared' || event.status === 'collapsed') {
       if (ctx.time >= (r.e.riftPoolFullAt ?? -Infinity) + POOL_FULL_NOTICE_COOLDOWN) {
@@ -541,28 +557,77 @@ export function enterRift(
     event.contentLocked = true;
   }
 
-  // Members of one group share an instance. Every other group entering the same
-  // event receives another slot with identical generated content. A dead
-  // member may match their own DECIDED run (corpse retrieval, above).
-  // A dead entrant matches by MEMBERSHIP ONLY (never the partyKey arm), so the
-  // instance entered is guaranteed to be the same one the combat gate above
+  // ---- Instance resolution (WoW-raid-style binding) --------------------------
+  // The first mob kill (or plundered cache) marks a run PROGRESSED. A progressed
+  // run binds its members: they always re-enter that run and can never land in a
+  // different instance of the same event, whatever their party does. An
+  // UNPROGRESSED run is disposable: once its members regroup and enter another
+  // run, the stale empty copy recycles so a freshly formed party shares one
+  // clean instance instead of being split across leftovers.
+  // A dead entrant still matches by MEMBERSHIP ONLY (never the partyKey arm), so
+  // the instance entered is guaranteed to be the same one the combat gate above
   // checked, and may be a decided (won) run for corpse retrieval.
-  let inst =
-    ctx.riftInstances.find(
-      (candidate) =>
-        candidate.partyKey !== null &&
-        (deadEntry
-          ? candidate.memberIds.has(r.meta.entityId)
-          : candidate.outcome === 'active' &&
-            (candidate.memberIds.has(r.meta.entityId) || candidate.partyKey === key)) &&
-        (eventId !== null
-          ? candidate.eventId === eventId
-          : candidate.eventId === null && candidate.seed === seed >>> 0),
-    ) ?? null;
+  let inst: RiftInstance | null = null;
+  if (deadEntry) {
+    inst =
+      ctx.riftInstances.find(
+        (candidate) =>
+          candidate.partyKey !== null &&
+          candidate.memberIds.has(r.meta.entityId) &&
+          matchesEvent(candidate),
+      ) ?? null;
+    if (!inst) return; // a ghost never allocates a fresh run
+  } else {
+    // 1. Binding wins over everything, including the entrant's current party.
+    inst =
+      ctx.riftInstances.find(
+        (candidate) =>
+          liveMatch(candidate) && candidate.progressed && candidate.memberIds.has(r.meta.entityId),
+      ) ?? null;
+    // 2. The current group's run: exact key match first, then any live run a
+    //    CURRENT party member is inside of or bound to (covers party-id churn
+    //    and mid-run replacement invites). Entering a progressed run binds the
+    //    entrant to it via the membership added below.
+    if (inst === null) {
+      const partyPids = ctx.partyOf(r.meta.entityId)?.members ?? [];
+      const mateRun = (candidate: RiftInstance): boolean =>
+        liveMatch(candidate) &&
+        partyPids.some((pid) => pid !== r.meta.entityId && candidate.memberIds.has(pid));
+      inst =
+        ctx.riftInstances.find((candidate) => liveMatch(candidate) && candidate.partyKey === key) ??
+        ctx.riftInstances.find((candidate) => mateRun(candidate) && candidate.progressed) ??
+        ctx.riftInstances.find(mateRun) ??
+        null;
+      if (inst !== null) inst.partyKey = key; // the current group owns the run now
+    }
+    // 3. Recycle the entrant's stale, unprogressed, player-empty leftovers of
+    //    this event (they regrouped; the clean copies must not pin or leak).
+    for (const candidate of ctx.riftInstances) {
+      if (candidate === inst || !liveMatch(candidate) || candidate.progressed) continue;
+      if (!candidate.memberIds.has(r.meta.entityId)) continue;
+      if (instancePlayerIds(ctx, candidate).length > 0) continue;
+      // A zero-kill wipe leaves ghosts entitled to a corpse run (the death
+      // rules above): never recycle a run out from under a dead member.
+      let deadMember = false;
+      for (const memberId of candidate.memberIds) {
+        if (ctx.entities.get(memberId)?.dead) {
+          deadMember = true;
+          break;
+        }
+      }
+      if (deadMember) continue;
+      freeRiftInstance(ctx, candidate);
+    }
+  }
   if (!inst) {
-    if (deadEntry) return; // a ghost never allocates a fresh run
+    // The cap counts SLOT OCCUPANCY for the event, not just active races:
+    // decided (won/lost) runs still hold their slot until reclaim, and one
+    // hyped portal must never drain the whole global pool through them.
+    const eventRuns = ctx.riftInstances.filter(
+      (candidate) => candidate.partyKey !== null && matchesEvent(candidate),
+    ).length;
     const free = ctx.riftInstances.find((i) => i.partyKey === null);
-    if (!free) {
+    if (!free || eventRuns >= RIFT_EVENT_INSTANCE_CAP) {
       if (ctx.time >= (r.e.riftPoolFullAt ?? -Infinity) + POOL_FULL_NOTICE_COOLDOWN) {
         r.e.riftPoolFullAt = ctx.time;
         ctx.error(r.meta.entityId, 'All rifts are unstable right now. Try again soon.');
@@ -607,6 +672,7 @@ export function enterRift(
     inst.tier = eventId === null ? null : (portal?.riftTier ?? null);
     inst.portalId = portal?.id ?? null;
     inst.rewarded = false;
+    inst.progressed = false;
     markRiftEventActive(ctx, eventId);
     spawnRiftFloor(ctx, inst);
   }
@@ -1079,6 +1145,10 @@ export function riftOpenTreasure(ctx: SimContext, objectId: number, pid?: number
     return;
   }
   const inst = riftInstanceAtPos(ctx, r.e.pos);
+  // Plundering the cache spoils the run exactly like a kill: a recycled copy
+  // would respawn the chest, so an unbound leave-regroup-reenter loop could
+  // farm it. Progress pins the run instead.
+  if (inst) inst.progressed = true;
   const tier: LootTier =
     inst?.tier === 'S' ? 'premium' : inst?.tier === 'A' || inst?.tier === 'B' ? 'medium' : 'low';
   const cls = ctx.players.get(r.meta.entityId)?.cls ?? 'warrior';
@@ -1148,7 +1218,12 @@ function openExit(ctx: SimContext, inst: RiftInstance): void {
 // heroic dungeon/raid currency, and the rift prize is the clear-time gear
 // ladder, the first-clear rings/essence/gems, the mount rolls, and coin.
 
-function terminateLosingInstance(ctx: SimContext, inst: RiftInstance): void {
+/** Complete a run whose event was first-cleared by another group. No eject, no
+ * teardown (maintainer decision, 2026-07-30): the group keeps its instance to
+ * the end, the boss corpse still pays the rank-gated gear ladder, and only the
+ * event's first-clear extras (rings, essence, gems, the world banner) stay
+ * exclusive to the race winner. */
+function completeLosingRun(ctx: SimContext, inst: RiftInstance, boss: Entity | null): void {
   const event =
     inst.eventId === null
       ? null
@@ -1156,11 +1231,12 @@ function terminateLosingInstance(ctx: SimContext, inst: RiftInstance): void {
   const winnerNames = event?.firstClear?.memberNames ?? [];
   const clearTime = event?.firstClear?.duration ?? 0;
   const tier = event?.tier ?? inst.tier;
+  inst.rewarded = true;
   inst.outcome = 'lost';
   inst.finishedAt = ctx.time;
-  if (inst.lockpick) riftLockpickAbort(ctx, inst);
-  for (const pid of instancePlayerIds(ctx, inst)) {
-    if (event && tier) {
+  if (boss) addRiftClearGearLoot(ctx, boss, inst.baseLevel);
+  if (event && tier) {
+    for (const pid of instancePlayerIds(ctx, inst)) {
       ctx.emit({
         type: 'riftRaceResult',
         pid,
@@ -1171,27 +1247,21 @@ function terminateLosingInstance(ctx: SimContext, inst: RiftInstance): void {
         clearTime,
       });
     }
-    ctx.emit({
-      type: 'log',
-      text: `The rift has already been cleared by ${winnerNames.join(', ') || 'another party'}. Your run ends.`,
-      color: '#f99',
-      pid,
-    });
-    forceExitRiftPlayer(ctx, inst, pid, true);
   }
-  freeRiftInstance(ctx, inst);
 }
 
-/** Resolve the authoritative first-clear claim. The winning instance remains open
- * for loot and egress; every competing group is notified, ejected, and torn down. */
+/** Resolve the authoritative first-clear claim. Every finishing instance stays
+ * open for loot and egress; losing the race only forfeits the first-clear
+ * extras, never the run. Returns true when this run is decided and should get
+ * its exit spawned. */
 function completeRiftClear(ctx: SimContext, inst: RiftInstance, boss: Entity | null): boolean {
-  if (inst.rewarded) return inst.outcome === 'won';
+  if (inst.rewarded) return inst.outcome !== 'active';
   const present = instancePlayerIds(ctx, inst);
   const participants = present.length > 0 ? present : [...inst.memberIds];
   const claim = claimRiftFirstClear(ctx, inst, participants);
   if (!claim.won) {
-    terminateLosingInstance(ctx, inst);
-    return false;
+    completeLosingRun(ctx, inst, boss);
+    return true;
   }
 
   inst.rewarded = true;
@@ -1251,14 +1321,8 @@ function completeRiftClear(ctx: SimContext, inst: RiftInstance, boss: Entity | n
       text: `${winnerNames.join(', ') || 'A party'} won the ${claim.event.tier}-rank Rift race in ${clearTime.toFixed(1)}s!`,
       color: '#ffd76a',
     });
-
-    const competitors = ctx.riftInstances.filter(
-      (candidate) =>
-        candidate !== inst &&
-        candidate.partyKey !== null &&
-        candidate.eventId === claim.event?.eventId,
-    );
-    for (const competitor of competitors) terminateLosingInstance(ctx, competitor);
+    // Competing instances are deliberately left running: they finish their own
+    // race and complete as losers when their boss falls (completeLosingRun).
   }
   return true;
 }
@@ -1471,7 +1535,20 @@ export function updateRiftInstances(ctx: SimContext): void {
   // whose bosses fall inside the same window would be ranked by slot order and
   // the earlier kill could lose the shared race.
   for (const inst of ctx.riftInstances) {
-    if (inst.partyKey === null || inst.bossDiedAtTick !== null || inst.bossId === null) continue;
+    if (inst.partyKey === null) continue;
+    // First-kill watch: the moment ANY mob of an unspoiled run dies, the run is
+    // PROGRESSED (binds members, stops recycling). Self-disabling: once set, the
+    // scan never runs again for this instance.
+    if (!inst.progressed) {
+      for (const id of inst.mobIds) {
+        const mob = ctx.entities.get(id);
+        if (mob?.dead) {
+          inst.progressed = true;
+          break;
+        }
+      }
+    }
+    if (inst.bossDiedAtTick !== null || inst.bossId === null) continue;
     if (ctx.entities.get(inst.bossId)?.dead) {
       inst.bossDiedAtTick = ctx.tickCount;
       // Clear any pending lethal death zones so a zone placed just before the
@@ -1581,7 +1658,8 @@ export function updateRiftInstances(ctx: SimContext): void {
     )
     .sort((a, b) => (a.bossDiedAtTick as number) - (b.bossDiedAtTick as number) || a.slot - b.slot);
   for (const inst of cleared) {
-    // An earlier claim this sweep may have torn this competitor down already.
+    // Safety only: nothing tears down competitors mid-sweep anymore, but a
+    // freed slot must never be completed.
     if (inst.partyKey === null) continue;
     const boss = inst.bossId !== null ? ctx.entities.get(inst.bossId) : null;
     if (!completeRiftClear(ctx, inst, boss ?? null)) continue;

--- a/src/sim/rift/types.ts
+++ b/src/sim/rift/types.ts
@@ -269,6 +269,12 @@ export interface RiftInstance {
   startedAt: number;
   finishedAt: number | null;
   outcome: RiftInstanceOutcome;
+  /** True once the run is SPOILED: any mob killed, or the off-path cache
+   * plundered. A progressed run never recycles and binds its members WoW-raid
+   * style (enterRift routes them back and never into a sibling instance).
+   * Survives descent (floor teardown must not erase progress); reset only when
+   * the slot itself is freed. */
+  progressed: boolean;
   /** Snapshot of the event artifact at entry. Never changes mid-race. */
   upgrade: RiftUpgradeManifest | null;
   seed: number;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -154,7 +154,6 @@ import {
   abilitiesKnownAt,
   arenaOrigin,
   CLASSES,
-  COMMUNITY_RIFT_SLOT_COUNT,
   DELVE_COMPANIONS,
   DELVE_LIST,
   DELVE_SLOT_COUNT,
@@ -468,11 +467,7 @@ import {
   onNodeGatheredForQuests,
   onRecipeCraftedForQuests,
 } from './quests/quest_credit';
-import {
-  type NaturalRiftPortal,
-  RIFT_PORTAL_FIRST_AT,
-  updateRiftPortals as updateRiftPortalsImpl,
-} from './rift/portals';
+import { type NaturalRiftPortal, updateRiftPortals as updateRiftPortalsImpl } from './rift/portals';
 import {
   enchantRiftItem as enchantRiftItemImpl,
   type RiftForgeResult,
@@ -1747,7 +1742,9 @@ export class Sim {
   // scheduler; both live SimContext views).
   naturalRiftPortals: NaturalRiftPortal[] = [];
   riftPortalSpawnCount = 0;
-  riftPortalNextAt = RIFT_PORTAL_FIRST_AT;
+  // Placement-failure backoff gate only; per-zone cadence lives in the event
+  // history (rift/portals.ts riftZoneNextOpenAt).
+  riftPortalNextAt = 0;
   // Escort quest runs (src/sim/escort.ts), keyed by EscortDef id. Live
   // SimContext view; the module owns every mutation.
   escortRuns = new Map<string, EscortRunState>();
@@ -1856,7 +1853,6 @@ export class Sim {
       devCommands: this.devCommands,
       worldBossAtBoot: cfg.worldBossAtBoot ?? false,
       riftPortals: cfg.riftPortals ?? false,
-      communityRifts: cfg.communityRifts ?? false,
       lockoutNowMs: cfg.lockoutNowMs ?? (() => Math.floor(this.time * 1000)),
       raidResetMs: cfg.raidResetMs ?? ((nowMs: number) => nowMs + DEFAULT_RAID_LOCKOUT_MS),
       valeCupShowcase: cfg.valeCupShowcase ?? false,
@@ -2142,10 +2138,8 @@ export class Sim {
       }
     }
 
-    // Procedural rift instance pool (empty until a portal is entered). Public
-    // test realms opt into a larger pool without changing the normal host cap.
-    const riftSlotCount = this.cfg.communityRifts ? COMMUNITY_RIFT_SLOT_COUNT : RIFT_SLOT_COUNT;
-    for (let i = 0; i < riftSlotCount; i++) {
+    // Procedural rift instance pool (empty until a portal is entered).
+    for (let i = 0; i < RIFT_SLOT_COUNT; i++) {
       this.riftInstances.push({
         slot: i,
         instanceId: 0,
@@ -2191,6 +2185,7 @@ export class Sim {
         tier: null,
         portalId: null,
         rewarded: false,
+        progressed: false,
         seqResetAt: -Infinity,
         bossDeathZones: [],
       });

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -5043,9 +5043,6 @@ export interface SimConfig {
   // scheduler (rift/portals.ts). Default OFF so deterministic tests, parity
   // traces, and the RL env keep a portal-free world unless they opt in.
   riftPortals?: boolean;
-  // Public test realms may opt into a denser natural-portal policy and a larger
-  // instance pool. Default OFF so all existing hosts retain their current policy.
-  communityRifts?: boolean;
   // Host-computed next raid-reset instant for a given lockout "now" (epoch ms). The
   // authoritative server uses its realm-local 3 AM daily reset; offline/headless omit
   // this and fall back to a flat 24h day. Keeps the time zone out of the sim core.

--- a/tests/deploy_community_test_accounts.test.ts
+++ b/tests/deploy_community_test_accounts.test.ts
@@ -15,9 +15,12 @@ describe('community test account deploy contract', () => {
     expect(envExample).not.toMatch(/^PROVISION_TEST_ACCOUNTS=1$/m);
   });
 
-  it('documents the paired, reversible public-test profile', () => {
+  it('documents the reversible public-test profile without the retired rift flag', () => {
     expect(deploy).toContain('PROVISION_TEST_ACCOUNTS=1');
-    expect(deploy).toContain('COMMUNITY_TEST_RIFTS=1');
+    // Rift density no longer has a flag: one portal per eligible zone is the
+    // policy everywhere, so the deploy guide must not resurrect the toggle.
+    expect(deploy).not.toContain('COMMUNITY_TEST_RIFTS=1');
+    expect(compose).not.toContain('COMMUNITY_TEST_RIFTS');
     expect(deploy).toMatch(/newly created accounts/i);
     expect(deploy).toContain('ALLOW_DEV_COMMANDS');
     expect(deploy).toContain('RIFT_RUNTIME_ASSETS');

--- a/tests/rift_binding.test.ts
+++ b/tests/rift_binding.test.ts
@@ -1,0 +1,353 @@
+// WoW-raid-style rift instance binding and unspoiled-run recycling: the first
+// mob kill (or plundered cache) pins a run to its members; clean runs merge and
+// recycle so a freshly formed party is never split across leftover instances.
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_WORLD } from '../src/sim/data';
+import { spawnNaturalRiftPortal } from '../src/sim/rift/portals';
+import {
+  descendRift,
+  leaveRift,
+  riftInstanceAtPos,
+  updateRiftInstances,
+} from '../src/sim/rift/runs';
+import type { RiftInstance } from '../src/sim/rift/types';
+import { Sim } from '../src/sim/sim';
+
+const TEST_WORLD = {
+  ...BUILTIN_WORLD,
+  camps: [],
+  npcs: {},
+  groundObjects: [],
+};
+
+function makeSim(): Sim {
+  return new Sim({
+    seed: 99117,
+    playerClass: 'warrior',
+    noPlayer: true,
+    autoEquip: true,
+    devCommands: true,
+    riftPortals: true,
+    world: TEST_WORLD,
+  });
+}
+
+function activeRuns(sim: Sim): RiftInstance[] {
+  return sim.riftInstances.filter((instance) => instance.partyKey !== null);
+}
+
+function markFirstKill(sim: Sim, inst: RiftInstance): void {
+  const mob = sim.entities.get(inst.mobIds[0])!;
+  mob.hp = 0;
+  mob.dead = true;
+  updateRiftInstances(sim.ctx); // tick-resolution pre-pass stamps progressed
+  expect(inst.progressed).toBe(true);
+}
+
+function setup(memberCount: number): {
+  sim: Sim;
+  pids: number[];
+  portal: import('../src/sim/types').Entity;
+} {
+  const sim = makeSim();
+  const pids: number[] = [];
+  for (let i = 0; i < memberCount; i++) {
+    const pid = sim.addPlayer('warrior', `Binder${i}`);
+    sim.setPlayerLevel(20, pid);
+    pids.push(pid);
+  }
+  expect(spawnNaturalRiftPortal(sim.ctx, 0)).toBe(true);
+  const portal = sim.entities.get(sim.naturalRiftPortals[0].id)!;
+  return { sim, pids, portal };
+}
+
+function enter(sim: Sim, portal: import('../src/sim/types').Entity, pid: number): void {
+  sim.enterRift(portal.riftSeed!, portal.riftBaseLevel!, pid, undefined, portal);
+}
+
+describe('unspoiled runs merge and recycle', () => {
+  it('recycles independent clean solo runs into ONE shared run when the duo groups up', () => {
+    const { sim, pids, portal } = setup(2);
+    const [p1, p2] = pids;
+    enter(sim, portal, p1);
+    enter(sim, portal, p2);
+    expect(activeRuns(sim)).toHaveLength(2); // ungrouped players race by design
+
+    leaveRift(sim.ctx, p1);
+    leaveRift(sim.ctx, p2);
+    sim.time += 10; // clear the 3s re-entry grace
+    sim.partyInvite(p2, p1);
+    sim.partyAccept(p2);
+    enter(sim, portal, p1);
+    enter(sim, portal, p2);
+
+    const runs = activeRuns(sim);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].memberIds.has(p1)).toBe(true);
+    expect(runs[0].memberIds.has(p2)).toBe(true);
+    expect(runs[0].partyKey).toBe(`party:${sim.partyOf(p1)!.id}`);
+  });
+
+  it('merges the second member into the first member clean run when the invite lands late', () => {
+    const { sim, pids, portal } = setup(2);
+    const [p1, p2] = pids;
+    sim.partyInvite(p2, p1);
+    enter(sim, portal, p1); // walked in before the accept: solo-keyed run
+    expect(activeRuns(sim)[0].partyKey).toBe(`solo:${p1}`);
+    sim.partyAccept(p2);
+    enter(sim, portal, p2);
+
+    const runs = activeRuns(sim);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].memberIds).toEqual(new Set([p1, p2]));
+    expect(runs[0].partyKey).toBe(`party:${sim.partyOf(p1)!.id}`);
+  });
+
+  it('never recycles an OCCUPIED unspoiled leftover out from under its players', () => {
+    const { sim, pids, portal } = setup(3);
+    const [p1, p2, p3] = pids;
+    sim.partyInvite(p2, p1);
+    sim.partyAccept(p2);
+    enter(sim, portal, p1);
+    enter(sim, portal, p2);
+    const sharedRun = activeRuns(sim)[0];
+    expect(sharedRun.memberIds).toEqual(new Set([p1, p2]));
+
+    // P1 abandons P2 mid-look (no kills yet), regroups with P3, and re-enters.
+    leaveRift(sim.ctx, p1);
+    sim.partyLeave(p1);
+    sim.time += 10;
+    sim.partyInvite(p3, p1);
+    sim.partyAccept(p3);
+    enter(sim, portal, p1);
+
+    // P2 is still standing inside the old run: it must survive untouched even
+    // though it is unspoiled and P1 (a member) just entered a different run.
+    expect(sharedRun.partyKey).not.toBeNull();
+    expect(sharedRun.outcome).toBe('active');
+    const p2Entity = sim.entities.get(p2)!;
+    expect(riftInstanceAtPos(sim.ctx, p2Entity.pos)).toBe(sharedRun);
+    expect(sim.entities.has(sharedRun.mobIds[0])).toBe(true);
+    // P1 got a fresh run for the new party instead.
+    const p1Run = riftInstanceAtPos(sim.ctx, sim.entities.get(p1)!.pos)!;
+    expect(p1Run).not.toBe(sharedRun);
+    expect(p1Run.partyKey).toBe(`party:${sim.partyOf(p1)!.id}`);
+  });
+
+  it('survives party-id churn: a disband and reinvite still lands the duo together', () => {
+    const { sim, pids, portal } = setup(2);
+    const [p1, p2] = pids;
+    sim.partyInvite(p2, p1);
+    sim.partyAccept(p2);
+    const firstPartyId = sim.partyOf(p1)!.id;
+    enter(sim, portal, p1);
+    expect(activeRuns(sim)[0].partyKey).toBe(`party:${firstPartyId}`);
+
+    sim.partyLeave(p2); // 2-man party disbands entirely
+    sim.partyInvite(p2, p1);
+    sim.partyAccept(p2);
+    expect(sim.partyOf(p2)!.id).not.toBe(firstPartyId);
+    enter(sim, portal, p2);
+
+    const runs = activeRuns(sim);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].memberIds).toEqual(new Set([p1, p2]));
+    expect(runs[0].partyKey).toBe(`party:${sim.partyOf(p2)!.id}`);
+  });
+});
+
+describe('unspoiled runs and dead members', () => {
+  it('never recycles a zero-kill wipe out from under its dead members', () => {
+    const { sim, pids, portal } = setup(2);
+    const [p1, p2] = pids;
+    sim.partyInvite(p2, p1);
+    sim.partyAccept(p2);
+    enter(sim, portal, p1);
+    enter(sim, portal, p2);
+    const run = activeRuns(sim)[0];
+    expect(run.progressed).toBe(false);
+
+    // Wipe with ZERO kills: both die and release out of the region. The run is
+    // unspoiled and player-empty, i.e. recycle bait, but the ghosts are owed a
+    // corpse run (enterRift's death rules).
+    const e1 = sim.entities.get(p1)!;
+    const e2 = sim.entities.get(p2)!;
+    e1.dead = true;
+    e1.ghost = true; // released spirit: the only dead state allowed back in
+    e2.dead = true;
+    e2.ghost = true;
+    const releasePos = { x: run.returnPos.x, y: 0, z: run.returnPos.z };
+    e1.pos = { ...releasePos };
+    e1.prevPos = { ...releasePos };
+    e2.pos = { ...releasePos };
+    e2.prevPos = { ...releasePos };
+    sim.time += 10;
+
+    // P1 resurrects, quits the party, and enters solo: gets a FRESH run, and
+    // the wiped run must survive for the ghost.
+    e1.dead = false;
+    e1.ghost = false;
+    sim.partyLeave(p1);
+    enter(sim, portal, p1);
+    expect(run.partyKey).not.toBeNull();
+    expect(run.outcome).toBe('active');
+    expect(riftInstanceAtPos(sim.ctx, e1.pos)).not.toBe(run);
+
+    // The ghost re-enters their own run for the corpse.
+    enter(sim, portal, p2);
+    expect(riftInstanceAtPos(sim.ctx, e2.pos)).toBe(run);
+  });
+});
+
+describe('progressed runs bind their members', () => {
+  it('first kill pins the run: regrouping re-enters the SAME spoiled run for both', () => {
+    const { sim, pids, portal } = setup(2);
+    const [p1, p2] = pids;
+    enter(sim, portal, p1);
+    const run = activeRuns(sim)[0];
+    markFirstKill(sim, run);
+    leaveRift(sim.ctx, p1);
+    sim.time += 10;
+    sim.partyInvite(p2, p1);
+    sim.partyAccept(p2);
+
+    enter(sim, portal, p1);
+    enter(sim, portal, p2);
+    const runs = activeRuns(sim);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toBe(run); // the progressed run survived, nothing recycled
+    expect(run.memberIds).toEqual(new Set([p1, p2]));
+    expect(run.progressed).toBe(true);
+  });
+
+  it('progress survives descent: the flag persists across the floor teardown', () => {
+    const { sim, pids, portal } = setup(1);
+    const p1 = pids[0];
+    enter(sim, portal, p1);
+    const run = activeRuns(sim)[0];
+    markFirstKill(sim, run);
+
+    // Clear the floor for real so the descent opens, then take it.
+    for (const id of run.mobIds) {
+      const mob = sim.entities.get(id);
+      if (mob) {
+        mob.hp = 0;
+        mob.dead = true;
+      }
+    }
+    run.litPylons = new Set(run.pylonIds);
+    run.puzzleSolved = true;
+    sim.tickCount += (20 - (sim.tickCount % 20)) % 20;
+    updateRiftInstances(sim.ctx);
+    expect(run.descentOpen).toBe(true);
+    descendRift(sim.ctx, p1);
+    expect(run.floorIndex).toBe(1);
+    // The new floor spawned all-new living mobs; only the persisted flag keeps
+    // the run bound, so it MUST survive freeRiftFloorEntities.
+    expect(run.progressed).toBe(true);
+  });
+
+  it('a bound player entering the portal always lands in their own run, never the party one', () => {
+    const { sim, pids, portal } = setup(3);
+    const [p1, p3] = [pids[0], pids[2]];
+    enter(sim, portal, p1);
+    const runA = activeRuns(sim)[0];
+    markFirstKill(sim, runA);
+    leaveRift(sim.ctx, p1);
+
+    enter(sim, portal, p3);
+    const runB = activeRuns(sim).find((candidate) => candidate !== runA)!;
+    markFirstKill(sim, runB);
+
+    // P1 joins P3's party, but P1 is bound to run A: the portal must route P1
+    // back into A and never into the party's run B.
+    sim.time += 10;
+    sim.partyInvite(p1, p3);
+    sim.partyAccept(p1);
+    enter(sim, portal, p1);
+    expect(runB.memberIds.has(p1)).toBe(false);
+    expect(runA.memberIds.has(p1)).toBe(true);
+    const p1Entity = sim.entities.get(p1)!;
+    expect(riftInstanceAtPos(sim.ctx, p1Entity.pos)).toBe(runA);
+  });
+
+  it('a replacement invite joins the party live progressed run and becomes bound to it', () => {
+    const { sim, pids, portal } = setup(3);
+    const [p1, p2, p4] = pids;
+    sim.partyInvite(p2, p1);
+    sim.partyAccept(p2);
+    enter(sim, portal, p1);
+    enter(sim, portal, p2);
+    const run = activeRuns(sim)[0];
+    markFirstKill(sim, run);
+
+    // P2 drops out entirely; the 2-man party disbands, P1 keeps fighting.
+    leaveRift(sim.ctx, p2);
+    sim.partyLeave(p2);
+    sim.time += 10;
+    sim.partyInvite(p4, p1);
+    sim.partyAccept(p4);
+    enter(sim, portal, p4);
+
+    expect(run.memberIds.has(p4)).toBe(true);
+    expect(activeRuns(sim)).toHaveLength(1);
+    const p4Entity = sim.entities.get(p4)!;
+    expect(riftInstanceAtPos(sim.ctx, p4Entity.pos)).toBe(run);
+    // Bound now: even after leaving the party, P4 re-enters this same run.
+    leaveRift(sim.ctx, p4);
+    sim.partyLeave(p4);
+    sim.time += 10;
+    enter(sim, portal, p4);
+    expect(riftInstanceAtPos(sim.ctx, sim.entities.get(p4)!.pos)).toBe(run);
+  });
+
+  it('plundering the hidden cache spoils the run exactly like a kill, and binds', () => {
+    const sim = makeSim();
+    const p1 = sim.addPlayer('warrior', 'Plunderer');
+    const p2 = sim.addPlayer('priest', 'Sidekick');
+    sim.setPlayerLevel(20, p1);
+    sim.setPlayerLevel(20, p2);
+    // ~45% of non-boss floors tuck a cache away; walk dev seeds until one does.
+    // Capture the run BY SEED so stale leftovers from earlier iterations can
+    // never be mistaken for the current one.
+    let run: RiftInstance | null = null;
+    let chest: import('../src/sim/types').Entity | undefined;
+    for (let seed = 1; seed <= 40 && !chest; seed++) {
+      sim.enterRift(seed, 20, p1);
+      run = sim.riftInstances.find(
+        (instance) =>
+          instance.outcome === 'active' &&
+          instance.memberIds.has(p1) &&
+          instance.seed === seed >>> 0,
+      )!;
+      chest = run.objectIds
+        .map((id) => sim.entities.get(id))
+        .find((entity) => entity?.templateId === 'rift_treasure');
+      if (!chest) {
+        leaveRift(sim.ctx, p1);
+        sim.time += 10;
+      }
+    }
+    expect(chest, 'found a floor with a hidden cache').toBeDefined();
+    expect(run!.progressed).toBe(false);
+    const player = sim.entities.get(p1)!;
+    player.pos = { ...chest!.pos };
+    player.prevPos = { ...chest!.pos };
+    sim.riftOpenTreasure(chest!.id, p1);
+    expect(chest!.templateId).toBe('rift_treasure_open');
+    expect(run!.progressed).toBe(true);
+
+    // Same consequence as a kill: the spoiled run binds. Regrouping does not
+    // recycle it; P1 re-enters the SAME run (chest stays open, no farm loop)
+    // and the new mate lands in it too.
+    leaveRift(sim.ctx, p1);
+    sim.time += 10;
+    sim.partyInvite(p2, p1);
+    sim.partyAccept(p2);
+    sim.enterRift(run!.seed, 20, p1);
+    sim.enterRift(run!.seed, 20, p2);
+    expect(riftInstanceAtPos(sim.ctx, sim.entities.get(p1)!.pos)).toBe(run);
+    expect(riftInstanceAtPos(sim.ctx, sim.entities.get(p2)!.pos)).toBe(run);
+    expect(sim.entities.get(chest!.id)?.templateId).toBe('rift_treasure_open');
+  });
+});

--- a/tests/rift_portals.test.ts
+++ b/tests/rift_portals.test.ts
@@ -7,8 +7,13 @@ import {
 } from '../src/sim/content/rift/items';
 import { isRiftPos, ZONES } from '../src/sim/data';
 import {
+  closeNaturalRiftPortal,
+  eligibleRiftZones,
+  RIFT_EVENT_HISTORY_LIMIT,
   RIFT_MIN_LEVEL,
+  RIFT_PORTAL_FIRST_AT,
   RIFT_PORTAL_LIFETIME,
+  RIFT_PORTAL_ZONE_CYCLE,
   RIFT_TIER_INFO,
   riftTierForZone,
   updateRiftPortals,
@@ -40,13 +45,22 @@ function tickSeconds(sim: Sim, seconds: number): SimEvent[] {
 }
 
 // Portal cadence is a scheduler concern, not an integration test for 2,400 full
-// world ticks. Move the deterministic clock to its deadline and invoke that one
-// subsystem tick directly; run gameplay ticks only where the test needs them.
+// world ticks. Move the deterministic clock to the first-spawn boundary and
+// pump the 1 Hz scheduler pass directly. The scheduler spawns AT MOST ONE
+// portal per pass (tick-budget cap), so filling the one-portal-per-zone
+// population takes one pass per eligible zone; callers that only need "a
+// portal" take naturalRiftPortals[0].
 function spawnDuePortal(sim: Sim): SimEvent[] {
-  sim.time = sim.riftPortalNextAt + 0.1;
+  sim.time = Math.max(sim.time, RIFT_PORTAL_FIRST_AT) + 0.1;
   sim.tickCount += (10 - (sim.tickCount % 20) + 20) % 20;
-  updateRiftPortals(sim.ctx);
-  return sim.drainEvents();
+  const out: SimEvent[] = [];
+  for (let pass = 0; pass <= eligibleRiftZones().length; pass++) {
+    updateRiftPortals(sim.ctx);
+    out.push(...sim.drainEvents());
+    sim.time += 1;
+    sim.tickCount += 20;
+  }
+  return out;
 }
 
 function clearRiftToBossKill(sim: Sim, inst: RiftInstance): Entity {
@@ -121,48 +135,119 @@ describe('rift ranks: zone mapping and tuning', () => {
   });
 });
 
-describe('rift portals: natural spawn scheduler', () => {
-  it('spawns a ranked portal on the cadence and announces it world-visibly', () => {
+describe('rift portals: one-per-zone rotation scheduler', () => {
+  it('fills every eligible zone at the first boundary and announces each world-visibly', () => {
     const sim = makeSim();
     expect(sim.naturalRiftPortals.length).toBe(0);
     const events = spawnDuePortal(sim);
-    expect(sim.naturalRiftPortals.length).toBe(1);
-    const p = sim.naturalRiftPortals[0];
-    const portal = sim.entities.get(p.id)!;
-    expect(portal.templateId).toBe('rift_portal');
-    expect(portal.riftTier).toBe(p.tier);
-    expect(portal.riftBaseLevel).toBe(RIFT_TIER_INFO[p.tier].baseLevel);
-    // World-visible announce (no pid) naming the rank and the zone.
-    const announce = events.find(
-      (e) => e.type === 'log' && e.text === `A ${p.tier}-rank rift tears open in ${p.zoneName}!`,
-    );
-    expect(announce).toBeDefined();
-    expect((announce as { pid?: number }).pid).toBeUndefined();
-    // The zone name is a real zone and the tier legal for it.
-    const zi = ZONES.findIndex((z) => z.name === p.zoneName);
-    expect(zi).toBeGreaterThanOrEqual(0);
+    // One portal per eligible zone, all distinct zones, in a single pass.
+    const zones = eligibleRiftZones();
+    expect(zones.length).toBe(11);
+    expect(sim.naturalRiftPortals.length).toBe(zones.length);
+    expect(new Set(sim.naturalRiftPortals.map((q) => q.zoneId)).size).toBe(zones.length);
+    for (const p of sim.naturalRiftPortals) {
+      const portal = sim.entities.get(p.id)!;
+      expect(portal.templateId).toBe('rift_portal');
+      expect(portal.riftTier).toBe(p.tier);
+      expect(portal.riftBaseLevel).toBe(RIFT_TIER_INFO[p.tier].baseLevel);
+      // World-visible announce (no pid) naming the rank and the zone.
+      const announce = events.find(
+        (e) => e.type === 'log' && e.text === `A ${p.tier}-rank rift tears open in ${p.zoneName}!`,
+      );
+      expect(announce).toBeDefined();
+      expect((announce as { pid?: number }).pid).toBeUndefined();
+      const zi = ZONES.findIndex((z) => z.name === p.zoneName);
+      expect(zi).toBeGreaterThanOrEqual(0);
+    }
   });
 
-  it('is deterministic: two same-seed sims spawn the identical portal', () => {
+  it('spawns nothing before the first-spawn warmup on a fresh world', () => {
+    const sim = makeSim();
+    sim.time = RIFT_PORTAL_FIRST_AT - 5;
+    sim.tickCount += (10 - (sim.tickCount % 20) + 20) % 20;
+    updateRiftPortals(sim.ctx);
+    expect(sim.naturalRiftPortals).toHaveLength(0);
+  });
+
+  it('the riftPortalNextAt backoff gate blocks the whole zone scan until it lapses', () => {
+    const sim = makeSim();
+    sim.time = RIFT_PORTAL_FIRST_AT + 1;
+    sim.riftPortalNextAt = sim.time + 60; // as set by a placement failure
+    sim.tickCount += (10 - (sim.tickCount % 20) + 20) % 20;
+    updateRiftPortals(sim.ctx);
+    expect(sim.naturalRiftPortals).toHaveLength(0);
+    sim.time += 61;
+    for (let pass = 0; pass <= eligibleRiftZones().length; pass++) {
+      sim.tickCount += 20;
+      updateRiftPortals(sim.ctx);
+      sim.time += 1;
+    }
+    expect(sim.naturalRiftPortals).toHaveLength(eligibleRiftZones().length);
+  });
+
+  it('spawns at most one portal per scheduler pass (tick-budget cap)', () => {
+    const sim = makeSim();
+    sim.time = RIFT_PORTAL_FIRST_AT + 0.1;
+    sim.tickCount += (10 - (sim.tickCount % 20) + 20) % 20;
+    updateRiftPortals(sim.ctx);
+    expect(sim.naturalRiftPortals).toHaveLength(1);
+    sim.tickCount += 20;
+    updateRiftPortals(sim.ctx);
+    expect(sim.naturalRiftPortals).toHaveLength(2);
+  });
+
+  it('keeps the history limit comfortably above the zone count (cadence derivation)', () => {
+    // riftZoneNextOpenAt derives each zone's boundary from the newest event of
+    // that zone; the completed-event trim must never be able to drop it.
+    expect(eligibleRiftZones().length * 2).toBeLessThan(RIFT_EVENT_HISTORY_LIMIT);
+  });
+
+  it('a sealed zone stays empty until its hourly boundary, then reopens fresh', () => {
+    const sim = makeSim();
+    spawnDuePortal(sim);
+    const first = sim.naturalRiftPortals[0];
+    const firstOpenedAt = first.openedAt;
+    // Seal it early (a first clear closes the way in).
+    sim.time = firstOpenedAt + 600;
+    closeNaturalRiftPortal(sim.ctx, first.id, 'sealed');
+    expect(sim.naturalRiftPortals.some((q) => q.zoneId === first.zoneId)).toBe(false);
+    // Before the boundary: the zone must NOT refill.
+    sim.time = firstOpenedAt + RIFT_PORTAL_ZONE_CYCLE - 5;
+    sim.tickCount += (10 - (sim.tickCount % 20) + 20) % 20;
+    updateRiftPortals(sim.ctx);
+    expect(sim.naturalRiftPortals.some((q) => q.zoneId === first.zoneId)).toBe(false);
+    // At the boundary: a FRESH event opens in the same zone.
+    sim.time = firstOpenedAt + RIFT_PORTAL_ZONE_CYCLE + 1;
+    sim.tickCount += 20;
+    updateRiftPortals(sim.ctx);
+    const reopened = sim.naturalRiftPortals.find((q) => q.zoneId === first.zoneId);
+    expect(reopened).toBeDefined();
+    expect(reopened!.eventId).not.toBe(first.eventId);
+  });
+
+  it('is deterministic: two same-seed sims spawn the identical portal population', () => {
     const a = makeSim();
     const b = makeSim();
     spawnDuePortal(a);
     spawnDuePortal(b);
-    const pa = a.naturalRiftPortals[0];
-    const pb = b.naturalRiftPortals[0];
-    expect(pa.tier).toBe(pb.tier);
-    expect(pa.zoneName).toBe(pb.zoneName);
-    expect(pa.riftName).toBe(pb.riftName);
-    const ea = a.entities.get(pa.id)!;
-    const eb = b.entities.get(pb.id)!;
-    expect(ea.pos).toEqual(eb.pos);
+    expect(a.naturalRiftPortals.length).toBe(b.naturalRiftPortals.length);
+    for (let i = 0; i < a.naturalRiftPortals.length; i++) {
+      const pa = a.naturalRiftPortals[i];
+      const pb = b.naturalRiftPortals[i];
+      expect(pa.tier).toBe(pb.tier);
+      expect(pa.zoneName).toBe(pb.zoneName);
+      expect(pa.riftName).toBe(pb.riftName);
+      const ea = a.entities.get(pa.id)!;
+      const eb = b.entities.get(pb.id)!;
+      expect(ea.pos).toEqual(eb.pos);
+    }
   });
 
   it('collapses an unclosed portal after its lifetime, with a world announce', () => {
     const sim = makeSim();
     spawnDuePortal(sim);
     const p = sim.naturalRiftPortals[0];
-    expect(Math.abs(p.expiresAt - (sim.time + RIFT_PORTAL_LIFETIME))).toBeLessThan(3);
+    expect(p.expiresAt - p.openedAt).toBe(RIFT_PORTAL_LIFETIME);
     // Fast-forward the deadline instead of ticking 15 real minutes.
     p.expiresAt = sim.time + 1;
     sim.time = p.expiresAt + 0.1;
@@ -176,6 +261,24 @@ describe('rift portals: natural spawn scheduler', () => {
         (e) => e.type === 'log' && e.text === `The ${p.tier}-rank rift in ${p.zoneName} collapses.`,
       ),
     ).toBe(true);
+  });
+
+  it('replaces a naturally expired portal in the same pass (rolling hourly cycle)', () => {
+    const sim = makeSim();
+    spawnDuePortal(sim);
+    const p = sim.naturalRiftPortals[0];
+    // At the REAL expiry (openedAt + lifetime = the zone boundary), one pass
+    // both collapses the old portal and opens the zone's next event.
+    sim.time = p.openedAt + RIFT_PORTAL_LIFETIME + 0.2;
+    sim.tickCount += (10 - (sim.tickCount % 20) + 20) % 20;
+    updateRiftPortals(sim.ctx);
+    expect(sim.entities.has(p.id)).toBe(false);
+    const replacement = sim.naturalRiftPortals.find((q) => q.zoneId === p.zoneId);
+    expect(replacement).toBeDefined();
+    expect(replacement!.eventId).not.toBe(p.eventId);
+    // Still exactly one portal per zone across the whole population.
+    const zoneIds = sim.naturalRiftPortals.map((q) => q.zoneId);
+    expect(new Set(zoneIds).size).toBe(zoneIds.length);
   });
 });
 
@@ -310,23 +413,15 @@ describe('rift portals: sealing pays Heroic Marks by rank', () => {
     const sim = makeSim();
     sim.setPlayerLevel(RIFT_MIN_LEVEL);
     sim.utcDay = '2026-07-08';
-    // Force an A-rank portal (baseLevel 25) so the gem arm triggers.
+    // Need an A- or S-rank NATURAL portal so the gem arm triggers (a dev portal
+    // would pay no progression loot at all). The one-per-zone population always
+    // contains one: most eligible zones weight A/S heavily.
     spawnDuePortal(sim);
-    // If the spawned portal is not A or S, override to A via dev command.
-    const portal0 = sim.naturalRiftPortals[0];
-    if (!portal0 || (portal0.tier !== 'A' && portal0.tier !== 'S')) {
-      // Seed a new portal at the right rank via the dev command.
-      sim.chat('/dev portal 99 25 A', sim.player.id);
-      const portalEntity = [...sim.entities.values()].find(
-        (e) => e.templateId === 'rift_portal' && e.riftSeed === 99,
-      )!;
-      sim.player.pos = { ...portalEntity.pos };
-      sim.player.prevPos = { ...portalEntity.pos };
-    } else {
-      const portalEntity = sim.entities.get(portal0.id)!;
-      sim.player.pos = { ...portalEntity.pos };
-      sim.player.prevPos = { ...portalEntity.pos };
-    }
+    const ranked = sim.naturalRiftPortals.find((q) => q.tier === 'A' || q.tier === 'S');
+    expect(ranked, 'an A/S natural portal exists in the population').toBeDefined();
+    const portalEntity = sim.entities.get(ranked!.id)!;
+    sim.player.pos = { ...portalEntity.pos };
+    sim.player.prevPos = { ...portalEntity.pos };
     sim.tick();
     const inst = sim.riftInstances.find((i) => i.partyKey !== null)!;
     expect(inst, 'entered a rift').toBeDefined();

--- a/tests/rift_race.test.ts
+++ b/tests/rift_race.test.ts
@@ -122,9 +122,9 @@ describe('shared Rift race with group-isolated dungeon instances', () => {
     // absence assertions below cannot pass vacuously.
     expect((boss.loot?.items ?? []).some((item) => item.instance?.rift !== undefined)).toBe(true);
 
-    // The loser finishes their own run: lost outcome, egress spawned, the
-    // rank-gated corpse ladder still pays, but the first-clear extras (ring,
-    // essence, gem) stay exclusive to the winner.
+    // The loser finishes their own run: lost outcome, egress spawned, but NO
+    // completion loot of any kind (no gear ladder, no sealed cache, no
+    // first-clear extras): a loser keeps only what dropped off the mobs.
     clearToBoss(sim, loserRun, loser);
     const loserBoss = sim.entities.get(loserRun.bossId!)!;
     loserBoss.dead = true;
@@ -135,6 +135,8 @@ describe('shared Rift race with group-isolated dungeon instances', () => {
     expect(loserRun.outcome).toBe('lost');
     expect(loserRun.rewarded).toBe(true);
     expect(loserRun.exitId).not.toBeNull();
+    expect(loserRun.cacheId).toBeNull(); // the sealed cache is completion loot
+    expect(winnerRun.cacheId).not.toBeNull(); // ... and the winner does get it
     expect(loserEvents).toContainEqual(
       expect.objectContaining({
         type: 'riftRaceResult',
@@ -143,8 +145,12 @@ describe('shared Rift race with group-isolated dungeon instances', () => {
         winnerNames: ['Aleph'],
       }),
     );
+    // This kill was a dead-flag stamp (no handleDeath), so any corpse item here
+    // could only have come from a completion payout: there must be NONE. The
+    // per-item negatives stay as belt and braces should normal drops ever
+    // appear on this path.
     const loserItems = loserBoss.loot?.items ?? [];
-    expect(loserItems.length).toBeGreaterThan(0);
+    expect(loserItems).toHaveLength(0);
     expect(loserItems.some((item) => item.itemId === HEROIC_MARK_ITEM_ID)).toBe(false);
     expect(loserItems.some((item) => item.instance?.rift !== undefined)).toBe(false);
     expect(loserItems.some((item) => item.itemId === RIFT_ESSENCE_ITEM_ID)).toBe(false);

--- a/tests/rift_race.test.ts
+++ b/tests/rift_race.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { HEROIC_MARK_ITEM_ID } from '../src/sim/content/dungeon_difficulty';
+import { RIFT_ESSENCE_ITEM_ID, RIFT_GEM_IDS } from '../src/sim/content/rift/items';
 import { BUILTIN_WORLD, isRiftPos } from '../src/sim/data';
 import { spawnNaturalRiftPortal } from '../src/sim/rift/portals';
 import { descendRift, updateRiftInstances } from '../src/sim/rift/runs';
@@ -69,7 +70,7 @@ describe('shared Rift race with group-isolated dungeon instances', () => {
     expect(partyRun.mobIds).not.toEqual(rivalRun.mobIds);
   });
 
-  it('atomically rewards the first clear and ejects a party already mid-run', () => {
+  it('rewards the first clear atomically while a mid-run competitor keeps playing to a lost finish', () => {
     const sim = makeSim();
     sim.utcDay = '2026-07-10';
     const winner = sim.addPlayer('warrior', 'Aleph');
@@ -98,22 +99,69 @@ describe('shared Rift race with group-isolated dungeon instances', () => {
     expect(event.firstClear?.memberIds).toEqual([winner]);
     expect(event.firstClear?.memberNames).toEqual(['Aleph']);
     expect(winnerRun.outcome).toBe('won');
-    expect(loserRun.partyKey).toBeNull();
-    expect(isRiftPos(sim.entities.get(loser)!.pos.x)).toBe(false);
     expect(events).toContainEqual(
       expect.objectContaining({ type: 'riftRaceResult', pid: winner, outcome: 'won' }),
     );
-    expect(events).toContainEqual(
-      expect.objectContaining({ type: 'riftRaceResult', pid: loser, outcome: 'lost' }),
-    );
     expect(events).toContainEqual(expect.objectContaining({ type: 'riftRaceWorld' }));
     expect(sim.entities.has(portalInfo.id)).toBe(false);
+    // The competing group is NOT torn down (maintainer decision, 2026-07-30):
+    // no eject, no teleport, run still active, no premature loss banner.
+    expect(loserRun.partyKey).not.toBeNull();
+    expect(loserRun.outcome).toBe('active');
+    expect(isRiftPos(sim.entities.get(loser)!.pos.x)).toBe(true);
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: 'riftRaceResult', pid: loser, outcome: 'lost' }),
+    );
     // Rifts pay NO Heroic Marks (maintainer decision): the win pays the gear
     // ladder and first-clear extras instead, and the corpse stays lootable.
     expect((boss.loot?.items ?? []).some((item) => item.itemId === HEROIC_MARK_ITEM_ID)).toBe(
       false,
     );
     expect((boss.loot?.items ?? []).length).toBeGreaterThan(0);
+    // The winner corpse DOES carry the first-clear payload, so the loser-side
+    // absence assertions below cannot pass vacuously.
+    expect((boss.loot?.items ?? []).some((item) => item.instance?.rift !== undefined)).toBe(true);
+
+    // The loser finishes their own run: lost outcome, egress spawned, the
+    // rank-gated corpse ladder still pays, but the first-clear extras (ring,
+    // essence, gem) stay exclusive to the winner.
+    clearToBoss(sim, loserRun, loser);
+    const loserBoss = sim.entities.get(loserRun.bossId!)!;
+    loserBoss.dead = true;
+    sim.drainEvents();
+    sim.tickCount += (20 - (sim.tickCount % 20)) % 20;
+    updateRiftInstances(sim.ctx);
+    const loserEvents = sim.drainEvents();
+    expect(loserRun.outcome).toBe('lost');
+    expect(loserRun.rewarded).toBe(true);
+    expect(loserRun.exitId).not.toBeNull();
+    expect(loserEvents).toContainEqual(
+      expect.objectContaining({
+        type: 'riftRaceResult',
+        pid: loser,
+        outcome: 'lost',
+        winnerNames: ['Aleph'],
+      }),
+    );
+    const loserItems = loserBoss.loot?.items ?? [];
+    expect(loserItems.length).toBeGreaterThan(0);
+    expect(loserItems.some((item) => item.itemId === HEROIC_MARK_ITEM_ID)).toBe(false);
+    expect(loserItems.some((item) => item.instance?.rift !== undefined)).toBe(false);
+    expect(loserItems.some((item) => item.itemId === RIFT_ESSENCE_ITEM_ID)).toBe(false);
+    expect(
+      loserItems.some((item) => (RIFT_GEM_IDS as readonly string[]).includes(item.itemId)),
+    ).toBe(false);
+
+    // Idempotent: re-observing the dead boss in a later sweep must not re-emit
+    // the race result or re-roll the corpse ladder.
+    const itemCount = loserItems.length;
+    sim.tickCount += 20;
+    updateRiftInstances(sim.ctx);
+    const repeatEvents = sim.drainEvents();
+    expect(
+      repeatEvents.some((candidate) => (candidate as { type: string }).type === 'riftRaceResult'),
+    ).toBe(false);
+    expect((loserBoss.loot?.items ?? []).length).toBe(itemCount);
   });
 
   it('ranks same-window clears by boss-death tick, not slot order', () => {
@@ -153,7 +201,12 @@ describe('shared Rift race with group-isolated dungeon instances', () => {
     expect(event.status).toBe('cleared');
     expect(event.firstClear?.memberIds).toEqual([fast]);
     expect(fastRun.outcome).toBe('won');
-    expect(slowRun.partyKey).toBeNull(); // torn down as the race loser
+    // The race loser is decided in the same sweep but keeps their instance:
+    // lost outcome, corpse loot, and an egress instead of a teardown.
+    expect(slowRun.partyKey).not.toBeNull();
+    expect(slowRun.outcome).toBe('lost');
+    expect(slowRun.rewarded).toBe(true);
+    expect(slowRun.exitId).not.toBeNull();
   });
 
   it('freezes the upgraded artifact when the first group enters', () => {

--- a/tests/server/community_rifts.test.ts
+++ b/tests/server/community_rifts.test.ts
@@ -1,3 +1,6 @@
+// The one-per-zone rift population policy (which replaced the retired
+// COMMUNITY_TEST_RIFTS public-test profile): boot restore, per-zone hourly
+// cadence derived from persisted events, tolerant load, and instance capacity.
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const riftDb = vi.hoisted(() => ({
@@ -41,28 +44,40 @@ vi.mock('../../server/db', () => ({
 }));
 
 import { GameServer } from '../../server/game';
-import { riftInstanceOrigin, riftOriginAt } from '../../src/sim/data';
+import { RIFT_SLOT_COUNT, riftInstanceOrigin, riftOriginAt } from '../../src/sim/data';
 import { serializeRiftWorldState } from '../../src/sim/rift/persistence';
 import {
   closeNaturalRiftPortal,
+  eligibleRiftZones,
+  RIFT_PORTAL_FIRST_AT,
+  RIFT_PORTAL_LIFETIME,
+  RIFT_PORTAL_ZONE_CYCLE,
   spawnNaturalRiftPortal,
   updateRiftPortals,
 } from '../../src/sim/rift/portals';
+import { RIFT_EVENT_INSTANCE_CAP } from '../../src/sim/rift/runs';
 import { Sim } from '../../src/sim/sim';
-
-type GameServerOptions = { communityTestRifts?: boolean };
-
-function makeServer(communityTestRifts = false): GameServer {
-  const Server = GameServer as unknown as new (options?: GameServerOptions) => GameServer;
-  return new Server({ communityTestRifts });
-}
 
 function runPortalScheduler(sim: Sim): void {
   sim.tickCount += (10 - (sim.tickCount % 20) + 20) % 20;
   updateRiftPortals(sim.ctx);
 }
 
-describe('community Rift boot and persistence', () => {
+// The scheduler spawns at most ONE portal per 1 Hz pass (tick-budget cap), so
+// filling or refilling the population means pumping one pass per zone.
+function pumpScheduler(sim: Sim, passes = eligibleRiftZones().length + 1): void {
+  for (let pass = 0; pass < passes; pass++) {
+    runPortalScheduler(sim);
+    sim.time += 1;
+  }
+}
+
+function fillPopulation(sim: Sim): void {
+  sim.time = Math.max(sim.time, RIFT_PORTAL_FIRST_AT) + 0.1;
+  pumpScheduler(sim);
+}
+
+describe('rift population boot and persistence (one-per-zone rotation)', () => {
   beforeEach(() => {
     riftDb.load.mockReset();
     riftDb.save.mockReset();
@@ -70,163 +85,203 @@ describe('community Rift boot and persistence', () => {
     riftDb.save.mockResolvedValue();
   });
 
-  it('fills eight distinct eligible zones, uses six-hour lifetimes, and saves immediately', async () => {
-    const server = makeServer(true);
-
+  it('fills one portal per eligible zone at the first boundary and persists the population', async () => {
+    const server = new GameServer();
     await server.loadRifts();
+    expect(server.sim.naturalRiftPortals).toHaveLength(0);
 
-    expect(server.sim.naturalRiftPortals).toHaveLength(8);
-    expect(new Set(server.sim.naturalRiftPortals.map((portal) => portal.zoneId))).toHaveLength(8);
-    for (const portal of server.sim.naturalRiftPortals) {
-      expect(portal.expiresAt - server.sim.time).toBe(6 * 60 * 60);
-    }
-    expect(server.sim.riftPortalSpawnCount).toBe(8);
-    expect(riftDb.save).toHaveBeenCalledTimes(1);
-    expect(riftDb.load.mock.invocationCallOrder[0]).toBeLessThan(
-      riftDb.save.mock.invocationCallOrder[0],
+    fillPopulation(server.sim);
+    const zoneCount = eligibleRiftZones().length;
+    expect(zoneCount).toBe(11);
+    // Literal cadence pins: the tuning itself is load-bearing (rolling
+    // replacement only works while the cycle equals the lifetime).
+    expect(RIFT_PORTAL_LIFETIME).toBe(60 * 60);
+    expect(RIFT_PORTAL_ZONE_CYCLE).toBe(RIFT_PORTAL_LIFETIME);
+    expect(RIFT_PORTAL_FIRST_AT).toBe(120);
+    expect(server.sim.naturalRiftPortals).toHaveLength(zoneCount);
+    expect(new Set(server.sim.naturalRiftPortals.map((portal) => portal.zoneId)).size).toBe(
+      zoneCount,
     );
+    for (const portal of server.sim.naturalRiftPortals) {
+      expect(portal.expiresAt - portal.openedAt).toBe(RIFT_PORTAL_ZONE_CYCLE);
+    }
+    expect(server.sim.riftPortalSpawnCount).toBe(zoneCount);
+
+    await server.saveRifts();
+    expect(riftDb.save).toHaveBeenCalledTimes(1);
     expect(riftDb.save.mock.calls[0][0]).toEqual(
       expect.objectContaining({
         version: 1,
-        spawnCount: 8,
+        spawnCount: zoneCount,
         events: expect.arrayContaining([expect.objectContaining({ status: 'open' })]),
       }),
     );
   });
 
-  it('preserves overlapping persisted events while filling eight distinct regions', async () => {
+  it('derives each zone cadence from persisted events across a restart', async () => {
+    // Source realm: full population, then one zone first-cleared (sealed) early.
     const source = new Sim({
       seed: 20061,
       playerClass: 'warrior',
       noPlayer: true,
       riftPortals: true,
     });
-    expect(spawnNaturalRiftPortal(source.ctx, 0)).toBe(true);
-    const persistedEventId = source.riftEvents[0].eventId;
-    const saved = serializeRiftWorldState(source.ctx, Date.now());
-    const duplicate = structuredClone(saved.events[0]);
-    duplicate.eventId = `${persistedEventId}-dupe`;
-    duplicate.ordinal = 1;
-    saved.events.push(duplicate);
-    saved.spawnCount = 2;
-    riftDb.load.mockResolvedValueOnce(saved);
+    fillPopulation(source);
+    const sealed = source.naturalRiftPortals[0];
+    const sealedZoneId = sealed.zoneId;
+    const sealedOpenedAt = sealed.openedAt;
+    source.time = sealedOpenedAt + 600;
+    closeNaturalRiftPortal(source.ctx, sealed.id, 'sealed');
+    const sealedEvent = source.riftEvents.find((event) => event.eventId === sealed.eventId)!;
+    sealedEvent.status = 'cleared'; // production seal always follows the claim
+    // Serialize against the real host clock: GameServer.loadRifts restores with
+    // Date.now(), so a synthetic past timestamp would read as days of downtime
+    // and collapse every event before it loads.
+    riftDb.load.mockResolvedValueOnce(serializeRiftWorldState(source.ctx, Date.now()));
 
-    const server = makeServer(true);
+    // Restarted realm, restored from the same wall-clock instant.
+    const server = new GameServer();
     await server.loadRifts();
+    const sim = server.sim;
+    const zoneCount = eligibleRiftZones().length;
+    expect(sim.naturalRiftPortals).toHaveLength(zoneCount - 1);
+    expect(sim.naturalRiftPortals.some((portal) => portal.zoneId === sealedZoneId)).toBe(false);
 
-    expect(server.sim.naturalRiftPortals).toHaveLength(9);
-    expect(new Set(server.sim.naturalRiftPortals.map((portal) => portal.zoneId))).toHaveLength(8);
-    expect(server.sim.riftEvents.some((event) => event.eventId === persistedEventId)).toBe(true);
-    expect(server.sim.riftEvents.some((event) => event.eventId === duplicate.eventId)).toBe(true);
+    // The sealed zone must NOT reopen before its original hourly boundary,
+    // which sits CYCLE minus already-elapsed sim-seconds after the restart
+    // (loadRiftWorldState shifts openedAt into the past to absorb downtime).
+    const elapsedAtSave = source.time - sealedOpenedAt;
+    const boundary = RIFT_PORTAL_ZONE_CYCLE - elapsedAtSave;
+    sim.time = boundary - 5;
+    runPortalScheduler(sim);
+    expect(sim.naturalRiftPortals.some((portal) => portal.zoneId === sealedZoneId)).toBe(false);
+
+    sim.time = boundary + 5;
+    pumpScheduler(sim, zoneCount + 12);
+    const reopened = sim.naturalRiftPortals.find((portal) => portal.zoneId === sealedZoneId);
+    expect(reopened).toBeDefined();
+    expect(reopened!.eventId).not.toBe(sealed.eventId);
+    // The boundary window retires and replaces every restored sibling portal
+    // too, so the population is whole again with one portal per zone.
+    expect(new Set(sim.naturalRiftPortals.map((portal) => portal.zoneId)).size).toBe(zoneCount);
   });
 
-  it('waits sixty seconds and restores only one missing portal per interval', async () => {
-    const server = makeServer(true);
+  it('clamps an oversized legacy nextPortalAtMs so the upgrade boot cannot starve spawns', async () => {
+    // Before the rotation policy, nextPortalAtMs was the 2-4 h natural spawn
+    // deadline; the live prod row holds such a value at upgrade time. Loading
+    // it into the new backoff gate unclamped would silence every zone for
+    // hours.
+    riftDb.load.mockResolvedValueOnce({
+      version: 1,
+      savedAtMs: Date.now(),
+      spawnCount: 1,
+      nextPortalAtMs: Date.now() + 3 * 60 * 60 * 1000,
+      events: [],
+    });
+    const server = new GameServer();
     await server.loadRifts();
-    const closed = server.sim.naturalRiftPortals.slice(0, 2);
-    expect(closed).toHaveLength(2);
-
-    for (const portal of closed) closeNaturalRiftPortal(server.sim.ctx, portal.id, 'sealed');
-    expect(server.sim.naturalRiftPortals).toHaveLength(6);
-
-    server.sim.time += 59;
-    runPortalScheduler(server.sim);
-    expect(server.sim.naturalRiftPortals).toHaveLength(6);
-
-    server.sim.time += 1;
-    runPortalScheduler(server.sim);
-    expect(server.sim.naturalRiftPortals).toHaveLength(7);
-    expect(server.sim.riftPortalSpawnCount).toBe(9);
-
-    server.sim.time += 60;
-    runPortalScheduler(server.sim);
-    expect(server.sim.naturalRiftPortals).toHaveLength(8);
-    expect(new Set(server.sim.naturalRiftPortals.map((portal) => portal.zoneId))).toHaveLength(8);
-    expect(server.sim.riftPortalSpawnCount).toBe(10);
+    const sim = server.sim;
+    expect(sim.riftPortalNextAt - sim.time).toBeLessThanOrEqual(60);
+    sim.time = Math.max(sim.time, RIFT_PORTAL_FIRST_AT) + 61;
+    pumpScheduler(sim);
+    expect(sim.naturalRiftPortals).toHaveLength(eligibleRiftZones().length);
   });
 
-  it('does not consume the shared simulation RNG while filling the community population', async () => {
-    const community = makeServer(true);
-    const normal = makeServer(false);
-
-    await community.loadRifts();
-
-    expect(community.sim.rng.next()).toBe(normal.sim.rng.next());
+  it('does not consume the shared simulation RNG while filling the population', async () => {
+    const filled = new GameServer();
+    await filled.loadRifts();
+    fillPopulation(filled.sim);
+    const idle = new GameServer();
+    expect(filled.sim.rng.next()).toBe(idle.sim.rng.next());
   });
 
-  it('fails community boot on a Rift load or immediate-save failure', async () => {
-    const loadFailure = new Error('rift db unavailable');
-    riftDb.load.mockRejectedValueOnce(loadFailure);
-    await expect(makeServer(true).loadRifts()).rejects.toBe(loadFailure);
-    expect(riftDb.save).not.toHaveBeenCalled();
-
-    riftDb.load.mockResolvedValueOnce(null);
-    const saveFailure = new Error('rift db write unavailable');
-    riftDb.save.mockRejectedValueOnce(saveFailure);
-    await expect(makeServer(true).loadRifts()).rejects.toBe(saveFailure);
-  });
-
-  it('rejects unsupported persisted state without replacing it', async () => {
-    riftDb.load.mockResolvedValueOnce({ version: 99, events: [] });
-
-    await expect(makeServer(true).loadRifts()).rejects.toThrow(
-      'unsupported or malformed shared Rift state',
-    );
-    expect(riftDb.save).not.toHaveBeenCalled();
-  });
-
-  it('keeps production failure handling and capacity unchanged when the flag is off', async () => {
+  it('tolerates a rift load failure and still fills a fresh population', async () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {});
     const loadFailure = new Error('rift db unavailable');
     riftDb.load.mockRejectedValueOnce(loadFailure);
-    const server = makeServer(false);
+    const server = new GameServer();
 
     await expect(server.loadRifts()).resolves.toBeUndefined();
-    expect(server.sim.naturalRiftPortals).toHaveLength(0);
-    expect(server.sim.riftInstances).toHaveLength(8);
-    expect(riftDb.save).not.toHaveBeenCalled();
     expect(error).toHaveBeenCalledWith('failed to load shared Rift state:', loadFailure);
+    expect(server.sim.naturalRiftPortals).toHaveLength(0);
+    fillPopulation(server.sim);
+    expect(server.sim.naturalRiftPortals).toHaveLength(eligibleRiftZones().length);
     error.mockRestore();
+  });
+
+  it('treats unsupported persisted state as a fresh world instead of failing boot', async () => {
+    riftDb.load.mockResolvedValueOnce({ version: 99, events: [] });
+    const server = new GameServer();
+    await expect(server.loadRifts()).resolves.toBeUndefined();
+    expect(server.sim.naturalRiftPortals).toHaveLength(0);
+    expect(riftDb.save).not.toHaveBeenCalled();
   });
 });
 
-describe('community Rift instance capacity', () => {
-  it('allocates twenty-four slots and maps the final slot back to its own origin', () => {
-    const sim = new Sim({
-      seed: 99221,
-      playerClass: 'warrior',
-      noPlayer: true,
-      riftPortals: true,
-      communityRifts: true,
-    } as ConstructorParameters<typeof Sim>[0]);
-
-    expect(sim.riftInstances).toHaveLength(24);
-    const finalOrigin = riftInstanceOrigin(23, 0);
+describe('rift instance capacity', () => {
+  it('allocates the full slot pool and maps the final slot back to its own origin', () => {
+    const sim = new Sim({ seed: 99221, playerClass: 'warrior', noPlayer: true, riftPortals: true });
+    // Literal pins: the pool and cap values are the tuning under test, so a
+    // silent constant change must fail here, not just shift both sides.
+    expect(RIFT_SLOT_COUNT).toBe(64);
+    expect(RIFT_EVENT_INSTANCE_CAP).toBe(32);
+    expect(sim.riftInstances).toHaveLength(RIFT_SLOT_COUNT);
+    const finalOrigin = riftInstanceOrigin(RIFT_SLOT_COUNT - 1, 0);
     expect(riftOriginAt(finalOrigin.z)).toEqual(finalOrigin);
   });
 
-  it('admits twenty-four solo groups and rejects the twenty-fifth cleanly', () => {
-    const sim = new Sim({
-      seed: 77441,
-      playerClass: 'warrior',
-      noPlayer: true,
-      riftPortals: true,
-      communityRifts: true,
-    } as ConstructorParameters<typeof Sim>[0]);
-    const pids = Array.from({ length: 25 }, (_, index) =>
-      sim.addPlayer('warrior', `Rifter${String.fromCharCode(65 + index)}`),
+  it('admits solo groups up to the per-event cap and rejects the next cleanly', () => {
+    const sim = new Sim({ seed: 77441, playerClass: 'warrior', noPlayer: true, riftPortals: true });
+    const pids = Array.from({ length: RIFT_EVENT_INSTANCE_CAP + 1 }, (_, index) =>
+      sim.addPlayer('warrior', `Rifter${index}`),
     );
 
-    for (const pid of pids.slice(0, 24)) sim.enterRift(424242, 20, pid);
-    expect(sim.riftInstances.filter((instance) => instance.partyKey !== null)).toHaveLength(24);
+    for (const pid of pids.slice(0, RIFT_EVENT_INSTANCE_CAP)) sim.enterRift(424242, 20, pid);
+    expect(sim.riftInstances.filter((instance) => instance.partyKey !== null)).toHaveLength(
+      RIFT_EVENT_INSTANCE_CAP,
+    );
 
     sim.drainEvents();
-    sim.enterRift(424242, 20, pids[24]);
-    expect(sim.riftInstances.some((instance) => instance.memberIds.has(pids[24]))).toBe(false);
+    const overflow = pids[RIFT_EVENT_INSTANCE_CAP];
+    sim.enterRift(424242, 20, overflow);
+    expect(sim.riftInstances.some((instance) => instance.memberIds.has(overflow))).toBe(false);
     expect(sim.drainEvents()).toContainEqual(
       expect.objectContaining({
         type: 'error',
-        pid: pids[24],
+        pid: overflow,
+        text: 'All rifts are unstable right now. Try again soon.',
+      }),
+    );
+  });
+
+  it('caps a natural PORTAL event the same way, with free slots remaining', () => {
+    const sim = new Sim({ seed: 77441, playerClass: 'warrior', noPlayer: true, riftPortals: true });
+    expect(spawnNaturalRiftPortal(sim.ctx, 0)).toBe(true);
+    const info = sim.naturalRiftPortals[0];
+    const portal = sim.entities.get(info.id)!;
+    const pids = Array.from({ length: RIFT_EVENT_INSTANCE_CAP + 1 }, (_, index) => {
+      const pid = sim.addPlayer('warrior', `Walker${index}`);
+      sim.setPlayerLevel(20, pid);
+      return pid;
+    });
+    for (const pid of pids.slice(0, RIFT_EVENT_INSTANCE_CAP)) {
+      sim.enterRift(portal.riftSeed!, portal.riftBaseLevel!, pid, undefined, portal);
+    }
+    const eventRuns = sim.riftInstances.filter(
+      (instance) => instance.partyKey !== null && instance.eventId === info.eventId,
+    );
+    expect(eventRuns).toHaveLength(RIFT_EVENT_INSTANCE_CAP);
+    // The pool still has headroom: the denial below is provably the EVENT cap.
+    expect(sim.riftInstances.some((instance) => instance.partyKey === null)).toBe(true);
+
+    sim.drainEvents();
+    const overflow = pids[RIFT_EVENT_INSTANCE_CAP];
+    sim.enterRift(portal.riftSeed!, portal.riftBaseLevel!, overflow, undefined, portal);
+    expect(sim.riftInstances.some((instance) => instance.memberIds.has(overflow))).toBe(false);
+    expect(sim.drainEvents()).toContainEqual(
+      expect.objectContaining({
+        type: 'error',
+        pid: overflow,
         text: 'All rifts are unstable right now. Try again soon.',
       }),
     );

--- a/tests/server/http/config.test.ts
+++ b/tests/server/http/config.test.ts
@@ -203,17 +203,11 @@ describe('loadConfig', () => {
     );
   });
 
-  it('parses COMMUNITY_TEST_RIFTS strictly and defaults it off', () => {
-    expect(loadConfig({ ...MIN_ENV }).communityTestRifts).toBe(false);
-    expect(loadConfig({ ...MIN_ENV, COMMUNITY_TEST_RIFTS: '1' }).communityTestRifts).toBe(true);
-    expect(loadConfig({ ...MIN_ENV, COMMUNITY_TEST_RIFTS: 'true' }).communityTestRifts).toBe(true);
-    expect(loadConfig({ ...MIN_ENV, COMMUNITY_TEST_RIFTS: '0' }).communityTestRifts).toBe(false);
-    expect(loadConfig({ ...MIN_ENV, COMMUNITY_TEST_RIFTS: 'FALSE' }).communityTestRifts).toBe(
-      false,
-    );
-    expect(() => loadConfig({ ...MIN_ENV, COMMUNITY_TEST_RIFTS: 'yes' })).toThrow(
-      /COMMUNITY_TEST_RIFTS/,
-    );
+  it('ignores the retired COMMUNITY_TEST_RIFTS flag entirely', () => {
+    // The dense rift population is the one policy on every host now; a stale
+    // host .env value must neither throw nor surface on the config object.
+    const config = loadConfig({ ...MIN_ENV, COMMUNITY_TEST_RIFTS: 'yes' });
+    expect('communityTestRifts' in config).toBe(false);
   });
 
   it('reads the numeric and string overrides', () => {


### PR DESCRIPTION
## Summary

Reworks rift availability and instancing after the first prod portal (2026-07-30) surfaced the instance-split problem: party members who entered a rift without a live shared party key were split into separate racing instances, and everyone arriving later found either no portal or a drained 8-slot pool. This PR implements the agreed design: dense availability, WoW-raid-style binding, clean-run merging, and no competitor teardown. Targets release/v0.32.1.

### Availability: one rift per zone, hourly rotation
- Every eligible zone (all 11) keeps one open portal. A zone's next rift opens exactly one cycle (1 h) after the previous one OPENED: an uncleared portal collapses and is replaced immediately, a first-cleared (sealed) zone stays empty until its boundary, so a cleared rift can never be instantly refarmed.
- Tier stays the per-zone weighted random roll; no caps on tiers.
- The cadence is derived from the persisted event history, so restarts and deploys preserve it with NO persistence schema change.
- The scheduler spawns at most ONE portal per 1 Hz pass: a full 11-zone fill in a single tick measured 223 ms against the 50 ms budget, so fills spread over consecutive seconds instead.
- `COMMUNITY_TEST_RIFTS` is retired end to end (config, compose, .env.example, DEPLOY.md, docs): the dense population is now the one policy on every host, so PBE tests exactly what prod runs. A stale value in a host .env is ignored.

### Capacity
- Instance pool: 8 (24 community) to 64 physical slots; per-event cap of 32.
- The cap counts SLOT OCCUPANCY (decided-but-open runs included), so one hyped portal cannot drain the global pool.

### Binding and clean-run recycling (the actual fix for the player reports)
- The first mob kill, or plundering the hidden cache, marks a run PROGRESSED.
- A progressed run binds its members: they are always routed back into their own run and can never land in a sibling instance of the same rift, whatever their party does; anyone who enters a progressed run becomes bound to it (mid-run replacement invites work).
- Unspoiled runs are disposable: players who entered independently and then group up have their clean leftovers recycled and share one run. This closes every split flow reproduced during the diagnosis (enter-before-group, pending invite at entry, party disband + reinvite).
- Never recycled: runs with players still inside, and zero-kill wipes whose dead members are owed a corpse run.

### Race: losers finish their run, with NO completion loot
- One group's first clear no longer tears down other groups' in-progress attempts. A losing run plays to its own boss kill: outcome lost, riftRaceResult banner, and an egress home.
- A loser pays NOTHING at completion: no clear-time gear ladder, no sealed cache, no first-clear extras. Everything a loser walks out with came off the mobs (or a mid-run treasure chest) the normal way.
- First-clear extras stay winner-exclusive: personal ring, essence, gem, the world banner, the sealed cache, and the portal seal.

### Migration safety
- `loadRiftWorldState` clamps the legacy `nextPortalAtMs` (previously a 2-4 h spawn deadline; the live prod row holds such a value) to the new 60 s backoff, so the first boot after this deploys cannot starve every zone for hours.

## Testing
- New `tests/rift_binding.test.ts` (10 tests): merge/recycle flows, kill and chest binding, occupied-leftover and dead-member recycle negatives, progress-survives-descent.
- `tests/rift_portals.test.ts` rewritten for the rotation policy (18 tests): per-zone fill, boundary semantics, warmup and backoff negatives, one-spawn-per-pass cap, determinism, history-limit guard.
- `tests/server/community_rifts.test.ts` now covers the unified policy: boot fill, restart cadence derivation, legacy nextPortalAtMs clamp, tolerant load, capacity literals (64/32) on both the dev-seed and natural-portal arms.
- `tests/rift_race.test.ts` pins the no-eject semantics, the loser's zero-completion-loot corpse and missing cache against the winner's populated ones, and sweep idempotency.
- Full gate PASS (all 11 steps); parity goldens green (portal streams are seed+ordinal derived and never touch the shared rng); architecture and i18n guards green; read-only architecture-review and test-coverage-audit passes run on the diff, with every should-fix addressed.

## Test plan
- [ ] Deploy to QA; confirm 11 portals fill within ~2.5 min of boot, one per zone, announced world-visibly
- [ ] Clear a rift first as group A while group B is mid-run: B keeps playing, completes as lost with an egress, no cache, and only mob drops
- [ ] Enter solo, exit, party up, re-enter together: one shared instance
- [ ] Kill one mob solo, exit, party up, re-enter: both land in the original (bound) run
- [ ] Restart the server mid-hour: open portals restored, sealed zone still waits for its boundary
- [ ] First prod boot after deploy: portals appear within ~2 min despite the legacy nextPortalAtMs row

## Known debt (deliberate, follow-ups)
- Orphaned i18n matcher and key `sim.rift.raceLost` from the removed eject line (retire in a locale pass).
- `tests/server/community_rifts.test.ts` filename is now a misnomer (it tests the rotation policy).
- Rift discovery is still proximity-only (90 yd) plus one chat line; a map/minimap marker is a separate feature.