### PR TITLE
fix(sim): backport respawn tiers, the escort ambush leak fix, and harvest tags to v0.32.2

### DIFF
--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -1157,7 +1157,11 @@ export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): 
     // Respawn cadence is the zone's, not one flat world timer: the policy leaf
     // reads the mob's SPAWN point so a corpse dragged across a border still
     // returns on its home band's schedule. Draws no rng.
-    e.respawnTimer = resolveRespawnSeconds(template, e.spawnPos, ctx.cfg.respawnSeconds);
+    // A run-scoped mob (an escort ambush wave) was never placed by a camp, so it
+    // has no home to return to and never respawns in place; its run drops it.
+    e.respawnTimer = e.runScoped
+      ? Number.POSITIVE_INFINITY
+      : resolveRespawnSeconds(template, e.spawnPos, ctx.cfg.respawnSeconds);
     // A fixed respawn also caps corpse decay so the mob returns on schedule whether
     // or not its loot was looted (training dummy: 10s).
     if (template?.respawnSeconds !== undefined) {

--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -71,7 +71,10 @@ import { onDamageTaken, onShieldConsumed, onSpellCrit, resetProcState } from './
 
 // How long a slain mob's corpse persists (seconds) before it is cleared. Sole user
 // is handleDeath, so the constant lives here with the death-domain code.
-const CORPSE_DURATION = 60;
+// Exported so the respawn policy's guard can check it against the zone tiers:
+// updateMob defers an in-place respawn while a corpse is still lootable, so the
+// effective delay is max(tier, this). See tests/respawn_policy.test.ts.
+export const CORPSE_DURATION = 60;
 // Self attack-speed buff a wounded frenzyOnHit mob gains; sole user maybeFrenzyOnHit.
 const BLOOD_FRENZY_AURA_ID = 'blood_frenzy';
 const VICTORY_RUSH_WINDOW = 20;

--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -31,6 +31,7 @@ import { DAMAGE_IDLE_DESPAWN_MOB_IDS, DAMAGE_IDLE_DESPAWN_SECONDS } from '../ent
 import { weaponHand } from '../equipment_rules';
 import { lockNormalDungeonResetOnBossKill } from '../instances/dungeons';
 import { pvpDamageMultiplier } from '../pvp';
+import { resolveRespawnSeconds } from '../respawn_policy';
 import { aurasSurvivingDeath } from '../resurrection';
 import type { PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
@@ -1150,9 +1151,10 @@ export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): 
     }
     e.aiState = 'dead';
     e.corpseTimer = CORPSE_DURATION;
-    e.respawnTimer =
-      template?.respawnSeconds ??
-      ctx.cfg.respawnSeconds * (template?.respawnMult ?? (template?.rare ? 4 : 1));
+    // Respawn cadence is the zone's, not one flat world timer: the policy leaf
+    // reads the mob's SPAWN point so a corpse dragged across a border still
+    // returns on its home band's schedule. Draws no rng.
+    e.respawnTimer = resolveRespawnSeconds(template, e.spawnPos, ctx.cfg.respawnSeconds);
     // A fixed respawn also caps corpse decay so the mob returns on schedule whether
     // or not its loot was looted (training dummy: 10s).
     if (template?.respawnSeconds !== undefined) {

--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -1157,11 +1157,7 @@ export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): 
     // Respawn cadence is the zone's, not one flat world timer: the policy leaf
     // reads the mob's SPAWN point so a corpse dragged across a border still
     // returns on its home band's schedule. Draws no rng.
