### PR TITLE
fix(ui): show the item stat tooltip on trade window slots

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -545,7 +545,7 @@ import { TOOLTIP_PEEK_MS, TouchPeekGuard } from './touch_peek';
 import { bindTouchDoubleTap, bindTouchTap, CLICK_SUPPRESS_MS, TAP_SLOP_PX } from './touch_tap';
 import { buildTownFocusView, stepTownFocus, townFocusRenderSig } from './town_focus_view';
 import { renderTownFocusWindow } from './town_focus_window';
-import { tradeOfferCeiling } from './trade_view';
+import { tradeOfferCeiling, tradeRowTooltipTarget } from './trade_view';
 import { TutorialOverlay } from './tutorial';
 import { svgIcon } from './ui_icons';
 import { getUiScale } from './ui_scale';
@@ -15143,6 +15143,10 @@ export class Hud {
     if (sig === this.lastTradeSig) return;
     this.lastTradeSig = sig;
 
+    // Both offer sides render from the same InvSlot shape (TradeOffer.items in
+    // src/world_api/trade.ts), so the trade-slot tooltip reuses the exact bag
+    // tooltip (item + per-instance enchant/masterwork/signature detail) rather
+    // than any bespoke trade-only summary.
     const itemRow = (s: InvSlot, mine: boolean) => {
       const item = ITEMS[s.itemId];
       const label = `${item ? itemDisplayName(item) : s.itemId}${s.count > 1 ? ` x${formatNumber(s.count, { maximumFractionDigits: 0 })}` : ''}`;
@@ -15194,6 +15198,26 @@ export class Hud {
         }
       });
     });
+    // Wire the same stat tooltip bag/vendor/bank slots use onto both offer
+    // sides, keyed positionally (the rendered rows are the offer's own items
+    // in order, with no other `.trade-item` siblings to misalign against).
+    const attachTradeTooltips = (rows: NodeListOf<Element>, slots: InvSlot[]) => {
+      rows.forEach((row, i) => {
+        const target = tradeRowTooltipTarget(slots, i);
+        if (!target) return;
+        this.attachTooltip(row as HTMLElement, () =>
+          this.itemTooltip(target.item, true, target.instance),
+        );
+      });
+    };
+    attachTradeTooltips(
+      el.querySelectorAll('.trade-col:first-child .trade-item'),
+      info.myOffer.items,
+    );
+    attachTradeTooltips(
+      el.querySelectorAll('.trade-col:last-child .trade-item'),
+      info.theirOffer.items,
+    );
     const goldInput = el.querySelector('#trade-g') as HTMLInputElement;
     const silverInput = el.querySelector('#trade-s') as HTMLInputElement;
     const copperInput = el.querySelector('#trade-c') as HTMLInputElement;

--- a/src/ui/trade_view.ts
+++ b/src/ui/trade_view.ts
@@ -14,10 +14,28 @@
 // tradeOfferCeiling gives the trade window the same total.
 //
 // DOM/Three-free (registered in tests/architecture.test.ts UI_PURE_CORES).
-import type { InvSlot } from '../sim/types';
+import { ITEMS } from '../sim/data';
+import type { InvSlot, ItemDef, ItemInstancePayload } from '../sim/types';
 
 /** Total held count of `itemId` across every bag slot: the trade offer
  *  stepper's ceiling. */
 export function tradeOfferCeiling(inventory: InvSlot[], itemId: string): number {
   return inventory.filter((s) => s.itemId === itemId).reduce((n, s) => n + s.count, 0);
+}
+
+/** Resolves the bag-style tooltip target (item def + optional per-instance
+ *  payload) for the slot at `index` in a trade offer's item list. Both offer
+ *  sides render from the same `InvSlot[]` (`TradeOffer.items` in
+ *  `src/world_api/trade.ts`), so a trade slot's tooltip is exactly the item's
+ *  bag tooltip, instance detail included. Returns null for an out-of-range
+ *  index or an unrecognized item id (#2693). */
+export function tradeRowTooltipTarget(
+  items: InvSlot[],
+  index: number,
+): { item: ItemDef; instance?: ItemInstancePayload } | null {
+  const s = items[index];
+  if (!s) return null;
+  const item = ITEMS[s.itemId];
+  if (!item) return null;
+  return { item, instance: s.instance };
 }

--- a/tests/trade_view.test.ts
+++ b/tests/trade_view.test.ts
@@ -6,8 +6,9 @@
 // whichever single slot the old Array.find()-based lookup happened to hit.
 
 import { describe, expect, it } from 'vitest';
+import { ITEMS } from '../src/sim/data';
 import type { InvSlot } from '../src/sim/types';
