### PR TITLE
fix(native): unblock the release build (Gradle wrapper, SwiftPM pins, iOS build number, media dedup)

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -17,8 +17,8 @@
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		504EC31A1FED79650016851F /* AppViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3191FED79650016851F /* AppViewController.swift */; };
 		504EC3201FED79650016851F /* NativeAppUpdatePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC31F1FED79650016851F /* NativeAppUpdatePlugin.swift */; };
-		504EC3D2DEC0DE0016851F02 /* NativeDeviceInfoPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3D1DEC0DE0016851F01 /* NativeDeviceInfoPlugin.swift */; };
 		504EC3221FED79650016851F /* NativeAppleAuthPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3211FED79650016851F /* NativeAppleAuthPlugin.swift */; };
+		504EC3D2DEC0DE0016851F02 /* NativeDeviceInfoPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3D1DEC0DE0016851F01 /* NativeDeviceInfoPlugin.swift */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
 /* End PBXBuildFile section */
 
@@ -34,9 +34,9 @@
 		504EC3131FED79650016851F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		504EC3191FED79650016851F /* AppViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewController.swift; sourceTree = "<group>"; };
 		504EC31F1FED79650016851F /* NativeAppUpdatePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAppUpdatePlugin.swift; sourceTree = "<group>"; };
-		504EC3D1DEC0DE0016851F01 /* NativeDeviceInfoPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeDeviceInfoPlugin.swift; sourceTree = "<group>"; };
 		504EC3211FED79650016851F /* NativeAppleAuthPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAppleAuthPlugin.swift; sourceTree = "<group>"; };
 		504EC3231FED79650016851F /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
+		504EC3D1DEC0DE0016851F01 /* NativeDeviceInfoPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeDeviceInfoPlugin.swift; sourceTree = "<group>"; };
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
 		958DCC722DB07C7200EA8C5F /* debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = debug.xcconfig; path = ../debug.xcconfig; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
@@ -319,7 +319,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 9RT4S4TGA3;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -347,7 +347,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = 9RT4S4TGA3;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;

--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,48 @@
   "originHash" : "9a2c69911acccd3591b00284cbf5603280ae138e6c675df1a1f89e44feac9e9f",
   "pins" : [
     {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "7595cbcf59809f9977c5f6378500de2ad73b7ddb",
+        "version" : "5.12.0"
+      }
+    },
+    {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt.git",
+      "state" : {
+        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
+        "version" : "5.7.0"
+      }
+    },
+    {
       "identity" : "capacitor-swift-pm",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ionic-team/capacitor-swift-pm.git",
       "state" : {
         "revision" : "9b9fb0af76b2b653f6e9b999f658adc132b9ab4c",
         "version" : "8.4.2"
+      }
+    },
+    {
+      "identity" : "version",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mrackwitz/Version.git",
+      "state" : {
+        "revision" : "fd4b0eb5756aa7f1c33977fb626cf37d2140a3a0",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation.git",
+      "state" : {
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
       }
     }
   ],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "wiki:content": "node scripts/wiki/build_content.mjs",
     "wiki:stills": "node scripts/wiki/render_model_stills.mjs",
     "sitemap:build": "node scripts/build_sitemap.mjs",
-    "build:native": "VITE_NATIVE_APP=1 VITE_API_ORIGIN=${VITE_API_ORIGIN:-https://worldofclaudecraft.com} npm run build",
+    "build:native": "VITE_NATIVE_APP=1 VITE_API_ORIGIN=${VITE_API_ORIGIN:-https://worldofclaudecraft.com} npm run build && node scripts/build_media_manifest.mjs prune",
     "native:sync": "npm run build:native && npx cap sync",
     "ota:publish": "node scripts/ota/publish_bundle.mjs",
     "native:open:ios": "npm run native:sync && npx cap open ios",

--- a/scripts/build_media_manifest.d.mts
+++ b/scripts/build_media_manifest.d.mts
@@ -1,0 +1,23 @@
+/** An original kept because its hashed copy is not on disk (it is the only copy). */
+export interface KeptMediaOriginal {
+  /** manifest key, e.g. `env/amber_sunset_2k.hdr` */
+  logical: string;
+  /** hashed url the manifest maps it to, e.g. `/media/env/amber_sunset_2k.<hash>.hdr` */
+  hashed: string;
+}
+
+export interface MediaDuplicatePrunePlan {
+  /** logical paths whose hashed copy exists, so the original is a duplicate */
+  drop: string[];
+  /** originals with no hashed copy on disk; these must survive */
+  kept: KeptMediaOriginal[];
+}
+
+/**
+ * Decide which hashed-media originals a native/OTA bundle can drop.
+ * `hashedCopyExists` is the injected fs probe, called with the HASHED url.
+ */
+export function planMediaDuplicatePrune(
+  entries: Record<string, string>,
+  hashedCopyExists: (hashedUrl: string) => boolean,
+): MediaDuplicatePrunePlan;

