### PR TITLE
fix(quests): backport the escort evade fix and align the elite coin tier with v0.32.2

### DIFF
--- a/tests/economy_yield.test.ts
+++ b/tests/economy_yield.test.ts
@@ -141,8 +141,11 @@ describe('coin-family trash sits on the coin curve', () => {
     );
 
   it('checks a real population, not an empty set', () => {
-    expect(governed().length).toBeGreaterThanOrEqual(35);
-    expect(governedElites().length).toBeGreaterThanOrEqual(8);
+    // Floors sit at the REAL shipped counts (39 trash, 13 elite), not under
+    // them: the point of this pin is that a template silently dropping out of
+    // governance fails here rather than shrinking the sweep unnoticed.
+    expect(governed().length).toBeGreaterThanOrEqual(39);
+    expect(governedElites().length).toBeGreaterThanOrEqual(13);
   });
 
   it('pays elite capstones on their own higher band, not the trash curve', () => {


### PR DESCRIPTION
Closes the two gaps between `release/v0.33.0` and `release/v0.32.2` so the lines hold identical content.

## 1. Escort evade soft-lock (backport of #2683)

A wave mob that evades comes home with its hate table cleared by the leash reset, so the escortee threat seed is gone and nothing re-seeds it. The escortee stands frozen among idle attackers until the 600s run timeout silently fails the run. The wave-wait branch now re-commits any live wave mob whose threat table is empty, mirroring the spawn seed.

Dropped one line from the cherry-pick: `mob.summonedAdd = true`. That is v0.32.2's mechanism for keeping a slain wave mob from respawning, and this branch already does that with `Entity.runScoped` (#2677). Carrying both would be two fields for one job, and `summonedAdd` does not exist here.

## 2. Elite coin tier alignment

The two lines shipped different coin for the same twelve mobs. v0.32.2 pays capstone elites a premium (200 to 450 copper, about 10 to 22.5 per level) over the roughly 5 per level trash curve. #2677 landed a flat 5 per level here, putting a zone's capstone on the same rate as the trash beside it, and trimmed `ogre_crusher`, `ancient_guardian` and `treant_elder` as over-curve when they were on that elite band all along.

This adopts the v0.32.2 shape wholesale. `the_meredark`, `ogre_crusher` and `pale_huntsman` now read identically on both branches, so the eventual merge has nothing to resolve. `tests/economy_yield.test.ts` gains a matching elite band (8 to 25 c/level) and asserts the two bands stay disjoint.

## Note on the remaining duplication

`release/v0.32.2` uses `Entity.summonedAdd` for the no-respawn rule and this branch uses `Entity.runScoped`. Each branch carries exactly one, so neither is broken, but a merge will surface both. `summonedAdd` is the better mechanism (already general to boss adds, and it drops the corpse after its full loot window), so the consolidation should land on it. Not done here because it is a required Entity field, which the parity trace samples, so adopting it means re-minting every golden. Called out so it is not discovered by accident.

## Testing

`npm run gate`, plus `tests/escort.test.ts`, `tests/escort_ambush_leak.test.ts`, `tests/world_population_invariant.test.ts` (21 passing together) and the economy and density guards (60 passing).