### PR TITLE
feat(ui): hide premade Dungeon Finder listings for a locked-out dungeon

### DIFF
--- a/src/ui/dungeon_finder_view.ts
+++ b/src/ui/dungeon_finder_view.ts
@@ -435,8 +435,12 @@ export function buildDungeonFinderView(input: DungeonFinderViewInput): DungeonFi
     // is not something I can usefully apply to, and showing it invites a
     // player to join a group only to discover the lockout at the door. Hide
     // it from the browse list; my own listing is unaffected (it lives in
-    // `myListing`, a separate panel this loop never touches).
-    if (lockoutMinutesFor(activity, input.lockouts) > 0) continue;
+    // `myListing`, a separate panel this loop never touches). A listing I
+    // have already applied to stays visible even while locked out, so its
+    // row (and withdraw control) keep existing: otherwise a pending
+    // application could never be withdrawn once the lockout landed.
+    const applied = info.myApplication?.listingId === listing.id;
+    if (!applied && lockoutMinutesFor(activity, input.lockouts) > 0) continue;
     const blocked = blockReasonFor(activity, level, specRole);
     const mine = info.myListing?.id === listing.id;
     const roleFit =
@@ -447,7 +451,7 @@ export function buildDungeonFinderView(input: DungeonFinderViewInput): DungeonFi
       difficulty: activity.difficulty,
       kind: activity.kind,
       mine,
-      applied: info.myApplication?.listingId === listing.id,
+      applied,
       blocked,
       canApply:
         !mine &&

