### PR TITLE
fix(sim): consume Glacial Spike's Icicles gate atomically at cast commit

### DIFF
--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -708,9 +708,11 @@ export function castAbility(
     return;
   }
   // Kill-window abilities (Victory Rush): usable only while the enabling aura
-  // is worn; runEffects consumes it on a successful cast. Reuses the existing
-  // not-ready error literal so no new client matcher is needed. requiresAuraStacks
-  // (Glacial Spike's full 5-stack Icicles) additionally gates on the stack count.
+  // is worn; applyAbility consumes it atomically at cast commit, right before the
+  // cost/cooldown billing, so no early-return path can eat the aura without also
+  // committing the cast. Reuses the existing not-ready error literal so no new
+  // client matcher is needed. requiresAuraStacks (Glacial Spike's full 5-stack
+  // Icicles) additionally gates on the stack count.
   if (
     ability.requiresAuraKind &&
     !p.auras.some(

--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -78,6 +78,7 @@ import {
 } from './chronomancy';
 import { extendOwnedDot } from './dot_mutation';
 import {
+  consumeAuraKind,
   consumeFreeCostFor,
   consumeNextAttackCrit,
   consumeNextCastCheap,
@@ -1695,6 +1696,15 @@ function applyAbility(
         : Math.min(p.resource, ability.spendResourceCap);
     res = { ...res, cost: spend };
   }
+
+  // The cast is committed from this point on (target resolved, cost payable):
+  // consume the gating aura (Glacial Spike's full Icicles stack, Victory Rush's
+  // kill window) HERE, atomically with the cost/cooldown billing below, rather
+  // than inside runEffects. A ranged ability's runEffects can run ticks later,
+  // once its projectile lands (projectile_travel.ts); leaving the consume there
+  // left the Icicles aura alive for a second castAbility press made in that
+  // window, wrongly accepting a duplicate cast off the same stack (issue #2632).
+  if (ability.requiresAuraKind) consumeAuraKind(ctx, p, ability.requiresAuraKind);
 
   // helpful spells never miss
   if (

--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -71,7 +71,7 @@ import {
   selectCascadeTargets,
 } from './chronomancy';
 import { extendOwnedDot } from './dot_mutation';
-import { consumeAuraKind, consumeNextAttackCrit } from './empower_next';
+import { consumeNextAttackCrit } from './empower_next';
 import { runWeaponProcs } from './equip_procs';
 import { exclusiveAuraConflicts } from './exclusive_aura';
 import { fireGuaranteedCrit, personalBarrierIdForSpec } from './fire_mage';
@@ -315,7 +315,12 @@ export function runEffects(
     }
   }
 
-  if (ability.requiresAuraKind) consumeAuraKind(ctx, p, ability.requiresAuraKind);
+  // requiresAuraKind (Glacial Spike's Icicles, Victory Rush's kill window) is now
+  // consumed atomically at cast commit in casting_lifecycle.ts's applyAbility,
+  // alongside spendAbilityCost/armAbilityCooldown, not here: a ranged ability's
+  // runEffects can run ticks after the cast committed (once its projectile
+  // lands), which used to leave the gating aura alive for a same-tick second
+  // cast attempt (issue #2632).
 
   for (const eff of res.effects) {
     switch (eff.type) {

--- a/tests/glacial_spike.test.ts
+++ b/tests/glacial_spike.test.ts
@@ -169,4 +169,57 @@ describe('Glacial Spike gating + payoff', () => {
     // follow-up spells Shatter.
     expect(target.auras.some((a) => a.kind === 'root')).toBe(true);
   });
+
+  // Issue #2632: Glacial Spike's cast bar completes (mana spent, cooldown armed)
+  // several ticks before its frost bolt actually reaches the target (the
+  // projectile travels at PROJECTILE_SPEED). A rapid second press landing in
+  // that window used to re-check the Icicles gate, find it still at full stacks
+  // (the aura was only removed once the bolt LANDED, inside runEffects), and get
+  // wrongly accepted as a second legitimate cast off the same stack.
+  it('rejects a second press made while the first bolt is still in flight (issue #2632)', () => {
+    const { sim, p } = makeSim();
+    spawnTarget(sim, p);
+    pushAura(p, { id: 'icicles', name: 'Icicles', kind: 'icicles', stacks: ICICLE_MAX });
+    p.gcdRemaining = 0;
+    p.resource = p.maxResource;
+    sim.castAbility('glacial_spike');
+    const events: SimEvent[] = [...sim.drainEvents()];
+    expect(
+      events.some(
+        (e) => e.type === 'castStart' && e.entityId === p.id && e.ability === 'glacial_spike',
+      ),
+    ).toBe(true);
+
+    // Tick only far enough for the 2.7s cast bar to complete: the cast stops
+    // successfully, but the bolt (roughly 6 ticks over the spawnTarget distance)
+    // has not landed yet, so the Icicles gate is the only thing being tested.
+    let castCompleted = false;
+    for (let i = 0; i < 60 && !castCompleted; i++) {
+      events.push(...sim.tick());
+      castCompleted = events.some((e) => e.type === 'castStop' && e.entityId === p.id && e.success);
+    }
+    expect(castCompleted).toBe(true);
+    expect(damageEvents(events, 'Glacial Spike')).toHaveLength(0);
+
+    // A rapid second press in that window: must be rejected outright, not
+    // accepted as a fresh cast against the same (already-spent) Icicles stack.
+    const beforeSecondPress = events.length;
+    p.gcdRemaining = 0;
+    p.resource = p.maxResource;
+    sim.castAbility('glacial_spike');
+    events.push(...sim.drainEvents());
+    const secondPressEvents = events.slice(beforeSecondPress);
+    expect(
+      secondPressEvents.some(
+        (e) => e.type === 'castStart' && e.entityId === p.id && e.ability === 'glacial_spike',
+      ),
+    ).toBe(false);
+    expect(secondPressEvents.some((e) => e.type === 'error')).toBe(true);
+
+    // Let the first (and only accepted) bolt land, then confirm exactly one
+    // Glacial Spike hit landed and the whole Icicle stack was spent once.
+    for (let i = 0; i < 20; i++) events.push(...sim.tick());
+    expect(damageEvents(events, 'Glacial Spike')).toHaveLength(1);
+    expect(frostIcicleCharges(p.auras)).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

Frost Mage's Glacial Spike could be double-cast off a single 5-stack Icicles
buildup. The ability's Icicles gate was re-checked in `castAbility` but the
aura was only actually removed inside `runEffects`, which for a ranged spell
runs several ticks late, once its frost bolt lands (`projectile_travel.ts`).
That left a real window, from the moment the 2.7s cast bar finished (mana
spent, cooldown armed) to the moment the bolt hit, where the Icicles aura was
still sitting at full stacks. A rapid second press in that window re-entered
`castAbility`, found the gate still open, and got wrongly accepted as a
second, fully-paid cast off the same Icicles.

The fix consumes the gating aura (`AbilityDef.requiresAuraKind`) atomically at
the point the cast actually commits, in `applyAbility`
(`src/sim/combat/casting_lifecycle.ts`), alongside the existing
`spendAbilityCost`/`armAbilityCooldown` calls and before the
friendly/projectile/generic dispatch branches split. The redundant consume
that used to run at the start of `runEffects` (`src/sim/combat/effect_dispatch.ts`)
is removed. Victory Rush is the only other `requiresAuraKind` user; it is an
instant physical strike, so this move does not change its emitted event order
(the consume already ran before its effects were processed either way), which
`tests/parity` confirms stays green.

Note a real, intentional player-visible side effect of moving the consume
earlier: if the target dies in flight and the bolt fizzles, `runEffects`
never runs, so previously the Icicles stack survived a fizzled cast. Now the
consume already happened at cast commit, so the stack is spent regardless.
This matches the mana and cooldown, which were already spent at commit
either way, and matches classic semantics (a committed cast consumes its
resources even if it whiffs).

```mermaid
sequenceDiagram
    participant Player
    participant castAbility as castAbility (admission gate)
    participant applyAbility as applyAbility (cast commit)
    participant Icicles as Icicles aura (5 stacks)
    participant Bolt as Frost bolt (in flight, runEffects deferred)

    Player->>castAbility: press Glacial Spike
    castAbility->>Icicles: stacks >= 5?
    Icicles-->>castAbility: yes
    castAbility->>castAbility: start 2.7s cast bar
    Note over castAbility: 2.7s later, cast bar completes
    castAbility->>applyAbility: commit cast (spend cost, arm cooldown)
    applyAbility->>Icicles: consumeAuraKind (fix: moved here)
    Note right of Icicles: Old code only consumed the aura inside runEffects,<br/>once the bolt landed several ticks later,<br/>so it was still at 5 stacks at this point
    applyAbility->>Bolt: launch bolt, defer runEffects to landing
    Player->>castAbility: press Glacial Spike again (bolt still flying)
    castAbility->>Icicles: stacks >= 5?
    Icicles-->>castAbility: no, 0 stacks (fixed)
    castAbility-->>Player: "That ability is not ready yet."
    Bolt->>Bolt: lands, runs deferred effects, deals damage exactly once
```

## Related issues

Closes #2632

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands: `npx vitest run tests/glacial_spike.test.ts`, `npx vitest run
  tests/parity`, `npx tsc --noEmit`, `npm run gate`.
- Manual steps: reproduced the bug first with a new failing regression test
  (temporarily reverted the fix locally, confirmed the new test failed
  exactly on the duplicate-cast assertion, then reapplied the fix and
  confirmed it passed). Added `tests/glacial_spike.test.ts` "rejects a second
  press made while the first bolt is still in flight (issue #2632)": casts
  Glacial Spike at a full Icicles stack, ticks only far enough for the cast
  bar to complete (before the bolt lands), asserts a second press in that
  window is rejected (no second `castStart`, an error instead), then lets the
  bolt land and asserts exactly one Glacial Spike damage event and a
  fully-spent (0) Icicle stack. The two existing gating/payoff tests in the
  same file, plus the Victory Rush parity scenario, stay green.

## Screenshots / recordings

N/A. Sim-only logic fix, no player-visible UI change.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [ ] ~~Tested on desktop and mobile.~~ N/A, no UI change.
- [ ] ~~Accessible.~~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