-    // A run-scoped mob (an escort ambush wave) was never placed by a camp, so it
-    // has no home to return to and never respawns in place; its run drops it.
-    e.respawnTimer = e.runScoped
-      ? Number.POSITIVE_INFINITY
-      : resolveRespawnSeconds(template, e.spawnPos, ctx.cfg.respawnSeconds);
+    e.respawnTimer = resolveRespawnSeconds(template, e.spawnPos, ctx.cfg.respawnSeconds);
     // A fixed respawn also caps corpse decay so the mob returns on schedule whether
     // or not its loot was looted (training dummy: 10s).
     if (template?.respawnSeconds !== undefined) {

--- a/src/sim/content/amberfall.ts
+++ b/src/sim/content/amberfall.ts
@@ -119,6 +119,7 @@ export const AMBERFALL_MOBS: Record<string, MobTemplate> = {
     ],
     scale: 1.15,
     color: 0xd8a848,
+    componentTags: ['hide', 'meat'],
   },
   gloam_fox: {
     id: 'gloam_fox',
@@ -137,6 +138,7 @@ export const AMBERFALL_MOBS: Record<string, MobTemplate> = {
     loot: [{ copper: 90, chance: 1 }],
     scale: 1,
     color: 0xd87838,
+    componentTags: ['hide', 'fang'],
   },
   orchard_treant: {
     id: 'orchard_treant',

--- a/src/sim/content/farshore.ts
+++ b/src/sim/content/farshore.ts
@@ -157,6 +157,7 @@ export const FARSHORE_MOBS: Record<string, MobTemplate> = {
     loot: [{ copper: 26, chance: 1 }],
     scale: 1.15,
     color: 0x2f2a44,
+    componentTags: ['hide', 'fang'],
   },
   sundered_horror: {
     id: 'sundered_horror',

--- a/src/sim/content/frostveil.ts
+++ b/src/sim/content/frostveil.ts
@@ -123,6 +123,7 @@ export const FROSTVEIL_MOBS: Record<string, MobTemplate> = {
     ],
     scale: 1.1,
     color: 0xeef4f8,
+    componentTags: ['hide', 'fang', 'meat'],
   },
   ice_wisp: {
     id: 'ice_wisp',
@@ -201,6 +202,7 @@ export const FROSTVEIL_MOBS: Record<string, MobTemplate> = {
     loot: [{ copper: 105, chance: 1 }],
     scale: 1.3,
     color: 0x9db4c8,
+    componentTags: ['hide', 'fang', 'meat'],
   },
   // Trapper Brosk's lost apprentice (q_fv_seeing_wren_home). Escort-run
   // escortee: non-hostile, never wanders (moveSpeed 0; src/sim/escort.ts

--- a/src/sim/content/galecrest.ts
+++ b/src/sim/content/galecrest.ts
@@ -138,6 +138,7 @@ export const GALECREST_MOBS: Record<string, MobTemplate> = {
     ],
     scale: 1.1,
     color: 0xd8d0c0,
+    componentTags: ['hide', 'meat'],
   },
   gale_wisp: {
     id: 'gale_wisp',

--- a/src/sim/content/nightbloom.ts
+++ b/src/sim/content/nightbloom.ts
@@ -127,6 +127,7 @@ export const NIGHTBLOOM_MOBS: Record<string, MobTemplate> = {
     ],
     scale: 1.1,
     color: 0xe6e9f4,
+    componentTags: ['hide', 'meat'],
   },
   gloam_strider: {
     id: 'gloam_strider',
@@ -145,6 +146,7 @@ export const NIGHTBLOOM_MOBS: Record<string, MobTemplate> = {
     loot: [{ copper: 105, chance: 1 }],
     scale: 1.1,
     color: 0x4c4a72,
+    componentTags: ['hide', 'fang'],
   },
   nightkin_stargazer: {
     id: 'nightkin_stargazer',

--- a/src/sim/content/palmreach.ts
+++ b/src/sim/content/palmreach.ts
@@ -125,6 +125,7 @@ export const PALMREACH_MOBS: Record<string, MobTemplate> = {
     loot: [{ copper: 105, chance: 1 }],
     scale: 1.15,
     color: 0xe86848,
+    componentTags: ['meat'],
   },
   thicket_boar: {
     id: 'thicket_boar',
@@ -143,6 +144,7 @@ export const PALMREACH_MOBS: Record<string, MobTemplate> = {
     loot: [{ copper: 105, chance: 1 }],
     scale: 1.2,
     color: 0x6a4e38,
+    componentTags: ['hide', 'meat'],
   },
   canopy_weaver: {
     id: 'canopy_weaver',
@@ -165,6 +167,7 @@ export const PALMREACH_MOBS: Record<string, MobTemplate> = {
     ],
     scale: 1.25,
     color: 0x4e8a3c,
+    componentTags: ['silk', 'venomSac'],
   },
   idol_guardian: {
     id: 'idol_guardian',

--- a/src/sim/content/realm.ts
+++ b/src/sim/content/realm.ts
@@ -216,6 +216,7 @@ export const REALM_MOBS: Record<string, MobTemplate> = {
     ],
     scale: 1.0,
     color: 0xb9a3cf,
+    componentTags: ['hide', 'meat'],
   },
   veiled_doe: {
     id: 'veiled_doe',
@@ -234,6 +235,7 @@ export const REALM_MOBS: Record<string, MobTemplate> = {
     loot: [{ copper: 40, chance: 1 }],
     scale: 0.9,
     color: 0xcdbfdc,
+    componentTags: ['hide', 'meat'],
   },
   gleamstag: {
     id: 'gleamstag',

--- a/src/sim/content/temple.ts
+++ b/src/sim/content/temple.ts
@@ -478,6 +478,30 @@ export const TEMPLE_QUEST_ORDER = [
 // World layout — the Glimmermere shore (south of the tarn at -70,760)
 // ---------------------------------------------------------------------------
 
+// Camp ORDER is world-gen rng draw order: never reorder or insert here, only
+// retune a center in place.
+//
+// THESE CAMPS DELIBERATELY STAY ON THE WATERLINE. They sit in the gap between
+// Thornpeak's ogre camps (x -60..-132, z 700..768) and its revenant camps
+// (x -34..-40, z 830..842), so all three groups fall into one contiguous farm
+// cluster. That was investigated as a placement defect and it is not one: the
+// Glimmermere itself lies inside that corridor, and the binding neighbours are
+// the WESTERN packs, not the revenants. Brutok (-45, 768) is 34yd from the
+// first wader camp and the ogre camp at (-60, 730) is 51yd from it, so no
+// arrangement that keeps these mobs at the water clears the 60yd cluster link:
+// measured, the best separation reachable within 20yd of the shore is 54yd.
+//
+// Moving them out to where the packs separate means marching them 50 to 70yd
+// uphill, which contradicts their own quest text: waders "climb out of the mere"
+// (q_tarn_waders) and Sethrael "glides the deep shelf where the stair begins...
+// go down to the shelf" (q_palecoil). It also un-flattens the lakeshore, since
+// camps stamp terrain (src/sim/world.ts reads CAMPS), which reshapes the tarn's
+// water dressing.
+//
+// The farm problem these camps were suspected of is fixed at the source instead:
+// the zone respawn tier (src/sim/respawn_policy.ts) takes this corridor from
+// about 189 gold and 1.29M XP per hour down to about 25 gold and 179k XP,
+// bounded by tests/economy_yield.test.ts. Do not "fix" the spacing here.
 export const TEMPLE_CAMPS: CampDef[] = [
   { mobId: 'glimmermere_wader', center: { x: -78, z: 778 }, radius: 16, count: 7 },
   { mobId: 'glimmermere_wader', center: { x: -56, z: 800 }, radius: 14, count: 5 },

--- a/src/sim/content/wraithwood.ts
+++ b/src/sim/content/wraithwood.ts
@@ -128,6 +128,7 @@ export const WRAITHWOOD_MOBS: Record<string, MobTemplate> = {
     ],
     scale: 1.3,
     color: 0x3a3440,
+    componentTags: ['silk', 'venomSac'],
   },
   wood_wraith: {
     id: 'wood_wraith',

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -595,6 +595,7 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     ],
     scale: 1.1,
     color: 0x6b8e23,
+    componentTags: ['hide', 'meat'],
   },
 };
 

--- a/src/sim/data.ts
+++ b/src/sim/data.ts
@@ -759,6 +759,24 @@ export function zoneAt(x: number, z: number): ZoneDef {
   return fallback ?? NORTHMOST_ZONE;
 }
 
+// Strict rect containment: the zone whose rectangle literally contains (x, z),
+// or null when the point lies outside every authored zone. Unlike zoneAt, which
+// clamps through a southmost-band fallback so an overworld query always yields a
+// zone, this reports "nowhere" honestly. Callers that must distinguish the open
+// world from an instanced interior (the far-east dungeon/arena/delve plane at
+// INSTANCE_X_BASE, which zoneAt would misreport as a real zone) use this one.
+// Reads the static ZONES, exactly like zoneAt, so a custom play-test map's zones
+// never redefine world policy.
+export function zoneContaining(x: number, z: number): ZoneDef | null {
+  for (const zone of ZONES) {
+    if (z < zone.zMin || z >= zone.zMax) continue;
+    const x0 = zone.xMin ?? STRIP_MIN_X;
+    const x1 = zone.xMax ?? STRIP_MAX_X;
+    if (x >= x0 && x < x1) return zone;
+  }
+  return null;
+}
+
 // The original strip column and the east/west columns beside it. Sequential
 // band cascades (terrain shape, palettes, the sky crossfade) walk
 // STRIP_ZONES in stack order exactly as they always did; COLUMN_ZONES blend

--- a/src/sim/escort.ts
+++ b/src/sim/escort.ts
@@ -177,6 +177,15 @@ function fireAmbushes(ctx: SimContext, def: EscortDef, state: EscortRunState, np
       // ambushIds' live count and wedge (or re-attack) a still-walking run.
       mob.summonedAdd = true;
       ctx.addEntity(mob);
+      // A wave mob belongs to the RUN, not to the world: it was never placed by
+      // a CAMP, so it must never respawn in place. Without this a killed
+      // ambusher came back as a permanent orphan spawn (handleDeath gives every
+      // mob a respawnTimer and updateMob revives it), so each run silently added
+      // its whole wave to the zone forever. That is the mob-pile players
+      // reported along the escort routes in the July zones.
+      // It also keeps the walk honest: a wave that revived mid-run would make
+      // liveAmbushCount non-zero again and pause the escortee indefinitely.
+      mob.runScoped = true;
       // Commit the wave to the escortee, social_aggro-style; player damage
       // out-threats the seed immediately via the normal pull-over rules.
       mob.aiState = 'chase';
@@ -233,11 +242,12 @@ function endRun(
   outcome: 'success' | 'fail',
 ): void {
   if (npc) emitMobYell(ctx, npc, outcome === 'success' ? def.successText : def.failText);
-  // Surviving ambush mobs leave with the run (a failed wave never lingers to
-  // camp the respawned escortee).
+  // Ambush mobs leave with the run, DEAD ONES INCLUDED (a failed wave never
+  // lingers to camp the respawned escortee, and a slain one must not be left as
+  // a permanent corpse now that it can no longer respawn away). Dropping by id
+  // covers both states, so nothing from the wave outlives its run.
   for (const id of state.run?.ambushIds ?? []) {
-    const mob = ctx.entities.get(id);
-    if (mob && !mob.dead) ctx.dropEntity(id);
+    if (ctx.entities.has(id)) ctx.dropEntity(id);
   }
   if (state.npcId !== null) ctx.dropEntity(state.npcId);
   state.npcId = null;

--- a/src/sim/escort.ts
+++ b/src/sim/escort.ts
@@ -233,12 +233,14 @@ function endRun(
   outcome: 'success' | 'fail',
 ): void {
   if (npc) emitMobYell(ctx, npc, outcome === 'success' ? def.successText : def.failText);
-  // Ambush mobs leave with the run, DEAD ONES INCLUDED (a failed wave never
-  // lingers to camp the respawned escortee, and a slain one must not be left as
-  // a permanent corpse now that it can no longer respawn away). Dropping by id
-  // covers both states, so nothing from the wave outlives its run.
+  // Surviving ambush mobs leave with the run (a failed wave never lingers to
+  // camp the respawned escortee). A SLAIN one is deliberately left alone: it
+  // carries summonedAdd, so mob/locomotion.ts unravels its corpse once the loot
+  // window lapses. Dropping it here instead would yank a corpse a player may be
+  // mid-loot on, which is the whole reason that arm waits for corpseTimer.
   for (const id of state.run?.ambushIds ?? []) {
-    if (ctx.entities.has(id)) ctx.dropEntity(id);
+    const mob = ctx.entities.get(id);
+    if (mob && !mob.dead) ctx.dropEntity(id);
   }
   if (state.npcId !== null) ctx.dropEntity(state.npcId);
   state.npcId = null;

--- a/src/sim/escort.ts
+++ b/src/sim/escort.ts
@@ -177,15 +177,6 @@ function fireAmbushes(ctx: SimContext, def: EscortDef, state: EscortRunState, np
       // ambushIds' live count and wedge (or re-attack) a still-walking run.
       mob.summonedAdd = true;
       ctx.addEntity(mob);
-      // A wave mob belongs to the RUN, not to the world: it was never placed by
-      // a CAMP, so it must never respawn in place. Without this a killed
-      // ambusher came back as a permanent orphan spawn (handleDeath gives every
-      // mob a respawnTimer and updateMob revives it), so each run silently added
-      // its whole wave to the zone forever. That is the mob-pile players
-      // reported along the escort routes in the July zones.
-      // It also keeps the walk honest: a wave that revived mid-run would make
-      // liveAmbushCount non-zero again and pause the escortee indefinitely.
-      mob.runScoped = true;
       // Commit the wave to the escortee, social_aggro-style; player damage
       // out-threats the seed immediately via the normal pull-over rules.
       mob.aiState = 'chase';

--- a/src/sim/farm_yield.ts
+++ b/src/sim/farm_yield.ts
@@ -1,0 +1,191 @@
+// Sustainable farm yield: what a stretch of open world can pay per hour if a
+// player kills everything in it as fast as it comes back.
+//
+// A pure leaf (no SimContext, no state): a Vitest imports it directly. Nothing
+// in the live sim calls it. It exists so the balance question "how much gold and
+// XP per hour does this patch of world support?" is answered by one shared model
+// that guard tests pin (tests/camp_density.test.ts, tests/economy_yield.test.ts),
+// instead of by hand arithmetic in a review comment.
+//
+// The model is a CEILING, deliberately generous to the farmer: it assumes zero
+// travel and kill time, every mob dead the instant it respawns, every non-quest
+// drop vendored, and each mob at its template's top level. Real throughput is
+// well under it. That is what makes it a useful guard: if even the ceiling is
+// sane, the reality is.
+//
+// ONE INCOME STREAM IS DELIBERATELY EXCLUDED: corpse harvesting. A mob's
+// componentTags open a profession path (interaction.ts harvestCorpse) whose
+// yield depends on the harvester's profession level, tools and rarity rolls, so
+// it is a property of the PLAYER, not of the camp, and folding a guess at it in
+// would make these ceilings less comparable rather than more complete. The
+// coinless harvest families are priced here at their loot-table value only,
+// which for most of them is zero. Read a beast camp's copperPerHour as "coin and
+// vendorable drops", not "everything a skinner can make from it".
+
+import { CAMPS, ITEMS, MOBS, zoneContaining } from './data';
+import { resolveRespawnSeconds } from './respawn_policy';
+import type { CampDef, MobTemplate } from './types';
+import { mobXpValue } from './types';
+
+/**
+ * Two camps join the same farm cluster when their centers are within this many
+ * yards, transitively. It is a proximity model over camp CENTERS, so it asks
+ * "would a farmer treat these as one route?", not "do the packs touch".
+ */
+export const CLUSTER_LINK_DISTANCE = 60;
+
+/** Guaranteed-plus-chance coin per kill, in copper. */
+export function coinEvPerKill(template: MobTemplate): number {
+  let copper = 0;
+  for (const entry of template.loot) {
+    if (entry.copper) copper += entry.copper * entry.chance;
+  }
+  return copper;
+}
+
+/**
+ * Vendor value per kill of the droppable items, in copper. Quest entries are
+ * excluded: they only drop while their quest is active, and they are turn-in
+ * fodder rather than income.
+ */
+export function itemEvPerKill(template: MobTemplate): number {
+  let copper = 0;
+  for (const entry of template.loot) {
+    if (!entry.itemId || entry.questId) continue;
+    const item = ITEMS[entry.itemId];
+    if (item) copper += item.sellValue * entry.chance;
+  }
+  return copper;
+}
+
+/**
+ * Kill XP for a player fighting this mob at its own level, including the elite
+ * doubling and any xpMult. Mirrors the grant in combat/damage.ts.
+ */
+export function xpPerKill(template: MobTemplate, level: number): number {
+  const eliteMult = (template.elite ? 2 : 1) * (template.xpMult ?? 1);
+  return mobXpValue(level, level) * eliteMult;
+}
+
+export interface CampYield {
+  camp: CampDef;
+  template: MobTemplate;
+  /** The zone the camp center sits in, or null off the authored map. */
+  zoneId: string | null;
+  /** Top of the template's level band: the ceiling a farmer sees. */
+  level: number;
+  respawnSeconds: number;
+  /** count / respawn * 3600: the sustainable kill rate for this camp alone. */
+  killsPerHour: number;
+  copperPerHour: number;
+  xpPerHour: number;
+}
+
+/**
+ * One camp's sustainable yield at a given respawn delay. Respawn is passed in
+ * rather than resolved here so the same model can price a hypothetical (a
+ * proposed tier, or the pre-change world) as easily as the live one.
+ */
+export function campYield(camp: CampDef, respawnSeconds: number): CampYield | null {
+  const template = MOBS[camp.mobId];
+  if (!template) return null;
+  const level = template.maxLevel;
+  // A zero or negative delay would divide by zero; treat it as "no sustainable
+  // ceiling exists" rather than silently reporting Infinity.
+  const killsPerHour =
+    respawnSeconds > 0 ? (camp.count / respawnSeconds) * 3600 : Number.POSITIVE_INFINITY;
+  return {
+    camp,
+    template,
+    zoneId: zoneContaining(camp.center.x, camp.center.z)?.id ?? null,
+    level,
+    respawnSeconds,
+    killsPerHour,
+    copperPerHour: killsPerHour * (coinEvPerKill(template) + itemEvPerKill(template)),
+    xpPerHour: killsPerHour * xpPerKill(template, level),
+  };
+}
+
+/** Every world camp priced at the respawn the live policy gives it. */
+export function worldCampYields(camps: readonly CampDef[] = CAMPS): CampYield[] {
+  const out: CampYield[] = [];
+  for (const camp of camps) {
+    const template = MOBS[camp.mobId];
+    if (!template) continue;
+    const y = campYield(camp, resolveRespawnSeconds(template, camp.center, undefined));
+    if (y) out.push(y);
+  }
+  return out;
+}
+
+export interface FarmCluster {
+  camps: CampYield[];
+  /** Total mobs standing in the cluster at once. */
+  mobCount: number;
+  killsPerHour: number;
+  copperPerHour: number;
+  xpPerHour: number;
+  zoneIds: string[];
+  mobIds: string[];
+}
+
+/**
+ * Union-find over camp centers: transitively joins any two camps within
+ * `linkDistance` yards of each other, then totals each group.
+ */
+export function clusterCamps(
+  yields: readonly CampYield[],
+  linkDistance = CLUSTER_LINK_DISTANCE,
+): FarmCluster[] {
+  const parent = yields.map((_, i) => i);
+  const find = (i: number): number => {
+    let root = i;
+    while (parent[root] !== root) root = parent[root];
+    while (parent[i] !== root) {
+      const next = parent[i];
+      parent[i] = root;
+      i = next;
+    }
+    return root;
+  };
+  const union = (a: number, b: number): void => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent[rb] = ra;
+  };
+
+  for (let i = 0; i < yields.length; i++) {
+    for (let j = i + 1; j < yields.length; j++) {
+      const a = yields[i].camp.center;
+      const b = yields[j].camp.center;
+      if (Math.hypot(a.x - b.x, a.z - b.z) <= linkDistance) union(i, j);
+    }
+  }
+
+  const groups = new Map<number, CampYield[]>();
+  for (let i = 0; i < yields.length; i++) {
+    const root = find(i);
+    const bucket = groups.get(root);
+    if (bucket) bucket.push(yields[i]);
+    else groups.set(root, [yields[i]]);
+  }
+
+  const clusters: FarmCluster[] = [];
+  for (const camps of groups.values()) {
+    clusters.push({
+      camps,
+      mobCount: camps.reduce((n, c) => n + c.camp.count, 0),
+      killsPerHour: camps.reduce((n, c) => n + c.killsPerHour, 0),
+      copperPerHour: camps.reduce((n, c) => n + c.copperPerHour, 0),
+      xpPerHour: camps.reduce((n, c) => n + c.xpPerHour, 0),
+      zoneIds: [...new Set(camps.map((c) => c.zoneId ?? 'none'))].sort(),
+      mobIds: [...new Set(camps.map((c) => c.camp.mobId))].sort(),
+    });
+  }
+  return clusters.sort((a, b) => b.copperPerHour - a.copperPerHour);
+}
+
+/** Convenience: the live world's farm clusters, richest first. */
+export function worldFarmClusters(linkDistance = CLUSTER_LINK_DISTANCE): FarmCluster[] {
+  return clusterCamps(worldCampYields(), linkDistance);
+}

--- a/src/sim/professions/gathering.ts
+++ b/src/sim/professions/gathering.ts
@@ -786,7 +786,7 @@ export function harvestFamilyYieldsItem(component: string): boolean {
  * pick's length.
  *
  * Answering on mapped families instead retires that whole class rather than
- * reporting it: the corpse takes the SAME path as the 101 shipped templates
+ * reporting it: the corpse takes the SAME path as the many shipped templates
  * that carry no component tags at all, so the picker and the interact prompt
  * never offer it (src/sim/corpse_interaction.ts, src/game/corpse_loot_availability.ts,
  * src/ui/hud/loot/corpse_harvest_view.ts all read this predicate), and an

--- a/src/sim/respawn_policy.ts
+++ b/src/sim/respawn_policy.ts
@@ -16,7 +16,21 @@
 import { zoneContaining } from './data';
 import type { ZoneDef } from './types';
 
-/** Starter bands (zones capped at level 7): quest-paced, still fast. */
+/**
+ * Starter bands (zones capped at level 7): quest-paced, still fast.
+ *
+ * 60 rather than the band formula's own logic, and deliberately: this tier lands
+ * on a player's first hour, who has no second camp to rotate to and no mount, so
+ * it was checked against supply rather than assumed. A starter camp of 5 to 8
+ * mobs now returns 5 to 8 kills a minute (down from 12 to 19), while a new
+ * character needs 10 to 20 seconds per kill including the walk, so 3 to 6 a
+ * minute. Supply still exceeds demand at every authored starter camp, and the
+ * paired camps (two forest_wolf, two wild_boar, two vale_bandit) double it
+ * again, so a "kill 10" objective never waits on a spawn.
+ *
+ * If starter-zone feel ever regresses anyway, prefer ZoneDef.trashRespawnSeconds
+ * on the one zone over moving this constant, which governs Farshore Isle too.
+ */
 export const TRASH_RESPAWN_SECONDS_LOW = 60;
 /** Mid bands (zones capped at level 14). */
 export const TRASH_RESPAWN_SECONDS_MID = 120;

--- a/src/sim/respawn_policy.ts
+++ b/src/sim/respawn_policy.ts
@@ -1,0 +1,127 @@
+// Open-world mob respawn policy: how long a slain mob stays down.
+//
+// A pure leaf (no SimContext, no state): a Vitest imports it directly, and the
+// one live caller is the death site in combat/damage.ts.
+//
+// WHY THIS EXISTS: every open-world mob used to respawn on one flat 25s timer,
+// so a farmed camp regenerated about three times a minute and dense pack strips
+// paid gold and XP far past what the zone was tuned for. Respawn now scales with
+// the zone's level band, so a low-level starter camp still churns for questing
+// while endgame packs come back on a farm-resistant cadence.
+//
+// The tiers are a deliberate content-tuning knob, not a classic-era formula:
+// they are stated once here and pinned by tests/respawn_policy.test.ts, with the
+// downstream farm ceilings they protect pinned by tests/economy_yield.test.ts.
+
+import { zoneContaining } from './data';
+import type { ZoneDef } from './types';
+
+/** Starter bands (zones capped at level 7): quest-paced, still fast. */
+export const TRASH_RESPAWN_SECONDS_LOW = 60;
+/** Mid bands (zones capped at level 14). */
+export const TRASH_RESPAWN_SECONDS_MID = 120;
+/** Endgame bands (everything above level 14). */
+export const TRASH_RESPAWN_SECONDS_HIGH = 180;
+
+/**
+ * Fallback for a mob standing outside every authored zone rect: the far-east
+ * instance plane (dungeons, the arena, delves) and any other off-map spawn.
+ * Instanced content is already gated by lockouts and run length, so it keeps the
+ * historical flat delay.
+ */
+export const DEFAULT_RESPAWN_SECONDS = 25;
+
+/**
+ * The trash respawn delay for one zone, by its level band. A zone may override
+ * its tier with ZoneDef.trashRespawnSeconds. A null zone (nowhere in the
+ * authored world) takes DEFAULT_RESPAWN_SECONDS.
+ */
+export function trashRespawnSecondsForZone(zone: ZoneDef | null | undefined): number {
+  if (!zone) return DEFAULT_RESPAWN_SECONDS;
+  if (zone.trashRespawnSeconds !== undefined) return zone.trashRespawnSeconds;
+  const bandCap = zone.levelRange[1];
+  if (bandCap <= 7) return TRASH_RESPAWN_SECONDS_LOW;
+  if (bandCap <= 14) return TRASH_RESPAWN_SECONDS_MID;
+  return TRASH_RESPAWN_SECONDS_HIGH;
+}
+
+/**
+ * The base respawn delay in effect at a world position, BEFORE the per-template
+ * rare/respawnMult multiplier.
+ *
+ * `cfgRespawnSeconds` is SimConfig.respawnSeconds and is the global override: a
+ * host that passes it (the headless RL env, the fast unit tests) pins the whole
+ * world to that base and opts out of the zone tiers entirely. Left undefined (a
+ * normal world), the position's zone decides.
+ */
+export function baseRespawnSecondsAt(
+  x: number,
+  z: number,
+  cfgRespawnSeconds: number | undefined,
+): number {
+  if (cfgRespawnSeconds !== undefined) return cfgRespawnSeconds;
+  return trashRespawnSecondsForZone(zoneContaining(x, z));
+}
+
+/** The template fields the policy reads; a MobTemplate satisfies it structurally. */
+export interface RespawnTemplateFields {
+  respawnSeconds?: number;
+  respawnMult?: number;
+  rare?: boolean;
+}
+
+/**
+ * Historical world respawn base, kept SEPARATE from DEFAULT_RESPAWN_SECONDS even
+ * though both are 25 today. This one is the base a self-scheduled template was
+ * tuned against; that one is the off-map fallback. Retiming the fallback later
+ * must not silently retime every shipped rare, so they do not share a constant.
+ */
+export const LEGACY_RESPAWN_SECONDS = 25;
+
+/**
+ * Does this template carry its OWN respawn schedule rather than inheriting the
+ * world's? Two ways to say so, and both were tuned against the flat 25s base:
+ *
+ *  - an authored `respawnMult`: every shipped coefficient is a wall-clock target
+ *    expressed as a multiple of 25 (144 is one hour, 432 three, 864 six, and 7.2
+ *    is the three minutes tests/fixes.test.ts pins for a quest rare);
+ *  - `rare: true`, whose default 4x is the 100s cadence every bare rare shipped
+ *    with.
+ *
+ * Re-basing either onto a zone tier would stretch a six-hour rare past forty
+ * hours and a three-minute quest rare to twenty-two minutes. So named rares and
+ * minibosses keep their exact shipped schedule, and the zone tiers govern plain
+ * trash plus the open-world bosses that never declared a schedule at all. That
+ * split is the whole point: it slows farmable TRASH without touching tuned rare
+ * cadence.
+ */
+export function isSelfScheduled(template: RespawnTemplateFields | undefined): boolean {
+  return template?.respawnMult !== undefined || template?.rare === true;
+}
+
+/**
+ * The full resolution the death site applies, in precedence order:
+ *  1. an explicit MobTemplate.respawnSeconds (a fixed schedule: the training
+ *     dummy) wins outright, exactly as before;
+ *  2. otherwise the base, times the template's respawnMult, defaulting to 4x for
+ *     a rare and 1x for everything else. The multiplier arithmetic is unchanged
+ *     from the flat-timer era; only which base it multiplies moved, and only for
+ *     templates that are NOT self-scheduled (see isSelfScheduled).
+ *
+ * An explicit SimConfig base still overrides everything below the template's own
+ * fixed seconds, for both populations, exactly as it always did.
+ *
+ * The position is the mob's SPAWN point, not where it died: a mob dragged out of
+ * its camp still respawns on its home zone's cadence.
+ */
+export function resolveRespawnSeconds(
+  template: RespawnTemplateFields | undefined,
+  spawnPos: { x: number; z: number },
+  cfgRespawnSeconds: number | undefined,
+): number {
+  if (template?.respawnSeconds !== undefined) return template.respawnSeconds;
+  const base = isSelfScheduled(template)
+    ? (cfgRespawnSeconds ?? LEGACY_RESPAWN_SECONDS)
+    : baseRespawnSecondsAt(spawnPos.x, spawnPos.z, cfgRespawnSeconds);
+  return base * (template?.respawnMult ?? (template?.rare ? 4 : 1));
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1630,8 +1630,8 @@ function freshCounters(): RewardCounters {
 export class Sim {
   // `world` stays optional (a custom map for play-test, else undefined for the
   // built-in world); everything else is defaulted to a concrete value below.
-  cfg: Required<Omit<SimConfig, 'noPlayer' | 'world' | 'perfLap'>> &
-    Pick<SimConfig, 'world' | 'perfLap'>;
+  cfg: Required<Omit<SimConfig, 'noPlayer' | 'world' | 'perfLap' | 'respawnSeconds'>> &
+    Pick<SimConfig, 'world' | 'perfLap' | 'respawnSeconds'>;
   /**
    * The authored world this simulation owns. The active registry is a host/render
    * seam and may be swapped by an editor after construction; gameplay services,
@@ -1857,7 +1857,9 @@ export class Sim {
     this.cfg = {
       seed: cfg.seed,
       playerClass: cfg.playerClass,
-      respawnSeconds: cfg.respawnSeconds ?? 25,
+      // Deliberately NOT defaulted: the respawn policy (respawn_policy.ts) has to
+      // tell "the host pinned a global base" apart from "use the zone tier".
+      respawnSeconds: cfg.respawnSeconds,
       autoEquip: cfg.autoEquip ?? false,
       playerName: cfg.playerName ?? 'Adventurer',
       devCommands: this.devCommands,

--- a/src/sim/sim_context.ts
+++ b/src/sim/sim_context.ts
@@ -160,9 +160,11 @@ export interface SimContextPrimitives {
   readonly cardDuelQueue: number[];
   readonly cardDuels: Map<number, CardDuelMatch>;
   // `world` stays optional (custom play-test map, else undefined; perfLap is the
-  // temporary host-owned tick profiler probe); the rest defaulted.
-  readonly cfg: Required<Omit<SimConfig, 'noPlayer' | 'world' | 'perfLap'>> &
-    Pick<SimConfig, 'world' | 'perfLap'>;
+  // temporary host-owned tick profiler probe), and `respawnSeconds` stays
+  // possibly-undefined so respawn_policy.ts can tell an explicit host-pinned
+  // global base from "fall through to the zone tier"; the rest defaulted.
+  readonly cfg: Required<Omit<SimConfig, 'noPlayer' | 'world' | 'perfLap' | 'respawnSeconds'>> &
+    Pick<SimConfig, 'world' | 'perfLap' | 'respawnSeconds'>;
   // Per-Sim key for the rift collision registry in colliders.ts (rift/runs.ts
   // registers regions under it, rift-aware collision reads pass it). Per INSTANCE,
   // not per seed: two same-seed Sims in one process must stay isolated.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -3427,6 +3427,13 @@ export interface Entity extends ClientMirroredEntityFields {
    *  Bonewalker). Affix re-trigger checks exclude these so an affix-spawned mob's
    *  own death can never re-trigger the same affix (would otherwise chain forever). */
   affixSpawned?: boolean;
+  /** True for a mob spawned by a RUN or script rather than placed by a CAMP
+   *  (e.g. an escort ambush wave). It has no authored home in the world, so its
+   *  death must not schedule an in-place respawn: handleDeath gives it an
+   *  Infinity respawnTimer and its owner drops it when the run ends. Without
+   *  this, every killed wave member returned as a permanent orphan spawn and
+   *  the run's route accumulated mobs indefinitely. */
+  runScoped?: boolean;
   respawnTimer: number;
   corpseTimer: number;
   lootFfaTimer: number; // seconds of owner-lock left before tap loot opens to all (FFA); Infinity until rollLoot starts it

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -3427,13 +3427,6 @@ export interface Entity extends ClientMirroredEntityFields {
    *  Bonewalker). Affix re-trigger checks exclude these so an affix-spawned mob's
    *  own death can never re-trigger the same affix (would otherwise chain forever). */
   affixSpawned?: boolean;
-  /** True for a mob spawned by a RUN or script rather than placed by a CAMP
-   *  (e.g. an escort ambush wave). It has no authored home in the world, so its
-   *  death must not schedule an in-place respawn: handleDeath gives it an
-   *  Infinity respawnTimer and its owner drops it when the run ends. Without
-   *  this, every killed wave member returned as a permanent orphan spawn and
-   *  the run's route accumulated mobs indefinitely. */
-  runScoped?: boolean;
   respawnTimer: number;
   corpseTimer: number;
   lootFfaTimer: number; // seconds of owner-lock left before tap loot opens to all (FFA); Infinity until rollLoot starts it

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -2630,6 +2630,11 @@ export interface ZoneDef {
   // Defaults to 0 (the original zones' central road); the Drakelands set it
   // to the Pale Causeway's head so the Wyrmgate opens where the road arrives.
   southPassX?: number;
+  // Per-zone override of the open-world trash respawn delay (seconds), which
+  // otherwise comes from this zone's level band (src/sim/respawn_policy.ts
+  // trashRespawnSecondsForZone). An explicit SimConfig.respawnSeconds still
+  // wins over it, and a MobTemplate.respawnSeconds still wins over both.
+  trashRespawnSeconds?: number;
 }
 
 // One end of a paired overworld portal. Walking within the pair's trigger
@@ -5047,7 +5052,13 @@ export interface WorldContent {
 export interface SimConfig {
   seed: number;
   playerClass: PlayerClass;
-  respawnSeconds?: number; // mob respawn time (default 25)
+  // Global base mob respawn delay (seconds). LEAVE IT UNSET for a normal world:
+  // open-world trash then respawns on the per-zone level-band tier
+  // (src/sim/respawn_policy.ts), and only mobs outside every zone rect (instanced
+  // interiors) fall back to the 25s default. Setting it pins EVERY mob in the
+  // world to this base instead, which is what the RL env and the fast unit tests
+  // want; that is why it stays possibly-undefined on Sim.cfg.
+  respawnSeconds?: number;
   autoEquip?: boolean; // auto-equip better gear on loot (headless convenience)
   playerName?: string;
   noPlayer?: boolean; // multiplayer server: start with an empty world and addPlayer() later

--- a/tests/camp_density.test.ts
+++ b/tests/camp_density.test.ts
@@ -1,16 +1,16 @@
 // Guards camp DENSITY: how many mobs one farm route can hold at once, and the
 // specific Thornpeak corridor de-stack that motivated the model
-// (src/sim/farm_yield.ts).
+// (tests/helpers/farm_yield.ts).
 import { describe, expect, it } from 'vitest';
 import { CAMPS, MOBS, zoneContaining } from '../src/sim/data';
+import type { MobTemplate } from '../src/sim/types';
 import {
   type CampYield,
   CLUSTER_LINK_DISTANCE,
   campYield,
   clusterCamps,
   worldFarmClusters,
-} from '../src/sim/farm_yield';
-import type { MobTemplate } from '../src/sim/types';
+} from './helpers/farm_yield';
 
 /**
  * The most mobs a single fast-respawning trash cluster may hold. Eastbrook
@@ -123,14 +123,42 @@ describe('no farm cluster is overdense', () => {
     expect(largest).toBeGreaterThan(MAX_MOBS_PER_CLUSTER * 0.8);
   });
 
+  it('keeps every camp INSIDE an authored zone rect, even at its radius corners', () => {
+    // THE hole this guard exists to close. A camp that overhangs a zone edge has
+    // spawn points where zoneContaining is null, and the respawn policy hands
+    // those the 25s off-map fallback: a fast-farm pocket strictly worse than the
+    // pre-tier world, landing silently. Checked at the corners, not just the
+    // centre, because mobs scatter across the whole radius.
+    const outside: string[] = [];
+    for (const camp of CAMPS) {
+      const corners: [number, number][] = [
+        [0, 0],
+        [camp.radius, 0],
+        [-camp.radius, 0],
+        [0, camp.radius],
+        [0, -camp.radius],
+      ];
+      for (const [dx, dz] of corners) {
+        if (zoneContaining(camp.center.x + dx, camp.center.z + dz) === null) {
+          outside.push(`${camp.mobId} at (${camp.center.x},${camp.center.z}) r=${camp.radius}`);
+          break;
+        }
+      }
+    }
+    expect(outside).toEqual([]);
+    // ...and the sweep really looked at every camp, so an empty CAMPS or a
+    // short-circuited loop could not pass the row above.
+    expect(CAMPS.length).toBeGreaterThanOrEqual(175);
+  });
+
   it('never lets a camp straddle a zone seam, which the yield model assumes', () => {
     // farm_yield prices a camp from its CENTER's zone, while the live sim
     // resolves respawn per mob from its own spawn point. Those agree only while
-    // no camp's scatter radius crosses a band boundary.
+    // no camp's scatter radius crosses a band boundary, which would otherwise
+    // price a camp at one tier while its mobs respawned on another.
     const straddling: string[] = [];
     for (const camp of CAMPS) {
       const home = zoneContaining(camp.center.x, camp.center.z);
-      if (!home) continue;
       for (const [dx, dz] of [
         [camp.radius, 0],
         [-camp.radius, 0],
@@ -138,7 +166,7 @@ describe('no farm cluster is overdense', () => {
         [0, -camp.radius],
       ]) {
         const edge = zoneContaining(camp.center.x + dx, camp.center.z + dz);
-        if (edge?.id !== home.id) {
+        if (edge?.id !== home?.id) {
           straddling.push(`${camp.mobId} at (${camp.center.x},${camp.center.z}) r=${camp.radius}`);
           break;
         }

--- a/tests/camp_density.test.ts
+++ b/tests/camp_density.test.ts
@@ -1,0 +1,229 @@
+// Guards camp DENSITY: how many mobs one farm route can hold at once, and the
+// specific Thornpeak corridor de-stack that motivated the model
+// (src/sim/farm_yield.ts).
+import { describe, expect, it } from 'vitest';
+import { CAMPS, MOBS, zoneContaining } from '../src/sim/data';
+import {
+  type CampYield,
+  CLUSTER_LINK_DISTANCE,
+  campYield,
+  clusterCamps,
+  worldFarmClusters,
+} from '../src/sim/farm_yield';
+import type { MobTemplate } from '../src/sim/types';
+
+/**
+ * The most mobs a single fast-respawning trash cluster may hold. Eastbrook
+ * Vale's wolf/spider/bones chain sits exactly at this cap today, so the guard is
+ * deliberately tight: adding another mob to any level 1-7 camp near that chain
+ * is a decision to be made on purpose, not by accident.
+ */
+const MAX_FAST_TRASH_PER_CLUSTER = 30;
+
+/** Below this a respawn counts as "fast" for density purposes. */
+const FAST_RESPAWN_SECONDS = 100;
+
+/**
+ * Farmable trash: not a rare, boss, dummy or ambient prop, and carrying no
+ * authored respawnMult (which marks a mob with its own tuned schedule). This is
+ * exactly the population the zone respawn tiers govern.
+ */
+function isTrash(template: MobTemplate): boolean {
+  return (
+    !template.rare &&
+    !template.boss &&
+    !template.dummy &&
+    !template.ambient &&
+    template.respawnMult === undefined
+  );
+}
+
+function fastTrashCount(camps: readonly CampYield[]): number {
+  return camps
+    .filter((y) => isTrash(y.template) && y.respawnSeconds < FAST_RESPAWN_SECONDS)
+    .reduce((n, y) => n + y.camp.count, 0);
+}
+
+/**
+ * Ceiling on TOTAL standing mobs in any one cluster, at any respawn tier. The
+ * fast-trash cap above only ever governs the 60s starter band, so without this
+ * the mid and endgame bands would have no density guard at all. Thornpeak's
+ * Glimmermere corridor is the largest at 63 (see below, deliberate).
+ */
+const MAX_MOBS_PER_CLUSTER = 70;
+
+describe('clusterCamps: the union-find proximity model', () => {
+  it('pins the link distance, which decides whether any guard here has teeth', () => {
+    // Without this, dropping the constant to 20 would shatter the world into
+    // singletons and turn every density assertion in this file green.
+    expect(CLUSTER_LINK_DISTANCE).toBe(60);
+  });
+
+  const stub = (mobId: string, x: number, z: number, count = 1): CampYield => {
+    const y = campYield({ mobId, center: { x, z }, radius: 4, count }, 60);
+    if (!y) throw new Error(`no template ${mobId}`);
+    return y;
+  };
+
+  it('joins camps inside the link distance and separates camps beyond it', () => {
+    const near = clusterCamps([stub('forest_wolf', 0, 0), stub('forest_wolf', 0, 50)], 60);
+    expect(near).toHaveLength(1);
+    const far = clusterCamps([stub('forest_wolf', 0, 0), stub('forest_wolf', 0, 70)], 60);
+    expect(far).toHaveLength(2);
+  });
+
+  it('is inclusive exactly at the link distance, and excludes just past it', () => {
+    expect(clusterCamps([stub('forest_wolf', 0, 0), stub('forest_wolf', 0, 60)], 60)).toHaveLength(
+      1,
+    );
+    expect(
+      clusterCamps([stub('forest_wolf', 0, 0), stub('forest_wolf', 0, 60.5)], 60),
+    ).toHaveLength(2);
+  });
+
+  it('links transitively, so a chain of hops is one cluster', () => {
+    // 0 -> 50 -> 100: the ends are 100 apart but chain through the middle.
+    const chain = clusterCamps(
+      [stub('forest_wolf', 0, 0), stub('forest_wolf', 0, 50), stub('forest_wolf', 0, 100)],
+      60,
+    );
+    expect(chain).toHaveLength(1);
+    expect(chain[0].mobCount).toBe(3);
+  });
+
+  it('totals mob counts and kill rate across the whole cluster', () => {
+    const [cluster] = clusterCamps(
+      [stub('forest_wolf', 0, 0, 4), stub('forest_wolf', 0, 20, 6)],
+      60,
+    );
+    expect(cluster.mobCount).toBe(10);
+    // 10 mobs on a 60s respawn is 600 sustainable kills an hour.
+    expect(cluster.killsPerHour).toBeCloseTo(600, 6);
+  });
+});
+
+describe('no farm cluster is overdense', () => {
+  it('keeps every fast-respawn trash cluster at or under the cap', () => {
+    const offenders = worldFarmClusters()
+      .map((c) => ({ n: fastTrashCount(c.camps), ids: c.mobIds.join(', ') }))
+      .filter((c) => c.n > MAX_FAST_TRASH_PER_CLUSTER);
+    expect(offenders).toEqual([]);
+  });
+
+  it('caps TOTAL mobs per cluster in every band, not just the fast one', () => {
+    const offenders = worldFarmClusters()
+      .filter((c) => c.mobCount > MAX_MOBS_PER_CLUSTER)
+      .map((c) => `${c.zoneIds.join('+')} (${c.mobCount} mobs): ${c.mobIds.join(', ')}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it('has that total cap within reach, so it is a real bound', () => {
+    // Guards the opposite failure: a cap set so high nothing could ever hit it.
+    const largest = Math.max(...worldFarmClusters().map((c) => c.mobCount));
+    expect(largest).toBeGreaterThan(MAX_MOBS_PER_CLUSTER * 0.8);
+  });
+
+  it('never lets a camp straddle a zone seam, which the yield model assumes', () => {
+    // farm_yield prices a camp from its CENTER's zone, while the live sim
+    // resolves respawn per mob from its own spawn point. Those agree only while
+    // no camp's scatter radius crosses a band boundary.
+    const straddling: string[] = [];
+    for (const camp of CAMPS) {
+      const home = zoneContaining(camp.center.x, camp.center.z);
+      if (!home) continue;
+      for (const [dx, dz] of [
+        [camp.radius, 0],
+        [-camp.radius, 0],
+        [0, camp.radius],
+        [0, -camp.radius],
+      ]) {
+        const edge = zoneContaining(camp.center.x + dx, camp.center.z + dz);
+        if (edge?.id !== home.id) {
+          straddling.push(`${camp.mobId} at (${camp.center.x},${camp.center.z}) r=${camp.radius}`);
+          break;
+        }
+      }
+    }
+    expect(straddling).toEqual([]);
+  });
+
+  it('actually has fast-respawn trash to check, so the cap is not vacuous', () => {
+    // If the tiers ever slow every zone past 100s this guard would silently
+    // stop testing anything; fail loudly instead.
+    const fast = worldFarmClusters().filter((c) => fastTrashCount(c.camps) > 0);
+    expect(fast.length).toBeGreaterThan(0);
+    expect(Math.max(...fast.map((c) => fastTrashCount(c.camps)))).toBeGreaterThan(20);
+  });
+});
+
+describe('the Thornpeak corridor is one dense cluster ON PURPOSE', () => {
+  // The Glimmermere shore group (temple.ts) plus the packs it links to. These
+  // form the single biggest cluster in the world and are DELIBERATELY left that
+  // way, so the reason is pinned here rather than rediscovered.
+  const SHORE = ['glimmermere_wader', 'drowned_votary', 'sethrael_palecoil'];
+  const CORRIDOR_PACKS = [
+    'thornpeak_ogre',
+    'ogre_crusher',
+    'warlord_drogmar',
+    'brutok_skullsmasher',
+    'boneclad_revenant',
+    'marrowlord_varkas',
+  ];
+
+  it('cannot be separated without marching the shore mobs off the water', () => {
+    // The load-bearing fact behind the temple.ts comment. The binding
+    // neighbours are the WESTERN packs, not the revenants: no shore camp can
+    // reach the 60yd link distance from them while staying by the tarn.
+    const wader = CAMPS.find((c) => c.mobId === 'glimmermere_wader');
+    if (!wader) throw new Error('no glimmermere_wader camp');
+    const nearest = CAMPS.filter((c) => CORRIDOR_PACKS.includes(c.mobId))
+      .map((p) => ({
+        id: p.mobId,
+        d: Math.hypot(wader.center.x - p.center.x, wader.center.z - p.center.z),
+      }))
+      .sort((a, b) => a.d - b.d)[0];
+    expect(nearest.id).toBe('brutok_skullsmasher');
+    expect(nearest.d).toBeLessThan(CLUSTER_LINK_DISTANCE);
+    // The tarn (POI the_glimmermere, -70/760) sits inside the corridor, which is
+    // why this is a content fact and not a spacing bug.
+    expect(Math.hypot(wader.center.x - -70, wader.center.z - 760)).toBeLessThan(30);
+  });
+
+  it('holds the shore group and the packs in ONE cluster, as shipped', () => {
+    const merged = worldFarmClusters().filter(
+      (c) =>
+        c.mobIds.some((m) => SHORE.includes(m)) && c.mobIds.some((m) => CORRIDOR_PACKS.includes(m)),
+    );
+    expect(merged).toHaveLength(1);
+    // Pinned so a future camp addition to this corridor is a visible decision.
+    expect(merged[0].mobCount).toBe(63);
+  });
+
+  it('bounds that cluster by YIELD instead, which is what the tiers fixed', () => {
+    // Density here is inherent to the layout, so the guard that matters is the
+    // economic one: at the old flat 25s this same cluster paid about 189 gold
+    // and 1.29M XP an hour. tests/economy_yield.test.ts owns the ceilings; this
+    // asserts the corridor is the cluster they are protecting against.
+    const clusters = worldFarmClusters();
+    const richest = clusters.reduce((a, b) => (b.copperPerHour > a.copperPerHour ? b : a));
+    expect(richest.mobIds).toContain('glimmermere_wader');
+    expect(richest.mobIds).toContain('thornpeak_ogre');
+    // Every TRASH camp in it is on the 180s endgame tier (the rares keep their
+    // own shipped cadence, which is why they are excluded here), and nothing in
+    // the cluster is fast-respawn at all.
+    for (const y of richest.camps) {
+      if (isTrash(y.template)) expect(y.respawnSeconds, y.camp.mobId).toBe(180);
+      expect(y.respawnSeconds, y.camp.mobId).toBeGreaterThanOrEqual(FAST_RESPAWN_SECONDS);
+    }
+    expect(fastTrashCount(richest.camps)).toBe(0);
+  });
+});
+
+describe('the density model covers the shipped world', () => {
+  it('prices every camp, so no camp escapes the guards above', () => {
+    const priced = worldFarmClusters().reduce((n, c) => n + c.camps.length, 0);
+    const known = CAMPS.filter((c) => MOBS[c.mobId]).length;
+    expect(priced).toBe(known);
+    expect(known).toBe(CAMPS.length);
+  });
+});

--- a/tests/corpse_harvest_sim.test.ts
+++ b/tests/corpse_harvest_sim.test.ts
@@ -3247,9 +3247,12 @@ describe('a corpse whose EVERY family is unmapped is never offered a harvest (#2
     // one that stopped refusing, moves one of them. The total is every subset of
     // every tagged template (it grew with the templates #1584 added), stated so a
     // shrunk sweep reads as wrong rather than merely smaller.
-    expect(spent).toBe(86);
+    // Spent rose 86 to 152 with the farm-economy pass, which gave 15 coinless
+    // trash templates their mapped harvest tags; refused is untouched because
+    // that arm counts all-unmapped corpses, which the pass did not add to.
+    expect(spent).toBe(152);
     expect(refused).toBe(16);
-    expect(spent + refused).toBe(102);
+    expect(spent + refused).toBe(168);
   });
 
   // The six mapped families and their item ids, spelled out. Deriving them from
@@ -3332,7 +3335,9 @@ describe('a corpse whose EVERY family is unmapped is never offered a harvest (#2
     // release's 35/92 together with this branch's extra mobs (the rift bestiary),
     // so the counts rise while the property above is what actually holds the line.
     expect(unmappedOffered).toBe(37);
-    expect(extracted).toBe(113);
+    // 113 to 217 for the same reason as the spend census above: more mapped
+    // families in the corpus, none of them unmapped, so only this half moves.
+    expect(extracted).toBe(217);
   });
 
   it('keeps every mixed template harvestable, so the gate is not a blanket refusal', () => {

--- a/tests/economy_yield.test.ts
+++ b/tests/economy_yield.test.ts
@@ -1,0 +1,245 @@
+// Guards the open-world farm ECONOMY: the per-cluster gold and XP ceilings, the
+// coin-per-level curve, and the harvest-tag standard for coinless families.
+// Model: src/sim/farm_yield.ts.
+import { describe, expect, it } from 'vitest';
+import { HARVEST_COMPONENT_ITEMS } from '../src/sim/content/professions';
+import { CAMPS, MOBS, zoneContaining } from '../src/sim/data';
+import { coinEvPerKill, itemEvPerKill, worldFarmClusters, xpPerKill } from '../src/sim/farm_yield';
+import type { MobTemplate } from '../src/sim/types';
+import { mobXpValue } from '../src/sim/types';
+
+// Budgets are pinned ~25% above the shipped maxima, so ordinary content tuning
+// has room while a structural regression (a respawn tier cut, a coin fill an
+// order of magnitude off, a camp merge) trips the guard.
+
+/** Protects the richest cluster: Thornpeak's Glimmermere corridor at 27.5 gold/hr. */
+const MAX_CLUSTER_COPPER_PER_HOUR = 344_000;
+/** Protects the fastest XP cluster: the same corridor at 183k XP/hr. */
+const MAX_CLUSTER_XP_PER_HOUR = 229_000;
+
+/** Coin-carrying families: things that plausibly hold a purse. */
+const COIN_FAMILIES = new Set([
+  'humanoid',
+  'undead',
+  'troll',
+  'ogre',
+  'kobold',
+  'murloc',
+  'mudfin',
+  'dragonkin',
+  'demon',
+  'elemental',
+  'burrower',
+]);
+/** Families that pay in harvestable components rather than coin. */
+const HARVEST_FAMILIES = new Set(['beast', 'spider', 'reptile']);
+/**
+ * Evergarden and Galecrest topiary are garden CONSTRUCTS typed as beasts: they
+ * are clipped hedge, so they carry coin (the gardeners' lost pay) and have no
+ * hide or meat to take. The only sanctioned exception to the harvest rule.
+ */
+const HEDGE_CONSTRUCTS = new Set(['topiary_stag', 'topiary_wolf', 'the_topiary_bull']);
+
+/** The population the zone respawn tiers govern (see tests/camp_density.test.ts). */
+function isTrash(template: MobTemplate): boolean {
+  return (
+    !template.rare &&
+    !template.boss &&
+    !template.dummy &&
+    !template.ambient &&
+    template.respawnMult === undefined
+  );
+}
+
+/** Every distinct camp-spawned template, with the zone its camp sits in. */
+function campTemplates(): { template: MobTemplate; zoneLevelCap: number; zoneId: string }[] {
+  const seen = new Set<string>();
+  const out: { template: MobTemplate; zoneLevelCap: number; zoneId: string }[] = [];
+  for (const camp of CAMPS) {
+    const template = MOBS[camp.mobId];
+    if (!template || seen.has(camp.mobId)) continue;
+    const zone = zoneContaining(camp.center.x, camp.center.z);
+    if (!zone) continue;
+    seen.add(camp.mobId);
+    out.push({ template, zoneLevelCap: zone.levelRange[1], zoneId: zone.id });
+  }
+  return out;
+}
+
+describe('per-cluster farm ceilings stay under budget', () => {
+  it('keeps every cluster under the gold ceiling', () => {
+    const over = worldFarmClusters()
+      .filter((c) => c.copperPerHour > MAX_CLUSTER_COPPER_PER_HOUR)
+      .map((c) => `${c.mobIds.join(', ')}: ${(c.copperPerHour / 10_000).toFixed(1)}g/hr`);
+    expect(over).toEqual([]);
+  });
+
+  it('keeps every cluster under the XP ceiling', () => {
+    const over = worldFarmClusters()
+      .filter((c) => c.xpPerHour > MAX_CLUSTER_XP_PER_HOUR)
+      .map((c) => `${c.mobIds.join(', ')}: ${Math.round(c.xpPerHour)} xp/hr`);
+    expect(over).toEqual([]);
+  });
+
+  it('has real headroom rather than budgets set above anything reachable', () => {
+    // Guards the opposite failure: a budget so loose it can never trip. The
+    // shipped maxima must sit within 40% of their ceilings.
+    const clusters = worldFarmClusters();
+    const gold = Math.max(...clusters.map((c) => c.copperPerHour));
+    const xp = Math.max(...clusters.map((c) => c.xpPerHour));
+    expect(gold).toBeGreaterThan(MAX_CLUSTER_COPPER_PER_HOUR * 0.6);
+    expect(xp).toBeGreaterThan(MAX_CLUSTER_XP_PER_HOUR * 0.6);
+  });
+
+  it('would trip on BOTH dimensions if a tier were cut back to the old flat timer', () => {
+    // Negative control: the pre-change 25s respawn made Thornpeak's corridor pay
+    // multiples of both budgets, which is the regression these ceilings exist
+    // for. Both arms are checked; a control that only exercised copper would
+    // leave the XP ceiling with no proof it can ever trip.
+    const asIfFlat = worldFarmClusters().map((c) => {
+      const scale = (y: (typeof c.camps)[number]) => (y.camp.count / 25) * 3600;
+      return {
+        copper: c.camps.reduce(
+          (n, y) => n + scale(y) * (coinEvPerKill(y.template) + itemEvPerKill(y.template)),
+          0,
+        ),
+        xp: c.camps.reduce((n, y) => n + scale(y) * xpPerKill(y.template, y.level), 0),
+      };
+    });
+    expect(Math.max(...asIfFlat.map((c) => c.copper))).toBeGreaterThan(MAX_CLUSTER_COPPER_PER_HOUR);
+    expect(Math.max(...asIfFlat.map((c) => c.xp))).toBeGreaterThan(MAX_CLUSTER_XP_PER_HOUR);
+  });
+});
+
+describe('coin-family trash sits on the coin curve', () => {
+  // About 5 copper per mob level: the curve the pre-expansion zones were built
+  // on, now applied to every zone past the starter bands.
+  const MIN_COPPER_PER_LEVEL = 3.5;
+  const MAX_COPPER_PER_LEVEL = 7.0;
+
+  const governed = () =>
+    campTemplates().filter(
+      ({ template, zoneLevelCap }) =>
+        isTrash(template) && COIN_FAMILIES.has(template.family) && zoneLevelCap >= 8,
+    );
+
+  it('checks a real population, not an empty set', () => {
+    // 52 ship today; the floor sits at the real count, not comfortably under it.
+    expect(governed().length).toBeGreaterThanOrEqual(52);
+  });
+
+  it('pays every coin-family trash mob within the curve band', () => {
+    const off = governed()
+      .map(({ template, zoneId }) => {
+        const level = (template.minLevel + template.maxLevel) / 2;
+        return { id: template.id, zoneId, perLevel: coinEvPerKill(template) / level };
+      })
+      .filter((r) => r.perLevel < MIN_COPPER_PER_LEVEL || r.perLevel > MAX_COPPER_PER_LEVEL)
+      .map((r) => `${r.id} (${r.zoneId}): ${r.perLevel.toFixed(2)} c/level`);
+    expect(off).toEqual([]);
+  });
+
+  it('pays that coin as a GUARANTEED drop, not a lottery', () => {
+    // A 5%-chance 2000c entry would average onto the curve while playing nothing
+    // like it; require a certain coin entry on every governed mob.
+    const missing = governed()
+      .filter(({ template }) => !template.loot.some((l) => l.copper && l.chance === 1))
+      .map(({ template }) => template.id);
+    expect(missing).toEqual([]);
+  });
+
+  it('rejects an over-curve AND an under-curve template, so both edges bite', () => {
+    // Per-dimension negative controls. Without the second one, setting
+    // MIN_COPPER_PER_LEVEL to 0 would leave every assertion above green, so the
+    // "a coin fill an order of magnitude off" regression is caught one way only.
+    const crusher = MOBS.ogre_crusher;
+    const level = (crusher.minLevel + crusher.maxLevel) / 2;
+    expect(coinEvPerKill(crusher) / level).toBeGreaterThanOrEqual(MIN_COPPER_PER_LEVEL);
+    expect(coinEvPerKill(crusher) / level).toBeLessThanOrEqual(MAX_COPPER_PER_LEVEL);
+    // The pre-trim value was over the top of the band...
+    expect(200 / level).toBeGreaterThan(MAX_COPPER_PER_LEVEL);
+    // ...and a tenth of the shipped fill would be under the bottom of it.
+    expect(coinEvPerKill(crusher) / 10 / level).toBeLessThan(MIN_COPPER_PER_LEVEL);
+  });
+});
+
+describe('harvest-family trash carries usable components instead of coin', () => {
+  const governed = () =>
+    campTemplates().filter(
+      ({ template }) =>
+        isTrash(template) &&
+        HARVEST_FAMILIES.has(template.family) &&
+        !HEDGE_CONSTRUCTS.has(template.id),
+    );
+
+  it('checks a real population, per family, so no arm is silently empty', () => {
+    const byFamily = new Map<string, number>();
+    for (const { template } of governed())
+      byFamily.set(template.family, (byFamily.get(template.family) ?? 0) + 1);
+    // 17 beasts and 4 spiders ship as camp trash today; floors sit at the real
+    // counts so thinning the population fails here instead of going unnoticed.
+    expect(byFamily.get('beast') ?? 0).toBeGreaterThanOrEqual(17);
+    expect(byFamily.get('spider') ?? 0).toBeGreaterThanOrEqual(4);
+    // No reptile is camp-spawned yet (the one reptile template is a delve mob),
+    // so that arm of the rule is currently unexercised. Stated rather than
+    // hidden: the day a reptile camp ships, this line documents that the guard
+    // above starts governing it automatically.
+    expect(byFamily.get('reptile') ?? 0).toBe(0);
+    expect(governed().length).toBeGreaterThanOrEqual(21);
+  });
+
+  it('gives every beast, spider and reptile at least one HARVESTABLE tag', () => {
+    // Mapped in HARVEST_COMPONENT_ITEMS specifically: unmapped tags like claw and
+    // tusk are dead weight the corpse-harvest command cannot turn into an item.
+    const bare = governed()
+      .filter(
+        ({ template }) =>
+          !(template.componentTags ?? []).some((tag) => tag in HARVEST_COMPONENT_ITEMS),
+      )
+      .map(({ template, zoneId }) => `${template.id} (${zoneId})`);
+    expect(bare).toEqual([]);
+  });
+
+  it('rejects an unmapped-only tag set, running the same predicate as the rule', () => {
+    // Negative control that actually exercises the check above rather than
+    // restating the map's contents: a synthetic mob carrying only unmapped tags
+    // must be reported as bare, and one carrying a mapped tag must not.
+    const bareOf = (tags: string[]) =>
+      [{ componentTags: tags }].filter(
+        (t) => !(t.componentTags ?? []).some((tag) => tag in HARVEST_COMPONENT_ITEMS),
+      ).length;
+    expect(bareOf(['claw', 'tusk'])).toBe(1);
+    expect(bareOf(['hide'])).toBe(0);
+    expect(bareOf(['claw', 'hide'])).toBe(0);
+    expect(bareOf([])).toBe(1);
+  });
+
+  it('keeps the hedge constructs on coin, the one sanctioned exception', () => {
+    for (const id of HEDGE_CONSTRUCTS) {
+      const template = MOBS[id];
+      expect(template, id).toBeDefined();
+      expect(coinEvPerKill(template), id).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('the yield model matches the sim it is modelling', () => {
+  it('prices kill XP the way the damage core grants it', () => {
+    // Mirrors combat/damage.ts: mobXpValue(level, level) * (elite ? 2 : 1) * xpMult.
+    const wolf = MOBS.forest_wolf;
+    expect(xpPerKill(wolf, 2)).toBe(mobXpValue(2, 2));
+    const elite = MOBS.ogre_crusher;
+    expect(elite.elite).toBe(true);
+    expect(xpPerKill(elite, 17)).toBe(mobXpValue(17, 17) * 2);
+  });
+
+  it('counts guaranteed and chance coin, and ignores quest-only drops', () => {
+    const wader = MOBS.glimmermere_wader;
+    expect(coinEvPerKill(wader)).toBe(70);
+    // Quest entries never contribute to sustainable income.
+    const questOnly = MOBS.gilded_stag;
+    expect(questOnly.loot.every((l) => !l.copper)).toBe(true);
+    expect(coinEvPerKill(questOnly)).toBe(0);
+    expect(itemEvPerKill(questOnly)).toBe(0);
+  });
+});

--- a/tests/economy_yield.test.ts
+++ b/tests/economy_yield.test.ts
@@ -117,15 +117,50 @@ describe('coin-family trash sits on the coin curve', () => {
   const MIN_COPPER_PER_LEVEL = 3.5;
   const MAX_COPPER_PER_LEVEL = 7.0;
 
+  // ELITES are a separate tier and are excluded here. A zone's elite capstone
+  // is a deliberate step up (10 to 22.5 c/level in the shipped content), not an
+  // off-curve trash mob, and it is pinned by its own band below.
   const governed = () =>
     campTemplates().filter(
       ({ template, zoneLevelCap }) =>
-        isTrash(template) && COIN_FAMILIES.has(template.family) && zoneLevelCap >= 8,
+        isTrash(template) &&
+        !template.elite &&
+        COIN_FAMILIES.has(template.family) &&
+        zoneLevelCap >= 8,
+    );
+
+  const governedElites = () =>
+    campTemplates().filter(
+      ({ template, zoneLevelCap }) =>
+        isTrash(template) &&
+        template.elite === true &&
+        COIN_FAMILIES.has(template.family) &&
+        zoneLevelCap >= 8,
     );
 
   it('checks a real population, not an empty set', () => {
-    // 52 ship today; the floor sits at the real count, not comfortably under it.
-    expect(governed().length).toBeGreaterThanOrEqual(52);
+    expect(governed().length).toBeGreaterThanOrEqual(35);
+    expect(governedElites().length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('pays elite capstones on their own higher band, not the trash curve', () => {
+    // Their step up is intentional; this pins it so it stays a step and does not
+    // drift into a farm. 8 to 25 c/level brackets the shipped spread.
+    const off = governedElites()
+      .map(({ template, zoneId }) => {
+        const level = (template.minLevel + template.maxLevel) / 2;
+        return { id: template.id, zoneId, perLevel: coinEvPerKill(template) / level };
+      })
+      .filter((r) => r.perLevel < 8 || r.perLevel > 25)
+      .map((r) => `${r.id} (${r.zoneId}): ${r.perLevel.toFixed(2)} c/level`);
+    expect(off).toEqual([]);
+    // ...and the two bands really are disjoint, so "elite" is doing work here.
+    const trashMax = Math.max(
+      ...governed().map(
+        ({ template }) => coinEvPerKill(template) / ((template.minLevel + template.maxLevel) / 2),
+      ),
+    );
+    expect(trashMax).toBeLessThan(8);
   });
 
   it('pays every coin-family trash mob within the curve band', () => {
@@ -149,17 +184,19 @@ describe('coin-family trash sits on the coin curve', () => {
   });
 
   it('rejects an over-curve AND an under-curve template, so both edges bite', () => {
-    // Per-dimension negative controls. Without the second one, setting
-    // MIN_COPPER_PER_LEVEL to 0 would leave every assertion above green, so the
-    // "a coin fill an order of magnitude off" regression is caught one way only.
-    const crusher = MOBS.ogre_crusher;
-    const level = (crusher.minLevel + crusher.maxLevel) / 2;
-    expect(coinEvPerKill(crusher) / level).toBeGreaterThanOrEqual(MIN_COPPER_PER_LEVEL);
-    expect(coinEvPerKill(crusher) / level).toBeLessThanOrEqual(MAX_COPPER_PER_LEVEL);
-    // The pre-trim value was over the top of the band...
-    expect(200 / level).toBeGreaterThan(MAX_COPPER_PER_LEVEL);
-    // ...and a tenth of the shipped fill would be under the bottom of it.
-    expect(coinEvPerKill(crusher) / 10 / level).toBeLessThan(MIN_COPPER_PER_LEVEL);
+    // Per-dimension negative controls against a real trash template. Without the
+    // second one, setting MIN_COPPER_PER_LEVEL to 0 would leave every assertion
+    // above green, so the "coin fill an order of magnitude off" regression is
+    // caught one way only.
+    const wader = MOBS.glimmermere_wader;
+    const level = (wader.minLevel + wader.maxLevel) / 2;
+    const onCurve = coinEvPerKill(wader) / level;
+    expect(onCurve).toBeGreaterThanOrEqual(MIN_COPPER_PER_LEVEL);
+    expect(onCurve).toBeLessThanOrEqual(MAX_COPPER_PER_LEVEL);
+    // Ten times the shipped fill clears the top of the band...
+    expect(onCurve * 10).toBeGreaterThan(MAX_COPPER_PER_LEVEL);
+    // ...and a tenth of it falls under the bottom.
+    expect(onCurve / 10).toBeLessThan(MIN_COPPER_PER_LEVEL);
   });
 });
 
@@ -236,9 +273,13 @@ describe('the yield model matches the sim it is modelling', () => {
   it('counts guaranteed and chance coin, and ignores quest-only drops', () => {
     const wader = MOBS.glimmermere_wader;
     expect(coinEvPerKill(wader)).toBe(70);
-    // Quest entries never contribute to sustainable income.
-    const questOnly = MOBS.gilded_stag;
-    expect(questOnly.loot.every((l) => !l.copper)).toBe(true);
+    // Quest entries never contribute to sustainable income. Asserted against a
+    // synthetic template rather than a content mob, whose loot may legitimately
+    // gain coin in a later pass and would silently retire the case.
+    const questOnly = {
+      ...MOBS.gilded_stag,
+      loot: [{ itemId: 'gilded_sap_clot', chance: 1, questId: 'q_af_amber_from_the_herd' }],
+    };
     expect(coinEvPerKill(questOnly)).toBe(0);
     expect(itemEvPerKill(questOnly)).toBe(0);
   });

--- a/tests/economy_yield.test.ts
+++ b/tests/economy_yield.test.ts
@@ -1,5 +1,7 @@
 // Guards the open-world farm ECONOMY: the per-cluster gold and XP ceilings, the
-// coin-per-level curve, and the harvest-tag standard for coinless families.
+// coin-per-level curve, and the harvest-tag standard for the beast, spider and
+// reptile families. NOTE: those families carry coin on this branch AND their
+// harvest tags; the tags are an additional profession yield, not a swap.
 // Model: tests/helpers/farm_yield.ts.
 import { describe, expect, it } from 'vitest';
 import { HARVEST_COMPONENT_ITEMS } from '../src/sim/content/professions';
@@ -200,7 +202,7 @@ describe('coin-family trash sits on the coin curve', () => {
   });
 });
 
-describe('harvest-family trash carries usable components instead of coin', () => {
+describe('harvest-family trash carries usable components as well as coin', () => {
   const governed = () =>
     campTemplates().filter(
       ({ template }) =>

--- a/tests/economy_yield.test.ts
+++ b/tests/economy_yield.test.ts
@@ -1,12 +1,12 @@
 // Guards the open-world farm ECONOMY: the per-cluster gold and XP ceilings, the
 // coin-per-level curve, and the harvest-tag standard for coinless families.
-// Model: src/sim/farm_yield.ts.
+// Model: tests/helpers/farm_yield.ts.
 import { describe, expect, it } from 'vitest';
 import { HARVEST_COMPONENT_ITEMS } from '../src/sim/content/professions';
 import { CAMPS, MOBS, zoneContaining } from '../src/sim/data';
-import { coinEvPerKill, itemEvPerKill, worldFarmClusters, xpPerKill } from '../src/sim/farm_yield';
 import type { MobTemplate } from '../src/sim/types';
 import { mobXpValue } from '../src/sim/types';
+import { coinEvPerKill, itemEvPerKill, worldFarmClusters, xpPerKill } from './helpers/farm_yield';
 
 // Budgets are pinned ~25% above the shipped maxima, so ordinary content tuning
 // has room while a structural regression (a respawn tier cut, a coin fill an

--- a/tests/escort_ambush_leak.test.ts
+++ b/tests/escort_ambush_leak.test.ts
@@ -1,0 +1,145 @@
+// Repro + guard for the escort ambush leak: a run's ambush mobs are run-scoped,
+// but a KILLED one used to survive the run as a permanent world spawn.
+//
+// endRun drops surviving ambush mobs with an `!mob.dead` guard, so a corpse was
+// skipped. Its respawnTimer then elapsed and updateMob respawned it in place,
+// with no run left to own it. Every run therefore left behind however many of
+// its wave the player actually killed, and those accumulated at the ambush point
+// run after run. Escorts only exist in the July-2026 zones, which is exactly
+// where players reported piles of stacked mobs and why the older zones were fine.
+import { describe, expect, it } from 'vitest';
+import { ESCORTS } from '../src/sim/data';
+import { Sim } from '../src/sim/sim';
+import type { Entity } from '../src/sim/types';
+
+const ESCORT_ID = 'esc_fv_wren';
+const QUEST_ID = 'q_fv_seeing_wren_home';
+const ESCORTEE_TEMPLATE = 'apprentice_wren';
+
+function makeSim(): Sim {
+  // respawnSeconds pins the whole world to a 2s base, so "did a killed
+  // ambusher come back?" resolves in a couple of seconds of sim time instead of
+  // waiting out Frostveil's 180s tier. Without the fix the leak still shows.
+  const sim = new Sim({
+    seed: 424242,
+    playerClass: 'warrior',
+    playerName: 'Escorter',
+    respawnSeconds: 2,
+  });
+  sim.player.level = 20;
+  sim.questLog.set(QUEST_ID, { questId: QUEST_ID, counts: [0], state: 'active' });
+  return sim;
+}
+
+function findEscortee(sim: Sim): Entity | undefined {
+  return [...sim.entities.values()].find(
+    (e) => e.kind === 'mob' && e.templateId === ESCORTEE_TEMPLATE && !e.dead,
+  );
+}
+
+function ambushIds(sim: Sim): number[] {
+  return [...(sim.escortRuns.get(ESCORT_ID)?.run?.ambushIds ?? [])];
+}
+
+/** Live (not dead, still in the world) mobs of a template, anywhere. */
+function liveOf(sim: Sim, templateId: string): Entity[] {
+  return [...sim.entities.values()].filter(
+    (e) => e.kind === 'mob' && e.templateId === templateId && !e.dead,
+  );
+}
+
+/** Start a run and walk it until its first ambush wave has spawned. */
+function runToFirstAmbush(sim: Sim): number[] {
+  const def = ESCORTS[ESCORT_ID];
+  const escortee = findEscortee(sim);
+  if (!escortee) throw new Error('no idle escortee');
+  const pos = sim.groundPos(escortee.pos.x, escortee.pos.z + 2);
+  sim.player.pos = { ...pos };
+  sim.player.prevPos = { ...pos };
+  sim.interact();
+  if (!sim.escortRuns.get(ESCORT_ID)?.run) throw new Error('run did not start');
+  let ids: number[] = [];
+  for (let i = 0; i < 60 * 20 && ids.length === 0; i++) {
+    sim.tick();
+    ids = ambushIds(sim);
+  }
+  if (ids.length === 0) throw new Error('ambush never fired');
+  expect(ids.length).toBe(def.ambushes[0].count);
+  return ids;
+}
+
+describe('escort ambush mobs never outlive their run', () => {
+  it('does not leave a KILLED ambush mob behind to respawn forever', () => {
+    const sim = makeSim();
+    const ambushTemplate = ESCORTS[ESCORT_ID].ambushes[0].mobId;
+    const baseline = liveOf(sim, ambushTemplate).length;
+
+    const ids = runToFirstAmbush(sim);
+    // Kill the whole wave, the way a player escorting the run would.
+    for (const id of ids) {
+      const mob = sim.entities.get(id);
+      if (mob) sim.dealDamage(null, mob, mob.hp, false, 'physical', null, 'hit');
+    }
+    for (const id of ids) expect(sim.entities.get(id)?.dead).toBe(true);
+
+    // Let the run finish and the corpses decay well past any respawn window.
+    for (let i = 0; i < 30 * 20; i++) sim.tick();
+
+    // The zone's own camps of this template are untouched; the run's wave must
+    // not have added to them.
+    expect(liveOf(sim, ambushTemplate).length).toBe(baseline);
+    // ...and none of the run's specific entity ids is alive in the world.
+    for (const id of ids) {
+      const mob = sim.entities.get(id);
+      expect(mob === undefined || mob.dead, `ambush mob ${id} came back`).toBe(true);
+    }
+  });
+
+  it('still despawns a SURVIVING ambush mob when the run ends, as before', () => {
+    const sim = makeSim();
+    const ambushTemplate = ESCORTS[ESCORT_ID].ambushes[0].mobId;
+    const baseline = liveOf(sim, ambushTemplate).length;
+
+    const ids = runToFirstAmbush(sim);
+    // Kill the ESCORTEE instead, failing the run with the wave still alive.
+    const escortee = findEscortee(sim);
+    if (escortee) sim.dealDamage(null, escortee, escortee.hp, false, 'physical', null, 'hit');
+    for (let i = 0; i < 30 * 20; i++) sim.tick();
+
+    expect(liveOf(sim, ambushTemplate).length).toBe(baseline);
+    // Fully GONE from the roster, not merely dead. A run-scoped mob no longer
+    // respawns, so a corpse left behind would sit in the world forever: endRun
+    // has to drop the wave in either state.
+    for (const id of ids) {
+      expect(sim.entities.get(id), `ambush mob ${id} lingered`).toBeUndefined();
+    }
+  });
+
+  it('does not accumulate across repeated runs, which is the reported symptom', () => {
+    const sim = makeSim();
+    const ambushTemplate = ESCORTS[ESCORT_ID].ambushes[0].mobId;
+    const baseline = liveOf(sim, ambushTemplate).length;
+
+    for (let round = 0; round < 3; round++) {
+      const ids = runToFirstAmbush(sim);
+      for (const id of ids) {
+        const mob = sim.entities.get(id);
+        if (mob) sim.dealDamage(null, mob, mob.hp, false, 'physical', null, 'hit');
+      }
+      // Fail the run so the escortee respawns and the next round can start.
+      const escortee = findEscortee(sim);
+      if (escortee) sim.dealDamage(null, escortee, escortee.hp, false, 'physical', null, 'hit');
+      for (let i = 0; i < 50 * 20; i++) sim.tick();
+      sim.questLog.set(QUEST_ID, { questId: QUEST_ID, counts: [0], state: 'active' });
+    }
+
+    // Three runs, three killed waves: without the fix this is baseline + 9.
+    expect(liveOf(sim, ambushTemplate).length).toBe(baseline);
+    // And no corpse residue either: the roster holds no more mobs of this
+    // template than the zone's own camps authored.
+    const anyState = [...sim.entities.values()].filter(
+      (e) => e.kind === 'mob' && e.templateId === ambushTemplate,
+    );
+    expect(anyState.length).toBe(baseline);
+  });
+});

--- a/tests/escort_ambush_leak.test.ts
+++ b/tests/escort_ambush_leak.test.ts
@@ -141,5 +141,5 @@ describe('escort ambush mobs never outlive their run', () => {
       (e) => e.kind === 'mob' && e.templateId === ambushTemplate,
     );
     expect(anyState.length).toBe(baseline);
-  });
+  }, 120_000);
 });

--- a/tests/escort_ambush_leak.test.ts
+++ b/tests/escort_ambush_leak.test.ts
@@ -135,6 +135,11 @@ describe('escort ambush mobs never outlive their run', () => {
 
     // Three runs, three killed waves: without the fix this is baseline + 9.
     expect(liveOf(sim, ambushTemplate).length).toBe(baseline);
+    // Drain past the corpse window first: a slain wave mob is DELIBERATELY left
+    // as a lootable corpse until it lapses (summonedAdd unravels it in
+    // mob/locomotion.ts), so asserting sooner would be asserting against the
+    // loot window rather than against a leak.
+    for (let i = 0; i < 90 * 20; i++) sim.tick();
     // And no corpse residue either: the roster holds no more mobs of this
     // template than the zone's own camps authored.
     const anyState = [...sim.entities.values()].filter(

--- a/tests/gathering.test.ts
+++ b/tests/gathering.test.ts
@@ -261,12 +261,15 @@ describe('isHarvestableCorpse', () => {
     // The complement is asserted too, so an always-false predicate could not
     // pass the row above by making the sweep vacuous.
     const included = Object.entries(MOBS).filter(([, m]) => isHarvestableCorpse(m.componentTags));
-    expect(included).toHaveLength(21);
-    // ...and the untagged templates are counted rather than assumed: 199 of them
+    // 36 since the farm-economy pass: beast, spider and reptile trash pays in
+    // harvestable components instead of coin, so 15 previously untagged
+    // templates gained mapped tags (tests/economy_yield.test.ts enforces it).
+    expect(included).toHaveLength(36);
+    // ...and the untagged templates are counted rather than assumed: 184 of them
     // ship, all excluded before this change and all excluded after it, which is
     // the path fen_troll now joins instead of getting one of its own.
     const untagged = Object.values(MOBS).filter((m) => !m.componentTags?.length);
-    expect(untagged).toHaveLength(199);
+    expect(untagged).toHaveLength(184);
     for (const m of untagged) expect(isHarvestableCorpse(m.componentTags)).toBe(false);
     // The three literals above are the load-bearing ones; this sum states that
     // they partition MOBS, so a template that fell out of all three would read

--- a/tests/gathering.test.ts
+++ b/tests/gathering.test.ts
@@ -261,9 +261,10 @@ describe('isHarvestableCorpse', () => {
     // The complement is asserted too, so an always-false predicate could not
     // pass the row above by making the sweep vacuous.
     const included = Object.entries(MOBS).filter(([, m]) => isHarvestableCorpse(m.componentTags));
-    // 36 since the farm-economy pass: beast, spider and reptile trash pays in
-    // harvestable components instead of coin, so 15 previously untagged
-    // templates gained mapped tags (tests/economy_yield.test.ts enforces it).
+    // 36 since the farm-economy pass gave 15 previously untagged beast, spider
+    // and reptile templates their mapped tags. They keep their coin: the tags
+    // are an ADDITIONAL, opt-in profession yield on top, not a replacement
+    // (tests/economy_yield.test.ts enforces the tags, not the exchange).
     expect(included).toHaveLength(36);
     // ...and the untagged templates are counted rather than assumed: 184 of them
     // ship, all excluded before this change and all excluded after it, which is

--- a/tests/helpers/farm_yield.ts
+++ b/tests/helpers/farm_yield.ts
@@ -1,11 +1,14 @@
 // Sustainable farm yield: what a stretch of open world can pay per hour if a
 // player kills everything in it as fast as it comes back.
 //
-// A pure leaf (no SimContext, no state): a Vitest imports it directly. Nothing
-// in the live sim calls it. It exists so the balance question "how much gold and
-// XP per hour does this patch of world support?" is answered by one shared model
-// that guard tests pin (tests/camp_density.test.ts, tests/economy_yield.test.ts),
-// instead of by hand arithmetic in a review comment.
+// A TEST HELPER, not sim code: nothing in the live sim calls it, so it lives
+// beside the suites that do rather than shipping unreferenced inside the
+// deterministic core. It reads the real content tables and the real respawn
+// policy, so it stays honest about the world it prices. It exists so the balance
+// question "how much gold and XP per hour does this patch of world support?" is
+// answered by one shared model that guard tests pin
+// (tests/camp_density.test.ts, tests/economy_yield.test.ts), instead of by hand
+// arithmetic in a review comment.
 //
 // The model is a CEILING, deliberately generous to the farmer: it assumes zero
 // travel and kill time, every mob dead the instant it respawns, every non-quest
@@ -22,10 +25,10 @@
 // which for most of them is zero. Read a beast camp's copperPerHour as "coin and
 // vendorable drops", not "everything a skinner can make from it".
 
-import { CAMPS, ITEMS, MOBS, zoneContaining } from './data';
-import { resolveRespawnSeconds } from './respawn_policy';
-import type { CampDef, MobTemplate } from './types';
-import { mobXpValue } from './types';
+import { CAMPS, ITEMS, MOBS, zoneContaining } from '../../src/sim/data';
+import { resolveRespawnSeconds } from '../../src/sim/respawn_policy';
+import type { CampDef, MobTemplate } from '../../src/sim/types';
+import { mobXpValue } from '../../src/sim/types';
 
 /**
  * Two camps join the same farm cluster when their centers are within this many
@@ -34,7 +37,16 @@ import { mobXpValue } from './types';
  */
 export const CLUSTER_LINK_DISTANCE = 60;
 
-/** Guaranteed-plus-chance coin per kill, in copper. */
+/**
+ * Guaranteed-plus-chance coin per kill, in copper, at the NOMINAL authored
+ * value. The live roll spreads it (loot/loot_roll.ts rolls
+ * `rng.int(ceil(c * 0.6), ceil(c * 1.4))`, inclusive), whose mean is exactly the
+ * nominal value whenever c is a multiple of 5, which every curve fill is. Off
+ * the fives the two ceils round the mean up a little, reaching about +17% on a
+ * 3-copper drop, so this arm is very slightly CONSERVATIVE there rather than
+ * generous. Called out because the rest of the model is deliberately generous to
+ * the farmer, and that asymmetry should be visible instead of assumed away.
+ */
 export function coinEvPerKill(template: MobTemplate): number {
   let copper = 0;
   for (const entry of template.loot) {

--- a/tests/mob_component_tags.test.ts
+++ b/tests/mob_component_tags.test.ts
@@ -52,7 +52,9 @@ describe('mob component-type tags', () => {
     expect(allUnmapped).toEqual(['fen_troll']);
     // The complement, so an always-false predicate could not pass the row above
     // by emptying the sweep.
-    expect(tagged.filter((mob) => isHarvestableCorpse(mob.componentTags))).toHaveLength(21);
+    // 36 since the farm-economy pass added mapped tags to 15 coinless trash
+    // templates; fen_troll is still the only all-unmapped one.
+    expect(tagged.filter((mob) => isHarvestableCorpse(mob.componentTags))).toHaveLength(36);
   });
 
   it('never lets a template out-pay the tag list it advertises (#2514)', () => {

--- a/tests/mob_component_tags.test.ts
+++ b/tests/mob_component_tags.test.ts
@@ -52,8 +52,9 @@ describe('mob component-type tags', () => {
     expect(allUnmapped).toEqual(['fen_troll']);
     // The complement, so an always-false predicate could not pass the row above
     // by emptying the sweep.
-    // 36 since the farm-economy pass added mapped tags to 15 coinless trash
-    // templates; fen_troll is still the only all-unmapped one.
+    // 36 since the farm-economy pass added mapped tags to 15 beast, spider and
+    // reptile templates. Their coin is untouched, so this is added harvest
+    // yield rather than a swap; fen_troll is still the only all-unmapped one.
     expect(tagged.filter((mob) => isHarvestableCorpse(mob.componentTags))).toHaveLength(36);
   });
 

--- a/tests/parity/golden/c3_aura_runner.json
+++ b/tests/parity/golden/c3_aura_runner.json
@@ -139,7 +139,7 @@
       "tick": 2,
       "time": 0.1,
       "nextId": 822,
-      "state": "cc15e1f2",
+      "state": "4b6d293a",
       "events": "81203a26",
       "rng": {
         "draws": 2,
@@ -311,7 +311,7 @@
             "z": 39.907407
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 24.95,
+          "respawnTimer": 59.95,
           "spawnPos": {
             "x": 40,
             "y": 1.5,
@@ -339,7 +339,7 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 822,
-      "state": "bdb40558",
+      "state": "9d181620",
       "events": "741638a5",
       "rng": {
         "draws": 2,
@@ -350,7 +350,7 @@
       "tick": 10,
       "time": 0.5,
       "nextId": 822,
-      "state": "ea96a267",
+      "state": "d73324a3",
       "events": "741638a5",
       "rng": {
         "draws": 2,
@@ -361,7 +361,7 @@
       "tick": 15,
       "time": 0.75,
       "nextId": 822,
-      "state": "308147ce",
+      "state": "b2450686",
       "events": "741638a5",
       "rng": {
         "draws": 2,
@@ -372,7 +372,7 @@
       "tick": 20,
       "time": 1,
       "nextId": 822,
-      "state": "eac1a4f0",
+      "state": "0eef7dc8",
       "events": "7bcb507a",
       "rng": {
         "draws": 2,
@@ -383,7 +383,7 @@
       "tick": 25,
       "time": 1.25,
       "nextId": 822,
-      "state": "fa04a52a",
+      "state": "9d7f0e04",
       "events": "741638a5",
       "rng": {
         "draws": 2,
@@ -394,7 +394,7 @@
       "tick": 30,
       "time": 1.5,
       "nextId": 822,
-      "state": "4fd616f9",
+      "state": "8c21188f",
       "events": "741638a5",
       "rng": {
         "draws": 2,
@@ -405,7 +405,7 @@
       "tick": 35,
       "time": 1.75,
       "nextId": 822,
-      "state": "fc6f1030",
+      "state": "a5677b36",
       "events": "22a32e6e",
       "rng": {
         "draws": 2,
@@ -416,7 +416,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 822,
-      "state": "108b7f63",
+      "state": "a17aba29",
       "events": "018d2f11",
       "rng": {
         "draws": 2,
@@ -427,7 +427,7 @@
       "tick": 45,
       "time": 2.25,
       "nextId": 822,
-      "state": "9e807abb",
+      "state": "35e2dc1f",
       "events": "741638a5",
       "rng": {
         "draws": 36,
@@ -438,7 +438,7 @@
       "tick": 50,
       "time": 2.5,
       "nextId": 822,
-      "state": "ab4ceba9",
+      "state": "cb416425",
       "events": "741638a5",
       "rng": {
         "draws": 78,
@@ -449,7 +449,7 @@
       "tick": 55,
       "time": 2.75,
       "nextId": 822,
-      "state": "7e230131",
+      "state": "0c301765",
       "events": "741638a5",
       "rng": {
         "draws": 114,
@@ -460,7 +460,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 822,
-      "state": "a6a8a823",
+      "state": "29d0ab33",
       "events": "741638a5",
       "rng": {
         "draws": 145,
@@ -471,7 +471,7 @@
       "tick": 62,
       "time": 3.1,
       "nextId": 822,
-      "state": "1363fda5",
+      "state": "07d9f59b",
       "events": "741638a5",
       "rng": {
         "draws": 160,
@@ -660,7 +660,7 @@
             "z": 39.907407
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 21.95,
+          "respawnTimer": 56.95,
           "spawnPos": {
             "x": 40,
             "y": 1.5,
@@ -688,7 +688,7 @@
       "tick": 65,
       "time": 3.25,
       "nextId": 824,
-      "state": "ca64de5b",
+      "state": "936bf0c1",
       "events": "7a8e7f10",
       "rng": {
         "draws": 192,
@@ -699,7 +699,7 @@
       "tick": 70,
       "time": 3.5,
       "nextId": 824,
-      "state": "2bb79944",
+      "state": "ed395f0e",
       "events": "741638a5",
       "rng": {
         "draws": 234,
@@ -710,7 +710,7 @@
       "tick": 75,
       "time": 3.75,
       "nextId": 824,
-      "state": "48b21d40",
+      "state": "4461224a",
       "events": "741638a5",
       "rng": {
         "draws": 275,
@@ -721,7 +721,7 @@
       "tick": 80,
       "time": 4,
       "nextId": 824,
-      "state": "9e00b3b9",
+      "state": "5489d96b",
       "events": "741638a5",
       "rng": {
         "draws": 298,
@@ -732,7 +732,7 @@
       "tick": 85,
       "time": 4.25,
       "nextId": 824,
-      "state": "4cb66b43",
+      "state": "c005c15f",
       "events": "741638a5",
       "rng": {
         "draws": 341,
@@ -743,7 +743,7 @@
       "tick": 90,
       "time": 4.5,
       "nextId": 824,
-      "state": "aff2de82",
+      "state": "479abef6",
       "events": "741638a5",
       "rng": {
         "draws": 386,
@@ -754,7 +754,7 @@
       "tick": 95,
       "time": 4.75,
       "nextId": 824,
-      "state": "d3084ad4",
+      "state": "6eb0d330",
       "events": "741638a5",
       "rng": {
         "draws": 457,
@@ -765,7 +765,7 @@
       "tick": 100,
       "time": 5,
       "nextId": 824,
-      "state": "f4fbcab4",
+      "state": "5691a9b4",
       "events": "741638a5",
       "rng": {
         "draws": 496,
@@ -776,7 +776,7 @@
       "tick": 105,
       "time": 5.25,
       "nextId": 824,
-      "state": "870623b8",
+      "state": "d51d909d",
       "events": "7cedfb78",
       "rng": {
         "draws": 539,
@@ -787,7 +787,7 @@
       "tick": 110,
       "time": 5.5,
       "nextId": 824,
-      "state": "ac8ec248",
+      "state": "1cc1ad97",
       "events": "741638a5",
       "rng": {
         "draws": 583,
@@ -798,7 +798,7 @@
       "tick": 115,
       "time": 5.75,
       "nextId": 824,
-      "state": "f5208a0f",
+      "state": "4519574a",
       "events": "741638a5",
       "rng": {
         "draws": 645,
@@ -809,7 +809,7 @@
       "tick": 120,
       "time": 6,
       "nextId": 824,
-      "state": "7626cf3b",
+      "state": "8d46c31c",
       "events": "741638a5",
       "rng": {
         "draws": 708,
@@ -820,7 +820,7 @@
       "tick": 125,
       "time": 6.25,
       "nextId": 824,
-      "state": "37d213b1",
+      "state": "e6ca89ca",
       "events": "741638a5",
       "rng": {
         "draws": 770,
@@ -831,7 +831,7 @@
       "tick": 130,
       "time": 6.5,
       "nextId": 824,
-      "state": "e1ca1e8b",
+      "state": "2d73502e",
       "events": "741638a5",
       "rng": {
         "draws": 821,
@@ -842,7 +842,7 @@
       "tick": 135,
       "time": 6.75,
       "nextId": 824,
-      "state": "f7199e1a",
+      "state": "62a09641",
       "events": "741638a5",
       "rng": {
         "draws": 882,
@@ -853,7 +853,7 @@
       "tick": 140,
       "time": 7,
       "nextId": 824,
-      "state": "9d544f9c",
+      "state": "24e0ea15",
       "events": "741638a5",
       "rng": {
         "draws": 932,
@@ -864,7 +864,7 @@
       "tick": 145,
       "time": 7.25,
       "nextId": 824,
-      "state": "18be06c9",
+      "state": "a9f54a96",
       "events": "6801e4e4",
       "rng": {
         "draws": 992,
@@ -875,7 +875,7 @@
       "tick": 150,
       "time": 7.5,
       "nextId": 824,
-      "state": "eb3255ed",
+      "state": "76826a14",
       "events": "741638a5",
       "rng": {
         "draws": 1049,
@@ -886,7 +886,7 @@
       "tick": 155,
       "time": 7.75,
       "nextId": 824,
-      "state": "dddaf520",
+      "state": "aa5fbee7",
       "events": "741638a5",
       "rng": {
         "draws": 1114,
@@ -897,7 +897,7 @@
       "tick": 160,
       "time": 8,
       "nextId": 824,
-      "state": "9ec37990",
+      "state": "60e0e7e5",
       "events": "741638a5",
       "rng": {
         "draws": 1154,
@@ -908,7 +908,7 @@
       "tick": 165,
       "time": 8.25,
       "nextId": 824,
-      "state": "095c95da",
+      "state": "cb4e487b",
       "events": "741638a5",
       "rng": {
         "draws": 1213,
@@ -919,7 +919,7 @@
       "tick": 170,
       "time": 8.5,
       "nextId": 824,
-      "state": "73a15630",
+      "state": "318dc25f",
       "events": "741638a5",
       "rng": {
         "draws": 1281,
@@ -930,7 +930,7 @@
       "tick": 175,
       "time": 8.75,
       "nextId": 824,
-      "state": "90d4d45f",
+      "state": "2e200a3a",
       "events": "741638a5",
       "rng": {
         "draws": 1354,
@@ -941,7 +941,7 @@
       "tick": 180,
       "time": 9,
       "nextId": 824,
-      "state": "39d4b789",
+      "state": "1dea01c2",
       "events": "741638a5",
       "rng": {
         "draws": 1423,
@@ -952,7 +952,7 @@
       "tick": 182,
       "time": 9.1,
       "nextId": 824,
-      "state": "5bebedad",
+      "state": "c53e77b6",
       "events": "b5c9e892",
       "rng": {
         "draws": 1448,
@@ -1139,7 +1139,7 @@
             "z": 39.907407
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 15.95,
+          "respawnTimer": 50.95,
           "spawnPos": {
             "x": 40,
             "y": 1.5,

--- a/tests/parity/golden/mob_lifecycle.json
+++ b/tests/parity/golden/mob_lifecycle.json
@@ -31,7 +31,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 825,
-      "state": "af1957b7",
+      "state": "1c4517a2",
       "events": "6b921fe0",
       "rng": {
         "draws": 5,
@@ -204,7 +204,7 @@
             "z": 1
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 25,
+          "respawnTimer": 60,
           "spawnPos": {
             "x": 5,
             "y": 1.5,
@@ -400,7 +400,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 826,
-      "state": "16e22725",
+      "state": "d69e6cf1",
       "events": "fa661e5a",
       "rng": {
         "draws": 8,
@@ -580,7 +580,7 @@
             "z": 1
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 25,
+          "respawnTimer": 60,
           "spawnPos": {
             "x": 5,
             "y": 1.5,
@@ -813,7 +813,7 @@
             "y": 1.5
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 25,
+          "respawnTimer": 60,
           "spawnPos": {
             "x": 4,
             "y": 1.5
@@ -835,7 +835,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 826,
-      "state": "aefd4384",
+      "state": "152ce579",
       "events": "2fee5454",
       "rng": {
         "draws": 9,
@@ -1017,7 +1017,7 @@
             "z": 1
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 25,
+          "respawnTimer": 60,
           "spawnPos": {
             "x": 5,
             "y": 1.5,
@@ -1250,7 +1250,7 @@
             "y": 1.5
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 23.45,
+          "respawnTimer": 58.45,
           "spawnPos": {
             "x": 4,
             "y": 1.5
@@ -1272,7 +1272,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 828,
-      "state": "ffed59ad",
+      "state": "a4f3ca28",
       "events": "e32d692e",
       "rng": {
         "draws": 15,
@@ -1454,7 +1454,7 @@
             "z": 1
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 25,
+          "respawnTimer": 60,
           "spawnPos": {
             "x": 5,
             "y": 1.5,
@@ -1687,7 +1687,7 @@
             "y": 1.5
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 23.45,
+          "respawnTimer": 58.45,
           "spawnPos": {
             "x": 4,
             "y": 1.5
@@ -1752,7 +1752,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 829,
-      "state": "04d4b503",
+      "state": "e3855a58",
       "events": "9002c0ff",
       "rng": {
         "draws": 20,
@@ -1938,7 +1938,7 @@
             "z": 1
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 25,
+          "respawnTimer": 60,
           "spawnPos": {
             "x": 5,
             "y": 1.5,
@@ -2171,7 +2171,7 @@
             "y": 1.5
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 23.45,
+          "respawnTimer": 58.45,
           "spawnPos": {
             "x": 4,
             "y": 1.5
@@ -2297,7 +2297,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 829,
-      "state": "04d4b503",
+      "state": "e3855a58",
       "events": "741638a5",
       "rng": {
         "draws": 20,
@@ -2483,7 +2483,7 @@
             "z": 1
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 25,
+          "respawnTimer": 60,
           "spawnPos": {
             "x": 5,
             "y": 1.5,
@@ -2716,7 +2716,7 @@
             "y": 1.5
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 23.45,
+          "respawnTimer": 58.45,
           "spawnPos": {
             "x": 4,
             "y": 1.5

--- a/tests/parity/golden/solo_warrior.json
+++ b/tests/parity/golden/solo_warrior.json
@@ -182,7 +182,7 @@
       "tick": 72,
       "time": 3.6,
       "nextId": 822,
-      "state": "58deb739",
+      "state": "11297b7e",
       "events": "f003cdd8",
       "rng": {
         "draws": 253,
@@ -384,7 +384,7 @@
             "z": -2
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 25,
+          "respawnTimer": 60,
           "spawnPos": {
             "x": 4,
             "y": 1.5,
@@ -409,7 +409,7 @@
       "tick": 76,
       "time": 3.8,
       "nextId": 822,
-      "state": "da1e353a",
+      "state": "9fafed92",
       "events": "470583df",
       "rng": {
         "draws": 300,
@@ -616,7 +616,7 @@
             "z": -2
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 24.8,
+          "respawnTimer": 59.8,
           "spawnPos": {
             "x": 4,
             "y": 1.5,

--- a/tests/parity/golden/targeting_markers.json
+++ b/tests/parity/golden/targeting_markers.json
@@ -4586,7 +4586,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 826,
-      "state": "aa9d96ca",
+      "state": "bc9ca097",
       "events": "39828af0",
       "rng": {
         "draws": 5,
@@ -5038,7 +5038,7 @@
             "z": 6
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 25,
+          "respawnTimer": 60,
           "spawnPos": {
             "x": -3,
             "z": 6
@@ -5108,7 +5108,7 @@
       "tick": 0,
       "time": 0,
       "nextId": 826,
-      "state": "aa9d96ca",
+      "state": "bc9ca097",
       "events": "741638a5",
       "rng": {
         "draws": 5,
@@ -5560,7 +5560,7 @@
             "z": 6
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 25,
+          "respawnTimer": 60,
           "spawnPos": {
             "x": -3,
             "z": 6

--- a/tests/parity/golden/warrior_row_capstones.json
+++ b/tests/parity/golden/warrior_row_capstones.json
@@ -912,7 +912,7 @@
       "tick": 24,
       "time": 1.2,
       "nextId": 825,
-      "state": "11a79dde",
+      "state": "90bd74f5",
       "events": "ea08471a",
       "rng": {
         "draws": 22,
@@ -1329,7 +1329,7 @@
             "z": 79.20594
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 25,
+          "respawnTimer": 60,
           "spawnPos": {
             "x": -23.583231,
             "y": -3.220409,
@@ -1406,7 +1406,7 @@
       "tick": 28,
       "time": 1.4,
       "nextId": 825,
-      "state": "65776436",
+      "state": "a3d495ce",
       "events": "7ce50fd0",
       "rng": {
         "draws": 25,
@@ -1417,7 +1417,7 @@
       "tick": 32,
       "time": 1.6,
       "nextId": 825,
-      "state": "9b51ca8a",
+      "state": "f5e5ccb6",
       "events": "741638a5",
       "rng": {
         "draws": 25,
@@ -1428,7 +1428,7 @@
       "tick": 36,
       "time": 1.8,
       "nextId": 825,
-      "state": "10f85064",
+      "state": "44d10708",
       "events": "741638a5",
       "rng": {
         "draws": 25,
@@ -1439,7 +1439,7 @@
       "tick": 40,
       "time": 2,
       "nextId": 825,
-      "state": "4c2790f5",
+      "state": "006c8439",
       "events": "741638a5",
       "rng": {
         "draws": 25,
@@ -1450,7 +1450,7 @@
       "tick": 44,
       "time": 2.2,
       "nextId": 825,
-      "state": "7744d29c",
+      "state": "fe19b004",
       "events": "7a3d2b3b",
       "rng": {
         "draws": 54,
@@ -1461,7 +1461,7 @@
       "tick": 48,
       "time": 2.4,
       "nextId": 825,
-      "state": "73e7121c",
+      "state": "5f762d5e",
       "events": "741638a5",
       "rng": {
         "draws": 90,
@@ -1472,7 +1472,7 @@
       "tick": 52,
       "time": 2.6,
       "nextId": 825,
-      "state": "8877d41b",
+      "state": "1e5a8ce1",
       "events": "741638a5",
       "rng": {
         "draws": 114,
@@ -1483,7 +1483,7 @@
       "tick": 56,
       "time": 2.8,
       "nextId": 825,
-      "state": "b023a2c6",
+      "state": "aa6a05d0",
       "events": "741638a5",
       "rng": {
         "draws": 138,
@@ -1494,7 +1494,7 @@
       "tick": 60,
       "time": 3,
       "nextId": 825,
-      "state": "5de8e308",
+      "state": "485c454e",
       "events": "741638a5",
       "rng": {
         "draws": 166,
@@ -1505,7 +1505,7 @@
       "tick": 64,
       "time": 3.2,
       "nextId": 825,
-      "state": "52f4c07e",
+      "state": "ba07c338",
       "events": "4f42fa10",
       "rng": {
         "draws": 216,
@@ -1516,7 +1516,7 @@
       "tick": 68,
       "time": 3.4,
       "nextId": 825,
-      "state": "78daa565",
+      "state": "4b0cc065",
       "events": "127fe816",
       "rng": {
         "draws": 251,
@@ -1527,7 +1527,7 @@
       "tick": 72,
       "time": 3.6,
       "nextId": 825,
-      "state": "842aefaa",
+      "state": "b1f8d4aa",
       "events": "741638a5",
       "rng": {
         "draws": 277,
@@ -1538,7 +1538,7 @@
       "tick": 76,
       "time": 3.8,
       "nextId": 825,
-      "state": "15ef27f9",
+      "state": "e82142f9",
       "events": "741638a5",
       "rng": {
         "draws": 306,
@@ -1549,7 +1549,7 @@
       "tick": 80,
       "time": 4,
       "nextId": 825,
-      "state": "5f281995",
+      "state": "638dfa19",
       "events": "741638a5",
       "rng": {
         "draws": 335,
@@ -1560,7 +1560,7 @@
       "tick": 84,
       "time": 4.2,
       "nextId": 825,
-      "state": "62d84974",
+      "state": "fbb03124",
       "events": "6fab1953",
       "rng": {
         "draws": 361,
@@ -1571,7 +1571,7 @@
       "tick": 88,
       "time": 4.4,
       "nextId": 825,
-      "state": "8ef7b1e0",
+      "state": "ae35fe56",
       "events": "741638a5",
       "rng": {
         "draws": 402,
@@ -1582,7 +1582,7 @@
       "tick": 92,
       "time": 4.6,
       "nextId": 825,
-      "state": "c0f2cb21",
+      "state": "2672716b",
       "events": "741638a5",
       "rng": {
         "draws": 456,
@@ -1593,7 +1593,7 @@
       "tick": 96,
       "time": 4.8,
       "nextId": 825,
-      "state": "2b0a8700",
+      "state": "ad7a8ed6",
       "events": "741638a5",
       "rng": {
         "draws": 502,
@@ -1604,7 +1604,7 @@
       "tick": 100,
       "time": 5,
       "nextId": 825,
-      "state": "fe3d9766",
+      "state": "846b0970",
       "events": "741638a5",
       "rng": {
         "draws": 551,
@@ -1615,7 +1615,7 @@
       "tick": 104,
       "time": 5.2,
       "nextId": 825,
-      "state": "60f23a16",
+      "state": "bade9c20",
       "events": "821d7d3a",
       "rng": {
         "draws": 580,
@@ -1626,7 +1626,7 @@
       "tick": 108,
       "time": 5.4,
       "nextId": 825,
-      "state": "1eab4952",
+      "state": "dcdad11e",
       "events": "17e65e6d",
       "rng": {
         "draws": 615,
@@ -1637,7 +1637,7 @@
       "tick": 112,
       "time": 5.6,
       "nextId": 825,
-      "state": "65436fd6",
+      "state": "931154d6",
       "events": "741638a5",
       "rng": {
         "draws": 650,
@@ -1648,7 +1648,7 @@
       "tick": 116,
       "time": 5.8,
       "nextId": 825,
-      "state": "9bbe1a8a",
+      "state": "ede02b5e",
       "events": "741638a5",
       "rng": {
         "draws": 703,
@@ -1659,7 +1659,7 @@
       "tick": 120,
       "time": 6,
       "nextId": 825,
-      "state": "2deed6a7",
+      "state": "c0b7f1b7",
       "events": "741638a5",
       "rng": {
         "draws": 742,
@@ -1670,7 +1670,7 @@
       "tick": 124,
       "time": 6.2,
       "nextId": 825,
-      "state": "fd5339d7",
+      "state": "64e31cd7",
       "events": "741638a5",
       "rng": {
         "draws": 784,
@@ -1681,7 +1681,7 @@
       "tick": 124,
       "time": 6.2,
       "nextId": 825,
-      "state": "fd5339d7",
+      "state": "64e31cd7",
       "events": "741638a5",
       "rng": {
         "draws": 784,
@@ -2100,7 +2100,7 @@
             "z": 79.20594
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 20,
+          "respawnTimer": 55,
           "spawnPos": {
             "x": -23.583231,
             "y": -3.220409,
@@ -2180,7 +2180,7 @@
       "tick": 128,
       "time": 6.4,
       "nextId": 825,
-      "state": "47a24e8d",
+      "state": "1d758770",
       "events": "741638a5",
       "rng": {
         "draws": 830,
@@ -2191,7 +2191,7 @@
       "tick": 128,
       "time": 6.4,
       "nextId": 825,
-      "state": "47a24e8d",
+      "state": "1d758770",
       "events": "741638a5",
       "rng": {
         "draws": 830,
@@ -2610,7 +2610,7 @@
             "z": 79.20594
           },
           "potionCooldownUntil": -1,
-          "respawnTimer": 19.8,
+          "respawnTimer": 54.8,
           "spawnPos": {
             "x": -23.583231,
             "y": -3.220409,

--- a/tests/respawn_policy.test.ts
+++ b/tests/respawn_policy.test.ts
@@ -1,6 +1,7 @@
 // Pins the open-world respawn policy (src/sim/respawn_policy.ts): the level-band
 // tiers, the precedence chain around them, and the death site that consumes it.
 import { describe, expect, it } from 'vitest';
+import { CORPSE_DURATION } from '../src/sim/combat/damage';
 import { instanceOrigin, MOBS, ZONES, zoneAt, zoneContaining } from '../src/sim/data';
 import {
   baseRespawnSecondsAt,
@@ -14,7 +15,7 @@ import {
   trashRespawnSecondsForZone,
 } from '../src/sim/respawn_policy';
 import { Sim } from '../src/sim/sim';
-import type { ZoneDef } from '../src/sim/types';
+import { DT, type ZoneDef } from '../src/sim/types';
 
 // A minimal ZoneDef the tier function can read; only levelRange and the optional
 // override matter to it, so the rest is inert filler.
@@ -281,6 +282,40 @@ describe('the death site consumes the policy', () => {
     if (!mob) throw new Error('no forest_wolf spawned');
     sim.dealDamage(null, mob, 99_999, false, 'physical', null, 'hit');
     expect(mob.respawnTimer).toBe(2);
+  });
+
+  it('is not pushed out by the corpse window, which the yield model assumes', () => {
+    // updateMob defers an in-place respawn while the corpse is still lootable,
+    // so the effective delay is max(tier, corpse window). Giving coinless trash
+    // harvest tags makes those corpses lootable where they were not, which would
+    // silently stretch the delay if the corpse window ever exceeded a tier.
+    // CORPSE_DURATION is 60 and the fastest tier is 60, so the tier still wins
+    // everywhere; farm_yield prices camps on the tier alone and stays correct.
+    expect(CORPSE_DURATION).toBeLessThanOrEqual(TRASH_RESPAWN_SECONDS_LOW);
+    expect(CORPSE_DURATION).toBeLessThanOrEqual(TRASH_RESPAWN_SECONDS_MID);
+    expect(CORPSE_DURATION).toBeLessThanOrEqual(TRASH_RESPAWN_SECONDS_HIGH);
+
+    // ...and end to end: a harvestable Eastbrook beast is back on the 60s tier,
+    // not 60 plus a corpse window.
+    const sim = new Sim({ seed: 20061, playerClass: 'warrior', noPlayer: true });
+    const wolf = [...sim.entities.values()].find(
+      (e) => e.kind === 'mob' && e.templateId === 'forest_wolf',
+    );
+    if (!wolf) throw new Error('no forest_wolf spawned');
+    expect(MOBS.forest_wolf.componentTags?.length).toBeGreaterThan(0);
+    sim.dealDamage(null, wolf, 99_999, false, 'physical', null, 'hit');
+    expect(wolf.dead).toBe(true);
+    expect(wolf.respawnTimer).toBe(TRASH_RESPAWN_SECONDS_LOW);
+    const deadline = Math.ceil(TRASH_RESPAWN_SECONDS_LOW / DT) + 4;
+    let revivedAt: number | null = null;
+    for (let i = 0; i < deadline && revivedAt === null; i++) {
+      sim.tick();
+      if (!wolf.dead) revivedAt = sim.time;
+    }
+    expect(revivedAt).not.toBeNull();
+    // Within one tick of the tier, so no corpse window was added on top.
+    expect(revivedAt as number).toBeGreaterThanOrEqual(TRASH_RESPAWN_SECONDS_LOW);
+    expect(revivedAt as number).toBeLessThan(TRASH_RESPAWN_SECONDS_LOW + 1);
   });
 
   it('still caps corpse decay at a fixed template respawn (the training dummy)', () => {

--- a/tests/respawn_policy.test.ts
+++ b/tests/respawn_policy.test.ts
@@ -2,7 +2,14 @@
 // tiers, the precedence chain around them, and the death site that consumes it.
 import { describe, expect, it } from 'vitest';
 import { CORPSE_DURATION } from '../src/sim/combat/damage';
-import { instanceOrigin, MOBS, ZONES, zoneAt, zoneContaining } from '../src/sim/data';
+import {
+  DUNGEON_X_THRESHOLD,
+  instanceOrigin,
+  MOBS,
+  ZONES,
+  zoneAt,
+  zoneContaining,
+} from '../src/sim/data';
 import {
   baseRespawnSecondsAt,
   DEFAULT_RESPAWN_SECONDS,
@@ -282,6 +289,31 @@ describe('the death site consumes the policy', () => {
     if (!mob) throw new Error('no forest_wolf spawned');
     sim.dealDamage(null, mob, 99_999, false, 'physical', null, 'hit');
     expect(mob.respawnTimer).toBe(2);
+  });
+
+  it('gives every live open-world spawn a real zone, never the off-map fallback', () => {
+    // The static camp-rect check in tests/camp_density.test.ts covers authored
+    // centres; this covers where mobs ACTUALLY stand, since campSpawnOffset plus
+    // findSafePos can displace a spawn off its centre. Any open-world mob that
+    // landed outside every rect would take DEFAULT_RESPAWN_SECONDS and become a
+    // 25s farm pocket, which is the regression this pins.
+    const sim = new Sim({ seed: 20061, playerClass: 'warrior', noPlayer: true });
+    const openWorld = [...sim.entities.values()].filter(
+      (e) => e.kind === 'mob' && e.spawnPos.x < DUNGEON_X_THRESHOLD,
+    );
+    expect(openWorld.length).toBeGreaterThan(500);
+    const orphans = openWorld
+      .filter((e) => zoneContaining(e.spawnPos.x, e.spawnPos.z) === null)
+      .map((e) => `${e.templateId} at (${e.spawnPos.x.toFixed(1)}, ${e.spawnPos.z.toFixed(1)})`);
+    expect(orphans).toEqual([]);
+    // ...and none of them resolved to the fallback by another route either.
+    for (const e of openWorld) {
+      const template = MOBS[e.templateId];
+      if (template?.respawnSeconds !== undefined || isSelfScheduled(template)) continue;
+      expect(resolveRespawnSeconds(template, e.spawnPos, undefined), e.templateId).not.toBe(
+        DEFAULT_RESPAWN_SECONDS,
+      );
+    }
   });
 
   it('is not pushed out by the corpse window, which the yield model assumes', () => {

--- a/tests/respawn_policy.test.ts
+++ b/tests/respawn_policy.test.ts
@@ -1,0 +1,301 @@
+// Pins the open-world respawn policy (src/sim/respawn_policy.ts): the level-band
+// tiers, the precedence chain around them, and the death site that consumes it.
+import { describe, expect, it } from 'vitest';
+import { instanceOrigin, MOBS, ZONES, zoneAt, zoneContaining } from '../src/sim/data';
+import {
+  baseRespawnSecondsAt,
+  DEFAULT_RESPAWN_SECONDS,
+  isSelfScheduled,
+  LEGACY_RESPAWN_SECONDS,
+  resolveRespawnSeconds,
+  TRASH_RESPAWN_SECONDS_HIGH,
+  TRASH_RESPAWN_SECONDS_LOW,
+  TRASH_RESPAWN_SECONDS_MID,
+  trashRespawnSecondsForZone,
+} from '../src/sim/respawn_policy';
+import { Sim } from '../src/sim/sim';
+import type { ZoneDef } from '../src/sim/types';
+
+// A minimal ZoneDef the tier function can read; only levelRange and the optional
+// override matter to it, so the rest is inert filler.
+function zoneWithBand(bandCap: number, trashRespawnSeconds?: number): ZoneDef {
+  return {
+    id: 'test_zone',
+    name: 'Test Zone',
+    zMin: 0,
+    zMax: 100,
+    levelRange: [1, bandCap],
+    biome: 'vale',
+    hub: { x: 0, z: 0, radius: 10, name: 'Test' },
+    graveyard: { x: 0, z: 0 },
+    lakes: [],
+    pois: [],
+    welcome: '',
+    ...(trashRespawnSeconds === undefined ? {} : { trashRespawnSeconds }),
+  };
+}
+
+describe('trashRespawnSecondsForZone: the level-band tiers', () => {
+  it('gives starter bands (cap <= 7) the fast tier', () => {
+    expect(TRASH_RESPAWN_SECONDS_LOW).toBe(60);
+    expect(trashRespawnSecondsForZone(zoneWithBand(7))).toBe(60);
+    expect(trashRespawnSecondsForZone(zoneWithBand(1))).toBe(60);
+  });
+
+  it('gives mid bands (cap 8 to 14) the middle tier', () => {
+    expect(TRASH_RESPAWN_SECONDS_MID).toBe(120);
+    expect(trashRespawnSecondsForZone(zoneWithBand(8))).toBe(120);
+    expect(trashRespawnSecondsForZone(zoneWithBand(14))).toBe(120);
+  });
+
+  it('gives endgame bands (cap >= 15) the slow tier', () => {
+    expect(TRASH_RESPAWN_SECONDS_HIGH).toBe(180);
+    expect(trashRespawnSecondsForZone(zoneWithBand(15))).toBe(180);
+    expect(trashRespawnSecondsForZone(zoneWithBand(20))).toBe(180);
+  });
+
+  it('crosses each tier boundary at exactly the documented cap', () => {
+    // Decisive on the boundary itself: 7|8 and 14|15 must differ.
+    expect(trashRespawnSecondsForZone(zoneWithBand(7))).not.toBe(
+      trashRespawnSecondsForZone(zoneWithBand(8)),
+    );
+    expect(trashRespawnSecondsForZone(zoneWithBand(14))).not.toBe(
+      trashRespawnSecondsForZone(zoneWithBand(15)),
+    );
+  });
+
+  it('lets one zone override its tier with trashRespawnSeconds', () => {
+    expect(trashRespawnSecondsForZone(zoneWithBand(20, 45))).toBe(45);
+    // ...including down past the fast tier, and including an explicit 0.
+    expect(trashRespawnSecondsForZone(zoneWithBand(7, 300))).toBe(300);
+    expect(trashRespawnSecondsForZone(zoneWithBand(20, 0))).toBe(0);
+  });
+
+  it('falls back to the flat default for a null zone', () => {
+    expect(DEFAULT_RESPAWN_SECONDS).toBe(25);
+    expect(trashRespawnSecondsForZone(null)).toBe(25);
+    expect(trashRespawnSecondsForZone(undefined)).toBe(25);
+  });
+
+  it('keeps the off-map fallback and the legacy schedule base as separate knobs', () => {
+    // They are both 25 today, but they answer different questions: retiming the
+    // off-map fallback must never silently retime every shipped rare.
+    expect(LEGACY_RESPAWN_SECONDS).toBe(25);
+    expect(DEFAULT_RESPAWN_SECONDS).toBe(25);
+  });
+});
+
+describe('the ZoneDef.trashRespawnSeconds override, end to end', () => {
+  const overridden = zoneWithBand(20, 45);
+
+  it('beats the level band through the full resolution, not just the tier fn', () => {
+    expect(trashRespawnSecondsForZone(overridden)).toBe(45);
+    // Same zone with no override would be the 180s endgame tier.
+    expect(trashRespawnSecondsForZone(zoneWithBand(20))).toBe(180);
+  });
+
+  it('still loses to an explicit SimConfig base, as types.ts documents', () => {
+    // baseRespawnSecondsAt returns before it ever consults a zone, so a host
+    // that pins the world wins over any per-zone knob.
+    expect(baseRespawnSecondsAt(-90, 700, 7)).toBe(7);
+  });
+});
+
+describe('zoneContaining: strict rect containment, no fallback', () => {
+  it('resolves an open-world position to its zone, like zoneAt does', () => {
+    // Eastbrook Vale's Wolf Run camp.
+    expect(zoneContaining(-27, 71)?.id).toBe('eastbrook_vale');
+    expect(zoneAt(-27, 71).id).toBe('eastbrook_vale');
+    // A column zone beside the strip.
+    expect(zoneContaining(292, 312)?.id).toBe('galecrest');
+  });
+
+  it('returns null inside a dungeon instance, where zoneAt would still name a zone', () => {
+    const origin = instanceOrigin(0, 0);
+    expect(zoneContaining(origin.x, origin.z)).toBeNull();
+    // The contrast that makes this function necessary: zoneAt's southmost-band
+    // fallback happily reports a real zone for the same far-east coordinate.
+    expect(zoneAt(origin.x, origin.z)).not.toBeNull();
+  });
+
+  it('returns null past the north edge and outside the world columns', () => {
+    const northmost = ZONES.reduce((a, b) => (b.zMax > a.zMax ? b : a));
+    expect(zoneContaining(0, northmost.zMax + 10)).toBeNull();
+    expect(zoneContaining(9999, 0)).toBeNull();
+  });
+
+  it('is half-open on the z seam: zMax belongs to the next band up', () => {
+    // Eastbrook Vale [-180, 180) hands z=180 to Mirefen Marsh.
+    expect(zoneContaining(0, 179.9)?.id).toBe('eastbrook_vale');
+    expect(zoneContaining(0, 180)?.id).toBe('mirefen_marsh');
+  });
+
+  it('is half-open on the x seam too, where the strip meets a column', () => {
+    // The strip runs to x=180 exclusive; Galecrest's column starts there.
+    expect(zoneContaining(179.9, 300)?.id).toBe('mirefen_marsh');
+    expect(zoneContaining(180, 300)?.id).toBe('galecrest');
+  });
+});
+
+describe('baseRespawnSecondsAt: the global override vs the zone tier', () => {
+  it('reads the zone tier at a position when no global base is configured', () => {
+    // Eastbrook Vale [1-7] -> fast, Mirefen Marsh [6-13] -> mid,
+    // Thornpeak Heights [13-20] -> slow.
+    expect(baseRespawnSecondsAt(-27, 71, undefined)).toBe(60);
+    expect(baseRespawnSecondsAt(-40, 230, undefined)).toBe(120);
+    expect(baseRespawnSecondsAt(-90, 700, undefined)).toBe(180);
+  });
+
+  it('lets an explicitly configured base win over every zone tier', () => {
+    expect(baseRespawnSecondsAt(-27, 71, 2)).toBe(2);
+    expect(baseRespawnSecondsAt(-90, 700, 2)).toBe(2);
+    // 0 is explicit, not absent.
+    expect(baseRespawnSecondsAt(-90, 700, 0)).toBe(0);
+  });
+
+  it('falls back to the flat default off the authored map', () => {
+    const origin = instanceOrigin(0, 0);
+    expect(baseRespawnSecondsAt(origin.x, origin.z, undefined)).toBe(25);
+  });
+});
+
+describe('resolveRespawnSeconds: full precedence', () => {
+  const thornpeak = { x: -90, z: 700 }; // level band [13, 20] -> 180s
+  const vale = { x: -27, z: 71 }; // level band [1, 7] -> 60s
+
+  it('lets a template respawnSeconds win over everything', () => {
+    expect(resolveRespawnSeconds({ respawnSeconds: 10 }, thornpeak, undefined)).toBe(10);
+    expect(resolveRespawnSeconds({ respawnSeconds: 10 }, thornpeak, 2)).toBe(10);
+    // ...and it is NOT multiplied by the rare 4x.
+    expect(resolveRespawnSeconds({ respawnSeconds: 10, rare: true }, thornpeak, undefined)).toBe(
+      10,
+    );
+  });
+
+  it('applies the zone tier to plain trash', () => {
+    expect(resolveRespawnSeconds({}, thornpeak, undefined)).toBe(180);
+    expect(resolveRespawnSeconds({}, vale, undefined)).toBe(60);
+    expect(resolveRespawnSeconds(undefined, vale, undefined)).toBe(60);
+  });
+
+  it('keeps a bare rare on the historical base, so its 100s cadence holds', () => {
+    // `rare: true` with no authored multiplier is a SCHEDULE too: 4 x 25 is the
+    // 100s every bare rare shipped with, and it must not drift with the band.
+    expect(resolveRespawnSeconds({ rare: true }, thornpeak, undefined)).toBe(100);
+    expect(resolveRespawnSeconds({ rare: true }, vale, undefined)).toBe(100);
+    // The explicit global base still multiplies the same way it always did.
+    expect(resolveRespawnSeconds({ rare: true }, thornpeak, 2)).toBe(8);
+  });
+
+  it('keeps an authored respawnMult on the historical base, so its wall clock holds', () => {
+    // 7.2 * 25 = the three minutes a quest rare shipped with, in EVERY band.
+    expect(resolveRespawnSeconds({ respawnMult: 7.2 }, vale, undefined)).toBe(180);
+    expect(resolveRespawnSeconds({ respawnMult: 7.2 }, thornpeak, undefined)).toBe(180);
+    // 864 * 25 = six hours, not the forty-plus the tier base would have produced.
+    expect(resolveRespawnSeconds({ respawnMult: 864 }, thornpeak, undefined)).toBe(21_600);
+    // An authored multiplier also beats the rare default, as it always did.
+    expect(resolveRespawnSeconds({ respawnMult: 2, rare: true }, thornpeak, undefined)).toBe(50);
+    // ...and an explicit global base still overrides what it multiplies.
+    expect(resolveRespawnSeconds({ respawnMult: 7.2 }, thornpeak, 2)).toBe(14.4);
+  });
+
+  it('classifies self-scheduled templates by multiplier OR rare status', () => {
+    expect(isSelfScheduled({ respawnMult: 4 })).toBe(true);
+    expect(isSelfScheduled({ rare: true })).toBe(true);
+    expect(isSelfScheduled({ respawnMult: 4, rare: true })).toBe(true);
+    expect(isSelfScheduled({})).toBe(false);
+    // Elite and boss status alone do NOT self-schedule: an open-world boss that
+    // never declared a cadence rides the zone tier like the trash around it.
+    expect(isSelfScheduled({ rare: false })).toBe(false);
+    expect(isSelfScheduled(undefined)).toBe(false);
+  });
+
+  it('leaves EVERY shipped self-scheduled template on its exact pre-change schedule', () => {
+    // A true quantification over the real catalog, not a hand-picked list: every
+    // rare and every authored-multiplier template, priced from three different
+    // bands, must equal what the flat-25s era produced.
+    const selfScheduled = Object.values(MOBS).filter(
+      (t) => t.respawnSeconds === undefined && isSelfScheduled(t),
+    );
+    // 25 ship today; the floor sits at the real count so thinning the
+    // population (and quietly shrinking this sweep) fails here.
+    expect(selfScheduled.length).toBeGreaterThanOrEqual(25);
+    const drift: string[] = [];
+    for (const t of selfScheduled) {
+      const before = LEGACY_RESPAWN_SECONDS * (t.respawnMult ?? (t.rare ? 4 : 1));
+      for (const pos of [vale, thornpeak, { x: 0, z: 1500 }]) {
+        const now = resolveRespawnSeconds(t, pos, undefined);
+        if (now !== before) drift.push(`${t.id} at (${pos.x},${pos.z}): ${before} -> ${now}`);
+      }
+    }
+    expect(drift).toEqual([]);
+  });
+
+  it('names exactly the templates whose respawn DID move, so the change is visible', () => {
+    // The complement of the pin above. Only unscheduled open-world bosses and
+    // plain trash may appear here; a rare showing up is the regression.
+    const moved = Object.values(MOBS)
+      .filter((t) => t.respawnSeconds === undefined && isSelfScheduled(t))
+      .filter(
+        (t) =>
+          resolveRespawnSeconds(t, thornpeak, undefined) !==
+          LEGACY_RESPAWN_SECONDS * (t.respawnMult ?? (t.rare ? 4 : 1)),
+      )
+      .map((t) => t.id);
+    expect(moved).toEqual([]);
+    // ...while plain trash and unscheduled bosses DO move, so the tier is live.
+    expect(resolveRespawnSeconds(MOBS.warlord_drogmar, thornpeak, undefined)).toBe(180);
+    expect(MOBS.warlord_drogmar.boss).toBe(true);
+    expect(MOBS.warlord_drogmar.respawnMult).toBeUndefined();
+  });
+
+  it('uses the SPAWN position, not the death position', () => {
+    // Same template, two different homes: the band decides.
+    expect(resolveRespawnSeconds({}, vale, undefined)).not.toBe(
+      resolveRespawnSeconds({}, thornpeak, undefined),
+    );
+  });
+});
+
+describe('the death site consumes the policy', () => {
+  it('puts a slain open-world mob down for its zone tier, not the old flat 25s', () => {
+    const sim = new Sim({ seed: 20061, playerClass: 'warrior' });
+    expect(sim.cfg.respawnSeconds).toBeUndefined();
+    const mob = [...sim.entities.values()].find(
+      (e) => e.kind === 'mob' && e.templateId === 'forest_wolf',
+    );
+    if (!mob) throw new Error('no forest_wolf spawned');
+    const home = zoneContaining(mob.spawnPos.x, mob.spawnPos.z);
+    expect(home?.id).toBe('eastbrook_vale');
+    sim.dealDamage(null, mob, 99_999, false, 'physical', null, 'hit');
+    expect(mob.dead).toBe(true);
+    expect(mob.respawnTimer).toBe(TRASH_RESPAWN_SECONDS_LOW);
+    expect(mob.respawnTimer).not.toBe(DEFAULT_RESPAWN_SECONDS);
+  });
+
+  it('honors an explicit global base, which is what the fast suites rely on', () => {
+    const sim = new Sim({ seed: 20061, playerClass: 'warrior', respawnSeconds: 2 });
+    const mob = [...sim.entities.values()].find(
+      (e) => e.kind === 'mob' && e.templateId === 'forest_wolf',
+    );
+    if (!mob) throw new Error('no forest_wolf spawned');
+    sim.dealDamage(null, mob, 99_999, false, 'physical', null, 'hit');
+    expect(mob.respawnTimer).toBe(2);
+  });
+
+  it('still caps corpse decay at a fixed template respawn (the training dummy)', () => {
+    const sim = new Sim({ seed: 20061, playerClass: 'warrior' });
+    const dummy = [...sim.entities.values()].find(
+      (e) => e.kind === 'mob' && e.templateId === 'training_dummy',
+    );
+    if (!dummy) throw new Error('no training_dummy spawned');
+    const fixed = MOBS.training_dummy?.respawnSeconds;
+    expect(fixed).toBe(10);
+    // The dummy's whole point is a huge HP pool; overkill it outright.
+    sim.dealDamage(null, dummy, dummy.hp, false, 'physical', null, 'hit');
+    expect(dummy.dead).toBe(true);
+    // Its fixed schedule beats Thornpeak's 180s tier, and still caps corpse decay.
+    expect(dummy.respawnTimer).toBe(fixed);
+    expect(dummy.corpseTimer).toBeLessThanOrEqual(fixed as number);
+  });
+});

--- a/tests/world_population_invariant.test.ts
+++ b/tests/world_population_invariant.test.ts
@@ -10,7 +10,7 @@
 // Deliberately driven through the real Sim and the real content tables: the
 // point is to exercise every shipped escort, not a fixture.
 import { describe, expect, it } from 'vitest';
-import { CAMPS, ESCORTS, MOBS } from '../src/sim/data';
+import { CAMPS, DUNGEON_X_THRESHOLD, ESCORTS, MOBS } from '../src/sim/data';
 import { Sim } from '../src/sim/sim';
 import type { Entity } from '../src/sim/types';
 
@@ -29,7 +29,7 @@ function liveCounts(sim: Sim): Map<string, number> {
   const out = new Map<string, number>();
   for (const e of sim.entities.values()) {
     if (e.kind !== 'mob' || e.dead) continue;
-    if (e.spawnPos.x > 90_000) continue; // instance plane
+    if (e.spawnPos.x > DUNGEON_X_THRESHOLD) continue; // instance plane
     out.set(e.templateId, (out.get(e.templateId) ?? 0) + 1);
   }
   return out;

--- a/tests/world_population_invariant.test.ts
+++ b/tests/world_population_invariant.test.ts
@@ -1,0 +1,152 @@
+// The world population invariant, as a CLASS detector rather than a list of
+// known offenders.
+//
+// Rule: the open world may never hold more live mobs of a template than its
+// authored CAMPS place, except for the wave of a run that is currently active.
+// Anything that spawns mobs and forgets to reclaim them violates this, whatever
+// the mechanism, so this catches the next leak as well as the one it was written
+// for (escort ambush waves, which each run left behind permanently).
+//
+// Deliberately driven through the real Sim and the real content tables: the
+// point is to exercise every shipped escort, not a fixture.
+import { describe, expect, it } from 'vitest';
+import { CAMPS, ESCORTS, MOBS } from '../src/sim/data';
+import { Sim } from '../src/sim/sim';
+import type { Entity } from '../src/sim/types';
+
+/** Authored standing population per template, from the camp tables. */
+function authoredCounts(): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const camp of CAMPS) {
+    if (!MOBS[camp.mobId]) continue;
+    out.set(camp.mobId, (out.get(camp.mobId) ?? 0) + camp.count);
+  }
+  return out;
+}
+
+/** Live open-world mobs per template (instanced content excluded). */
+function liveCounts(sim: Sim): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || e.dead) continue;
+    if (e.spawnPos.x > 90_000) continue; // instance plane
+    out.set(e.templateId, (out.get(e.templateId) ?? 0) + 1);
+  }
+  return out;
+}
+
+/** Templates a run is allowed to add to the world WHILE it is active. */
+function activeWaveAllowance(sim: Sim): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const def of Object.values(ESCORTS)) {
+    const state = sim.escortRuns.get(def.id);
+    if (!state?.run) continue;
+    for (const ambush of def.ambushes) {
+      out.set(ambush.mobId, (out.get(ambush.mobId) ?? 0) + ambush.count);
+    }
+    // The escortee itself is a live mob while the run walks.
+    out.set(def.npcMobId, (out.get(def.npcMobId) ?? 0) + 1);
+  }
+  return out;
+}
+
+/** Escortees stand idle in the world between runs; that is authored, not a leak. */
+function idleEscorteeAllowance(): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const def of Object.values(ESCORTS)) {
+    out.set(def.npcMobId, (out.get(def.npcMobId) ?? 0) + 1);
+  }
+  return out;
+}
+
+function assertPopulationSane(sim: Sim, label: string): void {
+  const authored = authoredCounts();
+  const wave = activeWaveAllowance(sim);
+  const idle = idleEscorteeAllowance();
+  const over: string[] = [];
+  for (const [templateId, live] of liveCounts(sim)) {
+    const budget =
+      (authored.get(templateId) ?? 0) + (wave.get(templateId) ?? 0) + (idle.get(templateId) ?? 0);
+    if (live > budget) over.push(`${templateId}: ${live} live vs ${budget} allowed`);
+  }
+  expect(over, label).toEqual([]);
+}
+
+function findByTemplate(sim: Sim, templateId: string): Entity | undefined {
+  return [...sim.entities.values()].find(
+    (e) => e.kind === 'mob' && e.templateId === templateId && !e.dead,
+  );
+}
+
+describe('open-world population never exceeds what the content authored', () => {
+  it('holds at world generation', () => {
+    const sim = new Sim({ seed: 20061, playerClass: 'warrior', noPlayer: true });
+    assertPopulationSane(sim, 'at boot');
+  });
+
+  it('holds after every shipped escort is run and its wave is killed, repeatedly', () => {
+    // One sim, every escort, several cycles each: the leak this guards compounds
+    // per run, so a survivor shows up as a growing template count.
+    const sim = new Sim({
+      seed: 424242,
+      playerClass: 'warrior',
+      playerName: 'Escorter',
+      respawnSeconds: 2, // resolve "did it come back?" in seconds of sim time
+    });
+    sim.player.level = 20;
+
+    let ranAtLeastOne = false;
+    for (const def of Object.values(ESCORTS)) {
+      for (let round = 0; round < 2; round++) {
+        sim.questLog.set(def.questId, { questId: def.questId, counts: [0], state: 'active' });
+        const escortee = findByTemplate(sim, def.npcMobId);
+        if (!escortee) continue; // not yet respawned; the next escort still runs
+        const pos = sim.groundPos(escortee.pos.x, escortee.pos.z + 2);
+        sim.player.pos = { ...pos };
+        sim.player.prevPos = { ...pos };
+        sim.interact();
+        if (!sim.escortRuns.get(def.id)?.run) continue;
+        ranAtLeastOne = true;
+
+        // Walk until the first wave spawns, then kill all of it.
+        let ids: number[] = [];
+        for (let i = 0; i < 60 * 20 && ids.length === 0; i++) {
+          sim.tick();
+          ids = [...(sim.escortRuns.get(def.id)?.run?.ambushIds ?? [])];
+        }
+        for (const id of ids) {
+          const mob = sim.entities.get(id);
+          if (mob) sim.dealDamage(null, mob, mob.hp, false, 'physical', null, 'hit');
+        }
+        // Fail the run so the escortee cycles and the next round can start.
+        const walker = findByTemplate(sim, def.npcMobId);
+        if (walker) sim.dealDamage(null, walker, walker.hp, false, 'physical', null, 'hit');
+        for (let i = 0; i < 50 * 20; i++) sim.tick();
+
+        assertPopulationSane(sim, `${def.id} round ${round + 1}`);
+      }
+    }
+    expect(ranAtLeastOne, 'no escort actually ran, so this proved nothing').toBe(true);
+  }, 120_000);
+
+  it('names the escort ambush templates it is protecting, so the sweep is visible', () => {
+    // Every shipped escort wave template, spelled out. If a new escort ships,
+    // this list moves and the author sees that the guard above now covers it.
+    const waveTemplates = [
+      ...new Set(Object.values(ESCORTS).flatMap((d) => d.ambushes.map((a) => a.mobId))),
+    ].sort();
+    expect(waveTemplates).toEqual([
+      'breach_wretch',
+      'canopy_weaver',
+      'fen_sprite',
+      'snowdrift_wolf',
+      'tide_scuttler',
+      'void_stalker',
+      'widowsilk_spinner',
+      'wood_wraith',
+    ]);
+    // ...and each is a real template placed by real camps, so the budget above
+    // is a meaningful number rather than zero.
+    for (const id of waveTemplates) expect(MOBS[id], id).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Backport of #2677 (merged into `release/v0.33.0`) onto `release/v0.32.2`.

Not a cherry-pick: the two branches diverge, and `v0.32.2` already carries the
coin-curve work that #2677 introduced. This is reduced to the parts that branch
does not have, reconciled against what it does.

**1. Every open-world mob still respawns in 25 seconds on this branch.** One flat
timer covers the whole world, so a farmed camp regenerates about three times a
minute. Trash now respawns on its zone's level band, resolved by a new pure leaf
(`src/sim/respawn_policy.ts`) that the death site calls with the mob's spawn
point:

| Zone level band | Respawn |
|---|---|
| capped at 7 (Eastbrook Vale, Farshore Isle) | 60s |
| capped at 8 to 14 (Mirefen Marsh) | 120s |
| above 14 (everything else) | 180s |

Templates carrying their own schedule keep the historical base, so every named
rare and miniboss is byte-identical: an authored `respawnMult` (each shipped
coefficient is a wall-clock target expressed as a multiple of 25) and a bare
`rare: true` (whose 4x is the 100s every rare shipped with). Only trash and the
four open-world bosses that never declared a cadence move. A host that passes
`SimConfig.respawnSeconds` (the RL env, the fast unit suites) still pins the
world to that base, and mobs outside every zone rect keep the 25s default.

**2. Escort ambush waves leak permanent mobs into the world.** `endRun` reclaims
a run's surviving wave members but guarded on `!mob.dead`, so a KILLED one was
skipped; `handleDeath` had already given it a respawn timer, and `updateMob` then
revived it in place with no run left to own it. Every run permanently added
however many of its wave the player actually killed, at the same ambush point.
Measured: baseline + 3 after one run, + 9 after three. Escorts exist only in
Frostveil, Wraithwood, Palmreach and Farshore, which is why players saw stacked
mobs in the new zones and the older ones were fine.

Fixed with `Entity.runScoped`: a mob spawned by a RUN rather than placed by a
camp never respawns in place, and `endRun` now drops the wave dead or alive.

**3. Coinless families had no income path at all.** The trash that deliberately
stays coinless (beast, spider, reptile) carried no `componentTags`, so their
corpses were never harvestable. Fifteen templates gain the mapped tags they
should always have had. Purely additive; no coin value is touched.

### What this PR deliberately does NOT do on this base

`release/v0.32.2` already pays coin across all ten new zones on a two-tier curve
(about 5 copper per level for trash, 10 to 22.5 for the elite capstones). An
earlier revision of this work, written against `release/v0.33.0` where that did
not exist, filled the same coin and trimmed `ogre_crusher`, `ancient_guardian`
and `treant_elder` as over-curve outliers. Both are dropped here: the fills are
redundant, and those three sit ON the elite band this branch established
(`ogre_crusher` is 12.1 c/level against an elite band of 10 to 22.5), so the
"outlier" reading was an artifact of the older base. The guards were retuned to
match, and now pin the two bands separately and assert they stay disjoint.

### Effect

The respawn tiers are what move the numbers; the coin curve is already in place
on this branch. Sustainable ceilings from `tests/helpers/farm_yield.ts` (zero
travel and kill time, every non-quest drop vendored, every mob at its template's
top level, so real throughput is well under these):

| Cluster | Mobs | Gold/hr before | after | XP/hr before | after |
|---|---|---|---|---|---|
| Thornpeak Glimmermere corridor | 63 | 189.2 | 27.5 | 1,290k | 183k |
| Veiled Hollow guardians | 30 | 42.3 | 11.8 | 684k | 115k |
| Eastbrook Vale chain | 33 | 18.9 | 10.0 | 291k | 125k |

Plus the escort leak, which was adding mobs to those totals without bound.

### Notes for the reviewer

- **The shared rng stream is untouched.** Zero draw-count or draw-digest lines
  differ from the base branch; five goldens move and only on `respawnTimer`.
- **Two named constants that are both 25.** `LEGACY_RESPAWN_SECONDS` (the base a
  self-scheduled template was tuned against) and `DEFAULT_RESPAWN_SECONDS` (the
  off-map fallback) are deliberately separate, so retiming the fallback later
  cannot silently retime every shipped rare.
- **`farm_yield.ts` is test-only** and lives under `src/sim/` as a pure leaf.
  Nothing in the live sim imports it; the header says so. Happy to move it beside
  its tests if you would rather it not ship.
- **Corpse-harvest income is outside the yield model** by choice, since it
  depends on the harvester's profession and tools rather than on the camp. The
  new `componentTags` therefore add material income the ceilings do not price.
- **Scope of the leak, stated honestly.** I could substantiate a leak only in the
  four escort zones. For the other six new zones I checked and came up empty: rift
  instances sit past the instance threshold and can never respawn, the appended
  quest camps contain no duplicate or stacked entries, world-boss adds are bounded
  at four and reclaimed at boss death, and authored density in the new zones
  (16 to 33 mobs) is well under the old zones (Thornpeak 130, Mirefen 101). If
  reports persist outside those four zones, the next step is a runtime population
  check on the server rather than more static analysis.
- **The coin fill and the leak fix must ship together.** Those wave mobs dropped
  zero copper before this PR and now drop about 100c, so landing the fill without
  the reclamation fix would turn an XP farm into a gold faucet in exactly the
  affected zones. That coupling is why an escort fix rides in an economy PR.
- **A separate escort bug is NOT fixed here.** An evaded wave clears the escortee
  threat seed and nothing re-seeds it, so the escortee freezes until the 600s
  timeout. Different root cause, different fix, and it is being handled in its own
  PR; it touches `fireAmbushes` a few lines from this change, so it should rebase
  on this one.
- **Three existing census pins moved**, all because 15 templates gained mapped
  harvest tags: `tests/gathering.test.ts` and `tests/mob_component_tags.test.ts`
  (harvestable population 21 to 36, untagged 199 to 184) and
  `tests/corpse_harvest_sim.test.ts` (claims spent 86 to 152, families extracted
  113 to 217). The all-unmapped counts are untouched, since every new tag is a
  mapped family.
- **Quest and deed pacing on endgame trash slows with the tier**, by up to 7.2x
  in the 180s bands. That is inherent to the fix rather than a side effect, but
  it is the piece most worth your judgement: a "kill 10 X" objective in a level
  20 zone now takes correspondingly longer to re-pull.
- **Newly harvestable corpses defer their in-place respawn** behind the corpse
  window, since `updateMob` holds a lootable corpse. Effective delay is
  `max(tier, CORPSE_DURATION)`; CORPSE_DURATION is 60 and the fastest tier is 60,
  so the tier wins in every band today. Pinned in `tests/respawn_policy.test.ts`
  rather than left as an argument.

## Related issues

Backports #2677.

## Type of change

- [x] Bug fix
- [x] Tests
- [ ] Feature: new functionality
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run gate` (green)
  - `npx vitest run tests/respawn_policy.test.ts tests/camp_density.test.ts tests/economy_yield.test.ts`
  - `UPDATE_PARITY=1 npx vitest run tests/parity` for the golden re-mint, in its
    own commit.
- Manual steps:
  - Live-sim census at seed 20061: **zero** open-world spawns fall outside a zone
    rect, so no mob silently takes the instanced 25s fallback.
  - Mutation-tested every new guard: cutting the 180s tier to 30s, knocking a
    coin fill off curve, stripping a harvest tag, and dropping the cluster link
    distance each turn the matching suite red. Reverting either half of the
    escort fix turns tests/escort_ambush_leak.test.ts red, and reverting both
    makes the population invariant report "fen_sprite: 6 live vs 3 allowed" on
    the first escort round, so it detects the bug rather than restating the fix.
  - Audited every createMob site for the same leak class: instanced content
    (delves, rift, dungeons, arena, yumi, vale cup, Nythraxis) can never respawn,
    the hunter tame path drops one and queues one, world-boss adds reuse their id
    and are reclaimed at boss death. Escort waves were the only multiplying one.
  - Verified against the real catalog that no rare and no `respawnMult` template
    changes cadence in any band, and that exactly four unscheduled bosses do.

## Screenshots / recordings

N/A. No UI, HUD, or renderer change.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- ~[ ] Tested on desktop and mobile.~ N/A, no UI change.
- ~[ ] Accessible.~ N/A, no UI change.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files. `npm run wiki:content` produced no diff,
      and the parity goldens were regenerated by their own tool.
