### PR TITLE
fix(quests): re-engage evaded escort ambush waves onto the escortee

### DIFF
--- a/src/sim/escort.ts
+++ b/src/sim/escort.ts
@@ -6,9 +6,10 @@
 //   idle -> (interact with the quest active) -> walking -> ambush (paused
 //   until the wave is dead) -> ... -> final waypoint -> credit + despawn ->
 //   respawn after def.respawnSeconds. Escortee death fails the run the same
-//   respawn way, so the quest is simply retried. A wave mob that evades (its
-//   hate table cleared by the leash reset) is re-committed to the escortee by
-//   the driver, so a kited wave can never wedge the walk until the timeout.
+//   respawn way, so the quest is simply retried. A wave mob that evades keeps
+//   its normal leash contract (it walks home and resets); once it lands idle
+//   with an empty hate table the driver re-commits it to the escortee, so a
+//   kited wave can never wedge the walk until the timeout.
 //
 // The escortee is an ordinary non-hostile mob entity, so it rides the normal
 // entity snapshot to clients with no new wire plumbing. Players cannot attack
@@ -170,6 +171,11 @@ function fireAmbushes(ctx: SimContext, def: EscortDef, state: EscortRunState, np
         npc.pos.z + Math.cos(angle) * radius,
       );
       const mob = createMob(ctx.nextId++, template, template.minLevel, pos);
+      // A slain wave mob unravels once its corpse decays (the summoned-add arm
+      // in mob/locomotion.ts) instead of riding the generic in-place respawn:
+      // a wave that respawned 25s after being cut down would re-enter
+      // ambushIds' live count and wedge (or re-attack) a still-walking run.
+      mob.summonedAdd = true;
       ctx.addEntity(mob);
       // Commit the wave to the escortee, social_aggro-style; player damage
       // out-threats the seed immediately via the normal pull-over rules.
@@ -183,10 +189,15 @@ function fireAmbushes(ctx: SimContext, def: EscortDef, state: EscortRunState, np
   }
 }
 
