### PR TITLE
fix(build): stop shipping every hashed media asset twice in native bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "wiki:content": "node scripts/wiki/build_content.mjs",
     "wiki:stills": "node scripts/wiki/render_model_stills.mjs",
     "sitemap:build": "node scripts/build_sitemap.mjs",
-    "build:native": "VITE_NATIVE_APP=1 VITE_API_ORIGIN=${VITE_API_ORIGIN:-https://worldofclaudecraft.com} npm run build",
+    "build:native": "VITE_NATIVE_APP=1 VITE_API_ORIGIN=${VITE_API_ORIGIN:-https://worldofclaudecraft.com} npm run build && node scripts/build_media_manifest.mjs prune",
     "native:sync": "npm run build:native && npx cap sync",
     "ota:publish": "node scripts/ota/publish_bundle.mjs",
     "native:open:ios": "npm run native:sync && npx cap open ios",

--- a/scripts/build_media_manifest.mjs
+++ b/scripts/build_media_manifest.mjs
@@ -6,6 +6,7 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import path from 'node:path';
@@ -85,9 +86,85 @@ function emit() {
   );
 }
 
+/**
+ * Decide which hashed-media ORIGINALS a bundle can drop.
+ *
+ * `emit` COPIES public/<logical> to dist/media/<name>.<hash><ext> and leaves the
+ * source in place, while vite separately copies all of public/ into dist/. A web
+ * deploy does not care (a CDN only transfers what is requested), but the native
+ * shells package the whole of dist/ into the app, and the OTA publisher zips it,
+ * so both carried every models/textures/env/vfx asset TWICE. That is what pushed
+ * the Play base module past its 500 MB compressed download ceiling.
+ *
+ * Production runtime resolves these through assetUrl() (src/render/assets/media.ts),
+ * which returns MEDIA_ASSETS[logical] and only falls back to the original path for a
+ * logical path that is NOT in the manifest. Every path this plan drops therefore has
+ * a hashed copy that the app asks for instead, and anything outside the manifest is
+ * never considered here.
+ *
+ * Pure so tests/media_duplicate_prune.test.ts can prove the teeth (including the
+ * refusal below) without a build; `hashedCopyExists` is the injected fs probe.
+ */
+export function planMediaDuplicatePrune(entries, hashedCopyExists) {
+  const drop = [];
+  const kept = [];
+  for (const logical of Object.keys(entries).sort()) {
+    const hashed = entries[logical];
+    // Never delete the only copy: no hashed twin on disk means emit did not run
+    // (or ran against different content), so the original is still load-bearing.
+    if (hashedCopyExists(hashed)) drop.push(logical);
+    else kept.push({ logical, hashed });
+  }
+  return { drop, kept };
+}
+
+function prune() {
+  const entries = manifestEntries();
+  const total = Object.keys(entries).length;
+  if (total === 0) {
+    console.log('media prune: manifest is empty, nothing to prune');
+    return;
+  }
+  const { drop, kept } = planMediaDuplicatePrune(entries, (url) =>
+    existsSync(path.join(distDir, url.replace(/^\//, ''))),
+  );
+  // A wholesale miss means this ran before `emit`, i.e. a build-order bug. Fail
+  // loudly rather than shipping the duplicates again in silence.
+  if (drop.length === 0) {
+    throw new Error(
+      `media prune: none of the ${total} hashed copies exist under dist/media; ` +
+        'run `node scripts/build_media_manifest.mjs emit` first',
+    );
+  }
+  let bytes = 0;
+  let removed = 0;
+  for (const logical of drop) {
+    const original = path.join(distDir, logical);
+    // Idempotent: a second run finds the originals already gone.
+    if (!existsSync(original)) continue;
+    bytes += statSync(original).size;
+    rmSync(original, { force: true });
+    removed++;
+  }
+  console.log(
+    `media prune: dropped ${removed} duplicated originals from dist ` +
+      `(${(bytes / 1048576).toFixed(1)} MB uncompressed; ${drop.length} hashed copies kept)`,
+  );
+  if (kept.length > 0) {
+    console.warn(
+      `media prune: kept ${kept.length} original(s) with no hashed copy on disk: ` +
+        kept
+          .slice(0, 5)
+          .map((k) => k.logical)
+          .join(', '),
+    );
+  }
+}
+
 const cmd = process.argv[2] ?? 'generate';
 if (cmd === 'generate') generate();
 else if (cmd === 'emit') emit();
+else if (cmd === 'prune') prune();
 else {
   console.error(`unknown command: ${cmd}`);
   process.exit(1);

--- a/tests/media_duplicate_prune.test.ts
+++ b/tests/media_duplicate_prune.test.ts
@@ -1,0 +1,115 @@
+// The native/OTA bundle carried every hashed media asset twice: `emit` copies
+// public/<logical> to dist/media/<name>.<hash><ext> and leaves the source, while
+// vite copies all of public/ into dist/ separately. That duplication pushed the
+// Play base module past its 500 MB compressed download ceiling.
+//
+// planMediaDuplicatePrune decides which originals may go. The rule that matters
+// is the refusal: an original with no hashed twin on disk is the ONLY copy and
+// must survive, because assetUrl() falls back to the original path for anything
+// the manifest does not carry.
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error - untyped zero-dep build helper (same convention as other scripts/*.mjs)
+import { planMediaDuplicatePrune } from '../scripts/build_media_manifest.mjs';
+
+interface KeptOriginal {
+  logical: string;
+  hashed: string;
+}
+
+const ENTRIES: Record<string, string> = {
+  'env/amber_sunset_2k.hdr': '/media/env/amber_sunset_2k.bc457362165a.hdr',
+  'models/props/farm_crate.glb': '/media/models/props/farm_crate.0b9724332a2d.glb',
+  'textures/terrain/grass.jpg': '/media/textures/terrain/grass.3d8343ec47c0.jpg',
+  'vfx/spark_04.png': '/media/vfx/spark_04.1b495e2b31b8.png',
+};
+
+/** fs probe stub: the given hashed urls exist under dist/, nothing else does. */
+const existing = (present: readonly string[]) => (url: string) => present.includes(url);
+
+describe('planMediaDuplicatePrune', () => {
+  it('drops every original whose hashed copy is on disk', () => {
+    const { drop, kept } = planMediaDuplicatePrune(ENTRIES, existing(Object.values(ENTRIES)));
+    expect(drop).toEqual([
+      'env/amber_sunset_2k.hdr',
+      'models/props/farm_crate.glb',
+      'textures/terrain/grass.jpg',
+      'vfx/spark_04.png',
+    ]);
+    expect(kept).toEqual([]);
+  });
+
+  it('KEEPS an original when its hashed copy is missing (never delete the only copy)', () => {
+    // Only the env twin was emitted; the other three originals are load-bearing.
+    const { drop, kept } = planMediaDuplicatePrune(
+      ENTRIES,
+      existing(['/media/env/amber_sunset_2k.bc457362165a.hdr']),
+    );
+    expect(drop).toEqual(['env/amber_sunset_2k.hdr']);
+    expect(kept.map((k: KeptOriginal) => k.logical)).toEqual([
+      'models/props/farm_crate.glb',
+      'textures/terrain/grass.jpg',
+      'vfx/spark_04.png',
+    ]);
+  });
+
+  it('probes the HASHED url, not the logical path', () => {
+    // A plan that tested the wrong side of the mapping would find nothing on
+    // disk under dist/media and either delete every only-copy or nothing at all.
+    const asked: string[] = [];
+    planMediaDuplicatePrune(ENTRIES, (url: string) => {
+      asked.push(url);
+      return true;
+    });
+    expect(asked).toEqual(
+      Object.keys(ENTRIES)
+        .sort()
+        .map((k) => ENTRIES[k]),
+    );
+    expect(asked.every((u) => u.startsWith('/media/'))).toBe(true);
+  });
+
+  it('drops nothing when emit never ran, so the caller can fail the build', () => {
+    const { drop, kept } = planMediaDuplicatePrune(ENTRIES, () => false);
+    expect(drop).toEqual([]);
+    expect(kept).toHaveLength(Object.keys(ENTRIES).length);
+  });
+
+  it('carries the hashed url alongside each kept original for the warning', () => {
+    const { kept } = planMediaDuplicatePrune(ENTRIES, () => false);
+    expect(kept).toContainEqual({
+      logical: 'env/amber_sunset_2k.hdr',
+      hashed: '/media/env/amber_sunset_2k.bc457362165a.hdr',
+    });
+  });
+
+  it('is deterministic and sorted regardless of manifest key order', () => {
+    const shuffled: Record<string, string> = {
+      'vfx/spark_04.png': ENTRIES['vfx/spark_04.png'],
+      'env/amber_sunset_2k.hdr': ENTRIES['env/amber_sunset_2k.hdr'],
+      'textures/terrain/grass.jpg': ENTRIES['textures/terrain/grass.jpg'],
+      'models/props/farm_crate.glb': ENTRIES['models/props/farm_crate.glb'],
+    };
+    const a = planMediaDuplicatePrune(ENTRIES, existing(Object.values(ENTRIES)));
+    const b = planMediaDuplicatePrune(shuffled, existing(Object.values(shuffled)));
+    expect(b.drop).toEqual(a.drop);
+  });
+
+  it('handles an empty manifest without inventing work', () => {
+    expect(planMediaDuplicatePrune({}, () => true)).toEqual({ drop: [], kept: [] });
+  });
+});
+
+describe('native build wiring', () => {
+  it('prunes only in build:native, never in the web build', async () => {
+    const pkg = (await import('../package.json')) as unknown as {
+      default: { scripts: Record<string, string> };
+    };
+    const scripts = pkg.default.scripts;
+    expect(scripts['build:native']).toContain('build_media_manifest.mjs prune');
+    // The web deploy serves public/ verbatim, so the originals must stay there.
+    expect(scripts.build).not.toContain('prune');
+    // Order matters: prune reads dist/media, which `emit` (end of build) creates.
+    const native = scripts['build:native'];
+    expect(native.indexOf('npm run build')).toBeLessThan(native.indexOf('prune'));
+  });
+});


### PR DESCRIPTION
## Summary

The Play Console refuses a production upload of the current bundle:

> Some feature modules of your app bundle exceed the maximum compressed download size (500 MB). Reduce the size of these modules: base.

The base module was carrying **every hashed media asset twice**. `scripts/build_media_manifest.mjs emit` *copies* `public/<logical>` to `dist/media/<name>.<hash><ext>` and leaves the source in place, while vite separately copies all of `public/` into `dist/`. Both survive into `dist/`, so the native shells package both and the OTA publisher zips both.

Measured inside the rejected `.aab`, the duplication is exact:

| tree | original | hashed copy under `media/` |
|---|---|---|
| env | 73.6 MB | 73.6 MB |
| models | 61.0 MB | 61.0 MB |
| textures | 36.7 MB | 36.7 MB |
| vfx | 0.7 MB | 0.7 MB |

They are byte-identical (same SHA-256 for a sampled pair), and only one copy is ever requested: `assetUrl()` (`src/render/assets/media.ts`) returns `MEDIA_ASSETS[logical]` in production and falls back to the original path **only** for a logical path the manifest does not carry. No HTML entry or stylesheet references those trees directly, so nothing bypasses that mapping.

This adds a `prune` command that drops the duplicated originals from `dist/` after the build, wired into **`build:native` only**. The web deploy keeps serving `public/` verbatim as documented, where a duplicate costs nothing because a CDN transfers only what is requested.

## Result, measured not estimated

Both numbers below come from the same content, built before and after this change, measuring the compressed `base/` entries inside each `.aab` (the module Play's limit applies to).

| | base module, compressed | `dist/` |
|---|---|---|
| before (the rejected upload) | **600.5 MB** | 859 MB |
| after | **428.5 MB** | 567 MB |

That clears the 500 MB ceiling with roughly 70 MB of headroom, with no content, resolution, or quality change whatsoever: the same 1309 assets ship, once each instead of twice.

OTA bundles shrink by the same ~173 MB, since `scripts/ota/publish_bundle.mjs` zips the same `build:native` output.

## Safety

Two refusals, both covered by tests:

- **Never delete the only copy.** An original whose hashed twin is not on disk is kept, because `assetUrl()` would fall back to it. The plan reports those separately and the CLI warns.
- **Fail loudly on a build-order mistake.** If *none* of the hashed copies exist, `prune` throws instead of silently doing nothing, which is exactly what running it before `emit` looks like.

Pruning is driven by the manifest's own key list, so anything outside the manifest is never considered. Verified against the real build: the 10 `CLAUDE.md` docs under `dist/models/**` (excluded from the manifest by extension) are still present afterwards, and `dist/media/env` retains all 32 hashed HDRs while `dist/env` is empty.

The pure decision lives in `planMediaDuplicatePrune()` with the file I/O in the CLI, following `scripts/check_backdrop_survival.mjs`, so `tests/media_duplicate_prune.test.ts` proves the teeth without a build.

## Type of change

- [x] Bug fix
- [x] Build, CI, or tooling

## How was this tested?

- **A real release bundle was rebuilt end to end**: `npm run build:native` (prune reports `dropped 1309 duplicated originals from dist (289.4 MB uncompressed; 1309 hashed copies kept)`), `npx cap sync android`, then `./gradlew bundleRelease`. The resulting base module is 428.5 MB compressed against the previous 600.5 MB.
- `npx vitest run tests/media_duplicate_prune.test.ts` (8 cases: drops duplicates, keeps an only-copy, probes the hashed side of the mapping rather than the logical side, reports nothing when `emit` never ran, deterministic ordering, empty manifest, and the `build:native`-only wiring).
- `npx vitest run tests/backdrop_filter_survival.test.ts tests/release_version.test.ts` (the neighbouring build-script guards) plus `npm run check:types` (0 errors) and `npm run ci:changed`.
- The pruned `dist/` was inspected directly to confirm originals are gone, hashed copies intact, and non-manifest files untouched.

Note for reproduction: `./gradlew bundleRelease` needs JDK 21 (Android Studio's bundled JBR works; a JDK 17 on `PATH` fails at `:capacitor-android:compileReleaseJavaWithJavac` with `invalid source release: 21`).

## Screenshots / recordings

N/A. Build packaging only; no application code and nothing player-visible.

## Follow-ups, deliberately not here

- `audio/` is now the largest remaining item at 177 MB compressed, of which `audio/voice` is 103 MB. Voice clips already fail soft (`src/game/CLAUDE.md`: a missing clip is "a silent no-op (the dialogue/combat text stays the source of truth)"), and music is already fetched over HTTP at runtime, so both are candidates for delivery outside the store binary. Not needed to clear this blocker, and worth deciding deliberately rather than under upload pressure.
- Internal per-directory `CLAUDE.md` docs under `public/models/**` are copied into the shipped bundle by vite's `public/` copy. Tiny, but they are internal documentation in a store artifact.
- Three problems in a row now trace to this pipeline producing a wrong artifact with no error: a dropped OTA plugin from a stale install, a 0.31.0 archive containing a v0.30.0 web bundle, and this duplication. One pre-archive check asserting bundle size, plugin presence, and the embedded build id would catch all three before an upload is rejected or, worse, accepted.

---

## Checklist

### Quality

- [x] Decisive tests added for the new behaviour, including both refusals; a real bundle was rebuilt and measured rather than estimated. The two long-standing local suite failures (`tests/discord_server.test.ts` reading a developer `.env` invite override, `tests/texture_upload.test.ts` expecting Three to lack the update-range API) are environmental and unrelated.

### Cross-platform

- [x] Affects the native Android and iOS bundles and the OTA zip, all of which shrink identically. The web deploy is untouched by construction: the prune runs only in `build:native`, asserted by a test.

### Localization (i18n)

- [x] N/A. No strings.

### Hygiene

- [x] No secrets or `.env` material; `ALLOW_DEV_COMMANDS` untouched.
- [x] No generated files hand-edited. The prune deletes build output under `dist/`, never anything in `public/` or the repository.
