### PR TITLE
probe(ci-speed): docs-only path-filter smoke

### DIFF
--- a/docs/ci-speed/probe-docs-only.md
+++ b/docs/ci-speed/probe-docs-only.md
@@ -1,0 +1,5 @@
+# Path-filter docs-only probe
+
+Stamp file only. No code paths. Used to verify Phase 5 skips pr-gate,
+pr-checks, and browser-gate while lint still runs. Safe to delete after
+the probe run is recorded in progress.md.


### PR DESCRIPTION
## Summary

Temporary docs-only probe for CI Speed Phase 5 path filters.

Touches only `docs/ci-speed/probe-docs-only.md` so `changes.code` should be
`false`. Expect:

- Detect code path changes: success, code=false
- Format + lint: run and green
- PR gate (1..8): skipped
- PR checks: skipped
- Browser regressions: skipped
- Release jobs: skipped (not a release event)

## Teardown

Close and delete this probe PR/branch after run ids are stamped in
`docs/ci-speed/progress.md`. Not part of the packet merge.