-// A live wave mob whose evade reset wiped its hate table (idle or walking
-// home, no threat entries) re-commits to the escortee, mirroring the spawn
-// seed in fireAmbushes. Never touches an engaged mob (threat non-empty) or a
-// fleeing one (a flee keeps its table). Draws no rng.
+// A live wave mob whose evade completed (it walked home, resetEvadingMob ran,
+// and it now sits idle with an empty hate table) re-commits to the escortee,
+// mirroring the spawn seed in fireAmbushes. Strictly `idle`: touching the
+// `evade` state would fire on the leash-break tick itself (the leash prelude
+// clears threat and enters `evade` in one step, and this driver runs later
+// the same tick), re-anchoring the leash at the kite spot and making the wave
+// leash-immune. Waiting for `idle` preserves the full walk-home reset. Never
+// touches an engaged mob (threat non-empty) or a fleeing one (a flee keeps
+// its table). Draws no rng.
 function recommitEvadedAmbushers(
   ctx: SimContext,
   run: NonNullable<EscortRunState['run']>,
@@ -195,7 +206,7 @@ function recommitEvadedAmbushers(
   for (const id of run.ambushIds) {
     const mob = ctx.entities.get(id);
     if (!mob || mob.dead) continue;
-    if (mob.aiState !== 'idle' && mob.aiState !== 'evade') continue;
+    if (mob.aiState !== 'idle') continue;
     if (mob.threat.size > 0) continue;
     mob.aiState = 'chase';
     mob.aggroTargetId = npc.id;
@@ -287,9 +298,9 @@ export function updateEscorts(ctx: SimContext): void {
     }
     // An ambush wave holds the walk: the escortee waits while any of its
     // attackers still stands. A wave mob that EVADED (a player kited it past
-    // its leash, then died, stealthed, or ran) comes home with a cleared hate
-    // table and would otherwise idle beside the waiting escortee until the
-    // run timeout: re-commit it to the escortee so the wave resumes the
+    // its leash, then died, stealthed, or ran) walks home, resets, and lands
+    // idle with a cleared hate table; it would otherwise stand there until
+    // the run timeout: re-commit it to the escortee so the wave resumes the
     // attack and the run always resolves one way or the other.
     if (liveAmbushCount(ctx, run) > 0) {
       recommitEvadedAmbushers(ctx, run, npc);

--- a/src/sim/escort.ts
+++ b/src/sim/escort.ts
@@ -6,7 +6,9 @@
 //   idle -> (interact with the quest active) -> walking -> ambush (paused
 //   until the wave is dead) -> ... -> final waypoint -> credit + despawn ->
 //   respawn after def.respawnSeconds. Escortee death fails the run the same
-//   respawn way, so the quest is simply retried.
+//   respawn way, so the quest is simply retried. A wave mob that evades (its
+//   hate table cleared by the leash reset) is re-committed to the escortee by
+//   the driver, so a kited wave can never wedge the walk until the timeout.
 //
 // The escortee is an ordinary non-hostile mob entity, so it rides the normal
 // entity snapshot to clients with no new wire plumbing. Players cannot attack
@@ -181,6 +183,28 @@ function fireAmbushes(ctx: SimContext, def: EscortDef, state: EscortRunState, np
   }
 }
 
+// A live wave mob whose evade reset wiped its hate table (idle or walking
+// home, no threat entries) re-commits to the escortee, mirroring the spawn
+// seed in fireAmbushes. Never touches an engaged mob (threat non-empty) or a
+// fleeing one (a flee keeps its table). Draws no rng.
+function recommitEvadedAmbushers(
+  ctx: SimContext,
+  run: NonNullable<EscortRunState['run']>,
+  npc: Entity,
+): void {
+  for (const id of run.ambushIds) {
+    const mob = ctx.entities.get(id);
+    if (!mob || mob.dead) continue;
+    if (mob.aiState !== 'idle' && mob.aiState !== 'evade') continue;
+    if (mob.threat.size > 0) continue;
+    mob.aiState = 'chase';
+    mob.aggroTargetId = npc.id;
+    mob.inCombat = true;
+    mob.leashAnchor = { ...mob.pos };
+    addThreat(mob, npc.id, ESCORT_SEED_THREAT);
+  }
+}
+
 function liveAmbushCount(ctx: SimContext, run: NonNullable<EscortRunState['run']>): number {
   let live = 0;
   for (const id of run.ambushIds) {
@@ -262,8 +286,15 @@ export function updateEscorts(ctx: SimContext): void {
       continue;
     }
     // An ambush wave holds the walk: the escortee waits while any of its
-    // attackers still stands.
-    if (liveAmbushCount(ctx, run) > 0) continue;
+    // attackers still stands. A wave mob that EVADED (a player kited it past
+    // its leash, then died, stealthed, or ran) comes home with a cleared hate
+    // table and would otherwise idle beside the waiting escortee until the
+    // run timeout: re-commit it to the escortee so the wave resumes the
+    // attack and the run always resolves one way or the other.
+    if (liveAmbushCount(ctx, run) > 0) {
+      recommitEvadedAmbushers(ctx, run, npc);
+      continue;
+    }
     // Past the last waypoint with every wave down (a final-waypoint ambush
     // resolves here on the tick after its wave dies): the escort succeeds.
     if (run.waypointIndex >= def.waypoints.length) {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -11867,6 +11867,7 @@ export class Hud {
       'Finish your trade before queueing.': 'hud.errors.arenaQueueTrading',
       'You cannot queue from inside an instance.': 'hud.errors.arenaQueueInstance',
       'A trade is already in progress.': 'hud.errors.tradeInProgress',
+      'That player is already trading.': 'hud.errors.tradeAlreadyTrading',
       'Target is too far away to trade.': 'hud.errors.tradeTooFar',
       'The trade request has expired.': 'hud.errors.tradeExpired',
       'Trade failed: items or money no longer available.': 'hud.errors.tradeFailed',

--- a/src/ui/i18n.catalog/hud.ts
+++ b/src/ui/i18n.catalog/hud.ts
@@ -380,6 +380,7 @@ const hudStringsEn = {
       arenaQueueTrading: 'Finish your trade before queueing.',
       arenaQueueInstance: 'You cannot queue from inside an instance.',
       tradeInProgress: 'A trade is already in progress.',
+      tradeAlreadyTrading: 'That player is already trading.',
       tradeTooFar: 'Target is too far away to trade.',
       tradeExpired: 'The trade request has expired.',
       tradeFailed: 'Trade failed: items or money no longer available.',

--- a/src/ui/i18n.catalog/translation_keys.generated.ts
+++ b/src/ui/i18n.catalog/translation_keys.generated.ts
@@ -5624,6 +5624,7 @@ export type TranslationKeyFlat =
   | 'hud.errors.targetMustDodge'
   | 'hud.errors.targetTooFar'
   | 'hud.errors.tooClose'
+  | 'hud.errors.tradeAlreadyTrading'
   | 'hud.errors.tradeBound'
   | 'hud.errors.tradeExpired'
   | 'hud.errors.tradeFailed'

--- a/src/ui/i18n.locales/ja_JP.ts
+++ b/src/ui/i18n.locales/ja_JP.ts
@@ -1998,6 +1998,7 @@ export const ja_JP: Partial<Record<TranslationKey, string>> = {
   'hud.errors.arenaQueueTrading': '取引を終えてからキューに入ってください。',
   'hud.errors.arenaQueueInstance': 'インスタンス内からキューには入れません。',
   'hud.errors.tradeInProgress': 'すでに取引が進行中です。',
+  'hud.errors.tradeAlreadyTrading': 'そのプレイヤーはすでに取引中です。',
   'hud.errors.tradeTooFar': '対象が遠すぎて取引できません。',
   'hud.errors.tradeExpired': '取引リクエストは期限切れです。',
   'hud.errors.tradeFailed': '取引失敗: アイテムまたは所持金が利用できません。',

--- a/src/ui/i18n.locales/ko_KR.ts
+++ b/src/ui/i18n.locales/ko_KR.ts
@@ -1983,6 +1983,7 @@ export const ko_KR: Partial<Record<TranslationKey, string>> = {
   'hud.errors.arenaQueueTrading': '거래를 끝낸 뒤 대기열에 들어가세요.',
   'hud.errors.arenaQueueInstance': '인스턴스 안에서는 대기열에 들어갈 수 없습니다.',
   'hud.errors.tradeInProgress': '이미 거래가 진행 중입니다.',
+  'hud.errors.tradeAlreadyTrading': '그 플레이어는 이미 거래 중입니다.',
   'hud.errors.tradeTooFar': '대상이 너무 멀어 거래할 수 없습니다.',
   'hud.errors.tradeExpired': '거래 요청이 만료되었습니다.',
   'hud.errors.tradeFailed': '거래 실패: 아이템이나 돈을 더 이상 사용할 수 없습니다.',

--- a/src/ui/i18n.locales/ru_RU.ts
+++ b/src/ui/i18n.locales/ru_RU.ts
@@ -2020,6 +2020,7 @@ export const ru_RU: Partial<Record<TranslationKey, string>> = {
   'hud.errors.arenaQueueTrading': 'Завершите обмен перед постановкой в очередь.',
   'hud.errors.arenaQueueInstance': 'Нельзя вставать в очередь из подземелья.',
   'hud.errors.tradeInProgress': 'Обмен уже идет.',
+  'hud.errors.tradeAlreadyTrading': 'Этот игрок уже торгует.',
   'hud.errors.tradeTooFar': 'Цель слишком далеко для обмена.',
   'hud.errors.tradeExpired': 'Запрос обмена истек.',
   'hud.errors.tradeFailed': 'Обмен не удался: предметы или деньги больше недоступны.',

--- a/src/ui/i18n.locales/zh_CN.ts
+++ b/src/ui/i18n.locales/zh_CN.ts
@@ -1905,6 +1905,7 @@ export const zh_CN: Partial<Record<TranslationKey, string>> = {
   'hud.errors.arenaQueueTrading': '请先完成交易再加入队列。',
   'hud.errors.arenaQueueInstance': '你不能在副本内加入队列。',
   'hud.errors.tradeInProgress': '已有交易正在进行。',
+  'hud.errors.tradeAlreadyTrading': '该玩家已在交易中。',
   'hud.errors.tradeTooFar': '目标太远，无法交易。',
   'hud.errors.tradeExpired': '交易请求已过期。',
   'hud.errors.tradeFailed': '交易失败：物品或金钱已不可用。',

--- a/src/ui/i18n.locales/zh_TW.ts
+++ b/src/ui/i18n.locales/zh_TW.ts
@@ -1907,6 +1907,7 @@ export const zh_TW: Partial<Record<TranslationKey, string>> = {
   'hud.errors.arenaQueueTrading': '請先完成交易再加入佇列。',
   'hud.errors.arenaQueueInstance': '你不能在副本內加入佇列。',
   'hud.errors.tradeInProgress': '已有交易正在進行。',
+  'hud.errors.tradeAlreadyTrading': '該玩家已在交易中。',
   'hud.errors.tradeTooFar': '目標太遠，無法交易。',
   'hud.errors.tradeExpired': '交易請求已過期。',
   'hud.errors.tradeFailed': '交易失敗：物品或金錢已不可用。',

--- a/src/ui/i18n.resolved.generated/cs_CZ.ts
+++ b/src/ui/i18n.resolved.generated/cs_CZ.ts
@@ -6479,6 +6479,7 @@ export const cs_CZ: EnTranslations = {
       "arenaQueueTrading": "Před zařazením do fronty dokonči obchod.",
       "arenaQueueInstance": "Z instance se nemůžeš zařadit do fronty.",
       "tradeInProgress": "Obchod už probíhá.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Cíl je příliš daleko pro obchod.",
       "tradeExpired": "Žádost o obchod vypršela.",
       "tradeFailed": "Obchod selhal: předměty nebo peníze už nejsou dostupné.",

--- a/src/ui/i18n.resolved.generated/da_DK.ts
+++ b/src/ui/i18n.resolved.generated/da_DK.ts
@@ -6479,6 +6479,7 @@ export const da_DK: EnTranslations = {
       "arenaQueueTrading": "Afslut din handel, før du stiller dig i kø.",
       "arenaQueueInstance": "Du kan ikke stille dig i kø inde fra en instans.",
       "tradeInProgress": "En handel er allerede i gang.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Målet er for langt væk til at handle.",
       "tradeExpired": "Handelsanmodningen er udløbet.",
       "tradeFailed": "Handel mislykkedes: genstande eller penge er ikke længere tilgængelige.",

--- a/src/ui/i18n.resolved.generated/de_DE.ts
+++ b/src/ui/i18n.resolved.generated/de_DE.ts
@@ -6479,6 +6479,7 @@ export const de_DE: EnTranslations = {
       "arenaQueueTrading": "Beendet Euren Handel, bevor Ihr Euch anmeldet.",
       "arenaQueueInstance": "Aus einer Instanz heraus könnt Ihr Euch nicht anmelden.",
       "tradeInProgress": "Es läuft bereits ein Handel.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Das Ziel ist zu weit entfernt zum Handeln.",
       "tradeExpired": "Die Handelsanfrage ist abgelaufen.",
       "tradeFailed": "Handel fehlgeschlagen: Gegenstände oder Geld sind nicht mehr verfügbar.",

--- a/src/ui/i18n.resolved.generated/en.ts
+++ b/src/ui/i18n.resolved.generated/en.ts
@@ -6479,6 +6479,7 @@ export const en: EnTranslations = {
       "arenaQueueTrading": "Finish your trade before queueing.",
       "arenaQueueInstance": "You cannot queue from inside an instance.",
       "tradeInProgress": "A trade is already in progress.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Target is too far away to trade.",
       "tradeExpired": "The trade request has expired.",
       "tradeFailed": "Trade failed: items or money no longer available.",

--- a/src/ui/i18n.resolved.generated/en_CA.ts
+++ b/src/ui/i18n.resolved.generated/en_CA.ts
@@ -6479,6 +6479,7 @@ export const en_CA: EnTranslations = {
       "arenaQueueTrading": "Finish your trade before queueing.",
       "arenaQueueInstance": "You cannot queue from inside an instance.",
       "tradeInProgress": "A trade is already in progress.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Target is too far away to trade.",
       "tradeExpired": "The trade request has expired.",
       "tradeFailed": "Trade failed: items or money no longer available.",

--- a/src/ui/i18n.resolved.generated/en_XA.ts
+++ b/src/ui/i18n.resolved.generated/en_XA.ts
@@ -6479,6 +6479,7 @@ export const en_XA: EnTranslations = {
       "arenaQueueTrading": "[Ƒíñíšĥ ýóúŕ ţŕáðé ƀéƒóŕé ɋúéúéíñĝ.]",
       "arenaQueueInstance": "[Ýóú çáññóţ ɋúéúé ƒŕóɱ íñšíðé áñ íñšţáñçé.]",
       "tradeInProgress": "[Á ţŕáðé íš áļŕéáðý íñ þŕóĝŕéšš.]",
+      "tradeAlreadyTrading": "[Ţĥáţ þļáýéŕ íš áļŕéáðý ţŕáðíñĝ.]",
       "tradeTooFar": "[Ţáŕĝéţ íš ţóó ƒáŕ áŵáý ţó ţŕáðé.]",
       "tradeExpired": "[Ţĥé ţŕáðé ŕéɋúéšţ ĥáš éẋþíŕéð.]",
       "tradeFailed": "[Ţŕáðé ƒáíļéð: íţéɱš óŕ ɱóñéý ñó ļóñĝéŕ áʋáíļáƀļé.]",

--- a/src/ui/i18n.resolved.generated/es.ts
+++ b/src/ui/i18n.resolved.generated/es.ts
@@ -6479,6 +6479,7 @@ export const es: EnTranslations = {
       "arenaQueueTrading": "Termina tu comercio antes de entrar en cola.",
       "arenaQueueInstance": "No puedes entrar en cola desde una instancia.",
       "tradeInProgress": "Ya hay un comercio en curso.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "El objetivo está demasiado lejos para comerciar.",
       "tradeExpired": "La solicitud de comercio ha expirado.",
       "tradeFailed": "Comercio fallido: los objetos o el dinero ya no están disponibles.",

--- a/src/ui/i18n.resolved.generated/es_ES.ts
+++ b/src/ui/i18n.resolved.generated/es_ES.ts
@@ -6479,6 +6479,7 @@ export const es_ES: EnTranslations = {
       "arenaQueueTrading": "Termina tu comercio antes de entrar en cola.",
       "arenaQueueInstance": "No puedes entrar en cola desde una instancia.",
       "tradeInProgress": "Ya hay un comercio en curso.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "El objetivo está demasiado lejos para comerciar.",
       "tradeExpired": "La solicitud de comercio ha expirado.",
       "tradeFailed": "Comercio fallido: los objetos o el dinero ya no están disponibles.",

--- a/src/ui/i18n.resolved.generated/fr_CA.ts
+++ b/src/ui/i18n.resolved.generated/fr_CA.ts
@@ -6479,6 +6479,7 @@ export const fr_CA: EnTranslations = {
       "arenaQueueTrading": "Terminez votre échange avant de rejoindre la file.",
       "arenaQueueInstance": "Vous ne pouvez pas rejoindre la file depuis une instance.",
       "tradeInProgress": "Un échange est déjà en cours.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "La cible est trop éloignée pour échanger.",
       "tradeExpired": "La demande d'échange a expiré.",
       "tradeFailed": "Échange échoué : objets ou argent indisponibles.",

--- a/src/ui/i18n.resolved.generated/fr_FR.ts
+++ b/src/ui/i18n.resolved.generated/fr_FR.ts
@@ -6479,6 +6479,7 @@ export const fr_FR: EnTranslations = {
       "arenaQueueTrading": "Terminez votre échange avant de rejoindre la file.",
       "arenaQueueInstance": "Vous ne pouvez pas rejoindre la file depuis une instance.",
       "tradeInProgress": "Un échange est déjà en cours.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "La cible est trop éloignée pour échanger.",
       "tradeExpired": "La demande d'échange a expiré.",
       "tradeFailed": "Échange échoué : objets ou argent indisponibles.",

--- a/src/ui/i18n.resolved.generated/id_ID.ts
+++ b/src/ui/i18n.resolved.generated/id_ID.ts
@@ -6479,6 +6479,7 @@ export const id_ID: EnTranslations = {
       "arenaQueueTrading": "Selesaikan dulu perdaganganmu sebelum antre.",
       "arenaQueueInstance": "Kamu tidak bisa antre dari dalam instance.",
       "tradeInProgress": "Perdagangan sudah berlangsung.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Sasaran terlalu jauh untuk berdagang.",
       "tradeExpired": "Permintaan perdagangan telah kedaluwarsa.",
       "tradeFailed": "Perdagangan gagal: barang atau uang sudah tidak tersedia.",

--- a/src/ui/i18n.resolved.generated/it_IT.ts
+++ b/src/ui/i18n.resolved.generated/it_IT.ts
@@ -6479,6 +6479,7 @@ export const it_IT: EnTranslations = {
       "arenaQueueTrading": "Termina lo scambio prima di metterti in coda.",
       "arenaQueueInstance": "Non puoi metterti in coda da dentro un'istanza.",
       "tradeInProgress": "Uno scambio è già in corso.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Il bersaglio è troppo lontano per commerciare.",
       "tradeExpired": "La richiesta di scambio è scaduta.",
       "tradeFailed": "Scambio fallito: oggetti o denaro non più disponibili.",

--- a/src/ui/i18n.resolved.generated/ja_JP.ts
+++ b/src/ui/i18n.resolved.generated/ja_JP.ts
@@ -6479,6 +6479,7 @@ export const ja_JP: EnTranslations = {
       "arenaQueueTrading": "取引を終えてからキューに入ってください。",
       "arenaQueueInstance": "インスタンス内からキューには入れません。",
       "tradeInProgress": "すでに取引が進行中です。",
+      "tradeAlreadyTrading": "そのプレイヤーはすでに取引中です。",
       "tradeTooFar": "対象が遠すぎて取引できません。",
       "tradeExpired": "取引リクエストは期限切れです。",
       "tradeFailed": "取引失敗: アイテムまたは所持金が利用できません。",

--- a/src/ui/i18n.resolved.generated/ko_KR.ts
+++ b/src/ui/i18n.resolved.generated/ko_KR.ts
@@ -6479,6 +6479,7 @@ export const ko_KR: EnTranslations = {
       "arenaQueueTrading": "거래를 끝낸 뒤 대기열에 들어가세요.",
       "arenaQueueInstance": "인스턴스 안에서는 대기열에 들어갈 수 없습니다.",
       "tradeInProgress": "이미 거래가 진행 중입니다.",
+      "tradeAlreadyTrading": "그 플레이어는 이미 거래 중입니다.",
       "tradeTooFar": "대상이 너무 멀어 거래할 수 없습니다.",
       "tradeExpired": "거래 요청이 만료되었습니다.",
       "tradeFailed": "거래 실패: 아이템이나 돈을 더 이상 사용할 수 없습니다.",

--- a/src/ui/i18n.resolved.generated/nl_NL.ts
+++ b/src/ui/i18n.resolved.generated/nl_NL.ts
@@ -6479,6 +6479,7 @@ export const nl_NL: EnTranslations = {
       "arenaQueueTrading": "Rond je ruil af voordat je in de wachtrij gaat.",
       "arenaQueueInstance": "Je kunt niet in de wachtrij gaan vanuit een instantie.",
       "tradeInProgress": "Er is al een ruil aan de gang.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Het doelwit is te ver weg om mee te ruilen.",
       "tradeExpired": "Het ruilverzoek is verlopen.",
       "tradeFailed": "Ruil mislukt: voorwerpen of geld niet langer beschikbaar.",

--- a/src/ui/i18n.resolved.generated/pending.ts
+++ b/src/ui/i18n.resolved.generated/pending.ts
@@ -9,25 +9,55 @@
 // Reproducibility is checked by tests/i18n_resolved_equivalence.test.ts.
 
 export const pending: Record<string, readonly string[]> = {
-  "es": [],
-  "es_ES": [],
-  "fr_FR": [],
-  "fr_CA": [],
+  "es": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "es_ES": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "fr_FR": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "fr_CA": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
   "en_CA": [],
-  "it_IT": [],
-  "de_DE": [],
+  "it_IT": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "de_DE": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
   "zh_CN": [],
   "zh_TW": [],
   "ko_KR": [],
   "ja_JP": [],
-  "pt_BR": [],
+  "pt_BR": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
   "ru_RU": [],
-  "cs_CZ": [],
-  "nl_NL": [],
-  "pl_PL": [],
-  "id_ID": [],
-  "tr_TR": [],
-  "sv_SE": [],
-  "vi_VN": [],
-  "da_DK": []
+  "cs_CZ": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "nl_NL": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "pl_PL": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "id_ID": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "tr_TR": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "sv_SE": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "vi_VN": [
+    "hud.errors.tradeAlreadyTrading"
+  ],
+  "da_DK": [
+    "hud.errors.tradeAlreadyTrading"
+  ]
 };

--- a/src/ui/i18n.resolved.generated/pl_PL.ts
+++ b/src/ui/i18n.resolved.generated/pl_PL.ts
@@ -6479,6 +6479,7 @@ export const pl_PL: EnTranslations = {
       "arenaQueueTrading": "Zakończ wymianę przed dołączeniem do kolejki.",
       "arenaQueueInstance": "Nie możesz dołączyć do kolejki będąc wewnątrz instancji.",
       "tradeInProgress": "Wymiana już trwa.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Cel jest zbyt daleko, by handlować.",
       "tradeExpired": "Prośba o wymianę wygasła.",
       "tradeFailed": "Wymiana nieudana: przedmioty lub pieniądze są już niedostępne.",

--- a/src/ui/i18n.resolved.generated/pt_BR.ts
+++ b/src/ui/i18n.resolved.generated/pt_BR.ts
@@ -6479,6 +6479,7 @@ export const pt_BR: EnTranslations = {
       "arenaQueueTrading": "Termine sua troca antes de entrar na fila.",
       "arenaQueueInstance": "Você não pode entrar na fila dentro de uma instância.",
       "tradeInProgress": "Já há uma troca em andamento.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "O alvo está longe demais para trocar.",
       "tradeExpired": "A solicitação de troca expirou.",
       "tradeFailed": "Troca falhou: itens ou dinheiro não estão mais disponíveis.",

--- a/src/ui/i18n.resolved.generated/ru_RU.ts
+++ b/src/ui/i18n.resolved.generated/ru_RU.ts
@@ -6479,6 +6479,7 @@ export const ru_RU: EnTranslations = {
       "arenaQueueTrading": "Завершите обмен перед постановкой в очередь.",
       "arenaQueueInstance": "Нельзя вставать в очередь из подземелья.",
       "tradeInProgress": "Обмен уже идет.",
+      "tradeAlreadyTrading": "Этот игрок уже торгует.",
       "tradeTooFar": "Цель слишком далеко для обмена.",
       "tradeExpired": "Запрос обмена истек.",
       "tradeFailed": "Обмен не удался: предметы или деньги больше недоступны.",

--- a/src/ui/i18n.resolved.generated/sv_SE.ts
+++ b/src/ui/i18n.resolved.generated/sv_SE.ts
@@ -6479,6 +6479,7 @@ export const sv_SE: EnTranslations = {
       "arenaQueueTrading": "Avsluta din handel innan du köar.",
       "arenaQueueInstance": "Du kan inte köa inifrån en instans.",
       "tradeInProgress": "En handel pågår redan.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Målet är för långt bort för att handla.",
       "tradeExpired": "Handelsförfrågan har gått ut.",
       "tradeFailed": "Handeln misslyckades: föremål eller pengar är inte längre tillgängliga.",

--- a/src/ui/i18n.resolved.generated/tr_TR.ts
+++ b/src/ui/i18n.resolved.generated/tr_TR.ts
@@ -6479,6 +6479,7 @@ export const tr_TR: EnTranslations = {
       "arenaQueueTrading": "Sıraya girmeden önce takasını bitir.",
       "arenaQueueInstance": "Bir zindanın içinden sıraya giremezsin.",
       "tradeInProgress": "Zaten devam eden bir takas var.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Hedef takas için çok uzakta.",
       "tradeExpired": "Takas isteğinin süresi doldu.",
       "tradeFailed": "Takas başarısız: eşyalar ya da para artık mevcut değil.",

--- a/src/ui/i18n.resolved.generated/vi_VN.ts
+++ b/src/ui/i18n.resolved.generated/vi_VN.ts
@@ -6479,6 +6479,7 @@ export const vi_VN: EnTranslations = {
       "arenaQueueTrading": "Hãy hoàn tất giao dịch trước khi xếp hàng.",
       "arenaQueueInstance": "Bạn không thể xếp hàng khi đang ở trong hầm ngục.",
       "tradeInProgress": "Một giao dịch đang diễn ra.",
+      "tradeAlreadyTrading": "That player is already trading.",
       "tradeTooFar": "Mục tiêu ở quá xa để giao dịch.",
       "tradeExpired": "Yêu cầu giao dịch đã hết hạn.",
       "tradeFailed": "Giao dịch thất bại: vật phẩm hoặc tiền không còn khả dụng.",

--- a/src/ui/i18n.resolved.generated/zh_CN.ts
+++ b/src/ui/i18n.resolved.generated/zh_CN.ts
@@ -6479,6 +6479,7 @@ export const zh_CN: EnTranslations = {
       "arenaQueueTrading": "请先完成交易再加入队列。",
       "arenaQueueInstance": "你不能在副本内加入队列。",
       "tradeInProgress": "已有交易正在进行。",
+      "tradeAlreadyTrading": "该玩家已在交易中。",
       "tradeTooFar": "目标太远，无法交易。",
       "tradeExpired": "交易请求已过期。",
       "tradeFailed": "交易失败：物品或金钱已不可用。",

--- a/src/ui/i18n.resolved.generated/zh_TW.ts
+++ b/src/ui/i18n.resolved.generated/zh_TW.ts
@@ -6479,6 +6479,7 @@ export const zh_TW: EnTranslations = {
       "arenaQueueTrading": "請先完成交易再加入佇列。",
       "arenaQueueInstance": "你不能在副本內加入佇列。",
       "tradeInProgress": "已有交易正在進行。",
+      "tradeAlreadyTrading": "該玩家已在交易中。",
       "tradeTooFar": "目標太遠，無法交易。",
       "tradeExpired": "交易請求已過期。",
       "tradeFailed": "交易失敗：物品或金錢已不可用。",

--- a/tests/escort.test.ts
+++ b/tests/escort.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { visualKeyFor } from '../src/render/characters/manifest';
 import { ESCORTS, MOBS, NPCS, QUESTS, ZONES } from '../src/sim/data';
 import { Sim } from '../src/sim/sim';
-import type { Entity, SimEvent } from '../src/sim/types';
+import { dist2d, type Entity, LEASH_DISTANCE, type SimEvent } from '../src/sim/types';
 import { groundHeight, WATER_LEVEL } from '../src/sim/world';
 
 const ESCORT_ID = 'esc_fv_wren';
@@ -345,6 +345,11 @@ describe('escort run guards', () => {
     const wave = liveAmbushers(sim);
     expect(wave.length).toBe(3);
 
+    // Wound one mob through the real damage path so the full-health check
+    // below can prove the walk-home reset (which heals) actually ran.
+    (sim as any).dealDamage(sim.player, wave[0], 50, false, 'physical', null, 'hit');
+    expect(wave[0].hp).toBeLessThan(wave[0].maxHp);
+
     // The live-server kite: drag the whole wave far past its leash. The chase
     // exceeds LEASH_DISTANCE, the mobs evade home, and the evade reset clears
     // their hate tables, the escortee seed included. Without the driver
@@ -354,6 +359,9 @@ describe('escort run guards', () => {
       const far = sim.groundPos(mob.pos.x + 80, mob.pos.z);
       mob.pos = { ...far };
       mob.prevPos = { ...far };
+      // Precondition pin: the drag genuinely exceeds the leash, so the pass
+      // below exercises a real evade, not the surviving spawn commitment.
+      expect(dist2d(mob.pos, wren.pos)).toBeGreaterThan(LEASH_DISTANCE);
     }
     let reengaged = false;
     for (let i = 0; i < 120 * 20 && !reengaged; i++) {
@@ -364,9 +372,20 @@ describe('escort run guards', () => {
         live.every((m) => m.aggroTargetId === wren.id && (m.threat.get(wren.id) ?? 0) > 0);
     }
     expect(reengaged).toBe(true);
+    // Full health proves the re-commit happened AFTER the walk-home reset
+    // (resetEvadingMob heals), not on the leash-break tick: the escort driver
+    // must never bypass the leash contract.
+    for (const mob of liveAmbushers(sim)) expect(mob.hp).toBe(mob.maxHp);
+
+    // The wave resumes the ATTACK, not just the aggro fields: the escortee
+    // takes fresh hits after the re-commit.
+    const hpAtReengage = wren.hp;
+    for (let i = 0; i < 120 * 20 && wren.hp >= hpAtReengage; i++) sim.tick();
+    expect(wren.hp).toBeLessThan(hpAtReengage);
 
     // With the wave re-committed, cutting it down releases the walk: the run
-    // advances past the held waypoint instead of stalling to the timeout.
+    // survives and advances past the held waypoint instead of stalling to the
+    // timeout or failing.
     const before = state.run?.waypointIndex ?? -1;
     for (const mob of liveAmbushers(sim)) {
       mob.hp = 0;
@@ -376,7 +395,64 @@ describe('escort run guards', () => {
     for (let i = 0; i < 30 * 20 && state.run !== null && state.run.waypointIndex <= before; i++) {
       sim.tick();
     }
-    expect(state.run === null || state.run.waypointIndex > before).toBe(true);
+    expect(wren.dead).toBe(false);
+    expect(state.run).not.toBeNull();
+    expect(state.run?.waypointIndex ?? before).toBeGreaterThan(before);
+  });
+
+  it('never re-seeds a wave mob a player is actively fighting', () => {
+    const sim = makeSim();
+    const def = ESCORTS[ESCORT_ID];
+    teleportTo(sim, def.start.x, def.start.z);
+    activateQuest(sim);
+    sim.interact();
+    const wren = findEscortee(sim);
+    expect(wren).toBeTruthy();
+    if (!wren) return;
+    for (let i = 0; i < 60 * 20 && liveAmbushers(sim).length === 0; i++) sim.tick();
+    const mob = liveAmbushers(sim)[0];
+    expect(mob).toBeTruthy();
+
+    // The player pulls one wave mob through the real damage path: their
+    // threat towers over the escortee seed and the mob turns on them.
+    teleportTo(sim, mob.pos.x + 2, mob.pos.z);
+    (sim as any).dealDamage(sim.player, mob, 50, false, 'physical', null, 'hit');
+    for (let i = 0; i < 20; i++) sim.tick();
+    expect(mob.dead).toBe(false);
+    expect(mob.aggroTargetId).toBe(sim.player.id);
+    // The driver never re-seeded the fight: the escortee entry is still the
+    // untouched spawn seed of 1, below the player's damage threat.
+    expect(mob.threat.get(wren.id) ?? 0).toBeLessThanOrEqual(1);
+    expect(mob.threat.get(sim.player.id) ?? 0).toBeGreaterThan(1);
+  });
+
+  it('a slain wave unravels after its loot window instead of respawning into the run', () => {
+    const sim = makeSim();
+    const def = ESCORTS[ESCORT_ID];
+    teleportTo(sim, def.start.x, def.start.z);
+    activateQuest(sim);
+    sim.interact();
+    for (let i = 0; i < 60 * 20 && liveAmbushers(sim).length === 0; i++) sim.tick();
+    const waveIds = [...(sim.escortRuns.get(ESCORT_ID)?.run?.ambushIds ?? [])];
+    expect(waveIds.length).toBe(3);
+    // Cut the wave down through the real damage path so death runs the full
+    // handleDeath arm (corpse window, respawn timer assignment).
+    for (const mob of liveAmbushers(sim)) {
+      (sim as any).dealDamage(sim.player, mob, 999999, false, 'physical', null, 'hit');
+    }
+    // Pre-fix, the generic in-place camp respawn (cfg default 25s, deferred by
+    // the corpse window) revived the wave into ambushIds and wedged or
+    // re-attacked any run still walking. Now the summoned-add arm drops the
+    // corpse once its loot window (60s) lapses, and the mob NEVER comes back:
+    // watch well past corpse decay plus the old respawn delay.
+    for (let i = 0; i < 100 * 20; i++) {
+      sim.tick();
+      for (const id of waveIds) {
+        const mob = sim.entities.get(id);
+        expect(!mob || mob.dead).toBe(true);
+      }
+    }
+    for (const id of waveIds) expect(sim.entities.get(id)).toBeUndefined();
   });
 });
 

--- a/tests/escort.test.ts
+++ b/tests/escort.test.ts
@@ -328,6 +328,56 @@ describe('escort run guards', () => {
     }
     expect(state.run?.waypointIndex ?? before + 1).toBeGreaterThan(before);
   });
+
+  it('re-engages an evaded ambush wave onto the escortee instead of wedging the run', () => {
+    const sim = makeSim();
+    const def = ESCORTS[ESCORT_ID];
+    teleportTo(sim, def.start.x, def.start.z);
+    activateQuest(sim);
+    sim.interact();
+    const wren = findEscortee(sim);
+    const state = sim.escortRuns.get(ESCORT_ID);
+    expect(wren && state?.run).toBeTruthy();
+    if (!wren || !state?.run) return;
+
+    // Walk to the first ambush.
+    for (let i = 0; i < 60 * 20 && liveAmbushers(sim).length === 0; i++) sim.tick();
+    const wave = liveAmbushers(sim);
+    expect(wave.length).toBe(3);
+
+    // The live-server kite: drag the whole wave far past its leash. The chase
+    // exceeds LEASH_DISTANCE, the mobs evade home, and the evade reset clears
+    // their hate tables, the escortee seed included. Without the driver
+    // re-commit they would idle beside the waiting escortee until the run
+    // timeout (the reported "escortee just stops walking" wedge).
+    for (const mob of wave) {
+      const far = sim.groundPos(mob.pos.x + 80, mob.pos.z);
+      mob.pos = { ...far };
+      mob.prevPos = { ...far };
+    }
+    let reengaged = false;
+    for (let i = 0; i < 120 * 20 && !reengaged; i++) {
+      sim.tick();
+      const live = liveAmbushers(sim);
+      reengaged =
+        live.length === 3 &&
+        live.every((m) => m.aggroTargetId === wren.id && (m.threat.get(wren.id) ?? 0) > 0);
+    }
+    expect(reengaged).toBe(true);
+
+    // With the wave re-committed, cutting it down releases the walk: the run
+    // advances past the held waypoint instead of stalling to the timeout.
+    const before = state.run?.waypointIndex ?? -1;
+    for (const mob of liveAmbushers(sim)) {
+      mob.hp = 0;
+      mob.dead = true;
+      mob.respawnTimer = 99999;
+    }
+    for (let i = 0; i < 30 * 20 && state.run !== null && state.run.waypointIndex <= before; i++) {
+      sim.tick();
+    }
+    expect(state.run === null || state.run.waypointIndex > before).toBe(true);
+  });
 });
 
 // Every authored escort route must be WALKABLE in the real world: the escortee


### PR DESCRIPTION
## Summary

Every escort quest (Wraithwood, Frostveil, Palmreach, Farshore) soft-locks when its ambush wave evades: a player kiting the wave past its leash (or dying, stealthing, or running ahead) triggers the leash reset, which clears the wave's hate table including the seeded escortee threat. The mobs end up idling beside the waiting escortee, and the driver holds the walk while any wave mob is alive, so the run freezes until the 600s timeout silently fails it. This is the live report of the Wraithwood escortee "just stopping by the spiders" mid-path; it reproduces headless on the production seed for esc_ww_mosley and esc_pr_navigator, and applies to all four defs by shared driver.

Three commits:

1. **The wedge fix.** The driver's wave-wait branch re-commits any live wave mob that has finished its evade (idle, empty threat table) back onto the escortee, mirroring the spawn-time seed in fireAmbushes. An evaded wave resumes its attack and the run always resolves. Engaged mobs (threat non-empty) and fleeing mobs are untouched; the re-commit draws no rng.
2. **Review follow-ups** (from the sim architecture and test-coverage review passes): the guard is strictly `idle`, never `evade`, because the leash prelude clears threat and enters `evade` on the leash-break tick itself; re-committing then would re-anchor the leash at the kite spot and make wave mobs leash-immune (measured: a repeatedly kited wave walked 296 yards from spawn without ever resetting). Waiting for `idle` preserves the full walk-home reset. Wave mobs are also marked `summonedAdd` so a slain wave unravels after its 60s loot window instead of riding the generic 25s in-place camp respawn back into a still-walking run, which re-wedged (pre-fix) or re-attacked (post-fix) any run outlasting the respawn timer.
3. **A base-branch CI repair.** release/v0.32.2 backported the "That player is already trading." trade emit without its localization arm, so the S3 drift guard and the non-Latin completeness guard fail on the base branch itself. Adds the matcher row, catalog key, and the five non-Latin overlay fills, all copied verbatim from release/v0.33.0, plus regenerated bundles.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands:
  - `npm run gate`: all 11 steps green (full suite: 22,977 passed).
  - `npx vitest run tests/escort.test.ts`: 18/18, including three new tests: the evade re-commit (leash precondition pinned against LEASH_DISTANCE, full-health-after-reset proves the walk-home ran, the escortee takes fresh hits, and the run survives and advances), the player-fight guard (an actively fought wave mob is never re-seeded), and the no-respawn lifecycle (a slain wave never returns and unravels after its loot window).
  - Mutation checks: restoring the `evade` arm fails the reset pin; stripping the guards fails the player-fight test. The headline test was also verified red against the unfixed module.
  - `npx vitest run tests/parity tests/architecture.test.ts`: goldens byte-identical (the fix draws no rng and no golden scenario starts an escort run).
- Manual steps: headless Sim repro on the production seed (20061) driving esc_ww_mosley through unassisted, assisted, and kited-wave scenarios. Before the fix the kite scenario wedges at waypoint 1 for 600s with the wave idling at zero threat; after the fix it resolves normally.

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive tests for changed behavior and recorded any manual checks above.

### Localization (i18n)

- [x] **New player-visible strings follow the contributor policy.** The only i18n change backports an existing v0.33.0 key (matcher, catalog English, and the five required non-Latin fills copied verbatim); no new strings were authored.
- [x] Player-facing text emitted from `src/sim/` is re-localized at the client boundary in this same change, and `npx vitest run tests/localization_fixes.test.ts` passes.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] Generated files were regenerated by their owning build step (`npm run i18n:gen`), not hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
