### PR TITLE
fix(render): preserve nearby dressing visibility

### DIFF
--- a/src/render/foliage.ts
+++ b/src/render/foliage.ts
@@ -198,8 +198,14 @@ const TREE_MODEL_URLS: ReadonlySet<string> = new Set([
   ...MODEL_URLS.twisted,
   ...MODEL_URLS.dead,
 ]);
+const DRESSING_MODEL_URLS: ReadonlySet<string> = new Set([
+  ...MODEL_URLS.bush,
+  ...MODEL_URLS.bushFlowers,
+  ...MODEL_URLS.fern,
+  ...MODEL_URLS.mushroom,
+]);
 const collapseRoleForUrl = (url: string): CollapseRole =>
-  TREE_MODEL_URLS.has(url) ? 'tree' : 'plain';
+  TREE_MODEL_URLS.has(url) ? 'tree' : DRESSING_MODEL_URLS.has(url) ? 'dressing' : 'plain';
 
 // kick off fetches at import; buildFoliage assumes the cache is populated
 const loadedModels = new Map<string, GLTF>();
@@ -513,6 +519,8 @@ interface BucketMesh {
   radius: number;
   minDist?: number;
   maxDist?: number;
+  /** maxDist is enforced per instance; this bucket is a coverage bound only. */
+  maxAtInstance?: boolean;
   // The real model ends, and the impostor begins, at the RUNTIME tree-detail
   // distance (it tracks fog, so it is unknown when the bucket is built). These
   // compose with the numeric caps above rather than replacing them: near-fill
@@ -1882,6 +1890,7 @@ function buildDressing(parent: THREE.Group, seed: number, registry: BucketMesh[]
           z: bz,
           radius: bRadius,
           maxDist: lodDists().dressFar,
+          maxAtInstance: true,
           lod: 'dressing',
           ...bucketMeshCost(im),
         });
@@ -3062,13 +3071,19 @@ export function buildFoliage(seed: number): FoliageView {
     maxDist: undefined,
     minAtDetail: undefined,
     maxAtDetail: undefined,
+    maxAtInstance: undefined,
     distanceScale: 1,
     detailFar: 0,
     revealScale: 1,
     fogLimit: 0,
   };
   // Reused per frame for the same reason as bucketWindow above.
