### PR TITLE
fix(sim): reclassify Gloam Strider onto the reptile family

### DIFF
--- a/src/guide/content.generated.ts
+++ b/src/guide/content.generated.ts
@@ -1879,7 +1879,8 @@ export const GUIDE_ZONES: GuideZoneInfo[] = [
     "families": [
       "beast",
       "undead",
-      "elemental"
+      "elemental",
+      "reptile"
     ]
   },
   {
@@ -2251,16 +2252,6 @@ export const GUIDE_FAMILIES: GuideFamily[] = [
         "model": "mob_wolf",
         "tint": "#9db4c8",
         "still": "/guide-stills/mob_wolf__9db4c8.webp"
-      },
-      {
-        "name": "Gloam Strider",
-        "min": 20,
-        "max": 20,
-        "rare": false,
-        "templateId": "gloam_strider",
-        "model": "mob_raptor",
-        "tint": "#4c4a72",
-        "still": "/guide-stills/mob_raptor__4c4a72.webp"
       },
       {
         "name": "Moonfleece Grazer",
@@ -2898,6 +2889,21 @@ export const GUIDE_FAMILIES: GuideFamily[] = [
         "model": "mob_demonalt",
         "tint": "#7a3fb0",
         "still": "/guide-stills/mob_demonalt__7a3fb0.webp"
+      }
+    ]
+  },
+  {
+    "family": "reptile",
+    "creatures": [
+      {
+        "name": "Gloam Strider",
+        "min": 20,
+        "max": 20,
+        "rare": false,
+        "templateId": "gloam_strider",
+        "model": "mob_raptor",
+        "tint": "#4c4a72",
+        "still": "/guide-stills/mob_raptor__4c4a72.webp"
       }
     ]
   }

--- a/src/sim/content/nightbloom.ts
+++ b/src/sim/content/nightbloom.ts
@@ -130,7 +130,7 @@ export const NIGHTBLOOM_MOBS: Record<string, MobTemplate> = {
     name: 'Gloam Strider',
     minLevel: 20,
     maxLevel: 20,
-    family: 'beast',
+    family: 'reptile',
     hpBase: 58,
     hpPerLevel: 20,
     dmgBase: 12,


### PR DESCRIPTION
## Summary

- `gloam_strider` (Nightbloom zone, level 20) uses the `mob_raptor` model (`velociraptor.glb`, via its own `MOB_KEYS` override in `src/render/characters/manifest.ts`) but was tagged `family: 'beast'`, so it plays generic beast sounds instead of the reptile family's own hiss/snarl/idle set (`MOB_VOICE_CUES.reptile`, `src/ui/combat_sfx.ts`) that already exists and is a better fit for the model.
- This is the same mistake caught and fixed once before for `deepfen_spearjaw` (see the comment at `src/render/characters/manifest.ts:1739`), not a one-off guess.
- Retags `gloam_strider`'s `family` field from `'beast'` to `'reptile'`. The model is unaffected: `MOB_KEYS['gloam_strider']` already pins it directly to `mob_raptor`, independent of family, so this change is sound-only.
- `reptile` is not in `FLEEING_FAMILIES` (`src/sim/sim.ts`) and isn't referenced by `mobCanSpawnInWater`, so there is no gameplay-behavior change, only the sound swap.
- Regenerated the wiki bestiary content (`npm run wiki:content`): Gloam Strider now lists under the reptile family instead of beast, and Nightbloom's zone family list gains reptile. No new model still needed since the model didn't change.

## Type of change

- [x] Bug fix
- [ ] Feature: new functionality
- [ ] Refactor or performance (no behavior change)
- [ ] Tests
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - `npx tsc --noEmit` clean
  - `npx @biomejs/biome check src/sim/content/nightbloom.ts` clean (0 errors)
  - Full `npx vitest run`: 1,773/1,774 files, 22,797/22,798 tests passed (the one non-pass is the wiki freshness check against the pre-commit working tree, which resolves once committed, same as every prior content change this cycle)
  - `npm run wiki:content` regenerated and committed
- Manual verification:
  - Confirmed `gloam_strider`'s own record (not a neighboring one) via a targeted read, not a context-window grep
  - Traced `MOB_KEYS['gloam_strider']` -> `mob_raptor` to confirm the model resolves independently of `family`, so this is sound-only
  - Checked `FLEEING_FAMILIES` and `mobCanSpawnInWater` for a `reptile` reference: neither exists, so no gameplay-behavior ripple
  - Diffed `src/guide/content.generated.ts` to confirm only the expected bestiary re-bucketing (beast -> reptile) and the Nightbloom zone family list addition

## Behavior change worth flagging, not just cosmetic

Reptile is not in the hunter-taming whitelist (`tameError`, `src/sim/pet/pet_commands.ts:248`, which only allows `beast`/`spider`), unlike `beast`. Gloam Strider was previously tameable as a hunter pet and will no longer be after this retag. This matches the existing precedent (`deepfen_spearjaw`, already on the reptile family, is not tameable either), so it's very likely the correct outcome, not an oversight, but flagging explicitly since it is a real gameplay-behavior change beyond sound, same as the disclosure pattern in PR #2670.