--- a/scripts/build_media_manifest.mjs
+++ b/scripts/build_media_manifest.mjs
@@ -6,6 +6,7 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import path from 'node:path';
@@ -85,9 +86,85 @@ function emit() {
   );
 }
 
+/**
+ * Decide which hashed-media ORIGINALS a bundle can drop.
+ *
+ * `emit` COPIES public/<logical> to dist/media/<name>.<hash><ext> and leaves the
+ * source in place, while vite separately copies all of public/ into dist/. A web
+ * deploy does not care (a CDN only transfers what is requested), but the native
+ * shells package the whole of dist/ into the app, and the OTA publisher zips it,
+ * so both carried every models/textures/env/vfx asset TWICE. That is what pushed
+ * the Play base module past its 500 MB compressed download ceiling.
+ *
+ * Production runtime resolves these through assetUrl() (src/render/assets/media.ts),
+ * which returns MEDIA_ASSETS[logical] and only falls back to the original path for a
+ * logical path that is NOT in the manifest. Every path this plan drops therefore has
+ * a hashed copy that the app asks for instead, and anything outside the manifest is
+ * never considered here.
+ *
+ * Pure so tests/media_duplicate_prune.test.ts can prove the teeth (including the
+ * refusal below) without a build; `hashedCopyExists` is the injected fs probe.
+ */
+export function planMediaDuplicatePrune(entries, hashedCopyExists) {
+  const drop = [];
+  const kept = [];
+  for (const logical of Object.keys(entries).sort()) {
+    const hashed = entries[logical];
+    // Never delete the only copy: no hashed twin on disk means emit did not run
+    // (or ran against different content), so the original is still load-bearing.
+    if (hashedCopyExists(hashed)) drop.push(logical);
+    else kept.push({ logical, hashed });
+  }
+  return { drop, kept };
+}
+
+function prune() {
+  const entries = manifestEntries();
+  const total = Object.keys(entries).length;
+  if (total === 0) {
+    console.log('media prune: manifest is empty, nothing to prune');
+    return;
+  }
+  const { drop, kept } = planMediaDuplicatePrune(entries, (url) =>
+    existsSync(path.join(distDir, url.replace(/^\//, ''))),
+  );
+  // A wholesale miss means this ran before `emit`, i.e. a build-order bug. Fail
+  // loudly rather than shipping the duplicates again in silence.
+  if (drop.length === 0) {
+    throw new Error(
+      `media prune: none of the ${total} hashed copies exist under dist/media; ` +
+        'run `node scripts/build_media_manifest.mjs emit` first',
+    );
+  }
+  let bytes = 0;
+  let removed = 0;
+  for (const logical of drop) {
+    const original = path.join(distDir, logical);
+    // Idempotent: a second run finds the originals already gone.
+    if (!existsSync(original)) continue;
+    bytes += statSync(original).size;
+    rmSync(original, { force: true });
+    removed++;
+  }
+  console.log(
+    `media prune: dropped ${removed} duplicated originals from dist ` +
+      `(${(bytes / 1048576).toFixed(1)} MB uncompressed; ${drop.length} hashed copies kept)`,
+  );
+  if (kept.length > 0) {
+    console.warn(
+      `media prune: kept ${kept.length} original(s) with no hashed copy on disk: ` +
+        kept
+          .slice(0, 5)
+          .map((k) => k.logical)
+          .join(', '),
+    );
+  }
+}
+
 const cmd = process.argv[2] ?? 'generate';
 if (cmd === 'generate') generate();
 else if (cmd === 'emit') emit();
+else if (cmd === 'prune') prune();
 else {
   console.error(`unknown command: ${cmd}`);
   process.exit(1);

--- a/tests/media_duplicate_prune.test.ts
+++ b/tests/media_duplicate_prune.test.ts
@@ -1,0 +1,109 @@
+// The native/OTA bundle carried every hashed media asset twice: `emit` copies
+// public/<logical> to dist/media/<name>.<hash><ext> and leaves the source, while
+// vite copies all of public/ into dist/ separately. That duplication pushed the
+// Play base module past its 500 MB compressed download ceiling.
+//
+// planMediaDuplicatePrune decides which originals may go. The rule that matters
+// is the refusal: an original with no hashed twin on disk is the ONLY copy and
+// must survive, because assetUrl() falls back to the original path for anything
+// the manifest does not carry.
+import { describe, expect, it } from 'vitest';
+import { planMediaDuplicatePrune } from '../scripts/build_media_manifest.mjs';
+
+const ENTRIES: Record<string, string> = {
+  'env/amber_sunset_2k.hdr': '/media/env/amber_sunset_2k.bc457362165a.hdr',
+  'models/props/farm_crate.glb': '/media/models/props/farm_crate.0b9724332a2d.glb',
+  'textures/terrain/grass.jpg': '/media/textures/terrain/grass.3d8343ec47c0.jpg',
+  'vfx/spark_04.png': '/media/vfx/spark_04.1b495e2b31b8.png',
+};
+
+/** fs probe stub: the given hashed urls exist under dist/, nothing else does. */
+const existing = (present: readonly string[]) => (url: string) => present.includes(url);
+
+describe('planMediaDuplicatePrune', () => {
+  it('drops every original whose hashed copy is on disk', () => {
+    const { drop, kept } = planMediaDuplicatePrune(ENTRIES, existing(Object.values(ENTRIES)));
+    expect(drop).toEqual([
+      'env/amber_sunset_2k.hdr',
+      'models/props/farm_crate.glb',
+      'textures/terrain/grass.jpg',
+      'vfx/spark_04.png',
+    ]);
+    expect(kept).toEqual([]);
+  });
+
+  it('KEEPS an original when its hashed copy is missing (never delete the only copy)', () => {
+    // Only the env twin was emitted; the other three originals are load-bearing.
+    const { drop, kept } = planMediaDuplicatePrune(
+      ENTRIES,
+      existing(['/media/env/amber_sunset_2k.bc457362165a.hdr']),
+    );
+    expect(drop).toEqual(['env/amber_sunset_2k.hdr']);
+    expect(kept.map((k) => k.logical)).toEqual([
+      'models/props/farm_crate.glb',
+      'textures/terrain/grass.jpg',
+      'vfx/spark_04.png',
+    ]);
+  });
+
+  it('probes the HASHED url, not the logical path', () => {
+    // A plan that tested the wrong side of the mapping would find nothing on
+    // disk under dist/media and either delete every only-copy or nothing at all.
+    const asked: string[] = [];
+    planMediaDuplicatePrune(ENTRIES, (url) => {
+      asked.push(url);
+      return true;
+    });
+    expect(asked).toEqual(
+      Object.keys(ENTRIES)
+        .sort()
+        .map((k) => ENTRIES[k]),
+    );
+    expect(asked.every((u) => u.startsWith('/media/'))).toBe(true);
+  });
+
+  it('drops nothing when emit never ran, so the caller can fail the build', () => {
+    const { drop, kept } = planMediaDuplicatePrune(ENTRIES, () => false);
+    expect(drop).toEqual([]);
+    expect(kept).toHaveLength(Object.keys(ENTRIES).length);
+  });
+
+  it('carries the hashed url alongside each kept original for the warning', () => {
+    const { kept } = planMediaDuplicatePrune(ENTRIES, () => false);
+    expect(kept).toContainEqual({
+      logical: 'env/amber_sunset_2k.hdr',
+      hashed: '/media/env/amber_sunset_2k.bc457362165a.hdr',
+    });
+  });
+
+  it('is deterministic and sorted regardless of manifest key order', () => {
+    const shuffled: Record<string, string> = {
+      'vfx/spark_04.png': ENTRIES['vfx/spark_04.png'],
+      'env/amber_sunset_2k.hdr': ENTRIES['env/amber_sunset_2k.hdr'],
+      'textures/terrain/grass.jpg': ENTRIES['textures/terrain/grass.jpg'],
+      'models/props/farm_crate.glb': ENTRIES['models/props/farm_crate.glb'],
+    };
+    const a = planMediaDuplicatePrune(ENTRIES, existing(Object.values(ENTRIES)));
+    const b = planMediaDuplicatePrune(shuffled, existing(Object.values(shuffled)));
+    expect(b.drop).toEqual(a.drop);
+  });
+
+  it('handles an empty manifest without inventing work', () => {
+    expect(planMediaDuplicatePrune({}, () => true)).toEqual({ drop: [], kept: [] });
+  });
+});
+
+describe('native build wiring', () => {
+  it('prunes only in build:native, never in the web build', async () => {
+    const pkg = (await import('../package.json')) as unknown as {
+      default: { scripts: Record<string, string> };
+    };
+    const scripts = pkg.default.scripts;
+    expect(scripts['build:native']).toContain('build_media_manifest.mjs prune');
+    // The web deploy serves public/ verbatim, so the originals must stay there.
+    expect(scripts.build).not.toContain('prune');
+    // Order matters: prune reads dist/media, which `emit` (end of build) creates.
+    const native = scripts['build:native'];
+    expect(native.indexOf('npm run build')).toBeLessThan(native.indexOf('prune'));
+  });
+});


### PR DESCRIPTION
## Summary

Everything needed to ship the current native release, in one branch. Replaces #2654 and #2657, which are closed in favour of this. Two commits, kept separate because they fix unrelated things:

**1. `chore(native)`: Gradle wrapper, iOS SwiftPM pins, iOS build number.** Android Studio refuses to assemble a signed release bundle on the wrapper we pinned and prompts for an upgrade; the build succeeds after taking 8.14.5. `Package.resolved` records the SwiftPM pins for the Capgo OTA updater's transitive dependencies (Alamofire 5.12.0, BigInt 5.7.0, Version 0.8.0, ZIPFoundation 0.9.20), absent until now because the plugin landed after the last iOS resolve, so every machine and CI run resolved those versions independently. The iOS `CURRENT_PROJECT_VERSION` advances 37 to 38 because build 37 is already on TestFlight and is one of the binaries missing the OTA plugin, so the corrective upload needs a strictly higher number and cannot wait for the next `npm version`. `project.pbxproj` also adopts Xcode's own ordering for the two `NativeDeviceInfoPlugin.swift` entries, so opening the project stops dirtying the tree.

**2. `fix(build)`: stop shipping every hashed media asset twice.** The Play Console rejects the production upload:

> Some feature modules of your app bundle exceed the maximum compressed download size (500 MB). Reduce the size of these modules: base.

`scripts/build_media_manifest.mjs emit` *copies* `public/<logical>` to `dist/media/<name>.<hash><ext>` and leaves the source, while vite separately copies all of `public/` into `dist/`. Both survive, so the shells packaged both and the OTA publisher zipped both:

| tree | original | hashed copy under `media/` |
|---|---|---|
| env | 73.6 MB | 73.6 MB |
| models | 61.0 MB | 61.0 MB |
| textures | 36.7 MB | 36.7 MB |
| vfx | 0.7 MB | 0.7 MB |

Byte-identical (same SHA-256 on a sampled pair), and only one copy is ever requested: `assetUrl()` returns `MEDIA_ASSETS[logical]` in production and falls back to the original path **only** for a logical path the manifest does not carry. No HTML entry or stylesheet references those trees directly. A new `prune` command drops the duplicated originals from `dist/` after the build, wired into **`build:native` only**, so the web deploy keeps serving `public/` verbatim (a duplicate costs a CDN nothing, since it transfers only what is requested).

## Result, measured on a real bundle

Built from this branch: `npm run build:native`, `npx cap sync android`, `./gradlew bundleRelease`. Sizes are the compressed `base/` entries inside each `.aab`, which is what Play's ceiling applies to.

| | base module, compressed | `dist/` |
|---|---|---|
| the rejected upload | **600.5 MB** | 859 MB |
| this branch | **428.5 MB** | 567 MB |

Clears the 500 MB ceiling with roughly 70 MB of headroom, with no content, resolution, or quality change: the same 1309 assets ship once each instead of twice. Verified in the built bundle: 1309 hashed media entries present, and the only remaining entries under the original trees are the 10 per-directory `CLAUDE.md` docs, which are outside the manifest by extension and correctly untouched.

OTA bundles shrink by the same ~173 MB, since `scripts/ota/publish_bundle.mjs` zips the same `build:native` output.

## Safety of the prune

Two refusals, both covered by tests:

- **Never delete the only copy.** An original whose hashed twin is not on disk is kept, because `assetUrl()` would fall back to it. The plan returns those separately and the CLI warns.
- **Fail loudly on a build-order mistake.** If *none* of the hashed copies exist, `prune` throws rather than silently doing nothing, which is exactly what running before `emit` looks like.

The pure decision is `planMediaDuplicatePrune()` with the file I/O in the CLI, following `scripts/check_backdrop_survival.mjs`, and it carries a hand-written `scripts/build_media_manifest.d.mts` per `scripts/CLAUDE.md` so the type-checked suite imports it directly.

## Type of change

- [x] Bug fix
- [x] Build, CI, or tooling

## How was this tested?

- **A real release bundle, end to end on this branch**: `build:native` (prune reports `dropped 1309 duplicated originals from dist (289.4 MB uncompressed; 1309 hashed copies kept)`), `cap sync android`, `./gradlew bundleRelease` (`Gradle 8.14.5`, BUILD SUCCESSFUL), base module 428.5 MB against the previous 600.5 MB.
- `npx vitest run tests/media_duplicate_prune.test.ts` (8 cases: drops duplicates, keeps an only-copy, probes the hashed side of the mapping rather than the logical side, reports nothing when `emit` never ran, deterministic ordering, empty manifest, and the `build:native`-only wiring), plus `tests/backdrop_filter_survival.test.ts`, `tests/release_version.test.ts`, `tests/ios_entry_memory.test.ts`, `tests/ios_entry_diagnostics.test.ts`.
- `npm run check:types` (0 errors) and `npm run ci:changed`.
- `./gradlew --version` confirms the committed wrapper resolves to 8.14.5.
- `npx cap sync` leaves the generated native files clean, confirming the OTA plugin is wired on both platforms.

Reproduction note: `./gradlew bundleRelease` needs **JDK 21** (Android Studio's bundled JBR works; a JDK 17 on `PATH` fails at `:capacitor-android:compileReleaseJavaWithJavac` with `invalid source release: 21`). The bundle measured here is unsigned, as the keystore is not in the repo; signing changes the size negligibly.

## Notes on two judgement calls

The wrapper upgrade also switched the distribution from `-all` to `-bin`. `-all` ships sources and Javadoc for IDE completion; `-bin` is binary-only and builds identically. Kept as-is because this is the exact configuration a signed bundle was verified against, and nothing in `docs/` or `.github/` pins either choice. Restoring `-all` while keeping 8.14.5 is a one-line follow-up if that was deliberate.

Android's `versionCode` intentionally stays at 32: no Play upload has consumed it. The two counters normally advance together via `scripts/version_sync.mjs`, so they are briefly out of step here by design; the next `npm version <x.y.z>` moves iOS to 39 and Android to 33, and both stay monotonic.

## Screenshots / recordings

N/A. Native build configuration and packaging only; no application code and nothing player-visible.

## Follow-ups, deliberately not here

- `audio/` is now the largest remaining item at 177 MB compressed, of which `audio/voice` is 103 MB. Voice clips already fail soft (`src/game/CLAUDE.md`: a missing clip is "a silent no-op (the dialogue/combat text stays the source of truth)") and music is already fetched over HTTP at runtime, so both are candidates for delivery outside the store binary. Not needed to clear this blocker, and better decided deliberately than under upload pressure.
- Internal per-directory `CLAUDE.md` docs under `public/models/**` are copied into the shipped bundle by vite's `public/` copy. Tiny, but they are internal documentation in a store artifact.
- Three artifact-level problems in a row now trace to this pipeline producing a wrong result with no error: an OTA plugin dropped by a stale install, a 0.31.0 archive carrying a v0.30.0 web bundle, and this duplication. One pre-archive check asserting bundle size, plugin presence, and the embedded build id would have caught all three before an upload was rejected or, worse, accepted.

---

## Checklist

### Quality

- [x] Decisive tests for the new behaviour including both refusals, and a real bundle rebuilt and measured rather than estimated. The two long-standing local suite failures (`tests/discord_server.test.ts` reading a developer `.env` invite override, `tests/texture_upload.test.ts` expecting Three to lack the update-range API) are environmental and reproduce on clean `main`.

### Cross-platform

- [x] Affects the native Android and iOS bundles and the OTA zip, which all shrink identically. The web deploy is untouched by construction: the prune runs only in `build:native`, asserted by a test.

### Localization (i18n)

- [x] N/A. No strings.

### Hygiene

- [x] No secrets, credentials, keystore, or `.env` material. The signing step wrote nothing into the repository, and `ALLOW_DEV_COMMANDS` is untouched.
- [x] No generated files hand-edited. The prune deletes build output under `dist/`, never anything in `public/` or the repository. `Package.resolved` is a resolver lockfile committed by design under `xcshareddata`.
