### PR TITLE
fix(sim): stop slain summoned adds respawning where they erupted (Deeprock Diggers in Eastbrook town)

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -1250,6 +1250,7 @@ function blankEntity(id: number): Entity {
     detonateTimer: Infinity,
     firedSummons: 0,
     summonedIds: [],
+    summonedAdd: false,
     enraged: false,
     healedThisPull: false,
     threat: new Map(),

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -342,6 +342,10 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
     armorPerLevel: 24,
     moveSpeed: 7,
     aggroRadius: 13,
+    // Hard tether: the Tunnelking fights on his own ground. Kiting him past 50
+    // yards of his spawn (the town square is 100+) sends him home to a full
+    // reset, adds swept with him.
+    hardLeashRadius: 50,
     aoePulse: { min: 12, max: 18, radius: 8, every: 9, name: 'Cave-In', school: 'physical' },
     summonAdds: { mobId: 'tunnel_rat', count: 2, atHpPct: [0.55, 0.3] },
     enrage: { belowHpPct: 0.3, dmgMult: 1.4, hasteMult: 1.3 },

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -159,6 +159,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     warcryTimer: 0,
     firedSummons: 0,
     summonedIds: [],
+    summonedAdd: false,
     enraged: false,
     healedThisPull: false,
     threat: new Map(),

--- a/src/sim/mob/combat_profile.ts
+++ b/src/sim/mob/combat_profile.ts
@@ -62,6 +62,18 @@ export function updateMobCombatProfile(
   if (ctx.maybeFlee(mob, target)) return 'done';
 
   if (profile.canLeash) {
+    // The hard tether measures from the SPAWN, never the refreshing anchor,
+    // and ignores the flee-recovery grace: past it the mob goes home, however
+    // the fight has been dragged. Checked before the soft leash so a tethered
+    // mob can never be walked out one anchor-refresh at a time.
+    const hardLeash = MOBS[mob.templateId]?.hardLeashRadius;
+    if (hardLeash !== undefined && dist2d(mob.pos, mob.spawnPos) > hardLeash) {
+      mob.aiState = 'evade';
+      mob.aggroTargetId = null;
+      clearThreat(mob);
+      mob.leashAnchor = null;
+      return 'done';
+    }
     const leash = mob.spawnPos.x > DUNGEON_X_THRESHOLD ? DUNGEON_LEASH_DISTANCE : LEASH_DISTANCE;
     const leashAnchor = mob.leashAnchor ?? mob.spawnPos;
     if (mob.fleeReturnTimer > 0) {

--- a/src/sim/mob/locomotion.ts
+++ b/src/sim/mob/locomotion.ts
@@ -123,6 +123,16 @@ export function updateMob(ctx: SimContext, mob: Entity): void {
     }
     // dungeon mobs stay dead until the instance resets
     const isInstanceMob = mob.spawnPos.x > DUNGEON_X_THRESHOLD;
+    // A slain summoned add unravels once its corpse decays, like the summoned
+    // demon above, rather than respawning into the wild: its spawnPos is
+    // wherever its summoner stood when the wave erupted (a kited boss hatches
+    // adds far from any camp, e.g. Grix dragged to the Eastbrook town square),
+    // and the only other cleanup is despawnSummonedAdds on the summoner's own
+    // respawn, hours away for a rare. The corpse keeps its full loot window.
+    if (!isInstanceMob && mob.summonedAdd) {
+      if (mob.corpseTimer <= 0) ctx.dropEntity(mob.id);
+      return;
+    }
     // Corpse-decay window (classic-faithful, issue #1539): an in-place respawn
     // reuses this entity id and respawnMob wipes the loot, so while the corpse is
     // still lootable the respawn is DEFERRED until its corpse timer elapses. The

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -7318,6 +7318,9 @@ export class Sim {
       // ever swinging. Kited from here, the chase-case leash check walks it back to
       // this eruption point, not the boss's distant home.
       add.tappedById = boss.tappedById;
+      // Slain adds unravel with their corpse (mob/locomotion.ts) rather than
+      // respawning at the eruption point, which is wherever the fight dragged.
+      add.summonedAdd = true;
       this.addEntity(add);
       boss.summonedIds.push(add.id);
       inst?.mobIds.push(add.id);

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1159,6 +1159,12 @@ export interface MobTemplate {
   armorPerLevel: number;
   moveSpeed: number;
   aggroRadius: number; // base, at equal level
+  // Hard tether (yards from spawnPos): past it the mob evades home to a full
+  // reset, whatever its refreshing leashAnchor says. The soft leash measures
+  // from an anchor every hostile action re-seeds, so a patient player can walk
+  // an ordinary mob across the map one leash-length at a time; a mob carrying
+  // this cannot be kited off its ground (mob/combat_profile.ts).
+  hardLeashRadius?: number;
   loot: LootEntry[];
   scale: number; // render hint
   color: number; // render hint

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -3344,6 +3344,11 @@ export interface Entity extends ClientMirroredEntityFields {
   warcryTimer: number; // warcry ally-haste pulse countdown
   firedSummons: number; // summonAdds thresholds already triggered
   summonedIds: number[]; // live adds this boss summoned; despawned on reset
+  // Server-local (never on the wire; blankEntity keeps host shapes identical):
+  // true for a mob spawnBossAdds erupted beside its summoner. A slain add
+  // unravels with its corpse instead of respawning at its eruption point,
+  // which is wherever the fight dragged (see mob/locomotion.ts).
+  summonedAdd: boolean;
   enraged: boolean; // enrage mechanic active
   // Heroic-instance mechanic scaling (instances/difficulty.ts applyDungeonMobTuning).
   // Mechanic numbers (aoePulse/bigCast/stomp damage; mendAlly/wardAllies/stoneskin

--- a/tests/mob_hard_leash.test.ts
+++ b/tests/mob_hard_leash.test.ts
@@ -1,0 +1,124 @@
+// The hard tether (MobTemplate.hardLeashRadius): a mob carrying it evades home
+// the moment it is dragged further than the tether from its SPAWN, whatever its
+// refreshing leashAnchor says. The ordinary soft leash measures from an anchor
+// that every hostile action re-seeds, which is exactly what lets a patient
+// player walk a mob across the map one leash-length at a time; the tether makes
+// the marked mob unkiteable. Grix the Tunnelking carries it so his add waves
+// can never be dragged to town in the first place.
+
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_WORLD, MOBS, setActiveWorldContent } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import { Sim } from '../src/sim/sim';
+import type { WorldContent } from '../src/sim/types';
+
+const SEED = 42;
+const HOME = { x: -95, z: -78 };
+
+function makeWorld(): Sim {
+  const world: WorldContent = {
+    ...BUILTIN_WORLD,
+    camps: [],
+    npcs: {},
+    groundObjects: [],
+  };
+  setActiveWorldContent(world);
+  const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true, world });
+  const pid = sim.addPlayer('warrior', 'Kiter');
+  const p = sim.entities.get(pid);
+  if (!p) throw new Error('player missing');
+  sim.setPlayerLevel(10, pid);
+  sim.drainEvents();
+  return sim;
+}
+
+function placePlayer(sim: Sim, x: number, z: number) {
+  const p = sim.player;
+  p.pos = sim.groundPos(x, z);
+  p.prevPos = { ...p.pos };
+  sim.grid.update(p);
+  sim.playerGrid.update(p);
+}
+
+function engagedMob(sim: Sim, templateId: string, id: number) {
+  const mob = createMob(
+    id,
+    MOBS[templateId],
+    MOBS[templateId].maxLevel,
+    sim.groundPos(HOME.x, HOME.z),
+  );
+  sim.entities.set(mob.id, mob);
+  sim.grid.update(mob);
+  placePlayer(sim, HOME.x + 2, HOME.z);
+  sim.ctx.dealDamage(sim.player, mob, 1, false, 'physical', null, 'hit');
+  sim.tick();
+  expect(mob.aggroTargetId).toBe(sim.player.id);
+  return mob;
+}
+
+// The kite proxy: the mob stands `dist` from its spawn with a FRESH leash
+// anchor at its feet (every hit re-seeds the anchor, so a real kite always
+// looks like this) and its victim in reach, so the soft anchor leash alone
+// would keep it fighting.
+function dragTo(sim: Sim, mob: ReturnType<typeof engagedMob>, dist: number) {
+  mob.pos = sim.groundPos(HOME.x + dist, HOME.z);
+  mob.prevPos = { ...mob.pos };
+  sim.grid.update(mob);
+  mob.leashAnchor = { ...mob.pos };
+  placePlayer(sim, HOME.x + dist + 2, HOME.z);
+}
+
+describe('mob hard leash tether', () => {
+  it('Grix carries the tether in content', () => {
+    expect(MOBS.grix_the_tunnelking.hardLeashRadius).toBe(50);
+  });
+
+  it('a tethered rare dragged past his tether evades home to full hp, adds swept', () => {
+    const sim = makeWorld();
+    const grix = engagedMob(sim, 'grix_the_tunnelking', 940001);
+
+    // Fight him down across the add threshold first, so the evade also proves
+    // the wave is swept with the reset.
+    sim.ctx.dealDamage(
+      sim.player,
+      grix,
+      Math.ceil(grix.maxHp * 0.5) - 1,
+      false,
+      'physical',
+      null,
+      'hit',
+    );
+    sim.tick();
+    expect(grix.summonedIds.length).toBeGreaterThan(0);
+    const addIds = [...grix.summonedIds];
+
+    dragTo(sim, grix, 55);
+    sim.tick();
+    expect(grix.aiState).toBe('evade');
+    expect(grix.aggroTargetId).toBeNull();
+
+    // Walk all the way home: full reset, classic evade rules.
+    for (let i = 0; i < 20 * 60 && grix.aiState === 'evade'; i++) sim.tick();
+    expect(Math.hypot(grix.pos.x - HOME.x, grix.pos.z - HOME.z)).toBeLessThan(6);
+    expect(grix.hp).toBe(grix.maxHp);
+    for (const id of addIds) expect(sim.entities.has(id)).toBe(false);
+  });
+
+  it('inside the tether he keeps fighting', () => {
+    const sim = makeWorld();
+    const grix = engagedMob(sim, 'grix_the_tunnelking', 940002);
+    dragTo(sim, grix, 40);
+    sim.tick();
+    expect(grix.aiState).not.toBe('evade');
+    expect(grix.aggroTargetId).toBe(sim.player.id);
+  });
+
+  it('an untethered mob with a fresh anchor is still kiteable past the same distance', () => {
+    const sim = makeWorld();
+    const wolf = engagedMob(sim, 'forest_wolf', 940003);
+    dragTo(sim, wolf, 55);
+    sim.tick();
+    expect(wolf.aiState).not.toBe('evade');
+    expect(wolf.aggroTargetId).toBe(sim.player.id);
+  });
+});

--- a/tests/summoned_add_respawn.test.ts
+++ b/tests/summoned_add_respawn.test.ts
@@ -1,0 +1,132 @@
+// Summoned boss adds must UNRAVEL when slain, never respawn into the wild.
+//
+// spawnBossAdds anchors an add where it ERUPTED (deliberate: a kited boss must
+// not hatch adds already past their own leash), so its spawnPos is wherever the
+// fight happened to drag: on prod, Grix the Tunnelking kited to the Eastbrook
+// town square left Deeprock Diggers squatting between the town NPCs. The dead-mob
+// respawn gate treated those adds like camp mobs, respawning them at the eruption
+// point on the normal cadence, and the only cleanup was despawnSummonedAdds on the
+// summoner's own respawn, 432x base for a rare like Grix, hours away.
+
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_WORLD, MOBS, setActiveWorldContent } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import { Sim } from '../src/sim/sim';
+import type { WorldContent } from '../src/sim/types';
+
+const SEED = 42;
+const TOWN = { x: 2, z: -2 };
+
+function makeWorld(): Sim {
+  const world: WorldContent = {
+    ...BUILTIN_WORLD,
+    camps: [],
+    npcs: {},
+    groundObjects: [],
+  };
+  setActiveWorldContent(world);
+  const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true, world });
+  const pid = sim.addPlayer('warrior', 'Townsfolk');
+  const p = sim.entities.get(pid);
+  if (!p) throw new Error('player missing');
+  p.pos = sim.groundPos(TOWN.x, TOWN.z);
+  p.prevPos = { ...p.pos };
+  sim.grid.update(p);
+  sim.playerGrid.update(p);
+  sim.setPlayerLevel(10, pid);
+  sim.drainEvents();
+  return sim;
+}
+
+function spawnGrixAt(sim: Sim, x: number, z: number) {
+  const grix = createMob(920001, MOBS.grix_the_tunnelking, 7, sim.groundPos(x, z));
+  sim.entities.set(grix.id, grix);
+  sim.grid.update(grix);
+  return grix;
+}
+
+function summonedAddsOf(sim: Sim, boss: { summonedIds: number[] }) {
+  return boss.summonedIds
+    .map((id) => sim.entities.get(id))
+    .filter((e): e is NonNullable<typeof e> => e != null);
+}
+
+describe('summoned add lifecycle', () => {
+  it('adds slain in the wild unravel with their corpse instead of respawning there', () => {
+    const sim = makeWorld();
+    const player = sim.player;
+    // The kite proxy: Grix stands in town when his add wave erupts, so the adds
+    // anchor (spawnPos) beside the town square, far from any camp.
+    const grix = spawnGrixAt(sim, TOWN.x + 4, TOWN.z);
+
+    // Cross the first summon threshold (55%) with the player as the aggressor.
+    sim.ctx.dealDamage(player, grix, Math.ceil(grix.maxHp * 0.5), false, 'physical', null, 'hit');
+    sim.tick();
+    const adds = summonedAddsOf(sim, grix);
+    expect(adds.length).toBeGreaterThan(0);
+    for (const add of adds) {
+      expect(add.templateId).toBe('tunnel_rat');
+      expect(Math.hypot(add.spawnPos.x - grix.pos.x, add.spawnPos.z - grix.pos.z)).toBeLessThan(10);
+    }
+
+    // Slay every add, then let its corpse window fully elapse.
+    for (const add of adds) {
+      sim.ctx.dealDamage(null, add, add.maxHp * 10, false, 'physical', null, 'hit');
+      expect(add.dead).toBe(true);
+      add.corpseTimer = 0;
+      add.respawnTimer = 0;
+      add.lootable = false;
+    }
+    sim.tick();
+
+    // The add unravels like a slain summoned demon: no respawn squatting at the
+    // eruption point until the summoner's distant respawn cleans it up.
+    for (const add of adds) {
+      expect(sim.entities.has(add.id)).toBe(false);
+    }
+  });
+
+  it('ordinary wild mobs still respawn at their spawn point', () => {
+    const sim = makeWorld();
+    const wolf = createMob(920002, MOBS.forest_wolf, 5, sim.groundPos(TOWN.x + 6, TOWN.z + 6));
+    sim.entities.set(wolf.id, wolf);
+    sim.grid.update(wolf);
+
+    sim.ctx.dealDamage(null, wolf, wolf.maxHp * 10, false, 'physical', null, 'hit');
+    expect(wolf.dead).toBe(true);
+    wolf.corpseTimer = 0;
+    wolf.respawnTimer = 0;
+    wolf.lootable = false;
+    sim.tick();
+
+    const respawned = sim.entities.get(wolf.id);
+    expect(respawned).toBeDefined();
+    expect(respawned?.dead).toBe(false);
+    expect(respawned?.pos.x).toBeCloseTo(wolf.spawnPos.x, 3);
+    expect(respawned?.pos.z).toBeCloseTo(wolf.spawnPos.z, 3);
+  });
+
+  it('the summoner respawn cleanup still despawns any adds left alive', () => {
+    const sim = makeWorld();
+    const player = sim.player;
+    const grix = spawnGrixAt(sim, TOWN.x + 4, TOWN.z);
+    sim.ctx.dealDamage(player, grix, Math.ceil(grix.maxHp * 0.5), false, 'physical', null, 'hit');
+    sim.tick();
+    const adds = summonedAddsOf(sim, grix);
+    expect(adds.length).toBeGreaterThan(0);
+
+    // Grix dies; his live adds linger (loot rights et al), then his own respawn
+    // sweeps them, the pre-existing contract.
+    sim.ctx.dealDamage(null, grix, grix.maxHp * 100, false, 'physical', null, 'hit');
+    expect(grix.dead).toBe(true);
+    grix.corpseTimer = 0;
+    grix.respawnTimer = 0;
+    grix.lootable = false;
+    sim.tick();
+
+    expect(grix.dead).toBe(false);
+    for (const add of adds) {
+      expect(sim.entities.has(add.id)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Removes the Deeprock Diggers squatting around the Eastbrook town square (screenshot report: several of them standing between the town NPCs and the boars).

## What was actually wrong

They are not authored spawns, so there was nothing to delete in content. No digger camp reaches town: the only camp is at the mine where it belongs (center -82,-62, radius 33, and two quests target the mob there), idle wander is capped at 9 yards from spawnPos, and a fresh world provably spawns all eight diggers inside the mine disc.

The town diggers are **Grix the Tunnelking's summoned adds**. `spawnBossAdds` deliberately anchors an add where it erupts (so a kited boss does not hatch adds already past their own leash), which means a Grix dragged into town and killed there leaves his two waves of two tunnel_rats with town as their `spawnPos`. The bug was their afterlife: the dead-mob gate in `mob/locomotion.ts` excluded only instance mobs and slain summoned demons, so each killed add **respawned at its eruption point on the ordinary cadence**. The only cleanup, `despawnSummonedAdds`, fires on the summoner's evade or respawn, and Grix carries `respawnMult: 432`, hours away. One town kill of Grix seeded self-renewing diggers in the square.

## The fix

Summoned adds now carry a server-local `Entity.summonedAdd` flag (mirrored in `blankEntity`, never on the wire) and the dead-mob gate unravels them once their corpse decays, exactly like the slain summoned-demon rule beside it: the full loot window survives, then the entity drops instead of respawning. Instance adds keep their stay-dead-until-reset behavior, and the summoner-respawn sweep still clears any adds left alive.

No content change: the mine camp and both tunnel_rat quests are untouched, no world-init rng draw moves, and the parity goldens stand unchanged. The current prod squatters clear on the next deploy (world mobs rebuild at boot); after that, a kited boss's adds die once and stay gone.

## Test plan

- [x] New `tests/summoned_add_respawn.test.ts`, written failing-first: the unravel case was red before the fix; also pins the ordinary-mob respawn control and the summoner-respawn sweep contract
- [x] Full parity suite green at existing goldens, architecture suite green
- [x] Ripple suites green (entity_roster, world_boss, delves, combat_sfx, rift_difficulty_floors, interactions): 514 tests
- [x] tsc clean
- [ ] CI green on this PR
