### PR TITLE
fix(server): keep saved hotbar layout when resume meta omits it

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -3116,8 +3116,14 @@ export class GameServer {
     // Re-validate the freshly-read layout (untrusted at rest), same as a fresh
     // join. Without this, a mid-session save that already landed durably would
     // be clobbered by the stale join-time snapshot once lastSent resets below
-    // forces a resend.
-    session.initialHotbarLayout = sanitizeActionBarLayout(meta.hotbarLayout);
+    // forces a resend. Only refresh when the caller actually supplies a layout:
+    // ws_auth.ts always does on the real reconnect path, but an in-process/test
+    // caller that omits it (meta = {}) must keep the session's saved value
+    // rather than being reset to null, matching the sibling bankBonus
+    // "absent means keep" pattern above.
+    if (meta.hotbarLayout !== undefined) {
+      session.initialHotbarLayout = sanitizeActionBarLayout(meta.hotbarLayout);
+    }
     session.lastInputSeq = 0;
     session.lastInputAt = this.sim.time;
     session.lastSent = {};

--- a/tests/action_bar_layout_persistence_game.test.ts
+++ b/tests/action_bar_layout_persistence_game.test.ts
@@ -208,6 +208,26 @@ describe('action-bar layout persistence (wire round trip)', () => {
     expect(resumedSnap.self.hbl).toEqual(LAYOUT_AFTER_MIDSESSION_EDIT);
   });
 
+  it('resume keeps the saved layout when the caller omits hotbarLayout in meta', () => {
+    // ws_auth.ts (the real reconnect path) always supplies hotbarLayout, but an
+    // in-process/test caller passing meta = {} must not have the session's
+    // layout reset to null: that would read to the client as "server has no
+    // copy, seed from this device" and clobber a real saved layout.
+    const server = new GameServer();
+    const firstFc = fakeWs();
+    const session = join(server, firstFc, 12, 'BareResumer', { hotbarLayout: LAYOUT });
+    broadcast(server);
+    expect(lastSnap(firstFc.sent).self.hbl).toEqual(LAYOUT);
+
+    session.linkdead = true;
+    const secondFc = fakeWs();
+    const resumed = join(server, secondFc, 12, 'BareResumer');
+    expect(resumed).toBe(session);
+    broadcast(server);
+    const resumedSnap = lastSnap(secondFc.sent);
+    expect(resumedSnap.self.hbl).toEqual(LAYOUT);
+  });
+
   it('drops a garbage / oversized payload server-side without crashing or persisting', async () => {
     const server = new GameServer();
     const fc = fakeWs();


### PR DESCRIPTION
## Summary
- Small follow-up to #2613 (already merged), addressing the non-blocking nit from EnriqueGF's approving review.
- `resumeSession()` unconditionally overwrote `session.initialHotbarLayout`, so a caller that omits `hotbarLayout` in `meta` (today only in-process/test callers, since `server/ws_auth.ts` always supplies it on the real reconnect path) would reset a real saved layout to `null`, which the client reads as "server has no copy, seed from this device".
- Guarded the refresh behind an explicit `meta.hotbarLayout !== undefined` check, matching the sibling `bankBonus` "absent means keep" pattern already used a few lines above. Behavior on the real reconnect path (`ws_auth.ts` always sets `hotbarLayout`) is unchanged.

## Test plan
- [x] `npx tsc --noEmit`: clean.
- [x] `npx vitest run tests/action_bar_layout_persistence_game.test.ts tests/action_bar_layout_client.test.ts tests/action_bar_layout_core.test.ts tests/action_bar_layout_sync.test.ts tests/character_lease_game.test.ts tests/snapshots.test.ts tests/linkdead.test.ts`: 238 passed, including a new regression case pinning the kept-layout behavior on a bare resume call.
- [ ] `npm run gate` not run (shared box under heavy load at the time); targeted tsc + vitest above cover the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)