### PR TITLE
feat(ui): remember the last opened crafting tab

### DIFF
--- a/src/ui/crafting_tab_pref.ts
+++ b/src/ui/crafting_tab_pref.ts
@@ -1,0 +1,27 @@
+// Pure, DOM-free persistence helpers for the crafting window's last-selected
+// tab (issue #2347: reopening the crafting menu defaulted back to the first
+// profession tab instead of the one the player was last using). Mirrors the
+// bag_filter.ts precedent: a tolerant parse that falls back to "no pick yet"
+// on anything malformed, so a corrupt localStorage value can never break the
+// window. profession ids are open-ended content (src/sim/content/recipes.ts),
+// not a fixed enum, so the only shape check here is "non-empty string"; the
+// actual membership check against the player's current tabs still happens in
+// resolveSelectedCraft() (crafting_view.ts), which is what guards against a
+// stale/renamed profession id.
+//
+// DOM-free so tests/crafting_tab_pref.test.ts can drive it directly.
+
+export function serializeCraftingTab(professionId: string | null): string {
+  return JSON.stringify(professionId);
+}
+
+export function parseCraftingTab(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  return typeof parsed === 'string' && parsed.length > 0 ? parsed : null;
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -191,6 +191,7 @@ import {
   type CraftTierUp,
   observeCraftSkillsForTierUps,
 } from './craft_celebration_view';
+import { parseCraftingTab, serializeCraftingTab } from './crafting_tab_pref';
 import { buildCraftingView, craftingReagentSig, craftLearnHints } from './crafting_view';
 import { renderCraftingWindow, stationNameText } from './crafting_window';
 import { shouldRefreshDailyRewardsLauncher } from './daily_rewards_launcher_core';
@@ -933,6 +934,8 @@ const DEFAULT_EMOTE_WHEEL: OverheadEmoteId[] = [
 // chat event filter): keeping a second, name-keyed local list live online is
 // exactly how you get "I unignored them and still cannot see them".
 const LOCAL_IGNORES_KEY = 'woc_ignored_chat_names';
+// The persisted last-selected crafting tab (issue #2347). See selectedCraftTab.
+const CRAFTING_TAB_KEY = 'woc_crafting_tab';
 // The persisted top-left keys for the movable unit frames live in
 // frame_pos_reset.ts (imported above) so the one-time reset clears the same
 // keys the MovableFrames read.
@@ -1428,9 +1431,16 @@ export class Hud {
   private readonly craftCommissionOptIn = new Set<string>();
   // The crafting window's selected craft tab. Held here (the commission-set
   // precedent) so staleness repaints keep the player's tab; null means "no
-  // pick yet" and the painter falls back to the first tab. Cleared on close
-  // so reopening always starts at the front of the book.
-  private selectedCraftTab: string | null = null;
+  // pick yet" and the painter falls back to the first tab. Persisted across
+  // sessions (issue #2347: reopening always fell back to the first tab), so
+  // it survives window close instead of resetting like the commission set.
+  private selectedCraftTab: string | null = (() => {
+    try {
+      return parseCraftingTab(localStorage.getItem(CRAFTING_TAB_KEY));
+    } catch {
+      return null;
+    }
+  })();
   private readonly delveBoard: DelveBoardController;
   private readonly delveTracker: DelveTrackerController;
   private readonly riftTracker: RiftFloorTrackerController;
@@ -12999,6 +13009,7 @@ export class Hud {
         selectedCraft: () => this.selectedCraftTab,
         onSelectCraft: (professionId) => {
           this.selectedCraftTab = professionId;
+          this.persistCraftingTab();
           this.renderCrafting();
           // A fresh tab starts at the top of its recipe list, not wherever
           // the previous craft's scroll happened to rest.
@@ -13022,9 +13033,17 @@ export class Hud {
     this.hideTooltip();
     // Commission opt-ins are per-session-of-the-window: closing it drops any
     // armed-but-uncrafted checkboxes, so reopening always starts clean (the
-    // off-by-default rule). The selected tab resets with them.
+    // off-by-default rule). The selected tab is persisted separately
+    // (issue #2347) and deliberately survives the close.
     this.craftCommissionOptIn.clear();
-    this.selectedCraftTab = null;
+  }
+
+  private persistCraftingTab(): void {
+    try {
+      localStorage.setItem(CRAFTING_TAB_KEY, serializeCraftingTab(this.selectedCraftTab));
+    } catch {
+      /* storage unavailable (private mode); tab pick still works in-session */
+    }
   }
   // -------------------------------------------------------------------------
   // The World Market — the Merchant's auction house

--- a/tests/crafting_tab_pref.test.ts
+++ b/tests/crafting_tab_pref.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { parseCraftingTab, serializeCraftingTab } from '../src/ui/crafting_tab_pref';
+
+describe('serialize / parse round-trip', () => {
+  it('round-trips a valid profession id', () => {
+    expect(parseCraftingTab(serializeCraftingTab('cooking'))).toBe('cooking');
+  });
+
+  it('round-trips null (no pick yet)', () => {
+    expect(parseCraftingTab(serializeCraftingTab(null))).toBeNull();
+  });
+});
+
+describe('parseCraftingTab tolerance', () => {
+  it('falls back to null on garbage input', () => {
+    expect(parseCraftingTab('not json')).toBeNull();
+    expect(parseCraftingTab(null)).toBeNull();
+    expect(parseCraftingTab(undefined)).toBeNull();
+    expect(parseCraftingTab('')).toBeNull();
+  });
+
+  it('falls back to null on a non-string JSON value', () => {
+    expect(parseCraftingTab('42')).toBeNull();
+    expect(parseCraftingTab('true')).toBeNull();
+    expect(parseCraftingTab('{"professionId":"cooking"}')).toBeNull();
+    expect(parseCraftingTab('[]')).toBeNull();
+  });
+
+  it('falls back to null on an empty string profession id', () => {
+    expect(parseCraftingTab('""')).toBeNull();
+  });
+
+  it('accepts any non-empty profession id string (open-ended content, not an enum)', () => {
+    expect(parseCraftingTab('"weaponcrafting"')).toBe('weaponcrafting');
+    expect(parseCraftingTab('"some_future_profession"')).toBe('some_future_profession');
+  });
+});


### PR DESCRIPTION
## Summary
- The crafting window always reopened on the first profession tab (weaponcrafting), forcing players to reselect cooking (or whatever craft they actually use) every time.
- `selectedCraftTab` in `src/ui/hud.ts` was reset to `null` on every window close instead of persisted.
- Added `src/ui/crafting_tab_pref.ts`, a pure serialize/parse module mirroring the existing `bag_filter.ts` localStorage precedent (tolerant parse, falls back to "no pick yet" on anything malformed).
- `Hud` now seeds `selectedCraftTab` from `localStorage` (`woc_crafting_tab`) at construction, persists it on every tab pick, and no longer clears it in `closeCrafting()`.
- `resolveSelectedCraft()` (`src/ui/crafting_view.ts`) already falls back to the first tab if the stored profession id no longer matches a known tab, so a stale or corrupted value degrades safely.

## Test plan
- [x] Added `tests/crafting_tab_pref.test.ts` covering round-trip serialize/parse, tolerant fallback on garbage/non-string/empty values, and acceptance of any non-empty profession id (open-ended content, not a fixed enum).
- [x] `npx vitest run tests/crafting_view.test.ts tests/crafting_tab_pref.test.ts tests/architecture.test.ts` passes (82 tests).
- [x] `npx tsc --noEmit` shows no new errors introduced by this change (the one remaining error, `src/render/assets/ktx2_support.ts`, is pre-existing on `release/v0.33.0` and unrelated).
- [x] `npx @biomejs/biome check --write` run on the changed files.

Fixes #2347

🤖 Generated with [Claude Code](https://claude.com/claude-code)