### PR TITLE
fix(sim): keep worn offhand instance payloads across save/load

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -63,15 +63,14 @@ import {
 } from '../src/sim/talent_allocation_input';
 import { stealthDetectionRadius, threatEntries } from '../src/sim/threat';
 import {
-  ALL_EQUIP_SLOTS,
   type Aura,
   DT,
   dist2d,
   type Entity,
-  type EquipSlot,
   emptyMoveInput,
   type ItemInstancePayload,
   isDungeonDifficulty,
+  isEquipSlot,
   MAX_LEVEL,
   type MobFamily,
   RUN_SPEED,
@@ -4385,10 +4384,7 @@ export class GameServer {
           // sim's own resolver rather than trusting the client. The sim then
           // re-validates the slot against the item itself.
           const aimed =
-            typeof msg.slot === 'string' &&
-            (ALL_EQUIP_SLOTS as readonly string[]).includes(msg.slot)
-              ? (msg.slot as EquipSlot)
-              : undefined;
+            typeof msg.slot === 'string' && isEquipSlot(msg.slot) ? msg.slot : undefined;
           if (aimed) sim.equipItemToSlot(msg.item, aimed, pid);
           else sim.equipItem(msg.item, pid);
         }
@@ -4401,13 +4397,8 @@ export class GameServer {
         }
         break;
       case 'unequip_item':
-        // ALL_EQUIP_SLOTS, not the frozen EQUIP_SLOTS: the latter omits the
-        // additive 'offhand' slot, so any offhand unequip was silently dropped here.
-        if (
-          typeof msg.slot === 'string' &&
-          (ALL_EQUIP_SLOTS as readonly string[]).includes(msg.slot)
-        ) {
-          sim.unequipItem(msg.slot as EquipSlot, pid);
+        if (typeof msg.slot === 'string' && isEquipSlot(msg.slot)) {
+          sim.unequipItem(msg.slot, pid);
         }
         break;
       case 'use':
@@ -4478,11 +4469,7 @@ export class GameServer {
           // to undefined, which is the bagged arm. The sim then re-validates that
           // the named slot is actually wearing this item id and, without the
           // confirm flag below, that the worn copy is not already enchanted.
-          const worn =
-            typeof msg.slot === 'string' &&
-            (ALL_EQUIP_SLOTS as readonly string[]).includes(msg.slot)
-              ? (msg.slot as EquipSlot)
-              : undefined;
+          const worn = typeof msg.slot === 'string' && isEquipSlot(msg.slot) ? msg.slot : undefined;
           // `confirm` (#2415): the explicit consent to replace an existing
           // enchant. A strict boolean-true check (the dispatch type-guard
           // rule, the craft_item `commission` precedent); anything else reads

--- a/src/sim/CLAUDE.md
+++ b/src/sim/CLAUDE.md
@@ -124,7 +124,10 @@ a row here or a Key files entry (`sim.ts`, `sim_context.ts`, `entity_roster.ts`)
 these before inlining pure logic in a system module: `spell_scaling.ts` (spell/attack
 power coefficients), `stun_dr.ts` (CC diminishing-return categories), `item_level.ts`/
 `item_budget.ts`/`item_level_req.ts` (drop power math), `equipment_rules.ts` (equip
-legality), `cooldown_persist.ts` (cooldown save/load), `unstuck_cooldown.ts` (the hidden
+legality), `launch_paperdoll_slots.ts` (the FROZEN launch-era eleven-slot list, for
+launch-era completeness records ONLY: never validate a slot against it, use
+`isEquipSlot` from `types.ts`, which is derived from the live `ALL_EQUIP_SLOTS`),
+`cooldown_persist.ts` (cooldown save/load), `unstuck_cooldown.ts` (the hidden
 recovery timer across competitive resets), `tab_target.ts`/`assist.ts`/
 `dead_target.ts` (target cycling, /assist, dead-target selectability), `flee_speed.ts`,
 `mob/scan_counters.ts` (the per-tick mob scan-visit tally the server reads post-tick),

--- a/src/sim/deeds.ts
+++ b/src/sim/deeds.ts
@@ -29,6 +29,7 @@ import { DEED_ORDER, DEEDS, DEEDS_ERA } from './content/deeds';
 import { GATHERING_PROFESSION_IDS } from './content/professions';
 import { pointsSpent } from './content/talents';
 import { ITEMS, MOBS, zoneAt } from './data';
+import { LAUNCH_PAPERDOLL_SLOTS } from './launch_paperdoll_slots';
 import { RESURRECTION_SICKNESS_ID } from './resurrection';
 import type { ArenaMatch, InstanceSlot, PlayerMeta } from './sim';
 import type { SimContext } from './sim_context';
@@ -736,24 +737,9 @@ const FLAGS: Record<DeedFlagId, (meta: PlayerMeta, e: Entity) => boolean> = {
   // Guild membership is server-stamped onto the entity; offline it stays ''
   // (never satisfiable there, matching the offline-sandbox model).
   guildMember: (_m, e) => e.guild !== '',
-  // Slot list PINNED as of v1 (the launch EQUIP_SLOTS); a future twelfth slot
-  // does not grow this deed.
-  allEquipSlotsFilled: (m) =>
-    (
-      [
-        'mainhand',
-        'helmet',
-        'neck',
-        'shoulder',
-        'chest',
-        'waist',
-        'legs',
-        'gloves',
-        'feet',
-        'ring1',
-        'ring2',
-      ] as const
-    ).every((slot) => !!m.equipment[slot]),
+  // Slot list PINNED as of v1 (LAUNCH_PAPERDOLL_SLOTS); a future twelfth slot
+  // does not grow this deed, so already-earned rows keep their meaning.
+  allEquipSlotsFilled: (m) => LAUNCH_PAPERDOLL_SLOTS.every((slot) => !!m.equipment[slot]),
   nonDefaultSkin: (m) => m.skinCatalog === 'mech' || m.skin > 0,
   // The marked set resets whenever the authoritative reward window advances,
   // so containment of all four ids already means one complete circuit.

--- a/src/sim/launch_paperdoll_slots.ts
+++ b/src/sim/launch_paperdoll_slots.ts
@@ -1,0 +1,37 @@
+// The eleven LAUNCH equip slots, frozen as a historical record. This is NOT the
+// equipment surface: it omits the additive 'offhand' slot, and any future slot
+// will be missing from it too, by design.
+//
+// It lives in its own module rather than beside ALL_EQUIP_SLOTS in types.ts on
+// purpose. As a second same-shaped export named EQUIP_SLOTS it read like the
+// obvious default and was picked up twice by code that wanted the live list:
+// once by the offhand unequip/drag validators (tests/offhand_equip_wire.ts) and
+// once by the equipmentInstance load path, which silently dropped every worn
+// offhand's enchant on login. Four call sites were carrying hand-written "use
+// ALL_EQUIP_SLOTS, not the frozen one" comments; the fifth was not, and that was
+// the bug. A frozen list you have to import by this name, from here, is one
+// nobody reaches for by accident.
+//
+// NEVER validate against this list. Untrusted slot strings go through
+// isEquipSlot (types.ts), which is derived from the live ALL_EQUIP_SLOTS.
+// The only legitimate readers are launch-era completeness records that must
+// keep meaning exactly what they meant at launch:
+//   - the full-paperdoll deed (deeds.ts allEquipSlotsFilled), whose earned
+//     rows would otherwise silently change meaning under existing players
+//   - the all-slot PvP set profiles (tests/pvp_honor_gear.test.ts)
+
+import type { EquipSlot } from './types';
+
+export const LAUNCH_PAPERDOLL_SLOTS: readonly EquipSlot[] = [
+  'mainhand',
+  'helmet',
+  'neck',
+  'shoulder',
+  'chest',
+  'waist',
+  'legs',
+  'gloves',
+  'feet',
+  'ring1',
+  'ring2',
+];

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -578,7 +578,6 @@ import {
   type DungeonDifficulty,
   dist2d,
   type Entity,
-  EQUIP_SLOTS,
   type EquipSlot,
   type ErrorReason,
   type EscortRunState,
@@ -590,6 +589,7 @@ import {
   type ItemInstancePayload,
   isConsuming,
   isDungeonDifficulty,
+  isEquipSlot,
   isPetClass,
   isQuestTurnInNpc,
   LEASH_DISTANCE,
@@ -2593,15 +2593,15 @@ export class Sim {
       for (const [slot, instance] of Object.entries(
         s.equipmentInstance ?? s.equipmentInstances ?? {},
       )) {
-        if (!(EQUIP_SLOTS as readonly string[]).includes(slot) || !instance) continue;
-        const itemId = meta.equipment[slot as EquipSlot];
+        if (!isEquipSlot(slot) || !instance) continue;
+        const itemId = meta.equipment[slot];
         if (!itemId) continue;
         // A rift payload is validated against the worn item (anti-tamper); any
         // other instance (an enchant) deep-clones through the shared rules.
         const clean = instance.rift
           ? sanitizeRiftGearInstance(itemId, instance, player.id)
           : cloneItemInstancePayload(instance);
-        if (clean) meta.equipmentInstance[slot as EquipSlot] = clean;
+        if (clean) meta.equipmentInstance[slot] = clean;
       }
       // The shared tamper ceiling (bags.ts instancedCountCap, same rule as the
       // bank arm below): a counted instanced slot loads capped at what

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -572,26 +572,14 @@ export type EquipSlot =
   | 'ring1'
   | 'ring2';
 
-// The eleven launch equip slots, frozen for the original full-paperdoll deed and
-// the all-slot PvP sets. Offhand is intentionally not added to this historical
-// list: ALL_EQUIP_SLOTS is the live stat/command surface.
-export const EQUIP_SLOTS: readonly EquipSlot[] = [
-  'mainhand',
-  'helmet',
-  'neck',
-  'shoulder',
-  'chest',
-  'waist',
-  'legs',
-  'gloves',
-  'feet',
-  'ring1',
-  'ring2',
-];
-
 // Every live equipment key, including the redesigned Warrior's additive
-// offhand. Stat derivation and command validators use this list; launch-era
-// completeness rewards continue to use the frozen EQUIP_SLOTS list above.
+// offhand. THE equipment surface: stat derivation, command validators, and
+// anything else that iterates or checks slots reads this list.
+//
+// The frozen eleven-slot launch list is deliberately NOT here beside it; it
+// lives in launch_paperdoll_slots.ts, which explains why. Sitting next to this
+// one under the near-identical name EQUIP_SLOTS, it got picked up twice by code
+// that meant this list.
 export const ALL_EQUIP_SLOTS: readonly EquipSlot[] = [
   'mainhand',
   'offhand',
@@ -606,6 +594,19 @@ export const ALL_EQUIP_SLOTS: readonly EquipSlot[] = [
   'ring1',
   'ring2',
 ];
+
+/** Narrow an untrusted slot string (a wire field, a DOM dataset value, a
+ *  persisted JSONB key) to an EquipSlot against the LIVE slot surface.
+ *
+ *  Use this instead of hand-rolling a membership check. Every hand-rolled one
+ *  needed an `as readonly string[]` cast to compile, and that cast erases
+ *  exactly the type information that would flag the wrong list: five sites
+ *  carried it, four with a comment warning which constant to use, and the
+ *  unguarded fifth dropped every worn offhand's enchant on login. The cast
+ *  belongs here, once, where the list it applies to is not a choice. */
+export function isEquipSlot(value: string): value is EquipSlot {
+  return (ALL_EQUIP_SLOTS as readonly string[]).includes(value);
+}
 
 // What an ITEM declares as its slot. Rings declare the slot KIND ('ring'); the
 // equip path resolves the concrete ring1/ring2 equipment key at equip time

--- a/src/ui/item_drop_hit_test.ts
+++ b/src/ui/item_drop_hit_test.ts
@@ -8,7 +8,7 @@
 // other surface (a window, the HUD chrome, the action bar) is inert, so releasing a
 // stack over the chat box never destroys it.
 
-import { ALL_EQUIP_SLOTS, type EquipSlot } from '../sim/types';
+import { type EquipSlot, isEquipSlot } from '../sim/types';
 
 /** The world surface: the one element the destroy drop accepts. */
 const WORLD_CANVAS_SELECTOR = '#game-canvas';
@@ -32,13 +32,10 @@ export function resolveDropTargetAt(
   if (!el) return { kind: 'none' };
   const socket = el.closest?.('[data-equip-slot]') as HTMLElement | null;
   const raw = socket?.dataset.equipSlot;
-  // Validate against the canonical slot list rather than trusting the attribute:
-  // a stale or hand-edited value must resolve to no target, never to a wrong slot.
-  // ALL_EQUIP_SLOTS (includes the additive 'offhand' slot), not the frozen
-  // EQUIP_SLOTS, else a finger-drag released over the offhand socket resolves to
-  // no target.
-  if (raw && (ALL_EQUIP_SLOTS as readonly string[]).includes(raw)) {
-    return { kind: 'equip', slot: raw as EquipSlot };
+  // Validate rather than trusting the attribute: a stale or hand-edited value
+  // must resolve to no target, never to a wrong slot.
+  if (raw && isEquipSlot(raw)) {
+    return { kind: 'equip', slot: raw };
   }
   // A bag cell (the manual-order drop): its data-bag-index IS an inventory index
   // while the grid shows the raw array order, which is the only view that stamps it.

--- a/tests/community_test_accounts.test.ts
+++ b/tests/community_test_accounts.test.ts
@@ -13,7 +13,7 @@ import { ITEMS } from '../src/sim/data';
 import { canEquipItem } from '../src/sim/equipment_rules';
 import { meetsLevelRequirement } from '../src/sim/item_level_req';
 import { Sim } from '../src/sim/sim';
-import { ALL_CLASSES, EQUIP_SLOTS, MAX_LEVEL, xpToReachLevel } from '../src/sim/types';
+import { ALL_CLASSES, MAX_LEVEL, xpToReachLevel } from '../src/sim/types';
 
 describe('community test account configuration', () => {
   it('is disabled until boot explicitly enables it', () => {

--- a/tests/persistence_round_trip.test.ts
+++ b/tests/persistence_round_trip.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
+import { ALL_EQUIP_SLOTS, type EquipSlot } from '../src/sim/types';
 
 function makeWorld() {
   return new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
@@ -156,5 +157,42 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     const s = sim.serializeCharacter(pid)!;
     expect(s.level).toBe(8);
     expect(s.xp).toBe(1234);
+  });
+});
+
+// equipmentInstance is the per-slot instanced-copy payload map: an enchant, a
+// masterwork copy's baked stats, a Rift-forged upgrade, crafted provenance, a
+// signer. Losing one silently reverts worn gear to plain on the next login, so
+// every LIVE slot has to survive the save/load boundary.
+//
+// Driven by ALL_EQUIP_SLOTS rather than a hand-listed set, deliberately: the
+// offhand payload was dropped for exactly as long as it took one load-path
+// validator to reach for the frozen launch-era slot list instead of the live
+// one, and a hand-listed test would have been written from that same stale
+// list. Parameterizing over the live list is what makes a future twelfth slot
+// inherit this coverage instead of needing someone to remember.
+describe('equipmentInstance survives the save/load boundary for every live slot', () => {
+  it.each([...ALL_EQUIP_SLOTS])('keeps the %s instance payload', (slot: EquipSlot) => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Enchanted');
+    const meta = sim.meta(pid)!;
+    // The item id is irrelevant to the payload plumbing under test (the load
+    // path keys on the slot being worn, not on the def), so one real id in
+    // every slot keeps the fixture honest without 12 slot-legal picks.
+    meta.equipment[slot] = 'worn_sword';
+    meta.equipmentInstance[slot] = { enchant: 'test_enchant', rolled: { stats: { str: 3 } } };
+
+    const saved = sim.serializeCharacter(pid)!;
+    expect(saved.equipmentInstance?.[slot]).toEqual({
+      enchant: 'test_enchant',
+      rolled: { stats: { str: 3 } },
+    });
+
+    const sim2 = makeWorld();
+    const pid2 = sim2.addPlayer('warrior', 'Enchanted', { state: saved });
+    expect(sim2.meta(pid2)!.equipmentInstance[slot]).toEqual({
+      enchant: 'test_enchant',
+      rolled: { stats: { str: 3 } },
+    });
   });
 });

--- a/tests/pvp_honor_gear.test.ts
+++ b/tests/pvp_honor_gear.test.ts
@@ -17,8 +17,9 @@ import {
   itemSourceLevel,
   primaryStatSum,
 } from '../src/sim/item_level';
+import { LAUNCH_PAPERDOLL_SLOTS } from '../src/sim/launch_paperdoll_slots';
 import { pvpFractionsFromRatings } from '../src/sim/pvp';
-import { EQUIP_SLOTS, type EquipSlot, type PlayerClass } from '../src/sim/types';
+import type { EquipSlot, PlayerClass } from '../src/sim/types';
 
 const SLOT_PRICES: Record<string, number> = {
   mainhand: 800,
@@ -259,7 +260,7 @@ describe('FURY WARFARE class and role coverage', () => {
   it('provides every supported equipment slot to every intended class profile', () => {
     for (const profile of PROFILES) {
       const ids = profileItemIds(profile);
-      expect(ids).toHaveLength(EQUIP_SLOTS.length);
+      expect(ids).toHaveLength(LAUNCH_PAPERDOLL_SLOTS.length);
 
       const concreteSlots = new Set<EquipSlot>();
       for (const id of ids) {
@@ -270,7 +271,7 @@ describe('FURY WARFARE class and role coverage', () => {
           concreteSlots.add(slot);
         }
       }
-      expect([...concreteSlots].sort(), profile.name).toEqual([...EQUIP_SLOTS].sort());
+      expect([...concreteSlots].sort(), profile.name).toEqual([...LAUNCH_PAPERDOLL_SLOTS].sort());
 
       for (const cls of profile.classes) {
         for (const id of ids) {


### PR DESCRIPTION
## Summary

A worn offhand lost its enchant on login. The character load path validated saved `equipmentInstance` keys against `EQUIP_SLOTS`, the frozen launch-era eleven-slot list that deliberately omits the additive `offhand` slot, so every offhand payload was silently discarded while `serializeCharacter` had written it correctly. Enchants are the visible symptom; the same map carries masterwork stats, Rift-forged upgrades, crafted provenance (`craftedRecipeId`), and signer, so all of those were lost from the offhand too.

Reproduced before fixing (`tests/persistence_round_trip.test.ts`, one `it.each` case per live slot): 11 slots passed, `offhand` failed.

```
saved offhand   : {"enchant":"...","rolled":{"stats":{"str":3}}}
loaded mainhand : {"enchant":"...","rolled":{"stats":{"str":3}}}
loaded offhand  : undefined
```

### Why this is not a one-line constant swap

This is the second time the frozen list has been mistaken for the live one. The first was `unequip_item{slot:'offhand'}` and the touch-drag hit test (`tests/offhand_equip_wire.test.ts`). The reason it recurs is that the codebase was defending against it with prose: there are five hand-rolled slot validators, all shaped `(LIST as readonly string[]).includes(x)`, and four carried a hand-written comment saying which constant to use. The fifth did not, and that one is this bug. The `as readonly string[]` cast is present at all five and erases exactly the type information that would have flagged the mismatch, so the compiler could never help.

So the trap is retired rather than the constant swapped:

- **`EQUIP_SLOTS` is deleted from `src/sim/types.ts`.** It had no correct production consumer: this bug was its only production import, `deeds.ts` already inlined its own frozen literal, one test used it legitimately, and one imported it without using it. Reaching for it is now a compile error rather than a silently wrong answer, and `tsc` here runs in about two seconds.
- **The frozen list moves to `src/sim/launch_paperdoll_slots.ts`** as `LAUNCH_PAPERDOLL_SLOTS`, with a header stating it is never for validation and naming its only two legitimate readers. Physically separate and loudly named, so it is not something you pick up by accident.
- **`isEquipSlot(value): value is EquipSlot`** is added to `types.ts`, derived from `ALL_EQUIP_SLOTS`, and all five call sites use it. Every `as EquipSlot` and `as readonly string[]` cast at those sites is gone; the cast now exists once, inside the validator, where the list it applies to is not a choice. A sixth call site is safe by construction.
- **The pin is parameterized over the live list**, `it.each(ALL_EQUIP_SLOTS)`, so it catches a per-slot payload drop whatever the cause and a future twelfth slot inherits coverage instead of needing someone to remember.

No scan-guard test: the compiler already enforces the deletion, faster and with no allowlist to maintain.

### Behavior notes

- `deeds.ts allEquipSlotsFilled` now reads `LAUNCH_PAPERDOLL_SLOTS`, byte-identical to the literal it replaces, so already-earned deed rows keep their exact meaning.
- Not retroactive: payloads already dropped at load were overwritten by the next autosave and cannot be recovered. Saves not loaded since the last enchant still hold their data.
- Rollback-safe: a save written by this build carries offhand payloads that an older build would simply drop again, which is the current behavior.

## Related issues

Part of the same defect class as the offhand work in `tests/offhand_equip_wire.test.ts`.

## Type of change

- [x] Bug fix
- [x] Refactor or performance (no behavior change)
- [x] Tests

## How was this tested?

- Commands:
  - `npm run gate` -> **PASS: all 11 steps green**
  - `npx tsc --noEmit` -> clean
  - `npx vitest run tests/persistence_round_trip.test.ts` -> the new per-slot pin fails on `offhand` before the fix, passes after
  - Directly affected suites green: `offhand_equip_wire`, `equip_drop_core`, `pvp_honor_gear`, `community_test_accounts`, `deeds`, `deeds_content`, `enchant_apply_view`, `professions_enchanting`, `professions_enchanting_commands`, `architecture`
- Manual steps: none; the bug is on the save/load boundary and is covered by the round-trip pin.

## Screenshots / recordings

N/A, no visual change.

---

## Checklist

### Quality

- [x] **The full gate passes.** `npm run gate` is green, with a decisive per-slot round-trip pin that fails without the fix.

### Cross-platform

- [x] N/A. No UI change. `item_drop_hit_test.ts` changes only which validator it calls; its behavior is unchanged and stays covered by `equip_drop_core`.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)