### PR TITLE
test(sim): pin the bindOnTrade round trip through vendor buyback (#2412)

### DIFF
--- a/docs/design/professions.md
+++ b/docs/design/professions.md
@@ -502,9 +502,10 @@ the lever is material quantities per craft.
 - Closest-call name keeps flagged for review: Quartermaster Bree (recorded
   voice assets raise the rename cost), Highwatch (TERA's endgame hub city
   shares the exact coin; the town predates professions scope).
-- Buyback payload option b: whether vendor buyback should record and
-  re-grant the exact instance payload instead of a plain copy
+- Buyback payload option b (RESOLVED, shipped): vendor buyback records and
+  re-grants the exact instance payload instead of a plain copy
   (self-inflicted-loss class, not a wash; the bound arm is closed).
+  `items.ts` `recordVendorBuyback`/`buyBackItem` (#2412).
 
 ### Post-launch watches
 - Shard prices and heroic clear speed (tune enchanting via reagent costs).

--- a/tests/professions_bind_on_trade_surfaces.test.ts
+++ b/tests/professions_bind_on_trade_surfaces.test.ts
@@ -309,7 +309,11 @@ describe('vendor: plain and armed copies sell, stamped copies are refused (wash 
     sim.sellItem(R, 1, pid);
     sim.drainEvents();
     expect(slotsOf(sim, pid, R)).toHaveLength(0);
-    sim.buyBackItem(R, undefined, undefined, pid);
+    // Exercise the load-bearing discriminator path (index + expected payload),
+    // not just the legacy itemId-only fallback: this is the resolution order
+    // buyBackItem actually uses when a vendor's buyback row holds more than
+    // one line for the same itemId.
+    sim.buyBackItem(R, 0, { ...ARMED }, pid);
     expect(errorTexts(sim.drainEvents())).toHaveLength(0);
     const back = slotsOf(sim, pid, R);
     expect(back).toHaveLength(1);

--- a/tests/professions_bind_on_trade_surfaces.test.ts
+++ b/tests/professions_bind_on_trade_surfaces.test.ts
@@ -298,6 +298,24 @@ describe('vendor: plain and armed copies sell, stamped copies are refused (wash 
     expect(slotsOf(sim, pid, R)).toHaveLength(0);
   });
 
+  it('buying back an ARMED copy keeps its bindOnTrade flag (#2412): the plain re-grant never strips it', () => {
+    // The instance-preservation mechanism in buyBackItem is not special-cased
+    // per payload field, but bindOnTrade is the one flag the issue calls out
+    // by name since a stripped arm would let the piece trade or vendor-sell
+    // again as if it had never been primed. Round trip it explicitly.
+    const { sim, pid } = vendorSetup();
+    setCopper(sim, pid, 40);
+    sim.addItemInstance(R, { ...ARMED }, pid);
+    sim.sellItem(R, 1, pid);
+    sim.drainEvents();
+    expect(slotsOf(sim, pid, R)).toHaveLength(0);
+    sim.buyBackItem(R, undefined, undefined, pid);
+    expect(errorTexts(sim.drainEvents())).toHaveLength(0);
+    const back = slotsOf(sim, pid, R);
+    expect(back).toHaveLength(1);
+    expect(back[0].instance).toEqual({ bindOnTrade: true });
+  });
+
   it('selling one while holding 1 plain + 1 stamped consumes the PLAIN copy first', () => {
     const { sim, pid } = vendorSetup();
     setCopper(sim, pid, 0);


### PR DESCRIPTION
## Summary

Issue #2412 describes vendor buyback destroying an item instance payload
(enchant, masterwork, signature) at sell time. Reviewing the current
`release/v0.33.0` tree shows the fix described in the issue's own Scope
section is already implemented in `src/sim/items.ts` (landed separately by
PR #2398, "preserve masterwork and signer data through vendor buyback"):

- `sellItem` and `sellAllJunk` capture the removed unit's instance payload
  via `removeVendorSellUnits` (which returns `{instance, craftedRecipeId}`
  per consumed unit).
- `recordVendorBuyback` stores that payload (deep-cloned) and merges a row
  into an existing one only when `canStackInstancePayloads` says the
  payloads match, so a plain sale never merges into an instanced row and a
  differently-rolled instanced sale never merges into another one.
- `buyBackItem` takes a row discriminator (`index`, `expectedInstance`,
  `expectedCraftedRecipeId`), resolves the exact row (index match, then a
  full `(itemId, payload)` scan, then a legacy itemId-only fallback),
  preflights capacity with the merge-aware `countFit` instead of a
  payload-blind check, and re-grants through `addStacked` so the instance is
  never stripped.
- The row discriminator is already threaded through the `IWorld` facet
  (`src/world_api/inventory.ts`), both `Sim` and `ClientWorld`, the wire
  command (`server/game.ts`), and the `IWORLD_MEMBERS`/`COMMAND_FACETS` pins.

The full relevant suite (`professions_bind_on_trade_surfaces`,
`professions_commissions`, `items`, `world_api_parity`, `guide`,
`localization_fixes`) already passes and covers every acceptance criterion
in the issue except one: a `bindOnTrade`-armed copy keeping its armed flag
through sell *plus* buyback was only pinned on the sell side, never
round-tripped through a buyback call. This PR closes that one coverage gap
and updates a stale planning note.

## What this PR changes

- `tests/professions_bind_on_trade_surfaces.test.ts`: adds a regression test
  that sells an ARMED (`bindOnTrade: true`) copy to a vendor, buys it back,
  and asserts the returned instance still equals `{ bindOnTrade: true }`
  (no `boundTo`), i.e. the plain re-grant path never strips the flag.
- `docs/design/professions.md`: marks the "Buyback payload option b" item
  under Maintainer-side items as resolved and shipped, citing the
  `items.ts` functions and this issue, since the decision described there
  has already been made and implemented.

No production `src/sim/`, `world_api/`, `net/`, `server/`, or HUD changes
are needed; this is a test-coverage and documentation-accuracy change only.

## Related issues

Closes #2412

## Type of change

- [ ] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/professions_bind_on_trade_surfaces.test.ts`
  - `npx vitest run tests/world_api_parity.test.ts tests/professions_commissions.test.ts tests/items.test.ts tests/guide.test.ts tests/localization_fixes.test.ts`
  - `npm run gate` (full local CI-equivalent gate: PASS, all 11 steps green)
- Manual steps: none; this is a sim-logic test and a doc change, not a
  player-visible or visual change.

Note on the gate run: this worktree shared a heavily loaded CI/dev machine
with several other concurrent jobs. An early full-gate attempt surfaced
33 unrelated test failures (mail_expiry, terrain_streaming, frost_mage_procs,
threat, malware_scan, and others), every one of them an explicit vitest
`Test timed out` (or a wall-clock-sensitive assertion) rather than a logic
failure, and none touching `src/sim/items.ts` or this PR's two files. Every
one of those files was re-run in isolation and passed cleanly (525/525
tests), and a subsequent full `npm run gate` run once machine load eased
came back fully green (22799/22852 tests passed, 53 pre-existing skips;
`[gate] PASS: all 11 steps green`).

## Screenshots / recordings

N/A. No player-visible or visual change.

## Flow this pins

```mermaid
sequenceDiagram
    participant Player
    participant sellItem as items.ts sellItem
    participant recordVendorBuyback
    participant buyBackItem as items.ts buyBackItem
    participant Bags as Player inventory

    Player->>sellItem: sell 1x enchanted/masterwork/signed/armed copy
    sellItem->>Bags: removeVendorSellUnits (returns {instance, craftedRecipeId})
    sellItem->>recordVendorBuyback: record row(itemId, instance, craftedRecipeId)
    Note right of recordVendorBuyback: merges only when<br/>canStackInstancePayloads matches;<br/>otherwise a distinct row
    recordVendorBuyback-->>sellItem: buyback row stored, payload deep-cloned

    Player->>buyBackItem: buy back (index, expectedInstance, expectedCraftedRecipeId)
    buyBackItem->>buyBackItem: resolve exact row (index match, else full scan,<br/>else itemId-only fallback for legacy calls)
    buyBackItem->>Bags: countFit(itemId, 1, slot.instance, slot.craftedRecipeId)
    Note right of buyBackItem: capacity preflight is merge-aware,<br/>not payload-blind
    buyBackItem->>Bags: addItemSilent -> addStacked(instance, craftedRecipeId)
    Bags-->>Player: exact copy restored: enchant, masterwork,<br/>signature, and bindOnTrade arm intact
```

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added a
      decisive regression test for the one previously-unpinned acceptance
      criterion and recorded the commands above.

### Cross-platform

- [x] N/A. Sim-logic test and documentation change only; no rendered UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS`
      is not enabled in any production path.
- [x] I didn't hand-edit generated files.
