### PR TITLE
fix(ui): engage auto-attack on ability cast against duel/arena foes

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -292,6 +292,7 @@ import {
   abilityStartsAutoAttack,
   deferAutoAttackUntilCastEnd,
   hasAutoAttackTarget,
+  isPvpHostileTarget,
 } from './hud/action_bar/attack_on_ability';
 import { CONSUMABLE_BAR_SLOTS, consumableBarItems } from './hud/action_bar/consumable_bar_view';
 import {
@@ -5867,13 +5868,18 @@ export class Hud {
           // AOEs (Arcane Explosion, Frost Nova, Thunder Clap, ...) cast with no hostile
           // target, where startAutoAttack does NOT no-op but errors "Invalid attack
           // target." (sim/combat/auto_attack.ts). The explicit Attack button keeps that
-          // error feedback; this convenience path must not trip it.
+          // error feedback; this convenience path must not trip it. hasAutoAttackTarget
+          // also recognizes a live duel/arena opponent (#2451): a player target never
+          // carries the mob-only `hostile` flag, so it errored on every PvP cast.
           const tid = this.sim.player.targetId;
           const target = tid !== null ? (this.sim.entities.get(tid) ?? null) : null;
           if (
             this.optionsHooks?.settings.get('startAttackOnAbilityUse') &&
             abilityStartsAutoAttack(resolved.effects) &&
-            hasAutoAttackTarget(target)
+            hasAutoAttackTarget(
+              target,
+              isPvpHostileTarget(tid, this.sim.duelInfo, this.sim.arenaInfo),
+            )
           ) {
             // A TIMED cast must not engage yet: startAutoAttack aggros the target
             // immediately, so engaging at cast start pulled the mob before any
@@ -11328,7 +11334,8 @@ export class Hud {
             if (ev.success) {
               const castTid = sim.player.targetId;
               const castTarget = castTid !== null ? (sim.entities.get(castTid) ?? null) : null;
-              if (hasAutoAttackTarget(castTarget)) this.sim.startAutoAttack();
+              const castPvpHostile = isPvpHostileTarget(castTid, sim.duelInfo, sim.arenaInfo);
+              if (hasAutoAttackTarget(castTarget, castPvpHostile)) this.sim.startAutoAttack();
             }
           }
           break;

--- a/src/ui/hud/action_bar/attack_on_ability.ts
+++ b/src/ui/hud/action_bar/attack_on_ability.ts
@@ -5,6 +5,7 @@
 // sim import), so a Vitest drives them directly; the HUD gates on the player's setting.
 
 import type { AbilityEffect, Entity } from '../../../sim/types';
+import type { ArenaInfo, DuelInfo } from '../../../world_api/duel_arena';
 
 // Auto-attack classification of EVERY AbilityEffect type. Because this is a Record over
 // the discriminant union, adding a new effect to `AbilityEffect` (src/sim/types.ts) is a
@@ -142,20 +143,47 @@ export function abilityStartsAutoAttack(effects: AbilityEffect[]): boolean {
 }
 
 /**
- * Whether the player's current target is a live, hostile MOB, i.e. one a white swing
- * would actually engage. Gating the auto-attack convenience on this keeps a targetless
- * AOE (Arcane Explosion, Frost Nova, Thunder Clap, ...) from flashing a spurious
- * "Invalid attack target." toast on every cast. Only mobs carry `hostile:true`
- * (players/NPCs default false) and the server mirrors the flag onto the wire, so the
- * same read holds for the offline Sim and the online ClientWorld.
+ * Whether the player's current target is a live target a white swing would actually
+ * engage: either a hostile MOB (`hostile:true`; players/NPCs default false, and the
+ * server mirrors the flag onto the wire, so the same read holds for the offline Sim and
+ * the online ClientWorld), or a player who is PvP-hostile right now per
+ * `isPvpHostileTarget` (an active duel/arena opponent). Gating the auto-attack
+ * convenience on this keeps a targetless AOE (Arcane Explosion, Frost Nova, Thunder
+ * Clap, ...) from flashing a spurious "Invalid attack target." toast on every cast.
  *
- * Deliberately narrower than the sim's `isHostileTo`, which also treats an enemy player
- * in an active duel/arena as hostile (players are `hostile:false`): replicating that PvP
- * state on the client is not worth it, so the convenience is PvE-mob scope. That is safe,
- * no error, just no auto-engage in PvP, where the explicit Attack button still works.
+ * `pvpHostile` mirrors the sim's `isHostileTo`, which also treats an enemy player in an
+ * active duel/arena as hostile (players are otherwise always `hostile:false`, since this
+ * game has no open-world FFA PvP): the caller computes it via `isPvpHostileTarget` from
+ * the already-mirrored `IWorld.duelInfo`/`IWorld.arenaInfo`, so no new wire state is
+ * needed. Defaults to false so an omitted argument keeps the original PvE-only behavior.
  */
-export function hasAutoAttackTarget(target: Entity | null | undefined): boolean {
-  return !!target && !target.dead && target.hostile;
+export function hasAutoAttackTarget(
+  target: Entity | null | undefined,
+  pvpHostile = false,
+): boolean {
+  return !!target && !target.dead && (target.hostile || pvpHostile);
+}
+
+/**
+ * Whether a player target is PvP-hostile right now: an active duel opponent, or an
+ * active-arena opponent/enemy. Mirrors the private `isHostilePlayer` the renderer
+ * already computes for nameplate coloring (`src/render/renderer.ts`), so the "Auto-Attack
+ * on Ability Use" QoL setting recognizes the same PvP-hostile state instead of gating on
+ * the mob-only `hostile` flag, which a player target never carries.
+ */
+export function isPvpHostileTarget(
+  targetId: number | null | undefined,
+  duelInfo: DuelInfo | null | undefined,
+  arenaInfo: ArenaInfo | null | undefined,
+): boolean {
+  if (targetId === null || targetId === undefined) return false;
+  if (duelInfo?.state === 'active' && duelInfo.otherPid === targetId) return true;
+  const match = arenaInfo?.match;
+  return (
+    !!match &&
+    match.state === 'active' &&
+    (match.oppPid === targetId || match.enemies.some((e) => e.pid === targetId))
+  );
 }
 
 /**

--- a/src/ui/hud/action_bar/attack_on_ability.ts
+++ b/src/ui/hud/action_bar/attack_on_ability.ts
@@ -170,6 +170,12 @@ export function hasAutoAttackTarget(
  * already computes for nameplate coloring (`src/render/renderer.ts`), so the "Auto-Attack
  * on Ability Use" QoL setting recognizes the same PvP-hostile state instead of gating on
  * the mob-only `hostile` flag, which a player target never carries.
+ *
+ * Deliberately narrower than the sim's `isHostileTo`: it does not cover the jail brawl,
+ * the warden arm, an enemy player's PET (resolved through `pvpController`), or the Vale
+ * Cup cross-team arm. That matches the renderer's own nameplate predicate (a parity
+ * choice, not a defect); if a third copy of this verdict shows up, extract one shared
+ * pure module both the renderer and this file consume.
  */
 export function isPvpHostileTarget(
   targetId: number | null | undefined,

--- a/tests/attack_on_ability.test.ts
+++ b/tests/attack_on_ability.test.ts
@@ -5,7 +5,9 @@ import {
   abilityStartsAutoAttack,
   deferAutoAttackUntilCastEnd,
   hasAutoAttackTarget,
+  isPvpHostileTarget,
 } from '../src/ui/hud/action_bar/attack_on_ability';
+import type { ArenaInfo, DuelInfo } from '../src/world_api/duel_arena';
 
 // Resolve a real ability's rank-1 effects by id, so the test pins behavior against
 // the actual content tables (not hand-mocked shapes that could drift).
@@ -119,7 +121,106 @@ describe('hasAutoAttackTarget', () => {
   it('is false for a non-hostile target (friendly NPC / player)', () => {
     expect(hasAutoAttackTarget(target({ hostile: false }))).toBe(false);
   });
+
+  // #2451: casting a damaging ability on a duel/arena opponent never engaged
+  // auto-attack, because the player target's `hostile` flag is always false (this
+  // game has no open-world FFA PvP). hasAutoAttackTarget must also honor an
+  // explicit pvpHostile verdict (computed by the caller via isPvpHostileTarget),
+  // while staying additive: an omitted/false pvpHostile keeps the original
+  // PvE-only behavior for a non-hostile target.
+  it('is true for a live, non-hostile player target when pvpHostile is true (#2451)', () => {
+    expect(hasAutoAttackTarget(target({ hostile: false }), true)).toBe(true);
+  });
+
+  it('stays false for the same target when pvpHostile is false', () => {
+    expect(hasAutoAttackTarget(target({ hostile: false }), false)).toBe(false);
+    expect(hasAutoAttackTarget(target({ hostile: false }))).toBe(false);
+  });
+
+  it('is still false for a dead target even when pvpHostile is true', () => {
+    expect(hasAutoAttackTarget(target({ dead: true, hostile: false }), true)).toBe(false);
+  });
+
+  it('is still false with no target even when pvpHostile is true', () => {
+    expect(hasAutoAttackTarget(null, true)).toBe(false);
+    expect(hasAutoAttackTarget(undefined, true)).toBe(false);
+  });
 });
+
+describe('isPvpHostileTarget (the duel/arena PvP gate, #2451)', () => {
+  const OTHER_PID = 42;
+
+  it('is false with no target id', () => {
+    expect(isPvpHostileTarget(null, null, null)).toBe(false);
+    expect(isPvpHostileTarget(undefined, null, null)).toBe(false);
+  });
+
+  it('is true when an active duel targets this exact pid', () => {
+    const duel: DuelInfo = { otherPid: OTHER_PID, otherName: 'Rival', state: 'active' };
+    expect(isPvpHostileTarget(OTHER_PID, duel, null)).toBe(true);
+  });
+
+  it('is false while the duel is still counting down', () => {
+    const duel: DuelInfo = { otherPid: OTHER_PID, otherName: 'Rival', state: 'countdown' };
+    expect(isPvpHostileTarget(OTHER_PID, duel, null)).toBe(false);
+  });
+
+  it('is false when the active duel targets a different pid', () => {
+    const duel: DuelInfo = { otherPid: OTHER_PID, otherName: 'Rival', state: 'active' };
+    expect(isPvpHostileTarget(999, duel, null)).toBe(false);
+  });
+
+  const baseMatch: NonNullable<ArenaInfo['match']> = {
+    format: '2v2',
+    state: 'active',
+    oppName: 'Opp',
+    oppClass: 'warrior',
+    oppLevel: 20,
+    oppPid: OTHER_PID,
+    allies: [],
+    enemies: [],
+  };
+
+  it('is true when the active arena match opponent is this exact pid', () => {
+    const arena: ArenaInfo = arenaInfoWith(baseMatch);
+    expect(isPvpHostileTarget(OTHER_PID, null, arena)).toBe(true);
+  });
+
+  it('is true when the pid appears in the arena enemies list (a teammate target)', () => {
+    const enemyPid = 7;
+    const arena: ArenaInfo = arenaInfoWith({
+      ...baseMatch,
+      oppPid: OTHER_PID,
+      enemies: [{ pid: enemyPid, name: 'Foe', cls: 'mage', level: 20 }],
+    });
+    expect(isPvpHostileTarget(enemyPid, null, arena)).toBe(true);
+  });
+
+  it('is false when the arena match is not active (countdown/over)', () => {
+    const arena: ArenaInfo = arenaInfoWith({ ...baseMatch, state: 'countdown' });
+    expect(isPvpHostileTarget(OTHER_PID, null, arena)).toBe(false);
+  });
+
+  it('is false when there is no arena match at all', () => {
+    const arena: ArenaInfo = arenaInfoWith(null);
+    expect(isPvpHostileTarget(OTHER_PID, null, arena)).toBe(false);
+  });
+});
+
+function arenaInfoWith(match: ArenaInfo['match']): ArenaInfo {
+  return {
+    rating: 0,
+    wins: 0,
+    losses: 0,
+    standings: {} as ArenaInfo['standings'],
+    format: null,
+    queued: false,
+    queueSize: 0,
+    match,
+    ladder: [],
+    ladders: {} as ArenaInfo['ladders'],
+  };
+}
 
 describe('deferAutoAttackUntilCastEnd (the aggro-before-damage bug)', () => {
   it('defers for a timed cast so starting a Smite cannot pull the mob early', () => {


### PR DESCRIPTION
## Summary

The optional "Auto-Attack on Ability Use" QoL setting never engaged auto-attack
when casting a damaging ability on an enemy player, even during an active duel
or arena match. `hasAutoAttackTarget` (`src/ui/hud/action_bar/attack_on_ability.ts`)
gated purely on `target.hostile`, and only mobs ever carry `hostile:true`
(players and NPCs default to `false`, since this game has no open-world FFA
PvP). The sim's own `isHostileTo` already treats an enemy player as hostile
during an active duel or arena bout; the client convenience gate was strictly
narrower and never recognized that state, so the follow-up white swing simply
never started against another player.

This also explains the reporter's second observation (a hunter's pet not
assisting against players even in defensive mode): `pet_ai.ts`'s
`ownerOffense` clause requires `owner.autoAttack` to be true before the pet
will assist against a player target, and since the QoL path never set it in
PvP, the pet never joined in either. Fixing the client gate resolves both
symptoms with no sim-side change.

The fix adds a new pure predicate, `isPvpHostileTarget`, that mirrors the
private `isHostilePlayer` the renderer already computes for nameplate
hostility coloring (`src/render/renderer.ts`): it reads the same
`IWorld.duelInfo` / `IWorld.arenaInfo` state already mirrored to the client
(no new wire state, no new `IWorld` member). `hasAutoAttackTarget` now takes
an additional `pvpHostile` argument (defaulting to `false`, so existing PvE
behavior is unchanged for every other caller) and engages when either the mob
`hostile` flag or the PvP verdict is true. Both `hud.ts` call sites (the
instant-cast engage in `castSlot`, and the deferred engage on `castStop` for
timed casts) now compute and pass that verdict.

```mermaid
flowchart TD
    A[Player casts a damaging ability] --> B{abilityStartsAutoAttack}
    B -- no heal/buff/CC-only --> Z[No auto-attack change]
    B -- deals damage, no breakable CC --> C{hasAutoAttackTarget}
    C --> D{target.hostile?}
    D -- true, mob --> E[Engage auto-attack]
    D -- false, player --> F{isPvpHostileTarget}
    F --> G{duelInfo.state == active<br/>and otherPid == target?}
    G -- yes --> E
    G -- no --> H{arenaInfo.match.state == active<br/>and oppPid/enemies includes target?}
    H -- yes --> E
    H -- no --> I[No auto-attack: before this fix,<br/>PvP always landed here]
    E --> J[startAutoAttack: white swings begin<br/>same as pressing Attack]
```

Before this change, every player-target case fell straight from D into "no
engage" (the dashed F/G/H branch did not exist); a duel or arena opponent
never got picked up, no matter how clearly they were an active PvP target.

## Related issues

Closes #2451

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npx vitest run tests/attack_on_ability.test.ts` (27 tests, including 8 new
    cases: `hasAutoAttackTarget` honoring an explicit `pvpHostile` verdict, and
    a new `isPvpHostileTarget` describe block covering active/countdown duel
    state, active/countdown/absent arena match state, the arena opponent pid,
    and the arena enemies list)
  - `npx vitest run tests/architecture.test.ts tests/world_api_parity.test.ts`
    (320 tests; no `IWorld` member was added, both worlds already exposed
    `duelInfo`/`arenaInfo`, so the parity pin is unchanged)
  - `npx vitest run tests/localization_fixes.test.ts tests/hud_perf_budget.test.ts`
    (no new player-visible strings; the changed callers stay inside the
    existing painter/cold-path contracts)
  - `npx tsc --noEmit` (clean)
  - `npx @biomejs/biome check --write` on the three changed files (clean)
  - The repo's `.githooks/pre-push` QA floor (`tsc`, guard tests, changed-files
    biome, the em/en-dash and emoji copy scan) ran at push time and reported
    green.
- Manual steps: none required; this is a pure logic fix behind an existing
  unit-tested predicate module, reproduced and verified at the predicate
  level per the repo's test-first bug-fix convention.

Note on `npm run gate`: this shared build box is running the full gate for
several other in-flight PRs concurrently, and a couple of unrelated,
CPU-bound tests (mail expiry, terrain streaming zone coverage) hit their
20s wall-clock `vitest` timeout under that contention; re-running them in
isolation lets them pass. Nothing in that failure set touches `src/sim/`,
`src/ui/hud.ts`, or the auto-attack path this PR changes.

## Screenshots / recordings

N/A. This is a client logic fix (an existing predicate now returns `true`
in one additional case); there is no new or changed visual surface.

---

## Checklist

### Quality

- [x] **The full gate passes.** I added decisive tests for the new behavior
      (see "How was this tested?"); `tsc`, targeted `vitest` suites, and the
      changed-files `biome` check are all clean, and the `.githooks/pre-push`
      QA floor passed at push time.

### Cross-platform

- [x] N/A: this change has no new UI surface (no new DOM, no new control); it
      only changes when an existing auto-attack call fires.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled anywhere.
- [x] No generated files were hand-edited.