-import { tradeOfferCeiling } from '../src/ui/trade_view';
+import { tradeOfferCeiling, tradeRowTooltipTarget } from '../src/ui/trade_view';
 
 describe('tradeOfferCeiling (trade offer stepper cap)', () => {
   it('sums an item split across multiple bag slots instead of capping at one slot', () => {
@@ -39,5 +40,54 @@ describe('tradeOfferCeiling (trade offer stepper cap)', () => {
   it('returns 0 when the item is not held at all', () => {
     const inventory: InvSlot[] = [{ itemId: 'mat_linen_cloth', count: 20 }];
     expect(tradeOfferCeiling(inventory, 'mat_wool_cloth')).toBe(0);
+  });
+});
+
+// Issue #2693: hovering an item in the trade window showed no stats tooltip
+// because updateTradeWindow (hud.ts) never wired the trade slots to the
+// shared attachTooltip/itemTooltip infrastructure bag slots use.
+// tradeRowTooltipTarget is the pure lookup hud.ts's wiring resolves through:
+// same InvSlot shape as a bag row (both offer sides carry it, per
+// src/world_api/trade.ts's TradeOffer), so it must expose the exact item def
+// plus per-instance payload (enchant/masterwork/signature) the bag tooltip
+// itself reads.
+describe('tradeRowTooltipTarget (trade slot tooltip wiring, #2693)', () => {
+  it('resolves the item def for a plain trade slot', () => {
+    const items: InvSlot[] = [{ itemId: 'worn_sword', count: 1 }];
+    const target = tradeRowTooltipTarget(items, 0);
+    expect(target?.item).toBe(ITEMS.worn_sword);
+    expect(target?.instance).toBeUndefined();
+  });
+
+  it('carries the per-instance payload (enchant/masterwork/signature) through, matching the bag tooltip', () => {
+    const items: InvSlot[] = [
+      {
+        itemId: 'worn_sword',
+        count: 1,
+        instance: { signer: 'Anna', rolled: { masterwork: true, stats: { str: 2 } } },
+      },
+    ];
+    const target = tradeRowTooltipTarget(items, 0);
+    expect(target?.instance).toEqual({
+      signer: 'Anna',
+      rolled: { masterwork: true, stats: { str: 2 } },
+    });
+  });
+
+  it('resolves each offer row positionally, so the second slot does not pick up the first slot instance', () => {
+    const items: InvSlot[] = [
+      { itemId: 'worn_sword', count: 1 },
+      { itemId: 'gnarled_staff', count: 1, instance: { signer: 'Bob' } },
+    ];
+    expect(tradeRowTooltipTarget(items, 0)?.item).toBe(ITEMS.worn_sword);
+    expect(tradeRowTooltipTarget(items, 0)?.instance).toBeUndefined();
+    expect(tradeRowTooltipTarget(items, 1)?.item).toBe(ITEMS.gnarled_staff);
+    expect(tradeRowTooltipTarget(items, 1)?.instance).toEqual({ signer: 'Bob' });
+  });
+
+  it('returns null out of range (the trade-empty placeholder row) and for an unrecognized item id', () => {
+    const items: InvSlot[] = [{ itemId: 'worn_sword', count: 1 }];
+    expect(tradeRowTooltipTarget(items, 1)).toBeNull();
+    expect(tradeRowTooltipTarget([{ itemId: 'not_a_real_item', count: 1 }], 0)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Hovering an item in the trade window (either offer side) showed no tooltip: `updateTradeWindow` (`src/ui/hud.ts`) rendered the `.trade-item` rows without ever wiring them to the shared `attachTooltip`/`itemTooltip` infrastructure that bag, vendor, and bank slots already use.
- Adds `tradeRowTooltipTarget` (`src/ui/trade_view.ts`), a pure lookup that resolves the bag-style tooltip target (item def plus optional per-instance enchant/masterwork/signature payload) for a row in a trade offer's item list, and wires it onto both offer sides in `updateTradeWindow`, matching the bag tooltip exactly (including per-instance detail).
- Display only: no change to trade mechanics.

Fixes #2693

## Test plan
- [x] `npx vitest run tests/trade_view.test.ts` (new `tradeRowTooltipTarget` suite: plain item, per-instance payload passthrough, positional resolution across both offer sides, out-of-range/unrecognized-item null cases)
- [x] `npm test` (full vitest suite)
- [x] `npx tsc --noEmit` (pre-existing unrelated failure in `src/render/assets/ktx2_support.ts` confirmed present on `release/v0.33.0` before this change; nothing in this diff touches that file)
- [x] `npx @biomejs/biome check src/ui/hud.ts src/ui/trade_view.ts tests/trade_view.test.ts` (clean aside from a pre-existing unrelated unused-import warning in `hud.ts`, confirmed present before this change via `git stash`)

Not independently reachable in this sandbox: live two-character trade UI verification (a live trade needs a second connected player). Verified instead via the pure `tradeRowTooltipTarget` unit tests plus reading `attachTooltip`'s existing desktop/touch handling (`src/ui/hud.ts`), which the trade rows now reuse unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)