### PR TITLE
fix(sim,render): Last Keep terrace stuck-spots and backward stairs

### DIFF
--- a/src/render/castle_features.ts
+++ b/src/render/castle_features.ts
@@ -71,6 +71,11 @@ export const castleFeaturesPreloadInternalsForTest = {
 /** world scale for the wall modules: the KayKit wall is 4 units long */
 const S = CASTLE.module / 4; // 1.75
 
+// How far south (+z, toward the bailey) the ward stair-cut mesh sits off the
+// terrace edge so its high back does not clip into the terrace face. Cosmetic
+// only: the walkable ramp wedge is unchanged.
+const WARD_STEP_MESH_PUSH = 0.5;
+
 interface Placement {
   x: number;
   y: number;
@@ -401,11 +406,19 @@ export function buildCastleFeatures(): CastleFeaturesView {
     // leaves the cuts out with the rest of the ward, so this carries them)
     for (const cut of WARD_STEPS) {
       const cx = (cut.x0 + cut.x1) / 2;
+      // kcasStairsWide climbs toward -z at rot 0 (the wall-flight foot treads
+      // below set the convention: rot PI climbs +z, -PI/2 climbs +x). This cut
+      // rises from the bailey at z1+run UP to the terrace at z1, i.e. toward -z,
+      // so the tread faces must point -z; the authored PI had the whole flight
+      // reversed (players read the steps as leading the wrong way off the
+      // terrace). The wedge below is symmetric, so only the mesh yaw was wrong.
+      // Nudged a touch south (+z, toward the bailey) off the terrace edge so the
+      // flight's high back no longer buries itself in the terrace face.
       put('kcasStairsWide', {
         x: cx,
         y: padY,
-        z: w.z1 + WARD_STEP_RUN / 2,
-        rot: Math.PI,
+        z: w.z1 + WARD_STEP_RUN / 2 + WARD_STEP_MESH_PUSH,
+        rot: 0,
         s: 0.62,
       });
       const z0 = w.z1;

--- a/src/sim/player_motion.ts
+++ b/src/sim/player_motion.ts
@@ -198,8 +198,20 @@ export function stepPlayerMotion(deps: PlayerMotionDeps, p: Entity, inp: MoveInp
   // Steepness is of the RIDDEN surface (submerged ground clamps to the
   // waterline), so an uneven lake bed never strips control from a wader and
   // slides it back into deep water.
-  const steepGround =
+  //
+  // The steepness gate reads a 1-yard-CELL memo (rideSteepnessAt rounds to the
+  // cell): a level point one step from a sheer riser inherits the cell's slope
+  // and reads steep though the ground under the feet is flat. Stripping control
+  // off that alone froze the body against the riser base, input disabled and no
+  // downhill to slide off (players stuck all along the Last Keep's west terrace
+  // edge). So the control strip also requires an ACTUAL downhill, sampled at the
+  // EXACT position (terrainDownhill): genuinely steep ground still strips
+  // control and slides, but a flat shoulder the cell memo over-reads keeps
+  // control, and the wall/contour gate below still refuses the climb.
+  const steepFlagged =
     p.onGround && !swimming && rideSteepnessAt(p.pos.x, p.pos.z, deps.seed) > MAX_CLIMB_SLOPE;
+  const steepSlide = steepFlagged ? terrainDownhill(p.pos.x, p.pos.z, deps.seed) : null;
+  const steepGround = steepSlide !== null;
   // Move-to-cancel: any movement input during a summon channel cancels the cast.
   // Dismount channels (mountCastKey === '') remain fully rooted (handled by mountLocked below).
   if (p.mountCastRemaining > 0 && p.mountCastKey !== '' && hasMoveInput) {
@@ -249,7 +261,7 @@ export function stepPlayerMotion(deps: PlayerMotionDeps, p: Entity, inp: MoveInp
   // Also what lets a jump STARTED in place drift forward, and a fall off a
   // ledge stay steerable, instead of the old frozen-at-takeoff trajectory.
   const airSteering = moving && !p.onGround && !swimming;
-  const slide = steepGround ? terrainDownhill(p.pos.x, p.pos.z, deps.seed) : null;
+  const slide = steepSlide;
   if (slide || movingOnGround || airSteering || (!p.onGround && (p.vx !== 0 || p.vz !== 0))) {
     if (slide && p.castingAbility) deps.cancelCast(p);
     if (airSteering) {

--- a/tests/last_keep_flank_traps.test.ts
+++ b/tests/last_keep_flank_traps.test.ts
@@ -348,4 +348,25 @@ describe('the Last Keep flanks hold no wedge pockets', () => {
       expect(p.pos.y, 'stays on the terrace').toBeGreaterThan(CASTLE.ward.h - 0.4);
     }
   });
+
+  it('never freezes a walker pressed into the ward terrace retaining edge', () => {
+    // The ward terrace's faces are sheer 2.6yd risers. The steepness gate reads
+    // a 1-yard-cell memo, so the flat bailey ground one step out from the west
+    // face inherits the cell's slope and reads as steep. That alone used to strip
+    // movement control while the exact-position downhill was flat (nothing to
+    // slide off), trapping the body at the base with input disabled: players were
+    // stuck all along the west edge and had to /unstuck. A walker pressed into
+    // the edge must be REFUSED the climb yet still free to walk back off it.
+    for (const z of [2000, 2005, 2010, 2015]) {
+      const { sim, p, meta } = makeWalker({ x: 395, z });
+      pushToward(sim, p, meta, { x: 404, z }, 20 * 3); // press east into the face
+      const pinnedX = p.pos.x;
+      expect(pinnedX, `refused the sheer west face at z=${z}`).toBeLessThan(CASTLE.ward.x0);
+      pushToward(sim, p, meta, { x: 384, z }, 20 * 3); // now try to walk back west
+      expect(
+        pinnedX - p.pos.x,
+        `walks back off the west edge instead of freezing at z=${z}`,
+      ).toBeGreaterThan(3);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Two fixes for the Last Keep (The Drakelands):

- **Players get stuck all around the raised platform (the inner ward terrace).** The steep-ground control gate reads the 1-yard-cell steepness memo (`rideSteepnessAt` rounds to the cell), so flat bailey ground one step out from the terrace's sheer retaining edge inherits the cell's slope and reads as "too steep." That disabled movement input with no downhill to slide off, freezing players in place along the platform's west face (reproduced at the live realm seed). The control strip now also requires an actual `terrainDownhill` sampled at the exact position: genuinely steep ground still slides you, but a flat shoulder the cell memo over-reads keeps control while the wall gate still refuses the climb. This clears the freeze along the whole edge, not just one spot.
- **The terrace stairs faced the wrong way and clipped the terrace.** The ward stair-cut mesh was yawed `rot: Math.PI` (climbing +z), but the cut rises toward -z, so the steps read as leading the wrong way off the terrace. Flipped to `rot: 0` per the wall-flight convention already in the file, and nudged the flight a touch south (`WARD_STEP_MESH_PUSH`) so its high back stops burying into the terrace face. Cosmetic only: the walkable ramp wedge is unchanged.

Scoped to those two issues. A separate, pre-existing knife-edge fall-through at the terrace's south lip (a player standing exactly on the sharp cliff line drops) is left for a follow-up.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/last_keep_flank_traps.test.ts` (added a decisive regression: a walker pressed into the terrace edge must be refused the climb yet still free to walk away; it fails without the fix and passes with it)
  - `npx vitest run tests/player_motion.test.ts tests/self_motion.test.ts` (movement client/server parity)
  - `npx vitest run tests/parity/ tests/architecture.test.ts` (golden-trace rng-draw-order plus determinism and sim purity)
  - the full movement, Last Keep, climb, and physics suites, `tsc --noEmit`, and biome on the changed files
  - `npm run gate` green on the v0.32.0 base with identical changes; after rebasing onto `release/v0.32.1` I re-verified `tsc` and the sim, movement, and Last Keep suites (CI runs the full gate here)
- Manual steps: playtested offline at the Last Keep (`/dev tp 397 2005` for the west edge, `/dev tp 405 2020` for the stairs). Confirmed in game that the getting-stuck is fixed and the stairs now face the right way.

## Screenshots / recordings

The stair change is cosmetic and was confirmed in game (facing corrected, plus a small outward nudge so it stops clipping the terrace face). The movement fix is not a visual change. Formal before and after captures can be added on request; flagged here rather than blocking the fix.

## Checklist

- [x] Decisive tests added for the changed behavior (the freeze regression fails without the fix).
- [x] Determinism and client/server movement parity verified (golden-trace and `player_motion`/`self_motion`).
- [x] No layout change to the town; the fix is the movement kernel plus a cosmetic mesh yaw/offset.

Generated with Claude Code (https://claude.com/claude-code)
