### PR TITLE
chore(native): refresh the Android Gradle wrapper, iOS SwiftPM pins, and build number

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -17,8 +17,8 @@
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		504EC31A1FED79650016851F /* AppViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3191FED79650016851F /* AppViewController.swift */; };
 		504EC3201FED79650016851F /* NativeAppUpdatePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC31F1FED79650016851F /* NativeAppUpdatePlugin.swift */; };
-		504EC3D2DEC0DE0016851F02 /* NativeDeviceInfoPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3D1DEC0DE0016851F01 /* NativeDeviceInfoPlugin.swift */; };
 		504EC3221FED79650016851F /* NativeAppleAuthPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3211FED79650016851F /* NativeAppleAuthPlugin.swift */; };
+		504EC3D2DEC0DE0016851F02 /* NativeDeviceInfoPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3D1DEC0DE0016851F01 /* NativeDeviceInfoPlugin.swift */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
 /* End PBXBuildFile section */
 
@@ -34,9 +34,9 @@
 		504EC3131FED79650016851F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		504EC3191FED79650016851F /* AppViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewController.swift; sourceTree = "<group>"; };
 		504EC31F1FED79650016851F /* NativeAppUpdatePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAppUpdatePlugin.swift; sourceTree = "<group>"; };
-		504EC3D1DEC0DE0016851F01 /* NativeDeviceInfoPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeDeviceInfoPlugin.swift; sourceTree = "<group>"; };
 		504EC3211FED79650016851F /* NativeAppleAuthPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAppleAuthPlugin.swift; sourceTree = "<group>"; };
 		504EC3231FED79650016851F /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
+		504EC3D1DEC0DE0016851F01 /* NativeDeviceInfoPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeDeviceInfoPlugin.swift; sourceTree = "<group>"; };
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
 		958DCC722DB07C7200EA8C5F /* debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = debug.xcconfig; path = ../debug.xcconfig; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
@@ -319,7 +319,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 9RT4S4TGA3;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -347,7 +347,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 9RT4S4TGA3;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;

--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,48 @@
   "originHash" : "9a2c69911acccd3591b00284cbf5603280ae138e6c675df1a1f89e44feac9e9f",
   "pins" : [
     {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "7595cbcf59809f9977c5f6378500de2ad73b7ddb",
+        "version" : "5.12.0"
+      }
+    },
+    {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt.git",
+      "state" : {
+        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
+        "version" : "5.7.0"
+      }
+    },
+    {
       "identity" : "capacitor-swift-pm",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ionic-team/capacitor-swift-pm.git",
       "state" : {
         "revision" : "9b9fb0af76b2b653f6e9b999f658adc132b9ab4c",
         "version" : "8.4.2"
+      }
+    },
+    {
+      "identity" : "version",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mrackwitz/Version.git",
+      "state" : {
+        "revision" : "fd4b0eb5756aa7f1c33977fb626cf37d2140a3a0",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation.git",
+      "state" : {
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
       }
     }
   ],


### PR DESCRIPTION
## Summary

Native build-config drift picked up while producing a signed Android release bundle off `main`, plus the iOS build number needed for a corrective TestFlight upload. Three files, no application code.

- **`android/gradle/wrapper/gradle-wrapper.properties`**: Android Studio refuses to assemble a signed release bundle on the previously pinned wrapper and prompts for an upgrade; the build succeeds after taking it. This is the configuration a signed `.aab` was actually produced with, verified here by `./gradlew --version` reporting `Gradle 8.14.5`.
- **`ios/App/.../swiftpm/Package.resolved`**: records the SwiftPM pins for the Capgo OTA updater's transitive dependencies (Alamofire 5.12.0, BigInt 5.7.0, Version 0.8.0, ZIPFoundation 0.9.20). They were absent because `@capgo/capacitor-updater` landed after the last iOS resolve, so every machine and CI run was free to resolve those versions independently.
- **`ios/App/App.xcodeproj/project.pbxproj`**: advances the iOS build number (see below) and adopts Xcode's own ordering for the two `NativeDeviceInfoPlugin.swift` entries (it sorts these sections by identifier), which stops opening the project from producing a dirty tree.

## Note on the wrapper change

The upgrade also switched the distribution from `-all` to `-bin`:

```
-distributionUrl=...gradle-8.14.3-all.zip
+distributionUrl=...gradle-8.14.5-bin.zip
```

`-all` ships sources and Javadoc for IDE completion; `-bin` is binary-only and builds identically. Kept as-is deliberately, because this is the exact configuration a signed bundle was verified against, and nothing in `docs/` or `.github/` pins either choice. If the `-all` distribution was a deliberate developer-experience decision, restoring it while keeping the 8.14.5 version is a one-line follow-up.

## iOS build number

`CURRENT_PROJECT_VERSION` advances `37` to `38` in both iOS build configurations.

Build 37 was already uploaded to TestFlight, and it is one of the affected binaries: it carries no OTA plugin, for the reason described below. The corrective upload therefore needs a strictly higher build number, and cannot wait for the next `npm version` release bump to supply one.

Android's `versionCode` intentionally stays at `32`, because no Play upload has consumed it. The two counters normally advance together via `scripts/version_sync.mjs`, so they are momentarily out of step by design here; the next `npm version <x.y.z>` moves iOS to `39` and Android to `33`, and both stay monotonic.

## Related context

The same investigation found a stale local `node_modules` that had silently dropped `@capgo/capacitor-updater` from both native projects during `npx cap sync` (it is in `package.json` and `package-lock.json` but was not installed). That produced an `.aab` with no OTA plugin and no error anywhere, since `src/net/native_ota.ts` duck-types the plugin and no-ops when absent while `capacitor.config.ts` still advertises `autoUpdate`. Resolved by reinstalling and re-syncing rather than by committing the removal; the generated native files now come back clean, which is what the `Package.resolved` addition above reflects.

## Type of change

- [x] Build, CI, or tooling

## How was this tested?

- `./gradlew --version` in `android/` resolves the committed wrapper: `Gradle 8.14.5`.
- A signed release `.aab` builds in Android Studio on this wrapper (the failure that prompted the upgrade no longer occurs).
- `npm run ci:changed` (no lintable files in this diff), and `npx vitest run tests/ios_entry_memory.test.ts tests/release_version.test.ts tests/ios_entry_diagnostics.test.ts` (37 tests green) covering the guards that read `project.pbxproj`, the Swift sources, and the release-version surfaces.
- `npx cap sync` leaves all generated native files clean, confirming the OTA plugin is wired on both platforms.

Not re-run for this diff: the full suite and the client/server/env builds, none of which read these three files. CI covers them.

## Screenshots / recordings

N/A. Native build configuration only; no application code and nothing player-visible.

---

## Checklist

### Quality

- [x] Targeted verification recorded above. The two long-standing local suite failures (`tests/discord_server.test.ts` reading a developer `.env` invite override, `tests/texture_upload.test.ts` expecting Three to lack the update-range API) are environmental and unrelated to this diff.

### Cross-platform

- [x] Touches the Android and iOS build configuration only; the web and desktop clients are unaffected.

### Localization (i18n)

- [x] N/A. No strings.

### Hygiene

- [x] No secrets, credentials, keystore, or `.env` material. The signing step wrote nothing into the repository (no untracked files at all), and `ALLOW_DEV_COMMANDS` is untouched.
- [x] No generated application artifacts hand-edited. `Package.resolved` is a resolver lockfile committed by design under `xcshareddata`.
