### PR TITLE
perf(ci): reshard pr-gate and release-gate from 4 to 6 vitest shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ permissions:
 #                 registry-in-sync, s3_registered (every emit maps to a registered
 #                 key/RULE), and placeholder parity for the translations that
 #                 actually exist. An English-only PR (sparse overlay) passes here.
-#                 The test suite runs as a 4-shard matrix (each shard executes a
-#                 quarter of the test files), so the job's wall time is the
-#                 slowest quarter, not the whole suite.
+#                 The test suite runs as a 6-shard matrix (each shard executes a
+#                 sixth of the test files), so the job's wall time is the
+#                 slowest sixth, not the whole suite.
 #
 #   pr-checks     the PR tier's serialized checks (i18n freshness + coverage
 #                 summary, malware gate, game/admin typecheck, env/server/client
@@ -35,7 +35,7 @@ permissions:
 #   release-gate  full 21-locale tier. Runs on release/** pushes and on the
 #                 release-to-main PR merge result, with I18N_RELEASE_TIER=1. A merely
 #                 `pending` (untranslated) key cannot survive this gate. Its test
-#                 step runs the same 4-shard matrix as pr-gate; the serialized
+#                 step runs the same 6-shard matrix as pr-gate; the serialized
 #                 checks and builds run once, on shard 1 only.
 #
 # The release tier is a superset: its `npm test` runs every PR-tier check plus the
@@ -135,9 +135,9 @@ jobs:
 
   # The PR tier is two parallel jobs: pr-gate runs the test suite while pr-checks
   # runs the serialized checks, so the PR critical path is max(tests, checks)
-  # instead of their sum. pr-gate additionally fans the suite across a 4-shard
+  # instead of their sum. pr-gate additionally fans the suite across a 6-shard
   # matrix (vitest --shard: a sha1-hash partition of the test FILES), so its wall
-  # time is the slowest quarter. Locally `npm run gate` (scripts/gate.mjs) runs
+  # time is the slowest sixth. Locally `npm run gate` (scripts/gate.mjs) runs
   # the SAME combined step list serially with ONE full unsharded vitest run by
   # design (bounded workers); keep that script's step list in sync when adding
   # or removing a step in either job.
@@ -146,13 +146,13 @@ jobs:
     if: (github.event_name == 'pull_request' && (github.base_ref != 'main' || !startsWith(github.head_ref, 'release/'))) || (github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release/')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
-    # fail-fast stays off: shards pass or fail independently, so one red quarter
-    # never cancels the other three and a failure report always covers the whole
+    # fail-fast stays off: shards pass or fail independently, so one red shard
+    # never cancels the other five and a failure report always covers the whole
     # suite.
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
 
     steps:
       - name: Check out repository
@@ -174,8 +174,8 @@ jobs:
       # lives in pr-checks.
       # Full Sim suites are CPU-heavy. Keep each shard at half the runner's
       # available cores, matching the bounded local gate.
-      - name: Run tests (PR tier, shard ${{ matrix.shard }} of 4)
-        run: npm test -- --shard=${{ matrix.shard }}/4 --maxWorkers="$(node -p 'Math.max(1, Math.floor(require("node:os").availableParallelism() / 2))')"
+      - name: Run tests (PR tier, shard ${{ matrix.shard }} of 6)
+        run: npm test -- --shard=${{ matrix.shard }}/6 --maxWorkers="$(node -p 'Math.max(1, Math.floor(require("node:os").availableParallelism() / 2))')"
 
   # Runs in parallel with pr-gate: same if-condition, no needs edge in either
   # direction. The default pull_request merge-ref checkout MUST be preserved
@@ -246,14 +246,14 @@ jobs:
     env:
       I18N_RELEASE_TIER: '1'
 
-    # The same 4-shard matrix as pr-gate: the test step partitions across the
-    # four runners, while every serialized check and build below carries a
+    # The same 6-shard matrix as pr-gate: the test step partitions across the
+    # six runners, while every serialized check and build below carries a
     # single-shard condition so it runs exactly once (on shard 1) instead of
-    # four times. fail-fast stays off so shards report independently.
+    # six times. fail-fast stays off so shards report independently.
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
 
     steps:
       - name: Check out repository
@@ -302,8 +302,8 @@ jobs:
       # matter which shard they hash into.
       # Full Sim suites are CPU-heavy. Keep each shard at half the runner's
       # available cores, matching the bounded local gate.
-      - name: Run tests (release tier - 21-locale + empty-pending, shard ${{ matrix.shard }} of 4)
-        run: npm test -- --shard=${{ matrix.shard }}/4 --maxWorkers="$(node -p 'Math.max(1, Math.floor(require("node:os").availableParallelism() / 2))')"
+      - name: Run tests (release tier - 21-locale + empty-pending, shard ${{ matrix.shard }} of 6)
+        run: npm test -- --shard=${{ matrix.shard }}/6 --maxWorkers="$(node -p 'Math.max(1, Math.floor(require("node:os").availableParallelism() / 2))')"
 
       - name: Typecheck
         if: matrix.shard == 1

--- a/scripts/gate.mjs
+++ b/scripts/gate.mjs
@@ -1,6 +1,6 @@
 // The full local pre-merge gate: the CI checks from .github/workflows/ci.yml run
 // locally. Order: the PR tier's combined step list (CI splits it across the
-// parallel pr-gate and pr-checks jobs and fans the test step across a 4-shard
+// parallel pr-gate and pr-checks jobs and fans the test step across a 6-shard
 // matrix; this script runs the same list serially with ONE full unsharded
 // vitest run by design), with the parallel lint job's changed-files biome pulled forward
 // as an early fast-fail; on a release/** branch the steps run release-tier

--- a/tests/ci_workflow.test.ts
+++ b/tests/ci_workflow.test.ts
@@ -104,11 +104,11 @@ describe('CI workflow parity', () => {
     }
   });
 