-  const collapseWindows: InstanceCullWindows = { treeMax: 0, impostorMin: 0, fogCull: 0 };
+  const collapseWindows: InstanceCullWindows = {
+    treeMax: 0,
+    impostorMin: 0,
+    fogCull: 0,
+    dressingMax: 0,
+  };
   buildTrees(group, seed, bucketMeshes, treeHideables);
   buildDressing(group, seed, bucketMeshes);
   for (const b of bucketMeshes) {
@@ -3144,7 +3159,14 @@ export function buildFoliage(seed: number): FoliageView {
       // The vertex shaders enforce these same boundaries per INSTANCE, so a
       // surviving slab no longer drags its whole tree population along with it
       // (foliage_collapse.ts; the windows themselves are instanceCullWindows).
-      updateCollapseUniforms(instanceCullWindowsInto(detailFar, fogLimit, collapseWindows));
+      updateCollapseUniforms(
+        instanceCullWindowsInto(
+          detailFar,
+          fogLimit,
+          lodDists().dressFar * distanceScale,
+          collapseWindows,
+        ),
+      );
       modelVisibleBuckets = 0;
       modelVisibleDraws = 0;
       modelVisibleTriangles = 0;
@@ -3168,6 +3190,7 @@ export function buildFoliage(seed: number): FoliageView {
         bucketWindow.maxDist = b.maxDist;
         bucketWindow.minAtDetail = b.minAtDetail;
         bucketWindow.maxAtDetail = b.maxAtDetail;
+        bucketWindow.maxAtInstance = b.maxAtInstance;
         bucketWindow.distanceScale = distanceScale;
         bucketWindow.detailFar = detailFar;
         bucketWindow.revealScale = revealScale;

--- a/src/render/foliage_collapse.ts
+++ b/src/render/foliage_collapse.ts
@@ -29,9 +29,10 @@ import type { InstanceCullWindows } from './foliage_lod';
  * Which window a material's instances collapse against:
  * - 'tree': real model parts, alive in [0, treeMax)
  * - 'impostor': the far stand-ins, alive in [impostorMin, fogCull)
- * - 'plain': rocks and dressing, alive in [0, fogCull)
+ * - 'dressing': bushes and ground plants, alive in [0, dressingMax)
+ * - 'plain': rocks, alive in [0, fogCull)
  */
-export type CollapseRole = 'tree' | 'impostor' | 'plain';
+export type CollapseRole = 'tree' | 'impostor' | 'dressing' | 'plain';
 
 interface UniformValue {
   value: number;
@@ -61,12 +62,14 @@ const ZERO: UniformValue = { value: 0 };
 const uTreeMax: UniformValue = { value: FAR_SEED };
 const uImpostorMin: UniformValue = { value: FAR_SEED };
 const uFogCull: UniformValue = { value: FAR_SEED };
+const uDressingMax: UniformValue = { value: FAR_SEED };
 
 /** Per-frame: push the windows every collapse-enabled material reads. */
 export function updateCollapseUniforms(w: InstanceCullWindows): void {
   uTreeMax.value = w.treeMax;
   uImpostorMin.value = w.impostorMin;
   uFogCull.value = w.fogCull;
+  uDressingMax.value = w.dressingMax;
 }
 
 const COLLAPSE_PARS = `
@@ -102,7 +105,7 @@ const COLLAPSE_VERTEX = `
  */
 export function applyInstanceCollapse(mat: CollapsibleMaterial, role: CollapseRole): void {
   const min = role === 'impostor' ? uImpostorMin : ZERO;
-  const max = role === 'tree' ? uTreeMax : uFogCull;
+  const max = role === 'tree' ? uTreeMax : role === 'dressing' ? uDressingMax : uFogCull;
   const prev = mat.onBeforeCompile;
   const prevSrc = typeof prev === 'function' ? prev.toString() : '';
   mat.onBeforeCompile = (shader, renderer) => {

--- a/src/render/foliage_collapse.ts
+++ b/src/render/foliage_collapse.ts
@@ -10,7 +10,7 @@
 //
 // The windows arrive per frame via updateCollapseUniforms (the shared-uniform
 // pattern of gfx.ts sharedUniforms.uTime): every material references the same
-// value objects, so the per-frame cost is three number writes. The decision
+// value objects, so the per-frame cost is four number writes. The decision
 // arithmetic lives in foliage_lod.ts (instanceCullWindows); this module is only
 // the Three-side injection, kept import-free so tests can drive it with plain
 // fakes.

--- a/src/render/foliage_lod.ts
+++ b/src/render/foliage_lod.ts
@@ -219,19 +219,20 @@ export interface BucketWindowInput {
  * are measured against the bucket's CENTER, as they always have been. They
  * are cost controls and a bucket is ~240u deep, so measuring them from the near
  * edge would keep every bucket alive for another half-bucket past its cap and
- * quietly multiply the triangles they exist to cut. Dressing is the exception:
+ * quietly multiply the triangles they exist to cut. Dressing is one exception:
  * its shader enforces the adaptive cap per instance, so its bucket test uses the
  * near edge only as a conservative coverage bound.
  *
- * The tree-detail swap is the exception: its two arms are COVERAGE tests, not a
- * partition. The real model draws while any part of the bucket is inside the
- * swap (near edge), the impostor while any part is outside it (far edge), so a
- * bucket straddling the boundary draws both meshes and the per-instance windows
- * (instanceCullWindows, enforced in the vertex shader) split the trees exactly.
- * Keyed on the center, a bucket you are standing at the edge of could already
- * have flipped to impostors, putting cones a few strides away; keyed near-edge
- * only, as this was before the shader owned the boundary, every tree in a
- * 540x240u slab drew at full detail until the whole slab left the swap.
+ * The tree-detail swap is a second, unrelated exception, for a different reason:
+ * its two arms are COVERAGE tests, not a partition. The real model draws while
+ * any part of the bucket is inside the swap (near edge), the impostor while any
+ * part is outside it (far edge), so a bucket straddling the boundary draws both
+ * meshes and the per-instance windows (instanceCullWindows, enforced in the
+ * vertex shader) split the trees exactly. Keyed on the center, a bucket you are
+ * standing at the edge of could already have flipped to impostors, putting
+ * cones a few strides away; keyed near-edge only, as this was before the shader
+ * owned the boundary, every tree in a 540x240u slab drew at full detail until
+ * the whole slab left the swap.
  */
 export function bucketVisible(w: BucketWindowInput): boolean {
   const nearEdge = w.centerDist - w.radius;

--- a/src/render/foliage_lod.ts
+++ b/src/render/foliage_lod.ts
@@ -138,6 +138,9 @@ export function treeDetailDistance(
  * silhouettes players report in the murky realms. The shader collapses each
  * INSTANCE against these windows instead, so the bucket tests only need to
  * answer "could any instance of this mesh be alive", never "are all of them".
+ * Dressing uses the same coverage rule at its adaptive distance cap, so an
+ * orbiting camera cannot drop nearby bushes just because the bucket center
+ * crossed the cap.
  *
  * Real tree parts live in [0, treeMax); impostors in [impostorMin, fogCull).
  * treeMax and impostorMin are the same number by construction: the windows
@@ -148,16 +151,27 @@ export interface InstanceCullWindows {
   treeMax: number;
   impostorMin: number;
   fogCull: number;
+  dressingMax: number;
 }
 
-export function instanceCullWindows(detailFar: number, fogLimit: number): InstanceCullWindows {
-  return instanceCullWindowsInto(detailFar, fogLimit, { treeMax: 0, impostorMin: 0, fogCull: 0 });
+export function instanceCullWindows(
+  detailFar: number,
+  fogLimit: number,
+  dressingLimit = fogLimit,
+): InstanceCullWindows {
+  return instanceCullWindowsInto(detailFar, fogLimit, dressingLimit, {
+    treeMax: 0,
+    impostorMin: 0,
+    fogCull: 0,
+    dressingMax: 0,
+  });
 }
 
 /** Allocation-free variant for the per-frame caller (the nameplatePlanInto idiom). */
 export function instanceCullWindowsInto(
   detailFar: number,
   fogLimit: number,
+  dressingLimit: number,
   out: InstanceCullWindows,
 ): InstanceCullWindows {
   const fogCull = Math.max(0, fogLimit);
@@ -165,6 +179,7 @@ export function instanceCullWindowsInto(
   out.treeMax = treeMax;
   out.impostorMin = treeMax;
   out.fogCull = fogCull;
+  out.dressingMax = Math.min(Math.max(0, dressingLimit), fogCull);
   return out;
 }
 
@@ -186,6 +201,9 @@ export interface BucketWindowInput {
    */
   minAtDetail?: boolean;
   maxAtDetail?: boolean;
+  /** The max cap is exact in the per-instance shader. The bucket test is
+   * coverage only and may reject the mesh once its near edge leaves the cap. */
+  maxAtInstance?: boolean;
   /** adaptive budget scale applied to the build-time bounds */
   distanceScale: number;
   /** runtime tree-detail boundary (see treeDetailDistance) */
@@ -197,11 +215,13 @@ export interface BucketWindowInput {
 }
 
 /**
- * The build-time caps (the near-fill density cull, rocks, dressing, the early bark
- * cull) are measured against the bucket's CENTER, as they always have been. They
+ * Most build-time caps (the near-fill density cull, rocks, the early bark cull)
+ * are measured against the bucket's CENTER, as they always have been. They
  * are cost controls and a bucket is ~240u deep, so measuring them from the near
  * edge would keep every bucket alive for another half-bucket past its cap and
- * quietly multiply the triangles they exist to cut.
+ * quietly multiply the triangles they exist to cut. Dressing is the exception:
+ * its shader enforces the adaptive cap per instance, so its bucket test uses the
+ * near edge only as a conservative coverage bound.
  *
  * The tree-detail swap is the exception: its two arms are COVERAGE tests, not a
  * partition. The real model draws while any part of the bucket is inside the
@@ -221,7 +241,8 @@ export function bucketVisible(w: BucketWindowInput): boolean {
     w.maxDist === undefined
       ? Number.POSITIVE_INFINITY
       : w.maxDist * w.distanceScale * w.revealScale;
-  if (w.centerDist < minCap || w.centerDist >= maxCap) return false;
+  if (w.centerDist < minCap) return false;
+  if (w.maxAtInstance ? nearEdge >= maxCap : w.centerDist >= maxCap) return false;
 
   if (w.minAtDetail && w.centerDist + w.radius < w.detailFar) return false;
   if (w.maxAtDetail && nearEdge >= w.detailFar) return false;

--- a/tests/foliage_collapse.test.ts
+++ b/tests/foliage_collapse.test.ts
@@ -80,26 +80,32 @@ describe('foliage collapse: shader injection', () => {
     const tree: CollapsibleMaterial = {};
     const impostor: CollapsibleMaterial = {};
     const plain: CollapsibleMaterial = {};
+    const dressing: CollapsibleMaterial = {};
     applyInstanceCollapse(tree, 'tree');
     applyInstanceCollapse(impostor, 'impostor');
     applyInstanceCollapse(plain, 'plain');
+    applyInstanceCollapse(dressing, 'dressing');
     const shTree = compile(tree);
     const shImpostor = compile(impostor);
     const shPlain = compile(plain);
+    const shDressing = compile(dressing);
 
-    updateCollapseUniforms(instanceCullWindows(138, 146.85));
+    updateCollapseUniforms(instanceCullWindows(138, 146.85, 104));
     expect(shTree.uniforms.uCollapseMin.value).toBe(0);
     expect(shTree.uniforms.uCollapseMax.value).toBe(138);
     expect(shImpostor.uniforms.uCollapseMin.value).toBe(138);
     expect(shImpostor.uniforms.uCollapseMax.value).toBe(146.85);
     expect(shPlain.uniforms.uCollapseMin.value).toBe(0);
     expect(shPlain.uniforms.uCollapseMax.value).toBe(146.85);
+    expect(shDressing.uniforms.uCollapseMin.value).toBe(0);
+    expect(shDressing.uniforms.uCollapseMax.value).toBe(104);
 
     // shared value objects: the next frame's write reaches already-compiled programs
-    updateCollapseUniforms(instanceCullWindows(368, 418.15));
+    updateCollapseUniforms(instanceCullWindows(368, 418.15, 200));
     expect(shTree.uniforms.uCollapseMax.value).toBe(368);
     expect(shImpostor.uniforms.uCollapseMin.value).toBe(368);
     expect(shImpostor.uniforms.uCollapseMax.value).toBe(418.15);
+    expect(shDressing.uniforms.uCollapseMax.value).toBe(200);
   });
 
   it('composes with an existing hook and rejects before its vertex edits', () => {

--- a/tests/foliage_gpu_contract.test.ts
+++ b/tests/foliage_gpu_contract.test.ts
@@ -66,4 +66,24 @@ describe('foliage GPU optimization production wiring', () => {
       'shader.fragmentShader = reuseDiffuseMapSampleForEmissive(shader.fragmentShader);',
     );
   });
+
+  it('keeps nearby dressing buckets covered while capping their instances exactly', () => {
+    const dressingModels = /const DRESSING_MODEL_URLS[^=]*= new Set\(\[([\s\S]*?)\]\);/.exec(
+      foliage,
+    )?.[1];
+    expect(dressingModels).toBeDefined();
+    expect(dressingModels).toContain('...MODEL_URLS.bush,');
+    expect(dressingModels).toContain('...MODEL_URLS.bushFlowers,');
+    expect(dressingModels).toContain('...MODEL_URLS.fern,');
+    expect(dressingModels).toContain('...MODEL_URLS.mushroom,');
+    expect(dressingModels).not.toContain('MODEL_URLS.rock');
+    expect(foliage).toContain("DRESSING_MODEL_URLS.has(url) ? 'dressing' : 'plain'");
+    expect(foliage).toMatch(/material: foliageMaterial\([\s\S]*?collapseRoleForUrl\(url\),\s*\),/);
+    expect(foliage).toMatch(
+      /function foliageMaterial\([\s\S]*?applyInstanceCollapse\(mat, role\);/,
+    );
+    expect(foliage).toContain('maxAtInstance: true,');
+    expect(foliage).toContain('lodDists().dressFar * distanceScale');
+    expect(foliage).toContain('bucketWindow.maxAtInstance = b.maxAtInstance;');
+  });
 });

--- a/tests/foliage_lod.test.ts
+++ b/tests/foliage_lod.test.ts
@@ -324,7 +324,7 @@ describe('foliage LOD: the real-model and impostor windows cover the world', () 
   });
 
   it('a cost cap cuts on the bucket CENTER, not its near edge', () => {
-    // Buckets are ~240u deep. The density/rock/dressing caps exist to cut
+    // Buckets are ~240u deep. The density and rock caps exist to cut
     // triangles, so measuring them from the near edge would keep every bucket
     // alive for another half-bucket past its cap: measured live in the Vale, that
     // one slip took foliage from ~1.0M to ~4.6M triangles a frame. Only the
@@ -341,6 +341,24 @@ describe('foliage LOD: the real-model and impostor windows cover the world', () 
     expect(bucketVisible({ ...pastCap, centerDist: cap - 20 })).toBe(true);
   });
 
+  it('keeps a dressing bucket alive while any instance can be inside its exact cap', () => {
+    // Regression at Evergarden 437,896: the camera orbits across the edge of
+    // a wide dressing bucket. Its center crosses the adaptive cap even though
+    // hedge instances remain a few yards away, so the whole hedge popped out
+    // from one viewing side. Dressing has an exact per-instance shader cap;
+    // the bucket test is only allowed to reject it once its near edge leaves.
+    const dressing = windowFor({
+      centerDist: 210,
+      radius: 120,
+      maxDist: LOD_HIGH.dressFar,
+      maxAtInstance: true,
+    });
+    expect(bucketVisible({ ...dressing, centerDist: 195 })).toBe(true);
+    expect(bucketVisible(dressing)).toBe(true);
+    expect(bucketVisible({ ...dressing, centerDist: 320 })).toBe(false);
+    expect(bucketVisible({ ...dressing, centerDist: 321 })).toBe(false);
+  });
+
   it('the budget still scales build-time bounds, just not the fog-derived one', () => {
     // A plain numeric bound (rocks, dressing, the near-fill cull) keeps shrinking
     // under load, which is the budget's whole point. rockFar 360 at half budget
@@ -353,10 +371,11 @@ describe('foliage LOD: the real-model and impostor windows cover the world', () 
 
 describe('foliage LOD: per-instance collapse windows', () => {
   it('real and impostor windows are exact complements at the swap', () => {
-    const w = instanceCullWindows(368, 418.15);
+    const w = instanceCullWindows(368, 418.15, 180);
     expect(w.treeMax).toBe(368);
     expect(w.impostorMin).toBe(w.treeMax);
     expect(w.fogCull).toBe(418.15);
+    expect(w.dressingMax).toBe(180);
   });
 
   it('a swap at the cull line leaves no impostor band but stays complementary', () => {
@@ -373,13 +392,19 @@ describe('foliage LOD: per-instance collapse windows', () => {
     const w = instanceCullWindows(258, 146.85);
     expect(w.treeMax).toBe(146.85);
     expect(w.impostorMin).toBe(w.treeMax);
+    expect(instanceCullWindows(258, 146.85, 180).dressingMax).toBe(146.85);
+  });
+
+  it('defaults dressing to fog and clamps a negative dressing cap to zero', () => {
+    expect(instanceCullWindows(138, 146.85).dressingMax).toBe(146.85);
+    expect(instanceCullWindows(138, 146.85, -1).dressingMax).toBe(0);
   });
 
   it('the allocation-free variant fills identically', () => {
-    const out = { treeMax: -1, impostorMin: -1, fogCull: -1 };
-    const returned = instanceCullWindowsInto(368, 418.15, out);
+    const out = { treeMax: -1, impostorMin: -1, fogCull: -1, dressingMax: -1 };
+    const returned = instanceCullWindowsInto(368, 418.15, 180, out);
     expect(returned).toBe(out); // fills the caller-owned object, no allocation
-    expect(out).toEqual(instanceCullWindows(368, 418.15));
+    expect(out).toEqual(instanceCullWindows(368, 418.15, 180));
   });
 });
 
@@ -387,6 +412,8 @@ describe('foliage LOD: tiers and purity', () => {
   it('hands the low tier its own, tighter table', () => {
     expect(lodDistsFor(true)).toBe(LOD_LOW);
     expect(lodDistsFor(false)).toBe(LOD_HIGH);
+    expect(LOD_HIGH.dressFar).toBe(200);
+    expect(LOD_LOW.dressFar).toBe(185);
     expect(LOD_LOW.treeDetailFar).toBeLessThan(LOD_HIGH.treeDetailFar);
   });
 

--- a/tests/foliage_lod.test.ts
+++ b/tests/foliage_lod.test.ts
@@ -359,6 +359,21 @@ describe('foliage LOD: the real-model and impostor windows cover the world', () 
     expect(bucketVisible({ ...dressing, centerDist: 321 })).toBe(false);
   });
 
+  it('scales the exact per-instance dressing cap by distanceScale too', () => {
+    // The regression above pins the maxAtInstance near-edge compare only at
+    // windowFor's default distanceScale (BEST_SCALE, which is 1): coverage for
+    // the budget actually shrinking that same cap, not just the plain-numeric one.
+    const scaledDressing = windowFor({
+      centerDist: 150,
+      radius: 60,
+      maxDist: LOD_HIGH.dressFar, // 200, scaled to 100 at half budget
+      maxAtInstance: true,
+      distanceScale: 0.5,
+    });
+    expect(bucketVisible(scaledDressing)).toBe(true); // nearEdge 90 < maxCap 100
+    expect(bucketVisible({ ...scaledDressing, centerDist: 160 })).toBe(false); // nearEdge 100 >= 100
+  });
+
   it('the budget still scales build-time bounds, just not the fog-derived one', () => {
     // A plain numeric bound (rocks, dressing, the near-fill cull) keeps shrinking
     // under load, which is the budget's whole point. rockFar 360 at half budget


### PR DESCRIPTION
## Summary

- Prevent wide ground-dressing buckets from disappearing when a camera orbit moves the bucket center beyond the adaptive dressing draw cap while nearby instances remain in range.
- Keep the bucket-level cull conservative for dressing coverage, then enforce the adaptive cap exactly per instance in the foliage collapse shader.
- Add regression coverage for the Evergarden camera-orbit case near coordinates 437,896 and for the production shader wiring.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/foliage_lod.test.ts tests/foliage_collapse.test.ts tests/foliage_gpu_contract.test.ts` (127 tests passed)
  - `npx tsc --noEmit`
  - `npm run ci:changed`
  - `git diff --check`
  - `npm run gate` (all 11 steps passed, including 24,360 unit tests, 90 browser tests, typechecks, security checks, and production builds)
- Manual steps:
  - Loaded the Evergarden near coordinates 437,896.
  - Orbited the camera to view the affected hedge from both reported sides.
  - Confirmed ingame that nearby bushes remain visible across the camera orbit.

## Screenshots / recordings

Before:

<img width="1896" height="1312" alt="Screenshot from 2026-08-01 14-13-08" src="https://github.com/user-attachments/assets/baaeb14b-1e4b-44ef-8a84-67669cfb6a86" />

After:

<img width="1896" height="1312" alt="image" src="https://github.com/user-attachments/assets/a9c47b7d-5af5-4c66-b240-cb9cb9505b1f" />


---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [x] **The full gate passes.** `npm run gate` is green. I added or updated decisive
      tests for changed behavior and recorded any manual checks above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings follow the contributor policy.** Every user-facing
      string is a `t()` key added to the matching English catalog. I did not edit locale
      overlays, except for the five required non-Latin fills when the M16 wordy-copy
      rule applies (see `src/ui/CLAUDE.md`).
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

> Commit messages and PR titles use [Conventional Commits](https://www.conventionalcommits.org/)
> with a required scope (`feat(talents): ...`, `fix(net): ...`).

---