--- a/src/ui/dungeon_finder_view.ts
+++ b/src/ui/dungeon_finder_view.ts
@@ -431,6 +431,12 @@ export function buildDungeonFinderView(input: DungeonFinderViewInput): DungeonFi
   for (const listing of board) {
     const activity = finderActivity(listing.activityId);
     if (!activity) continue;
+    // Issue #2030: a listing for a dungeon/raid I am currently locked out of
+    // is not something I can usefully apply to, and showing it invites a
+    // player to join a group only to discover the lockout at the door. Hide
+    // it from the browse list; my own listing is unaffected (it lives in
+    // `myListing`, a separate panel this loop never touches).
+    if (lockoutMinutesFor(activity, input.lockouts) > 0) continue;
     const blocked = blockReasonFor(activity, level, specRole);
     const mine = info.myListing?.id === listing.id;
     const roleFit =

--- a/src/ui/dungeon_finder_view.ts
+++ b/src/ui/dungeon_finder_view.ts
@@ -434,15 +434,18 @@ export function buildDungeonFinderView(input: DungeonFinderViewInput): DungeonFi
     // Issue #2030: a listing for a dungeon/raid I am currently locked out of
     // is not something I can usefully apply to, and showing it invites a
     // player to join a group only to discover the lockout at the door. Hide
-    // it from the browse list; my own listing is unaffected (it lives in
-    // `myListing`, a separate panel this loop never touches). A listing I
-    // have already applied to stays visible even while locked out, so its
-    // row (and withdraw control) keep existing: otherwise a pending
-    // application could never be withdrawn once the lockout landed.
+    // it from the browse list. The board payload is viewer-independent, so
+    // my own listing DOES pass through this loop (it also renders in the
+    // separate `myListing` panel): exempt it the same as `applied`, or a
+    // leader who takes the lockout mid-run loses their own row from Open
+    // Listings. A listing I have already applied to stays visible even
+    // while locked out, so its row (and withdraw control) keep existing:
+    // otherwise a pending application could never be withdrawn once the
+    // lockout landed.
     const applied = info.myApplication?.listingId === listing.id;
-    if (!applied && lockoutMinutesFor(activity, input.lockouts) > 0) continue;
-    const blocked = blockReasonFor(activity, level, specRole);
     const mine = info.myListing?.id === listing.id;
+    if (!applied && !mine && lockoutMinutesFor(activity, input.lockouts) > 0) continue;
+    const blocked = blockReasonFor(activity, level, specRole);
     const roleFit =
       activity.composition === null || info.roles.some((r) => (listing.needed?.[r] ?? 0) > 0);
     listings.push({

--- a/tests/dungeon_finder_view.test.ts
+++ b/tests/dungeon_finder_view.test.ts
@@ -332,6 +332,33 @@ describe('dungeon finder view core', () => {
     expect(locked.board.listings).toEqual([]);
   });
 
+  it('keeps a listing visible for withdraw when the viewer applied before going locked (#2030)', () => {
+    const heroicListing = {
+      id: 8,
+      activityId: 'hollow_crypt_heroic',
+      leaderName: 'Lead',
+      tags: [],
+      size: 1,
+      capacity: 5,
+      needed: { tank: 0, healer: 1, dps: 3 },
+      members: [{ cls: 'warrior' as const, level: 20, role: 'tank' as const }],
+    };
+    const view = live(
+      buildDungeonFinderView(
+        input({
+          tab: 'board',
+          playerLevel: 20,
+          board: [heroicListing],
+          info: makeInfo('sim', { myApplication: { listingId: 8 } }),
+          lockouts: [{ id: 'hollow_crypt:heroic', msRemaining: 3_600_000 }],
+        }),
+      ),
+    );
+    expect(view.board.listings.map((l) => l.id)).toEqual([8]);
+    expect(view.board.listings[0].applied).toBe(true);
+    expect(view.board.listings[0].canApply).toBe(false);
+  });
+
   it('keeps the 1 Hz clock numbers OUT of the render-skip signature', () => {
     const base = input({
       info: makeInfo('sim', {

--- a/tests/dungeon_finder_view.test.ts
+++ b/tests/dungeon_finder_view.test.ts
@@ -302,6 +302,36 @@ describe('dungeon finder view core', () => {
     expect(applied.board.listings[0].canApply).toBe(false);
   });
 
+  it('hides premade listings for a dungeon the viewer is locked out of (#2030)', () => {
+    const heroicListing = {
+      id: 8,
+      activityId: 'hollow_crypt_heroic',
+      leaderName: 'Lead',
+      tags: [],
+      size: 1,
+      capacity: 5,
+      needed: { tank: 0, healer: 1, dps: 3 },
+      members: [{ cls: 'warrior' as const, level: 20, role: 'tank' as const }],
+    };
+    const unlocked = live(
+      buildDungeonFinderView(
+        input({ tab: 'board', playerLevel: 20, board: [heroicListing], lockouts: [] }),
+      ),
+    );
+    expect(unlocked.board.listings.map((l) => l.id)).toEqual([8]);
+    const locked = live(
+      buildDungeonFinderView(
+        input({
+          tab: 'board',
+          playerLevel: 20,
+          board: [heroicListing],
+          lockouts: [{ id: 'hollow_crypt:heroic', msRemaining: 3_600_000 }],
+        }),
+      ),
+    );
+    expect(locked.board.listings).toEqual([]);
+  });
+
   it('keeps the 1 Hz clock numbers OUT of the render-skip signature', () => {
     const base = input({
       info: makeInfo('sim', {

--- a/tests/dungeon_finder_view.test.ts
+++ b/tests/dungeon_finder_view.test.ts
@@ -359,6 +359,74 @@ describe('dungeon finder view core', () => {
     expect(view.board.listings[0].canApply).toBe(false);
   });
 
+  it('keeps a leader listing visible in Open listings when its OWN dungeon goes locked (#2030 followup)', () => {
+    const heroicListing = {
+      id: 8,
+      activityId: 'hollow_crypt_heroic',
+      leaderName: 'Lead',
+      tags: [],
+      size: 1,
+      capacity: 5,
+      needed: { tank: 0, healer: 1, dps: 3 },
+      members: [{ cls: 'warrior' as const, level: 20, role: 'tank' as const }],
+    };
+    const view = live(
+      buildDungeonFinderView(
+        input({
+          tab: 'board',
+          playerLevel: 20,
+          board: [heroicListing],
+          info: makeInfo('sim', {
+            myListing: { id: 8, activityId: 'hollow_crypt_heroic', tags: [], applicants: [] },
+          }),
+          lockouts: [{ id: 'hollow_crypt:heroic', msRemaining: 3_600_000 }],
+        }),
+      ),
+    );
+    expect(view.board.listings.map((l) => l.id)).toEqual([8]);
+    expect(view.board.listings[0].mine).toBe(true);
+  });
+
+  it('does not hide a listing over a lockout on a DIFFERENT dungeon or a lockout-free difficulty (#2030 followup)', () => {
+    const heroicListing = {
+      id: 8,
+      activityId: 'hollow_crypt_heroic',
+      leaderName: 'Lead',
+      tags: [],
+      size: 1,
+      capacity: 5,
+      needed: { tank: 0, healer: 1, dps: 3 },
+      members: [{ cls: 'warrior' as const, level: 20, role: 'tank' as const }],
+    };
+    // A lockout on an unrelated dungeon must not hide this listing.
+    const otherDungeonLocked = live(
+      buildDungeonFinderView(
+        input({
+          tab: 'board',
+          playerLevel: 20,
+          board: [heroicListing],
+          lockouts: [{ id: 'sunken_temple:heroic', msRemaining: 3_600_000 }],
+        }),
+      ),
+    );
+    expect(otherDungeonLocked.board.listings.map((l) => l.id)).toEqual([8]);
+
+    // hollow_crypt normal has lockout:'none', so a listing for it must stay
+    // visible even if the (unrelated) heroic difficulty is locked.
+    const normalListing = { ...heroicListing, id: 9, activityId: 'hollow_crypt_normal' };
+    const normalDifficultyUnaffected = live(
+      buildDungeonFinderView(
+        input({
+          tab: 'board',
+          playerLevel: 20,
+          board: [normalListing],
+          lockouts: [{ id: 'hollow_crypt:heroic', msRemaining: 3_600_000 }],
+        }),
+      ),
+    );
+    expect(normalDifficultyUnaffected.board.listings.map((l) => l.id)).toEqual([9]);
+  });
+
   it('keeps the 1 Hz clock numbers OUT of the render-skip signature', () => {
     const base = input({
       info: makeInfo('sim', {


### PR DESCRIPTION
## Summary
- Hides a Dungeon Finder premade group listing from the browse board when the viewing player is currently locked out of that dungeon/raid activity, so a locked-out player no longer sees (or is tempted to apply to) a group they cannot actually join.
- Reuses the existing `lockoutMinutesFor` helper (already backing the catalogue tab's lock countdown) inside the board listing loop of the pure view core `buildDungeonFinderView` in `src/ui/dungeon_finder_view.ts`, so no sim/wire/server changes are needed: the viewer's own `raidLockouts()` data was already shipped to the client.
- The board payload is viewer-independent, so the viewer's OWN published listing does pass through this loop (it also renders separately via `myListing`). It is exempted from the lockout hide, the same way an applied-to listing already is: a leader who publishes a listing and then takes the lockout mid-run must still see their own row in Open listings.
- A listing the viewer has already applied to also stays visible even while locked out, so its row (and withdraw control) keep existing.

## Test plan
- [x] `tests/dungeon_finder_view.test.ts`: "hides premade listings for a dungeon the viewer is locked out of (#2030)" covers the unlocked (listing visible) and locked (listing hidden) cases; "keeps a listing visible for withdraw when the viewer applied before going locked (#2030)" covers the applied exemption; "keeps a leader listing visible in Open listings when its OWN dungeon goes locked (#2030 followup)" covers the own-listing exemption; "does not hide a listing over a lockout on a DIFFERENT dungeon or a lockout-free difficulty (#2030 followup)" pins that key matching, not "any lockout present", drives the hide.
- [x] `npx vitest run tests/dungeon_finder_view.test.ts` passes.
- [x] `npx vitest run tests/dungeon_finder.test.ts` passes except one pre-existing unrelated timeout flake ("a decline returns accepted units...") confirmed present on the unmodified base branch too.
- [x] `npx tsc --noEmit` shows only pre-existing unrelated errors in `src/render/` (not touched by this change).
- [x] `npx @biomejs/biome check` clean on both changed files.

Fixes #2030