-  it('shards the PR and release test steps four ways and keeps the checks single-shard', () => {
+  it('shards the PR and release test steps six ways and keeps the checks single-shard', () => {
     const prGate = jobSource('pr-gate');
     const prChecks = jobSource('pr-checks');
     const releaseGate = jobSource('release-gate');
-    // Both test jobs fan the ONE suite across the same 4-shard matrix. The run
+    // Both test jobs fan the ONE suite across the same 6-shard matrix. The run
     // line stays `npm test` (whose pretest regenerates the i18n artifacts in
     // every shard: the S3 guard, guide freshness, and the git-subprocess suites
     // need them regardless of which shard they hash into), never a bare vitest
@@ -119,11 +119,11 @@ describe('CI workflow parity', () => {
     for (const job of [prGate, releaseGate]) {
       expect(job).toContain('strategy:');
       expect(job).toContain('fail-fast: false');
-      expect(job).toContain('shard: [1, 2, 3, 4]');
-      expect(job).toContain('run: npm test -- --shard=${{ matrix.shard }}/4');
+      expect(job).toContain('shard: [1, 2, 3, 4, 5, 6]');
+      expect(job).toContain('run: npm test -- --shard=${{ matrix.shard }}/6');
       expect(job).toContain(halfCoreCap);
     }
-    expect(workflow.match(/run: npm test -- --shard=\$\{\{ matrix\.shard \}\}\/4/g)).toHaveLength(
+    expect(workflow.match(/run: npm test -- --shard=\$\{\{ matrix\.shard \}\}\/6/g)).toHaveLength(
       2,
     );
     expect(workflow).not.toContain('npx vitest');
@@ -141,7 +141,7 @@ describe('CI workflow parity', () => {
     // pr-gate is tests-only, so nothing in it is gated to a single shard...
     expect(prGate).not.toContain('matrix.shard == 1');
     // ...while release-gate keeps its serialized checks and builds on exactly
-    // one shard each (they are not partitionable and must not run four times):
+    // one shard each (they are not partitionable and must not run six times):
     // i18n:gen, the freshness diff, the coverage summary, the malware gate,
     // typecheck, and the three builds. Every new non-test step added to
     // release-gate needs the same single-shard condition, and this count.
@@ -149,15 +149,15 @@ describe('CI workflow parity', () => {
     // The release TEST step itself must stay un-gated (run on every shard):
     // name-to-run adjacency proves no if: line sits between them, so a
     // compensating double-edit (gate the test step, un-gate a build; count
-    // still 8) cannot silently shrink the release tier to a quarter of the
+    // still 8) cannot silently shrink the release tier to a sixth of the
     // suite.
     expect(releaseGate).toMatch(
-      /- name: Run tests \(release tier[^\n]*\n {8}run: npm test -- --shard=\$\{\{ matrix\.shard \}\}\/4/,
+      /- name: Run tests \(release tier[^\n]*\n {8}run: npm test -- --shard=\$\{\{ matrix\.shard \}\}\/6/,
     );
     // Structural step counts close the remaining direction: a NEW step added
     // to either matrix job changes these totals and must consciously update
     // this test (an unconditioned addition to release-gate would otherwise
-    // run four times per release push; pr-gate stays exactly checkout,
+    // run six times per release push; pr-gate stays exactly checkout,
     // setup-node, npm ci, and the sharded test run).
     expect(prGate.match(/\n {6}- name: /g)).toHaveLength(4);
     expect(releaseGate.match(/\n {6}- name: /g)).toHaveLength(12);


### PR DESCRIPTION
<!--
Thanks for contributing to World of ClaudeCraft!
-->

## Summary

The PR gate takes 8 to 11 minutes on every pull request (issue #1885). Pulling real timings
with `gh run view --json jobs` across several recent completed runs on `levy-street/world-of-claudecraft`
shows the workflow's total wall time equals the slowest of `pr-gate`'s 4 vitest shards, and that
shard is consistently 30-70% heavier than the fastest one, for example (run `30704449673`):

| shard | duration |
|---|---|
| 1 | 8m11s |
| 4 | 9m14s |
| 2 | 11m02s |
| 3 | 14m02s (slowest, sets the wall clock) |

For comparison, `pr-checks` (the parallel job with the serialized i18n/typecheck/build steps)
finished the same run in 2m01s, `lint` in 2m49s, `browser-gate` in 1m38s. None of them are close
to `pr-gate`'s slowest shard, so nothing else in the workflow moves the headline number.

`vitest`'s `BaseSequencer.shard()` computes `sha1(relativeFilePath)` for every test file, sorts
the whole file list by that hash, then cuts it into N equal-**count** contiguous slices. It has
zero awareness of runtime, so a shard's actual wall time depends entirely on which slow files
land in its slice by chance. Going from 4 buckets to 6 under that same effectively-random hash
partition statistically narrows the gap between the heaviest and lightest bucket (more, smaller
buckets lower the variance of the max bucket) with no new infrastructure.

### The change

`.github/workflows/ci.yml`:
- `pr-gate`: `shard: [1, 2, 3, 4]` -> `[1, 2, 3, 4, 5, 6]`, `--shard=.../4` -> `--shard=.../6`.
- `release-gate`: same edit, kept in lockstep per the file's own "same matrix as pr-gate" comment.
- Updated the two explanatory block comments that said "4-shard" / "same 4-shard matrix" so the
  docs don't rot, plus the matching comment in `scripts/gate.mjs` (which itself is unaffected: it
  never passes `--shard`, by design, so `npm run gate` still runs one full unsharded pass).
- Updated the `tests/ci_workflow.test.ts` pin that hard-coded the previous 4-shard matrix, so the
  assertions track the real workflow instead of silently going stale.

### What I deliberately did NOT change (from the investigation brief)

- **`--maxWorkers` half-core cap: left untouched.** It predates and is independent of the now-dead
  `PERF_GATE_WALLCLOCK` rationale; it exists to keep CPU-bound tick-loop Sim tests (fiesta/social/
  threat, 1200-1600 ticks) from intermittently timing out when vitest spawns one fork per core on
  a shared runner. Doubling worker concurrency risks reintroducing that flake mode.
- **`.worktrees` missing from the malware scanner's `SKIP_PATHS`: real bug, but no timing signal
  in real CI** (a fresh Actions checkout never has a `.worktrees/` directory), so it doesn't move
  this issue's number. Left for its own follow-up.
- Every test file still runs exactly once, in exactly one shard; nothing is skipped, sampled, or
  moved off the PR tier. `vitest` itself refuses a shard count exceeding the file count, and this
  repo has 1932 test files, so 6 is trivially safe.

## Related issues

Addresses #1885

## Type of change

- [x] Refactor or performance (no behavior change)
- [x] Build, CI, or tooling

## How was this tested?

The shared dev machine this branch was built on was under heavy CPU contention from many other
concurrent agent processes (`uptime` load average ~40-68 on a 16-core box) while I worked, so I
did not force a full `npm run gate` through that contention. Instead:

- Commands:
  - `npx tsc --noEmit` (repo-wide): clean, no errors.
  - `npx @biomejs/biome check --write scripts/gate.mjs tests/ci_workflow.test.ts`: clean (one
    pre-existing `noTemplateCurlyInString` warning on the shard-string assertion, unchanged in
    kind from before this PR, and warnings don't fail the gate per this repo's convention).
  - `npm run i18n:gen && npx vitest run tests/architecture.test.ts tests/localization_fixes.test.ts`:
    77 passed, 3 skipped (the two guard suites the pre-push hook itself runs).
  - `npx vitest run tests/ci_workflow.test.ts`: 7 passed (the pin updated in this PR).
  - Verified `.github/workflows/ci.yml` parses as valid YAML with `js-yaml` and that both
    `pr-gate` and `release-gate` resolve to a `[1,2,3,4,5,6]` shard matrix.
  - `git push` ran this repo's `.githooks/pre-push` QA floor (typecheck, the same two guard
    suites, changed-file biome, copy-rule scan) unmodified, and it went green.
- Manual steps: pulled real `pr-gate` shard timings for several recent completed runs on
  `levy-street/world-of-claudecraft` via `gh run view --json jobs` to ground the diagnosis (see
  Summary and the diagram below) before making the change.
- **Not run locally, by design / contention:** a full unsharded `npm run gate` pass. This is a
  pure CI-topology config change (shard count only); the real confirmation is CI itself running
  this PR with the new 6-shard matrix, which I'll check once it runs.

## Timing structure: before vs after

```mermaid
flowchart TB
    subgraph before["BEFORE: 4-shard pr-gate (measured, run 30704449673 on levy-street/world-of-claudecraft)"]
        direction LR
        B0(["PR opened<br/>checkout + npm ci in every job"])
        B0 --> B1["pr-gate shard 1<br/>8m11s"]
        B0 --> B2["pr-gate shard 2<br/>11m02s"]
        B0 --> B3["pr-gate shard 3<br/>14m02s<br/>SLOWEST, sets wall clock"]
        B0 --> B4["pr-gate shard 4<br/>9m14s"]
        B0 --> BC["pr-checks<br/>2m01s"]
        B0 --> BL["lint<br/>2m49s"]
        B0 --> BG["browser-gate<br/>1m38s"]
        B1 & B2 & B3 & B4 & BC & BL & BG --> BEND(["workflow green<br/>total wall clock = 14m13s"])
    end

    subgraph after["AFTER: 6-shard pr-gate (same files, projected)"]
        direction LR
        A0(["PR opened<br/>checkout + npm ci in every job"])
        A0 --> A1["pr-gate shard 1..6<br/>narrower spread<br/>(more, smaller hash buckets)"]
        A0 --> AC["pr-checks<br/>unchanged, ~2m"]
        A0 --> AL["lint<br/>unchanged, ~3m"]
        A0 --> AG["browser-gate<br/>unchanged, ~2m"]
        A1 --> AEND(["workflow green<br/>target: slowest shard and total wall clock<br/>drop toward ~9-10m (down from 12-14m)"])
        AC & AL & AG --> AEND
    end

    before -.->|"this PR"| after
```

All jobs in the workflow already run in parallel (no `needs:` edges between `pr-gate`,
`pr-checks`, `lint`, `browser-gate`); this PR does not change that shape. It only changes how many
buckets `pr-gate`'s test files are hashed into, which narrows the spread of the max bucket and
should pull the slowest-shard number (and therefore the workflow's total wall clock) down.

## Screenshots / recordings

N/A. CI-configuration-only change, no player- or operator-visible surface.

---

## Checklist

### Quality

- [x] **The full gate passes.** Could not run the full `npm run gate` locally due to severe
      shared-machine CPU contention at the time of this change (see "How was this tested?"); ran
      the targeted equivalent checks instead (`tsc`, the two guard suites the pre-push hook runs,
      the updated `ci_workflow.test.ts` pin, YAML validation) and they are all green. CI on this
      PR will run the real, unsharded-machine gate and is the authoritative confirmation.
- [x] I added or updated decisive tests for changed behavior: `tests/ci_workflow.test.ts` now
      pins the 6-shard matrix instead of the stale 4-shard one.

### Cross-platform

- [ ] N/A. No UI or gameplay surface touched.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in
      any production path.
- [x] I didn't hand-edit generated files.
