### PR TITLE
refactor(bot): verification foundation for the Discord bot stability packet (Phase 1)

### DIFF
--- a/.claude/agents/qa-checklist.md
+++ b/.claude/agents/qa-checklist.md
@@ -247,8 +247,8 @@ Skip if no `src/sim/content/` files are in scope.
   `npm run i18n:gen` then the i18n freshness check
   (`git diff --exit-code` over the generated i18n artifacts), `npm run security:gate`,
   `npm run ci:changed` (biome, changed files), `npm run sfx:check`,
-  `npm test`, `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`,
-  `npm run build:bot`, `npm run build`.
+  `npm test`, `npm run test:browser`, `npm run check:types`, `npm run build:env`,
+  `npm run build:server`, `npm run build:bot`, `npm run build`.
 - Biome gates CHANGED FILES ONLY (`npm run ci:changed`); it fails on errors and format diffs,
   not lint warnings. A stray whole-tree `biome --write` that drags an unrelated monolith into
   the diff is a `[FAIL]` (the global Biome chore is deferred; never reformat the legacy tree).

--- a/.claude/agents/qa-checklist.md
+++ b/.claude/agents/qa-checklist.md
@@ -247,7 +247,8 @@ Skip if no `src/sim/content/` files are in scope.
   `npm run i18n:gen` then the i18n freshness check
   (`git diff --exit-code` over the generated i18n artifacts), `npm run security:gate`,
   `npm run ci:changed` (biome, changed files), `npm run sfx:check`,
-  `npm test`, `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, `npm run build`.
+  `npm test`, `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`,
+  `npm run build:bot`, `npm run build`.
 - Biome gates CHANGED FILES ONLY (`npm run ci:changed`); it fails on errors and format diffs,
   not lint warnings. A stray whole-tree `biome --write` that drags an unrelated monolith into
   the diff is a `[FAIL]` (the global Biome chore is deferred; never reformat the legacy tree).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ permissions:
 #                 slowest quarter, not the whole suite.
 #
 #   pr-checks     the PR tier's serialized checks (i18n freshness + coverage
-#                 summary, malware gate, game/admin typecheck, env/server/client
+#                 summary, malware gate, game/admin typecheck, env/server/bot/client
 #                 builds), split into their own job so they run in parallel with
 #                 pr-gate and the PR critical path is max(tests, checks), not
 #                 their sum. Same triggers as pr-gate.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,12 @@ jobs:
       - name: Build server
         run: npm run build:server
 
+      # The Discord bot bundles from the same tree and ships in the same image
+      # (Dockerfile runs build:bot), so a broken bot bundle must fail here rather
+      # than on the production host during docker compose up --build.
+      - name: Build Discord bot
+        run: npm run build:bot
+
       - name: Build client
         run: npm run build
 
@@ -316,6 +322,12 @@ jobs:
       - name: Build server
         if: matrix.shard == 1
         run: npm run build:server
+
+      # Same reason as the PR-tier job: the bot bundles from this tree and ships
+      # in the same image, so a broken bot bundle fails here, not on the host.
+      - name: Build Discord bot
+        if: matrix.shard == 1
+        run: npm run build:bot
 
       - name: Build client
         if: matrix.shard == 1

--- a/bot/CLAUDE.md
+++ b/bot/CLAUDE.md
@@ -58,7 +58,7 @@ Zero new dependencies: Gateway over the existing `ws`, REST via built-in `fetch`
   after construction is still seen, and the global is never invoked with the
   instance as its `this`. Every shell also has a test that drives the DEFAULT
   path, not just the injected one; keep that pair when adding a shell, and write
-  it the only two ways that can actually fail:
+  it so that it can actually fail, which takes BOTH of these:
   **construct the shell BEFORE stubbing the global** (stub-then-construct passes
   for a capturing `= fetch`, so it does not guard this rule at all), and
   **assert every argument the default forwards**, not just the first (a

--- a/bot/CLAUDE.md
+++ b/bot/CLAUDE.md
@@ -21,10 +21,15 @@ Zero new dependencies: Gateway over the existing `ws`, REST via built-in `fetch`
 - `logic.ts`: **pure, IO-free** protocol/diff/message-builder logic. Unit-tested in
   `tests/discord_bot.test.ts`.
 - `gateway.ts`: ws Gateway (v10) IO shell (HELLO/heartbeat, IDENTIFY, RESUME).
-- `discord_api.ts`: thin Discord REST client (bot-token authed).
+  Tested in `tests/discord_bot_gateway.test.ts`.
+- `discord_api.ts`: thin Discord REST client (bot-token authed). Tested in
+  `tests/discord_bot_discord_api.test.ts`.
 - `server_client.ts`: client for the game server's secret-gated `/internal/discord/*`
   endpoints (`x-woc-discord-secret`); grep `/internal/discord/` there for the live set.
-- `config.ts`: env to `BotConfig` (throws on missing required).
+  Tested in `tests/discord_bot_server_client.test.ts`.
+- `config.ts`: env to `BotConfig` (throws on missing required). Tested in
+  `tests/discord_bot_config.test.ts`.
+- `cadence.ts`: the poll-loop interval constants, importable without booting `main.ts`.
 - `main.ts`: wiring only: guild state seeded from `GUILD_CREATE` (plus the op 8
   member backfill for large guilds), kept live by the `GUILD_MEMBER_*` events,
   event dispatch, the poll loops.
@@ -44,6 +49,15 @@ Zero new dependencies: Gateway over the existing `ws`, REST via built-in `fetch`
 - **Pure/IO split** (like `wallet_link.ts` vs `wallet.ts`): protocol/diff/embed
   logic in `logic.ts` (tested), ws/fetch IO in the shells. Don't inline opcode or
   role-diff logic into `gateway.ts`/`main.ts`.
+- **One injection convention in the three shells.** Each shell takes its IO as
+  TRAILING constructor parameters with production defaults, so `main.ts` keeps
+  constructing with the leading arguments only and gets exactly production IO.
+  Every default FORWARDS to the global, `(...args) => fetch(...args)` and
+  `(cb, ms) => setTimeout(cb, ms)`, never `= fetch` or `= { setTimeout }`: the
+  forwarding form reads the global at CALL time, so a test that swaps a global
+  after construction is still seen, and the global is never invoked with the
+  instance as its `this`. Every shell also has a test that drives the DEFAULT
+  path, not just the injected one; keep that pair when adding a shell.
 - **Secrets are env only**; never commit them. `DISCORD_BOT_SECRET` must match the server's.
 - **Privileged intents:** `GUILD_MEMBERS` + `GUILD_PRESENCES` must be enabled for the
   application in the Discord developer portal, or IDENTIFY is rejected (close 4014).

--- a/bot/CLAUDE.md
+++ b/bot/CLAUDE.md
@@ -57,7 +57,14 @@ Zero new dependencies: Gateway over the existing `ws`, REST via built-in `fetch`
   forwarding form reads the global at CALL time, so a test that swaps a global
   after construction is still seen, and the global is never invoked with the
   instance as its `this`. Every shell also has a test that drives the DEFAULT
-  path, not just the injected one; keep that pair when adding a shell.
+  path, not just the injected one; keep that pair when adding a shell, and write
+  it the only two ways that can actually fail:
+  **construct the shell BEFORE stubbing the global** (stub-then-construct passes
+  for a capturing `= fetch`, so it does not guard this rule at all), and
+  **assert every argument the default forwards**, not just the first (a
+  one-parameter stub passes for `(input) => fetch(input)`, which type-checks
+  because TypeScript accepts an arity-reduced function, and which would strip
+  the auth header off every request in production).
 - **Secrets are env only**; never commit them. `DISCORD_BOT_SECRET` must match the server's.
 - **Privileged intents:** `GUILD_MEMBERS` + `GUILD_PRESENCES` must be enabled for the
   application in the Discord developer portal, or IDENTIFY is rejected (close 4014).

--- a/bot/cadence.ts
+++ b/bot/cadence.ts
@@ -5,7 +5,8 @@
 // env, real Discord REST, a real WebSocket). Keeping them here lets the suite
 // pin the cadences directly.
 //
-// Values only: no env parsing, no derived timers. Every consumer is main.ts.
+// Values only: no env parsing, no derived timers. main.ts is the only RUNTIME
+// consumer; the suite imports them directly to pin them.
 
 export const ROLE_SYNC_INTERVAL_MS = 5 * 60_000;
 export const PRESENCE_DEBOUNCE_MS = 4_000;

--- a/bot/cadence.ts
+++ b/bot/cadence.ts
@@ -1,0 +1,12 @@
+// How often the bot's background loops run.
+//
+// These live outside main.ts because main.ts calls main() at module scope, so a
+// test cannot import a constant from there without booting the whole bot (real
+// env, real Discord REST, a real WebSocket). Keeping them here lets the suite
+// pin the cadences directly.
+//
+// Values only: no env parsing, no derived timers. Every consumer is main.ts.
+
+export const ROLE_SYNC_INTERVAL_MS = 5 * 60_000;
+export const PRESENCE_DEBOUNCE_MS = 4_000;
+export const RELAY_POLL_MS = 3_000; // how often the bot pulls queued in-game "!" posts

--- a/bot/discord_api.ts
+++ b/bot/discord_api.ts
@@ -6,7 +6,20 @@
 const API = 'https://discord.com/api/v10';
 
 export class DiscordApi {
-  constructor(private token: string) {}
+  // `fetch` and the retry-after sleep are trailing constructor parameters with
+  // their production defaults so tests can drive the request path (including the
+  // 429 retry) with no real network IO and no real wait. Constructed with the
+  // token alone, as main.ts does, this is exactly the production client.
+  //
+  // Every default forwards to the global rather than capturing it, which keeps
+  // one convention across the three shells: the global is read at CALL time, so
+  // it is never invoked with the instance as its `this`, and a test that swaps a
+  // global after construction is still seen. See bot/CLAUDE.md.
+  constructor(
+    private token: string,
+    private fetchImpl: typeof fetch = (...args) => fetch(...args),
+    private sleep: (ms: number) => Promise<void> = (ms) => new Promise((r) => setTimeout(r, ms)),
+  ) {}
 
   private async request(
     method: string,
@@ -14,7 +27,7 @@ export class DiscordApi {
     body?: unknown,
     retry = true,
   ): Promise<unknown> {
-    const resp = await fetch(`${API}${path}`, {
+    const resp = await this.fetchImpl(`${API}${path}`, {
       method,
       headers: {
         Authorization: `Bot ${this.token}`,
@@ -26,7 +39,7 @@ export class DiscordApi {
     if (resp.status === 429 && retry) {
       const data = (await resp.json().catch(() => ({}))) as { retry_after?: number };
       const waitMs = Math.min(10_000, Math.max(500, (data.retry_after ?? 1) * 1000));
-      await new Promise((r) => setTimeout(r, waitMs));
+      await this.sleep(waitMs);
       return this.request(method, path, body, false);
     }
     if (!resp.ok) {

--- a/bot/gateway.ts
+++ b/bot/gateway.ts
@@ -15,8 +15,23 @@ export interface GatewayHandlers {
   onDispatch(type: string, data: Record<string, unknown>): void;
 }
 
+/** Opens the gateway socket. Injected so tests can hand the Gateway a fake
+ *  socket; production is the `ws` client this file already imports. The return
+ *  type is `ws`'s own WebSocket so the `on('message'|'close'|'error', ...)`
+ *  callbacks keep their contextual parameter types and `WebSocket.OPEN` stays
+ *  reachable. */
+export type GatewaySocketFactory = (url: string) => WebSocket;
+
+/** The timers the reconnect delays and the heartbeat run on. Injected so tests
+ *  can drive those paths on fake timers instead of real waits. */
+export interface GatewayTimers {
+  setTimeout: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  setInterval: (cb: () => void, ms: number) => ReturnType<typeof setInterval>;
+  clearInterval: (id: ReturnType<typeof setInterval>) => void;
+}
+
 // Close codes we cannot resume from / must not auto-reconnect (bad token, bad
-// intents, etc.) — see Discord gateway close-code docs.
+// intents, etc.), see Discord gateway close-code docs.
 const FATAL_CLOSE_CODES = new Set([4004, 4010, 4011, 4012, 4013, 4014]);
 
 export class Gateway {
@@ -32,6 +47,17 @@ export class Gateway {
     private token: string,
     private gatewayUrl: string,
     private handlers: GatewayHandlers,
+    // Socket + timers trail `handlers` with their production defaults, so
+    // main.ts keeps constructing with the first three arguments and gets exactly
+    // today's IO; tests pass a fake socket and fake timers instead. Each default
+    // forwards to the global rather than capturing it, the same convention the
+    // other two shells use (see bot/CLAUDE.md).
+    private socketFactory: GatewaySocketFactory = (url) => new WebSocket(url),
+    private timers: GatewayTimers = {
+      setTimeout: (cb, ms) => setTimeout(cb, ms),
+      setInterval: (cb, ms) => setInterval(cb, ms),
+      clearInterval: (id) => clearInterval(id),
+    },
   ) {}
 
   /**
@@ -47,7 +73,7 @@ export class Gateway {
   connect(resume = false): void {
     this.resuming = resume && this.sessionId !== null;
     const base = this.resuming && this.resumeUrl ? this.resumeUrl : this.gatewayUrl;
-    const ws = new WebSocket(`${base}/?v=10&encoding=json`);
+    const ws = this.socketFactory(`${base}/?v=10&encoding=json`);
     this.ws = ws;
     ws.on('message', (raw) => {
       try {
@@ -81,7 +107,7 @@ export class Gateway {
       case GATEWAY_OP.INVALID_SESSION:
         // d=true means resumable; else re-identify after a short delay.
         this.resuming = payload.d === true;
-        setTimeout(() => this.reconnect(this.resuming), 1500);
+        this.timers.setTimeout(() => this.reconnect(this.resuming), 1500);
         break;
       case GATEWAY_OP.RECONNECT:
         this.reconnect(true);
@@ -108,7 +134,7 @@ export class Gateway {
   private startHeartbeat(intervalMs: number): void {
     this.stopHeartbeat();
     this.acked = true;
-    this.heartbeatTimer = setInterval(() => {
+    this.heartbeatTimer = this.timers.setInterval(() => {
       if (!this.acked) {
         // No ACK since the last beat: the connection is a zombie. Drop + resume.
         this.ws?.terminate();
@@ -124,7 +150,7 @@ export class Gateway {
   }
 
   private stopHeartbeat(): void {
-    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
+    if (this.heartbeatTimer) this.timers.clearInterval(this.heartbeatTimer);
     this.heartbeatTimer = null;
   }
 
@@ -138,7 +164,7 @@ export class Gateway {
       console.error(`[bot] gateway closed with fatal code ${code}; not reconnecting`);
       return;
     }
-    setTimeout(() => this.reconnect(true), 2000);
+    this.timers.setTimeout(() => this.reconnect(true), 2000);
   }
 
   private reconnect(resume: boolean): void {

--- a/bot/gateway.ts
+++ b/bot/gateway.ts
@@ -155,6 +155,11 @@ export class Gateway {
   }
 
   private send(obj: Record<string, unknown>): void {
+    // NOTE for anyone injecting a socketFactory: OPEN is read from the `ws`
+    // module imported above, not from the socket this returned. A fake whose
+    // OPEN differs makes every send a silent no-op (no IDENTIFY, no heartbeat,
+    // no error), which reads as a hung gateway rather than a wiring bug. The
+    // suite avoids it by module-mocking `ws` so both sides are the same class.
     if (this.ws?.readyState === WebSocket.OPEN) this.ws.send(JSON.stringify(obj));
   }
 

--- a/bot/main.ts
+++ b/bot/main.ts
@@ -12,6 +12,7 @@
 // this file is the wiring. esbuild-bundled for Node via `npm run bot`.
 
 import { DISCORD_REWARD_GRANTS } from '../src/sim/discord_tier';
+import { PRESENCE_DEBOUNCE_MS, RELAY_POLL_MS, ROLE_SYNC_INTERVAL_MS } from './cadence';
 import { loadConfig } from './config';
 import { DiscordApi } from './discord_api';
 import { Gateway } from './gateway';
@@ -42,10 +43,6 @@ import {
   voiceMembersForChannel,
 } from './logic';
 import { ServerClient, type VoiceMemberPush } from './server_client';
-
-const ROLE_SYNC_INTERVAL_MS = 5 * 60_000;
-const PRESENCE_DEBOUNCE_MS = 4_000;
-const RELAY_POLL_MS = 3_000; // how often the bot pulls queued in-game "!" posts
 
 async function main(): Promise<void> {
   // Load .env (and optional .env.local) into process.env, matching server/db.ts.

--- a/bot/server_client.ts
+++ b/bot/server_client.ts
@@ -23,17 +23,42 @@ export interface VoiceMemberPush {
   selfMute: boolean;
 }
 
+/**
+ * How long one server call may run before its AbortController fires. Named
+ * rather than inline so the suite can pin the deadline against a literal.
+ */
+export const SERVER_CALL_TIMEOUT_MS = 8000;
+
+/** What a TimerSeam hands back. Opaque: only ever passed back to clearTimeout. */
+export type TimerHandle = ReturnType<typeof setTimeout> | number;
+
+/** The timer pair backing the per-call deadline. */
+export interface TimerSeam {
+  setTimeout: (fn: () => void, ms: number) => TimerHandle;
+  clearTimeout: (handle: TimerHandle) => void;
+}
+
 export class ServerClient {
+  // `fetch` and the deadline timer pair are trailing constructor parameters with
+  // their production defaults, so a test can drive the whole request/response
+  // envelope with no network IO and fire the abort deadline without a real 8
+  // second wait. Constructed with a base URL and a secret alone, as main.ts
+  // does, this is exactly the production client.
   constructor(
     private baseUrl: string,
     private secret: string,
+    private fetchImpl: typeof fetch = (...args) => fetch(...args),
+    private timers: TimerSeam = {
+      setTimeout: (fn, ms) => setTimeout(fn, ms),
+      clearTimeout: (handle) => clearTimeout(handle),
+    },
   ) {}
 
   private async call<T>(method: string, path: string, body?: unknown): Promise<T | null> {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 8000);
+    const timer = this.timers.setTimeout(() => controller.abort(), SERVER_CALL_TIMEOUT_MS);
     try {
-      const resp = await fetch(`${this.baseUrl}${path}`, {
+      const resp = await this.fetchImpl(`${this.baseUrl}${path}`, {
         method,
         headers: {
           'x-woc-discord-secret': this.secret,
@@ -52,7 +77,7 @@ export class ServerClient {
       console.error(`[bot] server ${method} ${path} failed`, err);
       return null;
     } finally {
-      clearTimeout(timer);
+      this.timers.clearTimeout(timer);
     }
   }
 

--- a/docs/discord-bot-stability/README.md
+++ b/docs/discord-bot-stability/README.md
@@ -1,0 +1,38 @@
+# Discord Bot Stability Packet
+
+Rebuild the Discord bot integration so the 2026-07-29 incident class (a sustained 429
+retry storm against Discord plus internal polling that doubled the game server's HTTP
+volume) is structurally impossible, and so the integration scales cleanly to 10x the
+current population (design envelope: 1,000 concurrent players, 5,000 guild members).
+Stability and architecture only: no new player-facing features in this packet.
+
+Branch: `feature/discord-bot-stability` off `release/v0.33.0`.
+Worktree: `/Users/fernando/Documents/wocc-discord-bot`.
+
+## Reading order
+
+1. [incident-2026-07-29.md](incident-2026-07-29.md): the production diagnosis this packet answers.
+2. [brainstorm.md](brainstorm.md): findings from the code and Discord-contract research, the approved architecture, and OPEN items.
+3. [implementation-plan.md](implementation-plan.md): canonical workflow, review dispatch matrix, phase summary.
+4. [state.md](state.md): locked decisions, validation matrix, key paths. Read this first in every session.
+5. [progress.md](progress.md): phase status and deliverable checklists.
+6. [qa-checklist.md](qa-checklist.md): the whole-feature integration matrix for the final QA phase.
+
+## Phases (each implementation phase is followed by its own QA session)
+
+| Phase | File | QA file |
+|---|---|---|
+| 1. Bot verification foundation | [phase-01-verification-foundation.md](phase-01-verification-foundation.md) | [phase-01-qa.md](phase-01-qa.md) |
+| 2. Discord rate-limit governor | [phase-02-rate-limit-governor.md](phase-02-rate-limit-governor.md) | [phase-02-qa.md](phase-02-qa.md) |
+| 3. Loop scheduler + diff-before-write | [phase-03-scheduler-and-diffs.md](phase-03-scheduler-and-diffs.md) | [phase-03-qa.md](phase-03-qa.md) |
+| 4. Server set-based endpoints | [phase-04-server-batch-endpoints.md](phase-04-server-batch-endpoints.md) | [phase-04-qa.md](phase-04-qa.md) |
+| 5. Outbox + linked-member change feed | [phase-05-outbox-change-feed.md](phase-05-outbox-change-feed.md) | [phase-05-qa.md](phase-05-qa.md) |
+| 6. Bot consumes the new surface | [phase-06-bot-new-surface.md](phase-06-bot-new-surface.md) | [phase-06-qa.md](phase-06-qa.md) |
+| 7. Supervision + deploy hardening | [phase-07-supervision-deploy.md](phase-07-supervision-deploy.md) | [phase-07-qa.md](phase-07-qa.md) |
+| 8. Observability | [phase-08-observability.md](phase-08-observability.md) | [phase-08-qa.md](phase-08-qa.md) |
+| 9. /api/discord caching | [phase-09-api-discord-caching.md](phase-09-api-discord-caching.md) | [phase-09-qa.md](phase-09-qa.md) |
+
+Every phase runs as a fresh Claude Code session using the starter prompt in its file.
+Every QA phase runs at full rigor: ultracode (adversarial-verify workflow) plus mutation
+spot checks on the new pure modules. Phase 9 QA closes the packet and offers teardown of
+this directory before the PR.

--- a/docs/discord-bot-stability/brainstorm.md
+++ b/docs/discord-bot-stability/brainstorm.md
@@ -1,0 +1,165 @@
+# Brainstorm: Discord Bot Stability
+
+## Vision
+
+The Discord bot becomes a well-behaved citizen of both ecosystems it touches: it never
+exceeds Discord's documented rate-limit contract (and structurally cannot, even under
+fault), and it imposes near-constant load on the game server regardless of population.
+The 2026-07-29 incident class becomes impossible by construction, not by tuning.
+
+Approved direction (user sign-off 2026-07-30):
+- Transport for game-to-bot events: one consolidated outbox poll endpoint with adaptive cadence.
+- Deploy hardening in scope: bot container healthcheck + fatal-close exit, and Caddy 404 for `/internal/*`.
+- `/api/discord` public caching included as its own phase; `/api/site-presence` untouched.
+- Interim prod: left as is; no hotfix branch, no container stop. The packet is the fix.
+- QA: full rigor every phase (ultracode adversarial workflows + mutation spot checks).
+- Scale envelope: 10x today (1,000 concurrent players, 5,000 guild members).
+- Scope: stability only; feature additions (two-way relay etc.) are follow-up issues.
+
+## Incident summary (full report: incident-2026-07-29.md)
+
+~600,000 failed Discord requests over 2 days, peaking at 35 to 38k 429s/hr, with Discord
+issuing a global temporary API ban around 22:00 both nights. Separately, the bot
+generated ~13.5k of the game server's ~30k HTTP requests in a sample hour (about 45%)
+and held ~110 established TCP connections to :8787. The game itself stayed healthy
+(19.99 Hz). A restart re-ignites the storm within the hour.
+
+## Root causes (five compounding defects)
+
+1. **Unconditional nickname PATCH** (`bot/main.ts:241-247`). Roles are diffed before
+   writing (`computeRoleSync`, `bot/logic.ts:136`); nicknames are not. Every linked
+   online member gets a guild-member PATCH every 5-minute sweep forever. Each PATCH
+   makes Discord emit `GUILD_MEMBER_UPDATE`, whose handler (`bot/main.ts:319-333`)
+   unconditionally POSTs `/internal/discord/members-meta` back into the game: the bot
+   generates its own inbound load (~63/min observed).
+2. **The 429 handler escalates instead of backing off** (`bot/discord_api.ts:26-31`).
+   The wait is clamped to a 10-second ceiling (global penalties run far longer); a
+   non-JSON 429 body (the Cloudflare ban response) falls through to a 1-second retry;
+   the `global` flag and all `X-RateLimit-*` headers are ignored; every error is
+   swallowed at the call sites so the sweep continues.
+3. **No overlap guards.** Six bare `setInterval` loops (`bot/main.ts:518-537`) fire
+   whether or not the previous run finished. Once backoff stretches a sweep past its
+   5-minute period, sweeps stack and volume climbs. This converts a burst into a
+   sustained storm that restarts re-ignite.
+4. **The ban mechanism is Discord's invalid-request counter**: ~10,000 requests
+   returning 401/403/429 per 10 minutes per IP triggers a temporary ban. Ignored 429s
+   count toward it, and permanent 403s (members whose top role outranks the bot) were
+   retried every sweep forever.
+5. **Server-side amplification.** The sweep iterates every online Discord user (not
+   linked players; `onlineUsers` populated from `PRESENCE_UPDATE`, `bot/main.ts:298-306`)
+   paying 1 to 4 uncached Postgres queries each via `/internal/discord/flex`
+   (`accountForDiscord` `server/discord_db.ts:134`, then `discordFlexForAccount`
+   `server/discord.ts:950` fanning to `highestCharacterForAccount` `server/db.ts:2669`
+   with its JSONB-expression sort). `members-meta` runs one serial UPDATE per member
+   with no change detection (`server/internal.ts:533` -> `setDiscordMemberMeta`
+   `server/discord_db.ts:590`). Three pollers fire every 3 seconds against queues that
+   are almost always empty, while the only free endpoint (presence, zero DB) polls least.
+   No `/internal/*` route uses the cached-read seam; none is rate-limited.
+
+Ops gaps that let it fester: only `bot/logic.ts` is type-checked (tsconfig `include`
+lacks `bot`; `scripts/gate.mjs` has no `build:bot` step; the bundle first compiles on
+the prod host during `docker compose up --build`); the bot container has no healthcheck,
+no `mem_limit`, no `stop_grace_period` (`docker-compose.yml:201-224`) and a fatal
+gateway close (`bot/gateway.ts:135-142`) logs and returns without exiting, leaving a
+zombie process Docker never restarts; `/internal/*` is publicly reachable through Caddy
+(`deploy/user-data.sh:84-92` 404s only `/livez /readyz /metrics`) with the shared header
+secret (`server/http/middleware/require_internal_secret.ts`) as the only gate.
+
+Ruled out early: "use the gateway instead of polling Discord" is already done. The bot
+consumes `GUILD_MEMBER_UPDATE`/`ADD`/`REMOVE`, presences, and voice states over a real
+Gateway v10 connection with the `GUILD_MEMBERS` + `GUILD_PRESENCES` privileged intents
+(`bot/logic.ts:12-17`). The polling exists to observe game-side changes (level ups, tier
+changes), which Discord cannot report. The fix is a game-to-bot change feed.
+
+## Existing assets to reuse
+
+- The pure/IO split (`bot/CLAUDE.md`): protocol and diff logic in `bot/logic.ts` with
+  real tests (`tests/discord_bot.test.ts`, 635 lines); ws/fetch IO in thin shells. The
+  governor and scheduler land as pure tested modules under this convention.
+- `computeRoleSync` (`bot/logic.ts:136`): the correct diff-before-write exemplar,
+  including update-cache-only-after-success.
+- The server's RouteDef pipeline (`server/http/`): all 12 internal routes are already
+  proper RouteDef modules in `server/internal.ts:329-549` behind
+  `requireInternalSecret`, with strong tests (`tests/server/internal.test.ts`) and the
+  characterization spine (`surface_inventory.ts`, `parity.test.ts`, `completeness`).
+- The bounded FIFO queue pattern (`server/discord_relay.ts` cap 50,
+  `server/discord_activity.ts` cap 100 + 30s dedupe): the template for the new
+  linked-member change feed. Note both modules currently have NO tests
+  (`tests/discord_relay.test.ts` tests the unrelated `src/sim/discord_relay.ts`).
+- The in-memory presence cache (`setDiscordPresenceCache`, `server/discord.ts:185`,
+  staleness zeroing at `:191-203`): the zero-cost push exemplar, and the piggyback
+  vehicle for bot observability counters.
+- Server hot-path seams (`server/CLAUDE.md`): `createCachedRead`/`singleFlight` with
+  moderation busts (currently unused by every Discord route), the retention sweep
+  (`server/main.ts:3080-3087`), `teeMetricSink` (`server/http/middleware/metric_sink.ts:26`),
+  and the `GameStateSource` readout object (`server/main.ts:3008-3022`).
+
+## New work needed
+
+Bot: rate-limit governor (pure), loop scheduler with overlap guards and adaptive
+cadence (pure), nickname + members-meta diff-before-write with echo suppression,
+linked-set sweep, bounded keep-alive transport, fatal-close exit + heartbeat, counters.
+
+Server: `POST /internal/discord/flex-batch`, linked-member change feed module,
+`GET /internal/discord/outbox` (drains relay + activity + winners + changes with
+batched account lookups), members-meta multi-row upsert with unchanged-row skip,
+`reward_ledger` retention story, `/api/discord` keyed cached-read with moderation busts.
+
+Deploy: bot healthcheck/limits in compose, Caddy 404 for `/internal/*`, DEPLOY.md bot
+section + incident runbook.
+
+Verification: `bot` in tsconfig include, `build:bot` in the gate, tests for the five
+untested bot files, tests for `discord_relay.ts`/`discord_activity.ts`, query-count
+assertions, cadence pins, deploy pins.
+
+## Discord contract research (primary sources, verified 2026-07-30)
+
+Full citations in the research brief summarized here; canonical docs now live at
+docs.discord.com (old discord.com/developers URLs 301-redirect).
+
+- 429 body: `retry_after` (float seconds), `global` flag, plus `Retry-After` header and
+  the normal `X-RateLimit-*` set (`Limit`, `Remaining`, `Reset`, `Reset-After`,
+  `Bucket`, and on 429 `Scope`: `user` | `global` | `shared`). Shared-scope 429s do NOT
+  count toward the ban counter; everything else invalid does.
+- Buckets key on route + major parameter (`guild_id`/`channel_id`/`webhook_id`); track
+  them via the `X-RateLimit-Bucket` hash (bootstrap with a provisional
+  method+route+majorParam key, remap after the first response). Proactive rule: never
+  dispatch from a bucket at `Remaining == 0`; wait out `Reset-After`.
+- Global: 50 req/s per bot. Invalid-request ban: 10,000 requests returning 401/403/429
+  per 10 minutes per IP; ban duration undocumented (design as indefinite).
+- No published numeric limit for `PATCH /guilds/{guild.id}/members/{user.id}`; per-route
+  limits are runtime-discoverable only. Never hard-code numbers; headers drive.
+- Gateway full-member chunk requests (opcode 8, `limit: 0`) are rate limited to 1 per
+  guild per bot per 30 seconds (changelog 2025-08-14, enforced everywhere 2025-10-01);
+  backfill once at connect, maintain incrementally, never re-chunk on a timer.
+- IDENTIFY: 1,000 per 24h (exceeding resets the bot token). Gateway sends cap: 120
+  events per connection per 60s. Privileged-intent policy changed 2026-06-10: threshold
+  is now 10,000 unique users (we are far under; self-toggle in the portal).
+- Requests must carry a valid `User-Agent` (`DiscordBot ($url, $versionNumber)`); pin
+  the API version in the base URL explicitly (`/api/v10`); `X-Audit-Log-Reason`
+  (1-512 chars) is supported on member PATCH with no rate-limit cost.
+
+## OPEN items (flagged, not blockers)
+
+- O1: Ban duration undocumented; the breaker treats it as indefinite.
+- O2: Member-PATCH per-route numeric limits undocumented; the governor learns them from
+  headers at runtime.
+- O3: A stricter hidden nickname-write limit is community-reported but unconfirmed;
+  headers drive either way.
+- O4 (human): confirm `GUILD_MEMBERS` + `GUILD_PRESENCES` stay enabled in the Developer
+  Portal under the 2026-06-10 policy (self-serve under 10,000 users).
+- O5: Whether member-write 429s return `user` or `shared` scope decides ban-counter
+  exposure; instrument `X-RateLimit-Scope` from day one and check logs after deploy.
+- O6: The gateway `RATE_LIMITED` event payload shape is unconfirmed; irrelevant unless
+  someone reintroduces timed re-chunking (do not).
+- O7: The Caddy `/internal/*` change takes effect at the next prod rollout, a deliberate
+  manual step after the packet merges.
+
+## Follow-ups deliberately out of scope (file as issues after the packet)
+
+- Two-way chat relay (Discord into the world): moderation/sanitization/i18n surface.
+- `/api/site-presence` write cadence.
+- Retiring the now-unused per-endpoint internal GET routes (relay, activity, winners)
+  once the frozen legacy ladder deletion lands (dual-arm churn makes it wrong to do now).
+- Retiring the legacy `handleDiscordInternal` ladder itself (`server/internal.ts:75-241`),
+  owned by the pipeline packet, not this one.

--- a/docs/discord-bot-stability/implementation-plan.md
+++ b/docs/discord-bot-stability/implementation-plan.md
@@ -1,0 +1,279 @@
+# Implementation Plan: Discord Bot Stability
+
+Nine implementation phases, each followed by its own QA session (18 sessions total).
+Every session is fresh, runs the starter prompt from its `phase-XX-*.md` file, and obeys
+`state.md`. Model per session: Opus 4.8 or newer at xhigh effort. Every QA session runs
+ultracode (D19).
+
+## Canonical workflow (every phase)
+
+1. **Step 0, pre-flight**: `git status` clean in the worktree
+   (`/Users/fernando/Documents/wocc-discord-bot`); memory scan of `MEMORY.md` for the
+   phase domain.
+2. **Step 1, load context**: spawn an Explore agent over `state.md`, `progress.md`, the
+   phase file, and the phase's listed source files. The main loop reads conclusions,
+   not raw files.
+3. **Step 2, execute**: pick the lightest orchestration (parallel Agent fan-out for
+   independent slices, ultracode Workflow for batch or adversarial work). Request
+   fan-out explicitly; give agents the Explore summary, not raw planning docs.
+4. **Step 3, validate + review**: run the `state.md` validation matrix rows matching
+   the diff, then dispatch review agents per the matrix below (only matching rows).
+   Prompt every reviewer for COVERAGE, not filtering; resume truncated reviewers with
+   "Stop reading more files. Output the full report now. No more tool calls. Format:
+   BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT." Do not commit until no BLOCKING
+   remains.
+5. **Step 4, docs**: update `progress.md` + `state.md` (same commit as the work,
+   explicit paths). Record surprising rules to memory.
+
+**Agent scaling**: split by vertical slice (a module plus its tests), never by file
+type. Merge trivial sides into one agent. Escalate to a Workflow past ~5 parallel
+agents or for uniform batch work. Use `isolation: "worktree"` only when agents mutate
+overlapping files concurrently.
+
+**Code hygiene**: module-first behind existing seams; new code gets decisive tests;
+delete replaced code, imports, and types; no generated-file hand-edits; Conventional
+Commits with a scope and a body; no em dashes, en dashes, or emojis anywhere.
+
+## Review Dispatch Matrix (the one canonical copy; phase files reference it)
+
+| Agent | Spawn ONLY when the diff touches | Skip it for |
+|-------|----------------------------------|-------------|
+| `privacy-security-review` | `server/`, `src/admin/`, `src/net/`, a deploy/secret file (Docker/compose/env/CI yml/`DEPLOY.md`/`deploy/`), OR introduces SQL / auth / a secret handling change | a pure `bot/`-logic, docs, or test-only change |
+| `migration-safety` | `server/db.ts`, `server/social_db.ts`, any `server/*_db.ts` DDL, or a persisted-state shape change | any diff with no DDL and no persisted-shape change |
+| `database-performance-reviewer` | SQL or a database call site, query cadence or cardinality, indexes, pool/lock/timeout behavior, or stored-data growth | any diff that cannot change database work or growth |
+| `cross-platform-sync` | `src/world_api*`, `src/sim/` behavior, `src/net/online.ts`, `server/game.ts` wire/dispatch, the sim/server i18n matchers, or the RL surface | this packet's expected diffs (bot/, server REST, deploy); if it matches, the phase went out of scope |
+| `architecture-reviewer` | any `src/sim/` change | everything this packet should touch |
+| `frontend-seam-reviewer` | `src/ui/`, `src/render/`, `src/game/`, `src/styles/` | everything this packet should touch |
+| `qa-checklist` | a phase is COMPLETE | mid-phase work |
+
+Bot-specific note: `bot/` appears in no row by design; a bot-only diff gets
+`qa-checklist` at phase end plus the phase's own adversarial QA session. If NO row
+matches, spawn no reviewer.
+
+## Phase summary
+
+Sizing note: each phase is one slice, 3 to 5 deliverables, completable in one focused
+session. QA phases apply D19 rigor: ultracode adversarial-verify plus mutation spot
+checks on that phase's new pure modules, plus the review matrix.
+
+### Phase 1: Bot verification foundation
+Make the bot verifiable before changing its behavior.
+- Add `bot` to `tsconfig.json` include; fix every latent type error that surfaces
+  (behavior-preserving fixes only).
+- Add `build:bot` to `scripts/gate.mjs` so the bundle compiles in the gate and CI, not
+  first on the prod host.
+- Introduce injectable seams for testability: `discord_api.ts`, `server_client.ts`, and
+  `gateway.ts` accept an injected fetch/socket/clock (constructor args with production
+  defaults; no behavior change).
+- Baseline tests: `bot/config.ts` (required/optional/fallback arms),
+  `bot/server_client.ts` (call envelope, secret header, timeout abort), and pins for
+  the three cadence constants (`bot/main.ts:46-48`) so later phases consciously move
+  them.
+Out of scope: any behavior change. Commits: `chore(bot)` + `test(bot)`.
+
+### Phase 2: Discord rate-limit governor
+The pure module that makes exceeding Discord's contract structurally impossible.
+- `bot/rate_governor.ts` (pure, no IO): bucket registry with provisional
+  method+route+majorParam keys remapped onto `X-RateLimit-Bucket` hashes; per-bucket
+  serialized queues; proactive gating (`Remaining == 0` waits `Reset-After`); global
+  send-rate cap (`DISCORD_MAX_RPS`, D2); process-wide global pause honoring full
+  `retry_after` with the non-JSON-429 Cloudflare arm (D2); the invalid-request circuit
+  breaker with half-open recovery (D3); the 401/403 permanent-failure cache (D4);
+  counter outputs for Phase 8.
+- Rewire `DiscordApi.request()` through the governor; pin the REST base to `/api/v10`;
+  add `X-Audit-Log-Reason` to member PATCHes; log `X-RateLimit-Scope` on every 429 (O5).
+- Config: new env keys (D2/D3/D4 names) in `bot/config.ts` with defaults.
+- Tests (the heart of the phase): header-driven pacing, 429 user/global/shared arms,
+  HTML-body 429, breaker trip and half-open, forbidden-cache no-retry, queue ordering,
+  counter correctness. Same-inputs-same-schedule determinism with an injected clock.
+Out of scope: touching the sweep, loops, or server. Commits: `feat(bot)` x2 + `test(bot)`.
+
+### Phase 3: Loop scheduler + diff-before-write
+Kill the storm mechanics: stacking loops and pointless writes.
+- `bot/scheduler.ts` (pure core + thin driver): chained-timeout loops with overlap
+  guards, jitter, adaptive idle backoff (D1 cadences), coalescing for event-triggered
+  runs (the `GUILD_CREATE` re-sweep trap), env-configurable intervals (D13).
+- Migrate all six `main.ts` loops and the presence debounce onto it; delete the bare
+  `setInterval`s.
+- Nickname diff-before-PATCH: cache member nicks from `GUILD_CREATE` / chunk /
+  `GUILD_MEMBER_UPDATE`; skip the PATCH when the computed nick matches (D5); update the
+  cache only after success (the `computeRoleSync` pattern).
+- members-meta diff: track last-successfully-pushed meta per member; push only deltas;
+  suppress self-caused `GUILD_MEMBER_UPDATE` echoes (D5).
+- Tests: fake-timer scheduler suites (overlap, backoff, coalescing), nick-diff arms
+  (no-op, changed, cache-update-on-success-only), meta-diff and echo-suppression arms.
+Out of scope: the sweep's iteration set (Phase 6), server changes. Commits:
+`feat(bot)` x2 + `refactor(bot)` + `test(bot)`.
+
+### Phase 4: Server set-based endpoints
+Make the game side cheap per call.
+- `POST /internal/discord/flex-batch` (new RouteDef in `server/internal.ts`, D9): a
+  list of Discord user ids returns flex payloads for LINKED members only, via set-based
+  queries (one `discord_links` IN pass, then batched loads), input capped and clamped
+  like members-meta; hand-added `surface_inventory.ts` rows; tests on the R1 rigs
+  including a query-count assertion (makePool `calls` array) at the D18 envelope.
+- members-meta bulk upsert (BOTH arms, D9/D10): one multi-row statement with
+  `IS DISTINCT FROM` skip; response gains an unchanged-skipped count; existing clamp
+  and cap pins stay green.
+- `reward_ledger` keep-forever comment at its DDL (D12).
+- Tests for the untested queue modules `server/discord_relay.ts` and
+  `server/discord_activity.ts` (caps, dedupe TTL, drain semantics), landing here so
+  Phase 5 refactors against a green baseline.
+Out of scope: the outbox (Phase 5). Commits: `feat(server)` x2 + `test(server)` +
+`docs(server)`.
+
+### Phase 5: Outbox + linked-member change feed
+The one poll that replaces four.
+- `server/discord_link_changes.ts`: a bounded FIFO with dedupe (the
+  `discord_activity.ts` pattern), enqueued wherever the server already learns a linked
+  account's flex-relevant state changed (level up, class change, points/tier change,
+  link/unlink); the Explore step locates every feed site and the phase enumerates them
+  in `state.md`.
+- `GET /internal/discord/outbox` (new RouteDef, D9): drains relay + activity + winners
+  + link changes in one envelope; the per-item `discordForAccount` N+1 collapses into
+  one IN query across all four streams; hand-added spine rows; a `since`/cursor-free
+  drain (destructive read, matching existing relay semantics).
+- Query-count and payload-size assertions at the D18 envelope; winners' outbound
+  daily-reward-service fetch stays TTL-cached and is pinned as at-most-once per drain.
+- Tests: full-envelope RouteDef tests on the R1 rigs, empty-drain zero-query pin,
+  mixed-stream ordering, cap behavior under overflow.
+Out of scope: bot-side consumption (Phase 6). Commits: `feat(server)` x2 +
+`test(server)`.
+
+### Phase 6: Bot consumes the new surface
+Rewire the bot onto flex-batch + outbox and delete the old paths.
+- `server_client.ts`: `flexBatch()` and `drainOutbox()` methods; delete the per-user
+  flex, relay, activity, and winners methods once unreferenced.
+- Sweep rewrite: maintain the linked-member set from flex-batch results plus outbox
+  link-change events; sweep iterates ONLY that set (D6) through the governor; spread
+  writes across the sweep window.
+- Replace the three 3-second pollers and the flex sweep's per-user GETs with one
+  outbox loop on the Phase 3 scheduler at D1 cadence; presence push unchanged.
+- Delete dead code (old poll wiring, unused logic helpers); the connection-count
+  acceptance check (a handful of established sockets at steady state, not ~110).
+- Tests: linked-set maintenance arms, outbox dispatch fan-out (relay/activity/winners/
+  changes each reach their handler), end-to-end fake-server integration of one sweep
+  cycle at the D18 envelope.
+Out of scope: deploy files. Commits: `feat(bot)` x2 + `refactor(bot)` + `test(bot)`.
+
+### Phase 7: Supervision + deploy hardening
+The process can no longer zombie, and the internal surface leaves the public internet.
+- Fatal gateway close (`FATAL_CLOSE_CODES`) exits nonzero after logging; heartbeat file
+  touched by the main loop; compose healthcheck testing heartbeat freshness plus
+  `mem_limit` and `stop_grace_period` for the bot service (game service parity).
+- Caddy: `/internal/*` joins the 404 block in `deploy/user-data.sh` (D15, O7).
+- `tests/deploy_discord_bot.test.ts` pins extended: restart policy, profile,
+  healthcheck presence, Caddy block content.
+- DEPLOY.md: a bot section (env keys from D13, health verification, the incident
+  runbook commands from incident-2026-07-29.md).
+Out of scope: server code. Commits: `feat(bot)` + `feat(deploy)` + `docs(deploy)`.
+
+### Phase 8: Observability
+See the next storm before Discord does.
+- Bot counters (Phase 2 governor outputs plus queue depths, sweep durations, outbox
+  drain sizes) ride the existing presence POST body (BOTH arms per D9), clamped and
+  validated server-side like the rest of presence.
+- Server holds them in the presence-cache module pattern and emits prom lines on the
+  existing metrics path (respecting the prom-counter no-backfill gotcha); staleness
+  zeroing mirrors presence.
+- A short Grafana note in DEPLOY.md naming the new series and the two alert-worthy
+  signals (breaker opens, 429 rate).
+- Tests: presence-body clamp arms for the new fields, metric line rendering, staleness.
+Out of scope: new tables, new endpoints. Commits: `feat(bot)` + `feat(server)` +
+`test(server)`.
+
+### Phase 9: /api/discord caching
+The last uncached hot read the report measured.
+- Wrap the per-account `/api/discord` payload assembly in the `createCachedRead` seam
+  (short TTL, keyed by account) with moderation busts wired in the same change (D17);
+  the presence block keeps its existing cache.
+- Check the route's legacy-arm status first and honor D9 dual-arm rules if one exists.
+- Query-count assertions: a cache-hit request performs zero payload queries; the
+  15/min rate guard stays.
+- Tests: hit/miss/bust arms (including the bust-refuses-inflight-joiners gotcha),
+  fake-timer TTL, moderation-action bust wiring.
+Out of scope: `/api/site-presence`. Commits: `feat(server)` + `test(server)`.
+Phase 9 QA additionally runs the whole-feature `qa-checklist.md` matrix, the full
+`npm run gate`, and offers packet teardown.
+
+## Starter prompt templates
+
+Phase files embed these verbatim with the braces filled. Implementation template:
+
+```
+This is Phase N of the Discord Bot Stability packet: {title}.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code.
+Worktree: /Users/fernando/Documents/wocc-discord-bot (branch feature/discord-bot-stability).
+{ULTRACODE line if the phase warrants a Workflow}
+
+Goal: {one sentence}
+
+STEP 0 - PRE-FLIGHT: git status clean in the worktree (ask if dirty; another session
+may share the checkout); memory scan of MEMORY.md for {domains}.
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly): spawn an Explore agent over
+docs/discord-bot-stability/state.md, progress.md, this phase file, and: {file list}.
+It returns: {summary spec}.
+
+STEP 2 - EXECUTE: {orchestration and agent split with per-agent deliverables}.
+
+INVARIANTS IN PLAY: {the D-numbers from state.md this phase must keep, spelled out}.
+
+OUT OF SCOPE: {exclusions}.
+
+STEP 3 - VALIDATION + REVIEW: {matrix rows from state.md}; dispatch reviewers per the
+Review Dispatch Matrix in implementation-plan.md (only matching rows); COVERAGE not
+filtering; no commit while BLOCKING findings stand.
+
+STEP 4 - COMMITS: {2 to 5 Conventional Commit headlines, explicit paths, bodies
+required, no em dashes or emojis}.
+
+STEP 5 - ACCEPTANCE: {verifiable checklist}.
+
+STEP 6 - DOCS: update progress.md and state.md (same commit as the work); record
+surprising rules to memory.
+
+STEP 7 - FINAL RESPONSE: phase status, files touched, validation results, reviewer
+verdicts, deferrals, one-line handoff for the QA session.
+
+STOPPING RULES: {phase-specific stops}.
+```
+
+QA template (D19 applies to every phase):
+
+```
+This is Phase N QA of the Discord Bot Stability packet: verify {title}.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code. ULTRACODE: yes, run the
+adversarial-verify Workflow (every finding independently confirmed by a skeptic agent
+before it counts) plus mutation spot checks on {the phase's new pure modules}.
+Worktree: /Users/fernando/Documents/wocc-discord-bot.
+
+STEP 0 - PRE-FLIGHT: git status clean (Phase N committed); memory scan including the
+test-pin trap index (READ IT before judging or writing any pin).
+
+STEP 1 - LOAD CONTEXT: Explore agent over state.md, progress.md, phase-N file, and the
+Phase N diff (git diff against the phase-start commit). Returns: promised deliverables,
+files touched, acceptance criteria.
+
+STEP 2 - AUDIT (parallel, COVERAGE not filtering): correctness agent (every deliverable
+and acceptance criterion actually met; edge cases; the D-invariants in play); test
+coverage agent (decisive assertions, missing arms, orphaned tests); dead-code agent
+(unused imports/types, leftover replaced code); plus the Review Dispatch Matrix rows
+matching the diff, plus qa-checklist. Mutation pass: mutate {named modules} (guard
+inversions, boundary shifts, dropped calls) in an ISOLATED worktree and prove the suite
+kills each mutant; prove the tests RAN (memory: mutation-harness-must-prove-tests-ran).
+
+STEP 3 - FIX: apply ALL findings (blocking, should-fix, AND nits per standing user
+rule); review the fix round itself (fresh eyes agent); re-run the validation matrix.
+
+STEP 4 - DOCS: progress.md (QA complete, deferrals), state.md (drift found).
+
+STEP 5 - {final phase only: whole-feature qa-checklist.md matrix, full npm run gate,
+teardown offer per README; otherwise omit}.
+
+STEP 6 - FINAL RESPONSE: verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL), counts found and
+fixed, mutation kill tally, deferrals, one-line handoff.
+
+STOPPING RULES: stop and surface if a BLOCKING item cannot be fixed without changing
+phase scope.
+```

--- a/docs/discord-bot-stability/incident-2026-07-29.md
+++ b/docs/discord-bot-stability/incident-2026-07-29.md
@@ -1,0 +1,92 @@
+# Prod HTTP Traffic Spike: Diagnosis Report
+
+**Date:** 2026-07-29
+**Host:** `world-of-claudecraft-prod-2` (10.2.0.150, behind bastion)
+**Symptom:** Grafana panels for HTTP/network requests spiked despite only ~70 concurrent players.
+**Verdict:** Not player traffic, not an attack. The `eastbrook-discord-bot` container is responsible on two fronts: a sustained 429 retry storm against Discord's API, and internal polling that accounts for ~45% of the game server's own HTTP request volume.
+
+---
+
+## Game health at time of diagnosis (~23:30 to 00:15 UTC)
+
+The game server itself is fine:
+
+- Tick rate: 19.99 Hz (target 20), tick p95/max total = 25.84 / 60.86 ms
+- 63 players online, 561 entities
+- Host load average: 2.35 (moderate, not concerning)
+- External request sources are diverse residential/mobile IPs polling public endpoints (`/api/discord`, `/api/site-presence`), consistent with normal website visitors, no single-source flood, no attack signature
+
+## Finding 1: Discord API retry storm (~600k failed requests over 2 days)
+
+The bot's role/nickname sync loop:
+
+```
+syncAllOnlineRoles (bot.cjs:4657)
+  → syncRolesFor (bot.cjs:4653)
+    → DiscordApi.setNickname (bot.cjs:3833)
+      → PATCH /guilds/1515097174378020894/members/<id>  → 429
+```
+
+It PATCHes guild members with **no rate-limit handling**: it does not honor Discord's `retry_after`, so failures pile up and Discord escalates.
+
+**Hourly 429 counts show a daily cycle** (timestamps UTC, from `docker logs -t`):
+
+| Window | Pattern |
+|---|---|
+| Overnight | ~3 to 6k 429s/hr baseline |
+| Daytime ramp | climbs steadily from ~08:00 |
+| Evening peak | 35 to 38k/hr (~600+/min) |
+| ~22:00 both nights | Discord issues a **global temporary API ban** ("You are being blocked from accessing our API temporarily due to exceeding global rate limits"), count crashes |
+| After ban expiry | cycle reignites |
+
+Totals: ~112,830 429s in the 6 hours before diagnosis; ~600,000 since the storm began.
+
+**Onset:** the storm started within the first hour after the bot container restarted at **2026-07-27 11:08 UTC** (the game container restarted at the same moment, presumably that day's deploy). Restarting the bot is therefore **not** a fix; the storm ignited immediately after a restart.
+
+**History:** this is the escalated form of a known issue from the 2026-07-07 incident review: the bot's per-member flex sweep was already flagged as unthrottled and scaling with Discord guild size (not game population). Back then it failed with 403s (missing Manage Nicknames permission); now the PATCHes go through in volume and trip Discord's global limits instead.
+
+## Finding 2: Bot generates ~45% of the game server's HTTP traffic
+
+Of **30,262** requests logged by the game in one sample hour, **13,526 came from `172.18.0.x`** (the docker network, i.e. the bot), via the game's internal API on `127.0.0.1:8787`:
+
+| Route | Req/hr | Cadence |
+|---|---|---|
+| `/internal/discord/flex` | 5,319 | ~89/min |
+| `/internal/discord/members-meta` | 3,790 | ~63/min |
+| `/internal/discord/relay` | 1,200 | exactly 20/min |
+| `/internal/discord/daily-rewards-winners` | 1,200 | exactly 20/min |
+| `/internal/discord/activity` | 1,200 | exactly 20/min |
+| `/internal/discord/presence` | 724 | ~12/min |
+
+Any Grafana panel counting the game's HTTP requests is roughly **doubled** by this internal polling. The remainder of the traffic is public-endpoint polling by site visitors (`/api/discord` 7,356/hr, `/api/site-presence` 3,583/hr), which scales with site viewers, not logged-in players.
+
+Additionally, the bot holds **~110 established TCP connections** to the game's :8787 at any moment (observed fluctuating 69→115→111). Not a monotonic leak, but it indicates per-request connections with no keep-alive agent/pooling.
+
+## Recommended fixes (bot code, this repo)
+
+1. **Honor `retry_after` on 429**: back off instead of continuing the sweep. The global bans are Discord escalating specifically because the bot ignores per-route rate limits.
+2. **Skip `setNickname` when the nickname is already correct**: diff before PATCH. This alone likely eliminates the bulk of the write volume.
+3. **Throttle `syncAllOnlineRoles`**: bound the sweep rate by Discord's limits, not guild size.
+4. **Slow internal polling cadences**: `/flex` at ~89/min and `/members-meta` at ~63/min are the big contributors; 3 other endpoints poll every 3s each.
+5. **Use a shared keep-alive HTTP agent** for game-API polling to stop connection churn.
+
+## Immediate mitigation (optional)
+
+Stopping the `eastbrook-discord-bot` container flattens the Grafana spike and stops the Discord bans at the cost of role/nickname/relay sync. Deliberately **not** done during this diagnosis (look-only request).
+
+## Diagnostic commands used (for future reference)
+
+```bash
+# request rate + breakdown from game access logs
+sudo docker logs --since 60m eastbrook-game 2>&1 | grep '"msg":"access"' \
+  | grep -o '"route":"[^"]*"' | sort | uniq -c | sort -rn | head -15
+
+# who is generating it (internal 172.18.0.x vs external)
+... | grep -o '"ip":"[^"]*"' | sort | uniq -c | sort -rn | head -10
+
+# bot 429 timeline
+sudo docker logs -t eastbrook-discord-bot 2>&1 | grep 429 | cut -c1-13 | sort | uniq -c
+
+# connections to the game's internal API
+sudo ss -tn state established '( dport = :8787 )' | wc -l
+```

--- a/docs/discord-bot-stability/phase-01-qa.md
+++ b/docs/discord-bot-stability/phase-01-qa.md
@@ -1,0 +1,97 @@
+# Phase 1 QA: Bot verification foundation
+
+Phase 1 promised zero behavior change while touching five bot files, the tsconfig include, the
+gate step list, and CI. Both halves need proof: that the type fixes and the injected seams really
+did leave the bot's runtime behavior identical, and that the new baseline tests are decisive
+enough to be worth having, since Phases 2 and 3 build on them. This session audits both, and
+mutation-checks the exact code paths those baseline tests claim to cover.
+
+## Starter prompt
+
+```
+This is Phase 1 QA of the Discord Bot Stability packet: verify the bot verification foundation.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code. ULTRACODE: yes, run the
+adversarial-verify Workflow (every finding independently confirmed by a skeptic agent before it
+counts) plus mutation spot checks on the code paths the new baseline tests claim to cover:
+bot/config.ts (required, default, and fallback arms) and bot/server_client.ts (the call
+envelope). Judge every refutation yourself rather than taking it on faith, and require the
+skeptic to have the file open before a refutation counts.
+Worktree: /Users/fernando/Documents/wocc-discord-bot.
+
+STEP 0 - PRE-FLIGHT: run `git status` and confirm it is clean with Phase 1 committed; another
+session may share this checkout, so ASK before touching anything you did not create. Memory scan
+including the test-pin trap index (READ IT before judging or writing any pin), plus
+mutation-harness-must-prove-tests-ran, mutation-test-uncommitted-revert-trap, and the
+worktree/node_modules entries (worktree-symlink-vitest-limitation,
+stale-node-modules-fullsuite-failure-set) since the mutation pass needs a second worktree that
+can actually run vitest.
+
+STEP 1 - LOAD CONTEXT: spawn an Explore agent over docs/discord-bot-stability/state.md,
+docs/discord-bot-stability/progress.md,
+docs/discord-bot-stability/phase-01-verification-foundation.md, and the Phase 1 diff (find the
+phase-start commit from the branch log, the commit immediately before the first Phase 1 commit,
+and diff it against HEAD). It returns: the promised deliverables and acceptance criteria, the
+files touched with a one-line summary of each change, the new test file names and what each test
+claims to pin, and whether the gate and CI step lists both gained the bot build.
+
+STEP 2 - AUDIT (parallel agents, COVERAGE not filtering: report every gap with confidence and
+severity, do not pre-filter):
+  - Correctness agent: is every Phase 1 deliverable and acceptance criterion actually met? The
+    load-bearing question is whether the diff is genuinely behavior-preserving. Hunt for a type
+    "fix" that silently changed a runtime branch (an added `?? ''` or `|| default` that swallows
+    a real value, a narrowing guard that now skips a call, a changed comparison or coercion), an
+    injected constructor parameter whose DEFAULT is not exactly today's production value, and any
+    reordering that changes when a request is issued. Confirm bot/cadence.ts (ruling R6) is a
+    pure move: same names, same values, no new logic, bot/main.ts importing them. The
+    one-character em dash fix in the bot/gateway.ts FATAL_CLOSE_CODES comment is sanctioned by
+    ruling R9, so do not report it as scope creep. Check the D-invariants in play: D7 (no new
+    dependency), D8 (logic.ts still pure, shells still thin, wiring still in main.ts), no src/
+    edit, no secret committed, no em dash or en dash or emoji anywhere else in the diff.
+  - Test coverage agent: are the new assertions decisive? Every config arm present including the
+    fallback chains and the exact-string DISCORD_SYNC_NICKNAMES arm; the server_client envelope
+    covering method, URL, secret header, content type, omitted body, non-ok status, and
+    success-false; the abort test really driving the deadline rather than asserting a constant;
+    the cadence pins comparing against literals rather than re-reading the same source
+    (constant-self-comparison trap); no orphaned or skipped tests; no `.only(`.
+  - Dead-code agent: unused imports or types left behind by the type fixes, an injected parameter
+    that is never actually used by the code it was added to, and any leftover scaffolding.
+  - Review Dispatch Matrix rows matching the diff, per implementation-plan.md: a bot-only diff
+    matches no row, so `qa-checklist` is the baseline; if the diff touched
+    .github/workflows/ci.yml, also spawn `privacy-security-review` (CI yml is a listed deploy
+    file).
+  Mutation pass, in an ISOLATED worktree created from the Phase 1 HEAD commit (never check out
+  over uncommitted work), each mutant applied one at a time:
+    - bot/config.ts: make one required() return '' instead of throwing; swap a fallback order so
+      activity falls back to test before relay; invert the DISCORD_SYNC_NICKNAMES comparison
+      (=== for !==, or "1" for "0"); drop one default URL.
+    - bot/server_client.ts: drop the x-woc-discord-secret header; rename the header; drop the
+      abort signal from the request; return env.data regardless of env.success; treat a non-ok
+      response as ok; change the timeout constant.
+    Each mutant must be killed by a NAMED test. Prove the suite actually ran for every mutant:
+    record the vitest summary line (files, tests, passed, failed) and confirm a nonzero failure
+    count, since a config or path mistake that runs zero tests looks like a pass.
+  Also prove the new gate step has teeth: introduce a temporary syntax error in a bot file,
+  confirm `npm run build:bot` exits nonzero, and revert it.
+
+STEP 3 - FIX: apply ALL findings, blocking, should-fix, AND nits (standing user rule). Then
+review the fix round itself with a fresh-eyes agent, because the fixes are unreviewed code. Then
+re-run the state.md bot-only validation row: `npx tsc --noEmit`,
+`npx vitest run tests/discord_bot.test.ts` plus the new test files, `npm run build:bot`,
+`npm run ci:changed`, and `npm run gate` at close. Commit with explicit paths, a scoped
+Conventional Commit subject, and a body; no `git add -A`.
+
+STEP 4 - DOCS: update docs/discord-bot-stability/progress.md (Phase 1 QA row complete, plus any
+deferrals under the per-phase notes) and docs/discord-bot-stability/state.md (any drift the audit
+found: corrected file paths, new gotchas for implementers, the final test file names). Record
+genuinely reusable traps to memory as one file per fact plus its MEMORY.md pointer line.
+
+STEP 6 - FINAL RESPONSE: verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL), counts found and fixed by
+severity, the mutation kill tally (mutants planted, killed, survived, with the survivor
+explained), deferrals with reasons, and a one-line handoff for the Phase 2 session.
+
+STOPPING RULES: stop and surface if a BLOCKING item cannot be fixed without changing Phase 1's
+scope (for example a latent type error whose only correct fix is a behavior change, which belongs
+to a later phase or its own issue). Stop if a surviving mutant can only be killed by changing
+behavior rather than by adding a test, and report it as a finding instead of changing behavior
+here. Stop if the mutation worktree cannot run the suite, rather than reporting an unproven kill.
+```

--- a/docs/discord-bot-stability/phase-01-verification-foundation.md
+++ b/docs/discord-bot-stability/phase-01-verification-foundation.md
@@ -1,0 +1,193 @@
+# Phase 1: Bot verification foundation
+
+Nothing in the repo currently verifies the Discord bot. `tsconfig.json` includes `src`,
+`headless`, `tests`, `server`, and `private`, so the only bot file that gets type-checked is
+`bot/logic.ts` (pulled in by the test that imports it); the other five files are unchecked, and
+the bundle first compiles on the production host during `docker compose up --build`. This phase
+changes no behavior at all. It makes the bot verifiable: `bot` joins the tsconfig include and
+every latent type error that surfaces is fixed behavior-preserving, `build:bot` joins the
+pre-merge gate and CI, the three IO shells accept an injected fetch, socket, and clock (plain
+constructor parameters with production defaults) so Phases 2 and 3 can test them, the three
+cadence constants move into their own module (ruling R6) so tests can read them without executing
+the bot, and a baseline test suite pins today's config arms, the server call envelope, and those
+cadence values.
+
+## Starter prompt
+
+```
+This is Phase 1 of the Discord Bot Stability packet: Bot verification foundation.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code.
+Worktree: /Users/fernando/Documents/wocc-discord-bot (branch feature/discord-bot-stability).
+No Workflow needed: this phase is small and mostly serial, and a 2-agent fan-out in STEP 2 is
+the right size.
+
+Goal: make the Discord bot verifiable (type-checked, gate-built, and testable through injected
+IO seams) without changing one line of its runtime behavior.
+
+STEP 0 - PRE-FLIGHT: run `git status` in the worktree and confirm it is clean; another session
+may share this checkout, so ASK before touching anything you did not create. Scan MEMORY.md for
+the domains in play: bot/Discord work, tsconfig and toolchain rules, the gate and CI step lists,
+Biome on changed files, test-pin traps, and shared-worktree commit care.
+
+STEP 1 - LOAD CONTEXT (do NOT read the planning docs directly): spawn one Explore agent over
+docs/discord-bot-stability/state.md, docs/discord-bot-stability/progress.md,
+docs/discord-bot-stability/phase-01-verification-foundation.md, and these source files:
+bot/config.ts, bot/discord_api.ts, bot/server_client.ts, bot/gateway.ts, bot/main.ts,
+bot/logic.ts, bot/CLAUDE.md, the root CLAUDE.md, tsconfig.json, scripts/gate.mjs,
+scripts/build_bot.mjs, tests/discord_bot.test.ts, package.json (scripts block), and
+.github/workflows/ci.yml.
+It returns, as conclusions rather than file dumps:
+  a. every IO call each of the three shells makes (global fetch, `new WebSocket` from ws,
+     setTimeout / setInterval / AbortController / Date) with the constructor signature of each
+     class and its construction site in bot/main.ts;
+  b. how tests/discord_bot.test.ts is organized, what it already pins, and its import style;
+  c. the gate step list in scripts/gate.mjs and the CI jobs that carry the equivalent build
+     steps (there is more than one job), naming where a bot build step slots in each;
+  d. whether bot/main.ts can be imported by a test without side effects, with the evidence;
+  e. any existing repo exemplar for a constructor-injected dependency with a production default
+     (name the file and line);
+  f. a candidate list of bot code that will likely fail `tsc` once `bot` is included (a list to
+     verify, never a fix, and never a substitute for actually running the check).
+
+STEP 2 - EXECUTE in two stages so no two agents ever edit the same file.
+
+Stage 1 (serial, in the main loop):
+  - Add "bot" to the `include` array in tsconfig.json. Run `npx tsc --noEmit` (the native
+    TypeScript 7 binary; a full-repo run takes about 2 seconds, so run it liberally). Fix EVERY
+    error it reports with behavior-preserving edits only: a type annotation, a boundary cast at
+    a point the code already validates, a narrowing guard that cannot change a runtime branch.
+    Which errors exist is unknown until you run it. DISCOVER them; do not assume the candidate
+    list from STEP 1 is right or complete. Never silence an error with a blanket `any`, a
+    ts-ignore, or a widened include exclusion.
+  - Add a bot build step to the `steps` list in scripts/gate.mjs next to the existing server
+    build step, then mirror it into .github/workflows/ci.yml. Per ruling R7 in state.md it goes
+    into EVERY CI job that builds the server (the header comment of scripts/gate.mjs demands the
+    two step lists stay in sync, and more than one job carries the build steps). Find those jobs;
+    do not guess their names.
+  - Extract the three cadence constants at bot/main.ts:46-48 (ROLE_SYNC_INTERVAL_MS 300000,
+    PRESENCE_DEBOUNCE_MS 4000, RELAY_POLL_MS 3000) into a new module bot/cadence.ts, per ruling
+    R6 in state.md. This is a MOVE only: no value, name, or ordering change, and bot/main.ts
+    imports them from the new module. It exists because bot/main.ts calls `main()` at module
+    scope, so a test cannot import the constants from there, and it seeds Phase 3's D13
+    env-overridable cadences, which layer env parsing over the same module. Doing it in Stage 1
+    keeps bot/main.ts out of the Stage 2 agents' hands.
+
+Stage 2 (two parallel agents, disjoint files, each given the STEP 1 summary rather than the
+planning docs):
+  - Agent A, Discord IO seams: give `DiscordApi` (bot/discord_api.ts) an injected fetch, and
+    `Gateway` (bot/gateway.ts) an injected socket factory plus an injected timer/clock, as
+    constructor parameters that DEFAULT to exactly today's production values (global `fetch`,
+    `new WebSocket(url)` from ws, setInterval / setTimeout). No call-site change and no behavior
+    change: bot/main.ts must keep constructing both exactly as it does today.
+    Note: the comment above FATAL_CLOSE_CODES in bot/gateway.ts contains a pre-existing em dash.
+    The repo copy rule bans em dashes and the Stop hook (.claude/hooks/qa-stop.sh) checks the
+    diff, so once that file is in your diff the Stop hook would block on it. Ruling R9 in
+    state.md sanctions replacing that one character here (a comma or parentheses reads fine),
+    scoped to that one comment; do not extend it to files this phase does not otherwise touch.
+    QA will not treat it as scope creep.
+  - Agent B, server-client seam plus the baseline tests: the same injected-fetch treatment for
+    `ServerClient` (bot/server_client.ts), including its 8000 ms abort timer so a test can drive
+    the deadline without a real wait. Then the new tests. Agent B does not edit bot/main.ts,
+    bot/discord_api.ts, or bot/gateway.ts.
+
+Baseline test arms Agent B owns (decisive assertions on literals, never smoke tests):
+  - bot/config.ts: each of the four required keys throws with its own name when absent; the
+    GAME_SERVER_URL and PUBLIC_GAME_URL defaults; the relay fallback (relay, then test) and the
+    activity fallback (activity, then relay, then test) including the arm where only the test
+    channel is set; DISCORD_SYNC_NICKNAMES is off ONLY for the exact string "0" (assert that
+    "false" leaves it ON, which is the arm a careless rewrite breaks).
+  - bot/server_client.ts: the call envelope (method, URL built from baseUrl plus path, the
+    `x-woc-discord-secret` header carrying the configured secret, the JSON content type, body
+    omitted when undefined), an envelope with success false returning null, a non-ok HTTP status
+    returning null, and the abort timer firing at its deadline (drive it with the injected
+    clock or fake timers).
+  - The three cadence constants, imported from the bot/cadence.ts module Stage 1 extracted:
+    assert each value against a literal (300000, 4000, 3000), never against a value re-read from
+    the source that defines it. Do not change any of the three values in this phase.
+  - Put the new tests in new file(s) alongside tests/discord_bot.test.ts, which stays pure-logic
+    only. Suggested names: tests/discord_bot_config.test.ts and
+    tests/discord_bot_server_client.test.ts. Consolidating into one file is fine; record the
+    final names in state.md.
+
+INVARIANTS IN PLAY (from state.md):
+  - D7, zero new npm dependencies: no discord.js, no rate-limiter package, no mocking library.
+    Injection is plain constructor parameters.
+  - D8, the pure/IO split stands: bot/logic.ts stays pure, the three shells stay thin IO shells,
+    and wiring stays in bot/main.ts.
+  - D13, cadences become env-configurable in Phase 3: this phase moves the constants into
+    bot/cadence.ts and PINS their values (R6), it does not parameterize them or read any env.
+  - D19, every phase's QA session runs mutation spot checks on what the new tests claim to
+    cover, so write assertions that would actually fail on a regression.
+  - Packet non-negotiables: no src/ edit at all (src/sim is untouched by this packet); secrets
+    are env only and .env is never committed; no em dashes, en dashes, or emojis anywhere in
+    code, comments, docs, or commit text; commit with EXPLICIT paths, never `git add -A`,
+    because the worktree is shared.
+
+OUT OF SCOPE: any behavior change whatsoever, including "obvious" bug fixes found while
+type-checking (record them for the QA session instead). No rate-limit or retry work (Phase 2),
+no scheduler or diff-before-write work (Phase 3), no server/ change, no deploy or compose file,
+no DEPLOY.md prose (Phase 7), no new env keys (Phase 2 adds the first ones).
+
+STEP 3 - VALIDATION + REVIEW: run the state.md bot-only row: `npx tsc --noEmit`,
+`npx vitest run tests/discord_bot.test.ts` plus every new test file, `npm run build:bot`, and
+`npm run ci:changed` (Biome on changed files; fix with a scoped
+`npx @biomejs/biome check --write <file>`, never a whole-repo write). Prove the include actually
+took effect instead of assuming: `npx tsc --noEmit --listFiles` should list bot/main.ts, or
+introduce a deliberate type error in a bot file, watch the check fail, and revert it. At phase
+close run `npm run gate` (exit-code-safe; never an ad-hoc && chain).
+Dispatch reviewers per the Review Dispatch Matrix in implementation-plan.md, matching rows ONLY:
+a bot-only diff matches no row, so `qa-checklist` at phase end is the baseline. This phase edits
+.github/workflows/ci.yml, so the `privacy-security-review` row matches (CI yml is a listed deploy
+file) and you spawn it too, per ruling R7. Prompt every reviewer for COVERAGE, not filtering.
+Resume a truncated reviewer with: "Stop reading more files. Output the full report now. No more tool
+calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT." Do not commit while a BLOCKING
+finding stands.
+
+STEP 4 - COMMITS: Conventional Commits with a scope, explicit paths, and a BODY on every commit
+(1 to 4 plain sentences saying what changed and why, wrapped near 72 columns). No em dashes, no
+en dashes, no emojis, and no session-link or other trailers. The plan suggests `chore(bot)` plus
+`test(bot)`; expanded:
+  1. chore(bot): type-check bot/ and fix the errors the include surfaces
+  2. chore(bot): build the bot bundle in the pre-merge gate and CI
+  3. refactor(bot): move the cadence constants into bot/cadence.ts
+  4. refactor(bot): accept an injected fetch, socket, and clock in the IO shells
+  5. test(bot): pin the config arms, server call envelope, and cadence constants
+Fold 1 and 2 together if the type fixes turn out trivial; keep the tests as their own commit.
+
+STEP 5 - ACCEPTANCE (every item verifiable by a command or an assertion, not by claim):
+  - tsconfig.json `include` contains "bot" and `npx tsc --noEmit` exits 0, with bot/main.ts
+    proven to be in the checked file set.
+  - `npm run build:bot` exits 0 and writes dist-bot/bot.cjs; the gate step list contains the bot
+    build; every CI job that builds the server also builds the bot.
+  - Constructing DiscordApi, ServerClient, and Gateway with no extra arguments still yields
+    today's production IO, and a test asserts the DEFAULT path, not only the injected one.
+  - The new tests fail if the pinned behavior changes: every config arm, the secret header, the
+    timeout abort, and each cadence value asserts against a literal, never against a value
+    re-read from the same source (memory: test-pin-constant-self-comparison).
+  - bot/cadence.ts holds the three constants, bot/main.ts imports them, and the diff shows a pure
+    move: the same names, the same values, no new logic in the module.
+  - `git diff` over bot/ shows no runtime behavior change: no altered branch, no altered
+    constant, no added or removed call; only type annotations, defaulted constructor parameters,
+    comments, the cadence move, and the one sanctioned gateway comment fix (R9).
+  - `npm run ci:changed` clean on the touched files and `npm run gate` green.
+
+STEP 6 - DOCS: update docs/discord-bot-stability/progress.md (the Phase 1 status row and its
+four checkboxes) and docs/discord-bot-stability/state.md ("Current phase" and the "Created by
+this packet" list: bot/cadence.ts, the new test file names, and "none" for new env keys this
+phase) in the SAME commit as the work, with explicit paths. Correct the state.md "Key file paths"
+bot line too, since the cadence constants no longer live in bot/main.ts. Record any surprising
+rule you hit to memory as one file per fact plus its MEMORY.md pointer line.
+
+STEP 7 - FINAL RESPONSE: phase status, files touched (absolute paths), validation results
+(command plus outcome for each), reviewer verdicts, anything deferred with the reason, and a
+one-line handoff for the Phase 1 QA session.
+
+STOPPING RULES:
+  - Stop and surface if fixing a latent type error requires a behavior change. Report the error,
+    the file, and the options you weighed; do not change what the code does to make tsc happy,
+    and do not suppress the error to keep moving.
+  - Stop if the work appears to need a new npm dependency (D7) or any edit under src/ (a src/
+    edit means the phase went out of scope).
+  - Stop if the worktree is dirty with work that is not yours, or if a shared-checkout conflict
+    appears mid-phase.
+```

--- a/docs/discord-bot-stability/phase-02-qa.md
+++ b/docs/discord-bot-stability/phase-02-qa.md
@@ -1,0 +1,112 @@
+# Phase 2 QA: Discord rate-limit governor
+
+The governor is the module that has to hold under fault, in production, where nobody is watching:
+if a guard is inverted or a boundary is off by one, the failure mode is another temporary API ban
+rather than a red test. This session verifies that every D2, D3, and D4 behavior is actually
+implemented and actually asserted, that nothing in the rewire changed which Discord calls the bot
+makes, and it mutation-checks bot/rate_governor.ts guard by guard.
+
+## Starter prompt
+
+```
+This is Phase 2 QA of the Discord Bot Stability packet: verify the Discord rate-limit governor.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code. ULTRACODE: yes, run the
+adversarial-verify Workflow (every finding independently confirmed by a skeptic agent before it
+counts) plus mutation spot checks on bot/rate_governor.ts. Judge every refutation yourself rather
+than taking it on faith, and require the skeptic to have the file open before a refutation
+counts.
+Worktree: /Users/fernando/Documents/wocc-discord-bot.
+
+STEP 0 - PRE-FLIGHT: run `git status` and confirm it is clean with Phase 2 committed; another
+session may share this checkout, so ASK before touching anything you did not create. Memory scan
+including the test-pin trap index (READ IT before judging or writing any pin), plus
+mutation-harness-must-prove-tests-ran, mutation-test-uncommitted-revert-trap, the clock and
+timer traps (cachedread-captured-clock-vs-fake-timers, settimeout-fractional-delay-fires-early),
+env-empty-numeric-default-shift, and the worktree/node_modules entries
+(worktree-symlink-vitest-limitation, stale-node-modules-fullsuite-failure-set) since the mutation
+pass needs a second worktree that can actually run vitest.
+
+STEP 1 - LOAD CONTEXT: spawn an Explore agent over docs/discord-bot-stability/state.md,
+docs/discord-bot-stability/progress.md, docs/discord-bot-stability/phase-02-rate-limit-governor.md,
+and the Phase 2 diff (find the phase-start commit from the branch log, the commit immediately
+before the first Phase 2 commit, and diff it against HEAD). It returns: the promised deliverables
+and acceptance criteria, the files touched with a one-line summary of each change, the governor's
+public surface and internal state machine in prose, the new env keys with their defaults, and a
+map of which test covers which D2/D3/D4 behavior.
+
+STEP 2 - AUDIT (parallel agents, COVERAGE not filtering: report every gap with confidence and
+severity, do not pre-filter):
+  - Correctness agent, Discord contract: does the governor provably never dispatch at
+    `Remaining == 0`? Is the FULL retry_after honored on all three scopes with no ceiling (the
+    old 10 second clamp gone)? Does a non-JSON 429 body pause for DISCORD_BAN_PAUSE_MS and log,
+    rather than short-retrying? Does the breaker exclude scope `shared` from its count, trip at
+    DISCORD_BREAKER_LIMIT, roll its 10 minute window, and half-open only after a full quiet
+    window? Does the forbidden cache actually suppress retries for its TTL and expose a
+    role-position invalidation? Are the provisional bucket key and the returned bucket hash
+    reconciled without double counting? Are there any hard-coded per-route numeric limits (O2
+    says there must be none)? Is /api/v10 pinned, the User-Agent still valid, X-Audit-Log-Reason
+    present on member PATCHes, and X-RateLimit-Scope logged on every 429 (O5)?
+  - Correctness agent, rewire: did the call set change? Every Discord REST call the bot made
+    before must still be made, with the same method, path, and payload, and the caller-visible
+    contracts (what throws, what returns null, what is swallowed) must be intact or deliberately
+    and documentedly changed. Check purity: no fetch, ws, Date.now, setTimeout, setInterval, or
+    performance.now inside bot/rate_governor.ts. Check the D-invariants: D7 (no new dependency),
+    D8 (pure module plus thin shell plus wiring in main.ts), no src/ or server/ edit, no secret
+    committed, no em dash, en dash, or emoji in the diff including log strings.
+  - Test coverage agent: is every arm named in the phase spec actually present and decisive?
+    Header-driven pacing, the three 429 scopes, the HTML-body 429, breaker trip and half-open and
+    window roll, forbidden-cache no-retry and TTL expiry, queue ordering, bucket remap, counter
+    correctness, and the same-inputs-same-schedule determinism run. Flag any arm that asserts a
+    call count where it should assert a schedule, any timing test whose clock cannot actually
+    advance, any breaker test that only checks the tripping side of the boundary, and any pin
+    that re-reads the value it claims to pin. Confirm the env defaults are asserted with an
+    empty-string arm, not only an unset arm, and that all four keys reached the commented Discord
+    block in .env.example with their defaults (ruling R8), with no real secret committed.
+  - Dead-code agent: the old retry path fully deleted (no orphaned constant, no unused import, no
+    unreachable branch left from the 10 second clamp), unused exports on the governor, and types
+    that no longer have a consumer.
+  - Review Dispatch Matrix rows matching the diff, per implementation-plan.md: the bot code
+    matches no row, but the sanctioned .env.example edit (R8) matches the
+    `privacy-security-review` row, so that reviewer plus `qa-checklist` is the expected set, and
+    the .env.example edit is NOT scope creep. Any OTHER matching row (server/, src/net/, compose,
+    CI) is a finding: the phase went out of scope.
+  Mutation pass on bot/rate_governor.ts, in an ISOLATED worktree created from the Phase 2 HEAD
+  commit (never check out over uncommitted work), each mutant applied one at a time:
+    - Guard inversions: dispatch WHEN Remaining is 0; count scope `shared` toward the breaker;
+      skip the global pause on a global-scope 429; treat a non-JSON 429 body as a normal 429.
+    - Boundary shifts: `Remaining <= 0` to `< 0`; Reset-After read as milliseconds instead of
+      seconds (or the reverse); breaker limit off by one in each direction; the rolling window
+      edge (an entry exactly at 10 minutes); the forbidden TTL edge.
+    - Dropped calls: never record a 429; never open the breaker; never write the forbidden cache;
+      never increment a counter; never remap the provisional bucket key.
+    - Half-open: probe without waiting for a full quiet window; close the breaker on a FAILED
+      probe.
+    Each mutant must be killed by a NAMED test. Prove the suite actually ran for every mutant:
+    record the vitest summary line (files, tests, passed, failed) and confirm a nonzero failure
+    count, since a config or path mistake that runs zero tests looks like a pass.
+
+STEP 3 - FIX: apply ALL findings, blocking, should-fix, AND nits (standing user rule). Then
+review the fix round itself with a fresh-eyes agent, because the fixes are unreviewed code. Then
+re-run the state.md bot-only validation row: `npx tsc --noEmit`,
+`npx vitest run tests/discord_bot.test.ts` plus every bot test file, `npm run build:bot`,
+`npm run ci:changed`, and `npm run gate` at close. Commit with explicit paths, a scoped
+Conventional Commit subject, and a body; no `git add -A`.
+
+STEP 4 - DOCS: update docs/discord-bot-stability/progress.md (Phase 2 QA row complete, plus
+deferrals under the per-phase notes) and docs/discord-bot-stability/state.md (drift the audit
+found, the final env key names and defaults, the counter names Phase 8 will consume, and any new
+implementer gotcha). If the audit answered or sharpened an OPEN item (O2, O5), say so in state.md
+rather than closing it silently. Record genuinely reusable traps to memory as one file per fact
+plus its MEMORY.md pointer line.
+
+STEP 6 - FINAL RESPONSE: verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL), counts found and fixed by
+severity, the mutation kill tally (mutants planted, killed, survived, with the survivor
+explained), deferrals with reasons, and a one-line handoff for the Phase 3 session.
+
+STOPPING RULES: stop and surface if a BLOCKING item cannot be fixed without changing Phase 2's
+scope (for example a contract gap whose fix belongs to the Phase 3 scheduler or the Phase 6 sweep
+rewrite). Stop if a surviving mutant can only be killed by changing behavior rather than by
+adding a test, and report it as a finding instead of changing behavior here. Stop if closing a
+gap would need a new npm dependency (D7): escalate to the user instead. Stop if the mutation
+worktree cannot run the suite, rather than reporting an unproven kill.
+```

--- a/docs/discord-bot-stability/phase-02-rate-limit-governor.md
+++ b/docs/discord-bot-stability/phase-02-rate-limit-governor.md
@@ -1,0 +1,215 @@
+# Phase 2: Discord rate-limit governor
+
+The 429 handler at `bot/discord_api.ts:26-31` is the incident's escalation engine: the wait is
+clamped to 10 seconds while global penalties run far longer, a non-JSON 429 body (Cloudflare's
+ban response) falls through to a 1 second retry, the `global` flag and every `X-RateLimit-*`
+header are ignored, and call sites swallow the error so the sweep keeps going. This phase
+replaces it with one pure, tested module that owns ALL Discord REST dispatch, so exceeding
+Discord's contract becomes structurally impossible instead of a tuning problem: bucket-keyed
+serialized queues remapped onto the returned bucket hashes, proactive gating that never
+dispatches at `Remaining == 0`, a process-wide pause honoring the full `retry_after`, an
+invalid-request circuit breaker that opens far below Discord's ban line, and a permanent-failure
+cache for the 403s the old sweep retried forever. The module is pure and clock-injected, so its
+behavior is provable in tests rather than observable only in production.
+
+## Starter prompt
+
+```
+This is Phase 2 of the Discord Bot Stability packet: Discord rate-limit governor.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code.
+Worktree: /Users/fernando/Documents/wocc-discord-bot (branch feature/discord-bot-stability).
+ULTRACODE: yes. This is the packet's highest-risk module and its test matrix is uniform batch
+work (one arm per Discord response shape), so build the module serially and fan the test matrix
+plus an adversarial pass out through a Workflow.
+
+Goal: make every Discord REST call flow through one pure, tested governor that cannot exceed
+Discord's documented rate-limit contract, even under fault.
+
+STEP 0 - PRE-FLIGHT: run `git status` in the worktree and confirm it is clean with Phase 1
+committed; another session may share this checkout, so ASK before touching anything you did not
+create. Scan MEMORY.md for the domains in play: bot/Discord work, clock and fake-timer traps,
+env parsing traps, test-pin traps, Biome on changed files, and shared-worktree commit care.
+
+STEP 1 - LOAD CONTEXT (do NOT read the planning docs directly): spawn one Explore agent over
+docs/discord-bot-stability/state.md, docs/discord-bot-stability/progress.md,
+docs/discord-bot-stability/phase-02-rate-limit-governor.md, and these source files:
+bot/discord_api.ts, bot/config.ts, bot/main.ts, bot/logic.ts, bot/server_client.ts,
+bot/gateway.ts, bot/CLAUDE.md, the root CLAUDE.md, tests/discord_bot.test.ts plus the Phase 1
+test files, scripts/build_bot.mjs, scripts/gate.mjs, and tsconfig.json.
+It returns, as conclusions rather than file dumps:
+  a. every Discord REST call the bot makes today, with its method, path shape, which path
+     segment is the major parameter (guild_id, channel_id, webhook_id), and the call site;
+  b. the current request/429/retry path line by line, and exactly which behaviors are load
+     bearing for callers (what throws, what returns null, what is swallowed where);
+  c. the Phase 1 injected-fetch seam signature on DiscordApi and how its tests drive it;
+  d. bot/config.ts structure and how Phase 1's config tests are written;
+  e. the repo's exemplar of a pure module with an injected clock, if one exists (name file and
+     line), and the fake-timer conventions used in tests/.
+
+STEP 2 - EXECUTE.
+
+Stage 1 (serial, in the main loop): write bot/rate_governor.ts, a pure module with no IO. It
+imports no fetch, no ws, no node timer, and never reads a wall clock directly: time comes from
+an injected clock and a wait/sleep the caller provides. Whether the governor invokes an injected
+dispatch callback or returns a "wait this long, then go" decision is your design call; both keep
+the module IO-free, and both must be fully drivable from a test with a synthetic clock. Deliver:
+  - Bucket registry: a provisional key of method plus route TEMPLATE plus major parameter, where
+    the template keeps major parameter ids and does NOT interpolate non-major ids (a per-user key
+    would defeat bucketing), remapped onto the `X-RateLimit-Bucket` hash after the first response
+    from that route. The two keys must not double count once remapped.
+  - Per-bucket serialized FIFO queues, so two writes into the same bucket never race.
+  - Proactive gating (D2): never dispatch from a bucket whose last response reported
+    `Remaining == 0`; wait out `Reset-After` first. Headers drive everything: no hard-coded
+    per-route numeric limits anywhere (O2, they are runtime-discoverable only).
+  - Global send-rate cap: DISCORD_MAX_RPS, default 8 (Discord's ceiling is 50).
+  - Process-wide pause on any global-scope 429 for the FULL `retry_after` with no ceiling (D2),
+    plus the Cloudflare arm: a 429 whose body is not JSON is treated as a ban response and pauses
+    for DISCORD_BAN_PAUSE_MS (default 600000) with an error log.
+  - Invalid-request circuit breaker (D3): a rolling 10 minute window counting local 401, 403, and
+    429 responses, EXCLUDING scope `shared` (shared-scope 429s do not count toward Discord's ban
+    counter); at DISCORD_BREAKER_LIMIT (default 300, against Discord's 10000 per 10 minutes per
+    IP) sweeps and non-essential writes stop; a single half-open probe after a full quiet window,
+    closing on success and re-opening on failure.
+  - Permanent-failure cache (D4): a member that answers 401 or 403 is not retried until
+    DISCORD_FORBIDDEN_TTL_MS (default 86400000, 24h) expires or the bot's own role position
+    changes. Expose the invalidation hook even though nothing calls it until a later phase.
+  - Counter outputs for Phase 8 (D16): requests, 429s by scope, breaker state and breaker opens,
+    queue depths. A snapshot getter, no IO, no formatting.
+
+Stage 2 (serial, in the main loop): rewire `DiscordApi.request()` through the governor.
+  - Keep the REST base pinned at /api/v10 and pin it in a test (D14); keep the existing valid
+    User-Agent.
+  - Add `X-Audit-Log-Reason` (1 to 512 characters, plain ASCII, no em dashes or emojis) to member
+    PATCHes.
+  - Log `X-RateLimit-Scope` on every 429 (O5 is answered from these logs after deploy: whether
+    member-write 429s come back as `user` or `shared` scope decides ban-counter exposure).
+  - Preserve every caller-visible contract the Explore step identified. Pacing and error handling
+    may change; WHICH calls the bot makes may not.
+  - Add the new env keys to bot/config.ts with the defaults above and their BotConfig fields.
+    Numeric env parsing has a known trap: an empty or non-numeric value must fall back to the
+    default, not to 0 (memory: env-empty-numeric-default-shift).
+  - Add the same four keys to the existing commented Discord block in .env.example, commented and
+    carrying their defaults, in this change (ruling R8 in state.md). The full operator
+    documentation of these keys still lands in DEPLOY.md in Phase 7 (D13 unchanged).
+
+Stage 3 (ULTRACODE Workflow fan-out, uniform batch work): the governor test suite, one agent per
+arm group, each agent owning its own test file section and none editing bot/rate_governor.ts:
+  - Header-driven pacing: a response's Remaining and Reset-After gate the next dispatch in that
+    bucket; two calls to the same bucket serialize; different buckets proceed in parallel up to
+    the RPS cap; the provisional key remaps onto the returned bucket hash.
+  - The three 429 scopes: `user`, `global` (process-wide pause), and `shared` (paused and
+    retried, but NOT counted by the breaker). Every arm asserts the FULL retry_after is honored:
+    a retry_after of 60 waits 60 seconds, not the old 10 second clamp. Pin that explicitly as the
+    incident regression.
+  - The HTML-body 429: a non-JSON body pauses for DISCORD_BAN_PAUSE_MS and logs an error, and
+    does NOT fall through to a short retry.
+  - Breaker: does not trip one below the limit, trips at the limit, old entries age out of the
+    rolling window, the half-open probe runs only after a full quiet window, closes on success,
+    re-opens on failure.
+  - Forbidden cache: a 403 suppresses the next attempt for that member, TTL expiry allows a
+    retry, and the role-position invalidation clears it early.
+  - Counters: each counter moves exactly once per event, and the snapshot shape matches what
+    Phase 8 will ship.
+  - Determinism: the same inputs with the same injected clock produce the same dispatch schedule
+    on two consecutive runs (record the schedule and compare, do not eyeball it).
+  Before writing timing tests, read the memory entries cachedread-captured-clock-vs-fake-timers
+  (a clock captured at construction does not move under fake timers) and
+  settimeout-fractional-delay-fires-early (a fractional delay fires EARLY).
+
+INVARIANTS IN PLAY (from state.md):
+  - D2, the governor owns ALL Discord REST dispatch: bucket-keyed serialized queues, proactive
+    gating at Remaining == 0, full retry_after with no ceiling, the non-JSON 429 ban pause,
+    DISCORD_MAX_RPS default 8.
+  - D3, the invalid-request breaker: rolling 10 minute window over local 401/403/429 excluding
+    scope shared, DISCORD_BREAKER_LIMIT default 300, half-open probe after a quiet window.
+  - D4, the permanent-failure cache: a 401/403 member is not retried until the role position
+    changes or DISCORD_FORBIDDEN_TTL_MS expires.
+  - D7, zero new npm dependencies: no rate-limiter package, no discord.js, no HTTP agent package.
+    Connection bounding comes from app-level serialization over default keep-alive fetch.
+  - D8, the pure/IO split: the governor is a DOM-free pure module with Vitest coverage,
+    bot/discord_api.ts stays a thin IO shell, wiring stays in bot/main.ts.
+  - D13, new cadences and thresholds are env-configurable with safe defaults; the DEPLOY.md
+    documentation of these keys lands in Phase 7, so record the key names in state.md now.
+  - D14, /api/v10 pinned, valid User-Agent kept, X-Audit-Log-Reason on member PATCHes,
+    X-RateLimit-Scope logged from day one.
+  - D16, the counters this phase emits are the ones Phase 8 ships on the presence POST.
+  - D19, the QA session mutation-tests this module, so every guard needs a decisive test.
+  - Packet non-negotiables: no src/ edit; secrets env only; no em dashes, en dashes, or emojis in
+    code, comments, log lines, docs, or commits; commit with EXPLICIT paths, never `git add -A`.
+
+OUT OF SCOPE: the sweep and its iteration set (Phase 3 and Phase 6), the poll loops and the
+presence debounce (Phase 3), every server/ change (Phases 4 and 5), deploy and compose files plus
+the DEPLOY.md bot section (Phase 7, with the .env.example key block the one exception R8 puts in
+this phase), the presence-counter transport (Phase 8), and retiring any server endpoint the bot
+calls (Phase 6). Do not change which Discord calls the bot makes, only
+how they are dispatched.
+
+STEP 3 - VALIDATION + REVIEW: run the state.md bot-only row: `npx tsc --noEmit`,
+`npx vitest run tests/discord_bot.test.ts` plus the Phase 1 and Phase 2 bot test files,
+`npm run build:bot`, and `npm run ci:changed` (scoped
+`npx @biomejs/biome check --write <file>` for fixes, never a whole-repo write). At phase close
+run `npm run gate` (exit-code-safe; never an ad-hoc && chain).
+Dispatch reviewers per the Review Dispatch Matrix in implementation-plan.md, matching rows ONLY:
+the bot code itself matches no row, but this phase edits .env.example, which the
+`privacy-security-review` row lists as an env/deploy file, so spawn that reviewer plus
+`qa-checklist` at phase end. If any OTHER matrix row matches (server/, src/net/, compose, CI),
+the phase went out of scope. Prompt every reviewer for COVERAGE, not filtering. Resume a
+truncated reviewer with: "Stop reading more files. Output the full report now. No more tool
+calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT." Do not commit while a BLOCKING
+finding stands.
+
+STEP 4 - COMMITS: Conventional Commits with a scope, explicit paths, and a BODY on every commit
+(1 to 4 plain sentences saying what changed and why, wrapped near 72 columns). No em dashes, no
+en dashes, no emojis, no trailers. The plan suggests `feat(bot)` twice plus `test(bot)`:
+  1. feat(bot): add the pure Discord rate-limit governor
+  2. feat(bot): dispatch every Discord REST call through the governor
+  3. feat(bot): add the governor env knobs with safe defaults (bot/config.ts and .env.example)
+  4. test(bot): cover pacing, every 429 scope, the breaker, and the forbidden cache
+Fold 3 into 1 if the config change is a few lines; keep the tests as their own commit. Never
+commit a real .env; only the commented example keys.
+
+STEP 5 - ACCEPTANCE (every item verifiable by a command or an assertion, not by claim):
+  - bot/rate_governor.ts is pure: a grep for fetch, ws, Date.now, setTimeout, setInterval, and
+    performance.now in that file returns nothing, and every test drives it with a synthetic
+    clock.
+  - No hard-coded per-route rate numbers: every limit in the module comes from a response header
+    or a config key (O2).
+  - Every Discord REST call in bot/discord_api.ts is dispatched through the governor; no direct
+    fetch remains except the single injected dispatch the governor drives.
+  - The old behavior is provably gone: a test pins that a retry_after of 60 seconds waits 60
+    seconds (no 10 second clamp) and that a non-JSON 429 body pauses for the ban interval instead
+    of retrying after 1 second.
+  - A test pins the /api/v10 base as a literal, a member PATCH carrying X-Audit-Log-Reason, and a
+    429 log line that includes the scope.
+  - Config defaults assert 8, 600000, 300, and 86400000, each with an empty-string env arm that
+    still yields the default.
+  - All four keys appear commented, with their defaults, in the .env.example Discord block (R8).
+  - The breaker asserts both edges (limit minus one does not trip, the limit does), and the
+    half-open probe has its own arm.
+  - The determinism test compares two recorded schedules and passes on a repeat run.
+  - `npx tsc --noEmit`, the bot test files, `npm run build:bot`, `npm run ci:changed`, and
+    `npm run gate` all green.
+
+STEP 6 - DOCS: update docs/discord-bot-stability/progress.md (the Phase 2 status row and its four
+checkboxes) and docs/discord-bot-stability/state.md ("Current phase", the "Created by this
+packet" list: bot/rate_governor.ts, the four new env keys with their defaults, the new test
+files, and the counter names Phase 8 will consume) in the SAME commit as the work, with explicit
+paths. The .env.example entries land with the config change itself per R8, not in this step, and
+the operator documentation in DEPLOY.md stays Phase 7 work. Record surprising rules to memory as
+one file per fact plus its MEMORY.md pointer.
+
+STEP 7 - FINAL RESPONSE: phase status, files touched (absolute paths), validation results
+(command plus outcome for each), reviewer verdicts, anything deferred with the reason, the four
+env key names and defaults, and a one-line handoff for the Phase 2 QA session.
+
+STOPPING RULES:
+  - Stop and surface if the governor cannot be pure without a new dependency (D7). No
+    rate-limiter package, no discord.js, no HTTP agent package. If measurements say a
+    hand-rolled node:http agent wrapper is genuinely required, escalate to the user before
+    writing it.
+  - Stop if the rewire would change WHICH Discord calls the bot makes or their user-visible
+    effect. Pacing and error handling are in scope; the call set is not.
+  - Stop if the work appears to need an edit under src/ or server/, which means the phase went
+    out of scope.
+  - Stop if the worktree is dirty with work that is not yours.
+```

--- a/docs/discord-bot-stability/phase-03-qa.md
+++ b/docs/discord-bot-stability/phase-03-qa.md
@@ -1,0 +1,118 @@
+# Phase 3 QA: Loop scheduler + diff-before-write
+
+Phase 3 rewrote how every bot loop is driven and made two write paths conditional, which is the
+change most likely to be subtly wrong in a way tests wave through: a skip condition that skips
+the wrong case, a cache updated before the write it is supposed to record, or an echo suppression
+that also suppresses a real update. This session verifies the migration preserved behavior beyond
+cadence, that a steady state genuinely writes nothing, and it mutation-checks bot/scheduler.ts
+and the nickname and members-meta diff logic.
+
+## Starter prompt
+
+```
+This is Phase 3 QA of the Discord Bot Stability packet: verify the loop scheduler and
+diff-before-write.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code. ULTRACODE: yes, run the
+adversarial-verify Workflow (every finding independently confirmed by a skeptic agent before it
+counts) plus mutation spot checks on bot/scheduler.ts and the nickname and members-meta diff
+logic. Judge every refutation yourself rather than taking it on faith, and require the skeptic to
+have the file open before a refutation counts.
+Worktree: /Users/fernando/Documents/wocc-discord-bot.
+
+STEP 0 - PRE-FLIGHT: run `git status` and confirm it is clean with Phase 3 committed; another
+session may share this checkout, so ASK before touching anything you did not create. Memory scan
+including the test-pin trap index (READ IT before judging or writing any pin), plus
+mutation-harness-must-prove-tests-ran, mutation-test-uncommitted-revert-trap, the clock and timer
+traps (cachedread-captured-clock-vs-fake-timers, settimeout-fractional-delay-fires-early), and
+the worktree/node_modules entries (worktree-symlink-vitest-limitation,
+stale-node-modules-fullsuite-failure-set) since the mutation pass needs a second worktree that
+can actually run vitest.
+
+STEP 1 - LOAD CONTEXT: spawn an Explore agent over docs/discord-bot-stability/state.md,
+docs/discord-bot-stability/progress.md,
+docs/discord-bot-stability/phase-03-scheduler-and-diffs.md, and the Phase 3 diff (find the
+phase-start commit from the branch log, the commit immediately before the first Phase 3 commit,
+and diff it against HEAD). It returns: the promised deliverables and acceptance criteria, the
+files touched with a one-line summary of each change, a before-and-after table of the six loops
+plus the presence debounce (what drove each before, what drives it now, at what cadence, under
+which config key), and where the nick cache and the last-pushed meta cache live and who writes
+them.
+
+STEP 2 - AUDIT (parallel agents, COVERAGE not filtering: report every gap with confidence and
+severity, do not pre-filter):
+  - Correctness agent, migration: did every one of the six loops survive with the same function,
+    the same ordering (including the refreshSpecialRoles then pushAllMemberMeta pairing), and the
+    same failure handling? Is any loop now silently unscheduled, double-scheduled, or scheduled
+    off a different trigger? Do the GUILD_CREATE kicks coalesce rather than multiply, given that
+    GUILD_CREATE fires on every re-IDENTIFY? Are timers still unref'd so the process can exit? Is
+    `setInterval` really gone from bot/main.ts (the gateway heartbeat is out of scope and stays)?
+    Do the env-configurable intervals still default to 300000, 4000, and 3000, with an
+    empty-or-non-numeric value falling back to the default rather than to 0?
+  - Correctness agent, diffs: does the nickname skip fire on equality and only on equality, and
+    is the cache updated ONLY after a successful PATCH (the computeRoleSync pattern)? Is the nick
+    cache fed from every source that can change a nick (GUILD_CREATE seeding, member chunks,
+    GUILD_MEMBER_ADD, GUILD_MEMBER_UPDATE), and is it reading the live nick rather than a display
+    name that falls back to global_name or username? Does the members-meta diff compare against
+    the last SUCCESSFULLY pushed record? Do the clearing paths (GUILD_MEMBER_REMOVE,
+    clearDepartedFlair) still push, and is a departed member's cache entry dropped so a rejoin
+    re-pushes? Does echo suppression suppress only the bot's own writes, never a genuine
+    third-party change? Check the D-invariants: D5 (diff-before-write universal), D6 explicitly
+    NOT started here (the sweep's iteration set must be unchanged), D7 (no new dependency), D8
+    (pure cores plus wiring only in main.ts), no src/ or server/ edit, no em dash, en dash, or
+    emoji in the diff.
+  - Test coverage agent: are the arms decisive? Overlap (a run longer than its interval never
+    starts a second concurrent run), backoff in both directions (walks to idle, snaps back on
+    work), coalescing (N kicks during a run produce exactly one follow-up), jitter band, the
+    nick-diff no-op / changed / failure-leaves-cache-untouched arms, the meta-diff arms, the
+    echo-suppression arm plus its negative twin (a real third-party update still pushes), and a
+    steady-state assertion of ZERO writes at the D18 envelope. Flag any timing test whose clock
+    cannot actually advance, any arm asserting a call count where it should assert cache state,
+    and any pin that re-reads the value it claims to pin.
+  - Dead-code agent: the deleted setIntervals leaving no orphaned constants, helpers, or imports;
+    unused exports on the scheduler; superseded comments in bot/main.ts and bot/CLAUDE.md that
+    now describe a cadence mechanism that no longer exists.
+  - Review Dispatch Matrix rows matching the diff, per implementation-plan.md: a bot-only diff
+    matches no row, so `qa-checklist` is the reviewer set. If a row for server/, src/, or a
+    deploy file matches, that itself is a finding: the phase went out of scope.
+  Mutation pass in an ISOLATED worktree created from the Phase 3 HEAD commit (never check out
+  over uncommitted work), each mutant applied one at a time:
+    - bot/scheduler.ts: remove the overlap guard so a slow run can stack; flip the backoff
+      direction (idle to active instead of active to idle); drop coalescing so each kick queues
+      its own run; coalesce too aggressively so a kick during a run is dropped entirely; shift the
+      next-delay boundary by one tick; widen or zero the jitter band; schedule the next run before
+      the previous one settles.
+    - Nickname diff: invert the skip condition (write when equal, skip when different); move the
+      cache update BEFORE the awaited PATCH so a failed write is masked; update the cache even in
+      the catch path.
+    - members-meta diff: compare against the freshly built record instead of the last pushed one;
+      remove echo suppression entirely; over-suppress so a genuine third-party update is dropped;
+      skip the clearing push for a departed member.
+    Each mutant must be killed by a NAMED test. Prove the suite actually ran for every mutant:
+    record the vitest summary line (files, tests, passed, failed) and confirm a nonzero failure
+    count, since a config or path mistake that runs zero tests looks like a pass.
+
+STEP 3 - FIX: apply ALL findings, blocking, should-fix, AND nits (standing user rule). Then
+review the fix round itself with a fresh-eyes agent, because the fixes are unreviewed code. Then
+re-run the state.md bot-only validation row: `npx tsc --noEmit`,
+`npx vitest run tests/discord_bot.test.ts` plus every bot test file, `npm run build:bot`,
+`npm run ci:changed`, and `npm run gate` at close. Commit with explicit paths, a scoped
+Conventional Commit subject, and a body; no `git add -A`.
+
+STEP 4 - DOCS: update docs/discord-bot-stability/progress.md (Phase 3 QA row complete, plus
+deferrals under the per-phase notes) and docs/discord-bot-stability/state.md (drift the audit
+found, the final interval env key names and defaults, and any new implementer gotcha, especially
+around the GUILD_CREATE coalescing trap). If bot/CLAUDE.md's "Poll loops" section still describes
+the old bare-interval world, fix it here. Record genuinely reusable traps to memory as one file
+per fact plus its MEMORY.md pointer line.
+
+STEP 6 - FINAL RESPONSE: verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL), counts found and fixed by
+severity, the mutation kill tally (mutants planted, killed, survived, with the survivor
+explained), deferrals with reasons, and a one-line handoff for the Phase 4 session.
+
+STOPPING RULES: stop and surface if a BLOCKING item cannot be fixed without changing Phase 3's
+scope (for example a diff that can only be made correct once the Phase 5 change feed exists, or a
+sweep-iteration problem that is Phase 6's D6 work). Stop if a surviving mutant can only be killed
+by changing behavior rather than by adding a test, and report it as a finding instead of changing
+behavior here. Stop if the mutation worktree cannot run the suite, rather than reporting an
+unproven kill.
+```

--- a/docs/discord-bot-stability/phase-03-scheduler-and-diffs.md
+++ b/docs/discord-bot-stability/phase-03-scheduler-and-diffs.md
@@ -1,0 +1,193 @@
+# Phase 3: Loop scheduler + diff-before-write
+
+Two of the incident's root causes live in `bot/main.ts`. Six bare `setInterval` loops
+(`bot/main.ts:518-537`) fire whether or not the previous run finished, so once backoff stretches
+a sweep past its 5 minute period the sweeps stack, which is what turns a burst into a sustained
+storm that survives restarts. And the nickname PATCH (`bot/main.ts:241-247`) is unconditional
+where the role sync right above it correctly diffs first, so every linked online member is
+written every sweep forever, and each write makes Discord emit `GUILD_MEMBER_UPDATE`, whose
+handler POSTs members-meta straight back into the game (about 63 per minute of load the bot
+generates against itself). This phase adds the pure scheduler that makes overlap and reconnect
+storms impossible, and the diffs that make a steady-state sweep write nothing at all.
+
+## Starter prompt
+
+```
+This is Phase 3 of the Discord Bot Stability packet: Loop scheduler + diff-before-write.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code.
+Worktree: /Users/fernando/Documents/wocc-discord-bot (branch feature/discord-bot-stability).
+No Workflow needed: two independent module slices plus one serial wiring stage. Use a 2-agent
+fan-out in STEP 2 stage 1 and keep the bot/main.ts migration in the main loop.
+
+Goal: replace the six bare interval loops with one pure scheduler that cannot overlap or storm,
+and make every nickname and members-meta write conditional on an actual change.
+
+STEP 0 - PRE-FLIGHT: run `git status` in the worktree and confirm it is clean with Phase 2
+committed; another session may share this checkout, so ASK before touching anything you did not
+create. Scan MEMORY.md for the domains in play: bot/Discord work, fake-timer and captured-clock
+traps, test-pin traps, Biome on changed files, and shared-worktree commit care.
+
+STEP 1 - LOAD CONTEXT (do NOT read the planning docs directly): spawn one Explore agent over
+docs/discord-bot-stability/state.md, docs/discord-bot-stability/progress.md,
+docs/discord-bot-stability/phase-03-scheduler-and-diffs.md, and these source files: bot/main.ts,
+bot/logic.ts, bot/config.ts, bot/discord_api.ts, bot/server_client.ts, bot/gateway.ts,
+bot/rate_governor.ts (Phase 2), bot/CLAUDE.md, the root CLAUDE.md, tests/discord_bot.test.ts plus
+the Phase 1 and Phase 2 bot test files, scripts/build_bot.mjs, scripts/gate.mjs, and
+tsconfig.json.
+It returns, as conclusions rather than file dumps:
+  a. each of the six interval loops at bot/main.ts:518-537: what it calls, at what cadence, what
+     it does on failure, and every other place that same function is invoked (GUILD_CREATE and
+     the member-chunk completion both kick some of them);
+  b. the presence debounce (schedulePresencePush) and its exact timing semantics;
+  c. the nickname write path (bot/main.ts:203-251) and which caches hold a member's live nick
+     versus their display name, including what displayNameOf falls back to;
+  d. the members-meta push paths (single member, full roster, and the clearing paths on
+     GUILD_MEMBER_REMOVE and in clearDepartedFlair), with the byte-batching contract;
+  e. the computeRoleSync update-cache-only-after-success pattern as the exemplar to copy;
+  f. the Phase 2 governor's public surface, so the scheduler composes with it and does not
+     re-implement pacing.
+
+STEP 2 - EXECUTE.
+
+Stage 1 (two parallel agents, disjoint files, neither touching bot/main.ts):
+  - Agent A, bot/scheduler.ts plus its tests. A pure core with a thin driver (D8): the decision
+    logic (next delay, may-this-run-start, coalesce state, backoff state) is IO-free and takes an
+    injected clock; the driver owns the actual timer and is the only part that touches one.
+    Deliver:
+      * Chained timeouts, never setInterval: the next run is scheduled only after the previous
+        run settles, so a slow run cannot stack. Keep an explicit in-flight guard for
+        event-triggered kicks as well.
+      * Jitter, so several loops do not align on the same tick. The Rng rule in the root
+        CLAUDE.md is scoped to src/sim, so Math.random is an acceptable production default here,
+        but the source must be injectable so tests are deterministic.
+      * Adaptive idle backoff: a task reports whether it did work, and the cadence walks from its
+        active interval toward its idle interval and snaps back to active on work. D1's shape for
+        the outbox is 3 seconds active decaying to 15 seconds idle; this phase ships the
+        mechanism only, the outbox task itself is Phase 6.
+      * Coalescing for event-triggered runs: repeated kicks while a run is in flight collapse
+        into exactly ONE follow-up run. This is the GUILD_CREATE trap: GUILD_CREATE fires on
+        every re-IDENTIFY, so a reconnect storm must not multiply sweeps.
+      * Env-configurable intervals (D13) whose defaults are today's values: ROLE_SYNC_INTERVAL_MS
+        300000, PRESENCE_DEBOUNCE_MS 4000, RELAY_POLL_MS 3000. Key names go in bot/config.ts next
+        to the Phase 2 keys, with the same empty-or-non-numeric-falls-back-to-default handling
+        (memory: env-empty-numeric-default-shift).
+      * Timers stay unref'd, as today's loops are, so the process can still exit.
+  - Agent B, the pure diff cores in bot/logic.ts plus their tests: the nickname decision (given
+    the computed nick and the cached live nick, write or skip), the members-meta delta decision
+    (given a freshly built record and the last successfully pushed record, push or skip), and the
+    self-echo predicate (given an incoming GUILD_MEMBER_UPDATE and what the bot just wrote, is
+    this our own echo). Pure functions only, no IO, no caches owned here beyond what a caller
+    passes in.
+
+Stage 2 (serial, in the main loop, after both agents land): the bot/main.ts wiring, which is the
+only place wiring belongs (D8).
+  - Migrate all six loops and the presence debounce onto the scheduler, and delete the bare
+    setIntervals. Preserve exactly which function runs and what it does; only the cadence
+    mechanism changes. The refreshSpecialRoles-then-pushAllMemberMeta pairing keeps its ordering.
+  - The GUILD_CREATE handler's immediate syncAllOnlineRoles and pushAllMemberMeta kicks become
+    coalescing kicks on the scheduler rather than bare fire-and-forget calls.
+  - Wire the nickname diff: cache the member's live nick from GUILD_CREATE seeding,
+    GUILD_MEMBERS_CHUNK, GUILD_MEMBER_ADD, and GUILD_MEMBER_UPDATE, skip the PATCH when the
+    computed nick equals the cached one (D5), and update the cache ONLY after a successful PATCH,
+    following the computeRoleSync pattern so a failed write retries next sweep instead of being
+    masked. Note from the Explore step whether the existing memberNames cache is the right source
+    or whether the live nick needs tracking separately, since displayNameOf falls back to
+    global_name and username.
+  - Wire the members-meta diff: track the last SUCCESSFULLY pushed record per member, push only
+    changed members, and keep the existing byte-batching for whatever remains. Suppress
+    self-caused GUILD_MEMBER_UPDATE echoes by comparing the incoming state to what the bot just
+    wrote (D5). The clearing paths must still push: a cleared record IS a change, and a departed
+    member's cache entry must be dropped so a rejoin re-pushes.
+
+Stage 3 (serial): the wiring-level tests. Fake-timer scheduler suites (overlap, backoff,
+coalescing, jitter band), the nick-diff arms (no-op, changed, failure leaves the cache
+untouched), the meta-diff arms, and the echo-suppression arms. Before writing timing tests, read
+the memory entries cachedread-captured-clock-vs-fake-timers (a clock captured at construction
+does not move under fake timers) and settimeout-fractional-delay-fires-early (a fractional delay
+fires EARLY).
+
+INVARIANTS IN PLAY (from state.md):
+  - D1, the adaptive cadence shape (active decaying to idle) is the scheduler's job; the
+    consolidated outbox poll that uses it arrives in Phase 6.
+  - D5, diff-before-write is universal: a nickname PATCH only when the computed nick differs from
+    the cached member nick, members-meta pushed only for members whose meta changed since the
+    last successful push, and self-caused GUILD_MEMBER_UPDATE echoes suppressed.
+  - D6 is NOT this phase: the sweep still iterates the set it iterates today. Changing the
+    iteration set to linked members only is Phase 6.
+  - D7, zero new npm dependencies: no scheduler or timer package.
+  - D8, the pure/IO split: scheduler and diff cores are pure modules with Vitest coverage, and
+    bot/main.ts holds wiring only.
+  - D13, intervals are env-configurable with today's values as defaults; DEPLOY.md documentation
+    of the keys lands in Phase 7, so record the names in state.md now.
+  - D19, the QA session mutation-tests the scheduler and the diff logic, so every guard and every
+    cache-update ordering needs a decisive test.
+  - Packet non-negotiables: no src/ edit; secrets env only; no em dashes, en dashes, or emojis in
+    code, comments, log lines, docs, or commits; commit with EXPLICIT paths, never `git add -A`.
+
+OUT OF SCOPE: the sweep's iteration set (D6, Phase 6), every server/ change (Phases 4 and 5), the
+outbox endpoint and its bot-side consumption (Phases 5 and 6), governor internals (Phase 2 owns
+pacing; the scheduler must not re-implement it), deploy and compose files plus the DEPLOY.md bot
+section (Phase 7), and observability counters (Phase 8). Do not change what a sweep DOES beyond
+skipping writes that would have been no-ops.
+
+STEP 3 - VALIDATION + REVIEW: run the state.md bot-only row: `npx tsc --noEmit`,
+`npx vitest run tests/discord_bot.test.ts` plus every Phase 1 to Phase 3 bot test file,
+`npm run build:bot`, and `npm run ci:changed` (scoped
+`npx @biomejs/biome check --write <file>` for fixes, never a whole-repo write). At phase close
+run `npm run gate` (exit-code-safe; never an ad-hoc && chain).
+Dispatch reviewers per the Review Dispatch Matrix in implementation-plan.md, matching rows ONLY:
+a bot-only diff matches no row, so `qa-checklist` at phase end is the reviewer set. A row match
+for server/, src/, or deploy files means the phase went out of scope. Prompt every reviewer for
+COVERAGE, not filtering. Resume a truncated reviewer with: "Stop reading more files. Output the
+full report now. No more tool calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT." Do
+not commit while a BLOCKING finding stands.
+
+STEP 4 - COMMITS: Conventional Commits with a scope, explicit paths, and a BODY on every commit
+(1 to 4 plain sentences saying what changed and why, wrapped near 72 columns). No em dashes, no
+en dashes, no emojis, no trailers. The plan suggests `feat(bot)` twice plus `refactor(bot)` plus
+`test(bot)`:
+  1. feat(bot): add the pure loop scheduler with overlap guards and adaptive backoff
+  2. refactor(bot): run every poll loop and the presence debounce on the scheduler
+  3. feat(bot): diff nicknames and members-meta before writing
+  4. test(bot): cover the scheduler timing arms and every diff-before-write path
+
+STEP 5 - ACCEPTANCE (every item verifiable by a command or an assertion, not by claim):
+  - `grep -n "setInterval" bot/main.ts` returns nothing. The gateway heartbeat interval in
+    bot/gateway.ts is not in scope and stays.
+  - All six loops plus the presence debounce run through the scheduler, and each names its config
+    key; the defaults still equal 300000, 4000, and 3000.
+  - Steady state writes nothing: a test where no member's nick or meta has changed performs ZERO
+    setNickname calls and ZERO members-meta pushes.
+  - The failure arm asserts the CACHE, not just a call count: a rejected PATCH leaves the cached
+    nick unchanged, so the next sweep retries.
+  - The echo loop is closed: a PATCH that produces a GUILD_MEMBER_UPDATE carrying exactly what
+    the bot wrote results in no members-meta POST, while a genuine third-party update still
+    pushes.
+  - Coalescing: several GUILD_CREATE events arriving during an in-flight sweep produce exactly
+    one additional sweep, not one per event.
+  - Overlap: a run that takes longer than its interval never starts a second concurrent run.
+  - The scheduler pure core imports no timer and no clock, and its tests drive it with a
+    synthetic clock or fake timers.
+  - `npx tsc --noEmit`, the bot test files, `npm run build:bot`, `npm run ci:changed`, and
+    `npm run gate` all green.
+
+STEP 6 - DOCS: update docs/discord-bot-stability/progress.md (the Phase 3 status row and its five
+checkboxes) and docs/discord-bot-stability/state.md ("Current phase", the "Created by this
+packet" list: bot/scheduler.ts, the new diff helpers, the new interval env keys with defaults,
+and the new test files) in the SAME commit as the work, with explicit paths. If bot/CLAUDE.md's
+"Poll loops" section no longer describes reality after the migration, update it in the same
+change. Record surprising rules to memory as one file per fact plus its MEMORY.md pointer.
+
+STEP 7 - FINAL RESPONSE: phase status, files touched (absolute paths), validation results
+(command plus outcome for each), reviewer verdicts, anything deferred with the reason, the new
+env key names and defaults, and a one-line handoff for the Phase 3 QA session.
+
+STOPPING RULES:
+  - Stop and surface if migrating a loop would change user-visible sync behavior beyond cadence:
+    which members are synced, the ordering of operations inside a sweep, or what gets pushed. A
+    cadence change is the whole point; a behavior change is not.
+  - Stop if a diff decision would need the game server to tell the bot what changed. That is the
+    Phase 5 change feed, not this phase.
+  - Stop if the work appears to need a new npm dependency (D7) or an edit under src/ or server/.
+  - Stop if the worktree is dirty with work that is not yours.
+```

--- a/docs/discord-bot-stability/phase-04-qa.md
+++ b/docs/discord-bot-stability/phase-04-qa.md
@@ -1,0 +1,89 @@
+# Phase 4 QA: Server set-based endpoints
+
+Phase 4 added a new secret-gated endpoint, rewrote a hot write path onto one multi-row
+statement across two arms, and wrote the first tests for two previously untested queue modules.
+Each of those is a place where a test can look decisive and prove nothing: a query-count pin
+that counts mocked calls instead of statements, an `IS DISTINCT FROM` skip that never actually
+skips in the fixtures, a cap test that passes because the cap was never reached. This QA
+session verifies the deliverables adversarially and then proves the tests bite by mutating the
+new logic and watching the suite fail.
+
+```
+This is Phase 4 QA of the Discord Bot Stability packet: verify Server set-based endpoints.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code. ULTRACODE: yes, run the
+adversarial-verify Workflow (every finding independently confirmed by a skeptic agent before it
+counts) plus mutation spot checks on the flex-batch handler logic, the members-meta bulk
+upsert, and the relay/activity queue modules (decision D19: every phase's QA runs ultracode).
+Worktree: /Users/fernando/Documents/wocc-discord-bot.
+
+STEP 0 - PRE-FLIGHT: `git status` clean and Phase 4 committed (if the tree is dirty, ASK; this
+checkout may be shared). Memory scan including the test-pin trap index: READ IT before judging
+or writing any pin. Load at minimum the constant-self-comparison trap, the "prove the tests
+RAN" rule, the no-checkout-over-WIP mutation trap, the vitest `-t` regex trap, the unquoted
+vitest filter trap, and the pg traps for SQL text pins (raw versus evaluated SQL).
+
+STEP 1 - LOAD CONTEXT: spawn an Explore agent over docs/discord-bot-stability/state.md,
+docs/discord-bot-stability/progress.md,
+docs/discord-bot-stability/phase-04-server-batch-endpoints.md, and the Phase 4 diff
+(`git diff <phase-start-commit>..HEAD`, plus `git log` for the phase's commits). It returns:
+the deliverables Phase 4 promised, the acceptance criteria it claimed, every file touched, and
+every new or changed test with the behavior each one claims to pin.
+
+STEP 2 - AUDIT (parallel agents, COVERAGE not filtering):
+  - Correctness agent: is every Phase 4 deliverable and acceptance criterion actually met?
+    Specifically: does flex-batch really resolve links in one IN pass and batch the follow-on
+    loads, or does a per-id loop survive somewhere in the call chain? Are unlinked ids
+    genuinely absent rather than answered with a zero-valued payload? Are the input cap, the
+    per-id length slice, and the non-string drop identical to members-meta? Does the
+    members-meta upsert skip on ALL of the meta fields, including the null and cleared cases
+    (a role cleared to null, a name cleared to null, a missing joinedAt)? Do the D-invariants
+    hold: D9 (no legacy twin for the new route; both arms edited for members-meta or a
+    ledgered deviation), D10 (one statement, both caps intact), D11 (no existing route
+    retired), D12 (comment present, no prune added), D18 (assertions at the 1,000 player /
+    5,000 member envelope)?
+  - Test coverage agent: are the assertions DECISIVE? Does the query-count pin count real SQL
+    statements (the makePool `calls` rig) rather than mock invocations that would not move if
+    an N+1 returned? Is the batch-size-invariance pin a real comparison rather than a constant
+    compared against itself? Are both sides of the activity dedupe TTL boundary tested? Does a
+    cap test actually push past the cap and assert WHICH items were dropped? Any orphaned or
+    unreferenced test, any single-arm test of an "all fields" claim?
+  - Dead-code agent: unused imports, types, or helpers left behind by the members-meta rewrite;
+    a now-unreachable per-member update path; leftover scaffolding from `npm run new:endpoint`.
+  - Plus the Review Dispatch Matrix rows matching the diff (privacy-security-review,
+    migration-safety, database-performance-reviewer) and qa-checklist.
+  Mutation pass, in an ISOLATED worktree (never over the working tree; consult the memory
+  entries on worktree symlinks and on stash being shared across worktrees before creating it):
+  mutate, one at a time, and prove the suite kills each mutant:
+    1. flex-batch: invert the linked-only filter so unlinked ids also return payloads.
+    2. flex-batch: drop the input cap (remove the array slice).
+    3. flex-batch: shift the per-id length slice boundary by one.
+    4. members-meta: remove the `IS DISTINCT FROM` skip so every row writes.
+    5. members-meta: invert the skip so only unchanged rows write.
+    6. members-meta: change the returned skipped count to the total instead of the skipped
+       subset.
+    7. discord_relay: raise the cap by one, and separately splice from the wrong end so the
+       NEWEST items are dropped.
+    8. discord_activity: make the dedupe TTL comparison inclusive versus exclusive at the
+       boundary, and separately drop the dedupe check entirely.
+  For every mutant, PROVE the tests ran (capture the vitest output showing the test count and
+  the failing test names, not just a nonzero exit code; a suite that silently matched zero
+  tests is the classic false kill). Record a kill tally.
+
+STEP 3 - FIX: apply ALL findings, blocking, should-fix, AND nits (standing user rule). Then
+review the fix round itself with a fresh-eyes agent: the fixes are unreviewed code. Re-run the
+state.md server-only validation row plus the http spine, the new queue tests,
+`npm run build:server`, and `npm run ci:changed`.
+
+STEP 4 - DOCS: update docs/discord-bot-stability/progress.md (Phase 4 QA complete, any
+deferrals, the mutation kill tally) and docs/discord-bot-stability/state.md (any drift the
+audit found in the locked decisions, the key file paths, or the created-by-this-packet list).
+Commit with explicit paths and a body.
+
+STEP 6 - FINAL RESPONSE: verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL), counts of findings found
+and fixed by severity, the mutation kill tally (killed / survived, and what a survivor means),
+deferrals with their reason, and a one-line handoff for Phase 5.
+
+STOPPING RULES: stop and surface if a BLOCKING item cannot be fixed without changing phase
+scope. Stop and surface if a mutant SURVIVES and the test that should have killed it cannot be
+strengthened without redesigning the Phase 4 implementation.
+```

--- a/docs/discord-bot-stability/phase-04-server-batch-endpoints.md
+++ b/docs/discord-bot-stability/phase-04-server-batch-endpoints.md
@@ -1,0 +1,206 @@
+# Phase 4: Server set-based endpoints
+
+Root cause 5 of the 2026-07-29 incident was server-side amplification: the bot's sweep asked
+`/internal/discord/flex` once per online Discord user and each call paid 1 to 4 uncached Postgres
+queries, while `members-meta` ran one serial UPDATE per member with no change detection. This
+phase makes the game side cheap per call, before Phase 6 rewires the bot onto it: one batched
+flex endpoint that answers for linked members only with set-based queries, one multi-row
+members-meta upsert that skips rows whose stored meta already matches, the `reward_ledger`
+retention decision recorded at its DDL (D12), and first tests for `server/discord_relay.ts` and
+`server/discord_activity.ts` so Phase 5 refactors those queues against a green baseline. No bot
+code changes here; the existing per-endpoint routes stay exactly where they are (D11).
+
+```
+This is Phase 4 of the Discord Bot Stability packet: Server set-based endpoints.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code.
+Worktree: /Users/fernando/Documents/wocc-discord-bot (branch feature/discord-bot-stability).
+ULTRACODE: not required for this phase. Use parallel Agent fan-out (STEP 2), not a Workflow.
+
+Goal: make the game server answer the bot's needs with set-based work: one batched flex endpoint
+covering linked members only, one multi-row members-meta upsert that skips unchanged rows, and a
+green test baseline for the two in-memory queue modules Phase 5 will refactor.
+
+STEP 0 - PRE-FLIGHT: run `git status` in the worktree and confirm it is clean; ASK before
+touching anything if it is dirty (another session may share this checkout, and commits in this
+packet use EXPLICIT paths, never `git add -A`). Memory scan of MEMORY.md for: server SQL and
+pg traps, HTTP pipeline / RouteDef traps, test-pin traps, and cached-read traps.
+
+STEP 1 - LOAD CONTEXT (do NOT read the planning docs directly): spawn ONE Explore agent over
+docs/discord-bot-stability/state.md, docs/discord-bot-stability/progress.md,
+docs/discord-bot-stability/phase-04-server-batch-endpoints.md, and these source files:
+  - server/internal.ts (RouteDef table around :329-549; the FROZEN legacy
+    handleDiscordInternal ladder around :75-241; the members-meta arms at :212-229 legacy and
+    :514-538 RouteDef; clampInt and the ok/fail envelope helpers)
+  - server/discord.ts (discordFlexForAccount around :950, the status payload around :798,
+    the presence cache around :185)
+  - server/discord_db.ts (accountForDiscord :134, discordForAccount :122,
+    setDiscordMemberMeta :590, discordIdsWithGuildFlair :576, the reward_ledger DDL :86-95)
+  - server/discord_relay.ts (cap 50, drain splice) and server/discord_activity.ts (cap 100,
+    30s dedupe TTL, the 512-key sweep)
+  - server/db.ts (highestCharacterForAccount around :2669 and its JSONB-expression sort)
+  - server/http/registry.ts (the internal routes import and the route assembly)
+  - server/http/middleware/require_internal_secret.ts
+  - tests/server/http/surface_inventory.ts, tests/server/http/parity.test.ts,
+    tests/server/http/completeness.test.ts, tests/server/http/ownership_coverage.test.ts,
+    tests/server/http/known_deviations.ts
+  - tests/server/internal.test.ts (the runRoute rig, the hoisted module mocks, the
+    members-meta cases), tests/discord_db.test.ts (the makePool fake with its `calls` array),
+    tests/server/helpers/ (fakeCtx, the FakeDb classes, the barrel)
+  - server/CLAUDE.md (hot-path seams, SQL placement) and server/http/CLAUDE.md (RouteDef
+    contract, `npm run new:endpoint`, spine artifacts)
+It returns, as CONCLUSIONS not file dumps:
+  (a) the exact RouteDef shape a new internal route must have (method/path/surface/meta/
+      middleware/handler, which gate const, how ok/fail write the envelope);
+  (b) the current members-meta behavior on BOTH arms, field by field, including every clamp
+      and cap, so the bulk rewrite can be proven behavior-identical;
+  (c) the full query fan-out of one flex payload today (which functions, how many statements,
+      which are per-account) and which of them can be batched by account id;
+  (d) how tests/server/internal.test.ts drives a route (its vi.mock module fakes plus the
+      runRoute helper) and how tests/discord_db.test.ts counts SQL statements (the hand-rolled
+      makePool fake and its `calls` array). Ruling R1 in state.md governs here: reuse the rig
+      the matching suite already uses, count every query-count pin off that `calls` array, and
+      never invent a raw pg mock;
+  (e) the exact surface_inventory row shape for an internal Discord route, and what the
+      parity / completeness / ownership_coverage tests will demand of a RouteDef-only route
+      with no legacy twin;
+  (f) whether tests/discord_relay.test.ts (which covers src/sim/discord_relay.ts, NOT the
+      server module of the same name) forces a different file name for the new queue tests.
+
+STEP 2 - EXECUTE: four agents. Agents C and D touch files nobody else touches and run in
+PARALLEL with agent A. Agents A and B both edit server/internal.ts, server/discord_db.ts, and
+tests/server/internal.test.ts, so run B only after A returns (do not run them concurrently and
+do not reach for worktree isolation for a two-agent sequence).
+  - Agent A (flex-batch slice): add the batched read function to server/discord_db.ts (or
+    server/discord.ts if the Explore report shows the payload assembly belongs there; SQL
+    lives only in db.ts / *_db.ts either way). Ruling R3 in state.md: this phase MAY add
+    batched set-based variants of per-account reads (the top-character read and its friends)
+    in db.ts / *_db.ts to serve flex-batch, and that is the point of the phase, not scope
+    creep. Keep every per-account original in place for its existing callers and do not
+    re-point those callers here. Then add the new RouteDef
+    `POST /internal/discord/flex-batch` to the server/internal.ts routes table, behind the
+    same discordGate the other Discord routes use. Body is a list of Discord user ids;
+    validate and clamp it the way members-meta does (array cap, per-id length slice, drop
+    non-strings). Resolve links with ONE `discord_links` IN pass, then batch the follow-on
+    loads by account id. UNLINKED ids get no fabricated payload. Tests in
+    tests/server/internal.test.ts plus tests/discord_db.test.ts, including a query-count
+    assertion that the statement count for a 200-id batch equals the count for a 1-id batch.
+  - Agent B (members-meta bulk upsert, runs after A): replace the per-member serial UPDATE
+    with ONE multi-row statement (unnest arrays) that skips rows whose stored values are not
+    `IS DISTINCT FROM` the incoming ones, and land it on BOTH the RouteDef arm and the frozen
+    legacy handleDiscordInternal arm in this same change (D9). The response keeps `updated`
+    and gains a count of unchanged rows skipped. Every existing clamp and cap pin stays
+    green. Also add the `reward_ledger` keep-forever comment at its DDL (D12).
+  - Agent C (queue tests): first tests for server/discord_relay.ts and
+    server/discord_activity.ts. Cover: enqueue then drain returns items in FIFO order and
+    leaves the queue empty; overflow past the cap drops the OLDEST items and keeps the cap;
+    the depth accessor tracks both; activity dedupe suppresses a repeat key inside the TTL and
+    admits it at and past the boundary (test both sides of the boundary, with the injected
+    `now`, never a real clock); the 512-key sweep prunes only expired keys. File names must
+    not collide with tests/discord_relay.test.ts, which covers the unrelated
+    src/sim/discord_relay.ts; put a comment in the new files naming that trap.
+  - Agent D (spine rows): hand-add the surface_inventory.ts row for the new route (dispatcher
+    internal, the secret-discord auth scope, the same content-type class as its siblings,
+    handler anchored on a symbol or route string, never a line number) and run the four spine
+    tests. This row is for a RouteDef-only route with NO legacy twin; if completeness or
+    parity demands a legacy-arm counterpart, STOP and report rather than adding a legacy arm
+    (D9 forbids a legacy twin for new endpoints).
+Give each agent the Explore summary, not the raw planning docs.
+
+INVARIANTS IN PLAY:
+  - D9 (endpoint placement): new endpoints are RouteDef-only, no legacy twin, behind
+    requireInternalSecret, with HAND-ADDED rows in tests/server/http/surface_inventory.ts; a
+    behavior edit to an EXISTING internal route (members-meta here) lands on BOTH the RouteDef
+    and the frozen legacy arm in the same change, or gets a ledgered deviation in
+    tests/server/http/known_deviations.ts.
+  - D10 (members-meta shape): ONE multi-row upsert (unnest arrays) skipping unchanged rows via
+    `IS DISTINCT FROM`; the 1000-member server cap and the 200-member bot batch both stand.
+  - D11 (no retirement yet): the existing per-endpoint GET routes (relay, activity, winners,
+    flex) stay in place and keep working; retiring them is a post-packet follow-up issue.
+  - D12 (retention): `reward_ledger` is an audit ledger and gets an explicit keep-forever
+    comment at its DDL instead of a prune.
+  - D18 (scale envelope): design and assert at 1,000 concurrent players and 5,000 guild
+    members; query-count and payload assertions pin against fixtures at that scale where
+    practical.
+  - D7 (dependencies): zero new npm packages.
+  - Pipeline contract: handlers are req/res-free `(ctx) => Awaitable<unknown>` writing through
+    the module's ok/fail helpers; SQL lives only in db.ts / *_db.ts; SQL is parameterized;
+    errors are stable codes from the append-only error_codes.ts.
+  - Copy and commit rules: no em dashes, no en dashes, no emojis anywhere (code, comments,
+    docs, commit text); commit with EXPLICIT paths, never `git add -A`.
+  - src/sim/ and the wire protocol are untouched by this packet.
+
+OUT OF SCOPE: the outbox endpoint and the linked-member change feed (Phase 5); any bot/ change
+(Phase 6); deleting or retiring the existing per-endpoint internal routes (D11); deploy assets
+(Phase 7); observability counters (Phase 8); /api/discord caching (Phase 9); any new table or
+DDL beyond the reward_ledger comment; any change to the presence route.
+
+STEP 3 - VALIDATION + REVIEW: run the state.md server-only row: `npx tsc --noEmit`, then
+`npx vitest run tests/server/internal.test.ts tests/discord_server.test.ts
+tests/server/discord.test.ts tests/discord_db.test.ts`, then the http spine
+(`npx vitest run tests/server/http/parity.test.ts tests/server/http/completeness.test.ts
+tests/server/http/ownership_coverage.test.ts tests/server/http/surface_inventory.test.ts`),
+then the new queue test files, then `npm run build:server`, then `npm run ci:changed` (scoped
+`--write` on changed files only if it reports format diffs, never a whole-tree write).
+Dispatch reviewers per the Review Dispatch Matrix in implementation-plan.md, matching rows only:
+privacy-security-review (server/ plus SQL and secret-gated surface), migration-safety (a
+server/*_db.ts DDL edit), database-performance-reviewer (new SQL, query cadence and
+cardinality, write amplification). Do NOT spawn cross-platform-sync, architecture-reviewer, or
+frontend-seam-reviewer; if a matrix row for those matches, the phase went out of scope.
+Prompt every reviewer for COVERAGE, not filtering. Resume a truncated reviewer with: "Stop
+reading more files. Output the full report now. No more tool calls. Format: BLOCKING /
+SHOULD-FIX / NICE-TO-HAVE / VERDICT." Do not commit while any BLOCKING finding stands.
+
+STEP 4 - COMMITS (Conventional Commits with a scope, explicit paths, every commit carries a
+body of 1 to 4 plain sentences saying what changed and why, no em dashes, no emojis):
+  1. `feat(server): add POST /internal/discord/flex-batch for linked-member batch reads`
+  2. `feat(server): collapse members-meta into one multi-row upsert that skips unchanged rows`
+  3. `test(server): cover the discord relay and activity queue modules`
+  4. `docs(server): record the reward_ledger keep-forever retention decision`
+Fold docs/discord-bot-stability/progress.md and docs/discord-bot-stability/state.md into the
+final commit of the phase.
+
+STEP 5 - ACCEPTANCE (each item verifiable, check them off explicitly in the final response):
+  - `POST /internal/discord/flex-batch` exists in the server/internal.ts routes table behind
+    discordGate, and has NO arm in handleDiscordInternal.
+  - A test proves the SQL statement count for a 200-id batch equals the count for a 1-id batch,
+    counted off the makePool `calls` array per ruling R1 (state the number in the final
+    response).
+  - Any per-account read that gained a batched variant still exists in its per-account form and
+    its existing callers are unchanged (R3).
+  - A test proves an unlinked id yields no payload for that id, and that an over-cap array,
+    over-long ids, and non-string entries are clamped or dropped exactly like members-meta.
+  - members-meta issues ONE statement per request regardless of member count; re-pushing
+    identical meta reports zero rows updated and a non-zero skipped count; `updated` keeps its
+    existing meaning for changed rows.
+  - Both members-meta arms produce identical responses for identical bodies (spine parity
+    green), or a ledgered deviation exists in known_deviations.ts with a stated reason.
+  - The surface_inventory row was hand-added; surface_inventory, parity, completeness, and
+    ownership_coverage tests are green.
+  - The reward_ledger DDL carries the keep-forever comment and no prune was added.
+  - tests for server/discord_relay.ts and server/discord_activity.ts exist under names that do
+    not collide with tests/discord_relay.test.ts, and cover cap overflow, drain-empties,
+    both sides of the dedupe TTL boundary, and the key sweep.
+  - `npx tsc --noEmit` clean, `npm run build:server` green, `npm run ci:changed` clean.
+
+STEP 6 - DOCS: update docs/discord-bot-stability/progress.md (Phase 4 status row and every
+Phase 4 checkbox) and docs/discord-bot-stability/state.md ("Created by this packet": the new
+endpoint, the new modules or functions, the new test files; plus any drift you found in the
+key file paths section). Record genuinely surprising rules to memory, one fact per file.
+
+STEP 7 - FINAL RESPONSE: phase status, files touched (absolute paths), validation results
+command by command, reviewer verdicts, anything deferred, and a one-line handoff for the
+Phase 4 QA session.
+
+STOPPING RULES:
+  - STOP if the bulk upsert cannot keep BOTH members-meta arms behavior-identical. Report the
+    exact divergence, the proposed known_deviations.ts row text, and wait. Do not invent a
+    deviation and do not silently let the arms drift.
+  - Do NOT stop on the per-account reads: ruling R3 permits adding batched set-based variants
+    of them in db.ts / *_db.ts for flex-batch, with the per-account originals left in place for
+    their existing callers. STOP only on the hidden-N+1 failure: never ship a per-item loop
+    dressed up as "batched". If some read genuinely cannot be batched, report the shape and
+    cost of what a batched version would need before writing any loop.
+  - STOP if any work would require touching src/, the wire protocol, or a new table.
+  - STOP and surface the proposed code first if the new route seems to need an error code that
+    error_codes.ts does not already have.
+```

--- a/docs/discord-bot-stability/phase-05-outbox-change-feed.md
+++ b/docs/discord-bot-stability/phase-05-outbox-change-feed.md
@@ -1,0 +1,201 @@
+# Phase 5: Outbox + linked-member change feed
+
+Three of the bot's loops poll every 3 seconds against queues that are almost always empty, and
+the only way the bot learns that a linked player levelled up, changed class, or crossed a
+status tier is to re-read every online user's flex payload on a timer. This phase replaces both
+with one server-side change feed and one consolidated drain: `server/discord_link_changes.ts`
+is a bounded FIFO, enqueued wherever the server ALREADY learns that a linked account's
+flex-relevant state changed, and `GET /internal/discord/outbox` drains relay, activity, daily
+reward winners, and link changes in a single envelope, collapsing the per-item
+`discordForAccount` N+1 into one IN query across all four streams (D1). The failure mode of
+this phase is a MISSED feed site: a state transition nobody enqueued is a change the bot never
+sees, and it will look like an intermittent staleness bug months later. Enumerating every site
+is therefore a first-class deliverable, not a side effect.
+
+```
+This is Phase 5 of the Discord Bot Stability packet: Outbox + linked-member change feed.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code.
+Worktree: /Users/fernando/Documents/wocc-discord-bot (branch feature/discord-bot-stability).
+ULTRACODE: not required, but the feed-site enumeration in STEP 1 must be EXHAUSTIVE; give the
+Explore agent "very thorough" breadth and treat its output as a deliverable, not a hint.
+
+Goal: one server-side outbox that the bot can drain in a single request, fed by a bounded
+linked-member change feed wired at EVERY site where the server already learns a linked
+account's flex-relevant state changed.
+
+STEP 0 - PRE-FLIGHT: run `git status` in the worktree and confirm it is clean; ASK before
+touching anything if it is dirty (this checkout may be shared, and commits use EXPLICIT paths,
+never `git add -A`). Memory scan of MEMORY.md for: server hot-path and cached-read traps, pg
+traps, HTTP pipeline traps, and the daily-rewards module memo traps.
+
+STEP 1 - LOAD CONTEXT (do NOT read the planning docs directly): spawn an Explore agent, breadth
+"very thorough", over docs/discord-bot-stability/state.md, docs/discord-bot-stability/
+progress.md, docs/discord-bot-stability/phase-05-outbox-change-feed.md, and these files:
+  - server/internal.ts (the RouteDef table around :329-549, especially the relay, activity, and
+    daily-rewards-winners handlers and their enrichment loops; the FROZEN legacy ladder
+    :75-241; the Phase 4 flex-batch route as the template for a new RouteDef)
+  - server/discord_relay.ts and server/discord_activity.ts (the bounded-FIFO pattern the new
+    module copies: cap constant, drain splice, depth accessor, injected `now` dedupe)
+  - server/discord_db.ts (discordForAccount :122, accountForDiscord :134, linkDiscordToAccount
+    :146, unlinkDiscord :190, grantRewardPoints :382, setDiscordGuildMember :210)
+  - server/discord.ts (discordFlexForAccount around :950, the link and unlink call sites, the
+    status tier helper) and server/db.ts (highestCharacterForAccount around :2669)
+  - server/daily_rewards.ts (discordWinnerAnnouncements and markDiscordWinnersAnnounced, and
+    whatever caching or memoization already sits under them)
+  - server/http/registry.ts, server/http/middleware/require_internal_secret.ts
+  - tests/server/http/surface_inventory.ts, parity.test.ts, completeness.test.ts,
+    ownership_coverage.test.ts, known_deviations.ts
+  - tests/server/internal.test.ts (the runRoute rig), tests/discord_db.test.ts (the makePool
+    fake and its `calls` array for statement counting), tests/server/helpers/ (fakeCtx, FakeDb).
+    Ruling R1 in state.md governs the rigs: reuse the rig the matching suite already uses,
+    count every query-count pin off the makePool `calls` array, never invent a raw pg mock
+  - server/CLAUDE.md (hot-path seams: cached reads, single-flight, retention) and
+    server/http/CLAUDE.md (RouteDef contract)
+It returns, as conclusions:
+  (a) THE FEED-SITE ENUMERATION, the load-bearing output of this step: every server-side site
+      where a LINKED account's flex-relevant state changes. Flex-relevant means anything the
+      bot renders or acts on: character level, character class or which character is the
+      account's top character, reward points or the derived status tier, and link or unlink
+      itself. Sweep server/ exhaustively; the enqueueActivity call sites in server/game.ts,
+      the linkDiscordToAccount and unlinkDiscord callers in server/discord.ts, and the
+      grantRewardPoints callers are KNOWN STARTING POINTS, not the answer. For each site
+      return: file path, enclosing symbol, which transition it represents, whether an account
+      id is in hand there, and whether the code path already knows the account is linked.
+  (b) the exact enrichment loop each existing stream does today (relay per item, activity per
+      participant, winners) and which account ids each stream needs resolved;
+  (c) the winners lookup: discordWinnerAnnouncements calls unannouncedWinnerDays on every
+      request today, so report what caching or memoization already exists beneath it, the
+      createCachedRead and single-flight seam server/CLAUDE.md offers, and the site where a
+      reward day is FINALIZED (that site is what must bust the new cache);
+  (d) the existing drain semantics (destructive splice, no cursor, no ack) so the outbox
+      matches them;
+  (e) the RouteDef and surface_inventory shapes to copy from the Phase 4 route.
+
+STEP 2 - EXECUTE: three agents, run in the order below.
+  - Agent A (change feed module, runs first, others depend on its exported surface):
+    server/discord_link_changes.ts, modelled on server/discord_activity.ts. A bounded FIFO of
+    change records keyed by account id (carry the Discord user id too when the site has it),
+    with a cap constant, dedupe over a short TTL with an INJECTED `now` so a burst of
+    transitions for one account collapses to one item, a destructive `drain`, and a depth
+    accessor. Pure and dependency-free: no DB, no IO, no Discord types. Its tests land with
+    it (FIFO order, cap drops oldest, dedupe inside and outside the TTL boundary, depth).
+  - Agent B (feed wiring, runs after A): enqueue at EVERY site from the STEP 1 enumeration.
+    Wiring must be cheap and must not change the behavior of the call site it hooks: no extra
+    query to discover linkage where the site does not already know it (if a site would need
+    one, record it and apply the stopping rule below). Add a test per transition class proving
+    the enqueue happens.
+  - Agent C (outbox endpoint, runs after A): `GET /internal/discord/outbox` as a new RouteDef
+    in server/internal.ts behind the same discordGate, draining relay + activity + winners +
+    link changes into ONE envelope with a named field per stream. Collect the account ids
+    every stream needs, resolve them in ONE IN query, then enrich from that map: the per-item
+    discordForAccount calls disappear. Keep the existing per-stream item shapes so Phase 6 can
+    reuse the bot-side handlers. Hand-add the surface_inventory row, anchored on the RouteDef
+    symbol or route string per ruling R4 (never by adding a legacy twin), and run the spine
+    tests. Also wrap the winners lookup (unannouncedWinnerDays) in a short TTL cache, 30 to 60
+    seconds, busted at day finalization, using the existing createCachedRead seam rather than a
+    bespoke timer, so a warm empty drain is fully query-free. Ruling R2 in state.md puts this
+    cache in Phase 5 scope; Phase 9 owns only the public /api/discord route. If the
+    day-finalization bust site cannot be located, surface that rather than shipping a cache
+    that can serve a stale winner day.
+Give each agent the Explore summary, not the raw planning docs.
+
+INVARIANTS IN PLAY:
+  - D1 (transport): ONE consolidated outbox poll draining relay, activity, winners, and linked
+    member changes in a single response; adaptive cadence lives on the bot side (Phase 6), not
+    here. No long-poll, no bot WebSocket, no server push.
+  - D9 (endpoint placement): the outbox is RouteDef-only, no legacy twin, behind
+    requireInternalSecret, with a HAND-ADDED surface_inventory row.
+  - D11 (no retirement yet): the existing relay, activity, and winners GET routes stay in place
+    and keep working; the bot stops calling them in Phase 6, and retiring them is a post-packet
+    follow-up issue.
+  - D18 (scale envelope): 1,000 concurrent players, 5,000 guild members; query-count and
+    payload-size assertions pin at that envelope.
+  - D7 (dependencies): zero new npm packages.
+  - Drain semantics: destructive read with no cursor and no ack, matching the existing relay
+    and activity behavior. Do NOT invent an acknowledgement protocol in this phase.
+  - Pipeline contract: handlers are req/res-free `(ctx) => Awaitable<unknown>` writing through
+    the module's ok/fail helpers; SQL lives only in db.ts / *_db.ts; SQL is parameterized;
+    errors are stable codes from the append-only error_codes.ts.
+  - Server authority: the feed reports state the server already computed. The bot never
+    computes rewards and this phase does not move any decision to it.
+  - Copy and commit rules: no em dashes, no en dashes, no emojis anywhere; commit with EXPLICIT
+    paths, never `git add -A`.
+  - src/sim/ and the wire protocol are untouched.
+
+OUT OF SCOPE: every bot-side change, including consuming the outbox and deleting the old
+pollers (Phase 6); retiring the existing per-endpoint routes (D11); deploy assets (Phase 7);
+observability counters (Phase 8); /api/discord caching (Phase 9); new tables or DDL; changing
+what the daily-rewards service COMPUTES (wrapping its winners lookup in a TTL cache is IN scope
+per R2; changing the winner set it returns is not); a two-way relay.
+
+STEP 3 - VALIDATION + REVIEW: run the state.md server-only row: `npx tsc --noEmit`, then
+`npx vitest run tests/server/internal.test.ts tests/discord_server.test.ts
+tests/server/discord.test.ts tests/discord_db.test.ts`, then the http spine
+(`npx vitest run tests/server/http/parity.test.ts tests/server/http/completeness.test.ts
+tests/server/http/ownership_coverage.test.ts tests/server/http/surface_inventory.test.ts`),
+then the new change-feed and outbox test files, then `npm run build:server`, then
+`npm run ci:changed` (scoped `--write` on changed files only if it reports format diffs).
+Dispatch reviewers per the Review Dispatch Matrix in implementation-plan.md, matching rows
+only: privacy-security-review (server/, SQL, a secret-gated surface),
+database-performance-reviewer (the new IN query, drain cadence, cardinality at the D18
+envelope, and whether the feed wiring added work to any hot path), and migration-safety ONLY
+if the diff ends up touching a *_db.ts DDL or a persisted shape (it should not). Do not spawn
+cross-platform-sync, architecture-reviewer, or frontend-seam-reviewer. Prompt every reviewer
+for COVERAGE, not filtering. Resume a truncated reviewer with: "Stop reading more files. Output
+the full report now. No more tool calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE /
+VERDICT." Do not commit while any BLOCKING finding stands.
+
+STEP 4 - COMMITS (Conventional Commits with a scope, explicit paths, bodies required, no em
+dashes, no emojis):
+  1. `feat(server): add the bounded linked-member change feed`
+  2. `feat(server): add GET /internal/discord/outbox draining all four streams in one envelope`
+  3. `test(server): pin outbox query counts, ordering, and overflow behavior`
+The winners TTL cache rides commit 2 (it exists to keep the drain query-free), unless it grows
+big enough to read on its own. Fold docs/discord-bot-stability/progress.md and
+docs/discord-bot-stability/state.md into the final commit. If the feed wiring is large enough
+to read as its own change, split it out as a fourth commit (`feat(server): enqueue link changes
+at every flex-relevant transition`).
+
+STEP 5 - ACCEPTANCE (each item verifiable, check them off explicitly in the final response):
+  - state.md lists EVERY feed site found in STEP 1, with file path, symbol, and the transition
+    it covers, and every listed site has an enqueue plus a test.
+  - `GET /internal/discord/outbox` exists as a RouteDef behind discordGate with no legacy arm,
+    and its surface_inventory row was hand-added; the four spine tests are green.
+  - A test proves ONE account-lookup query serves all four streams: a drain containing relay,
+    activity, winners, and change items performs exactly one identity IN query, counted off the
+    makePool `calls` array per ruling R1 (state the number in the final response).
+  - The winners lookup is wrapped in a 30 to 60 second TTL cache busted at day finalization,
+    with tests for its hit, miss, and bust arms (memory: a cached-read bust refuses in-flight
+    joiners, and a captured clock does not move under fake timers).
+  - A test proves the zero-query pin: an empty drain performs ZERO Postgres queries on the
+    in-memory streams unconditionally, and ZERO on the winners stream while its cache is warm.
+    A second test pins the winners lookup to at most once per drain.
+  - A test proves the drain is destructive: a second immediate drain returns empty.
+  - A test proves mixed-stream ordering is stable and documented, and that per-stream cap
+    overflow drops the oldest items rather than the newest.
+  - A payload-size assertion at the D18 envelope: a full drain at cap on every stream stays
+    within a stated size bound (state the measured size in the final response).
+  - `npx tsc --noEmit` clean, `npm run build:server` green, `npm run ci:changed` clean.
+
+STEP 6 - DOCS: update docs/discord-bot-stability/progress.md (Phase 5 status row and every
+Phase 5 checkbox) and docs/discord-bot-stability/state.md (the feed-site enumeration as a named
+section, the new endpoint and module under "Created by this packet", plus any drift found in
+the key file paths). Record surprising rules to memory, one fact per file.
+
+STEP 7 - FINAL RESPONSE: phase status, files touched (absolute paths), the feed-site
+enumeration count and any transition deliberately not wired with its reason, validation results
+command by command, reviewer verdicts, deferrals, and a one-line handoff for the Phase 5 QA
+session.
+
+STOPPING RULES:
+  - STOP AND SURFACE if a flex-relevant state transition has NO locatable server-side change
+    feed site (for example, if a class change or top-character switch happens somewhere the
+    server never learns about with an account id in hand). Name the transition, list where you
+    searched, and give the options. Do not invent a new hook, do not add a polling fallback,
+    and do not silently drop the transition.
+  - STOP if wiring a site would require a new query on a hot path just to discover whether the
+    account is linked. Report the site and the cost instead.
+  - STOP if collapsing the identity lookups would change any existing item shape in a way
+    Phase 6 cannot consume without also changing the existing per-endpoint routes (D11 keeps
+    those frozen).
+```

--- a/docs/discord-bot-stability/phase-05-qa.md
+++ b/docs/discord-bot-stability/phase-05-qa.md
@@ -1,0 +1,100 @@
+# Phase 5 QA: Outbox + linked-member change feed
+
+Phase 5's dangerous failure is silent: a feed site nobody wired, a stream that merges in an
+order the bot's handlers do not expect, or a "destructive read" that is not actually
+destructive under concurrency. None of those break a build. This QA session re-derives the
+feed-site enumeration independently (rather than trusting the phase's own list), attacks the
+drain semantics, and proves the tests bite by mutating the change feed and the outbox drain.
+
+```
+This is Phase 5 QA of the Discord Bot Stability packet: verify Outbox + linked-member change
+feed.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code. ULTRACODE: yes, run the
+adversarial-verify Workflow (every finding independently confirmed by a skeptic agent before it
+counts) plus mutation spot checks on server/discord_link_changes.ts and the outbox drain
+handler (decision D19: every phase's QA runs ultracode).
+Worktree: /Users/fernando/Documents/wocc-discord-bot.
+
+STEP 0 - PRE-FLIGHT: `git status` clean and Phase 5 committed (if the tree is dirty, ASK; this
+checkout may be shared). Memory scan including the test-pin trap index: READ IT before judging
+or writing any pin. Load at minimum the constant-self-comparison trap, the "prove the tests
+RAN" rule, the no-checkout-over-WIP mutation trap, the vitest `-t` regex trap, the SQL text pin
+raw-versus-evaluated trap, and the cached-read traps (bust refuses in-flight joiners, captured
+clock versus fake timers).
+
+STEP 1 - LOAD CONTEXT: spawn an Explore agent over docs/discord-bot-stability/state.md,
+docs/discord-bot-stability/progress.md,
+docs/discord-bot-stability/phase-05-outbox-change-feed.md, and the Phase 5 diff
+(`git diff <phase-start-commit>..HEAD` plus `git log` for the phase's commits). It returns: the
+promised deliverables, the acceptance criteria claimed, every file touched, the feed-site list
+Phase 5 recorded in state.md, and every new or changed test with the behavior it claims to pin.
+
+STEP 2 - AUDIT (parallel agents, COVERAGE not filtering):
+  - Feed-completeness agent (the highest-value audit of this phase): INDEPENDENTLY sweep
+    server/ for every site where a linked account's level, class, top character, reward points,
+    status tier, or link state changes, WITHOUT reading Phase 5's enumeration first. Then diff
+    your list against the one in state.md. Every site in your list and not theirs is a
+    candidate BLOCKING gap; every site in theirs and not yours needs an explanation. Also check
+    the inverse error: an enqueue at a site that fires for UNLINKED accounts, which would flood
+    the feed with items the bot must discard.
+  - Correctness agent: is every deliverable and acceptance criterion actually met? Is the
+    identity resolution really ONE IN query across all four streams, or does an enrichment loop
+    still resolve per item somewhere? Is the drain genuinely destructive and safe against two
+    overlapping requests (nothing delivered twice, nothing lost between splice and serialize)?
+    Do cap overflows drop the OLDEST items? Is dedupe keyed so that two different accounts
+    never collide? Do the D-invariants hold: D1 (one envelope, all four streams), D9 (RouteDef
+    only, spine row hand-added), D11 (existing routes untouched and still working), D18
+    (assertions at 1,000 players / 5,000 members)?
+  - Test coverage agent: are the assertions DECISIVE? Does the query-count pin count real SQL
+    statements rather than mock calls? Is the empty-drain zero-query pin actually reachable
+    (does the fixture leave every stream empty, including winners on a warm cache)? Is the
+    payload-size assertion pinned to a measured bound rather than a value derived from the same
+    code it checks? Are both sides of the dedupe TTL boundary covered? Is stream ordering
+    asserted, or merely observed?
+  - Dead-code agent: unused imports, types, or helpers; enrichment code left behind after the
+    IN-query collapse; scaffolding from `npm run new:endpoint`.
+  - Plus the Review Dispatch Matrix rows matching the diff (privacy-security-review,
+    database-performance-reviewer, and migration-safety only if a DDL or persisted shape moved)
+    and qa-checklist.
+  Mutation pass, in an ISOLATED worktree (never over the working tree; consult the memory
+  entries on worktree symlinks and on stash being shared across worktrees before creating it):
+  mutate, one at a time, and prove the suite kills each mutant:
+    1. discord_link_changes: raise the cap by one.
+    2. discord_link_changes: splice from the wrong end so the NEWEST items are dropped.
+    3. discord_link_changes: drop the dedupe check, and separately flip its TTL comparison at
+       the boundary.
+    4. discord_link_changes: make `drain` non-destructive (return a copy without clearing).
+    5. Outbox: omit one stream from the merged envelope (do this once per stream, four
+       mutants, since a test that only checks "some items came back" will survive).
+    6. Outbox: resolve identities per item again instead of from the batched map.
+    7. Outbox: pass only the first stream's account ids to the IN lookup.
+    8. Outbox: call the winners lookup twice per drain.
+    9. Winners TTL cache (ruling R2 made it a Phase 5 deliverable): drop the day-finalization
+       bust so a finalized day keeps serving from cache, and separately drop the cache so every
+       drain queries.
+  For every mutant, PROVE the tests ran: capture vitest output showing the test count and the
+  failing test names, never a bare nonzero exit code (a filter that matched zero tests is the
+  classic false kill). Record a kill tally.
+
+STEP 3 - FIX: apply ALL findings, blocking, should-fix, AND nits (standing user rule). Any feed
+site the completeness agent found gets wired and tested in this session. Then review the fix
+round itself with a fresh-eyes agent: the fixes are unreviewed code. Re-run the state.md
+server-only validation row plus the http spine, the new test files, `npm run build:server`, and
+`npm run ci:changed`.
+
+STEP 4 - DOCS: update docs/discord-bot-stability/progress.md (Phase 5 QA complete, deferrals,
+the mutation kill tally) and docs/discord-bot-stability/state.md (any newly found feed sites
+added to the enumeration, plus any drift in the locked decisions or key file paths). Commit
+with explicit paths and a body.
+
+STEP 6 - FINAL RESPONSE: verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL), counts of findings found
+and fixed by severity, how many feed sites the independent sweep confirmed and how many it
+added, the mutation kill tally (killed / survived, and what a survivor means), deferrals with
+their reason, and a one-line handoff for Phase 6.
+
+STOPPING RULES: stop and surface if a BLOCKING item cannot be fixed without changing phase
+scope. Stop and surface if a missing feed site cannot be wired without a new hook or a new
+query on a hot path (that is a design decision for the user, not a QA fix). Stop and surface if
+a mutant SURVIVES and the test that should have killed it cannot be strengthened without
+redesigning the Phase 5 implementation.
+```

--- a/docs/discord-bot-stability/phase-06-bot-new-surface.md
+++ b/docs/discord-bot-stability/phase-06-bot-new-surface.md
@@ -1,0 +1,183 @@
+# Phase 6: Bot consumes the new surface
+
+Phases 4 and 5 built the cheap server surface; this phase is where the incident's load profile
+actually changes. The bot stops asking for one flex payload per online Discord user and starts
+asking for the linked set in batches; the three 3-second pollers and their per-user GETs
+collapse into one outbox loop on the Phase 3 scheduler at the D1 adaptive cadence; the sweep
+iterates ONLY linked members (D6), dispatches every Discord write through the Phase 2 governor,
+and spreads those writes across the sweep window instead of firing them in one burst. The old
+client methods and poll wiring are deleted in the same change, because a dead path that still
+compiles is a path a future session will re-enable. The measurable outcome is the one the
+incident named: roughly 110 established sockets to the game server at steady state becomes a
+handful.
+
+```
+This is Phase 6 of the Discord Bot Stability packet: Bot consumes the new surface.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code.
+Worktree: /Users/fernando/Documents/wocc-discord-bot (branch feature/discord-bot-stability).
+ULTRACODE: not required. Use parallel Agent fan-out (STEP 2), not a Workflow.
+
+Goal: rewire the bot onto flex-batch plus the outbox, sweep only linked members through the
+governor with writes spread across the sweep window, and delete every path the new surface
+replaces.
+
+STEP 0 - PRE-FLIGHT: run `git status` in the worktree and confirm it is clean; ASK before
+touching anything if it is dirty (this checkout may be shared, and commits use EXPLICIT paths,
+never `git add -A`). Memory scan of MEMORY.md for: fake-timer and captured-clock traps,
+scheduler and backoff traps, test-pin traps, and any bot-domain entries.
+
+STEP 1 - LOAD CONTEXT (do NOT read the planning docs directly): spawn an Explore agent over
+docs/discord-bot-stability/state.md, docs/discord-bot-stability/progress.md,
+docs/discord-bot-stability/phase-06-bot-new-surface.md, and these files:
+  - bot/main.ts (the wiring; the role sync around :203-251 including the per-user
+    `server.flex` read and the nickname write; the gateway dispatch around :254-390 including
+    GUILD_CREATE, PRESENCE_UPDATE, GUILD_MEMBER_ADD/UPDATE/REMOVE and GUILD_MEMBERS_CHUNK; the
+    poll wiring and the interval block around :518-537)
+  - bot/server_client.ts (the call envelope at :32-57 and every method on the class)
+  - bot/logic.ts (the pure protocol and diff helpers, computeRoleSync, buildLevelNick, the
+    members-meta batch constant), bot/config.ts, bot/discord_api.ts, bot/gateway.ts
+  - bot/rate_governor.ts and bot/scheduler.ts (the Phase 2 and Phase 3 modules this phase must
+    use rather than work around) plus their test files
+  - bot/CLAUDE.md (the pure/IO split convention) and tests/discord_bot.test.ts
+  - the Phase 4 and Phase 5 server surface for the exact response shapes:
+    server/internal.ts (the flex-batch and outbox RouteDefs), server/discord_link_changes.ts,
+    and the Phase 5 outbox tests in tests/server/internal.test.ts
+It returns, as conclusions:
+  (a) an inventory of every outbound call the bot makes today: which method, which loop or
+      event drives it, at what cadence, and which of them the new surface replaces;
+  (b) the exact request and response shapes of flex-batch and the outbox, field by field, and
+      which existing bot-side handler consumes each stream;
+  (c) the governor's public seam (how a caller enqueues work, how it reports completion or
+      failure) and the scheduler's public seam (how a loop is registered, how coalescing and
+      the adaptive idle backoff are configured);
+  (d) every reference to each ServerClient method the phase plans to delete, INCLUDING
+      references from outside bot/ (tests import from bot/, for example
+      tests/server/internal.test.ts imports a constant from bot/logic.ts);
+  (e) which Phase 3 diff-before-write caches (nickname, members-meta) the linked-set sweep
+      must keep feeding, so this phase does not regress D5.
+
+STEP 2 - EXECUTE: three agents. A and B both edit bot/main.ts, so run B after A returns; C
+touches the client and its tests and can run in PARALLEL with A.
+  - Agent C (client surface): add `flexBatch()` and `drainOutbox()` to bot/server_client.ts
+    following the existing `call()` envelope (secret header, timeout abort, envelope unwrap,
+    null on failure). Delete the per-user flex, relay, activity, and winners methods ONCE they
+    are unreferenced (keep `roles()`, which the /whoami interaction uses; keep the winners
+    MARK method, the presence push, grant, setMember, pushMembersMeta, and flairedIds). Tests
+    for the two new methods: request shape, batching, and the failure arms.
+  - Agent A (linked set and sweep): maintain the linked-member set from flex-batch results plus
+    the outbox link-change stream. The sweep iterates ONLY that set (D6), never the
+    presence-derived online-user set, and every Discord write it makes goes through the Phase 2
+    governor. Spread the writes across the sweep window rather than dispatching them in one
+    burst, using the Phase 3 scheduler's existing facilities; do not add a second timer
+    mechanism. Keep the Phase 3 nickname and members-meta diffs in force: a steady-state sweep
+    with nothing changed performs ZERO Discord writes. Put the set maintenance itself in a
+    pure, tested module (bot/CLAUDE.md pure/IO split, D8), not inline in main.ts.
+  - Agent B (loop consolidation and deletion, runs after A): replace the three 3-second pollers
+    and the flex sweep's per-user GETs with ONE outbox loop registered on the Phase 3 scheduler
+    at the D1 adaptive cadence (3s while the previous drain returned items, decaying to 15s
+    idle, env-configurable per D13). Fan the drained envelope out to the existing per-stream
+    handlers. Presence push behavior is unchanged. Delete the replaced poll functions, their
+    interval wiring, and any logic helper left unreferenced.
+Give each agent the Explore summary, not the raw planning docs.
+
+INVARIANTS IN PLAY:
+  - D1 (transport): one consolidated outbox poll, adaptive 3s active decaying to 15s idle. No
+    long-poll, no bot WebSocket, no second poller sneaking back in.
+  - D2 / D3 / D4 (governor): ALL Discord REST dispatch goes through the Phase 2 governor. Do
+    not add a bypass path, do not call the REST shell directly from the sweep, and do not
+    defeat the breaker or the forbidden cache with a retry of your own.
+  - D5 (diff before write): nickname PATCH only when the computed nick differs from the cached
+    member nick; members-meta pushed only for members whose meta changed since the last
+    SUCCESSFUL push; self-caused GUILD_MEMBER_UPDATE echoes stay suppressed. Phase 3 landed
+    this; Phase 6 must not regress it.
+  - D6 (sweep set): the sweep iterates linked members only, discovered via flex-batch and
+    maintained by the outbox change feed. Never the whole online-Discord-user set.
+  - D7 (dependencies): zero new npm packages. Connection bounding comes from app-level
+    serialization (governor queues plus scheduler overlap guards) over default keep-alive
+    fetch.
+  - D8 (pure/IO split): new logic is a DOM-free pure module with Vitest coverage;
+    server_client.ts and discord_api.ts stay thin IO shells; wiring only in main.ts.
+  - D11 (server routes stay): the old per-endpoint internal routes remain on the server; the
+    bot simply stops calling them. Do not delete or edit a server route in this phase.
+  - D13 (operator levers): every cadence and threshold this phase introduces is
+    env-configurable with a safe default, and gets recorded for the Phase 7 DEPLOY.md section.
+  - D18 (scale envelope): integration assertions run at 1,000 concurrent players and 5,000
+    guild members.
+  - Copy and commit rules: no em dashes, no en dashes, no emojis anywhere; commit with EXPLICIT
+    paths, never `git add -A`.
+  - src/sim/ and the wire protocol are untouched.
+
+OUT OF SCOPE: any server/ change (Phases 4 and 5 shipped the surface; if the bot needs a shape
+the server does not provide, that is a stopping rule, not a server edit); deploy assets, the
+compose healthcheck, and the fatal-close exit (Phase 7); observability counters (Phase 8);
+/api/discord caching (Phase 9); retiring the now-unused server routes (D11); two-way relay or
+any new bot feature.
+
+STEP 3 - VALIDATION + REVIEW: run the state.md bot-only row: `npx tsc --noEmit`, then
+`npx vitest run tests/discord_bot.test.ts` plus every bot test file this phase added or
+changed, then `npm run build:bot`, then `npm run ci:changed` (scoped `--write` on changed files
+only if it reports format diffs, never a whole-tree write). Per the Review Dispatch Matrix in
+implementation-plan.md, a bot-only diff matches NO reviewer row: spawn no domain reviewer and
+run qa-checklist at phase end instead. If the diff turns out to touch server/ or a deploy file,
+the phase went out of scope: stop and re-read this file. Prompt qa-checklist for COVERAGE, not
+filtering. Resume a truncated agent with: "Stop reading more files. Output the full report now.
+No more tool calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT." Do not commit
+while any BLOCKING finding stands.
+
+STEP 4 - COMMITS (Conventional Commits with a scope, explicit paths, bodies required, no em
+dashes, no emojis):
+  1. `feat(bot): add flex-batch and outbox client methods`
+  2. `feat(bot): sweep only linked members through the governor with spread writes`
+  3. `refactor(bot): replace the three pollers with one outbox loop and delete the old paths`
+  4. `test(bot): cover linked-set maintenance, outbox fan-out, and a full sweep cycle`
+Fold docs/discord-bot-stability/progress.md and docs/discord-bot-stability/state.md into the
+final commit.
+
+STEP 5 - ACCEPTANCE (each item verifiable, check them off explicitly in the final response):
+  - `grep` proves no remaining call to the deleted client methods anywhere in the repo, and the
+    methods themselves are gone (not merely unused).
+  - The sweep's iteration source is the linked set: a test drives a fixture where the online
+    set is much larger than the linked set and asserts the sweep touched only the linked
+    members (D6).
+  - A test proves every Discord write in the sweep path goes through the governor (no direct
+    REST shell call survives in the sweep).
+  - A test proves writes are spread: at the D18 envelope the sweep does not dispatch its whole
+    write set in one tick.
+  - A steady-state test at the D18 envelope with nothing changed performs ZERO Discord writes
+    and ZERO members-meta pushes (D5 not regressed).
+  - Exactly ONE outbox loop exists; the three 3-second pollers and their intervals are gone; a
+    test proves each drained stream (relay, activity, winners, link changes) reaches its
+    handler, one assertion per stream.
+  - The outbox loop's cadence adapts (busy drain keeps the fast cadence, an empty drain decays
+    toward idle) and both bounds are env-configurable with safe defaults (D13); the new env
+    keys are recorded in state.md for the Phase 7 DEPLOY.md section.
+  - An end-to-end test runs one full sweep cycle against a fake server at the D18 envelope.
+  - Connection count: derive the steady-state expectation analytically from the final loop
+    inventory (one outbox loop, the presence push, the sweep's serialized governor queue) and
+    state it. Where a local run is possible (`npm run server` plus the built bot pointed at
+    it), measure with `lsof -nP -iTCP:8787 -sTCP:ESTABLISHED | wc -l` and report the number
+    against the incident's ~110. If no Discord credentials are available to run the bot, record
+    the analytic bound plus the loop inventory and mark the socket count as verify-at-deploy in
+    progress.md; do not claim a measurement you did not take.
+  - `npx tsc --noEmit` clean, `npm run build:bot` green, `npm run ci:changed` clean.
+
+STEP 6 - DOCS: update docs/discord-bot-stability/progress.md (Phase 6 status row and every
+Phase 6 checkbox) and docs/discord-bot-stability/state.md (new env keys, new modules, deleted
+client methods, and the connection-count result or its verify-at-deploy status). Record
+surprising rules to memory, one fact per file.
+
+STEP 7 - FINAL RESPONSE: phase status, files touched (absolute paths), the before-and-after
+outbound call inventory, validation results command by command, the qa-checklist verdict,
+deferrals, and a one-line handoff for the Phase 6 QA session.
+
+STOPPING RULES:
+  - STOP if deleting an old client method would break a caller OUTSIDE bot/. Name the caller
+    and the file, and do not delete the method until the phase is re-scoped.
+  - STOP if the Phase 2 governor or the Phase 3 scheduler lacks a seam the sweep needs. Report
+    what is missing. Do NOT add a second dispatch path around the governor or a bare timer
+    beside the scheduler.
+  - STOP if the linked set cannot be maintained without a full-roster scan or a periodic
+    re-discovery sweep; that would reintroduce the load profile this packet exists to remove.
+  - STOP if the server surface returns a shape the bot cannot consume. Editing server/ is out
+    of scope for this phase; report the gap instead.
+```

--- a/docs/discord-bot-stability/phase-06-qa.md
+++ b/docs/discord-bot-stability/phase-06-qa.md
@@ -1,0 +1,100 @@
+# Phase 6 QA: Bot consumes the new surface
+
+Phase 6 is the phase whose regressions are invisible in a green suite: a linked set that
+quietly grows to the whole online roster, a stream the outbox fan-out silently drops, a write
+path that skips the governor because it was easier to call the REST shell directly, or a
+deletion that left the old poller registered under a different name. This QA session checks the
+load profile the packet exists to change, not just the code that claims to change it, and it
+proves the tests bite by mutating the linked-set maintenance and the outbox dispatch fan-out.
+
+```
+This is Phase 6 QA of the Discord Bot Stability packet: verify Bot consumes the new surface.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code. ULTRACODE: yes, run the
+adversarial-verify Workflow (every finding independently confirmed by a skeptic agent before it
+counts) plus mutation spot checks on the linked-set maintenance module and the outbox dispatch
+fan-out (decision D19: every phase's QA runs ultracode).
+Worktree: /Users/fernando/Documents/wocc-discord-bot.
+
+STEP 0 - PRE-FLIGHT: `git status` clean and Phase 6 committed (if the tree is dirty, ASK; this
+checkout may be shared). Memory scan including the test-pin trap index: READ IT before judging
+or writing any pin. Load at minimum the constant-self-comparison trap, the "prove the tests
+RAN" rule, the no-checkout-over-WIP mutation trap, the vitest `-t` regex trap, the unquoted
+vitest filter trap, and the clock traps (fake timers versus captured clocks, fractional
+setTimeout firing early, clamp-after-jitter ordering).
+
+STEP 1 - LOAD CONTEXT: spawn an Explore agent over docs/discord-bot-stability/state.md,
+docs/discord-bot-stability/progress.md, docs/discord-bot-stability/phase-06-bot-new-surface.md,
+and the Phase 6 diff (`git diff <phase-start-commit>..HEAD` plus `git log` for the phase's
+commits). It returns: the promised deliverables, the acceptance criteria claimed, every file
+touched, the before-and-after outbound call inventory Phase 6 recorded, and every new or
+changed test with the behavior it claims to pin.
+
+STEP 2 - AUDIT (parallel agents, COVERAGE not filtering):
+  - Load-profile agent (the highest-value audit of this phase): independently enumerate every
+    outbound call the bot can now make, from the source rather than from the phase's own
+    inventory. Confirm there is exactly ONE outbox loop, that no timer or interval outside the
+    scheduler survives anywhere in bot/, that no code path can start a second loop (a
+    GUILD_CREATE re-sweep on every re-IDENTIFY is the known trap), and that the sweep's
+    iteration source is the linked set rather than the presence-derived online set. Recompute
+    the steady-state request rate at the D18 envelope and compare it against the number Phase 6
+    reported.
+  - Correctness agent: is every deliverable and acceptance criterion actually met? Does the
+    linked set add on link events and REMOVE on unlink and on member departure, and does it
+    survive a reconnect without a full re-discovery? Does every Discord write in the sweep path
+    go through the governor (grep for direct REST shell calls)? Are writes really spread across
+    the sweep window, or merely queued and then drained in one tick? Do the D-invariants hold:
+    D1 (one poll, adaptive cadence with both bounds), D2/D3/D4 (no governor bypass), D5 (zero
+    writes at steady state, echo suppression intact), D6 (linked members only), D7 (no new
+    dependency), D8 (pure logic in a tested module, shells stay thin), D11 (no server route
+    edited), D13 (new cadences env-configurable with safe defaults)?
+  - Test coverage agent: are the assertions DECISIVE? Does the fan-out test assert per stream,
+    or would dropping one stream still pass? Does the "spread writes" test actually fail if
+    every write fires in one tick? Does the steady-state zero-writes test use a fixture where
+    a write WOULD occur without the diff (a test that would pass with no members at all proves
+    nothing)? Do the timing tests use injected clocks or fake timers correctly for the
+    scheduler under test? Any orphaned test, any single-arm test of an "each" claim?
+  - Dead-code agent: leftovers from the deletion pass. Unreferenced ServerClient methods,
+    orphaned logic helpers, unused imports and types, a poll function that is gone from the
+    interval block but still defined, and any comment that still describes the deleted
+    three-poller design.
+  - Per the Review Dispatch Matrix in implementation-plan.md, a bot-only diff matches no
+    domain reviewer row: run qa-checklist and do not spawn one. If the diff touches server/ or
+    a deploy file, that is itself a finding (Phase 6 went out of scope) and the matching rows
+    apply.
+  Mutation pass, in an ISOLATED worktree (never over the working tree; consult the memory
+  entries on worktree symlinks and on stash being shared across worktrees before creating it):
+  mutate, one at a time, and prove the suite kills each mutant:
+    1. Linked set: never remove on unlink (the set only grows).
+    2. Linked set: seed it from the online-user set instead of flex-batch results (the D6
+       regression, and the exact shape of the original incident).
+    3. Linked set: drop the link-change stream update so the set goes stale.
+    4. Outbox fan-out: skip one stream (do this once per stream, four mutants).
+    5. Outbox fan-out: dispatch the same envelope twice.
+    6. Cadence: pin the loop to the fast interval so the idle decay never happens, and
+       separately pin it to the idle interval so a busy drain never speeds up.
+    7. Sweep: dispatch all writes in the first tick instead of spreading them.
+    8. Sweep: bypass the governor for one write path.
+  For every mutant, PROVE the tests ran: capture vitest output showing the test count and the
+  failing test names, never a bare nonzero exit code. Record a kill tally.
+
+STEP 3 - FIX: apply ALL findings, blocking, should-fix, AND nits (standing user rule). Then
+review the fix round itself with a fresh-eyes agent: the fixes are unreviewed code. Re-run the
+state.md bot-only validation row (`npx tsc --noEmit`, `npx vitest run tests/discord_bot.test.ts`
+plus the phase's bot test files, `npm run build:bot`) and `npm run ci:changed`.
+
+STEP 4 - DOCS: update docs/discord-bot-stability/progress.md (Phase 6 QA complete, deferrals,
+the mutation kill tally, and the connection-count status if it is still verify-at-deploy) and
+docs/discord-bot-stability/state.md (any drift in the locked decisions, the env-key list, or
+the key file paths). Commit with explicit paths and a body.
+
+STEP 6 - FINAL RESPONSE: verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL), counts of findings found
+and fixed by severity, the independently recomputed steady-state request rate against the one
+Phase 6 claimed, the mutation kill tally (killed / survived, and what a survivor means),
+deferrals with their reason, and a one-line handoff for Phase 7.
+
+STOPPING RULES: stop and surface if a BLOCKING item cannot be fixed without changing phase
+scope. Stop and surface if the load-profile audit finds the steady-state request rate is not
+materially better than the incident baseline (that is a design problem, not a QA fix). Stop and
+surface if a mutant SURVIVES and the test that should have killed it cannot be strengthened
+without redesigning the Phase 6 implementation.
+```

--- a/docs/discord-bot-stability/phase-07-qa.md
+++ b/docs/discord-bot-stability/phase-07-qa.md
@@ -1,0 +1,96 @@
+# Phase 7 QA: Supervision + deploy hardening
+
+Adversarial verification of the Phase 7 diff. The risk this session exists to catch is a
+supervision change that looks right in a diff and is inert in production: an exit that never
+fires, a healthcheck that passes on a dead bot (or fails on a healthy one), a Caddy block
+that lands on one vhost, and documentation that tells an operator the wrong thing during the
+next incident. Deploy assets have no runtime test coverage in CI, so the string pins are the
+only guard, which makes pin quality the whole game here.
+
+Starter prompt for the session:
+
+```
+This is Phase 7 QA of the Discord Bot Stability packet: verify Supervision + deploy
+hardening.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code. ULTRACODE: yes, run the
+adversarial-verify Workflow (every finding independently confirmed by a skeptic agent
+before it counts) plus mutation spot checks on the Phase 7 fatal-close handling and the
+heartbeat module.
+Worktree: /Users/fernando/Documents/wocc-discord-bot.
+
+STEP 0 - PRE-FLIGHT: git status clean (Phase 7 committed). Memory scan including the
+test-pin trap index (READ IT before judging or writing any pin: the source-scrape and
+literal-arm traps apply directly to the deploy string pins in this diff), plus the docker
+health watchdog gotchas entry (a SIGSTOPped PID 1 is a no-op for some probes) and the
+compose override merge entry.
+
+STEP 1 - LOAD CONTEXT: spawn an Explore agent over docs/discord-bot-stability/state.md,
+progress.md, phase-07-supervision-deploy.md, and the Phase 7 diff (git diff against the
+phase-start commit; find it from the progress.md status row or the first Phase 7 commit).
+It returns: the promised deliverables and acceptance criteria, every file touched, the new
+module names and their exported surface, the exact heartbeat path and staleness bound on
+both sides (bot/config.ts default and the compose healthcheck literal), and the list of
+test files that now pin deploy assets.
+
+STEP 2 - AUDIT (parallel agents, COVERAGE not filtering; every finding independently
+confirmed by a skeptic agent before it counts):
+  - Correctness agent: every Phase 7 deliverable and acceptance criterion actually met.
+    Specifically: does the exit fire on every code in the fatal set and on no other code;
+    is the exit code nonzero and consistent with the existing fatal handler; is the exit
+    reachable in the real close path (not only through the injected test seam); does the
+    heartbeat prove loop liveness rather than mere process existence; does a heartbeat
+    write failure degrade safely; does the healthcheck fail on a MISSING file, an
+    UNREADABLE file, and a STALE file, and pass only on a fresh one; are mem_limit and
+    stop_grace_period plausible for this workload with a comment saying why; do both Caddy
+    vhosts carry /internal/* identically; does DEPLOY.md now describe the system as it
+    actually is after this change.
+  - Test coverage agent (or test-coverage-auditor): are the assertions DECISIVE. Hunt the
+    constant-self-comparison trap in the compose and Caddy pins (a pin that reads a string
+    out of the same file it asserts against proves nothing). Check both arms of every
+    either/or claim: fatal versus non-fatal close, fresh versus stale heartbeat, present
+    versus missing file. Check that the heartbeat-path agreement pin would actually fail
+    if only ONE side moved.
+  - Dead-code agent: unused imports, types, and any leftover of the replaced close
+    handling; a config key added but never read; a test helper left orphaned.
+  - Review Dispatch Matrix rows matching the diff: privacy-security-review (deploy and
+    secret-adjacent files). Confirm no other row matches; if one does, the phase went out
+    of scope and that is a BLOCKING finding.
+  - qa-checklist over the diff.
+  - Mutation pass, in an ISOLATED worktree (never over the live checkout; a stash is shared
+    across worktrees, so do not lean on one). Mutate, one at a time, and prove the suite
+    kills each mutant:
+      1. Invert the fatal-close membership guard (fatal codes reconnect, non-fatal exit).
+      2. Delete the exit call, keeping the log line.
+      3. Change the exit code to 0.
+      4. Drop the heartbeat write from the scheduled callback.
+      5. Flip the heartbeat staleness comparison (> to <) and separately shift its boundary
+         by one interval.
+      6. Make the healthcheck's missing-file arm exit 0.
+      7. Remove /internal/* from ONE of the two Caddy heredocs only (the occurrence-count
+         pin must fail; if it does not, the pin is counting the wrong thing).
+      8. Delete mem_limit, then separately stop_grace_period, from the bot service.
+    For every mutant, PROVE THE TESTS RAN (memory: mutation-harness-must-prove-tests-ran):
+    capture the runner output showing the test count and the failing assertion, never just
+    a nonzero exit code. A mutant that survives is a missing test, not a curiosity: record
+    which test should have caught it.
+
+STEP 3 - FIX: apply ALL findings, blocking, should-fix, AND nits (standing user rule). Then
+review the fix round itself with a FRESH eyes agent (the fixes are unreviewed code). Re-run
+the validation matrix: npx tsc --noEmit; npx vitest run tests/discord_bot.test.ts plus the
+Phase 7 bot test files; npm run build:bot; npx vitest run tests/deploy_discord_bot.test.ts
+tests/deploy_watchdog.test.ts; npm run ci:changed.
+
+STEP 4 - DOCS: progress.md (Phase 7 QA complete, with any deferral named), state.md (any
+drift the audit found, plus gotchas worth carrying: the heartbeat path writability
+constraint, the Caddy occurrence-count pin, anything the mutation pass revealed about pin
+quality).
+
+STEP 6 - FINAL RESPONSE: verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL); counts found and
+fixed by severity; mutation kill tally (killed over attempted, with any survivor named and
+its fix); deferrals; one-line handoff for Phase 8.
+
+STOPPING RULES: stop and surface if a BLOCKING item cannot be fixed without changing phase
+scope. Stop and surface if the mutation pass cannot prove the tests ran (a harness that
+reports kills without evidence is worse than no harness). Do not run the mutation pass over
+the live worktree.
+```

--- a/docs/discord-bot-stability/phase-07-supervision-deploy.md
+++ b/docs/discord-bot-stability/phase-07-supervision-deploy.md
@@ -1,0 +1,207 @@
+# Phase 7: Supervision + deploy hardening
+
+Phases 1 to 6 made the bot behave; this phase makes the box behave. Today a fatal gateway
+close (bad token, bad intents) logs one line and returns, leaving a process that is alive,
+idle, and forever useless: `restart: unless-stopped` only acts on process exit, so Docker
+never notices. The bot container also has no healthcheck, no `mem_limit`, and no
+`stop_grace_period`, all of which the game service already has, and `/internal/*` is
+reachable from the public internet with the shared header secret as its only gate. This
+phase closes those four gaps and writes the operator documentation that did not exist when
+the 2026-07-29 incident happened (DEPLOY.md currently contains no Discord section at all).
+
+Starter prompt for the session:
+
+```
+This is Phase 7 of the Discord Bot Stability packet: Supervision + deploy hardening.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code.
+Worktree: /Users/fernando/Documents/wocc-discord-bot (branch feature/discord-bot-stability).
+No ultracode Workflow for this phase: it is three small independent slices, so a parallel
+Agent fan-out is the lightest orchestration that fits. Its QA session runs ultracode.
+
+Goal: a Discord bot process that cannot zombie (fatal close exits, stale heartbeat fails
+the container healthcheck) and an internal HTTP surface that no longer answers the public
+edge, both pinned by tests and documented in DEPLOY.md.
+
+STEP 0 - PRE-FLIGHT: git status clean in the worktree (ask if dirty; another session may
+share the checkout). Memory scan of MEMORY.md for: deploy and compose (docker health
+watchdog gotchas, compose override ports merge, node heap cgroup and compose mem), the
+docs mirror and worktree hook gotchas, and the shared-worktree commit rule (explicit
+paths, never git add -A).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly): spawn an Explore agent over
+docs/discord-bot-stability/state.md, docs/discord-bot-stability/progress.md, this phase
+file, and:
+  - bot/gateway.ts (FATAL_CLOSE_CODES near :20, onClose near :135-142, plus whatever
+    injectable seam Phase 1 added to the constructor)
+  - bot/main.ts (process wiring and the fatal handler at the bottom of the file),
+    bot/config.ts (env loading shape and defaults), bot/scheduler.ts (the Phase 3 module
+    that now owns the loops; confirm its actual name and API)
+  - docker-compose.yml (the discord-bot service block, and the game service block above
+    it: its healthcheck, stop_grace_period, mem_limit and memswap_limit are the parity
+    exemplar, including the comment style that explains WHY each value)
+  - Dockerfile (the runtime stage: node:26-slim, USER node, WORKDIR /app, dist-bot copy)
+  - deploy/user-data.sh (the Caddy Caddyfile heredocs, around :83-115)
+  - tests/deploy_discord_bot.test.ts and tests/deploy_watchdog.test.ts
+  - DEPLOY.md (section layout; the ops-endpoint claims around :61-62, :125-131, :342-348,
+    :394-403)
+  - docs/discord-bot-stability/incident-2026-07-29.md (the diagnostic commands section)
+It returns: the exact current text of every line the phase must change; the game service's
+healthcheck/limit block verbatim as the parity template; every place in the repo that
+pins the Caddy ops-path string or restates it in prose; the name and API of the Phase 3
+scheduler; whether the runtime image can write to the heartbeat path you intend (the
+container runs as USER node and only /app/dist/media is chowned, so /app is NOT writable);
+and the env-key naming convention Phases 2, 3 and 6 established in bot/config.ts.
+
+STEP 2 - EXECUTE: three parallel Agents, one per vertical slice, each owning its code plus
+its tests. Give each the Explore summary, not the raw planning docs.
+
+  Agent A, bot supervision (bot/ + tests):
+  - Fatal gateway close exits nonzero. bot/gateway.ts onClose currently logs
+    "gateway closed with fatal code" and returns; it must log and then exit. Route the
+    exit through an injectable dependency (default process.exit, following the seam
+    Phase 1 already added to this class) so a Vitest can assert it fired without killing
+    the test process, and keep the close-code decision itself in a pure, directly tested
+    helper. Use the same exit code the existing top-level fatal handler in bot/main.ts
+    uses, so operators see one convention.
+  - Heartbeat file: a small module (its own file, not a block appended to main.ts) that
+    writes or touches a file on a cadence, wired into the Phase 3 scheduler so it proves
+    the process's loop is still turning, not merely that the process exists. Path and
+    cadence are env-configurable with defaults (D13). The default path must be writable
+    by the non-root `node` user in the runtime image: verify this against the Dockerfile
+    rather than assuming, and pick the default accordingly.
+  - Tests: fatal close exits with the expected code; a non-fatal close does NOT exit and
+    still schedules the reconnect; heartbeat writes on cadence; heartbeat failure (an
+    unwritable path) is logged and does not crash the bot.
+
+  Agent B, deploy assets (docker-compose.yml + deploy/user-data.sh + deploy tests):
+  - discord-bot service gains a healthcheck that tests heartbeat-file FRESHNESS (not file
+    existence): a `node -e` one-liner in exec form, exiting nonzero when the file is
+    missing, unreadable, or older than the staleness bound. The runtime image is
+    node:26-slim with no curl and no wget, so node is the only probe available; the game
+    service healthcheck at the top of its block is the shape to copy.
+  - discord-bot service gains mem_limit and stop_grace_period sized for a bot, not a game
+    server, each with a comment saying why that number (game service comment style).
+  - The heartbeat path in the healthcheck literal and the default in bot/config.ts must
+    agree; if compose passes the path as an env key, pass it once and use it on both
+    sides. Add a test that pins the agreement, because silent drift here produces a
+    healthcheck that is always red or always green.
+  - Caddy: /internal/* joins the @ops 404 block in BOTH heredocs in deploy/user-data.sh
+    (the public site vhost and the admin vhost). They must stay character-identical:
+    tests/deploy_watchdog.test.ts:136-137 counts occurrences with split() and fails on any
+    drift between the two.
+  - Update the pins your change falsifies, in the same commit: tests/deploy_watchdog.test.ts
+    :136 and :146 pin the exact string '@ops path /livez /readyz /metrics'. R12 (state.md
+    rulings block) puts ALL fallout of the Caddy change in this phase, so this is sanctioned
+    scope, not creep.
+  - Extend tests/deploy_discord_bot.test.ts per the plan: restart policy, the discord
+    profile, healthcheck presence, mem_limit and stop_grace_period presence, and the Caddy
+    block content for /internal/*.
+
+  Agent C, documentation (DEPLOY.md):
+  - A new Discord bot section (DEPLOY.md has none today). It documents: every env key the
+    bot reads, including every key Phases 2, 3, 6, 7 added (D13), with its default and what
+    raising or lowering it does during an incident; how to verify bot health (container
+    health status, heartbeat freshness, what a red healthcheck means); and the incident
+    runbook, which is the diagnostic command block from incident-2026-07-29.md (request
+    rate by route, internal versus external source IPs, the bot 429 timeline, established
+    connections to :8787) with one line each saying what a healthy reading looks like.
+  - Fix every claim this phase falsifies (R12 in the state.md rulings block puts all of them
+    in Phase 7, including the prose ones): the "the edge hides /livez /readyz /metrics
+    but not /internal/*" parenthetical near :127, the metrics-scrape note near :342-348
+    that says the edge 404s "all three ops paths", and the by-hand Caddy retrofit snippet
+    near :394-403 (an operator copying the old snippet leaves /internal/* public). Say in
+    the runbook that the edge change lands only at the next prod rollout (O7), and keep the
+    existing guidance that the internal secret is still a real production secret: the edge
+    404 is defense in depth, not the gate.
+  - Do not change the restart-countdown runbook step: that curl already targets
+    127.0.0.1:8787 directly and never traverses Caddy.
+
+INVARIANTS IN PLAY:
+- D15 (deploy hardening, this phase's headline): the bot service gets a healthcheck built
+  on the heartbeat file, plus mem_limit and stop_grace_period; a fatal gateway close exits
+  the process nonzero so `restart: unless-stopped` can act; Caddy 404s /internal/* next to
+  /livez, /readyz and /metrics.
+- D13 (operator levers): every cadence and threshold this phase adds is env-configurable
+  with a safe default, and every new env key is documented in DEPLOY.md in this change.
+- D7 (zero new npm dependencies): the healthcheck and the heartbeat use node and node:fs
+  only. No curl, no wget, no health library, no new package.
+- D8 (pure/IO split): the close-code decision and the staleness comparison are pure and
+  directly tested; gateway.ts and the heartbeat writer stay thin IO shells.
+- Non-negotiables from state.md: src/sim/ is untouched; secrets stay env-only and nothing
+  resembling a token or secret lands in a doc, a compose default, or a test fixture; commit
+  with explicit paths, never git add -A; no em dashes, en dashes, or emojis anywhere,
+  including DEPLOY.md prose and commit bodies.
+- R9 (state.md rulings block): the pre-existing em dash in the bot/gateway.ts
+  FATAL_CLOSE_CODES comment was already fixed in Phase 1, so Phase 7 need not act on it.
+
+OUT OF SCOPE: all server/ code (Phase 8 and 9 own the server side); any change to the
+governor, the scheduler's cadences, or the sweep; the game service's own healthcheck,
+limits, or Caddy behavior; adding a listening port or an HTTP endpoint to the bot; the
+prod rollout itself (O7: the operator applies it manually after the packet merges);
+Grafana or metric series (Phase 8).
+
+STEP 3 - VALIDATION + REVIEW: run the state.md matrix rows that match the diff:
+`npx tsc --noEmit`; `npx vitest run tests/discord_bot.test.ts` plus the new bot test files;
+`npm run build:bot`; `npx vitest run tests/deploy_discord_bot.test.ts
+tests/deploy_watchdog.test.ts`; `npm run ci:changed` (scoped --write only on files you
+changed, never whole-tree). Then dispatch reviewers per the Review Dispatch Matrix in
+implementation-plan.md, matching rows only: privacy-security-review matches (this diff
+touches deploy and secret-adjacent files: docker-compose.yml, deploy/user-data.sh,
+DEPLOY.md). migration-safety, database-performance-reviewer, cross-platform-sync,
+architecture-reviewer and frontend-seam-reviewer do NOT match; if one of them does match,
+the phase went out of scope, so stop and re-read this file. Prompt every reviewer for
+COVERAGE, not filtering. Resume a truncated reviewer with: "Stop reading more files. Output
+the full report now. No more tool calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE /
+VERDICT." Do not commit while a BLOCKING finding stands.
+
+STEP 4 - COMMITS (Conventional Commits with a scope, explicit paths, every commit carries a
+body of 1 to 4 plain sentences saying what changed and why, no em dashes, no emojis):
+1. feat(bot): exit on a fatal gateway close and heartbeat the run loop
+2. feat(deploy): healthcheck, limits, and an edge 404 for the bot's internal surface
+   (carries the extended tests/deploy_discord_bot.test.ts and the updated
+   tests/deploy_watchdog.test.ts Caddy pins, since they pin exactly what this commit
+   changes)
+3. docs(deploy): document the Discord bot env keys, health checks, and incident runbook
+
+STEP 5 - ACCEPTANCE (each item verifiable, not asserted):
+- A test proves a fatal close code exits with a nonzero code and that a non-fatal code does
+  not exit and still reconnects.
+- A test proves the heartbeat file is written on cadence and that an unwritable path is
+  logged without crashing the process.
+- `docker compose config` (or the deploy test) shows the discord-bot service with
+  restart: unless-stopped, the discord profile, a healthcheck, mem_limit, and
+  stop_grace_period.
+- The healthcheck command literal and bot/config.ts agree on the heartbeat path, pinned by
+  a test that fails if either side moves.
+- deploy/user-data.sh 404s /internal/* on BOTH vhosts, with the two heredocs identical, and
+  tests/deploy_watchdog.test.ts still counts occurrences correctly.
+- `grep -n "internal" DEPLOY.md` shows no surviving claim that the edge leaves /internal/*
+  public, and the by-hand Caddy retrofit snippet includes /internal/*.
+- DEPLOY.md lists every env key the bot reads today, and the incident runbook commands run
+  as written.
+- `npx tsc --noEmit`, `npm run build:bot`, the bot and deploy test files, and
+  `npm run ci:changed` are all green.
+
+STEP 6 - DOCS: tick the Phase 7 boxes in progress.md and set its status row; update state.md
+(the "Created by this packet" env-key and module lists, plus any gotcha you hit that the
+next session would otherwise rediscover, for example the heartbeat path writability
+constraint or a Caddy matcher subtlety). Same commit as the work, explicit paths. Record
+genuinely surprising rules to memory.
+
+STEP 7 - FINAL RESPONSE: phase status; files touched; validation results (command by
+command); reviewer verdicts; anything deferred and why; and a one-line handoff for the
+Phase 7 QA session.
+
+STOPPING RULES:
+- Stop and surface if the healthcheck approach you land on would require a new dependency
+  (curl, wget, or any npm package) or a new listening port exposed outside the container.
+  Neither is authorized; the heartbeat file plus a node one-liner is the sanctioned shape.
+- Do NOT stop over the crash loop: R13 (state.md rulings block) settles it. Exiting on a
+  fatal close crash-loops under restart: unless-stopped when the cause is unrecoverable (bad
+  token, bad intents), and a visible crash loop with Docker's backoff is the desired outcome
+  over today's silent zombie. No retry limiter, no supervisor, no backoff of your own, and no
+  re-litigating it in QA.
+- Stop if the Caddy change would break a documented runbook step that traverses the public
+  edge. Report which step and do not proceed with that part.
+- Stop if a BLOCKING reviewer finding cannot be fixed inside this phase's scope.
+```

--- a/docs/discord-bot-stability/phase-08-observability.md
+++ b/docs/discord-bot-stability/phase-08-observability.md
@@ -1,0 +1,203 @@
+# Phase 8: Observability
+
+The 2026-07-29 incident ran for two days before anyone looked, and it was found by reading
+container logs by hand. Everything the governor and the scheduler now know (429s by scope,
+breaker state and opens, queue depths, sweep durations, outbox drain sizes) exists only
+inside the bot process. This phase carries those numbers out on a channel that already
+exists and already costs nothing: the presence POST the bot sends every few seconds. The
+server holds them in memory exactly like the presence snapshot, and renders them as
+Prometheus lines on the metrics path Grafana already scrapes. No new endpoint, no new
+table, no new poll: the point is to see the next storm forming, not to build a metrics
+system.
+
+Starter prompt for the session:
+
+```
+This is Phase 8 of the Discord Bot Stability packet: Observability.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code.
+Worktree: /Users/fernando/Documents/wocc-discord-bot (branch feature/discord-bot-stability).
+No ultracode Workflow for this phase: it is one bot slice, one server slice, and a doc
+note, so a parallel Agent fan-out is the lightest orchestration that fits. Its QA session
+runs ultracode.
+
+Goal: the bot's rate-limit and loop counters ride the existing presence POST, are clamped
+and held server-side like presence, and render as Prometheus series on the existing metrics
+path, with the two alert-worthy signals (breaker opens, 429 rate) documented.
+
+STEP 0 - PRE-FLIGHT: git status clean in the worktree (ask if dirty; another session may
+share the checkout). Memory scan of MEMORY.md for: prom-counter-no-scrape-backfill (READ
+IT, it decides the Counter versus Gauge shape below), the cached-read and captured-clock
+entries (staleness testing), and the shared-worktree commit rule (explicit paths, never
+git add -A).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly): spawn an Explore agent over
+docs/discord-bot-stability/state.md, docs/discord-bot-stability/progress.md, this phase
+file, and:
+  - bot/rate_governor.ts (the Phase 2 counter outputs: what is exposed, in what shape, and
+    whether the values are cumulative or windowed), bot/scheduler.ts (queue depth and run
+    duration, if exposed), and the Phase 6 outbox loop (drain sizes)
+  - bot/main.ts (the presence push site and its debounce), bot/server_client.ts (the
+    presence call envelope)
+  - server/internal.ts: the presence handler on BOTH arms, the frozen legacy arm near
+    :107-119 and the RouteDef near :376-394. Report the clamp helpers they use (clampInt,
+    the string slice bounds, the voice array cap) and the body-size limit readBody enforces
+  - server/discord.ts near :168-204: the presence snapshot type, setDiscordPresenceCache,
+    and discordPresenceCache with its 5-minute staleness zeroing (note WHICH fields it
+    zeroes and which it preserves)
+  - server/http/metrics.ts (createHttpMetrics, the private Registry, metricsText),
+    server/http/business_metrics.ts (the Gauge-with-collect pattern, the Counter touched
+    at registration with inc(labels, 0), the naming convention), server/http/game_metrics.ts
+    (registerGameStateMetrics reading a live source object)
+  - server/main.ts around :2595 and :3008-3030 (where the exporter is built and where the
+    register functions are called at boot), and :2800 (the /metrics route)
+  - tests/server/http/business_metrics.test.ts (how metric rendering is asserted today),
+    tests/server/internal.test.ts (how the presence route is tested today),
+    tests/server/http/{parity,completeness,ownership_coverage}.test.ts and
+    known_deviations.ts
+  - DEPLOY.md around :342-348 (the metrics endpoint and scrape section this phase extends)
+It returns: the exact counter surface the bot can offer today; the exact clamp idiom used by
+the presence handlers on both arms; the presence staleness rule verbatim; the metric naming
+convention and registration wiring; and whether any existing test pins the presence request
+or response shape in a way this change must update.
+
+STEP 2 - EXECUTE: two parallel Agents (bot slice, server slice), then a short doc pass. Give
+each agent the Explore summary, not the raw planning docs.
+
+  Agent A, bot slice (bot/ + tests):
+  - A small pure module that collects the counter sources into ONE bounded snapshot with a
+    FIXED key set (never an open map, never a caller-supplied key), and its own tests. Do
+    not append this to main.ts.
+  - The presence push attaches the snapshot to the existing presence POST body. Presence
+    keeps working unchanged when the snapshot is absent or partial: this is telemetry, and
+    it must never be able to fail a presence push.
+  - Decide and record whether the bot sends cumulative totals or per-interval deltas. That
+    choice constrains the server rendering shape (see Agent B), so make it first, state the
+    reasoning, and record it in state.md.
+  - Tests: snapshot shape and bounds; presence push still succeeds with counters missing;
+    counters never throw out of the push path.
+
+  Agent B, server slice (server/ + tests):
+  - Both presence arms accept the counters block: the RouteDef arm AND the frozen legacy
+    handleDiscordInternal arm, in this same change (D9). Every field is clamped with the
+    same idiom the surrounding presence fields use; unknown or malformed fields are dropped,
+    not stored. Confirm the enlarged body still fits whatever limit readBody enforces, and
+    say what that limit is in the final response.
+  - Hold the snapshot in a sibling module (its own file next to the presence cache, not a
+    new block inside a big file), following the presence-cache pattern: a setter the route
+    calls, a getter the metrics registration reads, and staleness zeroing that mirrors the
+    presence rule. Say explicitly which fields zero and which persist when the bot goes
+    quiet, and test the boundary.
+  - Render the series on the EXISTING metrics path by adding a register function in the
+    style of business_metrics.ts / game_metrics.ts, wired at boot next to the existing
+    register calls. Follow the existing metric naming convention.
+  - Respect the prom-counter no-backfill rule (memory: prom-counter-no-scrape-backfill): a
+    prom-client Counter has no set(), so a pushed value CANNOT be backfilled at scrape time.
+    Only two shapes work: a Gauge with collect() reading the cached snapshot, or a real
+    Counter incremented from the push event by a computed delta. Pick one consciously,
+    record the decision and its reasoning in state.md, and handle the consequence you chose:
+    a Gauge of a cumulative total resets to a lower value when the bot restarts (rate() is
+    not meaningful on it), and a delta-incremented Counter needs an explicit guard for that
+    same restart, where the pushed value goes DOWN.
+  - Bound label cardinality hard: the 429 scope label takes values from a fixed allowlist
+    (user, global, shared) and nothing else. A bot-supplied string must never become a label
+    value directly. Decide whether an unrecognized scope is dropped or bucketed, and pin it.
+  - Touch every fixed labeled series once at registration so it renders at 0 before the
+    first push (an absent series and a zero series look different to a dashboard and to an
+    alert).
+  - Tests: clamp arms for each new field on BOTH presence arms (in range, over the cap,
+    wrong type, missing); the rendered exposition text contains the expected series with
+    expected values after a push; the series render at 0 before any push; staleness zeroes
+    the values at the boundary (inject the clock, do not sleep; see the captured-clock
+    memory entries before writing a fake-timer test).
+
+  Doc pass (DEPLOY.md): extend the existing metrics section with a short Grafana note that
+  names each new series and states the two alert-worthy signals: breaker opens (any open is
+  worth an alert) and the 429 rate. Keep it to what an operator needs at 2am. Do not invent
+  threshold numbers that nobody has validated; say what to watch and what "normal" looks
+  like after this packet (429s near zero).
+
+INVARIANTS IN PLAY:
+- D16 (this phase's headline): bot counters piggyback the existing presence POST, held in
+  server memory, exposed as prom lines on the existing metrics path. No new tables.
+- D9 (dual-arm rule): presence is an EXISTING internal route, so this behavior edit lands on
+  BOTH the RouteDef and the frozen legacy handleDiscordInternal arm in the same change, or
+  carries a ledgered deviation in tests/server/http/known_deviations.ts. A deviation is a
+  deliberate, justified choice, never the accident of forgetting an arm.
+- D13 (operator levers): any new cadence or threshold this phase adds is env-configurable
+  with a safe default and documented in DEPLOY.md.
+- D18 (scale envelope): the counter block is fixed-size and bounded regardless of guild size
+  or player count; nothing here grows with 5,000 members.
+- D8 (pure/IO split): the bot-side collector and the server-side snapshot module are pure
+  and directly tested; the route handlers and the registration function stay thin.
+- Non-negotiables from state.md: no SQL and no DDL in this phase; handlers stay
+  req/res-free; secrets stay env-only; commit with explicit paths, never git add -A; no em
+  dashes, en dashes, or emojis anywhere.
+
+OUT OF SCOPE: new tables, new endpoints, and new routes of any kind; changing the presence
+cadence or the presence payload's existing fields; the /metrics auth gate; touching the
+governor's or scheduler's behavior (read their counters, do not change what they count);
+Grafana dashboards or alert rules as artifacts (a DEPLOY.md note only); /api/discord (Phase
+9).
+
+STEP 3 - VALIDATION + REVIEW: run the state.md matrix rows that match the diff. Bot side:
+`npx tsc --noEmit`, `npx vitest run tests/discord_bot.test.ts` plus the new bot test files,
+`npm run build:bot`. Server side: `npx vitest run tests/server/internal.test.ts
+tests/discord_server.test.ts tests/server/discord.test.ts tests/discord_db.test.ts` plus the
+new metrics test file, the http spine (`npx vitest run tests/server/http/parity.test.ts
+tests/server/http/completeness.test.ts tests/server/http/ownership_coverage.test.ts`), and
+`npm run build:server`. Then `npm run ci:changed` (scoped --write only on files you changed).
+Dispatch reviewers per the Review Dispatch Matrix in implementation-plan.md, matching rows
+only: privacy-security-review matches (server/ change). database-performance-reviewer
+matches ONLY if you touched a database call site or added stored growth, which this phase
+should not; if it matches, ask yourself why. migration-safety does not match (no DDL, no
+persisted-shape change: an in-memory snapshot is not persisted state). cross-platform-sync,
+architecture-reviewer and frontend-seam-reviewer do not match; if one does, the phase went
+out of scope. Prompt every reviewer for COVERAGE, not filtering. Resume a truncated reviewer
+with: "Stop reading more files. Output the full report now. No more tool calls. Format:
+BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT." Do not commit while a BLOCKING finding
+stands.
+
+STEP 4 - COMMITS (Conventional Commits with a scope, explicit paths, every commit carries a
+body of 1 to 4 plain sentences saying what changed and why, no em dashes, no emojis):
+1. feat(bot): report governor and loop counters on the presence push
+2. feat(server): accept and expose the bot counters as prometheus series (both presence
+   arms, clamped, with staleness zeroing)
+3. test(server): pin the counter clamps, exposition rendering, and staleness boundary
+4. docs(deploy): name the new bot series and the two alert-worthy signals
+
+STEP 5 - ACCEPTANCE (each item verifiable, not asserted):
+- A test drives a presence POST with counters through BOTH arms and asserts identical
+  stored state, or a ledgered deviation exists with a written justification.
+- Each new field has an over-cap, wrong-type, and missing arm asserted; no clamp that
+  existed before this phase is loosened.
+- The exposition text (metricsText) contains every new series at 0 before any push, and the
+  pushed values after one.
+- Staleness zeroing is asserted AT the boundary in both directions with an injected clock,
+  not a sleep.
+- The 429 scope label can only take allowlisted values; a test drives a hostile scope string
+  and proves it cannot create a new series.
+- `npx tsc --noEmit`, the bot and server suites, the http spine, both builds, and
+  `npm run ci:changed` are green.
+- DEPLOY.md names every new series and both alert signals.
+
+STEP 6 - DOCS: tick the Phase 8 boxes in progress.md and set its status row; update state.md
+with the recorded decisions (cumulative versus delta, Gauge versus Counter, the unknown-scope
+rule, the staleness field list) and any new env keys. Same commit as the work, explicit
+paths. Record surprising rules to memory.
+
+STEP 7 - FINAL RESPONSE: phase status; files touched; validation results (command by
+command); reviewer verdicts; the recorded decisions and the readBody body-size limit you
+confirmed; deferrals; and a one-line handoff for the Phase 8 QA session.
+
+STOPPING RULES:
+- Stop and surface if a counter cannot ride the presence body without widening a documented
+  clamp unsafely, or without pushing the body past the size limit readBody enforces. Drop
+  the counter and report it rather than loosening a validation bound that exists for a
+  reason.
+- Stop and surface if the counters cannot land on both presence arms identically. A ledgered
+  deviation is allowed, but only as a deliberate decision you state and justify, never as a
+  silent one-arm change.
+- Stop if this phase finds itself adding a table, a route, or a poll. None of the three is
+  authorized here.
+- Stop if a BLOCKING reviewer finding cannot be fixed inside this phase's scope.
+```

--- a/docs/discord-bot-stability/phase-08-qa.md
+++ b/docs/discord-bot-stability/phase-08-qa.md
@@ -1,0 +1,97 @@
+# Phase 8 QA: Observability
+
+Adversarial verification of the Phase 8 diff. Telemetry fails quietly: a series that renders
+a frozen 0, a staleness rule that never fires, a clamp that silently accepts a hostile value,
+or a counter that landed on one presence arm and not the other. None of those break a test
+anyone is watching, and all of them mean the next incident is invisible again. This session
+proves the numbers are real, bounded, and correct on both arms.
+
+Starter prompt for the session:
+
+```
+This is Phase 8 QA of the Discord Bot Stability packet: verify Observability.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code. ULTRACODE: yes, run the
+adversarial-verify Workflow (every finding independently confirmed by a skeptic agent
+before it counts) plus mutation spot checks on the Phase 8 clamp, render, and staleness
+logic (the bot-side counter collector, the server-side snapshot module, and the metrics
+register function).
+Worktree: /Users/fernando/Documents/wocc-discord-bot.
+
+STEP 0 - PRE-FLIGHT: git status clean (Phase 8 committed). Memory scan including the
+test-pin trap index (READ IT before judging or writing any pin), plus
+prom-counter-no-scrape-backfill and the captured-clock versus fake-timers entries: both
+decide whether this phase's tests can catch what they claim to catch.
+
+STEP 1 - LOAD CONTEXT: spawn an Explore agent over docs/discord-bot-stability/state.md,
+progress.md, phase-08-observability.md, and the Phase 8 diff (git diff against the
+phase-start commit). It returns: the promised deliverables and acceptance criteria; every
+file touched; the recorded decisions (cumulative versus delta, Gauge versus Counter, the
+unknown-scope rule, which fields zero on staleness); the full list of new series names and
+their label sets; and the clamp bounds now applied on each presence arm.
+
+STEP 2 - AUDIT (parallel agents, COVERAGE not filtering; every finding independently
+confirmed by a skeptic agent before it counts):
+  - Correctness agent: every deliverable and acceptance criterion actually met. Specifically:
+    do the two presence arms store byte-identical state for the same body (or is there a
+    ledgered deviation with a real justification); is every clamp bound sane and no
+    pre-existing bound loosened; can any bot-supplied string reach a label value; does the
+    chosen Counter-or-Gauge shape survive a bot restart (the pushed value going DOWN); does
+    the staleness rule actually fire, and does it zero the fields the phase said it would;
+    can a malformed or oversized counters block break a presence push (it must not); is the
+    register function wired at boot on the same registry /metrics serves.
+  - Test coverage agent (or test-coverage-auditor): are the assertions DECISIVE. Check that
+    the exposition assertions pin literal series names and values, not a regex that would
+    pass on an empty body. Check the "renders at 0 before any push" arm exists (the
+    no-backfill trap publishes a frozen 0, which a post-push-only test cannot distinguish
+    from a working counter). Check per-field negative cases: a multi-field clamp test that
+    only ever violates one field proves nothing about the others. Check both arms of every
+    either/or claim, and that the staleness test asserts the boundary in BOTH directions.
+  - Dead-code agent: unused imports and types, a counter collected by the bot and never
+    read by the server, a series registered and never set, a config key added and never
+    used, leftovers of any replaced code.
+  - Review Dispatch Matrix rows matching the diff: privacy-security-review (server/ change).
+    database-performance-reviewer only if the diff touched a database call site or added
+    stored growth; if it did, that is itself a finding, since Phase 8 should touch neither.
+    Confirm no other row matches; if one does, the phase went out of scope, and that is
+    BLOCKING.
+  - qa-checklist over the diff.
+  - Mutation pass, in an ISOLATED worktree (never over the live checkout; a stash is shared
+    across worktrees, so do not lean on one). Mutate, one at a time, and prove the suite
+    kills each mutant:
+      1. Widen one clamp bound by an order of magnitude, and separately remove one clamp
+         entirely (the raw value flows through).
+      2. Drop the counters block from the LEGACY presence arm only, leaving the RouteDef arm
+         correct (the dual-arm pin must fail).
+      3. Drop one field from the rendered series set.
+      4. Invert the staleness comparison, and separately shift the staleness threshold by
+         one interval.
+      5. Delete the registration-time touch that makes each series render at 0.
+      6. Accept an unrecognized 429 scope string as a label value.
+      7. If the phase chose delta-incremented Counters: remove the restart guard so a
+         decreasing pushed value produces a negative or wrapped delta. If it chose Gauges:
+         make collect() read a stale local copy instead of the live snapshot getter.
+    For every mutant, PROVE THE TESTS RAN (memory: mutation-harness-must-prove-tests-ran):
+    capture runner output showing the test count and the failing assertion, never just a
+    nonzero exit code. Record every survivor and the test that should have caught it.
+
+STEP 3 - FIX: apply ALL findings, blocking, should-fix, AND nits (standing user rule). Then
+review the fix round itself with a FRESH eyes agent (the fixes are unreviewed code). Re-run
+the validation matrix: npx tsc --noEmit; the bot suite plus the Phase 8 bot tests;
+npm run build:bot; npx vitest run tests/server/internal.test.ts tests/discord_server.test.ts
+tests/server/discord.test.ts tests/discord_db.test.ts plus the new metrics test file; the
+http spine (tests/server/http/parity.test.ts, completeness.test.ts,
+ownership_coverage.test.ts); npm run build:server; npm run ci:changed.
+
+STEP 4 - DOCS: progress.md (Phase 8 QA complete, with any deferral named), state.md (drift
+found, plus anything the mutation pass taught about these pins).
+
+STEP 6 - FINAL RESPONSE: verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL); counts found and fixed
+by severity; mutation kill tally (killed over attempted, with any survivor named and its
+fix); deferrals; one-line handoff for Phase 9.
+
+STOPPING RULES: stop and surface if a BLOCKING item cannot be fixed without changing phase
+scope. Stop and surface if a fix would require widening a clamp or adding a route, a table,
+or a poll: none is authorized in this phase, so report it as a follow-up instead. Stop and
+surface if the mutation pass cannot prove the tests ran. Do not run the mutation pass over
+the live worktree.
+```

--- a/docs/discord-bot-stability/phase-09-api-discord-caching.md
+++ b/docs/discord-bot-stability/phase-09-api-discord-caching.md
@@ -1,0 +1,196 @@
+# Phase 9: /api/discord caching
+
+The incident report measured `/api/discord` at 7,356 requests per hour from site visitors,
+and every one of them ran four uncached database reads. It scales with people looking at the
+site, not with people playing, and it is the last hot read in this packet's blast radius that
+still hits Postgres on every request. This phase puts the account-scoped part of the payload
+behind the repo's existing `createCachedRead` seam with a short TTL, wires the busts in the
+same change so a link, an unlink, a points grant or a swag claim is never served stale, and
+leaves the presence block exactly as live as it is today. It is deliberately the smallest
+phase in the packet, and its QA session closes the packet.
+
+Verified against the tree on 2026-07-30 (re-confirm before relying on it): `GET /api/discord`
+has TWO arms, the RouteDef in `server/discord.ts` (near :1382, handler `discordStatusHandler`
+at :1322) and the frozen legacy arm in `server/main.ts` (near :2229). Both funnel into
+`handleDiscordStatus` (`server/discord.ts:790`), which calls `discordStatusPayload` (:798).
+Caching inside `discordStatusPayload` therefore covers both arms parity-identically by
+construction, which is what makes this phase small.
+
+Starter prompt for the session:
+
+```
+This is Phase 9 of the Discord Bot Stability packet: /api/discord caching.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code.
+Worktree: /Users/fernando/Documents/wocc-discord-bot (branch feature/discord-bot-stability).
+No ultracode Workflow for this phase: it is one small server slice. Its QA session runs
+ultracode and closes the packet.
+
+Goal: the account-scoped part of the GET /api/discord payload is served from a keyed,
+bounded, short-TTL cached read with every bust wired in the same change, so a cache-hit
+request performs zero payload queries and no caller can be served stale data after a change
+it just made.
+
+STEP 0 - PRE-FLIGHT: git status clean in the worktree (ask if dirty; another session may
+share the checkout). Memory scan of MEMORY.md for: cached-read-bust-inflight-joiner (a bust
+during an in-flight refresh), cachedread-captured-clock-vs-fake-timers (why a cached read
+built at module load binds Date.now and defeats fake timers), daily-rewards-module-memo-reset
+and beforeEach-busts-the-cache (test isolation between cases), and the shared-worktree commit
+rule (explicit paths, never git add -A).
+
+STEP 1 - LOAD CONTEXT (do NOT read planning docs directly): spawn an Explore agent over
+docs/discord-bot-stability/state.md, docs/discord-bot-stability/progress.md, this phase file,
+and:
+  - server/discord.ts: discordStatusPayload (near :798) and every read it performs
+    (discordForAccount, loadRewardState, listSwagClaims, accountById) plus the
+    discordPresenceCache() call it composes in; handleDiscordStatus (near :790); the
+    RouteDef table entry for GET /api/discord (near :1382) and discordStatusHandler (near
+    :1322); handleDiscordUnlink (near :846) and the swag claim handler
+  - server/main.ts: the legacy GET /api/discord arm (near :2229) and its rate guard
+  - server/cached_read.ts (the whole file: TTL, single-flight, the epoch guard, stale-serve,
+    the injected clock)
+  - server/main.ts:809 (projectStatsCache), server/admin_overview_cache.ts,
+    server/daily_rewards_board_cache.ts, and every existing .bust() call site: these are the
+    bust-wiring exemplars
+  - server/discord_db.ts and wherever else the payload's inputs are WRITTEN: the OAuth link
+    callback, unlink, guild-member updates, reward-point grants (including the internal
+    grant and member routes and the daily-rewards path), swag claims, and the password-set
+    path that flips accounts.password_set
+  - the rate guard on both arms (discordActiveRateGuard and discordRateLimited): what the
+    limit is and where it is enforced
+  - server/CLAUDE.md "Hot paths" (the cached-read, single-flight, and unbounded-growth rules)
+  - the test rigs R1 (state.md rulings block) sanctions: tests/server/internal.test.ts (its
+    vi.mock module fakes plus the runRoute helper) and tests/discord_db.test.ts (the
+    hand-rolled makePool fake whose calls array is the sanctioned way to count SQL
+    statements), plus tests/server/discord.test.ts and any existing test that pins the
+    /api/discord response. Never invent a raw pg mock
+It returns: the two arms and whether they still share discordStatusPayload; the exhaustive
+list of write sites that can change any field in the payload, each with file:line; whether
+any keyed cached-read wrapper already exists in server/ (as of 2026-07-30 there is none:
+every existing caller of createCachedRead holds a single value); the rate-guard limits on
+both arms; and the test helpers and fixtures already available for this route.
+
+STEP 2 - EXECUTE: one agent is enough for the implementation; run a second agent in parallel
+to do nothing but enumerate and verify the bust sites (that enumeration is where this phase
+actually fails). Give both the Explore summary, not the raw planning docs.
+
+  Implementation:
+  - A small keyed cache module of its own, sanctioned as this phase's scope by R11 in the
+    state.md rulings block (not a Map open-coded inside server/discord.ts):
+    it owns per-account CachedRead instances built on createCachedRead, exposes a read for
+    one account, a bust for one account, and a bust-all, and it is BOUNDED. An unbounded map
+    keyed by account id is exactly the "table that grows without bound" defect server/CLAUDE.md
+    names, so it needs an eviction story (a cap with eviction, or a sweep of idle entries)
+    and a test that pins the bound. Take the clock injection through to createCachedRead's
+    opts.now so tests can drive the TTL.
+  - The cached unit is the DATABASE-BACKED part of the payload only. discordPresenceCache()
+    is read fresh on every request and composed into the response, so the presence block
+    stays exactly as live as it is today, and a cache hit still performs zero queries because
+    presence is already an in-memory read. This is the confirmed reading of D17, settled as
+    R10 in the state.md rulings block: presence is never frozen behind the payload TTL, and
+    the reading is not open for re-litigation.
+  - Cache inside the shared payload assembly so both arms get identical behavior from one
+    change. Same for the busts: wire each bust in the shared handler or the shared write
+    function, never in a route-table entry, or the legacy arm will diverge.
+  - TTL: short, env-configurable with a safe default (D13), documented with the other new
+    env keys.
+  - Every write site the enumeration agent found gets its bust wired in THIS change (D17).
+    A bust that is "obviously" covered by the TTL is not covered: a user who unlinks and
+    immediately reloads must not see themselves still linked.
+  - The 15-per-minute rate guard stays exactly as it is on both arms. Caching is not a
+    reason to loosen it.
+
+  Tests (reuse the rig the matching suite already uses, per R1; never a raw pg mock):
+  - Miss then hit: the second request inside the TTL performs ZERO payload queries (assert
+    the query count, not just the response body).
+  - TTL expiry refreshes, driven by the injected clock, not by sleeping.
+  - Bust arms: one bust per enumerated write site, each proving the next read reflects the
+    change. Drive them through the real code path (call the unlink or grant function), not
+    by calling bust() directly, or the test proves only that bust() exists.
+  - The in-flight joiner arm: a bust landing during a refresh must not let a post-bust reader
+    join the pre-bust flight (memory: cached-read-bust-inflight-joiner).
+  - Cross-account isolation: account A's cached payload is never served to account B. This is
+    the highest-severity failure mode in the phase, so give it its own decisive test.
+  - The bound: filling the cache past its cap evicts rather than growing forever.
+  - Both arms return identical payloads for the same account and cache state.
+
+INVARIANTS IN PLAY:
+- D17 (this phase's headline): /api/discord gets a per-account short-TTL cached read through
+  the createCachedRead seam, with moderation and mutation busts wired in the SAME change;
+  the presence block stays as is.
+- D9 (dual-arm rule): /api/discord HAS a frozen legacy arm. A behavior edit lands on both the
+  RouteDef and the legacy arm in the same change, or carries a ledgered deviation in
+  tests/server/http/known_deviations.ts. Caching inside the shared payload function satisfies
+  this by construction; verify that the two arms still share it before relying on that.
+- D13 (operator levers): the TTL and any cap are env-configurable with safe defaults and
+  documented in DEPLOY.md.
+- D18 (scale envelope): the cache is bounded at 1,000 concurrent players and beyond; state
+  the bound and what happens past it.
+- Non-negotiables from state.md: no DDL and no new persisted state (this is process-local
+  memory); SQL stays in db.ts / *_db.ts; handlers stay req/res-free; errors stay stable codes
+  from the append-only error_codes.ts; commit with explicit paths, never git add -A; no em
+  dashes, en dashes, or emojis anywhere.
+
+OUT OF SCOPE: /api/site-presence (explicitly untouched by this packet); the presence cache
+itself; any change to the payload's SHAPE or to what the endpoint returns; the DELETE
+/api/discord and swag-claim behaviors beyond adding their busts; retiring the legacy ladder
+(owned by the pipeline packet); new endpoints, new tables, and new indexes; bot/ changes of
+any kind.
+
+STEP 3 - VALIDATION + REVIEW: run the state.md matrix rows that match the diff: `npx tsc
+--noEmit`; `npx vitest run tests/server/internal.test.ts tests/discord_server.test.ts
+tests/server/discord.test.ts tests/discord_db.test.ts` plus the new cache test file; the http
+spine (`npx vitest run tests/server/http/parity.test.ts tests/server/http/completeness.test.ts
+tests/server/http/ownership_coverage.test.ts`); `npm run build:server`; `npm run ci:changed`
+(scoped --write only on files you changed). Dispatch reviewers per the Review Dispatch Matrix
+in implementation-plan.md, matching rows only: privacy-security-review matches (server/
+change, and a per-account cache is an account-data-privacy surface: a keying bug leaks one
+player's Discord identity to another) and database-performance-reviewer matches (this changes
+query cadence on a hot read). migration-safety does not match (no DDL, no persisted-shape
+change). cross-platform-sync, architecture-reviewer and frontend-seam-reviewer do not match;
+if one does, the phase went out of scope. Prompt every reviewer for COVERAGE, not filtering.
+Resume a truncated reviewer with: "Stop reading more files. Output the full report now. No
+more tool calls. Format: BLOCKING / SHOULD-FIX / NICE-TO-HAVE / VERDICT." Do not commit while
+a BLOCKING finding stands.
+
+STEP 4 - COMMITS (Conventional Commits with a scope, explicit paths, every commit carries a
+body of 1 to 4 plain sentences saying what changed and why, no em dashes, no emojis):
+1. feat(server): add a bounded per-account keyed cached read
+2. feat(server): serve /api/discord from the keyed cache and bust it on every write
+3. test(server): pin the cache hit, TTL, bust, isolation, and bound arms
+(Collapsing 1 and 2 into one commit is fine if the module and its only caller land together;
+do not split the busts away from the caching, they are one change.)
+
+STEP 5 - ACCEPTANCE (each item verifiable, not asserted):
+- A cache-hit request performs zero payload queries, asserted by counting statements on the
+  makePool fake's calls array (the R1 rig), not by inspecting the response body.
+- Every enumerated write site has a test proving the next read reflects its change, driven
+  through the real code path.
+- Account A's payload is provably never served to account B.
+- The TTL is driven by an injected clock in tests, and the cache is not built at module load
+  in a way that binds a real Date.now where a test needs otherwise.
+- The cache is bounded, with the bound pinned by a test.
+- Both /api/discord arms return identical payloads for the same account and cache state, or
+  a ledgered deviation exists with a written justification.
+- The 15-per-minute rate guard is unchanged on both arms, pinned by an existing or new test.
+- `npx tsc --noEmit`, the server suites, the http spine, `npm run build:server`, and
+  `npm run ci:changed` are green.
+
+STEP 6 - DOCS: tick the Phase 9 boxes in progress.md and set its status row; update state.md
+(the new module, the new env keys, and the enumerated bust-site list, which is the artifact a
+future reader will need most). Same commit as the work, explicit paths. Record surprising
+rules to memory.
+
+STEP 7 - FINAL RESPONSE: phase status; files touched; validation results (command by
+command); reviewer verdicts; the bust-site enumeration; deferrals; and a one-line handoff for
+the Phase 9 QA session, noting that it is the packet-close session.
+
+STOPPING RULES:
+- Stop and surface if GET /api/discord has a legacy arm that cannot be kept parity-identical
+  (for example the two arms no longer share the payload assembly). Report the divergence and
+  the options; do not silently cache one arm.
+- Do NOT stop over the caching unit: R10 settles it. Cache the database-backed part, compose
+  presence fresh per request, and never let the presence block sit behind the TTL.
+- Stop if bounding the keyed cache would require an eviction policy that could serve one
+  account's entry to another. Correctness beats the bound; report it.
+- Stop if a BLOCKING reviewer finding cannot be fixed inside this phase's scope.
+```

--- a/docs/discord-bot-stability/phase-09-qa.md
+++ b/docs/discord-bot-stability/phase-09-qa.md
@@ -1,0 +1,130 @@
+# Phase 9 QA: /api/discord caching, and packet close
+
+Two jobs in one session. First, adversarially verify the Phase 9 diff: a per-account cache is
+a privacy surface, so a keying mistake here does not just serve stale data, it serves one
+player's Discord identity to another. Second, close the packet: run the whole-feature matrix
+in qa-checklist.md across all nine phases, run the full gate, file the follow-ups that were
+deliberately deferred, surface the OPEN items that need a human, and offer teardown of this
+planning directory.
+
+Starter prompt for the session:
+
+```
+This is Phase 9 QA of the Discord Bot Stability packet: verify /api/discord caching, then
+close the packet.
+Model: Opus 4.8 or newer, xhigh effort. Harness: Claude Code. ULTRACODE: yes, run the
+adversarial-verify Workflow (every finding independently confirmed by a skeptic agent before
+it counts) plus mutation spot checks on the Phase 9 cache keying, TTL, and bust wiring.
+Worktree: /Users/fernando/Documents/wocc-discord-bot.
+
+STEP 0 - PRE-FLIGHT: git status clean (Phase 9 committed). Memory scan including the test-pin
+trap index (READ IT before judging or writing any pin), cached-read-bust-inflight-joiner,
+cachedread-captured-clock-vs-fake-timers, the cache-bust and memo-reset entries, and
+full-npm-test-contention-flakes (the full gate run in STEP 5 goes through a Monitor with
+bounded workers, never an ad-hoc chain).
+
+STEP 1 - LOAD CONTEXT: spawn an Explore agent over docs/discord-bot-stability/state.md,
+progress.md, phase-09-api-discord-caching.md, and the Phase 9 diff (git diff against the
+phase-start commit). It returns: the promised deliverables and acceptance criteria; every file
+touched; the cache module's exported surface, its key, its TTL source and its bound; the
+enumerated bust-site list Phase 9 recorded in state.md; and which tests cover which arm.
+
+STEP 2 - AUDIT (parallel agents, COVERAGE not filtering; every finding independently confirmed
+by a skeptic agent before it counts):
+  - Correctness agent: every deliverable and acceptance criterion actually met. Specifically:
+    is the cache key genuinely per-account everywhere it is read, with no path that can share
+    an entry across accounts; is the enumerated bust list COMPLETE (re-derive it independently
+    by finding every writer of every field in the payload, do not trust the recorded list);
+    does each bust fire on the shared code path so both /api/discord arms are covered; is the
+    TTL bounded and env-configurable; is the cache bounded with a real eviction path; does the
+    presence block stay live per request; is the rate guard untouched; does a failed refresh
+    stale-serve in a way that could outlive a moderation action (read the stale-serve arm in
+    server/cached_read.ts before judging).
+  - Test coverage agent (or test-coverage-auditor): are the assertions DECISIVE. The
+    zero-query claim must assert a query COUNT, not a response body. Each bust test must drive
+    the real write function, not call bust() directly. The cross-account test must actually
+    populate two accounts with DIFFERENT payloads (identical fixtures make the assertion
+    vacuous, the constant-self-comparison trap). The TTL test must use the injected clock.
+    Check that no test passes only because the cache was cold.
+  - Dead-code agent: unused imports and types, an exported cache method nobody calls, leftover
+    pre-cache code paths, a config key added and never read.
+  - Review Dispatch Matrix rows matching the diff: privacy-security-review (account-data
+    privacy on a keyed cache) and database-performance-reviewer (query cadence on a hot read).
+    Confirm no other row matches.
+  - qa-checklist over the diff.
+  - Mutation pass, in an ISOLATED worktree (never over the live checkout; a stash is shared
+    across worktrees, so do not lean on one). Mutate, one at a time, and prove the suite kills
+    each mutant:
+      1. Key the cache by a constant so every account shares one entry (the cross-account
+         isolation test MUST fail; if it does not, that test is vacuous and this is BLOCKING).
+      2. Make the TTL effectively infinite, and separately make it zero.
+      3. Delete one bust call site, then another; every enumerated site should have a test
+         that fails.
+      4. Replace bust() with a plain cache-entry delete that does not bump the epoch (the
+         in-flight-joiner arm must fail).
+      5. Remove the eviction bound so the keyed map grows forever.
+      6. Serve the cached presence block instead of reading it fresh.
+      7. Cache on only ONE of the two /api/discord arms.
+    For every mutant, PROVE THE TESTS RAN (memory: mutation-harness-must-prove-tests-ran):
+    capture runner output showing the test count and the failing assertion, never just a
+    nonzero exit code. Record every survivor and the test that should have caught it.
+
+STEP 3 - FIX: apply ALL findings, blocking, should-fix, AND nits (standing user rule). Then
+review the fix round itself with a FRESH eyes agent (the fixes are unreviewed code). Re-run the
+validation matrix: npx tsc --noEmit; npx vitest run tests/server/internal.test.ts
+tests/discord_server.test.ts tests/server/discord.test.ts tests/discord_db.test.ts plus the
+Phase 9 cache tests; the http spine (tests/server/http/parity.test.ts, completeness.test.ts,
+ownership_coverage.test.ts); npm run build:server; npm run ci:changed.
+
+STEP 4 - DOCS: progress.md (Phase 9 QA complete, packet status), state.md (drift found, the
+verified bust-site enumeration, anything the mutation pass taught).
+
+STEP 5 - PACKET CLOSE (this is the final phase, so this step runs in full):
+  a. Whole-feature matrix: work through EVERY row of docs/discord-bot-stability/qa-checklist.md
+     against the full packet diff (git diff release/v0.33.0...HEAD), not just Phase 9. The
+     first row is scope containment: prove no src/ path is in the diff. Each row gets a verdict
+     backed by a command or a test, never an assertion. Fan out across rows in parallel; they
+     are independent. Audit against the "Rulings settled during authoring" block in state.md
+     as well as the D-numbers: every ruling (R1 onward) either landed as written across the
+     nine phases, or carries a recorded and justified deviation. Read that block BEFORE
+     raising anything, and check it again before writing a finding up: an apparent gap that a
+     ruling already settles is not a finding, it is a ruling you had not read.
+  b. Full gate: npm run gate in the worktree. It is exit-code-safe, so run it directly and read
+     its exit code; never pipe it through tail and never substitute an ad-hoc && chain. Run it
+     through a Monitor (memory: full-npm-test-contention-flakes) and expect it to include
+     build:bot, which Phase 1 added. Green is required to call the packet done.
+  c. Follow-up issues: brainstorm.md ends with a list of work deliberately left out of scope.
+     ASK THE USER FIRST, then file the ones they approve with the file-issue skill, in the
+     maintainer's house format: (1) the two-way chat relay from Discord into the world, with
+     its moderation, sanitization and i18n surface; (2) /api/site-presence write cadence; (3)
+     retiring the now-unused per-endpoint internal GET routes (relay, activity, winners) once
+     the frozen legacy ladder deletion lands (D11). Do NOT file the fourth item, retiring the
+     legacy handleDiscordInternal ladder itself: brainstorm.md assigns it to the pipeline
+     packet, not this one. Report the issue numbers in the final response.
+  d. Surface the OPEN items that need a human, verbatim and unresolved: O4, confirm the
+     GUILD_MEMBERS and GUILD_PRESENCES privileged intents stay enabled in the Discord Developer
+     Portal under the 2026-06-10 policy (self-serve under 10,000 users); and O5, whether
+     member-write 429s return user or shared scope, which decides ban-counter exposure and
+     resolves from production logs after the first deploy. Neither is a blocker and neither is
+     yours to decide.
+  e. Teardown offer, exactly per docs/discord-bot-stability/README.md: offer to delete the
+     planning directory before the PR. Delete it ONLY on explicit user confirmation, and only
+     with an explicit path: git rm -r docs/discord-bot-stability. Never git add -A, and never
+     delete anything else. If the user does not confirm, leave the directory in place and say
+     so.
+  f. Do not push the branch, open a PR, or merge anything unless the user explicitly asks.
+     Report what a PR would contain instead.
+
+STEP 6 - FINAL RESPONSE: verdict (PASS / PASS-WITH-FOLLOWUPS / FAIL) for Phase 9 AND for the
+packet; counts found and fixed by severity; mutation kill tally (killed over attempted, with
+any survivor named and its fix); the qa-checklist.md matrix results row by row; the gate
+result; issue numbers filed; O4 and O5 surfaced for the user; teardown status; and anything
+deferred, with a one-line statement of what remains before this packet can ship.
+
+STOPPING RULES: stop and surface if a BLOCKING item cannot be fixed without changing phase
+scope. Stop and surface if a whole-feature matrix row fails for a reason that belongs to an
+EARLIER phase: report it with the phase number rather than expanding this session into a
+re-implementation. Stop and surface if the mutation pass cannot prove the tests ran. Do not
+run the mutation pass over the live worktree, do not delete the planning directory without
+explicit confirmation, and do not file an issue the user has not approved.
+```

--- a/docs/discord-bot-stability/progress.md
+++ b/docs/discord-bot-stability/progress.md
@@ -87,6 +87,14 @@
 
 ### Phase 1 (2026-07-30)
 
+Release sync: NO-OP. `origin/release/v0.33.0` was still at `b0acba0adc`, the commit
+this branch was cut from, so there was nothing to merge (6 ahead, 0 behind). Every
+later phase repeats the check at its START, per the standing rules at the top of
+state.md.
+
+Environment: this worktree had no `node_modules`; `npm ci` was run in it to get the
+real TypeScript 7 native binary and a runnable gate.
+
 The tsconfig include surfaced ZERO latent type errors, so the "fix the errors the
 include surfaces" commit collapsed into the include itself. The include was proven
 live two ways rather than assumed: `tsc --noEmit --listFiles` lists all six bot files

--- a/docs/discord-bot-stability/progress.md
+++ b/docs/discord-bot-stability/progress.md
@@ -1,0 +1,87 @@
+# Progress: Discord Bot Stability
+
+## Status
+
+| Phase | Status | Started | Completed |
+|---|---|---|---|
+| Phase 1: Bot verification foundation | not started | | |
+| Phase 1 QA | not started | | |
+| Phase 2: Discord rate-limit governor | not started | | |
+| Phase 2 QA | not started | | |
+| Phase 3: Loop scheduler + diff-before-write | not started | | |
+| Phase 3 QA | not started | | |
+| Phase 4: Server set-based endpoints | not started | | |
+| Phase 4 QA | not started | | |
+| Phase 5: Outbox + linked-member change feed | not started | | |
+| Phase 5 QA | not started | | |
+| Phase 6: Bot consumes the new surface | not started | | |
+| Phase 6 QA | not started | | |
+| Phase 7: Supervision + deploy hardening | not started | | |
+| Phase 7 QA | not started | | |
+| Phase 8: Observability | not started | | |
+| Phase 8 QA | not started | | |
+| Phase 9: /api/discord caching | not started | | |
+| Phase 9 QA (packet close) | not started | | |
+
+## Deliverable checklists
+
+### Phase 1
+- [ ] `bot` in tsconfig include, latent type errors fixed behavior-preserving
+- [ ] `build:bot` in `scripts/gate.mjs`
+- [ ] Injectable fetch/socket/clock seams in `discord_api.ts`, `server_client.ts`, `gateway.ts`
+- [ ] Cadence constants extracted into `bot/cadence.ts` as a pure move (R6)
+- [ ] Baseline tests: config arms, server_client envelope/secret/timeout, cadence pins via the module
+
+### Phase 2
+- [ ] `bot/rate_governor.ts` pure module (buckets, proactive gating, global pause, breaker, forbidden cache, counters)
+- [ ] `DiscordApi.request()` rewired; `/api/v10` pinned; audit-log reason on member PATCH; scope logging
+- [ ] New env keys in `bot/config.ts` with defaults
+- [ ] Governor test suite (all 429 arms, HTML 429, breaker, pacing determinism)
+
+### Phase 3
+- [ ] `bot/scheduler.ts` (overlap guards, jitter, adaptive backoff, coalescing, env cadences)
+- [ ] All six loops + presence debounce migrated; bare setIntervals deleted
+- [ ] Nickname diff-before-PATCH with success-only cache update
+- [ ] members-meta diff + self-echo suppression
+- [ ] Fake-timer scheduler tests; diff-arm tests
+
+### Phase 4
+- [ ] `POST /internal/discord/flex-batch` RouteDef + spine rows + R1-rig tests + query-count pin
+- [ ] members-meta bulk upsert with unchanged-skip, BOTH arms
+- [ ] `reward_ledger` keep-forever comment
+- [ ] Tests for `server/discord_relay.ts` and `server/discord_activity.ts`
+
+### Phase 5
+- [ ] `server/discord_link_changes.ts` bounded FIFO + every feed site enumerated in state.md
+- [ ] `GET /internal/discord/outbox` RouteDef + spine rows, batched account lookups
+- [ ] Query-count + payload assertions at the D18 envelope; winners fetch at-most-once pin
+- [ ] Full-envelope tests incl. empty-drain zero-query pin
+
+### Phase 6
+- [ ] `flexBatch()` + `drainOutbox()`; old per-endpoint client methods deleted
+- [ ] Linked-set sweep through the governor with write spreading
+- [ ] One outbox loop replaces three pollers + per-user flex GETs
+- [ ] Dead code removed; steady-state connection count verified small
+- [ ] Integration test of a full sweep cycle at the D18 envelope
+
+### Phase 7
+- [ ] Fatal gateway close exits nonzero; heartbeat file
+- [ ] Compose healthcheck + mem_limit + stop_grace_period for the bot service
+- [ ] Caddy 404s `/internal/*`
+- [ ] Deploy test pins extended; DEPLOY.md bot section + runbook
+
+### Phase 8
+- [ ] Counters ride presence POST (both arms), clamped server-side
+- [ ] Prom lines on the existing metrics path with staleness zeroing
+- [ ] Grafana note in DEPLOY.md
+- [ ] Clamp/render/staleness tests
+
+### Phase 9
+- [ ] `/api/discord` payload behind keyed `createCachedRead` + moderation busts
+- [ ] Legacy-arm status checked and honored
+- [ ] Cache-hit zero-query assertion; rate guard intact
+- [ ] Hit/miss/bust/TTL tests
+
+## Per-phase notes
+
+(fill in after each session)

--- a/docs/discord-bot-stability/progress.md
+++ b/docs/discord-bot-stability/progress.md
@@ -5,7 +5,7 @@
 | Phase | Status | Started | Completed |
 |---|---|---|---|
 | Phase 1: Bot verification foundation | built | 2026-07-30 | 2026-07-30 |
-| Phase 1 QA | not started | | |
+| Phase 1 QA | done | 2026-07-30 | 2026-07-30 |
 | Phase 2: Discord rate-limit governor | not started | | |
 | Phase 2 QA | not started | | |
 | Phase 3: Loop scheduler + diff-before-write | not started | | |
@@ -27,7 +27,7 @@
 
 ### Phase 1
 - [x] `bot` in tsconfig include, latent type errors fixed behavior-preserving
-      (the include surfaced none; all six bot files are in the checked set)
+      (the include surfaced none; all seven bot files are in the checked set)
 - [x] `build:bot` in `scripts/gate.mjs` (and in both CI jobs that build the server, R7)
 - [x] Injectable fetch/socket/clock seams in `discord_api.ts`, `server_client.ts`, `gateway.ts`
 - [x] Cadence constants extracted into `bot/cadence.ts` as a pure move (R6)
@@ -97,7 +97,7 @@ real TypeScript 7 native binary and a runnable gate.
 
 The tsconfig include surfaced ZERO latent type errors, so the "fix the errors the
 include surfaces" commit collapsed into the include itself. The include was proven
-live two ways rather than assumed: `tsc --noEmit --listFiles` lists all six bot files
+live two ways rather than assumed: `tsc --noEmit --listFiles` lists all seven bot files
 including `bot/main.ts`, and a deliberate type error added to `bot/main.ts` failed the
 check before being reverted.
 
@@ -136,7 +136,7 @@ two counts, so deleting it and adding any other single-shard step kept the suite
 It is now also pinned by name, along with the other three builds and the four gate
 steps. The decoy-swap mutation confirms the hole is closed.
 
-The killed mutants: both cadence constants, the `'0'` nickname arm, the `||` default
+The killed mutants: all three cadence constants, the `'0'` nickname arm, the `||` default
 fallback, the `!v` required guard, the activity ladder rung, two channel key swaps, the
 secret header name, the 8000 ms deadline, the success-flag check, the `finally`
 clearTimeout, the Content-Type header, the non-ok short circuit, the injected-fetch
@@ -148,3 +148,62 @@ and the count-preserving CI decoy swap.
 Worktree note for later phases: this checkout had no `node_modules`, and the main
 checkout's install is stale (TypeScript 5.9.3, no ffmpeg-static). A local `npm ci` in
 the worktree is what gets the real TypeScript 7 native binary and a runnable gate.
+
+### Phase 1 QA (2026-07-30)
+
+Release sync: NO-OP again. `origin/release/v0.33.0` was still `b0acba0adc` on a fresh
+fetch, 0 behind / 7 ahead, so there was nothing to merge and no release-merge audit.
+
+Verdict PASS-WITH-FOLLOWUPS. Zero behavior defects: the diff really is behavior-neutral.
+Every injected default was traced against the code it replaced and each reproduces the
+original exactly, no await or call order moved, no timer handle stopped being cleared,
+the cadence move is verbatim, and `bot/main.ts`'s three construction sites are
+byte-identical to the base. What the audit found was almost entirely a gap between what
+the phase's docs CLAIMED and what its tests ENFORCED, which is the debt a verification
+foundation exists to remove.
+
+Method: 12 read-only finder agents over the diff with one independent skeptic per
+finding (96 agents, 64 confirmed / 20 refuted), plus `qa-checklist`,
+`privacy-security-review`, and `test-coverage-auditor`, plus a mutation pass in an
+ISOLATED worktree at the phase tip with its own `npm ci`. Most of the 20 refutations
+were verify agents racing the fix commits and reading a tree where the finding was
+already closed; none hid a real defect.
+
+Mutation tally, all NEW mutants beyond Phase 1's 31: 79 planted, 79 resolved, and the
+un-mutated baseline re-run green at the end with the worktree clean. 43 of the first 52
+SURVIVED, which is the real story of this QA round. `bot/gateway.ts` was the worst: 16
+of 18 protocol mutants lived, including the zombie-terminate branch, RESUME versus
+IDENTIFY, and seq tracking. After the fixes every one of those dies against a named
+test.
+
+Four traps are worth carrying forward, because each looked like a passing test:
+
+  - The HELLO heartbeat test asked for `heartbeat_interval: 41250`, which is exactly
+    `heartbeatIntervalMs`'s own fallback default, so a gateway that ignored the payload
+    entirely still produced 41250 and the assertion could not fail.
+  - `rejects.toThrow(string)` is a SUBSTRING match in vitest, so the 200-character
+    truncation pin passed with a 300-character message. An Error argument is equality.
+  - The default-path tests stubbed the global BEFORE constructing, which passes for a
+    capture-form default, and stubbed with a ONE-parameter function, which passes for
+    `(input) => fetch(input)`. That second form type-checks and would strip the auth
+    header off every request. Both are now R16.
+  - The gate.mjs step pin was a bare substring, so commenting the step out kept it
+    green. Now R17.
+
+Also corrected: L3's rationale was false (the seams are OPTIONAL parameters, so `tsc`
+proves nothing about construction-site arity; the conclusion still stands for the
+reason the security review gave), L4 was overclaimed as closed when only the connect
+handshake was covered, and the "six bot files" count was stale within its own commit.
+L5 was closed here instead of deferred. L6 is new and open: `bot/` type-checks against
+lib DOM, so a Node-missing DOM global passes both `tsc` and `build:bot`.
+
+Deferred, with reasons: L1 and L2 (the interaction token and the discord_user_id in log
+lines) stay routed to Phase 2, which rewrites `request()` anyway; the security review
+added that the redaction must live in the THROW in `discord_api.ts`, not in the one
+named catch, because 15 other bare `console.error(e)` handlers would re-open it. L6 is
+a toolchain restructure, routed to Phase 7. The cadence constants remain unpinned
+against `bot/main.ts`'s USE of them (a swap survives): `main.ts` calls `main()` at
+module scope so it cannot be imported, and R6 forbids a source-text pin, so this is a
+ruled-acceptable residual rather than a finding.
+
+Gate: PASS, all 12 steps.

--- a/docs/discord-bot-stability/progress.md
+++ b/docs/discord-bot-stability/progress.md
@@ -209,13 +209,27 @@ handshake was covered, and the "six bot files" count was stale within its own co
 L5 was closed here instead of deferred. L6 is new and open: `bot/` type-checks against
 lib DOM, so a Node-missing DOM global passes both `tsc` and `build:bot`.
 
+A second workflow then reviewed the FIX ROUND, which is unreviewed code, and it earned
+its keep: the round had broken the very rule it had just written into `bot/CLAUDE.md`.
+Two new default-path tests installed the fake clock BEFORE constructing, the ordering
+R16 exists to forbid, so a capture-form default would have passed them. The sleep test
+also awaited its pending promise before asserting, and awaiting waits out a REAL timer,
+so a captured `setTimeout` still settled and passed. Both are fixed and both mutants now
+die. R17 had the same shape of problem: it was minted and then applied to only one of
+six `scripts/gate.mjs` pins, so the rest still matched the raw source.
+
 Deferred, with reasons: L1 and L2 (the interaction token and the discord_user_id in log
 lines) stay routed to Phase 2, which rewrites `request()` anyway; the security review
 added that the redaction must live in the THROW in `discord_api.ts`, not in the one
 named catch, because 15 other bare `console.error(e)` handlers would re-open it. L6 is
-a toolchain restructure, routed to Phase 7. The cadence constants remain unpinned
-against `bot/main.ts`'s USE of them (a swap survives): `main.ts` calls `main()` at
-module scope so it cannot be imported, and R6 forbids a source-text pin, so this is a
-ruled-acceptable residual rather than a finding.
+a toolchain restructure, routed to Phase 7. L7 is a genuine gateway behavior defect (a
+non-resumable INVALID_SESSION never clears `sessionId`, so a close before the next READY
+RESUMEs a session Discord already declared dead); fixing it changes runtime behavior,
+which this phase forbids, so it is ledgered for Phase 3 or 7. L8 records that
+`bot/main.ts`'s two pure helpers are unreachable from any test.
+
+The cadence constants remain unpinned against `bot/main.ts`'s USE of them (a swap
+survives): `main.ts` calls `main()` at module scope so it cannot be imported, and R6
+forbids a source-text pin, so this is a ruled-acceptable residual rather than a finding.
 
 Gate: PASS, all 12 steps.

--- a/docs/discord-bot-stability/progress.md
+++ b/docs/discord-bot-stability/progress.md
@@ -4,7 +4,7 @@
 
 | Phase | Status | Started | Completed |
 |---|---|---|---|
-| Phase 1: Bot verification foundation | not started | | |
+| Phase 1: Bot verification foundation | built | 2026-07-30 | 2026-07-30 |
 | Phase 1 QA | not started | | |
 | Phase 2: Discord rate-limit governor | not started | | |
 | Phase 2 QA | not started | | |
@@ -26,11 +26,12 @@
 ## Deliverable checklists
 
 ### Phase 1
-- [ ] `bot` in tsconfig include, latent type errors fixed behavior-preserving
-- [ ] `build:bot` in `scripts/gate.mjs`
-- [ ] Injectable fetch/socket/clock seams in `discord_api.ts`, `server_client.ts`, `gateway.ts`
-- [ ] Cadence constants extracted into `bot/cadence.ts` as a pure move (R6)
-- [ ] Baseline tests: config arms, server_client envelope/secret/timeout, cadence pins via the module
+- [x] `bot` in tsconfig include, latent type errors fixed behavior-preserving
+      (the include surfaced none; all six bot files are in the checked set)
+- [x] `build:bot` in `scripts/gate.mjs` (and in both CI jobs that build the server, R7)
+- [x] Injectable fetch/socket/clock seams in `discord_api.ts`, `server_client.ts`, `gateway.ts`
+- [x] Cadence constants extracted into `bot/cadence.ts` as a pure move (R6)
+- [x] Baseline tests: config arms, server_client envelope/secret/timeout, cadence pins via the module
 
 ### Phase 2
 - [ ] `bot/rate_governor.ts` pure module (buckets, proactive gating, global pause, breaker, forbidden cache, counters)
@@ -84,4 +85,58 @@
 
 ## Per-phase notes
 
-(fill in after each session)
+### Phase 1 (2026-07-30)
+
+The tsconfig include surfaced ZERO latent type errors, so the "fix the errors the
+include surfaces" commit collapsed into the include itself. The include was proven
+live two ways rather than assumed: `tsc --noEmit --listFiles` lists all six bot files
+including `bot/main.ts`, and a deliberate type error added to `bot/main.ts` failed the
+check before being reverted.
+
+The bot build had fallout the plan did not name: `tests/ci_workflow.test.ts` pins the
+release-gate structure by count, so adding a step moved the single-shard condition
+count from 8 to 9 and the release-gate step count from 12 to 13. Both new pins were
+mutation-checked (dropping either new CI step turns the suite red).
+
+Seam shapes chosen, all trailing parameters with production defaults so every
+existing call site in `bot/main.ts` is untouched: `DiscordApi(token, fetchImpl, sleep)`,
+`ServerClient(baseUrl, secret, fetchImpl, timers)`, and
+`Gateway(token, gatewayUrl, handlers, socketFactory, timers)`. The Gateway socket
+factory returns `ws`'s own `WebSocket` type deliberately, because widening it to a
+structural interface would strip the contextual parameter types off the
+`on('message'|'close'|'error', ...)` callbacks and put `WebSocket.OPEN` out of reach.
+
+Verification: 98 tests green across the seven bot-related suites, and two independent
+mutation rounds killed 31/31.
+
+The review round changed the shape of the phase in three ways worth carrying forward.
+The `qa-checklist` pass found the acceptance criterion "a test asserts the DEFAULT
+path" was met for `ServerClient` only, while `DiscordApi` and `Gateway` had no test
+importing them at all. That is not cosmetic: this phase INTRODUCED the failure mode
+(`request()` used to call the global `fetch` directly and now calls `this.fetchImpl`),
+so a broken default parameter would have shipped silently. Both are now covered, the
+Gateway one by module-mocking `ws`, which also closed the L4 ledger item outright
+rather than deferring it to Phase 3.
+
+Second, the three shells had drifted into two different injection conventions
+(capture-the-global versus forward-to-the-global). They are now uniformly
+forward-to-the-global, which is both fake-timer friendly for Phases 2 and 3 and avoids
+calling a global with the instance as its `this`. Recorded as R15 and in `bot/CLAUDE.md`.
+
+Third, the CI guard was compensable: `build:bot` in `release-gate` was pinned only by
+two counts, so deleting it and adding any other single-shard step kept the suite green.
+It is now also pinned by name, along with the other three builds and the four gate
+steps. The decoy-swap mutation confirms the hole is closed.
+
+The killed mutants: both cadence constants, the `'0'` nickname arm, the `||` default
+fallback, the `!v` required guard, the activity ladder rung, two channel key swaps, the
+secret header name, the 8000 ms deadline, the success-flag check, the `finally`
+clearTimeout, the Content-Type header, the non-ok short circuit, the injected-fetch
+routing, the `Bot` versus `Bearer` prefix, the v10 base, all three retry-clamp bounds,
+the retry-once bound, the User-Agent, both Gateway default-socket arms, the v10/json
+query string, the 4014 fatal-close code, the reconnect delay, the deleted gate step,
+and the count-preserving CI decoy swap.
+
+Worktree note for later phases: this checkout had no `node_modules`, and the main
+checkout's install is stale (TypeScript 5.9.3, no ffmpeg-static). A local `npm ci` in
+the worktree is what gets the real TypeScript 7 native binary and a runnable gate.

--- a/docs/discord-bot-stability/progress.md
+++ b/docs/discord-bot-stability/progress.md
@@ -169,9 +169,11 @@ ISOLATED worktree at the phase tip with its own `npm ci`. Most of the 20 refutat
 were verify agents racing the fix commits and reading a tree where the finding was
 already closed; none hid a real defect.
 
-Mutation tally, all NEW mutants beyond Phase 1's own 31: 70 distinct mutants over 139
-runs (discovery plus re-verification), in an isolated worktree, with the un-mutated
-baseline re-run green at the end and the worktree left clean.
+Mutation tally, all NEW mutants beyond Phase 1's own 31: 162 mutant runs (discovery,
+re-verification after each fix, and the fix round's own pins), in an isolated worktree
+with its own `npm ci`, with the un-mutated baseline re-run green at the end and the
+worktree left clean. Every run proved the patch APPLIED (cmp against a backup) and that
+tests actually RAN, so a silently-unapplied patch could not be scored as a survivor.
 
   - Against the phase as committed: 58 planted, 9 killed, **49 SURVIVED**. That is the
     real story of this round. `bot/gateway.ts` was the worst, 16 of 18 protocol mutants

--- a/docs/discord-bot-stability/progress.md
+++ b/docs/discord-bot-stability/progress.md
@@ -169,12 +169,24 @@ ISOLATED worktree at the phase tip with its own `npm ci`. Most of the 20 refutat
 were verify agents racing the fix commits and reading a tree where the finding was
 already closed; none hid a real defect.
 
-Mutation tally, all NEW mutants beyond Phase 1's 31: 79 planted, 79 resolved, and the
-un-mutated baseline re-run green at the end with the worktree clean. 43 of the first 52
-SURVIVED, which is the real story of this QA round. `bot/gateway.ts` was the worst: 16
-of 18 protocol mutants lived, including the zombie-terminate branch, RESUME versus
-IDENTIFY, and seq tracking. After the fixes every one of those dies against a named
-test.
+Mutation tally, all NEW mutants beyond Phase 1's own 31: 70 distinct mutants over 139
+runs (discovery plus re-verification), in an isolated worktree, with the un-mutated
+baseline re-run green at the end and the worktree left clean.
+
+  - Against the phase as committed: 58 planted, 9 killed, **49 SURVIVED**. That is the
+    real story of this round. `bot/gateway.ts` was the worst, 16 of 18 protocol mutants
+    alive, including the zombie-terminate branch, RESUME versus IDENTIFY, and seq
+    tracking.
+  - After the fixes: 46 of those 49 die against a named test.
+  - The fix round's own new pins were then mutated in turn: 12 more mutants, all killed.
+
+Three survivors are deliberate and must not be "fixed":
+  - `M01`/`M02`, swapping which cadence constant a `bot/main.ts` loop uses. `main.ts`
+    calls `main()` at module scope so it cannot be imported, and R6 forbids a source-text
+    pin. Ruled-acceptable residual.
+  - `S05`, deleting the `body === undefined ? undefined :` ternary in `ServerClient.call`.
+    `JSON.stringify(undefined)` IS `undefined`, so the guard is a semantic no-op and no
+    assertion can distinguish it. The test comment was corrected instead of the test.
 
 Four traps are worth carrying forward, because each looked like a passing test:
 

--- a/docs/discord-bot-stability/qa-checklist.md
+++ b/docs/discord-bot-stability/qa-checklist.md
@@ -1,0 +1,46 @@
+# Whole-feature QA matrix (run at Phase 9 QA, packet close)
+
+This packet touches `bot/`, `server/`, deploy assets, and one public route. It must NOT
+touch `src/sim/`, `src/world_api*`, `src/net/`, `src/ui/`, `src/render/`, or the wire
+protocol; the first check is that it did not.
+
+- **Scope containment**: `git diff --name-only release/v0.33.0...HEAD` contains no
+  `src/` path except (possibly) none at all; no wire/snapshot suite changed behavior.
+- **Discord contract**: the governor provably never dispatches at `Remaining == 0`,
+  honors full `retry_after` on all three scopes, hard-pauses on the HTML-body 429, and
+  the breaker opens far below Discord's 10,000/10min line (D3). No hard-coded per-route
+  numbers anywhere (O2). `/api/v10` pinned; valid User-Agent; scope logged on every 429.
+- **Diff-before-write**: a steady-state sweep at the D18 envelope (1,000 players /
+  5,000 members, nothing changing) performs ZERO Discord writes and ZERO members-meta
+  row updates. The echo loop (PATCH -> GUILD_MEMBER_UPDATE -> members-meta POST) is
+  demonstrably closed.
+- **Load profile**: steady-state internal traffic is one outbox poll cadence (~20/min
+  active, less idle) plus presence; no per-user flex GETs remain; established
+  connections to :8787 at steady state are a small handful. The empty outbox drain is
+  zero Postgres queries.
+- **Dual-arm parity**: every behavior edit to an existing internal route landed on both
+  the RouteDef and the legacy arm, or carries a ledgered deviation (D9); the http spine
+  (surface_inventory, parity, completeness, ownership_coverage) is green.
+- **Server authority + security**: the bot still never computes rewards; new endpoints
+  sit behind `requireInternalSecret` with clamped inputs; Caddy 404s `/internal/*`; no
+  secret is committed; parameterized SQL only.
+- **Supervision**: a fatal gateway close exits the process nonzero; the compose
+  healthcheck fails on a stale heartbeat; `restart: unless-stopped` + healthcheck +
+  limits pinned by `tests/deploy_discord_bot.test.ts`.
+- **Persistence**: no DDL beyond the `reward_ledger` comment; `discord_links` upsert is
+  idempotent and back-compatible; retention rules satisfied (D12).
+- **Copy rules**: no em dashes, en dashes, or emojis anywhere in the diff (code,
+  comments, docs, commits, Discord-facing strings); no new player-visible game-client
+  strings (if any exist, full i18n treatment applies).
+- **Tests**: every new module has decisive tests; mutation tallies recorded per QA
+  phase; the `discord_relay`/`discord_activity` name-collision trap documented where a
+  future reader will hit it; cadence constants pinned.
+- **Observability**: counters visible as prom lines; staleness zeroing works; the two
+  alert signals (breaker opens, 429 rate) documented in DEPLOY.md.
+- **Build gate**: `npm run gate` green in the worktree, including `build:bot`.
+- **Docs**: DEPLOY.md bot section complete (env keys, health verification, runbook);
+  follow-up issues from brainstorm.md "out of scope" actually filed; OPEN items O4/O5
+  surfaced to the user in the final report.
+- **Deploy verification** (after the user's manual rollout, not part of the packet):
+  `curl -s localhost:8787/api/status` ok; bot 429 count near zero over 24h; Grafana
+  internal-request panel roughly halved; O5 scope question answered from logs.

--- a/docs/discord-bot-stability/state.md
+++ b/docs/discord-bot-stability/state.md
@@ -149,8 +149,9 @@ vi.mock module fakes + `runRoute`; `tests/discord_db.test.ts` `makePool` fake, w
 `tests/discord_relay.test.ts` covers `src/sim/discord_relay.ts`, NOT the server module
 of the same name.
 
-Config: `tsconfig.json` (`include` carries `bot` as of Phase 1, so all six bot files
-are type-checked and every construction site's arity is compiler-enforced),
+Config: `tsconfig.json` (`include` carries `bot` as of Phase 1, so all SEVEN bot files
+are type-checked, `bot/main.ts` among them; pinned by `tests/deploy_discord_bot.test.ts`
+because dropping the one word is otherwise silent),
 `scripts/gate.mjs` (the `steps` list, which now carries the `bot build` step).
 
 ## Created by this packet (update per phase)
@@ -250,6 +251,20 @@ are type-checked and every construction site's arity is compiler-enforced),
   and the global is never invoked with the instance as its `this`, which is harmless on
   Node today but is a real trap on any other host. New shells follow this. Recorded in
   `bot/CLAUDE.md`.
+- R16 (settled in Phase 1 QA): a default-path test must construct the shell BEFORE
+  stubbing the global, and must observe EVERY argument the default forwards. Both halves
+  are load-bearing and neither is obvious. Stub-then-construct passes for a capture-form
+  default (`= fetch`), so it cannot guard R15 at all. A one-parameter stub passes for
+  `(input) => fetch(input)`, which type-checks because TypeScript accepts an
+  arity-reduced function where a wider signature is expected, and which would strip the
+  auth header off every request in production. Adding `bot` to the tsconfig include does
+  NOT catch either one.
+- R17 (settled in Phase 1 QA): a source-text pin over `scripts/gate.mjs` or
+  `.github/workflows/ci.yml` must be matched against a COMMENT-STRIPPED source and be
+  either line-anchored or name-to-run adjacent. A bare `toContain` is satisfied by the
+  step commented out, by `|| true`, by `continue-on-error`, and by an `if:` slipped
+  between the name and the run line. Keep the whitespace in such a pin tolerant so a
+  biome re-wrap does not red it falsely.
 
 ## OPEN items
 
@@ -275,26 +290,40 @@ route each to a phase or file it.
   which for `flex()` and `roles()` carries `?discord_user_id=<id>`. Low sensitivity
   (a Discord id is pseudonymous and guild-visible) but it is user-identifying data in
   an operator log. Pre-existing.
-- L3 RESOLVED, do not add the pin. The concern was that nothing stops a future call site
-  from passing a wrapping `fetchImpl` that observes the bot token or the shared secret.
-  Ruling: `tsc` now proves the arity of every construction site (that is what adding
-  `bot` to the include bought), which is a stronger guard than a source-text scan and
-  costs nothing, and a text pin would carry the documented source-scrape traps. No pin.
-- L4 CLOSED by Phase 1. `tests/discord_bot_gateway.test.ts` module-mocks `ws` and covers
-  both directions: the DEFAULT factory constructs the real `ws` client at
-  `/?v=10&encoding=json`, and an injected factory is used instead of it. It also
-  exercises HELLO to IDENTIFY, the heartbeat interval, and the fatal-versus-normal close
-  branch. Phases 3 and 7 extend it rather than starting from nothing.
-- L5 (coverage gap, Phase 5 territory): two `bot/server_client.ts` contracts are still
-  unpinned. `flairedIds()` distinguishes null (meaning "change nothing", per its own doc
-  comment) from an empty array, and its `typeof x === 'string'` filter is untested;
-  `pushMembersMeta()` has an untested zero-updated silent-drop warning branch. Both were
-  outside Phase 1's assigned arm list. Phase 5 touches both, so pin them there.
+- L3 RESOLVED (conclusion stands, RATIONALE CORRECTED in Phase 1 QA). Do not add the pin.
+  The concern was that nothing stops a future call site from passing a wrapping
+  `fetchImpl` that observes the bot token or the shared secret. The original rationale
+  said `tsc` "proves the arity of every construction site". **That is false and must not
+  be reasoned from:** the seams are OPTIONAL trailing parameters, so `tsc` accepts two,
+  three, or four arguments equally (the suite itself constructs with all of them). The
+  real reason no pin is needed is the one the security review gave: passing a wrapping
+  `fetchImpl` requires editing `bot/main.ts`, which is code-execution the attacker
+  already has, so this is not a privilege boundary. A text pin would also carry the
+  documented source-scrape traps. No pin.
+- L4 CLOSED, genuinely, as of Phase 1 QA. Phase 1's own claim ("closed outright") was
+  overstated: the file covered the CONNECT handshake only, and 16 of 18 gateway protocol
+  mutants survived it. `tests/discord_bot_gateway.test.ts` now also pins seq tracking,
+  the heartbeat tick including the zombie-terminate and ACK arms, stopHeartbeat on close,
+  RESUME versus IDENTIFY with the session and resume-URL capture, all six fatal close
+  codes plus five reconnecting ones with the reconnect actually fired, INVALID_SESSION
+  both arms, op 7, the send readyState guard, op 8, and the dispatch and parse catches.
+  20 of 20 gateway mutants now die. Phases 3 and 7 extend it.
+- L5 CLOSED by Phase 1 QA rather than deferred to Phase 5: both halves were a few lines.
+  `flairedIds()` has all three arms (the `typeof x === 'string'` filter, a genuinely
+  empty array, and null for an unreachable server or a malformed payload), and
+  `pushMembersMeta()`'s zero-updated warning is pinned on both sides of its non-empty
+  guard. Phase 5 inherits the pins instead of writing them.
+- L6 (nice-to-have, toolchain, OPEN): `bot/` type-checks against the shared tsconfig,
+  whose `lib` is `["ES2022","DOM","DOM.Iterable"]` with `types: ["vite/client","node"]`.
+  A Node-missing DOM global therefore passes BOTH `tsc` and `build:bot` (esbuild does not
+  typecheck) and only fails at runtime in the container. A bot-specific tsconfig would
+  close it; that is a toolchain restructure, not a QA-round edit. Natural home is Phase 7,
+  which already owns the bot's deploy hardening.
 
 ## Known gotchas for implementers
 
-- Only `bot/logic.ts` is currently type-checked; expect latent type errors in the other
-  five bot files when Phase 1 adds `bot` to tsconfig.
+- RESOLVED by Phase 1: all seven bot files are type-checked. The include surfaced ZERO
+  latent type errors, so there were none to fix. Do not plan around the old warning.
 - The bot reuses the `eastbrook-game` image (compose `discord` profile), so bot and
   server always deploy in lockstep; wire-format changes between them need no
   cross-version compatibility story.

--- a/docs/discord-bot-stability/state.md
+++ b/docs/discord-bot-stability/state.md
@@ -83,6 +83,25 @@ Current phase: Phase 1 built (2026-07-30), QA session next.
 - Shared-worktree care: commit with EXPLICIT paths, never `git add -A`.
 - WS `maxPayload` 16 KiB is not widened; the game wire protocol is not touched.
 
+## Every phase starts here (standing rules, set by the user 2026-07-30)
+
+1. **Sync the release base FIRST.** `git fetch origin release/v0.33.0`, then
+   `git rev-list --left-right --count HEAD...origin/release/v0.33.0`. If behind, merge
+   the release branch into `feature/discord-bot-stability` BEFORE doing the phase's
+   work, so each phase eats one small conflict set instead of handing a huge one to a
+   later phase. Compare against the FRESHLY fetched tip, not a stale tracking ref.
+   After any non-empty merge, run the `release-merge-audit` skill and re-run the gate
+   (a gate that was green before a merge says nothing about the merged result). Record
+   the sync in progress.md, including "no-op, already current".
+2. **Install what the toolchain needs.** A fresh worktree has no `node_modules`, and
+   the main checkout's install is stale (TypeScript 5.9.3, no ffmpeg-static). Run
+   `npm ci` in THIS worktree; do not degrade the verification to avoid it. This does
+   NOT relax D7: no new packages.
+3. **Apply EVERY review finding**, blocking, should-fix, nice-to-have, and nit alike,
+   before the phase is called done. If a finding is genuinely not a defect, say so and
+   why; do not silently drop it. The fix round is itself unreviewed code, so
+   mutation-check the tests it adds too.
+
 ## Validation matrix
 
 - bot-only change: `npx tsc --noEmit` + `npx vitest run tests/discord_bot.test.ts` plus

--- a/docs/discord-bot-stability/state.md
+++ b/docs/discord-bot-stability/state.md
@@ -1,0 +1,219 @@
+# State: Discord Bot Stability (cross-phase cheat sheet)
+
+Current phase: Phase 1 not started.
+
+## Locked decisions
+
+- D1 Transport: one consolidated `GET /internal/discord/outbox` poll draining relay,
+  activity, daily-reward winners, and linked-member changes in a single response.
+  Adaptive cadence: 3s while the previous drain returned items, decaying to 15s idle.
+  No long-poll, no bot WebSocket.
+- D2 Governor: a pure, tested module owning ALL Discord REST dispatch. Bucket-keyed
+  serialized queues remapped onto `X-RateLimit-Bucket` hashes; proactive gating (never
+  dispatch at `Remaining == 0`, wait `Reset-After`); process-wide pause on any
+  global-scope 429 honoring the FULL `retry_after` (no ceiling); a non-JSON 429 body is
+  treated as a Cloudflare ban: global pause of `DISCORD_BAN_PAUSE_MS` (default 600000)
+  and an error log. Target send rate `DISCORD_MAX_RPS` default 8 (limit is 50).
+- D3 Circuit breaker: rolling 10-minute window counting local 401/403/429 (excluding
+  scope `shared`); at `DISCORD_BREAKER_LIMIT` (default 300, vs Discord's 10,000 ban
+  threshold) all sweeps and non-essential writes stop; half-open probe after a full
+  quiet window.
+- D4 Permanent-failure cache: a 401/403 for a member is never retried until the bot's
+  own role position changes or `DISCORD_FORBIDDEN_TTL_MS` (default 24h) expires.
+- D5 Diff-before-write is universal: nickname PATCH only when the computed nick differs
+  from the gateway-cached member nick; members-meta pushed only for members whose meta
+  changed since last successful push; self-caused `GUILD_MEMBER_UPDATE` echoes
+  suppressed (compare incoming state to what we just wrote).
+- D6 Sweep iterates linked members only, discovered via `flex-batch` and maintained by
+  the outbox change feed; never the whole online-Discord-user set.
+- D7 Zero new npm dependencies (bot/CLAUDE.md stands). No discord.js, no rate-limiter
+  package. Connection bounding comes from app-level serialization (governor queues +
+  scheduler overlap guards) over default keep-alive fetch; a hand-rolled node:http
+  agent wrapper only if measurements force it (escalate to the user first).
+- D8 Pure/IO split stands: governor and scheduler are DOM-free pure modules with Vitest
+  coverage; `discord_api.ts` and `server_client.ts` stay thin IO shells; wiring only in
+  `main.ts`.
+- D9 New server endpoints (`flex-batch`, `outbox`) are RouteDef-only (no legacy twins),
+  behind `requireInternalSecret`, with HAND-ADDED rows in
+  `tests/server/http/surface_inventory.ts`. Behavior edits to EXISTING internal routes
+  (members-meta, presence) land on BOTH the RouteDef and the frozen legacy
+  `handleDiscordInternal` arm in the same change, or get a ledgered deviation in
+  `tests/server/http/known_deviations.ts`.
+- D10 members-meta becomes ONE multi-row upsert (unnest arrays) skipping unchanged rows
+  (`IS DISTINCT FROM`); the 1000-member server cap and 200-member bot batch stand.
+- D11 Existing per-endpoint GET routes (relay, activity, winners, flex) stay in place;
+  the bot stops calling them; retirement is a post-ladder-deletion follow-up issue.
+- D12 `reward_ledger` gets an explicit keep-forever comment at its DDL (audit ledger),
+  satisfying the retention rule without a prune.
+- D13 Cadences and thresholds are env-configurable with safe defaults; the operator
+  incident lever the bot currently lacks. All new env keys documented in DEPLOY.md.
+- D14 Discord REST base pinned to `/api/v10`; valid `User-Agent` kept;
+  `X-Audit-Log-Reason` sent on member PATCHes; `X-RateLimit-Scope` logged from day one.
+- D15 Deploy hardening: bot service gets healthcheck (heartbeat file + compose test),
+  `mem_limit`, `stop_grace_period`; fatal gateway close exits the process (nonzero) so
+  `restart: unless-stopped` acts; Caddy 404s `/internal/*` alongside `/metrics`.
+- D16 Observability: bot counters (requests, 429s by scope, breaker state and opens,
+  queue depths, sweep durations, outbox drain sizes) piggyback on the existing presence
+  POST (both arms per D9), held in server memory, exposed as prom lines on the existing
+  metrics path. No new tables.
+- D17 `/api/discord`: per-account short-TTL cached read via the `createCachedRead` seam
+  with moderation busts wired in the same change; presence block stays as is.
+- D18 Scale envelope for design and assertions: 1,000 concurrent players, 5,000 guild
+  members (10x today). Query-count and payload assertions pin against fixtures at this
+  scale where practical.
+- D19 QA rigor: EVERY phase's QA session runs ultracode (adversarial-verify workflow)
+  plus mutation spot checks on that phase's new pure modules. Consult the memory
+  test-pin trap index before writing or mutation-checking any pin.
+- D20 Interim prod: left as is by explicit user decision (2026-07-30). No hotfix
+  branch, no container stop. Do not re-raise.
+
+## Non-negotiable constraints
+
+- `src/sim/` is untouched by this packet. No IWorld, wire-protocol, or renderer surface
+  is involved; if a phase finds itself editing `src/`, stop and re-read the phase file.
+- Server authority stands: the bot never computes rewards; the server validates grants
+  via dedupe keys.
+- Secrets are env only; `DISCORD_BOT_SECRET` must match server and bot; never commit env.
+- Discord-facing copy is English by existing convention, but repo copy rules still
+  apply: no em dashes, no en dashes, no emojis in any new string, comment, doc, or
+  commit. No player-visible game-client strings are added by this packet (if one
+  appears, it needs the full i18n treatment per root CLAUDE.md).
+- Handlers are req/res-free `(ctx) => Awaitable<unknown>`; SQL lives only in `db.ts` /
+  `*_db.ts`; errors are stable codes from the append-only `error_codes.ts`.
+- Shared-worktree care: commit with EXPLICIT paths, never `git add -A`.
+- WS `maxPayload` 16 KiB is not widened; the game wire protocol is not touched.
+
+## Validation matrix
+
+- bot-only change: `npx tsc --noEmit` + `npx vitest run tests/discord_bot.test.ts` plus
+  the phase's new bot test files + `npm run build:bot`.
+- server-only change: `npx tsc --noEmit` + `npx vitest run tests/server/internal.test.ts
+  tests/discord_server.test.ts tests/server/discord.test.ts tests/discord_db.test.ts` +
+  the http spine (`npx vitest run tests/server/http/parity.test.ts
+  tests/server/http/completeness.test.ts tests/server/http/ownership_coverage.test.ts`)
+  + `npm run build:server`.
+- deploy-asset change: `npx vitest run tests/deploy_discord_bot.test.ts`.
+- any code change: `npm run ci:changed` (Biome, changed files only; scoped `--write` for
+  fixes, never whole-tree).
+- pre-merge / phase close: `npm run gate` (exit-code-safe; never an ad-hoc chain).
+- Full `npm test` runs go through a Monitor with bounded workers (memory:
+  full-npm-test-contention-flakes).
+
+## Key file paths
+
+Bot: `bot/main.ts` (wiring, intervals at :518-537, sync at :203-251, dispatch at
+:254-390), `bot/logic.ts` (pure), `bot/discord_api.ts` (REST shell, request() :11-38),
+`bot/server_client.ts` (game API shell, call() :32-57), `bot/gateway.ts` (ws shell,
+fatal closes :135-142), `bot/config.ts`. Build: `scripts/build_bot.mjs` ->
+`dist-bot/bot.cjs`; `package.json:80`.
+
+Server: `server/internal.ts` (RouteDef table :329-549, FROZEN legacy twins :75-241),
+`server/discord.ts` (flex :950, status payload :798, presence cache :185),
+`server/discord_db.ts` (accountForDiscord :134, setDiscordMemberMeta :590,
+reward_ledger DDL :86-95), `server/discord_relay.ts` (cap 50),
+`server/discord_activity.ts` (cap 100, 30s dedupe), `server/db.ts`
+(highestCharacterForAccount :2669), `server/http/middleware/require_internal_secret.ts`,
+`server/http/registry.ts` (:33, :123), `server/main.ts` (retention :3080-3087,
+GameStateSource :3008-3022), `server/reports.ts` (site-presence :285).
+
+Deploy: `docker-compose.yml` (bot service :201-224, game healthcheck exemplar
+:171-199), `deploy/user-data.sh` (Caddy 404 block :84-92), `Dockerfile` (:11, :29,
+:37), `DEPLOY.md`, `deploy/game_watchdog.sh`.
+
+Tests: `tests/discord_bot.test.ts` (logic only today), `tests/server/internal.test.ts`,
+`tests/server/http/{surface_inventory,parity,completeness,ownership_coverage,
+known_deviations}.ts`, `tests/deploy_discord_bot.test.ts`, `tests/server/helpers/`. Test rigs per ruling R1
+below: reuse the rig the matching suite already uses (`tests/server/internal.test.ts`
+vi.mock module fakes + `runRoute`; `tests/discord_db.test.ts` `makePool` fake, whose
+`calls` array is the sanctioned statement counter); never invent a raw pg mock. Trap:
+`tests/discord_relay.test.ts` covers `src/sim/discord_relay.ts`, NOT the server module
+of the same name.
+
+Config: `tsconfig.json` (`include` lacks `bot` until Phase 1), `scripts/gate.mjs`
+(steps :56-74).
+
+## Created by this packet (update per phase)
+
+- Phase 1: (pending)
+- New env keys: (pending)
+- New endpoints: (pending; planned `POST /internal/discord/flex-batch`,
+  `GET /internal/discord/outbox`)
+- New modules: (pending; planned governor, scheduler, change feed)
+- New tests: (pending)
+
+## Rulings settled during authoring (2026-07-30)
+
+- R1 Test rigs: reuse the rig the matching suite already uses; never invent a raw pg
+  mock. `tests/server/internal.test.ts` drives routes via its vi.mock module fakes and
+  `runRoute` helper; `tests/discord_db.test.ts` uses the hand-rolled `makePool` fake
+  with a `calls` array, and that `calls` array is the sanctioned way to count SQL
+  statements for query-count pins. The earlier "FakeDb + fakeCtx" phrasing in this file
+  is superseded by this ruling.
+- R2 (extends D1): Phase 5 wraps the winners lookup (`unannouncedWinnerDays`) in a
+  short TTL cache (30 to 60s) busted at day finalization, so a warm empty outbox drain
+  is fully query-free. The zero-query pin covers the in-memory streams unconditionally
+  and the winners stream on a warm cache. This cache is Phase 5 scope; Phase 9 owns
+  only the public `/api/discord` route.
+- R3: Phase 4 MAY add batched set-based variants of per-account reads
+  (`highestCharacterForAccount` and friends) in `db.ts`/`*_db.ts` for flex-batch,
+  keeping the per-account originals for existing callers. That is the point of the
+  phase, not scope creep.
+- R4: New RouteDef-only routes anchor their `surface_inventory.ts` rows on the RouteDef
+  symbol/route string (the post-migration scaffold precedent), never by adding a legacy
+  twin (D9 forbids it).
+- R5: QA prompts keep the template's STEP numbering (STEP 5 exists only in the final
+  phase's QA); non-final QA files jump STEP 4 to STEP 6 by design.
+- R6: The three cadence constants move OUT of `bot/main.ts` in Phase 1 via a
+  behavior-preserving extraction into a small module (`bot/cadence.ts`) that `main.ts`
+  imports and tests import directly. No source-text pins for them. This also seeds
+  Phase 3's D13 env-overridable cadences, which layer env parsing over the same module.
+- R7: `build:bot` mirrors into every CI job that builds the server (the gate.mjs header
+  demands step-list sync with `.github/workflows/ci.yml`). Editing a CI yml makes the
+  `privacy-security-review` matrix row match for Phase 1; dispatch it.
+- R8: Phase 2 adds its four new env keys to the existing commented Discord block in
+  `.env.example` in the same change that introduces them; the full operator
+  documentation still lands in DEPLOY.md in Phase 7 (D13 unchanged).
+- R9: The pre-existing em dash in the `bot/gateway.ts` FATAL_CLOSE_CODES comment is
+  fixed as a one-character copy fix inside Phase 1 (the phase touches that file for the
+  socket seam and the Stop hook would otherwise block the diff). Scoped to that one
+  comment; QA must not flag it as scope creep. Phase 7 need not act on it.
+- R10 (D17 reading, confirmed): Phase 9 caches only the database-backed part of the
+  `/api/discord` payload; `discordPresenceCache()` is composed fresh per request so
+  presence is never frozen behind the payload TTL. Both routes (RouteDef
+  `server/discord.ts:1382` and legacy arm `server/main.ts:2229`) funnel through
+  `discordStatusPayload`, so parity holds by construction; verify, do not fork it.
+- R11: `createCachedRead` is single-value; Phase 9 builds a NEW small keyed cached-read
+  sibling module with a hard entry bound and eviction (an unbounded per-account map is
+  the exact growth defect server/CLAUDE.md forbids). Sanctioned scope with its own
+  acceptance item and mutant.
+- R12: Phase 7 owns ALL fallout of the Caddy change: the occurrence-count pins in
+  `tests/deploy_watchdog.test.ts` (:136-137, :146-147) and every DEPLOY.md restatement
+  of the ops-path claim, including the line that currently says the edge does NOT hide
+  `/internal/*`. Leaving the branch red or the docs wrong is not an option.
+- R13: Exit-on-fatal-close stands even though an unrecoverable cause (bad token, bad
+  intents) crash-loops under `restart: unless-stopped`: a visible crash-loop with
+  Docker's backoff is the desired behavior over today's silent zombie. No retry
+  limiter, no supervisor. The Counter-versus-Gauge shape for pushed bot counters is
+  DELIBERATELY delegated to the Phase 8 runner (pick, justify, record here).
+
+## OPEN items
+
+See brainstorm.md O1 to O7. O4 (Developer Portal intent toggles) needs the user.
+O5 (member-write 429 scope) resolves from logs after first prod deploy.
+
+## Known gotchas for implementers
+
+- Only `bot/logic.ts` is currently type-checked; expect latent type errors in the other
+  five bot files when Phase 1 adds `bot` to tsconfig.
+- The bot reuses the `eastbrook-game` image (compose `discord` profile), so bot and
+  server always deploy in lockstep; wire-format changes between them need no
+  cross-version compatibility story.
+- An empty relay/activity drain costs zero Postgres queries (in-memory splice); the
+  expense is the HTTP request itself plus N+1 `discordForAccount` lookups when items
+  DO exist. The outbox batches those into one IN query.
+- `GUILD_CREATE` fires on every re-IDENTIFY and today triggers a full sweep; the
+  scheduler must coalesce, or a reconnect storm multiplies sweeps.
+- The game server's keep-alive window is 5s (`server/http/server_timeouts.ts`); a 3s
+  poller reuses its connection, the 5-minute loops never do.
+- Fake timers vs captured clocks: see memory entries cachedread-captured-clock-vs-fake-
+  timers and settimeout-fractional-delay-fires-early before testing scheduler timing.

--- a/docs/discord-bot-stability/state.md
+++ b/docs/discord-bot-stability/state.md
@@ -1,6 +1,6 @@
 # State: Discord Bot Stability (cross-phase cheat sheet)
 
-Current phase: Phase 1 built (2026-07-30), QA session next.
+Current phase: Phase 1 built AND QA'd (2026-07-30). Next: Phase 2, the rate-limit governor.
 
 ## Locked decisions
 
@@ -170,14 +170,19 @@ because dropping the one word is otherwise silent),
   `tests/discord_bot_server_client.test.ts` (call envelope, secret header, deadline,
   production-default path), `tests/discord_bot_discord_api.test.ts` (auth headers, the
   v10 base, the 429 retry clamps and the retry-once bound, production-default path),
-  `tests/discord_bot_gateway.test.ts` (module-mocks `ws`; default socket factory,
-  injected factory, HELLO to IDENTIFY, fatal-versus-normal close).
-  `tests/discord_bot.test.ts` stays pure-logic only.
+  `tests/discord_bot_gateway.test.ts` (module-mocks `ws`; both defaults, the injected
+  factory, the whole opcode surface, the heartbeat tick with its zombie-terminate and ACK
+  arms, RESUME versus IDENTIFY, and every fatal close code).
+  `tests/discord_bot.test.ts` stays pure-logic only. The Phase 1 QA round widened all four
+  well past the arm lists above; treat the files, not this summary, as the inventory.
 - New exported constant: `SERVER_CALL_TIMEOUT_MS` (8000) in `bot/server_client.ts`,
   named so the suite can pin the deadline against a literal.
 - Touched pins: `tests/ci_workflow.test.ts` structural counts (release-gate
   single-shard conditions 8 to 9, release-gate steps 12 to 13) plus the pr-checks
-  build-step coverage loop.
+  build-step coverage loop. Phase 1 QA then rewrote that file's gate and CI pins per
+  R17 (comment-stripped source, line and adjacency anchors, a pr-checks step count, and
+  a workflow trust-posture test) and extended `tests/deploy_discord_bot.test.ts` with the
+  bot build and typecheck surface.
 
 ## Rulings settled during authoring (2026-07-30)
 
@@ -294,14 +299,17 @@ route each to a phase or file it.
   The concern was that nothing stops a future call site from passing a wrapping
   `fetchImpl` that observes the bot token or the shared secret. The original rationale
   said `tsc` "proves the arity of every construction site". **That is false and must not
-  be reasoned from:** the seams are OPTIONAL trailing parameters, so `tsc` accepts two,
-  three, or four arguments equally (the suite itself constructs with all of them). The
+  be reasoned from:** the seams are OPTIONAL trailing parameters, so `tsc` accepts the
+  leading arguments alone or any prefix of the seams as well (2 to 4 for `DiscordApi` and
+  `ServerClient`, 3 to 5 for `Gateway`), and the suite itself constructs with all of them.
+  Verified with a `tsc` probe under the repo's own compiler options, with a negative
+  control to prove the probe was not vacuous. The
   real reason no pin is needed is the one the security review gave: passing a wrapping
   `fetchImpl` requires editing `bot/main.ts`, which is code-execution the attacker
   already has, so this is not a privilege boundary. A text pin would also carry the
   documented source-scrape traps. No pin.
 - L4 CLOSED, genuinely, as of Phase 1 QA. Phase 1's own claim ("closed outright") was
-  overstated: the file covered the CONNECT handshake only, and 16 of 18 gateway protocol
+  overstated: the file covered the CONNECT handshake only, and 16 of the first 18 gateway
   mutants survived it. `tests/discord_bot_gateway.test.ts` now also pins seq tracking,
   the heartbeat tick including the zombie-terminate and ACK arms, stopHeartbeat on close,
   RESUME versus IDENTIFY with the session and resume-URL capture, all six fatal close
@@ -313,12 +321,29 @@ route each to a phase or file it.
   empty array, and null for an unreachable server or a malformed payload), and
   `pushMembersMeta()`'s zero-updated warning is pinned on both sides of its non-empty
   guard. Phase 5 inherits the pins instead of writing them.
+### Found during Phase 1 QA (2026-07-30), OPEN
+
 - L6 (nice-to-have, toolchain, OPEN): `bot/` type-checks against the shared tsconfig,
   whose `lib` is `["ES2022","DOM","DOM.Iterable"]` with `types: ["vite/client","node"]`.
   A Node-missing DOM global therefore passes BOTH `tsc` and `build:bot` (esbuild does not
   typecheck) and only fails at runtime in the container. A bot-specific tsconfig would
   close it; that is a toolchain restructure, not a QA-round edit. Natural home is Phase 7,
   which already owns the bot's deploy hardening.
+
+- L7 (should-fix, behavior, OPEN): a NON-resumable `INVALID_SESSION` (op 9 with `d:false`)
+  never clears `this.sessionId` in `bot/gateway.ts`; the field is only ever assigned in the
+  READY handler. So after Discord tells the bot its session is dead, a socket close that
+  arrives before the next READY takes `reconnect(true)` to
+  `this.resuming = resume && this.sessionId !== null`, which is still true, and the bot
+  RESUMEs a session it was just told is gone. Discord answers with another
+  INVALID_SESSION, so it self-corrects at the cost of a wasted round trip and a slower
+  recovery during exactly the reconnect storms this packet exists to tame. Fixing it is a
+  RUNTIME BEHAVIOR CHANGE, which Phase 1 forbids, so it is recorded rather than landed.
+  Natural home is Phase 3 (scheduler and reconnect coalescing) or Phase 7 (supervision).
+- L8 (nice-to-have, coverage, OPEN): the two pure helpers at the bottom of `bot/main.ts`
+  are unreachable from any test, because `main.ts` calls `main()` at module scope. If a
+  later phase needs them pinned, extract them into a sibling module first (the same move
+  R6 made for the cadences); do not add a source-text pin.
 
 ## Known gotchas for implementers
 

--- a/docs/discord-bot-stability/state.md
+++ b/docs/discord-bot-stability/state.md
@@ -1,6 +1,6 @@
 # State: Discord Bot Stability (cross-phase cheat sheet)
 
-Current phase: Phase 1 not started.
+Current phase: Phase 1 built (2026-07-30), QA session next.
 
 ## Locked decisions
 
@@ -101,11 +101,12 @@ Current phase: Phase 1 not started.
 
 ## Key file paths
 
-Bot: `bot/main.ts` (wiring, intervals at :518-537, sync at :203-251, dispatch at
-:254-390), `bot/logic.ts` (pure), `bot/discord_api.ts` (REST shell, request() :11-38),
-`bot/server_client.ts` (game API shell, call() :32-57), `bot/gateway.ts` (ws shell,
-fatal closes :135-142), `bot/config.ts`. Build: `scripts/build_bot.mjs` ->
-`dist-bot/bot.cjs`; `package.json:80`.
+Bot: `bot/main.ts` (wiring, the six intervals, sync, dispatch), `bot/cadence.ts` (the
+three poll-loop constants, moved out of `main.ts` by Phase 1 per R6), `bot/logic.ts`
+(pure), `bot/discord_api.ts` (REST shell, one `request()` funnel), `bot/server_client.ts`
+(game API shell, one `call()` funnel), `bot/gateway.ts` (ws shell, fatal closes),
+`bot/config.ts`. Build: `scripts/build_bot.mjs` -> `dist-bot/bot.cjs`; `package.json`
+`build:bot`, in the gate and both CI build jobs since Phase 1.
 
 Server: `server/internal.ts` (RouteDef table :329-549, FROZEN legacy twins :75-241),
 `server/discord.ts` (flex :950, status payload :798, presence cache :185),
@@ -129,17 +130,34 @@ vi.mock module fakes + `runRoute`; `tests/discord_db.test.ts` `makePool` fake, w
 `tests/discord_relay.test.ts` covers `src/sim/discord_relay.ts`, NOT the server module
 of the same name.
 
-Config: `tsconfig.json` (`include` lacks `bot` until Phase 1), `scripts/gate.mjs`
-(steps :56-74).
+Config: `tsconfig.json` (`include` carries `bot` as of Phase 1, so all six bot files
+are type-checked and every construction site's arity is compiler-enforced),
+`scripts/gate.mjs` (the `steps` list, which now carries the `bot build` step).
 
 ## Created by this packet (update per phase)
 
-- Phase 1: (pending)
-- New env keys: (pending)
+- Phase 1: `bot` added to the tsconfig `include` (it surfaced ZERO latent type errors,
+  so no behavior-preserving fixes were needed); `build:bot` added to the gate step list
+  and to both CI jobs that build the server (`pr-checks`, and `release-gate` under
+  `if: matrix.shard == 1`); injected IO seams on all three shells; cadence constants
+  extracted per R6.
+- New env keys: none (Phase 2 adds the first ones).
 - New endpoints: (pending; planned `POST /internal/discord/flex-batch`,
   `GET /internal/discord/outbox`)
-- New modules: (pending; planned governor, scheduler, change feed)
-- New tests: (pending)
+- New modules: `bot/cadence.ts` (the three poll-loop constants, values only).
+  Still planned: governor, scheduler, change feed.
+- New tests: `tests/discord_bot_config.test.ts` (config arms + the cadence pins),
+  `tests/discord_bot_server_client.test.ts` (call envelope, secret header, deadline,
+  production-default path), `tests/discord_bot_discord_api.test.ts` (auth headers, the
+  v10 base, the 429 retry clamps and the retry-once bound, production-default path),
+  `tests/discord_bot_gateway.test.ts` (module-mocks `ws`; default socket factory,
+  injected factory, HELLO to IDENTIFY, fatal-versus-normal close).
+  `tests/discord_bot.test.ts` stays pure-logic only.
+- New exported constant: `SERVER_CALL_TIMEOUT_MS` (8000) in `bot/server_client.ts`,
+  named so the suite can pin the deadline against a literal.
+- Touched pins: `tests/ci_workflow.test.ts` structural counts (release-gate
+  single-shard conditions 8 to 9, release-gate steps 12 to 13) plus the pr-checks
+  build-step coverage loop.
 
 ## Rulings settled during authoring (2026-07-30)
 
@@ -175,8 +193,12 @@ Config: `tsconfig.json` (`include` lacks `bot` until Phase 1), `scripts/gate.mjs
   documentation still lands in DEPLOY.md in Phase 7 (D13 unchanged).
 - R9: The pre-existing em dash in the `bot/gateway.ts` FATAL_CLOSE_CODES comment is
   fixed as a one-character copy fix inside Phase 1 (the phase touches that file for the
-  socket seam and the Stop hook would otherwise block the diff). Scoped to that one
-  comment; QA must not flag it as scope creep. Phase 7 need not act on it.
+  socket seam anyway, and the repo copy rule bans em dashes outright). Scoped to that
+  one comment; QA must not flag it as scope creep. Phase 7 need not act on it.
+  Correction (Phase 1, verified): the original rationale said the Stop hook would have
+  blocked the diff. It would not have. `.claude/hooks/qa-stop.sh` scans ADDED lines
+  only, so an untouched pre-existing comment never trips it. The fix stands on the copy
+  rule alone. Do not reason from the old premise.
 - R10 (D17 reading, confirmed): Phase 9 caches only the database-backed part of the
   `/api/discord` payload; `discordPresenceCache()` is composed fresh per request so
   presence is never frozen behind the payload TTL. Both routes (RouteDef
@@ -195,11 +217,60 @@ Config: `tsconfig.json` (`include` lacks `bot` until Phase 1), `scripts/gate.mjs
   Docker's backoff is the desired behavior over today's silent zombie. No retry
   limiter, no supervisor. The Counter-versus-Gauge shape for pushed bot counters is
   DELIBERATELY delegated to the Phase 8 runner (pick, justify, record here).
+- R14 (settled in Phase 1): naming the previously inline `8000` as the exported
+  `SERVER_CALL_TIMEOUT_MS` is sanctioned, even though acceptance item 6 enumerates only
+  "type annotations, defaulted constructor parameters, comments, the cadence move, and
+  the gateway comment fix". It is value-identical, and a named export is what lets the
+  suite pin the deadline against a literal instead of re-reading the source (the
+  constant-self-comparison trap). Do not re-litigate it in QA.
+- R15 (settled in Phase 1): the three IO shells share ONE injection convention. Every
+  default FORWARDS to the global (`(...args) => fetch(...args)`, `(cb, ms) =>
+  setTimeout(cb, ms)`) rather than capturing it (`= fetch`, `= { setTimeout }`). Two
+  reasons: the global is then read at CALL time, so a test that swaps a global after
+  construction is still seen (this matters for the fake-timer work in Phases 2 and 3);
+  and the global is never invoked with the instance as its `this`, which is harmless on
+  Node today but is a real trap on any other host. New shells follow this. Recorded in
+  `bot/CLAUDE.md`.
 
 ## OPEN items
 
 See brainstorm.md O1 to O7. O4 (Developer Portal intent toggles) needs the user.
 O5 (member-write 429 scope) resolves from logs after first prod deploy.
+
+### Ledgered during Phase 1 (found, deliberately NOT fixed there)
+
+Phase 1 forbids any runtime behavior change, and each of these changes behavior or
+adds a guard, so they were recorded rather than landed. The Phase 1 QA session should
+route each to a phase or file it.
+
+- L1 (should-fix, security): `bot/discord_api.ts` throws
+  `[bot] discord ${method} ${path} -> ...` with `path` interpolated verbatim, and three
+  interaction call sites (`respondInteraction`, `deferInteraction`,
+  `editOriginalResponse`) carry the INTERACTION TOKEN inside `path`. The throw is caught
+  by the `console.error('[bot] interaction error', e)` handler in `bot/main.ts`, so a
+  400/401/404 (or a twice-429) on a slash-command reply writes a live ~15 minute bearer
+  credential into the container log. PRE-EXISTING, not a regression of Phase 1. Fix
+  shape: redact the token segment, or log a safe label beside the real path. Natural
+  home is Phase 2, which already rewrites `request()` for the governor.
+- L2 (nice-to-have, privacy): `bot/server_client.ts` non-ok log line prints `path`,
+  which for `flex()` and `roles()` carries `?discord_user_id=<id>`. Low sensitivity
+  (a Discord id is pseudonymous and guild-visible) but it is user-identifying data in
+  an operator log. Pre-existing.
+- L3 RESOLVED, do not add the pin. The concern was that nothing stops a future call site
+  from passing a wrapping `fetchImpl` that observes the bot token or the shared secret.
+  Ruling: `tsc` now proves the arity of every construction site (that is what adding
+  `bot` to the include bought), which is a stronger guard than a source-text scan and
+  costs nothing, and a text pin would carry the documented source-scrape traps. No pin.
+- L4 CLOSED by Phase 1. `tests/discord_bot_gateway.test.ts` module-mocks `ws` and covers
+  both directions: the DEFAULT factory constructs the real `ws` client at
+  `/?v=10&encoding=json`, and an injected factory is used instead of it. It also
+  exercises HELLO to IDENTIFY, the heartbeat interval, and the fatal-versus-normal close
+  branch. Phases 3 and 7 extend it rather than starting from nothing.
+- L5 (coverage gap, Phase 5 territory): two `bot/server_client.ts` contracts are still
+  unpinned. `flairedIds()` distinguishes null (meaning "change nothing", per its own doc
+  comment) from an empty array, and its `typeof x === 'string'` filter is untested;
+  `pushMembersMeta()` has an untested zero-updated silent-drop warning branch. Both were
+  outside Phase 1's assigned arm list. Phase 5 touches both, so pin them there.
 
 ## Known gotchas for implementers
 

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -38,7 +38,7 @@ fixing a red gate.
 `npm run gate` mirrors the CI contract: generated i18n freshness, malware scanning,
 changed-file formatting, the SFX conformance check, the full test suite, the browser
 regression suite (`npm run test:browser`, which drives Chromium through Playwright), the
-typecheck, and env, server, and client builds. Release branches use the release i18n tier. It stops at
+typecheck, and env, server, bot, and client builds. Release branches use the release i18n tier. It stops at
 the first failure and bounds Vitest workers to avoid load flakes on shared machines. It
 resolves FFmpeg (`ffmpeg` and `ffprobe`) from the bundled `ffmpeg-static`/`ffprobe-static`
 npm packages, falling back to PATH, and refuses to run when neither source yields a

--- a/docs/qa-gate.md
+++ b/docs/qa-gate.md
@@ -38,7 +38,8 @@ fixing a red gate.
 `npm run gate` mirrors the CI contract: generated i18n freshness, malware scanning,
 changed-file formatting, the SFX conformance check, the full test suite, the browser
 regression suite (`npm run test:browser`, which drives Chromium through Playwright), the
-typecheck, and env, server, bot, and client builds. Release branches use the release i18n tier. It stops at
+typecheck, and env, server, bot, and client builds. Release branches use the release i18n
+tier. It stops at
 the first failure and bounds Vitest workers to avoid load flakes on shared machines. It
 resolves FFmpeg (`ffmpeg` and `ffprobe`) from the bundled `ffmpeg-static`/`ffprobe-static`
 npm packages, falling back to PATH, and refuses to run when neither source yields a

--- a/scripts/gate.mjs
+++ b/scripts/gate.mjs
@@ -70,6 +70,7 @@ const steps = [
   ['typecheck', 'npm', ['run', 'check:types']],
   ['env build', 'npm', ['run', 'build:env']],
   ['server build', 'npm', ['run', 'build:server']],
+  ['bot build', 'npm', ['run', 'build:bot']],
   ['client build', 'npm', ['run', 'build']],
 ];
 

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -3,9 +3,18 @@ import { describe, expect, it } from 'vitest';
 
 const workflow = readFileSync(new URL('../.github/workflows/ci.yml', import.meta.url), 'utf8');
 const gate = readFileSync(new URL('../scripts/gate.mjs', import.meta.url), 'utf8');
+// gate.mjs with its line comments removed. A raw-substring pin on a step is not
+// a pin at all: commenting the step out leaves the substring in the file, so the
+// assertion stays green while the local gate quietly stops running it. Anything
+// after `://` is left alone so a URL in a string cannot be truncated.
+const gateCode = gate.replace(/(^|[^:])\/\/.*$/gm, '$1');
 
 function jobSource(name: string): string {
-  const match = workflow.match(new RegExp(`\\n  ${name}:[\\s\\S]*?(?=\\n  [a-z][a-z-]+:|$)`));
+  // The lookahead is the job boundary. It accepts digits and underscores too:
+  // a future job id like `pr-gate2` would otherwise not terminate the previous
+  // slice, letting one job's text bleed into another and quietly satisfying a
+  // by-name pin from the wrong job.
+  const match = workflow.match(new RegExp(`\\n  ${name}:[\\s\\S]*?(?=\\n  [a-z][a-z0-9_-]*:|$)`));
   if (!match) throw new Error(`missing CI job: ${name}`);
   return match[0];
 }
@@ -180,13 +189,59 @@ describe('CI workflow parity', () => {
     // scripts/gate.mjs is the local mirror of the CI step list (its own header
     // says to keep them in sync), and nothing else pins its build steps: a
     // deleted gate step is invisible to CI, which runs its own list.
-    for (const step of [
-      "['env build', 'npm', ['run', 'build:env']]",
-      "['server build', 'npm', ['run', 'build:server']]",
-      "['bot build', 'npm', ['run', 'build:bot']]",
-      "['client build', 'npm', ['run', 'build']]",
-    ]) {
-      expect(gate).toContain(step);
+    // Matched against the comment-stripped source and with tolerant whitespace,
+    // so neither commenting a step out nor a biome re-wrap can decide this.
+    for (const [label, script] of [
+      ['env build', 'build:env'],
+      ['server build', 'build:server'],
+      ['bot build', 'build:bot'],
+      ['client build', 'build'],
+    ] as const) {
+      expect(gateCode).toMatch(
+        new RegExp(
+          `\\[\\s*'${label}',\\s*'npm',\\s*\\[\\s*'run',\\s*'${script}'\\s*\\]\\s*,?\\s*\\]`,
+        ),
+      );
     }
+    // ...and in the CI order, so the cheap bundles still fail before the slow
+    // client build does.
+    expect(gateCode.indexOf("'server build'")).toBeLessThan(gateCode.indexOf("'bot build'"));
+    expect(gateCode.indexOf("'bot build'")).toBeLessThan(gateCode.indexOf("'client build'"));
+  });
+
+  it('keeps the bot build a real, ungated failure in both CI jobs', () => {
+    const prChecks = jobSource('pr-checks');
+    const releaseGate = jobSource('release-gate');
+    // Name-to-run adjacency, because `toContain('run: npm run build:bot')` is
+    // also satisfied by `run: npm run build:bot || true` (which can never fail)
+    // and by a copy-pasted `if: matrix.shard == 1` slipped between the two
+    // lines, which in this unsharded job is never true and would disable the
+    // build outright. Either would put a broken bundle back on the host.
+    expect(prChecks).toMatch(/- name: Build Discord bot\n {8}run: npm run build:bot\n/);
+    // A step that is allowed to fail is not a gate.
+    expect(workflow).not.toContain('continue-on-error');
+    // In release-gate the step must ALSO stay tied to its own name and its
+    // single-shard condition: the aggregate count of 9 is compensable, so
+    // un-gating this build while gating some other step keeps the count and
+    // quietly runs the bot build four times per release push.
+    expect(releaseGate).toMatch(
+      /- name: Build Discord bot\n {8}if: matrix\.shard == 1\n {8}run: npm run build:bot\n/,
+    );
+  });
+
+  it('never runs untrusted pull-request code with write access', () => {
+    // The jobs above run `npm ci`, the full suite, and four builds over the
+    // head ref of any fork PR. That is only safe while the workflow stays on
+    // `pull_request` with a read-only token: switching to
+    // `pull_request_target`, or granting a job write scope so some check
+    // "works on forks", would hand that untrusted code a privileged token and
+    // nothing else in the repo would go red.
+    expect(workflow).not.toContain('pull_request_target');
+    expect(workflow).toMatch(/\npermissions:\n {2}contents: read\n/);
+    // Unanchored on purpose: the read-only grant is workflow-level, and a JOB
+    // may re-declare `permissions:` at its own indent to widen it. Matching
+    // only at column 0 would miss exactly that escalation.
+    expect(workflow.match(/^\s*permissions:/gm)).toHaveLength(1);
+    expect(workflow).not.toContain('secrets.');
   });
 });

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -12,11 +12,13 @@ const gate = readFileSync(new URL('../scripts/gate.mjs', import.meta.url), 'utf8
 const gateCode = gate.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
 
 function jobSource(name: string): string {
-  // The lookahead is the job boundary. It accepts digits and underscores too:
-  // a future job id like `pr-gate2` would otherwise not terminate the previous
-  // slice, letting one job's text bleed into another and quietly satisfying a
-  // by-name pin from the wrong job.
-  const match = workflow.match(new RegExp(`\\n  ${name}:[\\s\\S]*?(?=\\n  [a-z][a-z0-9_-]*:|$)`));
+  // The lookahead is the job boundary. It accepts digits, underscores, and an
+  // uppercase initial: a future job id like `pr-gate2` or `Release` would
+  // otherwise not terminate the previous slice, letting one job's text bleed
+  // into another and quietly satisfying a by-name pin from the wrong job.
+  const match = workflow.match(
+    new RegExp(`\\n  ${name}:[\\s\\S]*?(?=\\n  [A-Za-z][A-Za-z0-9_-]*:|$)`),
+  );
   if (!match) throw new Error(`missing CI job: ${name}`);
   return match[0];
 }
@@ -25,7 +27,7 @@ describe('CI workflow parity', () => {
   it('runs the canonical game and admin typecheck in CI and the local gate', () => {
     expect(workflow.match(/run: npm run check:types/g)).toHaveLength(2);
     expect(workflow).not.toContain('run: npx tsc --noEmit');
-    expect(gate).toContain("['typecheck', 'npm', ['run', 'check:types']]");
+    expect(gateCode).toContain("['typecheck', 'npm', ['run', 'check:types']]");
   });
 
   it('provisions FFmpeg from the static npm packages instead of apt', () => {
@@ -36,14 +38,14 @@ describe('CI workflow parity', () => {
     // Either way no CI job apt-installs system FFmpeg; reintroducing the install
     // step would put its cost back on every job it touches.
     expect(workflow).not.toContain('apt-get');
-    expect(gate).toContain("from './sfx/ffmpeg_paths.mjs'");
+    expect(gateCode).toContain("from './sfx/ffmpeg_paths.mjs'");
   });
 
   it('runs the opt-in Chromium browser regressions in their own CI job', () => {
     const browserGate = jobSource('browser-gate');
     expect(browserGate).toContain('run: npx playwright install --with-deps chromium');
     expect(browserGate).toContain('run: npm run test:browser');
-    expect(gate).toContain("['browser regressions', 'npm', ['run', 'test:browser']]");
+    expect(gateCode).toContain("['browser regressions', 'npm', ['run', 'test:browser']]");
   });
 
   it('posts the i18n coverage summary and diffs the committed artifacts in both jobs', () => {
@@ -61,7 +63,7 @@ describe('CI workflow parity', () => {
       );
       expect(job).not.toContain('src/ui/i18n.status.summary.json');
     }
-    expect(gate).not.toContain('src/ui/i18n.status.summary.json');
+    expect(gateCode).not.toContain('src/ui/i18n.status.summary.json');
   });
 
   it('runs the release tier against a release-to-main pull request merge result', () => {
@@ -111,9 +113,20 @@ describe('CI workflow parity', () => {
       'run: npm run build:bot',
       'run: npm run build\n',
     ]) {
-      expect(prChecks).toContain(step);
+      // Anchored to the start of a step line, so a YAML-commented-out step
+      // (`#        run: npm run build:server`) cannot satisfy it: the substring
+      // survives the comment, the anchored form does not.
+      expect(prChecks).toMatch(new RegExp(`\\n {8}${step.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
       expect(prGate).not.toContain(step);
     }
+    // ...and a structural count, the same backstop release-gate has: an added
+    // or removed pr-checks step must consciously update this test rather than
+    // slipping in beside the by-name pins above.
+    expect(prChecks.match(/\n {6}- name: /g)).toHaveLength(12);
+    // pr-checks is unsharded, so NO step in it may carry a condition: an
+    // `if: matrix.shard == 1` copy-pasted here is never true and would disable
+    // that step outright.
+    expect(prChecks).not.toMatch(/\n {8}if: /);
   });
 
   it('shards the PR and release test steps four ways and keeps the checks single-shard', () => {
@@ -144,9 +157,9 @@ describe('CI workflow parity', () => {
     // turn the pre-merge gate into a partial run, deleting the step would
     // silently drop tests from the gate entirely, and dropping the worker
     // bound would reintroduce the documented core-contention flake mode.
-    expect(gate).not.toContain('--shard');
-    expect(gate).toContain("'vitest (full suite)'");
-    expect(gate).toContain('--maxWorkers=');
+    expect(gateCode).not.toContain('--shard');
+    expect(gateCode).toContain("'vitest (full suite)'");
+    expect(gateCode).toContain('--maxWorkers=');
     // pr-checks stays a single unsharded job: its serialized checks run once.
     expect(prChecks).not.toContain('strategy:');
     expect(prChecks).not.toContain('matrix:');
@@ -239,11 +252,15 @@ describe('CI workflow parity', () => {
     // "works on forks", would hand that untrusted code a privileged token and
     // nothing else in the repo would go red.
     expect(workflow).not.toContain('pull_request_target');
-    expect(workflow).toMatch(/\npermissions:\n {2}contents: read\n/);
+    // The WHOLE block, terminated by a blank line: matching only the first
+    // entry would let `packages: write` be appended underneath it.
+    expect(workflow).toMatch(/\npermissions:\n {2}contents: read\n\n/);
     // Unanchored on purpose: the read-only grant is workflow-level, and a JOB
     // may re-declare `permissions:` at its own indent to widen it. Matching
     // only at column 0 would miss exactly that escalation.
     expect(workflow.match(/^\s*permissions:/gm)).toHaveLength(1);
     expect(workflow).not.toContain('secrets.');
+    expect(workflow).not.toContain("secrets['");
+    expect(workflow).not.toContain('secrets["');
   });
 });

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -97,6 +97,7 @@ describe('CI workflow parity', () => {
       'run: npm run check:types',
       'run: npm run build:env',
       'run: npm run build:server',
+      'run: npm run build:bot',
       'run: npm run build\n',
     ]) {
       expect(prChecks).toContain(step);
@@ -143,13 +144,14 @@ describe('CI workflow parity', () => {
     // ...while release-gate keeps its serialized checks and builds on exactly
     // one shard each (they are not partitionable and must not run four times):
     // i18n:gen, the freshness diff, the coverage summary, the malware gate,
-    // typecheck, and the three builds. Every new non-test step added to
-    // release-gate needs the same single-shard condition, and this count.
-    expect(releaseGate.match(/if: matrix\.shard == 1/g)).toHaveLength(8);
+    // typecheck, and the four builds (env, server, bot, client). Every new
+    // non-test step added to release-gate needs the same single-shard
+    // condition, and this count.
+    expect(releaseGate.match(/if: matrix\.shard == 1/g)).toHaveLength(9);
     // The release TEST step itself must stay un-gated (run on every shard):
     // name-to-run adjacency proves no if: line sits between them, so a
     // compensating double-edit (gate the test step, un-gate a build; count
-    // still 8) cannot silently shrink the release tier to a quarter of the
+    // still 9) cannot silently shrink the release tier to a quarter of the
     // suite.
     expect(releaseGate).toMatch(
       /- name: Run tests \(release tier[^\n]*\n {8}run: npm test -- --shard=\$\{\{ matrix\.shard \}\}\/4/,
@@ -160,6 +162,31 @@ describe('CI workflow parity', () => {
     // run four times per release push; pr-gate stays exactly checkout,
     // setup-node, npm ci, and the sharded test run).
     expect(prGate.match(/\n {6}- name: /g)).toHaveLength(4);
-    expect(releaseGate.match(/\n {6}- name: /g)).toHaveLength(12);
+    expect(releaseGate.match(/\n {6}- name: /g)).toHaveLength(13);
+    // ...and by NAME, because the two counts above are compensable: deleting a
+    // build step and adding any other single-shard step keeps both totals and
+    // would silently stop shipping that bundle from the release tier.
+    for (const build of [
+      'run: npm run build:env',
+      'run: npm run build:server',
+      'run: npm run build:bot',
+      'run: npm run build\n',
+    ]) {
+      expect(releaseGate).toContain(build);
+    }
+  });
+
+  it('builds every bundle in the local gate too, including the Discord bot', () => {
+    // scripts/gate.mjs is the local mirror of the CI step list (its own header
+    // says to keep them in sync), and nothing else pins its build steps: a
+    // deleted gate step is invisible to CI, which runs its own list.
+    for (const step of [
+      "['env build', 'npm', ['run', 'build:env']]",
+      "['server build', 'npm', ['run', 'build:server']]",
+      "['bot build', 'npm', ['run', 'build:bot']]",
+      "['client build', 'npm', ['run', 'build']]",
+    ]) {
+      expect(gate).toContain(step);
+    }
   });
 });

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, it } from 'vitest';
 
 const workflow = readFileSync(new URL('../.github/workflows/ci.yml', import.meta.url), 'utf8');
 const gate = readFileSync(new URL('../scripts/gate.mjs', import.meta.url), 'utf8');
-// gate.mjs with its line comments removed. A raw-substring pin on a step is not
-// a pin at all: commenting the step out leaves the substring in the file, so the
-// assertion stays green while the local gate quietly stops running it. Anything
-// after `://` is left alone so a URL in a string cannot be truncated.
-const gateCode = gate.replace(/(^|[^:])\/\/.*$/gm, '$1');
+// gate.mjs with its comments removed, BOTH kinds. A raw-substring pin on a step
+// is not a pin at all: commenting the step out leaves the substring in the file,
+// so the assertion stays green while the local gate quietly stops running it.
+// Block comments are stripped first (a `/* ... */` wrapper defeats a line-comment
+// strip just as well), then line comments, leaving anything after `://` alone so
+// a URL inside a string cannot be truncated.
+const gateCode = gate.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
 
 function jobSource(name: string): string {
   // The lookahead is the job boundary. It accepts digits and underscores too:

--- a/tests/deploy_discord_bot.test.ts
+++ b/tests/deploy_discord_bot.test.ts
@@ -57,5 +57,10 @@ describe('Discord bot build and typecheck surface', () => {
     // drag most of bot/ in through their own imports, but bot/main.ts (the
     // wiring) is imported by nothing and would drop out.
     expect(tsconfig.include).toContain('bot');
+    // ...and that the gate's typecheck actually reads THAT tsconfig. A bare
+    // `tsc --noEmit` defaults to the root tsconfig.json; pointing it at another
+    // project file would leave the include above pinning a config nothing runs.
+    expect(packageJson.scripts['check:ts']).toBe('tsc --noEmit');
+    expect(packageJson.scripts['check:types']).toContain('check:ts');
   });
 });

--- a/tests/deploy_discord_bot.test.ts
+++ b/tests/deploy_discord_bot.test.ts
@@ -53,9 +53,9 @@ describe('Discord bot build and typecheck surface', () => {
     // This is the headline deliverable of the stability packet's first phase,
     // and it is one word in one array. Removing it is completely silent:
     // build:bot is esbuild, which does not typecheck, and `npm run check:types`
-    // would simply check a smaller file set and stay green. The four bot suites
+    // would simply check a smaller file set and stay green. The bot test suites
     // drag most of bot/ in through their own imports, but bot/main.ts (the
-    // wiring, and the largest file) is imported by nothing and would drop out.
+    // wiring) is imported by nothing and would drop out.
     expect(tsconfig.include).toContain('bot');
   });
 });

--- a/tests/deploy_discord_bot.test.ts
+++ b/tests/deploy_discord_bot.test.ts
@@ -5,6 +5,13 @@ const dockerfile = readFileSync('Dockerfile', 'utf8');
 const dockerignore = readFileSync('.dockerignore', 'utf8');
 const compose = readFileSync('docker-compose.yml', 'utf8');
 const composeEnv = (name: string) => `$${`{${name}:-}`}`;
+const packageJson = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as { scripts: Record<string, string> };
+const buildBot = readFileSync(new URL('../scripts/build_bot.mjs', import.meta.url), 'utf8');
+const tsconfig = JSON.parse(readFileSync(new URL('../tsconfig.json', import.meta.url), 'utf8')) as {
+  include: string[];
+};
 
 describe('Discord bot deploy container contract', () => {
   it('builds and ships the bundled Discord bot artifact', () => {
@@ -27,5 +34,28 @@ describe('Discord bot deploy container contract', () => {
 
   it('passes the shared Discord bot secret to the game server', () => {
     expect(compose).toContain(`DISCORD_BOT_SECRET: ${composeEnv('DISCORD_BOT_SECRET')}`);
+  });
+});
+
+describe('Discord bot build and typecheck surface', () => {
+  it('bundles bot/main.ts to the exact artifact the compose command runs', () => {
+    // The deploy contract has three legs and only two were pinned: the
+    // Dockerfile runs build:bot and copies dist-bot, and compose runs
+    // `node dist-bot/bot.cjs`. Nothing said what build:bot actually produces,
+    // so repointing the entry or the outfile (or neutering the script) left the
+    // image assembling cleanly and the container failing to start on the host.
+    expect(packageJson.scripts['build:bot']).toBe('node scripts/build_bot.mjs');
+    expect(buildBot).toContain("entryPoints: ['bot/main.ts']");
+    expect(buildBot).toContain("outfile: 'dist-bot/bot.cjs'");
+  });
+
+  it('keeps bot/ inside the typecheck surface', () => {
+    // This is the headline deliverable of the stability packet's first phase,
+    // and it is one word in one array. Removing it is completely silent:
+    // build:bot is esbuild, which does not typecheck, and `npm run check:types`
+    // would simply check a smaller file set and stay green. The four bot suites
+    // drag most of bot/ in through their own imports, but bot/main.ts (the
+    // wiring, and the largest file) is imported by nothing and would drop out.
+    expect(tsconfig.include).toContain('bot');
   });
 });

--- a/tests/deploy_discord_bot.test.ts
+++ b/tests/deploy_discord_bot.test.ts
@@ -1,17 +1,23 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-const dockerfile = readFileSync('Dockerfile', 'utf8');
-const dockerignore = readFileSync('.dockerignore', 'utf8');
-const compose = readFileSync('docker-compose.yml', 'utf8');
+// Resolved from THIS file, not process.cwd(): a vitest invocation from another
+// directory would otherwise fail at module scope with ENOENT.
+const read = (name: string) => readFileSync(new URL(`../${name}`, import.meta.url), 'utf8');
+const dockerfile = read('Dockerfile');
+const dockerignore = read('.dockerignore');
+const compose = read('docker-compose.yml');
 const composeEnv = (name: string) => `$${`{${name}:-}`}`;
-const packageJson = JSON.parse(
-  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
-) as { scripts: Record<string, string> };
-const buildBot = readFileSync(new URL('../scripts/build_bot.mjs', import.meta.url), 'utf8');
-const tsconfig = JSON.parse(readFileSync(new URL('../tsconfig.json', import.meta.url), 'utf8')) as {
-  include: string[];
-};
+const packageJson = JSON.parse(read('package.json')) as { scripts: Record<string, string> };
+const buildBot = read('scripts/build_bot.mjs');
+// tsconfig.json is JSONC by spec, so strip comments before parsing: a perfectly
+// legal `// note` added to it would otherwise crash this file at module scope
+// and take every test in it down with an error that names none of them.
+const tsconfig = JSON.parse(
+  read('tsconfig.json')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1'),
+) as { include: string[] };
 
 describe('Discord bot deploy container contract', () => {
   it('builds and ships the bundled Discord bot artifact', () => {

--- a/tests/discord_bot_config.test.ts
+++ b/tests/discord_bot_config.test.ts
@@ -250,10 +250,11 @@ describe('loadConfig env-key inventory', () => {
     // the ambient environment and could make a fallback test pass for the wrong
     // reason. Line comments are stripped first so a commented-out read cannot
     // pad the set.
-    const source = readFileSync(new URL('../bot/config.ts', import.meta.url), 'utf8').replace(
-      /(^|[^:])\/\/.*$/gm,
-      '$1',
-    );
+    // bot/config.ts is mostly JSDoc, so block comments have to go first: a
+    // `/** process.env.FOO */` would otherwise be counted as a real read.
+    const source = readFileSync(new URL('../bot/config.ts', import.meta.url), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');
     const direct = [...source.matchAll(/process\.env\.([A-Z0-9_]+)/g)].map((m) => m[1]);
     const dynamic = source.match(/process\.env\[/g) ?? [];
     const viaRequired = [...source.matchAll(/required\('([A-Z0-9_]+)'\)/g)].map((m) => m[1]);

--- a/tests/discord_bot_config.test.ts
+++ b/tests/discord_bot_config.test.ts
@@ -248,8 +248,8 @@ describe('loadConfig env-key inventory', () => {
     // another suite) from deciding an arm. It is only as good as its coverage:
     // a key added to bot/config.ts and not here would silently read through to
     // the ambient environment and could make a fallback test pass for the wrong
-    // reason. Comments are stripped first so a commented-out read cannot pad
-    // the set.
+    // reason. Line comments are stripped first so a commented-out read cannot
+    // pad the set.
     const source = readFileSync(new URL('../bot/config.ts', import.meta.url), 'utf8').replace(
       /(^|[^:])\/\/.*$/gm,
       '$1',

--- a/tests/discord_bot_config.test.ts
+++ b/tests/discord_bot_config.test.ts
@@ -1,0 +1,234 @@
+// Boot-time constants of the Discord bot: the env contract `loadConfig` reads
+// and the background-loop cadences. Both are pure value reads with no IO, so
+// they are testable in plain Node; the env arms mutate `process.env` and restore
+// it key by key so nothing leaks into another test file.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { PRESENCE_DEBOUNCE_MS, RELAY_POLL_MS, ROLE_SYNC_INTERVAL_MS } from '../bot/cadence';
+import { loadConfig } from '../bot/config';
+
+// Every env key loadConfig reads. Each test starts from a clean slate of these,
+// so a value left by another test (or by the developer's own shell) can never
+// decide an arm.
+const BOT_ENV_KEYS = [
+  'DISCORD_BOT_TOKEN',
+  'DISCORD_CLIENT_ID',
+  'DISCORD_GUILD_ID',
+  'DISCORD_BOT_SECRET',
+  'GAME_SERVER_URL',
+  'PUBLIC_GAME_URL',
+  'DISCORD_VOICE_CHANNEL_ID',
+  'DISCORD_WELCOME_CHANNEL_ID',
+  'DISCORD_TEST_CHANNEL_ID',
+  'DISCORD_RELAY_CHANNEL_ID',
+  'DISCORD_ACTIVITY_CHANNEL_ID',
+  'DISCORD_DAILY_REWARDS_CHANNEL_ID',
+  'DISCORD_SYNC_NICKNAMES',
+] as const;
+
+/** Fill the four required keys with obvious non-secret placeholders. */
+function setRequired(): void {
+  process.env.DISCORD_BOT_TOKEN = 'token-placeholder';
+  process.env.DISCORD_CLIENT_ID = 'client-placeholder';
+  process.env.DISCORD_GUILD_ID = 'guild-placeholder';
+  process.env.DISCORD_BOT_SECRET = 'secret-placeholder';
+}
+
+let savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of BOT_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of BOT_ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('loadConfig required env', () => {
+  it('names the ONE missing key in the thrown message, for each of the four', () => {
+    // The four are evaluated in object-literal order, so each arm fills the
+    // other three and clears only its own key: an implementation that reported
+    // a fixed name (or the first key every time) fails here.
+    const cases = [
+      ['DISCORD_BOT_TOKEN', '[bot] missing required env DISCORD_BOT_TOKEN'],
+      ['DISCORD_CLIENT_ID', '[bot] missing required env DISCORD_CLIENT_ID'],
+      ['DISCORD_GUILD_ID', '[bot] missing required env DISCORD_GUILD_ID'],
+      ['DISCORD_BOT_SECRET', '[bot] missing required env DISCORD_BOT_SECRET'],
+    ] as const;
+    for (const [key, message] of cases) {
+      setRequired();
+      delete process.env[key];
+      expect(() => loadConfig()).toThrowError(new Error(message));
+    }
+  });
+
+  it('treats an EMPTY required value as missing (the !v guard, not a key check)', () => {
+    setRequired();
+    process.env.DISCORD_BOT_SECRET = '';
+    // The key IS present: only the falsy-value guard rejects this, which is what
+    // stops a blank line in a .env from booting a bot that cannot authenticate.
+    expect('DISCORD_BOT_SECRET' in process.env).toBe(true);
+    expect(() => loadConfig()).toThrowError(
+      new Error('[bot] missing required env DISCORD_BOT_SECRET'),
+    );
+  });
+
+  it('passes the four required values through verbatim once all are set', () => {
+    setRequired();
+    const cfg = loadConfig();
+    expect(cfg.token).toBe('token-placeholder');
+    expect(cfg.clientId).toBe('client-placeholder');
+    expect(cfg.guildId).toBe('guild-placeholder');
+    expect(cfg.botSecret).toBe('secret-placeholder');
+  });
+});
+
+describe('loadConfig defaults', () => {
+  it('defaults the game server URL and the public game URL', () => {
+    setRequired();
+    const cfg = loadConfig();
+    expect(cfg.gameServerUrl).toBe('http://127.0.0.1:8787');
+    expect(cfg.gameUrl).toBe('https://worldofclaudecraft.com');
+  });
+
+  it('lets an env value override each default', () => {
+    setRequired();
+    process.env.GAME_SERVER_URL = 'http://10.0.0.5:9000';
+    process.env.PUBLIC_GAME_URL = 'https://staging.example.test';
+    const cfg = loadConfig();
+    expect(cfg.gameServerUrl).toBe('http://10.0.0.5:9000');
+    expect(cfg.gameUrl).toBe('https://staging.example.test');
+  });
+
+  it('falls back to the default when the override is an EMPTY string', () => {
+    // `||`, not `??`: an empty GAME_SERVER_URL would otherwise make every
+    // /internal/discord call target a relative path against no host.
+    setRequired();
+    process.env.GAME_SERVER_URL = '';
+    process.env.PUBLIC_GAME_URL = '';
+    const cfg = loadConfig();
+    expect(cfg.gameServerUrl).toBe('http://127.0.0.1:8787');
+    expect(cfg.gameUrl).toBe('https://worldofclaudecraft.com');
+  });
+
+  it('defaults every optional channel id to the empty string', () => {
+    setRequired();
+    const cfg = loadConfig();
+    expect(cfg.voiceChannelId).toBe('');
+    expect(cfg.welcomeChannelId).toBe('');
+    expect(cfg.testChannelId).toBe('');
+    expect(cfg.relayChannelId).toBe('');
+    expect(cfg.activityChannelId).toBe('');
+    expect(cfg.dailyRewardsChannelId).toBe('');
+  });
+
+  it('reads each channel field from its OWN env key', () => {
+    // Every value is distinct, so a swapped key name (voice reading the welcome
+    // key, say) cannot pass. The all-defaults test above cannot catch that: both
+    // arms are the empty string there.
+    setRequired();
+    process.env.DISCORD_VOICE_CHANNEL_ID = 'voice-id';
+    process.env.DISCORD_WELCOME_CHANNEL_ID = 'welcome-id';
+    process.env.DISCORD_TEST_CHANNEL_ID = 'test-id';
+    process.env.DISCORD_RELAY_CHANNEL_ID = 'relay-id';
+    process.env.DISCORD_ACTIVITY_CHANNEL_ID = 'activity-id';
+    process.env.DISCORD_DAILY_REWARDS_CHANNEL_ID = 'daily-id';
+
+    const cfg = loadConfig();
+    expect(cfg.voiceChannelId).toBe('voice-id');
+    expect(cfg.welcomeChannelId).toBe('welcome-id');
+    expect(cfg.testChannelId).toBe('test-id');
+    expect(cfg.relayChannelId).toBe('relay-id');
+    expect(cfg.activityChannelId).toBe('activity-id');
+    expect(cfg.dailyRewardsChannelId).toBe('daily-id');
+  });
+});
+
+describe('loadConfig channel fallback ladders', () => {
+  it('prefers the relay channel over the test channel', () => {
+    setRequired();
+    process.env.DISCORD_RELAY_CHANNEL_ID = 'relay-1';
+    process.env.DISCORD_TEST_CHANNEL_ID = 'test-1';
+    expect(loadConfig().relayChannelId).toBe('relay-1');
+  });
+
+  it('falls the relay channel back to the test channel, then to empty', () => {
+    setRequired();
+    process.env.DISCORD_TEST_CHANNEL_ID = 'test-1';
+    expect(loadConfig().relayChannelId).toBe('test-1');
+    delete process.env.DISCORD_TEST_CHANNEL_ID;
+    expect(loadConfig().relayChannelId).toBe('');
+  });
+
+  it('walks the activity ladder: activity, then relay, then test, then empty', () => {
+    setRequired();
+    process.env.DISCORD_ACTIVITY_CHANNEL_ID = 'activity-1';
+    process.env.DISCORD_RELAY_CHANNEL_ID = 'relay-1';
+    process.env.DISCORD_TEST_CHANNEL_ID = 'test-1';
+    expect(loadConfig().activityChannelId).toBe('activity-1');
+
+    delete process.env.DISCORD_ACTIVITY_CHANNEL_ID;
+    expect(loadConfig().activityChannelId).toBe('relay-1');
+
+    delete process.env.DISCORD_RELAY_CHANNEL_ID;
+    expect(loadConfig().activityChannelId).toBe('test-1');
+
+    delete process.env.DISCORD_TEST_CHANNEL_ID;
+    expect(loadConfig().activityChannelId).toBe('');
+  });
+
+  it('points BOTH relay and activity at the test channel when only it is set', () => {
+    // The single-channel deployment: one announce channel carries the in-game
+    // "!" posts and the activity feed.
+    setRequired();
+    process.env.DISCORD_TEST_CHANNEL_ID = 'test-1';
+    const cfg = loadConfig();
+    expect(cfg.relayChannelId).toBe('test-1');
+    expect(cfg.activityChannelId).toBe('test-1');
+  });
+});
+
+describe('loadConfig nickname sync opt-out', () => {
+  it('is ON when unset', () => {
+    setRequired();
+    expect(loadConfig().syncNicknames).toBe(true);
+  });
+
+  it("is OFF for exactly '0'", () => {
+    setRequired();
+    process.env.DISCORD_SYNC_NICKNAMES = '0';
+    expect(loadConfig().syncNicknames).toBe(false);
+  });
+
+  it("stays ON for 'false', 'off', and '' (only '0' opts out)", () => {
+    // The arm a careless rewrite to a truthiness check (or to `=== '1'`)
+    // breaks: nothing but the literal '0' turns nickname sync off.
+    setRequired();
+    for (const value of ['false', 'off', 'no', '', '1', 'true']) {
+      process.env.DISCORD_SYNC_NICKNAMES = value;
+      expect(loadConfig().syncNicknames).toBe(true);
+    }
+  });
+});
+
+describe('bot loop cadences', () => {
+  it('pins each cadence against its literal', () => {
+    expect(ROLE_SYNC_INTERVAL_MS).toBe(300000);
+    expect(PRESENCE_DEBOUNCE_MS).toBe(4000);
+    expect(RELAY_POLL_MS).toBe(3000);
+  });
+
+  it('keeps the presence debounce and relay poll well under the role sync', () => {
+    // The ordering is the point: presence and relay are player-visible loops,
+    // role sync is the slow reconcile.
+    expect(PRESENCE_DEBOUNCE_MS).toBeLessThan(ROLE_SYNC_INTERVAL_MS);
+    expect(RELAY_POLL_MS).toBeLessThan(ROLE_SYNC_INTERVAL_MS);
+  });
+});

--- a/tests/discord_bot_config.test.ts
+++ b/tests/discord_bot_config.test.ts
@@ -2,6 +2,7 @@
 // and the background-loop cadences. Both are pure value reads with no IO, so
 // they are testable in plain Node; the env arms mutate `process.env` and restore
 // it key by key so nothing leaks into another test file.
+import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { PRESENCE_DEBOUNCE_MS, RELAY_POLL_MS, ROLE_SYNC_INTERVAL_MS } from '../bot/cadence';
 import { loadConfig } from '../bot/config';
@@ -70,14 +71,21 @@ describe('loadConfig required env', () => {
   });
 
   it('treats an EMPTY required value as missing (the !v guard, not a key check)', () => {
-    setRequired();
-    process.env.DISCORD_BOT_SECRET = '';
     // The key IS present: only the falsy-value guard rejects this, which is what
     // stops a blank line in a .env from booting a bot that cannot authenticate.
-    expect('DISCORD_BOT_SECRET' in process.env).toBe(true);
-    expect(() => loadConfig()).toThrowError(
-      new Error('[bot] missing required env DISCORD_BOT_SECRET'),
-    );
+    // Every one of the four, not just the secret: `required` is shared today,
+    // but an inlined key check on any single one would be invisible otherwise.
+    for (const key of [
+      'DISCORD_BOT_TOKEN',
+      'DISCORD_CLIENT_ID',
+      'DISCORD_GUILD_ID',
+      'DISCORD_BOT_SECRET',
+    ] as const) {
+      setRequired();
+      process.env[key] = '';
+      expect(key in process.env).toBe(true);
+      expect(() => loadConfig()).toThrowError(new Error(`[bot] missing required env ${key}`));
+    }
   });
 
   it('passes the four required values through verbatim once all are set', () => {
@@ -184,6 +192,22 @@ describe('loadConfig channel fallback ladders', () => {
     expect(loadConfig().activityChannelId).toBe('');
   });
 
+  it('walks past an EMPTY rung, not just an absent one', () => {
+    // Every other ladder arm deletes the key, and `??` walks past a deleted key
+    // exactly like `||` does, so the two are indistinguishable there. An empty
+    // value is where they part, and empty is the realistic shape: a bare
+    // `DISCORD_RELAY_CHANNEL_ID=` line in a .env sets it to ''. Under `??` the
+    // ladder would stop on that empty string and post nowhere.
+    setRequired();
+    process.env.DISCORD_RELAY_CHANNEL_ID = '';
+    process.env.DISCORD_ACTIVITY_CHANNEL_ID = '';
+    process.env.DISCORD_TEST_CHANNEL_ID = 'test-1';
+
+    const cfg = loadConfig();
+    expect(cfg.relayChannelId).toBe('test-1');
+    expect(cfg.activityChannelId).toBe('test-1');
+  });
+
   it('points BOTH relay and activity at the test channel when only it is set', () => {
     // The single-channel deployment: one announce channel carries the in-game
     // "!" posts and the activity feed.
@@ -215,6 +239,36 @@ describe('loadConfig nickname sync opt-out', () => {
       process.env.DISCORD_SYNC_NICKNAMES = value;
       expect(loadConfig().syncNicknames).toBe(true);
     }
+  });
+});
+
+describe('loadConfig env-key inventory', () => {
+  it('reads no env key that BOT_ENV_KEYS does not save and restore', () => {
+    // The save/restore list above is what stops the developer's own shell (or
+    // another suite) from deciding an arm. It is only as good as its coverage:
+    // a key added to bot/config.ts and not here would silently read through to
+    // the ambient environment and could make a fallback test pass for the wrong
+    // reason. Comments are stripped first so a commented-out read cannot pad
+    // the set.
+    const source = readFileSync(new URL('../bot/config.ts', import.meta.url), 'utf8').replace(
+      /(^|[^:])\/\/.*$/gm,
+      '$1',
+    );
+    const direct = [...source.matchAll(/process\.env\.([A-Z0-9_]+)/g)].map((m) => m[1]);
+    const dynamic = source.match(/process\.env\[/g) ?? [];
+    const viaRequired = [...source.matchAll(/required\('([A-Z0-9_]+)'\)/g)].map((m) => m[1]);
+
+    // Account for EVERY process.env touch first, so a read written in some
+    // other shape cannot simply go unseen by the two patterns above and leave
+    // the set comparison passing for the wrong reason.
+    const total = source.match(/process\.env/g) ?? [];
+    expect(direct.length + dynamic.length).toBe(total.length);
+    // The one dynamic lookup is required()'s own, whose keys are the literals
+    // collected above.
+    expect(dynamic.length).toBe(1);
+    expect(viaRequired.length).toBe(4);
+
+    expect([...new Set([...direct, ...viaRequired])].sort()).toEqual([...BOT_ENV_KEYS].sort());
   });
 });
 

--- a/tests/discord_bot_discord_api.test.ts
+++ b/tests/discord_bot_discord_api.test.ts
@@ -398,12 +398,17 @@ describe('DiscordApi production defaults', () => {
   it('backs the default retry sleep with the real global setTimeout', async () => {
     // Fake timers prove the default sleep is a genuine timer rather than an
     // accidental no-op: nothing resolves until the clock is advanced.
+    // Constructed BEFORE the fake clock, per R16: the default is evaluated at
+    // construction, so a form that captured setTimeout would bind the REAL one
+    // here and never resolve under the fake clock. Installing the fake first
+    // passes for both forms.
+    const api = new DiscordApi('tok');
     vi.useFakeTimers();
     let settled = false;
     vi.stubGlobal('fetch', async () => fakeResponse({ status: 429, body: { retry_after: 5 } }));
 
     try {
-      const pending = new DiscordApi('tok')
+      const pending = api
         .guildRoles('g1')
         .then(() => {
           settled = true;
@@ -415,9 +420,14 @@ describe('DiscordApi production defaults', () => {
       await vi.advanceTimersByTimeAsync(4999);
       expect(settled).toBe(false); // still inside the 5000 ms clamped wait
 
+      // Assert BEFORE awaiting `pending`. Awaiting first would wait out a REAL
+      // timer too, so a default that captured setTimeout at construction (and
+      // therefore scheduled on the real clock, ignoring the fake) would still
+      // settle eventually and pass. Advancing the FAKE clock has to be what
+      // resolves it.
       await vi.advanceTimersByTimeAsync(1);
-      await pending;
       expect(settled).toBe(true);
+      await pending;
     } finally {
       vi.useRealTimers();
       vi.unstubAllGlobals();

--- a/tests/discord_bot_discord_api.test.ts
+++ b/tests/discord_bot_discord_api.test.ts
@@ -1,7 +1,8 @@
 // The DiscordApi request envelope and its injected IO seams. Every method funnels
-// through the one private `request()`, so driving `gatewayUrl()` and a couple of
-// the writes covers the whole class. The last block constructs the client the way
-// bot/main.ts does (token only) to prove the production defaults are still the
+// through the one private `request()`, so driving a representative call covers the
+// shared envelope, and a table drives the per-method method/path/body triples that
+// only that method can get wrong. The production-defaults block constructs the
+// client the way bot/main.ts does (token only) to prove the defaults are still the
 // real global fetch and a real setTimeout-backed sleep, which is the arm a broken
 // default parameter would otherwise silently replace.
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -14,14 +15,32 @@ interface FetchCall {
   init: RequestInit;
 }
 
-/** A response carrying only the fields `request()` touches. */
-function fakeResponse(opts: { status?: number; body?: unknown; text?: string } = {}): Response {
+/** A response carrying only the fields `request()` touches. `reads` records every
+ *  body read, so a test can prove a body was never parsed. */
+function fakeResponse(
+  opts: {
+    status?: number;
+    body?: unknown;
+    text?: string;
+    reads?: string[];
+    jsonThrows?: boolean;
+    textThrows?: boolean;
+  } = {},
+): Response {
   const status = opts.status ?? 200;
   return {
     ok: status >= 200 && status < 300,
     status,
-    json: async () => opts.body,
-    text: async () => opts.text ?? '',
+    json: async () => {
+      opts.reads?.push('json');
+      if (opts.jsonThrows) throw new SyntaxError('Unexpected token < in JSON');
+      return opts.body;
+    },
+    text: async () => {
+      opts.reads?.push('text');
+      if (opts.textThrows) throw new Error('body already consumed');
+      return opts.text ?? '';
+    },
   } as unknown as Response;
 }
 
@@ -68,25 +87,173 @@ describe('DiscordApi request envelope', () => {
     expect(await new DiscordApi('tok', impl).gatewayUrl()).toBe('wss://gateway.discord.gg');
   });
 
-  it('JSON-encodes a write body and returns null on 204', async () => {
-    const { calls, impl } = recordingFetch([fakeResponse({ status: 204 })]);
-    const api = new DiscordApi('tok', impl);
-
-    await api.setNickname('g1', 'u1', 'Aran (12)');
-
-    expect(calls[0].init.method).toBe('PATCH');
-    expect(calls[0].url).toBe(`${API}/guilds/g1/members/u1`);
-    expect(calls[0].init.body).toBe('{"nick":"Aran (12)"}');
+  it('falls back to the public gateway URL for an EMPTY url, not just a missing one', async () => {
+    // `||`, not `??`: Discord answering with an empty string would otherwise
+    // hand the Gateway '' and every connect would target the bare query string.
+    const { impl } = recordingFetch([fakeResponse({ body: { url: '' } })]);
+    expect(await new DiscordApi('tok', impl).gatewayUrl()).toBe('wss://gateway.discord.gg');
   });
 
-  it('throws with the status and the truncated response text on a non-ok status', async () => {
+  it('returns null on a 204 WITHOUT reading the body', async () => {
+    // The empty-body short circuit, pinned by the absent read rather than by the
+    // return value alone: a 204 has no body, so falling through to resp.json()
+    // relies entirely on its .catch to paper over the parse failure.
+    const reads: string[] = [];
+    const { impl } = recordingFetch([fakeResponse({ status: 204, reads })]);
+
+    expect(await new DiscordApi('tok', impl).createGuildRole('g1', 'WoC Initiate')).toBe(null);
+    expect(reads).toEqual([]);
+  });
+
+  it('returns null rather than throwing when a 200 body is not JSON', async () => {
+    // Cloudflare and Discord both answer with HTML on some errors; the parse
+    // guard is what stops that from throwing an unexpected shape at the caller.
+    const { impl } = recordingFetch([fakeResponse({ jsonThrows: true })]);
+    expect(await new DiscordApi('tok', impl).createGuildRole('g1', 'WoC Initiate')).toBe(null);
+  });
+
+  it('throws with the status and the response text TRUNCATED to 200 characters', async () => {
     const { impl } = recordingFetch([fakeResponse({ status: 403, text: 'x'.repeat(300) })]);
     const api = new DiscordApi('tok', impl);
 
+    // An Error argument is message EQUALITY in vitest; a bare string would be a
+    // substring match, which a 300-character slice would also satisfy, leaving
+    // the truncation this test is named for completely unpinned.
     await expect(api.guildRoles('g1')).rejects.toThrow(
-      `[bot] discord GET /guilds/g1/roles -> 403 ${'x'.repeat(200)}`,
+      new Error(`[bot] discord GET /guilds/g1/roles -> 403 ${'x'.repeat(200)}`),
     );
   });
+
+  it('still throws with the status when the error body cannot be read', async () => {
+    const { impl } = recordingFetch([fakeResponse({ status: 500, textThrows: true })]);
+    await expect(new DiscordApi('tok', impl).guildRoles('g1')).rejects.toThrow(
+      new Error('[bot] discord GET /guilds/g1/roles -> 500 '),
+    );
+  });
+
+  it('normalizes a non-array roles payload to an empty array', async () => {
+    // Discord answers this route with an error OBJECT on a permissions change;
+    // without the guard the caller's role diff iterates a non-array and throws.
+    const { impl } = recordingFetch([fakeResponse({ body: { message: 'Missing Access' } })]);
+    expect(await new DiscordApi('tok', impl).guildRoles('g1')).toEqual([]);
+  });
+});
+
+describe('DiscordApi per-method call envelopes', () => {
+  // Every row is a method whose ONLY wire contract is its verb, path, and body.
+  // A copy-paste slip between the add/remove role pair, or a lost EPHEMERAL
+  // flag, is invisible to the shared-envelope tests above.
+  const ROWS: {
+    name: string;
+    drive: (api: DiscordApi) => Promise<unknown>;
+    method: string;
+    path: string;
+    body: string | undefined;
+    response?: Response;
+  }[] = [
+    {
+      name: 'registerGuildCommands',
+      drive: (api) => api.registerGuildCommands('c1', 'g1', [{ name: 'whoami' }]),
+      method: 'PUT',
+      path: '/applications/c1/guilds/g1/commands',
+      body: '[{"name":"whoami"}]',
+    },
+    {
+      name: 'respondInteraction',
+      drive: (api) => api.respondInteraction('i1', 'tkn', { content: 'hi' }),
+      method: 'POST',
+      path: '/interactions/i1/tkn/callback',
+      // type 4 is CHANNEL_MESSAGE_WITH_SOURCE: the immediate visible reply.
+      body: '{"type":4,"data":{"content":"hi"}}',
+    },
+    {
+      name: 'deferInteraction (ephemeral)',
+      drive: (api) => api.deferInteraction('i1', 'tkn', true),
+      method: 'POST',
+      path: '/interactions/i1/tkn/callback',
+      // 64 is the EPHEMERAL flag; losing it posts a private reply publicly.
+      body: '{"type":5,"data":{"flags":64}}',
+    },
+    {
+      name: 'deferInteraction (public)',
+      drive: (api) => api.deferInteraction('i1', 'tkn', false),
+      method: 'POST',
+      path: '/interactions/i1/tkn/callback',
+      body: '{"type":5,"data":{}}',
+    },
+    {
+      name: 'editOriginalResponse',
+      drive: (api) => api.editOriginalResponse('app1', 'tkn', { content: 'done' }),
+      method: 'PATCH',
+      path: '/webhooks/app1/tkn/messages/@original',
+      body: '{"content":"done"}',
+    },
+    {
+      name: 'guildRoles',
+      drive: (api) => api.guildRoles('g1'),
+      method: 'GET',
+      path: '/guilds/g1/roles',
+      body: undefined,
+      response: fakeResponse({ body: [] }),
+    },
+    {
+      name: 'createGuildRole (default color)',
+      drive: (api) => api.createGuildRole('g1', 'WoC Initiate'),
+      method: 'POST',
+      path: '/guilds/g1/roles',
+      // color 0 means "no color"; hoist/mentionable false keep the tier roles
+      // out of the member sidebar and out of @-mention range.
+      body: '{"name":"WoC Initiate","color":0,"mentionable":false,"hoist":false}',
+    },
+    {
+      name: 'createGuildRole (explicit color)',
+      drive: (api) => api.createGuildRole('g1', 'WoC Champion', 0xff8800),
+      method: 'POST',
+      path: '/guilds/g1/roles',
+      body: '{"name":"WoC Champion","color":16746496,"mentionable":false,"hoist":false}',
+    },
+    {
+      name: 'addMemberRole',
+      drive: (api) => api.addMemberRole('g1', 'u1', 'r1'),
+      method: 'PUT',
+      path: '/guilds/g1/members/u1/roles/r1',
+      body: undefined,
+    },
+    {
+      name: 'removeMemberRole',
+      drive: (api) => api.removeMemberRole('g1', 'u1', 'r1'),
+      method: 'DELETE',
+      path: '/guilds/g1/members/u1/roles/r1',
+      body: undefined,
+    },
+    {
+      name: 'setNickname',
+      drive: (api) => api.setNickname('g1', 'u1', 'Aran (12)'),
+      method: 'PATCH',
+      path: '/guilds/g1/members/u1',
+      body: '{"nick":"Aran (12)"}',
+    },
+    {
+      name: 'createMessage',
+      drive: (api) => api.createMessage('ch1', { content: 'hello' }),
+      method: 'POST',
+      path: '/channels/ch1/messages',
+      body: '{"content":"hello"}',
+    },
+  ];
+
+  for (const row of ROWS) {
+    it(`${row.name} sends ${row.method} ${row.path}`, async () => {
+      const { calls, impl } = recordingFetch([row.response ?? fakeResponse({ body: {} })]);
+
+      await row.drive(new DiscordApi('tok', impl));
+
+      expect(calls.length).toBe(1);
+      expect(calls[0].init.method).toBe(row.method);
+      expect(calls[0].url).toBe(`${API}${row.path}`);
+      expect(calls[0].init.body).toBe(row.body);
+    });
+  }
 });
 
 describe('DiscordApi 429 retry', () => {
@@ -105,8 +272,27 @@ describe('DiscordApi 429 retry', () => {
     // retry_after is SECONDS, so 2 becomes 2000 ms, inside the 500..10000 clamp.
     expect(slept).toEqual([2000]);
     expect(calls.length).toBe(2);
-    expect(calls[0].url).toBe(calls[1].url);
-    expect(calls[0].init.method).toBe(calls[1].init.method);
+    // Both sides pinned to a literal, not just to each other: a relation-only
+    // assertion holds even if BOTH requests go somewhere wrong.
+    expect(calls[1].url).toBe(`${API}/guilds/g1/roles`);
+    expect(calls[1].init.method).toBe('GET');
+  });
+
+  it('replays the BODY too, not just the method and path', async () => {
+    // Every other retry arm drives a bodyless GET, so dropping `body` from the
+    // recursive call was invisible. The likeliest 429 in this bot is a relay
+    // post, which would then be replayed as an empty message.
+    const { calls, impl } = recordingFetch([
+      fakeResponse({ status: 429, body: { retry_after: 1 } }),
+      fakeResponse({ body: {} }),
+    ]);
+    const api = new DiscordApi('tok', impl, async () => {});
+
+    await api.createMessage('ch1', { content: 'hello' });
+
+    expect(calls.length).toBe(2);
+    expect(calls[1].init.body).toBe('{"content":"hello"}');
+    expect(calls[1].url).toBe(`${API}/channels/ch1/messages`);
   });
 
   it('clamps the wait to the 500 ms floor and the 10000 ms ceiling', async () => {
@@ -138,6 +324,21 @@ describe('DiscordApi 429 retry', () => {
     expect(slept).toEqual([1000]);
   });
 
+  it('falls back to the 1 second default when the 429 body is not JSON at all', async () => {
+    // An edge 429 comes from Cloudflare ahead of Discord's own limiter and
+    // carries HTML; without the parse guard the whole call throws instead of
+    // backing off.
+    const slept: number[] = [];
+    const { impl } = recordingFetch([
+      fakeResponse({ status: 429, jsonThrows: true }),
+      fakeResponse({ body: [] }),
+    ]);
+    await new DiscordApi('tok', impl, async (ms) => {
+      slept.push(ms);
+    }).guildRoles('g1');
+    expect(slept).toEqual([1000]);
+  });
+
   it('retries at most once: a second 429 is thrown, not slept on again', async () => {
     const slept: number[] = [];
     const { calls, impl } = recordingFetch([
@@ -157,7 +358,14 @@ describe('DiscordApi 429 retry', () => {
 });
 
 describe('DiscordApi production defaults', () => {
-  it('uses the real global fetch when constructed with the token alone', async () => {
+  it('reads the global fetch at CALL time, not at construction', async () => {
+    // Construction happens BEFORE the stub deliberately. A capture-form default
+    // (`= fetch`) would bind the pre-stub global here and never see the swap,
+    // which is exactly the regression bot/CLAUDE.md's forward-to-the-global
+    // invariant exists to prevent, and which a stub-then-construct ordering
+    // cannot detect.
+    const api = new DiscordApi('tok');
+
     const seen: string[] = [];
     vi.stubGlobal('fetch', async (input: unknown) => {
       seen.push(String(input));
@@ -165,8 +373,6 @@ describe('DiscordApi production defaults', () => {
     });
 
     try {
-      // Exactly the construction in bot/main.ts: no fetch, no sleep.
-      const api = new DiscordApi('tok');
       expect(await api.gatewayUrl()).toBe('wss://real.test');
     } finally {
       vi.unstubAllGlobals();

--- a/tests/discord_bot_discord_api.test.ts
+++ b/tests/discord_bot_discord_api.test.ts
@@ -1,0 +1,206 @@
+// The DiscordApi request envelope and its injected IO seams. Every method funnels
+// through the one private `request()`, so driving `gatewayUrl()` and a couple of
+// the writes covers the whole class. The last block constructs the client the way
+// bot/main.ts does (token only) to prove the production defaults are still the
+// real global fetch and a real setTimeout-backed sleep, which is the arm a broken
+// default parameter would otherwise silently replace.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DiscordApi } from '../bot/discord_api';
+
+const API = 'https://discord.com/api/v10';
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+/** A response carrying only the fields `request()` touches. */
+function fakeResponse(opts: { status?: number; body?: unknown; text?: string } = {}): Response {
+  const status = opts.status ?? 200;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => opts.body,
+    text: async () => opts.text ?? '',
+  } as unknown as Response;
+}
+
+function recordingFetch(responses: Response[]): { calls: FetchCall[]; impl: typeof fetch } {
+  const calls: FetchCall[] = [];
+  const queue = [...responses];
+  const impl: typeof fetch = async (input, init) => {
+    calls.push({ url: String(input), init: init ?? {} });
+    const next = queue.shift();
+    if (!next) throw new Error('recordingFetch ran out of queued responses');
+    return next;
+  };
+  return { calls, impl };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('DiscordApi request envelope', () => {
+  it('sends the bot token, the JSON content type, and the pinned User-Agent to /api/v10', async () => {
+    const { calls, impl } = recordingFetch([fakeResponse({ body: { url: 'wss://gw.test' } })]);
+    const api = new DiscordApi('tok', impl);
+
+    expect(await api.gatewayUrl()).toBe('wss://gw.test');
+
+    expect(calls.length).toBe(1);
+    expect(calls[0].url).toBe('https://discord.com/api/v10/gateway/bot');
+    expect(calls[0].init.method).toBe('GET');
+    expect(calls[0].init.headers).toEqual({
+      // `Bot ` prefix, not `Bearer`: a bot token is rejected as a bearer token.
+      Authorization: 'Bot tok',
+      'Content-Type': 'application/json',
+      'User-Agent': 'WorldOfClaudeCraftBot (https://worldofclaudecraft.com, 1.0)',
+    });
+    // No body key value on a GET.
+    expect(calls[0].init.body).toBe(undefined);
+  });
+
+  it('falls back to the public gateway URL when the payload has none', async () => {
+    const { impl } = recordingFetch([fakeResponse({ body: {} })]);
+    expect(await new DiscordApi('tok', impl).gatewayUrl()).toBe('wss://gateway.discord.gg');
+  });
+
+  it('JSON-encodes a write body and returns null on 204', async () => {
+    const { calls, impl } = recordingFetch([fakeResponse({ status: 204 })]);
+    const api = new DiscordApi('tok', impl);
+
+    await api.setNickname('g1', 'u1', 'Aran (12)');
+
+    expect(calls[0].init.method).toBe('PATCH');
+    expect(calls[0].url).toBe(`${API}/guilds/g1/members/u1`);
+    expect(calls[0].init.body).toBe('{"nick":"Aran (12)"}');
+  });
+
+  it('throws with the status and the truncated response text on a non-ok status', async () => {
+    const { impl } = recordingFetch([fakeResponse({ status: 403, text: 'x'.repeat(300) })]);
+    const api = new DiscordApi('tok', impl);
+
+    await expect(api.guildRoles('g1')).rejects.toThrow(
+      `[bot] discord GET /guilds/g1/roles -> 403 ${'x'.repeat(200)}`,
+    );
+  });
+});
+
+describe('DiscordApi 429 retry', () => {
+  it('waits the clamped retry_after ONCE and replays the same request', async () => {
+    const slept: number[] = [];
+    const { calls, impl } = recordingFetch([
+      fakeResponse({ status: 429, body: { retry_after: 2 } }),
+      fakeResponse({ body: [{ id: 'r1', name: 'WoC Initiate' }] }),
+    ]);
+    const api = new DiscordApi('tok', impl, async (ms) => {
+      slept.push(ms);
+    });
+
+    expect(await api.guildRoles('g1')).toEqual([{ id: 'r1', name: 'WoC Initiate' }]);
+
+    // retry_after is SECONDS, so 2 becomes 2000 ms, inside the 500..10000 clamp.
+    expect(slept).toEqual([2000]);
+    expect(calls.length).toBe(2);
+    expect(calls[0].url).toBe(calls[1].url);
+    expect(calls[0].init.method).toBe(calls[1].init.method);
+  });
+
+  it('clamps the wait to the 500 ms floor and the 10000 ms ceiling', async () => {
+    for (const [retryAfter, expected] of [
+      [0.01, 500],
+      [30, 10_000],
+    ] as const) {
+      const slept: number[] = [];
+      const { impl } = recordingFetch([
+        fakeResponse({ status: 429, body: { retry_after: retryAfter } }),
+        fakeResponse({ body: [] }),
+      ]);
+      await new DiscordApi('tok', impl, async (ms) => {
+        slept.push(ms);
+      }).guildRoles('g1');
+      expect(slept).toEqual([expected]);
+    }
+  });
+
+  it('defaults a missing retry_after to 1 second', async () => {
+    const slept: number[] = [];
+    const { impl } = recordingFetch([
+      fakeResponse({ status: 429, body: {} }),
+      fakeResponse({ body: [] }),
+    ]);
+    await new DiscordApi('tok', impl, async (ms) => {
+      slept.push(ms);
+    }).guildRoles('g1');
+    expect(slept).toEqual([1000]);
+  });
+
+  it('retries at most once: a second 429 is thrown, not slept on again', async () => {
+    const slept: number[] = [];
+    const { calls, impl } = recordingFetch([
+      fakeResponse({ status: 429, body: { retry_after: 1 } }),
+      fakeResponse({ status: 429, body: { retry_after: 1 }, text: 'rate limited' }),
+    ]);
+    const api = new DiscordApi('tok', impl, async (ms) => {
+      slept.push(ms);
+    });
+
+    // The retry flag is false on the replay, so the second 429 falls through to
+    // the non-ok throw instead of looping. This is the unbounded-retry guard.
+    await expect(api.guildRoles('g1')).rejects.toThrow('-> 429 rate limited');
+    expect(slept).toEqual([1000]);
+    expect(calls.length).toBe(2);
+  });
+});
+
+describe('DiscordApi production defaults', () => {
+  it('uses the real global fetch when constructed with the token alone', async () => {
+    const seen: string[] = [];
+    vi.stubGlobal('fetch', async (input: unknown) => {
+      seen.push(String(input));
+      return fakeResponse({ body: { url: 'wss://real.test' } });
+    });
+
+    try {
+      // Exactly the construction in bot/main.ts: no fetch, no sleep.
+      const api = new DiscordApi('tok');
+      expect(await api.gatewayUrl()).toBe('wss://real.test');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    expect(seen).toEqual(['https://discord.com/api/v10/gateway/bot']);
+  });
+
+  it('backs the default retry sleep with the real global setTimeout', async () => {
+    // Fake timers prove the default sleep is a genuine timer rather than an
+    // accidental no-op: nothing resolves until the clock is advanced.
+    vi.useFakeTimers();
+    let settled = false;
+    vi.stubGlobal('fetch', async () => fakeResponse({ status: 429, body: { retry_after: 5 } }));
+
+    try {
+      const pending = new DiscordApi('tok')
+        .guildRoles('g1')
+        .then(() => {
+          settled = true;
+        })
+        .catch(() => {
+          settled = true;
+        });
+
+      await vi.advanceTimersByTimeAsync(4999);
+      expect(settled).toBe(false); // still inside the 5000 ms clamped wait
+
+      await vi.advanceTimersByTimeAsync(1);
+      await pending;
+      expect(settled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/tests/discord_bot_discord_api.test.ts
+++ b/tests/discord_bot_discord_api.test.ts
@@ -366,19 +366,33 @@ describe('DiscordApi production defaults', () => {
     // cannot detect.
     const api = new DiscordApi('tok');
 
-    const seen: string[] = [];
-    vi.stubGlobal('fetch', async (input: unknown) => {
-      seen.push(String(input));
-      return fakeResponse({ body: { url: 'wss://real.test' } });
+    const seen: { url: string; init: RequestInit | undefined }[] = [];
+    // The stub takes BOTH parameters. A one-parameter stub cannot tell
+    // `(...args) => fetch(...args)` from `(input) => fetch(input)`, and the
+    // latter type-checks fine (TypeScript allows an arity-reduced function
+    // where a wider one is expected), so every Discord call would go out with
+    // no method, no Authorization, no User-Agent, and no body while the suite
+    // stayed green.
+    vi.stubGlobal('fetch', async (input: unknown, init?: RequestInit) => {
+      seen.push({ url: String(input), init });
+      return fakeResponse({ status: 204 });
     });
 
     try {
-      expect(await api.gatewayUrl()).toBe('wss://real.test');
+      await api.setNickname('g1', 'u1', 'Aran (12)');
     } finally {
       vi.unstubAllGlobals();
     }
 
-    expect(seen).toEqual(['https://discord.com/api/v10/gateway/bot']);
+    expect(seen.length).toBe(1);
+    expect(seen[0].url).toBe('https://discord.com/api/v10/guilds/g1/members/u1');
+    expect(seen[0].init?.method).toBe('PATCH');
+    expect(seen[0].init?.headers).toEqual({
+      Authorization: 'Bot tok',
+      'Content-Type': 'application/json',
+      'User-Agent': 'WorldOfClaudeCraftBot (https://worldofclaudecraft.com, 1.0)',
+    });
+    expect(seen[0].init?.body).toBe('{"nick":"Aran (12)"}');
   });
 
   it('backs the default retry sleep with the real global setTimeout', async () => {

--- a/tests/discord_bot_gateway.test.ts
+++ b/tests/discord_bot_gateway.test.ts
@@ -5,17 +5,19 @@
 // used instead of it. The mock stands in for the `ws` module so neither arm
 // opens a socket; asserting the mocked constructor was called IS the proof that
 // the default routes through `ws`.
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /** Every socket the code under test constructed, in order. */
 const constructed: { url: string; socket: FakeSocket }[] = [];
 
 class FakeSocket {
   static OPEN = 1;
-  readyState = FakeSocket.OPEN;
+  readyState: number = FakeSocket.OPEN;
   readonly listeners = new Map<string, (arg: unknown) => void>();
   readonly sent: string[] = [];
   terminated = 0;
+  closed = 0;
+  listenersRemoved = 0;
 
   constructor(url: string) {
     constructed.push({ url, socket: this });
@@ -34,7 +36,17 @@ class FakeSocket {
     this.terminated += 1;
   }
 
-  close(): void {}
+  close(): void {
+    this.closed += 1;
+  }
+
+  // Gateway.reconnect() calls this FIRST; without it the real call throws into
+  // its own `catch {}` and close() is never reached, which would make the
+  // teardown half of a reconnect untestable (and silently so).
+  removeAllListeners(): void {
+    this.listenersRemoved += 1;
+    this.listeners.clear();
+  }
 
   emit(event: string, arg?: unknown): void {
     this.listeners.get(event)?.(arg);
@@ -56,6 +68,7 @@ function fakeTimers() {
   const armed: { ms: number; fn: () => void }[] = [];
   const intervals: { ms: number; fn: () => void }[] = [];
   const cleared: unknown[] = [];
+  let nextInterval = 1;
   return {
     armed,
     intervals,
@@ -67,7 +80,7 @@ function fakeTimers() {
       },
       setInterval: (fn: () => void, ms: number) => {
         intervals.push({ fn, ms });
-        return 0 as unknown as ReturnType<typeof setInterval>;
+        return nextInterval++ as unknown as ReturnType<typeof setInterval>;
       },
       clearInterval: (id: ReturnType<typeof setInterval>) => {
         cleared.push(id);
@@ -76,8 +89,52 @@ function fakeTimers() {
   };
 }
 
+/** A Gateway on an injected socket + injected timers, the rig most arms need. */
+function rig(): {
+  socket: FakeSocket;
+  timers: ReturnType<typeof fakeTimers>;
+  gateway: InstanceType<typeof Gateway>;
+  factoryUrls: string[];
+  sockets: FakeSocket[];
+} {
+  const timers = fakeTimers();
+  const factoryUrls: string[] = [];
+  const sockets: FakeSocket[] = [];
+  const gateway = new Gateway(
+    'tok',
+    'wss://gateway.discord.gg',
+    noopHandlers(),
+    (url) => {
+      factoryUrls.push(url);
+      const s = new FakeSocket('injected');
+      sockets.push(s);
+      return s as unknown as never;
+    },
+    timers.seam,
+  );
+  gateway.connect(false);
+  return { socket: sockets[0], timers, gateway, factoryUrls, sockets };
+}
+
+/** Deliver one gateway frame the way `ws` does, as a Buffer. */
+function frame(socket: FakeSocket, payload: unknown): void {
+  socket.emit('message', Buffer.from(JSON.stringify(payload)));
+}
+
+function lastSent(socket: FakeSocket): { op: number; d: Record<string, unknown> } {
+  return JSON.parse(socket.sent[socket.sent.length - 1]) as {
+    op: number;
+    d: Record<string, unknown>;
+  };
+}
+
 beforeEach(() => {
   constructed.length = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 describe('Gateway production defaults', () => {
@@ -104,6 +161,30 @@ describe('Gateway production defaults', () => {
       'error',
       'message',
     ]);
+  });
+
+  it('runs the reconnect delay and the heartbeat on the REAL global timers', async () => {
+    // The socket factory has a default-path test above; the timers seam did not,
+    // so replacing all three members with no-ops used to keep the suite green
+    // while the production bot would never heartbeat and never reconnect.
+    vi.useFakeTimers();
+    const gateway = new Gateway('tok', 'wss://gateway.discord.gg', noopHandlers());
+    gateway.connect(false);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // A HELLO on the default timers must arm a real interval.
+    frame(constructed[0].socket, { op: 10, d: { heartbeat_interval: 30_000 } });
+    expect(constructed[0].socket.sent.length).toBe(1); // IDENTIFY
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(lastSent(constructed[0].socket).op).toBe(1); // the heartbeat fired
+
+    // And an abnormal close must arm a real 2000 ms reconnect.
+    constructed[0].socket.emit('close', 1006);
+    expect(constructed.length).toBe(1);
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(constructed.length).toBe(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(constructed.length).toBe(2);
   });
 });
 
@@ -132,54 +213,281 @@ describe('Gateway injected socket factory', () => {
   });
 
   it('IDENTIFYs over the injected socket on HELLO and starts the heartbeat', () => {
+    const { socket, timers } = rig();
+
+    // 30000 deliberately, NOT 41250: 41250 is heartbeatIntervalMs's own default,
+    // so a gateway that ignored the HELLO payload entirely would still produce
+    // it and the assertion could not fail.
+    frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
+
+    expect(timers.intervals.map((i) => i.ms)).toEqual([30_000]);
+    const identify = lastSent(socket);
+    expect(identify.op).toBe(2); // IDENTIFY
+    expect(identify.d.token).toBe('tok');
+  });
+});
+
+describe('Gateway heartbeat', () => {
+  it('beats with the last seq it saw, and clears acked before each beat', () => {
+    const { socket, timers } = rig();
+    frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
+    // A DISPATCH carrying s=7 is what advances the sequence the heartbeat sends;
+    // without seq tracking Discord cannot tell what the RESUME already delivered.
+    frame(socket, { op: 0, s: 7, t: 'GUILD_CREATE', d: {} });
+
+    timers.intervals[0].fn();
+
+    expect(lastSent(socket)).toEqual({ op: 1, d: 7 });
+  });
+
+  it('terminates a zombie socket when a beat goes unacked, and resumes after an ACK', () => {
+    const { socket, timers } = rig();
+    frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
+    const beat = timers.intervals[0].fn;
+
+    beat(); // acked starts true: this one sends
+    expect(socket.terminated).toBe(0);
+    beat(); // no ACK arrived: the connection is a zombie
+    expect(socket.terminated).toBe(1);
+    // A terminate must not also send: that is the whole point of the early return.
+    expect(socket.sent.filter((s) => JSON.parse(s).op === 1).length).toBe(1);
+
+    // op 11 is HEARTBEAT_ACK; once it lands the next beat sends again.
+    frame(socket, { op: 11 });
+    beat();
+    expect(socket.terminated).toBe(1);
+    expect(socket.sent.filter((s) => JSON.parse(s).op === 1).length).toBe(2);
+  });
+
+  it('answers a server-requested heartbeat (op 1) immediately', () => {
+    const { socket } = rig();
+    frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
+    frame(socket, { op: 0, s: 3, t: 'READY', d: {} });
+
+    frame(socket, { op: 1 });
+
+    expect(lastSent(socket)).toEqual({ op: 1, d: 3 });
+  });
+
+  it('stops the heartbeat on close, so a reconnect does not stack a second one', () => {
+    const { socket, timers } = rig();
+    frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    socket.emit('close', 1006);
+
+    // The interval handle armed by startHeartbeat is the one cleared.
+    expect(timers.cleared).toEqual([1]);
+  });
+});
+
+describe('Gateway resume', () => {
+  it('captures the session from READY and RESUMEs to the resume URL after a drop', () => {
+    const { socket, timers, factoryUrls, sockets } = rig();
+    frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
+    frame(socket, {
+      op: 0,
+      s: 12,
+      t: 'READY',
+      d: { session_id: 'sess-1', resume_gateway_url: 'wss://resume.discord.gg' },
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    socket.emit('close', 1006);
+    timers.armed[0].fn(); // fire the 2000 ms reconnect
+
+    // The old socket is torn down before the new one opens.
+    expect(socket.listenersRemoved).toBe(1);
+    expect(socket.closed).toBe(1);
+    // The RESUME goes to the resume_gateway_url Discord handed back, not the
+    // original gateway URL: reconnecting to the base URL loses the session.
+    expect(factoryUrls[1]).toBe('wss://resume.discord.gg/?v=10&encoding=json');
+
+    frame(sockets[1], { op: 10, d: { heartbeat_interval: 30_000 } });
+    const resume = lastSent(sockets[1]);
+    expect(resume.op).toBe(6); // RESUME, not IDENTIFY
+    expect(resume.d).toEqual({ token: 'tok', session_id: 'sess-1', seq: 12 });
+  });
+
+  it('IDENTIFYs instead of RESUMEing when READY never gave a session', () => {
+    const { socket, timers, factoryUrls, sockets } = rig();
+    frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    socket.emit('close', 1006);
+    timers.armed[0].fn();
+
+    // No session id, so no resume URL either: back to the configured gateway.
+    expect(factoryUrls[1]).toBe('wss://gateway.discord.gg/?v=10&encoding=json');
+    frame(sockets[1], { op: 10, d: { heartbeat_interval: 30_000 } });
+    expect(lastSent(sockets[1]).op).toBe(2); // IDENTIFY
+  });
+
+  it('re-identifies after a non-resumable INVALID_SESSION, and resumes after a resumable one', () => {
+    for (const [resumable, expectedOp] of [
+      [false, 2], // d=false: the session is gone, start a fresh IDENTIFY
+      [true, 6], // d=true: Discord says the session survives, RESUME it
+    ] as const) {
+      constructed.length = 0;
+      const { socket, timers, sockets } = rig();
+      frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
+      frame(socket, {
+        op: 0,
+        s: 5,
+        t: 'READY',
+        d: { session_id: 'sess-1', resume_gateway_url: 'wss://resume.discord.gg' },
+      });
+
+      frame(socket, { op: 9, d: resumable });
+
+      // op 9 reconnects on its own short delay, not the 2000 ms close delay.
+      expect(timers.armed.map((t) => t.ms)).toEqual([1500]);
+      timers.armed[0].fn();
+      frame(sockets[1], { op: 10, d: { heartbeat_interval: 30_000 } });
+      expect(lastSent(sockets[1]).op).toBe(expectedOp);
+    }
+  });
+
+  it('does not aim at the resume URL when READY gave one but no session id', () => {
+    // A malformed READY is the only state where connect()'s own
+    // `this.sessionId !== null` check does work its two consumers do not already
+    // do: without it the bot would reconnect to the resume endpoint carrying no
+    // session, which Discord answers with INVALID_SESSION rather than a resume.
+    const { socket, timers, factoryUrls, sockets } = rig();
+    frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
+    frame(socket, {
+      op: 0,
+      s: 4,
+      t: 'READY',
+      d: { resume_gateway_url: 'wss://resume.discord.gg' },
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    socket.emit('close', 1006);
+    timers.armed[0].fn();
+
+    expect(factoryUrls[1]).toBe('wss://gateway.discord.gg/?v=10&encoding=json');
+    frame(sockets[1], { op: 10, d: { heartbeat_interval: 30_000 } });
+    expect(lastSent(sockets[1]).op).toBe(2); // IDENTIFY, not RESUME
+  });
+
+  it('reconnects immediately on op 7 RECONNECT, with no delay at all', () => {
+    const { socket, timers, sockets } = rig();
+    frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
+    frame(socket, { op: 0, s: 1, t: 'READY', d: { session_id: 'sess-1' } });
+
+    frame(socket, { op: 7 });
+
+    expect(timers.armed).toEqual([]); // op 7 means "now", not "in a moment"
+    expect(sockets.length).toBe(2);
+  });
+});
+
+describe('Gateway close handling', () => {
+  it('does NOT reconnect after ANY fatal close code', () => {
+    // The whole set matters, not just 4014: 4004 is a bad/rotated token, and
+    // reconnecting on it hammers Discord with a doomed handshake forever.
+    for (const code of [4004, 4010, 4011, 4012, 4013, 4014]) {
+      const { socket, timers, sockets } = rig();
+      const errors: unknown[][] = [];
+      vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+        errors.push(args);
+      });
+
+      socket.emit('close', code);
+
+      expect(timers.armed).toEqual([]);
+      expect(sockets.length).toBe(1);
+      // The log line is the only operator-visible signal that the bot stopped.
+      expect(errors).toEqual([[`[bot] gateway closed with fatal code ${code}; not reconnecting`]]);
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('DOES reconnect after a non-fatal close, and actually opens the new socket', () => {
+    for (const code of [1000, 1001, 1006, 4000, 4009]) {
+      const { socket, timers, sockets, factoryUrls } = rig();
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      socket.emit('close', code);
+
+      expect(timers.armed.map((t) => t.ms)).toEqual([2000]);
+      expect(sockets.length).toBe(1); // nothing until the delay elapses
+      timers.armed[0].fn();
+      // Firing the timer must genuinely reconnect: an empty callback used to
+      // pass here, which would leave the bot silently offline after a drop.
+      expect(sockets.length).toBe(2);
+      expect(factoryUrls[1]).toBe('wss://gateway.discord.gg/?v=10&encoding=json');
+      vi.restoreAllMocks();
+    }
+  });
+});
+
+describe('Gateway send guard and dispatch', () => {
+  it('sends nothing while the socket is not OPEN', () => {
+    const { socket } = rig();
+    socket.readyState = 0; // CONNECTING
+
+    frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
+
+    // The IDENTIFY is dropped rather than thrown: sending on a CONNECTING ws
+    // raises, and the reconnect path re-IDENTIFYs anyway.
+    expect(socket.sent).toEqual([]);
+  });
+
+  it('requests the full member list with op 8', () => {
+    const { socket, gateway } = rig();
+
+    gateway.requestGuildMembers('g1');
+
+    // query '' + limit 0 is what asks for EVERY member, online and offline; the
+    // op 8 backfill is the only way large guilds learn about offline staff.
+    expect(JSON.parse(socket.sent[socket.sent.length - 1])).toEqual({
+      op: 8,
+      d: { guild_id: 'g1', query: '', limit: 0, presences: true },
+    });
+  });
+
+  it('forwards each DISPATCH to the handler and survives a throwing handler', () => {
+    const seen: [string, Record<string, unknown>][] = [];
     const timers = fakeTimers();
     const socket = new FakeSocket('injected');
     const gateway = new Gateway(
       'tok',
       'wss://gateway.discord.gg',
-      noopHandlers(),
+      {
+        onDispatch: (type, data) => {
+          seen.push([type, data]);
+          if (type === 'BOOM') throw new Error('handler exploded');
+        },
+      },
       () => socket as unknown as never,
       timers.seam,
     );
     gateway.connect(false);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    socket.emit(
-      'message',
-      Buffer.from(JSON.stringify({ op: 10, d: { heartbeat_interval: 41250 } })),
-    );
+    frame(socket, { op: 0, s: 1, t: 'GUILD_CREATE', d: { id: 'g1' } });
+    frame(socket, { op: 0, s: 2, t: 'BOOM', d: {} });
+    // A later frame must still be delivered: one bad handler call cannot kill
+    // the socket's message pump.
+    frame(socket, { op: 0, s: 3, t: 'GUILD_MEMBER_ADD', d: { user: { id: 'u1' } } });
 
-    // The heartbeat runs on the interval Discord handed back in HELLO.
-    expect(timers.intervals.map((i) => i.ms)).toEqual([41250]);
-    const identify = JSON.parse(socket.sent[socket.sent.length - 1]) as {
-      op: number;
-      d: { token: string };
-    };
-    expect(identify.op).toBe(2); // IDENTIFY
-    expect(identify.d.token).toBe('tok');
+    expect(seen.map(([t]) => t)).toEqual(['GUILD_CREATE', 'BOOM', 'GUILD_MEMBER_ADD']);
+    expect(seen[0][1]).toEqual({ id: 'g1' });
   });
 
-  it('does NOT reconnect after a fatal close code, but does after a normal one', () => {
-    for (const [code, expectedReconnects] of [
-      [4014, 0], // disallowed privileged intents: reconnecting would loop forever
-      [1006, 1], // abnormal close: reconnect after the 2000 ms delay
-    ] as const) {
-      const timers = fakeTimers();
-      const socket = new FakeSocket('injected');
-      const gateway = new Gateway(
-        'tok',
-        'wss://gateway.discord.gg',
-        noopHandlers(),
-        () => socket as unknown as never,
-        timers.seam,
-      );
-      gateway.connect(false);
-      vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('survives an unparseable frame', () => {
+    const { socket } = rig();
+    const errors: unknown[][] = [];
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args);
+    });
 
-      socket.emit('close', code);
+    socket.emit('message', Buffer.from('{not json'));
+    frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
 
-      expect(timers.armed.length).toBe(expectedReconnects);
-      if (expectedReconnects > 0) expect(timers.armed[0].ms).toBe(2000);
-      vi.restoreAllMocks();
-    }
+    expect(errors[0][0]).toBe('[bot] gateway parse error');
+    expect(lastSent(socket).op).toBe(2); // the pump still works
   });
 });

--- a/tests/discord_bot_gateway.test.ts
+++ b/tests/discord_bot_gateway.test.ts
@@ -400,10 +400,12 @@ describe('Gateway resume', () => {
 });
 
 describe('Gateway close handling', () => {
-  it('does NOT reconnect after ANY fatal close code', () => {
-    // The whole set matters, not just 4014: 4004 is a bad/rotated token, and
-    // reconnecting on it hammers Discord with a doomed handshake forever.
-    for (const code of [4004, 4010, 4011, 4012, 4013, 4014]) {
+  // One test per code rather than one loop over all of them: a loop stops at the
+  // first failing row, so a regression affecting several codes would report as one.
+  // The whole set matters, not just 4014: 4004 is a bad or rotated token, and
+  // reconnecting on it hammers Discord with a doomed handshake forever.
+  for (const code of [4004, 4010, 4011, 4012, 4013, 4014]) {
+    it(`does NOT reconnect after fatal close ${code}`, () => {
       const { socket, timers, sockets } = rig();
       const errors: unknown[][] = [];
       vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
@@ -416,12 +418,11 @@ describe('Gateway close handling', () => {
       expect(sockets.length).toBe(1);
       // The log line is the only operator-visible signal that the bot stopped.
       expect(errors).toEqual([[`[bot] gateway closed with fatal code ${code}; not reconnecting`]]);
-      vi.restoreAllMocks();
-    }
-  });
+    });
+  }
 
-  it('DOES reconnect after a non-fatal close, and actually opens the new socket', () => {
-    for (const code of [1000, 1001, 1006, 4000, 4009]) {
+  for (const code of [1000, 1001, 1006, 4000, 4009]) {
+    it(`reconnects after non-fatal close ${code}, and actually opens the new socket`, () => {
       const { socket, timers, sockets, factoryUrls } = rig();
       vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -434,8 +435,23 @@ describe('Gateway close handling', () => {
       // pass here, which would leave the bot silently offline after a drop.
       expect(sockets.length).toBe(2);
       expect(factoryUrls[1]).toBe('wss://gateway.discord.gg/?v=10&encoding=json');
-      vi.restoreAllMocks();
-    }
+    });
+  }
+
+  it('tears the old socket down even when removeAllListeners throws', () => {
+    // reconnect() wraps the teardown in an empty catch. Without it a socket that
+    // rejects the teardown (a foreign implementation, or one already destroyed)
+    // would stop the reconnect entirely and leave the bot offline for good.
+    const { socket, timers, sockets } = rig();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    socket.removeAllListeners = () => {
+      throw new Error('already destroyed');
+    };
+
+    socket.emit('close', 1006);
+    timers.armed[0].fn();
+
+    expect(sockets.length).toBe(2); // the reconnect still happened
   });
 });
 
@@ -499,6 +515,25 @@ describe('Gateway send guard and dispatch', () => {
     // connect(), and the pump still survives, so the delivery assertions above
     // pass either way. Only the log line separates the two catches.
     expect(errors).toEqual([['[bot] dispatch handler error', expect.any(Error)]]);
+  });
+
+  it('logs a socket error without tearing the connection down', () => {
+    // The 'error' listener exists to keep an emitted socket error from becoming
+    // an unhandled 'error' event, which in Node terminates the process. Nothing
+    // else in the class references it, so only driving it proves it is wired.
+    const { socket } = rig();
+    const errors: unknown[][] = [];
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args);
+    });
+
+    socket.emit('error', new Error('ECONNRESET'));
+
+    expect(errors[0][0]).toBe('[bot] gateway socket error');
+    // No reconnect, no terminate: 'error' is followed by 'close', which owns that.
+    expect(socket.terminated).toBe(0);
+    frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
+    expect(lastSent(socket).op).toBe(2); // still usable
   });
 
   it('survives an unparseable frame', () => {

--- a/tests/discord_bot_gateway.test.ts
+++ b/tests/discord_bot_gateway.test.ts
@@ -1,0 +1,185 @@
+// The Gateway socket seam. Two directions matter and they need opposite setups,
+// so `ws` is module-mocked for the whole file: the DEFAULT socket factory must
+// construct the real `ws` client at the real gateway URL (the arm a broken
+// default parameter would silently replace), and an INJECTED factory must be
+// used instead of it. The mock stands in for the `ws` module so neither arm
+// opens a socket; asserting the mocked constructor was called IS the proof that
+// the default routes through `ws`.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Every socket the code under test constructed, in order. */
+const constructed: { url: string; socket: FakeSocket }[] = [];
+
+class FakeSocket {
+  static OPEN = 1;
+  readyState = FakeSocket.OPEN;
+  readonly listeners = new Map<string, (arg: unknown) => void>();
+  readonly sent: string[] = [];
+  terminated = 0;
+
+  constructor(url: string) {
+    constructed.push({ url, socket: this });
+  }
+
+  on(event: string, cb: (arg: unknown) => void): this {
+    this.listeners.set(event, cb);
+    return this;
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  terminate(): void {
+    this.terminated += 1;
+  }
+
+  close(): void {}
+
+  emit(event: string, arg?: unknown): void {
+    this.listeners.get(event)?.(arg);
+  }
+}
+
+vi.mock('ws', () => ({ WebSocket: FakeSocket }));
+
+// Imported AFTER the mock declaration; vi.mock is hoisted, so bot/gateway.ts
+// binds to FakeSocket rather than the real client.
+const { Gateway } = await import('../bot/gateway');
+
+function noopHandlers() {
+  return { onDispatch: () => {} };
+}
+
+/** Timers that record rather than run, so no test waits on a real delay. */
+function fakeTimers() {
+  const armed: { ms: number; fn: () => void }[] = [];
+  const intervals: { ms: number; fn: () => void }[] = [];
+  const cleared: unknown[] = [];
+  return {
+    armed,
+    intervals,
+    cleared,
+    seam: {
+      setTimeout: (fn: () => void, ms: number) => {
+        armed.push({ fn, ms });
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      },
+      setInterval: (fn: () => void, ms: number) => {
+        intervals.push({ fn, ms });
+        return 0 as unknown as ReturnType<typeof setInterval>;
+      },
+      clearInterval: (id: ReturnType<typeof setInterval>) => {
+        cleared.push(id);
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  constructed.length = 0;
+});
+
+describe('Gateway production defaults', () => {
+  it('constructs the real ws client at the v10 JSON gateway URL with three arguments', () => {
+    // Exactly the construction in bot/main.ts: token, gateway URL, handlers.
+    // No socket factory, no timers.
+    const gateway = new Gateway('tok', 'wss://gateway.discord.gg', noopHandlers());
+
+    gateway.connect(false);
+
+    expect(constructed.length).toBe(1);
+    // The query string is what selects protocol v10 and JSON (not ETF) encoding;
+    // dropping either silently changes the wire format the parser expects.
+    expect(constructed[0].url).toBe('wss://gateway.discord.gg/?v=10&encoding=json');
+    expect(constructed[0].socket).toBeInstanceOf(FakeSocket);
+  });
+
+  it('registers the message, close, and error listeners on the default socket', () => {
+    const gateway = new Gateway('tok', 'wss://gateway.discord.gg', noopHandlers());
+    gateway.connect(false);
+
+    expect([...constructed[0].socket.listeners.keys()].sort()).toEqual([
+      'close',
+      'error',
+      'message',
+    ]);
+  });
+});
+
+describe('Gateway injected socket factory', () => {
+  it('uses the injected factory INSTEAD of the default, with the same URL', () => {
+    const seen: string[] = [];
+    const injected = new FakeSocket('unused');
+    const gateway = new Gateway(
+      'tok',
+      'wss://gateway.discord.gg',
+      noopHandlers(),
+      (url) => {
+        seen.push(url);
+        return injected as unknown as never;
+      },
+      fakeTimers().seam,
+    );
+
+    // The factory pushed 'unused' at its own construction, so reset the log the
+    // Gateway sees to prove the DEFAULT path did not also run.
+    constructed.length = 0;
+    gateway.connect(false);
+
+    expect(seen).toEqual(['wss://gateway.discord.gg/?v=10&encoding=json']);
+    expect(constructed).toEqual([]); // the default never constructed a socket
+  });
+
+  it('IDENTIFYs over the injected socket on HELLO and starts the heartbeat', () => {
+    const timers = fakeTimers();
+    const socket = new FakeSocket('injected');
+    const gateway = new Gateway(
+      'tok',
+      'wss://gateway.discord.gg',
+      noopHandlers(),
+      () => socket as unknown as never,
+      timers.seam,
+    );
+    gateway.connect(false);
+
+    socket.emit(
+      'message',
+      Buffer.from(JSON.stringify({ op: 10, d: { heartbeat_interval: 41250 } })),
+    );
+
+    // The heartbeat runs on the interval Discord handed back in HELLO.
+    expect(timers.intervals.map((i) => i.ms)).toEqual([41250]);
+    const identify = JSON.parse(socket.sent[socket.sent.length - 1]) as {
+      op: number;
+      d: { token: string };
+    };
+    expect(identify.op).toBe(2); // IDENTIFY
+    expect(identify.d.token).toBe('tok');
+  });
+
+  it('does NOT reconnect after a fatal close code, but does after a normal one', () => {
+    for (const [code, expectedReconnects] of [
+      [4014, 0], // disallowed privileged intents: reconnecting would loop forever
+      [1006, 1], // abnormal close: reconnect after the 2000 ms delay
+    ] as const) {
+      const timers = fakeTimers();
+      const socket = new FakeSocket('injected');
+      const gateway = new Gateway(
+        'tok',
+        'wss://gateway.discord.gg',
+        noopHandlers(),
+        () => socket as unknown as never,
+        timers.seam,
+      );
+      gateway.connect(false);
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      socket.emit('close', code);
+
+      expect(timers.armed.length).toBe(expectedReconnects);
+      if (expectedReconnects > 0) expect(timers.armed[0].ms).toBe(2000);
+      vi.restoreAllMocks();
+    }
+  });
+});

--- a/tests/discord_bot_gateway.test.ts
+++ b/tests/discord_bot_gateway.test.ts
@@ -34,10 +34,12 @@ class FakeSocket {
 
   terminate(): void {
     this.terminated += 1;
+    this.readyState = 3; // CLOSED, as the real ws client does
   }
 
   close(): void {
     this.closed += 1;
+    this.readyState = 3;
   }
 
   // Gateway.reconnect() calls this FIRST; without it the real call throws into
@@ -257,23 +259,41 @@ describe('Gateway heartbeat', () => {
     expect(lastSent(socket)).toEqual({ op: 1, d: 7 });
   });
 
-  it('terminates a zombie socket when a beat goes unacked, and resumes after an ACK', () => {
+  it('terminates a zombie socket when a beat goes unacked', () => {
     const { socket, timers } = rig();
     frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
     const beat = timers.intervals[0].fn;
+    const beats = () => socket.sent.filter((f) => JSON.parse(f).op === 1).length;
 
     beat(); // acked starts true: this one sends
     expect(socket.terminated).toBe(0);
+    expect(beats()).toBe(1);
+
     beat(); // no ACK arrived: the connection is a zombie
     expect(socket.terminated).toBe(1);
-    // A terminate must not also send: that is the whole point of the early return.
-    expect(socket.sent.filter((s) => JSON.parse(s).op === 1).length).toBe(1);
+    // A terminate must NOT also send: that is the whole point of the early
+    // return. (The fake goes to readyState CLOSED on terminate, as ws does, so
+    // this also proves the guard rather than the fake's willingness to buffer.)
+    expect(beats()).toBe(1);
+  });
 
-    // op 11 is HEARTBEAT_ACK; once it lands the next beat sends again.
+  it('keeps beating while ACKs keep arriving', () => {
+    // The other half of the same flag, on a socket that stays alive: op 11 is
+    // HEARTBEAT_ACK, and each one has to re-arm the next beat. Without the
+    // reset every second beat would kill a perfectly healthy connection.
+    const { socket, timers } = rig();
+    frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
+    const beat = timers.intervals[0].fn;
+    const beats = () => socket.sent.filter((f) => JSON.parse(f).op === 1).length;
+
+    beat();
     frame(socket, { op: 11 });
     beat();
-    expect(socket.terminated).toBe(1);
-    expect(socket.sent.filter((s) => JSON.parse(s).op === 1).length).toBe(2);
+    frame(socket, { op: 11 });
+    beat();
+
+    expect(beats()).toBe(3);
+    expect(socket.terminated).toBe(0);
   });
 
   it('answers a server-requested heartbeat (op 1) immediately', () => {
@@ -284,6 +304,24 @@ describe('Gateway heartbeat', () => {
     frame(socket, { op: 1 });
 
     expect(lastSent(socket)).toEqual({ op: 1, d: 3 });
+  });
+
+  it('does not stack a second interval when a reconnect never saw a close', () => {
+    // op 7 and INVALID_SESSION reconnect WITHOUT a close event, so onClose's
+    // stopHeartbeat never runs and the leading stopHeartbeat() inside
+    // startHeartbeat is the only thing left. Drop it and every reconnect leaves
+    // another live interval beating against a dead socket forever, which is the
+    // request-amplification shape this whole packet exists to stop.
+    const { socket, timers, sockets } = rig();
+    frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
+    expect(timers.intervals.length).toBe(1);
+
+    frame(socket, { op: 7 }); // RECONNECT: no close, straight to a new socket
+    frame(sockets[1], { op: 10, d: { heartbeat_interval: 30_000 } });
+
+    // Two armed in total, but the FIRST was cleared before the second started.
+    expect(timers.intervals.length).toBe(2);
+    expect(timers.cleared).toEqual([1]);
   });
 
   it('stops the heartbeat on close, so a reconnect does not stack a second one', () => {

--- a/tests/discord_bot_gateway.test.ts
+++ b/tests/discord_bot_gateway.test.ts
@@ -191,6 +191,17 @@ describe('Gateway production defaults', () => {
     expect(constructed.length).toBe(1);
     await vi.advanceTimersByTimeAsync(1);
     expect(constructed.length).toBe(2);
+
+    // And the third member: the close ran stopHeartbeat, so the interval must
+    // be genuinely cleared on the real clock. A no-op default clearInterval
+    // would keep beating forever against every future socket.
+    // Counted as TERMINATIONS, not sends: the first beat left acked false, so a
+    // leaked interval takes the zombie branch and terminates instead of
+    // sending, which a send count cannot see.
+    const terminations = () => constructed.reduce((n, c) => n + c.socket.terminated, 0);
+    expect(terminations()).toBe(0);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(terminations()).toBe(0);
   });
 });
 

--- a/tests/discord_bot_gateway.test.ts
+++ b/tests/discord_bot_gateway.test.ts
@@ -149,7 +149,6 @@ describe('Gateway production defaults', () => {
     // The query string is what selects protocol v10 and JSON (not ETF) encoding;
     // dropping either silently changes the wire format the parser expects.
     expect(constructed[0].url).toBe('wss://gateway.discord.gg/?v=10&encoding=json');
-    expect(constructed[0].socket).toBeInstanceOf(FakeSocket);
   });
 
   it('registers the message, close, and error listeners on the default socket', () => {
@@ -167,8 +166,15 @@ describe('Gateway production defaults', () => {
     // The socket factory has a default-path test above; the timers seam did not,
     // so replacing all three members with no-ops used to keep the suite green
     // while the production bot would never heartbeat and never reconnect.
-    vi.useFakeTimers();
+    //
+    // Constructed BEFORE the fake clock is installed, per R16: the default
+    // parameter is evaluated at construction, so a capture form
+    // (`= { setTimeout, setInterval, clearInterval }`) would bind the REAL
+    // timers here and never see the fake, and neither the heartbeat nor the
+    // reconnect below would fire. Installing the fake first passes for both
+    // forms and would guard nothing.
     const gateway = new Gateway('tok', 'wss://gateway.discord.gg', noopHandlers());
+    vi.useFakeTimers();
     gateway.connect(false);
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -228,7 +234,7 @@ describe('Gateway injected socket factory', () => {
 });
 
 describe('Gateway heartbeat', () => {
-  it('beats with the last seq it saw, and clears acked before each beat', () => {
+  it('beats with the last seq it saw', () => {
     const { socket, timers } = rig();
     frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
     // A DISPATCH carrying s=7 is what advances the sequence the heartbeat sends;
@@ -328,7 +334,6 @@ describe('Gateway resume', () => {
       [false, 2], // d=false: the session is gone, start a fresh IDENTIFY
       [true, 6], // d=true: Discord says the session survives, RESUME it
     ] as const) {
-      constructed.length = 0;
       const { socket, timers, sockets } = rig();
       frame(socket, { op: 10, d: { heartbeat_interval: 30_000 } });
       frame(socket, {
@@ -465,7 +470,10 @@ describe('Gateway send guard and dispatch', () => {
       timers.seam,
     );
     gateway.connect(false);
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const errors: unknown[][] = [];
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args);
+    });
 
     frame(socket, { op: 0, s: 1, t: 'GUILD_CREATE', d: { id: 'g1' } });
     frame(socket, { op: 0, s: 2, t: 'BOOM', d: {} });
@@ -475,6 +483,11 @@ describe('Gateway send guard and dispatch', () => {
 
     expect(seen.map(([t]) => t)).toEqual(['GUILD_CREATE', 'BOOM', 'GUILD_MEMBER_ADD']);
     expect(seen[0][1]).toEqual({ id: 'g1' });
+    // The MESSAGE label, not the parse one. Without the inner try/catch around
+    // onDispatch the throw still gets swallowed, by the outer handler in
+    // connect(), and the pump still survives, so the delivery assertions above
+    // pass either way. Only the log line separates the two catches.
+    expect(errors).toEqual([['[bot] dispatch handler error', expect.any(Error)]]);
   });
 
   it('survives an unparseable frame', () => {

--- a/tests/discord_bot_server_client.test.ts
+++ b/tests/discord_bot_server_client.test.ts
@@ -1,0 +1,258 @@
+// The ServerClient request envelope: what actually reaches the game server's
+// secret-gated /internal/discord/* endpoints, and how the per-call abort
+// deadline is armed and cleared. Everything runs through the injected fetch and
+// timer seams, so there is no network IO and no real 8 second wait; the last
+// case constructs the client the way bot/main.ts does (two arguments) to prove
+// the production defaults are still the real globals.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  SERVER_CALL_TIMEOUT_MS,
+  ServerClient,
+  type TimerHandle,
+  type TimerSeam,
+} from '../bot/server_client';
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+/** A response carrying only the three fields `call()` touches. `reads` records
+ *  every body read, so a test can prove a body was never parsed. */
+function fakeResponse(opts: { status?: number; body?: unknown; reads?: string[] } = {}): Response {
+  const status = opts.status ?? 200;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => {
+      opts.reads?.push('json');
+      return opts.body;
+    },
+  } as unknown as Response;
+}
+
+/** A fetch that logs every call and answers from the supplied responder. */
+function recordingFetch(respond: (call: FetchCall) => Promise<Response> | Response): {
+  calls: FetchCall[];
+  impl: typeof fetch;
+} {
+  const calls: FetchCall[] = [];
+  const impl: typeof fetch = async (input, init) => {
+    const call: FetchCall = { url: String(input), init: init ?? {} };
+    calls.push(call);
+    return respond(call);
+  };
+  return { calls, impl };
+}
+
+/** A timer pair that arms nothing: the test fires the deadline by hand. */
+function fakeTimers(): {
+  armed: { fn: () => void; ms: number }[];
+  cleared: TimerHandle[];
+  seam: TimerSeam;
+} {
+  const armed: { fn: () => void; ms: number }[] = [];
+  const cleared: TimerHandle[] = [];
+  let nextHandle = 1;
+  const seam: TimerSeam = {
+    setTimeout: (fn, ms) => {
+      armed.push({ fn, ms });
+      return nextHandle++;
+    },
+    clearTimeout: (handle) => {
+      cleared.push(handle);
+    },
+  };
+  return { armed, cleared, seam };
+}
+
+const ROLES_ENVELOPE = {
+  success: true,
+  data: { linked: true, statusTier: 3, points: 12, lifetimePoints: 40 },
+  error: null,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('ServerClient request envelope', () => {
+  it('sends the method, the RAW baseUrl + path concatenation, and the secret header', async () => {
+    const timers = fakeTimers();
+    const { calls, impl } = recordingFetch(() => fakeResponse({ body: ROLES_ENVELOPE }));
+    // The trailing slash on the base is deliberate: nothing normalizes the URL.
+    const client = new ServerClient('http://host:8787/', 'sekrit', impl, timers.seam);
+
+    const roles = await client.roles('u 1');
+
+    expect(calls.length).toBe(1);
+    expect(calls[0].init.method).toBe('GET');
+    // Both slashes survive, and the id is percent-encoded by the caller.
+    expect(calls[0].url).toBe('http://host:8787//internal/discord/roles?discord_user_id=u%201');
+    // Lowercase header name, the secret verbatim, no Bearer prefix, and the
+    // JSON content type even though this GET carries no body.
+    expect(calls[0].init.headers).toEqual({
+      'x-woc-discord-secret': 'sekrit',
+      'Content-Type': 'application/json',
+    });
+    expect(roles).toEqual({ linked: true, statusTier: 3, points: 12, lifetimePoints: 40 });
+  });
+
+  it('leaves the body key present but undefined when no body is passed', async () => {
+    const timers = fakeTimers();
+    const { calls, impl } = recordingFetch(() =>
+      fakeResponse({ body: { success: true, data: { items: [] }, error: null } }),
+    );
+    const client = new ServerClient('http://host', 'sekrit', impl, timers.seam);
+
+    await client.drainRelay();
+
+    expect(calls[0].init.body).toBe(undefined);
+    expect('body' in calls[0].init).toBe(true);
+  });
+
+  it('POSTs the body as JSON.stringify output, byte for byte', async () => {
+    const timers = fakeTimers();
+    const { calls, impl } = recordingFetch(() =>
+      fakeResponse({ body: { success: true, data: null, error: null } }),
+    );
+    const client = new ServerClient('http://host', 'sekrit', impl, timers.seam);
+
+    await client.markDailyRewardWinners('2026-07-30');
+    expect(calls[0].init.method).toBe('POST');
+    expect(calls[0].url).toBe('http://host/internal/discord/daily-rewards-winners/mark');
+    expect(calls[0].init.body).toBe('{"day":"2026-07-30"}');
+
+    // An absent dedupe key is dropped by JSON.stringify, not sent as null: the
+    // server treats a null key as a real value and would dedupe against it.
+    await client.grant('u1', 'daily', 5);
+    expect(calls[1].init.body).toBe('{"discord_user_id":"u1","reason":"daily","points":5}');
+
+    await client.grant('u1', 'daily', 5, 'k1');
+    expect(calls[2].init.body).toBe(
+      '{"discord_user_id":"u1","reason":"daily","points":5,"dedupeKey":"k1"}',
+    );
+  });
+});
+
+describe('ServerClient envelope handling', () => {
+  it('returns null for a { success: false } envelope on an HTTP 200', async () => {
+    const timers = fakeTimers();
+    const { impl } = recordingFetch(() =>
+      // Data IS present: only the success flag decides, so a server-side
+      // failure never reaches the caller as a half-filled record.
+      fakeResponse({ body: { success: false, data: { linked: true }, error: 'nope' } }),
+    );
+    const client = new ServerClient('http://host', 'sekrit', impl, timers.seam);
+
+    expect(await client.roles('u1')).toBe(null);
+    expect(timers.cleared).toEqual([1]);
+  });
+
+  it('returns null on a non-ok status and never reads the body', async () => {
+    const errors: unknown[][] = [];
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args);
+    });
+    const reads: string[] = [];
+    const timers = fakeTimers();
+    const { impl } = recordingFetch(() =>
+      fakeResponse({ status: 500, body: { success: true, data: { items: [1] } }, reads }),
+    );
+    const client = new ServerClient('http://host', 'sekrit', impl, timers.seam);
+
+    expect(await client.drainRelay()).toEqual([]);
+    expect(reads).toEqual([]);
+    expect(errors).toEqual([['[bot] server GET /internal/discord/relay -> 500']]);
+  });
+
+  it('returns null when the fetch itself rejects, and still clears the deadline', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const timers = fakeTimers();
+    const { impl } = recordingFetch(() => Promise.reject(new Error('socket hang up')));
+    const client = new ServerClient('http://host', 'sekrit', impl, timers.seam);
+
+    expect(await client.roles('u1')).toBe(null);
+    expect(timers.cleared).toEqual([1]); // the finally runs on the throwing path too
+  });
+});
+
+describe('ServerClient call deadline', () => {
+  it('pins the per-call deadline at 8000 ms', () => {
+    expect(SERVER_CALL_TIMEOUT_MS).toBe(8000);
+  });
+
+  it('arms the deadline at 8000 ms and aborts the in-flight request when it fires', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const timers = fakeTimers();
+    const signals: AbortSignal[] = [];
+    // A fetch that never settles on its own: only the abort ends it.
+    const impl: typeof fetch = (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (signal) {
+          signals.push(signal);
+          signal.addEventListener('abort', () => reject(new Error('The operation was aborted')));
+        }
+      });
+    const client = new ServerClient('http://host', 'sekrit', impl, timers.seam);
+
+    const pending = client.roles('u1');
+    expect(timers.armed.length).toBe(1);
+    expect(timers.armed[0].ms).toBe(8000);
+    expect(signals[0].aborted).toBe(false);
+
+    timers.armed[0].fn(); // fire the deadline
+
+    expect(signals[0].aborted).toBe(true);
+    expect(await pending).toBe(null);
+    expect(timers.cleared).toEqual([1]);
+  });
+
+  it('arms and clears one deadline PER call, each with its own signal', async () => {
+    const timers = fakeTimers();
+    const { calls, impl } = recordingFetch(() => fakeResponse({ body: ROLES_ENVELOPE }));
+    const client = new ServerClient('http://host', 'sekrit', impl, timers.seam);
+
+    await client.roles('u1');
+    await client.roles('u2');
+
+    expect(timers.armed.map((t) => t.ms)).toEqual([8000, 8000]);
+    // Cleared on the success path too: without the finally, every call would
+    // leak an 8 second handle.
+    expect(timers.cleared).toEqual([1, 2]);
+    expect(calls[0].init.signal).not.toBe(calls[1].init.signal);
+  });
+});
+
+describe('ServerClient production defaults', () => {
+  it('uses the real global fetch and the real 8000 ms deadline when constructed with two arguments', async () => {
+    const seen: string[] = [];
+    const armedMs: number[] = [];
+    const realSetTimeout = globalThis.setTimeout;
+    vi.stubGlobal('fetch', async (input: unknown) => {
+      seen.push(String(input));
+      return fakeResponse({ body: { success: true, data: { items: [{ id: 7 }] }, error: null } });
+    });
+    // Delegates to the real timer so the deadline is a genuine handle the
+    // client's finally can clear.
+    vi.stubGlobal('setTimeout', (fn: () => void, ms?: number) => {
+      armedMs.push(ms ?? -1);
+      return realSetTimeout(fn, ms);
+    });
+
+    try {
+      // Exactly the construction in bot/main.ts: no fetch, no timer seam.
+      const client = new ServerClient('http://host:8787', 'sekrit');
+      expect(await client.drainRelay()).toEqual([{ id: 7 }]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    expect(seen).toEqual(['http://host:8787/internal/discord/relay']);
+    // Exactly one arm, at the real deadline: the defaults read the globals and
+    // pass the production timeout, not an injected one.
+    expect(armedMs).toEqual([8000]);
+  });
+});

--- a/tests/discord_bot_server_client.test.ts
+++ b/tests/discord_bot_server_client.test.ts
@@ -488,7 +488,7 @@ describe('ServerClient call deadline', () => {
     expect(await first).toBe(null);
     settle[1](fakeResponse({ body: ROLES_ENVELOPE }));
     expect(await second).toEqual({ linked: true, statusTier: 3, points: 12, lifetimePoints: 40 });
-    expect(timers.cleared.sort()).toEqual([1, 2]);
+    expect([...timers.cleared].sort((a, b) => Number(a) - Number(b))).toEqual([1, 2]);
   });
 });
 

--- a/tests/discord_bot_server_client.test.ts
+++ b/tests/discord_bot_server_client.test.ts
@@ -2,7 +2,7 @@
 // secret-gated /internal/discord/* endpoints, and how the per-call abort
 // deadline is armed and cleared. Everything runs through the injected fetch and
 // timer seams, so there is no network IO and no real 8 second wait; the last
-// case constructs the client the way bot/main.ts does (two arguments) to prove
+// block constructs the client the way bot/main.ts does (two arguments) to prove
 // the production defaults are still the real globals.
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -66,6 +66,14 @@ function fakeTimers(): {
   return { armed, cleared, seam };
 }
 
+/** A client whose every call succeeds with `data`, plus the recorded calls. */
+function clientReturning(data: unknown): { calls: FetchCall[]; client: ServerClient } {
+  const { calls, impl } = recordingFetch(() =>
+    fakeResponse({ body: { success: true, data, error: null } }),
+  );
+  return { calls, client: new ServerClient('http://host', 'sekrit', impl, fakeTimers().seam) };
+}
+
 const ROLES_ENVELOPE = {
   success: true,
   data: { linked: true, statusTier: 3, points: 12, lifetimePoints: 40 },
@@ -99,7 +107,11 @@ describe('ServerClient request envelope', () => {
     expect(roles).toEqual({ linked: true, statusTier: 3, points: 12, lifetimePoints: 40 });
   });
 
-  it('leaves the body key present but undefined when no body is passed', async () => {
+  it('sends no body on a GET', async () => {
+    // Note this does NOT pin the `body === undefined ? undefined :` ternary in
+    // call(): JSON.stringify(undefined) is itself undefined, so the guard is
+    // defensive rather than load-bearing and no assertion can distinguish it.
+    // What this DOES pin is that a GET reaches fetch with no body at all.
     const timers = fakeTimers();
     const { calls, impl } = recordingFetch(() =>
       fakeResponse({ body: { success: true, data: { items: [] }, error: null } }),
@@ -134,6 +146,110 @@ describe('ServerClient request envelope', () => {
       '{"discord_user_id":"u1","reason":"daily","points":5,"dedupeKey":"k1"}',
     );
   });
+});
+
+describe('ServerClient per-endpoint routes', () => {
+  // Each row is the ONE wire contract only that method can get wrong. A typo in
+  // any path 404s, call() returns null, and the drain methods answer with an
+  // empty array, so the feed stops with no error surface at all.
+  const ROWS: {
+    name: string;
+    drive: (c: ServerClient) => Promise<unknown>;
+    method: string;
+    path: string;
+    body: string | undefined;
+    data: unknown;
+  }[] = [
+    {
+      name: 'flex',
+      drive: (c) => c.flex('u 1'),
+      method: 'GET',
+      path: '/internal/discord/flex?discord_user_id=u%201',
+      body: undefined,
+      data: { linked: true },
+    },
+    {
+      name: 'roles',
+      drive: (c) => c.roles('u 1'),
+      method: 'GET',
+      path: '/internal/discord/roles?discord_user_id=u%201',
+      body: undefined,
+      data: {},
+    },
+    {
+      name: 'pushPresence',
+      drive: (c) =>
+        c.pushPresence({ onlineCount: 3, memberTotal: 9, voiceChannelName: null, voice: [] }),
+      method: 'POST',
+      path: '/internal/discord/presence',
+      body: '{"onlineCount":3,"memberTotal":9,"voiceChannelName":null,"voice":[]}',
+      data: {},
+    },
+    {
+      name: 'setMember',
+      drive: (c) => c.setMember('u1', true),
+      method: 'POST',
+      path: '/internal/discord/member',
+      body: '{"discord_user_id":"u1","guildMember":true}',
+      data: {},
+    },
+    {
+      name: 'drainRelay',
+      drive: (c) => c.drainRelay(),
+      method: 'GET',
+      path: '/internal/discord/relay',
+      body: undefined,
+      data: { items: [] },
+    },
+    {
+      name: 'drainActivity',
+      drive: (c) => c.drainActivity(),
+      method: 'GET',
+      path: '/internal/discord/activity',
+      body: undefined,
+      data: { items: [] },
+    },
+    {
+      name: 'dailyRewardWinners',
+      drive: (c) => c.dailyRewardWinners(),
+      method: 'GET',
+      // limit=2 decides how many days of winners can still be announced after a
+      // missed run; shrinking it silently drops a day.
+      path: '/internal/discord/daily-rewards-winners?limit=2',
+      body: undefined,
+      data: { days: [] },
+    },
+    {
+      name: 'pushMembersMeta',
+      drive: (c) =>
+        c.pushMembersMeta([{ discord_user_id: 'u1', name: 'A', joinedAtMs: 1, role: null }]),
+      method: 'POST',
+      path: '/internal/discord/members-meta',
+      body: '{"members":[{"discord_user_id":"u1","name":"A","joinedAtMs":1,"role":null}]}',
+      data: { updated: 1 },
+    },
+    {
+      name: 'flairedIds',
+      drive: (c) => c.flairedIds(),
+      method: 'GET',
+      path: '/internal/discord/flaired-ids',
+      body: undefined,
+      data: { ids: [] },
+    },
+  ];
+
+  for (const row of ROWS) {
+    it(`${row.name} sends ${row.method} ${row.path}`, async () => {
+      const { calls, client } = clientReturning(row.data);
+
+      await row.drive(client);
+
+      expect(calls.length).toBe(1);
+      expect(calls[0].init.method).toBe(row.method);
+      expect(calls[0].url).toBe(`http://host${row.path}`);
+      expect(calls[0].init.body).toBe(row.body);
+    });
+  }
 });
 
 describe('ServerClient envelope handling', () => {
@@ -175,6 +291,88 @@ describe('ServerClient envelope handling', () => {
 
     expect(await client.roles('u1')).toBe(null);
     expect(timers.cleared).toEqual([1]); // the finally runs on the throwing path too
+  });
+});
+
+describe('ServerClient flairedIds null-versus-empty contract', () => {
+  it('returns the ids, keeping only the strings', async () => {
+    // The reconcile treats every id it gets back as "still flaired"; a stray
+    // number would stringify into an id that matches nobody and silently drop
+    // that member's flair.
+    const { client } = clientReturning({ ids: ['a', 1, null, 'b', { id: 'c' }] });
+    expect(await client.flairedIds()).toEqual(['a', 'b']);
+  });
+
+  it('returns an EMPTY ARRAY for a real "nothing flagged" answer', async () => {
+    const { client } = clientReturning({ ids: [] });
+    expect(await client.flairedIds()).toEqual([]);
+  });
+
+  it('returns NULL when the server is unreachable or the payload is malformed', async () => {
+    // Null means "change nothing" per the method's own doc comment. Collapsing
+    // it to an empty array would tell the departed-member reconcile that every
+    // linked member lost their flair, and strip the lot.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const timers = fakeTimers();
+
+    const unreachable = new ServerClient(
+      'http://host',
+      'sekrit',
+      recordingFetch(() => fakeResponse({ status: 503 })).impl,
+      timers.seam,
+    );
+    expect(await unreachable.flairedIds()).toBe(null);
+
+    for (const ids of [undefined, null, 'a,b', { 0: 'a' }, 7]) {
+      const { client } = clientReturning({ ids });
+      expect(await client.flairedIds()).toBe(null);
+    }
+  });
+});
+
+describe('ServerClient pushMembersMeta silent-drop warning', () => {
+  it('warns when a NON-EMPTY push processed zero rows', async () => {
+    // The server coerces an over-cap body to an empty member list and still
+    // answers 200 { updated: 0 }, so this is the one silent-drop signature.
+    const errors: unknown[][] = [];
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args);
+    });
+    const { client } = clientReturning({ updated: 0 });
+
+    await client.pushMembersMeta([
+      { discord_user_id: 'u1', name: 'A', joinedAtMs: null, role: null },
+      { discord_user_id: 'u2', name: 'B', joinedAtMs: null, role: null },
+    ]);
+
+    expect(errors).toEqual([['[bot] members-meta push of 2 processed 0 rows']]);
+  });
+
+  it('stays quiet when rows were processed, when the push was empty, and on failure', async () => {
+    const errors: unknown[][] = [];
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args);
+    });
+    const member = { discord_user_id: 'u1', name: 'A', joinedAtMs: null, role: null };
+
+    // Rows processed: nothing to report.
+    await clientReturning({ updated: 1 }).client.pushMembersMeta([member]);
+    // An empty push legitimately updates nothing, so the guard is on the
+    // REQUEST being non-empty, not on the response alone.
+    await clientReturning({ updated: 0 }).client.pushMembersMeta([]);
+
+    expect(errors).toEqual([]);
+
+    // A failed call returns null, which must not be read as a zero-row success.
+    const timers = fakeTimers();
+    const failed = new ServerClient(
+      'http://host',
+      'sekrit',
+      recordingFetch(() => fakeResponse({ status: 500 })).impl,
+      timers.seam,
+    );
+    await failed.pushMembersMeta([member]);
+    expect(errors).toEqual([['[bot] server POST /internal/discord/members-meta -> 500']]);
   });
 });
 
@@ -227,10 +425,20 @@ describe('ServerClient call deadline', () => {
 });
 
 describe('ServerClient production defaults', () => {
-  it('uses the real global fetch and the real 8000 ms deadline when constructed with two arguments', async () => {
+  it('reads the global fetch and timers at CALL time, and clears the handle it armed', async () => {
+    // Exactly the construction in bot/main.ts: no fetch, no timer seam. It
+    // happens BEFORE the stubs deliberately, because a capture-form default
+    // (`= fetch`, `= { setTimeout, clearTimeout }`) would bind the pre-stub
+    // globals and never see the swap. That is the regression bot/CLAUDE.md's
+    // forward-to-the-global invariant exists to prevent, and a
+    // stub-then-construct ordering cannot detect it.
+    const client = new ServerClient('http://host:8787', 'sekrit');
+
     const seen: string[] = [];
-    const armedMs: number[] = [];
+    const armed: { ms: number; handle: unknown }[] = [];
+    const cleared: unknown[] = [];
     const realSetTimeout = globalThis.setTimeout;
+    const realClearTimeout = globalThis.clearTimeout;
     vi.stubGlobal('fetch', async (input: unknown) => {
       seen.push(String(input));
       return fakeResponse({ body: { success: true, data: { items: [{ id: 7 }] }, error: null } });
@@ -238,13 +446,16 @@ describe('ServerClient production defaults', () => {
     // Delegates to the real timer so the deadline is a genuine handle the
     // client's finally can clear.
     vi.stubGlobal('setTimeout', (fn: () => void, ms?: number) => {
-      armedMs.push(ms ?? -1);
-      return realSetTimeout(fn, ms);
+      const handle = realSetTimeout(fn, ms);
+      armed.push({ ms: ms ?? -1, handle });
+      return handle;
+    });
+    vi.stubGlobal('clearTimeout', (handle: unknown) => {
+      cleared.push(handle);
+      realClearTimeout(handle as Parameters<typeof clearTimeout>[0]);
     });
 
     try {
-      // Exactly the construction in bot/main.ts: no fetch, no timer seam.
-      const client = new ServerClient('http://host:8787', 'sekrit');
       expect(await client.drainRelay()).toEqual([{ id: 7 }]);
     } finally {
       vi.unstubAllGlobals();
@@ -253,6 +464,10 @@ describe('ServerClient production defaults', () => {
     expect(seen).toEqual(['http://host:8787/internal/discord/relay']);
     // Exactly one arm, at the real deadline: the defaults read the globals and
     // pass the production timeout, not an injected one.
-    expect(armedMs).toEqual([8000]);
+    expect(armed.map((a) => a.ms)).toEqual([8000]);
+    // And the default clearTimeout really cancels THAT handle. Without this the
+    // member could be a no-op and every call would leak a live 8 second timer;
+    // the relay poller runs every 3 seconds, so the backlog is permanent.
+    expect(cleared).toEqual([armed[0].handle]);
   });
 });

--- a/tests/discord_bot_server_client.test.ts
+++ b/tests/discord_bot_server_client.test.ts
@@ -194,6 +194,23 @@ describe('ServerClient per-endpoint routes', () => {
       data: {},
     },
     {
+      name: 'grant',
+      drive: (c) => c.grant('u1', 'daily', 5, 'k1'),
+      method: 'POST',
+      // The points-granting call: a path swap here silently stops every reward.
+      path: '/internal/discord/grant',
+      body: '{"discord_user_id":"u1","reason":"daily","points":5,"dedupeKey":"k1"}',
+      data: {},
+    },
+    {
+      name: 'markDailyRewardWinners',
+      drive: (c) => c.markDailyRewardWinners('2026-07-30'),
+      method: 'POST',
+      path: '/internal/discord/daily-rewards-winners/mark',
+      body: '{"day":"2026-07-30"}',
+      data: {},
+    },
+    {
       name: 'drainRelay',
       drive: (c) => c.drainRelay(),
       method: 'GET',
@@ -281,6 +298,23 @@ describe('ServerClient envelope handling', () => {
     expect(await client.drainRelay()).toEqual([]);
     expect(reads).toEqual([]);
     expect(errors).toEqual([['[bot] server GET /internal/discord/relay -> 500']]);
+  });
+
+  it('treats a 3xx as not-ok, not just a 5xx', async () => {
+    // 200 and 500 agree under every plausible rewrite of `!resp.ok`, including
+    // `resp.status >= 400`. A redirect is where they part: the game server
+    // answering 301 (a proxy misconfiguration, the realistic case) must not be
+    // read as success and parsed as an envelope.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const reads: string[] = [];
+    const timers = fakeTimers();
+    const { impl } = recordingFetch(() =>
+      fakeResponse({ status: 301, body: { success: true, data: { items: [1] } }, reads }),
+    );
+    const client = new ServerClient('http://host', 'sekrit', impl, timers.seam);
+
+    expect(await client.drainRelay()).toEqual([]);
+    expect(reads).toEqual([]);
   });
 
   it('returns null when the fetch itself rejects, and still clears the deadline', async () => {
@@ -422,6 +456,40 @@ describe('ServerClient call deadline', () => {
     expect(timers.cleared).toEqual([1, 2]);
     expect(calls[0].init.signal).not.toBe(calls[1].init.signal);
   });
+
+  it('keeps each in-flight call on its OWN handle and signal when they overlap', async () => {
+    // The sequential test above cannot see a shared handle: call 2 arms after
+    // call 1 has already cleared. The bot's poll loops genuinely overlap (six
+    // of them, two on a 3 second tick), so a shared controller would let one
+    // call's deadline abort another's request.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const timers = fakeTimers();
+    const settle: ((r: Response) => void)[] = [];
+    const signals: (AbortSignal | null | undefined)[] = [];
+    const impl: typeof fetch = (_input, init) => {
+      signals.push(init?.signal);
+      return new Promise<Response>((resolve, reject) => {
+        settle.push(resolve);
+        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+    };
+    const client = new ServerClient('http://host', 'sekrit', impl, timers.seam);
+
+    const first = client.roles('u1');
+    const second = client.roles('u2');
+    expect(timers.armed.length).toBe(2);
+    expect(signals[0]).not.toBe(signals[1]);
+
+    // Firing only the FIRST deadline must abort only the first request.
+    timers.armed[0].fn();
+    expect(signals[0]?.aborted).toBe(true);
+    expect(signals[1]?.aborted).toBe(false);
+
+    expect(await first).toBe(null);
+    settle[1](fakeResponse({ body: ROLES_ENVELOPE }));
+    expect(await second).toEqual({ linked: true, statusTier: 3, points: 12, lifetimePoints: 40 });
+    expect(timers.cleared.sort()).toEqual([1, 2]);
+  });
 });
 
 describe('ServerClient production defaults', () => {
@@ -434,13 +502,17 @@ describe('ServerClient production defaults', () => {
     // stub-then-construct ordering cannot detect it.
     const client = new ServerClient('http://host:8787', 'sekrit');
 
-    const seen: string[] = [];
+    const seen: { url: string; init: RequestInit | undefined }[] = [];
     const armed: { ms: number; handle: unknown }[] = [];
     const cleared: unknown[] = [];
     const realSetTimeout = globalThis.setTimeout;
     const realClearTimeout = globalThis.clearTimeout;
-    vi.stubGlobal('fetch', async (input: unknown) => {
-      seen.push(String(input));
+    // Both parameters, deliberately. A one-parameter stub cannot tell
+    // `(...args) => fetch(...args)` from `(input) => fetch(input)`, and the
+    // arity-reduced form type-checks, so every internal call would lose its
+    // secret header, its method, its body, and its abort signal unnoticed.
+    vi.stubGlobal('fetch', async (input: unknown, init?: RequestInit) => {
+      seen.push({ url: String(input), init });
       return fakeResponse({ body: { success: true, data: { items: [{ id: 7 }] }, error: null } });
     });
     // Delegates to the real timer so the deadline is a genuine handle the
@@ -461,7 +533,16 @@ describe('ServerClient production defaults', () => {
       vi.unstubAllGlobals();
     }
 
-    expect(seen).toEqual(['http://host:8787/internal/discord/relay']);
+    expect(seen.length).toBe(1);
+    expect(seen[0].url).toBe('http://host:8787/internal/discord/relay');
+    expect(seen[0].init?.method).toBe('GET');
+    // The shared secret is the whole authentication story for /internal/*: a
+    // forwarder that drops `init` would strip it and every call would 401.
+    expect(seen[0].init?.headers).toEqual({
+      'x-woc-discord-secret': 'sekrit',
+      'Content-Type': 'application/json',
+    });
+    expect(seen[0].init?.signal).toBeInstanceOf(AbortSignal);
     // Exactly one arm, at the real deadline: the defaults read the globals and
     // pass the production timeout, not an injected one.
     expect(armed.map((a) => a.ms)).toEqual([8000]);

--- a/tests/discord_bot_server_client.test.ts
+++ b/tests/discord_bot_server_client.test.ts
@@ -328,6 +328,30 @@ describe('ServerClient envelope handling', () => {
   });
 });
 
+describe('ServerClient drain fallbacks', () => {
+  it('answers with an empty list when the call fails, for every drain', async () => {
+    // Each drain ends in `?? []`. Without it a failed call hands the caller
+    // undefined and the poll loop throws on the next `.length`, killing the
+    // loop rather than skipping one cycle. drainRelay is covered above; these
+    // are the two that were not.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const timers = fakeTimers();
+    const failing = () =>
+      new ServerClient(
+        'http://host',
+        'sekrit',
+        recordingFetch(() => fakeResponse({ status: 500 })).impl,
+        timers.seam,
+      );
+
+    expect(await failing().drainActivity()).toEqual([]);
+    expect(await failing().dailyRewardWinners()).toEqual([]);
+    // And a 200 whose envelope carries no list at all.
+    expect(await clientReturning({}).client.drainActivity()).toEqual([]);
+    expect(await clientReturning({}).client.dailyRewardWinners()).toEqual([]);
+  });
+});
+
 describe('ServerClient flairedIds null-versus-empty contract', () => {
   it('returns the ids, keeping only the strings', async () => {
     // The reconcile treats every id it gets back as "still flaired"; a stray

--- a/tests/discord_bot_server_client.test.ts
+++ b/tests/discord_bot_server_client.test.ts
@@ -148,114 +148,127 @@ describe('ServerClient request envelope', () => {
   });
 });
 
+const ROUTE_ROWS: {
+  name: string;
+  methodName: string;
+  drive: (c: ServerClient) => Promise<unknown>;
+  method: string;
+  path: string;
+  body: string | undefined;
+  data: unknown;
+}[] = [
+  {
+    name: 'flex',
+    methodName: 'flex',
+    drive: (c) => c.flex('u 1'),
+    method: 'GET',
+    path: '/internal/discord/flex?discord_user_id=u%201',
+    body: undefined,
+    data: { linked: true },
+  },
+  {
+    name: 'roles',
+    methodName: 'roles',
+    drive: (c) => c.roles('u 1'),
+    method: 'GET',
+    path: '/internal/discord/roles?discord_user_id=u%201',
+    body: undefined,
+    data: {},
+  },
+  {
+    name: 'pushPresence',
+    methodName: 'pushPresence',
+    drive: (c) =>
+      c.pushPresence({ onlineCount: 3, memberTotal: 9, voiceChannelName: null, voice: [] }),
+    method: 'POST',
+    path: '/internal/discord/presence',
+    body: '{"onlineCount":3,"memberTotal":9,"voiceChannelName":null,"voice":[]}',
+    data: {},
+  },
+  {
+    name: 'setMember',
+    methodName: 'setMember',
+    drive: (c) => c.setMember('u1', true),
+    method: 'POST',
+    path: '/internal/discord/member',
+    body: '{"discord_user_id":"u1","guildMember":true}',
+    data: {},
+  },
+  {
+    name: 'grant',
+    methodName: 'grant',
+    drive: (c) => c.grant('u1', 'daily', 5, 'k1'),
+    method: 'POST',
+    // The points-granting call: a path swap here silently stops every reward.
+    path: '/internal/discord/grant',
+    body: '{"discord_user_id":"u1","reason":"daily","points":5,"dedupeKey":"k1"}',
+    data: {},
+  },
+  {
+    name: 'markDailyRewardWinners',
+    methodName: 'markDailyRewardWinners',
+    drive: (c) => c.markDailyRewardWinners('2026-07-30'),
+    method: 'POST',
+    path: '/internal/discord/daily-rewards-winners/mark',
+    body: '{"day":"2026-07-30"}',
+    data: {},
+  },
+  {
+    name: 'drainRelay',
+    methodName: 'drainRelay',
+    drive: (c) => c.drainRelay(),
+    method: 'GET',
+    path: '/internal/discord/relay',
+    body: undefined,
+    data: { items: [] },
+  },
+  {
+    name: 'drainActivity',
+    methodName: 'drainActivity',
+    drive: (c) => c.drainActivity(),
+    method: 'GET',
+    path: '/internal/discord/activity',
+    body: undefined,
+    data: { items: [] },
+  },
+  {
+    name: 'dailyRewardWinners',
+    methodName: 'dailyRewardWinners',
+    drive: (c) => c.dailyRewardWinners(),
+    method: 'GET',
+    // limit=2 decides how many days of winners can still be announced after a
+    // missed run; shrinking it silently drops a day.
+    path: '/internal/discord/daily-rewards-winners?limit=2',
+    body: undefined,
+    data: { days: [] },
+  },
+  {
+    name: 'pushMembersMeta',
+    methodName: 'pushMembersMeta',
+    drive: (c) =>
+      c.pushMembersMeta([{ discord_user_id: 'u1', name: 'A', joinedAtMs: 1, role: null }]),
+    method: 'POST',
+    path: '/internal/discord/members-meta',
+    body: '{"members":[{"discord_user_id":"u1","name":"A","joinedAtMs":1,"role":null}]}',
+    data: { updated: 1 },
+  },
+  {
+    name: 'flairedIds',
+    methodName: 'flairedIds',
+    drive: (c) => c.flairedIds(),
+    method: 'GET',
+    path: '/internal/discord/flaired-ids',
+    body: undefined,
+    data: { ids: [] },
+  },
+];
+
 describe('ServerClient per-endpoint routes', () => {
   // Each row is the ONE wire contract only that method can get wrong. A typo in
   // any path 404s, call() returns null, and the drain methods answer with an
   // empty array, so the feed stops with no error surface at all.
-  const ROWS: {
-    name: string;
-    drive: (c: ServerClient) => Promise<unknown>;
-    method: string;
-    path: string;
-    body: string | undefined;
-    data: unknown;
-  }[] = [
-    {
-      name: 'flex',
-      drive: (c) => c.flex('u 1'),
-      method: 'GET',
-      path: '/internal/discord/flex?discord_user_id=u%201',
-      body: undefined,
-      data: { linked: true },
-    },
-    {
-      name: 'roles',
-      drive: (c) => c.roles('u 1'),
-      method: 'GET',
-      path: '/internal/discord/roles?discord_user_id=u%201',
-      body: undefined,
-      data: {},
-    },
-    {
-      name: 'pushPresence',
-      drive: (c) =>
-        c.pushPresence({ onlineCount: 3, memberTotal: 9, voiceChannelName: null, voice: [] }),
-      method: 'POST',
-      path: '/internal/discord/presence',
-      body: '{"onlineCount":3,"memberTotal":9,"voiceChannelName":null,"voice":[]}',
-      data: {},
-    },
-    {
-      name: 'setMember',
-      drive: (c) => c.setMember('u1', true),
-      method: 'POST',
-      path: '/internal/discord/member',
-      body: '{"discord_user_id":"u1","guildMember":true}',
-      data: {},
-    },
-    {
-      name: 'grant',
-      drive: (c) => c.grant('u1', 'daily', 5, 'k1'),
-      method: 'POST',
-      // The points-granting call: a path swap here silently stops every reward.
-      path: '/internal/discord/grant',
-      body: '{"discord_user_id":"u1","reason":"daily","points":5,"dedupeKey":"k1"}',
-      data: {},
-    },
-    {
-      name: 'markDailyRewardWinners',
-      drive: (c) => c.markDailyRewardWinners('2026-07-30'),
-      method: 'POST',
-      path: '/internal/discord/daily-rewards-winners/mark',
-      body: '{"day":"2026-07-30"}',
-      data: {},
-    },
-    {
-      name: 'drainRelay',
-      drive: (c) => c.drainRelay(),
-      method: 'GET',
-      path: '/internal/discord/relay',
-      body: undefined,
-      data: { items: [] },
-    },
-    {
-      name: 'drainActivity',
-      drive: (c) => c.drainActivity(),
-      method: 'GET',
-      path: '/internal/discord/activity',
-      body: undefined,
-      data: { items: [] },
-    },
-    {
-      name: 'dailyRewardWinners',
-      drive: (c) => c.dailyRewardWinners(),
-      method: 'GET',
-      // limit=2 decides how many days of winners can still be announced after a
-      // missed run; shrinking it silently drops a day.
-      path: '/internal/discord/daily-rewards-winners?limit=2',
-      body: undefined,
-      data: { days: [] },
-    },
-    {
-      name: 'pushMembersMeta',
-      drive: (c) =>
-        c.pushMembersMeta([{ discord_user_id: 'u1', name: 'A', joinedAtMs: 1, role: null }]),
-      method: 'POST',
-      path: '/internal/discord/members-meta',
-      body: '{"members":[{"discord_user_id":"u1","name":"A","joinedAtMs":1,"role":null}]}',
-      data: { updated: 1 },
-    },
-    {
-      name: 'flairedIds',
-      drive: (c) => c.flairedIds(),
-      method: 'GET',
-      path: '/internal/discord/flaired-ids',
-      body: undefined,
-      data: { ids: [] },
-    },
-  ];
 
-  for (const row of ROWS) {
+  for (const row of ROUTE_ROWS) {
     it(`${row.name} sends ${row.method} ${row.path}`, async () => {
       const { calls, client } = clientReturning(row.data);
 
@@ -325,6 +338,38 @@ describe('ServerClient envelope handling', () => {
 
     expect(await client.roles('u1')).toBe(null);
     expect(timers.cleared).toEqual([1]); // the finally runs on the throwing path too
+  });
+});
+
+describe('ServerClient response unwrapping', () => {
+  it('returns the payload each accessor is named for, not the envelope', async () => {
+    // The route table above asserts what goes OUT; this asserts what comes back.
+    // Each of these reaches into a differently-named field of `data`, so a
+    // copy-paste slip (activity reading `days`, winners reading `items`) yields
+    // undefined, and the `?? []` fallback then hides it as an empty feed.
+    expect(await clientReturning({ linked: true, level: 12 }).client.flex('u1')).toEqual({
+      linked: true,
+      level: 12,
+    });
+    expect(await clientReturning({ items: [{ id: 'a' }] }).client.drainActivity()).toEqual([
+      { id: 'a' },
+    ]);
+    expect(
+      await clientReturning({ days: [{ day: '2026-07-30' }] }).client.dailyRewardWinners(),
+    ).toEqual([{ day: '2026-07-30' }]);
+    expect(await clientReturning({ ids: ['a'] }).client.flairedIds()).toEqual(['a']);
+  });
+
+  it('covers every public method of the class in the route table', () => {
+    // Ties the table to the SURFACE: a method added to ServerClient without a
+    // row here would otherwise ship with no path assertion at all, which is the
+    // state seven of the twelve were in before this suite grew.
+    const publicMethods = Object.getOwnPropertyNames(ServerClient.prototype)
+      // `call` is the private shared helper; TS `private` is erased at runtime.
+      .filter((n) => n !== 'constructor' && n !== 'call')
+      .sort();
+    const covered = [...new Set(ROUTE_ROWS.map((r) => r.methodName))].sort();
+    expect(covered).toEqual(publicMethods);
   });
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
       "#bot-detector": ["./private/bot_detector/src/index.ts", "./server/bot_detector/stub.ts"]
     }
   },
-  "include": ["src", "headless", "tests", "server", "private"]
+  "include": ["src", "headless", "tests", "server", "private", "bot"]
 }


### PR DESCRIPTION
## Summary

Phase 1 of the Discord Bot Stability packet: the verification foundation the
remaining phases build on. **Zero runtime behavior change by design.**

The packet answers the 2026-07-29 production incident (a sustained 429 retry storm
against Discord, plus internal polling that accounted for ~45% of the game server's
own HTTP volume). Before any of that can be fixed safely, `bot/` needed to be
type-checked, built by the gate, and covered by tests. That is all this PR does.

What landed:

- `bot` added to the `tsconfig.json` include, so all seven bot files are type-checked
  (it surfaced zero latent type errors, so there were none to fix)
- `build:bot` added to `scripts/gate.mjs` and to both CI jobs that build the server
- the three poll-loop cadence constants moved verbatim out of `bot/main.ts` into
  `bot/cadence.ts`, so a test can import them without booting the bot
- the three IO shells (`discord_api.ts`, `server_client.ts`, `gateway.ts`) gained
  **trailing** constructor parameters with production defaults, so `bot/main.ts`
  constructs them unchanged and gets exactly today's IO
- four new test suites plus a QA round that widened them considerably

Behavior neutrality was verified rather than asserted: every injected default was
traced against the code it replaced, no await or call order moved, no timer handle
stopped being cleared, and `bot/main.ts`'s three construction sites are byte-identical
to the base commit.

The QA round is the larger half of this PR. It planted ~180 mutants in an isolated
worktree; **49 of the first 58 survived**, which is what the added tests close.
`bot/gateway.ts` was the worst offender, with 16 of 18 protocol mutants alive
(the zombie-terminate branch, RESUME versus IDENTIFY, sequence tracking). Four of the
survivors were traps that looked like passing tests:

- `toThrow('...')` is a **substring** match in vitest, so a pin on a 200-character
  truncation passed with a 300-character message
- the heartbeat test asked for `heartbeat_interval: 41250`, which is exactly
  `heartbeatIntervalMs`'s own fallback, so a gateway ignoring the payload still passed
- the default-path tests stubbed the global **before** constructing (which passes for a
  capture-form default) and with **one-parameter** stubs; `(input) => fetch(input)`
  type-checks and would strip the auth header off every request
- the gate step pin was a bare substring, so commenting the step out stayed green

## Related issues

Part of the Discord Bot Stability packet. Design, phase plans, and the incident
diagnosis are in `docs/discord-bot-stability/` (start with `README.md`, then
`state.md`). Phases 2 to 9 land on this same branch.

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Tests
- [x] Build, CI, or tooling
- [x] Documentation

## How was this tested?

- Commands:
  - `npm run gate` green (all 12 steps, including the new `bot build`)
  - `npx tsc --noEmit` clean; `tsc --noEmit --listFiles` confirms all seven `bot/` files
    are in the checked set, `bot/main.ts` among them
  - 171 tests across the seven bot-related suites, verified order-independent and with
    no mock leakage into the server suite
  - `npm run ci:changed` clean on the touched files
- Manual steps:
  - Proved the new gate step has teeth: introduced a syntax error in a bot file,
    confirmed `npm run build:bot` exits non-zero, reverted.
  - Mutation pass in an isolated worktree with its own `npm ci`. Every run proved the
    patch actually applied and that tests actually ran, so an unapplied patch could not
    be scored as a survivor.
  - Reviews: an adversarial workflow with one independent skeptic per finding, plus
    `qa-checklist`, `privacy-security-review`, and `test-coverage-auditor`, plus a second
    review pass over the fix round itself.

Three mutants survive deliberately and are documented in `progress.md`: the two
`bot/main.ts` cadence-use swaps (ruling R6 forbids a source-text pin and `main.ts` calls
`main()` at module scope, so it cannot be imported), and the undefined-body ternary in
`ServerClient.call`, which is a semantic no-op because `JSON.stringify(undefined)` is
itself `undefined`.

## Screenshots / recordings

N/A. No player-visible or operator-visible surface changes.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green, with decisive tests added for
      the pinned behavior and the manual checks recorded above.

### Cross-platform

- ~[ ] Tested on desktop and mobile.~ N/A, no UI surface.
- ~[ ] Accessible.~ N/A, no UI surface.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings. `bot/` copy is English by existing
      convention and none is added here.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not
      enabled in any production path. Test placeholders are obvious non-secrets.
- [x] I didn't hand-edit generated files.

## Known follow-ups, deliberately not in this PR

Recorded as ledger items in `docs/discord-bot-stability/state.md`:

- **L1 / L2** (security, pre-existing): `bot/discord_api.ts` interpolates `path` into its
  thrown error, and three interaction call sites carry the interaction token in `path`,
  so a failed slash-command reply can log a live bearer credential. Routed to Phase 2,
  which rewrites `request()` anyway. The redaction must live in the throw, not in the one
  named catch, or 15 other bare handlers re-open it.
- **L6** (toolchain): `bot/` type-checks against the shared tsconfig, whose lib includes
  DOM, so a Node-missing DOM global passes both `tsc` and `build:bot`. Routed to Phase 7.
- **L7** (behavior): a non-resumable `INVALID_SESSION` never clears `sessionId`, so a
  socket close arriving before the next READY resumes a session Discord already declared
  dead. Fixing it is a runtime behavior change, which this phase forbids, so it is
  recorded rather than landed. Routed to Phase 3 or 7.
